### PR TITLE
research: two verified 0-axiom entries — infinitude-primes-4k3-oq-03-oq-01 (∞ primes ≡1 mod 3) + cauchy-schwarz-oq-06-oq-01 (Gram determinant criterion)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3050,6 +3050,7 @@ import Proofs.InfinitudePrimes4k3OQ01Q12Q24
 import Proofs.InfinitudePrimes4k3OQ01Tower
 import Proofs.InfinitudePrimes4k3OQ02
 import Proofs.InfinitudePrimes4k3OQ03
+import Proofs.InfinitudePrimes4k3OQ03OQ01
 import Proofs.InfinitudePrimesOQ05
 import Proofs.IntegralRootTheoremOQ01
 import Proofs.IntermediateValueTheorem

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -608,6 +608,7 @@ import Proofs.CauchySchwarzOQ03OQ02OQ01
 import Proofs.CauchySchwarzOQ04
 import Proofs.CauchySchwarzOQ04OQ01
 import Proofs.CauchySchwarzOQ06
+import Proofs.CauchySchwarzOQ06OQ01
 import Proofs.CauchySchwarzOQ07
 import Proofs.CauchySchwarzOQ08
 import Proofs.CayleyHamilton

--- a/proofs/Proofs/CauchySchwarzOQ06OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ06OQ01.lean
@@ -1,0 +1,114 @@
+/-
+  Cauchy-Schwarz for Finite Families: The Gram Determinant Criterion
+  Open Question: cauchy-schwarz-oq-06-oq-01
+
+  The parent entry (cauchy-schwarz-oq-06) characterized the EQUALITY case of the
+  Cauchy-Schwarz inequality for a PAIR `{x, y}`: equality `‖⟪x, y⟫‖ = ‖x‖ · ‖y‖`
+  holds iff the pair is linearly DEPENDENT.  This file lifts that dichotomy from
+  two vectors to an arbitrary FINITE family `v : n → E`, replacing the scalar
+  Cauchy-Schwarz gap by the **Gram determinant**:
+
+      det (Gram v) = 0   ↔   the family `{vᵢ}` is linearly DEPENDENT,
+
+  equivalently `det (Gram v) ≠ 0 ↔ {vᵢ}` is linearly independent, where the Gram
+  matrix is `Gᵢⱼ = ⟪vᵢ, vⱼ⟫`.  For `n = 2` the Gram determinant is exactly
+  `‖x‖² ‖y‖² − ‖⟪x, y⟫‖²`, the squared Cauchy-Schwarz gap, so the parent's
+  equality case is the two-dimensional slice of this statement.
+
+  Strategy — two short bridges over Mathlib's `Matrix.gram` API:
+
+  * Independence ⟹ det ≠ 0.  `posDef_gram_of_linearIndependent` makes the Gram
+    matrix positive definite; a positive-definite matrix over a field is a unit
+    (`Matrix.PosDef.isUnit`), so its determinant is a unit and therefore nonzero.
+
+  * Dependence ⟹ det = 0.  A nontrivial vanishing combination `∑ cᵢ vᵢ = 0` is a
+    *nonzero null vector* of the Gram matrix: `(G *ᵥ c) j = ⟪vⱼ, ∑ cᵢ vᵢ⟫ = 0`
+    by linearity of the inner product in its second slot.  A matrix with a
+    nonzero kernel vector has zero determinant
+    (`Matrix.exists_mulVec_eq_zero_iff`).
+
+  These combine into the biconditionals
+  `gram_det_ne_zero_iff_linearIndependent` and
+  `gram_det_eq_zero_iff_not_linearIndependent`.
+
+  References:
+  - J. P. Gram, "Über die Entwicklung reeller Functionen in Reihen…" (1883):
+    the Gram determinant / Gramian.
+  - Horn & Johnson, "Matrix Analysis" (2nd ed., 2013), §7.2 (Gram matrices).
+  - Mathlib `Mathlib/Analysis/InnerProductSpace/GramMatrix.lean`:
+    `Matrix.gram`, `Matrix.posSemidef_gram`,
+    `Matrix.posDef_gram_iff_linearIndependent`.
+-/
+
+import Mathlib
+
+namespace CauchySchwarzOQ06OQ01
+
+open scoped InnerProductSpace ComplexOrder
+open Matrix
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+-- ============================================================================
+-- Part I: Linear independence ⟹ nonvanishing Gram determinant
+-- ============================================================================
+
+/-- **Independence ⟹ nonsingular Gram matrix.** If a finite family `v` is linearly
+independent then its Gram matrix is positive definite, hence a unit, hence has a
+nonzero determinant. -/
+theorem gram_det_ne_zero_of_linearIndependent
+    {v : n → E} (h : LinearIndependent 𝕜 v) :
+    (gram 𝕜 v).det ≠ 0 := by
+  have hpd : (gram 𝕜 v).PosDef := posDef_gram_of_linearIndependent h
+  have hunit : IsUnit (gram 𝕜 v).det := (isUnit_iff_isUnit_det _).mp hpd.isUnit
+  exact hunit.ne_zero
+
+-- ============================================================================
+-- Part II: Linear dependence ⟹ vanishing Gram determinant
+-- ============================================================================
+
+omit [DecidableEq n] in
+/-- The Gram matrix sends a coefficient vector `c` to the vector of inner products
+of each `vⱼ` with the combination `∑ cᵢ vᵢ`. This is the linearity-of-the-inner-
+product computation underlying the kernel argument. -/
+theorem gram_mulVec_apply (v : n → E) (c : n → 𝕜) (j : n) :
+    (gram 𝕜 v *ᵥ c) j = ⟪v j, ∑ k, c k • v k⟫_𝕜 := by
+  simp only [mulVec, dotProduct, gram_apply, inner_sum, inner_smul_right]
+  exact Finset.sum_congr rfl fun k _ => mul_comm _ _
+
+/-- **Dependence ⟹ singular Gram matrix.** If a finite family `v` is linearly
+dependent, a nontrivial vanishing combination is a nonzero kernel vector of the
+Gram matrix, so the determinant vanishes. -/
+theorem gram_det_eq_zero_of_not_linearIndependent
+    {v : n → E} (h : ¬ LinearIndependent 𝕜 v) :
+    (gram 𝕜 v).det = 0 := by
+  obtain ⟨c, hsum, i, hi⟩ := Fintype.not_linearIndependent_iff.mp h
+  rw [← Matrix.exists_mulVec_eq_zero_iff]
+  refine ⟨c, fun hc => hi (by simp [hc]), ?_⟩
+  funext j
+  rw [Pi.zero_apply, gram_mulVec_apply, hsum, inner_zero_right]
+
+-- ============================================================================
+-- Part III: The Gram determinant dichotomy
+-- ============================================================================
+
+/-- **Gram determinant criterion (nonvanishing form).** A finite family of vectors
+in an inner-product space is linearly independent iff its Gram determinant is
+nonzero. The classical `n = 2` Gram determinant `‖x‖²‖y‖² − ‖⟪x,y⟫‖²` recovers
+the parent's pairwise equality case. -/
+theorem gram_det_ne_zero_iff_linearIndependent {v : n → E} :
+    (gram 𝕜 v).det ≠ 0 ↔ LinearIndependent 𝕜 v := by
+  refine ⟨fun hdet => ?_, gram_det_ne_zero_of_linearIndependent⟩
+  by_contra hli
+  exact hdet (gram_det_eq_zero_of_not_linearIndependent hli)
+
+/-- **Gram determinant criterion (vanishing form).** A finite family of vectors in
+an inner-product space is linearly DEPENDENT iff its Gram determinant vanishes —
+the finite-family generalization of the Cauchy-Schwarz equality case. -/
+theorem gram_det_eq_zero_iff_not_linearIndependent {v : n → E} :
+    (gram 𝕜 v).det = 0 ↔ ¬ LinearIndependent 𝕜 v := by
+  rw [← not_ne_iff (a := (gram 𝕜 v).det), gram_det_ne_zero_iff_linearIndependent]
+
+end CauchySchwarzOQ06OQ01

--- a/proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean
+++ b/proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean
@@ -1,0 +1,167 @@
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Tactic
+
+/-!
+# Infinitely Many Primes ≡ 1 (mod 3) via the cyclotomic Φ₃ Euclid argument
+# (infinitude-primes-4k3-oq-03-oq-01)
+
+## The Open Question
+
+**OQ-03-OQ-01 from infinitude-primes-4k3**: The parent chain established infinitely many
+primes ≡ 3 (mod 4) (product argument) and ≡ 1 (mod 4) (Euler's criterion for −1). Can a
+*cyclotomic* Euclid-style argument prove infinitely many primes ≡ 1 (mod 3) using the third
+cyclotomic polynomial Φ₃(x) = x² + x + 1?
+
+## The Answer
+
+**Yes.** This is the smallest genuinely "cyclotomic" instance of the Euclid argument. The key
+fact about Φ₄(x) = x² + 1 used in the ≡ 1 (mod 4) case generalizes: a prime p dividing
+Φ₃(m) = m² + m + 1 forces the multiplicative order of m mod p to be exactly 3 (unless p = 3),
+and `orderOf m ∣ p − 1` then gives 3 ∣ p − 1, i.e. p ≡ 1 (mod 3).
+
+## The Proof Idea
+
+1. Given n, set m = 3 · (n+1)! and consider N = Φ₃(m) = m² + m + 1.
+2. N ≥ 2, so N has a prime factor p.
+3. **Coprimality**: p ∤ m, because p ∣ m would give p ∣ N − (m² + m) = 1.
+   In particular p ≠ 3 (since 3 ∣ m) and p > n (since every prime ≤ n+1 divides (n+1)! ∣ m).
+4. **Order argument**: m² + m + 1 ≡ 0 (mod p) ⟹ m³ ≡ 1 (mod p) (because
+   (m − 1)(m² + m + 1) = m³ − 1). So `orderOf m ∣ 3`, hence `orderOf m ∈ {1, 3}`.
+   - `orderOf m = 1` ⟹ m ≡ 1 ⟹ 3 ≡ 0 (mod p) ⟹ p = 3, contradiction.
+   - So `orderOf m = 3`, and `orderOf m ∣ p − 1` (Fermat) gives 3 ∣ p − 1, i.e. p ≡ 1 (mod 3).
+5. Hence for every n there is a prime p > n with p ≡ 1 (mod 3): infinitely many.
+
+## Comparison with the mod-4 siblings
+
+| | ≡ 3 (mod 4) | ≡ 1 (mod 4) | ≡ 1 (mod 3) (this file) |
+|-|-------------|-------------|--------------------------|
+| Polynomial | linear (4·k − 1) | Φ₄ = x² + 1 | Φ₃ = x² + x + 1 |
+| Key fact | product of ≡1 stays ≡1 | −1 is a QR ⟺ p ≡ 1 (mod 4) | ord₃(m) = 3 ⟹ 3 ∣ p − 1 |
+| Tool | parity of product | Euler's criterion | multiplicative order + Fermat |
+
+The cyclotomic order argument is the prototype for the general statement "infinitely many
+primes ≡ 1 (mod k) via Φ_k", specialized here to k = 3.
+
+## Summary: 5 theorems, 0 new axioms, 0 sorries
+-/
+
+namespace InfinitudePrimes4k3OQ03OQ01
+
+open Nat
+
+/-! ## Key Lemma: primes dividing m² + m + 1 (other than 3) are ≡ 1 (mod 3) -/
+
+/-- If a prime `p ≠ 3` divides `m² + m + 1 = Φ₃(m)`, then `p ≡ 1 (mod 3)`.
+
+    Working mod `p`, the divisibility gives `m² + m + 1 = 0`, hence `m³ = 1`
+    (since `(m − 1)(m² + m + 1) = m³ − 1`). Thus `orderOf m ∣ 3`, so the order is
+    `1` or `3`. Order `1` would force `m = 1` and then `3 = 0 (mod p)`, i.e. `p = 3`;
+    excluded. So the order is exactly `3`, and `orderOf m ∣ p − 1` (Fermat) yields
+    `3 ∣ p − 1`, i.e. `p ≡ 1 (mod 3)`. -/
+lemma prime_dvd_phi3_mod_three {p m : ℕ} (hp : Nat.Prime p) (hp3 : p ≠ 3)
+    (hdiv : p ∣ m ^ 2 + m + 1) : p % 3 = 1 := by
+  haveI : Fact (Nat.Prime p) := ⟨hp⟩
+  -- Reduce the divisibility to an equation in `ZMod p`.
+  have hz : ((m ^ 2 + m + 1 : ℕ) : ZMod p) = 0 := (ZMod.natCast_eq_zero_iff _ _).mpr hdiv
+  have h0 : (m : ZMod p) ^ 2 + (m : ZMod p) + 1 = 0 := by push_cast at hz; linear_combination hz
+  -- `m³ = 1` in `ZMod p`, because `(m − 1)(m² + m + 1) = m³ − 1`.
+  have hcube : (m : ZMod p) ^ 3 = 1 := by linear_combination ((m : ZMod p) - 1) * h0
+  -- `m ≠ 0` (else `0 = 1` in `ZMod p`).
+  have hm0 : (m : ZMod p) ≠ 0 := by
+    intro h; rw [h] at hcube; simp at hcube
+  -- The order of `m` divides 3, so it is 1 or 3.
+  have hord_dvd3 : orderOf (m : ZMod p) ∣ 3 := orderOf_dvd_of_pow_eq_one hcube
+  rcases (Nat.dvd_prime Nat.prime_three).mp hord_dvd3 with hord1 | hord3
+  · -- Order 1 ⟹ `m = 1` ⟹ `3 = 0 (mod p)` ⟹ `p = 3`: contradiction.
+    rw [orderOf_eq_one_iff] at hord1
+    rw [hord1] at h0
+    norm_num at h0
+    -- `h0 : (3 : ZMod p) = 0`, so `p ∣ 3`, so `p = 3`.
+    have hp_dvd_3 : p ∣ 3 := by
+      have : ((3 : ℕ) : ZMod p) = 0 := by exact_mod_cast h0
+      exact (ZMod.natCast_eq_zero_iff 3 p).mp this
+    exact absurd ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp hp_dvd_3) hp3
+  · -- Order 3, and `orderOf m ∣ p − 1` (Fermat) ⟹ `3 ∣ p − 1` ⟹ `p ≡ 1 (mod 3)`.
+    have hdvd : orderOf (m : ZMod p) ∣ p - 1 := ZMod.orderOf_dvd_card_sub_one hm0
+    rw [hord3] at hdvd
+    have hp2 : p ≥ 2 := hp.two_le
+    omega
+
+/-! ## The Main Theorem -/
+
+/-- **THE MAIN THEOREM: Infinitely many primes ≡ 1 (mod 3)**
+
+    Given any natural number `n`, there exists a prime `p > n` with `p ≡ 1 (mod 3)`.
+    The witness is a prime factor of `N = Φ₃(3·(n+1)!) = (3·(n+1)!)² + 3·(n+1)! + 1`. -/
+theorem infinitely_many_primes_1_mod_3 :
+    ∀ n : ℕ, ∃ p : ℕ, Nat.Prime p ∧ p > n ∧ p % 3 = 1 := by
+  intro n
+  set m := 3 * (n + 1).factorial with hm
+  have hfac : (n + 1).factorial ≥ 1 := Nat.factorial_pos _
+  have hm3 : m ≥ 3 := by rw [hm]; omega
+  -- `N = m² + m + 1 ≥ 2`, so it has a prime factor `p`.
+  have hN_ne1 : m ^ 2 + m + 1 ≠ 1 := by nlinarith [hm3]
+  obtain ⟨p, hp_prime, hp_div⟩ := Nat.exists_prime_and_dvd hN_ne1
+  -- `p ∤ m`: otherwise `p ∣ (m² + m + 1) − (m² + m) = 1`.
+  have hp_ndvd_m : ¬ p ∣ m := by
+    intro hpm
+    have h1 : p ∣ m ^ 2 + m := Nat.dvd_add (dvd_pow hpm two_ne_zero) hpm
+    have hsub : m ^ 2 + m + 1 - (m ^ 2 + m) = 1 := by omega
+    have : p ∣ 1 := by
+      have := Nat.dvd_sub hp_div h1
+      rwa [hsub] at this
+    exact hp_prime.not_dvd_one this
+  -- `p ≠ 3` since `3 ∣ m`.
+  have hp_ne3 : p ≠ 3 := by
+    intro h3
+    exact hp_ndvd_m (h3 ▸ (by rw [hm]; exact dvd_mul_right 3 _))
+  refine ⟨p, hp_prime, ?_, prime_dvd_phi3_mod_three hp_prime hp_ne3 hp_div⟩
+  -- `p > n`: every prime `≤ n+1` divides `(n+1)! ∣ m`, contradicting `p ∤ m`.
+  by_contra hle
+  push_neg at hle
+  apply hp_ndvd_m
+  rw [hm]
+  exact (Nat.dvd_factorial hp_prime.pos (by omega)).mul_left 3
+
+/-! ## Consequences -/
+
+/-- The set of primes `≡ 1 (mod 3)` is infinite. -/
+theorem primes_1_mod_3_infinite : Set.Infinite {p : ℕ | Nat.Prime p ∧ p % 3 = 1} := by
+  rw [Set.infinite_iff_exists_gt]
+  intro n
+  obtain ⟨p, hp_prime, hp_gt, hp_mod⟩ := infinitely_many_primes_1_mod_3 n
+  exact ⟨p, ⟨hp_prime, hp_mod⟩, hp_gt⟩
+
+/-- There is no largest prime `≡ 1 (mod 3)`. -/
+theorem no_largest_prime_1_mod_3 :
+    ¬∃ p : ℕ, Nat.Prime p ∧ p % 3 = 1 ∧ ∀ q : ℕ, Nat.Prime q → q % 3 = 1 → q ≤ p := by
+  intro ⟨p, _, _, hp_largest⟩
+  obtain ⟨q, hq_prime, hq_gt, hq_mod⟩ := infinitely_many_primes_1_mod_3 p
+  exact absurd (hp_largest q hq_prime hq_mod) (by omega)
+
+/-! ## Examples -/
+
+/-- 7 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 7 ∧ 7 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 13 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 13 ∧ 13 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 19 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 19 ∧ 19 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 31 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 31 ∧ 31 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 37 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 37 ∧ 37 % 3 = 1 := ⟨by decide, rfl⟩
+
+#check @infinitely_many_primes_1_mod_3
+#check @primes_1_mod_3_infinite
+#check @no_largest_prime_1_mod_3
+
+end InfinitudePrimes4k3OQ03OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "cs-oq0601-ann-header",
+    "proofId": "cauchy-schwarz-oq-06-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "concept",
+    "title": "From the Cauchy-Schwarz Gap to the Gram Determinant",
+    "content": "The parent entry characterized Cauchy-Schwarz equality for a pair {x,y} as linear dependence. Here the scalar gap ‖x‖‖y‖ − ‖⟪x,y⟫‖ is replaced by the Gram determinant of a finite family v : n → E, where the Gram matrix is Gᵢⱼ = ⟪vᵢ,vⱼ⟫. The goal is the dichotomy det(Gram v) = 0 ↔ v linearly dependent. The setup fixes 𝕜 via RCLike (the common abstraction of ℝ and ℂ), E as an inner-product space, and a finite index type n; opening ComplexOrder supplies the scoped partial order on 𝕜 needed to talk about positive-definite matrices.",
+    "mathContext": "$G_{ij} = \\langle v_i, v_j\\rangle, \\qquad \\det G = 0 \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gram matrix",
+      "Gram determinant",
+      "Cauchy-Schwarz inequality",
+      "linear dependence",
+      "RCLike"
+    ],
+    "prerequisites": [
+      "inner product spaces over ℝ or ℂ",
+      "Gram matrices",
+      "matrix determinants"
+    ]
+  },
+  {
+    "id": "cs-oq0601-ann-independence",
+    "proofId": "cauchy-schwarz-oq-06-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Independence ⟹ Nonvanishing Determinant",
+    "content": "`gram_det_ne_zero_of_linearIndependent` runs the chain independence ⟹ positive definite ⟹ unit ⟹ unit determinant ⟹ nonzero. Mathlib's `posDef_gram_of_linearIndependent` supplies positive-definiteness of the Gram matrix; `Matrix.PosDef.isUnit` makes a positive-definite matrix over a field invertible; `Matrix.isUnit_iff_isUnit_det` transfers unit-ness to the determinant; and `IsUnit.ne_zero` finishes. This is the analytic half of the dichotomy.",
+    "mathContext": "$\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v \\implies \\mathrm{PosDef}(G) \\implies \\det G \\ne 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positive definite matrix",
+      "unit (invertible) matrix",
+      "determinant"
+    ],
+    "prerequisites": [
+      "Matrix.posDef_gram_of_linearIndependent",
+      "Matrix.PosDef.isUnit"
+    ]
+  },
+  {
+    "id": "cs-oq0601-ann-mulvec",
+    "proofId": "cauchy-schwarz-oq-06-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Coefficient Vectors are Kernel Vectors",
+    "content": "`gram_mulVec_apply` computes (Gram v *ᵥ c) j = ⟪vⱼ, ∑ₖ cₖ • vₖ⟫. Unfolding `mulVec`/`dotProduct` and `gram_apply` gives ∑ₖ ⟪vⱼ,vₖ⟫ · cₖ; pushing the sum and scalars through the inner product with `inner_sum` and `inner_smul_right` collects them as ⟪vⱼ, ∑ₖ cₖ • vₖ⟫. The point: applying the Gram matrix to a coefficient vector c reproduces the inner products of each vⱼ with the combination ∑ cₖ vₖ — so a vanishing combination is literally a null vector of the matrix.",
+    "mathContext": "$(G c)_j = \\sum_k \\langle v_j, v_k\\rangle c_k = \\Big\\langle v_j, \\sum_k c_k v_k\\Big\\rangle.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "matrix-vector product",
+      "linearity of inner product",
+      "kernel of a matrix"
+    ],
+    "prerequisites": [
+      "inner_sum",
+      "inner_smul_right",
+      "Matrix.mulVec"
+    ]
+  },
+  {
+    "id": "cs-oq0601-ann-dependence",
+    "proofId": "cauchy-schwarz-oq-06-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Dependence ⟹ Vanishing Determinant",
+    "content": "`gram_det_eq_zero_of_not_linearIndependent` extracts, from `Fintype.not_linearIndependent_iff`, coefficients c with ∑ₖ cₖ • vₖ = 0 and some cᵢ ≠ 0. By the previous lemma each coordinate of Gram v *ᵥ c equals ⟪vⱼ, 0⟫ = 0, so c is a nonzero null vector. `Matrix.exists_mulVec_eq_zero_iff` then forces det(Gram v) = 0. This is the algebraic half of the dichotomy.",
+    "mathContext": "$\\sum_k c_k v_k = 0,\\ c \\ne 0 \\implies G c = 0 \\implies \\det G = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear dependence",
+      "singular matrix",
+      "nonzero kernel vector"
+    ],
+    "prerequisites": [
+      "Fintype.not_linearIndependent_iff",
+      "Matrix.exists_mulVec_eq_zero_iff"
+    ]
+  },
+  {
+    "id": "cs-oq0601-ann-dichotomy",
+    "proofId": "cauchy-schwarz-oq-06-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "The Gram Determinant Dichotomy",
+    "content": "`gram_det_ne_zero_iff_linearIndependent` and `gram_det_eq_zero_iff_not_linearIndependent` assemble the two implications into biconditionals. The nonvanishing form combines independence ⟹ det ≠ 0 with the contrapositive of dependence ⟹ det = 0; the vanishing form is its logical negation (via `not_ne_iff`). Specializing to n = 2, where det(Gram) = ‖x‖²‖y‖² − ‖⟪x,y⟫‖², recovers the parent's pairwise Cauchy-Schwarz equality case exactly.",
+    "mathContext": "$\\det G \\ne 0 \\iff \\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v, \\qquad \\det G = 0 \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gram determinant",
+      "linear independence",
+      "Cauchy-Schwarz equality",
+      "generalization"
+    ],
+    "prerequisites": [
+      "the two preceding implications",
+      "propositional negation of biconditionals"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-06-oq-01/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOQ06OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOQ06OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOQ06OQ01Data: ProofData = {
+  proof: cauchySchwarzOQ06OQ01Proof,
+  annotations: cauchySchwarzOQ06OQ01Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06-oq-01/meta.json
@@ -1,0 +1,436 @@
+{
+  "id": "cauchy-schwarz-oq-06-oq-01",
+  "title": "Cauchy-Schwarz for Finite Families: The Gram Determinant Criterion",
+  "slug": "cauchy-schwarz-oq-06-oq-01",
+  "description": "Lifts the parent's pairwise Cauchy-Schwarz equality case to an arbitrary finite family v : n → E via the Gram determinant: det(Gram v) = 0 iff the family is linearly dependent, equivalently det(Gram v) ≠ 0 iff it is linearly independent, where Gᵢⱼ = ⟪vᵢ,vⱼ⟫. For n = 2 the Gram determinant is exactly ‖x‖²‖y‖² − ‖⟪x,y⟫‖², the squared Cauchy-Schwarz gap, so the parent's equality case is the two-dimensional slice. Verified with 0 axioms and 0 sorries over any real or complex inner-product space.",
+  "meta": {
+    "author": "Gram (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gram_matrix",
+    "date": "1883",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "gram-matrix",
+      "gram-determinant",
+      "linear-dependence",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ06OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.gram",
+        "description": "The Gram matrix of a family v : n → E, with (gram 𝕜 v) i j = ⟪v i, v j⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.posDef_gram_of_linearIndependent",
+        "description": "Linear independence of v makes its Gram matrix positive definite",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.PosDef.isUnit",
+        "description": "A positive-definite matrix over a field is invertible (a unit)",
+        "module": "Mathlib.LinearAlgebra.Matrix.PosDef"
+      },
+      {
+        "theorem": "Matrix.isUnit_iff_isUnit_det",
+        "description": "A square matrix over a commutative ring is a unit iff its determinant is a unit",
+        "module": "Mathlib.LinearAlgebra.Matrix.NonsingularInverse"
+      },
+      {
+        "theorem": "Matrix.exists_mulVec_eq_zero_iff",
+        "description": "Over an integral domain, a matrix has a nonzero null vector iff its determinant is zero",
+        "module": "Mathlib.LinearAlgebra.Matrix.ToLinearEquiv"
+      },
+      {
+        "theorem": "Fintype.not_linearIndependent_iff",
+        "description": "Linear dependence of a finite family as an explicit nontrivial vanishing combination ∑ gᵢ vᵢ = 0 with some gᵢ ≠ 0",
+        "module": "Mathlib.LinearAlgebra.LinearIndependent.Defs"
+      },
+      {
+        "theorem": "inner_sum / inner_smul_right / inner_zero_right",
+        "description": "Linearity of the inner product in its second slot, used to show G *ᵥ c = 0 for a vanishing combination c",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gram_det_ne_zero_of_linearIndependent: independence ⟹ the Gram determinant is nonzero, via positive-definiteness ⟹ unit ⟹ unit determinant",
+      "gram_mulVec_apply: the linearity computation (Gram v *ᵥ c) j = ⟪vⱼ, ∑ cᵢ vᵢ⟫ identifying coefficient vectors with kernel vectors of the Gram matrix",
+      "gram_det_eq_zero_of_not_linearIndependent: dependence ⟹ the Gram determinant vanishes, exhibiting a nontrivial vanishing combination as a nonzero kernel vector",
+      "gram_det_ne_zero_iff_linearIndependent: the full nonvanishing biconditional det(Gram v) ≠ 0 ↔ LinearIndependent 𝕜 v for finite families",
+      "gram_det_eq_zero_iff_not_linearIndependent: the vanishing biconditional det(Gram v) = 0 ↔ ¬ LinearIndependent 𝕜 v — the finite-family generalization of the parent's equality case"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 114,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; the main biconditionals depend only on [propext, Classical.choice, Quot.sound]. Builds on Mathlib's Gram matrix API (the Gram matrix is positive semidefinite, and positive definite iff the family is linearly independent); the new content is the determinant bridge in both directions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Jørgen Pedersen Gram introduced the Gram determinant (the Gramian) in his 1883 work on least-squares approximation in function spaces. For a finite family of vectors $v_1,\\dots,v_n$ in an inner-product space, the Gram matrix $G_{ij} = \\langle v_i, v_j\\rangle$ is the canonical encoding of all pairwise inner products. Its determinant — the Gram determinant — measures the squared volume of the parallelepiped spanned by the vectors, and vanishes exactly when that volume collapses, i.e. when the vectors are linearly dependent. The $n=2$ Gram determinant $\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2$ is precisely the (squared) slack in the Cauchy-Schwarz inequality, so the Gram criterion is the many-vector generalization of Cauchy-Schwarz equality.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-06-oq-01)**: Extend the linear-dependence equality case of the parent entry from a pair $\\{x,y\\}$ to an arbitrary finite family $\\{v_1,\\dots,v_n\\}$: show that the Gram determinant vanishes iff the family is linearly dependent.\n\n**Result**: For $v : n \\to E$ over $\\mathbb{K}\\in\\{\\mathbb{R},\\mathbb{C}\\}$, $\\det(\\mathrm{Gram}\\,v) = 0 \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v$, equivalently $\\det(\\mathrm{Gram}\\,v) \\neq 0 \\iff \\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v$.",
+    "text": "The finite-family generalization of the Cauchy-Schwarz equality case: the Gram determinant of a family of vectors vanishes precisely when the family is linearly dependent.",
+    "proofStrategy": "**Two short bridges over Mathlib's Gram matrix API.**\n\n1. **Independence ⟹ det ≠ 0.** `Matrix.posDef_gram_of_linearIndependent` upgrades linear independence to positive-definiteness of the Gram matrix. A positive-definite matrix over a field is invertible (`Matrix.PosDef.isUnit`), and a matrix is a unit iff its determinant is (`Matrix.isUnit_iff_isUnit_det`); a unit determinant is nonzero.\n\n2. **Dependence ⟹ det = 0.** From `Fintype.not_linearIndependent_iff`, a dependent family admits coefficients $c$ with $\\sum_k c_k v_k = 0$ and some $c_i \\neq 0$. The computation $(\\mathrm{Gram}\\,v \\cdot c)_j = \\langle v_j, \\sum_k c_k v_k\\rangle = \\langle v_j, 0\\rangle = 0$ (linearity of the inner product in the second slot) shows $c$ is a nonzero kernel vector. By `Matrix.exists_mulVec_eq_zero_iff` the determinant vanishes.\n\n3. **Assemble.** The nonvanishing biconditional combines the two implications (the reverse direction is the contrapositive of step 2); the vanishing biconditional is its logical negation.",
+    "keyInsights": [
+      "**The Gram determinant is the right scalar invariant.** Replacing the Cauchy-Schwarz gap $\\|x\\|\\|y\\| - \\|\\langle x,y\\rangle\\|$ by $\\det(\\mathrm{Gram}\\,v)$ promotes the pairwise dichotomy to families of any finite size, with linear dependence as the unifying condition.",
+      "**Positive definiteness carries the analysis; the determinant carries the algebra.** Mathlib already proves $\\mathrm{PosDef}(\\mathrm{Gram}\\,v) \\iff \\mathrm{LinearIndependent}\\ v$. The only new work is translating definiteness into determinant non-vanishing — one direction via `PosDef.isUnit`, the other via an explicit kernel vector.",
+      "**A vanishing combination is literally a kernel vector.** The identity $(\\mathrm{Gram}\\,v \\cdot c)_j = \\langle v_j, \\sum_k c_k v_k\\rangle$ makes the equivalence transparent: the coefficient vector witnessing dependence is exactly the null vector witnessing singularity.",
+      "**The 2×2 case recovers the parent.** For $n=2$, $\\det(\\mathrm{Gram})= \\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2$, so 'Gram determinant vanishes' is 'Cauchy-Schwarz equality', tying this entry to cauchy-schwarz-oq-06 as a strict generalization."
+    ],
+    "prerequisites": [
+      "Inner product spaces over ℝ or ℂ (RCLike 𝕜, InnerProductSpace 𝕜 E in Mathlib)",
+      "The Gram matrix and its positive semidefiniteness (Mathlib's Matrix.gram API)",
+      "Linear independence of a finite family of vectors",
+      "Determinant of a square matrix and its relation to invertibility / nonzero kernel"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Statement and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Docstring framing the Gram determinant as the finite-family generalization of the Cauchy-Schwarz gap, with the n=2 identity ‖x‖²‖y‖² − ‖⟪x,y⟫‖² linking back to the parent. Imports Mathlib, opens InnerProductSpace and ComplexOrder notation (the latter supplying the RCLike partial order), and fixes 𝕜 (RCLike), E (inner-product space), and the finite index type n."
+    },
+    {
+      "id": "sec-independence",
+      "title": "Part I — Independence ⟹ Nonvanishing Determinant",
+      "startLine": 53,
+      "endLine": 67,
+      "summary": "gram_det_ne_zero_of_linearIndependent: positive-definiteness of the Gram matrix (posDef_gram_of_linearIndependent) makes it a unit (PosDef.isUnit), so its determinant is a unit (isUnit_iff_isUnit_det) and hence nonzero."
+    },
+    {
+      "id": "sec-dependence",
+      "title": "Part II — Dependence ⟹ Vanishing Determinant",
+      "startLine": 68,
+      "endLine": 92,
+      "summary": "gram_mulVec_apply computes (Gram v *ᵥ c) j = ⟪vⱼ, ∑ cₖ vₖ⟫ from inner_sum and inner_smul_right; gram_det_eq_zero_of_not_linearIndependent then turns a nontrivial vanishing combination into a nonzero kernel vector and applies exists_mulVec_eq_zero_iff."
+    },
+    {
+      "id": "sec-dichotomy",
+      "title": "Part III — The Gram Determinant Dichotomy",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "gram_det_ne_zero_iff_linearIndependent and gram_det_eq_zero_iff_not_linearIndependent assemble the two implications into biconditionals — the finite-family generalization of the parent's pairwise equality case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-06",
+      "relationship": "extends",
+      "description": "Generalizes the parent's pairwise equality case (‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ linear dependence) to a finite family via the Gram determinant; the parent is exactly the n = 2 slice, where det(Gram) = ‖x‖²‖y‖² − ‖⟪x,y⟫‖²."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The Gram determinant criterion is the many-vector form of Cauchy-Schwarz: nonnegativity of det(Gram) for n = 2 is the inequality, and its vanishing is the equality case."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, machine-checked characterization of linear dependence of a finite family of vectors via vanishing of the Gram determinant, over any real or complex inner-product space, generalizing the parent's pairwise Cauchy-Schwarz equality case. Fully verified (0 sorries, 0 axioms).",
+    "implications": "The Gram determinant criterion is the standard test for linear dependence in inner-product geometry: it underlies least-squares solvability (the normal equations are nonsingular iff the design columns are independent), the non-degeneracy of the parallelepiped volume √det(Gram), and the positivity of Gram determinants for orthonormal-expansion error bounds. Phrasing it as det = 0 ↔ dependence packages all of these uniformly.",
+    "openQuestions": [
+      "Strengthen the nonvanishing direction to positivity: det(Gram v) > 0 for a linearly independent family (the Gram determinant of an independent family is the squared parallelepiped volume), using the eigenvalue/spectral decomposition of the positive-definite Gram matrix.",
+      "Relate the rank of the Gram matrix to the dimension of the span of {vᵢ}, generalizing the determinant criterion to the rank criterion rank(Gram v) = dim span {vᵢ}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "ComplexOrder",
+      "Matrix"
+    ],
+    "namespace": "CauchySchwarzOQ06OQ01",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gram_det_eq_zero_iff_not_linearIndependent",
+      "type": "core",
+      "description": "**The headline result.** For a finite family v : n → E over 𝕜 = ℝ or ℂ, the Gram determinant det(Gram 𝕜 v) vanishes if and only if v is linearly DEPENDENT. This is the finite-family generalization of the parent's pairwise equality case: for n = 2 the Gram determinant is ‖x‖²‖y‖² − ‖⟪x,y⟫‖², so vanishing is exactly Cauchy-Schwarz equality.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, (Matrix.gram 𝕜 v).det = 0 ↔ ¬ LinearIndependent 𝕜 v"
+    },
+    {
+      "name": "gram_det_ne_zero_iff_linearIndependent",
+      "type": "core",
+      "description": "**The dual nonvanishing form.** A finite family is linearly independent iff its Gram determinant is nonzero. Forward direction: positive-definiteness of the Gram matrix makes it a unit, hence its determinant is a unit. Reverse: the contrapositive of the dependence ⟹ singular implication.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, (Matrix.gram 𝕜 v).det ≠ 0 ↔ LinearIndependent 𝕜 v"
+    },
+    {
+      "name": "gram_det_ne_zero_of_linearIndependent",
+      "type": "supporting",
+      "description": "Independence ⟹ nonsingular Gram matrix: posDef_gram_of_linearIndependent makes the Gram matrix positive definite, PosDef.isUnit makes it a unit, and isUnit_iff_isUnit_det transfers unit-ness to the determinant, which is therefore nonzero.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, LinearIndependent 𝕜 v → (Matrix.gram 𝕜 v).det ≠ 0"
+    },
+    {
+      "name": "gram_det_eq_zero_of_not_linearIndependent",
+      "type": "supporting",
+      "description": "Dependence ⟹ singular Gram matrix: a nontrivial vanishing combination ∑ cₖ vₖ = 0 (from Fintype.not_linearIndependent_iff) is a nonzero kernel vector of the Gram matrix, so the determinant vanishes by exists_mulVec_eq_zero_iff.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, ¬ LinearIndependent 𝕜 v → (Matrix.gram 𝕜 v).det = 0"
+    },
+    {
+      "name": "gram_mulVec_apply",
+      "type": "supporting",
+      "description": "The linearity computation underpinning the kernel argument: the Gram matrix applied to a coefficient vector c yields, in coordinate j, the inner product of vⱼ with the combination ∑ cₖ vₖ. Proved by unfolding mulVec and using inner_sum and inner_smul_right.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] (v : n → E) (c : n → 𝕜) (j : n), (Matrix.gram 𝕜 v *ᵥ c) j = ⟪v j, ∑ k, c k • v k⟫_𝕜"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gram, Jørgen Pedersen",
+      "title": "Über die Entwicklung reeller Functionen in Reihen mittelst der Methode der kleinsten Quadrate",
+      "year": "1883",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "note": "Introduces the Gram determinant in the context of least-squares approximation; its vanishing characterizes linear dependence."
+    },
+    {
+      "authors": "Horn, Roger A. and Johnson, Charles R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press (2nd edition)",
+      "note": "Section 7.2: Gram matrices are positive semidefinite, positive definite iff the generating vectors are linearly independent — the structural facts wrapped by this entry."
+    },
+    {
+      "authors": "Halmos, Paul R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer, Undergraduate Texts in Mathematics (2nd edition)",
+      "note": "Treats the Gram (Gramian) determinant and its vanishing as the linear-dependence criterion generalizing Cauchy-Schwarz equality."
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "cauchy-schwarz-oq-06-oq-01",
+  "title": "Cauchy-Schwarz for Finite Families: The Gram Determinant Criterion",
+  "slug": "cauchy-schwarz-oq-06-oq-01",
+  "description": "Lifts the parent's pairwise Cauchy-Schwarz equality case to an arbitrary finite family v : n → E via the Gram determinant: det(Gram v) = 0 iff the family is linearly dependent, equivalently det(Gram v) ≠ 0 iff it is linearly independent, where Gᵢⱼ = ⟪vᵢ,vⱼ⟫. For n = 2 the Gram determinant is exactly ‖x‖²‖y‖² − ‖⟪x,y⟫‖², the squared Cauchy-Schwarz gap, so the parent's equality case is the two-dimensional slice. Verified with 0 axioms and 0 sorries over any real or complex inner-product space.",
+  "meta": {
+    "author": "Gram (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gram_matrix",
+    "date": "1883",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "gram-matrix",
+      "gram-determinant",
+      "linear-dependence",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ06OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.gram",
+        "description": "The Gram matrix of a family v : n → E, with (gram 𝕜 v) i j = ⟪v i, v j⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.posDef_gram_of_linearIndependent",
+        "description": "Linear independence of v makes its Gram matrix positive definite",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      },
+      {
+        "theorem": "Matrix.PosDef.isUnit",
+        "description": "A positive-definite matrix over a field is invertible (a unit)",
+        "module": "Mathlib.LinearAlgebra.Matrix.PosDef"
+      },
+      {
+        "theorem": "Matrix.isUnit_iff_isUnit_det",
+        "description": "A square matrix over a commutative ring is a unit iff its determinant is a unit",
+        "module": "Mathlib.LinearAlgebra.Matrix.NonsingularInverse"
+      },
+      {
+        "theorem": "Matrix.exists_mulVec_eq_zero_iff",
+        "description": "Over an integral domain, a matrix has a nonzero null vector iff its determinant is zero",
+        "module": "Mathlib.LinearAlgebra.Matrix.ToLinearEquiv"
+      },
+      {
+        "theorem": "Fintype.not_linearIndependent_iff",
+        "description": "Linear dependence of a finite family as an explicit nontrivial vanishing combination ∑ gᵢ vᵢ = 0 with some gᵢ ≠ 0",
+        "module": "Mathlib.LinearAlgebra.LinearIndependent.Defs"
+      },
+      {
+        "theorem": "inner_sum / inner_smul_right / inner_zero_right",
+        "description": "Linearity of the inner product in its second slot, used to show G *ᵥ c = 0 for a vanishing combination c",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gram_det_ne_zero_of_linearIndependent: independence ⟹ the Gram determinant is nonzero, via positive-definiteness ⟹ unit ⟹ unit determinant",
+      "gram_mulVec_apply: the linearity computation (Gram v *ᵥ c) j = ⟪vⱼ, ∑ cᵢ vᵢ⟫ identifying coefficient vectors with kernel vectors of the Gram matrix",
+      "gram_det_eq_zero_of_not_linearIndependent: dependence ⟹ the Gram determinant vanishes, exhibiting a nontrivial vanishing combination as a nonzero kernel vector",
+      "gram_det_ne_zero_iff_linearIndependent: the full nonvanishing biconditional det(Gram v) ≠ 0 ↔ LinearIndependent 𝕜 v for finite families",
+      "gram_det_eq_zero_iff_not_linearIndependent: the vanishing biconditional det(Gram v) = 0 ↔ ¬ LinearIndependent 𝕜 v — the finite-family generalization of the parent's equality case"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 114,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; the main biconditionals depend only on [propext, Classical.choice, Quot.sound]. Builds on Mathlib's Gram matrix API (the Gram matrix is positive semidefinite, and positive definite iff the family is linearly independent); the new content is the determinant bridge in both directions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Jørgen Pedersen Gram introduced the Gram determinant (the Gramian) in his 1883 work on least-squares approximation in function spaces. For a finite family of vectors $v_1,\\dots,v_n$ in an inner-product space, the Gram matrix $G_{ij} = \\langle v_i, v_j\\rangle$ is the canonical encoding of all pairwise inner products. Its determinant — the Gram determinant — measures the squared volume of the parallelepiped spanned by the vectors, and vanishes exactly when that volume collapses, i.e. when the vectors are linearly dependent. The $n=2$ Gram determinant $\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2$ is precisely the (squared) slack in the Cauchy-Schwarz inequality, so the Gram criterion is the many-vector generalization of Cauchy-Schwarz equality.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-06-oq-01)**: Extend the linear-dependence equality case of the parent entry from a pair $\\{x,y\\}$ to an arbitrary finite family $\\{v_1,\\dots,v_n\\}$: show that the Gram determinant vanishes iff the family is linearly dependent.\n\n**Result**: For $v : n \\to E$ over $\\mathbb{K}\\in\\{\\mathbb{R},\\mathbb{C}\\}$, $\\det(\\mathrm{Gram}\\,v) = 0 \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v$, equivalently $\\det(\\mathrm{Gram}\\,v) \\neq 0 \\iff \\mathrm{LinearIndependent}\\ \\mathbb{K}\\ v$.",
+    "text": "The finite-family generalization of the Cauchy-Schwarz equality case: the Gram determinant of a family of vectors vanishes precisely when the family is linearly dependent.",
+    "proofStrategy": "**Two short bridges over Mathlib's Gram matrix API.**\n\n1. **Independence ⟹ det ≠ 0.** `Matrix.posDef_gram_of_linearIndependent` upgrades linear independence to positive-definiteness of the Gram matrix. A positive-definite matrix over a field is invertible (`Matrix.PosDef.isUnit`), and a matrix is a unit iff its determinant is (`Matrix.isUnit_iff_isUnit_det`); a unit determinant is nonzero.\n\n2. **Dependence ⟹ det = 0.** From `Fintype.not_linearIndependent_iff`, a dependent family admits coefficients $c$ with $\\sum_k c_k v_k = 0$ and some $c_i \\neq 0$. The computation $(\\mathrm{Gram}\\,v \\cdot c)_j = \\langle v_j, \\sum_k c_k v_k\\rangle = \\langle v_j, 0\\rangle = 0$ (linearity of the inner product in the second slot) shows $c$ is a nonzero kernel vector. By `Matrix.exists_mulVec_eq_zero_iff` the determinant vanishes.\n\n3. **Assemble.** The nonvanishing biconditional combines the two implications (the reverse direction is the contrapositive of step 2); the vanishing biconditional is its logical negation.",
+    "keyInsights": [
+      "**The Gram determinant is the right scalar invariant.** Replacing the Cauchy-Schwarz gap $\\|x\\|\\|y\\| - \\|\\langle x,y\\rangle\\|$ by $\\det(\\mathrm{Gram}\\,v)$ promotes the pairwise dichotomy to families of any finite size, with linear dependence as the unifying condition.",
+      "**Positive definiteness carries the analysis; the determinant carries the algebra.** Mathlib already proves $\\mathrm{PosDef}(\\mathrm{Gram}\\,v) \\iff \\mathrm{LinearIndependent}\\ v$. The only new work is translating definiteness into determinant non-vanishing — one direction via `PosDef.isUnit`, the other via an explicit kernel vector.",
+      "**A vanishing combination is literally a kernel vector.** The identity $(\\mathrm{Gram}\\,v \\cdot c)_j = \\langle v_j, \\sum_k c_k v_k\\rangle$ makes the equivalence transparent: the coefficient vector witnessing dependence is exactly the null vector witnessing singularity.",
+      "**The 2×2 case recovers the parent.** For $n=2$, $\\det(\\mathrm{Gram})= \\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2$, so 'Gram determinant vanishes' is 'Cauchy-Schwarz equality', tying this entry to cauchy-schwarz-oq-06 as a strict generalization."
+    ],
+    "prerequisites": [
+      "Inner product spaces over ℝ or ℂ (RCLike 𝕜, InnerProductSpace 𝕜 E in Mathlib)",
+      "The Gram matrix and its positive semidefiniteness (Mathlib's Matrix.gram API)",
+      "Linear independence of a finite family of vectors",
+      "Determinant of a square matrix and its relation to invertibility / nonzero kernel"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Statement and Setup",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Docstring framing the Gram determinant as the finite-family generalization of the Cauchy-Schwarz gap, with the n=2 identity ‖x‖²‖y‖² − ‖⟪x,y⟫‖² linking back to the parent. Imports Mathlib, opens InnerProductSpace and ComplexOrder notation (the latter supplying the RCLike partial order), and fixes 𝕜 (RCLike), E (inner-product space), and the finite index type n."
+    },
+    {
+      "id": "sec-independence",
+      "title": "Part I — Independence ⟹ Nonvanishing Determinant",
+      "startLine": 53,
+      "endLine": 67,
+      "summary": "gram_det_ne_zero_of_linearIndependent: positive-definiteness of the Gram matrix (posDef_gram_of_linearIndependent) makes it a unit (PosDef.isUnit), so its determinant is a unit (isUnit_iff_isUnit_det) and hence nonzero."
+    },
+    {
+      "id": "sec-dependence",
+      "title": "Part II — Dependence ⟹ Vanishing Determinant",
+      "startLine": 68,
+      "endLine": 92,
+      "summary": "gram_mulVec_apply computes (Gram v *ᵥ c) j = ⟪vⱼ, ∑ cₖ vₖ⟫ from inner_sum and inner_smul_right; gram_det_eq_zero_of_not_linearIndependent then turns a nontrivial vanishing combination into a nonzero kernel vector and applies exists_mulVec_eq_zero_iff."
+    },
+    {
+      "id": "sec-dichotomy",
+      "title": "Part III — The Gram Determinant Dichotomy",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "gram_det_ne_zero_iff_linearIndependent and gram_det_eq_zero_iff_not_linearIndependent assemble the two implications into biconditionals — the finite-family generalization of the parent's pairwise equality case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-06",
+      "relationship": "extends",
+      "description": "Generalizes the parent's pairwise equality case (‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ linear dependence) to a finite family via the Gram determinant; the parent is exactly the n = 2 slice, where det(Gram) = ‖x‖²‖y‖² − ‖⟪x,y⟫‖²."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The Gram determinant criterion is the many-vector form of Cauchy-Schwarz: nonnegativity of det(Gram) for n = 2 is the inequality, and its vanishing is the equality case."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, machine-checked characterization of linear dependence of a finite family of vectors via vanishing of the Gram determinant, over any real or complex inner-product space, generalizing the parent's pairwise Cauchy-Schwarz equality case. Fully verified (0 sorries, 0 axioms).",
+    "implications": "The Gram determinant criterion is the standard test for linear dependence in inner-product geometry: it underlies least-squares solvability (the normal equations are nonsingular iff the design columns are independent), the non-degeneracy of the parallelepiped volume √det(Gram), and the positivity of Gram determinants for orthonormal-expansion error bounds. Phrasing it as det = 0 ↔ dependence packages all of these uniformly.",
+    "openQuestions": [
+      "Strengthen the nonvanishing direction to positivity: det(Gram v) > 0 for a linearly independent family (the Gram determinant of an independent family is the squared parallelepiped volume), using the eigenvalue/spectral decomposition of the positive-definite Gram matrix.",
+      "Relate the rank of the Gram matrix to the dimension of the span of {vᵢ}, generalizing the determinant criterion to the rank criterion rank(Gram v) = dim span {vᵢ}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "ComplexOrder",
+      "Matrix"
+    ],
+    "namespace": "CauchySchwarzOQ06OQ01",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gram_det_eq_zero_iff_not_linearIndependent",
+      "type": "core",
+      "description": "**The headline result.** For a finite family v : n → E over 𝕜 = ℝ or ℂ, the Gram determinant det(Gram 𝕜 v) vanishes if and only if v is linearly DEPENDENT. This is the finite-family generalization of the parent's pairwise equality case: for n = 2 the Gram determinant is ‖x‖²‖y‖² − ‖⟪x,y⟫‖², so vanishing is exactly Cauchy-Schwarz equality.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, (Matrix.gram 𝕜 v).det = 0 ↔ ¬ LinearIndependent 𝕜 v"
+    },
+    {
+      "name": "gram_det_ne_zero_iff_linearIndependent",
+      "type": "core",
+      "description": "**The dual nonvanishing form.** A finite family is linearly independent iff its Gram determinant is nonzero. Forward direction: positive-definiteness of the Gram matrix makes it a unit, hence its determinant is a unit. Reverse: the contrapositive of the dependence ⟹ singular implication.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, (Matrix.gram 𝕜 v).det ≠ 0 ↔ LinearIndependent 𝕜 v"
+    },
+    {
+      "name": "gram_det_ne_zero_of_linearIndependent",
+      "type": "supporting",
+      "description": "Independence ⟹ nonsingular Gram matrix: posDef_gram_of_linearIndependent makes the Gram matrix positive definite, PosDef.isUnit makes it a unit, and isUnit_iff_isUnit_det transfers unit-ness to the determinant, which is therefore nonzero.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, LinearIndependent 𝕜 v → (Matrix.gram 𝕜 v).det ≠ 0"
+    },
+    {
+      "name": "gram_det_eq_zero_of_not_linearIndependent",
+      "type": "supporting",
+      "description": "Dependence ⟹ singular Gram matrix: a nontrivial vanishing combination ∑ cₖ vₖ = 0 (from Fintype.not_linearIndependent_iff) is a nonzero kernel vector of the Gram matrix, so the determinant vanishes by exists_mulVec_eq_zero_iff.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] [DecidableEq n] {v : n → E}, ¬ LinearIndependent 𝕜 v → (Matrix.gram 𝕜 v).det = 0"
+    },
+    {
+      "name": "gram_mulVec_apply",
+      "type": "supporting",
+      "description": "The linearity computation underpinning the kernel argument: the Gram matrix applied to a coefficient vector c yields, in coordinate j, the inner product of vⱼ with the combination ∑ cₖ vₖ. Proved by unfolding mulVec and using inner_sum and inner_smul_right.",
+      "leanType": "∀ {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {n : Type*} [Fintype n] (v : n → E) (c : n → 𝕜) (j : n), (Matrix.gram 𝕜 v *ᵥ c) j = ⟪v j, ∑ k, c k • v k⟫_𝕜"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gram, Jørgen Pedersen",
+      "title": "Über die Entwicklung reeller Functionen in Reihen mittelst der Methode der kleinsten Quadrate",
+      "year": "1883",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "note": "Introduces the Gram determinant in the context of least-squares approximation; its vanishing characterizes linear dependence."
+    },
+    {
+      "authors": "Horn, Roger A. and Johnson, Charles R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press (2nd edition)",
+      "note": "Section 7.2: Gram matrices are positive semidefinite, positive definite iff the generating vectors are linearly independent — the structural facts wrapped by this entry."
+    },
+    {
+      "authors": "Halmos, Paul R.",
+      "title": "Finite-Dimensional Vector Spaces",
+      "year": "1958",
+      "venue": "Springer, Undergraduate Texts in Mathematics (2nd edition)",
+      "note": "Treats the Gram (Gramian) determinant and its vanishing as the linear-dependence criterion generalizing Cauchy-Schwarz equality."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/annotations.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": "imports",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 6 },
+    "type": "concept",
+    "title": "Imports: ZMod, Finite Fields, and Multiplicative Order",
+    "content": "Unlike the mod-4 siblings, this file does not import its parent proofs — it is fully self-contained. The essential imports are Mathlib.Data.ZMod.Basic (the ring ZMod p), Mathlib.FieldTheory.Finite.Basic (which supplies ZMod.orderOf_dvd_card_sub_one, the multiplicative-order form of Fermat's little theorem), and Mathlib.GroupTheory.OrderOfElement (orderOf and orderOf_dvd_of_pow_eq_one). These three are exactly the tools the cyclotomic order argument consumes.",
+    "mathContext": "The proof works in $\\mathbb{F}_p = \\mathbb{Z}/p\\mathbb{Z}$ and uses that the unit group $\\mathbb{F}_p^\\times$ is cyclic of order $p-1$, so any element's multiplicative order divides $p-1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod p",
+      "finite fields",
+      "multiplicative order",
+      "Fermat's little theorem"
+    ],
+    "prerequisites": [
+      "Lean 4 import system",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "overview-docstring",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 8, "endLine": 50 },
+    "type": "concept",
+    "title": "The Cyclotomic Φ₃ Strategy",
+    "content": "The module docstring states OQ-03-OQ-01 and answers it. The strategy is the smallest genuinely cyclotomic instance of Euclid's argument: where the ≡ 1 (mod 4) sibling used Φ₄(x) = x² + 1 plus Euler's criterion, this file uses Φ₃(x) = x² + x + 1 plus the multiplicative-order argument. A comparison table shows the three constructions side by side, identifying the order argument as the general template that Euler's criterion specializes.",
+    "mathContext": "$\\Phi_3(x) = x^2 + x + 1$ is the 3rd cyclotomic polynomial, with roots the primitive cube roots of unity. A prime $p \\nmid 3$ divides $\\Phi_3(m)$ iff $m$ has order 3 in $\\mathbb{F}_p^\\times$, which requires $3 \\mid p-1$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cyclotomic polynomials",
+      "Euclid's argument",
+      "Dirichlet's theorem",
+      "roots of unity"
+    ],
+    "prerequisites": [
+      "Euclid's infinitude of primes",
+      "cyclotomic polynomials"
+    ]
+  },
+  {
+    "id": "key-lemma-statement",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 65, "endLine": 67 },
+    "type": "theorem",
+    "title": "Key Lemma: prime_dvd_phi3_mod_three",
+    "content": "States the arithmetic core: any prime p ≠ 3 dividing m² + m + 1 satisfies p % 3 = 1. This is the q = 3 case of the general cyclotomic fact 'a prime p ∤ q dividing Φ_q(m) lies in 1 mod q'. The hypothesis p ≠ 3 is essential — 3 is the ramified prime for ℚ(ζ₃) and is the single exceptional prime that can divide Φ₃(m) without being ≡ 1 (mod 3).",
+    "mathContext": "$p \\text{ prime},\\, p \\neq 3,\\, p \\mid m^2+m+1 \\;\\Rightarrow\\; p \\equiv 1 \\pmod 3$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cyclotomic polynomials",
+      "multiplicative order",
+      "ramification"
+    ],
+    "prerequisites": [
+      "ZMod p",
+      "multiplicative order"
+    ]
+  },
+  {
+    "id": "reduce-to-zmod",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 72 },
+    "type": "proof-step",
+    "title": "Reducing Divisibility to an Equation in ZMod p",
+    "content": "The divisibility p ∣ m² + m + 1 is translated into the equation (m : ZMod p)² + m + 1 = 0 via ZMod.natCast_eq_zero_iff (which says (a : ZMod b) = 0 ↔ b ∣ a), followed by push_cast and linear_combination to clear the cast bookkeeping. The Fact (Nat.Prime p) instance makes ZMod p a field, enabling the order machinery.",
+    "mathContext": "$(m^2+m+1 : \\mathbb{Z}/p) = 0$, i.e. $m$ is a root of $\\Phi_3$ in $\\mathbb{F}_p$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod.natCast_eq_zero_iff",
+      "push_cast",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "casting ℕ → ZMod p"
+    ]
+  },
+  {
+    "id": "cube-equals-one",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 73, "endLine": 73 },
+    "type": "proof-step",
+    "title": "The Cyclotomic Identity: m³ = 1",
+    "content": "Multiplying the equation m² + m + 1 = 0 by (m − 1) yields m³ − 1 = 0, i.e. m³ = 1 in ZMod p. This is the crucial move: it converts the additive Φ₃ relation into a multiplicative one that the order machinery can read. The factor (m − 1) is handed to linear_combination as the certificate of the polynomial identity (m − 1)(m² + m + 1) = m³ − 1.",
+    "mathContext": "$(m-1)(m^2+m+1) = m^3 - 1$, so $m^2+m+1 = 0 \\Rightarrow m^3 = 1$ in $\\mathbb{F}_p$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cyclotomic factorization",
+      "linear_combination",
+      "roots of unity"
+    ],
+    "prerequisites": [
+      "polynomial identities"
+    ]
+  },
+  {
+    "id": "order-divides-three",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 74, "endLine": 80 },
+    "type": "proof-step",
+    "title": "Order Divides 3, So Is 1 or 3",
+    "content": "From m³ = 1, orderOf_dvd_of_pow_eq_one gives orderOf m ∣ 3. Since 3 is prime, Nat.dvd_prime splits this into orderOf m = 1 or orderOf m = 3. The element m is nonzero in ZMod p (otherwise 0³ = 1 is absurd), so it lives in the unit group and orderOf is meaningful.",
+    "mathContext": "$\\mathrm{ord}_p(m) \\mid 3$ and $3$ prime $\\Rightarrow \\mathrm{ord}_p(m) \\in \\{1, 3\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orderOf_dvd_of_pow_eq_one",
+      "Nat.dvd_prime",
+      "cyclic group structure"
+    ],
+    "prerequisites": [
+      "multiplicative order",
+      "divisors of a prime"
+    ]
+  },
+  {
+    "id": "order-one-excluded",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 81, "endLine": 88 },
+    "type": "proof-step",
+    "title": "Order 1 Forces p = 3 (Excluded)",
+    "content": "If orderOf m = 1 then m = 1 in ZMod p, so the equation m² + m + 1 = 0 becomes 3 = 0 in ZMod p, i.e. p ∣ 3, hence p = 3 by Nat.prime_dvd_prime_iff_eq. This contradicts the hypothesis p ≠ 3, eliminating the order-1 branch. This is exactly where the single exceptional prime 3 is quarantined.",
+    "mathContext": "$\\mathrm{ord}_p(m) = 1 \\Rightarrow m \\equiv 1 \\Rightarrow 3 \\equiv 0 \\pmod p \\Rightarrow p = 3$, contradiction.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orderOf_eq_one_iff",
+      "Nat.prime_dvd_prime_iff_eq"
+    ],
+    "prerequisites": [
+      "multiplicative order"
+    ]
+  },
+  {
+    "id": "fermat-step",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 89, "endLine": 92 },
+    "type": "proof-step",
+    "title": "Order 3 and Fermat: 3 ∣ p − 1",
+    "content": "In the surviving branch orderOf m = 3. ZMod.orderOf_dvd_card_sub_one (the multiplicative-order form of Fermat's little theorem) gives orderOf m ∣ p − 1, so 3 ∣ p − 1. With p ≥ 2 this is closed by omega to conclude p % 3 = 1. This is the payoff: the order forces the residue class.",
+    "mathContext": "$\\mathrm{ord}_p(m) = 3 \\mid p - 1 \\Rightarrow 3 \\mid p-1 \\Rightarrow p \\equiv 1 \\pmod 3$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "ZMod.orderOf_dvd_card_sub_one",
+      "Fermat's little theorem",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "multiplicative order",
+      "Fermat's little theorem"
+    ]
+  },
+  {
+    "id": "main-theorem",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 100, "endLine": 128 },
+    "type": "theorem",
+    "title": "Main Theorem: infinitely_many_primes_1_mod_3",
+    "content": "For every n, exhibits a prime p > n with p ≡ 1 (mod 3). The construction is the Euclid move: let m = 3·(n+1)! and N = m² + m + 1 ≥ 2, take any prime factor p of N. The factor 3 in m guarantees p ≠ 3, and the factorial guarantees p > n — both via p ∤ m (since p ∣ m would give p ∣ N − (m² + m) = 1). The key lemma then places p in the class 1 mod 3.",
+    "mathContext": "Witness $N = \\Phi_3(3(n+1)!) = (3(n+1)!)^2 + 3(n+1)! + 1$. Coprimality $p \\nmid 3(n+1)!$ delivers both $p \\neq 3$ and $p > n$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Euclid's argument",
+      "Nat.exists_prime_and_dvd",
+      "Nat.dvd_factorial"
+    ],
+    "prerequisites": [
+      "factorial divisibility",
+      "Euclid's infinitude of primes"
+    ]
+  },
+  {
+    "id": "coprimality-step",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 109, "endLine": 124 },
+    "type": "proof-step",
+    "title": "Coprimality: p ∤ m Gives Both p ≠ 3 and p > n",
+    "content": "The single fact p ∤ m does double duty. Because 3 ∣ m, p ∤ m implies p ≠ 3. Because every prime ≤ n+1 divides (n+1)! which divides m, p ∤ m implies p > n. The proof of p ∤ m is the classic Euclid step: if p ∣ m then p ∣ m² + m, so p ∣ (m² + m + 1) − (m² + m) = 1, impossible for a prime.",
+    "mathContext": "$p \\mid m \\Rightarrow p \\mid (m^2+m+1) - (m^2+m) = 1$, contradiction. Hence $p \\nmid m = 3(n+1)!$, giving $p \\neq 3$ and $p > n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclid's coprimality trick",
+      "Nat.dvd_factorial",
+      "Nat.dvd_sub"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "factorial"
+    ]
+  },
+  {
+    "id": "consequences",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 133, "endLine": 144 },
+    "type": "theorem",
+    "title": "Consequences: Set.Infinite and No Largest Prime",
+    "content": "primes_1_mod_3_infinite restates the main theorem as Set.Infinite {p | Nat.Prime p ∧ p % 3 = 1} via Set.infinite_iff_exists_gt. no_largest_prime_1_mod_3 is the contrapositive 'no maximal element' form: a putative largest prime ≡ 1 (mod 3) is contradicted by a strictly larger one from the main theorem.",
+    "mathContext": "$\\{p \\mid \\mathrm{prime}\\,p \\wedge p \\equiv 1 \\pmod 3\\}$ is infinite; equivalently it has no maximum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Set.Infinite",
+      "Set.infinite_iff_exists_gt"
+    ],
+    "prerequisites": [
+      "set infinitude"
+    ]
+  },
+  {
+    "id": "examples",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 146, "endLine": 165 },
+    "type": "concept",
+    "title": "Examples: 7, 13, 19, 31, 37",
+    "content": "Five concrete primes ≡ 1 (mod 3), each verified by decide. They illustrate the class the theorem populates; note the sequence 7, 13, 19, 31, 37 skips 25 = 5² (not prime) — the primes ≡ 1 (mod 3) are not an arithmetic progression, only a residue class within the primes.",
+    "mathContext": "First primes $\\equiv 1 \\pmod 3$: $7, 13, 19, 31, 37, 43, 61, 67, \\ldots$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide",
+      "residue classes"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/meta.json
@@ -1,0 +1,229 @@
+{
+  "id": "infinitude-primes-4k3-oq-03-oq-01",
+  "title": "Infinitely Many Primes ≡ 1 (mod 3) via the Cyclotomic Φ₃ Euclid Argument",
+  "slug": "infinitude-primes-4k3-oq-03-oq-01",
+  "description": "Answers OQ-03-OQ-01 from infinitude-primes-4k3: proves infinitely many primes ≡ 1 (mod 3) by the smallest genuinely cyclotomic instance of Euclid's argument. A prime p ≠ 3 dividing Φ₃(m) = m² + m + 1 forces the multiplicative order of m mod p to be exactly 3, so 3 ∣ p − 1 by Fermat's little theorem, i.e. p ≡ 1 (mod 3). Euclid's construction with N = Φ₃(3·(n+1)!) then produces arbitrarily large such primes. Self-contained and elementary — uses only the multiplicative order machinery and Fermat's little theorem, not Dirichlet's L-functions. 4 theorems/lemmas, 0 new axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions",
+    "date": "formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "elementary",
+      "primes",
+      "modular-arithmetic",
+      "cyclotomic-polynomials",
+      "multiplicative-order"
+    ],
+    "proofRepoPath": "Proofs/InfinitudePrimes4k3OQ03OQ01.lean",
+    "parentProofId": "infinitude-primes-4k3-oq-03",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "newAxiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.orderOf_dvd_card_sub_one",
+        "description": "For a ≠ 0 in ZMod p (p prime), orderOf a ∣ p − 1 — the multiplicative-order form of Fermat's little theorem",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "orderOf_dvd_of_pow_eq_one",
+        "description": "If aⁿ = 1 then orderOf a ∣ n — used to deduce orderOf m ∣ 3 from m³ = 1",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a — bridges natural-number divisibility and equations in ZMod p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "Prime p ≤ n divides n! — gives p > n in the Euclid step",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.exists_prime_and_dvd",
+        "description": "Every natural number ≠ 1 has a prime factor — produces the witness prime",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "prime_dvd_phi3_mod_three: a prime p ≠ 3 dividing m² + m + 1 satisfies p ≡ 1 (mod 3), proved via the multiplicative order of m mod p being exactly 3",
+      "infinitely_many_primes_1_mod_3: ∀ n, ∃ prime p > n with p ≡ 1 (mod 3) — direct answer to OQ-03-OQ-01, witness a prime factor of Φ₃(3·(n+1)!)",
+      "primes_1_mod_3_infinite: the set {p prime | p ≡ 1 (mod 3)} is Set.Infinite",
+      "no_largest_prime_1_mod_3: there is no largest prime ≡ 1 (mod 3)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 167,
+    "assumptions": "0 new axioms. Depends only on propext, Classical.choice, Quot.sound (the standard Lean/Mathlib foundational axioms, which do not count as assumptions). No sorryAx, no Lean.ofReduceBool.",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The infinitude of primes in a residue class a (mod q) with gcd(a, q) = 1 is **Dirichlet's theorem** (1837), whose general proof needs Dirichlet L-functions and their non-vanishing at s = 1. Many *individual* classes, however, admit fully elementary Euclid-style proofs. The cleanest family is the classes ≡ 1 (mod q), detected by the **q-th cyclotomic polynomial** Φ_q: any prime p ∤ q dividing Φ_q(k) for some integer k must satisfy p ≡ 1 (mod q). This is because such a p makes k a root of Φ_q mod p, forcing k to have multiplicative order exactly q in 𝔽_p^×, and Lagrange's theorem (Fermat's little theorem) then gives q ∣ p − 1.\n\nThis file is the smallest genuinely cyclotomic instance: q = 3, Φ₃(x) = x² + x + 1. The parent chain (infinitude-primes-4k3 and its OQ-03 sibling for ≡ 1 mod 4 via Φ₄ = x² + 1) established the mod-4 picture; the parent's own open-question list explicitly anticipated this mod-3 construction. The case ≡ 1 (mod 3) is the prototype that the mod-4 quadratic-residue argument generalizes to: instead of Euler's criterion for −1, the order argument works for any cyclotomic class ≡ 1 (mod q).",
+    "problemStatement": "**Open Question (infinitude-primes-4k3-OQ-03-OQ-01)**: The parent chain proved infinitely many primes ≡ 3 (mod 4) (product argument) and ≡ 1 (mod 4) (Euler's criterion, the Φ₄ case). Can a genuinely *cyclotomic* Euclid-style argument prove infinitely many primes ≡ 1 (mod 3) using the third cyclotomic polynomial Φ₃(x) = x² + x + 1?\n\n**Answer**: Yes. A prime p ≠ 3 dividing Φ₃(m) = m² + m + 1 forces the multiplicative order of m mod p to be exactly 3 (since (m − 1)(m² + m + 1) = m³ − 1 gives m³ ≡ 1, and order 1 would force p = 3). Then orderOf m ∣ p − 1 (Fermat) yields 3 ∣ p − 1, i.e. p ≡ 1 (mod 3). Euclid's construction with N = Φ₃(3·(n+1)!) supplies a prime factor > n in this class for every n.",
+    "proofStrategy": "**Key lemma** `prime_dvd_phi3_mod_three`: reduce p ∣ m² + m + 1 to an equation in ZMod p; multiply by (m − 1) to get m³ = 1; conclude orderOf m ∣ 3, so the order is 1 or 3. Order 1 means m ≡ 1, whence m² + m + 1 ≡ 3 ≡ 0, so p ∣ 3 and p = 3 (excluded). Hence order 3, and `ZMod.orderOf_dvd_card_sub_one` gives 3 ∣ p − 1, so p % 3 = 1 (by omega).\n\n**Main theorem** `infinitely_many_primes_1_mod_3`: set m = 3·(n+1)! and N = m² + m + 1 ≥ 2. Take any prime factor p of N. Then p ∤ m (else p ∣ N − (m² + m) = 1), which gives both p ≠ 3 (since 3 ∣ m) and p > n (since every prime ≤ n+1 divides (n+1)! ∣ m). The key lemma then gives p ≡ 1 (mod 3).\n\n**Consequences**: `primes_1_mod_3_infinite` repackages the main theorem as Set.Infinite via `Set.infinite_iff_exists_gt`; `no_largest_prime_1_mod_3` is the contrapositive form.",
+    "keyInsights": [
+      "**The order argument is the cyclotomic heart**: p ∣ m² + m + 1 ⟺ m has order dividing 3 mod p. The only way the order can fail to be 3 is order 1 (m ≡ 1), which collapses Φ₃(m) to 3 and forces p = 3. This is exactly the Φ_q mechanism specialized to q = 3.",
+      "**Why multiply by (m − 1)**: the identity (m − 1)(m² + m + 1) = m³ − 1 turns the divisibility m² + m + 1 ≡ 0 into the multiplicative statement m³ = 1, which is what the order machinery consumes. The factor (m − 1) is supplied to `linear_combination`.",
+      "**The single excluded prime is 3 itself**: Φ₃(m) ≡ 0 (mod 3) exactly when m ≡ 1 (mod 3), and 3 is the ramified prime for the cyclotomic field ℚ(ζ₃). Choosing m ≡ 0 (mod 3) in the construction sidesteps it cleanly — N ≡ 1 (mod 3), so 3 ∤ N.",
+      "**Comparison to the mod-4 siblings**: ≡ 3 (mod 4) needs only that a product of ≡ 1 numbers stays ≡ 1; ≡ 1 (mod 4) needs Euler's criterion for −1 (the Φ₄ = x² + 1 case); ≡ 1 (mod 3) needs the order argument for Φ₃. The order argument is the general template, with Euler's criterion being its q = 4 shadow.",
+      "**Not Dirichlet, no L-functions**: the whole argument is finite and elementary — multiplicative order plus Fermat's little theorem. It does not touch the analytic machinery that the general Dirichlet theorem requires, and is genuinely simpler than even the q = 4 sum-of-two-squares route."
+    ],
+    "prerequisites": [
+      "Euclid's infinitude of primes (build N with a prime factor outside any finite set)",
+      "Modular arithmetic and the ring ZMod p for p prime",
+      "Multiplicative order of an element and orderOf_dvd_of_pow_eq_one",
+      "Fermat's little theorem in the form orderOf a ∣ p − 1 for a ≠ 0 (ZMod.orderOf_dvd_card_sub_one)",
+      "The factorization (x − 1)(x² + x + 1) = x³ − 1 (the q = 3 cyclotomic identity)",
+      "The factorial and its prime-factor divisibility (Nat.dvd_factorial)",
+      "Parent/sibling files: infinitude-primes-4k3 (≡ 3 mod 4) and infinitude-primes-4k3-oq-03 (≡ 1 mod 4, the Φ₄ case)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "prime_dvd_phi3_mod_three",
+      "type": "core",
+      "statement": "$\\forall p, m,\\; p$ prime $\\wedge\\, p \\neq 3 \\wedge p \\mid m^2 + m + 1 \\;\\Rightarrow\\; p \\equiv 1 \\pmod 3$",
+      "significance": "The arithmetic core and the genuinely cyclotomic step. A prime p ≠ 3 dividing Φ₃(m) = m² + m + 1 makes m a root of Φ₃ in 𝔽_p, so m³ = 1 (via (m − 1)(m² + m + 1) = m³ − 1) while m ≠ 1 (order 1 would force p = 3). Hence m has multiplicative order exactly 3, and Fermat (orderOf m ∣ p − 1) gives 3 ∣ p − 1. This is the q = 3 specialization of the general fact that primes dividing Φ_q(k) lie in the residue class 1 mod q.",
+      "description": "Key lemma: any prime p ≠ 3 dividing m² + m + 1 satisfies p ≡ 1 (mod 3), via the multiplicative order of m being exactly 3."
+    },
+    {
+      "name": "infinitely_many_primes_1_mod_3",
+      "type": "core",
+      "statement": "$\\forall n \\in \\mathbb{N},\\; \\exists p$ prime$,\\; p > n \\wedge p \\equiv 1 \\pmod 3$",
+      "significance": "Direct answer to OQ-03-OQ-01. The witness is a prime factor of N = Φ₃(3·(n+1)!) = (3·(n+1)!)² + 3·(n+1)! + 1. Coprimality p ∤ 3·(n+1)! gives simultaneously p ≠ 3 and p > n; the key lemma then places p in the class 1 mod 3. This is the elementary cyclotomic Euclid argument completed.",
+      "description": "Main theorem: for every n there is a prime p > n with p ≡ 1 (mod 3)."
+    },
+    {
+      "name": "primes_1_mod_3_infinite",
+      "type": "core",
+      "statement": "$\\mathrm{Set.Infinite}\\,\\{p : \\mathbb{N} \\mid \\mathrm{Nat.Prime}\\,p \\wedge p \\bmod 3 = 1\\}$",
+      "significance": "Repackages the main theorem in set-theoretic form using Set.infinite_iff_exists_gt: a set of naturals is infinite iff it contains elements exceeding any bound. The substantive content is entirely in infinitely_many_primes_1_mod_3.",
+      "description": "The set of primes ≡ 1 (mod 3) is infinite."
+    },
+    {
+      "name": "no_largest_prime_1_mod_3",
+      "type": "supporting",
+      "statement": "$\\neg\\,\\exists p,\\; \\mathrm{Nat.Prime}\\,p \\wedge p \\bmod 3 = 1 \\wedge \\forall q,\\; \\mathrm{Nat.Prime}\\,q \\to q \\bmod 3 = 1 \\to q \\le p$",
+      "significance": "The 'no maximal element' restatement of infinitude, dual to primes_1_mod_3_infinite. Given a putative largest such prime p, the main theorem produces a strictly larger one, contradicting maximality.",
+      "description": "There is no largest prime ≡ 1 (mod 3)."
+    }
+  ],
+  "references": [
+    {
+      "type": "research-paper",
+      "citation": "Dirichlet, P.G.L. (1837). \"Beweis des Satzes, dass jede unbegrenzte arithmetische Progression, deren erstes Glied und Differenz ganze Zahlen ohne gemeinschaftlichen Factor sind, unendlich viele Primzahlen enthält.\" Abhandlungen der Königlich Preussischen Akademie der Wissenschaften, 45-81.",
+      "relevance": "The general theorem on primes in arithmetic progressions, of which 'infinitely many primes ≡ 1 (mod 3)' is the special case (q, a) = (3, 1) proved here elementarily. Dirichlet's proof uses L-functions; this file avoids all analytic machinery via the cyclotomic order argument available for the specific class a = 1."
+    },
+    {
+      "type": "textbook",
+      "citation": "Hardy, G.H., and Wright, E.M. (2008). \"An Introduction to the Theory of Numbers,\" 6th ed., revised by D.R. Heath-Brown and J.H. Silverman. Oxford University Press. §2.2 (Euclid's proof and variants), §6 (Fermat's and Euler's theorems), §16.1 (Quadratic and higher residues).",
+      "relevance": "Standard reference for the Euclid-style elementary infinitude proofs in special residue classes and for the multiplicative-order / Fermat little theorem tools (§6) that drive the key lemma. §2.2 discusses the analogue for ≡ 3 (mod 4); the mod-3 cyclotomic case is the next natural example."
+    },
+    {
+      "type": "textbook",
+      "citation": "Ireland, K., and Rosen, M. (1990). \"A Classical Introduction to Modern Number Theory,\" 2nd ed. Springer GTM 84. Ch. 4 (Finite fields, multiplicative order), Ch. 13 (Cyclotomic fields and the cyclotomic polynomials Φ_n).",
+      "relevance": "Develops the cyclotomic-polynomial framework that explains *why* the argument works: any prime p ∤ n dividing Φ_n(k) satisfies p ≡ 1 (mod n) because k generates a cyclic subgroup of order n in 𝔽_p^×. This file is the n = 3 instance; the same template proves infinitely many primes ≡ 1 (mod n) for every n."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Murty, M. Ram (1988). \"Primes in certain arithmetic progressions.\" Functiones et Approximatio Commentarii Mathematici, 35, 249-259.",
+      "relevance": "Characterizes which arithmetic progressions {a + kq} admit Euclid-style elementary infinitude proofs: essentially those with a² ≡ 1 (mod q). The class a = 1 always qualifies (the cyclotomic case formalized here); classes a ≢ ±1 generally require Dirichlet's analytic method or the Selberg–Erdős elementary proof."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.FieldTheory.Finite.Basic\" — `ZMod.orderOf_dvd_card_sub_one`. (accessed 2026)",
+      "relevance": "Supplies the multiplicative-order form of Fermat's little theorem used in the key lemma: for a ≠ 0 in ZMod p, orderOf a ∣ p − 1. Combined with orderOf m = 3 this is exactly the step 3 ∣ p − 1 ⟹ p ≡ 1 (mod 3)."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.NumberTheory.PrimesCongruentOne\" — `Nat.exists_prime_gt_modEq_one`, `Nat.infinite_setOf_prime_modEq_one`. (accessed 2026)",
+      "relevance": "Mathlib's general cyclotomic infinitude theorem (infinitely many primes ≡ 1 mod k for any k ≠ 0), proved via Φ_k and the multiplicative order. This file gives the explicit, self-contained k = 3 instance with the concrete polynomial m² + m + 1 and the Euclid construction spelled out, complementing Mathlib's abstract version with a fully transparent special case."
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Open Question Statement",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports the ZMod, finite-field, and order-of-element modules. The module comment states OQ-03-OQ-01, answers it affirmatively, sketches the order argument, and gives a comparison table with the ≡ 3 (mod 4) and ≡ 1 (mod 4) siblings showing Φ₃ as the prototype cyclotomic case.",
+      "mathContext": "The table contrasts the linear (4k−1) construction, the Φ₄ = x²+1 construction (Euler's criterion), and the Φ₃ = x²+x+1 construction (multiplicative order). The order argument generalizes Euler's criterion."
+    },
+    {
+      "id": "key-lemma",
+      "title": "prime_dvd_phi3_mod_three: The Cyclotomic Order Argument",
+      "startLine": 56,
+      "endLine": 92,
+      "summary": "The arithmetic core. Reduces p ∣ m²+m+1 to (m:ZMod p)²+m+1 = 0, multiplies by (m−1) via linear_combination to get m³ = 1, deduces orderOf m ∣ 3, and case-splits: order 1 forces p = 3 (excluded), order 3 gives 3 ∣ p−1 via ZMod.orderOf_dvd_card_sub_one, hence p % 3 = 1.",
+      "mathContext": "$p \\mid m^2+m+1,\\,p\\neq 3 \\Rightarrow \\mathrm{ord}_p(m) = 3 \\Rightarrow 3 \\mid p-1 \\Rightarrow p \\equiv 1 \\pmod 3$. The identity $(m-1)(m^2+m+1)=m^3-1$ converts the additive divisibility to the multiplicative $m^3=1$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "infinitely_many_primes_1_mod_3: The Euclid Construction",
+      "startLine": 94,
+      "endLine": 128,
+      "summary": "Sets m = 3·(n+1)! and N = m²+m+1 ≥ 2, extracts a prime factor p, shows p ∤ m (else p ∣ 1), which yields p ≠ 3 (3 ∣ m) and p > n (every prime ≤ n+1 divides (n+1)! ∣ m). The key lemma then gives p ≡ 1 (mod 3).",
+      "mathContext": "$N = \\Phi_3(3 \\cdot (n+1)!)$. Coprimality $p \\nmid 3\\cdot(n+1)!$ simultaneously excludes $p = 3$ and forces $p > n$; the key lemma places $p$ in the class $1 \\pmod 3$."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences: Set.Infinite and No Largest Prime",
+      "startLine": 130,
+      "endLine": 144,
+      "summary": "primes_1_mod_3_infinite recasts the main theorem via Set.infinite_iff_exists_gt; no_largest_prime_1_mod_3 derives the contradiction from a putative maximal prime ≡ 1 (mod 3) using the main theorem to exceed it.",
+      "mathContext": "$\\mathrm{Set.Infinite}\\,\\{p \\mid \\mathrm{prime}\\,p \\wedge p \\bmod 3 = 1\\}$ and its dual 'no maximal element' form."
+    },
+    {
+      "id": "examples",
+      "title": "Examples: 7, 13, 19, 31, 37",
+      "startLine": 146,
+      "endLine": 165,
+      "summary": "Five concrete primes ≡ 1 (mod 3) verified by decide, illustrating the class the theorem populates.",
+      "mathContext": "The first few primes ≡ 1 (mod 3): 7, 13, 19, 31, 37, ... (note 31 skips 25 = 5² which is not prime)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered: yes, infinitely many primes ≡ 1 (mod 3) by the smallest genuinely cyclotomic Euclid argument, using Φ₃(x) = x² + x + 1. The key step is that a prime p ≠ 3 dividing Φ₃(m) forces the multiplicative order of m mod p to be exactly 3, so 3 ∣ p − 1. The proof is fully elementary, self-contained, and 0-axiom.",
+    "implications": "This file completes the cyclotomic picture the mod-4 chain pointed toward: where ≡ 1 (mod 4) used Euler's criterion (the Φ₄ = x² + 1 case), ≡ 1 (mod 3) uses the multiplicative-order argument for Φ₃, which is the general template. The same proof structure — evaluate Φ_q at q·k!, extract a coprime prime factor, read off its order — gives elementary infinitude for every class ≡ 1 (mod q). Mathlib's `Nat.infinite_setOf_prime_modEq_one` is the abstract form of this; the present file is the transparent, hand-built q = 3 instance.",
+    "openQuestions": [
+      "Can the q = 5 case ≡ 1 (mod 5) be formalized the same way with Φ₅(x) = x⁴ + x³ + x² + x + 1, and does the order argument scale cleanly to a single generic lemma parameterized by q? The obstruction is purely the algebra of Φ_q, not the Euclid step.",
+      "The companion class ≡ 2 (mod 3) admits an easy product-style proof (parallel to ≡ 3 mod 4). Can both mod-3 classes be packaged into a complete elementary classification of primes mod 3 — every prime ≠ 3 is ≡ 1 or ≡ 2 (mod 3), both classes infinite — mirroring the mod-4 classification already in the gallery?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "infinitude-primes-4k3-oq-03",
+      "relationship": "parent",
+      "description": "Proves infinitely many primes ≡ 1 (mod 4) via the Φ₄ = x² + 1 / Euler's criterion route, and its open-question list explicitly anticipated this Φ₃ construction for ≡ 1 (mod 3)."
+    },
+    {
+      "proofId": "infinitude-primes-4k3",
+      "relationship": "ancestor",
+      "description": "The base mod-4 entry (≡ 3 mod 4 via N = 4(n+1)! − 1) whose OQ-03 chain this file extends to the cyclotomic mod-3 setting."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "ancestor",
+      "description": "Euclid's original infinitude of primes; every variant here adapts its 'build N with a new prime factor' skeleton."
+    },
+    {
+      "proofId": "infinitude-primes-oq-03",
+      "relationship": "sibling",
+      "description": "Elementary proof of infinitely many primes ≡ 2 (mod 3) by a product argument; together with this file it covers both nontrivial residue classes mod 3."
+    }
+  ],
+  "leanFile": {
+    "namespace": "InfinitudePrimes4k3OQ03OQ01",
+    "lineCount": 167,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/InfinitudePrimes4k3OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
This branch delivers **two independent verified, 0-axiom research entries**.

---

## 1. infinitude-primes-4k3-oq-03-oq-01 — Infinitely many primes ≡ 1 (mod 3)

Cyclotomic Φ₃ Euclid argument: any prime divisor of `Φ₃(N) = N² + N + 1` exceeding 1 is ≡ 1 (mod 3), giving Euclid-style infinitude of primes ≡ 1 (mod 3). Verified, 0 sorries, 0 axioms.

Files: `proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean`, `src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/{meta.json,annotations.json}`.

---

## 2. cauchy-schwarz-oq-06-oq-01 — Gram determinant criterion for finite families

Lifts the parent **cauchy-schwarz-oq-06** (pairwise Cauchy-Schwarz equality ↔ linear dependence) to an arbitrary finite family `v : n → E` via the Gram determinant:

```
det(Gram 𝕜 v) = 0  ↔  ¬ LinearIndependent 𝕜 v
det(Gram 𝕜 v) ≠ 0  ↔    LinearIndependent 𝕜 v
```

For `n = 2`, det(Gram) = ‖x‖²‖y‖² − ‖⟪x,y⟫‖² (the squared Cauchy-Schwarz gap), so the parent is the 2-D slice. This is precisely the open question recorded in the parent's `conclusion.openQuestions`.

**Proof** — two short bridges over Mathlib's `Matrix.gram` API (which proves `PosDef(gram v) ↔ LinearIndependent v`):
- independence ⟹ det ≠ 0 via `posDef_gram_of_linearIndependent` → `PosDef.isUnit` → `isUnit_iff_isUnit_det`;
- dependence ⟹ det = 0: a nontrivial vanishing combination is a nonzero kernel vector (`gram_mulVec_apply`), then `exists_mulVec_eq_zero_iff`.

5 theorems, 0 sorries, 0 axioms (`#print axioms` → only `propext`/`Classical.choice`/`Quot.sound`).

Files: `proofs/Proofs/CauchySchwarzOQ06OQ01.lean` (114 lines), `src/data/proofs/cauchy-schwarz-oq-06-oq-01/{meta.json,annotations.json,index.ts}`, registration in `proofs/Proofs.lean`.

---

Both entries kernel-checked against Mathlib 4.26.0 via `lake env lean` (docker backend was down this cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)