### PR TITLE
fix(#28788): downgrade 2 cauchy-schwarz Lp-duality metas verified→formalized (Mathlib drift)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures (Complete)",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
-  "description": "Sigma-finite Lp Riesz representation theorem fully formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) are proved with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction.",
+  "description": "Sigma-finite Lp Riesz representation theorem formalized in Lean 4: all three steps (A localization, B Lp truncation convergence, C density extension) with 0 sorries in this file. Step A (localization_existence, ~600 lines) was completed in PR #15581 via the Hölder extremizer construction; Step B uses Vitali's convergence theorem; Step C uses Lp.induction. NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status downgraded to formalized until the chain builds green.",
   "leanFile": {
     "namespace": "RieszSigmaFiniteComplete",
     "lineCount": 952,
@@ -13,7 +13,7 @@
     "sorries": 0
   },
   "meta": {
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
     "tags": [
       "functional-analysis",
@@ -27,7 +27,8 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 952,
-    "assumptions": "All three sorries eliminated: Step A (localization_existence) was proved in PR #15581 via the Hölder extremizer construction (g_seq truncations + MCT for hgnorm, ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for indicator agreement). Steps B (lp_truncation_tendsto_zero via Vitali) and C (integral_representation_sf via Lp.induction) were proved earlier. The proof depends on lemmas in the parent file Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean — assess parent's status independently.",
+    "buildStatus": "broken",
+    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file imports the chain foundation Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean (line 33), which produces 53 Mathlib-drift errors against leanprover/lean4:v4.26.0, so this file transitively fails to compile. There are 0 literal `sorry` tactics and 0 `axiom` declarations — the formalization exists but is not currently machine-checked, so status was downgraded verified→formalized pending repair of the foundation. Mathematical content unchanged: Step A (localization_existence) proved in PR #15581 via the Hölder extremizer construction (g_seq truncations + MCT for hgnorm, ae_eq_of_forall_setIntegral_eq_of_sigmaFinite for indicator agreement); Steps B (lp_truncation_tendsto_zero via Vitali) and C (integral_representation_sf via Lp.induction) proved earlier. As the assumptions already noted, the parent's status must be assessed independently — it is now also formalized/broken.",
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
-  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes — the three previously HARD (not OPEN) sorries (Lp truncation convergence, localization construction, and density extension) are now completed via delegation to the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (namespace `RieszSigmaFiniteComplete`).",
+  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes — the three previously HARD (not OPEN) sorries (Lp truncation convergence, localization construction, and density extension) are completed via delegation to the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (namespace `RieszSigmaFiniteComplete`). NOTE (2026-06-24, #28788): this file transitively fails to compile against the pinned v4.26.0 toolchain because its imported foundation has 53 Mathlib-drift errors; status has been downgraded to formalized until the chain builds green.",
   "meta": {
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
     "tags": [
       "functional-analysis",
@@ -18,7 +18,8 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 208,
-    "assumptions": "0 axioms, 0 sorries. All 3 sorries eliminated by importing proofs from CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean (namespace RieszSigmaFiniteComplete). The theorems have identical signatures; delegation via exact calls.",
+    "buildStatus": "broken",
+    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file transitively fails to compile against leanprover/lean4:v4.26.0. It imports the chain foundation CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean, which produces 53 Mathlib-drift errors; the dependent companion CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean and this file therefore also fail to build. There are 0 literal `sorry` tactics and 0 `axiom` declarations — the formalization exists but is not currently machine-checked, so status was downgraded verified→formalized pending repair of the foundation file. Mathematical content (3 main theorems delegated to RieszSigmaFiniteComplete.* via exact calls) is unchanged.",
     "dateAdded": "2026-05-03",
     "theoremCount": 5,
     "definitionCount": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
   "title": "Radon-Nikodým Route to Lp Duality",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
-  "description": "Can Mathlib's Radon-Nikodým machinery (SignedMeasure.rnDeriv) be composed with Lp membership to eliminate the surjectivity axiom? Answer: yes — all steps proved, 0 sorries.",
+  "description": "Can Mathlib's Radon-Nikodým machinery (SignedMeasure.rnDeriv) be composed with Lp membership to eliminate the surjectivity axiom? Answer: yes — all steps formalized with 0 sorries. NOTE (2026-06-24, #28788): the file no longer compiles against the pinned v4.26.0 toolchain due to Mathlib API drift (53 errors); repair is tracked separately and the status has been downgraded to formalized until the build is green.",
   "meta": {
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
     "tags": [
       "functional-analysis",
@@ -17,7 +17,8 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 1077,
-    "assumptions": "No axioms, no sorries. Main theorem riesz_lp_surjective_from_rn proved via signedMeasureOfFunctional + holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc + integral_representation. Dead-path theorems (truncated_rn_deriv_lq_bound, rn_deriv_memLq) removed 2026-04-23.",
+    "buildStatus": "broken",
+    "assumptions": "BUILD BROKEN (2026-06-24, issue #28788): this file does NOT currently compile against the pinned toolchain leanprover/lean4:v4.26.0 — Mathlib API drift produces 53 errors (`Real.HolderTriple.one_lt_of_lt` removed, `Function.sign` removed, `MeasureTheory.Measure.withDensityᵥ_apply` renamed, plus ~dozen unsolved-goals / application-type-mismatch sites). The file was last green ~2026-04 before a Mathlib bump; no automated gate built it, so the drift rotted silently. There are 0 literal `sorry` tactics and 0 `axiom` declarations, but the formalization is not currently machine-checked, so status was downgraded verified→formalized pending repair. Mathematical content (riesz_lp_surjective_from_rn via signedMeasureOfFunctional + holder_extremizer_lq_bound + rn_deriv_memLq_from_trunc + integral_representation) is unchanged; dead-path theorems (truncated_rn_deriv_lq_bound, rn_deriv_memLq) removed 2026-04-23.",
     "dateAdded": "2026-04-13",
     "theoremCount": 18,
     "definitionCount": 3


### PR DESCRIPTION
## Summary

Fixes the integrity violation in #28788. The σ-finite Riesz-representation **Lᵖ-duality** chain does **not compile** against the pinned toolchain `leanprover/lean4:v4.26.0`. Two gallery entries claimed `status: verified, axiomCount: 0` over this broken source.

Reproduced on `main` (host `lake env lean`, green positive control `BaselProblem` builds clean):
- `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` → **53 errors** of Mathlib API drift
  (`Real.HolderTriple.one_lt_of_lt` removed, `Function.sign` removed, `withDensityᵥ_apply` renamed, plus ~dozen `unsolved goals` / `Application type mismatch` sites).
- The dependent companion `...OQ01OQ01Incomplete01.lean` (imports the foundation at line 33) + `...OQ01OQ01.lean` transitively fail.

**Note:** the issue table listed 2 entries; a **3rd** gallery entry (`...-incomplete-01`, the mid-chain companion) also claimed `verified` over the broken source and is corrected here too.

There are **0 literal `sorry` tactics** and **0 `axiom` declarations** — the formalizations exist but are not currently machine-checked.

## Change (remediation step 3 of #28788)

Both metas downgraded `verified → formalized`, `buildStatus: "broken"` added, and the drift documented in `assumptions`/`description`:

| Entry | before | after |
|---|---|---|
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` | verified / mathlib / 0 | **formalized** / mathlib / 0 |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` | verified / original / 0 | **formalized** / original / 0 |
| `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01` | verified / original / 0 | **formalized** / original / 0 |

`badge` and `axiomCount` are unchanged (no axioms; `formalized` allows any badge — 70 existing entries use it).

## Scope

Metadata-only. This restores honest gallery claims **now**. The deep multi-session Lean repair (mechanical renames → unsolved-goals sites → rebuild up the chain) is left to the research strand already working `cauchy-schwarz-integral-lp-duality-synthesis`; once the chain is green again, status can be restored to `verified`.

Refs #28788 (status-correction step only — does **not** close it; the multi-session Lean repair remains tracked by the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

