### PR TITLE
research(pentagonal-number-theorem-oq-01): pentSeriesCoeff as a finite sum over the computable pentIndices enumerator

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -401,6 +401,36 @@ theorem pentSeriesCoeff_one : pentSeriesCoeff 1 = -1 := by
   rw [genPent_one] at h
   rw [h]; rfl
 
+/-- **The series coefficient as a finite sum over the computable enumerator.**
+Although `pentSeriesCoeff` is `noncomputable` (it picks the matching index via
+`Classical.choose`), it agrees with the *explicit* finite sum over `pentIndices n`
+(Part 3c) that keeps only the index landing on `n` exactly.  Since `genPent` is
+injective, at most one summand survives, so the right-hand side is `pentSign k`
+when `n = g(k)` and `0` otherwise — precisely `pentSeriesCoeff`.  This turns the
+abstract `[Xⁿ]` coefficient into a `Finset`-evaluable expression: the form
+Euler's recurrence `p(n) = ∑ₖ (-1)ᵏ⁻¹ p(n - g_k)` ranges over. -/
+theorem pentSeriesCoeff_eq_sum_pentIndices (n : ℤ) :
+    pentSeriesCoeff n
+      = ∑ k ∈ pentIndices n, if genPent k = n then pentSign k else 0 := by
+  by_cases h : IsGenPent n
+  · obtain ⟨k₀, hk₀⟩ := h
+    have hval : genPent k₀ = n := by
+      have h2 := two_mul_genPent k₀; linarith [hk₀, h2]
+    rw [Finset.sum_eq_single k₀]
+    · rw [if_pos hval, ← hval, pentSeriesCoeff_genPent]
+    · intro b _ hb
+      have hbne : genPent b ≠ n := fun hbn =>
+        hb (genPent_injective (hbn.trans hval.symm))
+      rw [if_neg hbne]
+    · intro hmem
+      exact absurd (mem_pentIndices.mpr hval.le) hmem
+  · rw [pentSeriesCoeff_of_not h]
+    refine (Finset.sum_eq_zero ?_).symm
+    intro k _
+    have hkne : genPent k ≠ n := fun hkn =>
+      h ⟨k, by have h2 := two_mul_genPent k; linarith [hkn, h2]⟩
+    rw [if_neg hkne]
+
 /-! ## Part 6: The Mathlib power-series bridges (both ends of Euler's identity)
 
 Mathlib's 2025 `Combinatorics.Enumerative.Partition.GenFun` (Weiyi Wang) supplies

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -13,9 +13,9 @@
       "PowerSeries.WithPiTopology"
     ],
     "namespace": "PentagonalNumberTheoremOQ01",
-    "lineCount": 564,
+    "lineCount": 594,
     "axiomCount": 0,
-    "theoremCount": 43,
+    "theoremCount": 44,
     "definitionCount": 6,
     "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
     "sorries": 0
@@ -84,13 +84,14 @@
       "Both ends of Euler's identity machine-checked through Mathlib's 2025 Partition.GenFun (Weiyi Wang) under the Euler character pentChar i c = (if c = 1 then -1 else 0): genFun_pent_eq_tprod proves the PRODUCT side genFun pentChar = ∏_{i}(1 - X^{i+1}) (each inner tsum collapses to -(X^{i+1}) since the character is supported on multiplicity 1, via tsum_eq_single), and coeff_genFun_pent proves the COEFFICIENT side [Xⁿ] genFun pentChar = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card} = p_even(n)-p_odd(n) (a partition with a repeated part contributes a 0 factor and drops out; a distinct-part partition contributes (-1)^{#parts}, via a Nodup/¬Nodup split over n.Partition and Finset.sum_filter_add_sum_filter_not). Together these reduce the entire remaining open core to the single Franklin-involution identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n).",
       "The two ends joined with no genFun intermediary visible: coeff_tprod_pent composes the product side genFun_pent_eq_tprod with the coefficient side coeff_genFun_pent to state Euler's identity directly on Mathlib's power-series product — [Xⁿ] ∏'_{i}(1 - X^{i+1}) = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card}. coeff_tprod_pent_eq_evenOdd_diff then splits that signed sum by the parity of the number of parts to read the coefficient as the literal difference p_even(n) - p_odd(n): [Xⁿ]∏(1-Xᵐ) = #{distinct-part partitions of n with an even number of parts} - #{those with an odd number}. This is the directly-citable form of Euler's product/partition identity, leaving only the Franklin involution ∑_{p∈distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n) as the open core.",
       "disc_genPent / disc_genPent_neg: explicit discriminant roots 24·g(±k)+1 = (6k∓1)², naming the concrete square in the recognition criterion (where isGenPent_iff_isSquare only asserts existence); the two roots 6k∓1 of the ±k pair straddle 6k symmetrically",
-      "genPent_add_neg: the ±-pairing sum g(k)+g(-k) = 3k² (complementing genPent_neg's difference g(-k)-g(k)=k), so the two pentagonal shifts in Euler's recurrence have sum 3k² and difference k"
+      "genPent_add_neg: the ±-pairing sum g(k)+g(-k) = 3k² (complementing genPent_neg's difference g(-k)-g(k)=k), so the two pentagonal shifts in Euler's recurrence have sum 3k² and difference k",
+      "pentSeriesCoeff_eq_sum_pentIndices: the noncomputable series coefficient pentSeriesCoeff n equals the explicit finite sum over the computable enumerator pentIndices n keeping only the index hitting n exactly (sum of pentSign k over k with genPent k = n); by genPent_injective at most one summand survives, turning the abstract [Xn] coefficient into a Finset-evaluable expression in the form Euler's partition recurrence ranges over"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,
-    "lineCount": 530,
+    "lineCount": 594,
     "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. pentSeriesCoeff is a noncomputable def using Classical.choice (a foundational axiom that the project's axiom policy does not count toward axiomCount). The genFun bridges genFun_pent_eq_tprod, coeff_genFun_pent and the two composed tprod headlines coeff_tprod_pent, coeff_tprod_pent_eq_evenOdd_diff each #print axioms to [propext, Classical.choice, Quot.sound] — only the standard foundational axioms, none counted. Machine-verified — the file compiles cleanly under the docker Lean build against Mathlib (Built Proofs.PentagonalNumberTheoremOQ01, 7743 jobs, exit 0).",
-    "theoremCount": 39,
+    "theoremCount": 40,
     "definitionCount": 6
   },
   "overview": {

--- a/src/data/research/problems/pentagonal-number-theorem-oq-01.json
+++ b/src/data/research/problems/pentagonal-number-theorem-oq-01.json
@@ -21,7 +21,8 @@
       "genPent_sq_le_self (k²≤g(k)), index_le_genPent / neg_index_le_genPent / abs_index_le_genPent (|k|≤g(k)), mul_pred_nonneg / mul_succ_nonneg (consecutive-integer products ≥0) [PentagonalNumberTheoremOQ01.lean]",
       "indexSet_finite: for any n, {k | g(k) ≤ n} is finite (⊆ [-n,n]) — Euler's recurrence is a finite sum [PentagonalNumberTheoremOQ01.lean]",
       "pentIndices (def) + mem_pentIndices + coe_pentIndices: COMPUTABLE Finset enumerator of contributing indices {k | g(k) ≤ n} filtered from [-n,n]; membership ⟺ g(k) ≤ n, and its Set coercion is exactly the index set indexSet_finite proves finite [PentagonalNumberTheoremOQ01.lean]",
-      "genPent_neg: the ±k pairing g(-k) = g(k) + k of Euler's recurrence (the two shifts g(k), g(-k) appearing together differ by exactly k) [PentagonalNumberTheoremOQ01.lean]"
+      "genPent_neg: the ±k pairing g(-k) = g(k) + k of Euler's recurrence (the two shifts g(k), g(-k) appearing together differ by exactly k) [PentagonalNumberTheoremOQ01.lean]",
+      "pentSeriesCoeff_eq_sum_pentIndices: the noncomputable [Xⁿ] series coefficient pentSeriesCoeff n = ∑_{k∈pentIndices n} (if genPent k = n then pentSign k else 0) — a finite, Finset-evaluable expression over the computable enumerator; genPent_injective leaves at most one surviving summand [PentagonalNumberTheoremOQ01.lean]"
     ],
     "mathlibGaps": [
       "Franklin's sign-reversing involution on partitions into distinct parts is still absent from Mathlib — the genuine combinatorial heart.",
@@ -29,6 +30,7 @@
       "RESOLVED 2026-06-19 (was an open gap S1–S4): the formal-power-series infinite product ∏(1-Xⁿ) IS now in Mathlib via Combinatorics.Enumerative.Partition.GenFun (genFun, genFun_eq_tprod, coeff_genFun) + Partition.Glaisher; distincts/odds are in Partition.Basic."
     ],
     "nextSteps": [
+      "DONE (Session 7, researcher-8): pentSeriesCoeff is now expressed as a finite sum over pentIndices (pentSeriesCoeff_eq_sum_pentIndices), so the RHS [Xⁿ]∑(-1)ᵏX^{g(k)} coefficient is Finset-evaluable — the bridge between Part 3c's computable enumerator and Part 5's abstract coefficient is closed. Remaining open core unchanged: Franklin's involution ∑_{p∈distincts n}(-1)^{#parts} = pentSeriesCoeff (n:ℤ).",
       "State the two now-FREE bridges as lemmas (when a backend recovers): (a) genFun (fun i c => if c=1 then (-1:ℤ) else 0) = ∏'_i (1 - X^{i+1}) via genFun_eq_tprod, and (b) coeff n (genFun f) = ∑_{p∈distincts n} (-1)^{p.parts.card} via coeff_genFun (show the character weight is 0 on repeated-part partitions, (-1)^{#parts} on distinct-part ones).",
       "State the lone remaining open identity as a single sorry: ∑_{p∈distincts n} (-1)^{p.parts.card} = pentSeriesCoeff (n:ℤ) (the ℕ↔ℤ bookkeeping aligns genFun's coefficient with pentSeriesCoeff_genPent/genPent_injective).",
       "Frontier: prove that sorry via Franklin's involution (pair smallest part with longest terminal staircase; fixed points ⟺ pentagonal staircases) — the deep multi-file development now isolated as the ONLY remaining gap."
@@ -39,8 +41,8 @@
     {
       "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
       "filename": "PentagonalNumberTheoremOQ01.lean",
-      "lineCount": 565,
-      "theoremCount": 41,
+      "lineCount": 594,
+      "theoremCount": 42,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Adds one verified theorem to the existing **Pentagonal Number Theorem OQ-01** entry, closing the gap between two halves of the file that previously sat unconnected:

- **Part 3c** built the *computable* enumerator `pentIndices n` — the `Finset` of indices `k` with `g(k) ≤ n`.
- **Part 5** built the *abstract* series coefficient `pentSeriesCoeff` — defined `noncomputable`ly via `Classical.choose`.

The new `pentSeriesCoeff_eq_sum_pentIndices` ties them together:

```
pentSeriesCoeff n = ∑ k ∈ pentIndices n, if genPent k = n then pentSign k else 0
```

This turns the otherwise-noncomputable `[Xⁿ]` coefficient of `∑ₖ (-1)ᵏ X^{g(k)}` into a `Finset`-evaluable expression — exactly the form Euler's partition recurrence `p(n) = ∑ₖ (-1)ᵏ⁻¹ p(n − g_k)` ranges over.

## Proof sketch

Case split on `IsGenPent n`:
- **Pentagonal** (`n = g(k₀)`): `Finset.sum_eq_single k₀` isolates the unique surviving summand. Uniqueness is `genPent_injective`; membership `k₀ ∈ pentIndices n` is `mem_pentIndices.mpr hval.le`; the value is `pentSign k₀ = pentSeriesCoeff n` via `pentSeriesCoeff_genPent`.
- **Non-pentagonal**: no index hits `n`, so every summand is `0` (`Finset.sum_eq_zero`); a hit would witness `IsGenPent n`.

## Verification

- Host-built against Mathlib (Lean `v4.26.0`), Docker daemon being unavailable this cycle.
- `#print axioms pentSeriesCoeff_eq_sum_pentIndices` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- **verified · +1 theorem (42 named theorems total) · 0 axioms · 0 sorries.**

## Scope

The deep open core is **unchanged**: Franklin's sign-reversing involution `∑_{p∈distincts n}(-1)^{#parts} = pentSeriesCoeff (n:ℤ)`, still absent from Mathlib. This PR is an index-theory bookkeeping step, not a claim on that identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)