### PR TITLE
research(catalan-numbers-oq-01-oq-01-oq-03): closed forms for central-binomial neighbours

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ01OQ03.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-
+# Catalan Numbers: closed forms for the central-binomial neighbours
+
+Open Question (`catalan-numbers-oq-01-oq-01-oq-03`, child of the reflection-form
+entry `catalan-numbers-oq-01-oq-01`).  The parent
+(`CatalanReflectionFormOQ01`) records the classical *reflection* identity
+
+  `catalan n = C(2n, n) − C(2n, n + 1)`,    i.e.    `C(2n, n) = catalan n + C(2n, n + 1)`,
+
+splitting the central binomial coefficient `B = C(2n, n)` as the Catalan number
+`C = catalan n` plus its immediate right neighbour `R = C(2n, n + 1)`.  That proof
+used the auxiliary relation `(n + 1) · R = n · B` as a *step*, but never recorded
+the resulting **closed form** of the neighbour itself.
+
+This entry sharpens the reflection form into exact closed forms: every binomial
+coefficient *adjacent* to the centre of row `2n` is an explicit multiple of the
+Catalan number.
+
+  * `C(2n, n + 1) = n · catalan n`            (the right neighbour, the main result),
+  * `C(2n, n − 1) = n · catalan n`            (the left neighbour, by the row symmetry),
+  * `(n + 2) · C(2n, n + 2) = n(n − 1) · catalan n`   (the second neighbour).
+
+Combinatorially: of the `C(2n, n)` central lattice paths, the `catalan n` Dyck
+paths sit at the centre, and each of the two flanking columns holds exactly
+`n · catalan n` of the remaining paths — the reflection principle counts them.
+The closed form `R = n · catalan n` makes the *strict* gap `R < B` transparent and
+recovers `(n + 1) · catalan n = centralBinom n` as the simple consequence
+`B = C + R = catalan n + n · catalan n`.
+
+Everything is over `ℕ`, fully machine-checked, `0` axioms.  We use only Mathlib's
+`succ_mul_catalan_eq_centralBinom`, the binomial step `Nat.choose_succ_right_eq`,
+and the row symmetry `Nat.choose_symm`.
+
+## Main results
+
+* `choose_central_succ`        : `C(2n, n + 1) = n · catalan n`.
+* `choose_central_pred`        : `C(2n, n − 1) = n · catalan n` (for `n ≥ 1`).
+* `succ_mul_choose_central_succ` : `(n + 1) · C(2n, n + 1) = n · centralBinom n`.
+* `choose_central_succ_two`    : `(n + 2) · C(2n, n + 2) = n(n − 1) · catalan n`.
+* `choose_central_succ_lt`     : `C(2n, n + 1) < C(2n, n)` (the strict reflection gap).
+* `centralBinom_eq_catalan_add_choose` : recovers the parent's additive split.
+-/
+
+namespace CatalanNumbersOQ01OQ01OQ03
+
+open Nat
+
+/-- The central binomial coefficient equals `(n + 1) · catalan n`, phrased with the
+explicit `(2 * n).choose n` (definitionally Mathlib's `centralBinom n`). -/
+private theorem choose_central (n : ℕ) : (2 * n).choose n = (n + 1) * catalan n :=
+  (succ_mul_catalan_eq_centralBinom n).symm
+
+/-- **Right neighbour of the central binomial coefficient.**
+
+  `C(2n, n + 1) = n · catalan n`.
+
+The immediate right neighbour of the central coefficient is exactly `n` times the
+`n`-th Catalan number.  This is the closed form behind the parent's reflection
+identity: the auxiliary relation `(n + 1) · C(2n, n+1) = n · C(2n, n)` is solved for
+`C(2n, n+1)` using `C(2n, n) = (n + 1) · catalan n`. -/
+theorem choose_central_succ (n : ℕ) :
+    (2 * n).choose (n + 1) = n * catalan n := by
+  -- Neighbour relation `(n + 1) · R = n · B`, from `Nat.choose_succ_right_eq`.
+  have hstep : (n + 1) * ((2 * n).choose (n + 1)) = n * ((2 * n).choose n) := by
+    have h := Nat.choose_succ_right_eq (2 * n) n
+    have e : 2 * n - n = n := by omega
+    rw [e] at h
+    calc (n + 1) * ((2 * n).choose (n + 1))
+          = (2 * n).choose (n + 1) * (n + 1) := by ring
+      _ = (2 * n).choose n * n := h
+      _ = n * ((2 * n).choose n) := by ring
+  -- Cancel the positive factor `n + 1` after substituting `B = (n + 1) · catalan n`.
+  have hmul : (n + 1) * ((2 * n).choose (n + 1)) = (n + 1) * (n * catalan n) := by
+    rw [hstep, choose_central]; ring
+  exact Nat.eq_of_mul_eq_mul_left (show 0 < n + 1 by omega) hmul
+
+/-- **Left neighbour of the central binomial coefficient.**
+
+  `C(2n, n − 1) = n · catalan n`    (for `n ≥ 1`).
+
+By the symmetry of row `2n` the left neighbour equals the right neighbour, hence
+the same closed form. -/
+theorem choose_central_pred (n : ℕ) (hn : 1 ≤ n) :
+    (2 * n).choose (n - 1) = n * catalan n := by
+  have hsymm : (2 * n).choose (n - 1) = (2 * n).choose (n + 1) := by
+    have e : 2 * n - (n + 1) = n - 1 := by omega
+    rw [← e, Nat.choose_symm (by omega)]
+  rw [hsymm, choose_central_succ]
+
+/-- **Multiplicative form of the right-neighbour identity.**
+
+  `(n + 1) · C(2n, n + 1) = n · centralBinom n`.
+
+The neighbour is to the centre as `n` is to `n + 1`. -/
+theorem succ_mul_choose_central_succ (n : ℕ) :
+    (n + 1) * (2 * n).choose (n + 1) = n * Nat.centralBinom n := by
+  rw [choose_central_succ, show Nat.centralBinom n = (2 * n).choose n from rfl,
+      choose_central]
+  ring
+
+/-- **Second right neighbour.**
+
+  `(n + 2) · C(2n, n + 2) = n · (n − 1) · catalan n`.
+
+Iterating the binomial step once more past the right neighbour `C(2n, n + 1)`. -/
+theorem choose_central_succ_two (n : ℕ) :
+    (n + 2) * (2 * n).choose (n + 2) = n * (n - 1) * catalan n := by
+  have h := Nat.choose_succ_right_eq (2 * n) (n + 1)
+  -- h : (2*n).choose (n + 1 + 1) * (n + 1 + 1) = (2*n).choose (n + 1) * (2*n - (n + 1))
+  rw [choose_central_succ] at h
+  have e : 2 * n - (n + 1) = n - 1 := by omega
+  rw [e] at h
+  -- h : (2*n).choose (n + 2) * (n + 2) = n * catalan n * (n - 1)
+  calc (n + 2) * (2 * n).choose (n + 2)
+        = (2 * n).choose (n + 2) * (n + 2) := by ring
+    _ = n * catalan n * (n - 1) := h
+    _ = n * (n - 1) * catalan n := by ring
+
+/-- The Catalan number is strictly positive (every row of `2n` has at least one
+Dyck path). -/
+private theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  rcases Nat.eq_zero_or_pos (catalan n) with h0 | h0
+  · exfalso
+    have h := succ_mul_catalan_eq_centralBinom n
+    rw [h0, Nat.mul_zero] at h
+    exact (Nat.centralBinom_pos n).ne h
+  · exact h0
+
+/-- **Strict reflection gap.**
+
+  `C(2n, n + 1) < C(2n, n)`.
+
+The right neighbour is strictly below the central coefficient (their difference is
+the positive number `catalan n`), so the `ℕ`-subtraction in the parent's reflection
+form is a genuine difference, never truncated. -/
+theorem choose_central_succ_lt (n : ℕ) :
+    (2 * n).choose (n + 1) < (2 * n).choose n := by
+  rw [choose_central_succ, choose_central]
+  have hpos := catalan_pos n
+  nlinarith [hpos]
+
+/-- **Recovering the parent's additive reflection split** from the closed form:
+
+  `C(2n, n) = catalan n + C(2n, n + 1)`. -/
+theorem centralBinom_eq_catalan_add_choose (n : ℕ) :
+    (2 * n).choose n = catalan n + (2 * n).choose (n + 1) := by
+  rw [choose_central, choose_central_succ]; ring
+
+/-- Sanity check (`n = 4`): `C(8, 5) = 56 = 4 · 14 = 4 · catalan 4`. -/
+example : (2 * 4).choose (4 + 1) = 4 * catalan 4 := choose_central_succ 4
+
+/-- `C(8, 5) = 56 = 4 · 14`. -/
+example : Nat.choose 8 5 = 4 * 14 := by decide
+
+/-- Second neighbour at `n = 4`: `(4 + 2) · C(8, 6) = 4 · 3 · catalan 4`, i.e.
+`6 · 28 = 12 · 14 = 168`. -/
+example : Nat.choose 8 6 * 6 = 4 * 3 * 14 := by decide
+
+end CatalanNumbersOQ01OQ01OQ03

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-03",
+    "range": { "startLine": 3, "endLine": 44 },
+    "type": "context",
+    "title": "From the reflection split to closed-form neighbours",
+    "content": "The parent reflection-form entry proved catalan n = C(2n,n) − C(2n,n+1), i.e. the additive split C(2n,n) = catalan n + C(2n,n+1). To get there it used the binomial step relation (n+1)·C(2n,n+1) = n·C(2n,n) but only as scaffolding — it never recorded what the neighbour C(2n,n+1) actually equals. This entry closes that gap: solving the step relation gives the clean closed form C(2n,n+1) = n·catalan n. So the two coefficients flanking the centre of row 2n are exact integer multiples of the n-th Catalan number, and the reflection split reappears as C(2n,n) = catalan n + n·catalan n = (n+1)·catalan n.",
+    "mathContext": "$\\binom{2n}{n+1} = n\\,\\mathrm{catalan}\\,n$, $\\binom{2n}{n-1} = n\\,\\mathrm{catalan}\\,n$, and $\\binom{2n}{n} = (n+1)\\,\\mathrm{catalan}\\,n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "central binomial coefficient",
+      "reflection principle",
+      "ballot numbers",
+      "binomial coefficients"
+    ],
+    "prerequisites": ["binomial coefficients", "Catalan numbers"]
+  },
+  {
+    "id": "ann-choose-central-succ",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-03",
+    "range": { "startLine": 55, "endLine": 77 },
+    "type": "key-insight",
+    "title": "The right-neighbour closed form C(2n, n+1) = n·catalan n",
+    "content": "The headline result. Two Mathlib facts combine: the bridge C(2n,n) = (n+1)·catalan n (succ_mul_catalan_eq_centralBinom) and the binomial step (n+1)·C(2n,n+1) = n·C(2n,n) (Nat.choose_succ_right_eq at (2n,n), using 2n−n = n). Substituting the first into the second gives (n+1)·C(2n,n+1) = n·(n+1)·catalan n; cancelling the positive factor n+1 (Nat.eq_of_mul_eq_mul_left) leaves C(2n,n+1) = n·catalan n. Combinatorially: of the C(2n,n) central lattice paths, catalan n are Dyck paths and the flanking column holds exactly n times as many.",
+    "mathContext": "$(n+1)\\binom{2n}{n+1} = n\\binom{2n}{n} = n(n+1)\\,\\mathrm{catalan}\\,n \\Rightarrow \\binom{2n}{n+1} = n\\,\\mathrm{catalan}\\,n$.",
+    "significance": "high",
+    "relatedConcepts": ["central binomial coefficient", "Catalan numbers", "cancellation"],
+    "prerequisites": ["binomial recurrence", "Catalan–central-binomial bridge"]
+  },
+  {
+    "id": "ann-choose-central-pred",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-03",
+    "range": { "startLine": 79, "endLine": 90 },
+    "type": "technique",
+    "title": "Left neighbour via row symmetry",
+    "content": "The left neighbour needs no new arithmetic: row 2n is symmetric, and since (n+1)+(n−1) = 2n we have C(2n, n−1) = C(2n, n+1) by Nat.choose_symm. Hence C(2n, n−1) = n·catalan n as well (for n ≥ 1, so that n−1 and the symmetry index are well-formed over ℕ).",
+    "mathContext": "$\\binom{2n}{n-1} = \\binom{2n}{2n-(n+1)} = \\binom{2n}{n+1} = n\\,\\mathrm{catalan}\\,n$.",
+    "significance": "medium",
+    "relatedConcepts": ["binomial symmetry", "central binomial coefficient"],
+    "prerequisites": ["binomial coefficient symmetry"]
+  },
+  {
+    "id": "ann-choose-central-succ-two",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-03",
+    "range": { "startLine": 103, "endLine": 119 },
+    "type": "key-insight",
+    "title": "Second neighbour: (n+2)·C(2n, n+2) = n(n-1)·catalan n",
+    "content": "Iterating the binomial step once more, at (2n, n+1), gives (n+2)·C(2n,n+2) = (2n−(n+1))·C(2n,n+1) = (n−1)·C(2n,n+1). Substituting the first-neighbour closed form C(2n,n+1) = n·catalan n yields (n+2)·C(2n,n+2) = n(n−1)·catalan n. Kept in multiplicative form so the identity stays exact over ℕ (the quotient n(n−1)/(n+2) need not be an integer).",
+    "mathContext": "$(n+2)\\binom{2n}{n+2} = (n-1)\\binom{2n}{n+1} = n(n-1)\\,\\mathrm{catalan}\\,n$.",
+    "significance": "medium",
+    "relatedConcepts": ["ballot numbers", "Catalan triangle", "binomial recurrence"],
+    "prerequisites": ["binomial recurrence"]
+  },
+  {
+    "id": "ann-strict-gap",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-03",
+    "range": { "startLine": 121, "endLine": 142 },
+    "type": "observation",
+    "title": "The strict gap C(2n,n+1) < C(2n,n) and a genuine difference",
+    "content": "Because C(2n,n) = (n+1)·catalan n and C(2n,n+1) = n·catalan n, the gap between centre and neighbour is exactly catalan n. Strict positivity of catalan n (forced by Nat.centralBinom_pos through the bridge) gives n·catalan n < (n+1)·catalan n, so C(2n,n+1) < C(2n,n). This certifies that the ℕ-subtraction in the parent's reflection form catalan n = C(2n,n) − C(2n,n+1) is a true difference, never silently truncated to 0.",
+    "mathContext": "$\\binom{2n}{n} - \\binom{2n}{n+1} = (n+1)\\,\\mathrm{catalan}\\,n - n\\,\\mathrm{catalan}\\,n = \\mathrm{catalan}\\,n > 0$.",
+    "significance": "medium",
+    "relatedConcepts": ["strict monotonicity", "Catalan positivity"],
+    "prerequisites": ["positivity of central binomial coefficient"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,99 @@
+{
+  "id": "catalan-numbers-oq-01-oq-01-oq-03",
+  "slug": "catalan-numbers-oq-01-oq-01-oq-03",
+  "title": "Catalan Numbers: closed forms for the central-binomial neighbours C(2n,n±1) = n·catalan n",
+  "description": "Closed forms for the binomial coefficients adjacent to the centre of row 2n, sharpening the parent reflection identity. The right neighbour C(2n, n+1) = n·catalan n, the left neighbour C(2n, n-1) = n·catalan n (by row symmetry), and the second neighbour (n+2)·C(2n, n+2) = n(n-1)·catalan n. The parent reflection-form entry proved only the additive split C(2n,n) = catalan n + C(2n,n+1) and used (n+1)·C(2n,n+1) = n·C(2n,n) as an internal step, but never recorded the resulting closed form of the neighbour itself; this entry solves for it. The closed form makes the strict gap C(2n,n+1) < C(2n,n) transparent and recovers the parent's additive split as the one-line consequence C(2n,n) = catalan n + n·catalan n = (n+1)·catalan n. Fully verified over ℕ, 0 axioms, 0 sorries.",
+  "overview": "Mathlib gives the multiplicative bridge succ_mul_catalan_eq_centralBinom: (n+1)·catalan n = centralBinom n = C(2n,n), and the binomial step Nat.choose_succ_right_eq, which at (2n, n) reads (n+1)·C(2n,n+1) = n·C(2n,n) since 2n−n = n. Substituting C(2n,n) = (n+1)·catalan n into the step and cancelling the positive factor n+1 yields the headline closed form C(2n,n+1) = n·catalan n. The left neighbour follows from the row symmetry Nat.choose_symm (C(2n,n−1) = C(2n,n+1)). Iterating Nat.choose_succ_right_eq once more at (2n, n+1) gives the second neighbour (n+2)·C(2n,n+2) = (n−1)·C(2n,n+1) = n(n−1)·catalan n. Strict positivity of catalan n (from centralBinom_pos) certifies the strict gap C(2n,n+1) < C(2n,n). Everything is elementary arithmetic over ℕ.",
+  "conclusion": "The binomial coefficients flanking the centre of row 2n are exact multiples of the Catalan number: both immediate neighbours equal n·catalan n, and the second neighbour satisfies (n+2)·C(2n,n+2) = n(n-1)·catalan n. These closed forms are the multiplicative counterpart of the parent's additive reflection identity, and they exhibit the strict descent C(2n,n+1) < C(2n,n) whose difference is exactly catalan n. Mathlib records neither the reflection difference nor these neighbour closed forms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat"],
+    "namespace": "CatalanNumbersOQ01OQ01OQ03",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The reflection-form entry: catalan n = C(2n,n) − C(2n,n+1), the additive split C(2n,n) = catalan n + C(2n,n+1). This child solves the internal neighbour relation (n+1)·C(2n,n+1) = n·C(2n,n) for the closed form C(2n,n+1) = n·catalan n, recovering the additive split as a corollary."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "related",
+      "description": "The grandparent: the O(1) holonomic recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n, also derived from the central-binomial bridge succ_mul_catalan_eq_centralBinom."
+    },
+    {
+      "proofId": "dyck-catalan-count-oq-01",
+      "relationship": "related",
+      "description": "Enumerates Dyck paths by the Catalan numbers — the combinatorial objects whose central and near-central lattice-path counts these binomial identities compare."
+    }
+  ],
+  "references": [],
+  "sections": [],
+  "meta": {
+    "author": "Classical central-binomial identities; Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "central-binomial",
+      "binomial-coefficients",
+      "reflection-principle",
+      "closed-form",
+      "enumerative-combinatorics",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n + 1) * catalan n = Nat.centralBinom n. The multiplicative bridge from Catalan numbers to the central binomial coefficient; supplies C(2n,n) = (n+1)*catalan n, used to cancel n+1 and to substitute for the central coefficient.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "n.choose (k+1) * (k+1) = n.choose k * (n - k). At (2n, n) gives the first-neighbour relation (n+1)*C(2n,n+1) = n*C(2n,n); at (2n, n+1) gives the second-neighbour relation (n+2)*C(2n,n+2) = (n-1)*C(2n,n+1).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "k ≤ n → n.choose (n - k) = n.choose k. At (2n, n+1) gives the row symmetry C(2n, n-1) = C(2n, n+1), so the left neighbour shares the right neighbour's closed form.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < Nat.centralBinom n. Combined with the bridge it forces catalan n > 0, certifying the strict gap C(2n,n+1) < C(2n,n).",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "0 < k → k*a = k*b → a = b. Cancels the positive factor n+1 to extract the closed form C(2n,n+1) = n*catalan n.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "choose_central_succ: the closed form C(2n, n+1) = n·catalan n for the right neighbour of the central binomial coefficient — the headline. Obtained by solving the parent's internal step relation (n+1)·C(2n,n+1) = n·C(2n,n) using C(2n,n) = (n+1)·catalan n and cancelling n+1. Not in Mathlib.",
+      "choose_central_pred: the left neighbour C(2n, n-1) = n·catalan n (n ≥ 1), via the row symmetry C(2n,n-1) = C(2n,n+1).",
+      "succ_mul_choose_central_succ: the multiplicative form (n+1)·C(2n,n+1) = n·centralBinom n — the neighbour is to the centre as n is to n+1.",
+      "choose_central_succ_two: the second neighbour (n+2)·C(2n,n+2) = n(n-1)·catalan n, iterating the binomial step once past the first neighbour. ℕ-clean multiplicative form.",
+      "choose_central_succ_lt: the strict gap C(2n,n+1) < C(2n,n), certifying that the parent's reflection subtraction is a genuine (non-truncated) difference of size catalan n > 0.",
+      "centralBinom_eq_catalan_add_choose: recovers the parent's additive reflection split C(2n,n) = catalan n + C(2n,n+1) as a one-line consequence of the closed form.",
+      "Kernel-decide witnesses: C(8,5) = 56 = 4·14 = 4·catalan 4 and C(8,6)·6 = 168 = 4·3·14, confirming the first- and second-neighbour identities numerically with no native_decide."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all six public theorems. Concrete checks use kernel `decide` only (no native_decide, hence no Lean.ofReduceBool).",
+    "lineCount": 161,
+    "theoremCount": 8,
+    "definitionCount": 0
+  }
+}

--- a/src/data/research/problems/catalan-numbers-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/catalan-numbers-oq-01-oq-01-oq-03.json
@@ -1,0 +1,149 @@
+{
+  "slug": "catalan-numbers-oq-01-oq-01-oq-03",
+  "title": "Catalan convolution / further central-binomial identity extending the reflection form",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in combinatorics: Catalan convolution / further central-binomial identity extending the reflection form.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T04:57:05.033Z",
+    "iteration": 1,
+    "focus": "Completed: closed forms for central-binomial neighbours, verified 0-axiom.",
+    "blockers": [],
+    "nextAction": "None — entry shipped (PR #28792).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom closed forms for the central-binomial neighbours, sharpening the parent reflection identity (PR #28792).",
+    "builtItems": [
+      "choose_central_succ: C(2n,n+1) = n*catalan n",
+      "choose_central_pred: C(2n,n-1) = n*catalan n (n>=1)",
+      "succ_mul_choose_central_succ: (n+1)*C(2n,n+1) = n*centralBinom n",
+      "choose_central_succ_two: (n+2)*C(2n,n+2) = n(n-1)*catalan n",
+      "choose_central_succ_lt: C(2n,n+1) < C(2n,n)",
+      "centralBinom_eq_catalan_add_choose: recovers the parent additive split"
+    ],
+    "insights": [
+      "The parent reflection-form entry proved the additive split C(2n,n) = catalan n + C(2n,n+1) and used (n+1)*C(2n,n+1) = n*C(2n,n) only as an internal step, never recording the neighbour closed form.",
+      "Solving that step relation with the bridge C(2n,n) = (n+1)*catalan n and cancelling n+1 gives C(2n,n+1) = n*catalan n — the headline result, not in Mathlib.",
+      "Row symmetry (Nat.choose_symm) makes the left neighbour C(2n,n-1) share the same closed form n*catalan n.",
+      "Iterating Nat.choose_succ_right_eq at (2n,n+1) yields (n+2)*C(2n,n+2) = n(n-1)*catalan n, kept multiplicative to stay exact over the naturals.",
+      "Strict positivity of catalan n (via Nat.centralBinom_pos) certifies the strict gap C(2n,n+1) < C(2n,n), the genuine reflection difference."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the catalan<->centralBinom bridge and the binomial step recurrence but records neither the reflection difference nor closed forms for the off-central coefficients C(2n,n+-k)."
+    ],
+    "nextSteps": [
+      "Open extension: central-binomial self-convolution sum centralBinom i * centralBinom (n-i) = 4^n, needs generalized-binomial (Ring.choose over the rationals) Chu-Vandermonde; materially harder."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "catalan",
+    "binomial",
+    "seeker-selected",
+    "intermediate"
+  ],
+  "relatedProofs": [
+    "catalan-numbers-oq-01",
+    "catalan-numbers-oq-01-oq-01",
+    "catalan-numbers-oq-01-oq-01-oq-02",
+    "catalan-numbers-oq-01-oq-01-oq-02-oq-03",
+    "catalan-numbers-oq-01-oq-02",
+    "catalan-numbers-oq-01-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T04:57:05.033Z",
+  "lastUpdate": "2026-06-24T05:00:00.000Z",
+  "significance": 5,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "axiomCount": 0,
+      "defCount": 0,
+      "filename": "CatalanNumbersOQ01OQ01OQ03.lean",
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01OQ01OQ03.lean",
+      "isAristotle": false,
+      "lineCount": 161,
+      "path": "Proofs/CatalanNumbersOQ01OQ01OQ03.lean",
+      "sorryCount": 0,
+      "theoremCount": 8
+    },
+    {
+      "path": "Proofs/CatalanNumbersOQ01.lean",
+      "filename": "CatalanNumbersOQ01.lean",
+      "lineCount": 64,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01.lean"
+    },
+    {
+      "path": "Proofs/CatalanNumbersOQ01OQ01OQ02.lean",
+      "filename": "CatalanNumbersOQ01OQ01OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CatalanNumbersOQ01OQ01OQ02OQ03.lean",
+      "filename": "CatalanNumbersOQ01OQ01OQ02OQ03.lean",
+      "lineCount": 104,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01OQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CatalanNumbersOQ01OQ02.lean",
+      "filename": "CatalanNumbersOQ01OQ02.lean",
+      "lineCount": 176,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CatalanNumbersOQ01OQ02OQ01.lean",
+      "filename": "CatalanNumbersOQ01OQ02OQ01.lean",
+      "lineCount": 138,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CatalanNumbersOQ01OQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **catalan-numbers-oq-01-oq-01-oq-03**, a child of the reflection-form entry `catalan-numbers-oq-01-oq-01`. It sharpens the parent's *additive* reflection identity into **closed forms** for the binomial coefficients flanking the centre of row `2n`:

| identity | statement |
|---|---|
| right neighbour (headline) | `C(2n, n+1) = n · catalan n` |
| left neighbour | `C(2n, n-1) = n · catalan n` (row symmetry) |
| second neighbour | `(n+2) · C(2n, n+2) = n(n-1) · catalan n` |
| multiplicative form | `(n+1) · C(2n, n+1) = n · centralBinom n` |
| strict gap | `C(2n, n+1) < C(2n, n)` |
| corollary | recovers the parent's additive split `C(2n,n) = catalan n + C(2n,n+1)` |

## Why this is new

The parent reflection-form entry proved `catalan n = C(2n,n) − C(2n,n+1)` and used the binomial step `(n+1)·C(2n,n+1) = n·C(2n,n)` only as **internal scaffolding** — it never recorded what the neighbour `C(2n,n+1)` actually equals. This entry solves that step relation (substitute the bridge `C(2n,n) = (n+1)·catalan n`, cancel `n+1`) to obtain the closed form `C(2n,n+1) = n·catalan n`. Mathlib records neither the reflection difference nor these neighbour closed forms.

## Verification

- Builds against Mathlib v4.26.0 (`Proofs.CatalanNumbersOQ01OQ01OQ03`).
- **0 sorries, 0 axioms.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for all six public theorems.
- Numeric witnesses use **kernel `decide`** only (no `native_decide`, hence no `Lean.ofReduceBool`).
- 161 lines, 8 theorems (6 public + 2 private helpers), 0 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)