### PR TITLE
Enrich Feuerbach Altitude-Length Law: add annotations

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-02/annotations.json
@@ -1,0 +1,184 @@
+[
+  {
+    "id": "ann-ftd-oq0102-docstring",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "The Open Question: Measuring the Altitude",
+    "content": "The module docstring frames the gap left by the sibling file FeuerbachsTheoremDefsOQ01. That file pins down each altitude foot by its defining properties — the foot lies on the opposite side (collinearity) and the altitude meets the base at a right angle (perpendicularity) — and records the Pythagorean split at the foot. What it never computes is the *length* of the altitude, the height $h_a = |A H_a|$ that the schoolbook formula packages as $\\text{Area} = \\tfrac{1}{2}\\,|BC|\\,h_a$. Without a length law the foot is characterized only by direction; the metric content — how far the vertex sits from its opposite side — is missing. This file supplies exactly that, for all three altitudes at once, and then proves the area computed from any base agrees.",
+    "mathContext": "Foot of the altitude from $A$: $H_a = B + t\\,(C-B)$ with $t = \\dfrac{(A-B)\\cdot(C-B)}{\\lVert C-B\\rVert^2}$. The unmeasured quantity is the squared height $\\lVert A H_a\\rVert^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "altitude",
+      "orthogonal projection",
+      "nine-point circle",
+      "Feuerbach point"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "Euclidean distance"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-imports",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Importing the Coordinate API",
+    "content": "The file imports only FeuerbachsTheoremDefs, reusing the entire coordinate API rather than re-deriving it: the Point and Triangle structures, the foot definitions foot_a/foot_b/foot_c, the squared-distance function dist2_sq, the area function, and — crucially — the side-length non-degeneracy lemmas bc_sq_ne_zero / ca_sq_ne_zero / ab_sq_ne_zero. Those non-degeneracy facts are what license clearing the projection denominators. The section is marked noncomputable because the parent's area uses real-valued operations, and unusedVariables linting is disabled because the triangle argument T appears only inside unfolded definitions.",
+    "mathContext": "Reused non-degeneracy: $\\lVert C-B\\rVert^2 \\neq 0$, $\\lVert A-C\\rVert^2 \\neq 0$, $\\lVert B-A\\rVert^2 \\neq 0$, each equivalent to two vertices being distinct.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-degeneracy",
+      "code reuse",
+      "noncomputable definitions"
+    ],
+    "prerequisites": [
+      "Lean module system",
+      "FeuerbachsTheoremDefs"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-length-law-a",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "The Altitude-Length Law via Lagrange's Identity",
+    "content": "This is the heart of the file. The theorem foot_a_altitude_length_sq states that the squared altitude length times the squared base equals the squared signed area. The proof is purely algebraic: after `unfold dist2_sq Triangle.foot_a`, the squared height carries the projection denominator $\\lVert C-B\\rVert^2$ in it, so multiplying by $\\lVert C-B\\rVert^2$ cancels that denominator (justified by bc_sq_ne_zero, fed to field_simp). What survives is the Gram/Lagrange numerator $\\lVert A-B\\rVert^2\\lVert C-B\\rVert^2 - ((A-B)\\cdot(C-B))^2$, and Lagrange's identity equates it with the squared cross product — the signed area squared. A single `ring` discharges the polynomial identity.",
+    "mathContext": "$\\lVert A H_a\\rVert^2\\,\\lVert C-B\\rVert^2 = \\lVert A-B\\rVert^2\\lVert C-B\\rVert^2 - \\big((A-B)\\cdot(C-B)\\big)^2 = \\big((A-B)\\times(C-B)\\big)^2 = \\Delta^2.$ Lagrange/Cauchy–Binet in 2D: $\\lVert u\\rVert^2\\lVert v\\rVert^2 - (u\\cdot v)^2 = (u\\times v)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange's identity",
+      "Cauchy–Binet formula",
+      "Gram determinant",
+      "orthogonal projection",
+      "cross product"
+    ],
+    "prerequisites": [
+      "Lagrange's identity",
+      "dot and cross products",
+      "field_simp / ring tactics"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-length-law-bc",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 97
+    },
+    "type": "technique",
+    "title": "The Same Law from the Other Two Bases",
+    "content": "foot_b_altitude_length_sq and foot_c_altitude_length_sq repeat the identical proof skeleton — `unfold`, supply the matching non-degeneracy lemma (ca_sq_ne_zero, ab_sq_ne_zero), `field_simp; ring` — for the altitudes from B and C. The striking feature is that all three theorems have the *same* right-hand side: the cross product $(B-A)\\times(C-A)$ squared. This is the translation invariance of the shoelace determinant at work: the signed area does not change when you re-base the vectors at a different vertex, so each base yields the same $\\Delta^2$. The uniformity of the proofs reflects the uniformity of the geometry.",
+    "mathContext": "$\\lVert B H_b\\rVert^2\\,\\lVert A-C\\rVert^2 = \\Delta^2$ and $\\lVert C H_c\\rVert^2\\,\\lVert B-A\\rVert^2 = \\Delta^2$, with $\\Delta = (B-A)\\times(C-A)$ shared across all three. Translation invariance: $(B-A)\\times(C-A) = (C-B)\\times(A-B) = (A-C)\\times(B-C)$ up to sign.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "translation invariance",
+      "shoelace formula",
+      "signed area",
+      "symmetry"
+    ],
+    "prerequisites": [
+      "Lagrange's identity",
+      "determinants"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-two-area-sq",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 103,
+      "endLine": 113
+    },
+    "type": "technique",
+    "title": "Bridging the Absolute Value to the Polynomial",
+    "content": "two_area_sq is the one genuinely analytic step in the file. The area function is defined with an absolute value, $\\text{Area} = |\\Delta|/2$, but the altitude-length laws produce the bare polynomial $\\Delta^2$. The lemma reconciles them: unfold the area, simplify $2\\cdot(|\\Delta|/2) = |\\Delta|$ by `ring`, then apply `sq_abs` ($|x|^2 = x^2$) to turn $|\\Delta|^2$ into $\\Delta^2$. This is exactly where the sign of the determinant becomes irrelevant — squaring erases it — which is why an *unsigned* area can equal a *signed* polynomial. After this bridge the rest of the file is pure rewriting.",
+    "mathContext": "$(2\\,\\text{Area})^2 = \\left(2\\cdot\\tfrac{|\\Delta|}{2}\\right)^2 = |\\Delta|^2 = \\Delta^2$ by sq_abs. The squaring is what removes the orientation sign carried by the determinant.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absolute value",
+      "signed vs unsigned area",
+      "sq_abs",
+      "orientation"
+    ],
+    "prerequisites": [
+      "absolute value identities",
+      "rewriting tactics"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-area-forms",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 131
+    },
+    "type": "concept",
+    "title": "Restating the Laws Through the Area Function",
+    "content": "foot_a_altitude_area, foot_b_altitude_area, and foot_c_altitude_area each compose the corresponding length law with two_area_sq by a single `rw`, converting the abstract $\\Delta^2$ into the user-facing $(2\\,\\text{Area})^2$. This is the form a downstream proof actually wants: it directly licenses $\\text{Area} = \\tfrac{1}{2}\\,\\text{base}\\,\\cdot\\text{height}$ once a square root is taken. Keeping these as separate named theorems (rather than inlining) makes the area form a reusable lemma in the foot API.",
+    "mathContext": "$\\lVert A H_a\\rVert^2\\,\\lVert C-B\\rVert^2 = (2\\,\\text{Area})^2$, and likewise at $B$ and $C$. Taking square roots gives the classical $\\text{Area} = \\tfrac{1}{2}\\,|BC|\\,h_a$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "base times height",
+      "area formula",
+      "lemma composition"
+    ],
+    "prerequisites": [
+      "rewriting tactics"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-base-independence",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 137,
+      "endLine": 148
+    },
+    "type": "insight",
+    "title": "Base-Independence Capstone",
+    "content": "altitude_length_base_independent bundles the three area-form laws into a single conjunction, witnessed by the anonymous constructor $\\langle \\ldots \\rangle$. Its content is conceptual rather than computational: because each of the three $(\\text{altitude length})^2 \\cdot (\\text{base length})^2$ products equals the *common* value $(2\\,\\text{Area})^2$, the three products must equal one another. This is the coordinate proof that $\\tfrac{1}{2}\\,\\text{base}\\cdot\\text{height}$ is well-defined — the area of a triangle does not depend on which side you pick as the base, a fact usually taken for granted in the schoolbook formula.",
+    "mathContext": "$\\lVert A H_a\\rVert^2\\lVert BC\\rVert^2 = \\lVert B H_b\\rVert^2\\lVert CA\\rVert^2 = \\lVert C H_c\\rVert^2\\lVert AB\\rVert^2 = (2\\,\\text{Area})^2.$ Equality through a common value: $x = v \\wedge y = v \\wedge z = v \\implies x = y = z$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "well-definedness",
+      "base-independence of area",
+      "invariance"
+    ],
+    "prerequisites": [
+      "logical conjunction",
+      "transitivity of equality"
+    ]
+  },
+  {
+    "id": "ann-ftd-oq0102-example",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-02",
+    "range": {
+      "startLine": 154,
+      "endLine": 171
+    },
+    "type": "context",
+    "title": "Worked Example: The 3-4-5 Triangle",
+    "content": "The closing two theorems instantiate the abstract laws at a concrete right triangle $A=(0,0)$, $B=(3,0)$, $C=(0,4)$. triangle_345_altitude_a_sq computes the squared altitude from A onto the hypotenuse as $144/25$ (so $h_a = 12/5$), discharged by `norm_num` after unfolding. triangle_345_altitude_law then checks the length law numerically: $(144/25)\\cdot 25 = 144 = (2\\cdot 6)^2$, matching the triangle's area of 6 via $6 = \\tfrac{1}{2}\\cdot 5\\cdot\\tfrac{12}{5}$. The example grounds the general theorems and serves as a sanity check that the orientation conventions are consistent.",
+    "mathContext": "For the 3-4-5 triangle: $|BC| = 5$, $\\text{Area} = 6$, $h_a = \\dfrac{2\\,\\text{Area}}{|BC|} = \\dfrac{12}{5}$, $h_a^2 = \\dfrac{144}{25}$, and $h_a^2 \\cdot |BC|^2 = \\dfrac{144}{25}\\cdot 25 = 144 = (2\\cdot 6)^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "3-4-5 triangle",
+      "Pythagorean triple",
+      "worked example",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "arithmetic",
+      "right triangles"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-01-oq-02` (quality 43, 0 prior passes).

## Gap
This recently-merged research entry shipped with a rich `meta.json` but **no `annotations.json`** — a common pattern for fresh research entries. (Per-proof `index.ts` is no longer needed: the loader was refactored in #20993 to fetch from build-generated `public/data/proofs/`.)

## Changes
Added 8 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. The open question (docstring) — what OQ01 left unmeasured
2. Importing the coordinate API + non-degeneracy lemmas
3. **The altitude-length law via Lagrange's identity** (key) — Gram numerator → cross product → Δ²
4. The same law from the other two bases (translation invariance)
5. **two_area_sq** (key) — the abs→polynomial bridge via `sq_abs`
6. The area-form restatements
7. **Base-independence capstone** (key) — ½·base·height is well-defined
8. The worked 3-4-5 example

## Verification
- `pnpm annotations:build`: my entry resolves cleanly to Lean constructs, 0 warnings; listings.json regenerated.
- Axiom integrity: confirmed `status: verified` / `badge: original` / `axiomCount: 0` accurately reflect the 0-sorry, 0-axiom Lean source (no structure-encoded assumptions; inherits the verified coordinate API).