### PR TITLE
Enrich The Inverse of a Matrix is a Polynomial in the Matrix: add annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-07/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-07/annotations.json
@@ -1,0 +1,249 @@
+[
+  {
+    "id": "ann-chmoq07-1",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 42,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Finite Square Matrices over a Field",
+    "content": "**Setup**: `{n : Type*} [DecidableEq n] [Fintype n]` and `{K : Type*} [Field K]`.\n\nThe index type $n$ is an arbitrary finite type (with decidable equality so that matrix multiplication and the identity matrix are computable), and the entries lie in a field $K$. Nothing here assumes $n = \\mathrm{Fin}\\ m$; the development works for matrices indexed by any finite set.\n\nThe field hypothesis is used in exactly one place: to invert the nonzero scalar $-c_0$. Over a general commutative ring the same argument goes through whenever $\\det A$ is a unit — see the open question on relaxing `Field K` to `IsUnit (det A)`.",
+    "mathContext": "A matrix $A \\in M_n(K)$ acts on the $n$-dimensional vector space $K^n$. The characteristic polynomial $\\chi_A(t) = \\det(tI - A)$ is a monic polynomial of degree $n = |n|$ (`Fintype.card n`), and the field structure guarantees that any nonzero scalar is invertible.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Matrix algebra",
+      "Finite index type",
+      "Field"
+    ],
+    "prerequisites": [
+      "Matrices over a commutative ring",
+      "Characteristic polynomial"
+    ],
+    "tags": [
+      "setup",
+      "field",
+      "matrix"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-2",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 45,
+      "endLine": 49
+    },
+    "type": "definition",
+    "title": "The Inverse Polynomial invPoly",
+    "content": "**`invPoly A : K[X]`** is defined as $r = C\\,(-c_0)^{-1} \\cdot \\mathrm{divX}(\\chi_A)$, where $c_0 = (\\chi_A).\\mathrm{coeff}\\ 0$ is the constant term of the characteristic polynomial and $\\mathrm{divX}$ drops the constant term and divides by $X$.\n\nThis is the central object of the entry: it is the *explicit* polynomial whose evaluation at $A$ is the inverse. The definition is purely formal — it makes sense for any matrix — but its defining property $A^{-1} = (\\text{aeval } A)(\\text{invPoly } A)$ only holds once $\\det A \\neq 0$ guarantees $-c_0$ is invertible (so the leading $C(-c_0)^{-1}$ is a genuine scalar, not a division by zero).\n\nMarked `noncomputable` because field inversion in Lean's `Field` typeclass is noncomputable in general.",
+    "mathContext": "Writing $\\chi_A(t) = t^n + a_{n-1}t^{n-1} + \\cdots + a_1 t + c_0$, the operation $\\mathrm{divX}$ produces $\\frac{\\chi_A - c_0}{t} = t^{n-1} + a_{n-1}t^{n-2} + \\cdots + a_1$, so $r = (-c_0)^{-1}\\bigl(t^{n-1} + \\cdots + a_1\\bigr)$ has degree $n-1 < n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Characteristic polynomial",
+      "Polynomial division by X",
+      "Algebra evaluation map"
+    ],
+    "prerequisites": [
+      "Polynomial.divX",
+      "Polynomial.C",
+      "Matrix.charpoly"
+    ],
+    "tags": [
+      "definition",
+      "inverse-polynomial",
+      "divX"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-3",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 51,
+      "endLine": 57
+    },
+    "type": "technique",
+    "title": "Invertibility Makes the Constant Term a Unit",
+    "content": "**`charpoly_coeff_zero_ne_zero`**: if $\\det A \\neq 0$ then $c_0 = (\\chi_A).\\mathrm{coeff}\\ 0 \\neq 0$.\n\nThe proof is a one-line contrapositive: assume $c_0 = 0$; then `Matrix.det_eq_sign_charpoly_coeff` rewrites $\\det A = (-1)^n c_0 = (-1)^n \\cdot 0 = 0$, contradicting $\\det A \\neq 0$.\n\nThis lemma is the linchpin that connects the *analytic* hypothesis (invertibility, $\\det A \\neq 0$) to the *algebraic* fact needed (the scalar $-c_0$ is a unit we may divide by). Without it the inverse polynomial would be dividing by zero.",
+    "mathContext": "The constant term of $\\chi_A$ is $\\chi_A(0) = \\det(0\\cdot I - A) = \\det(-A) = (-1)^n \\det A$. So $c_0 = (-1)^n \\det A$, and $\\det A \\neq 0 \\iff c_0 \\neq 0$ — invertibility is *exactly* the unit condition on the constant term.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Determinant",
+      "Constant term of characteristic polynomial",
+      "Units of a field"
+    ],
+    "prerequisites": [
+      "Matrix.det_eq_sign_charpoly_coeff",
+      "Contrapositive proof"
+    ],
+    "tags": [
+      "determinant",
+      "constant-term",
+      "invertibility"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-4",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 59,
+      "endLine": 70
+    },
+    "type": "technique",
+    "title": "Cayley–Hamilton in Additive Form",
+    "content": "**`aeval_divX_mul_self`**: $(\\mathrm{divX}\\,\\chi_A)(A)\\cdot A + c_0 \\cdot I = 0$.\n\nThis is the engine of the whole proof. Three steps:\n1. `Matrix.aeval_self_charpoly` supplies Cayley–Hamilton itself: $\\chi_A(A) = 0$.\n2. `divX_mul_X_add` is the *polynomial identity* $\\mathrm{divX}(p)\\cdot X + C(p.\\mathrm{coeff}\\ 0) = p$ — splitting off the constant term.\n3. Evaluating that identity at $A$ via the algebra homomorphism `aeval` (`map_add`, `map_mul`, `aeval_X`, `aeval_C`) turns $\\chi_A(A) = 0$ into $(\\mathrm{divX}\\,\\chi_A)(A)\\cdot A + c_0\\cdot I = 0$.\n\nThe key idea: applying the *ring homomorphism* aeval to an *abstract polynomial identity* mechanically produces the matrix relation we want. The decomposition isolates a single factor of $A$, which is what lets us solve for $A^{-1}$.",
+    "mathContext": "From $p = \\mathrm{divX}(p)\\cdot X + c_0$ and $\\mathrm{aeval}_A$ a $K$-algebra homomorphism $K[X] \\to M_n(K)$ sending $X \\mapsto A$ and $C\\,\\lambda \\mapsto \\lambda I$, we get $0 = \\mathrm{aeval}_A(\\chi_A) = (\\mathrm{divX}\\,\\chi_A)(A)\\cdot A + c_0 I$, i.e. $(\\mathrm{divX}\\,\\chi_A)(A)\\cdot A = -c_0 I$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cayley–Hamilton theorem",
+      "Algebra homomorphism",
+      "Polynomial evaluation"
+    ],
+    "prerequisites": [
+      "Matrix.aeval_self_charpoly",
+      "Polynomial.divX_mul_X_add",
+      "aeval (map_add, map_mul)"
+    ],
+    "tags": [
+      "cayley-hamilton",
+      "aeval",
+      "additive-form"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-5",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 72,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "Dividing by the Unit to Get a Left Inverse",
+    "content": "**`aeval_invPoly_mul_self`**: $(\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A)\\cdot A = I$.\n\nThis is where the additive Cayley–Hamilton relation is solved for the inverse. The proof:\n- From `aeval_divX_mul_self`, `eq_neg_of_add_eq_zero_left` gives $(\\mathrm{divX}\\,\\chi_A)(A)\\cdot A = (-c_0)\\cdot I$ (rewriting the algebra map as a scalar via `Algebra.algebraMap_eq_smul_one`).\n- Expanding the definition of `invPoly` shows $(\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A) = (-c_0)^{-1}\\cdot (\\mathrm{divX}\\,\\chi_A)(A)$.\n- Multiplying on the right by $A$ and using `inv_mul_cancel₀` (valid because $-c_0 \\neq 0$ from `charpoly_coeff_zero_ne_zero`) cancels the scalar: $(-c_0)^{-1}(-c_0)\\cdot I = I$.\n\nThe finite-dimensionality of matrices matters here: a *left* inverse of a square matrix is automatically a two-sided inverse, which the next lemmas exploit.",
+    "mathContext": "$(\\mathrm{divX}\\,\\chi_A)(A)\\cdot A = -c_0 I$, so $\\bigl((-c_0)^{-1}(\\mathrm{divX}\\,\\chi_A)(A)\\bigr)\\cdot A = (-c_0)^{-1}(-c_0)I = I$. The bracketed factor is exactly $(\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A)$, a polynomial in $A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Left inverse",
+      "Scalar cancellation",
+      "Smul-mul associativity"
+    ],
+    "prerequisites": [
+      "eq_neg_of_add_eq_zero_left",
+      "inv_mul_cancel₀",
+      "Algebra.algebraMap_eq_smul_one"
+    ],
+    "tags": [
+      "left-inverse",
+      "unit-division",
+      "core"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-6",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 88,
+      "endLine": 92
+    },
+    "type": "insight",
+    "title": "Main Result: The Inverse is a Polynomial in A",
+    "content": "**`inv_eq_aeval_invPoly`**: $A^{-1} = (\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A)$.\n\nThe headline theorem, and a one-liner given the work above: `Matrix.inv_eq_left_inv` promotes the left inverse from `aeval_invPoly_mul_self` to *the* nonsingular inverse $A^{-1}$. For square matrices any left inverse is the inverse, so the left-inverse relation $B\\cdot A = I$ pins down $B = A^{-1}$.\n\nConceptually this is striking: the inverse — usually computed via cofactors and the adjugate, an object of degree $n-1$ in the *entries* of $A$ — is here written as a polynomial of degree $n-1$ in *$A$ itself*. The two viewpoints agree but the polynomial form reveals structure the cofactor formula hides (commutativity with $A$, membership in $K[A]$).",
+    "mathContext": "$A^{-1} = (-c_0)^{-1}\\bigl(A^{n-1} + a_{n-1}A^{n-2} + \\cdots + a_1 I\\bigr)$ where $\\chi_A(t) = t^n + a_{n-1}t^{n-1} + \\cdots + a_1 t + c_0$. This is the basis of the Faddeev–LeVerrier inversion algorithm.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix inverse",
+      "Faddeev–LeVerrier method",
+      "Adjugate matrix"
+    ],
+    "prerequisites": [
+      "Matrix.inv_eq_left_inv",
+      "Nonsingular inverse"
+    ],
+    "tags": [
+      "main-result",
+      "inverse",
+      "polynomial-in-A"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-7",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 94,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Degree Bound: deg(invPoly) < n",
+    "content": "**`invPoly_natDegree_lt`**: $\\deg(\\mathrm{invPoly}\\ A) < n = \\mathrm{Fintype.card}\\ n$ (assuming `[Nonempty n]`).\n\nThe bound needs *no* invertibility hypothesis — it is a pure degree computation:\n- $\\deg(\\mathrm{invPoly}\\ A) \\le \\deg(\\mathrm{divX}\\,\\chi_A)$ since multiplying by the constant $C(-c_0)^{-1}$ cannot raise the degree (`natDegree_C_mul_le`).\n- $\\deg(\\mathrm{divX}\\,\\chi_A) < \\deg(\\chi_A) = n$. The `by_cases` on whether $\\mathrm{divX}\\,\\chi_A = 0$ handles the degenerate $1\\times 1$-after-divX edge: if it vanishes its degree is $0 < n$ (using `Fintype.card_pos`, hence `[Nonempty n]`); otherwise `degree_divX_lt` applies.\n- `omega` closes the arithmetic.\n\nThis sharpens the main result: $A^{-1}$ is not merely *some* polynomial in $A$ but one of degree strictly below $n$, matching the minimal-polynomial bound — higher powers of $A$ are redundant by Cayley–Hamilton.",
+    "mathContext": "Since $\\chi_A$ is monic of degree $n$, $\\mathrm{divX}\\,\\chi_A$ has degree $n-1$, and scaling by a constant preserves this. Thus $\\{I, A, A^2, \\ldots, A^{n-1}\\}$ already spans the cyclic algebra needed to express $A^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial degree",
+      "Minimal polynomial",
+      "Monic polynomial"
+    ],
+    "prerequisites": [
+      "natDegree_C_mul_le",
+      "degree_divX_lt",
+      "Matrix.charpoly_natDegree_eq_dim"
+    ],
+    "tags": [
+      "degree-bound",
+      "divX",
+      "natDegree"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-8",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 108,
+      "endLine": 112
+    },
+    "type": "insight",
+    "title": "The Inverse Lives in the Subalgebra K[A]",
+    "content": "**`inv_mem_adjoin`**: $A^{-1} \\in \\mathrm{Algebra.adjoin}\\ K\\ \\{A\\}$.\n\nRewriting via the main result and `Algebra.adjoin_singleton_eq_range_aeval` (which says $K[A] = \\mathrm{adjoin}\\ K\\ \\{A\\}$ equals the *range* of $\\mathrm{aeval}_A$), membership is immediate: $A^{-1} = (\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A)$ is a value of $\\mathrm{aeval}_A$.\n\nThis is the *structural* payoff and the most conceptual statement in the file. Because $A^{-1}$ is a polynomial in $A$:\n- $A^{-1}$ **commutes** with $A$ (obvious now, less so from the adjugate formula);\n- $A^{-1}$ commutes with *everything that commutes with $A$* — the centralizer of $A$ is closed under inversion;\n- the commutative subalgebra $K[A]$ is closed under taking inverses of its invertible elements.",
+    "mathContext": "$K[A] = \\{f(A) : f \\in K[X]\\}$ is the smallest subalgebra containing $A$; it is commutative. The result $A^{-1} \\in K[A]$ shows $K[A]$ is closed under inversion, making it (when $A$ is invertible and more, regular) relevant to the rational canonical form and the theory of $K[X]$-module structure on $K^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Generated subalgebra",
+      "Centralizer",
+      "Rational canonical form"
+    ],
+    "prerequisites": [
+      "Algebra.adjoin",
+      "Algebra.adjoin_singleton_eq_range_aeval"
+    ],
+    "tags": [
+      "subalgebra",
+      "adjoin",
+      "commutativity"
+    ]
+  },
+  {
+    "id": "ann-chmoq07-9",
+    "proofId": "cayley-hamilton-minpoly-oq-07",
+    "range": {
+      "startLine": 114,
+      "endLine": 124
+    },
+    "type": "technique",
+    "title": "Right-Inverse Companion and Packaged Existence",
+    "content": "Two finishing lemmas:\n\n**`self_mul_aeval_invPoly`**: $A\\cdot (\\mathrm{aeval}\\ A)(\\mathrm{invPoly}\\ A) = I$ — the *right*-inverse statement, obtained from the left-inverse lemma via `Matrix.mul_eq_one_comm` (for square matrices $BA = I \\iff AB = I$). This makes the two-sided nature explicit, though it is also automatic once $A^{-1}$ is identified.\n\n**`exists_inv_eq_aeval`**: $\\exists\\, r : K[X],\\ \\deg r < n \\ \\wedge\\ A^{-1} = (\\mathrm{aeval}\\ A)\\,r$ — a self-contained existential packaging the degree bound and the main result together. This is the clean, witness-free statement one would cite downstream: *every invertible matrix over a field has its inverse expressible as a polynomial of degree $< n$ in the matrix*, with `invPoly A` supplied as the explicit witness.",
+    "mathContext": "`mul_eq_one_comm` reflects that $M_n(K)$ is a finite-dimensional algebra, where one-sided inverses are two-sided. The packaged $\\exists r$ statement abstracts away the specific witness `invPoly A`, exposing only the existence and the sharp degree bound $< n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Two-sided inverse",
+      "Existential packaging",
+      "Finite-dimensional algebra"
+    ],
+    "prerequisites": [
+      "Matrix.mul_eq_one_comm",
+      "Existential introduction"
+    ],
+    "tags": [
+      "right-inverse",
+      "existence",
+      "packaging"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-07`.

This recently-merged research entry had a rich `meta.json` but **no `annotations.json`** — so the proof page rendered without any inline commentary. This PR adds a complete, high-quality annotation layer.

## Changes
- **New `annotations.json`** with 9 annotations, one per declaration in `CayleyHamiltonMinpolyOQ07.lean`:
  1. Finite square matrices over a field (setup)
  2. The inverse polynomial `invPoly` (definition)
  3. Invertibility makes the constant term a unit (`charpoly_coeff_zero_ne_zero`)
  4. Cayley–Hamilton in additive form (`aeval_divX_mul_self`)
  5. Dividing by the unit to get a left inverse (`aeval_invPoly_mul_self`)
  6. Main result: the inverse is a polynomial in A (`inv_eq_aeval_invPoly`)
  7. Degree bound deg < n (`invPoly_natDegree_lt`)
  8. The inverse lives in K[A] (`inv_mem_adjoin`)
  9. Right-inverse companion + packaged existence

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, and `tags`, and the line ranges fully cover the Lean source.

## Verification
- `pnpm build` passes (data enrichment + tsc + vite).
- JSON validated; axiom/status fields unchanged (entry remains verified / 0-axiom).