### PR TITLE
research(lagrange-oq-01-oq-01-oq-02): non-abelian uniqueness infrastructure — range determines the semidirect product [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
@@ -315,4 +315,116 @@ theorem order_15_iso {G H : Type*} [Group G] [Group H] [Fintype G] [Fintype H]
   exact ⟨mulEquivOfCyclicCardEq
     (by rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, hG, hH])⟩
 
+/-
+  ## Part VI — Non-abelian uniqueness infrastructure: the iso type of a semidirect
+  product is determined by the *range* of its action map.
+
+  The only branch of OQ-01-OQ-01-OQ-02 not settled above is the `p ∣ (q-1)`
+  *non-abelian* uniqueness: any two non-cyclic groups of order `pq` are isomorphic.
+  Classically each such group is an internal semidirect product `ℤ/q ⋊ ℤ/p` for some
+  nontrivial action `ℤ/p →* Aut(ℤ/q)`, and the proof reduces to: *different nontrivial
+  actions still give isomorphic products.*
+
+  This part proves the structural engine for that reduction, fully and self-containedly
+  from Mathlib. The key observation is that the isomorphism type of `N ⋊[φ] G` depends
+  only on the **image** `φ.range ≤ MulAut N` of the action map, not on the particular
+  homomorphism `φ`:
+
+  - `autOfRangeEq` / `exists_mulEquiv_comp_of_range_eq`: two injective homs `f, g` with
+    `f.range = g.range` differ by a source automorphism `α`, i.e. `g = f ∘ α`. The
+    witness is the composite `G ≃* g.range ≃* f.range ≃* G` built from
+    `MonoidHom.ofInjective` and `MulEquiv.subgroupCongr`.
+  - `semidirectProductIsoOfRangeEq`: feeding that `α` into Mathlib's
+    `SemidirectProduct.congr` (with `fn = id` on `N`) yields `N ⋊[g] G ≃* N ⋊[f] G`.
+  - `injective_of_prime_card`: a nontrivial hom out of a group of prime order is
+    injective (its kernel divides the prime, so is `⊥` or `⊤`; `⊤` would force the map
+    to be `1`).
+  - `semidirectProductIso_of_nontrivial_range_eq`: the capstone — two *nontrivial*
+    action maps from a prime-order group with equal range give isomorphic semidirect
+    products.
+
+  **What remains for full non-abelian uniqueness** (two documented standard facts, both
+  outside the scope verified here):
+  1. *Internal recognition*: every non-cyclic group of order `pq` is `≃*` to some
+     `ℤ/q ⋊[φ] ℤ/p` with `φ` nontrivial. Mathlib lacks a packaged normal-complement ⟹
+     internal-semidirect-product lemma for this.
+  2. *Common range*: any two nontrivial `φ₁, φ₂ : ℤ/p →* Aut(ℤ/q)` have equal range —
+     the unique order-`p` subgroup of the cyclic group `Aut(ℤ/q) ≅ (ℤ/q)ˣ` (which has
+     order `q-1`, divisible by `p` exactly in this branch). This is the uniqueness of
+     subgroups of given order in a cyclic group.
+
+  Given (1) and (2), `semidirectProductIso_of_nontrivial_range_eq` closes the
+  non-abelian case. This part delivers the reusable middle link with `0` sorries and
+  `0` axioms.
+-/
+
+variable {Γ Δ : Type*} [Group Γ] [Group Δ]
+
+/-- The source automorphism `α : Γ ≃* Γ` witnessing that two injective homomorphisms
+    `f g : Γ →* Δ` with equal range differ by precomposition: `g = f ∘ α`. The witness is
+    the composite `Γ ≃* g.range ≃* f.range ≃* Γ`. -/
+noncomputable def autOfRangeEq {f g : Γ →* Δ} (hf : Function.Injective f)
+    (hg : Function.Injective g) (hr : f.range = g.range) : Γ ≃* Γ :=
+  (MonoidHom.ofInjective hg).trans
+    ((MulEquiv.subgroupCongr hr.symm).trans (MonoidHom.ofInjective hf).symm)
+
+/-- The defining property of `autOfRangeEq`: `g x = f (α x)` for all `x`. -/
+theorem autOfRangeEq_spec {f g : Γ →* Δ} (hf : Function.Injective f)
+    (hg : Function.Injective g) (hr : f.range = g.range) (x : Γ) :
+    g x = f (autOfRangeEq hf hg hr x) := by
+  rw [autOfRangeEq]
+  simp only [MulEquiv.trans_apply]
+  rw [MonoidHom.apply_ofInjective_symm hf, MulEquiv.subgroupCongr_apply,
+      MonoidHom.ofInjective_apply hg]
+
+/-- Two injective homomorphisms with the same range differ by an automorphism of the
+    source: there is `α : Γ ≃* Γ` with `g = f ∘ α`. -/
+theorem exists_mulEquiv_comp_of_range_eq {f g : Γ →* Δ} (hf : Function.Injective f)
+    (hg : Function.Injective g) (hr : f.range = g.range) :
+    ∃ α : Γ ≃* Γ, ∀ x, g x = f (α x) :=
+  ⟨autOfRangeEq hf hg hr, autOfRangeEq_spec hf hg hr⟩
+
+/-- **Range determines the semidirect product.** If two action maps `f g : Γ →* MulAut N`
+    are injective and have equal range, the associated semidirect products are isomorphic:
+    the isomorphism type of `N ⋊ Γ` depends only on the *image* of the action map. The
+    isomorphism keeps `N` fixed and twists `Γ` by `autOfRangeEq`, via
+    `SemidirectProduct.congr`. -/
+noncomputable def semidirectProductIsoOfRangeEq {N : Type*} [Group N]
+    {f g : Γ →* MulAut N} (hf : Function.Injective f) (hg : Function.Injective g)
+    (hr : f.range = g.range) :
+    SemidirectProduct N Γ g ≃* SemidirectProduct N Γ f :=
+  SemidirectProduct.congr (MulEquiv.refl N) (autOfRangeEq hf hg hr) <| by
+    intro x
+    ext n
+    simp only [MulEquiv.trans_apply, MulEquiv.refl_apply, autOfRangeEq_spec hf hg hr x]
+
+/-- A homomorphism out of a group of prime order is injective unless it is trivial: its
+    kernel has order dividing the prime, hence is `⊥` (injective) or `⊤` (forcing the map
+    to be `1`). -/
+theorem injective_of_prime_card [Fintype Γ] {p : ℕ} (hp : p.Prime)
+    (hcard : Fintype.card Γ = p) {f : Γ →* Δ} (hf : f ≠ 1) : Function.Injective f := by
+  rw [← MonoidHom.ker_eq_bot_iff]
+  have hNat : Nat.card Γ = p := by rw [Nat.card_eq_fintype_card, hcard]
+  have hdvd : Nat.card f.ker ∣ p := hNat ▸ Subgroup.card_subgroup_dvd_card f.ker
+  rcases (hp.eq_one_or_self_of_dvd _ hdvd) with h1 | hpeq
+  · exact f.ker.eq_bot_of_card_eq h1
+  · exfalso
+    apply hf
+    have htop : f.ker = ⊤ := Subgroup.eq_top_of_card_eq f.ker (by rw [hpeq, hNat])
+    ext x
+    have hx : x ∈ f.ker := htop ▸ Subgroup.mem_top x
+    simpa [MonoidHom.mem_ker] using hx
+
+/-- **Capstone (non-abelian `pq` thread).** Two *nontrivial* action maps from a group of
+    prime order `p` with equal range give isomorphic semidirect products. With the two
+    standard facts noted above (internal recognition; all nontrivial `ℤ/p`-actions on
+    `ℤ/q` share the unique order-`p` subgroup of the cyclic `Aut(ℤ/q)`), this pins the
+    non-abelian isomorphism class of groups of order `pq`. -/
+theorem semidirectProductIso_of_nontrivial_range_eq {N : Type*} [Group N] [Fintype Γ]
+    {p : ℕ} (hp : p.Prime) (hcard : Fintype.card Γ = p)
+    {f g : Γ →* MulAut N} (hf : f ≠ 1) (hg : g ≠ 1) (hr : f.range = g.range) :
+    Nonempty (SemidirectProduct N Γ g ≃* SemidirectProduct N Γ f) :=
+  ⟨semidirectProductIsoOfRangeEq (injective_of_prime_card hp hcard hf)
+    (injective_of_prime_card hp hcard hg) hr⟩
+
 end LagrangeOQ01OQ01OQ02

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
@@ -9,10 +9,75 @@ each other, for each of the two cases" (cyclic case `p ∤ q-1`; non-cyclic case
 
 - **Abelian case: SOLVED & verified.** Every abelian group of order `pq` (any
   distinct primes `p ≠ q`) is cyclic, hence any two are isomorphic, each ≅
-  `Multiplicative (ZMod pq)`. Shipped in `Proofs/LagrangeTheoremOQ01OQ01OQ02.lean`
-  (7 theorems, 0 sorries, 0 axioms, Mathlib-only, kernel-verified standard triple).
-- **General cyclic case & non-abelian case: BLOCKED** on the parent Sylow
-  classification.
+  `Multiplicative (ZMod pq)`. Shipped in `Proofs/LagrangeTheoremOQ01OQ01OQ02.lean`.
+- **General cyclic case: SOLVED & verified** (Part IV, already merged). For
+  `¬p∣(q-1)` and `¬q∣(p-1)`, *every* group of order `pq` is cyclic (Sylow counting ⟹
+  both Sylow normal ⟹ nilpotent ⟹ squarefree Z-group ⟹ cyclic), so any two are
+  isomorphic (`pq_isCyclic`, `pq_cyclic_iso`). The knowledge.md "BLOCKED" note below
+  was stale — Part IV was added directly from Mathlib's Sylow/Z-group API, no parent.
+- **Non-abelian case: structural engine SOLVED & verified** (Part VI, Session 2). The
+  iso type of `N ⋊[φ] G` depends only on `φ.range`; two nontrivial prime-order action
+  maps with equal range give isomorphic products. Reduces the open non-abelian
+  uniqueness to two documented standard facts (internal recognition + common range).
+- File now: **18 theorems, 2 defs, 0 sorries, 0 axioms, Mathlib-only**, kernel-verified
+  standard `[propext, Classical.choice, Quot.sound]` triple.
+
+## Session 2026-06-24 (Session 2) — Non-abelian semidirect-product infrastructure
+
+**Mode**: DEPTH-FIRST (MODERATE) · **Outcome**: progress (verified, +4 thms +2 defs)
+
+### What I Did
+- Found knowledge.md stale: the file already contained Part IV (full cyclic case),
+  merged in `main`, despite knowledge.md marking it BLOCKED. Re-scoped to the only
+  genuinely open piece: the non-abelian `p∣(q-1)` uniqueness.
+- Discovered Mathlib already has `SemidirectProduct.congr` / `map`, so the bare
+  precomposition congruence is free. The substantive missing content is *range
+  uniqueness of the action map*.
+- Built and kernel-verified **Part VI** (range determines the semidirect product):
+  - `autOfRangeEq` (noncomputable def) + `autOfRangeEq_spec` + `exists_mulEquiv_comp_of_range_eq`:
+    two injective homs `f,g : Γ →* Δ` with `f.range = g.range` differ by a source
+    automorphism `α`, `g = f∘α`. Witness `Γ ≃* g.range ≃* f.range ≃* Γ` from
+    `MonoidHom.ofInjective` + `MulEquiv.subgroupCongr`.
+  - `semidirectProductIsoOfRangeEq` (noncomputable def): `N ⋊[g] Γ ≃* N ⋊[f] Γ` via
+    `SemidirectProduct.congr (MulEquiv.refl N) (autOfRangeEq …)`.
+  - `injective_of_prime_card`: nontrivial hom out of a prime-order group is injective
+    (ker divides `p` ⟹ `⊥` or `⊤`; `⊤` forces map `= 1`).
+  - `semidirectProductIso_of_nontrivial_range_eq` (capstone).
+
+### Key Findings / API
+- `MonoidHom.ofInjective hf : G ≃* f.range`; coe lemmas `MonoidHom.ofInjective_apply`
+  (`↑(ofInjective hf x) = f x`) and `MonoidHom.apply_ofInjective_symm`
+  (`f ((ofInjective hf).symm y) = ↑y`). Note: namespace is **MonoidHom**, not MulEquiv.
+- `MulEquiv.subgroupCongr (h : A = B) : A ≃* B`, with `subgroupCongr_apply` preserving coe.
+- `SemidirectProduct.congr (fn : N₁≃*N₂) (fg : G₁≃*G₂) (h : ∀ g, (φ₁ g).trans fn = fn.trans (φ₂ (fg g)))`.
+  With `fn = refl`, the condition reduces (via `MulEquiv.trans_refl`/`refl_trans` — or
+  `ext n; simp`) to `g x = f (α x)`.
+- `Subgroup.eq_bot_of_card_eq` uses dot notation `f.ker.eq_bot_of_card_eq h` (the
+  subgroup is the explicit first arg); plain `Subgroup.eq_bot_of_card_eq h` fails.
+- `Subgroup.card_subgroup_dvd_card (s) : Nat.card s ∣ Nat.card α`; `eq_top_of_card_eq`;
+  `MonoidHom.ker_eq_bot_iff`.
+
+### Build
+- Docker DOWN (old `docker info` hung; a background read failed exit 144). Host recipe:
+  `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean <abs path to file>` against the MAIN
+  repo's cached Mathlib oleans (worktree `proofs/.lake/packages` is empty). Iterated on
+  a `/tmp` scratch with `import Mathlib` first, then appended to the real file.
+- `#print axioms` inline (append `open NS in #print axioms thm` to a copy, recompile) —
+  all new decls = standard triple, no `sorryAx`/`ofReduceBool`.
+
+### Next Steps (to fully close non-abelian uniqueness)
+1. **Common range** (tractable): prove any two nontrivial `φ₁,φ₂ : ℤ/p →* Aut(ℤ/q)`
+   have equal range = unique order-`p` subgroup of cyclic `Aut(ℤ/q)`. Route: in a finite
+   cyclic `K`, two subgroups of equal card are equal — both ⊆ d-torsion
+   `ker(powMonoidHom d)` which has card ≤ d (`IsCyclic.card_pow_eq_one_le`), so an
+   order-d subgroup equals it (`Subgroup.eq_of_le_of_card_ge`). Needs Fintype/Nat.card
+   bridging for the torsion card. Then `Aut(ℤ/q) ≅ (ℤ/q)ˣ` cyclic for prime `q`.
+2. **Internal recognition** (harder, Mathlib gap): every non-cyclic order-`pq` group
+   `≃* ℤ/q ⋊[φ] ℤ/p`. No packaged normal-complement ⟹ internal-semidirect lemma.
+3. Feed 1+2 into `semidirectProductIso_of_nontrivial_range_eq` to finish.
+
+---
+### (Stale — superseded by the summary above) original Session-1 BLOCKED notes follow:
 
 ## Session 2026-06-23 (Session 1) — Abelian uniqueness, FRESH
 

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,11 +1,11 @@
 {
   "id": "lagrange-theorem-oq-01-oq-01-oq-02",
-  "title": "pq-Groups: Isomorphism Uniqueness — Abelian Thread + Full Cyclic Case (every group of order pq with p∤q-1 is ℤ/pq)",
+  "title": "pq-Groups: Isomorphism Uniqueness — Abelian Thread, Full Cyclic Case, and Non-Abelian Semidirect-Product Infrastructure",
   "slug": "lagrange-theorem-oq-01-oq-01-oq-02",
-  "description": "Upgrades the parent pq-classification from a counting statement to genuine MulEquiv isomorphisms, using only Mathlib. (1) ABELIAN thread: for ANY distinct primes p ≠ q, every abelian group of order pq is cyclic (Cauchy + the coprime-order product law), so any two are isomorphic — each ≅ Multiplicative (ZMod pq). (2) FULL CYCLIC case: when ¬ p∣(q-1) and ¬ q∣(p-1), EVERY group of order pq (not just the abelian ones) is cyclic — both Sylow subgroups are forced normal by Sylow counting, so G is nilpotent, and a nilpotent Z-group of squarefree order is cyclic. Consequently any two groups of order pq in this branch are isomorphic (e.g. all groups of order 15 or 35). Self-contained: imports only Mathlib, avoiding the parent's (non-compiling) Sylow file. Only the non-abelian p|(q-1) uniqueness remains open.",
+  "description": "Upgrades the parent pq-classification from a counting statement to genuine MulEquiv isomorphisms, using only Mathlib. (1) ABELIAN thread: for ANY distinct primes p ≠ q, every abelian group of order pq is cyclic (Cauchy + the coprime-order product law), so any two are isomorphic — each ≅ Multiplicative (ZMod pq). (2) FULL CYCLIC case: when ¬ p∣(q-1) and ¬ q∣(p-1), EVERY group of order pq (not just the abelian ones) is cyclic — both Sylow subgroups are forced normal by Sylow counting, so G is nilpotent, and a nilpotent Z-group of squarefree order is cyclic. Consequently any two groups of order pq in this branch are isomorphic (e.g. all groups of order 15 or 35). (3) NON-ABELIAN infrastructure (Part VI): the isomorphism type of a semidirect product N ⋊[φ] G depends only on the IMAGE φ.range ≤ Aut(N), not on φ — two injective action maps with equal range give isomorphic products (via SemidirectProduct.congr twisting the G-factor by a source automorphism), and a nontrivial map out of a prime-order group is injective. This is the reusable engine for non-abelian pq uniqueness, reducing it to two documented standard facts (internal recognition; common range of all nontrivial ℤ/p-actions on ℤ/q). Self-contained: imports only Mathlib, avoiding the parent's (non-compiling) Sylow file.",
   "meta": {
     "author": "Lean Genius",
-    "date": "2026-06-23",
+    "date": "2026-06-24",
     "status": "verified",
     "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
     "tags": [
@@ -21,16 +21,18 @@
       "Z-group",
       "nilpotent",
       "ZMod",
-      "finite-groups"
+      "finite-groups",
+      "semidirect-product",
+      "automorphism"
     ],
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 318,
-    "theoremCount": 14,
-    "definitionCount": 0,
-    "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API: Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv` (abelian thread); and `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae`, `IsZGroup.of_squarefree` (cyclic case). No `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Kernel-verified on Mathlib v4.26.0: all 14 theorems depend on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`).",
+    "lineCount": 430,
+    "theoremCount": 18,
+    "definitionCount": 2,
+    "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API: Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv` (abelian thread); `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae`, `IsZGroup.of_squarefree` (cyclic case); and `SemidirectProduct.congr`, `MonoidHom.ofInjective`/`ofInjective_apply`/`apply_ofInjective_symm`, `MulEquiv.subgroupCongr`, `MonoidHom.ker_eq_bot_iff`, `Subgroup.card_subgroup_dvd_card`/`eq_bot_of_card_eq`/`eq_top_of_card_eq` (non-abelian Part VI). No `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Kernel-verified on Mathlib v4.26.0: all 18 theorems and 2 definitions depend on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`).",
     "originalContributions": [
       "pq_abelian_isCyclic: every finite ABELIAN group of order pq (any distinct primes p ≠ q) is cyclic — proved from Cauchy (elements of order p and q) plus the coprime-order product law orderOf(a·b) = pq = |G|. Holds with NO divisibility hypothesis, so it also applies inside the non-cyclic p | (q-1) branch.",
       "pq_abelian_iso / pq_abelian_iso_zmod: any two abelian groups of order pq are isomorphic, and each ≅ the canonical model Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq and zmodCyclicMulEquiv.",
@@ -38,7 +40,11 @@
       "pq_isCyclic_of_lt: the classical criterion — for primes p < q with p∤(q-1), every group of order pq is cyclic (the side condition ¬ q∣(p-1) is discharged automatically since 0 < p-1 < q).",
       "pq_cyclic_iso: consequently any two groups of order pq in the cyclic branch are isomorphic to each other.",
       "Concrete corollaries: order_15_cyclic and order_35_cyclic (EVERY group of order 15 or 35 is cyclic, strengthening the abelian-only order_15/35_abelian_unique of Part III), and order_15_iso (any two groups of order 15 are isomorphic). Order 6 = 2·3 escapes the criterion (2 | (3-1)), matching the existence of the non-abelian S₃.",
-      "Self-contained: imports only Mathlib, deliberately avoiding the parent Sylow classification dependency `Proofs.SylowTheoremOQ01` which does not compile on Mathlib v4.26.0 — the cyclic case is rebuilt directly from Mathlib's Sylow/Z-group API."
+      "Self-contained: imports only Mathlib, deliberately avoiding the parent Sylow classification dependency `Proofs.SylowTheoremOQ01` which does not compile on Mathlib v4.26.0 — the cyclic case is rebuilt directly from Mathlib's Sylow/Z-group API.",
+      "Part VI — semidirectProductIsoOfRangeEq (NEW infrastructure for the non-abelian branch): the isomorphism type of a semidirect product N ⋊[φ] G is determined by the IMAGE φ.range ≤ MulAut N of the action map, not by φ itself. Precisely, if two action maps f, g : G →* MulAut N are injective with f.range = g.range, then N ⋊[g] G ≃* N ⋊[f] G. The isomorphism fixes the N-factor and twists the G-factor by a source automorphism, fed into Mathlib's SemidirectProduct.congr.",
+      "Part VI — autOfRangeEq / exists_mulEquiv_comp_of_range_eq: two injective homomorphisms f, g : Γ →* Δ with equal range differ by a source automorphism α : Γ ≃* Γ, i.e. g = f ∘ α. The explicit witness is the composite Γ ≃* g.range ≃* f.range ≃* Γ built from MonoidHom.ofInjective and MulEquiv.subgroupCongr — a reusable lemma in its own right.",
+      "Part VI — injective_of_prime_card: a homomorphism out of a group of prime order p is injective unless it is the trivial map (its kernel has order dividing p, hence is ⊥ or ⊤; the ⊤ case forces the map to be 1). Used to discharge injectivity of nontrivial action maps from ℤ/p.",
+      "Part VI — semidirectProductIso_of_nontrivial_range_eq (capstone): two NONTRIVIAL action maps from a prime-order group with equal range yield isomorphic semidirect products. This is the structural engine reducing the open non-abelian pq uniqueness to two standard facts (internal recognition of each non-cyclic order-pq group as ℤ/q ⋊ ℤ/p, and the common range of all nontrivial ℤ/p-actions on ℤ/q = the unique order-p subgroup of the cyclic Aut(ℤ/q))."
     ]
   },
   "overview": {
@@ -102,15 +108,23 @@
       "id": "cyclic-corollaries",
       "title": "Part V — Cyclic Concrete Corollaries (orders 15, 35)",
       "startLine": 292,
-      "endLine": 318,
+      "endLine": 317,
       "summary": "order_15_cyclic and order_35_cyclic: EVERY group of order 15 or 35 is cyclic (15 = 3·5 with 3∤4, 35 = 5·7 with 5∤6), strengthening the abelian-only statements of Part III. order_15_iso: any two groups of order 15 are isomorphic."
+    },
+    {
+      "id": "nonabelian-infrastructure",
+      "title": "Part VI — Non-Abelian Uniqueness Infrastructure: Range Determines the Semidirect Product",
+      "startLine": 319,
+      "endLine": 430,
+      "summary": "The structural engine for the non-abelian branch. autOfRangeEq / autOfRangeEq_spec / exists_mulEquiv_comp_of_range_eq: two injective homs Γ →* Δ with equal range differ by a source automorphism (g = f ∘ α), via MonoidHom.ofInjective and MulEquiv.subgroupCongr. semidirectProductIsoOfRangeEq: feeding that α to SemidirectProduct.congr gives N ⋊[g] G ≃* N ⋊[f] G — the iso type depends only on the action map's image. injective_of_prime_card: a nontrivial hom out of a prime-order group is injective. semidirectProductIso_of_nontrivial_range_eq: capstone — two nontrivial prime-order action maps with equal range give isomorphic products, reducing the open non-abelian pq uniqueness to internal recognition + common range of nontrivial ℤ/p-actions on ℤ/q."
     }
   ],
   "conclusion": {
-    "summary": "This file proves 14 theorems with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only, no native_decide). It resolves, up to MulEquiv, BOTH the abelian isomorphism class of order pq (every abelian group of order pq is cyclic ≅ ℤ/pq, for any distinct primes) and the full cyclic branch (when ¬p∣(q-1) and ¬q∣(p-1), every group of order pq is cyclic, so any two are isomorphic — e.g. all groups of order 15 and 35).",
-    "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the cyclic side of the order-pq classification now has genuine isomorphisms, not just a class count — and crucially without assuming commutativity, rebuilt directly from Mathlib's Sylow/Z-group API rather than the parent's non-compiling Sylow file. The single outstanding piece of full isomorphism uniqueness is the non-abelian case (any two non-cyclic groups of order pq, with p | q-1, are isomorphic), which requires an internal semidirect-product recognition ℤ/q ⋊ ℤ/p.",
+    "summary": "This file proves 18 theorems and 2 definitions with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only, no native_decide). It resolves, up to MulEquiv, BOTH the abelian isomorphism class of order pq (every abelian group of order pq is cyclic ≅ ℤ/pq, for any distinct primes) and the full cyclic branch (when ¬p∣(q-1) and ¬q∣(p-1), every group of order pq is cyclic, so any two are isomorphic — e.g. all groups of order 15 and 35). Part VI then builds the structural engine for the remaining non-abelian branch: the isomorphism type of a semidirect product N ⋊[φ] G is determined by the image of its action map, so two nontrivial prime-order action maps with equal range give isomorphic products.",
+    "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the cyclic side of the order-pq classification now has genuine isomorphisms, not just a class count — and crucially without assuming commutativity, rebuilt directly from Mathlib's Sylow/Z-group API rather than the parent's non-compiling Sylow file. The non-abelian case now has its key middle link verified (range-determines-iso), reducing 'any two non-cyclic groups of order pq are isomorphic' to two standard, documented facts: (1) internal recognition of each non-cyclic order-pq group as ℤ/q ⋊ ℤ/p, and (2) the common range of all nontrivial ℤ/p-actions on ℤ/q (the unique order-p subgroup of the cyclic Aut(ℤ/q)).",
     "openQuestions": [
-      "Non-abelian uniqueness: prove any two non-cyclic groups of order pq (with p | q-1) are isomorphic, by recognizing each as the internal semidirect product ℤ/q ⋊ ℤ/p and showing all non-trivial actions ℤ/p → Aut(ℤ/q) yield isomorphic products. (The cyclic-case uniqueness, previously open here, is now resolved by pq_isCyclic / pq_cyclic_iso.)",
+      "Non-abelian uniqueness — remaining piece 1 (internal recognition): show every non-cyclic group of order pq is ≃* to the internal semidirect product ℤ/q ⋊[φ] ℤ/p for some nontrivial φ. Mathlib lacks a packaged normal-complement ⟹ internal-semidirect-product lemma; SemidirectProduct.mulEquivSubgroup recognizes the product but not from a normal subgroup + complement.",
+      "Non-abelian uniqueness — remaining piece 2 (common range): show any two nontrivial φ₁, φ₂ : ℤ/p →* Aut(ℤ/q) have equal range — the unique order-p subgroup of the cyclic group Aut(ℤ/q) ≅ (ℤ/q)ˣ (order q-1, divisible by p exactly in this branch). This is uniqueness of subgroups of given order in a cyclic group (the d-torsion ker(powMonoidHom d) has order exactly d). Combined with Part VI's semidirectProductIso_of_nontrivial_range_eq, pieces 1 and 2 close the non-abelian case.",
       "Canonical model for the cyclic branch: package pq_isCyclic with zmodCyclicMulEquiv to state directly that every group of order pq (¬p∣q-1) is ≅ Multiplicative (ZMod pq), mirroring pq_abelian_iso_zmod but without the commutativity hypothesis.",
       "REPAIR FLAG (lower priority now): the parent chain `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` uses Mathlib names absent in v4.26.0 (e.g. `Nat.Prime.eq_of_dvd_of_prime`, `orderOf_eq_one_iff_eq_one`); a Mechanic pass would let downstream entries reuse that infrastructure, though this file no longer depends on it."
     ]
@@ -129,10 +143,10 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01OQ01OQ02",
-    "lineCount": 318,
+    "lineCount": 430,
     "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 0,
+    "theoremCount": 18,
+    "definitionCount": 2,
     "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
     "sorries": 0,
     "imports": [

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
@@ -31,26 +31,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified, self-contained): abelian-case isomorphism uniqueness fully formalized — every abelian group of order pq is cyclic ≅ ℤ/pq (7 thms, 0 sorries, 0 axioms, Mathlib-only). General cyclic + non-abelian uniqueness BLOCKED on parent SylowTheoremOQ01 which fails to compile on v4.26.0.",
+    "progressSummary": "PROGRESS (verified, self-contained, 18 thms / 2 defs / 0 sorries / 0 axioms, Mathlib-only). Abelian + FULL CYCLIC isomorphism uniqueness both complete (every group of order pq with ¬p∣q-1 is cyclic ≅ ℤ/pq). Session 2 added Part VI: the non-abelian structural engine — the iso type of N ⋊[φ] G depends only on φ.range, so two nontrivial prime-order action maps with equal range give isomorphic products (semidirectProductIsoOfRangeEq / semidirectProductIso_of_nontrivial_range_eq). Remaining for full non-abelian uniqueness: internal recognition (Mathlib gap) + common range of nontrivial ℤ/p-actions on ℤ/q (cyclic subgroup uniqueness).",
     "builtItems": [
       "pq_abelian_isCyclic (LagrangeTheoremOQ01OQ01OQ02.lean): any CommGroup of order pq is cyclic (no divisibility hyp) via Cauchy exists_prime_orderOf_dvd_card + Commute.orderOf_mul_eq_mul_orderOf_of_coprime + isCyclic_of_orderOf_eq_card",
       "pq_abelian_iso, pq_abelian_iso_zmod: any two abelian order-pq groups isomorphic, each ≅ Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq + zmodCyclicMulEquiv",
-      "Concrete: order_6/15/35_abelian_unique (≅ ℤ/n), order_15_abelian_pair. Kernel-verified standard triple, 0 axioms"
+      "Concrete: order_6/15/35_abelian_unique (≅ ℤ/n), order_15_abelian_pair. Kernel-verified standard triple, 0 axioms",
+      "Part VI semidirectProductIsoOfRangeEq (LagrangeTheoremOQ01OQ01OQ02.lean): if f,g : Γ →* MulAut N are injective with f.range = g.range then N ⋊[g] Γ ≃* N ⋊[f] Γ — iso type determined by the action map IMAGE. Via SemidirectProduct.congr (refl N) (autOfRangeEq …).",
+      "autOfRangeEq / exists_mulEquiv_comp_of_range_eq: two injective homs with equal range differ by a source automorphism α (g = f∘α); witness Γ ≃* g.range ≃* f.range ≃* Γ from MonoidHom.ofInjective + MulEquiv.subgroupCongr.",
+      "injective_of_prime_card: nontrivial hom out of a prime-order group is injective (ker ∣ p ⟹ ⊥ or ⊤). Capstone semidirectProductIso_of_nontrivial_range_eq combines it with the range-iso."
     ],
     "insights": [
       "Mathlib mulEquivOfCyclicCardEq (Cyclic.lean:787) upgrades IsCyclic-level classification to genuine MulEquiv from equal Nat.card — short but is the count→isomorphism step",
       "Abelian of squarefree order pq is cyclic for EVERY pair of distinct primes, independent of p|(q-1); isolates the abelian iso class on both sides of the dichotomy",
       "Fintype.card (parent) must be bridged to Nat.card (cyclic-iso API) via Nat.card_eq_fintype_card",
       "Commute.orderOf_mul_eq_mul_orderOf_of_coprime is in namespace Commute (dot notation), not _root_",
-      "BLOCKER: parent chain Proofs.SylowTheoremOQ01 → LagrangeTheoremOQ01OQ01 does NOT compile on Mathlib v4.26.0 — uses removed/renamed names Nat.Prime.eq_of_dvd_of_prime and orderOf_eq_one_iff_eq_one (confirmed absent from Mathlib source; 14 deterministic errors). The parent entry is marked verified but is stale → Mechanic repair needed. This file therefore imports ONLY Mathlib and delivers the abelian case independently."
+      "BLOCKER: parent chain Proofs.SylowTheoremOQ01 → LagrangeTheoremOQ01OQ01 does NOT compile on Mathlib v4.26.0 — uses removed/renamed names Nat.Prime.eq_of_dvd_of_prime and orderOf_eq_one_iff_eq_one (confirmed absent from Mathlib source; 14 deterministic errors). The parent entry is marked verified but is stale → Mechanic repair needed. This file therefore imports ONLY Mathlib and delivers the abelian case independently.",
+      "Mathlib SemidirectProduct.congr/map already give the bare precomposition congruence — the real content for non-abelian pq uniqueness is RANGE UNIQUENESS of the action map, not the congruence itself.",
+      "MonoidHom.ofInjective (NOT MulEquiv.ofInjective) : G ≃* f.range; coe lemmas MonoidHom.ofInjective_apply and MonoidHom.apply_ofInjective_symm. Subgroup.eq_bot_of_card_eq needs dot notation f.ker.eq_bot_of_card_eq.",
+      "Non-abelian uniqueness now reduced to two standard facts: (1) internal recognition G ≃* ℤ/q ⋊ ℤ/p (Mathlib lacks normal-complement ⟹ internal semidirect), (2) all nontrivial ℤ/p → Aut(ℤ/q) share the unique order-p subgroup of cyclic Aut(ℤ/q)."
     ],
     "mathlibGaps": [
       "No Mathlib lemma recognizing an internal semidirect product from a normal subgroup + complement (needed for nonabelian uniqueness)",
       "Parent SylowTheoremOQ01.lean stale on v4.26.0 (renamed lemmas) — must be repaired before the general cyclic-case (p∤q-1 ⟹ cyclic) and non-abelian uniqueness can build on pq_unique_when_coprime"
     ],
     "nextSteps": [
-      "Non-abelian uniqueness: recognize any non-cyclic order-pq group as internal semidirect product ZMod q ⋊ ZMod p, and show all nontrivial actions ZMod p → Aut(ZMod q) give isomorphic products — the harder open direction",
-      "Consider whether Mathlib SemidirectProduct + the sibling oq-01-oq-01-oq-01 ApproachB actionHom infrastructure can be reused to build the nonabelian iso"
+      "Prove common range: any two nontrivial φ : ℤ/p →* Aut(ℤ/q) have equal range. Route via cyclic-subgroup uniqueness (d-torsion ker(powMonoidHom d), IsCyclic.card_pow_eq_one_le, Subgroup.eq_of_le_of_card_ge) + Aut(ℤ/q) ≅ (ℤ/q)ˣ cyclic.",
+      "Prove internal recognition: every non-cyclic order-pq group ≃* ℤ/q ⋊[φ] ℤ/p (the harder Mathlib gap).",
+      "Feed both into semidirectProductIso_of_nontrivial_range_eq to close the non-abelian case."
     ]
   },
   "tags": [
@@ -86,7 +93,7 @@
     "mathlib": []
   },
   "started": "2026-06-23T23:16:23.903Z",
-  "lastUpdate": "2026-06-23",
+  "lastUpdate": "2026-06-24",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -148,10 +155,10 @@
     {
       "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
       "filename": "LagrangeTheoremOQ01OQ01OQ02.lean",
-      "lineCount": 168,
-      "theoremCount": 8,
+      "lineCount": 430,
+      "theoremCount": 18,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean"


### PR DESCRIPTION
## Summary

Advances the order-`pq` isomorphism-uniqueness problem (`lagrange-theorem-oq-01-oq-01-oq-02`). The abelian thread and the **full cyclic case** were already verified and merged. This PR adds **Part VI**, the structural engine for the remaining **non-abelian `p ∣ (q-1)` branch**.

**Key result.** The isomorphism type of a semidirect product `N ⋊[φ] G` depends only on the **image** `φ.range ≤ Aut(N)` of the action map, not on `φ`:

- `autOfRangeEq` / `exists_mulEquiv_comp_of_range_eq` — two injective homs `f, g : Γ →* Δ` with `f.range = g.range` differ by a source automorphism `α` (`g = f ∘ α`). Explicit witness `Γ ≃* g.range ≃* f.range ≃* Γ` from `MonoidHom.ofInjective` + `MulEquiv.subgroupCongr`.
- `semidirectProductIsoOfRangeEq` — feeding `α` to Mathlib's `SemidirectProduct.congr` yields `N ⋊[g] Γ ≃* N ⋊[f] Γ`.
- `injective_of_prime_card` — a nontrivial hom out of a prime-order group is injective.
- `semidirectProductIso_of_nontrivial_range_eq` (capstone) — two **nontrivial** prime-order action maps with equal range give isomorphic semidirect products.

This reduces "any two non-cyclic groups of order `pq` are isomorphic" to two documented standard facts:
1. *Internal recognition*: each non-cyclic order-`pq` group `≃* ℤ/q ⋊ ℤ/p` (a Mathlib gap — no packaged normal-complement ⟹ internal-semidirect lemma).
2. *Common range*: all nontrivial `ℤ/p`-actions on `ℤ/q` share the unique order-`p` subgroup of the cyclic `Aut(ℤ/q)`.

## Verification

- File: `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean` — now **18 theorems, 2 defs, 0 sorries, 0 axioms**, imports only Mathlib.
- Kernel-verified on Mathlib v4.26.0: every new declaration depends on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`).
- `status: verified`, `badge: verified`.

## Files
- `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean` — Part VI appended (+112 lines)
- `src/data/proofs/.../meta.json` — counts, sections, contributions, open questions
- `research/problems/.../knowledge.md`, `src/data/research/problems/....json` — session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)