### PR TITLE
research(cauchy-oq-01-oq-01-oq-01-oq-01): exact count of xⁿ=1 in cyclic groups = gcd(n,|G|) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Tactic
+
+/-
+# Counting solutions to `xⁿ = 1` in a cyclic group: exactly `gcd(n, |G|)`
+
+## What This Proves
+
+For a finite **cyclic** group `G` and any exponent `n : ℕ`, the number of
+solutions of the equation `xⁿ = 1` is **exactly** `gcd(n, |G|)`:
+
+```
+#{a : G | aⁿ = 1} = Nat.gcd n (Fintype.card G)
+```
+
+This is the sharp count. Mathlib only records the one-sided bound
+`IsCyclic.card_pow_eq_one_le : #{a | aⁿ = 1} ≤ n` (for `0 < n`); the present
+file pins down the value on the nose, for *every* `n` (including `n = 0`, where
+both sides equal `|G|`).
+
+## Why it matters: toward Frobenius' divisibility theorem
+
+**Frobenius' theorem** states that in *any* finite group `G`, the number of
+solutions of `xⁿ = 1` is divisible by `gcd(n, |G|)`. The cyclic case is the
+base case and the extremal case: here the divisibility is an *equality*. The
+corollary `frobenius_cyclic` records the divisibility statement that Frobenius
+generalises to arbitrary groups, now established with the exact constant on the
+cyclic fibre.
+
+This also refines the parent file `CauchyGroupTheoremOQ01OQ01OQ01` (the
+power-map dichotomy `x ↦ xⁿ` is a bijection iff `gcd(n,|G|) = 1`). That result
+is the `gcd = 1` slice of the count: the power map is injective on a *cyclic*
+group iff the only solution of `xⁿ = 1` is `1`, i.e. iff the count is `1`
+(`pow_injective_iff_card_pow_eq_one_eq_one`).
+
+## Proof strategy
+
+Pick a generator `g` (so `orderOf g = |G| =: m`) and set `d := gcd(n, m)`,
+`k := m / d`. The single subgroup `zpowers (g ^ k)` is exactly the solution
+set:
+
+* `orderOf (g ^ k) = m / gcd(m, k) = m / k = d`, using `k ∣ m`
+  (`Nat.gcd_eq_right`, `Nat.div_div_self`).
+* **`xⁿ = 1 ⟹ x ∈ zpowers (g ^ k)`.** Writing `x = gᵉ`, the relation
+  `gᵉⁿ = 1` gives `m ∣ e·n`, and the elementary number theory lemma
+  `div_gcd_dvd_of_dvd_mul` upgrades this to `k ∣ e` (the heart of the argument:
+  `m = d·k`, `n = d·n'`, `gcd(k, n') = 1`, so `k ∣ e·n' ⟹ k ∣ e`). Hence
+  `x = gᵉ ∈ zpowers (g ^ k)`.
+* **`x ∈ zpowers (g ^ k) ⟹ xⁿ = 1`.** Then `orderOf x ∣ orderOf (g ^ k) = d ∣ n`
+  (`orderOf_dvd_of_mem_zpowers`), so `xⁿ = 1`.
+
+The cardinality of the solution set is therefore `|zpowers (g ^ k)| =
+orderOf (g ^ k) = d = gcd(n, m)`.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01OQ01OQ01
+
+open Finset Subgroup Submonoid Function
+
+/-- **Number-theoretic core.** If `m ∣ e · n` then `m / gcd(n, m)` already
+divides `e`. Equivalently: writing `d = gcd(n, m)`, `m = d·k` and `n = d·n'`
+with `gcd(k, n') = 1`, the factor `k` of `m` that is coprime to `n` must come
+entirely from `e`. This is the arithmetic engine behind the exact count. -/
+theorem div_gcd_dvd_of_dvd_mul {n m e : ℕ} (hn : 0 < n) (h : m ∣ e * n) :
+    m / Nat.gcd n m ∣ e := by
+  set d := Nat.gcd n m with hd
+  have hdpos : 0 < d :=
+    Nat.pos_of_ne_zero fun h0 => hn.ne' (Nat.gcd_eq_zero_iff.mp h0).1
+  have hdm : d ∣ m := Nat.gcd_dvd_right n m
+  have hdn : d ∣ n := Nat.gcd_dvd_left n m
+  -- `m = d * (m / d)` and `n = d * (n / d)`.
+  have hmdk : d * (m / d) = m := Nat.mul_div_cancel' hdm
+  have hndn : d * (n / d) = n := Nat.mul_div_cancel' hdn
+  -- coprimality of the cofactors.
+  have hcop : Nat.Coprime (m / d) (n / d) :=
+    (Nat.coprime_div_gcd_div_gcd hdpos).symm
+  -- From `m ∣ e * n`, cancel the common `d` to get `(m/d) ∣ e * (n/d)`.
+  have key : d * (e * (n / d)) = e * n := by rw [mul_left_comm, hndn]
+  have hmul : d * (m / d) ∣ d * (e * (n / d)) := by rw [hmdk, key]; exact h
+  have hk_dvd : (m / d) ∣ e * (n / d) := Nat.dvd_of_mul_dvd_mul_left hdpos hmul
+  -- `gcd(m/d, n/d) = 1` lets us drop the `n/d` factor.
+  exact hcop.dvd_of_dvd_mul_right hk_dvd
+
+variable {α : Type*} [Group α]
+
+/-- **Main theorem.** In a finite cyclic group, the number of solutions of
+`xⁿ = 1` is exactly `gcd(n, |G|)`. Holds for every `n`, including `n = 0`
+(both sides are `|G|`). -/
+theorem card_pow_eq_one_eq_gcd [DecidableEq α] [Fintype α] [IsCyclic α] (n : ℕ) :
+    (univ.filter (fun a : α => a ^ n = 1)).card = Nat.gcd n (Fintype.card α) := by
+  classical
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · -- `n = 0`: every element solves `x⁰ = 1`, and `gcd(0, m) = m`.
+    subst hn
+    have huniv : (univ.filter (fun a : α => a ^ 0 = 1)) = univ := by
+      ext a; simp
+    rw [huniv, card_univ, Nat.gcd_zero_left]
+  -- Fix a generator and the relevant quantities.
+  obtain ⟨g, hg⟩ := IsCyclic.exists_generator (α := α)
+  set m := Fintype.card α with hm
+  have hmpos : 0 < m := Fintype.card_pos
+  have hgo : orderOf g = m := by
+    rw [hm, ← Nat.card_eq_fintype_card]
+    exact orderOf_eq_card_of_forall_mem_zpowers hg
+  set d := Nat.gcd n m with hd
+  have hdpos : 0 < d :=
+    Nat.pos_of_ne_zero fun h0 => hn.ne' (Nat.gcd_eq_zero_iff.mp h0).1
+  have hdm : d ∣ m := Nat.gcd_dvd_right n m
+  have hdn : d ∣ n := Nat.gcd_dvd_left n m
+  set k := m / d with hk
+  have hkm : k ∣ m := Nat.div_dvd_of_dvd hdm
+  -- The order of `g ^ k` is exactly `d`.
+  have hgk_order : orderOf (g ^ k) = d := by
+    rw [orderOf_pow, hgo, Nat.gcd_eq_right hkm, hk, Nat.div_div_self hdm hmpos.ne']
+  -- The solution set is exactly the subgroup `zpowers (g ^ k)`.
+  have hset : (univ.filter (fun a : α => a ^ n = 1))
+      = (zpowers (g ^ k) : Set α).toFinset := by
+    ext a
+    simp only [mem_filter, mem_univ, true_and, Set.mem_toFinset, SetLike.mem_coe]
+    constructor
+    · intro ha
+      -- `a = g ^ e` for some `e`.
+      obtain ⟨e, he⟩ := (mem_powers_iff a g).mp (mem_powers_iff_mem_zpowers.mpr (hg a))
+      -- `m ∣ e * n`.
+      have hpow : g ^ (e * n) = 1 := by rw [pow_mul, he]; exact ha
+      have hmen : m ∣ e * n := by rw [← hgo]; exact orderOf_dvd_iff_pow_eq_one.mpr hpow
+      -- hence `k = m / d ∣ e`.
+      have hke : k ∣ e := by rw [hk, hd]; exact div_gcd_dvd_of_dvd_mul hn hmen
+      obtain ⟨t, ht⟩ := hke
+      exact mem_zpowers_iff.mpr ⟨(t : ℤ), by rw [zpow_natCast, ← pow_mul, ← ht, he]⟩
+    · intro ha
+      -- `orderOf a ∣ orderOf (g ^ k) = d ∣ n`, so `a ^ n = 1`.
+      have h1 : orderOf a ∣ d := by
+        have := orderOf_dvd_of_mem_zpowers ha
+        rwa [hgk_order] at this
+      exact orderOf_dvd_iff_pow_eq_one.mp (h1.trans hdn)
+  -- Conclude by counting the subgroup.
+  rw [hset]
+  simp only [Set.toFinset_card, SetLike.coe_sort_coe]
+  rw [Fintype.card_zpowers, hgk_order]
+
+/-- **Frobenius' divisibility, cyclic case.** `gcd(n, |G|)` divides the number
+of solutions of `xⁿ = 1` — here, with equality. This is the statement Frobenius'
+theorem generalises to arbitrary finite groups. -/
+theorem frobenius_cyclic [DecidableEq α] [Fintype α] [IsCyclic α] (n : ℕ) :
+    Nat.gcd n (Fintype.card α) ∣ (univ.filter (fun a : α => a ^ n = 1)).card := by
+  rw [card_pow_eq_one_eq_gcd]
+
+/-- The solution set is a singleton (only the identity) iff `n` is coprime to
+`|G|`. This is the cyclic incarnation of the power-map dichotomy of the parent
+file: `x ↦ xⁿ` is injective iff the only `n`-th root of unity is `1`. -/
+theorem card_pow_eq_one_eq_one_iff_coprime [DecidableEq α] [Fintype α] [IsCyclic α]
+    (n : ℕ) :
+    (univ.filter (fun a : α => a ^ n = 1)).card = 1 ↔ n.Coprime (Fintype.card α) := by
+  rw [card_pow_eq_one_eq_gcd]
+
+/-- When the exponent is a multiple of `|G|`, every element is a solution: the
+count is the whole group. -/
+theorem card_pow_eq_one_eq_card_of_card_dvd [DecidableEq α] [Fintype α] [IsCyclic α]
+    {n : ℕ} (h : Fintype.card α ∣ n) :
+    (univ.filter (fun a : α => a ^ n = 1)).card = Fintype.card α := by
+  rw [card_pow_eq_one_eq_gcd, Nat.gcd_eq_right h]
+
+end CauchyGroupTheoremOQ01OQ01OQ01OQ01

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01",
+  "title": "Counting solutions to xⁿ = 1 in a cyclic group: exactly gcd(n, |G|)",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Finset", "Subgroup", "Submonoid", "Function"],
+    "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "For a finite cyclic group G and any exponent n, the number of solutions of xⁿ = 1 is exactly gcd(n, |G|): #{a : G | aⁿ = 1} = Nat.gcd n (Fintype.card G), for every n including n = 0 (both sides equal |G|). Mathlib records only the one-sided bound IsCyclic.card_pow_eq_one_le (#{a | aⁿ = 1} ≤ n, for 0 < n); this entry pins the value on the nose. The proof fixes a generator g (orderOf g = |G| =: m), sets d = gcd(n, m) and k = m/d, and shows the single cyclic subgroup zpowers (g^k) IS the solution set: its order is m/gcd(m,k) = m/k = d. The forward inclusion (aⁿ = 1 ⟹ a ∈ zpowers (g^k)) is the crux — writing a = gᵉ, the relation m ∣ e·n is upgraded to k ∣ e by the elementary number-theory lemma div_gcd_dvd_of_dvd_mul (m = d·k, n = d·n', gcd(k,n') = 1, so k ∣ e·n' ⟹ k ∣ e). The reverse inclusion is orderOf a ∣ orderOf (g^k) = d ∣ n via orderOf_dvd_of_mem_zpowers. Corollaries: the Frobenius divisibility statement on the cyclic fibre (here an equality), the count = 1 ⟺ coprimality reduction to the parent's power-map dichotomy, and count = |G| when |G| ∣ n.",
+  "overview": {
+    "historicalContext": "Frobenius proved in 1895 that in any finite group G the number of solutions of xⁿ = 1 is divisible by gcd(n, |G|) whenever gcd(n, |G|) ∣ |G| — one of the oldest counting theorems in group theory and the seed of the Frobenius conjecture (that when the count equals gcd(n, |G|) = the divisor, the solution set is a subgroup). The cyclic case is both the base case and the extremal case of Frobenius' divisibility: on a cyclic group the count is not merely divisible by gcd(n, |G|), it equals it, and the solution set is always the unique subgroup of that order. This refines the parent chain CauchyGroupTheoremOQ01OQ01OQ01 (the power-map dichotomy x ↦ xⁿ is a bijection iff gcd(n, |G|) = 1): bijectivity is exactly the count = 1 slice, and on a cyclic group the dichotomy becomes a full root-counting formula. Mathlib's IsCyclic.card_pow_eq_one_le supplies only the inequality ≤ n that underlies its proof that finite subgroups of a field are cyclic; the exact value gcd(n, |G|) was not recorded.",
+    "problemStatement": "For a finite cyclic group G and a natural number n, determine exactly how many elements x satisfy xⁿ = 1. Prove that this count equals gcd(n, |G|) for every n, identify the solution set as a specific cyclic subgroup, and deduce the cyclic case of Frobenius' divisibility theorem together with the coprimality and full-group boundary cases.",
+    "proofStrategy": "Handle n = 0 separately (x⁰ = 1 for all x, and gcd(0, m) = m). For 0 < n, pick a generator g so orderOf g = |G| =: m, and set d = gcd(n, m), k = m/d. Compute orderOf (g^k) = orderOf g / gcd(orderOf g, k) = m / gcd(m, k) = m/k = d, using k ∣ m (Nat.gcd_eq_right, Nat.div_div_self). Then prove the solution set equals the subgroup zpowers (g^k) by a two-way inclusion. Forward: if aⁿ = 1 write a = gᵉ (mem_powers_iff via the generator); gᵉⁿ = 1 gives orderOf g = m ∣ e·n (orderOf_dvd_iff_pow_eq_one), and the standalone arithmetic lemma div_gcd_dvd_of_dvd_mul upgrades m ∣ e·n to k = m/gcd(n,m) ∣ e by cancelling the common gcd factor and using coprimality of the cofactors (Nat.coprime_div_gcd_div_gcd, Nat.Coprime.dvd_of_dvd_mul_right); hence a = gᵉ = (g^k)^(e/k) ∈ zpowers (g^k). Reverse: a ∈ zpowers (g^k) gives orderOf a ∣ orderOf (g^k) = d ∣ n (orderOf_dvd_of_mem_zpowers), so aⁿ = 1. Finally |solution set| = |zpowers (g^k)| = orderOf (g^k) = d = gcd(n, |G|) via Fintype.card_zpowers.",
+    "keyInsights": [
+      "On a cyclic group of order m the solutions of xⁿ = 1 are not just bounded by gcd(n, m) — they are exactly the unique subgroup of order gcd(n, m), namely zpowers (g^(m/gcd(n,m))). The root-counting equation and the subgroup structure are the same fact.",
+      "The number-theoretic heart is isolated as div_gcd_dvd_of_dvd_mul: from m ∣ e·n one extracts m/gcd(n,m) ∣ e. Writing m = d·k and n = d·n' with gcd(k, n') = 1, the factor k of m that is coprime to n must be absorbed entirely by e — pure arithmetic, fully decoupled from the group theory.",
+      "The order computation orderOf (g^k) = m/k hinges on k ∣ m forcing gcd(m, k) = k; choosing k = m/gcd(n,m) is exactly what makes the resulting subgroup have order gcd(n, m).",
+      "This is the extremal case of Frobenius' theorem: in an arbitrary finite group gcd(n, |G|) only divides the count, but on the cyclic fibre the divisibility is saturated to equality, so frobenius_cyclic is a corollary with the sharp constant.",
+      "The parent's power-map dichotomy is recovered as the boundary case: count = 1 ⟺ gcd(n, |G|) = 1 ⟺ x ↦ xⁿ injective, so the cyclic root count interpolates continuously between 'only the identity' (coprime) and 'everything' (|G| ∣ n)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "arithmetic-core",
+      "title": "The Number-Theoretic Core",
+      "startLine": 60,
+      "endLine": 89,
+      "summary": "div_gcd_dvd_of_dvd_mul: if m ∣ e·n then m/gcd(n,m) ∣ e. Setting d = gcd(n,m), the proof writes m = d·(m/d) and n = d·(n/d), cancels the common d from m ∣ e·n to get (m/d) ∣ e·(n/d), and drops the n/d factor using gcd(m/d, n/d) = 1. This is the arithmetic engine of the exact count, fully decoupled from the group theory.",
+      "mathContext": "m ∣ e·n ⟹ (m/gcd(n,m)) ∣ e, via d·k = m, d·n' = n, gcd(k, n') = 1, k ∣ e·n' ⟹ k ∣ e."
+    },
+    {
+      "id": "main-count",
+      "title": "The Exact Solution Count",
+      "startLine": 90,
+      "endLine": 143,
+      "summary": "card_pow_eq_one_eq_gcd: #{a : G | aⁿ = 1} = gcd(n, |G|) for every n. After the n = 0 case, a generator g and the subgroup zpowers (g^k) with k = m/gcd(n,m) are introduced; orderOf (g^k) = d is computed; the solution set is shown equal to zpowers (g^k) by two inclusions (forward via div_gcd_dvd_of_dvd_mul, reverse via orderOf_dvd_of_mem_zpowers); and the count is read off as orderOf (g^k) = d.",
+      "mathContext": "{a | aⁿ = 1} = zpowers (g^(m/d)), of cardinality orderOf (g^(m/d)) = m/(m/d) = d = gcd(n, m)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Frobenius Divisibility and Boundary Cases",
+      "startLine": 144,
+      "endLine": 165,
+      "summary": "frobenius_cyclic records gcd(n, |G|) ∣ count (the statement Frobenius generalises to arbitrary groups, here with equality). card_pow_eq_one_eq_one_iff_coprime reduces count = 1 to coprimality of n and |G| — the cyclic incarnation of the parent's power-map dichotomy. card_pow_eq_one_eq_card_of_card_dvd gives count = |G| when |G| ∣ n.",
+      "mathContext": "gcd(n,|G|) ∣ count; count = 1 ⟺ n.Coprime |G|; |G| ∣ n ⟹ count = |G|."
+    }
+  ],
+  "conclusion": {
+    "summary": "On a finite cyclic group the equation xⁿ = 1 has exactly gcd(n, |G|) solutions, and they form the unique cyclic subgroup of that order, zpowers (g^(|G|/gcd(n,|G|))). The proof factors cleanly into a self-contained divisibility lemma (m ∣ e·n ⟹ m/gcd(n,m) ∣ e) and a generator-based identification of the solution set with that subgroup. This sharpens Mathlib's one-sided bound #{a | aⁿ = 1} ≤ n to an exact value, realises the extremal (equality) case of Frobenius' divisibility theorem, and recovers the parent's power-map dichotomy as the coprime boundary count = 1.",
+    "implications": [
+      "Upgrades Mathlib's IsCyclic.card_pow_eq_one_le (an inequality ≤ n) to the exact count gcd(n, |G|), valid for every n including n = 0.",
+      "Establishes the cyclic — extremal — case of Frobenius' theorem, where the gcd(n, |G|) that merely divides the solution count in a general finite group is attained with equality.",
+      "Frames the parent power-map dichotomy as a root-counting boundary: x ↦ xⁿ is a bijection on a cyclic group iff the only n-th root of unity is 1, i.e. iff the count is 1, with the count rising to |G| as |G| ∣ n."
+    ],
+    "openQuestions": [
+      "Frobenius' theorem gives gcd(n, |G|) ∣ #{x | xⁿ = 1} in any finite group; can the general divisibility be formalized by reducing along the cyclic subgroups generated by each element, using this exact cyclic count as the base case?",
+      "When does the Frobenius bound become an equality in a non-cyclic group — characterize the finite groups G and exponents n for which #{x | xⁿ = 1} = gcd(n, |G|), the saturated case underlying the Frobenius conjecture on solution sets being subgroups.",
+      "What is the exact count of solutions of xⁿ = g for a fixed non-identity g in a cyclic group (the inhomogeneous equation), and how does it depend on whether g lies in the image subgroup of the n-th power map?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Specialises and sharpens the parent's power-map dichotomy to cyclic groups: bijectivity of x ↦ xⁿ is the count = 1 slice, and on a cyclic group the dichotomy becomes the full root-counting formula gcd(n, |G|). card_pow_eq_one_eq_one_iff_coprime recovers the parent's coprimality boundary."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01",
+      "relationship": "related",
+      "description": "Both quantify how arithmetic of n against |G| controls the structure of the n-th power map; Cauchy's theorem detects prime obstructions in arbitrary groups, while this entry gives the exact solution count on the cyclic fibre, the base/extremal case of the Frobenius divisibility that generalises Cauchy-style counting."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (cyclic root-counting toward Frobenius' theorem)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "cyclic-groups",
+      "frobenius-theorem",
+      "solution-counting",
+      "order-of-element",
+      "roots-of-unity",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCyclic.card_pow_eq_one_le",
+        "description": "The one-sided bound #{a | aⁿ = 1} ≤ n for 0 < n on a cyclic group; this entry sharpens it to the exact value gcd(n, |G|).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "IsCyclic.exists_generator",
+        "description": "A cyclic group has a generator g with every element a power of g; fixes the generator whose order is |G|.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "orderOf_eq_card_of_forall_mem_zpowers",
+        "description": "If every element lies in zpowers g then orderOf g = Nat.card G; gives orderOf g = |G| = m.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "orderOf_pow",
+        "description": "orderOf (x^n) = orderOf x / gcd(orderOf x, n); computes orderOf (g^k) = m / gcd(m, k) = m/k = d.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_dvd_of_mem_zpowers",
+        "description": "y ∈ zpowers x ⟹ orderOf y ∣ orderOf x; supplies the reverse inclusion (every power of g^k satisfies xⁿ = 1 since d ∣ n).",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf x ∣ n ↔ xⁿ = 1; converts between the divisibility m ∣ e·n and the relation gᵉⁿ = 1, and closes the reverse inclusion.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Fintype.card_zpowers",
+        "description": "Fintype.card (zpowers x) = orderOf x; turns the identified solution subgroup into the count d = gcd(n, |G|).",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Nat.coprime_div_gcd_div_gcd",
+        "description": "0 < gcd m n ⟹ Coprime (m/gcd) (n/gcd); supplies the coprimality of the cofactors in the arithmetic core lemma.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Frobenius, Ferdinand Georg",
+        "title": "Verallgemeinerung des Sylow'schen Satzes",
+        "year": "1895",
+        "note": "Sitzungsberichte der Königlich Preußischen Akademie der Wissenschaften zu Berlin — the theorem that gcd(n, |G|) divides the number of solutions of xⁿ = 1 in any finite group; the cyclic case proved here is its extremal (equality) instance."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — Frobenius' solution-counting theorem and the conjecture that a saturated solution set is a subgroup; cyclic groups as the base case."
+      },
+      {
+        "authors": "Hall, Marshall",
+        "title": "The Theory of Groups",
+        "year": "1959",
+        "note": "Macmillan — root-counting in cyclic and abelian groups; the unique subgroup of each order dividing |G| in a cyclic group is exactly the solution set of xⁿ = 1."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

For a finite **cyclic** group `G` and any exponent `n`, the number of solutions of `xⁿ = 1` is **exactly** `gcd(n, |G|)`:

```
#{a : G | aⁿ = 1} = Nat.gcd n (Fintype.card G)
```

for every `n` (including `n = 0`, where both sides are `|G|`). Mathlib records only the one-sided bound `IsCyclic.card_pow_eq_one_le` (`#{a | aⁿ = 1} ≤ n`, for `0 < n`); this entry pins the value on the nose.

## What's new vs. Mathlib

- **Exact equality**, not just `≤ n`. The solution set is identified with the unique cyclic subgroup `zpowers (g^(m/d))` of order `d = gcd(n, |G|)`, where `g` is a generator and `m = |G|`.
- The number-theoretic core is isolated as a standalone lemma `div_gcd_dvd_of_dvd_mul`: `m ∣ e·n ⟹ m/gcd(n,m) ∣ e`.

## Mathematical content

Toward **Frobenius' divisibility theorem** (in any finite group, `gcd(n,|G|)` divides `#{x | xⁿ = 1}`): the cyclic case is the **extremal case**, where the divisibility is saturated to *equality*. Recorded as `frobenius_cyclic`.

This sharpens the parent chain `CauchyGroupTheoremOQ01OQ01OQ01` (the power-map dichotomy `x ↦ xⁿ` bijective iff `gcd(n,|G|)=1`): bijectivity is the `count = 1` slice (`card_pow_eq_one_eq_one_iff_coprime`), and the count rises to `|G|` when `|G| ∣ n` (`card_pow_eq_one_eq_card_of_card_dvd`).

## Proof sketch

Fix a generator `g` (`orderOf g = m`), set `d = gcd(n,m)`, `k = m/d`.
- `orderOf (g^k) = m/gcd(m,k) = m/k = d` (using `k ∣ m`).
- **Forward** (`aⁿ=1 ⟹ a ∈ zpowers (g^k)`): write `a = gᵉ`; `m ∣ e·n` upgrades to `k ∣ e` via `div_gcd_dvd_of_dvd_mul`.
- **Reverse**: `orderOf a ∣ orderOf (g^k) = d ∣ n` (`orderOf_dvd_of_mem_zpowers`).
- Count `= |zpowers (g^k)| = orderOf (g^k) = d = gcd(n,|G|)`.

## Verification

- **5 theorems, 0 sorries, 0 `axiom` declarations.**
- `#print axioms card_pow_eq_one_eq_gcd` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`). Genuinely **verified / 0-axiom**.
- Builds against Mathlib `v4.26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)