### PR TITLE
Enrich Weighted Power-Mean Monotonicity: add annotations

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "ann-pm-header",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "One Square Bound Climbs the Dyadic Ladder",
+    "content": "The docstring states the file's thesis: the parent's weighted square bound $(\\sum w_i f_i)^2 \\le W\\sum w_i f_i^2$ is precisely the $p = 1 \\le 2$ rung of the power-mean ladder, and substituting $f_i = a_i^r$ then iterating climbs the dyadic exponents $1, 2, 4, 8, \\ldots$. The file deliberately isolates exactly what a single Cauchy–Schwarz bound yields: weighted $L^p$ monotonicity along powers of two. Full continuous monotonicity $M_p \\le M_q$ for all $p \\le q$ requires Hölder's inequality, which is intentionally out of scope — pinpointing the gap rather than papering over it.",
+    "mathContext": "Power mean $M_r = \\Big(\\dfrac{\\sum w_i a_i^r}{\\sum w_i}\\Big)^{1/r}$ interpolates harmonic ($r{=}{-}1$), geometric ($r\\to 0$), arithmetic ($r{=}1$), quadratic ($r{=}2$). The square bound gives $M_r \\le M_{2r}$, hence $M_r \\le M_{2^k r}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "power mean",
+      "Lᵖ monotonicity",
+      "Cauchy–Schwarz inequality",
+      "Hölder's inequality"
+    ],
+    "prerequisites": [
+      "generalized means",
+      "weighted square bound"
+    ]
+  },
+  {
+    "id": "ann-pm-lyapunov",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 50,
+      "endLine": 78
+    },
+    "type": "insight",
+    "title": "The Natural-Exponent Lyapunov Chain",
+    "content": "pow_sum_sq_le delivers the discrete log-convexity of the power-sum sequence $P(m) = \\sum w_i a_i^m$: $P(m+t)^2 \\le P(m)\\,P(m+2t)$. It is obtained by feeding the parent's square bound the weights $w_i a_i^m$ (nonnegative since $a_i, w_i \\ge 0$) and the function $a_i^t$. The left side becomes $P(m+t)^2$, the multiplier is $P(m)$, and $\\sum (w_i a_i^m)(a_i^t)^2 = P(m+2t)$ after exponent arithmetic (pow_add, pow_mul). Because the exponents are natural numbers, the whole statement is root-free and purely algebraic — this is exactly Lyapunov's inequality for moments. pow_sum_log_convex is the consecutive $t = 1$ case.",
+    "mathContext": "$P(m+t)^2 \\le P(m)\\,P(m+2t)$ with $P(m) = \\sum_i w_i a_i^m$ — log-convexity: $\\log P$ is a convex function of the exponent. Consecutive: $P(m+1)^2 \\le P(m)P(m+2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lyapunov's inequality",
+      "log-convexity",
+      "moments",
+      "power sums"
+    ],
+    "prerequisites": [
+      "weighted square bound",
+      "pow_add / pow_mul"
+    ]
+  },
+  {
+    "id": "ann-pm-rpow",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 80,
+      "endLine": 94
+    },
+    "type": "technique",
+    "title": "The Real-Exponent Rung r ↦ 2r",
+    "content": "rpow_sum_sq_le moves from natural to real exponents, the form needed for the power mean. Applying the parent square bound to $f_i = a_i^r$ (real rpow) gives $(\\sum w_i a_i^r)^2 \\le W\\sum w_i a_i^{2r}$. The only rewriting is $(a_i^r)^2 = a_i^{2r}$, which needs $a_i \\ge 0$ and goes through Real.rpow_natCast (to read the square as an rpow) and Real.rpow_mul (to multiply exponents). This single substitution IS the $r \\mapsto 2r$ rung — no new analytic content beyond the square bound.",
+    "mathContext": "$\\Big(\\sum_i w_i a_i^r\\Big)^2 \\le \\Big(\\sum_i w_i\\Big)\\sum_i w_i a_i^{2r}$, using $(a_i^r)^2 = a_i^{r\\cdot 2} = a_i^{2r}$ for $a_i \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "real powers (rpow)",
+      "Real.rpow_mul",
+      "exponent arithmetic"
+    ],
+    "prerequisites": [
+      "Real.rpow_natCast",
+      "Real.rpow_mul"
+    ]
+  },
+  {
+    "id": "ann-pm-def",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 96,
+      "endLine": 101
+    },
+    "type": "definition",
+    "title": "The Weighted Power Mean",
+    "content": "weightedPowerMean defines the order-$r$ weighted (generalized / Hölder) mean $M_r = \\big(\\sum w_i a_i^r / \\sum w_i\\big)^{1/r}$, the weighted average of $a_i^r$ raised to the reciprocal power. It is marked noncomputable because the real power rpow is. This is the central object whose monotonicity in $r$ the file establishes; at $r = 1$ it is the weighted arithmetic mean, at $r = 2$ the weighted quadratic mean.",
+    "mathContext": "$M_r = \\Big(\\dfrac{\\sum_{i\\in s} w_i a_i^r}{\\sum_{i\\in s} w_i}\\Big)^{1/r}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "generalized mean",
+      "Hölder mean",
+      "weighted average"
+    ],
+    "prerequisites": [
+      "real powers (rpow)"
+    ]
+  },
+  {
+    "id": "ann-pm-double",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 132
+    },
+    "type": "insight",
+    "title": "Dyadic Power-Mean Monotonicity M_r ≤ M_2r",
+    "content": "weightedPowerMean_le_double is the headline result. Writing $N_r = \\sum w_i a_i^r / W$, the real-exponent square bound rearranges to $N_r^2 \\le N_{2r}$ (via div_pow and div_le_div_iff₀ plus an nlinarith). Then, since $x \\mapsto x^{1/(2r)}$ is monotone on the nonnegatives (Real.rpow_le_rpow), $M_{2r} = N_{2r}^{1/(2r)} \\ge (N_r^2)^{1/(2r)} = N_r^{1/r} = M_r$, using the exponent identity $2\\cdot\\frac{1}{2r} = \\frac{1}{r}$. No inequality between means is assumed — only the squared-mean comparison and one monotone-root step. This is weighted $L^p$ monotonicity, derived purely from the square bound.",
+    "mathContext": "$N_r^2 \\le N_{2r}$ where $N_r = \\frac{\\sum w_i a_i^r}{W}$. Apply $(\\cdot)^{1/(2r)}$: $M_r = (N_r^2)^{1/(2r)} \\le N_{2r}^{1/(2r)} = M_{2r}$, since $2\\cdot\\frac{1}{2r} = \\frac{1}{r}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "power-mean inequality",
+      "Real.rpow_le_rpow",
+      "monotone root"
+    ],
+    "prerequisites": [
+      "rpow monotonicity",
+      "div_le_div_iff₀",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-pm-ladder",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 134,
+      "endLine": 148
+    },
+    "type": "technique",
+    "title": "Iterating: M_r ≤ M_(2^k r)",
+    "content": "weightedPowerMean_le_pow_two_mul climbs the whole dyadic ladder by induction on $k$. The base case $k = 0$ is reflexivity ($2^0 r = r$). The successor step chains the induction hypothesis $M_r \\le M_{2^n r}$ with one more doubling $M_{2^n r} \\le M_{2\\cdot 2^n r}$ (weightedPowerMean_le_double applied at order $2^n r > 0$), and rewrites $2\\cdot 2^n r = 2^{n+1} r$. The result spans every power-of-two exponent — the exact reach of repeated squaring.",
+    "mathContext": "$M_r \\le M_{2^k r}$ for all $k \\in \\mathbb{N}$, by induction: $M_r \\le M_{2^n r} \\le M_{2\\cdot 2^n r} = M_{2^{n+1} r}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "induction",
+      "dyadic exponents",
+      "transitivity"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "weightedPowerMean_le_double"
+    ]
+  },
+  {
+    "id": "ann-pm-instance",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 150,
+      "endLine": 160
+    },
+    "type": "context",
+    "title": "Worked Instance: M₁ ≤ M₂",
+    "content": "A concrete dyadic comparison instantiating weightedPowerMean_le_double: for the data $a = (0,1,2)$ with weights $w = (1,2,3)$ over range 3, the weighted arithmetic mean $M_1$ is at most the weighted quadratic mean $M_2$. The hypotheses (nonnegativity of $a$ and $w$, positivity of the total weight $W = 6$) are discharged by positivity and norm_num, and the conclusion follows by simpa. This grounds the abstract ladder at its first, most familiar rung — the AM ≤ QM inequality.",
+    "mathContext": "$M_1 = \\frac{\\sum w_i a_i}{6} \\le M_2 = \\Big(\\frac{\\sum w_i a_i^2}{6}\\Big)^{1/2}$ for $a=(0,1,2)$, $w=(1,2,3)$ — the weighted AM ≤ QM.",
+    "significance": "context",
+    "relatedConcepts": [
+      "AM-QM inequality",
+      "worked example",
+      "weighted means"
+    ],
+    "prerequisites": [
+      "arithmetic",
+      "positivity"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-01-oq-03` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 7 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Header — one square bound climbs the dyadic ladder
2. **Natural-exponent Lyapunov chain** (key) — log-convexity of power sums
3. The real-exponent r↦2r rung
4. The weighted power mean definition
5. **Dyadic monotonicity M_r ≤ M_2r** (key)
6. Iterating to M_r ≤ M_(2^k r)
7. AM ≤ QM worked instance

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: original` / `axiomCount: 0` / 0 sorries — accurate against the Lean source.

Per-target branch to avoid clobbering open enricher PRs.