### PR TITLE
research(wilsons-theorem-oq-05-oq-01-oq-02): Gauss's prime-power form of Wilson's theorem [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2719,6 +2719,7 @@ import Proofs.EulerTotientOQ04OQ01
 import Proofs.EulerTotientOQ05
 import Proofs.EulerTotientOQ06
 import Proofs.EulerTotientOQ07
+import Proofs.EulerTotientOQ07OQ04
 import Proofs.EulerTotientOQ10
 import Proofs.EulerTotientOQ09
 import Proofs.EulerTotientOQ09OQ01

--- a/proofs/Proofs/EulerTotientOQ07OQ04.lean
+++ b/proofs/Proofs/EulerTotientOQ07OQ04.lean
@@ -1,0 +1,135 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Tactic
+
+/-!
+# Setwise coprimality of a finite family of totients
+
+**Open Question (`euler-totient-oq-07-oq-04`)**: extend the *pairwise* coprimality
+criterion for Euler totients to an arbitrary finite family.
+
+The parent entry (`euler-totient-oq-07`) packages Mathlib's
+`Nat.totient_coprime_totient_iff`:
+
+  `gcd(φ m, φ n) = 1 ↔ (m = 1 ∨ m = 2) ∨ (n = 1 ∨ n = 2)`,
+
+together with the structural fact that for `m, n ≥ 3` the gcd is always even.
+The driving phenomenon is the **parity of the totient**: `φ(k)` is even for every
+`k > 2` (`Nat.totient_even`), and `φ(0) = 0` is even as well, so the *only* values
+of `k` with an **odd** totient are `k ∈ {1, 2}` (where `φ(k) = 1`).
+
+This file lifts the criterion from two arguments to a finite family
+`a : ι → ℕ` indexed by a `Finset s`.  The natural object is the setwise gcd
+`s.gcd (fun i ↦ φ (a i))`, i.e. the largest integer dividing *every* totient in
+the family.  The headline result is the clean biconditional
+
+  `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2`.
+
+Read left to right: a finite family of totients is setwise coprime **iff at least
+one argument lands in `{1, 2}`** (contributing the unit `φ = 1`).  Equivalently,
+the moment *every* argument avoids `{1, 2}` the whole family shares the factor `2`.
+
+This is genuinely stronger than the pairwise statement — the pairwise case is the
+two-element specialization (`example` at the end) — and Mathlib has no
+finite-family form.
+
+## Contents
+
+* `two_dvd_totient_of_ne_one_two`   — `a ∉ {1,2} ⟹ 2 ∣ φ a` (the parity engine).
+* `two_dvd_gcd_totient_family`      — `(∀ i ∈ s, a i ∉ {1,2}) ⟹ 2 ∣ s.gcd (φ ∘ a)`.
+* `gcd_totient_family_eq_one_iff`   — the headline biconditional.
+* `gcd_totient_family_ne_one_of_forall` — its contrapositive, stated directly.
+
+Fully machine-checked: `0` sorries, `0` axioms (the `decide` calls reduce
+concrete small naturals in the kernel, not `native_decide`).
+-/
+
+namespace EulerTotientOQ07OQ04
+
+open Nat
+
+variable {ι : Type*}
+
+/-- **The parity engine.**  Every natural other than `1` and `2` has an *even*
+totient: `φ(0) = 0` is even, and `φ(k)` is even for all `k > 2`
+(`Nat.totient_even`).  Hence `2 ∣ φ(a)` whenever `a ∉ {1, 2}`. -/
+theorem two_dvd_totient_of_ne_one_two {a : ℕ} (h1 : a ≠ 1) (h2 : a ≠ 2) :
+    2 ∣ φ a := by
+  rcases Nat.eq_zero_or_pos a with h0 | hpos
+  · simp [h0]
+  · exact (totient_even (by omega)).two_dvd
+
+/-- **Shared factor of a totient family.**  If *every* argument avoids `{1, 2}`,
+then the totients all share the factor `2`, so `2` divides their setwise gcd.
+(For the empty family this is `2 ∣ 0`, which holds.) -/
+theorem two_dvd_gcd_totient_family (s : Finset ι) (a : ι → ℕ)
+    (h : ∀ i ∈ s, a i ≠ 1 ∧ a i ≠ 2) :
+    2 ∣ s.gcd (fun i ↦ φ (a i)) := by
+  apply Finset.dvd_gcd
+  intro i hi
+  obtain ⟨h1, h2⟩ := h i hi
+  exact two_dvd_totient_of_ne_one_two h1 h2
+
+/-- **Headline: setwise coprimality criterion for a finite family of totients.**
+The totients `{φ(a i) : i ∈ s}` are setwise coprime (their gcd is `1`) **iff at
+least one argument `a i` lies in `{1, 2}`**, where the totient equals the unit `1`.
+
+Equivalently: as soon as every argument avoids `{1, 2}`, the family shares the
+factor `2` (`two_dvd_gcd_totient_family`) and is never setwise coprime.  This is
+the finite-family generalization of the pairwise `Nat.totient_coprime_totient_iff`. -/
+theorem gcd_totient_family_eq_one_iff (s : Finset ι) (a : ι → ℕ) :
+    s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2 := by
+  constructor
+  · intro h
+    by_contra hcon
+    push_neg at hcon
+    have h2 : (2 : ℕ) ∣ s.gcd (fun i ↦ φ (a i)) :=
+      two_dvd_gcd_totient_family s a hcon
+    rw [h] at h2
+    exact absurd h2 (by decide)
+  · rintro ⟨i, hi, hai⟩
+    have hphi : φ (a i) = 1 := by rcases hai with h | h <;> simp [h]
+    have hdvd : s.gcd (fun j ↦ φ (a j)) ∣ φ (a i) := Finset.gcd_dvd hi
+    rw [hphi] at hdvd
+    exact Nat.dvd_one.mp hdvd
+
+/-- **Contrapositive form.**  If every argument of the family avoids `{1, 2}`, then
+the totients are *not* setwise coprime: their gcd is at least `2`. -/
+theorem gcd_totient_family_ne_one_of_forall (s : Finset ι) (a : ι → ℕ)
+    (h : ∀ i ∈ s, a i ≠ 1 ∧ a i ≠ 2) :
+    s.gcd (fun i ↦ φ (a i)) ≠ 1 := by
+  intro hcontra
+  obtain ⟨i, hi, hai⟩ := (gcd_totient_family_eq_one_iff s a).mp hcontra
+  obtain ⟨h1, h2⟩ := h i hi
+  rcases hai with h' | h' <;> [exact h1 h'; exact h2 h']
+
+/-! ### Recovering the pairwise parent and worked examples -/
+
+/-- The pairwise criterion `euler-totient-oq-07` is the two-element
+specialization: take the family `![m, n]` indexed by `Fin 2`. -/
+example (m n : ℕ) :
+    (Finset.univ : Finset (Fin 2)).gcd (fun i ↦ φ (![m, n] i)) = 1 ↔
+      (m = 1 ∨ m = 2) ∨ (n = 1 ∨ n = 2) := by
+  rw [gcd_totient_family_eq_one_iff]
+  constructor
+  · rintro ⟨i, -, hi⟩
+    fin_cases i <;> simp_all
+  · rintro (h | h)
+    · exact ⟨0, Finset.mem_univ _, by simpa using h⟩
+    · exact ⟨1, Finset.mem_univ _, by simpa using h⟩
+
+-- A three-element family hitting `{1,2}`: `φ 2 = 1` forces setwise coprimality,
+-- regardless of the other (large) arguments.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![100, 2, 999] k)) = 1 := by
+  rw [gcd_totient_family_eq_one_iff]
+  exact ⟨1, Finset.mem_univ _, Or.inr (by decide)⟩
+
+-- A family entirely outside `{1,2}` is never setwise coprime: `φ 3 = φ 4 = φ 9 = even`.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![3, 4, 9] k)) ≠ 1 := by
+  apply gcd_totient_family_ne_one_of_forall
+  decide
+
+-- The concrete shared factor of `2` for that family: `gcd(φ3, φ4, φ9) = gcd(2,2,6) = 2`.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![3, 4, 9] k)) = 2 := by decide
+
+end EulerTotientOQ07OQ04

--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ02.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ02.lean
@@ -1,0 +1,176 @@
+import Mathlib
+
+/-
+# Gauss's prime-power form of Wilson's theorem
+
+**Open Question (`wilsons-theorem-oq-05-oq-01-oq-02`)**: the parent chain
+`wilsons-theorem-oq-05 → …-oq-01` classified the *classical* residue
+`(n - 1)! mod n` for every `n` (prime ⟹ `n-1`, `n = 4` ⟹ `2`, composite `≠ 4`
+⟹ `0`).  That trichotomy is about the bare factorial `(n-1)!`.  This file follows
+the *other* registered branch: instead of the residue of `(n-1)!`, study the
+**product of the units of `ℤ/nℤ`** — equivalently `∏_{1 ≤ a < n, gcd(a,n)=1} a`
+— and prove the **prime-power generalisation of Wilson's theorem** due to Gauss.
+
+Mathlib proves Wilson only for a *prime* modulus, where `ℤ/pℤ` is a field:
+`prod_univ_units_id_eq_neg_one` gives `∏_{x ∈ (ℤ/pℤ)ˣ} x = -1`, and its proof
+pairs each unit with its inverse, the only self-paired survivors being `±1`
+(`Units.inv_eq_self_iff`, which needs an integral domain).  For a prime *power*
+`p^k` the ring `ℤ/p^kℤ` is **not** a domain, so that lemma does not apply.  The
+correct statement is nonetheless
+
+  `∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1`   for every **odd** prime `p` and `k ≥ 1`,
+
+and the reason is structural rather than field-theoretic: `(ℤ/p^kℤ)ˣ` is a
+**cyclic** group (Gauss's primitive-root theorem, `ZMod.isCyclic_units_of_prime_pow`)
+of *even* order, and in any finite cyclic group of even order the equation
+`x² = 1` has *exactly two* solutions, `1` and the unique element of order two.
+
+## The reusable engine
+
+The heart of the file is a clean group-theoretic lemma, of independent interest
+and absent from Mathlib in this packaged form:
+
+* `prod_univ_eq_orderTwo` — **in a finite cyclic group, if `t` is an element with
+  `t·t = 1` and `t ≠ 1`, then the product of *all* the group elements is `t`.**
+  (`t` is then automatically the unique involution.)  The proof is the
+  inverse-pairing involution `x ↦ x⁻¹` on `univ.erase t`: cyclicity forces the
+  only fixed points of squaring to be `{1, t}` (`IsCyclic.card_pow_eq_one_le`
+  bounds the solution count of `x² = 1` by `2`), so after erasing `t` the lone
+  surviving fixed point is `1` and the pairing kills everything, leaving `t`.
+
+## The number-theoretic payload
+
+* `gauss_prime_pow_units` — `∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1` for odd prime `p`, `k ≥ 1`;
+* `gauss_prime_pow_cast` — the same identity pushed into `ℤ/p^kℤ`;
+* `wilson_units_prime` — the `k = 1` slice recovers the classical prime case
+  (matching Mathlib's `prod_univ_units_id_eq_neg_one`), so this is a genuine
+  generalisation of Wilson's theorem and not a sibling result;
+* `prod_units_zmod_nine` — a concrete check at `p = 3, k = 2`: the six units of
+  `ℤ/9ℤ` multiply to `-1 = 8`.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace WilsonsTheoremOQ05OQ01OQ02
+
+open Finset
+
+/-! ### The group-theoretic engine -/
+
+/-- In a finite cyclic group, the only solutions of `x² = 1` are `1` and a fixed
+element `t` of order two: once we know one nontrivial square root `t` of `1`,
+every square root is `1` or `t`.  This is the cyclic replacement for the
+integral-domain fact `Units.inv_eq_self_iff`. -/
+theorem sq_eq_one_iff_eq_one_or_eq
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G] [IsCyclic G]
+    {t : G} (ht2 : t * t = 1) (ht1 : t ≠ 1) {u : G} (hu : u * u = 1) :
+    u = 1 ∨ u = t := by
+  -- The squaring-fixed set has at most two elements, and `{1, t}` already gives two.
+  have hle : (univ.filter (fun a : G => a ^ 2 = 1)).card ≤ 2 :=
+    IsCyclic.card_pow_eq_one_le (by norm_num)
+  have hsub : ({1, t} : Finset G) ⊆ univ.filter (fun a : G => a ^ 2 = 1) := by
+    intro x hx
+    rw [mem_filter]
+    refine ⟨mem_univ _, ?_⟩
+    rcases mem_insert.1 hx with h | h
+    · subst h; simp
+    · rw [mem_singleton] at h; subst h; rw [sq]; exact ht2
+  have hcard : ({1, t} : Finset G).card = 2 := card_pair (Ne.symm ht1)
+  have heq : ({1, t} : Finset G) = univ.filter (fun a : G => a ^ 2 = 1) :=
+    eq_of_subset_of_card_le hsub (by rw [hcard]; exact hle)
+  have humem : u ∈ ({1, t} : Finset G) := by
+    rw [heq, mem_filter]; exact ⟨mem_univ _, by rw [sq]; exact hu⟩
+  rcases mem_insert.1 humem with h | h
+  · exact Or.inl h
+  · exact Or.inr (mem_singleton.1 h)
+
+/-- **The product of all elements of a finite cyclic group is its unique
+involution.**  If `t · t = 1` and `t ≠ 1` in a finite cyclic group `G`, then
+`∏_{x ∈ G} x = t`.  (Such a `t` is automatically the only element of order two.)
+The proof pairs each element with its inverse on `univ.erase t`. -/
+theorem prod_univ_eq_orderTwo
+    {G : Type*} [CommGroup G] [Fintype G] [DecidableEq G] [IsCyclic G]
+    {t : G} (ht2 : t * t = 1) (ht1 : t ≠ 1) :
+    ∏ x : G, x = t := by
+  have htinv : t⁻¹ = t := inv_eq_of_mul_eq_one_right ht2
+  -- The inverse-pairing involution wipes out everything once `t` is removed.
+  have key : ∏ x ∈ univ.erase t, x = 1 := by
+    refine prod_involution (fun a _ => a⁻¹) (fun a _ => mul_inv_cancel a) ?_ ?_ ?_
+    · -- non-fixed: `a ≠ 1 → a⁻¹ ≠ a`
+      intro a ha hane hcontra
+      have hcontra' : a⁻¹ = a := hcontra
+      -- `a⁻¹ = a` forces `a * a = 1`, so `a = 1` or `a = t`; but `a ≠ t`, hence `a = 1`.
+      have hsq : a * a = 1 := by nth_rewrite 1 [← hcontra']; exact inv_mul_cancel a
+      rcases sq_eq_one_iff_eq_one_or_eq ht2 ht1 hsq with h | h
+      · exact hane h
+      · exact (mem_erase.1 ha).1 h
+    · -- closure: `a⁻¹ ∈ univ.erase t`
+      intro a ha
+      refine mem_erase.2 ⟨?_, mem_univ _⟩
+      intro hc
+      have hc' : a⁻¹ = t := hc
+      -- `a⁻¹ = t` ⟹ `a = t⁻¹ = t`, contradicting `a ≠ t`.
+      exact (mem_erase.1 ha).1 (by rw [← inv_inv a, hc', htinv])
+    · -- involutivity
+      intro a _; exact inv_inv a
+  calc ∏ x : G, x = ∏ x ∈ insert t (univ.erase t), x := by
+        rw [insert_erase (mem_univ t)]
+    _ = t * ∏ x ∈ univ.erase t, x := prod_insert (notMem_erase t univ)
+    _ = t := by rw [key, mul_one]
+
+/-! ### Gauss's prime-power Wilson theorem -/
+
+/-- `-1 ≠ 1` among the units of `ℤ/mℤ` whenever the modulus `m` exceeds `2`
+(so `2 ≠ 0` in `ℤ/mℤ`).  This is the unique-nontrivial-square-root input the
+engine needs, for both the prime-power and prime moduli below. -/
+theorem neg_one_ne_one_units {m : ℕ} [NeZero m] (hm : 2 < m) :
+    (-1 : (ZMod m)ˣ) ≠ 1 := by
+  intro h
+  have hc : (-1 : ZMod m) = 1 := by simpa using congrArg Units.val h
+  have h2 : (2 : ZMod m) = 0 := by linear_combination -hc
+  have hdvd : m ∣ 2 := by
+    have hcast : ((2 : ℕ) : ZMod m) = 0 := by exact_mod_cast h2
+    exact (ZMod.natCast_eq_zero_iff 2 m).1 hcast
+  have := Nat.le_of_dvd (by norm_num) hdvd
+  omega
+
+variable {p : ℕ}
+
+/-- **Gauss's prime-power form of Wilson's theorem.**  For every odd prime `p`
+and every `k ≥ 1`, the product of all units of `ℤ/p^kℤ` is `-1`. -/
+theorem gauss_prime_pow_units (hp : p.Prime) (hp2 : p ≠ 2) {k : ℕ} (hk : k ≠ 0)
+    [NeZero (p ^ k)] : ∏ x : (ZMod (p ^ k))ˣ, x = -1 := by
+  haveI : IsCyclic (ZMod (p ^ k))ˣ := ZMod.isCyclic_units_of_prime_pow p hp hp2 k
+  have h2lt : 2 < p ^ k :=
+    lt_of_lt_of_le (lt_of_le_of_ne hp.two_le (Ne.symm hp2)) (Nat.le_self_pow hk p)
+  exact prod_univ_eq_orderTwo (by simp) (neg_one_ne_one_units h2lt)
+
+/-- Gauss's identity pushed into the ring `ℤ/p^kℤ`: the product of the units,
+viewed as ring elements, is `-1`. -/
+theorem gauss_prime_pow_cast (hp : p.Prime) (hp2 : p ≠ 2) {k : ℕ} (hk : k ≠ 0)
+    [NeZero (p ^ k)] : (∏ x : (ZMod (p ^ k))ˣ, (x : ZMod (p ^ k))) = -1 := by
+  have h := gauss_prime_pow_units hp hp2 hk
+  have e : (Units.coeHom (ZMod (p ^ k))) (∏ x : (ZMod (p ^ k))ˣ, x)
+         = ∏ x : (ZMod (p ^ k))ˣ, (x : ZMod (p ^ k)) := map_prod _ _ _
+  rw [← e, h]; simp
+
+/-- The `k = 1` slice recovers the **classical Wilson theorem** for a prime
+modulus, `∏_{x ∈ (ℤ/pℤ)ˣ} x = -1`. -/
+theorem wilson_units_prime (hp : p.Prime) (hp2 : p ≠ 2) [NeZero p] :
+    ∏ x : (ZMod p)ˣ, x = -1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : IsCyclic (ZMod p)ˣ := inferInstance
+  have h2lt : 2 < p := lt_of_le_of_ne hp.two_le (Ne.symm hp2)
+  exact prod_univ_eq_orderTwo (by simp) (neg_one_ne_one_units h2lt)
+
+/-! ### A concrete check: the six units of `ℤ/9ℤ` -/
+
+/-- The units of `ℤ/9ℤ` are `{1, 2, 4, 5, 7, 8}` and their product is `-1 = 8`,
+the `p = 3, k = 2` instance of Gauss's prime-power Wilson theorem. -/
+theorem prod_units_zmod_nine :
+    (∏ x : (ZMod 9)ˣ, (x : ZMod 9)) = -1 := by
+  haveI : NeZero ((3 : ℕ) ^ 2) := ⟨by norm_num⟩
+  have h := gauss_prime_pow_cast (p := 3) (by norm_num) (by norm_num) (k := 2) (by norm_num)
+  simpa using h
+
+end WilsonsTheoremOQ05OQ01OQ02

--- a/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-two-dvd-totient-of-ne-one-two",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 51, "endLine": 63 },
+    "type": "theorem",
+    "title": "The Parity Engine: a ∉ {1,2} ⟹ 2 ∣ φ a",
+    "content": "Packages the totient's parity into a single divisibility usable element-by-element. The proof cases on `a`: if `a = 0` then `φ 0 = 0` is divisible by 2 (`simp`); otherwise `a` is positive and, being ≠ 1 and ≠ 2, satisfies `2 < a` (by `omega`), so `Nat.totient_even` makes `φ a` even and `Even.two_dvd` extracts the factor. The naturals with an odd totient are exactly {1, 2}.",
+    "mathContext": "$a\\notin\\{1,2\\} \\implies 2\\mid\\varphi(a)$, since $\\varphi(0)=0$ and $\\varphi(k)$ is even for $k>2$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "parity of totient", "divisibility", "Nat.totient_even"],
+    "prerequisites": ["Euler's totient function", "parity of φ", "divisibility by 2"]
+  },
+  {
+    "id": "ann-two-dvd-gcd-totient-family",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 65, "endLine": 71 },
+    "type": "theorem",
+    "title": "Shared Factor of a Totient Family: 2 ∣ s.gcd",
+    "content": "When every argument of the family avoids {1,2}, all the totients are even, so 2 divides each entry; `Finset.dvd_gcd` lifts this uniform per-element divisibility to a divisibility of the setwise gcd. Holds vacuously for the empty family (2 ∣ 0). This is the explicit common divisor of an entire family of totients — the structural fact that drives non-coprimality.",
+    "mathContext": "$(\\forall i\\in s,\\ a_i\\notin\\{1,2\\}) \\implies 2 \\mid \\gcd_{i\\in s}\\varphi(a_i)$, via $k\\mid f(i)\\ \\forall i \\implies k\\mid \\gcd_i f(i)$.",
+    "significance": "key",
+    "relatedConcepts": ["setwise gcd", "Finset.dvd_gcd", "common divisor", "parity of totient"],
+    "prerequisites": ["Finset.gcd", "divisibility", "parity of φ"]
+  },
+  {
+    "id": "ann-gcd-totient-family-eq-one-iff",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 80, "endLine": 96 },
+    "type": "theorem",
+    "title": "Headline: Setwise Coprimality ⟺ Some Argument in {1,2}",
+    "content": "The flagship biconditional generalizing the pairwise `Nat.totient_coprime_totient_iff` to an arbitrary finite family. Forward direction is the contrapositive: if no argument is in {1,2}, then `two_dvd_gcd_totient_family` gives 2 ∣ s.gcd, contradicting s.gcd = 1 (`2 ∣ 1` is false by `decide`). Reverse direction: an argument with φ(a i) = 1 makes the setwise gcd divide 1 via `Finset.gcd_dvd`, so it equals 1 by `Nat.dvd_one`. No induction on the family is needed — the two one-directional gcd facts suffice.",
+    "mathContext": "$\\gcd_{i\\in s}\\varphi(a_i) = 1 \\iff \\exists i\\in s,\\ a_i\\in\\{1,2\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["setwise gcd", "coprimality", "finite family", "Finset.gcd_dvd", "biconditional characterization"],
+    "prerequisites": ["Finset.gcd", "coprimality", "parity of φ", "dvd_one"]
+  },
+  {
+    "id": "ann-gcd-totient-family-ne-one-of-forall",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 98, "endLine": 104 },
+    "type": "theorem",
+    "title": "Contrapositive: Family Avoiding {1,2} Is Never Setwise Coprime",
+    "content": "States the practically useful direction directly: if every argument avoids {1,2} the totients are not setwise coprime. Proved by feeding a hypothetical gcd = 1 through the headline biconditional to extract an argument in {1,2}, contradicting the hypothesis. The clean 'no escape ⟹ shared factor' form callers reach for.",
+    "mathContext": "$(\\forall i\\in s,\\ a_i\\notin\\{1,2\\}) \\implies \\gcd_{i\\in s}\\varphi(a_i)\\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["setwise gcd", "coprimality", "contrapositive"],
+    "prerequisites": ["Finset.gcd", "coprimality"]
+  },
+  {
+    "id": "ann-pairwise-recovery",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 108, "endLine": 119 },
+    "type": "example",
+    "title": "Recovering the Pairwise Parent (Fin 2 Specialization)",
+    "content": "Shows the pairwise criterion of `euler-totient-oq-07` is exactly the two-element case: the setwise gcd over the family `![m, n]` indexed by `Fin 2` equals 1 iff (m ∈ {1,2}) ∨ (n ∈ {1,2}). Confirms the family theorem is a genuine generalization, not a parallel statement — `fin_cases` on the index recovers the two-argument disjunction.",
+    "mathContext": "$\\gcd(\\varphi(m),\\varphi(n)) = 1 \\iff (m\\in\\{1,2\\})\\lor(n\\in\\{1,2\\})$ as the Fin 2 instance.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "pairwise criterion", "Fin 2", "fin_cases"],
+    "prerequisites": ["Finset.univ over Fin n", "Matrix.cons notation"]
+  },
+  {
+    "id": "ann-worked-examples",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 121, "endLine": 133 },
+    "type": "example",
+    "title": "Worked Fin 3 Families",
+    "content": "Three concrete witnesses over Fin 3: the family ![100, 2, 999] is setwise coprime because a₁ = 2 gives φ = 1; the family ![3, 4, 9] is not setwise coprime (all arguments ≥ 3) via `gcd_totient_family_ne_one_of_forall`; and its setwise gcd is exactly gcd(φ3, φ4, φ9) = gcd(2, 2, 6) = 2 by kernel `decide`.",
+    "mathContext": "$\\gcd(\\varphi 100,\\varphi 2,\\varphi 999)=1$; $\\gcd(\\varphi 3,\\varphi 4,\\varphi 9)=\\gcd(2,2,6)=2\\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "kernel decide", "setwise gcd"],
+    "prerequisites": ["finite evaluation of φ", "Finset.gcd over Fin 3"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "euler-totient-oq-07-oq-04",
+  "title": "Setwise Coprimality of a Finite Family of Totients: $\\gcd_i \\varphi(a_i)=1$ Iff Some $a_i\\in\\{1,2\\}$",
+  "slug": "euler-totient-oq-07-oq-04",
+  "description": "Generalizes the pairwise coprimality criterion for Euler totients (parent `euler-totient-oq-07`) to an arbitrary finite family. For a family a : ι → ℕ indexed by a Finset s, the setwise gcd of the totients satisfies `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2`: the family of totients is setwise coprime exactly when at least one argument lands in {1,2}, where φ = 1 is a unit. The engine is the parity of the totient — φ(0) = 0 and φ(k) is even for every k > 2 (`Nat.totient_even`), so {1,2} are the only naturals with an odd totient — combined with `Finset.dvd_gcd`/`Finset.gcd_dvd`: once every argument avoids {1,2} the whole family shares the factor 2. Mathlib has the pairwise `Nat.totient_coprime_totient_iff` but no finite-family form; this entry supplies it and directly answers a follow-up question posed in the parent's open-questions list. Fully machine-checked: 0 sorries, 0 axioms (the `decide` calls reduce concrete small naturals in the kernel, not `native_decide`).",
+  "meta": {
+    "author": "Euler (1763, totient function); finite-family coprimality criterion formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ07OQ04.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "coprimality",
+      "gcd",
+      "parity",
+      "finite-family",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The parity input is `Nat.totient_even` (φ(k) even for k > 2, via the order-2 unit −1 and Lagrange); the finite-family gcd reasoning uses `Finset.dvd_gcd` and `Finset.gcd_dvd`. The `decide` calls evaluate φ at concrete naturals (2, 3, 4, 9) and finite Fin 3 quantifications in the kernel (not `native_decide`), so the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_even",
+        "description": "`2 < n → Even n.totient`. The parity engine: every argument outside {1,2} (i.e. 0 or ≥ 3) has an even totient, so the family shares the factor 2.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.dvd_gcd",
+        "description": "`(∀ i ∈ s, k ∣ f i) → k ∣ s.gcd f`. Lifts the per-element divisibility 2 ∣ φ(a i) to 2 ∣ s.gcd (fun i ↦ φ (a i)).",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.gcd_dvd",
+        "description": "`i ∈ s → s.gcd f ∣ f i`. Gives the converse direction: a single argument with φ = 1 forces the whole setwise gcd to divide 1, hence to equal 1.",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Nat.totient_coprime_totient_iff",
+        "description": "Pairwise criterion `(φ m).Coprime (φ n) ↔ (m ∈ {1,2}) ∨ (n ∈ {1,2})`. The two-argument special case this entry generalizes to families; recovered as the Fin 2 specialization.",
+        "module": "Mathlib.Data.Nat.Totient"
+      }
+    ],
+    "originalContributions": [
+      "`gcd_totient_family_eq_one_iff`: the finite-family criterion `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2` — the headline generalization of the pairwise `Nat.totient_coprime_totient_iff`, which Mathlib does not state for families.",
+      "`two_dvd_totient_of_ne_one_two`: the clean parity statement `a ≠ 1 → a ≠ 2 → 2 ∣ φ a`, packaging φ(0) = 0 and `Nat.totient_even` into a single divisibility usable element-by-element.",
+      "`two_dvd_gcd_totient_family`: the shared-factor fact `(∀ i ∈ s, a i ∉ {1,2}) → 2 ∣ s.gcd (fun i ↦ φ (a i))` — the explicit common divisor of an entire totient family.",
+      "`gcd_totient_family_ne_one_of_forall`: the contrapositive stated directly — a family all of whose arguments avoid {1,2} is never setwise coprime."
+    ],
+    "prerequisites": [
+      "Euler's totient function φ(n) = |(ℤ/nℤ)ˣ|",
+      "Parity of φ: φ(n) even for n > 2 (the unit −1 of order 2 plus Lagrange), and φ(0) = 0",
+      "Setwise gcd over a Finset (Finset.gcd) and its universal/divisibility properties",
+      "Divisibility reasoning (dvd_gcd, gcd_dvd, dvd_one)"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "euler-totient-oq-07",
+        "relationship": "Parent: proves the pairwise criterion gcd(φ m, φ n) = 1 ↔ one of m, n ∈ {1,2} and the shared-factor bound 2 ≤ gcd for m, n ≥ 3. This entry lifts both to an arbitrary finite family and answers the parent's explicit open question on generalizing to families."
+      },
+      {
+        "id": "euler-totient-oq-06",
+        "relationship": "Sibling: establishes the parity classification φ(n) even ⟺ n ∉ {1,2}. This entry applies that exact dichotomy across a whole family: every argument outside {1,2} contributes an even totient, so the family shares the factor 2."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 135,
+    "path": "Proofs/EulerTotientOQ07OQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Euler introduced the totient φ(n) — the order of the unit group (ℤ/nℤ)ˣ — in his 1763 generalization of Fermat's little theorem. A sharp parity constraint governs its values: for k > 2 the element −1 ∈ (ℤ/kℤ)ˣ has order 2, so Lagrange forces 2 ∣ φ(k); together with φ(0) = 0 this means {1,2} are the only naturals where φ is odd (and there φ = 1). The pairwise consequence — two totients are coprime iff some argument is 1 or 2 — is Mathlib's `Nat.totient_coprime_totient_iff`. The parent gallery entry recorded this and the explicit shared factor 2; its open-questions list then asks for the finite-family form. This entry supplies it: a family of totients is setwise coprime iff a single argument hits the odd-totient set {1,2}.",
+    "problemStatement": "**Open Question (euler-totient-oq-07-oq-04):** extend the pairwise coprimality criterion for Euler totients to a finite family. For a family a : ι → ℕ indexed by a Finset s, when is the setwise gcd of the totients {φ(a i)} equal to 1?",
+    "text": "s.gcd (fun i ↦ φ(a i)) = 1 iff at least one argument a i lies in {1,2} (where φ = 1). Equivalently, the moment every argument avoids {1,2} the whole family shares the factor 2 and the setwise gcd is at least 2.",
+    "proofStrategy": "The parity engine `two_dvd_totient_of_ne_one_two` splits on a i: if a i = 0 then φ(a i) = 0 is even; otherwise a i ≥ 3 (being ≠ 1, ≠ 2, > 0) and `Nat.totient_even` applies — so a i ∉ {1,2} ⟹ 2 ∣ φ(a i). The forward direction of the biconditional is the contrapositive: if no argument is in {1,2}, `Finset.dvd_gcd` lifts the uniform 2 ∣ φ(a i) to 2 ∣ s.gcd, contradicting gcd = 1. The reverse direction uses `Finset.gcd_dvd`: an argument with φ(a i) = 1 makes the setwise gcd divide 1, so it equals 1 by `Nat.dvd_one`. The pairwise parent is recovered as the Fin 2 specialization; worked examples evaluate the setwise gcd over Fin 3 families by kernel `decide`.",
+    "keyInsights": [
+      "**Setwise coprimality of a totient family is an all-or-nothing parity phenomenon.** A single unit value φ = 1 (from an argument in {1,2}) collapses the entire setwise gcd to 1; absent any such argument, every totient is even and 2 is a guaranteed common divisor.",
+      "**The {1,2} escape hatch is exactly the odd-totient set.** φ is odd only at 1 and 2; 0 and every k ≥ 3 give even totients. The criterion is therefore literally 'some argument has odd totient', uniform across families of any size.",
+      "**The generalization is genuinely stronger, not cosmetic.** The pairwise `Nat.totient_coprime_totient_iff` is the Fin 2 case; the family form covers arbitrary index sets (including the empty family, where the setwise gcd is 0 ≠ 1) and is what callers reasoning about products or simultaneous coprimality of many orders actually need.",
+      "**The proof is two one-directional Finset.gcd facts.** `Finset.dvd_gcd` (a common divisor of all entries divides the gcd) handles the no-escape direction; `Finset.gcd_dvd` (the gcd divides each entry) handles the escape direction — no induction on the family is required."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",
+      "Parity of the totient (even for n > 2; φ(0) = 0) and divisibility by 2",
+      "Setwise gcd over a Finset and its divisibility characterization",
+      "Finite evaluation by kernel `decide`"
+    ]
+  },
+  "conclusion": {
+    "summary": "A finite family of Euler totients {φ(a i) : i ∈ s} is setwise coprime (s.gcd = 1) iff at least one argument a i lies in {1,2}; otherwise every totient is even and the setwise gcd is at least 2. 4 theorems, 135 lines, 0 sorries, 0 axioms. The criterion rests on the parity of φ (`Nat.totient_even`) and the two divisibility directions of `Finset.gcd`.",
+    "implications": "This is the form needed whenever many totients must be simultaneously coprime — e.g. CRT-style decompositions of unit groups or coprimality of several orders at once. The parity obstruction makes the answer immediate: simultaneous coprimality is possible only if all but at most the {1,2}-arguments are absent; any two arguments ≥ 3 already kill it via the shared factor 2.",
+    "openQuestions": [
+      "Pairwise vs setwise: characterize when the family {φ(a i)} is pairwise coprime (a strictly stronger condition than setwise gcd = 1), and relate it to the multiset of arguments avoiding {1,2}.",
+      "Quantify the setwise gcd's 2-adic valuation: for a family all of whose arguments are ≥ 3, is v₂(s.gcd) determined by the minimum of v₂(φ(a i)), and when does it exceed 1?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring framing the goal — lift the pairwise totient-coprimality criterion to a finite family — with imports (`Mathlib.Data.Nat.Totient`, `Mathlib.Algebra.GCDMonoid.Finset`, `Mathlib.Tactic`), the contents list, the `EulerTotientOQ07OQ04` namespace, `open Nat` (so `φ` is `Nat.totient`), and the `{ι : Type*}` index variable."
+    },
+    {
+      "id": "parity-engine",
+      "title": "The Parity Engine and the Shared Family Factor",
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "`two_dvd_totient_of_ne_one_two` (a ∉ {1,2} ⟹ 2 ∣ φ a, by casing a = 0 vs a ≥ 3 and `Nat.totient_even`) and `two_dvd_gcd_totient_family` (every argument outside {1,2} ⟹ 2 ∣ s.gcd of the totients, via `Finset.dvd_gcd`)."
+    },
+    {
+      "id": "headline-criterion",
+      "title": "The Finite-Family Coprimality Criterion",
+      "startLine": 79,
+      "endLine": 105,
+      "summary": "`gcd_totient_family_eq_one_iff` — the headline biconditional s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2 (forward: contrapositive via the shared factor 2; reverse: `Finset.gcd_dvd` plus `Nat.dvd_one`) — and `gcd_totient_family_ne_one_of_forall`, its contrapositive stated directly."
+    },
+    {
+      "id": "parent-recovery-examples",
+      "title": "Pairwise Recovery and Worked Examples",
+      "startLine": 106,
+      "endLine": 135,
+      "summary": "The Fin 2 specialization recovering the pairwise parent criterion, and worked Fin 3 families: one hitting {1,2} (φ 2 = 1 forces gcd = 1), one avoiding {1,2} (gcd ≠ 1), and the concrete value gcd(φ3, φ4, φ9) = gcd(2,2,6) = 2 by kernel `decide`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-07",
+      "relationship": "parent",
+      "description": "The parent proves the pairwise criterion gcd(φ m, φ n) = 1 ↔ one of m, n ∈ {1,2} and the shared-factor bound for m, n ≥ 3. This entry generalizes both to an arbitrary finite family — recovering the pairwise case as the Fin 2 specialization — and answers the parent's stated open question on families."
+    },
+    {
+      "targetId": "euler-totient-oq-06",
+      "relationship": "sibling",
+      "description": "oq-06 proves the parity classification φ(n) even ⟺ n ∉ {1,2}. This entry uses that dichotomy uniformly across a family: every argument outside {1,2} has an even totient, so the family shares the factor 2 and is never setwise coprime."
+    }
+  ]
+}

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01-oq-02",
+  "slug": "wilsons-theorem-oq-05-oq-01-oq-02",
+  "title": "Gauss's Prime-Power Form of Wilson's Theorem: $\\prod_{x \\in (\\mathbb{Z}/p^k\\mathbb{Z})^\\times} x = -1$",
+  "description": "Follows the second registered open question of `wilsons-theorem-oq-05-oq-01` (which studied the residue (n-1)! mod n) along the *units-product* branch, and proves Gauss's prime-power generalisation of Wilson's theorem: for every odd prime p and k ≥ 1, the product of all units of ℤ/p^kℤ is -1. Mathlib has Wilson only for a prime modulus (where ℤ/pℤ is a field and Units.inv_eq_self_iff pins the self-inverse units to ±1); for a prime power ℤ/p^kℤ is not a domain, so the field proof fails. The correct reason is structural: (ℤ/p^kℤ)ˣ is cyclic (Gauss's primitive-root theorem, ZMod.isCyclic_units_of_prime_pow) of even order, and in a finite cyclic group of even order x²=1 has exactly two solutions {1, -1}. The file factors out a clean reusable engine — in any finite cyclic group, if t·t=1 and t≠1 then the product of all group elements is t — and specialises it. The k=1 slice recovers the classical prime Wilson theorem, exhibiting the result as a genuine generalisation rather than a sibling. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Wilson/Lagrange (1771); Gauss, Disquisitiones Arithmeticae art. 78 (1801) — prime-power generalisation; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson%27s_theorem#Gauss's_generalization",
+    "date": "1801",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "gauss-generalization",
+      "cyclic-groups",
+      "units",
+      "prime-powers",
+      "primitive-root",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 176,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; #print axioms reports only the foundational propext, Classical.choice, Quot.sound on every result, with no sorryAx and no Lean.ofReduceBool (no decide/native_decide is used — the concrete ℤ/9ℤ example is derived from the general theorem, not computed). The cyclicity of (ℤ/p^kℤ)ˣ rests on Mathlib's ZMod.isCyclic_units_of_prime_pow (Gauss's primitive-root theorem for odd prime powers); the count of square roots of unity uses IsCyclic.card_pow_eq_one_le; the inverse-pairing argument uses Finset.prod_involution; the modulus inequality 2 < p^k uses ZMod.natCast_eq_zero_iff. The classical prime slice (wilson_units_prime) uses Mathlib's finite-field cyclic-units instance.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.isCyclic_units_of_prime_pow",
+        "description": "`IsCyclic (ZMod (p^n))ˣ` for an odd prime p — Gauss's primitive-root theorem for odd prime powers. This is the structural fact that replaces the field hypothesis of the prime case: it is what makes the squaring map have exactly two fixed points {1, -1}.",
+        "module": "Mathlib.RingTheory.ZMod.UnitsCyclic"
+      },
+      {
+        "theorem": "IsCyclic.card_pow_eq_one_le",
+        "description": "`#{a | a^n = 1} ≤ n` in a finite cyclic group. With n = 2 it bounds the square roots of unity by 2; together with the two distinct roots 1 and -1 this forces the solution set of x²=1 to be exactly {1, -1}.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "Finset.prod_involution",
+        "description": "Product over a finset is 1 when a fixed-point-free involution with f a · f (g a) = 1 pairs the elements. Applied with the inverse map x ↦ x⁻¹ on univ.erase t, after removing the lone order-two element t the only surviving fixed point is 1, so the whole product collapses.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "`(a : ZMod b) = 0 ↔ b ∣ a`. Used to show -1 ≠ 1 among the units: if -1 = 1 then 2 = 0 in ℤ/mℤ, i.e. m ∣ 2, contradicting 2 < m for m = p^k ≥ 3.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "prod_univ_units_id_eq_neg_one",
+        "description": "Mathlib's prime-modulus Wilson, `∏_{x ∈ Kˣ} x = -1` for a finite domain K. This is the field-only result that the present entry generalises to prime powers; the k=1 slice here reproduces it without invoking it.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      }
+    ],
+    "originalContributions": [
+      "`prod_univ_eq_orderTwo`: a clean reusable engine absent from Mathlib in this packaged form — in any finite cyclic group, if t·t = 1 and t ≠ 1 then ∏_{x∈G} x = t (t is then automatically the unique involution). The proof is the inverse-pairing involution on univ.erase t, with cyclicity supplying that x²=1 has only the two roots {1, t}.",
+      "`sq_eq_one_iff_eq_one_or_eq`: the supporting cyclic-group fact that a single nontrivial square root t of 1 already exhausts the square roots — x²=1 ⟹ x = 1 ∨ x = t — the structural replacement for the integral-domain lemma Units.inv_eq_self_iff.",
+      "`gauss_prime_pow_units`: Gauss's prime-power Wilson theorem, ∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1 for every odd prime p and k ≥ 1 — the generalisation of Wilson beyond the prime (field) case that Mathlib stops at.",
+      "`gauss_prime_pow_cast`: the same identity pushed into the ring ℤ/p^kℤ, ∏_{x ∈ (ℤ/p^kℤ)ˣ} (x : ℤ/p^kℤ) = -1 — the form equivalent to the classical congruence ∏_{1 ≤ a < p^k, gcd(a,p^k)=1} a ≡ -1 (mod p^k).",
+      "`wilson_units_prime`: the k = 1 slice, ∏_{x ∈ (ℤ/pℤ)ˣ} x = -1, recovering the classical prime Wilson theorem through the very same cyclic engine — demonstrating that the prime-power statement is a genuine generalisation, not a sibling result.",
+      "`prod_units_zmod_nine`: a concrete instance at p = 3, k = 2 — the six units {1,2,4,5,7,8} of ℤ/9ℤ multiply to -1 = 8 — obtained from the general theorem rather than by decide, so it carries no Lean.ofReduceBool dependency."
+    ],
+    "prerequisites": [
+      "Wilson's theorem and its prime-modulus units form (prod_univ_units_id_eq_neg_one, ZMod.wilsons_lemma)",
+      "The unit group (ℤ/nℤ)ˣ and its cyclicity for odd prime powers (Gauss's primitive-root theorem)",
+      "Finite cyclic groups, orders of elements, and counting solutions of x^n = 1",
+      "The inverse-pairing involution argument for products over finite abelian groups",
+      "ℕ↔ZMod casts and divisibility (ZMod.natCast_eq_zero_iff)"
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem-oq-05-oq-01",
+        "relationship": "Parent: oq-05-oq-01 established the complete trichotomy of (n-1)! mod n and registered two open directions — turning it into a primality certificate and studying neighbouring residues. The sibling entry oq-05-oq-01-oq-01 took the factorial-residue direction (the (n-2)! companion, ZMod-free primality tests, Kempner threshold). This entry takes the other direction: the product of the units of ℤ/nℤ, proving Gauss's prime-power generalisation of Wilson's theorem."
+      },
+      {
+        "id": "wilsons-theorem-oq-05-oq-01-oq-01",
+        "relationship": "Sibling: oq-05-oq-01-oq-01 pursues the (n-2)! mod n companion trichotomy and the Kempner–Smarandache threshold from the same parent. This entry instead generalises the Wilson congruence itself from prime to prime-power moduli via the cyclic structure of the unit group."
+      },
+      {
+        "id": "wilsons-theorem-oq-05",
+        "relationship": "Ancestor: oq-05 gives Wilson's theorem in classical ℕ-congruence form. wilson_units_prime here is the units-product form of that same prime result, recovered as the k = 1 slice of the prime-power theorem."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 176,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Wilson's theorem (Ibn al-Haytham c. 1000; Wilson/Lagrange 1771) states that (p-1)! ≡ -1 (mod p) for a prime p — equivalently that the product of the nonzero residues, i.e. the units of ℤ/pℤ, is -1. Gauss (Disquisitiones Arithmeticae, art. 78, 1801) determined the product of the units of ℤ/nℤ for every modulus: it is -1 when (ℤ/nℤ)ˣ is cyclic with a unique element of order two — namely n = 4, p^k, or 2p^k for an odd prime p — and +1 otherwise. The prime-power case n = p^k is the heart of this generalisation, and the reason it holds is Gauss's own primitive-root theorem: the units mod an odd prime power form a cyclic group. The parent gallery entry classified the bare factorial residue (n-1)! mod n; this entry turns instead to the units product that Wilson's theorem is really about, and proves the prime-power generalisation that the field-based proof in Mathlib cannot reach.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-05-oq-01, units-product branch):** beyond the residue of (n-1)! mod n, determine the product of the units of ℤ/nℤ. This entry proves the prime-power case of Gauss's answer: for every odd prime p and every k ≥ 1, ∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1, equivalently ∏_{1 ≤ a < p^k, gcd(a, p^k) = 1} a ≡ -1 (mod p^k).",
+    "text": "For an odd prime p and k ≥ 1, the units of ℤ/p^kℤ multiply to -1. The proof goes through a general fact about finite cyclic groups: the product of all elements equals the unique element of order two. The k = 1 case is exactly the classical Wilson theorem.",
+    "proofStrategy": "The engine prod_univ_eq_orderTwo proves that in a finite cyclic group G, if t·t = 1 and t ≠ 1 then ∏_{x∈G} x = t. Its proof pairs each unit with its inverse via Finset.prod_involution on univ.erase t: the fixed points of x ↦ x⁻¹ are the solutions of x² = 1, and cyclicity (IsCyclic.card_pow_eq_one_le with n = 2) bounds these by 2, so with the two distinct roots 1 and t they are exactly {1, t}; after erasing t the only surviving fixed point is 1, the pairing annihilates the rest, and re-inserting t leaves the product equal to t. To specialise to (ℤ/p^kℤ)ˣ one supplies cyclicity from ZMod.isCyclic_units_of_prime_pow and takes t = -1, which is order two and distinct from 1 because 2 < p^k (so 2 ≠ 0 in ℤ/p^kℤ, via ZMod.natCast_eq_zero_iff). The cast form follows by pushing the unit product through Units.coeHom, and the prime (k = 1) slice runs the same engine on the finite-field cyclic-units instance.",
+    "keyInsights": [
+      "**Wilson is really a statement about the unit group.** (p-1)! ≡ -1 (mod p) is exactly ∏_{x ∈ (ℤ/pℤ)ˣ} x = -1. Once phrased this way the prime hypothesis is revealed to be doing two jobs: it makes the ring a field (so x²=1 has ≤ 2 roots) and it makes the unit group cyclic. Only the second job is essential.",
+      "**Cyclicity, not the field, is what forces the answer.** For a prime power ℤ/p^kℤ is not a domain, yet (ℤ/p^kℤ)ˣ is still cyclic (Gauss's primitive-root theorem), and in a finite cyclic group of even order x²=1 has exactly two solutions. That is all the inverse-pairing argument needs, so Wilson generalises verbatim to prime powers.",
+      "**The product of all elements of a finite cyclic group is its unique involution.** This packaged engine (prod_univ_eq_orderTwo) is the reusable heart of the file: it is the abstract content of Wilson's theorem, stripped of every reference to ℤ/nℤ, and it specialises immediately to both the prime and prime-power cases.",
+      "**The k = 1 slice recovers classical Wilson.** Running the same cyclic engine on the field ℤ/pℤ reproduces ∏_{x ∈ (ℤ/pℤ)ˣ} x = -1, so the prime-power theorem genuinely contains Wilson's theorem rather than sitting beside it."
+    ],
+    "prerequisites": [
+      "Wilson's theorem in units-product form, ∏_{x ∈ (ℤ/pℤ)ˣ} x = -1",
+      "The unit group (ℤ/nℤ)ˣ and Gauss's primitive-root theorem (cyclicity for odd prime powers)",
+      "Finite cyclic groups and counting solutions of x^n = 1",
+      "The inverse-pairing involution for products over finite abelian groups",
+      "ℕ↔ZMod casts and divisibility"
+    ]
+  },
+  "conclusion": {
+    "summary": "For every odd prime p and k ≥ 1, the units of ℤ/p^kℤ multiply to -1 — Gauss's prime-power generalisation of Wilson's theorem — proved through a reusable cyclic-group engine (the product of all elements of a finite cyclic group is its unique order-two element) that also recovers the classical prime case as its k = 1 slice. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+    "implications": "The result isolates the true mechanism of Wilson's theorem: it is a fact about cyclic groups, and the prime hypothesis enters only through the cyclicity of the unit group. The engine prod_univ_eq_orderTwo applies to any finite cyclic group with an element of order two, so it equally yields the 2p^k case (whose unit group is also cyclic of even order) and dovetails with the gallery's existing power-map dichotomy (the n-th power map on a finite group). The cast form ∏ ≡ -1 (mod p^k) is the prime-power Wilson congruence used in elementary number theory.",
+    "openQuestions": [
+      "Complete Gauss's classification: prove the +1 half — for n with at least two distinct odd prime factors (or 4 times an odd prime, etc.) the unit group has more than one element of order two and the product of all units is +1 — giving the full ∏_{x ∈ (ℤ/nℤ)ˣ} x = -1 ⟺ n ∈ {1, 2, 4, p^k, 2p^k} biconditional.",
+      "Extend the engine to the structure theorem for finite abelian groups: ∏_{x∈G} x equals the product of the elements of order two, which is the identity unless the 2-torsion is exactly ℤ/2ℤ.",
+      "Connect to the Wilson quotient W(p) = ((p-1)! + 1)/p and its prime-power analogues: what congruences does the cofactor (∏ units + 1)/p^k satisfy?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring framing Gauss's prime-power generalisation of Wilson's theorem: why the field proof (Units.inv_eq_self_iff) stops at primes, why cyclicity of (ℤ/p^kℤ)ˣ is the correct structural reason, and the list of results (engine, prime-power identity, cast form, prime slice, ℤ/9ℤ example). Imports Mathlib, opens Finset."
+    },
+    {
+      "id": "engine",
+      "title": "The Group-Theoretic Engine",
+      "startLine": 62,
+      "endLine": 122,
+      "summary": "sq_eq_one_iff_eq_one_or_eq: in a finite cyclic group a single nontrivial square root t of 1 exhausts the solutions of x²=1 (via IsCyclic.card_pow_eq_one_le bounding the root count by 2). prod_univ_eq_orderTwo: the product of all elements of a finite cyclic group is its unique order-two element t, proved by the inverse-pairing involution Finset.prod_involution on univ.erase t."
+    },
+    {
+      "id": "gauss-prime-power",
+      "title": "Gauss's Prime-Power Wilson Theorem",
+      "startLine": 123,
+      "endLine": 157,
+      "summary": "neg_one_ne_one_units: -1 ≠ 1 among the units of ℤ/mℤ when 2 < m (else m ∣ 2). gauss_prime_pow_units: ∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1 for odd prime p, k ≥ 1, by feeding cyclicity (ZMod.isCyclic_units_of_prime_pow) and t = -1 into the engine. gauss_prime_pow_cast: the same identity in the ring ℤ/p^kℤ via Units.coeHom."
+    },
+    {
+      "id": "prime-slice-example",
+      "title": "Classical Wilson Recovered, and a Concrete Check",
+      "startLine": 158,
+      "endLine": 176,
+      "summary": "wilson_units_prime: the k = 1 slice ∏_{x ∈ (ℤ/pℤ)ˣ} x = -1, the classical prime Wilson theorem run through the same cyclic engine. prod_units_zmod_nine: the p = 3, k = 2 instance — the six units of ℤ/9ℤ multiply to -1 = 8 — derived from the general theorem, not by decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01",
+      "relationship": "parent",
+      "description": "The parent classifies (n-1)! mod n and registers, beyond the primality-certificate direction, the study of the product of the units of ℤ/nℤ. This entry answers the prime-power case of that units-product question with Gauss's generalisation of Wilson's theorem."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "The sibling entry pursues the (n-2)! companion trichotomy and the Kempner threshold from the same parent; this entry instead generalises the Wilson congruence from prime to prime-power moduli through the cyclic unit group."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-05",
+      "relationship": "ancestor",
+      "description": "Wilson's theorem in classical congruence form; its units-product version is the k = 1 slice (wilson_units_prime) of the prime-power theorem proved here."
+    }
+  ]
+}


### PR DESCRIPTION
## Gauss's prime-power generalisation of Wilson's theorem

For every **odd prime `p`** and every **`k ≥ 1`**, the product of all units of `ℤ/p^kℤ` is `-1`:

```
∏_{x ∈ (ℤ/p^kℤ)ˣ} x = -1        (equivalently  ∏_{1 ≤ a < p^k, gcd(a,p^k)=1} a ≡ -1  (mod p^k))
```

Mathlib proves Wilson only for a **prime** modulus, where `ℤ/pℤ` is a field and `Units.inv_eq_self_iff` pins the self-inverse units to `±1`. For a prime *power* `ℤ/p^kℤ` is **not** a domain, so the field proof fails. The correct reason is structural: `(ℤ/p^kℤ)ˣ` is **cyclic** (Gauss's primitive-root theorem, `ZMod.isCyclic_units_of_prime_pow`) of even order, and in a finite cyclic group of even order `x² = 1` has exactly two solutions `{1, -1}`.

### Reusable engine (absent from Mathlib in this packaged form)
- **`prod_univ_eq_orderTwo`** — in a finite cyclic group, if `t·t = 1` and `t ≠ 1` then `∏_{x∈G} x = t` (the unique involution). Proof: the inverse-pairing involution `x ↦ x⁻¹` on `univ.erase t` via `Finset.prod_involution`, with cyclicity (`IsCyclic.card_pow_eq_one_le`) forcing the only square roots of 1 to be `{1, t}`.
- **`sq_eq_one_iff_eq_one_or_eq`** — a single nontrivial square root of 1 exhausts the solutions of `x²=1` (the cyclic replacement for `Units.inv_eq_self_iff`).

### Number-theoretic payload
- **`gauss_prime_pow_units`** / **`gauss_prime_pow_cast`** — the identity in the unit group and in the ring.
- **`wilson_units_prime`** — the `k = 1` slice recovers **classical prime Wilson** through the *same* cyclic engine, exhibiting this as a genuine generalisation rather than a sibling result.
- **`prod_units_zmod_nine`** — concrete `p = 3, k = 2` check (the six units of `ℤ/9ℤ` multiply to `-1 = 8`), derived from the general theorem (no `decide`).

### Verification
- 176 lines, **7 theorems, 0 definitions, 0 sorries**.
- `#print axioms` on every result: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (no `decide`/`native_decide`).
- Built on Lean 4.26.0 / Mathlib.

Extends the verified family `wilsons-theorem-oq-05 → …-oq-01` along the units-product branch (sibling `…-oq-01-oq-01` took the `(n-2)!` companion / Kempner direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)