### PR TITLE
Enrich Two-Sided Falling-Factorial Moment of Squared Binomials: add annotations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-01-oq-03/annotations.json
@@ -1,0 +1,157 @@
+[
+  {
+    "id": "ann-cf2s-header",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "context",
+    "title": "Weighting the Palindromic Squared Row from Both Ends",
+    "content": "The docstring frames the two-sided generalization. The parent (OQ-07-OQ-04-OQ-01) weighted the squared Pascal row by a single falling factorial $(k)_r$ anchored at the left end $k=0$, giving $\\sum (k)_r C(n,k)^2 = (n)_r C(2n-r, n-r)$. But the squared row is a palindrome ($C(n,k)^2 = C(n,n-k)^2$), so the right end $k=n$ is on equal footing. The honest general object is the two-sided moment, weighted by $(k)_r(n-k)_s$ from both ends at once. The headline reveals that the two orders combine additively in the off-centre shift: a left order $r$ and right order $s$ push the Vandermonde entry from the centre $C(2n,n)$ out to $C(2n-r-s, n-r-s)$, seeing only the sum $r+s$.",
+    "mathContext": "$\\sum_{k=0}^{n} (k)_r\\,(n-k)_s\\,C(n,k)^2 = (n)_r\\,(n)_s\\,C(2n-r-s,\\ n-r-s)$ for $r+s\\le n$, where $(x)_r = $ Nat.descFactorial $x\\,r$. Faces: $s{=}0$ → parent; $r{=}0$ → mirror; $r{=}s{=}1$ → symmetric first moment.",
+    "significance": "context",
+    "relatedConcepts": [
+      "binomial coefficients",
+      "falling factorial",
+      "factorial moments",
+      "hypergeometric distribution"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Vandermonde's convolution"
+    ]
+  },
+  {
+    "id": "ann-cf2s-coabsorption",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "Right-End Co-Absorption: Reflect, Absorb, Reflect Back",
+    "content": "descFactorial_sub_mul_choose obtains the right-anchored absorption $(n-k)_s\\,C(n,k) = (n)_s\\,C(n-s,k)$ for free, with no new induction. The trick: reflect the row via $C(n,k) = C(n,n-k)$ (Nat.choose_symm), apply the parent's established left absorption descFactorial_mul_choose at the reflected index $n-k$, then reflect the resulting binomial back with a second choose_symm and an omega index computation. This 'reflect, absorb, reflect back' scheme is a reusable way to derive right-anchored identities from left-anchored ones — the parent's lemma does all the actual work.",
+    "mathContext": "$(n-k)_s\\,C(n,k) = (n)_s\\,C(n-s,k)$ for $k\\le n$, $s\\le n-k$. Derivation: $C(n,k) = C(n,n-k)$, then $(n-k)_s\\,C(n,n-k) = (n)_s\\,C(n-s,(n-k)-s)$, then $C(n-s,(n-k)-s) = C(n-s,k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity",
+      "Nat.choose_symm",
+      "reflection symmetry"
+    ],
+    "prerequisites": [
+      "descFactorial_mul_choose",
+      "Nat.choose_symm"
+    ]
+  },
+  {
+    "id": "ann-cf2s-vandermonde",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "The Two-Parameter Vandermonde Diagonal",
+    "content": "vandermonde_diag_two reads the gallery's Vandermonde convolution range form (add_choose_eq_sum_range, from OQ-07) along a diagonal shifted $t$ off-centre against a second row $b$ of independent length: $\\sum_j C(a,j)\\,C(b,j+t) = C(a+b, b-t)$. The reflection $C(b,j+t) = C(b,(b-t)-j)$ (Nat.choose_symm) aligns the shifted summand with the convolution. The parent's one-row vandermonde_diag is the case $b=n$, $t=r$; here the second row $b$ is itself shortened to $n-s$, which is precisely what lets an independent right falling weight $s$ enter the final answer.",
+    "mathContext": "$\\sum_{j=0}^{b-t} C(a,j)\\,C(b,j+t) = C(a+b,\\ b-t)$ for $t\\le b$. Used with $a=n-r$, $b=n-s$, $t=r$ to give $C(2n-r-s,\\ n-r-s)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vandermonde's identity",
+      "diagonal convolution",
+      "Nat.choose_symm"
+    ],
+    "prerequisites": [
+      "Vandermonde convolution",
+      "reindexing sums"
+    ]
+  },
+  {
+    "id": "ann-cf2s-main",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 104,
+      "endLine": 164
+    },
+    "type": "insight",
+    "title": "The Two-Sided Falling-Factorial Moment (✦)",
+    "content": "sum_twoSided_descFactorial_weighted_sq is the headline theorem. The two falling factorials prune the index range automatically: $(k)_r = 0$ kills $k<r$ on the left and $(n-k)_s = 0$ kills $k>n-s$ on the right (Nat.descFactorial_eq_zero_iff_lt), so the sum truncates to the band $[r, n-s]$ with no artificial peeling — the two vanishing blocks are split off by Finset.sum_Ico_consecutive. After reindexing $k \\mapsto r+j$, each survivor is rewritten by applying BOTH absorptions to $C(n,k)^2 = C(n,k)\\cdot C(n,k)$ — the left one removes $(k)_r$, the mirror one removes $(n-k)_s$ — leaving $(n)_r(n)_s\\,C(n-r,j)\\,C(n-s,j+r)$. Pulling out the constant $(n)_r(n)_s$, the inner sum is exactly the doubly-shifted Vandermonde diagonal, closing to $C(2n-r-s, n-r-s)$. No generating functions, no order-dependent recombination.",
+    "mathContext": "$\\sum_{k=0}^{n}(k)_r(n-k)_s C(n,k)^2 = (n)_r(n)_s C(2n-r-s,n-r-s)$. Band $[r,n-s]$; each term $\\to (n)_r(n)_s C(n-r,j)C(n-s,j+r)$; inner sum $= C(2n-r-s,n-r-s)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "factorial moments",
+      "absorption from both ends",
+      "Vandermonde diagonal",
+      "sum truncation"
+    ],
+    "prerequisites": [
+      "Finset.sum_Ico_consecutive",
+      "both absorption lemmas",
+      "vandermonde_diag_two"
+    ]
+  },
+  {
+    "id": "ann-cf2s-onesided",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 166,
+      "endLine": 174
+    },
+    "type": "concept",
+    "title": "Recovering the One-Sided Parent (s = 0)",
+    "content": "sum_oneSided_of_twoSided sets $s=0$ in the two-sided formula. Since $(n-k)_0 = 1$ (Nat.descFactorial_zero) and $n-0 = n$, the right weight disappears and the identity collapses to the parent's one-sided moment $\\sum (k)_r C(n,k)^2 = (n)_r C(2n-r, n-r)$. This is a consistency check: the bivariate form specialises correctly to the established result, confirming the two-sided generalization genuinely contains the one-sided ladder as its $s=0$ face.",
+    "mathContext": "At $s=0$: $(n-k)_0 = 1$, so $\\sum (k)_r C(n,k)^2 = (n)_r\\,(n)_0\\,C(2n-r-0, n-r-0) = (n)_r C(2n-r, n-r)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization",
+      "consistency check",
+      "one-sided moment"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial_zero"
+    ]
+  },
+  {
+    "id": "ann-cf2s-first",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 176,
+      "endLine": 183
+    },
+    "type": "concept",
+    "title": "The Symmetric First Moment (r = s = 1)",
+    "content": "sum_twoSided_first is the cleanest genuinely two-sided instance, $r=s=1$: $\\sum_{k} k(n-k)\\,C(n,k)^2 = n^2\\,C(2n-2, n-2)$ for $n\\ge 2$. Since $(x)_1 = x$ (Nat.descFactorial_one), the symmetric weight $k(n-k)$ appears, and the off-centre shift $r+s = 2$ lands on $C(2n-2, n-2)$ — the same binomial reached by the grandparent's second moment $\\sum k(k-1)C(n,k)^2 = n(n-1)C(2n-2,n-2)$, but via a different (two-sided, symmetric) weighting with constant $n^2$ instead of $n(n-1)$.",
+    "mathContext": "$\\sum_{k=0}^{n} k(n-k)\\,C(n,k)^2 = n^2\\,C(2n-2,\\ n-2)$, $n\\ge 2$. Shift $r+s=2$; same target $C(2n-2,n-2)$ as the grandparent's second moment, different constant.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "first moment",
+      "symmetric weight",
+      "off-centre shift"
+    ],
+    "prerequisites": [
+      "Nat.descFactorial_one"
+    ]
+  },
+  {
+    "id": "ann-cf2s-checks",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-01-oq-03",
+    "range": {
+      "startLine": 185,
+      "endLine": 197
+    },
+    "type": "context",
+    "title": "Kernel-decide Sanity Checks",
+    "content": "Two numeric examples certify the closed form at concrete orders. At $(r,s,n) = (1,1,3)$: $\\sum_k k(3-k)C(3,k)^2 = 0 + 18 + 18 + 0 = 36 = 3^2\\cdot C(4,1)$. At $(r,s,n) = (2,1,4)$: $\\sum_k (k)_2(4-k)C(4,k)^2 = (4)_2\\cdot 4\\cdot C(5,1) = 12\\cdot 4\\cdot 5 = 240$. Both are discharged by kernel `decide` (not native_decide), so they introduce no extra trust assumptions — the proof stays clean of Lean.ofReduceBool.",
+    "mathContext": "$(1,1,3)$: $18+18 = 36 = 9\\cdot 4$. $(2,1,4)$: $12\\cdot 4\\cdot 5 = 240$. Both verified by kernel reduction via `decide`.",
+    "significance": "context",
+    "relatedConcepts": [
+      "numerical verification",
+      "kernel decide",
+      "worked example"
+    ],
+    "prerequisites": [
+      "decidability",
+      "arithmetic"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-07-oq-04-oq-01-oq-03` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 7 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Header — weighting the palindromic squared row from both ends
2. **Right-end co-absorption** (key) — reflect, absorb, reflect back
3. **Two-parameter Vandermonde diagonal** (key)
4. **The two-sided moment (✦)** (key)
5. One-sided recovery (s=0)
6. Symmetric first moment (r=s=1)
7. Kernel-decide sanity checks

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: examples use kernel `decide` (not native_decide → no Lean.ofReduceBool). Note: the meta's own `assumptions` field transparently discloses this file was **not kernel-rebuilt** in its authoring session (Docker host unavailable) and is `verified` pending the deployer build-gate — I did not alter that status; annotations are math-only and do not depend on the build state.

Per-target branch to avoid clobbering open enricher PRs.