### PR TITLE
Enrich De Moivre OQ-04 (n-th Roots of Unity): add annotations

### DIFF
--- a/src/data/proofs/de-moivre-oq-04/annotations.json
+++ b/src/data/proofs/de-moivre-oq-04/annotations.json
@@ -1,0 +1,157 @@
+[
+  {
+    "id": "ann-dm04-docstring",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "From De Moivre's Formula to the Regular n-gon",
+    "content": "The docstring sets the goal: use De Moivre's formula to exhibit the $n$-th roots of unity as the powers of $\\omega = \\cos(2\\pi/n) + i\\sin(2\\pi/n)$. Specializing $(\\cos\\theta + i\\sin\\theta)^n = \\cos(n\\theta) + i\\sin(n\\theta)$ to $\\theta = 2\\pi/n$ collapses the right side to $\\cos(2\\pi) + i\\sin(2\\pi) = 1$, so $\\omega^n = 1$. Identifying $\\omega$ with $e^{2\\pi i/n}$ (Euler) shows it is primitive: its powers $\\omega^0,\\ldots,\\omega^{n-1}$ are distinct and enumerate all solutions of $z^n = 1$. This is the trigonometric-form companion to the De Moivre family (oq-01 Chebyshev extraction, oq-03 fractional exponents), and the geometric gateway to cyclotomy.",
+    "mathContext": "$\\omega = \\cos(2\\pi/n) + i\\sin(2\\pi/n)$; the $n$ powers are the vertices of a regular $n$-gon inscribed in the unit circle, the solution set of $z^n = 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "De Moivre's theorem",
+      "roots of unity",
+      "cyclotomy",
+      "regular n-gon"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "Euler's formula"
+    ]
+  },
+  {
+    "id": "ann-dm04-def",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 47,
+      "endLine": 51
+    },
+    "type": "definition",
+    "title": "The Generator ω",
+    "content": "omega defines the candidate primitive root in trigonometric form, $\\omega(n) = \\cos(2\\pi/n) + \\sin(2\\pi/n)\\cdot i$, marked noncomputable because it uses the real transcendental functions. Geometrically it is the first vertex after 1 of the regular $n$-gon on the unit circle — the point at angle $2\\pi/n$. Casting the real argument $2\\pi/n$ into $\\mathbb{C}$ is what lets Complex.cos/Complex.sin apply.",
+    "mathContext": "$\\omega(n) = \\cos\\!\\left(\\tfrac{2\\pi}{n}\\right) + i\\sin\\!\\left(\\tfrac{2\\pi}{n}\\right)$, the angle-$2\\pi/n$ point on the unit circle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "trigonometric form",
+      "unit circle",
+      "noncomputable definition"
+    ],
+    "prerequisites": [
+      "Complex.cos / Complex.sin"
+    ]
+  },
+  {
+    "id": "ann-dm04-collapse",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 52,
+      "endLine": 78
+    },
+    "type": "insight",
+    "title": "The De Moivre Collapse and the Euler Bridge",
+    "content": "omega_pow_n is the headline: $\\omega^n = 1$ for $n > 0$. The proof applies Mathlib's De Moivre lemma cos_add_sin_mul_I_pow to get $\\cos(n\\cdot 2\\pi/n) + i\\sin(n\\cdot 2\\pi/n)$, then the single arithmetic collapse $n\\cdot(2\\pi/n) = 2\\pi$ (needing $n\\ne 0$, via field_simp) reduces the argument to $2\\pi$, where $\\cos(2\\pi) = 1$, $\\sin(2\\pi) = 0$ (Real.cos_two_pi/sin_two_pi). No induction or power series — just the multiple-angle formula and one cancellation. omega_eq_exp then bridges to the exponential form $\\omega = e^{2\\pi i/n}$ via exp_mul_I, identifying the trigonometric generator with the number Mathlib's primitive-root API is written for.",
+    "mathContext": "$\\omega^n = \\cos(n\\cdot\\tfrac{2\\pi}{n}) + i\\sin(n\\cdot\\tfrac{2\\pi}{n}) = \\cos 2\\pi + i\\sin 2\\pi = 1$. Euler: $\\omega = e^{2\\pi i/n}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "De Moivre's formula",
+      "Euler's formula",
+      "cos_add_sin_mul_I_pow",
+      "exp_mul_I"
+    ],
+    "prerequisites": [
+      "De Moivre's formula",
+      "cos(2π) = 1"
+    ]
+  },
+  {
+    "id": "ann-dm04-primitivity",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 79,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "ω Is a Primitive n-th Root",
+    "content": "omega_isPrimitiveRoot transports Mathlib's Complex.isPrimitiveRoot_exp along the Euler bridge to prove $\\omega$ is primitive of order exactly $n$. Primitivity is what upgrades 'a root' to 'the generator': it guarantees the powers do not repeat before the $n$-th, so $\\langle\\omega\\rangle$ is the full cyclic group $\\mu_n$ rather than a proper subgroup. Because $\\omega = e^{2\\pi i/n}$ (the Euler bridge), the rich primitive-root API written for exp applies verbatim — no separate argument is needed for the trigonometric form.",
+    "mathContext": "$\\omega = e^{2\\pi i/n}$ has order exactly $n$: $\\mathrm{IsPrimitiveRoot}(\\omega, n)$, the generator of $\\mu_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive root of unity",
+      "cyclic group μₙ",
+      "isPrimitiveRoot_exp"
+    ],
+    "prerequisites": [
+      "primitive roots",
+      "cyclic groups"
+    ]
+  },
+  {
+    "id": "ann-dm04-roots-distinct",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 87,
+      "endLine": 104
+    },
+    "type": "technique",
+    "title": "Powers Are Roots, and Are Distinct",
+    "content": "Two facts about the powers. omega_pow_pow_n shows every power is again a root: $(\\omega^k)^n = (\\omega^n)^k = 1^k = 1$, so the powers never leave $\\mu_n$. omega_pow_inj and omega_pow_injOn give distinctness via IsPrimitiveRoot.pow_inj/injOn_pow: for $0\\le i,j<n$, $\\omega^i = \\omega^j$ forces $n\\mid(i-j)$ hence $i=j$ — a pigeonhole fact about the order of $\\omega$. Together they establish that $\\omega^0,\\ldots,\\omega^{n-1}$ are $n$ distinct elements of $\\mu_n$.",
+    "mathContext": "$(\\omega^k)^n = (\\omega^n)^k = 1$. Distinctness: $\\omega^i = \\omega^j,\\ 0\\le i,j<n \\Rightarrow n\\mid(i-j) \\Rightarrow i=j$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole",
+      "order of an element",
+      "IsPrimitiveRoot.pow_inj"
+    ],
+    "prerequisites": [
+      "primitive root API",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-dm04-enumeration",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 105,
+      "endLine": 118
+    },
+    "type": "insight",
+    "title": "The Powers Enumerate All n-th Roots",
+    "content": "nthRoots_eq_omega_powers proves the powers are *exactly* the roots: as a multiset, $\\text{nthRoots}\\,n\\,1 = (\\text{range}\\,n).\\text{map}(\\omega^{\\cdot})$, via IsPrimitiveRoot.nthRoots_eq. card_nthRootsFinset then confirms there are exactly $n$ distinct $n$-th roots of unity. Combining distinctness ($n$ distinct powers) with the fact that $z^n - 1$ has at most $n$ roots, the powers fill the entire solution set — the constructive counterpart of the Fundamental Theorem of Algebra for $z^n - 1$.",
+    "mathContext": "$\\{z : z^n = 1\\} = \\{\\omega^0, \\omega^1, \\ldots, \\omega^{n-1}\\}$, and $\\#\\,\\mu_n = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "root enumeration",
+      "Fundamental Theorem of Algebra",
+      "nthRootsFinset"
+    ],
+    "prerequisites": [
+      "IsPrimitiveRoot.nthRoots_eq",
+      "polynomial roots"
+    ]
+  },
+  {
+    "id": "ann-dm04-examples-summary",
+    "proofId": "de-moivre-oq-04",
+    "range": {
+      "startLine": 119,
+      "endLine": 158
+    },
+    "type": "context",
+    "title": "Small Cases and the Summary Bundle",
+    "content": "The verified examples compute the generator at small $n$: $\\omega(1) = 1$, $\\omega(2) = \\cos\\pi + i\\sin\\pi = -1$, and $\\omega(4) = \\cos(\\pi/2) + i\\sin(\\pi/2) = i$ — the generators of $\\mu_1$, $\\mu_2$, $\\mu_4$, each discharged by rewriting with the special-angle values and norm_num. demoivre_oq04_summary then bundles the four main results into one theorem: $\\omega^n = 1$, $\\omega$ primitive, every $\\omega^k$ a root, and exactly $n$ distinct $n$-th roots. Note the entry's badge is 'mathlib': $\\omega^n = 1$ is proved directly, but primitivity, distinctness, and enumeration are transported from Mathlib's primitive-root API.",
+    "mathContext": "$\\omega(1) = 1$, $\\omega(2) = -1$, $\\omega(4) = i$. Summary: $\\omega^n = 1\\,\\wedge\\,\\mathrm{IsPrimitiveRoot}\\,\\omega\\,n\\,\\wedge\\,(\\forall k,(\\omega^k)^n=1)\\,\\wedge\\,\\#\\mu_n = n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "special angles",
+      "summary theorem"
+    ],
+    "prerequisites": [
+      "special-angle trig values",
+      "norm_num"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-04` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 7 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Docstring — De Moivre's formula to the regular n-gon
2. The ω generator definition
3. **The De Moivre collapse + Euler bridge** (key)
4. **ω is a primitive n-th root** (key)
5. Powers are roots, and are distinct
6. **The powers enumerate all n-th roots** (key)
7. Small cases + summary bundle

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: mathlib` / `axiomCount: 0` / 0 sorries — badge accurately reflects that ωⁿ=1 is proved directly while primitivity/distinctness/enumeration are transported from Mathlib's primitive-root API.

Per-target branch to avoid clobbering open enricher PRs.