### PR TITLE
Enrich De Moivre OQ-04-OQ-01 (primitive powers & φ(n)): add annotations

### DIFF
--- a/src/data/proofs/de-moivre-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-04-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-dm0401-docstring",
+    "proofId": "de-moivre-oq-04-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Which Vertices of the n-gon Generate It",
+    "content": "The docstring frames the follow-up to the parent: the parent isolated $\\omega = \\cos(2\\pi/n) + i\\sin(2\\pi/n)$ as a primitive root whose powers enumerate all $n$-th roots of unity; this file asks which powers $\\omega^k$ are *themselves* primitive. The answer — $\\gcd(k,n) = 1$ — is the gateway to cyclotomy, raised by Gauss in the Disquisitiones (1801). Since the order of $\\omega^k$ is $n/\\gcd(k,n)$, it has order $n$ (is primitive) exactly when $\\gcd(k,n) = 1$, and counting those exponents is the definition of Euler's totient, so there are $\\varphi(n)$ primitive $n$-th roots — recovered concretely through the explicit generator.",
+    "mathContext": "$\\omega^k$ primitive $\\iff \\gcd(k,n) = 1$; there are $\\varphi(n)$ such $k\\in[0,n)$, so $\\#\\,(\\text{primitive }n\\text{-th roots}) = \\varphi(n)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "primitive roots of unity",
+      "Euler's totient",
+      "cyclotomy",
+      "cyclotomic polynomial"
+    ],
+    "prerequisites": [
+      "roots of unity",
+      "order of group elements",
+      "coprimality"
+    ]
+  },
+  {
+    "id": "ann-dm0401-criterion",
+    "proofId": "de-moivre-oq-04-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 59
+    },
+    "type": "insight",
+    "title": "The Primitivity Criterion: gcd(k,n) = 1",
+    "content": "omega_pow_isPrimitiveRoot_iff is the headline: $\\omega^k$ is a primitive $n$-th root of unity iff $\\gcd(k,n) = 1$. The entire criterion is one Mathlib lemma — IsPrimitiveRoot.pow_iff_coprime — applied to the parent's primitive root omega_isPrimitiveRoot. The underlying reason is that $\\omega^k$ has multiplicative order $n/\\gcd(k,n)$, which equals $n$ exactly when $\\gcd(k,n) = 1$. The example confirms $\\omega^1 = \\omega$ is primitive, since $\\gcd(1,n) = 1$.",
+    "mathContext": "$\\mathrm{IsPrimitiveRoot}(\\omega^k, n) \\iff \\gcd(k,n) = 1$, because $\\operatorname{ord}(\\omega^k) = n/\\gcd(k,n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsPrimitiveRoot.pow_iff_coprime",
+      "order of a power",
+      "coprimality"
+    ],
+    "prerequisites": [
+      "primitive root API",
+      "element order"
+    ]
+  },
+  {
+    "id": "ann-dm0401-structure",
+    "proofId": "de-moivre-oq-04-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 81
+    },
+    "type": "insight",
+    "title": "The Primitive Roots Are Exactly the Coprime Powers",
+    "content": "primitiveRoots_eq_omega_image gives the explicit description: the set of primitive $n$-th roots equals the image of the coprime exponents $\\{k\\in[0,n) : \\gcd(k,n)=1\\}$ under $k\\mapsto\\omega^k$. The $\\supseteq$ direction is just the criterion. The $\\subseteq$ direction is where the parent's enumeration pays off: a primitive root $\\zeta$ satisfies $\\zeta^n = 1$, so IsPrimitiveRoot.eq_pow_of_pow_eq_one gives $\\zeta = \\omega^i$ for some $i<n$ — every primitive root is *some* power — and primitivity of $\\omega^i$ then forces $\\gcd(i,n) = 1$. Only after knowing $\\zeta$ is a power does the coprimality test apply.",
+    "mathContext": "$\\{\\zeta : \\zeta \\text{ primitive}\\} = \\{\\omega^k : 0\\le k<n,\\ \\gcd(k,n)=1\\}$. $\\subseteq$ via eq_pow_of_pow_eq_one; $\\supseteq$ via the criterion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "structure theorem",
+      "eq_pow_of_pow_eq_one",
+      "set image"
+    ],
+    "prerequisites": [
+      "the criterion",
+      "root enumeration (parent)"
+    ]
+  },
+  {
+    "id": "ann-dm0401-totient",
+    "proofId": "de-moivre-oq-04-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 105
+    },
+    "type": "insight",
+    "title": "The Count Is Euler's Totient φ(n)",
+    "content": "Two theorems recover the count. card_coprime_powers_eq_totient shows the number of exponents $0\\le k<n$ with $\\gcd(k,n) = 1$ is $\\varphi(n)$, via Nat.totient_eq_card_coprime up to the symmetry of coprimality (coprime_comm). card_primitiveRoots_via_omega then transfers this to $\\#\\,(\\text{primitiveRoots } n\\,\\mathbb{C}) = \\varphi(n)$: the map $k\\mapsto\\omega^k$ is injective on $[0,n)$ (parent omega_pow_injOn, restricted to the coprime subset), so Finset.card_image_of_injOn makes the count of *exponents* equal the count of *roots*. Counting through the explicit generator — rather than quoting Mathlib's abstract card_primitiveRoots — keeps the $\\varphi(n)$ tied to the concrete picture: $\\varphi(n)$ of the $n$ equally-spaced $n$-gon vertices are primitive.",
+    "mathContext": "$\\#\\{k\\in[0,n):\\gcd(k,n)=1\\} = \\varphi(n)$; injectivity of $k\\mapsto\\omega^k$ gives $\\#\\,(\\text{primitive roots}) = \\varphi(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's totient",
+      "Nat.totient_eq_card_coprime",
+      "card_image_of_injOn",
+      "injectivity"
+    ],
+    "prerequisites": [
+      "totient function",
+      "omega_pow_injOn (parent)"
+    ]
+  },
+  {
+    "id": "ann-dm0401-summary",
+    "proofId": "de-moivre-oq-04-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 122
+    },
+    "type": "concept",
+    "title": "Summary Bundle",
+    "content": "demoivre_oq04_oq01_summary packages the three results into one theorem: (1) $\\omega^k$ is primitive $\\iff\\gcd(k,n)=1$, (2) the primitive $n$-th roots are exactly the coprime powers of $\\omega$, and (3) there are $\\varphi(n)$ of them. The $\\varphi(n)$ count is precisely the degree of the cyclotomic polynomial $\\Phi_n$, setting up the next step (open question): identifying the primitive roots as the roots of $\\Phi_n = \\prod_{\\gcd(k,n)=1}(X - \\omega^k)$ and developing $\\Phi_n$ as the minimal polynomial of $\\omega$ over $\\mathbb{Q}$.",
+    "mathContext": "Three results in one. $\\deg\\Phi_n = \\varphi(n)$ — this entry is the counting half of the cyclotomic-polynomial identification.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "summary theorem",
+      "cyclotomic polynomial",
+      "minimal polynomial"
+    ],
+    "prerequisites": [
+      "the three main results"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-04-oq-01` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 5 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Docstring — which n-gon vertices generate it
2. **The primitivity criterion gcd(k,n)=1** (key)
3. **Structure theorem** (key) — primitive roots = coprime powers of ω
4. **The φ(n) count via the explicit generator** (key)
5. Summary bundle

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: original` / `axiomCount: 0` / 0 sorries — accurate against the Lean source (no native_decide).

Per-target branch to avoid clobbering open enricher PRs.