### PR TITLE
Enrich De Moivre OQ-05 (roots of unity sum to zero): add annotations

### DIFF
--- a/src/data/proofs/de-moivre-oq-05/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-dm05-docstring",
+    "proofId": "de-moivre-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "The Roots of Unity Sum to Zero",
+    "content": "The docstring states the classical fact: for $n>1$ the $n$ complex $n$-th roots of unity sum to zero, with the standard one-line geometric-series argument $\\sum_{i=0}^{n-1}\\zeta^i = (\\zeta^n-1)/(\\zeta-1) = 0$ for a primitive root $\\zeta$. It pinpoints the gap in Mathlib: the library records the geometric-series form (geom_sum_eq_zero, summing the powers $\\zeta^0,\\ldots,\\zeta^{n-1}$ as an indexed list) but NOT the coordinate-free set form (summing the underlying roots without privileging a generator). The two are connected by the also-absent structural identity that the roots ARE the powers of one primitive root; this file supplies that bridge and the de Moivre / discrete-Fourier form $\\sum_k e^{2\\pi ik/n} = 0$.",
+    "mathContext": "$\\sum_{x\\in\\mu_n} x = 0$ for $n>1$. Geometric series: $\\sum_{i=0}^{n-1}\\zeta^i = \\frac{\\zeta^n-1}{\\zeta-1} = 0$ since $\\zeta^n=1$, $\\zeta\\ne 1$. Also the Vieta relation for $z^n-1$ (no $z^{n-1}$ term).",
+    "significance": "context",
+    "relatedConcepts": [
+      "roots of unity",
+      "geometric series",
+      "discrete Fourier transform",
+      "Gauss sums"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "primitive roots",
+      "finite geometric series"
+    ]
+  },
+  {
+    "id": "ann-dm05-bridge",
+    "proofId": "de-moivre-oq-05",
+    "range": {
+      "startLine": 53,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "The Bridge: Roots = Powers of a Primitive Root",
+    "content": "nthRootsFinset_eq_image is the structural identity Mathlib lacks: $\\text{nthRootsFinset}\\,n\\,1 = (\\text{range}\\,n).\\text{image}(\\zeta^{\\cdot})$ for a primitive root $\\zeta$. It is proved by a double-counting argument rather than an explicit bijection: the image is contained in the root set (each $\\zeta^i$ satisfies $x^n = 1$, via $(\\zeta^i)^n = (\\zeta^n)^i = 1$), and both sides have cardinality $n$ — the image because $i\\mapsto\\zeta^i$ is injective on $\\{0,\\ldots,n-1\\}$ (injOn_pow), the root set by card_nthRootsFinset (a degree-$n$ polynomial has at most $n$ roots). Containment plus equal cardinality forces equality (Finset.eq_of_subset_of_card_le). This is the structural fact that $\\zeta$ generates $\\mu_n$.",
+    "mathContext": "$\\mu_n = \\{\\zeta^0,\\ldots,\\zeta^{n-1}\\}$. Image $\\subseteq$ root set, both card $n$ $\\Rightarrow$ equality. No explicit bijection needed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "double counting",
+      "cardinality argument",
+      "primitive root generation",
+      "Finset.image"
+    ],
+    "prerequisites": [
+      "card_nthRootsFinset",
+      "injOn_pow",
+      "eq_of_subset_of_card_le"
+    ]
+  },
+  {
+    "id": "ann-dm05-coordfree",
+    "proofId": "de-moivre-oq-05",
+    "range": {
+      "startLine": 76,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "The Coordinate-Free Vanishing Sum",
+    "content": "sum_nthRootsFinset_eq_zero proves $\\sum_{x\\in\\mu_n} x = 0$ for $n>1$ over any integral domain possessing a primitive root. Rewriting the set sum along the bridge identity and applying Finset.sum_image (using injectivity again) converts $\\sum_{x\\in\\text{nthRootsFinset}} x$ into the indexed geometric series $\\sum_{i\\in\\text{range }n}\\zeta^i$, which vanishes by Mathlib's IsPrimitiveRoot.geom_sum_eq_zero. The hypothesis $n>1$ is essential: for $n=1$ the lone root is 1 and the sum is 1, not 0 — primitivity needs $\\zeta\\ne 1$ to make $\\zeta-1$ invertible.",
+    "mathContext": "$\\sum_{x\\in\\mu_n} x = \\sum_{i\\in\\text{range }n}\\zeta^i = 0$ for $n>1$, by geom_sum_eq_zero. Fails at $n=1$ (sum $= 1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "geom_sum_eq_zero",
+      "Finset.sum_image",
+      "reindexing"
+    ],
+    "prerequisites": [
+      "the bridge identity",
+      "geometric series vanishing"
+    ]
+  },
+  {
+    "id": "ann-dm05-complex",
+    "proofId": "de-moivre-oq-05",
+    "range": {
+      "startLine": 86,
+      "endLine": 91
+    },
+    "type": "concept",
+    "title": "The Complex Specialization",
+    "content": "sum_complex_nthRootsFinset_eq_zero instantiates the coordinate-free result over $\\mathbb{C}$, supplying the primitive root $\\zeta = e^{2\\pi i/n}$ from Complex.isPrimitiveRoot_exp. This is the concrete statement that the $n$ complex $n$-th roots of unity sum to zero — geometrically, the centroid of a regular $n$-gon inscribed in the unit circle sits at the centre.",
+    "mathContext": "$\\sum_{x\\in\\mu_n\\subset\\mathbb{C}} x = 0$, with $\\zeta = e^{2\\pi i/n}$ via isPrimitiveRoot_exp.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isPrimitiveRoot_exp",
+      "regular n-gon centroid"
+    ],
+    "prerequisites": [
+      "complex primitive root"
+    ]
+  },
+  {
+    "id": "ann-dm05-dft",
+    "proofId": "de-moivre-oq-05",
+    "range": {
+      "startLine": 93,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "The Explicit de Moivre / Discrete-Fourier Form",
+    "content": "sum_exp_eq_zero gives the version that appears in discrete Fourier analysis: $\\sum_{k=0}^{n-1} e^{2\\pi ik/n} = 0$ for $n>1$. The proof recognises $e^{2\\pi ik/n} = (e^{2\\pi i/n})^k$ (Complex.exp_nat_mul, then ring on the exponent) to reduce the claim to the geometric series for the primitive root $e^{2\\pi i/n}$. This is the identity behind the vanishing of a full period of a discrete Fourier sampling sum — the foundation of character-sum orthogonality and Gauss sums in analytic number theory.",
+    "mathContext": "$\\sum_{k=0}^{n-1} e^{2\\pi ik/n} = \\sum_{k=0}^{n-1}(e^{2\\pi i/n})^k = 0$ — a full period of DFT sampling phases cancels.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discrete Fourier transform",
+      "Complex.exp_nat_mul",
+      "character orthogonality",
+      "sampling phases"
+    ],
+    "prerequisites": [
+      "complex exponential",
+      "geometric series"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 5 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Docstring — the roots of unity sum to zero + the Mathlib gap
2. **The bridge** (key) — roots = powers of a primitive root, by double-counting
3. **The coordinate-free vanishing sum** (key)
4. The complex specialization
5. **The explicit de Moivre / discrete-Fourier form** (key)

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: mathlib` / `axiomCount: 0` / 0 sorries — badge accurately reflects the geometric-series vanishing is Mathlib's while the set-form bridge is supplied here.

Per-target branch to avoid clobbering open enricher PRs.