### PR TITLE
Enrich De Moivre OQ-05-OQ-01 (orthogonality / DFT inversion): add annotations

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01/annotations.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "ann-dm0501-docstring",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "From a Single Vanishing Sum to Full Orthogonality",
+    "content": "The docstring frames the generalization: the parent (de-moivre-oq-05) proved $\\sum_{k<n}\\zeta^k = 0$, which is exactly the $j=1$ slice of the full orthogonality relation underlying the discrete Fourier transform. For a primitive root $\\zeta$ and any frequency $j$, $\\sum_{k<n}\\zeta^{jk} = n$ if $n\\mid j$ (all phases coincide) and $0$ otherwise (geometric cancellation). This is the DFT-inversion identity: the columns of the DFT matrix are pairwise orthogonal, and a full period of any non-trivial sampling character sums to zero. Mathlib records only the $j=1$ geometric vanishing; this file supplies the full frequency-indexed dichotomy, its signed-frequency form, and the character orthonormality.",
+    "mathContext": "$\\sum_{k=0}^{n-1}\\zeta^{jk} = \\begin{cases} n & n\\mid j\\\\ 0 & n\\nmid j\\end{cases}$ — the orthogonality relation for the characters of $\\mathbb{Z}/n\\mathbb{Z}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "discrete Fourier transform",
+      "character orthogonality",
+      "roots of unity",
+      "Gauss sums"
+    ],
+    "prerequisites": [
+      "roots of unity",
+      "geometric series",
+      "cyclic group characters"
+    ]
+  },
+  {
+    "id": "ann-dm0501-dichotomy",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 92
+    },
+    "type": "insight",
+    "title": "The Orthogonality Dichotomy via Geometric Collapse",
+    "content": "sum_pow_eq_ite is the core: $\\sum_{k<n}\\zeta^{jk} = n\\cdot[n\\mid j]$ over any integral domain with a primitive root. Writing $\\zeta^{jk} = (\\zeta^j)^k$ turns the sum into a geometric series with ratio $w = \\zeta^j$. The only fact about $j$ that matters is whether $\\zeta^j = 1$, i.e. whether $n\\mid j$ (supplied by pow_eq_one_iff_dvd). If $n\\mid j$, $w=1$ and every term is 1, giving $n$. Otherwise $w\\ne 1$ but $w^n = (\\zeta^n)^j = 1$, so the telescoping geom_sum_mul gives $(\\sum_{k<n} w^k)(w-1) = w^n - 1 = 0$, and in an integral domain mul_eq_zero with $w-1\\ne 0$ forces the sum to vanish. Working over a domain (not a field) avoids division entirely. sum_pow_eq_zero_of_not_dvd packages the off-diagonal case.",
+    "mathContext": "$\\sum_{k<n}(\\zeta^j)^k$: $=n$ if $\\zeta^j=1$ ($n\\mid j$); else $(\\sum w^k)(w-1) = w^n-1 = 0$ with $w-1\\ne 0$ $\\Rightarrow$ sum $=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric series",
+      "geom_sum_mul",
+      "pow_eq_one_iff_dvd",
+      "integral domain"
+    ],
+    "prerequisites": [
+      "telescoping identity",
+      "no zero divisors",
+      "primitive root order"
+    ]
+  },
+  {
+    "id": "ann-dm0501-complex",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 115
+    },
+    "type": "concept",
+    "title": "Complex and Explicit Exponential Forms",
+    "content": "Two specializations to $\\mathbb{C}$. sum_complex_pow_eq_ite instantiates the dichotomy with $\\zeta = e^{2\\pi i/n}$ (Complex.isPrimitiveRoot_exp). sum_exp_orthogonality gives the explicit de Moivre / DFT form $\\sum_{k<n} e^{2\\pi i jk/n} = n\\cdot[n\\mid j]$, recognising $e^{2\\pi i jk/n} = (e^{2\\pi i/n})^{jk}$ via Complex.exp_nat_mul. The $n$ sampled phases of frequency $j$ sum to $n$ when $j$ is a multiple of $n$ (phases coincide) and to 0 otherwise (a full period cancels) — the parent's vanishing sum is the $j=1$ instance.",
+    "mathContext": "$\\sum_{k<n} e^{2\\pi i jk/n} = n\\,[n\\mid j]$, via $e^{2\\pi i jk/n} = (e^{2\\pi i/n})^{jk}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isPrimitiveRoot_exp",
+      "Complex.exp_nat_mul",
+      "sampling phases"
+    ],
+    "prerequisites": [
+      "complex exponential",
+      "the dichotomy"
+    ]
+  },
+  {
+    "id": "ann-dm0501-signed",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 144
+    },
+    "type": "technique",
+    "title": "Signed Frequencies (Negative Modes)",
+    "content": "sum_complex_zpow_eq_ite extends orthogonality to signed frequencies $j\\in\\mathbb{Z}$, covering negative Fourier modes via the integer power $\\zeta^{jk}$. The proof is the same geometric collapse, now using the integer divisibility criterion zpow_eq_one_iff_dvd ($\\zeta^j = 1 \\iff (n:\\mathbb{Z})\\mid j$) and the zpow arithmetic to establish $(\\zeta^j)^n = 1$. This signed form is exactly what feeds the orthonormality of the Fourier characters, where the inner product produces the negative-mode $\\zeta^{(a-b)k}$.",
+    "mathContext": "$\\sum_{k<n}(\\zeta^j)^k = n\\,[(n:\\mathbb{Z})\\mid j]$ for $j\\in\\mathbb{Z}$, via zpow_eq_one_iff_dvd.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "signed frequencies",
+      "negative Fourier modes",
+      "zpow_eq_one_iff_dvd"
+    ],
+    "prerequisites": [
+      "integer powers",
+      "the geometric collapse"
+    ]
+  },
+  {
+    "id": "ann-dm0501-orthonormal",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 186
+    },
+    "type": "insight",
+    "title": "Orthonormality of the DFT Characters",
+    "content": "sum_char_inner is the payoff: $\\sum_{k<n} e^{2\\pi i ak/n}\\,\\overline{e^{2\\pi i bk/n}} = n\\cdot[a=b]$ for $a,b<n$ — the orthogonality of the rows of the DFT matrix, the identity that makes the inverse discrete Fourier transform recover coefficients by one inner product. The conjugate of a sampling character is the negative-frequency mode ($\\overline{\\zeta^{bk}} = \\zeta^{-bk}$, via exp_conj/exp_int_mul), so the product telescopes to the single signed mode $\\zeta^{(a-b)k}$ and signed orthogonality gives the dichotomy. The bound $|a-b|<n$ turns the divisibility test $n\\mid(a-b)$ into the equality test $a=b$ (closed by an omega/nlinarith argument bounding the quotient $c$ to 0).",
+    "mathContext": "$\\sum_{k<n} \\chi_a(k)\\overline{\\chi_b(k)} = \\sum_{k<n}\\zeta^{(a-b)k} = n\\,[a=b]$; $|a-b|<n$ makes $n\\mid(a-b) \\iff a=b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "DFT inversion",
+      "character orthonormality",
+      "exp_conj",
+      "negative-frequency mode"
+    ],
+    "prerequisites": [
+      "signed orthogonality",
+      "complex conjugation",
+      "omega bounding"
+    ]
+  },
+  {
+    "id": "ann-dm0501-parent",
+    "proofId": "de-moivre-oq-05-oq-01",
+    "range": {
+      "startLine": 188,
+      "endLine": 196
+    },
+    "type": "concept",
+    "title": "Parent Recovery (j = 1)",
+    "content": "sum_geom_eq_zero recovers the parent statement $\\sum_{k<n}\\zeta^k = 0$ for $n>1$ as the $j=1$ corollary of orthogonality: since $n\\nmid 1$ (as $n>1$), the off-diagonal case applies and the sum vanishes. This closes the loop — the parent's single vanishing sum is exactly one slice of the frequency-indexed dichotomy proved here, confirming the generalization genuinely subsumes it.",
+    "mathContext": "$\\sum_{k<n}\\zeta^k = 0$ for $n>1$: the $j=1$ case, since $n\\nmid 1$ — exactly de-moivre-oq-05.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parent recovery",
+      "corollary",
+      "consistency check"
+    ],
+    "prerequisites": [
+      "sum_pow_eq_zero_of_not_dvd"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-01` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 6 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Docstring — single vanishing sum → full orthogonality
2. **The orthogonality dichotomy** (key) — geometric collapse over a domain
3. Complex and explicit exponential forms
4. Signed frequencies (negative modes)
5. **Orthonormality of the DFT characters** (key) — DFT inversion
6. Parent recovery (j=1)

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: original` / `axiomCount: 0` / 0 sorries — accurate against the Lean source (no native_decide).

Per-target branch to avoid clobbering open enricher PRs.