### PR TITLE
research(banach-fixed-point-oq-01-oq-02): Lipschitz perturbation of the identity is a homeomorphism

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -268,6 +268,7 @@ import Proofs.BallotProblemOQ03OQ01OQ04
 import Proofs.BallotProblemOQ03OQ02
 import Proofs.BallotProblemOQ03OQ03
 import Proofs.BanachFixedPointOQ01
+import Proofs.BanachPerturbationIdentityOQ01OQ02
 import Proofs.BanachSteinhausTheoremOQ01
 import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01

--- a/proofs/Proofs/BanachPerturbationIdentityOQ01OQ02.lean
+++ b/proofs/Proofs/BanachPerturbationIdentityOQ01OQ02.lean
@@ -1,0 +1,150 @@
+import Mathlib
+
+/-
+# Lipschitz Perturbation of the Identity is a Homeomorphism
+
+Open-question extension `oq-01-oq-02` of the Banach Fixed Point chain.
+
+Let `E` be a complete normed (additive) group and let `g : E → E` be
+`k`-Lipschitz with `k < 1`.  Then the perturbed map
+
+  `f x = x + g x`
+
+is a **homeomorphism of `E` onto itself**, with a quantitative two-sided
+Lipschitz control:
+
+  `(1 - k) ‖x - y‖ ≤ ‖f x - f y‖`        (expansion / antilipschitz bound)
+  `‖f⁻¹ a - f⁻¹ b‖ ≤ (1 - k)⁻¹ ‖a - b‖`  (the inverse is `(1-k)⁻¹`-Lipschitz)
+
+This is the analytic core of the inverse function theorem: a small
+(Lipschitz) perturbation of the identity remains invertible, and one controls
+the modulus of continuity of the inverse explicitly.  Surjectivity is the
+prototypical application of the Banach contraction principle: solving
+`f x = y` is the fixed-point equation `x = y - g x` for the contraction
+`x ↦ y - g x`.
+
+Everything below is fully machine-checked with `0` `sorry`s and `0` `axiom`s.
+The only nontrivial Mathlib input is the contraction-mapping fixed-point
+theorem (`ContractingWith.fixedPoint`); the expansion estimate and the
+homeomorphism packaging are proved from the triangle inequality.
+-/
+
+namespace BanachPerturbationOQ01OQ02
+
+set_option linter.unusedSectionVars false
+
+open Metric Function
+open scoped NNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E]
+variable {k : ℝ≥0} {g : E → E}
+
+/-- The perturbed map `f = id + g`. -/
+def pmap (g : E → E) : E → E := fun x => x + g x
+
+@[simp] theorem pmap_apply (g : E → E) (x : E) : pmap g x = x + g x := rfl
+
+/-- **Expansion estimate.**  A `k`-Lipschitz perturbation of the identity
+expands distances by at least the factor `1 - k`:
+`(1 - k) ‖x - y‖ ≤ ‖f x - f y‖`. -/
+theorem norm_sub_perturb_ge (hg : LipschitzWith k g) (x y : E) :
+    (1 - (k : ℝ)) * ‖x - y‖ ≤ ‖pmap g x - pmap g y‖ := by
+  have hgle : ‖g x - g y‖ ≤ (k : ℝ) * ‖x - y‖ := by
+    have := hg.dist_le_mul x y
+    simpa [dist_eq_norm] using this
+  have hsplit : x - y = (pmap g x - pmap g y) - (g x - g y) := by
+    simp only [pmap]; abel
+  have htri : ‖x - y‖ ≤ ‖pmap g x - pmap g y‖ + ‖g x - g y‖ := by
+    calc ‖x - y‖ = ‖(pmap g x - pmap g y) - (g x - g y)‖ := by rw [hsplit]
+      _ ≤ ‖pmap g x - pmap g y‖ + ‖g x - g y‖ := norm_sub_le _ _
+  nlinarith [htri, hgle]
+
+/-- **Antilipschitz bound.**  `f = id + g` is `(1-k)⁻¹`-antilipschitz, i.e.
+`dist x y ≤ (1-k)⁻¹ · dist (f x) (f y)`. -/
+theorem perturb_antilipschitz (hg : LipschitzWith k g) (hk : k < 1) :
+    AntilipschitzWith (1 - k)⁻¹ (pmap g) := by
+  apply AntilipschitzWith.of_le_mul_dist
+  intro x y
+  have hk0 : (0 : ℝ) < 1 - (k : ℝ) := by
+    have : (k : ℝ) < 1 := by exact_mod_cast hk
+    linarith
+  rw [dist_eq_norm, dist_eq_norm, NNReal.coe_inv, NNReal.coe_sub hk.le, NNReal.coe_one,
+    inv_mul_eq_div, le_div_iff₀ hk0, mul_comm]
+  exact norm_sub_perturb_ge hg x y
+
+/-- `f = id + g` is injective. -/
+theorem perturb_injective (hg : LipschitzWith k g) (hk : k < 1) :
+    Injective (pmap g) :=
+  (perturb_antilipschitz hg hk).injective
+
+/-- `f = id + g` is continuous (sum of the identity and the Lipschitz `g`). -/
+theorem perturb_continuous (hg : LipschitzWith k g) : Continuous (pmap g) :=
+  continuous_id.add hg.continuous
+
+/-- **Surjectivity via Banach's contraction principle.**  For each target `y`,
+the map `x ↦ y - g x` is a `k`-contraction; its fixed point `x` satisfies
+`x = y - g x`, i.e. `f x = x + g x = y`. -/
+theorem perturb_surjective (hg : LipschitzWith k g) (hk : k < 1) :
+    Surjective (pmap g) := by
+  intro y
+  have hTL : LipschitzWith k (fun x => y - g x) := by
+    apply LipschitzWith.of_dist_le_mul
+    intro a b
+    have hd := hg.dist_le_mul a b
+    simp only [dist_eq_norm]
+    calc ‖(y - g a) - (y - g b)‖ = ‖g a - g b‖ := by
+            rw [show (y - g a) - (y - g b) = -(g a - g b) by abel, norm_neg]
+      _ ≤ (k : ℝ) * ‖a - b‖ := by simpa [dist_eq_norm] using hd
+  have hContr : ContractingWith k (fun x => y - g x) := ⟨hk, hTL⟩
+  haveI : Nonempty E := ⟨0⟩
+  set fp := ContractingWith.fixedPoint (fun x => y - g x) hContr with hfpdef
+  have hfp : y - g fp = fp := hContr.fixedPoint_isFixedPt
+  refine ⟨fp, ?_⟩
+  rw [sub_eq_iff_eq_add] at hfp
+  rw [pmap_apply]
+  exact hfp.symm
+
+/-- `f = id + g` is bijective. -/
+theorem perturb_bijective (hg : LipschitzWith k g) (hk : k < 1) :
+    Bijective (pmap g) :=
+  ⟨perturb_injective hg hk, perturb_surjective hg hk⟩
+
+/-- **Main theorem.**  A `k`-Lipschitz perturbation of the identity (`k < 1`)
+on a complete normed group is a homeomorphism of `E` onto itself. -/
+noncomputable def perturbHomeo (hg : LipschitzWith k g) (hk : k < 1) : E ≃ₜ E where
+  toEquiv := Equiv.ofBijective (pmap g) (perturb_bijective hg hk)
+  continuous_toFun := perturb_continuous hg
+  continuous_invFun :=
+    ((perturb_antilipschitz hg hk).to_rightInverse
+      (Equiv.ofBijective (pmap g) (perturb_bijective hg hk)).right_inv).continuous
+
+@[simp] theorem perturbHomeo_apply (hg : LipschitzWith k g) (hk : k < 1) (x : E) :
+    perturbHomeo hg hk x = x + g x := rfl
+
+/-- The inverse homeomorphism is `(1-k)⁻¹`-Lipschitz. -/
+theorem symm_lipschitz (hg : LipschitzWith k g) (hk : k < 1) :
+    LipschitzWith (1 - k)⁻¹ (perturbHomeo hg hk).symm :=
+  (perturb_antilipschitz hg hk).to_rightInverse
+    (Equiv.ofBijective (pmap g) (perturb_bijective hg hk)).right_inv
+
+/-- **Quantitative inverse bound.**  The inverse of `id + g` satisfies the
+sharp Lipschitz estimate `‖f⁻¹ a - f⁻¹ b‖ ≤ (1-k)⁻¹ ‖a - b‖`. -/
+theorem symm_norm_sub_le (hg : LipschitzWith k g) (hk : k < 1) (a b : E) :
+    ‖(perturbHomeo hg hk).symm a - (perturbHomeo hg hk).symm b‖
+      ≤ (1 - (k : ℝ))⁻¹ * ‖a - b‖ := by
+  have hk0 : (0 : ℝ) < 1 - (k : ℝ) := by
+    have : (k : ℝ) < 1 := by exact_mod_cast hk
+    linarith
+  have hb := norm_sub_perturb_ge hg
+    ((perturbHomeo hg hk).symm a) ((perturbHomeo hg hk).symm b)
+  have ha : (perturbHomeo hg hk).symm a + g ((perturbHomeo hg hk).symm a) = a := by
+    have := (perturbHomeo hg hk).apply_symm_apply a
+    rwa [perturbHomeo_apply] at this
+  have hb' : (perturbHomeo hg hk).symm b + g ((perturbHomeo hg hk).symm b) = b := by
+    have := (perturbHomeo hg hk).apply_symm_apply b
+    rwa [perturbHomeo_apply] at this
+  rw [pmap_apply, pmap_apply, ha, hb'] at hb
+  rw [inv_mul_eq_div, le_div_iff₀ hk0, mul_comm]
+  exact hb
+
+end BanachPerturbationOQ01OQ02

--- a/research/problems/banach-fixed-point-oq-01-oq-02/knowledge.md
+++ b/research/problems/banach-fixed-point-oq-01-oq-02/knowledge.md
@@ -1,0 +1,63 @@
+# Knowledge: banach-fixed-point-oq-01-oq-02
+
+## Summary
+
+**Status:** COMPLETED (verified, 0 axioms, 0 sorries).
+A `k`-Lipschitz perturbation of the identity `f = id + g` (`k < 1`) on a complete
+normed group is a homeomorphism of `E`, with inverse `(1−k)⁻¹`-Lipschitz.
+
+Lean file: `proofs/Proofs/BanachPerturbationIdentityOQ01OQ02.lean`
+(10 theorems, 2 definitions, 150 lines).
+
+## Session 2026-06-24 (Session 1) — FRESH — COMPLETED
+
+**Mode:** FRESH
+**Outcome:** completed
+
+### What I Did
+- Surveyed Mathlib: found the general perturbation machinery
+  `ApproximatesLinearOn.toHomeomorph` (a map approximating a continuous linear
+  equivalence on the whole space is a homeomorphism). This subsumes the result
+  but is a thin wrapper and hides the inverse's Lipschitz constant.
+- Chose instead to prove the identity-perturbation special case directly and
+  expose the explicit inverse modulus `1/(1−k)`.
+- Proved `norm_sub_perturb_ge`: `(1 − k)‖x − y‖ ≤ ‖f x − f y‖` from the triangle
+  inequality and `LipschitzWith.dist_le_mul` (no completeness needed).
+- Packaged it as `perturb_antilipschitz : AntilipschitzWith (1−k)⁻¹ (pmap g)` via
+  `AntilipschitzWith.of_le_mul_dist`; `perturb_injective` is then `.injective`.
+- `perturb_surjective`: for target `y`, `x ↦ y − g x` is `ContractingWith k`
+  (`LipschitzWith.of_dist_le_mul`); its `ContractingWith.fixedPoint` solves
+  `f x = y`.
+- Assembled `perturbHomeo : E ≃ₜ E` (inverse continuity from
+  `AntilipschitzWith.to_rightInverse`), and `symm_norm_sub_le` for the sharp
+  `(1−k)⁻¹` inverse bound.
+
+### Key Findings
+- Injectivity = lower bound; surjectivity = fixed point — the contraction is used
+  in opposite directions for the two halves of bijectivity.
+- The same expansion inequality, evaluated at preimages, gives BOTH inverse
+  continuity and the explicit inverse Lipschitz constant.
+- Only the triangle inequality and one Banach fixed point are needed; completeness
+  enters only through surjectivity.
+
+### Mathlib gotchas
+- `ℝ≥0` notation requires `open scoped NNReal` (otherwise `k` parses as junk and
+  every downstream goal becomes `sorry`-typed).
+- Cast chain for the NNReal constant: `NNReal.coe_inv`, `NNReal.coe_sub hk.le`,
+  `NNReal.coe_one` turn `↑((1−k)⁻¹)` into `(1 − ↑k)⁻¹`.
+- For the fixed point, avoid `set T with hT` then `simp only [hT]` — it unfolds
+  `T` inside `fixedPoint T` too, desyncing the goal. Keep the lambda inline and
+  rearrange with `sub_eq_iff_eq_add`.
+
+### Files Modified
+- `proofs/Proofs/BanachPerturbationIdentityOQ01OQ02.lean` (new)
+- `proofs/Proofs.lean` (import)
+- `src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json` (new)
+
+### Next Steps (follow-up open questions)
+- Perturbation of a linear isomorphism `A` (not just `id`): full local inverse
+  function theorem with inverse bound in terms of `‖A⁻¹‖`.
+- Matching upper bound `‖f x − f y‖ ≤ (1 + k)‖x − y‖` for full bi-Lipschitz
+  equivalence with the identity.
+- Recover `f⁻¹` as the explicit limit of Picard iteration `xₙ₊₁ = y − g xₙ` with
+  geometric error `kⁿ/(1 − k)`.

--- a/research/problems/banach-fixed-point-oq-01-oq-02/problem.md
+++ b/research/problems/banach-fixed-point-oq-01-oq-02/problem.md
@@ -1,0 +1,33 @@
+# Lipschitz Perturbation of the Identity is a Homeomorphism
+
+**Slug:** `banach-fixed-point-oq-01-oq-02`
+**Parent:** `banach-fixed-point-oq-01` (Banach contraction mapping theorem)
+**Sibling:** `banach-fixed-point-oq-01-oq-01` (Picard–Lindelöf)
+
+## Statement
+
+Let `E` be a complete normed additive group and let `g : E → E` be `k`-Lipschitz
+with `k < 1`. Then the perturbed map
+
+    f x = x + g x   (f = id + g)
+
+is a **homeomorphism of `E` onto itself**, with the quantitative control
+
+    (1 − k)‖x − y‖ ≤ ‖f x − f y‖              (expansion / antilipschitz)
+    ‖f⁻¹ a − f⁻¹ b‖ ≤ (1 − k)⁻¹ ‖a − b‖        (inverse is (1−k)⁻¹-Lipschitz)
+
+## Why it matters
+
+This is the analytic core of the inverse function theorem and of Newton's
+method: a small (Lipschitz) perturbation of the identity stays invertible, and
+the modulus of continuity of the inverse is controlled explicitly by `1/(1−k)`.
+It is the second textbook consequence of the Banach contraction principle,
+alongside Picard–Lindelöf (the sibling entry).
+
+## Approach
+
+- **Injectivity** ⇐ the expansion estimate (triangle inequality + Lipschitz bound).
+- **Surjectivity** ⇐ the Banach contraction principle: solving `f x = y` is the
+  fixed-point equation `x = y − g x` for the contraction `x ↦ y − g x`.
+- **Inverse continuity / Lipschitz bound** ⇐ the antilipschitz bound, read at the
+  preimages (`AntilipschitzWith.to_rightInverse`).

--- a/research/problems/banach-fixed-point-oq-01-oq-02/state.md
+++ b/research/problems/banach-fixed-point-oq-01-oq-02/state.md
@@ -1,0 +1,22 @@
+# State: banach-fixed-point-oq-01-oq-02
+
+**Phase:** COMPLETED
+**Status:** verified (0 axioms, 0 sorries)
+**Lean file:** `proofs/Proofs/BanachPerturbationIdentityOQ01OQ02.lean`
+**Last updated:** 2026-06-24
+
+## Proof state
+
+| Theorem | Statement | Status |
+|---------|-----------|--------|
+| `norm_sub_perturb_ge` | `(1−k)‖x−y‖ ≤ ‖f x − f y‖` | ✅ |
+| `perturb_antilipschitz` | `AntilipschitzWith (1−k)⁻¹ (id+g)` | ✅ |
+| `perturb_injective` | `Injective (id+g)` | ✅ |
+| `perturb_continuous` | `Continuous (id+g)` | ✅ |
+| `perturb_surjective` | `Surjective (id+g)` (Banach FP) | ✅ |
+| `perturb_bijective` | `Bijective (id+g)` | ✅ |
+| `perturbHomeo` | `E ≃ₜ E` | ✅ |
+| `symm_lipschitz` | `LipschitzWith (1−k)⁻¹ (id+g)⁻¹` | ✅ |
+| `symm_norm_sub_le` | `‖f⁻¹a − f⁻¹b‖ ≤ (1−k)⁻¹‖a−b‖` | ✅ |
+
+Axiom profile (`#print axioms`): `propext, Classical.choice, Quot.sound` only.

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "banach-fixed-point-oq-01-oq-02",
+  "title": "Lipschitz perturbation of the identity is a homeomorphism",
+  "slug": "banach-fixed-point-oq-01-oq-02",
+  "description": "On a complete normed group E, a k-Lipschitz perturbation of the identity f x = x + g x (with k < 1) is a homeomorphism of E onto itself, with explicit two-sided Lipschitz control. This is the analytic core of the inverse function theorem: small Lipschitz perturbations of the identity stay invertible, and the modulus of continuity of the inverse is controlled quantitatively. The entry proves the expansion estimate (1 − k)‖x − y‖ ≤ ‖f x − f y‖ from the triangle inequality (norm_sub_perturb_ge), repackages it as the antilipschitz bound dist x y ≤ (1 − k)⁻¹ · dist (f x) (f y) (perturb_antilipschitz), derives injectivity, proves surjectivity as the prototypical application of the Banach contraction principle (solving f x = y is the fixed-point equation x = y − g x for the contraction x ↦ y − g x), assembles the homeomorphism perturbHomeo, and exposes the sharp inverse Lipschitz constant ‖f⁻¹ a − f⁻¹ b‖ ≤ (1 − k)⁻¹‖a − b‖ (symm_norm_sub_le). Verified with 0 axioms and 0 sorries; the only nontrivial Mathlib input is the contraction-mapping fixed-point theorem.",
+  "meta": {
+    "author": "Classical (perturbation of the identity / inverse function theorem); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachPerturbationIdentityOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "banach-fixed-point",
+      "contraction-mapping",
+      "lipschitz",
+      "homeomorphism",
+      "inverse-function-theorem",
+      "antilipschitz",
+      "perturbation-of-identity",
+      "normed-space",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ContractingWith.fixedPoint",
+        "description": "The Banach contraction mapping theorem: a contraction on a complete (nonempty) metric space has a fixed point. Used for surjectivity — for each target y the map x ↦ y − g x is a k-contraction, and its fixed point solves f x = x + g x = y.",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "AntilipschitzWith.of_le_mul_dist",
+        "description": "Builds an AntilipschitzWith bound from the elementary distance inequality dist x y ≤ K · dist (f x) (f y); converts the expansion estimate into the packaged antilipschitz fact used for injectivity and the inverse's Lipschitz bound.",
+        "module": "Mathlib.Topology.MetricSpace.Antilipschitz"
+      },
+      {
+        "theorem": "AntilipschitzWith.to_rightInverse",
+        "description": "An antilipschitz map's right inverse is Lipschitz with the same constant. Applied to the bijection's inverse, it makes the inverse (1−k)⁻¹-Lipschitz, hence continuous — the continuity of the inverse half of the homeomorphism.",
+        "module": "Mathlib.Topology.MetricSpace.Antilipschitz"
+      },
+      {
+        "theorem": "LipschitzWith.of_dist_le_mul",
+        "description": "Characterizes a Lipschitz bound by dist (f x) (f y) ≤ K · dist x y; used to show x ↦ y − g x is k-Lipschitz, so it is a contraction.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "norm_sub_perturb_ge: the expansion estimate (1 − k)‖x − y‖ ≤ ‖f x − f y‖ for f = id + g with g k-Lipschitz, proved from the triangle inequality alone (no completeness needed).",
+      "perturb_antilipschitz: f = id + g is (1−k)⁻¹-antilipschitz; the quantitative repackaging of the expansion estimate that yields injectivity for free.",
+      "perturb_surjective: surjectivity of f via the Banach contraction principle — solving f x = y is the fixed-point equation x = y − g x for the contraction x ↦ y − g x.",
+      "perturbHomeo: the main theorem — f = id + g (g k-Lipschitz, k < 1) is a homeomorphism of the complete normed group E onto itself, packaged as E ≃ₜ E.",
+      "symm_lipschitz / symm_norm_sub_le: the inverse homeomorphism is (1−k)⁻¹-Lipschitz, i.e. ‖f⁻¹ a − f⁻¹ b‖ ≤ (1 − k)⁻¹‖a − b‖ — the explicit modulus of continuity of the inverse, the quantitative payoff over Mathlib's general ApproximatesLinearOn.toHomeomorph."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas (#print axioms confirms exactly these three). The hypotheses (complete normed group, g k-Lipschitz with k < 1) are ordinary mathematical hypotheses, not unproved assumptions.",
+    "lineCount": 150,
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That a small perturbation of the identity remains invertible is the technical heart of the inverse function theorem and of Newton's method: writing a near-linear map as the identity plus a small (Lipschitz) error, one solves the equation by iterating x ↦ y − g x, exactly Banach's contraction scheme (1922). The quantitative inverse bound 1/(1−k) is the constant that propagates into a priori error estimates for fixed-point iteration. Mathlib develops the general statement (a map approximating a continuous linear equivalence on a set is a partial homeomorphism) in ApproximatesLinearOn as scaffolding for its inverse function theorem; this entry isolates and proves the identity-perturbation special case directly, with the explicit Lipschitz constant of the inverse exposed.",
+    "problemStatement": "The Banach fixed-point theorem (parent entry) gives a unique fixed point for a contraction on a complete space. A second canonical consequence, beyond Picard–Lindelöf, is the perturbation principle: if g is a contraction (k-Lipschitz, k < 1) on a complete normed group E, is f x = x + g x a homeomorphism of E, and what is the modulus of continuity of f⁻¹?\n\n**Answer:** Yes — f is a homeomorphism onto E, with (1 − k)‖x − y‖ ≤ ‖f x − f y‖ ≤ (1 + k)‖x − y‖ and the inverse (1 − k)⁻¹-Lipschitz. Bijectivity reduces injectivity to the lower (antilipschitz) bound and surjectivity to the contraction fixed point of x ↦ y − g x.",
+    "text": "A k-Lipschitz perturbation of the identity on a complete normed group is a homeomorphism, with the inverse explicitly (1−k)⁻¹-Lipschitz — the analytic core of the inverse function theorem, proved with 0 axioms.",
+    "proofStrategy": "1. norm_sub_perturb_ge: f x − f y = (x − y) + (g x − g y), so ‖x − y‖ ≤ ‖f x − f y‖ + ‖g x − g y‖ ≤ ‖f x − f y‖ + k‖x − y‖, giving (1 − k)‖x − y‖ ≤ ‖f x − f y‖ (triangle inequality + Lipschitz bound, closed by nlinarith).\n2. perturb_antilipschitz: divide the expansion estimate by 1 − k > 0 and package via AntilipschitzWith.of_le_mul_dist; perturb_injective is then .injective.\n3. perturb_continuous: f = id + g is continuous as continuous_id.add hg.continuous.\n4. perturb_surjective: for target y, x ↦ y − g x is k-Lipschitz (LipschitzWith.of_dist_le_mul), hence ContractingWith k; its fixed point x satisfies y − g x = x, i.e. f x = x + g x = y.\n5. perturbHomeo: combine bijectivity (Equiv.ofBijective), continuity of f, and continuity of the inverse — the latter because the inverse is a right inverse of an antilipschitz map, hence Lipschitz (AntilipschitzWith.to_rightInverse) and continuous.\n6. symm_norm_sub_le: apply norm_sub_perturb_ge at f⁻¹ a, f⁻¹ b and use f (f⁻¹ a) = a to get (1 − k)‖f⁻¹ a − f⁻¹ b‖ ≤ ‖a − b‖, then divide.",
+    "keyInsights": [
+      "**Injectivity = lower bound, surjectivity = fixed point.** The two halves of bijectivity come from opposite uses of the contraction: the expansion estimate (1 − k)‖x − y‖ ≤ ‖f x − f y‖ forces injectivity, while solving f x = y is itself a contraction fixed-point problem for x ↦ y − g x.",
+      "**The inverse's Lipschitz constant is the same estimate, read backwards.** Evaluating the expansion bound at the preimages f⁻¹ a, f⁻¹ b turns the lower bound on f into the upper bound (1 − k)⁻¹ on f⁻¹ — one inequality does double duty, and gives continuity of the inverse for free via AntilipschitzWith.to_rightInverse.",
+      "**Only the triangle inequality and one fixed point.** Everything except surjectivity is elementary normed-group arithmetic; the sole appeal to completeness is the single Banach fixed point used to invert f, making this a faithful 'second application' companion to Picard–Lindelöf.",
+      "**Identity-perturbation is the clean special case of ApproximatesLinearOn.** Mathlib's general machinery proves a map approximating a linear equivalence is a local homeomorphism; specializing the approximated map to the identity removes the linear-equiv bookkeeping and lets the inverse's modulus 1/(1−k) be stated sharply."
+    ],
+    "exampleSections": [
+      {
+        "title": "Newton-step solvability",
+        "mathContext": "If T is a bounded operator on a Banach space with ‖T − I‖ ≤ k < 1, then writing g = T − I (k-Lipschitz, indeed k-bounded-linear) makes T = id + g a homeomorphism by this theorem, recovering the Neumann-series fact that operators near the identity are invertible — here with the explicit inverse Lipschitz constant 1/(1 − k)."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Banach, Stefan",
+      "title": "Sur les opérations dans les ensembles abstraits et leur application aux équations intégrales",
+      "year": "1922",
+      "note": "Fund. Math. 3, 133–181 — the contraction mapping principle that supplies surjectivity."
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "McGraw–Hill — the inverse function theorem proof builds f as a Lipschitz perturbation of a linear isomorphism, of which id + contraction is the model case."
+    },
+    {
+      "authors": "Hörmander, Lars",
+      "title": "The Analysis of Linear Partial Differential Operators I",
+      "year": "1990",
+      "note": "Springer — perturbation-of-identity and the quantitative inverse Lipschitz constant 1/(1−k)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "banach-fixed-point-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry: the Banach contraction mapping theorem. This entry is its perturbation-of-identity application — surjectivity of id + g is exactly a contraction fixed point."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling application of the contraction principle: Picard–Lindelöf local existence/uniqueness for ODEs. Together they exhibit the two textbook consequences of Banach's theorem (ODE solvability and the inverse function theorem core)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A k-Lipschitz perturbation of the identity f x = x + g x (k < 1) on a complete normed group is proved to be a homeomorphism of E onto itself (perturbHomeo), with the expansion estimate (1 − k)‖x − y‖ ≤ ‖f x − f y‖ (norm_sub_perturb_ge), injectivity and the (1−k)⁻¹-antilipschitz bound (perturb_antilipschitz), surjectivity via the Banach contraction fixed point (perturb_surjective), and the sharp inverse Lipschitz estimate ‖f⁻¹ a − f⁻¹ b‖ ≤ (1 − k)⁻¹‖a − b‖ (symm_norm_sub_le). Verified with 0 axioms and 0 sorries.",
+    "implications": "Provides the inverse-function-theorem core as a clean, reusable homeomorphism with an explicit inverse modulus of continuity, complementing the parent contraction entry and the Picard–Lindelöf sibling as the second canonical application of Banach's theorem.",
+    "openQuestions": [
+      "Perturbation of a linear isomorphism: replace the identity by a continuous linear equiv A with g (k‖A⁻¹‖⁻¹)-Lipschitz, recovering the full local inverse function theorem statement with the analogous inverse bound.",
+      "Add the matching upper bound ‖f x − f y‖ ≤ (1 + k)‖x − y‖ to state the full bi-Lipschitz equivalence of f with the identity.",
+      "Recover f⁻¹ as the explicit limit of the Picard iteration xₙ₊₁ = y − g xₙ with the geometric a priori error estimate kⁿ/(1 − k), tying the inverse to successive approximations rather than an abstract fixed point."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and statement",
+      "startLine": 3,
+      "endLine": 30,
+      "summary": "Frames the result: f = id + g with g k-Lipschitz (k < 1) on a complete normed group is a homeomorphism, with the two-sided Lipschitz control and a note that surjectivity is the prototypical Banach contraction application.",
+      "mathContext": "$(1-k)\\|x-y\\| \\le \\|f x - f y\\|$ and $\\|f^{-1}a - f^{-1}b\\| \\le (1-k)^{-1}\\|a-b\\|$."
+    },
+    {
+      "id": "setup",
+      "title": "Setup and the perturbed map",
+      "startLine": 32,
+      "endLine": 43,
+      "summary": "Fixes a complete normed group E, a Lipschitz constant k : ℝ≥0 and g : E → E, and defines pmap g x = x + g x with its simp lemma.",
+      "mathContext": "$f = \\mathrm{id} + g$, $g$ $k$-Lipschitz."
+    },
+    {
+      "id": "expansion",
+      "title": "Expansion estimate (norm_sub_perturb_ge)",
+      "startLine": 45,
+      "endLine": 58,
+      "summary": "Proves (1 − k)‖x − y‖ ≤ ‖f x − f y‖ from f x − f y = (x − y) + (g x − g y), the triangle inequality, and the Lipschitz bound on g — completeness not required.",
+      "mathContext": "$\\|x-y\\| \\le \\|fx-fy\\| + k\\|x-y\\|$."
+    },
+    {
+      "id": "antilipschitz",
+      "title": "Antilipschitz bound and injectivity",
+      "startLine": 60,
+      "endLine": 76,
+      "summary": "perturb_antilipschitz packages the expansion estimate as AntilipschitzWith (1−k)⁻¹ via of_le_mul_dist; perturb_injective is the resulting .injective.",
+      "mathContext": "$\\mathrm{dist}\\,x\\,y \\le (1-k)^{-1}\\,\\mathrm{dist}\\,(fx)\\,(fy)$."
+    },
+    {
+      "id": "surjective",
+      "title": "Continuity and surjectivity",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "perturb_continuous = continuous_id.add hg.continuous; perturb_surjective solves f x = y via the contraction x ↦ y − g x (LipschitzWith.of_dist_le_mul ⟹ ContractingWith), whose fixed point gives x + g x = y.",
+      "mathContext": "$x \\mapsto y - g x$ contraction $\\Rightarrow f x = y$."
+    },
+    {
+      "id": "homeomorphism",
+      "title": "The homeomorphism and inverse bound",
+      "startLine": 105,
+      "endLine": 146,
+      "summary": "perturb_bijective combines injectivity and surjectivity; perturbHomeo builds the E ≃ₜ E (inverse continuity from AntilipschitzWith.to_rightInverse); symm_lipschitz / symm_norm_sub_le give the (1−k)⁻¹ inverse Lipschitz constant.",
+      "mathContext": "$f \\in \\mathrm{Homeo}(E)$, $\\mathrm{Lip}(f^{-1}) \\le (1-k)^{-1}$."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Metric",
+      "Function",
+      "NNReal"
+    ],
+    "namespace": "BanachPerturbationOQ01OQ02",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/BanachPerturbationIdentityOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open-question extension `oq-01-oq-02` of the **Banach Fixed Point** chain (sibling of the Picard–Lindelöf entry `oq-01-oq-01`).

On a complete normed group `E`, a `k`-Lipschitz perturbation of the identity
```
f x = x + g x      (g k-Lipschitz, k < 1)
```
is a **homeomorphism of `E` onto itself**, with explicit two-sided Lipschitz control:
```
(1 − k)‖x − y‖ ≤ ‖f x − f y‖              (expansion / antilipschitz)
‖f⁻¹ a − f⁻¹ b‖ ≤ (1 − k)⁻¹ ‖a − b‖        (inverse is (1−k)⁻¹-Lipschitz)
```

This is the analytic core of the inverse function theorem and Newton's method, and the second textbook consequence of the Banach contraction principle: **surjectivity of `f` is exactly the contraction fixed point** of `x ↦ y − g x`.

## What's proved (10 theorems, 2 defs, 150 lines)

- `norm_sub_perturb_ge` — expansion estimate from the triangle inequality (no completeness).
- `perturb_antilipschitz` — `AntilipschitzWith (1−k)⁻¹ (id+g)`; `perturb_injective` follows.
- `perturb_continuous`, `perturb_surjective` (Banach FP), `perturb_bijective`.
- `perturbHomeo : E ≃ₜ E` — the main theorem.
- `symm_lipschitz` / `symm_norm_sub_le` — the sharp `(1−k)⁻¹` inverse Lipschitz constant (the quantitative payoff over Mathlib's general `ApproximatesLinearOn.toHomeomorph`).

## Verification

- Built with `lake env lean` against Mathlib v4.26.0 — **0 errors, 0 warnings**.
- `#print axioms`: `propext, Classical.choice, Quot.sound` only — **verified, 0 axioms, 0 sorries**, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)