### PR TITLE
Enrich Mirsky's Theorem hard direction: add annotations

### DIFF
--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-mirsky-docstring",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "Mirsky's Theorem: the Hard (Attainment) Direction",
+    "content": "The docstring scopes the file to the deep half of Mirsky's theorem (1971), the order-theoretic dual of Dilworth's: the minimum number of antichains covering a finite poset equals the maximum length of a chain. The companion file proved the easy direction $\\mathrm{maxChainLen} \\le |\\mathcal{A}|$ for any antichain cover; this file constructs a cover of size exactly $\\mathrm{maxChainLen}$, attaining the bound. The method is the height/level decomposition. A notable contrast: Dilworth's hard direction needs König/matching machinery, while Mirsky's follows from a single clean counting idea — partition by the longest-chain-ending-here depth. Classical decidability is registered as a local instance so Finset operations resolve uniformly.",
+    "mathContext": "Mirsky: $\\min(\\text{antichain cover}) = \\max(\\text{chain length})$. This file proves the attainment ($\\ge$) half over an arbitrary finite $[\\mathrm{PartialOrder}\\,\\alpha]\\,[\\mathrm{Fintype}\\,\\alpha]$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Mirsky's theorem",
+      "Dilworth's theorem",
+      "antichain cover",
+      "min-max duality"
+    ],
+    "prerequisites": [
+      "partial orders",
+      "chains and antichains"
+    ]
+  },
+  {
+    "id": "ann-mirsky-defs",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 67
+    },
+    "type": "definition",
+    "title": "chainsTo, height, maxChainLen",
+    "content": "The core definitions. chainsTo x is the Finset of chains whose maximum element is x (chains $C$ with $x\\in C$ and every member $\\le x$), filtered from the powerset of the universe. height x is the Finset.sup of their cardinalities — the size of a longest chain ending at x. allChains collects every chain of the poset, and maxChainLen is the sup of all chain cardinalities. All are noncomputable (they range over Finset α via classical Fintype). Working with Finset.sup rather than well-ordering by hand lets the proof extract concrete witnessing chains via Finset.exists_mem_eq_sup.",
+    "mathContext": "$\\mathrm{height}(x) = \\max\\{|C| : C \\text{ chain with top } x\\}$; $\\mathrm{maxChainLen} = \\max\\{|C| : C \\text{ chain}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "height function",
+      "Finset.sup",
+      "longest chain"
+    ],
+    "prerequisites": [
+      "Finset.powerset",
+      "Finset.sup"
+    ]
+  },
+  {
+    "id": "ann-mirsky-height-basics",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 107
+    },
+    "type": "technique",
+    "title": "Height Bounds and Attainment: 1 ≤ height x ≤ maxChainLen",
+    "content": "These lemmas pin down the height function. singleton_mem_chainsTo shows $\\{x\\}$ is a chain ending at x, giving chainsTo_nonempty and the lower bound one_le_height ($1\\le\\mathrm{height}\\,x$). exists_chainsTo_card_eq_height uses Finset.exists_mem_eq_sup to extract a *concrete* longest chain ending at x realizing the sup — the witness the key lemma will extend. height_le_maxChainLen bounds height above by maxChainLen (Finset.sup_mono, since every chain-ending-at-x is a chain of the whole poset). Together: $1\\le\\mathrm{height}(x)\\le\\mathrm{maxChainLen}$, the range the levels live in.",
+    "mathContext": "$1 \\le \\mathrm{height}(x) \\le \\mathrm{maxChainLen}$, with the height realized by a concrete chain ending at $x$ (exists_mem_eq_sup).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.exists_mem_eq_sup",
+      "Finset.sup_mono",
+      "attainment"
+    ],
+    "prerequisites": [
+      "Finset.le_sup",
+      "sup attainment"
+    ]
+  },
+  {
+    "id": "ann-mirsky-key-lemma",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 148
+    },
+    "type": "insight",
+    "title": "The Key Lemma: Each Level Is an Antichain",
+    "content": "level_isAntichain is the heart of the whole proof, and the entire hard direction reduces to it: elements of equal height are mutually incomparable. The argument is a contradiction. Suppose $x < y$ with $\\mathrm{height}(x) = \\mathrm{height}(y) = k$. Take a longest chain $C$ ending at $x$ (size $k$, from the attainment lemma). Since every member of $C$ is $\\le x < y$, $y\\notin C$ and insert y C is a chain ending at $y$ of size $k+1$ (verified by checking all comparability cases through $x$). Then $\\mathrm{height}(y) \\ge k+1$, contradicting $\\mathrm{height}(y) = k$. So $x<y$ forces $\\mathrm{height}(y) > \\mathrm{height}(x)$ — each level set is an antichain.",
+    "mathContext": "$x < y \\Rightarrow \\mathrm{height}(y) > \\mathrm{height}(x)$: appending $y$ to a longest chain ending at $x$ gives a chain of size $\\mathrm{height}(x)+1$ ending at $y$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "antichain",
+      "height monotonicity",
+      "chain extension",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "exists_chainsTo_card_eq_height",
+      "card_insert_of_notMem"
+    ]
+  },
+  {
+    "id": "ann-mirsky-cover",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 176
+    },
+    "type": "insight",
+    "title": "The Antichain Cover of Size ≤ maxChainLen",
+    "content": "mirsky_antichain_cover assembles the level sets into a cover. The cover is the image of the heights under level. It is an antichain cover (each level is an antichain by the key lemma) and it covers the poset (every x lies in level (height x)). The cardinality bound is the counting step: the number of distinct nonempty levels is at most the number of distinct heights (Finset.card_image_le), which is at most $|\\mathrm{Icc}\\,1\\,\\mathrm{maxChainLen}| = \\mathrm{maxChainLen}$ since every height lies in $[1, \\mathrm{maxChainLen}]$. This converts the existence of a height partition into the precise cardinality $\\le\\mathrm{maxChainLen}$.",
+    "mathContext": "The $\\le\\mathrm{maxChainLen}$ nonempty levels cover the poset by antichains. Count: $\\#\\text{levels} \\le \\#\\text{heights} \\le |\\mathrm{Icc}\\,1\\,\\mathrm{maxChainLen}| = \\mathrm{maxChainLen}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "antichain cover",
+      "Finset.card_image_le",
+      "level decomposition"
+    ],
+    "prerequisites": [
+      "the key lemma",
+      "height bounds",
+      "card_image_le"
+    ]
+  },
+  {
+    "id": "ann-mirsky-minmax",
+    "proofId": "dilworth-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 178,
+      "endLine": 221
+    },
+    "type": "concept",
+    "title": "Attainment and the Full Min–Max Identity",
+    "content": "The closing theorems complete the duality. exists_chain_card_eq_maxChainLen extracts a concrete longest chain (exists_mem_eq_sup over the nonempty allChains). maxChainLen_le_card_of_antichainCover re-states the imported easy direction using that chain: any antichain cover has $\\ge\\mathrm{maxChainLen}$ members. mirsky_min_antichain_cover combines both bounds — the level cover gives $\\le\\mathrm{maxChainLen}$, the easy direction gives $\\ge\\mathrm{maxChainLen}$ — so by le_antisymm the constructed cover has size exactly $\\mathrm{maxChainLen}$, and it is minimal among all antichain covers. This is the full $\\min(\\text{antichain cover}) = \\max(\\text{chain length})$, with the minimum attained.",
+    "mathContext": "$\\min(\\text{antichain cover}) = \\mathrm{maxChainLen} = \\max(\\text{chain length})$, by le_antisymm of the easy ($\\ge$) and hard ($\\le$) bounds.",
+    "significance": "key",
+    "relatedConcepts": [
+      "min-max theorem",
+      "le_antisymm",
+      "minimality",
+      "easy direction (companion)"
+    ],
+    "prerequisites": [
+      "mirsky_antichain_cover",
+      "chain_card_le_of_antichainCover"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `dilworth-theorem-oq-01-oq-01` (quality 45, 0 prior passes).

## Gap
Recently-merged research entry with rich `meta.json` but **no `annotations.json`**.

## Changes
Added 6 substantive annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Docstring — Mirsky's hard (attainment) direction
2. chainsTo / height / maxChainLen definitions
3. Height bounds and attainment (1 ≤ height x ≤ maxChainLen)
4. **The key lemma** (key) — each level is an antichain
5. **The antichain cover of size ≤ maxChainLen** (key)
6. **Attainment and the full min–max identity** (key)

## Verification
- `pnpm annotations:build`: entry resolves cleanly, 0 warnings; listings.json regenerated.
- Axiom integrity: `status: verified` / `badge: verified` / `axiomCount: 0` / 0 sorries — accurate against the Lean source (no native_decide; easy direction imported from companion).

Per-target branch to avoid clobbering open enricher PRs.