### PR TITLE
research(lagrange-theorem-oq-01-oq-01-oq-02): close BOTH non-abelian standard facts — common range + internal recognition [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
@@ -343,19 +343,19 @@ theorem order_15_iso {G H : Type*} [Group G] [Group H] [Fintype G] [Fintype H]
     action maps from a prime-order group with equal range give isomorphic semidirect
     products.
 
-  **What remains for full non-abelian uniqueness** (two documented standard facts, both
-  outside the scope verified here):
+  **What remains for full non-abelian uniqueness** (the second fact is now closed in
+  Part VII; only the first remains):
   1. *Internal recognition*: every non-cyclic group of order `pq` is `≃*` to some
      `ℤ/q ⋊[φ] ℤ/p` with `φ` nontrivial. Mathlib lacks a packaged normal-complement ⟹
      internal-semidirect-product lemma for this.
-  2. *Common range*: any two nontrivial `φ₁, φ₂ : ℤ/p →* Aut(ℤ/q)` have equal range —
-     the unique order-`p` subgroup of the cyclic group `Aut(ℤ/q) ≅ (ℤ/q)ˣ` (which has
-     order `q-1`, divisible by `p` exactly in this branch). This is the uniqueness of
-     subgroups of given order in a cyclic group.
+  2. *Common range* (**RESOLVED in Part VII**): any two nontrivial `φ₁, φ₂ : ℤ/p →*
+     Aut(ℤ/q)` have equal range — the unique order-`p` subgroup of the cyclic group
+     `Aut(ℤ/q) ≅ (ℤ/q)ˣ`. See `range_eq_of_nontrivial_prime_card`.
 
   Given (1) and (2), `semidirectProductIso_of_nontrivial_range_eq` closes the
-  non-abelian case. This part delivers the reusable middle link with `0` sorries and
-  `0` axioms.
+  non-abelian case; Part VII supplies (2) and the hypothesis-free capstone
+  `semidirectProductIso_of_nontrivial_into_cyclic`. This part delivers the reusable
+  middle link with `0` sorries and `0` axioms.
 -/
 
 variable {Γ Δ : Type*} [Group Γ] [Group Δ]
@@ -426,5 +426,84 @@ theorem semidirectProductIso_of_nontrivial_range_eq {N : Type*} [Group N] [Finty
     Nonempty (SemidirectProduct N Γ g ≃* SemidirectProduct N Γ f) :=
   ⟨semidirectProductIsoOfRangeEq (injective_of_prime_card hp hcard hf)
     (injective_of_prime_card hp hcard hg) hr⟩
+
+/-
+  ## Part VII — Common range: discharging the hypothesis of Part VI's capstone.
+
+  Part VI's `semidirectProductIso_of_nontrivial_range_eq` *assumes* `f.range = g.range`.
+  Here we **prove** that hypothesis for the case relevant to `pq`-groups: when the
+  target `K` (`= Aut N`) is a finite **cyclic** group, any two nontrivial maps out of
+  a group of prime order automatically have equal range. This settles the second of
+  the two "documented standard facts" listed at the top of Part VI (*common range*),
+  leaving only *internal recognition* (the Mathlib normal-complement gap) for full
+  non-abelian uniqueness.
+
+  The engine is **uniqueness of subgroups of a given order in a cyclic group**: every
+  subgroup `H` of a finite cyclic `K` equals the `(Nat.card H)`-torsion subgroup
+  `(powMonoidHom (Nat.card H)).ker` — the unique subgroup of that order. Indeed `H` is
+  contained in it (`h ^ (Nat.card H) = 1` for `h ∈ H`, Lagrange) and that torsion
+  subgroup has card `gcd(|K|, Nat.card H) = Nat.card H`, so the inclusion is an
+  equality (`Subgroup.eq_of_le_of_card_ge`). The torsion-card computation is Mathlib's
+  `IsCyclic.card_powMonoidHom_ker`. Hence two subgroups of equal order coincide, and
+  the two prime-order ranges (both `≅ Γ` via `MonoidHom.ofInjective`) are equal.
+-/
+
+section CommonRange
+
+variable {K : Type*} [CommGroup K] [Finite K] [IsCyclic K]
+
+/-- **Subgroups of a finite cyclic group are pinned down by their order.** A subgroup
+    `H` of a finite cyclic group equals the `(Nat.card H)`-torsion subgroup
+    `(powMonoidHom (Nat.card H)).ker`, the unique subgroup of that order. -/
+theorem subgroup_eq_powMonoidHom_ker (H : Subgroup K) :
+    H = (powMonoidHom (Nat.card H) : K →* K).ker := by
+  have hdvd : Nat.card H ∣ Nat.card K := Subgroup.card_subgroup_dvd_card H
+  have hcardker : Nat.card (powMonoidHom (Nat.card H) : K →* K).ker = Nat.card H := by
+    rw [IsCyclic.card_powMonoidHom_ker, Nat.gcd_eq_right_iff_dvd.2 hdvd]
+  have hle : H ≤ (powMonoidHom (Nat.card H) : K →* K).ker := by
+    intro x hx
+    rw [MonoidHom.mem_ker, powMonoidHom_apply]
+    have h1 : (⟨x, hx⟩ : H) ^ Nat.card H = 1 := pow_card_eq_one'
+    have h2 := congrArg (Subgroup.subtype H) h1
+    rw [map_pow, map_one] at h2
+    simpa using h2
+  exact Subgroup.eq_of_le_of_card_ge hle (le_of_eq hcardker)
+
+/-- **Uniqueness of subgroups of given order in a cyclic group.** Two subgroups of a
+    finite cyclic group with the same cardinality are equal. -/
+theorem subgroup_eq_of_card_eq {H₁ H₂ : Subgroup K} (h : Nat.card H₁ = Nat.card H₂) :
+    H₁ = H₂ := by
+  rw [subgroup_eq_powMonoidHom_ker H₁, subgroup_eq_powMonoidHom_ker H₂, h]
+
+/-- **Common range.** Any two *nontrivial* homomorphisms from a group of prime order
+    into a finite cyclic group have the same range — both are the unique subgroup of
+    order `p` of the cyclic target. This discharges the `f.range = g.range` hypothesis
+    of `semidirectProductIso_of_nontrivial_range_eq`. -/
+theorem range_eq_of_nontrivial_prime_card [Fintype Γ]
+    {p : ℕ} (hp : p.Prime) (hcard : Fintype.card Γ = p)
+    {f g : Γ →* K} (hf : f ≠ 1) (hg : g ≠ 1) :
+    f.range = g.range := by
+  have hif : Function.Injective f := injective_of_prime_card hp hcard hf
+  have hig : Function.Injective g := injective_of_prime_card hp hcard hg
+  apply subgroup_eq_of_card_eq
+  rw [(Nat.card_congr (MonoidHom.ofInjective hif).toEquiv).symm,
+      (Nat.card_congr (MonoidHom.ofInjective hig).toEquiv).symm]
+
+/-- **Capstone (hypothesis-free, cyclic-`Aut` case).** When `Aut N` is finite cyclic,
+    *any* two nontrivial action maps from a group of prime order `p` give isomorphic
+    semidirect products — no equal-range hypothesis required, since Part VII supplies
+    it automatically. Combined with internal recognition (every non-cyclic group of
+    order `pq` is such a semidirect product), this pins the non-abelian isomorphism
+    class of groups of order `pq`: `Aut (ℤ/q) ≅ (ℤ/q)ˣ` is cyclic for prime `q`. -/
+theorem semidirectProductIso_of_nontrivial_into_cyclic {N : Type*} [Group N]
+    [Finite (MulAut N)] [IsCyclic (MulAut N)] [Fintype Γ]
+    {p : ℕ} (hp : p.Prime) (hcard : Fintype.card Γ = p)
+    {f g : Γ →* MulAut N} (hf : f ≠ 1) (hg : g ≠ 1) :
+    Nonempty (SemidirectProduct N Γ g ≃* SemidirectProduct N Γ f) := by
+  letI : CommGroup (MulAut N) := IsCyclic.commGroup
+  exact semidirectProductIso_of_nontrivial_range_eq hp hcard hf hg
+    (range_eq_of_nontrivial_prime_card hp hcard hf hg)
+
+end CommonRange
 
 end LagrangeOQ01OQ01OQ02

--- a/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
@@ -343,19 +343,23 @@ theorem order_15_iso {G H : Type*} [Group G] [Group H] [Fintype G] [Fintype H]
     action maps from a prime-order group with equal range give isomorphic semidirect
     products.
 
-  **What remains for full non-abelian uniqueness** (the second fact is now closed in
-  Part VII; only the first remains):
-  1. *Internal recognition*: every non-cyclic group of order `pq` is `≃*` to some
-     `ℤ/q ⋊[φ] ℤ/p` with `φ` nontrivial. Mathlib lacks a packaged normal-complement ⟹
-     internal-semidirect-product lemma for this.
+  **What remains for full non-abelian uniqueness** (both facts are now closed below;
+  see Parts VII and VIII):
+  1. *Internal recognition* (**RESOLVED in Part VIII**): every group of order `pq`
+     (`p < q`) is `≃*` to an internal semidirect product `Q ⋊ P` of its Sylow
+     subgroups (`Q` the normal Sylow `q`-subgroup). See
+     `exists_internalSemidirect_of_card_pq`, built on Mathlib's
+     `SemidirectProduct.mulEquivSubgroup`.
   2. *Common range* (**RESOLVED in Part VII**): any two nontrivial `φ₁, φ₂ : ℤ/p →*
      Aut(ℤ/q)` have equal range — the unique order-`p` subgroup of the cyclic group
      `Aut(ℤ/q) ≅ (ℤ/q)ˣ`. See `range_eq_of_nontrivial_prime_card`.
 
   Given (1) and (2), `semidirectProductIso_of_nontrivial_range_eq` closes the
   non-abelian case; Part VII supplies (2) and the hypothesis-free capstone
-  `semidirectProductIso_of_nontrivial_into_cyclic`. This part delivers the reusable
-  middle link with `0` sorries and `0` axioms.
+  `semidirectProductIso_of_nontrivial_into_cyclic`, Part VIII supplies (1). The only
+  residual mathematical input is that the conjugation action is *nontrivial* in the
+  non-cyclic case. This part delivers the reusable middle link with `0` sorries and
+  `0` axioms.
 -/
 
 variable {Γ Δ : Type*} [Group Γ] [Group Δ]
@@ -505,5 +509,70 @@ theorem semidirectProductIso_of_nontrivial_into_cyclic {N : Type*} [Group N]
     (range_eq_of_nontrivial_prime_card hp hcard hf hg)
 
 end CommonRange
+
+/-
+  ## Part VIII — Internal recognition: every group of order `pq` (`p < q`) is an
+  internal semidirect product `Q ⋊ P` with `Q` the *normal* Sylow `q`-subgroup.
+
+  This supplies the *first* of Part VI's two standard facts — internal recognition —
+  the one previously flagged as a Mathlib gap. In fact Mathlib provides the missing
+  link, `SemidirectProduct.mulEquivSubgroup`, which turns a normal subgroup together
+  with a complement into an internal semidirect product `H ⋊ K ≃* G`. For `|G| = pq`
+  with `p < q`:
+
+  - the Sylow `q`-subgroup is **normal** — its count divides `p` and is `≡ 1 (mod q)`,
+    forcing `1` because `q > p` (so `q ∤ (p-1)` automatically), via `pq_card_sylow_one`
+    with the two primes swapped;
+  - the Sylow `p`-subgroup is a **complement** of coprime order
+    (`|Q|·|P| = q·p = |G|`, `gcd(q,p)=1`), via `Subgroup.isComplement'_of_coprime`;
+  - `mulEquivSubgroup` then assembles `G ≃* Q ⋊ P`.
+
+  With Part VII (common range) and Part VI (range determines the product), the
+  structural reduction of non-abelian `pq`-uniqueness is now backed by lemmas all in
+  hand; the only residual mathematical input is that the conjugation action is
+  *nontrivial* in the non-cyclic case (a trivial action would make `G ≅ Q × P` cyclic).
+-/
+
+/-- **Internal semidirect recognition for groups of order `pq`.** For primes `p < q`
+    with `|G| = pq`, `G` is (isomorphic to) an internal semidirect product `Q ⋊ P` of
+    its Sylow subgroups, with `Q` the normal Sylow `q`-subgroup (`|Q| = q`) and `P` a
+    Sylow `p`-subgroup (`|P| = p`). This discharges the *internal recognition* fact
+    that Part VI listed as a Mathlib gap, using `SemidirectProduct.mulEquivSubgroup`. -/
+theorem exists_internalSemidirect_of_card_pq {G : Type*} [Group G] [Fintype G]
+    {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpltq : p < q)
+    (hcard : Fintype.card G = p * q) :
+    ∃ (Q P : Subgroup G) (_ : Q.Normal) (φ : P →* MulAut Q),
+      Nat.card Q = q ∧ Nat.card P = p ∧
+        Nonempty (SemidirectProduct Q P φ ≃* G) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  have hpq : p ≠ q := Nat.ne_of_lt hpltq
+  have hpnq : ¬ p ∣ q := fun h => hpq ((Nat.prime_dvd_prime_iff_eq hp hq).mp h)
+  have hqnp : ¬ q ∣ p := fun h => absurd (Nat.le_of_dvd hp.pos h) (by omega)
+  set Q := (default : Sylow q G) with hQ
+  set P := (default : Sylow p G) with hP
+  -- Cardinalities of the two Sylow subgroups.
+  have hcardP : Nat.card (P : Subgroup G) = p := by
+    rw [hP, Sylow.card_eq_multiplicity, Nat.card_eq_fintype_card, hcard,
+        Nat.factorization_mul hp.pos.ne' hq.pos.ne', Finsupp.add_apply,
+        hp.factorization_self, Nat.factorization_eq_zero_of_not_dvd hpnq, add_zero, pow_one]
+  have hcardQ : Nat.card (Q : Subgroup G) = q := by
+    rw [hQ, Sylow.card_eq_multiplicity, Nat.card_eq_fintype_card, hcard,
+        Nat.factorization_mul hp.pos.ne' hq.pos.ne', Finsupp.add_apply,
+        Nat.factorization_eq_zero_of_not_dvd hqnp, hq.factorization_self, zero_add, pow_one]
+  -- The Sylow `q`-subgroup is unique (count `≡ 1 mod q` divides `p`, and `q > p`),
+  -- hence normal.
+  have hsylowq : Nat.card (Sylow q G) = 1 :=
+    pq_card_sylow_one (p := q) (q := p) hp (Ne.symm hpq) (by rw [hcard]; ring)
+      (by intro h; have := Nat.le_of_dvd (by have := hp.two_le; omega) h; omega)
+  haveI : Subsingleton (Sylow q G) := (Nat.card_eq_one_iff_unique.mp hsylowq).1
+  haveI hQnormal : (Q : Subgroup G).Normal := Sylow.normal_of_subsingleton Q
+  -- `P` is a complement of `Q` (coprime orders multiplying to `|G|`).
+  have hcompl : (Q : Subgroup G).IsComplement' (P : Subgroup G) := by
+    apply Subgroup.isComplement'_of_coprime
+    · rw [hcardQ, hcardP, Nat.card_eq_fintype_card, hcard]; ring
+    · rw [hcardQ, hcardP]; exact (Nat.coprime_primes hq hp).mpr (Ne.symm hpq)
+  exact ⟨(Q : Subgroup G), (P : Subgroup G), hQnormal, _, hcardQ, hcardP,
+    ⟨SemidirectProduct.mulEquivSubgroup hcompl⟩⟩
 
 end LagrangeOQ01OQ01OQ02

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
@@ -172,3 +172,41 @@ non-abelian case entirely.
 Docker DOWN. Host recipe: `cd <main>/proofs && LAKE_UNSAFE=1 ./bin/lake env lean
 <abs path to worktree file>` (worktree `.lake/packages` empty → reuse main's Mathlib
 cache). Axiom check: append `open NS in #print axioms thm` to a `/tmp` copy, recompile.
+
+---
+## Session 2026-06-24 (Session 3 cont., researcher-1) — Internal recognition (Part VIII)
+
+**Mode**: DEPTH-FIRST (RICH) · **Outcome**: progress (verified, +1 thm, 0 axioms)
+
+### What I Did
+Closed **fact (1) — "internal recognition"** from Part VI's open-items list, the one
+previously flagged as a Mathlib gap. **Mathlib actually has the missing link**:
+`SemidirectProduct.mulEquivSubgroup {H K : Subgroup G} [H.Normal] (h : H.IsComplement' K)
+: H ⋊[φ] K ≃* G` (φ = the normalizer action). New theorem:
+- `exists_internalSemidirect_of_card_pq`: for primes `p < q` with `|G| = pq`, `G` is
+  `≃*` an internal semidirect product `Q ⋊ P` of its Sylow subgroups, `Q` the normal
+  Sylow-`q` subgroup (`|Q|=q`), `P` Sylow-`p` (`|P|=p`).
+
+### Key API / technique
+- `Subgroup.isComplement'_of_coprime [Finite G] (|H|·|K| = |G|) (Coprime |H| |K|) :
+  H.IsComplement' K`.
+- q-Sylow normality: reuse the file's own `pq_card_sylow_one` with **primes swapped**
+  (`p := q, q := p`); the side hypothesis `¬ q ∣ (p-1)` is automatic for `p < q`
+  (`0 < p-1 < q` ⟹ `Nat.le_of_dvd` contradiction). Then
+  `Sylow.normal_of_subsingleton` (from `Nat.card (Sylow q G) = 1`).
+- Sylow cardinalities: replicate the existing `hcardP` chain
+  (`Sylow.card_eq_multiplicity` → `Nat.factorization_mul` → `factorization_self` /
+  `factorization_eq_zero_of_not_dvd`). For q-Sylow the nonzero term is second, so use
+  `zero_add` (vs `add_zero` for p-Sylow).
+- The existential's `φ` is left as `_` and unifies with `mulEquivSubgroup`'s fixed
+  normalizer action; the `[Q.Normal]` instance (haveI) feeds `mulEquivSubgroup`.
+- Built clean **first try**; `#print axioms` = standard triple only (0-axiom).
+
+### State of the non-abelian thread (BOTH Part VI standard facts now closed)
+- Part VI: range determines the semidirect product (`semidirectProductIso_*`).
+- Part VII: **common range** (`range_eq_of_nontrivial_prime_card`).
+- Part VIII: **internal recognition** (`exists_internalSemidirect_of_card_pq`).
+Only residual mathematical input for *full* uniqueness: the conjugation action is
+**nontrivial** in the non-cyclic case (a trivial action ⟹ `G ≅ Q × P` cyclic). With
+that, `semidirectProductIso_of_nontrivial_into_cyclic` (needs `IsCyclic (MulAut Q)`,
+true since `Aut(ℤ/q) ≅ (ℤ/q)ˣ` cyclic for prime `q`) finishes — a clean next session.

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
@@ -128,3 +128,47 @@ each other, for each of the two cases" (cyclic case `p ∤ q-1`; non-cyclic case
    ApproachB `actionHom` infrastructure; show all nontrivial actions give isomorphic
    products. Mathlib has `SemidirectProduct.mulEquivSubgroup` for the internal
    recognition but lacks a normal-complement → semidirect lemma packaged for this.
+
+---
+## Session 2026-06-24 (Session 3, researcher-1) — Common range (Part VII)
+
+**Mode**: DEPTH-FIRST (RICH) · **Outcome**: progress (verified, +4 thms, 0 axioms)
+
+### What I Did
+Closed **fact (2) — "common range"** from Part VI's open-items list. Part VI's
+capstone `semidirectProductIso_of_nontrivial_range_eq` took `f.range = g.range` as a
+hypothesis; Part VII now **proves** it whenever the target is finite cyclic.
+
+New theorems (all standard-triple, 0 axioms):
+- `subgroup_eq_powMonoidHom_ker`: in a finite cyclic group, any subgroup `H` equals the
+  `(Nat.card H)`-torsion subgroup `(powMonoidHom (Nat.card H)).ker` — the unique
+  subgroup of that order.
+- `subgroup_eq_of_card_eq`: uniqueness of subgroups of given order in a cyclic group.
+- `range_eq_of_nontrivial_prime_card`: two nontrivial homs from a prime-order group into
+  a finite cyclic group have equal range.
+- `semidirectProductIso_of_nontrivial_into_cyclic`: hypothesis-free capstone — needs
+  only `[IsCyclic (MulAut N)]` (true for `Aut(ℤ/q) ≅ (ℤ/q)ˣ`, `q` prime).
+
+### Key API
+- `IsCyclic.card_powMonoidHom_ker [CommGroup G] [IsCyclic G] [Finite G] (d) :
+  Nat.card (powMonoidHom d).ker = (Nat.card G).gcd d`. The d-torsion `{x | xᵈ=1}` is a
+  *packaged* `Subgroup` (the ker of `powMonoidHom`), which is what makes the uniqueness
+  argument clean — no need to hand-build the torsion subgroup.
+- `Nat.gcd_eq_right_iff_dvd.2 : d ∣ n → n.gcd d = d`.
+- `Subgroup.eq_of_le_of_card_ge (hle : H ≤ K) (Nat.card K ≤ Nat.card H) : H = K`.
+- `IsCyclic.commGroup` is a `def` (not instance), reuses the ambient `Group`, so
+  `letI := IsCyclic.commGroup` to get `powMonoidHom` causes no diamond.
+- `pow_card_eq_one'` (no Fintype needed, uses `Nat.card`); project from subgroup via
+  `congrArg H.subtype` then `rw [map_pow, map_one]` (NOT `simpa using congrArg …`, which
+  over-simplifies the raw term to `True`).
+
+### Remaining gap (only one left for full non-abelian uniqueness)
+**Internal recognition**: every non-cyclic group of order `pq` is `≃*` to some
+`ℤ/q ⋊[φ] ℤ/p` with `φ` nontrivial. Mathlib lacks a packaged normal-complement ⟹
+internal-semidirect-product lemma. With this, the cyclic-`Aut` capstone closes the
+non-abelian case entirely.
+
+### Build
+Docker DOWN. Host recipe: `cd <main>/proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+<abs path to worktree file>` (worktree `.lake/packages` empty → reuse main's Mathlib
+cache). Axiom check: append `open NS in #print axioms thm` to a `/tmp` copy, recompile.

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -30,7 +30,7 @@
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
     "lineCount": 430,
-    "theoremCount": 18,
+    "theoremCount": 22,
     "definitionCount": 2,
     "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API: Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv` (abelian thread); `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae`, `IsZGroup.of_squarefree` (cyclic case); and `SemidirectProduct.congr`, `MonoidHom.ofInjective`/`ofInjective_apply`/`apply_ofInjective_symm`, `MulEquiv.subgroupCongr`, `MonoidHom.ker_eq_bot_iff`, `Subgroup.card_subgroup_dvd_card`/`eq_bot_of_card_eq`/`eq_top_of_card_eq` (non-abelian Part VI). No `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Kernel-verified on Mathlib v4.26.0: all 18 theorems and 2 definitions depend on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`).",
     "originalContributions": [
@@ -143,9 +143,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01OQ01OQ02",
-    "lineCount": 430,
+    "lineCount": 509,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 22,
     "definitionCount": 2,
     "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
     "sorries": 0,

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -30,7 +30,7 @@
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
     "lineCount": 430,
-    "theoremCount": 22,
+    "theoremCount": 23,
     "definitionCount": 2,
     "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API: Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv` (abelian thread); `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae`, `IsZGroup.of_squarefree` (cyclic case); and `SemidirectProduct.congr`, `MonoidHom.ofInjective`/`ofInjective_apply`/`apply_ofInjective_symm`, `MulEquiv.subgroupCongr`, `MonoidHom.ker_eq_bot_iff`, `Subgroup.card_subgroup_dvd_card`/`eq_bot_of_card_eq`/`eq_top_of_card_eq` (non-abelian Part VI). No `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Kernel-verified on Mathlib v4.26.0: all 18 theorems and 2 definitions depend on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`).",
     "originalContributions": [
@@ -143,9 +143,9 @@
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01OQ01OQ02",
-    "lineCount": 509,
+    "lineCount": 578,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 23,
     "definitionCount": 2,
     "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
     "sorries": 0,

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
@@ -31,14 +31,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (verified, self-contained, 18 thms / 2 defs / 0 sorries / 0 axioms, Mathlib-only). Abelian + FULL CYCLIC isomorphism uniqueness both complete (every group of order pq with ¬p∣q-1 is cyclic ≅ ℤ/pq). Session 2 added Part VI: the non-abelian structural engine — the iso type of N ⋊[φ] G depends only on φ.range, so two nontrivial prime-order action maps with equal range give isomorphic products (semidirectProductIsoOfRangeEq / semidirectProductIso_of_nontrivial_range_eq). Remaining for full non-abelian uniqueness: internal recognition (Mathlib gap) + common range of nontrivial ℤ/p-actions on ℤ/q (cyclic subgroup uniqueness).",
+    "progressSummary": "PROGRESS: Part VII closes the 'common range' standard fact (fact 2 of Part VI). Non-abelian pq uniqueness now reduced to a SINGLE remaining gap: internal recognition (every non-cyclic order-pq group is an internal semidirect product), a Mathlib normal-complement gap. File: 22 thm, 2 def, 0 sorry, 0 axiom, verified.",
     "builtItems": [
       "pq_abelian_isCyclic (LagrangeTheoremOQ01OQ01OQ02.lean): any CommGroup of order pq is cyclic (no divisibility hyp) via Cauchy exists_prime_orderOf_dvd_card + Commute.orderOf_mul_eq_mul_orderOf_of_coprime + isCyclic_of_orderOf_eq_card",
       "pq_abelian_iso, pq_abelian_iso_zmod: any two abelian order-pq groups isomorphic, each ≅ Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq + zmodCyclicMulEquiv",
       "Concrete: order_6/15/35_abelian_unique (≅ ℤ/n), order_15_abelian_pair. Kernel-verified standard triple, 0 axioms",
       "Part VI semidirectProductIsoOfRangeEq (LagrangeTheoremOQ01OQ01OQ02.lean): if f,g : Γ →* MulAut N are injective with f.range = g.range then N ⋊[g] Γ ≃* N ⋊[f] Γ — iso type determined by the action map IMAGE. Via SemidirectProduct.congr (refl N) (autOfRangeEq …).",
       "autOfRangeEq / exists_mulEquiv_comp_of_range_eq: two injective homs with equal range differ by a source automorphism α (g = f∘α); witness Γ ≃* g.range ≃* f.range ≃* Γ from MonoidHom.ofInjective + MulEquiv.subgroupCongr.",
-      "injective_of_prime_card: nontrivial hom out of a prime-order group is injective (ker ∣ p ⟹ ⊥ or ⊤). Capstone semidirectProductIso_of_nontrivial_range_eq combines it with the range-iso."
+      "injective_of_prime_card: nontrivial hom out of a prime-order group is injective (ker ∣ p ⟹ ⊥ or ⊤). Capstone semidirectProductIso_of_nontrivial_range_eq combines it with the range-iso.",
+      "subgroup_eq_powMonoidHom_ker in LagrangeTheoremOQ01OQ01OQ02.lean (subgroup of finite cyclic group = its order's torsion subgroup)",
+      "subgroup_eq_of_card_eq (uniqueness of subgroups of given order in a cyclic group)",
+      "range_eq_of_nontrivial_prime_card (common range of nontrivial prime-order maps into a cyclic group)",
+      "semidirectProductIso_of_nontrivial_into_cyclic (hypothesis-free capstone for cyclic Aut)"
     ],
     "insights": [
       "Mathlib mulEquivOfCyclicCardEq (Cyclic.lean:787) upgrades IsCyclic-level classification to genuine MulEquiv from equal Nat.card — short but is the count→isomorphism step",
@@ -48,7 +52,8 @@
       "BLOCKER: parent chain Proofs.SylowTheoremOQ01 → LagrangeTheoremOQ01OQ01 does NOT compile on Mathlib v4.26.0 — uses removed/renamed names Nat.Prime.eq_of_dvd_of_prime and orderOf_eq_one_iff_eq_one (confirmed absent from Mathlib source; 14 deterministic errors). The parent entry is marked verified but is stale → Mechanic repair needed. This file therefore imports ONLY Mathlib and delivers the abelian case independently.",
       "Mathlib SemidirectProduct.congr/map already give the bare precomposition congruence — the real content for non-abelian pq uniqueness is RANGE UNIQUENESS of the action map, not the congruence itself.",
       "MonoidHom.ofInjective (NOT MulEquiv.ofInjective) : G ≃* f.range; coe lemmas MonoidHom.ofInjective_apply and MonoidHom.apply_ofInjective_symm. Subgroup.eq_bot_of_card_eq needs dot notation f.ker.eq_bot_of_card_eq.",
-      "Non-abelian uniqueness now reduced to two standard facts: (1) internal recognition G ≃* ℤ/q ⋊ ℤ/p (Mathlib lacks normal-complement ⟹ internal semidirect), (2) all nontrivial ℤ/p → Aut(ℤ/q) share the unique order-p subgroup of cyclic Aut(ℤ/q)."
+      "Non-abelian uniqueness now reduced to two standard facts: (1) internal recognition G ≃* ℤ/q ⋊ ℤ/p (Mathlib lacks normal-complement ⟹ internal semidirect), (2) all nontrivial ℤ/p → Aut(ℤ/q) share the unique order-p subgroup of cyclic Aut(ℤ/q).",
+      "Common-range fact PROVED (Part VII): two nontrivial homs from a prime-order group into a finite CYCLIC target have equal range, via uniqueness of subgroups of given order in a cyclic group (every order-d subgroup = (powMonoidHom d).ker, the d-torsion). This discharges fact (2) of Part VI's capstone; new hypothesis-free capstone semidirectProductIso_of_nontrivial_into_cyclic needs only [IsCyclic (MulAut N)]."
     ],
     "mathlibGaps": [
       "No Mathlib lemma recognizing an internal semidirect product from a normal subgroup + complement (needed for nonabelian uniqueness)",

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Part VII closes the 'common range' standard fact (fact 2 of Part VI). Non-abelian pq uniqueness now reduced to a SINGLE remaining gap: internal recognition (every non-cyclic order-pq group is an internal semidirect product), a Mathlib normal-complement gap. File: 22 thm, 2 def, 0 sorry, 0 axiom, verified.",
+    "progressSummary": "PROGRESS: Parts VII (common range) + VIII (internal recognition) close BOTH standard facts Part VI left open for non-abelian pq-uniqueness. exists_internalSemidirect_of_card_pq gives G≃*Q⋊P; common-range pins the action's range. Only residual: the conjugation action is nontrivial in the non-cyclic case (else G cyclic). File: 23 thm, 2 def, 0 sorry, 0 axiom, verified.",
     "builtItems": [
       "pq_abelian_isCyclic (LagrangeTheoremOQ01OQ01OQ02.lean): any CommGroup of order pq is cyclic (no divisibility hyp) via Cauchy exists_prime_orderOf_dvd_card + Commute.orderOf_mul_eq_mul_orderOf_of_coprime + isCyclic_of_orderOf_eq_card",
       "pq_abelian_iso, pq_abelian_iso_zmod: any two abelian order-pq groups isomorphic, each ≅ Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq + zmodCyclicMulEquiv",
@@ -42,7 +42,8 @@
       "subgroup_eq_powMonoidHom_ker in LagrangeTheoremOQ01OQ01OQ02.lean (subgroup of finite cyclic group = its order's torsion subgroup)",
       "subgroup_eq_of_card_eq (uniqueness of subgroups of given order in a cyclic group)",
       "range_eq_of_nontrivial_prime_card (common range of nontrivial prime-order maps into a cyclic group)",
-      "semidirectProductIso_of_nontrivial_into_cyclic (hypothesis-free capstone for cyclic Aut)"
+      "semidirectProductIso_of_nontrivial_into_cyclic (hypothesis-free capstone for cyclic Aut)",
+      "exists_internalSemidirect_of_card_pq in LagrangeTheoremOQ01OQ01OQ02.lean (G of order pq ≃* internal Q⋊P, verified 0-axiom)"
     ],
     "insights": [
       "Mathlib mulEquivOfCyclicCardEq (Cyclic.lean:787) upgrades IsCyclic-level classification to genuine MulEquiv from equal Nat.card — short but is the count→isomorphism step",
@@ -53,7 +54,8 @@
       "Mathlib SemidirectProduct.congr/map already give the bare precomposition congruence — the real content for non-abelian pq uniqueness is RANGE UNIQUENESS of the action map, not the congruence itself.",
       "MonoidHom.ofInjective (NOT MulEquiv.ofInjective) : G ≃* f.range; coe lemmas MonoidHom.ofInjective_apply and MonoidHom.apply_ofInjective_symm. Subgroup.eq_bot_of_card_eq needs dot notation f.ker.eq_bot_of_card_eq.",
       "Non-abelian uniqueness now reduced to two standard facts: (1) internal recognition G ≃* ℤ/q ⋊ ℤ/p (Mathlib lacks normal-complement ⟹ internal semidirect), (2) all nontrivial ℤ/p → Aut(ℤ/q) share the unique order-p subgroup of cyclic Aut(ℤ/q).",
-      "Common-range fact PROVED (Part VII): two nontrivial homs from a prime-order group into a finite CYCLIC target have equal range, via uniqueness of subgroups of given order in a cyclic group (every order-d subgroup = (powMonoidHom d).ker, the d-torsion). This discharges fact (2) of Part VI's capstone; new hypothesis-free capstone semidirectProductIso_of_nontrivial_into_cyclic needs only [IsCyclic (MulAut N)]."
+      "Common-range fact PROVED (Part VII): two nontrivial homs from a prime-order group into a finite CYCLIC target have equal range, via uniqueness of subgroups of given order in a cyclic group (every order-d subgroup = (powMonoidHom d).ker, the d-torsion). This discharges fact (2) of Part VI's capstone; new hypothesis-free capstone semidirectProductIso_of_nontrivial_into_cyclic needs only [IsCyclic (MulAut N)].",
+      "Internal recognition PROVED (Part VIII): every group of order pq (p<q) is ≃* an internal semidirect product Q⋊P of its Sylow subgroups (Q normal Sylow-q, |Q|=q; P Sylow-p, |P|=p), via Mathlib's SemidirectProduct.mulEquivSubgroup + isComplement'_of_coprime + pq_card_sylow_one (swapped primes give q-Sylow normal since q>p). This was the 'Mathlib gap' fact (1) of Part VI — Mathlib DID have mulEquivSubgroup. Both standard facts of Part VI now closed; only residual is nontriviality of the action in the non-cyclic case."
     ],
     "mathlibGaps": [
       "No Mathlib lemma recognizing an internal semidirect product from a normal subgroup + complement (needed for nonabelian uniqueness)",


### PR DESCRIPTION
## Summary
Research session for `lagrange-theorem-oq-01-oq-01-oq-02` (isomorphism uniqueness of groups of order `pq`). Adds **Part VII** and **Part VIII**, which together **close both** of the "documented standard facts" Part VI left open for full non-abelian `pq`-uniqueness.

## Progress — all fully verified (0-axiom), in `Proofs/LagrangeTheoremOQ01OQ01OQ02.lean`

### Part VII — Common range (fact 2)
- `subgroup_eq_powMonoidHom_ker` — in a finite cyclic group, any subgroup `H` equals the `(Nat.card H)`-torsion subgroup `(powMonoidHom (Nat.card H)).ker`, the unique subgroup of that order.
- `subgroup_eq_of_card_eq` — uniqueness of subgroups of given order in a cyclic group.
- `range_eq_of_nontrivial_prime_card` — two nontrivial homs from a prime-order group into a finite cyclic group have equal range.
- `semidirectProductIso_of_nontrivial_into_cyclic` — hypothesis-free capstone: when `Aut N` is finite cyclic, any two nontrivial prime-order action maps give isomorphic semidirect products.

### Part VIII — Internal recognition (fact 1)
- `exists_internalSemidirect_of_card_pq` — for primes `p < q` with `|G| = pq`, `G` is `≃*` an internal semidirect product `Q ⋊ P` of its Sylow subgroups (`Q` the **normal** Sylow `q`-subgroup, `|Q| = q`; `P` Sylow `p`, `|P| = p`).

## Findings
- The previously-flagged "Mathlib gap" for internal recognition does **not** exist: Mathlib provides `SemidirectProduct.mulEquivSubgroup` (normal subgroup + complement ⟹ internal semidirect product). Combined with `Subgroup.isComplement'_of_coprime` and the file's own `pq_card_sylow_one` (reused with primes swapped — `q ∤ (p-1)` is automatic for `p < q`), recognition assembles cleanly.
- The d-torsion `{x | xᵈ = 1}` is a packaged `Subgroup` (kernel of `powMonoidHom d`), so cyclic-subgroup uniqueness needs no hand-built torsion subgroup (`IsCyclic.card_powMonoidHom_ker`).
- `IsCyclic.commGroup` is a `def` reusing the ambient `Group`, so `letI := IsCyclic.commGroup` introduces `powMonoidHom` with no instance diamond.

## Verification
- Builds clean (host `lake env lean`, exit 0).
- `#print axioms` on all 5 new theorems: only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `ofReduceBool`.
- File: **23 theorems, 2 defs, 0 sorries, 0 axioms**.

## Status
**Outcome**: progress (verified). Both Part VI standard facts (common range + internal recognition) are now backed by verified lemmas. The only residual mathematical input for *full* non-abelian uniqueness is that the conjugation action is **nontrivial** in the non-cyclic case (a trivial action would make `G ≅ Q × P` cyclic) — a clean next step.

🤖 Generated by researcher-1