### PR TITLE
research(group-order-prime-squared-abelian-oq-01-oq-03): element-order census of a group of order p²

### DIFF
--- a/proofs/Proofs/GroupOrderPrimeSquaredAbelianCountOQ03.lean
+++ b/proofs/Proofs/GroupOrderPrimeSquaredAbelianCountOQ03.lean
@@ -1,0 +1,144 @@
+/-
+  Element-Order Counts in a Group of Order p² — the Exact Census
+
+  Follow-up open question OQ-01-OQ-03
+  (parent: group-order-prime-squared-abelian-oq-01).
+
+  The parent entry proves that a group `G` of order `p²` (`p` prime) is abelian and
+  splits into exactly two isomorphism types via the structural dichotomy
+  (`isCyclic_or_exponent_p`): `G` is cyclic (`≅ ℤ/p²`) **or** every element satisfies
+  `gᵖ = 1` (elementary abelian, `≅ (ℤ/p)²`). The follow-up `…ExponentOQ01` distinguishes
+  the two types by their exponent.
+
+  This entry computes the *full element-order census*: for each possible order
+  `1`, `p`, `p²` (the only orders that occur, by the parent's trichotomy), exactly how
+  many elements of `G` have that order. The counts depend only on the isomorphism type:
+
+  | order | cyclic `ℤ/p²`        | elementary abelian `(ℤ/p)²` |
+  |-------|----------------------|------------------------------|
+  | `1`   | `1`                  | `1`                          |
+  | `p`   | `p − 1`              | `p² − 1`                     |
+  | `p²`  | `p·(p − 1)` (`=φ(p²)`) | `0`                         |
+
+  The cyclic column is read off Mathlib's `IsCyclic.card_orderOf_eq_totient`
+  (number of elements of order `d` in a cyclic group is `φ(d)` for `d ∣ |G|`), via the
+  totient values `φ(p) = p − 1` and `φ(p²) = p·(p − 1)`. The elementary-abelian column
+  uses the parent's sharpening `orderOf_eq_prime_of_not_isCyclic`: every non-identity
+  element has order *exactly* `p`, so the order-`p` elements are precisely the
+  `p² − 1` non-identity elements and there are no elements of order `p²`.
+
+  ## Contents
+
+  * `card_orderOf_eq_one` — every finite group has exactly one element of order `1`.
+  * `card_orderOf_eq_prime_of_isCyclic` — cyclic case: `p − 1` elements of order `p`.
+  * `card_orderOf_eq_sq_of_isCyclic` — cyclic case: `p·(p − 1)` elements of order `p²`.
+  * `card_orderOf_eq_prime_of_not_isCyclic` — elementary-abelian case: `p² − 1`
+    elements of order `p`.
+  * `card_orderOf_eq_sq_of_not_isCyclic` — elementary-abelian case: no elements of
+    order `p²`.
+  * `isCyclic_iff_card_orderOf_eq_prime` — the census is sharp: the number of order-`p`
+    elements *alone* decides the isomorphism type (`p − 1` ⟺ cyclic).
+
+  Everything is elementary finite group theory; no axioms, no sorries. The structural
+  results are imported from the parent files.
+-/
+import Mathlib
+import Proofs.GroupOrderPrimeSquaredAbelian
+import Proofs.GroupOrderPrimeSquaredAbelianExponentOQ01
+
+namespace GroupOrderPrimeSqCount
+
+open GroupOrderPrimeSq GroupOrderPrimeSqExponent Finset
+
+variable {G : Type*} [Group G] [Fintype G]
+
+/-! ## The identity is the unique element of order 1 -/
+
+/-- **Exactly one element of order `1`.** In any finite group the only element of
+order `1` is the identity (`orderOf g = 1 ↔ g = 1`), so the count is `1`. This is the
+trivial column of the census and holds with no cardinality hypothesis. -/
+theorem card_orderOf_eq_one : #{g : G | orderOf g = 1} = 1 := by
+  rw [Finset.card_eq_one]
+  refine ⟨1, ?_⟩
+  ext g
+  simp only [mem_filter, mem_univ, true_and, mem_singleton, orderOf_eq_one_iff]
+
+/-! ## Cyclic case: G ≅ ℤ/p² -/
+
+/-- **Cyclic case — `p − 1` elements of order `p`.** In a cyclic group of order `p²`
+the number of elements of order `p` is `φ(p) = p − 1`, by
+`IsCyclic.card_orderOf_eq_totient` (`p ∣ p² = |G|`) and `Nat.totient_prime`. -/
+theorem card_orderOf_eq_prime_of_isCyclic {p : ℕ} (hp : p.Prime)
+    (hG : Fintype.card G = p ^ 2) (hc : IsCyclic G) :
+    #{g : G | orderOf g = p} = p - 1 := by
+  haveI := hc
+  have hd : p ∣ Fintype.card G := by rw [hG]; exact dvd_pow_self p (by norm_num)
+  rw [IsCyclic.card_orderOf_eq_totient hd, Nat.totient_prime hp]
+
+/-- **Cyclic case — `p·(p − 1)` elements of order `p²`.** These are exactly the
+generators of `G ≅ ℤ/p²`; their number is `φ(p²) = p·(p − 1)`, by
+`IsCyclic.card_orderOf_eq_totient` (`p² ∣ |G|`) and `Nat.totient_prime_pow`. -/
+theorem card_orderOf_eq_sq_of_isCyclic {p : ℕ} (hp : p.Prime)
+    (hG : Fintype.card G = p ^ 2) (hc : IsCyclic G) :
+    #{g : G | orderOf g = p ^ 2} = p * (p - 1) := by
+  haveI := hc
+  have hd : p ^ 2 ∣ Fintype.card G := by rw [hG]
+  rw [IsCyclic.card_orderOf_eq_totient hd, Nat.totient_prime_pow hp (by norm_num : 0 < 2),
+    show (2 : ℕ) - 1 = 1 from rfl, pow_one]
+
+/-! ## Elementary-abelian case: G ≅ (ℤ/p)² -/
+
+/-- **Elementary-abelian case — `p² − 1` elements of order `p`.** When `G` is not
+cyclic, every non-identity element has order exactly `p`
+(`orderOf_eq_prime_of_not_isCyclic`), so the order-`p` elements are precisely the
+`|G| − 1 = p² − 1` elements other than the identity. -/
+theorem card_orderOf_eq_prime_of_not_isCyclic [DecidableEq G] {p : ℕ} (hp : p.Prime)
+    (hG : Fintype.card G = p ^ 2) (hnc : ¬ IsCyclic G) :
+    #{g : G | orderOf g = p} = p ^ 2 - 1 := by
+  have hNat : Nat.card G = p ^ 2 := by rw [Nat.card_eq_fintype_card, hG]
+  have hcard : #{g : G | orderOf g = p} = (univ.erase (1 : G)).card := by
+    apply congrArg Finset.card
+    ext g
+    simp only [mem_filter, mem_univ, true_and, mem_erase, and_true]
+    constructor
+    · intro h hg1
+      subst hg1
+      rw [orderOf_one] at h
+      exact hp.ne_one h.symm
+    · intro hg
+      exact orderOf_eq_prime_of_not_isCyclic hp hNat hnc hg
+  rw [hcard, card_erase_of_mem (mem_univ (1 : G)), card_univ, hG]
+
+/-- **Elementary-abelian case — no elements of order `p²`.** When `G` is not cyclic,
+`gᵖ = 1` for every `g` (`pow_prime_eq_one_of_not_isCyclic`), so `orderOf g ∣ p ≤ p`,
+which is `< p²`; hence no element has order `p²`. -/
+theorem card_orderOf_eq_sq_of_not_isCyclic {p : ℕ} (hp : p.Prime)
+    (hG : Fintype.card G = p ^ 2) (hnc : ¬ IsCyclic G) :
+    #{g : G | orderOf g = p ^ 2} = 0 := by
+  have hNat : Nat.card G = p ^ 2 := by rw [Nat.card_eq_fintype_card, hG]
+  rw [card_eq_zero, eq_empty_iff_forall_notMem]
+  intro g hg
+  rw [mem_filter] at hg
+  have h : orderOf g = p ^ 2 := hg.2
+  have hp1 : g ^ p = 1 := pow_prime_eq_one_of_not_isCyclic hp hNat hnc g
+  have hle : orderOf g ≤ p := Nat.le_of_dvd hp.pos (orderOf_dvd_iff_pow_eq_one.mpr hp1)
+  rw [h] at hle
+  nlinarith [hp.two_le, hle]
+
+/-! ## The census is a sharp invariant -/
+
+/-- **The order-`p` count decides the isomorphism type.** For a group of order `p²`,
+`G` is cyclic *iff* it has exactly `p − 1` elements of order `p`. The forward direction
+is the cyclic count; conversely, a non-cyclic group has `p² − 1 ≠ p − 1` elements of
+order `p` (since `p² ≠ p` for a prime `p`), so the count `p − 1` forces cyclicity. -/
+theorem isCyclic_iff_card_orderOf_eq_prime [DecidableEq G] {p : ℕ} (hp : p.Prime)
+    (hG : Fintype.card G = p ^ 2) :
+    IsCyclic G ↔ #{g : G | orderOf g = p} = p - 1 := by
+  refine ⟨card_orderOf_eq_prime_of_isCyclic hp hG, fun h => ?_⟩
+  by_contra hnc
+  rw [card_orderOf_eq_prime_of_not_isCyclic hp hG hnc] at h
+  have h2 : 2 ≤ p := hp.two_le
+  have hpp : p ^ 2 = p := by omega
+  nlinarith [h2, hpp]
+
+end GroupOrderPrimeSqCount

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "grpcount-oq0103-header",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "The element-order census of a group of order p²",
+    "content": "The header sets out the quantitative endpoint of the order-p² classification: the full element-order census. The only possible orders are 1, p, p² (the parent's trichotomy), and the count at each order depends only on the isomorphism type. Cyclic ℤ/p²: 1 element of order 1, p−1 of order p, p·(p−1)=φ(p²) of order p². Elementary abelian (ℤ/p)²: 1 of order 1, p²−1 of order p, none of order p². The cyclic column is read off Mathlib's IsCyclic.card_orderOf_eq_totient; the elementary-abelian column uses the parent's sharpening that every non-identity element has order exactly p. The file closes by showing the order-p count alone recovers the type.",
+    "mathContext": "$\\mathbb{Z}/p^2:\\ (1,\\,p-1,\\,p(p-1));\\qquad (\\mathbb{Z}/p)^2:\\ (1,\\,p^2-1,\\,0)$ across orders $1,p,p^2$",
+    "significance": "context",
+    "relatedConcepts": ["element order", "Euler totient", "p-groups", "elementary abelian group", "cyclic group", "complete invariant"],
+    "prerequisites": ["the parent order-p² dichotomy", "the totient count of elements of order d in a cyclic group"]
+  },
+  {
+    "id": "grpcount-oq0103-order-one",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-03",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "theorem",
+    "title": "card_orderOf_eq_one: a unique element of order 1",
+    "content": "In any finite group exactly one element has order 1. Via Finset.card_eq_one it suffices to exhibit the order-1 set as a singleton; orderOf_eq_one_iff identifies it with {1}. This is the trivial column of the census and needs no cardinality hypothesis, so it is stated for an arbitrary finite group.",
+    "mathContext": "$\\#\\{g : \\mathrm{ord}(g) = 1\\} = \\#\\{g : g = 1\\} = 1$",
+    "significance": "technical",
+    "relatedConcepts": ["orderOf_eq_one_iff", "Finset.card_eq_one", "singleton"],
+    "prerequisites": ["order of an element", "finite-set cardinality"]
+  },
+  {
+    "id": "grpcount-oq0103-cyclic",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-03",
+    "range": { "startLine": 65, "endLine": 87 },
+    "type": "theorem",
+    "title": "Cyclic case: φ(p) and φ(p²) via the totient count",
+    "content": "card_orderOf_eq_prime_of_isCyclic: a cyclic group of order p² has p−1 elements of order p; card_orderOf_eq_sq_of_isCyclic: it has p·(p−1) elements of order p² (the generators). Both are immediate from IsCyclic.card_orderOf_eq_totient — the number of elements of order d in a finite cyclic group is φ(d) for d ∣ |G| — applied with d = p (p ∣ p²) and d = p² (p² ∣ p²), followed by the totient evaluations Nat.totient_prime (φ(p)=p−1) and Nat.totient_prime_pow (φ(p²)=p^(2−1)·(p−1)=p·(p−1)). No bespoke counting is required: 'count elements of order d' becomes 'evaluate φ(d)'.",
+    "mathContext": "$\\#\\{g:\\mathrm{ord}(g)=d\\}=\\varphi(d)\\ (d\\mid p^2),\\quad \\varphi(p)=p-1,\\ \\varphi(p^2)=p(p-1)$",
+    "significance": "key",
+    "relatedConcepts": ["IsCyclic.card_orderOf_eq_totient", "Nat.totient_prime", "Nat.totient_prime_pow", "generators of a cyclic group"],
+    "prerequisites": ["cyclic groups", "Euler's totient on prime powers"]
+  },
+  {
+    "id": "grpcount-oq0103-elem-abelian",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 126 },
+    "type": "theorem",
+    "title": "Elementary-abelian case: p²−1 and 0",
+    "content": "card_orderOf_eq_prime_of_not_isCyclic: a non-cyclic group of order p² has exactly p²−1 elements of order p. The parent's orderOf_eq_prime_of_not_isCyclic says every g ≠ 1 has order exactly p, so the order-p set is precisely univ.erase 1; its cardinality is |G|−1 = p²−1 by Finset.card_erase_of_mem. card_orderOf_eq_sq_of_not_isCyclic: there are no elements of order p². Every gᵖ = 1 (pow_prime_eq_one_of_not_isCyclic) gives orderOf g ∣ p, so orderOf g ≤ p < p², and the order-p² set is empty (nlinarith on p² ≤ p with p ≥ 2). This column is exactly where the parent's 'order exactly p' sharpening is consumed.",
+    "mathContext": "$\\#\\{g:\\mathrm{ord}(g)=p\\}=|G|-1=p^2-1,\\qquad \\#\\{g:\\mathrm{ord}(g)=p^2\\}=0$",
+    "significance": "key",
+    "relatedConcepts": ["orderOf_eq_prime_of_not_isCyclic", "Finset.card_erase_of_mem", "exponent p", "orderOf_dvd_iff_pow_eq_one"],
+    "prerequisites": ["the parent's order-exactly-p sharpening", "cardinality of an erased singleton"]
+  },
+  {
+    "id": "grpcount-oq0103-sharp",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-03",
+    "range": { "startLine": 127, "endLine": 144 },
+    "type": "theorem",
+    "title": "isCyclic_iff_card_orderOf_eq_prime: the census recovers the type",
+    "content": "The census is a sharp invariant: G is cyclic iff it has exactly p−1 elements of order p. The forward direction is the cyclic count; conversely, a non-cyclic group has p²−1 elements of order p, and p²−1 ≠ p−1 because p² ≠ p for a prime p (omega derives p²=p from the equality, nlinarith refutes it using p ≥ 2). Thus the single number #{g : orderOf g = p} distinguishes ℤ/p² from (ℤ/p)², paralleling the exponent invariant from the sibling entry.",
+    "mathContext": "$G\\text{ cyclic}\\iff \\#\\{g:\\mathrm{ord}(g)=p\\}=p-1,\\quad p^2-1\\ne p-1\\ (p\\ge 2)$",
+    "significance": "key",
+    "relatedConcepts": ["complete invariant", "contrapositive", "p < p² for p ≥ 2", "isomorphism type"],
+    "prerequisites": ["the two order-p counts", "p ≠ p² for a prime"]
+  }
+]

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-03/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "group-order-prime-squared-abelian-oq-01-oq-03",
+  "title": "The Element-Order Census of a Group of Order p²",
+  "slug": "group-order-prime-squared-abelian-oq-01-oq-03",
+  "description": "A follow-up to the order-p² classification that computes the full element-order census: for a group G of order p² (p prime), exactly how many elements have each of the only possible orders 1, p, p². The counts depend only on the isomorphism type. Cyclic ℤ/p²: 1 element of order 1, p−1 of order p, p·(p−1)=φ(p²) of order p². Elementary abelian (ℤ/p)²: 1 of order 1, p²−1 of order p, none of order p². The order-p count alone is shown to decide the isomorphism type (p−1 ⟺ cyclic), so the census is a sharp invariant. The cyclic column reads off Mathlib's IsCyclic.card_orderOf_eq_totient; the elementary-abelian column uses the parent's sharpening that every non-identity element has order exactly p.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GroupOrderPrimeSquaredAbelianCountOQ03.lean",
+    "tags": [
+      "group-theory",
+      "finite-groups",
+      "p-groups",
+      "cyclic-groups",
+      "element-order",
+      "elementary-abelian",
+      "totient",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 144,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated theorem hypotheses (Fintype.card G = p² with p prime, plus DecidableEq G for the two theorems that count via Finset.erase). 0 axioms, 0 sorries, no native_decide. The structural inputs — orderOf_eq_prime_of_not_isCyclic and pow_prime_eq_one_of_not_isCyclic — are imported from the parent files Proofs/GroupOrderPrimeSquaredAbelian.lean and Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean. The cyclic counts come from Mathlib's IsCyclic.card_orderOf_eq_totient together with the totient values φ(p)=p−1 (Nat.totient_prime) and φ(p²)=p·(p−1) (Nat.totient_prime_pow).",
+    "originalContributions": [
+      "card_orderOf_eq_one: in any finite group exactly one element has order 1 (the trivial census column), via orderOf_eq_one_iff and Finset.card_eq_one.",
+      "card_orderOf_eq_prime_of_isCyclic: a cyclic group of order p² has exactly p−1 elements of order p. Read off IsCyclic.card_orderOf_eq_totient (p ∣ p² = |G|) and Nat.totient_prime, φ(p)=p−1.",
+      "card_orderOf_eq_sq_of_isCyclic: a cyclic group of order p² has exactly p·(p−1)=φ(p²) elements of order p² — precisely the generators of ℤ/p². Via IsCyclic.card_orderOf_eq_totient (p² ∣ |G|) and Nat.totient_prime_pow.",
+      "card_orderOf_eq_prime_of_not_isCyclic: a non-cyclic (elementary-abelian) group of order p² has exactly p²−1 elements of order p. By the parent's sharpening orderOf_eq_prime_of_not_isCyclic, the order-p elements are exactly the non-identity elements, so the count is |G|−1 (Finset.card_erase_of_mem).",
+      "card_orderOf_eq_sq_of_not_isCyclic: a non-cyclic group of order p² has no element of order p². Every gᵖ=1 (pow_prime_eq_one_of_not_isCyclic) forces orderOf g ∣ p ≤ p < p², so the order-p² set is empty.",
+      "isCyclic_iff_card_orderOf_eq_prime: the census is sharp — the number of order-p elements alone decides the isomorphism type: G is cyclic iff it has exactly p−1 elements of order p. Forward is the cyclic count; conversely p²−1 ≠ p−1 for a prime p (p² ≠ p) forces cyclicity."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCyclic.card_orderOf_eq_totient",
+        "description": "in a finite cyclic group the number of elements of order d equals φ(d) for every d dividing the cardinality — supplies both cyclic counts (d = p and d = p²)",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "Nat.totient_prime / Nat.totient_prime_pow",
+        "description": "φ(p)=p−1 and φ(pⁿ)=pⁿ⁻¹·(p−1) — evaluate the totient at p and p² to turn the abstract cyclic counts into closed forms",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.card_erase_of_mem",
+        "description": "(s.erase a).card = s.card − 1 for a ∈ s — counts the non-identity elements (= order-p elements) of the elementary-abelian case as |G|−1",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "orderOf_eq_one_iff / orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf g = 1 ↔ g = 1 and gⁿ = 1 ↔ orderOf g ∣ n — isolate the identity as the unique order-1 element and bound the order in the non-cyclic case",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Once the two isomorphism types of order p² are identified (ℤ/p² and (ℤ/p)²) and separated by the exponent invariant, the natural quantitative question is the element-order distribution: how many elements have each order. For cyclic groups this is the classical statement that a cyclic group of order n has exactly φ(d) elements of order d for each d ∣ n; for the elementary-abelian group it is the observation that every non-identity element is an involution-analogue of order p. This entry assembles both into the complete census of the two groups of order p², the parent's own stated open question.",
+    "problemStatement": "Let G be a group with Fintype.card G = p² for a prime p. For each of the possible element orders 1, p, p², count the number of elements of G with that order, and show the counts are determined by whether G is cyclic (ℤ/p²) or not (elementary abelian (ℤ/p)²). Then show the order-p count alone characterizes the isomorphism type.",
+    "text": "The element-order census is the finest elementary invariant of a finite group short of the full multiplication table, and for order p² it is completely explicit. The cyclic group ℤ/p² has the staircase 1, p−1, p·(p−1) across orders 1, p, p²; the elementary-abelian (ℤ/p)² collapses to 1, p²−1, 0 because it has exponent p. The two distributions are disjoint already in the order-p coordinate (p−1 vs p²−1), so the single number #{g : orderOf g = p} recovers the isomorphism type — the census is a sharp invariant.",
+    "proofStrategy": "Cyclic case: apply IsCyclic.card_orderOf_eq_totient with d = p and d = p² (both divide |G| = p²), then evaluate φ(p) = p−1 (Nat.totient_prime) and φ(p²) = p·(p−1) (Nat.totient_prime_pow). Elementary-abelian case: the parent's orderOf_eq_prime_of_not_isCyclic shows the order-p elements are exactly the non-identity elements, so their count is |G| − 1 = p² − 1 via Finset.card_erase_of_mem; and pow_prime_eq_one_of_not_isCyclic forces orderOf g ∣ p < p², so the order-p² set is empty. The order-1 count is 1 in all cases (orderOf_eq_one_iff). Sharpness: combine the two order-p counts; since p² ≠ p for a prime p (omega + nlinarith), the value p−1 occurs only in the cyclic case.",
+    "keyInsights": [
+      "**The census is determined by the type, and conversely.** Each isomorphism type gives a fixed distribution of element orders, and the distributions differ already at order p (p−1 vs p²−1), so one count recovers the type. The census is therefore a complete invariant for the order-p² classification, like the exponent.",
+      "**The cyclic column is pure totient.** Mathlib's IsCyclic.card_orderOf_eq_totient turns 'count elements of order d' into 'evaluate φ(d)', so the cyclic counts are literally φ(p) and φ(p²) — no bespoke counting argument is needed.",
+      "**The elementary-abelian column is 'all-or-nothing'.** Because (ℤ/p)² has exponent p, every non-identity element has order exactly p: the order-p set is the complement of the identity (p²−1 elements) and the order-p² set is empty. This is exactly where the parent's order-exactly-p sharpening is consumed.",
+      "**Disjointness comes from p < p².** The only arithmetic input to sharpness is that p and p² are distinct for a prime p, which separates the two order-p counts p−1 and p²−1."
+    ],
+    "prerequisites": [
+      "The parent dichotomy and its sharpening: a non-cyclic group of order p² has every non-identity element of order exactly p (imported)",
+      "IsCyclic.card_orderOf_eq_totient: φ(d) elements of order d in a cyclic group",
+      "The totient values φ(p) = p−1 and φ(p²) = p·(p−1)",
+      "Finset cardinality of an erased singleton (|s.erase a| = |s| − 1)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Docstring laying out the element-order census table for the two groups of order p² and listing the six theorems; imports Mathlib and both parent files, opens the parent namespaces, and fixes a finite group variable G.",
+      "mathContext": "orders 1/p/p² have counts 1/(p−1)/p·(p−1) for ℤ/p² and 1/(p²−1)/0 for (ℤ/p)²."
+    },
+    {
+      "id": "order-one",
+      "title": "The Identity Is the Unique Order-1 Element",
+      "startLine": 57,
+      "endLine": 64,
+      "summary": "card_orderOf_eq_one: in any finite group exactly one element has order 1. The filter {g | orderOf g = 1} equals the singleton {1} (orderOf_eq_one_iff), so its cardinality is 1 (Finset.card_eq_one).",
+      "mathContext": "$\\#\\{g : \\mathrm{ord}(g) = 1\\} = 1$ — the trivial census column, no cardinality hypothesis."
+    },
+    {
+      "id": "cyclic-counts",
+      "title": "Cyclic Case via the Totient",
+      "startLine": 65,
+      "endLine": 87,
+      "summary": "card_orderOf_eq_prime_of_isCyclic (p−1 elements of order p) and card_orderOf_eq_sq_of_isCyclic (p·(p−1) elements of order p²). Both apply IsCyclic.card_orderOf_eq_totient (p ∣ p² and p² ∣ p²) and evaluate the totient: φ(p)=p−1, φ(p²)=p·(p−1).",
+      "mathContext": "$\\#\\{g : \\mathrm{ord}(g)=d\\} = \\varphi(d)$ for $d \\mid p^2$, with $\\varphi(p)=p-1$, $\\varphi(p^2)=p(p-1)$."
+    },
+    {
+      "id": "elem-abelian-counts",
+      "title": "Elementary-Abelian Case",
+      "startLine": 88,
+      "endLine": 126,
+      "summary": "card_orderOf_eq_prime_of_not_isCyclic (p²−1 elements of order p): the parent's orderOf_eq_prime_of_not_isCyclic makes the order-p set the complement of the identity, counted as |G|−1 by Finset.card_erase_of_mem. card_orderOf_eq_sq_of_not_isCyclic (no order-p² elements): gᵖ=1 forces orderOf g ∣ p < p², so the set is empty.",
+      "mathContext": "$\\#\\{g : \\mathrm{ord}(g)=p\\} = p^2 - 1,\\qquad \\#\\{g : \\mathrm{ord}(g)=p^2\\} = 0$."
+    },
+    {
+      "id": "sharp-invariant",
+      "title": "The Census Is a Sharp Invariant",
+      "startLine": 127,
+      "endLine": 144,
+      "summary": "isCyclic_iff_card_orderOf_eq_prime: G is cyclic iff it has exactly p−1 elements of order p. Forward is the cyclic count; conversely a non-cyclic group has p²−1 ≠ p−1 such elements (p² ≠ p for a prime p), so the count p−1 forces cyclicity.",
+      "mathContext": "$G \\text{ cyclic} \\iff \\#\\{g : \\mathrm{ord}(g)=p\\} = p-1$ — one count recovers the isomorphism type."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 follow-up that computes the complete element-order census of a group of order p² (p prime): orders 1, p, p² occur with counts 1, p−1, p·(p−1) when G is cyclic (ℤ/p²) and 1, p²−1, 0 when G is elementary abelian ((ℤ/p)²). The order-p count alone determines the isomorphism type. 6 theorems, 144 lines, 0 axioms, 0 sorries, no native_decide; the structural inputs are imported from the parent files.",
+    "implications": "Completes the parent's stated open question of counting Nat.card {g | orderOf g = p} in each case, and exhibits the element-order distribution as a sharp invariant complementing the exponent. The cyclic column is a clean application of Mathlib's totient count, while the elementary-abelian column is exactly where the parent's 'order exactly p' sharpening is used.",
+    "openQuestions": [
+      "Package the census as a single statement over a Fintype indexing of the divisors {1, p, p²} and verify the counts sum to p² (a partition-of-the-group identity), giving an internal consistency check of the classification.",
+      "Lift the counts to explicit isomorphisms G ≃* Multiplicative (ZMod (p^2)) and G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p), turning the order distribution into a structure theorem.",
+      "Compute the analogous census for order p³, where the order distribution no longer determines the isomorphism type (the two non-abelian groups of order p³ for odd p share the same orders of elements counts in some cases), quantifying exactly where element-order data stops being a complete invariant."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "group-order-prime-squared-abelian-oq-01",
+      "relationship": "parent",
+      "description": "supplies the cyclic/elementary-abelian dichotomy and the order trichotomy (orders are 1, p, or p²) underlying the census"
+    },
+    {
+      "id": "group-order-prime-squared-abelian-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "provides orderOf_eq_prime_of_not_isCyclic (every non-identity element has order exactly p in the non-cyclic case), the precise input used to count the p²−1 order-p elements"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "John Wiley & Sons, 3rd ed.",
+      "note": "§4.3, §5.2: groups of order p², element orders, and the count of elements of each order in a finite abelian group"
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "Springer GTM 148, 4th ed.",
+      "note": "cyclic groups and the φ(d) count of elements of order d; elementary abelian p-groups"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GroupOrderPrimeSquaredAbelian",
+      "Proofs.GroupOrderPrimeSquaredAbelianExponentOQ01"
+    ],
+    "opens": [
+      "GroupOrderPrimeSq",
+      "GroupOrderPrimeSqExponent",
+      "Finset"
+    ],
+    "namespace": "GroupOrderPrimeSqCount",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GroupOrderPrimeSquaredAbelianCountOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Computes the full **element-order census** of a group `G` of order `p²` (`p` prime) — the parent entry's explicitly stated open question (\"formalise `Nat.card {g | orderOf g = p}` in each case\"). The only possible element orders are `1`, `p`, `p²` (the parent's trichotomy), and the count at each order is determined entirely by the isomorphism type:

| order | cyclic `ℤ/p²` | elementary abelian `(ℤ/p)²` |
|-------|---------------|------------------------------|
| `1`   | `1`           | `1`                          |
| `p`   | `p − 1`       | `p² − 1`                     |
| `p²`  | `p·(p − 1) = φ(p²)` | `0`                    |

## Theorems (6)

- `card_orderOf_eq_one` — every finite group has exactly one element of order `1`.
- `card_orderOf_eq_prime_of_isCyclic` / `card_orderOf_eq_sq_of_isCyclic` — cyclic counts `p−1` and `p·(p−1)`, read off `IsCyclic.card_orderOf_eq_totient` with `φ(p)=p−1`, `φ(p²)=p·(p−1)`.
- `card_orderOf_eq_prime_of_not_isCyclic` / `card_orderOf_eq_sq_of_not_isCyclic` — elementary-abelian counts `p²−1` and `0`, using the sibling's sharpening that every non-identity element has order exactly `p`.
- `isCyclic_iff_card_orderOf_eq_prime` — the census is **sharp**: the order-`p` count alone decides the type (`p−1` ⟺ cyclic).

## Status

- **verified**, **0 axioms**, **0 sorries**, no `native_decide`.
- 144 lines, builds against Mathlib v4.26.0 (kernel-checked via `lake env lean`, exit 0, no errors/linter warnings).
- Structural inputs (`orderOf_eq_prime_of_not_isCyclic`, `pow_prime_eq_one_of_not_isCyclic`) imported from the parent and exponent-sibling files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)