### PR TITLE
Enrich Chebyshev's Integral Inequality (oq-01-oq-01-oq-01): add annotations + index.ts

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevSumInequalityOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevSumInequalityOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevSumInequalityOq01Oq01Oq01Data: ProofData = {
+  proof: chebyshevSumInequalityOq01Oq01Oq01Proof,
+  annotations: chebyshevSumInequalityOq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-01-oq-01` (continuous Chebyshev inequality).

## Critical fix
The entry was **missing `index.ts`** — without it Vite's `import.meta.glob` cannot discover the proof, so the page renders 'proof not found' on the live site. This PR adds it (plus the annotations).

## Relationship to #28800
A concurrent enricher PR (#28800) adds only `annotations.json` for this same entry and **omits `index.ts`**, so it would not fix the broken page. This PR is self-contained (both files) and strictly supersedes #28800; whichever merges first, the other will need a rebase/close. Recommend merging this one and closing #28800.

## Annotations
8 annotations covering every section, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the discrete→continuous arc, bounded⇒integrable, the nonnegative symmetric double integral, the Fubini four-term expansion, the anti-comonotone reversal, the second-moment/Cauchy–Schwarz bound, and the probability covariance form.

## Verification
- JSON validated; `tsc -b` passes.