### PR TITLE
research(abundant-number-oq-01-oq-01): abundant numbers have lower density ≥ 1/12 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -268,6 +268,7 @@ import Proofs.BallotProblemOQ03OQ01OQ04
 import Proofs.BallotProblemOQ03OQ02
 import Proofs.BallotProblemOQ03OQ03
 import Proofs.BanachFixedPointOQ01
+import Proofs.BanachFixedPointOQ01OQ02
 import Proofs.BanachSteinhausTheoremOQ01
 import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01

--- a/proofs/Proofs/AbundantDensityOQ01.lean
+++ b/proofs/Proofs/AbundantDensityOQ01.lean
@@ -1,0 +1,124 @@
+/-
+  A positive lower bound for the natural density of the abundant numbers.
+
+  A positive integer `n` is *abundant* when the sum of its proper divisors
+  exceeds `n` (equivalently `σ(n) > 2n`); Mathlib calls this `Nat.Abundant`.
+  The companion file `AbundantMultiplesOQ01.lean` proves that the abundant
+  numbers are *closed under positive multiples* and hence *infinite*. This file
+  pushes that qualitative statement to a **quantitative** one: the abundant
+  numbers have *positive lower density*. Concretely, writing
+
+      A(N) = #{ n ∈ (0, N] : n is abundant }
+
+  for the counting function, we show
+
+      ⌊N / 12⌋ ≤ A(N)        for every `N`,                      (counting form)
+      1/12 − 1/N ≤ A(N)/N    for every `N ≥ 1`,                  (ratio form)
+
+  and, as the capstone, that the lower density is at least `1/12`:
+
+      ∀ ε > 0, eventually (in `N → ∞`)  1/12 − ε ≤ A(N)/N.       (density form)
+
+  The mechanism is elementary and avoids the deep Davenport/Erdős theory that the
+  *exact* density of abundant numbers (≈ 0.2476…) requires. Every positive
+  multiple of the smallest abundant number `12` is itself abundant
+  (`AbundantMultiplesOQ01.abundant_of_abundant_dvd` with `Nat.abundant_twelve`),
+  so the multiples of `12` in `(0, N]` — of which there are exactly `⌊N/12⌋`
+  (`Nat.Ioc_filter_dvd_card_eq_div`) — form a subset of the abundant numbers in
+  `(0, N]`. Monotonicity of `Finset.card` under `⊆` gives the counting bound, and
+  the two analytic bounds follow by casting the floor estimate `12·⌊N/12⌋ ≥ N−11`
+  into `ℝ`.
+
+  The result is a genuine sharpening of `infinitely_many_abundant`: infinitude
+  only needs one abundant residue class, whereas a positive *density* lower bound
+  pins down a fixed proportion `1/12` of all integers. The constant `1/12` is not
+  optimal (the true density is larger), but it is unconditional, fully
+  constructive, and axiom-free (no `sorry`, no `axiom`, no `native_decide`).
+-/
+import Mathlib
+import Proofs.AbundantMultiplesOQ01
+
+namespace AbundantDensityOQ01
+
+open Finset
+
+/-- `Nat.Abundant n` unfolds to the decidable comparison `n < ∑ i ∈ properDivisors n, i`,
+so the predicate is decidable; Mathlib does not register the instance, so we supply it
+here to enable filtering. -/
+instance : DecidablePred Nat.Abundant :=
+  fun n => inferInstanceAs (Decidable (n < ∑ i ∈ n.properDivisors, i))
+
+/-- The counting function for abundant numbers: the number of abundant integers
+in the interval `(0, N]`. -/
+def abundantCount (N : ℕ) : ℕ := #{n ∈ Ioc 0 N | n.Abundant}
+
+/-- Within `(0, N]`, every multiple of `12` is abundant, so the multiples of `12`
+form a subset of the abundant numbers. -/
+theorem multiples_subset_abundant (N : ℕ) :
+    {x ∈ Ioc 0 N | (12 ∣ x)} ⊆ {n ∈ Ioc 0 N | n.Abundant} := by
+  intro x hx
+  rw [mem_filter, mem_Ioc] at hx
+  obtain ⟨⟨hx0, hxN⟩, hdvd⟩ := hx
+  rw [mem_filter, mem_Ioc]
+  refine ⟨⟨hx0, hxN⟩, ?_⟩
+  exact AbundantMultiplesOQ01.abundant_of_abundant_dvd Nat.abundant_twelve hdvd hx0
+
+/-- **Counting form.** At least `⌊N/12⌋` of the integers in `(0, N]` are abundant.
+The multiples of `12` in `(0, N]` number exactly `⌊N/12⌋`
+(`Nat.Ioc_filter_dvd_card_eq_div`) and are all abundant, so monotonicity of
+`Finset.card` under `⊆` gives the bound. -/
+theorem div_twelve_le_abundantCount (N : ℕ) : N / 12 ≤ abundantCount N := by
+  have hcard : #{x ∈ Ioc 0 N | (12 ∣ x)} = N / 12 := Nat.Ioc_filter_dvd_card_eq_div N 12
+  rw [← hcard]
+  exact card_le_card (multiples_subset_abundant N)
+
+/-- **Real lower bound on the count.** Casting the floor estimate
+`12·⌊N/12⌋ ≥ N − 11` into `ℝ` turns the counting bound into the clean linear
+inequality `N/12 − 1 ≤ A(N)`. -/
+theorem abundantCount_real_lower (N : ℕ) :
+    (N : ℝ) / 12 - 1 ≤ (abundantCount N : ℝ) := by
+  have hdm : 12 * (N / 12) + N % 12 = N := Nat.div_add_mod N 12
+  have hmod : N % 12 < 12 := Nat.mod_lt N (by norm_num)
+  have h1 : (12 : ℝ) * ((N / 12 : ℕ) : ℝ) + ((N % 12 : ℕ) : ℝ) = (N : ℝ) := by
+    exact_mod_cast hdm
+  have h2 : ((N % 12 : ℕ) : ℝ) < 12 := by exact_mod_cast hmod
+  have hcount : ((N / 12 : ℕ) : ℝ) ≤ (abundantCount N : ℝ) := by
+    exact_mod_cast div_twelve_le_abundantCount N
+  linarith [h1, h2, hcount]
+
+/-- **Ratio form.** For `N ≥ 1` the proportion of abundant numbers in `(0, N]` is
+at least `1/12 − 1/N`. As `N → ∞` the correction `1/N` vanishes, so the abundant
+numbers have *lower density at least `1/12`*. -/
+theorem abundantCount_ratio_lower {N : ℕ} (hN : 0 < N) :
+    (1 : ℝ) / 12 - 1 / N ≤ (abundantCount N : ℝ) / N := by
+  have hNR : (0 : ℝ) < N := by exact_mod_cast hN
+  have hNne : (N : ℝ) ≠ 0 := ne_of_gt hNR
+  rw [le_div_iff₀ hNR]
+  have hcancel : (1 / (N : ℝ)) * N = 1 := one_div_mul_cancel hNne
+  have expand : ((1 : ℝ) / 12 - 1 / N) * N = (N : ℝ) / 12 - 1 := by
+    rw [sub_mul, hcancel]; ring
+  rw [expand]
+  exact abundantCount_real_lower N
+
+/-- **Density form (capstone).** The abundant numbers have lower density at least
+`1/12`: for every `ε > 0`, eventually (as `N → ∞`) the proportion of abundant
+numbers in `(0, N]` exceeds `1/12 − ε`. Equivalently
+`liminf_{N} A(N)/N ≥ 1/12`. The proof feeds the ratio bound `A(N)/N ≥ 1/12 − 1/N`
+the elementary fact that `1/N → 0`. -/
+theorem abundant_lower_density (ε : ℝ) (hε : 0 < ε) :
+    ∀ᶠ N in Filter.atTop, (1 : ℝ) / 12 - ε ≤ (abundantCount N : ℝ) / N := by
+  obtain ⟨M, hM⟩ := exists_nat_gt (1 / ε)
+  rw [Filter.eventually_atTop]
+  refine ⟨max M 1, fun N hN => ?_⟩
+  have hN1 : 1 ≤ N := le_trans (le_max_right M 1) hN
+  have hNM : M ≤ N := le_trans (le_max_left M 1) hN
+  have hN0 : 0 < N := hN1
+  have hNR : (0 : ℝ) < N := by exact_mod_cast hN0
+  have hinvN : 1 / ε < (N : ℝ) := lt_of_lt_of_le hM (by exact_mod_cast hNM)
+  have hNε : 1 < N * ε := (div_lt_iff₀ hε).mp hinvN
+  have h1N : 1 / (N : ℝ) < ε :=
+    (div_lt_iff₀ hNR).mpr (by linarith [hNε, mul_comm ε (N : ℝ)])
+  have hr := abundantCount_ratio_lower hN0
+  linarith [hr, h1N]
+
+end AbundantDensityOQ01

--- a/proofs/Proofs/BanachFixedPointOQ01OQ02.lean
+++ b/proofs/Proofs/BanachFixedPointOQ01OQ02.lean
@@ -1,0 +1,184 @@
+import Mathlib
+
+/-
+# Banach Fixed Point OQ-01-OQ-02: Lipschitz Perturbations of the Identity are Homeomorphisms
+
+## Research Problem: banach-fixed-point-oq-01-oq-02
+
+The parent entry `banach-fixed-point-oq-01` poses (open question #2):
+
+  *Formalize the global Newton/Banach perturbation result: if g is a small
+  Lipschitz perturbation of the identity, then id + g is a homeomorphism
+  (a step toward the inverse function theorem).*
+
+This is the third pillar of the contraction-mapping circle of ideas, alongside the
+quantitative fixed-point theorem (parent OQ-01) and Picard–Lindelöf (sibling
+OQ-01-OQ-01). Where those *find* a fixed point, this entry *inverts a map*.
+
+## Mathematical Content
+
+Let E be a complete normed (additive) group and let g : E → E be Lipschitz with
+constant k < 1. Set
+
+  f(x) = x + g(x).
+
+Then f is a homeomorphism of E onto itself, and its inverse is Lipschitz with the
+sharp constant 1/(1 − k). The three ingredients:
+
+1. **Lower bound (antilipschitz).**
+     ‖f(x) − f(y)‖ ≥ ‖x − y‖ − ‖g(x) − g(y)‖ ≥ (1 − k)‖x − y‖,
+   so f is `AntilipschitzWith (1 − k)⁻¹` — immediately injective, and the bound
+   1/(1 − k) is exactly the Lipschitz constant of f⁻¹.
+
+2. **Surjectivity via the contraction principle.** To solve f(x) = y, i.e.
+   x + g(x) = y, rewrite it as the fixed-point equation x = y − g(x). The map
+   φ_y(x) = y − g(x) is a k-contraction (k < 1), so on the complete space E it has a
+   (unique) fixed point x*, and then f(x*) = y. **This is precisely where the parent
+   Banach fixed-point theorem powers the inverse.**
+
+3. **Upper bound (Lipschitz).** ‖f(x) − f(y)‖ ≤ (1 + k)‖x − y‖, so f is continuous;
+   combined with surjectivity + antilipschitz it is a homeomorphism, and the inverse
+   inherits continuity from the antilipschitz lower bound.
+
+The same computation underlies Hadamard's global inverse function theorem and the
+local inverse function theorem (where g is the nonlinear remainder of f after
+subtracting its derivative); Mathlib's `ApproximatesLinearOn` development is the
+abstract linear-model version of exactly this argument.
+
+## References
+- S. Banach (1922): contraction mapping principle
+- J. Hadamard (1906): global inverse function theorems
+- Mathlib: `AntilipschitzWith.add_lipschitzWith`, `ContractingWith.fixedPoint`,
+  `AntilipschitzWith.to_rightInverse`, `Equiv.ofBijective`
+-/
+
+open scoped NNReal
+
+namespace BanachFixedPointOQ01OQ02
+
+variable {E : Type*} [NormedAddCommGroup E] {k : ℝ≥0} {g : E → E}
+
+/-- The perturbation of the identity by `g`: `f(x) = x + g(x)`. -/
+def perturbId (g : E → E) : E → E := fun x => x + g x
+
+@[simp] theorem perturbId_apply (g : E → E) (x : E) : perturbId g x = x + g x := rfl
+
+/-! ## Part I: the two-sided Lipschitz estimates -/
+
+/-- **Upper bound.** `f = id + g` is Lipschitz with constant `1 + k`
+    (hence continuous). -/
+theorem perturbId_lipschitz (hg : LipschitzWith k g) :
+    LipschitzWith (1 + k) (perturbId g) :=
+  (LipschitzWith.id.add hg : LipschitzWith (1 + k) fun x => id x + g x)
+
+/-- **Lower bound (antilipschitz).** If `k < 1` then `f = id + g` is
+    `AntilipschitzWith (1 − k)⁻¹`. The constant `1/(1 − k)` is the Lipschitz
+    constant of the inverse. -/
+theorem perturbId_antilipschitz (hg : LipschitzWith k g) (hk : k < 1) :
+    AntilipschitzWith (1 - k)⁻¹ (perturbId g) := by
+  have hK : k < (1 : ℝ≥0)⁻¹ := by rwa [inv_one]
+  have h := (AntilipschitzWith.id (α := E)).add_lipschitzWith hg hK
+  rwa [inv_one] at h
+
+/-- f is injective (consequence of the antilipschitz lower bound). -/
+theorem perturbId_injective (hg : LipschitzWith k g) (hk : k < 1) :
+    Function.Injective (perturbId g) :=
+  (perturbId_antilipschitz hg hk).injective
+
+/-! ## Part II: surjectivity via the contraction principle -/
+
+/-- **Surjectivity.** On a complete space, `f = id + g` is surjective: for every
+    target `y`, the map `x ↦ y − g(x)` is a `k`-contraction (`k < 1`), so it has a
+    fixed point `x*`, and then `f(x*) = x* + g(x*) = y`. This is the Banach
+    fixed-point theorem (parent OQ-01) supplying the inverse image. -/
+theorem perturbId_surjective [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    Function.Surjective (perturbId g) := by
+  haveI : Nonempty E := ⟨0⟩
+  intro y
+  -- φ_y(x) = y − g(x) is a k-contraction
+  have hφ : LipschitzWith k (fun x => y - g x) :=
+    LipschitzWith.of_dist_le_mul fun a b => by
+      have h : dist (y - g a) (y - g b) = dist (g a) (g b) := by
+        rw [dist_eq_norm, dist_eq_norm, show y - g a - (y - g b) = -(g a - g b) by abel,
+          norm_neg]
+      rw [h]; exact hg.dist_le_mul a b
+  have hcon : ContractingWith k (fun x => y - g x) := ⟨hk, hφ⟩
+  -- the fixed point x₀ solves x₀ + g x₀ = y
+  refine ⟨ContractingWith.fixedPoint _ hcon, ?_⟩
+  have hfix : y - g (ContractingWith.fixedPoint _ hcon) = ContractingWith.fixedPoint _ hcon :=
+    hcon.fixedPoint_isFixedPt
+  rw [perturbId_apply]
+  exact (sub_eq_iff_eq_add.mp hfix).symm
+
+/-- **Bijectivity.** On a complete space, `f = id + g` is a bijection. -/
+theorem perturbId_bijective [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    Function.Bijective (perturbId g) :=
+  ⟨perturbId_injective hg hk, perturbId_surjective hg hk⟩
+
+/-! ## Part III: the homeomorphism and the sharp inverse bound -/
+
+/-- The bijection `f = id + g` as an `Equiv`. -/
+noncomputable def perturbIdEquiv [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    E ≃ E :=
+  Equiv.ofBijective (perturbId g) (perturbId_bijective hg hk)
+
+@[simp] theorem perturbIdEquiv_apply [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1)
+    (x : E) : perturbIdEquiv hg hk x = x + g x := rfl
+
+/-- **Sharp inverse bound.** The inverse of `f = id + g` is Lipschitz with constant
+    `1/(1 − k)`: `‖f⁻¹(a) − f⁻¹(b)‖ ≤ (1 − k)⁻¹ ‖a − b‖`. Obtained from the
+    antilipschitz lower bound on `f` and the fact that `f⁻¹` is a right inverse. -/
+theorem perturbIdEquiv_symm_lipschitz [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    LipschitzWith (1 - k)⁻¹ (perturbIdEquiv hg hk).symm :=
+  (perturbId_antilipschitz hg hk).to_rightInverse (perturbIdEquiv hg hk).apply_symm_apply
+
+/-- **Headline.** A Lipschitz perturbation `f = id + g` of the identity, with
+    Lipschitz constant `k < 1` of `g`, is a homeomorphism of the complete normed
+    space `E` onto itself. -/
+noncomputable def perturbIdHomeomorph [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    E ≃ₜ E where
+  toEquiv := perturbIdEquiv hg hk
+  continuous_toFun := (perturbId_lipschitz hg).continuous
+  continuous_invFun := (perturbIdEquiv_symm_lipschitz hg hk).continuous
+
+@[simp] theorem perturbIdHomeomorph_apply [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1)
+    (x : E) : perturbIdHomeomorph hg hk x = x + g x := rfl
+
+/-- The homeomorphism's inverse is Lipschitz with constant `1/(1 − k)`. -/
+theorem perturbIdHomeomorph_symm_lipschitz [CompleteSpace E]
+    (hg : LipschitzWith k g) (hk : k < 1) :
+    LipschitzWith (1 - k)⁻¹ (perturbIdHomeomorph hg hk).symm :=
+  perturbIdEquiv_symm_lipschitz hg hk
+
+/-! ## Part IV: a worked instance on ℝ -/
+
+-- g(x) = (1/2)·sin x is (1/2)-Lipschitz, so x ↦ x + (1/2)·sin x is a homeomorphism of ℝ.
+example : LipschitzWith (1/2 : ℝ≥0) (fun x : ℝ => (1/2 : ℝ) * Real.sin x) := by
+  refine LipschitzWith.of_dist_le_mul fun a b => ?_
+  have hsin := Real.lipschitzWith_sin.dist_le_mul a b
+  simp only [Real.dist_eq, NNReal.coe_one, one_mul] at hsin
+  rw [Real.dist_eq, Real.dist_eq,
+    show (1/2 : ℝ) * Real.sin a - (1/2) * Real.sin b = (1/2) * (Real.sin a - Real.sin b) by ring,
+    abs_mul, abs_of_pos (by norm_num : (0:ℝ) < 1/2)]
+  push_cast
+  nlinarith [hsin, abs_nonneg (a - b), abs_nonneg (Real.sin a - Real.sin b)]
+
+/-! ## Part V: Summary -/
+
+/-- **Banach Fixed Point OQ-01-OQ-02 Summary.** For a complete normed space `E` and
+    `g : E → E` Lipschitz with constant `k < 1`, the perturbation `f = id + g`:
+    (1) is `(1 + k)`-Lipschitz (continuous);
+    (2) is `AntilipschitzWith (1 − k)⁻¹` (in particular injective);
+    (3) is bijective (surjectivity via the contraction principle on `x ↦ y − g x`);
+    (4) is therefore a homeomorphism whose inverse is `(1 − k)⁻¹`-Lipschitz. -/
+theorem banach_oq01_oq02_summary [CompleteSpace E] (hg : LipschitzWith k g) (hk : k < 1) :
+    LipschitzWith (1 + k) (perturbId g) ∧
+    AntilipschitzWith (1 - k)⁻¹ (perturbId g) ∧
+    Function.Bijective (perturbId g) ∧
+    LipschitzWith (1 - k)⁻¹ (perturbIdHomeomorph hg hk).symm :=
+  ⟨perturbId_lipschitz hg,
+   perturbId_antilipschitz hg hk,
+   perturbId_bijective hg hk,
+   perturbIdHomeomorph_symm_lipschitz hg hk⟩
+
+end BanachFixedPointOQ01OQ02

--- a/src/data/proofs/abundant-number-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-01/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "abundant-density-ann-intro",
+    "proofId": "abundant-number-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "A Positive Lower Bound on the Density of Abundant Numbers",
+    "content": "Let $A(N) = \\#\\{n \\in (0, N] : n \\text{ is abundant}\\}$ count the abundant numbers up to $N$. The **natural density** of the abundant numbers is the limit of $A(N)/N$; Davenport (1933) proved it exists, and it is now known to be $\\approx 0.2476$. That exact value is a deep analytic result, but a *positive lower bound* is elementary. Since $12$ is the smallest abundant number and every positive multiple of an abundant number is abundant (closure, from the parent entry), **all multiples of $12$ are abundant** — a proportion $1/12$ of every initial segment. This entry formalizes the resulting bound: the lower density of the abundant numbers is at least $1/12$.",
+    "mathContext": "A single abundant residue class — the multiples of $12$ — already forces density $\\ge 1/12$.",
+    "significance": "key",
+    "prerequisites": [
+      "natural density and counting functions A(N)",
+      "abundant numbers and closure under multiples"
+    ],
+    "relatedConcepts": [
+      "natural density",
+      "abundant numbers",
+      "Davenport density theorem",
+      "counting function"
+    ]
+  },
+  {
+    "id": "abundant-density-ann-count-def",
+    "proofId": "abundant-number-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 56 },
+    "type": "definition",
+    "title": "Counting Abundant Numbers as a Finset Cardinality",
+    "content": "Mathlib's `Nat.Abundant n` unfolds to the decidable comparison $n < \\sum_{d \\in \\mathrm{properDivisors}\\, n} d$, but no `DecidablePred` instance is registered, so we supply one (defeq to that kernel-decidable inequality). With it, the abundant numbers in $(0,N]$ form a `Finset`, and we define\n$$ \\texttt{abundantCount}\\,N := \\#\\{n \\in \\mathrm{Ioc}\\,0\\,N \\mid n.\\mathrm{Abundant}\\}. $$\nKeeping the genuine decidable instance (rather than `Classical.dec`) means the count introduces no choice-based decision procedure and no `native_decide`.",
+    "mathContext": "Abundance is a decidable comparison of divisor sums, so abundant numbers up to N can be counted as `Finset.card`.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Finset.filter and DecidablePred",
+      "Nat.Abundant as a divisor-sum comparison"
+    ],
+    "relatedConcepts": [
+      "decidability",
+      "Finset.Ioc",
+      "Finset.card"
+    ]
+  },
+  {
+    "id": "abundant-density-ann-subset-count",
+    "proofId": "abundant-number-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 76 },
+    "type": "insight",
+    "title": "Density Reduces to an Exact Lattice-Point Count",
+    "content": "`multiples_subset_abundant` shows every $x \\in (0,N]$ divisible by $12$ is abundant — apply `abundant_of_abundant_dvd Nat.abundant_twelve` — giving the finset inclusion $\\{x \\in (0,N] : 12 \\mid x\\} \\subseteq \\{n \\in (0,N] : n.\\mathrm{Abundant}\\}$. The left-hand set has cardinality **exactly** $\\lfloor N/12 \\rfloor$ by Mathlib's `Nat.Ioc_filter_dvd_card_eq_div`, so `Finset.card_le_card` of the inclusion gives the counting bound\n$$ \\lfloor N/12 \\rfloor \\le A(N). $$\nThe only ingredients are an exact count of multiples and monotonicity of cardinality under $\\subseteq$ — no estimation.",
+    "mathContext": "The abundant numbers in (0, N] contain the ⌊N/12⌋ multiples of 12, so their count is at least ⌊N/12⌋.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.Ioc_filter_dvd_card_eq_div (count of multiples)",
+      "Finset.card_le_card",
+      "abundant_of_abundant_dvd (closure)"
+    ],
+    "relatedConcepts": [
+      "lattice-point counting",
+      "divisibility",
+      "Finset cardinality monotonicity"
+    ]
+  },
+  {
+    "id": "abundant-density-ann-real-ratio",
+    "proofId": "abundant-number-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 106 },
+    "type": "step",
+    "title": "From Floor Count to a Density Ratio",
+    "content": "Casting into $\\mathbb{R}$: from $12\\cdot(N/12) + (N \\bmod 12) = N$ with $N \\bmod 12 < 12$, the floor estimate $12\\cdot\\lfloor N/12\\rfloor \\ge N - 11$ gives `abundantCount_real_lower`: $\\;N/12 - 1 \\le A(N)$. Dividing by $N > 0$ (via `le_div_iff₀`) yields `abundantCount_ratio_lower`:\n$$ \\frac{1}{12} - \\frac{1}{N} \\le \\frac{A(N)}{N} \\qquad (N \\ge 1). $$\nThe floor loss $\\lfloor N/12\\rfloor \\ge N/12 - 1$ becomes the vanishing correction $1/N$ in the ratio.",
+    "mathContext": "The integer floor in ⌊N/12⌋ ≤ A(N) costs only a 1/N correction once divided through by N.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Nat.div_add_mod and Nat.mod_lt",
+      "le_div_iff₀",
+      "casting ℕ inequalities to ℝ"
+    ],
+    "relatedConcepts": [
+      "floor function",
+      "density ratio"
+    ]
+  },
+  {
+    "id": "abundant-density-ann-density",
+    "proofId": "abundant-number-oq-01-oq-01",
+    "range": { "startLine": 107, "endLine": 124 },
+    "type": "insight",
+    "title": "Capstone: Lower Density at Least 1/12",
+    "content": "`abundant_lower_density`: for every $\\varepsilon > 0$, eventually (as $N \\to \\infty$) $\\;A(N)/N > 1/12 - \\varepsilon$. Given $\\varepsilon$, pick $M > 1/\\varepsilon$ (`exists_nat_gt`); for $N \\ge \\max(M,1)$ one has $1/N < \\varepsilon$, so $A(N)/N \\ge 1/12 - 1/N > 1/12 - \\varepsilon$. Phrased with `Filter.eventually_atTop`, this is exactly\n$$ \\liminf_{N\\to\\infty} \\frac{A(N)}{N} \\ge \\frac{1}{12}, $$\nthe parent entry's first open question — a clean unconditional density lower bound — answered without the Davenport density theorem. The constant $1/12$ is honest but not sharp: the true density $\\approx 0.2476$ counts also the abundant numbers not divisible by $12$ (e.g. $20, 70, 945, \\dots$), and capturing those is what makes the exact value deep.",
+    "mathContext": "Eventually the proportion of abundant numbers exceeds 1/12 − ε for every ε, i.e. the lower density is ≥ 1/12.",
+    "significance": "key",
+    "prerequisites": [
+      "Filter.eventually_atTop and the atTop filter",
+      "exists_nat_gt; 1/N → 0",
+      "liminf interpretation of lower density"
+    ],
+    "relatedConcepts": [
+      "lower density",
+      "liminf",
+      "atTop filter"
+    ]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-01-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "abundant-number-oq-01-oq-01",
+  "title": "Abundant Numbers Have Lower Density at Least 1/12",
+  "slug": "abundant-number-oq-01-oq-01",
+  "description": "A follow-up to the parent entry's open question: prove a clean, unconditional lower bound on the natural density of the abundant numbers. Writing A(N) for the number of abundant integers in (0, N], this entry proves A(N) ≥ ⌊N/12⌋ for every N, hence A(N)/N ≥ 1/12 − 1/N for N ≥ 1, and as a capstone that the lower density is at least 1/12: for every ε > 0, eventually A(N)/N > 1/12 − ε (equivalently liminf A(N)/N ≥ 1/12). The mechanism is elementary and sidesteps the deep Davenport/Erdős density theory: every positive multiple of 12 is abundant (closure, from the parent file), the multiples of 12 in (0, N] number exactly ⌊N/12⌋ (Nat.Ioc_filter_dvd_card_eq_div), and Finset.card monotonicity under ⊆ does the rest. The constant 1/12 is not optimal (the true density is ≈ 0.2476), but it is unconditional, fully constructive, and machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Density studied by Davenport (1933); elementary lower bound is folklore",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantDensityOQ01.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "natural-density",
+      "counting",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 124,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. The decidability instance for Nat.Abundant is the genuine kernel-decidable comparison n < ∑ properDivisors (Mathlib simply does not register it), so no Classical decision procedure enters the counting argument; the only axioms reported by #print axioms are the standard foundational triple propext / Classical.choice / Quot.sound (none of which counts as an assumption). No native_decide, hence no Lean.ofReduceBool. Reuses AbundantMultiplesOQ01.abundant_of_abundant_dvd and Mathlib's Nat.abundant_twelve.",
+    "originalContributions": [
+      "Proves `div_twelve_le_abundantCount : N / 12 ≤ abundantCount N` — at least ⌊N/12⌋ of the integers in (0, N] are abundant. The multiples of 12 in (0, N] number exactly ⌊N/12⌋ by `Nat.Ioc_filter_dvd_card_eq_div`, and all are abundant, so `Finset.card_le_card` on the subset `{x ∈ Ioc 0 N | 12 ∣ x} ⊆ {n ∈ Ioc 0 N | n.Abundant}` gives the counting bound.",
+      "Proves `abundantCount_ratio_lower : 0 < N → (1:ℝ)/12 − 1/N ≤ abundantCount N / N` — the proportion of abundant numbers in (0, N] is at least 1/12 − 1/N, obtained by casting the floor estimate 12·⌊N/12⌋ ≥ N − 11 into ℝ.",
+      "Proves `abundant_lower_density : ∀ ε > 0, ∀ᶠ N in atTop, (1:ℝ)/12 − ε ≤ abundantCount N / N` — the abundant numbers have lower density at least 1/12 (equivalently liminf A(N)/N ≥ 1/12), feeding the ratio bound the fact that 1/N → 0. This directly answers the parent entry's first open question (a clean unconditional density lower bound) without invoking the Davenport density theorem.",
+      "Supplies the `DecidablePred Nat.Abundant` instance (defeq to the kernel-decidable comparison n < ∑ properDivisors n) that Mathlib omits, enabling `Finset.filter` over abundance and keeping the count constructive.",
+      "Defines the counting function `abundantCount N := #{n ∈ Ioc 0 N | n.Abundant}` and the subset lemma `multiples_subset_abundant`, packaging the closure-under-multiples fact into a density-ready form."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The natural density of the abundant numbers — the limiting proportion of integers n ≤ N with σ(n) > 2n — was first shown to exist by Davenport (1933), and is now known to be ≈ 0.247620. That value is a genuinely 20th-century analytic result. A *positive lower bound* on the density, however, is elementary: any single abundant residue class already forces a fixed proportion of abundant numbers. Since 12 is the smallest abundant number (parent entry) and every positive multiple of an abundant number is abundant (closure), the multiples of 12 — a proportion 1/12 of all integers — are all abundant, giving the unconditional bound density ≥ 1/12. This entry formalizes exactly that elementary lower bound, the parent entry's stated open question.",
+    "problemStatement": "Working with Mathlib's `Nat.Abundant` and the counting function A(N) = #{n ∈ (0, N] : n.Abundant}, establish a positive lower bound on the natural density of the abundant numbers: (1) A(N) ≥ ⌊N/12⌋ for all N; (2) A(N)/N ≥ 1/12 − 1/N for N ≥ 1; and (3) the lower density is at least 1/12, i.e. for every ε > 0, eventually A(N)/N > 1/12 − ε.",
+    "text": "A Lean 4 / Mathlib formalization (124 lines, 0 sorries, 0 axioms). The counting function `abundantCount N := #{n ∈ Ioc 0 N | n.Abundant}` is filtered using a supplied `DecidablePred Nat.Abundant` instance (the comparison n < ∑ properDivisors n is kernel-decidable; Mathlib just does not register it). The subset lemma `multiples_subset_abundant` shows every multiple of 12 in (0, N] is abundant — reusing `AbundantMultiplesOQ01.abundant_of_abundant_dvd` with `Nat.abundant_twelve` — and since those multiples number exactly ⌊N/12⌋ (`Nat.Ioc_filter_dvd_card_eq_div`), `Finset.card_le_card` yields the counting bound `div_twelve_le_abundantCount`. Casting the floor estimate 12·⌊N/12⌋ ≥ N − 11 into ℝ gives the real bound `abundantCount_real_lower : N/12 − 1 ≤ A(N)` and then the ratio bound `abundantCount_ratio_lower`. The capstone `abundant_lower_density` upgrades this to an atTop eventually-statement using that 1/N → 0.",
+    "proofStrategy": "1. **Decidable abundance.** `Nat.Abundant n` is definitionally `n < ∑ i ∈ properDivisors n, i`, a decidable ℕ-comparison; supplying the missing `DecidablePred` instance lets us form the Finset `{n ∈ Ioc 0 N | n.Abundant}` and define `abundantCount`.\n\n2. **Multiples of 12 are abundant (subset).** `multiples_subset_abundant`: for x ∈ (0, N] with 12 ∣ x, `abundant_of_abundant_dvd Nat.abundant_twelve` gives x abundant, so `{x ∈ Ioc 0 N | 12 ∣ x} ⊆ {n ∈ Ioc 0 N | n.Abundant}`.\n\n3. **Counting bound.** The left finset has cardinality exactly N/12 (`Nat.Ioc_filter_dvd_card_eq_div N 12`); `Finset.card_le_card` of the subset gives `N / 12 ≤ abundantCount N`.\n\n4. **Real and ratio bounds.** From `Nat.div_add_mod N 12` and `N % 12 < 12`, cast 12·(N/12) ≥ N − 11 into ℝ to get `N/12 − 1 ≤ A(N)`; dividing by N (via `le_div_iff₀`) gives `1/12 − 1/N ≤ A(N)/N`.\n\n5. **Density capstone.** Given ε > 0, choose M > 1/ε (`exists_nat_gt`); for N ≥ max M 1 one has 1/N < ε, so A(N)/N ≥ 1/12 − 1/N > 1/12 − ε. Phrased with `Filter.eventually_atTop`, this is liminf A(N)/N ≥ 1/12.",
+    "keyInsights": [
+      "**One abundant residue class buys positive density.** The density of abundant numbers is hard to compute exactly (Davenport), but bounding it below is trivial once closure is known: the multiples of any fixed abundant number a are all abundant and have density 1/a, so density ≥ 1/a. Taking a = 12 (the smallest abundant number) gives the clean bound 1/12.",
+      "**Density reduces to an exact lattice-point count.** The number of multiples of 12 in (0, N] is *exactly* ⌊N/12⌋ — no estimation — via `Nat.Ioc_filter_dvd_card_eq_div`. The entire density argument is then `Finset.card_le_card` applied to a subset inclusion, with the only analytic step being the harmless 1/N → 0 at the very end.",
+      "**Constructive, axiom-free counting.** Because `Nat.Abundant` is genuinely decidable (a comparison of concrete divisor sums), the counting function needs no Classical choice in its decision procedure and no `native_decide`; the result carries only the standard foundational axioms and so is reported as verified.",
+      "**The bound is honest, not sharp.** The true density ≈ 0.2476 is about three times 1/12. The gap is exactly the abundant numbers *not* divisible by 12 (e.g. 20, 70, 945, …); capturing them is what makes the exact density a deep theorem. Stating 1/12 transparently as a lower bound — rather than overclaiming the exact value — is the point.",
+      "**Infinitude → positive density is a real strengthening.** The parent entry's `infinitely_many_abundant` only needs that one abundant residue class is nonempty and infinite; positive *density* additionally pins a fixed *proportion* 1/12 of all integers, a strictly stronger quantitative statement obtained from the same closure fact by counting rather than by exhibiting an injection."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function and the abundant/perfect/deficient classification",
+      "Natural density and counting functions A(N) = #{n ≤ N : P n}",
+      "Finset.filter, Finset.card monotonicity, and exact lattice-point counts (Nat.Ioc_filter_dvd_card_eq_div)",
+      "Nat division floor estimates and the atTop filter / liminf"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement: A Positive Lower Density Bound",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring: defines the counting function A(N) and states the three nested results — the counting bound ⌊N/12⌋ ≤ A(N), the ratio bound A(N)/N ≥ 1/12 − 1/N, and the density capstone liminf A(N)/N ≥ 1/12 — together with the elementary mechanism (multiples of 12 are abundant and number exactly ⌊N/12⌋) and the contrast with the deep exact density ≈ 0.2476.",
+      "mathContext": "A single abundant residue class (the multiples of 12) already forces a positive lower density 1/12."
+    },
+    {
+      "id": "count-def",
+      "title": "Decidability Instance and Counting Function",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "Supplies `DecidablePred Nat.Abundant` (defeq to the decidable comparison n < ∑ properDivisors n) that Mathlib omits, then defines `abundantCount N := #{n ∈ Ioc 0 N | n.Abundant}`, the number of abundant integers in (0, N].",
+      "mathContext": "Abundance is a decidable comparison of divisor sums, so the abundant numbers up to N can be counted as a Finset cardinality."
+    },
+    {
+      "id": "subset-count",
+      "title": "Multiples of 12 Are Abundant; the Counting Bound",
+      "startLine": 57,
+      "endLine": 76,
+      "summary": "`multiples_subset_abundant`: every x ∈ (0, N] with 12 ∣ x is abundant (via `abundant_of_abundant_dvd Nat.abundant_twelve`), giving a subset inclusion of finsets. `div_twelve_le_abundantCount`: since the multiples of 12 in (0, N] number exactly N/12 (`Nat.Ioc_filter_dvd_card_eq_div`), `Finset.card_le_card` yields N/12 ≤ abundantCount N.",
+      "mathContext": "The abundant numbers in (0, N] contain the ⌊N/12⌋ multiples of 12, so their count is at least ⌊N/12⌋."
+    },
+    {
+      "id": "real-ratio",
+      "title": "Real and Ratio Bounds",
+      "startLine": 77,
+      "endLine": 106,
+      "summary": "`abundantCount_real_lower`: casting 12·(N/12) + N%12 = N with N%12 < 12 gives the real inequality N/12 − 1 ≤ A(N). `abundantCount_ratio_lower`: dividing by N > 0 (via `le_div_iff₀`) gives 1/12 − 1/N ≤ A(N)/N.",
+      "mathContext": "The floor loss ⌊N/12⌋ ≥ N/12 − 1 becomes the vanishing correction 1/N in the density ratio."
+    },
+    {
+      "id": "density",
+      "title": "Density Capstone: liminf A(N)/N ≥ 1/12",
+      "startLine": 107,
+      "endLine": 124,
+      "summary": "`abundant_lower_density`: for every ε > 0, choosing M > 1/ε makes 1/N < ε for N ≥ max M 1, so A(N)/N ≥ 1/12 − 1/N > 1/12 − ε. Phrased with `Filter.eventually_atTop`, this is the lower-density statement liminf A(N)/N ≥ 1/12 — the parent entry's open question, answered without the Davenport density theorem.",
+      "mathContext": "Eventually-in-N the proportion of abundant numbers exceeds 1/12 − ε for every ε, i.e. the lower density is at least 1/12."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "abundant_lower_density",
+      "type": "core",
+      "description": "For every ε > 0, eventually (as N → ∞) the proportion of abundant numbers in (0, N] exceeds 1/12 − ε; equivalently liminf A(N)/N ≥ 1/12. The abundant numbers have lower density at least 1/12 — a clean unconditional bound answering the parent entry's first open question, proved without the Davenport density theorem.",
+      "leanType": "∀ (ε : ℝ), 0 < ε → ∀ᶠ N in Filter.atTop, (1 : ℝ) / 12 - ε ≤ (abundantCount N : ℝ) / N"
+    },
+    {
+      "name": "div_twelve_le_abundantCount",
+      "type": "core",
+      "description": "N / 12 ≤ abundantCount N — at least ⌊N/12⌋ of the integers in (0, N] are abundant. The multiples of 12 in (0, N] number exactly ⌊N/12⌋ (Nat.Ioc_filter_dvd_card_eq_div) and are all abundant, so Finset.card monotonicity gives the bound.",
+      "leanType": "∀ (N : ℕ), N / 12 ≤ abundantCount N"
+    },
+    {
+      "name": "abundantCount_ratio_lower",
+      "type": "supporting",
+      "description": "For N ≥ 1, (1:ℝ)/12 − 1/N ≤ abundantCount N / N — the proportion of abundant numbers in (0, N] is at least 1/12 − 1/N, the finite-N form of the density bound.",
+      "leanType": "0 < N → (1 : ℝ) / 12 - 1 / N ≤ (abundantCount N : ℝ) / N"
+    },
+    {
+      "name": "abundantCount_real_lower",
+      "type": "supporting",
+      "description": "(N:ℝ)/12 − 1 ≤ abundantCount N — the counting bound recast over ℝ via the floor estimate 12·⌊N/12⌋ ≥ N − 11.",
+      "leanType": "∀ (N : ℕ), (N : ℝ) / 12 - 1 ≤ (abundantCount N : ℝ)"
+    },
+    {
+      "name": "multiples_subset_abundant",
+      "type": "supporting",
+      "description": "{x ∈ Ioc 0 N | 12 ∣ x} ⊆ {n ∈ Ioc 0 N | n.Abundant} — within (0, N] every multiple of 12 is abundant, the subset inclusion driving the counting bound.",
+      "leanType": "∀ (N : ℕ), {x ∈ Finset.Ioc 0 N | 12 ∣ x} ⊆ {n ∈ Finset.Ioc 0 N | n.Abundant}"
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the parent entry's closure-under-multiples theorem, this entry proves a clean unconditional lower bound on the natural density of the abundant numbers: A(N) ≥ ⌊N/12⌋ for every N, hence A(N)/N ≥ 1/12 − 1/N for N ≥ 1, and finally that the lower density is at least 1/12 (liminf A(N)/N ≥ 1/12). The argument reduces density to an exact lattice-point count — the ⌊N/12⌋ multiples of 12 in (0, N], all abundant — plus Finset.card monotonicity, with the only analytic input being 1/N → 0. All 5 theorems are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "This answers the parent entry's first open question (a clean unconditional density lower bound) and quantitatively strengthens its infinitude result: not merely infinitely many abundant numbers, but a fixed positive proportion 1/12 of all integers. The same recipe gives density ≥ 1/a from the multiples of any abundant number a, so sharper (still elementary) bounds follow from finitely many abundant residue classes — though closing the gap to the exact density ≈ 0.2476 requires the abundant numbers not covered by a single class and remains the deep Davenport/Erdős theory.",
+    "openQuestions": [
+      "Sharpen the elementary lower bound by uniting several abundant residue classes via inclusion–exclusion: the multiples of 12, 18, 20, 24, … are all abundant, so density ≥ (density of their union); formalizing this gives bounds approaching the true ≈ 0.2476 from below without analytic machinery.",
+      "Formalize that the natural density of the abundant numbers *exists* (Davenport, 1933) — i.e. A(N)/N converges — and not merely that its liminf is positive. This requires the Erdős–Wintner / Schoenberg theory of distribution functions of additive functions (here log σ(n)/n), a substantially deeper analytic development than the elementary lower bound."
+    ]
+  },
+  "references": [
+    {
+      "authors": "H. Davenport",
+      "title": "Über numeri abundantes",
+      "year": "1933",
+      "venue": "Sitzungsber. Preuss. Akad. Wiss., Phys.-Math. Kl.",
+      "note": "Proves the natural density of the abundant numbers exists; the value is now known to be ≈ 0.247620."
+    },
+    {
+      "authors": "Marc Deléglise",
+      "title": "Bounds for the density of abundant integers",
+      "year": "1998",
+      "venue": "Experimental Mathematics 7(2), 137–143",
+      "note": "Rigorous numerical bounds 0.2474 < density < 0.2480 for the abundant numbers."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005101: Abundant numbers (sum of divisors of n exceeds 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The sequence 12, 18, 20, 24, 30, 36, … ; 12 is the smallest abundant number and seeds the 1/12 density bound."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves minimality (12 is smallest), closure under multiples, and infinitude, and lists 'prove a positive natural density lower bound' as its first open question. This entry answers exactly that: it reuses the parent's `abundant_of_abundant_dvd` to show the multiples of 12 are abundant and counts them to obtain density ≥ 1/12."
+    },
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "related",
+      "description": "Both entries concern the sum-of-divisors function and the abundant classification σ(n) > 2n; this entry adds the density-counting layer on top of the divisor-sum inequality."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantDensityOQ01.lean",
+    "namespace": "AbundantDensityOQ01",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantMultiplesOQ01"
+    ],
+    "lineCount": 124,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 5,
+    "definitionCount": 1
+  }
+}

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "banach-fixed-point-oq-01-oq-02",
+  "title": "Banach Fixed Point OQ-01-OQ-02: Lipschitz Perturbations of the Identity are Homeomorphisms",
+  "slug": "banach-fixed-point-oq-01-oq-02",
+  "description": "On a complete normed space E, if g : E → E is Lipschitz with constant k < 1 then the perturbation of the identity f(x) = x + g(x) is a homeomorphism of E onto itself, and its inverse is Lipschitz with the sharp constant 1/(1 − k). Surjectivity is supplied by the parent Banach contraction principle: solving x + g(x) = y is the fixed-point equation x = y − g(x) for the k-contraction x ↦ y − g(x). Injectivity and the inverse bound come from the antilipschitz lower estimate ‖f(x) − f(y)‖ ≥ (1 − k)‖x − y‖. This is the global Newton/Banach perturbation result, the contraction-principle pillar of the inverse function theorem (parent OQ-01 open question #2).",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachFixedPointOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "fixed-point",
+      "contraction-mapping",
+      "banach",
+      "lipschitz",
+      "homeomorphism",
+      "inverse-function-theorem",
+      "perturbation-of-identity",
+      "metric-spaces"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "AntilipschitzWith.add_lipschitzWith",
+        "description": "If f is AntilipschitzWith Kf and g is LipschitzWith Kg with Kg < Kf⁻¹, then x ↦ f x + g x is AntilipschitzWith (Kf⁻¹ − Kg)⁻¹; specialized to f = id (Kf = 1) gives the (1 − k)⁻¹ lower bound",
+        "module": "Mathlib.Analysis.Normed.Group.Uniform"
+      },
+      {
+        "theorem": "ContractingWith.fixedPoint",
+        "description": "The Banach fixed-point theorem: a contraction on a complete nonempty space has a fixed point; used to invert f via the contraction x ↦ y − g x",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "AntilipschitzWith.to_rightInverse",
+        "description": "If f is AntilipschitzWith K and h is a right inverse of f, then h is LipschitzWith K; gives the sharp 1/(1 − k) Lipschitz constant of f⁻¹",
+        "module": "Mathlib.Topology.MetricSpace.Antilipschitz"
+      },
+      {
+        "theorem": "AntilipschitzWith.injective",
+        "description": "An antilipschitz map is injective",
+        "module": "Mathlib.Topology.MetricSpace.Antilipschitz"
+      },
+      {
+        "theorem": "Equiv.ofBijective",
+        "description": "Packages a bijective function as an equivalence, used to build the homeomorphism",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "LipschitzWith.add",
+        "description": "Sum of Lipschitz maps is Lipschitz with the sum of constants; gives f = id + g is (1 + k)-Lipschitz hence continuous",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "perturbId_antilipschitz: the perturbation f = id + g is AntilipschitzWith (1 − k)⁻¹, obtained by specializing AntilipschitzWith.add_lipschitzWith to the identity (antilipschitz constant 1) — this single estimate yields both injectivity and the sharp inverse Lipschitz constant",
+      "perturbId_surjective: surjectivity of f via the parent Banach contraction principle — solving f(x) = y is recast as the fixed-point equation x = y − g(x) for the explicitly-constructed k-contraction x ↦ y − g(x) on the complete space E",
+      "perturbIdHomeomorph: the headline assembly of injectivity + surjectivity + the two-sided Lipschitz bounds into an honest E ≃ₜ E homeomorphism, with both directions continuous",
+      "perturbIdHomeomorph_symm_lipschitz: the sharp quantitative inverse bound Lip(f⁻¹) ≤ 1/(1 − k), via AntilipschitzWith.to_rightInverse",
+      "A worked ℝ instance: x ↦ x + (1/2)·sin x is a homeomorphism, from the (1/2)-Lipschitz bound on (1/2)·sin",
+      "Summary theorem bundling the (1 + k)-Lipschitz, (1 − k)⁻¹-antilipschitz, bijective, and (1 − k)⁻¹-inverse-Lipschitz facts"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 184,
+    "assumptions": "0 axioms, 0 sorries (only Lean's foundational propext / Classical.choice / Quot.sound). E is a complete normed additive group; g : E → E is Lipschitz with constant k < 1. The antilipschitz and Lipschitz bounds are AntilipschitzWith.add_lipschitzWith / LipschitzWith.add specialized to the identity; surjectivity uses Mathlib's ContractingWith.fixedPoint (the Banach theorem) on the contraction x ↦ y − g x; the inverse bound is AntilipschitzWith.to_rightInverse.",
+    "theoremCount": 8,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "After Banach's 1922 contraction mapping principle, its most far-reaching consequence is the inverse function theorem: a continuously differentiable map with invertible derivative is locally invertible. The cleanest building block — and the one Banach himself emphasized — is the perturbation of the identity: if g is a Lipschitz map with constant strictly less than 1, then id + g is a global homeomorphism. This is the nonlinear analogue of the Neumann series (I + A is invertible when ‖A‖ < 1) and underlies Hadamard's global inverse function theorems. Mathlib develops the local inverse function theorem through ApproximatesLinearOn, where this exact estimate appears with the identity replaced by a linear model f'.",
+    "problemStatement": "**Open Question (parent OQ-01, follow-up #2)**: Formalize the global Newton/Banach perturbation result: if g is a small Lipschitz perturbation of the identity, then id + g is a homeomorphism (a step toward the inverse function theorem).\n\n**Answer**: For a complete normed space E and g Lipschitz with constant k < 1, the map f(x) = x + g(x) is a homeomorphism E ≃ₜ E. It is (1 + k)-Lipschitz, AntilipschitzWith (1 − k)⁻¹ (hence injective), and surjective by the contraction principle; its inverse is Lipschitz with the sharp constant 1/(1 − k).",
+    "text": "A Lipschitz perturbation f = id + g of the identity (Lipschitz constant k < 1 of g) on a complete normed space is a homeomorphism, with f⁻¹ Lipschitz of constant 1/(1 − k); surjectivity comes from the parent Banach contraction principle.",
+    "proofStrategy": "1. **Two-sided bounds**: f = id + g is (1 + k)-Lipschitz by LipschitzWith.add (continuity), and AntilipschitzWith (1 − k)⁻¹ by AntilipschitzWith.add_lipschitzWith specialized to the identity (antilipschitz constant 1, condition k < 1 = 1⁻¹). The antilipschitz bound gives injectivity directly.\n2. **Surjectivity via the contraction principle**: For a target y, the map φ_y(x) = y − g(x) is a k-contraction (explicitly: dist(φ_y a, φ_y b) = dist(g a, g b) ≤ k·dist(a,b)). By ContractingWith.fixedPoint on the complete space E it has a fixed point x*, and x* = y − g(x*) rearranges to x* + g(x*) = y, i.e. f(x*) = y.\n3. **Assembly**: injective + surjective gives a bijection (Equiv.ofBijective); continuity of f (Lipschitz) and of f⁻¹ (antilipschitz, via AntilipschitzWith.to_rightInverse) package it as a homeomorphism E ≃ₜ E. The inverse's Lipschitz constant is exactly the antilipschitz constant 1/(1 − k).",
+    "keyInsights": [
+      "The whole inverse is powered by the **parent Banach theorem**: surjectivity is nothing but 'every y has a preimage', and the preimage is the fixed point of the contraction x ↦ y − g(x). This is the cleanest place where the contraction principle reappears to invert a map rather than to find a single fixed point.",
+      "**One estimate does double duty**: the antilipschitz lower bound ‖f(x) − f(y)‖ ≥ (1 − k)‖x − y‖ gives injectivity AND the sharp Lipschitz constant 1/(1 − k) of the inverse — no separate inverse-continuity argument is needed.",
+      "Specializing AntilipschitzWith.add_lipschitzWith to the identity (antilipschitz constant 1) is what reduces the side condition to the familiar k < 1; the same lemma with a linear model f' in place of the identity is Mathlib's local inverse function theorem.",
+      "The perturbation of identity is the nonlinear Neumann series: (I + A) invertible for ‖A‖ < 1 becomes (id + g) homeomorphic for Lip(g) < 1.",
+      "Completeness of E is used in exactly one place — to run the contraction principle for surjectivity; injectivity and the Lipschitz bounds hold without it."
+    ],
+    "prerequisites": [
+      "Banach contraction mapping principle and ContractingWith (parent OQ-01)",
+      "Lipschitz and antilipschitz maps; the AntilipschitzWith API",
+      "Homeomorphisms of metric/normed spaces"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the perturbation-of-identity result, its role as the third contraction-principle pillar (after the fixed-point theorem and Picard–Lindelöf), and the three ingredients (antilipschitz lower bound, contraction-principle surjectivity, Lipschitz upper bound)",
+      "startLine": 1,
+      "endLine": 60,
+      "mathContext": "**Goal**: f(x) = x + g(x) with Lip(g) = k < 1 is a homeomorphism, Lip(f⁻¹) ≤ 1/(1 − k)."
+    },
+    {
+      "id": "lipschitz-bounds",
+      "title": "Part I: The Two-Sided Lipschitz Estimates",
+      "summary": "perturbId_lipschitz (LipschitzWith (1 + k)), perturbId_antilipschitz (AntilipschitzWith (1 − k)⁻¹ via add_lipschitzWith specialized to id), and perturbId_injective",
+      "startLine": 61,
+      "endLine": 90,
+      "mathContext": "$(1-k)\\|x-y\\| \\le \\|f(x)-f(y)\\| \\le (1+k)\\|x-y\\|$."
+    },
+    {
+      "id": "surjectivity",
+      "title": "Part II: Surjectivity via the Contraction Principle",
+      "summary": "perturbId_surjective: the map x ↦ y − g(x) is an explicitly-verified k-contraction, its ContractingWith.fixedPoint solves f(x) = y; perturbId_bijective combines with injectivity",
+      "startLine": 91,
+      "endLine": 124,
+      "mathContext": "$f(x)=y \\iff x = y - g(x)$, the fixed point of the $k$-contraction $\\varphi_y$."
+    },
+    {
+      "id": "homeomorphism",
+      "title": "Part III: The Homeomorphism and the Sharp Inverse Bound",
+      "summary": "perturbIdEquiv (the bijection as Equiv), perturbIdEquiv_symm_lipschitz (Lip(f⁻¹) ≤ (1 − k)⁻¹ via to_rightInverse), perturbIdHomeomorph (the E ≃ₜ E), and perturbIdHomeomorph_symm_lipschitz",
+      "startLine": 125,
+      "endLine": 156,
+      "mathContext": "$f \\in \\mathrm{Homeo}(E)$ with $\\mathrm{Lip}(f^{-1}) \\le 1/(1-k)$."
+    },
+    {
+      "id": "instance",
+      "title": "Part IV: A Worked Instance on ℝ",
+      "summary": "x ↦ x + (1/2)·sin x is a homeomorphism of ℝ, from the (1/2)-Lipschitz bound on (1/2)·sin",
+      "startLine": 157,
+      "endLine": 170,
+      "mathContext": "$g(x) = \\tfrac12\\sin x$ has $\\mathrm{Lip}(g) = \\tfrac12 < 1$."
+    },
+    {
+      "id": "summary",
+      "title": "Part V: Summary Theorem",
+      "summary": "banach_oq01_oq02_summary bundles the (1 + k)-Lipschitz, (1 − k)⁻¹-antilipschitz, bijective, and (1 − k)⁻¹-inverse-Lipschitz facts",
+      "startLine": 171,
+      "endLine": 184,
+      "mathContext": "Four facts in one: continuity, injectivity-with-margin, bijectivity, and the sharp inverse bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization answers the parent's second open question: on a complete normed space, a Lipschitz perturbation f = id + g of the identity (with Lip(g) = k < 1) is a homeomorphism, and its inverse is Lipschitz with the sharp constant 1/(1 − k). Surjectivity is supplied by the parent Banach contraction principle — solving f(x) = y is the fixed-point equation x = y − g(x) — while injectivity and the inverse bound come from the single antilipschitz estimate ‖f(x) − f(y)‖ ≥ (1 − k)‖x − y‖. Zero sorries, zero axioms beyond Lean's foundations.",
+    "implications": "This is the contraction-principle pillar of the inverse function theorem. Replacing the identity by a linear isomorphism f' (so g is the nonlinear remainder f − f') turns the same estimate into the local inverse function theorem, which Mathlib develops through ApproximatesLinearOn. The sharp 1/(1 − k) inverse bound is the quantitative heart of Newton-type iteration.",
+    "openQuestions": [
+      "Quantify the domain of invertibility for a local perturbation: if g is Lipschitz only on a ball, give an explicit radius on which id + g is a homeomorphism onto its image",
+      "Derive the Lipschitz inverse function theorem: for f with invertible derivative f', write f = f'∘(id + f'⁻¹∘(f − f')) and apply this perturbation result to obtain a local inverse"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "banach-fixed-point-oq-01",
+      "relationship": "Parent: the quantitative contraction mapping principle, whose fixed point supplies the inverse here (this answers its open question #2)"
+    },
+    {
+      "id": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "Sibling: Picard–Lindelöf, the parent's open question #1 — another application of the contraction principle (existence of ODE solutions)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped NNReal"
+    ],
+    "namespace": "BanachFixedPointOQ01OQ02",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/BanachFixedPointOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Stefan Banach",
+      "title": "Sur les opérations dans les ensembles abstraits et leur application aux équations intégrales",
+      "year": "1922",
+      "venue": "Fundamenta Mathematicae"
+    },
+    {
+      "authors": "Jacques Hadamard",
+      "title": "Sur les transformations ponctuelles (global inverse function theorems)",
+      "year": "1906",
+      "venue": "Bulletin de la Société Mathématique de France"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "banach-fixed-point-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the Banach contraction mapping principle. This entry uses its fixed point (Mathlib's ContractingWith.fixedPoint) to invert the perturbation f = id + g, answering the parent's second open question."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling Picard–Lindelöf entry: the parent's first open question. Both are applications of the contraction principle — one constructs ODE solutions, this one inverts a Lipschitz perturbation of the identity."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/abundant-number-oq-01-oq-01.json
+++ b/src/data/research/problems/abundant-number-oq-01-oq-01.json
@@ -1,0 +1,106 @@
+{
+  "slug": "abundant-number-oq-01-oq-01",
+  "title": "Positive Lower Bound for the Natural Density of Abundant Numbers",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\liminf_{N\\to\\infty} \\frac{\\#\\{n \\le N : \\sigma(n) > 2n\\}}{N} \\ge \\frac{1}{12}",
+    "plain": "The abundant numbers (those with sum of proper divisors exceeding the number, i.e. $\\sigma(n) > 2n$) are known to have a natural density $\\approx 0.2476$ (Davenport, 1933), but that exact value is a deep analytic result. The parent entry's open question asks for a clean unconditional *lower bound*. We prove the lower density is at least $1/12$: every multiple of $12$ is abundant, and the multiples of $12$ form a proportion $1/12$ of all integers.",
+    "whyMatters": [
+      "Quantitatively strengthens the parent entry's infinitude result to a positive density.",
+      "Answers the parent entry's stated first open question with an elementary, axiom-free argument."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "div_twelve_le_abundantCount: N/12 ≤ abundantCount N",
+      "abundantCount_ratio_lower: 0 < N → 1/12 − 1/N ≤ abundantCount N / N",
+      "abundant_lower_density: ∀ ε > 0, eventually 1/12 − ε ≤ abundantCount N / N (liminf ≥ 1/12)"
+    ],
+    "open": [
+      "Exact density exists (Davenport): A(N)/N converges — needs Erdős–Wintner distribution-function theory.",
+      "Sharper elementary bounds via inclusion–exclusion over several abundant residue classes (12, 18, 20, 24, …)."
+    ],
+    "goal": "Prove the lower density of the abundant numbers is at least 1/12, machine-checked and axiom-free."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "Completed in a single FRESH session: counting bound + ratio bound + liminf density bound.",
+    "blockers": [],
+    "nextAction": "Done. Optional follow-ups: inclusion–exclusion sharpening; existence of the density (Davenport).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved lower density ≥ 1/12 (verified, 0 axioms, 0 sorries) in Proofs/AbundantDensityOQ01.lean.",
+    "builtItems": [
+      "Proofs/AbundantDensityOQ01.lean: abundantCount counting function + DecidablePred Nat.Abundant instance",
+      "multiples_subset_abundant: {x ∈ Ioc 0 N | 12 ∣ x} ⊆ {n ∈ Ioc 0 N | n.Abundant}",
+      "div_twelve_le_abundantCount: N/12 ≤ abundantCount N (via Nat.Ioc_filter_dvd_card_eq_div + card_le_card)",
+      "abundantCount_real_lower, abundantCount_ratio_lower, abundant_lower_density"
+    ],
+    "insights": [
+      "Density ≥ 1/a for any abundant a, from closure: multiples of a are all abundant and have density 1/a. a = 12 (smallest abundant) gives 1/12.",
+      "Density reduces to an EXACT lattice-point count: #{multiples of 12 in (0,N]} = ⌊N/12⌋ (Nat.Ioc_filter_dvd_card_eq_div), then Finset.card monotonicity. Only analytic step is 1/N → 0.",
+      "Nat.Abundant has no registered DecidablePred in Mathlib but is defeq to a decidable < on divisor sums; supplying the instance keeps the count constructive (no Classical decision procedure, no native_decide).",
+      "1/12 is honest but not sharp (true density ≈ 0.2476); the gap is abundant numbers not divisible by 12 (20, 70, 945, …)."
+    ],
+    "mathlibGaps": [
+      "Mathlib registers no DecidablePred Nat.Abundant instance.",
+      "Mathlib lacks the density / liminf of the abundant numbers (Davenport's existence theorem is not formalized)."
+    ],
+    "nextSteps": [
+      "Inclusion–exclusion over abundant residue classes to push the elementary bound toward 0.2476.",
+      "Formalize existence of the density (Erdős–Wintner)."
+    ],
+    "markdown": "# Knowledge Base: abundant-number-oq-01-oq-01\n\n## Result (COMPLETE — verified, 0 axioms)\n\nLower density of abundant numbers ≥ 1/12, in `Proofs/AbundantDensityOQ01.lean`.\n\n- `div_twelve_le_abundantCount : N / 12 ≤ abundantCount N`\n- `abundantCount_ratio_lower : 0 < N → 1/12 − 1/N ≤ abundantCount N / N`\n- `abundant_lower_density : ∀ ε > 0, ∀ᶠ N in atTop, 1/12 − ε ≤ abundantCount N / N`  (liminf ≥ 1/12)\n\n## Method\n\nEvery positive multiple of 12 is abundant (closure, from `AbundantMultiplesOQ01.abundant_of_abundant_dvd` + `Nat.abundant_twelve`). The multiples of 12 in (0, N] number exactly ⌊N/12⌋ (`Nat.Ioc_filter_dvd_card_eq_div`). `Finset.card_le_card` on the subset inclusion gives the counting bound; casting the floor estimate and dividing by N gives the density bound.\n\n## Dead Ends / Notes\n\n- The exact density ≈ 0.2476 is deep (Davenport 1933); only the lower bound is elementary.\n- `Nat.Abundant` needs a user-supplied `DecidablePred` instance for `Finset.filter`.\n"
+  },
+  "tags": [
+    "number-theory",
+    "divisor-sum",
+    "abundant-numbers",
+    "natural-density",
+    "counting"
+  ],
+  "relatedProofs": [
+    "abundant-number-oq-01",
+    "abundant-number-oq-02",
+    "sum-of-divisors"
+  ],
+  "references": {
+    "papers": [
+      "H. Davenport, Über numeri abundantes (1933)",
+      "M. Deléglise, Bounds for the density of abundant integers, Experimental Mathematics 7 (1998)"
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Abundant_number",
+      "https://oeis.org/A005101"
+    ],
+    "mathlib": [
+      "Nat.Abundant",
+      "Nat.abundant_twelve",
+      "Nat.Ioc_filter_dvd_card_eq_div"
+    ]
+  },
+  "started": "2026-06-24",
+  "leanFiles": [
+    {
+      "path": "Proofs/AbundantDensityOQ01.lean",
+      "filename": "AbundantDensityOQ01.lean",
+      "lineCount": 124,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbundantDensityOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `abundant-number-oq-01` (*"prove a positive natural density lower bound … a clean lower bound such as density ≥ 1/c from the multiples of any fixed abundant number"*) with an elementary, unconditional, axiom-free proof.

Writing `A(N) = #{n ∈ (0,N] : n.Abundant}` for the abundant counting function, the new file `Proofs/AbundantDensityOQ01.lean` proves:

| Theorem | Statement |
|---|---|
| `div_twelve_le_abundantCount` | `N / 12 ≤ A(N)` (counting form) |
| `abundantCount_ratio_lower` | `0 < N → 1/12 − 1/N ≤ A(N)/N` (ratio form) |
| `abundant_lower_density` | `∀ ε>0, ∀ᶠ N in atTop, 1/12 − ε ≤ A(N)/N` — i.e. `liminf A(N)/N ≥ 1/12` |

## Method

Every positive multiple of `12` is abundant (closure under multiples, reusing `AbundantMultiplesOQ01.abundant_of_abundant_dvd` with `Nat.abundant_twelve`). The multiples of `12` in `(0,N]` number **exactly** `⌊N/12⌋` (`Nat.Ioc_filter_dvd_card_eq_div`), so `Finset.card_le_card` on the subset inclusion gives the counting bound. Casting the floor estimate `12·⌊N/12⌋ ≥ N − 11` into ℝ and letting `1/N → 0` yields the density bound. This sidesteps the deep Davenport (1933) density theorem.

The constant `1/12` is honest but **not sharp** — the true density is ≈ 0.2476; the gap is the abundant numbers not divisible by 12 (20, 70, 945, …), and the meta/annotations state this transparently.

## Verification

- **Verified, 0 axioms, 0 sorries.** `#print axioms` reports only `propext / Classical.choice / Quot.sound` (no `native_decide`, no `Lean.ofReduceBool`). A genuine `DecidablePred Nat.Abundant` instance (defeq to the kernel-decidable divisor-sum comparison) keeps the count constructive.
- Single-file typecheck passes under Lean v4.26.0 / Mathlib 4.26.0.
- New file: `Proofs/AbundantDensityOQ01.lean` (124 lines, 5 theorems, 1 def).

## Gallery

New entry `abundant-number-oq-01-oq-01` (meta.json + annotations.json) plus research-problem record. Cross-referenced to the parent as `extends`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)