### PR TITLE
Enrich Chebyshev's Integral Inequality (continuous Chebyshev sum inequality)

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cheb-int-integrable",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 42 },
+    "type": "technique",
+    "title": "Boundedness ⇒ integrability engine",
+    "content": "`integrable_of_bounded` is the small lemma that keeps the whole development hypothesis-free: a bounded measurable function lies in $L^\\infty$ (`memLp_top_of_bound`), and on a finite measure $L^\\infty \\subseteq L^1$ (`MemLp.integrable ... le_top`). Choosing boundedness rather than continuity or $L^2$ membership as the standing hypothesis means every later integrability obligation — including those on the finite product measure $\\mu \\otimes \\mu$ — is discharged by one reusable fact.",
+    "mathContext": "$\\|f\\|_\\infty \\le C,\\ \\mu(\\alpha) < \\infty \\;\\Rightarrow\\; f \\in L^1(\\mu).$",
+    "significance": "supporting",
+    "relatedConcepts": ["L^infinity space", "finite measure", "Bochner integrability"],
+    "prerequisites": ["measure theory", "Lp spaces"]
+  },
+  {
+    "id": "ann-cheb-int-nonneg",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 62 },
+    "type": "insight",
+    "title": "The one inequality that does all the work",
+    "content": "The entire family of results rests on a single sign fact: the integrand $(f z_1 - f z_2)(g z_1 - g z_2)$ is pointwise nonnegative by the comonotonicity hypothesis `hmono`, so its integral against the product measure $\\mu \\otimes \\mu$ is $\\ge 0$ by `integral_nonneg`. No completeness, no order structure on $\\alpha$ — comonotonicity is exactly the hypothesis that makes the symmetric integrand have a fixed sign.",
+    "mathContext": "$\\iint (f x - f y)(g x - g y)\\,d\\mu_x\\,d\\mu_y \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": ["comonotonicity", "correlation inequality", "FKG inequality"],
+    "prerequisites": ["product measure", "integral of nonnegative functions"]
+  },
+  {
+    "id": "ann-cheb-int-fubini",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 84 },
+    "type": "technique",
+    "title": "Fubini: evaluating the four product integrals",
+    "content": "Expanding the integrand gives four monomials $f z_i \\cdot g z_j$, each integrated separately. The two 'same-coordinate' terms $f z_1 g z_1$ and $f z_2 g z_2$ collapse via `integral_fun_fst`/`integral_fun_snd` to $\\mu(\\alpha)\\int fg$ (integrating out the unused coordinate yields a factor of $\\mu(\\alpha)$). The two 'cross' terms factor via the product-integral identity `integral_prod_mul` to $(\\int f)(\\int g)$. The block also records the four integrability witnesses (`comp_fst`, `comp_snd`, `mul_prod`) needed for the linearity split.",
+    "mathContext": "$\\int_{\\alpha^2} h(z_1)\\,d(\\mu\\otimes\\mu) = \\mu(\\alpha)\\int h,\\quad \\int_{\\alpha^2} f(z_1)g(z_2) = \\big(\\int f\\big)\\big(\\int g\\big).$",
+    "significance": "key",
+    "relatedConcepts": ["Fubini's theorem", "product measure", "Tonelli"],
+    "prerequisites": ["Fubini's theorem", "product measure integration"]
+  },
+  {
+    "id": "ann-cheb-int-expand",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 96 },
+    "type": "insight",
+    "title": "The covariance identity: double integral = 2·covariance",
+    "content": "Linearity (`integral_add`/`integral_sub`, justified by the integrability witnesses) assembles the four pieces into the exact identity $\\iint (f x - f y)(g x - g y) = 2\\big(\\mu(\\alpha)\\int fg - (\\int f)(\\int g)\\big)$. This is the continuous mirror of the discrete monovariance identity; it holds for *all* bounded measurable data, so the inequality is purely the statement that the left side is nonnegative. The final `linarith` combines that nonnegativity with the identity to conclude $(\\int f)(\\int g) \\le \\mu(\\alpha)\\int fg$.",
+    "mathContext": "$\\iint (f x - f y)(g x - g y) = 2\\big(\\mu(\\alpha)\\textstyle\\int fg - (\\int f)(\\int g)\\big) \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": ["covariance", "monovariance identity", "linearity of the integral"],
+    "prerequisites": ["linearity of integration", "algebraic manipulation"]
+  },
+  {
+    "id": "ann-cheb-int-antitone",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 111 },
+    "type": "concept",
+    "title": "Reversal by replacing g with −g",
+    "content": "`chebyshev_integral_ge_of_antitone` gets the reversed inequality for oppositely ordered (anti-comonotone) functions for free: if $(f x - f y)(g x - g y) \\le 0$ then $(f x - f y)(-g x - (-g y)) \\ge 0$, so $-g$ is comonotone with $f$. Applying the main theorem to $-g$ and pushing the sign through `integral_neg` flips the inequality. A clean instance of deriving the dual statement by a symmetry of the hypothesis rather than a fresh argument.",
+    "mathContext": "$f,g \\text{ anti-comonotone} \\iff f,-g \\text{ comonotone} \\;\\Rightarrow\\; \\mu(\\alpha)\\textstyle\\int fg \\le (\\int f)(\\int g).$",
+    "significance": "supporting",
+    "relatedConcepts": ["anti-comonotonicity", "duality", "negative correlation"],
+    "prerequisites": ["the main inequality"]
+  },
+  {
+    "id": "ann-cheb-int-corollaries",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 134 },
+    "type": "insight",
+    "title": "Second-moment bound and the probability form",
+    "content": "Two specializations. Setting $g = f$ makes comonotonicity automatic — $(f x - f y)^2 \\ge 0$ always — so every bounded measurable $f$ obeys the second-moment / Cauchy–Schwarz bound $(\\int f)^2 \\le \\mu(\\alpha)\\int f^2$ (Cauchy–Schwarz against the constant $1$). On a probability measure $\\mu(\\alpha) = 1$ collapses the inequality to $(\\int f)(\\int g) \\le \\int fg$, i.e. comonotone random variables have nonnegative covariance — the probabilistic reading of Chebyshev's correlation inequality.",
+    "mathContext": "$(\\textstyle\\int f)^2 \\le \\mu(\\alpha)\\int f^2;\\qquad \\mu(\\alpha)=1 \\Rightarrow \\mathrm{Cov}(f,g) = \\int fg - (\\int f)(\\int g) \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "variance", "covariance", "probability measure"],
+    "prerequisites": ["the main inequality", "probability measures"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-01-oq-01` (quality 45, pass 0).

## Gap
Rich meta.json but **no annotations.json** — zero inline annotation coverage.

## Changes
Added `annotations.json` with **6 annotations** covering the full proof:
1. Boundedness ⇒ integrability engine (`integrable_of_bounded`)
2. The one nonnegative double integral that does all the work
3. Fubini: evaluating the four product integrals
4. The covariance identity (double integral = 2·covariance)
5. Reversal by replacing g with −g (anti-comonotone case)
6. Second-moment bound and the probability form

Each includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- `pnpm annotations:build` passes with **no warnings** for this entry.
- JSON validated.
- meta.json unchanged (verified, 0 axioms — integrity intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)