### PR TITLE
research(pythagorean-triples-oq-10): hypotenuse of a primitive triple is ≡ 1 (mod 4) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3455,6 +3455,7 @@ import Proofs.PythagoreanTriplesOQ06
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
 import Proofs.PythagoreanTriplesOQ09
+import Proofs.PythagoreanTriplesOQ10
 import Proofs.QuadraticGaussSumDiagonal
 import Proofs.QuadraticGaussSumNormParseval
 import Proofs.QuadraticGaussSumSignReduction

--- a/proofs/Proofs/PythagoreanTriplesOQ10.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ10.lean
@@ -1,0 +1,126 @@
+/-
+Hypotenuse of a Primitive Pythagorean Triple is ≡ 1 (mod 4)
+
+Source: Open question pythagorean-triples-oq-10 from the pythagorean-triples gallery
+Status: VERIFIED (0 axioms, 0 sorries)
+
+For a primitive Pythagorean triple `x² + y² = z²` with coprime legs and positive
+hypotenuse `z`, the hypotenuse satisfies `z ≡ 1 (mod 4)` (and in particular `z` is
+odd).
+
+This *sharpens* the sibling result `PythagoreanTriplesOQ07.hypotenuse_odd`, which
+only establishes `z % 2 = 1`. The two are genuinely different in strength: oddness
+already follows from `z² = x² + y² ≡ 1 (mod 4)`, but that congruence is blind to
+whether `z ≡ 1` or `z ≡ 3 (mod 4)` — both odd residues square to `1`. Pinning the
+residue down to `1` requires the actual parametrization
+
+    z = m² + n²,   m, n coprime of opposite parity,
+
+supplied by Mathlib's `PythagoreanTriple.isPrimitiveClassified_of_coprime_of_pos`.
+With `m, n` of opposite parity one of `m², n²` is `0 (mod 4)` and the other is
+`1 (mod 4)`, so their sum — and hence `z` — is `1 (mod 4)`.
+
+The positivity hypothesis `0 < z` is essential: it selects the positive square
+root `z = +(m² + n²)` over `z = -(m² + n²)` (the latter would give `z ≡ 3`).
+
+Structural consequence: no integer `≡ 3 (mod 4)` is ever the hypotenuse of a
+primitive triple (e.g. `3, 7, 11, 19, …` are excluded), recorded below as
+`not_primitive_hypotenuse_of_three_mod_four`.
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesOQ10
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Part I: Squares modulo 4
+
+The two arithmetic facts behind the result: an even square is `0 (mod 4)` and an
+odd square is `1 (mod 4)`. -/
+
+/-- An even integer squared is `0 (mod 4)`. -/
+theorem sq_emod_four_of_even {a : ℤ} (ha : a % 2 = 0) : a ^ 2 % 4 = 0 := by
+  obtain ⟨k, rfl⟩ := Int.even_iff.mpr ha
+  have h : (k + k) ^ 2 = 4 * k ^ 2 := by ring
+  omega
+
+/-- An odd integer squared is `1 (mod 4)`. -/
+theorem sq_emod_four_of_odd {a : ℤ} (ha : a % 2 = 1) : a ^ 2 % 4 = 1 := by
+  obtain ⟨k, rfl⟩ := Int.odd_iff.mpr ha
+  have h : (2 * k + 1) ^ 2 = 4 * (k ^ 2 + k) + 1 := by ring
+  omega
+
+/-! ## Part II: The hypotenuse is `1 (mod 4)`
+
+We extract the primitive parametrization `x = m² − n², y = 2mn` (or the legs
+swapped), deduce `z² = (m² + n²)²`, use `0 < z` to take the positive root
+`z = m² + n²`, and finish with the mod-4 squares from Part I. -/
+
+/-- **Main result.** The hypotenuse of a primitive Pythagorean triple with `0 < z`
+satisfies `z ≡ 1 (mod 4)`. -/
+theorem hypotenuse_one_mod_four (h : PythagoreanTriple x y z)
+    (hc : Int.gcd x y = 1) (hz : 0 < z) : z % 4 = 1 := by
+  obtain ⟨m, n, hxy, -, hpar⟩ := h.isPrimitiveClassified_of_coprime_of_pos hc hz
+  have he : x * x + y * y = z * z := h
+  -- In either leg-ordering the Pythagorean identity gives z² = (m² + n²)².
+  have hsq : z * z = (m ^ 2 + n ^ 2) * (m ^ 2 + n ^ 2) := by
+    rcases hxy with ⟨hx, hy⟩ | ⟨hx, hy⟩
+    · subst hx; subst hy; linear_combination -he
+    · subst hx; subst hy; linear_combination -he
+  -- z and m² + n² are both ≥ 0 with equal squares, so they are equal.
+  have hw0 : (0 : ℤ) ≤ m ^ 2 + n ^ 2 := by positivity
+  have hfac : (z - (m ^ 2 + n ^ 2)) * (z + (m ^ 2 + n ^ 2)) = 0 := by
+    linear_combination hsq
+  have hzeq : z = m ^ 2 + n ^ 2 := by
+    rcases mul_eq_zero.mp hfac with h1 | h2
+    · linarith
+    · linarith
+  rw [hzeq]
+  -- m, n have opposite parity: one square is 0 mod 4, the other 1 mod 4.
+  rcases hpar with ⟨hme, hno⟩ | ⟨hmo, hne⟩
+  · have h1 := sq_emod_four_of_even hme
+    have h2 := sq_emod_four_of_odd hno
+    omega
+  · have h1 := sq_emod_four_of_odd hmo
+    have h2 := sq_emod_four_of_even hne
+    omega
+
+/-! ## Part III: Consequences -/
+
+/-- The hypotenuse of a primitive Pythagorean triple (with `0 < z`) is odd. This
+is the weaker statement `PythagoreanTriplesOQ07.hypotenuse_odd`, recovered here as
+an immediate corollary of the sharper mod-4 result. -/
+theorem hypotenuse_odd (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1)
+    (hz : 0 < z) : z % 2 = 1 := by
+  have := hypotenuse_one_mod_four h hc hz
+  omega
+
+/-- **Structural consequence.** No integer `≡ 3 (mod 4)` is the hypotenuse of a
+primitive Pythagorean triple. Concretely, `3, 7, 11, 19, 23, …` never occur as a
+primitive hypotenuse. -/
+theorem not_primitive_hypotenuse_of_three_mod_four
+    (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) (hz : 0 < z) :
+    z % 4 ≠ 3 := by
+  have := hypotenuse_one_mod_four h hc hz
+  omega
+
+/-- The smallest primitive triple `(3, 4, 5)`: its hypotenuse `5 ≡ 1 (mod 4)`. -/
+theorem example_3_4_5 :
+    PythagoreanTriple 3 4 5 ∧ Int.gcd 3 4 = 1 ∧ (5 : ℤ) % 4 = 1 := by
+  refine ⟨?_, ?_, ?_⟩
+  · unfold PythagoreanTriple; norm_num
+  · decide
+  · decide
+
+/-- `(20, 21, 29)`, a primitive triple with both legs large: `29 ≡ 1 (mod 4)`. -/
+theorem example_20_21_29 :
+    PythagoreanTriple 20 21 29 ∧ Int.gcd 20 21 = 1 ∧ (29 : ℤ) % 4 = 1 := by
+  refine ⟨?_, ?_, ?_⟩
+  · unfold PythagoreanTriple; norm_num
+  · decide
+  · decide
+
+end PythagoreanTriplesOQ10

--- a/src/data/proofs/pythagorean-triples-oq-10/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-10/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-sq-mod-four",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 45, "endLine": 54 },
+    "type": "technique",
+    "title": "Squares mod 4: even ↦ 0, odd ↦ 1",
+    "content": "The two residue facts the whole result rests on. Writing an even integer as $a = k+k$ gives $a^2 = 4k^2 \\equiv 0 \\pmod 4$; an odd integer $a = 2k+1$ gives $a^2 = 4(k^2+k)+1 \\equiv 1 \\pmod 4$. Each proof destructures the parity hypothesis into an explicit witness (`Int.even_iff` / `Int.odd_iff`), supplies the polynomial identity by `ring`, and lets `omega` read off the residue over the opaque atom $a^2$. The mod-4 refinement (not just mod 2) is precisely what distinguishes this entry from mere oddness.",
+    "mathContext": "$a \\equiv 0 \\pmod 2 \\Rightarrow a^2 \\equiv 0;\\quad a \\equiv 1 \\pmod 2 \\Rightarrow a^2 \\equiv 1 \\pmod 4.$",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residues", "modular arithmetic", "parity"],
+    "prerequisites": ["modular arithmetic", "integer division with remainder"]
+  },
+  {
+    "id": "ann-extract-param",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 64, "endLine": 73 },
+    "type": "insight",
+    "title": "Why z² Is Not Enough — Extracting z = m² + n²",
+    "content": "The crux of the sharpening. The weaker sibling result deduces oddness from $z^2 = x^2+y^2 \\equiv 1 \\pmod 4$, but that congruence cannot tell $z \\equiv 1$ from $z \\equiv 3$ — both odd residues square to 1. To pin the residue we need the actual value of $z$, so we call Mathlib's `isPrimitiveClassified_of_coprime_of_pos` to obtain coprime $m,n$ of opposite parity with $x = m^2-n^2,\\ y = 2mn$ (or the legs swapped). Substituting into the Pythagorean identity and clearing with `linear_combination` yields $z^2 = (m^2+n^2)^2$ in both leg-orderings.",
+    "mathContext": "$(m^2-n^2)^2 + (2mn)^2 = (m^2+n^2)^2$, so $z^2 = (m^2+n^2)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean parametrisation", "primitive triples", "sum of two squares"],
+    "prerequisites": ["Pythagorean triple classification", "polynomial identities"]
+  },
+  {
+    "id": "ann-positive-root",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 74, "endLine": 82 },
+    "type": "technique",
+    "title": "Taking the Positive Square Root Algebraically",
+    "content": "From $z^2 = (m^2+n^2)^2$ we want $z = m^2+n^2$, not $z = -(m^2+n^2)$. No `sqrt` is invoked: instead $(z-(m^2+n^2))(z+(m^2+n^2)) = z^2-(m^2+n^2)^2 = 0$ (supplied by `linear_combination`), and `mul_eq_zero` splits into two cases. The hypothesis $0 < z$ together with $m^2+n^2 \\ge 0$ kills the $z + (m^2+n^2) = 0$ branch by `linarith`, leaving $z = m^2+n^2$. This is exactly where positivity is load-bearing — drop it and $z \\equiv 3 \\pmod 4$ becomes possible.",
+    "mathContext": "$z^2 = w^2,\\ 0 < z,\\ 0 \\le w \\Rightarrow z = w$ via $(z-w)(z+w)=0$.",
+    "significance": "key",
+    "relatedConcepts": ["no zero divisors", "square roots in ordered rings", "positivity"],
+    "prerequisites": ["integral domains", "ordered ring inequalities"]
+  },
+  {
+    "id": "ann-residue",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 83, "endLine": 89 },
+    "type": "insight",
+    "title": "Opposite Parity Forces z ≡ 1 (mod 4)",
+    "content": "With $z = m^2+n^2$ in hand, the classification guarantees $m,n$ have opposite parity. In either case one of $m^2, n^2$ is $0 \\pmod 4$ and the other is $1 \\pmod 4$ (by the Part I lemmas), so their sum — and hence $z$ — is $1 \\pmod 4$. `omega` closes both branches over the atoms $m^2, n^2$ given their residues. Had $m,n$ shared parity, the sum would be $0$ or $2 \\pmod 4$; opposite parity is the structural fact pinning the answer to exactly $1$.",
+    "mathContext": "$\\{m^2,n^2\\} \\equiv \\{0,1\\} \\pmod 4 \\Rightarrow z = m^2+n^2 \\equiv 1 \\pmod 4.$",
+    "significance": "key",
+    "relatedConcepts": ["parity", "modular arithmetic", "sum of two squares"],
+    "prerequisites": ["modular arithmetic", "parity of integers"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 91, "endLine": 109 },
+    "type": "context",
+    "title": "Corollaries: Odd, and No 3-mod-4 Hypotenuses",
+    "content": "Two immediate consequences of $z \\equiv 1 \\pmod 4$. First, `hypotenuse_odd` recovers $z \\% 2 = 1$ by `omega` — this is the strictly weaker sibling statement (OQ-07), here a one-line corollary. Second, `not_primitive_hypotenuse_of_three_mod_four` records the structural exclusion: no integer $\\equiv 3 \\pmod 4$ is ever the hypotenuse of a primitive triple, so $3, 7, 11, 19, 23, \\dots$ are ruled out despite being odd. This is the parity shadow of the deeper fact that a primitive hypotenuse is a product of primes $\\equiv 1 \\pmod 4$.",
+    "mathContext": "$z \\equiv 1 \\pmod 4 \\Rightarrow z \\text{ odd and } z \\not\\equiv 3 \\pmod 4.$",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of two squares", "primes 1 mod 4", "Diophantine obstructions"],
+    "prerequisites": ["modular arithmetic"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "pythagorean-triples-oq-10",
+    "range": { "startLine": 110, "endLine": 126 },
+    "type": "context",
+    "title": "Concrete Witnesses (3,4,5) and (20,21,29)",
+    "content": "Two primitive triples confirming the residue. The smallest, $(3,4,5)$, has hypotenuse $5 \\equiv 1 \\pmod 4$; the less obvious $(20,21,29)$ — with both legs large and close — has $29 \\equiv 1 \\pmod 4$. Each is checked by `norm_num` for the Pythagorean identity and `decide` for the gcd and residue, grounding the abstract theorem in computable instances.",
+    "mathContext": "$3^2+4^2=5^2,\\ 5 \\equiv 1;\\quad 20^2+21^2=29^2,\\ 29 \\equiv 1 \\pmod 4.$",
+    "significance": "supporting",
+    "relatedConcepts": ["primitive triples", "worked examples"],
+    "prerequisites": ["arithmetic"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-10/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-10/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ10.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq10Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq10Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq10Data: ProofData = {
+  proof: pythagoreanTriplesOq10Proof,
+  annotations: pythagoreanTriplesOq10Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-10/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-10/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "pythagorean-triples-oq-10",
+  "title": "Hypotenuse of a Primitive Pythagorean Triple is ≡ 1 (mod 4)",
+  "slug": "pythagorean-triples-oq-10",
+  "description": "For a primitive Pythagorean triple x²+y²=z² with coprime legs and positive hypotenuse, the hypotenuse satisfies z ≡ 1 (mod 4) — in particular z is odd. This sharpens the sibling 'hypotenuse is odd' result: oddness follows from z² ≡ 1 (mod 4) alone, but pinning the residue to 1 (rather than 3) requires the actual parametrization z = m²+n² with m,n of opposite parity. Consequently no integer ≡ 3 (mod 4) is ever a primitive hypotenuse.",
+  "meta": {
+    "author": "classical; Euclid / Fermat",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ10.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "modular-arithmetic",
+      "parity",
+      "diophantine",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.isPrimitiveClassified_of_coprime_of_pos",
+        "description": "A primitive triple with 0 < z admits the parametrization x = m²−n², y = 2mn (or legs swapped) with m,n coprime of opposite parity",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "Int.odd_iff",
+        "description": "Odd n ↔ n % 2 = 1",
+        "module": "Mathlib.Algebra.Ring.Int.Parity"
+      },
+      {
+        "theorem": "Int.even_iff",
+        "description": "Even n ↔ n % 2 = 0",
+        "module": "Mathlib.Algebra.Group.Int.Even"
+      },
+      {
+        "theorem": "mul_eq_zero",
+        "description": "a * b = 0 ↔ a = 0 ∨ b = 0 (no zero divisors), used to take the positive square root",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sq_emod_four_of_even / sq_emod_four_of_odd: the residues of even and odd squares mod 4 (0 and 1)",
+      "hypotenuse_one_mod_four: the main result — z ≡ 1 (mod 4) for a primitive triple with 0 < z, via z = m²+n² and opposite parity",
+      "hypotenuse_odd: oddness recovered as a corollary of the sharper mod-4 statement",
+      "not_primitive_hypotenuse_of_three_mod_four: structural consequence — no integer ≡ 3 (mod 4) is a primitive hypotenuse",
+      "example_3_4_5 / example_20_21_29: concrete primitive triples confirming 5 ≡ 1 and 29 ≡ 1 (mod 4)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 126,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Every primitive Pythagorean triple has the form x = m²−n², y = 2mn, z = m²+n² with m,n coprime of opposite parity (Euclid's Elements, Book X). A direct corollary, already known to Fermat and central to his work on sums of two squares, is that the hypotenuse z = m²+n² is a sum of two coprime squares, hence ≡ 1 (mod 4) and a product of primes ≡ 1 (mod 4). This is strictly stronger than the bare statement that the hypotenuse is odd: the residue 3 (mod 4) is impossible, so numbers like 3, 7, 11, 19, 23, … never occur as a primitive hypotenuse even though they are odd.",
+    "problemStatement": "Can we machine-check that the hypotenuse of a primitive Pythagorean triple (with positive z) is ≡ 1 (mod 4), not merely odd?\n\n**Answer: Yes.** Extracting the parametrization z = m²+n² and using that m,n have opposite parity, one square is 0 (mod 4) and the other 1 (mod 4), so z ≡ 1 (mod 4).",
+    "text": "The hypotenuse of a primitive Pythagorean triple is ≡ 1 (mod 4) — a sharpening of mere oddness that needs the parametrization, not just z².",
+    "proofStrategy": "Invoke Mathlib's isPrimitiveClassified_of_coprime_of_pos to obtain m,n with x = m²−n², y = 2mn (or legs swapped), coprime and of opposite parity. Substituting into the Pythagorean identity gives z² = (m²+n²)². Since 0 < z and m²+n² ≥ 0, factor (z−(m²+n²))(z+(m²+n²)) = 0 and use no-zero-divisors plus positivity to take the positive root z = m²+n². Finally, opposite parity makes one of m², n² ≡ 0 and the other ≡ 1 (mod 4) (sq_emod_four_of_even / sq_emod_four_of_odd), so z ≡ 1 (mod 4) by omega.",
+    "keyInsights": [
+      "z² ≡ 1 (mod 4) alone is NOT enough: both 1 and 3 square to 1 mod 4, so oddness is all z² can give. The residue is determined only by the explicit value z = m²+n².",
+      "The positivity hypothesis 0 < z is load-bearing — it picks the positive square root z = +(m²+n²) over z = −(m²+n²); the latter would give z ≡ 3 (mod 4).",
+      "Opposite parity of m,n is exactly what forces z = m²+n² ≡ 0+1 = 1 (mod 4); if m,n could share parity the residue would change.",
+      "Taking the square root is done algebraically with no `sqrt`: (z−w)(z+w)=0 with w ≥ 0 < z forces z = w via mul_eq_zero and linarith.",
+      "omega finishes the modular bookkeeping over the opaque atoms m², n² once their residues mod 4 are supplied."
+    ],
+    "prerequisites": [
+      "Modular arithmetic (residues mod 4)",
+      "Parity of integers",
+      "Pythagorean triples, primitivity, and the Euclidean parametrization"
+    ]
+  },
+  "sections": [
+    {
+      "id": "squares-mod-four",
+      "title": "Squares modulo 4",
+      "startLine": 39,
+      "endLine": 54,
+      "summary": "An even square is 0 mod 4 and an odd square is 1 mod 4 — the two residue facts the result rests on.",
+      "mathContext": "$a$ even $\\Rightarrow a^2 \\equiv 0$, $\\;a$ odd $\\Rightarrow a^2 \\equiv 1 \\pmod 4$."
+    },
+    {
+      "id": "main",
+      "title": "The Hypotenuse is 1 (mod 4)",
+      "startLine": 56,
+      "endLine": 89,
+      "summary": "Extract z = m²+n² from the primitive parametrization (using 0 < z to pick the positive root), then opposite parity gives z ≡ 1 mod 4.",
+      "mathContext": "$z = m^2+n^2$ with $m,n$ opposite parity $\\Rightarrow z \\equiv 0+1 = 1 \\pmod 4$."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences",
+      "startLine": 91,
+      "endLine": 126,
+      "summary": "The hypotenuse is odd (corollary), no integer ≡ 3 mod 4 is a primitive hypotenuse, and the (3,4,5) and (20,21,29) examples.",
+      "mathContext": "$z \\equiv 1 \\pmod 4 \\Rightarrow z$ odd and $z \\not\\equiv 3 \\pmod 4$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book X",
+      "year": "c. 300 BCE",
+      "note": "Classical parametrisation of primitive Pythagorean triples"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Primitive-triple parametrisation; hypotenuse as a sum of two coprime squares ≡ 1 mod 4"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "extends",
+      "description": "OQ-07 proves the hypotenuse is odd (z % 2 = 1); this entry sharpens it to z ≡ 1 (mod 4), which requires the explicit parametrization rather than z² alone."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "OQ-06 establishes the coprime-parameter classification (m²−n², 2mn, m²+n²) used here to extract z = m²+n²."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Refines the structure of Pythagorean triples by pinning the hypotenuse residue mod 4."
+    }
+  ],
+  "conclusion": {
+    "summary": "The hypotenuse of a primitive Pythagorean triple with 0 < z is ≡ 1 (mod 4), machine-checked with 0 axioms. The proof extracts z = m²+n² from Mathlib's classification, takes the positive square root algebraically, and reads off the residue from the opposite parity of m,n.",
+    "implications": "Strengthens the classical 'hypotenuse is odd' to the sharp residue z ≡ 1 (mod 4), excluding all z ≡ 3 (mod 4). This is the parity face of the deeper fact that a primitive hypotenuse is a sum of two coprime squares, hence a product of primes ≡ 1 (mod 4).",
+    "openQuestions": [
+      "Can one formalise the converse direction — that every integer all of whose prime factors are ≡ 1 (mod 4) is the hypotenuse of some primitive triple?",
+      "Does the even leg's stronger divisibility (4 ∣ even leg) combine with this to characterise hypotenuse residues mod 8?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanTriplesOQ10",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ10.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves that the hypotenuse of a **primitive** Pythagorean triple $x^2+y^2=z^2$ (coprime legs) with $0 < z$ satisfies $z \equiv 1 \pmod 4$ — in particular $z$ is odd.

This **sharpens** the sibling entry `pythagorean-triples-oq-07`, which only establishes $z \% 2 = 1$ (oddness).

## Why this is a genuine strengthening, not a restatement

Oddness already follows from $z^2 = x^2 + y^2 \equiv 1 \pmod 4$. But that congruence is **blind** to whether $z \equiv 1$ or $z \equiv 3 \pmod 4$ — both odd residues square to $1$. Determining the residue requires the *actual value*
$$z = m^2 + n^2,\qquad m,n \text{ coprime of opposite parity},$$
supplied by Mathlib's `PythagoreanTriple.isPrimitiveClassified_of_coprime_of_pos`. Opposite parity makes one of $m^2, n^2$ equal to $0 \pmod 4$ and the other $1 \pmod 4$, so $z \equiv 1 \pmod 4$.

The positivity hypothesis $0 < z$ is **load-bearing**: it selects the positive square root $z = +(m^2+n^2)$ over $z = -(m^2+n^2)$ (the latter gives $z \equiv 3$). The root is taken algebraically — $(z-w)(z+w)=0$ with $0<z$, $w\ge 0$ — with no `sqrt`.

## Contents (7 theorems, 126 lines, 0 sorries)

- `sq_emod_four_of_even` / `sq_emod_four_of_odd` — even/odd squares mod 4 are 0/1
- `hypotenuse_one_mod_four` — **main result**, $z \equiv 1 \pmod 4$
- `hypotenuse_odd` — oddness as a one-line corollary (the weaker OQ-07 statement)
- `not_primitive_hypotenuse_of_three_mod_four` — structural consequence: no integer $\equiv 3 \pmod 4$ (e.g. $3,7,11,19,\dots$) is ever a primitive hypotenuse
- `example_3_4_5`, `example_20_21_29` — concrete witnesses ($5\equiv1$, $29\equiv1$)

## Verification

- **0 sorries, 0 axioms** (`#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`)
- Built with host `lake env lean`, Lean **v4.26.0** / Mathlib **4.26.0**
- No `native_decide`; the two examples use `decide` only on small concrete gcd/residue facts

🤖 Generated with [Claude Code](https://claude.com/claude-code)