### PR TITLE
research(derangements-convergence-oq-04): (n−1) ∣ D(n) for n ≥ 2 + companion congruence D(n) ≡ (−1)ⁿ (mod n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/DerangementsConvergenceOQ04.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ04.lean
@@ -1,0 +1,92 @@
+/-
+  Derangements: (n − 1) divides D(n) for all n ≥ 2
+  Open Question: derangements-convergence-oq-04
+
+  The number of derangements D(n) = numDerangements n is divisible by n − 1
+  for every n ≥ 2.
+
+  ## Main Result
+
+  `sub_one_dvd_numDerangements` (PROVED): For n ≥ 2,
+    (n - 1) ∣ numDerangements n
+
+  This is an immediate consequence of the additive derangement recurrence
+    D(n) = (n - 1) · (D(n-2) + D(n-1))           (numDerangements_add_two)
+  which exhibits n − 1 as an explicit factor of D(n). We also record the
+  explicit factorisation `numDerangements_eq_sub_one_mul`.
+
+  ## Companion Result
+
+  `numDerangements_congr_neg_one_pow` (PROVED): For all n,
+    (n : ℤ) ∣ (numDerangements n - (-1)^n)
+  i.e. D(n) ≡ (-1)^n (mod n). This is the classical companion congruence,
+  obtained from the multiplicative recurrence
+    D(n+1) = (n+1) · D(n) − (-1)^n             (numDerangements_succ)
+  by cancelling the alternating term: D(n+1) − (-1)^{n+1} = (n+1) · D(n).
+
+  Both divisibility facts are read directly off the two standard Mathlib
+  recurrences for `numDerangements`; the proofs are fully machine-checked
+  with no additional axioms.
+-/
+
+import Mathlib
+
+open Nat
+
+namespace DerangementsConvergenceOQ04
+
+/-- Explicit factorisation of D(n) for n ≥ 2: the additive recurrence rewritten
+    with the index shifted back so that the factor `n - 1` is visible. -/
+theorem numDerangements_eq_sub_one_mul (n : ℕ) (hn : 2 ≤ n) :
+    numDerangements n = (n - 1) * (numDerangements (n - 2) + numDerangements (n - 1)) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  simpa using numDerangements_add_two m
+
+/-- **Main result.** For every n ≥ 2, the number of derangements D(n) is
+    divisible by n − 1.
+
+    Proof: write n = m + 2, so n − 1 = m + 1. The additive recurrence
+    `numDerangements_add_two` gives
+      D(m+2) = (m+1) · (D(m) + D(m+1)),
+    exhibiting m + 1 = n − 1 as an explicit factor. -/
+theorem sub_one_dvd_numDerangements (n : ℕ) (hn : 2 ≤ n) :
+    (n - 1) ∣ numDerangements n := by
+  refine ⟨numDerangements (n - 2) + numDerangements (n - 1), ?_⟩
+  exact numDerangements_eq_sub_one_mul n hn
+
+/-- **Companion congruence.** For every n, `n ∣ (D(n) − (-1)^n)`, i.e.
+    D(n) ≡ (-1)^n (mod n).
+
+    Proof: from the multiplicative recurrence
+      D(n+1) = (n+1) · D(n) − (-1)^n        (numDerangements_succ)
+    we compute, using (-1)^{n+1} = −(-1)^n,
+      D(n+1) − (-1)^{n+1} = (n+1) · D(n),
+    so n + 1 divides D(n+1) − (-1)^{n+1}. The case n = 0 is `0 ∣ 0`. -/
+theorem numDerangements_congr_neg_one_pow (n : ℕ) :
+    (n : ℤ) ∣ ((numDerangements n : ℤ) - (-1) ^ n) := by
+  cases n with
+  | zero => simp
+  | succ k =>
+    refine ⟨numDerangements k, ?_⟩
+    rw [numDerangements_succ k, pow_succ]
+    push_cast
+    ring
+
+/-- Restatement of the companion congruence as a `ZMod` equality:
+    D(n) = (-1)^n in ℤ/nℤ. -/
+theorem numDerangements_zmod_eq (n : ℕ) :
+    (numDerangements n : ZMod n) = (-1) ^ n := by
+  have h := numDerangements_congr_neg_one_pow n
+  have := (ZMod.intCast_zmod_eq_zero_iff_dvd _ n).mpr h
+  push_cast at this
+  linear_combination this
+
+-- Concrete sanity checks of the main divisibility statement.
+example : (2 - 1) ∣ numDerangements 2 := sub_one_dvd_numDerangements 2 (by norm_num)
+example : (4 - 1) ∣ numDerangements 4 := sub_one_dvd_numDerangements 4 (by norm_num)
+example : numDerangements 4 = 9 := by decide
+example : numDerangements 5 = 44 := by decide
+-- D(5) = 44 = 4 · 11, so 4 = 5 − 1 divides D(5).
+example : (5 - 1) ∣ numDerangements 5 := sub_one_dvd_numDerangements 5 (by norm_num)
+
+end DerangementsConvergenceOQ04

--- a/src/data/proofs/derangements-convergence-oq-04/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-04/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-dcoq04-header",
+    "proofId": "derangements-convergence-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "Module Overview: Divisibility and Congruence for Derangements",
+    "content": "This module proves two arithmetic facts about the derangement numbers D(n) = numDerangements n. The main result is that n − 1 divides D(n) for every n ≥ 2; the companion result is the classical congruence D(n) ≡ (−1)^n (mod n) for all n. Both are read directly off Mathlib's two standard recurrences for numDerangements — no induction or case analysis beyond a single index shift is required. The module imports all of Mathlib and opens the Nat namespace.",
+    "mathContext": "The two recurrences: the additive $D(n+2) = (n+1)\\,(D(n)+D(n+1))$ (`numDerangements_add_two`) puts $n-1$ in front as a literal factor, giving $(n-1)\\mid D(n)$; the multiplicative $(D(n+1):\\mathbb{Z}) = (n+1)D(n) - (-1)^n$ (`numDerangements_succ`) gives the congruence $D(n)\\equiv(-1)^n\\pmod n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "numDerangements",
+      "numDerangements_add_two",
+      "numDerangements_succ",
+      "derangement recurrence"
+    ],
+    "prerequisites": [
+      "Mathlib.Combinatorics.Derangements.Finite (numDerangements and its recurrences)",
+      "Basic divisibility and modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-dcoq04-factorisation",
+    "proofId": "derangements-convergence-oq-04",
+    "range": {
+      "startLine": 38,
+      "endLine": 43
+    },
+    "type": "proof_technique",
+    "title": "Explicit Factorisation D(n) = (n−1)·(D(n−2)+D(n−1))",
+    "content": "The lemma numDerangements_eq_sub_one_mul reindexes the additive recurrence so that n − 1 appears explicitly. Writing n = m + 2 (legitimate since n ≥ 2, discharged by omega), the goal becomes D(m+2) = (m+1)·(D(m)+D(m+1)), which is exactly numDerangements_add_two up to the Nat subtractions n−1 = m+1 and n−2 = m; `simpa` closes the gap. This factorisation is the single source of the divisibility witness used in the main theorem.",
+    "mathContext": "$D(n) = (n-1)\\,(D(n-2)+D(n-1))$. The combinatorial content: place element $n$ into one of the $n-1$ non-fixed positions, then either the resulting transposition is reciprocated (leaving a derangement of the other $n-2$ elements) or not (leaving a derangement-like structure on $n-1$ elements).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "numDerangements_add_two",
+      "index shift",
+      "omega",
+      "simpa"
+    ],
+    "prerequisites": [
+      "numDerangements_add_two: D(n+2) = (n+1)(D(n)+D(n+1))",
+      "Nat subtraction and the n = m + 2 reindexing"
+    ]
+  },
+  {
+    "id": "ann-dcoq04-main",
+    "proofId": "derangements-convergence-oq-04",
+    "range": {
+      "startLine": 45,
+      "endLine": 55
+    },
+    "type": "key_step",
+    "title": "Main Theorem: (n − 1) ∣ D(n)",
+    "content": "sub_one_dvd_numDerangements is proved by supplying the explicit quotient: the divisibility (n−1) ∣ D(n) unfolds to ∃ c, D(n) = (n−1)·c, and the factorisation lemma provides c = D(n−2) + D(n−1) together with the required equation. The proof is therefore `refine ⟨_, ?_⟩; exact numDerangements_eq_sub_one_mul n hn`. The hypothesis n ≥ 2 ensures n − 1 is a meaningful modulus and that the reindexing in the factorisation lemma applies.",
+    "mathContext": "$(n-1)\\mid D(n)$ with explicit quotient $D(n)/(n-1) = D(n-2)+D(n-1)$. Verified at small values: $D(2)=1$ (n−1=1), $D(4)=9=3\\cdot 3$, $D(5)=44=4\\cdot 11$, $D(6)=265=5\\cdot 53$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Dvd",
+      "divisibility witness",
+      "numDerangements_eq_sub_one_mul"
+    ],
+    "prerequisites": [
+      "Definition of divisibility a ∣ b ↔ ∃ c, b = a·c",
+      "The factorisation lemma numDerangements_eq_sub_one_mul"
+    ]
+  },
+  {
+    "id": "ann-dcoq04-congruence",
+    "proofId": "derangements-convergence-oq-04",
+    "range": {
+      "startLine": 57,
+      "endLine": 92
+    },
+    "type": "key_step",
+    "title": "Companion Congruence: D(n) ≡ (−1)^n (mod n)",
+    "content": "numDerangements_congr_neg_one_pow proves (n : ℤ) ∣ (D(n) − (−1)^n) for all n. The n = 0 case is 0 ∣ 0 (simp). For n = k + 1, the witness is D(k); substituting numDerangements_succ (D(k+1) = (k+1)·D(k) − (−1)^k) and expanding (−1)^{k+1} = (−1)^k·(−1) via pow_succ, the identity D(k+1) − (−1)^{k+1} = (k+1)·D(k) is closed by push_cast and ring. The follow-on numDerangements_zmod_eq restates this in ZMod n as (D(n) : ZMod n) = (−1)^n, bridging via ZMod.intCast_zmod_eq_zero_iff_dvd. Three closing examples sanity-check the main divisibility on n = 2, 4, 5.",
+    "mathContext": "$D(n+1) - (-1)^{n+1} = (n+1)D(n)$ because $(-1)^{n+1} = -(-1)^n$, so the $-(-1)^n$ in the recurrence cancels the $-(-1)^{n+1}$. Hence $n \\mid D(n) - (-1)^n$, equivalently $D(n) \\equiv (-1)^n \\pmod n$. This holds for every $n$, including the degenerate $n = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "numDerangements_succ",
+      "ZMod.intCast_zmod_eq_zero_iff_dvd",
+      "pow_succ",
+      "modular congruence"
+    ],
+    "prerequisites": [
+      "numDerangements_succ: (D(n+1) : ℤ) = (n+1)·D(n) − (−1)^n",
+      "(−1)^{n+1} = −(−1)^n",
+      "The ZMod ↔ integer-divisibility correspondence"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-04/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-04/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "derangements-convergence-oq-04",
+  "title": "(n − 1) divides D(n)",
+  "slug": "derangements-convergence-oq-04",
+  "description": "Proves that the number of derangements D(n) = numDerangements n is divisible by n − 1 for every n ≥ 2. The divisibility is read directly off the additive derangement recurrence D(n) = (n−1)·(D(n−2)+D(n−1)), which exhibits n−1 as an explicit factor. A companion result establishes the classical congruence D(n) ≡ (−1)^n (mod n) for all n, obtained from the multiplicative recurrence D(n+1) = (n+1)·D(n) − (−1)^n.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "divisibility",
+      "recurrence",
+      "congruence",
+      "number-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Both theorems are fully machine-checked. The proofs delegate to Mathlib's two standard recurrences for numDerangements: the additive recurrence numDerangements_add_two (D(n+2) = (n+1)·(D(n)+D(n+1))) and the multiplicative/alternating recurrence numDerangements_succ ((D(n+1) : ℤ) = (n+1)·D(n) − (−1)^n). Only the foundational axioms propext, Classical.choice, Quot.sound are used.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 92,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "sub_one_dvd_numDerangements (PROVED, MAIN): for n ≥ 2, (n − 1) ∣ numDerangements n",
+      "numDerangements_eq_sub_one_mul (PROVED, helper): for n ≥ 2, D(n) = (n−1)·(D(n−2)+D(n−1)) — the additive recurrence reindexed to expose n−1 as a factor",
+      "numDerangements_congr_neg_one_pow (PROVED, companion): for all n, (n : ℤ) ∣ (D(n) − (−1)^n), i.e. D(n) ≡ (−1)^n (mod n)",
+      "numDerangements_zmod_eq (PROVED, restatement): for all n, (D(n) : ZMod n) = (−1)^n"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements_add_two",
+        "description": "Additive recurrence D(n+2) = (n+1)·(D(n) + D(n+1)) — exhibits n−1 as an explicit factor of D(n)",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "numDerangements_succ",
+        "description": "Multiplicative/alternating recurrence (D(n+1) : ℤ) = (n+1)·D(n) − (−1)^n — engine for the companion congruence",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(a : ZMod n) = 0 ↔ (n : ℤ) ∣ a — bridges the integer divisibility to the ZMod restatement",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Derangements — permutations with no fixed point — were first counted by Pierre de Montmort (1708) and Leonhard Euler (1751), who derived D(n) = n!·Σ_{k=0}^n (−1)^k/k!. Two recurrences underlie virtually all elementary facts about D(n): the symmetric additive recurrence D(n) = (n−1)·(D(n−1)+D(n−2)) and the asymmetric multiplicative recurrence D(n) = n·D(n−1) + (−1)^n. The additive recurrence has a transparent combinatorial proof (condition on where element n is sent and whether the swap is reciprocated), and it immediately shows that n−1 divides D(n) — the statement of this open question. The multiplicative recurrence yields, just as immediately, the classical congruence D(n) ≡ (−1)^n (mod n), a standard exercise in elementary number theory. Both are folklore results that appear in Riordan's and Stanley's combinatorics texts.",
+    "problemStatement": "**OQ-04 of derangements-convergence**\n\nProve that for every n ≥ 2, the number of derangements D(n) is divisible by n − 1:\n\n  (n − 1) ∣ D(n).",
+    "text": "For n ≥ 2, (n - 1) ∣ numDerangements n.",
+    "proofStrategy": "**Main result (one step).** Write n = m + 2, so n − 1 = m + 1. Mathlib's `numDerangements_add_two` states D(m+2) = (m+1)·(D(m)+D(m+1)), which already exhibits m+1 = n−1 as a factor of D(n). The divisibility witness is therefore D(n−2) + D(n−1).\n\n**Companion congruence.** For n = k + 1, the multiplicative recurrence `numDerangements_succ` gives (D(k+1) : ℤ) = (k+1)·D(k) − (−1)^k. Since (−1)^{k+1} = −(−1)^k, we get D(k+1) − (−1)^{k+1} = (k+1)·D(k), so (k+1) ∣ (D(k+1) − (−1)^{k+1}). The n = 0 case is 0 ∣ 0. Casting into ZMod n via `ZMod.intCast_zmod_eq_zero_iff_dvd` restates this as (D(n) : ZMod n) = (−1)^n.",
+    "keyInsights": [
+      "The additive recurrence D(n) = (n−1)·(D(n−1)+D(n−2)) is the right tool: it puts n−1 in front as a literal factor, so the divisibility is definitional once the index is shifted. No induction is needed.",
+      "The two standard derangement recurrences encode two different divisibility facts: the *additive* recurrence gives (n−1) ∣ D(n), while the *multiplicative* recurrence D(n) = n·D(n−1)+(−1)^n gives the congruence D(n) ≡ (−1)^n (mod n). The companion result captures the second, complementary to the headline.",
+      "The congruence D(n) ≡ (−1)^n (mod n) holds for ALL n (including n = 0, where it degenerates to 0 ∣ 0), not just n ≥ 2 — it is in this sense more uniform than the headline divisibility, which needs n ≥ 2 for n−1 to be a meaningful modulus.",
+      "Combining the two: for n ≥ 2 both n−1 (exactly) and n (up to the sign correction (−1)^n) constrain D(n). Since gcd(n−1, n) = 1, this pins down D(n) modulo n(n−1) once the residues are known.",
+      "The proofs are computation-free in the sense of requiring no case analysis beyond a single index shift; `ring` and `push_cast` discharge the algebraic identity D(n+1) − (−1)^{n+1} = (n+1)·D(n) after substituting the recurrence."
+    ],
+    "prerequisites": [
+      "numDerangements_add_two and numDerangements_succ from Mathlib's Combinatorics.Derangements.Finite",
+      "Basic divisibility (Dvd) and the ZMod ↔ integer-divisibility bridge",
+      "The derangement function numDerangements and its definition by the order-2 recurrence"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring stating the main divisibility (n−1) ∣ D(n) for n ≥ 2 and the companion congruence D(n) ≡ (−1)^n (mod n), with the two driving Mathlib recurrences. Imports Mathlib, opens Nat, namespace DerangementsConvergenceOQ04.",
+      "mathContext": "The two engines: `numDerangements_add_two` (additive, gives the n−1 factor) and `numDerangements_succ` (multiplicative, gives the congruence)."
+    },
+    {
+      "id": "sec-factorisation",
+      "title": "Explicit Factorisation",
+      "startLine": 38,
+      "endLine": 43,
+      "summary": "numDerangements_eq_sub_one_mul: for n ≥ 2, D(n) = (n−1)·(D(n−2)+D(n−1)). Proof writes n = m+2 and simplifies numDerangements_add_two.",
+      "mathContext": "$D(n) = (n-1)\\,(D(n-2)+D(n-1))$ — the additive recurrence reindexed so the factor $n-1$ is visible."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Result: (n − 1) ∣ D(n)",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "sub_one_dvd_numDerangements: for n ≥ 2, (n−1) ∣ numDerangements n. The divisibility witness D(n−2)+D(n−1) comes directly from the factorisation lemma.",
+      "mathContext": "$(n-1)\\mid D(n)$ because $D(n) = (n-1)\\cdot(D(n-2)+D(n-1))$; the quotient is $D(n-2)+D(n-1)$."
+    },
+    {
+      "id": "sec-congruence",
+      "title": "Companion Congruence: D(n) ≡ (−1)^n (mod n)",
+      "startLine": 57,
+      "endLine": 92,
+      "summary": "numDerangements_congr_neg_one_pow: for all n, (n : ℤ) ∣ (D(n) − (−1)^n), via numDerangements_succ and (−1)^{n+1} = −(−1)^n; n=0 is 0∣0. numDerangements_zmod_eq restates it as (D(n) : ZMod n) = (−1)^n. Closing examples sanity-check the main divisibility on n = 2, 4, 5.",
+      "mathContext": "$D(n+1) - (-1)^{n+1} = (n+1)\\,D(n)$ follows from $D(n+1) = (n+1)D(n) - (-1)^n$ since $(-1)^{n+1} = -(-1)^n$; hence $D(n) \\equiv (-1)^n \\pmod n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Root: derangement definitions D(n) = n!·Σ(−1)^k/k! and the recurrences numDerangements_add_two / numDerangements_succ used here."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "sibling",
+      "description": "Parent convergence entry; this OQ extracts an elementary divisibility/congruence property of D(n) rather than its asymptotics."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling proving D(n) = round(n!/e); together the OQ-03/OQ-04 pair record the analytic (rounding) and arithmetic (divisibility/congruence) faces of the same recurrence."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "foundational",
+      "description": "The derangement count and its recurrences originate from the inclusion-exclusion sieve over fixed-point sets."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified: for all n ≥ 2, (n − 1) ∣ D(n), read directly off the additive recurrence D(n) = (n−1)·(D(n−2)+D(n−1)). A companion result proves the classical congruence D(n) ≡ (−1)^n (mod n) for all n, from the multiplicative recurrence. Zero sorries, zero extra axioms.",
+    "implications": "**Arithmetic structure of D(n)**: The two recurrences give two divisibility constraints — (n−1) ∣ D(n) exactly, and D(n) ≡ (−1)^n (mod n). Since gcd(n, n−1) = 1, these jointly determine D(n) modulo n(n−1).\\n\\n**Quotient sequence**: D(n)/(n−1) = D(n−2) + D(n−1) is itself an integer sequence worth naming; it satisfies its own linear recurrence inherited from D.",
+    "openQuestions": [
+      "Identify the quotient sequence q(n) = D(n)/(n−1) = D(n−2)+D(n−1) in the OEIS and prove a closed form or generating function for it.",
+      "Sharpen the modulus: for which n does n(n−1) ∣ (D(n) − c) for an explicit residue c, combining the two divisibility facts via CRT?",
+      "Generalise to r-derangements (permutations avoiding a fixed cycle structure): does an analogous (n−1)-divisibility or (−1)^n-congruence hold for the generalized derangement numbers D_r(n)?",
+      "Formalise the purely combinatorial bijective proof of the additive recurrence (condition on the image of element n and whether the transposition is reciprocated), making the n−1 factor structural rather than recurrence-derived."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "sub_one_dvd_numDerangements",
+      "type": "core",
+      "description": "For n ≥ 2, (n − 1) divides numDerangements n.",
+      "leanType": "(n : ℕ) → 2 ≤ n → (n - 1) ∣ numDerangements n"
+    },
+    {
+      "name": "numDerangements_congr_neg_one_pow",
+      "type": "core",
+      "description": "For all n, n divides D(n) − (−1)^n, i.e. D(n) ≡ (−1)^n (mod n).",
+      "leanType": "(n : ℕ) → (n : ℤ) ∣ ((numDerangements n : ℤ) - (-1) ^ n)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "DerangementsConvergenceOQ04",
+    "lineCount": 92,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 2,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "First derivation of the derangement numbers and their recurrences in the analysis of the game of rencontres."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Independent treatment of derangements; states both the additive and multiplicative recurrences underlying the divisibility facts proved here."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3 'Permutations with restricted position'",
+      "note": "Standard reference for the derangement recurrences D(n) = (n−1)(D(n−1)+D(n−2)) and D(n) = nD(n−1)+(−1)^n, from which (n−1) ∣ D(n) and D(n) ≡ (−1)^n (mod n) follow."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, 2nd edition, §2.2",
+      "note": "Modern treatment via exponential generating functions e^{-x}/(1-x); the recurrences and elementary divisibility properties are standard exercises."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves open question **oq-04** of the parent `derangements-convergence` entry: the number of derangements $D(n) = $ `numDerangements n` is divisible by $n-1$ for every $n \ge 2$.

The result is read directly off Mathlib's **additive** derangement recurrence; a companion result captures the complementary arithmetic fact coming from the **multiplicative** recurrence.

## Theorems (all PROVED, 0 sorries, 0 extra axioms)

| Theorem | Statement |
|---|---|
| `sub_one_dvd_numDerangements` (MAIN) | for $n \ge 2$, $(n-1) \mid D(n)$ |
| `numDerangements_eq_sub_one_mul` (helper) | $D(n) = (n-1)\,(D(n-2)+D(n-1))$ for $n \ge 2$ |
| `numDerangements_congr_neg_one_pow` (companion) | $n \mid (D(n) - (-1)^n)$ for all $n$, i.e. $D(n) \equiv (-1)^n \pmod n$ |
| `numDerangements_zmod_eq` | $(D(n) : \mathrm{ZMod}\ n) = (-1)^n$ |

## Proof engines

- **Main:** `numDerangements_add_two` — $D(n+2) = (n+1)\,(D(n)+D(n+1))$ exhibits $n-1$ as a literal factor after the index shift $n = m+2$; the quotient is $D(n-2)+D(n-1)$. No induction needed.
- **Companion:** `numDerangements_succ` — $(D(n+1):\mathbb{Z}) = (n+1)D(n) - (-1)^n$; since $(-1)^{n+1} = -(-1)^n$, the alternating term cancels to give $D(n+1) - (-1)^{n+1} = (n+1)D(n)$.

The additive and multiplicative recurrences thus encode two distinct divisibility facts; since $\gcd(n-1,n)=1$ they jointly pin down $D(n) \bmod n(n-1)$.

## Verification

- `lake env lean` typechecks clean (Lean v4.26.0, Mathlib).
- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status `verified`, badge `original`, `axiomCount` 0.
- Examples sanity-check the divisibility on $n = 2, 4, 5$ (using `decide`, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)