### PR TITLE
research(erdos-1023-oq-03): strict monotonicity F(n) < F(n+1) for union-free families [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1023ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos1023ProblemOQ03.lean
@@ -327,10 +327,113 @@ element never decreases the maximum union-free family size. -/
 theorem unionFreeMax_le_succ (n : ℕ) : unionFreeMax n ≤ unionFreeMax (n + 1) :=
   unionFreeMax_mono (Nat.le_succ n)
 
+/-!
+## Strict monotonicity via a fresh ground element
+
+The successor bound `F(n) ≤ F(n+1)` above can be sharpened to *strict*
+monotonicity `F(n) + 1 ≤ F(n+1)`: the extra ground element `n` always lets us
+enlarge an extremal family by exactly one. Take an extremal union-free family
+`G` on `Fin n`, relabel it into `Fin (n+1)` (so no member then contains the new
+top element `Fin.last n`), and adjoin the singleton `{Fin.last n}`. That new
+element is *fresh* — it lies in no relabelled member — so the enlarged family is
+still union-free (`unionFree_insert_fresh`) and strictly larger, giving
+`F(n) + 1 ≤ F(n+1)` (`unionFreeMax_succ_strict`). Hence `F` is *strictly*
+increasing (`unionFreeMax_strictMono`), a sharpening of `unionFreeMax_monotone`.
+-/
+
+/-- **Adjoining a set with a fresh element preserves union-freeness.** If `F` is
+union-free and `A` contains a ground element `x` lying in no member of `F`, then
+`insert A F` is union-free. The fresh element `x` blocks every potential
+spurious union: a union of `≥ 2` members equal to `A` would have to omit `x`
+(no member of `F` contains it), and a union producing some `B ∈ F` cannot use
+`A` (that would force `x ∈ B`), so it reduces to a spurious union already inside
+`F`. -/
+theorem unionFree_insert_fresh {n : ℕ} {F : SetFamily n} {A : Finset (Fin n)}
+    (hF : isUnionFree F) {x : Fin n} (hxA : x ∈ A) (hxF : ∀ B ∈ F, x ∉ B) :
+    isUnionFree (insert A F) := by
+  -- `x` lies in no union of a subfamily of `F`
+  have hxUnion : ∀ {G : SetFamily n}, G ⊆ F → x ∉ familyUnion G := by
+    intro G hG hx
+    rw [mem_familyUnion] at hx
+    obtain ⟨C, hC, hxC⟩ := hx
+    exact hxF C (hG hC) hxC
+  intro B hB ⟨G, hGsub, hGcard, hBnotG, hGunion⟩
+  rcases Finset.mem_insert.mp hB with rfl | hBF
+  · -- `B = A`: the union `G` lives in `F`, so it misses `x ∈ A`
+    have hGF : G ⊆ F := by
+      intro C hC
+      have hmem := hGsub hC
+      rw [Finset.mem_erase, Finset.mem_insert] at hmem
+      rcases hmem.2 with rfl | h
+      · exact absurd rfl hmem.1
+      · exact h
+    apply hxUnion hGF
+    rw [hGunion]; exact hxA
+  · -- `B ∈ F`: `A ∉ G` (else `x ∈ B`), so `G ⊆ F.erase B` is a spurious union in `F`
+    have hAnotG : A ∉ G := by
+      intro hAG
+      exact hxF B hBF (hGunion ▸ mem_sub_familyUnion hAG hxA)
+    have hGsub' : G ⊆ F.erase B := by
+      intro C hC
+      have hmem := hGsub hC
+      rw [Finset.mem_erase, Finset.mem_insert] at hmem
+      rw [Finset.mem_erase]
+      refine ⟨hmem.1, ?_⟩
+      rcases hmem.2 with rfl | h
+      · exact absurd hC hAnotG
+      · exact h
+    exact hF B hBF ⟨G, hGsub', hGcard, hBnotG, hGunion⟩
+
+/-- **Strict monotonicity:** `F(n) + 1 ≤ F(n+1)`. The fresh ground element `n`
+strictly increases the maximum union-free family size: relabel an extremal
+family into `Fin (n+1)` and adjoin the singleton `{Fin.last n}` of the new top
+element, which lies in no relabelled member. -/
+theorem unionFreeMax_succ_strict (n : ℕ) :
+    unionFreeMax n + 1 ≤ unionFreeMax (n + 1) := by
+  -- an extremal family `G` of size `F(n)` exists: the `sSup` of a nonempty
+  -- subset of `ℕ` bounded above is attained
+  have hne : { k : ℕ | ∃ F : SetFamily n, isUnionFree F ∧ F.card = k }.Nonempty :=
+    ⟨0, ∅, isUnionFree_empty, Finset.card_empty⟩
+  obtain ⟨G, hG, hGcard⟩ :
+      ∃ G : SetFamily n, isUnionFree G ∧ G.card = unionFreeMax n :=
+    Nat.sSup_mem hne (unionFree_sizes_bddAbove n)
+  -- relabel into `Fin (n+1)` along `castLE`, then adjoin `{Fin.last n}`
+  set e : Fin n ↪ Fin (n + 1) := Fin.castLEEmb (Nat.le_succ n) with he
+  set A : Finset (Fin (n + 1)) := {Fin.last n} with hA
+  have hxA : Fin.last n ∈ A := Finset.mem_singleton_self _
+  -- the new element is fresh: no relabelled member contains `Fin.last n`
+  have hfresh : ∀ B ∈ pushFamily e G, Fin.last n ∉ B := by
+    intro B hB
+    rw [mem_pushFamily] at hB
+    obtain ⟨C, _, rfl⟩ := hB
+    rw [Finset.mem_map]
+    rintro ⟨a, _, ha⟩
+    have h1 : ((e a : Fin (n + 1)) : ℕ) = (a : ℕ) := rfl
+    have h2 : ((e a : Fin (n + 1)) : ℕ) = n := by rw [ha]; exact Fin.val_last n
+    have h3 : (a : ℕ) < n := a.isLt
+    omega
+  -- the enlarged family is union-free and strictly larger
+  have hUF : isUnionFree (insert A (pushFamily e G)) :=
+    unionFree_insert_fresh (pushFamily_unionFree e G hG) hxA hfresh
+  have hAnot : A ∉ pushFamily e G := fun h => hfresh A h hxA
+  have hcard : (insert A (pushFamily e G)).card = unionFreeMax n + 1 := by
+    rw [Finset.card_insert_of_notMem hAnot, pushFamily_card, hGcard]
+  rw [← hcard]
+  exact le_csSup (unionFree_sizes_bddAbove (n + 1))
+    ⟨insert A (pushFamily e G), hUF, rfl⟩
+
+/-- **`F` is strictly monotone.** Strengthens `unionFreeMax_monotone`: the
+extremal union-free family size strictly increases with the number of ground
+elements, `n < m → F(n) < F(m)`. -/
+theorem unionFreeMax_strictMono : StrictMono unionFreeMax :=
+  strictMono_nat_of_lt_succ unionFreeMax_succ_strict
+
 #check @layer_antichain
 #check @unionFreeMax_ge_choose
 #check @unionFreeMax_exponential_lower_bound
 #check @unionFreeMax_mono
 #check @pushFamily_unionFree
+#check @unionFreeMax_succ_strict
+#check @unionFreeMax_strictMono
 
 end Erdos1023OQ03

--- a/research/problems/erdos-1023-oq-03/knowledge.md
+++ b/research/problems/erdos-1023-oq-03/knowledge.md
@@ -1,0 +1,44 @@
+# erdos-1023-oq-03 — knowledge
+
+## Status
+SOLVED / verified, 0-axiom. File `proofs/Proofs/Erdos1023ProblemOQ03.lean`.
+Isolates the axiom-free **lower-bound** half of Erdős #1023 (union-free families
+`F(n) = max size with no member the union of ≥2 others`).
+
+## Established (parent + prior sessions)
+- `unionFreeMax_ge_choose`: `F(n) ≥ C(n,k)` for every layer `k` (every layer is
+  an antichain, antichains are union-free).
+- `unionFreeMax_exponential_lower_bound`: `2ⁿ ≤ (n+1)·F(n)`, i.e. `F(n) ≥ 2ⁿ/(n+1)`.
+- `unionFreeMax_mono` / `unionFreeMax_le_succ`: `F(n) ≤ F(m)` for `n ≤ m`, via a
+  relabelling push-forward `pushFamily e` (preserves card + union-freeness).
+
+## This session (2026-06-24, researcher-1)
+Added **strict monotonicity**, sharpening `F(n) ≤ F(n+1)` to `F(n) < F(n+1)`:
+- `unionFree_insert_fresh`: adjoining a set `A` containing a ground element `x`
+  in no member of `F` keeps `insert A F` union-free. Fresh `x` blocks every
+  spurious union (a union = `A` must omit `x`; a union = some `B∈F` cannot use
+  `A` without forcing `x∈B`).
+- `unionFreeMax_succ_strict`: `F(n) + 1 ≤ F(n+1)`. Extract an extremal family `G`
+  via `Nat.sSup_mem` (sSup of a nonempty bounded ℕ-set is attained), push it into
+  `Fin (n+1)` along `Fin.castLEEmb (Nat.le_succ n)`, adjoin `{Fin.last n}` —
+  fresh because `castLE` values are `< n`.
+- `unionFreeMax_strictMono`: `StrictMono unionFreeMax`, via
+  `strictMono_nat_of_lt_succ`.
+
+### Gotchas
+- Fresh worktree off `origin/main` has NO mathlib build cache → re-clones deps,
+  `unknown module prefix 'Mathlib'`. Build in the MAIN checkout (`cp` file in,
+  `git checkout --` to restore), `git` from the worktree.
+- `Finset.card_insert_of_not_mem` deprecated → `Finset.card_insert_of_notMem`.
+- `(Fin.castLE h a : ℕ) = (a : ℕ)` is `rfl`; `(Fin.last n : ℕ) = n` is
+  `Fin.val_last` → close freshness with `omega`.
+- `Nat.sSup_mem hne bdd` gives membership; ascribe the `obtain` type with
+  `unionFreeMax n` (def-eq to the `sSup`) so `hGcard : G.card = unionFreeMax n`.
+
+## Still open
+1. Tighten `2ⁿ/(n+1)` toward sharp `C(n,⌊n/2⌋)` (axiom-free Stirling estimates).
+2. Axiom-free Erdős–Kleitman upper bound `F(n) ≤ C(n,⌊n/2⌋)` (removes parent's
+   Problem-447 axioms).
+3. Quantitative growth: axiom-free `F(n+1) ≥ F(n) + g(n)` with `g(n) → ∞`
+   (the fresh-element trick only gives `+1`).
+4. `k`-union-free / other forbidden Boolean operations.

--- a/src/data/proofs/erdos-1023-oq-03/meta.json
+++ b/src/data/proofs/erdos-1023-oq-03/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-1023-oq-03",
-  "title": "Erdős #1023: an axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) and monotonicity F(n) ≤ F(m) for union-free families from single-layer constructions",
+  "title": "Erdős #1023: an axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) and strict monotonicity F(n) < F(n+1) for union-free families from single-layer constructions",
   "slug": "erdos-1023-oq-03",
   "leanFile": {
     "imports": [
@@ -10,14 +10,14 @@
       "Finset"
     ],
     "namespace": "Erdos1023OQ03",
-    "lineCount": 336,
+    "lineCount": 439,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 8,
     "path": "Proofs/Erdos1023ProblemOQ03.lean",
     "sorries": 0
   },
-  "description": "Isolates the fully self-contained, axiom-free part of Erdős Problem #1023 (union-free families: F(n) = max size of a family of subsets of {1,…,n} with no member the union of two or more others). The parent file proves F(n) = C(n, ⌊n/2⌋) but routes the matching UPPER bound through Problem 447 as an external input (5 axioms). This entry develops only the LOWER-bound construction, which needs no axioms. Three points: (1) the middle layer is not special — EVERY layer (all k-element subsets, any fixed k) is an antichain, hence union-free, so F(n) ≥ C(n, k) for every k (unionFreeMax_ge_choose), strictly generalising the parent's middle-layer bound; (2) summing the binomial row 2ⁿ = Σ C(n,k) and bounding each term by the central one gives 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (two_pow_le_succ_mul_central); (3) combining them yields the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1), proved purely from the single middle-layer construction and independent of the harder upper bound. This already certifies F(n) grows exponentially — the crude pigeonhole 2ⁿ/(n+1) differs from the true ~√(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1). A fourth, structural point is added: (4) the extremal function is MONOTONE, F(n) ≤ F(m) for n ≤ m (unionFreeMax_mono), with successor form F(n) ≤ F(n+1) (unionFreeMax_le_succ). The proof is a relabelling push-forward — any injection Fin n ↪ Fin m lifts to a map pushFamily on set families that relabels every member set, preserving cardinality (pushFamily_card) and union-freeness (pushFamily_unionFree, via familyUnion_pushFamily: taking images along an injection commutes with unions), so every achievable family size on Fin n is achievable on Fin m and the supremum can only grow. Self-contained: the small lower-bound infrastructure (set families, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared from the parent so nothing depends on the axiom-carrying asymptotic section. 20 theorems, 8 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "description": "Isolates the fully self-contained, axiom-free part of Erdős Problem #1023 (union-free families: F(n) = max size of a family of subsets of {1,…,n} with no member the union of two or more others). The parent file proves F(n) = C(n, ⌊n/2⌋) but routes the matching UPPER bound through Problem 447 as an external input (5 axioms). This entry develops only the LOWER-bound construction, which needs no axioms. Three points: (1) the middle layer is not special — EVERY layer (all k-element subsets, any fixed k) is an antichain, hence union-free, so F(n) ≥ C(n, k) for every k (unionFreeMax_ge_choose), strictly generalising the parent's middle-layer bound; (2) summing the binomial row 2ⁿ = Σ C(n,k) and bounding each term by the central one gives 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (two_pow_le_succ_mul_central); (3) combining them yields the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1), proved purely from the single middle-layer construction and independent of the harder upper bound. This already certifies F(n) grows exponentially — the crude pigeonhole 2ⁿ/(n+1) differs from the true ~√(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1). A fourth, structural point is added: (4) the extremal function is MONOTONE, F(n) ≤ F(m) for n ≤ m (unionFreeMax_mono), with successor form F(n) ≤ F(n+1) (unionFreeMax_le_succ). The proof is a relabelling push-forward — any injection Fin n ↪ Fin m lifts to a map pushFamily on set families that relabels every member set, preserving cardinality (pushFamily_card) and union-freeness (pushFamily_unionFree, via familyUnion_pushFamily: taking images along an injection commutes with unions), so every achievable family size on Fin n is achievable on Fin m and the supremum can only grow. Self-contained: the small lower-bound infrastructure (set families, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared from the parent so nothing depends on the axiom-carrying asymptotic section. 20 theorems, 8 definitions, 0 sorries, 0 axioms, no native_decide. A fifth point STRENGTHENS the monotonicity to STRICT: F(n) + 1 ≤ F(n+1) (unionFreeMax_succ_strict), so F is strictly increasing (unionFreeMax_strictMono). The argument adjoins, to the relabelled extremal family on Fin (n+1), the singleton {Fin.last n} of the fresh top element — which lies in no relabelled member — and a general lemma (unionFree_insert_fresh) shows that adjoining any set containing a ground element absent from every current member preserves union-freeness, while strictly increasing the size. 23 theorems, 8 definitions, 0 sorries, 0 axioms, no native_decide.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -36,9 +36,9 @@
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
-    "assumptions": "Machine-checked against the Mathlib pin (Lean v4.26.0). 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound] for every theorem (verified on unionFreeMax_exponential_lower_bound, unionFreeMax_ge_choose, layer_antichain, unionFreeMax_ge_two_pow_div, unionFreeMax_mono, pushFamily_unionFree, unionFreeMax_le_succ). Self-contained: the lower-bound infrastructure (SetFamily, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared here verbatim from the parent Erdos1023Problem.lean, whose asymptotic section carries the 5 axioms routing the matching upper bound through Problem 447 — those are neither imported nor used here. Honest scope: this is the unconditional LOWER bound F(n) ≥ 2ⁿ/(n+1) (the exponential growth certificate) plus the structural monotonicity F(n) ≤ F(m), not the sharp value F(n) = C(n, ⌊n/2⌋), whose upper half remains the parent's axiomatised external input.",
-    "lineCount": 336,
-    "theoremCount": 20,
+    "assumptions": "Machine-checked against the Mathlib pin (Lean v4.26.0). 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound] for every theorem (verified on unionFreeMax_exponential_lower_bound, unionFreeMax_ge_choose, layer_antichain, unionFreeMax_ge_two_pow_div, unionFreeMax_mono, pushFamily_unionFree, unionFreeMax_le_succ, unionFreeMax_succ_strict, unionFreeMax_strictMono, unionFree_insert_fresh). Self-contained: the lower-bound infrastructure (SetFamily, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared here verbatim from the parent Erdos1023Problem.lean, whose asymptotic section carries the 5 axioms routing the matching upper bound through Problem 447 — those are neither imported nor used here. Honest scope: this is the unconditional LOWER bound F(n) ≥ 2ⁿ/(n+1) (the exponential growth certificate) plus the structural monotonicity F(n) ≤ F(m), not the sharp value F(n) = C(n, ⌊n/2⌋), whose upper half remains the parent's axiomatised external input.",
+    "lineCount": 439,
+    "theoremCount": 23,
     "definitionCount": 8,
     "originalContributions": [
       "layer_antichain: every layer (the family of all k-element subsets of Fin n) is an antichain, for every k — generalising the parent's middleLayer_antichain (the k = n/2 case)",
@@ -50,7 +50,10 @@
       "pushFamily / familyUnion_pushFamily / pushFamily_card: a relabelling push-forward of set families along an embedding Fin n ↪ Fin m that preserves cardinality and commutes with familyUnion (taking images along an injection distributes over unions)",
       "pushFamily_unionFree: union-freeness is preserved under the relabelling push-forward — a spurious union among relabelled sets pulls back to one among the originals",
       "unionFreeMax_mono / unionFreeMax_monotone: monotonicity of the extremal function, F(n) ≤ F(m) for n ≤ m — a structural property of F absent from the parent, obtained by pushing an extremal family forward along Fin.castLEEmb so the set of achievable sizes can only grow",
-      "unionFreeMax_le_succ: the successor form F(n) ≤ F(n+1)"
+      "unionFreeMax_le_succ: the successor form F(n) ≤ F(n+1)",
+      "unionFree_insert_fresh: adjoining a set with a FRESH ground element (one belonging to no current member) to a union-free family preserves union-freeness — the fresh element blocks every spurious union, reducing any new union back to one inside the original family; a reusable enlargement lemma",
+      "unionFreeMax_succ_strict: STRICT monotonicity F(n) + 1 ≤ F(n+1), sharpening unionFreeMax_le_succ — relabel an extremal family into Fin (n+1) and adjoin the singleton {Fin.last n} of the new top element, which is fresh, giving a strictly larger union-free family",
+      "unionFreeMax_strictMono: F is strictly monotone (StrictMono unionFreeMax), n < m → F(n) < F(m), strengthening unionFreeMax_monotone from ≤ to <"
     ]
   },
   "overview": {
@@ -62,7 +65,8 @@
       "The central binomial coefficient already controls the whole row: 2ⁿ = Σ_k C(n,k) ≤ (n+1)·C(n, ⌊n/2⌋), so a single layer captures at least a 1/(n+1) fraction of all 2ⁿ subsets.",
       "Combining the two gives an unconditional exponential lower bound 2ⁿ/(n+1) ≤ F(n) that needs none of the axiomatised upper-bound machinery — the crude pigeonhole differs from the sharp √(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1).",
       "Separating the axiom-free lower-bound half from the axiom-carrying upper-bound half makes the unconditional content of the formalization explicit and machine-verifiable as 0-axiom.",
-      "Monotonicity is structural, not numeric: relabelling a union-free family along an injection Fin n ↪ Fin m preserves both its size and its union-freeness (image along an injection commutes with unions), so F(n) ≤ F(m) follows by transporting extremal families forward — independent of the exact value of F."
+      "Monotonicity is structural, not numeric: relabelling a union-free family along an injection Fin n ↪ Fin m preserves both its size and its union-freeness (image along an injection commutes with unions), so F(n) ≤ F(m) follows by transporting extremal families forward — independent of the exact value of F.",
+      "Monotonicity is in fact STRICT: the new ground element always buys exactly one more set. Adjoining the singleton of the fresh top element to a relabelled extremal family stays union-free (a set built only from a fresh element cannot be a union of old members, and no old member is a union using it), so F(n) < F(n+1) — strengthening F(n) ≤ F(n+1) to strict."
     ]
   },
   "sections": [
@@ -92,19 +96,20 @@
     },
     {
       "id": "monotonicity",
-      "title": "Monotonicity of the extremal function via relabelling push-forward",
-      "summary": "isUnionFree_empty (nonemptiness witness) and mem_familyUnion; pushFamily (relabel a family along Fin n ↪ Fin m), pushFamily_card (injective relabelling preserves size), familyUnion_pushFamily (images along an injection commute with unions), pushFamily_unionFree (union-freeness is preserved by pushing forward), and the payoff unionFreeMax_mono / unionFreeMax_monotone (F(n) ≤ F(m) for n ≤ m, via Fin.castLEEmb) with the successor form unionFreeMax_le_succ (F(n) ≤ F(n+1)).",
+      "title": "Monotonicity (and strict monotonicity) of the extremal function",
+      "summary": "isUnionFree_empty (nonemptiness witness) and mem_familyUnion; pushFamily (relabel a family along Fin n ↪ Fin m), pushFamily_card (injective relabelling preserves size), familyUnion_pushFamily (images along an injection commute with unions), pushFamily_unionFree (union-freeness is preserved by pushing forward), and the payoff unionFreeMax_mono / unionFreeMax_monotone (F(n) ≤ F(m) for n ≤ m, via Fin.castLEEmb) with the successor form unionFreeMax_le_succ (F(n) ≤ F(n+1)). Strengthened to STRICT monotonicity: unionFree_insert_fresh (adjoining a set with a fresh ground element preserves union-freeness), unionFreeMax_succ_strict (F(n)+1 ≤ F(n+1)), and unionFreeMax_strictMono (StrictMono unionFreeMax).",
       "startLine": 192,
-      "endLine": 336,
+      "endLine": 439,
       "mathContext": "A new structural property of the extremal function, absent from the parent: F is monotone. Pushing an extremal union-free family forward along the standard embedding Fin n ↪ Fin m relabels its members injectively while preserving union-freeness, so every achievable family size on n ground elements is achievable on m ≥ n, and the supremum unionFreeMax can only increase."
     }
   ],
   "conclusion": {
-    "summary": "The union-free extremal function satisfies the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), equivalently F(n) ≥ 2ⁿ/(n+1). It is obtained by generalising the parent's single middle-layer construction to all layers (F(n) ≥ C(n,k) for every k) and combining the k = ⌊n/2⌋ case with the row bound 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋). This certifies exponential growth of F(n) using none of the axiomatised upper-bound machinery, and is verified 0-axiom over Mathlib.",
+    "summary": "The union-free extremal function satisfies the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), equivalently F(n) ≥ 2ⁿ/(n+1). It is obtained by generalising the parent's single middle-layer construction to all layers (F(n) ≥ C(n,k) for every k) and combining the k = ⌊n/2⌋ case with the row bound 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋). This certifies exponential growth of F(n) using none of the axiomatised upper-bound machinery, and is verified 0-axiom over Mathlib. The structural monotonicity is moreover STRICT, F(n) < F(n+1), via a fresh-element enlargement of any extremal family.",
     "implications": "Separates the unconditional lower-bound content of Erdős #1023 from the harder, externally-routed upper bound, making the machine-verifiable axiom-free core explicit. The single-layer construction and the central-binomial row bound 2ⁿ ≤ (n+1)·C(n,⌊n/2⌋) are reusable across extremal set theory (Sperner-type antichain bounds, LYM, union-free and cover-free families).",
     "openQuestions": [
       "Tighten the elementary lower bound from 2ⁿ/(n+1) toward the sharp C(n, ⌊n/2⌋) by replacing the crude row bound with Stirling-type central-binomial estimates, keeping the argument axiom-free.",
       "Give an axiom-free formalization of the Erdős–Kleitman upper bound F(n) ≤ C(n, ⌊n/2⌋), removing the parent's dependence on the Problem-447 external input.",
+      "Quantify the strict growth: is F(n+1) − F(n) eventually large (the single fresh element gives only +1, but the true gap C(n+1,⌊(n+1)/2⌋) − C(n,⌊n/2⌋) grows)? Establish an axiom-free super-additive growth bound F(n+1) ≥ F(n) + g(n) with g(n) → ∞.",
       "Generalise the single-layer lower bound to k-union-free families (no member the union of at most k others) and to other forbidden Boolean operations (intersection-free, difference-free)."
     ]
   },


### PR DESCRIPTION
## Summary

Extends the verified, 0-axiom Erdős #1023 lower-bound entry (`erdos-1023-oq-03`) with **strict monotonicity** of the union-free extremal function `F(n)`, sharpening the existing successor bound.

The entry was already SOLVED (verified, 0 axioms, 0 sorries). Per the SOLVED follow-up strategy, this adds a genuinely new, theory-level structural result:

- Existing: `unionFreeMax_le_succ` — `F(n) ≤ F(n+1)`.
- **New:** `unionFreeMax_succ_strict` — `F(n) + 1 ≤ F(n+1)`, hence `unionFreeMax_strictMono` — `StrictMono unionFreeMax` (`n < m → F(n) < F(m)`).

## Mathematical content

The new ground element always buys exactly one more set. Take an extremal union-free family `G` on `Fin n` (it exists: `Nat.sSup_mem` — the `sSup` of a nonempty bounded `ℕ`-set is attained), relabel it into `Fin (n+1)` along `Fin.castLEEmb`, and adjoin the singleton `{Fin.last n}` of the new top element. That element is **fresh** — it lies in no relabelled member — so the enlarged family is still union-free and strictly larger.

This is packaged as a reusable lemma `unionFree_insert_fresh`: adjoining any set containing a ground element absent from every current member preserves union-freeness. The fresh element blocks every spurious union (a union equal to `A` must omit it; a union equal to some old member can't use `A` without forcing the fresh element into that member), reusing the existing `pushFamily` push-forward infrastructure.

## Verification

- 3 new theorems, all 0-axiom: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for `unionFree_insert_fresh`, `unionFreeMax_succ_strict`, `unionFreeMax_strictMono`.
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- Builds against the Mathlib pin (Lean v4.26.0).
- File: 20 → 23 theorems, 336 → 439 lines. `meta.json` and `knowledge.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)