### PR TITLE
research(fibonacci-oq-02-oq-01-oq-01): Fibonacci–Lucas quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean
@@ -1,0 +1,187 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# The Fibonacci–Lucas Quadratic Identity `Lₙ² − 5Fₙ² = 4(−1)ⁿ`
+
+## What This Proves
+
+The parent entry (`fibonacci-identities-oq-02-oq-01`) settled the *divisibility*
+question for the Lucas numbers `Lₙ` (`L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁`):
+the Lucas numbers are **not** a strong divisibility sequence, and its positive
+engine was the **product identity** `F_{2n} = Fₙ · Lₙ`.
+
+This entry supplies the *second* fundamental Fibonacci–Lucas identity — the one
+that complements the product identity — as a **universally quantified theorem**
+(not merely on instances):
+
+    Lₙ² − 5·Fₙ² = 4·(−1)ⁿ                        (`lucas_sq_sub_five_fib_sq`)
+
+over `ℤ`. Two structural consequences follow:
+
+* **`Lₙ² = 5·Fₙ² ± 4`.** The Lucas number `Lₙ` is, up to the fixed defect `±4`,
+  exactly `√5·Fₙ`. This is the integer shadow of Binet's formulas
+  `Fₙ = (φⁿ − ψⁿ)/√5`, `Lₙ = φⁿ + ψⁿ`, with `φψ = −1`.
+
+* **`gcd(Fₙ, Lₙ) ∣ 2`** (`gcd_fib_lucas_dvd_two`): the Fibonacci and Lucas
+  numbers of the *same* index are coprime up to a factor of `2`. So
+  `gcd(Fₙ, Lₙ) ∈ {1, 2}` always — the companion sequences barely interact
+  multiplicatively at a fixed index, in sharp contrast to the product identity
+  `Fₙ ∣ F_{2n}` and `Lₙ ∣ F_{2n}` linking index `n` to index `2n`.
+
+## How It's Proved
+
+Everything reduces, via the already-established bridge `Lₙ = 2·Fₙ₊₁ − Fₙ`, to a
+single **pure Fibonacci identity**
+
+    Fₙ₊₁² − Fₙ₊₁·Fₙ − Fₙ² = (−1)ⁿ              (`fib_sq_sub`)
+
+— a sign-clean relative of Cassini's identity. This one closes under a
+*one-step* induction: substituting `Fₙ₊₂ = Fₙ + Fₙ₊₁` turns the `(n+1)` form
+into the negation of the `n` form (`ring`), so the value just flips sign at each
+step. Substituting the bridge then gives `Lₙ² − 5Fₙ² = 4·(Fₙ₊₁² − Fₙ₊₁Fₙ − Fₙ²)
+= 4(−1)ⁿ` by `linear_combination`.
+
+The `gcd` corollary is elementary: any common divisor `d` of `Fₙ` and `Lₙ`
+divides `Lₙ + Fₙ = 2·Fₙ₊₁`; since `Fₙ` and `Fₙ₊₁` are coprime
+(`Nat.fib_coprime_fib_succ`), `d` is coprime to `Fₙ₊₁`, hence `d ∣ 2`.
+-/
+
+namespace FibonacciIdentitiesOQ02OQ01OQ01
+
+open Nat
+
+/-! ## Definition of the Lucas numbers
+
+We reuse the structural pair recursion of the parent entry so this file is
+self-contained. `lucas` reduces by `rfl` / `decide`. -/
+
+/-- The pair `(Lₙ, Lₙ₊₁)`. -/
+def lucasPair : ℕ → ℕ × ℕ
+  | 0 => (2, 1)
+  | n + 1 => ((lucasPair n).2, (lucasPair n).1 + (lucasPair n).2)
+
+/-- The Lucas numbers `Lₙ`: `L₀ = 2`, `L₁ = 1`, `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+def lucas (n : ℕ) : ℕ := (lucasPair n).1
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining recurrence `Lₙ₊₂ = Lₙ + Lₙ₊₁`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-! ## The Fibonacci bridge `2·Fₙ₊₁ = Lₙ + Fₙ` -/
+
+/-- The subtraction-free bridge `2·Fₙ₊₁ = Lₙ + Fₙ`, by two-step induction. -/
+theorem two_mul_fib_succ (n : ℕ) : 2 * fib (n + 1) = lucas n + fib n := by
+  induction n using Nat.twoStepInduction with
+  | zero => rfl
+  | one => rfl
+  | more n ih1 ih2 =>
+      have h1 : fib (n + 2) = fib n + fib (n + 1) := fib_add_two
+      have h2 : fib (n + 3) = fib (n + 1) + fib (n + 2) := fib_add_two
+      have h3 : lucas (n + 2) = lucas n + lucas (n + 1) := lucas_add_two n
+      -- restate the IHs with `n+2` (defeq to `n+1+1`) so `omega` shares atoms
+      have e1 : 2 * fib (n + 1) = lucas n + fib n := ih1
+      have e2 : 2 * fib (n + 2) = lucas (n + 1) + fib (n + 1) := ih2
+      show 2 * fib (n + 3) = lucas (n + 2) + fib (n + 2)
+      omega
+
+/-- The closed form over `ℤ`: `Lₙ = 2·Fₙ₊₁ − Fₙ` (no truncated subtraction). -/
+theorem lucas_eq_int (n : ℕ) : (lucas n : ℤ) = 2 * fib (n + 1) - fib n := by
+  have := two_mul_fib_succ n
+  have : (2 * fib (n + 1) : ℤ) = lucas n + fib n := by exact_mod_cast this
+  linarith
+
+/-! ## The core Fibonacci identity `Fₙ₊₁² − Fₙ₊₁·Fₙ − Fₙ² = (−1)ⁿ` -/
+
+/-- A sign-clean relative of Cassini's identity:
+`Fₙ₊₁² − Fₙ₊₁·Fₙ − Fₙ² = (−1)ⁿ`, over `ℤ`. Proved by one-step induction —
+substituting `Fₙ₊₂ = Fₙ + Fₙ₊₁` negates the form, so the sign alternates. -/
+theorem fib_sq_sub (n : ℕ) :
+    (fib (n + 1) : ℤ) ^ 2 - fib (n + 1) * fib n - (fib n) ^ 2 = (-1) ^ n := by
+  induction n with
+  | zero => norm_num
+  | succ k ih =>
+      have hrec : (fib (k + 1 + 1) : ℤ) = fib k + fib (k + 1) := by
+        exact_mod_cast fib_add_two
+      -- the `(k+1)`-form is the negation of the `k`-form (pure `ring` after `hrec`)
+      have key : (fib (k + 1 + 1) : ℤ) ^ 2 - fib (k + 1 + 1) * fib (k + 1)
+                   - (fib (k + 1)) ^ 2
+               = -((fib (k + 1) : ℤ) ^ 2 - fib (k + 1) * fib k - (fib k) ^ 2) := by
+        rw [hrec]; ring
+      rw [key, ih]; ring
+
+/-! ## The quadratic identity and its consequences -/
+
+/-- **The Fibonacci–Lucas quadratic identity:** `Lₙ² − 5·Fₙ² = 4·(−1)ⁿ`,
+over `ℤ`, for every `n`. The companion to the product identity
+`F_{2n} = Fₙ·Lₙ`; the integer shadow of `φψ = −1` in Binet's formulas. -/
+theorem lucas_sq_sub_five_fib_sq (n : ℕ) :
+    (lucas n : ℤ) ^ 2 - 5 * (fib n) ^ 2 = 4 * (-1) ^ n := by
+  have hb := lucas_eq_int n
+  have hc := fib_sq_sub n
+  -- substitute the bridge, then it is `4 ×` the core identity
+  rw [hb]
+  linear_combination 4 * hc
+
+/-- `Lₙ² = 5·Fₙ² + 4·(−1)ⁿ`: the Lucas square is `5Fₙ²` shifted by the defect
+`±4`. Rearrangement of `lucas_sq_sub_five_fib_sq`. -/
+theorem lucas_sq_eq (n : ℕ) :
+    (lucas n : ℤ) ^ 2 = 5 * (fib n) ^ 2 + 4 * (-1) ^ n := by
+  have := lucas_sq_sub_five_fib_sq n; linarith
+
+/-- The even-index specialisation `L_{2k}² = 5·F_{2k}² + 4` (defect `+4`). -/
+theorem lucas_sq_even (k : ℕ) :
+    (lucas (2 * k) : ℤ) ^ 2 = 5 * (fib (2 * k)) ^ 2 + 4 := by
+  have h := lucas_sq_eq (2 * k)
+  rw [Even.neg_one_pow ⟨k, by ring⟩] at h; linarith
+
+/-- The odd-index specialisation `L_{2k+1}² = 5·F_{2k+1}² − 4` (defect `−4`). -/
+theorem lucas_sq_odd (k : ℕ) :
+    (lucas (2 * k + 1) : ℤ) ^ 2 = 5 * (fib (2 * k + 1)) ^ 2 - 4 := by
+  have h := lucas_sq_eq (2 * k + 1)
+  rw [Odd.neg_one_pow ⟨k, by ring⟩] at h; linarith
+
+/-! ## `gcd(Fₙ, Lₙ) ∣ 2` -/
+
+/-- **`gcd(Fₙ, Lₙ) ∣ 2`.** The Fibonacci and Lucas numbers of the same index
+are coprime up to a factor of `2`, so `gcd(Fₙ, Lₙ) ∈ {1, 2}`. A common divisor
+`d` of `Fₙ` and `Lₙ` divides `Lₙ + Fₙ = 2·Fₙ₊₁`; since `gcd(Fₙ, Fₙ₊₁) = 1`,
+`d` is coprime to `Fₙ₊₁`, forcing `d ∣ 2`. -/
+theorem gcd_fib_lucas_dvd_two (n : ℕ) : Nat.gcd (fib n) (lucas n) ∣ 2 := by
+  set d := Nat.gcd (fib n) (lucas n) with hd
+  have hdf : d ∣ fib n := Nat.gcd_dvd_left _ _
+  have hdl : d ∣ lucas n := Nat.gcd_dvd_right _ _
+  -- d divides 2·Fₙ₊₁ = Lₙ + Fₙ
+  have hsum : lucas n + fib n = 2 * fib (n + 1) := (two_mul_fib_succ n).symm
+  have hd2 : d ∣ 2 * fib (n + 1) := by
+    rw [← hsum]; exact Dvd.dvd.add hdl hdf
+  -- d is coprime to Fₙ₊₁ since it divides Fₙ and gcd(Fₙ, Fₙ₊₁) = 1
+  have hcop : Nat.Coprime (fib n) (fib (n + 1)) := Nat.fib_coprime_fib_succ n
+  have hdcop : Nat.Coprime d (fib (n + 1)) :=
+    Nat.Coprime.coprime_dvd_left hdf hcop
+  -- so d ∣ 2
+  exact (Nat.Coprime.dvd_of_dvd_mul_right hdcop hd2)
+
+/-- Consequently `gcd(Fₙ, Lₙ) ∈ {1, 2}`. -/
+theorem gcd_fib_lucas_eq_one_or_two (n : ℕ) :
+    Nat.gcd (fib n) (lucas n) = 1 ∨ Nat.gcd (fib n) (lucas n) = 2 := by
+  have h := gcd_fib_lucas_dvd_two n
+  exact (Nat.dvd_prime Nat.prime_two).mp h
+
+/-! ## Concrete sanity checks -/
+
+/-- `L₅² = 5·F₅² − 4`: `121 = 5·25 − 4`. -/
+theorem check_five : (lucas 5 : ℤ) ^ 2 = 5 * (fib 5) ^ 2 - 4 := by decide
+
+/-- `L₆² = 5·F₆² + 4`: `324 = 5·64 + 4`. -/
+theorem check_six : (lucas 6 : ℤ) ^ 2 = 5 * (fib 6) ^ 2 + 4 := by decide
+
+/-- `gcd(F₆, L₆) = gcd(8, 18) = 2` — the factor `2` is attained. -/
+theorem gcd_six_attains_two : Nat.gcd (fib 6) (lucas 6) = 2 := by decide
+
+/-- `gcd(F₅, L₅) = gcd(5, 11) = 1` — coprime case. -/
+theorem gcd_five_coprime : Nat.gcd (fib 5) (lucas 5) = 1 := by decide
+
+end FibonacciIdentitiesOQ02OQ01OQ01

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-fiboq020101-1",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "context",
+    "title": "The Quadratic Companion of the Product Identity",
+    "content": "**Module framing.** The parent entry isolated the *product* identity $F_{2n}=F_n\\cdot L_n$ as the engine of Lucas divisibility. This module supplies the *quadratic* companion as a universally quantified theorem over $\\mathbb{Z}$: $L_n^2-5F_n^2=4(-1)^n$. The two are the fundamental degree-2 relations between the companion sequences. The quadratic identity is the integer residue of Binet's formulas $F_n=(\\varphi^n-\\psi^n)/\\sqrt5$, $L_n=\\varphi^n+\\psi^n$: since $\\varphi\\psi=-1$, eliminating $\\varphi,\\psi$ makes $\\sqrt5$ vanish and leaves $L_n^2-5F_n^2=4(\\varphi\\psi)^n=4(-1)^n$. Two consequences are drawn: $L_n^2=5F_n^2\\pm4$ (sign by parity) and $\\gcd(F_n,L_n)\\mid 2$.",
+    "mathContext": "$L_n^2-5F_n^2=4(-1)^n$; $\\varphi+\\psi=1,\\ \\varphi\\psi=-1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Binet's formulas",
+      "Lucas sequences Uₙ, Vₙ",
+      "Cassini's identity",
+      "Pell-type quadratic forms"
+    ],
+    "prerequisites": [
+      "The Fibonacci/Lucas recurrence and base values",
+      "gcd and divisibility on ℕ"
+    ],
+    "tags": ["module-header", "framing", "quadratic-identity", "binet"]
+  },
+  {
+    "id": "ann-fiboq020101-2",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 94 },
+    "type": "concept",
+    "title": "Lucas Numbers and the Subtraction-Free Bridge",
+    "content": "Mathlib has `Nat.fib` but not the Lucas numbers, so we reuse the parent's structural pair recursion `lucasPair n = (L_n, L_{n+1})`, giving `lucas n` that reduces by `rfl`/`decide`. The link to Fibonacci is the subtraction-free bridge $2F_{n+1}=L_n+F_n$ (`two_mul_fib_succ`, a two-step induction), which over $\\mathbb{Z}$ becomes the closed form $L_n=2F_{n+1}-F_n$ (`lucas_eq_int`). This single substitution is what converts every Lucas statement below into a pure Fibonacci statement.",
+    "mathContext": "$2F_{n+1}=L_n+F_n\\ \\Rightarrow\\ L_n=2F_{n+1}-F_n$ over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Structural recursion",
+      "Definitional reduction (rfl/decide)",
+      "Lucas–Fibonacci bridge"
+    ],
+    "prerequisites": [
+      "Two-step induction Nat.twoStepInduction",
+      "Pair-accumulator recursion"
+    ],
+    "tags": ["definition", "lucas-numbers", "bridge"]
+  },
+  {
+    "id": "ann-fiboq020101-3",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 113 },
+    "type": "insight",
+    "title": "The Sign-Clean Cassini Relative (the whole engine)",
+    "content": "The entire result rests on one Fibonacci identity: $F_{n+1}^2-F_{n+1}F_n-F_n^2=(-1)^n$ (`fib_sq_sub`). Unlike the index-shifted Cassini identity $F_{n+1}F_{n-1}-F_n^2=(-1)^n$ (which needs $n\\ge1$), this form is valid at $n=0$ and — crucially — closes under a *single-step* induction: substituting $F_{n+2}=F_n+F_{n+1}$ turns the $(n{+}1)$-form into the exact negation of the $n$-form (lemma `key`, closed by `ring`). So the quadratic form simply flips sign at each step, starting from $(-1)^0=1$. No coupled invariant or two-step scheme is needed.",
+    "mathContext": "$F_{n+1}^2-F_{n+1}F_n-F_n^2=(-1)^n$; the $(n{+}1)$-form $=-$ the $n$-form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Sign-alternating invariants",
+      "One-step induction"
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "Polynomial normalisation (ring)"
+    ],
+    "tags": ["core-lemma", "cassini", "induction"]
+  },
+  {
+    "id": "ann-fiboq020101-4",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 144 },
+    "type": "insight",
+    "title": "The Quadratic Identity and Its Parity Specialisations",
+    "content": "Substituting the bridge $L_n=2F_{n+1}-F_n$ into $L_n^2-5F_n^2$ and expanding shows it equals $4\\,(F_{n+1}^2-F_{n+1}F_n-F_n^2)$, which is $4(-1)^n$ by the core lemma — a single `linear_combination 4 * fib_sq_sub n` (`lucas_sq_sub_five_fib_sq`). Rearranging gives $L_n^2=5F_n^2+4(-1)^n$ (`lucas_sq_eq`); collapsing $(-1)^n$ with `Even/Odd.neg_one_pow` gives the clean parity forms $L_{2k}^2=5F_{2k}^2+4$ and $L_{2k+1}^2=5F_{2k+1}^2-4$. So $L_n$ is the nearest integer to $\\sqrt5\\,F_n$, with the parity of $n$ choosing the side.",
+    "mathContext": "$L_n^2=5F_n^2+4(-1)^n$; $L_{2k}^2=5F_{2k}^2+4$, $L_{2k+1}^2=5F_{2k+1}^2-4$.",
+    "significance": "primary",
+    "relatedConcepts": [
+      "Quadratic Fibonacci–Lucas identity",
+      "Binet √5-elimination",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "The bridge lucas_eq_int and the core lemma fib_sq_sub",
+      "Even.neg_one_pow / Odd.neg_one_pow"
+    ],
+    "tags": ["main-theorem", "quadratic-identity", "parity"]
+  },
+  {
+    "id": "ann-fiboq020101-5",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01",
+    "range": { "startLine": 146, "endLine": 187 },
+    "type": "insight",
+    "title": "Same-Index Coprimality: gcd(Fₙ, Lₙ) ∈ {1, 2}",
+    "content": "A structural payoff: $\\gcd(F_n,L_n)\\mid 2$ (`gcd_fib_lucas_dvd_two`). Any common divisor $d$ of $F_n$ and $L_n$ divides $L_n+F_n=2F_{n+1}$; since consecutive Fibonacci numbers are coprime (`Nat.fib_coprime_fib_succ`), $d$ is coprime to $F_{n+1}$ and therefore divides $2$. With $2$ prime, `Nat.dvd_prime` yields $\\gcd(F_n,L_n)\\in\\{1,2\\}$ (`gcd_fib_lucas_eq_one_or_two`). Both values occur: $\\gcd(F_5,L_5)=\\gcd(5,11)=1$ and $\\gcd(F_6,L_6)=\\gcd(8,18)=2$. This is the single-index counterpart of the parent's cross-index link $L_n\\mid F_{2n}$: at a fixed index the companion sequences barely share factors.",
+    "mathContext": "$d\\mid F_n,\\ d\\mid L_n\\Rightarrow d\\mid 2F_{n+1}$ and $\\gcd(d,F_{n+1})=1\\Rightarrow d\\mid 2$.",
+    "significance": "primary",
+    "relatedConcepts": [
+      "Coprimality of consecutive Fibonacci numbers",
+      "gcd and Bézout-style descent",
+      "Nat.dvd_prime"
+    ],
+    "prerequisites": [
+      "The quadratic identity / the bridge",
+      "Nat.fib_coprime_fib_succ"
+    ],
+    "tags": ["corollary", "gcd", "coprimality"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ02OQ01OQ01Data: ProofData = {
+  proof: fibonacciIdentitiesOQ02OQ01OQ01Proof,
+  annotations: fibonacciIdentitiesOQ02OQ01OQ01Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-01-oq-01",
+  "title": "The Fibonacci–Lucas Quadratic Identity Lₙ² − 5Fₙ² = 4(−1)ⁿ",
+  "slug": "fibonacci-identities-oq-02-oq-01-oq-01",
+  "description": "The parent entry (fibonacci-identities-oq-02-oq-01) resolved the Lucas divisibility question and isolated the PRODUCT identity F_{2n} = Fₙ·Lₙ as its engine. This entry supplies the SECOND fundamental Fibonacci–Lucas identity — the quadratic companion — as a universally quantified theorem over ℤ: Lₙ² − 5·Fₙ² = 4·(−1)ⁿ for every n. Two structural consequences follow. (1) Lₙ² = 5·Fₙ² ± 4: the Lucas number is √5·Fₙ up to the fixed defect ±4 (the integer shadow of Binet's φⁿ+ψⁿ, (φⁿ−ψⁿ)/√5 with φψ = −1), with the even/odd specialisations L_{2k}² = 5F_{2k}²+4 and L_{2k+1}² = 5F_{2k+1}²−4. (2) gcd(Fₙ, Lₙ) ∣ 2, hence gcd(Fₙ,Lₙ) ∈ {1,2}: the same-index Fibonacci and Lucas numbers are coprime up to a factor of 2 (attained: gcd(F₆,L₆)=gcd(8,18)=2), in sharp contrast to the cross-index links Fₙ∣F_{2n} and Lₙ∣F_{2n}. Everything reduces, via the bridge Lₙ = 2Fₙ₊₁ − Fₙ, to a single sign-clean Cassini relative Fₙ₊₁² − Fₙ₊₁Fₙ − Fₙ² = (−1)ⁿ, which closes under a one-step induction (substituting Fₙ₊₂ = Fₙ + Fₙ₊₁ negates the form, flipping the sign).",
+  "meta": {
+    "author": "Édouard Lucas / classical Fibonacci–Lucas identity theory; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number#Relationship_to_Fibonacci_numbers",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-numbers",
+      "quadratic-identity",
+      "gcd",
+      "coprimality",
+      "binet",
+      "cassini",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the Fibonacci recurrence, the single rewrite that drives the one-step induction for the sign-clean Cassini relative fib_sq_sub",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "induction deriving P (n+2) from P n and P (n+1) — used for the subtraction-free Lucas–Fibonacci bridge 2·Fₙ₊₁ = Lₙ + Fₙ",
+        "module": "Mathlib.Data.Nat.Init"
+      },
+      {
+        "theorem": "Nat.fib_coprime_fib_succ",
+        "description": "gcd (fib n) (fib (n+1)) = 1 — consecutive Fibonacci numbers are coprime; the lever that upgrades gcd(Fₙ,Lₙ) ∣ 2·Fₙ₊₁ to gcd(Fₙ,Lₙ) ∣ 2",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)^n = 1 for n even, −1 for n odd — collapses the alternating sign in the even/odd-index specialisations",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_prime",
+        "description": "for prime p, a ∣ p ↔ a = 1 ∨ a = p — turns gcd(Fₙ,Lₙ) ∣ 2 into gcd(Fₙ,Lₙ) ∈ {1,2}",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_sq_sub: the sign-clean Cassini relative Fₙ₊₁² − Fₙ₊₁·Fₙ − Fₙ² = (−1)ⁿ over ℤ, proved by a one-step induction in which substituting the Fibonacci recurrence negates the quadratic form",
+      "lucas_sq_sub_five_fib_sq: the headline quadratic identity Lₙ² − 5·Fₙ² = 4·(−1)ⁿ, obtained from fib_sq_sub by substituting the bridge Lₙ = 2Fₙ₊₁ − Fₙ and a single linear_combination",
+      "lucas_sq_eq, lucas_sq_even, lucas_sq_odd: the rearrangement Lₙ² = 5Fₙ² + 4(−1)ⁿ and its even/odd specialisations L_{2k}² = 5F_{2k}²+4, L_{2k+1}² = 5F_{2k+1}²−4",
+      "gcd_fib_lucas_dvd_two: gcd(Fₙ, Lₙ) ∣ 2 — same-index Fibonacci/Lucas coprimality up to 2, via d ∣ Lₙ+Fₙ = 2Fₙ₊₁ and coprimality of consecutive Fibonacci numbers",
+      "gcd_fib_lucas_eq_one_or_two: gcd(Fₙ, Lₙ) ∈ {1, 2}, with both values attained (gcd(F₅,L₅)=1, gcd(F₆,L₆)=2)"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 187,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). Concrete checks use decide (kernel evaluation), not native_decide, so no Lean.ofReduceBool is introduced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 16,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci numbers Fₙ and the Lucas numbers Lₙ are the two real Lucas sequences for P=1, Q=−1: Uₙ(1,−1)=Fₙ and Vₙ(1,−1)=Lₙ. Binet's formulas express them through the golden ratio φ and its conjugate ψ=−1/φ: Fₙ=(φⁿ−ψⁿ)/√5 and Lₙ=φⁿ+ψⁿ, with φ+ψ=1, φψ=−1. Eliminating φ,ψ between these two gives the algebraic relation Lₙ²−5Fₙ²=4(φψ)ⁿ=4(−1)ⁿ — the integer identity that makes the irrational √5 disappear. It is the quadratic companion of the product identity F_{2n}=Fₙ·Lₙ and the source of the classical fact that Fₙ and Lₙ are nearly coprime.",
+    "problemStatement": "**Follow-up to fibonacci-identities-oq-02-oq-01**: the parent isolated the product identity F_{2n}=Fₙ·Lₙ. Establish the complementary quadratic identity relating Lₙ and Fₙ at a single index, as a universally quantified theorem, and extract its structural consequence for gcd(Fₙ,Lₙ).\n\n**Resolution**: Lₙ²−5·Fₙ²=4·(−1)ⁿ for all n (over ℤ). Consequently Lₙ²=5Fₙ²±4 (sign by parity of n), and gcd(Fₙ,Lₙ)∣2, so gcd(Fₙ,Lₙ)∈{1,2} with both values attained.",
+    "text": "With Fₙ the Fibonacci numbers (0,1,1,2,3,5,8,13,…) and Lₙ the Lucas numbers (2,1,3,4,7,11,18,…), the quantity Lₙ²−5Fₙ² is not merely bounded but exactly ±4, alternating with the parity of n: +4 for even n, −4 for odd n. Equivalently 5Fₙ² and Lₙ² differ by exactly 4. Because any common divisor of Fₙ and Lₙ must divide Lₙ+Fₙ=2Fₙ₊₁ while being coprime to Fₙ₊₁ (consecutive Fibonacci numbers are coprime), the gcd of a same-index Fibonacci/Lucas pair is always 1 or 2.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Reuse the structural Lucas definition (lucasPair / lucas, reducing by rfl/decide) and the subtraction-free bridge 2·Fₙ₊₁ = Lₙ + Fₙ (two_mul_fib_succ, two-step induction), giving the ℤ closed form Lₙ = 2Fₙ₊₁ − Fₙ (lucas_eq_int).\n\n2. Core lemma (fib_sq_sub): Fₙ₊₁² − Fₙ₊₁Fₙ − Fₙ² = (−1)ⁿ over ℤ. One-step induction: substituting Fₙ₊₂ = Fₙ + Fₙ₊₁ shows the (n+1)-form equals the negation of the n-form (pure ring), so the value flips sign at each step from the base (−1)⁰ = 1.\n\n3. Headline (lucas_sq_sub_five_fib_sq): substitute the bridge into Lₙ²−5Fₙ² and recognise it as 4·(Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²) = 4(−1)ⁿ via linear_combination 4·fib_sq_sub.\n\n4. Specialisations (lucas_sq_eq/_even/_odd): rearrange and collapse (−1)ⁿ using Even/Odd.neg_one_pow.\n\n5. gcd corollary (gcd_fib_lucas_dvd_two): a common divisor d of Fₙ, Lₙ divides Lₙ+Fₙ=2Fₙ₊₁; coprimality of Fₙ,Fₙ₊₁ makes d coprime to Fₙ₊₁, so d∣2. Then Nat.dvd_prime gives gcd∈{1,2}.",
+    "keyInsights": [
+      "**The quadratic identity is the √5-eliminating companion of the product identity.** Where F_{2n}=Fₙ·Lₙ multiplies the two companion sequences, Lₙ²−5Fₙ²=4(−1)ⁿ subtracts their squares; together they are the two fundamental same-/double-index Fibonacci–Lucas relations. It is exactly the integer residue of Binet's φψ=−1.",
+      "**One quadratic Fibonacci identity does all the work.** The whole result rests on Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ, a sign-clean form of Cassini's identity that — unlike the index-shifted Cassini Fₙ₊₁Fₙ₋₁−Fₙ²=(−1)ⁿ — is valid at n=0 and closes under a single-step induction with one application of the recurrence and `ring`.",
+      "**The Lucas square pins down 5Fₙ² to within ±4.** Lₙ²=5Fₙ²+4 for even n and 5Fₙ²−4 for odd n. So Lₙ is the nearest integer to √5·Fₙ; the parity of n selects which side of 5Fₙ² the square Lₙ² lands.",
+      "**Same-index Fibonacci and Lucas numbers are coprime up to 2.** gcd(Fₙ,Lₙ)∈{1,2}, with 2 attained exactly when 3∣n (e.g. gcd(F₆,L₆)=2). This is the single-index counterpart to the parent's cross-index divisibility Lₙ∣F_{2n}: at a fixed index the two sequences barely share factors."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and coprimality of consecutive Fibonacci numbers Nat.fib_coprime_fib_succ",
+      "The Lucas recurrence and the bridge Lₙ = 2Fₙ₊₁ − Fₙ (two-step induction)",
+      "Binet's formulas and the role of φψ = −1; Cassini's identity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Framing",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring positioning the quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ as the companion to the parent's product identity F_{2n}=Fₙ·Lₙ, stating the two consequences (Lₙ²=5Fₙ²±4 and gcd(Fₙ,Lₙ)∣2) and the reduction to the sign-clean Cassini relative.",
+      "mathContext": "$L_n^2 - 5F_n^2 = 4(-1)^n$; Binet $L_n=\\varphi^n+\\psi^n$, $F_n=(\\varphi^n-\\psi^n)/\\sqrt5$, $\\varphi\\psi=-1$."
+    },
+    {
+      "id": "definition",
+      "title": "Definition of the Lucas Numbers and the Fibonacci Bridge",
+      "startLine": 54,
+      "endLine": 94,
+      "summary": "lucasPair / lucas (structural pair recursion, reducing by rfl/decide), the base values and recurrence lucas_add_two, the subtraction-free bridge two_mul_fib_succ (2·Fₙ₊₁ = Lₙ + Fₙ, two-step induction), and its ℤ closed form lucas_eq_int (Lₙ = 2Fₙ₊₁ − Fₙ).",
+      "mathContext": "$2F_{n+1}=L_n+F_n$, hence $L_n=2F_{n+1}-F_n$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "core",
+      "title": "The Sign-Clean Cassini Relative",
+      "startLine": 96,
+      "endLine": 113,
+      "summary": "fib_sq_sub: Fₙ₊₁² − Fₙ₊₁·Fₙ − Fₙ² = (−1)ⁿ over ℤ, by one-step induction — the key lemma `key` shows substituting Fₙ₊₂ = Fₙ + Fₙ₊₁ negates the quadratic form, so the value alternates sign from the base (−1)⁰ = 1.",
+      "mathContext": "$F_{n+1}^2 - F_{n+1}F_n - F_n^2 = (-1)^n$."
+    },
+    {
+      "id": "quadratic",
+      "title": "The Quadratic Identity and Specialisations",
+      "startLine": 115,
+      "endLine": 144,
+      "summary": "lucas_sq_sub_five_fib_sq (the headline Lₙ²−5Fₙ²=4(−1)ⁿ via the bridge and linear_combination 4·fib_sq_sub), lucas_sq_eq (Lₙ²=5Fₙ²+4(−1)ⁿ), and the even/odd specialisations lucas_sq_even (L_{2k}²=5F_{2k}²+4) and lucas_sq_odd (L_{2k+1}²=5F_{2k+1}²−4).",
+      "mathContext": "$L_n^2 = 5F_n^2 + 4(-1)^n$; $L_{2k}^2=5F_{2k}^2+4$, $L_{2k+1}^2=5F_{2k+1}^2-4$."
+    },
+    {
+      "id": "gcd",
+      "title": "Same-Index Coprimality: gcd(Fₙ, Lₙ) ∣ 2",
+      "startLine": 146,
+      "endLine": 187,
+      "summary": "gcd_fib_lucas_dvd_two (a common divisor d of Fₙ, Lₙ divides Lₙ+Fₙ=2Fₙ₊₁ and is coprime to Fₙ₊₁, so d∣2), gcd_fib_lucas_eq_one_or_two (gcd∈{1,2} via Nat.dvd_prime), and concrete checks: L₅²=5F₅²−4, L₆²=5F₆²+4, gcd(F₆,L₆)=2 (attained), gcd(F₅,L₅)=1.",
+      "mathContext": "$\\gcd(F_n,L_n)\\mid 2$, so $\\gcd(F_n,L_n)\\in\\{1,2\\}$; value $2$ attained when $3\\mid n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: resolved the Lucas divisibility question with the product identity F_{2n}=Fₙ·Lₙ. This entry supplies the complementary quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ and the same-index coprimality gcd(Fₙ,Lₙ)∈{1,2}, reusing the same Lucas definition and Fibonacci bridge."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "related",
+      "description": "Cassini's identity Fₙ₊₁Fₙ₋₁−Fₙ²=(−1)ⁿ; the core lemma here, Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ, is the sign-clean equivalent that drives the quadratic Fibonacci–Lucas identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Fibonacci–Lucas quadratic identity Lₙ²−5·Fₙ²=4·(−1)ⁿ is proved as a universally quantified theorem over ℤ, completing the pair of fundamental same-/double-index relations alongside the parent's product identity F_{2n}=Fₙ·Lₙ. Its consequences — Lₙ²=5Fₙ²±4 (parity-selected) and gcd(Fₙ,Lₙ)∈{1,2} (both values attained) — are extracted, the latter from coprimality of consecutive Fibonacci numbers. Everything rests on the sign-clean Cassini relative Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ, which closes under a one-step induction.",
+    "implications": "Promotes the parent's instance-checked divisibility statements to a closed-form algebraic identity at a single index, supplies the integer residue of Binet's φψ=−1, and packages the classical near-coprimality of same-index Fibonacci/Lucas numbers as a fully verified 0-axiom theorem with an explicit, decidable Lucas definition (absent from Mathlib).",
+    "openQuestions": [
+      "Prove the exact gcd value gcd(Fₙ,Lₙ) = 2 ⟺ 3∣n (and = 1 otherwise) as a universally quantified biconditional, using L_{3k} even ⟺ the 3-periodicity of parity in the Lucas sequence.",
+      "Establish the companion sum-of-squares identity Lₙ² + 5Fₙ² = 2·L_{2n} and the cross identity Lₙ·Fₙ = F_{2n} together as the full set of degree-2 Fibonacci–Lucas relations.",
+      "Generalise Vₙ(P,Q)² − D·Uₙ(P,Q)² = 4·Qⁿ (D = P²−4Q) to arbitrary Lucas sequences, recovering the present identity at P=1, Q=−1, D=5."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ02OQ01OQ01",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Origin of the Lucas sequences Uₙ, Vₙ and the degree-2 identity Vₙ²−D·Uₙ²=4Qⁿ specialising to Lₙ²−5Fₙ²=4(−1)ⁿ"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "The quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ, Binet's formulas, and the near-coprimality gcd(Fₙ,Lₙ)∈{1,2}"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/fibonacci-identities-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/fibonacci-identities-oq-02-oq-01-oq-01.json
@@ -1,0 +1,95 @@
+{
+  "slug": "fibonacci-identities-oq-02-oq-01-oq-01",
+  "title": "The Fibonacci–Lucas quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ and gcd(Fₙ,Lₙ)∈{1,2}",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "L_n^2 - 5\\,F_n^2 = 4\\,(-1)^n \\quad (\\forall n),\\qquad \\gcd(F_n, L_n) \\mid 2.",
+    "plain": "The parent (fibonacci-identities-oq-02-oq-01) isolated the product identity F_{2n}=Fₙ·Lₙ and proved gcd(Fₙ,Lₙ)∣2 only as a remark. This child proves the complementary degree-2 identity Lₙ²−5Fₙ²=4(−1)ⁿ as a universally quantified theorem over ℤ (the integer residue of Binet's φψ=−1), derives the parity forms L_{2k}²=5F_{2k}²+4 and L_{2k+1}²=5F_{2k+1}²−4, and gives a clean proof of gcd(Fₙ,Lₙ)∈{1,2}.",
+    "whyMatters": [
+      "Completes the pair of fundamental same-/double-index Fibonacci–Lucas relations (product + quadratic).",
+      "Supplies the √5-eliminating integer identity behind Binet's formulas as a verified 0-axiom theorem."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Lₙ²−5Fₙ²=4(−1)ⁿ over ℤ for all n (lucas_sq_sub_five_fib_sq)",
+      "Lₙ²=5Fₙ²+4(−1)ⁿ and parity forms L_{2k}²=5F_{2k}²+4, L_{2k+1}²=5F_{2k+1}²−4",
+      "gcd(Fₙ,Lₙ)∣2, hence gcd(Fₙ,Lₙ)∈{1,2}, both values attained"
+    ],
+    "open": [],
+    "goal": "Prove the quadratic Fibonacci–Lucas identity and extract gcd(Fₙ,Lₙ)∈{1,2}."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Proved and verified; PR opened.",
+    "blockers": [],
+    "nextAction": "None — entry complete (0 sorries, 0 axioms).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: quadratic identity Lₙ²−5Fₙ²=4(−1)ⁿ over ℤ + parity specialisations + gcd(Fₙ,Lₙ)∈{1,2}. 16 thm/2 def, 0 sorry/0 axiom, verified on host (Lean 4.26.0).",
+    "builtItems": [
+      "fib_sq_sub: sign-clean Cassini relative Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ over ℤ (one-step induction) in Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean:101",
+      "lucas_sq_sub_five_fib_sq: headline Lₙ²−5Fₙ²=4(−1)ⁿ via bridge + linear_combination :120",
+      "lucas_sq_eq / lucas_sq_even / lucas_sq_odd: rearrangement + parity forms :130,135,141",
+      "gcd_fib_lucas_dvd_two / gcd_fib_lucas_eq_one_or_two: gcd(Fₙ,Lₙ)∈{1,2} :152,168"
+    ],
+    "insights": [
+      "The quadratic identity reduces entirely to the single Fibonacci identity Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ once the bridge Lₙ=2Fₙ₊₁−Fₙ is substituted; linear_combination 4·(core) closes it.",
+      "That core identity — a sign-clean Cassini relative — closes under a ONE-step induction, not two: substituting Fₙ₊₂=Fₙ+Fₙ₊₁ negates the quadratic form, so its value just flips sign. No coupled invariant needed.",
+      "(−1)ⁿ collapses cleanly with Even.neg_one_pow ⟨k, by ring⟩ / Odd.neg_one_pow ⟨k, by ring⟩ for the parity specialisations.",
+      "gcd(Fₙ,Lₙ)∣2 needs only d∣Lₙ+Fₙ=2Fₙ₊₁ plus Nat.fib_coprime_fib_succ; the quadratic identity is not even required for it."
+    ],
+    "mathlibGaps": [
+      "Mathlib still lacks the Lucas integer sequence; reused the parent's structural lucasPair/lucas definition."
+    ],
+    "nextSteps": [
+      "Prove the exact gcd biconditional gcd(Fₙ,Lₙ)=2 ⟺ 3∣n.",
+      "Generalise to Vₙ(P,Q)²−D·Uₙ(P,Q)²=4Qⁿ for arbitrary Lucas sequences (D=P²−4Q)."
+    ],
+    "markdown": "# Knowledge Base: fibonacci-identities-oq-02-oq-01-oq-01\n\n## Problem Understanding\n\nFollow-up to the parent Lucas-divisibility entry. The parent proved the product identity F_{2n}=Fₙ·Lₙ and noted gcd(Fₙ,Lₙ)∣2; this child supplies the quadratic companion Lₙ²−5Fₙ²=4(−1)ⁿ as a universally quantified theorem and gives the clean gcd∈{1,2} result.\n\n## Insights\n\n- Reduce to the pure Fibonacci identity Fₙ₊₁²−Fₙ₊₁Fₙ−Fₙ²=(−1)ⁿ via the bridge Lₙ=2Fₙ₊₁−Fₙ.\n- That Fibonacci identity closes under ONE-step induction (the form negates each step).\n\n## Dead Ends\n\n- Attempting the quadratic identity directly by two-step induction generates a coupled mixed identity (LₙLₙ₊₁−5FₙFₙ₊₁=2(−1)ⁿ); routing through the Fibonacci form avoids the coupling entirely.\n"
+  },
+  "tags": [
+    "number-theory",
+    "fibonacci",
+    "lucas-numbers",
+    "quadratic-identity",
+    "gcd"
+  ],
+  "relatedProofs": [
+    "fibonacci-identities",
+    "fibonacci-identities-oq-01",
+    "fibonacci-identities-oq-02",
+    "fibonacci-identities-oq-02-oq-01",
+    "fibonacci-identities-oq-02-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T08:20:00.000Z",
+  "lastUpdate": "2026-06-24T08:30:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ02OQ01OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New **depth-2** child of the verified parent `fibonacci-identities-oq-02-oq-01` (*Lucas Numbers Are Not a Strong Divisibility Sequence*). It executes the parent's explicitly stated next step — *"Prove the signed identity Lₙ² − 5·Fₙ² = 4·(−1)ⁿ over ℤ"* — and packages it as a gallery entry.

The parent isolated the **product** identity `F_{2n} = Fₙ·Lₙ`. This entry supplies the complementary **quadratic** identity, the second fundamental degree-2 relation between the companion sequences:

> **Lₙ² − 5·Fₙ² = 4·(−1)ⁿ**  for all `n` (over ℤ)

— the integer residue of Binet's `φψ = −1` (the identity that makes `√5` vanish).

## Results (16 theorems / 2 defs, verified, 0 sorries, 0 axioms)

- `lucas_sq_sub_five_fib_sq` — the headline `Lₙ² − 5Fₙ² = 4(−1)ⁿ`, universally quantified
- `lucas_sq_even` / `lucas_sq_odd` — parity forms `L_{2k}² = 5F_{2k}²+4`, `L_{2k+1}² = 5F_{2k+1}²−4`
- `gcd_fib_lucas_dvd_two` / `gcd_fib_lucas_eq_one_or_two` — `gcd(Fₙ,Lₙ) ∈ {1,2}`, both values attained (`gcd(F₅,L₅)=1`, `gcd(F₆,L₆)=2`)

## Proof engine

Everything reduces, via the bridge `Lₙ = 2Fₙ₊₁ − Fₙ`, to a single **sign-clean Cassini relative**

> `Fₙ₊₁² − Fₙ₊₁Fₙ − Fₙ² = (−1)ⁿ`  (`fib_sq_sub`)

which — unlike the index-shifted Cassini identity — is valid at `n=0` and closes under a **one-step** induction: substituting `Fₙ₊₂ = Fₙ + Fₙ₊₁` negates the quadratic form, so its value flips sign each step. The headline then follows from `linear_combination 4 * fib_sq_sub n`. The `gcd` corollary uses only `d ∣ Lₙ+Fₙ = 2Fₙ₊₁` plus `Nat.fib_coprime_fib_succ`.

## Verification

- Built on host with **Lean 4.26.0 / Mathlib** (`lake env lean`), exit 0.
- `#print axioms` on the headline and gcd theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**. Concrete checks use `decide` (kernel), not `native_decide`.

## Files
- `proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean` (187 lines)
- `src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01/{meta,annotations}.json`, `index.ts`
- `src/data/research/problems/fibonacci-identities-oq-02-oq-01-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)