### PR TITLE
Enrich Factor/Remainder OQ-05 (at most deg-many roots): add annotations + index.ts

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-05/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 3, "endLine": 40 },
+    "type": "context",
+    "title": "At Most deg-Many Roots: the Headline Corollary",
+    "content": "The central counting corollary of the factor theorem: over an integral domain a nonzero polynomial has at most deg(p) roots. The factor theorem (X−a) ∣ p ⟺ p(a) = 0 lets one peel off a linear factor per root; over an integral domain a product vanishes only if a factor does, so each peeling drops the degree by one and the root count cannot exceed the degree. The contrapositive — a low-degree polynomial cannot vanish at too many points — is exactly interpolation uniqueness.",
+    "mathContext": "$\\#\\mathrm{roots}(p) \\le \\deg(p)$, over an integral domain $R$ with $[\\mathrm{IsDomain}\\,R]$.",
+    "significance": "context",
+    "relatedConcepts": ["factor theorem", "integral domain", "polynomial roots", "interpolation"],
+    "prerequisites": ["polynomials over a ring", "the factor theorem"]
+  },
+  {
+    "id": "ann-root-bound",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 42, "endLine": 53 },
+    "type": "concept",
+    "title": "The Root-Count Bound",
+    "content": "card_roots_le_natDegree wraps Mathlib's card_roots': over an integral domain the number of roots counted with multiplicity is ≤ natDegree p. card_roots_le_degree gives the WithBot ℕ degree-valued form for nonzero p. These package the deep multiset-level fact (each root contributes its multiplicity, and the total is bounded by the degree) into the form the corollaries consume.",
+    "mathContext": "$\\mathrm{card}(p.\\mathrm{roots}) \\le p.\\mathrm{natDegree};\\quad p \\ne 0 \\Rightarrow (\\mathrm{card}\\,p.\\mathrm{roots} : \\mathrm{WithBot}\\,\\mathbb{N}) \\le \\deg p.$",
+    "significance": "key",
+    "relatedConcepts": ["multiset of roots", "multiplicity", "Polynomial.card_roots'", "natDegree vs degree"],
+    "prerequisites": ["Multiset.card", "WithBot ℕ degree"]
+  },
+  {
+    "id": "ann-distinct-roots",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "technique",
+    "title": "Distinct Roots Bounded by Degree",
+    "content": "card_roots_finset_le_natDegree restates the bound for distinct points (ignoring multiplicity): if a nonzero p vanishes on a finset Z, then every element of Z is a root (mem_roots' gives x ∈ p.roots ⟺ p ≠ 0 ∧ IsRoot p x), so Z.val ⊆ p.roots and card_le_degree_of_subset_roots yields |Z| ≤ deg(p). This finset form is what the interpolation argument needs — it counts distinct evaluation nodes.",
+    "mathContext": "$p \\ne 0,\\; \\forall x \\in Z,\\; p(x) = 0 \\implies |Z| \\le \\deg(p).$",
+    "significance": "supporting",
+    "relatedConcepts": ["distinct roots", "mem_roots'", "card_le_degree_of_subset_roots", "Finset of roots"],
+    "prerequisites": ["Finset to Multiset coercion", "subset of roots"]
+  },
+  {
+    "id": "ann-interpolation-uniqueness",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 66, "endLine": 84 },
+    "type": "insight",
+    "title": "Interpolation Uniqueness via p − q",
+    "content": "The key derivation: if p and q both have degree < |s| and agree on the |s| points of s, then p = q. Suppose not; then p − q ≠ 0 vanishes on all of s, giving |s| ≤ deg(p − q) by the distinct-roots bound. But natDegree_sub_le bounds deg(p − q) ≤ max(deg p, deg q) < |s|. The two inequalities contradict (omega). This is the contrapositive of the root bound applied to the difference — too many agreements force p − q to be zero.",
+    "mathContext": "$|s| \\le \\deg(p-q) \\le \\max(\\deg p, \\deg q) < |s| \\;\\Rightarrow\\; p - q = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["interpolation uniqueness", "Lagrange interpolation", "natDegree_sub_le", "proof by contradiction"],
+    "prerequisites": ["the distinct-roots bound", "sub_ne_zero", "degree of a difference"]
+  },
+  {
+    "id": "ann-zero-corollary",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 86, "endLine": 91 },
+    "type": "concept",
+    "title": "Vanishing-on-|s|-points Corollary",
+    "content": "Specializing q = 0: a polynomial of degree < |s| that vanishes on all |s| points of s is the zero polynomial. This is the cleanest packaging of the bound and is the form most directly used in coding theory and identity testing — a nonzero low-degree polynomial simply cannot be zero too often.",
+    "mathContext": "$\\deg(p) < |s|,\\; \\forall x \\in s,\\; p(x) = 0 \\implies p = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["zero polynomial", "specialization", "identity testing"],
+    "prerequisites": ["interpolation uniqueness"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 93, "endLine": 109 },
+    "type": "context",
+    "title": "Verified Examples over ℚ",
+    "content": "Two concrete checks over the field ℚ: the root bound applied to X² − 1 (≤ 2 roots, matching its degree), and the two-point uniqueness instance — two polynomials of degree < 2 agreeing at {0, 1} are equal, discharged by instantiating the general theorem at s = {0, 1}. The examples confirm the abstract integral-domain results specialize correctly.",
+    "mathContext": "$X^2 - 1$ over $\\mathbb{Q}$ has $\\le 2$ roots; agreement at $\\{0,1\\}$ with $\\deg < 2 \\Rightarrow$ equality.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "field as integral domain", "two-point interpolation"],
+    "prerequisites": ["ℚ[X]", "Finset {0,1}"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "factor-remainder-theorem-oq-05",
+    "range": { "startLine": 111, "endLine": 122 },
+    "type": "concept",
+    "title": "Summary Theorem",
+    "content": "factor_remainder_oq05_summary bundles the two headline facts into one statement: the root bound card(roots p) ≤ deg(p) together with the interpolation-uniqueness conclusion p = q. Stating uniqueness over a general integral domain (not just a field) is slightly stronger than the usual Lagrange formulation, since the argument needs only the root bound, which holds in any integral domain.",
+    "mathContext": "$(\\mathrm{card}\\,p.\\mathrm{roots} \\le \\deg p) \\;\\wedge\\; (p = q).$",
+    "significance": "supporting",
+    "relatedConcepts": ["result packaging", "integral domain generality", "Reed–Solomon codes"],
+    "prerequisites": ["the root bound", "interpolation uniqueness"]
+  }
+]

--- a/src/data/proofs/factor-remainder-theorem-oq-05/index.ts
+++ b/src/data/proofs/factor-remainder-theorem-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FactorRemainderTheoremOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const factorRemainderTheoremOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const factorRemainderTheoremOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const factorRemainderTheoremOq05Data: ProofData = {
+  proof: factorRemainderTheoremOq05Proof,
+  annotations: factorRemainderTheoremOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-05`.

## Critical fix
Entry was **missing `index.ts`** — without it Vite cannot discover the proof, so the page shows 'proof not found' on the live site. Added from the standard template.

## Annotations (new `annotations.json`)
Added **7 annotations** covering every section, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- The at-most-deg-roots corollary of the factor theorem
- The root-count bound (multiset + WithBot degree forms)
- The distinct-roots finset bound
- Interpolation uniqueness via p−q (the key derivation)
- The vanishing-on-|s|-points corollary
- The worked ℚ examples
- The summary theorem

## Verification
- JSON validated; `tsc -b` passes.