### PR TITLE
research(harmonic-divergence-oq-06): reciprocals of the odd numbers diverge [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/HarmonicDivergenceOQ06.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ06.lean
@@ -1,0 +1,106 @@
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Tactic
+
+/-
+# Divergence of the Reciprocals of the Odd Numbers
+
+## What This Proves
+
+The classical harmonic-series entries (`HarmonicDivergence`, `…OQ01–OQ05`) study
+`∑ 1/n`.  This entry isolates the **odd-indexed subseries**
+
+  `∑_{k≥0} 1/(2k+1) = 1 + 1/3 + 1/5 + 1/7 + …`
+
+and proves it diverges.  The point is that throwing away *half* the harmonic
+terms — every even denominator — does not restore summability: the surviving
+"thinner" series is still divergent.
+
+## The argument
+
+The proof is a clean comparison with the harmonic series itself.  For every `k`,
+
+  `1/(2k+1) ≥ 1/(2k+2) = (1/2)·1/(k+1)`,
+
+because `2k+1 ≤ 2k+2`.  Two consequences:
+
+* **Quantitative** (`oddPartial_ge_half_harmonic`): the `N`-term partial sum of
+  the odd reciprocals dominates *half* the corresponding harmonic partial sum,
+  `∑_{k<N} 1/(2k+1) ≥ (1/2)·∑_{k<N} 1/(k+1)`.  Since the harmonic partial sums
+  are unbounded, so are these.
+
+* **Qualitative** (`not_summable_one_div_odd`): if `∑ 1/(2k+1)` converged, the
+  termwise-smaller nonnegative series `∑ 1/(2k+2) = (1/2)∑ 1/(k+1)` would
+  converge too, contradicting `Real.not_summable_one_div_natCast`.
+
+From non-summability and nonnegativity we read off divergence to `+∞`
+(`tendsto_oddPartial_atTop`).
+
+## Relation to Mathlib
+
+Mathlib proves `¬ Summable (fun n => 1/n)` (`Real.not_summable_one_div_natCast`)
+and the divergence of the *full* harmonic partial sums, but it does not record
+the divergence of the odd-reciprocal subseries.  We obtain it here by an
+elementary comparison, with an explicit partial-sum lower bound as a bonus.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Headline `not_summable_one_div_odd` plus quantitative partial-sum bound
+-/
+
+namespace HarmonicDivergenceOQ06
+
+open Finset Filter Topology
+
+/-- **Termwise comparison.** Each odd reciprocal dominates half the corresponding
+harmonic term: `(1/2)·1/(k+1) ≤ 1/(2k+1)`, because `2k+1 ≤ 2(k+1)`. -/
+theorem half_harmonic_le_odd (k : ℕ) :
+    (1 : ℝ) / 2 * (1 / ((k : ℝ) + 1)) ≤ 1 / (2 * (k : ℝ) + 1) := by
+  have hk1 : (0 : ℝ) < 2 * k + 1 := by positivity
+  have hle : (2 : ℝ) * k + 1 ≤ 2 * (k + 1) := by linarith
+  have e : (1 : ℝ) / 2 * (1 / ((k : ℝ) + 1)) = 1 / (2 * ((k : ℝ) + 1)) := by
+    rw [div_mul_div_comm, one_mul]
+  rw [e]
+  exact one_div_le_one_div_of_le hk1 hle
+
+/-- **Quantitative partial-sum bound.** The `N`-term partial sum of the odd
+reciprocals is at least half the `N`-term harmonic partial sum:
+
+  `(1/2)·∑_{k<N} 1/(k+1) ≤ ∑_{k<N} 1/(2k+1)`. -/
+theorem oddPartial_ge_half_harmonic (N : ℕ) :
+    (1 : ℝ) / 2 * ∑ k ∈ range N, (1 / ((k : ℝ) + 1)) ≤
+      ∑ k ∈ range N, (1 / (2 * (k : ℝ) + 1)) := by
+  rw [Finset.mul_sum]
+  exact Finset.sum_le_sum (fun k _ => half_harmonic_le_odd k)
+
+/-- **Headline: the reciprocals of the odd numbers are not summable.**
+
+`∑_{k≥0} 1/(2k+1) = 1 + 1/3 + 1/5 + …` diverges. -/
+theorem not_summable_one_div_odd :
+    ¬ Summable (fun n : ℕ => (1 : ℝ) / (2 * n + 1)) := by
+  intro h
+  -- Compare against the termwise-smaller even reciprocals `1/(2n+2)`.
+  have hcmp : Summable (fun n : ℕ => (1 : ℝ) / (2 * n + 2)) := by
+    refine Summable.of_nonneg_of_le (fun n => by positivity) (fun n => ?_) h
+    have hpos : (0 : ℝ) < 2 * n + 1 := by positivity
+    have hle : (2 : ℝ) * n + 1 ≤ 2 * n + 2 := by linarith
+    exact one_div_le_one_div_of_le hpos hle
+  -- `2 · 1/(2n+2) = 1/(n+1)`, so the harmonic series (shifted) would converge.
+  have hharm : Summable (fun n : ℕ => (1 : ℝ) / (n + 1)) := by
+    have h2 := hcmp.mul_left 2
+    refine h2.congr (fun n => ?_)
+    rw [mul_one_div, div_eq_div_iff (by positivity) (by positivity)]
+    ring
+  -- Shift back to `1/n` and contradict the harmonic non-summability lemma.
+  have hnat : Summable (fun n : ℕ => (1 : ℝ) / n) := by
+    rw [← summable_nat_add_iff 1]
+    simpa using hharm
+  exact Real.not_summable_one_div_natCast hnat
+
+/-- **Divergence to `+∞`.** The partial sums `∑_{k<N} 1/(2k+1)` tend to `+∞`. -/
+theorem tendsto_oddPartial_atTop :
+    Tendsto (fun N => ∑ k ∈ range N, (1 : ℝ) / (2 * k + 1)) atTop atTop := by
+  have hnn : ∀ n : ℕ, 0 ≤ (1 : ℝ) / (2 * n + 1) := fun n => by positivity
+  exact (not_summable_iff_tendsto_nat_atTop_of_nonneg hnn).mp not_summable_one_div_odd
+
+end HarmonicDivergenceOQ06

--- a/src/data/proofs/harmonic-divergence-oq-06/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-06/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Setup: The Odd-Reciprocal Series ∑ 1/(2k+1)",
+    "content": "The target object is Summable (fun n : ℕ => (1:ℝ)/(2*n+1)), i.e. the series 1 + 1/3 + 1/5 + 1/7 + ⋯ of reciprocals of the odd numbers. The import Mathlib.Analysis.PSeries supplies Real.not_summable_one_div_natCast (the harmonic series is not summable) and not_summable_iff_tendsto_nat_atTop_of_nonneg, the two Mathlib facts the proof leans on. A subtle Lean point recurs throughout: a bare term like 1/(k+1) with k : ℕ elaborates over ℕ (where it is truncating integer division, almost always 0), so every sum body is annotated with an explicit (k : ℝ) cast to force real division.",
+    "mathContext": "The harmonic series splits as $\\sum 1/n = \\sum 1/(2k) + \\sum 1/(2k+1)$ — an even half and an odd half. This entry isolates the odd half and shows it alone already diverges.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.not_summable_one_div_natCast",
+      "Summable",
+      "natural-number casts to ℝ"
+    ],
+    "prerequisites": [
+      "series and summability",
+      "Lean 4 numeric coercions"
+    ]
+  },
+  {
+    "id": "ann-termwise",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 57,
+      "endLine": 67
+    },
+    "type": "key_step",
+    "title": "The Termwise Comparison: (1/2)·1/(k+1) ≤ 1/(2k+1)",
+    "content": "half_harmonic_le_odd is the single inequality the whole entry rests on. Rewriting the left side, (1/2)·1/(k+1) = 1/(2(k+1)) = 1/(2k+2) (via div_mul_div_comm). Since 2k+1 ≤ 2(k+1) and x ↦ 1/x is decreasing on the positives (one_div_le_one_div_of_le), 1/(2(k+1)) ≤ 1/(2k+1). So each odd reciprocal 1/(2k+1) dominates half of the corresponding harmonic term 1/(k+1). Both the explicit partial-sum bound and the non-summability proof are immediate consequences of this one comparison.",
+    "mathContext": "$\\frac12\\cdot\\frac{1}{k+1} = \\frac{1}{2k+2} \\le \\frac{1}{2k+1}$ because $2k+1 \\le 2k+2$. Geometrically, the odd term sits just to the left of the even term and is therefore larger.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "one_div_le_one_div_of_le",
+      "div_mul_div_comm",
+      "monotonicity of reciprocal"
+    ],
+    "prerequisites": [
+      "antitonicity of x ↦ 1/x"
+    ]
+  },
+  {
+    "id": "ann-partial-bound",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 69,
+      "endLine": 77
+    },
+    "type": "key_step",
+    "title": "Explicit Partial-Sum Bound: ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1)",
+    "content": "oddPartial_ge_half_harmonic sums the termwise comparison over range N. The factor 1/2 is distributed into the harmonic partial sum with Finset.mul_sum, after which Finset.sum_le_sum lifts half_harmonic_le_odd term by term. The result is a quantitative witness of divergence: the odd partial sums dominate half the harmonic partial sums, which are themselves unbounded (≈ ln N), so the odd partial sums grow at least like (1/2)ln N.",
+    "mathContext": "$\\sum_{k<N}\\frac{1}{2k+1} \\ge \\frac12\\sum_{k<N}\\frac{1}{k+1} \\approx \\frac12\\ln N$. This makes the divergence quantitative without invoking summability machinery.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.mul_sum",
+      "Finset.sum_le_sum",
+      "harmonic partial sums"
+    ],
+    "prerequisites": [
+      "termwise comparison of finite sums"
+    ]
+  },
+  {
+    "id": "ann-not-summable",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 79,
+      "endLine": 99
+    },
+    "type": "main_result",
+    "title": "The Odd Reciprocals Are Not Summable",
+    "content": "not_summable_one_div_odd is the headline. The argument is by contradiction. Assume ∑ 1/(2k+1) is summable. Since 0 ≤ 1/(2k+2) ≤ 1/(2k+1), the comparison test Summable.of_nonneg_of_le makes ∑ 1/(2k+2) summable. Multiplying by 2 (Summable.mul_left, then Summable.congr with the identity 2·1/(2k+2) = 1/(k+1)) gives ∑ 1/(k+1) summable. A single index shift (summable_nat_add_iff 1) turns this into ∑ 1/n summable, contradicting Real.not_summable_one_div_natCast. The whole chain is just 'comparison → scale → shift', each step elementary.",
+    "mathContext": "If $\\sum 1/(2k+1) < \\infty$ then $\\sum 1/(2k+2) = \\tfrac12\\sum 1/(k+1) < \\infty$, hence $\\sum 1/n < \\infty$ — contradicting the divergence of the harmonic series.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Summable.of_nonneg_of_le",
+      "Summable.mul_left",
+      "summable_nat_add_iff",
+      "Real.not_summable_one_div_natCast",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "the comparison test",
+      "shift-invariance of summability"
+    ]
+  },
+  {
+    "id": "ann-tendsto",
+    "proofId": "harmonic-divergence-oq-06",
+    "range": {
+      "startLine": 101,
+      "endLine": 106
+    },
+    "type": "concept",
+    "title": "Divergence to +∞",
+    "content": "tendsto_oddPartial_atTop upgrades non-summability to a genuine limit. For a nonnegative series the equivalence not_summable_iff_tendsto_nat_atTop_of_nonneg says non-summability is the same as the partial sums tending to +∞. Feeding in positivity of the terms (positivity) and the headline non-summability result yields Tendsto (fun N => ∑_{k<N} 1/(2k+1)) atTop atTop.",
+    "mathContext": "For nonnegative $f$, $\\neg\\text{Summable } f \\iff \\sum_{k<N} f(k) \\to +\\infty$. Here this gives $1 + 1/3 + 1/5 + \\cdots + 1/(2N-1) \\to +\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "not_summable_iff_tendsto_nat_atTop_of_nonneg",
+      "Filter.Tendsto",
+      "monotone partial sums"
+    ],
+    "prerequisites": [
+      "limits at infinity",
+      "nonnegative series"
+    ]
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-06/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-06/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "harmonic-divergence-oq-06",
+  "title": "The Reciprocals of the Odd Numbers Diverge",
+  "slug": "harmonic-divergence-oq-06",
+  "description": "Discarding every even term of the harmonic series still leaves a divergent series: ∑_{k≥0} 1/(2k+1) = 1 + 1/3 + 1/5 + ⋯ is not summable. Proved by an elementary comparison with the harmonic series, with an explicit partial-sum lower bound ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1) as a bonus.",
+  "meta": {
+    "author": "Classical; formalization original to this gallery",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ06.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "divergence",
+      "harmonic-series",
+      "summability",
+      "comparison-test"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.not_summable_one_div_natCast",
+        "description": "The harmonic series ∑ 1/n is not summable",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "Summable.of_nonneg_of_le",
+        "description": "Comparison test: a nonneg series dominated by a summable one is summable",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "summable_nat_add_iff",
+        "description": "Summability is invariant under a finite index shift",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "not_summable_iff_tendsto_nat_atTop_of_nonneg",
+        "description": "For a nonneg series, non-summability is equivalent to the partial sums tending to +∞",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "Antitonicity of x ↦ 1/x on the positives",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Termwise comparison of finite sums",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "not_summable_one_div_odd: ∑ 1/(2k+1) is not summable — the odd-indexed harmonic subseries diverges. Mathlib records non-summability of the full harmonic series but not of this thinned subseries.",
+      "oddPartial_ge_half_harmonic: the explicit partial-sum bound ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1), exhibiting that the odd reciprocals dominate half the harmonic sum termwise.",
+      "half_harmonic_le_odd: the sharp termwise comparison (1/2)·1/(k+1) ≤ 1/(2k+1), the engine of both the quantitative and qualitative results.",
+      "tendsto_oddPartial_atTop: divergence to +∞ of the odd-reciprocal partial sums, read off from non-summability and nonnegativity."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "lineCount": 106,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the harmonic series diverges is Oresme's theorem (~1350). A natural refinement asks which subseries survive the thinning: removing terms can certainly restore convergence (e.g. ∑ 1/2^k or the Kempner series of denominators missing a digit). The odd-reciprocal series ∑ 1/(2k+1) keeps exactly half the harmonic terms, and the question is whether that half is still 'large' enough to diverge. It is — and the reason is simply that each surviving term 1/(2k+1) is bigger than the even term 1/(2k+2) it sits next to, so the odd series dominates half of the whole harmonic series.",
+    "problemStatement": "Does the series of reciprocals of the odd numbers, 1 + 1/3 + 1/5 + 1/7 + ⋯, converge or diverge?\n\n**Answer: it diverges.** Keeping only the odd denominators is not enough thinning to make the harmonic series summable.",
+    "text": "A self-contained proof that ∑ 1/(2k+1) diverges, by comparison with the harmonic series, together with an explicit lower bound on its partial sums.",
+    "proofStrategy": "1. half_harmonic_le_odd: since 2k+1 ≤ 2(k+1), antitonicity of 1/x gives 1/(2(k+1)) ≤ 1/(2k+1), i.e. (1/2)·1/(k+1) ≤ 1/(2k+1).\n2. oddPartial_ge_half_harmonic: summing the termwise bound over range N (Finset.sum_le_sum, Finset.mul_sum) yields ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1).\n3. not_summable_one_div_odd: assume ∑ 1/(2k+1) summable. The termwise-smaller nonneg series ∑ 1/(2k+2) is then summable (Summable.of_nonneg_of_le); multiplying by 2 gives ∑ 1/(k+1) summable, and an index shift (summable_nat_add_iff) gives ∑ 1/n summable, contradicting Real.not_summable_one_div_natCast.\n4. tendsto_oddPartial_atTop: non-summability plus nonnegativity gives divergence to +∞ via not_summable_iff_tendsto_nat_atTop_of_nonneg.",
+    "keyInsights": [
+      "**Half is still infinite**: the even reciprocals ∑ 1/(2k) = (1/2)∑ 1/k and the odd reciprocals ∑ 1/(2k+1) both diverge; the harmonic series is the sum of two divergent halves. This entry pins down the odd half.",
+      "**One inequality does all the work**: the single termwise comparison 1/(2k+1) ≥ 1/(2k+2) drives both the explicit partial-sum bound and the non-summability proof.",
+      "**Comparison, not condensation**: unlike the dyadic-block (Oresme/Cauchy-condensation) entries, this divergence is obtained by direct comparison with the harmonic series itself — the cleanest available route.",
+      "**Not in Mathlib**: Mathlib has Real.not_summable_one_div_natCast for the full harmonic series, but the non-summability of the odd-indexed subseries is supplied here.",
+      "**Quantitative shadow**: because ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1) ≈ (1/2)ln N, the odd partial sums grow at least logarithmically — the same rate as the harmonic series, up to the factor 1/2."
+    ],
+    "prerequisites": [
+      "Real analysis (series, summability, partial sums)",
+      "The comparison test for nonnegative series",
+      "Basic manipulation of finite sums over Finset"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-namespace",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Imports Mathlib.Analysis.PSeries (home of Real.not_summable_one_div_natCast) and the infinite-sum basics. Opens Finset, Filter, Topology. The header documents the comparison strategy.",
+      "mathContext": "The target series is ∑_{k≥0} 1/(2k+1), formalized as Summable (fun n : ℕ => (1:ℝ)/(2*n+1))."
+    },
+    {
+      "id": "termwise",
+      "title": "The Termwise Comparison",
+      "startLine": 57,
+      "endLine": 67,
+      "summary": "half_harmonic_le_odd: (1/2)·1/(k+1) ≤ 1/(2k+1). Rewrites the left side as 1/(2(k+1)) and applies one_div_le_one_div_of_le with 2k+1 ≤ 2(k+1).",
+      "mathContext": "$\\frac12\\cdot\\frac{1}{k+1} = \\frac{1}{2(k+1)} = \\frac{1}{2k+2} \\le \\frac{1}{2k+1}$, since $2k+1 \\le 2k+2$ and $x\\mapsto 1/x$ is decreasing on the positives."
+    },
+    {
+      "id": "partial-bound",
+      "title": "Explicit Partial-Sum Lower Bound",
+      "startLine": 69,
+      "endLine": 77,
+      "summary": "oddPartial_ge_half_harmonic: ∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1). Pushes the 1/2 through the sum (Finset.mul_sum) and applies the termwise bound under Finset.sum_le_sum.",
+      "mathContext": "$\\sum_{k<N}\\frac{1}{2k+1} \\ge \\frac12\\sum_{k<N}\\frac{1}{k+1}$ — the odd partial sums dominate half the harmonic partial sums."
+    },
+    {
+      "id": "not-summable",
+      "title": "Non-Summability of the Odd Reciprocals",
+      "startLine": 79,
+      "endLine": 99,
+      "summary": "not_summable_one_div_odd: by contradiction. If ∑ 1/(2k+1) were summable, the comparison gives ∑ 1/(2k+2) summable; doubling yields ∑ 1/(k+1) summable; an index shift yields ∑ 1/n summable, contradicting Real.not_summable_one_div_natCast.",
+      "mathContext": "Comparison (Summable.of_nonneg_of_le) + scaling by 2 + index shift (summable_nat_add_iff) reduce convergence of the odd series to convergence of the harmonic series, which is false."
+    },
+    {
+      "id": "tendsto",
+      "title": "Divergence to +∞",
+      "startLine": 101,
+      "endLine": 106,
+      "summary": "tendsto_oddPartial_atTop: the partial sums tend to +∞, via not_summable_iff_tendsto_nat_atTop_of_nonneg applied to the non-summability result and positivity of the terms.",
+      "mathContext": "For a nonnegative series, non-summability is equivalent to the partial sums tending to $+\\infty$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Oresme, Nicole",
+      "title": "Quaestiones super geometriam Euclidis",
+      "year": "~1350",
+      "note": "First proof of harmonic divergence; the odd subseries treated here is the odd half of that series"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "extends",
+      "description": "The base entry proves the full harmonic series diverges; this entry shows the odd-indexed half already diverges, by comparison with the base series"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-05",
+      "relationship": "sibling",
+      "description": "OQ-05 gives an explicit lower bound for the full harmonic partial sums; OQ-06 gives the analogous comparison-based bound and divergence for the odd subseries"
+    }
+  ],
+  "conclusion": {
+    "summary": "The reciprocals of the odd numbers form a divergent series: ∑ 1/(2k+1) is not summable, and its partial sums tend to +∞. The proof is a one-inequality comparison — 1/(2k+1) ≥ 1/(2k+2) — that dominates half the harmonic series, sharpened into an explicit partial-sum lower bound.",
+    "implications": "Removing every even term does not tame the harmonic series; the surviving odd half still grows logarithmically. Combined with ∑ 1/(2k) = (1/2)∑ 1/k, this exhibits the harmonic series as a sum of two divergent halves.",
+    "openQuestions": [
+      "What is the smallest density of a subset S ⊆ ℕ guaranteeing ∑_{n∈S} 1/n diverges, and can a sharp threshold be formalized?",
+      "Can the matching upper bound ∑_{k<N} 1/(2k+1) ≤ 1 + (1/2)∑_{k<N} 1/(k+1) be added to sandwich the odd partial sums?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "HarmonicDivergenceOQ06",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/HarmonicDivergenceOQ06.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **harmonic-divergence-oq-06**: the series of reciprocals of the odd numbers diverges.

$$\sum_{k\ge 0}\frac{1}{2k+1} = 1 + \tfrac13 + \tfrac15 + \tfrac17 + \cdots = \infty.$$

Discarding every even term of the harmonic series is not enough thinning to restore summability — the surviving odd half still diverges.

## Approach

A clean one-inequality comparison with the harmonic series. For every `k`,
`1/(2k+1) ≥ 1/(2k+2) = (1/2)·1/(k+1)` because `2k+1 ≤ 2k+2`. From this:

- **`half_harmonic_le_odd`** — the termwise comparison `(1/2)·1/(k+1) ≤ 1/(2k+1)`.
- **`oddPartial_ge_half_harmonic`** — explicit partial-sum bound `∑_{k<N} 1/(2k+1) ≥ (1/2)∑_{k<N} 1/(k+1)`.
- **`not_summable_one_div_odd`** (headline) — non-summability, by contradiction: a convergent odd series would force `∑ 1/(2k+2)` convergent (comparison test), hence `∑ 1/(k+1)` and then `∑ 1/n` convergent (scale + index shift), contradicting `Real.not_summable_one_div_natCast`.
- **`tendsto_oddPartial_atTop`** — divergence of the partial sums to `+∞`.

## Relation to Mathlib

Mathlib records non-summability of the full harmonic series (`Real.not_summable_one_div_natCast`) but not of this odd-indexed subseries; it is supplied here by elementary comparison.

## Verification

- **4 theorems, 0 definitions, 0 sorries, 106 lines.**
- `#print axioms` on all four theorems reports only `propext`, `Classical.choice`, `Quot.sound` → **0 axioms, status `verified`**.
- Checked with `lean v4.26.0` (Mathlib 4.26.0).

Gallery data (`meta.json`, `annotations.json`) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)