### PR TITLE
Enrich Factor/Remainder OQ-06 (rational root theorem, concrete form): add annotations + index.ts

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-06/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "factor-remainder-theorem-oq-06",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "The Rational Root Theorem in Usable num/den Form",
+    "content": "Mathlib proves the rational root theorem in great generality — for any root in the fraction field of a UFD — phrased through the fraction-ring numerator/denominator, which are only defined up to a unit. The textbook statement a reader expects (a rational root a/b in lowest terms has a ∣ a₀ and b ∣ aₙ) is not what that abstract theorem says verbatim. This file supplies the concrete form using the canonical reduced Rat.num/Rat.den, bridging across Rat.associated_num_den, and derives the rational root test and the irrationality of √2.",
+    "mathContext": "$\\mathrm{aeval}\\,r\\,p = 0 \\implies r.\\mathrm{num} \\mid p.\\mathrm{coeff}\\,0 \\;\\wedge\\; (r.\\mathrm{den} : \\mathbb{Z}) \\mid p.\\mathrm{leadingCoeff}.$",
+    "significance": "context",
+    "relatedConcepts": ["rational root theorem", "factor theorem", "fraction ring", "associatedness"],
+    "prerequisites": ["polynomials over ℤ", "rational numbers in lowest terms"]
+  },
+  {
+    "id": "ann-concrete-divisibility",
+    "proofId": "factor-remainder-theorem-oq-06",
+    "range": { "startLine": 59, "endLine": 75 },
+    "type": "insight",
+    "title": "Concrete Divisibility via Association Transfer",
+    "content": "The core specialization. Mathlib's num_dvd_of_is_root / den_dvd_of_is_root give divisibility for the abstract fraction-ring num/den; Rat.associated_num_den says these are associated to the canonical r.num, r.den. Since associated elements divide each other, divisibility — being insensitive to unit factors (over ℤ the units are ±1) — transfers cleanly: num_dvd_constantCoeff and den_dvd_leadingCoeff state it for the literal reduced fraction. num_den_dvd packages both — exactly the data the rational root test enumerates.",
+    "mathContext": "$\\mathrm{Associated}\\,a\\,b \\Rightarrow b \\mid a$; transfer $\\mathrm{num}_{\\mathbb{Z}}\\,r \\mid a_0$ to $r.\\mathrm{num} \\mid a_0$.",
+    "significance": "key",
+    "relatedConcepts": ["associatedness", "unit-insensitive divisibility", "Rat.associated_num_den", "fraction-ring num/den"],
+    "prerequisites": ["Associated.dvd", "num_dvd_of_is_root"]
+  },
+  {
+    "id": "ann-integral-root",
+    "proofId": "factor-remainder-theorem-oq-06",
+    "range": { "startLine": 77, "endLine": 91 },
+    "type": "concept",
+    "title": "The Integral Root Theorem",
+    "content": "For a monic integer polynomial the leading coefficient is 1, so the positive integer r.den divides 1 and therefore equals 1 — every rational root is an integer (monic_root_den_eq_one). This collapses the rational root theorem to 'rational roots are integers dividing the constant term' (monic_root_num_dvd_const), the form used to test for integer roots. It is the lemma the √2 application rests on.",
+    "mathContext": "$p \\text{ monic} \\Rightarrow \\mathrm{leadingCoeff} = 1 \\Rightarrow (r.\\mathrm{den}:\\mathbb{Z}) \\mid 1 \\Rightarrow r.\\mathrm{den} = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["integral root theorem", "monic polynomial", "Int.eq_one_of_dvd_one"],
+    "prerequisites": ["den_dvd_leadingCoeff", "Monic.leadingCoeff"]
+  },
+  {
+    "id": "ann-root-test",
+    "proofId": "factor-remainder-theorem-oq-06",
+    "range": { "startLine": 93, "endLine": 107 },
+    "type": "technique",
+    "title": "The Rational Root Test",
+    "content": "The contrapositive packaging that makes the theorem an algorithm. no_rational_root_of_no_candidate: if no fraction whose numerator divides a₀ and whose denominator divides aₙ is a root, then p has no rational root at all — a finite check once a₀, aₙ ≠ 0. rational_root_mem_candidates states every rational root lies in the divisor-determined candidate set, turning root-finding into a finite divisor enumeration.",
+    "mathContext": "$\\big(\\forall q,\\; q.\\mathrm{num}\\mid a_0 \\wedge q.\\mathrm{den}\\mid a_n \\Rightarrow \\mathrm{aeval}\\,q\\,p \\ne 0\\big) \\Rightarrow \\forall q,\\; \\mathrm{aeval}\\,q\\,p \\ne 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["rational root test", "finite candidate set", "contrapositive", "divisor enumeration"],
+    "prerequisites": ["num_den_dvd", "the concrete divisibility lemmas"]
+  },
+  {
+    "id": "ann-application",
+    "proofId": "factor-remainder-theorem-oq-06",
+    "range": { "startLine": 109, "endLine": 147 },
+    "type": "insight",
+    "title": "Worked Application: √2 Is Irrational (inside ℚ)",
+    "content": "sq_ne_two proves no rational number squares to 2, purely inside ℚ from the rational root theorem. X² − 2 is monic (monic_X_pow_sub), so any rational root q has q.den = 1, i.e. q = q.num is an integer n with n² = 2. The helper int_sq_ne_two bounds |n| ≤ 2 via Int.le_of_dvd (n ∣ 2) and interval_cases rules out ±1, ±2. This is the rational shadow of √2 ∉ ℝ∖ℚ, obtained without ever leaving ℚ.",
+    "mathContext": "$q^2 = 2 \\Rightarrow q.\\mathrm{den} = 1 \\Rightarrow q.\\mathrm{num}^2 = 2,\\; |q.\\mathrm{num}| \\le 2$ — no solution.",
+    "significance": "key",
+    "relatedConcepts": ["irrationality of √2", "monic_X_pow_sub", "interval_cases", "integral root theorem"],
+    "prerequisites": ["the integral root theorem", "Int.le_of_dvd", "Rat.num_div_den"]
+  }
+]

--- a/src/data/proofs/factor-remainder-theorem-oq-06/index.ts
+++ b/src/data/proofs/factor-remainder-theorem-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FactorRemainderTheoremOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const factorRemainderTheoremOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const factorRemainderTheoremOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const factorRemainderTheoremOq06Data: ProofData = {
+  proof: factorRemainderTheoremOq06Proof,
+  annotations: factorRemainderTheoremOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-06`.

## Critical fix
Entry was **missing `index.ts`** — without it Vite cannot discover the proof, so the page shows 'proof not found' on the live site. Added from the standard template.

## Annotations (new `annotations.json`)
Added **5 annotations** covering every section, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- The abstract-vs-concrete num/den gap the entry closes
- Concrete divisibility via association transfer (the core specialization)
- The integral root theorem (monic ⇒ rational roots are integers)
- The rational root test and finite candidate set
- The √2 irrationality application, proved purely inside ℚ

## Verification
- JSON validated; `tsc -b` passes.