### PR TITLE
Enrich Baire OQ-01-OQ-02 (perfect space has cardinality ≥ 𝔠): add annotations + index.ts

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "baire-category-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "From Uncountable to Cardinality ≥ 𝔠",
+    "content": "The parent Baire-category entry showed a nonempty complete metric space with no isolated points is uncountable (no singleton is everywhere, so it is not a countable union of singletons). This file sharpens that to an explicit cardinal floor: such a space has at least the cardinality of the continuum, 𝔠 = 2^ℵ₀. The mechanism is the classical Cantor scheme — a binary tree of shrinking nonempty closed sets whose 2^ℵ₀ branches inject into the space. Mathlib packages the tree as Perfect.exists_nat_bool_injection; this entry assembles it into the cardinal statement.",
+    "mathContext": "$\\mathfrak{c} = 2^{\\aleph_0} \\le \\#\\alpha$ for a nonempty complete metric space $\\alpha$ with no isolated points.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor scheme", "perfect set", "continuum", "descriptive set theory", "Cantor–Bendixson"],
+    "prerequisites": ["cardinal arithmetic", "complete metric spaces", "perfect sets"]
+  },
+  {
+    "id": "ann-cardinal-arith",
+    "proofId": "baire-category-theorem-oq-01-oq-02",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "technique",
+    "title": "Cardinal Arithmetic: #(ℕ → Bool) = 𝔠",
+    "content": "The cardinal identity underlying the bound: the set of binary sequences (the Cantor space) has cardinality #Bool ^ #ℕ = 2^ℵ₀ = 𝔠. Proved by chaining mk_arrow, mk_bool, mk_nat and two_power_aleph0 (with the lift lemmas for universe bookkeeping). This is the target the Cantor-scheme injection lands against.",
+    "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = \\#\\mathrm{Bool}^{\\#\\mathbb{N}} = 2^{\\aleph_0} = \\mathfrak{c}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Cantor space", "cardinal exponentiation", "mk_arrow", "two_power_aleph0"],
+    "prerequisites": ["Cardinal.mk", "cardinal exponentiation"]
+  },
+  {
+    "id": "ann-set-bound",
+    "proofId": "baire-category-theorem-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 65 },
+    "type": "insight",
+    "title": "Headline: Perfect Sets Have Cardinality ≥ 𝔠",
+    "content": "The core result continuum_le_mk_of_perfect: for a nonempty perfect set C in a complete metric space, Mathlib's Cantor-scheme injection (ℕ → Bool) ↪ α (with range ⊆ C) is corestricted to C — staying injective because Subtype.ext peels the coercion — giving 𝔠 = #(ℕ → Bool) ≤ #C. The deep topological work (building the shrinking-closed-set tree, using completeness to converge each branch) is delegated to Mathlib; the cardinal conclusion is then pure bookkeeping.",
+    "mathContext": "$C$ perfect, nonempty, $\\alpha$ complete metric $\\implies \\mathfrak{c} \\le \\#C$, via $(\\mathbb{N}\\to\\mathrm{Bool}) \\hookrightarrow C$.",
+    "significance": "key",
+    "relatedConcepts": ["perfect set", "Cantor-scheme injection", "corestriction", "mk_le_of_injective"],
+    "prerequisites": ["Perfect.exists_nat_bool_injection", "Subtype injectivity"]
+  },
+  {
+    "id": "ann-space-bound",
+    "proofId": "baire-category-theorem-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 90 },
+    "type": "concept",
+    "title": "Space-Level Form and Uncountability Corollaries",
+    "content": "continuum_le_mk_of_perfectSpace specializes the set bound to univ: a PerfectSpace has Perfect (univ) (PerfectSpace.univ_perfect), and #(univ) = #α (mk_univ), so 𝔠 ≤ #α — the open question's statement. Two corollaries strictly sharpen the parent's uncountability: aleph0_lt_mk_of_perfectSpace (ℵ₀ < 𝔠 ≤ #α) and not_countable_of_perfectSpace (¬ Countable α via mk_le_aleph0_iff). 'Cardinality ≥ 𝔠' is genuinely stronger than 'uncountable'.",
+    "mathContext": "$\\mathrm{PerfectSpace}\\,\\alpha + \\mathrm{complete} + \\mathrm{nonempty} \\implies \\mathfrak{c} \\le \\#\\alpha \\implies \\aleph_0 < \\#\\alpha.$",
+    "significance": "key",
+    "relatedConcepts": ["PerfectSpace", "PerfectSpace.univ_perfect", "uncountability", "mk_univ"],
+    "prerequisites": ["the set-level bound", "aleph0_lt_continuum"]
+  },
+  {
+    "id": "ann-bridge-real",
+    "proofId": "baire-category-theorem-oq-01-oq-02",
+    "range": { "startLine": 92, "endLine": 106 },
+    "type": "context",
+    "title": "No-Isolated-Points Bridge and the ℝ Instance",
+    "content": "perfectSpace_iff_no_isolated confirms PerfectSpace α is exactly the open question's hypothesis — every punctured neighbourhood filter 𝓝[≠] x is nontrivial (no point is isolated). continuum_le_mk_real then derives 𝔠 ≤ #ℝ purely formally: ℝ is a nontrivial connected T1 complete metric space, hence a PerfectSpace, so the cardinality floor follows from the topological hypothesis alone — no use of ℝ's order or field structure. Completeness is essential: ℚ has no isolated points yet is countable.",
+    "mathContext": "$\\mathrm{PerfectSpace}\\,\\alpha \\iff \\forall x,\\; \\mathcal{N}[{\\ne}]\\,x \\text{ is nontrivial}$; and $\\mathfrak{c} \\le \\#\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isolated points", "neighborhood filter", "real line", "role of completeness"],
+    "prerequisites": ["perfectSpace_iff_forall_not_isolated", "ℝ as a PerfectSpace"]
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BairePerfectContinuumOQ0102.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baireCategoryTheoremOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baireCategoryTheoremOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baireCategoryTheoremOq01Oq02Data: ProofData = {
+  proof: baireCategoryTheoremOq01Oq02Proof,
+  annotations: baireCategoryTheoremOq01Oq02Annotations,
+}

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "A Complete Metric Space with No Isolated Points Has Cardinality ≥ 𝔠",
+  "description": "Sharpens the parent Baire-category uncountability result to an explicit cardinal floor: a nonempty complete metric space with no isolated points (a PerfectSpace) has cardinality at least the continuum, 𝔠 ≤ #α — and more generally every nonempty perfect set C in a complete metric space satisfies 𝔠 ≤ #C. The proof corestricts Mathlib's Cantor-scheme injection (ℕ → Bool) ↪ C and uses #(ℕ → Bool) = 2^ℵ₀ = 𝔠. Corollaries strictly improve the parent's bare uncountability (ℵ₀ < #α, ¬ Countable α), and the motivating instance 𝔠 ≤ #ℝ follows purely from the topological hypothesis.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `baire-category-theorem-oq-01-oq-02`.

## Critical fix
Entry was **missing `index.ts`** — without it Vite cannot discover the proof, so the page shows 'proof not found' on the live site. Added from the standard template. Also added the **missing top-level `description`** field to meta.json (the Proof type expects it).

## Annotations (new `annotations.json`)
Added **5 annotations** covering every section, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- From uncountable to cardinality ≥ 𝔠 (the sharpening)
- Cardinal arithmetic #(ℕ → Bool) = 2^ℵ₀ = 𝔠
- The headline perfect-set bound via the corestricted Cantor-scheme injection
- The space-level form (PerfectSpace) and uncountability corollaries
- The no-isolated-points bridge and the 𝔠 ≤ #ℝ instance

## Verification
- JSON validated; `tsc -b` passes.