### PR TITLE
Enrich Plancherel/Parseval for the Discrete Fourier Transform

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-dft-kernel-transform",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 67 },
+    "type": "definition",
+    "title": "The DFT kernel and transform",
+    "content": "`char n j k = exp(2πi·jk/n)` is the sampled Fourier character — exactly the summand of the parent's `sum_char_inner`. The (unnormalised) discrete Fourier transform `dft n x j = ∑_{k<n} x(k)·char n j k` evaluates a length-$n$ signal $x$ at frequency $j$. Working with explicit exponentials (rather than Mathlib's abstract `ZMod n` measure-theoretic Fourier transform) is what keeps the whole Parseval argument elementary — built directly from roots-of-unity orthogonality.",
+    "mathContext": "$\\hat{x}(j) = \\sum_{k<n} x(k)\\,e^{2\\pi i jk/n}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["discrete Fourier transform", "roots of unity", "Fourier character"],
+    "prerequisites": ["complex exponential", "finite sums"]
+  },
+  {
+    "id": "ann-dft-kernel-symmetry",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 77 },
+    "type": "insight",
+    "title": "Kernel symmetry: time ↔ frequency",
+    "content": "`char_symm`: the kernel is symmetric, $\\mathrm{char}(j,k) = \\mathrm{char}(k,j)$, because the exponent $jk$ is symmetric. This tiny observation is the linchpin: the parent's orthonormality is summed over the *time* index, but Plancherel needs it summed over the *frequency* index. Symmetry lets one be reused as the other with no new computation.",
+    "mathContext": "$e^{2\\pi i jk/n} = e^{2\\pi i kj/n}.$",
+    "significance": "key",
+    "relatedConcepts": ["symmetry", "time-frequency duality"],
+    "prerequisites": ["complex exponential"]
+  },
+  {
+    "id": "ann-dft-orthonormality",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 101 },
+    "type": "concept",
+    "title": "Character orthonormality over time and frequency",
+    "content": "`char_inner` repackages the parent's `sum_char_inner`: the sampled characters are orthonormal with squared norm $n$, $\\sum_{k<n} \\mathrm{char}(a,k)\\,\\overline{\\mathrm{char}(b,k)} = n\\,[a=b]$. `freq_orthonormal` then transports this to a sum over the *frequency* index $j$ (fixing two time indices $k,l$) using `char_symm`. This frequency-indexed dichotomy is the exact form the Plancherel computation consumes — it is what collapses the double time-sum to its diagonal.",
+    "mathContext": "$\\sum_{j<n} \\mathrm{char}(j,k)\\,\\overline{\\mathrm{char}(j,l)} = n\\,[k=l].$",
+    "significance": "key",
+    "relatedConcepts": ["orthonormality", "roots of unity orthogonality", "Kronecker delta"],
+    "prerequisites": ["the parent orthogonality relation", "kernel symmetry"]
+  },
+  {
+    "id": "ann-dft-linearity",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 103, "endLine": 110 },
+    "type": "context",
+    "title": "Linearity of the transform",
+    "content": "`dft_add`: the DFT is additive, $\\widehat{x+y} = \\hat{x} + \\hat{y}$ pointwise in frequency — a one-line distributivity fact. It records the transform's linear-map character, the structural backdrop against which 'energy preservation up to scale $n$' means the DFT is $\\sqrt n$ times a unitary.",
+    "mathContext": "$\\widehat{(x+y)}(j) = \\hat{x}(j) + \\hat{y}(j).$",
+    "significance": "context",
+    "relatedConcepts": ["linearity", "linear operator"],
+    "prerequisites": ["the DFT definition"]
+  },
+  {
+    "id": "ann-dft-plancherel",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 159 },
+    "type": "technique",
+    "title": "Plancherel: ∑ x̂·conj ŷ = n·∑ x·conj y",
+    "content": "The main theorem and the technical heart. Expanding both transforms turns each frequency summand into a double time-sum over $k,l$ weighted by $\\mathrm{char}(j,k)\\overline{\\mathrm{char}(j,l)}$. The proof then (1) pushes the frequency sum $\\sum_j$ innermost via `Finset.sum_comm`, (2) pulls the time-only coefficient $x(k)\\overline{y(l)}$ out, (3) applies `freq_orthonormal` so the inner $\\sum_j$ becomes $n\\,[k=l]$, and (4) collapses the diagonal with `sum_eq_single`. What survives is $n\\sum_k x(k)\\overline{y(k)}$ — the Hermitian inner product scaled by $n$.",
+    "mathContext": "$\\sum_{j<n} \\hat{x}(j)\\overline{\\hat{y}(j)} = n\\sum_{k<n} x(k)\\overline{y(k)}.$",
+    "significance": "key",
+    "relatedConcepts": ["Plancherel theorem", "Hermitian inner product", "summation interchange"],
+    "prerequisites": ["frequency orthonormality", "double-sum manipulation"]
+  },
+  {
+    "id": "ann-dft-parseval",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01",
+    "range": { "startLine": 161, "endLine": 182 },
+    "type": "insight",
+    "title": "Parseval: energy preservation up to scale n",
+    "content": "Setting $y = x$ in Plancherel gives Parseval, $\\sum_{j<n} |\\hat{x}(j)|^2 = n\\sum_{k<n} |x(k)|^2$ (`dft_parseval`, via `Complex.mul_conj`), and `dft_parseval_norm` restates it with the Euclidean norm $\\|\\cdot\\|$. The DFT therefore preserves $\\ell^2$-energy up to the factor $n$ — it is $\\sqrt n$ times a unitary map. Mathlib has unitarity of the *normalised* Fourier transform abstractly; this explicit-exponential energy identity, built straight from roots-of-unity orthogonality, was missing.",
+    "mathContext": "$\\sum_{j<n} |\\hat{x}(j)|^2 = n\\sum_{k<n} |x(k)|^2.$",
+    "significance": "key",
+    "relatedConcepts": ["Parseval theorem", "unitary operator", "energy conservation", "ℓ² norm"],
+    "prerequisites": ["the Plancherel identity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-01-oq-01` (quality 45, pass 0).

## Gap
Rich meta.json but **no annotations.json** — zero inline annotation coverage.

## Changes
Added `annotations.json` with **6 annotations** covering the full proof:
1. The DFT kernel and transform
2. Kernel symmetry: time ↔ frequency (the linchpin reuse trick)
3. Character orthonormality over time and frequency
4. Linearity of the transform
5. Plancherel: ∑ x̂·conj ŷ = n·∑ x·conj y (double-sum collapse)
6. Parseval: energy preservation up to scale n (DFT = √n · unitary)

Each includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- `pnpm annotations:build` passes with **no warnings** for this entry.
- JSON validated. meta.json unchanged (verified, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)