### PR TITLE
research(fibonacci-identities-oq-02-oq-01): general forward direction of the Lucas odd-quotient law [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ01.lean
@@ -91,6 +91,9 @@ theorem two_mul_fib_succ (n : ℕ) : 2 * fib (n + 1) = lucas n + fib n := by
   | one => rfl
   | more n ih1 ih2 =>
       show 2 * fib (n + 3) = lucas (n + 2) + fib (n + 2)
+      -- restate `ih2` with the index in canonical `n + 2` form (defeq to
+      -- `n + 1 + 1`) so `omega` unifies it with the `fib (n + 2)` below
+      have ih2' : 2 * fib (n + 2) = lucas (n + 1) + fib (n + 1) := ih2
       have h1 : fib (n + 2) = fib n + fib (n + 1) := fib_add_two
       have h2 : fib (n + 3) = fib (n + 1) + fib (n + 2) := fib_add_two
       have h3 : lucas (n + 2) = lucas n + lucas (n + 1) := lucas_add_two n
@@ -152,11 +155,11 @@ theorem lucas_gcd_two_four : Nat.gcd (lucas 2) (lucas 4) = 1 := by decide
 
 /-! ## The correct law: the "odd quotient" characterization
 
-For `m ≥ 2`, `Lₘ ∣ Lₙ ⟺ m ∣ n and n / m is odd`. We do not prove the general
-biconditional here (it requires the integer Lucas addition law
-`L_{a+2m} = L_{a+m}·Lₘ − (−1)ᵐ·L_a`, beyond the present Mathlib-backed scope);
-instead we verify the rule on the structurally decisive instances, contrasting
-the odd-quotient (divisible) and even-quotient (not divisible) cases. -/
+For `m ≥ 2`, `Lₘ ∣ Lₙ ⟺ m ∣ n and n / m is odd`. We verify the rule on the
+structurally decisive instances, contrasting the odd-quotient (divisible) and
+even-quotient (not divisible) cases. The **forward direction** — odd quotient
+implies divisibility — is then proved in full generality below
+(`lucas_dvd_of_odd_quotient`); only the converse remains for future work. -/
 
 /-- `L₂ ∣ L₆`: quotient `6 / 2 = 3` is odd. (`L₂ = 3 ∣ 18 = L₆`.) -/
 theorem lucas_two_dvd_lucas_six : lucas 2 ∣ lucas 6 := by decide
@@ -176,5 +179,88 @@ theorem lucas_three_not_dvd_lucas_six : ¬ lucas 3 ∣ lucas 6 := by decide
 `m ≥ 2` hypothesis (here `1 / 1 = 1` is odd, consistent with the rule, but the
 content is vacuous since `L₁ = 1`). -/
 theorem lucas_one_dvd (n : ℕ) : lucas 1 ∣ lucas n := by simp
+
+/-! ## The forward direction of the odd-quotient law, in full generality
+
+We now prove the "if" half of the odd-quotient characterization as a
+universally quantified theorem: for every `m` and every `n` with `m ∣ n` and
+`n / m` odd, `Lₘ ∣ Lₙ`. This subsumes the concrete instances above
+(`L₂ ∣ L₆`, `L₃ ∣ L₉`, …).
+
+The engine is the **Lucas shift identity**
+
+    L_{a+1+b} = F_{b+1} · L_{a+1} + F_b · L_a       (`lucas_add_shift`)
+
+— the Lucas analogue of `Nat.fib_add`, proved by two-step induction on `b`
+purely from the recurrences `Lₙ₊₂ = Lₙ + Lₙ₊₁` and `Fₙ₊₂ = Fₙ + Fₙ₊₁`, with no
+subtraction and no signs. Writing an odd multiple as `(2k+1)·m = m + 2·(k·m)`,
+the shift identity gives
+
+    L_{(2k+1)m} = F_{2km+1} · Lₘ + F_{2km} · L_{m-1},
+
+and `Lₘ ∣ F_{2km}` (because `Lₘ ∣ F_{2m} ∣ F_{2km}`, using `Nat.fib_dvd`), so
+both terms are divisible by `Lₘ`. -/
+
+/-- **Lucas shift identity** (the Lucas analogue of `Nat.fib_add`):
+`L_{a+1+b} = F_{b+1}·L_{a+1} + F_b·L_a`. Proved by two-step induction on `b`
+from the Lucas and Fibonacci recurrences — subtraction-free and sign-free, the
+shifted form chosen to avoid any `a - 1`. -/
+theorem lucas_add_shift (a b : ℕ) :
+    lucas (a + 1 + b) = fib (b + 1) * lucas (a + 1) + fib b * lucas a := by
+  induction b using Nat.twoStepInduction with
+  | zero => simp
+  | one =>
+      show lucas (a + 2) = fib 2 * lucas (a + 1) + fib 1 * lucas a
+      rw [lucas_add_two, fib_two, fib_one]; ring
+  | more b ih1 ih2 =>
+      have hrec : lucas (a + 1 + (b + 2))
+          = lucas (a + 1 + b) + lucas (a + 1 + (b + 1)) := by
+        rw [show a + 1 + (b + 2) = (a + 1 + b) + 2 from by ring, lucas_add_two,
+            show a + 1 + b + 1 = a + 1 + (b + 1) from by ring]
+      have ih2' : lucas (a + 1 + (b + 1))
+          = fib (b + 2) * lucas (a + 1) + fib (b + 1) * lucas a := by
+        have h : b + 1 + 1 = b + 2 := rfl
+        rw [← h]; exact ih2
+      have fA : fib (b + 2) = fib b + fib (b + 1) := fib_add_two
+      have fB : fib (b + 2 + 1) = fib (b + 1) + fib (b + 2) := fib_add_two
+      rw [hrec, ih1, ih2', fB, fA]; ring
+
+/-- The same identity with the index split as `m + b` for `m ≥ 1`, exposing the
+divisor `Lₘ` directly: `L_{m+b} = F_{b+1}·Lₘ + F_b·L_{m-1}`. -/
+theorem lucas_add_eq {m : ℕ} (hm : 1 ≤ m) (b : ℕ) :
+    lucas (m + b) = fib (b + 1) * lucas m + fib b * lucas (m - 1) := by
+  obtain ⟨a, rfl⟩ : ∃ a, m = a + 1 := ⟨m - 1, by omega⟩
+  simpa using lucas_add_shift a b
+
+/-- `Lₘ ∣ F_{2(km)}`: the Lucas number `Lₘ` divides every even-multiple-of-`m`
+Fibonacci number, from `Lₘ ∣ F_{2m}` (`lucas_dvd_fib_two_mul`) and
+`F_{2m} ∣ F_{2(km)}` (`Nat.fib_dvd`, since `2m ∣ 2(km)`). -/
+theorem lucas_dvd_fib_even_mul (m k : ℕ) : lucas m ∣ fib (2 * (k * m)) :=
+  (lucas_dvd_fib_two_mul m).trans (fib_dvd (2 * m) (2 * (k * m)) ⟨k, by ring⟩)
+
+/-- **Odd multiples divide (general).** For all `m, k`, `Lₘ ∣ L_{(2k+1)m}`.
+The odd-quotient case of the divisibility rule, proved universally. -/
+theorem lucas_dvd_lucas_odd_mul (m k : ℕ) :
+    lucas m ∣ lucas ((2 * k + 1) * m) := by
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · subst hm; simp
+  · rw [show (2 * k + 1) * m = m + 2 * (k * m) from by ring, lucas_add_eq hm]
+    exact Nat.dvd_add (dvd_mul_left _ _)
+      ((lucas_dvd_fib_even_mul m k).mul_right _)
+
+/-- **Forward direction of the odd-quotient law (general).** If `m ∣ n` and the
+quotient `n / m` is odd, then `Lₘ ∣ Lₙ`. This proves the "⟸" half of the
+characterization `Lₘ ∣ Lₙ ⟺ m ∣ n ∧ n/m odd` for all `m, n`, generalising the
+concrete instances `L₂ ∣ L₆` and `L₃ ∣ L₉`. The converse remains open. -/
+theorem lucas_dvd_of_odd_quotient {m n : ℕ} (hmn : m ∣ n) (hodd : Odd (n / m)) :
+    lucas m ∣ lucas n := by
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · rw [hm, Nat.div_zero] at hodd; exact absurd hodd (by decide)
+  · obtain ⟨q, hq⟩ := hmn
+    obtain ⟨k, hk⟩ := hodd
+    have hqv : q = 2 * k + 1 := by
+      rw [← hk, hq, Nat.mul_div_cancel_left q hm]
+    rw [hq, hqv, mul_comm]
+    exact lucas_dvd_lucas_odd_mul m k
 
 end FibonacciIdentitiesOQ02OQ01

--- a/research/problems/fibonacci-identities-oq-02-oq-01/knowledge.md
+++ b/research/problems/fibonacci-identities-oq-02-oq-01/knowledge.md
@@ -1,0 +1,43 @@
+# fibonacci-identities-oq-02-oq-01 — knowledge
+
+## Status
+verified / 0-axiom. File `proofs/Proofs/FibonacciIdentitiesOQ02OQ01.lean`.
+Topic: Lucas numbers are NOT a strong divisibility sequence; the correct law is
+the odd-quotient rule `Lₘ ∣ Lₙ ⟺ m∣n ∧ Odd(n/m)` (m ≥ 2).
+
+## Established (prior sessions)
+- `lucas` via pair recursion; bridge `2·Fₙ₊₁ = Lₙ + Fₙ`, closed form
+  `Lₙ = 2Fₙ₊₁ − Fₙ`, product identity `F₂ₙ = Fₙ·Lₙ`, hence `Lₙ ∣ F₂ₙ`.
+- Strong-divisibility failure + the odd-quotient rule verified on instances
+  (`L₂∣L₆`, `L₂∤L₄`, `L₃∣L₉`, `L₃∤L₆`).
+
+## This session (2026-06-24, researcher-1) — forward direction, GENERAL
+Proved the entire "⟸" half of the odd-quotient biconditional:
+- `lucas_add_shift`: `L_{a+1+b} = F_{b+1}·L_{a+1} + F_b·L_a` (Lucas analogue of
+  `Nat.fib_add`), two-step induction on `b`, subtraction-free / sign-free.
+- `lucas_add_eq`: split form `L_{m+b} = F_{b+1}·Lₘ + F_b·L_{m-1}` (m ≥ 1).
+- `lucas_dvd_fib_even_mul`: `Lₘ ∣ F_{2(km)}` (via `Lₘ ∣ F_{2m} ∣ F_{2km}`,
+  `Nat.fib_dvd`).
+- `lucas_dvd_lucas_odd_mul`: `Lₘ ∣ L_{(2k+1)m}` for all m, k.
+- `lucas_dvd_of_odd_quotient`: `m∣n ∧ Odd(n/m) → Lₘ ∣ Lₙ`, all m, n.
+
+All 0-axiom (`#print axioms` → propext/Classical.choice/Quot.sound only).
+
+### Gotchas
+- `rec` is a RESERVED keyword → cannot name a `have` it; use `hrec`. Parse error
+  cascades into spurious errors elsewhere (looked like a failure at line 97).
+- **omega atom fragility** (pre-existing, repaired): omega does NOT unify
+  `fib (n+1+1)` (from a two-step IH) with `fib (n+2)`. `two_mul_fib_succ`'s
+  `more` case failed standalone in the current Mathlib pin. Fix: restate the IH
+  `have ih2' : 2 * fib (n+2) = … := ih2` (defeq) so omega sees one atom. Same
+  care taken in `lucas_add_shift` (used `ring` after explicit index rewrites).
+- `Nat.fib_dvd (m n) (h : m ∣ n) : fib m ∣ fib n` — m, n explicit then h.
+- Build: fresh worktree off origin/main has NO mathlib cache → `cp` file into
+  the MAIN checkout, build with host `lake env lean`, `git checkout --` to
+  restore main, commit from worktree.
+
+## Still open
+1. CONVERSE: `Lₘ ∣ Lₙ → m∣n ∧ Odd(n/m)` (m ≥ 2) — the even-quotient
+   non-divisibility / 2-adic obstruction at the doubling step.
+2. gcd law `gcd(Lₘ,Lₙ) = L_{gcd(m,n)}` when `v₂(m)=v₂(n)`, else `∈ {1,2}`.
+3. General Lucas sequences `Vₙ(P,Q)`.

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "fibonacci-identities-oq-02-oq-01",
-  "title": "Lucas Numbers Are Not a Strong Divisibility Sequence",
+  "title": "Lucas Numbers Are Not a Strong Divisibility Sequence — with the general forward direction of the odd-quotient law",
   "slug": "fibonacci-identities-oq-02-oq-01",
-  "description": "The parent entry showed the Fibonacci numbers form a strong divisibility sequence — fib (gcd m n) = gcd (fib m) (fib n), and for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n. Its first open question asks for the Lucas-number analogue. This entry settles it with a sharp contrast: the Lucas numbers Lₙ (L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁) are NOT a strong divisibility sequence. Concretely gcd(L₂,L₄)=gcd(3,7)=1 while L_{gcd(2,4)}=L₂=3, so the strong law fails; and 2∣4 yet L₂=3∤7=L₄, so index divisibility does not transfer to value divisibility — the Fibonacci implication m∣n ⇒ fib m ∣ fib n has no Lucas analogue. The correct law is the odd-quotient rule: for m ≥ 2, Lₘ ∣ Lₙ ⟺ m ∣ n and n/m is odd, verified here on the decisive instances (L₂∣L₆ but L₂∤L₄; L₃∣L₉ but L₃∤L₆). The positive engine is the product identity F_{2n} = Fₙ·Lₙ (from Mathlib's Nat.fib_two_mul via the bridge Lₙ = 2·Fₙ₊₁ − Fₙ), giving Lₙ ∣ F_{2n}: the Lucas numbers sit inside the Fibonacci divisibility lattice exactly at the even indices.",
+  "description": "The parent entry showed the Fibonacci numbers form a strong divisibility sequence — fib (gcd m n) = gcd (fib m) (fib n), and for 3 ≤ m, fib m ∣ fib n ↔ m ∣ n. Its first open question asks for the Lucas-number analogue. This entry settles it with a sharp contrast: the Lucas numbers Lₙ (L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁) are NOT a strong divisibility sequence. Concretely gcd(L₂,L₄)=gcd(3,7)=1 while L_{gcd(2,4)}=L₂=3, so the strong law fails; and 2∣4 yet L₂=3∤7=L₄, so index divisibility does not transfer to value divisibility — the Fibonacci implication m∣n ⇒ fib m ∣ fib n has no Lucas analogue. The correct law is the odd-quotient rule: for m ≥ 2, Lₘ ∣ Lₙ ⟺ m ∣ n and n/m is odd, verified here on the decisive instances (L₂∣L₆ but L₂∤L₄; L₃∣L₉ but L₃∤L₆). The positive engine is the product identity F_{2n} = Fₙ·Lₙ (from Mathlib's Nat.fib_two_mul via the bridge Lₙ = 2·Fₙ₊₁ − Fₙ), giving Lₙ ∣ F_{2n}: the Lucas numbers sit inside the Fibonacci divisibility lattice exactly at the even indices. This session additionally proves the FORWARD DIRECTION of the odd-quotient law in full generality: for all m, n, if m ∣ n and n/m is odd then Lₘ ∣ Lₙ (lucas_dvd_of_odd_quotient), subsuming the concrete instances. The engine is the Lucas shift identity L_{a+1+b} = F_{b+1}·L_{a+1} + F_b·L_a (lucas_add_shift, the Lucas analogue of Nat.fib_add), proved by two-step induction from the Lucas/Fibonacci recurrences with no subtraction and no signs; writing (2k+1)·m = m + 2(km) and using Lₘ ∣ F_{2km} (from Lₘ ∣ F_{2m} ∣ F_{2km}) makes both summands divisible by Lₘ (lucas_dvd_lucas_odd_mul). Only the converse of the biconditional remains open.",
   "meta": {
     "author": "Édouard Lucas / classical Lucas-sequence theory; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number#Divisibility_properties",
@@ -46,13 +46,18 @@
       "fib_two_mul_eq: the product identity F_{2n} = Fₙ·Lₙ, and lucas_dvd_fib_two_mul: Lₙ ∣ F_{2n}",
       "lucas_not_strong_divisibility: the Lucas numbers are NOT a strong divisibility sequence (gcd(L₂,L₄)=1 ≠ 3 = L_{gcd(2,4)})",
       "index_dvd_not_imp_lucas_dvd: m ∣ n does NOT imply Lₘ ∣ Lₙ (2∣4 but L₂=3∤7=L₄) — the Fibonacci transfer law has no Lucas analogue",
-      "odd-quotient characterization verified on decisive instances: L₂∣L₆ vs L₂∤L₄, L₃∣L₉ vs L₃∤L₆"
+      "odd-quotient characterization verified on decisive instances: L₂∣L₆ vs L₂∤L₄, L₃∣L₉ vs L₃∤L₆",
+      "lucas_add_shift: the Lucas shift identity L_{a+1+b} = F_{b+1}·L_{a+1} + F_b·L_a — the Lucas analogue of Nat.fib_add — proved by two-step induction on b from the Lucas and Fibonacci recurrences, subtraction-free and sign-free",
+      "lucas_add_eq: the same identity split as L_{m+b} = F_{b+1}·Lₘ + F_b·L_{m-1} (m ≥ 1), exposing the divisor Lₘ directly",
+      "lucas_dvd_fib_even_mul: Lₘ ∣ F_{2(km)} for all k, from Lₘ ∣ F_{2m} and F_{2m} ∣ F_{2(km)} (Nat.fib_dvd)",
+      "lucas_dvd_lucas_odd_mul: the universal odd-multiple divisibility Lₘ ∣ L_{(2k+1)m} for all m, k",
+      "lucas_dvd_of_odd_quotient: the FORWARD direction of the odd-quotient law in full generality — m ∣ n ∧ Odd (n/m) → Lₘ ∣ Lₙ — proving the '⟸' half of the open biconditional and subsuming the concrete instances L₂ ∣ L₆, L₃ ∣ L₉"
     ],
     "dateAdded": "2026-06-23",
-    "lineCount": 180,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). All concrete instances use decide (kernel evaluation of the structural definitions), not native_decide, so no Lean.ofReduceBool is introduced.",
+    "lineCount": 266,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). All concrete instances use decide (kernel evaluation of the structural definitions), not native_decide, so no Lean.ofReduceBool is introduced. The forward-direction results lucas_add_shift, lucas_add_eq, lucas_dvd_lucas_odd_mul, and lucas_dvd_of_odd_quotient were each #print axioms-checked to depend only on the standard foundational axioms (no sorry, no native_decide); a pre-existing omega atom-unification fragility in two_mul_fib_succ (the IH index fib (n+1+1) vs fib (n+2)) was repaired by restating the induction hypothesis in canonical form.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 2
   },
   "overview": {
@@ -64,7 +69,8 @@
       "**Lucas numbers are NOT strongly divisible.** Unlike Fibonacci, gcd(Lₘ,Lₙ) is generally not a Lucas number: gcd(L₂,L₄)=1 but L_{gcd(2,4)}=3. The headline analogue of the parent's fib_gcd simply fails.",
       "**Index divisibility does not transfer.** The Fibonacci law m∣n ⇒ Fₘ∣Fₙ (Mathlib's Nat.fib_dvd) has no Lucas counterpart: 2∣4 but L₂=3∤7=L₄. This is the decisive structural difference.",
       "**The correct law is the odd-quotient rule.** Lₘ ∣ Lₙ ⟺ m∣n ∧ n/m odd (m ≥ 2). Divisibility detects not just the index ratio but its parity — even quotients break it (L₂∤L₄, L₃∤L₆), odd quotients preserve it (L₂∣L₆, L₃∣L₉).",
-      "**The bridge is the product identity F_{2n} = Fₙ·Lₙ.** It is what places the Lucas numbers inside the Fibonacci divisibility lattice (Lₙ ∣ F_{2n}) and explains the parity obstruction: doubling the index is exactly where Lₙ ∣ F_{2n} holds but Lₙ ∣ L_{2n} fails."
+      "**The bridge is the product identity F_{2n} = Fₙ·Lₙ.** It is what places the Lucas numbers inside the Fibonacci divisibility lattice (Lₙ ∣ F_{2n}) and explains the parity obstruction: doubling the index is exactly where Lₙ ∣ F_{2n} holds but Lₙ ∣ L_{2n} fails.",
+      "The forward direction of the odd-quotient law needs no integer Lucas sequence or signed addition law: the subtraction-free Lucas shift identity L_{a+1+b} = F_{b+1}L_{a+1} + F_b L_a, together with Lₘ ∣ F_{2m} ∣ F_{2km}, gives Lₘ ∣ L_{(2k+1)m} directly over ℕ."
     ],
     "prerequisites": [
       "The Lucas recurrence and the Fibonacci doubling identity Nat.fib_two_mul",
@@ -135,10 +141,10 @@
     }
   ],
   "conclusion": {
-    "summary": "The Lucas numbers are not a strong divisibility sequence: gcd(L₂,L₄)=1 ≠ 3 = L_{gcd(2,4)}, and 2∣4 does not give L₂∣L₄. The Fibonacci transfer law m∣n ⇒ Fₘ∣Fₙ has no Lucas analogue; the correct law is the odd-quotient rule Lₘ∣Lₙ ⟺ m∣n ∧ n/m odd (m ≥ 2), verified on decisive instances. The product identity F_{2n} = Fₙ·Lₙ provides the positive bridge Lₙ ∣ F_{2n}.",
+    "summary": "The Lucas numbers are not a strong divisibility sequence: gcd(L₂,L₄)=1 ≠ 3 = L_{gcd(2,4)}, and 2∣4 does not give L₂∣L₄. The Fibonacci transfer law m∣n ⇒ Fₘ∣Fₙ has no Lucas analogue; the correct law is the odd-quotient rule Lₘ∣Lₙ ⟺ m∣n ∧ n/m odd (m ≥ 2), verified on decisive instances. The product identity F_{2n} = Fₙ·Lₙ provides the positive bridge Lₙ ∣ F_{2n}. The forward direction of the odd-quotient characterization is now proved in full generality (lucas_dvd_of_odd_quotient); the converse remains the sole open part.",
     "implications": "Resolves the parent's first open question in the negative for the strong-divisibility law, supplies the correct characterization, and packages the Lucas–Fibonacci product identity F_{2n} = Fₙ·Lₙ as a fully verified statement with an explicit, decidable Lucas definition (absent from Mathlib).",
     "openQuestions": [
-      "Prove the general odd-quotient biconditional Lₘ ∣ Lₙ ⟺ m∣n ∧ n/m odd (m ≥ 2) as a universally quantified theorem, via the integer Lucas addition law L_{a+2m} = L_{a+m}·Lₘ − (−1)ᵐ·L_a.",
+      "Prove the CONVERSE of the odd-quotient law: Lₘ ∣ Lₙ → m ∣ n ∧ n/m odd (m ≥ 2). The forward direction (m ∣ n ∧ n/m odd → Lₘ ∣ Lₙ) is now established as lucas_dvd_of_odd_quotient; the converse needs the even-quotient non-divisibility, i.e. a parity/2-adic obstruction at the doubling step.",
       "Establish the exact gcd law gcd(Lₘ,Lₙ) = L_{gcd(m,n)} when v₂(m) = v₂(n) and gcd(Lₘ,Lₙ) ∈ {1,2} otherwise.",
       "Extend the characterization to general Lucas sequences Vₙ(P,Q)."
     ]
@@ -148,11 +154,13 @@
       "Mathlib.Data.Nat.Fib.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat"],
+    "opens": [
+      "Nat"
+    ],
     "namespace": "FibonacciIdentitiesOQ02OQ01",
-    "lineCount": 180,
+    "lineCount": 266,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/FibonacciIdentitiesOQ02OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Advances the verified, 0-axiom entry `fibonacci-identities-oq-02-oq-01` (*Lucas Numbers Are Not a Strong Divisibility Sequence*) by proving the **forward direction of the odd-quotient law in full generality** — its first open question previously held only on concrete instances.

The odd-quotient law is `Lₘ ∣ Lₙ ⟺ m ∣ n ∧ Odd(n/m)` (m ≥ 2). This PR settles the `⟸` half universally:

```lean
theorem lucas_dvd_of_odd_quotient {m n : ℕ}
    (hmn : m ∣ n) (hodd : Odd (n / m)) : lucas m ∣ lucas n
```

subsuming the prior witnesses `L₂ ∣ L₆` and `L₃ ∣ L₉`.

## Method

The engine is a new **Lucas shift identity** — the Lucas analogue of `Nat.fib_add`:

```lean
theorem lucas_add_shift (a b : ℕ) :
    lucas (a + 1 + b) = fib (b + 1) * lucas (a + 1) + fib b * lucas a
```

proved by two-step induction from the `Lₙ₊₂ = Lₙ + Lₙ₊₁` and `Fₙ₊₂ = Fₙ + Fₙ₊₁` recurrences — **no integer Lucas sequence, no signed addition law, no subtraction**. Writing an odd multiple as `(2k+1)·m = m + 2(km)` and using `Lₘ ∣ F₂ₘ ∣ F_{2km}` (via `Nat.fib_dvd`) makes both summands divisible by `Lₘ`:

- `lucas_add_eq` — split form `L_{m+b} = F_{b+1}·Lₘ + F_b·L_{m-1}`
- `lucas_dvd_fib_even_mul` — `Lₘ ∣ F_{2(km)}`
- `lucas_dvd_lucas_odd_mul` — `Lₘ ∣ L_{(2k+1)m}` for all `m, k`
- `lucas_dvd_of_odd_quotient` — the forward biconditional half

## Verification

- 5 new theorems, all 0-axiom: `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`; no `sorry`, no `native_decide`.
- Also **repairs a pre-existing build fragility**: `two_mul_fib_succ`'s two-step-induction `more` case fed `omega` an IH with index `fib (n+1+1)` that `omega` no longer unifies with `fib (n+2)`, so the committed file failed to compile standalone against the current Mathlib pin. Fixed by restating the hypothesis in canonical `fib (n+2)` form (defeq). The file now builds clean.
- File: 22 → 27 theorems, 180 → 266 lines. `meta.json` + `knowledge.md` updated.

Only the **converse** (`Lₘ ∣ Lₙ → m∣n ∧ Odd(n/m)`, the even-quotient obstruction) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)