### PR TITLE
Enrich Gauss's prime-power Wilson theorem (wilsons-theorem-oq-05-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-module-overview",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 52 },
+    "type": "context",
+    "title": "Why the field proof stops at primes",
+    "content": "The module docstring frames the obstruction. Mathlib's Wilson theorem, prod_univ_units_id_eq_neg_one, lives on a prime modulus because ℤ/pℤ is a field: pairing each unit with its inverse, the only self-paired survivors are the roots of x²=1, which an integral domain pins to exactly ±1 (Units.inv_eq_self_iff). For a prime power p^k the ring ℤ/p^kℤ has zero divisors, so x²=1 can a priori have more solutions and the field proof collapses. Gauss's resolution is structural: replace 'domain' by 'cyclic unit group'.",
+    "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/p^k\\mathbb{Z})^\\times} x = -1 \\quad (p \\text{ odd prime},\\ k \\geq 1)$",
+    "significance": "context",
+    "relatedConcepts": ["Wilson's theorem", "integral domain", "self-inverse units", "Gauss's generalization"],
+    "prerequisites": ["modular arithmetic", "field theory", "unit groups"]
+  },
+  {
+    "id": "ann-sq-roots-cyclic",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 85 },
+    "type": "technique",
+    "title": "Two roots of unity in a cyclic group",
+    "content": "sq_eq_one_iff_eq_one_or_eq is the cyclic-group replacement for the integral-domain lemma. In a finite cyclic group the solution set of x²=1 has cardinality at most 2 (IsCyclic.card_pow_eq_one_le with n=2). Since {1, t} are two distinct solutions whenever t·t=1 and t≠1, a cardinality squeeze (eq_of_subset_of_card_le) forces the solution set to be exactly {1, t}. Thus any u with u²=1 is 1 or t — no field hypothesis required.",
+    "mathContext": "$\\#\\{a \\in G : a^2 = 1\\} \\leq 2,\\quad \\{1, t\\} \\subseteq \\{a : a^2 = 1\\} \\implies \\{a : a^2 = 1\\} = \\{1, t\\}$",
+    "significance": "key",
+    "relatedConcepts": ["cyclic groups", "roots of unity", "order-two elements", "cardinality argument"],
+    "prerequisites": ["finite cyclic groups", "Lagrange's theorem", "Finset cardinality"]
+  },
+  {
+    "id": "ann-engine-prod-involution",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 87, "endLine": 119 },
+    "type": "insight",
+    "title": "The reusable engine: product of all elements equals the unique involution",
+    "content": "prod_univ_eq_orderTwo is the abstract heart of Wilson's theorem, stripped of any reference to ℤ/nℤ. In a finite cyclic group with t·t=1 and t≠1, the product of all elements is t. The proof applies Finset.prod_involution with the inverse map x↦x⁻¹ on univ.erase t: a fixed point a⁻¹=a means a²=1, so a∈{1,t} by the previous lemma; having erased t, the only surviving fixed point is 1, the pairing annihilates every other element, and re-inserting t (prod_insert) leaves exactly t. This single lemma serves both the prime-power and prime cases below.",
+    "mathContext": "$\\prod_{x \\in G} x = t \\cdot \\prod_{x \\in G \\setminus \\{t\\}} x = t \\cdot 1 = t,\\quad \\text{where } x \\mapsto x^{-1} \\text{ pairs } G \\setminus \\{t\\}$",
+    "significance": "key",
+    "relatedConcepts": ["involution pairing", "Finset.prod_involution", "abelian group products", "unique element of order two"],
+    "prerequisites": ["involutions", "products over finite groups", "inverse-pairing argument"]
+  },
+  {
+    "id": "ann-neg-one-ne-one",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 135 },
+    "type": "technique",
+    "title": "−1 ≠ 1 in the units, via 2 < m",
+    "content": "neg_one_ne_one_units supplies the 'nontrivial square root' hypothesis the engine demands. If −1 = 1 as units of ℤ/mℤ, then 2 = 0 in the ring, so m ∣ 2 (ZMod.natCast_eq_zero_iff), forcing m ≤ 2 and contradicting 2 < m. For an odd prime power m = p^k ≥ 3 this always holds, which is exactly why Gauss's classification needs p odd: at p=2 one has p^k ∈ {2,4,...} where the order-two structure differs.",
+    "mathContext": "$-1 = 1 \\text{ in } (\\mathbb{Z}/m\\mathbb{Z})^\\times \\implies 2 \\equiv 0 \\pmod{m} \\implies m \\mid 2 \\implies m \\leq 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod divisibility", "characteristic", "order-two unit"],
+    "prerequisites": ["ZMod casts", "divisibility"]
+  },
+  {
+    "id": "ann-gauss-prime-power",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 139, "endLine": 155 },
+    "type": "concept",
+    "title": "Gauss's prime-power Wilson theorem",
+    "content": "gauss_prime_pow_units is the headline result: for odd prime p and k≥1, the units of ℤ/p^kℤ multiply to −1. It is assembled from two inputs to the engine — cyclicity of the unit group (ZMod.isCyclic_units_of_prime_pow, Gauss's primitive-root theorem) and t = −1 being a nontrivial involution (since 2 < p^k via Nat.le_self_pow). gauss_prime_pow_cast pushes the identity through the coercion Units.coeHom into the ring ℤ/p^kℤ, giving the classical congruence ∏_{gcd(a,p^k)=1} a ≡ −1 (mod p^k).",
+    "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/p^k\\mathbb{Z})^\\times} x = -1 \\iff \\prod_{\\substack{1 \\leq a < p^k \\\\ \\gcd(a, p^k) = 1}} a \\equiv -1 \\pmod{p^k}$",
+    "significance": "key",
+    "relatedConcepts": ["primitive root theorem", "cyclic unit group", "Wilson congruence", "Units.coeHom"],
+    "prerequisites": ["Gauss's primitive-root theorem", "unit groups of ℤ/nℤ", "group homomorphisms"]
+  },
+  {
+    "id": "ann-prime-slice",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 157, "endLine": 164 },
+    "type": "insight",
+    "title": "The k = 1 slice recovers classical Wilson",
+    "content": "wilson_units_prime runs the very same engine on the field ℤ/pℤ — whose unit group is cyclic by the finite-field instance — to obtain ∏_{x∈(ℤ/pℤ)ˣ} x = −1, i.e. (p−1)! ≡ −1 (mod p). This demonstrates that the prime-power theorem genuinely contains Wilson's theorem as its k=1 case rather than sitting beside it: the classical result and its prime-power generalisation share one proof, parameterised only by where cyclicity comes from.",
+    "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times} x = (p-1)! \\equiv -1 \\pmod{p}$",
+    "significance": "key",
+    "relatedConcepts": ["classical Wilson's theorem", "finite fields", "factorial congruence", "specialization"],
+    "prerequisites": ["Wilson's theorem", "finite field unit groups"]
+  },
+  {
+    "id": "ann-zmod-nine",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-02",
+    "range": { "startLine": 166, "endLine": 174 },
+    "type": "context",
+    "title": "Concrete check: the six units of ℤ/9ℤ",
+    "content": "prod_units_zmod_nine instantiates p=3, k=2. The units of ℤ/9ℤ are {1,2,4,5,7,8}, and 1·2·4·5·7·8 = 2240 ≡ 8 ≡ −1 (mod 9). Crucially this is derived from gauss_prime_pow_cast, not by decide or native_decide — so the example carries no Lean.ofReduceBool dependency and the whole file remains a genuine 0-axiom proof. It is a sanity check that the general theorem produces the right concrete number.",
+    "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/9\\mathbb{Z})^\\times} x = 1 \\cdot 2 \\cdot 4 \\cdot 5 \\cdot 7 \\cdot 8 = 2240 \\equiv 8 \\equiv -1 \\pmod 9$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "axiom-free computation", "ℤ/9ℤ units"],
+    "prerequisites": ["modular arithmetic"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheoremOQ05OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOq05Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOq05Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOq05Oq01Oq02Data: ProofData = {
+  proof: wilsonsTheoremOq05Oq01Oq02Proof,
+  annotations: wilsonsTheoremOq05Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01-oq-02`.

The entry had a rich meta.json but was missing **annotations.json** and **index.ts** — without index.ts the proof page renders "proof not found" on the live site.

## Changes
- **Added `index.ts`** — Vite entry point so `import.meta.glob` discovers the proof.
- **Added `annotations.json`** — 7 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Module overview — why the field proof (Units.inv_eq_self_iff) stops at primes
  2. `sq_eq_one_iff_eq_one_or_eq` — the two-roots-of-unity cyclic lemma
  3. `prod_univ_eq_orderTwo` — the reusable engine (product of all elements = unique involution)
  4. `neg_one_ne_one_units` — −1 ≠ 1 via 2 < m
  5. `gauss_prime_pow_units`/`_cast` — the headline prime-power Wilson theorem
  6. `wilson_units_prime` — the k=1 slice recovering classical Wilson
  7. `prod_units_zmod_nine` — the axiom-free ℤ/9ℤ concrete check

Axiom integrity unchanged: status `verified`, 0 axioms, 0 sorries — confirmed against the Lean source (no decide/native_decide; the ℤ/9ℤ example is derived from the general theorem).