### PR TITLE
research(automorphic-number-oq-01-oq-03-oq-01): automorphic idempotent tower over an arbitrary base [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -235,6 +235,7 @@ import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02
 import Proofs.AutomorphicNumberOQ01OQ03
+import Proofs.AutomorphicNumberOQ01OQ03OQ01
 import Proofs.BaireCategoryTheoremOQ01
 import Proofs.BaireCategoryTheoremOQ01OQ01
 import Proofs.BallotProblem

--- a/proofs/Proofs/AutomorphicNumberOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ03OQ01.lean
@@ -1,0 +1,197 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+import Proofs.AutomorphicNumberOQ01OQ01
+import Proofs.AutomorphicNumberOQ01OQ02
+import Proofs.AutomorphicNumberOQ01OQ03
+
+/-!
+# The automorphic idempotent tower over an arbitrary base
+
+## What This Proves
+
+The parent file `AutomorphicNumberOQ01OQ03` establishes, for the *concrete* base `10`, that
+the idempotents of `ZMod (10 ^ k)` — the `k`-digit automorphic residues — form a coherent
+**tower**: the digit-dropping reduction `ZMod (10 ^ (k+1)) →+* ZMod (10 ^ k)` is a bijection
+between the two four-element idempotent sets, so every `k`-digit automorphic number extends
+uniquely to a `(k+1)`-digit one (`5 → 25 → 625 → …`).  Sibling `…OQ01OQ01` proves the count
+is `2 ^ ω(n)` for *every* modulus `n`.
+
+This file removes the special role of `10`: it proves the same tower structure over an
+**arbitrary base** `m`.  Write `red m k : ZMod (m ^ (k+1)) →+* ZMod (m ^ k)` for the
+canonical reduction.  The results, all uniform in `m`:
+
+* **`idem_card`** — for `k ≥ 1` the modulus `m ^ k` has exactly `2 ^ ω(m)` idempotents.
+  (The exponent is `ω(m)`, *not* `ω(m ^ k)`: a prime power has the same prime support as its
+  base, `Nat.primeFactors_pow`.  This is what makes every level of the tower have the *same*
+  number of idempotents, the combinatorial reason a bijection can exist.)
+* **`ker_red_nilpotent`** — the kernel of `red m k` is a nil ideal: any `x` with
+  `red m k x = 0` is a multiple of `m ^ k`, hence `x ^ 2 = 0` in `ZMod (m ^ (k+1))` because
+  `m ^ (k+1) ∣ (m ^ k) ^ 2 = m ^ (2k)` once `k ≥ 1` — independent of `m`.
+* **`red_injOn_idem`** — `red m k` is therefore injective on idempotents (two idempotents
+  with equal reduction differ by a nilpotent, so coincide: `idem_eq_of_sub_nilpotent`).
+* **`red_image_idem`** — injectivity together with the *equal* cardinality `2 ^ ω(m)` at
+  both levels forces the image to be the whole lower idempotent set: `red m k` is a
+  **bijection** on idempotents.
+* **`unique_digit_extension`** (main theorem) — consequently every `k`-digit automorphic
+  residue mod `m ^ k` lifts to a **unique** `(k+1)`-digit one mod `m ^ (k+1)`.  Thus for
+  *every* base `m ≥ 1` the automorphic residues organize into `2 ^ ω(m)` coherent threads
+  converging to the `2 ^ ω(m)` idempotents of the `m`-adic integers
+  `ℤ_m ≅ ∏_{p ∣ m} ℤ_p`.
+
+The base-`10` parent is the case `ω(10) = 2`, giving `2 ^ 2 = 4` threads.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms, no `native_decide`.  Reuses the
+ring-generic lemmas `AutomorphicNumberOQ01OQ02.idem_eq_of_sub_nilpotent` and
+`AutomorphicNumberOQ01OQ03.map_idem`, and the general count
+`AutomorphicNumberOQ01OQ01.idempotent_count`.
+-/
+
+namespace AutomorphicNumberOQ01OQ03OQ01
+
+open Finset
+
+/-! ## The digit-dropping reduction homomorphism over base `m` -/
+
+/-- The canonical reduction `ZMod (m ^ (k+1)) →+* ZMod (m ^ k)` — "drop the leading
+base-`m` digit".  It sends a residue mod `m ^ (k+1)` to its class mod `m ^ k`. -/
+def red (m k : ℕ) : ZMod (m ^ (k + 1)) →+* ZMod (m ^ k) :=
+  ZMod.castHom (pow_dvd_pow m (Nat.le_succ k)) (ZMod (m ^ k))
+
+/-! ## Every level of the tower has the same idempotent count `2 ^ ω(m)` -/
+
+/-- **The level count.**  For `k ≥ 1` the ring `ZMod (m ^ k)` has exactly `2 ^ ω(m)`
+idempotents.  This is the general count `idempotent_count` specialized to `n = m ^ k`,
+together with `ω(m ^ k) = ω(m)` (`Nat.primeFactors_pow`). -/
+theorem idem_card {m : ℕ} [NeZero m] (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (m ^ k) => e * e = e)).card = 2 ^ m.primeFactors.card := by
+  have hm : 0 < m := Nat.pos_of_ne_zero (NeZero.ne m)
+  rw [← Fintype.card_subtype (fun e : ZMod (m ^ k) => e * e = e),
+      ← Nat.card_eq_fintype_card,
+      AutomorphicNumberOQ01OQ01.idempotent_count _ (pow_pos hm k),
+      Nat.primeFactors_pow m hk.ne']
+
+/-! ## The kernel of `red` is a nil ideal -/
+
+/-- **The kernel of `red m k` is nilpotent.**  If `red m k x = 0` then `x` is a multiple of
+`m ^ k`, and since `(m ^ k) ^ 2 = m ^ (2k) = 0` in `ZMod (m ^ (k+1))` (for `k ≥ 1`),
+already `x ^ 2 = 0`.  This is the structural fact that makes idempotent lifting unique. -/
+theorem ker_red_nilpotent {m : ℕ} [NeZero m] (k : ℕ) (hk : 0 < k)
+    {x : ZMod (m ^ (k + 1))} (hx : red m k x = 0) : IsNilpotent x := by
+  -- Lift `x` to a natural number `c`.
+  obtain ⟨c, rfl⟩ := (ZMod.natCast_rightInverse (n := m ^ (k + 1))).surjective x
+  -- `red` commutes with `Nat.cast`, so the hypothesis says `m ^ k ∣ c`.
+  rw [red, map_natCast, ZMod.natCast_eq_zero_iff] at hx
+  obtain ⟨t, rfl⟩ := hx
+  -- `x ^ 2 = (m ^ k * t) ^ 2 = 0` because `m ^ (k+1) ∣ (m ^ k * t) ^ 2`.
+  refine ⟨2, ?_⟩
+  rw [show (((m ^ k * t : ℕ)) : ZMod (m ^ (k + 1))) ^ 2
+        = ((m ^ k * t) ^ 2 : ℕ) from by push_cast; ring]
+  rw [ZMod.natCast_eq_zero_iff]
+  have hle : k + 1 ≤ 2 * k := by omega
+  refine dvd_trans (pow_dvd_pow m hle) ⟨t ^ 2, ?_⟩
+  rw [mul_pow, ← pow_mul, Nat.mul_comm k 2]
+
+/-! ## Reduction is a bijection on idempotents -/
+
+/-- **`red m k` is injective on idempotents.**  Two idempotents with the same reduction
+differ by a nilpotent (their difference lies in the nil kernel), hence are equal. -/
+theorem red_injOn_idem {m : ℕ} [NeZero m] (k : ℕ) (hk : 0 < k)
+    {e f : ZMod (m ^ (k + 1))} (he : e * e = e) (hf : f * f = f)
+    (h : red m k e = red m k f) : e = f := by
+  have hker : red m k (e - f) = 0 := by rw [map_sub, h, sub_self]
+  exact AutomorphicNumberOQ01OQ02.idem_eq_of_sub_nilpotent he hf
+    (ker_red_nilpotent k hk hker)
+
+/-- **`red m k` is a bijection on idempotents.**  The image under `red m k` of the
+`(k+1)`-digit automorphic residues is *exactly* the `k`-digit ones.  Injectivity
+(`red_injOn_idem`) plus equal cardinality (`idem_card`, both `2 ^ ω(m)`) forces the image to
+fill the whole target set. -/
+theorem red_image_idem {m : ℕ} [NeZero m] (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (m ^ (k + 1)) => e * e = e)).image (red m k)
+      = univ.filter (fun e : ZMod (m ^ k) => e * e = e) := by
+  apply Finset.eq_of_subset_of_card_le
+  · -- image lands inside the lower idempotent set
+    intro y hy
+    rw [Finset.mem_image] at hy
+    obtain ⟨e, he, rfl⟩ := hy
+    rw [mem_filter] at he ⊢
+    exact ⟨mem_univ _, AutomorphicNumberOQ01OQ03.map_idem (red m k) he.2⟩
+  · -- lower set (card `2 ^ ω(m)`) is no bigger than the image (same card, by injectivity)
+    have hinj : Set.InjOn (red m k)
+        (univ.filter (fun e : ZMod (m ^ (k + 1)) => e * e = e) : Finset _) := by
+      intro e he f hf h
+      simp only [Finset.coe_filter, mem_univ, true_and, Set.mem_setOf_eq] at he hf
+      exact red_injOn_idem k hk he hf h
+    rw [Finset.card_image_of_injOn hinj,
+        idem_card k hk, idem_card (k + 1) (by omega)]
+
+/-! ## Main theorem: unique digit-by-digit extension over base `m` -/
+
+/-- **Main theorem — unique digit extension.**  Every `k`-digit automorphic residue `ē`
+(idempotent of `ZMod (m ^ k)`) is the reduction of a **unique** `(k+1)`-digit automorphic
+residue `e` (idempotent of `ZMod (m ^ (k+1))`).  Thus, for every base `m ≥ 1`, the
+automorphic residues form `2 ^ ω(m)` coherent towers converging to the `2 ^ ω(m)`
+idempotents of the `m`-adic integers. -/
+theorem unique_digit_extension {m : ℕ} [NeZero m] (k : ℕ) (hk : 0 < k)
+    {ē : ZMod (m ^ k)} (hē : ē * ē = ē) :
+    ∃! e : ZMod (m ^ (k + 1)), e * e = e ∧ red m k e = ē := by
+  -- `ē` lies in the lower idempotent set, hence in the image of the reduction.
+  have hmem : ē ∈ univ.filter (fun e : ZMod (m ^ k) => e * e = e) := by
+    rw [mem_filter]; exact ⟨mem_univ _, hē⟩
+  rw [← red_image_idem k hk, Finset.mem_image] at hmem
+  obtain ⟨e, he, hred⟩ := hmem
+  rw [mem_filter] at he
+  refine ⟨e, ⟨he.2, hred⟩, ?_⟩
+  rintro e' ⟨he', hred'⟩
+  exact red_injOn_idem k hk he' he.2 (by rw [hred', hred])
+
+/-! ## Concrete bases beyond `10`
+
+The structure is genuinely base-independent.  We read off the number of coherent towers for
+several bases directly from `idem_card` (the count is `2 ^ ω(m)`, with `ω` the number of
+distinct prime divisors): squarefree or prime-power, only the *prime support* matters. -/
+
+/-- Base `6 = 2·3` has `ω = 2`, so `4` automorphic towers — like base `10`. -/
+theorem towers_base_six (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (6 ^ k) => e * e = e)).card = 4 := by
+  rw [idem_card (m := 6) k hk,
+      show (6 : ℕ) = 2 * 3 from rfl,
+      Nat.primeFactors_mul (by norm_num) (by norm_num),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 2),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 3)]
+  decide
+
+/-- Base `12 = 2²·3` has the same prime support `{2, 3}`, so also `4` towers — the extra
+factor of `2` does **not** add a tower. -/
+theorem towers_base_twelve (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (12 ^ k) => e * e = e)).card = 4 := by
+  rw [idem_card (m := 12) k hk,
+      show (12 : ℕ) = 2 ^ 2 * 3 from rfl,
+      Nat.primeFactors_mul (by norm_num) (by norm_num),
+      Nat.primeFactors_prime_pow (by norm_num) (by norm_num : Nat.Prime 2),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 3)]
+  decide
+
+/-- Base `30 = 2·3·5` has `ω = 3`, so `8` automorphic towers. -/
+theorem towers_base_thirty (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (30 ^ k) => e * e = e)).card = 8 := by
+  rw [idem_card (m := 30) k hk,
+      show (30 : ℕ) = 2 * (3 * 5) from rfl,
+      Nat.primeFactors_mul (by norm_num) (by norm_num),
+      Nat.primeFactors_mul (by norm_num) (by norm_num),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 2),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 3),
+      Nat.Prime.primeFactors (by norm_num : Nat.Prime 5)]
+  decide
+
+/-- A prime base `m = 7` has a *single* nontrivial structure: `ω(7) = 1`, so only
+`2 ^ 1 = 2` idempotents (`0` and `1`) at every level — no nontrivial automorphic numbers,
+matching the fact that `ZMod (7 ^ k)` is local. -/
+theorem towers_base_prime {p : ℕ} [NeZero p] (hp : p.Prime) (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (p ^ k) => e * e = e)).card = 2 := by
+  rw [idem_card (m := p) k hk, hp.primeFactors]
+  simp
+
+end AutomorphicNumberOQ01OQ03OQ01

--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-autonum-oq01oq03oq01-context",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 53
+    },
+    "type": "concept",
+    "title": "Removing the special role of 10: the automorphic tower over an arbitrary base",
+    "content": "The parent entry proves, only for base 10, that the digit-dropping reduction red k : ZMod (10^(k+1)) → ZMod (10^k) is a bijection between the four-element idempotent sets, so each automorphic residue lifts uniquely by one digit. Its first open question asks whether this is special to 10. This file answers no: write red m k for the reduction over an ARBITRARY base m. The same two facts that drove base 10 — a nil reduction kernel, and equal idempotent counts at consecutive levels — both hold for every m, so the bijection and the unique digit-extension generalize verbatim. The only new ingredient is the level count, now 2^ω(m) (with ω the number of distinct prime factors), reused from the sibling general-count entry.",
+    "mathContext": "For any base $m=\\prod p_i^{a_i}$, the CRT splitting $\\mathbb{Z}/m^k \\cong \\prod_i \\mathbb{Z}/p_i^{a_i k}$ makes $\\mathbb{Z}/m^k$ a product of $\\omega(m)$ local rings, hence $2^{\\omega(m)}$ idempotents at every level $k\\ge 1$. The inverse limit is the $m$-adic ring $\\mathbb{Z}_m\\cong\\prod_{p\\mid m}\\mathbb{Z}_p$, with the same $2^{\\omega(m)}$ idempotents.",
+    "significance": "context",
+    "relatedConcepts": ["idempotent", "inverse limit", "p-adic integers", "automorphic number", "Chinese remainder theorem", "prime factorization"],
+    "prerequisites": ["modular arithmetic", "idempotents of a ring", "p-adic integers", "distinct prime factors ω(n)"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-reduction",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "The reduction homomorphism over base m",
+    "content": "red m k := ZMod.castHom (m^k ∣ m^(k+1)) (ZMod (m^k)) is the canonical 'drop the leading base-m digit' map ZMod (m^(k+1)) →+* ZMod (m^k). The only general fact needed about it — that any ring homomorphism sends idempotents to idempotents (f e · f e = f(e·e) = f e) — is the parent's reusable lemma map_idem, so red m k carries the (k+1)-digit automorphic residues into the k-digit ones. This is the MapsTo half of the eventual bijection, before injectivity and cardinality finish the job.",
+    "mathContext": "The maps $\\mathbb{Z}/m^{k+1}\\to\\mathbb{Z}/m^{k}$ are the transition maps of the inverse system $\\{\\mathbb{Z}/m^k\\}_k$; idempotency is preserved along every one of them, for every base $m$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring homomorphism", "ZMod.castHom", "idempotent", "MapsTo"],
+    "prerequisites": ["ring homomorphisms", "quotient rings ZMod"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-levelcount",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Every level has 2^ω(m) idempotents — and ω(m^k) = ω(m)",
+    "content": "idem_card establishes the count that makes a level-to-level bijection possible. The Finset count (univ.filter idempotent).card is first rewritten as a Nat.card subtype (Fintype.card_subtype, then Nat.card_eq_fintype_card), so the sibling's general result idempotent_count applies at n = m^k, giving 2^(m^k).primeFactors.card. The decisive step is Nat.primeFactors_pow: a prime power has the SAME set of prime divisors as its base, so ω(m^k) = ω(m). Hence both level k and level k+1 carry exactly 2^ω(m) idempotents — the count is constant up the tower, which is precisely the condition a bijection requires.",
+    "mathContext": "$\\omega(m^k)=\\omega(m)$ for $k\\ge 1$ because $(m^k).\\mathrm{primeFactors}=m.\\mathrm{primeFactors}$. The exponent in $2^{\\omega(m)}$ is the prime support of the base, never of $m^k$ — repeated prime factors and higher powers are invisible to the count.",
+    "significance": "critical",
+    "relatedConcepts": ["distinct prime factors", "Nat.primeFactors_pow", "Fintype.card_subtype", "idempotent count", "CRT"],
+    "prerequisites": ["prime factorization", "cardinality of finite subtypes", "the count 2^ω(n) of idempotents"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-nilkernel",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 94
+    },
+    "type": "technique",
+    "title": "The kernel of reduction is nil, uniformly in m: (m^k)² = 0 in ZMod (m^(k+1))",
+    "content": "ker_red_nilpotent shows the kernel of red m k is a nil ideal, independent of the base. A kernel element x is lifted to a natural number c (ZMod.natCast_rightInverse); red m k (↑c) = 0 means m^k ∣ c (ZMod.natCast_eq_zero_iff), so c = m^k·t and x² = (m^k·t)² is a multiple of m^(2k). Because k+1 ≤ 2k for k ≥ 1, m^(k+1) ∣ m^(2k), so x² = 0 in ZMod (m^(k+1)). The vanishing depends only on the exponent inequality k+1 ≤ 2k, not on m.",
+    "mathContext": "The kernel of $\\mathbb{Z}/m^{k+1}\\to\\mathbb{Z}/m^{k}$ is the ideal $(m^k)$, and $(m^k)^2=m^{2k}\\equiv 0 \\pmod{m^{k+1}}$ for $k\\ge 1$. A surjection of rings with nil kernel lifts idempotents uniquely — the finite shadow of Hensel's lemma.",
+    "significance": "critical",
+    "relatedConcepts": ["nil ideal", "nilpotent", "IsNilpotent", "kernel of reduction", "Hensel's lemma"],
+    "prerequisites": ["ideals and kernels", "nilpotent elements", "divisibility of powers"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-bijection",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 96,
+      "endLine": 128
+    },
+    "type": "technique",
+    "title": "Injective + equal count = bijective on idempotents",
+    "content": "red_injOn_idem: two idempotents e,f with red m k e = red m k f satisfy red m k (e−f) = 0, so e−f lies in the nil kernel and is nilpotent; the parent's idem_eq_of_sub_nilpotent forces e = f. red_image_idem: the injective image of the (k+1)-level idempotents is contained in the k-level idempotents (map_idem) and, by idem_card, both sets have the same size 2^ω(m); Finset.card_image_of_injOn and Finset.eq_of_subset_of_card_le then upgrade the inclusion to equality. So red m k is a bijection between the idempotent sets of consecutive levels.",
+    "mathContext": "An injective map between finite sets of equal cardinality is a bijection. Injectivity comes from the nil kernel; equal cardinality $2^{\\omega(m)}$ comes from the constant level count. No explicit lifting formula is needed.",
+    "significance": "major",
+    "relatedConcepts": ["injective on a set", "Finset.eq_of_subset_of_card_le", "Finset.card_image_of_injOn", "bijection", "idempotent lifting"],
+    "prerequisites": ["finite cardinality arguments", "images of finite sets", "idem_eq_of_sub_nilpotent"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-unique",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 130,
+      "endLine": 148
+    },
+    "type": "key-step",
+    "title": "Main theorem: unique digit extension over every base",
+    "content": "unique_digit_extension: an idempotent ē of ZMod (m^k) lies in the lower idempotent set, which by red_image_idem equals the image of the reduction; so a lift e with red m k e = ē and e·e=e exists. Uniqueness is immediate from red_injOn_idem: any two lifts have the same reduction ē, hence coincide. This is the ∃! statement that makes each automorphic residue grow by exactly one digit, now for every base m ≥ 1 — the affirmative answer to the parent's first open question.",
+    "mathContext": "$\\exists!\\, e,\\ e\\cdot e=e \\wedge \\mathrm{red}\\,m\\,k\\,e=\\bar e$ for every idempotent $\\bar e$. The $2^{\\omega(m)}$ towers are the coherent threads converging to the $2^{\\omega(m)}$ idempotents of $\\mathbb{Z}_m\\cong\\prod_{p\\mid m}\\mathbb{Z}_p$.",
+    "significance": "critical",
+    "relatedConcepts": ["unique existence", "idempotent lifting", "inverse limit", "m-adic integers", "automorphic tower"],
+    "prerequisites": ["existential uniqueness ∃!", "bijections of idempotent sets"]
+  },
+  {
+    "id": "ann-autonum-oq01oq03oq01-concrete",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 197
+    },
+    "type": "concept",
+    "title": "Concrete bases: 6 and 12 give four towers, 30 gives eight, primes give two",
+    "content": "Four corollaries read the number of towers off idem_card via primeFactors computations. towers_base_six: 6 = 2·3 has ω = 2, so 2² = 4 towers — like base 10. towers_base_twelve: 12 = 2²·3 has the SAME prime support {2,3}, so also 4 — the repeated factor of 2 adds no tower (Nat.primeFactors_prime_pow). towers_base_thirty: 30 = 2·3·5 has ω = 3, so 2³ = 8. towers_base_prime: a prime base p has ω = 1, so only 2 idempotents (0 and 1) at every level, matching the fact that ZMod (p^k) is local with no nontrivial automorphic numbers.",
+    "mathContext": "The number of automorphic threads over base $m$ is $2^{\\omega(m)}$, depending only on the set of primes dividing $m$. Squarefree or not, only the support matters: bases $6,10,12$ all give four, base $30$ gives eight, prime powers give two.",
+    "significance": "supporting",
+    "relatedConcepts": ["distinct prime factors", "Nat.primeFactors_mul", "Nat.primeFactors_prime_pow", "local ring", "squarefree support"],
+    "prerequisites": ["prime factorization", "computing primeFactors of small numbers"]
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AutomorphicNumberOQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const automorphicNumberOQ01OQ03OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const automorphicNumberOQ01OQ03OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const automorphicNumberOQ01OQ03OQ01Data: ProofData = {
+  proof: automorphicNumberOQ01OQ03OQ01Proof,
+  annotations: automorphicNumberOQ01OQ03OQ01Annotations,
+}

--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,233 @@
+{
+  "id": "automorphic-number-oq-01-oq-03-oq-01",
+  "slug": "automorphic-number-oq-01-oq-03-oq-01",
+  "title": "The Automorphic Idempotent Tower Over an Arbitrary Base",
+  "description": "The parent entry proves, for the concrete base 10, that the digit-dropping reduction red k : ZMod (10^(k+1)) →+* ZMod (10^k) restricts to a bijection between the two four-element idempotent sets, so every k-digit automorphic residue n²≡n (mod 10^k) extends uniquely to a (k+1)-digit one (5→25→625→…, 6→76→376→…). Its first stated open question asks whether the same nil-kernel argument works for an ARBITRARY modulus m, giving a bijection between the 2^ω(m) idempotent sets of ZMod (m^(k+1)) and ZMod (m^k). This entry answers it affirmatively and uniformly in m. Write red m k : ZMod (m^(k+1)) →+* ZMod (m^k) for the reduction. (1) idem_card: for k ≥ 1 the modulus m^k has exactly 2^ω(m) idempotents — the general count 2^ω(n) of the sibling entry specialized to n = m^k, together with ω(m^k) = ω(m) (a prime power has the same prime support as its base, Nat.primeFactors_pow). The exponent is ω(m), NOT ω(m^k): this is precisely why every level of the tower carries the SAME number of idempotents, the combinatorial reason a bijection can exist. (2) ker_red_nilpotent: the kernel of red m k is nil — any x with red m k x = 0 is a multiple of m^k, hence x² is a multiple of m^(2k) = 0 in ZMod (m^(k+1)) because k+1 ≤ 2k for k ≥ 1, independent of m. (3) red_injOn_idem: therefore red m k is injective on idempotents (idempotents with nilpotent difference coincide, reusing the parent's idem_eq_of_sub_nilpotent). (4) red_image_idem: injectivity plus equal cardinality 2^ω(m) at both levels forces red m k to be a bijection on idempotents. (5) unique_digit_extension (main theorem): every k-digit automorphic residue mod m^k lifts to a UNIQUE (k+1)-digit one mod m^(k+1). Thus for every base m ≥ 1 the automorphic residues organize into 2^ω(m) coherent threads converging to the 2^ω(m) idempotents of the m-adic integers ℤ_m ≅ ∏_{p∣m} ℤ_p. The base-10 parent is the case ω(10) = 2. Concrete level counts are read off for bases 6 (=2·3, four towers), 12 (=2²·3, still four — the repeated prime adds none), 30 (=2·3·5, eight) and any prime (two).",
+  "meta": {
+    "author": "Lean Genius Researcher-7",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "nilpotent",
+      "idempotent-lifting",
+      "ring-homomorphism",
+      "inverse-limit",
+      "p-adic",
+      "crt",
+      "prime-factors"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 197,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The only `decide` calls evaluate concrete finite prime-support cardinalities in the base-6/12/30 corollaries; they sit inside named theorems but decide closed Boolean/numeric facts (e.g. ({2,3} : Finset ℕ).card = 2) and introduce no nonstandard axiom. #print axioms confirms every named result (unique_digit_extension, red_image_idem, red_injOn_idem, ker_red_nilpotent, idem_card, towers_base_thirty) depends only on the standard foundational axioms propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no sorryAx. Builds on the verified parent entries AutomorphicNumberOQ01OQ01.lean (reusing idempotent_count, the general count = 2^ω(n)), AutomorphicNumberOQ01OQ02.lean (reusing idem_eq_of_sub_nilpotent, uniqueness of idempotent lifts modulo a nil ideal), and AutomorphicNumberOQ01OQ03.lean (reusing map_idem, that ring maps preserve idempotents).",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.castHom",
+        "description": "The canonical ring homomorphism ZMod n →+* R for m ∣ n; instantiated it is the digit-dropping reduction red m k : ZMod (m^(k+1)) →+* ZMod (m^k) over an arbitrary base m",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.primeFactors_pow",
+        "description": "(n^k).primeFactors = n.primeFactors for k ≠ 0; the engine of idem_card — a prime power has the same prime support as its base, so ω(m^k) = ω(m) and every level of the tower has the same idempotent count 2^ω(m)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod b) = 0 ↔ b ∣ a; converts red m k (↑c) = 0 into the divisibility m^k ∣ c that exhibits a kernel element as a multiple of m^k",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_rightInverse",
+        "description": "Nat.cast is a right inverse of ZMod.val, hence surjective; used to lift a kernel element of ZMod (m^(k+1)) to a natural number",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Fintype.card_subtype",
+        "description": "Fintype.card {x // p x} = (univ.filter p).card; bridges the Finset-card form of idem_card to the Nat.card subtype form of the imported general count",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "An injective-on map preserves cardinality of the image; with the equal count 2^ω(m) on both sides it forces red m k's image of the idempotents to be the whole lower idempotent set",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.eq_of_subset_of_card_le",
+        "description": "s ⊆ t and t.card ≤ s.card give s = t; promotes image ⊆ lower idempotent set (equal card 2^ω(m)) to set equality, i.e. surjectivity of the reduction on idempotents",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01OQ01.idempotent_count",
+        "description": "The verified sibling result that ZMod n has exactly 2^ω(n) idempotents for n ≥ 1; specialized at n = m^k it supplies the equal-cardinality input at every level of the tower",
+        "module": "Proofs.AutomorphicNumberOQ01OQ01"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01OQ02.idem_eq_of_sub_nilpotent",
+        "description": "Uniqueness of idempotent lifts modulo a nil ideal (idempotents with nilpotent difference coincide); applied to the nil kernel of red m k it yields injectivity on idempotents",
+        "module": "Proofs.AutomorphicNumberOQ01OQ02"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01OQ03.map_idem",
+        "description": "Any ring homomorphism between commutative rings preserves idempotency; reused so red m k maps automorphic residues to automorphic residues (the MapsTo half of the bijection)",
+        "module": "Proofs.AutomorphicNumberOQ01OQ03"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01",
+      "Proofs.AutomorphicNumberOQ01OQ01",
+      "Proofs.AutomorphicNumberOQ01OQ02",
+      "Proofs.AutomorphicNumberOQ01OQ03"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ03OQ01",
+    "lineCount": 197,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "Automorphic numbers — integers whose square ends in the same digits (5²=25, 6²=36, 25²=625, 76²=5776) — are recreational in base 10, but their meaning is purely ring-theoretic: a k-digit automorphic residue mod m^k is an idempotent of ZMod (m^k), since n²≡n (mod m^k) ⟺ e·e=e. The parent entry treats the single base 10, where 10 = 2·5 gives ZMod (10^k) ≅ ZMod (2^k) × ZMod (5^k) (CRT) and exactly four idempotents at every level, the two nontrivial ones being the …5 and …6 towers, converging in the inverse limit to the four idempotents of ℤ₁₀ ≅ ℤ₂ × ℤ₅. Nothing about that argument is special to 10. For an arbitrary base m = ∏ p_i^{a_i}, the ring ZMod (m^k) ≅ ∏ ZMod (p_i^{ak_i}) is a product of ω(m) local rings, so it has 2^ω(m) idempotents at every level k ≥ 1 — the prime support, not the exponents, controls the count. This entry isolates that base-independence: the unique lifting of idempotents along a reduction with nil kernel is the elementary finite shadow of Hensel's lemma and of idempotent-lifting modulo the Jacobson radical, here realized for every base at once.",
+    "problemStatement": "The parent entry proves, only for base 10, that reduction ZMod (10^(k+1)) → ZMod (10^k) is a bijection on the four-element idempotent sets, so each automorphic residue lifts uniquely by one digit. Its first open question asks whether this is a feature of 10 or of the construction: for an arbitrary base m with ω(m) distinct prime factors, is the digit-dropping reduction red m k : ZMod (m^(k+1)) →+* ZMod (m^k) a bijection between the 2^ω(m) idempotents at consecutive levels, so that every k-digit automorphic residue ē has exactly one (k+1)-digit residue e reducing to it? We prove ∃! e, e·e=e ∧ red m k e = ē for every base m ≥ 1, every idempotent ē of ZMod (m^k), and every k ≥ 1.",
+    "proofStrategy": "1. idem_card: rewrite the Finset count (univ.filter idempotent).card as a Nat.card subtype (Fintype.card_subtype, Nat.card_eq_fintype_card), apply the sibling's general count idempotent_count giving 2^(m^k).primeFactors.card, then collapse ω(m^k) = ω(m) by Nat.primeFactors_pow. Both consecutive levels k and k+1 thus have the same count 2^ω(m).\n2. ker_red_nilpotent: lift a kernel element x to a natural number c (ZMod.natCast_rightInverse); red m k x = 0 gives m^k ∣ c (ZMod.natCast_eq_zero_iff), so x is a multiple of m^k and x² a multiple of m^(2k); since k+1 ≤ 2k for k ≥ 1, m^(k+1) ∣ m^(2k), hence x² = 0 — independent of m.\n3. red_injOn_idem: idempotents e,f with red m k e = red m k f have red m k (e−f) = 0, so e−f is nilpotent; the parent's idem_eq_of_sub_nilpotent forces e = f.\n4. red_image_idem: the injective image of the upper idempotents lies in the lower ones (map_idem) and has the same cardinality 2^ω(m) (idem_card on both levels), so Finset.eq_of_subset_of_card_le upgrades inclusion to equality.\n5. unique_digit_extension: ē ∈ lower idempotent set = image (step 4) gives a lift; uniqueness is red_injOn_idem.\n6. Corollaries towers_base_six/twelve/thirty/prime read off 2^ω(m) for m = 6, 12, 30 and any prime via primeFactors computations.",
+    "keyInsights": [
+      "The base-10 tower argument never used the value 10: the only inputs are (a) a nil reduction kernel and (b) equal idempotent counts at consecutive levels. Both hold for every base m, so the whole structure generalizes with no new idea — only the count must be recomputed.",
+      "The level count is 2^ω(m), with the exponent the prime support of the BASE, not of m^k: Nat.primeFactors_pow gives ω(m^k) = ω(m) for k ≥ 1. This is the combinatorial crux — a bijection between levels can only exist because the count is constant up the tower, and it is constant precisely because raising to a power does not change the set of prime divisors.",
+      "Repeated prime factors are invisible: base 12 = 2²·3 has the same four towers as base 6 = 2·3 and base 10 = 2·5, since all three have prime support of size 2. Only squarefree-ness of the support matters, captured cleanly by ω.",
+      "The nil-kernel arithmetic m^(k+1) ∣ (m^k)² = m^(2k) holds for every m once k ≥ 1, so unique lifting is genuinely base-uniform; the doubly-exponential vanishing that pinned the last digit in base 10 is a feature of the exponent k+1 ≤ 2k, not of the base.",
+      "Surjectivity is again free: injective + equal finite cardinality 2^ω(m) on both sides = bijective. The hard counting (2^ω(n) idempotents, proved via CRT in the sibling entry) is imported, not redone — the generalization costs only the prime-support bookkeeping ω(m^k)=ω(m).",
+      "The 2^ω(m) coherent towers converge to the 2^ω(m) idempotents of the m-adic integers ℤ_m ≅ ∏_{p∣m} ℤ_p; the base-10 case ω(10)=2 with its four idempotents is one slice of a uniform family indexed by all bases."
+    ],
+    "prerequisites": [
+      "Idempotents of a commutative ring and the equivalence n²≡n (mod m^k) ⟺ idempotent of ZMod (m^k)",
+      "The count of idempotents of ZMod n is 2^ω(n) via CRT (the sibling general-count entry)",
+      "Stability of prime support under powers: ω(m^k) = ω(m) for k ≥ 1 (Nat.primeFactors_pow)",
+      "Reduction homomorphisms ZMod.castHom and the inverse system ZMod (m^(k+1)) → ZMod (m^k)",
+      "Nilpotent elements, nil ideals, and unique lifting of idempotents across a nil kernel (idem_eq_of_sub_nilpotent)",
+      "Finite-set counting: injective-on maps preserve cardinality and an injection between equinumerous finite sets is a bijection (Finset.card_image_of_injOn, Finset.eq_of_subset_of_card_le)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "unique_digit_extension",
+      "type": "headline",
+      "statement": "[NeZero m] → 0 < k → ē*ē=ē → ∃! e : ZMod (m^(k+1)), e*e=e ∧ red m k e = ē",
+      "description": "For every base m ≥ 1 and every k ≥ 1, each k-digit automorphic residue ē (idempotent of ZMod (m^k)) is the reduction of a UNIQUE (k+1)-digit automorphic residue e (idempotent of ZMod (m^(k+1))). So the automorphic residues over base m form 2^ω(m) coherent towers converging to the 2^ω(m) idempotents of the m-adic integers ℤ_m ≅ ∏_{p∣m} ℤ_p.",
+      "significance": "Answers the parent entry's first open question: the unique-digit-extension phenomenon is base-independent. Base 10 (ω=2, four towers) is the slice of a uniform family covering every base at once."
+    },
+    {
+      "name": "idem_card",
+      "type": "headline",
+      "statement": "[NeZero m] → 0 < k → (univ.filter (e ↦ e*e=e) : ZMod (m^k)).card = 2^ω(m)",
+      "description": "For k ≥ 1 the ring ZMod (m^k) has exactly 2^ω(m) idempotents. This is the sibling's general count 2^ω(n) specialized to n = m^k, collapsed by ω(m^k) = ω(m) (Nat.primeFactors_pow). The exponent is the prime support of the base, not of m^k.",
+      "significance": "The combinatorial heart of the generalization: every level of the tower carries the SAME number of idempotents, which is exactly the condition that lets a level-to-level bijection exist."
+    },
+    {
+      "name": "red_image_idem",
+      "type": "core",
+      "statement": "[NeZero m] → 0 < k → (univ.filter (e ↦ e*e=e)).image (red m k) = univ.filter (e ↦ e*e=e)",
+      "description": "The image under red m k of the (k+1)-level idempotents is exactly the k-level ones: reduction is a bijection between the two 2^ω(m)-element idempotent sets. Injectivity (red_injOn_idem) plus equal cardinality (idem_card, both 2^ω(m)) forces the image to fill the target.",
+      "significance": "The structural statement uniform in m: reduction restricts to a bijection of idempotent sets at every base, so the levels of every automorphic tower are in canonical one-to-one correspondence."
+    },
+    {
+      "name": "ker_red_nilpotent",
+      "type": "core",
+      "statement": "[NeZero m] → 0 < k → red m k x = 0 → IsNilpotent x",
+      "description": "The kernel of red m k is a nil ideal: if red m k x = 0 then x is a multiple of m^k, and since (m^k)² = m^(2k) = 0 in ZMod (m^(k+1)) for k ≥ 1, already x² = 0. The argument is independent of m.",
+      "significance": "The base-uniform arithmetic engine. The vanishing m^(k+1) ∣ m^(2k) holds for every m once k ≥ 1, so unique idempotent lifting is genuinely base-independent."
+    },
+    {
+      "name": "red_injOn_idem",
+      "type": "supporting",
+      "statement": "[NeZero m] → 0 < k → e*e=e → f*f=f → red m k e = red m k f → e = f",
+      "description": "red m k is injective on idempotents: two idempotents with the same reduction have nilpotent difference (it lies in the nil kernel), hence are equal by the parent's idem_eq_of_sub_nilpotent.",
+      "significance": "Uniqueness of the lift — the second half of the bijection — derived purely from the kernel being nil, verbatim from the base-10 argument."
+    },
+    {
+      "name": "towers_base_thirty",
+      "type": "supporting",
+      "statement": "0 < k → (univ.filter (e ↦ e*e=e) : ZMod (30^k)).card = 8",
+      "description": "Base 30 = 2·3·5 has ω = 3, so 2³ = 8 automorphic towers — read off idem_card via a primeFactors computation. Companion corollaries give 4 towers for bases 6 and 12 and 2 for any prime base.",
+      "significance": "Demonstrates the generality concretely beyond base 10: the number of coherent automorphic threads is 2^(number of distinct primes), with repeated primes (base 12 = 2²·3) contributing nothing."
+    }
+  ],
+  "sections": [
+    {
+      "id": "reduction-hom",
+      "title": "Part I: The digit-dropping reduction over base m",
+      "startLine": 55,
+      "endLine": 60,
+      "summary": "red m k := ZMod.castHom (m^k ∣ m^(k+1)) (ZMod (m^k)) is the canonical reduction ZMod (m^(k+1)) →+* ZMod (m^k) for an arbitrary base m. The MapsTo half — that it sends idempotents to idempotents — is supplied by the parent's reusable map_idem.",
+      "mathContext": "The rings ZMod (m^k) form an inverse system under reduction for every base m; red m k is one transition map, and ring homomorphisms preserve the idempotent equation e·e=e."
+    },
+    {
+      "id": "level-count",
+      "title": "Part II: Every level has 2^ω(m) idempotents",
+      "startLine": 62,
+      "endLine": 73,
+      "summary": "idem_card: convert the Finset idempotent count to a Nat.card subtype (Fintype.card_subtype, Nat.card_eq_fintype_card), apply the sibling's idempotent_count = 2^ω(n) at n = m^k, then collapse ω(m^k) = ω(m) via Nat.primeFactors_pow. Both level k and level k+1 have the same count 2^ω(m).",
+      "mathContext": "A prime power has the same prime support as its base, so the idempotent count is constant up the tower — the necessary condition for a level-to-level bijection."
+    },
+    {
+      "id": "nil-kernel",
+      "title": "Part III: The kernel of reduction is a nil ideal",
+      "startLine": 75,
+      "endLine": 94,
+      "summary": "ker_red_nilpotent: lift x to a natural number c (ZMod.natCast_rightInverse); red m k (↑c) = 0 gives m^k ∣ c (ZMod.natCast_eq_zero_iff), so c = m^k·t and x² = (m^k·t)² is a multiple of m^(2k), which is 0 in ZMod (m^(k+1)) since m^(k+1) ∣ m^(2k) for k ≥ 1. Hence x² = 0, uniformly in m.",
+      "mathContext": "The kernel of ZMod (m^(k+1)) → ZMod (m^k) is the ideal (m^k), and (m^k)² = m^(2k) ≡ 0, so the kernel is nil — the hypothesis under which idempotents lift uniquely."
+    },
+    {
+      "id": "bijection",
+      "title": "Part IV: Reduction is a bijection on idempotents",
+      "startLine": 96,
+      "endLine": 128,
+      "summary": "red_injOn_idem: idempotents with equal reduction differ by a nilpotent kernel element, so coincide (idem_eq_of_sub_nilpotent). red_image_idem: the image of the (k+1)-level idempotents lies in the k-level ones (map_idem) and, being injective with both sets of card 2^ω(m) (idem_card), fills it — Finset.eq_of_subset_of_card_le upgrades inclusion to equality.",
+      "mathContext": "Injective + equal finite cardinality 2^ω(m) = bijective: the idempotents of each level correspond one-to-one with those below, for every base m."
+    },
+    {
+      "id": "unique-extension",
+      "title": "Part V: Unique digit-by-digit extension and concrete bases",
+      "startLine": 130,
+      "endLine": 197,
+      "summary": "unique_digit_extension: membership of ē in the lower idempotent set, rewritten through red_image_idem, exhibits a lift e; uniqueness is red_injOn_idem. The corollaries towers_base_six (4), towers_base_twelve (4), towers_base_thirty (8) and towers_base_prime (2) read off 2^ω(m) for specific bases, showing repeated prime factors add no towers.",
+      "mathContext": "Each automorphic number over base m extends uniquely by one digit, so the residues form 2^ω(m) coherent sequences — the idempotents of the m-adic completion ∏_{p∣m} ℤ_p."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms, no native_decide) proof that for EVERY base m ≥ 1 the digit-dropping reduction red m k : ZMod (m^(k+1)) →+* ZMod (m^k) restricts to a bijection between the 2^ω(m)-element idempotent sets at consecutive levels, so every k-digit automorphic residue extends to a UNIQUE (k+1)-digit one. This answers the parent entry's first open question: the tower structure proved there for base 10 is base-independent. The argument is the base-10 one verbatim — a nil reduction kernel ((m^k)²=0 in ZMod (m^(k+1))) plus equal idempotent counts up the tower — with the single new ingredient that the count is 2^ω(m) at every level, because raising to a power preserves prime support (ω(m^k)=ω(m)).",
+    "implications": "The rings ZMod (m^k) form an inverse system whose transition maps are bijective on idempotents for every base m; the inverse limit is the m-adic ring ℤ_m ≅ ∏_{p∣m} ℤ_p, whose 2^ω(m) idempotents are exactly the limits of the 2^ω(m) towers. The base-10 entry (ω(10)=2, four idempotents 0,1,e₂,e₅) is one member of this uniform family. The mechanism — unique lifting of idempotents along a surjection with nil kernel — is the elementary finite model of Hensel's lemma and of idempotent lifting modulo the Jacobson radical in complete local rings, and the generalization shows it depends only on the prime support of the base.",
+    "openQuestions": [
+      "Assemble the levelwise bijections into an isomorphism of profinite idempotent sets, identifying the 2^ω(m) idempotents of ℤ_m ≅ ∏_{p∣m} ℤ_p as the inverse limit lim_k {idempotents of ZMod (m^k)}, and formalize this as an inverse-limit statement in Mathlib.",
+      "Give the explicit CRT description of the 2^ω(m) towers as the subsets-of-prime-divisors indexing: each idempotent corresponds to a subset S ⊆ {p : p ∣ m}, being 1 on the ZMod (p^{ak}) factors with p ∈ S and 0 elsewhere; can the bijection of this entry be upgraded to a natural identification with the Boolean lattice 2^{primeFactors m}?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "automorphic-number-oq-01-oq-03",
+      "description": "Parent entry: proves the unique digit-extension / reduction-bijection tower for the concrete base 10. This entry answers its first stated open question by removing the special role of 10 and proving the same structure uniformly for every base m, with the level count 2^ω(m)."
+    },
+    {
+      "targetId": "automorphic-number-oq-01-oq-01",
+      "description": "Sibling entry: proves ZMod n has exactly 2^ω(n) idempotents via CRT. Specialized to n = m^k (with ω(m^k)=ω(m)) it is the equal-cardinality input idem_card that turns injectivity of reduction into a bijection at every base."
+    },
+    {
+      "targetId": "automorphic-number-oq-01-oq-02",
+      "description": "Sibling entry: proves idem_eq_of_sub_nilpotent (idempotents with nilpotent difference coincide). Reused verbatim to get injectivity of reduction on idempotents from the nil kernel."
+    }
+  ]
+}

--- a/src/data/research/problems/automorphic-number-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/automorphic-number-oq-01-oq-03-oq-01.json
@@ -1,0 +1,114 @@
+{
+  "slug": "automorphic-number-oq-01-oq-03-oq-01",
+  "title": "Idempotent Tower in an Arbitrary Modulus Base",
+  "phase": "OBSERVE",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\rho_k : \\mathbb{Z}/m^{k+1}\\mathbb{Z} \\longrightarrow \\mathbb{Z}/m^{k}\\mathbb{Z}",
+    "plain": "The parent (`automorphic-number-oq-01-oq-03`) studies base-10 automorphic numbers, whose",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T01:25:49-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: base-m generalization of the automorphic idempotent tower verified 0-axiom (AutomorphicNumberOQ01OQ03OQ01.lean, 9 thm). Answers parent oq-03 open question #1.",
+    "builtItems": [
+      "idem_card: #idempotents(ZMod m^k)=2^ω(m) for k≥1 (AutomorphicNumberOQ01OQ03OQ01.lean:67)",
+      "ker_red_nilpotent, red_injOn_idem, red_image_idem (bijection), unique_digit_extension (∃! lift) over arbitrary base m (lines 80-148)",
+      "Corollaries towers_base_six/twelve/thirty/prime: concrete tower counts 4/4/8/2 (lines 157-196)"
+    ],
+    "insights": [
+      "The base-10 tower proof of the parent (AutomorphicNumberOQ01OQ03) generalizes VERBATIM to an arbitrary base m: the only base-specific inputs are a nil reduction kernel and equal idempotent counts at consecutive levels, both of which hold for every m.",
+      "Level count is 2^ω(m), exponent = prime support of the BASE not of m^k, via Nat.primeFactors_pow (ω(m^k)=ω(m) for k≥1). This constancy up the tower is exactly what permits a level-to-level bijection.",
+      "Nil-kernel arithmetic m^(k+1) ∣ (m^k)^2 = m^(2k) holds for all m once k+1≤2k (k≥1) — base-independent.",
+      "Repeated prime factors are invisible: base 12=2^2·3 has the same 4 towers as base 6 and 10 (ω=2)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Assemble levelwise bijections into an inverse-limit isomorphism identifying the 2^ω(m) idempotents of ℤ_m ≅ ∏_{p∣m} ℤ_p.",
+      "Natural identification of the idempotent set with the Boolean lattice 2^{primeFactors m} via CRT subset indexing."
+    ],
+    "markdown": "# Knowledge Base: automorphic-number-oq-01-oq-03-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "idempotents",
+    "chinese-remainder-theorem"
+  ],
+  "relatedProofs": [
+    "automorphic-number-oq-01-oq-01",
+    "automorphic-number-oq-01-oq-02",
+    "automorphic-number-oq-01-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T08:41:40.943Z",
+  "lastUpdate": "2026-06-24T08:41:40.970Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/AutomorphicNumberOQ01.lean",
+      "filename": "AutomorphicNumberOQ01.lean",
+      "lineCount": 190,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AutomorphicNumberOQ01.lean"
+    },
+    {
+      "path": "Proofs/AutomorphicNumberOQ01OQ01.lean",
+      "filename": "AutomorphicNumberOQ01OQ01.lean",
+      "lineCount": 136,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AutomorphicNumberOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AutomorphicNumberOQ01OQ02.lean",
+      "filename": "AutomorphicNumberOQ01OQ02.lean",
+      "lineCount": 213,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AutomorphicNumberOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/AutomorphicNumberOQ01OQ03.lean",
+      "filename": "AutomorphicNumberOQ01OQ03.lean",
+      "lineCount": 155,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AutomorphicNumberOQ01OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the parent entry **automorphic-number-oq-01-oq-03** (the base-10 automorphic idempotent tower) to an **arbitrary base m**, directly answering the parent's first stated open question.

The digit-dropping reduction `red m k : ZMod (m^(k+1)) →+* ZMod (m^k)` restricts to a **bijection** between the `2^ω(m)`-element idempotent sets at consecutive levels, so every `k`-digit automorphic residue `n²≡n (mod m^k)` lifts to a **unique** `(k+1)`-digit one. Thus for every base `m ≥ 1` the automorphic residues organize into `2^ω(m)` coherent towers converging to the idempotents of the m-adic integers `ℤ_m ≅ ∏_{p∣m} ℤ_p`.

## Why it generalizes for free

The base-10 proof used only two facts, both base-independent:
- **Nil reduction kernel**: `m^(k+1) ∣ (m^k)² = m^(2k)` holds for all `m` once `k+1 ≤ 2k` (k≥1), so idempotents lift uniquely.
- **Equal idempotent counts up the tower**: the new lemma `idem_card` reuses the sibling general count `idempotent_count = 2^ω(n)` at `n = m^k` and collapses `ω(m^k) = ω(m)` via `Nat.primeFactors_pow`. The exponent is the prime support of the **base**, not of `m^k` — which is exactly what lets a level-to-level bijection exist.

Reuses the verified siblings `idempotent_count`, `idem_eq_of_sub_nilpotent`, and `map_idem` rather than redoing the hard counting.

## Results (`Proofs/AutomorphicNumberOQ01OQ03OQ01.lean`)
- `idem_card` — `#idempotents(ZMod m^k) = 2^ω(m)` for `k ≥ 1`
- `ker_red_nilpotent` — the reduction kernel is nil, uniformly in `m`
- `red_injOn_idem`, `red_image_idem` — reduction is a bijection on idempotents
- `unique_digit_extension` (headline) — `∃! e, e·e=e ∧ red m k e = ē`
- `towers_base_six/twelve/thirty/prime` — concrete tower counts 4 / 4 / 8 / 2 (repeated primes add none)

## Verification
- **9 theorems + 1 def, 197 lines, 0 sorries, 0 axioms.**
- `#print axioms` on every named result: depends only on `propext` / `Classical.choice` / `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`, no `native_decide`.
- Builds against Mathlib 4.26.0 (`lake build Proofs.AutomorphicNumberOQ01OQ03OQ01`).
- Gallery entry added with full meta/annotations; `pnpm annotations:build` discovers it with no annotation-range warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)