### PR TITLE
research(british-flag-theorem-oq-01-oq-01): parallelogram defect identity = 2⟪u,v⟫ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BritishFlagTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/BritishFlagTheoremOQ01OQ01.lean
@@ -1,0 +1,79 @@
+/-
+  The Parallelogram Defect Identity (sharp generalization of the British Flag Theorem)
+  Open Question: british-flag-theorem-oq-01-oq-01
+
+  For a parallelogram A, B = A+u, C = A+u+v, D = A+v in any real inner product
+  space, and any point P, the "British-flag defect"
+    |PA|² + |PC|² − |PB|² − |PD|²
+  equals 2⟪u, v⟫ — independent of the observer P and of the base point A. When
+  the parallelogram is a rectangle (u ⊥ v) the defect vanishes, recovering the
+  British Flag Theorem in arbitrary dimension.
+
+  ## Main Result
+
+  `parallelogram_defect` (PROVED): in a real inner product space,
+    ‖P − A‖² + ‖P − (A+u+v)‖² − ‖P − (A+u)‖² − ‖P − (A+v)‖² = 2⟪u, v⟫.
+
+  ## Corollaries
+
+  `british_flag_of_orthogonal` : u ⊥ v ⟹ the two diagonal sums are equal.
+  `british_flag`               : vertex form with C = B + D − A and AB ⊥ AD,
+                                 the British Flag Theorem in any dimension.
+
+  ## Proof Strategy
+
+  Translate so the base point is A: with x = P − A, the four points become
+  x, x − u, x − u − v, x − v. Expanding each squared norm with
+  `norm_sub_sq_real` / `norm_add_sq_real` (all inner products appear with the
+  same orientation, so no symmetry juggling is needed) and cancelling, the
+  P- and A-dependent terms drop out, leaving exactly 2⟪u, v⟫.
+-/
+
+import Mathlib
+
+open scoped InnerProductSpace
+
+namespace BritishFlagTheoremOQ01OQ01
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- **Parallelogram defect identity.** For a parallelogram with vertex `A` and
+    edge vectors `u`, `v` (so the vertices are `A`, `A+u`, `A+u+v`, `A+v`), and
+    for any point `P`, the British-flag defect equals `2⟪u, v⟫`, independent of
+    `P` and `A`. -/
+theorem parallelogram_defect (P A u v : V) :
+    ‖P - A‖ ^ 2 + ‖P - (A + u + v)‖ ^ 2 - ‖P - (A + u)‖ ^ 2 - ‖P - (A + v)‖ ^ 2
+      = 2 * ⟪u, v⟫_ℝ := by
+  have e1 : P - (A + u + v) = (P - A) - (u + v) := by abel
+  have e2 : P - (A + u) = (P - A) - u := by abel
+  have e3 : P - (A + v) = (P - A) - v := by abel
+  rw [e1, e2, e3, norm_sub_sq_real (P - A) (u + v), norm_sub_sq_real (P - A) u,
+    norm_sub_sq_real (P - A) v, norm_add_sq_real u v, inner_add_right]
+  ring
+
+/-- If the parallelogram is a rectangle (`u ⊥ v`), the defect vanishes: the sum
+    of squared distances to one diagonal's endpoints equals the sum to the
+    other's. This is the British Flag Theorem, here in an arbitrary real inner
+    product space. -/
+theorem british_flag_of_orthogonal (P A u v : V) (h : ⟪u, v⟫_ℝ = 0) :
+    ‖P - A‖ ^ 2 + ‖P - (A + u + v)‖ ^ 2 = ‖P - (A + u)‖ ^ 2 + ‖P - (A + v)‖ ^ 2 := by
+  have hd := parallelogram_defect P A u v
+  rw [h, mul_zero] at hd
+  linarith
+
+/-- **British Flag Theorem (vertex form, any dimension).** If `ABCD` is a
+    rectangle — `C = B + D − A` closes the parallelogram and `AB ⊥ AD` — then for
+    every point `P`,
+      ‖P − A‖² + ‖P − C‖² = ‖P − B‖² + ‖P − D‖². -/
+theorem british_flag (P A B C D : V) (hC : C = B + D - A)
+    (hperp : ⟪B - A, D - A⟫_ℝ = 0) :
+    ‖P - A‖ ^ 2 + ‖P - C‖ ^ 2 = ‖P - B‖ ^ 2 + ‖P - D‖ ^ 2 := by
+  have hd := parallelogram_defect P A (B - A) (D - A)
+  rw [hperp, mul_zero] at hd
+  have hB : A + (B - A) = B := by abel
+  have hD : A + (D - A) = D := by abel
+  have hBC : B + (D - A) = C := by rw [hC]; abel
+  rw [hB, hD, hBC] at hd
+  linarith
+
+end BritishFlagTheoremOQ01OQ01

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-bftoq0101-header",
+    "proofId": "british-flag-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Module Overview: The Parallelogram Defect Identity",
+    "content": "This module generalizes the British Flag Theorem from a rectangle to an arbitrary parallelogram, in any real inner product space. The parallelogram is encoded by a vertex A and two edge vectors u, v (vertices A, A+u, A+u+v, A+v). The module imports Mathlib, opens the InnerProductSpace scope for the ⟪·,·⟫_ℝ notation, and fixes a real inner product space V via a `variable` declaration.",
+    "mathContext": "The ambient setting is `[NormedAddCommGroup V] [InnerProductSpace ℝ V]`. Phrasing the result abstractly — rather than in ℝ² coordinates — is what makes it a *sharp, dimension-free* generalization of the parent entry.",
+    "significance": "key",
+    "relatedConcepts": [
+      "inner product space",
+      "British Flag Theorem",
+      "parallelogram",
+      "squared norm"
+    ],
+    "prerequisites": [
+      "Real inner product spaces",
+      "norm_sub_sq_real / norm_add_sq_real expansion lemmas"
+    ]
+  },
+  {
+    "id": "ann-bftoq0101-defect",
+    "proofId": "british-flag-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 57
+    },
+    "type": "key_step",
+    "title": "Main Theorem: Defect = 2⟪u, v⟫",
+    "content": "parallelogram_defect proves ‖P−A‖² + ‖P−(A+u+v)‖² − ‖P−(A+u)‖² − ‖P−(A+v)‖² = 2⟪u,v⟫. The proof first rewrites the three composite points as differences from P−A using `abel` (P−(A+u+v) = (P−A)−(u+v), etc.), then expands every squared norm with norm_sub_sq_real, expands ‖u+v‖² with norm_add_sq_real, splits ⟪P−A, u+v⟫ with inner_add_right, and closes with ring. All inner products emerge in the canonical orientation ⟪x,y⟫, so ring needs no commutativity rewrite.",
+    "mathContext": "Setting x = P − A: ‖x‖² + ‖x−u−v‖² − ‖x−u‖² − ‖x−v‖². Expanding, the ‖x‖², ⟪x,u⟫, ⟪x,v⟫, ‖u‖², ‖v‖² contributions all cancel, leaving 2⟪u,v⟫ — independent of both P and A.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "norm_sub_sq_real",
+      "norm_add_sq_real",
+      "inner_add_right",
+      "abel",
+      "ring"
+    ],
+    "prerequisites": [
+      "Squared-norm expansion in an inner product space",
+      "Bilinearity of the real inner product"
+    ]
+  },
+  {
+    "id": "ann-bftoq0101-corollaries",
+    "proofId": "british-flag-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 79
+    },
+    "type": "concept",
+    "title": "Corollaries: Orthogonal Case and Vertex Form",
+    "content": "british_flag_of_orthogonal substitutes ⟪u,v⟫ = 0 into the defect identity (so the defect is 0) and rearranges via linarith to ‖P−A‖² + ‖P−(A+u+v)‖² = ‖P−(A+u)‖² + ‖P−(A+v)‖². british_flag is the classical vertex form: given C = B + D − A (parallelogram closure) and ⟪B−A, D−A⟫ = 0 (right angle at A), it applies parallelogram_defect with u = B−A, v = D−A and rewrites A+(B−A)=B, A+(D−A)=D, B+(D−A)=C to land on the British Flag equality — now valid in any dimension.",
+    "mathContext": "The British Flag Theorem ‖PA‖²+‖PC‖² = ‖PB‖²+‖PD‖² is exactly the zero-defect case 2⟪u,v⟫ = 0, i.e. perpendicular edges. The abstract setting subsumes the parent's planar ℝ² proof.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonality",
+      "British Flag Theorem",
+      "vertex form",
+      "linarith"
+    ],
+    "prerequisites": [
+      "The main defect identity parallelogram_defect",
+      "Vector arithmetic (abel) for the vertex substitutions"
+    ]
+  }
+]

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "british-flag-theorem-oq-01-oq-01",
+  "title": "The Parallelogram Defect Identity",
+  "slug": "british-flag-theorem-oq-01-oq-01",
+  "description": "Proves the sharp generalization of the British Flag Theorem to an arbitrary parallelogram in any real inner product space: for a parallelogram with vertex A and edge vectors u, v (vertices A, A+u, A+u+v, A+v) and any point P, the defect |PA|² + |PC|² − |PB|² − |PD|² equals exactly 2⟪u, v⟫, independent of P and A. When the parallelogram is a rectangle (u ⊥ v) the defect vanishes, recovering the British Flag Theorem in arbitrary dimension.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BritishFlagTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "inner-product-space",
+      "british-flag-theorem",
+      "parallelogram",
+      "euclidean-geometry",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All three theorems are fully machine-checked in an arbitrary real inner product space (NormedAddCommGroup V with InnerProductSpace ℝ V). The proof expands squared norms via Mathlib's norm_sub_sq_real / norm_add_sq_real and closes by ring/linarith. Only the foundational axioms propext, Classical.choice, Quot.sound are used.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 79,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "parallelogram_defect (PROVED, MAIN): ‖P−A‖² + ‖P−(A+u+v)‖² − ‖P−(A+u)‖² − ‖P−(A+v)‖² = 2⟪u,v⟫ in any real inner product space — the sharp defect identity answering the parent's open question",
+      "british_flag_of_orthogonal (PROVED): u ⊥ v ⟹ the two diagonal squared-distance sums coincide",
+      "british_flag (PROVED): vertex form with C = B + D − A and ⟪B−A, D−A⟫ = 0 — the British Flag Theorem in arbitrary dimension"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x − y‖² = ‖x‖² − 2⟪x,y⟫_ℝ + ‖y‖² — expands the three difference norms",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_add_sq_real",
+        "description": "‖x + y‖² = ‖x‖² + 2⟪x,y⟫_ℝ + ‖y‖² — expands ‖u+v‖²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_add_right",
+        "description": "⟪x, y+z⟫ = ⟪x,y⟫ + ⟪x,z⟫ — splits the cross term ⟪P−A, u+v⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The British Flag Theorem states that for any point P and any rectangle ABCD, |PA|² + |PC|² = |PB|² + |PD|² — the squared distances to one diagonal's pair of corners sum to the same value as the other diagonal's pair. The name refers to the Union Jack pattern the diagonals trace. The natural question is what happens for a general parallelogram, where the right-angle hypothesis is dropped. The answer is that the two sums no longer coincide but differ by a fixed 'defect' equal to twice the inner product of the two edge vectors — a quantity that measures exactly how far the parallelogram is from being a rectangle. This entry formalizes that defect identity in full generality, in any real inner product space, so it simultaneously covers the planar case, higher-dimensional parallelograms, and the rectangle special case (defect zero).",
+    "problemStatement": "**OQ-01-01 of british-flag-theorem**\n\nWhat is the sharp generalization of the British Flag Theorem to a parallelogram that is not a rectangle? Show that the defect\n  |PA|² + |PC|² − |PB|² − |PD|²\nequals 2⟪u, v⟫ where u, v are the edge vectors, measuring the failure of the right-angle condition.",
+    "text": "In a real inner product space, ‖P−A‖² + ‖P−(A+u+v)‖² − ‖P−(A+u)‖² − ‖P−(A+v)‖² = 2⟪u, v⟫.",
+    "proofStrategy": "Translate the configuration so the base point is A: setting x = P − A, the four vertices become x, x−u, x−u−v, x−v. Expand each squared norm with `norm_sub_sq_real` (and `norm_add_sq_real` for ‖u+v‖², `inner_add_right` for the split cross term). Crucially, all inner products are produced with the SAME left/right orientation by these lemmas, so no symmetry (`real_inner_comm`) juggling is needed and `ring` closes the identity: every P- and A-dependent term cancels, leaving 2⟪u, v⟫. The two corollaries substitute ⟪u,v⟫ = 0 and `linarith`.",
+    "keyInsights": [
+      "The defect 2⟪u, v⟫ is independent of the observer point P AND of the base vertex A — both cancel completely in the expansion. The identity is a statement purely about the two edge vectors.",
+      "Working in an abstract real inner product space (rather than ℝ² with explicit coordinates as in the parent entry) is what makes the result 'sharp': the same one-line expansion proves the theorem in every dimension at once, answering the parent's higher-dimensional open question as a special case.",
+      "Using `norm_sub_sq_real`/`norm_add_sq_real` instead of unfolding ⟪·,·⟫ by hand keeps every inner product in canonical orientation ⟪x, y⟫ (never the flipped ⟪y, x⟫), so `ring` sees consistent atoms and closes without any commutativity rewrite — a small but decisive proof-engineering choice.",
+      "The rectangle case ⟪u,v⟫ = 0 recovers the British Flag Theorem; the defect 2⟪u,v⟫ = 2‖u‖‖v‖cos θ vanishes exactly when the edges are perpendicular, making 'defect = 0' synonymous with 'right angle at A'.",
+      "The vertex form `british_flag` (with C = B + D − A and AB ⊥ AD) reproduces the classical statement but now in arbitrary dimension, subsuming the planar coordinate proof of the parent entry."
+    ],
+    "prerequisites": [
+      "Real inner product spaces and the squared-norm expansion lemmas norm_sub_sq_real / norm_add_sq_real",
+      "Bilinearity of the real inner product (inner_add_right)",
+      "Basic vector arithmetic (abel) and linear arithmetic (linarith, ring)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the defect identity, its corollaries, and the translate-and-expand strategy. Imports Mathlib, opens the InnerProductSpace scope (for the ⟪·,·⟫_ℝ notation), and fixes a real inner product space V via `variable`.",
+      "mathContext": "The ambient structure is `[NormedAddCommGroup V] [InnerProductSpace ℝ V]`; the notation `⟪x, y⟫_ℝ` denotes the real inner product."
+    },
+    {
+      "id": "sec-defect",
+      "title": "Main Theorem: The Parallelogram Defect",
+      "startLine": 44,
+      "endLine": 57,
+      "summary": "parallelogram_defect: the defect equals 2⟪u,v⟫. Proof rewrites P−(A+u+v), P−(A+u), P−(A+v) as differences from P−A (abel), then expands all squared norms with norm_sub_sq_real / norm_add_sq_real / inner_add_right and closes with ring.",
+      "mathContext": "With x = P − A: ‖x‖² + ‖x−u−v‖² − ‖x−u‖² − ‖x−v‖² = 2⟪u,v⟫. Every term in x cancels; the residue is 2⟪u,v⟫."
+    },
+    {
+      "id": "sec-corollaries",
+      "title": "Corollaries: Orthogonal Case and Vertex Form",
+      "startLine": 58,
+      "endLine": 79,
+      "summary": "british_flag_of_orthogonal: substituting ⟪u,v⟫ = 0 gives defect 0, i.e. equal diagonal sums (linarith). british_flag: the vertex form with C = B + D − A and ⟪B−A, D−A⟫ = 0, reducing to parallelogram_defect with u = B−A, v = D−A after rewriting A+(B−A)=B, A+(D−A)=D, B+(D−A)=C.",
+      "mathContext": "The British Flag Theorem ‖PA‖² + ‖PC‖² = ‖PB‖² + ‖PD‖² is the zero-defect specialization, now valid in any dimension."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "british-flag-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the British Flag Theorem in the coordinate plane ℝ². This entry generalizes it to an arbitrary parallelogram in any real inner product space, with the defect 2⟪u,v⟫ measuring the deviation from a right angle — the parent's first open question."
+    },
+    {
+      "targetId": "parallelogram-law",
+      "relationship": "related",
+      "description": "Both identities live in the inner-product-space squared-norm calculus; the defect identity is a four-point relative of the parallelogram law ‖x+y‖²+‖x−y‖² = 2‖x‖²+2‖y‖²."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified in an arbitrary real inner product space: the British-flag defect |PA|² + |PC|² − |PB|² − |PD|² equals 2⟪u,v⟫, independent of the observer point and base vertex. The rectangle case (u ⊥ v) recovers the British Flag Theorem in any dimension. Zero sorries, zero extra axioms.",
+    "implications": "**Sharp generalization**: the result identifies the exact obstruction to the British Flag equality for a non-rectangular parallelogram — it is 2⟪u,v⟫, vanishing iff the edges are perpendicular.\\n\\n**Dimension-free**: phrased in an abstract inner product space, the identity holds verbatim in ℝ², ℝ³, and any Hilbert space, subsuming the parent's planar coordinate proof and answering the higher-dimensional open question for parallelograms.",
+    "openQuestions": [
+      "Boxes vs. parallelepipeds: does a constant-defect identity characterize orthotopes (right-angled boxes) among general parallelepipeds in dimension n, summing squared distances over the 2ⁿ vertices with alternating signs? The defect should be a sum of pairwise edge inner products Σ_{i<j} ±2⟪u_i, u_j⟫.",
+      "Weighted / affine-combination versions: replace the four corners by an affine simplex and ask for the analogous squared-distance identity, connecting to the Leibniz / Stewart relations.",
+      "Complex inner product spaces: state and prove the Hermitian analogue, where the defect becomes 2 Re⟪u, v⟫ and the imaginary part records an oriented-area contribution."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "parallelogram_defect",
+      "type": "core",
+      "description": "In a real inner product space, the British-flag defect equals 2⟪u, v⟫.",
+      "leanType": "(P A u v : V) → ‖P - A‖^2 + ‖P - (A + u + v)‖^2 - ‖P - (A + u)‖^2 - ‖P - (A + v)‖^2 = 2 * ⟪u, v⟫_ℝ"
+    },
+    {
+      "name": "british_flag",
+      "type": "core",
+      "description": "British Flag Theorem (vertex form) in arbitrary dimension: C = B+D−A and AB ⊥ AD imply ‖PA‖²+‖PC‖² = ‖PB‖²+‖PD‖².",
+      "leanType": "(P A B C D : V) → C = B + D - A → ⟪B - A, D - A⟫_ℝ = 0 → ‖P - A‖^2 + ‖P - C‖^2 = ‖P - B‖^2 + ‖P - D‖^2"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace (scoped)"
+    ],
+    "namespace": "BritishFlagTheoremOQ01OQ01",
+    "lineCount": 79,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "substantiveTheoremCount": 2,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/BritishFlagTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Martin Gardner",
+      "title": "Mathematical Games",
+      "year": "1970",
+      "venue": "Scientific American",
+      "note": "Popularized the British Flag Theorem as a recreational result; the rectangle identity |PA|²+|PC|²=|PB|²+|PD|² is the zero-defect case of the identity formalized here."
+    },
+    {
+      "authors": "Harvey, F. Reese",
+      "title": "Spinors and Calibrations",
+      "year": "1990",
+      "venue": "Academic Press",
+      "note": "Background on inner product space identities; the squared-norm polarization calculus used here underlies the defect computation."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** of the parent British Flag Theorem entry: the sharp generalization to a non-rectangular parallelogram, in **any real inner product space**.

For a parallelogram with vertex $A$ and edge vectors $u, v$ (vertices $A,\ A+u,\ A+u+v,\ A+v$) and any point $P$, the British-flag **defect** is exactly $2\langle u, v\rangle$ — independent of the observer $P$ and the base vertex $A$. It vanishes precisely when $u \perp v$, recovering the British Flag Theorem.

## Theorems (all PROVED, 0 sorries, 0 extra axioms)

| Theorem | Statement |
|---|---|
| `parallelogram_defect` (MAIN) | $\lVert P-A\rVert^2 + \lVert P-(A+u+v)\rVert^2 - \lVert P-(A+u)\rVert^2 - \lVert P-(A+v)\rVert^2 = 2\langle u,v\rangle$ |
| `british_flag_of_orthogonal` | $\langle u,v\rangle = 0 \implies$ equal diagonal sums |
| `british_flag` | vertex form: $C=B+D-A,\ \langle B-A,D-A\rangle=0 \implies \lVert PA\rVert^2+\lVert PC\rVert^2 = \lVert PB\rVert^2+\lVert PD\rVert^2$ |

## Proof

Translate so the base point is $A$: with $x = P-A$ the points become $x,\ x-u,\ x-u-v,\ x-v$. Expanding each squared norm with `norm_sub_sq_real` / `norm_add_sq_real` produces every inner product in the **same orientation** $\langle x,y\rangle$, so `ring` closes with no `real_inner_comm` juggling. All $P$- and $A$-dependent terms cancel, leaving $2\langle u,v\rangle$.

Phrasing the result in an abstract real inner product space makes it dimension-free: it covers the plane, higher-dimensional parallelograms, and (defect zero) the rectangle case, subsuming the parent's coordinate proof in $\mathbb{R}^2$.

## Verification

- `lake env lean` typechecks clean (Lean v4.26.0, Mathlib).
- `#print axioms` on all three theorems: only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`, badge `original`, `axiomCount` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)