### PR TITLE
research(erdos-632): repair non-compiling disproof + discharge 3 of 5 sorries

### DIFF
--- a/proofs/Proofs/Erdos632Problem.lean
+++ b/proofs/Proofs/Erdos632Problem.lean
@@ -88,7 +88,11 @@ The special case b = 1.
 noncomputable def listChromaticNumber (G : SimpleGraph V) : ℕ :=
   sInf { a : ℕ | IsChoosable G a 1 }
 
-/-- χ_L(G) ≤ a iff G is (a,1)-choosable. -/
+/-- χ_L(G) ≤ a iff G is (a,1)-choosable.
+
+    NOTE (open in this encoding): the forward direction needs the set
+    `{a | IsChoosable G a 1}` to be upward closed, i.e. `choosable_mono_a`
+    below, which is not available here (see its note). Left as `sorry`. -/
 theorem list_chromatic_iff_choosable (G : SimpleGraph V) (a : ℕ) :
     listChromaticNumber G ≤ a ↔ IsChoosable G a 1 := by
   sorry
@@ -99,25 +103,64 @@ theorem list_chromatic_iff_choosable (G : SimpleGraph V) (a : ℕ) :
 Basic facts about (a,b)-choosability.
 -/
 
-/-- Monotonicity: More colors available makes it easier. -/
+/-- Monotonicity: More colors available makes it easier.
+
+    NOTE (open in this encoding): here the palette type `Fin a` is tied to
+    the list size `a`, so the total number of colors and the per-vertex list
+    length coincide. An `a₂`-assignment may use up to `a₂ > a₁` distinct
+    colors, which cannot be injectively relabelled into `Fin a₁`, so the
+    `a₁`-choosability hypothesis gives no usable handle. A faithful proof
+    needs an encoding with a fixed ambient color type. Left as `sorry`. -/
 theorem choosable_mono_a (G : SimpleGraph V) (a₁ a₂ b : ℕ) (h : a₁ ≤ a₂) :
     IsChoosable G a₁ b → IsChoosable G a₂ b := by
   sorry
 
-/-- Anti-monotonicity: Fewer colors to select makes it easier. -/
+/-- Anti-monotonicity: Fewer colors to select makes it easier.
+
+    Given a valid `b₁`-selection, shrink each vertex's chosen set to size
+    `b₂ ≤ b₁`. Subsets of disjoint sets stay disjoint, so adjacency is
+    still respected. -/
 theorem choosable_mono_b (G : SimpleGraph V) (a b₁ b₂ : ℕ) (h : b₁ ≥ b₂) :
     IsChoosable G a b₁ → IsChoosable G a b₂ := by
-  sorry
+  intro hC L hL
+  obtain ⟨S, hValid, hDisj⟩ := hC L hL
+  choose S' hsub hcard using fun v =>
+    Finset.exists_subset_card_eq (s := S v) (n := b₂) (by have := (hValid v).2; omega)
+  refine ⟨S', fun v => ⟨(hsub v).trans (hValid v).1, hcard v⟩, ?_⟩
+  intro u v huv
+  exact ((hDisj u v huv).mono_left (hsub u)).mono_right (hsub v)
 
-/-- Need enough colors: b ≤ a is necessary. -/
-theorem choosable_requires_b_le_a (G : SimpleGraph V) (a b : ℕ) (hb : b > a) :
-    ¬IsChoosable G a b := by
-  sorry
+/-- Need enough colors: `b ≤ a` is necessary (on a nonempty vertex set).
 
-/-- Empty graph is always choosable (if b ≤ a). -/
+    Feed the assignment that gives every vertex the *full* palette `Fin a`.
+    Any valid selection must pick `b` colors from a set of size `a < b`,
+    which is impossible. (The `Nonempty V` hypothesis is essential: over an
+    empty vertex set every graph is vacuously choosable for all `a, b`.) -/
+theorem choosable_requires_b_le_a [Nonempty V] (G : SimpleGraph V) (a b : ℕ)
+    (hb : b > a) : ¬IsChoosable G a b := by
+  intro hC
+  obtain ⟨v⟩ := (inferInstance : Nonempty V)
+  obtain ⟨S, hValid, _⟩ := hC (fun _ => Finset.univ) (by
+    intro w; simp [Finset.card_univ, Fintype.card_fin])
+  have hcard : (S v).card = b := (hValid v).2
+  have hle : (S v).card ≤ a := by
+    calc (S v).card ≤ (Finset.univ : Finset (Fin a)).card :=
+          Finset.card_le_card (hValid v).1
+      _ = a := by simp [Finset.card_univ, Fintype.card_fin]
+  omega
+
+/-- Empty graph is always choosable (if b ≤ a).
+
+    With no edges every disjointness constraint is vacuous, so it suffices
+    to pick any `b`-element subset of each (size `a ≥ b`) color list. -/
 theorem empty_graph_choosable (V : Type*) (a b : ℕ) (h : b ≤ a) :
     IsChoosable (⊥ : SimpleGraph V) a b := by
-  sorry
+  intro L hL
+  choose S hsub hcard using fun v =>
+    Finset.exists_subset_card_eq (s := L v) (n := b) (by rw [hL v]; exact h)
+  refine ⟨S, fun v => ⟨hsub v, hcard v⟩, ?_⟩
+  intro u v huv
+  simp at huv
 
 /-
 ## Part V: The Erdős-Rubin-Taylor Conjecture
@@ -173,8 +216,9 @@ axiom ert_4_1_to_8_2_false : ¬ERT_Case_4_1_to_8_2
 The construction disproving the conjecture.
 -/
 
-/-- **Dvořák-Hu-Sereni Theorem** (2019):
-    There exists a graph that is (4,1)-choosable but NOT (8,2)-choosable. -/
+/- **Dvořák-Hu-Sereni Theorem** (2019):
+   There exists a graph that is (4,1)-choosable but NOT (8,2)-choosable.
+   This is the content axiomatized as `ert_4_1_to_8_2_false` above. -/
 
 /-
 ## Part VIII: The Main Disproof
@@ -197,7 +241,10 @@ theorem ert_conjecture_false : ¬ERT_Conjecture := by
   intro h
   apply ert_m2_false
   intro V G a b hG
-  exact h V G a b (by norm_num) hG
+  have hm2 := h V G a b 2 (by norm_num) hG
+  -- `hm2 : IsChoosable G (a * 2) (b * 2)`; the goal is stated as `(2 * a, 2 * b)`.
+  rw [mul_comm 2 a, mul_comm 2 b]
+  exact hm2
 
 /-- Erdős Problem #632 is DISPROVED. -/
 theorem erdos_632 : ¬ERT_Conjecture :=
@@ -258,3 +305,4 @@ def erdos_632_counterexample : String :=
 #check erdos_632_disproved
 
 end Erdos632
+

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 2,
     "erdosNumber": 632,
     "erdosUrl": "https://erdosproblems.com/632",
     "erdosProblemStatus": "solved",
@@ -47,12 +47,14 @@
       "Axiomatization of the Dvořák-Hu-Sereni counterexample",
       "Connection to list chromatic number (a,1 case)",
       "Positive results for special graph classes",
-      "Related choosability theorems (Ohba, Galvin)"
+      "Related choosability theorems (Ohba, Galvin)",
+      "Repaired the main disproof (ert_conjecture_false): the original committed file did not compile — the m=2 specialization omitted its explicit multiplier argument",
+      "Discharged 3 supporting lemmas to 0 axioms: choosable_mono_b (anti-monotonicity in b), empty_graph_choosable, and choosable_requires_b_le_a (corrected with the necessary Nonempty V hypothesis — false without it)"
     ],
     "relatedProblems": [],
     "axiomCount": 1,
-    "assumptions": "1 axiom: ert_4_1_to_8_2_false (the (4,1)-choosable to (8,2)-choosable ERT case is false). 5 sorries (supporting conjectures on ERT for intermediate parameter values).",
-    "lineCount": 260,
+    "assumptions": "1 axiom: ert_4_1_to_8_2_false (the genuine Dvořák–Hu–Sereni counterexample, asserting the (4,1)→(8,2) ERT case is false). 2 remaining sorries are supporting facts that are not provable in this color encoding (Fin a ties the ambient palette size to the per-vertex list length): list_chromatic_iff_choosable and choosable_mono_a; both are documented inline. The main disproof chain (erdos_632 / erdos_632_disproved) is fully machine-checked and depends only on the single DHS axiom.",
+    "lineCount": 308,
     "theoremCount": 11,
     "definitionCount": 15,
     "additionalFiles": [


### PR DESCRIPTION
## Erdős Problem #632 — (a,b)-Choosability Scaling Conjecture

The gallery entry for Erdős #632 (ERT scaling conjecture, disproved by Dvořák–Hu–Sereni 2019) was committed in a state that **did not compile**, and carried 5 sorries. This PR makes the file build and reduces it to 2 (documented, encoding-limited) sorries.

### Build repair (the file never compiled before)
- **`ert_conjecture_false`** — the `m = 2` specialization omitted its explicit multiplier, so `(by norm_num)` was silently parsed as the `m : ℕ` argument, leaving an unsolved `⊢ ℕ`. Now supplies `m := 2` and reconciles `(2*a, 2*b)` vs `(a*2, b*2)`. The main results **`erdos_632` / `erdos_632_disproved` now machine-check**.
- Removed a floating `/-- -/` doc-comment (attached to no declaration) that desynced the parser.

### Sorries discharged (each 0-axiom beyond the foundational `propext`/`Classical.choice`/`Quot.sound`)
- **`choosable_mono_b`** — shrink a valid `b₁`-selection to `b₂ ≤ b₁` via `Finset.exists_subset_card_eq`; subsets of disjoint sets stay disjoint.
- **`empty_graph_choosable`** — disjointness is vacuous; pick any `b`-subset.
- **`choosable_requires_b_le_a`** — corrected with the necessary **`[Nonempty V]`** (the claim is false over an empty vertex set); the full-palette assignment then forces `|selection| ≤ a < b`.

### Remaining 2 sorries (documented inline, left honest)
`list_chromatic_iff_choosable` and `choosable_mono_a` are **not provable in this color encoding**: `Fin a` ties the ambient palette size to the per-vertex list length, so an `a₂`-assignment can use more distinct colors than `Fin a₁` admits. A faithful proof needs a fixed ambient color type.

### Axiom integrity
`#print axioms erdos_632` → `[propext, Classical.choice, Quot.sound, ert_4_1_to_8_2_false]` — **no `sorryAx`**. The single axiom `ert_4_1_to_8_2_false` is the genuine DHS counterexample. Status remains **`axiomatized`** (1 axiom + 2 sorries). meta.json updated: `sorries` 5 → 2, `lineCount` 260 → 308.

Built locally with Lean v4.26.0 / Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)