### PR TITLE
research(hilbert-17): eliminate 2 axioms — Motzkin & Robinson non-negativity machine-checked [10→8]

### DIFF
--- a/proofs/Proofs/Hilbert17SumOfSquares.lean
+++ b/proofs/Proofs/Hilbert17SumOfSquares.lean
@@ -61,7 +61,8 @@ Allowing rational functions g²/h² = (g/h)² provides more flexibility.
 - [x] Connection to real closed fields
 - [x] Explanation of why rational functions are needed
 - [x] Pedagogical example
-- [ ] Incomplete (10 axioms - full proof requires model theory and real algebraic geometry)
+- [x] Motzkin and Robinson non-negativity machine-checked (nlinarith; AM-GM / Schur)
+- [ ] Incomplete (8 axioms - full proof requires model theory and real algebraic geometry)
 
 ## Mathlib Dependencies
 
@@ -198,30 +199,23 @@ def motzkin : MvPolynomial (Fin 2) ℝ :=
   let y := MvPolynomial.X (1 : Fin 2)
   x^4 * y^2 + x^2 * y^4 - 3 * x^2 * y^2 + 1
 
-/-- **Axiom: Motzkin Non-Negativity**
-
-    The Motzkin polynomial M(x,y) = x⁴y² + x²y⁴ - 3x²y² + 1 is non-negative everywhere.
-
-    The proof uses the arithmetic-geometric mean inequality:
-    By AM-GM: (x⁴y² + x²y⁴ + 1) / 3 ≥ ∛(x⁴y² · x²y⁴ · 1) = x²y²
-    Therefore: x⁴y² + x²y⁴ + 1 ≥ 3x²y², which gives M(x,y) ≥ 0.
-
-    Axiomatized because the proof requires:
-    - Multivariate polynomial evaluation machinery
-    - AM-GM inequality for three terms
-    - Real number arithmetic and algebraic manipulation -/
-axiom motzkin_nonneg_aux : IsPositiveSemidefiniteMv motzkin
-
-/-- **The Motzkin Polynomial is Non-Negative**
+/-- **The Motzkin Polynomial is Non-Negative** (axiom-free).
 
     M(x,y) = x⁴y² + x²y⁴ - 3x²y² + 1 ≥ 0 for all (x,y) ∈ ℝ².
 
-    **Proof Sketch** (using AM-GM):
-    By the arithmetic-geometric mean inequality:
-      (x⁴y² + x²y⁴ + 1) / 3 ≥ ∛(x⁴y² · x²y⁴ · 1) = x²y²
-
-    Therefore: x⁴y² + x²y⁴ + 1 ≥ 3x²y², which gives M(x,y) ≥ 0. -/
-theorem motzkin_nonneg : IsPositiveSemidefiniteMv motzkin := motzkin_nonneg_aux
+    **Proof.** The AM–GM step `x⁴y² + x²y⁴ + 1 ≥ 3x²y²` is a polynomial
+    inequality that `nlinarith` discharges from the square hints
+    `(x²y² - 1)²`, `(x²y - y)²`, `(xy² - x)² ≥ 0` together with `x²y² ≥ 0`.
+    (Formerly the axiom `motzkin_nonneg_aux`; now fully machine-checked.) -/
+theorem motzkin_nonneg : IsPositiveSemidefiniteMv motzkin := by
+  intro v
+  simp only [motzkin, map_add, map_sub, map_mul, map_pow, map_ofNat, map_one,
+    MvPolynomial.eval_X]
+  set x := v 0
+  set y := v 1
+  nlinarith [sq_nonneg (x * y - 1), sq_nonneg (x ^ 2 * y - y),
+    sq_nonneg (x * y ^ 2 - x), sq_nonneg (x * y),
+    mul_nonneg (sq_nonneg x) (sq_nonneg y), sq_nonneg (x ^ 2 * y ^ 2 - 1)]
 
 /-- **Axiom: Motzkin Not Polynomial-SOS**
 
@@ -482,20 +476,32 @@ def robinson : MvPolynomial (Fin 3) ℝ :=
   - x^2*y^4 - y^2*z^4 - z^2*x^4
   + 3*x^2*y^2*z^2
 
-/-- **Axiom: Robinson Non-Negativity**
+/-- **Robinson's polynomial is non-negative** (axiom-free).
 
-    Robinson's polynomial R(x,y,z) = x^6 + y^6 + z^6 - x^4*y^2 - y^4*z^2 - z^4*x^2
-                                   - x^2*y^4 - y^2*z^4 - z^2*x^4 + 3*x^2*y^2*z^2
-    is non-negative everywhere on R^3.
+    R(x,y,z) = x⁶ + y⁶ + z⁶ - x⁴y² - y⁴z² - z⁴x² - x²y⁴ - y²z⁴ - z²x⁴ + 3x²y²z² ≥ 0.
 
-    Axiomatized because the proof requires:
-    - Multivariate polynomial evaluation
-    - Symmetric function analysis
-    - Careful algebraic manipulation to establish the inequality -/
-axiom robinson_nonneg_aux : IsPositiveSemidefiniteMv robinson
-
-/-- Robinson's polynomial is non-negative. -/
-theorem robinson_nonneg : IsPositiveSemidefiniteMv robinson := robinson_nonneg_aux
+    **Proof.** With `a = x², b = y², c = z² ≥ 0`, `R` is precisely Schur's
+    expression `a(a-b)(a-c) + b(b-a)(b-c) + c(c-a)(c-b)`, nonnegative by Schur's
+    inequality. `nlinarith` finds the certificate from the hints
+    `a·(a-b)² , b·(b-c)² , c·(c-a)² , …  ≥ 0` and `a·b·c ≥ 0`.
+    (Formerly the axiom `robinson_nonneg_aux`; now fully machine-checked.) -/
+theorem robinson_nonneg : IsPositiveSemidefiniteMv robinson := by
+  intro v
+  simp only [robinson, map_add, map_sub, map_mul, map_pow, map_ofNat,
+    MvPolynomial.eval_X]
+  set x := v 0
+  set y := v 1
+  set z := v 2
+  have ha : (0 : ℝ) ≤ x ^ 2 := sq_nonneg x
+  have hb : (0 : ℝ) ≤ y ^ 2 := sq_nonneg y
+  have hc : (0 : ℝ) ≤ z ^ 2 := sq_nonneg z
+  nlinarith [mul_nonneg ha (sq_nonneg (x ^ 2 - y ^ 2)),
+    mul_nonneg hb (sq_nonneg (y ^ 2 - z ^ 2)),
+    mul_nonneg hc (sq_nonneg (z ^ 2 - x ^ 2)),
+    mul_nonneg ha (sq_nonneg (x ^ 2 - z ^ 2)),
+    mul_nonneg hb (sq_nonneg (x ^ 2 - y ^ 2)),
+    mul_nonneg hc (sq_nonneg (y ^ 2 - z ^ 2)),
+    mul_nonneg (mul_nonneg ha hb) hc]
 
 /-- **Axiom: Robinson Not Polynomial-SOS**
 

--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -1,0 +1,35 @@
+# hilbert-17-oq-03 — knowledge
+
+## Problem
+"Complexity of Deciding PSD Polynomial Sum-of-Squares" — what is the
+computational complexity of deciding whether a given PSD polynomial is a sum of
+squares. This is a **complexity meta-question**, not a clean Lean theorem
+target. The underlying mathematical substance is the PSD ⊋ SOS separation,
+whose canonical witnesses are the Motzkin and Robinson polynomials.
+
+## Session 2026-06-24 (researcher-1) — axiom elimination in parent hilbert-17
+The parent entry `hilbert-17` (Hilbert17SumOfSquares.lean) carried 10 axioms,
+two of which were *non-negativity* claims discharged here:
+
+- `motzkin_nonneg`  (M = x⁴y²+x²y⁴−3x²y²+1 ≥ 0): the AM–GM step
+  `x⁴y²+x²y⁴+1 ≥ 3x²y²` is a polynomial inequality `nlinarith` closes from
+  square hints `(x²y²−1)², (x²y−y)², (xy²−x)²` and `x²y² ≥ 0`. No cube-root.
+- `robinson_nonneg` (R = Σx⁶ − Σx⁴y² + 3x²y²z² ≥ 0): with a=x², b=y², c=z² ≥ 0,
+  R IS Schur's expression `a(a−b)(a−c)+b(b−a)(b−c)+c(c−a)(c−b)`; `nlinarith`
+  finds the constrained certificate from `a·(a−b)² ≥ 0` terms + `abc ≥ 0`.
+
+Both now `#print axioms` → propext/Classical.choice/Quot.sound only.
+**axiomCount 10 → 8.** Reduction step in `IsPositiveSemidefiniteMv`:
+`intro v; simp only [<poly def>, map_add, map_sub, map_mul, map_pow, map_ofNat,
+map_one, MvPolynomial.eval_X]; set x := v 0; …; nlinarith [...]`.
+
+### Gotcha
+- `def motzkin : MvPolynomial …` in a scratch needs `noncomputable`; in the real
+  file it already lives in a context where it builds. The THEOREM proofs are
+  computable-irrelevant — only the eval reduction + nlinarith matter.
+
+## Still open
+- Non-SOS direction (`motzkin_not_sos`, `robinson_not_sos`) — homogeneous-form
+  degree analysis; would remove 2 more axioms.
+- The actual complexity classification (SOS membership ≈ SDP feasibility) — a
+  meta/complexity statement; unclear how to formalize meaningfully in Lean.

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-17",
   "title": "Hilbert's 17th Problem: Sum of Squares",
   "slug": "hilbert-17",
-  "description": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample).",
+  "description": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample). UPDATE: the non-negativity of both classical counterexamples — Motzkin M(x,y)=x⁴y²+x²y⁴−3x²y²+1 (via AM–GM) and Robinson R(x,y,z) (which equals Schur's expression in x²,y²,z²) — is now machine-checked via nlinarith with explicit square certificates, eliminating the axioms motzkin_nonneg_aux and robinson_nonneg_aux (axiom count 10 → 8).",
   "meta": {
     "proofRepoPath": "Proofs/Hilbert17SumOfSquares.lean",
     "author": "Emil Artin (1927)",
@@ -39,22 +39,21 @@
       "Robinson and Choi-Lam additional counterexamples",
       "Hilbert's 1888 classification of when PSD = polynomial-SOS",
       "Pfister's and Cassels' quantitative bounds on number of squares",
-      "Connection to real closed fields and model-theoretic transfer"
+      "Connection to real closed fields and model-theoretic transfer",
+      "motzkin_nonneg / robinson_nonneg: the PSD (non-negativity) direction of the two canonical PSD-but-not-SOS counterexamples is now proved axiom-free by nlinarith — Motzkin from AM–GM square hints, Robinson from Schur's inequality on x²,y²,z² — removing two former axioms"
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 17,
-    "axiomCount": 10,
-    "lineCount": 561,
+    "axiomCount": 8,
+    "lineCount": 567,
     "assumptions": [
       "artin_hilbert17: Every PSD multivariate polynomial over R is a sum of squares of rational functions (Artin's theorem)",
       "artin_univariate_aux: Every PSD univariate polynomial is a sum of squares of rational functions",
-      "motzkin_nonneg_aux: The Motzkin polynomial M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1 is non-negative everywhere (AM-GM)",
       "motzkin_not_sos_polynomial_aux: The Motzkin polynomial is not a sum of squares of polynomials (degree analysis)",
       "univariate_psd_is_sos_aux: Every PSD univariate polynomial is a sum of squares of polynomials (complex factorization)",
       "quadratic_psd_is_sos_aux: Every PSD quadratic form is a sum of squares of polynomials (Gram matrix / Cholesky)",
       "pfister_bound_aux: At most 2^n rational function squares needed for n-variable PSD polynomials (Pfister forms)",
       "cassels_bound_bivariate_aux: At most 4 rational function squares needed for bivariate PSD polynomials",
-      "robinson_nonneg_aux: Robinson's polynomial is non-negative everywhere (Schur's inequality)",
       "robinson_not_sos_aux: Robinson's polynomial is not a sum of squares of polynomials (homogeneous form analysis)"
     ],
     "mathlib_version": "4.26.0",
@@ -218,8 +217,8 @@
       "RatFunc"
     ],
     "namespace": "Hilbert17",
-    "lineCount": 561,
-    "axiomCount": 10,
+    "lineCount": 567,
+    "axiomCount": 8,
     "theoremCount": 10,
     "definitionCount": 8,
     "path": "Proofs/Hilbert17SumOfSquares.lean",

--- a/src/data/research/problems/hilbert-17-oq-03.json
+++ b/src/data/research/problems/hilbert-17-oq-03.json
@@ -29,11 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "Session (researcher-1, 2026-06-24): the complexity question (deciding whether a PSD polynomial is SOS) rests on the PSD⊋SOS separation, whose canonical witnesses are the Motzkin and Robinson polynomials. Strengthened the foundation by eliminating two axioms in the parent hilbert-17 entry: motzkin_nonneg and robinson_nonneg are now machine-checked (nlinarith; Robinson = Schur's inequality on x²,y²,z²). axiomCount 10→8. The decision-problem framing (complexity class of SOS membership) remains a meta-question not yet formalized as a Lean theorem.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "Motzkin non-negativity is a polynomial AM–GM inequality that nlinarith closes from square hints (x²y²−1)², (x²y−y)², (xy²−x)²; no transcendental cube-root argument is needed at the eval level.",
+      "Robinson's polynomial equals Schur's expression a(a−b)(a−c)+… under a=x², b=y², c=z²≥0, so its non-negativity is exactly Schur's inequality — nlinarith finds the constrained certificate from a·(a−b)² ≥ 0 terms."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Formalize the non-SOS direction (motzkin_not_sos / robinson_not_sos) via homogeneous-component degree analysis to remove two more axioms.",
+      "State the actual complexity content (SOS membership as SDP feasibility) precisely; assess whether any decidability fragment is Lean-formalizable."
+    ]
   },
   "tags": [
     "computational-algebra",


### PR DESCRIPTION
## Summary

Eliminates **two axioms** from the `hilbert-17` entry (*Hilbert's 17th Problem: Sum of Squares*) by machine-checking the non-negativity (PSD direction) of the two classical PSD-but-not-SOS counterexamples. **axiomCount 10 → 8.**

This is axiom-elimination, the highest-value form of formalization work: the file previously *assumed* these polynomials were non-negative.

## What changed

```lean
theorem motzkin_nonneg : IsPositiveSemidefiniteMv motzkin
theorem robinson_nonneg : IsPositiveSemidefiniteMv robinson
```

were `:= motzkin_nonneg_aux` / `:= robinson_nonneg_aux` (axioms). Now both have real proofs:

- **Motzkin** `M(x,y) = x⁴y² + x²y⁴ − 3x²y² + 1 ≥ 0`. The AM–GM step `x⁴y² + x²y⁴ + 1 ≥ 3x²y²` is a polynomial inequality `nlinarith` discharges from the square hints `(x²y²−1)²`, `(x²y−y)²`, `(xy²−x)²` and `x²y² ≥ 0`.
- **Robinson** `R(x,y,z) = Σx⁶ − Σx⁴y² + 3x²y²z² ≥ 0`. Substituting `a=x², b=y², c=z² ≥ 0`, `R` is *exactly* Schur's expression `a(a−b)(a−c) + b(b−a)(b−c) + c(c−a)(c−b)`, so `nlinarith` finds the constrained certificate from `a·(a−b)² ≥ 0` terms and `abc ≥ 0`.

The PSD reduction is uniform: `intro v; simp only [<def>, map_add, map_sub, map_mul, map_pow, map_ofNat, map_one, MvPolynomial.eval_X]; nlinarith [...]`.

## Verification

- `#print axioms motzkin_nonneg` / `robinson_nonneg` → `[propext, Classical.choice, Quot.sound]` only; no `sorry`, no `native_decide`.
- Full file builds clean against the Mathlib pin (Lean v4.26.0).
- `meta.json` axiomCount 10 → 8, `assumptions` list trimmed, file-header status updated.

## Context

Filed under the `hilbert-17-oq-03` research claim (*complexity of deciding whether a PSD polynomial is SOS*). That question is a complexity meta-question with no clean Lean theorem; this PR instead strengthens the **foundation** it rests on — the PSD ⊋ SOS separation. The non-SOS direction (`motzkin_not_sos`, `robinson_not_sos`, 2 remaining axioms) and the complexity classification itself remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)