### PR TITLE
Enrich Erdős #220 OQ-01 squared-gap lower bound (erdos-220-oq-01)

### DIFF
--- a/src/data/proofs/erdos-220-oq-01/annotations.json
+++ b/src/data/proofs/erdos-220-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The easy lower half of Erdős #220",
     "content": "Erdős Problem #220 asks whether ∑(a_{k+1} − a_k)² ≪ n²/φ(n) for the reduced residues a₁ < ⋯ < a_{φ(n)} mod n. The hard direction is the UPPER bound, proved by Montgomery and Vaughan (1986) and axiomatized in the parent entry. This file proves the complementary, entirely elementary LOWER bound ∑(a_{k+1} − a_k)² ≥ (n−2)²/(φ(n)−1). Because (n−2)²/(φ(n)−1) and n²/φ(n) have the same order of magnitude, the two bounds pin the squared-gap sum: ∑(a_{k+1} − a_k)² ≍ n²/φ(n). The parent's Part VI/VII comments asserted the matching lower behaviour ('if all gaps were average the squared sum would be exactly n²/φ(n)') but never proved it.",
-    "mathContext": "$\\sum_k (a_{k+1}-a_k)^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1} \\asymp \\dfrac{n^2}{\\varphi(n)}$, matching Montgomery–Vaughan from below."
+    "mathContext": "$\\sum_k (a_{k+1}-a_k)^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1} \\asymp \\dfrac{n^2}{\\varphi(n)}$, matching Montgomery–Vaughan from below.",
+    "significance": "key",
+    "relatedConcepts": ["reduced residues", "totient gaps", "Montgomery–Vaughan", "Cauchy–Schwarz lower bound"],
+    "prerequisites": ["Euler totient", "reduced residue system", "asymptotic order of magnitude"]
   },
   {
     "id": "ann-erdos220oq01-card",
@@ -15,7 +18,10 @@
     "type": "key-step",
     "title": "Counting the reduced residues: card = φ(n)",
     "content": "reducedResidues n is the integers m ∈ [1, n−1] with gcd(m,n) = 1. card_reducedResidues identifies its cardinality with Mathlib's Nat.totient via Nat.totient_eq_card_coprime and Finset.filter_congr: the two filters over range n differ only in the predicate, and the discrepancy at m = 0 vanishes because gcd(0,n) = n ≠ 1 for n ≥ 2 (Nat.coprime_zero_right). For all m ≥ 1 the clause `1 ≤ m` is automatic and coprimality is symmetric (Nat.coprime_comm). The parent entry left the analogous card statement as a `sorry`.",
-    "mathContext": "$\\#\\{1\\le m<n: \\gcd(m,n)=1\\} = \\varphi(n)$ for $n\\ge 2$."
+    "mathContext": "$\\#\\{1\\le m<n: \\gcd(m,n)=1\\} = \\varphi(n)$ for $n\\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient", "coprimality", "Finset.filter", "Nat.totient_eq_card_coprime"],
+    "prerequisites": ["gcd and coprimality", "Finset cardinality"]
   },
   {
     "id": "ann-erdos220oq01-endpoints",
@@ -24,7 +30,10 @@
     "type": "key-step",
     "title": "The extreme reduced residues are 1 and n − 1",
     "content": "Both 1 and n − 1 are coprime to n: gcd(1,n) = 1 trivially, and gcd(n−1, n) = gcd(n−1, 1) = 1 (coprime_pred_self, derived from Nat.coprime_add_self_left). Since every reduced residue lies in [1, n−1], the minimum is 1 and the maximum is n − 1, proved by le_antisymm against Finset.min'_le / le_min' and max'_le / le_max'. These lemmas are stated for an arbitrary nonemptiness witness H, so they rewrite cleanly regardless of how the witness is produced downstream.",
-    "mathContext": "$a_1 = \\min = 1$ and $a_{\\varphi(n)} = \\max = n-1$."
+    "mathContext": "$a_1 = \\min = 1$ and $a_{\\varphi(n)} = \\max = n-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["extreme residues", "Finset.min'/max'", "coprime_pred_self", "le_antisymm"],
+    "prerequisites": ["coprimality", "Finset min'/max'"]
   },
   {
     "id": "ann-erdos220oq01-enum",
@@ -33,7 +42,10 @@
     "type": "technique",
     "title": "Enumerating a sorted finset with orderEmbOfFin",
     "content": "Rather than manipulate Finset.sort directly, the k-th reduced residue is read off Mathlib's Finset.orderEmbOfFin — the strictly monotone order embedding Fin (s.card) ↪o ℕ of the sorted set. E n k casts this to ℝ, padding with 0 for k ≥ φ(n) so the value is a total function ℕ → ℝ. The endpoint lemmas orderEmbOfFin_zero (= min') and orderEmbOfFin_last (= max') then give E 0 = 1 and E (φ(n)−1) = n − 1 directly, without any low-level list reasoning.",
-    "mathContext": "$E(k)$ is the order-isomorphic image of $k$, so $E(0)=\\min=1$ and $E(\\varphi(n)-1)=\\max=n-1$."
+    "mathContext": "$E(k)$ is the order-isomorphic image of $k$, so $E(0)=\\min=1$ and $E(\\varphi(n)-1)=\\max=n-1$.",
+    "significance": "technical",
+    "relatedConcepts": ["order embedding", "Finset.orderEmbOfFin", "sorted enumeration", "monotone bijection"],
+    "prerequisites": ["order embeddings", "Finset.sort", "Fin"]
   },
   {
     "id": "ann-erdos220oq01-telescope",
@@ -42,7 +54,10 @@
     "type": "key-step",
     "title": "The gaps telescope to n − 2",
     "content": "gap n k = E n (k+1) − E n k. Summing over k < φ(n) − 1, Finset.sum_range_sub (the additive-group telescoping lemma ∑(f(i+1) − f i) = f n − f 0) collapses the sum to E(φ(n)−1) − E(0) = (n−1) − 1 = n − 2. This is the total feeding Cauchy–Schwarz. Working over ℝ (not truncated ℕ subtraction) is what makes the group telescoping lemma applicable.",
-    "mathContext": "$\\sum_{k} (a_{k+1}-a_k) = a_{\\varphi(n)} - a_1 = (n-1) - 1 = n - 2$."
+    "mathContext": "$\\sum_{k} (a_{k+1}-a_k) = a_{\\varphi(n)} - a_1 = (n-1) - 1 = n - 2$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "Finset.sum_range_sub", "additive group", "real vs ℕ subtraction"],
+    "prerequisites": ["telescoping sums", "the endpoint values"]
   },
   {
     "id": "ann-erdos220oq01-bound",
@@ -51,6 +66,9 @@
     "type": "key-step",
     "title": "Cauchy–Schwarz closes the lower bound",
     "content": "Chebyshev's special case sq_sum_le_card_mul_sum_sq gives (∑ gap)² ≤ (#gaps)·∑ gap². With #gaps = φ(n) − 1 (Finset.card_range) and ∑ gap = n − 2 (sum_gaps), this is exactly (n−2)² ≤ (φ(n)−1)·∑ gap² (sq_le_card_mul_sumSq, division-free). The headline sumSquaredGaps_lower_bound then divides through: for n ≥ 3, φ(n) ≥ 2 (Nat.totient_eq_one_iff rules out φ(n) = 1), so the denominator φ(n) − 1 is positive and div_le_iff₀ applies.",
-    "mathContext": "$(\\sum g_i)^2 \\le m\\sum g_i^2$ with $m=\\varphi(n)-1$ and $\\sum g_i = n-2$ gives $\\sum g_i^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1}$."
+    "mathContext": "$(\\sum g_i)^2 \\le m\\sum g_i^2$ with $m=\\varphi(n)-1$ and $\\sum g_i = n-2$ gives $\\sum g_i^2 \\ge \\dfrac{(n-2)^2}{\\varphi(n)-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy–Schwarz", "Chebyshev sum inequality", "sq_sum_le_card_mul_sum_sq", "div_le_iff₀"],
+    "prerequisites": ["Cauchy–Schwarz inequality", "totient lower bounds"]
   }
 ]

--- a/src/data/proofs/erdos-220-oq-01/index.ts
+++ b/src/data/proofs/erdos-220-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos220OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos220Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos220Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos220Oq01Data: ProofData = {
+  proof: erdos220Oq01Proof,
+  annotations: erdos220Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-220-oq-01`.

The entry had 6 good annotations (content + mathContext) but each was missing the depth fields `significance`, `relatedConcepts`, and `prerequisites`; it also lacked **index.ts**, so the proof page rendered "proof not found" on the live site.

## Changes
- **Added `index.ts`** — Vite entry point so the proof loads.
- **Deepened `annotations.json`** — added `significance`, `relatedConcepts`, and `prerequisites` to all 6 annotations (context, card = φ(n), extreme residues, orderEmbOfFin enumeration, telescoping, Cauchy–Schwarz). Existing content and mathContext preserved verbatim.

Axiom integrity unchanged: no Lean source changes.