### PR TITLE
research(lifting-the-exponent-oq-02-oq-01): LTE for sums xⁿ+yⁿ at p=2 + all-primes dispatch [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LiftingTheExponentOQ02OQ01.lean
+++ b/proofs/Proofs/LiftingTheExponentOQ02OQ01.lean
@@ -1,0 +1,208 @@
+import Mathlib.NumberTheory.Multiplicity
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Tactic
+
+/-
+# Lifting the Exponent for **sums** `xⁿ + yⁿ`, the even prime `p = 2`, and an
+all-primes dispatch
+
+The companion file `LiftingTheExponentOQ02` computes `v₂(xⁿ - yⁿ)`. This file
+handles the **sum** `xⁿ + yⁿ`, where the behaviour at `p = 2` splits sharply on
+the parity of the exponent:
+
+* **`n` odd.**  `v₂(xⁿ + yⁿ) = v₂(x + y)` — exactly the odd-prime sum shape with
+  no `v₂(n)` correction, because `2 ∤ n`. This is obtained from the *general*
+  prime lemma `emultiplicity_pow_sub_pow_of_prime` (valid for **every** prime,
+  `p` included, as long as `p ∤ n`) via `xⁿ + yⁿ = xⁿ - (-y)ⁿ`.
+
+* **`n` even (and `n ≠ 0`).**  For odd `x, y`,
+  `xⁿ + yⁿ ≡ 2 (mod 8)`, so `v₂(xⁿ + yⁿ) = 1` *exactly*, independent of `x, y`
+  and `n`. The mechanism is the classical `odd² ≡ 1 (mod 8)`.
+
+Mathlib supplies the **odd-prime** sum LTE `Int.emultiplicity_pow_add_pow`
+(which carries a `+ vₚ(n)` term) but no `p = 2` sum statement. We fill that gap
+and then package everything into a single **all-primes dispatch**
+`emultiplicity_pow_add_pow_odd_exp`: for *any* prime `p` and *odd* exponent `n`,
+
+  vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n),
+
+which specialises to `v₂(x + y)` at `p = 2` precisely because `v₂(n) = 0` for
+odd `n`. The contribution is the `p = 2` analysis (both parities) and the
+uniform statement; the odd-prime core is Mathlib's.
+-/
+
+namespace LiftingTheExponentOQ02OQ01
+
+variable {x y : ℤ} {n : ℕ}
+
+/-! ### Arithmetic helpers -/
+
+/-- Two odd integers sum to an even integer. -/
+theorem two_dvd_add_of_not_dvd (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) :
+    (2 : ℤ) ∣ x + y := by
+  rcases Int.even_or_odd x with hex | hox
+  · exact absurd hex.two_dvd hx
+  rcases Int.even_or_odd y with hey | hoy
+  · exact absurd hey.two_dvd hy
+  obtain ⟨a, rfl⟩ := hox
+  obtain ⟨b, rfl⟩ := hoy
+  exact ⟨a + b + 1, by ring⟩
+
+/-- If `2 ∤ x` and `2 ∣ x + y` then `2 ∤ y`. -/
+theorem not_dvd_right_of_dvd_add (hx : ¬(2 : ℤ) ∣ x) (hxy : (2 : ℤ) ∣ x + y) :
+    ¬(2 : ℤ) ∣ y := by
+  intro hy
+  exact hx (by simpa using (Dvd.dvd.sub hxy hy))
+
+/-- An integer not divisible by `2` is odd. -/
+theorem odd_of_not_two_dvd {a : ℤ} (ha : ¬(2 : ℤ) ∣ a) : Odd a := by
+  rcases Int.even_or_odd a with h | h
+  · exact absurd h.two_dvd ha
+  · exact h
+
+/-- `¬ (2 : ℤ) ∣ ↑n` for odd `n`. -/
+theorem two_not_dvd_cast_of_odd (hn : Odd n) : ¬(2 : ℤ) ∣ (n : ℤ) := by
+  obtain ⟨m, rfl⟩ := hn
+  push_cast
+  omega
+
+/-- **Odd squares are `1` mod `8`.** For any odd integer `a`, `a² ≡ 1 [ZMOD 8]`. -/
+theorem odd_sq_modEq_eight {a : ℤ} (ha : Odd a) : a ^ 2 ≡ 1 [ZMOD 8] := by
+  obtain ⟨k, rfl⟩ := ha
+  obtain ⟨j, hj⟩ := Int.even_mul_succ_self k
+  refine (Int.modEq_iff_dvd.mpr ⟨-j, ?_⟩)
+  -- 1 - (2k+1)^2 = 8 * (-j),  using k*(k+1) = j + j
+  linear_combination (-4 : ℤ) * hj
+
+/-! ### The odd-exponent case at `p = 2` -/
+
+/-- **Sum LTE at `p = 2`, odd exponent (`emultiplicity` form).**
+For odd `x, y` and odd `n`, `v₂(xⁿ + yⁿ) = v₂(x + y)`. There is no `v₂(n)`
+correction because `2 ∤ n`. -/
+theorem two_emultiplicity_pow_add_pow_odd
+    (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) (hn : Odd n) :
+    emultiplicity 2 (x ^ n + y ^ n) = emultiplicity 2 (x + y) := by
+  have hxy : (2 : ℤ) ∣ x + y := two_dvd_add_of_not_dvd hx hy
+  rw [← sub_neg_eq_add] at hxy
+  rw [← sub_neg_eq_add, ← sub_neg_eq_add, ← Odd.neg_pow hn]
+  exact emultiplicity_pow_sub_pow_of_prime Int.prime_two hxy hx (two_not_dvd_cast_of_odd hn)
+
+/-! ### The even-exponent case at `p = 2` -/
+
+/-- For odd `x` and even `n`, `xⁿ ≡ 1 [ZMOD 8]`. -/
+theorem odd_pow_even_modEq_eight (hx : ¬(2 : ℤ) ∣ x) (hn : Even n) :
+    x ^ n ≡ 1 [ZMOD 8] := by
+  obtain ⟨m, rfl⟩ := hn
+  have hox : Odd x := odd_of_not_two_dvd hx
+  have hoxm : Odd (x ^ m) := hox.pow
+  have h := odd_sq_modEq_eight hoxm
+  calc x ^ (m + m) = (x ^ m) ^ 2 := by ring
+    _ ≡ 1 [ZMOD 8] := h
+
+/-- **Sum LTE at `p = 2`, even exponent (`emultiplicity` form).**
+For odd `x, y` and even `n ≠ 0`, `v₂(xⁿ + yⁿ) = 1` exactly: the sum is
+`≡ 2 (mod 8)`. -/
+theorem two_emultiplicity_pow_add_pow_even
+    (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) (hn : Even n) :
+    emultiplicity 2 (x ^ n + y ^ n) = 1 := by
+  have hmod : x ^ n + y ^ n ≡ 2 [ZMOD 8] := by
+    have hx8 := odd_pow_even_modEq_eight hx hn
+    have hy8 := odd_pow_even_modEq_eight hy hn
+    calc x ^ n + y ^ n ≡ 1 + 1 [ZMOD 8] := hx8.add hy8
+      _ = 2 := by ring
+  -- extract z = 8 t + 2
+  obtain ⟨t, ht⟩ : ∃ t, x ^ n + y ^ n = 8 * t + 2 := by
+    obtain ⟨c, hc⟩ := (Int.modEq_iff_dvd.mp hmod)
+    exact ⟨-c, by linarith⟩
+  have h2 : (2 : ℤ) ^ 1 ∣ x ^ n + y ^ n := ⟨4 * t + 1, by rw [ht]; ring⟩
+  have h4 : ¬(2 : ℤ) ^ (1 + 1) ∣ x ^ n + y ^ n := by
+    rintro ⟨s, hs⟩
+    rw [ht] at hs
+    omega
+  have : emultiplicity (2 : ℤ) (x ^ n + y ^ n) = ((1 : ℕ) : ℕ∞) :=
+    emultiplicity_eq_coe.mpr ⟨h2, h4⟩
+  simpa using this
+
+/-! ### All-primes dispatch (odd exponent) -/
+
+/-- **Unified sum LTE for an odd exponent, every prime.**
+For a prime `p`, odd `n`, with `p ∣ x + y` and `p ∤ x`,
+
+  vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n).
+
+For odd primes this is Mathlib's `Int.emultiplicity_pow_add_pow`; for `p = 2`
+the `vₚ(n)` term vanishes (`2 ∤ n`) and it reduces to
+`two_emultiplicity_pow_add_pow_odd`. -/
+theorem emultiplicity_pow_add_pow_odd_exp
+    {p : ℕ} (hp : p.Prime) (hx : ¬(p : ℤ) ∣ x) (hxy : (p : ℤ) ∣ x + y) (hn : Odd n) :
+    emultiplicity (p : ℤ) (x ^ n + y ^ n)
+      = emultiplicity (p : ℤ) (x + y) + emultiplicity p n := by
+  rcases eq_or_ne p 2 with hp2 | hp2
+  · subst hp2
+    have hx' : ¬(2 : ℤ) ∣ x := by simpa using hx
+    have hxy' : (2 : ℤ) ∣ x + y := by simpa using hxy
+    have hy : ¬(2 : ℤ) ∣ y := not_dvd_right_of_dvd_add hx' hxy'
+    have hzero : emultiplicity 2 n = 0 :=
+      emultiplicity_eq_zero.mpr (by have := Nat.odd_iff.mp hn; omega)
+    rw [hzero, add_zero]
+    simpa using two_emultiplicity_pow_add_pow_odd hx' hy hn
+  · have hp1 : Odd p := hp.odd_of_ne_two hp2
+    exact Int.emultiplicity_pow_add_pow hp hp1 hxy hx hn
+
+/-! ### `padicValInt` (schoolbook `v₂`) forms -/
+
+/-- For odd `x, y`, odd `n`, with `x + y ≠ 0`, the sum `xⁿ + yⁿ` is nonzero. -/
+theorem pow_add_pow_ne_zero_odd
+    (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) (hn : Odd n) (hadd : x + y ≠ 0) :
+    x ^ n + y ^ n ≠ 0 := by
+  intro h0
+  have key := two_emultiplicity_pow_add_pow_odd hx hy hn
+  rw [h0, emultiplicity_zero] at key
+  have hfin : FiniteMultiplicity (2 : ℤ) (x + y) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hadd⟩
+  rw [hfin.emultiplicity_eq_multiplicity] at key
+  exact (ENat.coe_ne_top _) key.symm
+
+/-- **Sum LTE at `p = 2`, odd exponent (`padicValInt` form).**
+For odd `x, y`, odd `n`, and `x + y ≠ 0`, `v₂(xⁿ + yⁿ) = v₂(x + y)`. -/
+theorem two_padicValInt_pow_add_pow_odd
+    (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) (hn : Odd n) (hadd : x + y ≠ 0) :
+    padicValInt 2 (x ^ n + y ^ n) = padicValInt 2 (x + y) := by
+  have hne0 : x ^ n + y ^ n ≠ 0 := pow_add_pow_ne_zero_odd hx hy hn hadd
+  have key := two_emultiplicity_pow_add_pow_odd hx hy hn
+  have hfin_lhs : FiniteMultiplicity (2 : ℤ) (x ^ n + y ^ n) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hne0⟩
+  have hfin_add : FiniteMultiplicity (2 : ℤ) (x + y) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hadd⟩
+  rw [hfin_lhs.emultiplicity_eq_multiplicity, hfin_add.emultiplicity_eq_multiplicity] at key
+  have hmul : multiplicity (2 : ℤ) (x ^ n + y ^ n) = multiplicity (2 : ℤ) (x + y) := by
+    exact_mod_cast key
+  rw [padicValInt.of_ne_one_ne_zero (by decide) hne0,
+      padicValInt.of_ne_one_ne_zero (by decide) hadd]
+  exact_mod_cast hmul
+
+/-- **Sum LTE at `p = 2`, even exponent (`padicValInt` form).**
+For odd `x, y` and even `n ≠ 0`, `v₂(xⁿ + yⁿ) = 1`. -/
+theorem two_padicValInt_pow_add_pow_even
+    (hx : ¬(2 : ℤ) ∣ x) (hy : ¬(2 : ℤ) ∣ y) (hn : Even n) :
+    padicValInt 2 (x ^ n + y ^ n) = 1 := by
+  have hne0 : x ^ n + y ^ n ≠ 0 := by
+    intro h0
+    -- sum of two odds is even, so cannot be 0? we instead use it's 2 mod 8 hence ≠0
+    have hmod : x ^ n + y ^ n ≡ 2 [ZMOD 8] := by
+      have hx8 := odd_pow_even_modEq_eight hx hn
+      have hy8 := odd_pow_even_modEq_eight hy hn
+      calc x ^ n + y ^ n ≡ 1 + 1 [ZMOD 8] := hx8.add hy8
+        _ = 2 := by ring
+    rw [h0] at hmod
+    have : (8 : ℤ) ∣ (2 - 0) := (Int.modEq_iff_dvd.mp hmod)
+    omega
+  have hemul := two_emultiplicity_pow_add_pow_even hx hy hn
+  have hfin_lhs : FiniteMultiplicity (2 : ℤ) (x ^ n + y ^ n) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hne0⟩
+  rw [hfin_lhs.emultiplicity_eq_multiplicity] at hemul
+  have hmul : multiplicity (2 : ℤ) (x ^ n + y ^ n) = 1 := by exact_mod_cast hemul
+  rw [padicValInt.of_ne_one_ne_zero (by decide) hne0]
+  exact_mod_cast hmul
+
+end LiftingTheExponentOQ02OQ01

--- a/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "lifting-the-exponent-oq-02-oq-01",
+  "slug": "lifting-the-exponent-oq-02-oq-01",
+  "title": "Lifting the Exponent for Sums $x^n + y^n$ at $p = 2$, and an All-Primes Dispatch",
+  "description": "Answers both open questions of the parent entry lifting-the-exponent-oq-02 (which computes v₂(xⁿ − yⁿ)). It derives the sum companion v₂(xⁿ + yⁿ) for the even prime, where the behaviour splits sharply on the parity of the exponent: for odd n, v₂(xⁿ + yⁿ) = v₂(x + y) with no v₂(n) correction (since 2 ∤ n); for even n ≠ 0 and odd x, y, the sum is ≡ 2 (mod 8), so v₂(xⁿ + yⁿ) = 1 exactly, independent of x, y, n — driven by the classical odd² ≡ 1 (mod 8). Mathlib supplies the odd-prime sum LTE Int.emultiplicity_pow_add_pow but no p = 2 sum statement; this entry fills that gap. It then packages OQ-01 (odd p) and the p = 2 result into a single all-primes dispatch: for any prime p and odd n with p ∣ x + y, p ∤ x, vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n), specialising to v₂(x + y) at p = 2 precisely because vₚ(n) = 0 there. Both emultiplicity and schoolbook padicValInt forms are given. Fully machine-checked: 12 theorems, 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "The Lifting-the-Exponent (LTE) lemma computes the exact p-adic valuation of xⁿ ± yⁿ. The difference case is classical and uniform across primes; the sum case xⁿ + yⁿ is governed by the substitution xⁿ + yⁿ = xⁿ − (−y)ⁿ, valid for odd n. The even prime p = 2 is the structurally exceptional case throughout LTE: for differences a v₂(x + y) correction and a −1 shift appear (the parent entry), and for sums the exponent parity becomes decisive. Olympiad and competition number theory treat the p = 2 sum case as a separate rule precisely because of this split; this entry formalizes it and unifies it with the odd-prime theory.",
+    "problemStatement": "**Open Questions (lifting-the-exponent-oq-02):** (1) derive the xⁿ + yⁿ companion for the even prime, reconciling the odd-n and even-n behaviour in one statement; (2) combine OQ-01 (odd p) and OQ-02 (p = 2) into a single dispatching theorem covering all primes. This entry settles both.",
+    "text": "For odd x, y: if n is odd then v₂(xⁿ + yⁿ) = v₂(x + y); if n is even (n ≠ 0) then v₂(xⁿ + yⁿ) = 1. Uniformly, for any prime p, odd n, p ∣ x + y, p ∤ x: vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n).",
+    "proofStrategy": "Odd exponent at p = 2: rewrite xⁿ + yⁿ = xⁿ − (−y)ⁿ and invoke Mathlib's general prime lemma `emultiplicity_pow_sub_pow_of_prime` (valid for every prime when p ∤ n, and 2 ∤ n for odd n). Even exponent at p = 2: for odd x, the square (xᵐ)² ≡ 1 (mod 8) gives xⁿ ≡ 1 (mod 8), so xⁿ + yⁿ ≡ 2 (mod 8); writing the sum as 8t + 2 shows 2¹ ∥ (xⁿ + yⁿ), i.e. emultiplicity = 1. The all-primes dispatch case-splits on p = 2 (where emultiplicity 2 n = 0 collapses the correction) versus odd p (Mathlib's `Int.emultiplicity_pow_add_pow`). Finite-multiplicity bridges (`Int.finiteMultiplicity_iff`, `FiniteMultiplicity.emultiplicity_eq_multiplicity`) transfer the emultiplicity statements to the schoolbook `padicValInt` forms.",
+    "keyInsights": [
+      "**Odd exponent erases the correction.** v₂(xⁿ + yⁿ) = v₂(x + y) with no +v₂(n) term, because 2 ∤ n for odd n — the same shape as the odd-prime sum LTE but with the correction automatically zero. The substitution xⁿ + yⁿ = xⁿ − (−y)ⁿ reduces the sum case to the difference case Mathlib already covers for general primes.",
+      "**Even exponent freezes the valuation at 1.** For odd x, y and even n, xⁿ + yⁿ ≡ 2 (mod 8), so v₂ is exactly 1 regardless of x, y, n. This is the LTE 'exception within the exception': no valuation growth at all, controlled entirely by odd² ≡ 1 (mod 8).",
+      "**One theorem, all primes.** `emultiplicity_pow_add_pow_odd_exp` unifies the odd-prime sum LTE and the p = 2 case for odd exponents into vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n); the even prime is not a special case to remember but a corollary where vₚ(n) vanishes.",
+      "**emultiplicity vs padicValInt.** The core is proved in `emultiplicity` (ℕ∞-valued, total) and then transferred to `padicValNat`/`padicValInt` under explicit nonzero hypotheses — the standard discipline for valuations of expressions that could in principle vanish."
+    ],
+    "prerequisites": [
+      "p-adic valuation of integers (`emultiplicity`, `multiplicity`, `padicValInt`)",
+      "The Lifting-the-Exponent lemma for differences and the odd-prime sum form",
+      "Modular arithmetic: odd² ≡ 1 (mod 8)",
+      "Mathlib's `emultiplicity_pow_sub_pow_of_prime` and `Int.emultiplicity_pow_add_pow`"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-helpers",
+      "title": "Overview, Imports, and Arithmetic Helpers",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Module docstring laying out the odd-n / even-n split at p = 2 and the all-primes goal. Imports `Mathlib.NumberTheory.Multiplicity` and `Mathlib.NumberTheory.Padics.PadicVal.Basic`. Helper lemmas: two odds sum to an even (`two_dvd_add_of_not_dvd`), the third-odd consequence (`not_dvd_right_of_dvd_add`), not-2-divisible ⇒ odd, odd n casts to a non-2-divisible integer, and the keystone `odd_sq_modEq_eight` (a² ≡ 1 mod 8 for odd a, via k(k+1) even and `linear_combination`)."
+    },
+    {
+      "id": "odd-exponent",
+      "title": "Odd Exponent at p = 2",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "`two_emultiplicity_pow_add_pow_odd`: for odd x, y and odd n, v₂(xⁿ + yⁿ) = v₂(x + y). Proof rewrites xⁿ + yⁿ = xⁿ − (−y)ⁿ (`Odd.neg_pow`) and applies the general-prime difference lemma `emultiplicity_pow_sub_pow_of_prime` with 2 ∤ n."
+    },
+    {
+      "id": "even-exponent",
+      "title": "Even Exponent at p = 2",
+      "startLine": 90,
+      "endLine": 124,
+      "summary": "`odd_pow_even_modEq_eight` (xⁿ ≡ 1 mod 8 for odd x, even n) and `two_emultiplicity_pow_add_pow_even`: for odd x, y and even n, v₂(xⁿ + yⁿ) = 1. The sum is shown ≡ 2 (mod 8), rewritten as 8t + 2, and pinned to emultiplicity 1 via `emultiplicity_eq_coe` (2¹ divides, 2² does not)."
+    },
+    {
+      "id": "all-primes",
+      "title": "All-Primes Dispatch and padicValInt Forms",
+      "startLine": 126,
+      "endLine": 208,
+      "summary": "`emultiplicity_pow_add_pow_odd_exp`: for any prime p, odd n, p ∣ x + y, p ∤ x, vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n) (case-split p = 2 with the correction collapsing vs odd p via Mathlib). Then nonzero-ness (`pow_add_pow_ne_zero_odd`) and the schoolbook `padicValInt` restatements `two_padicValInt_pow_add_pow_odd` (= v₂(x + y)) and `two_padicValInt_pow_add_pow_even` (= 1), transferred via finite-multiplicity bridges."
+    }
+  ],
+  "conclusion": {
+    "summary": "The p = 2 sum case of Lifting-the-Exponent is fully formalized: v₂(xⁿ + yⁿ) = v₂(x + y) for odd n and = 1 for even n (odd x, y), in both emultiplicity and padicValInt forms, plus an all-primes dispatch vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n) for odd exponents that subsumes the odd-prime and p = 2 cases uniformly. 12 theorems, 208 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the LTE picture for sums alongside the parent's difference treatment: every prime and both exponent parities are now covered by machine-checked statements. The all-primes dispatch is the form usable in downstream divisibility and order-of-element arguments (e.g. when bounding 2-adic valuations in cyclotomic and Fermat-type problems) without remembering p = 2 as a special case. The odd² ≡ 1 (mod 8) keystone is reusable for other even-prime valuation computations.",
+    "openQuestions": [
+      "State the even-exponent sum at p = 2 without the 'odd x, y' hypothesis: factor out the common 2-power, reducing the general case xⁿ + yⁿ to the odd-residual case treated here.",
+      "Give the matching padicValInt form of the all-primes dispatch (currently emultiplicity-only) under explicit nonzero hypotheses, completing the schoolbook-valuation API across all primes.",
+      "Combine the difference dispatch (OQ-01/OQ-02) and this sum dispatch into one signed statement vₚ(xⁿ − sⁿyⁿ) with s = ±1, branching on the sign and the parities of p and n."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lifting-the-exponent-oq-02",
+      "relationship": "parent",
+      "description": "The parent computes v₂(xⁿ − yⁿ) (the difference at p = 2) and poses two open questions: the xⁿ + yⁿ companion and an all-primes dispatch. This entry answers both — the p = 2 sum LTE (both exponent parities) and the unified vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n)."
+    },
+    {
+      "targetId": "lifting-the-exponent-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-01 packages the odd-prime LTE vₚ(xⁿ ± yⁿ) = vₚ(x ± y) + vₚ(n). This entry handles the even prime sum case and folds OQ-01's odd-prime sum statement into the same all-primes dispatch."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 208,
+    "path": "Proofs/LiftingTheExponentOQ02OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 12
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius researcher (2026); odd-prime core from Mathlib, p = 2 sum analysis original",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lifting-the-exponent_lemma",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LiftingTheExponentOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "lifting-the-exponent",
+      "p-adic-valuation",
+      "multiplicity",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 208,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries — every theorem depends only on the foundational propext / Classical.choice / Quot.sound (confirmed via `#print axioms`). `decide` discharges only tiny numeric facts like (2 : ℤ).natAbs ≠ 1 via kernel reduction; no `native_decide`, so no `Lean.ofReduceBool`. The odd-prime sum core uses Mathlib's `Int.emultiplicity_pow_add_pow` and `emultiplicity_pow_sub_pow_of_prime`; the p = 2 sum analysis (both exponent parities) and the all-primes dispatch are original.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "emultiplicity_pow_sub_pow_of_prime",
+        "description": "The general-prime difference LTE: for a prime p with p ∣ x − y, p ∤ x, p ∤ n, emultiplicity p (xⁿ − yⁿ) = emultiplicity p (x − y). Applied at p = 2 (which is allowed since 2 ∤ n for odd n) after rewriting xⁿ + yⁿ = xⁿ − (−y)ⁿ.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Int.emultiplicity_pow_add_pow",
+        "description": "The odd-prime sum LTE carrying the +vₚ(n) correction; the odd-p branch of the all-primes dispatch.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Int.finiteMultiplicity_iff",
+        "description": "Characterizes finite multiplicity (p not a unit and the argument nonzero); used to bridge `emultiplicity` results to `multiplicity`/`padicValInt` under nonzero hypotheses.",
+        "module": "Mathlib.RingTheory.Multiplicity"
+      },
+      {
+        "theorem": "Int.ModEq",
+        "description": "Integer congruence machinery (`Int.modEq_iff_dvd`, `Int.ModEq.add`) for the odd² ≡ 1 (mod 8) and xⁿ + yⁿ ≡ 2 (mod 8) computations.",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "`two_emultiplicity_pow_add_pow_odd`: the p = 2 sum LTE for odd exponents, v₂(xⁿ + yⁿ) = v₂(x + y), obtained by reducing the sum to a difference via xⁿ + yⁿ = xⁿ − (−y)ⁿ. Mathlib has the odd-prime sum LTE but no p = 2 statement.",
+      "`two_emultiplicity_pow_add_pow_even`: the even-exponent collapse v₂(xⁿ + yⁿ) = 1 (odd x, y), from xⁿ + yⁿ ≡ 2 (mod 8) via the keystone `odd_sq_modEq_eight`.",
+      "`emultiplicity_pow_add_pow_odd_exp`: the all-primes dispatch vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n) for odd n, unifying the odd-prime LTE and the p = 2 case (where the correction vanishes) into one theorem — the parent's second open question.",
+      "`two_padicValInt_pow_add_pow_odd` and `two_padicValInt_pow_add_pow_even`: the schoolbook `padicValInt` forms under explicit nonzero hypotheses (with `pow_add_pow_ne_zero_odd`), making the results usable in concrete divisibility arguments."
+    ],
+    "prerequisites": [
+      "p-adic valuation of integers (emultiplicity / multiplicity / padicValInt)",
+      "Lifting-the-Exponent for differences and the odd-prime sum form",
+      "odd² ≡ 1 (mod 8) and integer modular arithmetic"
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "lifting-the-exponent-oq-02",
+        "relationship": "Parent: computes v₂(xⁿ − yⁿ); this entry answers its two open questions (the xⁿ + yⁿ companion at p = 2 and the all-primes dispatch)."
+      },
+      {
+        "id": "lifting-the-exponent-oq-01",
+        "relationship": "Sibling: the odd-prime LTE, folded into this entry's unified all-primes dispatch."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **both** open questions of the parent entry `lifting-the-exponent-oq-02` (which computes v₂(xⁿ − yⁿ)):

1. **The sum companion at the even prime.** For odd `x, y`:
   - `n` odd → `v₂(xⁿ + yⁿ) = v₂(x + y)` (no `v₂(n)` correction, since `2 ∤ n`; via `xⁿ + yⁿ = xⁿ − (−y)ⁿ` reduced to Mathlib's general-prime difference LTE).
   - `n` even (`n ≠ 0`) → `v₂(xⁿ + yⁿ) = 1` exactly (`xⁿ + yⁿ ≡ 2 (mod 8)`, keystone `odd² ≡ 1 (mod 8)`).
2. **The all-primes dispatch.** For any prime `p`, odd `n`, `p ∣ x + y`, `p ∤ x`:
   `vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n)` — the `p = 2` case is the corollary where `vₚ(n) = 0`.

Mathlib supplies the odd-prime sum LTE (`Int.emultiplicity_pow_add_pow`) but **no `p = 2` sum statement**; this entry fills that gap. Results are given in both `emultiplicity` and schoolbook `padicValInt` forms.

## Verification

- **12 theorems, 208 lines, 0 sorries, 0 axioms.**
- `#print axioms` on the main results lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool` (the `decide` calls are kernel reductions over tiny numeric facts, not `native_decide`).
- Typechecks against Mathlib 4.26.0.

## Files

- `proofs/Proofs/LiftingTheExponentOQ02OQ01.lean`
- `src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)