### PR TITLE
research(jacobi-symbol-oq-01-oq-03): J(a|n)=1 parity characterization [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3096,6 +3096,7 @@ import Proofs.IsoscelesTriangleOQ02
 import Proofs.IsoscelesTriangleOQ01
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
+import Proofs.JacobiSymbolOQ0103
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01
 import Proofs.JensenInequalityOQ01OQ01OQ01OQ01

--- a/proofs/Proofs/JacobiSymbolOQ0103.lean
+++ b/proofs/Proofs/JacobiSymbolOQ0103.lean
@@ -1,0 +1,143 @@
+/-
+  Jacobi symbol `J(a | n) = 1` as a PARITY count of non-residue prime factors.
+
+  The Jacobi symbol is the product of Legendre symbols over the prime factors of
+  the (odd) modulus `n`, *taken with multiplicity*:
+
+      `J(a | n) = ∏_{p ∣ n} (a | p)`   (each `p` repeated `vₚ(n)` times).
+
+  When `gcd(a, n) = 1` every factor `(a | p)` is `±1`, so the whole product is a
+  sign determined entirely by HOW MANY of those factors equal `-1`.  Writing
+  `k = #{p ∣ n (with multiplicity) : (a | p) = -1}` we obtain the clean dichotomy
+
+      `J(a | n) = (-1)^k`,   hence   `J(a | n) = 1  ↔  k is even`.
+
+  This is the structural fact behind the parent entry's puzzle `J(2 | 15) = 1`
+  with `2` a genuine non-residue mod `15`:  both prime factors `3` and `5` are
+  non-residue witnesses (`(2|3) = (2|5) = -1`), and `2` of them is an EVEN number,
+  so the two `-1`'s cancel.  This is exactly why the Jacobi symbol produces
+  "false witnesses" in the Solovay–Strassen primality test: an even number of
+  non-residue prime factors hides the non-residuosity of `a`.
+
+  A subtlety the title's set-notation `#{p ∣ n}` glosses over: the count must be
+  taken **with multiplicity**.  For `n = 45 = 3² · 5` the distinct bad primes are
+  `{3, 5}` (count `2`, even) yet `J(2 | 45) = -1`; the multiplicity-aware count is
+  `3` (odd), the list `[3, 3, 5]`.  We work with `Nat.primeFactorsList`, which
+  carries multiplicity, so the statement is correct for every modulus.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Nat ZMod
+
+namespace JacobiSymbolOQ0103
+
+/-! ### The list of Legendre symbols over the prime factors of `n` -/
+
+/-- The Legendre symbols `(a | p)` as `p` ranges over the prime factors of `n`
+**with multiplicity**.  By definition `jacobiSym a n` is the product of this
+list. -/
+def legVals (a : ℤ) (n : ℕ) : List ℤ :=
+  n.primeFactorsList.pmap (fun p pp => @legendreSym p ⟨pp⟩ a)
+    (fun _ pf => prime_of_mem_primeFactorsList pf)
+
+/-- `jacobiSym a n` is literally the product of the Legendre-symbol list. -/
+theorem jacobiSym_eq_legVals_prod (a : ℤ) (n : ℕ) :
+    jacobiSym a n = (legVals a n).prod := rfl
+
+/-- When `gcd(a, n) = 1`, every Legendre symbol over a prime factor of `n` is a
+genuine sign `±1` (none vanish, since no prime factor of `n` divides `a`). -/
+theorem legVals_mem_eq_one_or_neg_one {a : ℤ} {n : ℕ} (cop : a.gcd n = 1)
+    {x : ℤ} (hx : x ∈ legVals a n) : x = 1 ∨ x = -1 := by
+  rw [legVals, List.mem_pmap] at hx
+  obtain ⟨p, hp, rfl⟩ := hx
+  have hpp : p.Prime := prime_of_mem_primeFactorsList hp
+  haveI : Fact p.Prime := ⟨hpp⟩
+  apply legendreSym.eq_one_or_neg_one
+  rw [Ne, intCast_zmod_eq_zero_iff_dvd]
+  intro hdvd
+  have hn0 : n ≠ 0 := by rintro rfl; simp at hp
+  have hpn : p ∣ n := ((Nat.mem_primeFactorsList hn0).mp hp).2
+  have hpa : p ∣ a.natAbs := by
+    have h := Int.natAbs_dvd_natAbs.mpr hdvd
+    rwa [Int.natAbs_natCast] at h
+  have hdg : p ∣ Nat.gcd a.natAbs n := Nat.dvd_gcd hpa hpn
+  have hcop : Nat.gcd a.natAbs n = 1 := by
+    have h : Int.gcd a (n : ℤ) = Nat.gcd a.natAbs n := by
+      simp [Int.gcd, Int.natAbs_natCast]
+    rwa [h] at cop
+  rw [hcop] at hdg
+  exact hpp.one_lt.ne' (Nat.dvd_one.mp hdg)
+
+/-! ### The product of a list of signs is `(-1)` to the number of `-1`'s -/
+
+/-- For a list of integers each equal to `1` or `-1`, the product equals `-1`
+raised to the number of entries equal to `-1`. -/
+theorem prod_eq_neg_one_pow_count {L : List ℤ}
+    (h : ∀ x ∈ L, x = 1 ∨ x = -1) :
+    L.prod = (-1 : ℤ) ^ (L.count (-1)) := by
+  induction L with
+  | nil => simp
+  | cons x xs ih =>
+      have ih' := ih (fun y hy => h y (List.mem_cons_of_mem x hy))
+      rcases h x (List.mem_cons_self) with hx | hx
+      · subst hx
+        rw [List.prod_cons, ih', List.count_cons_of_ne (by decide : (1 : ℤ) ≠ -1),
+          one_mul]
+      · subst hx
+        rw [List.prod_cons, ih', List.count_cons_self, pow_succ]
+        ring
+
+/-! ### Main results: the parity characterisation -/
+
+/-- The number of prime factors of `n` (counted **with multiplicity**) modulo
+which `a` is a quadratic non-residue, i.e. `#{p ∣ n : (a | p) = -1}`. -/
+def numNonResidueFactors (a : ℤ) (n : ℕ) : ℕ := (legVals a n).count (-1)
+
+/-- **Sign formula.** For coprime `a, n` the Jacobi symbol is `(-1)` raised to
+the number of non-residue prime factors (with multiplicity). -/
+theorem jacobiSym_eq_neg_one_pow (a : ℤ) (n : ℕ) (cop : a.gcd n = 1) :
+    jacobiSym a n = (-1 : ℤ) ^ numNonResidueFactors a n := by
+  rw [jacobiSym_eq_legVals_prod, numNonResidueFactors]
+  exact prod_eq_neg_one_pow_count fun _ hx => legVals_mem_eq_one_or_neg_one cop hx
+
+/-- **Parity characterisation of `J(a|n) = 1`.** For coprime `a, n`, the Jacobi
+symbol equals `1` exactly when an EVEN number of prime factors of `n` (with
+multiplicity) are non-residue witnesses.  This explains how `J(a | n)` can be
+`1` while `a` is a non-residue: the `-1`'s cancel in even number. -/
+theorem jacobiSym_eq_one_iff_even (a : ℤ) (n : ℕ) (cop : a.gcd n = 1) :
+    jacobiSym a n = 1 ↔ Even (numNonResidueFactors a n) := by
+  rw [jacobiSym_eq_neg_one_pow a n cop]
+  exact neg_one_pow_eq_one_iff_even (by decide)
+
+/-- Dually, `J(a | n) = -1` exactly when an ODD number of prime factors are
+non-residue witnesses. -/
+theorem jacobiSym_eq_neg_one_iff_odd (a : ℤ) (n : ℕ) (cop : a.gcd n = 1) :
+    jacobiSym a n = -1 ↔ Odd (numNonResidueFactors a n) := by
+  rw [jacobiSym_eq_neg_one_pow a n cop]
+  constructor
+  · intro hpow
+    rcases Nat.even_or_odd (numNonResidueFactors a n) with he | ho
+    · rw [he.neg_one_pow] at hpow; norm_num at hpow
+    · exact ho
+  · intro ho; exact ho.neg_one_pow
+
+/-! ### Worked examples: multiplicity matters
+
+`J(2 | 15) = 1` with `2` a non-residue mod `15`: an even count (`2`, primes `3, 5`)
+of non-residue witnesses.  `J(2 | 45) = -1`: an odd count (`3`, list `[3,3,5]`),
+showing the count genuinely needs multiplicity — the distinct-prime count `{3,5}`
+is `2` (even) and would give the wrong sign. -/
+
+/-- `J(2 | 15) = 1`, so the number of non-residue prime factors of `15` is even —
+even though `2` is a genuine non-residue mod `15`. -/
+theorem even_numNonResidue_two_fifteen : Even (numNonResidueFactors 2 15) :=
+  (jacobiSym_eq_one_iff_even 2 15 (by decide)).mp (by norm_num)
+
+/-- `J(2 | 45) = -1`, so the **multiplicity-aware** count for `45 = 3² · 5` is odd
+(`3`), whereas the count of *distinct* bad primes `{3, 5}` is `2` (even). -/
+theorem odd_numNonResidue_two_fortyfive : Odd (numNonResidueFactors 2 45) :=
+  (jacobiSym_eq_neg_one_iff_odd 2 45 (by decide)).mp (by norm_num)
+
+end JacobiSymbolOQ0103

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-03/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-module-header",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 29
+    },
+    "title": "Module Header: J(a|n) = 1 as a Parity Count",
+    "content": "Answers the parent entry's open question: characterize exactly when $J(a\\mid n) = 1$ even though $a$ is a non-residue. For coprime $a, n$ the Jacobi symbol is a pure sign $(-1)^k$, where $k = \\#\\{p \\mid n : (a\\mid p) = -1\\}$ counts the prime factors of $n$ **with multiplicity** at which $a$ is a non-residue. So $J(a\\mid n) = 1 \\iff k$ is even — the $-1$'s cancel in pairs. The parent's puzzle $J(2\\mid 15) = 1$ is the case $k = 2$ (both $3$ and $5$ are non-residue witnesses); $J(2\\mid 45) = -1$ is the case $k = 3$ (the list $[3,3,5]$), showing multiplicity is essential."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-legvals",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "definition",
+    "range": {
+      "startLine": 38,
+      "endLine": 47
+    },
+    "title": "The Legendre-Symbol List",
+    "content": "`legVals a n` is the list of Legendre symbols $(a\\mid p)$ as $p$ ranges over `n.primeFactorsList` — the prime factorization of $n$ **as a list, carrying multiplicity**. By the very definition of Mathlib's `jacobiSym`, the Jacobi symbol is the product of this list (`jacobiSym_eq_legVals_prod`, proved by `rfl`). This is the definitional bridge that turns the Jacobi symbol into a counting problem over its prime-factor signs."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-each-sign",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 49,
+      "endLine": 71
+    },
+    "title": "Coprimality Makes Each Factor a Genuine Sign",
+    "content": "`legVals_mem_eq_one_or_neg_one`: when $\\gcd(a,n) = 1$, every entry $(a\\mid p)$ of the list is $\\pm 1$, never $0$. A Legendre symbol $(a\\mid p)$ vanishes iff $p \\mid a$ (`ZMod.intCast_zmod_eq_zero_iff_dvd`); but $p$ is a prime factor of $n$, so $p \\mid a$ would give $p \\mid \\gcd(a,n) = 1$, impossible. This is the hypothesis that lets the product-of-signs argument run."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-product-sign",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 75,
+      "endLine": 90
+    },
+    "title": "Product of ±1's is (-1) to the Count of -1's",
+    "content": "`prod_eq_neg_one_pow_count`: the elementary engine. For any list $L$ of integers each equal to $1$ or $-1$, $\\prod L = (-1)^{\\#\\{x \\in L : x = -1\\}}$. A one-line induction: a head $+1$ leaves both product and count unchanged (`List.count_cons_of_ne`), while a head $-1$ multiplies the product by $-1$ and increments the count by one (`List.count_cons_self`), matching `pow_succ`. Reusable sign-counting infrastructure, independent of number theory."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-sign-formula",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 94,
+      "endLine": 103
+    },
+    "title": "The Sign Formula J(a|n) = (-1)^k",
+    "content": "`numNonResidueFactors a n` is $k = \\#\\{p \\mid n \\text{ (with multiplicity)} : (a\\mid p) = -1\\}$, the count of $-1$ entries in `legVals a n`. Combining the two preceding lemmas, `jacobiSym_eq_neg_one_pow` gives $J(a\\mid n) = (-1)^k$ for coprime $a, n$: the Jacobi symbol is determined entirely by how many prime factors of $n$ (with multiplicity) see $a$ as a non-residue."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-parity",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 105,
+      "endLine": 124
+    },
+    "title": "The Parity Characterization (Main Result)",
+    "content": "`jacobiSym_eq_one_iff_even`: reading the sign formula through `neg_one_pow_eq_one_iff_even`, $J(a\\mid n) = 1 \\iff k$ is even. This is the exact answer to the parent's open question — $J(a\\mid n) = 1$ while $a$ is a non-residue happens precisely when an EVEN (positive) number of prime factors are non-residue witnesses. Dually `jacobiSym_eq_neg_one_iff_odd`: $J(a\\mid n) = -1 \\iff k$ is odd, recovering the classical one-sided obstruction as the odd-parity case."
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-03-examples",
+    "proofId": "jacobi-symbol-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 126,
+      "endLine": 142
+    },
+    "title": "Worked Examples: Multiplicity Matters",
+    "content": "`even_numNonResidue_two_fifteen`: from $J(2\\mid 15) = 1$ the count is even ($k = 2$: both $3$ and $5$ are non-residue witnesses for $2$) — the parent's puzzle, explained. `odd_numNonResidue_two_fortyfive`: from $J(2\\mid 45) = -1$ the **multiplicity-aware** count is odd ($k = 3$, the list $[3,3,5]$), even though only two DISTINCT bad primes occur. The distinct-prime count $\\{3,5\\} = 2$ (even) would predict the wrong sign — so the characterization genuinely requires multiplicity. Both parities are read off the kernel-checked `norm_num` Jacobi values, so no `native_decide` enters."
+  }
+]

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-03/meta.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-03/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "jacobi-symbol-oq-01-oq-03",
+  "title": "When J(a|n) = 1 for a Non-Residue: A Parity Count of Bad Primes",
+  "slug": "jacobi-symbol-oq-01-oq-03",
+  "description": "Characterizes exactly when the Jacobi symbol J(a|n) equals 1 even though a is a quadratic non-residue. For coprime a, n the Jacobi symbol is the sign (-1)^k where k = #{p ∣ n : (a|p) = -1} counts the prime factors of n (WITH MULTIPLICITY) modulo which a is a non-residue. Hence J(a|n) = 1 ⟺ k is even, and J(a|n) = -1 ⟺ k is odd. This explains the parent entry's puzzle J(2|15)=1: both prime factors 3 and 5 are non-residue witnesses ((2|3)=(2|5)=-1) and an even number of -1's cancel. The example J(2|45)=-1 (45=3²·5, count 3 with multiplicity, odd) shows the count genuinely needs multiplicity — the distinct-prime count {3,5} is 2 (even) and gives the wrong sign. 8 theorems, 2 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
+    "date": "Carl Gustav Jacob Jacobi, 1837",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "parity",
+      "solovay-strassen",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/JacobiSymbolOQ0103.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 8 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete values J(2|15)=1 and J(2|45)=-1 are produced by the norm_num Jacobi-symbol extension (kernel-checked); the coprimality side-conditions gcd(2,15)=1 and gcd(2,45)=1 by decide — no native_decide, so no Lean.ofReduceBool.",
+    "originalContributions": [
+      "jacobiSym_eq_neg_one_pow: the SIGN FORMULA J(a|n) = (-1)^k for coprime a, n, where k = numNonResidueFactors a n is the number of prime factors of n (with multiplicity) at which a is a non-residue. This is the structural content answering the parent entry's open question OQ-03.",
+      "jacobiSym_eq_one_iff_even: the PARITY CHARACTERIZATION J(a|n) = 1 ⟺ k is even — the exact answer to 'when is J(a|n) = 1 while a is a non-residue': precisely when an even number of prime factors see a as a non-residue, so the -1's cancel.",
+      "jacobiSym_eq_neg_one_iff_odd: dually J(a|n) = -1 ⟺ k is odd, recovering the one-sided obstruction as the odd-parity case.",
+      "legVals / numNonResidueFactors: the Legendre-symbol list (a|p) over the prime factors of n with multiplicity, and the count of its -1 entries; the bridge making the parity statement precise.",
+      "legVals_mem_eq_one_or_neg_one: under gcd(a,n)=1 every Legendre symbol over a prime factor of n is a genuine sign ±1 (no factor vanishes, since no prime factor of n divides a).",
+      "prod_eq_neg_one_pow_count: the elementary sign-product lemma — a list of ±1's multiplies to (-1)^(number of -1 entries) — isolated as reusable infrastructure.",
+      "even_numNonResidue_two_fifteen / odd_numNonResidue_two_fortyfive: worked examples showing the count must be taken WITH MULTIPLICITY — for 45 = 3²·5 the distinct bad primes {3,5} (count 2, even) would wrongly predict J = 1, while the multiplicity-aware count 3 (odd) correctly gives J(2|45) = -1."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym (definition)",
+        "description": "J(a|n) = (n.primeFactorsList.pmap legendreSym ...).prod — the Jacobi symbol as the product of Legendre symbols over the prime factors of n with multiplicity. jacobiSym_eq_legVals_prod is this unfolding.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "legendreSym.eq_one_or_neg_one",
+        "description": "If (a : ZMod p) ≠ 0 then legendreSym p a = ±1. Drives legVals_mem_eq_one_or_neg_one.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(a : ZMod p) = 0 ↔ (p : ℤ) ∣ a, used to turn coprimality into non-vanishing of each Legendre factor.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "neg_one_pow_eq_one_iff_even",
+        "description": "(-1)^k = 1 ↔ Even k (in a ring with -1 ≠ 1). Converts the sign formula into the parity characterization.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.prime_of_mem_primeFactorsList / Nat.mem_primeFactorsList",
+        "description": "Membership in the prime-factor list means prime and dividing n; supplies the Fact p.Prime instance and the divisibility used in the coprimality argument.",
+        "module": "Mathlib.Data.Nat.Factors"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 143,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Jacobi symbol (Jacobi, 1837) extends the Legendre symbol multiplicatively to composite odd moduli and can be evaluated rapidly by quadratic reciprocity WITHOUT factoring n. The price is that it no longer detects quadratic residues: J(a|n) = 1 does not force a to be a square. The parent entry exhibits this with J(2|15) = 1 and 2 a non-residue mod 15. The natural follow-up — recorded as that entry's third open question — is to characterize EXACTLY when this happens. The answer is a parity count, and it is exactly the mechanism behind the 'false witnesses' of the Solovay–Strassen primality test.",
+    "problemStatement": "**Open Question (parent OQ-03)**: Characterize exactly when J(a|n) = 1 yet a is a non-residue, in terms of the number of prime factors p ∣ n with (a|p) = -1.\n\n**Answer formalized**: For coprime a, n, J(a|n) = (-1)^k where k = #{p ∣ n (with multiplicity) : (a|p) = -1}. Therefore J(a|n) = 1 ⟺ k is even (jacobiSym_eq_one_iff_even) and J(a|n) = -1 ⟺ k is odd (jacobiSym_eq_neg_one_iff_odd). The phenomenon 'J = 1 with a a non-residue' is precisely an even, positive number of non-residue prime factors.",
+    "text": "A 143-line formalization over Mathlib's jacobiSym. The Jacobi symbol is, by definition, the product of the Legendre symbols (a|p) as p ranges over n's prime factors with multiplicity (legVals). Under gcd(a,n) = 1 each such Legendre symbol is a genuine sign ±1 (legVals_mem_eq_one_or_neg_one: a vanishing factor would need a prime factor of n to divide a). A list of ±1's multiplies to (-1) raised to the number of -1 entries (prod_eq_neg_one_pow_count), giving the sign formula J(a|n) = (-1)^k (jacobiSym_eq_neg_one_pow). Reading off the parity yields the two characterizations. Two worked examples make the multiplicity subtlety explicit: J(2|15)=1 has an even count (2: primes 3,5), while J(2|45)=-1 has an odd count (3: the list [3,3,5]) even though only two DISTINCT bad primes occur. All theorems compile with 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "**Sign formula**: unfold jacobiSym as the product of the Legendre-symbol list legVals (jacobiSym_eq_legVals_prod, by rfl). Show every entry is ±1 under coprimality: an entry (a|p) with p ∣ n vanishes iff p ∣ a (ZMod.intCast_zmod_eq_zero_iff_dvd), which together with p ∣ n would force p ∣ gcd(a,n) = 1 — impossible for a prime. Then prod_eq_neg_one_pow_count (a one-line induction using List.count_cons_self and List.count_cons_of_ne) gives prod = (-1)^(count of -1). \n\n**Parity characterization**: rewrite by the sign formula and apply neg_one_pow_eq_one_iff_even (for J = 1) and a short even/odd case split with Odd.neg_one_pow / Even.neg_one_pow (for J = -1).\n\n**Examples**: derive evenness/oddness of the count directly from the characterizations applied to the norm_num values J(2|15) = 1 and J(2|45) = -1 — so the exact Legendre values never need to be computed by decide.",
+    "keyInsights": [
+      "**The Jacobi symbol is a pure sign count**: for coprime arguments J(a|n) = (-1)^k depends only on HOW MANY prime factors of n (with multiplicity) see a as a non-residue — not on which ones, nor on the exponents beyond their parity.",
+      "**'J = 1 with a a non-residue' = even number of bad primes**: the -1's from the non-residue prime factors cancel in pairs. This is the precise answer to the parent's open question, and the exact reason the Jacobi symbol produces false witnesses in Solovay–Strassen.",
+      "**Multiplicity is essential**: for n = 45 = 3²·5 the distinct bad primes {3,5} number 2 (even) but the correct count is 3 (the multiset [3,3,5]), giving J(2|45) = -1. The set-cardinality reading of the question is only valid for squarefree n; the multiplicity-aware list count is correct for every modulus.",
+      "**One-sidedness recovered as parity**: the classical fact 'J(a|n) = -1 ⟹ a is a non-residue' is exactly the odd-parity case (an odd number of -1's cannot cancel), while the even-parity case is where information is lost.",
+      "**0-axiom numerics by design**: the worked examples obtain the parity of the count from the characterization applied to kernel-checked norm_num Jacobi values, so no native_decide and no Lean.ofReduceBool enter the proof."
+    ],
+    "prerequisites": [
+      "The Legendre symbol (a|p) and its values ±1 for p ∤ a (legendreSym.eq_one_or_neg_one)",
+      "The Jacobi symbol jacobiSym a n = ∏_{p ∣ n} (a|p) over the prime factors of n with multiplicity (Mathlib jacobiSym)",
+      "Nat.primeFactorsList (the prime factorization as a list, carrying multiplicity) and its membership lemmas",
+      "List.prod, List.count and the cons lemmas List.count_cons_self / List.count_cons_of_ne",
+      "neg_one_pow_eq_one_iff_even and Even/Odd.neg_one_pow for reading (-1)^k by parity"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "jacobi-symbol-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry exhibits J(2|15) = 1 with 2 a non-residue mod 15 and records, as its third open question, the problem of characterizing exactly when J(a|n) = 1 yet a is a non-residue in terms of the prime factors p ∣ n with (a|p) = -1. This entry answers it: J(a|n) = (-1)^#{p ∣ n (with mult) : (a|p) = -1}, so J = 1 ⟺ that count is even."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "related",
+      "description": "Euler's criterion makes the Legendre symbol a faithful residue test modulo a prime. The parity formula shows precisely how that faithfulness degrades over composite moduli: the per-prime signs survive only through their parity, so an even number of non-residue prime factors is invisible to the Jacobi symbol."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "JacobiSymbolOQ0103",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/JacobiSymbolOQ0103.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "jacobiSym_eq_one_iff_even",
+      "type": "core",
+      "statement": "$\\gcd(a,n)=1 \\Rightarrow \\big(J(a \\mid n) = 1 \\iff \\#\\{p \\mid n : (a\\mid p) = -1\\}\\text{ is even}\\big)$",
+      "significance": "The headline answer to the parent's open question: J(a|n) = 1 exactly when an EVEN number of prime factors of n (with multiplicity) are non-residue witnesses. This is precisely how J(a|n) = 1 can occur while a is a genuine non-residue — the -1's cancel in pairs.",
+      "description": "J(a|n) = 1 ⟺ even count of non-residue prime factors."
+    },
+    {
+      "name": "jacobiSym_eq_neg_one_pow",
+      "type": "core",
+      "statement": "$\\gcd(a,n)=1 \\Rightarrow J(a \\mid n) = (-1)^{\\#\\{p \\mid n : (a\\mid p) = -1\\}}$",
+      "significance": "The sign formula underlying everything: for coprime arguments the Jacobi symbol is determined entirely by the number (with multiplicity) of prime factors at which a is a non-residue.",
+      "description": "J(a|n) = (-1)^k, k = number of non-residue prime factors."
+    },
+    {
+      "name": "jacobiSym_eq_neg_one_iff_odd",
+      "type": "core",
+      "statement": "$\\gcd(a,n)=1 \\Rightarrow \\big(J(a \\mid n) = -1 \\iff \\#\\{p \\mid n : (a\\mid p) = -1\\}\\text{ is odd}\\big)$",
+      "significance": "The dual characterization: the classical one-sided obstruction J(a|n) = -1 ⟹ non-residue is exactly the odd-parity case, where the -1's cannot fully cancel.",
+      "description": "J(a|n) = -1 ⟺ odd count of non-residue prime factors."
+    },
+    {
+      "name": "legVals_mem_eq_one_or_neg_one",
+      "type": "supporting",
+      "statement": "$\\gcd(a,n)=1,\\ x \\in \\mathrm{legVals}(a,n) \\Rightarrow x = 1 \\vee x = -1$",
+      "significance": "Coprimality guarantees every Legendre symbol over a prime factor of n is a genuine sign, never 0 — the hypothesis that makes the product-of-signs argument apply.",
+      "description": "Each Legendre factor is ±1 when gcd(a,n)=1."
+    },
+    {
+      "name": "prod_eq_neg_one_pow_count",
+      "type": "supporting",
+      "statement": "$(\\forall x \\in L,\\ x = \\pm 1) \\Rightarrow \\prod L = (-1)^{\\#\\{x \\in L : x = -1\\}}$",
+      "significance": "The elementary engine: a list of ±1's multiplies to (-1) raised to the number of -1 entries. Reusable sign-counting infrastructure independent of the Jacobi symbol.",
+      "description": "Product of ±1's is (-1)^(number of -1's)."
+    },
+    {
+      "name": "jacobiSym_eq_legVals_prod",
+      "type": "supporting",
+      "statement": "$J(a \\mid n) = \\prod \\mathrm{legVals}(a,n)$",
+      "significance": "Unfolds Mathlib's jacobiSym as the product of the Legendre-symbol list over n's prime factors with multiplicity — the definitional bridge to the counting argument.",
+      "description": "J(a|n) is the product of the Legendre-symbol list."
+    },
+    {
+      "name": "even_numNonResidue_two_fifteen",
+      "type": "supporting",
+      "statement": "$\\#\\{p \\mid 15 : (2\\mid p) = -1\\}\\text{ is even}$",
+      "significance": "The parent's witness explained: J(2|15) = 1 forces an even count — both 3 and 5 are non-residue witnesses for 2, and the two -1's cancel.",
+      "description": "Even non-residue-prime count for J(2|15)=1."
+    },
+    {
+      "name": "odd_numNonResidue_two_fortyfive",
+      "type": "supporting",
+      "statement": "$\\#\\{p \\mid 45 : (2\\mid p) = -1\\}\\text{ (with multiplicity) is odd}$",
+      "significance": "Demonstrates that multiplicity is essential: for 45 = 3²·5 the distinct bad primes {3,5} number 2 (even) but the multiplicity-aware count is 3 (odd), correctly matching J(2|45) = -1.",
+      "description": "Odd multiplicity-count for J(2|45)=-1 (multiplicity matters)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Jacobi, C. G. J. (1837). Über die Kreisteilung und ihre Anwendung auf die Zahlentheorie. The Jacobi symbol as a multiplicative extension of the Legendre symbol.",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "text": "Solovay, R. & Strassen, V. (1977). A fast Monte-Carlo test for primality. The 'false witnesses' of the test are exactly moduli with an even number of non-residue prime factors — the even-parity case characterized here.",
+      "url": "https://en.wikipedia.org/wiki/Solovay%E2%80%93Strassen_primality_test"
+    },
+    {
+      "text": "Mathlib4: jacobiSym, legendreSym.eq_one_or_neg_one, ZMod.intCast_zmod_eq_zero_iff_dvd, neg_one_pow_eq_one_iff_even (NumberTheory/LegendreSymbol/, Data/ZMod/Basic.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the parent entry's open question OQ-03: for coprime a, n the Jacobi symbol is the sign J(a|n) = (-1)^k with k = #{p ∣ n (with multiplicity) : (a|p) = -1}, so J(a|n) = 1 ⟺ k is even and J(a|n) = -1 ⟺ k is odd. The phenomenon 'J(a|n) = 1 while a is a non-residue' is exactly an even, positive number of non-residue prime factors, whose -1's cancel in pairs. Worked examples J(2|15) = 1 (count 2) and J(2|45) = -1 (count 3 with multiplicity) show the count must be taken with multiplicity. All 8 theorems verified with 0 sorries, 0 axioms, no native_decide.",
+    "implications": "The parity formula pinpoints exactly how the Jacobi symbol loses residue-detection over composite moduli: only the parity of the per-prime non-residue signs survives, so an even number of non-residue prime factors becomes invisible. This is the precise source of the false witnesses exploited (and bounded) in the Solovay–Strassen primality test, and it sharpens the parent's one-sided obstruction into a complete two-sided parity criterion.",
+    "openQuestions": [
+      "Specialize the parity formula to squarefree n, where the multiplicity count collapses to the cardinality of the set {p ∣ n : (a|p) = -1}, and count the residue classes a (mod n) with J(a|n) = 1 that are nonetheless non-residues.",
+      "Use the parity characterization to bound the density of Euler liars for a composite modulus n in the Solovay–Strassen test."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `jacobi-symbol-oq-01`:

> *Characterize exactly when J(a|n) = 1 yet a is a non-residue, in terms of the number of prime factors p ∣ n with (a|p) = −1.*

**Answer.** For coprime `a, n` the Jacobi symbol is a pure sign:

$$J(a \mid n) = (-1)^k, \qquad k = \#\{\,p \mid n \text{ (with multiplicity)} : (a\mid p) = -1\,\}.$$

Hence **`J(a|n) = 1 ⟺ k is even`** and **`J(a|n) = -1 ⟺ k is odd`**. The phenomenon "J(a|n) = 1 while `a` is a non-residue" is exactly an **even, positive** number of non-residue prime factors — their `-1` signs cancel in pairs. This is the precise mechanism behind the **false witnesses** of the Solovay–Strassen primality test.

## Why this is substantive

- The parent entry exhibits `J(2|15) = 1` with `2` a genuine non-residue mod 15 as an unexplained puzzle. This entry *explains* it: both `3` and `5` are non-residue witnesses (`(2|3)=(2|5)=-1`), an even count, so the signs cancel.
- **Multiplicity matters** (a subtlety the set-notation `#{p|n}` hides): for `45 = 3²·5` the *distinct* bad primes `{3,5}` count `2` (even) and would wrongly predict `J = 1`, but the multiplicity-aware count is `3` (the list `[3,3,5]`), correctly giving `J(2|45) = -1`. The statement uses `Nat.primeFactorsList`, which carries multiplicity, so it is correct for **every** modulus.

## Contents

- `jacobiSym_eq_neg_one_pow` — the sign formula `J(a|n) = (-1)^k`
- `jacobiSym_eq_one_iff_even` — **main**: `J(a|n) = 1 ⟺ k even`
- `jacobiSym_eq_neg_one_iff_odd` — dual: `J(a|n) = -1 ⟺ k odd`
- `legVals_mem_eq_one_or_neg_one` — coprimality ⟹ each Legendre factor is `±1`
- `prod_eq_neg_one_pow_count` — reusable: a list of `±1` multiplies to `(-1)^(#-1's)`
- `even_numNonResidue_two_fifteen`, `odd_numNonResidue_two_fortyfive` — worked examples

## Verification

- **8 theorems, 2 definitions, 143 lines, 0 sorries, 0 axioms, no `native_decide`.**
- `#print axioms` on every theorem reports only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Built clean against Mathlib `v4.26.0` (`Built Proofs.JacobiSymbolOQ0103`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)