### PR TITLE
research(subset-count-oq-02-oq-02): Pascal's recurrence and row-sum 2^n from powerset decompositions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3665,6 +3665,7 @@ import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02
 import Proofs.SubsetCountOQ02OQ01
+import Proofs.SubsetCountOQ02OQ02
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ04

--- a/proofs/Proofs/SubsetCountOQ02OQ02.lean
+++ b/proofs/Proofs/SubsetCountOQ02OQ02.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-
+# Pascal's Recurrence from the Powerset Decomposition (OQ-02-OQ-02)
+
+## Open Question
+
+The parent entry counts distinct submultisets via the product formula
+`∏ a, (mₐ + 1)` (Mathlib's `Multiset.card_Iic`). A natural follow-up asks: can
+the *binomial* recurrences be recovered the same combinatorial way — by
+decomposing the powerset itself, rather than by unfolding the recursive
+definition of `Nat.choose`?
+
+This file answers YES for the two canonical decompositions of a powerset:
+
+1. **Fix an element.** The `(k+1)`-subsets of `a ::ₘ s` split into those that
+   omit `a` (the `(k+1)`-subsets of `s`) and those that use `a` (in bijection
+   with the `k`-subsets of `s`). Counting both sides yields **Pascal's
+   recurrence**
+   `(m+1).choose (k+1) = m.choose (k+1) + m.choose k`.
+
+2. **Fix the size.** The full powerset of an `m`-set is the disjoint union of
+   its size-`k` layers for `k = 0, …, m`. Counting both sides yields the
+   **row-sum identity** `∑ k, m.choose k = 2^m`.
+
+Both proofs are genuinely combinatorial: they read the arithmetic off a
+structural decomposition of a finite collection of sets, not off the
+`Nat.rec` definition of the binomial coefficient. Mathlib *does* contain
+`Nat.choose_succ_succ` and `Nat.sum_range_choose`, but those are proved by
+recursion/induction; here we derive them from `powersetCard_cons`,
+`powersetCard_succ_insert`, and `powerset_card_disjiUnion`.
+
+## Summary Statistics
+
+- Sorries: 0
+- Axioms: 0 (no `axiom`, no `native_decide`)
+- Key Mathlib inputs: `Multiset.powersetCard_cons`, `Multiset.card_powersetCard`,
+  `Finset.powersetCard_succ_insert`, `Finset.powerset_card_disjiUnion`,
+  `Finset.card_powerset`
+-/
+
+namespace SubsetCountPascal
+
+open Multiset Finset
+
+-- ===========================================================================
+-- Part I.  Fix an element  →  Pascal's recurrence
+-- ===========================================================================
+
+/-- **Structural decomposition (multisets).** The `(k+1)`-submultisets of
+    `a ::ₘ s` are exactly the `(k+1)`-submultisets of `s` together with the
+    image, under `cons a`, of the `k`-submultisets of `s`.
+
+    This is `Multiset.powersetCard_cons` restated under the names used in this
+    file; it is the entire combinatorial content of Pascal's recurrence. -/
+theorem powersetCard_succ_cons {α : Type*} (k : ℕ) (a : α) (s : Multiset α) :
+    powersetCard (k + 1) (a ::ₘ s)
+      = powersetCard (k + 1) s + (powersetCard k s).map (cons a) :=
+  Multiset.powersetCard_cons k a s
+
+/-- **Pascal's recurrence, combinatorially.**
+    `(m+1).choose (k+1) = m.choose (k+1) + m.choose k`.
+
+    We instantiate the structural decomposition at a concrete `m`-element
+    multiset (`Multiset.range m`, with the fresh element `m` consed on) and take
+    cardinalities. The `+ map (cons a)` summand contributes `m.choose k` because
+    `cons a` is injective, so `card (map (cons a) X) = card X`. No appeal to the
+    recursive definition of `choose` is made. -/
+theorem choose_succ_succ_comb (m k : ℕ) :
+    (m + 1).choose (k + 1) = m.choose (k + 1) + m.choose k := by
+  have hcard := congrArg Multiset.card
+    (powersetCard_succ_cons k m (Multiset.range m))
+  simp only [Multiset.card_powersetCard, Multiset.card_cons, Multiset.card_range,
+    Multiset.card_add, Multiset.card_map] at hcard
+  exact hcard
+
+/-- **Pascal's recurrence via the Finset powerset.** The same identity, now read
+    off the honest set-theoretic partition of the `(k+1)`-subsets of
+    `insert x s`: those avoiding `x` (a disjoint copy of the `(k+1)`-subsets of
+    `s`) and those containing `x` (the image, under the *injective* map
+    `insert x`, of the `k`-subsets of `s`). -/
+theorem choose_succ_succ_finset {α : Type*} [DecidableEq α]
+    {x : α} {s : Finset α} (hx : x ∉ s) (k : ℕ) :
+    (s.card + 1).choose (k + 1) = s.card.choose (k + 1) + s.card.choose k := by
+  -- cardinality of `insert x s`
+  have hins : (insert x s).card = s.card + 1 := Finset.card_insert_of_notMem hx
+  -- the two layers are disjoint: one consists of subsets avoiding `x`, the other
+  -- of subsets containing `x`.
+  have hdisj : Disjoint (s.powersetCard (k + 1))
+      ((s.powersetCard k).image (insert x)) := by
+    rw [Finset.disjoint_left]
+    rintro t ht htim
+    rw [Finset.mem_powersetCard] at ht
+    obtain ⟨u, hu, rfl⟩ := Finset.mem_image.mp htim
+    -- `t ⊆ s` forces `x ∉ t`, but `t = insert x u` forces `x ∈ t`.
+    exact hx (ht.1 (Finset.mem_insert_self x u))
+  -- `insert x` is injective on the `k`-subsets of `s` (all avoid `x`).
+  have hinj : Set.InjOn (insert x) (s.powersetCard k : Set (Finset α)) := by
+    intro a ha b hb hab
+    rw [Finset.mem_coe, Finset.mem_powersetCard] at ha hb
+    have hxa : x ∉ a := fun h => hx (ha.1 h)
+    have hxb : x ∉ b := fun h => hx (hb.1 h)
+    have := congrArg (Finset.erase · x) hab
+    simpa [Finset.erase_insert hxa, Finset.erase_insert hxb] using this
+  have hcard := congrArg Finset.card
+    (Finset.powersetCard_succ_insert hx k)
+  rw [Finset.card_union_of_disjoint hdisj, Finset.card_powersetCard,
+      Finset.card_powersetCard, Finset.card_image_of_injOn hinj,
+      Finset.card_powersetCard, hins] at hcard
+  exact hcard
+
+/-- The disjoint-partition statement behind `choose_succ_succ_finset`, isolated
+    as a structural fact: the `(k+1)`-subsets of `insert x s` partition into the
+    `(k+1)`-subsets of `s` and the `x`-augmented `k`-subsets of `s`. -/
+theorem powersetCard_insert_decomp {α : Type*} [DecidableEq α]
+    {x : α} {s : Finset α} (hx : x ∉ s) (k : ℕ) :
+    (insert x s).powersetCard (k + 1)
+      = s.powersetCard (k + 1) ∪ (s.powersetCard k).image (insert x) :=
+  Finset.powersetCard_succ_insert hx k
+
+-- ===========================================================================
+-- Part II.  Fix the size  →  row sum  ∑ choose = 2^n
+-- ===========================================================================
+
+/-- **Row-sum identity, combinatorially.** `∑ k ∈ range (m+1), m.choose k = 2^m`.
+
+    The powerset of an `m`-element set is the *disjoint* union of its size-`k`
+    layers for `k = 0, …, m` (`Finset.powerset_card_disjiUnion`). Counting the
+    left side directly gives `2^m` (`Finset.card_powerset`); counting the right
+    side layer-by-layer gives `∑ k, m.choose k` (`Finset.card_powersetCard`).
+    Equality of the two counts is the identity. -/
+theorem sum_choose_eq_two_pow_comb {α : Type*} (s : Finset α) :
+    (∑ k ∈ Finset.range (s.card + 1), s.card.choose k) = 2 ^ s.card := by
+  have hpow := congrArg Finset.card (Finset.powerset_card_disjiUnion s)
+  rw [Finset.card_powerset, Finset.card_disjiUnion] at hpow
+  simp only [Finset.card_powersetCard] at hpow
+  exact hpow.symm
+
+/-- The same row sum stated purely arithmetically (for any `m : ℕ`), obtained by
+    evaluating `sum_choose_eq_two_pow_comb` at `Finset.range m`. -/
+theorem sum_range_choose_comb (m : ℕ) :
+    (∑ k ∈ Finset.range (m + 1), m.choose k) = 2 ^ m := by
+  have := sum_choose_eq_two_pow_comb (Finset.range m)
+  simpa [Finset.card_range] using this
+
+-- ===========================================================================
+-- Part III.  Sanity checks
+-- ===========================================================================
+
+-- Pascal's triangle entries, recomputed via the combinatorial recurrence.
+example : (4 : ℕ).choose 2 = 3 + 3 := choose_succ_succ_comb 3 1
+example : (5 : ℕ).choose 3 = 6 + 4 := choose_succ_succ_comb 4 2
+
+-- Row sums.
+example : (∑ k ∈ Finset.range 5, (4 : ℕ).choose k) = 16 := by decide
+
+-- The recurrence really does rebuild the triangle from the two boundary edges.
+example : (∀ k, (0 : ℕ).choose (k + 1) = 0) ∧ (∀ m : ℕ, m.choose 0 = 1) :=
+  ⟨fun k => Nat.choose_zero_succ k, fun m => Nat.choose_zero_right m⟩
+
+end SubsetCountPascal

--- a/src/data/proofs/subset-count-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-powersetcard-cons-is-pascal",
+    "proofId": "subset-count-oq-02-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 80
+    },
+    "type": "insight",
+    "title": "powersetCard_cons IS Pascal — Counting the Decomposition",
+    "content": "Mathlib's `Multiset.powersetCard_cons` packages the fix-an-element decomposition as an equation of multisets:\n\n```lean\ntheorem powersetCard_cons (k : ℕ) (a : α) (s) :\n    powersetCard (k + 1) (a ::ₘ s)\n      = powersetCard (k + 1) s + map (cons a) (powersetCard k s)\n```\n\nThe $(k+1)$-submultisets of `a ::ₘ s` are exactly those omitting `a` (the $(k+1)$-submultisets of `s`) together with the `cons a`-image of the $k$-submultisets of `s`. Taking `Multiset.card` of both sides and simplifying turns this single structural fact into Pascal's recurrence:\n\n```lean\ntheorem choose_succ_succ_comb (m k : ℕ) :\n    (m + 1).choose (k + 1) = m.choose (k + 1) + m.choose k := by\n  have hcard := congrArg Multiset.card\n    (powersetCard_succ_cons k m (Multiset.range m))\n  simp only [Multiset.card_powersetCard, Multiset.card_cons, Multiset.card_range,\n    Multiset.card_add, Multiset.card_map] at hcard\n  exact hcard\n```\n\nThe `card_map` rewrite is exactly the place where the bijection enters: `card (map (cons a) X) = card X` because `cons a` is injective.",
+    "mathContext": "Counting $\\mathcal{P}_{k+1}(a ::_m s) = \\mathcal{P}_{k+1}(s) \\sqcup \\mathrm{cons}\\,a\\,(\\mathcal{P}_k(s))$ with `card_add` and `card_map`: $\\binom{|s|+1}{k+1} = \\binom{|s|}{k+1} + \\binom{|s|}{k}$. Instantiating at $s = \\text{range}\\,m$ (card $m$) gives $\\binom{m+1}{k+1} = \\binom{m}{k+1} + \\binom{m}{k}$. No appeal to the recursive definition of `choose`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Multiset.powersetCard_cons",
+      "Multiset.card_powersetCard",
+      "Multiset.card_map",
+      "Pascal's recurrence"
+    ],
+    "prerequisites": [
+      "Multisets",
+      "Powerset by cardinality",
+      "Binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-finset-bijection-honest",
+    "proofId": "subset-count-oq-02-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 119
+    },
+    "type": "concept",
+    "title": "The Honest Bijection: Disjointness + Injectivity",
+    "content": "The `Finset` version makes the combinatorial bijection fully explicit. `Finset.powersetCard_succ_insert` decomposes the $(k+1)$-subsets of `insert x s` into two layers, and counting requires two facts:\n\n- **Disjointness.** The two layers cannot overlap: members of `s.powersetCard (k+1)` are subsets of `s`, hence avoid `x` (since `x ∉ s`); members of `(s.powersetCard k).image (insert x)` all contain `x`. Proved via `Finset.disjoint_left`.\n- **Injectivity.** `insert x` is injective on the $k$-subsets of `s`: each such subset `a` avoids `x`, so `erase x (insert x a) = a` recovers it (`Finset.erase_insert`). Proved as a `Set.InjOn`.\n\nThese feed `Finset.card_union_of_disjoint` and `Finset.card_image_of_injOn`:\n\n```lean\nrw [Finset.card_union_of_disjoint hdisj, Finset.card_powersetCard,\n    Finset.card_powersetCard, Finset.card_image_of_injOn hinj,\n    Finset.card_powersetCard, hins] at hcard\n```\n\nThis is the textbook proof — partition by membership of `x`, relabel the `x`-containing subsets by deleting `x` — carried out literally.",
+    "mathContext": "$\\binom{S}{k+1}$ for $S = \\{x\\} \\cup s$ ($x \\notin s$) partitions as $\\binom{s}{k+1} \\sqcup \\{T \\cup \\{x\\} : T \\in \\binom{s}{k}\\}$. The map $T \\mapsto T \\cup \\{x\\}$ is a bijection onto the second block (inverse: delete $x$), so $|\\binom{S}{k+1}| = |\\binom{s}{k+1}| + |\\binom{s}{k}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.powersetCard_succ_insert",
+      "Finset.card_union_of_disjoint",
+      "Finset.card_image_of_injOn",
+      "Finset.erase_insert"
+    ],
+    "prerequisites": [
+      "Finsets",
+      "Disjoint unions",
+      "Injective maps and cardinality"
+    ]
+  },
+  {
+    "id": "ann-fix-size-row-sum",
+    "proofId": "subset-count-oq-02-oq-02",
+    "range": {
+      "startLine": 121,
+      "endLine": 144
+    },
+    "type": "insight",
+    "title": "The Second Decomposition: Fix the Size → 2^n",
+    "content": "The same powerset, organized by cardinality instead of by membership, yields the row-sum identity. `Finset.powerset_card_disjiUnion` states that the full powerset is the disjoint union of its size layers:\n\n```lean\nFinset.powerset s = (range (s.card + 1)).disjiUnion (fun i => powersetCard i s) _\n```\n\nCounting both sides:\n\n```lean\ntheorem sum_choose_eq_two_pow_comb (s : Finset α) :\n    (∑ k ∈ Finset.range (s.card + 1), s.card.choose k) = 2 ^ s.card := by\n  have hpow := congrArg Finset.card (Finset.powerset_card_disjiUnion s)\n  rw [Finset.card_powerset, Finset.card_disjiUnion] at hpow\n  simp only [Finset.card_powersetCard] at hpow\n  exact hpow.symm\n```\n\nThe left side is `card_powerset` $= 2^{|s|}$; the right side is `card_disjiUnion` summing the layer cardinalities `card_powersetCard` $= \\binom{|s|}{k}$. Two ways of counting one set give $\\sum_k \\binom{n}{k} = 2^n$ — again with no induction.",
+    "mathContext": "$\\mathcal{P}(S) = \\bigsqcup_{k=0}^{|S|} \\binom{S}{k}$ (disjoint over size). Counting: $2^{|S|} = |\\mathcal{P}(S)| = \\sum_{k=0}^{|S|} |\\binom{S}{k}| = \\sum_{k=0}^{|S|} \\binom{|S|}{k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.powerset_card_disjiUnion",
+      "Finset.card_powerset",
+      "Finset.card_disjiUnion",
+      "Binomial theorem"
+    ],
+    "prerequisites": [
+      "Finsets",
+      "Disjoint unions over an index",
+      "Cardinality of the powerset"
+    ]
+  }
+]

--- a/src/data/proofs/subset-count-oq-02-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/meta.json
@@ -1,0 +1,70 @@
+{
+  "id": "subset-count-oq-02-oq-02",
+  "title": "Pascal's Recurrence from the Powerset Decomposition",
+  "slug": "subset-count-oq-02-oq-02",
+  "description": "Derives the two canonical binomial identities combinatorially, by decomposing the powerset rather than unfolding the recursive definition of Nat.choose. Fixing an element splits the (k+1)-subsets of a ::ₘ s (resp. insert x s) into those omitting it and those using it, giving Pascal's recurrence (m+1).choose(k+1) = m.choose(k+1) + m.choose k from Multiset.powersetCard_cons and Finset.powersetCard_succ_insert. Fixing the size partitions the full powerset into its cardinality layers, giving the row sum ∑ m.choose k = 2^m from Finset.powerset_card_disjiUnion. 0 sorries, 0 axioms.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "powerset",
+      "pascal",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/SubsetCountOQ02OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the lone numerical sanity check uses kernel `decide`, so no `Lean.ofReduceBool`). The only axioms appearing in `#print axioms` are the ordinary foundational ones (propext, Classical.choice, Quot.sound), which the project policy does not count. Key Mathlib inputs: Multiset.powersetCard_cons, Multiset.card_powersetCard, Finset.powersetCard_succ_insert, Finset.powerset_card_disjiUnion, Finset.card_powerset, Finset.card_image_of_injOn, Finset.card_union_of_disjoint.",
+    "lineCount": 161,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "The binomial coefficient $\\binom{n}{k}$ counts the $k$-element subsets of an $n$-element set, and its two most fundamental identities are **Pascal's recurrence** $\\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$ and the **row sum** $\\sum_{k} \\binom{n}{k} = 2^n$. Both have one-line proofs by induction on the recursive definition (this is how Mathlib proves `Nat.choose_succ_succ` and `Nat.sum_range_choose`), but their *mathematical content* is combinatorial: each is a count of the same finite family of sets, organized two different ways.\n\nThe powerset $\\mathcal{P}(S)$ admits two canonical decompositions. **Fixing an element** $x \\in S$: every subset either contains $x$ or not, partitioning $\\mathcal{P}(S)$ into the subsets of $S \\setminus \\{x\\}$ and their $x$-augmentations — restricting to size $k+1$ gives Pascal. **Fixing the size**: $\\mathcal{P}(S)$ is the disjoint union of its layers $\\binom{S}{0}, \\binom{S}{1}, \\ldots, \\binom{S}{n}$ — counting both sides gives the row sum. This entry formalizes both decompositions and reads the arithmetic off them, recovering the identities without ever invoking the `Nat.rec` definition of `choose`.",
+    "problemStatement": "**Open Question (OQ-02-OQ-02)**: The parent entry counts distinct submultisets via the product formula $\\prod_a (m_a+1)$ (Mathlib's `Multiset.card_Iic`). Can the *binomial recurrences* be recovered the same combinatorial way — by decomposing the powerset itself, rather than by unfolding the recursive definition of `Nat.choose`?\n\n**Answer: YES.** The structural decompositions `Multiset.powersetCard_cons`, `Finset.powersetCard_succ_insert`, and `Finset.powerset_card_disjiUnion` yield Pascal's recurrence and the row-sum identity directly, by taking cardinalities.",
+    "proofStrategy": "**Part I — Fix an element (Pascal).** `powersetCard_succ_cons` restates `Multiset.powersetCard_cons`: the $(k+1)$-submultisets of $a ::_m s$ are those of $s$ plus the `cons a`-image of the $k$-submultisets of $s$. Taking `Multiset.card` of both sides and simplifying with `card_powersetCard`, `card_cons`, `card_range`, `card_add`, `card_map` collapses to Pascal $\\binom{m+1}{k+1} = \\binom{m}{k+1} + \\binom{m}{k}$ (`choose_succ_succ_comb`); the `card_map` step is exactly where injectivity of `cons a` supplies the bijection. `choose_succ_succ_finset` redoes this for `Finset`s via `powersetCard_succ_insert`, where the two layers are genuinely disjoint (one consists of subsets avoiding $x$, the other of subsets containing $x$) and `insert x` is injective on the $k$-subsets of $s$ (all avoid $x$, recovered by `erase_insert`); cardinalities then combine through `card_union_of_disjoint` and `card_image_of_injOn`.\n\n**Part II — Fix the size (row sum).** `sum_choose_eq_two_pow_comb` takes `Finset.card` of `Finset.powerset_card_disjiUnion`: the left side is `card_powerset` $= 2^{|s|}$, the right side is `card_disjiUnion` summing `card_powersetCard` $= \\sum_k \\binom{|s|}{k}$. `sum_range_choose_comb` specializes to `Finset.range m`.\n\n**Part III — Sanity checks.** Pascal triangle entries recomputed via the recurrence, the row sum for $n=4$ checked by kernel `decide`, and the two boundary edges of the triangle.",
+    "keyInsights": [
+      "Pascal's recurrence and ∑ choose = 2^n are the same powerset counted two ways: by membership of a fixed element, and by cardinality. Both are 'structure first, arithmetic second'.",
+      "Multiset.powersetCard_cons already packages the fix-an-element decomposition as an equation of multisets; the entire proof of Pascal is then just card_add + card_map (the map being the bijection cons a).",
+      "The Finset version makes the bijection explicit and honest: disjointness of the two layers (avoid x vs contain x) and injectivity of insert x on x-free subsets (inverse = erase x), combined via card_union_of_disjoint and card_image_of_injOn.",
+      "The row sum needs no induction: card_powerset gives 2^n on the left and card_disjiUnion sums the layer cardinalities on the right of Finset.powerset_card_disjiUnion.",
+      "Unlike Mathlib's Nat.choose_succ_succ / Nat.sum_range_choose (proved by recursion on the definition of choose), these proofs never touch Nat.rec — they are bijective in spirit and in mechanism."
+    ],
+    "prerequisites": [
+      "Multiset.powersetCard_cons and Multiset.card_powersetCard (Mathlib.Data.Multiset.Powerset)",
+      "Finset.powersetCard_succ_insert and Finset.card_powersetCard (Mathlib.Data.Finset.Powerset)",
+      "Finset.powerset_card_disjiUnion and Finset.card_powerset",
+      "Finset.card_union_of_disjoint and Finset.card_image_of_injOn"
+    ]
+  },
+  "sections": [
+    {
+      "id": "decomp-element",
+      "title": "Part I: Fix an Element → Pascal's Recurrence",
+      "startLine": 46,
+      "endLine": 119,
+      "summary": "powersetCard_succ_cons restates the multiset decomposition; choose_succ_succ_comb derives Pascal by counting it; choose_succ_succ_finset redoes it for Finsets with explicit disjointness + injectivity; powersetCard_insert_decomp isolates the structural partition.",
+      "mathContext": "$\\binom{m+1}{k+1} = \\binom{m}{k+1} + \\binom{m}{k}$ from $\\mathcal{P}_{k+1}(a ::_m s) = \\mathcal{P}_{k+1}(s) \\sqcup \\mathrm{cons}\\,a\\,(\\mathcal{P}_k(s))$"
+    },
+    {
+      "id": "decomp-size",
+      "title": "Part II: Fix the Size → Row Sum 2^n",
+      "startLine": 121,
+      "endLine": 144,
+      "summary": "sum_choose_eq_two_pow_comb counts the powerset as a disjoint union of its size layers (card_powerset = 2^n on the left, ∑ card_powersetCard on the right); sum_range_choose_comb specializes to range m.",
+      "mathContext": "$\\sum_{k=0}^{m} \\binom{m}{k} = 2^m$ from $\\mathcal{P}(s) = \\bigsqcup_{k=0}^{|s|} \\binom{s}{k}$"
+    },
+    {
+      "id": "sanity",
+      "title": "Part III: Sanity Checks",
+      "startLine": 146,
+      "endLine": 161,
+      "summary": "Pascal triangle entries via the recurrence, the n=4 row sum by kernel decide, and the two boundary edges choose 0 (k+1) = 0 and choose m 0 = 1.",
+      "mathContext": "$\\binom{4}{2} = 3+3$; $\\sum_{k} \\binom{4}{k} = 16$; boundary edges of the triangle"
+    }
+  ]
+}

--- a/src/data/research/problems/subset-count-oq-02-oq-02.json
+++ b/src/data/research/problems/subset-count-oq-02-oq-02.json
@@ -1,0 +1,130 @@
+{
+  "slug": "subset-count-oq-02-oq-02",
+  "title": "Pascal's recurrence from the multiset powerset decomposition",
+  "phase": "OBSERVE",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\bigl|\\,\\mathrm{powersetCard}\\;k\\;(a ::_{\\mathrm m} s)\\,\\bigr|\n\\;=\\;\n\\bigl|\\,\\mathrm{powersetCard}\\;k\\;s\\,\\bigr|\n\\;+\\;\n\\bigl|\\,\\mathrm{powersetCard}\\;(k-1)\\;s\\,\\bigr|,",
+    "plain": "Counting how many ways you can pick `k` items from a collection has a recursive",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T01:37:13-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Pascal + row-sum 2^n derived combinatorially from powerset decompositions (verified, 0-axiom, 6 theorems).",
+    "builtItems": [
+      "SubsetCountPascal.powersetCard_succ_cons (Proofs/SubsetCountOQ02OQ02.lean)",
+      "SubsetCountPascal.choose_succ_succ_comb — Pascal via multiset card",
+      "SubsetCountPascal.choose_succ_succ_finset — Pascal via Finset disjoint partition + InjOn",
+      "SubsetCountPascal.powersetCard_insert_decomp — structural partition statement",
+      "SubsetCountPascal.sum_choose_eq_two_pow_comb / sum_range_choose_comb — row sum 2^n"
+    ],
+    "insights": [
+      "Multiset.powersetCard_cons already encodes the fix-an-element decomposition as a multiset equation; taking card with card_add+card_map collapses directly to Pascal — no Nat.rec.",
+      "The Finset version (powersetCard_succ_insert) makes the bijection explicit: disjoint layers (avoid x vs contain x) + InjOn (insert x) with inverse erase x, via card_union_of_disjoint and card_image_of_injOn.",
+      "Fixing the SIZE gives the second decomposition: powerset_card_disjiUnion + card_powerset=2^n yields the row sum sum m.choose k = 2^m, again no induction.",
+      "Both classical binomial identities are one finite family (the powerset) counted two ways — genuinely combinatorial where Mathlib choose_succ_succ / sum_range_choose are recursive."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Complementation bijection for symmetry C(n,k)=C(n,n-k) as a third decomposition.",
+      "Vandermonde via powersetCard of a disjoint union."
+    ],
+    "markdown": "# Knowledge Base: subset-count-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "multiset",
+    "binomial-coefficients"
+  ],
+  "relatedProofs": [
+    "subset-count",
+    "subset-count-multiset",
+    "subset-count-multiset-oq-01",
+    "subset-count-oq-01",
+    "subset-count-oq-02",
+    "subset-count-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T08:41:40.944Z",
+  "lastUpdate": "2026-06-24T08:41:40.972Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/SubsetCount.lean",
+      "filename": "SubsetCount.lean",
+      "lineCount": 179,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCount.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountMultisetOQ01.lean",
+      "filename": "SubsetCountMultisetOQ01.lean",
+      "lineCount": 227,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountMultisetOQ01.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountOQ01.lean",
+      "filename": "SubsetCountOQ01.lean",
+      "lineCount": 91,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountOQ01.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountOQ02.lean",
+      "filename": "SubsetCountOQ02.lean",
+      "lineCount": 121,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountOQ02.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountOQ02OQ01.lean",
+      "filename": "SubsetCountOQ02OQ01.lean",
+      "lineCount": 160,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountOQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **OQ-02-OQ-02** (child of the distinct-submultiset-count entry): recovers the two canonical binomial identities **combinatorially**, by decomposing the powerset itself rather than unfolding the recursive `Nat.rec` definition of `Nat.choose`.

| Decomposition | Identity | Mathlib input |
|---|---|---|
| **Fix an element** (in/out of a fixed `x`) | Pascal `(m+1).choose(k+1) = m.choose(k+1) + m.choose k` | `Multiset.powersetCard_cons`, `Finset.powersetCard_succ_insert` |
| **Fix the size** (layer by cardinality) | Row sum `∑ m.choose k = 2^m` | `Finset.powerset_card_disjiUnion`, `Finset.card_powerset` |

The multiset proof collapses to Pascal by taking `card` of the decomposition (`card_add` + `card_map`, the `map (cons a)` being the bijection). The Finset proof makes the bijection fully explicit: the two layers are disjoint (subsets avoiding `x` vs containing `x`) and `insert x` is injective on the `x`-free `k`-subsets (inverse = `erase x`), combined via `card_union_of_disjoint` and `card_image_of_injOn`.

Unlike Mathlib's `Nat.choose_succ_succ` / `Nat.sum_range_choose` (proved by recursion), these proofs never touch `Nat.rec` — they are bijective in spirit and mechanism.

## Verification
- **6 theorems, 0 sorries, 0 axioms**
- No `native_decide`; the lone numerical sanity check uses kernel `decide` (no `Lean.ofReduceBool`)
- `#print axioms` shows only foundational `propext` / `Classical.choice` / `Quot.sound` (not counted)
- Built with Lean v4.26.0 / Mathlib

## Files
- `proofs/Proofs/SubsetCountOQ02OQ02.lean` (new, 161 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/subset-count-oq-02-oq-02/{meta,annotations}.json` (new)
- `src/data/research/problems/subset-count-oq-02-oq-02.json` (knowledge update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)