### PR TITLE
research(harmonic-divergence-oq-05-oq-02): explicit dyadic-block bounds for p-series partial sums [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2978,6 +2978,7 @@ import Proofs.HarmonicDivergenceOQ02
 import Proofs.HarmonicDivergenceOQ03
 import Proofs.HarmonicDivergenceOQ04
 import Proofs.HarmonicDivergenceOQ05
+import Proofs.HarmonicDivergenceOQ05OQ02
 import Proofs.HermiteLindemann
 import Proofs.HeronsFormula
 import Proofs.HeronsFormulaOQ01

--- a/proofs/Proofs/HarmonicDivergenceOQ05OQ02.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ05OQ02.lean
@@ -1,0 +1,242 @@
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Tactic
+
+/-
+# Explicit Dyadic-Block Bounds for the `p`-Series Partial Sums
+
+## What This Proves
+
+The parent entry `HarmonicDivergenceOQ05` makes Oresme's grouping argument for the
+harmonic series (`p = 1`) completely explicit:
+
+  `H_{2^n} = ∑_{j=1}^{2^n} 1/j ≥ 1 + n/2`.
+
+Here we generalise the **dyadic-block** technique to the full real `p`-series
+
+  `H_p(N) = ∑_{j=1}^{N} 1/j^p`,
+
+and extract *two-sided* explicit bounds on the dyadic partial sums `H_p(2^n)`:
+
+* **Divergent regime `0 < p ≤ 1`.**  Every dyadic block still contributes at least
+  `1/2`, so the Oresme bound survives unchanged:
+
+    `H_p(2^n) ≥ 1 + n/2`   (hence `H_p → ∞`).
+
+* **Convergent regime `p > 1`.**  Every dyadic block is now majorised by the
+  geometric term `(2^{1-p})^m`, giving a *uniform explicit ceiling*
+
+    `H_p(2^n) ≤ 1 + 1/(1 - 2^{1-p})`   for all `n`,
+
+  so the partial sums are bounded — the quantitative heart of the `p`-series
+  convergence test, with an explicit constant.
+
+Mathlib has the qualitative `p`-series dichotomy
+(`Real.summable_one_div_nat_rpow`) but no explicit dyadic partial-sum bounds; the
+constants `1 + n/2` and `1 + 1/(1 - 2^{1-p})` are original to this gallery family.
+The exponent is a genuine real `p`, handled with `Real.rpow`.
+
+## Indexing convention
+
+As in the parent and in `Real.tendsto_sum_range_one_div_nat_succ_atTop`:
+
+  `Hp p N := ∑ k ∈ Finset.range N, (1 : ℝ) / (k + 1) ^ p`   (`^` is `Real.rpow`).
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Lower bound `Hp_two_pow_ge` (divergence, `p ≤ 1`)
+- [x] Upper bound `Hp_two_pow_le` (uniform ceiling, `p > 1`)
+-/
+
+namespace HarmonicDivergenceOQ05OQ02
+
+open Finset
+
+/-- `p`-series partial sum `H_p(N) = ∑_{j=1}^{N} 1/j^p`, with a real exponent `p`
+handled through `Real.rpow`. Indexed exactly as the parent's harmonic `H`. -/
+noncomputable def Hp (p : ℝ) (N : ℕ) : ℝ :=
+    ∑ k ∈ Finset.range N, (1 : ℝ) / ((k : ℝ) + 1) ^ p
+
+/-- Splitting `H_p(2^{n+1})` into the head `H_p(2^n)` plus one dyadic block
+`∑_{k = 2^n}^{2^{n+1}-1} 1/(k+1)^p`. -/
+theorem Hp_two_pow_succ (p : ℝ) (n : ℕ) :
+    Hp p (2 ^ (n + 1)) = Hp p (2 ^ n)
+      + ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((k : ℝ) + 1) ^ p := by
+  unfold Hp
+  rw [← Finset.sum_range_add_sum_Ico _ (Nat.pow_le_pow_right (by norm_num) (Nat.le_succ n))]
+
+/-- `H_p` is monotone in the number of terms (each summand `1/(k+1)^p` is `≥ 0`). -/
+theorem Hp_mono (p : ℝ) : Monotone (Hp p) := by
+  intro a b hab
+  unfold Hp
+  apply Finset.sum_le_sum_of_subset_of_nonneg (Finset.range_mono hab)
+  intro i _ _
+  positivity
+
+/-! ### Divergent regime `0 < p ≤ 1` -/
+
+/-- **Dyadic block lower bound (`p ≤ 1`).** For `0 < p ≤ 1` each of the `2^n` terms
+of the block at level `n` is at least `1/(2^{n+1})^p ≥ 1/2^{n+1}` (raising the base
+`2^{n+1} ≥ 1` to the *smaller* exponent `p ≤ 1` can only shrink it), so the whole
+block contributes at least `2^n · 1/2^{n+1} = 1/2`. -/
+theorem block_ge_half {p : ℝ} (hp0 : 0 < p) (hp1 : p ≤ 1) (n : ℕ) :
+    (1 : ℝ) / 2 ≤
+      ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((k : ℝ) + 1) ^ p := by
+  have hterm : ∀ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)),
+      (1 : ℝ) / 2 ^ (n + 1) ≤ (1 : ℝ) / ((k : ℝ) + 1) ^ p := by
+    intro k hk
+    rw [Finset.mem_Ico] at hk
+    have hk_le : (k : ℝ) + 1 ≤ (2 : ℝ) ^ (n + 1) := by
+      have : k + 1 ≤ 2 ^ (n + 1) := by omega
+      exact_mod_cast this
+    have hbase1 : (1 : ℝ) ≤ (2 : ℝ) ^ (n + 1) := one_le_pow₀ (by norm_num)
+    have step1 : ((k : ℝ) + 1) ^ p ≤ ((2 : ℝ) ^ (n + 1)) ^ p :=
+      Real.rpow_le_rpow (by positivity) hk_le hp0.le
+    have step2 : ((2 : ℝ) ^ (n + 1)) ^ p ≤ ((2 : ℝ) ^ (n + 1)) ^ (1 : ℝ) :=
+      Real.rpow_le_rpow_of_exponent_le hbase1 hp1
+    rw [Real.rpow_one] at step2
+    have hkp_pos : (0 : ℝ) < ((k : ℝ) + 1) ^ p := Real.rpow_pos_of_pos (by positivity) _
+    exact one_div_le_one_div_of_le hkp_pos (le_trans step1 step2)
+  have hconst : ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / 2 ^ (n + 1)
+      = (1 : ℝ) / 2 := by
+    rw [Finset.sum_const, Nat.card_Ico]
+    have hpow : (2 : ℕ) ^ (n + 1) - 2 ^ n = 2 ^ n := by
+      have : (2 : ℕ) ^ (n + 1) = 2 * 2 ^ n := by ring
+      omega
+    rw [hpow, nsmul_eq_mul]
+    have h2 : (2 : ℝ) ^ (n + 1) = 2 * 2 ^ n := by ring
+    rw [h2]
+    push_cast
+    have hne : (2 : ℝ) ^ n ≠ 0 := by positivity
+    field_simp
+  calc (1 : ℝ) / 2
+      = ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / 2 ^ (n + 1) := hconst.symm
+    _ ≤ ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((k : ℝ) + 1) ^ p :=
+        Finset.sum_le_sum hterm
+
+/-- **Generalised Oresme lower bound (`0 < p ≤ 1`).** The `2^n`-th partial sum of the
+`p`-series satisfies `H_p(2^n) ≥ 1 + n/2`. So for `p ≤ 1` the `p`-series diverges at
+least as fast as the harmonic series — the parent bound (`p = 1`) as the boundary case. -/
+theorem Hp_two_pow_ge {p : ℝ} (hp0 : 0 < p) (hp1 : p ≤ 1) (n : ℕ) :
+    1 + (n : ℝ) / 2 ≤ Hp p (2 ^ n) := by
+  induction n with
+  | zero => simp [Hp, Real.one_rpow]
+  | succ n ih =>
+      rw [Hp_two_pow_succ]
+      have hblock := block_ge_half hp0 hp1 n
+      push_cast
+      have hsplit : 1 + ((n : ℝ) + 1) / 2 = (1 + (n : ℝ) / 2) + 1 / 2 := by ring
+      rw [hsplit]
+      exact add_le_add ih hblock
+
+/-- **Divergence in the regime `0 < p ≤ 1`.** For any target `M` some dyadic partial
+sum exceeds it. -/
+theorem Hp_exceeds {p : ℝ} (hp0 : 0 < p) (hp1 : p ≤ 1) (M : ℝ) :
+    ∃ n : ℕ, M < Hp p (2 ^ n) := by
+  obtain ⟨n, hn⟩ := exists_nat_gt (2 * (M - 1))
+  refine ⟨n, ?_⟩
+  have hb := Hp_two_pow_ge hp0 hp1 n
+  have : M < 1 + (n : ℝ) / 2 := by linarith
+  linarith
+
+/-- **Divergence of the `p`-series partial sums for `0 < p ≤ 1`.** -/
+theorem Hp_tendsto_atTop {p : ℝ} (hp0 : 0 < p) (hp1 : p ≤ 1) :
+    Filter.Tendsto (Hp p) Filter.atTop Filter.atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro M
+  obtain ⟨n, hn⟩ := Hp_exceeds hp0 hp1 M
+  exact ⟨2 ^ n, fun N hN => le_of_lt (lt_of_lt_of_le hn (Hp_mono p hN))⟩
+
+/-! ### Convergent regime `p > 1` -/
+
+/-- The algebraic core of the geometric majorisation: `2^n / (2^n)^p = (2^{1-p})^n`. -/
+private lemma two_pow_div_rpow (p : ℝ) (n : ℕ) :
+    (2 : ℝ) ^ n / ((2 : ℝ) ^ n) ^ p = ((2 : ℝ) ^ (1 - p)) ^ n := by
+  rw [← Real.rpow_natCast ((2 : ℝ) ^ (1 - p)) n, ← Real.rpow_natCast (2 : ℝ) n,
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 2),
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 2),
+      ← Real.rpow_sub (by norm_num : (0 : ℝ) < 2)]
+  congr 1
+  ring
+
+/-- **Dyadic block geometric upper bound (`p ≥ 0`).** Each of the `2^n` terms of the
+block at level `n` is at most `1/(2^n)^p` (the base `k+1 ≥ 2^n` raised to `p ≥ 0`),
+so the block is `≤ 2^n / (2^n)^p = (2^{1-p})^n`. For `p > 1` the ratio `2^{1-p} < 1`
+makes this a convergent geometric majorant. -/
+theorem block_le_geom {p : ℝ} (hp : 0 ≤ p) (n : ℕ) :
+    ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((k : ℝ) + 1) ^ p
+      ≤ ((2 : ℝ) ^ (1 - p)) ^ n := by
+  have hterm : ∀ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)),
+      (1 : ℝ) / ((k : ℝ) + 1) ^ p ≤ (1 : ℝ) / ((2 : ℝ) ^ n) ^ p := by
+    intro k hk
+    rw [Finset.mem_Ico] at hk
+    have h2n_le : (2 : ℝ) ^ n ≤ (k : ℝ) + 1 := by
+      have hnat : (2 : ℕ) ^ n ≤ k + 1 := by omega
+      calc (2 : ℝ) ^ n = (((2 : ℕ) ^ n : ℕ) : ℝ) := by push_cast; ring
+        _ ≤ ((k + 1 : ℕ) : ℝ) := by exact_mod_cast hnat
+        _ = (k : ℝ) + 1 := by push_cast; ring
+    have hbpos : (0 : ℝ) < ((2 : ℝ) ^ n) ^ p := Real.rpow_pos_of_pos (by positivity) _
+    have hmono : ((2 : ℝ) ^ n) ^ p ≤ ((k : ℝ) + 1) ^ p :=
+      Real.rpow_le_rpow (by positivity) h2n_le hp
+    exact one_div_le_one_div_of_le hbpos hmono
+  have hconst : ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((2 : ℝ) ^ n) ^ p
+      = ((2 : ℝ) ^ (1 - p)) ^ n := by
+    rw [Finset.sum_const, Nat.card_Ico]
+    have hpow : (2 : ℕ) ^ (n + 1) - 2 ^ n = 2 ^ n := by
+      have : (2 : ℕ) ^ (n + 1) = 2 * 2 ^ n := by ring
+      omega
+    rw [hpow, nsmul_eq_mul]
+    rw [← two_pow_div_rpow p n]
+    push_cast
+    have hbpos : (0 : ℝ) < ((2 : ℝ) ^ n) ^ p := Real.rpow_pos_of_pos (by positivity) _
+    field_simp
+  calc ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((k : ℝ) + 1) ^ p
+      ≤ ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / ((2 : ℝ) ^ n) ^ p :=
+        Finset.sum_le_sum hterm
+    _ = ((2 : ℝ) ^ (1 - p)) ^ n := hconst
+
+/-- Closed bound for a finite geometric sum with ratio `0 ≤ r < 1`:
+`∑_{i<n} r^i ≤ 1/(1-r)`. -/
+private lemma geom_partial_le {r : ℝ} (hr0 : 0 ≤ r) (hr1 : r < 1) (n : ℕ) :
+    ∑ i ∈ Finset.range n, r ^ i ≤ 1 / (1 - r) := by
+  have hmul : (∑ i ∈ Finset.range n, r ^ i) * (1 - r) = 1 - r ^ n := by
+    have h := geom_sum_mul r n
+    linear_combination -h
+  rw [le_div_iff₀ (by linarith : (0 : ℝ) < 1 - r), hmul]
+  have : (0 : ℝ) ≤ r ^ n := by positivity
+  linarith
+
+/-- **Uniform explicit ceiling for the convergent `p`-series (`p > 1`).**
+For every `n`,
+
+  `H_p(2^n) ≤ 1 + 1/(1 - 2^{1-p})`.
+
+The dyadic partial sums are bounded by a constant independent of `n`: the head term
+`1` plus the geometric majorant of the blocks, ratio `2^{1-p} < 1`. This is the
+quantitative content of `p`-series convergence with an explicit bound. -/
+theorem Hp_two_pow_le {p : ℝ} (hp : 1 < p) (n : ℕ) :
+    Hp p (2 ^ n) ≤ 1 + 1 / (1 - (2 : ℝ) ^ (1 - p)) := by
+  set r : ℝ := (2 : ℝ) ^ (1 - p) with hr
+  have hr0 : 0 ≤ r := le_of_lt (Real.rpow_pos_of_pos (by norm_num) _)
+  have hr1 : r < 1 := Real.rpow_lt_one_of_one_lt_of_neg (by norm_num) (by linarith)
+  have hstep : Hp p (2 ^ n) ≤ 1 + ∑ i ∈ Finset.range n, r ^ i := by
+    induction n with
+    | zero => simp [Hp, Real.one_rpow]
+    | succ n ih =>
+        rw [Hp_two_pow_succ, Finset.sum_range_succ]
+        have hblock : ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)),
+            (1 : ℝ) / ((k : ℝ) + 1) ^ p ≤ r ^ n := by
+          rw [hr]; exact block_le_geom (le_of_lt (lt_trans one_pos hp)) n
+        linarith [ih, hblock]
+  have hgeo : ∑ i ∈ Finset.range n, r ^ i ≤ 1 / (1 - r) := geom_partial_le hr0 hr1 n
+  linarith [hstep, hgeo]
+
+/-- **Bounded partial sums for `p > 1`.** Every partial sum `H_p N` is `≤` the
+uniform ceiling, so the increasing sequence of partial sums is bounded above — the
+boundedness underlying convergence of the `p`-series. -/
+theorem Hp_bddAbove {p : ℝ} (hp : 1 < p) (N : ℕ) :
+    Hp p N ≤ 1 + 1 / (1 - (2 : ℝ) ^ (1 - p)) := by
+  have hN : N ≤ 2 ^ N := Nat.le_of_lt (Nat.lt_two_pow_self)
+  exact le_trans (Hp_mono p hN) (Hp_two_pow_le hp N)
+
+end HarmonicDivergenceOQ05OQ02

--- a/src/data/proofs/harmonic-divergence-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "harmonic-divergence-oq-05-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 75
+    },
+    "type": "concept",
+    "title": "The p-Series Partial Sum with a Real Exponent",
+    "content": "Hp p N = ∑_{k ∈ Finset.range N} 1/((k:ℝ)+1)^p generalizes the parent's harmonic partial sum by replacing the denominator k+1 with (k+1)^p, where ^ is Real.rpow so that the exponent p ranges over all reals (not just ℕ or ℚ). The (k+1) shift is inherited from the parent: it avoids the 1/0 term and synchronizes the range/Ico split with Finset.sum_range_add_sum_Ico. Hp_two_pow_succ performs that split, peeling H_p(2ⁿ⁺¹) into H_p(2ⁿ) plus the single dyadic block over Ico(2ⁿ, 2ⁿ⁺¹); the lower endpoint is annotated (2^n : ℕ) so the interval lives over ℕ (which has a LocallyFiniteOrder). Hp_mono records that Hp is monotone in N because every summand 1/(k+1)^p is nonnegative (Real.rpow of a positive base is positive).",
+    "mathContext": "$H_p(N) = \\sum_{j=1}^{N} j^{-p}$ with $p \\in \\mathbb{R}$ via $\\texttt{Real.rpow}$. The split $H_p(2^{n+1}) = H_p(2^n) + \\sum_{k=2^n}^{2^{n+1}-1}(k+1)^{-p}$ feeds the dyadic induction on both sides of $p = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.rpow",
+      "Finset.sum_range_add_sum_Ico",
+      "partial sums",
+      "monotonicity"
+    ],
+    "prerequisites": [
+      "Lean 4 Finset sums",
+      "Real power function rpow"
+    ]
+  },
+  {
+    "id": "ann-divergent-regime",
+    "proofId": "harmonic-divergence-oq-05-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 148
+    },
+    "type": "key_step",
+    "title": "Divergent Regime 0 < p ≤ 1: the Oresme Bound Survives Verbatim",
+    "content": "For 0 < p ≤ 1 the dyadic block estimate is unchanged from the parent. The new ingredient is purely about the exponent: for k+1 ≤ 2ⁿ⁺¹ we still need (k+1)^p ≤ 2ⁿ⁺¹. This factors through two rpow monotonicities — Real.rpow_le_rpow (monotone in the base, exponent p ≥ 0) gives (k+1)^p ≤ (2ⁿ⁺¹)^p, and Real.rpow_le_rpow_of_exponent_le (monotone in the exponent, base 2ⁿ⁺¹ ≥ 1) with p ≤ 1 gives (2ⁿ⁺¹)^p ≤ (2ⁿ⁺¹)^1 = 2ⁿ⁺¹. Hence 1/(k+1)^p ≥ 1/2ⁿ⁺¹, so block_ge_half delivers ≥ 1/2 per block exactly as before. Hp_two_pow_ge then inducts (base H_p(1) = 1 via Real.one_rpow) to reach H_p(2ⁿ) ≥ 1 + n/2, and Hp_exceeds / Hp_tendsto_atTop convert the bound into divergence to +∞. Conceptually this is the inequality 1/jᵖ ≥ 1/j for p ≤ 1, j ≥ 1: the p-series diverges at least as fast as the harmonic series.",
+    "mathContext": "$0 < p \\le 1 \\Rightarrow (k+1)^p \\le 2^{n+1}$ (base then exponent monotonicity), so each block $\\ge \\tfrac12$ and $H_p(2^n) \\ge 1 + n/2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.rpow_le_rpow",
+      "Real.rpow_le_rpow_of_exponent_le",
+      "Real.one_rpow",
+      "induction over dyadic blocks"
+    ],
+    "prerequisites": [
+      "rpow monotonicity in base and exponent",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "ann-rpow-identity",
+    "proofId": "harmonic-divergence-oq-05-oq-02",
+    "range": {
+      "startLine": 150,
+      "endLine": 165
+    },
+    "type": "key_step",
+    "title": "The Geometric-Ratio Identity 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ",
+    "content": "two_pow_div_rpow is the algebraic pivot that turns the convergent-side block bound into a genuine geometric series. The subtlety is that the proof mixes two different powers: the natural power 2ⁿ (Monoid.npow) and the real power (·)^p (Real.rpow). The chain first rewrites both natural powers to rpow via Real.rpow_natCast, then merges the iterated exponents with Real.rpow_mul (xʸ)ᶻ = x^{yz}, and finally combines the quotient with Real.rpow_sub x^{y-z} = xʸ/xᶻ, leaving the single goal 2^{n − np} = 2^{(1-p)n}, closed by ring on the exponents. The output ratio 2^{1-p} is exactly the geometric ratio of the dyadic blocks.",
+    "mathContext": "$\\dfrac{2^n}{(2^n)^p} = 2^{n - np} = 2^{n(1-p)} = (2^{1-p})^n$, written entirely inside $\\texttt{Real.rpow}$ so the natural and real powers can be combined.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Real.rpow_natCast",
+      "Real.rpow_mul",
+      "Real.rpow_sub"
+    ],
+    "prerequisites": [
+      "rpow algebraic identities",
+      "natural vs real power coercions"
+    ]
+  },
+  {
+    "id": "ann-convergent-regime",
+    "proofId": "harmonic-divergence-oq-05-oq-02",
+    "range": {
+      "startLine": 166,
+      "endLine": 242
+    },
+    "type": "key_step",
+    "title": "Convergent Regime p > 1: the Uniform Explicit Ceiling",
+    "content": "On the convergent side the per-block estimate flips direction. In block_le_geom, for k ≥ 2ⁿ we have 2ⁿ ≤ k+1, so (2ⁿ)^p ≤ (k+1)^p (Real.rpow_le_rpow, exponent p ≥ 0) and hence 1/(k+1)^p ≤ 1/(2ⁿ)^p; summing the 2ⁿ terms and applying two_pow_div_rpow bounds the block by (2^{1-p})ⁿ. geom_partial_le bounds the resulting geometric partial sum ∑_{i<n} rⁱ ≤ 1/(1−r) for 0 ≤ r < 1, proved by multiplying through by (1−r) > 0 and using the telescoping identity geom_sum_mul. Hp_two_pow_le inducts to get H_p(2ⁿ) ≤ 1 + ∑_{i<n} (2^{1-p})ⁱ ≤ 1 + 1/(1 − 2^{1-p}); the ratio is < 1 because 2 > 1 and the exponent 1 − p < 0 (Real.rpow_lt_one_of_one_lt_of_neg). Finally Hp_bddAbove uses N ≤ 2ᴺ together with Hp_mono to extend the ceiling from the dyadic subsequence to every partial sum — the boundedness that underlies convergence of the p-series, now with an explicit n-independent constant.",
+    "mathContext": "$p > 1 \\Rightarrow$ block $\\le (2^{1-p})^n$ and $\\sum_{i<n}(2^{1-p})^i \\le \\frac{1}{1-2^{1-p}}$, so $H_p(2^n) \\le 1 + \\frac{1}{1 - 2^{1-p}}$ uniformly in $n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.rpow_lt_one_of_one_lt_of_neg",
+      "geom_sum_mul",
+      "geometric series bound",
+      "Cauchy condensation test"
+    ],
+    "prerequisites": [
+      "finite geometric series",
+      "rpow monotonicity",
+      "bounded monotone sequences"
+    ]
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-05-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-02/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "harmonic-divergence-oq-05-oq-02",
+  "title": "Explicit Dyadic-Block Bounds for the p-Series Partial Sums",
+  "slug": "harmonic-divergence-oq-05-oq-02",
+  "description": "Generalizes the parent's explicit Oresme bound from the harmonic series (p=1) to the full real p-series H_p(N) = ∑_{j=1}^{N} 1/jᵖ, extracting two-sided explicit dyadic partial-sum bounds: for 0 < p ≤ 1 the Oresme lower bound survives unchanged, H_p(2ⁿ) ≥ 1 + n/2 (hence divergence); for p > 1 every dyadic block is majorized by the geometric term (2^{1-p})ᵐ, giving the uniform explicit ceiling H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}) and bounded partial sums. Directly answers the parent's stated open question on p-series near p=1.",
+  "meta": {
+    "author": "Oresme (~1350, p=1 case) + Cauchy condensation; formalization original to this gallery",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "p-series",
+      "divergence",
+      "convergence",
+      "explicit-bound",
+      "dyadic-blocks",
+      "rpow",
+      "geometric-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of x ↦ xᵖ in the base for nonnegative exponent",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow_of_exponent_le",
+        "description": "Monotonicity of x ↦ xᵃ in the exponent for base ≥ 1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_lt_one_of_one_lt_of_neg",
+        "description": "Base > 1 raised to a negative exponent is < 1 (gives ratio 2^{1-p} < 1 for p > 1)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "geom_sum_mul",
+        "description": "Telescoping identity (∑_{i<n} rⁱ)·(r−1) = rⁿ − 1, used to bound the geometric partial sum",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "Finset.sum_range_add_sum_Ico",
+        "description": "Splits a range sum into a head range and a tail Ico interval",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "Antitonicity of x ↦ 1/x on the positives",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Hp_two_pow_ge: the generalized Oresme lower bound H_p(2ⁿ) ≥ 1 + n/2 for all 0 < p ≤ 1 — the p-series diverges at least as fast as the harmonic series, with the parent (p=1) as the boundary case",
+      "Hp_two_pow_le: the uniform explicit ceiling H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}) for p > 1, bounding every dyadic partial sum by a single n-independent constant",
+      "block_le_geom: the dyadic block geometric majorization ∑_{k=2ⁿ}^{2ⁿ⁺¹-1} 1/(k+1)ᵖ ≤ (2^{1-p})ⁿ, the convergent-regime companion to the parent's block_ge_half",
+      "two_pow_div_rpow: the algebraic core 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ that converts the dyadic block bound into a clean geometric ratio (rpow_natCast/rpow_mul/rpow_sub)",
+      "Hp_bddAbove: every partial sum H_p N (not only the dyadic subsequence) is bounded by the explicit ceiling for p > 1 — the boundedness underlying p-series convergence",
+      "Hp_tendsto_atTop: divergence of the p-series partial sums for 0 < p ≤ 1, re-derived from the explicit bound plus monotonicity"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound on Hp_two_pow_ge, Hp_two_pow_le, Hp_tendsto_atTop, and Hp_bddAbove.",
+    "lineCount": 242,
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Oresme's ~1350 dyadic grouping argument shows the harmonic series (p = 1) diverges, and the parent entry sharpened it into the explicit bound H_{2ⁿ} ≥ 1 + n/2. The same dyadic blocks, applied to the general p-series ∑ 1/jᵖ, recover the classical convergence dichotomy (divergent for p ≤ 1, convergent for p > 1) — the elementary form of the Cauchy condensation / integral test. This entry keeps the blocks but, instead of only the qualitative dichotomy, extracts explicit two-sided bounds on the dyadic partial sums, with the same constants on the divergent side and an explicit geometric ceiling on the convergent side.",
+    "problemStatement": "Does Oresme's dyadic-block induction extend from the harmonic series to the full real p-series, and can it deliver explicit partial-sum bounds on both sides of the convergence threshold p = 1?\n\n**Answer: Yes.** For 0 < p ≤ 1, H_p(2ⁿ) ≥ 1 + n/2 (divergence); for p > 1, H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}) uniformly in n (bounded, hence convergent).",
+    "text": "Explicit dyadic-block lower and upper bounds for the p-series partial sums, generalizing the parent's Oresme bound and answering its open question about p near 1.",
+    "proofStrategy": "1. block_ge_half (p ≤ 1): each of the 2ⁿ block terms 1/(k+1)ᵖ ≥ 1/(2ⁿ⁺¹)ᵖ ≥ 1/2ⁿ⁺¹ because raising the base 2ⁿ⁺¹ ≥ 1 to the smaller exponent p ≤ 1 shrinks it (Real.rpow_le_rpow_of_exponent_le), so the block ≥ 1/2.\n2. Hp_two_pow_ge: induct on n exactly as the parent to get H_p(2ⁿ) ≥ 1 + n/2; Hp_exceeds and Hp_tendsto_atTop then give divergence.\n3. two_pow_div_rpow: the rpow identity 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ via rpow_natCast, rpow_mul, rpow_sub.\n4. block_le_geom (p ≥ 0): each block term 1/(k+1)ᵖ ≤ 1/(2ⁿ)ᵖ (base k+1 ≥ 2ⁿ raised to p ≥ 0), so the block ≤ 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ.\n5. geom_partial_le: ∑_{i<n} rⁱ ≤ 1/(1−r) for 0 ≤ r < 1 via the telescoping geom_sum_mul.\n6. Hp_two_pow_le (p > 1): induct to bound H_p(2ⁿ) ≤ 1 + ∑_{i<n} (2^{1-p})ⁱ ≤ 1 + 1/(1 − 2^{1-p}); the ratio 2^{1-p} < 1 by Real.rpow_lt_one_of_one_lt_of_neg.\n7. Hp_bddAbove: N ≤ 2ᴺ plus monotonicity lifts the ceiling from the dyadic subsequence to all partial sums.",
+    "keyInsights": [
+      "**One technique, both regimes**: the single dyadic-block idea gives the lower bound for p ≤ 1 and the upper bound for p > 1 — the threshold p = 1 is exactly where the per-block estimate flips from ≥ 1/2 to a summable geometric majorant.",
+      "**Divergent side is constant-free**: for every 0 < p ≤ 1 the bound is literally the harmonic one, H_p(2ⁿ) ≥ 1 + n/2, since 1/jᵖ ≥ 1/j; the p-series diverges at least as fast as the harmonic series.",
+      "**Convergent side has an explicit constant**: H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}), a closed n-independent ceiling. Mathlib's Real.summable_one_div_nat_rpow only asserts summability; the explicit bound on the partial sums is original here.",
+      "**Geometric ratio from an rpow identity**: the heart is 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ, turning the dyadic block bound into a genuine geometric series with ratio 2^{1-p} < 1.",
+      "**Real exponent throughout**: p is an arbitrary real, handled with Real.rpow, so the bounds hold for all p near 1 (and beyond), not just rational or integer exponents."
+    ],
+    "prerequisites": [
+      "Real analysis (p-series, convergence/divergence, partial sums)",
+      "Real power function Real.rpow and its monotonicity lemmas",
+      "Finite geometric series and telescoping",
+      "Induction over dyadic blocks"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-namespace",
+      "title": "Definition of the p-Series Partial Sum and the Split Lemma",
+      "startLine": 1,
+      "endLine": 75,
+      "summary": "Imports Mathlib.Analysis.PSeries. Defines Hp p N = ∑_{k∈range N} 1/(k+1)ᵖ with the real exponent through Real.rpow, indexed as in the parent. Hp_two_pow_succ splits H_p(2ⁿ⁺¹) into H_p(2ⁿ) plus one dyadic block; Hp_mono records monotonicity in N.",
+      "mathContext": "Hp p N = ∑_{j=1}^{N} 1/jᵖ. The range→range+Ico split aligns each induction step with one dyadic block."
+    },
+    {
+      "id": "divergent-regime",
+      "title": "Divergent Regime 0 < p ≤ 1: the Oresme Bound Survives",
+      "startLine": 76,
+      "endLine": 148,
+      "summary": "block_ge_half: for 0 < p ≤ 1 each dyadic block sums to ≥ 1/2 because raising 2ⁿ⁺¹ ≥ 1 to the smaller exponent p shrinks it. Hp_two_pow_ge: induction gives H_p(2ⁿ) ≥ 1 + n/2. Hp_exceeds and Hp_tendsto_atTop give explicit exceedance and divergence to +∞.",
+      "mathContext": "$H_p(2^n) \\ge 1 + n/2$ for $0 < p \\le 1$: since $1/j^p \\ge 1/j$, the p-series diverges at least as fast as the harmonic series."
+    },
+    {
+      "id": "rpow-identity",
+      "title": "The Geometric-Ratio rpow Identity",
+      "startLine": 150,
+      "endLine": 165,
+      "summary": "two_pow_div_rpow: the algebraic core 2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ, proved by converting natural powers to rpow (rpow_natCast), splitting the product (rpow_mul), and combining the quotient (rpow_sub).",
+      "mathContext": "$2^n / (2^n)^p = 2^{n(1-p)} = (2^{1-p})^n$, the ratio that makes the dyadic blocks geometric."
+    },
+    {
+      "id": "convergent-regime",
+      "title": "Convergent Regime p > 1: the Uniform Explicit Ceiling",
+      "startLine": 166,
+      "endLine": 242,
+      "summary": "block_le_geom: each dyadic block ≤ (2^{1-p})ⁿ. geom_partial_le: ∑_{i<n} rⁱ ≤ 1/(1−r) for 0 ≤ r < 1 via geom_sum_mul. Hp_two_pow_le: H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}) for p > 1, with ratio < 1 from rpow_lt_one_of_one_lt_of_neg. Hp_bddAbove lifts the ceiling to all partial sums.",
+      "mathContext": "$H_p(2^n) \\le 1 + \\sum_{i<n} (2^{1-p})^i \\le 1 + \\frac{1}{1 - 2^{1-p}}$, a finite bound independent of $n$, so the partial sums are bounded."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Oresme, Nicole",
+      "title": "Quaestiones super geometriam Euclidis",
+      "year": "~1350",
+      "note": "Dyadic grouping argument for harmonic divergence, generalized here to the p-series"
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Cours d'analyse de l'École royale polytechnique",
+      "year": "1821",
+      "note": "Condensation test: ∑ aₙ and ∑ 2ⁿ a_{2ⁿ} converge together — the qualitative shadow of these explicit dyadic bounds"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-05",
+      "relationship": "generalizes",
+      "description": "Extends the parent's explicit Oresme bound H_{2ⁿ} ≥ 1 + n/2 (p = 1) to the full real p-series, and answers its open question 'Does the same dyadic induction give explicit bounds for the p-series partial sums when p is near 1?'"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-04",
+      "relationship": "sharpens",
+      "description": "OQ-04 formalizes the qualitative Cauchy condensation test; this entry keeps the dyadic blocks but extracts explicit two-sided partial-sum bounds rather than only convergence/divergence"
+    }
+  ],
+  "conclusion": {
+    "summary": "Oresme's dyadic-block induction, applied to the general real p-series, yields explicit two-sided partial-sum bounds: H_p(2ⁿ) ≥ 1 + n/2 for 0 < p ≤ 1 (divergence) and H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p}) uniformly for p > 1 (bounded, hence convergent). The threshold p = 1 is exactly where the per-block estimate turns from ≥ 1/2 into a summable geometric majorant.",
+    "implications": "The convergence dichotomy of the p-series is recovered with explicit constants from a single elementary technique, with the parent's harmonic bound as the boundary case. The ceiling 1 + 1/(1 − 2^{1-p}) gives a concrete, computable upper bound on ∑ 1/jᵖ via the dyadic subsequence.",
+    "openQuestions": [
+      "Can the explicit ceiling be sharpened to the true tail constant, e.g. relating 1 + 1/(1 − 2^{1-p}) to ζ(p) as p → ∞?",
+      "Does the dyadic majorization upgrade to an explicit Summable witness with a quantitative rate of convergence for the p-series tails?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "HarmonicDivergenceOQ05OQ02",
+    "lineCount": 242,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/HarmonicDivergenceOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/harmonic-divergence-oq-05-oq-02.json
+++ b/src/data/research/problems/harmonic-divergence-oq-05-oq-02.json
@@ -1,0 +1,153 @@
+{
+  "slug": "harmonic-divergence-oq-05-oq-02",
+  "title": "Dyadic Explicit Bounds for p-Series Partial Sums Near p = 1",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "H^{(p)}_{2^n} \\;=\\; \\sum_{k=1}^{2^n} \\frac{1}{k^{p}} \\;\\ge\\; 2^{-p}\\cdot\\frac{2^{\\,n(1-p)} - 1}{2^{\\,1-p} - 1}.",
+    "plain": "The parent (`harmonic-divergence-oq-05`) proves Oresme's explicit lower bound",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T01:25:49-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Verified 0-axiom proof shipped. Generalized Oresme dyadic bound to real p-series: H_p(2ⁿ) ≥ 1+n/2 for 0<p≤1 (divergence) and H_p(2ⁿ) ≤ 1+1/(1−2^{1-p}) for p>1 (uniform ceiling, bounded). Answers parent oq-05 open question.",
+    "builtItems": [
+      "Hp_two_pow_ge: H_p(2ⁿ)≥1+n/2 for 0<p≤1 (HarmonicDivergenceOQ05OQ02.lean:120)",
+      "Hp_two_pow_le: H_p(2ⁿ)≤1+1/(1−2^{1-p}) for p>1 (HarmonicDivergenceOQ05OQ02.lean:217)",
+      "block_le_geom: dyadic block ≤(2^{1-p})ⁿ (HarmonicDivergenceOQ05OQ02.lean:166)",
+      "two_pow_div_rpow: 2ⁿ/(2ⁿ)ᵖ=(2^{1-p})ⁿ via rpow_natCast/rpow_mul/rpow_sub (HarmonicDivergenceOQ05OQ02.lean:153)",
+      "Hp_bddAbove: all partial sums ≤ ceiling for p>1 via N≤2ᴺ + monotonicity (HarmonicDivergenceOQ05OQ02.lean:237)"
+    ],
+    "insights": [
+      "p=1 is the exact threshold where the per-dyadic-block estimate flips: ≥1/2 (divergent) for p≤1, summable geometric majorant (2^{1-p})ⁿ for p>1",
+      "Divergent side is constant-free: for 0<p≤1, 1/jᵖ≥1/j gives the SAME harmonic bound H_p(2ⁿ)≥1+n/2 verbatim",
+      "Convergent side ceiling 1+1/(1−2^{1-p}) is original — Mathlib (Real.summable_one_div_nat_rpow) only asserts summability, no explicit partial-sum bound",
+      "Lower bound needs BOTH rpow monotonicities: rpow_le_rpow (base, exp≥0) then rpow_le_rpow_of_exponent_le (exp, base≥1) to get (k+1)ᵖ≤2ⁿ⁺¹"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Sharpen ceiling toward ζ(p) as p→∞",
+      "Upgrade dyadic majorization to explicit Summable witness with quantitative tail rate"
+    ],
+    "markdown": "# Knowledge Base: harmonic-divergence-oq-05-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "analysis",
+    "series",
+    "dyadic-blocks"
+  ],
+  "relatedProofs": [
+    "harmonic-divergence",
+    "harmonic-divergence-oq-01",
+    "harmonic-divergence-oq-02",
+    "harmonic-divergence-oq-03",
+    "harmonic-divergence-oq-04",
+    "harmonic-divergence-oq-05",
+    "harmonic-divergence-oq-06"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T08:41:40.943Z",
+  "lastUpdate": "2026-06-24T08:41:40.971Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/HarmonicDivergence.lean",
+      "filename": "HarmonicDivergence.lean",
+      "lineCount": 182,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergence.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ01.lean",
+      "filename": "HarmonicDivergenceOQ01.lean",
+      "lineCount": 254,
+      "theoremCount": 52,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ01.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ02.lean",
+      "filename": "HarmonicDivergenceOQ02.lean",
+      "lineCount": 290,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ02.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ03.lean",
+      "filename": "HarmonicDivergenceOQ03.lean",
+      "lineCount": 154,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ03.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ04.lean",
+      "filename": "HarmonicDivergenceOQ04.lean",
+      "lineCount": 107,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ04.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ05.lean",
+      "filename": "HarmonicDivergenceOQ05.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ05.lean"
+    },
+    {
+      "path": "Proofs/HarmonicDivergenceOQ06.lean",
+      "filename": "HarmonicDivergenceOQ06.lean",
+      "lineCount": 85,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HarmonicDivergenceOQ06.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the parent entry **harmonic-divergence-oq-05** (Oresme's explicit lower bound `H_{2ⁿ} ≥ 1 + n/2` for the harmonic series, `p = 1`) to the full real **p-series** `H_p(N) = ∑_{j=1}^{N} 1/jᵖ`, extracting *two-sided* explicit dyadic partial-sum bounds. This directly answers the parent's stated open question:

> *"Does the same dyadic induction give explicit bounds for the p-series partial sums when p is near 1?"*

## Results (all verified, 0 axioms, 0 sorries)

**Divergent regime `0 < p ≤ 1`:**
- `Hp_two_pow_ge`: `H_p(2ⁿ) ≥ 1 + n/2` — the Oresme bound survives verbatim (since `1/jᵖ ≥ 1/j`, the p-series diverges at least as fast as the harmonic series).
- `Hp_tendsto_atTop`: divergence to `+∞`, re-derived from the explicit bound plus monotonicity.

**Convergent regime `p > 1`:**
- `block_le_geom`: each dyadic block `≤ (2^{1-p})ⁿ`.
- `Hp_two_pow_le`: the uniform explicit ceiling `H_p(2ⁿ) ≤ 1 + 1/(1 − 2^{1-p})`, independent of `n`.
- `Hp_bddAbove`: every partial sum (not only the dyadic subsequence) is bounded by the ceiling.

The threshold `p = 1` is exactly where the per-block estimate flips from `≥ 1/2` to the summable geometric majorant `(2^{1-p})ⁿ`. Mathlib has the qualitative p-series dichotomy (`Real.summable_one_div_nat_rpow`) but no explicit partial-sum bounds — the constants `1 + n/2` and `1 + 1/(1 − 2^{1-p})` are original to this gallery family.

## Technical notes
- Real exponent `p` throughout, via `Real.rpow`.
- Algebraic core `two_pow_div_rpow`: `2ⁿ/(2ⁿ)ᵖ = (2^{1-p})ⁿ` (rpow_natCast / rpow_mul / rpow_sub), converting the dyadic block bound into a geometric ratio.
- 11 theorems/lemmas, 1 definition, 242 lines.

## Verification
- `lake env lean Proofs/HarmonicDivergenceOQ05OQ02.lean` — compiles clean, 0 errors.
- `#print axioms` on `Hp_two_pow_ge`, `Hp_two_pow_le`, `Hp_tendsto_atTop`, `Hp_bddAbove` reports only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)