### PR TITLE
Enrich Euler's Triangle Formula OI² = R² − 2Rr and Euler's Inequality R ≥ 2r

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02/annotations.json
@@ -1,0 +1,133 @@
+[
+  {
+    "id": "ann-euler-equidist",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 117
+    },
+    "type": "context",
+    "title": "Circumcenter equidistance (local)",
+    "content": "The proof reproves the two perpendicular-bisector relations $|B-O|^2 = |A-O|^2$ and $|C-O|^2 = |A-O|^2$ (the parent's are `private`). Each bisector identity is *linear* in the circumcenter $O$, so substituting the explicit formula closes it by `field_simp; ring`, then `nlinarith` upgrades it to the squared-distance equality. These three equal radii $|A-O| = |B-O| = |C-O| = R$ are exactly what collapses the incenter expansion in Part III.",
+    "mathContext": "$|A-O| = |B-O| = |C-O| = R.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "circumcenter",
+      "perpendicular bisector",
+      "circumradius"
+    ],
+    "prerequisites": [
+      "coordinate geometry"
+    ]
+  },
+  {
+    "id": "ann-euler-positivity",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 183
+    },
+    "type": "context",
+    "title": "Positivity of side lengths, area, and perimeter",
+    "content": "Bookkeeping that makes the later square-root and division steps legitimate: each side length $a, b, c$ is strictly positive (a degenerate side would contradict `T.nondegenerate`), the area is positive, and hence the perimeter $a+b+c > 0$ — needed to cancel the common denominator in the incenter formula. The squared-side lemmas ($a^2 = |BC|^2$, etc.) let the coordinate algebra run without `sqrt`.",
+    "mathContext": "$a, b, c > 0,\\ \\mathrm{Area} > 0,\\ a+b+c > 0;\\quad a^2 = |BC|^2.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-degeneracy",
+      "positivity",
+      "side lengths"
+    ],
+    "prerequisites": [
+      "coordinate geometry",
+      "Real.sqrt"
+    ]
+  },
+  {
+    "id": "ann-euler-affine-core",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 189,
+      "endLine": 253
+    },
+    "type": "insight",
+    "title": "The affine core: OI² = R² − abc/(a+b+c)",
+    "content": "The heart of Euler's formula, proved with no square roots. The incenter is the side-length-weighted average $I = \\frac{aA + bB + cC}{a+b+c}$. The master identity `weighted_norm_sq` expands $\\|a(A-O)+b(B-O)+c(C-O)\\|^2$, and the three equal radii plus the dot-product identities $\\,(A-O)\\cdot(B-O) = R^2 - c^2/2$ collapse it to $R^2(a+b+c)^2 - abc(a+b+c)$. Dividing by $(a+b+c)^2$ (then cancelling one factor) gives $\\mathrm{dist}^2(O,I) = R^2 - \\frac{abc}{a+b+c}$ (`OI_sq_eq_R2_sub`).",
+    "mathContext": "$\\mathrm{dist}^2(O,I) = R^2 - \\dfrac{abc}{a+b+c},\\quad I = \\dfrac{aA+bB+cC}{a+b+c}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "incenter",
+      "weighted barycenter",
+      "law of cosines",
+      "Euler's formula"
+    ],
+    "prerequisites": [
+      "circumcenter equidistance",
+      "incenter formula"
+    ]
+  },
+  {
+    "id": "ann-euler-law-of-sines",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 260,
+      "endLine": 332
+    },
+    "type": "technique",
+    "title": "The law-of-sines bridge: 4·R·Area = abc",
+    "content": "To turn the affine core's $\\frac{abc}{a+b+c}$ into $2Rr$ one needs the law of sines in area form. `sixteen_R2_area_sq` proves the *squared* coordinate identity $16R^2\\,\\mathrm{Area}^2 = a^2b^2c^2$; taking positive square roots (justified by the Part II positivity lemmas) gives `four_R_area_eq_abc`: $4R\\,\\mathrm{Area} = abc$. The squared form is what keeps the derivation polynomial — square roots enter only at the final extraction.",
+    "mathContext": "$16R^2\\,\\mathrm{Area}^2 = a^2b^2c^2 \\;\\Rightarrow\\; 4R\\,\\mathrm{Area} = abc.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "law of sines",
+      "triangle area",
+      "circumradius formula"
+    ],
+    "prerequisites": [
+      "positivity lemmas",
+      "circumradius"
+    ]
+  },
+  {
+    "id": "ann-euler-formula",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 338,
+      "endLine": 365
+    },
+    "type": "insight",
+    "title": "Euler's formula and inequality",
+    "content": "The payoff. Using $r = \\mathrm{Area}/s$ with $s = (a+b+c)/2$, the bridge gives `two_R_r_eq`: $2Rr = \\frac{abc}{a+b+c}$. Substituting into the affine core yields `euler_OI_formula`: $\\mathrm{dist}^2(O,I) = R^2 - 2Rr$ (Euler, 1765). Since a squared distance is non-negative, $R^2 - 2Rr \\ge 0$ and $R > 0$ force `euler_inequality`: $R \\ge 2r$ — with equality iff $O = I$ iff the triangle is equilateral.",
+    "mathContext": "$\\mathrm{dist}^2(O,I) = R^2 - 2Rr \\ge 0 \\;\\Rightarrow\\; R \\ge 2r.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's triangle formula",
+      "Euler's inequality",
+      "inradius",
+      "equilateral triangle"
+    ],
+    "prerequisites": [
+      "the affine core",
+      "the law-of-sines bridge"
+    ]
+  },
+  {
+    "id": "ann-euler-example",
+    "proofId": "feuerbachs-theorem-defs-oq-02",
+    "range": {
+      "startLine": 371,
+      "endLine": 385
+    },
+    "type": "context",
+    "title": "Worked example: the 3-4-5 triangle",
+    "content": "`triangle_345_OI_sq`: for the 3-4-5 right triangle, $\\mathrm{dist}^2(O,I) = 5/4$, matching $R^2 - 2Rr = (5/2)^2 - 2\\cdot(5/2)\\cdot1 = 25/4 - 5 = 5/4$ (`triangle_345_euler`). Here $R = 5/2$ (half the hypotenuse) and $r = 1$, a clean numeric confirmation of Euler's formula.",
+    "mathContext": "$R = 5/2,\\ r = 1:\\quad R^2 - 2Rr = 25/4 - 5 = 5/4 = \\mathrm{dist}^2(O,I).$",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "right triangle"
+    ],
+    "prerequisites": [
+      "Euler's formula"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-02` (quality 45, pass 0).

## Gap
Rich meta.json but **no annotations.json** — zero inline annotation coverage.

## Changes
Added `annotations.json` with **6 annotations** covering the full proof:
1. Circumcenter equidistance (local)
2. Positivity of side lengths, area, and perimeter
3. The affine core: OI² = R² − abc/(a+b+c) (no square roots)
4. The law-of-sines bridge: 4·R·Area = abc
5. Euler's formula and inequality (R ≥ 2r)
6. Worked example: the 3-4-5 triangle

Each includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- `pnpm annotations:build` passes with **no warnings** for this entry.
- JSON validated. meta.json unchanged (verified, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)