### PR TITLE
research(summation-by-parts-oq-01-oq-02-oq-01): second-moment sum ∑k²·rᵏ over any field — falling factorials + genuine Abel summation by parts [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3689,6 +3689,7 @@ import Proofs.SummationByPartsOQ01OQ01OQ01OQ02
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02OQ01
+import Proofs.SummationByPartsOQ01OQ02OQ01
 import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02

--- a/proofs/Proofs/SummationByPartsOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/SummationByPartsOQ01OQ02OQ01.lean
@@ -1,0 +1,118 @@
+import Mathlib.Algebra.BigOperators.Module
+import Mathlib.Tactic
+
+/-
+# Second-moment sum `∑ k²·rᵏ` over any field: falling factorials and Abel summation
+
+## What This Proves
+
+For a field element `r ≠ 1` and a natural number `n`,
+
+    ∑_{k=0}^{n-1} k² · rᵏ
+      = (rⁿ·(n² + (1 + 2n − 2n²)·r + (n−1)²·r²) − r − r²) / (r − 1)³.
+
+This is the **second-moment** arithmetico-geometric sum (each term `k²` times a
+geometric factor `rᵏ`).  Dropping the `rⁿ`-block leaves `(−r − r²)/(r − 1)³ =
+r(1+r)/(1−r)³`, the classical `∑ k²·rᵏ` for `|r| < 1`.
+
+## Relation to the Sibling Entry
+
+The entry `summation-by-parts-oq-01-oq-02` establishes the same headline closed
+form, but only **over `ℝ`** and **by bare induction** (clearing `(1−r)³` and
+closing with `ring`).  This entry strengthens that result along three axes:
+
+* **Generality.** The identity holds over an *arbitrary field* `K`, with no
+  reference to `ℝ` — it is an algebraic, not analytic, fact.
+* **The genuine summation-by-parts derivation.** The sibling never actually uses
+  Abel summation (despite the entry-family name).  Here
+  `sum_range_sq_geom_eq_byParts` re-derives the sum through
+  `Finset.sum_range_by_parts`, exposing that the weight `f(k) = k²` has *linear*
+  forward differences `f(k+1) − f k = 2k + 1`, so each nested geometric partial
+  sum is weighted by `2i + 1` — the discrete signature of differentiating `k²`.
+* **The falling-factorial companion and decomposition.**
+  `sum_range_falling_geom` evaluates `∑ k(k−1)·rᵏ` (the discrete second
+  derivative of the geometric series, limit `2r²/(1−r)³`), and
+  `sum_sq_eq_falling_add_linear` realizes `k² = k(k−1) + k` as a term-by-term
+  identity of finite sums — tying the second moment, the second falling moment,
+  and the first moment into one family.
+
+## Method
+
+Both closed forms are proved by induction on `n`: `Finset.sum_range_succ` adds
+the next term to the closed form at `m`, and clearing the common denominator
+`(r−1)³` (using `r − 1 ≠ 0`) reduces the goal to a polynomial identity closed by
+`ring` after `push_cast`/`field_simp`.  The decomposition is `Finset.sum_add_distrib`
+plus `ring` on the summand; the Abel form specializes `Finset.sum_range_by_parts`.
+-/
+
+namespace SummationByPartsOQ01OQ02OQ01
+
+open Finset
+
+variable {K : Type*} [Field K]
+
+/-- **Second-moment arithmetico-geometric sum, closed form, over any field.**
+For `r ≠ 1`,
+`∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1 + 2n − 2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³`. -/
+theorem sum_range_sq_geom {r : K} (hr : r ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * r ^ k
+      = (r ^ n * ((n : K) ^ 2 + (1 + 2 * (n : K) - 2 * (n : K) ^ 2) * r
+            + ((n : K) - 1) ^ 2 * r ^ 2) - r - r ^ 2) / (r - 1) ^ 3 := by
+  have hr1 : r - 1 ≠ 0 := sub_ne_zero.mpr hr
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ, ih]
+      push_cast
+      field_simp
+      ring
+
+/-- **Second falling-factorial sum, closed form.**
+For `r ≠ 1`,
+`∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n − 2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³`.
+This is the discrete analogue of the second derivative of the geometric series;
+its `n → ∞` limit for `|r| < 1` is `2r²/(1−r)³`. -/
+theorem sum_range_falling_geom {r : K} (hr : r ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) * ((k : K) - 1) * r ^ k
+      = (r ^ n * ((n : K) * ((n : K) - 1) + (4 * (n : K) - 2 * (n : K) ^ 2) * r
+            + ((n : K) - 1) * ((n : K) - 2) * r ^ 2) - 2 * r ^ 2) / (r - 1) ^ 3 := by
+  have hr1 : r - 1 ≠ 0 := sub_ne_zero.mpr hr
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ, ih]
+      push_cast
+      field_simp
+      ring
+
+/-- **Structural decomposition `k² = k(k−1) + k`.**
+The second moment splits, term by term, as the second falling moment plus the
+first moment — no closed forms required. -/
+theorem sum_sq_eq_falling_add_linear (r : K) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * r ^ k
+      = (∑ k ∈ range n, (k : K) * ((k : K) - 1) * r ^ k)
+        + ∑ k ∈ range n, (k : K) * r ^ k := by
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro k _
+  ring
+
+/-- The second-moment sum re-derived through **Abel's summation by parts**.
+Taking the weight `f k = (k : K)²` and the geometric sequence `g k = rᵏ`,
+`Finset.sum_range_by_parts` rewrites the sum as a boundary term minus a
+correction whose increments `f(k+1) − f k = 2k + 1` are *linear* in `k`; the
+correction therefore weights each nested geometric partial sum by `2i + 1`. -/
+theorem sum_range_sq_geom_eq_byParts (r : K) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * r ^ k
+      = (↑(n - 1) : K) ^ 2 * (∑ i ∈ range n, r ^ i)
+        - ∑ i ∈ range (n - 1), (2 * (i : K) + 1) * (∑ j ∈ range (i + 1), r ^ j) := by
+  have h := Finset.sum_range_by_parts (fun k => (k : K) ^ 2) (fun k => r ^ k) n
+  simp only [smul_eq_mul] at h
+  rw [h]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+end SummationByPartsOQ01OQ02OQ01

--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-sbpoq010201-header",
+    "proofId": "summation-by-parts-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 46 },
+    "type": "concept",
+    "title": "Strengthening the Second-Moment Sum: Field Generality and Summation by Parts",
+    "content": "This module evaluates the finite second-moment sum S(n) = ∑_{k<n} k²·rᵏ over an ARBITRARY field K. It strengthens the sibling entry summation-by-parts-oq-01-oq-02, which proves the same headline closed form but only over ℝ and by bare induction. Three additions: (1) the field-general closed form; (2) the genuine Abel summation-by-parts derivation the sibling omits; (3) the second falling-factorial companion ∑ k(k−1)·rᵏ together with the decomposition k²=k(k−1)+k.",
+    "mathContext": "The closed form is purely algebraic — a polynomial-over-(r−1)³ identity with no norm and no |r|<1 hypothesis. The n-independent block (−r−r²)/(r−1)³ equals r(1+r)/(1−r)³, the n→∞ limit when |r|<1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetico-geometric sum",
+      "second moment",
+      "falling factorial",
+      "Abel summation by parts"
+    ],
+    "prerequisites": [
+      "Finite sums over Finset.range",
+      "Field arithmetic and field_simp"
+    ]
+  },
+  {
+    "id": "ann-sbpoq010201-main",
+    "proofId": "summation-by-parts-oq-01-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 69 },
+    "type": "key_step",
+    "title": "Main Theorem: Field-General Closed Form by Induction",
+    "content": "sum_range_sq_geom proves ∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1+2n−2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³ for r ≠ 1 over any field. The numerator coefficients (in particular 1+2n−2n² and (n−1)²) are written with (n:K), so the field subtraction is genuine and never truncates as it would in ℕ. The zero case is the empty sum (simp). The successor case peels m²·rᵐ via Finset.sum_range_succ, applies the inductive hypothesis, and after push_cast / field_simp (using r−1 ≠ 0) reduces to a polynomial identity closed by ring.",
+    "mathContext": "field_simp clears the common (r−1)³ denominator that appears at both m and m+1; ring then verifies the resulting polynomial identity in r and the atom rᵐ (with rᵐ⁺¹ = rᵐ·r).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "field_simp",
+      "ring",
+      "induction"
+    ],
+    "prerequisites": [
+      "Casting ℕ into a field (push_cast)",
+      "Clearing denominators with field_simp"
+    ]
+  },
+  {
+    "id": "ann-sbpoq010201-falling",
+    "proofId": "summation-by-parts-oq-01-oq-02-oq-01",
+    "range": { "startLine": 75, "endLine": 88 },
+    "type": "key_step",
+    "title": "Falling-Factorial Companion ∑ k(k−1)·rᵏ",
+    "content": "sum_range_falling_geom evaluates ∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n−2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³, by the same induction. This is the discrete analogue of the SECOND derivative of the geometric series: the n-independent block −2r²/(r−1)³ equals 2r²/(1−r)³, the classical infinite value. Pairing it with the first-moment and second-moment forms covers all degree-≤2 weighted geometric sums.",
+    "mathContext": "The falling factorial k(k−1) is the natural basis for discrete differentiation: its forward difference (k+1)k − k(k−1) = 2k drops the degree by one, mirroring d/dx of a monomial.",
+    "significance": "key",
+    "relatedConcepts": [
+      "falling factorial",
+      "discrete second derivative",
+      "geometric series differentiation"
+    ],
+    "prerequisites": [
+      "Induction on Finset.range sums"
+    ]
+  },
+  {
+    "id": "ann-sbpoq010201-decomp",
+    "proofId": "summation-by-parts-oq-01-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 100 },
+    "type": "key_step",
+    "title": "The Decomposition k² = k(k−1) + k",
+    "content": "sum_sq_eq_falling_add_linear proves ∑ k²·rᵏ = (∑ k(k−1)·rᵏ) + ∑ k·rᵏ with no closed forms: Finset.sum_add_distrib merges the two right-hand sums into one, and Finset.sum_congr + ring verify the summand identity k²·rᵏ = k(k−1)·rᵏ + k·rᵏ term by term. This exhibits the second moment as literally the sum of the second falling moment and the first moment.",
+    "mathContext": "k² = k(k−1) + k is the order-2 instance of expressing ordinary powers in the falling-factorial basis (via Stirling numbers of the second kind); the identity lifts verbatim to the weighted sums.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "Stirling numbers",
+      "falling factorial basis"
+    ],
+    "prerequisites": [
+      "Linearity of finite sums"
+    ]
+  },
+  {
+    "id": "ann-sbpoq010201-byparts",
+    "proofId": "summation-by-parts-oq-01-oq-02-oq-01",
+    "range": { "startLine": 105, "endLine": 117 },
+    "type": "key_step",
+    "title": "The Genuine Abel Summation-by-Parts Derivation",
+    "content": "sum_range_sq_geom_eq_byParts re-derives the sum through Finset.sum_range_by_parts with weight f(k)=k² and sequence g(k)=rᵏ. The result is a boundary term (n−1)²·Gₙ minus a correction ∑_{i<n−1} (2i+1)·G_{i+1}, where Gₘ = ∑_{j<m} rʲ is the geometric partial sum. The 2i+1 factor is the forward difference f(i+1)−f(i) = (i+1)²−i², discharged by push_cast and ring after the congruence. This is the summation-by-parts derivation the ℝ-only sibling never performs, despite the entry-family name.",
+    "mathContext": "Contrast with the first moment, where f(k)=k has CONSTANT differences 1 and the correction collapses to a plain sum of partial sums. The linear differences 2k+1 are the discrete fingerprint of differentiating k²; for a degree-d weight the differences have degree d−1, recursing the closed form.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_by_parts",
+      "Abel summation",
+      "forward differences",
+      "discrete integration by parts"
+    ],
+    "prerequisites": [
+      "Abel's summation by parts",
+      "Partial sums of the geometric series"
+    ]
+  }
+]

--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SummationByPartsOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const summationByPartsOQ01OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const summationByPartsOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const summationByPartsOQ01OQ02OQ01Data: ProofData = {
+  proof: summationByPartsOQ01OQ02OQ01Proof,
+  annotations: summationByPartsOQ01OQ02OQ01Annotations,
+}

--- a/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "summation-by-parts-oq-01-oq-02-oq-01",
+  "slug": "summation-by-parts-oq-01-oq-02-oq-01",
+  "title": "Second-Moment Sum ∑ k²·rᵏ over Any Field: Falling Factorials and Abel Summation",
+  "description": "Strengthens the second-moment closed form ∑_{k<n} k²·rᵏ from ℝ to an arbitrary field, supplies the genuine Abel summation-by-parts derivation the sibling entry omitted (the weight k² has linear differences 2k+1), adds the second falling-factorial closed form ∑ k(k−1)·rᵏ (limit 2r²/(1−r)³), and realizes k²=k(k−1)+k as a term-by-term identity of finite sums. All over any field, for every r ≠ 1, verified with 0 axioms.",
+  "meta": {
+    "author": "Classical (Abel summation); formalized for the lean-genius gallery",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SummationByPartsOQ01OQ02OQ01.lean",
+    "tags": [
+      "algebra",
+      "finite-sums",
+      "arithmetico-geometric",
+      "second-moment",
+      "summation-by-parts",
+      "abel-summation",
+      "geometric-series",
+      "falling-factorial",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n, the step driving the induction for both closed forms",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_by_parts",
+        "description": "Abel's summation by parts for ranges: ∑ i<n, f i • g i = f(n-1)•G n − ∑ i<n-1, (f(i+1)−f i)•G(i+1), where G is the partial sum of g",
+        "module": "Mathlib.Algebra.BigOperators.Module"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "∑ (f i + g i) = ∑ f i + ∑ g i, used to split the second moment into the second falling moment plus the first moment term by term",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Generalizes the second-moment closed form ∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1+2n−2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³ from ℝ (the sibling entry summation-by-parts-oq-01-oq-02) to an arbitrary field — an algebraic, not analytic, identity valid for every r ≠ 1",
+      "Supplies the genuine Abel summation-by-parts derivation absent from the sibling: with weight f(k)=k² the forward differences f(k+1)−f(k)=2k+1 are linear (not constant, as for the first moment), so the correction term weights each nested geometric partial sum by 2i+1",
+      "The companion second falling-factorial closed form ∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n−2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³, the discrete analogue of the second derivative of the geometric series (limit 2r²/(1−r)³)",
+      "The structural decomposition k² = k(k−1) + k realized at the level of finite sums (sum_sq_eq_falling_add_linear), exhibiting the second moment as the sum of the second falling moment and the first moment with no closed form needed"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 4,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Module",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SummationByPartsOQ01OQ02OQ01",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/SummationByPartsOQ01OQ02OQ01.lean"
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Weighting the geometric series $\\sum_k r^k$ by $k$ gives the **arithmetico-geometric** sum (entry summation-by-parts-oq-01), and by $k^2$ the **second-moment** sum. These are the discrete shadows of differentiating the geometric series once and twice; their $n\\to\\infty$ limits (for $|r|<1$) are $r/(1-r)^2$ and $r(1+r)/(1-r)^3$. The classical tool is **Abel's summation by parts**, the discrete analogue of integration by parts. The sibling entry summation-by-parts-oq-01-oq-02 evaluates the second moment over $\\mathbb{R}$ by bare induction; this entry returns the result to its natural algebraic generality and to the summation-by-parts method the family is named for.",
+    "problemStatement": "**Theorem.** For $r$ in an arbitrary field $K$ with $r \\neq 1$ and $n \\in \\mathbb{N}$,\n$$\\sum_{k=0}^{n-1} k^2\\,r^{k} = \\frac{r^{n}\\bigl(n^2 + (1+2n-2n^2)\\,r + (n-1)^2\\,r^2\\bigr) - r - r^2}{(r-1)^3}.$$\nDropping the $r^n$-block leaves $(-r-r^2)/(r-1)^3 = r(1+r)/(1-r)^3$, the textbook $\\sum_{k\\ge0} k^2 r^k$ for $|r|<1$.",
+    "proofStrategy": "**Induction (headline).** Base case $n=0$ is the empty sum, $0=0/(r-1)^3$. The step adds $m^2 r^m$ (via `Finset.sum_range_succ`) to the closed form at $m$; clearing $(r-1)^3$ with $r-1\\neq0$ reduces to a polynomial identity closed by `ring` after `push_cast`/`field_simp`. The same scheme proves $\\sum k(k-1)r^k$.\n\n**Decomposition.** Since $k^2=k(k-1)+k$, the second moment splits term by term (`sum_sq_eq_falling_add_linear`), via `Finset.sum_add_distrib` and `ring`.\n\n**Summation by parts.** Specializing `Finset.sum_range_by_parts` to $f(k)=k^2$ gives the boundary term $(n-1)^2 G_n$ minus a correction; the differences $f(k+1)-f(k)=2k+1$ are linear, so $G_{i+1}$ is weighted by $2i+1$.",
+    "keyInsights": [
+      "**Field, not analysis.** The sibling entry works over $\\mathbb{R}$; but the identity is a polynomial-over-$(r-1)^3$ statement needing no norm and no convergence — it holds over any field for every $r\\neq1$, with $r(1+r)/(1-r)^3$ merely its $n\\to\\infty$ shadow when $|r|<1$.",
+      "**Linear differences are the fingerprint of $k^2$.** Abel summation expresses the sum via the forward differences of the weight: constant ($1$) for the first moment, linear ($2k+1$) for the second. The order of the discrete derivative is read off directly from how the correction term is weighted.",
+      "**One consistent family.** The falling-factorial form, the second-moment form, and the sibling first-moment form are tied by $k^2=k(k-1)+k$ as a term-by-term identity of finite sums — the second moment is literally the sum of the other two."
+    ]
+  },
+  "sections": [
+    {
+      "title": "The Second-Moment Closed Form over Any Field",
+      "body": ""
+    },
+    {
+      "title": "The Falling-Factorial Companion ∑ k(k−1)·rᵏ",
+      "body": ""
+    },
+    {
+      "title": "The Decomposition k² = k(k−1) + k",
+      "body": ""
+    },
+    {
+      "title": "The Abel Summation-by-Parts Derivation",
+      "body": ""
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sum_range_sq_geom",
+      "type": "core",
+      "description": "Second-moment closed form over any field: ∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1+2n−2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³ for r ≠ 1",
+      "leanType": "∀ {K : Type*} [Field K] {r : K}, r ≠ 1 → ∀ (n : ℕ), ∑ k ∈ Finset.range n, (k : K) ^ 2 * r ^ k = (r ^ n * ((n : K) ^ 2 + (1 + 2 * (n : K) - 2 * (n : K) ^ 2) * r + ((n : K) - 1) ^ 2 * r ^ 2) - r - r ^ 2) / (r - 1) ^ 3"
+    },
+    {
+      "name": "sum_range_falling_geom",
+      "type": "core",
+      "description": "Second falling-factorial closed form: ∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n−2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³ for r ≠ 1",
+      "leanType": "∀ {K : Type*} [Field K] {r : K}, r ≠ 1 → ∀ (n : ℕ), ∑ k ∈ Finset.range n, (k : K) * ((k : K) - 1) * r ^ k = (r ^ n * ((n : K) * ((n : K) - 1) + (4 * (n : K) - 2 * (n : K) ^ 2) * r + ((n : K) - 1) * ((n : K) - 2) * r ^ 2) - 2 * r ^ 2) / (r - 1) ^ 3"
+    },
+    {
+      "name": "sum_sq_eq_falling_add_linear",
+      "type": "supporting",
+      "description": "Term-by-term decomposition k² = k(k−1) + k: the second moment is the second falling moment plus the first moment",
+      "leanType": "∀ {K : Type*} [Field K] (r : K) (n : ℕ), ∑ k ∈ Finset.range n, (k : K) ^ 2 * r ^ k = (∑ k ∈ Finset.range n, (k : K) * ((k : K) - 1) * r ^ k) + ∑ k ∈ Finset.range n, (k : K) * r ^ k"
+    },
+    {
+      "name": "sum_range_sq_geom_eq_byParts",
+      "type": "supporting",
+      "description": "Abel summation-by-parts form: the weight k² has linear differences 2k+1, weighting each nested geometric partial sum by 2i+1",
+      "leanType": "∀ {K : Type*} [Field K] (r : K) (n : ℕ), ∑ k ∈ Finset.range n, (k : K) ^ 2 * r ^ k = (↑(n - 1) : K) ^ 2 * (∑ i ∈ Finset.range n, r ^ i) - ∑ i ∈ Finset.range (n - 1), (2 * (i : K) + 1) * (∑ j ∈ Finset.range (i + 1), r ^ j)"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry returns the finite second-moment identity ∑_{k<n} k²·rᵏ to its natural algebraic generality (any field, not just ℝ) and supplies the genuine Abel summation-by-parts derivation its ℝ-only sibling omitted. It adds the second falling-factorial closed form ∑ k(k−1)·rᵏ and the term-by-term decomposition k²=k(k−1)+k, tying the degree-≤2 weighted geometric sums into one family.",
+    "implications": "Over any field the closed form is a polynomial-over-(r−1)³ identity with no analytic content. The summation-by-parts derivation makes explicit that the order of the discrete derivative (constant vs. linear forward differences) governs the shape of the correction term — the structural lever for the general ∑ P(k)·rᵏ.",
+    "openQuestions": [
+      "Does the same induction / by-parts scheme give the general ∑_{k<n} P(k)·rᵏ for a fixed polynomial P of degree d, with the closed form supported on r⁰…r^d in the constant block and a degree-d polynomial in n in the rⁿ-block? The falling-factorial basis k^(d) = k(k−1)⋯(k−d+1), whose Abel differences drop degree by one, suggests an induction on deg P.",
+      "Can the falling-factorial forms be packaged uniformly as ∑_{k<n} k^(d)·rᵏ in terms of the d-th finite difference of the geometric partial sum, making the discrete d-th derivative structure explicit?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "summation-by-parts-oq-01-oq-02",
+      "relationship": "strengthens",
+      "description": "The ℝ-only, induction-only second-moment closed form. This entry generalizes it to any field, adds the genuine Abel summation-by-parts derivation, the falling-factorial companion, and the k²=k(k−1)+k decomposition."
+    },
+    {
+      "targetId": "summation-by-parts-oq-01",
+      "relationship": "extends",
+      "description": "The first-moment closed form ∑ k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)². The decomposition k²=k(k−1)+k ties the second moment to this first moment."
+    },
+    {
+      "targetId": "geometric-series-oq-06",
+      "relationship": "refinement",
+      "description": "The infinite series ∑ k²·rⁿ = r(1+r)/(1−r)³ (‖r‖<1). This entry is its exact finite partial sum, valid over any field with no convergence hypothesis."
+    }
+  ]
+}

--- a/src/data/research/problems/summation-by-parts-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/summation-by-parts-oq-01-oq-02-oq-01.json
@@ -1,0 +1,80 @@
+{
+  "slug": "summation-by-parts-oq-01-oq-02-oq-01",
+  "title": "Second-moment sum ∑ k²·rᵏ over any field: falling factorials and Abel summation",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "started": "2026-06-24T09:05:00.000Z",
+  "lastUpdate": "2026-06-24T09:30:00.000Z",
+  "problemStatement": "The sibling entry summation-by-parts-oq-01-oq-02 evaluates the finite second-moment sum ∑_{k<n} k²·rᵏ over ℝ by bare induction. Strengthen it: prove the same closed form over an arbitrary field, supply the genuine Abel summation-by-parts derivation, add the second falling-factorial closed form ∑ k(k−1)·rᵏ, and realize k²=k(k−1)+k as a finite-sum identity.",
+  "knownResults": {
+    "proven": [
+      "∑_{k<n} k²·rᵏ = (rⁿ·(n² + (1+2n−2n²)·r + (n−1)²·r²) − r − r²)/(r−1)³ over any field, r ≠ 1 (sum_range_sq_geom)",
+      "∑_{k<n} k(k−1)·rᵏ = (rⁿ·(n(n−1) + (4n−2n²)·r + (n−1)(n−2)·r²) − 2r²)/(r−1)³ over any field (sum_range_falling_geom)",
+      "k² = k(k−1) + k as a term-by-term identity of finite sums (sum_sq_eq_falling_add_linear)",
+      "Abel summation-by-parts form: boundary (n−1)²·Gₙ minus correction ∑ (2i+1)·G_{i+1} (sum_range_sq_geom_eq_byParts)"
+    ],
+    "open": [],
+    "goal": "Generalize the second-moment closed form to any field and supply the summation-by-parts derivation plus the falling-factorial companion."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: field-general second-moment closed form + falling-factorial companion + k²=k(k−1)+k decomposition + genuine Abel summation-by-parts derivation; verified, 0 axioms.",
+    "builtItems": [
+      "sum_range_sq_geom in Proofs/SummationByPartsOQ01OQ02OQ01.lean (field-general second-moment closed form)",
+      "sum_range_falling_geom (second falling-factorial closed form)",
+      "sum_sq_eq_falling_add_linear (k²=k(k−1)+k finite-sum decomposition)",
+      "sum_range_sq_geom_eq_byParts (Abel summation-by-parts derivation)"
+    ],
+    "insights": [
+      "The second-moment closed form is purely algebraic — over any field, a polynomial-over-(r−1)³ identity, no norm or |r|<1 needed; the sibling's ℝ restriction was inessential.",
+      "Coefficients must be written with (n:K) so the field subtraction 1+2n−2n² etc. never truncates as it would in ℕ.",
+      "Abel summation by parts exposes the order of the discrete derivative: the weight k² has linear forward differences 2k+1 (vs constant 1 for k), so the correction weights each geometric partial sum by 2i+1.",
+      "The falling-factorial basis k(k−1) has forward difference 2k, dropping degree by one — the discrete analogue of differentiating a monomial."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no closed form for ∑ k²·rᵏ or ∑ k(k−1)·rᵏ; only geom_sum_eq for ∑ rᵏ."
+    ],
+    "nextSteps": [
+      "General ∑ P(k)·rᵏ for fixed polynomial P of degree d via induction on deg P in the falling-factorial basis.",
+      "Uniform ∑ k^(d)·rᵏ in terms of the d-th finite difference of the geometric partial sum."
+    ],
+    "markdown": "# Knowledge Base: summation-by-parts-oq-01-oq-02-oq-01\n\nDepth-2 extension of the second-moment sum entry. Strengthens the ℝ-only sibling summation-by-parts-oq-01-oq-02 to an arbitrary field, supplies the genuine Abel summation-by-parts derivation, the second falling-factorial closed form, and the k²=k(k−1)+k decomposition. Verified, 0 axioms.\n"
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/SummationByPartsOQ01OQ02OQ01.lean",
+      "filename": "SummationByPartsOQ01OQ02OQ01.lean",
+      "lineCount": 118,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SummationByPartsOQ01OQ02OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "summation-by-parts-oq-01",
+    "summation-by-parts-oq-01-oq-02",
+    "summation-by-parts-oq-01-oq-02-oq-01",
+    "geometric-series-oq-06"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Finset.sum_range_succ",
+      "Finset.sum_range_by_parts",
+      "Finset.sum_add_distrib"
+    ]
+  },
+  "tags": [
+    "algebra",
+    "finite-sums",
+    "second-moment",
+    "summation-by-parts",
+    "falling-factorial",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Depth-2 extension of the just-merged sibling **summation-by-parts-oq-01-oq-02** (PR #28882, researcher-4), which proved the second-moment closed form only **over ℝ** and **by bare induction**. This entry strengthens that result over three axes, all **over an arbitrary field**, verified with **0 axioms**.

For `r ≠ 1` in any field `K`:
$$\sum_{k=0}^{n-1} k^2 r^k = \frac{r^n\big(n^2 + (1+2n-2n^2)r + (n-1)^2 r^2\big) - r - r^2}{(r-1)^3}.$$

## Theorems (4, 118 lines, 0 axioms)

- **`sum_range_sq_geom`** — the second-moment closed form over any field (induction; `field_simp`/`ring`).
- **`sum_range_sq_geom_eq_byParts`** — the *genuine Abel summation-by-parts* derivation the sibling omits despite the family name: weight `f(k)=k²` has **linear** forward differences `f(k+1)−f(k)=2k+1` (vs. the constant `1` of the first moment), so the correction weights each nested geometric partial sum by `2i+1`.
- **`sum_range_falling_geom`** — the second falling-factorial closed form `∑ k(k−1)·rᵏ` (discrete 2nd derivative of the geometric series; limit `2r²/(1−r)³`).
- **`sum_sq_eq_falling_add_linear`** — `k² = k(k−1) + k` as a term-by-term identity of finite sums, tying the second moment, the second falling moment, and the first moment into one family.

## Why distinct from the merged sibling

| | sibling oq-01-oq-02 (merged) | this entry |
|---|---|---|
| Base ring | ℝ only | **arbitrary field** |
| Summation by parts | not used (induction only) | **genuine Abel derivation** |
| Falling factorial ∑k(k−1)rᵏ | — | **yes** |
| k²=k(k−1)+k decomposition | — | **yes** |

## Verification

`#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Built single-file against the Mathlib v4.26.0 cache (`lake env lean`). Closed forms were independently confirmed by exact rational arithmetic before formalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)