### PR TITLE
research(central-limit-theorem-oq-02): discharge α-mixing sorry + repair build [0 sorries]

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02.lean
@@ -502,15 +502,38 @@ theorem independent_implies_zero_mixing
     ∀ k n, n ≥ 1 →
       alphaMixingCoeff μ (σ_k k) (σ_k (k + n)) = 0 := by
   intro k n hn
-  simp only [alphaMixingCoeff]
-  -- Each term = 0 by independence: μ(A∩B) = μ(A)·μ(B)
-  -- For all measurable A ∈ σ_k(k), B ∈ σ_k(k+n):
-  --   k + n = k + (n-1) + 1, so hIndep applies with gap (n-1)
-  --   |μ(A∩B).toReal - μ(A).toReal · μ(B).toReal| = |0| = 0
-  -- The nested ciSup of all-zero nonneg terms over ℝ (ConditionallyCompleteLattice)
-  -- requires showing sSup of range = 0, which is technically involved due to
-  -- the interaction of Prop-indexed sups and missing CompleteLattice on ℝ.
-  sorry
+  -- Every term in the defining supremum vanishes: for measurable `A ∈ σ_k k`
+  -- and `B ∈ σ_k (k+n)`, independence (gap `n-1`) gives `μ (A ∩ B) = μ A * μ B`,
+  -- so `|(μ (A∩B)).toReal - (μ A).toReal * (μ B).toReal| = 0`.
+  have hbody : ∀ (A : Set Ω), @MeasurableSet Ω (σ_k k) A →
+      ∀ (B : Set Ω), @MeasurableSet Ω (σ_k (k + n)) B →
+      |(μ (A ∩ B)).toReal - (μ A).toReal * (μ B).toReal| = 0 := by
+    intro A hA B hB
+    have hk : k + n = k + (n - 1) + 1 := by omega
+    have hB' : @MeasurableSet Ω (σ_k (k + (n - 1) + 1)) B := by rw [← hk]; exact hB
+    have hind : μ (A ∩ B) = μ A * μ B := hIndep k (n - 1) A B hA hB'
+    rw [hind, ENNReal.toReal_mul]
+    simp
+  -- A Prop-indexed supremum of the constant `0` is `0` (both when the Prop
+  -- holds and when it is empty), sidestepping the lack of a `CompleteLattice`
+  -- instance on `ℝ`.
+  have h0p : ∀ (p : Prop), (⨆ (_ : p), (0 : ℝ)) = 0 := by
+    intro p
+    by_cases h : p
+    · haveI : Nonempty p := ⟨h⟩; simp
+    · haveI : IsEmpty p := ⟨h⟩; simp
+  -- Rewrite the whole nested supremum as a nested supremum of `0`, then collapse.
+  have collapse : alphaMixingCoeff μ (σ_k k) (σ_k (k + n))
+      = ⨆ (A : Set Ω), ⨆ (_ : @MeasurableSet Ω (σ_k k) A),
+          ⨆ (B : Set Ω), ⨆ (_ : @MeasurableSet Ω (σ_k (k + n)) B), (0 : ℝ) := by
+    simp only [alphaMixingCoeff]
+    apply iSup_congr; intro A
+    apply iSup_congr; intro hA
+    apply iSup_congr; intro B
+    apply iSup_congr; intro hB
+    exact hbody A hA B hB
+  rw [collapse]
+  simp only [h0p, ciSup_const]
 
 /-
 ## Part IX: Relationship Between Generalizations
@@ -719,11 +742,10 @@ theorem iid_satisfies_lyapunov
     have hd : (0 : ℝ) < (n : ℝ) ^ (δ / 2) := Real.rpow_pos_of_pos hn_pos _
     rw [hpow, hsplit]
     field_simp [hnne, hd.ne']
-    ring
   -- The closed form tends to 0 since δ/2 > 0.
   have hlim : Tendsto (fun n : ℕ => C / (n : ℝ) ^ (δ / 2)) atTop (nhds 0) := by
     have hpow_tendsto : Tendsto (fun n : ℕ => (n : ℝ) ^ (δ / 2)) atTop atTop :=
-      (Real.tendsto_rpow_atTop (by positivity : (0 : ℝ) < δ / 2)).comp
+      (tendsto_rpow_atTop (by positivity : (0 : ℝ) < δ / 2)).comp
         tendsto_natCast_atTop_atTop
     simpa using hpow_tendsto.const_div_atTop C
   -- Transfer the limit back to the Lyapunov sum via eventual equality.

--- a/research/problems/central-limit-theorem-oq-02-oq-03/knowledge.md
+++ b/research/problems/central-limit-theorem-oq-02-oq-03/knowledge.md
@@ -1,0 +1,32 @@
+# central-limit-theorem-oq-02-oq-03 — knowledge
+
+## Problem
+Fresh EMPTY child of central-limit-theorem-oq-02 (CLT for dependent random
+variables). No problem statement exists for this slug. Parent is axiomatized
+(1 axiom martingale_clt = McLeish 1974, deep) with heavy open follow-ups
+(martingale CLT via characteristic functions, Ibragimov mixing CLT).
+
+## Session 2026-06-24 (researcher-1) — sorry elimination + build repair in parent
+Pivoted to the parent CentralLimitTheoremOQ02.lean, which was committed BROKEN
+(did not build against the current Mathlib pin) and carried 1 sorry:
+- Discharged `independent_implies_zero_mixing`: independent σ-algebras ⇒
+  α-mixing coefficient = 0. Each term of the nested ⨆ vanishes by independence
+  (`μ(A∩B)=μA·μB`, `ENNReal.toReal_mul`); the all-zero nested ⨆ over ℝ collapses
+  via helper `∀ p:Prop, ⨆(_:p),(0:ℝ)=0` (by_cases: Nonempty⇒`ciSup_const`,
+  IsEmpty⇒`ciSup_of_empty`/`Real.sSup_empty`, both closed by `simp`) plus
+  `iSup_congr`×4 to rewrite the guarded body to 0, then `simp [h0p, ciSup_const]`.
+- Repaired 2 pre-existing Mathlib-drift breakages: `Real.tendsto_rpow_atTop` →
+  `tendsto_rpow_atTop` (root namespace, no `Real.`); removed a stale trailing
+  `ring` after a `field_simp` that now closes its own goal ("No goals to solve").
+
+Result: file builds clean, 0 sorries, 1 axiom (martingale_clt). `#print axioms
+independent_implies_zero_mixing` → propext/Classical.choice/Quot.sound only.
+
+### Gotchas
+- Committed "verified/axiomatized" gallery files can be silently BROKEN vs the
+  current pin (Mathlib drift). Always standalone-build before trusting.
+- `⨆ over ℝ` is conditionally-complete: `iSup` of unbounded/empty → junk(0);
+  Prop-indexed `⨆(_:p),c` needs case split on p, no `iSup_const`.
+
+## Still open
+- The actual oq-02-oq-03 question (undefined) and parent's deep CLT axiom.

--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "central-limit-theorem-oq-02",
   "title": "Central Limit Theorem for Dependent Random Variables",
   "slug": "central-limit-theorem-oq-02",
-  "description": "Formalizes the CLT beyond i.i.d. sequences to dependent random variables via two generalizations: the Martingale CLT (McLeish 1974) for martingale difference arrays with Lindeberg condition, and the \u03b1-mixing CLT (Ibragimov 1962) for stationary mixing sequences. Proves Lyapunov implies Lindeberg, i.i.d. variance convergence, and classical CLT recovery. 23 theorems, 1 axiom, 1 sorry.",
+  "description": "Formalizes the CLT beyond i.i.d. sequences to dependent random variables via two generalizations: the Martingale CLT (McLeish 1974) for martingale difference arrays with Lindeberg condition, and the α-mixing CLT (Ibragimov 1962) for stationary mixing sequences. Proves Lyapunov implies Lindeberg, i.i.d. variance convergence, and classical CLT recovery. 23 theorems, 1 axiom, 1 sorry. UPDATE: the sole sorry (independent_implies_zero_mixing — independence ⇒ α-mixing coefficient 0) is now discharged: every term of the defining nested supremum vanishes by independence (ENNReal.toReal_mul), and the all-zero nested ⨆ over ℝ collapses via a Prop-indexed-sup-of-0 helper (handling both the inhabited and empty index cases, sidestepping the lack of CompleteLattice ℝ). Two pre-existing Mathlib-drift build breakages were also repaired (Real.tendsto_rpow_atTop → tendsto_rpow_atTop; a field_simp that now closes its goal, dropping a stale trailing ring). File now builds clean with 0 sorries; 1 axiom (martingale_clt, McLeish 1974) remains.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Martingale_central_limit_theorem",
@@ -19,11 +19,11 @@
       "dependent-variables"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
-    "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) \u2014 the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 1 sorry: nested ciSup of zeros = 0 for independent sequences (independent_implies_zero_mixing). (The i.i.d. Lindeberg condition and the i.i.d. Lyapunov condition, formerly sorries, are now fully proved in the main file.)",
-    "lineCount": 912,
+    "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) — the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 1 sorry: nested ciSup of zeros = 0 for independent sequences (independent_implies_zero_mixing). (The i.i.d. Lindeberg condition and the i.i.d. Lyapunov condition, formerly sorries, are now fully proved in the main file.)",
+    "lineCount": 934,
     "theoremCount": 23,
     "definitionCount": 14,
     "additionalFiles": [
@@ -32,29 +32,31 @@
     ],
     "originalContributions": [
       "MartingaleDiffArray: triangular array {X_{n,k}} with martingale difference property and square integrability",
-      "lindebergCondition: Lindeberg criterion \u2014 sum of truncated second moments vanishes",
-      "lyapunovCondition: Lyapunov sufficient condition for Lindeberg via (2+\u03b4)-th moments",
-      "varianceConverges: conditional variance convergence to \u03c3\u00b2",
-      "IIDSequence: i.i.d. sequence with mean 0 and finite variance \u03c3\u00b2, embedded as MDA",
-      "alphaMixingCoeff: \u03b1-mixing coefficient measuring \u03c3-algebra dependence decay",
-      "martingale_clt (axiom): McLeish 1974 theorem \u2014 MDA with Lindeberg + variance convergence implies Gaussian limit",
-      "lyapunov_implies_lindeberg: full proof \u2014 Lyapunov condition implies Lindeberg via rpow indicator bound",
-      "iid_mda_variance_converges: i.i.d. MDA variance sum = \u03c3\u00b2 exactly for n \u2265 1",
+      "lindebergCondition: Lindeberg criterion — sum of truncated second moments vanishes",
+      "lyapunovCondition: Lyapunov sufficient condition for Lindeberg via (2+δ)-th moments",
+      "varianceConverges: conditional variance convergence to σ²",
+      "IIDSequence: i.i.d. sequence with mean 0 and finite variance σ², embedded as MDA",
+      "alphaMixingCoeff: α-mixing coefficient measuring σ-algebra dependence decay",
+      "martingale_clt (axiom): McLeish 1974 theorem — MDA with Lindeberg + variance convergence implies Gaussian limit",
+      "lyapunov_implies_lindeberg: full proof — Lyapunov condition implies Lindeberg via rpow indicator bound",
+      "iid_mda_variance_converges: i.i.d. MDA variance sum = σ² exactly for n ≥ 1",
       "classical_clt_from_martingale: classical CLT follows from martingale CLT for i.i.d. sequences",
-      "rpow_indicator_bound: x\u00b2\u00b7\u03b5^\u03b4 \u2264 |x|^{2+\u03b4} when |x| > \u03b5 (key lemma)"
+      "rpow_indicator_bound: x²·ε^δ ≤ |x|^{2+δ} when |x| > ε (key lemma)",
+      "independent_implies_zero_mixing: discharged the file's only sorry — for independent σ-algebras the α-mixing coefficient is 0 — via term-wise vanishing + a robust collapse of the nested conditionally-complete ⨆ of zeros (Prop-indexed-sup-of-0 helper covering empty/inhabited index); also repaired two Mathlib-drift build errors so the file compiles axiom-free apart from martingale_clt"
     ]
   },
   "overview": {
-    "historicalContext": "The classical CLT was first rigorously stated by Lindeberg (1922) for independent, non-identically distributed variables; Feller (1935) proved the converse. Extending to dependent variables was a major 20th century problem in probability. Bernstein (1927) gave early results for weakly dependent sequences. Rosenblatt (1956) introduced the \u03b1-mixing coefficient as a quantitative measure of dependence decay. Ibragimov (1962) proved the mixing CLT: stationary sequences with $\\alpha(n) = O(n^{-5})$ satisfy the CLT, published in \u0422\u0435\u043e\u0440\u0438\u044f \u0432\u0435\u0440\u043e\u044f\u0442\u043d\u043e\u0441\u0442\u0435\u0439 \u0438 \u0435\u0451 \u043f\u0440\u0438\u043c\u0435\u043d\u0435\u043d\u0438\u044f. Brown (1971, JRSS B) proved CLT for martingale differences under L\u00b2 conditions. McLeish (1974, Annals of Probability) gave the definitive Martingale CLT with the Lindeberg condition, subsuming all previous results for MDAs. This formalization axiomatizes McLeish's theorem and proves the classical i.i.d. CLT as a corollary, establishing a hierarchy: i.i.d. \u2282 Lindeberg-Feller \u2282 MDA \u2282 \u03b1-mixing.",
-    "problemStatement": "Does the CLT hold for dependent random variables? Formalize the Martingale CLT and \u03b1-mixing CLT, and show that the classical i.i.d. CLT is a special case of both.",
-    "text": "A martingale difference array (MDA) {X_{n,k}} satisfies E[X_{n,k} | \u2131_{n,k-1}] = 0 \u2014 each term has conditional mean zero. The Martingale CLT says: if (1) the Lindeberg condition holds (truncated second moments vanish), and (2) the conditional variance sum converges to \u03c3\u00b2, then the row sum S_n = \u2211_k X_{n,k} converges in distribution to N(0, \u03c3\u00b2). The \u03b1-mixing CLT handles stationary sequences where \u03b1-mixing coefficients decay at a polynomial rate. Both reduce to the classical CLT when the sequence is i.i.d.: independence implies the MDA property, and i.i.d. sequences trivially satisfy any mixing condition.",
-    "proofStrategy": "Part I defines the MDA structure with integrability and variance properties. Part II defines the Lindeberg and Lyapunov conditions. Part III axiomatizes the Martingale CLT. Part IV constructs the i.i.d. MDA and proves variance convergence. Part V proves classical CLT as corollary (modulo 1 sorry for the i.i.d. Lindeberg condition; the i.i.d. Lyapunov condition is fully proved). Part VI defines \u03b1-mixing coefficients. Parts VII-XI prove supporting theorems: Lyapunov implies Lindeberg (fully proved), variance bounds, characteristic function properties.",
+    "historicalContext": "The classical CLT was first rigorously stated by Lindeberg (1922) for independent, non-identically distributed variables; Feller (1935) proved the converse. Extending to dependent variables was a major 20th century problem in probability. Bernstein (1927) gave early results for weakly dependent sequences. Rosenblatt (1956) introduced the α-mixing coefficient as a quantitative measure of dependence decay. Ibragimov (1962) proved the mixing CLT: stationary sequences with $\\alpha(n) = O(n^{-5})$ satisfy the CLT, published in Теория вероятностей и её применения. Brown (1971, JRSS B) proved CLT for martingale differences under L² conditions. McLeish (1974, Annals of Probability) gave the definitive Martingale CLT with the Lindeberg condition, subsuming all previous results for MDAs. This formalization axiomatizes McLeish's theorem and proves the classical i.i.d. CLT as a corollary, establishing a hierarchy: i.i.d. ⊂ Lindeberg-Feller ⊂ MDA ⊂ α-mixing.",
+    "problemStatement": "Does the CLT hold for dependent random variables? Formalize the Martingale CLT and α-mixing CLT, and show that the classical i.i.d. CLT is a special case of both.",
+    "text": "A martingale difference array (MDA) {X_{n,k}} satisfies E[X_{n,k} | ℱ_{n,k-1}] = 0 — each term has conditional mean zero. The Martingale CLT says: if (1) the Lindeberg condition holds (truncated second moments vanish), and (2) the conditional variance sum converges to σ², then the row sum S_n = ∑_k X_{n,k} converges in distribution to N(0, σ²). The α-mixing CLT handles stationary sequences where α-mixing coefficients decay at a polynomial rate. Both reduce to the classical CLT when the sequence is i.i.d.: independence implies the MDA property, and i.i.d. sequences trivially satisfy any mixing condition.",
+    "proofStrategy": "Part I defines the MDA structure with integrability and variance properties. Part II defines the Lindeberg and Lyapunov conditions. Part III axiomatizes the Martingale CLT. Part IV constructs the i.i.d. MDA and proves variance convergence. Part V proves classical CLT as corollary (modulo 1 sorry for the i.i.d. Lindeberg condition; the i.i.d. Lyapunov condition is fully proved). Part VI defines α-mixing coefficients. Parts VII-XI prove supporting theorems: Lyapunov implies Lindeberg (fully proved), variance bounds, characteristic function properties.",
     "keyInsights": [
       "The MDA structure abstracts away independence: only conditional mean zero is required",
-      "Lyapunov implies Lindeberg: if \u2211E[|X_{n,k}|^{2+\u03b4}] \u2192 0 then Lindeberg holds (proved via rpow bound)",
-      "For i.i.d. sequences, the MDA variance sum = \u03c3\u00b2 exactly (not just in the limit)",
-      "The characteristic function approach: E[exp(itS_n)] \u2192 exp(-\u03c3\u00b2t\u00b2/2) by product formula for MDAs",
-      "Mixing conditions quantify how quickly distant \u03c3-algebras become independent"
+      "Lyapunov implies Lindeberg: if ∑E[|X_{n,k}|^{2+δ}] → 0 then Lindeberg holds (proved via rpow bound)",
+      "For i.i.d. sequences, the MDA variance sum = σ² exactly (not just in the limit)",
+      "The characteristic function approach: E[exp(itS_n)] → exp(-σ²t²/2) by product formula for MDAs",
+      "Mixing conditions quantify how quickly distant σ-algebras become independent",
+      "A nested ⨆ over ℝ (no CompleteLattice) of an all-zero family collapses cleanly: rewrite the body to 0 under the measurability guards (iSup_congr), then a helper ⨆(_:p),0 = 0 — proved by cases on the Prop p (Nonempty ⇒ ciSup_const; IsEmpty ⇒ sSup ∅ = 0) — and ciSup_const finish it."
     ],
     "prerequisites": [
       "Martingale theory: filtrations, conditional expectations, martingale differences",
@@ -64,7 +66,7 @@
     ]
   },
   "conclusion": {
-    "summary": "The CLT for dependent variables is formally developed: MDA structure, Lindeberg and Lyapunov conditions, \u03b1-mixing coefficients, and the classical recovery. Lyapunov implies Lindeberg is fully proved. The Martingale CLT (McLeish 1974) is axiomatized as the deep core result. 23 theorems, 14 definitions, 912 lines, 1 axiom, 1 sorry.",
+    "summary": "The CLT for dependent variables is formally developed: MDA structure, Lindeberg and Lyapunov conditions, α-mixing coefficients, and the classical recovery. Lyapunov implies Lindeberg is fully proved. The Martingale CLT (McLeish 1974) is axiomatized as the deep core result. 23 theorems, 14 definitions, 912 lines, 1 axiom, 1 sorry.",
     "implications": "**Stochastic process infrastructure**: This formalization provides the foundational infrastructure for proving CLT-type results for stochastic processes in Lean 4. The MDA framework covers time series (ARMA, GARCH), Markov chains (via martingale approximation), and ergodic processes.\n\n**Financial mathematics**: The martingale CLT is the theoretical foundation for the Black-Scholes model: stock price increments form a martingale difference sequence, and the CLT gives the Gaussian limit underlying geometric Brownian motion. The mixing CLT applies to high-frequency trading data where temporal dependence decays.\n\n**Statistical estimation**: The dependent CLT is essential for proving asymptotic normality of estimators from dependent data. Maximum likelihood estimators for time series models, kernel density estimators for mixing processes, and sample means of Markov chains all require CLTs beyond the i.i.d. setting.\n\n**Completion path**: Completing the remaining sorry (nested ciSup = 0 for independence) would give a fully verified dependent CLT framework, modulo the axiom. The hardest remaining piece is the axiomatized martingale_clt itself, which requires characteristic function methods and conditional expectation products not yet in Mathlib.",
     "openQuestions": [
       "Prove martingale_clt: formalize McLeish 1974 via characteristic function method",
@@ -75,12 +77,12 @@
   },
   "leanFile": {
     "namespace": "CentralLimitTheoremOQ02",
-    "lineCount": 912,
+    "lineCount": 934,
     "axiomCount": 1,
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/CentralLimitTheoremOQ02.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/CentralLimitTheoremOQ02Aristotle.lean",
       "Proofs/CentralLimitTheoremOQ02OQ02.lean"
@@ -119,15 +121,15 @@
       "title": "Part I: Martingale Difference Array Structure",
       "startLine": 44,
       "endLine": 99,
-      "summary": "MartingaleDiffArray structure (rowSize, X, filtration \u2131, mda_property). rowSum definition. rowSum_mean_zero: E[S_n] = 0 via integral_finset_sum + mda_property.",
+      "summary": "MartingaleDiffArray structure (rowSize, X, filtration ℱ, mda_property). rowSum definition. rowSum_mean_zero: E[S_n] = 0 via integral_finset_sum + mda_property.",
       "mathContext": "$\\{X_{n,k}\\}$ MDA: $\\mathbb{E}[X_{n,k} \\mid \\mathcal{F}_{n,k-1}] = 0$; $S_n = \\sum_{k=0}^{\\text{rowSize}(n)-1} X_{n,k}$; $\\mathbb{E}[S_n] = 0$"
     },
     {
       "id": "sec-clt02-conditions",
-      "title": "Parts II\u2013III: Variance, Lindeberg, and Lyapunov Conditions",
+      "title": "Parts II–III: Variance, Lindeberg, and Lyapunov Conditions",
       "startLine": 100,
       "endLine": 177,
-      "summary": "varianceSum, lindebergSum (indicator 1{|X|>\u03b5}), lindebergCondition (L_n(\u03b5)\u21920), varianceConverges (V_n\u2192\u03c3\u00b2). lyapunovSum (\u2211E[|X|^{2+\u03b4}]), lyapunovCondition. lindeberg_sum_nonneg via Finset.sum_nonneg.",
+      "summary": "varianceSum, lindebergSum (indicator 1{|X|>ε}), lindebergCondition (L_n(ε)→0), varianceConverges (V_n→σ²). lyapunovSum (∑E[|X|^{2+δ}]), lyapunovCondition. lindeberg_sum_nonneg via Finset.sum_nonneg.",
       "mathContext": "$L_n(\\varepsilon) = \\sum_k \\mathbb{E}[X_{n,k}^2 \\cdot \\mathbf{1}_{|X_{n,k}|>\\varepsilon}] \\to 0$; $V_n = \\sum_k \\mathbb{E}[X_{n,k}^2] \\to \\sigma^2$; $\\Lambda_n(\\delta) = \\sum_k \\mathbb{E}[|X_{n,k}|^{2+\\delta}] \\to 0$"
     },
     {
@@ -135,39 +137,39 @@
       "title": "Part III: Lyapunov Implies Lindeberg (Fully Proved)",
       "startLine": 181,
       "endLine": 270,
-      "summary": "rpow_indicator_bound private lemma: x\u00b2\u00b7\u03b5^\u03b4 \u2264 |x|^{2+\u03b4} on {|x|>\u03b5} via Real.rpow_add + mul_le_mul. lyapunov_implies_lindeberg: L_n(\u03b5) \u2264 \u039b_n(\u03b4)/\u03b5^\u03b4 \u2192 0 via integral_mono_of_nonneg + squeeze theorem. variance_sum_nonneg.",
+      "summary": "rpow_indicator_bound private lemma: x²·ε^δ ≤ |x|^{2+δ} on {|x|>ε} via Real.rpow_add + mul_le_mul. lyapunov_implies_lindeberg: L_n(ε) ≤ Λ_n(δ)/ε^δ → 0 via integral_mono_of_nonneg + squeeze theorem. variance_sum_nonneg.",
       "mathContext": "$|x| > \\varepsilon, \\delta > 0 \\Rightarrow x^2 \\cdot \\varepsilon^\\delta \\leq |x|^{2+\\delta}$; $L_n(\\varepsilon) \\leq \\Lambda_n(\\delta)/\\varepsilon^\\delta \\to 0$ (squeeze: $0 \\leq L_n \\leq \\Lambda_n/\\varepsilon^\\delta \\to 0$)"
     },
     {
       "id": "sec-clt02-martingale-clt",
-      "title": "Part IV: Martingale CLT (McLeish 1974) \u2014 Axiomatized",
+      "title": "Part IV: Martingale CLT (McLeish 1974) — Axiomatized",
       "startLine": 272,
       "endLine": 318,
-      "summary": "rowSumCharFun definition (E[exp(itS_n)]). martingale_clt axiom: MDA + Lindeberg + V_n\u2192\u03c3\u00b2 \u27f9 char fn converges to Gaussian exp(-\u03c3\u00b2t\u00b2/2). Proof sketch via char fn Taylor expansion and conditional expectation.",
+      "summary": "rowSumCharFun definition (E[exp(itS_n)]). martingale_clt axiom: MDA + Lindeberg + V_n→σ² ⟹ char fn converges to Gaussian exp(-σ²t²/2). Proof sketch via char fn Taylor expansion and conditional expectation.",
       "mathContext": "$\\text{MDA} + \\text{Lindeberg} + V_n \\to \\sigma^2 \\Rightarrow \\forall t: \\mathbb{E}[e^{itS_n}] \\to e^{-\\sigma^2 t^2/2}$ (McLeish 1974, Brown 1971)"
     },
     {
       "id": "sec-clt02-iid-case",
-      "title": "Part V: i.i.d. Case \u2014 Classical CLT as Corollary",
+      "title": "Part V: i.i.d. Case — Classical CLT as Corollary",
       "startLine": 320,
       "endLine": 401,
-      "summary": "IIDSequence structure (mean zero, common variance \u03c3\u00b2). IIDSequence.toMDA: X_{n,k} = X_k/\u221an with trivial filtration. iid_mda_variance_converges: V_n = \u03c3\u00b2 exactly for n \u2265 1 (proved via integral_mul_const + Real.sq_sqrt + field_simp).",
+      "summary": "IIDSequence structure (mean zero, common variance σ²). IIDSequence.toMDA: X_{n,k} = X_k/√n with trivial filtration. iid_mda_variance_converges: V_n = σ² exactly for n ≥ 1 (proved via integral_mul_const + Real.sq_sqrt + field_simp).",
       "mathContext": "$X_{n,k} = X_k/\\sqrt{n}$; $V_n = \\sum_{k<n} \\sigma^2/n = \\sigma^2$ (exact for $n \\geq 1$); row sum $S_n = (\\sum_{k<n} X_k)/\\sqrt{n}$"
     },
     {
       "id": "sec-clt02-mixing",
-      "title": "Parts VI\u2013VIII: \u03b1-Mixing, Long-Run Variance, Independence",
+      "title": "Parts VI–VIII: α-Mixing, Long-Run Variance, Independence",
       "startLine": 403,
       "endLine": 499,
-      "summary": "alphaMixingCoeff (nested iSup over measurable sets). AlphaMixingSequence (mixing_bound, mixing_decay \u03b1(n)\u21920). longRunVariance = Var(X\u2081) + 2\u2211Cov. independent_implies_zero_mixing (sorry: nested ciSup = 0 in \u211d).",
+      "summary": "alphaMixingCoeff (nested iSup over measurable sets). AlphaMixingSequence (mixing_bound, mixing_decay α(n)→0). longRunVariance = Var(X₁) + 2∑Cov. independent_implies_zero_mixing (sorry: nested ciSup = 0 in ℝ).",
       "mathContext": "$\\alpha(\\mathcal{F}_1,\\mathcal{F}_2) = \\sup_{A,B} |P(A\\cap B) - P(A)P(B)|$; $\\sigma^2_\\infty = \\mathrm{Var}(X_1) + 2\\sum_{k\\geq 1}\\mathrm{Cov}(X_1,X_{k+1})$; $\\alpha(n) \\to 0$ (Rosenblatt 1956)"
     },
     {
       "id": "sec-clt02-additional",
-      "title": "Parts IX\u2013XI: Classical CLT Recovery and Additional Results",
+      "title": "Parts IX–XI: Classical CLT Recovery and Additional Results",
       "startLine": 501,
       "endLine": 727,
-      "summary": "classical_clt_from_martingale (derives classical CLT from the now-proved iid_satisfies_lindeberg + martingale_clt). iid_satisfies_lindeberg (proved via DCT on truncated moments). iid_satisfies_lyapunov (proved via rpow moment decay). lyapunov_sum_at_zero (\u03b4=0 = varianceSum via sq_abs). rowSumCharFun_zero. Zero-variable lemmas. variance_sum_bounded_of_converges (eventual bound + Finset.sup').",
+      "summary": "classical_clt_from_martingale (derives classical CLT from the now-proved iid_satisfies_lindeberg + martingale_clt). iid_satisfies_lindeberg (proved via DCT on truncated moments). iid_satisfies_lyapunov (proved via rpow moment decay). lyapunov_sum_at_zero (δ=0 = varianceSum via sq_abs). rowSumCharFun_zero. Zero-variable lemmas. variance_sum_bounded_of_converges (eventual bound + Finset.sup').",
       "mathContext": "$(X_1+\\cdots+X_n)/\\sqrt{n} \\xrightarrow{d} N(0,\\sigma^2)$; proved: $\\mathbb{E}[X^2 \\cdot \\mathbf{1}_{|X|>\\varepsilon\\sqrt{n}}] \\xrightarrow{\\text{DCT}} 0$; $\\Lambda_n(\\delta) = \\mathbb{E}[|X|^{2+\\delta}]/n^{\\delta/2} \\to 0$"
     }
   ],


### PR DESCRIPTION
## Summary

Repairs the `central-limit-theorem-oq-02` entry (*CLT for Dependent Random Variables*), which was **committed broken** (failed to build against the current Mathlib pin) and carried one `sorry`. After this PR it **builds clean with 0 sorries** (1 axiom, the deep `martingale_clt`, remains → still `axiomatized`).

## What changed

**Sorry discharged** — `independent_implies_zero_mixing`: for independent σ-algebras, the α-mixing coefficient is 0.

```lean
alphaMixingCoeff μ ℱ₁ ℱ₂ = ⨆ A, ⨆ (_ : MeasurableSet A), ⨆ B, ⨆ (_ : MeasurableSet B),
  |(μ (A ∩ B)).toReal - (μ A).toReal * (μ B).toReal|
```

Every term vanishes under independence (`μ(A∩B) = μA·μB`, `ENNReal.toReal_mul`), and the all-zero nested `⨆` over `ℝ` collapses via a Prop-indexed-sup-of-0 helper:

```lean
have h0p : ∀ (p : Prop), (⨆ (_ : p), (0:ℝ)) = 0 := by
  intro p; by_cases h : p
  · haveI : Nonempty p := ⟨h⟩; simp
  · haveI : IsEmpty p := ⟨h⟩; simp
```

plus `iSup_congr` to rewrite each guarded body to `0`. This is exactly the conditional-completeness / Prop-sup obstacle the original author flagged as the blocker (no `CompleteLattice ℝ`).

**Two Mathlib-drift build errors repaired:**
- `Real.tendsto_rpow_atTop` → `tendsto_rpow_atTop` (the lemma lives in the root namespace).
- removed a stale trailing `ring` after a `field_simp` that now closes its own goal (`No goals to be solved`).

## Verification

- Full file builds clean against the Mathlib pin (Lean v4.26.0): no errors, no `sorry` warnings.
- `#print axioms independent_implies_zero_mixing` → `[propext, Classical.choice, Quot.sound]`.
- `meta.json` sorries 1 → 0; line count synced.

## Context

Claimed under `central-limit-theorem-oq-02-oq-03`, a fresh statement-less child; the highest-value reachable work was repairing and de-sorrying its parent. The remaining axiom `martingale_clt` (McLeish 1974) is the genuinely deep result and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)