### PR TITLE
research(vandermonde-interpolation-oq-01-oq-02): evaluation at distinct nodes is a linear isomorphism [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3862,6 +3862,7 @@ import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VandermondeInterpolationOQ01OQ01
+import Proofs.VandermondeInterpolationOQ01OQ02
 import Proofs.VarignonTheorem
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02

--- a/proofs/Proofs/VandermondeInterpolationOQ01OQ02.lean
+++ b/proofs/Proofs/VandermondeInterpolationOQ01OQ02.lean
@@ -1,0 +1,131 @@
+/-
+  The evaluation-at-nodes map is a linear ISOMORPHISM: the full interpolation
+  isomorphism via the explicit Lagrange interpolant.
+
+  Fix `n` DISTINCT nodes `v : Fin n → F` over a field `F`.  The two companion
+  entries supply the two halves of the interpolation problem:
+
+    * `VandermondeInterpolationOQ01` — *uniqueness* (Vandermonde nonvanishing):
+      a polynomial of degree `< n` is determined by its values at the nodes;
+    * `VandermondeInterpolationOQ01OQ01` — *existence* (the explicit Lagrange
+      interpolant `interp v r` realizes any prescribed value vector `r`).
+
+  This entry packages the two halves into a single structural object: the
+  **evaluation map**
+
+      `evalNodes v : degreeLT F n →ₗ[F] (Fin n → F)`,  `p ↦ (j ↦ p.eval (v j))`
+
+  is a *linear isomorphism* `evalEquiv`, whose inverse is exactly the Lagrange
+  interpolant `interp v`.  Equivalently:
+
+    * **Surjectivity (existence half)** `evalNodes_surjective` /
+      `exists_eval_eq`: every value vector is hit by some degree `< n` polynomial;
+    * **Injectivity (uniqueness half)** `evalNodes_injective`;
+    * **Bijectivity / isomorphism** `evalEquiv`, with the explicit two-sided
+      inverse `interp v` (`evalEquiv_symm_apply`);
+    * **Structural consequence** `finrank_degreeLT`: the space of polynomials of
+      degree `< n` has dimension `n` (transported across the isomorphism).
+
+  Mathlib already has `Lagrange.funEquivDegreeLT : degreeLT F #s ≃ₗ[F] ↥s → F`,
+  but it is indexed by the *subtype* `↥s` and its inverse carries a `dite` guard
+  (`if hx : x ∈ s then r ⟨x, hx⟩ else 0`).  The contribution here is the clean
+  `Fin n → F` form matching the companion entries, with the honest companion
+  interpolant `interp v` (no `dite`) as the explicit two-sided inverse, and the
+  existence/surjectivity statement exposed standalone.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Polynomial Finset
+
+namespace VandermondeInterpolationOQ01OQ02
+
+variable {F : Type*} [Field F] {n : ℕ} {v : Fin n → F}
+
+/-- The number of nodes is `n`. -/
+private theorem card_univ_fin : #(univ : Finset (Fin n)) = n := by simp
+
+/-- The explicit **Lagrange interpolant** through the nodes `v` with values `r`
+(the same interpolant as the companion entry). -/
+noncomputable def interp (v r : Fin n → F) : F[X] :=
+  Lagrange.interpolate univ v r
+
+/-- The Lagrange interpolant lands in `degreeLT F n` (degree `< n`). -/
+theorem interp_mem_degreeLT (hv : Function.Injective v) (r : Fin n → F) :
+    Lagrange.interpolate univ v r ∈ degreeLT F n := by
+  rw [mem_degreeLT]
+  have h := Lagrange.degree_interpolate_lt (s := univ) (v := v) (r := r) hv.injOn
+  rwa [card_univ_fin] at h
+
+/-- **The evaluation-at-nodes map** `p ↦ (j ↦ p.eval (v j))`, as an `F`-linear
+map on the space of polynomials of degree `< n`. -/
+def evalNodes (v : Fin n → F) : degreeLT F n →ₗ[F] (Fin n → F) :=
+  LinearMap.pi fun j => (Polynomial.leval (v j)).comp (degreeLT F n).subtype
+
+@[simp] theorem evalNodes_apply (v : Fin n → F) (p : degreeLT F n) (j : Fin n) :
+    evalNodes v p j = (p : F[X]).eval (v j) := rfl
+
+/-- The Lagrange interpolant, as an `F`-linear map `(Fin n → F) →ₗ[F] degreeLT F n`
+(the codomain-restricted `Lagrange.interpolate`). -/
+noncomputable def interpLT (hv : Function.Injective v) :
+    (Fin n → F) →ₗ[F] degreeLT F n :=
+  LinearMap.codRestrict _ (Lagrange.interpolate univ v) (interp_mem_degreeLT hv)
+
+@[simp] theorem interpLT_coe (hv : Function.Injective v) (r : Fin n → F) :
+    (interpLT hv r : F[X]) = interp v r := rfl
+
+/-- **The full interpolation isomorphism.** Evaluation at `n` distinct nodes is
+a linear isomorphism `degreeLT F n ≃ₗ[F] (Fin n → F)`, whose inverse is the
+explicit Lagrange interpolant. -/
+noncomputable def evalEquiv (hv : Function.Injective v) :
+    degreeLT F n ≃ₗ[F] (Fin n → F) :=
+  LinearEquiv.ofLinear (evalNodes v) (interpLT hv)
+    (by
+      -- `evalNodes ∘ interpLT = id`: the interpolant realizes the values
+      refine LinearMap.ext fun r => funext fun j => ?_
+      show (Lagrange.interpolate univ v r).eval (v j) = r j
+      exact Lagrange.eval_interpolate_at_node r hv.injOn (mem_univ j))
+    (by
+      -- `interpLT ∘ evalNodes = id`: a degree `< n` polynomial is its own interpolant
+      refine LinearMap.ext fun p => Subtype.ext ?_
+      have hdeg : (p : F[X]).degree < #(univ : Finset (Fin n)) := by
+        rw [card_univ_fin]; exact mem_degreeLT.1 p.2
+      exact (Lagrange.eq_interpolate hv.injOn hdeg).symm)
+
+@[simp] theorem evalEquiv_apply (hv : Function.Injective v) (p : degreeLT F n) :
+    evalEquiv hv p = evalNodes v p := rfl
+
+@[simp] theorem evalEquiv_symm_apply (hv : Function.Injective v) (r : Fin n → F) :
+    ((evalEquiv hv).symm r : F[X]) = interp v r := rfl
+
+/-- The evaluation map is **bijective** (the interpolation problem is well-posed). -/
+theorem evalNodes_bijective (hv : Function.Injective v) :
+    Function.Bijective (evalNodes v) := (evalEquiv hv).bijective
+
+/-- **Surjectivity — the existence half.** Every value vector is the
+evaluation-at-nodes of some polynomial of degree `< n`. -/
+theorem evalNodes_surjective (hv : Function.Injective v) :
+    Function.Surjective (evalNodes v) := (evalEquiv hv).surjective
+
+/-- **Injectivity — the uniqueness half.** A polynomial of degree `< n` is
+determined by its values at the nodes. -/
+theorem evalNodes_injective (hv : Function.Injective v) :
+    Function.Injective (evalNodes v) := (evalEquiv hv).injective
+
+/-- **Existence (concrete form).** For any target values `r` there is a
+polynomial of degree `< n` interpolating the data — the Lagrange interpolant. -/
+theorem exists_eval_eq (hv : Function.Injective v) (r : Fin n → F) :
+    ∃ p : F[X], p.degree < (n : ℕ) ∧ ∀ j, p.eval (v j) = r j := by
+  refine ⟨interp v r, ?_, fun j => ?_⟩
+  · have h := Lagrange.degree_interpolate_lt (s := univ) (v := v) (r := r) hv.injOn
+    rwa [card_univ_fin] at h
+  · exact Lagrange.eval_interpolate_at_node r hv.injOn (mem_univ j)
+
+/-- **Structural consequence.** Transporting the isomorphism, the space of
+polynomials of degree `< n` over `F` has dimension `n`. -/
+theorem finrank_degreeLT (hv : Function.Injective v) :
+    Module.finrank F (degreeLT F n) = n := by
+  rw [(evalEquiv hv).finrank_eq, Module.finrank_fin_fun]
+
+end VandermondeInterpolationOQ01OQ02

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "vandermonde-interpolation-oq-01-oq-02",
+  "title": "Evaluation at Distinct Nodes is a Linear Isomorphism: the Full Interpolation Isomorphism",
+  "slug": "vandermonde-interpolation-oq-01-oq-02",
+  "description": "Over a field F, fix n distinct nodes v : Fin n → F. The two companion entries establish the two halves of the interpolation problem: vandermonde-interpolation-oq-01 proves uniqueness (a degree-< n polynomial is determined by its values at the nodes) and vandermonde-interpolation-oq-01-oq-01 proves existence (the explicit Lagrange interpolant realizes any value vector). This entry packages both halves into one structural object: the evaluation map evalNodes v : degreeLT F n →ₗ[F] (Fin n → F), p ↦ (j ↦ p(v_j)), is a LINEAR ISOMORPHISM whose inverse is exactly the Lagrange interpolant. Surjectivity is the existence half, injectivity the uniqueness half. The isomorphism evalEquiv carries the explicit interpolant interp v as its honest two-sided inverse (no dite guard), and transporting it gives the structural consequence that degreeLT F n has dimension n. Mathlib's Lagrange.funEquivDegreeLT proves the analogous equiv but indexed by the subtype ↥s with a dite-patched inverse; the contribution here is the clean Fin n → F form matching the companion entries with the companion interpolant as the explicit inverse, plus the standalone surjectivity (existence) statement. 11 theorems (incl. 4 simp lemmas), 4 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange_polynomial",
+    "date": "Joseph-Louis Lagrange (1795); Edward Waring (1779)",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "polynomials",
+      "interpolation",
+      "lagrange",
+      "vandermonde",
+      "linear-isomorphism",
+      "existence-uniqueness",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/VandermondeInterpolationOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere. The single hypothesis is that the node map v : Fin n → F is injective (the n nodes are distinct), which is exactly the well-posedness condition for interpolation.",
+    "originalContributions": [
+      "evalNodes: the evaluation-at-nodes map p ↦ (j ↦ p(v_j)) packaged as an F-linear map degreeLT F n →ₗ[F] (Fin n → F), built from Polynomial.leval and the submodule inclusion",
+      "interpLT: the Lagrange interpolant codomain-restricted to a linear map (Fin n → F) →ₗ[F] degreeLT F n",
+      "evalEquiv: the full interpolation ISOMORPHISM degreeLT F n ≃ₗ[F] (Fin n → F) with the explicit Lagrange interpolant interp v as honest two-sided inverse (no dite guard), via LinearEquiv.ofLinear",
+      "evalNodes_surjective: surjectivity — the existence half stated as a property of the evaluation map (every value vector is realized)",
+      "evalNodes_injective / evalNodes_bijective: injectivity (uniqueness) and bijectivity (well-posedness)",
+      "exists_eval_eq: concrete existence — for any target values there is a degree-< n polynomial interpolating them, exhibited as the Lagrange interpolant",
+      "finrank_degreeLT: structural consequence — degreeLT F n has F-dimension n, obtained by transporting the isomorphism to Fin n → F"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 131,
+    "theoremCount": 11,
+    "definitionCount": 4,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Polynomial interpolation through n distinct points is the prototypical well-posed linear problem: the data-to-polynomial correspondence is a bijection between value vectors (Fin n → F) and polynomials of degree < n. The companion entries proved the two implications separately — uniqueness from the Vandermonde determinant, existence from the explicit Lagrange interpolant. The structural way to say both at once is that evaluation at the nodes is a linear isomorphism of the n-dimensional spaces degreeLT F n and F^n, with the Lagrange interpolant as its inverse. This is the abstract content behind the change of representation between a polynomial and its sample values that underlies Reed–Solomon codes, the discrete Fourier transform viewpoint, and finite-element shape functions.",
+    "problemStatement": "**Open Question (OQ-02 of vandermonde-interpolation-oq-01)**: Establish the existence half of polynomial interpolation as surjectivity of the evaluation map at distinct nodes, giving the full interpolation isomorphism degreeLT F n ≃ₗ[F] (Fin n → F) via the explicit Lagrange interpolant.\n\n**Formalized**: evalNodes (evaluation as a linear map), interpLT (interpolant as a linear map), evalEquiv (the linear isomorphism), evalNodes_surjective / evalNodes_injective / evalNodes_bijective, exists_eval_eq (concrete existence), finrank_degreeLT (dimension consequence).",
+    "text": "A 131-line formalization that upgrades the companion entries' existence and uniqueness lemmas into a single linear isomorphism. The forward map evalNodes v sends a polynomial p of degree < n to its value vector (p(v_0), …, p(v_{n−1})); it is assembled as LinearMap.pi over Polynomial.leval (v j) composed with the submodule inclusion degreeLT F n ↪ F[X], so it is F-linear by construction. The inverse interpLT is the companion's Lagrange interpolant interp v = Lagrange.interpolate univ v, codomain-restricted into degreeLT F n (it lands there because its degree is < #univ = n). The two compositions are identities: evalNodes ∘ interpLT = id because the interpolant hits the prescribed values (Lagrange.eval_interpolate_at_node), and interpLT ∘ evalNodes = id because a degree-< n polynomial equals the interpolant of its own samples (Lagrange.eq_interpolate). LinearEquiv.ofLinear packages these into evalEquiv, whose symm is literally the Lagrange interpolant. Surjectivity (evalNodes_surjective) is the existence half asked for; injectivity (evalNodes_injective) is the companion uniqueness; together they give bijectivity. The concrete exists_eval_eq restates existence in elementary ∃ form, and finrank_degreeLT transports the isomorphism to conclude dim_F (degreeLT F n) = n. All steps are kernel-checked: 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "**evalNodes**: LinearMap.pi (fun j => (Polynomial.leval (v j)).comp (degreeLT F n).subtype); evalNodes_apply is rfl.\n\n**interp_mem_degreeLT**: mem_degreeLT.2 of Lagrange.degree_interpolate_lt (s := univ), rewriting #univ = n.\n\n**interpLT**: LinearMap.codRestrict of Lagrange.interpolate univ v using interp_mem_degreeLT; interpLT_coe is rfl.\n\n**evalEquiv**: LinearEquiv.ofLinear evalNodes interpLT with the two identity proofs. Right inverse (evalNodes ∘ interpLT = id): LinearMap.ext then funext, reduce to (interpolate univ v r)(v j) = r j = Lagrange.eval_interpolate_at_node. Left inverse (interpLT ∘ evalNodes = id): LinearMap.ext then Subtype.ext, reduce to interpolate univ v (fun j => p(v_j)) = p = (Lagrange.eq_interpolate hv.injOn hdeg).symm with hdeg from mem_degreeLT and #univ = n.\n\n**evalNodes_surjective / injective / bijective**: the corresponding properties of the LinearEquiv (evalEquiv hv).surjective / .injective / .bijective.\n\n**exists_eval_eq**: witness interp v r; degree bound from degree_interpolate_lt, value match from eval_interpolate_at_node.\n\n**finrank_degreeLT**: (evalEquiv hv).finrank_eq then Module.finrank_fin_fun.",
+    "keyInsights": [
+      "**Existence + uniqueness = isomorphism**: packaging the two halves not as a bare ∃! but as a linear bijection makes the structural content explicit — value vectors and degree-< n polynomials are the same n-dimensional space, identified by evaluation at the nodes.",
+      "**Surjectivity is existence, injectivity is uniqueness**: the two classical implications of the interpolation theorem are precisely the two halves of bijectivity of one linear map, so the isomorphism is the right object to carry both.",
+      "**The inverse is the explicit formula**: evalEquiv.symm is not an abstract inverse but literally the Lagrange interpolant interp v, so the isomorphism is computable and the change of representation is given by a formula.",
+      "**Clean Fin n form vs Mathlib's subtype form**: Mathlib's Lagrange.funEquivDegreeLT is indexed by the subtype ↥s and its inverse carries a dite guard (if x ∈ s then r⟨x,hx⟩ else 0); over the full node set univ : Finset (Fin n) the guard is vacuous, so the honest companion interpolant interp v serves as the explicit two-sided inverse and the codomain is the clean Fin n → F.",
+      "**Dimension by transport**: the most economical proof that degreeLT F n has dimension n routes through the isomorphism to F^n (Module.finrank_fin_fun) rather than through a basis — given n distinct nodes, evaluation already exhibits the coordinates.",
+      "**leval + codRestrict + ofLinear**: the whole isomorphism is assembled from three reusable Mathlib bricks — Polynomial.leval (evaluation as a linear map), LinearMap.codRestrict (restrict the interpolant's codomain), and LinearEquiv.ofLinear (two one-sided inverses make an equiv) — so the only mathematical inputs are the two companion-level facts.",
+      "**0-axiom, no native_decide**: every step is kernel-checked, depending only on propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "The companion entries vandermonde-interpolation-oq-01 (uniqueness from Vandermonde nonvanishing) and vandermonde-interpolation-oq-01-oq-01 (existence via the Lagrange interpolant)",
+      "Mathlib's Lagrange interpolation API: Lagrange.interpolate (a LinearMap), eval_interpolate_at_node, degree_interpolate_lt, eq_interpolate (LinearAlgebra/Lagrange.lean)",
+      "Polynomial.degreeLT and mem_degreeLT, Polynomial.leval (evaluation as a linear map)",
+      "LinearMap.pi, LinearMap.codRestrict, LinearEquiv.ofLinear, and LinearEquiv.finrank_eq / Module.finrank_fin_fun for the dimension consequence",
+      "Set.InjOn from Function.Injective (Function.Injective.injOn) and Finset.card_fin"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "vandermonde-interpolation-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The direct companion proves existence (the Lagrange interpolant realizes the data) and uniqueness as separate ∃!-style facts. This entry packages both into one linear isomorphism evalEquiv whose inverse is exactly that interpolant, exposing surjectivity (existence) and injectivity (uniqueness) as the two halves of bijectivity."
+    },
+    {
+      "proofId": "vandermonde-interpolation-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent proves interpolation uniqueness from the nonvanishing of the Vandermonde determinant. Here uniqueness reappears as injectivity of the evaluation linear map, now bundled with surjectivity into a full isomorphism."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "VandermondeInterpolationOQ01OQ02",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 4,
+    "path": "Proofs/VandermondeInterpolationOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "evalEquiv",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $\\mathrm{degreeLT}\\,F\\,n \\;\\simeq_{\\ell}[F]\\; (\\mathrm{Fin}\\,n \\to F)$ via $p \\mapsto (j \\mapsto p(v_j))$",
+      "significance": "The full interpolation isomorphism: evaluation at n distinct nodes is a linear isomorphism between the degree-< n polynomials and value vectors, with the explicit Lagrange interpolant as its inverse. Packages existence and uniqueness into one structural object.",
+      "description": "Evaluation at distinct nodes is a linear isomorphism; its inverse is the Lagrange interpolant."
+    },
+    {
+      "name": "evalNodes_surjective",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $\\mathrm{evalNodes}\\,v$ surjective",
+      "significance": "The existence half (the open question's target): every value vector is the evaluation-at-nodes of some degree-< n polynomial, i.e. the interpolation system is always solvable.",
+      "description": "Surjectivity of evaluation — existence of an interpolant for any data."
+    },
+    {
+      "name": "evalNodes_injective",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $\\mathrm{evalNodes}\\,v$ injective",
+      "significance": "The uniqueness half: a degree-< n polynomial is determined by its values at the nodes — the companion's Vandermonde uniqueness, now as injectivity of the evaluation map.",
+      "description": "Injectivity of evaluation — uniqueness of the interpolant."
+    },
+    {
+      "name": "exists_eval_eq",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $\\exists\\, p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$",
+      "significance": "Concrete elementary form of the existence half, with the Lagrange interpolant as the explicit witness.",
+      "description": "For any data there is a degree-< n interpolating polynomial."
+    },
+    {
+      "name": "finrank_degreeLT",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $\\dim_F (\\mathrm{degreeLT}\\,F\\,n) = n$",
+      "significance": "Structural consequence: transporting the isomorphism to F^n shows the degree-< n polynomials form an n-dimensional space, with the n node-evaluations as coordinates.",
+      "description": "The degree-< n polynomial space has dimension n."
+    },
+    {
+      "name": "evalNodes_bijective",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $\\mathrm{evalNodes}\\,v$ bijective",
+      "significance": "Well-posedness of interpolation as a single statement: the evaluation map is a bijection, combining existence and uniqueness.",
+      "description": "Evaluation at distinct nodes is bijective."
+    }
+  ],
+  "references": [
+    {
+      "text": "Lagrange polynomial: the explicit interpolant ∑_i y_i ∏_{j≠i} (x − x_j)/(x_i − x_j) through n distinct points.",
+      "url": "https://en.wikipedia.org/wiki/Lagrange_polynomial"
+    },
+    {
+      "text": "Polynomial interpolation — existence and uniqueness of the degree-< n interpolant through n distinct points.",
+      "url": "https://en.wikipedia.org/wiki/Polynomial_interpolation"
+    },
+    {
+      "text": "Mathlib4: Lagrange.interpolate, Lagrange.eval_interpolate_at_node, Lagrange.degree_interpolate_lt, Lagrange.eq_interpolate, Lagrange.funEquivDegreeLT (LinearAlgebra/Lagrange.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Lagrange.html"
+    }
+  ],
+  "conclusion": {
+    "summary": "Upgrades the companion entries' existence and uniqueness lemmas into a single linear isomorphism: evaluation at n distinct nodes, evalNodes v : degreeLT F n →ₗ[F] (Fin n → F), is bijective (evalNodes_bijective) — surjective (evalNodes_surjective, the existence half) and injective (evalNodes_injective, the uniqueness half) — and is packaged as the linear equivalence evalEquiv whose inverse is exactly the Lagrange interpolant. The concrete exists_eval_eq restates existence elementarily, and finrank_degreeLT transports the isomorphism to conclude the degree-< n polynomials have dimension n. All 8 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The interpolation problem is well-posed in the strongest structural sense: value vectors and degree-< n polynomials are the same n-dimensional F-space, identified by evaluation at the nodes, with an explicit computable inverse. This is the abstract content behind change-of-representation arguments in Reed–Solomon coding, polynomial sampling, and the basis duality between point-values and coefficients.",
+    "openQuestions": [
+      "Make the isomorphism a ring/algebra statement: identify evalNodes with the CRT isomorphism F[X]/∏(X − v_j) ≅ ∏ F[X]/(X − v_j) ≅ F^n, exhibiting interpolation as the inverse Chinese Remainder map.",
+      "Track the operator norm / conditioning: over ℝ or ℂ, bound the norm of evalEquiv and its inverse (the Lebesgue constant) in terms of the node configuration, quantifying numerical stability of interpolation."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Packages the **existence** and **uniqueness** halves of polynomial interpolation into a single structural object: the evaluation-at-nodes map

```
evalNodes v : degreeLT F n →ₗ[F] (Fin n → F),   p ↦ (j ↦ p(v_j))
```

is a **linear isomorphism** `evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F)` (for `v : Fin n → F` injective), whose two-sided inverse is exactly the explicit Lagrange interpolant `interp v`.

This answers OQ-02 of `vandermonde-interpolation-oq-01`: *establish the existence half as surjectivity of the evaluation map, giving the full interpolation isomorphism.*

### Results
- **`evalEquiv`** — the full interpolation isomorphism, inverse = Lagrange interpolant (`evalEquiv_symm_apply`).
- **`evalNodes_surjective`** — the **existence half** (every value vector is realized).
- **`evalNodes_injective`** — the **uniqueness half** (companion Vandermonde uniqueness, as injectivity).
- **`evalNodes_bijective`** — well-posedness in one statement.
- **`exists_eval_eq`** — concrete elementary existence (∃ degree-< n interpolant).
- **`finrank_degreeLT`** — structural consequence: `dim_F (degreeLT F n) = n`, by transporting the isomorphism.

### Relation to Mathlib
Mathlib has `Lagrange.funEquivDegreeLT : degreeLT F #s ≃ₗ[F] ↥s → F`, but indexed by the **subtype** `↥s` with a `dite`-patched inverse. This entry gives the clean `Fin n → F` form matching the companion entries, with the honest companion interpolant `interp v` (no `dite`) as the explicit inverse, plus the standalone surjectivity statement. Assembled from `Polynomial.leval` + `LinearMap.codRestrict` + `LinearEquiv.ofLinear`.

### Verification
- 11 theorems, 4 definitions, 131 lines.
- **0 sorries, 0 axioms** (`#print axioms` lists only `propext` / `Classical.choice` / `Quot.sound`).
- No `native_decide`. Built against Mathlib (lean4 v4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)