### PR TITLE
research(hall-marriage-theorem-oq-01-oq-01): defect (Ore) form of Hall's theorem — matching all but the deficiency [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2968,6 +2968,7 @@ import Proofs.GreensTheoremOQ03OQ04
 import Proofs.GreensTheoremOQ04
 import Proofs.HadamardThreeLines
 import Proofs.HallMarriageTheoremOQ01
+import Proofs.HallMarriageTheoremOQ01OQ01
 import Proofs.HallsTheoremOQ01
 import Proofs.HallsTheoremOQ01OQ01
 import Proofs.HallsTheoremOQ02

--- a/proofs/Proofs/HallMarriageTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/HallMarriageTheoremOQ01OQ01.lean
@@ -1,0 +1,213 @@
+import Mathlib
+import Proofs.HallMarriageTheoremOQ01
+
+/-
+# Hall's marriage theorem, defect form: matching all but the deficiency
+
+The companion entry `HallMarriageTheoremOQ01` proves Hall's marriage theorem
+together with the *deficiency obstruction*: a sub-family `s` that is deficient
+(`#s > #(s.biUnion t)`) blocks a full system of distinct representatives.  This
+file supplies the **quantitative converse** — the classical *defect* (or *Ore*)
+form of Hall's theorem:
+
+> Let `t : ι → Finset α` be a finite family.  Then a matching saturating **all
+> but `d`** of the indices exists **iff** the family is *`d`-deficient at worst*,
+> i.e. every sub-family `s` satisfies `#s ≤ #(s.biUnion t) + d`.
+
+Concretely, "a matching saturating all but `d` indices" means: a set `J ⊆ ι`
+with `#J ≥ #ι − d` together with an injective (on `J`) choice function
+`f : ι → α` with `f i ∈ t i` for every `i ∈ J`.
+
+## Why this is the right statement
+
+Setting `d = 0` recovers the ordinary marriage theorem (a full SDR).  The
+parameter `d` measures, sharply, how far the family is from satisfying Hall's
+condition: the largest *deficiency* `δ = maxₛ (#s − #(s.biUnion t))` is exactly
+the number of indices that *must* be left unmatched, and the theorem says a
+matching of size `#ι − δ` is always attainable.
+
+## The proof
+
+The substantive direction is the classical **dummy-target augmentation**.  Form
+the augmented family `aug t d : ι → Finset (α ⊕ Fin d)` by adjoining, to every
+target set, a shared block of `d` brand-new "dummy" targets (a copy of `Fin d`).
+For any nonempty `s`,
+
+  `#(s.biUnion (aug t d)) = #(s.biUnion t) + d`,
+
+because the `α`-part and the dummy block are disjoint.  Hence the deficiency
+hypothesis `#s ≤ #(s.biUnion t) + d` turns into Hall's condition for `aug t d`,
+and **Mathlib's marriage theorem** (`all_card_le_biUnion_card_iff_exists_injective`)
+yields an injective `f' : ι → α ⊕ Fin d` with `f' i ∈ aug t d i`.  The indices
+landing in the genuine `α` part form the matched set `J`; the rest inject into
+the `d` dummies, so at most `d` indices are unmatched, giving `#J ≥ #ι − d`.
+
+The reverse direction is a direct count: a matching on `J` injects `s ∩ J` into
+`s.biUnion t`, and `s \ J` has at most `d` elements.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no
+`native_decide`.
+-/
+
+open Finset Function
+
+namespace HallDefect
+
+variable {ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α]
+
+/-- The **augmented family**: to every target set `t i` we adjoin a shared block
+of `d` fresh "dummy" targets, realised as a copy of `Fin d` sitting in the right
+summand of `α ⊕ Fin d`. -/
+def aug (t : ι → Finset α) (d : ℕ) (i : ι) : Finset (α ⊕ Fin d) :=
+  (t i).map Embedding.inl ∪ (univ : Finset (Fin d)).map Embedding.inr
+
+omit [Fintype ι] [DecidableEq ι] [Nonempty α] in
+/-- **Augmentation satisfies Hall.** If the family is at worst `d`-deficient,
+then the augmented family satisfies Hall's condition outright: every sub-family
+`s` has `#s ≤ #(s.biUnion (aug t d))`. -/
+theorem aug_hall {t : ι → Finset α} {d : ℕ}
+    (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) :
+    ∀ s : Finset ι, s.card ≤ (s.biUnion (aug t d)).card := by
+  intro s
+  rcases s.eq_empty_or_nonempty with rfl | hs
+  · simp
+  · -- the augmented union splits as an `α`-part plus the full dummy block
+    have hsplit : s.biUnion (aug t d)
+        = (s.biUnion t).map Embedding.inl
+            ∪ (univ : Finset (Fin d)).map Embedding.inr := by
+      ext x
+      simp only [aug, mem_biUnion, mem_union, mem_map]
+      constructor
+      · rintro ⟨i, hi, h'⟩
+        rcases h' with ⟨a, ha, rfl⟩ | ⟨k, hk, rfl⟩
+        · exact Or.inl ⟨a, ⟨i, hi, ha⟩, rfl⟩
+        · exact Or.inr ⟨k, hk, rfl⟩
+      · rintro (⟨a, ⟨i, hi, ha⟩, rfl⟩ | ⟨k, hk, rfl⟩)
+        · exact ⟨i, hi, Or.inl ⟨a, ha, rfl⟩⟩
+        · obtain ⟨i, hi⟩ := hs
+          exact ⟨i, hi, Or.inr ⟨k, hk, rfl⟩⟩
+    have hdisj : Disjoint ((s.biUnion t).map Embedding.inl)
+        ((univ : Finset (Fin d)).map Embedding.inr) := by
+      rw [Finset.disjoint_left]
+      rintro x hx hx'
+      simp only [mem_map] at hx hx'
+      obtain ⟨a, -, rfl⟩ := hx
+      obtain ⟨k, -, hk⟩ := hx'
+      exact Sum.inr_ne_inl hk
+    have hcard : (s.biUnion (aug t d)).card = (s.biUnion t).card + d := by
+      rw [hsplit, Finset.card_union_of_disjoint hdisj, Finset.card_map,
+        Finset.card_map, Finset.card_univ, Fintype.card_fin]
+    rw [hcard]; exact h s
+
+/-- **Defect Hall, hard direction.** If the family is at worst `d`-deficient,
+there is a matching saturating all but at most `d` indices: a set `J` of size
+`≥ #ι − d` and a function `f` injective on `J` with `f i ∈ t i` for `i ∈ J`. -/
+theorem exists_matching_of_deficiency_le {t : ι → Finset α} {d : ℕ}
+    (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) :
+    ∃ (J : Finset ι) (f : ι → α),
+      Fintype.card ι - d ≤ J.card ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i := by
+  classical
+  obtain ⟨f', hf'inj, hf'mem⟩ :=
+    (Finset.all_card_le_biUnion_card_iff_exists_injective (aug t d)).mp (aug_hall h)
+  set J : Finset ι := univ.filter (fun i => (f' i).isLeft) with hJ
+  -- every matched index carries a genuine `α`-witness in `t i`
+  have hLeft : ∀ i ∈ J, ∃ a, a ∈ t i ∧ f' i = Sum.inl a := by
+    intro i hi
+    have hiL : (f' i).isLeft = true := by
+      rw [hJ, mem_filter] at hi; simpa using hi.2
+    have hm := hf'mem i
+    simp only [aug, mem_union, mem_map] at hm
+    rcases hm with ⟨a, ha, hae⟩ | ⟨k, -, hke⟩
+    · exact ⟨a, ha, hae.symm⟩
+    · rw [← hke] at hiL; simp at hiL
+  -- the witness function
+  let f : ι → α := fun i => if hi : i ∈ J then (hLeft i hi).choose else Classical.arbitrary α
+  have hf_spec : ∀ i (hi : i ∈ J), f' i = Sum.inl (f i) := by
+    intro i hi
+    have := (hLeft i hi).choose_spec.2
+    simpa only [f, dif_pos hi] using this
+  refine ⟨J, f, ?_, ?_, ?_⟩
+  · -- card bound: the unmatched indices inject into the `d` dummies
+    have hmap : ∀ i ∈ Jᶜ, ∃ k, f' i = Sum.inr k := by
+      intro i hi
+      rw [hJ, mem_compl, mem_filter] at hi
+      have hnotL : (f' i).isLeft ≠ true := by
+        intro hcon; exact hi ⟨mem_univ i, hcon⟩
+      cases hfi : f' i with
+      | inl a => rw [hfi] at hnotL; simp at hnotL
+      | inr k => exact ⟨k, rfl⟩
+    have hcompl : Jᶜ.card ≤ d := by
+      have hle : Jᶜ.card ≤ ((univ : Finset (Fin d)).map (Embedding.inr (α := α))).card := by
+        refine Finset.card_le_card_of_injOn f' ?_ (hf'inj.injOn)
+        intro i hi
+        obtain ⟨k, hk⟩ := hmap i hi
+        rw [hk]
+        simp only [Finset.mem_coe, Finset.mem_map]
+        exact ⟨k, mem_univ k, rfl⟩
+      rwa [Finset.card_map, Finset.card_univ, Fintype.card_fin] at hle
+    have htot := Finset.card_add_card_compl J
+    omega
+  · -- injective on `J`
+    intro i hi j hj hij
+    rw [mem_coe] at hi hj
+    apply hf'inj
+    rw [hf_spec i hi, hf_spec j hj, hij]
+  · -- membership
+    intro i hi
+    have h1 := (hLeft i hi).choose_spec.1
+    simpa only [f, dif_pos hi] using h1
+
+omit [Nonempty α] in
+/-- **Defect Hall, easy direction.** A matching saturating all but `d` indices
+forces the family to be at worst `d`-deficient. -/
+theorem deficiency_le_of_matching {t : ι → Finset α} {d : ℕ}
+    {J : Finset ι} {f : ι → α}
+    (hcard : Fintype.card ι - d ≤ J.card)
+    (hinj : Set.InjOn f ↑J) (hmem : ∀ i ∈ J, f i ∈ t i) :
+    ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d := by
+  intro s
+  have hsub : (s ∩ J).card ≤ (s.biUnion t).card := by
+    refine Finset.card_le_card_of_injOn f ?_ ?_
+    · intro i hi
+      simp only [Finset.mem_coe, mem_inter] at hi
+      simp only [Finset.mem_coe]
+      exact mem_biUnion.mpr ⟨i, hi.1, hmem i hi.2⟩
+    · exact hinj.mono (Finset.coe_subset.mpr Finset.inter_subset_right)
+  have hJc : Jᶜ.card ≤ d := by
+    have := Finset.card_add_card_compl J
+    omega
+  have hsplit : s.card ≤ (s ∩ J).card + Jᶜ.card := by
+    have hsubset : s ⊆ (s ∩ J) ∪ Jᶜ := by
+      intro x hx
+      by_cases hxJ : x ∈ J
+      · exact mem_union_left _ (mem_inter.mpr ⟨hx, hxJ⟩)
+      · exact mem_union_right _ (mem_compl.mpr hxJ)
+    calc s.card ≤ ((s ∩ J) ∪ Jᶜ).card := Finset.card_le_card hsubset
+      _ ≤ (s ∩ J).card + Jᶜ.card := Finset.card_union_le _ _
+  omega
+
+/-- **Defect form of Hall's marriage theorem.** A matching saturating all but
+`d` indices exists iff the family is at worst `d`-deficient. -/
+theorem deficiency_matching_iff {t : ι → Finset α} {d : ℕ} :
+    (∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) ↔
+      ∃ (J : Finset ι) (f : ι → α),
+        Fintype.card ι - d ≤ J.card ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i :=
+  ⟨exists_matching_of_deficiency_le,
+    fun ⟨_, _, hc, hi, hm⟩ => deficiency_le_of_matching hc hi hm⟩
+
+/-- **`d = 0` recovers the marriage theorem.** Hall's condition gives a full
+system of distinct representatives (injective on all of `ι`). -/
+theorem exists_full_sdr_of_hall {t : ι → Finset α}
+    (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) :
+    ∃ f : ι → α, Set.InjOn f Set.univ ∧ ∀ i, f i ∈ t i := by
+  obtain ⟨J, f, hc, hi, hm⟩ :=
+    exists_matching_of_deficiency_le (d := 0) (by simpa using h)
+  have hJ : J = univ := by
+    have hle := Finset.card_le_univ J
+    have : J.card = Fintype.card ι := by simp only [Nat.sub_zero] at hc; omega
+    exact Finset.eq_univ_of_card J this
+  refine ⟨f, ?_, ?_⟩
+  · rw [hJ] at hi; simpa using hi
+  · intro i; exact hm i (by rw [hJ]; exact mem_univ i)
+
+end HallDefect

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 56 },
+    "type": "context",
+    "title": "The Defect Form and the Dummy-Target Strategy",
+    "content": "The docstring states the quantitative defect (Ore) version of Hall's theorem: a matching saturating all but $d$ of the indices — a set $J$ with $\\#J \\ge \\#\\iota - d$ and an $f$ injective on $J$ with $f\\,i \\in t\\,i$ — exists iff the family is at worst $d$-deficient, i.e. $\\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d$ for every sub-family $s$. The companion entry proved the all-or-nothing deficiency *obstruction*; this entry refines it to an exact count and asked-and-answered question. The strategy is the classical dummy-target augmentation, reducing the defect form to Mathlib's marriage theorem.",
+    "mathContext": "Matching all but $d$ $\\iff \\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d$; $d = 0$ is the marriage theorem.",
+    "significance": "context",
+    "relatedConcepts": ["defect Hall theorem", "Ore deficiency", "dummy-target augmentation", "near-perfect matching"],
+    "prerequisites": ["Hall's marriage theorem", "finite cardinality", "injections"]
+  },
+  {
+    "id": "ann-augmentation",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 100 },
+    "type": "technique",
+    "title": "The Augmented Family Restores Hall's Condition",
+    "content": "`aug t d i = (t\\,i).\\mathrm{map}\\,\\mathrm{inl} \\cup (\\mathrm{univ} : \\mathrm{Finset}\\,(\\mathrm{Fin}\\,d)).\\mathrm{map}\\,\\mathrm{inr}$ adjoins a shared block of $d$ brand-new dummy targets — a copy of $\\mathrm{Fin}\\,d$ living in the right summand of $\\alpha \\oplus \\mathrm{Fin}\\,d$ — to every set. `aug_hall` is the crux: for nonempty $s$, $s.\\mathrm{biUnion}\\,(aug\\,t\\,d) = (s.\\mathrm{biUnion}\\,t).\\mathrm{map}\\,\\mathrm{inl} \\cup (\\text{dummy block})$, and these two parts are *disjoint* (left vs right summand), so by `card_union_of_disjoint` and `card_map`, $\\#(s.\\mathrm{biUnion}\\,(aug\\,t\\,d)) = \\#(s.\\mathrm{biUnion}\\,t) + d$. Hence the hypothesis $\\#s \\le \\#(s.\\mathrm{biUnion}\\,t) + d$ becomes exactly Hall's condition for the augmented family — no re-proof of Hall is needed.",
+    "mathContext": "$\\#(s.\\mathrm{biUnion}\\,(aug\\,t\\,d)) = \\#(s.\\mathrm{biUnion}\\,t) + d$, turning $d$-deficiency into Hall's condition.",
+    "significance": "key",
+    "relatedConcepts": ["Function.Embedding.inl/inr", "card_union_of_disjoint", "card_map", "disjoint union"],
+    "prerequisites": ["sum types", "Finset map and biUnion", "disjointness"]
+  },
+  {
+    "id": "ann-hard-direction",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01",
+    "range": { "startLine": 102, "endLine": 158 },
+    "type": "theorem",
+    "title": "From Deficiency to a Matching",
+    "content": "`exists_matching_of_deficiency_le` is the substantive direction. Mathlib's `all_card_le_biUnion_card_iff_exists_injective`, applied to `aug t d` via `aug_hall`, yields an injective $f' : \\iota \\to \\alpha \\oplus \\mathrm{Fin}\\,d$ with $f'\\,i \\in aug\\,t\\,d\\,i$. The matched set is $J = \\{i \\mid (f'\\,i).\\mathrm{isLeft}\\}$: each such $i$ carries a genuine witness $a \\in t\\,i$ with $f'\\,i = \\mathrm{inl}\\,a$, defining $f$. The *unmatched* indices $J^c$ map under $f'$ into the $d$ dummies; since $f'$ is injective, $\\#J^c \\le d$ (an injection into $\\mathrm{Fin}\\,d$), so $\\#J \\ge \\#\\iota - d$ by `card_add_card_compl`. Injectivity of $f$ on $J$ is inherited from $f'$ through the injectivity of $\\mathrm{inl}$.",
+    "mathContext": "Indices landing in the left summand are matched; at most $d$ escape into dummies, so $\\#J \\ge \\#\\iota - d$.",
+    "significance": "key",
+    "relatedConcepts": ["all_card_le_biUnion_card_iff_exists_injective", "Sum.isLeft", "card_le_card_of_injOn", "card_add_card_compl"],
+    "prerequisites": ["Hall's theorem", "complement cardinality", "choice functions"]
+  },
+  {
+    "id": "ann-easy-direction",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01",
+    "range": { "startLine": 160, "endLine": 187 },
+    "type": "theorem",
+    "title": "From a Matching to Deficiency",
+    "content": "`deficiency_le_of_matching` is the easy converse. Given a matching on $J$ of size $\\ge \\#\\iota - d$, for any sub-family $s$ the function $f$ injects $s \\cap J$ into $s.\\mathrm{biUnion}\\,t$ (each matched $f\\,i \\in t\\,i$), so $\\#(s \\cap J) \\le \\#(s.\\mathrm{biUnion}\\,t)$ via `card_le_card_of_injOn`. The unsaturated part is controlled by $\\#J^c \\le d$, and $s \\subseteq (s \\cap J) \\cup J^c$ gives $\\#s \\le \\#(s \\cap J) + \\#J^c \\le \\#(s.\\mathrm{biUnion}\\,t) + d$. This makes the bound in the main theorem tight: $d$-deficiency is both necessary and sufficient.",
+    "mathContext": "$\\#s \\le \\#(s \\cap J) + \\#J^c \\le \\#(s.\\mathrm{biUnion}\\,t) + d.$",
+    "significance": "supporting",
+    "relatedConcepts": ["card_le_card_of_injOn", "InjOn.mono", "card_union_le", "card_add_card_compl"],
+    "prerequisites": ["subset cardinality", "injections on sets"]
+  },
+  {
+    "id": "ann-packaging",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01",
+    "range": { "startLine": 189, "endLine": 213 },
+    "type": "theorem",
+    "title": "The Biconditional and the d = 0 Corollary",
+    "content": "`deficiency_matching_iff` packages the two directions into the defect form of Hall's marriage theorem. `exists_full_sdr_of_hall` specializes to $d = 0$: Hall's condition gives a matched set with $\\#J \\ge \\#\\iota$, forcing $J = \\mathrm{univ}$ (`eq_univ_of_card`), hence a *full* system of distinct representatives injective on all of $\\iota$. This exhibits the parent entry's marriage theorem as the zero-deficiency boundary case of the defect theorem proved here.",
+    "mathContext": "$d = 0 \\Rightarrow J = \\mathrm{univ}$ and $f$ is a full SDR injective on all of $\\iota$.",
+    "significance": "key",
+    "relatedConcepts": ["biconditional", "eq_univ_of_card", "system of distinct representatives", "boundary case"],
+    "prerequisites": ["Hall's marriage theorem", "Fintype cardinality"]
+  }
+]

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallMarriageTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallMarriageTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallMarriageTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallMarriageTheoremOQ01OQ01Data: ProofData = {
+  proof: hallMarriageTheoremOQ01OQ01Proof,
+  annotations: hallMarriageTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,195 @@
+{
+  "id": "hall-marriage-theorem-oq-01-oq-01",
+  "title": "Hall's marriage theorem, defect form: a matching saturating all but the deficiency",
+  "slug": "hall-marriage-theorem-oq-01-oq-01",
+  "description": "The quantitative defect (Ore) form of Hall's marriage theorem, answering the lead open question of the companion entry hall-marriage-theorem-oq-01. That entry proved Hall's biconditional and the all-or-nothing deficiency obstruction (a deficient sub-family blocks ANY full transversal); this entry refines the obstruction to an exact count. For a finite family t : ι → Finset α, a matching saturating all but d of the indices — a set J ⊆ ι with #J ≥ #ι − d together with a choice function f injective on J with f i ∈ t i for i ∈ J — exists IFF the family is at worst d-deficient, i.e. every sub-family s satisfies #s ≤ #(s.biUnion t) + d. Setting d = 0 recovers the full marriage theorem. The substantive direction is the classical dummy-target augmentation: adjoin a shared block of d brand-new targets (a copy of Fin d) to every set, verify that this restores Hall's condition exactly (the α-part and the dummy block are disjoint, so cardinalities add a clean +d), invoke Mathlib's marriage theorem on the augmented family, and read off the matched indices as those landing in the genuine α part — at most d indices escape into the dummies. Mathlib does not contain the defect/deficiency version; this is original content built on Finset.all_card_le_biUnion_card_iff_exists_injective.",
+  "meta": {
+    "author": "Øystein Ore (1955), P. Hall (1935); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HallMarriageTheoremOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "hall-marriage",
+      "transversal",
+      "matching",
+      "deficiency",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.all_card_le_biUnion_card_iff_exists_injective",
+        "description": "Hall's marriage theorem (set-system form): (∀ s, #s ≤ #(s.biUnion t)) ↔ ∃ f injective with f x ∈ t x. Applied to the augmented family aug t d to extract the matching.",
+        "module": "Mathlib.Combinatorics.Hall.Basic"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection from s into t bounds #s ≤ #t. Used twice: to bound the unmatched indices by the d dummies (#Jᶜ ≤ d), and in the converse to inject s ∩ J into s.biUnion t.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_union_of_disjoint",
+        "description": "#(A ∪ B) = #A + #B for disjoint A, B. Drives the key card identity #(s.biUnion (aug t d)) = #(s.biUnion t) + d, the α-part and the dummy block being disjoint (inl vs inr).",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_add_card_compl",
+        "description": "#J + #Jᶜ = Fintype.card ι. Converts the bound #Jᶜ ≤ d into the matched-size lower bound #J ≥ #ι − d.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Function.Embedding.inl / Function.Embedding.inr",
+        "description": "The canonical injections α ↪ α ⊕ Fin d and Fin d ↪ α ⊕ Fin d used to build the augmented target type (genuine targets in the left summand, d dummies in the right).",
+        "module": "Mathlib.Logic.Embedding.Basic"
+      }
+    ],
+    "originalContributions": [
+      "deficiency_matching_iff: the defect form of Hall's theorem as a biconditional — a matching saturating all but d indices exists ⟺ the family is at worst d-deficient (∀ s, #s ≤ #(s.biUnion t) + d). The quantitative refinement of the parent's all-or-nothing obstruction. Not in Mathlib.",
+      "exists_matching_of_deficiency_le: the substantive direction by dummy-target augmentation — from d-deficiency, produce a set J with #J ≥ #ι − d and an f injective on J with f i ∈ t i.",
+      "aug / aug_hall: the augmented family (adjoin a shared Fin d dummy block to every target) and the proof that d-deficiency of t becomes exact Hall's condition for aug t d, via the disjoint-union card identity #(s.biUnion (aug t d)) = #(s.biUnion t) + d.",
+      "deficiency_le_of_matching: the easy converse — a matching of size ≥ #ι − d forces d-deficiency, by injecting s ∩ J into s.biUnion t and bounding the unsaturated part by #Jᶜ ≤ d.",
+      "exists_full_sdr_of_hall: the d = 0 specialization recovering a full system of distinct representatives (injective on all of ι), tying the defect theorem back to the ordinary marriage theorem of the parent entry."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None beyond the foundational axioms propext, Classical.choice, Quot.sound (introduced by `classical` / the choice function and standard Mathlib lemmas). 0 `axiom` declarations, 0 sorries, no native_decide (so no Lean.ofReduceBool). The only typeclass hypothesis worth noting is [Nonempty α], a mild non-degeneracy assumption used so the partial matching can be packaged as a total function f : ι → α; it excludes only the degenerate empty-target case.",
+    "lineCount": 213,
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Hall's marriage theorem (1935) gives a yes/no criterion for a full system of distinct representatives. In applications one frequently has NO full transversal but still wants the largest possible partial one. Øystein Ore's defect (deficiency) version (1955) supplies the exact answer: the maximum number of indices that can be simultaneously matched is #ι − δ, where δ = maxₛ (#s − #(s.biUnion t)) is the deficiency. It is the cardinal form behind the König–Egerváry theorem and the standard tool for near-perfect matchings.",
+    "problemStatement": "The companion entry hall-marriage-theorem-oq-01 proved Hall's biconditional and the deficiency OBSTRUCTION (a deficient sub-family certifies that no full transversal exists), and asked: can the defect version be formalized quantitatively — that a matching of size #ι − δ always exists, refining the all-or-nothing obstruction to an exact count?\n\n**Answer:** Yes. The parametric defect theorem (matching all but d ⟺ d-deficiency) is proved by the classical dummy-target augmentation, reducing it to Mathlib's marriage theorem; d = 0 recovers the full SDR.",
+    "text": "The augmented family aug t d adjoins d shared dummy targets to every set; d-deficiency of t is exactly Hall's condition for aug t d; Mathlib's marriage theorem yields an injection, whose genuine (non-dummy) part is a matching saturating all but ≤ d indices. The converse is a direct count, and d = 0 recovers a full SDR.",
+    "proofStrategy": "1. aug: form the augmented target type α ⊕ Fin d, with aug t d i = (t i).map inl ∪ (univ : Finset (Fin d)).map inr.\n2. aug_hall: for nonempty s, s.biUnion (aug t d) = (s.biUnion t).map inl ∪ (dummy block); the two parts are disjoint (inl vs inr), so #(s.biUnion (aug t d)) = #(s.biUnion t) + d. The hypothesis #s ≤ #(s.biUnion t) + d becomes Hall's condition.\n3. exists_matching_of_deficiency_le: apply Mathlib's all_card_le_biUnion_card_iff_exists_injective to get injective f' : ι → α ⊕ Fin d. Let J = {i | (f' i).isLeft}; each i ∈ J carries a witness a ∈ t i with f' i = inl a, defining f. The unmatched indices Jᶜ inject (via f', injective) into the d dummies, so #Jᶜ ≤ d, hence #J ≥ #ι − d by card_add_card_compl.\n4. deficiency_le_of_matching: conversely, f injects s ∩ J into s.biUnion t and #Jᶜ ≤ d, so #s ≤ #(s ∩ J) + #Jᶜ ≤ #(s.biUnion t) + d.\n5. deficiency_matching_iff packages 3 and 4; exists_full_sdr_of_hall instantiates d = 0 (then #J = #ι forces J = univ).",
+    "keyInsights": [
+      "**Deficiency is a clean additive shift.** Adjoining d universal dummy targets raises every neighbourhood cardinality by exactly d (the dummies are disjoint from the genuine targets), so 'at worst d-deficient' for t is literally Hall's condition for the augmented family. No re-proof of Hall is needed — the hard work is borrowed from Mathlib.",
+      "**The matched set is read off by summand.** In the augmented injection f' : ι → α ⊕ Fin d, the indices landing in the left summand are exactly the matched ones; those landing in the right summand are absorbed by dummies and number at most d, since f' is injective and there are only d dummies. This is what turns 'd-deficient' into 'misses ≤ d'.",
+      "**The obstruction becomes an identity.** The parent's no_sdr_of_deficiency says deficiency ⟹ no full matching; here the same quantity d controls the EXACT shortfall, and the biconditional shows the bound #ι − d is achieved, not merely an upper limit.",
+      "**d = 0 is the marriage theorem.** Specializing the defect form to zero deficiency forces J = univ and recovers a full system of distinct representatives, exhibiting the parent's theorem as the boundary case of this one."
+    ],
+    "exampleSections": [
+      {
+        "title": "From obstruction to exact count",
+        "mathContext": "Where the parent certifies impossibility of a full transversal from a single deficient sub-family, the defect form guarantees a matching of size #ι − d whenever the deficiency is bounded by d — and conversely reads the bound off any matching."
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "deficiency_matching_iff",
+      "type": "main",
+      "description": "The defect (Ore) form of Hall's marriage theorem: a matching saturating all but d indices exists iff the family is at worst d-deficient. The quantitative refinement of the parent's deficiency obstruction; not present in Mathlib.",
+      "leanType": "{t : ι → Finset α} {d : ℕ} : (∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) ↔ ∃ (J : Finset ι) (f : ι → α), Fintype.card ι - d ≤ J.card ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i"
+    },
+    {
+      "name": "exists_matching_of_deficiency_le",
+      "type": "main",
+      "description": "The substantive direction: from d-deficiency, the dummy-target augmentation produces a matched set J of size ≥ #ι − d with a choice function injective on J landing in the prescribed targets.",
+      "leanType": "{t : ι → Finset α} {d : ℕ} (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) : ∃ (J : Finset ι) (f : ι → α), Fintype.card ι - d ≤ J.card ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i"
+    },
+    {
+      "name": "aug_hall",
+      "type": "lemma",
+      "description": "The augmentation engine: if t is at worst d-deficient then the augmented family aug t d satisfies Hall's condition outright, via the disjoint-union card identity #(s.biUnion (aug t d)) = #(s.biUnion t) + d.",
+      "leanType": "{t : ι → Finset α} {d : ℕ} (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d) : ∀ s : Finset ι, s.card ≤ (s.biUnion (aug t d)).card"
+    },
+    {
+      "name": "deficiency_le_of_matching",
+      "type": "lemma",
+      "description": "The easy converse: a matching saturating all but d indices forces the family to be at worst d-deficient, by injecting s ∩ J into s.biUnion t and bounding the unsaturated indices by #Jᶜ ≤ d.",
+      "leanType": "{t : ι → Finset α} {d : ℕ} {J : Finset ι} {f : ι → α} (hcard : Fintype.card ι - d ≤ J.card) (hinj : Set.InjOn f ↑J) (hmem : ∀ i ∈ J, f i ∈ t i) : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + d"
+    },
+    {
+      "name": "exists_full_sdr_of_hall",
+      "type": "lemma",
+      "description": "The d = 0 specialization: Hall's condition yields a full system of distinct representatives (injective on all of ι), recovering the ordinary marriage theorem as the zero-deficiency boundary case.",
+      "leanType": "{t : ι → Finset α} (h : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) : ∃ f : ι → α, Set.InjOn f Set.univ ∧ ∀ i, f i ∈ t i"
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Setup: the defect form and the dummy-target idea",
+      "startLine": 4,
+      "endLine": 56,
+      "summary": "Module docstring: the quantitative defect (Ore) version of Hall's theorem, the dummy-target augmentation strategy, and the variable setup {ι α} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α].",
+      "mathContext": "Matching all but d ⟺ ∀ s, #s ≤ #(s.biUnion t) + d."
+    },
+    {
+      "id": "augmentation",
+      "title": "The augmented family and Hall's condition",
+      "startLine": 58,
+      "endLine": 100,
+      "summary": "aug t d adjoins a shared block of d dummy targets (a copy of Fin d in the right summand of α ⊕ Fin d); aug_hall proves d-deficiency of t becomes exact Hall's condition for aug t d, via #(s.biUnion (aug t d)) = #(s.biUnion t) + d (disjoint α-part and dummy block).",
+      "mathContext": "#(s.biUnion (aug t d)) = #(s.biUnion t) + d for nonempty s."
+    },
+    {
+      "id": "hard-direction",
+      "title": "From deficiency to a matching",
+      "startLine": 102,
+      "endLine": 158,
+      "summary": "exists_matching_of_deficiency_le: apply Mathlib's marriage theorem to aug t d, take J = indices landing in the genuine α summand, and bound the unmatched part by the d dummies (#Jᶜ ≤ d via an injection into Fin d), giving #J ≥ #ι − d.",
+      "mathContext": "Injective f' : ι → α ⊕ Fin d ⇒ matched J with #J ≥ #ι − d."
+    },
+    {
+      "id": "easy-direction",
+      "title": "From a matching to deficiency",
+      "startLine": 160,
+      "endLine": 187,
+      "summary": "deficiency_le_of_matching: a matching on J of size ≥ #ι − d injects s ∩ J into s.biUnion t, and the unsaturated indices number ≤ #Jᶜ ≤ d, so #s ≤ #(s.biUnion t) + d.",
+      "mathContext": "#s ≤ #(s ∩ J) + #Jᶜ ≤ #(s.biUnion t) + d."
+    },
+    {
+      "id": "packaging",
+      "title": "The biconditional and the d = 0 corollary",
+      "startLine": 189,
+      "endLine": 213,
+      "summary": "deficiency_matching_iff combines the two directions into the defect form; exists_full_sdr_of_hall instantiates d = 0 to recover a full system of distinct representatives (J = univ), tying back to the parent's marriage theorem.",
+      "mathContext": "d = 0 ⇒ full SDR injective on all of ι."
+    }
+  ],
+  "conclusion": {
+    "summary": "The defect (Ore) form of Hall's marriage theorem is formalized: a matching saturating all but d of the indices exists iff the family is at worst d-deficient (deficiency_matching_iff). The substantive direction (exists_matching_of_deficiency_le) uses the classical dummy-target augmentation — aug / aug_hall reduce d-deficiency to Hall's condition for an augmented family, and Mathlib's marriage theorem supplies the injection. The converse (deficiency_le_of_matching) is a direct count, and the d = 0 case (exists_full_sdr_of_hall) recovers a full system of distinct representatives. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Answers the lead open question of hall-marriage-theorem-oq-01, upgrading the all-or-nothing deficiency obstruction to an exact, achievable count. Provides the cardinal building block (max matching = #ι − deficiency) behind König–Egerváry and near-perfect matching arguments, in the reusable set-system (transversal) idiom.",
+    "openQuestions": [
+      "Can the deficiency δ = maxₛ (#s − #(s.biUnion t)) be packaged as an explicit Finset-sup, turning deficiency_matching_iff into the closed-form statement 'maximum partial-transversal size = #ι − δ'?",
+      "Does the augmentation route generalize to the weighted / capacitated setting (Ore's defect formula for b-matchings), or to deriving König's min-cover = max-matching identity directly from this defect theorem?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "hall-marriage-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: Hall's biconditional, the direct necessity proof, and the all-or-nothing deficiency OBSTRUCTION. This entry answers its lead open question by refining the obstruction to the exact defect count (matching all but d ⟺ d-deficiency), recovering the parent's full-transversal theorem at d = 0."
+    },
+    {
+      "targetId": "halls-theorem-oq-01",
+      "relationship": "related",
+      "description": "The bipartite-graph matching formulation of Hall's theorem. The defect form proved here is the cardinal (max-matching) refinement, in the dual set-system / transversal idiom."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Ore, Øystein",
+      "title": "Graphs and matching theorems",
+      "year": "1955",
+      "note": "Duke Math. J. 22, 625–639 — the defect (deficiency) version of Hall's theorem: the maximum matching has size n − maxₛ(#s − #N(s))."
+    },
+    {
+      "authors": "Hall, Philip",
+      "title": "On Representatives of Subsets",
+      "year": "1935",
+      "note": "J. London Math. Soc. 10, 26–30 — the original marriage theorem; the d = 0 case of the defect form."
+    },
+    {
+      "authors": "van Lint, J. H.; Wilson, R. M.",
+      "title": "A Course in Combinatorics",
+      "year": "2001",
+      "note": "Chapter 5 — Hall's theorem, the deficiency version, and the dummy-vertex augmentation reducing the defect form to the ordinary marriage theorem."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **lead open question** of the parent entry `hall-marriage-theorem-oq-01`:

> Can the defect (deficiency) version of Hall's theorem be formalized quantitatively — that the maximum size of a partial transversal equals #ι − maxₛ(#s − #(s.biUnion t)) — refining the all-or-nothing obstruction to an exact count?

**Yes.** This entry proves the parametric **defect (Ore) form** of Hall's marriage theorem.

### Main results (`HallDefect`, `Proofs/HallMarriageTheoremOQ01OQ01.lean`)

- **`deficiency_matching_iff`** (MAIN): a matching saturating all but `d` indices exists ⟺ the family is at worst `d`-deficient, `∀ s, #s ≤ #(s.biUnion t) + d`.
- **`exists_matching_of_deficiency_le`**: the substantive direction, via the classical **dummy-target augmentation**. Adjoin a shared block of `d` fresh dummy targets (a copy of `Fin d` in `α ⊕ Fin d`); this restores Hall's condition *exactly* — `#(s.biUnion (aug t d)) = #(s.biUnion t) + d` because the genuine `α`-part and the dummy block are disjoint. Mathlib's `all_card_le_biUnion_card_iff_exists_injective` then yields an injection whose genuine (left-summand) part is the matched set `J`; at most `d` indices escape into the dummies, so `#J ≥ #ι − d`.
- **`aug` / `aug_hall`**: the augmented family and the disjoint-union card identity that powers the reduction.
- **`deficiency_le_of_matching`**: the easy converse (a direct count), making the bound tight.
- **`exists_full_sdr_of_hall`**: the `d = 0` specialization recovering a full system of distinct representatives — the parent's marriage theorem as the zero-deficiency boundary case.

Mathlib has no defect/deficiency version of Hall's theorem; this is original content built on its marriage theorem.

### Verification

- **213 lines, 5 theorems + 1 definition, 0 sorries.**
- `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only → **verified, 0-axiom** (no `native_decide`, no `Lean.ofReduceBool`).
- Built single-file with `lake env lean` against Mathlib v4.26.0 and the parent olean.
- The only typeclass note: `[Nonempty α]` (mild; lets the partial matching be packaged as a total `f : ι → α`, excluding only the degenerate empty-target case).

Gallery data added under `src/data/proofs/hall-marriage-theorem-oq-01-oq-01/` (meta, annotations, index); registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)