### PR TITLE
research(cauchy-interlacing-theorem-oq-03-oq-01): operator-norm eigenvalue stability |μ(k)−ν(k)| ≤ ‖T−U‖ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingOQ030101Stability.lean
+++ b/proofs/Proofs/CauchyInterlacingOQ030101Stability.lean
@@ -1,0 +1,166 @@
+import Mathlib
+import Proofs.CauchyInterlacingWeyl
+
+/-
+# Weyl's eigenvalue stability bound `|μ(k) − ν(k)| ≤ ‖T − U‖`
+
+This file derives the **operator-norm eigenvalue stability** (Weyl perturbation /
+Lipschitz) theorem for symmetric operators as a corollary of the Weyl
+*monotonicity* theorem `weyl_monotone` proved in `CauchyInterlacingWeyl.lean`
+(itself a corollary of the Courant–Fischer keystone, #25063, 0-sorry/0-axiom).
+No new spectral theory is introduced; the only new analytic input is the
+elementary Rayleigh bound `re⟪(A − B)x, x⟫ ≤ ‖A − B‖ · ‖x‖²` coming from
+Cauchy–Schwarz and the operator-norm inequality `‖(A − B)x‖ ≤ ‖A − B‖ · ‖x‖`.
+
+This answers the lead open question of the parent entry
+`cauchy-interlacing-theorem-oq-03`: *"Derive the operator-norm stability bound
+`|μ(k) − ν(k)| ≤ ‖T − U‖` from weyl_monotone by sandwiching T between
+`U − ‖T−U‖·I` and `U + ‖T−U‖·I` (Loewner)."*
+
+## The sandwich argument
+
+Write `δ := ‖T − U‖` and `E := T − U`. For every `x`,
+`re⟪E x, x⟫ ≤ ‖E x‖ · ‖x‖ ≤ ‖E‖ · ‖x‖² = δ · ‖x‖²` (and symmetrically for
+`U − T`, using `‖U − T‖ = ‖T − U‖`). Hence in the Loewner order
+
+  `U − δ·I  ⪯  T  ⪯  U + δ·I`.
+
+The operators `U ± δ·I` share `U`'s eigenbasis with eigenvalues `ν ± δ` (a real
+shift preserves the antitone ordering). Feeding the two Loewner inequalities into
+`weyl_monotone` gives
+
+  `μ(k) ≤ ν(k) + δ`   and   `ν(k) − δ ≤ μ(k)`,
+
+i.e. `|μ(k) − ν(k)| ≤ δ = ‖T − U‖`.
+
+Operators are presented as **continuous** linear maps `T U : E →L[𝕜] E` so that
+`‖T − U‖` is the genuine operator norm; the spectral presentation (orthonormal
+eigenbasis + antitone eigenvalue enumeration) is taken as input exactly as in the
+parent keystone.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open InnerProductSpace
+
+namespace CauchyInterlacing.Stability
+
+open CauchyInterlacing.Weyl
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-! ## The elementary Rayleigh / operator-norm bound -/
+
+/-- **Operator-norm Rayleigh bound.** For continuous operators `A`, `B`, the real
+Rayleigh quotient of the difference is controlled by the operator norm:
+`re⟪(A − B)x, x⟫ ≤ ‖A − B‖ · ‖x‖²`. Proof: Cauchy–Schwarz
+(`re_inner_le_norm`) followed by the operator-norm bound
+`‖(A − B)x‖ ≤ ‖A − B‖ · ‖x‖`. -/
+theorem reInner_diff_le (A B : E →L[𝕜] E) (x : E) :
+    RCLike.re (@inner 𝕜 E _ (A x - B x) x) ≤ ‖A - B‖ * ‖x‖ ^ 2 := by
+  have h1 : RCLike.re (@inner 𝕜 E _ (A x - B x) x) ≤ ‖A x - B x‖ * ‖x‖ :=
+    re_inner_le_norm (A x - B x) x
+  have h2 : A x - B x = (A - B) x := (ContinuousLinearMap.sub_apply A B x).symm
+  have h3 : ‖(A - B) x‖ ≤ ‖A - B‖ * ‖x‖ := (A - B).le_opNorm x
+  calc RCLike.re (@inner 𝕜 E _ (A x - B x) x)
+        ≤ ‖A x - B x‖ * ‖x‖ := h1
+    _ = ‖(A - B) x‖ * ‖x‖ := by rw [h2]
+    _ ≤ (‖A - B‖ * ‖x‖) * ‖x‖ := by
+          exact mul_le_mul_of_nonneg_right h3 (norm_nonneg x)
+    _ = ‖A - B‖ * ‖x‖ ^ 2 := by ring
+
+/-! ## Algebra of the scalar shift `V + s·I` -/
+
+/-- The real Rayleigh quotient of a scalar-shifted operator: `re⟪(V + s·I)x, x⟫`
+splits as `re⟪V x, x⟫ + s · ‖x‖²`. -/
+theorem reInner_add_smul (s : ℝ) (V : E →ₗ[𝕜] E) (x : E) :
+    RCLike.re (@inner 𝕜 E _ ((V + (s : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E)) x) x)
+      = RCLike.re (@inner 𝕜 E _ (V x) x) + s * ‖x‖ ^ 2 := by
+  rw [LinearMap.add_apply, LinearMap.smul_apply, LinearMap.id_apply, inner_add_left, map_add,
+    inner_smul_left, RCLike.conj_ofReal, RCLike.re_ofReal_mul, inner_self_eq_norm_sq]
+
+/-- The scalar shift `V + s·I` acts on an eigenvector `e i` (eigenvalue `lam i`)
+with the shifted eigenvalue `lam i + s`. -/
+theorem shift_eigen (s : ℝ) (V : E →ₗ[𝕜] E) {n : ℕ} (e : OrthonormalBasis (Fin n) 𝕜 E)
+    (lam : Fin n → ℝ) (hV : ∀ i, V (e i) = (lam i : 𝕜) • e i) (i : Fin n) :
+    (V + (s : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E)) (e i) = ((lam i + s : ℝ) : 𝕜) • e i := by
+  rw [LinearMap.add_apply, LinearMap.smul_apply, LinearMap.id_apply, hV i]
+  push_cast
+  rw [← add_smul]
+
+/-! ## The eigenvalue stability theorem -/
+
+/-- **Weyl's eigenvalue stability bound.** Let `T`, `U` be continuous operators on
+a finite-dimensional inner product space, each presented by an orthonormal
+eigenbasis (`b`, `c`) and an antitone (descending) eigenvalue enumeration
+(`μ`, `ν`). Then the eigenvalues are `1`-Lipschitz in the operator norm:
+
+`|μ(k) − ν(k)| ≤ ‖T − U‖`  for every index `k`.
+
+This is the classical Weyl perturbation theorem `|λ_k(A) − λ_k(B)| ≤ ‖A − B‖`,
+obtained here purely from `weyl_monotone` by the Loewner sandwich
+`U − ‖T−U‖·I ⪯ T ⪯ U + ‖T−U‖·I`. -/
+theorem weyl_eigenvalue_stability
+    [FiniteDimensional 𝕜 E] {n : ℕ}
+    (T U : E →L[𝕜] E)
+    (b : OrthonormalBasis (Fin n) 𝕜 E) (μ : Fin n → ℝ)
+    (hbT : ∀ i, T (b i) = (μ i : 𝕜) • b i) (hμ : Antitone μ)
+    (c : OrthonormalBasis (Fin n) 𝕜 E) (ν : Fin n → ℝ)
+    (hcU : ∀ i, U (c i) = (ν i : 𝕜) • c i) (hν : Antitone ν)
+    (k : Fin n) :
+    |μ k - ν k| ≤ ‖T - U‖ := by
+  set δ : ℝ := ‖T - U‖ with hδ
+  -- the eigen-presentations carried over to the LinearMap coercions
+  have hbT' : ∀ i, (T : E →ₗ[𝕜] E) (b i) = (μ i : 𝕜) • b i := hbT
+  have hcU' : ∀ i, (U : E →ₗ[𝕜] E) (c i) = (ν i : 𝕜) • c i := hcU
+  -- STEP 1: `T ⪯ U + δ·I`, giving `μ k ≤ ν k + δ`
+  have hle1 : ∀ x : E, RCLike.re (@inner 𝕜 E _ ((T : E →ₗ[𝕜] E) x) x)
+      ≤ RCLike.re (@inner 𝕜 E _ (((U : E →ₗ[𝕜] E) + (δ : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E)) x) x) := by
+    intro x
+    rw [reInner_add_smul]
+    have hb := reInner_diff_le T U x
+    have hsplit : RCLike.re (@inner 𝕜 E _ (T x - U x) x)
+        = RCLike.re (@inner 𝕜 E _ (T x) x) - RCLike.re (@inner 𝕜 E _ (U x) x) := by
+      rw [inner_sub_left, map_sub]
+    rw [hsplit] at hb
+    simp only [ContinuousLinearMap.coe_coe]
+    linarith
+  have h1 : μ k ≤ ν k + δ :=
+    weyl_monotone (T : E →ₗ[𝕜] E) ((U : E →ₗ[𝕜] E) + (δ : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E))
+      b μ hbT' hμ c (fun i => ν i + δ)
+      (fun i => shift_eigen δ (U : E →ₗ[𝕜] E) c ν hcU' i) (hν.add_const δ) hle1 k
+  -- STEP 2: `U − δ·I ⪯ T`, giving `ν k − δ ≤ μ k`
+  have hle2 : ∀ x : E,
+      RCLike.re (@inner 𝕜 E _ (((U : E →ₗ[𝕜] E) + ((-δ : ℝ) : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E)) x) x)
+        ≤ RCLike.re (@inner 𝕜 E _ ((T : E →ₗ[𝕜] E) x) x) := by
+    intro x
+    rw [reInner_add_smul]
+    have hb := reInner_diff_le U T x
+    rw [norm_sub_rev] at hb
+    have hsplit : RCLike.re (@inner 𝕜 E _ (U x - T x) x)
+        = RCLike.re (@inner 𝕜 E _ (U x) x) - RCLike.re (@inner 𝕜 E _ (T x) x) := by
+      rw [inner_sub_left, map_sub]
+    rw [hsplit] at hb
+    simp only [ContinuousLinearMap.coe_coe]
+    linarith
+  have h2 : ν k + (-δ) ≤ μ k :=
+    weyl_monotone ((U : E →ₗ[𝕜] E) + ((-δ : ℝ) : 𝕜) • (LinearMap.id : E →ₗ[𝕜] E)) (T : E →ₗ[𝕜] E)
+      c (fun i => ν i + (-δ))
+      (fun i => shift_eigen (-δ) (U : E →ₗ[𝕜] E) c ν hcU' i) (hν.add_const (-δ))
+      b μ hbT' hμ hle2 k
+  -- combine the two one-sided bounds
+  rw [abs_le]
+  constructor
+  · linarith
+  · linarith
+
+/-! ## Sanity check: the bound is non-vacuous and sharp at `T = U` -/
+
+/-- At `T = U` the eigenvalues coincide pointwise and the bound reads `0 ≤ 0`. -/
+example [FiniteDimensional 𝕜 E] {n : ℕ}
+    (T : E →L[𝕜] E)
+    (b : OrthonormalBasis (Fin n) 𝕜 E) (μ : Fin n → ℝ)
+    (hbT : ∀ i, T (b i) = (μ i : 𝕜) • b i) (hμ : Antitone μ) (k : Fin n) :
+    |μ k - μ k| ≤ ‖T - T‖ := weyl_eigenvalue_stability T T b μ hbT hμ b μ hbT hμ k
+
+end CauchyInterlacing.Stability

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "ann-stability-oq0301-rayleigh-bound",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "technique",
+    "title": "Cauchy–Schwarz Meets the Operator Norm",
+    "content": "reInner_diff_le is the only new analytic input of the proof: the real Rayleigh numerator of a difference is controlled by the operator norm, re⟪(A−B)x, x⟫ ≤ ‖A−B‖·‖x‖². It is a two-step chain — Cauchy–Schwarz on the real part (re_inner_le_norm: re⟪y, x⟫ ≤ ‖y‖·‖x‖) followed by the defining operator-norm inequality ‖(A−B)x‖ ≤ ‖A−B‖·‖x‖ (ContinuousLinearMap.le_opNorm). This estimate is precisely what converts the operator-norm hypothesis ‖T − U‖ into the two Loewner inequalities the eigenvalue sandwich runs on.",
+    "mathContext": "$$\\mathrm{re}\\langle (A-B)x, x\\rangle \\le \\|(A-B)x\\|\\,\\|x\\| \\le \\|A-B\\|\\,\\|x\\|^2.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Schwarz inequality",
+      "operator norm",
+      "Rayleigh quotient",
+      "Loewner order"
+    ],
+    "prerequisites": [
+      "continuous linear maps and the operator norm",
+      "inner product spaces over RCLike fields"
+    ]
+  },
+  {
+    "id": "ann-stability-oq0301-scalar-shift",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 76, "endLine": 89 },
+    "type": "concept",
+    "title": "A Real Scalar Shift Is Spectrally Transparent",
+    "content": "Two short lemmas record that adding a real multiple of the identity does nothing but shift the spectrum. reInner_add_smul: the Rayleigh quotient shifts by the scalar, re⟪(V + s·I)x, x⟫ = re⟪V x, x⟫ + s·‖x‖² (the cross term re⟪s·x, x⟫ becomes s·‖x‖² because s is real — RCLike.conj_ofReal passes it through the conjugate-linear slot, and inner_self_eq_norm_sq turns ⟪x,x⟫ into ‖x‖²). shift_eigen: the operator V + s·I acts on each eigenvector e i with the shifted eigenvalue lam i + s. Together they let U ± ‖T−U‖·I reuse U's eigenbasis with eigenvalues ν ± ‖T−U‖, which stay antitone (Antitone.add_const) — exactly the spectral presentation weyl_monotone demands.",
+    "mathContext": "$$(V + sI)e_i = (\\lambda_i + s)e_i, \\qquad \\frac{\\mathrm{re}\\langle (V+sI)x,x\\rangle}{\\|x\\|^2} = \\frac{\\mathrm{re}\\langle Vx,x\\rangle}{\\|x\\|^2} + s.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "scalar shift V + s·I",
+      "eigenvalue translation",
+      "antitone eigenvalue enumeration",
+      "Rayleigh quotient"
+    ],
+    "prerequisites": [
+      "eigenvectors and eigenvalues",
+      "inner_smul_left and the conjugate-linear slot",
+      "Antitone.add_const"
+    ]
+  },
+  {
+    "id": "ann-stability-oq0301-sandwich",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01",
+    "range": { "startLine": 103, "endLine": 156 },
+    "type": "key-step",
+    "title": "The Loewner Sandwich Lipschitz Bound",
+    "content": "weyl_eigenvalue_stability is the classical Weyl perturbation theorem |μ(k) − ν(k)| ≤ ‖T − U‖ — eigenvalues are 1-Lipschitz in the operator norm. The proof needs no new spectral theory: with δ = ‖T − U‖, the Rayleigh bound gives the two Loewner inequalities U − δ·I ⪯ T ⪯ U + δ·I. Feeding T ⪯ U + δ·I into the parent's weyl_monotone (with the shifted operator's eigenvalues ν + δ) yields μ(k) ≤ ν(k) + δ; feeding U − δ·I ⪯ T (using ‖U − T‖ = ‖T − U‖ via norm_sub_rev) yields ν(k) − δ ≤ μ(k). The two one-sided bounds combine through abs_le into |μ(k) − ν(k)| ≤ δ. This is the structural point: the qualitative monotonicity of the parent already contains the quantitative stability bound — bracket and apply twice.",
+    "mathContext": "$$U - \\|T-U\\|\\,I \\preceq T \\preceq U + \\|T-U\\|\\,I \\;\\Longrightarrow\\; |\\mu_k - \\nu_k| \\le \\|T-U\\|.$$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Weyl perturbation theorem",
+      "Loewner order sandwich",
+      "eigenvalue monotonicity",
+      "Lipschitz stability",
+      "Hoffman–Wielandt inequality"
+    ],
+    "prerequisites": [
+      "Weyl monotonicity (parent entry weyl_monotone)",
+      "the Loewner order on symmetric operators",
+      "abs_le and one-sided bounds"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-03-oq-01",
+  "title": "Weyl's Eigenvalue Stability Bound |μ(k) − ν(k)| ≤ ‖T − U‖",
+  "slug": "cauchy-interlacing-theorem-oq-03-oq-01",
+  "description": "Derives the operator-norm eigenvalue stability (Weyl perturbation / Lipschitz) theorem for symmetric operators as a corollary of the Weyl monotonicity theorem (weyl_monotone) proved in the parent entry cauchy-interlacing-theorem-oq-03. For continuous operators T, U on a finite-dimensional inner product space, each presented by an orthonormal eigenbasis and an antitone descending eigenvalue enumeration (μ, ν), the eigenvalues are 1-Lipschitz in the operator norm: |μ(k) − ν(k)| ≤ ‖T − U‖ for every index k. The proof is the classical Loewner sandwich U − ‖T−U‖·I ⪯ T ⪯ U + ‖T−U‖·I: the single new analytic input is the elementary Rayleigh bound re⟪(T−U)x, x⟫ ≤ ‖T−U‖·‖x‖² (Cauchy–Schwarz plus the operator-norm inequality ‖(T−U)x‖ ≤ ‖T−U‖·‖x‖); the shifted operators U ± ‖T−U‖·I share U's eigenbasis with eigenvalues ν ± ‖T−U‖ (a real shift preserves the antitone order), so feeding the two Loewner inequalities into weyl_monotone gives μ(k) ≤ ν(k) + ‖T−U‖ and ν(k) − ‖T−U‖ ≤ μ(k). This answers the lead open question of the parent entry oq-03.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingOQ030101Stability.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral-theory",
+      "eigenvalues",
+      "perturbation",
+      "operator-norm",
+      "weyl-inequality",
+      "loewner-order",
+      "cauchy-interlacing",
+      "inner-product-space"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 166,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond the spectral presentation taken as input, exactly as in the parent keystone: T and U are supplied as continuous linear operators (so ‖T − U‖ is the genuine operator norm) each with an orthonormal eigenbasis and an antitone (descending) eigenvalue enumeration μ/ν satisfying T(b i) = μ i • b i. Such a presentation always exists for a symmetric operator on a finite-dimensional inner product space by the spectral theorem; taking it as input keeps the file purely variational. Verified 0 axioms, 0 sorries: #print axioms reports only [propext, Classical.choice, Quot.sound] (no sorryAx, no Lean.ofReduceBool), as for its transitive imports CauchyInterlacingWeyl.lean and CauchyInterlacingKeystone.lean.",
+    "originalContributions": [
+      "weyl_eigenvalue_stability: the operator-norm eigenvalue stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ for symmetric operators, the classical Weyl perturbation / Lipschitz theorem |λ_k(A) − λ_k(B)| ≤ ‖A − B‖. Proved from weyl_monotone alone by the Loewner sandwich U − ‖T−U‖·I ⪯ T ⪯ U + ‖T−U‖·I; each side is one application of Weyl monotonicity to the shifted operator, and the two one-sided bounds combine via abs_le.",
+      "reInner_diff_le: the elementary operator-norm Rayleigh bound re⟪(A−B)x, x⟫ ≤ ‖A−B‖·‖x‖² for continuous operators, the sole new analytic input. Proof chains Cauchy–Schwarz (re_inner_le_norm) with the operator-norm inequality ‖(A−B)x‖ ≤ ‖A−B‖·‖x‖ (ContinuousLinearMap.le_opNorm). This is what converts the operator-norm hypothesis into the two Loewner inequalities.",
+      "reInner_add_smul: the Rayleigh quotient of a scalar-shifted operator splits as re⟪(V + s·I)x, x⟫ = re⟪V x, x⟫ + s·‖x‖² (via inner_smul_left, RCLike.conj_ofReal on the real scalar, and inner_self_eq_norm_sq). This is the algebraic identity that turns the Loewner sandwich into a statement about shifted eigenvalues.",
+      "shift_eigen: a real scalar shift V + s·I acts on each eigenvector e i (eigenvalue lam i) with shifted eigenvalue lam i + s, so the shifted operator inherits V's eigenbasis with eigenvalues lam + s — still antitone (Antitone.add_const). This supplies the spectral presentation of U ± ‖T−U‖·I required by weyl_monotone.",
+      "The structural confirmation that operator-norm eigenvalue stability needs NO new spectral theory beyond Weyl monotonicity: the entire perturbation bound is a Loewner sandwich plus a one-line Cauchy–Schwarz / operator-norm estimate, realising the prediction of the parent entry's conclusion that the |λ_k(A) − λ_k(B)| ≤ ‖A − B‖ bound is 'one short step' from the same keystone."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ContinuousLinearMap.le_opNorm",
+        "description": "‖f x‖ ≤ ‖f‖ · ‖x‖ for a continuous linear map f — supplies the operator-norm half of the Rayleigh bound reInner_diff_le, controlling ‖(T−U)x‖ by ‖T−U‖·‖x‖",
+        "module": "Mathlib.Analysis.Normed.Operator.Basic"
+      },
+      {
+        "theorem": "re_inner_le_norm",
+        "description": "re⟪x, y⟫ ≤ ‖x‖ · ‖y‖ (Cauchy–Schwarz on the real part) — the other half of reInner_diff_le, bounding the real Rayleigh numerator re⟪(T−U)x, x⟫ by ‖(T−U)x‖·‖x‖",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_self_eq_norm_sq",
+        "description": "re⟪x, x⟫ = ‖x‖² — converts the scalar-shift term re⟪s·x, x⟫ into s·‖x‖² in reInner_add_smul, making the Loewner sandwich an eigenvalue shift by ±‖T−U‖",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.conj_ofReal",
+        "description": "conj(↑r) = ↑r for a real scalar r — lets inner_smul_left pass the real shift s through the conjugate-linear slot unchanged, so re⟪(s·I)x, x⟫ = s·‖x‖²",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "Antitone.add_const",
+        "description": "Antitone f ⟹ Antitone (fun x => f x + c) — the shifted eigenvalue enumeration ν ± ‖T−U‖ stays descending, satisfying the antitone hypothesis of weyl_monotone for the sandwich operators U ± ‖T−U‖·I",
+        "module": "Mathlib.Order.Monotone.Basic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Weyl's 1912 perturbation theory for Hermitian eigenvalues culminates in the stability bound |λ_k(A) − λ_k(B)| ≤ ‖A − B‖₂: the k-th eigenvalue is a 1-Lipschitz function of the operator in the spectral (operator) norm. It is the quantitative backbone of numerical linear algebra — it guarantees that eigenvalues computed from a perturbed or rounded matrix are accurate to the size of the perturbation — and the scalar case of the Hoffman–Wielandt and Lidskii majorisation theorems (Horn–Johnson Cor. 4.3.15, Bhatia §III.2, VI.3). Classically it follows from the Courant–Fischer min-max principle via the monotonicity A ⪯ B ⟹ λ_k(A) ≤ λ_k(B) applied to the Loewner sandwich B − ‖A−B‖·I ⪯ A ⪯ B + ‖A−B‖·I. The parent gallery entry oq-03 proves Weyl monotonicity from the from-scratch keystone and lists this stability bound as its lead open question; this entry closes it.",
+    "problemStatement": "Using only the parent's Weyl monotonicity theorem weyl_monotone, prove the operator-norm eigenvalue stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ for symmetric continuous operators T, U presented by orthonormal eigenbases and antitone (descending) eigenvalue enumerations μ, ν. This is the scalar Weyl perturbation / Lipschitz theorem for eigenvalues, the quantitative completion of the qualitative monotonicity result.",
+    "text": "The argument is the Loewner sandwich. Write δ = ‖T − U‖. For every x, Cauchy–Schwarz and the operator-norm inequality give re⟪(T−U)x, x⟫ ≤ ‖(T−U)x‖·‖x‖ ≤ δ·‖x‖², and symmetrically re⟪(U−T)x, x⟫ ≤ δ·‖x‖² (using ‖U−T‖ = ‖T−U‖). Equivalently, in the Loewner order, U − δ·I ⪯ T ⪯ U + δ·I. The shifted operators U ± δ·I share U's eigenbasis c with the shifted eigenvalue enumerations ν ± δ, which remain antitone. Feeding T ⪯ U + δ·I into Weyl monotonicity gives μ(k) ≤ ν(k) + δ, and feeding U − δ·I ⪯ T gives ν(k) − δ ≤ μ(k); together |μ(k) − ν(k)| ≤ δ = ‖T − U‖.",
+    "proofStrategy": "Set δ = ‖T − U‖. KEY ESTIMATE (reInner_diff_le): re⟪(A−B)x, x⟫ ≤ ‖A−B‖·‖x‖² by re_inner_le_norm then ContinuousLinearMap.le_opNorm. SHIFT ALGEBRA (reInner_add_smul): re⟪(V + s·I)x, x⟫ = re⟪V x, x⟫ + s·‖x‖² by inner_add_left/inner_smul_left/RCLike.conj_ofReal/inner_self_eq_norm_sq; SHIFT SPECTRUM (shift_eigen): (V + s·I)(e i) = (lam i + s)·e i. STEP 1: build the Loewner hypothesis re⟪T x,x⟫ ≤ re⟪(U + δ·I)x,x⟫ from reInner_diff_le T U, then weyl_monotone T (U + δ·I) with eigenvalues ν + δ (Antitone.add_const) yields μ(k) ≤ ν(k) + δ. STEP 2: symmetric with reInner_diff_le U T (norm_sub_rev) and weyl_monotone (U − δ·I) T, eigenvalues ν − δ, yields ν(k) − δ ≤ μ(k). Combine via abs_le and linarith.",
+    "keyInsights": [
+      "**Stability is a Loewner sandwich, nothing more.** The qualitative monotonicity A ⪯ B ⟹ λ_k(A) ≤ λ_k(B) already contains the quantitative Lipschitz bound: bracket T between U ± ‖T−U‖·I and apply monotonicity twice. No min-max re-derivation, no spectral theorem invocation beyond what weyl_monotone already used.",
+      "**One Cauchy–Schwarz line bridges operator norm and Loewner order.** The only analytic content not already in the parent is re⟪(T−U)x, x⟫ ≤ ‖T−U‖·‖x‖² — Cauchy–Schwarz on the real part composed with ‖(T−U)x‖ ≤ ‖T−U‖·‖x‖. This single estimate converts the operator-norm hypothesis into the two Loewner inequalities the sandwich needs.",
+      "**A real scalar shift is spectrally transparent.** U ± δ·I keeps U's eigenbasis and shifts every eigenvalue by ±δ, preserving the antitone order (Antitone.add_const). This is why the sandwich operators slot directly into weyl_monotone with no new spectral presentation — only an arithmetic shift of the eigenvalue list.",
+      "**Continuous operators make the norm honest.** Presenting T, U as E →L[𝕜] E rather than bare linear maps means ‖T − U‖ is the genuine operator norm with the Lipschitz constant 1 it claims, not a placeholder; the eigen-presentation is carried to the LinearMap coercion to reuse weyl_monotone verbatim."
+    ],
+    "prerequisites": [
+      "The parent entry's Weyl monotonicity theorem (cauchy-interlacing-theorem-oq-03, weyl_monotone): re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x ⟹ μ(k) ≤ ν(k)",
+      "The operator-norm inequality ‖f x‖ ≤ ‖f‖·‖x‖ for continuous linear maps",
+      "Cauchy–Schwarz on the real part of the inner product, re⟪x,y⟫ ≤ ‖x‖·‖y‖",
+      "The Loewner order on symmetric operators and the spectral transparency of a real scalar shift V + s·I"
+    ]
+  },
+  "sections": [
+    {
+      "id": "rayleigh-bound",
+      "title": "The Operator-Norm Rayleigh Bound",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "reInner_diff_le: re⟪(A−B)x, x⟫ ≤ ‖A−B‖·‖x‖² for continuous operators, by Cauchy–Schwarz (re_inner_le_norm) composed with the operator-norm inequality ‖(A−B)x‖ ≤ ‖A−B‖·‖x‖ (ContinuousLinearMap.le_opNorm). The single new analytic input bridging operator norm and Loewner order.",
+      "mathContext": "The Cauchy–Schwarz + operator-norm estimate that turns ‖T−U‖ into the two Loewner inequalities of the sandwich."
+    },
+    {
+      "id": "shift-algebra",
+      "title": "Algebra of the Scalar Shift V + s·I",
+      "startLine": 72,
+      "endLine": 90,
+      "summary": "reInner_add_smul: re⟪(V + s·I)x, x⟫ = re⟪V x, x⟫ + s·‖x‖² (the Rayleigh quotient shifts by the scalar). shift_eigen: (V + s·I)(e i) = (lam i + s)·e i, so the shifted operator inherits V's eigenbasis with eigenvalues lam + s.",
+      "mathContext": "A real scalar shift is spectrally transparent: it adds s to every eigenvalue and to every Rayleigh quotient, preserving the eigenbasis and antitone order."
+    },
+    {
+      "id": "stability",
+      "title": "The Eigenvalue Stability Theorem",
+      "startLine": 91,
+      "endLine": 156,
+      "summary": "weyl_eigenvalue_stability: |μ(k) − ν(k)| ≤ ‖T − U‖. The Loewner sandwich U − δ·I ⪯ T ⪯ U + δ·I (δ = ‖T−U‖) feeds two applications of weyl_monotone to the shifted operators U ± δ·I, giving μ(k) ≤ ν(k) + δ and ν(k) − δ ≤ μ(k); abs_le combines them.",
+      "mathContext": "The classical Weyl perturbation theorem |λ_k(A) − λ_k(B)| ≤ ‖A − B‖ — eigenvalues are 1-Lipschitz in the operator norm."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of Weyl's operator-norm eigenvalue stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ for symmetric operators, derived entirely from the parent entry's Weyl monotonicity theorem by the Loewner sandwich U − ‖T−U‖·I ⪯ T ⪯ U + ‖T−U‖·I. The file is 0-axiom, 0-sorry (#print axioms: propext, Classical.choice, Quot.sound only), as are its transitive imports. It answers the lead open question of cauchy-interlacing-theorem-oq-03.",
+    "implications": "Completes the eigenvalue-perturbation layer of the Cauchy-interlacing family with its quantitative capstone: the qualitative monotonicity of oq-03 is upgraded to a 1-Lipschitz stability bound — the scalar case of Hoffman–Wielandt and the foundation of eigenvalue conditioning in numerical linear algebra. The two-sided bracket also yields, with no extra work, the symmetric statement ‖μ − ν‖_∞ ≤ ‖T − U‖ in the sup norm of the eigenvalue lists.",
+    "openQuestions": [
+      "Upgrade the pointwise bound to the Lidskii / Hoffman–Wielandt majorisation Σ_k |μ(k) − ν(k)|² ≤ ‖T − U‖_HS² (Frobenius norm), bounding the full eigenvalue vector rather than each coordinate, by combining weyl_add_le with a rearrangement / doubly-stochastic argument.",
+      "Derive the residual / a-posteriori bound: if ‖T x − λ x‖ ≤ ε for a unit vector x, then some eigenvalue μ(k) lies within ε of λ (Bauer–Fike for the Hermitian case), the converse direction of stability used in practice to certify computed eigenpairs."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "cauchy-interlacing-theorem-oq-03",
+      "relation": "Parent entry — proves Weyl monotonicity (weyl_monotone) and the additive inequality from the Courant–Fischer keystone, and lists this operator-norm stability bound as its lead open question. This entry closes that question, reusing weyl_monotone verbatim via the Loewner sandwich."
+    },
+    {
+      "slug": "cauchy-interlacing-theorem",
+      "relation": "Grandparent entry — proves the Courant–Fischer max–min keystone (eigenvalue_maxmin_lower / eigenvalue_maxmin_upper) on which Weyl monotonicity, and hence this stability bound, ultimately rest."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Horn, R.A.",
+        "Johnson, C.R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "venue": "Cambridge University Press, 2nd ed.",
+      "note": "Corollary 4.3.15 and §4.3 (Weyl's perturbation theorem |λ_k(A) − λ_k(B)| ≤ ‖A − B‖₂ from monotonicity and the Loewner sandwich)"
+    },
+    {
+      "authors": [
+        "Bhatia, R."
+      ],
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "venue": "Springer GTM 169",
+      "note": "§III.2 and §VI.3 (Weyl's inequalities, eigenvalue perturbation, and the Lipschitz / Lidskii bounds)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingWeyl"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "CauchyInterlacing.Weyl"
+    ],
+    "namespace": "CauchyInterlacing.Stability",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingOQ030101Stability.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-03-oq-01.json
@@ -1,0 +1,77 @@
+{
+  "slug": "cauchy-interlacing-theorem-oq-03-oq-01",
+  "title": "Operator-norm eigenvalue stability |μ(k)−ν(k)| ≤ ‖T−U‖ from Weyl monotonicity",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\forall k,\\ |\\mu(k)-\\nu(k)| \\le \\lVert T-U\\rVert",
+    "plain": "AVAILABLE: Derive the operator-norm eigenvalue stability bound |μ(k) − ν(k)| ≤ ‖T − U‖ for Hermitian operators from Weyl monotonicity (Courant–Fischer max–min keystone).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "weyl_eigenvalue_stability: |μ(k)−ν(k)| ≤ ‖T−U‖ (0-axiom)"
+    ],
+    "open": [],
+    "goal": "|μ(k) − ν(k)| ≤ ‖T − U‖ for symmetric operators, from Weyl monotonicity"
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T08:52:07.973Z",
+    "iteration": 1,
+    "focus": "Proved operator-norm eigenvalue stability via Loewner sandwich; verified 0-axiom.",
+    "blockers": [],
+    "nextAction": "Done — PR opened.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: operator-norm eigenvalue stability |μ(k)−ν(k)| ≤ ‖T−U‖ proved 0-axiom from weyl_monotone by the Loewner sandwich U−δI ⪯ T ⪯ U+δI.",
+    "builtItems": [
+      "weyl_eigenvalue_stability in Proofs/CauchyInterlacingOQ030101Stability.lean — |μ(k)−ν(k)| ≤ ‖T−U‖ for continuous symmetric operators",
+      "reInner_diff_le — re⟪(A−B)x,x⟫ ≤ ‖A−B‖·‖x‖² (Cauchy–Schwarz + ContinuousLinearMap.le_opNorm)",
+      "reInner_add_smul — re⟪(V+s·I)x,x⟫ = re⟪Vx,x⟫ + s·‖x‖²",
+      "shift_eigen — (V+s·I)(e i) = (lam i + s)·e i (scalar shift inherits eigenbasis)"
+    ],
+    "insights": [
+      "Stability is a Loewner sandwich: bracket T between U ± ‖T−U‖·I and apply weyl_monotone twice; no min-max re-derivation needed.",
+      "The only new analytic input over the parent is re⟪(T−U)x,x⟫ ≤ ‖T−U‖·‖x‖² (Cauchy–Schwarz composed with the operator-norm inequality).",
+      "Presenting operators as E →L[𝕜] E (continuous) makes ‖T−U‖ the genuine operator norm; the eigen-presentation is carried to the LinearMap coercion to reuse weyl_monotone verbatim.",
+      "A real scalar shift V + s·I is spectrally transparent: same eigenbasis, eigenvalues +s, antitone preserved (Antitone.add_const)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Lidskii / Hoffman–Wielandt majorisation Σ|μ(k)−ν(k)|² ≤ ‖T−U‖_HS² via weyl_add_le + rearrangement.",
+      "Bauer–Fike residual bound: ‖Tx−λx‖ ≤ ε ⟹ some eigenvalue within ε of λ."
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "spectral-theory",
+    "eigenvalues",
+    "perturbation",
+    "operator-norm",
+    "extension",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "cauchy-interlacing-theorem",
+    "cauchy-interlacing-theorem-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T08:52:07.973Z",
+  "lastUpdate": "2026-06-24T12:00:00.000Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Derives **Weyl's eigenvalue stability (perturbation / Lipschitz) bound** for symmetric operators as a corollary of the parent entry's Weyl monotonicity theorem (`weyl_monotone`, `cauchy-interlacing-theorem-oq-03`):

> For continuous operators `T, U` on a finite-dimensional inner product space, each presented by an orthonormal eigenbasis and an **antitone (descending)** eigenvalue enumeration `μ`, `ν`:
> **`|μ(k) − ν(k)| ≤ ‖T − U‖`** for every index `k`.

This is the classical Weyl perturbation theorem `|λ_k(A) − λ_k(B)| ≤ ‖A − B‖₂` — eigenvalues are **1-Lipschitz** in the operator norm — and it **answers the lead open question** of the parent entry oq-03.

## Proof — the Loewner sandwich

Write `δ = ‖T − U‖`. The single new analytic input is the Rayleigh bound

`re⟪(A − B)x, x⟫ ≤ ‖A − B‖ · ‖x‖²`  (Cauchy–Schwarz `re_inner_le_norm` ∘ `ContinuousLinearMap.le_opNorm`),

which yields the two Loewner inequalities `U − δ·I ⪯ T ⪯ U + δ·I`. The shifted operators `U ± δ·I` share `U`'s eigenbasis with eigenvalues `ν ± δ` (a real shift preserves the antitone order, `Antitone.add_const`), so applying `weyl_monotone` twice gives `μ(k) ≤ ν(k) + δ` and `ν(k) − δ ≤ μ(k)`; `abs_le` combines them. **No new spectral theory** beyond the parent.

## Verification

- `#print axioms weyl_eigenvalue_stability` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- **0 axioms, 0 sorries**, 4 theorems, 166 lines. Compiled with `lake env lean` against the Mathlib cache (v4.26.0).
- Follows the parent's convention: research file `Proofs/CauchyInterlacingOQ030101Stability.lean` imports `Proofs.CauchyInterlacingWeyl` and is **intentionally not registered** in `Proofs.lean` (mirroring the unregistered Weyl parent).

## Files

- `proofs/Proofs/CauchyInterlacingOQ030101Stability.lean` — the proof
- `src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01/{meta.json,annotations.json}` — gallery entry
- `src/data/research/problems/cauchy-interlacing-theorem-oq-03-oq-01.json` — knowledge update (phase → COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)