### PR TITLE
research(divisibility-rules-oq-04-oq-01): unified 7-11-13 rule from one base-1000 grouping [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -966,6 +966,7 @@ import Proofs.DivisibilityRulesOQ01OQ01
 import Proofs.DivisibilityRulesOQ01OQ01OQ01
 import Proofs.DivisibilityRulesOQ02
 import Proofs.DivisibilityRulesOQ04
+import Proofs.DivisibilityRulesOQ04OQ01
 import Proofs.DivisibilityTruncationGeneral
 import Proofs.DivisibilityTruncationGeneralOQ01
 import Proofs.DivisibilityTruncationGeneralOQ01OQ01

--- a/proofs/Proofs/DivisibilityRulesOQ04OQ01.lean
+++ b/proofs/Proofs/DivisibilityRulesOQ04OQ01.lean
@@ -1,0 +1,105 @@
+import Mathlib.Data.Nat.Digits.Div
+import Mathlib.Data.Nat.Digits.Lemmas
+import Mathlib.Tactic
+
+/-
+# The Unified 7-11-13 Divisibility Rule  (divisibility-rules-oq-04-oq-01)
+
+## Open Question (parent: divisibility-rules-oq-04)
+"Prove the unified 7-11-13 rule directly: `n` is divisible by each of 7, 11, 13
+iff that prime divides the alternating sum of three-digit blocks, exhibiting the
+single base-1000 grouping (`1001 = 7·11·13`) behind all three tests."
+
+The parent entry `divisibility-rules-oq-04` already records the three-digit
+block-alternating test *for 11* as one of three rules keyed to `10`, `100`,
+`1000` mod 11.  This entry isolates the genuinely unifying phenomenon: the
+**single** base-1000 grouping `b₀ - b₁ + b₂ - ⋯` simultaneously detects
+divisibility by 7, 11 **and** 13, because all three primes divide `1001`, and
+`1000 ≡ -1 (mod m)` precisely when `m ∣ 1001`.
+
+Rather than re-prove the 11-case, we factor the argument through one parametric
+lemma `dvd_iff_dvd_blockAltSum`: for *any* modulus `m ∣ 1001`, the same block
+alternating sum is the divisibility certificate.  The classical 7/11/13 rules,
+their conjunction, and the combined `1001`-rule are then one-line corollaries,
+making the shared `1001` structure explicit.  All results are fully verified
+(0 axioms): every step is a specialization of Mathlib's base-`b` digit machinery
+(`Nat.dvd_iff_dvd_ofDigits`, `Nat.ofDigits_neg_one`, `Nat.zmodeq_ofDigits_digits`)
+plus elementary coprimality.
+-/
+
+namespace DivisibilityRulesOQ04OQ01
+
+open Nat
+
+/-- The signed alternating sum of the base-1000 blocks (the three-decimal-digit
+groups, read from least significant): `b₀ - b₁ + b₂ - ⋯`.  This single quantity is
+the divisibility certificate shared by 7, 11 and 13. -/
+def blockAltSum (n : ℕ) : ℤ :=
+  ((Nat.digits 1000 n).map fun d : ℕ => (d : ℤ)).alternatingSum
+
+/-- The arithmetic fact behind everything: `1001 = 7 · 11 · 13`. -/
+theorem one_thousand_one_eq : (1001 : ℕ) = 7 * 11 * 13 := by norm_num
+
+/-- **Unified block-alternating divisibility test.** For *any* modulus `m` dividing
+`1001`, `m ∣ n` iff `m` divides the alternating sum of the base-1000 blocks of `n`.
+
+This is the single theorem behind all three classical rules: `1000 ≡ -1 (mod m)`
+holds exactly when `m ∣ (1000 - (-1)) = 1001`, so the one base-1000 grouping serves
+every divisor of `1001 = 7·11·13` at once. -/
+theorem dvd_iff_dvd_blockAltSum (m n : ℕ) (hm : (m : ℤ) ∣ 1001) :
+    m ∣ n ↔ (m : ℤ) ∣ blockAltSum n := by
+  have h : (m : ℤ) ∣ (1000 : ℤ) - (-1) := by simpa using hm
+  have t := Nat.dvd_iff_dvd_ofDigits m 1000 (-1 : ℤ) h n
+  rw [Nat.ofDigits_neg_one] at t
+  exact t
+
+/-- **Divisibility-by-7 rule** via the base-1000 alternating block sum. -/
+theorem seven_dvd_iff (n : ℕ) : 7 ∣ n ↔ (7 : ℤ) ∣ blockAltSum n :=
+  dvd_iff_dvd_blockAltSum 7 n (by norm_num)
+
+/-- **Divisibility-by-11 rule** via the *same* base-1000 alternating block sum. -/
+theorem eleven_dvd_iff (n : ℕ) : 11 ∣ n ↔ (11 : ℤ) ∣ blockAltSum n :=
+  dvd_iff_dvd_blockAltSum 11 n (by norm_num)
+
+/-- **Divisibility-by-13 rule** via the *same* base-1000 alternating block sum. -/
+theorem thirteen_dvd_iff (n : ℕ) : 13 ∣ n ↔ (13 : ℤ) ∣ blockAltSum n :=
+  dvd_iff_dvd_blockAltSum 13 n (by norm_num)
+
+/-- **The unified statement, as asked.** `n` is divisible by each of 7, 11, 13 iff
+that prime divides the alternating sum of the three-digit blocks — all three tests
+read off the one quantity `blockAltSum n`. -/
+theorem unified_7_11_13 (n : ℕ) :
+    (7 ∣ n ↔ (7 : ℤ) ∣ blockAltSum n) ∧
+    (11 ∣ n ↔ (11 : ℤ) ∣ blockAltSum n) ∧
+    (13 ∣ n ↔ (13 : ℤ) ∣ blockAltSum n) :=
+  ⟨seven_dvd_iff n, eleven_dvd_iff n, thirteen_dvd_iff n⟩
+
+/-- Divisibility by all of 7, 11, 13 is exactly divisibility by their product
+`1001` (they are pairwise coprime). -/
+theorem all_three_dvd_iff_dvd_1001 (n : ℕ) :
+    (7 ∣ n ∧ 11 ∣ n ∧ 13 ∣ n) ↔ 1001 ∣ n := by
+  constructor
+  · rintro ⟨h7, h11, h13⟩
+    have h77 : 77 ∣ n := Nat.Coprime.mul_dvd_of_dvd_of_dvd (by norm_num) h7 h11
+    have h1001 : 77 * 13 ∣ n := Nat.Coprime.mul_dvd_of_dvd_of_dvd (by norm_num) h77 h13
+    simpa using h1001
+  · intro h
+    exact ⟨dvd_trans (by norm_num) h, dvd_trans (by norm_num) h, dvd_trans (by norm_num) h⟩
+
+/-- **Combined `1001`-rule.** The very same base-1000 alternating block sum tests
+divisibility by `1001 = 7·11·13` itself: `n` is a multiple of all three primes iff
+`1001` divides `blockAltSum n`. -/
+theorem all_three_dvd_iff_blockAltSum (n : ℕ) :
+    (7 ∣ n ∧ 11 ∣ n ∧ 13 ∣ n) ↔ (1001 : ℤ) ∣ blockAltSum n := by
+  rw [all_three_dvd_iff_dvd_1001]
+  exact dvd_iff_dvd_blockAltSum 1001 n (by norm_num)
+
+/-- **Underlying congruence.** `n` is congruent to its base-1000 alternating block
+sum modulo `1001` — the residue identity (`1000 ≡ -1 (mod 1001)`) that powers every
+one of the rules above. -/
+theorem modEq_blockAltSum (n : ℕ) : (n : ℤ) ≡ blockAltSum n [ZMOD 1001] := by
+  have h : (1000 : ℤ) ≡ (-1 : ℤ) [ZMOD 1001] := Int.modEq_iff_dvd.mpr (by norm_num)
+  have t := Nat.zmodeq_ofDigits_digits 1001 1000 (-1 : ℤ) h n
+  rwa [Nat.ofDigits_neg_one] at t
+
+end DivisibilityRulesOQ04OQ01

--- a/src/data/proofs/divisibility-rules-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-droq0401-context",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 5, "endLine": 28 },
+    "type": "concept",
+    "title": "One Base-1000 Grouping, Three Primes",
+    "content": "The classical 7-11-13 test groups the decimal digits of n into blocks of three (read from the right) and alternately adds and subtracts them. The reason one grouping detects three different primes is a single arithmetic fact: 1000 ≡ -1 modulo each of 7, 11 and 13, because 1001 = 7·11·13. This entry makes that explicit by proving one parametric theorem — for ANY modulus m dividing 1001, the same alternating block sum is the divisibility certificate — and reading the 7, 11 and 13 rules off as instances. The parent divisibility-rules-oq-04 proved only the m = 11 case.",
+    "mathContext": "For modulus $m$ and base $b' = 1000$, $1000 \\equiv -1 \\pmod m$ holds exactly when $m \\mid 1000 - (-1) = 1001$. Then $n = \\sum_k c_k 1000^k \\equiv \\sum_k c_k(-1)^k \\pmod m$, where the $c_k$ are the three-digit blocks, so $m \\mid n$ iff $m$ divides their alternating sum. The divisors of $1001 = 7\\cdot 11\\cdot 13$ are precisely the moduli for which this works.",
+    "significance": "key",
+    "relatedConcepts": [
+      "base-1000 digit expansion",
+      "1001 = 7·11·13",
+      "alternating block sum",
+      "residues of powers modulo m"
+    ],
+    "prerequisites": [
+      "Nat.digits / Nat.ofDigits",
+      "modular arithmetic on powers"
+    ]
+  },
+  {
+    "id": "ann-droq0401-parametric",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 43, "endLine": 54 },
+    "type": "technique",
+    "title": "The Parametric Lemma: dvd_iff_dvd_blockAltSum",
+    "content": "`dvd_iff_dvd_blockAltSum m n (hm : (m:ℤ) ∣ 1001)` is the single theorem behind every rule. It applies `Nat.dvd_iff_dvd_ofDigits m 1000 (-1) h n`, whose side condition `(m:ℤ) ∣ (1000:ℤ) - (-1)` is `simpa`-equal to the hypothesis `(m:ℤ) ∣ 1001`, then rewrites the resulting `ofDigits (-1) (digits 1000 n)` into `blockAltSum n` via `Nat.ofDigits_neg_one`. Because the hypothesis is just m ∣ 1001 rather than a fixed prime, the 7, 11, 13 and 1001 rules are all `(by norm_num)` instances — the 1001 factorization is exposed in the statement, not buried in a per-prime computation.",
+    "mathContext": "$m \\mid n \\iff (m:\\mathbb{Z}) \\mid \\mathrm{ofDigits}(-1)\\,(\\mathrm{digits}\\,1000\\,n) = \\sum_k c_k(-1)^k$ for any $m$ with $(m:\\mathbb{Z}) \\mid 1001$. The clause $1000 - (-1) = 1001$ is the only place the modulus interacts with the base.",
+    "significance": "key",
+    "relatedConcepts": ["dvd_iff_dvd_ofDigits", "ofDigits_neg_one", "parametric divisibility rule"],
+    "prerequisites": ["Nat.dvd_iff_dvd_ofDigits", "Nat.ofDigits_neg_one"]
+  },
+  {
+    "id": "ann-droq0401-fusion",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 77, "endLine": 95 },
+    "type": "technique",
+    "title": "Coprimality Fusion: All Three Primes ↔ 1001",
+    "content": "`all_three_dvd_iff_dvd_1001` shows 7 ∣ n ∧ 11 ∣ n ∧ 13 ∣ n ↔ 1001 ∣ n. The forward direction chains `Nat.Coprime.mul_dvd_of_dvd_of_dvd` twice (first 7·11 = 77, then 77·13 = 1001), each coprimality discharged by `norm_num`; the reverse is three `dvd_trans` from 1001. Composing this with the m = 1001 instance of the parametric lemma gives `all_three_dvd_iff_blockAltSum`: the conjunction of the three single-prime tests is equivalent to a single 1001-divisibility test on blockAltSum n. This is why the three rules genuinely fuse into one.",
+    "mathContext": "Since $7, 11, 13$ are pairwise coprime, $\\mathrm{lcm} = 7\\cdot 11\\cdot 13 = 1001$, so $7\\mid n \\wedge 11\\mid n \\wedge 13\\mid n \\iff 1001 \\mid n$. Combined with the $m=1001$ rule, $1001 \\mid n \\iff (1001:\\mathbb{Z}) \\mid \\mathrm{blockAltSum}\\,n$.",
+    "significance": "important",
+    "relatedConcepts": ["Nat.Coprime.mul_dvd_of_dvd_of_dvd", "lcm of coprimes", "1001 = 7·11·13"],
+    "prerequisites": ["pairwise coprimality", "Nat.Coprime.mul_dvd_of_dvd_of_dvd"]
+  }
+]

--- a/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "divisibility-rules-oq-04-oq-01",
+  "slug": "divisibility-rules-oq-04-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Digits.Div",
+      "Mathlib.Data.Nat.Digits.Lemmas",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "DivisibilityRulesOQ04OQ01",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DivisibilityRulesOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Unified 7-11-13 Divisibility Rule from One Base-1000 Grouping",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DivisibilityRulesOQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "digit-sums",
+      "modular-arithmetic",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 105,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "mathlib",
+    "originalContributions": [
+      "dvd_iff_dvd_blockAltSum: the single parametric theorem behind the whole rule — for ANY modulus m with (m:ℤ) ∣ 1001, m ∣ n ↔ (m:ℤ) ∣ blockAltSum n, where blockAltSum n is the alternating sum of the base-1000 (three-decimal-digit) blocks. The side condition 1000 ≡ -1 (mod m) holds exactly when m ∣ (1000 - (-1)) = 1001, so one base-1000 grouping serves every divisor of 1001 = 7·11·13 at once. Proved from Nat.dvd_iff_dvd_ofDigits and Nat.ofDigits_neg_one.",
+      "unified_7_11_13: the open question answered directly — the seven_dvd_iff / eleven_dvd_iff / thirteen_dvd_iff trio packaged together, each test reading off the same quantity blockAltSum n, making the shared 1001 structure explicit (the parent oq-04 only established the m = 11 instance).",
+      "all_three_dvd_iff_dvd_1001: divisibility by all of 7, 11, 13 is exactly divisibility by their product 1001, proved by two applications of Nat.Coprime.mul_dvd_of_dvd_of_dvd (pairwise coprimality) — the structural reason the three tests fuse into one.",
+      "all_three_dvd_iff_blockAltSum: the combined 1001-rule — 7 ∣ n ∧ 11 ∣ n ∧ 13 ∣ n ↔ (1001:ℤ) ∣ blockAltSum n, obtained by composing the coprimality fusion with the m = 1001 instance of the parametric lemma.",
+      "modEq_blockAltSum: the underlying residue identity n ≡ blockAltSum n [ZMOD 1001] (from 1000 ≡ -1 mod 1001 via Nat.zmodeq_ofDigits_digits), exhibiting the congruence that powers every one of the rules."
+    ],
+    "prerequisites": [
+      "Nat.digits in an arbitrary base and Nat.ofDigits",
+      "Mathlib's base-b divisibility machinery (dvd_iff_dvd_ofDigits, zmodeq_ofDigits_digits)",
+      "the factorization 1001 = 7·11·13 and pairwise coprimality of 7, 11, 13",
+      "List.alternatingSum and Nat.ofDigits_neg_one"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.dvd_iff_dvd_ofDigits",
+        "description": "For (m:ℤ) ∣ (b':ℤ) - c, m ∣ n ↔ (m:ℤ) ∣ ofDigits c (digits b' n). Instantiated at b' = 1000, c = -1; the side condition (m:ℤ) ∣ 1001 is exactly what makes the rule work for every divisor of 1001.",
+        "module": "Mathlib.Data.Nat.Digits.Div"
+      },
+      {
+        "theorem": "Nat.ofDigits_neg_one",
+        "description": "ofDigits (-1) L = (L.map (↑·)).alternatingSum. Turns the ofDigits form into the explicit alternating sum of three-digit blocks, blockAltSum.",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.zmodeq_ofDigits_digits",
+        "description": "n ≡ ofDigits c (digits b' n) [ZMOD m] whenever b' ≡ c [ZMOD m]. With b' = 1000, c = -1, m = 1001 it yields the residue identity n ≡ blockAltSum n [ZMOD 1001].",
+        "module": "Mathlib.Data.Nat.Digits.Div"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+        "description": "Coprime a b → a ∣ n → b ∣ n → a*b ∣ n. Applied twice (7·11 then 77·13) to prove 7∣n ∧ 11∣n ∧ 13∣n ↔ 1001∣n.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-rules-oq-04",
+      "relationship": "extends",
+      "description": "Parent. oq-04 established the three-digit block-alternating test for the single modulus 11. This entry isolates the parametric phenomenon (one rule for every m ∣ 1001), answering oq-04's open question by deriving the simultaneous 7-11-13 test from a single base-1000 grouping."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Data.Nat.Digits.Div",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of dvd_iff_dvd_ofDigits and zmodeq_ofDigits_digits, the base-b divisibility/congruence machinery specialized here to the divisors of 1001."
+    },
+    {
+      "title": "The 100 Theorems list (Theorem 85: Divisibility by 3 Rule)",
+      "author": "Freek Wiedijk",
+      "year": "2024",
+      "venue": "Radboud University",
+      "description": "The classical digit-based divisibility rules whose base-b generalization underlies the unified 7-11-13 rule established here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "A fully verified (0-axiom) derivation of the unified 7-11-13 divisibility rule from a single base-1000 grouping. The parametric lemma dvd_iff_dvd_blockAltSum proves that for ANY modulus m ∣ 1001, m ∣ n ↔ (m:ℤ) ∣ blockAltSum n, where blockAltSum n is the alternating sum of the three-decimal-digit blocks; the side condition 1000 ≡ -1 (mod m) holds precisely when m ∣ 1001 = 7·11·13. The 7, 11 and 13 rules, their conjunction (unified_7_11_13), the coprimality fusion all_three_dvd_iff_dvd_1001, the combined 1001-rule all_three_dvd_iff_blockAltSum, and the residue identity modEq_blockAltSum are all one- or few-line corollaries. 105 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The parent oq-04 established only the m = 11 instance; this entry exhibits the genuinely unifying mechanism — a single base-1000 alternating block sum is the divisibility certificate for every divisor of 1001 simultaneously — and proves that the three single-prime tests are equivalent to one 1001-divisibility test via pairwise coprimality. The parametric form makes the role of the 1001 = 7·11·13 factorization explicit rather than hidden inside a per-prime norm_num computation.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent **divisibility-rules-oq-04**: prove the unified 7-11-13 divisibility rule directly, exhibiting the *single* base-1000 grouping (`1001 = 7·11·13`) behind all three tests. The parent established only the `m = 11` instance.

## Mathematical content

The whole rule is factored through **one parametric theorem**:

```
dvd_iff_dvd_blockAltSum (m n : ℕ) (hm : (m:ℤ) ∣ 1001) :
    m ∣ n ↔ (m:ℤ) ∣ blockAltSum n
```

where `blockAltSum n` is the alternating sum of the base-1000 (three-decimal-digit) blocks. The side condition `1000 ≡ -1 (mod m)` holds **exactly** when `m ∣ (1000 - (-1)) = 1001`, so one base-1000 grouping serves every divisor of `1001 = 7·11·13` at once. Everything else is corollaries:

- `seven_dvd_iff`, `eleven_dvd_iff`, `thirteen_dvd_iff` — each a `(by norm_num)` instance reading off the *same* `blockAltSum n`
- `unified_7_11_13` — the open question, packaged
- `all_three_dvd_iff_dvd_1001` — `7∣n ∧ 11∣n ∧ 13∣n ↔ 1001∣n` via pairwise coprimality (`Nat.Coprime.mul_dvd_of_dvd_of_dvd` twice)
- `all_three_dvd_iff_blockAltSum` — the combined 1001-rule
- `modEq_blockAltSum` — the residue identity `n ≡ blockAltSum n [ZMOD 1001]`

## Verification

- **8 theorems, 1 definition, 105 lines, 0 sorries, 0 axioms**
- `#print axioms` reports only `propext, Classical.choice, Quot.sound`
- Built via host `lake env lean` (single file, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)