### PR TITLE
Enrich Largest divisibility-antichain in {1,…,N} — ⌈N/2⌉ generalization (OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-edpoq0101-header",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "concept",
+    "title": "Problem Statement: the arbitrary-N extremal value ⌈N/2⌉",
+    "content": "The classic Erdős divisibility pigeonhole says any n+1 elements of {1,…,2n} contain a pair related by divisibility, so the largest divisibility-antichain (primitive set) in {1,…,2n} has size n. This entry lifts that even-interval optimum to an **arbitrary** upper bound N: the largest divisibility-antichain in {1,…,N} has size exactly ⌈N/2⌉ = (N+1)/2 in natural-number division, attained by the top-half block (N/2, N]. The header docstring lays out both halves of the argument — the odd-part pigeonhole for the upper bound and the top-half construction for the lower bound — and notes that N = 2n recovers the parent.",
+    "mathContext": "$\\max\\{|S| : S \\subseteq \\{1,\\dots,N\\},\\ S\\text{ primitive}\\} = \\lceil N/2\\rceil = \\lfloor (N+1)/2\\rfloor$, attained by $\\{\\lfloor N/2\\rfloor+1,\\dots,N\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "primitive set", "antichain", "extremal combinatorics", "divisibility poset"],
+    "prerequisites": ["divisibility", "natural-number division", "Erdős primitive sequences"]
+  },
+  {
+    "id": "ann-edpoq0101-odd-recover",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 47 },
+    "type": "lemma",
+    "title": "Odd-part helpers: recovering and detecting oddness",
+    "content": "`odd_recoverN` shows that for odd o, the half-index map o ↦ (o−1)/2 is invertible via 2·((o−1)/2)+1 = o — this is what makes the half-index injective on odd numbers, so a collision under it forces equal odd parts. `odd_ordComplN` certifies that the odd part ordCompl[2] m really is odd for m ≠ 0: by definition it carries no factor of 2 (Nat.not_dvd_ordCompl), and omega turns ¬(2 ∣ x) into Odd x. Together they let the proof move freely between an odd number and its half-index.",
+    "mathContext": "For odd $o$, write $o = 2k+1$; then $(o-1)/2 = k$ and $2k+1 = o$. The odd part $\\mathrm{ordCompl}[2]\\,m = m / 2^{v_2(m)}$ is never divisible by $2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["odd part", "2-adic valuation", "ordCompl", "injectivity"],
+    "prerequisites": ["parity", "p-adic valuation", "omega tactic"]
+  },
+  {
+    "id": "ann-edpoq0101-dvd-orient",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 67 },
+    "type": "lemma",
+    "title": "Equal odd parts orient the division",
+    "content": "`dvd_or_dvd_of_ordCompl_eqN` is the heart of the pigeonhole: if a and b share an odd part, one divides the other. The proof uses the factorization identity 2^(v₂ a)·ordCompl[2] a = a (Nat.ordProj_mul_ordCompl_eq_self). With equal odd parts, a and b differ only in their power of two, so a case split on which exponent is smaller (le_total) makes the smaller power divide the larger via pow_dvd_pow and mul_dvd_mul_right. This is the structural reason the odd-part classification controls divisibility.",
+    "mathContext": "If $a = 2^i o$ and $b = 2^j o$ with $i \\le j$ then $a \\mid b$ since $2^i \\mid 2^j$. The identity $2^{v_2(m)}\\cdot \\mathrm{ordCompl}[2]\\,m = m$ underlies the whole argument.",
+    "significance": "critical",
+    "relatedConcepts": ["unique factorization", "2-adic valuation", "divisibility chains", "ordProj"],
+    "prerequisites": ["prime factorization", "divisibility of prime powers"]
+  },
+  {
+    "id": "ann-edpoq0101-general-pigeonhole",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 103 },
+    "type": "theorem",
+    "title": "General divisibility pigeonhole over {1,…,N}",
+    "content": "`erdos_divisibility_pigeonhole_general`: any S ⊆ {1,…,N} with |S| > (N+1)/2 contains distinct a, b with a ∣ b. The half-index map f(m) = (ordCompl[2] m − 1)/2 is shown to land in range((N+1)/2) — the crux is a single omega call from 1 ≤ ordCompl[2] m ≤ N, which silently counts the ⌈N/2⌉ odd numbers ≤ N without enumerating them. Since |S| exceeds the target's size, Finset.exists_ne_map_eq_of_card_lt_of_maps_to forces two members with equal half-index; injectivity on odds (odd_recoverN) upgrades this to equal odd parts, and dvd_or_dvd_of_ordCompl_eqN orients the division.",
+    "mathContext": "There are exactly $\\lceil N/2\\rceil$ odd numbers in $\\{1,\\dots,N\\}$. The map $m \\mapsto (\\mathrm{ordCompl}[2]\\,m - 1)/2$ sends $\\{1,\\dots,N\\} \\to \\{0,\\dots,\\lceil N/2\\rceil - 1\\}$, so $|S| > \\lceil N/2\\rceil \\Rightarrow$ a collision.",
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "Finset.exists_ne_map_eq_of_card_lt_of_maps_to", "odd-part classification", "counting without enumeration"],
+    "prerequisites": ["pigeonhole principle", "Finset cardinality", "divisibility"]
+  },
+  {
+    "id": "ann-edpoq0101-predicate",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 121 },
+    "type": "definition",
+    "title": "Divisibility-antichain predicate and the Mathlib bridge",
+    "content": "`IsDivAntichainN N S` packages a primitive subset of {1,…,N}: S ⊆ Icc 1 N together with the condition that no distinct members divide one another. `isDivAntichainN_iff` shows this is exactly Mathlib's order-theoretic IsAntichain (· ∣ ·) restricted to the interval — connecting the bespoke combinatorial predicate to the general theory of antichains in a poset (here the divisibility poset). This bridge is what justifies calling the maximum a Dilworth/Mirsky optimum.",
+    "mathContext": "$S$ is a *primitive set* iff $\\forall a,b\\in S,\\ a\\ne b \\Rightarrow a \\nmid b$, i.e. an antichain in the poset $(\\mathbb{N}_{\\ge 1}, \\mid)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["antichain", "divisibility poset", "primitive set", "IsAntichain", "partial order"],
+    "prerequisites": ["partial orders", "antichains", "Finset"]
+  },
+  {
+    "id": "ann-edpoq0101-upper-bound",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 131 },
+    "type": "theorem",
+    "title": "Upper bound: |S| ≤ ⌈N/2⌉",
+    "content": "`antichainN_card_le` is the clean contrapositive of the general pigeonhole: if a divisibility-antichain had more than (N+1)/2 elements, the pigeonhole would produce a divisible pair, contradicting the antichain condition. The proof is `by_contra` + `push_neg`, then feeds the strict inequality into erdos_divisibility_pigeonhole_general. This is the half of the IsGreatest claim asserting (N+1)/2 is an upper bound.",
+    "mathContext": "$S$ primitive in $\\{1,\\dots,N\\} \\Rightarrow |S| \\le \\lceil N/2\\rceil$.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "upper bound", "extremal bound", "antichain"],
+    "prerequisites": ["proof by contradiction", "divisibility"]
+  },
+  {
+    "id": "ann-edpoq0101-construction",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 133, "endLine": 154 },
+    "type": "theorem",
+    "title": "Top-half construction attains the bound",
+    "content": "`blockN_isDivAntichain` exhibits the extremal witness: the block {⌊N/2⌋+1,…,N} of integers in (N/2, N] is itself a divisibility-antichain of size (N+1)/2. The antichain property is the geometric fact that a proper multiple of any a > N/2 is at least 2a > N, hence outside the block (the c ≥ 2 case analysis and nlinarith establish 2a ≤ b). The cardinality is the identity N − ⌊N/2⌋ = ⌈N/2⌉, discharged by omega uniformly across the parity of N — no case split needed.",
+    "mathContext": "If $a > N/2$ and $a \\mid b$ with $a \\ne b$ then $b \\ge 2a > N$. The block $(N/2, N]$ has $N - \\lfloor N/2\\rfloor = \\lceil N/2\\rceil$ elements.",
+    "significance": "critical",
+    "relatedConcepts": ["extremal construction", "tightness", "interval cardinality", "Nat.card_Icc"],
+    "prerequisites": ["divisibility", "natural-number division", "nlinarith"]
+  },
+  {
+    "id": "ann-edpoq0101-isgreatest",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 156, "endLine": 166 },
+    "type": "theorem",
+    "title": "The extremal form as IsGreatest",
+    "content": "`max_antichainN_card` packages the two halves into a single IsGreatest statement: ⌈N/2⌉ is both achieved (by the top-half block, from blockN_isDivAntichain) and an upper bound (from antichainN_card_le) for the set of achievable divisibility-antichain sizes. IsGreatest s a unfolds to a ∈ s ∧ a ∈ upperBounds s, so this one declaration encodes 'the maximum exists and equals ⌈N/2⌉', the precise extremal claim of the entry.",
+    "mathContext": "$\\mathrm{IsGreatest}\\ \\{k \\mid \\exists S,\\ S\\text{ primitive in }\\{1,\\dots,N\\} \\wedge |S| = k\\}\\ \\lceil N/2\\rceil$.",
+    "significance": "key",
+    "relatedConcepts": ["IsGreatest", "upperBounds", "extremal value", "maximum"],
+    "prerequisites": ["order theory", "least upper bounds"]
+  },
+  {
+    "id": "ann-edpoq0101-parent",
+    "proofId": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+    "range": { "startLine": 168, "endLine": 183 },
+    "type": "theorem",
+    "title": "Specialization recovers the parent (N = 2n)",
+    "content": "`max_antichainN_recovers_parent` certifies that this generalization strictly contains the parent: substituting N = 2n collapses (2n+1)/2 to n (an omega arithmetic fact) and rewrites max_antichainN_card into the parent's max_antichain_card over {1,…,2n} with maximum n. Verifying the specialization is what distinguishes a genuine generalization from a merely-resembling statement. The closing #print axioms confirms dependence only on propext, Classical.choice, Quot.sound — no native_decide, no sorry.",
+    "mathContext": "$(2n+1)/2 = n$ in natural-number division, so the general value $\\lceil N/2\\rceil$ at $N = 2n$ is exactly the parent's $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "generalization", "axiom audit", "parent entry"],
+    "prerequisites": ["natural-number division", "Lean #print axioms"]
+  }
+]

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdosDivisibilityPigeonholeOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdosDivisibilityPigeonholeOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdosDivisibilityPigeonholeOq01Oq01Data: ProofData = {
+  proof: erdosDivisibilityPigeonholeOq01Oq01Proof,
+  annotations: erdosDivisibilityPigeonholeOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-divisibility-pigeonhole-oq-01-oq-01` (quality 45, passes 0).

## What was missing
The entry had a rich `meta.json` but **no `annotations.json` and no `index.ts`**. Without `index.ts` the proof page renders 'proof not found' on the live site.

## Changes
- **Created `index.ts`** — wires meta + annotations + raw Lean source so the page loads.
- **Created `annotations.json`** — 9 annotations covering all 7 sections, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - Problem statement (⌈N/2⌉ = (N+1)/2 extremal value)
  - Odd-part helper lemmas (`odd_recoverN`, `odd_ordComplN`)
  - Equal-odd-parts-orient-division (`dvd_or_dvd_of_ordCompl_eqN`) — the structural core
  - General pigeonhole over {1,…,N} (`erdos_divisibility_pigeonhole_general`)
  - Antichain predicate + Mathlib `IsAntichain` bridge
  - Upper bound, top-half construction, `IsGreatest` packaging
  - N=2n specialization recovering the parent

## Verification
- `pnpm build` passes (✓ built in 2m 21s).
- JSON validated; annotations line ranges align with the Lean source.
- Axiom integrity confirmed: `status: verified`, `axiomCount: 0`, 0 sorries, no `native_decide` — matches the Lean file's `#print axioms` (propext/Classical.choice/Quot.sound only).