### PR TITLE
research(burnside-counting-oq-05-oq-01): even-cycle reflection counts — vertex k^(n/2+1) vs edge k^(n/2) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -509,6 +509,7 @@ import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ04OQ01
 import Proofs.BurnsideCountingOQ04OQ02
 import Proofs.BurnsideCountingOQ05
+import Proofs.BurnsideCountingOQ05OQ01
 import Proofs.CantorDiagonalization
 import Proofs.CantorDiagonalizationOQ01
 import Proofs.CantorDiagonalizationOQ01OQ01

--- a/proofs/Proofs/BurnsideCountingOQ05OQ01.lean
+++ b/proofs/Proofs/BurnsideCountingOQ05OQ01.lean
@@ -1,0 +1,249 @@
+import Mathlib
+
+/-
+# Burnside Counting: Reflection-Fixed Colorings of an **Even** Cycle
+
+This file is the even-`n` counterpart of `BurnsideCountingOQ05.lean`, which counted the
+`k`-colorings of an `n`-cycle fixed by a reflection for **odd** `n = 2m+1`.
+
+For a cycle with an **even** number of positions `n = 2m`, the dihedral group `D_n` has two
+geometrically distinct conjugacy classes of reflections, and they fix different numbers of
+colorings:
+
+* **Vertex-axis reflections** pass through two opposite *vertices*. Modelled as negation
+  `i ↦ -i` on `ZMod (2m)`, this involution fixes exactly the two positions `0` and `m`
+  (the solutions of `2i = 0`). The remaining `2m - 2` positions split into `m - 1` orbit
+  pairs `{j, -j}`, so there are `2 + (m-1) = m + 1` orbits and the fixed colorings number
+  `k^(m+1) = k^(n/2 + 1)`.
+
+* **Edge-axis reflections** pass through the midpoints of two opposite *edges*. Modelled as
+  `i ↦ -1 - i` on `ZMod (2m)`, this involution has **no** fixed points (`2i + 1 = 0` has no
+  solution modulo the even number `2m`). All `2m` positions split into `m` orbit pairs
+  `{i, -1-i}`, so there are `m` orbits and the fixed colorings number `k^m = k^(n/2)`.
+
+The contrast with the odd case (a single reflection type, `k^((n+1)/2)`) is the whole point:
+for even cycles the reflection count is **not** a single power of `k` — it depends on which
+of the two reflection types is used.
+
+## Main results
+
+* `card_vertexInvariant`   — `k^(m+1)` colorings of `ZMod (2m)` invariant under `i ↦ -i`.
+* `card_edgeInvariant`     — `k^m`   colorings of `ZMod (2m)` invariant under `i ↦ -1-i`.
+* `card_reflectionInvariant_even_vertex` — restated for any even `n` as `k^(n/2 + 1)`.
+* `card_reflectionInvariant_even_edge`   — restated for any even `n` as `k^(n/2)`.
+
+Each count is proved by an explicit bijection with the colorings of a fundamental domain,
+exactly as in the odd case: a fixed coloring is reconstructed from its values on a set of
+orbit representatives by *folding* every position to its representative.
+
+This and `BurnsideCountingOQ05.lean` (odd case) together give the reflection contribution to
+Burnside's lemma for the full dihedral necklace count. Absent from Mathlib.
+-/
+
+namespace BurnsideCountingOQ05OQ01
+
+variable {k : ℕ}
+
+/-- For `m ≠ 0` the modulus `2m` is also nonzero (needed for `ZMod.val` lemmas). -/
+instance neZero_two_mul (m : ℕ) [NeZero m] : NeZero (2 * m) :=
+  ⟨by have := NeZero.ne m; omega⟩
+
+/-! ## Type I — vertex-axis reflection `i ↦ -i`
+
+The fixed points of `i ↦ -i` on `ZMod (2m)` are `{0, m}`, so the fundamental domain is
+`{0, 1, …, m}`, i.e. `Fin (m+1)`. The development mirrors the odd case verbatim, with
+`2m+1` replaced by `2m`. -/
+
+/-- Inclusion of the fundamental domain `{0,…,m}` into the cycle `ZMod (2m)`. -/
+def incl1 (m : ℕ) (j : Fin (m + 1)) : ZMod (2 * m) := (j.val : ZMod (2 * m))
+
+/-- Fold a position to its representative in `{0,…,m}` via `i ↦ min(i.val, 2m - i.val)`. -/
+def fold1 (m : ℕ) [NeZero m] (i : ZMod (2 * m)) : Fin (m + 1) :=
+  ⟨min i.val (2 * m - i.val), by have h := ZMod.val_lt i; omega⟩
+
+theorem fold1_incl1 (m : ℕ) [NeZero m] (j : Fin (m + 1)) : fold1 m (incl1 m j) = j := by
+  have hm := Nat.pos_of_ne_zero (NeZero.ne m)
+  have hj : j.val < 2 * m := by have := j.isLt; omega
+  apply Fin.ext
+  simp only [fold1, incl1, ZMod.val_natCast_of_lt hj]
+  have := j.isLt
+  omega
+
+theorem fold1_neg (m : ℕ) [NeZero m] (i : ZMod (2 * m)) : fold1 m (-i) = fold1 m i := by
+  apply Fin.ext
+  simp only [fold1]
+  rcases eq_or_ne i 0 with hi | hi
+  · subst hi; simp
+  · have hv := ZMod.val_lt i
+    have hpos : 0 < i.val := by
+      rcases Nat.eq_zero_or_pos i.val with h0 | h0
+      · exact absurd ((ZMod.val_eq_zero i).mp h0) hi
+      · exact h0
+    rw [ZMod.neg_val, if_neg hi]
+    omega
+
+theorem incl1_fold1 (m : ℕ) [NeZero m] (i : ZMod (2 * m)) :
+    incl1 m (fold1 m i) = i ∨ incl1 m (fold1 m i) = -i := by
+  have hv := ZMod.val_lt i
+  rcases le_total i.val (2 * m - i.val) with h | h
+  · left
+    have hmin : min i.val (2 * m - i.val) = i.val := by omega
+    simp only [incl1, fold1, hmin, ZMod.natCast_zmod_val]
+  · right
+    have hmin : min i.val (2 * m - i.val) = 2 * m - i.val := by omega
+    simp only [incl1, fold1, hmin]
+    have hle : i.val ≤ 2 * m := le_of_lt hv
+    rw [Nat.cast_sub hle, ZMod.natCast_self, ZMod.natCast_zmod_val, zero_sub]
+
+/-- A vertex-reflection-invariant coloring of `ZMod (2m)` is the same data as an arbitrary
+coloring of the fundamental domain `Fin (m+1)`. -/
+def vertexInvariantEquiv (m k : ℕ) [NeZero m] :
+    {c : ZMod (2 * m) → Fin k // ∀ i, c (-i) = c i} ≃ (Fin (m + 1) → Fin k) where
+  toFun c j := c.1 (incl1 m j)
+  invFun g := ⟨fun i => g (fold1 m i), by
+    intro i; show g (fold1 m (-i)) = g (fold1 m i); rw [fold1_neg]⟩
+  left_inv := by
+    rintro ⟨c, hc⟩
+    apply Subtype.ext
+    funext i
+    show c (incl1 m (fold1 m i)) = c i
+    rcases incl1_fold1 m i with h | h
+    · rw [h]
+    · rw [h]; exact hc i
+  right_inv := by
+    intro g
+    funext j
+    show g (fold1 m (incl1 m j)) = g j
+    rw [fold1_incl1]
+
+/-- **Vertex-axis reflection count.** For `n = 2m`, exactly `k^(m+1)` colorings of the
+`n`-cycle are invariant under the vertex reflection `i ↦ -i`. -/
+theorem card_vertexInvariant (m k : ℕ) [NeZero m] :
+    Fintype.card {c : ZMod (2 * m) → Fin k // ∀ i, c (-i) = c i} = k ^ (m + 1) := by
+  rw [Fintype.card_congr (vertexInvariantEquiv m k), Fintype.card_fun,
+    Fintype.card_fin, Fintype.card_fin]
+
+/-! ## Type II — edge-axis reflection `i ↦ -1 - i`
+
+This reflection has no fixed points; the fundamental domain is `{0, 1, …, m-1}`, i.e.
+`Fin m`. The orbit of `i` is `{i, -1-i}`, paired as `{j, 2m-1-j}`. The key computation is
+that `(-1 - i).val = 2m - 1 - i.val`. -/
+
+/-- The edge reflection `i ↦ -1-i` equals the cast of `2m - 1 - i.val`. -/
+theorem edge_cast (m : ℕ) [NeZero m] (i : ZMod (2 * m)) :
+    ((2 * m - 1 - i.val : ℕ) : ZMod (2 * m)) = -1 - i := by
+  have hlt := ZMod.val_lt i
+  have step : ((2 * m - 1 - i.val : ℕ) : ZMod (2 * m))
+      = ((2 * m : ℕ) : ZMod (2 * m)) - 1 - ((i.val : ℕ) : ZMod (2 * m)) := by
+    rw [Nat.cast_sub (by omega), Nat.cast_sub (by omega), Nat.cast_one]
+  rw [step, ZMod.natCast_self, ZMod.natCast_zmod_val, zero_sub]
+
+/-- The `ZMod.val` of the edge reflection. -/
+theorem edge_val (m : ℕ) [NeZero m] (i : ZMod (2 * m)) :
+    (-1 - i : ZMod (2 * m)).val = 2 * m - 1 - i.val := by
+  rw [← edge_cast m i]
+  have hlt := ZMod.val_lt i
+  exact ZMod.val_natCast_of_lt (by omega)
+
+/-- Inclusion of the fundamental domain `{0,…,m-1}` into the cycle `ZMod (2m)`. -/
+def incl2 (m : ℕ) (j : Fin m) : ZMod (2 * m) := (j.val : ZMod (2 * m))
+
+/-- Fold a position to its representative in `{0,…,m-1}` via `i ↦ min(i.val, 2m-1-i.val)`. -/
+def fold2 (m : ℕ) [NeZero m] (i : ZMod (2 * m)) : Fin m :=
+  ⟨min i.val (2 * m - 1 - i.val), by
+    have h := ZMod.val_lt i
+    have hm := Nat.pos_of_ne_zero (NeZero.ne m)
+    omega⟩
+
+theorem fold2_incl2 (m : ℕ) [NeZero m] (j : Fin m) : fold2 m (incl2 m j) = j := by
+  have hj : j.val < 2 * m := by have := j.isLt; omega
+  apply Fin.ext
+  simp only [fold2, incl2, ZMod.val_natCast_of_lt hj]
+  have := j.isLt
+  omega
+
+theorem fold2_edge (m : ℕ) [NeZero m] (i : ZMod (2 * m)) :
+    fold2 m (-1 - i) = fold2 m i := by
+  apply Fin.ext
+  simp only [fold2, edge_val]
+  have hlt := ZMod.val_lt i
+  omega
+
+theorem incl2_fold2 (m : ℕ) [NeZero m] (i : ZMod (2 * m)) :
+    incl2 m (fold2 m i) = i ∨ incl2 m (fold2 m i) = -1 - i := by
+  have hv := ZMod.val_lt i
+  rcases le_total i.val (2 * m - 1 - i.val) with h | h
+  · left
+    have hmin : min i.val (2 * m - 1 - i.val) = i.val := by omega
+    simp only [incl2, fold2, hmin, ZMod.natCast_zmod_val]
+  · right
+    have hmin : min i.val (2 * m - 1 - i.val) = 2 * m - 1 - i.val := by omega
+    simp only [incl2, fold2, hmin]
+    exact edge_cast m i
+
+/-- An edge-reflection-invariant coloring of `ZMod (2m)` is the same data as an arbitrary
+coloring of the fundamental domain `Fin m`. -/
+def edgeInvariantEquiv (m k : ℕ) [NeZero m] :
+    {c : ZMod (2 * m) → Fin k // ∀ i, c (-1 - i) = c i} ≃ (Fin m → Fin k) where
+  toFun c j := c.1 (incl2 m j)
+  invFun g := ⟨fun i => g (fold2 m i), by
+    intro i; show g (fold2 m (-1 - i)) = g (fold2 m i); rw [fold2_edge]⟩
+  left_inv := by
+    rintro ⟨c, hc⟩
+    apply Subtype.ext
+    funext i
+    show c (incl2 m (fold2 m i)) = c i
+    rcases incl2_fold2 m i with h | h
+    · rw [h]
+    · rw [h]; exact hc i
+  right_inv := by
+    intro g
+    funext j
+    show g (fold2 m (incl2 m j)) = g j
+    rw [fold2_incl2]
+
+/-- **Edge-axis reflection count.** For `n = 2m`, exactly `k^m` colorings of the `n`-cycle
+are invariant under the edge reflection `i ↦ -1-i`. -/
+theorem card_edgeInvariant (m k : ℕ) [NeZero m] :
+    Fintype.card {c : ZMod (2 * m) → Fin k // ∀ i, c (-1 - i) = c i} = k ^ m := by
+  rw [Fintype.card_congr (edgeInvariantEquiv m k), Fintype.card_fun,
+    Fintype.card_fin, Fintype.card_fin]
+
+/-! ## Restatement for an arbitrary even `n` -/
+
+/-- **Vertex reflection, even case.** For any even `n > 0`, the number of `k`-colorings of
+the `n`-cycle fixed by a vertex-axis reflection `i ↦ -i` is `k^(n/2 + 1)`. -/
+theorem card_reflectionInvariant_even_vertex (n k : ℕ) [NeZero n] (hn : Even n) :
+    Fintype.card {c : ZMod n → Fin k // ∀ i, c (-i) = c i} = k ^ (n / 2 + 1) := by
+  obtain ⟨m, hm⟩ := hn
+  have hn2 : n = 2 * m := by omega
+  subst hn2
+  haveI : NeZero m := ⟨by have := NeZero.ne (2 * m); omega⟩
+  rw [card_vertexInvariant]
+  congr 1
+  omega
+
+/-- **Edge reflection, even case.** For any even `n > 0`, the number of `k`-colorings of the
+`n`-cycle fixed by an edge-axis reflection `i ↦ -1-i` is `k^(n/2)`. -/
+theorem card_reflectionInvariant_even_edge (n k : ℕ) [NeZero n] (hn : Even n) :
+    Fintype.card {c : ZMod n → Fin k // ∀ i, c (-1 - i) = c i} = k ^ (n / 2) := by
+  obtain ⟨m, hm⟩ := hn
+  have hn2 : n = 2 * m := by omega
+  subst hn2
+  haveI : NeZero m := ⟨by have := NeZero.ne (2 * m); omega⟩
+  rw [card_edgeInvariant]
+  congr 1
+  omega
+
+/-- **The two reflection types differ.** For `n = 2m` with `m ≥ 1` and at least two colors,
+the vertex-axis reflection fixes strictly more colorings than the edge-axis reflection:
+`k^m < k^(m+1)`. This is the structural contrast with the odd case (one reflection type). -/
+theorem vertex_gt_edge (m k : ℕ) [NeZero m] (hk : 2 ≤ k) :
+    Fintype.card {c : ZMod (2 * m) → Fin k // ∀ i, c (-1 - i) = c i}
+      < Fintype.card {c : ZMod (2 * m) → Fin k // ∀ i, c (-i) = c i} := by
+  rw [card_vertexInvariant, card_edgeInvariant]
+  have hpos : 0 < k ^ m := pow_pos (by omega) m
+  calc k ^ m < k ^ m * k := (lt_mul_iff_one_lt_right hpos).mpr (by omega)
+    _ = k ^ (m + 1) := (pow_succ k m).symm
+
+end BurnsideCountingOQ05OQ01

--- a/src/data/proofs/burnside-counting-oq-05-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-05-oq-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "burnside-counting-oq-05-oq-01",
+  "title": "Reflection-Fixed Colorings of an Even Cycle: Vertex vs Edge Axes",
+  "slug": "burnside-counting-oq-05-oq-01",
+  "description": "The even-n counterpart of oq-05, answering that entry's lead open question. For a cycle with an even number n = 2m of positions, the dihedral group D_n has two geometrically distinct conjugacy classes of reflections that fix different numbers of k-colorings. A vertex-axis reflection (modelled as i ↦ −i on ZMod (2m)) fixes the two positions 0 and m, leaving m−1 orbit pairs {j,−j}; the m+1 orbits give k^(m+1) = k^(n/2+1) fixed colorings. An edge-axis reflection (modelled as i ↦ −1−i) has no fixed points, so all 2m positions split into m orbit pairs {i,−1−i}, giving k^m = k^(n/2) fixed colorings. Each count is proved by an explicit fundamental-domain bijection (folding every position to its orbit representative), and the two are shown to differ strictly (k^m < k^(m+1)) for at least two colors — the structural contrast with the single reflection type of the odd case.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ05OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "necklaces",
+      "fixed-points",
+      "zmod",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "card (α → β) = card β ^ card α — turns each fundamental-domain bijection into the power k^(m+1) (vertex) or k^m (edge)",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "ZMod.neg_val",
+        "description": "(−a).val = if a = 0 then 0 else n − a.val — the value-level description of the vertex reflection used to prove its fold is invariant",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.val_natCast_of_lt",
+        "description": "(↑a : ZMod n).val = a when a < n — recovers the value of the edge reflection (−1−i).val = 2m−1−i.val and of fundamental-domain representatives",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_zmod_val",
+        "description": "(↑a.val : ZMod n) = a — recovers a position from its representative, the inverse half of each fundamental-domain bijection",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "neZero_two_mul: the modulus 2m is nonzero whenever m is, the instance needed throughout for ZMod.val lemmas",
+      "incl1 / fold1 / fold1_incl1 / fold1_neg / incl1_fold1: an explicit fundamental domain {0,…,m} = Fin (m+1) for the vertex reflection i ↦ −i, with folding i ↦ min(i.val, 2m−i.val), shown invariant and a section of the inclusion",
+      "vertexInvariantEquiv: the explicit bijection {c : ZMod (2m) → Fin k // ∀ i, c(−i)=c i} ≃ (Fin (m+1) → Fin k)",
+      "card_vertexInvariant: exactly k^(m+1) colorings of ZMod (2m) are invariant under the vertex reflection",
+      "edge_cast / edge_val: the edge reflection i ↦ −1−i equals the cast of 2m−1−i.val, with (−1−i).val = 2m−1−i.val",
+      "incl2 / fold2 / fold2_incl2 / fold2_edge / incl2_fold2: an explicit fixed-point-free fundamental domain {0,…,m−1} = Fin m for the edge reflection, with folding i ↦ min(i.val, 2m−1−i.val)",
+      "edgeInvariantEquiv: the explicit bijection {c : ZMod (2m) → Fin k // ∀ i, c(−1−i)=c i} ≃ (Fin m → Fin k)",
+      "card_edgeInvariant: exactly k^m colorings of ZMod (2m) are invariant under the edge reflection",
+      "card_reflectionInvariant_even_vertex / card_reflectionInvariant_even_edge: restated for any even n as k^(n/2+1) and k^(n/2)",
+      "vertex_gt_edge: for m ≥ 1 and k ≥ 2 the vertex reflection fixes strictly more colorings than the edge reflection (k^m < k^(m+1)) — the structural contrast with the odd case"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 249,
+    "theoremCount": 12,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "The dihedral group D_n acting on a cycle of n beads has its symmetries split into rotations and reflections, and the Burnside (Cauchy–Frobenius) lemma averages the number of colorings each fixes. The rotation contributions are the gcd-counts k^gcd(n,r) (cf. oq-03); the reflection contributions depend on the parity of n. The odd case (oq-05) is uniform: every reflection axis passes through one vertex and the opposite edge-midpoint, fixing one bead and giving k^((n+1)/2). The even case, formalized here, is genuinely two-typed: half the reflection axes pass through two opposite vertices, half through two opposite edge-midpoints, and the two types fix different numbers of colorings. This dichotomy is exactly what makes the even-n necklace count more subtle than a single power of k.",
+    "problemStatement": "How many k-colorings of an even n = 2m cycle are fixed by a reflection?\n\n**Answer: it depends on the axis type.** A vertex-axis reflection (i ↦ −i) fixes the two beads 0 and m and pairs the rest, giving m+1 = n/2+1 orbits and k^(n/2+1) fixed colorings. An edge-axis reflection (i ↦ −1−i) has no fixed beads and pairs all 2m positions, giving m = n/2 orbits and k^(n/2) fixed colorings. The two counts differ: k^(n/2) < k^(n/2+1).",
+    "text": "An even-cycle reflection fixes k^(n/2+1) colorings through a vertex axis but only k^(n/2) through an edge axis.",
+    "proofStrategy": "Model the two reflection types on ZMod (2m): the vertex reflection as negation i ↦ −i (fixed points 0 and m, the solutions of 2i = 0), the edge reflection as i ↦ −1−i (no fixed points, since 2i+1 = 0 has no solution modulo the even 2m). For each, build an explicit fundamental domain — Fin (m+1) for the vertex axis, Fin m for the edge axis — with an inclusion incl and a folding section fold mapping each position to min of its value and its mirror's value. Prove fold ∘ incl = id, fold is reflection-invariant (fold(−i) = fold i; fold(−1−i) = fold i, via the value-level descriptions ZMod.neg_val and edge_val), and incl(fold i) returns i or its mirror. These assemble into explicit Equivs between reflection-invariant colorings and free colorings of the fundamental domain; Fintype.card_fun evaluates the counts as k^(m+1) and k^m. A final calc shows k^m < k^(m+1).",
+    "keyInsights": [
+      "Parity changes the orbit structure qualitatively: for even 2m the negation involution has two fixed points {0, m} (not one), and a second reflection class — the fixed-point-free i ↦ −1−i — appears that has no odd analogue",
+      "The edge reflection i ↦ −1−i is handled by the clean value identity (−1−i).val = 2m−1−i.val, which turns its fold into the same min-of-value template used for the vertex axis",
+      "Both counts come from explicit computable folding sections, not abstract orbit-quotient machinery — the same reusable pattern as the odd case, instantiated at two different fundamental domains",
+      "The strict inequality k^(n/2) < k^(n/2+1) is the formal statement that even-cycle reflections are not a single power of k, the precise sense in which the even case is richer than the odd one"
+    ],
+    "prerequisites": [
+      "Group actions and the Burnside/Cauchy–Frobenius counting philosophy",
+      "The ring ZMod n and its value function (ZMod.val, ZMod.neg_val, ZMod.val_natCast_of_lt)",
+      "Counting functions on a finite type: card (α → β) = card β ^ card α"
+    ]
+  },
+  "sections": [
+    {
+      "id": "vertex-axis",
+      "title": "Type I — Vertex-Axis Reflection i ↦ −i",
+      "startLine": 51,
+      "endLine": 124,
+      "summary": "The negation involution on ZMod (2m) fixes 0 and m; its fundamental domain is {0,…,m} = Fin (m+1) with folding i ↦ min(i.val, 2m−i.val). The bijection vertexInvariantEquiv yields card_vertexInvariant = k^(m+1).",
+      "mathContext": "$\\#\\{c : \\mathbb{Z}/2m \\to \\mathrm{Fin}\\,k \\mid c(-i)=c(i)\\} = k^{m+1}$."
+    },
+    {
+      "id": "edge-axis",
+      "title": "Type II — Edge-Axis Reflection i ↦ −1−i",
+      "startLine": 126,
+      "endLine": 210,
+      "summary": "The reflection i ↦ −1−i has no fixed points; (−1−i).val = 2m−1−i.val. Its fundamental domain is {0,…,m−1} = Fin m with folding i ↦ min(i.val, 2m−1−i.val). The bijection edgeInvariantEquiv yields card_edgeInvariant = k^m.",
+      "mathContext": "$\\#\\{c : \\mathbb{Z}/2m \\to \\mathrm{Fin}\\,k \\mid c(-1-i)=c(i)\\} = k^{m}$."
+    },
+    {
+      "id": "even-restatement",
+      "title": "Restatement for Arbitrary Even n and the Contrast",
+      "startLine": 212,
+      "endLine": 246,
+      "summary": "Both counts restated for any even n > 0 as k^(n/2+1) and k^(n/2), with vertex_gt_edge proving the vertex axis fixes strictly more colorings (k^m < k^(m+1)) when k ≥ 2.",
+      "mathContext": "$k^{n/2} < k^{n/2+1}$ — the two reflection types are not equinumerous."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral necklace counts, including the even/odd reflection dichotomy"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-05",
+      "relationship": "extends",
+      "description": "oq-05 counts reflection-fixed colorings of an ODD cycle as the single power k^((n+1)/2). This entry answers oq-05's lead open question by treating the EVEN case, where reflections split into vertex-axis (k^(n/2+1)) and edge-axis (k^(n/2)) types that fix different numbers of colorings."
+    },
+    {
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "related",
+      "description": "oq-03 counts rotation-fixed colorings as k^gcd(n,r); together with the reflection counts here and in oq-05 these supply the two families of terms in the dihedral Burnside average."
+    }
+  ],
+  "conclusion": {
+    "summary": "For even n = 2m, the two reflection types of D_n fix different numbers of k-colorings: a vertex-axis reflection (i ↦ −i, fixed points {0, m}) fixes k^(n/2+1), an edge-axis reflection (i ↦ −1−i, fixed-point-free) fixes k^(n/2), and k^(n/2) < k^(n/2+1). Each is proved by an explicit fundamental-domain bijection with 0 axioms.",
+    "implications": "Completes the parity picture of dihedral reflection contributions begun in oq-05: odd cycles have one uniform reflection count, even cycles have two. Both are delivered as fully verified, computable folding bijections — a reusable template for counting fixtures of involutions and fixed-point-free involutions on ZMod n, ready to be combined with the rotation counts into a full Burnside necklace average.",
+    "openQuestions": [
+      "Can the rotation counts (k^gcd(n,r)) and both even/odd reflection counts now be assembled into a fully formalized closed form for the number of inequivalent dihedral necklaces via Burnside's lemma, with the even case correctly weighting m vertex-axis and m edge-axis reflections?",
+      "Does the same vertex/edge fundamental-domain template compute, for a fixed colour budget, the number of reflection-symmetric necklaces under additional constraints (e.g. proper colorings where adjacent beads differ)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BurnsideCountingOQ05OQ01",
+    "lineCount": 249,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 7,
+    "path": "Proofs/BurnsideCountingOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **lead open question** of `burnside-counting-oq-05` (which counted odd-cycle reflection-fixed colorings as `k^((n+1)/2)`): the **even** case `n = 2m`, where the dihedral group's reflections split into two geometrically distinct conjugacy classes that fix *different* numbers of `k`-colorings.

| Reflection type | Model on `ZMod (2m)` | Fixed points | Orbits | Fixed colorings |
|---|---|---|---|---|
| **Vertex-axis** | `i ↦ -i` | `{0, m}` | `m+1` | `k^(m+1) = k^(n/2+1)` |
| **Edge-axis** | `i ↦ -1-i` | none | `m` | `k^m = k^(n/2)` |

The contrast `k^(n/2) < k^(n/2+1)` (theorem `vertex_gt_edge`, for `k ≥ 2`) is the whole point: unlike the odd case's single uniform reflection count, even-cycle reflections are **not** a single power of `k`.

## Method

Each count is proved by an explicit, computable **fundamental-domain bijection** — no abstract orbit-quotient machinery. A fixed coloring is reconstructed from its values on orbit representatives by *folding* each position to its representative:
- Vertex: `fold₁ i = min(i.val, 2m - i.val)` onto `Fin (m+1)`.
- Edge: `fold₂ i = min(i.val, 2m-1 - i.val)` onto `Fin m`, using the value identity `(-1-i).val = 2m-1-i.val`.

## Results
- `card_vertexInvariant` — `k^(m+1)` colorings invariant under `i ↦ -i`
- `card_edgeInvariant` — `k^m` colorings invariant under `i ↦ -1-i`
- `card_reflectionInvariant_even_vertex` / `_edge` — restated for any even `n` as `k^(n/2+1)` / `k^(n/2)`
- `vertex_gt_edge` — the strict inequality

## Verification
- **13 theorems, 7 defs, 249 lines, 0 sorries**
- `#print axioms` on all main results: only `propext`, `Classical.choice`, `Quot.sound` — **verified, 0-axiom**
- Builds against Mathlib (lean4 v4.26.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)