### PR TITLE
research(compactness-finite-subcover-oq-02-oq-02): continuous partition of unity from distance-to-complement bumps [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -798,6 +798,7 @@ import Proofs.CompactnessFiniteSubcoverOq01Oq02
 import Proofs.CompactnessFiniteSubcoverOq01Oq02Oq01
 import Proofs.CompactnessFiniteSubcoverOq02
 import Proofs.CompactnessFiniteSubcoverOq02Oq01
+import Proofs.CompactnessFiniteSubcoverOq02Oq02
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01

--- a/proofs/Proofs/CompactnessFiniteSubcoverOq02Oq02.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcoverOq02Oq02.lean
@@ -1,0 +1,206 @@
+import Mathlib
+
+/-
+# Continuous Partition of Unity Subordinate to a Finite Open Cover
+
+## What This Proves
+
+Given a **finite** open cover `U : ι → Set X` of a metric space `X`
+(`Fintype ι`, every `U i` open, `⋃ i, U i = univ`), we construct an explicit
+continuous **partition of unity** subordinate to the cover:
+
+* `psi U i : X → ℝ` is continuous for every `i`;
+* `0 ≤ psi U i x` everywhere (nonnegativity);
+* `psi U i x ≠ 0 → x ∈ U i` (subordination — the support of `psi U i` sits
+  inside `U i`);
+* `∑ i, psi U i x = 1` for every `x` (the partition sums to one).
+
+The bundled statement is `exists_partition_of_unity`.
+
+## The Construction
+
+The bump for the cover member `U i` is the distance from `x` to the complement
+of `U i`:
+
+```
+bump U i x = infDist x (U i)ᶜ        (guarded so `U i = univ ↦ 1`)
+```
+
+Because `U i` is open, `(U i)ᶜ` is closed, so `infDist x (U i)ᶜ > 0` exactly
+when `x ∈ U i` (`Metric.infDist_pos_iff_notMem_closure`).  The single guard
+handles the degenerate member `U i = univ`, whose complement is empty and whose
+`infDist` would otherwise collapse to `0`; there we use the constant `1`.
+
+Each `x` lies in some `U i`, so `bump U i x > 0`, hence the finite sum
+`∑ j, bump U j x` is strictly positive everywhere.  Normalizing,
+`psi U i x = bump U i x / ∑ j, bump U j x`, gives the partition of unity.
+
+## Why Compactness Is Not Needed
+
+The open question that motivated this entry asks for a partition of unity on a
+*compact* metric space, built from a subordinate ε-net of bump functions.  The
+construction here shows that **once the cover is finite, compactness plays no
+role**: the distance-to-complement bumps are purely metric and need neither a
+Lebesgue number nor an ε-net.  Compactness is only what reduces an *arbitrary*
+open cover to a finite one; that reduction is supplied by
+`exists_partition_of_unity_compact`, which extracts a finite subcover
+(`IsCompact.elim_finite_subcover`) and then applies the finite construction.
+
+This separates the two ingredients cleanly: compactness ⇒ finiteness of the
+cover, and finiteness ⇒ partition of unity (no further topology required).
+-/
+
+open Set Metric
+open scoped BigOperators Classical
+
+namespace CompactnessFiniteSubcoverOq02Oq02
+
+variable {X : Type*} [MetricSpace X]
+variable {ι : Type*} [Fintype ι]
+
+/-- Unnormalized bump for the cover member `U i`: the distance from `x` to the
+complement of `U i`, guarded so the pathological member `U i = univ` (empty
+complement) contributes the constant `1` rather than collapsing to `0`. -/
+noncomputable def bump (U : ι → Set X) (i : ι) (x : X) : ℝ :=
+  if (U i)ᶜ = ∅ then 1 else infDist x (U i)ᶜ
+
+@[simp] lemma bump_nonneg (U : ι → Set X) (i : ι) (x : X) : 0 ≤ bump U i x := by
+  unfold bump
+  split
+  · exact zero_le_one
+  · exact infDist_nonneg
+
+lemma bump_continuous (U : ι → Set X) (i : ι) : Continuous (bump U i) := by
+  unfold bump
+  by_cases h : (U i)ᶜ = ∅
+  · simp only [if_pos h]; exact continuous_const
+  · simp only [if_neg h]; exact continuous_infDist_pt (U i)ᶜ
+
+/-- On the cover member `U i`, the bump is strictly positive. -/
+lemma bump_pos_of_mem (U : ι → Set X) {i : ι} (hUi : IsOpen (U i)) {x : X}
+    (hx : x ∈ U i) : 0 < bump U i x := by
+  unfold bump
+  by_cases h : (U i)ᶜ = ∅
+  · simp only [if_pos h]; exact zero_lt_one
+  · simp only [if_neg h]
+    have hne : ((U i)ᶜ).Nonempty := nonempty_iff_ne_empty.mpr h
+    have hclosed : IsClosed (U i)ᶜ := hUi.isClosed_compl
+    have hxc : x ∉ closure (U i)ᶜ := by
+      rw [hclosed.closure_eq]; simpa using hx
+    exact (infDist_pos_iff_notMem_closure hne).mp hxc
+
+/-- Subordination of the bump: it can only be nonzero inside `U i`. -/
+lemma bump_subordinate (U : ι → Set X) {i : ι} {x : X} (hb : bump U i x ≠ 0) :
+    x ∈ U i := by
+  by_cases h : (U i)ᶜ = ∅
+  · have : x ∉ (U i)ᶜ := by rw [h]; exact notMem_empty x
+    simpa using this
+  · by_contra hxni
+    have hxc : x ∈ (U i)ᶜ := hxni
+    apply hb
+    unfold bump
+    rw [if_neg h]
+    exact infDist_zero_of_mem hxc
+
+/-- The total weight `∑ j, bump U j x` is strictly positive at every point of a
+finite open cover. -/
+lemma sum_bump_pos (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) (x : X) : 0 < ∑ i, bump U i x := by
+  obtain ⟨i, hi⟩ : ∃ i, x ∈ U i := by
+    have hx : x ∈ ⋃ i, U i := by rw [hcov]; trivial
+    simpa using hx
+  refine Finset.sum_pos' (fun j _ => bump_nonneg U j x) ?_
+  exact ⟨i, Finset.mem_univ i, bump_pos_of_mem U (hU i) hi⟩
+
+/-- The normalized partition-of-unity function for the member `U i`. -/
+noncomputable def psi (U : ι → Set X) (i : ι) (x : X) : ℝ :=
+  bump U i x / ∑ j, bump U j x
+
+lemma psi_continuous (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) (i : ι) : Continuous (psi U i) := by
+  refine Continuous.div (bump_continuous U i)
+    (continuous_finset_sum _ (fun j _ => bump_continuous U j)) ?_
+  exact fun x => (sum_bump_pos U hU hcov x).ne'
+
+lemma psi_nonneg (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) (i : ι) (x : X) : 0 ≤ psi U i x :=
+  div_nonneg (bump_nonneg U i x) (sum_bump_pos U hU hcov x).le
+
+lemma psi_subordinate (U : ι → Set X) {i : ι} {x : X} (h : psi U i x ≠ 0) :
+    x ∈ U i := by
+  refine bump_subordinate U (fun hb => h ?_)
+  unfold psi
+  rw [hb, zero_div]
+
+lemma psi_sum_eq_one (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) (x : X) : ∑ i, psi U i x = 1 := by
+  unfold psi
+  rw [← Finset.sum_div]
+  exact div_self (sum_bump_pos U hU hcov x).ne'
+
+/-- **Continuous partition of unity subordinate to a finite open cover.**
+Every finite open cover of a metric space carries an explicit continuous
+partition of unity: nonnegative continuous functions, each supported inside its
+cover member, summing pointwise to `1`. -/
+theorem exists_partition_of_unity (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) :
+    ∃ ψ : ι → X → ℝ,
+      (∀ i, Continuous (ψ i)) ∧
+      (∀ i x, 0 ≤ ψ i x) ∧
+      (∀ i x, ψ i x ≠ 0 → x ∈ U i) ∧
+      (∀ x, ∑ i, ψ i x = 1) :=
+  ⟨psi U,
+    fun i => psi_continuous U hU hcov i,
+    fun i x => psi_nonneg U hU hcov i x,
+    fun _ _ h => psi_subordinate U h,
+    fun x => psi_sum_eq_one U hU hcov x⟩
+
+/-- **Partition of unity on a compact metric space.** An *arbitrary* open cover
+of a compact metric space admits a finite subset `s` of indices and a continuous
+partition of unity subordinate to `{U i}_{i ∈ s}` summing to one — compactness
+serves only to reduce the cover to a finite one, after which the metric
+construction above applies. -/
+theorem exists_partition_of_unity_compact [CompactSpace X]
+    {ι : Type*} (U : ι → Set X) (hU : ∀ i, IsOpen (U i))
+    (hcov : (⋃ i, U i) = univ) :
+    ∃ (s : Finset ι) (ψ : ι → X → ℝ),
+      (∀ i, Continuous (ψ i)) ∧
+      (∀ i x, 0 ≤ ψ i x) ∧
+      (∀ i x, ψ i x ≠ 0 → x ∈ U i) ∧
+      (∀ x, ∑ i ∈ s, ψ i x = 1) := by
+  -- Extract a finite subcover.
+  obtain ⟨s, hs⟩ :=
+    isCompact_univ.elim_finite_subcover U hU (by rw [hcov])
+  -- Reindex by the finite subcover and build the partition of unity there.
+  classical
+  have hscov : (⋃ i : {i // i ∈ s}, U i.1) = univ := by
+    rw [eq_univ_iff_forall]
+    intro x
+    have hx : x ∈ ⋃ i ∈ s, U i := hs (mem_univ x)
+    obtain ⟨i, hi, hxi⟩ := mem_iUnion₂.mp hx
+    exact mem_iUnion.mpr ⟨⟨i, hi⟩, hxi⟩
+  obtain ⟨ψ', hcont', hnonneg', hsub', hsum'⟩ :=
+    exists_partition_of_unity (X := X) (ι := {i // i ∈ s})
+      (fun i => U i.1) (fun i => hU i.1) hscov
+  -- Push the subtype-indexed family back to a family on all of `ι`.
+  refine ⟨s, fun i => if h : i ∈ s then ψ' ⟨i, h⟩ else fun _ => 0, ?_, ?_, ?_, ?_⟩
+  · intro i
+    by_cases h : i ∈ s
+    · simp only [h, dif_pos]; exact hcont' ⟨i, h⟩
+    · simp only [h]; exact continuous_const
+  · intro i x
+    by_cases h : i ∈ s
+    · simp only [h, dif_pos]; exact hnonneg' ⟨i, h⟩ x
+    · simp only [h]; exact le_refl 0
+  · intro i x hx
+    by_cases h : i ∈ s
+    · simp only [h, dif_pos] at hx; exact hsub' ⟨i, h⟩ x hx
+    · simp only [h] at hx; exact absurd rfl hx
+  · intro x
+    rw [← hsum' x]
+    -- Beta-reduce the applied family `(fun i => …) i x` inside the sum.
+    simp only []
+    rw [← Finset.sum_coe_sort s
+          (fun a => (if h : a ∈ s then ψ' ⟨a, h⟩ else fun _ : X => (0:ℝ)) x)]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [dif_pos i.2, Subtype.coe_eta]

--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "distance-to-complement-bump",
+    "proofId": "compactness-finite-subcover-oq-02-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "Distance-to-Complement Is the Right Bump",
+    "content": "bump U i x = infDist x (U i)ᶜ is the conceptual heart. The distance-to-a-set function is continuous for free (continuous_infDist_pt) and nonnegative (infDist_nonneg). The decisive fact is that for an OPEN U i, its complement is CLOSED, so closure (U i)ᶜ = (U i)ᶜ and infDist_pos_iff_notMem_closure says infDist x (U i)ᶜ > 0 exactly when x ∉ (U i)ᶜ, i.e. when x ∈ U i. One elementary metric object thus delivers continuity AND support control in a single stroke. The lone guard handles U i = univ, whose complement is empty: there infDist would be 0, so we substitute the constant 1.",
+    "mathContext": "$\\mathrm{bump}_i(x) = d(x,(U_i)^c),\\qquad \\mathrm{bump}_i(x) > 0 \\iff x \\in U_i \\quad (U_i\\text{ open}).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "distance to a set",
+      "infDist",
+      "open vs closed sets",
+      "support of a bump function"
+    ],
+    "prerequisites": [
+      "metric spaces",
+      "infimum distance infDist",
+      "closure and closed complements of open sets"
+    ]
+  },
+  {
+    "id": "positive-total-weight",
+    "proofId": "compactness-finite-subcover-oq-02-oq-02",
+    "range": {
+      "startLine": 105,
+      "endLine": 139
+    },
+    "type": "insight",
+    "title": "Finiteness, Not Compactness, Makes Normalization Work",
+    "content": "sum_bump_pos shows the total weight ∑ j, bump U j x is strictly positive at every point: x lies in some cover member U i (the cover hypothesis), where bump U i x > 0, and a finite sum of nonnegatives with one strictly positive term is positive (Finset.sum_pos'). Because the denominator never vanishes, ψ i x = bump U i x / ∑ j, bump U j x is globally continuous (Continuous.div), nonnegative, subordinate (numerator vanishes off U i), and ∑ i, ψ i x = 1 (Finset.sum_div then div_self). Nothing here uses compactness — only that the cover is finite.",
+    "mathContext": "$\\psi_i(x) = \\frac{\\mathrm{bump}_i(x)}{\\sum_j \\mathrm{bump}_j(x)},\\qquad \\sum_j \\mathrm{bump}_j(x) > 0,\\qquad \\sum_i \\psi_i(x) = 1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "partition of unity",
+      "normalization",
+      "finite sums",
+      "continuity of quotients"
+    ],
+    "prerequisites": [
+      "finite sums over a Fintype",
+      "strict positivity of a finite sum",
+      "continuity of division with nonzero denominator"
+    ]
+  },
+  {
+    "id": "compactness-only-finitizes",
+    "proofId": "compactness-finite-subcover-oq-02-oq-02",
+    "range": {
+      "startLine": 158,
+      "endLine": 203
+    },
+    "type": "insight",
+    "title": "Compactness Contributes Exactly One Step",
+    "content": "exists_partition_of_unity_compact takes an ARBITRARY open cover of a compact space and does only one thing with compactness: IsCompact.elim_finite_subcover extracts a finite subcover indexed by a Finset s. Reindexing the cover by the subtype {i // i ∈ s} turns it into a finite cover, the metric construction (exists_partition_of_unity) builds the partition there, and the family is pushed back to all of ι by zero off s. This makes the parent entry's intuition literal: compactness finitizes the cover, and finiteness — not compactness — produces the partition of unity. No Lebesgue number or ε-net is needed for the construction itself.",
+    "mathContext": "$\\text{compact} \\xRightarrow{\\text{elim\\_finite\\_subcover}} \\text{finite cover} \\xRightarrow{\\text{metric bumps}} \\text{partition of unity}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "finite subcover",
+      "compactness",
+      "subtype reindexing",
+      "extension by zero"
+    ],
+    "prerequisites": [
+      "compact spaces and finite subcovers",
+      "reindexing sums over a Finset via its attach/coe-sort",
+      "dependent if-then-else (dite)"
+    ]
+  }
+]

--- a/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "compactness-finite-subcover-oq-02-oq-02",
+  "slug": "compactness-finite-subcover-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "CompactnessFiniteSubcoverOq02Oq02",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "path": "Proofs/CompactnessFiniteSubcoverOq02Oq02.lean",
+    "sorries": 0
+  },
+  "title": "A Continuous Partition of Unity from Distance-to-Complement Bumps",
+  "description": "Given a finite open cover U : ι → Set X of a metric space (Fintype ι, every U i open, ⋃ i, U i = univ), we construct an explicit continuous partition of unity subordinate to the cover: nonnegative continuous functions ψ i with ψ i x ≠ 0 ⟹ x ∈ U i and ∑ i, ψ i x = 1 everywhere. The bump for member U i is the distance to its complement, bump U i x = infDist x (U i)ᶜ, guarded so the degenerate member U i = univ (empty complement) contributes the constant 1. Because U i is open, (U i)ᶜ is closed, so infDist x (U i)ᶜ > 0 exactly when x ∈ U i (infDist_pos_iff_notMem_closure); subordination is infDist_zero_of_mem in the contrapositive. Each x lies in some cover member, so the finite total weight ∑ j, bump U j x is strictly positive, and normalizing ψ i x = bump U i x / ∑ j, bump U j x produces the partition. The headline exists_partition_of_unity bundles all four properties; exists_partition_of_unity_compact then handles an ARBITRARY open cover of a compact space by extracting a finite subcover (IsCompact.elim_finite_subcover) and reindexing onto it — making precise the parent's open question that compactness contributes only the reduction to a finite cover, after which the construction is purely metric and needs neither a Lebesgue number nor an ε-net.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOq02Oq02.lean",
+    "tags": [
+      "topology",
+      "metric-spaces",
+      "compactness",
+      "partition-of-unity",
+      "bump-functions",
+      "subordinate-cover",
+      "infDist",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 203,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "bump: the unnormalized bump for cover member U i, defined as the distance infDist x (U i)ᶜ from x to the complement, guarded by a single if so the pathological member U i = univ (empty complement, whose infDist would collapse to 0) instead contributes the constant 1. This is an explicit, elementary bump function built from metric primitives alone — no smooth-manifold or higher-level BumpCovering machinery.",
+      "bump_pos_of_mem / bump_subordinate: the two halves of the support characterization. Positivity on U i comes from infDist_pos_iff_notMem_closure applied to the closed set (U i)ᶜ; subordination (the bump vanishes outside U i) is the contrapositive via infDist_zero_of_mem. Together they pin the support of bump U i exactly inside U i.",
+      "sum_bump_pos: the total weight ∑ j, bump U j x is strictly positive at every point, because the cover hypothesis places x in some member where that member's bump is positive (Finset.sum_pos' from one strictly-positive summand among nonnegative ones). This positivity is what makes normalization legitimate everywhere.",
+      "psi and psi_continuous / psi_nonneg / psi_subordinate / psi_sum_eq_one: the normalized family ψ i x = bump U i x / ∑ j, bump U j x, together with continuity (quotient of continuous functions with nowhere-zero denominator), nonnegativity, subordination inherited from the bump, and the partition identity ∑ i, ψ i x = 1 (Finset.sum_div then div_self of the positive total).",
+      "exists_partition_of_unity: the headline for a FINITE open cover of an arbitrary metric space — an explicit continuous partition of unity subordinate to the cover, bundling continuity, nonnegativity, subordination, and summation to one. Compactness is absent; finiteness of the cover is the only hypothesis the construction uses.",
+      "exists_partition_of_unity_compact: the compact-space corollary for an ARBITRARY open cover. It extracts a finite subcover with IsCompact.elim_finite_subcover, reindexes the cover by the subtype {i // i ∈ s}, applies the finite construction there, and pushes the resulting family back to all of ι (zero off the subcover). This isolates the exact role of compactness — reduce the cover to a finite one — from the metric content that produces the partition."
+    ],
+    "prerequisites": [
+      "Metric.infDist_pos_iff_notMem_closure: for a nonempty set s, infDist x s > 0 ↔ x ∉ closure s — turns openness of U i (closedness of its complement) into strict positivity of the bump on U i",
+      "Metric.infDist_zero_of_mem: x ∈ s ⟹ infDist x s = 0 — gives subordination (the bump vanishes off U i) in the contrapositive",
+      "continuous_infDist_pt: x ↦ infDist x s is continuous — continuity of each bump",
+      "IsCompact.elim_finite_subcover: a compact set covered by opens admits a finite subcover — the sole place compactness enters the compact-space corollary",
+      "Finset.sum_pos', Finset.sum_div, div_self, Continuous.div: the finite-sum and normalization bookkeeping"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Metric.infDist_pos_iff_notMem_closure",
+        "description": "infDist x s > 0 ↔ x ∉ closure s for nonempty s. Converts membership in the open U i into strict positivity of the distance-to-complement bump.",
+        "module": "Mathlib.Topology.MetricSpace.Infimum"
+      },
+      {
+        "theorem": "Metric.infDist_zero_of_mem",
+        "description": "x ∈ s ⟹ infDist x s = 0. Supplies subordination: the bump can be nonzero only inside U i.",
+        "module": "Mathlib.Topology.MetricSpace.Infimum"
+      },
+      {
+        "theorem": "IsCompact.elim_finite_subcover",
+        "description": "A compact set covered by a family of opens has a finite subcover. The only use of compactness, reducing an arbitrary cover to a finite one before the metric construction.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "Finset.sum_pos'",
+        "description": "A finite sum of nonnegative terms is strictly positive if at least one term is strictly positive. Gives the strictly-positive total weight from the cover hypothesis.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Partitions of unity are the standard device for gluing local data into global data: subordinate to an open cover, a family of nonnegative functions summing to one lets one patch local constructions (sections, metrics, integrals) together continuously. On smooth manifolds they are built from smooth bump functions and paracompactness; on a metric space the elementary route uses the distance-to-a-set function, which is automatically continuous and vanishes exactly on the closure of the set. The parent entry (compactness-finite-subcover-oq-02) built a subordinate finite ε-net on a compact metric space from the Lebesgue number lemma and asked, as oq-02-oq-02, for the partition of unity that net is meant to support. This entry answers it and, in doing so, separates two ingredients usually bundled together: compactness (which only reduces an arbitrary cover to a finite one) and the metric bump construction (which needs only finiteness).",
+    "problemStatement": "**Open Question (oq-02 of oq-02)**: construct a continuous partition of unity subordinate to a finite open cover of a compact metric space, localizing bump functions by the subordinate net, and verify the partition sums to one.",
+    "proofStrategy": "For a finite open cover U : ι → Set X, define bump U i x = infDist x (U i)ᶜ, guarded to be the constant 1 when (U i)ᶜ = ∅. Each bump is continuous (continuous_infDist_pt), nonnegative (infDist_nonneg), strictly positive precisely on U i (infDist_pos_iff_notMem_closure, since (U i)ᶜ is closed), and zero off U i (infDist_zero_of_mem) — giving subordination. Since the U i cover X, every x lies in some member, so the finite total ∑ j, bump U j x is strictly positive (Finset.sum_pos'). Normalize: ψ i x = bump U i x / ∑ j, bump U j x. The quotient is continuous (nowhere-zero denominator), nonnegative, subordinate (numerator vanishes off U i), and ∑ i, ψ i x = 1 (Finset.sum_div then div_self). For a compact space and an arbitrary cover, first extract a finite subcover s via IsCompact.elim_finite_subcover, reindex by the subtype {i // i ∈ s}, run the finite construction, and push the family back to ι by zero off s.",
+    "keyInsights": [
+      "Distance-to-complement is the right bump: infDist x (U i)ᶜ is continuous for free, and for an OPEN U i its complement is closed, so infDist_pos_iff_notMem_closure makes the bump strictly positive exactly on U i and zero outside — support control and continuity in one elementary object.",
+      "Finiteness, not compactness, is what the construction needs. The total weight is a FINITE sum, so its positivity (one positive summand among nonnegatives) and continuity are immediate; compactness never appears in exists_partition_of_unity.",
+      "Compactness contributes exactly one step: IsCompact.elim_finite_subcover turns an arbitrary open cover into a finite one. The compact-space theorem is therefore a thin wrapper — extract subcover, reindex, apply the finite construction — making the parent's intuition ('compactness only finitizes the cover') a literal proof structure.",
+      "The single guard for U i = univ is genuinely necessary: there (U i)ᶜ = ∅, infDist to the empty set is 0, and the unguarded bump would vanish identically; setting it to 1 keeps that member's weight positive without disturbing any other case.",
+      "Normalization is legitimate everywhere precisely because the cover is a cover: the total weight is bounded below by a single positive bump at each point, so the denominator is never zero and ψ is globally continuous."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bump-construction",
+      "title": "The Distance-to-Complement Bump",
+      "startLine": 61,
+      "endLine": 103,
+      "summary": "bump U i x = infDist x (U i)ᶜ (guarded to 1 when the complement is empty). bump_nonneg, bump_continuous, bump_pos_of_mem (positivity on U i via infDist_pos_iff_notMem_closure), and bump_subordinate (vanishing off U i via infDist_zero_of_mem) establish nonnegativity, continuity, and exact support control."
+    },
+    {
+      "id": "normalization",
+      "title": "Positive Total Weight and Normalization",
+      "startLine": 105,
+      "endLine": 139,
+      "summary": "sum_bump_pos shows the finite total ∑ j, bump U j x is strictly positive at every point of the cover. psi U i x = bump U i x / ∑ j, bump U j x is then continuous, nonnegative, subordinate, and sums to one (psi_sum_eq_one via Finset.sum_div and div_self)."
+    },
+    {
+      "id": "finite-cover-headline",
+      "title": "Partition of Unity for a Finite Open Cover",
+      "startLine": 141,
+      "endLine": 156,
+      "summary": "exists_partition_of_unity bundles the four properties into the headline for an arbitrary metric space with a finite open cover — compactness nowhere used."
+    },
+    {
+      "id": "compact-corollary",
+      "title": "The Compact-Space Corollary",
+      "startLine": 158,
+      "endLine": 203,
+      "summary": "exists_partition_of_unity_compact handles an arbitrary open cover of a compact space: extract a finite subcover (IsCompact.elim_finite_subcover), reindex by the subtype {i // i ∈ s}, apply the finite construction, and push the family back to ι by zero off the subcover."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "compactness-finite-subcover-oq-02-oq-02-oq-01",
+      "question": "Strengthen subordination to closed-support control: produce a partition of unity whose closed supports {x | ψ i x ≠ 0}ᶜᶜ (the closures) are still contained in the cover members — i.e. a shrinking of the cover — rather than only the open condition ψ i x ≠ 0 ⟹ x ∈ U i. On a normal/metric space this is the genuine 'subordinate' condition used to glue closed data.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "compactness-finite-subcover-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: oq-02 builds the subordinate finite ε-net on a compact metric space from the Lebesgue number lemma; this entry constructs the continuous partition of unity that net supports and shows compactness enters only through the reduction to a finite cover."
+    },
+    {
+      "targetId": "compactness-finite-subcover-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling oq-01 cashes the parent's subordinate net for Heine–Cantor (uniform continuity) via the Lebesgue number as a global modulus; this oq-02 cashes it for the partition of unity via distance-to-complement bumps."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.MetricSpace.Infimum",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of infDist_pos_iff_notMem_closure and infDist_zero_of_mem, the metric facts characterizing the support of the distance-to-complement bump."
+    },
+    {
+      "title": "Topology",
+      "author": "Munkres",
+      "year": "2000",
+      "venue": "Prentice Hall",
+      "description": "Classical construction of partitions of unity subordinate to a finite open cover (§36), via distance/Urysohn bump functions and normalization."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Every finite open cover of a metric space carries an explicit continuous partition of unity (exists_partition_of_unity): the normalized distance-to-complement bumps ψ i x = infDist x (U i)ᶜ / ∑ j, infDist x (U j)ᶜ are continuous, nonnegative, supported inside their cover members, and sum to one. For a compact space and an arbitrary open cover, exists_partition_of_unity_compact first extracts a finite subcover (IsCompact.elim_finite_subcover) and then applies the finite construction. 203 lines, 11 theorems/lemmas, 2 definitions, 0 axioms, 0 sorries.",
+    "implications": "The construction makes the parent's open question precise: compactness contributes only the reduction of an arbitrary cover to a finite one; the partition of unity itself is a purely metric object requiring neither a Lebesgue number nor an ε-net, only finiteness of the cover. The metric facts used (infDist positivity/vanishing) are Mathlib's, but the explicit normalized-bump partition and the clean separation of compactness from the metric content are written from scratch (badge: original), bypassing Mathlib's higher-level partition-of-unity / BumpCovering APIs.",
+    "openQuestions": [
+      "Strengthen open-support subordination to closed-support control (a shrinking of the cover), the condition needed to glue closed data on normal/metric spaces."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **oq-02-oq-02** stated by the parent entry `compactness-finite-subcover-oq-02`: *construct a continuous partition of unity subordinate to a finite open cover of a compact metric space, localizing bump functions, and verify it sums to one.*

The entry separates two ingredients usually bundled together: **compactness** (which only reduces an arbitrary cover to a finite one) and the **metric bump construction** (which needs only finiteness).

## Construction

For a finite open cover `U : ι → Set X`:

- **`bump U i x = infDist x (U i)ᶜ`** (guarded to the constant `1` when `(U i)ᶜ = ∅`). Distance-to-a-set is continuous for free; openness of `U i` makes `(U i)ᶜ` closed, so `infDist_pos_iff_notMem_closure` gives `bump U i x > 0 ⟺ x ∈ U i`, and `infDist_zero_of_mem` gives subordination (`bump` vanishes off `U i`).
- **Positive total weight** `∑ j, bump U j x > 0` everywhere — the cover places `x` in some member where that bump is positive (`Finset.sum_pos'`).
- **`psi U i x = bump U i x / ∑ j, bump U j x`** is continuous, nonnegative, subordinate, and `∑ i, psi U i x = 1`.

## Theorems

- `exists_partition_of_unity` — headline for a **finite** open cover of an arbitrary metric space (compactness unused).
- `exists_partition_of_unity_compact` — an **arbitrary** open cover of a **compact** space: extract a finite subcover via `IsCompact.elim_finite_subcover`, reindex by the subtype `{i // i ∈ s}`, apply the finite construction, push back by zero off the subcover. This makes the parent's intuition literal: compactness finitizes the cover; finiteness produces the partition.

## Verification

- **0 axioms** (only `propext`, `Classical.choice`, `Quot.sound`), **0 sorries**
- 11 theorems/lemmas, 2 definitions, 203 lines
- Builds against Mathlib (`lean4 v4.26.0`), verified single-file with `lake env lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)