### PR TITLE
Enrich Erdős #57 Companion: Odd Closed Walks & the Bipartite Characterization

### DIFF
--- a/src/data/proofs/erdos-57-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-57-incomplete-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 36 },
     "type": "concept",
     "title": "Goal: the bipartite characterization, in closed-walk form",
-    "content": "The parent file `Proofs/Erdos57Problem.lean` axiomatizes the Liu–Montgomery (2020) theorem and leaves one open `sorry`: the hard reverse direction of the bipartite characterization, 'no odd cycle ⟹ 2-colorable'. Mathlib itself flags this exact statement as future work in `Mathlib.Combinatorics.SimpleGraph.Bipartite`.\n\nThis companion proves the genuinely hard *construction* direction in its clean closed-walk form, fully axiom-free:\n\n    G.IsBipartite ↔ G has no odd closed walk.\n\nThe odd-closed-walk version is the 'right' intermediate result: its construction direction is exactly the deferred half, while the odd-CYCLE version additionally needs the combinatorial lemma 'every odd closed walk contains an odd cycle' — which is assumed nowhere here."
+    "content": "The parent file `Proofs/Erdos57Problem.lean` axiomatizes the Liu–Montgomery (2020) theorem and leaves one open `sorry`: the hard reverse direction of the bipartite characterization, 'no odd cycle ⟹ 2-colorable'. Mathlib itself flags this exact statement as future work in `Mathlib.Combinatorics.SimpleGraph.Bipartite`.\n\nThis companion proves the genuinely hard *construction* direction in its clean closed-walk form, fully axiom-free:\n\n    G.IsBipartite ↔ G has no odd closed walk.\n\nThe odd-closed-walk version is the 'right' intermediate result: its construction direction is exactly the deferred half, while the odd-CYCLE version additionally needs the combinatorial lemma 'every odd closed walk contains an odd cycle' — which is assumed nowhere here.",
+    "mathContext": "$G.\\mathrm{IsBipartite} \\iff \\neg\\,\\exists u,\\ \\exists p : G.\\mathrm{Walk}\\ u\\ u,\\ \\mathrm{Odd}(\\mathrm{length}\\ p)$. Bipartite means $2$-colorable, i.e. $\\chi(G) \\le 2$.",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graph", "2-coloring", "odd cycle", "closed walk", "chromatic number"],
+    "prerequisites": ["graph theory", "proper colorings", "parity arguments"]
   },
   {
     "id": "ann-57inc-hasoddwalk",
@@ -13,7 +17,11 @@
     "range": { "startLine": 47, "endLine": 61 },
     "type": "definition",
     "title": "Odd closed walks and parity well-definedness",
-    "content": "`HasOddClosedWalk G` asserts the existence of a walk `u → u` of odd length.\n\nThe key technical lemma `even_length_iff_of_noOddClosedWalk` says: if `G` has no odd closed walk, then any two walks `p, q : G.Walk x y` with the same endpoints have the same length parity. Proof: `p.append q.reverse` is a closed walk at `x` of length `p.length + q.length`; by hypothesis it cannot be odd, hence is even, hence the two summands share parity (`Nat.even_add`). This is exactly the well-definedness that makes the parity coloring legitimate."
+    "content": "`HasOddClosedWalk G` asserts the existence of a walk `u → u` of odd length.\n\nThe key technical lemma `even_length_iff_of_noOddClosedWalk` says: if `G` has no odd closed walk, then any two walks `p, q : G.Walk x y` with the same endpoints have the same length parity. Proof: `p.append q.reverse` is a closed walk at `x` of length `p.length + q.length`; by hypothesis it cannot be odd, hence is even, hence the two summands share parity (`Nat.even_add`). This is exactly the well-definedness that makes the parity coloring legitimate.",
+    "mathContext": "If no closed walk has odd length, then for $p, q : x \\rightsquigarrow y$ the concatenation $p \\cdot \\bar q$ is a closed walk at $x$ of length $\\ell(p)+\\ell(q)$, which is even; by $\\mathrm{Even}(a+b) \\Rightarrow (\\mathrm{Even}\\,a \\leftrightarrow \\mathrm{Even}\\,b)$ the parities agree.",
+    "significance": "critical",
+    "relatedConcepts": ["walk concatenation", "walk reversal", "parity", "Nat.even_add", "well-definedness"],
+    "prerequisites": ["walks in graphs", "Even/Odd arithmetic"]
   },
   {
     "id": "ann-57inc-base",
@@ -21,15 +29,23 @@
     "range": { "startLine": 63, "endLine": 75 },
     "type": "definition",
     "title": "A base vertex per connected component",
-    "content": "`baseVertex G v := (G.connectedComponentMk v).out` selects a canonical representative of `v`'s connected component using `ConnectedComponent.out`. Since `out_eq` gives `connectedComponentMk (baseVertex v) = connectedComponentMk v`, `ConnectedComponent.exact` yields `reachable_baseVertex : G.Reachable (baseVertex G v) v`. The chosen witness walk `baseWalk G v : G.Walk (baseVertex G v) v` is `(reachable_baseVertex G v).some`."
+    "content": "`baseVertex G v := (G.connectedComponentMk v).out` selects a canonical representative of `v`'s connected component using `ConnectedComponent.out`. Since `out_eq` gives `connectedComponentMk (baseVertex v) = connectedComponentMk v`, `ConnectedComponent.exact` yields `reachable_baseVertex : G.Reachable (baseVertex G v) v`. The chosen witness walk `baseWalk G v : G.Walk (baseVertex G v) v` is `(reachable_baseVertex G v).some`.",
+    "mathContext": "Each connected component is a quotient class under reachability; $\\mathrm{out}$ picks a representative via `Quot.out`. Reachability $\\mathrm{baseVertex}(v) \\rightsquigarrow v$ holds because both lie in the same component.",
+    "significance": "supporting",
+    "relatedConcepts": ["connected component", "reachability", "Quot.out", "choice", "quotient representative"],
+    "prerequisites": ["connectivity", "quotient types", "classical choice"]
   },
   {
     "id": "ann-57inc-coloring",
     "proofId": "erdos-57-incomplete-01",
     "range": { "startLine": 77, "endLine": 102 },
-    "type": "proof",
+    "type": "definition",
     "title": "The parity 2-coloring (the construction Mathlib defers)",
-    "content": "`parityColoring h` colors each vertex `v` by `decide (Odd (baseWalk G v).length)` — the parity of a walk back to its component's base vertex. Validity (adjacent vertices get different colors): for `G.Adj u v`, both lie in the same component, so `baseVertex G u = baseVertex G v`. Forming two walks `baseVertex u → v` — one through the edge `u-v` (length `(baseWalk u).length + 1`), one transported from `baseWalk v` via `Walk.copy` (length `(baseWalk v).length`) — the parity lemma forces these to share parity, i.e. `(baseWalk u).length` and `(baseWalk v).length` have OPPOSITE parity. Hence the two `decide (Odd …)` values differ. This is the component-wise walk-parity construction, in full and axiom-free."
+    "content": "`parityColoring h` colors each vertex `v` by `decide (Odd (baseWalk G v).length)` — the parity of a walk back to its component's base vertex. Validity (adjacent vertices get different colors): for `G.Adj u v`, both lie in the same component, so `baseVertex G u = baseVertex G v`. Forming two walks `baseVertex u → v` — one through the edge `u-v` (length `(baseWalk u).length + 1`), one transported from `baseWalk v` via `Walk.copy` (length `(baseWalk v).length`) — the parity lemma forces these to share parity, i.e. `(baseWalk u).length` and `(baseWalk v).length` have OPPOSITE parity. Hence the two `decide (Odd …)` values differ. This is the component-wise walk-parity construction, in full and axiom-free.",
+    "mathContext": "Color $v$ by $c(v) := [\\,\\mathrm{Odd}\\,\\ell(\\mathrm{baseWalk}\\,v)\\,]$. For an edge $u\\!\\sim\\!v$: $\\ell(\\mathrm{baseWalk}\\,u)+1$ and $\\ell(\\mathrm{baseWalk}\\,v)$ have equal parity, so $\\ell(\\mathrm{baseWalk}\\,u) \\not\\equiv \\ell(\\mathrm{baseWalk}\\,v) \\pmod 2$, giving $c(u) \\ne c(v)$.",
+    "significance": "critical",
+    "relatedConcepts": ["proper coloring", "Walk.copy", "Coloring.mk", "parity coloring", "transport of equality"],
+    "prerequisites": ["proper colorings", "walks in graphs", "decidability of Odd"]
   },
   {
     "id": "ann-57inc-headline",
@@ -37,7 +53,11 @@
     "range": { "startLine": 104, "endLine": 120 },
     "type": "theorem",
     "title": "Headline: IsBipartite ⟺ no odd closed walk",
-    "content": "`isBipartite_iff_no_oddClosedWalk`. Forward (easy): from a `Fin 2`-coloring, recolor to `Bool` and apply `Coloring.even_length_iff_congr` at a closed walk (`c u ↔ c u` trivially) to force even length, contradicting an odd closed walk. Reverse (the construction): `parityColoring h` is a `Bool`-coloring, so `(parityColoring h).colorable` gives `Colorable (Fintype.card Bool) = Colorable 2 = IsBipartite`. This is the bipartite characterization's hard half, proved completely."
+    "content": "`isBipartite_iff_no_oddClosedWalk`. Forward (easy): from a `Fin 2`-coloring, recolor to `Bool` and apply `Coloring.even_length_iff_congr` at a closed walk (`c u ↔ c u` trivially) to force even length, contradicting an odd closed walk. Reverse (the construction): `parityColoring h` is a `Bool`-coloring, so `(parityColoring h).colorable` gives `Colorable (Fintype.card Bool) = Colorable 2 = IsBipartite`. This is the bipartite characterization's hard half, proved completely.",
+    "mathContext": "$G.\\mathrm{IsBipartite} \\iff \\neg\\,\\mathrm{HasOddClosedWalk}\\,G$. Forward: a $2$-coloring makes every closed walk even (color must return to itself). Reverse: $\\mathrm{Colorable}(|\\mathrm{Bool}|) = \\mathrm{Colorable}\\,2 = \\mathrm{IsBipartite}$.",
+    "significance": "key",
+    "relatedConcepts": ["IsBipartite", "Coloring.even_length_iff_congr", "recolorOfEquiv", "Colorable", "Fintype.card_bool"],
+    "prerequisites": ["proper colorings", "biconditional proofs", "Fin 2 / Bool equivalence"]
   },
   {
     "id": "ann-57inc-cycles",
@@ -45,7 +65,11 @@
     "range": { "startLine": 122, "endLine": 148 },
     "type": "theorem",
     "title": "Odd cycles obstruct bipartiteness (easy direction)",
-    "content": "An odd cycle is in particular an odd closed walk (`hasOddClosedWalk_of_oddCycle`), so a nonempty `oddCycleLengths G` yields an odd closed walk (`hasOddClosedWalk_of_oddCycleLengths`). Composing with the headline gives `not_isBipartite_of_oddCycleLengths` (odd cycle ⟹ not bipartite) and, contrapositively, `oddCycleLengths_empty_of_isBipartite` — recovering the parent's forward direction of `bipartite_iff_no_odd_cycles` through the closed-walk framework."
+    "content": "An odd cycle is in particular an odd closed walk (`hasOddClosedWalk_of_oddCycle`), so a nonempty `oddCycleLengths G` yields an odd closed walk (`hasOddClosedWalk_of_oddCycleLengths`). Composing with the headline gives `not_isBipartite_of_oddCycleLengths` (odd cycle ⟹ not bipartite) and, contrapositively, `oddCycleLengths_empty_of_isBipartite` — recovering the parent's forward direction of `bipartite_iff_no_odd_cycles` through the closed-walk framework.",
+    "mathContext": "An odd cycle $c : u \\rightsquigarrow u$ with $\\mathrm{Odd}\\,\\ell(c)$ is an odd closed walk. Hence $(\\mathrm{oddCycleLengths}\\,G)\\ne\\emptyset \\Rightarrow \\neg\\,G.\\mathrm{IsBipartite}$, and contrapositively bipartite $\\Rightarrow \\mathrm{oddCycleLengths}\\,G = \\emptyset$.",
+    "significance": "supporting",
+    "relatedConcepts": ["odd cycle", "oddCycleLengths", "contrapositive", "IsCycle", "obstruction"],
+    "prerequisites": ["cycles in graphs", "contraposition"]
   },
   {
     "id": "ann-57inc-chromatic",
@@ -53,6 +77,10 @@
     "range": { "startLine": 150, "endLine": 163 },
     "type": "theorem",
     "title": "Quantitative obstruction: χ(G) ≥ 3",
-    "content": "`three_le_chromaticNumber_of_hasOddClosedWalk` upgrades the qualitative obstruction to a bound: an odd closed walk forces `3 ≤ G.chromaticNumber`, via Mathlib's `Walk.three_le_chromaticNumber_of_odd_loop`. Specializing to cycles, an odd cycle forces `χ(G) ≥ 3` (`three_le_chromaticNumber_of_oddCycleLengths`). The remaining gap to the parent's full odd-cycle characterization is now isolated to the single combinatorial lemma 'every odd closed walk contains an odd cycle', assumed nowhere here."
+    "content": "`three_le_chromaticNumber_of_hasOddClosedWalk` upgrades the qualitative obstruction to a bound: an odd closed walk forces `3 ≤ G.chromaticNumber`, via Mathlib's `Walk.three_le_chromaticNumber_of_odd_loop`. Specializing to cycles, an odd cycle forces `χ(G) ≥ 3` (`three_le_chromaticNumber_of_oddCycleLengths`). The remaining gap to the parent's full odd-cycle characterization is now isolated to the single combinatorial lemma 'every odd closed walk contains an odd cycle', assumed nowhere here.",
+    "mathContext": "$\\mathrm{HasOddClosedWalk}\\,G \\Rightarrow 3 \\le \\chi(G)$. Since $\\chi(G) \\le 2 \\iff$ bipartite, an odd closed walk pushes the chromatic number strictly past the bipartite threshold.",
+    "significance": "supporting",
+    "relatedConcepts": ["chromatic number", "Walk.three_le_chromaticNumber_of_odd_loop", "quantitative bound", "odd loop"],
+    "prerequisites": ["chromatic number", "proper colorings"]
   }
 ]

--- a/src/data/proofs/erdos-57-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-57-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos57OddClosedWalk.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos57Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos57Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos57Incomplete01Data: ProofData = {
+  proof: erdos57Incomplete01Proof,
+  annotations: erdos57Incomplete01Annotations,
+}

--- a/src/data/proofs/erdos-57-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-57-incomplete-01/meta.json
@@ -49,6 +49,66 @@
       "Parity arguments (Even/Odd of natural numbers)"
     ]
   },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Problem Statement & Setup",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring framing the goal: prove the hard construction direction of the bipartite characterization in closed-walk form (G.IsBipartite ↔ no odd closed walk), the exact step the parent file leaves as a sorry and Mathlib lists as future work. Imports Mathlib and the parent Erdos57Problem; opens Set and SimpleGraph in namespace Erdos57."
+    },
+    {
+      "id": "odd-closed-walks",
+      "title": "Odd Closed Walks & Parity Well-Definedness",
+      "startLine": 47,
+      "endLine": 61,
+      "summary": "Defines HasOddClosedWalk G (a walk u → u of odd length) and proves even_length_iff_of_noOddClosedWalk: with no odd closed walk, any two walks sharing endpoints have equal length parity, since their append-with-reverse is an even closed walk. This is the well-definedness that legitimizes the parity coloring."
+    },
+    {
+      "id": "base-vertex",
+      "title": "Canonical Base Vertex per Component",
+      "startLine": 63,
+      "endLine": 75,
+      "summary": "baseVertex G v selects a representative of v's connected component via ConnectedComponent.out; reachable_baseVertex establishes reachability from base to v (ConnectedComponent.exact on out_eq); baseWalk G v is a chosen witness walk back to the base."
+    },
+    {
+      "id": "parity-coloring",
+      "title": "The Parity 2-Coloring (Mathlib's deferred construction)",
+      "startLine": 77,
+      "endLine": 102,
+      "summary": "parityColoring h colors each vertex by the parity of a walk to its component base (decide (Odd (baseWalk G v).length)). Properness: adjacent u, v share a base vertex; two walks base → v (one through the edge, one via Walk.copy) have equal parity, forcing the base-walk lengths to opposite parity, so colors differ. The genuinely hard construction direction, axiom-free."
+    },
+    {
+      "id": "headline",
+      "title": "Headline: Bipartite ⟺ No Odd Closed Walk",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "isBipartite_iff_no_oddClosedWalk. Forward (easy): a Bool-recoloring forces closed walks even (Coloring.even_length_iff_congr). Reverse (the construction): parityColoring h is a Bool-coloring, so colorable with Fintype.card Bool = 2 = IsBipartite."
+    },
+    {
+      "id": "odd-cycle-consequences",
+      "title": "Odd-Cycle Consequences (easy obstruction)",
+      "startLine": 122,
+      "endLine": 148,
+      "summary": "An odd cycle is an odd closed walk (hasOddClosedWalk_of_oddCycle / _of_oddCycleLengths), so a nonempty oddCycleLengths obstructs bipartiteness (not_isBipartite_of_oddCycleLengths), and contrapositively a bipartite graph has empty oddCycleLengths (oddCycleLengths_empty_of_isBipartite) — recovering the parent's forward direction."
+    },
+    {
+      "id": "chromatic-obstruction",
+      "title": "Quantitative Chromatic Obstruction",
+      "startLine": 150,
+      "endLine": 163,
+      "summary": "three_le_chromaticNumber_of_hasOddClosedWalk: an odd closed walk forces 3 ≤ χ(G) via Mathlib's Walk.three_le_chromaticNumber_of_odd_loop; three_le_chromaticNumber_of_oddCycleLengths specializes this to odd cycles."
+    }
+  ],
+  "conclusion": {
+    "summary": "This companion proves, fully axiom-free, the construction (hard) direction of the bipartite characterization in its closed-walk form: a simple graph is bipartite iff it has no odd closed walk (isBipartite_iff_no_oddClosedWalk). The reverse direction is the component-wise parity 2-coloring — choosing a base vertex per connected component and coloring by the parity of a walk back to it — which is exactly the step the parent file leaves as a sorry and Mathlib lists as future work. The easy obstruction direction (odd cycle ⟹ not bipartite, and the quantitative χ(G) ≥ 3) is recovered as a consequence, and the parent's forward bipartite direction is reproved through the closed-walk framework.",
+    "implications": "Isolating bipartiteness to the absence of odd CLOSED WALKS, rather than odd cycles, is what makes the construction direction fully constructive: parity well-definedness is precisely the no-odd-closed-walk hypothesis, so no appeal to the existence of a specific odd cycle is needed. This separates the topological/parity content of the characterization (handled here completely) from the purely combinatorial content (every odd closed walk contains an odd cycle), which is the only remaining gap to the parent's full odd-cycle statement and is assumed nowhere in this file. As the base case of the Erdős–Hajnal cycle-richness hierarchy underlying Erdős #57, the bipartite characterization is the foundation on which the deep Liu–Montgomery result builds.",
+    "openQuestions": [
+      "Formalize the missing combinatorial lemma 'every odd closed walk contains an odd cycle' to close the gap and obtain the parent's full odd-cycle characterization (G.IsBipartite ↔ no odd cycle) axiom-free.",
+      "Upstream the closed-walk characterization to Mathlib, directly resolving the 'future work' note in Mathlib.Combinatorics.SimpleGraph.Bipartite.",
+      "Quantify the obstruction further: relate the shortest odd closed walk / odd girth to lower bounds on χ(G) beyond the threshold χ(G) ≥ 3."
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib",


### PR DESCRIPTION
Enrichment pass for `erdos-57-incomplete-01` (quality 45, passes 0).

## What was missing
- **No `index.ts`** — without it the proof page renders 'proof not found' on the live site.
- `annotations.json` existed but **every annotation lacked `mathContext`, `significance`, `relatedConcepts`, `prerequisites`**.
- `meta.json` had no `sections` array and no `conclusion`.

## Changes
- **Created `index.ts`** — wires meta + annotations + raw Lean source.
- **`annotations.json`** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 7 annotations; content preserved.
- **`meta.json`** — added a 7-section `sections` array covering the full Lean file (setup, odd closed walks, base vertex, parity coloring, headline, odd-cycle consequences, chromatic obstruction), plus a `conclusion` with `summary`, `implications`, and 3 `openQuestions` (notably: formalize 'every odd closed walk contains an odd cycle' to close the parent's gap).

## Verification
- `pnpm build` passes (✓ built).
- JSON validated; section/annotation line ranges align with `Proofs/Erdos57OddClosedWalk.lean`.
- Axiom integrity confirmed: `status: verified`, `badge: verified`, `axiomCount: 0`, 0 sorries — matches the Lean file (parent's `erdos_57` axiom and `sorry` are not used).