### PR TITLE
research(pythagorean-triples-oq-06-oq-01): parity dichotomy — exactly one leg even [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3453,6 +3453,7 @@ import Proofs.PythagoreanTriplesOQ03
 import Proofs.PythagoreanTriplesOQ04
 import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ06
+import Proofs.PythagoreanTriplesOQ06OQ01
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
 import Proofs.PythagoreanTriplesOQ09

--- a/proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean
@@ -1,0 +1,129 @@
+/-
+  # Parity dichotomy of primitive Pythagorean triples
+  # (pythagorean-triples-oq-06-oq-01)
+
+  ## The Open Question
+
+  The parent entry `pythagorean-triples-oq-06` packages Euclid's classification of
+  primitive Pythagorean triples. Its open question asks us to *use* the classification
+  (or an elementary argument) to prove the **parity dichotomy**:
+
+  > In a primitive Pythagorean triple `x² + y² = z²` with `gcd(x, y) = 1`, **exactly one
+  > of the two legs `x, y` is even**, and the hypotenuse `z` is always odd.
+
+  ## The argument (fully elementary — no classification needed)
+
+  The dichotomy follows from two independent parity facts, each provable directly from
+  the defining equation `x*x + y*y = z*z`:
+
+  * **Not both even.** If `2 ∣ x` and `2 ∣ y` then `2 ∣ gcd(x, y) = 1`, impossible.
+    (This is the only place coprimality is used.)
+  * **Not both odd.** If `x, y` are both odd then `x² + y² ≡ 2 (mod 4)`. But a perfect
+    square is `≡ 0` or `1 (mod 4)`, so `z²` can never be `≡ 2 (mod 4)`. Contradiction.
+    (No coprimality needed — this holds for *every* Pythagorean triple.)
+
+  Together: the two legs have opposite parity, so exactly one is even. The sum of an
+  even square and an odd square is odd, hence `z²` is odd and `z` is odd.
+
+  The mod-4 step is carried out by abstracting each square as an opaque integer and
+  letting `omega` discharge the resulting linear contradiction (`4a + 1 = 4b + 2` etc.).
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.Tactic
+
+namespace PythTriplesParity
+
+/-- **Not both even.** In a primitive triple the two legs cannot both be even: that
+    would force `2 ∣ gcd(x, y) = 1`. This is the only step that uses coprimality. -/
+theorem not_both_even {x y z : ℤ} (_h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) : ¬ (Even x ∧ Even y) := by
+  rintro ⟨hx, hy⟩
+  have hg : (2 : ℕ) ∣ Int.gcd x y :=
+    Nat.dvd_gcd (Int.natAbs_even.mpr hx).two_dvd (Int.natAbs_even.mpr hy).two_dvd
+  omega
+
+/-- **Not both odd.** No Pythagorean triple has two odd legs: `odd² + odd² ≡ 2 (mod 4)`,
+    while every square is `≡ 0` or `1 (mod 4)`. Holds for *all* triples, primitive or
+    not — coprimality is irrelevant here. -/
+theorem not_both_odd {x y z : ℤ} (h : PythagoreanTriple x y z) :
+    ¬ (Odd x ∧ Odd y) := by
+  rintro ⟨⟨a, ha⟩, ⟨b, hb⟩⟩
+  have heq : x * x + y * y = z * z := h
+  -- x² + y² = 4·(a²+a+b²+b) + 2 once x = 2a+1, y = 2b+1.
+  have hsum : x * x + y * y = 4 * (a * a + a + b * b + b) + 2 := by subst ha hb; ring
+  have hz2 : z * z = 4 * (a * a + a + b * b + b) + 2 := heq.symm.trans hsum
+  rcases Int.even_or_odd z with ⟨c, hc⟩ | ⟨c, hc⟩
+  · -- z = c + c : z² = 4·c², so 4c² = 4(…)+2, impossible mod 4.
+    have hzc : z * z = 4 * (c * c) := by subst hc; ring
+    omega
+  · -- z = 2c + 1 : z² = 4·(c²+c)+1, so 4(c²+c)+1 = 4(…)+2, impossible mod 4.
+    have hzc : z * z = 4 * (c * c + c) + 1 := by subst hc; ring
+    omega
+
+/-- **Parity dichotomy.** In a primitive Pythagorean triple, exactly one leg is even:
+    either `x` is even and `y` is odd, or `x` is odd and `y` is even. -/
+theorem parity_dichotomy {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) :
+    (Even x ∧ Odd y) ∨ (Odd x ∧ Even y) := by
+  rcases Int.even_or_odd x with hx | hx
+  · rcases Int.even_or_odd y with hy | hy
+    · exact absurd ⟨hx, hy⟩ (not_both_even h hco)
+    · exact Or.inl ⟨hx, hy⟩
+  · rcases Int.even_or_odd y with hy | hy
+    · exact Or.inr ⟨hx, hy⟩
+    · exact absurd ⟨hx, hy⟩ (not_both_odd h)
+
+/-- **"Exactly one" as a biconditional.** A leg `x` is even iff the other leg `y` is
+    odd. This is the sharpest packaging of the dichotomy. -/
+theorem even_left_iff_odd_right {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) : Even x ↔ Odd y := by
+  constructor
+  · intro hx
+    rcases parity_dichotomy h hco with ⟨_, hy⟩ | ⟨hx', _⟩
+    · exact hy
+    · exact absurd hx (by simpa [Int.not_even_iff_odd] using hx')
+  · intro hy
+    rcases parity_dichotomy h hco with ⟨hx, _⟩ | ⟨_, hy'⟩
+    · exact hx
+    · exact absurd hy (by simpa [Int.not_odd_iff_even] using hy')
+
+/-- **The hypotenuse is odd.** Since the legs have opposite parity, `x² + y²` is
+    `even + odd = odd`, hence `z²` and therefore `z` is odd. -/
+theorem hypotenuse_odd {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) : Odd z := by
+  have heq : x * x + y * y = z * z := h
+  have hsq : Odd (x * x + y * y) := by
+    rcases parity_dichotomy h hco with ⟨hx, hy⟩ | ⟨hx, hy⟩
+    · exact (hx.mul_right x).add_odd (hy.mul hy)
+    · exact (hx.mul hx).add_even (hy.mul_right y)
+  rw [heq] at hsq
+  exact (Int.odd_mul.mp hsq).1
+
+/-- The smallest primitive triple `(3, 4, 5)` realises the dichotomy: `3` is odd and
+    `4` is even, and the hypotenuse `5` is odd. -/
+theorem triple_3_4_5_parity :
+    ((Even (3 : ℤ) ∧ Odd (4 : ℤ)) ∨ (Odd (3 : ℤ) ∧ Even (4 : ℤ))) ∧ Odd (5 : ℤ) :=
+  ⟨parity_dichotomy (x := 3) (y := 4) (z := 5)
+      (show (3 : ℤ) * 3 + 4 * 4 = 5 * 5 by norm_num) (by decide), by decide⟩
+
+end PythTriplesParity
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `not_both_even`          | primitive ⟹ ¬(Even x ∧ Even y)  (uses gcd = 1) |
+  | `not_both_odd`           | any triple ⟹ ¬(Odd x ∧ Odd y)   (mod-4 argument) |
+  | `parity_dichotomy`       | primitive ⟹ exactly one leg even |
+  | `even_left_iff_odd_right`| primitive ⟹ (Even x ↔ Odd y) |
+  | `hypotenuse_odd`         | primitive ⟹ Odd z |
+  | `triple_3_4_5_parity`    | (3, 4, 5): leg parity split + odd hypotenuse |
+
+  The dichotomy is fully elementary: `not_both_odd` is a pure mod-4 fact about the
+  Pythagorean equation, and `not_both_even` is the lone place coprimality enters. No
+  appeal to the Euclid parametrization is required.
+-/

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "Parity Dichotomy of Primitive Pythagorean Triples",
+    "content": "A primitive Pythagorean triple solves x² + y² = z² with gcd(x,y) = 1. The parity dichotomy says exactly one of the two legs x, y is even (and the hypotenuse z is odd). The whole result follows from two parity facts about the equation, with no appeal to Euclid's parametrization: the legs are NOT both even (else 2 ∣ gcd = 1) and NOT both odd (odd² + odd² ≡ 2 mod 4, while every square is ≡ 0 or 1 mod 4). The mod-4 step is carried out by abstracting each square as an opaque integer and letting omega finish the linear contradiction.",
+    "mathContext": "Primitive $x^2+y^2=z^2 \\Rightarrow$ exactly one leg even, $z$ odd.",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triples", "parity", "quadratic residues mod 4", "primitivity"],
+    "prerequisites": ["number theory", "parity", "modular arithmetic"]
+  },
+  {
+    "id": "ann-not-both-even",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 39, "endLine": 46 },
+    "type": "theorem",
+    "title": "not_both_even: The Legs Cannot Both Be Even",
+    "content": "If x and y were both even, then 2 divides x.natAbs and y.natAbs, so 2 ∣ Nat.gcd x.natAbs y.natAbs = Int.gcd x y = 1 — impossible, closed by omega. This is the ONLY step in the whole development that uses coprimality. Even x is pushed onto x.natAbs via Int.natAbs_even, and the divisibility of the gcd comes from Nat.dvd_gcd.",
+    "mathContext": "$2 \\mid x,\\ 2 \\mid y \\Rightarrow 2 \\mid \\gcd(x,y) = 1$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["Int.natAbs_even", "Nat.dvd_gcd", "coprimality"],
+    "prerequisites": ["gcd", "parity"]
+  },
+  {
+    "id": "ann-not-both-odd",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 48, "endLine": 64 },
+    "type": "theorem",
+    "title": "not_both_odd: No Pythagorean Triple Has Two Odd Legs",
+    "content": "Writing x = 2a+1 and y = 2b+1, the leg sum is x² + y² = 4(a²+a+b²+b) + 2, so z² ≡ 2 (mod 4). But splitting z by parity gives z² = 4c² (z even) or z² = 4(c²+c)+1 (z odd) — i.e. z² ≡ 0 or 1 (mod 4) — so the equation 4·k = 4·m + 2 or 4·k + 1 = 4·m + 2 is unsatisfiable. omega closes both once each square is abstracted to an opaque atom (omega is linear but treats nonlinear subterms as atoms). Crucially this lemma needs NO coprimality: it holds for every Pythagorean triple.",
+    "mathContext": "$\\text{odd}^2 + \\text{odd}^2 \\equiv 2 \\pmod 4$, but $z^2 \\equiv 0,1 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residues mod 4", "omega", "Int.even_or_odd"],
+    "prerequisites": ["modular arithmetic", "parity"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 66, "endLine": 91 },
+    "type": "theorem",
+    "title": "parity_dichotomy / even_left_iff_odd_right: Exactly One Leg Is Even",
+    "content": "parity_dichotomy case-splits each leg with Int.even_or_odd into four corners and discharges the two same-parity corners (even/even, odd/odd) with not_both_even and not_both_odd, leaving exactly (Even x ∧ Odd y) ∨ (Odd x ∧ Even y). even_left_iff_odd_right repackages this as the sharpest 'exactly one' statement, the biconditional Even x ↔ Odd y, using Int.not_even_iff_odd / Int.not_odd_iff_even to eliminate the impossible branch in each direction.",
+    "mathContext": "$(\\text{Even } x \\wedge \\text{Odd } y) \\vee (\\text{Odd } x \\wedge \\text{Even } y)$; equivalently $\\text{Even } x \\leftrightarrow \\text{Odd } y$.",
+    "significance": "key",
+    "relatedConcepts": ["Int.even_or_odd", "opposite parity", "biconditional"],
+    "prerequisites": ["parity", "case analysis"]
+  },
+  {
+    "id": "ann-hypotenuse",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 93, "endLine": 103 },
+    "type": "theorem",
+    "title": "hypotenuse_odd: The Hypotenuse Is Odd",
+    "content": "Since the legs have opposite parity, x² + y² = even² + odd² is odd (Even.add_odd / Odd.add_even after Even.mul_right and Odd.mul). Rewriting through x*x + y*y = z*z gives Odd (z*z), and Int.odd_mul descends this to Odd z. A free corollary of the dichotomy, needing no further case analysis.",
+    "mathContext": "$\\text{even} + \\text{odd} = \\text{odd} \\Rightarrow z^2 \\text{ odd} \\Rightarrow z \\text{ odd}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.odd_mul", "Even.add_odd", "Odd.add_even"],
+    "prerequisites": ["parity"]
+  },
+  {
+    "id": "ann-example",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 105, "endLine": 111 },
+    "type": "example",
+    "title": "triple_3_4_5_parity: The Smallest Triple",
+    "content": "Instantiating the dichotomy at (3,4,5) recovers the split 3 odd, 4 even, with odd hypotenuse 5. The Pythagorean equation 3·3 + 4·4 = 5·5 is checked by norm_num and the gcd / parity side conditions by decide — a concrete sanity check that the abstract statement is correctly formulated.",
+    "mathContext": "$(3,4,5)$: $3$ odd, $4$ even, $5$ odd.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete instance", "(3,4,5)"],
+    "prerequisites": ["Pythagorean triples"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq06Oq01Data: ProofData = {
+  proof: pythagoreanTriplesOq06Oq01Proof,
+  annotations: pythagoreanTriplesOq06Oq01Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "pythagorean-triples-oq-06-oq-01",
+  "title": "Parity dichotomy of primitive Pythagorean triples",
+  "slug": "pythagorean-triples-oq-06-oq-01",
+  "description": "Answers the open question of pythagorean-triples-oq-06: in a primitive Pythagorean triple x² + y² = z² (gcd(x,y) = 1), exactly one leg is even and the hypotenuse is odd. The proof is fully elementary and needs no parametrization. Two independent parity facts do all the work: the legs cannot both be even (else 2 ∣ gcd = 1), and they cannot both be odd (odd² + odd² ≡ 2 mod 4, but no square is ≡ 2 mod 4). The mod-4 step abstracts each square as an opaque integer and lets omega close a linear contradiction. Packaged as the dichotomy, an 'exactly one' biconditional Even x ↔ Odd y, the odd-hypotenuse corollary, and the (3,4,5) instance. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "pythagorean-triples",
+      "parity",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 129,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.even_or_odd",
+        "description": "Every integer is even or odd — the case split driving both the dichotomy and the mod-4 argument",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Int.natAbs_even",
+        "description": "Even n.natAbs ↔ Even n, used to push parity of x, y onto their natAbs for the gcd contradiction",
+        "module": "Mathlib.Data.Int.Parity"
+      },
+      {
+        "theorem": "Nat.dvd_gcd",
+        "description": "k ∣ m → k ∣ n → k ∣ gcd m n, giving 2 ∣ Int.gcd x y = 1 in the not-both-even case",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Int.odd_mul",
+        "description": "Odd (m*n) ↔ Odd m ∧ Odd n, used to descend Odd (z*z) to Odd z for the hypotenuse",
+        "module": "Mathlib.Data.Int.Parity"
+      }
+    ],
+    "originalContributions": [
+      "not_both_even: in a primitive triple the legs cannot both be even, since that forces 2 ∣ gcd(x,y) = 1 — the sole use of coprimality",
+      "not_both_odd: NO Pythagorean triple has two odd legs; odd² + odd² ≡ 2 (mod 4) while every square is ≡ 0 or 1 (mod 4), discharged by abstracting squares and applying omega",
+      "parity_dichotomy: combining the two, exactly one leg is even — (Even x ∧ Odd y) ∨ (Odd x ∧ Even y)",
+      "even_left_iff_odd_right: the sharpest 'exactly one' packaging, Even x ↔ Odd y",
+      "hypotenuse_odd: the hypotenuse z is always odd, since even² + odd² is odd",
+      "triple_3_4_5_parity: the smallest triple (3,4,5) realises the split (3 odd, 4 even) with odd hypotenuse 5"
+    ],
+    "prerequisites": [
+      "Pythagorean triples x² + y² = z² and primitivity (gcd(x,y) = 1)",
+      "Parity of integers and quadratic residues mod 4",
+      "Mathlib's PythagoreanTriple definition"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PythagoreanTriples",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "PythTriplesParity",
+    "path": "Proofs/PythagoreanTriplesOQ06OQ01.lean",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "That a primitive Pythagorean triple has one even and one odd leg is the first structural fact one proves about such triples, and it is the gateway to Euclid's classification: knowing y is the even leg lets one write y = 2mn and solve for m, n. The mod-4 obstruction — that 2 is not a quadratic residue mod 4 — is the same elementary device behind the proof that x² + y² = z² forces the even/odd split, and behind Fermat's observation that a sum of two odd squares is never a perfect square. Hardy and Wright derive the parity split (Theorem 225) as the opening move of the classification rather than as a consequence of it.",
+    "problemStatement": "Prove, with 0 sorries and 0 axioms, the parity dichotomy of primitive Pythagorean triples: if x² + y² = z² with gcd(x,y) = 1, then exactly one of x, y is even, and z is odd.",
+    "text": "In a primitive Pythagorean triple the two legs have opposite parity — exactly one is even — and the hypotenuse is odd.",
+    "proofStrategy": "Two independent parity lemmas, each proved directly from x*x + y*y = z*z, then assembled. (1) not_both_even: if x and y were both even, then 2 divides each natAbs and hence 2 ∣ Int.gcd x y = 1, a contradiction closed by omega — the only place coprimality is used. (2) not_both_odd: writing x = 2a+1, y = 2b+1 gives x² + y² = 4(a²+a+b²+b) + 2, so z² ≡ 2 (mod 4); splitting z as even (z² = 4c²) or odd (z² = 4(c²+c)+1) yields 4·(opaque) = 4·(opaque) + 2 or 4·(opaque)+1 = 4·(opaque)+2, both impossible by omega once the squares are abstracted to atoms. (3) parity_dichotomy case-splits each leg with Int.even_or_odd and discharges the two same-parity corners with the lemmas. (4) even_left_iff_odd_right repackages this as Even x ↔ Odd y. (5) hypotenuse_odd: the legs have opposite parity, so x² + y² = even + odd is odd, hence z² and z are odd via Int.odd_mul. (6) triple_3_4_5_parity instantiates at (3,4,5).",
+    "keyInsights": [
+      "**Coprimality is needed only once.** Ruling out two odd legs is a fact about the equation alone — it holds for every Pythagorean triple, primitive or not. Only ruling out two even legs uses gcd(x,y) = 1. So 'opposite parity' is two theorems of very different strength glued together.",
+      "**2 is not a quadratic residue mod 4.** odd² ≡ 1 (mod 4), so a sum of two odd squares is ≡ 2 (mod 4); but a square is only ever ≡ 0 or 1 (mod 4). This single residue obstruction is the whole content of not_both_odd.",
+      "**omega handles modular arithmetic if you hide the squares.** omega is linear and cannot square, but it treats nonlinear subterms as opaque atoms. Rewriting z² as 4·c² or 4·(c²+c)+1 and the leg sum as 4·k + 2 turns the mod-4 contradiction into a linear one omega closes outright — no ZMod, no decide.",
+      "**The hypotenuse parity is a free corollary.** Once the legs are opposite-parity, x² + y² is even + odd = odd, so z² is odd and therefore z is odd. No extra case analysis is needed.",
+      "**No parametrization required.** The parent entry derives this kind of fact through Euclid's (m²−n², 2mn, m²+n²) form, where 2mn is visibly even. The dichotomy is logically prior: it is what licenses choosing y as the even leg in the first place, and here it is proved directly, decoupled from the classification."
+    ],
+    "prerequisites": [
+      "Pythagorean triples x² + y² = z² and primitivity",
+      "Parity of integers (even/odd) and the mod-4 behaviour of squares",
+      "Greatest common divisor and coprimality",
+      "The omega decision procedure for linear integer arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "States the parity dichotomy and outlines the two-lemma elementary argument (not both even via gcd, not both odd via mod 4); imports Mathlib's PythagoreanTriples.",
+      "mathContext": "Primitive Pythagorean triples and parity of integers."
+    },
+    {
+      "id": "not-both-even",
+      "title": "not_both_even — the legs are not both even",
+      "startLine": 39,
+      "endLine": 46,
+      "summary": "If x and y are both even then 2 divides each natAbs, hence 2 ∣ Int.gcd x y = 1, closed by omega. The only step that uses coprimality.",
+      "mathContext": "Primitivity rules out a common factor of 2."
+    },
+    {
+      "id": "not-both-odd",
+      "title": "not_both_odd — no triple has two odd legs",
+      "startLine": 48,
+      "endLine": 64,
+      "summary": "Writing x = 2a+1, y = 2b+1 gives x²+y² ≡ 2 (mod 4); splitting z's parity and abstracting squares to atoms lets omega derive a contradiction. Holds for every triple.",
+      "mathContext": "2 is not a quadratic residue mod 4."
+    },
+    {
+      "id": "dichotomy",
+      "title": "parity_dichotomy / even_left_iff_odd_right — exactly one leg is even",
+      "startLine": 66,
+      "endLine": 91,
+      "summary": "Case-splitting both legs with Int.even_or_odd and discharging the same-parity corners with the two lemmas gives the dichotomy, repackaged as the biconditional Even x ↔ Odd y.",
+      "mathContext": "Opposite parity of the legs."
+    },
+    {
+      "id": "hypotenuse",
+      "title": "hypotenuse_odd — the hypotenuse is odd",
+      "startLine": 93,
+      "endLine": 103,
+      "summary": "From opposite-parity legs, x²+y² = even + odd is odd, so z² and hence z is odd via Int.odd_mul.",
+      "mathContext": "Parity of z from the parity of the legs."
+    },
+    {
+      "id": "example",
+      "title": "triple_3_4_5_parity — the smallest triple",
+      "startLine": 105,
+      "endLine": 111,
+      "summary": "Instantiates the dichotomy at (3,4,5): 3 odd, 4 even, hypotenuse 5 odd.",
+      "mathContext": "A concrete witness of the dichotomy."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parity dichotomy of primitive Pythagorean triples is formalized with 0 axioms and 0 sorries: exactly one leg is even and the hypotenuse is odd. The proof is fully elementary — not_both_odd is a mod-4 fact about the bare equation (coprimality-free), and not_both_even is the single step invoking gcd(x,y) = 1 — and is decoupled from Euclid's parametrization.",
+    "implications": "Supplies the structural fact that underlies the classification entry pythagorean-triples-oq-06: knowing exactly one leg is even is what licenses writing the even leg as 2mn. The mod-4 technique — abstracting squares to atoms so omega can settle a residue obstruction — is reusable for other quadratic Diophantine parity arguments.",
+    "openQuestions": [
+      {
+        "id": "pythagorean-triples-oq-06-oq-01-oq-01",
+        "question": "Sharpen the even leg: in a primitive triple the even leg is in fact divisible by 4 (since y = 2mn with exactly one of m, n even). Formalize 4 ∣ (the even leg).",
+        "significance": "low"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "extends",
+      "description": "Parent classification entry; this answers its open question by proving the parity dichotomy directly, without the parametrization."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Root Pythagorean-triples entry."
+    }
+  ],
+  "references": [
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "Hardy, Wright",
+      "year": "2008",
+      "venue": "Oxford University Press",
+      "description": "Theorem 225 and surrounding discussion: the parity split of the legs as the first step in classifying primitive Pythagorean triples."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01",
+      "question": "Sharpen the even leg: show the even leg of a primitive triple is divisible by 4.",
+      "significance": "low"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of **pythagorean-triples-oq-06** (Euclid's classification): in a primitive Pythagorean triple `x² + y² = z²` with `gcd(x, y) = 1`, **exactly one leg is even** and the hypotenuse `z` is odd.

The proof is fully elementary and **decoupled from Euclid's parametrization** — it works directly from the defining equation `x*x + y*y = z*z`.

## Results (6 theorems, 129 lines, 0 sorries, 0 axioms)

| Theorem | Statement |
|---------|-----------|
| `not_both_even` | primitive ⟹ ¬(Even x ∧ Even y) — both even forces `2 ∣ gcd(x,y) = 1`. *The only use of coprimality.* |
| `not_both_odd` | any triple ⟹ ¬(Odd x ∧ Odd y) — `odd² + odd² ≡ 2 (mod 4)`, but no square is `≡ 2 (mod 4)`. *Coprimality-free.* |
| `parity_dichotomy` | primitive ⟹ `(Even x ∧ Odd y) ∨ (Odd x ∧ Even y)` |
| `even_left_iff_odd_right` | primitive ⟹ `Even x ↔ Odd y` (sharpest "exactly one" packaging) |
| `hypotenuse_odd` | primitive ⟹ `Odd z` |
| `triple_3_4_5_parity` | `(3,4,5)`: 3 odd, 4 even, hypotenuse 5 odd |

## Key ideas

- **Coprimality is needed exactly once.** Ruling out two odd legs is a fact about the equation alone (true for *every* Pythagorean triple); only ruling out two even legs uses `gcd = 1`.
- **2 is not a quadratic residue mod 4.** This single residue obstruction is the entire content of `not_both_odd`.
- **`omega` settles modular arithmetic via atom abstraction.** Rewriting `z²` as `4c²` or `4(c²+c)+1` and the leg sum as `4k + 2` turns the mod-4 contradiction into a linear one `omega` closes — no `ZMod`, no `decide`, no `native_decide`.

## Verification

`#print axioms` on all six results lists only `[propext, Classical.choice, Quot.sound]` — the standard foundational axioms, which do **not** count as assumptions. **Verified, 0-axiom.** Builds cleanly under `lake env lean` (Lean v4.26.0, Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)