### PR TITLE
research(sylow-theorem-oq-02-oq-01): nilpotent ⟺ every Sylow normal ⟺ every n_p=1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3693,6 +3693,7 @@ import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02
 import Proofs.SylowTheoremOQ02Orbit
+import Proofs.SylowTheoremOQ02OQ01Nilpotent
 import Proofs.SylowTheoremOQ03
 import Proofs.SylowTheoremOQ03OQ02
 import Proofs.SylowTheoremSchurZassenhausOQ03

--- a/proofs/Proofs/SylowTheoremOQ02OQ01Nilpotent.lean
+++ b/proofs/Proofs/SylowTheoremOQ02OQ01Nilpotent.lean
@@ -1,0 +1,95 @@
+/-
+# Nilpotency of a Finite Group via its Sylow Subgroups
+
+OQ-02-OQ-01 follow-up to sylow-theorem (`sylow-theorem-oq-02`).
+
+The parent entry `sylow-theorem-oq-02` enumerated the Sylow p-subgroups via the
+conjugation orbit, obtaining `n_p = [G : N_G(P)]` and the per-prime criterion
+`n_p = 1 ↔ P ◁ G`.  This file lifts that *local* (single prime) picture to a
+*global* structural characterization of the whole group:
+
+  For a finite group G, the following are equivalent:
+    (1) G is nilpotent;
+    (4) every Sylow p-subgroup of G is normal;
+    (★) every Sylow count is one:  n_p = #(Sylow p G) = 1 for all primes p.
+
+Mathlib already provides the five-way TFAE `isNilpotent_of_finite_tfae`
+(nilpotent ⟺ normalizer condition ⟺ all maximal subgroups normal ⟺ all Sylow
+normal ⟺ internal direct product of Sylow subgroups).  Our contribution is to
+
+  * extract the clean two-way headline `nilpotent ⟺ all Sylow normal`, and
+  * fuse it with Sylow *uniqueness* (`Sylow.unique_of_normal` /
+    `Sylow.normal_of_subsingleton`) to obtain the counting form
+    `nilpotent ⟺ ∀ p, n_p = 1`,
+
+which is the bridge back to the parent's `n_p = [G : N_G(P)]`: nilpotency forces
+`N_G(P) = G`, hence index — and therefore the Sylow count — equals one.
+
+## Main Results
+
+- `nilpotent_iff_forall_sylow_normal` : `IsNilpotent G ↔ ∀ p P, (P : Subgroup G).Normal`
+- `sylow_normal_of_nilpotent`         : nilpotent ⇒ every Sylow p-subgroup is normal
+- `nilpotent_iff_forall_card_sylow_eq_one` : `IsNilpotent G ↔ ∀ p, #(Sylow p G) = 1`
+- `normalizer_eq_top_of_nilpotent`    : nilpotent ⇒ `N_G(P) = ⊤` (so `[G : N_G(P)] = 1`)
+
+## Tags
+group-theory, sylow, nilpotent, finite-groups, normalizer
+-/
+
+import Mathlib.GroupTheory.Nilpotent
+import Mathlib.GroupTheory.Sylow
+import Mathlib.Algebra.Group.Subgroup.Basic
+import Mathlib.Tactic
+
+namespace SylowNilpotent
+
+variable {G : Type*} [Group G] [Finite G]
+
+/-- **Headline equivalence.**  A finite group is nilpotent iff *every* Sylow
+p-subgroup (for every prime p) is normal.  This is the `(1) ↔ (4)` slice of
+Mathlib's five-way `isNilpotent_of_finite_tfae`. -/
+theorem nilpotent_iff_forall_sylow_normal :
+    Group.IsNilpotent G ↔
+      ∀ (p : ℕ) (_hp : Fact p.Prime) (P : Sylow p G), (P : Subgroup G).Normal :=
+  (isNilpotent_of_finite_tfae (G := G)).out 0 3
+
+/-- Forward direction, packaged for convenience: in a finite nilpotent group every
+Sylow p-subgroup is normal. -/
+theorem sylow_normal_of_nilpotent (h : Group.IsNilpotent G)
+    (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) : (P : Subgroup G).Normal :=
+  (nilpotent_iff_forall_sylow_normal.mp h) p hp P
+
+/-- In a finite nilpotent group the normalizer of every Sylow p-subgroup is the
+whole group.  Combined with the parent result `n_p = [G : N_G(P)]`, this is the
+reason the Sylow count collapses to one. -/
+theorem normalizer_eq_top_of_nilpotent (h : Group.IsNilpotent G)
+    (p : ℕ) [hp : Fact p.Prime] (P : Sylow p G) :
+    (P : Subgroup G).normalizer = ⊤ :=
+  Subgroup.normalizer_eq_top_iff.mpr (sylow_normal_of_nilpotent h p P)
+
+/-- **Counting characterization.**  A finite group is nilpotent iff every Sylow
+count is one, i.e. for each prime `p` there is a *unique* Sylow p-subgroup.
+
+This is the global counterpart of the parent's per-prime criterion
+`n_p = 1 ↔ P ◁ G`: nilpotency is exactly the statement that *all* of these
+local uniqueness conditions hold simultaneously. -/
+theorem nilpotent_iff_forall_card_sylow_eq_one :
+    Group.IsNilpotent G ↔
+      ∀ (p : ℕ) (_hp : Fact p.Prime), Nat.card (Sylow p G) = 1 := by
+  rw [nilpotent_iff_forall_sylow_normal]
+  constructor
+  · -- all Sylow normal ⇒ each is unique, so the count is one
+    intro h p hp
+    haveI := hp
+    obtain ⟨P⟩ := (Sylow.nonempty : Nonempty (Sylow p G))
+    haveI := Sylow.unique_of_normal P (h p hp P)
+    exact Nat.card_unique
+  · -- count one ⇒ subsingleton ⇒ the (unique) Sylow subgroup is characteristic, hence normal
+    intro h p hp P
+    haveI := hp
+    have hcard : Nat.card (Sylow p G) = 1 := h p hp
+    haveI : Subsingleton (Sylow p G) :=
+      (Nat.card_eq_one_iff_unique.mp hcard).1
+    exact Sylow.normal_of_subsingleton P
+
+end SylowNilpotent

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-sylnil-headline",
+    "proofId": "sylow-theorem-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 56 },
+    "type": "technique",
+    "title": "Extracting a Two-Way Slice from a TFAE",
+    "content": "nilpotent_iff_forall_sylow_normal is the (1) ⟺ (4) slice of Mathlib's five-way isNilpotent_of_finite_tfae, obtained in one line by TFAE.out 0 3. The TFAE lists [IsNilpotent, NormalizerCondition, all maximal subgroups normal, all Sylow normal, internal direct product of Sylow]; .out i j returns the bi-implication between entries i and j, here nilpotency and all-Sylow-normality. The explicit (_hp : Fact p.Prime) binder matches the TFAE's statement verbatim and is definitionally the instance-implicit form.",
+    "mathContext": "$$G \\text{ nilpotent} \\iff \\forall p,\\ P \\in \\mathrm{Syl}_p(G) \\Rightarrow P \\trianglelefteq G.$$",
+    "significance": "central",
+    "relatedConcepts": [
+      "nilpotent group",
+      "Sylow subgroup",
+      "TFAE",
+      "List.TFAE.out"
+    ],
+    "prerequisites": [
+      "Group.IsNilpotent",
+      "isNilpotent_of_finite_tfae"
+    ]
+  },
+  {
+    "id": "ann-sylnil-normalizer",
+    "proofId": "sylow-theorem-oq-02-oq-01",
+    "range": { "startLine": 65, "endLine": 72 },
+    "type": "insight",
+    "title": "Normalizer Collapse Bridges to n_p = [G : N_G(P)]",
+    "content": "normalizer_eq_top_of_nilpotent uses Subgroup.normalizer_eq_top_iff to convert normality of a Sylow subgroup into N_G(P) = ⊤. This is the explicit link to the parent entry: the parent proved n_p = [G : N_G(P)], so a normalizer equal to the whole group forces the index — and hence the Sylow count — to be one. Nilpotency is precisely the regime in which every Sylow subgroup self-normalizes maximally.",
+    "mathContext": "$$N_G(P) = G \\ \\Rightarrow\\ n_p = [G : N_G(P)] = 1.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "normalizer",
+      "Sylow counting",
+      "index of a subgroup"
+    ],
+    "prerequisites": [
+      "Subgroup.normalizer_eq_top_iff",
+      "n_p = [G : N_G(P)] (parent entry)"
+    ]
+  },
+  {
+    "id": "ann-sylnil-counting",
+    "proofId": "sylow-theorem-oq-02-oq-01",
+    "range": { "startLine": 76, "endLine": 94 },
+    "type": "technique",
+    "title": "Normality ⟺ Uniqueness Turns Structure into Counting",
+    "content": "nilpotent_iff_forall_card_sylow_eq_one fuses the headline with the fact that a Sylow p-subgroup is normal iff it is the unique one. Forward: from normality, Sylow.unique_of_normal yields Unique (Sylow p G), so Nat.card_unique gives n_p = 1. Backward: from n_p = 1, Nat.card_eq_one_iff_unique recovers Subsingleton (Sylow p G), and Sylow.normal_of_subsingleton (via characteristicity) returns normality. Quantifying over all primes converts 'all Sylow normal' into the arithmetic statement 'all n_p = 1', the global counterpart of the parent's per-prime n_p = 1 ⟺ P ◁ G.",
+    "mathContext": "$$G \\text{ nilpotent} \\iff \\forall p,\\ n_p = \\#\\,\\mathrm{Syl}_p(G) = 1.$$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Sylow uniqueness",
+      "subsingleton",
+      "Nat.card",
+      "Sylow counting number"
+    ],
+    "prerequisites": [
+      "Sylow.unique_of_normal",
+      "Sylow.normal_of_subsingleton",
+      "Nat.card_unique",
+      "Nat.card_eq_one_iff_unique"
+    ]
+  }
+]

--- a/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "sylow-theorem-oq-02-oq-01",
+  "title": "Nilpotency of a Finite Group via its Sylow Subgroups: nilpotent ⟺ every n_p = 1",
+  "slug": "sylow-theorem-oq-02-oq-01",
+  "description": "Lifts the parent entry's per-prime Sylow enumeration (n_p = [G : N_G(P)], with n_p = 1 ⟺ P ◁ G) to a global structural characterization of the whole finite group. A finite group G is nilpotent iff every Sylow p-subgroup is normal, iff every Sylow count is one (n_p = #(Sylow p G) = 1 for all primes p). The headline two-way equivalence is the (1) ⟺ (4) slice of Mathlib's five-way isNilpotent_of_finite_tfae; the counting form is obtained by fusing it with Sylow uniqueness (Sylow.unique_of_normal forward, Sylow.normal_of_subsingleton backward), giving the bridge back to the parent's n_p = [G : N_G(P)] — nilpotency forces N_G(P) = G, so the Sylow count collapses to one.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylowTheoremOQ02OQ01Nilpotent.lean",
+    "tags": [
+      "group-theory",
+      "sylow",
+      "nilpotent",
+      "finite-groups",
+      "normalizer",
+      "sylow-counting",
+      "structure-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 95,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond a finite group structure. The whole file assumes only [Group G] [Finite G]; no axioms, no sorries. Builds against Mathlib 4.26.0. The headline equivalence quotes Mathlib's isNilpotent_of_finite_tfae (itself 0-axiom); the counting characterization and normalizer corollary are derived here.",
+    "originalContributions": [
+      "nilpotent_iff_forall_sylow_normal: the clean two-way headline IsNilpotent G ↔ (∀ p [Fact p.Prime] (P : Sylow p G), (P : Subgroup G).Normal), extracted as the (1) ↔ (4) slice of Mathlib's five-way isNilpotent_of_finite_tfae via TFAE.out 0 3.",
+      "nilpotent_iff_forall_card_sylow_eq_one: the global counting characterization IsNilpotent G ↔ (∀ p [Fact p.Prime], Nat.card (Sylow p G) = 1). Forward: all-Sylow-normal feeds Sylow.unique_of_normal to get Unique (Sylow p G), hence Nat.card = 1 (Nat.card_unique). Backward: count one ⇒ Subsingleton (Nat.card_eq_one_iff_unique) ⇒ Sylow.normal_of_subsingleton ⇒ all normal. This is the global counterpart of the parent's per-prime n_p = 1 ⟺ P ◁ G — nilpotency is exactly all local uniqueness conditions holding simultaneously.",
+      "normalizer_eq_top_of_nilpotent: in a finite nilpotent group N_G(P) = ⊤ for every Sylow p-subgroup P (Subgroup.normalizer_eq_top_iff applied to the forward direction). This is the explicit bridge to the parent's n_p = [G : N_G(P)]: the normalizer being everything is exactly why the index — and therefore the Sylow count — equals one.",
+      "sylow_normal_of_nilpotent: the forward direction packaged with instance-implicit Fact p.Prime for direct downstream use."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "isNilpotent_of_finite_tfae",
+        "description": "the five-way TFAE for a finite group [IsNilpotent, NormalizerCondition, all maximal subgroups normal, all Sylow subgroups normal, internal direct product of Sylow subgroups]; TFAE.out 0 3 supplies the headline nilpotent ⟺ all-Sylow-normal equivalence",
+        "module": "Mathlib.GroupTheory.Nilpotent"
+      },
+      {
+        "theorem": "Sylow.unique_of_normal",
+        "description": "a normal Sylow p-subgroup is the only one: P.Normal → Unique (Sylow p G); the forward step of the counting characterization (uniqueness ⇒ Nat.card = 1)",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.normal_of_subsingleton",
+        "description": "if Sylow p G is a subsingleton then the (unique) Sylow p-subgroup is normal (via characteristic_of_subsingleton); the backward step of the counting characterization",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Nat.card_unique",
+        "description": "Nat.card α = 1 given [Nonempty α] [Subsingleton α]; converts Unique (Sylow p G) into the count n_p = 1",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.card_eq_one_iff_unique",
+        "description": "Nat.card α = 1 ↔ Subsingleton α ∧ Nonempty α; recovers Subsingleton (Sylow p G) from the count-one hypothesis in the backward direction",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Subgroup.normalizer_eq_top_iff",
+        "description": "H.normalizer = ⊤ ↔ H.Normal; turns Sylow normality into N_G(P) = ⊤, the link to the parent's normalizer-index enumeration",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "That a finite group is nilpotent precisely when each of its Sylow subgroups is normal — equivalently when it is the (internal) direct product of its Sylow subgroups — is one of the cornerstone structure theorems of finite group theory (Hall, Theory of Groups, Ch. 10; Isaacs, Finite Group Theory, Thm 1.26). It packages nilpotency, an a-priori recursive condition on the lower/upper central series, into a single statement about prime-local structure: the global group is built without 'interference' between distinct primes, exactly when each prime's Sylow subgroup sits normally. The Sylow counting numbers n_p, governed by Sylow III (n_p ≡ 1 mod p, n_p ∣ [G:P]) and by the parent entry's orbit formula n_p = [G : N_G(P)], all collapse to 1 in this regime.",
+    "problemStatement": "For a finite group G, prove the equivalence of: (1) G is nilpotent; (2) every Sylow p-subgroup of G is normal; (3) every Sylow count is one, n_p = #(Sylow p G) = 1 for all primes p. Connect (2)/(3) back to the parent entry's enumeration n_p = [G : N_G(P)] by showing nilpotency forces N_G(P) = G.",
+    "text": "The parent entry showed, prime by prime, that n_p = [G : N_G(P)] and hence n_p = 1 ⟺ P is normal. The present entry asks what it means for this local uniqueness to hold at every prime at once. The answer is nilpotency. Mathlib already proves the five-way equivalence isNilpotent_of_finite_tfae; the headline here is its nilpotent ⟺ all-Sylow-normal slice. The genuinely new content is the counting form: normality of a Sylow subgroup is equivalent to its uniqueness (Sylow.unique_of_normal one way, Sylow.normal_of_subsingleton the other), so 'all Sylow normal' and 'all n_p = 1' are the same condition, and either characterizes nilpotency. Finally N_G(P) = ⊤ for every Sylow subgroup of a nilpotent group exhibits, through the parent's orbit formula, exactly why the counts are one.",
+    "proofStrategy": "nilpotent_iff_forall_sylow_normal := (isNilpotent_of_finite_tfae (G := G)).out 0 3. nilpotent_iff_forall_card_sylow_eq_one: rewrite with the headline, then (→) pick any P (Sylow.nonempty), get Unique (Sylow p G) from Sylow.unique_of_normal, conclude Nat.card = 1 by Nat.card_unique; (←) from Nat.card = 1 get Subsingleton via Nat.card_eq_one_iff_unique, conclude normality by Sylow.normal_of_subsingleton. normalizer_eq_top_of_nilpotent := Subgroup.normalizer_eq_top_iff.mpr applied to the forward direction.",
+    "keyInsights": [
+      "**Normality and uniqueness coincide for Sylow subgroups.** A Sylow p-subgroup is normal iff it is the only Sylow p-subgroup; this two-line bi-implication (Sylow.unique_of_normal / Sylow.normal_of_subsingleton) is what turns the structural condition 'all Sylow normal' into the arithmetic condition 'all n_p = 1'.",
+      "**Nilpotency = simultaneous prime-local uniqueness.** The parent's per-prime criterion n_p = 1 ⟺ P ◁ G becomes a global theorem once quantified over all primes: a finite group is nilpotent exactly when every prime contributes a single Sylow subgroup.",
+      "**The normalizer collapses.** Nilpotency forces N_G(P) = ⊤ for every Sylow P, and through the parent's orbit formula n_p = [G : N_G(P)] this is precisely the reason every Sylow count equals one — making the bridge between the two entries explicit rather than incidental.",
+      "**Leverage over re-proof.** Mathlib's isNilpotent_of_finite_tfae already carries the hard direct-product construction; the contribution is the clean extraction plus the uniqueness/counting reformulation and the normalizer bridge, none of which appears in the TFAE itself."
+    ],
+    "prerequisites": [
+      "Sylow's theorems and the type Sylow p G of Sylow p-subgroups (Mathlib.GroupTheory.Sylow)",
+      "The notion of a nilpotent group (Group.IsNilpotent) and Mathlib's finite-group TFAE characterization",
+      "The parent entry's orbit enumeration n_p = [G : N_G(P)] and its per-prime corollary n_p = 1 ⟺ P ◁ G",
+      "Cardinality of a type via Nat.card and its value 1 for Unique / subsingleton-and-nonempty types"
+    ]
+  },
+  "sections": [
+    {
+      "id": "headline",
+      "title": "Nilpotent ⟺ All Sylow Normal",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "nilpotent_iff_forall_sylow_normal extracts IsNilpotent G ↔ (∀ p P, (P : Subgroup G).Normal) as the (1) ↔ (4) slice of isNilpotent_of_finite_tfae; sylow_normal_of_nilpotent packages the forward direction.",
+      "mathContext": "The headline structural equivalence, quoting Mathlib's five-way TFAE."
+    },
+    {
+      "id": "normalizer",
+      "title": "Normalizer Collapse",
+      "startLine": 64,
+      "endLine": 72,
+      "summary": "normalizer_eq_top_of_nilpotent: in a finite nilpotent group N_G(P) = ⊤ for every Sylow p-subgroup, the bridge to the parent's n_p = [G : N_G(P)].",
+      "mathContext": "Why the Sylow counts are one: the normalizer is the whole group, so the index is one."
+    },
+    {
+      "id": "counting",
+      "title": "Counting Characterization",
+      "startLine": 73,
+      "endLine": 95,
+      "summary": "nilpotent_iff_forall_card_sylow_eq_one: IsNilpotent G ↔ (∀ p, Nat.card (Sylow p G) = 1), fusing the headline with Sylow uniqueness (unique_of_normal forward, normal_of_subsingleton backward).",
+      "mathContext": "The global counterpart of the parent's per-prime n_p = 1 ⟺ P ◁ G."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof that a finite group is nilpotent iff every Sylow subgroup is normal iff every Sylow count n_p equals one, together with the normalizer-collapse N_G(P) = ⊤ that connects the result to the parent entry's enumeration n_p = [G : N_G(P)]. The file is 0-axiom, 0-sorry against Mathlib 4.26.0.",
+    "implications": "Completes the local-to-global arc of the Sylow strand: the parent entry counts Sylow subgroups one prime at a time (n_p = [G : N_G(P)]); this entry characterizes the groups for which every such count is minimal, identifying that class as exactly the nilpotent groups. The remaining classical refinements — that such groups are the internal direct product of their Sylow subgroups (TFAE item 5), and the p-group / Lagrange consequences of unique Sylow subgroups — are each one short step from the same equivalence.",
+    "openQuestions": [
+      "Specialize to a fixed prime power: for a finite group whose order is p^a · m with p ∤ m, derive |G| = |P| · ∏_{q≠p} |Q_q| in the nilpotent case directly from the direct-product decomposition (TFAE item 5), i.e. recover the order factorization from the Sylow product.",
+      "Prove the contrapositive sharpening: if some n_p > 1 then G is non-nilpotent and exhibit the smallest witness (S_3 with n_3 = 1 but n_2 = 3) as a decidable example, linking the abstract counting characterization to a concrete computation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "sylow-theorem-oq-02",
+      "relation": "Parent entry — enumerates the Sylow p-subgroups via the conjugation orbit, proving n_p = [G : N_G(P)] and the per-prime criterion n_p = 1 ⟺ P ◁ G. This entry quantifies that criterion over all primes and identifies the resulting class as the nilpotent groups, with normalizer_eq_top_of_nilpotent making the n_p = [G : N_G(P)] bridge explicit."
+    },
+    {
+      "slug": "sylow-theorem",
+      "relation": "Root entry — Sylow's existence, conjugacy, and counting theorems, the foundation on which both the parent enumeration and this nilpotency characterization rest."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Isaacs, I.M."
+      ],
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "American Mathematical Society, GSM 92",
+      "note": "Theorem 1.26: a finite group is nilpotent iff every Sylow subgroup is normal iff it is the direct product of its Sylow subgroups"
+    },
+    {
+      "authors": [
+        "Hall, M."
+      ],
+      "title": "The Theory of Groups",
+      "year": "1959",
+      "venue": "Macmillan",
+      "note": "Chapter 10: nilpotent groups and the normality of Sylow subgroups"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Nilpotent",
+      "Mathlib.GroupTheory.Sylow",
+      "Mathlib.Algebra.Group.Subgroup.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "SylowNilpotent",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SylowTheoremOQ02OQ01Nilpotent.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **sylow-theorem-oq-02** (orbit enumeration `n_p = [G : N_G(P)]`). Lifts that entry's *per-prime* Sylow criterion to a *global* structure theorem for finite groups:

> A finite group `G` is nilpotent **⟺** every Sylow p-subgroup is normal **⟺** every Sylow count is one (`n_p = #(Sylow p G) = 1` for all primes `p`).

## What's new

Mathlib already proves the five-way `isNilpotent_of_finite_tfae`. The contribution here is:

- **`nilpotent_iff_forall_sylow_normal`** — the clean `(1) ⟺ (4)` slice (`TFAE.out 0 3`).
- **`nilpotent_iff_forall_card_sylow_eq_one`** — the *counting* characterization, obtained by fusing the headline with Sylow uniqueness: forward via `Sylow.unique_of_normal` (normal ⇒ `Unique` ⇒ `Nat.card = 1`), backward via `Sylow.normal_of_subsingleton` (`Nat.card = 1` ⇒ `Subsingleton` ⇒ normal). This is the global counterpart of the parent's per-prime `n_p = 1 ⟺ P ◁ G`.
- **`normalizer_eq_top_of_nilpotent`** — `N_G(P) = ⊤` for every Sylow `P`, the explicit bridge to the parent's `n_p = [G : N_G(P)]`: the normalizer being everything is exactly why the count collapses to one.

## Verification

- **4 theorems, 95 lines, 0 sorries, 0 axioms** (`#print axioms` lists only `propext` / `Classical.choice` / `Quot.sound`).
- Compiles against Mathlib 4.26.0 (`lake env lean`, exit 0).
- Registered in `proofs/Proofs.lean`; gallery `meta.json` + `annotations.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)