### PR TITLE
research(pythagorean-triples-oq-06-oq-01): parity dichotomy + mod-4 refinements [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3453,6 +3453,7 @@ import Proofs.PythagoreanTriplesOQ03
 import Proofs.PythagoreanTriplesOQ04
 import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ06
+import Proofs.PythagoreanTriplesOQ06OQ01
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
 import Proofs.PythagoreanTriplesOQ09

--- a/proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean
@@ -1,0 +1,128 @@
+/-
+  # Parity dichotomy and the mod-4 refinements for primitive Pythagorean triples
+  # (pythagorean-triples-oq-06-oq-01)
+
+  ## The Open Question
+
+  Off the verified classification entry `pythagorean-triples-oq-06`, the seeker asked
+  to "use the classification to prove exactly one leg is even." Mathlib already records
+  the bare leg-parity dichotomy as `PythagoreanTriple.even_odd_of_coprime`
+  (one leg is even and the other odd). This file restates that fact in the idiomatic
+  `Even`/`Odd` form and then proves the three classical *refinements* that go strictly
+  beyond it and are **not** in Mathlib:
+
+  * **The hypotenuse is odd.** Pure parity: `z² = x² + y²` with one leg even and one
+    odd forces `z²` — hence `z` — odd.
+  * **The even leg is divisible by 4.** From the Euclid parametrization `y = 2mn` with
+    `m, n` of opposite parity, one of `m, n` is even, so `2mn ≡ 0 (mod 4)`.
+  * **The hypotenuse is `≡ 1 (mod 4)`.** From `z = m² + n²` with `m, n` of opposite
+    parity, `m² + n² ≡ 0 + 1 (mod 4)`.
+
+  The last two are the standard "next facts" after the parity dichotomy and are the
+  genuine mathematical content here; the first is a short parity supplement. Everything
+  is built on top of Mathlib's `even_odd_of_coprime` and `coprime_classification'`.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.Tactic
+
+open PythagoreanTriple
+
+namespace PythTriplesParity
+
+/-- **Parity dichotomy (idiomatic form).** In a primitive Pythagorean triple exactly
+    one leg is even and the other is odd. This is `even_odd_of_coprime` restated with
+    the `Even`/`Odd` predicates instead of the raw `% 2` residues. -/
+theorem one_leg_even {x y z : ℤ} (h : PythagoreanTriple x y z) (hco : Int.gcd x y = 1) :
+    (Even x ∧ Odd y) ∨ (Odd x ∧ Even y) := by
+  rcases h.even_odd_of_coprime hco with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · exact Or.inl ⟨Int.even_iff.mpr hx, Int.odd_iff.mpr hy⟩
+  · exact Or.inr ⟨Int.odd_iff.mpr hx, Int.even_iff.mpr hy⟩
+
+/-- **The hypotenuse is odd.** Since one leg is even and the other odd, `x² + y²` is
+    odd, so `z²` and therefore `z` are odd. Needs only the parity dichotomy, no
+    parametrization. -/
+theorem hyp_odd {x y z : ℤ} (h : PythagoreanTriple x y z) (hco : Int.gcd x y = 1) :
+    z % 2 = 1 := by
+  have heq : x * x + y * y = z * z := h
+  have key : (z * z) % 2 = 1 := by
+    rw [← heq]
+    rcases h.even_odd_of_coprime hco with ⟨hx, hy⟩ | ⟨hx, hy⟩ <;>
+      simp [Int.add_emod, Int.mul_emod, hx, hy]
+  rcases Int.emod_two_eq_zero_or_one z with hz | hz
+  · exfalso
+    rw [Int.mul_emod, hz] at key
+    simp at key
+  · exact hz
+
+/-- **The even leg is divisible by 4.** Taking the canonically oriented triple
+    (`x` the odd leg, `z > 0`), the Euclid parametrization gives `y = 2mn` with `m, n`
+    of opposite parity. One of `m, n` is even, so `y = 2mn` is a multiple of `4`. -/
+theorem even_leg_div_four {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hz : 0 < z) :
+    (4 : ℤ) ∣ y := by
+  obtain ⟨m, n, _hx, hy, _hzeq, _hmn, hpar, _hm⟩ := h.coprime_classification' hco hodd hz
+  subst hy
+  rcases hpar with ⟨hme, _hno⟩ | ⟨_hmo, hne⟩
+  · obtain ⟨k, rfl⟩ := Int.dvd_of_emod_eq_zero hme
+    exact ⟨k * n, by ring⟩
+  · obtain ⟨k, rfl⟩ := Int.dvd_of_emod_eq_zero hne
+    exact ⟨m * k, by ring⟩
+
+/-- **The hypotenuse is `≡ 1 (mod 4)`.** From `z = m² + n²` with `m, n` of opposite
+    parity: the even square contributes `0` and the odd square contributes `1` modulo
+    `4`, so `z ≡ 1 (mod 4)`. -/
+theorem hyp_one_mod_four {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hz : 0 < z) :
+    z % 4 = 1 := by
+  obtain ⟨m, n, _hx, _hy, hzeq, _hmn, hpar, _hm⟩ := h.coprime_classification' hco hodd hz
+  subst hzeq
+  rcases hpar with ⟨hme, hno⟩ | ⟨hmo, hne⟩
+  · -- m even, n odd
+    obtain ⟨a, rfl⟩ := Int.dvd_of_emod_eq_zero hme
+    obtain ⟨b, rfl⟩ : ∃ b, n = 2 * b + 1 := ⟨n / 2, by omega⟩
+    have : (2 * a) ^ 2 + (2 * b + 1) ^ 2 = 4 * (a ^ 2 + b ^ 2 + b) + 1 := by ring
+    rw [this]; omega
+  · -- m odd, n even
+    obtain ⟨a, rfl⟩ := Int.dvd_of_emod_eq_zero hne
+    obtain ⟨b, rfl⟩ : ∃ b, m = 2 * b + 1 := ⟨m / 2, by omega⟩
+    have : (2 * b + 1) ^ 2 + (2 * a) ^ 2 = 4 * (a ^ 2 + b ^ 2 + b) + 1 := by ring
+    rw [this]; omega
+
+/-- Concrete instance `(3, 4, 5)`: the even leg `4` is divisible by `4` and the
+    hypotenuse `5 ≡ 1 (mod 4)`. -/
+theorem example_3_4_5 :
+    (4 : ℤ) ∣ 4 ∧ (5 : ℤ) % 4 = 1 := by
+  refine ⟨⟨1, by norm_num⟩, by decide⟩
+
+/-- Concrete instance `(8, 15, 17)` (odd leg `15`): even leg `8` divisible by `4`,
+    hypotenuse `17 ≡ 1 (mod 4)`, obtained from the general theorems. -/
+theorem example_8_15_17 :
+    (4 : ℤ) ∣ 8 ∧ (17 : ℤ) % 4 = 1 := by
+  have h : PythagoreanTriple 15 8 17 := by unfold PythagoreanTriple; norm_num
+  have hco : Int.gcd 15 8 = 1 := by decide
+  exact ⟨even_leg_div_four h hco (by decide) (by norm_num),
+         hyp_one_mod_four h hco (by decide) (by norm_num)⟩
+
+end PythTriplesParity
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `one_leg_even`       | Exactly one leg even (Even/Odd form of `even_odd_of_coprime`) |
+  | `hyp_odd`            | The hypotenuse `z` is odd |
+  | `even_leg_div_four`  | The even leg is divisible by 4 |
+  | `hyp_one_mod_four`   | The hypotenuse `z ≡ 1 (mod 4)` |
+  | `example_8_15_17`    | The two refinements instantiated at (15, 8, 17) |
+
+  The leg dichotomy is Mathlib's `even_odd_of_coprime`; the three refinements
+  (`hyp_odd`, `even_leg_div_four`, `hyp_one_mod_four`) are the new content and are not
+  available in Mathlib. They rest on `coprime_classification'` (Euclid parametrization).
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Parity Dichotomy and the mod-4 Refinements",
+    "content": "In a primitive Pythagorean triple (gcd(x,y) = 1) exactly one leg is even and the other odd. Mathlib already proves this as PythagoreanTriple.even_odd_of_coprime — if both legs were odd then x² + y² ≡ 2 (mod 4), which is never a square. This file restates that dichotomy in idiomatic Even/Odd form and then proves the three classical sharpenings that go strictly beyond it and are NOT in Mathlib: the hypotenuse z is odd; the even leg is divisible by 4; and the hypotenuse satisfies z ≡ 1 (mod 4). The latter two read structural information off the Euclid parametrization y = 2mn, z = m² + n² with m, n of opposite parity.",
+    "mathContext": "Even leg $\\equiv 0\\pmod 4$, hypotenuse $z\\equiv 1\\pmod 4$, both odd-square + even-square facts.",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triples", "parity", "modular arithmetic", "sums of two squares"],
+    "prerequisites": ["number theory", "coprimality", "parity"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 35, "endLine": 42 },
+    "type": "theorem",
+    "title": "one_leg_even: The Parity Dichotomy in Even/Odd Form",
+    "content": "one_leg_even: in a primitive triple, (Even x ∧ Odd y) ∨ (Odd x ∧ Even y). This is Mathlib's even_odd_of_coprime — stated there with the raw residues x % 2, y % 2 — repackaged through Int.even_iff (Even n ↔ n % 2 = 0) and Int.odd_iff (Odd n ↔ n % 2 = 1) into the predicate form most callers want. It records exactly one leg is even; the next three theorems sharpen what that even leg and the hypotenuse look like modulo 4.",
+    "mathContext": "$(\\text{Even }x \\wedge \\text{Odd }y) \\vee (\\text{Odd }x \\wedge \\text{Even }y)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["PythagoreanTriple.even_odd_of_coprime", "Int.even_iff", "Int.odd_iff"],
+    "prerequisites": ["parity", "primitivity"]
+  },
+  {
+    "id": "ann-hyp-odd",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 44, "endLine": 58 },
+    "type": "theorem",
+    "title": "hyp_odd: The Hypotenuse is Odd",
+    "content": "hyp_odd: the hypotenuse z of a primitive triple is odd (z % 2 = 1). Pure parity, no parametrization: from z² = x² + y² with one leg even and one odd, the right side is odd, so z² is odd modulo 2 (computed via Int.add_emod and Int.mul_emod on the two parity cases). A z even would force z² even, contradiction — so z is odd. This keeps the result independent of the heavier classification machinery used by the mod-4 refinements below.",
+    "mathContext": "$z^2 = x^2+y^2$ odd $\\Rightarrow z$ odd.",
+    "significance": "key",
+    "relatedConcepts": ["Int.add_emod", "Int.mul_emod", "parity of squares"],
+    "prerequisites": ["modular arithmetic", "Pythagorean triples"]
+  },
+  {
+    "id": "ann-even-leg",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "theorem",
+    "title": "even_leg_div_four: The Even Leg is a Multiple of 4",
+    "content": "even_leg_div_four: for a canonically oriented primitive triple (x odd, z > 0) the even leg y is divisible by 4. This genuinely uses the Euclid parametrization (Mathlib's coprime_classification'): y = 2mn with m, n coprime of OPPOSITE parity, so one of m, n is even; writing that variable as 2k gives y = 2·(2k)·(other) = 4·(k·other). Note that x² + y² = z² alone only yields 2 ∣ y (the even leg's square is ≡ 0 mod 4); upgrading to 4 ∣ y is a parametrization fact, not a parity fact.",
+    "mathContext": "$y = 2mn$, one of $m,n$ even $\\Rightarrow 4 \\mid y$.",
+    "significance": "key",
+    "relatedConcepts": ["PythagoreanTriple.coprime_classification'", "Euclid parametrization", "Int.dvd_of_emod_eq_zero"],
+    "prerequisites": ["Euclid parametrization", "divisibility", "parity"]
+  },
+  {
+    "id": "ann-hyp-mod4",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 74, "endLine": 92 },
+    "type": "theorem",
+    "title": "hyp_one_mod_four: The Hypotenuse is ≡ 1 (mod 4)",
+    "content": "hyp_one_mod_four: for a canonically oriented primitive triple the hypotenuse satisfies z ≡ 1 (mod 4). From z = m² + n² (coprime_classification') with m, n of opposite parity, write the even variable as 2a and the odd as 2b+1; then z = (2a)² + (2b+1)² = 4(a² + b² + b) + 1, which omega reduces to residue 1 mod 4. Mathematically this says a primitive hypotenuse is a sum of two coprime squares of opposite parity — the entry point to factoring z in the Gaussian integers ℤ[i], where z = m² + n² is a norm.",
+    "mathContext": "$z = (2a)^2 + (2b+1)^2 = 4(a^2+b^2+b)+1 \\equiv 1\\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["coprime_classification'", "sums of two squares", "Gaussian integers", "omega"],
+    "prerequisites": ["Euclid parametrization", "modular arithmetic", "parity of squares"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "pythagorean-triples-oq-06-oq-01",
+    "range": { "startLine": 94, "endLine": 107 },
+    "type": "context",
+    "title": "example_3_4_5 / example_8_15_17: Concrete Instances",
+    "content": "example_3_4_5 records the refinements at the base triple (3,4,5): 4 ∣ 4 and 5 ≡ 1 (mod 4). example_8_15_17 applies the GENERAL theorems even_leg_div_four and hyp_one_mod_four to the non-base triple (15, 8, 17) — with x = 15 the odd leg, y = 8 the even leg, z = 17 — obtaining 4 ∣ 8 and 17 ≡ 1 (mod 4). The second example exercises the abstract machinery rather than just asserting a numeric fact, confirming the hypotheses (15 odd, gcd(15,8)=1, 17 > 0) feed the classification correctly.",
+    "mathContext": "$(15,8,17)$: $4 \\mid 8$, $17 \\equiv 1 \\pmod 4$.",
+    "significance": "context",
+    "relatedConcepts": ["3-4-5 triple", "8-15-17 triple", "decide"],
+    "prerequisites": ["Pythagorean triples"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq06Oq01Data: ProofData = {
+  proof: pythagoreanTriplesOq06Oq01Proof,
+  annotations: pythagoreanTriplesOq06Oq01Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "pythagorean-triples-oq-06-oq-01",
+  "title": "Parity dichotomy and mod-4 refinements for primitive Pythagorean triples",
+  "slug": "pythagorean-triples-oq-06-oq-01",
+  "description": "Answers the open question off the verified classification entry pythagorean-triples-oq-06. Mathlib already records the bare leg-parity dichotomy (one leg even, one odd) as PythagoreanTriple.even_odd_of_coprime; this entry restates it in idiomatic Even/Odd form and then proves the three classical refinements that go strictly beyond it and are not in Mathlib: the hypotenuse z is odd, the even leg is divisible by 4, and the hypotenuse satisfies z ≡ 1 (mod 4). The first is a short parity argument from z² = x² + y²; the latter two read off the Euclid parametrization y = 2mn, z = m² + n² with m, n of opposite parity. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ06OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "pythagorean-triples",
+      "parity",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 128,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.even_odd_of_coprime",
+        "description": "The bare leg-parity dichotomy: in a primitive triple one of x, y is even and the other odd (stated via % 2 residues)",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "PythagoreanTriple.coprime_classification'",
+        "description": "The sharpened Euclid parametrization (x odd, z > 0): x = m²-n², y = 2mn, z = m²+n² with m, n coprime of opposite parity — supplies m, n for the mod-4 refinements",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      }
+    ],
+    "originalContributions": [
+      "one_leg_even: the leg-parity dichotomy restated idiomatically as (Even x ∧ Odd y) ∨ (Odd x ∧ Even y), bridging Mathlib's % 2 form to the Even/Odd predicates",
+      "hyp_odd: the hypotenuse z is odd — a pure parity supplement (z² = x² + y² is odd, so z is) needing no parametrization, not present in Mathlib",
+      "even_leg_div_four: the even leg is divisible by 4 — from y = 2mn with one of m, n even, so 2mn ≡ 0 (mod 4); the standard refinement beyond bare parity",
+      "hyp_one_mod_four: the hypotenuse satisfies z ≡ 1 (mod 4) — from z = m² + n² with m, n of opposite parity, so m² + n² ≡ 0 + 1 (mod 4)",
+      "example_8_15_17: the two refinements instantiated at the non-trivial triple (15, 8, 17), exercising the general theorems rather than the base case"
+    ],
+    "prerequisites": [
+      "Pythagorean triples and primitivity (gcd(x,y) = 1)",
+      "Mathlib's PythagoreanTriple structure, even_odd_of_coprime and coprime_classification'",
+      "Modular arithmetic (residues mod 2 and mod 4) and parity of squares"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.PythagoreanTriples",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythTriplesParity",
+    "path": "Proofs/PythagoreanTriplesOQ06OQ01.lean",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "After Euclid's parametrization of Pythagorean triples, the first structural facts one proves are parity facts. Mathlib's even_odd_of_coprime captures the most basic one — exactly one leg is even — using a clean mod-4 contradiction (if both legs were odd, x² + y² ≡ 2 (mod 4), which is never a square). The classical number-theory texts (Hardy–Wright, Sierpiński) immediately sharpen this: the even leg is in fact a multiple of 4, and the hypotenuse is ≡ 1 (mod 4). These mod-4 refinements are what make Pythagorean triples behave well in descent arguments and in the arithmetic of Gaussian integers, where z = m² + n² is a norm.",
+    "problemStatement": "Off the verified classification pythagorean-triples-oq-06, prove the parity dichotomy and its sharpenings: exactly one leg of a primitive triple is even, the hypotenuse is odd, the even leg is divisible by 4, and the hypotenuse is ≡ 1 (mod 4) — with 0 sorries and 0 axioms.",
+    "text": "In a primitive Pythagorean triple exactly one leg is even; moreover the hypotenuse is odd, the even leg is a multiple of 4, and the hypotenuse is ≡ 1 (mod 4).",
+    "proofStrategy": "Six results layered on Mathlib. (1) one_leg_even repackages even_odd_of_coprime into the Even/Odd predicates via Int.even_iff / Int.odd_iff. (2) hyp_odd is pure parity: z² = x² + y² with one leg even and one odd is odd, so z is odd — computed by reducing both sides mod 2 (Int.add_emod, Int.mul_emod) and ruling out z even. (3) even_leg_div_four and (4) hyp_one_mod_four invoke coprime_classification' to get the Euclid pair (m, n) of opposite parity; the even leg y = 2mn has one of m, n even, hence 4 ∣ y, and z = m² + n² with opposite parity gives, after writing the even variable as 2a and the odd as 2b+1, z = 4·(…) + 1 closed by omega. (5)–(6) instantiate the refinements concretely at (3,4,5) and at the non-base triple (15, 8, 17).",
+    "keyInsights": [
+      "**Bare parity is already in Mathlib; the content is the sharpenings.** even_odd_of_coprime gives one-leg-even for free, so the genuine new results are 4 ∣ (even leg) and z ≡ 1 (mod 4) — facts Mathlib does not record.",
+      "**The hypotenuse being odd needs no parametrization.** It is forced by parity alone: an even square plus an odd square is odd, so z² and hence z is odd. This keeps hyp_odd independent of the (heavier) classification machinery.",
+      "**Divisibility of the even leg by 4 is a parametrization fact, not a parity fact.** From x² + y² = z² alone one only gets that the even leg's square is ≡ 0 (mod 4) (i.e. the leg is even); upgrading to 4 ∣ y genuinely uses y = 2mn with m, n of opposite parity, so one factor is even.",
+      "**z ≡ 1 (mod 4) is the Gaussian-integer shadow.** Writing the even Euclid variable as 2a and the odd as 2b+1 gives z = m² + n² = 4(a² + b² + b) + 1; this is the statement that a primitive hypotenuse is a sum of two coprime squares of opposite parity, the entry point to factoring z in ℤ[i].",
+      "**omega finishes the mod-4 computation.** Once the squares are expanded to 4·(integer) + 1 by ring, the residue is linear and omega discharges it — no manual modular bookkeeping."
+    ],
+    "prerequisites": [
+      "Pythagorean triples x² + y² = z² and primitivity",
+      "Euclid's parametrization m² - n², 2mn, m² + n²",
+      "Residues mod 2 and mod 4; parity of integer squares",
+      "Sums of two squares and norms in ℤ[i] (context for z ≡ 1 mod 4)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "States the open question and the split between the bare dichotomy (already in Mathlib) and the three new mod-4 refinements; imports Mathlib's PythagoreanTriples.",
+      "mathContext": "Parity dichotomy and the mod-4 sharpenings for primitive triples."
+    },
+    {
+      "id": "dichotomy",
+      "title": "one_leg_even — the parity dichotomy in Even/Odd form",
+      "startLine": 35,
+      "endLine": 42,
+      "summary": "Restates even_odd_of_coprime with the Even/Odd predicates, via Int.even_iff and Int.odd_iff.",
+      "mathContext": "Exactly one leg even and the other odd."
+    },
+    {
+      "id": "hyp-odd",
+      "title": "hyp_odd — the hypotenuse is odd",
+      "startLine": 44,
+      "endLine": 58,
+      "summary": "Pure parity argument: z² = x² + y² is odd (one leg even, one odd), so z is odd; rules out z even by reducing mod 2.",
+      "mathContext": "z odd, with no use of the Euclid parametrization."
+    },
+    {
+      "id": "even-leg",
+      "title": "even_leg_div_four — the even leg is a multiple of 4",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "From coprime_classification' the even leg is y = 2mn with one of m, n even, so 4 ∣ y.",
+      "mathContext": "4 ∣ (even leg) — beyond the parity fact 2 ∣ (even leg)."
+    },
+    {
+      "id": "hyp-mod4",
+      "title": "hyp_one_mod_four — the hypotenuse is ≡ 1 (mod 4)",
+      "startLine": 74,
+      "endLine": 92,
+      "summary": "z = m² + n² with m, n of opposite parity: writing even as 2a and odd as 2b+1 gives z = 4(a²+b²+b)+1, closed by omega.",
+      "mathContext": "z ≡ 1 (mod 4); a primitive hypotenuse is a sum of two coprime squares of opposite parity."
+    },
+    {
+      "id": "examples",
+      "title": "example_3_4_5 / example_8_15_17 — concrete instances",
+      "startLine": 94,
+      "endLine": 107,
+      "summary": "The refinements at (3,4,5) directly and at the non-base triple (15, 8, 17) by applying the general theorems.",
+      "mathContext": "Concrete witnesses: 4 ∣ 4, 4 ∣ 8, 5 ≡ 17 ≡ 1 (mod 4)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parity structure of primitive Pythagorean triples is formalized with 0 axioms and 0 sorries: exactly one leg is even and the other odd (Even/Odd restatement of Mathlib's even_odd_of_coprime), the hypotenuse is odd, the even leg is divisible by 4, and the hypotenuse is ≡ 1 (mod 4). The last two refinements are not in Mathlib and are read off the Euclid parametrization; concrete instances at (3,4,5) and (15,8,17) round out the entry.",
+    "implications": "Supplies the standard mod-4 sharpenings of the parity dichotomy that underlie descent arguments (e.g. Fermat's x⁴ + y⁴ = z²) and the Gaussian-integer view in which the hypotenuse z = m² + n² is a norm — the statement z ≡ 1 (mod 4) being exactly that z is a sum of two coprime squares of opposite parity.",
+    "openQuestions": [
+      {
+        "id": "pythagorean-triples-oq-06-oq-01-oq-01",
+        "question": "Strengthen the even-leg result: show the even leg of a primitive triple is divisible by 4 and, refining further, that exactly one of the legs is divisible by 3 and exactly one of the three sides is divisible by 5 — so 60 always divides the product xyz.",
+        "significance": "low"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "extends",
+      "description": "Parent classification entry; this answers its open question on the parity dichotomy and adds the mod-4 refinements."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "extends",
+      "description": "Root Pythagorean-triples entry; this records the parity and mod-4 structure of the primitive solutions."
+    }
+  ],
+  "references": [
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "Hardy, Wright",
+      "year": "2008",
+      "venue": "Oxford University Press",
+      "description": "Theorem 225 and surrounding discussion: parity of the legs and the mod-4 structure of primitive Pythagorean triples."
+    },
+    {
+      "title": "Pythagorean Triangles",
+      "author": "Sierpiński",
+      "year": "2003",
+      "venue": "Dover",
+      "description": "Elementary monograph deriving that the even leg is a multiple of 4 and the hypotenuse is ≡ 1 (mod 4)."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01",
+      "question": "Strengthen to the divisibility package: the even leg is divisible by 4, exactly one leg is divisible by 3, one side by 5, hence 60 ∣ xyz for every primitive triple.",
+      "significance": "low"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/pythagorean-triples-oq-06-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-06-oq-01.json
@@ -1,0 +1,91 @@
+{
+  "slug": "pythagorean-triples-oq-06-oq-01",
+  "title": "Parity dichotomy and mod-4 refinements for primitive Pythagorean triples",
+  "tier": "C",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "path": "full",
+  "started": "2026-06-24T00:00:00.000Z",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Parity dichotomy and the two mod-4 refinements (even leg ≡ 0, hypotenuse ≡ 1) for primitive Pythagorean triples.",
+    "blockers": [],
+    "nextAction": "Entry complete; optional follow-up is the 60 ∣ xyz divisibility package.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "problemStatement": "Off the verified classification entry pythagorean-triples-oq-06, prove the parity dichotomy for primitive Pythagorean triples (exactly one leg even) and its classical sharpenings: the hypotenuse is odd, the even leg is divisible by 4, and the hypotenuse is ≡ 1 (mod 4) — with 0 sorries and 0 axioms.",
+  "knowledge": {
+    "insights": [
+      "The bare leg-parity dichotomy (one leg even, one odd) is ALREADY in Mathlib as PythagoreanTriple.even_odd_of_coprime, proved by the mod-4 contradiction (two odd legs give x²+y² ≡ 2 mod 4, never a square). So the genuine new content is the two mod-4 sharpenings, not the dichotomy itself.",
+      "The hypotenuse being odd needs no parametrization — it is forced by parity alone: an even square plus an odd square is odd, so z² and hence z is odd.",
+      "Divisibility of the even leg by 4 is a parametrization fact, NOT a parity fact: x²+y²=z² alone gives only 2 ∣ (even leg); the upgrade to 4 ∣ y uses y = 2mn with m, n of opposite parity (one factor even).",
+      "z ≡ 1 (mod 4) is the Gaussian-integer shadow: z = m²+n² with m, n opposite parity = 4(a²+b²+b)+1 after writing even=2a, odd=2b+1; this is exactly 'a primitive hypotenuse is a sum of two coprime squares of opposite parity'."
+    ],
+    "builtItems": [
+      "one_leg_even in Proofs/PythagoreanTriplesOQ06OQ01.lean — Even/Odd restatement of even_odd_of_coprime via Int.even_iff / Int.odd_iff",
+      "hyp_odd — the hypotenuse z is odd, by reducing z² = x²+y² mod 2 over the two parity cases",
+      "even_leg_div_four — 4 ∣ (even leg) from coprime_classification' (y = 2mn, one of m,n even)",
+      "hyp_one_mod_four — z ≡ 1 (mod 4) from z = m²+n², writing even=2a, odd=2b+1, closed by omega",
+      "example_3_4_5 and example_8_15_17 — refinements instantiated at (3,4,5) and (via the general theorems) at (15,8,17)"
+    ],
+    "mathlibGaps": [
+      "Mathlib has even_odd_of_coprime and coprime_classification' but does NOT record the mod-4 refinements 4 ∣ (even leg) or hypotenuse ≡ 1 (mod 4); these are supplied here."
+    ],
+    "nextSteps": [
+      "Follow-up oq-01-oq-01: the full divisibility package — even leg divisible by 4, exactly one leg divisible by 3, one side by 5, hence 60 ∣ xyz for every primitive triple.",
+      "Optionally connect z = m²+n² ≡ 1 (mod 4) to a sum-of-two-coprime-squares statement and the ℤ[i] factorization of the hypotenuse."
+    ],
+    "progressSummary": "COMPLETE: verified, 0 sorries, 0 axioms. Parity dichotomy (Even/Odd form) plus the three refinements — z odd, even leg ≡ 0 (mod 4), z ≡ 1 (mod 4) — formalized over Mathlib's even_odd_of_coprime and coprime_classification'.",
+    "markdown": ""
+  },
+  "knownResults": [
+    "Mathlib: PythagoreanTriple.even_odd_of_coprime (leg-parity dichotomy)",
+    "Mathlib: PythagoreanTriple.coprime_classification' (Euclid parametrization, x odd, z > 0)",
+    "Hardy–Wright, Theorem 225 and surrounding parity/mod-4 discussion",
+    "Sierpiński, Pythagorean Triangles (even leg ≡ 0 mod 4, hypotenuse ≡ 1 mod 4)"
+  ],
+  "leanFiles": [
+    {
+      "path": "Proofs/PythagoreanTriplesOQ06OQ01.lean",
+      "filename": "PythagoreanTriplesOQ06OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ06OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "pythagorean-triples-oq-06",
+    "pythagorean-triples"
+  ],
+  "references": [
+    {
+      "title": "An Introduction to the Theory of Numbers",
+      "author": "Hardy, Wright",
+      "year": "2008"
+    },
+    {
+      "title": "Pythagorean Triangles",
+      "author": "Sierpiński",
+      "year": "2003"
+    }
+  ],
+  "tags": [
+    "number-theory",
+    "diophantine",
+    "pythagorean-triples",
+    "parity",
+    "modular-arithmetic",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question off the verified classification entry **pythagorean-triples-oq-06** (Euclid's classification of primitive Pythagorean triples).

Mathlib already records the bare leg-parity dichotomy — exactly one leg is even — as `PythagoreanTriple.even_odd_of_coprime`. So a mere restatement would add nothing. This entry restates that dichotomy in idiomatic `Even`/`Odd` form and then proves the **three classical mod-4 refinements that are not in Mathlib**:

| Theorem | Statement |
|---------|-----------|
| `one_leg_even` | `(Even x ∧ Odd y) ∨ (Odd x ∧ Even y)` — Even/Odd form of `even_odd_of_coprime` |
| `hyp_odd` | the hypotenuse `z` is **odd** (pure parity from `z² = x² + y²`, no parametrization) |
| `even_leg_div_four` | the even leg is **divisible by 4** (`y = 2mn`, one of `m, n` even) |
| `hyp_one_mod_four` | the hypotenuse `z ≡ 1 (mod 4)` (`z = m² + n²`, opposite parity) |
| `example_3_4_5`, `example_8_15_17` | the refinements instantiated at `(3,4,5)` and (via the general theorems) `(15,8,17)` |

### Why these refinements are real content

- `x² + y² = z²` **alone** only gives `2 ∣ (even leg)`; upgrading to `4 ∣ y` genuinely uses the Euclid parametrization `y = 2mn` with `m, n` of opposite parity.
- `z = m² + n² = 4(a² + b² + b) + 1` (writing even `= 2a`, odd `= 2b+1`) is the Gaussian-integer shadow: a primitive hypotenuse is a sum of two coprime squares of opposite parity.

### Verification

- **6 theorems, 128 lines, 0 sorries, 0 axioms.**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms — none count under the axiom-integrity policy).
- Built on Mathlib's `even_odd_of_coprime` and `coprime_classification'`.
- Compiles under Lean v4.26.0 + Mathlib via `lake env lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)