### PR TITLE
research(cube-root-3-irrational-oq-01-oq-02): explicit ℚ-basis {1,∛3,∛9} of ℚ(∛3) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -832,6 +832,7 @@ import Proofs.CubeRoot2IrrationalOQ05OQ01
 import Proofs.CubeRoot2IrrationalOQ05OQ01OQ01
 import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ01
+import Proofs.CubeRoot3IrrationalOQ01OQ02
 import Proofs.CubeRoot3IrrationalOQ02
 import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02

--- a/proofs/Proofs/CubeRoot3IrrationalOQ01OQ02.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ01OQ02.lean
@@ -1,0 +1,140 @@
+/-
+# The explicit ℚ-basis `{1, ∛3, ∛9}` of `ℚ(∛3)`  (OQ-01 / OQ-02 of ∛3)
+
+**Open Question OQ-02** of `cube-root-3-irrational-oq-01`:
+
+  > Prove `ℚ(∛3)` has degree 3 and **exhibit its ℚ-basis `{1, ∛3, ∛9}`**,
+  > linking to the parent's linear-independence open question.
+
+The companion file `CubeRoot3IrrationalOQ02OQ01.lean` already established the bare
+degree `[ℚ(∛3):ℚ] = 3` (as a corollary of the Eisenstein irreducibility of `X³-3`).
+That settles the *dimension*, but it does not produce an **explicit ordered basis**.
+
+This file supplies the missing certificate. From the integrality of `∛3` and the
+already-proved degree, Mathlib's `IntermediateField.adjoin.powerBasis` yields the
+power basis `1, ∛3, (∛3)²` of `ℚ(∛3)`. We:
+
+1. build the power basis `cbrt3PowerBasis : PowerBasis ℚ ℚ⟮∛3⟯` and show `dim = 3`;
+2. reindex it to an honest `Basis (Fin 3) ℚ ℚ⟮∛3⟯`;
+3. compute the three basis vectors as real numbers: `1`, `∛3`, and `∛9`
+   — the last via the arithmetic identity `(∛3)² = ∛9`;
+4. give the **representation theorem**: every `x ∈ ℚ(∛3)` is the unique
+   ℚ-combination `a·1 + b·∛3 + c·∛9`;
+5. record that the basis is linearly independent and spanning.
+
+This complements `CubeRoot3IrrationalOQ02OQ02.lean`, which proves the three *real
+numbers* `1, ∛3, ∛3²` are ℚ-linearly independent. Linear independence alone is not
+a basis: here we use the degree `[ℚ(∛3):ℚ] = 3` (companion `OQ02OQ01`) to upgrade
+those three vectors to a genuine **basis** of the field extension, with spanning
+and explicit coordinates — the structural content the parent's open question asks
+for ("exhibit its ℚ-basis").
+
+`∛9 = (∛3)²` is what makes `{1, ∛3, ∛9}` a *power* basis rather than an ad-hoc set:
+the basis is genuinely `{1, ∛3, ∛3²}`, and `∛3² = 3^{2/3} = 9^{1/3} = ∛9`.
+
+Zero axioms; builds on the Eisenstein degree corollary.
+-/
+
+import Proofs.CubeRoot2IrrationalOQ03
+
+open Polynomial IntermediateField Module CubeRoot2IrrationalOQ03
+
+namespace CubeRoot3IrrationalOQ01OQ02
+
+/-- `∛3` as a real number, matching the form used throughout the ∛3 strand. -/
+noncomputable abbrev cbrt3 : ℝ := (3 : ℝ) ^ ((1 : ℝ) / 3)
+
+/-- `∛9` as a real number. -/
+noncomputable abbrev cbrt9 : ℝ := (9 : ℝ) ^ ((1 : ℝ) / 3)
+
+/-- `∛3` is integral over `ℚ` (root of the monic `X³ - 3`). -/
+theorem cbrt3_isIntegral : IsIntegral ℚ cbrt3 :=
+  isIntegral_nthRoot 3 3 (by norm_num)
+
+/-- `[ℚ(∛3):ℚ] = 3`, specializing the general `adjoin_nthRoot_finrank` (n=m=p=3:
+`3 ∣ 3` but `9 ∤ 3`). Re-derived here directly from `CubeRoot2IrrationalOQ03` so
+this file does not depend on the (currently Mathlib-drifted) `OQ02OQ01` companion. -/
+theorem cbrt3_fieldExtDegree : Module.finrank ℚ ℚ⟮cbrt3⟯ = 3 :=
+  adjoin_nthRoot_finrank 3 3 3 (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+
+/-- The defining arithmetic identity of the third basis vector: `(∛3)² = ∛9`,
+since `(3^{1/3})² = 3^{2/3} = (3²)^{1/3} = 9^{1/3}`. -/
+theorem cbrt3_sq_eq_cbrt9 : cbrt3 ^ 2 = cbrt9 := by
+  show ((3 : ℝ) ^ ((1 : ℝ) / 3)) ^ 2 = (9 : ℝ) ^ ((1 : ℝ) / 3)
+  rw [← Real.rpow_natCast ((3 : ℝ) ^ ((1 : ℝ) / 3)) 2,
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 3),
+      show (9 : ℝ) = (3 : ℝ) ^ (2 : ℕ) by norm_num,
+      ← Real.rpow_natCast (3 : ℝ) 2,
+      ← Real.rpow_mul (by norm_num : (0 : ℝ) ≤ 3)]
+  congr 1
+  push_cast
+  ring
+
+/-! ## The power basis `1, ∛3, (∛3)²` of `ℚ(∛3)` -/
+
+/-- The power basis of `ℚ(∛3)` over `ℚ`, with generator `∛3` and vectors
+`1, ∛3, (∛3)²`. -/
+noncomputable def cbrt3PowerBasis : PowerBasis ℚ ℚ⟮cbrt3⟯ :=
+  IntermediateField.adjoin.powerBasis cbrt3_isIntegral
+
+/-- The power basis has dimension `3` — i.e. `[ℚ(∛3):ℚ] = 3`. -/
+theorem cbrt3PowerBasis_dim : cbrt3PowerBasis.dim = 3 := by
+  rw [← PowerBasis.finrank cbrt3PowerBasis]
+  exact cbrt3_fieldExtDegree
+
+/-- The generator of the power basis is `∛3` (as a real number). -/
+theorem coe_gen : ((cbrt3PowerBasis.gen : ℚ⟮cbrt3⟯) : ℝ) = cbrt3 := by
+  show ((IntermediateField.adjoin.powerBasis cbrt3_isIntegral).gen : ℝ) = cbrt3
+  rw [adjoin.powerBasis_gen, IntermediateField.AdjoinSimple.coe_gen]
+
+/-! ## The explicit ordered ℚ-basis `{1, ∛3, ∛9}` -/
+
+/-- The ordered ℚ-basis `(1, ∛3, ∛9)` of `ℚ(∛3)`, indexed by `Fin 3`. -/
+noncomputable def cbrt3Basis : Basis (Fin 3) ℚ ℚ⟮cbrt3⟯ :=
+  cbrt3PowerBasis.basis.reindex (finCongr cbrt3PowerBasis_dim)
+
+/-- The `i`-th basis vector is `(∛3)ⁱ` as a real number. -/
+theorem cbrt3Basis_coe (i : Fin 3) :
+    ((cbrt3Basis i : ℚ⟮cbrt3⟯) : ℝ) = cbrt3 ^ (i : ℕ) := by
+  have hb : (cbrt3Basis i : ℚ⟮cbrt3⟯) = cbrt3PowerBasis.gen ^ (i : ℕ) := by
+    show (cbrt3PowerBasis.basis.reindex (finCongr cbrt3PowerBasis_dim)) i
+        = cbrt3PowerBasis.gen ^ (i : ℕ)
+    rw [Basis.reindex_apply, PowerBasis.basis_eq_pow]
+    congr 1
+  rw [hb]
+  push_cast
+  rw [coe_gen]
+
+/-- First basis vector: `1`. -/
+theorem cbrt3Basis_zero : ((cbrt3Basis 0 : ℚ⟮cbrt3⟯) : ℝ) = 1 := by
+  rw [cbrt3Basis_coe 0, (by decide : ((0 : Fin 3) : ℕ) = 0), pow_zero]
+
+/-- Second basis vector: `∛3`. -/
+theorem cbrt3Basis_one : ((cbrt3Basis 1 : ℚ⟮cbrt3⟯) : ℝ) = cbrt3 := by
+  rw [cbrt3Basis_coe 1, (by decide : ((1 : Fin 3) : ℕ) = 1), pow_one]
+
+/-- Third basis vector: `∛9 = (∛3)²`. -/
+theorem cbrt3Basis_two : ((cbrt3Basis 2 : ℚ⟮cbrt3⟯) : ℝ) = cbrt9 := by
+  rw [cbrt3Basis_coe 2, (by decide : ((2 : Fin 3) : ℕ) = 2), cbrt3_sq_eq_cbrt9]
+
+/-! ## Representation and linear independence -/
+
+/-- **Representation theorem.** Every element of `ℚ(∛3)` is the ℚ-combination
+`a·1 + b·∛3 + c·∛9` of the basis, with coordinates `a, b, c` read off by
+`cbrt3Basis.repr`. Uniqueness is automatic from `cbrt3Basis` being a basis. -/
+theorem cbrt3_repr (x : ℚ⟮cbrt3⟯) :
+    cbrt3Basis.repr x (0 : Fin 3) • cbrt3Basis (0 : Fin 3)
+      + cbrt3Basis.repr x (1 : Fin 3) • cbrt3Basis (1 : Fin 3)
+      + cbrt3Basis.repr x (2 : Fin 3) • cbrt3Basis (2 : Fin 3) = x := by
+  have h := cbrt3Basis.sum_repr x
+  rwa [Fin.sum_univ_three] at h
+
+/-- The basis `{1, ∛3, ∛9}` is ℚ-linearly independent (inside `ℚ(∛3)`). -/
+theorem cbrt3Basis_linearIndependent : LinearIndependent ℚ cbrt3Basis :=
+  cbrt3Basis.linearIndependent
+
+/-- The basis spans all of `ℚ(∛3)`. -/
+theorem cbrt3Basis_span : Submodule.span ℚ (Set.range cbrt3Basis) = ⊤ :=
+  cbrt3Basis.span_eq
+
+end CubeRoot3IrrationalOQ01OQ02

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "cube-root-3-irrational-oq-01-oq-02",
+    "range": { "startLine": 38, "endLine": 58 },
+    "type": "concept",
+    "title": "Imports, Namespaces, and the Degree Fact",
+    "content": "The file imports only the parametric helper `Proofs.CubeRoot2IrrationalOQ03` (for adjoin_nthRoot_finrank and isIntegral_nthRoot) and opens four namespaces. The crucial one is `Module`: in the pinned Mathlib the basis type is `Module.Basis`, so without `open Module` the bare name `Basis` is silently auto-bound as an implicit type variable and every later basis statement degenerates. cbrt3 = 3^(1/3) and cbrt9 = 9^(1/3) are defined as abbrevs, ∛3 is shown integral over ℚ, and [ℚ(∛3):ℚ] = 3 is re-derived from adjoin_nthRoot_finrank 3 3 3 — deliberately NOT importing CubeRoot3IrrationalOQ02OQ01, which currently fails to compile against this Mathlib (minpoly.eq_X_sub_C API drift).",
+    "mathContext": "$\\mathbb{Q}(\\sqrt[3]{3})$ has $\\dim_{\\mathbb{Q}} = \\deg(\\mathrm{minpoly}_{\\mathbb{Q}}\\sqrt[3]{3}) = \\deg(X^3-3) = 3$. The five `norm_num` side-conditions of `adjoin_nthRoot_finrank 3 3 3` are $2\\le 3$, $\\mathrm{Prime}\\,3$, $3\\mid 3$, $9\\nmid 3$, $0<3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Module.Basis", "IntermediateField.adjoin", "field extension degree", "Mathlib API drift"],
+    "prerequisites": ["Lean 4 imports/namespaces", "Mathlib field theory"],
+    "tags": ["setup", "imports", "namespaces", "degree"]
+  },
+  {
+    "id": "ann-cbrt9-identity",
+    "proofId": "cube-root-3-irrational-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "theorem",
+    "title": "(∛3)² = ∛9 via rpow Arithmetic",
+    "content": "cbrt3_sq_eq_cbrt9 establishes the only real-analytic identity in the file: the square of ∛3 equals ∛9. The proof converts the natural-power square (∛3)² to an rpow exponent via Real.rpow_natCast, collapses (3^(1/3))^2 to 3^((1/3)·2) by Real.rpow_mul, rewrites 9 = 3² and likewise collapses (3²)^(1/3) to 3^(2·(1/3)), then closes by `congr 1; push_cast; ring` since the two exponents agree. This is what licenses displaying the third basis vector (∛3)² in the symmetric form ∛9.",
+    "mathContext": "$(3^{1/3})^2 = 3^{2/3} = (3^2)^{1/3} = 9^{1/3}$. Both sides reduce to $3^{2/3}$; positivity of the base ($0 \\le 3$) is the hypothesis for `Real.rpow_mul`.",
+    "significance": "key",
+    "relatedConcepts": ["real power (rpow)", "Real.rpow_mul", "Real.rpow_natCast", "radical identities"],
+    "prerequisites": ["real exponentiation", "laws of exponents"],
+    "tags": ["rpow", "cube-root", "arithmetic-identity"]
+  },
+  {
+    "id": "ann-powerbasis",
+    "proofId": "cube-root-3-irrational-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 88 },
+    "type": "theorem",
+    "title": "The Power Basis and its Dimension",
+    "content": "cbrt3PowerBasis is Mathlib's IntermediateField.adjoin.powerBasis applied to the integrality of ∛3 — a PowerBasis ℚ ℚ⟮∛3⟯ whose generator is ∛3 and whose basis vectors are the powers (∛3)^i. cbrt3PowerBasis_dim proves the dimension is 3 by rewriting through PowerBasis.finrank (Module.finrank = pb.dim) and the degree fact cbrt3_fieldExtDegree. coe_gen pins the generator's real value to ∛3 using the auto-generated simp lemma adjoin.powerBasis_gen together with IntermediateField.AdjoinSimple.coe_gen.",
+    "mathContext": "For a simple algebraic extension $\\mathbb{Q}(\\alpha)$ of degree $d$, the power basis is $1, \\alpha, \\dots, \\alpha^{d-1}$; Mathlib builds it through the isomorphism $\\mathbb{Q}[X]/(\\mathrm{minpoly}\\,\\alpha) \\cong \\mathbb{Q}(\\alpha)$. Here $\\alpha = \\sqrt[3]{3}$, $d=3$.",
+    "significance": "key",
+    "relatedConcepts": ["PowerBasis", "IntermediateField.adjoin.powerBasis", "PowerBasis.finrank", "AdjoinSimple.gen"],
+    "prerequisites": ["simple field extensions", "power bases", "minimal polynomial"],
+    "tags": ["power-basis", "dimension", "generator"]
+  },
+  {
+    "id": "ann-basis-vectors",
+    "proofId": "cube-root-3-irrational-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 117 },
+    "type": "theorem",
+    "title": "The Basis (Fin 3) and its Vectors 1, ∛3, ∛9",
+    "content": "cbrt3Basis reindexes the power basis (indexed by Fin pb.dim) along finCongr cbrt3PowerBasis_dim to a clean Basis (Fin 3) ℚ ℚ⟮∛3⟯. cbrt3Basis_coe computes the i-th vector's real value as (∛3)^i: a `show` unfolds the reindex by defeq, Basis.reindex_apply and PowerBasis.basis_eq_pow turn it into the generator's i-th power, `congr 1` discharges the Fin-cast on the exponent, and push_cast + coe_gen push the field coercion through. The three corollaries cbrt3Basis_zero, cbrt3Basis_one, cbrt3Basis_two then read the vectors off as 1, ∛3, and ∛9 — the last by feeding cbrt3_sq_eq_cbrt9 into (∛3)².",
+    "mathContext": "$b_0 = (\\sqrt[3]{3})^0 = 1,\\quad b_1 = \\sqrt[3]{3},\\quad b_2 = (\\sqrt[3]{3})^2 = \\sqrt[3]{9}$. The ordered basis is $(1, \\sqrt[3]{3}, \\sqrt[3]{9})$.",
+    "significance": "key",
+    "relatedConcepts": ["Module.Basis.reindex", "PowerBasis.basis_eq_pow", "finCongr", "Fin.cast"],
+    "prerequisites": ["bases of vector spaces", "reindexing", "Fin arithmetic"],
+    "tags": ["basis", "explicit-vectors", "reindex"]
+  },
+  {
+    "id": "ann-repr",
+    "proofId": "cube-root-3-irrational-oq-01-oq-02",
+    "range": { "startLine": 120, "endLine": 138 },
+    "type": "theorem",
+    "title": "Representation Theorem, Independence, Spanning",
+    "content": "cbrt3_repr is the structural payoff: every x ∈ ℚ(∛3) decomposes uniquely as cbrt3Basis.repr x 0 • 1 + cbrt3Basis.repr x 1 • ∛3 + cbrt3Basis.repr x 2 • ∛9. It is Basis.sum_repr (∑ᵢ rᵢ • bᵢ = x) expanded over Fin 3 by Fin.sum_univ_three. cbrt3Basis_linearIndependent and cbrt3Basis_span record the two defining properties of a basis, completing the certificate that {1, ∛3, ∛9} is a ℚ-basis (not merely linearly independent as in OQ-02-OQ-02).",
+    "mathContext": "The coordinate isomorphism $\\mathbb{Q}(\\sqrt[3]{3}) \\xrightarrow{\\sim} \\mathbb{Q}^3$, $a + b\\sqrt[3]{3} + c\\sqrt[3]{9} \\mapsto (a,b,c)$. Uniqueness of coordinates is `Basis.repr` being a linear equivalence.",
+    "significance": "key",
+    "relatedConcepts": ["Module.Basis.sum_repr", "Basis.repr", "Fin.sum_univ_three", "linear independence", "spanning"],
+    "prerequisites": ["coordinates relative to a basis", "linear combinations"],
+    "tags": ["representation", "coordinates", "basis-properties"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01-oq-02/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "cube-root-3-irrational-oq-01-oq-02",
+  "title": "The Explicit ℚ-Basis {1, ∛3, ∛9} of ℚ(∛3)",
+  "slug": "cube-root-3-irrational-oq-01-oq-02",
+  "description": "Exhibits the explicit ordered ℚ-basis {1, ∛3, ∛9} of the degree-3 field extension ℚ(∛3). Builds Mathlib's adjoin.powerBasis into a first-class PowerBasis and reindexes it to an honest Basis (Fin 3), computes the three basis vectors as the real numbers 1, ∛3, ∛9 (the last via the identity (∛3)² = ∛9), and proves the representation theorem: every element of ℚ(∛3) is the unique ℚ-combination a·1 + b·∛3 + c·∛9. Answers open question OQ-02 of cube-root-3-irrational-oq-01.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ01OQ02.lean",
+    "tags": [
+      "field-extensions",
+      "algebraic-numbers",
+      "power-basis",
+      "linear-algebra",
+      "cube-roots",
+      "minimal-polynomial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None — fully verified (depends only on the foundational axioms propext, Classical.choice, Quot.sound; no sorry, no native_decide). Builds on CubeRoot2IrrationalOQ03 for adjoin_nthRoot_finrank and isIntegral_nthRoot. The degree fact [ℚ(∛3):ℚ] = 3 is re-derived here directly from that helper so the file is independent of the CubeRoot3IrrationalOQ02OQ01 companion.",
+    "lineCount": 140,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "originalContributions": [
+      "cbrt3PowerBasis: the PowerBasis ℚ ℚ⟮∛3⟯ with generator ∛3 and vectors 1, ∛3, (∛3)², via IntermediateField.adjoin.powerBasis",
+      "cbrt3PowerBasis_dim: the power basis has dimension 3, from [ℚ(∛3):ℚ] = 3 and PowerBasis.finrank",
+      "cbrt3Basis: an explicit Basis (Fin 3) ℚ ℚ⟮∛3⟯ obtained by reindexing the power basis",
+      "cbrt3_sq_eq_cbrt9: the arithmetic identity (∛3)² = ∛9 (i.e. 3^{2/3} = 9^{1/3}) that names the third basis vector",
+      "cbrt3Basis_zero / cbrt3Basis_one / cbrt3Basis_two: the three basis vectors equal the real numbers 1, ∛3, ∛9",
+      "cbrt3_repr: representation theorem — every x ∈ ℚ(∛3) is the unique ℚ-combination of {1, ∛3, ∛9}",
+      "cbrt3Basis_linearIndependent / cbrt3Basis_span: linear independence and spanning of the basis"
+    ]
+  },
+  "leanFile": {
+    "lineCount": 140,
+    "path": "Proofs/CubeRoot3IrrationalOQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 12
+  },
+  "overview": {
+    "historicalContext": "That ℚ(∛3) is a 3-dimensional ℚ-vector space is the modern algebraic reading of the classical irrationality of ∛3. Dedekind's 1871 supplement to Dirichlet's Vorlesungen treated ℚ(∛3) as the smallest field containing ℚ and ∛3 and recognized its dimension; the notion of a power basis 1, α, …, α^{d-1} for a simple algebraic extension ℚ(α) of degree d is the natural coordinate system on such a space. For ∛3 the minimal polynomial is X³−3 (Eisenstein-irreducible at the prime 3), so the degree is 3 and {1, ∛3, ∛3²} is the canonical power basis. Writing ∛3² = ∛9 makes the basis read as the visually symmetric set {1, ∛3, ∛9}: the cube roots of 1, 3, and 9. The companion entry cube-root-3-irrational-oq-02-oq-01 established the bare dimension [ℚ(∛3):ℚ] = 3; cube-root-3-irrational-oq-02-oq-02 proved the three real numbers 1, ∛3, ∛3² are ℚ-linearly independent. This entry supplies what those leave open: the basis as a first-class object, with spanning and explicit coordinates.",
+    "problemStatement": "**Open Question OQ-02 of cube-root-3-irrational-oq-01**: Prove ℚ(∛3) has degree 3 and exhibit its ℚ-basis {1, ∛3, ∛9}, linking to the parent's linear-independence open question.\n\nThe degree [ℚ(∛3):ℚ] = 3 is settled by the Eisenstein corollary (OQ02OQ01). What remains is to *exhibit a basis*: produce a concrete ordered basis of the 3-dimensional ℚ-vector space ℚ(∛3) whose three vectors are 1, ∛3, and ∛9, and show every element is a unique ℚ-combination of them.",
+    "proofStrategy": "**Power basis.** Since ∛3 is integral over ℚ (root of the monic X³−3), Mathlib's `IntermediateField.adjoin.powerBasis` yields a `PowerBasis ℚ ℚ⟮∛3⟯` with generator ∛3 and basis vectors (∛3)^i. Its dimension equals [ℚ(∛3):ℚ] = 3, established via `PowerBasis.finrank` together with the degree corollary `adjoin_nthRoot_finrank 3 3 3` (re-derived locally, so the file does not depend on the currently Mathlib-drifted OQ02OQ01).\n\n**Reindex to Fin 3.** The power basis is indexed by `Fin pb.dim`; reindexing along `finCongr` (dim = 3) gives an honest `Basis (Fin 3) ℚ ℚ⟮∛3⟯`.\n\n**Naming the vectors.** `PowerBasis.basis_eq_pow` gives basis i = gen^i; pushing through the field coercion and `IntermediateField.AdjoinSimple.coe_gen` yields the real values 1, ∛3, (∛3)². The identity (∛3)² = ∛9 = 9^{1/3} is proved by rpow arithmetic (3^{1/3·2} = 3^{2/3} = (3²)^{1/3}).\n\n**Representation.** `Basis.sum_repr` expanded by `Fin.sum_univ_three` gives the unique decomposition x = c₀·1 + c₁·∛3 + c₂·∛9 for every x ∈ ℚ(∛3); linear independence and spanning follow from `Basis`.",
+    "keyInsights": [
+      "Linear independence alone is not a basis. cube-root-3-irrational-oq-02-oq-02 proves the three real numbers 1, ∛3, ∛3² are ℚ-linearly independent; to upgrade them to a *basis* one also needs that they span — which holds precisely because there are exactly 3 of them and [ℚ(∛3):ℚ] = 3. The PowerBasis packages independence + correct cardinality + spanning into a single object.",
+      "The third basis vector is a power, not an ad-hoc element: ∛9 = (∛3)². This is what makes {1, ∛3, ∛9} a power basis 1, α, α². The bridge 3^{2/3} = 9^{1/3} is a pure rpow computation, the only genuinely real-analytic step in an otherwise algebraic file.",
+      "Mathlib's `adjoin.powerBasis` already does the heavy lifting (it builds the basis from AdjoinRoot.powerBasis through the field isomorphism ℚ[X]/(minpoly) ≅ ℚ(∛3)); the contribution here is to specialize, reindex to Fin 3, and read off the three coordinates as concrete real numbers with the ∛9 form.",
+      "Decoupling matters under API drift: the sibling CubeRoot3IrrationalOQ02OQ01 (a merged, previously-verified entry) no longer compiles against the pinned Mathlib because `minpoly.eq_X_sub_C` now elaborates its element as `algebraMap ℚ ℚ q` rather than the coercion `↑q : ℝ`. Re-deriving the degree directly from the parametric helper CubeRoot2IrrationalOQ03 keeps this entry self-contained and green.",
+      "In the pinned Mathlib, `Basis` lives in `namespace Module` (it is `Module.Basis`); using the bare name `Basis` requires `open Module`, otherwise it is silently auto-bound as an implicit type variable and every basis statement degenerates."
+    ],
+    "prerequisites": [
+      "CubeRoot2IrrationalOQ03.lean: adjoin_nthRoot_finrank, isIntegral_nthRoot",
+      "Mathlib: IntermediateField.adjoin.powerBasis, PowerBasis.finrank, PowerBasis.basis_eq_pow, Module.Basis.reindex, Module.Basis.sum_repr, IntermediateField.AdjoinSimple.coe_gen, Real.rpow_mul"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-setup",
+      "title": "Setup: ∛3, ∛9, Integrality, and Degree",
+      "startLine": 38,
+      "endLine": 58,
+      "summary": "Imports the parametric n-th root helper CubeRoot2IrrationalOQ03 and opens Polynomial, IntermediateField, Module (needed so the bare name Basis = Module.Basis resolves), and the helper namespace. Defines cbrt3 = 3^(1/3) and cbrt9 = 9^(1/3), records that ∛3 is integral over ℚ (isIntegral_nthRoot), and re-derives [ℚ(∛3):ℚ] = 3 directly from adjoin_nthRoot_finrank 3 3 3 — keeping the file independent of the (currently broken) OQ02OQ01 companion.",
+      "mathContext": "$\\mathbb{Q}(\\sqrt[3]{3})$ is a 3-dimensional $\\mathbb{Q}$-vector space because $\\mathrm{minpoly}_{\\mathbb{Q}}(\\sqrt[3]{3}) = X^3 - 3$ is Eisenstein-irreducible at $3$; $\\dim_{\\mathbb{Q}}\\mathbb{Q}(\\sqrt[3]{3}) = \\deg(X^3-3) = 3$."
+    },
+    {
+      "id": "sec-cbrt9",
+      "title": "The Identity (∛3)² = ∛9",
+      "startLine": 60,
+      "endLine": 71,
+      "summary": "cbrt3_sq_eq_cbrt9 proves (∛3)² = ∛9 via rpow arithmetic: convert the natural-power square to an rpow, apply Real.rpow_mul to get 3^((1/3)·2) = 3^(2/3), and rewrite 9 = 3² so that 9^(1/3) = 3^(2·(1/3)) = 3^(2/3). This identity is what lets the third power-basis vector (∛3)² be displayed as ∛9.",
+      "mathContext": "$(3^{1/3})^2 = 3^{2/3} = (3^2)^{1/3} = 9^{1/3}$. The two real exponents $\\tfrac{1}{3}\\cdot 2$ and $2\\cdot\\tfrac{1}{3}$ are reconciled by commutativity after `push_cast`."
+    },
+    {
+      "id": "sec-powerbasis",
+      "title": "The Power Basis 1, ∛3, (∛3)²",
+      "startLine": 73,
+      "endLine": 88,
+      "summary": "cbrt3PowerBasis is IntermediateField.adjoin.powerBasis applied to the integrality of ∛3, a PowerBasis ℚ ℚ⟮∛3⟯ with generator ∛3. cbrt3PowerBasis_dim shows its dimension is 3 by rewriting through PowerBasis.finrank and the degree fact. coe_gen identifies the generator's real value as ∛3 via adjoin.powerBasis_gen and AdjoinSimple.coe_gen.",
+      "mathContext": "A simple algebraic extension $\\mathbb{Q}(\\alpha)$ of degree $d$ has the power basis $1, \\alpha, \\dots, \\alpha^{d-1}$. For $\\alpha = \\sqrt[3]{3}$, $d = 3$, the basis is $1, \\sqrt[3]{3}, (\\sqrt[3]{3})^2$."
+    },
+    {
+      "id": "sec-basis",
+      "title": "The Explicit Basis (Fin 3) and its Three Vectors",
+      "startLine": 90,
+      "endLine": 117,
+      "summary": "cbrt3Basis reindexes the power basis along finCongr (dim = 3) to an honest Basis (Fin 3) ℚ ℚ⟮∛3⟯. cbrt3Basis_coe computes the i-th vector as the real number (∛3)^i (using Basis.reindex_apply, PowerBasis.basis_eq_pow, and coe_gen). The three concrete corollaries cbrt3Basis_zero / _one / _two read the vectors off as 1, ∛3, and ∛9 (the last via cbrt3_sq_eq_cbrt9).",
+      "mathContext": "$b_0 = 1,\\; b_1 = \\sqrt[3]{3},\\; b_2 = (\\sqrt[3]{3})^2 = \\sqrt[3]{9}$. The set $\\{1, \\sqrt[3]{3}, \\sqrt[3]{9}\\}$ is the canonical $\\mathbb{Q}$-basis of $\\mathbb{Q}(\\sqrt[3]{3})$."
+    },
+    {
+      "id": "sec-repr",
+      "title": "Representation, Independence, Spanning",
+      "startLine": 120,
+      "endLine": 138,
+      "summary": "cbrt3_repr is the representation theorem: every x ∈ ℚ(∛3) equals c₀·1 + c₁·∛3 + c₂·∛9 with the coordinates cᵢ = cbrt3Basis.repr x i, obtained from Basis.sum_repr expanded by Fin.sum_univ_three. cbrt3Basis_linearIndependent and cbrt3Basis_span record the two defining properties of a basis.",
+      "mathContext": "Every element of $\\mathbb{Q}(\\sqrt[3]{3})$ has a unique expression $a + b\\sqrt[3]{3} + c\\sqrt[3]{9}$ with $a,b,c \\in \\mathbb{Q}$ — the coordinate isomorphism $\\mathbb{Q}(\\sqrt[3]{3}) \\cong \\mathbb{Q}^3$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry (Eisenstein irreducibility of Xⁿ−p). This file answers its open question OQ-02: exhibit the explicit ℚ-basis {1, ∛3, ∛9}."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-01",
+      "relationship": "builds-on",
+      "description": "Provides the degree [ℚ(∛3):ℚ] = 3 that fixes the power basis dimension. (The degree is re-derived locally here, since that companion currently fails to compile against the pinned Mathlib.)"
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-02",
+      "relationship": "complements",
+      "description": "That entry proves the three real numbers 1, ∛3, ∛3² are ℚ-linearly independent; this entry upgrades them to a full basis with spanning and explicit coordinates."
+    }
+  ],
+  "conclusion": {
+    "summary": "{1, ∛3, ∛9} is exhibited as a genuine ℚ-basis of ℚ(∛3): a PowerBasis ℚ ℚ⟮∛3⟯ of dimension 3, reindexed to a Basis (Fin 3) whose vectors are the real numbers 1, ∛3, ∛9, with a representation theorem giving unique coordinates. 12 theorems, 4 definitions, 0 sorries, 0 axioms.",
+    "implications": "**A basis, not just independence.** The deliverable is the coordinate system on ℚ(∛3): every element is uniquely a + b·∛3 + c·∛9 with rational a, b, c. This is the structural certificate the parent's open question asked for, strictly stronger than the linear independence of {1, ∛3, ∛3²} alone (which needs spanning to become a basis).\n\n**Power basis as the natural object.** Displaying the basis as 1, α, α² (with α² = ∛9) ties the entry to Mathlib's PowerBasis machinery, making the coordinates computable and connecting to the minimal polynomial X³−3.\n\n**Robustness under Mathlib drift.** By re-deriving the degree from the parametric helper CubeRoot2IrrationalOQ03, the entry stays green even though the sibling CubeRoot3IrrationalOQ02OQ01 no longer compiles against the pinned Mathlib — a small case study in keeping gallery entries self-contained.",
+    "openQuestions": [
+      "Make the coordinate map explicit as a ℚ-algebra structure: compute the multiplication table of {1, ∛3, ∛9} (e.g. ∛3·∛9 = 3, ∛9·∛9 = 3·∛3) to present ℚ(∛3) as ℚ[x]/(x³−3) with an explicit basis-level product.",
+      "Generalize to a uniform `nthRootPowerBasis n m` : Basis (Fin n) ℚ ℚ⟮(m:ℝ)^(1/n)⟯ whenever m has a prime factor p with p ∥ m, with the i-th vector exhibited as (m^i)^(1/n)."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question OQ-02** of `cube-root-3-irrational-oq-01`:

> Prove ℚ(∛3) has degree 3 and **exhibit its ℚ-basis {1, ∛3, ∛9}**, linking to the parent's linear-independence open question.

The bare degree `[ℚ(∛3):ℚ] = 3` was already settled (oq-02-oq-01) and the three reals `1, ∛3, ∛3²` were shown ℚ-linearly independent (oq-02-oq-02). This entry supplies what those leave open: **the basis as a first-class object**, with spanning and explicit coordinates.

## What's proved (`Proofs/CubeRoot3IrrationalOQ01OQ02.lean`)

- `cbrt3PowerBasis : PowerBasis ℚ ℚ⟮∛3⟯` via `IntermediateField.adjoin.powerBasis`, with `dim = 3` (`PowerBasis.finrank` + the degree fact).
- `cbrt3Basis : Basis (Fin 3) ℚ ℚ⟮∛3⟯` — the power basis reindexed to a clean `Fin 3` index.
- The three basis vectors equal the real numbers **1, ∛3, ∛9**; the third via the rpow identity `(∛3)² = 3^{2/3} = 9^{1/3} = ∛9`.
- `cbrt3_repr`: **representation theorem** — every `x ∈ ℚ(∛3)` is the unique ℚ-combination `a·1 + b·∛3 + c·∛9`.
- `cbrt3Basis_linearIndependent`, `cbrt3Basis_span`.

## Distinctness

`oq-02-oq-02` proves only that `{1, ∛3, ∛3²}` are ℚ-linearly independent as real numbers. Linear independence alone is not a basis — this entry uses `[ℚ(∛3):ℚ] = 3` to upgrade those vectors to a genuine **basis** (independence + spanning + coordinates).

## Notes

- **Decoupled from `CubeRoot3IrrationalOQ02OQ01`**, which currently fails to compile against the pinned Mathlib (`minpoly.eq_X_sub_C` now elaborates its element as `algebraMap ℚ ℚ q` rather than the coercion `↑q : ℝ`, plus an unsolved `1 < 3`). The degree `[ℚ(∛3):ℚ] = 3` is re-derived here directly from the parametric helper `CubeRoot2IrrationalOQ03`, so this entry is self-contained and builds green.
- In the pinned Mathlib, `Basis` is `Module.Basis` — the file `open Module`s accordingly.

## Verification

```
✔ Built Proofs.CubeRoot3IrrationalOQ01OQ02
#print axioms → propext, Classical.choice, Quot.sound only (no sorryAx, no ofReduceBool)
```

12 theorems, 4 definitions, 140 lines, **0 sorries, 0 axioms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)