### PR TITLE
research(hilbert-17-oq-03-oq-01): explicit rational SOS certificate for Motzkin [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3016,6 +3016,7 @@ import Proofs.Hilbert15OQ02OQ03OQ01
 import Proofs.Hilbert15SchubertCalculus
 import Proofs.Hilbert15SchubertCalculusOQ01
 import Proofs.Hilbert16
+import Proofs.Hilbert17MotzkinRationalSOS
 import Proofs.Hilbert17OQ01
 import Proofs.Hilbert17SumOfSquares
 import Proofs.Hilbert19OQ03

--- a/proofs/Proofs/Hilbert17MotzkinRationalSOS.lean
+++ b/proofs/Proofs/Hilbert17MotzkinRationalSOS.lean
@@ -1,0 +1,177 @@
+/-
+# Hilbert's 17th Problem, made constructive for the Motzkin polynomial
+
+Parent entry: `hilbert-17` (`Hilbert17SumOfSquares.lean`), whose headline statement —
+Artin's theorem, that every nonnegative real polynomial is a sum of squares of
+*rational functions* — is necessarily axiomatized (`artin_hilbert17`), since the
+general proof needs real-closed-field model theory.
+
+The companion fact in that file, that the Motzkin polynomial
+
+  M(x, y) = x⁴y² + x²y⁴ - 3x²y² + 1
+
+is **not** a sum of squares of *polynomials*, is likewise carried as an axiom
+(`motzkin_not_sos_polynomial_aux`).  What was missing is the *positive* side made
+explicit: a fully machine-checked witness that Motzkin nevertheless **is** a sum of
+squares of rational functions, i.e. a concrete instance of Artin's theorem for the
+canonical example.  This file supplies exactly that, with `0` axioms.
+
+## The certificate
+
+The heart is a single polynomial identity (an SOS *Positivstellensatz certificate*):
+
+  (4 + 4x² + 4y²) · M(x, y)
+      = (2xy - x³y - xy³)²            (three copies)
+      + (x³y - xy³)²
+      + (2x - 2xy²)²
+      + (2y - 2x²y)²
+      + (2 - 2x²y²)²
+
+Every coefficient is an integer, so the identity is closed by `ring`.  Because the
+multiplier `4 + 4x² + 4y² = 2² + (2x)² + (2y)²` is itself a sum of squares, dividing
+through in the field of rational functions and using that a product of two sums of
+squares is a sum of squares yields
+
+  M = Σ (rational function)²            (`motzkin_isSOS_ratFunc`).
+
+This is Hilbert's 17th problem solved *constructively* for Motzkin: the abstract
+existence axiom is replaced, for this polynomial, by an exhibited certificate.
+
+The SOS multiplier was found by solving the associated semidefinite Gram-matrix
+feasibility problem; Motzkin sits on the boundary of the SOS cone, and the rational
+Gram matrix factors into the five squares above.
+
+## Results
+* `multiplier_mul_motzkin_eq`   — the integer SOS Positivstellensatz certificate.
+* `motzkin_mul_isSumOfSquares`  — `(4 + 4x² + 4y²)·M` is a polynomial sum of squares.
+* `multiplier_isSumOfSquares`   — the multiplier `4 + 4x² + 4y²` is a sum of squares.
+* `motzkin_isSOS_ratFunc`       — `M` is a sum of squares of rational functions.
+-/
+
+import Mathlib
+
+namespace Hilbert17MotzkinRationalSOS
+
+open MvPolynomial
+
+noncomputable section
+
+/-- The two variables of `ℝ[x, y]`. -/
+local notation "x" => (X 0 : MvPolynomial (Fin 2) ℝ)
+local notation "y" => (X 1 : MvPolynomial (Fin 2) ℝ)
+
+/-- The **Motzkin polynomial** `M(x, y) = x⁴y² + x²y⁴ - 3x²y² + 1`, defined exactly as
+in the parent entry `Hilbert17SumOfSquares.lean`. -/
+def motzkin : MvPolynomial (Fin 2) ℝ :=
+  x ^ 4 * y ^ 2 + x ^ 2 * y ^ 4 - 3 * x ^ 2 * y ^ 2 + 1
+
+/-- The SOS **multiplier** `4 + 4x² + 4y² = 2² + (2x)² + (2y)²`. -/
+def multiplier : MvPolynomial (Fin 2) ℝ := 4 + 4 * x ^ 2 + 4 * y ^ 2
+
+/-! ### Sum-of-squares predicates -/
+
+/-- A multivariate polynomial is a sum of squares of polynomials. -/
+def IsSumOfSquaresMv (p : MvPolynomial (Fin 2) ℝ) : Prop :=
+  ∃ (m : ℕ) (q : Fin m → MvPolynomial (Fin 2) ℝ), p = ∑ i, q i ^ 2
+
+/-- The field of rational functions `ℝ(x, y)` in two variables. -/
+abbrev RF : Type := FractionRing (MvPolynomial (Fin 2) ℝ)
+
+/-- The embedding `ℝ[x, y] ↪ ℝ(x, y)`. -/
+abbrev toRF : MvPolynomial (Fin 2) ℝ →+* RF := algebraMap _ _
+
+/-- An element of the rational function field is a (finite) sum of squares of
+rational functions. -/
+def IsSumOfSquaresRF (z : RF) : Prop :=
+  ∃ (m : ℕ) (g : Fin m → RF), z = ∑ i, g i ^ 2
+
+/-! ### The polynomial SOS certificate -/
+
+/-- The five generators of the certificate (the first appears with multiplicity three). -/
+def G0 : MvPolynomial (Fin 2) ℝ := 2 * x * y - x ^ 3 * y - x * y ^ 3
+def G1 : MvPolynomial (Fin 2) ℝ := x ^ 3 * y - x * y ^ 3
+def G2 : MvPolynomial (Fin 2) ℝ := 2 * x - 2 * (x * y ^ 2)
+def G3 : MvPolynomial (Fin 2) ℝ := 2 * y - 2 * (x ^ 2 * y)
+def G4 : MvPolynomial (Fin 2) ℝ := 2 - 2 * (x ^ 2 * y ^ 2)
+
+/-- The seven square roots of `(4 + 4x² + 4y²)·M`. -/
+def qv : Fin 7 → MvPolynomial (Fin 2) ℝ := ![G0, G0, G0, G1, G2, G3, G4]
+
+/-- The three square roots of the multiplier `4 + 4x² + 4y² = 2² + (2x)² + (2y)²`. -/
+def dv : Fin 3 → MvPolynomial (Fin 2) ℝ := ![2, 2 * x, 2 * y]
+
+/-- **The SOS Positivstellensatz certificate for Motzkin** (integer coefficients,
+closed by `ring`):
+`(4 + 4x² + 4y²)·M = 3·G0² + G1² + G2² + G3² + G4²`. -/
+theorem multiplier_mul_motzkin_eq :
+    multiplier * motzkin = G0 ^ 2 + G0 ^ 2 + G0 ^ 2 + G1 ^ 2 + G2 ^ 2 + G3 ^ 2 + G4 ^ 2 := by
+  simp only [multiplier, motzkin, G0, G1, G2, G3, G4]
+  ring
+
+/-- `(4 + 4x² + 4y²)·M` is a sum of squares of polynomials (seven squares). -/
+theorem motzkin_mul_isSumOfSquares : IsSumOfSquaresMv (multiplier * motzkin) := by
+  refine ⟨7, qv, ?_⟩
+  rw [Fin.sum_univ_seven]
+  simp only [qv, Matrix.cons_val]
+  exact multiplier_mul_motzkin_eq
+
+/-- The multiplier `4 + 4x² + 4y² = 2² + (2x)² + (2y)²` is a sum of squares. -/
+theorem multiplier_isSumOfSquares : IsSumOfSquaresMv multiplier := by
+  refine ⟨3, dv, ?_⟩
+  rw [Fin.sum_univ_three]
+  simp only [dv, Matrix.cons_val]
+  simp only [multiplier]
+  ring
+
+/-! ### The rational-function corollary (Artin for Motzkin, constructively) -/
+
+/-- The multiplier is nonzero in `ℝ[x, y]` (its constant term is `4`). -/
+theorem multiplier_ne_zero : multiplier ≠ 0 := by
+  intro h
+  have := congrArg (eval (fun _ => (0 : ℝ))) h
+  simp only [multiplier, map_add, map_mul, map_pow, map_ofNat, eval_X, map_zero] at this
+  norm_num at this
+
+/-- The image of the multiplier in `ℝ(x, y)` is nonzero. -/
+theorem toRF_multiplier_ne_zero : toRF multiplier ≠ 0 := by
+  have hinj : Function.Injective (toRF : MvPolynomial (Fin 2) ℝ → RF) :=
+    IsFractionRing.injective (MvPolynomial (Fin 2) ℝ) RF
+  simpa [map_eq_zero_iff _ hinj] using multiplier_ne_zero
+
+/-- The 21-term product identity, as polynomials:
+`Σ_{i<7, j<3} (qᵢ·dⱼ)² = ((4+4x²+4y²)·M)·(4+4x²+4y²)`.  Both sides are concrete
+polynomials, so `ring` closes it. -/
+theorem product_identity :
+    (∑ p : Fin 7 × Fin 3, (qv p.1 * dv p.2) ^ 2) = (multiplier * motzkin) * multiplier := by
+  rw [Fintype.sum_prod_type]
+  simp only [qv, dv, Fin.sum_univ_seven, Fin.sum_univ_three, Matrix.cons_val]
+  simp only [multiplier, motzkin, G0, G1, G2, G3, G4]
+  ring
+
+/-- **Hilbert's 17th problem, constructively, for Motzkin.**  The Motzkin polynomial
+is a sum of squares of rational functions: `M = Σ (qᵢ·dⱼ / (4+4x²+4y²))²`.
+
+This is the explicit, fully machine-checked witness for the canonical example
+underlying the (necessarily axiomatized) general theorem `artin_hilbert17`. -/
+theorem motzkin_isSOS_ratFunc : IsSumOfSquaresRF (toRF motzkin) := by
+  set a : RF := toRF multiplier with ha
+  have ha0 : a ≠ 0 := toRF_multiplier_ne_zero
+  -- First, the statement indexed by `Fin 7 × Fin 3`.
+  have key : toRF motzkin = ∑ p : Fin 7 × Fin 3, (toRF (qv p.1 * dv p.2) / a) ^ 2 := by
+    have e1 : (∑ p : Fin 7 × Fin 3, (toRF (qv p.1 * dv p.2) / a) ^ 2)
+        = toRF (∑ p : Fin 7 × Fin 3, (qv p.1 * dv p.2) ^ 2) / a ^ 2 := by
+      rw [map_sum, Finset.sum_div]
+      refine Finset.sum_congr rfl (fun p _ => ?_)
+      rw [div_pow, map_pow]
+    rw [e1, product_identity, map_mul, map_mul, ← ha]
+    field_simp
+  -- Reindex `Fin 7 × Fin 3 ≃ Fin 21`.
+  let e : Fin 7 × Fin 3 ≃ Fin 21 := finProdFinEquiv
+  refine ⟨21, fun k => (toRF (qv (e.symm k).1 * dv (e.symm k).2) / a), ?_⟩
+  rw [key]
+  exact (Equiv.sum_comp e.symm
+    (fun p : Fin 7 × Fin 3 => (toRF (qv p.1 * dv p.2) / a) ^ 2)).symm
+
+end
+
+end Hilbert17MotzkinRationalSOS

--- a/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "ann-h17-oq0301-motzkin",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 69
+    },
+    "type": "definition",
+    "title": "The Motzkin polynomial and the SOS multiplier",
+    "content": "motzkin is defined exactly as in the parent entry Hilbert17SumOfSquares.lean: M = x⁴y² + x²y⁴ − 3x²y² + 1, the canonical polynomial that is nonnegative on ℝ² yet not a sum of squares of polynomials. The multiplier 4 + 4x² + 4y² is the key auxiliary: it is strictly positive, it is itself a sum of squares (2² + (2x)² + (2y)²), and multiplying M by it lands the product inside the polynomial SOS cone.",
+    "mathContext": "$M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1,\\qquad D(x,y) = 4 + 4x^2 + 4y^2 = 2^2 + (2x)^2 + (2y)^2.$",
+    "significance": "context"
+  },
+  {
+    "id": "ann-h17-oq0301-certificate",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "The SOS Positivstellensatz certificate",
+    "content": "The mathematical heart of the entry. A single polynomial identity, with all integer coefficients, certifies that D·M is a sum of squares: (4+4x²+4y²)·M = (2xy−x³y−xy³)² (three copies) + (x³y−xy³)² + (2x−2xy²)² + (2y−2x²y)² + (2−2x²y²)². Because every coefficient is an integer, Lean's ring tactic closes it outright. The five generators and the multiplier were found by solving the associated semidefinite Gram-matrix feasibility problem: Motzkin lies on the boundary of the SOS cone, and the rational boundary Gram matrix factors into exactly these squares.",
+    "mathContext": "$(4+4x^2+4y^2)\\,M = 3(2xy-x^3y-xy^3)^2 + (x^3y-xy^3)^2 + (2x-2xy^2)^2 + (2y-2x^2y)^2 + (2-2x^2y^2)^2.$",
+    "significance": "key"
+  },
+  {
+    "id": "ann-h17-oq0301-multiplier-sos",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "The multiplier is a sum of squares",
+    "content": "4 + 4x² + 4y² = 2² + (2x)² + (2y)². This is what lets the polynomial certificate become a rational-function certificate: dividing M = (D·M)/D by an SOS denominator D and using that the product of two sums of squares is again a sum of squares ((∑aᵢ²)(∑bⱼ²) = ∑ᵢⱼ(aᵢbⱼ)²) keeps the result a sum of squares, now of rational functions.",
+    "mathContext": "$D = 2^2 + (2x)^2 + (2y)^2,\\qquad M = \\frac{D\\cdot M}{D} = \\frac{(\\sum q_i^2)(\\sum d_j^2)}{D^2} = \\sum_{i,j}\\Big(\\frac{q_i d_j}{D}\\Big)^2.$",
+    "significance": "key"
+  },
+  {
+    "id": "ann-h17-oq0301-ratfunc",
+    "proofId": "hilbert-17-oq-03-oq-01",
+    "range": {
+      "startLine": 150,
+      "endLine": 177
+    },
+    "type": "theorem",
+    "title": "Hilbert's 17th, constructively, for Motzkin",
+    "content": "motzkin_isSOS_ratFunc concludes M is a sum of squares of rational functions in ℝ(x,y) = FractionRing ℝ[x,y]. The proof lifts the 21-term polynomial identity Σ_{i<7,j<3}(qᵢdⱼ)² = (D·M)·D through the embedding ℝ[x,y] ↪ ℝ(x,y), divides by D² (legitimate since D ≠ 0, its constant term being 4), and reindexes Fin 7 × Fin 3 ≃ Fin 21. The result is the explicit, 0-axiom witness for the canonical example underlying the parent's axiomatized general Artin theorem artin_hilbert17: where the parent only asserts existence, here a certificate is exhibited and machine-checked.",
+    "mathContext": "$M = \\sum_{i=1}^{7}\\sum_{j=1}^{3}\\Big(\\frac{q_i\\,d_j}{4+4x^2+4y^2}\\Big)^2 \\in \\Sigma\\,\\mathbb{R}(x,y)^2.$",
+    "significance": "key"
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "hilbert-17-oq-03-oq-01",
+  "title": "Hilbert's 17th, Constructively: An Explicit Rational SOS Certificate for the Motzkin Polynomial",
+  "slug": "hilbert-17-oq-03-oq-01",
+  "description": "Hilbert's 17th problem asks whether every nonnegative real polynomial is a sum of squares of rational functions; Artin's affirmative answer is necessarily axiomatized in the parent entry (artin_hilbert17), and the companion fact that the Motzkin polynomial M = x⁴y² + x²y⁴ − 3x²y² + 1 is not a sum of squares of polynomials is also carried as an axiom. What was missing is the explicit positive witness: a fully machine-checked certificate that Motzkin IS a sum of squares of rational functions. This entry supplies it, with 0 axioms. The heart is one integer-coefficient polynomial identity (an SOS Positivstellensatz certificate): (4 + 4x² + 4y²)·M = (2xy − x³y − xy³)² (three copies) + (x³y − xy³)² + (2x − 2xy²)² + (2y − 2x²y)² + (2 − 2x²y²)², closed by ring. The multiplier 4 + 4x² + 4y² = 2² + (2x)² + (2y)² is itself a sum of squares, so dividing through in the field of rational functions ℝ(x,y) and using that a product of two sums of squares is a sum of squares yields M = Σ (rational function)² — Artin's theorem made constructive for the canonical example. The certificate was found by solving the associated semidefinite Gram-matrix feasibility problem: Motzkin sits on the boundary of the SOS cone, and the rational boundary Gram matrix factors into the five squares above.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17MotzkinRationalSOS.lean",
+    "tags": [
+      "real-algebraic-geometry",
+      "sum-of-squares",
+      "hilbert-17",
+      "motzkin-polynomial",
+      "positivstellensatz",
+      "rational-functions",
+      "semidefinite-programming",
+      "constructive",
+      "multivariate-polynomials",
+      "artin-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsFractionRing.injective",
+        "description": "The map from a domain into its fraction field is injective — used to lift multiplier ≠ 0 in ℝ[x,y] to its image ≠ 0 in ℝ(x,y), validating the division step.",
+        "module": "Mathlib.RingTheory.Localization.FractionRing"
+      },
+      {
+        "theorem": "Fintype.sum_prod_type",
+        "description": "∑ over A × B equals the iterated sum ∑ₐ ∑ᵇ — organizes the 21 = 7×3 rational-function squares qᵢ·dⱼ/D as a product index.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "finProdFinEquiv",
+        "description": "The equivalence Fin m × Fin n ≃ Fin (m·n) — reindexes the Fin 7 × Fin 3 family of rational-function squares as a single Fin 21 family for the IsSumOfSquaresRF witness.",
+        "module": "Mathlib.Logic.Equiv.Fin"
+      },
+      {
+        "theorem": "Finset.sum_div",
+        "description": "(∑ aᵢ)/c = ∑ (aᵢ/c) — pulls the common denominator D² out of the sum of rational-function squares.",
+        "module": "Mathlib.Algebra.BigOperators.Field"
+      },
+      {
+        "theorem": "MvPolynomial.eval",
+        "description": "Evaluation of a multivariate polynomial — evaluating the multiplier at 0 gives its constant term 4 ≠ 0, proving multiplier ≠ 0.",
+        "module": "Mathlib.Algebra.MvPolynomial.Eval"
+      }
+    ],
+    "originalContributions": [
+      "multiplier_mul_motzkin_eq: an explicit integer-coefficient SOS Positivstellensatz certificate (4+4x²+4y²)·M = 3·G0² + G1² + G2² + G3² + G4², closed entirely by ring.",
+      "motzkin_isSOS_ratFunc: the fully machine-checked, 0-axiom proof that the Motzkin polynomial is a sum of squares of rational functions — Artin's theorem realized constructively for the canonical example, replacing the parent's existence axiom artin_hilbert17 for this M.",
+      "The SOS multiplier and its square decomposition were obtained by solving the semidefinite Gram-matrix feasibility problem numerically (alternating projection onto the affine constraint set and the PSD cone) and reading off the rational boundary Gram matrix.",
+      "Uses the elementary identity that a product of two sums of squares is a sum of squares ((∑aᵢ²)(∑bⱼ²) = ∑ᵢⱼ(aᵢbⱼ)²) together with the multiplier being SOS to convert the polynomial certificate into a rational-function SOS."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Hilbert's 17th problem and Artin's theorem (nonnegative ⇒ SOS of rational functions).",
+      "The Motzkin polynomial as the canonical PSD-but-not-polynomial-SOS example.",
+      "Sums of squares, the SOS cone, and SOS/SDP duality (Gram-matrix method).",
+      "Fraction field of a polynomial ring (ℝ(x,y) = FractionRing ℝ[x,y])."
+    ],
+    "lineCount": 177,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17",
+        "relationship": "Parent: states Artin's theorem and the Motzkin counterexample but carries both the existence of a rational SOS (artin_hilbert17) and Motzkin's non-polynomial-SOS (motzkin_not_sos_polynomial_aux) as axioms. This entry discharges the positive side concretely for Motzkin."
+      },
+      {
+        "id": "hilbert-17-oq-03",
+        "relationship": "Sibling strand: the complexity of deciding PSD ⇒ SOS membership. This entry exhibits an explicit membership certificate for the canonical hard instance, the concrete counterpart to that decision question."
+      },
+      {
+        "id": "hilbert-17-oq-01",
+        "relationship": "Sibling: the Pfister bound on the number of squares needed. Here the rational-function representation of Motzkin uses 21 = 7×3 squares (un-optimized)."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for every result, including motzkin_isSOS_ratFunc. No sorryAx, no native_decide / Lean.ofReduceBool. The Motzkin polynomial is defined identically to the parent entry Hilbert17SumOfSquares.lean.",
+    "theoremCount": 7,
+    "definitionCount": 12,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 177,
+    "namespace": "Hilbert17MotzkinRationalSOS",
+    "opens": [
+      "MvPolynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 4,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "path": "Proofs/Hilbert17MotzkinRationalSOS.lean",
+    "sorries": 0,
+    "definitionCount": 12,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "multiplier_mul_motzkin_eq",
+      "type": "theorem",
+      "description": "The SOS Positivstellensatz certificate: (4+4x²+4y²)·M = G0²+G0²+G0²+G1²+G2²+G3²+G4² with integer-coefficient generators. Closed by ring.",
+      "leanType": "multiplier * motzkin = G0^2 + G0^2 + G0^2 + G1^2 + G2^2 + G3^2 + G4^2"
+    },
+    {
+      "name": "motzkin_mul_isSumOfSquares",
+      "type": "theorem",
+      "description": "(4+4x²+4y²)·M is a sum of squares of polynomials (seven squares).",
+      "leanType": "IsSumOfSquaresMv (multiplier * motzkin)"
+    },
+    {
+      "name": "multiplier_isSumOfSquares",
+      "type": "theorem",
+      "description": "The multiplier 4+4x²+4y² = 2²+(2x)²+(2y)² is itself a sum of squares.",
+      "leanType": "IsSumOfSquaresMv multiplier"
+    },
+    {
+      "name": "motzkin_isSOS_ratFunc",
+      "type": "theorem",
+      "description": "Hilbert's 17th problem, constructively, for Motzkin: M is a sum of squares of rational functions, M = Σ (qᵢ·dⱼ / (4+4x²+4y²))². The explicit 0-axiom witness for the canonical example underlying the axiomatized general theorem artin_hilbert17.",
+      "leanType": "IsSumOfSquaresRF (toRF motzkin)"
+    },
+    {
+      "name": "product_identity",
+      "type": "theorem",
+      "description": "The 21-term polynomial product identity Σ_{i<7,j<3} (qᵢ·dⱼ)² = ((4+4x²+4y²)·M)·(4+4x²+4y²), the bridge from the polynomial certificate to the rational-function representation.",
+      "leanType": "∑ p : Fin 7 × Fin 3, (qv p.1 * dv p.2)^2 = (multiplier * motzkin) * multiplier"
+    }
+  ],
+  "overview": "The parent Hilbert's-17th entry states Artin's theorem — every nonnegative real polynomial is a sum of squares of rational functions — but must axiomatize it (the general proof needs real-closed-field model theory), and likewise axiomatizes that the Motzkin polynomial is not a sum of squares of polynomials. This follow-up supplies the missing constructive content for the canonical example. A single integer-coefficient polynomial identity certifies that 4 + 4x² + 4y² times Motzkin is a sum of seven polynomial squares; since that multiplier is 2² + (2x)² + (2y)², a sum of squares, dividing in ℝ(x,y) and multiplying the two SOS representations gives Motzkin itself as a sum of 21 squares of rational functions. Everything is checked by ring plus elementary field algebra, with 0 axioms. The certificate was discovered by solving the semidefinite Gram-matrix feasibility problem for the SOS multiplier.",
+  "conclusion": {
+    "summary": "A 177-line, 0-sorry, 0-axiom formalization giving an explicit, machine-checked rational sum-of-squares certificate for the Motzkin polynomial: the constructive, positive side of Hilbert's 17th problem for the canonical example, complementing the parent's axiomatized general Artin theorem.",
+    "implications": "Where the parent only asserts existence of a rational SOS (artin_hilbert17 as an axiom), this entry exhibits one for Motzkin and verifies it with 0 axioms. It also demonstrates the Gram-matrix / SDP route to SOS certificates inside a formal proof: solve the SDP numerically, read off the rational boundary Gram factorization, and discharge the resulting polynomial identity with ring.",
+    "openQuestions": [
+      "Minimize the number of rational-function squares: the construction uses 21 = 7×3; the true minimum (Pfister-type bound) for Motzkin over ℝ(x,y) is smaller and could be certified directly.",
+      "Discharge the companion axiom motzkin_not_sos_polynomial_aux (Motzkin is not a polynomial SOS) by the coefficient/degree argument, closing the negative side as well.",
+      "Generalize the SDP-certificate pipeline to the Robinson form (robinson_not_sos_aux) and other extremal PSD polynomials in the parent file."
+    ]
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "Motzkin polynomial — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Positive_polynomial"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    },
+    {
+      "title": "Artin, Über die Zerlegung definiter Funktionen in Quadrate (1927)",
+      "url": "https://link.springer.com/article/10.1007/BF02952513"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Motzkin, the multiplier, and the SOS predicates",
+      "startLine": 60,
+      "endLine": 101,
+      "summary": "motzkin = x⁴y² + x²y⁴ − 3x²y² + 1 (defined identically to the parent entry); multiplier = 4 + 4x² + 4y²; the polynomial- and rational-function- sum-of-squares predicates IsSumOfSquaresMv and IsSumOfSquaresRF over ℝ(x,y) = FractionRing ℝ[x,y]; and the integer-coefficient generators G0…G4 and the witness vectors qv (seven roots) and dv (three roots of the multiplier)."
+    },
+    {
+      "id": "certificate",
+      "title": "The polynomial SOS certificate",
+      "startLine": 103,
+      "endLine": 124,
+      "summary": "multiplier_mul_motzkin_eq is the integer-coefficient identity (4+4x²+4y²)·M = 3G0² + G1² + G2² + G3² + G4², closed by ring; motzkin_mul_isSumOfSquares packages it as IsSumOfSquaresMv, and multiplier_isSumOfSquares shows the multiplier is 2²+(2x)²+(2y)²."
+    },
+    {
+      "id": "rational-corollary",
+      "title": "Artin for Motzkin, constructively",
+      "startLine": 126,
+      "endLine": 177,
+      "summary": "multiplier_ne_zero / toRF_multiplier_ne_zero validate division by the multiplier in ℝ(x,y); product_identity is the 21-term polynomial identity Σ(qᵢdⱼ)² = (multiplier·M)·multiplier; motzkin_isSOS_ratFunc divides through and reindexes Fin 7 × Fin 3 ≃ Fin 21 to conclude M = Σ (qᵢdⱼ/multiplier)², a sum of squares of rational functions."
+    }
+  ]
+}

--- a/src/data/research/problems/hilbert-17-oq-03-oq-01.json
+++ b/src/data/research/problems/hilbert-17-oq-03-oq-01.json
@@ -1,0 +1,80 @@
+{
+  "slug": "hilbert-17-oq-03-oq-01",
+  "title": "Explicit rational sum-of-squares certificate for the Motzkin polynomial",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(4 + 4x^2 + 4y^2)\\cdot M = \\sum q_i^2,\\quad M = \\sum_{i,j}\\left(\\tfrac{q_i d_j}{4+4x^2+4y^2}\\right)^2.",
+    "plain": "Give an explicit, machine-checked certificate that the Motzkin polynomial M = x⁴y² + x²y⁴ − 3x²y² + 1, which is not a sum of squares of polynomials, is nevertheless a sum of squares of rational functions — the constructive, positive side of Hilbert's 17th problem for the canonical example.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Discharge, with 0 axioms, an explicit rational SOS representation of Motzkin, complementing the parent entry's axiomatized general Artin theorem."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "SOLVED: integer-coefficient SOS Positivstellensatz certificate (4+4x²+4y²)·M = 3G0²+G1²+G2²+G3²+G4² (ring), upgraded to M = Σ (qᵢdⱼ/D)² in ℝ(x,y); 0-axiom verified.",
+    "blockers": [],
+    "nextAction": "Done. PR shipped.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: verified 0-axiom (propext/Classical.choice/Quot.sound only), 7 theorems / 12 defs / 177 lines in Proofs/Hilbert17MotzkinRationalSOS.lean.",
+    "builtItems": [
+      "multiplier_mul_motzkin_eq : (4+4x²+4y²)·M = 3G0²+G1²+G2²+G3²+G4², integer-coefficient SOS Positivstellensatz certificate closed by ring",
+      "motzkin_mul_isSumOfSquares / multiplier_isSumOfSquares : the product is a polynomial SOS (7 squares); the multiplier is 2²+(2x)²+(2y)²",
+      "product_identity : Σ_{i<7,j<3} (qᵢdⱼ)² = (D·M)·D, the 21-term polynomial bridge",
+      "motzkin_isSOS_ratFunc : M = Σ (qᵢdⱼ/D)² in ℝ(x,y) = FractionRing ℝ[x,y] — Artin for Motzkin, constructively, 0 axioms"
+    ],
+    "keyInsights": [
+      "The SOS multiplier 4+4x²+4y² and its 5-square certificate were found by solving the SDP Gram-matrix feasibility problem (alternating projection onto affine constraints ∩ PSD cone); Motzkin sits on the SOS-cone boundary, giving a rank-deficient rational Gram matrix.",
+      "Using the multiplier 4(1+x²+y²)=2²+(2x)²+(2y)² instead of 1+x²+y² makes every square have integer coefficients, so ring closes the certificate with no C(1/2) fraction bookkeeping.",
+      "Product of two sums of squares is a sum of squares ((∑aᵢ²)(∑bⱼ²)=∑ᵢⱼ(aᵢbⱼ)²); combined with D itself being SOS this converts the polynomial certificate D·M=∑qᵢ² into M=∑(qᵢdⱼ/D)²."
+    ],
+    "deadEnds": [
+      "Multiplier 1+x²+y² also works but lands Motzkin exactly on the SOS-cone boundary with half-integer Gram entries (C(1/2) coefficients), which ring cannot fold; scaling by 4 removes the fractions."
+    ],
+    "nextSteps": [
+      "Reduce the 21 = 7×3 rational-function squares toward the minimal (Pfister-type) count for Motzkin.",
+      "Discharge the parent's companion axiom motzkin_not_sos_polynomial_aux (the negative side: Motzkin is not a polynomial SOS) via the coefficient/degree argument.",
+      "Apply the same SDP-certificate pipeline to the Robinson form (robinson_not_sos_aux)."
+    ]
+  },
+  "tags": [
+    "real-algebraic-geometry",
+    "sum-of-squares",
+    "hilbert-17",
+    "motzkin-polynomial",
+    "positivstellensatz",
+    "constructive",
+    "semidefinite-programming"
+  ],
+  "relatedProofs": [
+    "hilbert-17",
+    "hilbert-17-oq-01",
+    "hilbert-17-oq-03"
+  ],
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "started": "2026-06-24T00:00:00-07:00",
+  "significance": "Supplies the explicit, 0-axiom positive witness for Hilbert's 17th problem on the canonical Motzkin example, complementing the parent's axiomatized general theorem and demonstrating an SDP-to-Lean SOS-certificate pipeline.",
+  "tractability": "Solved in one session: SDP-found certificate discharged by ring plus elementary fraction-field algebra."
+}


### PR DESCRIPTION
## Summary

A fully machine-checked, **0-axiom** witness for Hilbert's 17th problem on its canonical example. The parent entry `hilbert-17` necessarily **axiomatizes** Artin's theorem (`artin_hilbert17`) and also carries Motzkin's non-polynomial-SOS status as an axiom (`motzkin_not_sos_polynomial_aux`). This follow-up supplies the missing **positive, constructive** side: an exhibited certificate that the Motzkin polynomial

  `M(x,y) = x⁴y² + x²y⁴ − 3x²y² + 1`

— which is *not* a sum of squares of polynomials — *is* a sum of squares of **rational functions**.

## The certificate

The heart is a single integer-coefficient polynomial identity (an SOS *Positivstellensatz certificate*), closed by `ring`:

```
(4 + 4x² + 4y²)·M = 3·(2xy − x³y − xy³)² + (x³y − xy³)² + (2x − 2xy²)² + (2y − 2x²y)² + (2 − 2x²y²)²
```

Because the multiplier `4 + 4x² + 4y² = 2² + (2x)² + (2y)²` is itself a sum of squares, dividing through in `ℝ(x,y) = FractionRing ℝ[x,y]` and using that a product of two sums of squares is a sum of squares `((∑aᵢ²)(∑bⱼ²) = ∑ᵢⱼ(aᵢbⱼ)²)` yields

```
M = Σ_{i<7, j<3} (qᵢ·dⱼ / (4+4x²+4y²))²   ∈ Σ ℝ(x,y)²
```

This is `motzkin_isSOS_ratFunc` — Artin's theorem realized constructively for Motzkin, replacing the parent's existence axiom for this `M`.

## Main results

| theorem | statement |
|---|---|
| `multiplier_mul_motzkin_eq` | the integer SOS certificate (closed by `ring`) |
| `motzkin_mul_isSumOfSquares` | `(4+4x²+4y²)·M` is a polynomial SOS (7 squares) |
| `multiplier_isSumOfSquares` | `4+4x²+4y² = 2²+(2x)²+(2y)²` |
| `product_identity` | the 21-term bridge `Σ(qᵢdⱼ)² = (D·M)·D` |
| `motzkin_isSOS_ratFunc` | **M is a sum of squares of rational functions** |

## Verification

- `#print axioms` for every result (including `motzkin_isSOS_ratFunc`) lists only `propext`, `Classical.choice`, `Quot.sound` → **0 axioms / verified**. No `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- `motzkin` is defined identically to the parent `Hilbert17SumOfSquares.lean`.
- 7 theorems / 12 definitions / 177 lines.

## How the certificate was found

The SOS multiplier and its 5-square decomposition were obtained by solving the associated **semidefinite Gram-matrix feasibility problem** numerically (alternating projection onto the affine constraint set ∩ the PSD cone). Motzkin sits on the *boundary* of the SOS cone (rank-deficient Gram); the smallest multiplier `1+x²+y²` gives half-integer Gram entries that `ring` cannot fold, so **scaling the multiplier by 4** clears all denominators to integers. A 4-parameter symmetric parity-block reduction pinned the exact rationals.

## Files
- `proofs/Proofs/Hilbert17MotzkinRationalSOS.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/hilbert-17-oq-03-oq-01/{meta.json,annotations.json}` (new)
- `src/data/research/problems/hilbert-17-oq-03-oq-01.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)