### PR TITLE
Enrich Feuerbach's Theorem: Euler's Metric Identity OH²=9R²−(a²+b²+c²)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-feuoq010101-header",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "concept",
+    "title": "The open question: measure OH, the Euler metric identity",
+    "content": "The orthocenter sub-line has so far been qualitative: altitude concurrency at H = A + B + C − 2O, and the reflections of H landing on the circumcircle. The grandparent records the Euler line only as the collinearity G = (2O + H)/3, never measuring the distance OH. This file caps the line with the classical METRIC identity OH² = 9R² − (a² + b² + c²) — the distance from circumcenter to orthocenter in terms of the circumradius R and side lengths a, b, c — which is also the algebraic source of Euler's inequality a² + b² + c² ≤ 9R².",
+    "mathContext": "$OH^2 = 9R^2 - (a^2 + b^2 + c^2)$, where $H = A + B + C - 2O$, $R$ is the circumradius and $a,b,c$ the side lengths.",
+    "significance": "key",
+    "relatedConcepts": ["Euler line", "orthocenter", "circumcenter", "circumradius", "Euler's inequality", "metric identity"],
+    "prerequisites": ["coordinate geometry", "squared distances", "triangle centers"]
+  },
+  {
+    "id": "ann-feuoq010101-equidist",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 123 },
+    "type": "lemma",
+    "title": "Pairwise equidistance of the circumcenter (local reproof)",
+    "content": "The parent declares its equidistance facts `private`, so the two needed here (against vertex A) are reproved locally. `perp_bisector_AB` and `perp_bisector_AC` are the perpendicular-bisector identities — linear in O — closed by substituting the circumcenter fraction and `field_simp; ring`. `equidistB` and `equidistC` then upgrade these to |B − O|² = |A − O|² and |C − O|² = |A − O|² via `nlinarith`. These two relations are the entire kernel the metric identity is reduced against.",
+    "mathContext": "Circumcenter $O$ equidistant from vertices: $|B-O|^2 = |A-O|^2$ and $|C-O|^2 = |A-O|^2$, i.e. $O$ lies on the perpendicular bisectors of $AB$ and $AC$.",
+    "significance": "supporting",
+    "relatedConcepts": ["circumcenter", "perpendicular bisector", "equidistance", "field_simp", "nlinarith"],
+    "prerequisites": ["circumcenter formula", "polynomial identities"]
+  },
+  {
+    "id": "ann-feuoq010101-bridge",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 125, "endLine": 132 },
+    "type": "lemma",
+    "title": "Part I: the squared-distance ↔ metric bridge",
+    "content": "`sq_dist2` proves (dist2 P Q)² = dist2_sq P Q: the metric distance is the square root of the polynomial squared-distance, so squaring recovers it (`Real.sq_sqrt` on a manifestly nonnegative argument via `positivity`). This single lemma isolates the only place Real.sqrt is touched, letting all the heavy algebra stay polynomial in dist2_sq and only converting to circumradius/side-lengths at the end.",
+    "mathContext": "$(\\mathrm{dist2}\\,P\\,Q)^2 = \\mathrm{dist2\\_sq}\\,P\\,Q$ since $\\mathrm{dist2} = \\sqrt{\\mathrm{dist2\\_sq}}$ and $\\mathrm{dist2\\_sq} \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sq_sqrt", "distance", "squared distance", "positivity"],
+    "prerequisites": ["square roots", "nonnegativity"]
+  },
+  {
+    "id": "ann-feuoq010101-metric",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 134, "endLine": 173 },
+    "type": "theorem",
+    "title": "Part II: Euler's metric identity OH² = 9R² − (a²+b²+c²)",
+    "content": "`orthocenter_circumcenter_dist_sq` proves the squared-distance form by a SINGLE `linear_combination 3·equidistB + 3·equidistC` after `simp only [dist2_sq, Triangle.orthocenter]`. The whole identity is exactly −3 times the sum of the two circumcenter-equidistance defects — so no cofactor search or case analysis is needed (unlike the reflection sibling, the certificate is trivial). `orthocenter_circumcenter_dist_classical` then rewrites each squared distance into circumradius/side-length form via the sq_dist2 bridge, giving the textbook OH² = 9R² − (a²+b²+c²). `sum_sq_sides_le_nine_circumradius_sq` derives Euler's inequality precursor a²+b²+c² ≤ 9R² by `linarith` against OH² ≥ 0.",
+    "mathContext": "$OH^2 - [9R^2 - (a^2+b^2+c^2)] = -3(|A-O|^2 - |B-O|^2) - 3(|A-O|^2 - |C-O|^2) = 0$. Since $OH^2 \\ge 0$: $a^2+b^2+c^2 \\le 9R^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["linear_combination", "Euler's inequality", "ideal membership", "circumradius", "nonnegativity"],
+    "prerequisites": ["polynomial certificates", "squared distances", "linarith"]
+  },
+  {
+    "id": "ann-feuoq010101-euler-line",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 175, "endLine": 205 },
+    "type": "theorem",
+    "title": "Part III: metric Euler line, OG : GH : OH = 1 : 2 : 3",
+    "content": "`centroid_circumcenter_dist_sq` (OH² = 9·OG²) and `centroid_orthocenter_dist_sq` (4·OH² = 9·GH²) together give the exact distance ratio OG : GH : OH = 1 : 2 : 3 — upgrading the grandparent's qualitative collinearity to a metric statement. These need NO equidistance: after unfolding the centroid and orthocenter definitions, G − O = (H − O)/3 and H − G = (2/3)(H − O) are visible, so squaring closes by `ring` alone. `centroid_circumcenter_dist_classical` combines OH² = 9·OG² with the classical identity to give OG² = R² − (a²+b²+c²)/9.",
+    "mathContext": "$G - O = \\tfrac{1}{3}(H - O)$ and $H - G = \\tfrac{2}{3}(H - O)$, so $OH^2 = 9\\,OG^2$, $4\\,OH^2 = 9\\,GH^2$, hence $OG : GH : OH = 1 : 2 : 3$ and $OG^2 = R^2 - (a^2+b^2+c^2)/9$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler line", "centroid", "distance ratio", "collinearity", "ring"],
+    "prerequisites": ["centroid formula", "vector scaling", "squared distances"]
+  },
+  {
+    "id": "ann-feuoq010101-example",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 207, "endLine": 229 },
+    "type": "theorem",
+    "title": "Part IV: worked example — the 3-4-5 right triangle",
+    "content": "`triangle_345_OH_sq` computes OH² = 25/4 for the 3-4-5 right triangle: the orthocenter is the right-angle vertex A = (0,0), the circumcenter is (3/2, 2), so OH² = (3/2)² + 2² = 25/4 and OH = 5/2 = R exactly (proved by `norm_num` after the parent's coordinate rewrites). `triangle_345_euler_metric` verifies the identity numerically: 9R² − (a²+b²+c²) = 9·(25/4) − (25+16+9) = 25/4 = OH².",
+    "mathContext": "$OH^2 = (3/2)^2 + 2^2 = 25/4 = (5/2)^2 = R^2$; and $9R^2 - (a^2+b^2+c^2) = 9\\cdot\\tfrac{25}{4} - 50 = \\tfrac{25}{4}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["right triangle", "worked example", "circumradius", "norm_num"],
+    "prerequisites": ["right triangles", "numerical verification"]
+  }
+]

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const feuerbachsTheoremDefsOq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const feuerbachsTheoremDefsOq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const feuerbachsTheoremDefsOq01Oq01Oq01Oq01Data: ProofData = {
+  proof: feuerbachsTheoremDefsOq01Oq01Oq01Oq01Proof,
+  annotations: feuerbachsTheoremDefsOq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-01` (quality 45, passes 0).

## What was missing
Complete `meta.json` (overview, sections, conclusion, mainTheorems) but **no `annotations.json` and no `index.ts`** — without `index.ts` the page renders 'proof not found'.

## Changes
- **Created `index.ts`** — wires meta + annotations + raw Lean source.
- **Created `annotations.json`** — 6 annotations covering all four parts, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Open-question framing (measure OH, the Euler metric identity)
  - Circumcenter pairwise equidistance (local reproof)
  - Part I: the `sq_dist2` squared-distance ↔ metric bridge
  - Part II: Euler's metric identity via a single `linear_combination` + the inequality precursor a²+b²+c² ≤ 9R²
  - Part III: the metric Euler line OG : GH : OH = 1 : 2 : 3
  - Part IV: the 3-4-5 worked example (OH = R = 5/2)

## Verification
- `pnpm build` passes (✓ built).
- JSON validated; annotation line ranges align with `Proofs/FeuerbachsTheoremDefsOQ01OQ01OQ01OQ01.lean`.
- Axiom integrity confirmed: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries — matches the Lean file (#print axioms: propext/Classical.choice/Quot.sound only).