### PR TITLE
research(vietas-formulas-oq-04): quadratic discriminant b²−4ac = a²(r−s)² via Vieta [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3868,6 +3868,7 @@ import Proofs.VietasFormulasOQ02
 import Proofs.VietasFormulasOQ03
 import Proofs.VietasFormulasOQ03OQ01
 import Proofs.VietasFormulasOQ03OQ05
+import Proofs.VietasFormulasOQ04
 import Proofs.VivianiTheorem
 import Proofs.WeakGoldbach
 import Proofs.WeitzenbockInequalityOQ01

--- a/proofs/Proofs/VietasFormulasOQ04.lean
+++ b/proofs/Proofs/VietasFormulasOQ04.lean
@@ -1,0 +1,145 @@
+/-
+  # The discriminant of a quadratic via Vieta's formulas
+  # (vietas-formulas-oq-04)
+
+  ## The Open Question
+
+  Vieta's formulas relate the coefficients of a polynomial to its roots. For a
+  quadratic `a·x² + b·x + c` with roots `r, s` (and `a ≠ 0`), the relations are
+
+      r + s = -b/a,      r·s = c/a,        equivalently   b = -a(r + s),  c = a·r·s.
+
+  The parent entry `vietas-formulas` packages these relations. This file answers the
+  open question: **express the discriminant `Δ = b² − 4ac` directly in terms of the
+  roots and prove that a quadratic has a repeated root exactly when `Δ = 0`.**
+
+  The key identity is purely algebraic:
+
+      b² − 4ac = a²·(r − s)².
+
+  From it everything follows: `Δ = 0 ⇔ r = s` over any field, `Δ ≥ 0` always over an
+  ordered field (it is a square), and `Δ > 0 ⇔ r ≠ s` (distinct real roots).
+
+  We also close the loop with `vieta_from_roots`, which *derives* the Vieta relations
+  `b = -a(r+s)`, `c = a·r·s` from the mere fact that `r ≠ s` are both roots — so the
+  discriminant identity holds for any quadratic with two distinct roots in the field.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib
+
+namespace VietaDiscriminant
+
+/-- **The discriminant identity (over any commutative ring).**
+    Substituting the Vieta relations `b = -a(r+s)`, `c = a·r·s` into `b² − 4ac`
+    collapses, by a single ring computation, to `a²·(r − s)²`. -/
+theorem discriminant_eq {R : Type*} [CommRing R] (a b c r s : R)
+    (hb : b = -a * (r + s)) (hc : c = a * (r * s)) :
+    b ^ 2 - 4 * a * c = a ^ 2 * (r - s) ^ 2 := by
+  subst hb hc; ring
+
+/-- **Vieta relations from two distinct roots (over a field).**
+    If `r ≠ s` are both roots of `a·x² + b·x + c`, then necessarily
+    `b = -a(r + s)` and `c = a·r·s`. Subtracting the two root equations gives
+    `(r − s)·(a(r+s) + b) = 0`; cancelling the nonzero factor `r − s` yields the
+    formula for `b`, and back-substitution yields the formula for `c`. -/
+theorem vieta_from_roots {F : Type*} [Field F] {a b c r s : F}
+    (hr : a * r ^ 2 + b * r + c = 0) (hs : a * s ^ 2 + b * s + c = 0)
+    (hrs : r ≠ s) :
+    b = -a * (r + s) ∧ c = a * (r * s) := by
+  -- Difference of the two root equations factors through `r − s`.
+  have key : (r - s) * (a * (r + s) + b) = 0 := by linear_combination hr - hs
+  have hrs' : r - s ≠ 0 := sub_ne_zero.mpr hrs
+  have hbz : a * (r + s) + b = 0 := (mul_eq_zero.mp key).resolve_left hrs'
+  have hb : b = -a * (r + s) := by linear_combination hbz
+  refine ⟨hb, ?_⟩
+  -- Back-substitute `b` into the first root equation to solve for `c`.
+  rw [hb] at hr
+  linear_combination hr
+
+/-- **Discriminant from two distinct roots.** Combining the two results above:
+    for any quadratic with distinct roots `r ≠ s` in a field, `b² − 4ac = a²(r−s)²`. -/
+theorem discriminant_eq_of_roots {F : Type*} [Field F] {a b c r s : F}
+    (hr : a * r ^ 2 + b * r + c = 0) (hs : a * s ^ 2 + b * s + c = 0)
+    (hrs : r ≠ s) :
+    b ^ 2 - 4 * a * c = a ^ 2 * (r - s) ^ 2 := by
+  obtain ⟨hb, hc⟩ := vieta_from_roots hr hs hrs
+  exact discriminant_eq a b c r s hb hc
+
+/-- **Repeated root criterion (over a field).** With `a ≠ 0`, the discriminant
+    vanishes exactly when the two roots coincide: `b² − 4ac = 0 ⇔ r = s`. -/
+theorem discriminant_zero_iff {F : Type*} [Field F] {a b c r s : F}
+    (ha : a ≠ 0) (hb : b = -a * (r + s)) (hc : c = a * (r * s)) :
+    b ^ 2 - 4 * a * c = 0 ↔ r = s := by
+  rw [discriminant_eq a b c r s hb hc]
+  constructor
+  · intro h
+    have ha2 : a ^ 2 ≠ 0 := pow_ne_zero 2 ha
+    have hsq : (r - s) ^ 2 = 0 := (mul_eq_zero.mp h).resolve_left ha2
+    exact sub_eq_zero.mp (sq_eq_zero_iff.mp hsq)
+  · intro h; subst h; ring
+
+/-- **Nonnegativity over an ordered field.** Since the discriminant equals the
+    square `a²(r−s)²`, it is always `≥ 0` when the roots lie in the field. -/
+theorem discriminant_nonneg {F : Type*} [Field F] [LinearOrder F]
+    [IsStrictOrderedRing F] {a b c r s : F}
+    (hb : b = -a * (r + s)) (hc : c = a * (r * s)) :
+    0 ≤ b ^ 2 - 4 * a * c := by
+  rw [discriminant_eq a b c r s hb hc]
+  positivity
+
+/-- **Strict positivity ⇔ distinct roots (over an ordered field).**
+    With `a ≠ 0`, the discriminant is strictly positive exactly when the roots
+    are distinct — the familiar "two distinct real roots ⇔ Δ > 0" dichotomy. -/
+theorem discriminant_pos_iff_distinct {F : Type*} [Field F] [LinearOrder F]
+    [IsStrictOrderedRing F] {a b c r s : F}
+    (ha : a ≠ 0) (hb : b = -a * (r + s)) (hc : c = a * (r * s)) :
+    0 < b ^ 2 - 4 * a * c ↔ r ≠ s := by
+  rw [discriminant_eq a b c r s hb hc]
+  constructor
+  · intro h hrs
+    subst hrs; simp at h
+  · intro hrs
+    have hrs' : r - s ≠ 0 := sub_ne_zero.mpr hrs
+    have h1 : 0 < a ^ 2 := by positivity
+    have h2 : 0 < (r - s) ^ 2 := by positivity
+    exact mul_pos h1 h2
+
+/-!
+## Concrete examples
+-/
+
+section Examples
+
+/-- `x² − 5x + 6` has roots `2, 3`: here `a = 1, b = −5, c = 6` and
+    `Δ = 25 − 24 = 1 = 1²·(3 − 2)²`. -/
+example : ((-5 : ℚ)) ^ 2 - 4 * 1 * 6 = (1 : ℚ) ^ 2 * (3 - 2) ^ 2 := by norm_num
+
+/-- A perfect square `x² − 4x + 4 = (x − 2)²` has the repeated root `2` and `Δ = 0`. -/
+example : ((-4 : ℚ)) ^ 2 - 4 * 1 * 4 = 0 := by norm_num
+
+/-- `x² + 1` (roots `±i`, not real) has `Δ = −4 < 0` over `ℚ`. -/
+example : ((0 : ℚ)) ^ 2 - 4 * 1 * 1 < 0 := by norm_num
+
+end Examples
+
+end VietaDiscriminant
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `discriminant_eq`              | `b² − 4ac = a²(r − s)²` from the Vieta relations (any `CommRing`) |
+  | `vieta_from_roots`             | `r ≠ s` roots ⟹ `b = -a(r+s)`, `c = a·r·s` (field) |
+  | `discriminant_eq_of_roots`     | `b² − 4ac = a²(r − s)²` from distinct roots (field) |
+  | `discriminant_zero_iff`        | `a ≠ 0 ⟹ (Δ = 0 ⇔ r = s)` (repeated root) |
+  | `discriminant_nonneg`          | `0 ≤ Δ` over a `LinearOrderedField` |
+  | `discriminant_pos_iff_distinct`| `a ≠ 0 ⟹ (0 < Δ ⇔ r ≠ s)` (distinct real roots) |
+
+  Everything reduces to the single ring identity `b² − 4ac = a²(r − s)²`.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/vietas-formulas-oq-04/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-04/annotations.json
@@ -1,0 +1,159 @@
+[
+  {
+    "id": "ann-vf-oq04-discriminant-eq",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 37,
+      "endLine": 39
+    },
+    "type": "theorem",
+    "title": "The Discriminant Identity b² − 4ac = a²(r − s)²",
+    "content": "The heart of the file. Given the Vieta relations `b = -a*(r + s)` and `c = a*(r*s)`, the discriminant `b² − 4ac` collapses to `a²·(r − s)²`. The proof is a single `subst hb hc; ring`: after substitution the goal is the polynomial identity a²(r+s)² − 4a·a·rs = a²(r − s)², which `ring` verifies. Stated over an arbitrary `CommRing R`, so it holds over ℤ, finite fields, and matrix rings alike — no field, order, or invertibility hypotheses.",
+    "mathContext": "b² − 4ac = (−a(r+s))² − 4a(a·rs) = a²[(r+s)² − 4rs] = a²(r−s)². The bracket is the classical 'sum of roots squared minus four times product' which equals the squared root-gap.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "discriminant",
+      "Vieta's formulas",
+      "ring identity",
+      "CommRing"
+    ],
+    "prerequisites": [
+      "Commutative ring axioms",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-vieta-from-roots",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 47,
+      "endLine": 61
+    },
+    "type": "theorem",
+    "title": "Deriving Vieta's Relations from Two Distinct Roots",
+    "content": "The converse direction: if `r ≠ s` are both roots of `a·x² + b·x + c` (over a field), then necessarily `b = -a(r + s)` and `c = a·r·s`. Subtracting the two root equations gives, via `linear_combination hr - hs`, the factorization `(r − s)·(a(r+s) + b) = 0`. Since `r ≠ s`, the factor `r − s` is nonzero, so `mul_eq_zero` forces `a(r+s) + b = 0`, i.e. the formula for b. Back-substituting b into the first root equation and a final `linear_combination` recovers `c = a·r·s`.",
+    "mathContext": "From a·r² + b·r + c = a·s² + b·s + c (both = 0), subtract: a(r² − s²) + b(r − s) = 0 = (r − s)(a(r+s) + b). Cancelling r − s ≠ 0 gives b = −a(r+s); then c = −(a·r² + b·r) = a·r·s.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "polynomial roots",
+      "mul_eq_zero",
+      "sub_ne_zero",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Field axioms",
+      "No-zero-divisor cancellation"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-discriminant-of-roots",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 70
+    },
+    "type": "theorem",
+    "title": "Discriminant from Distinct Roots",
+    "content": "Combines `vieta_from_roots` with `discriminant_eq`: for any quadratic with two distinct roots `r ≠ s` in a field, `b² − 4ac = a²(r − s)²` holds without separately assuming the Vieta relations. This shows the discriminant identity is intrinsic to having distinct roots, not an extra hypothesis.",
+    "mathContext": "The discriminant identity transported across the bridge: distinct roots ⟹ Vieta relations ⟹ discriminant = squared root-gap.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant",
+      "polynomial roots"
+    ],
+    "prerequisites": [
+      "vieta_from_roots",
+      "discriminant_eq"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-zero-iff",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 72,
+      "endLine": 83
+    },
+    "type": "theorem",
+    "title": "Repeated-Root Criterion: Δ = 0 ⇔ r = s",
+    "content": "Over a field with `a ≠ 0`, the discriminant vanishes exactly when the two roots coincide. Rewriting by the discriminant identity reduces the goal to `a²(r − s)² = 0 ⇔ r = s`. Forward: `a² ≠ 0` (as `pow_ne_zero 2 ha`) lets `mul_eq_zero` strip it, leaving `(r − s)² = 0`; then `sq_eq_zero_iff` and `sub_eq_zero` give `r = s`. Reverse: substitute `r = s` and `ring` closes `a²·0 = 0`.",
+    "mathContext": "Δ = a²(r−s)². With a ≠ 0 in a field (no zero divisors), Δ = 0 ⇔ (r−s)² = 0 ⇔ r − s = 0 ⇔ r = s. This is the algebraic meaning of a 'double root'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "repeated root",
+      "discriminant",
+      "sq_eq_zero_iff",
+      "pow_ne_zero"
+    ],
+    "prerequisites": [
+      "Field axioms",
+      "No-zero-divisor cancellation"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-nonneg",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 85,
+      "endLine": 89
+    },
+    "type": "theorem",
+    "title": "Discriminant Nonnegativity over an Ordered Field",
+    "content": "Over a linearly ordered field, `0 ≤ b² − 4ac` whenever the roots lie in the field. After rewriting to `a²(r − s)²`, the goal is closed by `positivity`: the discriminant is literally a product of squares, hence nonnegative — not an inequality requiring estimation. The typeclass uses the current Mathlib spelling `[Field F] [LinearOrder F] [IsStrictOrderedRing F]` (the former `LinearOrderedField` was refactored).",
+    "mathContext": "Δ = a²(r−s)² is a square in an ordered field, so Δ ≥ 0. This is the structural reason √Δ is real exactly when the roots are real.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ordered field",
+      "discriminant",
+      "positivity",
+      "IsStrictOrderedRing"
+    ],
+    "prerequisites": [
+      "Ordered field axioms",
+      "positivity tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-pos-iff",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 95,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Distinct-Roots Dichotomy: Δ > 0 ⇔ r ≠ s",
+    "content": "Over an ordered field with `a ≠ 0`, the discriminant is strictly positive exactly when the roots are distinct — the familiar 'two distinct real roots ⇔ Δ > 0'. Forward: if `r = s` then `a²(r − s)² = 0`, contradicting `0 < Δ` (closed by `simp`). Reverse: `r ≠ s` gives `r − s ≠ 0`, so both `a² > 0` and `(r − s)² > 0` by `positivity`, and `mul_pos` concludes.",
+    "mathContext": "Δ = a²(r−s)² > 0 ⇔ both factors positive ⇔ a ≠ 0 and r ≠ s. With a ≠ 0 fixed, the sign of the discriminant is governed entirely by whether the roots are distinct.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant",
+      "distinct roots",
+      "mul_pos",
+      "positivity"
+    ],
+    "prerequisites": [
+      "Ordered field axioms",
+      "positivity tactic"
+    ]
+  },
+  {
+    "id": "ann-vf-oq04-examples",
+    "proofId": "vietas-formulas-oq-04",
+    "range": {
+      "startLine": 117,
+      "endLine": 123
+    },
+    "type": "example",
+    "title": "Concrete Discriminant Computations",
+    "content": "Three sanity checks over ℚ: `x² − 5x + 6` (roots 2, 3) has Δ = 25 − 24 = 1 = 1²(3 − 2)²; the perfect square `x² − 4x + 4 = (x − 2)²` has Δ = 0 (repeated root); and `x² + 1` (no real roots) has Δ = −4 < 0. Each is dispatched by `norm_num`.",
+    "mathContext": "Δ > 0, Δ = 0, Δ < 0 illustrate the three regimes: distinct real roots, a repeated root, and no real roots.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "Rational arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/vietas-formulas-oq-04/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-04/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "vietas-formulas-oq-04",
+  "title": "The Quadratic Discriminant via Vieta's Formulas",
+  "slug": "vietas-formulas-oq-04",
+  "description": "Expresses the discriminant of a quadratic directly in terms of its roots: b² − 4ac = a²(r − s)². From this single ring identity follow the repeated-root criterion (Δ = 0 ⇔ r = s over any field), nonnegativity of the discriminant over an ordered field, and the distinct-roots dichotomy (Δ > 0 ⇔ r ≠ s). A companion lemma derives the Vieta relations b = −a(r+s), c = a·r·s from the mere fact that r ≠ s are both roots.",
+  "meta": {
+    "author": "Francois Viete (1615); formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant",
+    "date": "1615",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VietasFormulasOQ04.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "vietas-formulas",
+      "discriminant",
+      "quadratic",
+      "research",
+      "field-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "defCount": 0,
+    "lineCount": 145,
+    "mathlibDependencies": [
+      {
+        "theorem": "mul_eq_zero",
+        "description": "In a domain, a product is zero iff a factor is zero (used to cancel r − s and to read off the repeated-root criterion)",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      },
+      {
+        "theorem": "sq_eq_zero_iff",
+        "description": "a² = 0 ↔ a = 0 over a monoid with no zero divisors",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "sub_eq_zero",
+        "description": "a − b = 0 ↔ a = b (translating the root-coincidence to the discriminant)",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The core identity b² − 4ac = a²(r − s)² proved by a single ring computation over any commutative ring",
+      "vieta_from_roots: derives the Vieta relations b = −a(r+s), c = a·r·s from two distinct roots, by factoring the difference of the root equations through (r − s)",
+      "Repeated-root criterion: over any field with a ≠ 0, Δ = 0 ⇔ r = s",
+      "Discriminant nonnegativity over an ordered field (Δ is a square)",
+      "Distinct-roots dichotomy: with a ≠ 0, Δ > 0 ⇔ r ≠ s"
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Vieta's formulas for the quadratic (parent entry)",
+      "Commutative ring and field axioms",
+      "No-zero-divisor cancellation",
+      "Ordered field positivity (positivity tactic)"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The discriminant b² − 4ac of a quadratic ax² + bx + c is the classical quantity that detects repeated roots and, over the reals, the existence of two distinct real solutions. Its sign governs the qualitative behaviour of the quadratic formula. Vieta's formulas (Francois Viete, 1615) relate the coefficients of a polynomial to symmetric functions of its roots. This entry connects the two: it shows the discriminant is exactly a² times the squared root-gap (r − s)², making every property of the discriminant a transparent consequence of a single algebraic identity.",
+    "problemStatement": "For a quadratic ax² + bx + c with roots r, s (so b = −a(r+s) and c = a·r·s by Vieta), prove the discriminant identity b² − 4ac = a²(r − s)², and deduce: (i) over a field with a ≠ 0, the quadratic has a repeated root exactly when Δ = 0; (ii) over an ordered field the discriminant is always nonnegative; and (iii) it is strictly positive exactly when the roots are distinct.",
+    "text": "Expresses the discriminant b² − 4ac of a quadratic as a²(r − s)² in terms of its roots, and derives the repeated-root, nonnegativity, and distinct-roots criteria from this one identity. Also derives the Vieta relations themselves from the assumption that r ≠ s are roots.",
+    "proofStrategy": "Everything reduces to one ring identity. Substituting the Vieta relations b = −a(r+s), c = a·r·s into b² − 4ac and expanding gives a²[(r+s)² − 4rs] = a²(r − s)² — a one-line `ring` call valid over any commutative ring.\n\nThe converse direction, vieta_from_roots, recovers the Vieta relations from two distinct roots: subtracting the root equations a·r² + b·r + c = 0 and a·s² + b·s + c = 0 factors as (r − s)(a(r+s) + b) = 0; since r ≠ s the factor r − s is invertible, forcing b = −a(r+s), and back-substitution yields c = a·r·s. This step uses `linear_combination` for the algebraic rearrangements.\n\nThe corollaries are then immediate: Δ = 0 ⇔ (r − s)² = 0 ⇔ r = s (no zero divisors, a ≠ 0); Δ ≥ 0 because a²(r − s)² is a square (`positivity`); and Δ > 0 ⇔ r ≠ s because both a² and (r − s)² are strictly positive exactly when their bases are nonzero.",
+    "keyInsights": [
+      "**One identity, all corollaries**: The repeated-root test, the sign analysis, and the discriminant formula are not separate facts — they are three readings of b² − 4ac = a²(r − s)². Proving the identity once makes the rest follow by elementary algebra.",
+      "**Maximal generality for free**: The core identity needs only a commutative ring, so it holds over ℤ, finite fields, and matrix rings, not just ℝ. The field structure is invoked only where cancellation is genuinely required (deriving Vieta from roots, and the repeated-root iff), and the order only for the sign statements.",
+      "**Deriving Vieta from roots**: vieta_from_roots closes the loop — the discriminant identity does not depend on assuming the Vieta relations, since those relations are themselves forced by the existence of two distinct roots. The factor (r − s) appearing in the discriminant is the very factor cancelled to obtain Vieta.",
+      "**Why the discriminant is a square**: Over an ordered field the nonnegativity Δ ≥ 0 is not an inequality to be estimated but an identity: the discriminant literally equals a perfect square. This is the structural reason the quadratic formula's √Δ makes sense exactly when roots are real."
+    ],
+    "prerequisites": [
+      "Vieta's formulas for the quadratic",
+      "Commutative ring and field axioms",
+      "No-zero-divisor cancellation",
+      "Ordered-field positivity"
+    ]
+  },
+  "conclusion": {
+    "summary": "The quadratic discriminant equals a²(r − s)², a single ring identity from which the repeated-root criterion (Δ = 0 ⇔ r = s), discriminant nonnegativity, and the distinct-roots dichotomy (Δ > 0 ⇔ r ≠ s) all follow. A companion lemma derives the Vieta relations from two distinct roots. 6 theorems, 0 sorries, 0 axioms.",
+    "implications": "The identity b² − 4ac = a²(r − s)² makes the sign analysis of quadratics purely algebraic and characteristic-independent. The same root-gap-squared pattern underlies the discriminant of a polynomial as the squared Vandermonde of its roots, suggesting the natural generalization to higher degree.",
+    "openQuestions": [
+      "Express the cubic discriminant as the product of squared root-gaps ∏_{i<j}(rᵢ − rⱼ)² and verify it equals the classical −4p³ − 27q² for the depressed cubic.",
+      "Connect the general degree-n discriminant to the squared Vandermonde determinant of the roots via Mathlib's Polynomial.discriminant.",
+      "Show the discriminant equals the resultant of the polynomial and its derivative (up to leading-coefficient factors)."
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Viete, Francois",
+      "title": "De aequationum recognitione et emendatione",
+      "year": "1615",
+      "venue": "",
+      "note": "Origin of the coefficient-root relations now called Vieta's formulas"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "extends",
+      "description": "Extends Vieta's formulas to the discriminant of the general (non-monic) quadratic, expressing b² − 4ac in terms of the roots."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "VietaDiscriminant",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/VietasFormulasOQ04.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **OQ-04** of the verified `vietas-formulas` entry: express the discriminant of a quadratic directly in terms of its roots and derive the standard criteria.

The whole file pivots on one ring identity:

> **b² − 4ac = a²·(r − s)²**

for a quadratic `a·x² + b·x + c` with roots `r, s` (Vieta: `b = −a(r+s)`, `c = a·r·s`).

## Results (6 theorems, 0 defs, 145 lines)

| Theorem | Statement | Setting |
|---|---|---|
| `discriminant_eq` | `b² − 4ac = a²(r − s)²` | any `CommRing`, one `ring` |
| `vieta_from_roots` | two distinct roots ⟹ `b = −a(r+s)`, `c = a·r·s` | `Field` |
| `discriminant_eq_of_roots` | discriminant identity from distinct roots alone | `Field` |
| `discriminant_zero_iff` | `Δ = 0 ⇔ r = s` (repeated root) | `Field`, `a ≠ 0` |
| `discriminant_nonneg` | `0 ≤ Δ` (Δ is a square) | ordered field |
| `discriminant_pos_iff_distinct` | `0 < Δ ⇔ r ≠ s` (distinct real roots) | ordered field, `a ≠ 0` |

## Notes

- Maximal generality: the core identity needs only a commutative ring; field/order structure is invoked exactly where cancellation or sign reasoning is required.
- `vieta_from_roots` closes the loop — the discriminant identity does not presuppose Vieta; those relations are themselves forced by the existence of two distinct roots.
- Uses the current Mathlib ordered-algebra spelling `[Field F] [LinearOrder F] [IsStrictOrderedRing F]` (the former `LinearOrderedField` was refactored away in 4.26).

## Verification

`lake env lean Proofs/VietasFormulasOQ04.lean` compiles clean. `#print axioms` on all six theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)