### PR TITLE
research(wilsons-theorem-oq-06): Wilson quotient and Wilson primes [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3884,6 +3884,7 @@ import Proofs.WilsonsTheoremOQ03
 import Proofs.WilsonsTheoremOQ04
 import Proofs.WilsonsTheoremOQ04OQ02
 import Proofs.WilsonsTheoremOQ05
+import Proofs.WilsonsTheoremOQ06
 import Proofs.WolstenholmePrimeMod4
 import Proofs.WolstenholmeTheorem
 import Proofs.WolstenholmeTheoremOQ01

--- a/proofs/Proofs/WilsonsTheoremOQ06.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ06.lean
@@ -1,0 +1,126 @@
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Tactic
+
+/-
+# The Wilson quotient `W_p = ((p-1)! + 1) / p` and Wilson primes
+
+**Open Question (`wilsons-theorem-oq-06`)**: Wilson's theorem says a prime `p`
+divides `(p-1)! + 1`.  The quotient `W_p = ((p-1)! + 1) / p` is therefore an
+*integer* — the **Wilson quotient**.  A prime `p` is a **Wilson prime** when `p`
+itself divides `W_p`, equivalently `p² ∣ (p-1)! + 1`, equivalently
+`(p-1)! ≡ -1 (mod p²)`.  The only known Wilson primes are `5`, `13`, and `563`.
+
+This entry, building on the parent `wilsons-theorem` (Mathlib's
+`ZMod.wilsons_lemma`):
+
+* defines the Wilson quotient `wilsonQuotient p = ((p-1)! + 1) / p` and proves it
+  is a genuine quotient — `p * wilsonQuotient p = (p-1)! + 1` — by re-deriving the
+  divisibility `p ∣ (p-1)! + 1` from Wilson's lemma in `ℕ`;
+* proves the three equivalent forms of the Wilson-prime condition:
+    `p ∣ wilsonQuotient p  ↔  p² ∣ (p-1)! + 1  ↔  ((p-1)! : ZMod (p^2)) = -1`;
+* certifies the two small Wilson primes `5` and `13` by ordinary kernel `decide`
+  (NOT `native_decide`), keeping the whole development axiom-free.
+
+The bridge from `ZMod p` to `ℕ` is `ZMod.natCast_zmod_eq_zero_iff_dvd`; the
+`p ∣ W_p ↔ p² ∣ (p-1)! + 1` step is the cancellation
+`p·p ∣ p·W_p ↔ p ∣ W_p` once `(p-1)! + 1` is written as `p · W_p`.
+
+Main results:
+
+* `wilsonQuotient` — the Wilson quotient `((p-1)! + 1) / p`.
+* `prime_dvd_factorial_pred_add_one` — `p.Prime → p ∣ (p-1)! + 1` (Wilson, in `ℕ`).
+* `mul_wilsonQuotient` — `p.Prime → p * wilsonQuotient p = (p-1)! + 1`.
+* `WilsonPrime` — `p.Prime ∧ p² ∣ (p-1)! + 1`.
+* `wilsonPrime_iff_dvd_wilsonQuotient` — `WilsonPrime p ↔ p.Prime ∧ p ∣ wilsonQuotient p`.
+* `sq_dvd_iff_factorial_cast_eq_neg_one` — `p² ∣ (p-1)!+1 ↔ ((p-1)! : ZMod (p^2)) = -1`.
+* `wilsonPrime_five`, `wilsonPrime_thirteen` — `5` and `13` are Wilson primes.
+
+All `0` sorries, `0` axioms (only the foundational `propext`, `Classical.choice`,
+`Quot.sound`; the two certificates use kernel `decide`, not `native_decide`).
+-/
+
+open Nat
+open scoped Nat
+
+namespace WilsonQuotient
+
+/-- The **Wilson quotient** `W_p = ((p - 1)! + 1) / p`.  By Wilson's theorem this
+is an integer whenever `p` is prime (see `mul_wilsonQuotient`). -/
+def wilsonQuotient (p : ℕ) : ℕ := ((p - 1)! + 1) / p
+
+/-- **Wilson's theorem in `ℕ`**: a prime `p` divides `(p - 1)! + 1`.  Re-derived
+from Mathlib's `ZMod`-valued `wilsons_lemma` via the cast bridge. -/
+theorem prime_dvd_factorial_pred_add_one {p : ℕ} (hp : p.Prime) :
+    p ∣ (p - 1)! + 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- In `ZMod p`: `(p-1)! = -1`, hence `((p-1)! + 1 : ℕ) = 0`.
+  have hcast : (((p - 1)! + 1 : ℕ) : ZMod p) = 0 := by
+    push_cast
+    rw [ZMod.wilsons_lemma p]
+    ring
+  exact (ZMod.natCast_eq_zero_iff _ p).mp hcast
+
+/-- The Wilson quotient really is the quotient: `p * wilsonQuotient p = (p-1)! + 1`. -/
+theorem mul_wilsonQuotient {p : ℕ} (hp : p.Prime) :
+    p * wilsonQuotient p = (p - 1)! + 1 :=
+  Nat.mul_div_cancel' (prime_dvd_factorial_pred_add_one hp)
+
+/-- The Wilson quotient is positive (in fact `(p-1)! + 1 ≥ 1 > 0`). -/
+theorem wilsonQuotient_pos {p : ℕ} (hp : p.Prime) : 0 < wilsonQuotient p := by
+  rcases Nat.eq_zero_or_pos (wilsonQuotient p) with h | h
+  · exfalso
+    have := mul_wilsonQuotient hp
+    rw [h, Nat.mul_zero] at this
+    exact (Nat.succ_ne_zero _) this.symm
+  · exact h
+
+/-- A prime `p` divides its Wilson quotient iff `p²` divides `(p-1)! + 1`. -/
+theorem dvd_wilsonQuotient_iff {p : ℕ} (hp : p.Prime) :
+    p ∣ wilsonQuotient p ↔ p ^ 2 ∣ (p - 1)! + 1 := by
+  rw [← mul_wilsonQuotient hp, sq]
+  exact (Nat.mul_dvd_mul_iff_left hp.pos).symm
+
+/-- A prime `p` is a **Wilson prime** when `p² ∣ (p-1)! + 1`, equivalently
+`(p-1)! ≡ -1 (mod p²)`. -/
+def WilsonPrime (p : ℕ) : Prop := p.Prime ∧ p ^ 2 ∣ (p - 1)! + 1
+
+/-- The Wilson-prime condition in terms of the Wilson quotient:
+`p` is a Wilson prime iff `p` divides `W_p`. -/
+theorem wilsonPrime_iff_dvd_wilsonQuotient {p : ℕ} :
+    WilsonPrime p ↔ p.Prime ∧ p ∣ wilsonQuotient p := by
+  unfold WilsonPrime
+  constructor
+  · rintro ⟨hp, hdvd⟩
+    exact ⟨hp, (dvd_wilsonQuotient_iff hp).mpr hdvd⟩
+  · rintro ⟨hp, hdvd⟩
+    exact ⟨hp, (dvd_wilsonQuotient_iff hp).mp hdvd⟩
+
+/-- The `ZMod (p^2)` congruence form of the Wilson-prime condition:
+`p² ∣ (p-1)! + 1` iff `(p-1)! ≡ -1 (mod p²)` (for any `p`). -/
+theorem sq_dvd_iff_factorial_cast_eq_neg_one {p : ℕ} :
+    p ^ 2 ∣ (p - 1)! + 1 ↔ ((p - 1)! : ZMod (p ^ 2)) = -1 := by
+  rw [← ZMod.natCast_eq_zero_iff ((p - 1)! + 1) (p ^ 2)]
+  constructor
+  · intro h
+    have : ((p - 1)! : ZMod (p ^ 2)) + 1 = 0 := by push_cast at h; exact h
+    linear_combination this
+  · intro h
+    push_cast
+    rw [h]; ring
+
+/-- **`5` is a Wilson prime**: `4! + 1 = 25 = 5²`, so `5² ∣ 4! + 1`.
+Discharged by kernel `decide` (not `native_decide`). -/
+theorem wilsonPrime_five : WilsonPrime 5 := by
+  refine ⟨by norm_num, ?_⟩
+  decide
+
+/-- **`13` is a Wilson prime**: `12! + 1 = 479001601 = 169 · 2834329`, so
+`13² ∣ 12! + 1`.  Discharged by kernel `decide` (not `native_decide`). -/
+theorem wilsonPrime_thirteen : WilsonPrime 13 := by
+  refine ⟨by norm_num, ?_⟩
+  decide
+
+/-- The Wilson quotient of `5` is `5`, so `5 ∣ W₅` directly. -/
+theorem wilsonQuotient_five : wilsonQuotient 5 = 5 := by decide
+
+end WilsonQuotient

--- a/src/data/proofs/wilsons-theorem-oq-06/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-06/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "wq-ann-header",
+    "proofId": "wilsons-theorem-oq-06",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "The Wilson Quotient and Wilson Primes",
+    "content": "States the goal: Wilson's theorem gives p ∣ (p−1)!+1, so W_p = ((p−1)!+1)/p is an integer (the Wilson quotient). The entry defines W_p and proves the three equivalent Wilson-prime conditions, then certifies the small Wilson primes 5 and 13 with kernel decide (axiom-free, unlike native_decide). The definition `wilsonQuotient p = ((p−1)!+1)/p` is stated in ℕ; its integrality is the next theorem.",
+    "mathContext": "$W_p=\\dfrac{(p-1)!+1}{p}\\in\\mathbb{Z}$ for prime $p$; $p$ is a Wilson prime iff $p\\mid W_p$.",
+    "significance": "context",
+    "relatedConcepts": ["Wilson's theorem", "Wilson quotient", "Wilson primes", "decide vs native_decide"],
+    "prerequisites": ["factorials and divisibility", "Wilson's theorem"]
+  },
+  {
+    "id": "wq-ann-integrality",
+    "proofId": "wilsons-theorem-oq-06",
+    "range": { "startLine": 54, "endLine": 75 },
+    "type": "insight",
+    "title": "Integrality: Wilson in ℕ and p·W_p = (p−1)!+1",
+    "content": "prime_dvd_factorial_pred_add_one re-derives Wilson's theorem as the ℕ divisibility p ∣ (p−1)!+1: from ZMod.wilsons_lemma ((p−1)! = −1 in ZMod p), the cast of (p−1)!+1 is 0 in ZMod p, and ZMod.natCast_eq_zero_iff converts this to divisibility. mul_wilsonQuotient then applies Nat.mul_div_cancel' to get p·W_p = (p−1)!+1 exactly — this is what makes W_p a genuine quotient. wilsonQuotient_pos notes W_p > 0 because p·W_p is a successor (hence nonzero).",
+    "mathContext": "$((p-1)!+1 : \\mathrm{ZMod}\\,p)=0 \\Rightarrow p\\mid (p-1)!+1 \\Rightarrow p\\cdot W_p=(p-1)!+1.$",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.wilsons_lemma", "ZMod.natCast_eq_zero_iff", "Nat.mul_div_cancel'", "cast bridge"],
+    "prerequisites": ["Wilson's lemma in ZMod", "exact division in ℕ"]
+  },
+  {
+    "id": "wq-ann-equiv",
+    "proofId": "wilsons-theorem-oq-06",
+    "range": { "startLine": 77, "endLine": 109 },
+    "type": "insight",
+    "title": "The Wilson-Prime Equivalence is One Cancellation",
+    "content": "dvd_wilsonQuotient_iff proves p ∣ W_p ⟺ p² ∣ (p−1)!+1: rewrite (p−1)!+1 as p·W_p and p² as p·p, then Nat.mul_dvd_mul_iff_left cancels the common factor p. So the entire equivalence reduces to left-cancellation of divisibility — the number-theoretic depth lives only in Wilson's theorem upstream. WilsonPrime packages p.Prime ∧ p² ∣ (p−1)!+1; wilsonPrime_iff_dvd_wilsonQuotient restates it via the quotient. sq_dvd_iff_factorial_cast_eq_neg_one gives the ZMod (p²) congruence form (p−1)! ≡ −1 (mod p²), which holds for ALL p — primality is not needed for the equivalence, only for the divisibility to occur.",
+    "mathContext": "$p\\mid W_p \\iff p\\cdot p\\mid p\\cdot W_p=(p-1)!+1 \\iff p^2\\mid(p-1)!+1 \\iff (p-1)!\\equiv -1\\ (\\mathrm{mod}\\ p^2).$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.mul_dvd_mul_iff_left", "left-cancellation", "ZMod (p²) congruence", "Wilson prime definition"],
+    "prerequisites": ["divisibility cancellation", "the quotient identity p·W_p = (p−1)!+1"]
+  },
+  {
+    "id": "wq-ann-certs",
+    "proofId": "wilsons-theorem-oq-06",
+    "range": { "startLine": 111, "endLine": 126 },
+    "type": "technique",
+    "title": "Axiom-Free Certificates: 5 and 13 by Kernel decide",
+    "content": "wilsonPrime_five (4!+1 = 25 = 5², so 25 ∣ 25) and wilsonPrime_thirteen (12!+1 = 479001601 = 169·2834329, so 169 ∣ 479001601) are discharged by ordinary kernel `decide`. The primality halves are norm_num; the divisibility halves reduce factorials by Lean's GMP-accelerated kernel Nat arithmetic. Crucially this uses `decide`, NOT `native_decide`, so the certificates do not depend on Lean.ofReduceBool — #print axioms confirms only propext/Classical.choice/Quot.sound. wilsonQuotient_five records W₅ = 5.",
+    "mathContext": "$4!+1=25=5^2,\\quad 12!+1=479001601=13^2\\cdot 2834329.$",
+    "significance": "key",
+    "relatedConcepts": ["kernel decide", "native_decide", "Lean.ofReduceBool", "GMP Nat reduction", "Wilson primes 5 and 13"],
+    "prerequisites": ["decidability of divisibility", "factorial computation"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-06/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheoremOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOQ06Data: ProofData = {
+  proof: wilsonsTheoremOQ06Proof,
+  annotations: wilsonsTheoremOQ06Annotations,
+}

--- a/src/data/proofs/wilsons-theorem-oq-06/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-06/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "wilsons-theorem-oq-06",
+  "title": "The Wilson Quotient $W_p=\\frac{(p-1)!+1}{p}$ and Wilson Primes",
+  "slug": "wilsons-theorem-oq-06",
+  "description": "Answers the open question raised by the parent entry `wilsons-theorem`: Wilson's theorem says a prime p divides (p−1)!+1, so the quotient W_p = ((p−1)!+1)/p is a genuine integer — the Wilson quotient. This entry formalizes W_p (`wilsonQuotient`), proves it is a true quotient (`mul_wilsonQuotient`: p · W_p = (p−1)!+1) by re-deriving Wilson's divisibility p ∣ (p−1)!+1 in ℕ from Mathlib's ZMod-valued `wilsons_lemma` through the cast bridge `ZMod.natCast_eq_zero_iff`, and proves the three equivalent forms of the Wilson-prime condition: p ∣ W_p ⟺ p² ∣ (p−1)!+1 ⟺ (p−1)! ≡ −1 (mod p²). The first equivalence (`dvd_wilsonQuotient_iff`) is the cancellation p·p ∣ p·W_p ⟺ p ∣ W_p once (p−1)!+1 is rewritten as p·W_p; the second (`sq_dvd_iff_factorial_cast_eq_neg_one`) is the cast bridge in ZMod (p²) and holds for every p. The two known small Wilson primes 5 (4!+1 = 25 = 5²) and 13 (12!+1 = 479001601 = 169·2834329) are certified by ordinary kernel `decide` — NOT `native_decide` — so the entire development is axiom-free. Fully machine-checked: 0 sorries, 0 axioms (only the foundational propext, Classical.choice, Quot.sound; #print axioms confirms the 13-certificate does not depend on Lean.ofReduceBool).",
+  "meta": {
+    "author": "Wilson/Lagrange (1771); Wilson quotient and Wilson primes (Beeger 1913, the prime 13); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson_prime",
+    "date": "1771",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ06.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "wilson-quotient",
+      "wilson-primes",
+      "factorial",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Rests on Mathlib's `ZMod.wilsons_lemma` (the ZMod-valued Wilson lemma, for the divisibility p ∣ (p−1)!+1), `ZMod.natCast_eq_zero_iff` (the ℕ-cast-to-ZMod vanishing bridge), `Nat.mul_div_cancel'`, and `Nat.mul_dvd_mul_iff_left`. The two Wilson-prime certificates (5 and 13) are discharged by ordinary kernel `decide` (NOT `native_decide`), so the proof does not depend on `Lean.ofReduceBool`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.wilsons_lemma",
+        "description": "`[Fact p.Prime] → ((p-1)! : ZMod p) = -1`, the ZMod-valued Wilson lemma. Used (via the cast bridge) to obtain the natural-number divisibility p ∣ (p−1)!+1, the fact that makes the Wilson quotient an integer.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "`(a : ZMod b) = 0 ↔ b ∣ a` for naturals a, b. The bridge converting the ZMod identity ((p−1)!+1 : ZMod p) = 0 into the ℕ divisibility p ∣ (p−1)!+1, and (at modulus p²) the ZMod-congruence form of the Wilson-prime condition.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel'",
+        "description": "`a ∣ b → a * (b / a) = b`. Turns the divisibility p ∣ (p−1)!+1 into the exact quotient identity p · W_p = (p−1)!+1, establishing W_p as a genuine quotient.",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.mul_dvd_mul_iff_left",
+        "description": "`0 < a → (a*b ∣ a*c ↔ b ∣ c)`. The left-cancellation giving p ∣ W_p ⟺ p·p ∣ p·W_p = (p−1)!+1, i.e. the equivalence between divisibility of the quotient and p² ∣ (p−1)!+1.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      }
+    ],
+    "originalContributions": [
+      "`wilsonQuotient`: the Wilson quotient W_p = ((p−1)!+1)/p as a definition in ℕ, with `mul_wilsonQuotient` proving it is a genuine quotient (p · W_p = (p−1)!+1) for every prime p — the integrality of W_p stated and proved.",
+      "`prime_dvd_factorial_pred_add_one`: Wilson's theorem in elementary ℕ-divisibility form (p prime ⟹ p ∣ (p−1)!+1), re-derived self-contained from Mathlib's ZMod `wilsons_lemma` through the cast bridge.",
+      "`dvd_wilsonQuotient_iff`: the equivalence p ∣ W_p ⟺ p² ∣ (p−1)!+1, the bridge between the 'p divides its Wilson quotient' phrasing of a Wilson prime and the standard p² ∣ (p−1)!+1 definition.",
+      "`WilsonPrime` and `wilsonPrime_iff_dvd_wilsonQuotient`: the Wilson-prime predicate (p.Prime ∧ p² ∣ (p−1)!+1) together with its restatement in terms of the Wilson quotient.",
+      "`sq_dvd_iff_factorial_cast_eq_neg_one`: the ZMod (p²) congruence form, p² ∣ (p−1)!+1 ⟺ (p−1)! ≡ −1 (mod p²), holding for every p (no primality needed).",
+      "`wilsonPrime_five`, `wilsonPrime_thirteen`: certificates that 5 and 13 are Wilson primes, discharged by ordinary kernel `decide` — keeping the whole entry axiom-free (no `native_decide`/`Lean.ofReduceBool`), in contrast to typical large-factorial computations."
+    ],
+    "prerequisites": [
+      "Wilson's theorem and its ZMod formulation",
+      "Factorials and natural-number divisibility",
+      "Exact division `Nat.mul_div_cancel'` and cancellation `Nat.mul_dvd_mul_iff_left`",
+      "The ℕ-cast-to-ZMod vanishing criterion `ZMod.natCast_eq_zero_iff`"
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem",
+        "relationship": "Parent: the gallery's Wilson's theorem entry supplies the divisibility p ∣ (p−1)!+1 (in ZMod form). This entry uses it to define the Wilson quotient and to study when p divides that quotient (Wilson primes), answering the parent's open question about the arithmetic of the quotient ((p−1)!+1)/p."
+      },
+      {
+        "id": "wilsons-theorem-oq-05-oq-01",
+        "relationship": "Sibling: oq-05-oq-01 classifies the residue (n−1)! mod n across all n (the trichotomy). This entry instead studies the next-order quotient ((p−1)!+1)/p at primes — its integrality and the Wilson-prime condition p² ∣ (p−1)!+1 — and likewise keeps the small-case computations axiom-free via kernel `decide`."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Wilson's theorem (Ibn al-Haytham c. 1000; stated by John Wilson; first proved by Lagrange in 1771) says a prime p divides (p−1)!+1. The quotient W_p = ((p−1)!+1)/p is therefore a positive integer, the Wilson quotient, studied since the 19th century. A prime p is a Wilson prime when p itself divides W_p — equivalently p² ∣ (p−1)!+1, equivalently (p−1)! ≡ −1 (mod p²). Only three Wilson primes are known: 5, 13 (N. Beeger, 1913), and 563 (Goldberg, 1953); none other exist below 2×10¹³, and it is unknown whether infinitely many exist. This entry formalizes the Wilson quotient and the three equivalent Wilson-prime conditions, and certifies 5 and 13.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-06):** formalize the Wilson quotient W_p = ((p−1)!+1)/p as an integer (from Wilson's theorem), prove the equivalence of the Wilson-prime conditions p ∣ W_p ⟺ p² ∣ (p−1)!+1 ⟺ (p−1)! ≡ −1 (mod p²), and certify the small Wilson primes 5 and 13.",
+    "text": "For a prime p, Wilson's theorem gives p ∣ (p−1)!+1, so W_p = ((p−1)!+1)/p satisfies p·W_p = (p−1)!+1 and is a genuine integer. The prime p is a Wilson prime exactly when it divides this quotient once more, i.e. p² ∣ (p−1)!+1, i.e. (p−1)! ≡ −1 modulo p². The primes 5 and 13 pass this test (25 ∣ 25 and 169 ∣ 479001601).",
+    "proofStrategy": "First re-derive Wilson's theorem as a ℕ divisibility: from ZMod.wilsons_lemma, ((p−1)! : ZMod p) = −1, so (((p−1)!+1 : ℕ) : ZMod p) = 0, and ZMod.natCast_eq_zero_iff yields p ∣ (p−1)!+1 (prime_dvd_factorial_pred_add_one). Nat.mul_div_cancel' then gives p·W_p = (p−1)!+1 (mul_wilsonQuotient), establishing W_p as a quotient and (with the successor being nonzero) positive. For the Wilson-prime condition, rewrite (p−1)!+1 as p·W_p and p² as p·p, then Nat.mul_dvd_mul_iff_left cancels the common factor p to give p ∣ W_p ⟺ p² ∣ (p−1)!+1 (dvd_wilsonQuotient_iff). The ZMod (p²) congruence form is the same cast bridge at modulus p², valid for all p (sq_dvd_iff_factorial_cast_eq_neg_one). The two certificates reduce to kernel `decide` on small factorials (4! and 12!), which Lean's GMP-accelerated Nat reduction handles without `native_decide`, so no Lean.ofReduceBool appears.",
+    "keyInsights": [
+      "**Integrality is just Wilson + exact division.** The content that makes W_p well-defined is precisely Wilson's divisibility p ∣ (p−1)!+1; Nat.mul_div_cancel' converts it to the exact identity p·W_p = (p−1)!+1, after which 'p divides the quotient' is a clean ℕ statement.",
+      "**The Wilson-prime equivalence is one cancellation.** Writing (p−1)!+1 = p·W_p and p² = p·p, the three-way 'p ∣ W_p ⟺ p² ∣ (p−1)!+1' collapses to Nat.mul_dvd_mul_iff_left — left-cancelling the common factor p. No deeper number theory is needed for the equivalence itself; the depth is entirely in Wilson's theorem.",
+      "**The ZMod congruence form needs no primality.** p² ∣ (p−1)!+1 ⟺ (p−1)! ≡ −1 (mod p²) is just the natCast vanishing bridge at modulus p² and holds for every p; primality only enters when asserting the divisibility actually occurs.",
+      "**Axiom-free certificates via kernel decide.** 12!+1 = 479001601 is large but Lean's kernel reduces Nat arithmetic with GMP, so `decide` certifies 169 ∣ 479001601 directly — no `native_decide`, hence no Lean.ofReduceBool, keeping the whole entry on the foundational-axiom-only base. #print axioms confirms this."
+    ],
+    "prerequisites": [
+      "Wilson's theorem (ZMod form) and ZMod.wilsons_lemma",
+      "Factorials and natural-number divisibility",
+      "Exact division (Nat.mul_div_cancel') and left-cancellation of divisibility (Nat.mul_dvd_mul_iff_left)",
+      "The ℕ-cast-to-ZMod vanishing criterion ZMod.natCast_eq_zero_iff"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-definition",
+      "title": "Module Overview and the Wilson Quotient",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring stating the goal (Wilson quotient W_p = ((p−1)!+1)/p as an integer, the three equivalent Wilson-prime conditions, certification of 5 and 13 axiom-free), the result list, imports of Mathlib.NumberTheory.Wilson and Mathlib.Tactic, and the definition `wilsonQuotient p = ((p−1)!+1)/p`."
+    },
+    {
+      "id": "wilson-divisibility-and-quotient",
+      "title": "Wilson's Theorem in ℕ and the Quotient Identity",
+      "startLine": 54,
+      "endLine": 75,
+      "summary": "`prime_dvd_factorial_pred_add_one` re-derives p ∣ (p−1)!+1 from ZMod.wilsons_lemma via the cast bridge; `mul_wilsonQuotient` turns it into p·W_p = (p−1)!+1 with Nat.mul_div_cancel'; `wilsonQuotient_pos` shows W_p > 0 since p·W_p is a successor."
+    },
+    {
+      "id": "wilson-prime-conditions",
+      "title": "The Three Equivalent Wilson-Prime Conditions",
+      "startLine": 77,
+      "endLine": 109,
+      "summary": "`dvd_wilsonQuotient_iff` proves p ∣ W_p ⟺ p² ∣ (p−1)!+1 by rewriting (p−1)!+1 = p·W_p, p² = p·p and cancelling via Nat.mul_dvd_mul_iff_left; `WilsonPrime` packages the definition; `wilsonPrime_iff_dvd_wilsonQuotient` restates it through the quotient; `sq_dvd_iff_factorial_cast_eq_neg_one` gives the ZMod (p²) congruence form (for any p)."
+    },
+    {
+      "id": "wilson-prime-certificates",
+      "title": "Certifying the Wilson Primes 5 and 13",
+      "startLine": 111,
+      "endLine": 126,
+      "summary": "`wilsonPrime_five` (25 ∣ 25) and `wilsonPrime_thirteen` (169 ∣ 479001601) certified by kernel `decide` — not `native_decide` — keeping the entry axiom-free; `wilsonQuotient_five` records W₅ = 5."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Wilson quotient W_p = ((p−1)!+1)/p is formalized in ℕ and proved to be a genuine quotient (p·W_p = (p−1)!+1) for every prime p, from Wilson's theorem. The Wilson-prime condition is given in three equivalent forms — p ∣ W_p ⟺ p² ∣ (p−1)!+1 ⟺ (p−1)! ≡ −1 (mod p²) — and the two known small Wilson primes 5 and 13 are certified by kernel decide. 9 theorems, 2 definitions, 126 lines, 0 sorries, 0 axioms (no native_decide, no Lean.ofReduceBool).",
+    "implications": "Extends the gallery's Wilson's theorem from the prime criterion to the arithmetic of the next-order quotient, making 'Wilson prime' a formal, decidable-on-instances predicate. The equivalence machinery (exact division + left-cancellation of divisibility) is a reusable pattern for 'p divides the quotient ⟺ p² divides the dividend' arguments, and the axiom-free kernel-decide certification of 12!+1 shows large but bounded factorial congruences can stay on the foundational-axiom base.",
+    "openQuestions": [
+      "Certify the third known Wilson prime 563 (563² ∣ 562!+1): assess whether kernel `decide` on 562! is feasible or whether a structured congruence computation (Wilson quotient mod p² via products over residues) is needed to avoid native_decide.",
+      "Formalize the Wilson quotient modulo p in closed form (the Glaisher / Lerch-type congruence W_p ≡ −∑_{k=1}^{p−1} 1/k ... relating W_p to harmonic sums and Bernoulli numbers mod p), turning the Wilson-prime test into a sum-based criterion."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "wilsons-theorem",
+      "title": "Wilson's Theorem",
+      "relationship": "Parent — supplies the divisibility p ∣ (p−1)!+1 that makes the Wilson quotient an integer."
+    },
+    {
+      "id": "wilsons-theorem-oq-05-oq-01",
+      "title": "The Complete Trichotomy of (n−1)! mod n",
+      "relationship": "Sibling — classifies the residue (n−1)! mod n; this entry studies the next-order quotient ((p−1)!+1)/p and the p² refinement."
+    }
+  ],
+  "mainTheorems": "none",
+  "sorries": 0,
+  "leanFile": {
+    "lineCount": 126,
+    "path": "Proofs/WilsonsTheoremOQ06.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 9
+  }
+}


### PR DESCRIPTION
## Wilson quotient $W_p = \frac{(p-1)!+1}{p}$ and Wilson primes

Answers the open question off the gallery's **Wilson's theorem** entry: Wilson's theorem says a prime $p$ divides $(p-1)!+1$, so the quotient $W_p = \frac{(p-1)!+1}{p}$ is a genuine integer — the **Wilson quotient**. A prime is a **Wilson prime** when $p \mid W_p$.

### What's proved
- **`wilsonQuotient`** — the Wilson quotient as a `ℕ` definition.
- **`prime_dvd_factorial_pred_add_one`** — Wilson's theorem in elementary `ℕ` form $p \mid (p-1)!+1$, re-derived from Mathlib's `ZMod.wilsons_lemma` through `ZMod.natCast_eq_zero_iff`.
- **`mul_wilsonQuotient`** — integrality: $p \cdot W_p = (p-1)!+1$ for every prime $p$ (via `Nat.mul_div_cancel'`).
- **`dvd_wilsonQuotient_iff`** — $p \mid W_p \iff p^2 \mid (p-1)!+1$, by left-cancellation of divisibility (`Nat.mul_dvd_mul_iff_left`).
- **`WilsonPrime`** / **`wilsonPrime_iff_dvd_wilsonQuotient`** — the predicate and its quotient restatement.
- **`sq_dvd_iff_factorial_cast_eq_neg_one`** — the ZMod $(p^2)$ congruence form $(p-1)! \equiv -1 \pmod{p^2}$ (holds for all $p$).
- **`wilsonPrime_five`, `wilsonPrime_thirteen`** — $5$ and $13$ certified by **kernel `decide`** ($25 \mid 25$; $169 \mid 479001601$).

### Verification
- **0 sorries, 0 axioms.** `#print axioms` confirms only `propext`, `Classical.choice`, `Quot.sound`.
- The $13$-certificate (over $12! = 479001600$) uses ordinary kernel `decide`, **not** `native_decide`, so the entry does **not** depend on `Lean.ofReduceBool`.
- 9 theorems, 2 definitions, 126 lines. Builds against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)