### PR TITLE
research(cayley-hamilton-oq-01-oq-04): primary decomposition V = ⊕ ker(qᵢ^eᵢ(T)) from the minimal polynomial [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -662,6 +662,7 @@ import Proofs.CayleyHamiltonMinpolyOQ07
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ03
+import Proofs.CayleyHamiltonOQ01OQ04
 import Proofs.CayleyHamiltonOQ02
 import Proofs.CayleyHamiltonOQ02OQ02
 import Proofs.CayleyHamiltonReductionOQ01

--- a/proofs/Proofs/CayleyHamiltonOQ01OQ04.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ01OQ04.lean
@@ -1,0 +1,168 @@
+import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.Algebra.DirectSum.Module
+import Mathlib.FieldTheory.Minpoly.Field
+import Mathlib.Tactic
+
+/-
+# Primary Decomposition from the Minimal Polynomial
+
+## What This Proves
+This file answers the open question raised in `CayleyHamiltonOQ01` (Minimal
+Polynomial Reduction and Annihilator Theory):
+
+> Extend to primary decomposition: μ_T = ∏ pᵢ^{eᵢ} (distinct irreducibles) and
+> the corresponding V = ⊕ ker(pᵢ^{eᵢ}(T)).
+
+Given an endomorphism `T : V →ₗ[K] V` of a vector space over a field `K`, and a
+factorisation of the minimal polynomial into **pairwise coprime** factors
+`μ_T = ∏ᵢ qᵢ^{eᵢ}` (the distinct-irreducible-prime-power form), the space splits
+as an internal direct sum of the `T`-invariant generalized eigenspaces
+`Wᵢ = ker(qᵢ^{eᵢ}(T))`:
+
+    V = ⨁ᵢ ker( (qᵢ^{eᵢ})(T) ).
+
+This is the classical **Primary Decomposition Theorem**, the engine behind the
+rational canonical form and (over an algebraically closed field) the Jordan form.
+
+## Main results
+* `iSup_ker_aeval_eq_ker_aeval_prod` — for a finite family of pairwise coprime
+  polynomials, the supremum of the kernels of `qᵢ(T)` equals the kernel of the
+  product `(∏ qᵢ)(T)`. (Iterated CRT for the action of `K[X]` on `V`.)
+* `ker_aeval_mapsTo` — each kernel `ker(p(T))` is a `T`-invariant subspace.
+* `iSupIndep_ker_aeval` — the kernels of a pairwise coprime family are
+  independent (the sum is direct).
+* `iSup_ker_aeval_eq_top` — if the product annihilates `T`, the kernels span `V`.
+* `isInternal_ker_aeval` — the kernels form an internal direct sum decomposition
+  of `V` (general coprime form).
+* `isInternal_primaryDecomposition_of_minpoly` — the headline: specialising to a
+  pairwise-coprime prime-power factorisation of the minimal polynomial gives the
+  primary decomposition `V = ⨁ᵢ ker(qᵢ^{eᵢ}(T))`.
+
+## Method
+The whole argument is built from Mathlib's binary kernel lemmas
+(`Polynomial.sup_ker_aeval_eq_ker_aeval_mul_of_coprime` and
+`Polynomial.disjoint_ker_aeval_of_isCoprime`) lifted to an arbitrary finite
+family by `Finset` induction and the `IsCoprime.prod_right` coprimality combinator.
+No finiteness or algebraic-closure hypotheses on `V` are needed for the general
+statement; the minimal-polynomial corollary only uses `minpoly.aeval`.
+
+## Extends
+- `CayleyHamiltonOQ01.lean` (minimal polynomial reduction & annihilator theory)
+
+## Status
+0 sorries, 0 axioms. Fully machine-verified.
+-/
+
+open Polynomial Submodule LinearMap Finset
+
+namespace CayleyHamiltonOQ01OQ04
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+variable (T : V →ₗ[K] V)
+
+/-- Each "primary" subspace `ker (p(T))` is invariant under `T`, because every
+polynomial in `T` commutes with `T`. -/
+theorem ker_aeval_mapsTo (p : K[X]) :
+    ∀ x ∈ LinearMap.ker (aeval T p), T x ∈ LinearMap.ker (aeval T p) := by
+  intro x hx
+  rw [LinearMap.mem_ker] at hx ⊢
+  have hcomm : (aeval T p) * T = T * (aeval T p) := by
+    have e1 : (aeval T p) * T = aeval T (p * X) := by rw [map_mul, aeval_X]
+    have e2 : T * (aeval T p) = aeval T (X * p) := by rw [map_mul, aeval_X]
+    rw [e1, e2, mul_comm]
+  calc aeval T p (T x) = ((aeval T p) * T) x := by rw [Module.End.mul_apply]
+    _ = (T * (aeval T p)) x := by rw [hcomm]
+    _ = T (aeval T p x) := by rw [Module.End.mul_apply]
+    _ = T 0 := by rw [hx]
+    _ = 0 := by rw [map_zero]
+
+/-- **Iterated Chinese Remainder Theorem for `K[X]` acting on `V`.**
+For a finite family of pairwise coprime polynomials, the supremum of the kernels
+`ker(qᵢ(T))` equals the kernel of the product `(∏ qᵢ)(T)`. -/
+theorem iSup_ker_aeval_eq_ker_aeval_prod {ι : Type*} (p : ι → K[X]) {s : Finset ι}
+    (h : (s : Set ι).Pairwise (fun i j => IsCoprime (p i) (p j))) :
+    (⨆ i ∈ s, LinearMap.ker (aeval T (p i))) =
+      LinearMap.ker (aeval T (∏ i ∈ s, p i)) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp [Module.End.one_eq_id, LinearMap.ker_id]
+  | @insert a s ha ih =>
+      have hsub : (s : Set ι) ⊆ (insert a s : Finset ι) :=
+        Finset.coe_subset.mpr (Finset.subset_insert a s)
+      have hps : (s : Set ι).Pairwise (fun i j => IsCoprime (p i) (p j)) := h.mono hsub
+      have hcop : IsCoprime (p a) (∏ i ∈ s, p i) := by
+        refine IsCoprime.prod_right (fun i hi => ?_)
+        have hai : a ≠ i := fun he => ha (he ▸ hi)
+        exact h (Finset.mem_insert_self a s) (Finset.mem_insert_of_mem hi) hai
+      rw [Finset.iSup_insert, ih hps, Finset.prod_insert ha,
+        sup_ker_aeval_eq_ker_aeval_mul_of_coprime T hcop]
+
+variable {ι : Type*} [Fintype ι] (p : ι → K[X])
+
+/-- The kernels of a pairwise coprime family are **independent**: their sum is
+direct.  Each `ker(pᵢ(T))` is disjoint from the supremum of the others, since
+`pᵢ` is coprime to the product of the remaining factors. -/
+theorem iSupIndep_ker_aeval (hpw : Pairwise (fun i j => IsCoprime (p i) (p j))) :
+    iSupIndep (fun i => LinearMap.ker (aeval T (p i))) := by
+  classical
+  have huniv : (Set.univ : Set ι).Pairwise (fun i j => IsCoprime (p i) (p j)) :=
+    Set.pairwise_univ.mpr hpw
+  rw [iSupIndep_def]
+  intro i
+  -- Rewrite the supremum over `j ≠ i` as a kernel of a product over `univ.erase i`.
+  have herase : (Finset.univ.erase i : Set ι).Pairwise (fun i j => IsCoprime (p i) (p j)) :=
+    huniv.mono (by simp)
+  have hsup :
+      (⨆ (j) (_ : j ≠ i), LinearMap.ker (aeval T (p j))) =
+        LinearMap.ker (aeval T (∏ j ∈ Finset.univ.erase i, p j)) := by
+    rw [← iSup_ker_aeval_eq_ker_aeval_prod T p herase]
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+  rw [hsup]
+  -- `pᵢ` is coprime to the product of the remaining factors.
+  have hcop : IsCoprime (p i) (∏ j ∈ Finset.univ.erase i, p j) := by
+    refine IsCoprime.prod_right (fun j hj => ?_)
+    exact hpw (Finset.ne_of_mem_erase hj).symm
+  exact disjoint_ker_aeval_of_isCoprime T hcop
+
+/-- If the product of a pairwise coprime family annihilates `T`, the kernels
+span the whole space. -/
+theorem iSup_ker_aeval_eq_top (hpw : Pairwise (fun i j => IsCoprime (p i) (p j)))
+    (hprod : aeval T (∏ i, p i) = 0) :
+    (⨆ i, LinearMap.ker (aeval T (p i))) = ⊤ := by
+  classical
+  have huniv : ((Finset.univ : Finset ι) : Set ι).Pairwise (fun i j => IsCoprime (p i) (p j)) := by
+    rw [Finset.coe_univ]; exact Set.pairwise_univ.mpr hpw
+  have key : (⨆ i, LinearMap.ker (aeval T (p i))) =
+      LinearMap.ker (aeval T (∏ i, p i)) := by
+    rw [← iSup_ker_aeval_eq_ker_aeval_prod T p huniv]
+    simp only [Finset.mem_univ, iSup_true]
+  rw [key, hprod, LinearMap.ker_zero]
+
+/-- **Primary decomposition (general coprime form).**
+If `T : V →ₗ[K] V` is annihilated by the product of a finite family of pairwise
+coprime polynomials, then `V` is the internal direct sum of the kernels
+`ker(pᵢ(T))`. -/
+theorem isInternal_ker_aeval [DecidableEq ι] (hpw : Pairwise (fun i j => IsCoprime (p i) (p j)))
+    (hprod : aeval T (∏ i, p i) = 0) :
+    DirectSum.IsInternal (fun i => LinearMap.ker (aeval T (p i))) := by
+  rw [DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top]
+  exact ⟨iSupIndep_ker_aeval T p hpw, iSup_ker_aeval_eq_top T p hpw hprod⟩
+
+/-- **Primary Decomposition Theorem.**
+Let `μ_T = ∏ᵢ qᵢ^{eᵢ}` be a factorisation of the minimal polynomial of `T` into
+pairwise coprime prime powers (the distinct-irreducibles form).  Then `V`
+decomposes as the internal direct sum of the primary components
+`Wᵢ = ker(qᵢ^{eᵢ}(T))`:
+
+    V = ⨁ᵢ ker( (qᵢ^{eᵢ})(T) ).
+
+Each component `Wᵢ` is `T`-invariant (`ker_aeval_mapsTo`). -/
+theorem isInternal_primaryDecomposition_of_minpoly [DecidableEq ι] (q : ι → K[X]) (e : ι → ℕ)
+    (hq : Pairwise (fun i j => IsCoprime (q i) (q j)))
+    (hmin : minpoly K T = ∏ i, (q i) ^ (e i)) :
+    DirectSum.IsInternal (fun i => LinearMap.ker (aeval T ((q i) ^ (e i)))) := by
+  refine isInternal_ker_aeval T (fun i => (q i) ^ (e i)) (fun i j hij => ?_) ?_
+  · exact (hq hij).pow
+  · rw [← hmin]; exact minpoly.aeval K T
+
+end CayleyHamiltonOQ01OQ04

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-04/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "cayley-hamilton-oq-01-oq-04",
+  "title": "Primary Decomposition from the Minimal Polynomial",
+  "slug": "cayley-hamilton-oq-01-oq-04",
+  "description": "Given an endomorphism T of a vector space over a field K and a factorisation of its minimal polynomial into pairwise coprime factors μ_T = ∏ qᵢ^eᵢ, proves the Primary Decomposition Theorem: V splits as the internal direct sum of the T-invariant primary components Wᵢ = ker(qᵢ^eᵢ(T)). The argument lifts Mathlib's binary coprime-kernel lemmas to an arbitrary finite family by Finset induction, giving an iterated Chinese Remainder Theorem for the action of K[X] on V.",
+  "meta": {
+    "author": "researcher-7 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Primary_decomposition#Primary_decomposition_from_minimal_polynomial",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ01OQ04.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "primary-decomposition",
+      "module-theory",
+      "direct-sum",
+      "invariant-subspace",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.sup_ker_aeval_eq_ker_aeval_mul_of_coprime",
+        "description": "binary case: for coprime p, q, ker(p(f)) ⊔ ker(q(f)) = ker((p·q)(f))",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.disjoint_ker_aeval_of_isCoprime",
+        "description": "for coprime p, q, ker(p(f)) and ker(q(f)) are disjoint submodules",
+        "module": "Mathlib.RingTheory.Polynomial.Basic"
+      },
+      {
+        "theorem": "DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top",
+        "description": "a family of submodules is an internal direct sum iff it is independent and its supremum is ⊤",
+        "module": "Mathlib.Algebra.DirectSum.Module"
+      },
+      {
+        "theorem": "IsCoprime.prod_right",
+        "description": "a is coprime to a finite product when coprime to each factor",
+        "module": "Mathlib.RingTheory.Coprime.Lemmas"
+      },
+      {
+        "theorem": "IsCoprime.pow",
+        "description": "coprimality is preserved under taking powers of both arguments",
+        "module": "Mathlib.RingTheory.Coprime.Lemmas"
+      },
+      {
+        "theorem": "minpoly.aeval",
+        "description": "aeval T (minpoly K T) = 0 — the minimal polynomial annihilates T",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ker_aeval_mapsTo: each primary component ker(p(T)) is a T-invariant subspace, since every polynomial in T commutes with T",
+      "iSup_ker_aeval_eq_ker_aeval_prod: iterated CRT — for a finite family of pairwise coprime polynomials, ⨆ᵢ ker(pᵢ(T)) = ker((∏ pᵢ)(T)), by Finset induction on the binary coprime-kernel lemma and IsCoprime.prod_right",
+      "iSupIndep_ker_aeval: the kernels of a pairwise coprime family are independent, because each pᵢ is coprime to the product of the remaining factors (so ker(pᵢ(T)) is disjoint from the supremum of the others)",
+      "iSup_ker_aeval_eq_top: when the product of the family annihilates T, the kernels span the whole space",
+      "isInternal_ker_aeval: general coprime form — V = ⨁ᵢ ker(pᵢ(T)) as an internal direct sum, given pairwise coprimality and that the product annihilates T",
+      "isInternal_primaryDecomposition_of_minpoly: the headline Primary Decomposition Theorem — for a pairwise-coprime prime-power factorisation μ_T = ∏ qᵢ^eᵢ of the minimal polynomial, V = ⨁ᵢ ker(qᵢ^eᵢ(T))"
+    ],
+    "references": [
+      {
+        "authors": "Dummit, David S.; Foote, Richard M.",
+        "title": "Abstract Algebra",
+        "year": "2004",
+        "venue": "Wiley",
+        "note": "Section 12.3: the primary decomposition theorem and the Jordan/rational canonical forms"
+      },
+      {
+        "authors": "Hoffman, Kenneth; Kunze, Ray",
+        "title": "Linear Algebra",
+        "year": "1971",
+        "venue": "Prentice-Hall",
+        "note": "Theorem 12 (Primary Decomposition Theorem), Chapter 6"
+      }
+    ],
+    "prerequisites": [
+      "Minimal polynomial of an endomorphism and its annihilator ideal (parent entry cayley-hamilton-oq-01)",
+      "Coprimality of polynomials over a field and the Chinese Remainder Theorem",
+      "Internal direct sums of submodules (DirectSum.IsInternal: independence + spanning)",
+      "Invariant subspaces under a linear operator"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 168,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). The general theorem needs no finiteness or algebraic-closure hypotheses on V; the minimal-polynomial corollary takes the pairwise-coprime prime-power factorisation as a hypothesis (existence of such a factorisation over a field is standard but not formalised here).",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Primary Decomposition Theorem is the central structural result of operator theory on finite-dimensional spaces. Fixing an endomorphism T of V turns V into a module over the polynomial ring K[X], with X acting as T. Because K[X] is a principal ideal domain, the module structure is governed by the minimal polynomial μ_T. When μ_T factors into pairwise coprime pieces μ_T = ∏ qᵢ^eᵢ (the qᵢ distinct monic irreducibles), the Chinese Remainder Theorem for K[X] forces V to split as a direct sum of the kernels ker(qᵢ^eᵢ(T)). These summands — the primary components, or generalized eigenspaces — are T-invariant, and the decomposition is the launching point for both the rational canonical form (over any field) and, when the qᵢ are linear, the Jordan canonical form (over an algebraically closed field).\n\nThe parent entry cayley-hamilton-oq-01 established that the minimal polynomial generates the annihilator ideal of V and gives the optimal polynomial reduction f(T) = (f mod μ_T)(T). Its closing open question asked to extend this to the full primary decomposition. This entry answers that question.",
+    "problemStatement": "**Open Question (from parent proof cayley-hamilton-oq-01)**: Extend to primary decomposition: μ_T = ∏ pᵢ^eᵢ (distinct irreducibles) and the corresponding V = ⊕ ker(pᵢ^eᵢ(T)).\n\n**Resolution**: We prove the general coprime decomposition V = ⨁ᵢ ker(pᵢ(T)) for any finite pairwise-coprime family whose product annihilates T, and then specialise to the minimal-polynomial prime-power factorisation to obtain V = ⨁ᵢ ker(qᵢ^eᵢ(T)). Each component is shown to be T-invariant.",
+    "text": "A 168-line, axiom-free development (6 theorems, 0 definitions). The technical heart is iSup_ker_aeval_eq_ker_aeval_prod, an iterated Chinese Remainder Theorem proved by Finset induction: the binary identity ker(p(T)) ⊔ ker(q(T)) = ker((p·q)(T)) for coprime p, q (Mathlib's sup_ker_aeval_eq_ker_aeval_mul_of_coprime) is lifted to a finite product, using IsCoprime.prod_right to keep the inserted factor coprime to the running product. From this, iSupIndep_ker_aeval establishes independence (each pᵢ is coprime to the product of the others, so the kernels are pairwise-relatively disjoint via disjoint_ker_aeval_of_isCoprime), and iSup_ker_aeval_eq_top establishes spanning (the product annihilates T, so its kernel is everything). Combining these through DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top yields isInternal_ker_aeval, and substituting μ_T = ∏ qᵢ^eᵢ (with IsCoprime.pow promoting coprimality of the qᵢ to coprimality of the prime powers, and minpoly.aeval supplying annihilation) gives the headline isInternal_primaryDecomposition_of_minpoly.",
+    "proofStrategy": "The proof reduces the n-fold decomposition to Mathlib's binary coprime-kernel lemmas. (1) Spanning: ⨆ᵢ ker(pᵢ(T)) = ker((∏ pᵢ)(T)) by induction — base case ∏∅ = 1 gives ker(id) = ⊥; the insert step combines the binary sup-equals-kernel-of-product lemma with coprimality of the new factor to the rest (IsCoprime.prod_right). Since the product annihilates T, this kernel is ⊤. (2) Independence: by iSupIndep_def it suffices that each ker(pᵢ(T)) is disjoint from ⨆_{j≠i} ker(pⱼ(T)); rewriting the latter (over univ.erase i) as ker of the product of the remaining factors, disjoint_ker_aeval_of_isCoprime applies because pᵢ is coprime to that product. (3) DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top packages independence + spanning into IsInternal. (4) The minimal-polynomial corollary instantiates pᵢ = qᵢ^eᵢ: coprimality of prime powers from IsCoprime.pow, and annihilation from minpoly.aeval after rewriting along μ_T = ∏ qᵢ^eᵢ.",
+    "keyInsights": [
+      "The full primary decomposition is exactly an iterated Chinese Remainder Theorem for the K[X]-action on V; the only genuinely new content beyond Mathlib's binary lemmas is the Finset-induction bookkeeping and coprime-to-product arguments.",
+      "Independence and spanning both reduce to the same product-of-kernels identity: spanning uses the full product (= ⊤ since it annihilates), while independence uses the product over the complement of a single index (univ.erase i).",
+      "Coprimality of the factors propagates to coprimality with their products (IsCoprime.prod_right) and to coprimality of their powers (IsCoprime.pow) — these two combinators are what make the prime-power case fall out of the general coprime case.",
+      "T-invariance of each component is automatic: ker(p(T)) is invariant because p(T) commutes with T (both are polynomials in T), so T maps the kernel into itself.",
+      "No finiteness or algebraic-closure assumption on V is needed for the general theorem; the minimal polynomial enters only through its annihilation property minpoly.aeval, which holds unconditionally."
+    ],
+    "prerequisites": [
+      "Linear algebra (minimal/characteristic polynomial, generalized eigenspaces, canonical forms)",
+      "Module theory over a PID (annihilators, Chinese Remainder Theorem for K[X])",
+      "Coprime polynomials and internal direct-sum decompositions"
+    ]
+  },
+  "conclusion": {
+    "summary": "For an endomorphism T whose minimal polynomial factors into pairwise coprime prime powers μ_T = ∏ qᵢ^eᵢ, the space decomposes as an internal direct sum of the T-invariant primary components V = ⨁ᵢ ker(qᵢ^eᵢ(T)). The result is obtained from a general coprime decomposition V = ⨁ᵢ ker(pᵢ(T)) (for any pairwise-coprime family whose product annihilates T), itself an iterated Chinese Remainder Theorem built by Finset induction over Mathlib's binary coprime-kernel lemmas. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This is the structural backbone of operator canonical forms: the primary decomposition reduces the study of T to its action on each invariant component ker(qᵢ^eᵢ(T)), on which qᵢ^eᵢ is the minimal polynomial. Over an algebraically closed field the qᵢ are linear and the components are the generalized eigenspaces, yielding the Jordan form; over a general field it underlies the rational canonical form. It directly answers the parent entry's closing open question.",
+    "openQuestions": [
+      "Prove existence of the pairwise-coprime prime-power factorisation μ_T = ∏ qᵢ^eᵢ over an arbitrary field (factoriality of K[X]), turning the hypothesis of the headline theorem into a theorem.",
+      "Identify each primary component ker(qᵢ^eᵢ(T)) with the qᵢ-primary part of V as a K[X]-module and compute its minimal polynomial as qᵢ^eᵢ.",
+      "Assemble the Jordan canonical form by further decomposing each linear-prime component ker((X-λ)^e (T)) into cyclic (Jordan) blocks."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's closing open question by upgrading the whole-space annihilator theory to the full primary decomposition"
+    },
+    {
+      "targetId": "cayley-hamilton-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry on the cyclic-vector / vector-annihilator side of the same K[X]-module structure"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Cayley-Hamilton guarantees a finite-degree annihilating polynomial, the integrality that makes the minimal polynomial (and its factorisation) available"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Basic",
+      "Mathlib.Algebra.DirectSum.Module",
+      "Mathlib.FieldTheory.Minpoly.Field",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Polynomial",
+      "Submodule",
+      "LinearMap",
+      "Finset"
+    ],
+    "namespace": "CayleyHamiltonOQ01OQ04",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CayleyHamiltonOQ01OQ04.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Answers the closing open question of **cayley-hamilton-oq-01** (Minimal Polynomial Reduction and Annihilator Theory):

> Extend to primary decomposition: μ_T = ∏ pᵢ^eᵢ (distinct irreducibles) and the corresponding V = ⊕ ker(pᵢ^eᵢ(T)).

For an endomorphism `T : V →ₗ[K] V` over a field `K` whose minimal polynomial factors into **pairwise coprime prime powers** μ_T = ∏ qᵢ^eᵢ, the space splits as the internal direct sum of the **T-invariant primary components**:

    V = ⨁ᵢ ker( (qᵢ^eᵢ)(T) ).

## Method

The n-fold decomposition is reduced to Mathlib's *binary* coprime-kernel lemmas by `Finset` induction — an iterated Chinese Remainder Theorem for the action of K[X] on V:

- `iSup_ker_aeval_eq_ker_aeval_prod` — ⨆ᵢ ker(pᵢ(T)) = ker((∏ pᵢ)(T)) (induction on `sup_ker_aeval_eq_ker_aeval_mul_of_coprime` + `IsCoprime.prod_right`)
- `iSupIndep_ker_aeval` — independence, via `disjoint_ker_aeval_of_isCoprime` (each pᵢ coprime to the product of the rest)
- `iSup_ker_aeval_eq_top` — spanning, since the product annihilates T
- `isInternal_ker_aeval` — general coprime form, via `isInternal_submodule_iff_iSupIndep_and_iSup_eq_top`
- `isInternal_primaryDecomposition_of_minpoly` — headline, instantiating pᵢ = qᵢ^eᵢ (`IsCoprime.pow` + `minpoly.aeval`)
- `ker_aeval_mapsTo` — each component is T-invariant (p(T) commutes with T)

No finiteness or algebraic-closure hypotheses on V are needed for the general theorem.

## Verification

- **6 theorems, 0 definitions, 168 lines**
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext` / `Classical.choice` / `Quot.sound`
- Builds against Mathlib 4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)