### PR TITLE
research(binary-gcd-oq-02-oq-03): extended binary GCD with certified Bézout coefficients [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -353,6 +353,7 @@ import Proofs.BinaryGcdOQ01OQ04
 import Proofs.BinaryGcdOQ02
 import Proofs.BinaryGcdOQ02OQ01
 import Proofs.BinaryGcdOQ02OQ02
+import Proofs.BinaryGcdOQ02OQ03
 import Proofs.BinaryGcdOQ03
 import Proofs.BinaryGcdOQ03OQ01
 import Proofs.BinaryGcdOQ03OQ02

--- a/proofs/Proofs/BinaryGcdOQ02OQ03.lean
+++ b/proofs/Proofs/BinaryGcdOQ02OQ03.lean
@@ -1,0 +1,335 @@
+/-
+# Extended Binary GCD: Certified Bézout Coefficients (OQ-02-OQ-03)
+
+## What This Proves
+The Binary GCD (Stein's algorithm) computes only the *value* of `gcd`. This
+file builds the **extended** binary GCD `binaryXgcd` / `binaryXgcdInt`, which
+additionally returns a pair of Bézout coefficients `(x, y)` and proves the
+certified identity
+
+    a * x + b * y = gcd a b.
+
+The coefficients are produced *through the binary reductions themselves*
+(halving, parity-correction, subtract-and-halve), not by delegating to
+Mathlib's `Int.gcdA` / `Int.gcdB`. We then show the produced identity is
+equivalent to Mathlib's: both yield the same Bézout relation for `Int.gcd`.
+
+## The Coefficient Algebra
+Each Stein reduction transforms a Bézout relation for the reduced pair into
+one for the original pair. The only non-obvious step is *un-halving* an even
+operand: from `a' * x + b * y = g` with `b` odd we need integer `X, Y` with
+`(2a') * X + b * Y = a' * x + b * y`. Since `b` is odd, exactly one of `x`,
+`x + b` is even, giving the parity-correcting helper `hL` (and its mirror
+`hR`). Every other reduction is a linear recombination on top of `hL` / `hR`.
+
+## References
+- Stein (1967); Knuth TAOCP §4.5.2; Menezes–van Oorschot–Vanstone, HAC 14.61
+- Mathlib: `Int.gcd_eq_gcd_ab`, `Int.gcdA`, `Int.gcdB`, `Nat.gcd_mul_left`
+- Companion to the binary-gcd strand (`Proofs/BinaryGcdOQ02.lean`)
+-/
+import Mathlib.Data.Int.GCD
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+namespace BinaryGcdOQ02OQ03
+
+/-! ## Part I: `Nat.gcd` reduction identities (Stein's invariants)
+
+We reprove the four GCD-preserving reductions of the binary algorithm against
+the current Mathlib API, self-contained. -/
+
+/-- `gcd(2a, 2b) = 2·gcd(a, b)`. -/
+theorem gcd_two_mul (a b : ℕ) : Nat.gcd (2 * a) (2 * b) = 2 * Nat.gcd a b :=
+  Nat.gcd_mul_left 2 a b
+
+/-- `gcd(2a, b) = gcd(a, b)` when `b` is odd (2 is coprime to `b`). -/
+theorem gcd_two_mul_odd {a b : ℕ} (hb : b % 2 = 1) :
+    Nat.gcd (2 * a) b = Nat.gcd a b := by
+  apply Nat.dvd_antisymm
+  · apply Nat.dvd_gcd
+    · have hedvdb : Nat.gcd (2 * a) b ∣ b := Nat.gcd_dvd_right _ _
+      have heodd : Odd (Nat.gcd (2 * a) b) := by
+        rcases Nat.even_or_odd (Nat.gcd (2 * a) b) with he | he
+        · exfalso
+          have h2b : 2 ∣ b := dvd_trans he.two_dvd hedvdb
+          omega
+        · exact he
+      have hcop : Nat.Coprime (Nat.gcd (2 * a) b) 2 := Nat.coprime_two_right.mpr heodd
+      exact hcop.dvd_of_dvd_mul_left (Nat.gcd_dvd_left _ _)
+    · exact Nat.gcd_dvd_right _ _
+  · apply Nat.dvd_gcd
+    · exact Dvd.dvd.mul_left (Nat.gcd_dvd_left a b) 2
+    · exact Nat.gcd_dvd_right a b
+
+/-- `gcd(a, 2b) = gcd(a, b)` when `a` is odd. -/
+theorem gcd_two_mul_odd_right {a b : ℕ} (ha : a % 2 = 1) :
+    Nat.gcd a (2 * b) = Nat.gcd a b := by
+  rw [Nat.gcd_comm, gcd_two_mul_odd ha, Nat.gcd_comm]
+
+/-- `gcd(m - n, n) = gcd(m, n)` for `n ≤ m`. -/
+theorem gcd_sub_right {m n : ℕ} (h : n ≤ m) :
+    Nat.gcd (m - n) n = Nat.gcd m n := by
+  apply Nat.dvd_antisymm
+  · apply Nat.dvd_gcd
+    · have hd : Nat.gcd (m - n) n ∣ (m - n) + n :=
+        Nat.dvd_add (Nat.gcd_dvd_left _ _) (Nat.gcd_dvd_right _ _)
+      rwa [Nat.sub_add_cancel h] at hd
+    · exact Nat.gcd_dvd_right _ _
+  · apply Nat.dvd_gcd
+    · exact Nat.dvd_sub (Nat.gcd_dvd_left _ _) (Nat.gcd_dvd_right _ _)
+    · exact Nat.gcd_dvd_right _ _
+
+/-- Both odd, `n ≤ m`: `gcd((m - n)/2, n) = gcd(m, n)`. -/
+theorem gcd_odd_sub_half {m n : ℕ} (hm : m % 2 = 1) (hn : n % 2 = 1) (hge : n ≤ m) :
+    Nat.gcd ((m - n) / 2) n = Nat.gcd m n := by
+  have hhalf : 2 * ((m - n) / 2) = m - n := by omega
+  calc Nat.gcd ((m - n) / 2) n
+      = Nat.gcd (2 * ((m - n) / 2)) n := (gcd_two_mul_odd hn).symm
+    _ = Nat.gcd (m - n) n := by rw [hhalf]
+    _ = Nat.gcd m n := gcd_sub_right hge
+
+/-- Both odd, `m ≤ n`: `gcd(m, (n - m)/2) = gcd(m, n)`. -/
+theorem gcd_odd_sub_half_right {m n : ℕ} (hm : m % 2 = 1) (hn : n % 2 = 1) (hle : m ≤ n) :
+    Nat.gcd m ((n - m) / 2) = Nat.gcd m n := by
+  rw [Nat.gcd_comm, gcd_odd_sub_half hn hm hle, Nat.gcd_comm]
+
+/-! ## Part II: parity-correcting "un-halving" helpers -/
+
+/-- **Un-halve the left operand.** Given `a' * x + b * y = g` with `b` odd,
+returns `(X, Y)` for the *doubled* left operand: `(2a')·X + b·Y = a'·x + b·y`.
+If `x` is odd then `x + b` is even (since `b` is odd), keeping `X` integral. -/
+def hL (a' b x y : ℤ) : ℤ × ℤ :=
+  if x % 2 = 0 then (x / 2, y) else ((x + b) / 2, y - a')
+
+/-- **Un-halve the right operand** (mirror of `hL`), with `a` odd. -/
+def hR (a b' x y : ℤ) : ℤ × ℤ :=
+  if y % 2 = 0 then (x, y / 2) else (x - b', (y + a) / 2)
+
+theorem hL_spec {a' b x y : ℤ} (hb : b % 2 = 1) :
+    2 * a' * (hL a' b x y).1 + b * (hL a' b x y).2 = a' * x + b * y := by
+  unfold hL
+  split_ifs with h
+  · have h2 : (2 : ℤ) * (x / 2) = x := by omega
+    show 2 * a' * (x / 2) + b * y = a' * x + b * y
+    linear_combination a' * h2
+  · have h2 : (2 : ℤ) * ((x + b) / 2) = x + b := by omega
+    show 2 * a' * ((x + b) / 2) + b * (y - a') = a' * x + b * y
+    linear_combination a' * h2
+
+theorem hR_spec {a b' x y : ℤ} (ha : a % 2 = 1) :
+    a * (hR a b' x y).1 + 2 * b' * (hR a b' x y).2 = a * x + b' * y := by
+  unfold hR
+  split_ifs with h
+  · have h2 : (2 : ℤ) * (y / 2) = y := by omega
+    show a * x + 2 * b' * (y / 2) = a * x + b' * y
+    linear_combination b' * h2
+  · have h2 : (2 : ℤ) * ((y + a) / 2) = y + a := by omega
+    show a * (x - b') + 2 * b' * ((y + a) / 2) = a * x + b' * y
+    linear_combination b' * h2
+
+/-! ## Part III: the extended binary GCD on `ℕ`
+
+The recursion follows Stein's algorithm; each Bézout step composes one
+`hL` / `hR` un-halving with a linear recombination. -/
+
+/-- **Extended binary GCD** on naturals: returns Bézout coefficients
+`(x, y) : ℤ × ℤ` with `a * x + b * y = Nat.gcd a b`. -/
+def binaryXgcd : ℕ → ℕ → ℤ × ℤ
+  | 0, b => (0, 1)
+  | a, 0 => (1, 0)
+  | a + 1, b + 1 =>
+    if ha : (a + 1) % 2 = 0 then
+      if hb : (b + 1) % 2 = 0 then
+        -- both even: gcd doubles, coefficients unchanged
+        binaryXgcd ((a + 1) / 2) ((b + 1) / 2)
+      else
+        -- a+1 even, b+1 odd: un-halve the left operand
+        hL (((a + 1) / 2 : ℕ) : ℤ) ((b + 1 : ℕ) : ℤ)
+          (binaryXgcd ((a + 1) / 2) (b + 1)).1
+          (binaryXgcd ((a + 1) / 2) (b + 1)).2
+    else if hb : (b + 1) % 2 = 0 then
+      -- a+1 odd, b+1 even: un-halve the right operand
+      hR ((a + 1 : ℕ) : ℤ) (((b + 1) / 2 : ℕ) : ℤ)
+        (binaryXgcd (a + 1) ((b + 1) / 2)).1
+        (binaryXgcd (a + 1) ((b + 1) / 2)).2
+    else if a + 1 > b + 1 then
+      -- both odd, a+1 > b+1
+      let p := hL ((a + 1 - (b + 1)) / 2 : ℕ) ((b + 1 : ℕ) : ℤ)
+        (binaryXgcd ((a + 1 - (b + 1)) / 2) (b + 1)).1
+        (binaryXgcd ((a + 1 - (b + 1)) / 2) (b + 1)).2
+      (p.1, p.2 - p.1)
+    else
+      -- both odd, a+1 ≤ b+1
+      let p := hR ((a + 1 : ℕ) : ℤ) ((b + 1 - (a + 1)) / 2 : ℕ)
+        (binaryXgcd (a + 1) ((b + 1 - (a + 1)) / 2)).1
+        (binaryXgcd (a + 1) ((b + 1 - (a + 1)) / 2)).2
+      (p.1 - p.2, p.2)
+  termination_by a b => a + b
+  decreasing_by all_goals omega
+
+/-! ## Part IV: Bézout correctness over `ℕ` -/
+
+/-- **Bézout identity for the extended binary GCD.** -/
+theorem binaryXgcd_bezout :
+    ∀ a b : ℕ,
+      (a : ℤ) * (binaryXgcd a b).1 + (b : ℤ) * (binaryXgcd a b).2
+        = (Nat.gcd a b : ℤ) := by
+  intro a b
+  induction a, b using binaryXgcd.induct with
+  | case1 b =>
+    simp [binaryXgcd, Nat.gcd_zero_left]
+  | case2 a =>
+    simp [binaryXgcd, Nat.gcd_zero_right]
+  | case3 a b ha hb ih =>
+    simp only [binaryXgcd, ha, hb, ↓reduceDIte]
+    have gk : Nat.gcd (a + 1) (b + 1)
+        = 2 * Nat.gcd ((a + 1) / 2) ((b + 1) / 2) := by
+      conv_lhs => rw [show a + 1 = 2 * ((a + 1) / 2) by omega,
+        show b + 1 = 2 * ((b + 1) / 2) by omega]
+      exact gcd_two_mul _ _
+    have gkZ : ((Nat.gcd (a + 1) (b + 1) : ℕ) : ℤ)
+        = 2 * ((Nat.gcd ((a + 1) / 2) ((b + 1) / 2) : ℕ) : ℤ) := by
+      rw [gk]; push_cast; ring
+    have ca : ((a + 1 : ℕ) : ℤ) = 2 * (((a + 1) / 2 : ℕ) : ℤ) := by omega
+    have cb : ((b + 1 : ℕ) : ℤ) = 2 * (((b + 1) / 2 : ℕ) : ℤ) := by omega
+    linear_combination 2 * ih
+      + (binaryXgcd ((a + 1) / 2) ((b + 1) / 2)).1 * ca
+      + (binaryXgcd ((a + 1) / 2) ((b + 1) / 2)).2 * cb - gkZ
+  | case4 a b ha hb ih =>
+    simp only [binaryXgcd, ha, hb, ↓reduceDIte]
+    have hbodd : (b + 1) % 2 = 1 := by omega
+    have gk : Nat.gcd (a + 1) (b + 1) = Nat.gcd ((a + 1) / 2) (b + 1) := by
+      conv_lhs => rw [show a + 1 = 2 * ((a + 1) / 2) by omega]
+      exact gcd_two_mul_odd hbodd
+    have gkZ : ((Nat.gcd (a + 1) (b + 1) : ℕ) : ℤ)
+        = ((Nat.gcd ((a + 1) / 2) (b + 1) : ℕ) : ℤ) := by exact_mod_cast gk
+    have ca : ((a + 1 : ℕ) : ℤ) = 2 * (((a + 1) / 2 : ℕ) : ℤ) := by omega
+    have hbZ : ((b + 1 : ℕ) : ℤ) % 2 = 1 := by omega
+    have hs := hL_spec (a' := (((a + 1) / 2 : ℕ) : ℤ)) (b := ((b + 1 : ℕ) : ℤ))
+      (x := (binaryXgcd ((a + 1) / 2) (b + 1)).1)
+      (y := (binaryXgcd ((a + 1) / 2) (b + 1)).2) hbZ
+    linear_combination
+      (hL (((a + 1) / 2 : ℕ) : ℤ) ((b + 1 : ℕ) : ℤ)
+        (binaryXgcd ((a + 1) / 2) (b + 1)).1
+        (binaryXgcd ((a + 1) / 2) (b + 1)).2).1 * ca + hs + ih - gkZ
+  | case5 a b ha hb ih =>
+    simp only [binaryXgcd, ha, hb, ↓reduceDIte]
+    have haodd : (a + 1) % 2 = 1 := by omega
+    have gk : Nat.gcd (a + 1) (b + 1) = Nat.gcd (a + 1) ((b + 1) / 2) := by
+      conv_lhs => rw [show b + 1 = 2 * ((b + 1) / 2) by omega]
+      exact gcd_two_mul_odd_right haodd
+    have gkZ : ((Nat.gcd (a + 1) (b + 1) : ℕ) : ℤ)
+        = ((Nat.gcd (a + 1) ((b + 1) / 2) : ℕ) : ℤ) := by exact_mod_cast gk
+    have cb : ((b + 1 : ℕ) : ℤ) = 2 * (((b + 1) / 2 : ℕ) : ℤ) := by omega
+    have haZ : ((a + 1 : ℕ) : ℤ) % 2 = 1 := by omega
+    have hs := hR_spec (a := ((a + 1 : ℕ) : ℤ)) (b' := (((b + 1) / 2 : ℕ) : ℤ))
+      (x := (binaryXgcd (a + 1) ((b + 1) / 2)).1)
+      (y := (binaryXgcd (a + 1) ((b + 1) / 2)).2) haZ
+    linear_combination
+      (hR ((a + 1 : ℕ) : ℤ) (((b + 1) / 2 : ℕ) : ℤ)
+        (binaryXgcd (a + 1) ((b + 1) / 2)).1
+        (binaryXgcd (a + 1) ((b + 1) / 2)).2).2 * cb + hs + ih - gkZ
+  | case6 a b ha hb hgt ih =>
+    simp only [binaryXgcd, ha, hb, hgt, ↓reduceDIte, ↓reduceIte, Nat.succ_eq_add_one]
+    set c : ℕ := (a + 1 - (b + 1)) / 2 with hc
+    have haodd : (a + 1) % 2 = 1 := by omega
+    have hbodd : (b + 1) % 2 = 1 := by omega
+    have gk : Nat.gcd (a + 1) (b + 1) = Nat.gcd c (b + 1) :=
+      (gcd_odd_sub_half haodd hbodd (by omega)).symm
+    have gkZ : ((Nat.gcd (a + 1) (b + 1) : ℕ) : ℤ)
+        = ((Nat.gcd c (b + 1) : ℕ) : ℤ) := by exact_mod_cast gk
+    have hle6 : b + 1 ≤ a + 1 := by omega
+    have hsub6 : (a + 1) - (b + 1) = 2 * c := by omega
+    have cdiff : ((a + 1 : ℕ) : ℤ) - ((b + 1 : ℕ) : ℤ) = 2 * ((c : ℕ) : ℤ) := by
+      rw [← Nat.cast_sub hle6, hsub6]; push_cast; ring
+    have hbZ : ((b + 1 : ℕ) : ℤ) % 2 = 1 := by omega
+    have hs := hL_spec (a' := ((c : ℕ) : ℤ)) (b := ((b + 1 : ℕ) : ℤ))
+      (x := (binaryXgcd c (b + 1)).1)
+      (y := (binaryXgcd c (b + 1)).2) hbZ
+    linear_combination
+      (hL ((c : ℕ) : ℤ) ((b + 1 : ℕ) : ℤ)
+        (binaryXgcd c (b + 1)).1 (binaryXgcd c (b + 1)).2).1 * cdiff + hs + ih - gkZ
+  | case7 a b ha hb hle ih =>
+    simp only [binaryXgcd, ha, hb, show ¬ (a + 1 > b + 1) from by omega, ↓reduceDIte,
+      ↓reduceIte, Nat.succ_eq_add_one]
+    set c : ℕ := (b + 1 - (a + 1)) / 2 with hc
+    have haodd : (a + 1) % 2 = 1 := by omega
+    have hbodd : (b + 1) % 2 = 1 := by omega
+    have gk : Nat.gcd (a + 1) (b + 1) = Nat.gcd (a + 1) c :=
+      (gcd_odd_sub_half_right haodd hbodd (by omega)).symm
+    have gkZ : ((Nat.gcd (a + 1) (b + 1) : ℕ) : ℤ)
+        = ((Nat.gcd (a + 1) c : ℕ) : ℤ) := by exact_mod_cast gk
+    have hle7 : a + 1 ≤ b + 1 := by omega
+    have hsub7 : (b + 1) - (a + 1) = 2 * c := by omega
+    have cdiff : ((b + 1 : ℕ) : ℤ) - ((a + 1 : ℕ) : ℤ) = 2 * ((c : ℕ) : ℤ) := by
+      rw [← Nat.cast_sub hle7, hsub7]; push_cast; ring
+    have haZ : ((a + 1 : ℕ) : ℤ) % 2 = 1 := by omega
+    have hs := hR_spec (a := ((a + 1 : ℕ) : ℤ)) (b' := ((c : ℕ) : ℤ))
+      (x := (binaryXgcd (a + 1) c).1)
+      (y := (binaryXgcd (a + 1) c).2) haZ
+    linear_combination
+      (hR ((a + 1 : ℕ) : ℤ) ((c : ℕ) : ℤ)
+        (binaryXgcd (a + 1) c).1 (binaryXgcd (a + 1) c).2).2 * cdiff + hs + ih - gkZ
+
+/-! ## Part V: the integer extended binary GCD -/
+
+/-- **Extended binary GCD on integers.** Sign-adjusts the natural-number
+coefficients so that `a * x + b * y = Int.gcd a b`. -/
+def binaryXgcdInt (a b : ℤ) : ℤ × ℤ :=
+  (a.sign * (binaryXgcd a.natAbs b.natAbs).1,
+   b.sign * (binaryXgcd a.natAbs b.natAbs).2)
+
+/-- **Bézout identity for the integer extended binary GCD.** -/
+theorem binaryXgcdInt_bezout (a b : ℤ) :
+    a * (binaryXgcdInt a b).1 + b * (binaryXgcdInt a b).2 = (Int.gcd a b : ℤ) := by
+  unfold binaryXgcdInt
+  have hbz := binaryXgcd_bezout a.natAbs b.natAbs
+  have ha : a * a.sign = (a.natAbs : ℤ) := by
+    rw [mul_comm]; exact Int.sign_mul_self_eq_natAbs a
+  have hb : b * b.sign = (b.natAbs : ℤ) := by
+    rw [mul_comm]; exact Int.sign_mul_self_eq_natAbs b
+  have hg : (Int.gcd a b : ℤ) = (Nat.gcd a.natAbs b.natAbs : ℤ) := by rfl
+  rw [hg]
+  calc a * (a.sign * (binaryXgcd a.natAbs b.natAbs).1)
+        + b * (b.sign * (binaryXgcd a.natAbs b.natAbs).2)
+      = (a * a.sign) * (binaryXgcd a.natAbs b.natAbs).1
+        + (b * b.sign) * (binaryXgcd a.natAbs b.natAbs).2 := by ring
+    _ = (a.natAbs : ℤ) * (binaryXgcd a.natAbs b.natAbs).1
+        + (b.natAbs : ℤ) * (binaryXgcd a.natAbs b.natAbs).2 := by rw [ha, hb]
+    _ = (Nat.gcd a.natAbs b.natAbs : ℤ) := hbz
+
+/-- **Equivalence to Mathlib's `Int.gcdA` / `Int.gcdB`.** The Bézout relation
+produced by the extended *binary* GCD coincides with the one from Mathlib's
+extended Euclidean coefficients (both certify the same `Int.gcd`). The
+coefficients themselves need not be equal — Bézout coefficients are not
+unique — but the certified identities agree. -/
+theorem binaryXgcdInt_eq_gcdAB (a b : ℤ) :
+    a * (binaryXgcdInt a b).1 + b * (binaryXgcdInt a b).2
+      = a * Int.gcdA a b + b * Int.gcdB a b := by
+  rw [binaryXgcdInt_bezout, Int.gcd_eq_gcd_ab]
+
+/-! ## Part VI: concrete sanity checks -/
+
+-- 12 = 2²·3, 18 = 2·3²; gcd = 6.  Certifies 12x + 18y = 6.
+example : (12 : ℤ) * (binaryXgcdInt 12 18).1 + 18 * (binaryXgcdInt 12 18).2 = 6 := by
+  rw [binaryXgcdInt_bezout]; decide
+
+-- coprime case: 17x + 5y = 1
+example : (17 : ℤ) * (binaryXgcdInt 17 5).1 + 5 * (binaryXgcdInt 17 5).2 = 1 := by
+  rw [binaryXgcdInt_bezout]; decide
+
+-- negative arguments are handled by the sign adjustment
+example : (-12 : ℤ) * (binaryXgcdInt (-12) 18).1 + 18 * (binaryXgcdInt (-12) 18).2 = 6 := by
+  rw [binaryXgcdInt_bezout]; decide
+
+/-! ## Summary
+
+- `binaryXgcd` (ℕ) and `binaryXgcdInt` (ℤ): extended binary GCD returning
+  Bézout coefficients computed through Stein's reductions.
+- `binaryXgcd_bezout`, `binaryXgcdInt_bezout`: certified `a x + b y = gcd`.
+- `binaryXgcdInt_eq_gcdAB`: the produced identity matches Mathlib's
+  `Int.gcdA` / `Int.gcdB`.
+- Status: **complete and verified**, 0 axioms, 0 sorries. -/
+
+end BinaryGcdOQ02OQ03

--- a/src/data/proofs/binary-gcd-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-03/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-binxgcd-reductions",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 37,
+      "endLine": 95
+    },
+    "type": "concept",
+    "title": "Stein's GCD-preserving reductions",
+    "content": "The binary GCD algorithm rests on four identities that leave gcd unchanged: `gcd(2a,2b) = 2·gcd(a,b)`, `gcd(2a,b) = gcd(a,b)` for odd `b`, `gcd(m-n,n) = gcd(m,n)`, and the combined `gcd((m-n)/2, n) = gcd(m,n)` for both-odd inputs. They are reproved here against the current Mathlib API (self-contained): `gcd_two_mul` reuses `Nat.gcd_mul_left`; `gcd_two_mul_odd` cancels the factor of 2 by coprimality (`Odd b ⇒ Coprime (gcd) 2`); `gcd_sub_right` is a divisibility antisymmetry using the current `Nat.dvd_sub`.",
+    "mathContext": "Each recursive step of `binaryXgcd` corresponds to exactly one of these reductions, so the Bézout correctness proof can rewrite `Nat.gcd a b` to the reduced gcd in lockstep with the algorithm's recursion.",
+    "significance": "supporting",
+    "relatedConcepts": ["binary GCD", "Stein's algorithm", "Nat.gcd reductions", "coprimality"],
+    "prerequisites": ["Nat.gcd_mul_left", "Nat.dvd_sub", "Nat.coprime_two_right"]
+  },
+  {
+    "id": "ann-binxgcd-unhalve",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 97,
+      "endLine": 130
+    },
+    "type": "definition",
+    "title": "Parity-correcting un-halving (hL / hR)",
+    "content": "The single non-trivial coefficient step. When the algorithm halves an even left operand, a Bézout relation `a'·x + b·y = g` for the reduced pair must become `(2a')·X + b·Y = a'·x + b·y` for the original. The catch: `X` must be an integer. Since `b` is odd, exactly one of `x`, `x+b` is even, so `hL` branches on the parity of `x`: if `x` is even take `(x/2, y)`; otherwise take `((x+b)/2, y - a')`. The mirror `hR` un-halves the right operand. The specs `hL_spec`/`hR_spec` are one-line `linear_combination`s after an `omega` fact that `2·(x/2) = x` (resp. `2·((x+b)/2) = x+b`).",
+    "mathContext": "This is the classical resolution (HAC 14.61) of the coefficient-halving problem in the extended binary GCD: add an odd multiple of the modulus to flip parity, then divide by two, compensating in the other coefficient.",
+    "significance": "key",
+    "relatedConcepts": ["extended binary GCD", "Bézout coefficients", "parity correction", "integer division"],
+    "prerequisites": ["integer parity", "omega for div/mod by 2"]
+  },
+  {
+    "id": "ann-binxgcd-def",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 131,
+      "endLine": 170
+    },
+    "type": "definition",
+    "title": "binaryXgcd: the extended binary GCD on ℕ",
+    "content": "A well-founded recursion (measure `a + b`) following Stein's case split. Both-even returns the recursive coefficients unchanged (gcd doubles, the relation scales by 2). Even/odd applies one `hL` (resp. `hR`) un-halving. Both-odd subtract-and-halve applies an `hL`/`hR` and then a single linear recombination `(p.1, p.2 - p.1)` (resp. `(p.1 - p.2, p.2)`) to convert the reduced relation back to the original operands. The coefficients are genuinely computed by the binary algorithm — never delegated to Mathlib's `gcdA`/`gcdB`.",
+    "mathContext": "The recursion is identical in shape to the value-only binary GCD, so termination and the inductive structure transfer directly; only the coefficient payload is new.",
+    "significance": "key",
+    "relatedConcepts": ["well-founded recursion", "Stein's algorithm", "extended Euclidean algorithm"],
+    "prerequisites": ["termination_by / decreasing_by", "Stein's reductions"]
+  },
+  {
+    "id": "ann-binxgcd-bezout",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 171,
+      "endLine": 273
+    },
+    "type": "proof-technique",
+    "title": "Bézout correctness by induction on the algorithm",
+    "content": "`binaryXgcd_bezout` proves `a·x + b·y = Nat.gcd a b` by `binaryXgcd.induct`. Each recursive case rewrites `Nat.gcd a b` to the reduced gcd (via the Part I identities), then closes with a single `linear_combination` combining the induction hypothesis, the relevant `hL_spec`/`hR_spec`, the gcd-reduction cast, and an `omega`-supplied cast fact such as `↑(a+1) = 2·↑((a+1)/2)` or `↑(a+1) - ↑(b+1) = 2·↑c`. The integer/natural casts and division facts are discharged uniformly by `omega`.",
+    "mathContext": "Because both the algorithm and `Nat.gcd` satisfy the same four reductions, the induction is tight: the coefficient algebra (hL/hR plus a linear recombination) exactly accounts for the difference between the reduced and original Bézout relations.",
+    "significance": "key",
+    "relatedConcepts": ["structural induction", "linear_combination", "Bézout's identity"],
+    "prerequisites": ["binaryXgcd.induct", "Nat.gcd reductions", "hL_spec / hR_spec"]
+  },
+  {
+    "id": "ann-binxgcd-int",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 275,
+      "endLine": 305
+    },
+    "type": "definition",
+    "title": "binaryXgcdInt and the integer Bézout identity",
+    "content": "`binaryXgcdInt a b` runs `binaryXgcd` on `|a|, |b|` and sign-adjusts: `(a.sign · x, b.sign · y)`. The key algebraic fact is `a · a.sign = ↑a.natAbs` (`Int.sign_mul_self_eq_natAbs`), so `a · (a.sign·x) = ↑a.natAbs · x`. Composing with the ℕ-level Bézout identity gives `binaryXgcdInt_bezout : a·x + b·y = Int.gcd a b`.",
+    "mathContext": "`Int.gcd a b` is definitionally `a.natAbs.gcd b.natAbs`, so the sign adjustment is the only content needed to lift the natural-number certificate to ℤ.",
+    "significance": "key",
+    "relatedConcepts": ["Int.gcd", "Int.sign", "natAbs reduction"],
+    "prerequisites": ["Int.sign_mul_self_eq_natAbs", "binaryXgcd_bezout"]
+  },
+  {
+    "id": "ann-binxgcd-eq-gcdab",
+    "proofId": "binary-gcd-oq-02-oq-03",
+    "range": {
+      "startLine": 306,
+      "endLine": 335
+    },
+    "type": "key-result",
+    "title": "Equivalence to Mathlib's Int.gcdA / Int.gcdB",
+    "content": "`binaryXgcdInt_eq_gcdAB` states `a·x + b·y = a·gcdA a b + b·gcdB a b`: the Bézout relation produced by the extended *binary* GCD coincides with the one from Mathlib's extended Euclidean coefficients. Both certify the same `Int.gcd`, so the identities agree even though the coefficient pairs themselves need not (Bézout coefficients are not unique). This answers the binary-GCD analogue of the sibling open question (the Lehmer entry asks the same for `lehmerXgcdInt`). Three `decide`-checked examples (positive, coprime, and negative inputs) certify concrete instances at type-check time.",
+    "mathContext": "The result places the binary extended algorithm on equal footing with the Euclidean one as a certified producer of Bézout witnesses, completing the binary-GCD strand's coverage of the extended algorithm.",
+    "significance": "key",
+    "relatedConcepts": ["Int.gcdA", "Int.gcdB", "Int.gcd_eq_gcd_ab", "Bézout uniqueness"],
+    "prerequisites": ["Int.gcd_eq_gcd_ab", "binaryXgcdInt_bezout"]
+  }
+]

--- a/src/data/proofs/binary-gcd-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-03/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "binary-gcd-oq-02-oq-03",
+  "title": "Extended Binary GCD: Certified Bézout Coefficients",
+  "slug": "binary-gcd-oq-02-oq-03",
+  "description": "Builds the extended binary GCD `binaryXgcd`/`binaryXgcdInt`, which returns Bézout coefficients `(x, y)` computed *through Stein's reductions themselves* (halving, parity-correction, subtract-and-halve), and proves the certified identity `a·x + b·y = gcd a b`. The produced identity is shown equivalent to Mathlib's `Int.gcdA`/`Int.gcdB`. Unlike the gallery's other Bézout entries, the coefficients are not delegated to Mathlib's extended Euclidean algorithm — they are produced by the binary algorithm. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinaryGcdOQ02OQ03.lean",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "bezout",
+      "integers",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 335,
+    "assumptions": "None. 0 axiom declarations, 0 sorries. Depends only on Mathlib and the standard foundational axioms (propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.gcd_mul_left",
+        "description": "gcd(k·m, k·n) = k·gcd(m, n); supplies the both-even reduction",
+        "module": "Init.Data.Nat.Gcd"
+      },
+      {
+        "theorem": "Nat.dvd_sub",
+        "description": "k ∣ m → k ∣ n → k ∣ m - n on ℕ (truncated subtraction)",
+        "module": "Init.Data.Nat.Dvd"
+      },
+      {
+        "theorem": "Nat.coprime_two_right",
+        "description": "n.Coprime 2 ↔ Odd n; used in the odd-operand halving reduction",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.dvd_of_dvd_mul_left",
+        "description": "Coprime k n → k ∣ n·m → k ∣ m; cancels the factor of 2",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Int.sign_mul_self_eq_natAbs",
+        "description": "sign a · a = ↑a.natAbs; the sign-adjustment for the ℤ coefficients",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "Int.gcd_eq_gcd_ab",
+        "description": "↑(Int.gcd a b) = a·gcdA a b + b·gcdB a b (Mathlib's Bézout identity)",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "Definition of `binaryXgcd : ℕ → ℕ → ℤ × ℤ` (Proofs/BinaryGcdOQ02OQ03.lean:138), an extended binary GCD whose recursion follows Stein's algorithm and threads Bézout coefficients through every reduction",
+      "Parity-correcting un-halving helpers `hL`/`hR` (Proofs/BinaryGcdOQ02OQ03.lean:102,106) with specs `hL_spec`/`hR_spec`: from `a'·x + b·y = g` with `b` odd produce integer `X,Y` with `(2a')·X + b·Y = a'·x + b·y` (the only non-trivial coefficient step)",
+      "Bézout correctness `binaryXgcd_bezout` (Proofs/BinaryGcdOQ02OQ03.lean:174): `a·x + b·y = Nat.gcd a b`, proved by induction on the algorithm with each Stein reduction matched to a `Nat.gcd` reduction identity",
+      "Self-contained reproofs of the four Stein GCD-preserving reductions (gcd_two_mul, gcd_two_mul_odd, gcd_sub_right, gcd_odd_sub_half) against current Mathlib",
+      "Integer extension `binaryXgcdInt` (Proofs/BinaryGcdOQ02OQ03.lean:279) with sign-adjusted coefficients and `binaryXgcdInt_bezout`: `a·x + b·y = Int.gcd a b`",
+      "Equivalence `binaryXgcdInt_eq_gcdAB` (Proofs/BinaryGcdOQ02OQ03.lean:307) to Mathlib's `Int.gcdA`/`Int.gcdB`: both certify the same `Int.gcd`, answering the sibling open question's request for the binary analogue"
+    ],
+    "prerequisites": [
+      "The binary GCD algorithm (Stein 1967) and its GCD-preserving reductions",
+      "Bézout's identity and the extended Euclidean algorithm",
+      "Mathlib's `Int.gcd`, `Int.gcdA`/`Int.gcdB`, and `Int.gcd_eq_gcd_ab`"
+    ],
+    "theoremCount": 11,
+    "definitionCount": 4
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Int.GCD",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "BinaryGcdOQ02OQ03",
+    "lineCount": 335,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 4,
+    "path": "Proofs/BinaryGcdOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Builds the **extended binary GCD** `binaryXgcd` / `binaryXgcdInt`, which returns Bézout coefficients `(x, y)` and proves the certified identity `a·x + b·y = gcd a b`. Unlike the gallery's other Bézout entries, the coefficients are produced **through Stein's reductions themselves** (halving, parity-correction, subtract-and-halve) — not delegated to Mathlib's extended Euclidean `Int.gcdA`/`Int.gcdB`.

This answers the binary-GCD analogue of the sibling open question (the Lehmer entry `binary-gcd-oq-02-oq-02` explicitly asks for an extended GCD returning `(gcd, u, v)` with `u·a + v·b = gcd`, equivalent to `Int.gcdA`/`Int.gcdB`).

## Key results
- `binaryXgcd_bezout`: `a·x + b·y = Nat.gcd a b`, by induction on the algorithm's own recursion.
- `binaryXgcdInt_bezout`: `a·x + b·y = Int.gcd a b` (sign-adjusted via `Int.sign_mul_self_eq_natAbs`).
- `binaryXgcdInt_eq_gcdAB`: the produced identity equals Mathlib's `a·gcdA a b + b·gcdB a b` (both certify the same `Int.gcd`; coefficients themselves need not match, since Bézout coefficients are non-unique).

## The coefficient algebra
The only non-trivial step is *un-halving* an even operand: from `a'·x + b·y = g` with `b` odd, produce integer `X,Y` with `(2a')·X + b·Y = a'·x + b·y`. Since `b` is odd, exactly one of `x`, `x+b` is even — captured by the parity-correcting helpers `hL`/`hR` (HAC 14.61). Every other reduction is a one-line linear recombination on top of `hL`/`hR`.

## Notes
- **Self-contained.** The committed parent `GcdAlgorithmOQ02.lean` no longer compiles against Mathlib v4.26 (it uses the renamed `Nat.dvd_sub'` and the old `coprime_two_left` signature; its oleans were cached from an older Mathlib). So this file reproves the four Stein `Nat.gcd` reductions against the current API and certifies `Nat.gcd`/`Int.gcd` directly, importing only Mathlib.
- 11 theorems, 4 definitions, 335 lines.
- **0 sorries, 0 axioms.** `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool` (examples use kernel `decide`, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)