### PR TITLE
research(triangular-reciprocals-oq-02-oq-04): uniform truncation error 1/(N+1) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean
@@ -1,0 +1,181 @@
+/-
+  Truncation Error Bound for the Generalized Triangular Reciprocal Series
+  (triangular-reciprocals-oq-02-oq-04)
+
+  Parent: `Proofs/TriangularReciprocalsOQ02.lean` (slug `triangular-reciprocals-oq-02`)
+  proves the closed form
+
+      ∑_{n=1}^∞ 1/(n(n+k)) = H_k / k        (k ≥ 1)
+
+  and, en route, the partial-sum closed form
+
+      ∑_{n=1}^N 1/(n(n+k)) = (1/k)(H_k - (H_{N+k} - H_N)).
+
+  This file answers the parent's fourth open question:
+
+      "Quantify the rate of convergence: the closed form gives
+         |∑_{n=1}^∞ 1/(n(n+k)) - S_N(k)| = (1/k)(H_{N+k} - H_N) ≤ 1/(N+1)
+       uniformly in k — formalize this as a Mathlib-style truncation error
+       bound for the partial sums."
+
+  Mathematical content.
+    The truncation error is exactly (1/k)(H_{N+k} - H_N), an immediate algebraic
+    consequence of the parent's partial-sum closed form. The new ingredient is the
+    *uniform* bound
+        H_{N+k} - H_N = ∑_{i=N+1}^{N+k} 1/i ≤ k/(N+1)
+    (each of the k tail terms is ≤ 1/(N+1)), proved here by induction on k. Dividing
+    by k cancels the k completely, leaving the ceiling 1/(N+1) which does NOT depend
+    on k. That k-independence is the headline.
+
+  Results.
+    * `harmonic_diff_nonneg`        : 0 ≤ H_{N+k} - H_N
+    * `harmonic_diff_le`            : H_{N+k} - H_N ≤ k/(N+1)          (core new lemma)
+    * `truncation_error_eq`         : H_k/k - S_N = (1/k)(H_{N+k} - H_N)
+    * `truncation_error_nonneg`     : 0 ≤ H_k/k - S_N
+    * `truncation_error_le`         : H_k/k - S_N ≤ 1/(N+1)
+    * `truncation_error_abs`        : |H_k/k - S_N| ≤ 1/(N+1)
+    * `truncation_error_uniform`    : the bound 1/(N+1) holds for every k ≥ 1
+    * `truncation_error_tsum_abs`   : the same bound against the genuine ∑' value
+
+  Status: verified, 0 axioms (depends only on Mathlib + the parent module).
+-/
+import Mathlib
+import Proofs.TriangularReciprocalsOQ02
+
+namespace TriangularReciprocalsOQ02OQ04
+
+open Finset BigOperators Filter Topology Real
+open TriangularReciprocalsHarmonic
+
+-- ═══════════════════════════════════════════════════
+-- Harmonic tail difference: nonnegativity and the uniform k/(N+1) bound
+-- ═══════════════════════════════════════════════════
+
+/-- The harmonic tail difference is nonnegative: H_{N+k} ≥ H_N. -/
+theorem harmonic_diff_nonneg (N k : ℕ) :
+    (0 : ℝ) ≤ (harmonic (N + k) : ℝ) - (harmonic N : ℝ) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have hstep : (harmonic (N + (k + 1)) : ℝ) =
+        (harmonic (N + k) : ℝ) + 1 / ((N : ℝ) + (k : ℝ) + 1) := by
+      have h1 : N + (k + 1) = (N + k) + 1 := rfl
+      rw [h1, harmonic_succ]; push_cast; ring
+    rw [hstep]
+    have hpos : (0 : ℝ) ≤ 1 / ((N : ℝ) + (k : ℝ) + 1) := by positivity
+    linarith [ih]
+
+/-- **Uniform tail bound.** Each of the k harmonic terms H_{N+1}, …, H_{N+k}/… is at
+    most 1/(N+1), so
+
+        H_{N+k} - H_N ≤ k/(N+1).
+
+    Proved by induction on k: the inductive step adds one term 1/(N+k+1) ≤ 1/(N+1). -/
+theorem harmonic_diff_le (N k : ℕ) :
+    (harmonic (N + k) : ℝ) - (harmonic N : ℝ) ≤ (k : ℝ) / ((N : ℝ) + 1) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have hstep : (harmonic (N + (k + 1)) : ℝ) =
+        (harmonic (N + k) : ℝ) + 1 / ((N : ℝ) + (k : ℝ) + 1) := by
+      have h1 : N + (k + 1) = (N + k) + 1 := rfl
+      rw [h1, harmonic_succ]; push_cast; ring
+    have hterm : (1 : ℝ) / ((N : ℝ) + (k : ℝ) + 1) ≤ 1 / ((N : ℝ) + 1) := by
+      apply one_div_le_one_div_of_le
+      · positivity
+      · have : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+        linarith
+    rw [hstep]
+    push_cast
+    rw [add_div]
+    linarith [ih, hterm]
+
+-- ═══════════════════════════════════════════════════
+-- Truncation error identity and bound (partial sum in Icc form)
+-- ═══════════════════════════════════════════════════
+
+/-- **Exact truncation error.** The difference between the closed-form value H_k/k and
+    the N-term partial sum is exactly (1/k)(H_{N+k} - H_N). Immediate from the parent's
+    `partial_sum_closed_form`. -/
+theorem truncation_error_eq (N k : ℕ) (hk : 0 < k) :
+    (harmonic k : ℝ) / (k : ℝ) -
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+      (1 / (k : ℝ)) * ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)) := by
+  rw [partial_sum_closed_form N k hk]
+  ring
+
+/-- The partial sum underestimates the true value: H_k/k - S_N ≥ 0. -/
+theorem truncation_error_nonneg (N k : ℕ) (hk : 0 < k) :
+    (0 : ℝ) ≤ (harmonic k : ℝ) / (k : ℝ) -
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
+  rw [truncation_error_eq N k hk]
+  apply mul_nonneg
+  · positivity
+  · exact harmonic_diff_nonneg N k
+
+/-- **Uniform truncation error bound** (signed form): for every k ≥ 1,
+
+        H_k/k - S_N(k) ≤ 1/(N+1),
+
+    with the right-hand side independent of k. -/
+theorem truncation_error_le (N k : ℕ) (hk : 0 < k) :
+    (harmonic k : ℝ) / (k : ℝ) -
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) ≤
+      1 / ((N : ℝ) + 1) := by
+  have hk0 : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+  rw [truncation_error_eq N k hk, one_div_mul_eq_div, div_le_iff₀ hk0]
+  calc (harmonic (N + k) : ℝ) - (harmonic N : ℝ)
+      ≤ (k : ℝ) / ((N : ℝ) + 1) := harmonic_diff_le N k
+    _ = 1 / ((N : ℝ) + 1) * (k : ℝ) := by ring
+
+/-- **Uniform truncation error bound** (absolute-value form): for every k ≥ 1,
+
+        |H_k/k - S_N(k)| ≤ 1/(N+1). -/
+theorem truncation_error_abs (N k : ℕ) (hk : 0 < k) :
+    |(harmonic k : ℝ) / (k : ℝ) -
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k))| ≤
+      1 / ((N : ℝ) + 1) := by
+  rw [abs_of_nonneg (truncation_error_nonneg N k hk)]
+  exact truncation_error_le N k hk
+
+/-- **Uniformity, made explicit.** The single ceiling `1/(N+1)` controls the truncation
+    error simultaneously for *all* gap parameters k ≥ 1. This is the crux of the open
+    question: dividing the tail (1/k)(H_{N+k} - H_N) by k cancels every dependence on k. -/
+theorem truncation_error_uniform (N : ℕ) :
+    ∀ k : ℕ, 0 < k →
+      |(harmonic k : ℝ) / (k : ℝ) -
+          ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k))| ≤
+        1 / ((N : ℝ) + 1) :=
+  fun k hk => truncation_error_abs N k hk
+
+-- ═══════════════════════════════════════════════════
+-- Truncation error against the genuine infinite series (∑' form)
+-- ═══════════════════════════════════════════════════
+
+/-- Re-index the `range N` partial sum (used by the parent's `HasSum`/`tsum`) into the
+    `Icc 1 N` partial sum. Transferred from the parent's `h_range_to_Icc`. -/
+theorem range_sum_eq_Icc (N k : ℕ) :
+    ∑ i ∈ Finset.range N,
+        (1 : ℝ) / (((i + 1 : ℕ) : ℝ) * (((i + 1 : ℕ) : ℝ) + ↑k)) =
+      ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
+  rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
+        (Finset.Ico_succ_right_eq_Icc (a := 1) (b := N)).symm,
+      ← Nat.Ico_zero_eq_range]
+  have key := Finset.sum_Ico_add'
+    (fun m : ℕ => (1 : ℝ) / ((m : ℝ) * ((m : ℝ) + ↑k))) 0 N (c := 1)
+  simp only [zero_add] at key
+  rw [← key]
+
+/-- **Truncation error against the true sum.** The N-th partial sum of the actual
+    infinite series ∑' 1/((n+1)((n+1)+k)) differs from its value by at most 1/(N+1),
+    uniformly in k. This is the open question phrased directly in terms of the genuine
+    `tsum`, by combining the parent's closed form with `truncation_error_abs`. -/
+theorem truncation_error_tsum_abs (N k : ℕ) (hk : 0 < k) :
+    |(∑' n : ℕ, (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k))) -
+        ∑ i ∈ Finset.range N,
+          (1 : ℝ) / (((i + 1 : ℕ) : ℝ) * (((i + 1 : ℕ) : ℝ) + ↑k))| ≤
+      1 / ((N : ℝ) + 1) := by
+  rw [generalized_triangular_reciprocals_tsum k hk, range_sum_eq_Icc N k]
+  exact truncation_error_abs N k hk
+
+end TriangularReciprocalsOQ02OQ04

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Rate of Convergence for the Generalized Triangular Reciprocals",
+    "content": "The parent entry proves ∑_{n=1}^∞ 1/(n(n+k)) = H_k/k for every k ≥ 1. This file answers its fourth open question: how fast do the N-term partial sums approach the limit? The partial-fraction telescoping makes the truncation error exactly (1/k)(H_{N+k} - H_N). Bounding the harmonic tail by k/(N+1) — each of its k consecutive reciprocals being at most 1/(N+1) — and dividing by k cancels the gap parameter entirely, leaving the uniform ceiling 1/(N+1).",
+    "mathContext": "$\\left|\\frac{H_k}{k} - \\sum_{n=1}^{N}\\frac{1}{n(n+k)}\\right| = \\frac{1}{k}(H_{N+k} - H_N) \\le \\frac{1}{N+1}$, uniformly in $k \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "harmonic numbers",
+      "truncation error",
+      "rate of convergence",
+      "telescoping series",
+      "uniform bounds"
+    ],
+    "prerequisites": [
+      "real analysis (series partial sums)",
+      "harmonic numbers",
+      "induction in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-harmonic-diff-le",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 74, "endLine": 92 },
+    "type": "technique",
+    "title": "Uniform Tail Bound H_{N+k} - H_N ≤ k/(N+1)",
+    "content": "The core new lemma, proved by induction on the gap parameter k. The k=0 base case is 0 ≤ 0. The successor step uses `harmonic_succ` to write H_{N+(k+1)} = H_{N+k} + 1/(N+k+1); the new term is bounded by 1/(N+1) via `one_div_le_one_div_of_le` (since N+1 ≤ N+k+1), and adding it to the inductive hypothesis k/(N+1) gives (k+1)/(N+1) after `add_div`. No Finset reindexing is needed — the induction does all the bookkeeping.",
+    "mathContext": "$H_{N+k} - H_N = \\sum_{i=N+1}^{N+k}\\frac{1}{i} \\le k\\cdot\\frac{1}{N+1} = \\frac{k}{N+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic_succ", "induction on the gap", "reciprocal antitonicity", "tail estimate"],
+    "prerequisites": ["harmonic recurrence", "monotone reciprocals"]
+  },
+  {
+    "id": "ann-truncation-eq",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 100, "endLine": 106 },
+    "type": "insight",
+    "title": "Exact Truncation Error from the Parent's Closed Form",
+    "content": "Subtracting the parent's partial-sum closed form S_N(k) = (1/k)(H_k - (H_{N+k} - H_N)) from the limit H_k/k leaves exactly (1/k)(H_{N+k} - H_N). Because the manipulation is purely formal in the field inverse k⁻¹ (the H_k/k terms cancel symbolically), a single `ring` closes it — no hypothesis k ≠ 0 is even required at this step.",
+    "mathContext": "$\\frac{H_k}{k} - S_N(k) = \\frac{H_k}{k} - \\frac{1}{k}\\bigl(H_k - (H_{N+k}-H_N)\\bigr) = \\frac{1}{k}(H_{N+k}-H_N).$",
+    "significance": "supporting",
+    "relatedConcepts": ["partial_sum_closed_form", "ring tactic", "field inverse"],
+    "prerequisites": ["partial fractions", "the parent closed form"]
+  },
+  {
+    "id": "ann-truncation-le",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 121, "endLine": 132 },
+    "type": "technique",
+    "title": "Cancelling k: the Bound Becomes k-Independent",
+    "content": "With the error rewritten as (1/k)(H_{N+k} - H_N), `one_div_mul_eq_div` and `div_le_iff₀ hk0` clear the positive denominator k, reducing the goal to H_{N+k} - H_N ≤ (1/(N+1))·k. The tail lemma gives H_{N+k} - H_N ≤ k/(N+1) = (1/(N+1))·k, so the k on both sides cancels and the final ceiling 1/(N+1) carries no dependence on the gap parameter — the crux of the open question.",
+    "mathContext": "$\\frac{1}{k}(H_{N+k}-H_N) \\le \\frac{1}{k}\\cdot\\frac{k}{N+1} = \\frac{1}{N+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["div_le_iff₀", "one_div_mul_eq_div", "uniform bound"],
+    "prerequisites": ["ordered field inequalities"]
+  },
+  {
+    "id": "ann-truncation-tsum",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 157, "endLine": 181 },
+    "type": "insight",
+    "title": "Bounding the Genuine Infinite-Series Truncation",
+    "content": "To phrase the error against the actual ∑' value rather than the abstract closed form, `range_sum_eq_Icc` reindexes the range-N partial sum (the parent's HasSum convention, indexed by n+1) into the Icc 1 N form, and `generalized_triangular_reciprocals_tsum` replaces the tsum by H_k/k. The composite `truncation_error_tsum_abs` then delivers |∑' value - partial sum| ≤ 1/(N+1) directly from `truncation_error_abs`.",
+    "mathContext": "$\\left|\\sum_{n=1}^{\\infty}\\frac{1}{n(n+k)} - \\sum_{n=1}^{N}\\frac{1}{n(n+k)}\\right| \\le \\frac{1}{N+1}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum", "range↔Icc reindex", "Finset.sum_Ico_add'", "generalized_triangular_reciprocals_tsum"],
+    "prerequisites": ["infinite sums", "Finset reindexing"]
+  }
+]

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/index.ts
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangularReciprocalsOq02Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangularReciprocalsOq02Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangularReciprocalsOq02Oq04Data: ProofData = {
+  proof: triangularReciprocalsOq02Oq04Proof,
+  annotations: triangularReciprocalsOq02Oq04Annotations,
+}

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "triangular-reciprocals-oq-02-oq-04",
+  "title": "Uniform Truncation Error for the Generalized Triangular Reciprocal Series",
+  "slug": "triangular-reciprocals-oq-02-oq-04",
+  "description": "For every k ≥ 1, truncating ∑_{n=1}^∞ 1/(n(n+k)) = H_k/k at N terms leaves an error of exactly (1/k)(H_{N+k} - H_N), bounded by 1/(N+1) uniformly in k. Answers the rate-of-convergence open question of the parent generalized identity.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Harmonic_number",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "series",
+      "harmonic-numbers",
+      "telescoping",
+      "error-bound",
+      "rate-of-convergence",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/TriangularReciprocalsOQ02OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "harmonic",
+        "description": "Definition of the k-th harmonic number as ∑_{i=1}^k 1/i in ℚ",
+        "module": "Mathlib.NumberTheory.Harmonic.Defs"
+      },
+      {
+        "theorem": "harmonic_succ",
+        "description": "Recurrence H_{n+1} = H_n + 1/(n+1), driving the induction on the gap parameter",
+        "module": "Mathlib.NumberTheory.Harmonic.Defs"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "Antitonicity of reciprocal: a ≤ b ⇒ 1/b ≤ 1/a, used to bound each tail term by 1/(N+1)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "div_le_iff₀",
+        "description": "Clearing a positive denominator in an inequality",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Ico_add'",
+        "description": "Reindex a sum over Ico by shifting the running index (range ↔ Icc bridge)",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      }
+    ],
+    "originalContributions": [
+      "First Lean 4 formalization of the uniform-in-k truncation error bound for ∑ 1/(n(n+k))",
+      "Exact truncation error identity H_k/k - S_N(k) = (1/k)(H_{N+k} - H_N) from the parent's partial-sum closed form",
+      "Core uniform tail lemma H_{N+k} - H_N ≤ k/(N+1) by induction on k, with the k factor cancelling against the 1/k prefactor",
+      "Absolute-value bound |H_k/k - S_N(k)| ≤ 1/(N+1) and an explicit uniform-in-k restatement",
+      "tsum-form bound tying the partial sums of the genuine infinite series to its value via the parent's closed form"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 181,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry (triangular-reciprocals-oq-02) proves the generalized identity ∑_{n=1}^∞ 1/(n(n+k)) = H_k/k for every k ≥ 1, generalizing Leibniz's 1673 telescoping sum (k=1). A natural quantitative question — flagged as the parent's fourth open question — is the rate at which the N-term partial sums S_N(k) approach the limit. The partial-fraction telescoping makes the error exactly (1/k)(H_{N+k} - H_N), a difference of harmonic numbers whose elementary tail estimate H_{N+k} - H_N ≤ k/(N+1) (each of the k consecutive reciprocals 1/(N+1), …, 1/(N+k) being at most 1/(N+1)) divides out the k entirely. The result is a clean Mathlib-style truncation error bound that is uniform across all gap parameters.",
+    "problemStatement": "**Uniform truncation error.** For every integer $k \\ge 1$ and every $N$,\n\n$$\\left|\\frac{H_k}{k} - \\sum_{n=1}^{N} \\frac{1}{n(n+k)}\\right| = \\frac{1}{k}\\left(H_{N+k} - H_N\\right) \\le \\frac{1}{N+1},$$\n\nwith the right-hand bound independent of $k$.",
+    "text": "Quantifies the convergence of the parent's identity: the error in truncating ∑1/(n(n+k)) = H_k/k at N terms is exactly (1/k)(H_{N+k} - H_N), and is at most 1/(N+1) no matter how large the gap k is.",
+    "proofStrategy": "1. Exact error: subtract the parent's partial-sum closed form S_N(k) = (1/k)(H_k - (H_{N+k} - H_N)) from H_k/k, giving (1/k)(H_{N+k} - H_N) by `ring`. 2. Uniform tail bound H_{N+k} - H_N ≤ k/(N+1) by induction on k: the step adds one term 1/(N+k+1) ≤ 1/(N+1) (via one_div_le_one_div_of_le). 3. Divide by k > 0 (div_le_iff₀): the k cancels, leaving 1/(N+1). 4. Nonnegativity of the error gives the absolute-value form. 5. A tsum-form corollary replaces the closed form by the genuine ∑' value via the parent's `generalized_triangular_reciprocals_tsum` and a range↔Icc reindex.",
+    "keyInsights": [
+      "The error is *exactly* the harmonic tail (1/k)(H_{N+k} - H_N), not merely bounded by it — this falls straight out of the parent's partial-sum closed form by pure algebra (`ring`)",
+      "Uniformity in k is structural: the tail has k terms each ≤ 1/(N+1), so it is ≤ k/(N+1), and the 1/k prefactor from the partial fraction cancels the k exactly — the gap parameter disappears from the final bound",
+      "The tail estimate H_{N+k} - H_N ≤ k/(N+1) is proved by induction on k rather than by summing an Icc range, keeping the argument free of reindexing machinery",
+      "The signed error H_k/k - S_N(k) is nonnegative (the partial sums approach from below, since every omitted term is positive), so the absolute value collapses to the signed bound",
+      "The same 1/(N+1) ceiling controls the truncation of the genuine infinite series ∑' 1/((n+1)((n+1)+k)) once the parent's tsum closed form and a range↔Icc reindex are applied"
+    ],
+    "prerequisites": [
+      "Real analysis (series, partial sums, truncation error)",
+      "Harmonic numbers and the recurrence H_{n+1} = H_n + 1/(n+1)",
+      "Induction and elementary inequality manipulation in Lean 4 Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "harmonic-diff",
+      "title": "Harmonic Tail Difference: Nonnegativity and the k/(N+1) Bound",
+      "startLine": 50,
+      "endLine": 92,
+      "summary": "Establishes 0 ≤ H_{N+k} - H_N (harmonic_diff_nonneg) and the core uniform bound H_{N+k} - H_N ≤ k/(N+1) (harmonic_diff_le), both by induction on k. The successor step uses harmonic_succ to peel off one term 1/(N+k+1), bounded by 1/(N+1) via one_div_le_one_div_of_le.",
+      "mathContext": "$0 \\le H_{N+k} - H_N = \\sum_{i=N+1}^{N+k} \\frac{1}{i} \\le \\frac{k}{N+1}$, since each of the $k$ summands is at most $\\frac{1}{N+1}$."
+    },
+    {
+      "id": "truncation-icc",
+      "title": "Truncation Error Identity and Uniform Bound",
+      "startLine": 93,
+      "endLine": 150,
+      "summary": "truncation_error_eq derives H_k/k - S_N = (1/k)(H_{N+k} - H_N) from the parent's partial_sum_closed_form by `ring`. truncation_error_nonneg, truncation_error_le, and truncation_error_abs then give 0 ≤ error ≤ 1/(N+1) and the absolute-value form. truncation_error_uniform packages the k-independence as a single statement.",
+      "mathContext": "$\\left|\\frac{H_k}{k} - S_N(k)\\right| = \\frac{1}{k}(H_{N+k} - H_N) \\le \\frac{1}{k}\\cdot\\frac{k}{N+1} = \\frac{1}{N+1}$, uniformly in $k$."
+    },
+    {
+      "id": "truncation-tsum",
+      "title": "Truncation Error Against the Genuine Infinite Series",
+      "startLine": 151,
+      "endLine": 181,
+      "summary": "range_sum_eq_Icc reindexes the range-N partial sum (used by the parent's tsum) into the Icc 1 N form. truncation_error_tsum_abs then bounds |∑' value - range partial sum| by 1/(N+1), combining the parent's tsum closed form with truncation_error_abs.",
+      "mathContext": "$\\left|\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} - \\sum_{n=1}^{N} \\frac{1}{n(n+k)}\\right| \\le \\frac{1}{N+1}$, the open question stated directly for the actual `tsum`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals-oq-02",
+      "relationship": "answers",
+      "description": "Answers the parent's fourth open question (rate of convergence). Reuses the parent's `partial_sum_closed_form` to get the exact error and `generalized_triangular_reciprocals_tsum` for the tsum-form bound. The parent already noted the heuristic estimate H_{N+k} - H_N ≤ k/(N+1) inside its tail-decay lemma; this entry isolates and proves it as a standalone uniform bound and feeds it through the 1/k prefactor."
+    },
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "related",
+      "description": "Quantifies how fast the classical Leibniz telescoping sum (k=1 case, ∑1/(n(n+1)) = 1) converges: at k=1 the bound reads |1 - S_N(1)| ≤ 1/(N+1), matching the exact tail 1/(N+1) of the Leibniz series."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "complementary",
+      "description": "Divergence-vs-convergence pairing: the harmonic series ∑1/n diverges, but its fixed-width truncated tails H_{N+k} - H_N vanish at rate Θ(k/N). This entry makes that decay rate explicit and uniform, which is exactly what forces the gap-k reciprocal series to converge."
+    }
+  ],
+  "conclusion": {
+    "summary": "The uniform truncation error bound |H_k/k - S_N(k)| = (1/k)(H_{N+k} - H_N) ≤ 1/(N+1) is fully verified in Lean 4 (Mathlib v4.26.0) with 0 sorries and 0 axioms, answering the parent's rate-of-convergence open question. The bound is independent of the gap parameter k.",
+    "implications": "Provides the quantitative companion to the parent's qualitative identity: the partial sums S_N(k) converge to H_k/k uniformly in k at rate O(1/N). The exact error formula (1/k)(H_{N+k} - H_N) makes the convergence transparent and connects directly to digamma asymptotics (H_{N+k} - H_N = ψ(N+k+1) - ψ(N+1)). The k-independence of the ceiling means a single N suffices to approximate the entire family {H_k/k : k ≥ 1} to within 1/(N+1).",
+    "openQuestions": [
+      "Sharpen the bound to the exact asymptotic (1/k)(H_{N+k} - H_N) = (1/k)·ln((N+k)/N) + O(1/N²) via digamma/Euler–Maclaurin, exhibiting the leading constant",
+      "Establish a matching lower bound (1/k)(H_{N+k} - H_N) ≥ k/(k·(N+k)) = 1/(N+k) to pin the error between 1/(N+k) and 1/(N+1)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.TriangularReciprocalsOQ02"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter",
+      "Topology",
+      "Real",
+      "TriangularReciprocalsHarmonic"
+    ],
+    "namespace": "TriangularReciprocalsOQ02OQ04",
+    "lineCount": 181,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/TriangularReciprocalsOQ02OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **fourth open question** of `triangular-reciprocals-oq-02` (rate of convergence). The parent proves the generalized identity
$$\sum_{n=1}^{\infty} \frac{1}{n(n+k)} = \frac{H_k}{k} \quad (k \ge 1).$$
This entry quantifies how fast the $N$-term partial sums approach the limit:
$$\left|\frac{H_k}{k} - \sum_{n=1}^{N}\frac{1}{n(n+k)}\right| = \frac{1}{k}\bigl(H_{N+k} - H_N\bigr) \le \frac{1}{N+1},$$
with the right-hand bound **independent of the gap parameter $k$**.

## Mathematical content

- **Exact error** (`truncation_error_eq`): subtracting the parent's `partial_sum_closed_form` from $H_k/k$ gives exactly $(1/k)(H_{N+k}-H_N)$ — closed by `ring` (purely formal in $k^{-1}$).
- **Uniform tail bound** (`harmonic_diff_le`, the new core lemma): $H_{N+k}-H_N \le k/(N+1)$ by induction on $k$ — each of the $k$ consecutive reciprocals is $\le 1/(N+1)$.
- **Cancellation**: dividing the error by $k > 0$ cancels the $k$ in the numerator, leaving the $k$-independent ceiling $1/(N+1)$.
- Absolute-value form (`truncation_error_abs`), an explicit uniform-in-$k$ restatement (`truncation_error_uniform`), and a **tsum-form** bound against the genuine infinite series (`truncation_error_tsum_abs`) via the parent's `generalized_triangular_reciprocals_tsum` and a range↔Icc reindex.

## Verification

- **9 theorems, 0 definitions, 181 lines**, Mathlib v4.26.0.
- Builds on `Proofs.TriangularReciprocalsOQ02`.
- **0 axioms**: `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`.

## Files

- `proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean`
- `src/data/proofs/triangular-reciprocals-oq-02-oq-04/{meta.json,annotations.json,index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)