### PR TITLE
research(three-subgroups-lemma-oq-01-oq-01): lower central series bound ⁅γᵢ,γⱼ⁆ ≤ γ₍ᵢ₊ⱼ₎ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ThreeSubgroupsLemmaOQ01OQ01.lean
+++ b/proofs/Proofs/ThreeSubgroupsLemmaOQ01OQ01.lean
@@ -1,0 +1,94 @@
+import Mathlib.GroupTheory.Nilpotent
+import Mathlib.Tactic
+import Proofs.ThreeSubgroupsLemmaOQ01
+
+/-
+# Bilinear bound for the lower central series: `⁅γᵢ, γⱼ⁆ ≤ γ₍ᵢ₊ⱼ₎`
+
+## What This Proves
+
+For the lower central series `γ` of a group `G`, the commutator of two terms
+sits inside a later term according to the **additive** rule
+
+  `⁅γ_a, γ_b⁆ ≤ γ_{a+b+1}`   (Mathlib's `0`-indexed convention, `γ₀ = ⊤`).
+
+In the classical `1`-indexed convention `G = G₁`, `G_{i+1} = ⁅G_i, G⁆`, where
+`γ_n = G_{n+1}`, this is exactly the textbook statement
+
+  `⁅G_i, G_j⁆ ≤ G_{i+j}`,
+
+the central structural fact that makes the associated graded `⨁ γ_n / γ_{n+1}`
+a graded Lie ring and underlies the theory of nilpotent groups.
+
+## What Mathlib has — and what this adds
+
+Mathlib (`Mathlib/GroupTheory/Nilpotent.lean`) develops the lower central series
+and its basic API (`lowerCentralSeries_succ`, `lowerCentralSeries_antitone`,
+the normality instance `lowerCentralSeries_normal`, …), but it does **not**
+record this bilinear `⁅γ_a, γ_b⁆ ≤ γ_{a+b+1}` bound.  A search of the commutator
+and nilpotency files turns up only the diagonal recursion `γ_{n+1} = ⁅γ_n, ⊤⁆`
+and no cross-term estimate.
+
+The proof is the classical induction on `b` (generalising `a`), whose engine is
+the **three subgroups lemma**.  The base case is the defining recursion; the
+inductive step writes `γ_{b+1} = ⁅γ_b, ⊤⁆`, applies the normal-subgroup form of
+the three subgroups lemma proved in the parent entry
+(`ThreeSubgroupsLemmaOQ01.commutator_le_of_rotate_symm`), and discharges its two
+hypotheses from the induction hypothesis — one at `a`, one at the shifted index
+`a + 1`.  This is precisely the use case for which the `≤ N` generalisation of
+the three subgroups lemma (the parent's contribution over Mathlib's `= ⊥` form)
+was built.
+
+Verified: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace ThreeSubgroupsLemmaOQ01OQ01
+
+open Subgroup ThreeSubgroupsLemmaOQ01
+
+variable {G : Type*} [Group G]
+
+/-- **Bilinear lower-central-series bound.**  In Mathlib's `0`-indexed convention
+(`lowerCentralSeries G 0 = ⊤`), the commutator of the `a`-th and `b`-th terms of
+the lower central series lands in the `(a+b+1)`-th term:
+
+  `⁅γ_a, γ_b⁆ ≤ γ_{a+b+1}`.
+
+Equivalently, in the classical `1`-indexed convention `γ_n = G_{n+1}` this is the
+textbook filtration bound `⁅G_i, G_j⁆ ≤ G_{i+j}`.
+
+Proved by induction on `b` (generalising `a`) using the parent entry's
+three subgroups lemma (`commutator_le_of_rotate_symm`). -/
+theorem commutator_lowerCentralSeries_le (a b : ℕ) :
+    ⁅lowerCentralSeries G a, lowerCentralSeries G b⁆
+      ≤ lowerCentralSeries G (a + b + 1) := by
+  -- The defining recursion, in commutator form (`rfl`).  Mathlib's
+  -- `lowerCentralSeries_succ` unfolds the bracket to a raw `closure` set, which
+  -- does not rewrite against `⁅·, ⊤⁆`; this `rfl`-equation keeps it foldable.
+  have hsucc : ∀ n : ℕ,
+      lowerCentralSeries G (n + 1) = ⁅lowerCentralSeries G n, (⊤ : Subgroup G)⁆ :=
+    fun _ => rfl
+  induction b generalizing a with
+  | zero =>
+      -- `⁅γ_a, ⊤⁆ = γ_{a+1}`, and `a + 0 + 1 = a + 1` definitionally.
+      rw [lowerCentralSeries_zero]
+      exact le_of_eq (hsucc a).symm
+  | succ b ih =>
+      -- Unfold `γ_{b+1} = ⁅γ_b, ⊤⁆` and flip to outer-bracket form
+      -- `⁅⁅γ_b, ⊤⁆, γ_a⁆ ≤ N`; the index `a + (b+1) + 1` is defeq `a + b + 1 + 1`.
+      rw [hsucc b, commutator_comm (lowerCentralSeries G a) ⁅lowerCentralSeries G b, ⊤⁆]
+      show ⁅⁅lowerCentralSeries G b, (⊤ : Subgroup G)⁆, lowerCentralSeries G a⁆
+            ≤ lowerCentralSeries G (a + b + 1 + 1)
+      -- Three subgroups lemma with `H = ⊤`, `K = γ_a`, `L = γ_b`,
+      -- `N = γ_{a+b+1+1}` (normal as a lower-central-series term).
+      refine commutator_le_of_rotate (H := ⊤) (K := lowerCentralSeries G a)
+        (L := lowerCentralSeries G b) ?_ ?_
+      · -- `⁅⁅⊤, γ_a⁆, γ_b⁆ ≤ N`: rewrite `⁅⊤, γ_a⁆ = γ_{a+1}`, then ih at `a+1`.
+        rw [commutator_comm ⊤ (lowerCentralSeries G a), ← hsucc a]
+        have e : (a + 1) + b + 1 = a + b + 1 + 1 := by omega
+        exact e ▸ ih (a + 1)
+      · -- `⁅⁅γ_a, γ_b⁆, ⊤⁆ ≤ N`: expand `N = ⁅γ_{a+b+1}, ⊤⁆`, monotonicity + ih at `a`.
+        rw [hsucc (a + b + 1)]
+        exact commutator_mono (ih a) le_rfl
+
+end ThreeSubgroupsLemmaOQ01OQ01


### PR DESCRIPTION
## Summary

Formalizes the **bilinear bound for the lower central series**

$$\lbrack \gamma_a, \gamma_b \rbrack \le \gamma_{a+b+1}$$

in Mathlib's 0-indexed convention ($\gamma_0 = \top$, $\gamma_{n+1} = \lbrack \gamma_n, \top \rbrack$). In the classical 1-indexed convention $\gamma_n = G_{n+1}$ this is the textbook filtration estimate $\lbrack G_i, G_j \rbrack \le G_{i+j}$ — the central structural fact of nilpotency theory, the one that makes the associated graded $\bigoplus \gamma_n/\gamma_{n+1}$ a graded Lie ring.

This is the direct follow-up to the parent entry **three-subgroups-lemma-oq-01**, whose conclusion explicitly named this result as the natural next step.

## What Mathlib has vs. what this adds

Mathlib's `GroupTheory.Nilpotent` develops the lower central series with its diagonal recursion `lowerCentralSeries_succ` (γ_{n+1} = ⁅γ_n, ⊤⁆), `lowerCentralSeries_antitone`, the normality instance `lowerCentralSeries_normal`, and product/pi behaviour — but **no cross-term bound** `⁅γ_a, γ_b⁆ ≤ γ_{a+b+1}`. This entry supplies it.

## Proof

Induction on `b` (generalising `a`, so the IH is available at every first index), driven entirely by the parent's normal-subgroup three subgroups lemma `commutator_le_of_rotate`:

- **Base** `b = 0`: the defining recursion `⁅γ_a, ⊤⁆ = γ_{a+1}`.
- **Step**: write `γ_{b+1} = ⁅γ_b, ⊤⁆`, flip to outer-bracket form `⁅⁅γ_b, ⊤⁆, γ_a⁆ ≤ N`, and apply the three subgroups lemma at `N = γ_{a+b+2}` (a **nontrivial** normal subgroup — exactly why the parent's `≤ N` generalization over Mathlib's `= ⊥` form is needed). Its two hypotheses are the IH at `a+1` (after folding `⁅⊤, γ_a⁆ = γ_{a+1}`) and the IH at `a` (after expanding `N = ⁅γ_{a+b+1}, ⊤⁆` + `commutator_mono`).

A local `rfl`-equation carries the successor recursion in commutator form, because Mathlib's `lowerCentralSeries_succ` unfolds the bracket to a raw `closure` set that will not rewrite against `⁅·, ⊤⁆`.

## Verification

- **1 theorem**, 94 lines, **0 sorries**, **0 axioms**
- `#print axioms` → `propext, Classical.choice, Quot.sound` only
- No `native_decide`
- Builds against Mathlib 4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)