### PR TITLE
research(gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01): Hadamard row form + uniform n^(n/2) determinant bound [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2946,6 +2946,7 @@ import Proofs.GodelSecondIncompletenessOQ02Translate
 import Proofs.GoemansWilliamsonMaxCut
 import Proofs.GramLinearIndependenceOQ01
 import Proofs.GramLinearIndependenceOQ01OQ01
+import Proofs.GramLinearIndependenceOQ01OQ01OQ02OQ01
 import Proofs.GraphCore
 import Proofs.GreensTheorem
 import Proofs.GreensTheoremOQ01

--- a/proofs/Proofs/GramLinearIndependenceOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/GramLinearIndependenceOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,130 @@
+import Proofs.GramLinearIndependenceOQ01OQ01
+
+/-!
+# Hadamard's determinant inequality for square matrices: row and uniform forms
+
+The grandparent entry `gram-linear-independence-iff-oq-01-oq-01` proved the abstract
+**Gram-matrix** form of Hadamard's inequality `det (gram 𝕜 v) ≤ ∏ i, ‖v i‖²`, and the
+parent entry `gram-linear-independence-iff-oq-01-oq-01-oq-02` specialised it to the
+**column** form for a square matrix, `‖det A‖ ≤ ∏ j, ‖col j A‖`.
+
+This entry rounds out the matrix picture with the two remaining standard statements, both
+obtained from the column bridge `gram 𝕜 (columns A) = Aᴴ * A` (so that
+`det (Aᴴ A) = conj (det A) · det A = ‖det A‖²`):
+
+* `matrix_hadamard_inequality` — the **column** form
+  `‖det A‖ ≤ ∏ j, √(∑ i, ‖A i j‖²)`, re-derived self-containedly here as the platform for
+  the two extensions below;
+* `matrix_hadamard_inequality_rows` — the **row** form
+  `‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²)`, obtained by transposing (`det Aᵀ = det A`);
+* `matrix_hadamard_bound` — the **uniform** corollary `‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2)`
+  when every entry satisfies `‖A i j‖ ≤ M`, the classical ceiling showing a determinant of
+  bounded entries grows no faster than `n^(n/2)`.
+
+This file imports only the grandparent (`Proofs.GramLinearIndependenceOQ01OQ01`); the column
+form is reproved from the bridge so that the row and uniform extensions stand on their own.
+
+All results are machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace GramLinearIndependenceOQ01OQ01OQ02OQ01
+
+open Matrix RCLike Finset
+open scoped ComplexOrder InnerProductSpace
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
+
+/-- The `j`-th column of a square matrix `A`, viewed as a vector in `EuclideanSpace 𝕜 (Fin n)`. -/
+noncomputable def col (A : Matrix (Fin n) (Fin n) 𝕜) (j : Fin n) : EuclideanSpace 𝕜 (Fin n) :=
+  (WithLp.toLp 2 fun i => A i j)
+
+omit [RCLike 𝕜] in
+@[simp] theorem col_apply (A : Matrix (Fin n) (Fin n) 𝕜) (i j : Fin n) :
+    (col A j) i = A i j := rfl
+
+/-- **Bridge to the Gram matrix.** The Gram matrix of the columns of `A` is `Aᴴ * A`. -/
+theorem gram_col_eq (A : Matrix (Fin n) (Fin n) 𝕜) :
+    Matrix.gram 𝕜 (col A) = Aᴴ * A := by
+  ext i j
+  rw [Matrix.gram_apply, PiLp.inner_apply, Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [col_apply, col_apply, RCLike.inner_apply', Matrix.conjTranspose_apply, star_def]
+
+/-- The Gramian of the columns is the squared norm of the determinant:
+`det (gram 𝕜 (col A)) = ‖det A‖²`. -/
+theorem gram_col_det (A : Matrix (Fin n) (Fin n) 𝕜) :
+    (Matrix.gram 𝕜 (col A)).det = ((‖A.det‖ ^ 2 : ℝ) : 𝕜) := by
+  rw [gram_col_eq, Matrix.det_mul, Matrix.det_conjTranspose, star_def, RCLike.conj_mul]
+  push_cast
+  ring
+
+/-- The squared norm of the `j`-th column is the sum of the squared moduli of its entries. -/
+theorem norm_col_sq (A : Matrix (Fin n) (Fin n) 𝕜) (j : Fin n) :
+    ‖col A j‖ ^ 2 = ∑ i, ‖A i j‖ ^ 2 := by
+  rw [EuclideanSpace.norm_sq_eq]
+  exact Finset.sum_congr rfl fun i _ => by rw [col_apply]
+
+/-- **Squared form of Hadamard's inequality.** `‖det A‖² ≤ ∏ j, ∑ i, ‖A i j‖²`. -/
+theorem matrix_hadamard_sq (A : Matrix (Fin n) (Fin n) 𝕜) :
+    ‖A.det‖ ^ 2 ≤ ∏ j, ∑ i, ‖A i j‖ ^ 2 := by
+  have hbound := GramLinearIndependenceOQ01OQ01.hadamard_inequality_euclidean (col A)
+  rw [gram_col_det A] at hbound
+  have hreal : ‖A.det‖ ^ 2 ≤ ∏ j, ‖col A j‖ ^ 2 := by
+    have := (RCLike.ofReal_le_ofReal (K := 𝕜)).mp hbound
+    simpa using this
+  calc ‖A.det‖ ^ 2 ≤ ∏ j, ‖col A j‖ ^ 2 := hreal
+    _ = ∏ j, ∑ i, ‖A i j‖ ^ 2 := Finset.prod_congr rfl fun j _ => norm_col_sq A j
+
+/-- **Hadamard's inequality for matrices (column form).** The modulus of the determinant of a
+square matrix is at most the product of the Euclidean norms of its columns:
+`‖det A‖ ≤ ∏ j, √(∑ i, ‖A i j‖²)`. -/
+theorem matrix_hadamard_inequality (A : Matrix (Fin n) (Fin n) 𝕜) :
+    ‖A.det‖ ≤ ∏ j, Real.sqrt (∑ i, ‖A i j‖ ^ 2) := by
+  have hP : (0 : ℝ) ≤ ∏ j, Real.sqrt (∑ i, ‖A i j‖ ^ 2) :=
+    Finset.prod_nonneg fun j _ => Real.sqrt_nonneg _
+  have hsq : ‖A.det‖ ^ 2 ≤ (∏ j, Real.sqrt (∑ i, ‖A i j‖ ^ 2)) ^ 2 := by
+    rw [← Finset.prod_pow]
+    refine (matrix_hadamard_sq A).trans (le_of_eq ?_)
+    exact Finset.prod_congr rfl fun j _ =>
+      (Real.sq_sqrt (Finset.sum_nonneg fun i _ => sq_nonneg _)).symm
+  rw [← Real.sqrt_sq (norm_nonneg A.det), ← Real.sqrt_sq hP]
+  exact Real.sqrt_le_sqrt hsq
+
+/-- **Hadamard's inequality for matrices (row form).** The modulus of the determinant is at most
+the product of the Euclidean norms of the **rows**, obtained from the column form via
+`det Aᵀ = det A`. -/
+theorem matrix_hadamard_inequality_rows (A : Matrix (Fin n) (Fin n) 𝕜) :
+    ‖A.det‖ ≤ ∏ i, Real.sqrt (∑ j, ‖A i j‖ ^ 2) := by
+  have h := matrix_hadamard_inequality Aᵀ
+  rw [Matrix.det_transpose] at h
+  refine h.trans (le_of_eq (Finset.prod_congr rfl fun i _ => ?_))
+  exact congrArg Real.sqrt (Finset.sum_congr rfl fun j _ => by rw [Matrix.transpose_apply])
+
+/-- **Uniform entry bound.** If every entry of `A` has modulus at most `M ≥ 0`, then
+`‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2)` — the classical bound that shows the determinant of a
+matrix with bounded entries cannot grow faster than `n^(n/2)`. -/
+theorem matrix_hadamard_bound (A : Matrix (Fin n) (Fin n) 𝕜) {M : ℝ} (hM : 0 ≤ M)
+    (hbound : ∀ i j, ‖A i j‖ ≤ M) :
+    ‖A.det‖ ≤ (Real.sqrt n * M) ^ n := by
+  refine (matrix_hadamard_inequality A).trans ?_
+  have hcol : ∀ j, Real.sqrt (∑ i, ‖A i j‖ ^ 2) ≤ Real.sqrt n * M := by
+    intro j
+    have hsum : ∑ i, ‖A i j‖ ^ 2 ≤ (n : ℝ) * M ^ 2 := by
+      calc ∑ i, ‖A i j‖ ^ 2 ≤ ∑ _i : Fin n, M ^ 2 :=
+            Finset.sum_le_sum fun i _ => by nlinarith [norm_nonneg (A i j), hbound i j]
+        _ = (n : ℝ) * M ^ 2 := by
+            rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+    calc Real.sqrt (∑ i, ‖A i j‖ ^ 2) ≤ Real.sqrt ((n : ℝ) * M ^ 2) := Real.sqrt_le_sqrt hsum
+      _ = Real.sqrt n * M := by rw [Real.sqrt_mul (Nat.cast_nonneg n), Real.sqrt_sq hM]
+  calc ∏ j, Real.sqrt (∑ i, ‖A i j‖ ^ 2)
+      ≤ ∏ _j : Fin n, (Real.sqrt n * M) :=
+        Finset.prod_le_prod (fun j _ => Real.sqrt_nonneg _) (fun j _ => hcol j)
+    _ = (Real.sqrt n * M) ^ n := by
+        rw [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+
+end GramLinearIndependenceOQ01OQ01OQ02OQ01
+
+open GramLinearIndependenceOQ01OQ01OQ02OQ01 in
+#print axioms matrix_hadamard_inequality_rows
+open GramLinearIndependenceOQ01OQ01OQ02OQ01 in
+#print axioms matrix_hadamard_bound

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "gram-col-bridge",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 37, "endLine": 59 },
+    "type": "concept",
+    "title": "Columns as Euclidean Vectors: gram (col A) = AᴴA",
+    "content": "The j-th column of A is embedded as col A j ∈ EuclideanSpace 𝕜 (Fin n) with (col A j) i = A i j (col_apply, a definitional rewrite through WithLp.toLp). The bridge gram_col_eq proves Matrix.gram 𝕜 (col A) = Aᴴ * A entrywise: the L² inner product expands as ⟪col A i, col A j⟫ = ∑ k, conj(A k i)·(A k j) (PiLp.inner_apply, RCLike.inner_apply'), exactly (Aᴴ A) i j since Aᴴ i k = conj(A k i). Taking determinants, gram_col_det gives det(gram 𝕜 (col A)) = conj(det A)·det A = ‖det A‖² (Matrix.det_conjTranspose, RCLike.conj_mul).",
+    "mathContext": "$\\mathrm{Gram}(\\mathrm{col}\\,A) = A^{\\mathsf H} A,\\ \\det\\mathrm{Gram}(\\mathrm{col}\\,A) = \\lVert\\det A\\rVert^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Gram matrix", "conjugate transpose", "Euclidean inner product", "Hermitian product"],
+    "prerequisites": ["inner product spaces", "matrix multiplication"]
+  },
+  {
+    "id": "column-form-platform",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 91 },
+    "type": "technique",
+    "title": "The Column Form, Reproved Self-Containedly",
+    "content": "norm_col_sq evaluates ‖col A j‖² = ∑ i, ‖A i j‖² (EuclideanSpace.norm_sq_eq). matrix_hadamard_sq feeds gram_col_det and norm_col_sq into the grandparent's hadamard_inequality_euclidean and descends the 𝕜-valued bound to ℝ via RCLike.ofReal_le_ofReal, giving ‖det A‖² ≤ ∏ j, ∑ i, ‖A i j‖². matrix_hadamard_inequality rewrites ∏ j, ∑ i, ‖A i j‖² = (∏ j √(∑ i ‖A i j‖²))² (Real.sq_sqrt, Finset.prod_pow) and takes square roots (Real.sqrt_le_sqrt, Real.sqrt_sq) for the column bound. Reproving it here keeps the row and uniform extensions dependent only on the grandparent entry.",
+    "mathContext": "$\\lVert\\det A\\rVert \\le \\prod_j \\sqrt{\\textstyle\\sum_i \\lVert A_{ij}\\rVert^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hadamard's inequality", "square root monotonicity", "Euclidean norm"],
+    "prerequisites": ["real square roots", "finite products"]
+  },
+  {
+    "id": "row-form-transpose",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 93, "endLine": 101 },
+    "type": "insight",
+    "title": "The Row Form is Free: Transpose Invariance of det",
+    "content": "matrix_hadamard_inequality_rows is the column inequality applied to Aᵀ. Since det Aᵀ = det A (Matrix.det_transpose) the left side is unchanged, and rewriting the transposed entries Aᵀ i j = A j i (Matrix.transpose_apply) turns the product of column norms of Aᵀ into the product of Euclidean ROW norms of A: ‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²). The two faces of Hadamard's inequality — by columns and by rows — differ only by a transpose.",
+    "mathContext": "$\\lVert\\det A\\rVert \\le \\prod_i \\sqrt{\\textstyle\\sum_j \\lVert A_{ij}\\rVert^2}$.",
+    "significance": "key",
+    "relatedConcepts": ["transpose invariance of determinant", "row vs column duality"],
+    "prerequisites": ["determinants", "matrix transpose"]
+  },
+  {
+    "id": "uniform-nn2-bound",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 103, "endLine": 124 },
+    "type": "insight",
+    "title": "The Uniform n^(n/2) Determinant Bound",
+    "content": "matrix_hadamard_bound is Hadamard plus a crude per-column estimate. If every entry has modulus ‖A i j‖ ≤ M with M ≥ 0, then ∑ i, ‖A i j‖² ≤ ∑ i, M² = n·M², so each column norm is at most √(n·M²) = √n·√(M²) = √n·M (Real.sqrt_mul, Real.sqrt_sq). Multiplying the n column bounds (Finset.prod_le_prod, Finset.prod_const) gives ‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2) — the standard ceiling showing the determinant of a matrix with bounded entries cannot grow faster than n^(n/2). The bound is sharp in order, attained up to constants by ±1 Hadamard matrices.",
+    "mathContext": "$\\lVert A_{ij}\\rVert \\le M \\Rightarrow \\lVert\\det A\\rVert \\le (\\sqrt n\\,M)^n = M^n\\,n^{n/2}$.",
+    "significance": "key",
+    "relatedConcepts": ["geometry of numbers", "determinant growth bounds", "Hadamard matrices"],
+    "prerequisites": ["finite products", "real square roots"]
+  }
+]

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+  "slug": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.GramLinearIndependenceOQ01OQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "RCLike",
+      "Finset",
+      "ComplexOrder",
+      "InnerProductSpace"
+    ],
+    "namespace": "GramLinearIndependenceOQ01OQ01OQ02OQ01",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/GramLinearIndependenceOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Hadamard's Matrix Inequality: Row Form and the Uniform n^(n/2) Determinant Bound",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GramLinearIndependenceOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix",
+      "determinant",
+      "hadamard-inequality",
+      "inner-product-space",
+      "euclidean-space",
+      "gram-matrix",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 124,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "matrix_hadamard_inequality_rows: the ROW form of Hadamard's inequality ‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²) — the determinant is bounded by the product of the Euclidean norms of the rows, obtained from the column form by transposition (det Aᵀ = det A), completing the symmetric pair of matrix Hadamard bounds",
+      "matrix_hadamard_bound: the UNIFORM corollary ‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2) whenever every entry satisfies ‖A i j‖ ≤ M — the classical ceiling showing that a determinant with bounded entries grows no faster than n^(n/2), the workhorse estimate in the geometry of numbers and matrix conditioning",
+      "matrix_hadamard_inequality (re-derived self-containedly): the column form ‖det A‖ ≤ ∏ j, √(∑ i, ‖A i j‖²), reproved here from the bridge gram 𝕜 (col A) = Aᴴ A so the row and uniform extensions depend only on the grandparent entry",
+      "gram_col_eq / gram_col_det: the bridge identities gram 𝕜 (col A) = Aᴴ * A and det(gram 𝕜 (col A)) = ‖det A‖² (via det(Aᴴ) = conj(det A) and RCLike.conj_mul) that carry the abstract EuclideanSpace Gram bound down to honest matrices",
+      "matrix_hadamard_sq: the squared form ‖det A‖² ≤ ∏ j, ∑ i, ‖A i j‖², the direct image of the grandparent's EuclideanSpace Hadamard bound under the column embedding, from which all the square-rooted forms descend"
+    ],
+    "prerequisites": [
+      "The EuclideanSpace Gram-determinant Hadamard bound det(gram 𝕜 v) ≤ ∏ i, ‖v i‖² (grandparent entry gram-linear-independence-iff-oq-01-oq-01, hadamard_inequality_euclidean)",
+      "The column form of the matrix Hadamard inequality (sibling parent entry gram-linear-independence-iff-oq-01-oq-01-oq-02); reproved self-containedly here",
+      "Columns as Euclidean vectors: the L² inner product ⟪x, y⟫ = ∑ i, conj (x i) · y i (PiLp.inner_apply, RCLike.inner_apply') and norm ‖x‖² = ∑ i, ‖x i‖² (EuclideanSpace.norm_sq_eq)",
+      "Determinant and square-root algebra: Matrix.det_conjTranspose, Matrix.det_transpose, RCLike.conj_mul, Real.sqrt_le_sqrt / Real.sqrt_sq / Real.sqrt_mul, Finset.prod_le_prod / Finset.prod_const"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_transpose / Matrix.det_conjTranspose / Matrix.det_mul",
+        "description": "det(Aᵀ) = det A gives the row form for free from the column form; det(Aᴴ) = conj(det A) and multiplicativity give det(Aᴴ A) = ‖det A‖², the bridge to the abstract Gram determinant.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "PiLp.inner_apply / EuclideanSpace.norm_sq_eq",
+        "description": "The L² inner product and squared norm on EuclideanSpace, used to identify gram 𝕜 (col A) = Aᴴ A entrywise and to evaluate each column norm as the sum of squared entry moduli.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Real.sqrt_le_sqrt / Real.sqrt_sq / Real.sqrt_mul",
+        "description": "Monotonicity and the inverse of squaring for the real square root: descend ‖det A‖² ≤ (∏ ‖col j‖)² to ‖det A‖ ≤ ∏ ‖col j‖, and evaluate √(n·M²) = √n·M for the uniform bound.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Finset.prod_le_prod / Finset.prod_const / Finset.prod_pow",
+        "description": "Termwise product monotonicity and the constant/power product identities driving the uniform bound (∏ over n columns of √n·M = (√n·M)^n) and the squared-to-linear rewrite.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring.Finset"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Hadamard's 1893 determinant inequality comes in two mirror-image forms — by columns and by rows — and a uniform corollary for matrices with bounded entries. Geometrically the determinant is the signed volume of the parallelepiped spanned by the columns (equivalently the rows), and Hadamard's inequality says a box of fixed edge lengths has the largest volume when its edges are orthogonal; the uniform bound, |det A| ≤ M^n n^(n/2) for entries bounded by M, is the form that powers Minkowski's lattice-point estimates in the geometry of numbers and the conditioning bounds of numerical linear algebra. The grandparent entry proved the abstract Gram-matrix bound in an inner product space, and the sibling parent specialised it to the column form for a square matrix. This entry completes the matrix picture by adding the row form and the uniform n^(n/2) ceiling, both still absent from Mathlib.",
+    "problemStatement": "Building on the matrix column form of Hadamard's inequality, prove (i) the row form ‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²) for a square matrix A over an RCLike field 𝕜, and (ii) the uniform bound ‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2) whenever every entry satisfies ‖A i j‖ ≤ M. The column form is reproved self-containedly from the bridge det(gram 𝕜 (cols A)) = ‖det A‖² so the extensions rest only on the grandparent entry.",
+    "proofStrategy": "Embed the columns of A as col A j ∈ EuclideanSpace 𝕜 (Fin n) with (col A j) i = A i j. The bridge gram_col_eq gives gram 𝕜 (col A) = Aᴴ * A, hence gram_col_det: det(gram 𝕜 (col A)) = conj(det A)·det A = ‖det A‖² (Matrix.det_conjTranspose, RCLike.conj_mul); norm_col_sq gives ‖col A j‖² = ∑ i, ‖A i j‖². Feeding these into the grandparent's hadamard_inequality_euclidean yields matrix_hadamard_sq: ‖det A‖² ≤ ∏ j, ∑ i, ‖A i j‖², which descends by square roots to the column form matrix_hadamard_inequality. The ROW form matrix_hadamard_inequality_rows applies the column form to Aᵀ and rewrites det Aᵀ = det A together with the transposed entries. The UNIFORM bound matrix_hadamard_bound bounds each column norm by √(∑ i, M²) = √(n·M²) = √n·M (Real.sqrt_mul, Real.sqrt_sq) and multiplies the n column estimates (Finset.prod_le_prod, Finset.prod_const) to get (√n · M)^n.",
+    "keyInsights": [
+      "The row form is a free consequence of transpose-invariance of the determinant: applying the column inequality to Aᵀ and rewriting det Aᵀ = det A turns the product of column norms of Aᵀ into the product of row norms of A — the two faces of Hadamard's inequality differ only by a transpose.",
+      "The uniform n^(n/2) ceiling is Hadamard plus one crude estimate: a column of n entries each of modulus ≤ M has Euclidean length at most √(n·M²) = √n·M, and the n-fold product gives (√n·M)^n = M^n·n^(n/2) — the bound is sharp in order, attained up to constants by Hadamard matrices.",
+      "Everything rests on the single bridge gram 𝕜 (col A) = Aᴴ A: reading the columns of A as Euclidean vectors turns the abstract Gramian into det(Aᴴ A) = ‖det A‖², so the grandparent's inner-product-space bound becomes a statement about the honest matrix determinant with no further analysis.",
+      "Reproving the column form in-file (rather than importing the sibling parent) keeps the dependency graph shallow: the row and uniform extensions need only the grandparent entry, so they remain valid independently of how the column form is packaged elsewhere.",
+      "RCLike.conj_mul (conj z · z = ‖z‖²) makes the determinant of the Hermitian product Aᴴ A a manifestly nonnegative real uniformly over ℝ and ℂ, which is what lets the squared inequality be square-rooted cleanly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "columns-and-bridge",
+      "title": "Columns as Euclidean Vectors and the Bridge gram (col A) = AᴴA",
+      "startLine": 37,
+      "endLine": 59,
+      "summary": "col A j embeds the j-th column of A into EuclideanSpace 𝕜 (Fin n) with (col A j) i = A i j (col_apply). gram_col_eq proves gram 𝕜 (col A) = Aᴴ * A entrywise from the L² inner product, and gram_col_det computes det(gram 𝕜 (col A)) = conj(det A)·det A = ‖det A‖².",
+      "mathContext": "$\\mathrm{Gram}(\\mathrm{col}\\,A) = A^{\\mathsf H} A,\\quad \\det\\mathrm{Gram}(\\mathrm{col}\\,A) = \\lVert\\det A\\rVert^2$."
+    },
+    {
+      "id": "column-form",
+      "title": "The Column Form (Self-Contained Platform)",
+      "startLine": 61,
+      "endLine": 91,
+      "summary": "norm_col_sq evaluates ‖col A j‖² = ∑ i, ‖A i j‖². matrix_hadamard_sq feeds the bridge into the grandparent's hadamard_inequality_euclidean to get ‖det A‖² ≤ ∏ j, ∑ i, ‖A i j‖², and matrix_hadamard_inequality takes square roots for the column bound ‖det A‖ ≤ ∏ j, √(∑ i, ‖A i j‖²).",
+      "mathContext": "$\\lVert\\det A\\rVert \\le \\prod_j \\sqrt{\\textstyle\\sum_i \\lVert A_{ij}\\rVert^2}$."
+    },
+    {
+      "id": "row-form",
+      "title": "The Row Form by Transposition",
+      "startLine": 93,
+      "endLine": 101,
+      "summary": "matrix_hadamard_inequality_rows applies the column form to Aᵀ and rewrites det Aᵀ = det A (Matrix.det_transpose) and the transposed entries (Matrix.transpose_apply), bounding ‖det A‖ by the product of the Euclidean row norms.",
+      "mathContext": "$\\lVert\\det A\\rVert \\le \\prod_i \\sqrt{\\textstyle\\sum_j \\lVert A_{ij}\\rVert^2}$."
+    },
+    {
+      "id": "uniform-bound",
+      "title": "The Uniform n^(n/2) Bound",
+      "startLine": 103,
+      "endLine": 124,
+      "summary": "matrix_hadamard_bound assumes ‖A i j‖ ≤ M with M ≥ 0; each column norm is at most √(∑ i M²) = √(n·M²) = √n·M (Real.sqrt_mul, Real.sqrt_sq), and the n-fold product over columns (Finset.prod_const) gives ‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2).",
+      "mathContext": "$\\lVert A_{ij}\\rVert \\le M \\Rightarrow \\lVert\\det A\\rVert \\le (\\sqrt n\\,M)^n = M^n n^{n/2}$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "question": "Prove the uniform bound is sharp in order: exhibit a family of matrices (e.g. ±1 Hadamard matrices, where they exist) attaining ‖det A‖ = n^(n/2) with M = 1, certifying that the n^(n/2) ceiling cannot be improved.",
+      "significance": "medium"
+    },
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01-oq-02",
+      "question": "Establish the equality case of the matrix Hadamard inequality: for an invertible A, ‖det A‖ = ∏ j, ‖col j A‖ iff the columns are pairwise orthogonal, by transporting the grandparent's hadamard_eq_iff_orthogonal_euclidean through the column embedding.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The sibling parent entry proved the column form of the matrix Hadamard inequality ‖det A‖ ≤ ∏ ‖col j‖. This entry adds the two remaining standard statements — the row form (by transposition) and the uniform ‖det A‖ ≤ (√n·M)^n = M^n·n^(n/2) bound for matrices with entries of modulus at most M — reproving the column form self-containedly from the bridge gram(col A) = AᴴA."
+    },
+    {
+      "targetId": "gram-linear-independence-iff-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "The grandparent entry supplies the abstract EuclideanSpace Gram-determinant Hadamard bound det(gram 𝕜 v) ≤ ∏ ‖v i‖² (hadamard_inequality_euclidean), the only external Lean dependency: every matrix bound here is its image under the column embedding."
+    }
+  ],
+  "references": [
+    {
+      "title": "Jacques Hadamard, Résolution d'une question relative aux déterminants",
+      "author": "J. Hadamard",
+      "year": "1893",
+      "venue": "Bulletin des Sciences Mathématiques",
+      "description": "Original statement of the matrix Hadamard inequality and the uniform |det A| ≤ M^n n^(n/2) bound proved here in row and uniform forms."
+    },
+    {
+      "title": "Mathlib4: Analysis.InnerProductSpace.PiL2",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of EuclideanSpace, PiLp.inner_apply and EuclideanSpace.norm_sq_eq used to embed matrix columns as Euclidean vectors."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Extending the matrix column form of Hadamard's inequality, this entry proves the row form ‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²) (matrix_hadamard_inequality_rows, via det Aᵀ = det A) and the uniform bound ‖det A‖ ≤ (√n · M)^n = M^n · n^(n/2) for entries bounded by M (matrix_hadamard_bound). Both rest on the bridge gram 𝕜 (col A) = Aᴴ * A (gram_col_eq) with det(gram 𝕜 (col A)) = ‖det A‖² (gram_col_det), feeding the grandparent's hadamard_inequality_euclidean to get the squared bound (matrix_hadamard_sq) which descends by square roots to the column form (matrix_hadamard_inequality), reproved self-containedly. 124 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Together with the sibling column-form entry, this gives the gallery the complete pair of matrix Hadamard inequalities plus the uniform n^(n/2) determinant ceiling — none of which is in Mathlib — in directly usable form over both ℝ and ℂ. The reusable bridge gram 𝕜 (col A) = Aᴴ A and det(Aᴴ A) = ‖det A‖² are the entry points for the sharpness and equality-case questions recorded as open problems.",
+    "openQuestions": [
+      "Sharpness: matrices attaining ‖det A‖ = n^(n/2) with unit-modulus entries (Hadamard matrices).",
+      "Equality case: ‖det A‖ = ∏ ‖col j‖ for invertible A iff the columns are pairwise orthogonal."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Extends the matrix **column** form of Hadamard's determinant inequality (sibling parent `gram-linear-independence-iff-oq-01-oq-01-oq-02`) with the two remaining standard statements:

- **`matrix_hadamard_inequality_rows`** — the row form `‖det A‖ ≤ ∏ i, √(∑ j, ‖A i j‖²)`, obtained by transposing (`det Aᵀ = det A`).
- **`matrix_hadamard_bound`** — the uniform corollary `‖det A‖ ≤ (√n·M)^n = M^n·n^(n/2)` when every entry satisfies `‖A i j‖ ≤ M`; the classical ceiling that a determinant of bounded entries grows no faster than `n^(n/2)`.

The column form is reproved self-containedly from the bridge `gram 𝕜 (col A) = Aᴴ * A` (so `det(AᴴA) = ‖det A‖²`), so both extensions depend only on the grandparent entry `gram-linear-independence-iff-oq-01-oq-01` (`hadamard_inequality_euclidean`).

## Verification

- **7 theorems, 1 def, 124 lines, 0 sorries.**
- `#print axioms` on both headline results: `[propext, Classical.choice, Quot.sound]` only — **0 extra axioms**, no `sorryAx`/`Lean.ofReduceBool`.
- Builds clean against Mathlib v4.26.0 (`lake build Proofs.GramLinearIndependenceOQ01OQ01OQ02OQ01`, 33s).

## Files

- `proofs/Proofs/GramLinearIndependenceOQ01OQ01OQ02OQ01.lean`
- `proofs/Proofs.lean` (import)
- `src/data/proofs/gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)