### PR TITLE
Enrich Primary Decomposition from the Minimal Polynomial (cayley-hamilton-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-ch0104-header",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 6, "endLine": 54 },
+    "type": "concept",
+    "title": "Goal: the Primary Decomposition Theorem",
+    "content": "Fixing an endomorphism T of V makes V a module over K[X], with X acting as T. When the minimal polynomial factors into pairwise coprime prime powers μ_T = ∏ qᵢ^eᵢ, the Chinese Remainder Theorem for K[X] forces V to split as the internal direct sum of the T-invariant primary components ker(qᵢ^eᵢ(T)). This answers the closing open question of the parent entry cayley-hamilton-oq-01 and is the structural engine behind the rational canonical form (any field) and the Jordan form (algebraically closed field).",
+    "mathContext": "$V = \\bigoplus_i \\ker\\big((q_i^{e_i})(T)\\big)$, where $\\mu_T = \\prod_i q_i^{e_i}$ with the $q_i$ distinct monic irreducibles.",
+    "significance": "key",
+    "relatedConcepts": ["primary decomposition", "minimal polynomial", "K[X]-module structure", "generalized eigenspace", "Jordan canonical form", "rational canonical form"],
+    "prerequisites": ["linear algebra", "module theory over a PID", "minimal polynomial"]
+  },
+  {
+    "id": "ann-ch0104-invariance",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 63, "endLine": 77 },
+    "type": "technique",
+    "title": "Each primary component is T-invariant",
+    "content": "`ker_aeval_mapsTo` shows every kernel ker(p(T)) is invariant under T. The reason is that p(T) commutes with T — both are polynomials in T — formalised via `aeval T p * T = aeval T (p*X) = aeval T (X*p) = T * aeval T p` (using `mul_comm` in K[X]). For x ∈ ker(p(T)): p(T)(T x) = (p(T)·T)x = (T·p(T))x = T(p(T)x) = T 0 = 0, so T x stays in the kernel. This invariance is what makes the decomposition a decomposition into T-stable pieces, on each of which T can be studied separately.",
+    "mathContext": "$p(T)\\,T = T\\,p(T)$ since $p(T)\\in K[T]$; hence $x\\in\\ker p(T) \\Rightarrow p(T)(Tx) = T(p(T)x) = T0 = 0 \\Rightarrow Tx\\in\\ker p(T)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["invariant subspace", "commuting operators", "polynomial in an operator", "aeval algebra map"],
+    "prerequisites": ["linear operators", "kernels of linear maps", "polynomial evaluation aeval"]
+  },
+  {
+    "id": "ann-ch0104-crt",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 79, "endLine": 98 },
+    "type": "technique",
+    "title": "Iterated CRT: ⨆ ker(qᵢ(T)) = ker((∏qᵢ)(T))",
+    "content": "`iSup_ker_aeval_eq_ker_aeval_prod` is the technical heart: a Finset induction lifting Mathlib's binary identity `ker(p(T)) ⊔ ker(q(T)) = ker((p·q)(T))` (`sup_ker_aeval_eq_ker_aeval_mul_of_coprime`) to an arbitrary finite pairwise-coprime family. The `insert a s` step needs the new factor p a coprime to the running product ∏_{s} pᵢ; this is supplied by `IsCoprime.prod_right` from pairwise coprimality. The empty base case is ker((∏∅)(T)) = ker(1(T)) = ker(id) = ⊥. This single product-of-kernels identity drives both the independence and the spanning arguments below.",
+    "mathContext": "$\\bigsqcup_{i\\in s} \\ker(p_i(T)) = \\ker\\Big(\\big(\\textstyle\\prod_{i\\in s} p_i\\big)(T)\\Big)$, by induction; insert step uses $\\gcd(p_a, \\prod_s p_i) = 1$ from $\\mathrm{IsCoprime.prod\\_right}$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "Finset induction", "coprime polynomials", "IsCoprime.prod_right", "supremum of submodules"],
+    "prerequisites": ["coprimality", "Finset.induction", "submodule lattice operations"]
+  },
+  {
+    "id": "ann-ch0104-independence",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 102, "endLine": 125 },
+    "type": "technique",
+    "title": "Independence of the kernels",
+    "content": "`iSupIndep_ker_aeval` proves the sum is direct. By `iSupIndep_def` it suffices that each ker(pᵢ(T)) is disjoint from the supremum of the others. Rewriting that supremum over j ≠ i as the kernel of the product over `univ.erase i` (via the iterated-CRT lemma), disjointness follows from Mathlib's `disjoint_ker_aeval_of_isCoprime`, because pᵢ is coprime to the product of the remaining factors (again `IsCoprime.prod_right`). Note the symmetry with spanning: independence uses the product over the complement of one index, spanning uses the full product.",
+    "mathContext": "For each $i$: $\\ker(p_i(T)) \\cap \\bigsqcup_{j\\ne i}\\ker(p_j(T)) = \\ker(p_i(T)) \\cap \\ker\\big(\\textstyle\\prod_{j\\ne i}p_j(T)\\big) = \\bot$, since $\\gcd\\!\\big(p_i, \\prod_{j\\ne i}p_j\\big)=1$.",
+    "significance": "key",
+    "relatedConcepts": ["iSupIndep / independent submodules", "disjoint submodules", "univ.erase", "internal direct sum", "coprime complement product"],
+    "prerequisites": ["independence of submodules", "the iterated CRT lemma", "disjoint_ker_aeval_of_isCoprime"]
+  },
+  {
+    "id": "ann-ch0104-spanning",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 127, "endLine": 139 },
+    "type": "technique",
+    "title": "Spanning when the product annihilates T",
+    "content": "`iSup_ker_aeval_eq_top` shows the kernels span V whenever the product (∏ pᵢ)(T) = 0. By the iterated-CRT lemma over `univ`, ⨆ᵢ ker(pᵢ(T)) = ker((∏ pᵢ)(T)); since the product annihilates T, this kernel is the whole space (ker 0 = ⊤). This is where the annihilation hypothesis — supplied later by minpoly.aeval — enters.",
+    "mathContext": "$\\big(\\textstyle\\prod_i p_i\\big)(T) = 0 \\Rightarrow \\bigsqcup_i \\ker(p_i(T)) = \\ker(0) = \\top$.",
+    "significance": "supporting",
+    "relatedConcepts": ["spanning condition", "annihilating polynomial", "ker of zero map", "minpoly annihilation"],
+    "prerequisites": ["the iterated CRT lemma", "annihilator of an operator"]
+  },
+  {
+    "id": "ann-ch0104-general",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 141, "endLine": 149 },
+    "type": "theorem",
+    "title": "General coprime decomposition",
+    "content": "`isInternal_ker_aeval` packages independence and spanning into an internal direct sum, via Mathlib's `DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top`. The hypotheses are exactly pairwise coprimality (for independence) and that the product annihilates T (for spanning). This is the general form, free of any reference to the minimal polynomial, finiteness of V, or algebraic closure.",
+    "mathContext": "$\\mathrm{Pairwise}\\,(\\gcd(p_i,p_j)=1) \\wedge \\big(\\textstyle\\prod_i p_i\\big)(T)=0 \\Rightarrow V = \\bigoplus_i \\ker(p_i(T))$.",
+    "significance": "key",
+    "relatedConcepts": ["DirectSum.IsInternal", "internal direct sum criterion", "independence plus spanning", "coprime family"],
+    "prerequisites": ["internal direct sums", "independence and spanning lemmas"]
+  },
+  {
+    "id": "ann-ch0104-headline",
+    "proofId": "cayley-hamilton-oq-01-oq-04",
+    "range": { "startLine": 151, "endLine": 166 },
+    "type": "theorem",
+    "title": "Headline: Primary Decomposition from μ_T",
+    "content": "`isInternal_primaryDecomposition_of_minpoly` specialises the general theorem to pᵢ = qᵢ^eᵢ. Two combinators do the work: `IsCoprime.pow` promotes pairwise coprimality of the irreducibles qᵢ to coprimality of their prime powers qᵢ^eᵢ, and `minpoly.aeval` supplies the annihilation — after rewriting along the factorisation hypothesis μ_T = ∏ qᵢ^eᵢ, the product annihilates T because the minimal polynomial does. The result is V = ⨁ᵢ ker(qᵢ^eᵢ(T)), the classical Primary Decomposition Theorem, with each component T-invariant by `ker_aeval_mapsTo`.",
+    "mathContext": "$\\mu_T = \\prod_i q_i^{e_i}$, $\\gcd(q_i,q_j)=1 \\Rightarrow \\gcd(q_i^{e_i},q_j^{e_j})=1$ ($\\mathrm{IsCoprime.pow}$), and $(\\prod_i q_i^{e_i})(T) = \\mu_T(T) = 0$ ($\\mathrm{minpoly.aeval}$), giving $V = \\bigoplus_i \\ker(q_i^{e_i}(T))$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial factorisation", "prime-power coprimality", "IsCoprime.pow", "minpoly.aeval", "generalized eigenspaces"],
+    "prerequisites": ["the general coprime decomposition", "minimal polynomial annihilation", "prime-power factorisation"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-04/index.ts
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonOQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleyHamiltonOQ01OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleyHamiltonOQ01OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleyHamiltonOQ01OQ04Data: ProofData = {
+  proof: cayleyHamiltonOQ01OQ04Proof,
+  annotations: cayleyHamiltonOQ01OQ04Annotations,
+}

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-04/meta.json
@@ -109,6 +109,50 @@
       "Coprime polynomials and internal direct-sum decompositions"
     ]
   },
+  "sections": [
+    {
+      "id": "invariance",
+      "title": "T-Invariance of the Primary Components",
+      "startLine": 63,
+      "endLine": 77,
+      "summary": "ker_aeval_mapsTo: each kernel ker(p(T)) is T-invariant because p(T) commutes with T (both are polynomials in T), so T maps the kernel into itself."
+    },
+    {
+      "id": "iterated-crt",
+      "title": "Iterated Chinese Remainder Theorem",
+      "startLine": 79,
+      "endLine": 98,
+      "summary": "iSup_ker_aeval_eq_ker_aeval_prod: the technical heart. By Finset induction it lifts Mathlib's binary identity ker(p(T)) ⊔ ker(q(T)) = ker((p·q)(T)) to a finite pairwise-coprime family, keeping each inserted factor coprime to the running product via IsCoprime.prod_right."
+    },
+    {
+      "id": "independence",
+      "title": "Independence of the Kernels",
+      "startLine": 102,
+      "endLine": 125,
+      "summary": "iSupIndep_ker_aeval: each ker(pᵢ(T)) is disjoint from the supremum of the others, which the CRT lemma rewrites as the kernel of the product over univ.erase i; coprimality of pᵢ to that product gives disjointness (disjoint_ker_aeval_of_isCoprime)."
+    },
+    {
+      "id": "spanning",
+      "title": "Spanning When the Product Annihilates T",
+      "startLine": 127,
+      "endLine": 139,
+      "summary": "iSup_ker_aeval_eq_top: the CRT lemma over univ identifies ⨆ ker(pᵢ(T)) with ker((∏pᵢ)(T)); since the product annihilates T, that kernel is the whole space."
+    },
+    {
+      "id": "general-decomposition",
+      "title": "General Coprime Decomposition",
+      "startLine": 141,
+      "endLine": 149,
+      "summary": "isInternal_ker_aeval: independence + spanning are packaged into DirectSum.IsInternal via DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top, with no reference to the minimal polynomial, finiteness, or algebraic closure."
+    },
+    {
+      "id": "headline",
+      "title": "Headline: Primary Decomposition from the Minimal Polynomial",
+      "startLine": 151,
+      "endLine": 166,
+      "summary": "isInternal_primaryDecomposition_of_minpoly: specialising pᵢ = qᵢ^eᵢ, IsCoprime.pow promotes coprimality of the irreducibles to their prime powers and minpoly.aeval supplies annihilation, yielding V = ⨁ᵢ ker(qᵢ^eᵢ(T))."
+    }
+  ],
   "conclusion": {
     "summary": "For an endomorphism T whose minimal polynomial factors into pairwise coprime prime powers μ_T = ∏ qᵢ^eᵢ, the space decomposes as an internal direct sum of the T-invariant primary components V = ⨁ᵢ ker(qᵢ^eᵢ(T)). The result is obtained from a general coprime decomposition V = ⨁ᵢ ker(pᵢ(T)) (for any pairwise-coprime family whose product annihilates T), itself an iterated Chinese Remainder Theorem built by Finset induction over Mathlib's binary coprime-kernel lemmas. Fully verified, 0 axioms, 0 sorries.",
     "implications": "This is the structural backbone of operator canonical forms: the primary decomposition reduces the study of T to its action on each invariant component ker(qᵢ^eᵢ(T)), on which qᵢ^eᵢ is the minimal polynomial. Over an algebraically closed field the qᵢ are linear and the components are the generalized eigenspaces, yielding the Jordan form; over a general field it underlies the rational canonical form. It directly answers the parent entry's closing open question.",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-01-oq-04` (Primary Decomposition Theorem from the minimal polynomial).

## Gaps closed
- **Missing `index.ts`** — created it; without it the proof page shows 'proof not found' on the live site.
- **Missing `annotations.json`** — created 7 annotations covering all 6 theorems (T-invariance, the iterated CRT, independence, spanning, the general coprime decomposition, and the minimal-polynomial headline), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **Missing `sections` array** — added 6 sections covering the full Lean file with line-accurate ranges and summaries.

## Notes
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries — consistent with the Lean file and its disclosed Mathlib dependencies.
- Pre-existing `overview`, `conclusion` (object), and `crossReferences` left intact; cross-ref targets verified to exist.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)