### PR TITLE
research(pac-learning-bounds-oq-01-oq-07): VC dim of thresholds over any linear order [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PACLearningOQ01OQ07.lean
+++ b/proofs/Proofs/PACLearningOQ01OQ07.lean
@@ -1,0 +1,139 @@
+/-
+  PAC Learning OQ-01 OQ-07: VC Dimension of Thresholds over an Arbitrary Linear Order
+
+  Generalizes `PACLearningOQ01` (thresholds on ℕ have VC dimension 1) to thresholds
+  on ANY totally ordered set `[LinearOrder α]`. The parent proof for ℕ used arithmetic
+  (`a + 1`, `Nat.not_lt_zero`, `omega`); here we use ONLY the order axioms.
+
+  Two phenomena replace the ℕ-specific arithmetic:
+
+  - Part II (lower bound). Over ℕ every singleton `{a}` is shattered, because every `a`
+    has a successor `a + 1`. Over a general linear order this is FALSE at a maximum:
+    a top element cannot be included by any threshold `{x | x < t}`. The honest
+    statement is the sharp characterisation
+        `Shatters thresholds {a} ↔ ∃ b, a < b`   (i.e. `a` is not a maximum).
+    Hence VC dim ≥ 1 precisely when the order is `Nontrivial`.
+
+  - Part III (upper bound). No 2-element set is shattered — this holds over EVERY linear
+    order with no extra hypothesis, by the same monotonicity obstruction as the parent,
+    but discharged with `lt_of_lt_of_le` / `lt_asymm` instead of `omega`.
+
+  Vapnik-Chervonenkis (1971).
+-/
+import Mathlib
+
+namespace LearningTheory.VCDimension.LinearOrderThresholds
+
+open Finset
+
+variable {α : Type*} [LinearOrder α]
+
+/-- A hypothesis class `H ⊆ Set α` shatters a finite set `S ⊆ α` if every subset
+    `T ⊆ S` is realised as `h ∩ S` for some `h ∈ H`. Identical to the parent's
+    `Shatters`, now over an arbitrary type. -/
+def Shatters (H : Set (Set α)) (S : Finset α) : Prop :=
+  ∀ T : Finset α, T ⊆ S → ∃ h ∈ H, ∀ x ∈ S, (x ∈ h ↔ x ∈ T)
+
+/-- Threshold classifiers on a linear order: `h_t = { x | x < t }` for `t : α`. -/
+def thresholdClassifiers : Set (Set α) :=
+  { h | ∃ t : α, h = { x | x < t } }
+
+/-! ## Part II — Lower bound: which singletons are shattered
+
+The defining feature of the general case: a singleton `{a}` is shattered exactly when
+`a` is not a maximum of the order. -/
+
+/-- **Sharp characterisation.** Thresholds shatter the singleton `{a}` if and only if
+    `a` has a strict upper bound. Forward: to realise the labelling `T = {a}` we need a
+    threshold including `a`, i.e. some `t` with `a < t`. Backward: such a `t` includes
+    `a`, while `t = a` excludes it.
+
+    Over ℕ the right side `∃ b, a < b` is always true (`b = a + 1`), recovering the
+    parent's unconditional `threshold_shatters_singleton`. -/
+theorem threshold_shatters_singleton_iff (a : α) :
+    Shatters thresholdClassifiers ({a} : Finset α) ↔ ∃ b, a < b := by
+  constructor
+  · -- Shattering realises `T = {a}`, forcing a threshold above `a`.
+    intro hShatter
+    obtain ⟨h, ⟨t, ht⟩, hh⟩ := hShatter {a} (Finset.Subset.refl _)
+    subst ht
+    have ha_mem : a ∈ ({a} : Finset α) := Finset.mem_singleton_self a
+    have hiff := hh a ha_mem
+    -- `hiff : a ∈ {x | x < t} ↔ a ∈ {a}`, and `a ∈ {a}` holds.
+    exact ⟨t, hiff.mpr ha_mem⟩
+  · -- Build the two thresholds explicitly.
+    rintro ⟨b, hab⟩
+    intro T _
+    by_cases ha : a ∈ T
+    · -- Include `a`: threshold `b` works since `a < b`.
+      refine ⟨{x | x < b}, ⟨b, rfl⟩, ?_⟩
+      intro x hx
+      rw [Finset.mem_singleton] at hx; subst hx
+      exact ⟨fun _ => ha, fun _ => hab⟩
+    · -- Exclude `a`: threshold `a` works since `¬ a < a`.
+      refine ⟨{x | x < a}, ⟨a, rfl⟩, ?_⟩
+      intro x hx
+      rw [Finset.mem_singleton] at hx; subst hx
+      exact ⟨fun h => absurd h (lt_irrefl _), fun h => absurd h ha⟩
+
+/-- Every non-maximal element's singleton is shattered (the convenient direction). -/
+theorem threshold_shatters_singleton {a b : α} (hab : a < b) :
+    Shatters thresholdClassifiers ({a} : Finset α) :=
+  (threshold_shatters_singleton_iff a).mpr ⟨b, hab⟩
+
+/-! ## Part III — Upper bound: no pair is shattered (any linear order) -/
+
+/-- Thresholds cannot shatter any 2-element set `{a, b}` with `a < b`. The labelling
+    `T = {b}` (select only the larger point) demands a threshold `t` with `t ≤ a` (to
+    exclude `a`) and `b < t` (to include `b`); then `b < t ≤ a` contradicts `a < b`.
+    Pure order reasoning — no arithmetic. -/
+theorem threshold_not_shatters_pair {a b : α} (hab : a < b) :
+    ¬ Shatters thresholdClassifiers ({a, b} : Finset α) := by
+  intro hShatter
+  -- Witness labelling `T = {b}`.
+  have hSub : ({b} : Finset α) ⊆ ({a, b} : Finset α) := by
+    intro x hx
+    rw [Finset.mem_singleton] at hx; subst hx; simp
+  obtain ⟨h, ⟨t, ht⟩, hh⟩ := hShatter ({b} : Finset α) hSub
+  subst ht
+  have ha_mem : a ∈ ({a, b} : Finset α) := by simp
+  have hb_mem : b ∈ ({a, b} : Finset α) := by simp
+  have ha := hh a ha_mem  -- a < t ↔ a ∈ {b}
+  have hb := hh b hb_mem  -- b < t ↔ b ∈ {b}
+  -- `a` is excluded: `a ∉ {b}` because `a ≠ b`.
+  have ha' : ¬ (a < t) := by
+    intro hlt
+    have hmem : a ∈ ({b} : Finset α) := ha.mp hlt
+    rw [Finset.mem_singleton] at hmem
+    exact absurd hmem (ne_of_lt hab)
+  -- `b` is included.
+  have hb' : b < t := hb.mpr (Finset.mem_singleton_self b)
+  -- `b < t ≤ a` versus `a < b`.
+  exact lt_asymm hab (lt_of_lt_of_le hb' (le_of_not_gt ha'))
+
+/-! ## Combined bounds -/
+
+/-- **VC dimension of thresholds over a linear order is exactly 1.**
+
+    Upper bound (unconditional): no two-element set is shattered. Lower bound (needs the
+    order to be `Nontrivial`, otherwise there is nothing to learn): some singleton is
+    shattered. Over ℕ this recovers `threshold_vcdim_bounds`. -/
+theorem threshold_vcdim_bounds [Nontrivial α] :
+    (∃ a : α, Shatters thresholdClassifiers ({a} : Finset α)) ∧
+    (∀ a b : α, a ≠ b → ¬ Shatters thresholdClassifiers ({a, b} : Finset α)) := by
+  refine ⟨?_, ?_⟩
+  · -- Nontriviality gives a strictly comparable pair; its smaller element is shattered.
+    obtain ⟨a, b, hne⟩ := exists_pair_ne α
+    rcases lt_or_gt_of_ne hne with hlt | hgt
+    · exact ⟨a, threshold_shatters_singleton hlt⟩
+    · exact ⟨b, threshold_shatters_singleton hgt⟩
+  · intro a b hab hShatter
+    rcases lt_or_gt_of_ne hab with hlt | hgt
+    · exact threshold_not_shatters_pair hlt hShatter
+    · -- `{a, b} = {b, a}`; reuse the pair lemma with arguments swapped.
+      have heq : ({a, b} : Finset α) = ({b, a} : Finset α) := by
+        ext x; simp [Or.comm]
+      rw [heq] at hShatter
+      exact threshold_not_shatters_pair hgt hShatter
+
+end LearningTheory.VCDimension.LinearOrderThresholds

--- a/src/data/proofs/pac-learning-bounds-oq-01-oq-07/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01-oq-07/annotations.json
@@ -1,0 +1,132 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 1,
+      "endLine": 24
+    },
+    "type": "concept",
+    "title": "Setup — From ℕ-Thresholds to Thresholds over an Arbitrary Linear Order",
+    "content": "The parent file `PACLearningOQ01` computes the VC dimension of threshold classifiers on ℕ (exactly 1) using arithmetic: the successor `a + 1`, `Nat.not_lt_zero`, and `omega`. This file answers OQ-07: redo the computation over an arbitrary `[LinearOrder α]` using ONLY the order axioms. Two things change. The upper bound (no pair shattered) survives verbatim — it was never about ℕ. The lower bound does not: over ℕ every singleton is shattered because every point has a successor, but over a general order a maximum element's singleton cannot be shattered (no threshold can contain a maximal point). The honest generalization replaces the unconditional lower bound by a sharp biconditional.",
+    "mathContext": "Threshold class over α: $H_{thr} = \\{\\{x \\mid x < t\\} : t \\in \\alpha\\}$. VC dimension is a combinatorial invariant of the incidence relation $x < t$, independent of any metric or arithmetic on the domain.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "VC dimension",
+      "Shatters predicate",
+      "LinearOrder",
+      "order-only reasoning"
+    ],
+    "prerequisites": [
+      "VC dimension definition",
+      "threshold classifiers on ℕ (pac-learning-bounds-oq-01)"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 31,
+      "endLine": 39
+    },
+    "type": "definition",
+    "title": "Shatters and Threshold Classifiers, Generalized",
+    "content": "`Shatters H S` is the standard predicate: every subset `T ⊆ S` is realized as `h ∩ S` for some `h ∈ H`. `thresholdClassifiers` is `{ h | ∃ t : α, h = {x | x < t} }` — the downward-closed rays of the order. Both are now parameterized by `variable {α : Type*} [LinearOrder α]` instead of being fixed to ℕ. The definitions are otherwise identical to the parent's, which is the point: nothing about VC dimension required ℕ.",
+    "mathContext": "$\\text{Shatters}(H, S) \\equiv \\forall T \\subseteq S,\\ \\exists h \\in H,\\ h \\cap S = T$. Each threshold $\\{x \\mid x < t\\}$ is a down-set (initial segment) of the linear order.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "shattering",
+      "down-set / initial segment",
+      "hypothesis class"
+    ],
+    "prerequisites": [
+      "Finset basics",
+      "LinearOrder typeclass"
+    ]
+  },
+  {
+    "id": "ann-singleton-iff",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 41,
+      "endLine": 77
+    },
+    "type": "key-step",
+    "title": "Sharp Lower Bound: A Singleton Shatters iff Its Point Is Non-Maximal",
+    "content": "`threshold_shatters_singleton_iff` proves `Shatters thresholdClassifiers {a} ↔ ∃ b, a < b`. Forward: if `{a}` is shattered, applying the definition to the labeling `T = {a}` yields a threshold `{x | x < t}` containing `a`, which by definition means `a < t` — a strict upper bound. Backward: given `a < b`, the threshold `t = b` includes `a` (since `a < b`) and the threshold `t = a` excludes `a` (since `¬ a < a`), so both subsets `{a}` and `∅` are realized. This biconditional is the genuinely new content: it pinpoints exactly which singletons are shatterable, namely the non-maxima.",
+    "mathContext": "$\\text{Shatters}(H_{thr}, \\{a\\}) \\iff \\exists b,\\ a < b \\iff a \\text{ is not a maximum of } \\alpha$. Over ℕ the right side always holds ($b = a+1$), recovering the parent's unconditional singleton shattering.",
+    "significance": "central",
+    "relatedConcepts": [
+      "lower bound",
+      "maximal element",
+      "biconditional characterization"
+    ],
+    "prerequisites": [
+      "shattering",
+      "strict order, lt_irrefl"
+    ]
+  },
+  {
+    "id": "ann-singleton-conv",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 79,
+      "endLine": 82
+    },
+    "type": "key-step",
+    "title": "Convenient Direction: a < b ⟹ {a} Shattered",
+    "content": "`threshold_shatters_singleton` is the `mpr` of the biconditional packaged for downstream use: from `a < b` conclude `Shatters thresholdClassifiers {a}`. This is the form consumed by the combined-bounds theorem.",
+    "mathContext": "$a < b \\Rightarrow \\text{Shatters}(H_{thr}, \\{a\\})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "lower bound"
+    ],
+    "prerequisites": [
+      "threshold_shatters_singleton_iff"
+    ]
+  },
+  {
+    "id": "ann-pair-upper",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 84,
+      "endLine": 112
+    },
+    "type": "key-step",
+    "title": "Upper Bound: The Monotonicity Obstruction (Order-Only)",
+    "content": "`threshold_not_shatters_pair` shows no 2-element set `{a, b}` (with `a < b`) is shattered. The obstructing labeling is `T = {b}`: realizing it needs a threshold `t` that excludes `a` (so `¬ a < t`, i.e. `t ≤ a` by `le_of_not_gt`) yet includes `b` (so `b < t`). Then `b < t ≤ a` gives `b < a` via `lt_of_lt_of_le`, contradicting `a < b` via `lt_asymm`. The parent discharged this with `omega`; here it is pure order reasoning — transitivity and asymmetry only. This obstruction is exactly the statement that a down-set cannot exclude a smaller point while including a larger one.",
+    "mathContext": "If $t \\le a$ and $b < t$ then $b < a$, contradicting $a < b$. The one-parameter analogue of the convexity obstruction that caps interval classifiers at VC dim 2.",
+    "significance": "central",
+    "relatedConcepts": [
+      "upper bound",
+      "monotonicity / down-set",
+      "lt_asymm, lt_of_lt_of_le"
+    ],
+    "prerequisites": [
+      "shattering",
+      "linear order axioms"
+    ]
+  },
+  {
+    "id": "ann-combined",
+    "proofId": "pac-learning-bounds-oq-01-oq-07",
+    "range": {
+      "startLine": 114,
+      "endLine": 138
+    },
+    "type": "key-step",
+    "title": "Combined Bound: VC dim = 1 over a Nontrivial Linear Order",
+    "content": "`threshold_vcdim_bounds` assumes `[Nontrivial α]` and concludes (1) some singleton is shattered and (2) no two-element set is shattered. For (1), `exists_pair_ne` gives distinct `a, b`; `lt_or_gt_of_ne` orders them, and the smaller element — having a strict upper bound — is shattered by `threshold_shatters_singleton`. For (2), `lt_or_gt_of_ne` reduces any unequal pair to the `a < b` case of `threshold_not_shatters_pair`, with the `{a,b} = {b,a}` symmetry handled by `ext; simp [Or.comm]`. Nontriviality is necessary: on a one-point order nothing is shattered and the VC dimension is 0.",
+    "mathContext": "$\\text{VCdim}(H_{thr}) = 1$ over any nontrivial linear order: lower bound from a non-maximal point (guaranteed by nontriviality), upper bound unconditional.",
+    "significance": "central",
+    "relatedConcepts": [
+      "VC dimension",
+      "Nontrivial typeclass",
+      "exists_pair_ne"
+    ],
+    "prerequisites": [
+      "threshold_shatters_singleton",
+      "threshold_not_shatters_pair"
+    ]
+  }
+]

--- a/src/data/proofs/pac-learning-bounds-oq-01-oq-07/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01-oq-07/meta.json
@@ -1,0 +1,217 @@
+{
+  "id": "pac-learning-bounds-oq-01-oq-07",
+  "title": "VC Dimension of Thresholds over an Arbitrary Linear Order",
+  "slug": "pac-learning-bounds-oq-01-oq-07",
+  "description": "Generalizes the threshold VC-dimension result from ℕ to any totally ordered set [LinearOrder α], using only order axioms (no arithmetic). The lower bound becomes a sharp characterization — a singleton {a} is shattered iff a has a strict upper bound (is not a maximum) — so VC dim ≥ 1 exactly when the order is Nontrivial. The upper bound (no 2-element set shattered) holds over every linear order unconditionally. Answers OQ-07 of pac-learning-bounds-oq-01.",
+  "meta": {
+    "author": "Vapnik-Chervonenkis (1971), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
+    "date": "1971",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PACLearningOQ01OQ07.lean",
+    "tags": [
+      "learning-theory",
+      "combinatorics",
+      "order-theory",
+      "vc-dimension",
+      "cs-math-bridge"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries, 0 structure-encoded assumptions. The Shatters predicate and thresholdClassifiers family are concrete definitions over an arbitrary [LinearOrder α]. The lower-bound theorem additionally assumes [Nontrivial α] (otherwise the order has at most one point and nothing is learnable); this is a genuine necessary hypothesis, not a hidden assumption. All proofs use only the order axioms (transitivity, irreflexivity, totality) — no arithmetic, no omega. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.mem_singleton",
+        "description": "Membership in a Finset singleton",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.Subset.refl",
+        "description": "Reflexivity of Finset subset",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "lt_irrefl",
+        "description": "No element is strictly less than itself",
+        "module": "Mathlib.Order.Defs"
+      },
+      {
+        "theorem": "lt_of_lt_of_le",
+        "description": "a < b and b ≤ c imply a < c",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "lt_asymm",
+        "description": "a < b implies ¬ b < a",
+        "module": "Mathlib.Order.Defs"
+      },
+      {
+        "theorem": "le_of_not_gt",
+        "description": "¬ a < b implies b ≤ a in a linear order",
+        "module": "Mathlib.Order.Defs"
+      },
+      {
+        "theorem": "lt_or_gt_of_ne",
+        "description": "a ≠ b implies a < b or a > b in a linear order",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "exists_pair_ne",
+        "description": "A Nontrivial type has two distinct elements",
+        "module": "Mathlib.Logic.Nontrivial.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Shatters and thresholdClassifiers restated over an arbitrary [LinearOrder α]: h_t = {x | x < t} for t : α",
+      "threshold_shatters_singleton_iff: the sharp characterization — Shatters thresholds {a} ↔ ∃ b, a < b. A singleton is shattered exactly when its point is not a maximum. This is the genuinely new phenomenon: over ℕ the right side is always true (b = a+1), so the parent's unconditional singleton-shattering is the ℕ-specialization of this iff",
+      "threshold_shatters_singleton: convenient mpr direction — a < b gives Shatters thresholds {a}",
+      "threshold_not_shatters_pair: no 2-element set is shattered over ANY linear order, by the monotonicity obstruction (t ≤ a and b < t contradict a < b), discharged with lt_of_lt_of_le and lt_asymm instead of the parent's omega",
+      "threshold_vcdim_bounds: VC dim of thresholds over a linear order is exactly 1 — some singleton is shattered (under [Nontrivial α]) and no pair is shattered (unconditional)"
+    ],
+    "prerequisites": [
+      "VC dimension and shattering",
+      "Basic Finset operations in Mathlib",
+      "Order-theory typeclasses (LinearOrder, Nontrivial)",
+      "pac-learning-bounds-oq-01 (threshold classifiers on ℕ, VC dim 1)"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 139,
+    "relatedProblems": [
+      {
+        "id": "pac-learning-bounds-oq-01",
+        "relationship": "Generalizes the parent's ℕ-specific threshold result to an arbitrary linear order"
+      },
+      {
+        "id": "pac-learning-bounds-oq-01-oq-01",
+        "relationship": "Sibling: interval classifiers (VC dim 2) on ℕ — same shattering template, one parameter higher"
+      },
+      {
+        "id": "pac-learning-bounds",
+        "relationship": "Advances the parent's OQ about VC dimension of concrete hypothesis classes"
+      }
+    ],
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "pac-learning-bounds-oq-01",
+      "relationship": "generalizes",
+      "description": "Answers OQ-07: replace ℕ with [LinearOrder α]. The parent's proof used a + 1, Nat.not_lt_zero, and omega; this version uses only the order. The replacement reveals a phenomenon invisible over ℕ: singleton shattering depends on the existence of a strict upper bound, so it fails at a maximum element. The honest generalization is therefore a biconditional (shatters {a} ↔ a is not maximal), with the parent's unconditional statement recovered because every natural number has a successor."
+    },
+    {
+      "targetId": "pac-learning-bounds",
+      "relationship": "advances",
+      "description": "Strengthens the threshold VC-dimension computation from a single ordered domain (ℕ) to the full class of linearly ordered domains, isolating exactly which order property (existence of strict upper bounds / nontriviality) drives the lower bound."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Threshold classifiers are the one-parameter base case of VC theory, and their VC dimension 1 is the first worked example in every learning-theory course. The standard textbook treatment fixes the domain to be ℝ or ℕ and uses arithmetic. The observation formalized here is that the result is purely order-theoretic: the only structure used is the strict order <. Casting the proof over an arbitrary LinearOrder makes the dependence on the domain explicit and surfaces a boundary phenomenon — at a maximum element no threshold can include the point, so its singleton is not shattered. This is the order-theoretic analogue of the well-known fact that VC dimension is a combinatorial, not metric, quantity: it depends only on the incidence structure between hypotheses and points, here the relation x < t.",
+    "problemStatement": "Let α be a linearly ordered type and define the threshold hypothesis class H_thr = { {x | x < t} : t ∈ α }. Compute its VC dimension using only the order axioms.\n\nShow:\n1. (Lower bound, sharp) A singleton {a} is shattered by H_thr if and only if there exists b with a < b. Consequently, when α is Nontrivial some singleton is shattered, so VC dim ≥ 1.\n2. (Upper bound) No 2-element set is shattered, so VC dim ≤ 1.\n\nTogether these give VCdim(H_thr) = 1 over any nontrivial linear order.",
+    "text": "Threshold classifiers over an arbitrary linear order have VC dimension exactly 1. Verified in Lean 4 using only order axioms, with the lower bound sharpened to a biconditional characterizing which singletons are shattered.",
+    "proofStrategy": "1. **Lower bound (biconditional).** (→) If {a} is shattered, the labeling T = {a} is realized by some threshold {x | x < t}; membership of a forces a < t, giving a strict upper bound. (←) Given a < b, threshold t = b includes a (since a < b) and threshold t = a excludes a (since ¬ a < a), realizing both subsets of {a}.\n\n2. **Upper bound (monotonicity obstruction).** Given a < b, the labeling T = {b} on the pair {a, b} would require a threshold t with ¬(a < t) (exclude a) and b < t (include b). From ¬(a < t) we get t ≤ a, hence b < t ≤ a gives b < a, contradicting a < b via lt_asymm. This uses only transitivity and asymmetry of the order.\n\n3. **Combination.** Nontriviality yields a strictly comparable pair, whose smaller element has a strict upper bound and is therefore shattered; the pair lemma (applied to whichever ordering holds) rules out every 2-element set.",
+    "keyInsights": [
+      "VC dimension of thresholds is a purely order-theoretic invariant: the proof never uses addition, subtraction, successors, or any arithmetic — only the strict order < and its linearity. Replacing ℕ by an arbitrary LinearOrder loses nothing in the upper bound and clarifies the lower bound.",
+      "The lower bound is genuinely conditional in the general setting. Over ℕ every singleton is shattered because every n has a successor; over a general order a maximum element's singleton is NOT shattered, since no threshold {x | x < t} can contain a maximal point. The correct statement is the biconditional 'shatters {a} ↔ ∃ b, a < b', i.e. a is not maximal.",
+      "Nontriviality of α (at least two distinct points) is exactly the hypothesis needed for VC dim ≥ 1: it guarantees a strictly comparable pair, whose smaller element is non-maximal and hence shatterable. On a one-point (or empty) order there is nothing to learn and the VC dimension is 0.",
+      "The monotonicity obstruction for the upper bound is the order-theoretic heart of the threshold result: a downward-closed set {x | x < t} cannot exclude a smaller point while including a larger one. This is the one-parameter analogue of the convexity obstruction used for interval classifiers (VC dim 2)."
+    ],
+    "prerequisites": [
+      "VC dimension and shattering",
+      "Basic Finset operations in Mathlib",
+      "Order-theory typeclasses (LinearOrder, Nontrivial)",
+      "Threshold classifier result on ℕ (pac-learning-bounds-oq-01)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions: Shatters and Threshold Classifiers over a Linear Order",
+      "startLine": 31,
+      "endLine": 39,
+      "summary": "The standard shattering predicate and the threshold hypothesis class { {x | x < t} : t ∈ α }, both stated over an arbitrary [LinearOrder α].",
+      "mathContext": "H shatters S iff ∀ T ⊆ S, ∃ h ∈ H : h ∩ S = T. Threshold class over α: { {x | x < t} : t ∈ α }."
+    },
+    {
+      "id": "singleton-iff",
+      "title": "Sharp Lower Bound: Which Singletons Shatter",
+      "startLine": 41,
+      "endLine": 82,
+      "summary": "threshold_shatters_singleton_iff: {a} is shattered ⟺ ∃ b, a < b (a is not a maximum). Forward forces a threshold above a from the labeling T={a}; backward builds the include/exclude thresholds. threshold_shatters_singleton is the convenient mpr direction.",
+      "mathContext": "Shatters thresholds {a} ↔ ∃ b, a < b."
+    },
+    {
+      "id": "pair-upper",
+      "title": "Upper Bound: No Pair Shattered (Monotonicity Obstruction)",
+      "startLine": 84,
+      "endLine": 112,
+      "summary": "threshold_not_shatters_pair: for a < b, the labeling T={b} forces a threshold t with t ≤ a and b < t, so b < t ≤ a contradicts a < b. Pure order reasoning via lt_of_lt_of_le and lt_asymm.",
+      "mathContext": "∀ a < b: ¬ Shatters thresholds {a, b}."
+    },
+    {
+      "id": "combined",
+      "title": "Combined Bound (VC dim = 1)",
+      "startLine": 114,
+      "endLine": 138,
+      "summary": "threshold_vcdim_bounds: under [Nontrivial α], some singleton is shattered (lower bound), and no two-element set is shattered (upper bound, unconditional). Hence VC dim of thresholds over a nontrivial linear order is exactly 1.",
+      "mathContext": "VCdim(H_thr) = 1 over a nontrivial linear order."
+    }
+  ],
+  "conclusion": {
+    "summary": "Threshold classifiers over an arbitrary nontrivial linear order have VC dimension exactly 1. The upper bound holds over every linear order; the lower bound is sharpened to a biconditional (a singleton shatters iff its point is non-maximal), recovering the parent's unconditional ℕ result as a special case.",
+    "implications": "Isolating the order-only content of the threshold result clarifies what generalizes: the upper bound is universal, while the lower bound is governed by the existence of strict upper bounds. The same lens applies to interval classifiers (convexity obstruction, VC dim 2) and points toward order-theoretic treatments of monotone and downward-closed concept classes.",
+    "openQuestions": [
+      "Characterize VC dim of thresholds on an order with NO maximum versus one WITH a maximum: in both cases the VC dimension is 1 (some non-maximal singleton always exists when Nontrivial), but the set of shattered singletons differs — exactly the non-maximal points. Formalize 'the shattered singletons are precisely the non-maxima' as a set equality.",
+      "Generalize the upper bound to a preorder or partial order: over a partial order, two incomparable points cannot be separated by a single threshold either, so the no-pair-shattered statement may need the totality hypothesis. Pin down the weakest order hypothesis under which VC dim of thresholds is ≤ 1.",
+      "Define vcDim as a WithTop ℕ-valued function and prove vcDim H_thr = 1 directly over any nontrivial linear order, unifying the two bounds into a single supremum statement (this is the order-generalized form of OQ-03)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Vapnik, V. N.; Chervonenkis, A. Ya.",
+      "title": "On the uniform convergence of relative frequencies of events to their probabilities",
+      "year": "1971",
+      "venue": "Theory of Probability and Its Applications, 16(2), 264–280",
+      "note": "Original definition of VC dimension. Thresholds are the canonical one-parameter example."
+    },
+    {
+      "authors": "Shalev-Shwartz, Shai; Ben-David, Shai",
+      "title": "Understanding Machine Learning: From Theory to Algorithms",
+      "year": "2014",
+      "venue": "Cambridge University Press",
+      "note": "Chapter 6 computes VC dim of threshold classifiers; the proof uses only the order, motivating the LinearOrder generalization formalized here."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "threshold_shatters_singleton_iff",
+      "type": "core",
+      "description": "Sharp lower bound over an arbitrary linear order: thresholds shatter the singleton {a} if and only if a has a strict upper bound (is not a maximum).",
+      "leanType": "(a : α) : Shatters thresholdClassifiers {a} ↔ ∃ b, a < b"
+    },
+    {
+      "name": "threshold_vcdim_bounds",
+      "type": "core",
+      "description": "VC dimension of threshold classifiers over a nontrivial linear order equals 1: some singleton is shattered and no two-element set is shattered.",
+      "leanType": "[Nontrivial α] : (∃ a : α, Shatters thresholdClassifiers {a}) ∧ (∀ a b : α, a ≠ b → ¬ Shatters thresholdClassifiers {a, b})"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LearningTheory.VCDimension.LinearOrderThresholds",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/PACLearningOQ01OQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-07** of `pac-learning-bounds-oq-01`: generalize the VC-dimension computation for threshold classifiers from ℕ to an **arbitrary totally ordered set** `[LinearOrder α]`, using **only the order axioms** (no arithmetic, no `omega`).

The parent (`PACLearningOQ01`, thresholds on ℕ, VC dim 1) used `a + 1`, `Nat.not_lt_zero`, and `omega`. Casting the result over a general linear order surfaces a phenomenon invisible over ℕ and isolates exactly which order property drives each bound.

## Results (`Proofs/PACLearningOQ01OQ07.lean`)

- **`threshold_shatters_singleton_iff`** — sharp lower bound: `Shatters thresholdClassifiers {a} ↔ ∃ b, a < b`. A singleton is shattered **iff its point is non-maximal**. Over ℕ the right side always holds (`b = a+1`), recovering the parent's unconditional singleton-shattering as a special case.
- **`threshold_not_shatters_pair`** — upper bound: no 2-element set is shattered over **any** linear order, via the monotonicity obstruction (`t ≤ a` and `b < t` contradict `a < b`), discharged with `lt_of_lt_of_le` / `lt_asymm`.
- **`threshold_vcdim_bounds`** — combined: under `[Nontrivial α]`, VC dim of thresholds is exactly **1** (some singleton shattered, no pair shattered). Nontriviality is necessary — a one-point order has VC dim 0.

## Verification

- **0 sorries, 0 counted axioms.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- Builds against Mathlib (Lean v4.26.0).
- 4 theorems, 2 definitions, 139 lines.
- Gallery entry: `src/data/proofs/pac-learning-bounds-oq-01-oq-07/` (meta + annotations; annotation ranges validate clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)