### PR TITLE
Enrich Evaluation at Distinct Nodes is a Linear Isomorphism (vandermonde-interpolation-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-vi0102-header",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "Goal: the full interpolation isomorphism",
+    "content": "The two companion entries proved the halves of polynomial interpolation separately — uniqueness from the Vandermonde determinant (oq-01) and existence from the explicit Lagrange interpolant (oq-01-oq-01). This entry packages both into one structural object: evaluation at n distinct nodes, `evalNodes v : degreeLT F n →ₗ[F] (Fin n → F)`, is a linear isomorphism whose inverse is exactly the Lagrange interpolant. Surjectivity is the existence half, injectivity the uniqueness half. Mathlib's `Lagrange.funEquivDegreeLT` proves an analogous equiv but indexed by the subtype ↥s with a dite-patched inverse; the clean `Fin n → F` form here uses the honest companion interpolant as a guard-free two-sided inverse.",
+    "mathContext": "$\\mathrm{evalNodes}\\,v : \\mathrm{degreeLT}\\,F\\,n \\xrightarrow{\\ \\sim\\ } (\\mathrm{Fin}\\,n \\to F)$, $p \\mapsto (j \\mapsto p(v_j))$, an $F$-linear isomorphism with inverse the Lagrange interpolant.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial interpolation", "Lagrange interpolant", "linear isomorphism", "existence and uniqueness", "Vandermonde determinant", "change of representation"],
+    "prerequisites": ["linear algebra", "polynomials over a field", "Lagrange interpolation"]
+  },
+  {
+    "id": "ann-vi0102-interp",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 59 },
+    "type": "definition",
+    "title": "The Lagrange interpolant and its degree bound",
+    "content": "`interp v r := Lagrange.interpolate univ v r` is the companion's explicit interpolant through the nodes v with values r. `interp_mem_degreeLT` shows it lands in `degreeLT F n`: its degree is `< #univ = n` by `Lagrange.degree_interpolate_lt`, with `card_univ_fin : #(univ : Finset (Fin n)) = n` doing the cardinality bookkeeping. This degree bound is what lets the interpolant serve as the codomain of the inverse map.",
+    "mathContext": "$\\deg\\big(\\mathrm{interpolate}\\,\\mathrm{univ}\\,v\\,r\\big) < \\#\\mathrm{univ} = n$, so $\\mathrm{interp}\\,v\\,r \\in \\mathrm{degreeLT}\\,F\\,n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange.interpolate", "degreeLT", "degree bound", "Finset.card_fin"],
+    "prerequisites": ["Lagrange interpolation API", "polynomial degree"]
+  },
+  {
+    "id": "ann-vi0102-evalnodes",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 67 },
+    "type": "definition",
+    "title": "Evaluation at nodes as a linear map",
+    "content": "`evalNodes v : degreeLT F n →ₗ[F] (Fin n → F)` is the forward map p ↦ (p(v₀), …, p(v_{n−1})). It is assembled from three reusable Mathlib bricks: `Polynomial.leval (v j)` (evaluation at a point as an F-linear map), composed with the submodule inclusion `(degreeLT F n).subtype`, gathered over all j by `LinearMap.pi`. Because every component is linear, the map is F-linear by construction, and `evalNodes_apply` holds by `rfl`.",
+    "mathContext": "$\\mathrm{evalNodes}\\,v = \\mathrm{pi}_j\\big(\\mathrm{leval}(v_j) \\circ \\iota\\big)$, where $\\iota : \\mathrm{degreeLT}\\,F\\,n \\hookrightarrow F[X]$; $\\mathrm{evalNodes}\\,v\\,p\\,j = p(v_j)$.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.leval", "LinearMap.pi", "submodule inclusion", "evaluation map", "F-linear map"],
+    "prerequisites": ["linear maps", "polynomial evaluation", "submodules"]
+  },
+  {
+    "id": "ann-vi0102-interplt",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 69, "endLine": 76 },
+    "type": "definition",
+    "title": "The interpolant as a linear map (codomain-restricted)",
+    "content": "`interpLT hv : (Fin n → F) →ₗ[F] degreeLT F n` is the Lagrange interpolant `Lagrange.interpolate univ v` (already a LinearMap in its values) with its codomain restricted into `degreeLT F n` via `LinearMap.codRestrict`, justified by the degree bound `interp_mem_degreeLT`. This is the candidate inverse of `evalNodes`; `interpLT_coe` records that its underlying polynomial is `interp v r` by `rfl`.",
+    "mathContext": "$\\mathrm{interpLT}\\,hv = \\mathrm{codRestrict}\\big(\\mathrm{interpolate}\\,\\mathrm{univ}\\,v\\big)$ into $\\mathrm{degreeLT}\\,F\\,n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["LinearMap.codRestrict", "Lagrange.interpolate as LinearMap", "inverse map", "degreeLT codomain"],
+    "prerequisites": ["codomain restriction", "the degree bound"]
+  },
+  {
+    "id": "ann-vi0102-equiv",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 100 },
+    "type": "theorem",
+    "title": "The full interpolation isomorphism evalEquiv",
+    "content": "`evalEquiv hv : degreeLT F n ≃ₗ[F] (Fin n → F)` is built by `LinearEquiv.ofLinear evalNodes interpLT` from two one-sided inverse proofs. Right inverse (`evalNodes ∘ interpLT = id`): the interpolant hits the prescribed values, `(interpolate univ v r)(v j) = r j`, by `Lagrange.eval_interpolate_at_node`. Left inverse (`interpLT ∘ evalNodes = id`): a degree-< n polynomial equals the interpolant of its own samples, by `Lagrange.eq_interpolate` (needing the degree bound `(p).degree < #univ`). The simp lemma `evalEquiv_symm_apply` records that the inverse is literally `interp v` — so the isomorphism is computable, not abstract.",
+    "mathContext": "$\\mathrm{evalEquiv}\\,hv = \\mathrm{ofLinear}\\,(\\mathrm{evalNodes}\\,v)\\,(\\mathrm{interpLT}\\,hv)$; both composites are $\\mathrm{id}$ via $\\mathrm{eval\\_interpolate\\_at\\_node}$ and $\\mathrm{eq\\_interpolate}$. $(\\mathrm{evalEquiv}\\,hv)^{-1} = \\mathrm{interp}\\,v$.",
+    "significance": "key",
+    "relatedConcepts": ["LinearEquiv.ofLinear", "two-sided inverse", "eval_interpolate_at_node", "eq_interpolate", "explicit computable inverse"],
+    "prerequisites": ["linear equivalences", "one-sided inverses", "Lagrange interpolation identities"]
+  },
+  {
+    "id": "ann-vi0102-bij",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 123 },
+    "type": "theorem",
+    "title": "Surjectivity = existence, injectivity = uniqueness",
+    "content": "The three theorems `evalNodes_bijective`, `evalNodes_surjective`, `evalNodes_injective` are the corresponding properties of the equivalence (`.bijective` / `.surjective` / `.injective`). They make the classical interpolation theorem's two implications explicit as the two halves of bijectivity: surjectivity is existence (every value vector is realized — the open question's target), injectivity is uniqueness (a degree-< n polynomial is determined by its node values). `exists_eval_eq` restates existence in elementary ∃ form with the Lagrange interpolant as the explicit witness.",
+    "mathContext": "$\\mathrm{Surjective}(\\mathrm{evalNodes}\\,v)$ ⟺ existence; $\\mathrm{Injective}(\\mathrm{evalNodes}\\,v)$ ⟺ uniqueness; together ⟺ bijectivity (well-posedness). $\\exists p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$.",
+    "significance": "key",
+    "relatedConcepts": ["bijectivity", "existence and uniqueness", "well-posed problem", "interpolation theorem"],
+    "prerequisites": ["the isomorphism evalEquiv", "surjective/injective from equivalence"]
+  },
+  {
+    "id": "ann-vi0102-finrank",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 125, "endLine": 129 },
+    "type": "insight",
+    "title": "Dimension by transport: dim(degreeLT F n) = n",
+    "content": "`finrank_degreeLT` derives that the degree-< n polynomials form an n-dimensional space, the most economical route: transport the isomorphism to `Fin n → F` (`LinearEquiv.finrank_eq`) and use `Module.finrank_fin_fun` (dim F^n = n). Rather than exhibiting a basis, the n node-evaluations already serve as coordinates — the isomorphism IS the coordinate system.",
+    "mathContext": "$\\dim_F(\\mathrm{degreeLT}\\,F\\,n) = \\dim_F(\\mathrm{Fin}\\,n \\to F) = n$ via $\\mathrm{evalEquiv}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finrank", "transport of dimension", "Module.finrank_fin_fun", "coordinates from evaluation"],
+    "prerequisites": ["finite-dimensional vector spaces", "the isomorphism"]
+  }
+]

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
@@ -60,6 +60,50 @@
       "Set.InjOn from Function.Injective (Function.Injective.injOn) and Finset.card_fin"
     ]
   },
+  "sections": [
+    {
+      "id": "interpolant",
+      "title": "The Lagrange Interpolant and its Degree Bound",
+      "startLine": 46,
+      "endLine": 59,
+      "summary": "interp v r = Lagrange.interpolate univ v r is the companion's explicit interpolant; interp_mem_degreeLT shows it lands in degreeLT F n because its degree is < #univ = n (card_univ_fin), so it can serve as the inverse's codomain."
+    },
+    {
+      "id": "eval-map",
+      "title": "Evaluation at Nodes as a Linear Map",
+      "startLine": 61,
+      "endLine": 67,
+      "summary": "evalNodes v : degreeLT F n →ₗ[F] (Fin n → F) is the forward map p ↦ (j ↦ p(v_j)), assembled from Polynomial.leval, the submodule inclusion, and LinearMap.pi, hence F-linear by construction (evalNodes_apply is rfl)."
+    },
+    {
+      "id": "interp-map",
+      "title": "The Interpolant as a Codomain-Restricted Linear Map",
+      "startLine": 69,
+      "endLine": 76,
+      "summary": "interpLT hv is Lagrange.interpolate univ v with codomain restricted into degreeLT F n via LinearMap.codRestrict (justified by the degree bound) — the candidate inverse of evalNodes."
+    },
+    {
+      "id": "isomorphism",
+      "title": "The Full Interpolation Isomorphism",
+      "startLine": 78,
+      "endLine": 100,
+      "summary": "evalEquiv hv = LinearEquiv.ofLinear evalNodes interpLT, with right inverse from Lagrange.eval_interpolate_at_node (the interpolant hits the values) and left inverse from Lagrange.eq_interpolate (a degree-< n polynomial is its own interpolant). evalEquiv_symm_apply records that the inverse is literally interp v."
+    },
+    {
+      "id": "bijectivity",
+      "title": "Bijectivity: Existence and Uniqueness",
+      "startLine": 102,
+      "endLine": 123,
+      "summary": "evalNodes_bijective / surjective / injective are the equivalence's properties: surjectivity is the existence half (the open question's target), injectivity is uniqueness. exists_eval_eq restates existence in elementary ∃ form with the Lagrange interpolant as the witness."
+    },
+    {
+      "id": "dimension",
+      "title": "Dimension Consequence by Transport",
+      "startLine": 125,
+      "endLine": 129,
+      "summary": "finrank_degreeLT transports the isomorphism to Fin n → F (LinearEquiv.finrank_eq, Module.finrank_fin_fun) to conclude dim_F(degreeLT F n) = n — the n node-evaluations serve as coordinates."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "vandermonde-interpolation-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `vandermonde-interpolation-oq-01-oq-02` (the full interpolation isomorphism evalEquiv).

## Gaps closed
- **Missing `annotations.json`** — created 7 annotations covering the header, the Lagrange interpolant + degree bound, evaluation-as-a-linear-map, the codomain-restricted inverse, the isomorphism evalEquiv, the bijectivity (existence/uniqueness) trio, and the dimension consequence — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Missing `sections` array** — added 6 sections covering the full Lean file with line-accurate ranges.

## Notes
- No `index.ts`: gallery entries load from `meta.json` + `annotations.json` via the build-generated `listings.json`/`data-manifest.json` (verified the entry is in `data-manifest.json` without it); per-proof `index.ts` shims are legacy (only ~192/3419 entries carry one).
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries, no native_decide.
- Pre-existing `overview`, `conclusion` (object), `crossReferences`, `mainTheorems`, `references` left intact.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)