### PR TITLE
research(triangular-reciprocals-oq-02-oq-04): uniform truncation error bound 1/(N+1) for ∑1/(n(n+k)) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3862,6 +3862,7 @@ import Proofs.TriangularReciprocalAlternatingOQ03
 import Proofs.TriangularReciprocalGeneralized
 import Proofs.TriangularReciprocalsFigurate
 import Proofs.TriangularReciprocalsOQ02
+import Proofs.TriangularReciprocalsOQ02OQ04
 import Proofs.TriangularReciprocalsOQ02Aristotle
 import Proofs.TriangularReciprocalsOQ04
 import Proofs.TuranEdgeBound

--- a/proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02OQ04.lean
@@ -1,0 +1,205 @@
+/-
+  Uniform Truncation Error Bound for Generalized Triangular Reciprocals
+
+  Parent: `triangular-reciprocals-oq-02` (slug `TriangularReciprocalsOQ02.lean`),
+  which proves the closed form
+      ∑_{n=1}^∞ 1/(n(n+k)) = H_k / k          (H_k = harmonic k).
+
+  This file answers the parent's open question #4:
+
+    "Quantify the rate of convergence: the closed form gives
+        |∑_{n=1}^∞ 1/(n(n+k)) − S_N(k)| = (1/k)(H_{N+k} − H_N) ≤ 1/(N+1)
+     uniformly in k — formalize this as a Mathlib-style truncation error bound."
+
+  Main results:
+    * `truncation_error_eq`  : the tail (total − partial over `range N`) equals
+                               exactly (1/k)(H_{N+k} − H_N).
+    * `truncation_error_le`  : that tail is ≤ 1/(N+1), a bound **independent of k**
+                               (hence uniform in k).
+    * `truncation_error_ge`  : that tail is ≥ 1/(N+k), so the 1/(N+1) bound is
+                               essentially sharp (both sides ~ 1/N for fixed k).
+    * `truncation_error_abs` : |S_N − total| ≤ 1/(N+1).
+
+  The heart is the elementary harmonic-block estimate
+      H_{N+k} − H_N = ∑_{i=N+1}^{N+k} 1/i ,
+  each of the k terms lying in [1/(N+k), 1/(N+1)], giving
+      k/(N+k) ≤ H_{N+k} − H_N ≤ k/(N+1).
+
+  Status: all lemmas closed, no sorries, no extra axioms.
+-/
+import Mathlib
+import Proofs.TriangularReciprocalsOQ02
+
+namespace TriangularReciprocalsTruncation
+
+open Finset BigOperators Filter Topology Real
+open TriangularReciprocalsHarmonic
+
+/-- The summand of the generalized triangular series, indexed so that `n + 1`
+    ranges over 1, 2, 3, … (matching the parent's convention). -/
+private noncomputable def f (k : ℕ) (n : ℕ) : ℝ :=
+  (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + (k : ℝ)))
+
+-- ═══════════════════════════════════════════════════
+-- Harmonic numbers as real finite sums
+-- ═══════════════════════════════════════════════════
+
+/-- `(harmonic m : ℝ)` written as a finite real sum over `Icc 1 m`. -/
+theorem harmonic_real_eq (m : ℕ) :
+    (harmonic m : ℝ) = ∑ i ∈ Finset.Icc 1 m, (1 : ℝ) / (i : ℝ) := by
+  have h := harmonic_eq_sum_Icc (n := m)
+  have hR : ((harmonic m : ℚ) : ℝ) = (((∑ i ∈ Finset.Icc 1 m, (↑i)⁻¹ : ℚ) : ℝ)) := by
+    exact_mod_cast congrArg (Rat.cast : ℚ → ℝ) h
+  rw [hR]
+  push_cast
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [one_div]
+
+/-- Harmonic difference as a block sum: for `a ≤ b`,
+    `H_b − H_a = ∑_{i=a+1}^{b} 1/i`. -/
+theorem harmonic_sub {a b : ℕ} (hab : a ≤ b) :
+    (harmonic b : ℝ) - (harmonic a : ℝ) =
+      ∑ i ∈ Finset.Icc (a + 1) b, (1 : ℝ) / (i : ℝ) := by
+  rw [harmonic_real_eq b, harmonic_real_eq a]
+  rw [show Finset.Icc 1 b = Finset.Ico 1 (b + 1) from
+        (Finset.Ico_succ_right_eq_Icc (a := 1) (b := b)).symm,
+      show Finset.Icc 1 a = Finset.Ico 1 (a + 1) from
+        (Finset.Ico_succ_right_eq_Icc (a := 1) (b := a)).symm,
+      show Finset.Icc (a + 1) b = Finset.Ico (a + 1) (b + 1) from
+        (Finset.Ico_succ_right_eq_Icc (a := a + 1) (b := b)).symm]
+  have h_cons :
+      (∑ i ∈ Finset.Ico 1 (a + 1), (1 : ℝ) / (i : ℝ)) +
+        (∑ i ∈ Finset.Ico (a + 1) (b + 1), (1 : ℝ) / (i : ℝ)) =
+          ∑ i ∈ Finset.Ico 1 (b + 1), (1 : ℝ) / (i : ℝ) :=
+    Finset.sum_Ico_consecutive _ (by omega) (by omega)
+  linarith [h_cons]
+
+-- ═══════════════════════════════════════════════════
+-- Two-sided block estimate for H_{N+k} − H_N
+-- ═══════════════════════════════════════════════════
+
+/-- Upper estimate: `H_{N+k} − H_N ≤ k/(N+1)` (each of the k terms is ≤ 1/(N+1)). -/
+theorem harmonic_diff_le (N k : ℕ) :
+    (harmonic (N + k) : ℝ) - (harmonic N : ℝ) ≤ (k : ℝ) / ((N : ℝ) + 1) := by
+  rw [harmonic_sub (show N ≤ N + k by omega)]
+  have hN1 : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+  have hbound :
+      ∑ i ∈ Finset.Icc (N + 1) (N + k), (1 : ℝ) / (i : ℝ) ≤
+        ∑ _i ∈ Finset.Icc (N + 1) (N + k), (1 : ℝ) / ((N : ℝ) + 1) := by
+    apply Finset.sum_le_sum
+    intro i hi
+    rw [Finset.mem_Icc] at hi
+    have hi1 : (N : ℝ) + 1 ≤ (i : ℝ) := by exact_mod_cast hi.1
+    exact one_div_le_one_div_of_le hN1 hi1
+  refine hbound.trans ?_
+  rw [Finset.sum_const, Nat.card_Icc]
+  have hcard : (N + k + 1) - (N + 1) = k := by omega
+  rw [hcard, nsmul_eq_mul]
+  rw [mul_one_div]
+
+/-- Lower estimate: `H_{N+k} − H_N ≥ k/(N+k)` (each of the k terms is ≥ 1/(N+k)). -/
+theorem harmonic_diff_ge (N k : ℕ) (hk : 0 < k) :
+    (k : ℝ) / ((N : ℝ) + (k : ℝ)) ≤ (harmonic (N + k) : ℝ) - (harmonic N : ℝ) := by
+  rw [harmonic_sub (show N ≤ N + k by omega)]
+  have hNk : (0 : ℝ) < (N : ℝ) + (k : ℝ) := by
+    have : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+    positivity
+  have hbound :
+      ∑ _i ∈ Finset.Icc (N + 1) (N + k), (1 : ℝ) / ((N : ℝ) + (k : ℝ)) ≤
+        ∑ i ∈ Finset.Icc (N + 1) (N + k), (1 : ℝ) / (i : ℝ) := by
+    apply Finset.sum_le_sum
+    intro i hi
+    rw [Finset.mem_Icc] at hi
+    have hpos : (0 : ℝ) < (i : ℝ) := by
+      have : (1 : ℕ) ≤ i := by omega
+      exact_mod_cast Nat.lt_of_lt_of_le Nat.zero_lt_one this
+    have hiNk : (i : ℝ) ≤ (N : ℝ) + (k : ℝ) := by
+      have : i ≤ N + k := hi.2
+      have := (Nat.cast_le (α := ℝ)).mpr this
+      push_cast at this ⊢
+      linarith
+    exact one_div_le_one_div_of_le hpos hiNk
+  refine le_trans ?_ hbound
+  rw [Finset.sum_const, Nat.card_Icc]
+  have hcard : (N + k + 1) - (N + 1) = k := by omega
+  rw [hcard, nsmul_eq_mul]
+  rw [mul_one_div]
+
+-- ═══════════════════════════════════════════════════
+-- Partial sum over `range N` (lifted from parent's closed form)
+-- ═══════════════════════════════════════════════════
+
+/-- Partial sum of `f k` over `range N` in closed form:
+    `∑_{i<N} f k i = (1/k)(H_k − (H_{N+k} − H_N))`. -/
+theorem range_partial (N k : ℕ) (hk : 0 < k) :
+    ∑ i ∈ Finset.range N, f k i =
+      (1 / (k : ℝ)) *
+        ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) := by
+  -- Convert the `range`-indexed sum into the `Icc 1 N`-form used by the parent.
+  have h_range_to_Icc :
+      ∑ i ∈ Finset.range N, f k i =
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
+    unfold f
+    rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
+          (Finset.Ico_succ_right_eq_Icc (a := 1) (b := N)).symm,
+        ← Nat.Ico_zero_eq_range]
+    have key := Finset.sum_Ico_add'
+      (fun m : ℕ => (1 : ℝ) / ((m : ℝ) * ((m : ℝ) + ↑k))) 0 N (c := 1)
+    simp only [zero_add] at key
+    rw [← key]
+  rw [h_range_to_Icc, partial_sum_closed_form N k hk]
+
+-- ═══════════════════════════════════════════════════
+-- Truncation error: exact value and bounds
+-- ═══════════════════════════════════════════════════
+
+/-- **Exact truncation error.** The difference between the full series value
+    `H_k/k` and the partial sum over `range N` equals `(1/k)(H_{N+k} − H_N)`. -/
+theorem truncation_error_eq (N k : ℕ) (hk : 0 < k) :
+    (∑' n : ℕ, f k n) - ∑ i ∈ Finset.range N, f k i =
+      (1 / (k : ℝ)) * ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)) := by
+  have htsum : (∑' n : ℕ, f k n) = (harmonic k : ℝ) / (k : ℝ) := by
+    unfold f
+    exact generalized_triangular_reciprocals_tsum k hk
+  rw [htsum, range_partial N k hk]
+  ring
+
+/-- **Uniform truncation error bound.** The tail is ≤ `1/(N+1)`, a bound that
+    does **not depend on k** — hence holds uniformly over all gaps `k ≥ 1`. -/
+theorem truncation_error_le (N k : ℕ) (hk : 0 < k) :
+    (∑' n : ℕ, f k n) - ∑ i ∈ Finset.range N, f k i ≤ 1 / ((N : ℝ) + 1) := by
+  rw [truncation_error_eq N k hk]
+  have hk' : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+  have hkinv : (0 : ℝ) ≤ 1 / (k : ℝ) := by positivity
+  have hd := harmonic_diff_le N k
+  calc (1 / (k : ℝ)) * ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))
+        ≤ (1 / (k : ℝ)) * ((k : ℝ) / ((N : ℝ) + 1)) :=
+          mul_le_mul_of_nonneg_left hd hkinv
+    _ = 1 / ((N : ℝ) + 1) := by
+          field_simp
+
+/-- **Sharpness.** The tail is ≥ `1/(N+k)`, so the `1/(N+1)` bound cannot be
+    improved by more than the factor `(N+1)/(N+k)` (→ 1 as N → ∞ for fixed k). -/
+theorem truncation_error_ge (N k : ℕ) (hk : 0 < k) :
+    1 / ((N : ℝ) + (k : ℝ)) ≤ (∑' n : ℕ, f k n) - ∑ i ∈ Finset.range N, f k i := by
+  rw [truncation_error_eq N k hk]
+  have hk' : (0 : ℝ) < (k : ℝ) := by exact_mod_cast hk
+  have hkinv : (0 : ℝ) ≤ 1 / (k : ℝ) := by positivity
+  have hd := harmonic_diff_ge N k hk
+  calc 1 / ((N : ℝ) + (k : ℝ))
+        = (1 / (k : ℝ)) * ((k : ℝ) / ((N : ℝ) + (k : ℝ))) := by field_simp
+    _ ≤ (1 / (k : ℝ)) * ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)) :=
+          mul_le_mul_of_nonneg_left hd hkinv
+
+/-- **Absolute-value form.** `|S_N − ∑ f| ≤ 1/(N+1)`, uniformly in k. -/
+theorem truncation_error_abs (N k : ℕ) (hk : 0 < k) :
+    |(∑ i ∈ Finset.range N, f k i) - (∑' n : ℕ, f k n)| ≤ 1 / ((N : ℝ) + 1) := by
+  rw [abs_sub_comm]
+  have hge : 1 / ((N : ℝ) + (k : ℝ)) ≤
+      (∑' n : ℕ, f k n) - ∑ i ∈ Finset.range N, f k i := truncation_error_ge N k hk
+  have hnn : (0 : ℝ) ≤ 1 / ((N : ℝ) + (k : ℝ)) := by positivity
+  rw [abs_of_nonneg (le_trans hnn hge)]
+  exact truncation_error_le N k hk
+
+end TriangularReciprocalsTruncation

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/annotations.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "concept",
+    "title": "Goal: Uniform Truncation Error Bound",
+    "content": "The header states open question OQ-04 of the parent `triangular-reciprocals-oq-02`: quantify the convergence rate of $\\sum_{n=1}^\\infty \\frac{1}{n(n+k)} = H_k/k$. The truncation error after $N$ terms equals exactly $\\frac{1}{k}(H_{N+k} - H_N)$ and is bounded by $\\frac{1}{N+1}$ — a bound **independent of the gap $k$**. The strategy reduces everything to the elementary harmonic-block estimate $k/(N+k) \\le H_{N+k} - H_N \\le k/(N+1)$."
+  },
+  {
+    "id": "ann-summand-def",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 40, "endLine": 46 },
+    "type": "definition",
+    "title": "The Series Summand",
+    "content": "`f k n = 1/((n+1)((n+1)+k))` indexes the series so that `n+1` ranges over 1, 2, 3, …, matching the parent's `HasSum`/`tsum` convention. This lets the imported parent results (`generalized_triangular_reciprocals_tsum`, `partial_sum_closed_form`) be applied verbatim."
+  },
+  {
+    "id": "ann-harmonic-block",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 48, "endLine": 81 },
+    "type": "technique",
+    "title": "Harmonic Difference as a Contiguous Block",
+    "content": "`harmonic_real_eq` casts Mathlib's rational `harmonic m` to a real finite sum $\\sum_{i=1}^m 1/i$ via `harmonic_eq_sum_Icc`. `harmonic_sub` then proves $H_b - H_a = \\sum_{i=a+1}^b 1/i$ for $a \\le b$ by splitting $\\text{Icc}\\,1\\,b$ into consecutive intervals with `Finset.sum_Ico_consecutive`. The harmonic difference is thus a block of exactly $b-a$ reciprocals — the central object every bound estimates termwise."
+  },
+  {
+    "id": "ann-block-upper",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 82, "endLine": 100 },
+    "type": "key-step",
+    "title": "Upper Block Bound H_{N+k} − H_N ≤ k/(N+1)",
+    "content": "Each term $1/i$ with $N+1 \\le i \\le N+k$ satisfies $1/i \\le 1/(N+1)$ (`one_div_le_one_div_of_le`). Summing $k$ such terms via `Finset.sum_le_sum` and counting them with `Nat.card_Icc` (the block $\\text{Icc}(N{+}1)(N{+}k)$ has $k$ elements) gives $H_{N+k} - H_N \\le k/(N+1)$. This is where uniformity in $k$ originates: the factor $k$ here will cancel the $1/k$ prefactor of the error."
+  },
+  {
+    "id": "ann-block-lower",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 101, "endLine": 133 },
+    "type": "key-step",
+    "title": "Lower Block Bound H_{N+k} − H_N ≥ k/(N+k)",
+    "content": "Symmetrically, each term $1/i$ with $i \\le N+k$ satisfies $1/i \\ge 1/(N+k)$, so the $k$-term block is at least $k/(N+k)$. Together with the upper bound this pins the harmonic difference into $[k/(N+k), k/(N+1)]$, the source of the sharp two-sided error estimate."
+  },
+  {
+    "id": "ann-range-partial",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 134, "endLine": 157 },
+    "type": "technique",
+    "title": "Lifting the Parent's Closed Form",
+    "content": "`range_partial` reindexes the `range N`-indexed partial sum into the `Icc 1 N` form via `Finset.sum_Ico_add'`, then applies the parent's `partial_sum_closed_form` to get $S_N(k) = \\frac{1}{k}(H_k - (H_{N+k} - H_N))$. The analytic content (summability, convergence) is reused as an imported black box."
+  },
+  {
+    "id": "ann-error-eq",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 158, "endLine": 168 },
+    "type": "key-step",
+    "title": "Exact Error Identity",
+    "content": "`truncation_error_eq` subtracts the partial sum from the parent's `tsum` value $H_k/k$. The $H_k$ terms cancel under `ring`, leaving the error exactly $\\frac{1}{k}(H_{N+k} - H_N)$ — an equality, not an estimate."
+  },
+  {
+    "id": "ann-error-bounds",
+    "proofId": "triangular-reciprocals-oq-02-oq-04",
+    "range": { "startLine": 169, "endLine": 205 },
+    "type": "key-step",
+    "title": "Uniform Bound, Sharpness, and Absolute Form",
+    "content": "Multiplying the two-sided block estimate by the prefactor $1/k > 0$ yields $\\frac{1}{N+k} \\le \\text{error} \\le \\frac{1}{N+1}$ (`truncation_error_le`, `truncation_error_ge`); the $k$ cancels in the upper bound, making it uniform in $k$. The positive lower bound certifies nonnegativity of the error, so `truncation_error_abs` reads off $|S_N - \\sum' f| \\le \\frac{1}{N+1}$. The ratio of bounds $(N+1)/(N+k) \\to 1$ shows the estimate is asymptotically sharp."
+  }
+]

--- a/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02-oq-04/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "triangular-reciprocals-oq-02-oq-04",
+  "title": "Uniform Truncation Error Bound for Generalized Triangular Reciprocals",
+  "slug": "triangular-reciprocals-oq-02-oq-04",
+  "description": "For every k ≥ 1, the tail of ∑_{n=1}^∞ 1/(n(n+k)) after N terms equals exactly (1/k)(H_{N+k} − H_N) and is bounded by 1/(N+1) uniformly in k. A two-sided estimate 1/(N+k) ≤ tail ≤ 1/(N+1) shows the bound is essentially sharp. Answers open question OQ-04 of triangular-reciprocals-oq-02.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Harmonic_number",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "series",
+      "harmonic-numbers",
+      "telescoping",
+      "error-bounds",
+      "rate-of-convergence",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/TriangularReciprocalsOQ02OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "harmonic",
+        "description": "Definition of the k-th harmonic number as ∑_{i=1}^k 1/i in ℚ",
+        "module": "Mathlib.NumberTheory.Harmonic.Defs"
+      },
+      {
+        "theorem": "harmonic_eq_sum_Icc",
+        "description": "Equivalence of harmonic n with ∑ i ∈ Icc 1 n, (i)⁻¹",
+        "module": "Mathlib.NumberTheory.Harmonic.Defs"
+      },
+      {
+        "theorem": "Finset.sum_Ico_consecutive",
+        "description": "Decompose a sum over consecutive Ico intervals (used to write H_b − H_a as a block sum)",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of finite sums under termwise inequality (per-term harmonic bounds)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "Reciprocal reverses order on positives: 0 < a → a ≤ b → 1/b ≤ 1/a",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Nat.card_Icc",
+        "description": "Cardinality |Icc a b| = b + 1 − a, used to count the k harmonic-block terms",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      }
+    ],
+    "originalContributions": [
+      "Exact truncation-error identity: (∑' f) − S_N = (1/k)(H_{N+k} − H_N), derived from the parent closed form composed with the tsum value",
+      "Uniform-in-k upper bound: the tail is ≤ 1/(N+1), a constant independent of the gap k",
+      "Matching lower bound 1/(N+k) ≤ tail, proving the 1/(N+1) estimate is sharp up to the factor (N+1)/(N+k) → 1",
+      "Self-contained harmonic-block lemma H_b − H_a = ∑_{i=a+1}^b 1/i with two-sided estimates k/(N+k) ≤ H_{N+k} − H_N ≤ k/(N+1)",
+      "Absolute-value form |S_N − ∑' f| ≤ 1/(N+1) packaged as a Mathlib-style error bound"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 205,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The convergence rate of telescoping-type series is a classical concern in numerical analysis: for the gap-k harmonic series ∑ 1/(n(n+k)) = H_k/k (parent entry triangular-reciprocals-oq-02), the speed at which the partial sums S_N(k) approach the limit is governed entirely by the harmonic tail H_{N+k} − H_N. Since the harmonic numbers satisfy H_m = ln m + γ + O(1/m) (Euler-Maclaurin), the difference H_{N+k} − H_N = ln((N+k)/N) + O(1/N) ≈ k/N for fixed k and large N. This entry makes the elementary, non-asymptotic side of that estimate fully rigorous, bounding the tail above and below by the per-term harmonic block inequalities 1/(N+k) ≤ 1/i ≤ 1/(N+1) for N+1 ≤ i ≤ N+k.",
+    "problemStatement": "**Uniform truncation error**: For every integer $k \\ge 1$ and every $N \\ge 0$,\n\n$$\\left|\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} - \\sum_{n=1}^{N} \\frac{1}{n(n+k)}\\right| = \\frac{1}{k}\\bigl(H_{N+k} - H_N\\bigr) \\le \\frac{1}{N+1},$$\n\nwith the bound on the right **independent of $k$**, and a matching lower bound $\\frac{1}{N+k}$ showing sharpness.",
+    "text": "Quantifies how fast the generalized triangular series converges. After summing N terms, the remaining error equals (1/k)(H_{N+k} − H_N) exactly, and this never exceeds 1/(N+1) no matter how large the gap k is.",
+    "proofStrategy": "1. Express the harmonic difference as a finite block: H_b − H_a = ∑_{i=a+1}^b 1/i (harmonic_sub), via harmonic_eq_sum_Icc + Finset.sum_Ico_consecutive. 2. Bound the block two-sidedly: each of the k terms 1/i with N+1 ≤ i ≤ N+k lies in [1/(N+k), 1/(N+1)], so k/(N+k) ≤ H_{N+k} − H_N ≤ k/(N+1) (harmonic_diff_le, harmonic_diff_ge) using Finset.sum_le_sum + one_div_le_one_div_of_le + Nat.card_Icc. 3. Combine the parent's tsum value H_k/k with its partial-sum closed form to get the exact error identity (∑' f) − S_N = (1/k)(H_{N+k} − H_N) (truncation_error_eq). 4. Multiply the two-sided harmonic estimate by 1/k to land the bounds 1/(N+k) ≤ error ≤ 1/(N+1) (truncation_error_le, truncation_error_ge), and package the absolute-value form (truncation_error_abs).",
+    "keyInsights": [
+      "The error is computed *exactly*, not just bounded: total − partial = (1/k)(H_{N+k} − H_N), so the 1/(N+1) bound comes from a clean inequality on a known quantity rather than an opaque remainder estimate",
+      "Uniformity in k is structural: the harmonic block H_{N+k} − H_N has exactly k terms each ≤ 1/(N+1), so the sum ≤ k/(N+1); dividing by the prefactor 1/k cancels k entirely, leaving 1/(N+1) free of k",
+      "The same block, bounded below by k copies of 1/(N+k), yields tail ≥ 1/(N+k); the ratio of the two bounds (N+1)/(N+k) → 1, so 1/(N+1) is asymptotically sharp for every fixed k",
+      "Building on the parent's tsum value lets the analytic content (summability, limit of partial sums) be reused as a black box — this entry is pure finite-sum inequality manipulation on top of it",
+      "Nonnegativity of the error needed for the absolute-value form is free: the lower bound 1/(N+k) > 0 already certifies total − partial ≥ 0, so no separate monotonicity argument is required"
+    ],
+    "prerequisites": [
+      "Real analysis (series tails, rate of convergence)",
+      "Harmonic numbers and finite-sum reindexing",
+      "Monotonicity of finite sums and reciprocal inequalities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "harmonic-as-sum",
+      "title": "Harmonic Numbers as Real Finite Sums",
+      "startLine": 44,
+      "endLine": 81,
+      "summary": "harmonic_real_eq casts Mathlib's rational `harmonic m` to a real sum ∑_{i∈Icc 1 m} 1/i; harmonic_sub then writes the difference H_b − H_a (for a ≤ b) as the block sum ∑_{i∈Icc (a+1) b} 1/i using Finset.sum_Ico_consecutive.",
+      "mathContext": "$H_b - H_a = \\sum_{i=a+1}^{b} \\frac{1}{i}$ for $a \\le b$. The harmonic difference is a contiguous block of reciprocals — the object every subsequent bound estimates termwise."
+    },
+    {
+      "id": "block-bounds",
+      "title": "Two-Sided Harmonic Block Estimate",
+      "startLine": 82,
+      "endLine": 133,
+      "summary": "harmonic_diff_le bounds H_{N+k} − H_N ≤ k/(N+1) (each of the k terms ≤ 1/(N+1)); harmonic_diff_ge bounds it ≥ k/(N+k) (each term ≥ 1/(N+k)). Both close via Finset.sum_le_sum, one_div_le_one_div_of_le, and Nat.card_Icc giving the term count k.",
+      "mathContext": "$\\frac{k}{N+k} \\le H_{N+k} - H_N \\le \\frac{k}{N+1}$. The block has exactly $k$ terms, each reciprocal pinned between $1/(N+k)$ and $1/(N+1)$."
+    },
+    {
+      "id": "range-partial",
+      "title": "Partial Sum over range N",
+      "startLine": 134,
+      "endLine": 157,
+      "summary": "range_partial lifts the parent's partial_sum_closed_form into the range-indexed convention: ∑_{i<N} f(i) = (1/k)(H_k − (H_{N+k} − H_N)), by reindexing range N to Icc 1 N via Finset.sum_Ico_add'.",
+      "mathContext": "$S_N(k) = \\frac{1}{k}\\bigl(H_k - (H_{N+k} - H_N)\\bigr)$, the parent closed form expressed over the `range`-indexed summand used here."
+    },
+    {
+      "id": "error-identity",
+      "title": "Exact Truncation Error Identity",
+      "startLine": 158,
+      "endLine": 168,
+      "summary": "truncation_error_eq subtracts range_partial from the parent's tsum value H_k/k and simplifies with ring to (1/k)(H_{N+k} − H_N).",
+      "mathContext": "$\\bigl(\\sum_{n\\ge1} \\tfrac{1}{n(n+k)}\\bigr) - S_N(k) = \\frac{1}{k}(H_{N+k} - H_N)$. The $H_k$ contributions cancel, leaving exactly the tail."
+    },
+    {
+      "id": "error-bounds",
+      "title": "Uniform Upper Bound, Sharp Lower Bound, Absolute Form",
+      "startLine": 169,
+      "endLine": 205,
+      "summary": "truncation_error_le multiplies the upper block bound by 1/k to get error ≤ 1/(N+1) (independent of k); truncation_error_ge gives error ≥ 1/(N+k); truncation_error_abs packages |S_N − ∑' f| ≤ 1/(N+1) using the positive lower bound to discharge nonnegativity.",
+      "mathContext": "$\\frac{1}{N+k} \\le \\bigl(\\sum_{n\\ge1}\\tfrac{1}{n(n+k)}\\bigr) - S_N(k) \\le \\frac{1}{N+1}$, hence $\\bigl|S_N(k) - \\sum_{n\\ge1}\\tfrac{1}{n(n+k)}\\bigr| \\le \\frac{1}{N+1}$ uniformly in $k$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals-oq-02",
+      "relationship": "extends",
+      "description": "Directly answers open question OQ-04 of the parent: 'Quantify the rate of convergence ... formalize this as a Mathlib-style truncation error bound for the partial sums.' Reuses the parent's `partial_sum_closed_form` and `generalized_triangular_reciprocals_tsum` as imported black boxes, adding only finite-sum inequality work on top."
+    },
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "related",
+      "description": "For the classical k=1 Leibniz case ∑ 1/(n(n+1)) = 1, the error bound specializes to a tail ≤ 1/(N+1) with exact value (H_{N+1} − H_N) = 1/(N+1) — i.e. the bound is attained exactly when k=1, the sharpest possible instance of the uniform estimate."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "complementary",
+      "description": "The harmonic series ∑ 1/n diverges, yet its fixed-width tails H_{N+k} − H_N vanish at rate Θ(k/N). This entry quantifies exactly that vanishing — the convergent counterpart to harmonic divergence: globally the partial sums H_N → ∞, but locally the width-k differences are squeezed into [k/(N+k), k/(N+1)]."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Summability of ∑ 1/(n(n+k)) (the object whose tail is bounded here) rests on comparison with the Basel series ∑ 1/n²; this entry takes that convergence as given via the parent and instead pins down the convergence *rate*."
+    }
+  ],
+  "conclusion": {
+    "summary": "The truncation error of the generalized triangular series ∑_{n=1}^∞ 1/(n(n+k)) = H_k/k is computed exactly as (1/k)(H_{N+k} − H_N) and bounded two-sidedly by 1/(N+k) ≤ error ≤ 1/(N+1), with the upper bound uniform in the gap k. Fully verified in Lean 4 (Mathlib v4.26.0), 0 sorries, 0 axioms. Resolves open question OQ-04 of triangular-reciprocals-oq-02.",
+    "implications": "The uniform-in-k bound means a single truncation length N guarantees error ≤ 1/(N+1) simultaneously for the entire family of gap-k series — useful when summing the digamma reformulation H_k/k = (ψ(k+1) + γ)/k across many k. The matching lower bound certifies that no truncation strategy beats the 1/N rate, ruling out acceleration without resummation. The harmonic-block lemmas (harmonic_sub with two-sided estimates) are reusable infrastructure for any fixed-width harmonic-difference estimate.",
+    "openQuestions": [
+      "Sharpen the upper bound to the exact asymptotic (1/k)·ln((N+k)/N) using Euler-Maclaurin / Real.log estimates for harmonic numbers, replacing the elementary k/(N+1) block bound",
+      "Establish a uniform-over-k summability rate in the L¹ sense: bound ∑_{k=1}^K |error_N(k)| and study its growth in K and N"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.TriangularReciprocalsOQ02"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "Filter",
+      "Topology",
+      "Real",
+      "TriangularReciprocalsHarmonic"
+    ],
+    "namespace": "TriangularReciprocalsTruncation",
+    "lineCount": 205,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/TriangularReciprocalsOQ02OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question OQ-04** of the parent entry `triangular-reciprocals-oq-02`:

> "Quantify the rate of convergence: the closed form gives $|\sum_{n=1}^{\infty} \frac{1}{n(n+k)} - S_N(k)| = \frac{1}{k}(H_{N+k} - H_N) \leq \frac{1}{N+1}$ uniformly in $k$ — formalize this as a Mathlib-style truncation error bound."

The parent proves $\sum_{n=1}^\infty \frac{1}{n(n+k)} = H_k/k$. This entry pins down the **convergence rate**.

## Main results (9 theorems, 1 def, 205 lines)

- `truncation_error_eq` — the tail is **exactly** $(\sum' f) - S_N = \frac{1}{k}(H_{N+k} - H_N)$.
- `truncation_error_le` — tail $\le \frac{1}{N+1}$, a bound **independent of the gap $k$** (hence uniform in $k$).
- `truncation_error_ge` — tail $\ge \frac{1}{N+k}$, so the $\frac{1}{N+1}$ bound is **sharp** (ratio $(N+1)/(N+k) \to 1$).
- `truncation_error_abs` — $|S_N - \sum' f| \le \frac{1}{N+1}$.

## Engine

The harmonic difference is a contiguous block: `harmonic_sub` proves $H_b - H_a = \sum_{i=a+1}^b 1/i$ (via `Finset.sum_Ico_consecutive`). Each of the $k$ block terms with $N+1 \le i \le N+k$ lies in $[1/(N+k), 1/(N+1)]$, giving the two-sided estimate
$$\frac{k}{N+k} \le H_{N+k} - H_N \le \frac{k}{N+1}$$
(`one_div_le_one_div_of_le` + `Finset.sum_le_sum` + `Nat.card_Icc` for the term count). The $\frac{1}{k}$ prefactor of the error then cancels the $k$, producing the $k$-uniform $\frac{1}{N+1}$ bound. The analytic content (summability, limit of partial sums) is reused as a black box by importing the parent's `partial_sum_closed_form` and `generalized_triangular_reciprocals_tsum`.

## Verification

- Builds against Mathlib v4.26.0.
- **0 sorries**, **0 axioms** beyond the foundational `propext`, `Classical.choice`, `Quot.sound` (confirmed via `#print axioms` on all four `truncation_error_*` theorems — no `sorryAx`, no `Lean.ofReduceBool`).
- Gallery entry validated by `pnpm annotations:build` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)