### PR TITLE
research(isoperimetric-oq-02-oq-03): equality rigidity |∂S|=2 ⟺ S is an integer interval [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/IsoperimetricTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/IsoperimetricTheoremOQ02OQ03.lean
@@ -1,0 +1,212 @@
+/-
+Discrete Isoperimetric Inequality (1D): Equality Rigidity
+
+Open Question from: Isoperimetric Theorem (Wiedijk #43), OQ-02 → OQ-03
+
+The parent entry (IsoperimetricTheoremOQ02) proves the discrete 1D isoperimetric
+*inequality*: every finite `S ⊆ ℤ` with `|S| ≥ 2` has vertex edge boundary
+`|∂S| ≥ 2`, and integer intervals achieve `|∂S| = 2`. It explicitly leaves the
+equality characterization unformalized:
+
+  "The full equality characterization—|∂S| = 2 implies S is an interval—holds
+   but is not formalized here; only the lower bound and the interval case are
+   proved."
+
+This file closes that gap. We prove the full RIGIDITY statement: for any finite
+nonempty `S ⊆ ℤ`,
+
+      |∂S| = 2   ⟺   S is an integer interval `[min S, max S]`.
+
+Proof idea.
+  (⟸) For an interval `[a,b]` the boundary is exactly `{a-1, b+1}`, card 2.
+  (⟹) Contrapositive. Suppose `S` is not the interval `[m, M]` where `m = min S`,
+      `M = max S`. Since `S ⊆ [m, M]` always, there is a "gap": the smallest
+      element `g` of `[m, M] \ S`. Then `m < g < M` (because `m, M ∈ S`), and
+      `g - 1 ∈ S` (as `g` is the *smallest* missing point and `g - 1 ∈ [m, M]`).
+      Hence `g ∈ ∂S`, and `g` is distinct from the two extreme boundary points
+      `m - 1` and `M + 1`. So `{m-1, M+1, g} ⊆ ∂S` gives `|∂S| ≥ 3 > 2`.
+
+Remark on "boundary = 2·runs".
+  The *edge* count (number of lattice edges crossing between `S` and its
+  complement) equals `2·(number of maximal runs)`. That is NOT the same as the
+  cardinality of the *vertex* boundary `∂S` used here: e.g. `S = {0, 2}` has
+  `∂S = {-1, 1, 3}` (card 3), while the edge count is 4 = 2·2. We formalize the
+  correct vertex-boundary rigidity; for the vertex boundary the clean statement
+  is the `|∂S| = 2 ⟺ interval` equivalence proved below.
+
+References:
+  - Bollobás (1986), Combinatorics, Cambridge University Press.
+  - Harper (1966), Optimal numberings and isoperimetric problems on graphs.
+
+Tags: combinatorics, discrete-geometry, isoperimetric-inequality, rigidity
+-/
+import Mathlib
+
+namespace DiscreteIsoperimetric1DRigidity
+
+/-- The vertex edge boundary of `S ⊆ ℤ`: integers adjacent to some element of
+    `S` but not themselves in `S`. (Same definition as the parent OQ-02 entry;
+    repeated here to keep this file self-contained.) -/
+def edgeBoundary (S : Finset ℤ) : Finset ℤ :=
+  ((S.image (· - 1)) ∪ (S.image (· + 1))) \ S
+
+/-- Membership characterization for the edge boundary. -/
+lemma mem_edgeBoundary {S : Finset ℤ} {x : ℤ} :
+    x ∈ edgeBoundary S ↔ (x + 1 ∈ S ∨ x - 1 ∈ S) ∧ x ∉ S := by
+  simp only [edgeBoundary, Finset.mem_sdiff, Finset.mem_union, Finset.mem_image]
+  refine and_congr ?_ Iff.rfl
+  constructor
+  · rintro (⟨a, ha, hax⟩ | ⟨a, ha, hax⟩)
+    · left
+      have : a = x + 1 := by linarith
+      simpa [this] using ha
+    · right
+      have : a = x - 1 := by linarith
+      simpa [this] using ha
+  · rintro (h | h)
+    · exact Or.inl ⟨x + 1, h, by ring⟩
+    · exact Or.inr ⟨x - 1, h, by ring⟩
+
+/-- A finite nonempty `S ⊆ ℤ` is contained in the interval spanned by its
+    minimum and maximum. -/
+lemma subset_Icc_min'_max' {S : Finset ℤ} (h : S.Nonempty) :
+    S ⊆ Finset.Icc (S.min' h) (S.max' h) := by
+  intro x hx
+  exact Finset.mem_Icc.mpr ⟨S.min'_le x hx, S.le_max' x hx⟩
+
+/-- The edge boundary of an integer interval `[a, b]` is exactly `{a-1, b+1}`. -/
+theorem edgeBoundary_Icc {a b : ℤ} (h : a ≤ b) :
+    edgeBoundary (Finset.Icc a b) = {a - 1, b + 1} := by
+  ext x
+  rw [mem_edgeBoundary]
+  simp only [Finset.mem_Icc, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨h1, hnot⟩
+    rcases h1 with ⟨ha1, hb1⟩ | ⟨ha2, hb2⟩
+    · have : x < a := by
+        by_contra hc; push_neg at hc
+        exact hnot ⟨hc, by linarith⟩
+      left; linarith
+    · have : x > b := by
+        by_contra hc; push_neg at hc
+        exact hnot ⟨by linarith, hc⟩
+      right; linarith
+  · rintro (rfl | rfl)
+    · refine ⟨Or.inl ⟨?_, ?_⟩, ?_⟩
+      · linarith
+      · linarith
+      · push_neg; intro h1; linarith
+    · refine ⟨Or.inr ⟨?_, ?_⟩, ?_⟩
+      · linarith
+      · linarith
+      · push_neg; intro h1; linarith
+
+/-- For an interval `[a, b]` with `a ≤ b`, the edge boundary has exactly 2
+    elements. -/
+theorem edgeBoundary_Icc_card {a b : ℤ} (h : a ≤ b) :
+    (edgeBoundary (Finset.Icc a b)).card = 2 := by
+  rw [edgeBoundary_Icc h]
+  rw [Finset.card_insert_of_notMem (by simp; linarith), Finset.card_singleton]
+
+/-- The lower extreme `min S - 1` always lies in the boundary. -/
+lemma min_sub_one_mem_edgeBoundary {S : Finset ℤ} (h : S.Nonempty) :
+    S.min' h - 1 ∈ edgeBoundary S := by
+  rw [mem_edgeBoundary]
+  refine ⟨Or.inl ?_, ?_⟩
+  · simpa using S.min'_mem h
+  · intro hcontra
+    have := S.min'_le _ hcontra
+    omega
+
+/-- The upper extreme `max S + 1` always lies in the boundary. -/
+lemma max_add_one_mem_edgeBoundary {S : Finset ℤ} (h : S.Nonempty) :
+    S.max' h + 1 ∈ edgeBoundary S := by
+  rw [mem_edgeBoundary]
+  refine ⟨Or.inr ?_, ?_⟩
+  · simpa using S.max'_mem h
+  · intro hcontra
+    have := S.le_max' _ hcontra
+    omega
+
+/-- **Gap lemma.** If a finite nonempty `S ⊆ ℤ` is *not* the full interval
+    `[min S, max S]`, then there is an interior boundary point `g` with
+    `min S < g < max S`. -/
+lemma exists_interior_boundary_of_ne_Icc {S : Finset ℤ} (h : S.Nonempty)
+    (hne : S ≠ Finset.Icc (S.min' h) (S.max' h)) :
+    ∃ g, S.min' h < g ∧ g < S.max' h ∧ g ∈ edgeBoundary S := by
+  set m := S.min' h with hm
+  set M := S.max' h with hM
+  -- The complement of S inside [m, M] is nonempty, since S ⊆ [m, M] but S ≠ [m, M].
+  have hsub : S ⊆ Finset.Icc m M := subset_Icc_min'_max' h
+  have hmissing : (Finset.Icc m M \ S).Nonempty := by
+    rw [Finset.sdiff_nonempty]
+    intro hcon
+    exact hne (Finset.Subset.antisymm hsub hcon)
+  -- Take the smallest missing point g.
+  set g := (Finset.Icc m M \ S).min' hmissing with hg
+  have hg_mem : g ∈ Finset.Icc m M \ S := (Finset.Icc m M \ S).min'_mem hmissing
+  rw [Finset.mem_sdiff, Finset.mem_Icc] at hg_mem
+  obtain ⟨⟨hmg, hgM⟩, hgS⟩ := hg_mem
+  -- g ≠ m and g ≠ M since m, M ∈ S but g ∉ S.
+  have hm_mem : m ∈ S := S.min'_mem h
+  have hM_mem : M ∈ S := S.max'_mem h
+  have hg_ne_m : g ≠ m := fun hc => hgS (hc ▸ hm_mem)
+  have hg_ne_M : g ≠ M := fun hc => hgS (hc ▸ hM_mem)
+  have hmg' : m < g := lt_of_le_of_ne hmg (Ne.symm hg_ne_m)
+  have hgM' : g < M := lt_of_le_of_ne hgM hg_ne_M
+  -- g - 1 lies in [m, M] and is below the smallest missing point, hence in S.
+  have hg1_mem : g - 1 ∈ S := by
+    by_contra hc
+    have hg1_in : g - 1 ∈ Finset.Icc m M \ S := by
+      rw [Finset.mem_sdiff, Finset.mem_Icc]
+      exact ⟨⟨by omega, by omega⟩, hc⟩
+    have := (Finset.Icc m M \ S).min'_le _ hg1_in
+    rw [← hg] at this
+    omega
+  refine ⟨g, hmg', hgM', ?_⟩
+  rw [mem_edgeBoundary]
+  exact ⟨Or.inr hg1_mem, hgS⟩
+
+/-- **Equality rigidity** for the discrete 1D isoperimetric inequality.
+    For a finite nonempty `S ⊆ ℤ`, the vertex edge boundary has cardinality
+    exactly 2 **iff** `S` is the integer interval `[min S, max S]`. -/
+theorem edgeBoundary_card_eq_two_iff {S : Finset ℤ} (h : S.Nonempty) :
+    (edgeBoundary S).card = 2 ↔ S = Finset.Icc (S.min' h) (S.max' h) := by
+  set m := S.min' h with hm
+  set M := S.max' h with hM
+  have hmM : m ≤ M := S.min'_le _ (S.max'_mem h)
+  constructor
+  · -- card = 2 ⟹ interval. Contrapositive: not interval ⟹ a third boundary point.
+    intro hcard
+    by_contra hne
+    obtain ⟨g, hmg, hgM, hg_mem⟩ := exists_interior_boundary_of_ne_Icc h hne
+    -- {m-1, M+1, g} are three distinct boundary points.
+    have h_lo : m - 1 ∈ edgeBoundary S := min_sub_one_mem_edgeBoundary h
+    have h_hi : M + 1 ∈ edgeBoundary S := max_add_one_mem_edgeBoundary h
+    have h_sub : ({m - 1, M + 1, g} : Finset ℤ) ⊆ edgeBoundary S := by
+      intro x hx
+      simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl | rfl
+      · exact h_lo
+      · exact h_hi
+      · exact hg_mem
+    have h_card3 : ({m - 1, M + 1, g} : Finset ℤ).card = 3 := by
+      rw [Finset.card_insert_of_notMem, Finset.card_insert_of_notMem,
+        Finset.card_singleton]
+      · simp only [Finset.mem_singleton]; omega
+      · simp only [Finset.mem_insert, Finset.mem_singleton]; omega
+    have := Finset.card_le_card h_sub
+    rw [h_card3, hcard] at this
+    omega
+  · -- interval ⟹ card = 2
+    intro hS
+    rw [hS, edgeBoundary_Icc_card hmM]
+
+/-- Packaged rigidity statement, mirroring the parent's `discrete_isoperimetric_1d`:
+    the boundary attains its minimum value 2 exactly on integer intervals. -/
+theorem discrete_isoperimetric_1d_rigidity :
+    ∀ (S : Finset ℤ) (h : S.Nonempty),
+      (edgeBoundary S).card = 2 ↔ S = Finset.Icc (S.min' h) (S.max' h) :=
+  fun _ h => edgeBoundary_card_eq_two_iff h
+
+end DiscreteIsoperimetric1DRigidity

--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03/annotations.json
@@ -1,0 +1,131 @@
+[
+  {
+    "id": "ann-header-context",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Closing the Rigidity Gap Left by OQ-02",
+    "content": "The parent entry (Discrete Isoperimetric Inequality 1D, OQ-02) proved the lower bound |∂S| ≥ 2 for finite S ⊆ ℤ with |S| ≥ 2 and that integer intervals achieve equality, but explicitly left the converse — that |∂S| = 2 forces S to be an interval — unformalized, conjecturing it 'requires a careful induction on max(S) − min(S).' This file supplies that converse with a short, induction-free argument, completing the equality characterization into a sharp 'iff'. The header also clarifies that the cardinality of the vertex boundary is not 2·(number of runs): S = {0,2} has ∂S = {−1,1,3} of size 3, while the edge-crossing count is 4.",
+    "mathContext": "For finite nonempty $S \\subseteq \\mathbb{Z}$, $\\partial S = \\{x \\notin S : x+1 \\in S \\text{ or } x-1 \\in S\\}$. The rigidity statement is $|\\partial S| = 2 \\iff S = [\\min S, \\max S] \\cap \\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isoperimetric rigidity",
+      "equality cases",
+      "discrete geometry",
+      "extremal combinatorics"
+    ],
+    "prerequisites": [
+      "Finset min'/max'",
+      "linear arithmetic"
+    ]
+  },
+  {
+    "id": "ann-edge-boundary-def",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 45,
+      "endLine": 75
+    },
+    "type": "definition",
+    "title": "Edge Boundary, Membership, and Containment in the Spanning Interval",
+    "content": "edgeBoundary is re-defined exactly as in the parent (the shift-image difference ((S.image (· − 1)) ∪ (S.image (· + 1))) \\ S) so this file is self-contained and does not depend on the parent module compiling. mem_edgeBoundary gives the working characterization x ∈ ∂S ↔ (x+1 ∈ S ∨ x−1 ∈ S) ∧ x ∉ S. subset_Icc_min'_max' records the only structural fact about S the rigidity argument needs: every element lies between min S and max S, so S ⊆ Icc(min S, max S).",
+    "mathContext": "$S \\subseteq \\mathrm{Icc}(\\min' S, \\max' S)$ follows immediately from $\\min' S \\le x \\le \\max' S$ for all $x \\in S$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.image",
+      "Finset.sdiff",
+      "Finset.Icc"
+    ],
+    "prerequisites": [
+      "Finset operations"
+    ]
+  },
+  {
+    "id": "ann-interval-boundary",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 77,
+      "endLine": 109
+    },
+    "type": "proof-step",
+    "title": "Reverse Direction: Intervals Have Boundary {a−1, b+1}",
+    "content": "edgeBoundary_Icc computes the boundary of an interval exactly: ∂(Icc a b) = {a−1, b+1}, via a four-way case analysis on the membership characterization (whether x+1 or x−1 lands in [a,b], and whether x itself does), with linarith dispatching every branch. edgeBoundary_Icc_card then reads off |∂(Icc a b)| = 2 since a−1 ≠ b+1. This is the easy ('⟸') half of the rigidity equivalence.",
+    "mathContext": "$\\partial([a,b]) = \\{a-1, b+1\\}$, and $a-1 \\ne b+1$ whenever $a \\le b$, so $|\\partial([a,b])| = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval boundary",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "Finset.card_insert_of_notMem"
+    ]
+  },
+  {
+    "id": "ann-extreme-witnesses",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 111,
+      "endLine": 129
+    },
+    "type": "proof-step",
+    "title": "The Two Always-Present Boundary Witnesses",
+    "content": "min_sub_one_mem_edgeBoundary and max_add_one_mem_edgeBoundary isolate the fact (used in the parent's lower bound too) that min S − 1 and max S + 1 always lie in ∂S: each is adjacent to the corresponding endpoint of S yet lies strictly outside S (below the minimum / above the maximum), so omega closes the 'not in S' obligation. These are the two boundary points an interval already exhausts; the rigidity argument adds a third whenever a gap exists.",
+    "mathContext": "$\\min S - 1 \\in \\partial S$ since $(\\min S - 1) + 1 = \\min S \\in S$ and $\\min S - 1 < \\min S$ so $\\min S - 1 \\notin S$; symmetrically for $\\max S + 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "boundary witnesses",
+      "Finset.min'_le"
+    ],
+    "prerequisites": [
+      "Finset.min'_mem, Finset.max'_mem"
+    ]
+  },
+  {
+    "id": "ann-gap-lemma",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 131,
+      "endLine": 168
+    },
+    "type": "key-insight",
+    "title": "Gap Lemma: A Non-Interval Has an Interior Boundary Point",
+    "content": "This is the crux. If S ≠ Icc(min S, max S), then since S ⊆ Icc(min S, max S), the difference Icc(min S, max S) \\ S is nonempty (Finset.sdiff_nonempty). Let g be its *least* element. Because min S, max S ∈ S but g ∉ S, we get min S < g < max S. The choice of g as the smallest missing point is what forces g − 1 ∈ S: if g − 1 were also missing it would be a smaller element of the gap set, contradicting minimality (and g − 1 still lies in [min S, max S] since g > min S). Hence g ∈ ∂S. This single witness replaces the diameter induction the parent entry anticipated.",
+    "mathContext": "$g = \\min'(\\mathrm{Icc}(\\min S, \\max S) \\setminus S)$ satisfies $\\min S < g < \\max S$, $g \\notin S$, and $g - 1 \\in S$, hence $g \\in \\partial S$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "minimality argument",
+      "Finset.sdiff_nonempty",
+      "gap",
+      "well-ordering"
+    ],
+    "prerequisites": [
+      "Finset.min' on the gap set"
+    ]
+  },
+  {
+    "id": "ann-rigidity-main",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03",
+    "range": {
+      "startLine": 170,
+      "endLine": 212
+    },
+    "type": "key-insight",
+    "title": "Main Theorem: |∂S| = 2 ⟺ S Is an Interval",
+    "content": "edgeBoundary_card_eq_two_iff assembles the pieces. Forward direction by contraposition: assuming |∂S| = 2 but S ≠ Icc(min S, max S), the gap lemma yields an interior g ∈ ∂S distinct from both extreme witnesses min S − 1 and max S + 1 (it sits strictly between min S and max S). The three-element set {min S − 1, max S + 1, g} therefore injects into ∂S, so card_le_card gives |∂S| ≥ 3, contradicting 2. The reverse direction is edgeBoundary_Icc_card. discrete_isoperimetric_1d_rigidity repackages the equivalence in a quantified form mirroring the parent's discrete_isoperimetric_1d.",
+    "mathContext": "If $S$ is not an interval, $\\{\\min S - 1, \\max S + 1, g\\} \\subseteq \\partial S$ are three distinct points, so $|\\partial S| \\ge 3$; contrapositively $|\\partial S| = 2 \\Rightarrow S = [\\min S, \\max S]$. The converse is the interval computation.",
+    "significance": "central",
+    "relatedConcepts": [
+      "rigidity",
+      "contraposition",
+      "Finset.card_le_card",
+      "equality characterization"
+    ],
+    "prerequisites": [
+      "gap lemma",
+      "interval boundary card"
+    ]
+  }
+]

--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "isoperimetric-theorem-oq-02-oq-03",
+  "title": "Discrete Isoperimetric Inequality (1D): Equality Rigidity",
+  "slug": "isoperimetric-theorem-oq-02-oq-03",
+  "description": "Equality rigidity for the discrete 1D isoperimetric inequality on ℤ: a finite nonempty set S has vertex edge boundary of cardinality exactly 2 if and only if S is an integer interval [min S, max S]. This closes the converse uniqueness direction explicitly left open by the parent entry (IsoperimetricTheoremOQ02), which proved only the lower bound |∂S| ≥ 2 and the interval case.",
+  "meta": {
+    "author": "Robb Walters (Lean Genius Researcher)",
+    "sourceUrl": "https://www.cs.ru.nl/~freek/100/",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IsoperimetricTheoremOQ02OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "discrete-geometry",
+      "isoperimetric-inequality",
+      "rigidity",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.min', Finset.max'",
+        "description": "Minimum and maximum of a nonempty finset, used to span the candidate interval [min S, max S]",
+        "module": "Mathlib.Order.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sdiff_nonempty",
+        "description": "A \\ B is nonempty iff A is not a subset of B; used to extract a missing 'gap' point when S is not the full interval",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.min'_le, Finset.le_max', Finset.min'_mem",
+        "description": "Order facts about the minimum of a finset, used to show the smallest missing point lies strictly between min S and max S and that its predecessor is in S",
+        "module": "Mathlib.Order.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.card_insert_of_notMem",
+        "description": "Cardinality of an insert when the element is new; used to count the three-element witness set and the two-element interval boundary",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "edgeBoundary_card_eq_two_iff: the full rigidity equivalence |∂S| = 2 ↔ S = Icc (min S) (max S) for finite nonempty S ⊆ ℤ — the converse uniqueness direction the parent entry explicitly left unformalized",
+      "exists_interior_boundary_of_ne_Icc: the gap lemma — if S is not its spanning interval, the smallest point of Icc(min,max) \\ S is an interior boundary point strictly between min S and max S",
+      "subset_Icc_min'_max': every finite nonempty S ⊆ ℤ sits inside the interval spanned by its min and max",
+      "min_sub_one_mem_edgeBoundary / max_add_one_mem_edgeBoundary: the two extreme boundary witnesses, isolated as reusable lemmas",
+      "Self-contained re-derivation of edgeBoundary, mem_edgeBoundary, edgeBoundary_Icc, edgeBoundary_Icc_card so the file does not depend on the parent module compiling",
+      "discrete_isoperimetric_1d_rigidity: packaged rigidity statement mirroring the parent's discrete_isoperimetric_1d"
+    ],
+    "axiomCount": 0,
+    "lineCount": 212,
+    "assumptions": "0 axioms, 0 sorries — fully verified (depends only on propext, Classical.choice, Quot.sound).",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parent entry (Discrete Isoperimetric Inequality 1D, OQ-02) established the lower bound |∂S| ≥ 2 for finite S ⊆ ℤ with |S| ≥ 2 and showed integer intervals achieve equality, but its docstring and open-questions explicitly flagged the converse — that |∂S| = 2 forces S to be an interval — as unformalized, suggesting it 'requires a careful induction on max(S) − min(S).' This entry supplies the missing rigidity direction with a short, induction-free argument. Equality rigidity is the discrete shadow of the classical fact that the circle is the unique extremizer of the continuous isoperimetric inequality; in the lattice setting the unique minimizers of the vertex boundary are exactly the integer intervals.",
+    "problemStatement": "Let S ⊆ ℤ be a finite nonempty set with vertex edge boundary ∂S = {x : x ∉ S, x+1 ∈ S or x-1 ∈ S}. Prove that |∂S| = 2 holds if and only if S is the integer interval [min S, max S].",
+    "text": "Rigidity for discrete 1D isoperimetry: |∂S| = 2 ⟺ S is an integer interval.",
+    "proofStrategy": "The reverse direction (interval ⟹ |∂S| = 2) is the parent's interval computation ∂(Icc a b) = {a−1, b+1}, re-derived here. The forward direction is proved by contraposition. Every finite nonempty S satisfies S ⊆ Icc(min S, max S); if S is not equal to this interval, then Icc(min S, max S) \\ S is nonempty, so it has a least element g. Because min S and max S lie in S, we get min S < g < max S, and because g is the *smallest* missing point with g−1 still in the interval, g−1 ∈ S. Hence g ∈ ∂S, and g is distinct from the two always-present extreme boundary points min S − 1 and max S + 1. The three-element set {min S − 1, max S + 1, g} therefore embeds in ∂S, forcing |∂S| ≥ 3 and contradicting |∂S| = 2. No induction on the diameter is needed: a single application of Finset.min' to the gap set does the work.",
+    "keyInsights": [
+      "Rigidity reduces to producing ONE interior boundary point: any 'gap' g in S already gives a third boundary element beyond the two extreme witnesses min S − 1 and max S + 1, so |∂S| ≥ 3 whenever S is not an interval.",
+      "Choosing g = min'(Icc(min S, max S) \\ S) — the *smallest* missing point — is what makes g − 1 ∈ S automatic, sidestepping the diameter induction the parent entry anticipated.",
+      "The containment S ⊆ Icc(min S, max S) is the only structural fact about S used; everything else is order arithmetic dispatched by omega.",
+      "The equivalence is stated with the canonical interval Icc(min S, max S) rather than an existential ∃ a b, S = Icc a b; the two are interchangeable since the endpoints of an interval are forced to be its min and max, but the canonical form is cleaner to use downstream.",
+      "Vertex boundary versus edge count: the cardinality of the vertex boundary ∂S is NOT 2·(number of runs) — e.g. S = {0,2} has ∂S = {−1,1,3} (card 3) while the edge count is 4. The clean invariant for the vertex boundary is exactly the |∂S| = 2 ⟺ interval rigidity proved here."
+    ],
+    "prerequisites": [
+      "Finset basics (min', max', image, sdiff, card_insert)",
+      "Linear arithmetic over ℤ (omega)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Context: Closing the Rigidity Gap",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring quotes the parent entry's unformalized rigidity claim, states the |∂S| = 2 ⟺ interval equivalence, sketches the smallest-gap proof, and clarifies the vertex-boundary vs. 2·runs distinction. Imports Mathlib."
+    },
+    {
+      "id": "definitions",
+      "title": "Edge Boundary and Containment",
+      "startLine": 45,
+      "endLine": 75,
+      "summary": "Re-defines edgeBoundary, proves the membership characterization mem_edgeBoundary, and establishes subset_Icc_min'_max': S ⊆ Icc(min S, max S)."
+    },
+    {
+      "id": "interval-case",
+      "title": "Interval Boundary (reverse direction)",
+      "startLine": 77,
+      "endLine": 109,
+      "summary": "edgeBoundary_Icc shows ∂(Icc a b) = {a−1, b+1} and edgeBoundary_Icc_card concludes the interval boundary has cardinality 2."
+    },
+    {
+      "id": "extreme-witnesses",
+      "title": "Extreme Boundary Witnesses",
+      "startLine": 111,
+      "endLine": 129,
+      "summary": "min_sub_one_mem_edgeBoundary and max_add_one_mem_edgeBoundary isolate the two always-present boundary points min S − 1 and max S + 1."
+    },
+    {
+      "id": "gap-lemma",
+      "title": "Gap Lemma",
+      "startLine": 131,
+      "endLine": 168,
+      "summary": "exists_interior_boundary_of_ne_Icc: if S ≠ Icc(min S, max S), the least element g of the missing set Icc(min,max) \\ S satisfies min S < g < max S and g ∈ ∂S, because g − 1 ∈ S by minimality."
+    },
+    {
+      "id": "rigidity",
+      "title": "Main Rigidity Theorem",
+      "startLine": 170,
+      "endLine": 212,
+      "summary": "edgeBoundary_card_eq_two_iff combines the gap lemma and the two extreme witnesses into a three-element subset of ∂S to force |∂S| ≥ 3 in the non-interval case, proving the equivalence; discrete_isoperimetric_1d_rigidity repackages it."
+    }
+  ],
+  "conclusion": {
+    "summary": "The equality rigidity of the discrete 1D isoperimetric inequality is fully verified (0 axioms, 0 sorries, ~212 lines): for finite nonempty S ⊆ ℤ, the vertex edge boundary has cardinality exactly 2 iff S is the integer interval [min S, max S]. The forward direction uses a single smallest-gap witness rather than the diameter induction the parent entry anticipated, completing the equality characterization the parent left open.",
+    "openQuestions": [
+      "Quantitative stability: if |∂S| = 2 + 2k, show S has exactly k+1 maximal runs (gaps contribute boundary points additively), and bound the symmetric difference |S △ Icc(min S, max S)| in terms of k — the discrete analogue of Fuglede-type quantitative isoperimetric stability.",
+      "ℤ^d rigidity: characterize the equality cases of the Bollobás–Leader edge-isoperimetric inequality on ℤ^d (cubes / products of intervals) and identify which 1D rigidity ingredients survive the coordinate-slicing induction."
+    ],
+    "implications": "Completes the equality characterization of the base case of the discrete isoperimetric hierarchy, turning the parent's one-sided bound into a sharp 'iff'. This sharp form is the kind of statement that feeds into compression/uniqueness arguments for the higher-dimensional Bollobás–Leader and Harper theorems."
+  },
+  "references": [
+    {
+      "authors": "Harper, L. H.",
+      "title": "Optimal Numberings and Isoperimetric Problems on Graphs",
+      "year": "1966",
+      "venue": "Journal of Combinatorial Theory 1(3), pp. 385–393",
+      "note": "Origin of the compression technique for discrete isoperimetric problems; the 1D equality case formalized here is the base of that hierarchy."
+    },
+    {
+      "authors": "Bollobás, B. and Leader, I.",
+      "title": "Edge-Isoperimetric Inequalities in the Grid",
+      "year": "1991",
+      "venue": "Combinatorica 11(4), pp. 299–314",
+      "note": "Extends Harper's compression to ℤ^d; the equality cases (cubes) are the higher-dimensional analogue of the interval rigidity proved here."
+    },
+    {
+      "authors": "Bollobás, Béla",
+      "title": "Combinatorics: Set Systems, Hypergraphs, Families of Vectors and Combinatorial Probability",
+      "year": "1986",
+      "venue": "Cambridge University Press, Chapter 16 'The Isoperimetric Problem'",
+      "note": "Standard reference for discrete isoperimetric inequalities and their equality characterizations."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "DiscreteIsoperimetric1DRigidity",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/IsoperimetricTheoremOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "isoperimetric-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Supplies the converse uniqueness direction (|∂S| = 2 ⟹ S is an interval) that the parent OQ-02 entry proved one half of and explicitly left open. Reuses the parent's edgeBoundary definition and interval-boundary computation."
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "discrete-analog-of",
+      "description": "Discrete rigidity analogue of the classical isoperimetric uniqueness statement: just as the circle is the unique extremizer of the continuous inequality, integer intervals are the unique minimizers of the vertex edge boundary on ℤ."
+    },
+    {
+      "targetId": "isoperimetric-theorem-oq-01",
+      "relationship": "complements",
+      "description": "Sibling open-question entry covering curved-surface isoperimetric variants; this entry sharpens the discrete-lattice variant to an equality characterization."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **equality rigidity** (converse uniqueness) direction that the parent entry **IsoperimetricTheoremOQ02** explicitly left unformalized.

The parent proved the discrete 1D isoperimetric *inequality* — for finite `S ⊆ ℤ` with `|S| ≥ 2`, the vertex edge boundary satisfies `|∂S| ≥ 2`, with integer intervals achieving equality — but its docstring and open-questions noted:

> *"The full equality characterization — |∂S| = 2 implies S is an interval — holds but is not formalized here ... requires a careful induction on max(S) − min(S)."*

This PR proves the full equivalence, **without** the anticipated diameter induction:

```
theorem edgeBoundary_card_eq_two_iff {S : Finset ℤ} (h : S.Nonempty) :
    (edgeBoundary S).card = 2 ↔ S = Finset.Icc (S.min' h) (S.max' h)
```

## Proof idea

- **(⟸)** For an interval `[a,b]`, `∂(Icc a b) = {a−1, b+1}`, card 2 (re-derived from the parent).
- **(⟹)** Contrapositive. Every finite nonempty `S ⊆ ℤ` satisfies `S ⊆ Icc(min S, max S)`. If `S` is not equal to that interval, the missing set `Icc(min S, max S) \ S` is nonempty; let `g` be its **smallest** element. Then `min S < g < max S` (since `min S, max S ∈ S`), and `g − 1 ∈ S` by minimality. So `g ∈ ∂S`, and `g` is distinct from the two extreme witnesses `min S − 1` and `max S + 1`. The three-element set `{min S − 1, max S + 1, g} ⊆ ∂S` forces `|∂S| ≥ 3`, contradicting 2.

The key simplification: picking the *smallest* gap point makes `g − 1 ∈ S` automatic, replacing the diameter induction with a single `Finset.min'` application.

## Status

- **verified**, 0 axioms (only `propext`, `Classical.choice`, `Quot.sound`), 0 sorries
- 9 theorems/lemmas, 1 definition, 212 lines
- Self-contained (re-derives `edgeBoundary` etc.) so it does not depend on the parent module compiling
- Mathlib v4.26.0; typechecked via `lake env lean`; `#print axioms` confirms 0-axiom

## Note on "boundary = 2·runs"

The candidate's parenthetical "boundary = 2·runs" refers to the *edge-crossing* count, which differs from the *vertex* boundary used by the parent (e.g. `S = {0,2}` has vertex `∂S = {−1,1,3}`, card 3, while the edge count is 4). This PR formalizes the correct vertex-boundary rigidity, for which the clean invariant is the `|∂S| = 2 ⟺ interval` equivalence proved here.

## Files

- `proofs/Proofs/IsoperimetricTheoremOQ02OQ03.lean`
- `src/data/proofs/isoperimetric-theorem-oq-02-oq-03/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)