### PR TITLE
research(derangements-convergence-oq-03-oq-03): second-order sandwich for |D(n) − n!/e| [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -895,6 +895,7 @@ import Proofs.DerangementsConvergenceOQ01OQ01
 import Proofs.DerangementsConvergenceOQ02
 import Proofs.DerangementsConvergenceOQ03
 import Proofs.DerangementsConvergenceOQ03OQ01OQ02
+import Proofs.DerangementsConvergenceOQ03OQ03
 import Proofs.DerangementsOQ02
 import Proofs.DerangementsOQ02OQ01
 import Proofs.DerangementsOQ02OQ02

--- a/proofs/Proofs/DerangementsConvergenceOQ03OQ03.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ03OQ03.lean
@@ -1,0 +1,175 @@
+/-
+  Derangements: effective second-order sandwich for |D(n) - n!/e|
+  Open Question: derangements-convergence-oq-03-oq-03
+
+  The parent (derangements-convergence-oq-03) proved the *rounding* result
+  D(n) = round(n!/e), which only needs the one-sided bound
+    |D(n) - n!/e| ≤ 1/(n+1).
+  This entry sharpens that estimate to a two-sided sandwich, pinning down the
+  error to within an interval of width 1/((n+1)(n+2)):
+
+    1/(n+1) - 1/((n+1)(n+2))  ≤  |D(n) - n!/e|  ≤  1/(n+1).
+
+  ## Main Result
+
+  `derangements_second_order_sandwich` (PROVED, 0-axiom): for every n,
+    1/(n+1) - 1/((n+1)(n+2)) ≤ |↑(numDerangements n) - n! * rexp(-1)| ≤ 1/(n+1).
+
+  (The candidate asked for n ≥ 2; the statement in fact holds for all n. The
+  n ≥ 2 regime is exactly where the lower bound forces the error to be a
+  positive distance away from 1/2, which is what made the rounding result
+  non-trivial.)
+
+  ## Proof Strategy
+
+  Write the exact tail
+    D(n)/n! - rexp(-1) = -(-1)^(n+1) · A,    A := ∑'_k (-1)^k / ((n+1+k)!),
+  so |D(n) - n! rexp(-1)| = n! · A with A ≥ 0.  The alternating series A is
+  controlled by its first two terms:
+    1/(n+1)! - 1/(n+2)!  ≤  A  ≤  1/(n+1)!.
+  Multiplying through by n! gives the sandwich.
+
+  The upper bound A ≤ 1/(n+1)! and nonnegativity A ≥ 0 are repackaged from the
+  parent's `alt_partial_sum_le_first` / `alt_partial_sum_nonneg`.  The new
+  ingredient is the refined lower bound `alt_partial_sum_ge_first_sub_second`:
+  for N ≥ 2 the alternating partial sum exceeds (first term − second term),
+  because the remaining tail is itself a nonnegative alternating sum.
+-/
+
+import Mathlib
+import Proofs.DerangementsConvergence
+
+open Finset Nat Real BigOperators Filter Topology
+
+namespace DerangementsConvergenceOQ03OQ03
+
+/-- The shifted alternating summand `(-1)^k / (m+k)!` is summable.
+    (Mirrors the local computation inside `alternating_tail_bound`.) -/
+lemma summable_shiftedAlt (m : ℕ) :
+    Summable (fun k => (-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+  have hbnd_summable : Summable (fun k => (1 : ℝ) / ((m + k).factorial : ℝ)) := by
+    have h1 : Summable (fun (k : ℕ) => (1 : ℝ) / (k.factorial : ℝ)) := by
+      simpa only [one_pow] using summable_pow_div_factorial (1 : ℝ)
+    exact h1.comp_injective (fun ⦃a b⦄ (h : m + a = m + b) => by omega)
+  exact Summable.of_norm_bounded_eventually hbnd_summable (by
+    filter_upwards with k
+    apply le_of_eq
+    simp only [norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow, Nat.abs_cast])
+
+/-- Refined lower bound on the alternating partial sums: for `N ≥ 2` the partial
+    sum exceeds the first term minus the second.  This is the new ingredient
+    beyond the parent file (which only had `alt_partial_sum_le_first`). -/
+lemma alt_partial_sum_ge_first_sub_second (m N : ℕ) :
+    1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) ≤
+    ∑ k ∈ range (N + 2), ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+  -- Peel the two leading terms; the rest is a nonnegative alternating tail.
+  have hdecomp :
+      ∑ k ∈ range (N + 2), ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) =
+        (1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ)) +
+        ∑ k ∈ range N, ((-1 : ℝ) ^ k / (((m + 2) + k).factorial : ℝ)) := by
+    rw [Finset.sum_range_succ', Finset.sum_range_succ']
+    have hcongr :
+        ∑ k ∈ range N, ((-1 : ℝ) ^ (k + 1 + 1) / ((m + (k + 1 + 1)).factorial : ℝ)) =
+        ∑ k ∈ range N, ((-1 : ℝ) ^ k / (((m + 2) + k).factorial : ℝ)) := by
+      apply Finset.sum_congr rfl
+      intro k _
+      have hpow : (-1 : ℝ) ^ (k + 1 + 1) = (-1 : ℝ) ^ k := by
+        rw [pow_succ, pow_succ]; ring
+      have hidx : m + (k + 1 + 1) = (m + 2) + k := by omega
+      rw [hpow, hidx]
+    rw [hcongr]
+    simp only [Nat.add_zero, Nat.zero_add, pow_zero, pow_one, one_div]
+    ring
+  rw [hdecomp]
+  have hnn := alt_partial_sum_nonneg (m + 2) N
+  linarith
+
+/-- Nonnegativity of the shifted alternating tail `A(m) = ∑'_k (-1)^k/(m+k)!`. -/
+lemma shiftedAlt_tsum_nonneg (m : ℕ) :
+    0 ≤ ∑' k, ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+  apply le_of_tendsto_of_tendsto tendsto_const_nhds
+    (summable_shiftedAlt m).hasSum.tendsto_sum_nat
+  filter_upwards with N
+  exact alt_partial_sum_nonneg m N
+
+/-- Upper bound: `A(m) ≤ 1/m!`. -/
+lemma shiftedAlt_tsum_le_first (m : ℕ) :
+    ∑' k, ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) ≤ 1 / (m.factorial : ℝ) := by
+  apply le_of_tendsto (summable_shiftedAlt m).hasSum.tendsto_sum_nat
+  filter_upwards with N
+  exact alt_partial_sum_le_first m N
+
+/-- Lower bound: `A(m) ≥ 1/m! - 1/(m+1)!`. -/
+lemma shiftedAlt_tsum_ge_first_sub_second (m : ℕ) :
+    1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) ≤
+    ∑' k, ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) := by
+  apply ge_of_tendsto (summable_shiftedAlt m).hasSum.tendsto_sum_nat
+  filter_upwards [eventually_ge_atTop 2] with N hN
+  obtain ⟨M, rfl⟩ : ∃ M, N = M + 2 := ⟨N - 2, by omega⟩
+  exact alt_partial_sum_ge_first_sub_second m M
+
+/-- The signed error `D(n) - n!·e⁻¹` equals `-(-1)^(n+1) · n! · A(n+1)`,
+    hence its absolute value is exactly `n! · A(n+1)`. -/
+lemma abs_error_eq (n : ℕ) :
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| =
+    (n.factorial : ℝ) * ∑' k, ((-1 : ℝ) ^ k / (((n + 1) + k).factorial : ℝ)) := by
+  set A := ∑' k, ((-1 : ℝ) ^ k / (((n + 1) + k).factorial : ℝ)) with hA
+  -- rexp(-1) = partial sum + tail, and tail = (-1)^(n+1) · A
+  have htail : (∑' k, altFactTerm (n + 1 + k)) = (-1 : ℝ) ^ (n + 1) * A := by
+    have hfactor : ∀ k, altFactTerm (n + 1 + k) =
+        (-1 : ℝ) ^ (n + 1) * ((-1 : ℝ) ^ k / (((n + 1) + k).factorial : ℝ)) := by
+      intro k; simp only [altFactTerm]; rw [pow_add]; ring
+    rw [hA]
+    rw [show (∑' k, altFactTerm (n + 1 + k)) =
+        ∑' k, (-1 : ℝ) ^ (n + 1) * ((-1 : ℝ) ^ k / (((n + 1) + k).factorial : ℝ)) from
+      tsum_congr hfactor, tsum_mul_left]
+  -- assemble D(n) - n!·e⁻¹ = -n! · tail
+  have hexp : rexp (-1) = altFactPartialSum n + ∑' k, altFactTerm (n + 1 + k) := by
+    rw [exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail n]
+  have hD : (numDerangements n : ℝ) = (n.factorial : ℝ) * altFactPartialSum n :=
+    numDerangements_eq_factorial_mul_altSum n
+  have hsigned : (numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1) =
+      -((-1 : ℝ) ^ (n + 1) * ((n.factorial : ℝ) * A)) := by
+    rw [hD, hexp, htail]; ring
+  rw [hsigned, abs_neg, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul, abs_mul,
+    Nat.abs_cast, abs_of_nonneg (shiftedAlt_tsum_nonneg (n + 1))]
+
+/-- **Second-order sandwich for the derangement count.**
+    For every `n`,
+      `1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!/e| ≤ 1/(n+1)`.
+    This sharpens the parent rounding bound `|D(n) - n!/e| ≤ 1/(n+1)` with a
+    matching lower bound of the same leading order. -/
+theorem derangements_second_order_sandwich (n : ℕ) :
+    1 / ((n : ℝ) + 1) - 1 / (((n : ℝ) + 1) * ((n : ℝ) + 2)) ≤
+      |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ∧
+    |(numDerangements n : ℝ) - (n.factorial : ℝ) * rexp (-1)| ≤ 1 / ((n : ℝ) + 1) := by
+  rw [abs_error_eq n]
+  set A := ∑' k, ((-1 : ℝ) ^ k / (((n + 1) + k).factorial : ℝ)) with hA
+  have hnpos : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  have hn2pos : (0 : ℝ) < (n : ℝ) + 2 := by positivity
+  have hfact_pos : (0 : ℝ) < (n.factorial : ℝ) := Nat.cast_pos.mpr n.factorial_pos
+  -- factorial ratio identities, m = n+1
+  have hr1 : (n.factorial : ℝ) * (1 / (((n + 1).factorial : ℝ))) = 1 / ((n : ℝ) + 1) := by
+    rw [Nat.factorial_succ]; push_cast; field_simp; try ring
+  have hr2 : (n.factorial : ℝ) * (1 / (((n + 1 + 1).factorial : ℝ))) =
+      1 / (((n : ℝ) + 1) * ((n : ℝ) + 2)) := by
+    rw [Nat.factorial_succ, Nat.factorial_succ]; push_cast; field_simp; try ring
+  constructor
+  · -- lower bound
+    have hlo := shiftedAlt_tsum_ge_first_sub_second (n + 1)
+    rw [← hA] at hlo
+    have : (n.factorial : ℝ) *
+        (1 / (((n + 1).factorial : ℝ)) - 1 / (((n + 1 + 1).factorial : ℝ))) ≤
+        (n.factorial : ℝ) * A := by
+      apply mul_le_mul_of_nonneg_left hlo hfact_pos.le
+    rw [mul_sub, hr1, hr2] at this
+    linarith
+  · -- upper bound
+    have hhi := shiftedAlt_tsum_le_first (n + 1)
+    rw [← hA] at hhi
+    have : (n.factorial : ℝ) * A ≤ (n.factorial : ℝ) * (1 / (((n + 1).factorial : ℝ))) := by
+      apply mul_le_mul_of_nonneg_left hhi hfact_pos.le
+    rw [hr1] at this
+    linarith
+
+end DerangementsConvergenceOQ03OQ03

--- a/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-03/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "derangements-convergence-oq-03-oq-03",
+  "title": "Second-order sandwich for the derangement error |D(n) - n!/e|",
+  "slug": "derangements-convergence-oq-03-oq-03",
+  "description": "Sharpens the parent rounding bound |D(n) - n!/e| ≤ 1/(n+1) to a two-sided estimate 1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!/e| ≤ 1/(n+1), pinning the error to within an interval of width 1/((n+1)(n+2)). The new ingredient is a refined alternating-series lower bound: the partial sum exceeds (first term − second term) because the remaining tail is itself a nonnegative alternating sum. Holds for every n (the candidate asked only for n ≥ 2).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ03OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "alternating-series",
+      "real-analysis",
+      "asymptotics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). The error identity |D(n) - n!·e⁻¹| = n!·A(n+1) is derived from the parent file's exact tail decomposition; the two-sided bounds on the alternating tail A(m) follow from the parent's alt_partial_sum_nonneg / alt_partial_sum_le_first together with the newly proved alt_partial_sum_ge_first_sub_second.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 177,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "derangements_second_order_sandwich (PROVED): for every n, 1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!·e⁻¹| ≤ 1/(n+1) — a two-sided sharpening of the parent's one-sided 1/(n+1) bound, with matching leading order and an explicit gap of width 1/((n+1)(n+2))",
+      "alt_partial_sum_ge_first_sub_second (PROVED): the new alternating-series ingredient — for N ≥ 2, ∑_{k<N+2} (-1)^k/(m+k)! ≥ 1/m! - 1/(m+1)!, proved by peeling the two leading terms and recognising the remaining tail as a nonnegative alternating sum (parent only had the matching upper bound alt_partial_sum_le_first)",
+      "shiftedAlt_tsum_ge_first_sub_second / _le_first / _nonneg (PROVED): the two-sided pin on the shifted alternating tail A(m) = ∑'_k (-1)^k/(m+k)!, namely 1/m! - 1/(m+1)! ≤ A(m) ≤ 1/m! and 0 ≤ A(m), obtained by passing the partial-sum bounds to the limit",
+      "abs_error_eq (PROVED): the exact identity |D(n) - n!·e⁻¹| = n!·A(n+1), isolating the absolute error as n! times a single nonnegative alternating tail"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.summable_pow_div_factorial",
+        "description": "Summability of x^k/k!, used (with x = 1) to bound the shifted alternating series and establish its summability",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exponential"
+      },
+      {
+        "theorem": "ge_of_tendsto / le_of_tendsto",
+        "description": "Passes a uniform bound on partial sums to the limit, turning the partial-sum sandwich into a sandwich on the tsum",
+        "module": "Mathlib.Order.Topology.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the bottom term off a range sum, applied twice to extract the first two alternating terms in alt_partial_sum_ge_first_sub_second",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of derangements D(n) satisfies D(n)/n! → e⁻¹, and the classical rounding theorem D(n) = round(n!/e) rests on the one-sided estimate |D(n) - n!/e| ≤ 1/(n+1) < 1/2 for n ≥ 2. That bound, proved in the parent entry, is the first term of an alternating series; this entry shows the estimate is essentially tight by supplying a lower bound of the same leading order, sandwiching the error between consecutive partial sums of the alternating tail.",
+    "problemStatement": "**OQ-03-03 of derangements-convergence**\n\nSharpen the rounding bound to an effective second-order sandwich: for n ≥ 2,\n\n  1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!/e| ≤ 1/(n+1).",
+    "text": "For every n, 1/(n+1) - 1/((n+1)(n+2)) ≤ |↑(numDerangements n) - n!·rexp(-1)| ≤ 1/(n+1).",
+    "proofStrategy": "Write the exact tail D(n)/n! - e⁻¹ = -(-1)^(n+1)·A with A = ∑'_k (-1)^k/((n+1+k)!) ≥ 0, so |D(n) - n!·e⁻¹| = n!·A (lemma abs_error_eq, built on the parent's tsum_eq_partial_sum_add_tail and numDerangements_eq_factorial_mul_altSum). Bound the alternating tail A on both sides: the upper bound A ≤ 1/(n+1)! and nonnegativity are repackaged from the parent's alt_partial_sum_le_first / alt_partial_sum_nonneg; the lower bound A ≥ 1/(n+1)! - 1/(n+2)! is the new alt_partial_sum_ge_first_sub_second, proved by peeling the two leading terms (Finset.sum_range_succ' twice) and observing that the residual ∑_{k<N} (-1)^k/((m+2)+k)! is nonnegative. Multiplying the tail sandwich by n! and simplifying n!/(n+1)! = 1/(n+1), n!/(n+2)! = 1/((n+1)(n+2)) yields the result.",
+    "keyInsights": [
+      "The absolute error is exactly n! times a single nonnegative alternating tail A(n+1) = ∑_{k≥0} (-1)^k/((n+1+k)!). Both bounds are therefore statements about one alternating series, not about D(n) directly.",
+      "An alternating series with strictly decreasing terms lies between any two consecutive partial sums. The parent used only the crude bound 'tail ≤ first term'; pairing the leading two terms gives the matching lower bound 'tail ≥ first − second', which is the whole content of the sharpening.",
+      "The refined lower bound is structurally identical to the parent's upper bound: peel two terms, then reuse the SAME nonnegativity lemma alt_partial_sum_nonneg on the shifted index m+2. No new analytic machinery is needed — only a different grouping of the alternating tail.",
+      "The bound is sharp to leading order: upper and lower bounds share the term 1/(n+1) and differ by 1/((n+1)(n+2)) = O(1/n²), so the relative gap shrinks like 1/n. This is exactly the resolution at which the rounding theorem operates."
+    ],
+    "prerequisites": [
+      "The parent file Proofs/DerangementsConvergence.lean: numDerangements_eq_factorial_mul_altSum, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail, alt_partial_sum_nonneg, alt_partial_sum_le_first",
+      "Alternating-series intuition: partial sums of a decreasing alternating series bracket the limit",
+      "Passing inequalities to limits via ge_of_tendsto / le_of_tendsto"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring stating the second-order sandwich, the proof strategy, and how the new lower bound complements the parent's upper bound. Imports Mathlib and the parent Proofs.DerangementsConvergence; opens its namespace to reuse the tail machinery.",
+      "mathContext": "The error |D(n) - n!/e| is the absolute value of the alternating tail $\\sum_{k\\ge 0} (-1)^k/((n+1+k)!)$ scaled by $n!$."
+    },
+    {
+      "id": "sec-summable",
+      "title": "Summability of the Shifted Alternating Series",
+      "startLine": 48,
+      "endLine": 62,
+      "summary": "summable_shiftedAlt: the summand (-1)^k/(m+k)! is summable, by comparison with the summable 1/k! (reindexed). Mirrors the local computation inside the parent's alternating_tail_bound.",
+      "mathContext": "$\\sum_k 1/(m+k)!$ converges (a tail of $\\sum 1/k! = e$), dominating $|(-1)^k/(m+k)!|$."
+    },
+    {
+      "id": "sec-lower-partial",
+      "title": "Refined Lower Bound on Alternating Partial Sums (new)",
+      "startLine": 64,
+      "endLine": 88,
+      "summary": "alt_partial_sum_ge_first_sub_second: for N ≥ 2, ∑_{k<N+2} (-1)^k/(m+k)! ≥ 1/m! - 1/(m+1)!. Peels the two leading terms via Finset.sum_range_succ' (twice), rewrites the residual as ∑_{k<N} (-1)^k/((m+2)+k)!, and closes with the parent's alt_partial_sum_nonneg on the shifted index.",
+      "mathContext": "$S_{N} = (1/m! - 1/(m+1)!) + \\sum_{k<N-2} (-1)^k/((m+2)+k)!$, and the residual alternating sum is $\\ge 0$."
+    },
+    {
+      "id": "sec-tail-bounds",
+      "title": "Two-Sided Bounds on the Tail A(m)",
+      "startLine": 90,
+      "endLine": 113,
+      "summary": "shiftedAlt_tsum_nonneg, shiftedAlt_tsum_le_first, shiftedAlt_tsum_ge_first_sub_second: pass the partial-sum bounds to the limit (ge_of_tendsto / le_of_tendsto) to obtain 0 ≤ A(m), A(m) ≤ 1/m!, and 1/m! - 1/(m+1)! ≤ A(m).",
+      "mathContext": "$1/m! - 1/(m+1)! \\le A(m) := \\sum_{k\\ge 0} (-1)^k/(m+k)! \\le 1/m!$."
+    },
+    {
+      "id": "sec-error-identity",
+      "title": "Exact Error Identity",
+      "startLine": 115,
+      "endLine": 142,
+      "summary": "abs_error_eq: |D(n) - n!·e⁻¹| = n!·A(n+1). Uses the parent's tail decomposition rexp(-1) = partialSum n + tail, factors the tail as (-1)^(n+1)·A(n+1), and takes absolute values using A(n+1) ≥ 0.",
+      "mathContext": "$D(n) - n!\\,e^{-1} = -(-1)^{n+1}\\,n!\\,A(n+1)$, so $|D(n) - n!\\,e^{-1}| = n!\\,A(n+1)$."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorem: Second-Order Sandwich",
+      "startLine": 144,
+      "endLine": 177,
+      "summary": "derangements_second_order_sandwich: combines the error identity with the two-sided tail bounds, multiplies by n!, and simplifies the factorial ratios n!/(n+1)! = 1/(n+1), n!/(n+2)! = 1/((n+1)(n+2)) to deliver the sandwich for every n.",
+      "mathContext": "Multiplying $1/(n+1)! - 1/(n+2)! \\le A(n+1) \\le 1/(n+1)!$ by $n!$ gives $1/(n+1) - 1/((n+1)(n+2)) \\le |D(n)-n!/e| \\le 1/(n+1)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry: proves D(n) = round(n!/e) from the one-sided bound |D(n) - n!/e| ≤ 1/(n+1). This entry adds the matching lower bound, sharpening that estimate to a two-sided sandwich."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "foundational",
+      "description": "Supplies the alternating-tail infrastructure reused here: numDerangements_eq_factorial_mul_altSum, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail, alt_partial_sum_nonneg, alt_partial_sum_le_first."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03-oq-02",
+      "relationship": "sibling",
+      "description": "Companion sharpening of the same recurrence in the discrete/modular direction (exact ±1 one-term remainder); this entry sharpens the analytic 1/(n+1) error estimate instead."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified (0 sorries, 0 axioms beyond foundational): the derangement error is sandwiched as 1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!/e| ≤ 1/(n+1) for every n, sharpening the parent's one-sided rounding bound to a two-sided estimate of matching leading order. The single new analytic ingredient is the refined alternating-series lower bound alt_partial_sum_ge_first_sub_second.",
+    "implications": "The sandwich localises the error to an interval of width 1/((n+1)(n+2)) = O(1/n²) around 1/(n+1), so |D(n) - n!/e| → 0 at the exact rate 1/(n+1) with a quantified second-order correction. In particular the error is never zero and stays a definite positive distance below 1/2 for n ≥ 2, re-proving (and quantifying) the rounding theorem.",
+    "openQuestions": [
+      "Extend the alternating grouping to k leading terms to obtain an asymptotic expansion |D(n) - n!/e| = 1/(n+1) - 1/((n+1)(n+2)) + 1/((n+1)(n+2)(n+3)) - ··· with explicit truncation error of the next order.",
+      "Derive the analogous two-sided sandwich for the generalised derangement / rencontres numbers D(n,r) and their convergence to e⁻¹ times a Laguerre value."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "derangements_second_order_sandwich",
+      "type": "core",
+      "description": "Two-sided sandwich: 1/(n+1) - 1/((n+1)(n+2)) ≤ |D(n) - n!·e⁻¹| ≤ 1/(n+1) for every n",
+      "leanType": "(n : ℕ) → 1/((n:ℝ)+1) - 1/(((n:ℝ)+1)*((n:ℝ)+2)) ≤ |(numDerangements n : ℝ) - n.factorial * rexp (-1)| ∧ |(numDerangements n : ℝ) - n.factorial * rexp (-1)| ≤ 1/((n:ℝ)+1)"
+    },
+    {
+      "name": "abs_error_eq",
+      "type": "core",
+      "description": "Exact error identity: |D(n) - n!·e⁻¹| = n! · A(n+1) with A the shifted alternating tail",
+      "leanType": "(n : ℕ) → |(numDerangements n : ℝ) - n.factorial * rexp (-1)| = n.factorial * ∑' k, (-1)^k / (((n+1)+k).factorial : ℝ)"
+    },
+    {
+      "name": "alt_partial_sum_ge_first_sub_second",
+      "type": "supporting",
+      "description": "New alternating-series lower bound: ∑_{k<N+2} (-1)^k/(m+k)! ≥ 1/m! - 1/(m+1)!",
+      "leanType": "(m N : ℕ) → 1/(m.factorial : ℝ) - 1/((m+1).factorial : ℝ) ≤ ∑ k ∈ Finset.range (N+2), (-1)^k / ((m+k).factorial : ℝ)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Real",
+      "BigOperators",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ03OQ03",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsConvergenceOQ03OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "Origin of the derangement count and its expansion D(n) = n! Σ (-1)^k/k!, whose alternating tail is bounded two-sidedly here."
+    },
+    {
+      "authors": "Riordan, John",
+      "title": "An Introduction to Combinatorial Analysis",
+      "year": "1958",
+      "venue": "Wiley, Chapter 3 §3",
+      "note": "Classic treatment of derangements, the rounding identity D(n) = round(n!/e), and the alternating-series error estimate sharpened in this entry."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sharpens the parent rounding bound `|D(n) − n!/e| ≤ 1/(n+1)` (entry `derangements-convergence-oq-03`, which proves `D(n) = round(n!/e)`) to a **two-sided sandwich**:

$$\frac{1}{n+1} - \frac{1}{(n+1)(n+2)} \;\le\; \left|D(n) - \frac{n!}{e}\right| \;\le\; \frac{1}{n+1}.$$

This localises the derangement error to an interval of width `1/((n+1)(n+2)) = O(1/n²)` around `1/(n+1)`, so the estimate is sharp to leading order. **The result holds for every `n`** — the open question asked only for `n ≥ 2`.

## What's new vs. the parent

The parent only needed the crude one-sided bound `tail ≤ first term`. The new ingredient is the matching **lower** bound:

- `alt_partial_sum_ge_first_sub_second` — for `N ≥ 2`, an alternating partial sum exceeds `(first term − second term)`, proved by peeling the two leading terms (`Finset.sum_range_succ'` twice) and recognising the residual `∑ (-1)^k/((m+2)+k)!` as a nonnegative alternating sum (reusing the parent's `alt_partial_sum_nonneg`).
- `abs_error_eq` — the exact identity `|D(n) − n!·e⁻¹| = n!·A(n+1)`, isolating the absolute error as `n!` times a single nonnegative alternating tail `A(m) = ∑ₖ (-1)^k/(m+k)!`.
- `derangements_second_order_sandwich` — the main result; multiplies the two-sided tail bound by `n!` and simplifies `n!/(n+1)! = 1/(n+1)`, `n!/(n+2)! = 1/((n+1)(n+2))`.

## Verification

- Builds clean against Mathlib (Lean v4.26.0): `Built Proofs.DerangementsConvergenceOQ03OQ03`.
- `#print axioms derangements_second_order_sandwich` → `propext, Classical.choice, Quot.sound` only.
- 0 sorries, 0 axioms by policy. 7 lemmas/theorems, 177 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)