### PR TITLE
research(subset-count-oq-04): even-subset count = odd-subset count = 2^(n−1) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3682,6 +3682,7 @@ import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02
 import Proofs.SubsetCountOQ02OQ01
 import Proofs.SubsetCountOQ02OQ02
+import Proofs.SubsetCountOQ04
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ04

--- a/proofs/Proofs/SubsetCountOQ04.lean
+++ b/proofs/Proofs/SubsetCountOQ04.lean
@@ -1,0 +1,229 @@
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Tactic
+
+/-!
+# Even and Odd Subset Counts Are Equal — 2^(n−1) Each
+
+## What This Proves
+For a finite set with `n ≥ 1` elements, the number of subsets of *even* cardinality
+equals the number of subsets of *odd* cardinality, and each count is `2^(n-1)`:
+
+$$
+\#\{T \subseteq S : |T| \text{ even}\}
+  = \#\{T \subseteq S : |T| \text{ odd}\}
+  = 2^{n-1}\qquad(n\ge 1).
+$$
+
+Equivalently, splitting Pascal's row by parity,
+$$
+\sum_{k\ \text{even}}\binom{n}{k}
+  = \sum_{k\ \text{odd}}\binom{n}{k}
+  = 2^{n-1}\qquad(n\ge 1).
+$$
+
+## Approach
+The result is the cleanest consequence of the alternating binomial identity
+`∑ₖ (-1)ᵏ C(n,k) = 0` (for `n > 0`). Writing `E = ∑_{k even} C(n,k)` and
+`O = ∑_{k odd} C(n,k)`:
+
+* `E + O = 2ⁿ`           (`Nat.sum_range_choose`),
+* `E − O = 0`            (`Int.alternating_sum_range_choose_of_ne`, since the
+  signed sum splits as `E − O` after evaluating `(-1)ᵏ` on each parity class),
+
+so `2E = 2ⁿ` and `E = O = 2^(n-1)`.  The signed/unsigned reconciliation is done
+in `ℤ`, then transported back to `ℕ`.
+
+For the set-theoretic ("powerset") formulation we give the canonical
+**sign-reversing involution**: toggling membership of a fixed element `a ∈ s`
+(`t ↦ t.erase a` or `t ↦ insert a t`) is a bijection between the even- and
+odd-cardinality subsets, proving the two counts equal without binomial
+coefficients.  Combined with `Finset.card_powerset` this pins each count at
+`2^(n-1)`.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms
+- [x] Binomial-sum form (`even_choose_sum`, `odd_choose_sum`, `even_eq_odd_choose_sum`)
+- [x] Powerset form via involution (`card_even_subsets`, `card_odd_subsets`,
+      `card_even_eq_card_odd_subsets`)
+
+## Mathlib Dependencies
+- `Nat.sum_range_choose` : `∑ k ∈ range (n+1), C(n,k) = 2ⁿ`
+- `Int.alternating_sum_range_choose_of_ne` : `∑ k ∈ range (n+1), (-1)ᵏ C(n,k) = 0` for `n ≠ 0`
+- `Finset.card_powerset` : `#(s.powerset) = 2^(#s)`
+-/
+
+open Finset
+
+namespace SubsetCountOQ04
+
+/-- `2ⁿ = 2 · 2^(n-1)` for `n ≥ 1` (in `ℤ`). -/
+private lemma two_pow_split (n : ℕ) (hn : 1 ≤ n) : (2 : ℤ) ^ n = 2 * 2 ^ (n - 1) := by
+  rw [← pow_succ']
+  congr 1
+  omega
+
+/-- **Parity split of Pascal's row (integer form).**
+Both the even-indexed and the odd-indexed (here `¬ Even`) partial sums of row `n`
+equal `2^(n-1)`, for `n ≥ 1`. -/
+private lemma choose_parity_int (n : ℕ) (hn : 1 ≤ n) :
+    (∑ k ∈ (range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)) = 2 ^ (n - 1) ∧
+    (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ)) = 2 ^ (n - 1) := by
+  have hn0 : n ≠ 0 := by omega
+  -- E + O = 2ⁿ
+  have htot :
+      (∑ k ∈ (range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)) +
+        (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ)) = 2 ^ n := by
+    rw [Finset.sum_filter_add_sum_filter_not, ← Nat.cast_sum, Nat.sum_range_choose]
+    push_cast; ring
+  -- E − O = 0, via the alternating sum
+  have hdiff :
+      (∑ k ∈ (range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)) -
+        (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ)) = 0 := by
+    have hev :
+        (∑ k ∈ (range (n + 1)).filter (fun k => Even k), (-1 : ℤ) ^ k * (n.choose k)) =
+          ∑ k ∈ (range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ) := by
+      refine Finset.sum_congr rfl (fun k hk => ?_)
+      rw [Finset.mem_filter] at hk
+      rw [hk.2.neg_one_pow, one_mul]
+    have hod :
+        (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (-1 : ℤ) ^ k * (n.choose k)) =
+          - ∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ) := by
+      rw [← neg_one_mul (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ)),
+        Finset.mul_sum]
+      refine Finset.sum_congr rfl (fun k hk => ?_)
+      rw [Finset.mem_filter] at hk
+      rw [(Nat.not_even_iff_odd.mp hk.2).neg_one_pow]
+    have key :
+        (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k)) =
+          (∑ k ∈ (range (n + 1)).filter (fun k => Even k), (n.choose k : ℤ)) -
+            (∑ k ∈ (range (n + 1)).filter (fun k => ¬ Even k), (n.choose k : ℤ)) := by
+      rw [← Finset.sum_filter_add_sum_filter_not (range (n + 1)) (fun k => Even k)
+            (fun k => (-1 : ℤ) ^ k * (n.choose k)), hev, hod]
+      ring
+    rw [Int.alternating_sum_range_choose_of_ne hn0] at key
+    linarith
+  have h2 : (2 : ℤ) ^ n = 2 * 2 ^ (n - 1) := two_pow_split n hn
+  refine ⟨by linarith, by linarith⟩
+
+/-- **Even-indexed half of Pascal's row.** The sum of binomial coefficients
+`C(n,k)` over even `k` equals `2^(n-1)` for `n ≥ 1`. -/
+theorem even_choose_sum (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ (range (n + 1)).filter (fun k => Even k), n.choose k = 2 ^ (n - 1) := by
+  have h := (choose_parity_int n hn).1
+  rw [← Nat.cast_sum] at h
+  exact_mod_cast h
+
+/-- **Odd-indexed half of Pascal's row.** The sum of binomial coefficients
+`C(n,k)` over odd `k` equals `2^(n-1)` for `n ≥ 1`. -/
+theorem odd_choose_sum (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ (range (n + 1)).filter (fun k => Odd k), n.choose k = 2 ^ (n - 1) := by
+  have hfilt :
+      (range (n + 1)).filter (fun k => Odd k) =
+        (range (n + 1)).filter (fun k => ¬ Even k) :=
+    Finset.filter_congr (fun k _ => Nat.not_even_iff_odd.symm)
+  rw [hfilt]
+  have h := (choose_parity_int n hn).2
+  rw [← Nat.cast_sum] at h
+  exact_mod_cast h
+
+/-- **Even = Odd (binomial form).** The even- and odd-indexed partial sums of
+Pascal's row `n` coincide, for `n ≥ 1`. -/
+theorem even_eq_odd_choose_sum (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ (range (n + 1)).filter (fun k => Even k), n.choose k =
+      ∑ k ∈ (range (n + 1)).filter (fun k => Odd k), n.choose k := by
+  rw [even_choose_sum n hn, odd_choose_sum n hn]
+
+/-! ## Powerset (set-theoretic) form via a sign-reversing involution -/
+
+variable {α : Type*} [DecidableEq α]
+
+/-- Toggle membership of `a` in `t`: remove it if present, insert it otherwise.
+This is the canonical involution underlying the even/odd subset count. -/
+private def toggle (a : α) (t : Finset α) : Finset α :=
+  if a ∈ t then t.erase a else insert a t
+
+private lemma toggle_involutive (a : α) (t : Finset α) : toggle a (toggle a t) = t := by
+  unfold toggle
+  by_cases h : a ∈ t
+  · simp [h, Finset.insert_erase]
+  · simp [h]
+
+private lemma toggle_subset {s : Finset α} {a : α} (ha : a ∈ s) {t : Finset α}
+    (ht : t ⊆ s) : toggle a t ⊆ s := by
+  unfold toggle
+  by_cases h : a ∈ t
+  · simp only [h, if_true]
+    exact (Finset.erase_subset a t).trans ht
+  · simp only [h, if_false]
+    exact Finset.insert_subset ha ht
+
+/-- Toggling flips the parity of the cardinality. -/
+private lemma toggle_card_flip (a : α) (t : Finset α) :
+    Even (toggle a t).card ↔ ¬ Even t.card := by
+  unfold toggle
+  by_cases h : a ∈ t
+  · simp only [h, if_true, Finset.card_erase_of_mem h]
+    have hpos : 1 ≤ t.card := Finset.card_pos.mpr ⟨a, h⟩
+    rw [Nat.even_sub hpos]
+    have : ¬ Even 1 := by decide
+    tauto
+  · simp only [h, if_false, Finset.card_insert_of_notMem h]
+    exact Nat.even_add_one
+
+/-- **Even = Odd (powerset form).** For any nonempty finite carrier (witnessed by
+`a ∈ s`), toggling `a` is a bijection between even- and odd-cardinality subsets,
+so the two counts are equal. -/
+theorem card_even_eq_card_odd_subsets {s : Finset α} {a : α} (ha : a ∈ s) :
+    (s.powerset.filter (fun t => Even t.card)).card =
+      (s.powerset.filter (fun t => ¬ Even t.card)).card := by
+  apply Finset.card_nbij' (toggle a) (toggle a)
+  · intro t ht
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_powerset] at ht ⊢
+    exact ⟨toggle_subset ha ht.1, fun hc => (toggle_card_flip a t).mp hc ht.2⟩
+  · intro t ht
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_powerset] at ht ⊢
+    exact ⟨toggle_subset ha ht.1, (toggle_card_flip a t).mpr ht.2⟩
+  · intro t _; exact toggle_involutive a t
+  · intro t _; exact toggle_involutive a t
+
+/-- **Count of even-cardinality subsets.** A finite set with `≥ 1` element
+(witnessed by `a ∈ s`) has exactly `2^(#s - 1)` subsets of even cardinality. -/
+theorem card_even_subsets {s : Finset α} {a : α} (ha : a ∈ s) :
+    (s.powerset.filter (fun t => Even t.card)).card = 2 ^ (s.card - 1) := by
+  have hsplit :=
+    Finset.filter_card_add_filter_neg_card_eq_card (s := s.powerset) (p := fun t => Even t.card)
+  rw [Finset.card_powerset] at hsplit
+  have heq := card_even_eq_card_odd_subsets ha
+  have hpos : 1 ≤ s.card := Finset.card_pos.mpr ⟨a, ha⟩
+  have h2 : 2 ^ s.card = 2 * 2 ^ (s.card - 1) := by rw [← pow_succ']; congr 1; omega
+  omega
+
+/-- **Count of odd-cardinality subsets.** A finite set with `≥ 1` element
+(witnessed by `a ∈ s`) has exactly `2^(#s - 1)` subsets of odd cardinality. -/
+theorem card_odd_subsets {s : Finset α} {a : α} (ha : a ∈ s) :
+    (s.powerset.filter (fun t => Odd t.card)).card = 2 ^ (s.card - 1) := by
+  have hfilt : s.powerset.filter (fun t => Odd t.card) =
+      s.powerset.filter (fun t => ¬ Even t.card) :=
+    Finset.filter_congr (fun t _ => Nat.not_even_iff_odd.symm)
+  rw [hfilt]
+  have hE := card_even_subsets ha
+  have hsplit :=
+    Finset.filter_card_add_filter_neg_card_eq_card (s := s.powerset) (p := fun t => Even t.card)
+  rw [Finset.card_powerset] at hsplit
+  have hpos : 1 ≤ s.card := Finset.card_pos.mpr ⟨a, ha⟩
+  have h2 : 2 ^ s.card = 2 * 2 ^ (s.card - 1) := by rw [← pow_succ']; congr 1; omega
+  omega
+
+/-! ## Sanity checks -/
+
+/-- For `n = 3`: even-indexed sum `C(3,0)+C(3,2) = 1 + 3 = 4 = 2²`. -/
+example : ∑ k ∈ (range 4).filter (fun k => Even k), Nat.choose 3 k = 4 := by decide
+
+/-- For `n = 3`: odd-indexed sum `C(3,1)+C(3,3) = 3 + 1 = 4 = 2²`. -/
+example : ∑ k ∈ (range 4).filter (fun k => Odd k), Nat.choose 3 k = 4 := by decide
+
+/-- The three-element set `{0,1,2}` has `4 = 2²` even-cardinality subsets. -/
+example : (({0, 1, 2} : Finset ℕ).powerset.filter (fun t => Even t.card)).card = 4 := by decide
+
+end SubsetCountOQ04

--- a/src/data/proofs/subset-count-oq-04/meta.json
+++ b/src/data/proofs/subset-count-oq-04/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "subset-count-oq-04",
+  "title": "Even and Odd Subset Counts Are Equal — 2^(n−1) Each",
+  "slug": "subset-count-oq-04",
+  "description": "For a finite set with n ≥ 1 elements, the number of even-cardinality subsets equals the number of odd-cardinality subsets, and each count is 2^(n−1). Proved in two complementary ways: a binomial-sum form splitting Pascal's row by parity (∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1)) via the alternating identity ∑_k (−1)^k C(n,k) = 0, and a set-theoretic form via the canonical sign-reversing involution that toggles a fixed element, bijecting even- and odd-cardinality subsets.",
+  "meta": {
+    "author": "Classical; formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Combinatorial_proof",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SubsetCountOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "parity",
+      "powerset",
+      "involution",
+      "research",
+      "open-question"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "defCount": 1,
+    "lineCount": 229,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "∑ k ∈ range (n+1), C(n,k) = 2^n — the full binomial row sums to 2^n",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Int.alternating_sum_range_choose_of_ne",
+        "description": "∑ k ∈ range (n+1), (−1)^k C(n,k) = 0 for n ≠ 0 — the alternating binomial identity",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Finset.card_powerset",
+        "description": "#(s.powerset) = 2^(#s) — cardinality of the powerset",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.card_nbij'",
+        "description": "Two finsets have equal cardinality given mutually inverse maps between them (used for the toggle involution)",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "even_choose_sum / odd_choose_sum: each parity-restricted half of Pascal's row n equals 2^(n−1) for n ≥ 1, packaged as a single Mathlib-free statement (Mathlib has the full row sum and the alternating sum, but not this split)",
+      "choose_parity_int: the integer-level engine reconciling the unsigned sum (E + O = 2^n) with the alternating sum (E − O = 0) to force E = O = 2^(n−1), with the ℤ/ℕ casting handled cleanly",
+      "card_even_eq_card_odd_subsets: the canonical sign-reversing involution (toggle a fixed element a ∈ s) realized as an explicit Finset bijection, proving #even = #odd directly without binomial coefficients",
+      "card_even_subsets / card_odd_subsets: each subset-parity count pinned at 2^(n−1) by combining the involution with Finset.card_powerset",
+      "toggle_card_flip: the parity-flip lemma showing erasing/inserting a fixed element always changes cardinality parity, the combinatorial heart of the involution"
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Subset counting |P(S)| = 2^n (parent entry)",
+      "Binomial coefficients and Pascal's row",
+      "The alternating binomial identity ∑_k (−1)^k C(n,k) = 0",
+      "Finset powerset, filter, and cardinality bijections"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That a nonempty finite set has exactly as many even-sized subsets as odd-sized subsets — each being half the total, 2^(n−1) — is one of the oldest non-trivial facts of enumerative combinatorics and the textbook first example of two contrasting proof styles. The algebraic proof reads it off the binomial theorem at x = −1: (1−1)^n = ∑_k (−1)^k C(n,k) = 0, so the even-indexed and odd-indexed coefficients balance. The bijective proof exhibits the balance directly through a sign-reversing involution: fix any element a and toggle its membership; this pairs each even subset with an odd one. The empty set is the degenerate exception (its only subset, ∅, has even size 0), which is exactly why n ≥ 1 is required. The involution argument is the prototype for inclusion–exclusion parity cancellation and for the combinatorial proofs of identities throughout Stanley's Enumerative Combinatorics.",
+    "problemStatement": "For a finite set S with |S| = n ≥ 1, show that #{T ⊆ S : |T| even} = #{T ⊆ S : |T| odd} = 2^(n−1); equivalently ∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1).",
+    "text": "A 229-line formalization proving the even/odd subset count identity in both its binomial-sum and set-theoretic forms, with 0 sorries and 0 axioms. The binomial form is derived by reconciling the full row sum with the alternating sum; the powerset form is derived from the canonical element-toggling involution.",
+    "proofStrategy": "Two independent routes. (1) Binomial form: let E = ∑_{k even} C(n,k) and O = ∑_{k odd} C(n,k). Splitting range(n+1) by the predicate `Even k`, the unsigned sum gives E + O = 2^n (Nat.sum_range_choose) while the alternating sum ∑_k (−1)^k C(n,k) = 0 (Int.alternating_sum_range_choose_of_ne) evaluates to E − O after replacing (−1)^k with ±1 on each parity class. Hence 2E = 2^n and E = O = 2^(n−1). The signed/unsigned reconciliation is done in ℤ and transported back to ℕ by Nat.cast injectivity. (2) Powerset form: for a witness a ∈ s, the map t ↦ (if a ∈ t then t.erase a else insert a t) is its own inverse (an involution), stays inside s, and flips the parity of |t| (erasing decreases the card by one, inserting increases it by one). It is therefore a bijection between even- and odd-cardinality subsets, so the two counts are equal; combined with #(s.powerset) = 2^(#s) each equals 2^(#s − 1).",
+    "keyInsights": [
+      "**Two proofs, one fact**: The algebraic proof (evaluate the binomial theorem at −1) and the bijective proof (toggle a fixed element) are the canonical illustration that the same combinatorial identity can be both *computed* and *witnessed*. This entry formalizes both and shows they reach the identical 2^(n−1).",
+      "**The alternating sum IS the difference E − O**: Splitting Pascal's row by parity turns the signed identity ∑_k (−1)^k C(n,k) = 0 into the statement E = O. The unsigned identity ∑_k C(n,k) = 2^n then supplies E + O, and the two together pin both halves — no separate evaluation of either half is needed.",
+      "**Toggling flips parity, unconditionally**: The combinatorial core (toggle_card_flip) is that adding or removing a single fixed element always changes |t| by exactly one, hence flips its parity regardless of whether the element was present. This is what makes the toggle a perfect even↔odd pairing.",
+      "**Why n ≥ 1 is essential**: For n = 0 the set has a single subset (∅, even-sized), so even-count = 1 and odd-count = 0 — the involution has no fixed element a to toggle, and 2^(n−1) = 2^(−1) is undefined over ℕ. The hypothesis a ∈ s (equivalently 1 ≤ #s) is precisely what powers the argument."
+    ],
+    "prerequisites": [
+      "Subset counting |P(S)| = 2^n",
+      "Binomial coefficients and the alternating binomial identity",
+      "Finset powerset, filter, and cardinality bijections",
+      "Even/odd parity arithmetic over ℕ"
+    ]
+  },
+  "conclusion": {
+    "summary": "For n ≥ 1 the even- and odd-cardinality subsets of an n-set each number exactly 2^(n−1). The result is proved twice: algebraically, by reconciling ∑_k C(n,k) = 2^n with ∑_k (−1)^k C(n,k) = 0 to get ∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1); and bijectively, via the canonical element-toggling involution on the powerset. 11 theorems/lemmas, 1 definition, 0 sorries, 0 axioms.",
+    "implications": "The element-toggling involution is the base case behind inclusion–exclusion parity cancellation: the same sign-reversing pairing that balances even and odd subsets underlies the vanishing of alternating sums throughout combinatorics. The binomial form is the n-th row instance of evaluating a generating function at −1.",
+    "openQuestions": [
+      "Weighted refinement: for a fixed subset size constraint, characterize when ∑_{k even} C(n,k) x^k − ∑_{k odd} C(n,k) x^k = (1−x)^n factors detect parity, and formalize the q-analogue using Gaussian binomial coefficients.",
+      "Generalize the toggling involution to a group action: the cyclic group Z/2 acting by toggling a fixed element is the simplest case of a finite group acting on the powerset; relate the even/odd balance to Burnside-style orbit counting.",
+      "Prove the signed analogue ∑_{T ⊆ S} (−1)^{|T|} = [S = ∅] directly from the same involution (it equals #even − #odd) and connect it to the Möbius function of the Boolean lattice."
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Sign-reversing involutions and parity arguments"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "subset-count",
+      "relationship": "extends",
+      "description": "Refines the count |P(S)| = 2^n by splitting the powerset according to the parity of subset size, showing each parity class has exactly half the subsets."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SubsetCountOQ04",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/SubsetCountOQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "even_eq_odd_choose_sum",
+      "type": "core",
+      "description": "The even- and odd-indexed partial sums of Pascal's row n coincide (binomial form), for n ≥ 1",
+      "leanType": "∑ k ∈ (range (n+1)).filter (Even ·), n.choose k = ∑ k ∈ (range (n+1)).filter (Odd ·), n.choose k"
+    },
+    {
+      "name": "card_even_subsets",
+      "type": "core",
+      "description": "A finite set with a ∈ s has exactly 2^(#s − 1) even-cardinality subsets",
+      "leanType": "(s.powerset.filter (fun t => Even t.card)).card = 2 ^ (s.card - 1)"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

For a finite set with `n ≥ 1` elements, the number of **even-cardinality** subsets equals the number of **odd-cardinality** subsets, and each count is `2^(n−1)`. Answers the `subset-count-oq-04` open question, proved in two complementary ways.

### Binomial-sum form
```
∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1)   (n ≥ 1)
```
Let `E`, `O` be the even/odd halves of Pascal's row. Splitting `range (n+1)` by parity:
- `E + O = 2^n`  (`Nat.sum_range_choose`)
- `E − O = 0`  (`Int.alternating_sum_range_choose_of_ne`, after evaluating `(−1)^k` on each parity class)

so `2E = 2^n` and `E = O = 2^(n−1)`. The signed/unsigned reconciliation is done in `ℤ` and transported back to `ℕ`.

### Powerset (set-theoretic) form
The canonical **sign-reversing involution** — toggle a fixed element `a ∈ s` (`t ↦ if a∈t then t.erase a else insert a t`) — is its own inverse, stays inside `s`, and flips the parity of `|t|`. It is therefore a bijection between even- and odd-cardinality subsets (`card_even_eq_card_odd_subsets`); combined with `Finset.card_powerset` each count equals `2^(#s−1)` (`card_even_subsets`, `card_odd_subsets`).

## Verification
- **0 sorries, 0 axioms** — all six public theorems depend only on `propext`/`Classical.choice`/`Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiles against Mathlib v4.26.0.
- 6 theorems + 5 lemmas + 1 def, 229 lines.

## Files
- `proofs/Proofs/SubsetCountOQ04.lean` — the proof
- `proofs/Proofs.lean` — aggregator import
- `src/data/proofs/subset-count-oq-04/meta.json` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)