### PR TITLE
Enrich Reflection-Fixed Colorings of an Even Cycle (burnside-counting-oq-05-oq-01)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-05-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-bc0501-header",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 3, "endLine": 41 },
+    "type": "concept",
+    "title": "Even cycles have two reflection types",
+    "content": "The even-n counterpart of oq-05 (odd case). For a cycle of n = 2m positions, the dihedral group D_n has two geometrically distinct conjugacy classes of reflections that fix DIFFERENT numbers of k-colorings. Vertex-axis reflections (through two opposite vertices, modelled as i ↦ −i on ZMod(2m)) fix the two beads {0, m} and fix k^(n/2+1) colorings; edge-axis reflections (through two opposite edge-midpoints, modelled as i ↦ −1−i) have no fixed beads and fix only k^(n/2). The odd case has a single reflection type (k^((n+1)/2)); the even case splitting into two unequal types is the whole point and answers oq-05's lead open question.",
+    "mathContext": "Vertex axis: $k^{n/2+1}$ (fixes $\\{0,m\\}$, $m+1$ orbits). Edge axis: $k^{n/2}$ (fixed-point-free, $m$ orbits). $k^{n/2} < k^{n/2+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["dihedral group", "Burnside / Cauchy–Frobenius lemma", "necklace counting", "reflection conjugacy classes", "Pólya enumeration"],
+    "prerequisites": ["group actions", "dihedral symmetry", "ZMod n"]
+  },
+  {
+    "id": "ann-bc0501-fold1",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 57, "endLine": 97 },
+    "type": "technique",
+    "title": "Vertex axis: fundamental domain and folding",
+    "content": "The negation involution i ↦ −i on ZMod(2m) fixes exactly {0, m} (solutions of 2i = 0), so its fundamental domain is {0,…,m} = Fin(m+1). `incl1` includes a representative; `fold1 i = min(i.val, 2m−i.val)` folds any position to its orbit representative. Three facts make this a fundamental domain: `fold1_incl1` (fold ∘ incl = id), `fold1_neg` (fold is reflection-invariant, fold(−i) = fold(i), proved via `ZMod.neg_val`'s value description), and `incl1_fold1` (incl(fold i) returns i or its mirror −i).",
+    "mathContext": "$\\mathrm{fold}_1(i) = \\min(i.\\mathrm{val},\\, 2m - i.\\mathrm{val})$; fixed set $\\{i : 2i = 0\\} = \\{0, m\\}$; $\\mathrm{fold}_1(-i) = \\mathrm{fold}_1(i)$ via $(-i).\\mathrm{val} = 2m - i.\\mathrm{val}$ (for $i \\ne 0$).",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental domain", "orbit representative", "involution fixed points", "ZMod.neg_val", "section of an inclusion"],
+    "prerequisites": ["ZMod.val arithmetic", "Fin", "involutions"]
+  },
+  {
+    "id": "ann-bc0501-vertex-count",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 98, "endLine": 124 },
+    "type": "theorem",
+    "title": "Vertex-axis count: k^(m+1)",
+    "content": "`vertexInvariantEquiv` is the explicit bijection between reflection-invariant colorings {c : ZMod(2m) → Fin k // ∀ i, c(−i) = c i} and free colorings of the fundamental domain Fin(m+1): forward restricts c to representatives (c ∘ incl1), backward extends g by folding (g ∘ fold1), and the three folding lemmas verify both round-trips. `card_vertexInvariant` then reads off k^(m+1) via `Fintype.card_fun` (card(α→β) = card β ^ card α) and `Fintype.card_fin`.",
+    "mathContext": "$\\{c : \\mathbb{Z}/2m \\to \\mathrm{Fin}\\,k \\mid c(-i)=c(i)\\} \\simeq (\\mathrm{Fin}(m{+}1) \\to \\mathrm{Fin}\\,k)$, so the count is $k^{m+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv", "Fintype.card_fun", "invariant colorings", "fundamental-domain bijection"],
+    "prerequisites": ["the folding lemmas", "counting functions on a finite type"]
+  },
+  {
+    "id": "ann-bc0501-edge-val",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 126, "endLine": 146 },
+    "type": "technique",
+    "title": "Edge axis: the key value identity (−1−i).val = 2m−1−i.val",
+    "content": "The edge reflection i ↦ −1−i has no fixed points (2i+1 = 0 is unsolvable mod the even 2m). The clean computational bridge is `edge_cast` ((2m−1−i.val : ℕ) cast back equals −1−i) and `edge_val` ((−1−i).val = 2m−1−i.val, via `ZMod.val_natCast_of_lt`). This single value identity turns the edge fold into the same min-of-value template used for the vertex axis — the structural reuse that keeps both proofs parallel.",
+    "mathContext": "$(-1-i).\\mathrm{val} = 2m - 1 - i.\\mathrm{val}$; the orbit of $i$ is $\\{i, -1-i\\} = \\{j, 2m{-}1{-}j\\}$, fixed-point-free.",
+    "significance": "supporting",
+    "relatedConcepts": ["fixed-point-free involution", "ZMod.val_natCast_of_lt", "cast arithmetic in ZMod", "edge-axis reflection"],
+    "prerequisites": ["ZMod.val", "natural-number cast lemmas"]
+  },
+  {
+    "id": "ann-bc0501-edge-count",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 148, "endLine": 210 },
+    "type": "theorem",
+    "title": "Edge-axis count: k^m",
+    "content": "Mirroring the vertex case at the smaller fundamental domain Fin m: `incl2`/`fold2` (with fold2 i = min(i.val, 2m−1−i.val)), the three folding lemmas (`fold2_incl2`, `fold2_edge` via edge_val, `incl2_fold2` via edge_cast), and the explicit `edgeInvariantEquiv`. Because the involution is fixed-point-free, the domain is Fin m (not Fin(m+1)), giving `card_edgeInvariant = k^m` through Fintype.card_fun. The drop from m+1 to m orbits is exactly the absence of the two vertex fixed points.",
+    "mathContext": "$\\{c : \\mathbb{Z}/2m \\to \\mathrm{Fin}\\,k \\mid c(-1-i)=c(i)\\} \\simeq (\\mathrm{Fin}\\,m \\to \\mathrm{Fin}\\,k)$, so the count is $k^{m}$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point-free involution", "fundamental domain Fin m", "Equiv", "Fintype.card_fun"],
+    "prerequisites": ["the edge value identity", "folding lemmas", "counting functions"]
+  },
+  {
+    "id": "ann-bc0501-restate",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 212, "endLine": 236 },
+    "type": "theorem",
+    "title": "Restatement for arbitrary even n",
+    "content": "`card_reflectionInvariant_even_vertex` and `card_reflectionInvariant_even_edge` repackage the 2m-indexed counts for any even n > 0, as k^(n/2+1) and k^(n/2). The proofs destructure n = 2m (`obtain ⟨m, hm⟩ := hn`), substitute, reinstate the `NeZero m` instance, apply the core lemma, and close the index arithmetic (n/2+1 = m+1, n/2 = m) by `omega` via `congr 1`.",
+    "mathContext": "Even $n > 0$: vertex axis fixes $k^{n/2+1}$, edge axis fixes $k^{n/2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["even number destructuring", "NeZero instance management", "index normalization", "omega"],
+    "prerequisites": ["the 2m-indexed counts", "Even n"]
+  },
+  {
+    "id": "ann-bc0501-contrast",
+    "proofId": "burnside-counting-oq-05-oq-01",
+    "range": { "startLine": 238, "endLine": 248 },
+    "type": "insight",
+    "title": "The strict contrast: k^m < k^(m+1)",
+    "content": "`vertex_gt_edge` is the structural punchline: for m ≥ 1 and at least two colors, the vertex-axis reflection fixes strictly MORE colorings than the edge-axis one. The calc is elementary — k^m < k^m · k = k^(m+1) since k ≥ 2 and k^m > 0. This strict inequality is the formal statement that even-cycle reflection counts are NOT a single power of k, the precise sense in which the even case is richer than the uniform odd case.",
+    "mathContext": "$k \\ge 2,\\ m \\ge 1 \\Rightarrow k^m < k^m \\cdot k = k^{m+1}$ — the two reflection classes are not equinumerous.",
+    "significance": "key",
+    "relatedConcepts": ["strict monotonicity of powers", "even/odd dichotomy", "Burnside weighting", "lt_mul_iff_one_lt_right"],
+    "prerequisites": ["the two reflection counts", "power inequalities"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-05-oq-01` (even-cycle dihedral reflection counts).

## Gap closed
- **Missing `annotations.json`** — created 7 annotations covering the header (two reflection types), the vertex-axis fundamental domain + folding, the k^(m+1) vertex count, the edge value identity (−1−i).val = 2m−1−i.val, the k^m edge count, the even-n restatement, and the strict contrast k^m < k^(m+1). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Resolver alignment: 7/7 valid, 0 misaligned.

## Notes
- No `index.ts`: gallery entries load from `meta.json` + `annotations.json` via the build-generated `listings.json`/`data-manifest.json`; per-proof `index.ts` shims are legacy (only ~192/3419 entries carry one).
- Meta already had a structured `overview`, `sections` (3), `conclusion` (object), `crossReferences`, and `references` — left intact.
- Axiom integrity unchanged: `status: verified`, `axiomCount: 0`, 0 sorries.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)