### PR TITLE
Enrich Lusin's Theorem from Egorov's Theorem (egorov-theorem-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/egorov-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-egl0102-goal",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 8, "endLine": 42 },
+    "type": "concept",
+    "title": "Goal: Lusin from Egorov via Lᵖ density",
+    "content": "Lusin's theorem — Littlewood's third principle, 'every measurable function is nearly continuous' — derived from Egorov's theorem (the second principle) plus the density of continuous functions in Lᵖ. The classical five-step chain: (1) continuous functions are dense in Lᵖ, so f is an Lᵖ-limit of continuous gₙ; (2) Lᵖ convergence ⟹ convergence in measure ⟹ an a.e.-convergent subsequence; (3) Egorov (from the gallery parent) upgrades a.e. to uniform convergence off a small set; (4) a uniform limit of continuous functions is continuous; (5) inner regularity shrinks the bad set to a closed one. The engine is isolated as continuousOn_isClosed_of_ae_tendsto.",
+    "mathContext": "Lusin: $f$ measurable $\\Rightarrow \\forall \\varepsilon>0,\\ \\exists$ closed $K$ with $\\mu(K^c) \\le \\varepsilon$ and $f|_K$ continuous.",
+    "significance": "key",
+    "relatedConcepts": ["Lusin's theorem", "Egorov's theorem", "Littlewood's three principles", "Lᵖ density", "convergence in measure"],
+    "prerequisites": ["measure theory", "Lᵖ spaces", "modes of convergence"]
+  },
+  {
+    "id": "ann-egl0102-notmathlib",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 56 },
+    "type": "context",
+    "title": "Why this is not in Mathlib",
+    "content": "Mathlib has every individual link — Egorov, density of continuous functions in Lᵖ, convergence in measure, inner regularity — but assembles none of them into a measure-theoretic Lusin theorem (Mathlib's 'Lusin'-named results are the descriptive-set-theory Lusin–Souslin theorems on Polish spaces). The new content is the assembly, the closed-set Egorov core, and the bounded corollary. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "Mathlib provides the links; the measure-theoretic Lusin statement and its closed-set core are original here.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib gaps", "Lusin–Souslin theorem", "Polish spaces", "axiom-free verification"],
+    "prerequisites": ["familiarity with Mathlib's measure theory"]
+  },
+  {
+    "id": "ann-egl0102-core",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 66, "endLine": 105 },
+    "type": "technique",
+    "title": "The closed-set Egorov core",
+    "content": "`continuousOn_isClosed_of_ae_tendsto`: if continuous fₙ → g a.e. on a finite-measure measurable s, then for every ε there is a CLOSED K ⊆ s with μ(s\\K) ≤ ε and ContinuousOn g K. Three ingredients with split ε/2 budgets: Egorov (parent `egorov_uniform_off_small_set`) gives uniform convergence off a measurable t (budget ε/2); `TendstoUniformlyOn.continuousOn` turns the uniform limit into ContinuousOn g (s\\t); `MeasurableSet.exists_isClosed_diff_lt` (inner regularity, budget ε/2) carves a closed K ⊆ s\\t. The measure bookkeeping uses s\\K ⊆ t ∪ ((s\\t)\\K) and `add_halves`. This is the exact extra content Lusin adds over Egorov: a CLOSED set, not merely a measurable one.",
+    "mathContext": "Continuous $f_n \\to g$ a.e. on finite $s$ $\\Rightarrow$ closed $K \\subseteq s$, $\\mu(s\\setminus K) \\le \\varepsilon$, $g$ continuous on $K$. Budgets: $\\varepsilon/2$ (Egorov) $+ \\varepsilon/2$ (inner regularity).",
+    "significance": "key",
+    "relatedConcepts": ["Egorov's theorem", "inner regularity", "TendstoUniformlyOn.continuousOn", "uniform limit of continuous functions", "ε/2 budgeting"],
+    "prerequisites": ["Egorov's theorem", "weakly regular measures", "uniform convergence"]
+  },
+  {
+    "id": "ann-egl0102-lusin",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 107, "endLine": 135 },
+    "type": "theorem",
+    "title": "Lusin's theorem (Lᵖ form): manufacturing continuous approximants",
+    "content": "`lusin_memLp` is the headline. Step 1: `BoundedContinuousFunction.toLp_denseRange` places the Lᵖ class of f in the closure of the continuous functions, and `mem_closure_iff_seq_limit` extracts bounded continuous gₙ with toLp gₙ → toLp f. Step 2: `tendstoInMeasure_of_tendsto_Lp` converts Lᵖ convergence to convergence in measure, and `TendstoInMeasure.exists_seq_tendsto_ae` yields an a.e.-convergent subsequence g(ns k). Normality of α is what powers the Lᵖ density (Tietze-type extension), hence the `[NormalSpace α]` hypothesis.",
+    "mathContext": "Continuous functions dense in $L^p$ $\\Rightarrow$ bounded continuous $g_n$ with $g_n \\to f$ in $L^p$ $\\Rightarrow$ (in measure) $\\Rightarrow$ an a.e.-convergent subsequence.",
+    "significance": "key",
+    "relatedConcepts": ["toLp_denseRange", "mem_closure_iff_seq_limit", "tendstoInMeasure_of_tendsto_Lp", "NormalSpace / Tietze extension", "subsequence extraction"],
+    "prerequisites": ["Lᵖ density", "convergence in measure", "the closed-set core"]
+  },
+  {
+    "id": "ann-egl0102-transport",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 136, "endLine": 154 },
+    "type": "insight",
+    "title": "The a.e.-transport: representatives vs genuine continuous functions",
+    "content": "The delicate step: continuity is NOT an almost-everywhere property, so the proof must use the genuine bounded continuous gₙ, never their Lᵖ equivalence-class representatives ⇑(toLp gₙ) (which need not be continuous). The convergence obtained lives at the representatives; it is transported to the honest gₙ by combining the countable family of a.e. equalities `BoundedContinuousFunction.coeFn_toLp` through `ae_all_iff`, together with `MemLp.coeFn_toLp` for f. Then the core lemma applies on s = univ, and univ\\K = Kᶜ finishes.",
+    "mathContext": "$\\Vert{\\cdot}\\Vert$ a.e.: $\\widehat{\\mathrm{toLp}\\,g_n} =^{ae} g_n$ across all $n$ via $\\mathrm{ae\\_all\\_iff}$ transports a.e. convergence from representatives back to the genuine continuous $g_n$.",
+    "significance": "key",
+    "relatedConcepts": ["a.e. equality", "Lᵖ representatives", "coeFn_toLp", "ae_all_iff", "continuity is not an a.e. property"],
+    "prerequisites": ["a.e. equivalence classes", "the closed-set core", "countable a.e. intersection"]
+  },
+  {
+    "id": "ann-egl0102-bounded",
+    "proofId": "egorov-theorem-oq-01-oq-02",
+    "range": { "startLine": 156, "endLine": 164 },
+    "type": "theorem",
+    "title": "Lusin's theorem (bounded form)",
+    "content": "`lusin_of_bounded` specializes `lusin_memLp` to p = 2 and supplies Lᵖ membership from the bound via `MemLp.of_bound`. On a finite measure space a bounded strongly measurable function is automatically L², so this recovers the most-cited form of Lusin — continuous off a closed set of arbitrarily small complement — with NO integrability hypothesis needed.",
+    "mathContext": "Bounded measurable $f$ (with $\\Vert f x\\Vert \\le C$ a.e.) on a finite measure space $\\Rightarrow f \\in L^2 \\Rightarrow$ Lusin.",
+    "significance": "supporting",
+    "relatedConcepts": ["MemLp.of_bound", "bounded measurable functions", "finite measure space", "corollary specialization"],
+    "prerequisites": ["the Lᵖ-form theorem", "L² membership of bounded functions"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `egorov-theorem-oq-01-oq-02` (Lusin derived from Egorov + Lᵖ density).

## Gap closed
- **Missing `annotations.json`** — created 6 annotations covering the goal/five-step plan, the not-in-Mathlib note, the closed-set Egorov core (`continuousOn_isClosed_of_ae_tendsto`), the Lᵖ-density approximant construction, the subtle a.e.-transport from Lᵖ representatives to genuine continuous functions (continuity is not an a.e. property), and the bounded corollary. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Resolver alignment: 6/6 valid, 0 misaligned.

## Notes
- No `index.ts`: gallery entries load from `meta.json` + `annotations.json` via the build-generated `listings.json`/`data-manifest.json`; per-proof `index.ts` shims are legacy.
- Meta already had a structured `overview`, `sections` (4), `conclusion` (object), `crossReferences`, `references` — left intact.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries, no native_decide.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)