### PR TITLE
research(fundamental-theorem-algebra-oq-06): every odd-degree real polynomial has a real root [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2865,6 +2865,7 @@ import Proofs.FundamentalTheoremAlgebra
 import Proofs.FundamentalTheoremAlgebraOQ02
 import Proofs.FundamentalTheoremAlgebraOQ04
 import Proofs.FundamentalTheoremAlgebraOQ04OQ04
+import Proofs.FundamentalTheoremAlgebraOQ06
 import Proofs.FundamentalTheoremCalculus
 import Proofs.FundamentalTheoremCalculusLebesgue
 import Proofs.FundamentalTheoremCalculusLebesgueOQ01

--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ06.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ06.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+# Every Odd-Degree Real Polynomial Has a Real Root (Intermediate Value Form)
+
+## What This Proves
+Every polynomial `P ∈ ℝ[X]` of odd degree has a real root: `∃ x : ℝ, P.IsRoot x`.
+
+This is the **odd-degree intermediate value step** singled out in the parent entry's
+open question on Gauss's (1849) purely algebraic proof of the Fundamental Theorem of
+Algebra. Gauss's argument reduces the analytic content of FTA to exactly two facts:
+1. every odd-degree real polynomial has a real root (this entry), and
+2. every complex number has a complex square root.
+
+## Approach
+A degree-`n` real polynomial with `n` odd behaves like `c · xⁿ` at infinity, and an odd
+power flips sign between `+∞` and `−∞`. Concretely:
+
+- `0 < P.degree`, and `P.eval` is continuous.
+- The reflected polynomial `Q(x) = P(-x) = P.comp (-X)` has
+  `leadingCoeff Q = (-1)^(deg P) · leadingCoeff P = -leadingCoeff P` (oddness),
+  so `P` and `Q` have opposite end-behaviour at `+∞`.
+- Whatever the sign of `leadingCoeff P`, one of `{P, Q}` tends to `+∞` and the other to
+  `−∞` along `atTop`. Reading `Q.eval x = P.eval (-x)` back, `P.eval` therefore takes a
+  strictly negative value at some `a` and a strictly positive value at some `b`.
+- The intermediate value theorem on `[[a, b]]` then produces a root.
+
+## Mathlib Ingredients
+- `Polynomial.tendsto_atTop_of_leadingCoeff_nonneg` / `tendsto_atBot_of_leadingCoeff_nonpos`
+- `Polynomial.leadingCoeff_comp`, `Polynomial.natDegree_comp`, `Polynomial.eval_comp`
+- `intermediate_value_uIcc`, `Polynomial.continuousOn`
+- `Polynomial.dvd_iff_isRoot`
+
+Mathlib has no standalone "odd-degree real polynomial has a root" theorem; the result is
+built here from the end-behaviour lemmas and the IVT.
+
+Historical note: this is the ℝ-specialisation of the order-theoretic fact underlying
+real-closed fields (Artin–Schreier, 1927); for ℝ it is the IVT step of Gauss's 1849 proof.
+-/
+
+open Polynomial Filter Topology
+
+namespace FTAOddDegreeRoot
+
+/-- An odd-degree real polynomial takes both a strictly negative and a strictly positive
+value: the leading term dominates at `±∞` and an odd power flips sign. -/
+theorem exists_neg_and_pos_eval (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    (∃ a : ℝ, P.eval a < 0) ∧ (∃ b : ℝ, 0 < P.eval b) := by
+  obtain ⟨m, hm⟩ := hodd
+  have hpos_deg : 0 < P.natDegree := by omega
+  have hdeg : 0 < P.degree := natDegree_pos_iff_degree_pos.mp hpos_deg
+  -- The reflected polynomial Q(x) = P(-x).
+  set Q : ℝ[X] := P.comp (-X) with hQ
+  have hnd_negX : (-X : ℝ[X]).natDegree = 1 := by rw [natDegree_neg, natDegree_X]
+  have hlc_negX : (-X : ℝ[X]).leadingCoeff = -1 := by rw [leadingCoeff_neg, leadingCoeff_X]
+  have hne : (-X : ℝ[X]).natDegree ≠ 0 := by rw [hnd_negX]; norm_num
+  have hQdeg_nd : Q.natDegree = P.natDegree := by
+    rw [hQ, natDegree_comp, hnd_negX, mul_one]
+  have hQdeg : 0 < Q.degree := by
+    rw [← natDegree_pos_iff_degree_pos, hQdeg_nd]; exact hpos_deg
+  have hQlc : Q.leadingCoeff = -P.leadingCoeff := by
+    rw [hQ, leadingCoeff_comp hne, hlc_negX, Odd.neg_one_pow ⟨m, hm⟩]; ring
+  have hevalQ : ∀ x : ℝ, Q.eval x = P.eval (-x) := by
+    intro x; rw [hQ, eval_comp]; simp
+  rcases le_total 0 P.leadingCoeff with hlc | hlc
+  · -- leadingCoeff P ≥ 0: P → +∞ (positive value); Q → −∞ (negative value of P at -x).
+    have hP : Tendsto (fun x => P.eval x) atTop atTop :=
+      P.tendsto_atTop_of_leadingCoeff_nonneg hdeg hlc
+    have hb : ∃ b : ℝ, 0 < P.eval b := (hP.eventually (eventually_gt_atTop 0)).exists
+    have hQlc_nonpos : Q.leadingCoeff ≤ 0 := by rw [hQlc]; linarith
+    have hQt : Tendsto (fun x => Q.eval x) atTop atBot :=
+      Q.tendsto_atBot_of_leadingCoeff_nonpos hQdeg hQlc_nonpos
+    obtain ⟨x, hx⟩ := (hQt.eventually (eventually_lt_atBot 0)).exists
+    rw [hevalQ] at hx
+    exact ⟨⟨-x, hx⟩, hb⟩
+  · -- leadingCoeff P ≤ 0: P → −∞ (negative value); Q → +∞ (positive value of P at -x).
+    have hP : Tendsto (fun x => P.eval x) atTop atBot :=
+      P.tendsto_atBot_of_leadingCoeff_nonpos hdeg hlc
+    have ha : ∃ a : ℝ, P.eval a < 0 := (hP.eventually (eventually_lt_atBot 0)).exists
+    have hQlc_nonneg : 0 ≤ Q.leadingCoeff := by rw [hQlc]; linarith
+    have hQt : Tendsto (fun x => Q.eval x) atTop atTop :=
+      Q.tendsto_atTop_of_leadingCoeff_nonneg hQdeg hQlc_nonneg
+    obtain ⟨x, hx⟩ := (hQt.eventually (eventually_gt_atTop 0)).exists
+    rw [hevalQ] at hx
+    exact ⟨ha, ⟨-x, hx⟩⟩
+
+/-- **Odd-degree real root theorem.** Every real polynomial of odd degree has a real root. -/
+theorem odd_natDegree_has_real_root (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    ∃ x : ℝ, P.IsRoot x := by
+  obtain ⟨⟨a, ha⟩, ⟨b, hb⟩⟩ := exists_neg_and_pos_eval P hodd
+  have hcont : ContinuousOn (fun x => P.eval x) (Set.uIcc a b) := P.continuousOn
+  have h0mem : (0 : ℝ) ∈ Set.uIcc (P.eval a) (P.eval b) := by
+    rw [Set.mem_uIcc]; exact Or.inl ⟨le_of_lt ha, le_of_lt hb⟩
+  obtain ⟨c, _, hc⟩ := intermediate_value_uIcc hcont h0mem
+  exact ⟨c, hc⟩
+
+/-- Structural consequence: an odd-degree real polynomial has a linear factor `X - C x`. -/
+theorem odd_natDegree_has_linear_factor (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    ∃ x : ℝ, (X - C x) ∣ P := by
+  obtain ⟨x, hx⟩ := odd_natDegree_has_real_root P hodd
+  exact ⟨x, dvd_iff_isRoot.mpr hx⟩
+
+/-- Every odd-degree polynomial splits off a real root, so an **irreducible** real
+polynomial of degree `> 1` must have **even** degree. (Quadratics such as `X² + 1`,
+with no real root, are exactly the obstruction to ℝ being algebraically closed.) -/
+theorem natDegree_even_of_irreducible_of_one_lt
+    (P : ℝ[X]) (hirr : Irreducible P) (h1 : 1 < P.natDegree) : Even P.natDegree := by
+  rcases Nat.even_or_odd P.natDegree with he | hodd
+  · exact he
+  exfalso
+  obtain ⟨x, q, hq⟩ := odd_natDegree_has_linear_factor P hodd
+  rcases hirr.isUnit_or_isUnit hq with hu | hu
+  · -- `X - C x` a unit: impossible, its natDegree is `1 ≠ 0`.
+    have h1deg : (X - C x : ℝ[X]).natDegree = 1 := natDegree_X_sub_C x
+    have h0deg : (X - C x : ℝ[X]).natDegree = 0 := natDegree_eq_zero_of_isUnit hu
+    omega
+  · -- the cofactor `q` a unit: then `natDegree P = 1`, contradicting `1 < natDegree P`.
+    have hqne : q ≠ 0 := by rintro rfl; rw [mul_zero] at hq; exact hirr.ne_zero hq
+    have hqdeg : q.natDegree = 0 := natDegree_eq_zero_of_isUnit hu
+    have hPdeg : P.natDegree = 1 := by
+      rw [hq, natDegree_mul (X_sub_C_ne_zero x) hqne, natDegree_X_sub_C, hqdeg]
+    omega
+
+end FTAOddDegreeRoot

--- a/src/data/proofs/fundamental-theorem-algebra-oq-06/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "Goal and Imports",
+    "content": "The file imports all of `Mathlib` and opens `Polynomial`, `Filter`, and `Topology`. The objective is the odd-degree intermediate-value step of Gauss's 1849 algebraic proof of the Fundamental Theorem of Algebra: every real polynomial of odd degree has a real root. Mathlib provides the polynomial end-behaviour lemmas and the intermediate value theorem, but no packaged 'odd-degree root' theorem — the result is assembled here.",
+    "mathContext": "Target: $\\forall P \\in \\mathbb{R}[X],\\ \\mathrm{Odd}(\\deg P) \\Rightarrow \\exists x \\in \\mathbb{R},\\ P(x) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental theorem of algebra", "intermediate value theorem", "polynomial degree"],
+    "prerequisites": ["polynomial evaluation", "Lean 4 module system"]
+  },
+  {
+    "id": "ann-reflected-polynomial",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 53, "endLine": 67 },
+    "type": "technique",
+    "title": "The Reflected Polynomial Q(x) = P(−x)",
+    "content": "Rather than proving the $-\\infty$ behaviour with a separate `atBot` argument, the proof introduces `Q := P.comp (-X)`, so that `Q.eval x = P.eval (-x)`. Composition with the degree-1 polynomial `-X` preserves the degree (`natDegree_comp` with `natDegree (-X) = 1`) and transforms the leading coefficient: `leadingCoeff_comp` gives `leadingCoeff Q = leadingCoeff P · (leadingCoeff (-X))^(natDegree P) = leadingCoeff P · (-1)^(natDegree P)`. Because the degree is odd, `(-1)^(natDegree P) = -1` (via `Odd.neg_one_pow`), so `leadingCoeff Q = -leadingCoeff P`.",
+    "mathContext": "$\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P) = -\\mathrm{leadingCoeff}(P)$ for odd $\\deg P$.",
+    "significance": "central",
+    "relatedConcepts": ["polynomial composition", "leading coefficient", "parity"],
+    "prerequisites": ["Polynomial.comp", "leadingCoeff_comp", "Odd.neg_one_pow"]
+  },
+  {
+    "id": "ann-both-signs",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 68, "endLine": 85 },
+    "type": "technique",
+    "title": "Extracting a Negative and a Positive Value",
+    "content": "Case-split on the sign of `leadingCoeff P` with `le_total`. If `0 ≤ leadingCoeff P`, then `P` tends to `+∞` along `atTop` (`tendsto_atTop_of_leadingCoeff_nonneg`), so `(hP.eventually (eventually_gt_atTop 0)).exists` produces `b` with `P(b) > 0`; meanwhile `leadingCoeff Q ≤ 0`, so `Q` tends to `-∞`, yielding `x` with `Q(x) < 0`, i.e. `P(-x) < 0`. The other case is symmetric. Either way both signs are realised.",
+    "mathContext": "`Tendsto.eventually` pulls an eventual statement in the target filter back along the limit; `.exists` then turns 'eventually' into 'there exists'.",
+    "significance": "central",
+    "relatedConcepts": ["Filter.Tendsto", "end behaviour", "eventually"],
+    "prerequisites": ["tendsto_atTop_of_leadingCoeff_nonneg", "eventually_gt_atTop"]
+  },
+  {
+    "id": "ann-ivt",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "key-step",
+    "title": "Root via intermediate_value_uIcc",
+    "content": "With `P(a) < 0 < P(b)`, the value `0` lies in the unordered interval `[[P a, P b]]`. Since `P.eval` is continuous (`Polynomial.continuousOn`), `intermediate_value_uIcc` gives `[[P a, P b]] ⊆ P '' [[a, b]]`, so `0` is attained: there is `c` with `P(c) = 0`, i.e. `P.IsRoot c`. Using the unordered interval `[[a,b]]` avoids any case analysis on whether `a ≤ b`.",
+    "mathContext": "$0 \\in [[P(a),P(b)]] \\subseteq P([[a,b]])$, hence $\\exists c,\\ P(c)=0$.",
+    "significance": "central",
+    "relatedConcepts": ["intermediate value theorem", "continuity", "unordered interval"],
+    "prerequisites": ["intermediate_value_uIcc", "Polynomial.continuousOn", "Set.mem_uIcc"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "fundamental-theorem-algebra-oq-06",
+    "range": { "startLine": 97, "endLine": 124 },
+    "type": "concept",
+    "title": "Linear Factor and Even-Degree Irreducibles",
+    "content": "`odd_natDegree_has_linear_factor` turns the root into a divisibility statement via `dvd_iff_isRoot`: `(X - C x) ∣ P`. `natDegree_even_of_irreducible_of_one_lt` then argues that if an irreducible `P` had odd degree and `natDegree P > 1`, it would split off a linear factor; irreducibility forces either the linear factor or the cofactor to be a unit, and both options contradict `natDegree P > 1`. Hence irreducible real polynomials of degree above 1 have even degree — the algebraic shadow of the fact that ℝ's only irreducible higher-degree polynomials are quadratics like $X^2+1$.",
+    "mathContext": "Irreducible $P$ with $\\deg P > 1$ has no linear factor, so $\\deg P$ cannot be odd; the obstruction to ℝ being algebraically closed is exactly even degree.",
+    "significance": "supporting",
+    "relatedConcepts": ["irreducible polynomial", "linear factor", "algebraic closure"],
+    "prerequisites": ["dvd_iff_isRoot", "Irreducible.isUnit_or_isUnit", "natDegree_mul"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "fundamental-theorem-algebra-oq-06",
+  "slug": "fundamental-theorem-algebra-oq-06",
+  "title": "Every Odd-Degree Real Polynomial Has a Real Root",
+  "description": "Proves the intermediate-value step of Gauss's algebraic proof of the Fundamental Theorem of Algebra: every polynomial in ℝ[X] of odd degree has a real root. The end behaviour of an odd-degree polynomial is opposite at +∞ and −∞ (an odd power flips sign), so the polynomial takes both a strictly negative and a strictly positive value; the intermediate value theorem then produces a root. Corollaries: an odd-degree real polynomial has a linear factor X − C x, and every irreducible real polynomial of degree > 1 has even degree.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "FTAOddDegreeRoot",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "odd_natDegree_has_real_root",
+        "type": "original",
+        "description": "Every real polynomial of odd degree has a real root (the odd-degree IVT step of Gauss's FTA proof)",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → ∃ x : ℝ, P.IsRoot x"
+      },
+      {
+        "name": "exists_neg_and_pos_eval",
+        "type": "original",
+        "description": "An odd-degree real polynomial takes both a strictly negative and a strictly positive value, via opposite end behaviour at ±∞",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → (∃ a : ℝ, P.eval a < 0) ∧ (∃ b : ℝ, 0 < P.eval b)"
+      },
+      {
+        "name": "odd_natDegree_has_linear_factor",
+        "type": "original",
+        "description": "An odd-degree real polynomial splits off a linear factor X − C x",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → ∃ x : ℝ, (X - C x) ∣ P"
+      },
+      {
+        "name": "natDegree_even_of_irreducible_of_one_lt",
+        "type": "original",
+        "description": "Every irreducible real polynomial of degree > 1 has even degree (quadratics like X²+1 are the obstruction to ℝ being algebraically closed)",
+        "leanType": "(P : ℝ[X]) → Irreducible P → 1 < P.natDegree → Even P.natDegree"
+      }
+    ],
+    "path": "Proofs/FundamentalTheoremAlgebraOQ06.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ06.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "intermediate-value-theorem",
+      "fundamental-theorem-of-algebra",
+      "real-analysis",
+      "field-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). The proof builds on Mathlib's polynomial end-behaviour lemmas (tendsto_atTop_of_leadingCoeff_nonneg, tendsto_atBot_of_leadingCoeff_nonpos) and the intermediate value theorem (intermediate_value_uIcc); Mathlib has no standalone odd-degree-root theorem, so the result is assembled here.",
+    "originalContributions": [
+      "odd_natDegree_has_real_root: every odd-degree real polynomial has a real root — original, the IVT step of Gauss's FTA proof",
+      "exists_neg_and_pos_eval: an odd-degree polynomial takes both signs, via the reflected polynomial P(−x) = P.comp(−X) and leadingCoeff(P∘(−X)) = (−1)^deg · leadingCoeff(P) — original",
+      "odd_natDegree_has_linear_factor: linear factor X − C x via dvd_iff_isRoot — original corollary",
+      "natDegree_even_of_irreducible_of_one_lt: irreducible real polynomials of degree > 1 have even degree — original corollary"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg",
+        "description": "A polynomial with positive degree and nonnegative leading coefficient tends to +∞ at +∞",
+        "module": "Mathlib.Analysis.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.tendsto_atBot_of_leadingCoeff_nonpos",
+        "description": "A polynomial with positive degree and nonpositive leading coefficient tends to −∞ at +∞",
+        "module": "Mathlib.Analysis.Polynomial.Basic"
+      },
+      {
+        "theorem": "Polynomial.leadingCoeff_comp",
+        "description": "leadingCoeff (p ∘ q) = leadingCoeff p · (leadingCoeff q)^(natDegree p) when natDegree q ≠ 0",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "intermediate_value_uIcc",
+        "description": "Intermediate value theorem on an unordered interval [[a,b]]",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "Polynomial.dvd_iff_isRoot",
+        "description": "X − C a divides p iff a is a root of p",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Polynomial evaluation, degree, and leading coefficient",
+      "Limits of functions at infinity (Filter.Tendsto, atTop/atBot)",
+      "The intermediate value theorem for continuous real functions",
+      "Familiarity with Lean 4 and Mathlib"
+    ],
+    "wiedijkNumber": 2,
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
+    "date": "1849",
+    "relatedProblems": [
+      {
+        "id": "fundamental-theorem-algebra",
+        "relationship": "Proves the odd-degree intermediate-value step singled out in the parent entry's open question on Gauss's purely algebraic proof of FTA"
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "Does every real polynomial of odd degree have a real root? This is the intermediate-value ingredient of Gauss's (1849) algebraic proof of the Fundamental Theorem of Algebra, which reduces the analytic content of FTA to two facts: every odd-degree real polynomial has a real root, and every complex number has a complex square root.",
+    "text": "An odd-degree real polynomial $P$ behaves like its leading term $c\\,x^n$ near $\\pm\\infty$. Because $n$ is odd, $x^n$ has opposite signs at $+\\infty$ and $-\\infty$, so $P$ runs from one infinity to the other and must cross zero. Formalising this requires (a) the end-behaviour of polynomials, expressed through Mathlib's `tendsto` lemmas governed by the sign of the leading coefficient, and (b) the intermediate value theorem. The sign flip at $-\\infty$ is captured by the reflected polynomial $Q(x) = P(-x) = P \\circ (-X)$, whose leading coefficient is $(-1)^{\\deg P}\\,\\mathrm{lc}(P) = -\\mathrm{lc}(P)$ for odd degree, so $P$ and $Q$ have opposite limits along `atTop`.",
+    "proofStrategy": "Reduce to producing a point where $P$ is negative and a point where $P$ is positive, then apply the intermediate value theorem on the unordered interval between them. Whatever the sign of $\\mathrm{lc}(P)$, exactly one of $P$ and the reflected polynomial $Q(x)=P(-x)$ tends to $+\\infty$ along `atTop` and the other to $-\\infty$; reading $Q.\\mathrm{eval}\\,x = P.\\mathrm{eval}(-x)$ back yields both a positive and a negative value of $P$.",
+    "keyInsights": [
+      "Oddness of the degree is exactly what makes the leading term flip sign between $+\\infty$ and $-\\infty$ — this is the entire content of the theorem.",
+      "The sign flip at $-\\infty$ need not be proved by a separate atBot argument: composing with $-X$ converts $-\\infty$ behaviour into $+\\infty$ behaviour, and $\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P)$.",
+      "Using the unordered interval `[[a,b]]` and `intermediate_value_uIcc` removes any need to track whether $a \\le b$ or $b \\le a$.",
+      "The result explains the asymmetry in ℝ: odd-degree polynomials always have roots, so the obstruction to ℝ being algebraically closed lives entirely in even degree (e.g. $X^2+1$)."
+    ],
+    "historicalContext": "Gauss gave several proofs of the Fundamental Theorem of Algebra. His 1849 proof is the most algebraic, isolating the order structure of ℝ to two ingredients: the intermediate value property for odd-degree polynomials (proved here) and the existence of complex square roots. The general order-theoretic version — every odd-degree polynomial over a real-closed field has a root — is part of the Artin–Schreier theory of real-closed fields (1927).",
+    "prerequisites": [
+      "Polynomial evaluation, degree, and leading coefficient",
+      "Limits at infinity and the Filter.Tendsto API",
+      "The intermediate value theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Module Overview and Imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports Mathlib and opens Polynomial, Filter, and Topology. The docstring frames the result as the odd-degree IVT step of Gauss's algebraic FTA proof.",
+      "mathContext": "Goal: $\\forall P \\in \\mathbb{R}[X],\\ \\mathrm{Odd}(\\deg P) \\Rightarrow \\exists x,\\ P(x)=0$."
+    },
+    {
+      "id": "both-signs",
+      "title": "Both Signs via End Behaviour",
+      "startLine": 45,
+      "endLine": 85,
+      "summary": "Proves exists_neg_and_pos_eval: an odd-degree polynomial takes a strictly negative and a strictly positive value. Uses the reflected polynomial Q = P.comp(−X) with leadingCoeff Q = −leadingCoeff P, and case-splits on the sign of the leading coefficient.",
+      "mathContext": "$\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P) = -\\mathrm{leadingCoeff}(P)$; one of $P, Q$ tends to $+\\infty$ and the other to $-\\infty$ along `atTop`, and $Q(x)=P(-x)$."
+    },
+    {
+      "id": "ivt-root",
+      "title": "Root via the Intermediate Value Theorem",
+      "startLine": 87,
+      "endLine": 95,
+      "summary": "Proves odd_natDegree_has_real_root: feeds the negative and positive values into intermediate_value_uIcc to obtain c with P(c) = 0.",
+      "mathContext": "$0 \\in [[P(a), P(b)]] \\subseteq P([[a,b]])$ since $P(a) < 0 < P(b)$, giving a root $c$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Structural Corollaries",
+      "startLine": 97,
+      "endLine": 124,
+      "summary": "odd_natDegree_has_linear_factor extracts a linear factor X − C x via dvd_iff_isRoot. natDegree_even_of_irreducible_of_one_lt deduces that an irreducible real polynomial of degree > 1 must have even degree.",
+      "mathContext": "A linear factor of an irreducible $P$ with $\\deg P > 1$ forces a contradiction, so irreducibility above degree 1 lives in even degree; $X^2+1$ is the prototypical irreducible quadratic."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every odd-degree real polynomial has a real root, proved from polynomial end behaviour and the intermediate value theorem with 0 axioms and 0 sorries. Corollaries give a linear factor and show that irreducibility of real polynomials above degree 1 is confined to even degree.",
+    "implications": [
+      "Supplies the intermediate-value half of Gauss's algebraic FTA proof, isolating exactly where the order completeness of ℝ enters.",
+      "Explains why the obstruction to ℝ being algebraically closed is even-degree: odd-degree polynomials always factor off a real root.",
+      "Provides reusable infrastructure (both-signs-from-odd-degree, IVT root extraction) for downstream real-root arguments."
+    ],
+    "openQuestions": [
+      "Generalise to real-closed fields: every odd-degree polynomial over a real-closed field has a root (the Artin–Schreier order-theoretic version), using an abstract IVT for the order topology.",
+      "Quantify the root: produce an explicit bound on $|x|$ for a root in terms of the coefficients (e.g. a Cauchy root bound), making the existence proof effective.",
+      "Combine with 'every complex number has a square root' to assemble a fully formal version of Gauss's 1849 algebraic proof of FTA, minimising the analytic prerequisites."
+    ]
+  },
+  "references": [
+    {
+      "title": "Fundamental theorem of algebra",
+      "url": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
+      "description": "Overview of FTA and its proofs, including Gauss's algebraic argument reducing to odd-degree real roots and complex square roots."
+    },
+    {
+      "title": "Real closed field",
+      "url": "https://en.wikipedia.org/wiki/Real_closed_field",
+      "description": "Artin–Schreier theory: the order-theoretic generalisation in which every odd-degree polynomial has a root."
+    },
+    {
+      "title": "Intermediate value theorem",
+      "url": "https://en.wikipedia.org/wiki/Intermediate_value_theorem",
+      "description": "The analytic ingredient used to convert a sign change into a root."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra",
+      "relationship": "extends",
+      "description": "Proves the odd-degree intermediate-value step that the parent entry names as the key ingredient of Gauss's algebraic proof of FTA."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04",
+      "relationship": "complementary",
+      "description": "That entry shows ℝ is not algebraically closed via X²+1 (even degree); this entry shows odd-degree polynomials always have roots, so the obstruction is exactly even degree."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Proves the **odd-degree intermediate-value step** of Gauss's (1849) algebraic proof of the Fundamental Theorem of Algebra: every real polynomial of odd degree has a real root. This directly addresses **open question #2** of the parent `fundamental-theorem-algebra` entry, which names this exact result as the analytic ingredient that, together with "every complex number has a square root," underlies Gauss's algebraic FTA proof.

Mathlib has no standalone odd-degree-root theorem; it is assembled here from end-behaviour lemmas and the IVT.

## Mathematical content

An odd-degree polynomial behaves like `c·xⁿ` near `±∞`; since `n` is odd, the leading term flips sign between `+∞` and `−∞`, so `P` takes both a strictly negative and a strictly positive value and the IVT yields a root. The `−∞` behaviour is obtained without a separate `atBot` argument by composing with `-X`:

- `Q := P.comp (-X)` satisfies `Q.eval x = P.eval (-x)` and `leadingCoeff Q = (-1)^(deg P) · leadingCoeff P = -leadingCoeff P` (oddness).
- Whatever the sign of `leadingCoeff P`, one of `{P, Q}` tends to `+∞` along `atTop` and the other to `−∞`, giving both signs of `P`.
- `intermediate_value_uIcc` on the unordered interval `[[a,b]]` produces the root (no `a ≤ b` casework).

## Theorems (4, 124 lines, 0 sorries)

| Theorem | Statement |
|---------|-----------|
| `odd_natDegree_has_real_root` | `Odd P.natDegree → ∃ x, P.IsRoot x` (main) |
| `exists_neg_and_pos_eval` | takes both a negative and a positive value |
| `odd_natDegree_has_linear_factor` | `∃ x, (X - C x) ∣ P` |
| `natDegree_even_of_irreducible_of_one_lt` | `Irreducible P → 1 < natDegree P → Even (natDegree P)` |

The last corollary pins down the asymmetry of ℝ: odd-degree polynomials always factor off a real root, so the obstruction to ℝ being algebraically closed is confined to even degree (`X²+1`).

## Verification

- Typechecks with `lake env lean` on Lean `v4.26.0` / Mathlib `4.26.0`.
- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status: `verified`, badge `original`, `axiomCount: 0`.

## Files

- `proofs/Proofs/FundamentalTheoremAlgebraOQ06.lean`
- `src/data/proofs/fundamental-theorem-algebra-oq-06/{meta.json,annotations.json}`
- `proofs/Proofs.lean` (single import line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)