### PR TITLE
research(menelaus-theorem-oq-01-oq-02): Desargues's theorem via homogeneous determinant bracket [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/MenelausTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/MenelausTheoremOQ01OQ02.lean
@@ -1,0 +1,186 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+/-!
+# Desargues's Theorem via the homogeneous-coordinate determinant bracket
+
+## What This Proves
+Two triangles `A B C` and `A' B' C'` in the real projective plane are **perspective
+from a point** (the three lines `A A'`, `B B'`, `C C'` are concurrent) **iff** they are
+**perspective from a line** (the three intersection points of corresponding sides
+
+  `P = BC ∩ B'C'`,  `Q = CA ∩ C'A'`,  `R = AB ∩ A'B'`
+
+are collinear). This is **Desargues's theorem**, the foundational incidence theorem of
+projective geometry.
+
+Open question: `menelaus-theorem-oq-01-oq-02`.
+Parent: `Proofs/MenelausTheorem.lean` (`menelaus-theorem-oq-01`), whose mathematical
+heart is the *collinearity-via-determinant factorisation* `collinearDet_factor`. This
+file reuses exactly that idea — encode incidence by the vanishing of a determinant — but
+lifts it to **homogeneous coordinates** `ℝ³`, where the parallel-line degeneracies of the
+affine plane disappear and the whole theorem collapses to a single polynomial identity.
+
+## Approach
+Work in `ℝ³` with the standard projective dictionary:
+
+* a point is a nonzero vector `P : ℝ³`;
+* `cross P Q` (the vector cross product) is simultaneously the **line through** two
+  points and the **intersection** of two lines (point/line duality);
+* three points/lines are **collinear/concurrent** iff their `3×3` determinant `det3`
+  vanishes.
+
+Under this dictionary the two perspectivity conditions are
+`det3 (A×A') (B×B') (C×C') = 0` (concurrence) and `det3 P Q R = 0` (collinearity), and
+the entire content of Desargues is the **bracket identity**
+
+  `det3 P Q R = det3 A B C · det3 A' B' C' · det3 (A×A') (B×B') (C×C')`,
+
+a pure degree-`12` polynomial identity in the `18` coordinates, discharged by `ring`
+(`desargues_bracket_identity`). For non-degenerate triangles the two triangle brackets
+`det3 A B C` and `det3 A' B' C'` are nonzero, so the collinearity determinant vanishes
+**iff** the concurrence determinant does — which is Desargues, and is manifestly
+**self-dual**.
+
+## Status
+- [x] Cross product / `3×3` determinant in homogeneous coordinates
+- [x] The Desargues bracket identity (the geometric content)
+- [x] Main equivalence: perspective from a point ↔ perspective from a line
+- [x] Self-duality corollary and a concrete numerical instance
+- [x] 0 sorries, 0 axioms
+
+## Mathlib Dependencies
+Real arithmetic, `ring`, `mul_eq_zero`. Desargues's theorem is **not** a named Mathlib
+result, nor is the projective cross-product bracket calculus used here.
+-/
+
+namespace MenelausTheoremOQ01OQ02
+
+set_option linter.unusedVariables false
+
+/-- A homogeneous-coordinate vector in the real projective plane. Components are
+    accessed as `P.1`, `P.2.1`, `P.2.2`. -/
+abbrev Vec : Type := ℝ × ℝ × ℝ
+
+/-- The vector cross product. In the projective dictionary it is **both** the line
+    joining two points **and** the intersection of two lines (point/line duality). -/
+def cross (P Q : Vec) : Vec :=
+  (P.2.1 * Q.2.2 - P.2.2 * Q.2.1,
+   P.2.2 * Q.1 - P.1 * Q.2.2,
+   P.1 * Q.2.1 - P.2.1 * Q.1)
+
+/-- The `3×3` determinant (scalar triple product) `P · (Q × R)`. It vanishes exactly
+    when the three points are collinear / the three lines are concurrent. -/
+def det3 (P Q R : Vec) : ℝ :=
+  P.1 * (Q.2.1 * R.2.2 - Q.2.2 * R.2.1)
+    - P.2.1 * (Q.1 * R.2.2 - Q.2.2 * R.1)
+    + P.2.2 * (Q.1 * R.2.1 - Q.2.1 * R.1)
+
+/-- Two triangles `A B C`, `A' B' C'` in the projective plane, both non-degenerate
+    (their vertices are not collinear). -/
+structure DesarguesConfig where
+  A : Vec
+  B : Vec
+  C : Vec
+  A' : Vec
+  B' : Vec
+  C' : Vec
+  hABC : det3 A B C ≠ 0
+  hA'B'C' : det3 A' B' C' ≠ 0
+
+namespace DesarguesConfig
+
+variable (cfg : DesarguesConfig)
+
+/-- Intersection of corresponding sides `BC` and `B'C'`. -/
+def pointP : Vec := cross (cross cfg.B cfg.C) (cross cfg.B' cfg.C')
+
+/-- Intersection of corresponding sides `CA` and `C'A'`. -/
+def pointQ : Vec := cross (cross cfg.C cfg.A) (cross cfg.C' cfg.A')
+
+/-- Intersection of corresponding sides `AB` and `A'B'`. -/
+def pointR : Vec := cross (cross cfg.A cfg.B) (cross cfg.A' cfg.B')
+
+/-- Concurrence determinant of the three connector lines `A A'`, `B B'`, `C C'`. -/
+def concurDet : ℝ :=
+  det3 (cross cfg.A cfg.A') (cross cfg.B cfg.B') (cross cfg.C cfg.C')
+
+/-- Collinearity determinant of the three side-intersection points `P`, `Q`, `R`. -/
+def collDet : ℝ := det3 cfg.pointP cfg.pointQ cfg.pointR
+
+/-- The triangles are **perspective from a point**: the connectors `A A'`, `B B'`,
+    `C C'` meet in a common point (their concurrence determinant vanishes). -/
+def PerspectiveFromPoint : Prop := cfg.concurDet = 0
+
+/-- The triangles are **perspective from a line**: the side-intersections `P`, `Q`, `R`
+    are collinear (their determinant vanishes). -/
+def PerspectiveFromLine : Prop := cfg.collDet = 0
+
+end DesarguesConfig
+
+open DesarguesConfig
+
+/-- **The Desargues bracket identity** — the geometric content of the theorem.
+    The collinearity determinant of the three side-intersection points factors as the
+    product of the two triangle determinants and the concurrence determinant. A pure
+    degree-`12` polynomial identity in the `18` coordinates, discharged by `ring`. -/
+theorem desargues_bracket_identity (cfg : DesarguesConfig) :
+    cfg.collDet = det3 cfg.A cfg.B cfg.C * det3 cfg.A' cfg.B' cfg.C' * cfg.concurDet := by
+  simp only [DesarguesConfig.collDet, DesarguesConfig.concurDet, DesarguesConfig.pointP,
+    DesarguesConfig.pointQ, DesarguesConfig.pointR, det3, cross]
+  ring
+
+/-- **Desargues's Theorem.** For two non-degenerate triangles, perspective from a point
+    is equivalent to perspective from a line. The proof reads the equivalence directly
+    off the bracket identity: dividing out the two nonzero triangle determinants, the
+    collinearity determinant vanishes iff the concurrence determinant does. -/
+theorem desargues (cfg : DesarguesConfig) :
+    cfg.PerspectiveFromPoint ↔ cfg.PerspectiveFromLine := by
+  have key := desargues_bracket_identity cfg
+  unfold DesarguesConfig.PerspectiveFromPoint DesarguesConfig.PerspectiveFromLine
+  constructor
+  · intro h
+    rw [key, h, mul_zero]
+  · intro h
+    rw [key] at h
+    rcases mul_eq_zero.mp h with h1 | h2
+    · rcases mul_eq_zero.mp h1 with ha | hb
+      · exact absurd ha cfg.hABC
+      · exact absurd hb cfg.hA'B'C'
+    · exact h2
+
+/-- Perspective from a point implies perspective from a line. -/
+theorem perspectiveFromLine_of_point (cfg : DesarguesConfig)
+    (h : cfg.PerspectiveFromPoint) : cfg.PerspectiveFromLine :=
+  (desargues cfg).mp h
+
+/-- Perspective from a line implies perspective from a point. -/
+theorem perspectiveFromPoint_of_line (cfg : DesarguesConfig)
+    (h : cfg.PerspectiveFromLine) : cfg.PerspectiveFromPoint :=
+  (desargues cfg).mpr h
+
+/-- **Self-duality of Desargues.** Swapping points for lines (the two perspectivity
+    conditions) leaves the theorem unchanged: each direction is the converse of the
+    other. Stated here as the symmetric biconditional `point ↔ line`. -/
+theorem desargues_self_dual (cfg : DesarguesConfig) :
+    (cfg.PerspectiveFromPoint ↔ cfg.PerspectiveFromLine)
+      ∧ (cfg.PerspectiveFromLine ↔ cfg.PerspectiveFromPoint) :=
+  ⟨desargues cfg, (desargues cfg).symm⟩
+
+/-- A concrete instance. With centre `(0,0,1)` and the three connectors taken along the
+    `x`-axis, the `y`-axis, and the line `y = x`, the triangles
+    `A=(1,0,1), B=(0,1,1), C=(1,1,1)` and `A'=(3,0,1), B'=(0,2,1), C'=(2,2,1)` are
+    perspective from that point; Desargues then forces the three side-intersections to be
+    collinear. -/
+theorem desargues_example :
+    ∃ cfg : DesarguesConfig, cfg.PerspectiveFromPoint ∧ cfg.PerspectiveFromLine := by
+  refine ⟨{ A := (1, 0, 1), B := (0, 1, 1), C := (1, 1, 1),
+            A' := (3, 0, 1), B' := (0, 2, 1), C' := (2, 2, 1),
+            hABC := by norm_num [det3], hA'B'C' := by norm_num [det3] }, ?_, ?_⟩
+  · show concurDet _ = 0
+    norm_num [DesarguesConfig.concurDet, det3, cross]
+  · apply perspectiveFromLine_of_point
+    show concurDet _ = 0
+    norm_num [DesarguesConfig.concurDet, det3, cross]
+
+end MenelausTheoremOQ01OQ02

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "menelaus-theorem-oq-01-oq-02",
+  "title": "Desargues's Theorem via the Homogeneous-Coordinate Determinant Bracket",
+  "slug": "menelaus-theorem-oq-01-oq-02",
+  "description": "Answers the parent's open question by proving Desargues's theorem — two triangles are perspective from a point iff perspective from a line — entirely from a determinant bracket identity, reusing the parent's collinearity-via-determinant idea lifted to homogeneous coordinates ℝ³. In the projective dictionary the cross product is both the join of two points and the meet of two lines, and incidence is the vanishing of a 3×3 determinant. The concurrence determinant det3(A×A', B×B', C×C') and the collinearity determinant det3(P,Q,R) of the three side-intersections P=BC∩B'C', Q=CA∩C'A', R=AB∩A'B' satisfy the degree-12 identity det3(P,Q,R) = det3(A,B,C)·det3(A',B',C')·det3(A×A', B×B', C×C'), discharged by ring. For non-degenerate triangles the two triangle brackets are nonzero, so collinearity holds iff concurrence does — Desargues, manifestly self-dual. 6 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Desargues%27s_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MenelausTheoremOQ01OQ02.lean",
+    "tags": [
+      "geometry",
+      "projective-geometry",
+      "desargues",
+      "menelaus",
+      "collinearity",
+      "concurrence",
+      "determinant",
+      "homogeneous-coordinates",
+      "cross-product",
+      "duality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound).",
+    "lineCount": 186,
+    "theoremCount": 6,
+    "definitionCount": 10,
+    "originalContributions": [
+      "cross / det3: the projective calculus in homogeneous coordinates ℝ³ — the cross product serving by point/line duality as both the join of two points and the meet of two lines, and the scalar triple product det3 as the universal incidence determinant",
+      "DesarguesConfig: two triangles packaged with their non-degeneracy hypotheses det3 A B C ≠ 0 and det3 A' B' C' ≠ 0",
+      "pointP / pointQ / pointR: the three side-intersections BC∩B'C', CA∩C'A', AB∩A'B' as double cross products (meet of two joins)",
+      "concurDet / collDet, PerspectiveFromPoint / PerspectiveFromLine: the two perspectivity conditions expressed as vanishing determinants",
+      "desargues_bracket_identity: the geometric heart — the degree-12 polynomial identity det3 P Q R = det3 A B C · det3 A' B' C' · concurDet in the 18 coordinates, discharged by ring",
+      "desargues: the main biconditional, read directly off the bracket identity by dividing out the two nonzero triangle determinants",
+      "desargues_self_dual: the point↔line symmetry making Desargues its own converse",
+      "desargues_example: a concrete instance (centre (0,0,1); connectors along the x-axis, y-axis, and y=x) where perspective-from-point forces the side-intersections to be collinear"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Desargues's theorem (Girard Desargues, c. 1639) is the cornerstone of projective geometry: it holds in a projective plane exactly when that plane is coordinatised by a division ring, and its failure characterises the 'non-Desarguesian' planes. Its most transparent proof is algebraic: in homogeneous coordinates every incidence condition becomes the vanishing of a determinant, and the whole theorem reduces to a single bracket (determinant) identity. The parent gallery entry encodes Menelaus collinearity by the vanishing of a 2×2 signed-area determinant and proves its content as a polynomial factorisation; this entry carries the same determinant-as-incidence philosophy into the projective plane ℝ³, where it yields Desargues with no parallel-line case analysis.",
+    "problemStatement": "The parent open question asks to prove Desargues's theorem reusing the parent's determinant-collinearity factorisation, using homogeneous-coordinate determinant conditions. Concretely: working in ℝ³, show that two non-degenerate triangles A B C and A' B' C' are perspective from a point (the connectors A A', B B', C C' are concurrent) if and only if they are perspective from a line (the corresponding-side intersections P = BC∩B'C', Q = CA∩C'A', R = AB∩A'B' are collinear).",
+    "text": "Adopt the standard projective dictionary on ℝ³: a point is a nonzero vector, the cross product u × v is simultaneously the line joining two points and the intersection of two lines (point/line duality), and three vectors are collinear (as points) or concurrent (as lines) exactly when their 3×3 determinant det3 vanishes. The connectors are the lines A×A', B×B', C×C', so perspective-from-a-point is concurrence of these three lines: det3(A×A', B×B', C×C') = 0. The side-intersections are double cross products P = (B×C)×(B'×C'), and so on, and perspective-from-a-line is collinearity of P, Q, R: det3(P,Q,R) = 0. The two determinants are linked by an exact polynomial identity, det3(P,Q,R) = det3(A,B,C)·det3(A',B',C')·det3(A×A', B×B', C×C'). Since the two triangle determinants are nonzero by non-degeneracy, the left side vanishes iff the concurrence determinant does. That is Desargues, and because the identity is symmetric in the roles of points and lines, the theorem is self-dual.",
+    "proofStrategy": "Define cross and det3 by their explicit component formulas. Define the configuration DesarguesConfig carrying both triangles and the two non-degeneracy hypotheses det3 A B C ≠ 0, det3 A' B' C' ≠ 0. Define the side-intersections pointP, pointQ, pointR as double cross products, the two determinants concurDet and collDet, and the predicates PerspectiveFromPoint := concurDet = 0 and PerspectiveFromLine := collDet = 0. The single nontrivial step is desargues_bracket_identity: unfold every definition and let ring verify the degree-12 polynomial identity collDet = det3 A B C · det3 A' B' C' · concurDet across the 18 coordinates. The main theorem desargues then follows mechanically: in the forward direction substitute concurDet = 0 into the identity; in the reverse direction peel the product with mul_eq_zero twice and discharge the two triangle-determinant factors against the non-degeneracy hypotheses. Self-duality is the biconditional together with its symm, and the concrete witness is checked by norm_num.",
+    "keyInsights": [
+      "Homogeneous coordinates eliminate the affine parallel-line degeneracies: 'concurrent' and 'collinear' both become a single determinant vanishing, with points at infinity handled uniformly",
+      "Point/line duality is literally one operation — the cross product is the join of two points and the meet of two lines — so the side-intersections are double cross products",
+      "The entire theorem is one polynomial identity: collDet = det3 A B C · det3 A' B' C' · concurDet, an exact degree-12 bracket factorisation provable by ring",
+      "Non-degeneracy of the two triangles (nonzero brackets) is exactly what lets you divide the factorisation and conclude the biconditional",
+      "The factorisation is symmetric in points versus lines, which is precisely the self-duality of Desargues's theorem",
+      "This is the same 'incidence = vanishing determinant' principle as the parent's affine collinearDet, lifted to the projective plane"
+    ],
+    "prerequisites": [
+      "Homogeneous coordinates for the projective plane and the point/line duality of the cross product",
+      "The 3×3 determinant / scalar triple product as the incidence (collinearity / concurrence) detector",
+      "Parent philosophy: incidence encoded by a vanishing determinant (Proofs/MenelausTheorem.lean, collinearDet_factor)",
+      "mul_eq_zero and the fact that a product of reals vanishes iff a factor does"
+    ]
+  },
+  "conclusion": {
+    "summary": "Desargues's theorem is proved in full: for two non-degenerate triangles in the real projective plane, perspective from a point is equivalent to perspective from a line. The proof reuses the parent's determinant-as-incidence idea in homogeneous coordinates ℝ³, reducing the whole theorem to the exact degree-12 bracket identity det3(P,Q,R) = det3(A,B,C)·det3(A',B',C')·det3(A×A', B×B', C×C') (desargues_bracket_identity), from which the biconditional follows by dividing out the two nonzero triangle determinants. The result is manifestly self-dual. 6 theorems, 10 definitions, 186 lines, 0 sorries, 0 axioms.",
+    "implications": "Provides the gallery with the foundational incidence theorem of projective geometry via a fully elementary, ring-checkable route, and demonstrates that the parent's affine 'incidence = vanishing determinant' technique scales to the projective plane. The cross-product / det3 bracket calculus assembled here is reusable for other projective incidence results (Pappus's theorem, the projective form of Menelaus and Ceva, conics via the 3×3 symmetric form).",
+    "openQuestions": [
+      "Prove Pappus's theorem by the same bracket calculus, and use the Hessenberg implication (Pappus ⟹ Desargues) to relate the two within the gallery",
+      "Formalise the converse-degenerate analysis: classify exactly which collinear/concurrent configurations arise when a triangle determinant vanishes (the projectively degenerate cases excluded here)"
+    ]
+  },
+  "leanFile": {
+    "namespace": "MenelausTheoremOQ01OQ02",
+    "lineCount": 186,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 10,
+    "path": "Proofs/MenelausTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "menelaus-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling answering the same parent. This entry takes up the parent's determinant-collinearity factorisation and carries it to homogeneous coordinates to prove Desargues's theorem."
+    },
+    {
+      "targetId": "menelaus-theorem-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: the affine Menelaus criterion via the signed-area determinant collinearDet, the source of the incidence-as-vanishing-determinant idea reused here."
+    }
+  ],
+  "references": [
+    {
+      "text": "Girard Desargues (c. 1639), as transmitted via Bosse. The two-triangle perspectivity theorem.",
+      "url": "https://en.wikipedia.org/wiki/Desargues%27s_theorem"
+    },
+    {
+      "text": "Richter-Gebert, J. (2011). Perspectives on Projective Geometry. Springer. Bracket/determinant proofs of Desargues and Pappus.",
+      "url": "https://link.springer.com/book/10.1007/978-3-642-17286-1"
+    }
+  ],
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Imports",
+      "startLine": 4,
+      "endLine": 55,
+      "description": "Module docstring stating Desargues's theorem, the homogeneous-coordinate strategy, and how it reuses the parent's incidence-as-vanishing-determinant idea. Imports only Mathlib.",
+      "mathContext": "Perspective from a point $\\iff$ perspective from a line, encoded by vanishing $3\\times3$ determinants in $\\mathbb{R}^3$."
+    },
+    {
+      "id": "calculus",
+      "title": "Cross Product and 3×3 Determinant",
+      "startLine": 63,
+      "endLine": 79,
+      "description": "Defines the homogeneous-coordinate vector type Vec, the cross product (join of points / meet of lines by duality), and the scalar-triple-product determinant det3 whose vanishing detects collinearity and concurrence.",
+      "mathContext": "$\\det_3(P,Q,R)=P\\cdot(Q\\times R)$; vanishes $\\iff$ the three points are collinear / three lines concurrent."
+    },
+    {
+      "id": "configuration",
+      "title": "Configuration and Perspectivity Conditions",
+      "startLine": 81,
+      "endLine": 119,
+      "description": "DesarguesConfig packages two triangles with non-degeneracy hypotheses. Defines the side-intersections pointP, pointQ, pointR as double cross products, the determinants concurDet and collDet, and the predicates PerspectiveFromPoint and PerspectiveFromLine.",
+      "mathContext": "$P=(B\\times C)\\times(B'\\times C')$; concurrence $\\det_3(A\\times A',B\\times B',C\\times C')=0$; collinearity $\\det_3(P,Q,R)=0$."
+    },
+    {
+      "id": "bracket-identity",
+      "title": "The Desargues Bracket Identity",
+      "startLine": 127,
+      "endLine": 135,
+      "description": "desargues_bracket_identity: the geometric heart. The collinearity determinant factors as the product of the two triangle determinants and the concurrence determinant — a degree-12 polynomial identity in the 18 coordinates, discharged by ring.",
+      "mathContext": "$\\det_3(P,Q,R)=\\det_3(A,B,C)\\,\\det_3(A',B',C')\\,\\det_3(A\\times A',B\\times B',C\\times C')$."
+    },
+    {
+      "id": "desargues",
+      "title": "Desargues's Theorem and Self-Duality",
+      "startLine": 137,
+      "endLine": 172,
+      "description": "desargues: perspective from a point ↔ perspective from a line, read off the bracket identity by dividing out the two nonzero triangle determinants (mul_eq_zero). Directional corollaries and desargues_self_dual record the point↔line symmetry.",
+      "mathContext": "With $\\det_3(A,B,C)\\neq0$ and $\\det_3(A',B',C')\\neq0$: $\\det_3(P,Q,R)=0 \\iff \\det_3(A\\times A',B\\times B',C\\times C')=0$."
+    },
+    {
+      "id": "example",
+      "title": "Concrete Perspective Configuration",
+      "startLine": 174,
+      "endLine": 186,
+      "description": "desargues_example: centre (0,0,1) with connectors along the x-axis, y-axis, and the line y=x gives two perspective triangles; Desargues forces the three side-intersections to be collinear. Checked by norm_num.",
+      "mathContext": "$A=(1,0,1),B=(0,1,1),C=(1,1,1)$, $A'=(3,0,1),B'=(0,2,1),C'=(2,2,1)$: concurrent connectors $\\Rightarrow$ collinear $P,Q,R$."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question **menelaus-theorem-oq-01-oq-02**: prove **Desargues's theorem** by reusing the parent's *incidence-as-vanishing-determinant* idea, lifted from the affine plane to **homogeneous coordinates** ℝ³.

Two non-degenerate triangles `A B C`, `A' B' C'` are **perspective from a point** (connectors `AA'`, `BB'`, `CC'` concurrent) **iff** **perspective from a line** (side-intersections `P=BC∩B'C'`, `Q=CA∩C'A'`, `R=AB∩A'B'` collinear).

## Approach

Standard projective dictionary on ℝ³:
- a point is a nonzero vector; the **cross product** is by point/line duality both the *join* of two points and the *meet* of two lines;
- incidence (collinearity / concurrence) ⟺ the `3×3` determinant `det3` vanishes.

The entire theorem collapses to the **degree-12 bracket identity**

```
det3(P,Q,R) = det3(A,B,C) · det3(A',B',C') · det3(A×A', B×B', C×C')
```

a pure polynomial identity in the 18 coordinates, discharged by `ring` (`desargues_bracket_identity`). Non-degeneracy makes the two triangle brackets nonzero, so the collinearity determinant vanishes iff the concurrence determinant does — Desargues, manifestly **self-dual**.

## Content

- `cross`, `det3` — the projective incidence calculus
- `desargues_bracket_identity` — the geometric heart (one `ring`)
- `desargues` — the main biconditional
- `perspectiveFromLine_of_point` / `perspectiveFromPoint_of_line`, `desargues_self_dual`
- `desargues_example` — concrete instance (centre `(0,0,1)`; connectors along x-axis, y-axis, y=x)

**6 theorems, 10 definitions, 186 lines, 0 sorries, 0 axioms** (depends only on `propext`, `Classical.choice`, `Quot.sound`). Desargues is not a named Mathlib result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)