### PR TITLE
research(frobenius-number-oq-01-oq-03): symmetric of type one — PF(⟨a,b⟩)={g} [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FrobeniusNumberOQ01OQ03.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ01OQ03.lean
@@ -1,0 +1,136 @@
+/-
+  OQ-01-OQ-03: Two-Generator Numerical Semigroups Are Symmetric of Type One
+  (frobenius-number-oq-01-oq-03)
+
+  For coprime a, b ≥ 2 with Frobenius number g = ab - a - b, the numerical
+  semigroup S = ⟨a, b⟩ = { ax + by : x, y ∈ ℕ } is **symmetric**, and moreover
+  has **type one**: its set of pseudo-Frobenius numbers is exactly {g}.
+
+  ## What is new here (vs. the parent family)
+
+  - `frobenius-number-oq-01` proves the genus |ℕ \ S| = (a-1)(b-1)/2.
+  - `frobenius-number-oq-02` (`FrobeniusSymmetry.frobenius_symmetry`) proves the
+    interior duality  Rep(n) ↔ ¬Rep(g-n)  for the OPEN range 0 < n < g.
+
+  This file:
+  1. Completes the symmetry to the full closed interval 0 ≤ k ≤ g
+     (`symmetric_le_frobenius`), i.e. the genuine *symmetric numerical semigroup*
+     statement over the whole gap window, including the boundary k = 0 and k = g.
+  2. Introduces the **pseudo-Frobenius** predicate and proves the structural
+     characterisation  PF(S) = {g}  (`pseudoFrobenius_setOf_eq`), hence the
+     semigroup has **type 1** (`frobenius_type_eq_one`). Type 1 is precisely the
+     Gorenstein / symmetric condition in numerical-semigroup theory; two-generator
+     semigroups are its prototypical examples. This invariant (the size of PF(S))
+     is distinct from the genus and from the interior symmetry.
+
+  ## Status: 0 sorries, 0 axioms (built on verified parents).
+-/
+import Mathlib.Data.Set.Card
+import Mathlib.Tactic
+import Proofs.FrobeniusNumber
+import Proofs.FrobeniusNumberOQ02
+
+namespace FrobeniusNumberOQ01OQ03
+
+open FrobeniusNumber FrobeniusSymmetry
+
+variable {a b : ℕ}
+
+/-! ## Part 1: Full symmetry on the closed interval [0, g] -/
+
+/-- **Symmetric numerical semigroup (full statement).** For coprime `a, b ≥ 2`
+with Frobenius number `g = ab - a - b`, and for every `k ≤ g`, exactly one of
+`k` and `g - k` is representable:
+$$ k \in S \iff (g - k) \notin S. $$
+This extends `FrobeniusSymmetry.frobenius_symmetry` (which assumes `0 < k < g`)
+to the boundary points `k = 0` and `k = g`, giving the duality over the entire
+window `0 ≤ k ≤ g`. -/
+theorem symmetric_le_frobenius (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b)
+    {k : ℕ} (hk : k ≤ frobeniusNumber a b) :
+    Representable a b k ↔ ¬ Representable a b (frobeniusNumber a b - k) := by
+  rcases Nat.eq_zero_or_pos k with rfl | hpos
+  · -- k = 0:  0 ∈ S (true), and g - 0 = g ∉ S (true), so the iff is True ↔ ¬False.
+    simp only [Nat.sub_zero]
+    refine ⟨fun _ => frobenius_not_representable hab ha hb, fun _ => representable_zero a b⟩
+  · rcases eq_or_lt_of_le hk with heq | hlt
+    · -- k = g:  g ∉ S (LHS false), and g - g = 0 ∈ S (so ¬Rep is false). False ↔ False.
+      subst heq
+      simp only [Nat.sub_self]
+      exact ⟨fun h => absurd h (frobenius_not_representable hab ha hb),
+             fun h => absurd (representable_zero a b) h⟩
+    · -- 0 < k < g: the interior duality from OQ-02.
+      exact frobenius_symmetry ha hb hab hpos hlt
+
+/-! ## Part 2: Pseudo-Frobenius numbers and type -/
+
+/-- `x` is a **pseudo-Frobenius number** of the numerical semigroup `⟨a, b⟩` when
+`x` is itself a gap (not representable) but `x + s` is representable for every
+nonzero element `s` of the semigroup. Equivalently, `x` is maximal among the gaps
+under the order `u ≤ v ⟺ v - u ∈ S`. The cardinality of this set is the
+**type** of the semigroup. -/
+def IsPseudoFrobenius (a b x : ℕ) : Prop :=
+  ¬ Representable a b x ∧ ∀ s, 0 < s → Representable a b s → Representable a b (x + s)
+
+/-- The Frobenius number `g` is a pseudo-Frobenius number: it is a gap, and adding
+any positive representable value lands above `g`, hence back inside `S`. -/
+theorem frobenius_isPseudoFrobenius (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b) :
+    IsPseudoFrobenius a b (frobeniusNumber a b) := by
+  refine ⟨frobenius_not_representable hab ha hb, ?_⟩
+  intro s hs _
+  obtain ⟨_, _, hmax⟩ := sylvester_frobenius hab ha hb
+  exact hmax (frobeniusNumber a b + s) (by omega)
+
+/-- **Uniqueness.** Every pseudo-Frobenius number equals `g`. If `x` is a gap with
+`x < g`, then by symmetry `g - x ∈ S` and `g - x > 0`, so the pseudo-Frobenius
+closure forces `x + (g - x) = g ∈ S`, contradicting `g ∉ S`. And no gap exceeds
+`g`. -/
+theorem pseudoFrobenius_eq_frobenius (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b)
+    {x : ℕ} (hx : IsPseudoFrobenius a b x) : x = frobeniusNumber a b := by
+  obtain ⟨hx_notrep, hx_closed⟩ := hx
+  have hg_notrep : ¬ Representable a b (frobeniusNumber a b) :=
+    frobenius_not_representable hab ha hb
+  obtain ⟨_, _, hmax⟩ := sylvester_frobenius hab ha hb
+  rcases lt_trichotomy x (frobeniusNumber a b) with hlt | heq | hgt
+  · -- x < g
+    exfalso
+    have hx_pos : 0 < x := by
+      rcases Nat.eq_zero_or_pos x with rfl | hp
+      · exact absurd (representable_zero a b) hx_notrep
+      · exact hp
+    -- g - x is representable (symmetry), and positive
+    have hgx_rep : Representable a b (frobeniusNumber a b - x) := by
+      by_contra h
+      exact hx_notrep ((frobenius_symmetry ha hb hab hx_pos hlt).mpr h)
+    have hgsum : Representable a b (x + (frobeniusNumber a b - x)) :=
+      hx_closed _ (by omega) hgx_rep
+    rw [show x + (frobeniusNumber a b - x) = frobeniusNumber a b by omega] at hgsum
+    exact hg_notrep hgsum
+  · exact heq
+  · -- x > g: every value above g is representable, contradicting that x is a gap.
+    exact absurd (hmax x hgt) hx_notrep
+
+/-- The pseudo-Frobenius numbers of `⟨a, b⟩` are exactly `{g}`. -/
+theorem isPseudoFrobenius_iff (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b)
+    {x : ℕ} : IsPseudoFrobenius a b x ↔ x = frobeniusNumber a b :=
+  ⟨pseudoFrobenius_eq_frobenius ha hb hab, fun h => h ▸ frobenius_isPseudoFrobenius ha hb hab⟩
+
+/-- **PF(S) = {g}.** The set of pseudo-Frobenius numbers is the singleton `{g}`. -/
+theorem pseudoFrobenius_setOf_eq (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b) :
+    {x : ℕ | IsPseudoFrobenius a b x} = {frobeniusNumber a b} := by
+  ext x
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+  exact isPseudoFrobenius_iff ha hb hab
+
+/-- **Type one.** The two-generator numerical semigroup `⟨a, b⟩` has type 1: its set
+of pseudo-Frobenius numbers has cardinality one. This is the defining property of a
+*symmetric* (Gorenstein) numerical semigroup. -/
+theorem frobenius_type_eq_one (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b) :
+    {x : ℕ | IsPseudoFrobenius a b x}.ncard = 1 := by
+  rw [pseudoFrobenius_setOf_eq ha hb hab, Set.ncard_singleton]
+
+/-! ## Numerical sanity checks (⟨3,5⟩, g = 7) -/
+
+-- 7 is pseudo-Frobenius for ⟨3,5⟩; e.g. its only gaps are 1,2,4,7 and only 7 is maximal.
+example : frobeniusNumber 3 5 = 7 := by decide
+
+end FrobeniusNumberOQ01OQ03

--- a/proofs/Proofs/FrobeniusNumberOQ02.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ02.lean
@@ -25,18 +25,14 @@ variable {a b : ℕ}
 
 private lemma mul_mod_inj (ha : 0 < a) (hab : Nat.Coprime a b) :
     Function.Injective (fun k : Fin a => (⟨k.val * b % a, Nat.mod_lt _ ha⟩ : Fin a)) := by
-  intro ⟨i, hi⟩ ⟨j, hj⟩ h
+  intro i j h
   simp only [Fin.mk.injEq] at h
-  -- i*b ≡ j*b (mod a) → a | (i-j)*b → a | i-j → i = j
-  have key : (i : ZMod a) * b = (j : ZMod a) * b := by
-    ext; simp [ZMod.val_natCast, h]
-  have hb_unit : IsUnit ((b : ℕ) : ZMod a) := by
-    rw [ZMod.isUnit_natCast_iff]; exact hab.symm
-  have hij : (i : ZMod a) = (j : ZMod a) :=
-    mul_right_cancel₀ (IsUnit.ne_zero hb_unit) key
-  have := ZMod.natCast_zmod_eq_zero_iff_dvd (i + a - j) a |>.mpr
-  simp [ZMod.natCast_self_eq_zero, ← hij] at this
-  omega
+  -- h : i·b ≡ j·b (mod a); coprimality lets us cancel the right factor b.
+  have hmod : i.val * b ≡ j.val * b [MOD a] := h
+  have hij : i.val ≡ j.val [MOD a] := Nat.ModEq.cancel_right_of_coprime hab hmod
+  have heq : i.val % a = j.val % a := hij
+  rw [Nat.mod_eq_of_lt i.isLt, Nat.mod_eq_of_lt j.isLt] at heq
+  exact Fin.ext heq
 
 private lemma exists_kb_mod (ha : 0 < a) (hab : Nat.Coprime a b) (r : ℕ) (hr : r < a) :
     ∃ k < a, k * b % a = r := by
@@ -53,14 +49,28 @@ theorem rep_and_complement_false (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprim
     (hn : Representable a b n) (hgn : Representable a b (frobeniusNumber a b - n)) : False := by
   obtain ⟨x, y, hxy⟩ := hn; obtain ⟨x', y', hxy'⟩ := hgn
   have hge : a + b ≤ a * b := by nlinarith
-  have hkey : a * b = a * (x + x' + 1) + b * (y + y' + 1) := by
-    simp only [frobeniusNumber] at hn_lt hxy hxy'; omega
-  have hx1b : x + x' + 1 ≤ b := by nlinarith [Nat.zero_le (b * (y + y' + 1))]
-  have hy1a : y + y' + 1 ≤ a := by nlinarith [Nat.zero_le (a * (x + x' + 1))]
-  have hay : a ∣ b * (y + y' + 1) := ⟨b - (x + x' + 1), by omega⟩
-  have hbx : b ∣ a * (x + x' + 1) := ⟨a - (y + y' + 1), by omega⟩
-  linarith [Nat.mul_le_mul_left a (Nat.le_of_dvd (by omega) (hab.symm.dvd_of_dvd_mul_left hbx)),
-            Nat.mul_le_mul_left b (Nat.le_of_dvd (by omega) (hab.dvd_of_dvd_mul_left hay))]
+  simp only [frobeniusNumber] at hn_lt hxy hxy'
+  -- Summing the two representations: a·X + b·Y = a·b with X = x+x'+1, Y = y+y'+1 ≥ 1.
+  have hX1 : 1 ≤ x + x' + 1 := by omega
+  have hY1 : 1 ≤ y + y' + 1 := by omega
+  have hkey : a * (x + x' + 1) + b * (y + y' + 1) = a * b := by
+    have e : a * (x + x' + 1) + b * (y + y' + 1)
+        = (a * x + b * y) + (a * x' + b * y') + a + b := by ring
+    rw [e, ← hxy, ← hxy']; omega
+  -- a ∣ b·Y : b·Y = a·b − a·X is a multiple of a; coprimality lifts a ∣ b·Y to a ∣ Y.
+  have hbY : b * (y + y' + 1) = a * b - a * (x + x' + 1) := by omega
+  have hay : a ∣ b * (y + y' + 1) := by
+    rw [hbY]; exact Nat.dvd_sub ⟨b, rfl⟩ ⟨x + x' + 1, rfl⟩
+  have haX : a * (x + x' + 1) = a * b - b * (y + y' + 1) := by omega
+  have hbx : b ∣ a * (x + x' + 1) := by
+    rw [haX]; exact Nat.dvd_sub ⟨a, by ring⟩ ⟨y + y' + 1, rfl⟩
+  -- Hence Y ≥ a and X ≥ b, forcing a·X + b·Y ≥ 2ab > ab.
+  have hYa : a ≤ y + y' + 1 := Nat.le_of_dvd (by omega) (hab.dvd_of_dvd_mul_left hay)
+  have hXb : b ≤ x + x' + 1 := Nat.le_of_dvd (by omega) (hab.symm.dvd_of_dvd_mul_left hbx)
+  have hAX : a * b ≤ a * (x + x' + 1) := Nat.mul_le_mul (le_refl a) hXb
+  have hBY : b * a ≤ b * (y + y' + 1) := Nat.mul_le_mul (le_refl b) hYa
+  have hcomm : b * a = a * b := Nat.mul_comm b a
+  omega
 
 /-- For 0 < n < g, at least one of n and g-n is representable. -/
 theorem one_of_pair_rep (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b)
@@ -70,20 +80,32 @@ theorem one_of_pair_rep (ha : 2 ≤ a) (hb : 2 ≤ b) (hab : Nat.Coprime a b)
   have ha_pos : 0 < a := by omega
   simp only [frobeniusNumber] at hn_lt ⊢
   obtain ⟨k, hk_lt, hk_mod⟩ := exists_kb_mod ha_pos hab (n % a) (Nat.mod_lt n ha_pos)
+  -- hk_mod : k·b % a = n % a, i.e. k·b ≡ n (mod a).
+  have hmod : k * b ≡ n [MOD a] := hk_mod
+  have hcomm : k * b = b * k := Nat.mul_comm k b
   by_cases hle : k * b ≤ n
   · left
-    obtain ⟨q, hq⟩ := (Nat.dvd_iff_mod_eq_zero.mpr (by omega) : a ∣ n - k * b)
+    -- a ∣ n − k·b, so n = a·q + b·k.
+    obtain ⟨q, hq⟩ := (Nat.modEq_iff_dvd' hle).mp hmod
     exact ⟨q, k, by omega⟩
   · right
     push_neg at hle
-    have h_div : a ∣ k * b - n := Nat.dvd_iff_mod_eq_zero.mpr (by omega)
+    -- a ∣ k·b − n (a positive multiple of a since k·b > n).
+    have h_div : a ∣ k * b - n := (Nat.modEq_iff_dvd' hle.le).mp hmod.symm
     have hkb_ge : a ≤ k * b - n := Nat.le_of_dvd (by omega) h_div
     have hk_bound : k ≤ a - 1 := by omega
-    have hgn_lb : b * (a - 1 - k) ≤ a * b - a - b - n := by
-      nlinarith [Nat.mul_le_mul_right b hk_bound]
+    -- Nonlinear bookkeeping that `omega` cannot see on its own:
+    --   b·(a−1−k) + b·k + b = a·b   (valid because k ≤ a−1).
+    have hrel : b * (a - 1 - k) + b * k + b = a * b := by
+      have hk' : (a - 1 - k) + k + 1 = a := by omega
+      calc b * (a - 1 - k) + b * k + b
+          = b * ((a - 1 - k) + k + 1) := by ring
+        _ = b * a := by rw [hk']
+        _ = a * b := Nat.mul_comm b a
+    have hgn_lb : b * (a - 1 - k) ≤ a * b - a - b - n := by omega
     have h_div2 : a ∣ (a * b - a - b - n) - b * (a - 1 - k) := by
-      have : (a * b - a - b - n) - b * (a - 1 - k) = k * b - n - a := by omega
-      rw [this]; exact Nat.dvd_sub' h_div (dvd_refl a)
+      have hid : (a * b - a - b - n) - b * (a - 1 - k) = k * b - n - a := by omega
+      rw [hid]; exact Nat.dvd_sub h_div (dvd_refl a)
     obtain ⟨q, hq⟩ := h_div2
     exact ⟨q, a - 1 - k, by omega⟩
 

--- a/src/data/proofs/frobenius-number-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-frob-oq0103-context",
+    "proofId": "frobenius-number-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "concept",
+    "title": "Symmetric of type one: PF(⟨a,b⟩) = {g}",
+    "content": "For coprime $a, b \\geq 2$ with Frobenius number $g = ab - a - b$, the numerical semigroup $\\langle a, b\\rangle$ is **symmetric of type one**. Two contributions sit here: (1) `symmetric_le_frobenius` extends the interior duality of sibling OQ-02 (which assumes $0 < k < g$) to the *full* closed interval $0 \\le k \\le g$; (2) the **pseudo-Frobenius** predicate is introduced and $\\mathrm{PF}(\\langle a,b\\rangle) = \\{g\\}$ is proved, giving $\\mathrm{type} = 1$.",
+    "mathContext": "The type of a numerical semigroup is $|\\mathrm{PF}(S)|$; type one $\\Leftrightarrow$ symmetric $\\Leftrightarrow$ $k[t^a,t^b]$ Gorenstein (Kunz 1970)."
+  },
+  {
+    "id": "ann-frob-oq0103-fullsym",
+    "proofId": "frobenius-number-oq-01-oq-03",
+    "range": { "startLine": 35, "endLine": 68 },
+    "type": "proof-step",
+    "title": "symmetric_le_frobenius: closing the boundary",
+    "content": "OQ-02 proves $\\text{Rep}(k) \\Leftrightarrow \\neg\\text{Rep}(g-k)$ only for $0 < k < g$, because the two sides flip polarity at the endpoints. Here the endpoints are checked directly: at $k=0$, $0 \\in S$ and $g \\notin S$; at $k=g$, $g \\notin S$ and $0 \\in S$. The interior case delegates to `frobenius_symmetry`. The result is the genuine symmetric-semigroup statement over the whole gap window $[0,g]$.",
+    "mathContext": "A numerical semigroup is symmetric iff $k \\in S \\Leftrightarrow g - k \\notin S$ for every $0 \\le k \\le g$ — boundary included."
+  },
+  {
+    "id": "ann-frob-oq0103-pfdef",
+    "proofId": "frobenius-number-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 85 },
+    "type": "definition",
+    "title": "IsPseudoFrobenius and that g qualifies",
+    "content": "`IsPseudoFrobenius a b x := ¬Rep(x) ∧ ∀ s, 0 < s → Rep(s) → Rep(x + s)`: $x$ is a gap that becomes representable on adding *any* nonzero semigroup element. `frobenius_isPseudoFrobenius` shows $g$ qualifies — it is a gap (`frobenius_not_representable`), and $g + s > g$ is representable for positive representable $s$ by the maximality clause of `sylvester_frobenius`.",
+    "mathContext": "Pseudo-Frobenius numbers are the maximal gaps of $S$ under $u \\preceq v \\Leftrightarrow v - u \\in S$; their count is the type."
+  },
+  {
+    "id": "ann-frob-oq0103-uniqueness",
+    "proofId": "frobenius-number-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 111 },
+    "type": "key-insight",
+    "title": "Uniqueness: the symmetry corners the maximal gap at g",
+    "content": "`pseudoFrobenius_eq_frobenius` runs a trichotomy on $x$ versus $g$. If $x > g$, maximality makes $x$ representable, contradicting that it is a gap. If $x < g$, then $x > 0$ (as $0 \\in S$) and the interior symmetry yields a *representable* complement $g - x > 0$; feeding it into the pseudo-Frobenius closure produces $x + (g - x) = g \\in S$, contradicting $g \\notin S$. So $x = g$. The two parent facts — symmetry below $g$ and representability above $g$ — cover the line on both sides of $g$.",
+    "mathContext": "The Frobenius number is the unique maximal gap precisely when the semigroup is symmetric."
+  },
+  {
+    "id": "ann-frob-oq0103-type",
+    "proofId": "frobenius-number-oq-01-oq-03",
+    "range": { "startLine": 113, "endLine": 136 },
+    "type": "proof-step",
+    "title": "PF(S) = {g} and type = 1",
+    "content": "`isPseudoFrobenius_iff` fuses existence and uniqueness into $\\text{IsPseudoFrobenius}\\,a\\,b\\,x \\leftrightarrow x = g$. `pseudoFrobenius_setOf_eq` rewrites the set comprehension to the singleton $\\{g\\}$, and `frobenius_type_eq_one` reads off $\\mathrm{ncard} = 1$ via `Set.ncard_singleton`. The closing example checks $g(3,5) = 7$ by kernel `decide` (no `native_decide`), the semigroup $\\langle 3,5\\rangle$ having gaps $\\{1,2,4,7\\}$ with unique maximal gap $7$.",
+    "mathContext": "type$(\\langle a,b\\rangle) = 1$ — a distinct invariant from the genus $(a-1)(b-1)/2$ of sibling OQ-01."
+  }
+]

--- a/src/data/proofs/frobenius-number-oq-01-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03/meta.json
@@ -1,0 +1,219 @@
+{
+  "id": "frobenius-number-oq-01-oq-03",
+  "title": "Two-Generator Numerical Semigroups Are Symmetric of Type One: PF(⟨a,b⟩) = {g}",
+  "slug": "frobenius-number-oq-01-oq-03",
+  "description": "For coprime a, b ≥ 2 with Frobenius number g = ab − a − b, the numerical semigroup ⟨a, b⟩ = {ax + by : x, y ∈ ℕ} is symmetric of type one. Two contributions: (1) symmetric_le_frobenius completes the interior duality Rep(n) ↔ ¬Rep(g−n) of sibling OQ-02 (which assumed 0 < n < g) to the FULL closed interval 0 ≤ k ≤ g, including the boundary k = 0 and k = g — i.e. the genuine symmetric-numerical-semigroup statement over the whole gap window; (2) the pseudo-Frobenius predicate IsPseudoFrobenius is introduced and the structural theorem PF(⟨a,b⟩) = {g} is proved (pseudoFrobenius_setOf_eq), giving type(⟨a,b⟩) = 1 (frobenius_type_eq_one). Type one is exactly the Gorenstein/symmetric condition in numerical-semigroup theory; this invariant (the size of the pseudo-Frobenius set) is distinct from the genus (sibling OQ-01) and from the interior symmetry (sibling OQ-02). 6 theorems + 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ01OQ03.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean"
+    ],
+    "tags": [
+      "number-theory",
+      "frobenius",
+      "coin-problem",
+      "numerical-semigroups",
+      "symmetric-semigroup",
+      "pseudo-frobenius",
+      "gorenstein",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 136,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None. All results are proved from first principles on top of the verified parents FrobeniusNumber (Sylvester's g = ab−a−b and the maximality fact ∀ n > g, Rep n) and FrobeniusNumberOQ02 (the interior symmetry). The only hypotheses are the mathematical conditions a, b ≥ 2 and gcd(a, b) = 1. No axioms beyond Lean/Mathlib's foundational propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide / Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.ncard_singleton",
+        "description": "The cardinality (ncard) of a singleton set is 1 — converts PF(S) = {g} into type(S) = 1.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Nat.le_of_dvd",
+        "description": "Used indirectly through the parent symmetry; the maximality ∀ n > g, Rep n comes from FrobeniusNumber.sylvester_frobenius.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "symmetric_le_frobenius: extends the interior duality of OQ-02 (valid only for 0 < k < g) to the full closed interval 0 ≤ k ≤ g by handling the two boundary points — k = 0 (where 0 ∈ S and g ∉ S) and k = g (where g ∉ S and 0 ∈ S). This is the complete 'symmetric numerical semigroup' statement over the whole gap window.",
+      "IsPseudoFrobenius a b x := ¬Rep(x) ∧ ∀ s, 0 < s → Rep(s) → Rep(x + s): a clean Lean encoding of the pseudo-Frobenius (maximal-gap) condition, the building block of the type invariant of a numerical semigroup.",
+      "frobenius_isPseudoFrobenius: g is pseudo-Frobenius — it is a gap (parent frobenius_not_representable) and g + s lies above g for every positive representable s, hence is representable (parent maximality sylvester_frobenius).",
+      "pseudoFrobenius_eq_frobenius (uniqueness): any pseudo-Frobenius x equals g. A gap x with x < g forces, by the interior symmetry, g − x ∈ S with g − x > 0; the pseudo-Frobenius closure then yields x + (g − x) = g ∈ S, contradicting g ∉ S. And no gap exceeds g. Hence PF(⟨a,b⟩) = {g}.",
+      "frobenius_type_eq_one: the set of pseudo-Frobenius numbers has cardinality one, i.e. ⟨a, b⟩ has type 1 — the defining property of a symmetric (Gorenstein) numerical semigroup. The type invariant is distinct from the genus (a−1)(b−1)/2 of sibling OQ-01."
+    ],
+    "prerequisites": [
+      "frobenius-number (parent: g(a,b) = ab − a − b; maximality ∀ n > g, Rep n via sylvester_frobenius; g is a gap)",
+      "frobenius-number-oq-02 (interior symmetry Rep(n) ↔ ¬Rep(g−n) for 0 < n < g)",
+      "Definition Representable a b n := ∃ x y : ℕ, n = a·x + b·y",
+      "Set.ncard of a singleton (Mathlib.Data.Set.Card)"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The two-generator **Frobenius coin problem** (Chicken McNugget theorem) has a rich invariant theory beyond the largest gap $g = ab - a - b$. A numerical semigroup $S$ with Frobenius number $g$ is **symmetric** when $k \\in S \\Leftrightarrow g - k \\notin S$ for all integers $k$; equivalently (Kunz 1970) its coordinate ring $k[t^a, t^b]$ is **Gorenstein**. Symmetry is measured by the **type** of $S$ — the cardinality of the set $\\mathrm{PF}(S)$ of *pseudo-Frobenius numbers* (the maximal gaps under the order $u \\preceq v \\Leftrightarrow v - u \\in S$). The fundamental structural fact, going back to the work crystallized by Kunz and by Fröberg–Gottlieb–Häggkvist, is that $S$ is symmetric **iff** $\\mathrm{type}(S) = 1$, i.e. $\\mathrm{PF}(S) = \\{g\\}$. Two-generator semigroups are the prototypical type-one (symmetric, complete-intersection) examples. This entry proves $\\mathrm{PF}(\\langle a, b\\rangle) = \\{g\\}$ directly, and completes the sibling OQ-02 symmetry to the full gap interval.",
+    "problemStatement": "Let $a, b \\geq 2$ be coprime, $S = \\langle a, b\\rangle = \\{ax + by : x, y \\in \\mathbb{N}\\}$, and $g = ab - a - b$. (1) Prove the symmetry $k \\in S \\Leftrightarrow (g - k) \\notin S$ over the whole interval $0 \\leq k \\leq g$ (the boundary completion of OQ-02). (2) Define a pseudo-Frobenius number as a gap $x \\notin S$ with $x + s \\in S$ for every $s \\in S \\setminus \\{0\\}$, and prove that the set of pseudo-Frobenius numbers of $S$ is exactly $\\{g\\}$ — hence $\\mathrm{type}(S) = 1$.",
+    "text": "Two-generator numerical semigroups are symmetric of type one: the only maximal gap (pseudo-Frobenius number) is the Frobenius number g itself, so PF(⟨a,b⟩) = {g} and type = 1.",
+    "proofStrategy": "**Part 1 — full symmetry `symmetric_le_frobenius`.** For $0 \\le k \\le g$ split into three cases. $k = 0$: $0 \\in S$ (true) and $g - 0 = g \\notin S$ (parent `frobenius_not_representable`), so the biconditional is $\\text{True} \\leftrightarrow \\neg\\text{False}$. $k = g$: $g \\notin S$ and $g - g = 0 \\in S$, so it is $\\text{False} \\leftrightarrow \\neg\\text{True}$. $0 < k < g$: this is exactly OQ-02's `frobenius_symmetry`. **Part 2 — type one.** Define `IsPseudoFrobenius a b x := ¬Rep(x) ∧ ∀ s, 0 < s → Rep(s) → Rep(x + s)`. **(g is pseudo-Frobenius)** `frobenius_isPseudoFrobenius`: $g$ is a gap, and for positive representable $s$, $g + s > g$ so $g + s \\in S$ by the parent maximality `sylvester_frobenius`. **(uniqueness)** `pseudoFrobenius_eq_frobenius`: let $x$ be pseudo-Frobenius. If $x > g$ then $x \\in S$ (maximality), contradicting $x$ a gap; so $x \\le g$. If $x < g$ then $x > 0$ (since $0 \\in S$), and by the interior symmetry $g - x \\in S$ with $g - x > 0$; the closure property gives $x + (g - x) = g \\in S$, contradicting $g \\notin S$. Hence $x = g$. **(assembly)** `pseudoFrobenius_setOf_eq` packages $\\{x \\mid \\text{IsPseudoFrobenius } a\\, b\\, x\\} = \\{g\\}$, and `frobenius_type_eq_one` reads off `Set.ncard = 1` via `Set.ncard_singleton`.",
+    "keyInsights": [
+      "**Type one is the right invariant for 'symmetric'.** Where the genus (sibling OQ-01) counts the gaps and the interior duality (sibling OQ-02) pairs them, the type counts only the *maximal* gaps. Proving $\\mathrm{PF}(S) = \\{g\\}$ captures symmetry as a single-element structural statement — the combinatorial shadow of $k[t^a, t^b]$ being Gorenstein.",
+      "**The uniqueness proof is exactly where the interior symmetry does its work.** A gap $x$ strictly below $g$ has a *representable* complement $g - x$ (symmetry), and that complement is a legal positive semigroup element to feed into the pseudo-Frobenius closure — landing precisely on $g$, the one value forbidden. The maximality fact $\\forall n > g, n \\in S$ kills the $x > g$ case. The two parent facts (symmetry below $g$, representability above $g$) cover the line on either side of $g$.",
+      "**Boundary completion is not vacuous.** OQ-02 deliberately restricts to $0 < n < g$ because the biconditional's two sides flip polarity at the endpoints; `symmetric_le_frobenius` shows both endpoints still satisfy $k \\in S \\Leftrightarrow g - k \\notin S$ (both make it $\\text{T} \\leftrightarrow \\neg\\text{F}$ / $\\text{F} \\leftrightarrow \\neg\\text{T}$), so the symmetric-semigroup statement is genuinely valid on the entire closed window $[0, g]$.",
+      "**Pseudo-Frobenius numbers generalize past two generators, the closed form does not.** For three or more generators $\\mathrm{type}(S)$ can be arbitrarily large and there is no Sylvester-style formula for $g$; type one is the exception that the two-generator case always realizes. Encoding `IsPseudoFrobenius` abstractly (not tied to $a, b$) keeps the door open to those generalizations."
+    ],
+    "prerequisites": [
+      "Frobenius number $g(a,b) = ab - a - b$ and maximality $\\forall n > g,\\ n \\in S$ (parent `frobenius-number`)",
+      "Interior symmetry $\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g-n)$ for $0 < n < g$ (sibling `frobenius-number-oq-02`)",
+      "Pseudo-Frobenius numbers and the type of a numerical semigroup (Rosales–García-Sánchez, Ch. 4)",
+      "$\\mathrm{ncard}$ of a singleton set"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Documentation of the two contributions (full-interval symmetry and type-one) and the relationship to siblings OQ-01 (genus) and OQ-02 (interior symmetry). Imports Mathlib.Data.Set.Card (for Set.ncard) and the verified parents FrobeniusNumber and FrobeniusNumberOQ02.",
+      "mathContext": "Two-generator numerical semigroups are symmetric of type one — PF(⟨a,b⟩) = {g}."
+    },
+    {
+      "id": "full-symmetry",
+      "title": "Part 1: symmetric_le_frobenius (Symmetry on the closed interval [0, g])",
+      "startLine": 35,
+      "endLine": 68,
+      "summary": "For 0 ≤ k ≤ g, Rep(k) ↔ ¬Rep(g − k). Case k = 0: 0 ∈ S and g ∉ S. Case k = g: g ∉ S and 0 ∈ S. Case 0 < k < g: delegates to OQ-02's frobenius_symmetry. Completes the duality to the boundary points OQ-02 omitted.",
+      "mathContext": "The genuine symmetric-numerical-semigroup statement over the entire gap window, not just its interior."
+    },
+    {
+      "id": "pf-def",
+      "title": "Part 2: IsPseudoFrobenius (definition)",
+      "startLine": 70,
+      "endLine": 74,
+      "summary": "IsPseudoFrobenius a b x := ¬Representable a b x ∧ ∀ s, 0 < s → Representable a b s → Representable a b (x + s). A gap that becomes representable on adding any nonzero semigroup element; the cardinality of this set is the type.",
+      "mathContext": "Pseudo-Frobenius numbers are the maximal gaps under u ⪯ v ⟺ v − u ∈ S."
+    },
+    {
+      "id": "g-is-pf",
+      "title": "frobenius_isPseudoFrobenius (g is pseudo-Frobenius)",
+      "startLine": 76,
+      "endLine": 85,
+      "summary": "g is a gap (frobenius_not_representable) and for positive representable s, g + s > g hence representable by the maximality clause of sylvester_frobenius.",
+      "mathContext": "The Frobenius number is always a pseudo-Frobenius number of any numerical semigroup."
+    },
+    {
+      "id": "pf-uniqueness",
+      "title": "pseudoFrobenius_eq_frobenius (uniqueness)",
+      "startLine": 87,
+      "endLine": 111,
+      "summary": "Trichotomy on x vs g. x > g: maximality gives Rep(x), contradicting the gap hypothesis. x = g: done. x < g: x > 0 (since Rep 0), interior symmetry gives Rep(g − x) with g − x > 0, and the closure property forces Rep(g), contradicting g ∉ S. Hence x = g.",
+      "mathContext": "The interior symmetry plus maximality pin the unique maximal gap to g."
+    },
+    {
+      "id": "pf-set-and-type",
+      "title": "isPseudoFrobenius_iff, pseudoFrobenius_setOf_eq, frobenius_type_eq_one",
+      "startLine": 113,
+      "endLine": 129,
+      "summary": "Combine existence and uniqueness into IsPseudoFrobenius a b x ↔ x = g; rewrite the set comprehension to the singleton {g} (pseudoFrobenius_setOf_eq); and read off ncard = 1 via Set.ncard_singleton (frobenius_type_eq_one).",
+      "mathContext": "PF(⟨a,b⟩) = {g} ⟹ type(⟨a,b⟩) = 1: the semigroup is symmetric (Gorenstein)."
+    },
+    {
+      "id": "sanity",
+      "title": "Numerical sanity check",
+      "startLine": 131,
+      "endLine": 136,
+      "summary": "frobeniusNumber 3 5 = 7 by kernel decide (no native_decide), anchoring the example ⟨3,5⟩ whose only gaps are {1,2,4,7} with unique maximal gap 7.",
+      "mathContext": "For ⟨3,5⟩, g = 7 is the unique pseudo-Frobenius number; type = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "In 136 lines, 0 sorries, 0 axioms, the two-generator numerical semigroup ⟨a, b⟩ (coprime a, b ≥ 2) is shown symmetric of type one: the symmetry Rep(k) ↔ ¬Rep(g − k) holds on the full closed interval 0 ≤ k ≤ g (completing sibling OQ-02's interior result at the boundary), and the set of pseudo-Frobenius numbers is exactly {g}, so type(⟨a,b⟩) = 1. The uniqueness argument uses the interior symmetry (gap below g ⟹ representable complement) together with the parent maximality (everything above g is representable) to corner the unique maximal gap at g.",
+    "implications": "Type one is the defining combinatorial property of symmetric — equivalently Gorenstein — numerical semigroups (Kunz 1970). This entry makes the type invariant available alongside the genus (OQ-01) and the interior duality (OQ-02), completing the elementary invariant theory of the two-generator case. The pseudo-Frobenius predicate is stated abstractly, leaving a hook for the genuinely harder ≥ 3-generator theory where type can be large and no closed-form Frobenius number exists.",
+    "openQuestions": [
+      "Prove the converse direction of the structural theorem in this gallery: a numerical semigroup with type 1 (|PF(S)| = 1) is symmetric, i.e. k ∈ S ⟺ g − k ∉ S — closing the 'symmetric ⟺ type 1' equivalence in a generator-agnostic setting.",
+      "Define the genus directly from PF / the type and recover (a−1)(b−1)/2 of sibling OQ-01 as a corollary of type one, exhibiting the bijection between the two invariants for symmetric semigroups."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "extends",
+      "description": "Directly imports and uses FrobeniusSymmetry.frobenius_symmetry. symmetric_le_frobenius extends OQ-02's interior duality (0 < n < g) to the closed interval [0, g], and the pseudo-Frobenius uniqueness proof invokes the interior symmetry to produce the representable complement g − x."
+    },
+    {
+      "targetId": "frobenius-number-oq-01",
+      "relationship": "related",
+      "description": "Sibling: OQ-01 computes the genus |ℕ \\ S| = (a−1)(b−1)/2 (a count invariant). This entry computes the type |PF(S)| = 1 (a structural invariant). Both are facets of the symmetry, but the type is the one that characterizes the Gorenstein property."
+    },
+    {
+      "targetId": "frobenius-number",
+      "relationship": "foundational",
+      "description": "Parent: supplies Representable, frobeniusNumber = ab − a − b, frobenius_not_representable (g is a gap), and sylvester_frobenius (the maximality ∀ n > g, Rep n) that both the existence and the x > g branch of uniqueness rely on."
+    }
+  ],
+  "references": [
+    {
+      "title": "The value-semigroup of a one-dimensional Gorenstein ring",
+      "author": "Ernst Kunz",
+      "year": "1970",
+      "venue": "Proceedings of the American Mathematical Society 25, 748–751",
+      "description": "Establishes that a numerical semigroup is symmetric iff its coordinate ring is Gorenstein iff it has type one — the structural significance of PF(S) = {g}."
+    },
+    {
+      "title": "Numerical Semigroups",
+      "author": "J. C. Rosales, P. A. García-Sánchez",
+      "year": "2009",
+      "venue": "Springer Developments in Mathematics 20",
+      "description": "Chapter 4 develops pseudo-Frobenius numbers, the type, and the symmetric / pseudo-symmetric classification, with two-generator semigroups as the model type-one examples."
+    },
+    {
+      "title": "On numerical semigroups",
+      "author": "R. Fröberg, C. Gottlieb, R. Häggkvist",
+      "year": "1987",
+      "venue": "Semigroup Forum 35, 63–83",
+      "description": "Foundational treatment of the type, pseudo-Frobenius numbers, and symmetric/pseudo-symmetric numerical semigroups."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FrobeniusNumberOQ01OQ03.lean",
+    "filename": "FrobeniusNumberOQ01OQ03.lean",
+    "imports": [
+      "Mathlib.Data.Set.Card",
+      "Mathlib.Tactic",
+      "Proofs.FrobeniusNumber",
+      "Proofs.FrobeniusNumberOQ02"
+    ],
+    "namespace": "FrobeniusNumberOQ01OQ03",
+    "lineCount": 136,
+    "theoremCount": 6,
+    "axiomCount": 0,
+    "definitionCount": 1,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01OQ03.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean"
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-01",
+      "question": "Prove the converse: a numerical semigroup of type 1 (|PF(S)| = 1) is symmetric, completing the 'symmetric ⟺ type one' equivalence in a generator-agnostic setting.",
+      "significance": "high"
+    },
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-02",
+      "question": "Derive the genus (a−1)(b−1)/2 of sibling OQ-01 as a corollary of type one, exhibiting the bijection between the genus and type invariants for symmetric semigroups.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/frobenius-number-oq-02/meta.json
+++ b/src/data/proofs/frobenius-number-oq-02/meta.json
@@ -22,7 +22,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 101,
+    "lineCount": 123,
     "theoremCount": 5,
     "definitionCount": 0,
     "assumptions": "None. All results proved from first principles. The only hypotheses are the mathematical conditions of the theorem: a, b ≥ 2, gcd(a, b) = 1, and 0 < n < g. No axioms or structure-encoded assumptions.",
@@ -33,9 +33,14 @@
         "module": "Mathlib.Logic.Equiv.Defs"
       },
       {
-        "theorem": "ZMod.isUnit_natCast_iff",
-        "description": "b is a unit in ZMod a iff gcd(a, b) = 1 — the coprimality hypothesis enters here to cancel b in the residue injectivity proof.",
-        "module": "Mathlib.Data.ZMod.Basic"
+        "theorem": "Nat.ModEq.cancel_right_of_coprime",
+        "description": "If gcd(a, b) = 1 and i·b ≡ j·b (mod a) then i ≡ j (mod a) — cancels the right factor b in the residue injectivity proof (refreshed for Mathlib v4.26, replacing the older ZMod-unit cancellation).",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Nat.modEq_iff_dvd'",
+        "description": "For x ≤ y, x ≡ y (mod n) ↔ n ∣ y − x — converts the congruence k·b ≡ n (mod a) into the divisibility facts that build the explicit representations.",
+        "module": "Mathlib.Data.Nat.ModEq"
       },
       {
         "theorem": "Nat.Coprime.dvd_of_dvd_mul_left",
@@ -43,21 +48,21 @@
         "module": "Mathlib.Data.Nat.GCD.Basic"
       },
       {
-        "theorem": "Nat.dvd_sub'",
-        "description": "Divisibility is preserved under truncated subtraction — assembles the second witness in one_of_pair_rep.",
-        "module": "Mathlib.Data.Nat.Defs"
+        "theorem": "Nat.dvd_sub",
+        "description": "Divisibility is preserved under truncated subtraction — assembles the second witness in one_of_pair_rep and the a ∣ b·Y / b ∣ a·X facts in rep_and_complement_false.",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
       }
     ],
     "originalContributions": [
       "First-principles proof of the Frobenius/Sylvester symmetry Rep(n) ↔ ¬Rep(g−n) for two coprime generators, self-contained with no external symmetry axiom.",
       "rep_and_complement_false: if both n and g−n were representable, summing the witnesses forces a·b = a·(x+x'+1) + b·(y+y'+1) with each factor bounded by the other generator, yielding a ∣ b·(…) and b ∣ a·(…); coprimality then gives a contradiction via a counting/divisibility squeeze.",
-      "one_of_pair_rep: a constructive residue-completion argument — exists_kb_mod shows the map k ↦ k·b mod a is a bijection on Fin a (injective via ZMod cancellation by the unit b, hence surjective), so the residue n mod a equals k·b mod a for some k < a; a case split on k·b ≤ n produces an explicit representation of either n or g−n.",
+      "one_of_pair_rep: a constructive residue-completion argument — exists_kb_mod shows the map k ↦ k·b mod a is a bijection on Fin a (injective via Nat.ModEq.cancel_right_of_coprime cancelling the coprime factor b, hence surjective), so the residue n mod a equals k·b mod a for some k < a; a case split on k·b ≤ n produces an explicit representation of either n or g−n via Nat.modEq_iff_dvd'.",
       "Correction of the problem's posed statement: the symmetry is Rep(n) ↔ ¬Rep(g−n), NOT ¬Rep(n) ↔ ¬Rep(g−n) (counterexample a=3, b=5, g=7: n=1 non-rep, g−n=6 representable)."
     ],
     "prerequisites": [
       "frobenius-number (parent: Sylvester's Frobenius number formula g(a,b) = ab − a − b)",
       "Definition Representable a b n := ∃ x y : ℕ, n = a·x + b·y (from parent FrobeniusNumber)",
-      "ZMod arithmetic: units and cancellation (b invertible mod a ⇔ coprime)",
+      "Modular cancellation in ℕ: i·b ≡ j·b (mod a) ⇒ i ≡ j (mod a) when gcd(a, b) = 1",
       "Pigeonhole on finite types: injective ⇒ surjective on Fin a"
     ],
     "dateAdded": "2026-06-16",
@@ -67,18 +72,18 @@
     "historicalContext": "The **Frobenius coin problem** (Chicken McNugget theorem, postage-stamp problem) for two coprime generators $a, b$ was solved by **James Joseph Sylvester** (1880s): the largest non-representable integer is the *Frobenius number* $g(a, b) = ab - a - b$ (parent entry `frobenius-number`), and there are exactly $\\frac{(a-1)(b-1)}{2}$ non-representable positive integers (sibling `frobenius-number-oq-01`). Underlying *both* of Sylvester's theorems is a single structural fact: the numerical semigroup $\\langle a, b\\rangle$ is **symmetric**. A numerical semigroup $S$ with Frobenius number $g$ is called symmetric when for every $k \\in \\{0, 1, \\ldots, g\\}$, $k \\in S \\Leftrightarrow g - k \\notin S$. For two coprime generators this symmetry *always holds* — and that is precisely the statement formalized here: $\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g - n)$ for $0 < n < g$.\n\nThe notion of symmetric numerical semigroups was crystallized by **Kunz (1970)** and connected to **Gorenstein** local rings: $\\langle a, b\\rangle$ symmetric corresponds to $k[t^a, t^b]$ being a Gorenstein ring. **Herzog (1970)** generalized this to complete-intersection numerical semigroups. So the unassuming biconditional in this file is the elementary shadow of a deep duality in commutative algebra.",
     "problemStatement": "For coprime positive integers $a, b \\geq 2$ with Frobenius number $g(a, b) = ab - a - b$, and any $n$ with $0 < n < g$, prove the symmetry\n\n$$\\text{Representable}(a, b, n) \\;\\Longleftrightarrow\\; \\neg\\,\\text{Representable}(a, b, g - n),$$\n\nwhere $\\text{Representable}(a, b, m) := \\exists\\, x, y \\in \\mathbb{N},\\ m = ax + by$. Equivalently: in the open interval $(0, g)$, exactly one of each complementary pair $\\{n, g - n\\}$ is representable.",
     "text": "The structural symmetry of two-generator numerical semigroups: in the range below the Frobenius number, a value is representable exactly when its complement is not. This is the engine behind Sylvester's genus count.",
-    "proofStrategy": "**Two complementary halves, combined into a biconditional.** **(⇒, no two reps) `rep_and_complement_false`:** assume both $n = ax + by$ and $g - n = ax' + by'$ are representable. Adding and using $g = ab - a - b$ gives $ab = a(x + x' + 1) + b(y + y' + 1)$. Each summand is non-negative, forcing $x + x' + 1 \\leq b$ and $y + y' + 1 \\leq a$; rearranging shows $a \\mid b(y + y' + 1)$ and $b \\mid a(x + x' + 1)$. Coprimality (`Nat.Coprime.dvd_of_dvd_mul_left`) turns these into $a \\mid (y+y'+1)$ and $b \\mid (x+x'+1)$, and a `linarith` squeeze against the bounds yields `False`. **(⇐, at least one rep) `one_of_pair_rep`:** the helper `exists_kb_mod` proves $k \\mapsto k b \\bmod a$ is a bijection on $\\mathrm{Fin}\\,a$ — injectivity comes from cancelling the unit $b$ in $\\mathbb{Z}/a\\mathbb{Z}$ (coprimality via `ZMod.isUnit_natCast_iff`), and `Finite.injective_iff_surjective` upgrades to surjectivity — so some $k < a$ satisfies $kb \\equiv n \\pmod a$. Case split: if $kb \\leq n$ then $n - kb$ is a non-negative multiple of $a$, giving $\\text{Rep}(n)$ directly; otherwise an explicit witness $\\langle q, a - 1 - k\\rangle$ represents $g - n$. **Assembly `frobenius_symmetry`:** the forward direction is `rep_and_complement_false` contrapositive; the backward direction picks the representable element from `one_of_pair_rep`.",
+    "proofStrategy": "**Two complementary halves, combined into a biconditional.** **(⇒, no two reps) `rep_and_complement_false`:** assume both $n = ax + by$ and $g - n = ax' + by'$ are representable. Adding and using $g = ab - a - b$ gives $ab = a(x + x' + 1) + b(y + y' + 1)$. Each summand is non-negative, forcing $x + x' + 1 \\leq b$ and $y + y' + 1 \\leq a$; rearranging shows $a \\mid b(y + y' + 1)$ and $b \\mid a(x + x' + 1)$. Coprimality (`Nat.Coprime.dvd_of_dvd_mul_left`) turns these into $a \\mid (y+y'+1)$ and $b \\mid (x+x'+1)$, and a `linarith` squeeze against the bounds yields `False`. **(⇐, at least one rep) `one_of_pair_rep`:** the helper `exists_kb_mod` proves $k \\mapsto k b \\bmod a$ is a bijection on $\\mathrm{Fin}\\,a$ — injectivity comes from `Nat.ModEq.cancel_right_of_coprime` cancelling the coprime factor $b$ in $i b \\equiv j b \\pmod a$, and `Finite.injective_iff_surjective` upgrades to surjectivity — so some $k < a$ satisfies $kb \\equiv n \\pmod a$. Case split (`Nat.modEq_iff_dvd'` turns the congruence into divisibility): if $kb \\leq n$ then $n - kb$ is a non-negative multiple of $a$, giving $\\text{Rep}(n)$ directly; otherwise an explicit witness $\\langle q, a - 1 - k\\rangle$ represents $g - n$. **Assembly `frobenius_symmetry`:** the forward direction is `rep_and_complement_false` contrapositive; the backward direction picks the representable element from `one_of_pair_rep`.",
     "keyInsights": [
       "**The symmetry is the single source of *both* Sylvester theorems.** The Frobenius number formula (largest gap = $g$) and the genus formula (number of gaps = $\\frac{(a-1)(b-1)}{2}$, sibling OQ-01) are both corollaries of this one biconditional: it says the involution $k \\mapsto g - k$ swaps the representable and non-representable sets in $(0, g)$. OQ-01 literally imports this file and uses it as a one-line black box inside a `Finset.card_bij`.",
-      "**Coprimality enters exactly twice, in dual guises.** In `rep_and_complement_false` it converts $a \\mid bc$ into $a \\mid c$ (a *divisibility* use). In `one_of_pair_rep` it makes $b$ a *unit* in $\\mathbb{Z}/a\\mathbb{Z}$, so multiplication by $b$ permutes residues (a *cancellation* use). Both are facets of $\\gcd(a, b) = 1$, and without it the result is false — non-coprime generators only represent multiples of the gcd.",
+      "**Coprimality enters exactly twice, in dual guises.** In `rep_and_complement_false` it converts $a \\mid bc$ into $a \\mid c$ (a *divisibility* use). In `one_of_pair_rep` it cancels the factor $b$ in a congruence mod $a$, so multiplication by $b$ permutes residues (a *cancellation* use, via `Nat.ModEq.cancel_right_of_coprime`). Both are facets of $\\gcd(a, b) = 1$, and without it the result is false — non-coprime generators only represent multiples of the gcd.",
       "**The residue-completion lemma is the constructive core.** `exists_kb_mod` says every residue class mod $a$ is realized by some multiple $kb$ with $k < a$. This is a finite pigeonhole (injective map on $\\mathrm{Fin}\\,a$ is surjective) and is exactly the statement that $\\{0, b, 2b, \\ldots, (a-1)b\\}$ is a complete residue system mod $a$ when $\\gcd(a, b) = 1$. It converts the *existence* of a representation into a concrete search bounded by $a$.",
       "**Statement correction matters.** The problem JSON posed $\\neg\\text{Rep}(n) \\Leftrightarrow \\neg\\text{Rep}(g-n)$, which is FALSE: it would say representability is symmetric under $n \\mapsto g - n$, but the truth is *anti*-symmetric (representable ↔ complement non-representable). The header documents the counterexample $(a,b)=(3,5)$, $g=7$: $n=1$ is non-representable while $g-n=6 = 3\\cdot2$ is representable. Getting the polarity right is the whole content.",
-      "**`Finite.injective_iff_surjective` is the right Lean idiom for complete-residue-system arguments.** Rather than constructing an explicit inverse, the proof packages $k \\mapsto kb \\bmod a$ as an endomorphism of $\\mathrm{Fin}\\,a$, proves injectivity by `ZMod` cancellation, and reads off surjectivity for free. **Pattern reusable** for any 'multiplication by a unit permutes the residues' argument."
+      "**`Finite.injective_iff_surjective` is the right Lean idiom for complete-residue-system arguments.** Rather than constructing an explicit inverse, the proof packages $k \\mapsto kb \\bmod a$ as an endomorphism of $\\mathrm{Fin}\\,a$, proves injectivity by modular cancellation (`Nat.ModEq.cancel_right_of_coprime`), and reads off surjectivity for free. **Pattern reusable** for any 'multiplication by a coprime factor permutes the residues' argument."
     ],
     "prerequisites": [
       "Frobenius number $g(a, b) = ab - a - b$ for coprime $a, b \\geq 2$ (parent `frobenius-number`)",
       "Definition $\\text{Representable}(a, b, n) := \\exists x, y \\in \\mathbb{N},\\ n = ax + by$",
-      "Units and cancellation in $\\mathbb{Z}/a\\mathbb{Z}$: $b$ invertible $\\Leftrightarrow \\gcd(a, b) = 1$",
+      "Modular cancellation: $i b \\equiv j b \\pmod a \\Rightarrow i \\equiv j \\pmod a$ when $\\gcd(a, b) = 1$",
       "Finite pigeonhole: an injective self-map of $\\mathrm{Fin}\\,a$ is surjective"
     ]
   },
@@ -96,8 +101,8 @@
       "title": "Helpers: mul_mod_inj and exists_kb_mod (Complete Residue System)",
       "startLine": 24,
       "endLine": 46,
-      "summary": "Two private lemmas. mul_mod_inj: the map k ↦ (k·b mod a) on Fin a is injective, proved by lifting to ZMod a, cancelling the unit b (ZMod.isUnit_natCast_iff from coprimality), and an omega finish. exists_kb_mod: by Finite.injective_iff_surjective the injective map is surjective, so for every residue r < a there is some k < a with k·b mod a = r.",
-      "mathContext": "{0, b, 2b, …, (a−1)b} is a complete residue system mod a precisely when gcd(a, b) = 1 — multiplication by a unit permutes ℤ/aℤ."
+      "summary": "Two private lemmas. mul_mod_inj: the map k ↦ (k·b mod a) on Fin a is injective, proved by reducing to a congruence i·b ≡ j·b (mod a) and cancelling the coprime factor b (Nat.ModEq.cancel_right_of_coprime). exists_kb_mod: by Finite.injective_iff_surjective the injective map is surjective, so for every residue r < a there is some k < a with k·b mod a = r.",
+      "mathContext": "{0, b, 2b, …, (a−1)b} is a complete residue system mod a precisely when gcd(a, b) = 1 — multiplication by a coprime factor permutes ℤ/aℤ."
     },
     {
       "id": "no-two-reps",
@@ -157,7 +162,7 @@
     {
       "targetId": "gcd-algorithm",
       "relationship": "foundational",
-      "description": "The hypothesis gcd(a, b) = 1 is used twice: to cancel b as a unit in ℤ/aℤ (one_of_pair_rep) and to pass from a ∣ bc to a ∣ c (rep_and_complement_false). Without coprimality only multiples of gcd(a, b) are representable and the symmetry fails."
+      "description": "The hypothesis gcd(a, b) = 1 is used twice: to cancel the coprime factor b in a congruence mod a (one_of_pair_rep) and to pass from a ∣ bc to a ∣ c (rep_and_complement_false). Without coprimality only multiples of gcd(a, b) are representable and the symmetry fails."
     }
   ],
   "references": [
@@ -199,7 +204,7 @@
       "Proofs.FrobeniusNumber"
     ],
     "namespace": "FrobeniusSymmetry",
-    "lineCount": 101,
+    "lineCount": 123,
     "theoremCount": 5,
     "axiomCount": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Two-generator numerical semigroups $\langle a,b\rangle$ (coprime $a,b\ge2$, Frobenius number $g=ab-a-b$) are **symmetric of type one**. New verified entry `Proofs/FrobeniusNumberOQ01OQ03.lean` (6 theorems + 1 definition, **0 sorries, 0 axioms** — `#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`/`Lean.ofReduceBool`).

### What's new vs. the parent family
- **`frobenius-number-oq-01`** = genus $|\mathbb N\setminus S| = (a-1)(b-1)/2$ (a *count* invariant).
- **`frobenius-number-oq-02`** = interior duality $\mathrm{Rep}(n)\leftrightarrow\neg\mathrm{Rep}(g-n)$ for the **open** range $0<n<g$.

This entry adds:
1. **`symmetric_le_frobenius`** — completes OQ-02's duality to the **full closed interval** $0\le k\le g$ (the boundary $k=0$, $k=g$), i.e. the genuine *symmetric numerical semigroup* statement over the entire gap window.
2. **`IsPseudoFrobenius`** + **`pseudoFrobenius_setOf_eq`**: $\mathrm{PF}(\langle a,b\rangle)=\{g\}$, hence **`frobenius_type_eq_one`**: $\mathrm{type}(\langle a,b\rangle)=1$. Type one is the defining Gorenstein/symmetric condition (Kunz 1970); this *structural* invariant is distinct from the genus and the interior symmetry.

### Pivot note
The seeded candidate's literal statement ("$k\in S\iff g-k\notin S$") **already exists** as OQ-02's `frobenius_symmetry`. Rather than duplicate it, this entry ships the genuinely distinct **pseudo-Frobenius / type-one** characterization (an open thread OQ-02's own meta lists), plus the boundary completion of the symmetry.

### Parent repair (bundled)
`Proofs/FrobeniusNumberOQ02.lean` was **broken-on-recompile** under Mathlib v4.26 — it survived only via a stale `.olean`. Forced recompilation exposed removed APIs (`ZMod.isUnit_natCast_iff`, `Nat.dvd_sub'`) and `omega` regressions on nonlinear goals. Repaired with statements unchanged, still verified/0-axiom:
- ZMod-unit cancellation → `Nat.ModEq.cancel_right_of_coprime`
- mod-arithmetic divisibility → `Nat.modEq_iff_dvd'`
- `Nat.dvd_sub'` → `Nat.dvd_sub`
- nonlinear `omega`/`nlinarith` goals fed explicit product relations (e.g. `b·(a−1−k)+b·k+b = a·b`)

Meta synced: `lineCount` 101→123, `mathlibDependencies` and ZMod narrative updated to the `Nat.ModEq` approach.

## Verification
- `./proofs/scripts/docker-build.sh` unavailable (docker unresponsive under load); built on host toolchain (v4.26.0, Mathlib cached): `Build completed successfully (3060 jobs)`.
- `#print axioms` on all 6 new theorems + the 3 repaired OQ-02 theorems → only the 3 foundational axioms.

## Files
- `proofs/Proofs/FrobeniusNumberOQ01OQ03.lean` (new, 136 lines)
- `proofs/Proofs/FrobeniusNumberOQ02.lean` (repair)
- `src/data/proofs/frobenius-number-oq-01-oq-03/{meta,annotations}.json` (new)
- `src/data/proofs/frobenius-number-oq-02/meta.json` (sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)