### PR TITLE
Enrich Vandermonde Interpolation Isomorphism (oq-01-oq-02)

### DIFF
--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["linear algebra", "polynomials over a field", "Lagrange interpolation"]
   },
   {
+    "id": "ann-vi0102-setup",
+    "proofId": "vandermonde-interpolation-oq-01-oq-02",
+    "range": { "startLine": 38, "endLine": 47 },
+    "type": "context",
+    "title": "Setup: field, nodes, and the node count",
+    "content": "The whole development works over an arbitrary field `F` with `n` nodes `v : Fin n → F`; the distinctness hypothesis enters later as `hv : Function.Injective v`. `open Polynomial Finset` brings `degreeLT`, `leval`, `univ`, and `#` into scope. The private helper `card_univ_fin : #(univ : Finset (Fin n)) = n` (proved by `simp`) does the small but pervasive bookkeeping that bridges Mathlib's set-indexed Lagrange API — whose degree bounds and interpolation identities are stated over a finite set `s` and reference `#s` — to the clean `Fin n` indexing used here, where the relevant set is all of `univ` and `#univ = n`.",
+    "mathContext": "$F$ a field, $v : \\mathrm{Fin}\\,n \\to F$; $\\#(\\mathrm{univ} : \\mathrm{Finset}\\,(\\mathrm{Fin}\\,n)) = n$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.univ", "Finset.card_fin", "degreeLT", "set-indexed Lagrange API"],
+    "prerequisites": ["finite types", "Finset cardinality"]
+  },
+  {
     "id": "ann-vi0102-interp",
     "proofId": "vandermonde-interpolation-oq-01-oq-02",
     "range": { "startLine": 49, "endLine": 59 },

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02/meta.json
@@ -114,6 +114,11 @@
       "proofId": "vandermonde-interpolation-oq-01",
       "relationship": "extends",
       "description": "The grandparent proves interpolation uniqueness from the nonvanishing of the Vandermonde determinant. Here uniqueness reappears as injectivity of the evaluation linear map, now bundled with surjectivity into a full isomorphism."
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "The evaluation isomorphism is the F-linear shadow of polynomial CRT: with pairwise coprime moduli (X − v_j), the ring isomorphism F[X]/∏_j (X − v_j) ≅ ∏_j F[X]/(X − v_j) ≅ F^n sends a polynomial to its residues, i.e. its values p(v_j). evalEquiv restricts this to the degree-< n representatives and records only the additive/linear structure, so the Lagrange interpolant here plays exactly the role of the inverse-CRT reconstruction map that the constructive CRT entry builds over ℤ. The first open question below asks to promote evalEquiv to this full ring statement."
     }
   ],
   "leanFile": {
@@ -187,7 +192,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Upgrades the companion entries' existence and uniqueness lemmas into a single linear isomorphism: evaluation at n distinct nodes, evalNodes v : degreeLT F n →ₗ[F] (Fin n → F), is bijective (evalNodes_bijective) — surjective (evalNodes_surjective, the existence half) and injective (evalNodes_injective, the uniqueness half) — and is packaged as the linear equivalence evalEquiv whose inverse is exactly the Lagrange interpolant. The concrete exists_eval_eq restates existence elementarily, and finrank_degreeLT transports the isomorphism to conclude the degree-< n polynomials have dimension n. All 8 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "summary": "Upgrades the companion entries' existence and uniqueness lemmas into a single linear isomorphism: evaluation at n distinct nodes, evalNodes v : degreeLT F n →ₗ[F] (Fin n → F), is bijective (evalNodes_bijective) — surjective (evalNodes_surjective, the existence half) and injective (evalNodes_injective, the uniqueness half) — and is packaged as the linear equivalence evalEquiv whose inverse is exactly the Lagrange interpolant. The concrete exists_eval_eq restates existence elementarily, and finrank_degreeLT transports the isomorphism to conclude the degree-< n polynomials have dimension n. All 11 theorems (4 of them simp lemmas) and 4 definitions verified with 0 sorries and 0 axioms, no native_decide.",
     "implications": "The interpolation problem is well-posed in the strongest structural sense: value vectors and degree-< n polynomials are the same n-dimensional F-space, identified by evaluation at the nodes, with an explicit computable inverse. This is the abstract content behind change-of-representation arguments in Reed–Solomon coding, polynomial sampling, and the basis duality between point-values and coefficients.",
     "openQuestions": [
       "Make the isomorphism a ring/algebra statement: identify evalNodes with the CRT isomorphism F[X]/∏(X − v_j) ≅ ∏ F[X]/(X − v_j) ≅ F^n, exhibiting interpolation as the inverse Chinese Remainder map.",


### PR DESCRIPTION
Enrichment pass for `vandermonde-interpolation-oq-01-oq-02`.

The entry was already high quality (rich overview, 7 annotations with mathContext/significance, full sections, conclusion). Targeted, genuinely-additive improvements:

- **Cross-reference** to `chinese-remainder-constructive`: the evaluation isomorphism `evalEquiv` is the F-linear shadow of polynomial CRT, F[X]/∏(X−v_j) ≅ ∏F[X]/(X−v_j) ≅ F^n — exactly the structure named in the entry's first open question. Connects the interpolation cluster to the existing CRT cluster.
- **Annotation coverage**: added `ann-vi0102-setup` covering lines 38–47 (field/nodes setup + the `card_univ_fin` helper that bridges Mathlib's set-indexed Lagrange API to the clean `Fin n` indexing), closing the gap between the header annotation (ends line 37) and the interpolant annotation (starts line 49).
- **Accuracy fix**: conclusion said `All 8 theorems verified`; corrected to `11 theorems (4 simp lemmas) and 4 definitions` to match the meta description and `leanFile` counts (verified against the Lean source).

Axiom integrity: confirmed status `verified` / `axiomCount: 0` is accurate — the Lean file has 0 sorries, 0 axiom declarations, no native_decide, no assumption-carrying structures (the only hypothesis is node injectivity). No change needed.

Verified with `pnpm build` (✓ built).