### PR TITLE
research(product-of-segments-of-chords-oq-04): radical axis + radical center [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3438,6 +3438,7 @@ import Proofs.ProductOfSegmentsOfChords
 import Proofs.ProductOfSegmentsOfChordsConverse
 import Proofs.ProductOfSegmentsOfChordsOQ01
 import Proofs.ProductOfSegmentsOfChordsOQ03
+import Proofs.ProductOfSegmentsOfChordsOQ04
 import Proofs.IncidenceCauchySchwarz
 import Proofs.PropertyBFirstMoment
 import Proofs.PropertyBFirstMomentRamsey

--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ04.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ04.lean
@@ -1,0 +1,219 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Tactic
+
+/-!
+# Radical Axis and Radical Center (OQ-04)
+
+This file answers `product-of-segments-of-chords-oq-04`:
+
+> "What is the connection [of the power of a point] to algebraic geometry: the
+> power function defines a quadratic form, and the radical axis is the linear
+> locus where two quadratic forms agree?"
+
+The **power of a point** `P` with respect to a circle/sphere of centre `O` and
+radius `r` is `pow(P) = ‖P − O‖² − r²` (the signed quantity from the parent
+*Product of Segments of Chords* entry, generalised to any dimension).
+
+Although `pow` is a *quadratic* function of `P`, the **difference** of the power
+functions of two circles is **affine-linear** — the purely quadratic term
+`‖P‖²` cancels. Consequently the locus where two circles have equal power (the
+**radical axis**) is a hyperplane, and it is **perpendicular to the line of
+centres**. For three circles with non-collinear centres the three radical axes
+meet in a single point, the **radical centre**.
+
+## Main results
+
+* `power_expand` — the quadratic-form expansion `pow(P) = ‖P‖² − 2⟪P,O⟫ + ‖O‖² − r²`.
+* `radical_axis_linear` — equal power ⇔ a single affine-linear equation in `P`
+  (the radical-axis equation). This is the precise statement that the radical
+  axis is "the linear locus where two quadratic forms agree".
+* `radical_axis_perp` — the radical axis is orthogonal to the line of centres.
+* `radical_axis_affine` — the radical axis is closed under taking the line
+  through any two of its points (it is an affine subspace).
+* `equal_power_linear` — coordinate form of `radical_axis_linear` in `ℝ²`.
+* `radical_center_unique` / `radical_center_exists` / `radical_center_existsUnique`
+  — three circles with non-collinear centres have a **unique** radical centre.
+
+All results are dimension-independent except the radical-centre statements,
+which are specific to the plane (`EuclideanSpace ℝ (Fin 2)`).
+
+0 axioms, 0 sorries.
+-/
+
+set_option linter.unusedVariables false
+
+open scoped RealInnerProductSpace
+
+namespace ProductOfSegmentsOfChordsOQ04
+
+/-! ## Part 1: Power of a point, in any real inner product space -/
+
+section General
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The **power of the point** `P` with respect to the sphere of centre `O` and
+radius `r`: the signed quantity `‖P − O‖² − r²`. It is negative inside the
+sphere, zero on it, and positive outside. -/
+def power (O : E) (r : ℝ) (P : E) : ℝ := ‖P - O‖ ^ 2 - r ^ 2
+
+/-- **Quadratic-form expansion of the power function.**
+`pow(P) = ‖P‖² − 2⟪P, O⟫ + ‖O‖² − r²`. The leading term `‖P‖²` is the same for
+every sphere — this is the key fact that linearises the radical axis. -/
+theorem power_expand (O : E) (r : ℝ) (P : E) :
+    power O r P = ‖P‖ ^ 2 - 2 * ⟪P, O⟫ + ‖O‖ ^ 2 - r ^ 2 := by
+  unfold power
+  rw [norm_sub_sq_real]
+
+/-- **The radical axis is an affine hyperplane.**
+Two spheres `(O₁, r₁)` and `(O₂, r₂)` have equal power at `P` **iff** `P`
+satisfies the single affine-linear equation
+`2⟪P, O₂ − O₁⟫ = (‖O₂‖² − ‖O₁‖²) − (r₂² − r₁²)`.
+
+The quadratic term `‖P‖²` present in each power function cancels, leaving a
+linear equation whose normal vector `O₂ − O₁` points along the line of centres.
+This is exactly the sense in which "the radical axis is the linear locus where
+two quadratic forms agree." -/
+theorem radical_axis_linear (O₁ O₂ : E) (r₁ r₂ : ℝ) (P : E) :
+    power O₁ r₁ P = power O₂ r₂ P ↔
+      2 * ⟪P, O₂ - O₁⟫ = (‖O₂‖ ^ 2 - ‖O₁‖ ^ 2) - (r₂ ^ 2 - r₁ ^ 2) := by
+  rw [power_expand, power_expand, inner_sub_right]
+  constructor <;> intro h <;> linarith
+
+/-- **The radical axis is perpendicular to the line of centres.**
+If `P` and `Q` both lie on the radical axis of two spheres with centres
+`O₁ ≠ O₂`, then `Q − P` is orthogonal to `O₂ − O₁`. -/
+theorem radical_axis_perp (O₁ O₂ : E) (r₁ r₂ : ℝ) (P Q : E)
+    (hP : power O₁ r₁ P = power O₂ r₂ P)
+    (hQ : power O₁ r₁ Q = power O₂ r₂ Q) :
+    ⟪Q - P, O₂ - O₁⟫ = 0 := by
+  rw [radical_axis_linear] at hP hQ
+  rw [inner_sub_left]
+  linarith
+
+/-- **The radical axis is an affine subspace.**
+If `P` and `Q` lie on the radical axis, so does every point `P + t • (Q − P)` of
+the line through them. -/
+theorem radical_axis_affine (O₁ O₂ : E) (r₁ r₂ : ℝ) (P Q : E) (t : ℝ)
+    (hP : power O₁ r₁ P = power O₂ r₂ P)
+    (hQ : power O₁ r₁ Q = power O₂ r₂ Q) :
+    power O₁ r₁ (P + t • (Q - P)) = power O₂ r₂ (P + t • (Q - P)) := by
+  rw [radical_axis_linear] at hP hQ ⊢
+  rw [inner_add_left, real_inner_smul_left, inner_sub_left]
+  have hd : ⟪Q, O₂ - O₁⟫ - ⟪P, O₂ - O₁⟫ = 0 := by linarith
+  rw [hd, mul_zero, add_zero]
+  exact hP
+
+end General
+
+/-! ## Part 2: Coordinate form and the radical centre in the plane -/
+
+/-- 2D Euclidean point type, matching the parent file's convention. -/
+abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
+
+/-- For `Vec2`, the squared norm of a difference expands to the sum of squared
+coordinate differences. (Same helper as `ProductOfSegmentsOfChordsOQ03`.) -/
+lemma normSq_coord (X Y : Vec2) :
+    ‖X - Y‖ ^ 2 = (X 0 - Y 0) ^ 2 + (X 1 - Y 1) ^ 2 := by
+  rw [← real_inner_self_eq_norm_sq, PiLp.inner_apply, Fin.sum_univ_two]
+  simp [pow_two]
+
+/-- Coordinate expansion of the power function in the plane. -/
+lemma power_coord (O P : Vec2) (r : ℝ) :
+    power O r P = (P 0 - O 0) ^ 2 + (P 1 - O 1) ^ 2 - r ^ 2 := by
+  unfold power
+  rw [normSq_coord]
+
+/-- **Radical-axis equation, coordinate form.**
+The locus of equal power between the two planar circles `(Oa, ra)` and
+`(Ob, rb)` is the line
+`2[(Ob₀ − Oa₀)·P₀ + (Ob₁ − Oa₁)·P₁] = (Ob₀² + Ob₁² − rb²) − (Oa₀² + Oa₁² − ra²)`. -/
+lemma equal_power_linear (Oa Ob P : Vec2) (ra rb : ℝ) :
+    power Oa ra P = power Ob rb P ↔
+      2 * ((Ob 0 - Oa 0) * P 0 + (Ob 1 - Oa 1) * P 1)
+        = (Ob 0 ^ 2 + Ob 1 ^ 2 - rb ^ 2) - (Oa 0 ^ 2 + Oa 1 ^ 2 - ra ^ 2) := by
+  rw [power_coord, power_coord]
+  constructor <;> intro h <;> linear_combination h
+
+/-- **Uniqueness of the radical centre.**
+If two points `P, P'` both have equal power to all three circles `(Oᵢ, rᵢ)`
+and the centres are non-collinear (the centre determinant is nonzero), then
+`P = P'`. -/
+theorem radical_center_unique
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ) (P P' : Vec2)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0)
+    (hP12 : power O₁ r₁ P = power O₂ r₂ P)
+    (hP13 : power O₁ r₁ P = power O₃ r₃ P)
+    (hP'12 : power O₁ r₁ P' = power O₂ r₂ P')
+    (hP'13 : power O₁ r₁ P' = power O₃ r₃ P') :
+    P = P' := by
+  rw [equal_power_linear] at hP12 hP13 hP'12 hP'13
+  -- Subtract the `P` and `P'` equations: the constant right-hand sides cancel,
+  -- giving a homogeneous linear system in the coordinate differences.
+  have e1 : (O₂ 0 - O₁ 0) * (P 0 - P' 0) + (O₂ 1 - O₁ 1) * (P 1 - P' 1) = 0 := by
+    linear_combination (hP12 - hP'12) / 2
+  have e2 : (O₃ 0 - O₁ 0) * (P 0 - P' 0) + (O₃ 1 - O₁ 1) * (P 1 - P' 1) = 0 := by
+    linear_combination (hP13 - hP'13) / 2
+  -- Cramer elimination against the nonzero centre determinant forces both
+  -- coordinate differences to vanish.
+  have hx : ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))
+      * (P 0 - P' 0) = 0 := by
+    linear_combination (O₃ 1 - O₁ 1) * e1 - (O₂ 1 - O₁ 1) * e2
+  have hy : ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))
+      * (P 1 - P' 1) = 0 := by
+    linear_combination (O₂ 0 - O₁ 0) * e2 - (O₃ 0 - O₁ 0) * e1
+  have hP0 : P 0 = P' 0 := by
+    rcases mul_eq_zero.mp hx with h | h
+    · exact absurd h hdet
+    · linarith
+  have hP1 : P 1 = P' 1 := by
+    rcases mul_eq_zero.mp hy with h | h
+    · exact absurd h hdet
+    · linarith
+  ext i
+  fin_cases i
+  · exact hP0
+  · exact hP1
+
+/-- **Existence of the radical centre.**
+Three planar circles with non-collinear centres admit a point of equal power to
+all three: the explicit Cramer solution of the two radical-axis equations. -/
+theorem radical_center_exists
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0) :
+    ∃ P : Vec2, power O₁ r₁ P = power O₂ r₂ P ∧ power O₁ r₁ P = power O₃ r₃ P := by
+  -- The radical-axis equations form the 2×2 linear system
+  --   2[(O₂₀−O₁₀)x + (O₂₁−O₁₁)y] = K₁₂,   2[(O₃₀−O₁₀)x + (O₃₁−O₁₁)y] = K₁₃
+  -- with `Kᵢⱼ = (Oⱼ₀²+Oⱼ₁²−rⱼ²) − (Oᵢ₀²+Oᵢ₁²−rᵢ²)`. Cramer's rule solves it.
+  have hden : (2 : ℝ) *
+      ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0)) ≠ 0 := by
+    intro h; exact hdet (by linarith)
+  refine ⟨!₂[
+      (((O₂ 0 ^ 2 + O₂ 1 ^ 2 - r₂ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)) * (O₃ 1 - O₁ 1)
+        - ((O₃ 0 ^ 2 + O₃ 1 ^ 2 - r₃ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)) * (O₂ 1 - O₁ 1))
+        / (2 * ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))),
+      ((O₂ 0 - O₁ 0) * ((O₃ 0 ^ 2 + O₃ 1 ^ 2 - r₃ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2))
+        - (O₃ 0 - O₁ 0) * ((O₂ 0 ^ 2 + O₂ 1 ^ 2 - r₂ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)))
+        / (2 * ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0)))], ?_, ?_⟩
+  · rw [equal_power_linear]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+    rw [mul_div_assoc', mul_div_assoc', ← add_div, mul_div_assoc', div_eq_iff hden]
+    ring
+  · rw [equal_power_linear]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+    rw [mul_div_assoc', mul_div_assoc', ← add_div, mul_div_assoc', div_eq_iff hden]
+    ring
+
+/-- **The radical centre exists and is unique** for three circles with
+non-collinear centres. -/
+theorem radical_center_existsUnique
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0) :
+    ∃! P : Vec2, power O₁ r₁ P = power O₂ r₂ P ∧ power O₁ r₁ P = power O₃ r₃ P := by
+  obtain ⟨P, hP12, hP13⟩ := radical_center_exists O₁ O₂ O₃ r₁ r₂ r₃ hdet
+  refine ⟨P, ⟨hP12, hP13⟩, ?_⟩
+  rintro P' ⟨hP'12, hP'13⟩
+  exact radical_center_unique O₁ O₂ O₃ r₁ r₂ r₃ P' P hdet hP'12 hP'13 hP12 hP13
+
+end ProductOfSegmentsOfChordsOQ04

--- a/src/data/proofs/product-of-segments-of-chords-oq-04/annotations.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-04/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "ann-power-expand",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 56,
+      "endLine": 68
+    },
+    "type": "concept",
+    "title": "Power of a Point as a Quadratic Form",
+    "content": "`power O r P = ‖P − O‖² − r²` is the signed power of the point P with respect to the sphere of center O and radius r. `power_expand` rewrites it via `norm_sub_sq_real` into `‖P‖² − 2⟪P,O⟫ + ‖O‖² − r²`. The crucial feature is the leading term `‖P‖²`: it is the SAME for every sphere, regardless of center or radius. This is what makes the difference of two power functions affine-linear and ultimately linearizes the radical axis.",
+    "mathContext": "$\\operatorname{pow}(P) = \\|P-O\\|^2 - r^2 = \\|P\\|^2 - 2\\langle P,O\\rangle + \\|O\\|^2 - r^2$. As a function of $P$ this is a quadratic form $\\|P\\|^2$ plus an affine part; the quadratic part is independent of the circle.",
+    "significance": "key",
+    "relatedConcepts": [
+      "norm_sub_sq_real",
+      "InnerProductSpace",
+      "quadratic form",
+      "power of a point"
+    ],
+    "prerequisites": [
+      "inner product space axioms",
+      "norm from inner product"
+    ]
+  },
+  {
+    "id": "ann-radical-axis-linear",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 70,
+      "endLine": 83
+    },
+    "type": "key-step",
+    "title": "The Radical Axis is the Linear Locus of Equal Quadratic Forms",
+    "content": "`radical_axis_linear` is the heart of the file and the direct answer to the parent's open question. Two spheres have equal power at P if and only if P satisfies the single affine-linear equation `2⟪P, O₂ − O₁⟫ = (‖O₂‖² − ‖O₁‖²) − (r₂² − r₁²)`. The proof rewrites both powers via `power_expand`; the shared `‖P‖²` term cancels (handled by `linarith`), and `inner_sub_right` collects the linear term. The normal vector of this hyperplane is `O₂ − O₁`, the direction of the line of centers.",
+    "mathContext": "$\\operatorname{pow}_1(P) = \\operatorname{pow}_2(P) \\iff -2\\langle P,O_1\\rangle + \\|O_1\\|^2 - r_1^2 = -2\\langle P,O_2\\rangle + \\|O_2\\|^2 - r_2^2 \\iff 2\\langle P, O_2-O_1\\rangle = (\\|O_2\\|^2-\\|O_1\\|^2)-(r_2^2-r_1^2)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "radical axis",
+      "inner_sub_right",
+      "affine hyperplane",
+      "linarith"
+    ],
+    "prerequisites": [
+      "power_expand",
+      "bilinearity of the inner product"
+    ]
+  },
+  {
+    "id": "ann-radical-axis-perp",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 85,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "Perpendicularity to the Line of Centers and Affine-Subspace Structure",
+    "content": "Two structural consequences of linearity. `radical_axis_perp`: if P and Q both lie on the radical axis, then `⟪Q − P, O₂ − O₁⟫ = 0`, i.e. the radical axis is orthogonal to the line of centers — proved by subtracting the two linear equations via `inner_sub_left` and `linarith`. `radical_axis_affine`: the radical axis is closed under the line `P + t•(Q − P)` through any two of its points, so it is an affine subspace — proved by expanding the inner product with `inner_add_left` and `real_inner_smul_left`. Both hold in any dimension.",
+    "mathContext": "If $2\\langle P,d\\rangle = c$ and $2\\langle Q,d\\rangle = c$ with $d = O_2-O_1$, then $\\langle Q-P, d\\rangle = 0$, and for any $t$, $\\langle P + t(Q-P), d\\rangle = \\langle P,d\\rangle$, so the whole line lies on the radical axis.",
+    "significance": "high",
+    "relatedConcepts": [
+      "inner_sub_left",
+      "inner_add_left",
+      "real_inner_smul_left",
+      "affine subspace",
+      "orthogonality"
+    ],
+    "prerequisites": [
+      "radical_axis_linear"
+    ]
+  },
+  {
+    "id": "ann-equal-power-linear",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 116,
+      "endLine": 138
+    },
+    "type": "technique",
+    "title": "Coordinate Form via linear_combination",
+    "content": "Moving to the plane, `normSq_coord` and `power_coord` expand the power function into coordinates `(P 0, P 1)` using `real_inner_self_eq_norm_sq` and `PiLp.inner_apply`. `equal_power_linear` then restates the radical-axis equation purely in coordinates. Its bidirectional proof is a single `constructor <;> intro h <;> linear_combination h`: the polynomial difference between the equal-power equation and the linear equation is a ring identity (the squared coordinates cancel), so `linear_combination` discharges both directions at once.",
+    "mathContext": "$\\operatorname{pow}_a(P)=\\operatorname{pow}_b(P) \\iff 2[(O_{b0}-O_{a0})P_0 + (O_{b1}-O_{a1})P_1] = (O_{b0}^2+O_{b1}^2-r_b^2)-(O_{a0}^2+O_{a1}^2-r_a^2)$, the two sides differing by a ring identity.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "linear_combination",
+      "PiLp.inner_apply",
+      "EuclideanSpace",
+      "coordinate expansion"
+    ],
+    "prerequisites": [
+      "power_coord",
+      "Fin.sum_univ_two"
+    ]
+  },
+  {
+    "id": "ann-radical-center-unique",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 140,
+      "endLine": 181
+    },
+    "type": "key-step",
+    "title": "Uniqueness of the Radical Center by Determinant Elimination",
+    "content": "`radical_center_unique` shows that two points P, P' of equal power to three circles with non-collinear centers must coincide — WITHOUT computing the center. Subtracting the radical-axis equations for P and P' (the constant right-hand sides cancel) gives a homogeneous 2×2 linear system `e1, e2` in the coordinate differences. Multiplying through by the cofactors via `linear_combination` produces `det·(P₀−P'₀) = 0` and `det·(P₁−P'₁) = 0`; since the center determinant `det = (O₂−O₁)×(O₃−O₁)` is nonzero (non-collinearity), `mul_eq_zero` forces both differences to vanish, and `PiLp.ext` concludes P = P'.",
+    "mathContext": "Homogeneous system $a x + b y = 0$, $c x + d y = 0$ with $ad-bc \\neq 0$ has only the trivial solution: $(ad-bc)x = d(ax+by)-b(cx+dy)=0$, so $x=0$, and symmetrically $y=0$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "linear_combination",
+      "mul_eq_zero",
+      "PiLp.ext",
+      "Cramer's rule",
+      "determinant"
+    ],
+    "prerequisites": [
+      "equal_power_linear",
+      "non-collinearity as nonzero determinant"
+    ]
+  },
+  {
+    "id": "ann-radical-center-exists",
+    "proofId": "product-of-segments-of-chords-oq-04",
+    "range": {
+      "startLine": 182,
+      "endLine": 218
+    },
+    "type": "key-step",
+    "title": "Existence of the Radical Center via Cramer's Rule",
+    "content": "`radical_center_exists` constructs the radical center explicitly. The two radical-axis equations form a 2×2 linear system whose Cramer solution is supplied directly as the EuclideanSpace point `!₂[x, y]` (note: `!₂[...]` builds an `EuclideanSpace ℝ (Fin 2)` element, where the plain `![...]` matrix literal fails to elaborate at this type). Each equal-power condition is verified by reducing the coordinates with `Matrix.cons_val_*`, clearing the common denominator `2·det` with the chain `mul_div_assoc'`, `← add_div`, `div_eq_iff hden`, and closing with `ring`. `radical_center_existsUnique` then packages existence and uniqueness into `∃!`.",
+    "mathContext": "Solving $2(a x+b y)=K_{12}$, $2(c x+d y)=K_{13}$ by Cramer: $x = (K_{12}d - K_{13}b)/(2\\det)$, $y = (a K_{13} - c K_{12})/(2\\det)$, with $\\det = ad-bc \\neq 0$. Substituting back, $a\\cdot\\text{num}_x + b\\cdot\\text{num}_y = K_{12}\\det$, so the equation holds.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Cramer's rule",
+      "EuclideanSpace !₂ notation",
+      "div_eq_iff",
+      "mul_div_assoc'",
+      "ExistsUnique"
+    ],
+    "prerequisites": [
+      "equal_power_linear",
+      "denominator nonzero from non-collinearity"
+    ]
+  }
+]

--- a/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "product-of-segments-of-chords-oq-04",
+  "title": "Product of Segments of Chords OQ-04: Radical Axis and Radical Center",
+  "slug": "product-of-segments-of-chords-oq-04",
+  "description": "Formal proof that the power of a point — a quadratic function ‖P−O‖²−r² — produces an affine-linear radical axis: the locus where two circles have equal power is a hyperplane perpendicular to the line of centers, and three circles with non-collinear centers have a unique radical center. Answers the parent's open question on the connection between the power function as a quadratic form and the radical axis as a linear locus.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProductOfSegmentsOfChordsOQ04.lean",
+    "tags": [
+      "geometry",
+      "inner-product-space",
+      "power-of-a-point",
+      "radical-axis",
+      "radical-center",
+      "quadratic-form",
+      "wiedijk-100"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 219,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "None. Only the standard foundational axioms (propext, Classical.choice, Quot.sound) appear in #print axioms; no sorryAx and no Lean.ofReduceBool.",
+    "originalContributions": [
+      "Definition of the (signed) power of a point in any real inner product space and its quadratic-form expansion power_expand: pow(P) = ‖P‖² − 2⟪P,O⟫ + ‖O‖² − r²",
+      "radical_axis_linear: equal power between two spheres is equivalent to a single affine-linear equation 2⟪P, O₂−O₁⟫ = (‖O₂‖²−‖O₁‖²)−(r₂²−r₁²) — the precise statement that the radical axis is the linear locus where two quadratic forms agree",
+      "radical_axis_perp: the radical axis is orthogonal to the line of centers (dimension-independent)",
+      "radical_axis_affine: the radical axis is closed under the line through any two of its points (it is an affine subspace)",
+      "radical_center_existsUnique: three planar circles with non-collinear centers admit a UNIQUE point of equal power to all three, via an explicit Cramer-rule construction plus a determinant elimination uniqueness argument"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The power of a point with respect to a circle was systematized by Jakob Steiner in 1826 (*Potenz eines Punktes*), defined as d²−r² where d is the distance from the point to the center. The radical axis — the locus of points having equal power with respect to two circles — and the radical center of three circles are classical results of 19th-century projective and inversive geometry (Gaultier de Tours, 1813; Steiner). The key structural observation is that although the power of a point is a quadratic function of the point, the DIFFERENCE of two power functions is affine-linear: the quadratic term ‖P‖² is shared by every circle and cancels. This is the algebraic-geometry connection raised as the parent entry's fourth open question — the power function is a quadratic form, and the radical axis is the linear locus where two such forms agree.",
+    "problemStatement": "Formalize the connection between the power of a point as a quadratic form and the radical axis as a linear locus: (1) show that equal power between two circles/spheres is equivalent to a single affine-linear equation whose normal is the line of centers; (2) deduce that the radical axis is a hyperplane perpendicular to the line of centers and an affine subspace; (3) prove that three circles in the plane with non-collinear centers have a unique radical center.",
+    "proofStrategy": "Expand the power function via norm_sub_sq_real into ‖P‖² − 2⟪P,O⟫ + ‖O‖² − r². Equating the powers of two circles cancels the shared ‖P‖² term, leaving the linear equation 2⟪P, O₂−O₁⟫ = (‖O₂‖²−‖O₁‖²)−(r₂²−r₁²) (radical_axis_linear). Perpendicularity (radical_axis_perp) and the affine-subspace property (radical_axis_affine) follow from the linearity by inner-product manipulation and linarith. For the radical center, the two radical-axis equations of three circles form a 2×2 linear system in the plane; non-collinearity of the centers is exactly the non-vanishing of the system's determinant. Uniqueness follows by subtracting the equations for two candidate centers and eliminating against the nonzero determinant (linear_combination); existence is the explicit Cramer-rule solution, verified by clearing denominators and ring.",
+    "keyInsights": [
+      "The power function pow(P) = ‖P−O‖²−r² is a quadratic function of P, but its leading term ‖P‖² is independent of the circle. Subtracting the power functions of two circles therefore yields an AFFINE-LINEAR function — this single cancellation is what linearizes the radical axis.",
+      "The radical-axis equation 2⟪P, O₂−O₁⟫ = c has normal vector O₂−O₁, which points along the line of centers; hence the radical axis is automatically perpendicular to that line (radical_axis_perp), and this holds in every dimension, not just the plane.",
+      "Three circles' radical axes meet in a point iff the two governing linear equations have a common solution. In the plane this is a 2×2 system whose determinant is (O₂−O₁)×(O₃−O₁); the centers being non-collinear is exactly the statement that this determinant is nonzero, giving both existence (Cramer) and uniqueness (determinant elimination).",
+      "Uniqueness is proved without computing the center: subtracting the linear equations for two candidate radical centers gives a homogeneous 2×2 system in the coordinate differences, and multiplying through by the cofactors (linear_combination) yields det·(P₀−P'₀) = 0 and det·(P₁−P'₁) = 0, forcing equality since det ≠ 0.",
+      "All of Part 1 (the quadratic-form expansion, linearity, perpendicularity, affine-subspace property) is stated over an arbitrary real inner product space and is therefore dimension-free; only the radical-center statements, which rely on the plane being 2-dimensional, specialize to EuclideanSpace ℝ (Fin 2)."
+    ],
+    "prerequisites": [
+      "InnerProductSpace ℝ E and norm_sub_sq_real from Mathlib",
+      "Inner product bilinearity lemmas (inner_sub_left/right, inner_add_left, real_inner_smul_left)",
+      "EuclideanSpace ℝ (Fin 2) coordinate access via PiLp and the !₂[...] constructor",
+      "Cramer's rule for 2×2 linear systems and determinant non-vanishing"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Research Question and Main Results",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports and docstring stating OQ-04: the power function is a quadratic form and the radical axis is the linear locus where two quadratic forms agree. Lists the main results: quadratic-form expansion, radical-axis linearity, perpendicularity, affine-subspace property, and existence/uniqueness of the radical center."
+    },
+    {
+      "id": "power-quadratic",
+      "title": "Part 1: Power of a Point and the Linear Radical Axis",
+      "startLine": 50,
+      "endLine": 109,
+      "summary": "Over an arbitrary real inner product space: power O r P = ‖P−O‖²−r². power_expand gives the quadratic-form expansion. radical_axis_linear shows equal power ⇔ the affine-linear equation 2⟪P, O₂−O₁⟫ = (‖O₂‖²−‖O₁‖²)−(r₂²−r₁²). radical_axis_perp proves orthogonality to the line of centers; radical_axis_affine proves the radical axis is an affine subspace."
+    },
+    {
+      "id": "coordinate-form",
+      "title": "Part 2a: Coordinate Form in the Plane",
+      "startLine": 110,
+      "endLine": 138,
+      "summary": "Vec2 = EuclideanSpace ℝ (Fin 2). normSq_coord and power_coord give the coordinate expansion of the power function; equal_power_linear is the coordinate form of the radical-axis equation, proved by linear_combination."
+    },
+    {
+      "id": "radical-center",
+      "title": "Part 2b: Existence and Uniqueness of the Radical Center",
+      "startLine": 139,
+      "endLine": 218,
+      "summary": "radical_center_unique: two points of equal power to three circles with non-collinear centers coincide, via determinant elimination (linear_combination) against the nonzero centre determinant. radical_center_exists: explicit Cramer-rule construction of the radical center using the !₂[...] constructor, verified by clearing denominators with div_eq_iff and ring. radical_center_existsUnique packages both into ∃!."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file proves 9 theorems/lemmas and 1 definition with 0 sorries and 0 axioms (only the standard foundational axioms), establishing that the power of a point is a quadratic form whose pairwise differences are affine-linear, that the radical axis is a hyperplane perpendicular to the line of centers, and that three planar circles with non-collinear centers have a unique radical center.",
+    "implications": "The result formalizes the classical bridge between the metric notion of power of a point and the linear/affine structure of radical axes and centers. The Part 1 results hold in any real inner product space, showing the radical hyperplane is a dimension-free phenomenon; the radical center is the plane-specific consequence of a 2×2 linear system being uniquely solvable exactly when the circle centers are non-collinear.",
+    "openQuestions": [
+      "Formalize the radical center as the common point of all three pairwise radical axes explicitly (that the O₁O₂, O₁O₃, and O₂O₃ radical axes are concurrent), and characterize when the radical center has positive power to all three (lies outside the circles), giving a common tangent length / common orthogonal circle.",
+      "Generalize the radical-center existence to n+1 spheres in n dimensions with affinely independent centers: the n radical hyperplanes meet in a unique radical point, the solution of an n×n Cramer system."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "product-of-segments-of-chords",
+      "relationship": "extends",
+      "description": "Parent file proving the 2D intersecting chords theorem (power of a point, Wiedijk #55); OQ-04 addresses its open question on the quadratic-form / radical-axis connection."
+    },
+    {
+      "targetId": "product-of-segments-of-chords-oq-01",
+      "relationship": "related",
+      "description": "Sibling that generalizes the power of a point to spheres in any inner product space; OQ-04 reuses the same power(O,r,P) = ‖P−O‖²−r² formulation and dimension-free inner-product style."
+    },
+    {
+      "targetId": "product-of-segments-of-chords-oq-03",
+      "relationship": "related",
+      "description": "Sibling proving the 4×4 concyclicity determinant criterion; shares the Vec2 = EuclideanSpace ℝ (Fin 2) coordinate conventions and the normSq_coord helper."
+    }
+  ],
+  "leanFile": {
+    "namespace": "ProductOfSegmentsOfChordsOQ04",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/ProductOfSegmentsOfChordsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers open question **OQ-04** of *Product of Segments of Chords* (power of a point, Wiedijk #55):

> "What is the connection to algebraic geometry: the power function defines a quadratic form, and the radical axis is the linear locus where two quadratic forms agree?"

The power of a point `pow(P) = ‖P−O‖²−r²` is a quadratic function of `P`, but the **difference** of two power functions is **affine-linear** — the shared `‖P‖²` term cancels. This single cancellation linearizes the radical axis.

## Results (`Proofs/ProductOfSegmentsOfChordsOQ04.lean`, 219 lines)

**Part 1 — any real inner product space (dimension-free):**
- `power_expand` — quadratic-form expansion `pow(P) = ‖P‖² − 2⟪P,O⟫ + ‖O‖² − r²`
- `radical_axis_linear` — equal power ⇔ the affine-linear equation `2⟪P, O₂−O₁⟫ = (‖O₂‖²−‖O₁‖²)−(r₂²−r₁²)` (the radical axis is a hyperplane)
- `radical_axis_perp` — the radical axis is ⊥ to the line of centers
- `radical_axis_affine` — the radical axis is an affine subspace

**Part 2 — the plane (`EuclideanSpace ℝ (Fin 2)`):**
- `equal_power_linear` — coordinate form (proved by `linear_combination`)
- `radical_center_unique` — determinant-elimination uniqueness
- `radical_center_exists` — explicit Cramer-rule construction
- `radical_center_existsUnique` — the radical center exists and is unique for non-collinear centers

## Verification

- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`
- Status: `verified` / badge `original`
- Builds against Mathlib v4.26.0; added to `Proofs.lean` aggregator

🤖 Generated with [Claude Code](https://claude.com/claude-code)