### PR TITLE
research(lhopital-oq-05): cubic sine limit (x − sin x)/x³ → 1/6 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3148,6 +3148,7 @@ import Proofs.LHopitalOQ01
 import Proofs.LHopitalOQ02
 import Proofs.LHopitalOQ02Aristotle
 import Proofs.LHopitalOQ03
+import Proofs.LHopitalOQ05
 import Proofs.LagrangeFourSquares
 import Proofs.LagrangeFourSquaresOQ01
 import Proofs.LagrangeFourSquaresOQ01OQ01

--- a/proofs/Proofs/LHopitalOQ05.lean
+++ b/proofs/Proofs/LHopitalOQ05.lean
@@ -1,0 +1,83 @@
+import Mathlib
+
+/-
+# The Cubic Sine Limit (OQ-05)
+
+    lim_{x → 0} (x - sin x) / x³ = 1/6.
+
+This is the classic third-order L'Hôpital / Taylor limit: numerator and
+denominator both vanish to third order at `0`, and the leading nonzero Taylor
+term of `x - sin x` is `x³/6`, so the ratio tends to `1/6`.
+
+Rather than apply L'Hôpital's rule three times, we use the explicit cubic Taylor
+bound for sine that already lives in Mathlib,
+
+    Real.sin_bound : |x| ≤ 1 → |sin x - (x - x³/6)| ≤ |x|⁴ · (5/96).
+
+The error term has degree `4` while we divide by `x³`, so the deviation of
+`(x - sin x)/x³` from `1/6` is controlled *linearly* in `x`:
+
+    |(x - sin x)/x³ - 1/6| = |sin x - (x - x³/6)| / |x|³ ≤ (5/96)·|x|.
+
+This bound holds for every `0 < |x| ≤ 1`, and `(5/96)·|x| → 0`, so a squeeze
+delivers the limit. The hypothesis `|x| ≤ 1` is automatically met on a punctured
+neighbourhood of `0`.
+
+Self-contained: imports only Mathlib.
+-/
+
+namespace LHopitalOQ05
+
+open Filter Topology
+
+/-- **Linear deviation bound.** For `0 < |x| ≤ 1`, the difference quotient
+`(x - sin x)/x³` differs from `1/6` by at most `(5/96)·|x|`. This is exactly the
+cubic Taylor bound `Real.sin_bound`, divided through by `|x|³`. -/
+theorem abs_sub_le (x : ℝ) (hx0 : x ≠ 0) (hx1 : |x| ≤ 1) :
+    |(x - Real.sin x) / x ^ 3 - 1 / 6| ≤ 5 / 96 * |x| := by
+  have hb : (0 : ℝ) < |x| := abs_pos.mpr hx0
+  -- Recast the deviation as `-(sin x - (x - x³/6)) / x³`.
+  have heq : (x - Real.sin x) / x ^ 3 - 1 / 6
+      = -(Real.sin x - (x - x ^ 3 / 6)) / x ^ 3 := by
+    field_simp
+    ring
+  rw [heq, abs_div, abs_neg, abs_pow, div_le_iff₀ (pow_pos hb 3)]
+  calc |Real.sin x - (x - x ^ 3 / 6)|
+      ≤ |x| ^ 4 * (5 / 96) := Real.sin_bound hx1
+    _ = 5 / 96 * |x| * |x| ^ 3 := by ring
+
+/-- **The cubic sine limit.** `(x - sin x)/x³ → 1/6` as `x → 0` through nonzero
+`x`. Proved by squeezing the deviation `(x - sin x)/x³ - 1/6` between `0` and the
+linear bound `(5/96)·|x|` of `abs_sub_le`. -/
+theorem tendsto_cubic_sine :
+    Tendsto (fun x => (x - Real.sin x) / x ^ 3) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 6)) := by
+  rw [← tendsto_sub_nhds_zero_iff]
+  apply squeeze_zero_norm' (a := fun x => 5 / 96 * |x|)
+  · -- eventual bound: holds wherever `x ≠ 0` and `|x| ≤ 1`
+    have hmem : Metric.closedBall (0 : ℝ) 1 ∈ 𝓝[≠] (0 : ℝ) :=
+      nhdsWithin_le_nhds (Metric.closedBall_mem_nhds 0 one_pos)
+    filter_upwards [self_mem_nhdsWithin, hmem] with x hx hxball
+    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+    rw [Metric.mem_closedBall, Real.dist_eq, sub_zero] at hxball
+    rw [Real.norm_eq_abs]
+    exact abs_sub_le x hx hxball
+  · -- the bound tends to `0`
+    have habs : Tendsto (fun x : ℝ => |x|) (𝓝 (0 : ℝ)) (𝓝 0) := by
+      simpa using (continuous_abs.tendsto (0 : ℝ))
+    have h0 : Tendsto (fun x : ℝ => 5 / 96 * |x|) (𝓝[≠] (0 : ℝ)) (𝓝 (5 / 96 * 0)) :=
+      (habs.mono_left nhdsWithin_le_nhds).const_mul (5 / 96)
+    simpa using h0
+
+/-- The limit value `1/6` is exactly the reciprocal of `3! = 6`, i.e. the third
+Taylor coefficient of `x - sin x`. This packaging makes explicit that the cubic
+sine limit is the order-3 Taylor statement. -/
+theorem tendsto_cubic_sine_factorial :
+    Tendsto (fun x => (x - Real.sin x) / x ^ 3) (𝓝[≠] (0 : ℝ))
+      (𝓝 (1 / (Nat.factorial 3 : ℝ))) := by
+  have h := tendsto_cubic_sine
+  norm_num [Nat.factorial] at h ⊢
+  exact h
+
+#check @tendsto_cubic_sine
+
+end LHopitalOQ05

--- a/src/data/proofs/lhopital-oq-05/annotations.json
+++ b/src/data/proofs/lhopital-oq-05/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-deviation-bound",
+    "proofId": "lhopital-oq-05",
+    "range": {
+      "startLine": 33,
+      "endLine": 47
+    },
+    "type": "insight",
+    "title": "Divide the Taylor Remainder by x³",
+    "content": "abs_sub_le is the quantitative heart of the limit. Mathlib's Real.sin_bound says |sin x − (x − x³/6)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the cubic Maclaurin remainder. Rewriting the deviation as −(sin x − (x − x³/6))/x³ (field_simp; ring), then using |a/b| = |a|/|b| and |x³| = |x|³, the deviation equals |sin x − (x − x³/6)|/|x|³. Dividing the degree-4 numerator bound by the degree-3 denominator leaves (5/96)·|x|: a bound that is linear in x and hence visibly vanishes. No differentiation, no L'Hôpital."
+  },
+  {
+    "id": "ann-the-limit",
+    "proofId": "lhopital-oq-05",
+    "range": {
+      "startLine": 49,
+      "endLine": 69
+    },
+    "type": "insight",
+    "title": "One Squeeze Finishes It",
+    "content": "tendsto_cubic_sine reduces the limit-to-1/6 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|. The bound |deviation| ≤ a x of abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x| → 0 (continuity of absolute value) scaled by 5/96. The two-sided control sits inside a single absolute value, so one squeeze — not separate upper and lower envelopes — suffices."
+  },
+  {
+    "id": "ann-taylor-coefficient",
+    "proofId": "lhopital-oq-05",
+    "range": {
+      "startLine": 71,
+      "endLine": 81
+    },
+    "type": "concept",
+    "title": "1/6 Is the Third Taylor Coefficient",
+    "content": "tendsto_cubic_sine_factorial restates the value 1/6 as 1/3!. This is not cosmetic: x − sin x = x³/6 − x⁵/120 + ⋯, so its leading nonvanishing Maclaurin term is x³/3!, and the limit of (x − sin x)/x³ is exactly that coefficient 1/3!. It mirrors the order-1 sibling entry (OQ-04), where the limit is the ratio of first Taylor coefficients f'(a)/1! — here the single third coefficient is read off directly."
+  }
+]

--- a/src/data/proofs/lhopital-oq-05/meta.json
+++ b/src/data/proofs/lhopital-oq-05/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "lhopital-oq-05",
+  "title": "The Cubic Sine Limit: (x − sin x)/x³ → 1/6",
+  "slug": "lhopital-oq-05",
+  "description": "Answers the parent L'Hôpital entry's OQ-05 — evaluate the classic third-order indeterminate limit lim_{x→0} (x − sin x)/x³ = 1/6. Instead of applying L'Hôpital three times, the proof uses Mathlib's explicit cubic Taylor bound Real.sin_bound (|sin x − (x − x³/6)| ≤ |x|⁴·(5/96)). Because the error term has degree 4 while the denominator is x³, the deviation of (x − sin x)/x³ from 1/6 is bounded linearly by (5/96)·|x|, and a squeeze gives the limit. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Taylor/Maclaurin); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ05.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "lhopital",
+      "taylor-series",
+      "limits",
+      "trigonometry",
+      "squeeze-theorem"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 83,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abs_sub_le: the linear deviation bound — for 0 < |x| ≤ 1, |(x − sin x)/x³ − 1/6| ≤ (5/96)·|x|. This is Mathlib's cubic Taylor bound Real.sin_bound divided through by |x|³; the degree-4 error over the degree-3 denominator leaves an O(|x|) bound, which is the quantitative heart of the limit.",
+      "tendsto_cubic_sine: the headline limit (x − sin x)/x³ → 1/6 as x → 0 (through nonzero x), obtained by squeezing the deviation between 0 and the linear bound (5/96)·|x| with squeeze_zero_norm'. No iterated L'Hôpital, no Mean Value Theorem.",
+      "tendsto_cubic_sine_factorial: the same limit with the value written as 1/3!, making explicit that 1/6 is the third Taylor coefficient of x − sin x."
+    ],
+    "prerequisites": [
+      "The Maclaurin expansion sin x = x − x³/6 + O(x⁵) and its third-order truncation error",
+      "The squeeze (sandwich) theorem for limits, in its eventual/normed form squeeze_zero_norm'",
+      "Punctured-neighbourhood limits 𝓝[≠] 0 for an expression undefined at 0",
+      "Elementary absolute-value algebra: |a/b| = |a|/|b|, |xⁿ| = |x|ⁿ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sin_bound",
+        "description": "|x| ≤ 1 → |sin x − (x − x³/6)| ≤ |x|⁴·(5/96): the explicit cubic Taylor remainder bound for sine, the only analytic input to the whole proof.",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "squeeze_zero_norm'",
+        "description": "If ‖f x‖ ≤ a x eventually and a → 0, then f → 0. Used with a x = (5/96)·|x| to squeeze the deviation (x − sin x)/x³ − 1/6 to 0.",
+        "module": "Mathlib.Analysis.Normed.Group.Continuity"
+      },
+      {
+        "theorem": "tendsto_sub_nhds_zero_iff",
+        "description": "Tendsto (fun x => f x − c) l (𝓝 0) ↔ Tendsto f l (𝓝 c) — reduces the limit-to-1/6 statement to a limit-to-0 statement amenable to the squeeze.",
+        "module": "Mathlib.Topology.Algebra.Order.Group"
+      },
+      {
+        "theorem": "Metric.closedBall_mem_nhds",
+        "description": "The closed ball of positive radius is a neighbourhood of its centre — supplies the eventual hypothesis |x| ≤ 1 needed by Real.sin_bound on a punctured neighbourhood of 0.",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The limit lim_{x→0} (x − sin x)/x³ = 1/6 is one of the standard textbook indeterminate forms — a 0/0 case that resists naive evaluation and is traditionally cracked by three applications of L'Hôpital's rule or, equivalently, by the Maclaurin series sin x = x − x³/6 + x⁵/120 − ⋯. Subtracting the cubic Taylor polynomial leaves a fifth-order tail, so x − sin x = x³/6 + O(x⁵) and the ratio tends to 1/6. This entry formalizes the Taylor route in the cleanest possible way, reusing Mathlib's already-proved cubic bound on sine rather than differentiating three times.",
+    "problemStatement": "**Open Question (parent lhopital, OQ-05)**: evaluate the cubic sine limit lim_{x→0} (x − sin x)/x³ = 1/6 — the canonical third-order L'Hôpital / Taylor limit.\n\n**This entry**: proves Tendsto (fun x => (x − sin x)/x³) (𝓝[≠] 0) (𝓝 (1/6)) with zero axioms, via the explicit cubic Taylor bound and a squeeze, with no iterated L'Hôpital and no Mean Value Theorem.",
+    "text": "An 83-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. The engine is abs_sub_le, which divides Mathlib's cubic Taylor bound Real.sin_bound by |x|³ to get the linear deviation estimate |(x − sin x)/x³ − 1/6| ≤ (5/96)·|x| valid for 0 < |x| ≤ 1. The headline tendsto_cubic_sine feeds this bound — which holds eventually on 𝓝[≠] 0 since |x| ≤ 1 there — into squeeze_zero_norm', and tendsto_cubic_sine_factorial repackages the value 1/6 as the third Taylor coefficient 1/3!.",
+    "proofStrategy": "abs_sub_le rewrites the deviation as −(sin x − (x − x³/6))/x³ (field_simp; ring), so by abs_div, abs_neg and |x³| = |x|³ the deviation equals |sin x − (x − x³/6)|/|x|³; clearing the positive denominator (div_le_iff₀) reduces the goal to Real.sin_bound, since |x|⁴·(5/96) = (5/96)·|x|·|x|³. tendsto_cubic_sine rewrites the target with tendsto_sub_nhds_zero_iff to a limit-to-0, then applies squeeze_zero_norm' with bound a x = (5/96)·|x|: the eventual hypothesis ‖deviation‖ ≤ a x holds on the punctured neighbourhood because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds), giving |x| ≤ 1, and a x → 0 because |x| → 0 (continuity of absolute value) scaled by 5/96.",
+    "keyInsights": [
+      "The whole limit is quantitative: dividing the degree-4 Taylor error |sin x − (x − x³/6)| ≤ |x|⁴·(5/96) by the degree-3 denominator x³ leaves a bound of order |x|, which visibly vanishes — no separate L'Hôpital machinery is needed.",
+      "Reusing Mathlib's Real.sin_bound sidesteps both iterated differentiation and any explicit Taylor-with-remainder theorem; the cubic bound already packages exactly the third-order information the limit requires.",
+      "The hypothesis |x| ≤ 1 demanded by Real.sin_bound is free on a punctured neighbourhood of 0: the closed unit ball is a neighbourhood of 0, so the bound holds 'eventually', which is precisely what the eventual squeeze squeeze_zero_norm' consumes.",
+      "Writing the answer as 1/3! exposes the limit as the third Maclaurin coefficient of x − sin x, mirroring how the order-1 L'Hôpital entry (OQ-04) reads off the ratio of first Taylor coefficients.",
+      "The deviation is controlled in both directions simultaneously through its absolute value, so a single normed squeeze suffices — there is no need to build separate upper and lower envelope functions."
+    ]
+  },
+  "sections": [
+    {
+      "id": "deviation-bound",
+      "title": "The Linear Deviation Bound",
+      "startLine": 33,
+      "endLine": 47,
+      "summary": "abs_sub_le divides the cubic Taylor bound Real.sin_bound by |x|³ to obtain |(x − sin x)/x³ − 1/6| ≤ (5/96)·|x| for 0 < |x| ≤ 1.",
+      "mathContext": "A degree-4 error over a degree-3 denominator yields an O(|x|) estimate."
+    },
+    {
+      "id": "the-limit",
+      "title": "The Cubic Sine Limit via Squeeze",
+      "startLine": 49,
+      "endLine": 69,
+      "summary": "tendsto_cubic_sine squeezes the deviation between 0 and (5/96)·|x| using squeeze_zero_norm', with |x| ≤ 1 supplied eventually by the closed unit ball.",
+      "mathContext": "(x − sin x)/x³ → 1/6 as x → 0 through nonzero x, no iterated L'Hôpital."
+    },
+    {
+      "id": "taylor-coefficient",
+      "title": "The Value as a Taylor Coefficient",
+      "startLine": 71,
+      "endLine": 81,
+      "summary": "tendsto_cubic_sine_factorial restates the limit value 1/6 as 1/3!, the third Maclaurin coefficient of x − sin x.",
+      "mathContext": "1/6 = 1/3! identifies the limit with the leading nonvanishing Taylor term."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent L'Hôpital entry's OQ-05 by evaluating the cubic sine limit (x − sin x)/x³ → 1/6. The proof divides Mathlib's explicit cubic Taylor bound Real.sin_bound by |x|³ to bound the deviation from 1/6 linearly in |x|, then squeezes — with zero axioms, no iterated L'Hôpital, and no Mean Value Theorem.",
+    "implications": "The Taylor-bound route makes the third-order limit as elementary as a single squeeze: all the analytic content is the already-proved cubic estimate for sine, and the rest is absolute-value algebra. The deviation lemma abs_sub_le is reusable for nearby limits — e.g. (1 − cos x)/x² → 1/2 from the companion cosine bound — wherever a fixed-order Taylor remainder controls an indeterminate ratio.",
+    "openQuestions": [
+      "The companion cosine limit lim_{x→0} (1 − cos x)/x² = 1/2 via Real.cos_bound by the same divide-the-remainder argument, and the unified statement for (x − sin x)/x³ and (1 − cos x)/x² as a single 'second-order remainder' lemma.",
+      "A general order-n cubic-style bound: for f analytic with f(x) − T_{n−1}(x) = O(x^{n+1}), prove (f(x) − T_{n−1}(x))/xⁿ → f^{(n)}(0)/n! directly from an explicit remainder bound, generalising abs_sub_le beyond sine."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lhopital",
+      "relationship": "extends",
+      "description": "Parent entry: proves L'Hôpital's 0/0 rule via the Mean Value Theorem. This entry answers its OQ-05 by evaluating the cubic sine limit (x − sin x)/x³ → 1/6 along the Taylor route."
+    },
+    {
+      "targetId": "lhopital-oq-04",
+      "relationship": "related",
+      "description": "Sibling OQ entry: the order-1 Taylor / leading-order derivation of L'Hôpital. This entry is the order-3 quantitative instance, reading the limit value off as the third Taylor coefficient 1/3!."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "LHopitalOQ05",
+    "lineCount": 83,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "tendsto_cubic_sine",
+        "type": "core",
+        "description": "The cubic sine limit: (x − sin x)/x³ → 1/6 as x → 0 through nonzero x, by squeezing the deviation with the linear Taylor bound.",
+        "leanType": "Tendsto (fun x => (x - Real.sin x) / x ^ 3) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 6))"
+      },
+      {
+        "name": "abs_sub_le",
+        "type": "key",
+        "description": "The linear deviation bound: for 0 < |x| ≤ 1, |(x − sin x)/x³ − 1/6| ≤ (5/96)·|x|, obtained from Real.sin_bound divided by |x|³.",
+        "leanType": "(x : ℝ) → x ≠ 0 → |x| ≤ 1 → |(x - Real.sin x) / x ^ 3 - 1 / 6| ≤ 5 / 96 * |x|"
+      }
+    ],
+    "path": "Proofs/LHopitalOQ05.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "tendsto_cubic_sine",
+      "type": "core",
+      "description": "(x − sin x)/x³ → 1/6 as x → 0, via the cubic Taylor bound and a squeeze; no iterated L'Hôpital.",
+      "leanType": "Tendsto (fun x => (x - Real.sin x) / x ^ 3) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 6))"
+    },
+    {
+      "name": "abs_sub_le",
+      "type": "key",
+      "description": "Linear deviation bound |(x − sin x)/x³ − 1/6| ≤ (5/96)·|x| for 0 < |x| ≤ 1.",
+      "leanType": "(x : ℝ) → x ≠ 0 → |x| ≤ 1 → |(x - Real.sin x) / x ^ 3 - 1 / 6| ≤ 5 / 96 * |x|"
+    }
+  ],
+  "references": [
+    {
+      "authors": "de l'Hôpital, Guillaume (after Johann Bernoulli)",
+      "title": "Analyse des Infiniment Petits pour l'Intelligence des Lignes Courbes",
+      "year": "1696",
+      "venue": "Paris",
+      "note": "The original publication of the rule used for such 0/0 limits"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill (3rd ed.)",
+      "note": "Taylor's theorem with remainder, the basis for the cubic bound on sine"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **L'Hôpital** entry's **OQ-05**: evaluate the classic third-order indeterminate limit
$$\lim_{x\to 0}\frac{x-\sin x}{x^3}=\frac16.$$

Rather than apply L'Hôpital three times, the proof reuses Mathlib's explicit **cubic Taylor bound** `Real.sin_bound`:
$$|\sin x-(x-\tfrac{x^3}{6})|\le |x|^4\cdot\tfrac{5}{96}\quad(|x|\le 1).$$
Dividing this degree-4 error by the degree-3 denominator `x³` leaves a **linear** deviation bound, which a single squeeze drives to zero.

## Results (`proofs/Proofs/LHopitalOQ05.lean`, 83 lines)

- **`abs_sub_le`** — for `0 < |x| ≤ 1`, `|(x − sin x)/x³ − 1/6| ≤ (5/96)·|x|`. The quantitative core: `Real.sin_bound` divided through by `|x|³`.
- **`tendsto_cubic_sine`** — the headline `(x − sin x)/x³ → 1/6` on `𝓝[≠] 0`, via `squeeze_zero_norm'` with envelope `(5/96)·|x|`. The `|x| ≤ 1` hypothesis is supplied *eventually* because the closed unit ball is a neighbourhood of `0` (`Metric.closedBall_mem_nhds`).
- **`tendsto_cubic_sine_factorial`** — restates the value `1/6 = 1/3!`, exposing it as the third Maclaurin coefficient of `x − sin x`.

No iterated L'Hôpital, no Mean Value Theorem, no `native_decide`.

## Verification

`#print axioms` for all three theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status: **verified, 0 axioms, 0 sorries**.

Gallery entry added at `src/data/proofs/lhopital-oq-05/` (meta + annotations); annotations build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)