### PR TITLE
Enrich Even/Odd Subset Counts (subset-count-oq-04)

### DIFF
--- a/src/data/proofs/subset-count-oq-04/annotations.json
+++ b/src/data/proofs/subset-count-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-sc04-header",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 5, "endLine": 54 },
+    "type": "concept",
+    "title": "Goal: even subsets = odd subsets = 2^(n−1), two ways",
+    "content": "For a finite set with n ≥ 1 elements, the even-cardinality subsets and the odd-cardinality subsets are equinumerous, each numbering 2^(n−1). The file proves this twice: an *algebraic* route reading the identity off the binomial theorem at x = −1, and a *bijective* route exhibiting an explicit sign-reversing involution. The empty set (n = 0) is the genuine exception — it has one subset, ∅, of even size 0 — which is why the hypothesis n ≥ 1 (encoded as a witness a ∈ s) is required throughout.",
+    "mathContext": "$\\#\\{T \\subseteq S : |T|\\text{ even}\\} = \\#\\{T \\subseteq S : |T|\\text{ odd}\\} = 2^{\\,n-1}$ for $n \\ge 1$; equivalently $\\sum_{k\\text{ even}}\\binom{n}{k} = \\sum_{k\\text{ odd}}\\binom{n}{k} = 2^{\\,n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["parity", "binomial coefficients", "powerset", "sign-reversing involution", "combinatorial proof"],
+    "prerequisites": ["finite sets", "binomial coefficients", "even/odd parity"]
+  },
+  {
+    "id": "ann-sc04-engine",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 66, "endLine": 107 },
+    "type": "technique",
+    "title": "The reconciliation engine: E + O and E − O pin both halves",
+    "content": "choose_parity_int is the algebraic core. Working in ℤ, it derives two facts about E = ∑_{k even} C(n,k) and O = ∑_{k odd} C(n,k): the unsigned total E + O = 2^n (from Nat.sum_range_choose) and the signed difference E − O = 0. The difference comes from the alternating identity ∑_k (−1)^k C(n,k) = 0 (Int.alternating_sum_range_choose_of_ne, valid for n ≠ 0): on the even class (−1)^k = 1 leaves the terms untouched, on the odd class (−1)^k = −1 negates them, so the full alternating sum literally equals E − O. With E + O = 2^n and E − O = 0, linear arithmetic plus two_pow_split (2^n = 2·2^(n−1)) forces E = O = 2^(n−1). The whole reconciliation lives in ℤ precisely so subtraction is available.",
+    "mathContext": "$E + O = 2^n$ and $E - O = \\sum_k (-1)^k\\binom{n}{k} = 0$ $\\Rightarrow$ $2E = 2^n = 2\\cdot 2^{\\,n-1}$ $\\Rightarrow$ $E = O = 2^{\\,n-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating binomial identity", "Nat.sum_range_choose", "sum_filter_add_sum_filter_not", "neg_one_pow", "ℤ vs ℕ subtraction"],
+    "prerequisites": ["binomial theorem", "Finset sums", "integer arithmetic"]
+  },
+  {
+    "id": "ann-sc04-binomial",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 109, "endLine": 135 },
+    "type": "theorem",
+    "title": "Binomial-sum form: casting back to ℕ",
+    "content": "even_choose_sum and odd_choose_sum transport the two halves of the ℤ engine back to ℕ via Nat.cast injectivity (exact_mod_cast over Nat.cast_sum). The odd statement is phrased with the Odd predicate, so the proof first rewrites the `Odd k` filter to `¬ Even k` (Finset.filter_congr with Nat.not_even_iff_odd) to match the engine's ¬Even form. even_eq_odd_choose_sum is then a one-line corollary: both halves equal 2^(n−1), hence each other.",
+    "mathContext": "$\\sum_{k\\text{ even}}\\binom{n}{k} = \\sum_{k\\text{ odd}}\\binom{n}{k} = 2^{\\,n-1}$ in $\\mathbb{N}$, obtained from the $\\mathbb{Z}$ identities by casting.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.cast injectivity", "Finset.filter_congr", "Nat.not_even_iff_odd", "exact_mod_cast"],
+    "prerequisites": ["the reconciliation engine", "ℕ/ℤ casts"]
+  },
+  {
+    "id": "ann-sc04-involution",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 141, "endLine": 172 },
+    "type": "definition",
+    "title": "The toggling involution and its parity flip",
+    "content": "toggle a t = (if a ∈ t then t.erase a else insert a t) is the canonical sign-reversing involution: it removes the fixed element a when present and inserts it otherwise. Three lemmas establish its key properties: toggle_involutive (applying it twice returns t, via Finset.insert_erase / simp), toggle_subset (if a ∈ s and t ⊆ s then toggle a t ⊆ s, so it preserves the powerset of s), and the crucial toggle_card_flip — toggling always changes |t| by exactly one (card_erase_of_mem decreases, card_insert_of_notMem increases), so it flips the parity of the cardinality unconditionally.",
+    "mathContext": "$\\mathrm{toggle}\\,a\\,t = \\begin{cases} t \\setminus \\{a\\} & a \\in t \\\\ t \\cup \\{a\\} & a \\notin t \\end{cases}$; $\\mathrm{toggle}\\,a\\,(\\mathrm{toggle}\\,a\\,t) = t$ and $\\mathrm{Even}\\,|\\mathrm{toggle}\\,a\\,t| \\iff \\lnot\\,\\mathrm{Even}\\,|t|$.",
+    "significance": "key",
+    "relatedConcepts": ["sign-reversing involution", "Finset.insert_erase", "card_erase_of_mem", "card_insert_of_notMem", "parity flip"],
+    "prerequisites": ["Finset erase/insert", "involutions", "cardinality"]
+  },
+  {
+    "id": "ann-sc04-bijection",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 174, "endLine": 188 },
+    "type": "theorem",
+    "title": "Powerset form: the bijection #even = #odd",
+    "content": "card_even_eq_card_odd_subsets proves #even = #odd without binomial coefficients, using Finset.card_nbij' with toggle a as both the forward map and its own inverse. The four obligations are: toggle maps even subsets of s to odd ones (toggle_subset keeps it in the powerset, toggle_card_flip flips parity), it maps odd to even symmetrically, and it is two-sided inverse to itself (toggle_involutive both ways). This is the purest statement of the result: a single explicit pairing witnesses the balance.",
+    "mathContext": "$\\mathrm{toggle}\\,a : \\{T \\subseteq S : |T|\\text{ even}\\} \\xrightarrow{\\ \\sim\\ } \\{T \\subseteq S : |T|\\text{ odd}\\}$, a self-inverse bijection $\\Rightarrow \\#\\text{even} = \\#\\text{odd}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_nbij'", "bijective proof", "powerset filter", "equinumerosity"],
+    "prerequisites": ["the toggling involution", "cardinality via bijection"]
+  },
+  {
+    "id": "ann-sc04-counts",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 190, "endLine": 216 },
+    "type": "theorem",
+    "title": "Pinning each count at 2^(n−1)",
+    "content": "card_even_subsets and card_odd_subsets combine the bijection with the powerset split. Finset.filter_card_add_filter_neg_card_eq_card says #even + #(¬even) = #powerset = 2^(#s) (Finset.card_powerset), and the bijection gives #even = #(¬even); with 2^(#s) = 2·2^(#s−1) (valid since a ∈ s forces #s ≥ 1) omega closes each at 2^(#s−1). The odd count first rewrites the Odd filter to ¬Even, then reuses the even count.",
+    "mathContext": "$\\#\\text{even} + \\#\\text{odd} = 2^{\\#s}$ and $\\#\\text{even} = \\#\\text{odd}$ $\\Rightarrow$ each $= 2^{\\,\\#s - 1}$ (using $\\#s \\ge 1$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_powerset", "filter_card_add_filter_neg_card_eq_card", "omega", "pow_succ"],
+    "prerequisites": ["the bijection #even = #odd", "powerset cardinality"]
+  },
+  {
+    "id": "ann-sc04-sanity",
+    "proofId": "subset-count-oq-04",
+    "range": { "startLine": 218, "endLine": 228 },
+    "type": "context",
+    "title": "Decidable sanity checks at n = 3",
+    "content": "Three decide-checked examples confirm the result at n = 3: the even-indexed row sum C(3,0)+C(3,2) = 1+3 = 4, the odd-indexed sum C(3,1)+C(3,3) = 3+1 = 4, and the concrete set {0,1,2} having exactly 4 even-cardinality subsets — all matching 2² = 2^(3−1). These live in `example` blocks and are illustrative; they do not enter the verified theorems' axiom footprint.",
+    "mathContext": "$n = 3$: $\\binom{3}{0}+\\binom{3}{2} = \\binom{3}{1}+\\binom{3}{3} = 4 = 2^{3-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["decide", "worked example", "small cases"],
+    "prerequisites": ["binomial coefficients"]
+  }
+]

--- a/src/data/proofs/subset-count-oq-04/meta.json
+++ b/src/data/proofs/subset-count-oq-04/meta.json
@@ -82,6 +82,50 @@
       "Even/odd parity arithmetic over ℕ"
     ]
   },
+  "sections": [
+    {
+      "id": "statement",
+      "title": "Statement and Two-Route Strategy",
+      "startLine": 5,
+      "endLine": 58,
+      "summary": "Docstring fixing the claim — for n ≥ 1, #even-subsets = #odd-subsets = 2^(n−1) (equivalently ∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1)) — and outlining the two independent routes: an algebraic one from the alternating binomial identity and a bijective one from a sign-reversing involution."
+    },
+    {
+      "id": "engine",
+      "title": "The Integer Reconciliation Engine",
+      "startLine": 60,
+      "endLine": 107,
+      "summary": "two_pow_split (2^n = 2·2^(n−1) for n ≥ 1) and the core choose_parity_int: working in ℤ, combine E + O = 2^n (Nat.sum_range_choose) with E − O = 0 (Int.alternating_sum_range_choose_of_ne, after collapsing (−1)^k to ±1 on each parity class) to force E = O = 2^(n−1)."
+    },
+    {
+      "id": "binomial-form",
+      "title": "Binomial-Sum Form: Even and Odd Halves",
+      "startLine": 109,
+      "endLine": 135,
+      "summary": "even_choose_sum and odd_choose_sum cast the integer engine back to ℕ (via Nat.cast injectivity), pinning each parity-restricted half of Pascal's row at 2^(n−1); even_eq_odd_choose_sum states their equality. The odd half is obtained by rewriting the Odd filter to ¬Even."
+    },
+    {
+      "id": "involution",
+      "title": "The Toggling Involution",
+      "startLine": 137,
+      "endLine": 172,
+      "summary": "The canonical sign-reversing involution toggle a t = (if a ∈ t then t.erase a else insert a t), with toggle_involutive (self-inverse), toggle_subset (stays inside s when a ∈ s), and toggle_card_flip (it always changes |t| by one, flipping parity) — the combinatorial heart of the bijective proof."
+    },
+    {
+      "id": "powerset-form",
+      "title": "Powerset Form: Bijection and Each Count = 2^(n−1)",
+      "startLine": 174,
+      "endLine": 216,
+      "summary": "card_even_eq_card_odd_subsets uses Finset.card_nbij' with toggle as its own inverse to prove #even = #odd directly; card_even_subsets and card_odd_subsets then combine this with the powerset split (#powerset = 2^#s) to pin each count at 2^(#s − 1)."
+    },
+    {
+      "id": "sanity",
+      "title": "Sanity Checks",
+      "startLine": 218,
+      "endLine": 229,
+      "summary": "Three decide-checked examples for n = 3: the even-indexed sum C(3,0)+C(3,2) = 4, the odd-indexed sum C(3,1)+C(3,3) = 4, and the set {0,1,2} having 4 even-cardinality subsets — all equal to 2² = 2^(3−1)."
+    }
+  ],
   "conclusion": {
     "summary": "For n ≥ 1 the even- and odd-cardinality subsets of an n-set each number exactly 2^(n−1). The result is proved twice: algebraically, by reconciling ∑_k C(n,k) = 2^n with ∑_k (−1)^k C(n,k) = 0 to get ∑_{k even} C(n,k) = ∑_{k odd} C(n,k) = 2^(n−1); and bijectively, via the canonical element-toggling involution on the powerset. 11 theorems/lemmas, 1 definition, 0 sorries, 0 axioms.",
     "implications": "The element-toggling involution is the base case behind inclusion–exclusion parity cancellation: the same sign-reversing pairing that balances even and odd subsets underlies the vanishing of alternating sums throughout combinatorics. The binomial form is the n-th row instance of evaluating a generating function at −1.",
@@ -103,9 +147,19 @@
   ],
   "crossReferences": [
     {
-      "targetId": "subset-count",
+      "proofId": "subset-count",
       "relationship": "extends",
       "description": "Refines the count |P(S)| = 2^n by splitting the powerset according to the parity of subset size, showing each parity class has exactly half the subsets."
+    },
+    {
+      "proofId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The algebraic half of this entry is the binomial theorem evaluated at x = −1: (1 − 1)^n = ∑_k (−1)^k C(n,k) = 0 is exactly the alternating identity that forces the even- and odd-indexed coefficient sums to balance. The unsigned row sum ∑_k C(n,k) = 2^n (the binomial theorem at x = 1) supplies the total."
+    },
+    {
+      "proofId": "inclusion-exclusion",
+      "relationship": "related",
+      "description": "The element-toggling involution used here is the prototype for inclusion–exclusion parity cancellation: the same sign-reversing pairing that balances even- and odd-cardinality subsets is the mechanism behind the vanishing of alternating sums ∑_{T ⊆ S} (−1)^{|T|} that underlie the inclusion–exclusion principle."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `subset-count-oq-04` (even-cardinality subsets = odd-cardinality subsets = 2^(n−1)).

The entry had a rich overview/conclusion but was **missing its `sections` array and had no `annotations.json`**. Added both, plus cross-references.

- **`sections` array** (6 sections) covering the full 229-line Lean file: statement & two-route strategy, the integer reconciliation engine (E+O=2^n, E−O=0 ⟹ E=O=2^(n−1)), the binomial-sum form, the toggling involution, the powerset form, and the decide sanity checks.
- **`annotations.json`** (7 annotations, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`): the goal, the E±O engine, the ℕ-casting of the binomial halves, the toggle involution + unconditional parity flip, the `Finset.card_nbij'` bijection #even=#odd, the 2^(n−1) counts, and the n=3 sanity checks.
- **Cross-references** added to `binomial-theorem` (the algebraic half is literally the binomial theorem at x=−1) and `inclusion-exclusion` (the toggle is the prototype parity-cancellation involution behind ∑(−1)^|T|); normalized the existing `targetId` to `proofId`.

Axiom integrity: confirmed `status: verified` / `axiomCount: 0` is accurate — 0 sorries, 0 axiom declarations, no native_decide in the theorems (the three `decide` uses are illustrative `example` blocks), no assumption-carrying structures. No change needed.

Verified with `pnpm build` (✓ built).