### PR TITLE
research(product-of-segments-of-chords-oq-04): power of a point via Vieta + radical axis [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ProductOfSegmentsOfChordsOQ04.lean
+++ b/proofs/Proofs/ProductOfSegmentsOfChordsOQ04.lean
@@ -1,0 +1,321 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Tactic
+
+/-!
+# Power of a Point via Vieta, and the Radical Axis (OQ-04)
+
+This file answers `product-of-segments-of-chords-oq-04`:
+
+> "Power of a Point via Vieta: Direction-Independence of the Line–Circle
+> Intersection Product."
+
+The parent *Product of Segments of Chords* entry proves the classical fact that
+for two chords `AB`, `CD` of a circle meeting at an interior point `P` one has
+`PA · PB = PC · PD`. Here we explain **why** the product is the same for every
+chord through `P`, by reducing it to **Vieta's formula** for a quadratic, and we
+push the same algebra to its natural conclusion — the **radical axis** and
+**radical centre**.
+
+## The Vieta mechanism (Part 1)
+
+Fix a sphere of centre `O` and radius `r`, and a base point `P`. A line through
+`P` in **unit** direction `d` meets the sphere where the parameter `t` (the
+*signed* distance from `P`, since `‖d‖ = 1`) satisfies the monic quadratic
+
+`t² + 2⟪P − O, d⟫·t + (‖P − O‖² − r²) = 0`.
+
+The **constant coefficient** is `‖P − O‖² − r²` — the **power of the point** `P`,
+which does **not depend on the direction** `d`. By Vieta's formula the product of
+the two intersection parameters equals that constant coefficient. Hence the
+signed product `t₁ · t₂` is the power of `P` for **every** line through `P`,
+which is exactly the direction-independence the chord theorem observes.
+
+* `power_along_line` — the quadratic in `t` obtained by restricting `power` to a line.
+* `chord_product_eq_power` — Vieta: the two intersection parameters multiply to
+  the power of the point.
+* `chord_product_direction_independent` — the headline: the product is the same
+  for two different directions through `P`.
+* `chord_sum_eq` / `chord_product_sign` — the companion sum formula and the
+  inside/outside sign of the product.
+
+## The radical axis as a linear locus (Part 2)
+
+Although `power` is a *quadratic* function of `P`, the **difference** of the
+power functions of two spheres is **affine-linear** — the quadratic term `‖P‖²`
+cancels. So the locus where two spheres have equal power (the **radical axis**)
+is a hyperplane perpendicular to the line of centres, and three spheres with
+non-collinear centres have a unique common point (the **radical centre**).
+
+* `power_expand`, `radical_axis_linear`, `radical_axis_perp`, `radical_axis_affine`.
+* `equal_power_linear`, `radical_center_unique`, `radical_center_exists`,
+  `radical_center_existsUnique` (planar, `EuclideanSpace ℝ (Fin 2)`).
+
+0 axioms, 0 sorries.
+-/
+
+set_option linter.unusedVariables false
+
+open scoped RealInnerProductSpace
+
+namespace ProductOfSegmentsOfChordsOQ04
+
+/-! ## Power of a point, in any real inner product space -/
+
+section General
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- The **power of the point** `P` with respect to the sphere of centre `O` and
+radius `r`: the signed quantity `‖P − O‖² − r²`. It is negative inside the
+sphere, zero on it, and positive outside. -/
+def power (O : E) (r : ℝ) (P : E) : ℝ := ‖P - O‖ ^ 2 - r ^ 2
+
+/-! ### Part 1 — Vieta and direction-independence -/
+
+/-- **The power function restricted to a line is a quadratic in the parameter.**
+Along the line `t ↦ P + t • d` the power is
+`‖d‖²·t² + 2⟪P − O, d⟫·t + power O r P`.
+
+The constant term is `power O r P` — independent of the direction `d`. -/
+theorem power_along_line (O P d : E) (r t : ℝ) :
+    power O r (P + t • d)
+      = ‖d‖ ^ 2 * t ^ 2 + 2 * ⟪P - O, d⟫ * t + power O r P := by
+  unfold power
+  have hPt : P + t • d - O = (P - O) + t • d := by abel
+  rw [hPt, norm_add_sq_real, real_inner_smul_right, norm_smul, mul_pow, Real.norm_eq_abs,
+    sq_abs]
+  ring
+
+/-- For a **unit** direction the restriction is *monic*:
+`t² + 2⟪P − O, d⟫·t + power O r P`. -/
+theorem power_along_unit_line (O P d : E) (r t : ℝ) (hd : ‖d‖ = 1) :
+    power O r (P + t • d) = t ^ 2 + 2 * ⟪P - O, d⟫ * t + power O r P := by
+  rw [power_along_line, hd]; ring
+
+/-- **Vieta's formula for the chord parameters.**
+If a line through `P` in unit direction `d` meets the sphere at the two distinct
+parameters `t₁ ≠ t₂` (i.e. `P + tᵢ • d` lies on the sphere), then the product of
+the parameters is exactly the **power of the point** `P`:
+`t₁ · t₂ = power O r P`.
+
+Because the right-hand side has no dependence on `d`, this is the
+direction-independence of the line–circle intersection product. -/
+theorem chord_product_eq_power (O P d : E) (r t₁ t₂ : ℝ) (hd : ‖d‖ = 1)
+    (hne : t₁ ≠ t₂)
+    (h₁ : power O r (P + t₁ • d) = 0) (h₂ : power O r (P + t₂ • d) = 0) :
+    t₁ * t₂ = power O r P := by
+  rw [power_along_unit_line _ _ _ _ _ hd] at h₁ h₂
+  -- `t₂·(quad at t₁) − t₁·(quad at t₂) = (t₁ − t₂)·(t₁·t₂ − power)`.
+  have key : (t₁ - t₂) * (t₁ * t₂ - power O r P) = 0 := by
+    linear_combination t₂ * h₁ - t₁ * h₂
+  rcases mul_eq_zero.mp key with h | h
+  · exact absurd (sub_eq_zero.mp h) hne
+  · linarith [sub_eq_zero.mp h]
+
+/-- **The companion sum formula.** Under the same hypotheses the two chord
+parameters sum to `-2⟪P − O, d⟫`. -/
+theorem chord_sum_eq (O P d : E) (r t₁ t₂ : ℝ) (hd : ‖d‖ = 1) (hne : t₁ ≠ t₂)
+    (h₁ : power O r (P + t₁ • d) = 0) (h₂ : power O r (P + t₂ • d) = 0) :
+    t₁ + t₂ = -(2 * ⟪P - O, d⟫) := by
+  rw [power_along_unit_line _ _ _ _ _ hd] at h₁ h₂
+  have key : (t₁ - t₂) * (t₁ + t₂ + 2 * ⟪P - O, d⟫) = 0 := by
+    linear_combination h₁ - h₂
+  rcases mul_eq_zero.mp key with h | h
+  · exact absurd (sub_eq_zero.mp h) hne
+  · linarith
+
+/-- **Direction-independence of the chord product.**
+Two lines through `P`, in unit directions `d` and `d'`, each meeting the sphere
+at two distinct parameters, produce the **same** signed product:
+`t₁ · t₂ = s₁ · s₂`. Both equal the power of the point `P`. -/
+theorem chord_product_direction_independent (O P d d' : E) (r t₁ t₂ s₁ s₂ : ℝ)
+    (hd : ‖d‖ = 1) (hd' : ‖d'‖ = 1) (hne : t₁ ≠ t₂) (hne' : s₁ ≠ s₂)
+    (h₁ : power O r (P + t₁ • d) = 0) (h₂ : power O r (P + t₂ • d) = 0)
+    (g₁ : power O r (P + s₁ • d') = 0) (g₂ : power O r (P + s₂ • d') = 0) :
+    t₁ * t₂ = s₁ * s₂ := by
+  rw [chord_product_eq_power O P d r t₁ t₂ hd hne h₁ h₂,
+    chord_product_eq_power O P d' r s₁ s₂ hd' hne' g₁ g₂]
+
+/-- **Sign of the chord product.** With a nonnegative radius the signed product
+`t₁ · t₂` is negative exactly when `P` is strictly inside the sphere
+(`‖P − O‖ < r`) and positive exactly when `P` is strictly outside
+(`r < ‖P − O‖`) — the intersecting-chords vs. secant–secant dichotomy. -/
+theorem chord_product_sign (O P d : E) (r t₁ t₂ : ℝ) (hr : 0 ≤ r) (hd : ‖d‖ = 1)
+    (hne : t₁ ≠ t₂)
+    (h₁ : power O r (P + t₁ • d) = 0) (h₂ : power O r (P + t₂ • d) = 0) :
+    (t₁ * t₂ < 0 ↔ ‖P - O‖ < r) ∧ (0 < t₁ * t₂ ↔ r < ‖P - O‖) := by
+  have hprod : t₁ * t₂ = ‖P - O‖ ^ 2 - r ^ 2 :=
+    chord_product_eq_power O P d r t₁ t₂ hd hne h₁ h₂
+  have hn : (0 : ℝ) ≤ ‖P - O‖ := norm_nonneg _
+  rw [hprod]
+  refine ⟨⟨fun h => ?_, fun h => ?_⟩, ⟨fun h => ?_, fun h => ?_⟩⟩
+  · nlinarith
+  · nlinarith
+  · nlinarith
+  · nlinarith
+
+/-! ### Part 2 — The radical axis as a linear locus -/
+
+/-- **Quadratic-form expansion of the power function.**
+`pow(P) = ‖P‖² − 2⟪P, O⟫ + ‖O‖² − r²`. The leading term `‖P‖²` is the same for
+every sphere — this is the key fact that linearises the radical axis. -/
+theorem power_expand (O : E) (r : ℝ) (P : E) :
+    power O r P = ‖P‖ ^ 2 - 2 * ⟪P, O⟫ + ‖O‖ ^ 2 - r ^ 2 := by
+  unfold power
+  rw [norm_sub_sq_real]
+
+/-- **The radical axis is an affine hyperplane.**
+Two spheres `(O₁, r₁)` and `(O₂, r₂)` have equal power at `P` **iff** `P`
+satisfies the single affine-linear equation
+`2⟪P, O₂ − O₁⟫ = (‖O₂‖² − ‖O₁‖²) − (r₂² − r₁²)`.
+
+The quadratic term `‖P‖²` present in each power function cancels, leaving a
+linear equation whose normal vector `O₂ − O₁` points along the line of centres.
+This is exactly the sense in which "the radical axis is the linear locus where
+two quadratic forms agree." -/
+theorem radical_axis_linear (O₁ O₂ : E) (r₁ r₂ : ℝ) (P : E) :
+    power O₁ r₁ P = power O₂ r₂ P ↔
+      2 * ⟪P, O₂ - O₁⟫ = (‖O₂‖ ^ 2 - ‖O₁‖ ^ 2) - (r₂ ^ 2 - r₁ ^ 2) := by
+  rw [power_expand, power_expand, inner_sub_right]
+  constructor <;> intro h <;> linarith
+
+/-- **The radical axis is perpendicular to the line of centres.**
+If `P` and `Q` both lie on the radical axis of two spheres with centres
+`O₁ ≠ O₂`, then `Q − P` is orthogonal to `O₂ − O₁`. -/
+theorem radical_axis_perp (O₁ O₂ : E) (r₁ r₂ : ℝ) (P Q : E)
+    (hP : power O₁ r₁ P = power O₂ r₂ P)
+    (hQ : power O₁ r₁ Q = power O₂ r₂ Q) :
+    ⟪Q - P, O₂ - O₁⟫ = 0 := by
+  rw [radical_axis_linear] at hP hQ
+  rw [inner_sub_left]
+  linarith
+
+/-- **The radical axis is an affine subspace.**
+If `P` and `Q` lie on the radical axis, so does every point `P + t • (Q − P)` of
+the line through them. -/
+theorem radical_axis_affine (O₁ O₂ : E) (r₁ r₂ : ℝ) (P Q : E) (t : ℝ)
+    (hP : power O₁ r₁ P = power O₂ r₂ P)
+    (hQ : power O₁ r₁ Q = power O₂ r₂ Q) :
+    power O₁ r₁ (P + t • (Q - P)) = power O₂ r₂ (P + t • (Q - P)) := by
+  rw [radical_axis_linear] at hP hQ ⊢
+  rw [inner_add_left, real_inner_smul_left, inner_sub_left]
+  have hd : ⟪Q, O₂ - O₁⟫ - ⟪P, O₂ - O₁⟫ = 0 := by linarith
+  rw [hd, mul_zero, add_zero]
+  exact hP
+
+end General
+
+/-! ## The radical centre in the plane -/
+
+/-- 2D Euclidean point type, matching the parent file's convention. -/
+abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
+
+/-- For `Vec2`, the squared norm of a difference expands to the sum of squared
+coordinate differences. (Same helper as `ProductOfSegmentsOfChordsOQ03`.) -/
+lemma normSq_coord (X Y : Vec2) :
+    ‖X - Y‖ ^ 2 = (X 0 - Y 0) ^ 2 + (X 1 - Y 1) ^ 2 := by
+  rw [← real_inner_self_eq_norm_sq, PiLp.inner_apply, Fin.sum_univ_two]
+  simp [pow_two]
+
+/-- Coordinate expansion of the power function in the plane. -/
+lemma power_coord (O P : Vec2) (r : ℝ) :
+    power O r P = (P 0 - O 0) ^ 2 + (P 1 - O 1) ^ 2 - r ^ 2 := by
+  unfold power
+  rw [normSq_coord]
+
+/-- **Radical-axis equation, coordinate form.**
+The locus of equal power between the two planar circles `(Oa, ra)` and
+`(Ob, rb)` is the line
+`2[(Ob₀ − Oa₀)·P₀ + (Ob₁ − Oa₁)·P₁] = (Ob₀² + Ob₁² − rb²) − (Oa₀² + Oa₁² − ra²)`. -/
+lemma equal_power_linear (Oa Ob P : Vec2) (ra rb : ℝ) :
+    power Oa ra P = power Ob rb P ↔
+      2 * ((Ob 0 - Oa 0) * P 0 + (Ob 1 - Oa 1) * P 1)
+        = (Ob 0 ^ 2 + Ob 1 ^ 2 - rb ^ 2) - (Oa 0 ^ 2 + Oa 1 ^ 2 - ra ^ 2) := by
+  rw [power_coord, power_coord]
+  constructor <;> intro h <;> linear_combination h
+
+/-- **Uniqueness of the radical centre.**
+If two points `P, P'` both have equal power to all three circles `(Oᵢ, rᵢ)`
+and the centres are non-collinear (the centre determinant is nonzero), then
+`P = P'`. -/
+theorem radical_center_unique
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ) (P P' : Vec2)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0)
+    (hP12 : power O₁ r₁ P = power O₂ r₂ P)
+    (hP13 : power O₁ r₁ P = power O₃ r₃ P)
+    (hP'12 : power O₁ r₁ P' = power O₂ r₂ P')
+    (hP'13 : power O₁ r₁ P' = power O₃ r₃ P') :
+    P = P' := by
+  rw [equal_power_linear] at hP12 hP13 hP'12 hP'13
+  -- Subtract the `P` and `P'` equations: the constant right-hand sides cancel,
+  -- giving a homogeneous linear system in the coordinate differences.
+  have e1 : (O₂ 0 - O₁ 0) * (P 0 - P' 0) + (O₂ 1 - O₁ 1) * (P 1 - P' 1) = 0 := by
+    linear_combination (hP12 - hP'12) / 2
+  have e2 : (O₃ 0 - O₁ 0) * (P 0 - P' 0) + (O₃ 1 - O₁ 1) * (P 1 - P' 1) = 0 := by
+    linear_combination (hP13 - hP'13) / 2
+  -- Cramer elimination against the nonzero centre determinant forces both
+  -- coordinate differences to vanish.
+  have hx : ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))
+      * (P 0 - P' 0) = 0 := by
+    linear_combination (O₃ 1 - O₁ 1) * e1 - (O₂ 1 - O₁ 1) * e2
+  have hy : ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))
+      * (P 1 - P' 1) = 0 := by
+    linear_combination (O₂ 0 - O₁ 0) * e2 - (O₃ 0 - O₁ 0) * e1
+  have hP0 : P 0 = P' 0 := by
+    rcases mul_eq_zero.mp hx with h | h
+    · exact absurd h hdet
+    · linarith
+  have hP1 : P 1 = P' 1 := by
+    rcases mul_eq_zero.mp hy with h | h
+    · exact absurd h hdet
+    · linarith
+  ext i
+  fin_cases i
+  · exact hP0
+  · exact hP1
+
+/-- **Existence of the radical centre.**
+Three planar circles with non-collinear centres admit a point of equal power to
+all three: the explicit Cramer solution of the two radical-axis equations. -/
+theorem radical_center_exists
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0) :
+    ∃ P : Vec2, power O₁ r₁ P = power O₂ r₂ P ∧ power O₁ r₁ P = power O₃ r₃ P := by
+  -- The radical-axis equations form the 2×2 linear system
+  --   2[(O₂₀−O₁₀)x + (O₂₁−O₁₁)y] = K₁₂,   2[(O₃₀−O₁₀)x + (O₃₁−O₁₁)y] = K₁₃
+  -- with `Kᵢⱼ = (Oⱼ₀²+Oⱼ₁²−rⱼ²) − (Oᵢ₀²+Oᵢ₁²−rᵢ²)`. Cramer's rule solves it.
+  -- The common denominator `2·det` is nonzero; supply it explicitly so the
+  -- denominator-clearing step matches `hdet`'s un-expanded determinant.
+  have hden : (2 : ℝ) * ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0)) ≠ 0 :=
+    mul_ne_zero two_ne_zero hdet
+  refine ⟨!₂[
+      (((O₂ 0 ^ 2 + O₂ 1 ^ 2 - r₂ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)) * (O₃ 1 - O₁ 1)
+        - ((O₃ 0 ^ 2 + O₃ 1 ^ 2 - r₃ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)) * (O₂ 1 - O₁ 1))
+        / (2 * ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0))),
+      ((O₂ 0 - O₁ 0) * ((O₃ 0 ^ 2 + O₃ 1 ^ 2 - r₃ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2))
+        - (O₃ 0 - O₁ 0) * ((O₂ 0 ^ 2 + O₂ 1 ^ 2 - r₂ ^ 2) - (O₁ 0 ^ 2 + O₁ 1 ^ 2 - r₁ ^ 2)))
+        / (2 * ((O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0)))], ?_, ?_⟩
+  · rw [equal_power_linear]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+    rw [← mul_div_assoc, ← mul_div_assoc, ← add_div, ← mul_div_assoc,
+      div_eq_iff hden]
+    ring
+  · rw [equal_power_linear]
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
+    rw [← mul_div_assoc, ← mul_div_assoc, ← add_div, ← mul_div_assoc,
+      div_eq_iff hden]
+    ring
+
+/-- **The radical centre exists and is unique** for three circles with
+non-collinear centres. -/
+theorem radical_center_existsUnique
+    (O₁ O₂ O₃ : Vec2) (r₁ r₂ r₃ : ℝ)
+    (hdet : (O₂ 0 - O₁ 0) * (O₃ 1 - O₁ 1) - (O₂ 1 - O₁ 1) * (O₃ 0 - O₁ 0) ≠ 0) :
+    ∃! P : Vec2, power O₁ r₁ P = power O₂ r₂ P ∧ power O₁ r₁ P = power O₃ r₃ P := by
+  obtain ⟨P, hP12, hP13⟩ := radical_center_exists O₁ O₂ O₃ r₁ r₂ r₃ hdet
+  refine ⟨P, ⟨hP12, hP13⟩, ?_⟩
+  rintro P' ⟨hP'12, hP'13⟩
+  exact radical_center_unique O₁ O₂ O₃ r₁ r₂ r₃ P' P hdet hP'12 hP'13 hP12 hP13
+
+end ProductOfSegmentsOfChordsOQ04

--- a/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords-oq-04/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "product-of-segments-of-chords-oq-04",
+  "title": "Product of Segments of Chords OQ-04: Power of a Point via Vieta, and the Radical Axis",
+  "slug": "product-of-segments-of-chords-oq-04",
+  "description": "Explains why the intersecting-chords product PA·PB is the same for every chord through a fixed point P: restricting the power function to a line gives a monic quadratic whose constant coefficient is the power of the point, so by Vieta the product of the two intersection parameters equals that power, independently of the line's direction. The same quadratic-form algebra then linearises the radical axis (a hyperplane perpendicular to the line of centres) and yields a unique radical centre for three circles with non-collinear centres.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProductOfSegmentsOfChordsOQ04.lean",
+    "tags": [
+      "geometry",
+      "inner-product-space",
+      "power-of-a-point",
+      "vieta",
+      "radical-axis",
+      "radical-center",
+      "quadratic-form",
+      "wiedijk-100"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 321,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "assumptions": "None. All results are proved over an arbitrary real inner product space (or `EuclideanSpace ℝ (Fin 2)` for the radical-centre statements), with no axioms or sorries; `#print axioms` reports only propext / Classical.choice / Quot.sound.",
+    "originalContributions": [
+      "Identifies the precise mechanism behind the direction-independence of the intersecting-chords product: the restriction of the power function to a line is the monic quadratic t² + 2⟨P−O,d⟩·t + power(O,r,P), whose constant coefficient is the direction-free power of the point (power_along_line, power_along_unit_line).",
+      "chord_product_eq_power: a self-contained Vieta argument (subtract the two chord equations, divide by t₁−t₂) showing the product of the two intersection parameters equals the power of the point, with no appeal to a root-existence or polynomial-coefficient API.",
+      "chord_product_direction_independent: the headline statement that two secant lines through P in different unit directions produce the same signed product t₁·t₂ = s₁·s₂.",
+      "Unifies the Vieta picture with the radical axis: because the quadratic term ‖P‖² is shared by every power function, the difference of two power functions is affine-linear (radical_axis_linear), perpendicular to the line of centres (radical_axis_perp), and an affine subspace (radical_axis_affine).",
+      "radical_center_exists / radical_center_unique / radical_center_existsUnique: an explicit Cramer-rule construction of the radical centre of three planar circles with non-collinear centres, together with its uniqueness, giving a full ∃! statement."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euclid (Elements III.35–37) proved the intersecting-chords and secant relations; Jakob Steiner systematised them in 1826 under the name 'power of a point' (Potenz eines Punktes), defining pow(P) = d² − r². A recurring question is why the chord product PA·PB does not depend on which chord through P one chooses. The cleanest modern answer is algebraic: substitute the parametric line P + t·d into the circle equation and read off Vieta's product. Steiner also introduced the radical axis — the locus of points with equal power to two circles — and the radical centre of three circles; these are the natural structural sequel, because the power function is a quadratic form whose difference across two circles is linear. The intersecting-chords theorem is Wiedijk #55; this entry answers the parent's open question 'Power of a Point via Vieta: Direction-Independence of the Line–Circle Intersection Product' and folds in the radical-axis/quadratic-form question.",
+    "problemStatement": "Fix a sphere of centre O and radius r in a real inner product space and a base point P. (1) Show that for a unit direction d the parameters t at which the line P + t·d meets the sphere satisfy the monic quadratic t² + 2⟨P−O,d⟩·t + (‖P−O‖²−r²) = 0, and conclude by Vieta that the product of two distinct intersection parameters equals power(O,r,P) = ‖P−O‖²−r², independently of d. (2) Show that the locus where two spheres have equal power is the affine hyperplane 2⟨P,O₂−O₁⟩ = (‖O₂‖²−‖O₁‖²)−(r₂²−r₁²) (the radical axis), that it is perpendicular to the line of centres, and that three planar circles with non-collinear centres have a unique common equal-power point (the radical centre).",
+    "proofStrategy": "Define power(O,r,P) = ‖P−O‖²−r². Expanding ‖(P−O)+t·d‖² via `norm_add_sq_real` gives power(O,r,P+t·d) = ‖d‖²·t² + 2⟨P−O,d⟩·t + power(O,r,P); for a unit d this is monic with constant term the direction-free power. For two distinct on-sphere parameters t₁ ≠ t₂, the identity t₂·q(t₁) − t₁·q(t₂) = (t₁−t₂)(t₁·t₂ − power) (verified by `linear_combination`) forces t₁·t₂ = power, since t₁ ≠ t₂; the companion subtraction gives the sum t₁+t₂ = −2⟨P−O,d⟩. Direction-independence is then immediate. For Part 2, `power_expand` shows pow(P) = ‖P‖² − 2⟨P,O⟩ + ‖O‖² − r², so subtracting two power functions cancels ‖P‖² and leaves a single linear equation; perpendicularity and the affine-subspace property follow by `inner_*` bilinearity and `linarith`. In the plane, the two radical-axis equations form a 2×2 linear system solved explicitly by Cramer's rule (denominator 2·det ≠ 0), giving existence; uniqueness comes from eliminating the coordinate differences against the non-zero centre determinant.",
+    "keyInsights": [
+      "The whole 'direction-independence' phenomenon is the single fact that the constant coefficient of the chord quadratic — the power of the point — carries no dependence on the line direction d; the direction only enters the linear coefficient 2⟨P−O,d⟩.",
+      "Vieta's product can be extracted without naming the roots or invoking any polynomial API: the combination t₂·q(t₁) − t₁·q(t₂) factors as (t₁−t₂)(t₁·t₂ − power), so distinctness alone gives t₁·t₂ = power.",
+      "The radical axis is linear precisely because the leading quadratic term ‖P‖² of the power function is the same for every circle and cancels on subtraction — the quadratic forms agree exactly on an affine hyperplane.",
+      "The normal vector of the radical axis is O₂ − O₁, which is why the axis is perpendicular to the line of centres (radical_axis_perp).",
+      "The planar radical centre is the Cramer solution of the two radical-axis equations; the shared denominator 2·det is non-zero exactly when the three centres are non-collinear, which simultaneously yields existence and uniqueness."
+    ],
+    "prerequisites": [
+      "InnerProductSpace ℝ E and the real polarisation identities (norm_add_sq_real, norm_sub_sq_real, real_inner_smul_left/right, inner_add_left, inner_sub_left)",
+      "Vieta's relations for a monic quadratic",
+      "EuclideanSpace ℝ (Fin 2) = PiLp 2 coordinates and PiLp.ext for the planar statements",
+      "Cramer's rule / 2×2 linear elimination for the radical centre"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Main Results",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports and docstring stating the open question (why is the chord product direction-independent?) and answering it via Vieta, then extending the same algebra to the radical axis and radical centre. Lists the main theorems of both parts."
+    },
+    {
+      "id": "power-def",
+      "title": "The Power of a Point",
+      "startLine": 61,
+      "endLine": 73,
+      "summary": "Namespace, the general real-inner-product-space section, and the definition power O r P = ‖P − O‖² − r² (negative inside the sphere, zero on it, positive outside)."
+    },
+    {
+      "id": "vieta",
+      "title": "Part 1: Vieta and Direction-Independence",
+      "startLine": 74,
+      "endLine": 156,
+      "summary": "power_along_line restricts the power to a line, giving ‖d‖²·t² + 2⟨P−O,d⟩·t + power O r P; power_along_unit_line makes it monic. chord_product_eq_power is the Vieta product (t₁·t₂ = power) and chord_sum_eq the companion sum. chord_product_direction_independent gives the headline t₁·t₂ = s₁·s₂ for two directions, and chord_product_sign records the inside/outside sign dichotomy."
+    },
+    {
+      "id": "radical-axis",
+      "title": "Part 2: The Radical Axis as a Linear Locus",
+      "startLine": 158,
+      "endLine": 207,
+      "summary": "power_expand writes the power as a quadratic form with shared leading term ‖P‖². radical_axis_linear shows equal power is a single affine-linear equation; radical_axis_perp shows the axis is orthogonal to the line of centres; radical_axis_affine shows it is an affine subspace."
+    },
+    {
+      "id": "radical-center",
+      "title": "Part 3: The Radical Centre in the Plane",
+      "startLine": 209,
+      "endLine": 321,
+      "summary": "Vec2 = EuclideanSpace ℝ (Fin 2) with coordinate expansions normSq_coord, power_coord and the coordinate radical-axis equation equal_power_linear. radical_center_unique (Cramer elimination against the non-zero centre determinant), radical_center_exists (explicit Cramer witness), and radical_center_existsUnique (the full ∃!)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file proves 16 theorems/lemmas and 2 definitions with 0 sorries and 0 axioms. It pins down the exact reason the intersecting-chords product is the same for every chord through a point — the constant coefficient of the chord quadratic is the direction-free power of the point — and pushes the same quadratic-form algebra to the radical axis (a hyperplane perpendicular to the line of centres) and to the unique radical centre of three planar circles.",
+    "implications": "Direction-independence, the radical axis, and the radical centre are all consequences of one algebraic fact: the power function is a quadratic form whose pure-quadratic part is circle-independent. Part 1 holds in any real inner product space, including infinite-dimensional Hilbert spaces; only the radical-centre statements specialise to the plane, where a 2×2 Cramer solution is available. The Vieta argument needs no root-existence machinery, making it a clean template for 'product of intersection parameters' results.",
+    "openQuestions": [
+      "Radical centre in higher dimensions: for n+1 spheres in ℝⁿ with affinely independent centres, the n radical hyperplanes meet in a unique point — formalise this via the (n×n) centre-difference matrix being invertible, generalising the planar Cramer construction here.",
+      "Link the radical axis to the 4×4 concyclicity determinant of ProductOfSegmentsOfChordsOQ03: is the radical-axis equation exactly the vanishing of a 3×3 minor of that determinant, and does that viewpoint give the radical centre as a determinant ratio?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "product-of-segments-of-chords",
+      "relationship": "answers-open-question",
+      "description": "Parent file proving the 2D intersecting-chords theorem (Wiedijk #55); this entry answers its open question on the Vieta/direction-independence mechanism and the radical-axis/quadratic-form connection."
+    },
+    {
+      "targetId": "product-of-segments-of-chords-oq-01",
+      "relationship": "complements",
+      "description": "OQ-01 generalises the chord product to spheres in any inner product space; this entry isolates the Vieta reason for direction-independence and adds the radical axis/centre."
+    },
+    {
+      "targetId": "product-of-segments-of-chords-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 develops the 4×4 concyclicity determinant; the radical axis here is the linear locus where two such power quadratic forms agree."
+    }
+  ],
+  "leanFile": {
+    "namespace": "ProductOfSegmentsOfChordsOQ04",
+    "lineCount": 321,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "path": "Proofs/ProductOfSegmentsOfChordsOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent *Product of Segments of Chords* open question **"Power of a Point via Vieta: Direction-Independence of the Line–Circle Intersection Product"** (`product-of-segments-of-chords-oq-04`), and folds in the parent's radical-axis / quadratic-form question.

The classical intersecting-chords theorem says `PA·PB = PC·PD` for two chords through `P`. This file pins down **why** the product is the same for *every* chord through `P`, by reducing it to **Vieta's formula**, and pushes the same algebra to the **radical axis** and **radical centre**.

## Part 1 — Vieta and direction-independence (any real inner product space)

Define the power of a point `power O r P = ‖P − O‖² − r²`. Restricting it to a line `t ↦ P + t·d` gives

```
power O r (P + t·d) = ‖d‖²·t² + 2⟨P − O, d⟩·t + power O r P
```

— monic for a unit direction. The **constant coefficient is the power of the point**, with no dependence on `d`.

- `power_along_line`, `power_along_unit_line` — the restriction is a (monic) quadratic.
- `chord_product_eq_power` — Vieta: two distinct on-sphere parameters multiply to `power O r P`. Proved by the identity `t₂·q(t₁) − t₁·q(t₂) = (t₁−t₂)(t₁·t₂ − power)` (no root-existence API).
- `chord_product_direction_independent` — **headline**: two secants through `P` in different directions give the same signed product `t₁·t₂ = s₁·s₂`.
- `chord_sum_eq`, `chord_product_sign` — companion sum formula and the inside/outside sign dichotomy.

## Part 2 — Radical axis and radical centre

Because the leading term `‖P‖²` is shared by every power function, the difference of two power functions is **affine-linear**.

- `power_expand`, `radical_axis_linear` — equal power ⇔ one affine-linear equation (the radical axis).
- `radical_axis_perp` — the axis is orthogonal to the line of centres.
- `radical_axis_affine` — the axis is an affine subspace.
- `radical_center_unique` / `radical_center_exists` / `radical_center_existsUnique` — three planar circles with non-collinear centres have a **unique** radical centre (explicit Cramer construction).

## Verification

- 16 theorems/lemmas, 2 definitions, **0 sorries, 0 axioms**.
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- Typechecked against Mathlib (Lean `v4.26.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)