### PR TITLE
Enrich Wallis Product O(1/n) Rate (stirling-formula-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/stirling-formula-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-sfoq0301-header",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Goal: a quantitative Wallis product",
+    "content": "The parent entry (stirling-formula-oq-03) records only the qualitative Wallis limit ∏_{k=1}^{n} 4k²/(4k²−1) → π/2, mirroring Mathlib's Real.tendsto_prod_pi_div_two, which says nothing about speed. This file extracts an explicit, elementary O(1/n) error bound. The whole argument rides on the two-sided estimates Mathlib already proves for the partial product W k: the lower bound (2k+1)/(2k+2)·(π/2) ≤ W k and the upper bound W k ≤ π/2. Subtracting the lower bound from π/2 telescopes to π/(4(k+1)); the upper bound makes the gap nonnegative. The bound is then transported to the classical textbook product and shown sufficient to re-derive the limit by squeezing.",
+    "mathContext": "$0 \\le \\tfrac{\\pi}{2} - W_k \\le \\tfrac{\\pi}{4(k+1)} < \\tfrac{1}{k+1}$; the width of Mathlib's own squeeze bracket IS the error bound.",
+    "significance": "key",
+    "relatedConcepts": ["Wallis product", "rate of convergence", "infinite products", "π", "squeeze theorem"],
+    "prerequisites": ["infinite products", "limits of sequences", "elementary inequalities"]
+  },
+  {
+    "id": "ann-sfoq0301-gap-nonneg",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 53, "endLine": 57 },
+    "type": "theorem",
+    "title": "The gap is nonnegative (approach from below)",
+    "content": "wallis_gap_nonneg: 0 ≤ π/2 − W k, immediate from Mathlib's upper bound Real.Wallis.W_le (W k ≤ π/2) closed by linarith. This says the partial products never overshoot the limit — the classical product 2·2·4·4···/(1·3·3·5···) climbs to π/2 monotonically from below, so the error is a genuine nonnegative decreasing quantity rather than an oscillation.",
+    "mathContext": "$W_k \\le \\tfrac{\\pi}{2} \\;\\Rightarrow\\; \\tfrac{\\pi}{2} - W_k \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.Wallis.W_le", "monotone convergence", "one-sided approach"],
+    "prerequisites": ["real inequalities", "the Wallis partial product W"]
+  },
+  {
+    "id": "ann-sfoq0301-rate",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 59, "endLine": 90 },
+    "type": "theorem",
+    "title": "The explicit O(1/n) rate and its clean form",
+    "content": "wallis_gap_le is the heart: π/2 − W k ≤ π/(4(k+1)). Subtracting Mathlib's lower bound Real.Wallis.le_W from π/2, the difference telescopes — π/2 − (2k+1)/(2k+2)·(π/2) = (π/2)·(1/(2k+2)) = π/(4(k+1)) — a closed form verified by field_simp + ring, with the inequality then closed by linarith. wallis_gap_le_one_div sharpens this to the constant-free π/2 − W k ≤ 1/(k+1) using π ≤ 4 (Real.pi_le_four), since π/4 < 1, via div_le_div_iff₀ + nlinarith.",
+    "mathContext": "$\\tfrac{\\pi}{2} - \\tfrac{2k+1}{2k+2}\\cdot\\tfrac{\\pi}{2} = \\tfrac{\\pi}{2}\\cdot\\tfrac{1}{2k+2} = \\tfrac{\\pi}{4(k+1)} \\le \\tfrac{1}{k+1}$ (as $\\pi \\le 4$).",
+    "significance": "key",
+    "relatedConcepts": ["Real.Wallis.le_W", "telescoping", "Real.pi_le_four", "field_simp", "nlinarith"],
+    "prerequisites": ["the two-sided Wallis bounds", "field algebra", "π ≤ 4"]
+  },
+  {
+    "id": "ann-sfoq0301-abs",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 96 },
+    "type": "technique",
+    "title": "Absolute-value form of the rate",
+    "content": "abs_W_sub_pi_div_two_le packages the one-sided facts into the symmetric statement |W k − π/2| ≤ π/(4(k+1)). Because the gap is nonnegative (wallis_gap_nonneg), abs_of_nonneg collapses the absolute value to π/2 − W k (after abs_sub_comm), which the explicit rate already bounds. This is the form a generic 'rate of convergence' consumer expects, and the form squeeze_zero will later use.",
+    "mathContext": "$W_k \\le \\tfrac{\\pi}{2} \\;\\Rightarrow\\; |W_k - \\tfrac{\\pi}{2}| = \\tfrac{\\pi}{2} - W_k \\le \\tfrac{\\pi}{4(k+1)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["abs_of_nonneg", "abs_sub_comm", "convergence rate normal form"],
+    "prerequisites": ["the explicit rate", "the gap nonnegativity"]
+  },
+  {
+    "id": "ann-sfoq0301-transport",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 100, "endLine": 115 },
+    "type": "theorem",
+    "title": "Transport to the classical textbook product",
+    "content": "wallisProduct_eq_W identifies the parent's classical product ∏_{k=1}^{n} 4k²/(4k²−1) with Mathlib's W n termwise: the parent's wallisProduct_eq rewrites it to ∏ i<n, (2i+2)/(2i+1)·(2i+2)/(2i+3), which is W n by rfl (definitional). abs_wallisProduct_sub_pi_div_two_le then transports the rate verbatim: |∏_{k=1}^{n} 4k²/(4k²−1) − π/2| ≤ π/(4(n+1)), stating the bound in the textbook form the parent uses.",
+    "mathContext": "$\\prod_{k=1}^{n}\\tfrac{4k^2}{4k^2-1} = W_n \\;\\Rightarrow\\; \\big|\\prod_{k=1}^{n}\\tfrac{4k^2}{4k^2-1} - \\tfrac{\\pi}{2}\\big| \\le \\tfrac{\\pi}{4(n+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["definitional equality (rfl)", "reindexing", "textbook Wallis product", "StirlingFormulaOQ03.wallisProduct_eq"],
+    "prerequisites": ["the parent's product definition", "the rate for W"]
+  },
+  {
+    "id": "ann-sfoq0301-limit",
+    "proofId": "stirling-formula-oq-03-oq-01",
+    "range": { "startLine": 117, "endLine": 138 },
+    "type": "insight",
+    "title": "The limit re-derived from the rate by squeezing",
+    "content": "rate_tendsto_zero shows π/(4(n+1)) → 0 (a constant over 4(n+1) → +∞, via Tendsto.div_atTop). wallisProduct_tendsto then recovers Wallis' limit independently of Mathlib's derivation: rewriting convergence as dist → 0 (tendsto_iff_dist_tendsto_zero), squeeze_zero pins the error 0 ≤ |∏ − π/2| ≤ π/(4(n+1)) → 0. This is the conceptual payoff — the explicit O(1/n) estimate is not a mere a-posteriori byproduct of the limit; it is strong enough to *drive* the convergence on its own.",
+    "mathContext": "$0 \\le \\big|\\prod_{k=1}^{n}\\tfrac{4k^2}{4k^2-1} - \\tfrac{\\pi}{2}\\big| \\le \\tfrac{\\pi}{4(n+1)} \\to 0 \\;\\Rightarrow\\; \\prod \\to \\tfrac{\\pi}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze_zero", "Tendsto.div_atTop", "tendsto_iff_dist_tendsto_zero", "rate drives convergence"],
+    "prerequisites": ["the absolute-value rate", "the squeeze theorem", "filters and limits"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `stirling-formula-oq-03-oq-01` (an explicit O(1/n) convergence rate for the Wallis product).

The entry already had a rich overview, 5 sections, and conclusion, but **no `annotations.json`**. Added it.

- **`annotations.json`** (6 annotations, each with `mathContext` LaTeX / `significance` / `relatedConcepts` / `prerequisites`) covering: the quantitative goal (extracting the rate from Mathlib's own two-sided squeeze bracket), gap nonnegativity (`wallis_gap_nonneg`, approach from below), the telescoping O(1/n) rate `wallis_gap_le` + the constant-free `1/(k+1)` form, the absolute-value form `abs_W_sub_pi_div_two_le`, transport to the classical textbook product `∏ 4k²/(4k²−1)`, and the limit re-derived from the rate by `squeeze_zero`.
- Annotation ranges verified to snap cleanly to Lean constructs (`pnpm annotations:build` reports no warnings for this entry).

Axiom integrity: confirmed `status: verified` / `axiomCount: 0` is accurate — 0 sorries, 0 axiom declarations, no native_decide; headline theorems depend only on propext/Classical.choice/Quot.sound. No change needed.

Verified with `pnpm build` (✓ built).