### PR TITLE
research(cayley-hamilton-oq-04): explicit 2×2 Cayley–Hamilton + adjugate inverse [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -668,6 +668,7 @@ import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ01OQ04
 import Proofs.CayleyHamiltonOQ02
 import Proofs.CayleyHamiltonOQ02OQ02
+import Proofs.CayleyHamiltonOQ04
 import Proofs.CayleyHamiltonReductionOQ01
 import Proofs.CayleyHamiltonReductionOQ01OQ02
 import Proofs.CayleyHamiltonReductionOQ02

--- a/proofs/Proofs/CayleyHamiltonOQ04.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ04.lean
@@ -1,0 +1,127 @@
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Tactic
+
+/-
+# Explicit 2×2 Cayley–Hamilton and the Adjugate Inverse Formula
+
+## What This Proves
+For an arbitrary 2×2 matrix `A = !![a, b; c, d]` over a commutative ring `R`, everything
+about its characteristic polynomial, adjugate, and inverse can be written down in closed
+form. This file proves, *by direct entrywise computation* (not the general Cayley–Hamilton
+or Laplace-expansion machinery):
+
+1. **Explicit Cayley–Hamilton**: `A² − (tr A) • A + (det A) • 1 = 0`, i.e. every 2×2
+   matrix annihilates its own characteristic polynomial `X² − (tr A)X + det A`.
+2. **Explicit adjugate product**: `A * !![d, -b; -c, a] = (det A) • 1` and symmetrically
+   `!![d, -b; -c, a] * A = (det A) • 1`, where `!![d, -b; -c, a]` is the classical 2×2
+   adjugate (cofactor) matrix.
+3. **Inverse formula over a field**: if `det A ≠ 0` then
+   `A⁻¹ = (det A)⁻¹ • !![d, -b; -c, a]`, and this is a genuine two-sided inverse.
+
+## Why This Is Not Just a Re-export
+Mathlib's `Matrix.aeval_self_charpoly` states Cayley–Hamilton in terms of `charpoly`, a
+polynomial built from the determinant of `X • 1 − A`; it does *not* hand you the bare
+identity `A² − (tr A) • A + (det A) • 1 = 0` in trace/determinant form. Results (1) and (2)
+here are proved from scratch by expanding `Matrix.mul_apply` over `Fin 2` and closing with
+`ring`, so the file is self-contained down to `ring`. Result (3) then bridges these explicit
+identities to Mathlib's `Matrix.inv_def`, giving the familiar `1/(ad−bc) · [[d,-b],[-c,a]]`.
+
+## Mathematical Significance
+The 2×2 case is the workhorse of planar linear algebra: rotations, shears, the Jacobian of a
+two-variable change of coordinates, and Möbius transformations all reduce to these formulas.
+The closed form `A⁻¹ = 1/(ad−bc) · [[d,-b],[-c,a]]` is the first nontrivial instance of
+Cramer's rule and of the adjugate inverse `A⁻¹ = (det A)⁻¹ adj A`.
+
+## Extends
+- CayleyHamilton.lean (Wiedijk #49)
+- Open question OQ-04 of the Cayley–Hamilton entry.
+
+## Status
+- [x] Complete proof (no sorries, no axioms)
+-/
+
+namespace CayleyHamiltonOQ04
+
+open Matrix
+
+variable {R : Type*} [CommRing R]
+
+/-- The classical 2×2 adjugate (cofactor) matrix of `A = !![a,b;c,d]`, namely
+`!![d, -b; -c, a]`. We give it a name so the explicit results below read like the
+textbook formulas. This agrees with Mathlib's `Matrix.adjugate` (see
+`cofactor_eq_adjugate`). -/
+def cofactor (A : Matrix (Fin 2) (Fin 2) R) : Matrix (Fin 2) (Fin 2) R :=
+  !![A 1 1, -A 0 1; -A 1 0, A 0 0]
+
+/-- The hand-written `cofactor` matrix is exactly Mathlib's `adjugate` in the 2×2 case. -/
+theorem cofactor_eq_adjugate (A : Matrix (Fin 2) (Fin 2) R) :
+    cofactor A = adjugate A := by
+  rw [cofactor, adjugate_fin_two]
+
+/-- **Explicit 2×2 Cayley–Hamilton.** Every 2×2 matrix satisfies its own characteristic
+polynomial `X² − (tr A)X + det A`, proved by direct entrywise expansion. -/
+theorem sq_sub_trace_smul_add_det_smul (A : Matrix (Fin 2) (Fin 2) R) :
+    A ^ 2 - A.trace • A + A.det • 1 = 0 := by
+  rw [pow_two]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.trace_fin_two, Matrix.det_fin_two,
+      Matrix.add_apply, Matrix.sub_apply, Matrix.smul_apply, Matrix.zero_apply] <;> ring
+
+/-- A convenient restatement: `A² = (tr A) • A − (det A) • 1`, expressing the square of any
+2×2 matrix as a linear combination of `A` and the identity. -/
+theorem sq_eq (A : Matrix (Fin 2) (Fin 2) R) :
+    A ^ 2 = A.trace • A - A.det • 1 := by
+  have h := sq_sub_trace_smul_add_det_smul A
+  linear_combination (norm := module) h
+
+/-- **Explicit adjugate product (right).** `A · !![d,-b;-c,a] = (det A) • 1`, proved by
+direct entrywise computation. -/
+theorem mul_cofactor (A : Matrix (Fin 2) (Fin 2) R) :
+    A * cofactor A = A.det • 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [cofactor, Matrix.mul_apply, Fin.sum_univ_two, Matrix.det_fin_two,
+      Matrix.smul_apply] <;> ring
+
+/-- **Explicit adjugate product (left).** `!![d,-b;-c,a] · A = (det A) • 1`. -/
+theorem cofactor_mul (A : Matrix (Fin 2) (Fin 2) R) :
+    cofactor A * A = A.det • 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [cofactor, Matrix.mul_apply, Fin.sum_univ_two, Matrix.det_fin_two,
+      Matrix.smul_apply] <;> ring
+
+section Field
+
+variable {K : Type*} [Field K]
+
+/-- **Inverse formula over a field.** The inverse is the scaled cofactor matrix
+`A⁻¹ = (det A)⁻¹ • !![d,-b;-c,a]`. (This identity holds for every `A`: when `det A = 0`,
+both sides degenerate via Mathlib's `Ring.inverse`; the genuine two-sided inverse property
+requires `det A ≠ 0`, see `mul_det_inv_smul_cofactor` below.) -/
+theorem inv_eq_det_inv_smul_cofactor (A : Matrix (Fin 2) (Fin 2) K) :
+    A⁻¹ = (A.det)⁻¹ • cofactor A := by
+  rw [Matrix.inv_def, Ring.inverse_eq_inv', cofactor_eq_adjugate]
+
+/-- The scaled cofactor matrix is a genuine *right* inverse: `A · ((det A)⁻¹ • adj A) = 1`. -/
+theorem mul_det_inv_smul_cofactor (A : Matrix (Fin 2) (Fin 2) K) (h : A.det ≠ 0) :
+    A * ((A.det)⁻¹ • cofactor A) = 1 := by
+  rw [Matrix.mul_smul, mul_cofactor, smul_smul, inv_mul_cancel₀ h, one_smul]
+
+/-- The scaled cofactor matrix is a genuine *left* inverse: `((det A)⁻¹ • adj A) · A = 1`. -/
+theorem det_inv_smul_cofactor_mul (A : Matrix (Fin 2) (Fin 2) K) (h : A.det ≠ 0) :
+    ((A.det)⁻¹ • cofactor A) * A = 1 := by
+  rw [Matrix.smul_mul, cofactor_mul, smul_smul, inv_mul_cancel₀ h, one_smul]
+
+/-- The fully explicit closed form of the inverse:
+`A⁻¹ = (1/(ad − bc)) • !![d, -b; -c, a]`. -/
+theorem inv_fin_two_explicit (A : Matrix (Fin 2) (Fin 2) K) :
+    A⁻¹ = (A.det)⁻¹ • !![A 1 1, -A 0 1; -A 1 0, A 0 0] := by
+  rw [inv_eq_det_inv_smul_cofactor A, cofactor]
+
+end Field
+
+end CayleyHamiltonOQ04

--- a/src/data/proofs/cayley-hamilton-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-04/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-ch04-background",
+    "proofId": "cayley-hamilton-oq-04",
+    "range": {
+      "startLine": 6,
+      "endLine": 43
+    },
+    "type": "concept",
+    "title": "Closed-Form 2×2 Linear Algebra: Cayley's Original Explicit Computation",
+    "content": "The module docstring frames the file as the fully explicit, smallest nontrivial case of the Cayley–Hamilton theorem. Crucially, it documents WHY this is not a re-export: Mathlib's `Matrix.aeval_self_charpoly` phrases Cayley–Hamilton via the abstract `charpoly` polynomial, not the bare trace/determinant identity A² − (tr A)·A + (det A)·1 = 0. That identity, together with the two-sided adjugate products, is proved here from scratch by entrywise expansion over Fin 2 closed with `ring`. This mirrors Cayley's own 1858 approach, in which he verified the theorem explicitly for 2×2 and 3×3 matrices by direct computation.",
+    "mathContext": "For $A = \\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}$: $\\operatorname{tr} A = a + d$, $\\det A = ad - bc$, and the characteristic polynomial is $\\chi_A(X) = X^2 - (\\operatorname{tr} A)X + \\det A$. Cayley–Hamilton asserts $\\chi_A(A) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cayley-Hamilton theorem",
+      "characteristic polynomial",
+      "trace and determinant",
+      "adjugate matrix"
+    ],
+    "prerequisites": [
+      "2×2 matrix arithmetic",
+      "trace and determinant of a matrix"
+    ]
+  },
+  {
+    "id": "ann-ch04-cayley-hamilton",
+    "proofId": "cayley-hamilton-oq-04",
+    "range": {
+      "startLine": 63,
+      "endLine": 78
+    },
+    "type": "insight",
+    "title": "Explicit Cayley–Hamilton in Trace/Determinant Form",
+    "content": "`sq_sub_trace_smul_add_det_smul` proves A² − (tr A)·A + (det A)·1 = 0 by reducing to the four scalar entries: `ext i j` then `fin_cases i <;> fin_cases j` unfolds matrix multiplication via `Matrix.mul_apply`/`Fin.sum_univ_two`, expands `trace_fin_two` and `det_fin_two`, and closes each entry with `ring`. The companion `sq_eq` rearranges this to A² = (tr A)·A − (det A)·1, exhibiting the square of any 2×2 matrix as an explicit linear combination of A and the identity — the degree-reduction phenomenon at the heart of Cayley–Hamilton, made completely concrete.",
+    "mathContext": "$A^2 = \\begin{pmatrix} a^2+bc & b(a+d) \\\\ c(a+d) & d^2+bc \\end{pmatrix}$, so $A^2 - (a+d)A + (ad-bc)I = 0$ entrywise. Equivalently $A^2 = (\\operatorname{tr} A)\\,A - (\\det A)\\,I$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cayley-Hamilton theorem",
+      "characteristic polynomial",
+      "degree reduction",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "matrix multiplication",
+      "trace and determinant formulas for 2×2"
+    ]
+  },
+  {
+    "id": "ann-ch04-adjugate",
+    "proofId": "cayley-hamilton-oq-04",
+    "range": {
+      "startLine": 80,
+      "endLine": 95
+    },
+    "type": "insight",
+    "title": "The Two-Sided Adjugate Products A·adj A = adj A·A = (det A)·1",
+    "content": "`mul_cofactor` and `cofactor_mul` prove that the explicit cofactor matrix `cofactor A = !![A 1 1, -A 0 1; -A 1 0, A 0 0]` satisfies A·(cofactor A) = (det A)·1 and (cofactor A)·A = (det A)·1, again by entrywise `fin_cases`/`ring`. The earlier `cofactor_eq_adjugate` lemma identifies this hand-written matrix with Mathlib's general `adjugate` (via `adjugate_fin_two`), so these are genuine adjugate identities. They hold over ANY commutative ring R — invertibility of the determinant is never used — which is exactly why the same products underlie Cramer's rule over the integers and polynomial rings.",
+    "mathContext": "With $\\operatorname{adj} A = \\begin{pmatrix} d & -b \\\\ -c & a \\end{pmatrix}$, both products equal $\\begin{pmatrix} ad-bc & 0 \\\\ 0 & ad-bc \\end{pmatrix} = (\\det A)\\,I$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "adjugate matrix",
+      "Cramer's rule",
+      "determinant",
+      "commutative rings"
+    ],
+    "prerequisites": [
+      "adjugate (cofactor) matrix",
+      "matrix multiplication"
+    ]
+  },
+  {
+    "id": "ann-ch04-inverse",
+    "proofId": "cayley-hamilton-oq-04",
+    "range": {
+      "startLine": 101,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "The Closed-Form Inverse and Cramer's Rule for 2×2 Matrices",
+    "content": "Over a field, `inv_eq_det_inv_smul_cofactor` shows A⁻¹ = (det A)⁻¹·(cofactor A) by bridging to Mathlib's `Matrix.inv_def` (A⁻¹ = Ring.inverse(det A)·adjugate A) and rewriting `Ring.inverse_eq_inv'`. This identity is stated UNCONDITIONALLY — when det A = 0 both sides degenerate through `Ring.inverse` — and the genuine two-sided inverse property is isolated in `mul_det_inv_smul_cofactor` and `det_inv_smul_cofactor_mul`, which require det A ≠ 0 and use `inv_mul_cancel₀`. `inv_fin_two_explicit` unfolds the definition to the textbook closed form A⁻¹ = (det A)⁻¹·!![d,-b;-c,a], the 2×2 case of Cramer's rule.",
+    "mathContext": "When $\\det A \\neq 0$: $A^{-1} = \\frac{1}{ad-bc}\\begin{pmatrix} d & -b \\\\ -c & a \\end{pmatrix}$, and $A \\cdot A^{-1} = A^{-1} \\cdot A = I$ follows from $A \\cdot \\operatorname{adj} A = (\\det A) I$ and $\\frac{1}{\\det A}\\cdot \\det A = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "matrix inverse",
+      "Cramer's rule",
+      "adjugate inverse formula",
+      "field arithmetic"
+    ],
+    "prerequisites": [
+      "field inverses and cancellation",
+      "Mathlib Matrix.inv_def"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "cayley-hamilton-oq-04",
+  "title": "Explicit 2×2 Cayley–Hamilton and the Adjugate Inverse Formula",
+  "slug": "cayley-hamilton-oq-04",
+  "description": "Closed-form linear algebra of the 2×2 matrix, proved by direct entrywise computation rather than the general Cayley–Hamilton machinery. Establishes the explicit characteristic-polynomial identity A² − (tr A)·A + (det A)·1 = 0, the explicit adjugate products A·[[d,-b],[-c,a]] = [[d,-b],[-c,a]]·A = (det A)·1, and over a field the closed-form inverse A⁻¹ = (det A)⁻¹·[[d,-b],[-c,a]] with both-sided inverse verification. 9 theorems, 1 definition, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ04.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "matrices",
+      "adjugate",
+      "matrix-inverse",
+      "cramers-rule"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). The Cayley–Hamilton identity and both adjugate products are proved from scratch by entrywise Fin 2 expansion closed with `ring`; the inverse formula bridges to Mathlib's `Matrix.inv_def`.",
+    "lineCount": 127,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "sq_sub_trace_smul_add_det_smul: explicit 2×2 Cayley–Hamilton A² − (tr A)·A + (det A)·1 = 0 in trace/determinant form, proved entrywise (Mathlib only provides the charpoly form)",
+      "mul_cofactor / cofactor_mul: explicit two-sided adjugate products A·adj A = adj A·A = (det A)·1 proved from scratch over any commutative ring",
+      "inv_fin_two_explicit: fully explicit inverse A⁻¹ = (det A)⁻¹·[[d,-b],[-c,a]] (Cramer's rule for 2×2)",
+      "mul_det_inv_smul_cofactor / det_inv_smul_cofactor_mul: genuine two-sided inverse verification under det A ≠ 0"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The 2×2 inverse formula A⁻¹ = 1/(ad−bc)·[[d,-b],[-c,a]] is the oldest instance of the adjugate (classical adjoint) inverse and of Cramer's rule (Gabriel Cramer, 1750). Cayley's original 1858 'Memoir on the Theory of Matrices' verified the Cayley–Hamilton theorem explicitly precisely in the 2×2 (and 3×3) cases by direct computation, exactly as this file does — Cayley remarked that he had 'not thought it necessary to undertake the labour of a formal proof' in the general case. The trace/determinant form X² − (tr A)X + det A is the characteristic polynomial of a 2×2 matrix, and its vanishing on A is the smallest nontrivial case of the theorem that every square matrix annihilates its own characteristic polynomial.",
+    "problemStatement": "For any 2×2 matrix A = [[a,b],[c,d]] over a commutative ring, prove A² − (tr A)·A + (det A)·1 = 0 and A·adj A = adj A·A = (det A)·1 where adj A = [[d,-b],[-c,a]]; conclude that over a field with det A ≠ 0, A⁻¹ = (det A)⁻¹·adj A.",
+    "text": "Writing A = [[a,b],[c,d]], we have tr A = a+d and det A = ad−bc. A direct computation gives A² = [[a²+bc, ab+bd],[ca+dc, cb+d²]], and subtracting (a+d)·A and adding (ad−bc)·1 yields the zero matrix in every entry. The same entrywise expansion shows A·[[d,-b],[-c,a]] = [[ad−bc,0],[0,ad−bc]] = (det A)·1, and symmetrically on the left. Over a field, scaling by (det A)⁻¹ turns the adjugate into a genuine two-sided inverse whenever det A ≠ 0.",
+    "proofStrategy": "Every algebraic identity is reduced to its four scalar-entry identities via `Matrix.ext`, `Fin.forall_fin_two` (`fin_cases`), `Matrix.mul_apply`/`Fin.sum_univ_two`, `Matrix.det_fin_two`, `Matrix.trace_fin_two`, and closed with `ring`. The named `cofactor` definition is shown equal to Mathlib's `adjugate` (`adjugate_fin_two`), so the explicit products transfer; the inverse formula is then derived from `Matrix.inv_def` together with `Ring.inverse_eq_inv'` and the cancellation `inv_mul_cancel₀`.",
+    "keyInsights": [
+      "The trace/determinant Cayley–Hamilton identity A² − (tr A)·A + (det A)·1 = 0 is NOT what Mathlib's `Matrix.aeval_self_charpoly` provides — that theorem is phrased via the abstract `charpoly` polynomial — so the bare 2×2 identity must be proved from scratch.",
+      "Once reduced to entries by `fin_cases` over `Fin 2`, every matrix identity here is a polynomial identity in a, b, c, d that `ring` closes, making the file self-contained down to the ring axioms.",
+      "The adjugate inverse and Cramer's rule coincide in the 2×2 case: A⁻¹ = (1/det A)·[[d,-b],[-c,a]] is literally the cofactor matrix divided by the determinant.",
+      "Separating the unconditional algebraic identity A⁻¹ = (det A)⁻¹·adj A (true for all A via Mathlib's `Ring.inverse`) from the genuine inverse property (which needs det A ≠ 0) clarifies exactly where invertibility is used."
+    ],
+    "prerequisites": [
+      "2×2 matrix arithmetic: trace, determinant, matrix multiplication",
+      "The adjugate (cofactor) matrix and the adjugate inverse formula",
+      "Field arithmetic: multiplicative inverses and cancellation"
+    ]
+  },
+  "conclusion": {
+    "summary": "9 theorems, 1 definition, 127 lines, 0 axioms. A complete, self-contained treatment of the closed-form linear algebra of the 2×2 matrix: the explicit Cayley–Hamilton identity in trace/determinant form, the two-sided adjugate products over any commutative ring, and the closed-form inverse over a field with a genuine two-sided inverse check. Every algebraic identity is proved by entrywise expansion closed with `ring`.",
+    "implications": "These are the formulas behind every concrete planar linear-algebra computation: 2×2 matrix inversion, Cramer's rule for 2×2 systems, the Jacobian inverse for two-variable changes of coordinates, and the SL₂/GL₂ actions underlying Möbius transformations. As the smallest nontrivial case, the file also serves as a fully explicit, axiom-free witness of the Cayley–Hamilton theorem complementing the gallery's general charpoly/minpoly developments.",
+    "openQuestions": [
+      "Prove the analogous explicit 3×3 Cayley–Hamilton identity A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 where c₂ is the sum of the 2×2 principal minors, by the same entrywise method.",
+      "Derive the explicit 2×2 matrix exponential exp(tA) in closed form from sq_eq (A² = (tr A)·A − (det A)·1) by solving the resulting scalar recurrence for the coefficients of I and A."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonOQ04",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonOQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "extends",
+      "description": "The smallest nontrivial case of the Cayley–Hamilton theorem, proved explicitly in trace/determinant form."
+    },
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "related",
+      "description": "OQ-02 develops the general charpoly polynomial reduction; OQ-04 gives the fully explicit 2×2 closed forms and the adjugate inverse."
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Header stating the three results (explicit Cayley–Hamilton, explicit adjugate products, inverse formula), the entrywise from-scratch proof strategy, why it is not a re-export of Mathlib's charpoly Cayley–Hamilton, and the planar linear-algebra significance."
+    },
+    {
+      "id": "cofactor",
+      "title": "The 2×2 Cofactor Matrix",
+      "startLine": 49,
+      "endLine": 61,
+      "summary": "Defines `cofactor A = !![A 1 1, -A 0 1; -A 1 0, A 0 0]` and proves `cofactor_eq_adjugate` identifying it with Mathlib's `adjugate` via `adjugate_fin_two`."
+    },
+    {
+      "id": "cayley-hamilton",
+      "title": "Explicit Cayley–Hamilton",
+      "startLine": 63,
+      "endLine": 78,
+      "summary": "`sq_sub_trace_smul_add_det_smul`: A² − (tr A)·A + (det A)·1 = 0 by entrywise `fin_cases`/`ring`. `sq_eq`: the rearrangement A² = (tr A)·A − (det A)·1."
+    },
+    {
+      "id": "adjugate-products",
+      "title": "Explicit Adjugate Products",
+      "startLine": 80,
+      "endLine": 95,
+      "summary": "`mul_cofactor` and `cofactor_mul`: A·adj A = adj A·A = (det A)·1 over any commutative ring, each proved entrywise."
+    },
+    {
+      "id": "inverse",
+      "title": "The Inverse Formula over a Field",
+      "startLine": 97,
+      "endLine": 125,
+      "summary": "`inv_eq_det_inv_smul_cofactor` (unconditional identity via `Matrix.inv_def`), `mul_det_inv_smul_cofactor`/`det_inv_smul_cofactor_mul` (genuine two-sided inverse under det A ≠ 0), and `inv_fin_two_explicit` (closed-form A⁻¹ = (det A)⁻¹·[[d,-b],[-c,a]])."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves open question **OQ-04** of the Cayley–Hamilton gallery entry: the fully explicit, closed-form linear algebra of the 2×2 matrix, proved **from scratch by entrywise computation** (`Matrix.ext` + `fin_cases` over `Fin 2` + `ring`) rather than Mathlib's abstract `charpoly` machinery.

### Results (`Proofs/CayleyHamiltonOQ04.lean`, 9 thm / 1 def / 127 lines / 0 axioms)

1. **Explicit Cayley–Hamilton** — `sq_sub_trace_smul_add_det_smul`: `A² − (tr A)·A + (det A)·1 = 0`, in trace/determinant form (Mathlib's `aeval_self_charpoly` only gives the abstract `charpoly` form). Plus `sq_eq`: `A² = (tr A)·A − (det A)·1`.
2. **Explicit adjugate products** — `mul_cofactor` / `cofactor_mul`: `A·adj A = adj A·A = (det A)·1` over **any** commutative ring; `cofactor_eq_adjugate` ties the hand-written `!![d,-b;-c,a]` to Mathlib's `adjugate`.
3. **Inverse over a field** — `inv_fin_two_explicit`: `A⁻¹ = (det A)⁻¹·!![d,-b;-c,a]` (2×2 Cramer's rule), with the genuine two-sided inverse property isolated in `mul_det_inv_smul_cofactor` / `det_inv_smul_cofactor_mul` (require `det A ≠ 0`).

### Verification
- Compiles clean against Mathlib `v4.26.0` (`lake env lean`), **zero warnings**.
- `#print axioms` on all headline results: only `propext`, `Classical.choice`, `Quot.sound` — **0 extra axioms, 0 sorries**.

### Gallery
- `src/data/proofs/cayley-hamilton-oq-04/{meta.json,annotations.json}` added; `pnpm annotations:build` clean for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)