### PR TITLE
Enrich Alternating Harmonic Series = log 2 (harmonic-divergence-oq-03)

### DIFF
--- a/src/data/proofs/harmonic-divergence-oq-03/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-hd03-header",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "concept",
+    "title": "Goal: 1 − 1/2 + 1/3 − ⋯ = log 2, and why Abel is needed",
+    "content": "Where the parent entry shows the harmonic series ∑ 1/n diverges, this companion proves its alternating cousin converges to exactly Real.log 2 (the Mercator/Mengoli series). The subtlety: Mathlib's Mercator power series ∑ x^(n+1)/(n+1) = −log(1−x) holds only on the open interval |x| < 1, but the alternating harmonic series is the boundary value x → 1⁻, where the series is merely conditionally convergent. Bridging interior to boundary needs Abel's limit theorem — structurally the same device Mathlib uses for Leibniz's series for π (Real.tendsto_sum_pi_div_four).",
+    "mathContext": "$\\sum_{n\\ge 0}\\frac{(-1)^n}{n+1} = 1 - \\tfrac12 + \\tfrac13 - \\cdots = \\log 2$, the boundary $x\\to 1^-$ of $\\sum \\frac{(-1)^n}{n+1}x^n = \\frac{\\log(1+x)}{x}$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating harmonic series", "Mercator series", "Abel's limit theorem", "conditional convergence", "boundary value of a power series"],
+    "prerequisites": ["real power series", "radius of convergence", "the logarithm"]
+  },
+  {
+    "id": "ann-hd03-defs",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 55, "endLine": 60 },
+    "type": "definition",
+    "title": "The alternating term and partial sums",
+    "content": "altTerm n = (−1)^n/(n+1) is the n-th term indexed from 0 (so altTerm 0 = 1, altTerm 1 = −1/2, altTerm 2 = 1/3, …), and altPartial N = ∑_{i<N} altTerm i is the N-th ordered partial sum. The series value is defined as the limit of altPartial — an ordered limit, not a tsum, which the final theorem (not_summable_altTerm) shows is essential since no unconditional sum exists.",
+    "mathContext": "$\\mathrm{altPartial}\\,N = \\sum_{i=0}^{N-1}\\frac{(-1)^i}{i+1} = 1 - \\tfrac12 + \\tfrac13 - \\cdots \\pm \\tfrac1N$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partial sums", "ordered limit", "Finset.range sum"],
+    "prerequisites": ["finite sums", "sequences"]
+  },
+  {
+    "id": "ann-hd03-genfunc",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 62, "endLine": 86 },
+    "type": "theorem",
+    "title": "Generating function: ∑ (−1)ⁿ/(n+1) xⁿ = log(1+x)/x",
+    "content": "hasSum_altTerm_mul_pow packages the analytic content: for |x| < 1 and x ≠ 0, the power series sums to log(1+x)/x. It starts from Mathlib's Mercator series at y = −x (Real.hasSum_pow_div_log_of_abs_lt_one giving ∑ (−x)^(n+1)/(n+1) = −log(1+x)), scales by −1/x (HasSum.mul_left), then identifies value and terms separately: the value via field_simp after rewriting 1 − (−x) = 1 + x, and the terms via neg_pow + pow_succ to convert (−x)^(n+1) into altTerm n · xⁿ.",
+    "mathContext": "From $\\sum (-x)^{n+1}/(n+1) = -\\log(1+x)$, multiply by $-1/x$: $\\sum \\frac{(-1)^n}{n+1}x^n = \\frac{\\log(1+x)}{x}$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.hasSum_pow_div_log_of_abs_lt_one", "HasSum.mul_left", "neg_pow", "pow_succ", "generating function"],
+    "prerequisites": ["the Mercator series", "HasSum manipulation", "field algebra"]
+  },
+  {
+    "id": "ann-hd03-convergence",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 88, "endLine": 101 },
+    "type": "theorem",
+    "title": "Conditional convergence via the alternating series test",
+    "content": "exists_tendsto_altPartial establishes that the partial sums converge to *some* limit l, by Leibniz's alternating series test (Antitone.tendsto_alternating_series_of_tendsto_zero): the magnitudes 1/(n+1) are antitone (one_div_le_one_div_of_le) and tend to 0 (tendsto_one_div_add_atTop_nhds_zero_nat). The test's (−1)^n·aₙ form is reconciled with altTerm by a termwise ring rewrite. This gives existence of the limit; its *value* is pinned only later, by Abel.",
+    "mathContext": "Alternating series test: $\\sum (-1)^n a_n$ converges when $a_n \\downarrow 0$; here $a_n = \\tfrac{1}{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Antitone.tendsto_alternating_series_of_tendsto_zero", "Leibniz test", "antitone sequence", "tendsto_one_div_add_atTop"],
+    "prerequisites": ["monotone sequences", "limits", "the alternating series test"]
+  },
+  {
+    "id": "ann-hd03-main",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 103, "endLine": 135 },
+    "type": "theorem",
+    "title": "The value is log 2 (Abel + continuity + uniqueness)",
+    "content": "altHarmonic_tendsto_log_two is the headline. Abel's limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) sends the power series to the partial-sum limit l as x → 1⁻. On (0,1) the power series equals log(1+x)/x (from the generating function, transported by abel.congr' with a filter_upwards establishing |x| < 1 and x ≠ 0 eventually). Separately, x ↦ log(1+x)/x is continuous at 1 with value log(2)/1 = log 2 (built from Real.continuousAt_log and div). Two limits of the same function force l = log 2 by tendsto_nhds_unique.",
+    "mathContext": "$\\lim_{x\\to 1^-}\\sum \\mathrm{altTerm}\\,n\\cdot x^n = \\lim_{x\\to 1^-}\\frac{\\log(1+x)}{x} = \\frac{\\log 2}{1} = \\log 2 \\;\\Rightarrow\\; l = \\log 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.tendsto_tsum_powerSeries_nhdsWithin_lt", "Abel's limit theorem", "tendsto_nhds_unique", "Real.continuousAt_log", "nhdsWithin", "filter_upwards"],
+    "prerequisites": ["Abel's theorem", "continuity and limits", "uniqueness of limits"]
+  },
+  {
+    "id": "ann-hd03-notsummable",
+    "proofId": "harmonic-divergence-oq-03",
+    "range": { "startLine": 137, "endLine": 153 },
+    "type": "insight",
+    "title": "Only conditionally convergent — no tsum exists",
+    "content": "not_summable_altTerm records that the series is NOT (unconditionally) Summable: over ℝ (finite-dimensional) unconditional summability coincides with absolute summability (summable_norm_iff), and ‖altTerm n‖ = 1/(n+1) sums to the divergent harmonic series (Real.not_summable_one_div_natCast, shifted by summable_nat_add_iff). This is why the value log 2 must be taken as an *ordered* limit of partial sums reached through Abel's theorem, not as a tsum/HasSum — a clean illustration that for real series, convergence of partial sums (conditional) is strictly weaker than HasSum (unconditional).",
+    "mathContext": "$\\|\\mathrm{altTerm}\\,n\\| = \\tfrac{1}{n+1}$ and $\\sum \\tfrac{1}{n+1}$ diverges $\\Rightarrow$ altTerm is not Summable; the sum is intrinsically an ordered limit.",
+    "significance": "key",
+    "relatedConcepts": ["summable_norm_iff", "Real.not_summable_one_div_natCast", "conditional vs absolute convergence", "HasSum vs Tendsto", "Riemann rearrangement"],
+    "prerequisites": ["Summable / HasSum", "absolute vs conditional convergence", "harmonic divergence"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `harmonic-divergence-oq-03` (the alternating harmonic series 1 − 1/2 + 1/3 − ⋯ = log 2, Mercator/Mengoli).

The entry already had a rich overview, 5 sections, and conclusion, but **no `annotations.json`**. Added it.

- **`annotations.json`** (6 annotations, each with `mathContext` LaTeX / `significance` / `relatedConcepts` / `prerequisites`) covering: the goal and why a boundary value forces Abel's limit theorem (Mathlib's Mercator series is interior-only), the `altTerm`/`altPartial` definitions, the generating-function identity `∑(−1)ⁿ/(n+1)xⁿ = log(1+x)/x`, conditional convergence via the alternating series test, the value = log 2 via Abel + continuity + uniqueness of limits, and `not_summable_altTerm` (conditional-only convergence ⟹ ordered limit, not a tsum).
- Annotation ranges verified to snap cleanly to Lean constructs (`pnpm annotations:build` reports no warnings for this entry).

Axiom integrity: confirmed `status: verified` / `axiomCount: 0` is accurate — 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only propext/Classical.choice/Quot.sound. No change needed.

Verified with `pnpm build` (✓ built).