### PR TITLE
research(harmonic-divergence-oq-05-oq-01): dyadic upper bound H_{2ⁿ}≤1+n completes two-sided Oresme sandwich [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2991,6 +2991,7 @@ import Proofs.HarmonicDivergenceOQ02
 import Proofs.HarmonicDivergenceOQ03
 import Proofs.HarmonicDivergenceOQ04
 import Proofs.HarmonicDivergenceOQ05
+import Proofs.HarmonicDivergenceOQ05OQ01
 import Proofs.HarmonicDivergenceOQ05OQ02
 import Proofs.HermiteLindemann
 import Proofs.HeronsFormula

--- a/proofs/Proofs/HarmonicDivergenceOQ05OQ01.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ05OQ01.lean
@@ -1,0 +1,122 @@
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Tactic
+import Proofs.HarmonicDivergenceOQ05
+
+/-
+# The Dyadic Upper Bound `H_{2^n} ≤ 1 + n` (Two-Sided Oresme Sandwich)
+
+## What This Proves
+
+The parent entry `HarmonicDivergenceOQ05` proves the explicit *lower* bound
+
+  `H_{2^n} = ∑_{j=1}^{2^n} 1/j ≥ 1 + n/2`
+
+by grouping the partial sum into dyadic blocks, each of which contributes at
+least `1/2`. This entry proves the matching *upper* bound
+
+  `H_{2^n} ≤ 1 + n`,
+
+obtained from the dual observation that each dyadic block of `2^n` terms
+contributes **at most `1`** (every term `1/(k+1)` with `2^n ≤ k < 2^{n+1}`
+is at most `1/2^n`, and there are `2^n` of them). Together with the parent we
+get the complete two-sided sandwich
+
+  `1 + n/2 ≤ H_{2^n} ≤ 1 + n`,
+
+pinning the `2^n`-th harmonic partial sum to a window of width `n/2` around
+`1 + 3n/4`. This is the elementary fact behind `H_N ~ log N`: at the dyadic
+sampling points `N = 2^n` the partial sum grows exactly linearly in `n` (up to
+the factor between `1/2` and `1`), i.e. logarithmically in `N`.
+
+Mathlib has neither the lower nor the upper closed-form bound on the harmonic
+partial sums (only the existence-form divergence
+`Real.tendsto_sum_range_one_div_nat_succ_atTop`); both directions are derived
+here by a self-contained dyadic-block estimate and induction on `n`.
+
+## Indexing convention
+
+We reuse the parent's partial-sum definition
+`H N = ∑_{k ∈ range N} 1/(k+1) = 1 + 1/2 + … + 1/N`.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Headline `harmonic_two_pow_le` is original to the gallery family
+- [x] Corollary: the two-sided sandwich `harmonic_two_pow_sandwich`
+-/
+
+namespace HarmonicDivergenceOQ05OQ01
+
+open Finset HarmonicDivergenceOQ05
+
+/-- **Dual dyadic block estimate.** The block of `2^n` terms running from index
+`2^n` to `2^{n+1} - 1` contributes at most `1`:
+
+  `1/(2^n+1) + 1/(2^n+2) + … + 1/2^{n+1} ≤ 1`.
+
+Each of the `2^n` terms is at most `1/2^n` (since `k + 1 ≥ 2^n` on the block),
+and `2^n · (1/2^n) = 1`. -/
+theorem block_le_one (n : ℕ) :
+    ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / (k + 1) ≤ 1 := by
+  -- Each term in the block is ≤ 1 / 2^n.
+  have hterm : ∀ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)),
+      (1 : ℝ) / (k + 1) ≤ (1 : ℝ) / 2 ^ n := by
+    intro k hk
+    rw [Finset.mem_Ico] at hk
+    have hpow_pos : (0 : ℝ) < 2 ^ n := by positivity
+    have hle : (2 : ℝ) ^ n ≤ (k : ℝ) + 1 := by
+      have : (2 : ℕ) ^ n ≤ k + 1 := by omega
+      exact_mod_cast this
+    exact one_div_le_one_div_of_le hpow_pos hle
+  -- Sum of the constant upper bound over the block equals 1.
+  have hconst : ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / 2 ^ n = 1 := by
+    rw [Finset.sum_const, Nat.card_Ico]
+    have hpow : (2 : ℕ) ^ (n + 1) - 2 ^ n = 2 ^ n := by
+      have : (2 : ℕ) ^ (n + 1) = 2 * 2 ^ n := by ring
+      omega
+    rw [hpow, nsmul_eq_mul]
+    have hne : (2 : ℝ) ^ n ≠ 0 := by positivity
+    push_cast
+    field_simp
+  calc ∑ k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / (k + 1)
+      ≤ ∑ _k ∈ Finset.Ico (2 ^ n : ℕ) (2 ^ (n + 1)), (1 : ℝ) / 2 ^ n :=
+        Finset.sum_le_sum hterm
+    _ = 1 := hconst
+
+/-- **Dyadic upper bound.** The `2^n`-th partial sum of the harmonic series
+satisfies
+
+  `H_{2^n} = ∑_{j=1}^{2^n} 1/j ≤ 1 + n`.
+
+Proof by induction on `n`: the first term contributes `1 = H_{2^0}`, and each of
+the next `n` dyadic blocks contributes at most `1` (`block_le_one`). -/
+theorem harmonic_two_pow_le (n : ℕ) : H (2 ^ n) ≤ 1 + (n : ℝ) := by
+  induction n with
+  | zero => simp [H]
+  | succ n ih =>
+      rw [H_two_pow_succ]
+      have hblock := block_le_one n
+      push_cast
+      have hrw : 1 + ((n : ℝ) + 1) = (1 + (n : ℝ)) + 1 := by ring
+      rw [hrw]
+      exact add_le_add ih hblock
+
+/-- **Two-sided Oresme sandwich.** Combining the parent's lower bound
+`harmonic_two_pow_ge` with the upper bound above, the `2^n`-th harmonic partial
+sum is pinned to a window of width `n/2`:
+
+  `1 + n/2 ≤ H_{2^n} ≤ 1 + n`.
+
+This exhibits the logarithmic growth `H_N ~ log N` quantitatively at the dyadic
+sampling points `N = 2^n`. -/
+theorem harmonic_two_pow_sandwich (n : ℕ) :
+    1 + (n : ℝ) / 2 ≤ H (2 ^ n) ∧ H (2 ^ n) ≤ 1 + (n : ℝ) :=
+  ⟨harmonic_two_pow_ge n, harmonic_two_pow_le n⟩
+
+/-- **Width of the sandwich.** The lower and upper bounds on `H_{2^n}` differ by
+exactly `n/2`, so the dyadic partial sums are localised to an interval of length
+`n/2`. -/
+theorem harmonic_two_pow_window (n : ℕ) :
+    (1 + (n : ℝ)) - (1 + (n : ℝ) / 2) = (n : ℝ) / 2 := by ring
+
+end HarmonicDivergenceOQ05OQ01

--- a/src/data/proofs/harmonic-divergence-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "harmonic-divergence-oq-05-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 57
+    },
+    "type": "concept",
+    "title": "Reusing the Parent's Partial Sum H and Block Split",
+    "content": "Rather than redefine the harmonic partial sum, this entry imports the parent Proofs.HarmonicDivergenceOQ05 and opens its namespace, inheriting H N = ∑_{k ∈ Finset.range N} 1/(k+1) and the split lemma H_two_pow_succ. The only new ingredient is the dual block estimate; everything else (the indexing convention, the range→range+Ico decomposition) is shared verbatim with the lower-bound entry, so the two sides of the sandwich are guaranteed to speak about the same object. As in the parent, the Ico interval is forced to ℕ via the (2^n : ℕ) annotation, since ℝ has no LocallyFiniteOrder instance.",
+    "mathContext": "$H_N = \\sum_{k=0}^{N-1} \\frac{1}{k+1} = \\sum_{j=1}^{N} \\frac{1}{j}$, and $H_{2^{n+1}} = H_{2^n} + \\sum_{k \\in \\text{Ico}(2^n, 2^{n+1})} \\frac{1}{k+1}$ are both reused from the parent OQ-05.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.range",
+      "namespace reuse",
+      "partial sums",
+      "LocallyFiniteOrder"
+    ],
+    "prerequisites": [
+      "Lean 4 Finset sums",
+      "importing and opening namespaces"
+    ]
+  },
+  {
+    "id": "ann-block-le-one",
+    "proofId": "harmonic-divergence-oq-05-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 91
+    },
+    "type": "key_step",
+    "title": "The Dual Dyadic Block Estimate: Each Block Sums to ≤ 1",
+    "content": "block_le_one is the only genuinely new lemma, and it mirrors the parent's block_ge_half with the inequality reversed. The block over k ∈ Ico(2ⁿ, 2ⁿ⁺¹) has exactly 2ⁿ terms (Nat.card_Ico: 2ⁿ⁺¹ − 2ⁿ = 2ⁿ). For each such k, since k ≥ 2ⁿ we have k+1 ≥ 2ⁿ, hence 1/(k+1) ≤ 1/2ⁿ (one_div_le_one_div_of_le). Summing the constant upper bound 1/2ⁿ over the 2ⁿ terms gives 2ⁿ·(1/2ⁿ) = 1 (Finset.sum_const, then push_cast to turn ↑(2ⁿ) into the real (2:ℝ)ⁿ before field_simp). Finset.sum_le_sum lifts the termwise bound to the block, and the calc chains the actual block sum below the constant sum (= 1). Where the lower bound uses the smallest term 1/2ⁿ⁺¹, this uses the largest term 1/2ⁿ.",
+    "mathContext": "$\\sum_{k=2^n}^{2^{n+1}-1} \\frac{1}{k+1} \\le \\sum_{k=2^n}^{2^{n+1}-1} \\frac{1}{2^{n}} = 2^n \\cdot \\frac{1}{2^{n}} = 1$. Every term is at most the largest one $1/2^{n}$, and there are $2^{n+1}-2^n = 2^n$ of them.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "one_div_le_one_div_of_le",
+      "Finset.sum_le_sum",
+      "Finset.sum_const",
+      "Nat.card_Ico",
+      "dyadic grouping"
+    ],
+    "prerequisites": [
+      "monotonicity of reciprocal",
+      "constant sums over finite sets"
+    ]
+  },
+  {
+    "id": "ann-main-bound",
+    "proofId": "harmonic-divergence-oq-05-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 110
+    },
+    "type": "key_step",
+    "title": "The Dyadic Upper Bound H_{2ⁿ} ≤ 1 + n",
+    "content": "harmonic_two_pow_le inducts on n. The base case n=0 is H_1 = 1 = 1 + 0 (simp on the definition of H). The step rewrites H_{2ⁿ⁺¹} via the parent's H_two_pow_succ, then adds the inductive hypothesis H_{2ⁿ} ≤ 1 + n to the block bound block_le_one (≤ 1) using add_le_add, giving H_{2ⁿ⁺¹} ≤ (1 + n) + 1 = 1 + (n+1). The structure is the exact mirror of the parent's harmonic_two_pow_ge, with 1/2 replaced by 1 and ≥ replaced by ≤.",
+    "mathContext": "$H_{2^n} \\le 1 + n$ by induction: $H_{2^{n+1}} = H_{2^n} + \\text{block} \\le (1+n) + 1 = 1 + (n+1)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "induction",
+      "add_le_add",
+      "H_two_pow_succ",
+      "harmonic partial sums"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "monotonicity of addition for inequalities"
+    ]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "harmonic-divergence-oq-05-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 122
+    },
+    "type": "concept",
+    "title": "The Two-Sided Sandwich and Its Width",
+    "content": "harmonic_two_pow_sandwich simply pairs this entry's upper bound with the parent's harmonic_two_pow_ge to deliver 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n in one statement — answering the open question posed verbatim in the parent OQ-05's conclusion. harmonic_two_pow_window records that the gap between the two bounds is exactly (1 + n) − (1 + n/2) = n/2 (by ring), so the dyadic partial sums are localised to an interval of length n/2. This is the elementary, constant-free witness that H_N grows like log N: at N = 2ⁿ the sum sits between 1 + (log₂ N)/2 and 1 + log₂ N.",
+    "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$, gap $= n/2$. Equivalently $1 + \\tfrac{\\log_2 N}{2} \\le H_N \\le 1 + \\log_2 N$ at the dyadic points $N = 2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-sided bounds",
+      "logarithmic growth",
+      "harmonic_two_pow_ge",
+      "sandwich theorem"
+    ],
+    "prerequisites": [
+      "conjunction of inequalities",
+      "ring normalization"
+    ]
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-05-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-05-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "harmonic-divergence-oq-05-oq-01",
+  "title": "The Dyadic Upper Bound H_{2ⁿ} ≤ 1 + n (Two-Sided Oresme Sandwich)",
+  "slug": "harmonic-divergence-oq-05-oq-01",
+  "description": "Proves the matching elementary upper bound H_{2ⁿ} ≤ 1 + n for the harmonic partial sums: each dyadic block of 2ⁿ terms contributes at most 1. Combined with the parent's lower bound H_{2ⁿ} ≥ 1 + n/2 this yields the two-sided sandwich 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n, pinning the 2ⁿ-th harmonic partial sum to a window of width n/2 and exhibiting the logarithmic growth quantitatively.",
+  "meta": {
+    "author": "Classical (Oresme grouping, dual estimate); formalization original to this gallery",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ05OQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "divergence",
+      "harmonic-series",
+      "explicit-bound",
+      "dyadic-blocks",
+      "induction",
+      "two-sided-bound"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Termwise comparison of finite sums",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "one_div_le_one_div_of_le",
+        "description": "Antitonicity of x ↦ 1/x on the positives",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "Sum of a constant over a Finset equals card • the constant",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.card_Ico",
+        "description": "Cardinality of the half-open integer interval Ico a b is b − a",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      }
+    ],
+    "originalContributions": [
+      "harmonic_two_pow_le: the explicit upper bound H_{2ⁿ} ≤ 1 + n, dual to the parent's lower bound, proved by induction on n — not present in Mathlib",
+      "block_le_one: the dual dyadic-block estimate ∑_{k=2ⁿ}^{2ⁿ⁺¹-1} 1/(k+1) ≤ 1 (each of the 2ⁿ terms is ≤ 1/2ⁿ since k+1 ≥ 2ⁿ on the block)",
+      "harmonic_two_pow_sandwich: the complete two-sided bound 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n, combining this entry's upper bound with the parent's lower bound (answers the parent OQ-05's open question)",
+      "harmonic_two_pow_window: the lower and upper bounds differ by exactly n/2, localising the dyadic partial sums to an interval of length n/2"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool).",
+    "lineCount": 122,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Nicole Oresme's ~1350 dyadic grouping shows each block of 2ⁿ consecutive harmonic terms exceeds 1/2, giving the lower bound H_{2ⁿ} ≥ 1 + n/2 (parent entry OQ-05). The same grouping read in the opposite direction bounds each block from above: every term 1/(k+1) with 2ⁿ ≤ k < 2ⁿ⁺¹ is at most 1/2ⁿ, and the 2ⁿ terms sum to at most 1. This entry formalizes that dual estimate to obtain H_{2ⁿ} ≤ 1 + n, completing the two-sided sandwich 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n. The window matches the elementary fact behind H_N ~ ln N: at the dyadic sampling points N = 2ⁿ the partial sum grows linearly in n, hence logarithmically in N.",
+    "problemStatement": "The parent entry pins H_{2ⁿ} from below by 1 + n/2. Can a matching elementary upper bound be formalized to sandwich the partial sums?\n\n**Answer: Yes.** H_{2ⁿ} ≤ 1 + n, each dyadic block contributing at most 1, giving 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n.",
+    "text": "A matching elementary upper bound for the harmonic partial sums, completing a two-sided dyadic sandwich around H_{2ⁿ} of width n/2.",
+    "proofStrategy": "1. block_le_one: each dyadic block ∑_{k∈Ico(2ⁿ,2ⁿ⁺¹)} 1/(k+1) has 2ⁿ terms, each ≤ 1/2ⁿ (since k + 1 ≥ 2ⁿ on the block, via one_div_le_one_div_of_le), and 2ⁿ·(1/2ⁿ) = 1, so the block sums to ≤ 1 (Finset.sum_le_sum against the constant 1/2ⁿ, then Finset.sum_const · Nat.card_Ico).\n2. harmonic_two_pow_le: induct on n, reusing the parent's split H_{2ⁿ⁺¹} = H_{2ⁿ} + block (H_two_pow_succ). Base n=0 gives H_1 = 1 = 1 + 0. Step adds the block's ≤ 1 to the inductive 1 + n, yielding 1 + (n+1).\n3. harmonic_two_pow_sandwich: pair this upper bound with the parent's harmonic_two_pow_ge.\n4. harmonic_two_pow_window: (1 + n) − (1 + n/2) = n/2, by ring.",
+    "keyInsights": [
+      "**Dual reading of Oresme's blocks**: the lower bound bounds each block term by the smallest 1/2ⁿ⁺¹ (block ≥ 1/2); the upper bound bounds each term by the largest 1/2ⁿ (block ≤ 1). Same blocks, opposite endpoint.",
+      "**Completes the sandwich**: combined with the parent, 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n. The two bounds straddle H_{2ⁿ} with a gap of exactly n/2, the elementary shadow of H_N ~ ln N at the dyadic sampling points.",
+      "**Not a Mathlib lemma**: Mathlib offers only the existence-form divergence (Real.tendsto_sum_range_one_div_nat_succ_atTop) and no closed two-sided bound; both directions are original to this gallery family.",
+      "**Reuses parent infrastructure**: the induction reuses the parent's range→range+Ico split H_two_pow_succ verbatim, isolating the only new ingredient as the dual block estimate.",
+      "**Answers the parent's open question**: OQ-05 explicitly asked whether a matching elementary upper bound H_{2ⁿ} ≤ 1 + n could be formalized to sandwich the partial sums; this entry does exactly that."
+    ],
+    "prerequisites": [
+      "Real analysis (partial sums, series bounds)",
+      "Finite sums over Finset (Ico intervals, termwise comparison)",
+      "Induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-namespace",
+      "title": "Imports and Reuse of the Parent Partial Sum H",
+      "startLine": 1,
+      "endLine": 57,
+      "summary": "Imports the parent entry Proofs.HarmonicDivergenceOQ05 and opens its namespace, reusing the partial-sum definition H N = ∑_{k∈range N} 1/(k+1) and the split lemma H_two_pow_succ rather than redefining them.",
+      "mathContext": "H N = ∑_{j=1}^{N} 1/j with the range/(k+1) convention shared with the parent, so the inductive split H_{2ⁿ⁺¹} = H_{2ⁿ} + block carries over unchanged."
+    },
+    {
+      "id": "block-le-one",
+      "title": "The Dual Dyadic Block Estimate",
+      "startLine": 59,
+      "endLine": 91,
+      "summary": "block_le_one: the block of 2ⁿ terms from index 2ⁿ to 2ⁿ⁺¹−1 sums to at most 1. Each term 1/(k+1) ≤ 1/2ⁿ (since k+1 ≥ 2ⁿ), and there are 2ⁿ⁺¹−2ⁿ = 2ⁿ of them, with 2ⁿ·(1/2ⁿ) = 1.",
+      "mathContext": "$\\sum_{k=2^n}^{2^{n+1}-1} \\frac{1}{k+1} \\le 2^n \\cdot \\frac{1}{2^{n}} = 1$ via termwise comparison (one_div_le_one_div_of_le) and Finset.sum_const · Nat.card_Ico."
+    },
+    {
+      "id": "main-bound",
+      "title": "The Dyadic Upper Bound",
+      "startLine": 93,
+      "endLine": 110,
+      "summary": "harmonic_two_pow_le: H_{2ⁿ} ≤ 1 + n, by induction on n. Base case H_1 = 1. Step combines the inductive bound 1 + n with the block's ≤ 1 (block_le_one) to reach 1 + (n+1), reusing the parent's H_two_pow_succ split.",
+      "mathContext": "$H_{2^n} \\le 1 + n$. Inductive step: $(1 + n) + 1 = 1 + (n+1)$, with the added 1 supplied by block_le_one."
+    },
+    {
+      "id": "sandwich",
+      "title": "The Two-Sided Sandwich and Its Width",
+      "startLine": 112,
+      "endLine": 122,
+      "summary": "harmonic_two_pow_sandwich: pairs this entry's upper bound with the parent's harmonic_two_pow_ge to give 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n. harmonic_two_pow_window: the bounds differ by exactly n/2.",
+      "mathContext": "$1 + n/2 \\le H_{2^n} \\le 1 + n$ with gap $(1+n) - (1+n/2) = n/2$, localising the dyadic partial sums to an interval of length n/2."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Oresme, Nicole",
+      "title": "Quaestiones super geometriam Euclidis",
+      "year": "~1350",
+      "note": "Dyadic grouping argument; read from above it bounds each block by 1, giving the upper bound sandwiching the lower bound of OQ-05"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-05",
+      "relationship": "extends",
+      "description": "Supplies the matching upper bound H_{2ⁿ} ≤ 1 + n that the parent OQ-05 posed as an open question, completing the two-sided sandwich 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n; reuses the parent's H and H_two_pow_succ"
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "sharpens",
+      "description": "Upgrades the base entry's qualitative unboundedness with an explicit upper bound on the dyadic partial sums, the dual of its per-block lower estimate"
+    }
+  ],
+  "conclusion": {
+    "summary": "Read from above, Oresme's dyadic blocks each contribute at most 1, giving the explicit upper bound H_{2ⁿ} ≤ 1 + n. Combined with the parent's lower bound this sandwiches the 2ⁿ-th harmonic partial sum: 1 + n/2 ≤ H_{2ⁿ} ≤ 1 + n, a window of width n/2.",
+    "implications": "The two-sided bound exhibits the logarithmic growth of the harmonic partial sums with elementary, constant-free means: at the dyadic sampling points N = 2ⁿ, H_N lies between 1 + (log₂ N)/2 and 1 + log₂ N. It directly answers the open question posed by the parent entry OQ-05.",
+    "openQuestions": [
+      "Can the dyadic sandwich be interpolated to a bound on H_N for all N (not just N = 2ⁿ), e.g. ⌊log₂ N⌋/2 ≤ H_N − 1 ≤ ⌈log₂ N⌉?",
+      "Does the same dual block estimate give two-sided bounds for the p-series partial sums ∑ 1/jᵖ with p near 1?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Tactic",
+      "Proofs.HarmonicDivergenceOQ05"
+    ],
+    "opens": [
+      "Finset",
+      "HarmonicDivergenceOQ05"
+    ],
+    "namespace": "HarmonicDivergenceOQ05OQ01",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/HarmonicDivergenceOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the matching **upper** bound `H_{2ⁿ} ≤ 1 + n` for the harmonic partial sums, completing the two-sided **Oresme sandwich**

```
1 + n/2  ≤  H_{2ⁿ}  ≤  1 + n
```

with the parent entry [`harmonic-divergence-oq-05`](../tree/main/src/data/proofs/harmonic-divergence-oq-05) (which proved the lower bound `H_{2ⁿ} ≥ 1 + n/2`). This **answers the open question posed verbatim in the parent OQ-05's conclusion**: *"Can a matching elementary upper bound H_{2ⁿ} ≤ 1 + n be formalized to sandwich the partial sums?"*

## Mathematics

Read Oresme's dyadic grouping from above: each block of 2ⁿ terms over `k ∈ Ico(2ⁿ, 2ⁿ⁺¹)` has every term `1/(k+1) ≤ 1/2ⁿ` (since `k ≥ 2ⁿ`), and there are exactly 2ⁿ of them, so the block sums to `≤ 2ⁿ·(1/2ⁿ) = 1`. Induction on `n`, reusing the parent's range→range+Ico split `H_two_pow_succ`, then gives `H_{2ⁿ} ≤ 1 + n`. The two bounds differ by exactly `n/2`, localising the dyadic partial sums to a window of that width — the elementary, constant-free witness of `H_N ~ log N`.

## Contributions

- `block_le_one` — dual dyadic block estimate (the only new ingredient)
- `harmonic_two_pow_le` — the upper bound `H_{2ⁿ} ≤ 1 + n`
- `harmonic_two_pow_sandwich` — the full two-sided bound
- `harmonic_two_pow_window` — the gap is exactly `n/2`

Reuses the parent's `H` and `H_two_pow_succ` (imports `Proofs.HarmonicDivergenceOQ05`).

## Verification

- `#print axioms` on all theorems: `propext, Classical.choice, Quot.sound` only — **no `sorryAx`, no `Lean.ofReduceBool`**
- 0 sorries, 0 axioms, **verified**
- 4 theorems, 122 lines, Mathlib v4.26.0
- Compiles clean via `lake env lean` (host, parent olean built first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)