### PR TITLE
research(law-of-cosines-oq-08): triangle inequality from the law of cosines [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3209,6 +3209,7 @@ import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05
 import Proofs.LawOfCosinesOQ07
+import Proofs.LawOfCosinesOQ08
 import Proofs.LawOfSinesOQ06
 import Proofs.LawsOfLargeNumbers
 import Proofs.LawsOfLargeNumbersOQ01

--- a/proofs/Proofs/LawOfCosinesOQ08.lean
+++ b/proofs/Proofs/LawOfCosinesOQ08.lean
@@ -1,0 +1,149 @@
+/-
+# Law of Cosines OQ-08: The Triangle Inequality as a Corollary of the Law of Cosines
+
+The parent entry (`LawOfCosines`, Wiedijk #94) proves the law of cosines in both its
+classical scalar form `c² = a² + b² - 2ab·cos C` and its inner-product form
+`‖v - w‖² = ‖v‖² + ‖w‖² - 2⟨v, w⟩`.  One of its open questions asks to *derive the
+triangle inequality directly from the law of cosines*, using only the elementary fact
+that a cosine never drops below `-1`.
+
+This file does exactly that.  The single analytic input is `cos C ≥ -1`
+(`Real.neg_one_le_cos`):
+
+* **Scalar form.**  If `c² = a² + b² - 2ab·cos C` with `a, b, c ≥ 0` and `cos C ≥ -1`,
+  then `c ≤ a + b`.  The proof is one line of algebra:
+  `(a + b)² - c² = 2ab·(1 + cos C) ≥ 0`, and squares of non-negatives are monotone.
+
+* **Equality / degeneracy.**  For a genuine triangle (`a, b > 0`) equality `c = a + b`
+  holds **iff** `cos C = -1`, i.e. iff the angle `C = π` and the triangle is degenerate
+  (the three vertices are collinear with `C` between the other two).  When `cos C > -1`
+  the inequality is strict, `c < a + b`.
+
+* **Coordinate-free form.**  In *any* real inner-product space, the law of cosines in
+  vector-angle form (`InnerProductGeometry.norm_sub_sq_…_cos_angle`) together with
+  `cos ≥ -1` yields `‖x - y‖ ≤ ‖x‖ + ‖y‖`, with equality iff the angle between `x` and
+  `y` is `π`.  This recovers Mathlib's `norm_sub_le` via the law of cosines, exhibiting
+  the triangle inequality as a metric shadow of the cosine rule.
+
+Everything is reduced to the scalar lemma `triangle_ineq_of_law_cosines`, which is the
+mathematical heart of the result.  All proofs are fully machine-checked, with no `sorry`
+and no axioms beyond Lean/Mathlib's foundations.
+
+(The parent `Proofs.LawOfCosines` is referenced conceptually but not imported: this file
+is self-contained and obtains the cosine-rule identity directly from Mathlib's
+`InnerProductGeometry`, so it stays valid independently of the parent file's build state.)
+-/
+import Mathlib
+
+namespace LawOfCosinesOQ08
+
+open InnerProductGeometry Real
+open scoped RealInnerProductSpace
+
+/-! ### Monotonicity of squaring on the non-negative reals
+
+Two small bridges between `x ≤ y` and `x² ≤ y²` for non-negative `x, y`, obtained by
+taking square roots.  They turn the algebraic squared inequalities below into the genuine
+distance inequalities. -/
+
+/-- For non-negative reals, `c ≤ d` follows from `c² ≤ d²`. -/
+theorem le_of_sq_le_sq {c d : ℝ} (hc : 0 ≤ c) (hd : 0 ≤ d) (h : c ^ 2 ≤ d ^ 2) : c ≤ d := by
+  have := Real.sqrt_le_sqrt h
+  rwa [Real.sqrt_sq hc, Real.sqrt_sq hd] at this
+
+/-- For non-negative reals, `c < d` follows from `c² < d²`. -/
+theorem lt_of_sq_lt_sq {c d : ℝ} (hc : 0 ≤ c) (hd : 0 ≤ d) (h : c ^ 2 < d ^ 2) : c < d := by
+  have := Real.sqrt_lt_sqrt (sq_nonneg c) h
+  rwa [Real.sqrt_sq hc, Real.sqrt_sq hd] at this
+
+/-! ### Scalar form: the triangle inequality from the cosine rule -/
+
+/-- **Triangle inequality from the law of cosines (scalar form).**
+If the side `c` opposite the angle `C` satisfies the law of cosines
+`c² = a² + b² - 2ab·cos C`, with `a, b, c ≥ 0` and the only trigonometric input
+`cos C ≥ -1`, then `c ≤ a + b`.
+
+The whole content is `(a + b)² - c² = 2ab·(1 + cos C) ≥ 0`. -/
+theorem triangle_ineq_of_law_cosines {a b c cosC : ℝ}
+    (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hcos : -1 ≤ cosC)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c ≤ a + b := by
+  have hsq : c ^ 2 ≤ (a + b) ^ 2 := by
+    nlinarith [mul_nonneg (mul_nonneg ha hb) (by linarith : (0 : ℝ) ≤ 1 + cosC)]
+  exact le_of_sq_le_sq hc (by linarith) hsq
+
+/-- **Strict triangle inequality from the law of cosines.**
+For a non-degenerate angle (`cos C > -1`) and positive adjacent sides, the inequality is
+strict: `c < a + b`. -/
+theorem triangle_ineq_strict_of_law_cosines {a b c cosC : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 ≤ c) (hcos : -1 < cosC)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c < a + b := by
+  have hsq : c ^ 2 < (a + b) ^ 2 := by
+    nlinarith [mul_pos (mul_pos ha hb) (by linarith : (0 : ℝ) < 1 + cosC)]
+  exact lt_of_sq_lt_sq hc (by positivity) hsq
+
+/-- **Equality holds iff the triangle is degenerate.**
+For positive adjacent sides `a, b > 0`, the triangle inequality is an equality `c = a + b`
+exactly when `cos C = -1`, i.e. when the angle `C = π` and the configuration collapses to a
+straight segment. -/
+theorem degenerate_iff_eq {a b c cosC : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 ≤ c)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c = a + b ↔ cosC = -1 := by
+  constructor
+  · intro h
+    have hcsq : c ^ 2 = (a + b) ^ 2 := by rw [h]
+    -- `2ab·(1 + cos C) = 0`, and `2ab ≠ 0`, so `cos C = -1`.
+    have key : 2 * a * b * (1 + cosC) = 0 := by linear_combination hlc - hcsq
+    have hab : 2 * a * b ≠ 0 := by positivity
+    rcases mul_eq_zero.mp key with h1 | h1
+    · exact absurd h1 hab
+    · linarith
+  · intro h
+    have hcsq : c ^ 2 = (a + b) ^ 2 := by rw [hlc, h]; ring
+    have h1 : c ≤ a + b := le_of_sq_le_sq hc (by positivity) hcsq.le
+    have h2 : a + b ≤ c := le_of_sq_le_sq (by positivity) hc hcsq.ge
+    linarith
+
+/-! ### Coordinate-free form in a real inner-product space
+
+Specialising the scalar lemmas to `a = ‖x‖`, `b = ‖y‖`, `c = ‖x - y‖`, and
+`cos C = cos (angle x y)`, fed by Mathlib's vector-angle law of cosines. -/
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- **The triangle inequality, derived from the law of cosines.**
+In any real inner-product space, `‖x - y‖ ≤ ‖x‖ + ‖y‖`.  The proof feeds the vector-angle
+form of the law of cosines into `triangle_ineq_of_law_cosines`; the only analytic input is
+`cos (angle x y) ≥ -1`.  (This re-proves Mathlib's `norm_sub_le` through the cosine rule.) -/
+theorem norm_sub_le_of_law_cosines (x y : V) : ‖x - y‖ ≤ ‖x‖ + ‖y‖ := by
+  have hlc : ‖x - y‖ ^ 2 = ‖x‖ ^ 2 + ‖y‖ ^ 2 - 2 * ‖x‖ * ‖y‖ * Real.cos (angle x y) := by
+    simpa only [sq] using
+      norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle x y
+  exact triangle_ineq_of_law_cosines (norm_nonneg x) (norm_nonneg y) (norm_nonneg _)
+    (Real.neg_one_le_cos _) hlc
+
+/-- **Equality in the triangle inequality is a degenerate (collinear) angle.**
+For non-zero vectors, `‖x - y‖ = ‖x‖ + ‖y‖` holds iff the angle between `x` and `y` equals
+`π` (equivalently `cos (angle x y) = -1`): `x` and `y` point in opposite directions. -/
+theorem norm_sub_eq_iff_cos_angle {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
+    ‖x - y‖ = ‖x‖ + ‖y‖ ↔ Real.cos (angle x y) = -1 := by
+  have hlc : ‖x - y‖ ^ 2 = ‖x‖ ^ 2 + ‖y‖ ^ 2 - 2 * ‖x‖ * ‖y‖ * Real.cos (angle x y) := by
+    simpa only [sq] using
+      norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle x y
+  exact degenerate_iff_eq (norm_pos_iff.mpr hx) (norm_pos_iff.mpr hy) (norm_nonneg _) hlc
+
+/-! ### Concrete instance in the Euclidean plane
+
+Specialising the coordinate-free statement to the Euclidean plane `EuclideanSpace ℝ (Fin 2)`
+recovers the familiar planar triangle inequality (the setting `Vec2` of the parent entry),
+now obtained purely through the law of cosines. -/
+
+/-- The triangle inequality in the Euclidean plane, a direct instance of the
+law-of-cosines derivation. -/
+theorem triangle_inequality_euclidean (v w : EuclideanSpace ℝ (Fin 2)) :
+    ‖v - w‖ ≤ ‖v‖ + ‖w‖ :=
+  norm_sub_le_of_law_cosines v w
+
+end LawOfCosinesOQ08

--- a/src/data/proofs/law-of-cosines-oq-08/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-08/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-loc-oq08-sqrt-bridge",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 50,
+      "endLine": 57
+    },
+    "type": "theorem",
+    "title": "Squaring is Monotone on the Non-Negative Reals",
+    "content": "Two small bridges, `le_of_sq_le_sq` and `lt_of_sq_lt_sq`, turning `c² ≤ d²` (resp. `c² < d²`) into `c ≤ d` (resp. `c < d`) for non-negative `c, d`. Each is one application of `Real.sqrt` monotonicity (`Real.sqrt_le_sqrt` / `Real.sqrt_lt_sqrt`) followed by `Real.sqrt_sq` to undo the square. These are the only step that converts the squared inequalities below into genuine distance inequalities.",
+    "mathContext": "For 0 ≤ c, d: c = √(c²) ≤ √(d²) = d whenever c² ≤ d², since √ is monotone and √(x²) = x on the non-negatives.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sqrt",
+      "monotonicity",
+      "order on ℝ"
+    ],
+    "prerequisites": [
+      "Properties of the real square root"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-scalar-triangle",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Triangle Inequality from the Law of Cosines (scalar form)",
+    "content": "The mathematical heart of the entry. Given the law of cosines `c² = a² + b² − 2ab·cos C` with `a, b, c ≥ 0` and the single trigonometric input `cos C ≥ −1`, the third side satisfies `c ≤ a + b`. The proof computes `(a + b)² − c² = 2ab·(1 + cos C) ≥ 0` (one `nlinarith` with the product hint `ab·(1 + cos C) ≥ 0`), giving `c² ≤ (a + b)²`, and then `le_of_sq_le_sq` extracts `c ≤ a + b`.",
+    "mathContext": "(a + b)² − c² = (a² + 2ab + b²) − (a² + b² − 2ab·cos C) = 2ab + 2ab·cos C = 2ab(1 + cos C) ≥ 0, using ab ≥ 0 and 1 + cos C ≥ 0.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "law of cosines",
+      "triangle inequality",
+      "cosine bound",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Law of cosines",
+      "cos ≥ −1"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-degenerate",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 90,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Equality Holds iff the Triangle is Degenerate",
+    "content": "For positive adjacent sides `a, b > 0`, the triangle inequality is an equality `c = a + b` exactly when `cos C = −1`, i.e. the angle `C = π` and the three vertices are collinear. Forward: `c = a + b` gives `c² = (a + b)²`, and `linear_combination hlc - hcsq` produces `2ab·(1 + cos C) = 0`; since `2ab ≠ 0` (positivity), `mul_eq_zero` forces `cos C = −1`. Reverse: substituting `cos C = −1` makes `c² = (a + b)²`, and `le_of_sq_le_sq` both ways gives `c = a + b`.",
+    "mathContext": "c = a + b ⇔ c² = (a+b)² ⇔ 2ab(1 + cos C) = 0 ⇔ cos C = −1 (since ab > 0) ⇔ C = π.",
+    "significance": "key",
+    "relatedConcepts": [
+      "degenerate triangle",
+      "equality condition",
+      "mul_eq_zero",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Law of cosines",
+      "cos C = −1 ⇔ C = π"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-coordinate-free",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 120,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Coordinate-Free Triangle Inequality in an Inner-Product Space",
+    "content": "In any real inner-product space, `‖x − y‖ ≤ ‖x‖ + ‖y‖`. The proof rewrites Mathlib's vector-angle law of cosines `norm_sub_sq_eq_…_cos_angle` into the `^2` form and feeds it, with `Real.neg_one_le_cos (angle x y)`, into the scalar lemma `triangle_ineq_of_law_cosines` (taking `a = ‖x‖`, `b = ‖y‖`, `c = ‖x − y‖`). The companion `norm_sub_eq_iff_cos_angle` shows equality holds for non-zero `x, y` iff the angle between them is `π`. This re-derives Mathlib's `norm_sub_le` through the law of cosines rather than Cauchy–Schwarz.",
+    "mathContext": "‖x − y‖² = ‖x‖² + ‖y‖² − 2‖x‖‖y‖·cos(angle x y), and cos(angle x y) ≥ −1, so the scalar argument applies verbatim with the side lengths replaced by norms.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "inner-product space",
+      "angle between vectors",
+      "norm_sub_le",
+      "InnerProductGeometry"
+    ],
+    "prerequisites": [
+      "Vector-angle law of cosines",
+      "Norm and angle in inner-product spaces"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-euclidean",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 145,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "Euclidean Plane Instance",
+    "content": "The familiar planar triangle inequality `‖v − w‖ ≤ ‖v‖ + ‖w‖` in `EuclideanSpace ℝ (Fin 2)`, obtained as a direct instance of the coordinate-free `norm_sub_le_of_law_cosines`. This is the setting `Vec2` of the parent law-of-cosines entry, now reached purely through the cosine rule.",
+    "mathContext": "EuclideanSpace ℝ (Fin 2) is a real inner-product space, so the general theorem specialises with no extra work.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclidean plane",
+      "EuclideanSpace",
+      "specialisation"
+    ],
+    "prerequisites": [
+      "EuclideanSpace as an inner-product space"
+    ]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-08/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-08/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "law-of-cosines-oq-08",
+  "title": "The Triangle Inequality as a Corollary of the Law of Cosines",
+  "slug": "law-of-cosines-oq-08",
+  "description": "Derives the triangle inequality c ≤ a + b from the law of cosines c² = a² + b² − 2ab·cos C using only cos C ≥ −1, with equality iff C = π (degenerate triangle). The coordinate-free vector form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space is obtained from Mathlib's vector-angle cosine rule, exhibiting the triangle inequality as a metric shadow of the law of cosines.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ08.lean",
+    "tags": [
+      "geometry",
+      "law-of-cosines",
+      "triangle-inequality",
+      "inner-product-space",
+      "metric",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "assumptions": "No axioms or sorries. All theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions).",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Scalar derivation of the triangle inequality c ≤ a + b directly from the law of cosines, with the single analytic input cos C ≥ −1 (the whole content is the algebraic identity (a+b)² − c² = 2ab·(1 + cos C) ≥ 0)",
+      "Sharp equality characterisation: for positive adjacent sides, c = a + b holds iff cos C = −1 (degenerate / collinear triangle), and the strict inequality c < a + b for cos C > −1",
+      "Coordinate-free form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in an arbitrary real inner-product space, derived from Mathlib's vector-angle law of cosines together with cos ≥ −1, re-proving Mathlib's norm_sub_le through the cosine rule",
+      "Vector equality condition: ‖x − y‖ = ‖x‖ + ‖y‖ iff the angle between non-zero x and y is π (opposite directions)"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The law of cosines (al-Kashi's theorem, Wiedijk's 100 Theorems #94) generalises the Pythagorean theorem to arbitrary triangles: c² = a² + b² − 2ab·cos C. The triangle inequality — that any side is at most the sum of the other two — is usually taken as an axiom of a metric space or proved for norms via the Cauchy–Schwarz inequality. This entry instead derives it as a transparent corollary of the law of cosines: since a cosine is bounded below by −1, the squared third side can never exceed (a + b)², and equality pins the angle to π, the degenerate collinear configuration.",
+    "problemStatement": "Derive the triangle inequality c ≤ a + b from the law of cosines c² = a² + b² − 2ab·cos C together with cos C ≥ −1, characterising equality as the degenerate case C = π. Give the coordinate-free form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in a real inner-product space.",
+    "text": "Reduces the triangle inequality, in both scalar and coordinate-free vector form, to the single fact cos C ≥ −1 applied to the law of cosines.",
+    "proofStrategy": "1. le_of_sq_le_sq / lt_of_sq_lt_sq: bridges x ≤ y ⇐ x² ≤ y² for non-negative reals, via Real.sqrt monotonicity. 2. triangle_ineq_of_law_cosines: from c² = a² + b² − 2ab·cos C and cos C ≥ −1, conclude (a+b)² − c² = 2ab·(1 + cos C) ≥ 0 by nlinarith, then take square roots. 3. triangle_ineq_strict_of_law_cosines: the strict version for cos C > −1 and positive sides. 4. degenerate_iff_eq: c = a + b ⇔ cos C = −1, extracted by linear_combination and mul_eq_zero. 5. norm_sub_le_of_law_cosines: specialise the scalar lemma to a = ‖x‖, b = ‖y‖, c = ‖x − y‖, cos C = cos (angle x y), feeding Mathlib's InnerProductGeometry vector-angle law of cosines and Real.neg_one_le_cos. 6. norm_sub_eq_iff_cos_angle: the vector equality condition via degenerate_iff_eq. 7. triangle_inequality_euclidean: the planar instance in EuclideanSpace ℝ (Fin 2).",
+    "keyInsights": [
+      "The entire inequality is the single algebraic identity (a + b)² − c² = 2ab·(1 + cos C): non-negative because ab ≥ 0 and 1 + cos C ≥ 0. No Cauchy–Schwarz, no metric axioms — just the law of cosines and the elementary bound on cosine.",
+      "Equality c = a + b forces 2ab·(1 + cos C) = 0; with a, b > 0 this is exactly cos C = −1, i.e. C = π. The triangle inequality is therefore strict precisely away from the degenerate collinear configuration, recovering the geometric meaning of equality.",
+      "In a real inner-product space the same scalar lemma, fed Mathlib's vector-angle cosine rule and cos ≥ −1, yields ‖x − y‖ ≤ ‖x‖ + ‖y‖. This re-derives Mathlib's norm_sub_le from the law of cosines, presenting the triangle inequality as a metric shadow of the cosine rule rather than of Cauchy–Schwarz.",
+      "The development is axiom-clean (only propext / Classical.choice / Quot.sound) and self-contained: it obtains the cosine-rule identity directly from Mathlib's InnerProductGeometry, independent of the parent file's build state."
+    ],
+    "prerequisites": [
+      "The law of cosines in scalar and vector-angle form",
+      "Real inner-product spaces, norms, and the angle between vectors (InnerProductGeometry.angle)",
+      "Monotonicity of squaring on the non-negative reals (Real.sqrt)",
+      "Lean 4 tactics: nlinarith, linear_combination, positivity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-sqrt-bridges",
+      "title": "Part I: Monotonicity of Squaring",
+      "startLine": 43,
+      "endLine": 57,
+      "summary": "Bridges le_of_sq_le_sq and lt_of_sq_lt_sq between an inequality and its square for non-negative reals, via square roots — the step that turns squared inequalities into genuine distance inequalities."
+    },
+    {
+      "id": "part2-scalar",
+      "title": "Part II: Triangle Inequality from the Cosine Rule (scalar)",
+      "startLine": 59,
+      "endLine": 84,
+      "summary": "triangle_ineq_of_law_cosines (c ≤ a + b) and its strict form, with the only analytic input cos C ≥ −1; the content is (a + b)² − c² = 2ab·(1 + cos C) ≥ 0."
+    },
+    {
+      "id": "part3-degeneracy",
+      "title": "Part III: Equality iff Degenerate",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "degenerate_iff_eq: for positive adjacent sides, equality c = a + b holds exactly when cos C = −1, i.e. the angle C = π and the triangle collapses to a segment."
+    },
+    {
+      "id": "part4-coordinate-free",
+      "title": "Part IV: Coordinate-Free Form",
+      "startLine": 109,
+      "endLine": 135,
+      "summary": "norm_sub_le_of_law_cosines: ‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space from Mathlib's vector-angle law of cosines, with the equality condition norm_sub_eq_iff_cos_angle (angle = π)."
+    },
+    {
+      "id": "part5-euclidean",
+      "title": "Part V: Euclidean Plane Instance",
+      "startLine": 137,
+      "endLine": 147,
+      "summary": "triangle_inequality_euclidean: the planar triangle inequality in EuclideanSpace ℝ (Fin 2) as a direct instance of the law-of-cosines derivation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The triangle inequality is derived from the law of cosines using only cos C ≥ −1, in both scalar form (c ≤ a + b, equality iff C = π) and coordinate-free vector form (‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space). Verified, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "The reverse triangle inequality |‖x‖ − ‖y‖| ≤ ‖x − y‖ also follows from the law of cosines via cos C ≤ 1; can it be packaged alongside, completing the two-sided bound?",
+      "Can the polygon (n-gon) inequality — the length of one side is at most the sum of the others — be obtained by iterating this law-of-cosines triangle inequality?"
+    ],
+    "implications": "Presents the triangle inequality not as a metric axiom or a consequence of Cauchy–Schwarz, but as an immediate corollary of the law of cosines and the elementary bound cos C ≥ −1, with the degenerate (collinear) case recovered exactly as the equality condition."
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "parent-problem",
+      "description": "The parent entry (Wiedijk #94) proves the law of cosines c² = a² + b² − 2ab·cos C in scalar and inner-product form; this entry answers its open question of deriving the triangle inequality directly from it."
+    },
+    {
+      "targetId": "law-of-cosines-oq-07",
+      "relationship": "related",
+      "description": "A sibling corollary of the law of cosines (Apollonius's theorem and the parallelogram law); both extract classical metric facts from the cosine rule in coordinate-free form."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The law of cosines specialises to the Pythagorean theorem at C = π/2; the triangle inequality derived here holds for all angles, with the degenerate equality at C = π."
+    }
+  ],
+  "references": [
+    {
+      "author": "al-Kashi, Jamshid",
+      "title": "The Key to Arithmetic (Miftah al-Hisab)",
+      "year": 1427,
+      "note": "Classical trigonometric formulation of the law of cosines"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LawOfCosinesOQ08",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LawOfCosinesOQ08.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers an open question of the **Law of Cosines** parent entry (Wiedijk #94): *derive the triangle inequality directly from the law of cosines*, using only the elementary bound `cos C ≥ −1`.

- **Scalar form** (`triangle_ineq_of_law_cosines`): from `c² = a² + b² − 2ab·cos C` with `a, b, c ≥ 0` and `cos C ≥ −1`, conclude `c ≤ a + b`. The whole content is the identity `(a + b)² − c² = 2ab·(1 + cos C) ≥ 0`.
- **Equality / degeneracy** (`degenerate_iff_eq`, `triangle_ineq_strict_of_law_cosines`): for positive adjacent sides, `c = a + b` iff `cos C = −1` (degenerate `C = π`, collinear); strict inequality otherwise.
- **Coordinate-free form** (`norm_sub_le_of_law_cosines`): `‖x − y‖ ≤ ‖x‖ + ‖y‖` in any real inner-product space, from Mathlib's vector-angle cosine rule + `cos ≥ −1` — re-proving `norm_sub_le` through the law of cosines. Equality (`norm_sub_eq_iff_cos_angle`) iff the angle is `π`.
- **Euclidean instance** (`triangle_inequality_euclidean`) in `EuclideanSpace ℝ (Fin 2)`.

## Verification

- 8 theorems, 0 definitions, 0 sorries.
- **0 axioms**: every theorem depends only on `propext`, `Classical.choice`, `Quot.sound` (the Lean/Mathlib foundational standard, which do not count as assumptions). Confirmed via `#print axioms`.
- Builds clean against Mathlib v4.26.0 (`Proofs.LawOfCosinesOQ08`).

## Note

The file is **self-contained** and does not import the parent `Proofs.LawOfCosines`, which is currently **build-broken on Mathlib v4.26** (its `inner v w` usages now require an explicit `ℝ` argument and were left as `sorry`). The cosine-rule identity is obtained directly from Mathlib's `InnerProductGeometry`, so this entry is valid independently of the parent's build state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)