### PR TITLE
Enrich gallery entries: add annotations.json (3 entries)

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,192 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "context",
+    "title": "Which Moduli Admit an Alternating-Digit-Sum Rule?",
+    "content": "The familiar divisibility-by-11 test alternately adds and subtracts digits, because $10 \\equiv -1 \\pmod{11}$, so $10^i \\equiv (-1)^i$ and $n = \\sum d_i 10^i \\equiv d_0 - d_1 + d_2 - \\cdots$. The parent entry showed the *ordinary* digit-sum rule (driven by $10^k \\equiv 1$) exists for **every** modulus coprime to 10. This file resolves the parent's open question about the *alternating* analogue, which needs the sharper $10^k \\equiv -1 \\pmod d$ — i.e. $-1$ must lie in the cyclic group $\\langle 10\\rangle \\subseteq (\\mathbb{Z}/d)^\\times$. Such a group contains the order-two element $-1$ exactly when its order is even, so the rule is **not universal**: it exists for 11, 7, 13 but not 3 or 37.",
+    "mathContext": "$10^k \\equiv -1 \\pmod d \\iff -1 \\in \\langle 10\\rangle$; a cyclic group has the order-2 element $-1$ iff its order is even.",
+    "significance": "context",
+    "relatedConcepts": [
+      "divisibility by 11",
+      "alternating digit sum",
+      "multiplicative order",
+      "cyclic group structure"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "ZMod d and units",
+      "multiplicative order"
+    ]
+  },
+  {
+    "id": "ann-base-condition",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 71
+    },
+    "type": "technique",
+    "title": "The Base Condition (10 : ZMod d)^k = −1 and the Workhorse",
+    "content": "`pow_zmod_eq_neg_one_iff` translates the clean algebraic condition $(10 : \\mathbb{Z}/d)^k = -1$ into the integer divisibility $d \\mid 10^k + 1$ via `ZMod.intCast_zmod_eq_zero_iff_dvd` (after `eq_neg_iff_add_eq_zero`). The workhorse `altRule_of_pow_neg_one` then derives the actual base-$10^k$ alternating digit-sum rule: it feeds $d \\mid 10^k - (-1)$ into Mathlib's `Nat.dvd_iff_dvd_ofDigits` (the general fact $d \\mid n \\iff d \\mid \\operatorname{ofDigits} b\\, n$ when $d \\mid b - r$) and rewrites $\\operatorname{ofDigits}(-1)$ as the alternating sum through `Nat.ofDigits_neg_one`. This is the sufficiency half — a working congruence yields a working rule.",
+    "mathContext": "$(10:\\mathbb{Z}/d)^k = -1 \\iff d \\mid 10^k + 1$. Then $n = \\operatorname{ofDigits}(10^k) \\equiv \\operatorname{ofDigits}(-1) = \\sum (-1)^i d_i \\pmod d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.dvd_iff_dvd_ofDigits",
+      "Nat.ofDigits_neg_one",
+      "ZMod.intCast_zmod_eq_zero_iff_dvd",
+      "alternating sum"
+    ],
+    "prerequisites": [
+      "casts between ℤ and ZMod d",
+      "Nat.ofDigits",
+      "divisibility of ofDigits"
+    ]
+  },
+  {
+    "id": "ann-base-iff",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 112
+    },
+    "type": "insight",
+    "title": "A Genuine Per-Base Iff via a Single Test Value",
+    "content": "`altRule_base_iff` upgrades the one-directional workhorse to a true equivalence: for $k \\ge 1$, the base-$10^k$ alternating rule holds for *all* $n$ iff $(10:\\mathbb{Z}/d)^k = -1$. The forward (necessity) direction is the clever part — it is forced by evaluating the rule at the *single* test value $n = 10^k + 1$. `digits_pow_add_one` computes its base-$10^k$ digits as $[1,1]$ (quotient 1, remainder 1), whose alternating sum is $1 - 1 = 0$. The rule then says $d \\mid (10^k+1) \\iff d \\mid 0$, and since $d \\mid 0$ always holds, $d \\mid 10^k + 1$ — exactly the congruence. So a base for which the rule works *provably* satisfies $10^k \\equiv -1$; the converse is not merely assumed.",
+    "mathContext": "Test $n = 10^k+1$: digits $[1,1]$, alternating sum $1-1=0$. Rule $\\Rightarrow d \\mid 10^k+1 \\Rightarrow 10^k \\equiv -1 \\pmod d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "necessity from one witness",
+      "Nat.digits",
+      "alternating sum",
+      "per-base equivalence"
+    ],
+    "prerequisites": [
+      "altRule_of_pow_neg_one",
+      "digit expansion of 10^k+1",
+      "List.alternatingSum"
+    ]
+  },
+  {
+    "id": "ann-order-positivity",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 144
+    },
+    "type": "technique",
+    "title": "Order Positivity and 1 ≠ −1",
+    "content": "Two supporting facts for the cyclic-group argument. `orderOf_ten_pos`: for $d \\ge 2$ coprime to 10, $\\operatorname{ord}_d(10) > 0$, because by Fermat–Euler $10^{\\varphi(d)} \\equiv 1$ so the order divides $\\varphi(d) > 0$ and cannot be 0. `one_ne_neg_one`: in $\\mathbb{Z}/d$ with $d > 2$, $1 \\neq -1$, since $1 = -1$ would give $2 \\equiv 0$, i.e. $d \\mid 2$, forcing $d \\le 2$. The latter is exactly why the characterization needs $d > 2$ — for $d = 2$ one has $1 = -1$ and the order-two distinction collapses.",
+    "mathContext": "$\\operatorname{ord}_d(10) \\mid \\varphi(d)$ by Fermat–Euler; $1 = -1$ in $\\mathbb{Z}/d \\iff d \\mid 2 \\iff d \\le 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat–Euler theorem",
+      "orderOf_dvd_of_pow_eq_one",
+      "Nat.totient",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "multiplicative order divides φ(d)",
+      "Nat.ModEq.pow_totient",
+      "ZMod.natCast_eq_zero_iff"
+    ]
+  },
+  {
+    "id": "ann-cyclic-core",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 197
+    },
+    "type": "insight",
+    "title": "The Cyclic-Group Core: −1 ∈ ⟨10⟩ iff the Order is Even",
+    "content": "`exists_pow_neg_one_iff_order` is the heart of the characterization: $-1$ is a power of 10 in $\\mathbb{Z}/d$ iff $m = \\operatorname{ord}_d(10)$ is even and $10^{m/2} = -1$. Forward: from $10^k = -1$, squaring gives $10^{2k} = 1$ so $m \\mid 2k$; but $m \\nmid k$ (else $10^k = 1 = -1$, contradicting $1 \\neq -1$). With $m \\mid 2k$ and $m \\nmid k$, $m$ must be even (if $m$ were odd it would be coprime to 2, forcing $m \\mid k$). Writing $m = 2h$, $k = hq$, the element $y = 10^h$ satisfies $y^2 = 1$ and $y^q = -1$; reducing $y^q = y^{q \\bmod 2}$ forces $q$ odd and hence $y = 10^{m/2} = -1$. Backward is immediate with $k = m/2$. This is precisely the structure theorem that a cyclic group has a unique order-two element iff its order is even.",
+    "mathContext": "$\\exists k,\\ 10^k = -1 \\iff 2 \\mid m \\text{ and } 10^{m/2} = -1$, where $m = \\operatorname{ord}_d(10)$. The order-2 element is unique in a cyclic group.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclic group order-two element",
+      "orderOf_dvd_iff_pow_eq_one",
+      "parity of the order",
+      "coprime to 2"
+    ],
+    "prerequisites": [
+      "multiplicative order properties",
+      "even/odd divisibility arguments",
+      "one_ne_neg_one"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 203,
+      "endLine": 224
+    },
+    "type": "insight",
+    "title": "Main Theorem: Sharp Solvability Criterion",
+    "content": "`altRule_exists_iff` assembles the per-base iff and the cyclic-group core into the headline result resolving the open question: for $d > 2$ coprime to 10, a power-of-10 alternating digit-sum rule exists iff $\\operatorname{ord}_d(10)$ is even and $10^{\\operatorname{ord}_d(10)/2} \\equiv -1 \\pmod d$ — and the witness base is explicitly $10^{\\operatorname{ord}_d(10)/2}$. The forward direction extracts the working exponent $k$, converts it to $10^k = -1$ via `altRule_base_iff`, and applies `exists_pow_neg_one_iff_order`. The backward direction takes $k = m/2$ (positive since $m$ is even and positive, so $m \\ge 2$) and runs the workhorse. This is the alternating counterpart to the parent's universal digit-sum theorem.",
+    "mathContext": "Rule exists $\\iff 2 \\mid \\operatorname{ord}_d(10) \\text{ and } 10^{\\operatorname{ord}_d(10)/2} \\equiv -1$; witness base $B = 10^{\\operatorname{ord}_d(10)/2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "open question resolution",
+      "witness base",
+      "altRule_base_iff",
+      "exists_pow_neg_one_iff_order"
+    ],
+    "prerequisites": [
+      "the per-base iff",
+      "the cyclic-group core",
+      "order positivity"
+    ]
+  },
+  {
+    "id": "ann-positive-instances",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 240,
+      "endLine": 256
+    },
+    "type": "context",
+    "title": "Positive Instances: 11, 7, 13",
+    "content": "Three concrete moduli where the alternating rule exists, each obtained by applying the workhorse with the relevant congruence discharged by kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool` dependency). `eleven_altRule` uses $k=1$ since $10 \\equiv -1 \\pmod{11}$ — the classic test. `seven_altRule` and `thirteen_altRule` use $k=3$ since $10^3 = 1000 \\equiv -1$ modulo both 7 and 13 (because $1001 = 7 \\cdot 11 \\cdot 13$, so $7, 13 \\mid 10^3 + 1$). These are the grouped-three-digit alternating rules for 7 and 13.",
+    "mathContext": "$10 \\equiv -1 \\pmod{11}$; $10^3 \\equiv -1 \\pmod 7$ and $\\pmod{13}$ since $1001 = 7\\cdot 11\\cdot 13$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "1001 factorization",
+      "kernel decide",
+      "divisibility by 7 and 13",
+      "three-digit grouping"
+    ],
+    "prerequisites": [
+      "altRule_of_pow_neg_one",
+      "decidable arithmetic in ZMod d"
+    ]
+  },
+  {
+    "id": "ann-negative-instances",
+    "proofId": "divisibility-rules-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 258,
+      "endLine": 274
+    },
+    "type": "context",
+    "title": "Negative Instances: 3 and 37 (Non-Universality)",
+    "content": "Two moduli that admit **no** power-of-10 alternating rule, demonstrating the sharpness of the criterion. `three_no_altRule`: $10 \\equiv 1 \\pmod 3$, so every power of 10 is $1 \\neq -1$ (here $\\operatorname{ord}_3(10) = 1$ is odd). `thirtyseven_no_altRule`: $\\operatorname{ord}_{37}(10) = 3$ is odd; since $10^3 \\equiv 1$, every power reduces to $10^{k \\bmod 3} \\in \\{1, 10, 26\\}$, none of which equals $-1 = 36$ — closed by `interval_cases` over $k \\bmod 3$ then `decide`. These contrast with the digit-sum rule, which exists for *every* modulus coprime to 10.",
+    "mathContext": "$\\operatorname{ord}_3(10)=1$ (odd): powers $=\\{1\\}$. $\\operatorname{ord}_{37}(10)=3$ (odd): powers $=\\{1,10,26\\} \\not\\ni 36 = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-universality",
+      "odd multiplicative order",
+      "interval_cases",
+      "power cycle"
+    ],
+    "prerequisites": [
+      "powers cycle with period = order",
+      "decidable arithmetic in ZMod d"
+    ]
+  }
+]

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,254 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 61
+    },
+    "type": "context",
+    "title": "AH = 2·OM_a: A Vertex–Orthocenter Segment is Twice O to the Opposite Midpoint",
+    "content": "This file gives the geometric companion to the parent's metric identity $AH^2 = 4R^2 - a^2$: the distance from a vertex to the orthocenter equals *twice* the distance from the circumcenter $O$ to the midpoint $M_a$ of the opposite side. The deep point is that the vector form $A - H = 2(O - M_a)$ is **purely affine** — it holds for any triangle with no circle/equidistance hypothesis, because both sides equal $2O - B - C$ once $H = A+B+C-2O$ and $M_a = \\tfrac{B+C}{2}$ are substituted. The metric content $OM_a = R\\cos A$ (hence $2\\,OM_a = 2R\\cos A = AH$) only enters when relating $OM_a$ to $R$ and $a$.",
+    "mathContext": "$A - H = 2(O - M_a)$, so $AH = 2\\,OM_a = 2R\\cos A$. The right triangle $O M_a B$ gives $OM_a^2 = R^2 - (a/2)^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "orthocenter",
+      "nine-point circle",
+      "Euler line",
+      "medial triangle"
+    ],
+    "prerequisites": [
+      "orthocenter H = A+B+C−2O",
+      "midpoint of a side",
+      "circumradius"
+    ]
+  },
+  {
+    "id": "ann-perp-bisector",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "Perpendicular-Bisector Identities (Linear in O)",
+    "content": "`perp_bisector_AB` and `perp_bisector_AC` state that the circumcenter lies on the perpendicular bisectors of $AB$ and $AC$, written $(B-A)\\cdot(B+A-2O)=0$. The identity is *linear* in $O$, so substituting the closed-form circumcenter (with nonzero denominator $d$ from `circumcenter_denom_ne_zero`) reduces to a `ring` identity after `field_simp`. The parent declares its equidistance facts `private`, so they are reproved locally for an independent build; a raised `maxHeartbeats` absorbs the large rational expansion.",
+    "mathContext": "$(B-A)\\cdot\\big((B+A)-2O\\big)=0$ — the chord $AB$ is perpendicular to the line from its midpoint to $O$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "circumcenter formula",
+      "field_simp",
+      "circumcenter_denom_ne_zero"
+    ],
+    "prerequisites": [
+      "perpendicular bisector of a chord",
+      "closed-form circumcenter coordinates"
+    ]
+  },
+  {
+    "id": "ann-equidistance",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 127
+    },
+    "type": "concept",
+    "title": "Circumcenter Equidistance |B−O|² = |A−O|² = |C−O|²",
+    "content": "`equidistB` and `equidistC` upgrade the perpendicular-bisector relations to the defining property of the circumcenter — equidistance from the vertices, each distance equal to $R$. The quadratic rearrangement is closed by `nlinarith` with `sq_nonneg` seeds. These are the only circle-dependent facts the file uses, and they enter exactly once: to convert the circle-free $4\\,OM_a^2$ into $4R^2 - a^2$.",
+    "mathContext": "$|B-O|^2 = |A-O|^2 = |C-O|^2 = R^2$, derived from the perpendicular-bisector identities.",
+    "significance": "key",
+    "relatedConcepts": [
+      "circumcenter equidistance",
+      "circumradius",
+      "nlinarith",
+      "perpendicular bisector"
+    ],
+    "prerequisites": [
+      "perp_bisector lemmas",
+      "expanding squared norms"
+    ]
+  },
+  {
+    "id": "ann-sq-dist2-bridge",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 136
+    },
+    "type": "technique",
+    "title": "The sq_dist2 Bridge",
+    "content": "`sq_dist2` proves $(\\operatorname{dist2} P Q)^2 = \\operatorname{dist2\\_sq} P Q$ via `Real.sq_sqrt` on the manifestly nonnegative `dist2_sq`. It is the sole point where `Real.sqrt` appears: all algebra runs in the polynomial `dist2_sq`, and only the final textbook restatements and the genuine distance identity $AH = 2\\,OM_a$ pass through this bridge.",
+    "mathContext": "$\\operatorname{dist2} P Q = \\sqrt{\\operatorname{dist2\\_sq} P Q}$, $\\operatorname{dist2\\_sq} \\ge 0$, so $(\\sqrt{\\cdot})^2 = \\operatorname{dist2\\_sq}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "squared distance",
+      "positivity"
+    ],
+    "prerequisites": [
+      "Real.sqrt and its square"
+    ]
+  },
+  {
+    "id": "ann-vector-identity",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 145,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "The Exact Affine Vector Identity A − H = 2(O − M_a)",
+    "content": "`vertexA_orthocenter_vec` (and B, C) prove the directed identity $A - H = 2(O - M_a)$ componentwise. After unfolding $H = A+B+C-2O$ and $M_a = \\tfrac{B+C}{2}$, both sides equal $2O - B - C$ and the goal closes by `Prod.ext` + `ring` on each coordinate — a *purely affine* fact needing no equidistance or circle hypothesis. Geometrically this says the segment $HA$ is parallel to $OM_a$ and exactly twice its length; it is the homothety of ratio $-2$ centred at the centroid that carries the medial triangle to the original and $O$ to $H$ (the Euler-line homothety).",
+    "mathContext": "$A - H = A - (A+B+C-2O) = 2O - B - C = 2\\!\\left(O - \\tfrac{B+C}{2}\\right) = 2(O - M_a)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler-line homothety",
+      "medial triangle",
+      "parallel segments",
+      "Prod.ext"
+    ],
+    "prerequisites": [
+      "H = A + B + C − 2O",
+      "midpoint formula",
+      "vector arithmetic"
+    ]
+  },
+  {
+    "id": "ann-squared-length",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 177,
+      "endLine": 194
+    },
+    "type": "concept",
+    "title": "Squared Lengths AH² = 4·OM_a² (Still Circle-Free)",
+    "content": "`orthocenter_vertexA_eq_four_OMa_sq` (and B, C) square the vector identity to $AH^2 = 4\\,OM_a^2$. Because the vector identity is affine, so is this — each proof is a single `ring` after `simp only` unfolds the definitions. This isolates the only genuinely circle-dependent step (converting $4\\,OM_a^2$ to $4R^2 - a^2$) into the *next* part, a clean separation of the affine and metric content.",
+    "mathContext": "$AH^2 = |A-H|^2 = |2(O-M_a)|^2 = 4|O-M_a|^2 = 4\\,OM_a^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squared distance",
+      "affine identity",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "vertexA_orthocenter_vec",
+      "squaring a scaled vector"
+    ]
+  },
+  {
+    "id": "ann-circumcenter-midpoint",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 203,
+      "endLine": 234
+    },
+    "type": "insight",
+    "title": "The Circumcenter–Midpoint Distance 4·OM_a² = 4R² − a²",
+    "content": "`circumcenter_midpoint_a_sq` is where the circle enters: since $M_a$ lies on the perpendicular bisector of $BC$, the two equidistance relations collapse $4\\,OM_a^2$ to $4R^2 - a^2$ in a single `linear_combination 2·equidistB + 2·equidistC` (the B, C versions need just one each). This is the Pythagorean relation $OM_a^2 = R^2 - (a/2)^2$ for the right triangle $O M_a B$. `circumcenter_midpoint_a_classical` restates it in textbook $R$/side form via `sq_dist2`.",
+    "mathContext": "$OM_a^2 = R^2 - (a/2)^2$: in right triangle $O M_a B$, $OB = R$, $M_a B = a/2$, $OM_a \\perp BC$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pythagorean theorem",
+      "perpendicular bisector",
+      "linear_combination",
+      "R cos A"
+    ],
+    "prerequisites": [
+      "equidistB / equidistC",
+      "midpoint on the perpendicular bisector"
+    ]
+  },
+  {
+    "id": "ann-putting-together",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 240,
+      "endLine": 275
+    },
+    "type": "concept",
+    "title": "Assembling AH = 2·OM_a as a True Distance Identity",
+    "content": "`orthocenter_vertexA_eq_four_OMa_classical` chains the affine $AH^2 = 4\\,OM_a^2$ with the metric $4\\,OM_a^2 = 4R^2 - a^2$ to re-derive the parent's $AH^2 = 4R^2 - a^2$ — an independent cross-check. Then `orthocenter_vertexA_dist_eq_two_OMa` promotes the squared identity to genuine (square-root) distances $AH = 2\\,OM_a$, using `eq_of_sq_eq_of_nonneg` with both sides nonnegative (`dist2_nonneg`) plus the `sq_dist2` bridge. This is the textbook statement in its cleanest geometric form.",
+    "mathContext": "$AH^2 = 4\\,OM_a^2$ and $AH, OM_a \\ge 0 \\Rightarrow AH = 2\\,OM_a$ (square root of a nonnegative equality).",
+    "significance": "key",
+    "relatedConcepts": [
+      "eq_of_sq_eq_of_nonneg",
+      "nonnegative square root",
+      "sq_dist2",
+      "cross-check of parent"
+    ],
+    "prerequisites": [
+      "orthocenter_vertexA_eq_four_OMa_sq",
+      "circumcenter_midpoint_a_sq",
+      "uniqueness of nonnegative square roots"
+    ]
+  },
+  {
+    "id": "ann-altitude-perp",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 284,
+      "endLine": 291
+    },
+    "type": "insight",
+    "title": "Recovering the Altitude: (A − H) · (C − B) = 0",
+    "content": "`altitude_A_perp_BC` shows $HA \\perp BC$, recovering the defining property of the altitude through $A$. Since $A - H \\parallel O - M_a$ and $O M_a$ perpendicularly bisects $BC$, the dot product $(A-H)\\cdot(C-B)$ collapses to $|B-O|^2 - |C-O|^2$, which is exactly `equidistB − equidistC = 0`. So the perpendicularity of the altitude is *equivalent* to circumcenter equidistance — a satisfying closing of the loop, discharged by one `linear_combination`.",
+    "mathContext": "$(A-H)\\cdot(C-B) = |B-O|^2 - |C-O|^2 = 0$ by equidistance; hence $HA \\perp BC$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "altitude",
+      "orthogonality",
+      "dot product",
+      "perpendicular bisector"
+    ],
+    "prerequisites": [
+      "equidistB / equidistC",
+      "dot product and perpendicularity"
+    ]
+  },
+  {
+    "id": "ann-sum-identity",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 297,
+      "endLine": 309
+    },
+    "type": "concept",
+    "title": "Sum Identity: 4(OM_a²+OM_b²+OM_c²) = 12R² − (a²+b²+c²)",
+    "content": "`circumcenter_midpoint_sum_sq` sums the three circumcenter–midpoint identities, giving $4(OM_a^2 + OM_b^2 + OM_c^2) = 12R^2 - (a^2+b^2+c^2)$. Dividing by 4 and using $AH^2 = 4\\,OM_a^2$ yields $OM_a^2 + OM_b^2 + OM_c^2 = \\tfrac14(AH^2+BH^2+CH^2)$ — the circumcenter-to-midpoints sum is a quarter of the vertex-to-orthocenter sum, a scale reflection of the Euler-line homothety of ratio 2.",
+    "mathContext": "$OM_a^2+OM_b^2+OM_c^2 = \\tfrac14(AH^2+BH^2+CH^2) = 3R^2 - \\tfrac14(a^2+b^2+c^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of squared distances",
+      "homothety ratio 2",
+      "medial triangle"
+    ],
+    "prerequisites": [
+      "circumcenter_midpoint_*_sq",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-345-example",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 319,
+      "endLine": 345
+    },
+    "type": "context",
+    "title": "Worked Example: the 3-4-5 Right Triangle",
+    "content": "The 3-4-5 right triangle makes the identity concrete. Its circumcenter $O = (3/2, 2)$ is the midpoint of the hypotenuse (Thales), which coincides with $M_a$, so $OM_a = 0 = AH/2$ — consistent with the orthocenter being the right-angle vertex $A$. For the other sides $OM_b^2 = 9/4$ (so $2\\,OM_b = 3 = BH$) and $OM_c^2 = 4$ (so $2\\,OM_c = 4 = CH$). `triangle_345_vertexB_eq_four_OMb` checks $BH^2 = 4\\,OM_b^2$ numerically ($9 = 4\\cdot\\tfrac94$).",
+    "mathContext": "$O = M_a = (3/2,2)$: $OM_a=0$, $OM_b^2=9/4 \\Rightarrow 2OM_b=3=BH$, $OM_c^2=4 \\Rightarrow 2OM_c=4=CH$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Thales' theorem",
+      "right triangle circumcenter",
+      "3-4-5 triangle",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "triangle_345 computations",
+      "hypotenuse midpoint is the circumcenter"
+    ]
+  }
+]

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,214 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "context",
+    "title": "Orthocenter–Vertex Distances: AH² = 4R² − a²",
+    "content": "This file measures the squared distances from the orthocenter $H$ to the three vertices of a triangle, the metric companions of Euler's circumcenter–orthocenter distance $OH^2 = 9R^2 - (a^2+b^2+c^2)$ proved in the sibling entry. The headline $AH^2 = 4R^2 - a^2$ is the squared, coordinate-free form of the textbook relation $AH = 2R\\cos A$: since $a = 2R\\sin A$, one has $4R^2 - a^2 = 4R^2\\cos^2 A = (2R\\cos A)^2$. Note the *opposite* side $a = BC$ controls the distance to $A$. Everything is done in O-centred coordinates and reduces to a single `linear_combination` over two circumcenter-equidistance relations.",
+    "mathContext": "$AH^2 = 4R^2 - a^2$, $BH^2 = 4R^2 - b^2$, $CH^2 = 4R^2 - c^2$. Equivalent to $AH = 2R\\cos A$ via $a = 2R\\sin A$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "orthocenter",
+      "circumradius",
+      "law of sines",
+      "Euler line"
+    ],
+    "prerequisites": [
+      "triangle geometry",
+      "circumcenter and orthocenter",
+      "AH = 2R·cos A"
+    ]
+  },
+  {
+    "id": "ann-perp-bisector",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Perpendicular-Bisector Identities (Linear in O)",
+    "content": "`perp_bisector_AB` and `perp_bisector_AC` are the algebraic engine: they state that the circumcenter $O$ lies on the perpendicular bisectors of $AB$ and $AC$, written as $(B-A)\\cdot(B+A-2O) = 0$ and the analogue for $C$. Crucially this identity is *linear* in $O$, so substituting the closed-form circumcenter fraction and clearing the denominator $d = 2\\det(\\ldots) \\neq 0$ (`circumcenter_denom_ne_zero`) reduces it to a polynomial `ring` identity. A raised `maxHeartbeats` accommodates the large rational expansion. The parent file declares its equidistance facts `private`, so they are reproved locally here for an independent build.",
+    "mathContext": "$(B-A)\\cdot\\big((B+A) - 2O\\big) = 0$ — the midpoint $\\tfrac{A+B}{2}$ to $O$ direction is perpendicular to $B-A$. Linear in $O$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "circumcenter formula",
+      "field_simp",
+      "circumcenter_denom_ne_zero"
+    ],
+    "prerequisites": [
+      "perpendicular bisector of a chord",
+      "closed-form circumcenter coordinates",
+      "ring / field_simp"
+    ]
+  },
+  {
+    "id": "ann-equidistance",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 122
+    },
+    "type": "concept",
+    "title": "Circumcenter Equidistance |B−O|² = |A−O|² = |C−O|²",
+    "content": "`equidistB` and `equidistC` upgrade the perpendicular-bisector identities to the defining property of the circumcenter: it is equidistant from the vertices, $|B-O|^2 = |A-O|^2$ and $|C-O|^2 = |A-O|^2$ (each equal to $R^2$). The step from a perpendicular-bisector relation to a squared-norm equality is a quadratic rearrangement, closed by `nlinarith` seeded with the relevant `sq_nonneg` terms. These two relations are the *only* geometric facts the rest of the file consumes — every vertex-distance identity is a `linear_combination` over them.",
+    "mathContext": "$|B-O|^2 - |A-O|^2 = (B-A)\\cdot(B+A-2O) = 0$; hence $|A-O|^2 = |B-O|^2 = |C-O|^2 = R^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "circumcenter equidistance",
+      "circumradius",
+      "nlinarith",
+      "perpendicular bisector"
+    ],
+    "prerequisites": [
+      "perp_bisector lemmas",
+      "expanding squared norms",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-sq-dist2-bridge",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 128,
+      "endLine": 131
+    },
+    "type": "technique",
+    "title": "The sq_dist2 Bridge: Keeping Algebra Polynomial",
+    "content": "`sq_dist2` proves $(\\operatorname{dist2} P Q)^2 = \\operatorname{dist2\\_sq} P Q$, where `dist2` is the metric (square-root) distance and `dist2_sq` its polynomial square. Because `dist2_sq` is manifestly nonnegative, `Real.sq_sqrt` recovers it on squaring. This one lemma is the *only* place `Real.sqrt` is touched: all the heavy vertex-distance algebra is carried out in the polynomial `dist2_sq`, and the conversion to the metric circumradius $R^2$ and side lengths $a^2$ is isolated here. This separation of concerns is what keeps `linear_combination`/`ring` applicable throughout.",
+    "mathContext": "$\\operatorname{dist2} P Q = \\sqrt{\\operatorname{dist2\\_sq} P Q}$ with $\\operatorname{dist2\\_sq} \\ge 0$, so $(\\sqrt{\\cdot})^2 = \\operatorname{dist2\\_sq}$ via `Real.sq_sqrt`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "squared distance",
+      "positivity",
+      "metric vs polynomial distance"
+    ],
+    "prerequisites": [
+      "Real.sqrt and its square",
+      "nonnegativity of squared distance"
+    ]
+  },
+  {
+    "id": "ann-vertex-dist-sq",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 164
+    },
+    "type": "insight",
+    "title": "Vertex Distances as One-Line Linear Combinations",
+    "content": "`orthocenter_vertex_A_dist_sq` (and the B, C analogues) prove the squared-distance form $AH^2 = 4|O-A|^2 - |B-C|^2$. After `simp only [dist2_sq, Triangle.orthocenter]` substitutes $H = A + B + C - 2O$, the goal becomes a polynomial identity *modulo* the equidistance defects: $AH^2 - (4R^2 - a^2) = 2(|B-O|^2 - |A-O|^2) + 2(|C-O|^2 - |A-O|^2)$. So a single `linear_combination 2·equidistB + 2·equidistC` discharges the A-version. The B- and C-versions are even cheaper — each needs only *one* equidistance relation, because in O-centred coordinates $BH^2 = |a+c|^2$ already shares one vertex norm with the target.",
+    "mathContext": "In O-coords ($a=A-O$ etc.): $AH^2 = |b+c|^2 = |b|^2+|c|^2+2b\\cdot c$ and $a^2 = |c-b|^2 = |b|^2+|c|^2-2b\\cdot c$, so $AH^2 + a^2 = 2(|b|^2+|c|^2) = 4R^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear_combination",
+      "orthocenter formula H = A+B+C−2O",
+      "Triangle.orthocenter",
+      "polynomial identity modulo hypotheses"
+    ],
+    "prerequisites": [
+      "equidistB / equidistC",
+      "H = A + B + C − 2O",
+      "linear_combination tactic"
+    ]
+  },
+  {
+    "id": "ann-classical-forms",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 170,
+      "endLine": 189
+    },
+    "type": "concept",
+    "title": "Textbook Form in R and Side Lengths",
+    "content": "`orthocenter_vertex_A_dist_classical` (and B, C) restate the identities in the classical $AH^2 = 4R^2 - a^2$ form, with $R$ the genuine circumradius and $a$ the side length. The proofs simply rewrite $R^2 = \\operatorname{dist2\\_sq}(O,A)$ and $a^2 = \\operatorname{dist2\\_sq}(B,C)$ via the `sq_dist2` bridge, then invoke the squared-distance theorem. This is the form a textbook states; pinning it to the *opposite* side ($a = BC$ for vertex $A$) is the point worth remembering.",
+    "mathContext": "$AH^2 = 4R^2 - a^2$, $BH^2 = 4R^2 - b^2$, $CH^2 = 4R^2 - c^2$. Each distance pairs with the side opposite that vertex.",
+    "significance": "key",
+    "relatedConcepts": [
+      "circumradius",
+      "side length",
+      "sq_dist2",
+      "AH = 2R cos A"
+    ],
+    "prerequisites": [
+      "orthocenter_vertex_A_dist_sq",
+      "sq_dist2 bridge"
+    ]
+  },
+  {
+    "id": "ann-sum-and-euler",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 195,
+      "endLine": 224
+    },
+    "type": "insight",
+    "title": "The Sum and the Exact 3R² Gap to Euler's Identity",
+    "content": "`orthocenter_vertex_sum_sq` adds the three identities to $AH^2 + BH^2 + CH^2 = 12R^2 - (a^2+b^2+c^2)$ (the three $4R^2$ terms combine once equidistance identifies $|O-A|^2 = |O-B|^2 = |O-C|^2$). The elegant `orthocenter_vertex_sum_eq_OH` then proves $AH^2 + BH^2 + CH^2 = OH^2 + 3R^2$ from the *same* two equidistance facts in a single `linear_combination`. Together with Euler's $OH^2 = 9R^2 - (a^2+b^2+c^2)$ this is internally consistent: $12R^2 - \\Sigma a^2 = (9R^2 - \\Sigma a^2) + 3R^2$. The $3R^2$ surplus is the precise quantitative content linking the vertex-distance sum to the circumcenter–orthocenter distance.",
+    "mathContext": "$\\sum AH^2 = 12R^2 - (a^2+b^2+c^2)$ and $\\sum AH^2 = OH^2 + 3R^2$; consistent with Euler's $OH^2 = 9R^2 - (a^2+b^2+c^2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's metric identity",
+      "circumcenter–orthocenter distance",
+      "linear_combination",
+      "sum of squared distances"
+    ],
+    "prerequisites": [
+      "vertex-distance identities",
+      "equidistB / equidistC",
+      "Euler's OH² identity"
+    ]
+  },
+  {
+    "id": "ann-diameter-bound",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 230,
+      "endLine": 236
+    },
+    "type": "concept",
+    "title": "Diameter Bound AH² ≤ 4R²",
+    "content": "`orthocenter_vertex_le_diameter_sq` records that a vertex never lies farther from the orthocenter than the diameter $2R$ of the circumcircle: $AH^2 \\le 4R^2$. This is immediate from $AH^2 = 4R^2 - a^2$ together with $a^2 \\ge 0$ (`sq_nonneg`), closed by `linarith`. Equality $AH = 2R$ holds exactly in the degenerate $a = 0$ case. This kind of positivity/bound is invisible to the purely qualitative orthocenter facts (concurrency, reflections) and only becomes available once the metric identity is in hand.",
+    "mathContext": "$AH^2 = 4R^2 - a^2 \\le 4R^2$ since $a^2 \\ge 0$; equality iff $a = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sq_nonneg",
+      "linarith",
+      "diameter of circumcircle",
+      "metric bound"
+    ],
+    "prerequisites": [
+      "orthocenter_vertex_A_dist_classical",
+      "nonnegativity of squares"
+    ]
+  },
+  {
+    "id": "ann-345-example",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 245,
+      "endLine": 270
+    },
+    "type": "context",
+    "title": "Worked Example: the 3-4-5 Right Triangle",
+    "content": "The 3-4-5 right triangle instantiates the abstract identities numerically. Its right angle sits at vertex $A = (0,0)$, which for a right triangle *is* the orthocenter — so $AH^2 = 0$, the correct (if degenerate-looking) instance of $4R^2 - a^2 = 4\\cdot\\tfrac{25}{4} - 25 = 0$ (the hypotenuse $a = 5$ equals the diameter $2R$). `triangle_345_AH_sq`, `triangle_345_vertex_A_metric`, and `triangle_345_vertex_sum` discharge these by rewriting the parent's `triangle_345_orthocenter = (0,0)`, circumradius and side values, then `norm_num`. The full vertex sum is $0 + 9 + 16 = 25 = 12R^2 - (a^2+b^2+c^2)$.",
+    "mathContext": "$R = \\tfrac{5}{2}$, $a=5,b=4,c=3$: $AH^2 = 0 = 25-25$, $BH^2 = 9$, $CH^2 = 16$; sum $25 = 12\\cdot\\tfrac{25}{4} - (25+16+9)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "right triangle orthocenter",
+      "3-4-5 triangle",
+      "norm_num",
+      "Thales' theorem"
+    ],
+    "prerequisites": [
+      "triangle_345 computations from parent",
+      "right-angle vertex is the orthocenter"
+    ]
+  }
+]


### PR DESCRIPTION
Adds the missing inline annotation layer to three gallery entries that shipped with rich meta.json but **no annotations.json**.

| Entry | Topic | Annotations |
|---|---|---|
| feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02 | Orthocenter–Vertex Distances AH²=4R²−a² | 9 |
| feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02-oq-01 | AH = 2·OM_a | 11 |
| divisibility-rules-oq-01-oq-02-oq-01 | Which moduli admit an alternating-digit-sum rule | 8 |

Each annotation covers one Lean construct group and carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All line ranges validate against the Lean source (resolver: 0 misaligned across all three). meta.json integrity fields unchanged and accurate (all verified / 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)