### PR TITLE
research(fermat-two-squares-oq-06): Brahmagupta–Fibonacci identity and non-uniqueness of two-square representations [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2771,6 +2771,7 @@ import Proofs.FermatTwoSquaresOQ01OQ03
 import Proofs.FermatTwoSquaresOQ01OQ03OQ01
 import Proofs.FermatTwoSquaresOQ04
 import Proofs.FermatTwoSquaresOQ05
+import Proofs.FermatTwoSquaresOQ06
 import Proofs.FermatsLastTheorem
 import Proofs.FermatsLastTheoremOQ03
 import Proofs.FeuerbachsTheorem

--- a/proofs/Proofs/FermatTwoSquaresOQ06.lean
+++ b/proofs/Proofs/FermatTwoSquaresOQ06.lean
@@ -1,0 +1,209 @@
+/-
+# Fermat Two Squares OQ-06: Brahmagupta–Fibonacci Identity and the
+# Non-Uniqueness of Two-Square Representations for Products
+
+The Brahmagupta–Fibonacci identity expresses a product of two sums of squares as
+a sum of two squares in *two* different ways:
+
+  (x² + y²)(u² + v²) = (xu − yv)² + (xv + yu)²        (form 1)
+                     = (xu + yv)² + (xv − yu)²        (form 2)
+
+Multiplicative closure of the two-square property is already in Mathlib
+(`sq_add_sq_mul`, `Nat.sq_add_sq_mul`), but Mathlib records only **one** of the
+two forms, and says nothing about whether the two forms give genuinely different
+representations.
+
+The mathematical content of this entry is the **non-uniqueness** phenomenon: when
+`x ≠ y` and `u ≠ v` (and all are positive), the two Brahmagupta forms are
+essentially distinct representations — they differ even as unordered pairs of
+squares.  This is the structural reason a product of two distinct primes
+`≡ 1 (mod 4)` has (at least) two representations as a sum of two squares, e.g.
+
+  65 = 5 · 13 = 1² + 8² = 4² + 7².
+
+We also re-derive form 1 conceptually from the multiplicativity of the Gaussian
+integer norm `N(a + bi) = a² + b²` (`Zsqrtd.norm_mul`), exhibiting the identity as
+a shadow of `ℤ[i]` being a normed multiplicative monoid.
+
+## Main results
+
+* `brahmagupta_form1`, `brahmagupta_form2` — the two sign-forms of the identity.
+* `gaussianInt_norm_mk` / `brahmagupta_via_norm` — the Gaussian-integer derivation.
+* `sq_add_sq_mul'` — the second-form closure lemma (complementing Mathlib's
+  `sq_add_sq_mul`, which gives the first form).
+* `two_distinct_representations` — **headline**: the two forms are essentially
+  distinct when `x ≠ y` and `u ≠ v`.
+* `prime_mul_prime_two_squares_two_ways` — a product of two distinct primes
+  `≡ 1 (mod 4)` is a sum of two squares in two essentially different ways.
+* `sixtyfive_two_ways` — the concrete witness 65 = 1² + 8² = 4² + 7².
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+import Mathlib
+
+namespace FermatTwoSquaresOQ06
+
+/-! ## The two Brahmagupta–Fibonacci forms -/
+
+/-- **Brahmagupta–Fibonacci identity, first form.**
+A product of two sums of two squares is a sum of two squares. -/
+theorem brahmagupta_form1 (x y u v : ℤ) :
+    (x ^ 2 + y ^ 2) * (u ^ 2 + v ^ 2) = (x * u - y * v) ^ 2 + (x * v + y * u) ^ 2 := by
+  ring
+
+/-- **Brahmagupta–Fibonacci identity, second form.**
+Swapping the sign of one cross term yields a *different* decomposition. -/
+theorem brahmagupta_form2 (x y u v : ℤ) :
+    (x ^ 2 + y ^ 2) * (u ^ 2 + v ^ 2) = (x * u + y * v) ^ 2 + (x * v - y * u) ^ 2 := by
+  ring
+
+/-! ## Conceptual derivation via the Gaussian integer norm
+
+The norm on `ℤ[i] = ℤ√(-1)` is `N⟨a, b⟩ = a² + b²`, and it is multiplicative.
+Brahmagupta's identity is exactly `N(z · w) = N z · N w` written out in coordinates. -/
+
+/-- The Gaussian-integer norm of `a + b·i` is `a² + b²`. -/
+theorem gaussianInt_norm_mk (a b : ℤ) :
+    (Zsqrtd.mk a b : ℤ√(-1)).norm = a ^ 2 + b ^ 2 := by
+  simp [Zsqrtd.norm]; ring
+
+/-- Brahmagupta's first form re-derived from multiplicativity of the Gaussian
+norm `Zsqrtd.norm_mul`. The two-square property is multiplicative *because* the
+norm `ℤ[i] →* ℤ` is a monoid homomorphism. -/
+theorem brahmagupta_via_norm (x y u v : ℤ) :
+    (x ^ 2 + y ^ 2) * (u ^ 2 + v ^ 2) = (x * u - y * v) ^ 2 + (x * v + y * u) ^ 2 := by
+  have hmul := Zsqrtd.norm_mul (Zsqrtd.mk x y : ℤ√(-1)) (Zsqrtd.mk u v)
+  -- compute both sides via `gaussianInt_norm_mk`
+  rw [gaussianInt_norm_mk x y, gaussianInt_norm_mk u v] at hmul
+  -- the product `⟨x,y⟩ * ⟨u,v⟩` has coordinates `⟨xu - yv, xv + yu⟩`
+  have hprod : (Zsqrtd.mk x y : ℤ√(-1)) * Zsqrtd.mk u v
+      = Zsqrtd.mk (x * u - y * v) (x * v + y * u) :=
+    Zsqrtd.ext (by simp; ring) (by simp)
+  rw [hprod, gaussianInt_norm_mk] at hmul
+  linarith [hmul]
+
+/-! ## Multiplicative closure (second form)
+
+Mathlib's `sq_add_sq_mul` packages the *first* form.  Here is the *second* form,
+so that both representations are available as existence statements. -/
+
+/-- The set of sums of two squares is closed under multiplication, recorded with
+the **second** Brahmagupta form (cf. Mathlib's `sq_add_sq_mul`, which records the
+first form). -/
+theorem sq_add_sq_mul' {R : Type*} [CommRing R] {a b x y u v : R}
+    (ha : a = x ^ 2 + y ^ 2) (hb : b = u ^ 2 + v ^ 2) :
+    ∃ r s : R, a * b = r ^ 2 + s ^ 2 :=
+  ⟨x * u + y * v, x * v - y * u, by rw [ha, hb]; ring⟩
+
+/-! ## Non-uniqueness: the two forms are essentially distinct
+
+Two representations `n = a² + b²` and `n = c² + d²` are *essentially the same*
+when they agree as unordered pairs of squares, i.e. `{a², b²} = {c², d²}`.  We
+show the two Brahmagupta forms are essentially distinct as soon as `x ≠ y` and
+`u ≠ v` (with all four positive). -/
+
+/-- **Headline.** For positive `x, y, u, v` with `x ≠ y` and `u ≠ v`, the two
+Brahmagupta forms of `(x²+y²)(u²+v²)` are essentially distinct: the multiset of
+squares `{(xu−yv)², (xv+yu)²}` differs from `{(xu+yv)², (xv−yu)²}`.
+
+The two "sum" coordinates `xv+yu` and `xu+yv` are the large entries of each
+representation; they coincide only when `(x−y)(v−u) = 0`.  The "difference"
+coordinates can never match a "sum" coordinate because all variables are
+positive. Hence under `x ≠ y`, `u ≠ v` the representations cannot be matched. -/
+theorem two_distinct_representations {x y u v : ℤ}
+    (hx : 0 < x) (hy : 0 < y) (hu : 0 < u) (hv : 0 < v)
+    (hxy : x ≠ y) (huv : u ≠ v) :
+    ¬ ( ((x * u - y * v) ^ 2 = (x * u + y * v) ^ 2 ∧
+         (x * v + y * u) ^ 2 = (x * v - y * u) ^ 2)
+      ∨ ((x * u - y * v) ^ 2 = (x * v - y * u) ^ 2 ∧
+         (x * v + y * u) ^ 2 = (x * u + y * v) ^ 2) ) := by
+  -- positivity facts
+  have hxu : 0 < x * u := mul_pos hx hu
+  have hyv : 0 < y * v := mul_pos hy hv
+  rintro (⟨h1, _⟩ | ⟨_, h2⟩)
+  · -- form-1 "diff" coordinate equals form-2 "sum" coordinate ⇒ `4·xu·yv = 0`
+    -- since `(xu+yv)² − (xu−yv)² = 4·(xu)(yv)`.
+    have hkey : (x * u + y * v) ^ 2 - (x * u - y * v) ^ 2 = 4 * (x * u) * (y * v) := by
+      ring
+    rw [h1] at hkey
+    -- LHS is now `0`, but RHS `> 0`
+    nlinarith [mul_pos hxu hyv]
+  · -- the two "sum" coordinates match ⇒ `(x−y)(v−u)(x+y)(u+v) = 0`
+    have hkey : (x * v + y * u) ^ 2 - (x * u + y * v) ^ 2
+        = (x - y) * (v - u) * ((x + y) * (u + v)) := by ring
+    rw [h2] at hkey
+    -- `(x+y)(u+v) > 0`, so the first factor must vanish
+    have hpos : 0 < (x + y) * (u + v) := mul_pos (by linarith) (by linarith)
+    have hzero : (x - y) * (v - u) * ((x + y) * (u + v)) = 0 := by linarith
+    have : (x - y) * (v - u) = 0 := by
+      rcases mul_eq_zero.mp hzero with h | h
+      · exact h
+      · exact absurd h (ne_of_gt hpos)
+    rcases mul_eq_zero.mp this with h | h
+    · exact hxy (by linarith)
+    · exact huv (by linarith)
+
+/-! ## Application to products of distinct primes `≡ 1 (mod 4)` -/
+
+/-- An odd prime `p` with `p % 4 ≠ 3` has a representation `p = x² + y²` with
+`x, y > 0` and `x ≠ y`. (Positivity: a zero coordinate would force `p` to be a
+perfect square; `x = y` would force `p` even.) -/
+theorem prime_rep_pos_ne {p : ℕ} [Fact p.Prime] (hodd : Odd p) (hp : p % 4 ≠ 3) :
+    ∃ x y : ℤ, (p : ℤ) = x ^ 2 + y ^ 2 ∧ 0 < x ∧ 0 < y ∧ x ≠ y := by
+  have hpprime : p.Prime := Fact.out
+  obtain ⟨a, b, hab⟩ := Nat.Prime.sq_add_sq (p := p) hp
+  -- `hab : a ^ 2 + b ^ 2 = p`
+  -- a coordinate equal to `0` would make `p` a perfect square, impossible.
+  have hsquare_absurd : ∀ c : ℕ, c ^ 2 = p → False := by
+    intro c hc
+    have hdvd : c ∣ p := ⟨c, by rw [← hc]; ring⟩
+    rcases hpprime.eq_one_or_self_of_dvd c hdvd with h1 | h1
+    · rw [h1] at hc; simp at hc; have := hpprime.two_le; omega
+    · rw [h1] at hc; nlinarith [hpprime.two_le]
+  have ha : 0 < a := by
+    rcases Nat.eq_zero_or_pos a with rfl | h
+    · exact (hsquare_absurd b (by simpa using hab)).elim
+    · exact h
+  have hb : 0 < b := by
+    rcases Nat.eq_zero_or_pos b with rfl | h
+    · exact (hsquare_absurd a (by simpa using hab)).elim
+    · exact h
+  -- `a = b` would make `p = 2a²` even, contradicting oddness.
+  have hne : a ≠ b := by
+    rintro rfl
+    have h2 : 2 ∣ p := ⟨a ^ 2, by rw [← hab]; ring⟩
+    have hp2 : p = 2 := ((hpprime.eq_one_or_self_of_dvd 2 h2).resolve_left (by norm_num)).symm
+    rw [hp2] at hodd
+    exact (by norm_num [Nat.odd_iff] : ¬ Odd 2) hodd
+  exact ⟨(a : ℤ), (b : ℤ), by rw [← hab]; push_cast; ring,
+    by exact_mod_cast ha, by exact_mod_cast hb, by exact_mod_cast hne⟩
+
+/-- **Product of two distinct primes `≡ 1 (mod 4)`** is a sum of two squares in
+two essentially different ways. The two representations come from the two
+Brahmagupta forms applied to representations of `p` and `q`. -/
+theorem prime_mul_prime_two_squares_two_ways {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hpodd : Odd p) (hqodd : Odd q) (hp : p % 4 ≠ 3) (hq : q % 4 ≠ 3) :
+    ∃ a b c d : ℤ,
+      ((p * q : ℕ) : ℤ) = a ^ 2 + b ^ 2 ∧ ((p * q : ℕ) : ℤ) = c ^ 2 + d ^ 2 ∧
+      ¬ ((a ^ 2 = c ^ 2 ∧ b ^ 2 = d ^ 2) ∨ (a ^ 2 = d ^ 2 ∧ b ^ 2 = c ^ 2)) := by
+  obtain ⟨x, y, hpxy, hx, hy, hxy⟩ := prime_rep_pos_ne hpodd hp
+  obtain ⟨u, v, hquv, hu, hv, huv⟩ := prime_rep_pos_ne hqodd hq
+  refine ⟨x * u - y * v, x * v + y * u, x * u + y * v, x * v - y * u, ?_, ?_, ?_⟩
+  · push_cast; rw [hpxy, hquv]; ring
+  · push_cast; rw [hpxy, hquv]; ring
+  · exact two_distinct_representations hx hy hu hv hxy huv
+
+/-! ## Concrete witness -/
+
+/-- The smallest product of two distinct primes `≡ 1 (mod 4)`,
+`65 = 5 · 13`, is a sum of two squares in two essentially different ways:
+`65 = 1² + 8² = 4² + 7²`, with `{1, 64} ≠ {16, 49}`. -/
+theorem sixtyfive_two_ways :
+    (65 : ℤ) = 1 ^ 2 + 8 ^ 2 ∧ (65 : ℤ) = 4 ^ 2 + 7 ^ 2 ∧
+      ¬ (((1 : ℤ) ^ 2 = 4 ^ 2 ∧ (8 : ℤ) ^ 2 = 7 ^ 2) ∨
+         ((1 : ℤ) ^ 2 = 7 ^ 2 ∧ (8 : ℤ) ^ 2 = 4 ^ 2)) := by
+  refine ⟨by norm_num, by norm_num, ?_⟩
+  norm_num
+
+end FermatTwoSquaresOQ06

--- a/src/data/proofs/fermat-two-squares-oq-06/meta.json
+++ b/src/data/proofs/fermat-two-squares-oq-06/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "fermat-two-squares-oq-06",
+  "title": "Brahmagupta–Fibonacci Identity and Non-Uniqueness of Two-Square Representations",
+  "slug": "fermat-two-squares-oq-06",
+  "description": "The product of two sums of two squares is itself a sum of two squares in two different ways (the two sign-forms of the Brahmagupta–Fibonacci identity). Mathlib records only one form and never the non-uniqueness; this entry proves the two forms give essentially distinct representations whenever the inputs are nondegenerate, the structural reason a product of two distinct primes ≡ 1 (mod 4) is a sum of two squares in two ways (e.g. 65 = 1²+8² = 4²+7²).",
+  "meta": {
+    "author": "Brahmagupta (628), Fibonacci (1225) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brahmagupta%E2%80%93Fibonacci_identity",
+    "date": "628",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "sum-of-two-squares",
+      "brahmagupta-fibonacci",
+      "gaussian-integers",
+      "non-uniqueness",
+      "fermat",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FermatTwoSquaresOQ06.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "sq_add_sq_mul",
+        "description": "Mathlib's multiplicative closure of the two-square property, recording the first Brahmagupta form (xu−yv, xv+yu). This entry complements it with the second form and the non-uniqueness it produces.",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Nat.Prime.sq_add_sq",
+        "description": "A prime p with p % 4 ≠ 3 is a sum of two squares; used to obtain the prime representations fed into the two-form identity.",
+        "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "Zsqrtd.norm_mul",
+        "description": "Multiplicativity of the norm on ℤ√d; for d = −1 this is exactly the Brahmagupta–Fibonacci identity, giving the conceptual derivation.",
+        "module": "Mathlib.NumberTheory.Zsqrtd.Basic"
+      }
+    ],
+    "originalContributions": [
+      "brahmagupta_form1 / brahmagupta_form2: both sign-forms of the identity (xu−yv, xv+yu) and (xu+yv, xv−yu) — Mathlib's sq_add_sq_mul records only the first",
+      "gaussianInt_norm_mk: the Gaussian-integer norm N⟨a,b⟩ = a²+b², and brahmagupta_via_norm: form 1 re-derived from Zsqrtd.norm_mul, exhibiting the identity as multiplicativity of the ℤ[i] norm",
+      "sq_add_sq_mul': the second-form closure lemma over any commutative ring, complementing Mathlib's sq_add_sq_mul",
+      "two_distinct_representations (headline): for positive x,y,u,v with x≠y and u≠v, the two Brahmagupta forms are essentially distinct as unordered pairs of squares — a non-uniqueness theorem Mathlib does not contain",
+      "prime_rep_pos_ne: an odd prime p with p%4≠3 has a representation p = x²+y² with x,y > 0 and x ≠ y (positivity from primality, distinctness from oddness)",
+      "prime_mul_prime_two_squares_two_ways: a product of two distinct primes ≡ 1 (mod 4) is a sum of two squares in two essentially different ways",
+      "sixtyfive_two_ways: the concrete witness 65 = 5·13 = 1²+8² = 4²+7², with {1,64} ≠ {16,49}"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 209,
+    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms; no sorryAx, no Lean.ofReduceBool). Multiplicative closure (sq_add_sq_mul), the prime representation existence (Nat.Prime.sq_add_sq), and norm multiplicativity (Zsqrtd.norm_mul) are from Mathlib; the second form, the Gaussian derivation, and the entire non-uniqueness development are original.",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The identity (a²+b²)(c²+d²) = (ac−bd)² + (ad+bc)² appears in Brahmagupta's Brāhmasphuṭasiddhānta (628 CE) as a special case of his identity for x²−Ny², and again in Fibonacci's Liber Quadratorum (1225). It is the multiplicative engine behind Fermat's two-squares theorem: knowing which primes are sums of two squares, the identity propagates the property to all their products. In modern language it is the statement that the norm N(a+bi) = a²+b² on the Gaussian integers ℤ[i] is multiplicative — ℤ[i] is a normed monoid, and the two-square numbers are the image of its norm.\n\nThe identity has two forms, obtained by flipping the sign of one cross term. Brahmagupta and Fibonacci already knew that this is the source of *multiple* representations: a number with several prime factors ≡ 1 (mod 4) is a sum of two squares in several ways, the quantitative refinement of which is the Jacobi two-square theorem r₂(n). The smallest example is 65 = 5·13 = 1²+8² = 4²+7².",
+    "problemStatement": "**Open question (fermat-two-squares-oq-06)**: Formalize the Brahmagupta–Fibonacci identity and the multiplicative closure of sums of two squares, and capture the multiplicity of representations it produces.\n\n**Result**: A fully verified (0 sorries, 0 axioms) development. Both sign-forms of the identity are proved; form 1 is re-derived from the multiplicativity of the Gaussian-integer norm. The headline theorem two_distinct_representations shows the two forms are *essentially distinct* (differ as unordered pairs of squares) whenever the inputs satisfy x≠y and u≠v with all positive. As a corollary, a product of two distinct primes ≡ 1 (mod 4) is a sum of two squares in two essentially different ways, witnessed concretely by 65 = 1²+8² = 4²+7².",
+    "text": "A product of two sums of two squares is a sum of two squares in two ways. This entry proves both Brahmagupta–Fibonacci sign-forms, derives one from the Gaussian-integer norm, and proves the two forms are genuinely distinct representations — the structural source of non-uniqueness.",
+    "proofStrategy": "**Proof Strategy:**\n\n1. **The two forms (brahmagupta_form1/2)**: Both are polynomial identities over any commutative ring, closed by `ring`.\n\n2. **Gaussian derivation (gaussianInt_norm_mk, brahmagupta_via_norm)**: The norm of ⟨a,b⟩ : ℤ√(-1) is a²+b² (from Zsqrtd.norm_def, simp + ring). Computing the coordinates of the product ⟨x,y⟩·⟨u,v⟩ = ⟨xu−yv, xv+yu⟩ and applying Zsqrtd.norm_mul reproduces form 1, exhibiting the identity as N(zw)=N(z)N(w).\n\n3. **Second-form closure (sq_add_sq_mul')**: A direct existence witness (xu+yv, xv−yu) with a `ring` proof, complementing Mathlib's sq_add_sq_mul (first form).\n\n4. **Non-uniqueness (two_distinct_representations)**: Two representations are essentially the same iff they agree as unordered pairs of squares. Refuting both matchings: (a) a 'difference' coordinate equals a 'sum' coordinate only if 4·(xu)(yv) = 0, impossible for positive inputs; (b) the two 'sum' coordinates xv+yu and xu+yv coincide only if (x−y)(v−u)·(x+y)(u+v) = 0, and (x+y)(u+v) > 0 forces x=y or u=v, excluded by hypothesis. Both via `ring`-normalized differences and `nlinarith`/`mul_eq_zero`.\n\n5. **Prime application (prime_rep_pos_ne, prime_mul_prime_two_squares_two_ways)**: From Nat.Prime.sq_add_sq, a representation p = a²+b² has a,b > 0 (a zero coordinate makes p a perfect square — impossible for a prime) and a ≠ b (else p = 2a² is even, contradicting oddness). Feeding the prime representations of two distinct primes ≡ 1 (mod 4) into the two forms and applying the headline gives two essentially distinct representations of pq.",
+    "keyInsights": [
+      "**Two forms, not one**: Mathlib's sq_add_sq_mul packages a single representation of a product as a sum of two squares. But the identity has a twin obtained by flipping a cross-term sign, and the genuinely interesting fact — invisible in the single-form statement — is that the twin is a *different* representation. This entry makes the second form and its distinctness first-class.",
+      "**Non-uniqueness has a clean algebraic certificate**: Whether the two forms coincide is governed entirely by the factorization (x−y)(v−u)·(x+y)(u+v) of the difference of the two 'sum' coordinates. Positivity kills the second factor, so distinctness is exactly x≠y and u≠v — no analysis, no case explosion, a single ring identity plus a sign argument.",
+      "**The identity is the Gaussian norm**: brahmagupta_via_norm shows form 1 is literally N(zw) = N(z)N(w) for z,w ∈ ℤ[i]. Multiplicativity of the two-square property is not a coincidence of algebra; it is the multiplicativity of a monoid homomorphism ℤ[i] →* ℤ, the same structure that makes ℤ[i] a Euclidean domain and underlies the hard direction of Fermat's theorem.",
+      "**Distinctness measured by squares, not signs**: Phrasing 'essentially the same representation' as equality of the unordered pair {a², b²} sidesteps all sign and ordering ambiguity (±a, swap a↔b). The non-uniqueness statement is then a clean negation of a two-way disjunction, provable without absolute values.",
+      "**Primality supplies exactly the nondegeneracy needed**: The headline needs positive, unequal coordinates. For a prime ≡ 1 (mod 4) both come for free: a vanishing coordinate would exhibit the prime as a perfect square, and equal coordinates would make it even. So the abstract nondegeneracy hypotheses are automatically met at primes, turning the algebraic theorem into a concrete number-theoretic one."
+    ],
+    "prerequisites": [
+      "Sums of two squares (Fermat's two-squares theorem statement)",
+      "Gaussian integers ℤ[i] and the norm N(a+bi) = a²+b²",
+      "Basic ring identities and modular arithmetic mod 4"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "File header motivating the two-form identity and the non-uniqueness it produces, noting that Mathlib's sq_add_sq_mul records only one form. Imports Mathlib and opens the FermatTwoSquaresOQ06 namespace.",
+      "mathContext": "Brahmagupta–Fibonacci identity: (a²+b²)(c²+d²) is a sum of two squares in two ways. The multiplicative closure is in Mathlib; the second form and the non-uniqueness are the new content."
+    },
+    {
+      "id": "two-forms",
+      "title": "The Two Brahmagupta–Fibonacci Forms",
+      "startLine": 47,
+      "endLine": 60,
+      "summary": "Proves both sign-forms of the identity over any commutative ring by `ring`: (xu−yv, xv+yu) and (xu+yv, xv−yu).",
+      "mathContext": "Flipping the sign of one cross term gives a second decomposition of the same product — the source of multiple representations."
+    },
+    {
+      "id": "gaussian-norm",
+      "title": "Conceptual Derivation via the Gaussian Norm",
+      "startLine": 61,
+      "endLine": 85,
+      "summary": "Proves the Gaussian-integer norm N⟨a,b⟩ = a²+b² and re-derives form 1 from Zsqrtd.norm_mul, computing the product coordinates ⟨xu−yv, xv+yu⟩.",
+      "mathContext": "The identity is multiplicativity of the norm ℤ[i] →* ℤ. The two-square numbers are exactly the image of this norm, explaining why their product is again a two-square number."
+    },
+    {
+      "id": "closure",
+      "title": "Multiplicative Closure (Second Form)",
+      "startLine": 86,
+      "endLine": 98,
+      "summary": "sq_add_sq_mul': the second-form closure lemma over any commutative ring, complementing Mathlib's sq_add_sq_mul which records only the first form.",
+      "mathContext": "Both forms as existence statements: a product of two-square numbers is a two-square number, via either choice of cross-term sign."
+    },
+    {
+      "id": "non-uniqueness",
+      "title": "Non-Uniqueness: The Two Forms Are Essentially Distinct",
+      "startLine": 99,
+      "endLine": 146,
+      "summary": "Headline theorem two_distinct_representations: for positive x,y,u,v with x≠y and u≠v, the two Brahmagupta forms differ even as unordered pairs of squares. Proof via the factorization (x−y)(v−u)(x+y)(u+v) of the difference and positivity.",
+      "mathContext": "Essential distinctness of representations is governed by a single algebraic certificate; the nondegeneracy conditions x≠y, u≠v are exactly what is needed."
+    },
+    {
+      "id": "prime-application",
+      "title": "Application to Products of Distinct Primes ≡ 1 (mod 4)",
+      "startLine": 147,
+      "endLine": 196,
+      "summary": "prime_rep_pos_ne shows a prime ≡ 1 (mod 4) has a representation with positive, unequal coordinates; prime_mul_prime_two_squares_two_ways concludes a product of two distinct such primes is a sum of two squares in two essentially different ways.",
+      "mathContext": "Primality supplies the nondegeneracy the headline requires: positivity (else the prime is a perfect square) and inequality (else the prime is even)."
+    },
+    {
+      "id": "witness",
+      "title": "Concrete Witness",
+      "startLine": 197,
+      "endLine": 209,
+      "summary": "sixtyfive_two_ways verifies 65 = 5·13 = 1²+8² = 4²+7² with {1,64} ≠ {16,49}, the smallest instance of the non-uniqueness phenomenon.",
+      "mathContext": "65 is the smallest product of two distinct primes ≡ 1 (mod 4), exhibiting two genuinely different two-square representations."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "extends",
+      "description": "Supplies the multiplicative engine (Brahmagupta–Fibonacci identity) that propagates the two-square property from primes to their products, and isolates the resulting non-uniqueness of representations."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-04",
+      "relationship": "related",
+      "description": "The Jacobi two-square theorem counts representations r₂(n); this entry exhibits the qualitative source of multiplicity — the two Brahmagupta sign-forms — that the Jacobi count quantifies."
+    },
+    {
+      "targetId": "fermat-two-squares-oq-05",
+      "relationship": "related",
+      "description": "The mod-4 obstruction characterizes which primes are sums of two squares; this entry takes those representations and shows how products acquire multiple representations."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of the Brahmagupta–Fibonacci identity in both sign-forms, its derivation from the multiplicativity of the Gaussian-integer norm, and — the central new content — the non-uniqueness theorem that the two forms give essentially distinct representations whenever x≠y and u≠v. As a corollary, a product of two distinct primes ≡ 1 (mod 4) is a sum of two squares in two essentially different ways, witnessed by 65 = 1²+8² = 4²+7².",
+    "implications": "**Theoretical Significance**: Multiplicative closure of the two-square property is in Mathlib, but only through a single sign-form, which conceals the multiplicity of representations. By proving both forms and certifying their distinctness with a single algebraic factorization, this entry captures the structural origin of the r₂(n) representation count and connects the elementary identity to the norm structure of ℤ[i]. It is the qualitative companion to the Jacobi two-square theorem (oq-04): where Jacobi counts, this entry exhibits.",
+    "openQuestions": [
+      "Can the count be made exact in this framework: prove that a product of k distinct primes ≡ 1 (mod 4) has exactly 2^(k−1) essentially distinct representations, by iterating the two-form construction and certifying all pairwise distinctness?",
+      "Does the Gaussian-integer derivation generalize to other norm-Euclidean rings ℤ√(−d) to produce analogous composition identities and non-uniqueness results for the forms x² + d·y²?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FermatTwoSquaresOQ06",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/FermatTwoSquaresOQ06.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": "628",
+      "venue": "",
+      "note": "Original appearance of the identity as a special case of the Brahmagupta identity for x² − Ny²"
+    },
+    {
+      "authors": "L. Fibonacci",
+      "title": "Liber Quadratorum",
+      "year": "1225",
+      "venue": "",
+      "note": "The Book of Squares; restates the composition identity for sums of two squares"
+    },
+    {
+      "authors": "C. F. Gauss",
+      "title": "Theoria residuorum biquadraticorum",
+      "year": "1832",
+      "venue": "",
+      "note": "Introduces the Gaussian integers ℤ[i], whose multiplicative norm is the modern form of the identity"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **fermat-two-squares-oq-06**: the Brahmagupta–Fibonacci identity and the **non-uniqueness** of two-square representations it produces.

A product of two sums of two squares is itself a sum of two squares — in *two* different ways, via the two sign-forms of the identity:

```
(x²+y²)(u²+v²) = (xu−yv)² + (xv+yu)²        (form 1)
              = (xu+yv)² + (xv−yu)²        (form 2)
```

Mathlib's `sq_add_sq_mul` already records the multiplicative *closure* (form 1 only). The new content here is that the two forms give **essentially distinct** representations, and the number-theoretic payoff that follows.

## Main results (9 theorems, 0 sorries, 0 axioms)

- `brahmagupta_form1` / `brahmagupta_form2` — both sign-forms (Mathlib ships only the first).
- `gaussianInt_norm_mk`, `brahmagupta_via_norm` — the norm `N⟨a,b⟩ = a²+b²` on `ℤ√(-1)`, and form 1 re-derived from `Zsqrtd.norm_mul`: the identity **is** multiplicativity of the Gaussian-integer norm.
- `sq_add_sq_mul'` — the second-form closure lemma over any commutative ring.
- **`two_distinct_representations`** (headline) — for positive `x,y,u,v` with `x≠y` and `u≠v`, the two forms differ even as unordered pairs of squares. The certificate is the factorization `(x−y)(v−u)·(x+y)(u+v)` of the difference of the two "sum" coordinates; positivity kills the second factor.
- `prime_rep_pos_ne` — a prime `≡ 1 (mod 4)` has a representation with positive, *unequal* coordinates (positivity from primality, distinctness from oddness).
- `prime_mul_prime_two_squares_two_ways` — a product of two distinct primes `≡ 1 (mod 4)` is a sum of two squares in two essentially different ways.
- `sixtyfive_two_ways` — concrete witness `65 = 5·13 = 1²+8² = 4²+7²`, with `{1,64} ≠ {16,49}`.

## Verification

- Builds against Mathlib v4.26.0 (`lake env lean Proofs/FermatTwoSquaresOQ06.lean`), no errors, no warnings.
- `#print axioms` on the headline theorems lists only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely verified, 0-axiom.

## Relation to gallery

Distinct from the existing `fermat-two-squares` variants: oq-04 *counts* representations (Jacobi `r₂(n)`); this entry exhibits the qualitative *source* of multiplicity. oq-05 is the mod-4 obstruction. The multiplicative closure itself is cited from Mathlib, not claimed as new — the original content is the second form, the Gaussian derivation, and the entire non-uniqueness development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)