### PR TITLE
Enrich 2-adic Valuation of the Catalan Number (kummer-theorem-oq-04-oq-02)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-kc0402-header",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 3, "endLine": 67 },
+    "type": "concept",
+    "title": "Goal: closed form for v₂(Cₙ) and the odd Catalan numbers",
+    "content": "The parent (KummerTheoremOQ04) computes v₂(C(2n,n)) = s₂(n), the binary popcount. This entry answers the natural follow-up for the Catalan number Cₙ = C(2n,n)/(n+1): the boxed answer is v₂(Cₙ) = s₂(n+1) − 1. The derivation takes v₂ of Catalan's identity (n+1)·Cₙ = C(2n,n) and eliminates v₂(n+1) using a binary carry identity. The sharp payoff: Cₙ is odd ⟺ n+1 is a power of two ⟺ n = 2^k − 1, recovering the classical odd-Catalan indices 0,1,3,7,15,…. Mathlib has Catalan's identity, Legendre's formula, and padicValNat.mul, but not the Catalan valuation, the carry identity, or the oddness characterisation.",
+    "mathContext": "$v_2(C_n) = s_2(n+1) - 1$, and $C_n$ odd $\\iff n = 2^k - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's theorem", "Catalan numbers", "2-adic valuation", "binary digit sum (popcount)", "central binomial coefficient"],
+    "prerequisites": ["p-adic valuation", "Catalan numbers", "Legendre's formula"]
+  },
+  {
+    "id": "ann-kc0402-digit-infra",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 73, "endLine": 143 },
+    "type": "definition",
+    "title": "Reusable digit-sum infrastructure",
+    "content": "Four self-contained lemmas (re-derived from the parent so the file imports only Mathlib) translate the problem into pure popcount arithmetic: sum_digits_two_mul (s₂(2n) = s₂(n), doubling invariance), sum_digits_two_pos (s₂(n) > 0 for n > 0), sum_digits_two_pow (s₂(2^k) = 1), and the strong-induction popcount characterisation sum_digits_two_eq_one_iff (s₂(n) = 1 ⟺ ∃k, n = 2^k). Capping this, padicValNat_two_centralBinom re-derives the parent headline v₂(C(2n,n)) = s₂(n) from Kummer's digit-sum identity specialised to the diagonal.",
+    "mathContext": "$s_2(2n) = s_2(n)$, $s_2(2^k) = 1$, $s_2(n) = 1 \\iff n = 2^k$, and $v_2\\binom{2n}{n} = s_2(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.digits", "popcount", "Nat.strongRecOn", "sub_one_mul_padicValNat_choose_eq_sub_sum_digits", "doubling invariance"],
+    "prerequisites": ["binary representations", "strong induction", "Kummer's digit-sum identity"]
+  },
+  {
+    "id": "ann-kc0402-carry",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 145, "endLine": 168 },
+    "type": "technique",
+    "title": "The binary carry identity (the crux)",
+    "content": "digit_sum_succ_carry is the only genuinely new analytic ingredient: s₂(n) + 1 = s₂(n+1) + v₂(n+1). Rather than reasoning about bit patterns directly, it applies Legendre's formula v₂(m!) = m − s₂(m) at m = n and m = n+1, combines them with the factorial step v₂((n+1)!) = v₂(n+1) + v₂(n!) (from (n+1)! = (n+1)·n! and padicValNat.mul), adds the bounds s₂ ≤ m so the ℕ subtractions behave, and discharges the whole thing with omega over five atoms. Combinatorially: incrementing n clears its v₂(n+1) trailing 1-bits and sets one new bit, so the popcount changes by 1 − v₂(n+1).",
+    "mathContext": "$s_2(n) + 1 = s_2(n+1) + v_2(n+1)$, from $v_2(m!) = m - s_2(m)$ at $m = n, n+1$ and $(n+1)! = (n+1)\\cdot n!$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre's formula", "sub_one_mul_padicValNat_factorial", "padicValNat.mul", "carries in addition", "omega"],
+    "prerequisites": ["Legendre's formula", "additivity of v_p", "binary carries"]
+  },
+  {
+    "id": "ann-kc0402-headline",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 170, "endLine": 200 },
+    "type": "theorem",
+    "title": "The headline valuation v₂(Cₙ) = s₂(n+1) − 1",
+    "content": "catalan_ne_zero (from (n+1)·Cₙ = C(2n,n) ≠ 0) makes the valuations well-behaved. padicValNat_two_catalan_add_one then takes v₂ of Catalan's identity: by additivity v₂(n+1) + v₂(Cₙ) = v₂(C(2n,n)) = s₂(n); subtracting the carry identity eliminates v₂(n+1) and gives the subtraction-free v₂(Cₙ) + 1 = s₂(n+1) (closed by omega). padicValNat_two_catalan restates it as v₂(Cₙ) = s₂(n+1) − 1. No division or rational arithmetic appears despite Cₙ being defined by a quotient — additivity linearises everything.",
+    "mathContext": "$v_2(n+1) + v_2(C_n) = s_2(n)$ and $s_2(n)+1 = s_2(n+1)+v_2(n+1)$ $\\Rightarrow$ $v_2(C_n)+1 = s_2(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.succ_mul_catalan_eq_centralBinom", "padicValNat.mul", "the carry identity", "subtraction-free form"],
+    "prerequisites": ["Catalan's identity", "the carry identity", "the parent central-binomial formula"]
+  },
+  {
+    "id": "ann-kc0402-exact-power",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 201, "endLine": 215 },
+    "type": "theorem",
+    "title": "Exact power of two dividing Cₙ",
+    "content": "The valuation equality upgrades to a sharp exact-divisibility statement 2^{s₂(n+1)−1} ∥ Cₙ. two_pow_dvd_catalan (2^{s₂(n+1)−1} ∣ Cₙ) rewrites by the valuation and applies pow_padicValNat_dvd; not_two_pow_succ_dvd_catalan (¬2^{s₂(n+1)} ∣ Cₙ) uses the subtraction-free form with pow_succ_padicValNat_not_dvd. Together they pin the exact power, not merely a lower bound.",
+    "mathContext": "$2^{s_2(n+1)-1} \\mid C_n$ and $2^{s_2(n+1)} \\nmid C_n$, i.e. $2^{s_2(n+1)-1} \\,\\|\\, C_n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["exact divisibility", "pow_padicValNat_dvd", "pow_succ_padicValNat_not_dvd", "sharpness"],
+    "prerequisites": ["the valuation formula", "padicValNat divisibility API"]
+  },
+  {
+    "id": "ann-kc0402-odd",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 218, "endLine": 243 },
+    "type": "insight",
+    "title": "The odd Catalan numbers are the Mersenne-type indices",
+    "content": "odd_catalan_iff: Odd Cₙ ⟺ ∃k, n = 2^k − 1. Since Cₙ ≠ 0, Odd Cₙ reduces to v₂(Cₙ) = 0 (padicValNat.eq_zero_iff with the not-even/two-dvd bridge), which by the headline means s₂(n+1) = 1, i.e. n+1 is a power of two (popcount characterisation), i.e. n = 2^k − 1. This recovers the classical odd-Catalan sequence 0,1,3,7,15,31,… as a one-line corollary of the valuation formula.",
+    "mathContext": "Odd $C_n \\iff v_2(C_n) = 0 \\iff s_2(n+1) = 1 \\iff n+1 = 2^k \\iff n = 2^k - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["odd Catalan numbers", "Mersenne-type indices", "padicValNat.eq_zero_iff", "popcount characterisation"],
+    "prerequisites": ["the valuation formula", "powers of two via popcount"]
+  },
+  {
+    "id": "ann-kc0402-witnesses",
+    "proofId": "kummer-theorem-oq-04-oq-02",
+    "range": { "startLine": 251, "endLine": 280 },
+    "type": "context",
+    "title": "Worked numeric witnesses",
+    "content": "Concrete checks of the oddness pattern: C₂ = 2 (even, catalan_two), C₃ = 5 odd (3 = 2²−1), C₇ odd (7 = 2³−1, the next odd index), and C₄ not odd (4+1 = 5 is not a power of two, proved by casing on k). Values come from Mathlib's catalan_two/catalan_three and the characterisation rather than decide, because catalan is strong-recursive and the kernel cannot reduce it — so these examples remain 0-axiom (no Lean.ofReduceBool).",
+    "mathContext": "$C_2 = 2$, $C_3 = 5$ (odd, $3 = 2^2-1$), $C_7$ odd ($7 = 2^3-1$), $C_4$ even ($5$ not a power of two).",
+    "significance": "context",
+    "relatedConcepts": ["catalan_two", "catalan_three", "worked examples", "strong recursion vs decide"],
+    "prerequisites": ["the oddness characterisation"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `kummer-theorem-oq-04-oq-02` (v₂(Cₙ) = s₂(n+1) − 1, and the odd Catalan numbers).

The entry already had a rich overview, 7 sections, and conclusion, but **no `annotations.json`**. Added it.

- **`annotations.json`** (7 annotations, each with `mathContext` LaTeX / `significance` / `relatedConcepts` / `prerequisites`) covering: the goal + odd-Catalan payoff, the reusable digit-sum infrastructure, the binary carry identity `s₂(n)+1 = s₂(n+1)+v₂(n+1)` (the crux, from Legendre's formula), the headline valuation via Catalan's identity, the exact power `2^(s₂(n+1)−1) ∥ Cₙ`, the odd-Catalan ⟺ Mersenne-index `n = 2^k − 1` characterisation, and the numeric witnesses.
- Annotation ranges verified to snap cleanly to Lean constructs (`pnpm annotations:build` reports no warnings for this entry; one range that initially landed on a `/-! ### -/` section marker was bumped to the following docstring).

Axiom integrity: confirmed `status: verified` / `axiomCount: 0` is accurate — 0 sorries, 0 axiom declarations, no decide/native_decide anywhere (so no Lean.ofReduceBool); the numeric witnesses use `catalan_two`/`catalan_three` + the characterisation rather than kernel decide. No change needed.

Verified with `pnpm build` (✓ built).