### PR TITLE
research(fibonacci-identities-oq-01-oq-02-oq-01): Vajda's identity unifying Catalan, d'Ocagne, Cassini [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2800,6 +2800,7 @@ import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FibonacciIdentities
 import Proofs.FibonacciIdentitiesOQ01
 import Proofs.FibonacciIdentitiesOQ01OQ02
+import Proofs.FibonacciIdentitiesOQ01OQ02OQ01
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ02OQ01
 import Proofs.FibonacciIdentitiesOQ03

--- a/proofs/Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean
@@ -1,0 +1,171 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+import Proofs.FibonacciIdentitiesOQ01OQ02
+
+/-
+# Vajda's Identity and Catalan's Identity for Fibonacci Numbers
+
+## What This Proves
+
+With `Fₙ = Nat.fib n` the Fibonacci sequence (`F₀ = 0, F₁ = 1, Fₙ₊₂ = Fₙ + Fₙ₊₁`),
+**Vajda's identity** is the two-parameter cross-determinant relation
+
+    F_{n+i} · F_{n+j} − Fₙ · F_{n+i+j} = (−1)ⁿ · Fᵢ · Fⱼ      (over ℤ).
+
+This single identity is the common engine for the whole family of "index-arithmetic"
+Fibonacci identities:
+
+* **d'Ocagne** is the slice `j = 1`  (`F₁ = 1`): `F_{n+i}·Fₙ₊₁ − Fₙ·F_{n+i+1} = (−1)ⁿ·Fᵢ`
+  — exactly the parent's gap engine `fibonacci-identities-oq-01-oq-02`.
+* **Cassini**  is the slice `i = j = 1`:                 `Fₙ₊₁² − Fₙ·Fₙ₊₂ = (−1)ⁿ`.
+* **Catalan** is the symmetric slice `i = j = r`:        `Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ²`.
+
+Catalan's identity in the form on Wikipedia ("Cassini and Catalan identities") is
+
+    Fₙ² − F_{n−r} · F_{n+r} = (−1)ⁿ⁻ʳ · Fᵣ²       (for r ≤ n).
+
+(The orientation matters: with `n = 2, r = 1` one has `F₂² − F₁·F₃ = 1 − 2 = −1 = (−1)¹·F₁²`,
+so it is `Fₙ² − F_{n−r}F_{n+r}`, *not* `F_{n−r}F_{n+r} − Fₙ²`, that equals `(−1)ⁿ⁻ʳFᵣ²`.)
+
+## Approach
+
+The key observation is that for fixed `n, i`, the cross-determinant
+
+    g(j) := F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j}
+
+satisfies the **Fibonacci recurrence in `j`** — `g(j+2) = g(j) + g(j+1)` — because both
+`F_{n+j}` and `F_{n+i+j}` do, and the map is ℤ-linear in those two entries. The target
+`(−1)ⁿ·Fᵢ·Fⱼ` also satisfies the Fibonacci recurrence in `j` (only `Fⱼ` varies). Two
+sequences obeying the same second-order recurrence agree everywhere once they agree at
+`j = 0` and `j = 1`:
+
+* `j = 0`:  `g(0) = F_{n+i}·Fₙ − Fₙ·F_{n+i} = 0 = (−1)ⁿ·Fᵢ·F₀`     (trivial, `F₀ = 0`);
+* `j = 1`:  `g(1) = (−1)ⁿ·Fᵢ`  is **exactly d'Ocagne's identity** — supplied by the
+  parent entry's `fib_docagne_gap`.
+
+So Vajda is proved by `Nat.twoStepInduction` on `j`, with the inductive step closed by
+`linear_combination ih₀ + ih₁` after rewriting the two recurrences. This *literally
+unifies* Catalan with d'Ocagne: d'Ocagne is the base case `j = 1` of the induction that
+yields Vajda, and Catalan is the diagonal specialisation `i = j = r`.
+
+No closed form, Binet formula, or matrices are needed — only the recurrence and the
+already-proved d'Ocagne identity.
+
+No `decide`/`native_decide` is used in the theorems, so the proofs are axiom-free
+(only Mathlib's foundational axioms).
+
+## Distinctness
+
+Vajda's and Catalan's identities are **not** in Mathlib (`Mathlib.Data.Nat.Fib.Basic`
+has the recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, but no `(−1)ⁿ` determinant
+identities). This entry answers the first open question of the parent d'Ocagne entry
+(`fibonacci-identities-oq-01-oq-02`): prove Catalan's identity and unify it with
+d'Ocagne via a single two-parameter cross-determinant lemma.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace FibonacciIdentitiesOQ01OQ02OQ01
+
+open Nat
+
+/-- **Vajda's identity (gap-parameterised, two-parameter form).**  For all `n, i, j`,
+
+    F_{n+i} · F_{n+j} − Fₙ · F_{n+i+j} = (−1)ⁿ · Fᵢ · Fⱼ      (over ℤ).
+
+This is the single cross-determinant lemma that specialises to d'Ocagne (`j = 1`),
+Cassini (`i = j = 1`) and Catalan (`i = j = r`).  The proof is a two-step induction on
+`j`: the quantity satisfies the Fibonacci recurrence in `j`, the `j = 0` case is trivial
+(`F₀ = 0`), and the `j = 1` case is d'Ocagne's identity from the parent entry. -/
+theorem fib_vajda_gap (n i j : ℕ) :
+    (Nat.fib (n + i) : ℤ) * Nat.fib (n + j)
+      - (Nat.fib n : ℤ) * Nat.fib (n + i + j)
+      = (-1) ^ n * (Nat.fib i * Nat.fib j) := by
+  induction j using Nat.twoStepInduction with
+  | zero =>
+    -- F_{n+i}·F_n − F_n·F_{n+i} = 0 = (−1)ⁿ·Fᵢ·F₀.
+    simp [Nat.fib_zero]
+    ring
+  | one =>
+    -- F_{n+i}·F_{n+1} − F_n·F_{n+i+1} = (−1)ⁿ·Fᵢ·F₁ = (−1)ⁿ·Fᵢ — d'Ocagne's identity.
+    have h := FibonacciIdentitiesOQ01OQ02.fib_docagne_gap n i
+    simp only [Nat.fib_one, Nat.cast_one, mul_one]
+    linear_combination h
+  | more j ih0 ih1 =>
+    -- Fibonacci recurrence in j: g(j+2) = g(j) + g(j+1).
+    have e1 : (Nat.fib (n + (j + 2)) : ℤ)
+        = (Nat.fib (n + j) : ℤ) + Nat.fib (n + (j + 1)) := by
+      have h1 : n + (j + 2) = (n + j) + 2 := by ring
+      have h2 : n + (j + 1) = (n + j) + 1 := by ring
+      rw [h1, h2]; exact_mod_cast Nat.fib_add_two (n := n + j)
+    have e2 : (Nat.fib (n + i + (j + 2)) : ℤ)
+        = (Nat.fib (n + i + j) : ℤ) + Nat.fib (n + i + (j + 1)) := by
+      have h1 : n + i + (j + 2) = (n + i + j) + 2 := by ring
+      have h2 : n + i + (j + 1) = (n + i + j) + 1 := by ring
+      rw [h1, h2]; exact_mod_cast Nat.fib_add_two (n := n + i + j)
+    have e3 : (Nat.fib (j + 2) : ℤ) = (Nat.fib j : ℤ) + Nat.fib (j + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := j)
+    rw [e1, e2, e3]
+    linear_combination ih0 + ih1
+
+/-- **Catalan's identity, gap-parameterised form.**  For all `m` and `r`,
+
+    F_{m+r}² − Fₘ · F_{m+2r} = (−1)ᵐ · Fᵣ².
+
+The subtraction-free engine for Catalan: writing `m = n − r` recovers the named form. -/
+theorem fib_catalan_gap (m r : ℕ) :
+    (Nat.fib (m + r) : ℤ) ^ 2 - (Nat.fib m : ℤ) * Nat.fib (m + 2 * r)
+      = (-1) ^ m * (Nat.fib r : ℤ) ^ 2 := by
+  have h := fib_vajda_gap m r r
+  -- h : F_{m+r}·F_{m+r} − F_m·F_{m+r+r} = (−1)ᵐ·(F_r·F_r).
+  rw [show m + r + r = m + 2 * r from by ring] at h
+  linear_combination h
+
+/-- **Catalan's identity (named symmetric form).**  For `r ≤ n`,
+
+    Fₙ² − F_{n−r} · F_{n+r} = (−1)ⁿ⁻ʳ · Fᵣ².
+
+This is the symmetric companion of Cassini/d'Ocagne, obtained as the diagonal slice
+`i = j = r` of Vajda's identity. -/
+theorem fib_catalan (n r : ℕ) (h : r ≤ n) :
+    (Nat.fib n : ℤ) ^ 2 - (Nat.fib (n - r) : ℤ) * Nat.fib (n + r)
+      = (-1) ^ (n - r) * (Nat.fib r : ℤ) ^ 2 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le h    -- n = r + m
+  rw [Nat.add_sub_cancel_left]                     -- (r + m) − r = m  (fib arg and exponent)
+  rw [Nat.add_comm r m]                            -- r + m ↦ m + r everywhere
+  rw [show m + r + r = m + 2 * r from by ring]
+  linear_combination fib_catalan_gap m r
+
+/-- **d'Ocagne's identity as the `j = 1` slice of Vajda** (gap-parameterised form),
+re-deriving the parent entry's engine from the unified cross-determinant lemma:
+
+    F_{n+k} · Fₙ₊₁ − F_{n+k+1} · Fₙ = (−1)ⁿ · F_k. -/
+theorem fib_docagne_gap_of_vajda (n k : ℕ) :
+    (Nat.fib (n + k) : ℤ) * Nat.fib (n + 1)
+      - (Nat.fib (n + k + 1) : ℤ) * Nat.fib n = (-1) ^ n * Nat.fib k := by
+  have h := fib_vajda_gap n k 1
+  simp only [Nat.fib_one, Nat.cast_one, mul_one] at h
+  linear_combination h
+
+/-- **Cassini's identity as the `i = j = 1` slice of Vajda.**
+
+    Fₙ₊₁² − Fₙ · Fₙ₊₂ = (−1)ⁿ. -/
+theorem fib_cassini_of_vajda (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - (Nat.fib n : ℤ) * Nat.fib (n + 2) = (-1) ^ n := by
+  have h := fib_vajda_gap n 1 1
+  simp only [Nat.fib_one, Nat.cast_one, mul_one] at h
+  -- h : F_{n+1}·F_{n+1} − F_n·F_{n+1+1} = (−1)ⁿ ; n+1+1 = n+2 definitionally.
+  linear_combination h
+
+/-! ## Concrete examples -/
+
+-- Catalan, named form `Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ²`:
+-- n = 5, r = 2: F₅² − F₃·F₇ = 25 − 2·13 = −1 = (−1)³·F₂² = −1.
+example : (Nat.fib 5 : ℤ) ^ 2 - (Nat.fib 3 : ℤ) * Nat.fib 7 = -1 := by decide
+-- n = 6, r = 2: F₆² − F₄·F₈ = 64 − 3·21 = 1 = (−1)⁴·F₂² = 1.
+example : (Nat.fib 6 : ℤ) ^ 2 - (Nat.fib 4 : ℤ) * Nat.fib 8 = 1 := by decide
+-- Vajda, n = 2, i = 1, j = 3: F₃·F₅ − F₂·F₆ = 2·5 − 1·8 = 2 = (−1)²·F₁·F₃ = 2.
+example : (Nat.fib 3 : ℤ) * Nat.fib 5 - (Nat.fib 2 : ℤ) * Nat.fib 6 = 2 := by decide
+
+end FibonacciIdentitiesOQ01OQ02OQ01

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "fibonacci-identities-oq-01-oq-02-oq-01",
+  "title": "Vajda's and Catalan's Identities for Fibonacci Numbers",
+  "slug": "fibonacci-identities-oq-01-oq-02-oq-01",
+  "description": "Vajda's identity F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ over ℤ — the single two-parameter cross-determinant lemma that unifies the index-arithmetic Fibonacci identities. d'Ocagne is its j = 1 slice, Cassini its i = j = 1 slice, and Catalan its diagonal slice i = j = r, giving Catalan's identity Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ² (for r ≤ n, the Wikipedia orientation). The proof rests on the observation that for fixed n, i the cross-determinant g(j) = F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} satisfies the Fibonacci recurrence in j, as does the target (−1)ⁿ·Fᵢ·Fⱼ; two sequences obeying the same second-order recurrence agree everywhere once they agree at j = 0 (trivial, F₀ = 0) and j = 1 (exactly d'Ocagne's identity, imported from the parent entry's fib_docagne_gap). Vajda is therefore proved by Nat.twoStepInduction on j, the step closed by linear_combination ih₀ + ih₁ after rewriting the recurrence twice. This literally unifies Catalan with d'Ocagne: d'Ocagne is the base case of the induction yielding Vajda, and Catalan is the diagonal specialisation. Neither Vajda's nor Catalan's identity is in Mathlib.",
+  "meta": {
+    "author": "Steven Vajda / Eugène Catalan; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1879/1989",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "vajda",
+      "catalan",
+      "docagne",
+      "cassini",
+      "recurrence",
+      "induction",
+      "determinant",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence, cast to ℤ to drive the second-order recurrence in j at the two-step induction's successor step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Second-order induction principle (P 0, P 1, P n → P (n+1) → P (n+2)) — the engine for the induction on j, matching the Fibonacci recurrence satisfied by the cross-determinant",
+        "module": "Mathlib.Data.Nat.Init"
+      },
+      {
+        "theorem": "Nat.fib_zero / Nat.fib_one",
+        "description": "fib 0 = 0, fib 1 = 1 — base values that collapse the j = 0 case to 0 and reduce the j = 1 case (F₁ = 1) to d'Ocagne",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.exists_eq_add_of_le / Nat.add_sub_cancel_left",
+        "description": "From r ≤ n obtain n = r + m and simplify n − r = m, transporting the gap-parameterised Catalan engine to the named symmetric form",
+        "module": "Mathlib (Nat order/subtraction lemmas)"
+      }
+    ],
+    "originalContributions": [
+      "fib_vajda_gap: ∀ n i j, (fib (n+i) : ℤ)·fib (n+j) − fib n·fib (n+i+j) = (−1)ⁿ·(fib i·fib j) — Vajda's identity, the single two-parameter cross-determinant lemma unifying the family, absent from Mathlib",
+      "fib_catalan_gap: ∀ m r, (fib (m+r) : ℤ)² − fib m·fib (m+2r) = (−1)ᵐ·(fib r)² — the subtraction-free engine for Catalan, the diagonal i = j = r slice of Vajda",
+      "fib_catalan: ∀ n r, r ≤ n → (fib n : ℤ)² − fib (n−r)·fib (n+r) = (−1)ⁿ⁻ʳ·(fib r)² — Catalan's identity in its named symmetric form (Wikipedia orientation)",
+      "fib_docagne_gap_of_vajda: ∀ n k, (fib (n+k) : ℤ)·fib (n+1) − fib (n+k+1)·fib n = (−1)ⁿ·fib k — d'Ocagne's gap engine re-derived as the j = 1 slice of Vajda, witnessing the unification with the parent entry",
+      "fib_cassini_of_vajda: ∀ n, (fib (n+1) : ℤ)² − fib n·fib (n+2) = (−1)ⁿ — Cassini recovered as the i = j = 1 slice of Vajda"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 171,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound; #print axioms confirms no sorryAx and no Lean.ofReduceBool). No decide/native_decide is used in the main theorems (only in the trailing numeric example sanity-checks).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci 'index-arithmetic' identities form a tightly knit family. Cassini's identity (1680) measures the determinant of three consecutive terms, always ±1: Fₙ₊₁² − Fₙ₊₂Fₙ = (−1)ⁿ. Catalan's identity (Eugène Catalan, 1879) symmetrises it about a centre: Fₙ² − F_{n−r}F_{n+r} = (−1)ⁿ⁻ʳFᵣ². d'Ocagne's identity couples two independent indices. Vajda's identity (popularised in Steven Vajda's 1989 monograph) is the two-parameter master relation F_{n+i}F_{n+j} − FₙF_{n+i+j} = (−1)ⁿFᵢFⱼ from which all of the above are slices. In the matrix picture M = [[1,1],[1,0]], these are determinant comparisons of powers Mᵏ, whose off-diagonal/diagonal entries are Fibonacci numbers and whose determinant is (−1)ᵏ.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01-oq-02, Q1)**: Prove Catalan's identity Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ² (the symmetric companion of Cassini/d'Ocagne), and unify it with d'Ocagne via a single two-parameter cross-determinant lemma.\n\n**Result**: fib_catalan (named symmetric form, for r ≤ n), driven by the subtraction-free fib_catalan_gap, both obtained as the diagonal slice i = j = r of Vajda's identity fib_vajda_gap — the requested unifying cross-determinant lemma, of which d'Ocagne (fib_docagne_gap_of_vajda) and Cassini (fib_cassini_of_vajda) are also slices.",
+    "text": "Over ℤ, for all n, i, j: F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ (Vajda). Specialising i = j = r gives Catalan: for r ≤ n, Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ². The two-parameter cross-determinant of Fibonacci numbers equals, up to the alternating sign (−1)ⁿ, the product Fᵢ·Fⱼ at the two index offsets.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. State Vajda in the subtraction-free gap form fib_vajda_gap (n, i, j all genuine naturals). Cast to ℤ to expose the alternating sign.\n2. Fix n and i. The map j ↦ g(j) := F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} is ℤ-linear in the entries F_{n+j} and F_{n+i+j}, both of which obey the Fibonacci recurrence, so g satisfies the second-order recurrence g(j+2) = g(j) + g(j+1). The target (−1)ⁿ·Fᵢ·Fⱼ obeys the same recurrence in j (only Fⱼ varies). Hence it suffices to match them at j = 0 and j = 1.\n3. Induct on j with Nat.twoStepInduction. Base j = 0: g(0) = F_{n+i}·Fₙ − Fₙ·F_{n+i} = 0 = (−1)ⁿ·Fᵢ·F₀ (F₀ = 0), by simp + ring. Base j = 1: g(1) = (−1)ⁿ·Fᵢ is exactly d'Ocagne's identity, imported as FibonacciIdentitiesOQ01OQ02.fib_docagne_gap from the parent entry and closed by linear_combination.\n4. Successor step (j ⇒ j+2): cast the recurrence three times — for F_{n+(j+2)}, F_{n+i+(j+2)}, and F_{j+2} — normalising the indices to the canonical (·)+2 / (·)+1 forms, rewrite, and close with linear_combination ih₀ + ih₁ (g(j+2) = g(j) + g(j+1)).\n5. Catalan: take i = j = r. fib_catalan_gap is the diagonal slice with m + r + r ↦ m + 2r. fib_catalan recovers the named form: from r ≤ n write n = r + m (Nat.exists_eq_add_of_le), simplify n − r = m (Nat.add_sub_cancel_left), reconcile indices, and apply the gap form.\n6. Unification corollaries: fib_docagne_gap_of_vajda (j = 1) re-derives the parent's d'Ocagne engine, and fib_cassini_of_vajda (i = j = 1) recovers Cassini — both as one-line specialisations of Vajda.",
+    "keyInsights": [
+      "**One recurrence, two sequences.** The whole proof is the principle that two sequences satisfying the same second-order linear recurrence are equal once their first two terms agree. The cross-determinant g(j) and the target (−1)ⁿFᵢFⱼ both satisfy the Fibonacci recurrence in j, so Vajda reduces to two base cases.",
+      "**d'Ocagne IS the base case.** The j = 1 base case of the induction that proves Vajda is precisely d'Ocagne's identity. This is the concrete sense in which Vajda 'unifies' the family: d'Ocagne is not derived from Vajda after the fact — it is the seed from which Vajda grows, and Catalan is then the diagonal slice. The parent entry's fib_docagne_gap is reused verbatim.",
+      "**Parameterise the gap.** As in the parent, the ℕ-subtraction n − r in Catalan's named form is removed by an additive gap (m = n − r), so the engine fib_catalan_gap runs with no truncation and the named form follows by a one-line substitution.",
+      "**Sign orientation matters.** Catalan's identity is Fₙ² − F_{n−r}F_{n+r} = (−1)ⁿ⁻ʳFᵣ² (verified e.g. F₅² − F₃F₇ = 25 − 26 = −1 = (−1)³F₂²), not the reversed difference; the formalised statement matches the standard Wikipedia orientation.",
+      "**Not in Mathlib.** Mathlib carries the recurrence, fib_add, fib_two_mul, and fib_gcd, but none of the (−1)ⁿ determinant identities (Cassini, Catalan, d'Ocagne, Vajda), so the two-parameter cross-determinant lemma and its specialisations are original contributions."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and base values",
+      "Second-order induction (Nat.twoStepInduction) and the principle that equal recurrence + equal initial data ⇒ equal sequences",
+      "Casting ℕ → ℤ (exact_mod_cast) to expose the alternating sign",
+      "Eliminating ℕ-subtraction via Nat.exists_eq_add_of_le and Nat.add_sub_cancel_left",
+      "The linear_combination tactic for closing polynomial identities against hypotheses",
+      "The parent d'Ocagne entry (fibonacci-identities-oq-01-oq-02) supplying fib_docagne_gap"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 79,
+      "summary": "Module docstring stating Vajda's identity, the slices that recover d'Ocagne/Cassini/Catalan, the recurrence-in-j proof idea, and the Catalan sign orientation; imports (including the parent d'Ocagne entry), namespace, and open Nat.",
+      "mathContext": "$F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$, with $F_0=0, F_1=1, F_{n+2}=F_n+F_{n+1}$."
+    },
+    {
+      "id": "vajda-gap",
+      "title": "Vajda's Identity (Cross-Determinant Engine)",
+      "startLine": 81,
+      "endLine": 115,
+      "summary": "fib_vajda_gap: the two-parameter identity F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ, proved by Nat.twoStepInduction on j — j = 0 trivial (F₀ = 0), j = 1 is d'Ocagne (parent's fib_docagne_gap), successor step closes by linear_combination ih₀ + ih₁ after three recurrence rewrites.",
+      "mathContext": "$F_{n+i}F_{n+j} - F_n F_{n+i+j} = (-1)^n F_i F_j$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "catalan-gap",
+      "title": "Catalan's Identity (Gap Engine)",
+      "startLine": 117,
+      "endLine": 129,
+      "summary": "fib_catalan_gap: the diagonal slice i = j = r of Vajda, F_{m+r}² − Fₘ·F_{m+2r} = (−1)ᵐ·Fᵣ², obtained by specialising fib_vajda_gap m r r and normalising m + r + r = m + 2r.",
+      "mathContext": "$F_{m+r}^2 - F_m F_{m+2r} = (-1)^m F_r^2$."
+    },
+    {
+      "id": "catalan-named",
+      "title": "Catalan's Identity (Named Symmetric Form)",
+      "startLine": 131,
+      "endLine": 142,
+      "summary": "fib_catalan: from r ≤ n write n = r + m and simplify n − r = m, transporting the gap engine to Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ².",
+      "mathContext": "$F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ for $r \\le n$."
+    },
+    {
+      "id": "docagne-cassini-slices",
+      "title": "d'Ocagne and Cassini as Slices of Vajda",
+      "startLine": 144,
+      "endLine": 159,
+      "summary": "fib_docagne_gap_of_vajda re-derives the parent's d'Ocagne engine as the j = 1 slice; fib_cassini_of_vajda recovers Cassini as the i = j = 1 slice — both one-line specialisations of Vajda.",
+      "mathContext": "d'Ocagne $= $ Vajda at $j=1$; Cassini $=$ Vajda at $i=j=1$: $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples",
+      "startLine": 161,
+      "endLine": 171,
+      "summary": "Numeric sanity checks: Catalan at (n,r) = (5,2) and (6,2), and Vajda at (n,i,j) = (2,1,3), each by decide.",
+      "mathContext": "e.g. $F_5^2 - F_3 F_7 = 25 - 26 = -1 = (-1)^3 F_2^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Answers the first open question of the d'Ocagne entry (prove Catalan and unify with d'Ocagne via one cross-determinant lemma). Reuses the parent's fib_docagne_gap as the j = 1 base case of the induction yielding Vajda, and re-derives it as fib_docagne_gap_of_vajda."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "generalizes",
+      "description": "Cassini's identity (the parent of d'Ocagne) is the i = j = 1 slice of Vajda, re-derived directly here as fib_cassini_of_vajda."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of Vajda's two-parameter cross-determinant identity F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ over ℤ, with Catalan's identity Fₙ² − F_{n−r}·F_{n+r} = (−1)ⁿ⁻ʳ·Fᵣ² as the diagonal slice and d'Ocagne/Cassini recovered as further slices. The engine is a single second-order induction on j whose j = 1 base case is exactly d'Ocagne, literally unifying the family.",
+    "implications": "Supplies the master index-arithmetic Fibonacci identity as a universally quantified theorem absent from Mathlib, with Cassini, d'Ocagne, and Catalan as uniform specialisations — answering the parent entry's open question and exhibiting the cross-determinant structure underlying fast doubling and the strong divisibility Fₘ | Fₘₖ.",
+    "openQuestions": [
+      "Promote Vajda to a named two-sided form with both offsets allowed to be signed (working in ℤ-indexed Fibonacci, Int.fib), removing the last gap parameterisation.",
+      "Derive the strong divisibility Fₘ | Fₘₙ and fib_gcd-style consequences from Vajda by isolating the role of the (−1)ⁿ sign across the diagonal."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic",
+      "Proofs.FibonacciIdentitiesOQ01OQ02"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01OQ02OQ01",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "Vajda's identity and its specialisations to Cassini, Catalan, and d'Ocagne"
+    },
+    {
+      "authors": "Catalan, E.",
+      "title": "Notes sur la théorie des fractions continues et sur certaines séries",
+      "year": "1879",
+      "venue": "Mém. Acad. R. Sci. Belgique",
+      "note": "Original statement of Catalan's identity"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Catalan's, Vajda's, and the index-arithmetic identities for Fibonacci numbers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **Vajda's identity**, the two-parameter cross-determinant master relation for Fibonacci numbers, and derives **Catalan's identity** as its diagonal slice — answering the **first open question** of the parent d'Ocagne entry (`fibonacci-identities-oq-01-oq-02`): *"Prove Catalan's identity and unify it with d'Ocagne via a single two-parameter cross-determinant lemma."*

```
Vajda    F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j} = (−1)ⁿ·Fᵢ·Fⱼ        (over ℤ, all n,i,j)
Catalan  Fₙ² − F_{n−r}·F_{n+r}          = (−1)ⁿ⁻ʳ·Fᵣ²         (r ≤ n)   [i = j = r]
d'Ocagne F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ    = (−1)ⁿ·F_k                     [j = 1]
Cassini  Fₙ₊₁² − Fₙ·Fₙ₊₂                = (−1)ⁿ                          [i = j = 1]
```

## The unification

For fixed `n, i` the cross-determinant `g(j) = F_{n+i}·F_{n+j} − Fₙ·F_{n+i+j}` satisfies the **Fibonacci recurrence in `j`** (`g(j+2) = g(j) + g(j+1)`), and so does the target `(−1)ⁿ·Fᵢ·Fⱼ`. Two sequences with the same second-order recurrence agree once they agree at `j = 0` and `j = 1`:

- `j = 0`: trivial (`F₀ = 0`);
- `j = 1`: **is exactly d'Ocagne's identity** — imported verbatim from the parent's `fib_docagne_gap`.

So Vajda is proved by `Nat.twoStepInduction` on `j` whose base case *is* d'Ocagne, and Catalan is the diagonal specialisation. d'Ocagne is not derived from Vajda after the fact — it is the seed from which Vajda grows.

## Theorems (5, all 0-axiom)

- `fib_vajda_gap` — Vajda's identity
- `fib_catalan_gap`, `fib_catalan` — Catalan (gap engine + named symmetric form)
- `fib_docagne_gap_of_vajda` — d'Ocagne re-derived as the `j = 1` slice
- `fib_cassini_of_vajda` — Cassini as the `i = j = 1` slice

## Notes

- The parent's stated open-question sign (`F_{n−r}F_{n+r} − Fₙ² = (−1)ⁿ⁻ʳFᵣ²`) is off by a sign; the standard/Wikipedia orientation `Fₙ² − F_{n−r}F_{n+r} = (−1)ⁿ⁻ʳFᵣ²` is what is proved here (verified e.g. `F₅² − F₃F₇ = 25 − 26 = −1 = (−1)³F₂²`).
- Neither Vajda's nor Catalan's identity is in Mathlib (which has the recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, but no `(−1)ⁿ` determinant identities).

## Verification

- `lake build Proofs.FibonacciIdentitiesOQ01OQ02OQ01` ✓ (parent + module, 0 errors)
- `#print axioms` on all 5 theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. `decide` appears only in trailing numeric examples.
- 171 lines, 0 sorries, 0 axioms. Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)