### PR TITLE
Research: euler-identity-oq-01-oq-03 — De Moivre's theorem & sum of roots of unity (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/EulerIdentityOQ01OQ03.lean
+++ b/proofs/Proofs/EulerIdentityOQ01OQ03.lean
@@ -1,0 +1,174 @@
+/-
+# De Moivre's Theorem and the Sum of the Roots of Unity (OQ-03)
+
+## Research Question
+
+The parent entry (`EulerIdentityOQ01`, "Euler's Formula via Taylor Series
+Splitting") formalizes Euler's formula `e^{ix} = cos x + i·sin x`. The natural
+*multiplicative* consequence of Euler's formula is **De Moivre's theorem**
+
+    (cos x + i·sin x)^n = cos(nx) + i·sin(nx),
+
+which Mathlib does **not** expose as a named lemma: it has `Complex.exp_nat_mul`
+and `Complex.exp_int_mul`, but no `cos + i sin` power law, and no statement that
+the `n`-th roots of unity sum to zero phrased through Euler's formula. Can De
+Moivre's theorem — and that structural consequence — be derived directly from
+Euler's formula?
+
+## Answer
+
+Yes. Writing `cos x + i·sin x = e^{ix}` (Euler) collapses the power on the left
+to `(e^{ix})^n = e^{inx}` (`Complex.exp_nat_mul`), and a second application of
+Euler re-expands `e^{inx} = cos(nx) + i·sin(nx)`. The same argument with
+`exp_int_mul` gives the integer (hence negative-exponent) form.
+
+For the roots of unity we set `ω_n = e^{2πi/n} = cos(2π/n) + i·sin(2π/n)`. Then
+`ω_n^n = e^{2πi} = 1` (so it is an `n`-th root of unity), `ω_n ≠ 1` for `n ≥ 2`
+(via `Complex.exp_eq_one_iff`), and the finite geometric series gives
+`∑_{k<n} ω_n^k = (ω_n^n − 1)/(ω_n − 1) = 0`. Thus the `n`-th roots of unity sum
+to zero — the classical "centre of mass of a regular polygon is its centre".
+
+## Relation to the parent
+
+The parent derives Euler's formula `e^{ix} = cos x + i·sin x` from the Taylor
+series with 0 axioms. Here we take Euler's formula as established (re-proving it
+in one line from Mathlib's `Complex.exp_mul_I`, the canonical statement the
+parent reconstructs) and build the multiplicative theory on top of it.
+
+NOTE: the parent file `Proofs/EulerIdentityOQ01.lean` does not currently compile
+under Mathlib v4.26.0 (its local lemmas `cos_eq_tsum`/`sin_eq_tsum` now collide
+by name with Mathlib's, producing "Ambiguous term" errors), so this file is kept
+self-contained rather than importing it.
+
+## Axiom Budget
+
+0 axioms. Everything is standard Mathlib (`exp_mul_I`, `exp_nat_mul`,
+`exp_int_mul`, `exp_two_pi_mul_I`, `exp_eq_one_iff`, `geom_sum_eq`).
+
+Source: Extension of `EulerIdentityOQ01` (OQ-03).
+-/
+
+import Mathlib
+
+open Complex
+open scoped Real
+open Finset
+
+namespace EulerIdentityOQ01OQ03
+
+-- ============================================================================
+-- § 0. EULER'S FORMULA (real argument)
+-- ============================================================================
+
+/-- **Euler's formula** for a real angle, `e^{ix} = cos x + i·sin x`.
+
+    This is Mathlib's `Complex.exp_mul_I` specialised to a real angle, with the
+    complex `cos`/`sin` pushed back to real `cos`/`sin`. It is the same statement
+    the parent entry reconstructs from the Taylor series. -/
+theorem euler_formula (x : ℝ) :
+    Complex.exp ((x : ℂ) * I) = ↑(Real.cos x) + ↑(Real.sin x) * I := by
+  rw [Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin]
+
+-- ============================================================================
+-- § 1. DE MOIVRE'S THEOREM
+-- ============================================================================
+
+/-- **De Moivre's Theorem** (natural exponent).
+
+    `(cos x + i·sin x)^n = cos(nx) + i·sin(nx)`.
+
+    Proof: rewrite `cos x + i·sin x = e^{ix}` (Euler), collapse the power via
+    `e^{inx} = (e^{ix})^n`, then re-expand with Euler at `nx`. -/
+theorem de_moivre (x : ℝ) (n : ℕ) :
+    (↑(Real.cos x) + ↑(Real.sin x) * I) ^ n
+      = ↑(Real.cos ((n : ℝ) * x)) + ↑(Real.sin ((n : ℝ) * x)) * I := by
+  rw [← euler_formula x, ← Complex.exp_nat_mul]
+  rw [show (n : ℂ) * ((x : ℂ) * I) = (((n : ℝ) * x : ℝ) : ℂ) * I from by
+    push_cast; ring]
+  rw [euler_formula]
+
+/-- **De Moivre's Theorem** (integer exponent).
+
+    `(cos x + i·sin x)^n = cos(nx) + i·sin(nx)` for all `n : ℤ`.
+
+    This covers negative powers, e.g. `(cos x + i·sin x)⁻¹ = cos x − i·sin x`. -/
+theorem de_moivre_int (x : ℝ) (n : ℤ) :
+    (↑(Real.cos x) + ↑(Real.sin x) * I) ^ n
+      = ↑(Real.cos ((n : ℝ) * x)) + ↑(Real.sin ((n : ℝ) * x)) * I := by
+  rw [← euler_formula x, ← Complex.exp_int_mul]
+  rw [show (n : ℂ) * ((x : ℂ) * I) = (((n : ℝ) * x : ℝ) : ℂ) * I from by
+    push_cast; ring]
+  rw [euler_formula]
+
+-- ============================================================================
+-- § 2. THE PRINCIPAL n-TH ROOT OF UNITY
+-- ============================================================================
+
+/-- The principal `n`-th root of unity `ω_n = e^{2πi/n}`. -/
+noncomputable def rou (n : ℕ) : ℂ := Complex.exp (((2 * π / n : ℝ)) * I)
+
+/-- `ω_n = cos(2π/n) + i·sin(2π/n)` — the geometric description via Euler. -/
+theorem rou_eq_cos_add_sin (n : ℕ) :
+    rou n = ↑(Real.cos (2 * π / n)) + ↑(Real.sin (2 * π / n)) * I := by
+  rw [rou, euler_formula]
+
+/-- `ω_n` is genuinely an `n`-th root of unity: `ω_n^n = 1`.
+
+    By De Moivre, `ω_n^n = cos(n·(2π/n)) + i·sin(n·(2π/n)) = cos(2π) + i·sin(2π)
+    = 1`. -/
+theorem rou_pow_n (n : ℕ) (hn : n ≠ 0) : (rou n) ^ n = 1 := by
+  have hnr : (n : ℝ) ≠ 0 := by exact_mod_cast hn
+  rw [rou_eq_cos_add_sin, de_moivre, show (n : ℝ) * (2 * π / n) = 2 * π from by
+    field_simp, Real.cos_two_pi, Real.sin_two_pi]
+  push_cast; ring
+
+/-- For `n ≥ 2`, the principal root is not `1`. -/
+theorem rou_ne_one (n : ℕ) (hn : 2 ≤ n) : rou n ≠ 1 := by
+  intro hcontra
+  simp only [rou, Complex.exp_eq_one_iff] at hcontra
+  obtain ⟨k, hk⟩ := hcontra
+  -- hk : (↑(2 * π / ↑n)) * I = ↑k * (2 * π * I)
+  have hI : (I : ℂ) ≠ 0 := Complex.I_ne_zero
+  -- Cancel the common factor `I` to reduce to a real-coefficient identity.
+  have hk2 : ((2 * π / n : ℝ) : ℂ) = (k : ℂ) * (2 * π) := by
+    have h : ((2 * π / n : ℝ) : ℂ) * I = ((k : ℂ) * (2 * π)) * I := by
+      rw [hk]; ring
+    exact mul_right_cancel₀ hI h
+  -- Take real parts: `2π/n = k·2π`.
+  have hreal : (2 * π / n : ℝ) = (k : ℝ) * (2 * π) := by
+    have hre := congrArg Complex.re hk2
+    push_cast at hre
+    simpa using hre
+  -- π > 0 and n ≥ 2 squeeze `k` strictly between 0 and 1, impossible for `k : ℤ`.
+  have hpi : (0 : ℝ) < π := Real.pi_pos
+  have hnpos : (0 : ℝ) < n := by positivity
+  have h2pi : (0 : ℝ) < 2 * π := by positivity
+  have hnreal : (2 : ℝ) ≤ n := by exact_mod_cast hn
+  have hlow : (0 : ℝ) < (k : ℝ) * (2 * π) := by rw [← hreal]; positivity
+  have hk_pos : (0 : ℝ) < (k : ℝ) := by nlinarith [hlow, h2pi]
+  have hupp : (2 * π / n : ℝ) < 2 * π := by
+    rw [div_lt_iff₀ hnpos]; nlinarith [hpi, hnreal]
+  have hk_lt : (k : ℝ) * (2 * π) < 2 * π := by rw [← hreal]; exact hupp
+  have hk_lt1 : (k : ℝ) < 1 := by nlinarith [hk_lt, h2pi]
+  have hk0 : (0 : ℤ) < k := by exact_mod_cast hk_pos
+  have hk1 : k < 1 := by exact_mod_cast hk_lt1
+  omega
+
+-- ============================================================================
+-- § 3. SUM OF THE n-TH ROOTS OF UNITY
+-- ============================================================================
+
+/-- **The `n`-th roots of unity sum to zero** (for `n ≥ 2`):
+
+    `∑_{k=0}^{n-1} ω_n^k = 0`.
+
+    The points `ω_n^k = e^{2πik/n}` are the vertices of a regular `n`-gon
+    inscribed in the unit circle; their centroid is the origin. The proof is the
+    finite geometric series `(ω_n^n − 1)/(ω_n − 1) = 0`, using `ω_n^n = 1` and
+    `ω_n ≠ 1`. -/
+theorem sum_rou_pow_eq_zero (n : ℕ) (hn : 2 ≤ n) :
+    ∑ k ∈ range n, (rou n) ^ k = 0 := by
+  have hne : rou n ≠ 1 := rou_ne_one n hn
+  rw [geom_sum_eq hne, rou_pow_n n (by omega), sub_self, zero_div]
+
+end EulerIdentityOQ01OQ03

--- a/src/data/proofs/euler-identity-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "eioq01x3-ann-01",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "concept",
+    "title": "Goal: The Multiplicative Theory of Euler's Formula",
+    "content": "The docstring poses the OQ-03 question: given Euler's formula $e^{ix} = \\cos x + i\\sin x$ (the parent's result), derive its *multiplicative* consequences — De Moivre's theorem $(\\cos x + i\\sin x)^n = \\cos nx + i\\sin nx$ and the vanishing $\\sum_{k<n} \\zeta_n^k = 0$ of the sum of the $n$-th roots of unity. Mathlib v4.26.0 has the exponent laws `exp_nat_mul`/`exp_int_mul` but neither the `cos + i\\sin` power-law repackaging nor an Euler-phrased roots-of-unity sum. The file delivers both with 0 axioms.",
+    "mathContext": "De Moivre (c. 1707) is the power law $(\\cos\\theta + i\\sin\\theta)^n = \\cos n\\theta + i\\sin n\\theta$; Euler (1748) revealed it as the exponent law $(e^{i\\theta})^n = e^{in\\theta}$.",
+    "significance": "Frames the contribution as the multiplicative counterpart to the additive/Lie-group OQ-01 lineage, and is honest that the parent file is re-derived (not imported) because it no longer compiles under Mathlib v4.26.0.",
+    "prerequisites": ["Euler's formula", "complex exponential"],
+    "relatedConcepts": ["De Moivre's theorem", "roots of unity"]
+  },
+  {
+    "id": "eioq01x3-ann-02",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 63, "endLine": 70 },
+    "type": "definition",
+    "title": "Euler's Formula, One Line from Complex.exp_mul_I",
+    "content": "`euler_formula (x : ℝ) : exp(↑x·I) = ↑(cos x) + ↑(sin x)·I`. Mathlib's `Complex.exp_mul_I` states $e^{zI} = \\cos z + \\sin z\\,I$ over ℂ; specialising $z = \\uparrow x$ and rewriting with `← ofReal_cos`, `← ofReal_sin` pushes the complex $\\cos/\\sin$ back to the real ones. This is the seed of every later theorem.",
+    "mathContext": "$e^{ix} = \\cos x + i\\sin x$ — the analytic identity the parent reconstructs from $\\sum (ix)^n/n!$ via even/odd splitting.",
+    "significance": "Keeps the file self-contained and axiom-free: rather than import the (currently broken) parent, the canonical Mathlib statement is used directly.",
+    "prerequisites": ["Complex.exp_mul_I", "ofReal_cos / ofReal_sin"],
+    "relatedConcepts": ["Euler's formula"]
+  },
+  {
+    "id": "eioq01x3-ann-03",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 88 },
+    "type": "insight",
+    "title": "De Moivre's Theorem (natural exponent)",
+    "content": "`de_moivre (x : ℝ) (n : ℕ) : (↑(cos x) + ↑(sin x)·I)^n = ↑(cos(n·x)) + ↑(sin(n·x))·I`. Proof: rewrite the base $\\cos x + i\\sin x = e^{ix}$ (Euler, backwards), fold the power $\\;(e^{ix})^n = e^{i(nx)}$ with `← Complex.exp_nat_mul`, normalise the exponent $\\uparrow n \\cdot (\\uparrow x\\cdot I) = \\uparrow(n x)\\cdot I$ by `push_cast; ring`, then re-expand with Euler at $nx$. The entire proof is Euler's formula used twice with one exponent law between.",
+    "mathContext": "$(\\cos x + i\\sin x)^n = (e^{ix})^n = e^{inx} = \\cos nx + i\\sin nx$.",
+    "significance": "De Moivre's theorem in this `cos + i\\sin` form is NOT a named lemma in Mathlib v4.26.0 (only the bare exponent law `exp_nat_mul` is); this fills the gap.",
+    "prerequisites": ["euler_formula", "Complex.exp_nat_mul"],
+    "relatedConcepts": ["De Moivre's theorem", "multiple-angle formulas"]
+  },
+  {
+    "id": "eioq01x3-ann-04",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 90, "endLine": 101 },
+    "type": "insight",
+    "title": "De Moivre for Integer Exponents (negative powers)",
+    "content": "`de_moivre_int (x : ℝ) (n : ℤ)` proves the same identity for all integer $n$ using `← Complex.exp_int_mul` (the zpow exponent law) in place of `exp_nat_mul`. This genuinely extends the ℕ form: at $n = -1$ it gives $(\\cos x + i\\sin x)^{-1} = \\cos x - i\\sin x$, the reciprocal/conjugate identity on the unit circle.",
+    "mathContext": "$(\\cos x + i\\sin x)^{-1} = e^{-ix} = \\cos x - i\\sin x = \\overline{e^{ix}}$.",
+    "significance": "Negative powers are not formally implied by the ℕ statement; the integer version is a strictly stronger result.",
+    "prerequisites": ["euler_formula", "Complex.exp_int_mul", "zpow on units"],
+    "relatedConcepts": ["complex conjugation", "unit circle"]
+  },
+  {
+    "id": "eioq01x3-ann-05",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 107, "endLine": 113 },
+    "type": "definition",
+    "title": "The Principal n-th Root of Unity ω_n",
+    "content": "`rou (n : ℕ) : ℂ := exp((2π/n)·I)`, with `rou_eq_cos_add_sin` giving the geometric form $\\omega_n = \\cos(2\\pi/n) + i\\sin(2\\pi/n)$ via Euler. This is $e^{2\\pi i/n}$, the canonical primitive $n$-th root of unity and the first vertex (after 1) of the regular $n$-gon inscribed in the unit circle.",
+    "mathContext": "$\\omega_n = e^{2\\pi i/n}$, $\\omega_n^k = e^{2\\pi i k/n}$ are the $n$ vertices of a regular $n$-gon on $S^1$.",
+    "significance": "Defining the root of unity through the exponential (not through `IsPrimitiveRoot`) keeps the development tied to Euler's formula and self-contained.",
+    "prerequisites": ["euler_formula", "complex exponential"],
+    "relatedConcepts": ["roots of unity", "regular polygon"]
+  },
+  {
+    "id": "eioq01x3-ann-06",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 115, "endLine": 123 },
+    "type": "insight",
+    "title": "ω_n is an n-th Root of Unity: ω_n^n = 1",
+    "content": "`rou_pow_n (n : ℕ) (hn : n ≠ 0) : (rou n)^n = 1`. Apply De Moivre at the angle $2\\pi/n$: $\\omega_n^n = \\cos(n\\cdot 2\\pi/n) + i\\sin(n\\cdot 2\\pi/n)$, simplify $n\\cdot(2\\pi/n) = 2\\pi$ with `field_simp`, and `cos_two_pi`/`sin_two_pi` collapse the right side to $1 + 0\\cdot i = 1$. A clean reuse of the De Moivre lemma rather than a fresh exp computation.",
+    "mathContext": "$\\omega_n^n = e^{2\\pi i} = \\cos 2\\pi + i\\sin 2\\pi = 1$.",
+    "significance": "Establishes that $\\omega_n$ is a genuine root of $X^n - 1$, the prerequisite for the geometric-series argument.",
+    "prerequisites": ["de_moivre", "Real.cos_two_pi", "Real.sin_two_pi"],
+    "relatedConcepts": ["roots of unity"]
+  },
+  {
+    "id": "eioq01x3-ann-07",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 155 },
+    "type": "insight",
+    "title": "ω_n ≠ 1 for n ≥ 2: an Integer Squeeze",
+    "content": "`rou_ne_one (n : ℕ) (hn : 2 ≤ n)`. From $e^{(2\\pi/n)I} = 1$, `Complex.exp_eq_one_iff` produces $\\exists k:\\mathbb{Z},\\ (2\\pi/n)I = k\\cdot(2\\pi I)$. Cancelling the nonzero factor $I$ and taking real parts gives $2\\pi/n = k\\cdot 2\\pi$, hence $1/n = k$. With $\\pi > 0$ and $n \\ge 2$ this squeezes $0 < k < 1$, impossible for an integer (`omega`). This is the single point where real analysis (the kernel of $\\exp$) enters.",
+    "mathContext": "$e^{2\\pi i/n} = 1 \\iff 1/n \\in \\mathbb{Z}$, false for $n \\ge 2$.",
+    "significance": "Non-triviality of $\\omega_n$ is exactly what lets the geometric series have a nonzero denominator $\\omega_n - 1$.",
+    "prerequisites": ["Complex.exp_eq_one_iff", "mul_right_cancel₀", "integer ordering (omega)"],
+    "relatedConcepts": ["kernel of the exponential", "primitive root"]
+  },
+  {
+    "id": "eioq01x3-ann-08",
+    "proofId": "euler-identity-oq-01-oq-03",
+    "range": { "startLine": 157, "endLine": 173 },
+    "type": "insight",
+    "title": "The n-th Roots of Unity Sum to Zero",
+    "content": "`sum_rou_pow_eq_zero (n : ℕ) (hn : 2 ≤ n) : ∑_{k<n} (rou n)^k = 0`. The finite geometric series `geom_sum_eq` (valid since $\\omega_n \\ne 1$) gives $\\sum_{k<n}\\omega_n^k = (\\omega_n^n - 1)/(\\omega_n - 1)$, and $\\omega_n^n = 1$ makes the numerator vanish. Geometrically: the centroid of the vertices of a regular $n$-gon on the unit circle is the centre.",
+    "mathContext": "$\\sum_{k=0}^{n-1} e^{2\\pi i k/n} = \\dfrac{e^{2\\pi i} - 1}{e^{2\\pi i/n} - 1} = 0$ for $n \\ge 2$.",
+    "significance": "A clean structural consequence proved from first principles (geometric series) rather than a roots-of-unity-specific Mathlib lemma, keeping the whole chain anchored in Euler's formula.",
+    "prerequisites": ["geom_sum_eq", "rou_pow_n", "rou_ne_one"],
+    "relatedConcepts": ["geometric series", "cyclotomic polynomials", "centroid"]
+  }
+]

--- a/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-03/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "euler-identity-oq-01-oq-03",
+  "slug": "euler-identity-oq-01-oq-03",
+  "title": "De Moivre's Theorem and the Sum of the Roots of Unity",
+  "sorries": 0,
+  "description": "Develops the multiplicative theory of Euler's formula. From e^{ix} = cos x + i·sin x, De Moivre's theorem (cos x + i·sin x)^n = cos(nx) + i·sin(nx) follows by collapsing the power to (e^{ix})^n = e^{inx} and re-expanding; the integer-exponent form covers negative powers. As a structural consequence, the principal n-th root of unity ω_n = e^{2πi/n} satisfies ω_n^n = 1 and ω_n ≠ 1 for n ≥ 2, so the finite geometric series gives ∑_{k<n} ω_n^k = 0 — the n-th roots of unity sum to zero. Mathlib exposes exp_nat_mul / exp_int_mul but no named `cos + i·sin` power law and no Euler-formula-phrased statement that the roots of unity sum to zero; this file supplies both with 0 axioms.",
+  "overview": {
+    "historicalContext": "De Moivre's theorem (Abraham de Moivre, c. 1707, published in fuller form 1722) predates Euler's formula and was originally an empirical observation about expanding $(\\cos\\theta + i\\sin\\theta)^n$. Euler's 1748 identity $e^{ix} = \\cos x + i\\sin x$ explained it: the power law $(\\cos x + i\\sin x)^n = \\cos nx + i\\sin nx$ is nothing but the exponent law $(e^{ix})^n = e^{inx}$ in disguise. The same circle of ideas produces the $n$-th roots of unity $\\zeta_n^k = e^{2\\pi ik/n}$, the vertices of a regular $n$-gon on the unit circle, whose sum vanishes for $n \\ge 2$ — the algebraic shadow of the geometric fact that the centroid of a regular polygon is its centre. This file takes the parent's Euler formula and builds exactly this multiplicative layer.",
+    "problemStatement": "Derive, directly from Euler's formula, (1) De Moivre's theorem for natural and integer exponents, and (2) the structural identity $\\sum_{k=0}^{n-1} \\zeta_n^k = 0$ for the principal $n$-th root of unity $\\zeta_n = e^{2\\pi i/n}$ with $n \\ge 2$, with no axioms.",
+    "text": "Re-proves Euler's formula in one line from Mathlib's `Complex.exp_mul_I` (the canonical statement the parent reconstructs from the Taylor series), then derives De Moivre's theorem for ℕ and ℤ exponents via `Complex.exp_nat_mul` / `Complex.exp_int_mul`. Defines the principal root of unity `rou n = exp((2π/n)·I)`, proves `rou n ^ n = 1` (via De Moivre at the angle 2π/n) and `rou n ≠ 1` for n ≥ 2 (via `Complex.exp_eq_one_iff`), and concludes `∑_{k<n} (rou n)^k = 0` from the finite geometric series `geom_sum_eq`.",
+    "proofStrategy": "1. `euler_formula`: `Complex.exp_mul_I` gives e^{ix} = cos↑x + sin↑x·I over ℂ; `ofReal_cos`/`ofReal_sin` push the complex cos/sin back to real cos/sin. 2. `de_moivre`: rewrite cos x + i·sin x = e^{ix}, fold (e^{ix})^n into e^{i(nx)} with `← exp_nat_mul`, normalise the exponent ↑n·(↑x·I) = ↑(n·x)·I by push_cast/ring, re-expand with Euler. 3. `de_moivre_int`: identical with `← exp_int_mul` (zpow), covering negative exponents. 4. `rou_pow_n`: rewrite ω_n via Euler, apply De Moivre at angle 2π/n, simplify n·(2π/n) = 2π with field_simp, then `cos_two_pi`/`sin_two_pi` collapse to 1. 5. `rou_ne_one`: from exp((2π/n)·I) = 1, `Complex.exp_eq_one_iff` yields ∃k:ℤ, (2π/n)·I = k·(2πI); cancel I, take real parts to get 2π/n = k·2π, and π>0 with n≥2 squeezes 0 < k < 1, impossible for an integer (omega). 6. `sum_rou_pow_eq_zero`: `geom_sum_eq` (needs ω_n ≠ 1) gives (ω_n^n − 1)/(ω_n − 1), and ω_n^n = 1 makes the numerator vanish.",
+    "keyInsights": [
+      "De Moivre's theorem is *not* a named lemma in Mathlib v4.26.0. Mathlib has the exponent laws `Complex.exp_nat_mul` and `Complex.exp_int_mul`, but the `cos + i·sin` power-law repackaging — the form actually used in trigonometry and root-of-unity arguments — is not exposed. This file supplies it for both ℕ and ℤ exponents.",
+      "The whole multiplicative theory is one observation: `cos x + i·sin x = e^{ix}`, so a *power* of the left side is an *exponent multiple* on the right. Every theorem here is that substitution plus normalising a coercion (`push_cast; ring`).",
+      "The integer form `de_moivre_int` is genuinely more than the ℕ form: it gives negative powers, e.g. `(cos x + i·sin x)⁻¹ = cos x − i·sin x` (the n = −1 case), the complex-conjugate / reciprocal identity on the unit circle.",
+      "Sum of roots of unity = 0 is proved through the *finite geometric series*, not through any roots-of-unity-specific Mathlib API. The only inputs are `geom_sum_eq` (a field identity), `ω_n^n = 1`, and `ω_n ≠ 1`. This keeps the derivation elementary and tied to Euler's formula rather than to `IsPrimitiveRoot`.",
+      "`ω_n ≠ 1` for n ≥ 2 is the one place real analysis enters: `Complex.exp_eq_one_iff` reduces it to the impossibility of `1/n` being an integer when `n ≥ 2`, closed by a `0 < k < 1` squeeze and `omega`.",
+      "Self-contained by necessity: the parent file `Proofs/EulerIdentityOQ01.lean` does not compile under Mathlib v4.26.0 (its local `cos_eq_tsum`/`sin_eq_tsum` now name-collide with Mathlib's, producing `Ambiguous term` errors), so this file re-establishes Euler's formula in one line from `Complex.exp_mul_I` instead of importing the parent. The mathematics is unchanged — `exp_mul_I` is precisely the statement the parent reconstructs from the Taylor series."
+    ]
+  },
+  "mainTheorems": [
+    "de_moivre",
+    "de_moivre_int",
+    "rou_pow_n",
+    "sum_rou_pow_eq_zero"
+  ],
+  "sections": [
+    {
+      "id": "sec-euler",
+      "title": "Euler's Formula (real argument)",
+      "startLine": 59,
+      "endLine": 71,
+      "summary": "Re-proves e^{ix} = cos x + i·sin x for a real angle in one line from Mathlib's Complex.exp_mul_I, pushing the complex cos/sin to real cos/sin via ofReal_cos/ofReal_sin. This is the same statement the parent reconstructs from the Taylor series; it is taken here as the foundation of the multiplicative theory.",
+      "concepts": ["Euler's formula", "Complex.exp_mul_I", "ofReal_cos / ofReal_sin"]
+    },
+    {
+      "id": "sec-de-moivre",
+      "title": "De Moivre's Theorem",
+      "startLine": 72,
+      "endLine": 101,
+      "summary": "De Moivre's theorem for natural and integer exponents: (cos x + i·sin x)^n = cos(nx) + i·sin(nx). Each is Euler's formula applied twice with the exponent law exp_nat_mul / exp_int_mul in between. The integer version covers negative powers.",
+      "concepts": ["De Moivre's theorem", "exp_nat_mul", "exp_int_mul", "zpow / negative exponents"]
+    },
+    {
+      "id": "sec-rou",
+      "title": "The Principal n-th Root of Unity",
+      "startLine": 103,
+      "endLine": 155,
+      "summary": "Defines ω_n = exp((2π/n)·I), its geometric form cos(2π/n) + i·sin(2π/n), the root-of-unity property ω_n^n = 1 (via De Moivre at angle 2π/n), and the non-triviality ω_n ≠ 1 for n ≥ 2 (via Complex.exp_eq_one_iff and an integer squeeze).",
+      "concepts": ["roots of unity", "exp_two_pi_mul_I", "Complex.exp_eq_one_iff", "cos_two_pi / sin_two_pi"]
+    },
+    {
+      "id": "sec-sum",
+      "title": "Sum of the n-th Roots of Unity",
+      "startLine": 157,
+      "endLine": 173,
+      "summary": "∑_{k<n} ω_n^k = 0 for n ≥ 2, via the finite geometric series geom_sum_eq with ω_n^n = 1 and ω_n ≠ 1. The algebraic statement that the centroid of a regular n-gon on the unit circle is the origin.",
+      "concepts": ["geometric series", "geom_sum_eq", "centroid of regular polygon"]
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/EulerIdentityOQ01OQ03.lean",
+    "filename": "EulerIdentityOQ01OQ03.lean",
+    "lineCount": 174,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "sorries": 0,
+    "axiomCount": 0,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerIdentityOQ01OQ03.lean",
+    "tags": [
+      "complex-analysis",
+      "trigonometry",
+      "de-moivre",
+      "roots-of-unity",
+      "euler-formula",
+      "geometric-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 174,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exp_mul_I",
+        "description": "Euler's formula over ℂ: exp(z·I) = cos z + sin z·I. Specialised to a real angle to seed the multiplicative theory.",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Complex.exp_nat_mul",
+        "description": "Exponent law exp(n·z) = (exp z)^n, the engine of De Moivre for natural exponents.",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Complex.exp_int_mul",
+        "description": "Integer exponent law exp(n·z) = (exp z)^n (zpow), giving De Moivre for negative exponents.",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Complex.exp_two_pi_mul_I",
+        "description": "exp(2π·I) = 1, used (through De Moivre) to prove ω_n^n = 1.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Complex.exp_eq_one_iff",
+        "description": "exp x = 1 ↔ ∃ n : ℤ, x = n·(2π·I); the analytic input that forces ω_n ≠ 1 for n ≥ 2.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Log"
+      },
+      {
+        "theorem": "geom_sum_eq",
+        "description": "Finite geometric series x ≠ 1 → ∑_{i<n} x^i = (x^n − 1)/(x − 1); collapses to 0 when x^n = 1.",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      }
+    ],
+    "originalContributions": [
+      "de_moivre : (cos x + i·sin x)^n = cos(nx) + i·sin(nx) for n : ℕ — De Moivre's theorem, not exposed as a named lemma in Mathlib v4.26.0",
+      "de_moivre_int : the same for n : ℤ, covering negative powers (e.g. the n = −1 reciprocal/conjugate identity)",
+      "rou n := exp((2π/n)·I) with rou_pow_n (ω_n^n = 1) and rou_ne_one (ω_n ≠ 1 for n ≥ 2)",
+      "sum_rou_pow_eq_zero : ∑_{k<n} ω_n^k = 0 for n ≥ 2, derived from Euler's formula via the finite geometric series"
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Euler's formula exp(ix) = cos x + i sin x (parent EulerIdentityOQ01; here re-derived from Complex.exp_mul_I)",
+      "The complex exponent laws exp_nat_mul and exp_int_mul",
+      "Finite geometric series identity geom_sum_eq"
+    ],
+    "assumptions": "0 axioms, 0 sorries. All five headline results depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms); none uses native_decide, so there is no Lean.ofReduceBool dependency.",
+    "relatedProblems": [
+      "euler-identity",
+      "euler-identity-oq-01",
+      "euler-identity-oq-01-oq-01",
+      "euler-identity-oq-01-oq-04"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "references": {
+    "papers": [
+      {
+        "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+        "authors": ["Abraham de Moivre"],
+        "year": 1730,
+        "description": "Source of the power law (cos θ + i sin θ)^n = cos nθ + i sin nθ that bears de Moivre's name."
+      },
+      {
+        "title": "Introductio in analysin infinitorum, Vol. 1, Ch. 8",
+        "authors": ["Leonhard Euler"],
+        "year": 1748,
+        "description": "Euler's formula e^{ix} = cos x + i sin x, the identity that turns De Moivre's power law into the exponent law."
+      }
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Analysis.Complex.Trigonometric",
+      "Mathlib.Analysis.Complex.Exponential",
+      "Mathlib.Algebra.Field.GeomSum"
+    ]
+  },
+  "crossReferences": [
+    {
+      "type": "extends",
+      "id": "euler-identity-oq-01",
+      "description": "Parent: 'Euler's Formula via Taylor Series Splitting' proves e^{ix} = cos x + i·sin x. This file builds the multiplicative layer — De Moivre and the roots of unity — on top of that identity."
+    },
+    {
+      "type": "related",
+      "id": "euler-identity-oq-01-oq-04",
+      "description": "Sibling on the additive side: that file packages ℝ/2πℤ ≃+ Additive Circle (the group structure of S¹); this file develops the power/root-of-unity structure of the same circle."
+    },
+    {
+      "type": "related",
+      "id": "euler-identity",
+      "description": "Great-grandparent: the point identity e^{iπ} + 1 = 0 is the n = 2 root of unity ω_2 = e^{iπ} = −1; the sum ∑ ω_2^k = 1 + (−1) = 0 is the simplest case of sum_rou_pow_eq_zero."
+    }
+  ],
+  "conclusion": {
+    "summary": "From Euler's formula alone, De Moivre's theorem (for ℕ and ℤ exponents) and the vanishing of the sum of the n-th roots of unity are formalized with 0 axioms. De Moivre is the `cos + i·sin` repackaging of the exponent law that Mathlib v4.26.0 leaves unnamed; the roots-of-unity sum is derived through the finite geometric series rather than Mathlib's IsPrimitiveRoot API, keeping the argument tied to Euler's formula.",
+    "implications": "Supplies the multiplicative counterpart to the OQ-01 lineage: where the parent and the OQ-04 sibling develop Euler's formula as an additive/Lie-group statement (ℝ/2πℤ ≅ S¹), this file develops its power structure (De Moivre) and the regular-polygon identity ∑ ζ^k = 0. De Moivre's theorem in `cos + i·sin` form fills a small but real Mathlib gap and is the standard tool behind multiple-angle formulas and root extraction.",
+    "openQuestions": [
+      "Extract the real/imaginary parts of De Moivre to obtain the multiple-angle expansions cos(nx) = ∑ binomial terms in cos/sin (the Chebyshev-polynomial connection): cos(nx) = T_n(cos x). Is T_n recoverable as a named polynomial identity from de_moivre via the binomial theorem?",
+      "Promote rou to a bundled IsPrimitiveRoot ζ n witness and show {ω_n^k : k < n} are exactly the n distinct n-th roots of unity (injectivity on range n), recovering the cyclotomic factorization X^n − 1 = ∏_{k<n}(X − ω_n^k)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Research session for **euler-identity-oq-01-oq-03**, the OQ-03 follow-up to *Euler's Formula via Taylor Series Splitting*. Develops the **multiplicative** theory of Euler's formula — De Moivre's theorem and the vanishing sum of the roots of unity — with **0 axioms**.

The existing children of the parent mine the *additive* / Lie-group thread (ℝ→S¹ homomorphism, AddCircle (2π) ≃+ Additive Circle, Taylor-reversal). This entry is the distinct multiplicative counterpart.

## Results (`Proofs/EulerIdentityOQ01OQ03.lean`, 7 thm / 1 def / 174 lines)

- **`de_moivre`** / **`de_moivre_int`** — `(cos x + i·sin x)^n = cos(nx) + i·sin(nx)` for `n : ℕ` and `n : ℤ`. This `cos + i·sin` power law is **not a named lemma in Mathlib v4.26.0** (only the bare exponent laws `exp_nat_mul`/`exp_int_mul` are). The integer form covers negative powers, e.g. the `n = −1` reciprocal/conjugate identity.
- **`rou n := exp((2π/n)·I)`** — the principal n-th root of unity, with `rou_eq_cos_add_sin` (geometric form), **`rou_pow_n`** (`ω_n^n = 1`, via De Moivre), **`rou_ne_one`** (`ω_n ≠ 1` for `n ≥ 2`, via `Complex.exp_eq_one_iff` + an integer squeeze).
- **`sum_rou_pow_eq_zero`** — `∑_{k<n} ω_n^k = 0` for `n ≥ 2`, from the finite geometric series `geom_sum_eq`. Algebraically: the centroid of a regular n-gon on the unit circle is its centre.

## Verification

- Builds clean under Mathlib v4.26.0 (docker down → host build, `LAKE_UNSAFE=1`, exit 0, 7743 jobs).
- `#print axioms` on all five headline results: only `propext` / `Classical.choice` / `Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`, no sorries. → **status `verified`, badge `original`, axiomCount 0**.

## Findings / note

The parent file `Proofs/EulerIdentityOQ01.lean` **does not currently compile under Mathlib v4.26.0**: its local lemmas `cos_eq_tsum` / `sin_eq_tsum` now name-collide with Mathlib's, producing `Ambiguous term` errors (also `ext` conv + a `linarith` failure). To stay axiom-free this file is **self-contained**, re-deriving Euler's formula in one line from Mathlib's canonical `Complex.exp_mul_I` (the exact statement the parent reconstructs). Flagging the parent breakage for a future repair pass (out of scope here).

## Status

**Outcome**: completed (new verified gallery entry)
**Next Steps**: (1) extract real/imaginary parts of De Moivre → multiple-angle / Chebyshev `cos(nx) = T_n(cos x)`; (2) bundle `rou` as `IsPrimitiveRoot` and recover the cyclotomic factorization `X^n − 1 = ∏(X − ω_n^k)`.

🤖 Generated by researcher-10