### PR TITLE
research(isoperimetric-oq-02-oq-03-oq-01): edge boundary = 2·runs, quantitative 1D stability [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3106,6 +3106,7 @@ import Proofs.InverseGaloisOQ06OQ01
 import Proofs.IsoperimetricTheorem
 import Proofs.IsoperimetricTheoremOQ01
 import Proofs.IsoperimetricTheoremOQ02
+import Proofs.IsoperimetricTheoremOQ02OQ03OQ01
 import Proofs.IsoscelesTriangle
 import Proofs.IsoscelesTriangleOQ02
 import Proofs.IsoscelesTriangleOQ01

--- a/proofs/Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean
+++ b/proofs/Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean
@@ -1,0 +1,266 @@
+/-
+Quantitative 1D Edge-Isoperimetric Stability: Boundary Counts Runs
+
+Open Question from: Isoperimetric Theorem (Wiedijk #43), OQ-02 → OQ-03 → OQ-01
+
+The parent entry (IsoperimetricTheoremOQ02OQ03) proves the *equality rigidity*
+for the discrete 1D isoperimetric inequality on `ℤ`: a finite nonempty `S ⊆ ℤ`
+has *vertex* boundary `|∂S| = 2` iff `S` is an integer interval. In its closing
+remark it flags — but does **not** prove — the clean *edge*-boundary statement:
+
+  "The edge count (number of lattice edges crossing between S and its complement)
+   equals 2·(number of maximal runs)."
+
+This file proves exactly that identity and its quantitative consequences.
+
+Setup.
+  For a finite `S ⊆ ℤ` write `m = min S`, `M = max S`. A *maximal run* is a
+  maximal block of consecutive integers contained in `S`. We count runs by their
+  left endpoints:
+        `numRuns S := |{ x ∈ S : x - 1 ∉ S }|`.
+  The *edge boundary* is the set of lattice edges `(x, x+1)` with exactly one
+  endpoint in `S`. Such an edge is either *rising* (`x ∉ S`, `x+1 ∈ S`) or
+  *falling* (`x ∈ S`, `x+1 ∉ S`); we count
+        `edgeBoundaryCount S := |(S-1) \ S| + |(S+1) \ S|`
+  where `S ± 1` is the image of `S` under translation. The first summand counts
+  rising edges, the second falling edges.
+
+Main result.
+        `edgeBoundaryCount S = 2 * numRuns S`,
+  hence `edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1`: each additional
+  maximal run (each gap) contributes exactly two boundary edges. This is the
+  precise "boundary = 2·runs" identity and the quantitative stability statement.
+
+Proof idea (no telescoping needed).
+  Let `numRuns = |leftEnds|` count left endpoints `{x∈S : x-1∉S}` and let
+  `numEnds = |rightEnds|` count right endpoints `{x∈S : x+1∉S}`. Within `S`,
+  the left endpoints are the complement of the "has-predecessor" set
+  `internalL = {x∈S : x-1∈S}`, and the right endpoints are the complement of the
+  "has-successor" set `internalR = {x∈S : x+1∈S}`. The translation `x ↦ x-1` is a
+  bijection `internalL ≃ internalR`, so `|internalL| = |internalR|`, whence
+  `|leftEnds| = |S| - |internalL| = |S| - |internalR| = |rightEnds|`. The two edge
+  summands have the same cardinalities as `leftEnds` and `rightEnds`
+  respectively, so `edgeBoundaryCount = |leftEnds| + |rightEnds| = 2·numRuns`.
+
+References:
+  - Bollobás (1986), Combinatorics, Cambridge University Press.
+  - Harper (1966), Optimal numberings and isoperimetric problems on graphs.
+
+Tags: combinatorics, discrete-geometry, isoperimetric-inequality, stability
+-/
+import Mathlib
+
+namespace DiscreteIsoperimetric1DRuns
+
+/-- Right endpoints of the maximal runs of `S`: elements whose successor is
+    missing. -/
+def rightEnds (S : Finset ℤ) : Finset ℤ := S.filter (fun x => x + 1 ∉ S)
+
+/-- Left endpoints of the maximal runs of `S`: elements whose predecessor is
+    missing. The number of maximal runs is `|leftEnds S|`. -/
+def leftEnds (S : Finset ℤ) : Finset ℤ := S.filter (fun x => x - 1 ∉ S)
+
+/-- Elements of `S` whose successor is also in `S` ("has a right neighbour"). -/
+def internalR (S : Finset ℤ) : Finset ℤ := S.filter (fun x => x + 1 ∈ S)
+
+/-- Elements of `S` whose predecessor is also in `S` ("has a left neighbour"). -/
+def internalL (S : Finset ℤ) : Finset ℤ := S.filter (fun x => x - 1 ∈ S)
+
+/-- The number of maximal runs of `S`, counted by left endpoints. -/
+def numRuns (S : Finset ℤ) : ℕ := (leftEnds S).card
+
+/-- The number of boundary edges: rising edges `(S-1)\S` plus falling edges
+    `(S+1)\S`. -/
+def edgeBoundaryCount (S : Finset ℤ) : ℕ :=
+  ((S.image (· - 1)) \ S).card + ((S.image (· + 1)) \ S).card
+
+/-! ### Internal "has-neighbour" sets are equinumerous -/
+
+/-- Translation `x ↦ x - 1` carries the has-predecessor set onto the
+    has-successor set; hence they have equal cardinality. -/
+theorem card_internalL_eq_card_internalR (S : Finset ℤ) :
+    (internalL S).card = (internalR S).card := by
+  apply Finset.card_bij (fun x _ => x - 1)
+  · -- maps internalL into internalR
+    intro a ha
+    simp only [internalL, Finset.mem_filter] at ha
+    simp only [internalR, Finset.mem_filter]
+    obtain ⟨haS, hpred⟩ := ha
+    refine ⟨hpred, ?_⟩
+    simpa using haS
+  · -- injective
+    intro a _ b _ hab
+    omega
+  · -- surjective
+    intro b hb
+    simp only [internalR, Finset.mem_filter] at hb
+    refine ⟨b + 1, ?_, by ring⟩
+    simp only [internalL, Finset.mem_filter]
+    exact ⟨hb.2, by simpa using hb.1⟩
+
+/-! ### Left/right endpoint counts agree (= number of runs) -/
+
+/-- Within `S`, the right endpoints partition off the has-successor elements. -/
+theorem card_rightEnds_add_card_internalR (S : Finset ℤ) :
+    (rightEnds S).card + (internalR S).card = S.card := by
+  have key : internalR S = S.filter (fun x => ¬ (x + 1 ∉ S)) := by
+    simp only [internalR, not_not]
+  rw [rightEnds, key]
+  exact Finset.filter_card_add_filter_neg_card_eq_card (fun x => x + 1 ∉ S)
+
+/-- Within `S`, the left endpoints partition off the has-predecessor elements. -/
+theorem card_leftEnds_add_card_internalL (S : Finset ℤ) :
+    (leftEnds S).card + (internalL S).card = S.card := by
+  have key : internalL S = S.filter (fun x => ¬ (x - 1 ∉ S)) := by
+    simp only [internalL, not_not]
+  rw [leftEnds, key]
+  exact Finset.filter_card_add_filter_neg_card_eq_card (fun x => x - 1 ∉ S)
+
+/-- **Left = right.** The number of left endpoints equals the number of right
+    endpoints: every maximal run starts once and ends once. -/
+theorem card_leftEnds_eq_card_rightEnds (S : Finset ℤ) :
+    (leftEnds S).card = (rightEnds S).card := by
+  have hL := card_leftEnds_add_card_internalL S
+  have hR := card_rightEnds_add_card_internalR S
+  have hint := card_internalL_eq_card_internalR S
+  omega
+
+/-! ### Edge summands count endpoints -/
+
+/-- The rising-edge set `(S-1)\S` is the `(· - 1)`-image of the left endpoints,
+    hence has cardinality `numRuns`. -/
+theorem card_image_sub_one_sdiff (S : Finset ℤ) :
+    ((S.image (· - 1)) \ S).card = (leftEnds S).card := by
+  have hset : (S.image (· - 1)) \ S = (leftEnds S).image (· - 1) := by
+    ext x
+    simp only [Finset.mem_sdiff, Finset.mem_image, leftEnds, Finset.mem_filter]
+    constructor
+    · rintro ⟨⟨a, ha, rfl⟩, hx⟩
+      exact ⟨a, ⟨ha, by simpa using hx⟩, rfl⟩
+    · rintro ⟨a, ⟨ha, hpred⟩, rfl⟩
+      exact ⟨⟨a, ha, rfl⟩, by simpa using hpred⟩
+  rw [hset, Finset.card_image_of_injective]
+  intro a b hab
+  simpa using hab
+
+/-- The falling-edge set `(S+1)\S` is the `(· + 1)`-image of the right endpoints,
+    hence has cardinality `|rightEnds|`. -/
+theorem card_image_add_one_sdiff (S : Finset ℤ) :
+    ((S.image (· + 1)) \ S).card = (rightEnds S).card := by
+  have hset : (S.image (· + 1)) \ S = (rightEnds S).image (· + 1) := by
+    ext x
+    simp only [Finset.mem_sdiff, Finset.mem_image, rightEnds, Finset.mem_filter]
+    constructor
+    · rintro ⟨⟨a, ha, rfl⟩, hx⟩
+      exact ⟨a, ⟨ha, by simpa using hx⟩, rfl⟩
+    · rintro ⟨a, ⟨ha, hsucc⟩, rfl⟩
+      exact ⟨⟨a, ha, rfl⟩, by simpa using hsucc⟩
+  rw [hset, Finset.card_image_of_injective]
+  intro a b hab
+  simpa using hab
+
+/-! ### Main identity: boundary = 2 · runs -/
+
+/-- **Boundary counts runs.** For any finite `S ⊆ ℤ`, the number of boundary
+    edges equals twice the number of maximal runs:
+        `edgeBoundaryCount S = 2 * numRuns S`.
+    Each maximal run contributes exactly two boundary edges (one rising at its
+    left end, one falling at its right end). -/
+theorem edgeBoundaryCount_eq_two_mul_numRuns (S : Finset ℤ) :
+    edgeBoundaryCount S = 2 * numRuns S := by
+  rw [edgeBoundaryCount, numRuns, card_image_sub_one_sdiff,
+    card_image_add_one_sdiff, ← card_leftEnds_eq_card_rightEnds]
+  ring
+
+/-- **Quantitative stability.** The boundary has `2 + 2k` edges iff `S` has
+    exactly `k + 1` maximal runs: each extra run/gap adds two boundary edges. -/
+theorem edgeBoundaryCount_eq_iff_numRuns (S : Finset ℤ) (k : ℕ) :
+    edgeBoundaryCount S = 2 + 2 * k ↔ numRuns S = k + 1 := by
+  rw [edgeBoundaryCount_eq_two_mul_numRuns]
+  omega
+
+/-! ### Endpoints, nonemptiness and the single-run (interval) case -/
+
+/-- For nonempty `S`, the minimum is a left endpoint, so there is at least one
+    run. -/
+theorem min'_mem_leftEnds {S : Finset ℤ} (h : S.Nonempty) :
+    S.min' h ∈ leftEnds S := by
+  simp only [leftEnds, Finset.mem_filter]
+  refine ⟨S.min'_mem h, ?_⟩
+  intro hcon
+  have := S.min'_le _ hcon
+  omega
+
+/-- A nonempty set has at least one run. -/
+theorem one_le_numRuns {S : Finset ℤ} (h : S.Nonempty) : 1 ≤ numRuns S := by
+  rw [numRuns]
+  exact Finset.card_pos.mpr ⟨S.min' h, min'_mem_leftEnds h⟩
+
+/-- A nonempty set with a single run has boundary exactly `2`, recovering the
+    interval case of the parent rigidity theorem. -/
+theorem numRuns_eq_one_iff_edgeBoundaryCount_eq_two {S : Finset ℤ} :
+    numRuns S = 1 ↔ edgeBoundaryCount S = 2 := by
+  rw [edgeBoundaryCount_eq_two_mul_numRuns]
+  omega
+
+/-- An integer interval `[a, b]` (`a ≤ b`) has exactly one maximal run: only its
+    left endpoint `a` lacks a predecessor in the set. -/
+theorem numRuns_Icc {a b : ℤ} (h : a ≤ b) :
+    numRuns (Finset.Icc a b) = 1 := by
+  rw [numRuns]
+  have : leftEnds (Finset.Icc a b) = {a} := by
+    ext x
+    simp only [leftEnds, Finset.mem_filter, Finset.mem_Icc, Finset.mem_singleton]
+    constructor
+    · rintro ⟨⟨hax, hxb⟩, hpred⟩
+      by_contra hne
+      exact hpred ⟨by omega, by omega⟩
+    · rintro rfl
+      refine ⟨⟨le_refl _, h⟩, ?_⟩
+      rintro ⟨h1, _⟩
+      omega
+  rw [this, Finset.card_singleton]
+
+/-- Consequently an interval has boundary edge count exactly `2`. -/
+theorem edgeBoundaryCount_Icc {a b : ℤ} (h : a ≤ b) :
+    edgeBoundaryCount (Finset.Icc a b) = 2 := by
+  rw [edgeBoundaryCount_eq_two_mul_numRuns, numRuns_Icc h]
+
+/-! ### Fuglede-type lower bound: more runs ⇒ farther from an interval -/
+
+/-- The symmetric-difference distance from `S` to its spanning interval is at
+    least the number of gaps `numRuns S - 1`. Combined with the main identity,
+    `edgeBoundaryCount S = 2 + 2k` forces `S` to differ from the interval
+    `[min S, max S]` in at least `k` points: a discrete Fuglede-type stability
+    estimate. -/
+theorem numRuns_sub_one_le_card_sdiff {S : Finset ℤ} (h : S.Nonempty) :
+    numRuns S - 1 ≤ (Finset.Icc (S.min' h) (S.max' h) \ S).card := by
+  set m := S.min' h with hm
+  set M := S.max' h with hM
+  -- Build an injection from `leftEnds S \ {m}` into the missing points.
+  have key : ((leftEnds S).erase m).card ≤ (Finset.Icc m M \ S).card := by
+    apply Finset.card_le_card_of_injOn (fun x => x - 1)
+    · -- each non-minimal left endpoint has a missing predecessor in the interval
+      intro x hx
+      rw [Finset.mem_coe, Finset.mem_erase] at hx
+      obtain ⟨hxm, hxL⟩ := hx
+      rw [leftEnds, Finset.mem_filter] at hxL
+      obtain ⟨hxS, hpred⟩ := hxL
+      rw [Finset.mem_coe]
+      simp only [Finset.mem_sdiff, Finset.mem_Icc]
+      refine ⟨⟨?_, ?_⟩, hpred⟩
+      · -- m ≤ x - 1 : since x ∈ S, m ≤ x, and x ≠ m, x > m so x - 1 ≥ m
+        have hmx : m ≤ x := by rw [hm]; exact S.min'_le _ hxS
+        omega
+      · -- x - 1 ≤ M : x ≤ M so x - 1 < M
+        have hxM : x ≤ M := by rw [hM]; exact S.le_max' _ hxS
+        omega
+    · -- injective on the erase set
+      intro a _ b _ hab
+      have : a - 1 = b - 1 := hab
+      omega
+  have hcard : ((leftEnds S).erase m).card = numRuns S - 1 := by
+    rw [numRuns, Finset.card_erase_of_mem (min'_mem_leftEnds h)]
+  omega
+
+end DiscreteIsoperimetric1DRuns

--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-header-context",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "From Rigidity to Quantitative Stability",
+    "content": "The parent rigidity entry (OQ-02 → OQ-03) proved |∂_vertex S| = 2 ⟺ S is an interval and explicitly posed the quantitative follow-up: if the boundary is 2 + 2k, S should have k+1 maximal runs, with a bound on |S △ Icc(min S, max S)|. It also warned that the VERTEX boundary is not 2·(runs) — S = {0,2} has |∂_vertex S| = 3 but two runs. This file resolves the open question with the correct object: the EDGE boundary count (lattice edges crossing between S and its complement), which equals 2·(number of maximal runs) exactly. The proof is telescoping-free, resting on a single translation bijection."
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 79
+    },
+    "type": "definition",
+    "title": "Runs, Endpoints, and the Edge Count",
+    "content": "A maximal run is a maximal block of consecutive integers inside S. Runs are counted by their left endpoints leftEnds S = {x ∈ S : x − 1 ∉ S} (so numRuns S = |leftEnds S|) or right endpoints rightEnds S = {x ∈ S : x + 1 ∉ S}. The interior elements split into the has-predecessor set internalL = {x ∈ S : x − 1 ∈ S} and the has-successor set internalR = {x ∈ S : x + 1 ∈ S}. The edge boundary count edgeBoundaryCount S = |(S − 1) \\ S| + |(S + 1) \\ S| sums the rising edges (x ∉ S, x+1 ∈ S) and falling edges (x ∈ S, x+1 ∉ S)."
+  },
+  {
+    "id": "ann-shift-bijection",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 100
+    },
+    "type": "technique",
+    "title": "The Shift Bijection (heart of the proof)",
+    "content": "card_internalL_eq_card_internalR shows the translation x ↦ x − 1 is a bijection from internalL onto internalR: if x ∈ S and x − 1 ∈ S, then x − 1 ∈ S and (x − 1) + 1 = x ∈ S, so x − 1 ∈ internalR; the map is injective (subtraction) and surjective (y ↦ y + 1 inverts it). This single bijection is what replaces the telescoping sum or induction one might expect for a 'boundary counts components' identity, and it is the only nontrivial combinatorial step."
+  },
+  {
+    "id": "ann-left-eq-right",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 130
+    },
+    "type": "key-step",
+    "title": "Run Starts Equal Run Ends",
+    "content": "Finset.filter_card_add_filter_neg_card_eq_card partitions S: |rightEnds| + |internalR| = |S| and |leftEnds| + |internalL| = |S|. Since |internalL| = |internalR| by the shift bijection, card_leftEnds_eq_card_rightEnds concludes |leftEnds| = |rightEnds| by omega — every maximal run starts exactly once and ends exactly once, with no telescoping."
+  },
+  {
+    "id": "ann-edge-summands",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 166
+    },
+    "type": "key-step",
+    "title": "Boundary Edges Count Endpoints",
+    "content": "card_image_sub_one_sdiff shows the rising-edge set (S − 1) \\ S equals the injective image (leftEnds S).image (· − 1), so its cardinality is numRuns; symmetrically card_image_add_one_sdiff identifies the falling-edge set (S + 1) \\ S with rightEnds. Each maximal run thus contributes exactly two boundary edges — one rising at its left end, one falling at its right end."
+  },
+  {
+    "id": "ann-main-identity",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 167,
+      "endLine": 184
+    },
+    "type": "main-result",
+    "title": "Boundary = 2·Runs and the Stability Equivalence",
+    "content": "edgeBoundaryCount_eq_two_mul_numRuns assembles the pieces: edgeBoundaryCount S = |leftEnds| + |rightEnds| = 2·|leftEnds| = 2·numRuns S. The corollary edgeBoundaryCount_eq_iff_numRuns turns this into the quantitative-stability equivalence edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1: each additional run (each gap) adds exactly two boundary edges, exactly the statement the parent entry conjectured for the (corrected) edge count."
+  },
+  {
+    "id": "ann-interval-case",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 185,
+      "endLine": 225
+    },
+    "type": "key-step",
+    "title": "The Single-Run (Interval) Case",
+    "content": "min'_mem_leftEnds shows the minimum is always a run start, so one_le_numRuns gives numRuns ≥ 1 for nonempty S. numRuns_eq_one_iff_edgeBoundaryCount_eq_two records that one run ⟺ boundary 2, recovering the parent's rigidity threshold in edge-count language, and numRuns_Icc / edgeBoundaryCount_Icc compute that an interval [a,b] has exactly one run and edge boundary 2."
+  },
+  {
+    "id": "ann-stability",
+    "proofId": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 226,
+      "endLine": 266
+    },
+    "type": "main-result",
+    "title": "Discrete Fuglede-Type Lower Bound",
+    "content": "numRuns_sub_one_le_card_sdiff proves |Icc(min S, max S) \\ S| ≥ numRuns S − 1 by injecting each non-minimal run start x into its missing predecessor x − 1 (a point of the spanning interval not in S). Combined with the main identity, edgeBoundaryCount S = 2 + 2k forces S to differ from its spanning interval in at least k points — the discrete base case of Fuglede-type quantitative isoperimetric stability: more boundary edges than the interval minimum means provably farther from being an interval."
+  }
+]

--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+  "title": "Quantitative 1D Edge-Isoperimetric Stability: Boundary = 2·Runs",
+  "slug": "isoperimetric-theorem-oq-02-oq-03-oq-01",
+  "description": "The edge boundary of a finite S ⊆ ℤ has exactly 2·(number of maximal runs) crossing edges: edgeBoundaryCount S = 2·numRuns S. Hence |∂_edge S| = 2 + 2k iff S has exactly k+1 maximal runs, and S then differs from its spanning interval [min S, max S] in at least k points (a discrete Fuglede-type stability bound). This closes the quantitative-stability open question named by the parent rigidity entry (IsoperimetricTheoremOQ02OQ03), with the crucial correction that the clean 2·runs identity holds for the EDGE count, not the vertex boundary.",
+  "meta": {
+    "author": "Robb Walters (Lean Genius Researcher)",
+    "sourceUrl": "https://www.cs.ru.nl/~freek/100/",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "discrete-geometry",
+      "isoperimetric-inequality",
+      "stability",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_bij",
+        "description": "Cardinality equality from an explicit bijection; used to prove the has-predecessor and has-successor sets are equinumerous via the translation x ↦ x − 1",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "|S.filter p| + |S.filter ¬p| = |S|; used to split S into its endpoints (run starts/ends) and its interior (has-neighbour) elements",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "Image under an injective map preserves cardinality; used to identify each edge-summand (S±1)\\S with the left/right endpoint set",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection from A into B bounds |A| ≤ |B|; used to inject the non-minimal run starts into the missing points of the spanning interval for the Fuglede-type bound",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.min', Finset.max', Finset.min'_le, Finset.le_max', Finset.min'_mem",
+        "description": "Min/max of a nonempty finset and their order facts; used to span the interval [min S, max S] and to show the minimum is always a run start",
+        "module": "Mathlib.Order.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "edgeBoundaryCount_eq_two_mul_numRuns: the headline identity edgeBoundaryCount S = 2·numRuns S for every finite S ⊆ ℤ — the precise 'boundary = 2·runs' statement the parent rigidity entry flagged but did not prove",
+      "card_leftEnds_eq_card_rightEnds: left endpoints (run starts) and right endpoints (run ends) are equinumerous, proved with NO telescoping — via the translation bijection internalL ≃ internalR between the has-predecessor and has-successor sets",
+      "card_internalL_eq_card_internalR: the shift bijection x ↦ x − 1 carrying {x∈S : x−1∈S} onto {x∈S : x+1∈S}, the combinatorial heart that replaces a telescoping sum",
+      "edgeBoundaryCount_eq_iff_numRuns: the quantitative-stability equivalence edgeBoundaryCount S = 2 + 2k ↔ numRuns S = k + 1, exactly the parent's named open question (corrected to the edge count)",
+      "card_image_sub_one_sdiff / card_image_add_one_sdiff: the two edge summands (S−1)\\S and (S+1)\\S equal the left/right endpoint counts, identifying boundary edges with run endpoints",
+      "numRuns_sub_one_le_card_sdiff: discrete Fuglede-type stability — |S △ Icc(min S, max S)| ≥ numRuns S − 1, so edgeBoundaryCount = 2 + 2k forces at least k points of deviation from an interval",
+      "numRuns_Icc / edgeBoundaryCount_Icc / numRuns_eq_one_iff_edgeBoundaryCount_eq_two: the single-run (interval) case, recovering the parent's |∂_edge| = 2 ⟺ one run and connecting to the rigidity entry"
+    ],
+    "axiomCount": 0,
+    "lineCount": 266,
+    "assumptions": "0 axioms, 0 sorries — fully verified (depends only on propext, Classical.choice, Quot.sound).",
+    "theoremCount": 14,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "The parent rigidity entry (Discrete Isoperimetric Inequality 1D, OQ-02 → OQ-03) proved that a finite nonempty S ⊆ ℤ has vertex boundary |∂S| = 2 iff S is an interval, and explicitly posed a quantitative-stability follow-up: 'if |∂S| = 2 + 2k, show S has exactly k+1 maximal runs … and bound the symmetric difference |S △ Icc(min S, max S)| in terms of k — the discrete analogue of Fuglede-type quantitative isoperimetric stability.' That entry also warned that the cardinality of the VERTEX boundary is not 2·(runs) — e.g. S = {0,2} has |∂S| = 3 but two runs. This entry resolves the open question with the correct invariant: the EDGE boundary count (lattice edges crossing between S and its complement) equals 2·(number of maximal runs) exactly, so the '2 + 2k ⟺ k+1 runs' phenomenon is literally true for edges. Quantitative isoperimetric stability — measuring how far a near-extremal set is from the extremizer — is a central modern theme (Fuglede, Fusco–Maggi–Pratelli); this is its sharp discrete 1D base case.",
+    "problemStatement": "For a finite S ⊆ ℤ define numRuns S = |{x ∈ S : x − 1 ∉ S}| (maximal runs counted by their left endpoints) and the edge boundary count edgeBoundaryCount S = |(S−1) \\ S| + |(S+1) \\ S| (rising plus falling boundary edges). Prove edgeBoundaryCount S = 2·numRuns S; deduce edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1; and bound |Icc(min S, max S) \\ S| ≥ numRuns S − 1.",
+    "text": "Edge boundary = 2·runs for finite subsets of ℤ; each extra run adds exactly two boundary edges, and more runs force greater deviation from an interval.",
+    "proofStrategy": "Count runs by left endpoints leftEnds = {x∈S : x−1∉S} and by right endpoints rightEnds = {x∈S : x+1∉S}. Within S, the run starts are the complement of the has-predecessor set internalL = {x∈S : x−1∈S}, and the run ends are the complement of the has-successor set internalR = {x∈S : x+1∈S}, so |leftEnds| = |S| − |internalL| and |rightEnds| = |S| − |internalR|. The translation x ↦ x − 1 is a bijection internalL ≃ internalR (if x and x−1 both lie in S then x−1 and (x−1)+1 = x both lie in S), giving |internalL| = |internalR| and hence |leftEnds| = |rightEnds| with NO telescoping sum. The two edge summands (S−1)\\S and (S+1)\\S are the injective images of leftEnds and rightEnds, so edgeBoundaryCount = |leftEnds| + |rightEnds| = 2·numRuns. The arithmetic corollary and the interval (single-run) case follow by omega. For the Fuglede-type bound, map each non-minimal run start x to its missing predecessor x − 1, an injection from leftEnds \\ {min S} into Icc(min S, max S) \\ S.",
+    "keyInsights": [
+      "The clean '2·runs' law is about the EDGE count, not the vertex boundary: the parent entry correctly noted |∂_vertex {0,2}| = 3 ≠ 4, so the right object is edgeBoundaryCount = |(S−1)\\S| + |(S+1)\\S|, which counts every crossing edge once and is exactly 2·runs.",
+      "Left endpoints and right endpoints are equinumerous because the has-predecessor and has-successor sets are related by a single translation x ↦ x − 1 — a clean bijection that completely replaces the telescoping/induction one might expect for a 'boundary counts components' statement.",
+      "Each maximal run contributes exactly two boundary edges: one rising edge at its left end and one falling edge at its right end. This makes 'each gap adds 2 boundary points' a precise theorem rather than a heuristic.",
+      "The single-run case numRuns = 1 ⟺ edgeBoundaryCount = 2 recovers and reinterprets the parent's interval rigidity in edge-count language, linking the two entries.",
+      "Stability is one-directional and sharp at the lower end: numRuns − 1 gaps force at least numRuns − 1 missing interior points, so edgeBoundaryCount = 2 + 2k ⟹ |S △ Icc(min S, max S)| ≥ k; the deviation can be arbitrarily large above this, matching the fact that runs can be far apart."
+    ],
+    "prerequisites": [
+      "Finset basics (filter, image, sdiff, card, min', max')",
+      "Bijection/injection cardinality lemmas (card_bij, card_image_of_injective, card_le_card_of_injOn)",
+      "Linear arithmetic over ℤ (omega)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Context: From Rigidity to Quantitative Stability",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring quotes the parent's quantitative-stability open question, states the edge-boundary = 2·runs identity and its consequences, and explains the telescoping-free shift-bijection proof. Imports Mathlib and defines the run/endpoint/edge-count vocabulary."
+    },
+    {
+      "id": "definitions",
+      "title": "Runs, Endpoints, and the Edge Count",
+      "startLine": 56,
+      "endLine": 79,
+      "summary": "Defines rightEnds/leftEnds (run ends/starts), internalR/internalL (has-successor/predecessor elements), numRuns = |leftEnds|, and edgeBoundaryCount = |(S−1)\\S| + |(S+1)\\S|."
+    },
+    {
+      "id": "shift-bijection",
+      "title": "Has-Neighbour Sets are Equinumerous",
+      "startLine": 80,
+      "endLine": 100,
+      "summary": "card_internalL_eq_card_internalR: the translation x ↦ x − 1 is a bijection from {x∈S : x−1∈S} onto {x∈S : x+1∈S}, the combinatorial heart of the argument."
+    },
+    {
+      "id": "left-eq-right",
+      "title": "Run Starts = Run Ends",
+      "startLine": 101,
+      "endLine": 130,
+      "summary": "Partition lemmas split S into endpoints plus interior, and card_leftEnds_eq_card_rightEnds concludes |leftEnds| = |rightEnds| from the shift bijection — no telescoping."
+    },
+    {
+      "id": "edge-summands",
+      "title": "Boundary Edges Count Endpoints",
+      "startLine": 131,
+      "endLine": 166,
+      "summary": "card_image_sub_one_sdiff and card_image_add_one_sdiff identify the rising-edge set (S−1)\\S and falling-edge set (S+1)\\S with the left/right endpoint sets via injective images."
+    },
+    {
+      "id": "main-identity",
+      "title": "Boundary = 2·Runs",
+      "startLine": 167,
+      "endLine": 184,
+      "summary": "edgeBoundaryCount_eq_two_mul_numRuns proves the headline identity, and edgeBoundaryCount_eq_iff_numRuns derives the quantitative equivalence boundary = 2 + 2k ⟺ k+1 runs."
+    },
+    {
+      "id": "interval-case",
+      "title": "Nonemptiness and the Single-Run (Interval) Case",
+      "startLine": 185,
+      "endLine": 225,
+      "summary": "min'_mem_leftEnds, one_le_numRuns, numRuns_eq_one_iff_edgeBoundaryCount_eq_two, numRuns_Icc and edgeBoundaryCount_Icc handle the interval case, recovering the parent's |∂_edge| = 2 ⟺ one run."
+    },
+    {
+      "id": "stability",
+      "title": "Fuglede-Type Lower Bound",
+      "startLine": 226,
+      "endLine": 266,
+      "summary": "numRuns_sub_one_le_card_sdiff: |Icc(min S, max S) \\ S| ≥ numRuns S − 1, injecting each non-minimal run start to its missing predecessor; combined with the main identity, edgeBoundaryCount = 2 + 2k forces ≥ k points of deviation from an interval."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, 266 lines): for every finite S ⊆ ℤ the edge boundary count equals twice the number of maximal runs, edgeBoundaryCount S = 2·numRuns S. Consequently edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1 (each gap adds exactly two boundary edges), and |S △ Icc(min S, max S)| ≥ numRuns S − 1 (a discrete Fuglede-type stability bound). This resolves the quantitative-stability open question named by the parent rigidity entry, supplying the correct invariant — the edge count rather than the vertex boundary — and a telescoping-free proof via a single translation bijection.",
+    "openQuestions": [
+      "Sharp two-sided stability: pair the lower bound |S △ Icc| ≥ k with the natural family achieving it (k+1 runs separated by single-point gaps) and characterize all S with edgeBoundaryCount = 2 + 2k and |S △ Icc| = k as exactly the 'k single gaps' configurations.",
+      "ℤ^d edge-isoperimetric stability: does an analogous 'boundary − minimum = 2·(defect)' counting identity control the deviation from a sub-cube in the Bollobás–Leader inequality, and which 1D ingredients (the shift bijection, run counting) survive coordinate-slicing?"
+    ],
+    "implications": "Turns the parent's qualitative rigidity (|∂_edge| = 2 ⟺ interval) into a quantitative law (|∂_edge| = 2·runs) with an attached stability estimate, the discrete base case of Fuglede-type isoperimetric stability. The exact edge-count identity and the shift-bijection technique are the kind of clean counting facts that feed compression and defect arguments for higher-dimensional grid isoperimetry."
+  },
+  "references": [
+    {
+      "authors": "Harper, L. H.",
+      "title": "Optimal Numberings and Isoperimetric Problems on Graphs",
+      "year": "1966",
+      "venue": "Journal of Combinatorial Theory 1(3), pp. 385–393",
+      "note": "Origin of compression for discrete isoperimetric problems; the 1D edge count = 2·runs is the base-case counting fact underlying that hierarchy."
+    },
+    {
+      "authors": "Bollobás, B. and Leader, I.",
+      "title": "Edge-Isoperimetric Inequalities in the Grid",
+      "year": "1991",
+      "venue": "Combinatorica 11(4), pp. 299–314",
+      "note": "The ℤ^d edge-isoperimetric inequality whose stability/defect version this 1D identity feeds into."
+    },
+    {
+      "authors": "Fusco, N., Maggi, F. and Pratelli, A.",
+      "title": "The Sharp Quantitative Isoperimetric Inequality",
+      "year": "2008",
+      "venue": "Annals of Mathematics 168(3), pp. 941–980",
+      "note": "Modern continuous quantitative isoperimetric stability (deviation from the ball controlled by the isoperimetric deficit); this entry is a sharp discrete 1D analogue for runs."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "DiscreteIsoperimetric1DRuns",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 6,
+    "path": "Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "isoperimetric-theorem-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Resolves the quantitative-stability open question posed in the parent's conclusion (|∂S| = 2 + 2k ⟹ k+1 runs, plus a symmetric-difference bound), correcting it to the edge boundary count, for which the clean 2·runs identity actually holds."
+    },
+    {
+      "targetId": "isoperimetric-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Quantitative refinement of the base discrete 1D isoperimetric inequality: where OQ-02 gave the lower bound |∂S| ≥ 2, this entry computes the exact edge boundary as 2·(number of maximal runs)."
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "discrete-analog-of",
+      "description": "Discrete analogue of quantitative (Fuglede-type) isoperimetric stability: just as deviation from the ball is controlled by the continuous isoperimetric deficit, deviation from an interval is controlled here by the discrete edge defect 2·(runs − 1)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **quantitative-stability open question named in the parent rigidity entry** (`isoperimetric-theorem-oq-02-oq-03`), whose conclusion asked:

> *Quantitative stability: if |∂S| = 2 + 2k, show S has exactly k+1 maximal runs … and bound |S △ Icc(min S, max S)| in terms of k — the discrete analogue of Fuglede-type quantitative isoperimetric stability.*

**Key correction.** The parent correctly warned that the **vertex** boundary is *not* 2·(runs) — e.g. `S = {0,2}` has `|∂_vertex S| = 3` but two runs. The clean `2·runs` law holds for the **edge** boundary count (lattice edges crossing between `S` and its complement). This entry proves it for edges, where the statement is exact.

## Main results (`Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean`)

- `edgeBoundaryCount_eq_two_mul_numRuns`: `edgeBoundaryCount S = 2 * numRuns S` for every finite `S ⊆ ℤ`.
- `edgeBoundaryCount_eq_iff_numRuns`: `edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1` — each gap adds exactly two boundary edges.
- `numRuns_sub_one_le_card_sdiff`: `|Icc(min S, max S) \ S| ≥ numRuns S − 1` — discrete Fuglede-type stability: more boundary edges ⟹ provably farther from an interval.
- Single-run/interval case (`numRuns_Icc`, `edgeBoundaryCount_Icc`, `numRuns_eq_one_iff_edgeBoundaryCount_eq_two`) recovers the parent's `|∂_edge| = 2 ⟺ interval` threshold.

## Technique

Left endpoints (run starts) and right endpoints (run ends) are equinumerous **without telescoping or induction**: the translation `x ↦ x − 1` is a bijection between the has-predecessor set `internalL` and the has-successor set `internalR` (`card_internalL_eq_card_internalR`). Partitioning `S` into endpoints + interior then gives `|leftEnds| = |rightEnds| = numRuns`, and the two edge summands `(S±1)\S` are their injective images.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` on all main theorems lists only `propext, Classical.choice, Quot.sound`.
- Builds against Mathlib 4.26.0. 14 theorems, 6 definitions, 266 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)