### PR TITLE
research(subset-count-multiset-oq-02): signed submultiset count = ∏[mᵢ even], even/odd parity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SubsetCountMultisetOQ02.lean
+++ b/proofs/Proofs/SubsetCountMultisetOQ02.lean
@@ -1,0 +1,179 @@
+/-
+# Even–Odd Submultiset Parity (subset-count-multiset OQ-02)
+
+OQ-02 follow-up to `SubsetCountMultisetOQ01` (distinct submultiset count `∏(mᵢ+1)`).
+
+The parent counted the *distinct* submultisets of a finite multiset `s`.  Here we
+compute the **signed** count
+
+  signedSubMultisetCount s = ∑_{t ≤ s} (-1)^|t|
+
+(summing over the distinct submultisets `t`, each once).  The single-variable
+alternating sum factors over the distinct elements:
+
+  ∑_{t ≤ s} (-1)^|t| = ∏_{a ∈ s.toFinset} (∑_{j=0}^{count a} (-1)^j)
+                     = ∏_{a ∈ s.toFinset} [count a even].
+
+Consequently the signed count is `1` when every multiplicity is even and `0`
+as soon as **some** multiplicity is odd.  In the latter case the number of
+distinct submultisets of even size equals the number of odd size.
+
+## Example
+For `s = {a, a, b}` (count a = 2, count b = 1, so `b` has odd multiplicity):
+  even-size submultisets: {}, {a,a}, {a,b}        (3)
+  odd-size  submultisets: {a}, {b}, {a,a,b}       (3)
+The signed count `1 - 3 + 3 - 1 = 0` vanishes. ✓
+
+## Proof Strategy
+Transport the signed sum along the parent's bijection
+  `submultisetEquiv s : {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (count a + 1)`.
+Under it `|t| = ∑_a t.count a`, so `(-1)^|t| = ∏_a (-1)^{t.count a}`, and the
+"sum of products = product of sums" identity (`Finset.prod_univ_sum`) collapses
+the whole signed sum into a product of per-element alternating sums, each a
+finite geometric series `∑_{j<m+1} (-1)^j = [m even]` (`neg_one_geom_sum`).
+
+## Tags
+combinatorics, multisets, parity, generating-functions, alternating-sum
+-/
+
+import Mathlib.Tactic
+import Proofs.SubsetCountMultisetOQ01
+
+namespace SubsetCountMultisetOQ02
+
+open Multiset BigOperators
+open SubsetCountMultisetOQ01
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ## Definition -/
+
+/-- The signed count of distinct submultisets of `s`: `∑_{t ≤ s} (-1)^|t|`. -/
+def signedSubMultisetCount (s : Multiset α) : ℤ :=
+  ∑ t ∈ distinctSubMultisets s, (-1 : ℤ) ^ t.card
+
+/-! ## Helper Lemmas -/
+
+/-- For a submultiset `t ≤ s`, the size of `t` is the sum of its counts over the
+distinct elements of `s` (the counts off `s.toFinset` are zero). -/
+private lemma card_eq_sum_count_toFinset {s t : Multiset α} (ht : t ≤ s) :
+    t.card = ∑ a ∈ s.toFinset, t.count a := by
+  rw [← Multiset.toFinset_sum_count_eq t]
+  apply Finset.sum_subset
+  · exact Multiset.toFinset_subset.mpr (Multiset.subset_of_le ht)
+  · intro a _ ha
+    exact Multiset.count_eq_zero_of_notMem (by rwa [Multiset.mem_toFinset] at ha)
+
+/-- The composite bijection: distinct submultisets of `s` correspond to count
+functions on the distinct elements.  Built from the parent's `submultisetEquiv`
+after rewriting membership `t ∈ distinctSubMultisets s` as `t ≤ s`. -/
+private def dsmEquivPi (s : Multiset α) :
+    {t : Multiset α // t ∈ distinctSubMultisets s} ≃ (∀ a : ↑s.toFinset, Fin (s.count ↑a + 1)) :=
+  (Equiv.subtypeEquivRight (fun _ => mem_distinctSubMultisets)).trans (submultisetEquiv s)
+
+/-! ## The Factoring Theorem -/
+
+/-- **Signed count factors as a product of alternating sums.** -/
+theorem signedSubMultisetCount_eq_prod (s : Multiset α) :
+    signedSubMultisetCount s
+      = ∏ a ∈ s.toFinset, ∑ j ∈ Finset.range (s.count a + 1), (-1 : ℤ) ^ j := by
+  rw [signedSubMultisetCount,
+      ← Finset.sum_coe_sort (distinctSubMultisets s) (fun t => (-1 : ℤ) ^ t.card)]
+  rw [Fintype.sum_equiv (dsmEquivPi s)
+        (fun a => (-1 : ℤ) ^ (a : Multiset α).card)
+        (fun b => ∏ x : ↑s.toFinset, (-1 : ℤ) ^ ((b x).val))]
+  · -- ∑ b, ∏ x, (-1)^(b x).val = ∏ a ∈ s.toFinset, ∑ j ∈ range (count a + 1), (-1)^j
+    rw [← Finset.prod_coe_sort s.toFinset
+          (fun a => ∑ j ∈ Finset.range (s.count a + 1), (-1 : ℤ) ^ j)]
+    simp_rw [← Fin.sum_univ_eq_sum_range (fun j => (-1 : ℤ) ^ j)]
+    rw [Finset.prod_univ_sum (fun x : ↑s.toFinset => (Finset.univ : Finset (Fin (s.count ↑x + 1))))
+          (fun (x : ↑s.toFinset) (j : Fin (s.count ↑x + 1)) => (-1 : ℤ) ^ (j : ℕ))]
+    rw [Fintype.piFinset_univ]
+  · -- the pointwise transport condition
+    intro a
+    obtain ⟨t, ht⟩ := a
+    have hle : t ≤ s := mem_distinctSubMultisets.mp ht
+    have hval : ∀ x : ↑s.toFinset, ((dsmEquivPi s ⟨t, ht⟩) x).val = t.count ↑x := fun _ => rfl
+    simp_rw [hval]
+    rw [Finset.prod_coe_sort s.toFinset (fun a => (-1 : ℤ) ^ (t.count a)),
+        Finset.prod_pow_eq_pow_sum, ← card_eq_sum_count_toFinset hle]
+
+/-- The per-element alternating sum is `1` when the multiplicity is even, `0` otherwise. -/
+theorem signedSubMultisetCount_eq_prod_ite (s : Multiset α) :
+    signedSubMultisetCount s
+      = ∏ a ∈ s.toFinset, if Even (s.count a) then (1 : ℤ) else 0 := by
+  rw [signedSubMultisetCount_eq_prod]
+  refine Finset.prod_congr rfl (fun a _ => ?_)
+  rw [neg_one_geom_sum]
+  by_cases h : Even (s.count a) <;> simp [Nat.even_add_one, h]
+
+/-! ## Main Results -/
+
+/-- **Vanishing of the signed count.** If some element of `s` has odd
+multiplicity, the signed submultiset count is `0`. -/
+theorem signedSubMultisetCount_eq_zero_of_odd {s : Multiset α} {a : α}
+    (ha : a ∈ s.toFinset) (hodd : Odd (s.count a)) :
+    signedSubMultisetCount s = 0 := by
+  rw [signedSubMultisetCount_eq_prod_ite]
+  refine Finset.prod_eq_zero ha ?_
+  rw [if_neg (Nat.not_even_iff_odd.mpr hodd)]
+
+/-- The signed count equals `#{even-size submultisets} − #{odd-size submultisets}`. -/
+theorem signedSubMultisetCount_eq_even_sub_odd (s : Multiset α) :
+    signedSubMultisetCount s
+      = (((distinctSubMultisets s).filter (fun t => Even t.card)).card : ℤ)
+        - (((distinctSubMultisets s).filter (fun t => ¬ Even t.card)).card : ℤ) := by
+  rw [signedSubMultisetCount,
+      ← Finset.sum_filter_add_sum_filter_not (distinctSubMultisets s) (fun t => Even t.card)
+          (fun t => (-1 : ℤ) ^ t.card)]
+  have e1 : ∑ t ∈ (distinctSubMultisets s).filter (fun t => Even t.card), (-1 : ℤ) ^ t.card
+      = (((distinctSubMultisets s).filter (fun t => Even t.card)).card : ℤ) := by
+    rw [Finset.sum_congr rfl (fun t ht => Even.neg_one_pow (Finset.mem_filter.mp ht).2)]
+    simp
+  have e2 : ∑ t ∈ (distinctSubMultisets s).filter (fun t => ¬ Even t.card), (-1 : ℤ) ^ t.card
+      = -(((distinctSubMultisets s).filter (fun t => ¬ Even t.card)).card : ℤ) := by
+    rw [Finset.sum_congr rfl
+          (fun t ht => Odd.neg_one_pow (Nat.not_even_iff_odd.mp (Finset.mem_filter.mp ht).2))]
+    simp
+  rw [e1, e2]
+  ring
+
+/-- **Even–Odd Submultiset Parity.** If some element of the multiset `s` occurs
+with odd multiplicity, then the distinct submultisets of even size are exactly as
+many as those of odd size. -/
+theorem even_card_eq_odd_card_of_odd_multiplicity {s : Multiset α} {a : α}
+    (ha : a ∈ s.toFinset) (hodd : Odd (s.count a)) :
+    ((distinctSubMultisets s).filter (fun t => Even t.card)).card
+      = ((distinctSubMultisets s).filter (fun t => ¬ Even t.card)).card := by
+  have hzero := signedSubMultisetCount_eq_zero_of_odd ha hodd
+  rw [signedSubMultisetCount_eq_even_sub_odd] at hzero
+  omega
+
+/-- **Converse direction.** If every element of `s` has even multiplicity, the
+signed count is `1` (so there is exactly one more even submultiset than odd). -/
+theorem signedSubMultisetCount_eq_one_of_all_even {s : Multiset α}
+    (h : ∀ a ∈ s.toFinset, Even (s.count a)) :
+    signedSubMultisetCount s = 1 := by
+  rw [signedSubMultisetCount_eq_prod_ite]
+  refine Finset.prod_eq_one (fun a ha => ?_)
+  rw [if_pos (h a ha)]
+
+/-! ## Examples -/
+
+/-- `s = {1, 1, 2}`: element `2` has odd multiplicity, so even = odd = 3. -/
+example :
+    ((distinctSubMultisets ({1, 1, 2} : Multiset ℕ)).filter (fun t => Even t.card)).card
+      = ((distinctSubMultisets ({1, 1, 2} : Multiset ℕ)).filter (fun t => ¬ Even t.card)).card := by
+  apply even_card_eq_odd_card_of_odd_multiplicity (a := 2)
+  · decide
+  · decide
+
+/-- `s = {1, 1}`: every multiplicity even, signed count is `1`. -/
+example : signedSubMultisetCount ({1, 1} : Multiset ℕ) = 1 := by
+  apply signedSubMultisetCount_eq_one_of_all_even
+  decide
+
+#check @signedSubMultisetCount_eq_prod
+#check @even_card_eq_odd_card_of_odd_multiplicity
+
+end SubsetCountMultisetOQ02

--- a/src/data/proofs/subset-count-multiset-oq-02/annotations.json
+++ b/src/data/proofs/subset-count-multiset-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-scm-oq02-header",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "File Context: Signed Submultiset Count and the Parity Dichotomy",
+    "content": "This OQ-02 follow-up to subset-count-multiset-oq-01 weighs each distinct submultiset t ≤ s by its sign (-1)^|t| and evaluates the resulting signed count. The header states the central result: the signed count factors over the distinct elements as ∏ᵢ (∑_{j=0}^{mᵢ} (-1)^j) = ∏ᵢ [mᵢ even]. So it is 1 when every multiplicity is even and 0 once any multiplicity is odd, and in the odd case the even-size and odd-size submultisets are equinumerous. The worked example {a,a,b} (count b = 1 odd) makes the 1−3+3−1 = 0 cancellation concrete.",
+    "mathContext": "$\\sum_{t \\le s} (-1)^{|t|} = \\prod_{a \\in s.\\text{toFinset}} \\Big(\\sum_{j=0}^{s.\\text{count}\\,a} (-1)^j\\Big) = \\prod_{a} [\\,s.\\text{count}\\,a \\text{ even}\\,]$. This is the distinct-submultiset generating function $\\prod_i (1 + x + \\cdots + x^{m_i})$ evaluated at $x = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subset-count-multiset-oq-01",
+      "generating functions",
+      "alternating sum",
+      "parity",
+      "submultiset"
+    ],
+    "prerequisites": [
+      "Multiset count, le, toFinset",
+      "BigOperators Σ/Π notation",
+      "The parent bijection submultisetEquiv"
+    ]
+  },
+  {
+    "id": "ann-scm-oq02-def",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 49, "endLine": 53 },
+    "type": "definition",
+    "title": "The Signed Submultiset Count",
+    "content": "signedSubMultisetCount s sums (-1)^|t| over the distinct submultisets t of s (the finset distinctSubMultisets s from the parent, where each submultiset is counted once). The value lives in ℤ so the alternating signs can cancel. Splitting by the parity of |t|, this is #{even-size submultisets} − #{odd-size submultisets}, the quantity whose vanishing yields the parity headline.",
+    "mathContext": "$\\text{signedSubMultisetCount}\\,s = \\sum_{t \\in \\text{distinctSubMultisets}\\,s} (-1)^{|t|} \\in \\mathbb{Z}$.",
+    "significance": "central",
+    "relatedConcepts": ["distinctSubMultisets", "alternating sum", "integer-valued count"],
+    "prerequisites": ["Finset.sum", "integer powers of -1"]
+  },
+  {
+    "id": "ann-scm-oq02-helpers",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "lemma",
+    "title": "Size as a Sum of Counts, and the Composite Bijection",
+    "content": "Two pieces of plumbing. card_eq_sum_count_toFinset shows that for t ≤ s the size |t| equals ∑_{a∈s.toFinset} t.count a — the counts off s.toFinset are zero (Finset.sum_subset over t.toFinset ⊆ s.toFinset). This is exactly what lets (-1)^|t| split into a product. dsmEquivPi composes Equiv.subtypeEquivRight (rewriting membership t ∈ distinctSubMultisets s as t ≤ s via mem_distinctSubMultisets) with the parent's submultisetEquiv, giving a bijection from distinct submultisets to count functions ∀ a : ↑s.toFinset, Fin (count a + 1).",
+    "mathContext": "$|t| = \\sum_{a \\in s.\\text{toFinset}} t.\\text{count}\\,a$ for $t \\le s$; $\\text{dsmEquivPi} : \\{t \\mid t \\in \\text{distinctSubMultisets}\\,s\\} \\simeq \\prod_{a} \\text{Fin}(s.\\text{count}\\,a + 1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["submultisetEquiv", "Equiv.subtypeEquivRight", "Multiset.toFinset_sum_count_eq"],
+    "prerequisites": ["Finset.sum_subset", "Equiv composition"]
+  },
+  {
+    "id": "ann-scm-oq02-factoring",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 74, "endLine": 109 },
+    "type": "theorem",
+    "title": "Factoring the Signed Sum into a Product of Alternating Sums",
+    "content": "The heart of the proof. signedSubMultisetCount_eq_prod transports the signed sum along dsmEquivPi (Fintype.sum_equiv): under the bijection (-1)^|t| becomes ∏_a (-1)^{t.count a} (using card_eq_sum_count_toFinset and Finset.prod_pow_eq_pow_sum). The signed sum is then a sum over the product type ∀a, Fin(count a+1) of products, which the sum-of-products identity Finset.prod_univ_sum (combined with Fintype.piFinset_univ and Fin.sum_univ_eq_sum_range) collapses back into ∏ a ∈ s.toFinset, ∑_{j<count a+1} (-1)^j. The companion signedSubMultisetCount_eq_prod_ite then evaluates each factor with neg_one_geom_sum to if Even (count a) then 1 else 0.",
+    "mathContext": "$\\sum_{t} (-1)^{|t|} = \\sum_{f : \\prod_a \\text{Fin}(m_a+1)} \\prod_a (-1)^{f(a)} = \\prod_a \\sum_{j=0}^{m_a} (-1)^j$, and $\\sum_{j=0}^{m} (-1)^j = [m \\text{ even}]$.",
+    "significance": "central",
+    "relatedConcepts": ["Fintype.sum_equiv", "Finset.prod_univ_sum", "Finset.prod_pow_eq_pow_sum", "neg_one_geom_sum"],
+    "prerequisites": ["Reindexing sums by equivalences", "sum-of-products = product-of-sums", "finite geometric sums"]
+  },
+  {
+    "id": "ann-scm-oq02-main",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 110, "endLine": 160 },
+    "type": "theorem",
+    "title": "Vanishing, Even–Odd Parity, and the All-Even Converse",
+    "content": "The payoff. signedSubMultisetCount_eq_zero_of_odd: a single odd multiplicity makes a factor [m even] = 0, so the whole product (Finset.prod_eq_zero) vanishes. signedSubMultisetCount_eq_even_sub_odd rewrites the signed count as the integer #{even-size} − #{odd-size} via Even.neg_one_pow / Odd.neg_one_pow on the parity-filtered sums. Combining the two gives the headline even_card_eq_odd_card_of_odd_multiplicity: if some element has odd multiplicity then #{even-size submultisets} = #{odd-size submultisets} (closed by omega on the cast difference). The converse signedSubMultisetCount_eq_one_of_all_even shows that if every multiplicity is even, every factor is 1, so the signed count is 1.",
+    "mathContext": "$\\exists a,\\ \\text{Odd}(m_a) \\Rightarrow \\#\\{|t| \\text{ even}\\} = \\#\\{|t| \\text{ odd}\\}$; $(\\forall a,\\ \\text{Even}(m_a)) \\Rightarrow \\sum_t (-1)^{|t|} = 1$.",
+    "significance": "central",
+    "relatedConcepts": ["Finset.prod_eq_zero", "Even.neg_one_pow", "Odd.neg_one_pow", "parity dichotomy"],
+    "prerequisites": ["filtering finsets by a predicate", "integer casts of cardinalities"]
+  },
+  {
+    "id": "ann-scm-oq02-examples",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 161, "endLine": 175 },
+    "type": "concept",
+    "title": "Concrete Instances",
+    "content": "Two grounding examples discharged by the proved theorems (with decide, so the file stays free of native_decide and the Lean.ofReduceBool axiom). For s = {1,1,2}, element 2 has odd multiplicity, so the even-size and odd-size submultisets are equinumerous. For s = {1,1}, every multiplicity is even, so the signed count is 1.",
+    "mathContext": "$\\{1,1,2\\}$: $\\text{count}\\,2 = 1$ odd $\\Rightarrow$ #even $=$ #odd; $\\{1,1\\}$: all even $\\Rightarrow \\sum (-1)^{|t|} = 1$.",
+    "significance": "illustrative",
+    "relatedConcepts": ["even_card_eq_odd_card_of_odd_multiplicity", "signedSubMultisetCount_eq_one_of_all_even"],
+    "prerequisites": ["decide on concrete multisets"]
+  }
+]

--- a/src/data/proofs/subset-count-multiset-oq-02/meta.json
+++ b/src/data/proofs/subset-count-multiset-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "subset-count-multiset-oq-02",
+  "title": "Even–Odd Submultiset Parity: ∑ (-1)^|t| = ∏ [mᵢ even]",
+  "slug": "subset-count-multiset-oq-02",
+  "description": "Computes the signed count of distinct submultisets, ∑_{t ≤ s} (-1)^|t|, and shows it factors as the product over distinct elements of the per-element alternating sums ∑_{j=0}^{mᵢ} (-1)^j = [mᵢ even]. Hence the signed count is 1 when every multiplicity is even and 0 as soon as some multiplicity is odd — in which case the distinct submultisets of even size are exactly as many as those of odd size.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SubsetCountMultisetOQ02.lean",
+    "parentProofId": "subset-count-multiset-oq-01",
+    "tags": [
+      "combinatorics",
+      "multiset",
+      "parity",
+      "generating-functions",
+      "alternating-sum",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. All theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool — examples use decide, not native_decide).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_univ_sum",
+        "description": "Sum-of-products = product-of-sums: ∏ᵢ ∑ⱼ f i j = ∑ over piFinset of ∏ᵢ f i (p i)",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "Finite alternating geometric sum: ∑_{i<n} (-1)^i = if Even n then 0 else 1",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "Fintype.sum_equiv",
+        "description": "A sum is invariant under reindexing by an equivalence",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.prod_pow_eq_pow_sum",
+        "description": "∏ᵢ b^(f i) = b^(∑ᵢ f i), pushing the exponent sum out of the product",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Multiset.toFinset_sum_count_eq",
+        "description": "∑ a ∈ s.toFinset, s.count a = s.card (size as sum of counts)",
+        "module": "Mathlib.Data.Multiset.Dedup"
+      }
+    ],
+    "originalContributions": [
+      "Definition signedSubMultisetCount s = ∑_{t ≤ s} (-1)^|t|",
+      "Factoring theorem: signedSubMultisetCount s = ∏ a ∈ s.toFinset, ∑_{j<count a+1} (-1)^j, by transporting the signed sum along the parent's submultisetEquiv bijection",
+      "Per-element evaluation: each alternating sum equals [count a even], so the signed count is ∏ a [count a even]",
+      "Vanishing theorem: some odd multiplicity ⟹ signed count = 0",
+      "Headline: odd multiplicity ⟹ #{even-size submultisets} = #{odd-size submultisets}",
+      "Converse: all multiplicities even ⟹ signed count = 1"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 179,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "prerequisites": [
+      "Multiset count, toFinset, le",
+      "BigOperators: Finset.prod / Finset.sum and reindexing by equivalences",
+      "Finite geometric / alternating sums",
+      "The parent bijection submultisetEquiv (subset-count-multiset-oq-01)"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Where the parent proof (OQ-01) counted the distinct submultisets of a multiset s as ∏ᵢ(mᵢ+1), this follow-up weighs each submultiset by the sign (-1)^|t|. The signed count is the multiset analogue of the classical fact that a nonempty finite set has equally many even and odd subsets (∑_{A ⊆ X} (-1)^|A| = 0 for X ≠ ∅). For multisets the answer is more refined: the signed count factors over the distinct elements, and each element of multiplicity m contributes the finite alternating sum 1 - 1 + 1 - ⋯ ± 1 = ∑_{j=0}^{m} (-1)^j, which is 1 if m is even and 0 if m is odd. The full signed count is therefore the product ∏ᵢ [mᵢ even]: it is 1 exactly when every multiplicity is even, and 0 the moment a single multiplicity is odd.\n\nThis is the generating-function statement evaluated at x = -1: the distinct-submultiset generating function is ∏ᵢ (1 + x + ⋯ + x^{mᵢ}), and at x = -1 each factor collapses to [mᵢ even]. The vanishing case (some mᵢ odd) gives the parity corollary: the distinct submultisets of even size are exactly balanced by those of odd size.",
+    "problemStatement": "For a finite multiset s with element multiplicities mᵢ, evaluate the signed count ∑_{t ≤ s} (-1)^|t| of distinct submultisets, and deduce when the even-size and odd-size submultisets are equinumerous.",
+    "text": "The signed count of distinct submultisets equals ∏ᵢ [mᵢ even]; in particular any odd multiplicity forces #even = #odd.",
+    "proofStrategy": "Reuse the parent's bijection submultisetEquiv : {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (count a + 1). Under it the size |t| = ∑_a t.count a, so (-1)^|t| = ∏_a (-1)^{t.count a} (Finset.prod_pow_eq_pow_sum). Transporting the signed sum (Fintype.sum_equiv) turns it into a sum over the product type of products, which the sum-of-products identity Finset.prod_univ_sum (with piFinset_univ) collapses to a product of per-element alternating sums. Each alternating sum ∑_{j<m+1} (-1)^j is evaluated by neg_one_geom_sum to [m even]. The headline parity statement follows by writing the signed count as #even − #odd and using the vanishing case.",
+    "keyInsights": [
+      "The signed count is multiplicative over distinct elements because submultisets choose copies of each element independently (the bijection makes this precise)",
+      "(-1)^|t| = ∏_a (-1)^{t.count a} since |t| = ∑_a t.count a over s.toFinset",
+      "Each element of multiplicity m contributes ∑_{j=0}^{m} (-1)^j = [m even]; a single odd multiplicity zeroes the whole product",
+      "Signed count 0 means #{even-size submultisets} = #{odd-size submultisets}; signed count 1 means every multiplicity is even",
+      "This is the distinct-submultiset generating function ∏ᵢ(1+x+⋯+x^{mᵢ}) evaluated at x = -1"
+    ],
+    "prerequisites": [
+      "Multiset count, le, toFinset",
+      "BigOperators: Finset.prod, Finset.sum, reindexing",
+      "Finite alternating sums (neg_one_geom_sum)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Definition",
+      "startLine": 49,
+      "endLine": 53,
+      "summary": "Defines signedSubMultisetCount s = ∑_{t ∈ distinctSubMultisets s} (-1)^|t|.",
+      "mathContext": "The signed (alternating-by-size) count of distinct submultisets, valued in ℤ."
+    },
+    {
+      "id": "helpers",
+      "title": "Helper Lemmas",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "Size as a sum of counts over s.toFinset, and the composite bijection dsmEquivPi.",
+      "mathContext": "card_eq_sum_count_toFinset: |t| = ∑_{a∈s.toFinset} t.count a; dsmEquivPi reindexes membership t ∈ distinctSubMultisets s as t ≤ s then applies the parent submultisetEquiv."
+    },
+    {
+      "id": "factoring",
+      "title": "The Factoring Theorem",
+      "startLine": 74,
+      "endLine": 109,
+      "summary": "signedSubMultisetCount factors as a product of per-element alternating sums, then each is evaluated to [count a even].",
+      "mathContext": "Fintype.sum_equiv + Finset.prod_univ_sum + Finset.prod_pow_eq_pow_sum collapse the signed sum into ∏ a ∈ s.toFinset, ∑_{j<count a+1} (-1)^j; neg_one_geom_sum evaluates each factor."
+    },
+    {
+      "id": "main",
+      "title": "Main Results",
+      "startLine": 110,
+      "endLine": 160,
+      "summary": "Vanishing for odd multiplicity, signed count as #even − #odd, the even=odd parity headline, and the all-even converse (signed count 1).",
+      "mathContext": "even_card_eq_odd_card_of_odd_multiplicity is the headline; signedSubMultisetCount_eq_one_of_all_even is the converse."
+    },
+    {
+      "id": "examples",
+      "title": "Examples",
+      "startLine": 161,
+      "endLine": 175,
+      "summary": "{1,1,2} (odd multiplicity of 2) gives equal even/odd counts; {1,1} (all even) gives signed count 1.",
+      "mathContext": "Concrete instances verified via the proved theorems with decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "subset-count-multiset-oq-01",
+      "relationship": "follow-up",
+      "description": "Reuses OQ-01's submultisetEquiv bijection to compute the signed (rather than plain) count of distinct submultisets"
+    },
+    {
+      "targetId": "subset-count-oq-04",
+      "relationship": "sibling",
+      "description": "The set case: a nonempty finite set has equally many even and odd subsets; here generalized to multisets, where the answer depends on parity of the multiplicities"
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete 0-axiom formalization computing the signed submultiset count as ∏ᵢ [mᵢ even], with the parity corollary #even = #odd whenever some multiplicity is odd. 6 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "Refines the parent's distinct-count formula with sign information, realizing the distinct-submultiset generating function at x = -1 and giving a clean parity dichotomy.",
+    "openQuestions": [
+      "Does the same multiplicative factorization hold for weighted signs (roots of unity x = ζ) yielding submultiset counts in residue classes mod r?",
+      "Can the parity statement be packaged as a sign-reversing involution on submultisets when a chosen element has odd multiplicity?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.SubsetCountMultisetOQ01"
+    ],
+    "opens": [
+      "Multiset",
+      "BigOperators",
+      "SubsetCountMultisetOQ01"
+    ],
+    "namespace": "SubsetCountMultisetOQ02",
+    "lineCount": 179,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/SubsetCountMultisetOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "signedSubMultisetCount_eq_prod",
+      "type": "core",
+      "description": "The signed count factors as a product of per-element alternating sums",
+      "leanType": "(s : Multiset α) → signedSubMultisetCount s = ∏ a ∈ s.toFinset, ∑ j ∈ Finset.range (s.count a + 1), (-1)^j"
+    },
+    {
+      "name": "even_card_eq_odd_card_of_odd_multiplicity",
+      "type": "core",
+      "description": "If some element has odd multiplicity, the even-size and odd-size distinct submultisets are equinumerous",
+      "leanType": "a ∈ s.toFinset → Odd (s.count a) → ((distinctSubMultisets s).filter (Even ·.card)).card = ((distinctSubMultisets s).filter (¬ Even ·.card)).card"
+    },
+    {
+      "name": "signedSubMultisetCount_eq_zero_of_odd",
+      "type": "core",
+      "description": "Some odd multiplicity forces the signed submultiset count to vanish",
+      "leanType": "a ∈ s.toFinset → Odd (s.count a) → signedSubMultisetCount s = 0"
+    },
+    {
+      "name": "signedSubMultisetCount_eq_one_of_all_even",
+      "type": "corollary",
+      "description": "If every multiplicity is even, the signed count is 1",
+      "leanType": "(∀ a ∈ s.toFinset, Even (s.count a)) → signedSubMultisetCount s = 1"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up (OQ-02) to **subset-count-multiset-oq-01** (distinct submultiset count `∏(mᵢ+1)`). This proof weighs each distinct submultiset `t ≤ s` by its sign `(-1)^|t|` and evaluates the resulting **signed count**:

$$\sum_{t \le s} (-1)^{|t|} \;=\; \prod_{a \in s.\text{toFinset}} \Big(\sum_{j=0}^{s.\text{count}\,a} (-1)^j\Big) \;=\; \prod_{a}\, [\,s.\text{count}\,a \text{ even}\,].$$

Consequences:
- **Vanishing**: a single element with **odd** multiplicity forces the signed count to `0`.
- **Parity headline**: in that case `#{even-size submultisets} = #{odd-size submultisets}`.
- **Converse**: if **every** multiplicity is even, the signed count is `1`.

This realizes the distinct-submultiset generating function `∏ᵢ(1 + x + ⋯ + x^{mᵢ})` at `x = -1`, generalizing the classical set fact "a nonempty finite set has equally many even and odd subsets" to multisets.

## Proof technique

Reuse the parent's bijection `submultisetEquiv : {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (count a + 1)`:
1. Under it `|t| = ∑_a t.count a`, so `(-1)^|t| = ∏_a (-1)^{t.count a}` (`Finset.prod_pow_eq_pow_sum`).
2. Transport the signed sum (`Fintype.sum_equiv`) → a sum over the product type of products.
3. Collapse with the sum-of-products identity `Finset.prod_univ_sum` (+ `Fintype.piFinset_univ`, `Fin.sum_univ_eq_sum_range`) into `∏ a, ∑_{j<count a+1} (-1)^j`.
4. Evaluate each factor by `neg_one_geom_sum` to `[count a even]`.
5. Headline follows by writing the signed count as `#even − #odd` and using the vanishing case.

## Verification

- **6 theorems, 2 definitions, 179 lines, 0 sorries.**
- `#print axioms` on all main theorems: only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms**, no `sorryAx`, no `Lean.ofReduceBool` (examples use `decide`, not `native_decide`).
- Builds against Mathlib v4.26.0; annotations pass strict validation.

Gallery entry: `src/data/proofs/subset-count-multiset-oq-02/` (meta + 6 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)