### PR TITLE
Enrich Poisson Limit Theorem (binomial-theorem-oq-02-oq-01-oq-02-oq-03)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-plt-header",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 2, "endLine": 41 },
+    "type": "concept",
+    "title": "Goal: the Poisson limit theorem (law of rare events)",
+    "content": "Poisson's 1837 law of small numbers: as the number of trials n → ∞ while the per-trial success probability pₙ → 0 with n·pₙ → λ, the binomial pmf converges to the Poisson pmf e^(−λ)·λ^k/k!. The parent (BinomialTheoremOQ02OQ01OQ02) showed each multinomial marginal is binomial; this file supplies the limiting behaviour and the joint statement that a multinomial converges to *independent* Poisson components. Mathlib defines ProbabilityTheory.poissonPMFReal but has no theorem connecting it to the binomial limit, so this fills a genuine gap. The whole proof is a product of three independently convergent factors.",
+    "mathContext": "$\\binom{n}{k}p_n^k(1-p_n)^{n-k} \\to e^{-\\lambda}\\frac{\\lambda^k}{k!} = \\mathrm{poissonPMFReal}\\,\\lambda\\,k$ when $n p_n \\to \\lambda$.",
+    "significance": "key",
+    "relatedConcepts": ["Poisson limit theorem", "law of rare events", "binomial distribution", "Poisson distribution", "asymptotic independence"],
+    "prerequisites": ["probability mass functions", "limits of sequences", "the binomial and Poisson distributions"]
+  },
+  {
+    "id": "ann-plt-aux",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 56, "endLine": 97 },
+    "type": "technique",
+    "title": "Three auxiliary limits",
+    "content": "The reusable building blocks. tendsto_zero_of_tendsto_nat_mul: n·pₙ → λ forces pₙ → 0 (since pₙ = (n·pₙ)/n with denominator → ∞) — so p → 0 is not a separate hypothesis. tendsto_one_sub_pow_exp: (1−pₙ)^n → e^(−λ), the exponential factor, via Mathlib's Real.tendsto_one_add_pow_exp_of_tendsto applied with g n = −pₙ. tendsto_one_sub_pow_sub_exp: the shifted (1−pₙ)^(n−m) → e^(−λ) for any fixed m, since it equals (1−pₙ)^n/(1−pₙ)^m eventually and the denominator → 1 — reused by both the one-cell and joint theorems.",
+    "mathContext": "$np_n \\to \\lambda \\Rightarrow p_n \\to 0$; $(1-p_n)^n \\to e^{-\\lambda}$; $(1-p_n)^{n-m} \\to e^{-\\lambda}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.tendsto_one_add_pow_exp_of_tendsto", "div_atTop", "Tendsto.congr'", "filter_upwards"],
+    "prerequisites": ["filters and limits", "the exponential limit (1+t/n)^n → e^t"]
+  },
+  {
+    "id": "ann-plt-onecell",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 101, "endLine": 151 },
+    "type": "theorem",
+    "title": "Poisson limit theorem (one cell): the three-factor decomposition",
+    "content": "binomial_tendsto_poisson is the headline. The binomial pmf splits into three independently convergent factors: (1) C(n,k)·pₙ^k = (1/k!)·∏_{j<k}((n−j)·pₙ), where each falling factor (n−j)·pₙ → λ (since n·pₙ → λ and j·pₙ → 0), so the product → λ^k, giving → λ^k/k!; (2)·(3) the exponential factor (1−pₙ)^(n−k) → e^(−λ) from the auxiliary lemma. The algebraic identity C(n,k)·pₙ^k = (1/k!)·∏((n−j)·pₙ) is established via Nat.descFactorial (n!/(n−k)! = descFactorial = ∏(n−j)) and descFactorial = k!·C(n,k). Multiplying the limits gives e^(−λ)·λ^k/k!.",
+    "mathContext": "$\\binom{n}{k}p_n^k = \\frac{1}{k!}\\prod_{j<k}(n-j)p_n \\to \\frac{\\lambda^k}{k!}$, and $(1-p_n)^{n-k}\\to e^{-\\lambda}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.descFactorial", "tendsto_finset_prod", "falling factorial", "three-factor decomposition"],
+    "prerequisites": ["the auxiliary limits", "descending factorial identities", "limit algebra"]
+  },
+  {
+    "id": "ann-plt-poissonpmf",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 153, "endLine": 160 },
+    "type": "technique",
+    "title": "Restated against Mathlib's poissonPMFReal",
+    "content": "binomial_tendsto_poissonPMFReal restates the one-cell limit with an ℝ≥0 rate r against Mathlib's ProbabilityTheory.poissonPMFReal, so the result plugs directly into the existing Poisson distribution API. The proof is a one-liner: unfold poissonPMFReal (which is definitionally e^(−r)·r^k/k!) and apply the real-form theorem.",
+    "mathContext": "$\\binom{n}{k}p_n^k(1-p_n)^{n-k} \\to \\mathrm{ProbabilityTheory.poissonPMFReal}\\,r\\,k$ for $r : \\mathbb{R}_{\\ge 0}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ProbabilityTheory.poissonPMFReal", "ℝ≥0 rate", "Mathlib API compatibility"],
+    "prerequisites": ["the real-form Poisson limit", "Mathlib's Poisson pmf"]
+  },
+  {
+    "id": "ann-plt-prodlimit",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 166, "endLine": 207 },
+    "type": "theorem",
+    "title": "The bijection-free product limit",
+    "content": "tendsto_descFactorial_mul_prod is the combinatorial heart of the joint version: ∏_{j<K}(n−j)·∏ᵢ(pᵢ n)^{kᵢ} → ∏ᵢ λᵢ^{kᵢ} where K = ∑ᵢ kᵢ. Rather than pairing falling-factorial terms to cells via an explicit bijection, it rewrites the product as ∏_{j<K}(1−j/n)·∏ᵢ(n·pᵢ n)^{kᵢ}: the first factor → 1 and each n·pᵢ n → λᵢ. The regrouping hinges on n^K = ∏ᵢ n^{kᵢ} distributing across cells (Finset.prod_pow_eq_pow_sum), so the n-powers attach one per cell without any index bijection.",
+    "mathContext": "$\\prod_{j<K}(n-j)\\cdot\\prod_i (p_i n)^{k_i} = \\prod_{j<K}\\!\\big(1-\\tfrac{j}{n}\\big)\\cdot\\prod_i (n\\,p_i n)^{k_i} \\to \\prod_i \\lambda_i^{k_i}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod_pow_eq_pow_sum", "descending factorial", "bijection-free regrouping", "tendsto_finset_prod"],
+    "prerequisites": ["the one-cell falling-factorial idea", "Finset product algebra"]
+  },
+  {
+    "id": "ann-plt-multinomialdef",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 209, "endLine": 214 },
+    "type": "definition",
+    "title": "The multinomial pmf with a residual cell",
+    "content": "multinomialPMF models s-many 'rare' cells with probabilities pᵢ n and an implicit residual cell of probability 1 − ∑ᵢ pᵢ n: n!/(∏ᵢ kᵢ!·(n−∑k)!) · ∏ᵢ pᵢ^{kᵢ} · (1−∑p)^{n−∑k}, at fixed counts kᵢ. The residual cell is what makes the probabilities sum to one and is exactly the factor that supplies the exponential e^(−∑λᵢ) terms in the limit.",
+    "mathContext": "$\\mathrm{multinomialPMF} = \\frac{n!}{\\prod_i k_i!\\,(n-\\sum k)!}\\prod_i p_i^{k_i}\\,(1-\\textstyle\\sum p)^{\\,n-\\sum k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["multinomial distribution", "residual cell", "multinomial coefficient"],
+    "prerequisites": ["the multinomial coefficient", "probability mass functions"]
+  },
+  {
+    "id": "ann-plt-joint",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02-oq-03",
+    "range": { "startLine": 216, "endLine": 270 },
+    "type": "insight",
+    "title": "Multinomial → independent Poissons (asymptotic independence)",
+    "content": "multinomial_tendsto_prod_poisson is the open question's target: with n·pᵢ n → λᵢ per cell, the joint multinomial pmf converges to ∏ᵢ e^(−λᵢ)·λᵢ^{kᵢ}/kᵢ! — the cells become asymptotically independent, each Poisson(λᵢ). Two ingredients combine: the bijection-free product limit gives ∏ᵢ λᵢ^{kᵢ}, and the residual factor (1−∑pᵢ)^(n−K) → e^(−∑λᵢ), which factorises as ∏ᵢ e^(−λᵢ) (Real.exp_sum) to deliver exactly one e^(−λᵢ) per cell. The multinomial coefficient is reconciled with the falling factorial via n!/(n−K)! = ∏_{j<K}(n−j) and Nat.choose_mul_factorial_mul_factorial, then field_simp finishes.",
+    "mathContext": "$\\mathrm{multinomialPMF} \\to \\prod_i e^{-\\lambda_i}\\frac{\\lambda_i^{k_i}}{k_i!}$; independence is encoded in $e^{-\\sum\\lambda_i} = \\prod_i e^{-\\lambda_i}$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic independence", "Real.exp_sum", "Nat.choose_mul_factorial_mul_factorial", "Poisson point process", "product distribution"],
+    "prerequisites": ["the product limit", "the residual exponential factor", "multinomial coefficient identities"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-01-oq-02-oq-03` (the Poisson limit theorem: multinomial → independent Poissons).

The entry already had a rich overview, 4 sections, and conclusion, but **no `annotations.json`**. Added it.

- **`annotations.json`** (7 annotations, each with `mathContext` LaTeX / `significance` / `relatedConcepts` / `prerequisites`) covering: the law-of-rare-events goal + the Mathlib gap (poissonPMFReal exists, no binomial→Poisson convergence), the three auxiliary limits, the one-cell three-factor decomposition (`binomial_tendsto_poisson` via descFactorial), the `poissonPMFReal` restatement, the bijection-free product limit (`Finset.prod_pow_eq_pow_sum`), the `multinomialPMF` definition with its residual cell, and the joint multinomial → independent Poissons result (asymptotic independence encoded in `e^(−∑λ) = ∏ e^(−λᵢ)`).
- Annotation ranges verified to snap cleanly to Lean constructs (`pnpm annotations:build` reports no warnings for this entry).

Axiom integrity: confirmed `status: verified` / `axiomCount: 0` is accurate — 0 sorries, #print axioms reports only propext/Classical.choice/Quot.sound (no sorryAx, no Lean.ofReduceBool). No change needed.

Verified with `pnpm build` (✓ built).