### PR TITLE
research(subset-count-multiset-oq-02): even–odd submultiset parity via generating function at x=-1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SubsetCountMultisetOQ02.lean
+++ b/proofs/Proofs/SubsetCountMultisetOQ02.lean
@@ -1,0 +1,206 @@
+/-
+# Even–Odd Submultiset Parity (OQ-02 of subset-count-multiset)
+
+This file answers the parent's second open question — *"How do multiset powerset
+operations connect to generating functions?"* — with a concrete and complete
+formalization: the **alternating** (signed-by-size) count of distinct
+submultisets is exactly the value of the size generating function at `x = -1`.
+
+## What This Proves
+
+For a finite multiset `s` over `α`, the distinct submultisets of `s` (each
+counted once) are graded by cardinality. The generating function recording how
+many distinct submultisets there are of each size is the product
+
+  G(x) = ∏ a ∈ s.toFinset, (1 + x + x² + … + x^{m a}),     m a = s.count a,
+
+because the count `k a` of element `a` in a submultiset ranges freely over
+`{0, 1, …, m a}` and the size is `∑ a, k a`. Evaluating `G` at `x = -1`:
+
+  G(-1) = ∏ a, (∑_{k=0}^{m a} (-1)^k) = ∏ a, [m a even ? 1 : 0]
+        = (every multiplicity is even) ? 1 : 0.
+
+But `G(-1) = ∑_{t ≤ s} (-1)^{|t|} = #{even-size submultisets} − #{odd-size}`.
+Hence:
+
+  **#even − #odd = 1  if every multiplicity of `s` is even,  and 0 otherwise.**
+
+Equivalently: the even-size and odd-size distinct submultisets are **equinumerous
+unless every multiplicity is even**, in which case the even count exceeds the
+odd count by exactly one (the surplus is the empty submultiset's "partner-free"
+status when no element can flip parity).
+
+This is the multiset generalization of the classical fact that a *set* with at
+least one element has equally many even- and odd-sized subsets (there every
+multiplicity is `1`, never all even unless the set is empty).
+
+## Proof Strategy
+
+We reuse the bijection `submultisetEquiv` from `SubsetCountMultisetOQ01`
+(`{t // t ≤ s} ≃ ∀ a : s.toFinset, Fin (s.count a + 1)`) to transport the signed
+sum to a product of one-variable alternating sums, then evaluate each factor with
+`neg_one_geom_sum`.
+
+## Tags
+combinatorics, multisets, generating-functions, parity, alternating-sum
+-/
+
+import Mathlib
+import Proofs.SubsetCountMultisetOQ01
+
+namespace SubsetCountMultisetOQ02
+
+open Multiset BigOperators Finset
+open SubsetCountMultisetOQ01
+
+variable {α : Type*} [DecidableEq α]
+
+/-! ## Cardinality as a sum of counts over the ambient support -/
+
+/-- For a submultiset `t ≤ s`, its cardinality is the sum of its counts taken over
+the *ambient* support `s.toFinset` (counts off `t`'s own support contribute `0`). -/
+theorem card_eq_sum_count_toFinset {s t : Multiset α} (ht : t ≤ s) :
+    ∑ a ∈ s.toFinset, t.count a = t.card := by
+  have hsub : t.toFinset ⊆ s.toFinset := fun a ha =>
+    Multiset.mem_toFinset.mpr (Multiset.subset_of_le ht (Multiset.mem_toFinset.mp ha))
+  rw [← Finset.sum_subset hsub]
+  · exact Multiset.toFinset_sum_count_eq t
+  · intro a _ hna
+    exact Multiset.count_eq_zero.mpr (fun h => hna (Multiset.mem_toFinset.mpr h))
+
+/-! ## The signed (alternating-by-size) submultiset sum -/
+
+/-- **Generating-function evaluation at `x = -1`.**
+The alternating sum of `(-1)^{|t|}` over all distinct submultisets `t ≤ s` factors
+as a product over distinct elements of the one-variable alternating sums
+`∑_{k=0}^{m a} (-1)^k`, each of which is `1` if `m a` is even and `0` otherwise. -/
+theorem signed_sum_eq_prod (s : Multiset α) :
+    ∑ t ∈ distinctSubMultisets s, (-1 : ℤ) ^ t.card
+      = ∏ a ∈ s.toFinset, (if Even (s.count a) then (1 : ℤ) else 0) := by
+  classical
+  -- Fintype instance on submultisets, supplied as in the parent file.
+  haveI instLE : Fintype {t : Multiset α // t ≤ s} :=
+    Fintype.ofFinset (distinctSubMultisets s) (fun _ => mem_distinctSubMultisets)
+  -- Transport equation: `(-1)^|t| = ∏ a, (-1)^(t.count a)`.
+  have transport : ∀ x : {t : Multiset α // t ≤ s},
+      (-1 : ℤ) ^ (x : Multiset α).card
+        = ∏ a : ↑s.toFinset, (-1 : ℤ) ^ ((submultisetEquiv s x a).val) := by
+    rintro ⟨t, ht⟩
+    rw [Finset.prod_pow_eq_pow_sum]
+    congr 1
+    have hval : ∀ a : ↑s.toFinset, (submultisetEquiv s ⟨t, ht⟩ a).val = t.count (↑a : α) :=
+      fun _ => rfl
+    simp only [hval]
+    rw [Finset.sum_coe_sort s.toFinset (fun a => t.count a)]
+    exact (card_eq_sum_count_toFinset ht).symm
+  -- Step 1: sum over the Finset becomes a sum over the subtype `{t // t ≤ s}`.
+  rw [Finset.sum_subtype (distinctSubMultisets s)
+        (fun _ => mem_distinctSubMultisets) (fun t => (-1 : ℤ) ^ t.card)]
+  -- Step 2: transport along the counting bijection to count functions.
+  rw [Fintype.sum_equiv (submultisetEquiv s)
+        (fun x => (-1 : ℤ) ^ (x : Multiset α).card)
+        (fun φ => ∏ a : ↑s.toFinset, (-1 : ℤ) ^ ((φ a).val)) transport]
+  -- Step 3: product-of-sums ⇆ sum-of-products, then evaluate each factor.
+  rw [← Fintype.prod_sum
+        (fun (a : ↑s.toFinset) (j : Fin (s.count (↑a : α) + 1)) => (-1 : ℤ) ^ (j.val))]
+  rw [← Finset.prod_coe_sort s.toFinset
+        (fun a => if Even (s.count a) then (1 : ℤ) else 0)]
+  refine Finset.prod_congr rfl (fun a _ => ?_)
+  rw [Fin.sum_univ_eq_sum_range (fun k => (-1 : ℤ) ^ k) (s.count (↑a : α) + 1),
+      neg_one_geom_sum]
+  -- `Even (m+1) ↔ ¬ Even m`, so `(if Even (m+1) then 0 else 1) = if Even m then 1 else 0`.
+  by_cases h : Even (s.count (↑a : α)) <;> simp [Nat.even_add_one, h]
+
+/-! ## Even and odd submultisets -/
+
+/-- Distinct submultisets of `s` of even cardinality. -/
+def evenSubMultisets (s : Multiset α) : Finset (Multiset α) :=
+  (distinctSubMultisets s).filter (fun t => Even t.card)
+
+/-- Distinct submultisets of `s` of odd cardinality. -/
+def oddSubMultisets (s : Multiset α) : Finset (Multiset α) :=
+  (distinctSubMultisets s).filter (fun t => ¬ Even t.card)
+
+/-- The signed sum equals `#even − #odd`. -/
+theorem signed_sum_eq_card_diff (s : Multiset α) :
+    ∑ t ∈ distinctSubMultisets s, (-1 : ℤ) ^ t.card
+      = (evenSubMultisets s).card - (oddSubMultisets s).card := by
+  classical
+  simp only [evenSubMultisets, oddSubMultisets]
+  rw [← Finset.sum_filter_add_sum_filter_not (distinctSubMultisets s)
+        (fun t => Even t.card) (fun t => (-1 : ℤ) ^ t.card)]
+  have he : ∑ t ∈ (distinctSubMultisets s).filter (fun t => Even t.card),
+              (-1 : ℤ) ^ t.card
+            = ((distinctSubMultisets s).filter (fun t => Even t.card)).card := by
+    rw [Finset.sum_congr rfl (fun t ht => (Finset.mem_filter.mp ht).2.neg_one_pow),
+        Finset.sum_const, nsmul_eq_mul, mul_one]
+  have ho : ∑ t ∈ (distinctSubMultisets s).filter (fun t => ¬ Even t.card),
+              (-1 : ℤ) ^ t.card
+            = -(((distinctSubMultisets s).filter (fun t => ¬ Even t.card)).card) := by
+    rw [Finset.sum_congr rfl
+          (fun t ht => (Nat.not_even_iff_odd.mp (Finset.mem_filter.mp ht).2).neg_one_pow),
+        Finset.sum_const, nsmul_eq_mul, mul_neg_one]
+  rw [he, ho]
+  ring
+
+/-! ## Main theorem -/
+
+/-- **Even–Odd Submultiset Parity.**
+The number of even-size distinct submultisets minus the number of odd-size ones is
+`1` if every multiplicity of `s` is even, and `0` otherwise. -/
+theorem even_sub_odd_eq (s : Multiset α) :
+    (evenSubMultisets s).card - (oddSubMultisets s).card
+      = if (∀ a ∈ s.toFinset, Even (s.count a)) then (1 : ℤ) else 0 := by
+  classical
+  rw [← signed_sum_eq_card_diff, signed_sum_eq_prod]
+  by_cases h : ∀ a ∈ s.toFinset, Even (s.count a)
+  · rw [if_pos h]
+    apply Finset.prod_eq_one
+    intro a ha
+    rw [if_pos (h a ha)]
+  · rw [if_neg h]
+    push_neg at h
+    obtain ⟨a, ha, hne⟩ := h
+    apply Finset.prod_eq_zero ha
+    rw [if_neg hne]
+
+/-- **Equinumerous unless all multiplicities are even.**
+If some element of `s` occurs an odd number of times, then the even-size and
+odd-size distinct submultisets are exactly equal in number. -/
+theorem even_card_eq_odd_card_of_not_all_even (s : Multiset α)
+    (h : ¬ ∀ a ∈ s.toFinset, Even (s.count a)) :
+    (evenSubMultisets s).card = (oddSubMultisets s).card := by
+  have := even_sub_odd_eq s
+  rw [if_neg h] at this
+  omega
+
+/-- When every multiplicity of `s` is even, the even-size submultisets outnumber
+the odd-size ones by exactly one. -/
+theorem even_card_eq_odd_card_succ_of_all_even (s : Multiset α)
+    (h : ∀ a ∈ s.toFinset, Even (s.count a)) :
+    (evenSubMultisets s).card = (oddSubMultisets s).card + 1 := by
+  have := even_sub_odd_eq s
+  rw [if_pos h] at this
+  omega
+
+/-! ## Sanity checks -/
+
+/-- `{0}` (one odd multiplicity): even submultisets `{}` and odd `{0}` are equinumerous. -/
+example :
+    (evenSubMultisets ({0} : Multiset ℕ)).card
+      = (oddSubMultisets ({0} : Multiset ℕ)).card := by
+  apply even_card_eq_odd_card_of_not_all_even
+  decide
+
+/-- `{0, 0}` (all multiplicities even): even count = odd count + 1.
+    Submultisets `{}, {0}, {0,0}`: even `{}, {0,0}` (2), odd `{0}` (1). -/
+example :
+    (evenSubMultisets ({0, 0} : Multiset ℕ)).card
+      = (oddSubMultisets ({0, 0} : Multiset ℕ)).card + 1 := by
+  apply even_card_eq_odd_card_succ_of_all_even
+  decide
+
+#check @even_sub_odd_eq
+#check @signed_sum_eq_prod
+
+end SubsetCountMultisetOQ02

--- a/src/data/proofs/subset-count-multiset-oq-02/annotations.json
+++ b/src/data/proofs/subset-count-multiset-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-scm-oq02-header",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "File Context: Connecting Multiset Powersets to Generating Functions",
+    "content": "This file answers the parent proof's second open question — how multiset powerset operations connect to generating functions — by identifying a single generating-function evaluation. The size generating function of a multiset s is ∏ᵢ(1 + x + ⋯ + x^{mᵢ}), where the factor for element i records the 0,…,mᵢ copies that may be chosen. Evaluating at x = -1 collapses each factor to 1 (if mᵢ even) or 0 (if mᵢ odd), and equals the signed-by-size count ∑_{t ≤ s} (-1)^{|t|}. The file imports the OQ-01 companion to reuse its counting bijection submultisetEquiv.",
+    "mathContext": "$\\sum_{t \\le s} (-1)^{|t|} = \\prod_{a \\in s.\\mathrm{toFinset}} \\Big(\\sum_{k=0}^{m_a} (-1)^k\\Big) = \\prod_a [m_a \\text{ even}]$, evaluated as the product of the truncated geometric series $1 + x + \\cdots + x^{m_a}$ at $x = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subset-count-multiset",
+      "generating function",
+      "Multiset.powerset",
+      "alternating sum",
+      "roots-of-unity filter"
+    ],
+    "prerequisites": [
+      "Multiset basics (count, le, toFinset)",
+      "Generating functions for subset/submultiset counting",
+      "Alternating geometric sums"
+    ]
+  },
+  {
+    "id": "ann-scm-oq02-cardsum",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "lemma",
+    "title": "Cardinality Factors Additively over Distinct Elements",
+    "content": "For a submultiset t ≤ s, the cardinality |t| equals the sum of t's counts taken over the ambient support s.toFinset (not just t's own support). This works because any element outside t's support contributes count 0, so extending the sum from t.toFinset to the larger s.toFinset adds only zeros. This additive form of |t| is what later lets (-1)^{|t|} be written as a product of per-element signs.",
+    "mathContext": "$|t| = \\sum_{a \\in s.\\mathrm{toFinset}} t.\\mathrm{count}\\,a$ for $t \\le s$, obtained from $\\sum_{a \\in t.\\mathrm{toFinset}} t.\\mathrm{count}\\,a = |t|$ (toFinset_sum_count_eq) by Finset.sum_subset.",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.toFinset_sum_count_eq", "Finset.sum_subset", "submultiset"],
+    "prerequisites": ["Multiset count and toFinset", "Finite sums over finsets"]
+  },
+  {
+    "id": "ann-scm-oq02-signedsum",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 74, "endLine": 115 },
+    "type": "theorem",
+    "title": "The Generating Function Evaluated at x = -1",
+    "content": "The central result: the alternating sum ∑_{t ≤ s} (-1)^{|t|} over distinct submultisets factors into a product over distinct elements, each factor being 1 if that element's multiplicity is even and 0 if odd. The proof transports the sum along the OQ-01 bijection submultisetEquiv (submultisets ≃ count functions), rewrites (-1)^{|t|} = ∏_a (-1)^{count} using the additive cardinality and Finset.prod_pow_eq_pow_sum, swaps sum and product with Fintype.prod_sum, and evaluates each per-element factor ∑_{k=0}^{mₐ}(-1)^k with neg_one_geom_sum.",
+    "mathContext": "$\\sum_{t \\le s} (-1)^{|t|} = \\prod_{a \\in s.\\mathrm{toFinset}} \\big(\\mathbf{1}[\\,\\mathrm{Even}(s.\\mathrm{count}\\,a)\\,]\\big)$, since $\\sum_{k=0}^{m}(-1)^k = 1$ if $m$ even and $0$ if $m$ odd.",
+    "significance": "central",
+    "relatedConcepts": [
+      "submultisetEquiv",
+      "Fintype.prod_sum",
+      "neg_one_geom_sum",
+      "Finset.prod_pow_eq_pow_sum",
+      "generating function"
+    ],
+    "prerequisites": [
+      "OQ-01 counting bijection",
+      "Product-of-sums = sum-of-products",
+      "Alternating geometric sum"
+    ]
+  },
+  {
+    "id": "ann-scm-oq02-evenodd",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 116, "endLine": 149 },
+    "type": "definition",
+    "title": "Even/Odd Submultisets and the Signed Sum as #even − #odd",
+    "content": "Defines evenSubMultisets and oddSubMultisets as the distinct submultisets filtered by parity of cardinality, then shows the signed sum ∑ (-1)^{|t|} equals #even − #odd. Splitting the sum over the parity predicate (Finset.sum_filter_add_sum_filter_not), the even part contributes +1 per element (Even.neg_one_pow) and the odd part contributes -1 (Odd.neg_one_pow), giving exactly the difference of the two filtered cardinalities.",
+    "mathContext": "$\\sum_{t \\le s} (-1)^{|t|} = \\#\\{t : |t| \\text{ even}\\} - \\#\\{t : |t| \\text{ odd}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.filter", "Finset.sum_filter_add_sum_filter_not", "Even.neg_one_pow", "Odd.neg_one_pow"],
+    "prerequisites": ["Finset filtering", "Parity of (-1)^n"]
+  },
+  {
+    "id": "ann-scm-oq02-main",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 150, "endLine": 187 },
+    "type": "theorem",
+    "title": "Even–Odd Submultiset Parity Dichotomy",
+    "content": "Combining the two preceding results: #even − #odd equals 1 if every multiplicity of s is even, and 0 otherwise. The product ∏_a (Even? 1 : 0) is 1 exactly when all factors are 1 (Finset.prod_eq_one), and is 0 as soon as one factor vanishes (Finset.prod_eq_zero). Two corollaries restate this concretely: the counts are equal when some multiplicity is odd, and the even count beats the odd count by exactly one when all multiplicities are even — the multiset generalization of the classical 'equal even/odd subset count' for nonempty sets.",
+    "mathContext": "$\\#\\text{even} - \\#\\text{odd} = \\begin{cases} 1 & \\text{all multiplicities even}\\\\ 0 & \\text{otherwise}\\end{cases}$.",
+    "significance": "central",
+    "relatedConcepts": ["Finset.prod_eq_one", "Finset.prod_eq_zero", "even/odd subset parity", "subset-count-oq-04"],
+    "prerequisites": ["Products of 0/1 indicators", "The signed-sum identity"]
+  },
+  {
+    "id": "ann-scm-oq02-examples",
+    "proofId": "subset-count-multiset-oq-02",
+    "range": { "startLine": 188, "endLine": 204 },
+    "type": "example",
+    "title": "Numerical Sanity Checks",
+    "content": "Two concrete checks over ℕ. The multiset {0} has one element of odd multiplicity (1), so its even submultiset ({}) and odd submultiset ({0}) are equinumerous. The multiset {0,0} has all multiplicities even (count 0 = 2), so its even submultisets ({}, {0,0}) outnumber its odd ones ({0}) by exactly one. Both are discharged by kernel `decide` on the parity hypotheses — no native_decide, keeping the file free of Lean.ofReduceBool.",
+    "mathContext": "$\\{0\\}$: $1 = 1$.  $\\{0,0\\}$: even $= $ odd $+ 1$ (i.e. $2 = 1 + 1$).",
+    "significance": "illustrative",
+    "relatedConcepts": ["decide", "submultiset enumeration"],
+    "prerequisites": ["Decidable parity"]
+  }
+]

--- a/src/data/proofs/subset-count-multiset-oq-02/meta.json
+++ b/src/data/proofs/subset-count-multiset-oq-02/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "subset-count-multiset-oq-02",
+  "title": "Even–Odd Submultiset Parity via the Size Generating Function",
+  "slug": "subset-count-multiset-oq-02",
+  "description": "Answers the parent's open question on connecting multiset powerset operations to generating functions. The signed-by-size count of distinct submultisets is the value of the size generating function ∏(1 + x + … + x^mᵢ) at x = -1. Evaluating gives: the number of even-size distinct submultisets minus the number of odd-size ones is 1 if every multiplicity of s is even, and 0 otherwise. Equivalently, even- and odd-size submultisets are equinumerous unless every multiplicity is even.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SubsetCountMultisetOQ02.lean",
+    "parentProofId": "subset-count-multiset",
+    "tags": [
+      "combinatorics",
+      "multiset",
+      "generating-functions",
+      "parity",
+      "alternating-sum",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. The four named theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). The numerical sanity-check examples use kernel `decide` (no native_decide, no Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "∑ i ∈ range n, (-1)^i = if Even n then 0 else 1 — the one-variable alternating sum",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Fintype.prod_sum",
+        "description": "A product of sums equals a sum of products over the dependent function type",
+        "module": "Mathlib.Algebra.BigOperators.Ring.Finset"
+      },
+      {
+        "theorem": "Fintype.sum_equiv",
+        "description": "Transports a finite sum along a bijection",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Finset.prod_pow_eq_pow_sum",
+        "description": "∏ aᶠⁱ = a^(∑ fi): collapses a product of powers into a power of the sum",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Multiset.toFinset_sum_count_eq",
+        "description": "∑ a ∈ s.toFinset, s.count a = card s",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "signed_sum_eq_prod: ∑_{t ≤ s} (-1)^|t| = ∏ a ∈ s.toFinset, (Even (s.count a) ? 1 : 0) — generating function evaluated at x = -1",
+      "even_sub_odd_eq: #even − #odd = 1 if every multiplicity of s is even, else 0",
+      "even_card_eq_odd_card_of_not_all_even: even- and odd-size submultisets are equinumerous when some multiplicity is odd",
+      "even_card_eq_odd_card_succ_of_all_even: even count = odd count + 1 when every multiplicity is even",
+      "Reuses the parent OQ-01 bijection submultisetEquiv to transport the signed sum to a product of alternating sums"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 206,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "prerequisites": [
+      "Multiset count, ordering, toFinset, powerset",
+      "Finite sums/products and Fintype bijections",
+      "The alternating geometric sum neg_one_geom_sum"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "A classical fact about finite sets is that any nonempty set has exactly as many even-sized subsets as odd-sized subsets: the alternating sum ∑_{T ⊆ S} (-1)^{|T|} equals (1 - 1)^{|S|} = 0. The multiset analogue is subtler because the size generating function is a product of truncated geometric series ∏ᵢ (1 + x + x² + ⋯ + x^{mᵢ}) rather than ∏ᵢ (1 + x). Evaluating this product at x = -1 — which is exactly the signed-by-size count of distinct submultisets — gives a product of one-variable alternating sums, each of which is 1 when mᵢ is even and 0 when mᵢ is odd. The whole product is therefore 1 precisely when every multiplicity is even, and 0 otherwise.\n\nThis answers the second open question left by the parent proof (subset-count-multiset / SubsetCountOQ02): how do multiset powerset operations connect to generating functions? Here the connection is made concrete and fully verified — the generating-function evaluation at x = -1 is identified with the difference of even and odd submultiset counts.",
+    "problemStatement": "For a finite multiset s over a type with decidable equality, compare the number of distinct submultisets of even cardinality with the number of odd cardinality. Show the difference is 1 if every multiplicity of s is even and 0 otherwise.",
+    "text": "The even-size and odd-size distinct submultisets of s are equal in number, unless every multiplicity of s is even, in which case the even count exceeds the odd count by exactly one.",
+    "proofStrategy": "Form the signed sum ∑_{t ≤ s} (-1)^|t| over distinct submultisets. Transport it along the parent's counting bijection submultisetEquiv (submultisets ≃ count functions ∏ a, Fin (s.count a + 1)). Using |t| = ∑ a (count of a in t) and Finset.prod_pow_eq_pow_sum, the signed sum becomes ∑ over count-functions of ∏ a (-1)^(count). Fintype.prod_sum swaps the sum and product, yielding ∏ a (∑_{k=0}^{mₐ} (-1)^k). Each factor is evaluated by neg_one_geom_sum to (Even mₐ ? 1 : 0). Finally, the signed sum is identified with #even − #odd via Finset.sum_filter_add_sum_filter_not.",
+    "keyInsights": [
+      "The signed-by-size count ∑_{t ≤ s} (-1)^|t| IS the size generating function ∏(1 + x + ⋯ + x^mᵢ) evaluated at x = -1",
+      "Cardinality of a submultiset factors additively over distinct elements: |t| = ∑ a ∈ s.toFinset, t.count a (counts off t's support are 0)",
+      "(-1)^(∑ counts) = ∏ (-1)^count converts the size-grading into a product, enabling Fintype.prod_sum",
+      "Each per-element factor ∑_{k=0}^{mₐ} (-1)^k is 1 iff mₐ is even (neg_one_geom_sum), so the product is 1 iff all multiplicities are even",
+      "For sets (all multiplicities 1, never all even unless empty) this recovers the classical equal even/odd subset count"
+    ],
+    "prerequisites": [
+      "Multiset count, ordering, toFinset",
+      "Fintype bijections (Equiv) and finite sums/products",
+      "Alternating geometric sums"
+    ]
+  },
+  "sections": [
+    {
+      "id": "card-sum",
+      "title": "Cardinality as a sum of counts",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "card_eq_sum_count_toFinset: a submultiset's cardinality is the sum of its counts over the ambient support s.toFinset.",
+      "mathContext": "|t| = ∑ a ∈ s.toFinset, t.count a for t ≤ s, extending toFinset_sum_count_eq across the larger support."
+    },
+    {
+      "id": "signed-sum",
+      "title": "Generating function at x = -1",
+      "startLine": 74,
+      "endLine": 115,
+      "summary": "signed_sum_eq_prod: the alternating sum over distinct submultisets factors as ∏ a (Even (count a) ? 1 : 0).",
+      "mathContext": "Transport along submultisetEquiv, Finset.prod_pow_eq_pow_sum, Fintype.prod_sum, and neg_one_geom_sum."
+    },
+    {
+      "id": "even-odd-defs",
+      "title": "Even and odd submultisets",
+      "startLine": 116,
+      "endLine": 149,
+      "summary": "Defines evenSubMultisets / oddSubMultisets and proves the signed sum equals #even − #odd.",
+      "mathContext": "signed_sum_eq_card_diff via Finset.sum_filter_add_sum_filter_not, Even.neg_one_pow, Odd.neg_one_pow."
+    },
+    {
+      "id": "main",
+      "title": "Main theorem",
+      "startLine": 150,
+      "endLine": 187,
+      "summary": "even_sub_odd_eq and its two corollaries (equinumerous unless all even; even = odd + 1 when all even).",
+      "mathContext": "Product of (Even ? 1 : 0) is 1 iff all factors are even (Finset.prod_eq_one / prod_eq_zero)."
+    },
+    {
+      "id": "examples",
+      "title": "Sanity checks",
+      "startLine": 188,
+      "endLine": 204,
+      "summary": "Concrete checks: {0} gives equal counts; {0,0} gives even = odd + 1.",
+      "mathContext": "Verified by kernel decide on the parity hypotheses."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "subset-count-multiset",
+      "relationship": "follow-up",
+      "description": "Answers the parent's open question: connecting multiset powerset operations to generating functions"
+    },
+    {
+      "targetId": "subset-count-multiset-oq-01",
+      "relationship": "sibling",
+      "description": "Reuses the submultisetEquiv bijection from OQ-01 (distinct submultiset count ∏(mᵢ+1))"
+    },
+    {
+      "targetId": "subset-count-oq-04",
+      "relationship": "related",
+      "description": "The set-level even/odd subset parity (2^(n-1) each); this is the multiset generalization where parity can fail to balance"
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, axiom-free formalization identifying the signed-by-size submultiset count with the size generating function at x = -1, yielding the even–odd parity dichotomy. 6 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "Makes the generating-function/powerset connection precise for multisets and pinpoints exactly when the classical even/odd subset balance breaks: it survives unless every multiplicity is even.",
+    "openQuestions": [
+      "What is the full distribution of submultiset counts by size — i.e. the individual coefficients of ∏(1 + x + … + x^mᵢ), not just the value at x = -1?",
+      "Does evaluating the generating function at other roots of unity give a useful 'roots-of-unity filter' counting submultisets whose size lies in a fixed residue class?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SubsetCountMultisetOQ01"
+    ],
+    "opens": [
+      "Multiset",
+      "BigOperators",
+      "Finset",
+      "SubsetCountMultisetOQ01"
+    ],
+    "namespace": "SubsetCountMultisetOQ02",
+    "lineCount": 206,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/SubsetCountMultisetOQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "even_sub_odd_eq",
+      "type": "core",
+      "description": "The number of even-size distinct submultisets minus the number of odd-size ones is 1 if every multiplicity of s is even, and 0 otherwise",
+      "leanType": "(s : Multiset α) → ((evenSubMultisets s).card : ℤ) - (oddSubMultisets s).card = if (∀ a ∈ s.toFinset, Even (s.count a)) then 1 else 0"
+    },
+    {
+      "name": "signed_sum_eq_prod",
+      "type": "core",
+      "description": "The signed-by-size submultiset sum equals the size generating function evaluated at x = -1",
+      "leanType": "(s : Multiset α) → ∑ t ∈ distinctSubMultisets s, (-1)^t.card = ∏ a ∈ s.toFinset, (if Even (s.count a) then 1 else 0)"
+    },
+    {
+      "name": "even_card_eq_odd_card_of_not_all_even",
+      "type": "corollary",
+      "description": "Even- and odd-size distinct submultisets are equinumerous when some multiplicity is odd",
+      "leanType": "(s : Multiset α) → (¬ ∀ a ∈ s.toFinset, Even (s.count a)) → (evenSubMultisets s).card = (oddSubMultisets s).card"
+    },
+    {
+      "name": "even_card_eq_odd_card_succ_of_all_even",
+      "type": "corollary",
+      "description": "When every multiplicity is even, the even count exceeds the odd count by exactly one",
+      "leanType": "(s : Multiset α) → (∀ a ∈ s.toFinset, Even (s.count a)) → (evenSubMultisets s).card = (oddSubMultisets s).card + 1"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent proof's open question — *how do multiset powerset operations connect to generating functions?* — with a concrete, fully verified identity.

The **size generating function** of a multiset `s` is `G(x) = ∏ a (1 + x + ⋯ + x^{mₐ})`, where `mₐ = s.count a` and the factor for `a` records the `0,…,mₐ` copies a submultiset may include. Its value at `x = -1` is exactly the signed-by-size count of distinct submultisets:

```
∑_{t ≤ s} (-1)^|t| = ∏ a (∑_{k=0}^{mₐ} (-1)^k) = ∏ a [mₐ even]
                   = 1 if every multiplicity of s is even, else 0.
```

Since that signed sum is `#even-size − #odd-size`, this gives the **parity dichotomy**:

> The even-size and odd-size distinct submultisets of `s` are **equal in number, unless every multiplicity of `s` is even**, in which case the even count exceeds the odd count by exactly one.

For ordinary sets (all multiplicities `1`, never all even unless empty) this recovers the classical fact that a nonempty set has equally many even- and odd-sized subsets.

## Main results
- `signed_sum_eq_prod` — `∑_{t ≤ s} (-1)^|t| = ∏ a∈s.toFinset, (Even (s.count a) ? 1 : 0)` (generating function at `x = -1`)
- `even_sub_odd_eq` — `#even − #odd = if (∀ a, Even (count a)) then 1 else 0`
- `even_card_eq_odd_card_of_not_all_even` — equinumerous when some multiplicity is odd
- `even_card_eq_odd_card_succ_of_all_even` — even = odd + 1 when all multiplicities are even

## Technique
Reuses the **OQ-01 bijection** `submultisetEquiv : {t // t ≤ s} ≃ ∀ a, Fin (s.count a + 1)` to transport the signed sum to count-functions; `Finset.prod_pow_eq_pow_sum` turns `(-1)^|t|` into a product of per-element signs; `Fintype.prod_sum` swaps sum/product; `neg_one_geom_sum` evaluates each factor.

## Verification
- 6 theorems, 2 definitions, 206 lines, **0 sorries**
- `#print axioms` on all four named theorems: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom verified**. Sanity-check examples use kernel `decide` (no `native_decide`, no `Lean.ofReduceBool`).
- Builds against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)