### PR TITLE
research(ball-rivoal-oq010103): linear-form irrationality criterion + dimension reduction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3209,6 +3209,7 @@ import Proofs.LawOfCosinesOQ04OQ02
 import Proofs.LawOfCosinesOQ04OQ02OQ01
 import Proofs.LawOfCosinesOQ05
 import Proofs.LawOfCosinesOQ07
+import Proofs.LawOfCosinesOQ08
 import Proofs.LawOfSinesOQ06
 import Proofs.LawsOfLargeNumbers
 import Proofs.LawsOfLargeNumbersOQ01

--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean
@@ -1,0 +1,181 @@
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Tactic
+
+/-
+# Ball–Rivoal: the linear-form engine and the dimension reduction (OQ-01-OQ-01-OQ-03)
+
+Open Question from "Is ζ(5) Irrational? — Computational Bounds" (basel-problem-oq-01-oq-01).
+
+The Ball–Rivoal theorem states that infinitely many odd zeta values
+ζ(3), ζ(5), ζ(7), … are irrational.  A full formalization is far out of reach,
+but the proof has a precise logical skeleton that *is* formalizable, and which
+this file establishes with no axioms and no sorries.
+
+Two ingredients drive every known irrationality result of this kind (Apéry 1978
+for ζ(3); Rivoal 2000 / Ball–Rivoal for the whole odd family):
+
+* **The linear-form criterion** (Part I).  If one can build integer sequences
+  `pₙ, qₙ` with the real linear forms `qₙ·α − pₙ` nonzero but tending to `0`,
+  then `α` is irrational.  This is the *sufficiency* engine: a single nonzero
+  integer has absolute value `≥ 1`, so a rational `α = a/b` forces every nonzero
+  form `qₙ·α − pₙ = (qₙ·a − pₙ·b)/b` to stay `≥ 1/|b|` away from `0`,
+  contradicting convergence.  Mathlib has the Hurwitz characterization (good
+  rational approximations at the fixed rate `1/q²`) but not this rate-free form,
+  which is exactly what the Apéry/Ball–Rivoal hypergeometric constructions
+  supply.
+
+* **The dimension reduction** (Part II).  Rivoal's analytic input is a *lower
+  bound* on `dim_ℚ span{1, ζ(3), ζ(5), …, ζ(2n+1)}` that grows without bound in
+  `n`.  We prove the purely linear-algebraic step that converts unbounded
+  dimension into the conclusion "infinitely many of the values are irrational":
+  if only finitely many `xᵢ` were irrational, every span would sit inside a
+  single fixed finite-dimensional ℚ-subspace, capping the dimension.
+
+Axioms: 0
+Sorries: 0
+-/
+
+open Filter Topology
+
+namespace BaselProblemOQ01OQ01OQ03
+
+-- ============================================================
+-- Part I: The linear-form irrationality criterion (the engine)
+-- ============================================================
+
+/-- **Quantitative core.**  For a rational `α = a/b` with `b ≠ 0`, every integer
+linear form `q·α − p` that is nonzero is bounded away from `0` by `1/|b|`.  The
+form equals `(q·a − p·b)/b`, whose numerator is a nonzero integer, hence has
+absolute value at least `1`. -/
+theorem abs_linearForm_ge_of_rat (a b p q : ℤ) (hb : b ≠ 0)
+    (hne : (q : ℝ) * ((a : ℝ) / (b : ℝ)) - (p : ℝ) ≠ 0) :
+    1 / |(b : ℝ)| ≤ |(q : ℝ) * ((a : ℝ) / (b : ℝ)) - (p : ℝ)| := by
+  have hbR : (b : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hb
+  have hbpos : 0 < |(b : ℝ)| := abs_pos.mpr hbR
+  have hform : (q : ℝ) * ((a : ℝ) / (b : ℝ)) - (p : ℝ)
+      = ((q * a - p * b : ℤ) : ℝ) / (b : ℝ) := by
+    push_cast; field_simp
+  rw [hform] at hne ⊢
+  have hnum : (q * a - p * b : ℤ) ≠ 0 := by
+    intro h; apply hne; rw [h]; simp
+  rw [abs_div, div_le_div_iff_of_pos_right hbpos, ← Int.cast_abs]
+  exact_mod_cast Int.one_le_abs hnum
+
+/-- **The linear-form irrationality criterion.**  Given integer sequences
+`p, q : ℕ → ℤ` such that the real linear forms `qₙ·α − pₙ` are all nonzero yet
+tend to `0`, the number `α` is irrational.
+
+This is the abstract sufficiency theorem behind Apéry's proof that `ζ(3)` is
+irrational and behind the Ball–Rivoal construction for the odd zeta family. -/
+theorem irrational_of_linearForm_tendsto_zero {α : ℝ} (p q : ℕ → ℤ)
+    (hne : ∀ n, (q n : ℝ) * α - (p n : ℝ) ≠ 0)
+    (htend : Tendsto (fun n => (q n : ℝ) * α - (p n : ℝ)) atTop (𝓝 0)) :
+    Irrational α := by
+  rintro ⟨r, hr⟩
+  -- `α = r = r.num / r.den`, rational; derive a uniform lower bound on the forms.
+  have hden : ((r.den : ℤ)) ≠ 0 := by exact_mod_cast r.den_ne_zero
+  have hαeq : α = (r.num : ℝ) / ((r.den : ℤ) : ℝ) := by
+    rw [← hr, Rat.cast_def]; push_cast; ring
+  set ε : ℝ := 1 / |((r.den : ℤ) : ℝ)| with hε
+  have hεpos : 0 < ε := by rw [hε]; positivity
+  -- Eventually the forms lie within `ε` of `0` …
+  have hev : ∀ᶠ n in atTop, |(q n : ℝ) * α - (p n : ℝ)| < ε := by
+    refine (htend.eventually (Metric.ball_mem_nhds (0 : ℝ) hεpos)).mono ?_
+    intro n hn
+    rwa [Real.dist_eq, sub_zero] at hn
+  obtain ⟨n, hn⟩ := hev.exists
+  -- … yet each nonzero form is at least `ε` away — contradiction.
+  have hge : ε ≤ |(q n : ℝ) * α - (p n : ℝ)| := by
+    rw [hε, hαeq]
+    exact abs_linearForm_ge_of_rat r.num (r.den : ℤ) (p n) (q n) hden
+      (by rw [← hαeq]; exact hne n)
+  exact absurd hn (not_lt.mpr hge)
+
+/-- **Decay-rate packaging.**  In practice one has an explicit upper bound
+`|qₙ·α − pₙ| ≤ Cₙ` with `Cₙ → 0` (e.g. geometric decay `C·ρⁿ`, as Apéry obtains
+with `ρ = (√2 − 1)⁴ ≈ 1/34`).  Together with non-vanishing this yields
+irrationality. -/
+theorem irrational_of_linearForm_le_tendsto_zero {α : ℝ} (p q : ℕ → ℤ)
+    (C : ℕ → ℝ) (hne : ∀ n, (q n : ℝ) * α - (p n : ℝ) ≠ 0)
+    (hle : ∀ n, |(q n : ℝ) * α - (p n : ℝ)| ≤ C n)
+    (hC : Tendsto C atTop (𝓝 0)) :
+    Irrational α := by
+  apply irrational_of_linearForm_tendsto_zero p q hne
+  -- two-sided squeeze: `−Cₙ ≤ formₙ ≤ Cₙ` with `±Cₙ → 0`.
+  have hCneg : Tendsto (fun n => -C n) atTop (𝓝 0) := by simpa using hC.neg
+  refine tendsto_of_tendsto_of_tendsto_of_le_of_le hCneg hC ?_ ?_
+  · intro n; exact (abs_le.mp (hle n)).1
+  · intro n; exact (abs_le.mp (hle n)).2
+
+-- ============================================================
+-- Part II: The Ball–Rivoal dimension reduction
+-- ============================================================
+
+/-- **Dimension cap from finitely many irrationals.**  View `ℝ` as a
+`ℚ`-vector space.  If every value `x i` with index outside a finite set `T` is
+rational, then the span of `{1} ∪ {x i : i ∈ s}` over *any* finite index set `s`
+is contained in the fixed subspace spanned by `{1} ∪ {x i : i ∈ T}`, so its
+`ℚ`-dimension never exceeds `T.card + 1`. -/
+theorem finrank_span_le_of_irrational_subset (x : ℕ → ℝ) (T : Finset ℕ)
+    (hrat : ∀ i ∉ T, ¬ Irrational (x i)) (s : Finset ℕ) :
+    Module.finrank ℚ
+      (Submodule.span ℚ (↑(insert (1 : ℝ) (s.image x)) : Set ℝ)) ≤ T.card + 1 := by
+  classical
+  set F : Finset ℝ := insert (1 : ℝ) (T.image x) with hF
+  haveI hfin : Module.Finite ℚ ↥(Submodule.span ℚ (↑F : Set ℝ)) :=
+    Module.Finite.iff_fg.mpr (Submodule.fg_span F.finite_toSet)
+  have hsub : Submodule.span ℚ (↑(insert (1 : ℝ) (s.image x)) : Set ℝ)
+      ≤ Submodule.span ℚ (↑F : Set ℝ) := by
+    rw [Submodule.span_le]
+    intro y hy
+    simp only [Finset.coe_insert, Finset.coe_image, Set.mem_insert_iff, Set.mem_image,
+      Finset.mem_coe] at hy
+    rcases hy with rfl | ⟨i, _, rfl⟩
+    · exact Submodule.subset_span (by simp [hF])
+    · by_cases hiT : i ∈ T
+      · refine Submodule.subset_span ?_
+        simp only [hF, Finset.coe_insert, Finset.coe_image, Set.mem_insert_iff, Set.mem_image,
+          Finset.mem_coe]
+        exact Or.inr ⟨i, hiT, rfl⟩
+      · -- `x i` is rational, hence a ℚ-multiple of `1`, hence in the span.
+        have hr := hrat i hiT
+        rw [Irrational, not_not] at hr
+        obtain ⟨c, hc⟩ := hr
+        have hxi : x i = c • (1 : ℝ) := by rw [Rat.smul_one_eq_cast]; exact hc.symm
+        rw [hxi]
+        exact Submodule.smul_mem _ c (Submodule.subset_span (by simp [hF]))
+  calc Module.finrank ℚ (Submodule.span ℚ (↑(insert (1 : ℝ) (s.image x)) : Set ℝ))
+      ≤ Module.finrank ℚ (Submodule.span ℚ (↑F : Set ℝ)) := Submodule.finrank_mono hsub
+    _ ≤ F.card := finrank_span_finset_le_card F
+    _ ≤ T.card + 1 := by
+        rw [hF]
+        have h1 := Finset.card_insert_le (1 : ℝ) (T.image x)
+        have h2 := Finset.card_image_le (s := T) (f := x)
+        omega
+
+/-- **Ball–Rivoal dimension reduction.**  If the `ℚ`-dimension of
+`span{1} ∪ {x i : i ∈ s}` is unbounded as `s` ranges over finite index sets,
+then infinitely many of the `x i` are irrational.
+
+This is the linear-algebraic heart of Ball–Rivoal: Rivoal's analytic dimension
+lower bound `(1 + o(1))·log n / (1 + log 2) → ∞` for the odd zeta values feeds
+this lemma to conclude that infinitely many odd zeta values are irrational. -/
+theorem infinite_irrational_of_unbounded_finrank (x : ℕ → ℝ)
+    (hunb : ∀ N : ℕ, ∃ s : Finset ℕ,
+      N < Module.finrank ℚ (Submodule.span ℚ (↑(insert (1 : ℝ) (s.image x)) : Set ℝ))) :
+    {i | Irrational (x i)}.Infinite := by
+  classical
+  by_contra h
+  rw [Set.not_infinite] at h
+  set T : Finset ℕ := h.toFinset with hT
+  have hrat : ∀ i ∉ T, ¬ Irrational (x i) := by
+    intro i hi
+    rw [hT, Set.Finite.mem_toFinset] at hi
+    simpa using hi
+  obtain ⟨s, hs⟩ := hunb (T.card + 1)
+  have hcap := finrank_span_le_of_irrational_subset x T hrat s
+  omega
+
+end BaselProblemOQ01OQ01OQ03

--- a/proofs/Proofs/LawOfCosinesOQ08.lean
+++ b/proofs/Proofs/LawOfCosinesOQ08.lean
@@ -1,0 +1,149 @@
+/-
+# Law of Cosines OQ-08: The Triangle Inequality as a Corollary of the Law of Cosines
+
+The parent entry (`LawOfCosines`, Wiedijk #94) proves the law of cosines in both its
+classical scalar form `c² = a² + b² - 2ab·cos C` and its inner-product form
+`‖v - w‖² = ‖v‖² + ‖w‖² - 2⟨v, w⟩`.  One of its open questions asks to *derive the
+triangle inequality directly from the law of cosines*, using only the elementary fact
+that a cosine never drops below `-1`.
+
+This file does exactly that.  The single analytic input is `cos C ≥ -1`
+(`Real.neg_one_le_cos`):
+
+* **Scalar form.**  If `c² = a² + b² - 2ab·cos C` with `a, b, c ≥ 0` and `cos C ≥ -1`,
+  then `c ≤ a + b`.  The proof is one line of algebra:
+  `(a + b)² - c² = 2ab·(1 + cos C) ≥ 0`, and squares of non-negatives are monotone.
+
+* **Equality / degeneracy.**  For a genuine triangle (`a, b > 0`) equality `c = a + b`
+  holds **iff** `cos C = -1`, i.e. iff the angle `C = π` and the triangle is degenerate
+  (the three vertices are collinear with `C` between the other two).  When `cos C > -1`
+  the inequality is strict, `c < a + b`.
+
+* **Coordinate-free form.**  In *any* real inner-product space, the law of cosines in
+  vector-angle form (`InnerProductGeometry.norm_sub_sq_…_cos_angle`) together with
+  `cos ≥ -1` yields `‖x - y‖ ≤ ‖x‖ + ‖y‖`, with equality iff the angle between `x` and
+  `y` is `π`.  This recovers Mathlib's `norm_sub_le` via the law of cosines, exhibiting
+  the triangle inequality as a metric shadow of the cosine rule.
+
+Everything is reduced to the scalar lemma `triangle_ineq_of_law_cosines`, which is the
+mathematical heart of the result.  All proofs are fully machine-checked, with no `sorry`
+and no axioms beyond Lean/Mathlib's foundations.
+
+(The parent `Proofs.LawOfCosines` is referenced conceptually but not imported: this file
+is self-contained and obtains the cosine-rule identity directly from Mathlib's
+`InnerProductGeometry`, so it stays valid independently of the parent file's build state.)
+-/
+import Mathlib
+
+namespace LawOfCosinesOQ08
+
+open InnerProductGeometry Real
+open scoped RealInnerProductSpace
+
+/-! ### Monotonicity of squaring on the non-negative reals
+
+Two small bridges between `x ≤ y` and `x² ≤ y²` for non-negative `x, y`, obtained by
+taking square roots.  They turn the algebraic squared inequalities below into the genuine
+distance inequalities. -/
+
+/-- For non-negative reals, `c ≤ d` follows from `c² ≤ d²`. -/
+theorem le_of_sq_le_sq {c d : ℝ} (hc : 0 ≤ c) (hd : 0 ≤ d) (h : c ^ 2 ≤ d ^ 2) : c ≤ d := by
+  have := Real.sqrt_le_sqrt h
+  rwa [Real.sqrt_sq hc, Real.sqrt_sq hd] at this
+
+/-- For non-negative reals, `c < d` follows from `c² < d²`. -/
+theorem lt_of_sq_lt_sq {c d : ℝ} (hc : 0 ≤ c) (hd : 0 ≤ d) (h : c ^ 2 < d ^ 2) : c < d := by
+  have := Real.sqrt_lt_sqrt (sq_nonneg c) h
+  rwa [Real.sqrt_sq hc, Real.sqrt_sq hd] at this
+
+/-! ### Scalar form: the triangle inequality from the cosine rule -/
+
+/-- **Triangle inequality from the law of cosines (scalar form).**
+If the side `c` opposite the angle `C` satisfies the law of cosines
+`c² = a² + b² - 2ab·cos C`, with `a, b, c ≥ 0` and the only trigonometric input
+`cos C ≥ -1`, then `c ≤ a + b`.
+
+The whole content is `(a + b)² - c² = 2ab·(1 + cos C) ≥ 0`. -/
+theorem triangle_ineq_of_law_cosines {a b c cosC : ℝ}
+    (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (hcos : -1 ≤ cosC)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c ≤ a + b := by
+  have hsq : c ^ 2 ≤ (a + b) ^ 2 := by
+    nlinarith [mul_nonneg (mul_nonneg ha hb) (by linarith : (0 : ℝ) ≤ 1 + cosC)]
+  exact le_of_sq_le_sq hc (by linarith) hsq
+
+/-- **Strict triangle inequality from the law of cosines.**
+For a non-degenerate angle (`cos C > -1`) and positive adjacent sides, the inequality is
+strict: `c < a + b`. -/
+theorem triangle_ineq_strict_of_law_cosines {a b c cosC : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 ≤ c) (hcos : -1 < cosC)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c < a + b := by
+  have hsq : c ^ 2 < (a + b) ^ 2 := by
+    nlinarith [mul_pos (mul_pos ha hb) (by linarith : (0 : ℝ) < 1 + cosC)]
+  exact lt_of_sq_lt_sq hc (by positivity) hsq
+
+/-- **Equality holds iff the triangle is degenerate.**
+For positive adjacent sides `a, b > 0`, the triangle inequality is an equality `c = a + b`
+exactly when `cos C = -1`, i.e. when the angle `C = π` and the configuration collapses to a
+straight segment. -/
+theorem degenerate_iff_eq {a b c cosC : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 ≤ c)
+    (hlc : c ^ 2 = a ^ 2 + b ^ 2 - 2 * a * b * cosC) :
+    c = a + b ↔ cosC = -1 := by
+  constructor
+  · intro h
+    have hcsq : c ^ 2 = (a + b) ^ 2 := by rw [h]
+    -- `2ab·(1 + cos C) = 0`, and `2ab ≠ 0`, so `cos C = -1`.
+    have key : 2 * a * b * (1 + cosC) = 0 := by linear_combination hlc - hcsq
+    have hab : 2 * a * b ≠ 0 := by positivity
+    rcases mul_eq_zero.mp key with h1 | h1
+    · exact absurd h1 hab
+    · linarith
+  · intro h
+    have hcsq : c ^ 2 = (a + b) ^ 2 := by rw [hlc, h]; ring
+    have h1 : c ≤ a + b := le_of_sq_le_sq hc (by positivity) hcsq.le
+    have h2 : a + b ≤ c := le_of_sq_le_sq (by positivity) hc hcsq.ge
+    linarith
+
+/-! ### Coordinate-free form in a real inner-product space
+
+Specialising the scalar lemmas to `a = ‖x‖`, `b = ‖y‖`, `c = ‖x - y‖`, and
+`cos C = cos (angle x y)`, fed by Mathlib's vector-angle law of cosines. -/
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- **The triangle inequality, derived from the law of cosines.**
+In any real inner-product space, `‖x - y‖ ≤ ‖x‖ + ‖y‖`.  The proof feeds the vector-angle
+form of the law of cosines into `triangle_ineq_of_law_cosines`; the only analytic input is
+`cos (angle x y) ≥ -1`.  (This re-proves Mathlib's `norm_sub_le` through the cosine rule.) -/
+theorem norm_sub_le_of_law_cosines (x y : V) : ‖x - y‖ ≤ ‖x‖ + ‖y‖ := by
+  have hlc : ‖x - y‖ ^ 2 = ‖x‖ ^ 2 + ‖y‖ ^ 2 - 2 * ‖x‖ * ‖y‖ * Real.cos (angle x y) := by
+    simpa only [sq] using
+      norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle x y
+  exact triangle_ineq_of_law_cosines (norm_nonneg x) (norm_nonneg y) (norm_nonneg _)
+    (Real.neg_one_le_cos _) hlc
+
+/-- **Equality in the triangle inequality is a degenerate (collinear) angle.**
+For non-zero vectors, `‖x - y‖ = ‖x‖ + ‖y‖` holds iff the angle between `x` and `y` equals
+`π` (equivalently `cos (angle x y) = -1`): `x` and `y` point in opposite directions. -/
+theorem norm_sub_eq_iff_cos_angle {x y : V} (hx : x ≠ 0) (hy : y ≠ 0) :
+    ‖x - y‖ = ‖x‖ + ‖y‖ ↔ Real.cos (angle x y) = -1 := by
+  have hlc : ‖x - y‖ ^ 2 = ‖x‖ ^ 2 + ‖y‖ ^ 2 - 2 * ‖x‖ * ‖y‖ * Real.cos (angle x y) := by
+    simpa only [sq] using
+      norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_angle x y
+  exact degenerate_iff_eq (norm_pos_iff.mpr hx) (norm_pos_iff.mpr hy) (norm_nonneg _) hlc
+
+/-! ### Concrete instance in the Euclidean plane
+
+Specialising the coordinate-free statement to the Euclidean plane `EuclideanSpace ℝ (Fin 2)`
+recovers the familiar planar triangle inequality (the setting `Vec2` of the parent entry),
+now obtained purely through the law of cosines. -/
+
+/-- The triangle inequality in the Euclidean plane, a direct instance of the
+law-of-cosines derivation. -/
+theorem triangle_inequality_euclidean (v w : EuclideanSpace ℝ (Fin 2)) :
+    ‖v - w‖ ≤ ‖v‖ + ‖w‖ :=
+  norm_sub_le_of_law_cosines v w
+
+end LawOfCosinesOQ08

--- a/research/problems/basel-problem-oq-01-oq-01-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-03/state.md
@@ -1,25 +1,25 @@
 # Research State: basel-problem-oq-01-oq-01-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETE
 **Path**: full
-**Since**: 2026-04-05T20:06:18-07:00
-**Iteration**: 1
+**Since**: 2026-06-24
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Shipped a verified, 0-axiom Lean formalization of the two reachable components of
+the Ball–Rivoal theorem (infinitely many odd zeta values are irrational).
 
-## Active Approach
-None yet.
-
-## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
-
-## Blockers
-None.
+## Result
+- File: proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean (181 lines, 5 theorems, 0 defs).
+- Builds clean on Mathlib v4.26.0 (lake env lean).
+- #print axioms: only propext / Classical.choice / Quot.sound — no sorryAx,
+  no Lean.ofReduceBool. Status: verified, 0 axioms.
+- Part I: rate-free integer linear-form irrationality criterion (Apéry/Rivoal engine,
+  a genuine Mathlib gap) + decay-rate packaging variant.
+- Part II: dimension reduction — unbounded dim_ℚ span ⟹ infinitely many irrational.
+- Gallery entry: src/data/proofs/basel-problem-oq-01-oq-01-oq-03/ (meta + annotations).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Done. Remaining (out of scope): formalize Rivoal's analytic dimension lower bound,
+which combined with this file's reduction would complete a full Ball–Rivoal proof.

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-quantitative-floor",
+    "proofId": "basel-problem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 48,
+      "endLine": 64
+    },
+    "type": "insight",
+    "title": "The Quantitative Floor: Nonzero Integers Are ≥ 1",
+    "content": "`abs_linearForm_ge_of_rat` is the one inequality that powers the whole criterion. For a rational $\\alpha = a/b$ with $b \\neq 0$, the linear form rewrites as $q\\alpha - p = (qa - pb)/b$ via `field_simp`. The numerator $qa - pb$ is an integer; if it is nonzero then `Int.one_le_abs` gives $|qa - pb| \\geq 1$, and dividing by $|b|$ yields $|q\\alpha - p| \\geq 1/|b|$. The proof uses `div_le_div_iff_of_pos_right` to reduce the goal to the integer bound after `abs_div` separates the absolute values.",
+    "mathContext": "If $\\alpha = a/b \\in \\mathbb{Q}$ ($b \\neq 0$) and $q\\alpha - p \\neq 0$ with $p, q \\in \\mathbb{Z}$, then $|q\\alpha - p| = |qa - pb|/|b| \\geq 1/|b|$. This positive floor is impossible for an irrational target only because it must hold *uniformly* in $n$ for a rational $\\alpha$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Int.one_le_abs",
+      "integer linear forms",
+      "div_le_div_iff_of_pos_right",
+      "abs_div"
+    ],
+    "prerequisites": [
+      "field_simp",
+      "absolute value of integers cast to ℝ"
+    ]
+  },
+  {
+    "id": "ann-linear-form-criterion",
+    "proofId": "basel-problem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 66,
+      "endLine": 94
+    },
+    "type": "concept",
+    "title": "The Linear-Form Irrationality Criterion (the Apéry/Rivoal Engine)",
+    "content": "`irrational_of_linearForm_tendsto_zero` is the abstract sufficiency theorem. Assuming $\\alpha$ rational ($\\alpha = r$) for contradiction, it writes $\\alpha = r.\\mathrm{num}/r.\\mathrm{den}$ via `Rat.cast_def` and sets $\\varepsilon = 1/|r.\\mathrm{den}|$. Convergence `htend` gives that eventually $|q_n\\alpha - p_n| < \\varepsilon$ (extracted from a metric ball neighborhood of $0$), while `abs_linearForm_ge_of_rat` gives $|q_n\\alpha - p_n| \\geq \\varepsilon$ for every nonzero form. Picking any index in the eventual set yields $\\varepsilon \\le |\\cdot| < \\varepsilon$, a contradiction. Notably this needs no convergence *rate*, unlike Mathlib's Hurwitz characterization.",
+    "mathContext": "If there are integer sequences $p_n, q_n$ with $q_n\\alpha - p_n \\neq 0$ for all $n$ and $q_n\\alpha - p_n \\to 0$, then $\\alpha \\notin \\mathbb{Q}$. This is the precise statement underlying Apéry (1978) for $\\zeta(3)$ and the Ball–Rivoal construction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Irrational",
+      "Tendsto",
+      "Rat.cast_def",
+      "Metric.ball_mem_nhds",
+      "Apéry's theorem"
+    ],
+    "prerequisites": [
+      "filters and Eventually",
+      "rational num/den decomposition",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "ann-decay-packaging",
+    "proofId": "basel-problem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 96,
+      "endLine": 110
+    },
+    "type": "concept",
+    "title": "Decay-Rate Packaging via a Two-Sided Squeeze",
+    "content": "`irrational_of_linearForm_le_tendsto_zero` adapts the criterion to the hypothesis actually produced in practice: an explicit upper bound $|q_n\\alpha - p_n| \\le C_n$ with $C_n \\to 0$. Since $|q_n\\alpha - p_n| \\le C_n$ unfolds (via `abs_le`) to $-C_n \\le q_n\\alpha - p_n \\le C_n$, and both $\\pm C_n \\to 0$, the sandwich lemma `tendsto_of_tendsto_of_tendsto_of_le_of_le` forces the forms to $0$, after which the main criterion applies. Apéry's geometric decay $|b_n\\zeta(3) - a_n| \\sim C(\\sqrt{2}-1)^{4n}$ is exactly such a $C_n$.",
+    "mathContext": "If $q_n\\alpha - p_n \\neq 0$ and $|q_n\\alpha - p_n| \\le C_n$ with $C_n \\to 0$, then $\\alpha$ is irrational. For $\\zeta(3)$, $C_n = C(\\sqrt2-1)^{4n} \\to 0$ geometrically while the $b_n$ grow like $((1+\\sqrt2)^4)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "abs_le",
+      "geometric decay",
+      "Apéry numbers"
+    ],
+    "prerequisites": [
+      "two-sided sandwich for limits",
+      "Tendsto.neg"
+    ]
+  },
+  {
+    "id": "ann-dimension-cap",
+    "proofId": "basel-problem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 116,
+      "endLine": 156
+    },
+    "type": "insight",
+    "title": "Dimension Cap from Finitely Many Irrationals",
+    "content": "`finrank_span_le_of_irrational_subset` is the linear-algebraic heart. Treating $\\mathbb{R}$ as a $\\mathbb{Q}$-vector space, it fixes $F = \\{1\\} \\cup x(T)$ and shows $\\mathrm{span}_{\\mathbb{Q}}(\\{1\\}\\cup x(s)) \\le \\mathrm{span}_{\\mathbb{Q}}(F)$ for any finite index set $s$: each generator is either $1 \\in F$, or $x_i$ with $i \\in T$ (so $x_i \\in F$), or a rational $x_i = c \\cdot 1$ (via `Rat.smul_one_eq_cast`, landing in the span by `Submodule.smul_mem`). Then `Submodule.finrank_mono` and `finrank_span_finset_le_card` cap the dimension by $|F| \\le |T| + 1$. Finiteness of the span comes from `Module.Finite.iff_fg` and `Submodule.fg_span`.",
+    "mathContext": "If $x_i$ is rational for every $i \\notin T$ (a finite set), then for all finite $s$, $\\dim_{\\mathbb{Q}} \\mathrm{span}_{\\mathbb{Q}}(\\{1\\} \\cup \\{x_i : i \\in s\\}) \\le |T| + 1$. The bound is uniform in $s$ — that uniformity is what contradicts unbounded dimension.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Submodule.span",
+      "Module.finrank",
+      "Submodule.finrank_mono",
+      "finrank_span_finset_le_card",
+      "ℝ as a ℚ-vector space"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "spans and submodule containment",
+      "Rat.smul_one_eq_cast"
+    ]
+  },
+  {
+    "id": "ann-ballrivoal-reduction",
+    "proofId": "basel-problem-oq-01-oq-01-oq-03",
+    "range": {
+      "startLine": 158,
+      "endLine": 180
+    },
+    "type": "insight",
+    "title": "Ball–Rivoal Reduction: Unbounded Dimension ⟹ Infinitely Many Irrationals",
+    "content": "`infinite_irrational_of_unbounded_finrank` is the headline. By contradiction, if $\\{i : x_i \\text{ irrational}\\}$ were finite, take it as a `Finset` $T$ (via `Set.Finite.toFinset`); then every $x_i$ with $i \\notin T$ is rational, so the dimension cap from the previous theorem bounds every span's dimension by $|T| + 1$. But the unbounded-dimension hypothesis supplies a span of dimension $> |T| + 1$ — `omega` closes the contradiction. This is precisely how Rivoal's analytic dimension lower bound yields 'infinitely many odd zeta values irrational'.",
+    "mathContext": "If $\\sup_s \\dim_{\\mathbb{Q}} \\mathrm{span}_{\\mathbb{Q}}(\\{1\\} \\cup \\{x_i : i \\in s\\}) = \\infty$, then $\\{i : x_i \\notin \\mathbb{Q}\\}$ is infinite. With $x_k = \\zeta(2k+1)$ and Rivoal's bound $\\dim \\ge (1+o(1))\\log n/(1+\\log 2) \\to \\infty$, this gives the Ball–Rivoal conclusion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ball–Rivoal theorem",
+      "Set.Infinite",
+      "Set.Finite.toFinset",
+      "contrapositive",
+      "Rivoal dimension bound"
+    ],
+    "prerequisites": [
+      "finite vs infinite sets",
+      "the dimension cap lemma",
+      "omega"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "basel-problem-oq-01-oq-01-oq-03",
+  "title": "Ball–Rivoal: The Linear-Form Engine and the Dimension Reduction",
+  "slug": "basel-problem-oq-01-oq-01-oq-03",
+  "description": "Formalizes the two pieces of the Ball–Rivoal theorem (infinitely many odd zeta values are irrational) that are actually within reach: the rate-free integer linear-form irrationality criterion (the engine behind Apéry's ζ(3) proof) and the linear-algebraic dimension reduction (unbounded ℚ-dimension ⟹ infinitely many irrationals). Both fully machine-verified, 0 axioms.",
+  "meta": {
+    "author": "formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "open-problem",
+      "linear-algebra",
+      "irrationality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no sorryAx, no Lean.ofReduceBool. All 5 theorems are fully proved. The headline reduction theorem is stated with a hypothesis (Rivoal's unbounded-dimension input) that captures the analytic content not proved here; the implication itself is unconditional.",
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 181,
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Apéry stunned the mathematical world in 1978 by proving $\\zeta(3)$ irrational, via an explicit sequence of rational approximations. The mechanism — a sequence of integer linear forms $b_n\\alpha - a_n$ that are nonzero but converge to $0$ faster than the denominators grow — is the template for every subsequent irrationality result for zeta values. In 2000 Tanguy Rivoal proved the spectacular Ball–Rivoal theorem: infinitely many of the odd zeta values $\\zeta(3), \\zeta(5), \\zeta(7), \\ldots$ are irrational, even though not a single one beyond $\\zeta(3)$ is individually known to be irrational. Rivoal's proof produces a lower bound on the $\\mathbb{Q}$-dimension of $\\mathrm{span}\\{1, \\zeta(3), \\zeta(5), \\ldots, \\zeta(2n+1)\\}$ that grows like $\\log n$, and then a soft linear-algebra argument converts that growth into 'infinitely many irrationals'. The parent entry on $\\zeta(5)$ explicitly flagged formalizing Ball–Rivoal as an open question requiring 'Lean machinery for linear independence over $\\mathbb{Q}$ and asymptotic estimates'. This file isolates and verifies the two formalizable load-bearing components.",
+    "problemStatement": "Which parts of the Ball–Rivoal theorem can be formalized in Lean 4? The full theorem needs a deep analytic dimension estimate, but its logical skeleton has two reusable, fully-provable parts: (1) a sufficiency criterion turning a sequence of small nonzero integer linear forms into a proof of irrationality, and (2) a linear-algebraic reduction turning an unbounded-dimension hypothesis into the conclusion that infinitely many values are irrational.",
+    "proofStrategy": "Part I establishes the linear-form irrationality criterion. The quantitative core observes that if $\\alpha = a/b$ is rational then $q\\alpha - p = (qa - pb)/b$, whose numerator is an integer; if that numerator is nonzero it has absolute value at least $1$, so $|q\\alpha - p| \\geq 1/|b|$ — a fixed positive floor. Hence if the linear forms $q_n\\alpha - p_n$ are all nonzero yet $q_n\\alpha - p_n \\to 0$, they would have to cross below that floor: contradiction, so $\\alpha$ is irrational. A decay-rate packaging variant accepts the practical hypothesis $|q_n\\alpha - p_n| \\le C_n \\to 0$ via a two-sided squeeze. Part II establishes the dimension reduction. Working in $\\mathbb{R}$ as a $\\mathbb{Q}$-vector space, if only finitely many $x_i$ (those with index in a finite set $T$) are irrational, then every $x_i$ is either irrational (and indexed by $T$) or a $\\mathbb{Q}$-multiple of $1$; so $\\mathrm{span}_{\\mathbb{Q}}(\\{1\\}\\cup\\{x_i\\})$ over any finite index set is contained in the fixed subspace spanned by $\\{1\\}\\cup\\{x_i : i \\in T\\}$, capping its dimension at $|T| + 1$. Contrapositive: unbounded dimension forces infinitely many irrationals.",
+    "keyInsights": [
+      "The whole irrationality engine rests on one elementary fact: a nonzero integer has absolute value at least $1$. For rational $\\alpha = a/b$, the linear form $q\\alpha - p = (qa - pb)/b$ therefore cannot be nonzero and smaller than $1/|b|$ — a uniform floor that any convergent-to-zero sequence of nonzero forms must eventually violate.",
+      "Crucially the criterion is *rate-free*: it needs only $q_n\\alpha - p_n \\to 0$ with the forms nonzero, not the Hurwitz-type rate $1/q^2$ that Mathlib's existing `infinite_rat_abs_sub_lt_one_div_den_sq_iff_irrational` requires. This is exactly the form that Apéry- and Rivoal-style constructions produce, where $q_n$ may grow rapidly.",
+      "Ball–Rivoal's leap from 'dimension grows' to 'infinitely many irrational' is pure linear algebra, fully formalizable independent of the analysis: if all but finitely many $x_i$ were rational, the spans would live inside one finite-dimensional $\\mathbb{Q}$-subspace, so the dimension could not be unbounded.",
+      "The reduction is stated as an unconditional implication whose hypothesis is precisely Rivoal's analytic output ($\\dim_{\\mathbb{Q}} \\to \\infty$). This cleanly separates the verified soft part from the unformalized hard estimate, making explicit what a full formalization would still need to supply.",
+      "Apéry's concrete numbers fit the decay-rate variant exactly: $|b_n\\zeta(3) - a_n| \\sim C(\\sqrt 2 - 1)^{4n}$ tends to $0$ geometrically, which (with non-vanishing) the squeeze form converts into irrationality of $\\zeta(3)$."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Imports and Overview",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Imports the irrationality predicate, finite-rank/span machinery, and metric-space limits. The header explains the two formalizable Ball–Rivoal ingredients and records 0 axioms / 0 sorries."
+    },
+    {
+      "id": "linear-form-engine",
+      "title": "Part I: The Linear-Form Irrationality Criterion",
+      "startLine": 44,
+      "endLine": 110,
+      "summary": "abs_linearForm_ge_of_rat gives the quantitative floor 1/|b| for nonzero integer linear forms at a rational; irrational_of_linearForm_tendsto_zero turns nonzero forms tending to 0 into irrationality; irrational_of_linearForm_le_tendsto_zero packages the practical decay-bound hypothesis via a two-sided squeeze."
+    },
+    {
+      "id": "dimension-reduction",
+      "title": "Part II: The Ball–Rivoal Dimension Reduction",
+      "startLine": 112,
+      "endLine": 181,
+      "summary": "finrank_span_le_of_irrational_subset caps the ℚ-dimension of any finite span by |T|+1 when only the indices in T are irrational; infinite_irrational_of_unbounded_finrank is the headline contrapositive: unbounded dimension implies infinitely many irrational values."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Ball–Rivoal theorem cannot be formalized end-to-end today, but its logical skeleton can. This file machine-verifies, with no axioms, the rate-free integer linear-form irrationality criterion (the Apéry/Rivoal engine, a genuine gap in Mathlib) and the linear-algebraic reduction from unbounded ℚ-dimension to infinitely many irrational values. Together they reduce a full formalization to its single hard analytic input: Rivoal's dimension lower bound.",
+    "implications": "The linear-form criterion is independently reusable: any future Lean formalization of Apéry's ζ(3) proof, or of Beukers' integral approach, can invoke irrational_of_linearForm_le_tendsto_zero as its final step once the approximation sequence and its decay are constructed. The dimension reduction makes precise what 'infinitely many odd zeta values are irrational' formally requires — only that the dimension hypothesis be supplied — and isolates the soft part from the analysis. This is the standard pattern for formalizing the reachable core of a deep open-adjacent theorem.",
+    "openQuestions": [
+      "Can Rivoal's dimension lower bound $\\dim_{\\mathbb{Q}}\\mathrm{span}\\{1,\\zeta(3),\\ldots,\\zeta(2n+1)\\} \\geq (1+o(1))\\log n/(1+\\log 2)$ be formalized? This is the remaining analytic obstruction; it needs the hypergeometric/Padé construction of the linear forms and careful denominator (lcm) estimates.",
+      "Can Apéry's ζ(3) proof be completed in Lean by combining this file's criterion with a formal construction of the Apéry approximation sequences and their geometric decay?",
+      "Is $\\zeta(5)$ irrational? Still open; no Apéry-style sequence is known for it, so the criterion here has no known input to apply to $\\zeta(5)$ specifically."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's open question on whether Ball–Rivoal can be formalized, by verifying its two formalizable components."
+    },
+    {
+      "targetId": "basel-problem-oq-01",
+      "relationship": "related"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Real.Irrational",
+      "Mathlib.LinearAlgebra.Dimension.Constructions",
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "BaselProblemOQ01OQ01OQ03",
+    "lineCount": 181,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [],
+  "sorries": 0
+}

--- a/src/data/proofs/law-of-cosines-oq-08/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-08/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-loc-oq08-sqrt-bridge",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 50,
+      "endLine": 57
+    },
+    "type": "theorem",
+    "title": "Squaring is Monotone on the Non-Negative Reals",
+    "content": "Two small bridges, `le_of_sq_le_sq` and `lt_of_sq_lt_sq`, turning `c² ≤ d²` (resp. `c² < d²`) into `c ≤ d` (resp. `c < d`) for non-negative `c, d`. Each is one application of `Real.sqrt` monotonicity (`Real.sqrt_le_sqrt` / `Real.sqrt_lt_sqrt`) followed by `Real.sqrt_sq` to undo the square. These are the only step that converts the squared inequalities below into genuine distance inequalities.",
+    "mathContext": "For 0 ≤ c, d: c = √(c²) ≤ √(d²) = d whenever c² ≤ d², since √ is monotone and √(x²) = x on the non-negatives.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sqrt",
+      "monotonicity",
+      "order on ℝ"
+    ],
+    "prerequisites": [
+      "Properties of the real square root"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-scalar-triangle",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 67,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "Triangle Inequality from the Law of Cosines (scalar form)",
+    "content": "The mathematical heart of the entry. Given the law of cosines `c² = a² + b² − 2ab·cos C` with `a, b, c ≥ 0` and the single trigonometric input `cos C ≥ −1`, the third side satisfies `c ≤ a + b`. The proof computes `(a + b)² − c² = 2ab·(1 + cos C) ≥ 0` (one `nlinarith` with the product hint `ab·(1 + cos C) ≥ 0`), giving `c² ≤ (a + b)²`, and then `le_of_sq_le_sq` extracts `c ≤ a + b`.",
+    "mathContext": "(a + b)² − c² = (a² + 2ab + b²) − (a² + b² − 2ab·cos C) = 2ab + 2ab·cos C = 2ab(1 + cos C) ≥ 0, using ab ≥ 0 and 1 + cos C ≥ 0.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "law of cosines",
+      "triangle inequality",
+      "cosine bound",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Law of cosines",
+      "cos ≥ −1"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-degenerate",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 90,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Equality Holds iff the Triangle is Degenerate",
+    "content": "For positive adjacent sides `a, b > 0`, the triangle inequality is an equality `c = a + b` exactly when `cos C = −1`, i.e. the angle `C = π` and the three vertices are collinear. Forward: `c = a + b` gives `c² = (a + b)²`, and `linear_combination hlc - hcsq` produces `2ab·(1 + cos C) = 0`; since `2ab ≠ 0` (positivity), `mul_eq_zero` forces `cos C = −1`. Reverse: substituting `cos C = −1` makes `c² = (a + b)²`, and `le_of_sq_le_sq` both ways gives `c = a + b`.",
+    "mathContext": "c = a + b ⇔ c² = (a+b)² ⇔ 2ab(1 + cos C) = 0 ⇔ cos C = −1 (since ab > 0) ⇔ C = π.",
+    "significance": "key",
+    "relatedConcepts": [
+      "degenerate triangle",
+      "equality condition",
+      "mul_eq_zero",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Law of cosines",
+      "cos C = −1 ⇔ C = π"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-coordinate-free",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 120,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Coordinate-Free Triangle Inequality in an Inner-Product Space",
+    "content": "In any real inner-product space, `‖x − y‖ ≤ ‖x‖ + ‖y‖`. The proof rewrites Mathlib's vector-angle law of cosines `norm_sub_sq_eq_…_cos_angle` into the `^2` form and feeds it, with `Real.neg_one_le_cos (angle x y)`, into the scalar lemma `triangle_ineq_of_law_cosines` (taking `a = ‖x‖`, `b = ‖y‖`, `c = ‖x − y‖`). The companion `norm_sub_eq_iff_cos_angle` shows equality holds for non-zero `x, y` iff the angle between them is `π`. This re-derives Mathlib's `norm_sub_le` through the law of cosines rather than Cauchy–Schwarz.",
+    "mathContext": "‖x − y‖² = ‖x‖² + ‖y‖² − 2‖x‖‖y‖·cos(angle x y), and cos(angle x y) ≥ −1, so the scalar argument applies verbatim with the side lengths replaced by norms.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "inner-product space",
+      "angle between vectors",
+      "norm_sub_le",
+      "InnerProductGeometry"
+    ],
+    "prerequisites": [
+      "Vector-angle law of cosines",
+      "Norm and angle in inner-product spaces"
+    ]
+  },
+  {
+    "id": "ann-loc-oq08-euclidean",
+    "proofId": "law-of-cosines-oq-08",
+    "range": {
+      "startLine": 145,
+      "endLine": 147
+    },
+    "type": "theorem",
+    "title": "Euclidean Plane Instance",
+    "content": "The familiar planar triangle inequality `‖v − w‖ ≤ ‖v‖ + ‖w‖` in `EuclideanSpace ℝ (Fin 2)`, obtained as a direct instance of the coordinate-free `norm_sub_le_of_law_cosines`. This is the setting `Vec2` of the parent law-of-cosines entry, now reached purely through the cosine rule.",
+    "mathContext": "EuclideanSpace ℝ (Fin 2) is a real inner-product space, so the general theorem specialises with no extra work.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclidean plane",
+      "EuclideanSpace",
+      "specialisation"
+    ],
+    "prerequisites": [
+      "EuclideanSpace as an inner-product space"
+    ]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-08/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-08/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "law-of-cosines-oq-08",
+  "title": "The Triangle Inequality as a Corollary of the Law of Cosines",
+  "slug": "law-of-cosines-oq-08",
+  "description": "Derives the triangle inequality c ≤ a + b from the law of cosines c² = a² + b² − 2ab·cos C using only cos C ≥ −1, with equality iff C = π (degenerate triangle). The coordinate-free vector form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space is obtained from Mathlib's vector-angle cosine rule, exhibiting the triangle inequality as a metric shadow of the law of cosines.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ08.lean",
+    "tags": [
+      "geometry",
+      "law-of-cosines",
+      "triangle-inequality",
+      "inner-product-space",
+      "metric",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 149,
+    "assumptions": "No axioms or sorries. All theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions).",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Scalar derivation of the triangle inequality c ≤ a + b directly from the law of cosines, with the single analytic input cos C ≥ −1 (the whole content is the algebraic identity (a+b)² − c² = 2ab·(1 + cos C) ≥ 0)",
+      "Sharp equality characterisation: for positive adjacent sides, c = a + b holds iff cos C = −1 (degenerate / collinear triangle), and the strict inequality c < a + b for cos C > −1",
+      "Coordinate-free form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in an arbitrary real inner-product space, derived from Mathlib's vector-angle law of cosines together with cos ≥ −1, re-proving Mathlib's norm_sub_le through the cosine rule",
+      "Vector equality condition: ‖x − y‖ = ‖x‖ + ‖y‖ iff the angle between non-zero x and y is π (opposite directions)"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The law of cosines (al-Kashi's theorem, Wiedijk's 100 Theorems #94) generalises the Pythagorean theorem to arbitrary triangles: c² = a² + b² − 2ab·cos C. The triangle inequality — that any side is at most the sum of the other two — is usually taken as an axiom of a metric space or proved for norms via the Cauchy–Schwarz inequality. This entry instead derives it as a transparent corollary of the law of cosines: since a cosine is bounded below by −1, the squared third side can never exceed (a + b)², and equality pins the angle to π, the degenerate collinear configuration.",
+    "problemStatement": "Derive the triangle inequality c ≤ a + b from the law of cosines c² = a² + b² − 2ab·cos C together with cos C ≥ −1, characterising equality as the degenerate case C = π. Give the coordinate-free form ‖x − y‖ ≤ ‖x‖ + ‖y‖ in a real inner-product space.",
+    "text": "Reduces the triangle inequality, in both scalar and coordinate-free vector form, to the single fact cos C ≥ −1 applied to the law of cosines.",
+    "proofStrategy": "1. le_of_sq_le_sq / lt_of_sq_lt_sq: bridges x ≤ y ⇐ x² ≤ y² for non-negative reals, via Real.sqrt monotonicity. 2. triangle_ineq_of_law_cosines: from c² = a² + b² − 2ab·cos C and cos C ≥ −1, conclude (a+b)² − c² = 2ab·(1 + cos C) ≥ 0 by nlinarith, then take square roots. 3. triangle_ineq_strict_of_law_cosines: the strict version for cos C > −1 and positive sides. 4. degenerate_iff_eq: c = a + b ⇔ cos C = −1, extracted by linear_combination and mul_eq_zero. 5. norm_sub_le_of_law_cosines: specialise the scalar lemma to a = ‖x‖, b = ‖y‖, c = ‖x − y‖, cos C = cos (angle x y), feeding Mathlib's InnerProductGeometry vector-angle law of cosines and Real.neg_one_le_cos. 6. norm_sub_eq_iff_cos_angle: the vector equality condition via degenerate_iff_eq. 7. triangle_inequality_euclidean: the planar instance in EuclideanSpace ℝ (Fin 2).",
+    "keyInsights": [
+      "The entire inequality is the single algebraic identity (a + b)² − c² = 2ab·(1 + cos C): non-negative because ab ≥ 0 and 1 + cos C ≥ 0. No Cauchy–Schwarz, no metric axioms — just the law of cosines and the elementary bound on cosine.",
+      "Equality c = a + b forces 2ab·(1 + cos C) = 0; with a, b > 0 this is exactly cos C = −1, i.e. C = π. The triangle inequality is therefore strict precisely away from the degenerate collinear configuration, recovering the geometric meaning of equality.",
+      "In a real inner-product space the same scalar lemma, fed Mathlib's vector-angle cosine rule and cos ≥ −1, yields ‖x − y‖ ≤ ‖x‖ + ‖y‖. This re-derives Mathlib's norm_sub_le from the law of cosines, presenting the triangle inequality as a metric shadow of the cosine rule rather than of Cauchy–Schwarz.",
+      "The development is axiom-clean (only propext / Classical.choice / Quot.sound) and self-contained: it obtains the cosine-rule identity directly from Mathlib's InnerProductGeometry, independent of the parent file's build state."
+    ],
+    "prerequisites": [
+      "The law of cosines in scalar and vector-angle form",
+      "Real inner-product spaces, norms, and the angle between vectors (InnerProductGeometry.angle)",
+      "Monotonicity of squaring on the non-negative reals (Real.sqrt)",
+      "Lean 4 tactics: nlinarith, linear_combination, positivity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-sqrt-bridges",
+      "title": "Part I: Monotonicity of Squaring",
+      "startLine": 43,
+      "endLine": 57,
+      "summary": "Bridges le_of_sq_le_sq and lt_of_sq_lt_sq between an inequality and its square for non-negative reals, via square roots — the step that turns squared inequalities into genuine distance inequalities."
+    },
+    {
+      "id": "part2-scalar",
+      "title": "Part II: Triangle Inequality from the Cosine Rule (scalar)",
+      "startLine": 59,
+      "endLine": 84,
+      "summary": "triangle_ineq_of_law_cosines (c ≤ a + b) and its strict form, with the only analytic input cos C ≥ −1; the content is (a + b)² − c² = 2ab·(1 + cos C) ≥ 0."
+    },
+    {
+      "id": "part3-degeneracy",
+      "title": "Part III: Equality iff Degenerate",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "degenerate_iff_eq: for positive adjacent sides, equality c = a + b holds exactly when cos C = −1, i.e. the angle C = π and the triangle collapses to a segment."
+    },
+    {
+      "id": "part4-coordinate-free",
+      "title": "Part IV: Coordinate-Free Form",
+      "startLine": 109,
+      "endLine": 135,
+      "summary": "norm_sub_le_of_law_cosines: ‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space from Mathlib's vector-angle law of cosines, with the equality condition norm_sub_eq_iff_cos_angle (angle = π)."
+    },
+    {
+      "id": "part5-euclidean",
+      "title": "Part V: Euclidean Plane Instance",
+      "startLine": 137,
+      "endLine": 147,
+      "summary": "triangle_inequality_euclidean: the planar triangle inequality in EuclideanSpace ℝ (Fin 2) as a direct instance of the law-of-cosines derivation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The triangle inequality is derived from the law of cosines using only cos C ≥ −1, in both scalar form (c ≤ a + b, equality iff C = π) and coordinate-free vector form (‖x − y‖ ≤ ‖x‖ + ‖y‖ in any real inner-product space). Verified, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "The reverse triangle inequality |‖x‖ − ‖y‖| ≤ ‖x − y‖ also follows from the law of cosines via cos C ≤ 1; can it be packaged alongside, completing the two-sided bound?",
+      "Can the polygon (n-gon) inequality — the length of one side is at most the sum of the others — be obtained by iterating this law-of-cosines triangle inequality?"
+    ],
+    "implications": "Presents the triangle inequality not as a metric axiom or a consequence of Cauchy–Schwarz, but as an immediate corollary of the law of cosines and the elementary bound cos C ≥ −1, with the degenerate (collinear) case recovered exactly as the equality condition."
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "parent-problem",
+      "description": "The parent entry (Wiedijk #94) proves the law of cosines c² = a² + b² − 2ab·cos C in scalar and inner-product form; this entry answers its open question of deriving the triangle inequality directly from it."
+    },
+    {
+      "targetId": "law-of-cosines-oq-07",
+      "relationship": "related",
+      "description": "A sibling corollary of the law of cosines (Apollonius's theorem and the parallelogram law); both extract classical metric facts from the cosine rule in coordinate-free form."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The law of cosines specialises to the Pythagorean theorem at C = π/2; the triangle inequality derived here holds for all angles, with the degenerate equality at C = π."
+    }
+  ],
+  "references": [
+    {
+      "author": "al-Kashi, Jamshid",
+      "title": "The Key to Arithmetic (Miftah al-Hisab)",
+      "year": 1427,
+      "note": "Classical trigonometric formulation of the law of cosines"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LawOfCosinesOQ08",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LawOfCosinesOQ08.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Ball–Rivoal: the formalizable skeleton

Answers the open question raised by the parent entry **basel-problem-oq-01-oq-01** ("Is ζ(5) Irrational? — Computational Bounds"): *can the Ball–Rivoal theorem (infinitely many odd zeta values are irrational) be formalized?* The full theorem needs a deep analytic dimension estimate, but its logical skeleton has two reusable, fully-provable components — both machine-verified here with **0 axioms**.

### Part I — The linear-form irrationality criterion (the Apéry/Rivoal engine)
- `abs_linearForm_ge_of_rat`: for rational `α = a/b`, every nonzero integer linear form satisfies `|q·α − p| ≥ 1/|b|` (a nonzero integer numerator has absolute value ≥ 1).
- `irrational_of_linearForm_tendsto_zero`: if integer sequences `p, q` give nonzero forms `q_n·α − p_n` that tend to `0`, then `α` is irrational. **Rate-free** — unlike Mathlib's existing Hurwitz characterization (`infinite_rat_abs_sub_lt_one_div_den_sq_iff_irrational`), which requires the `1/q²` rate. This rate-free form is exactly what Apéry/Rivoal constructions produce, and it is a genuine gap in Mathlib.
- `irrational_of_linearForm_le_tendsto_zero`: decay-rate packaging — accepts `|q_n·α − p_n| ≤ C_n → 0` via a two-sided squeeze (matches Apéry's geometric decay `~ C·(√2−1)^{4n}` for ζ(3)).

### Part II — The dimension reduction
- `finrank_span_le_of_irrational_subset`: if only the indices in a finite set `T` are irrational, every finite span `span_ℚ({1} ∪ {x_i})` has `ℚ`-dimension ≤ `|T| + 1`.
- `infinite_irrational_of_unbounded_finrank`: the headline contrapositive — **unbounded `dim_ℚ span{1, x₀, …}` ⟹ infinitely many `x_i` irrational**. Stated as an unconditional implication whose hypothesis is precisely Rivoal's analytic dimension lower bound `(1+o(1))·log n/(1+log 2) → ∞`, cleanly separating the verified soft part from the unformalized hard estimate.

### Verification
- `proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean` — 5 theorems, 0 definitions, 181 lines.
- Builds clean on **Mathlib v4.26.0** (`lake env lean`).
- `#print axioms` on all theorems reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status: **verified**, 0 axioms.
- Gallery entry added: `src/data/proofs/basel-problem-oq-01-oq-01-oq-03/` (meta + 5 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)