### PR TITLE
Enrich gallery entries: add annotations.json (Brahmagupta–Fibonacci, Lyapunov)

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-06/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-06/annotations.json
@@ -1,0 +1,191 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "context",
+    "title": "Brahmagupta–Fibonacci Identity and Non-Uniqueness",
+    "content": "The Brahmagupta–Fibonacci identity writes a product of two sums of squares as a sum of squares in *two* ways, by flipping the sign of one cross term. Mathlib records only one form (`sq_add_sq_mul`) and says nothing about whether the two forms differ. This entry's mathematical content is the **non-uniqueness** phenomenon: when $x \\neq y$ and $u \\neq v$ (all positive) the two forms are genuinely distinct even as unordered pairs of squares. This is the structural reason a product of two distinct primes $\\equiv 1 \\pmod 4$ has at least two representations as a sum of two squares — the smallest being $65 = 5\\cdot 13 = 1^2 + 8^2 = 4^2 + 7^2$. Form 1 is also re-derived from multiplicativity of the Gaussian-integer norm $N(a+bi) = a^2 + b^2$.",
+    "mathContext": "$(x^2+y^2)(u^2+v^2) = (xu-yv)^2 + (xv+yu)^2 = (xu+yv)^2 + (xv-yu)^2$. Example: $65 = 1^2+8^2 = 4^2+7^2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci identity",
+      "Gaussian integers ℤ[i]",
+      "sum of two squares",
+      "Fermat's two-square theorem"
+    ],
+    "prerequisites": [
+      "sums of two squares",
+      "primes ≡ 1 (mod 4)",
+      "ring identities"
+    ]
+  },
+  {
+    "id": "ann-two-forms",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 49,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "The Two Sign-Forms of the Identity",
+    "content": "`brahmagupta_form1` and `brahmagupta_form2` state the two decompositions of $(x^2+y^2)(u^2+v^2)$, differing only in the signs of the cross terms $\\pm yv$ and $\\pm yu$. Both are pure polynomial identities, closed by a single `ring`. The two forms correspond to multiplying the Gaussian integers $\\overline{(x+yi)}(u+vi)$ vs $(x+yi)(u+vi)$ — i.e. conjugating one factor — which is exactly why both products have the same norm yet different real/imaginary coordinates.",
+    "mathContext": "Form 1: $(xu-yv)^2 + (xv+yu)^2$. Form 2: $(xu+yv)^2 + (xv-yu)^2$. Same product, conjugate factors in $\\mathbb{Z}[i]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial identity",
+      "complex conjugation",
+      "ring tactic",
+      "cross terms"
+    ],
+    "prerequisites": [
+      "algebraic expansion",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-gaussian-norm",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 66,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "Conceptual Derivation via the Gaussian Norm",
+    "content": "`gaussianInt_norm_mk` computes the norm of $a + bi$ in $\\mathbb{Z}[i] = \\mathbb{Z}\\sqrt{-1}$ as $a^2 + b^2$, and `brahmagupta_via_norm` re-derives form 1 from `Zsqrtd.norm_mul` — the fact that the norm is *multiplicative*, $N(zw) = N(z)N(w)$. Computing $N(\\langle x,y\\rangle \\cdot \\langle u,v\\rangle)$ two ways (product of norms vs norm of the explicit product $\\langle xu-yv,\\, xv+yu\\rangle$) yields the identity. This reveals Brahmagupta's identity as nothing more than the statement that $N : \\mathbb{Z}[i] \\to \\mathbb{Z}$ is a monoid homomorphism — the deep reason the two-square property is closed under multiplication.",
+    "mathContext": "$N(a+bi) = a^2+b^2$ and $N(zw) = N(z)N(w)$. With $z = x+yi$, $w = u+vi$: $zw = (xu-yv) + (xv+yu)i$, so $N(z)N(w) = (xu-yv)^2 + (xv+yu)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Zsqrtd.norm_mul",
+      "multiplicative norm",
+      "monoid homomorphism",
+      "norm of a product"
+    ],
+    "prerequisites": [
+      "Gaussian integers Zsqrtd",
+      "multiplicativity of the norm",
+      "Zsqrtd.ext"
+    ]
+  },
+  {
+    "id": "ann-second-form-closure",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 91,
+      "endLine": 97
+    },
+    "type": "technique",
+    "title": "The Second-Form Closure Lemma",
+    "content": "`sq_add_sq_mul'` records that the set of sums of two squares is closed under multiplication, using the *second* Brahmagupta form — complementing Mathlib's `sq_add_sq_mul`, which only provides the first form. Stated over any `CommRing R` as an existence statement $\\exists r, s,\\ ab = r^2 + s^2$, it supplies the witness $(xu+yv,\\ xv-yu)$. Having both forms available as existence lemmas is what lets the application produce two genuinely different representations rather than just one.",
+    "mathContext": "If $a = x^2+y^2$, $b = u^2+v^2$ then $ab = (xu+yv)^2 + (xv-yu)^2$ (second form).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sq_add_sq_mul",
+      "multiplicative closure",
+      "existence statement",
+      "CommRing"
+    ],
+    "prerequisites": [
+      "brahmagupta_form2",
+      "sums of squares in a commutative ring"
+    ]
+  },
+  {
+    "id": "ann-non-uniqueness",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 106,
+      "endLine": 145
+    },
+    "type": "insight",
+    "title": "Headline: The Two Forms Are Essentially Distinct",
+    "content": "`two_distinct_representations` is the core result: for positive $x,y,u,v$ with $x \\neq y$ and $u \\neq v$, the two Brahmagupta forms differ even as unordered pairs of squares. The proof rules out both ways the multisets could match. (i) A 'difference' coordinate equalling a 'sum' coordinate forces $4(xu)(yv) = 0$ via the identity $(xu+yv)^2 - (xu-yv)^2 = 4(xu)(yv)$ — impossible since all are positive (`nlinarith`). (ii) The two 'sum' coordinates matching forces $(x-y)(v-u)(x+y)(u+v) = 0$ via a clean factorisation; since $(x+y)(u+v) > 0$, one of $x = y$ or $u = v$ must hold, contradicting the hypotheses. The whole argument is driven by two `ring`-verified algebraic identities plus positivity.",
+    "mathContext": "$(xu+yv)^2-(xu-yv)^2 = 4(xu)(yv) > 0$; $(xv+yu)^2-(xu+yv)^2 = (x-y)(v-u)(x+y)(u+v)$, with $(x+y)(u+v)>0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "unordered pair of squares",
+      "factorisation identity",
+      "nlinarith",
+      "mul_eq_zero"
+    ],
+    "prerequisites": [
+      "positivity reasoning",
+      "ring-verified identities",
+      "no zero divisors"
+    ]
+  },
+  {
+    "id": "ann-prime-rep",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 149,
+      "endLine": 180
+    },
+    "type": "technique",
+    "title": "Prime Representation with Positive, Distinct Coordinates",
+    "content": "`prime_rep_pos_ne` refines Fermat's two-square theorem (`Nat.Prime.sq_add_sq`) to give, for an odd prime $p$ with $p \\not\\equiv 3 \\pmod 4$, a representation $p = x^2 + y^2$ with $x, y > 0$ and $x \\neq y$ — exactly the hypotheses `two_distinct_representations` needs. A zero coordinate is ruled out because it would make $p$ a perfect square (impossible for a prime), and $x = y$ is ruled out because it would make $p = 2x^2$ even, contradicting oddness. This bridges the existence theorem to the non-uniqueness machinery.",
+    "mathContext": "$p \\equiv 1 \\pmod 4$ odd prime $\\Rightarrow p = x^2+y^2$ with $x,y>0$, $x\\neq y$. (A square coordinate $\\Rightarrow p$ square; $x=y \\Rightarrow p = 2x^2$ even.)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.Prime.sq_add_sq",
+      "Fermat's two-square theorem",
+      "primality",
+      "parity"
+    ],
+    "prerequisites": [
+      "Fermat's two-square theorem",
+      "prime divisor reasoning",
+      "casts ℕ → ℤ"
+    ]
+  },
+  {
+    "id": "ann-product-two-ways",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 182,
+      "endLine": 195
+    },
+    "type": "insight",
+    "title": "Products of Two Distinct Primes Have Two Representations",
+    "content": "`prime_mul_prime_two_squares_two_ways` assembles the pieces: for distinct primes $p, q \\equiv 1 \\pmod 4$, the product $pq$ is a sum of two squares in two essentially different ways. It draws $p = x^2+y^2$ and $q = u^2+v^2$ (with positive, distinct coordinates from `prime_rep_pos_ne`), applies the two Brahmagupta forms to produce $a,b$ and $c,d$, and invokes `two_distinct_representations` to certify they differ as multisets of squares. This is the general mechanism behind the classical examples of non-unique two-square representations.",
+    "mathContext": "$pq = (xu-yv)^2 + (xv+yu)^2 = (xu+yv)^2 + (xv-yu)^2$, two distinct representations.",
+    "significance": "key",
+    "relatedConcepts": [
+      "products of primes",
+      "non-unique representation",
+      "two_distinct_representations",
+      "prime_rep_pos_ne"
+    ],
+    "prerequisites": [
+      "the two Brahmagupta forms",
+      "prime_rep_pos_ne",
+      "two_distinct_representations"
+    ]
+  },
+  {
+    "id": "ann-concrete-65",
+    "proofId": "fermat-two-squares-oq-06",
+    "range": {
+      "startLine": 199,
+      "endLine": 207
+    },
+    "type": "context",
+    "title": "Concrete Witness: 65 = 1² + 8² = 4² + 7²",
+    "content": "`sixtyfive_two_ways` exhibits the smallest product of two distinct primes $\\equiv 1 \\pmod 4$, namely $65 = 5 \\cdot 13$, as a sum of two squares in two essentially different ways: $65 = 1^2 + 8^2 = 4^2 + 7^2$, with $\\{1, 64\\} \\neq \\{16, 49\\}$. Both equalities and the multiset distinctness are discharged by `norm_num`. This is the canonical illustration of the abstract non-uniqueness theorem, and the classic textbook example for why unique factorization in $\\mathbb{Z}[i]$ does not translate into unique sum-of-squares representation for composite numbers.",
+    "mathContext": "$65 = 5 \\cdot 13$: from $5 = 1^2+2^2$, $13 = 2^2+3^2$ the two forms give $1^2+8^2$ and $4^2+7^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "65 example",
+      "norm_num",
+      "smallest witness",
+      "composite sum of squares"
+    ],
+    "prerequisites": [
+      "the non-uniqueness theorem",
+      "decidable numeric checks"
+    ]
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "Lyapunov's Inequality: Log-Convexity of the Moment Function",
+    "content": "For strictly positive families $w, x : \\iota \\to \\mathbb{R}$ on a finite index, the weighted moment function is $A(t) = \\sum_i w_i\\, x_i^t$. This file proves $t \\mapsto \\log A(t)$ is **convex** — log-convexity of moments, the classical Lyapunov inequality. This is a second-order refinement of power-mean monotonicity (which only says $M_r$ increases in $r$): log-convexity pins the *shape* of the moment curve and implies the power-mean inequality by interpolation. The entire result is one application of the two-function discrete Hölder inequality from the parent file, and underlies the interpolation theory of $L^p$ spaces. Mathlib has log-convexity for specific objects (the Gamma function) but not for the general discrete moment function.",
+    "mathContext": "$A(t) = \\sum_i w_i x_i^t$; $t \\mapsto \\log A(t)$ convex $\\iff A(ap+br) \\le A(p)^a A(r)^b$ ($a+b=1$) $\\iff A(q)^{r-p} \\le A(p)^{r-q} A(r)^{q-p}$ for $p<q<r$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lyapunov inequality",
+      "log-convexity",
+      "power means",
+      "Lᵖ interpolation"
+    ],
+    "prerequisites": [
+      "convex functions",
+      "rpow (real powers)",
+      "Hölder's inequality"
+    ]
+  },
+  {
+    "id": "ann-moment-def",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 53
+    },
+    "type": "definition",
+    "title": "The Weighted Moment Function",
+    "content": "`moment w x t` is $A(t) = \\sum_i w_i\\,(x_i)^t$, a finite weighted power sum with real exponent $t$ (via `Real.rpow`). Specialising recovers familiar objects: with uniform weights it is the (unnormalised) $t$-th power mean numerator; as a function of $t$ it is the discrete analogue of a moment-generating / two-sided Laplace transform of the measure $\\sum_i w_i \\delta_{\\log x_i}$, whose log-convexity is a general fact about such transforms.",
+    "mathContext": "$A(t) = \\sum_{i} w_i\\, x_i^{\\,t}$, $w_i, x_i > 0$, $t \\in \\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "power sum",
+      "moment generating function",
+      "Real.rpow",
+      "Finset.sum"
+    ],
+    "prerequisites": [
+      "real powers rpow",
+      "finite sums"
+    ]
+  },
+  {
+    "id": "ann-rpow-interp",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "The Pointwise Interpolation Identity",
+    "content": "`rpow_interp` is the only `rpow` bookkeeping the whole proof needs: $(w x^p)^a (w x^r)^b = w^{a+b}\\, x^{ap+br}$ for $w, x > 0$. It splits each factor with `Real.mul_rpow` and `Real.rpow_mul`, then recombines exponents via `Real.rpow_add`. When $a + b = 1$ the weight collapses to $w^1 = w$, so the summand $(w x^p)^a (w x^r)^b$ is exactly $w\\, x^{ap+br}$ — the integrand of $A(ap+br)$. This identity is what lets Hölder's inequality be applied termwise.",
+    "mathContext": "$(w x^p)^a (w x^r)^b = w^{a+b} x^{ap+br}$; with $a+b=1$ this is $w\\, x^{ap+br}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.mul_rpow",
+      "Real.rpow_add",
+      "Real.rpow_mul",
+      "exponent arithmetic"
+    ],
+    "prerequisites": [
+      "laws of real exponents",
+      "positivity of w, x"
+    ]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "Nonnegativity and Strict Positivity of Moments",
+    "content": "`moment_nonneg` and `moment_pos` record that $A(t) \\ge 0$ for nonnegative data and $A(t) > 0$ for strictly positive data on a nonempty index. Each summand $w_i x_i^t$ is nonnegative (`Real.rpow_nonneg`) resp. positive (`Real.rpow_pos_of_pos`), and the sum inherits it via `Finset.sum_nonneg` / `Finset.sum_pos`. Strict positivity is essential downstream: it licenses taking $\\log A(t)$ and dividing in the log-convexity step (`Real.log_le_log` and `Real.log_rpow` both require a positive argument).",
+    "mathContext": "$w_i, x_i \\ge 0 \\Rightarrow A(t) \\ge 0$; $w_i, x_i > 0$ and $\\iota$ nonempty $\\Rightarrow A(t) > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_pos",
+      "Real.rpow_pos_of_pos",
+      "positivity of a sum"
+    ],
+    "prerequisites": [
+      "rpow positivity",
+      "sums of positive terms"
+    ]
+  },
+  {
+    "id": "ann-interp-le",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "The Hölder Engine: Interpolation Inequality",
+    "content": "`moment_interp_le` proves $A(ap+br) \\le A(p)^a A(r)^b$ for convex weights $a, b > 0$, $a + b = 1$ — the multiplicative form of Lyapunov. It is a *single* application of the two-function discrete Hölder inequality `JensenHolder.inner_le_holder_two` with conjugate exponents $P = a^{-1}$, $Q = b^{-1}$ (so $1/P + 1/Q = a + b = 1$) and $u_i = (w_i x_i^p)^a$, $v_i = (w_i x_i^r)^b$. The `calc` has three steps: rewrite $A(ap+br) = \\sum u_i v_i$ using `rpow_interp`; apply Hölder; then simplify $(\\sum u_i^{1/a})^a = A(p)^a$ since $u_i^{1/a} = w_i x_i^p$. This is the whole mathematical content — everything else is exponent bookkeeping.",
+    "mathContext": "Hölder: $\\sum u_i v_i \\le (\\sum u_i^P)^{1/P}(\\sum v_i^Q)^{1/Q}$ with $P=a^{-1}, Q=b^{-1}$ gives $A(ap+br) \\le A(p)^a A(r)^b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hölder's inequality",
+      "conjugate exponents",
+      "JensenHolder.inner_le_holder_two",
+      "interpolation"
+    ],
+    "prerequisites": [
+      "discrete Hölder inequality",
+      "rpow_interp",
+      "conjugate exponent relation"
+    ]
+  },
+  {
+    "id": "ann-logconvex",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 110,
+      "endLine": 132
+    },
+    "type": "insight",
+    "title": "Log-Convexity: the Conceptual Statement",
+    "content": "`logConvexOn_moment` repackages the interpolation inequality as genuine convexity of $t \\mapsto \\log A(t)$ on all of $\\mathbb{R}$. After handling the degenerate endpoints $a = 0$ and $b = 0$ (where the convexity condition is trivial), the interior case takes logs of $A(ap+br) \\le A(p)^a A(r)^b$: monotonicity of `log` (`Real.log_le_log`) and $\\log(A(p)^a A(r)^b) = a\\log A(p) + b\\log A(r)$ (via `Real.log_mul` and `Real.log_rpow`) give exactly the convexity inequality $\\log A(ap+br) \\le a\\log A(p) + b\\log A(r)$. This is the clean structural form from which the symmetric Lyapunov inequality and power-mean monotonicity both follow.",
+    "mathContext": "$\\log A(ap+br) \\le \\log(A(p)^a A(r)^b) = a\\log A(p) + b\\log A(r)$ — the definition of convexity of $\\log A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ConvexOn",
+      "Real.log_rpow",
+      "Real.log_le_log",
+      "log-convexity"
+    ],
+    "prerequisites": [
+      "moment_interp_le",
+      "monotonicity of log",
+      "definition of ConvexOn"
+    ]
+  },
+  {
+    "id": "ann-lyapunov-symmetric",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 134,
+      "endLine": 164
+    },
+    "type": "concept",
+    "title": "The Symmetric Three-Exponent Form",
+    "content": "`moment_lyapunov` gives the classical symmetric statement: for $p < q < r$, $A(q)^{r-p} \\le A(p)^{r-q} A(r)^{q-p}$. The middle exponent $q$ is written as the convex combination $q = ap + br$ with $a = \\frac{r-q}{r-p}$, $b = \\frac{q-p}{r-p}$ (so $a+b=1$, both positive). Feeding these into `moment_interp_le` and raising both sides to the power $r-p$ — using $a(r-p) = r-q$ and $b(r-p) = q-p$ — clears all denominators and produces the symmetric form. This is the version that directly exhibits the moment curve's convexity as a three-point inequality and is the form most often quoted in interpolation theory.",
+    "mathContext": "$q = \\frac{r-q}{r-p}p + \\frac{q-p}{r-p}r$; raising $A(q) \\le A(p)^a A(r)^b$ to the power $r-p$ gives $A(q)^{r-p} \\le A(p)^{r-q} A(r)^{q-p}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "three-point convexity",
+      "convex combination",
+      "Real.rpow_le_rpow",
+      "interpolation theory"
+    ],
+    "prerequisites": [
+      "moment_interp_le",
+      "convex combination algebra",
+      "rpow monotonicity"
+    ]
+  }
+]


### PR DESCRIPTION
Adds the missing inline annotation layer to two gallery entries that shipped with rich meta.json but no annotations.json.

| Entry | Topic | Annotations |
|---|---|---|
| fermat-two-squares-oq-06 | Brahmagupta–Fibonacci identity & non-uniqueness of two-square reps | 8 |
| jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01 | Lyapunov's inequality / log-convexity of moments | 7 |

Each annotation covers one Lean construct group and carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All line ranges validate against the Lean source (resolver: 0 misaligned). meta.json integrity unchanged (both verified / 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)