### PR TITLE
research(stirling-first-kind-oq-01-oq-01): unsigned Stirling first-kind numbers are rising-factorial coefficients [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3683,6 +3683,7 @@ import Proofs.SternBrocotTreeOQ01
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFirstKindOQ01
+import Proofs.StirlingFirstKindOQ01OQ01
 import Proofs.StirlingFirstKindOQ02
 import Proofs.StirlingFormula
 import Proofs.StirlingFormulaOQ01OQ01

--- a/proofs/Proofs/StirlingFirstKindOQ01OQ01.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ01OQ01.lean
@@ -1,0 +1,97 @@
+import Mathlib
+
+/-
+# The Generating Identity for Unsigned Stirling Numbers of the First Kind
+
+## What This Proves
+The unsigned Stirling numbers of the first kind `c(n,k) = Nat.stirlingFirst n k` -- the number
+of permutations of `n` elements with exactly `k` disjoint cycles -- are exactly the coefficients
+of the **rising factorial**
+
+    x^(n↑) = x (x+1) (x+2) ⋯ (x + n − 1) = ascPochhammer R n.
+
+Concretely, as a polynomial identity over any commutative semiring `R`:
+
+    ascPochhammer R n = ∑_{k=0}^{n} c(n,k) • Xᵏ        (`ascPochhammer_eq_sum_stirlingFirst`)
+
+equivalently, coefficient-wise,
+
+    (ascPochhammer R n).coeff k = c(n,k)               (`coeff_ascPochhammer_eq_stirlingFirst`).
+
+## Context / Mathlib gap
+Mathlib defines `Nat.stirlingFirst` (`Combinatorics/Enumerative/Stirling.lean`) with its
+recurrences, and `ascPochhammer` (`RingTheory/Polynomial/Pochhammer.lean`) with the rising
+factorial recurrence -- but it never connects the two. In fact `Nat.stirlingFirst` is not
+referenced anywhere outside its own defining file. This entry supplies the missing bridge: the
+combinatorial cycle counts ARE the polynomial coefficients of the rising factorial.
+
+## Approach
+Induction on `n`, comparing coefficients. The Pochhammer recurrence
+`ascPochhammer R (n+1) = ascPochhammer R n * (X + n)` multiplies the coefficient sequence by
+`(X + n)`, i.e. sends `coeff k ↦ coeff (k−1) + n · coeff k`. This is exactly the Stirling
+recurrence `c(n+1, k) = c(n, k−1) + n · c(n,k)` (`Nat.stirlingFirst_succ_succ`).
+
+## Corollaries
+- `eval_ascPochhammer_eq_sum` -- the rising factorial value `x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ`.
+- `sum_stirlingFirst_eq_factorial` -- the row sum `∑ₖ c(n,k) = n!` (specialise to `x = 1`).
+-/
+
+open Polynomial Finset
+
+namespace StirlingFirstGenerating
+
+variable {R : Type*} [CommSemiring R]
+
+/-- **Coefficient form.** The coefficients of the rising factorial `ascPochhammer R n` are the
+unsigned Stirling numbers of the first kind: `(ascPochhammer R n).coeff k = c(n,k)`. -/
+theorem coeff_ascPochhammer_eq_stirlingFirst (n k : ℕ) :
+    (ascPochhammer R n).coeff k = (Nat.stirlingFirst n k : R) := by
+  induction n generalizing k with
+  | zero =>
+    rw [ascPochhammer_zero, coeff_one]
+    rcases k with _ | k
+    · simp
+    · simp
+  | succ n ih =>
+    rw [ascPochhammer_succ_right, mul_add, coeff_add, ← C_eq_natCast, coeff_mul_C]
+    rcases k with _ | m
+    · -- constant term: `(P * X)` has no constant coefficient
+      rw [mul_coeff_zero, coeff_X_zero, mul_zero, zero_add, ih]
+      rcases n with _ | t
+      · simp
+      · simp
+    · -- coefficient of `Xᵐ⁺¹`: the Pochhammer/Stirling recurrence
+      rw [coeff_mul_X, ih m, ih (m + 1), Nat.stirlingFirst_succ_succ]
+      push_cast
+      ring
+
+/-- **Generating identity (headline).** The rising factorial `x(x+1)⋯(x+n−1)` is the polynomial
+whose coefficients are the unsigned Stirling numbers of the first kind:
+`ascPochhammer R n = ∑_{k=0}^{n} c(n,k) Xᵏ`. -/
+theorem ascPochhammer_eq_sum_stirlingFirst (n : ℕ) :
+    ascPochhammer R n = ∑ k ∈ range (n + 1), C (Nat.stirlingFirst n k : R) * X ^ k := by
+  ext j
+  rw [coeff_ascPochhammer_eq_stirlingFirst, finset_sum_coeff]
+  simp only [coeff_C_mul, coeff_X_pow, mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_ite_eq (range (n + 1)) j (fun k => (Nat.stirlingFirst n k : R))]
+  split_ifs with hj
+  · rfl
+  · rw [Finset.mem_range, not_lt] at hj
+    rw [Nat.stirlingFirst_eq_zero_of_lt (by omega), Nat.cast_zero]
+
+/-- **Evaluation form.** The value of the rising factorial: `x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ`. -/
+theorem eval_ascPochhammer_eq_sum (n : ℕ) (x : R) :
+    (ascPochhammer R n).eval x = ∑ k ∈ range (n + 1), (Nat.stirlingFirst n k : R) * x ^ k := by
+  rw [ascPochhammer_eq_sum_stirlingFirst, eval_finset_sum]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [eval_mul, eval_C, eval_pow, eval_X]
+
+/-- **Row sum.** The unsigned Stirling numbers of the first kind in row `n` sum to `n!`,
+reflecting that the `n!` permutations are partitioned by their number of cycles. -/
+theorem sum_stirlingFirst_eq_factorial (n : ℕ) :
+    (∑ k ∈ range (n + 1), Nat.stirlingFirst n k) = Nat.factorial n := by
+  have h := eval_ascPochhammer_eq_sum (R := ℕ) n 1
+  rw [ascPochhammer_eval_one] at h
+  simpa using h.symm
+
+end StirlingFirstGenerating

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stirling-first-kind-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "Goal: Stirling Numbers as Rising-Factorial Coefficients",
+    "content": "The file imports all of `Mathlib` and opens `Polynomial` and `Finset`. The objective is the classical generating identity for the unsigned Stirling numbers of the first kind: the rising factorial `ascPochhammer R n = X(X+1)⋯(X+n−1)` has coefficient of `Xᵏ` equal to `c(n,k) = Nat.stirlingFirst n k`, the number of permutations of `n` elements with exactly `k` cycles. Mathlib defines both `Nat.stirlingFirst` and `ascPochhammer` but never connects them; `Nat.stirlingFirst` is in fact unused outside its defining file.",
+    "mathContext": "Target: $\\mathrm{ascPochhammer}\\,R\\,n = \\sum_{k=0}^{n} c(n,k)\\,X^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Stirling numbers of the first kind", "rising factorial", "generating functions"],
+    "prerequisites": ["polynomial coefficients", "Lean 4 module system"]
+  },
+  {
+    "id": "ann-recurrence-match",
+    "proofId": "stirling-first-kind-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 66 },
+    "type": "technique",
+    "title": "Matching the Pochhammer and Stirling Recurrences",
+    "content": "The inductive step rewrites `ascPochhammer R (n+1) = ascPochhammer R n * (X + n)` (`ascPochhammer_succ_right`) and distributes over the sum `X + (n : R[X])`. Converting `(n : R[X])` to `C (n : R)` via `C_eq_natCast` lets `coeff_mul_C` read the `(+n)` part as a scaling: `(P * C n).coeff k = P.coeff k * n`. For `k = m+1`, `coeff_mul_X` reads the `·X` part as a shift: `(P * X).coeff (m+1) = P.coeff m`. Applying the induction hypothesis to both gives `c(n,m) + c(n,m+1)·n`, which is `Nat.stirlingFirst_succ_succ`'s `n·c(n,m+1) + c(n,m) = c(n+1,m+1)` after `push_cast; ring`.",
+    "mathContext": "Multiplying $x^{(n\\uparrow)}$ by $(x+n)$ sends $\\mathrm{coeff}\\,k \\mapsto \\mathrm{coeff}\\,(k-1) + n\\,\\mathrm{coeff}\\,k$ — exactly $c(n+1,k) = c(n,k-1) + n\\,c(n,k)$.",
+    "significance": "central",
+    "relatedConcepts": ["recurrence relation", "polynomial coefficient shift", "induction"],
+    "prerequisites": ["ascPochhammer_succ_right", "coeff_mul_X", "coeff_mul_C", "Nat.stirlingFirst_succ_succ"]
+  },
+  {
+    "id": "ann-constant-term",
+    "proofId": "stirling-first-kind-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 62 },
+    "type": "key-step",
+    "title": "The Constant Term Vanishes Correctly",
+    "content": "The `k = 0` case is handled separately because `coeff_mul_X` only applies to a successor index. Here `(ascPochhammer R n * X).coeff 0 = 0` via `mul_coeff_zero` and `coeff_X_zero`, leaving only the `(+n)` contribution `c(n,0) · n`. A further case-split on `n` shows this is `0`: for `n = 0` it is `1 · 0 = 0`, and for `n = t+1` it is `c(t+1,0) · n = 0 · n = 0` (`stirlingFirst_succ_zero`), matching `c(n+1,0) = 0`.",
+    "mathContext": "$(p\\cdot X)$ has zero constant coefficient, and $c(n,0)\\,n = 0$ for every $n$, consistent with $c(n+1,0)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["constant coefficient", "edge values of Stirling numbers"],
+    "prerequisites": ["mul_coeff_zero", "coeff_X_zero", "Nat.stirlingFirst_succ_zero"]
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "stirling-first-kind-oq-01-oq-01",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "key-step",
+    "title": "From Coefficients to the Polynomial Identity",
+    "content": "`ascPochhammer_eq_sum_stirlingFirst` upgrades the coefficient lemma to a polynomial equation by `Polynomial.ext`. Comparing the `j`-th coefficient: the left side is `c(n,j)` by `coeff_ascPochhammer_eq_stirlingFirst`; the right side `(∑ C(c(n,k))·Xᵏ).coeff j` collapses via `finset_sum_coeff`, `coeff_C_mul`, and `coeff_X_pow` to `∑ k, if j = k then c(n,k) else 0`, which `Finset.sum_ite_eq` reduces to `c(n,j)` when `j ≤ n` and `0` otherwise. For `j > n` both sides are `0` (`stirlingFirst_eq_zero_of_lt`).",
+    "mathContext": "$\\left(\\sum_k c(n,k) X^k\\right).\\mathrm{coeff}\\,j = c(n,j)$ because $(X^k).\\mathrm{coeff}\\,j = [j=k]$.",
+    "significance": "central",
+    "relatedConcepts": ["Polynomial.ext", "coefficient extraction", "indicator sums"],
+    "prerequisites": ["finset_sum_coeff", "coeff_X_pow", "Finset.sum_ite_eq", "stirlingFirst_eq_zero_of_lt"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "stirling-first-kind-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 97 },
+    "type": "concept",
+    "title": "Evaluation Form and the Row Sum ∑ c(n,k) = n!",
+    "content": "`eval_ascPochhammer_eq_sum` evaluates the generating identity at any `x`, pushing `eval` through the finite sum (`eval_finset_sum`) and each monomial term to give `x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ`. Specialising to `x = 1` over `ℕ` and using `ascPochhammer_eval_one` (`= n!`) recovers the row sum `∑ c(n,k) = n!`. This reproves, via the generating function, the purely combinatorial identity established in the parent entry `stirling-first-kind-oq-01`.",
+    "mathContext": "At $x = 1$: $\\sum_k c(n,k) = (\\mathrm{ascPochhammer}\\,\\mathbb{N}\\,n).\\mathrm{eval}\\,1 = n!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial evaluation", "row sum identity", "factorial"],
+    "prerequisites": ["eval_finset_sum", "ascPochhammer_eval_one"]
+  }
+]

--- a/src/data/proofs/stirling-first-kind-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-01/meta.json
@@ -1,0 +1,212 @@
+{
+  "id": "stirling-first-kind-oq-01-oq-01",
+  "slug": "stirling-first-kind-oq-01-oq-01",
+  "title": "The Generating Identity for Unsigned Stirling Numbers of the First Kind",
+  "description": "Proves that the unsigned Stirling numbers of the first kind c(n,k) = Nat.stirlingFirst n k are exactly the coefficients of the rising factorial: ascPochhammer R n = ∑_{k=0}^{n} c(n,k) Xᵏ, equivalently (ascPochhammer R n).coeff k = c(n,k). Mathlib defines both Nat.stirlingFirst and ascPochhammer but never connects them — in fact Nat.stirlingFirst is unused outside its defining file. The proof is an induction on n comparing coefficients: the Pochhammer recurrence ascPochhammer (n+1) = ascPochhammer n · (X + n) realises exactly the Stirling recurrence c(n+1,k) = c(n,k−1) + n·c(n,k). Corollaries: the evaluation form x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ, and the row sum ∑ₖ c(n,k) = n! recovered via the generating function.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "StirlingFirstGenerating",
+    "lineCount": 97,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "ascPochhammer_eq_sum_stirlingFirst",
+        "type": "original",
+        "description": "The rising factorial is the polynomial whose coefficients are the unsigned Stirling numbers of the first kind: ascPochhammer R n = ∑_{k=0}^{n} c(n,k) Xᵏ",
+        "leanType": "(n : ℕ) → ascPochhammer R n = ∑ k ∈ Finset.range (n + 1), C (Nat.stirlingFirst n k : R) * X ^ k"
+      },
+      {
+        "name": "coeff_ascPochhammer_eq_stirlingFirst",
+        "type": "original",
+        "description": "Coefficient form: the k-th coefficient of the rising factorial ascPochhammer R n is c(n,k)",
+        "leanType": "(n k : ℕ) → (ascPochhammer R n).coeff k = (Nat.stirlingFirst n k : R)"
+      },
+      {
+        "name": "eval_ascPochhammer_eq_sum",
+        "type": "original",
+        "description": "Evaluation form: the value of the rising factorial x(x+1)⋯(x+n−1) equals ∑ c(n,k) xᵏ",
+        "leanType": "(n : ℕ) → (x : R) → (ascPochhammer R n).eval x = ∑ k ∈ Finset.range (n + 1), (Nat.stirlingFirst n k : R) * x ^ k"
+      },
+      {
+        "name": "sum_stirlingFirst_eq_factorial",
+        "type": "original",
+        "description": "Row sum: the unsigned Stirling numbers of the first kind in row n sum to n!, recovered here by specialising the generating function to x = 1",
+        "leanType": "(n : ℕ) → (∑ k ∈ Finset.range (n + 1), Nat.stirlingFirst n k) = Nat.factorial n"
+      }
+    ],
+    "path": "Proofs/StirlingFirstKindOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFirstKindOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "polynomials",
+      "stirling-numbers",
+      "rising-factorial",
+      "generating-functions",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 97,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). The result connects two existing Mathlib definitions — Nat.stirlingFirst and ascPochhammer — using the Pochhammer recurrence ascPochhammer_succ_right, the Stirling recurrence Nat.stirlingFirst_succ_succ, and standard polynomial coefficient lemmas. Mathlib does not contain this generating identity.",
+    "originalContributions": [
+      "ascPochhammer_eq_sum_stirlingFirst: the rising factorial equals ∑ c(n,k) Xᵏ — original, the headline generating identity not present in Mathlib",
+      "coeff_ascPochhammer_eq_stirlingFirst: (ascPochhammer R n).coeff k = c(n,k) — original coefficient characterisation, proved by induction matching the Pochhammer and Stirling recurrences",
+      "eval_ascPochhammer_eq_sum: evaluation form x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ — original corollary",
+      "sum_stirlingFirst_eq_factorial: row sum ∑ c(n,k) = n! recovered via the generating function at x = 1 — gives a second, structural proof of the OQ-01 row-sum identity"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ascPochhammer_succ_right",
+        "description": "Rising factorial recurrence: ascPochhammer R (n+1) = ascPochhammer R n * (X + n)",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "Nat.stirlingFirst_succ_succ",
+        "description": "Stirling first-kind recurrence: c(n+1,k+1) = n·c(n,k+1) + c(n,k)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_X",
+        "description": "(p * X).coeff (n+1) = p.coeff n — the multiply-by-X coefficient shift",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_C",
+        "description": "(p * C a).coeff n = p.coeff n * a — the multiply-by-constant coefficient law",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "ascPochhammer_eval_one",
+        "description": "(ascPochhammer S n).eval 1 = n! — used to recover the row sum",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Stirling numbers of the first kind and their cycle interpretation",
+      "The rising factorial / Pochhammer symbol as a polynomial",
+      "Polynomial coefficients and the coeff API in Mathlib",
+      "Induction comparing coefficients of polynomials",
+      "Familiarity with Lean 4 and Mathlib"
+    ],
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind",
+    "date": "1730",
+    "relatedProblems": [
+      {
+        "id": "stirling-first-kind-oq-01",
+        "relationship": "Answers the parent entry's open question asking for the generating identity ∑ c(n,k) xᵏ = rising factorial; also gives a second proof of that entry's row-sum identity ∑ c(n,k) = n! via the generating function"
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "The unsigned Stirling numbers of the first kind c(n,k) count permutations of n elements with exactly k cycles, and satisfy c(n+1,k) = c(n,k−1) + n·c(n,k). The rising factorial x^(n↑) = x(x+1)⋯(x+n−1) is a degree-n polynomial. Are the Stirling numbers exactly the coefficients of the rising factorial, i.e. x^(n↑) = ∑_{k=0}^{n} c(n,k) xᵏ? Mathlib defines both objects but never links them.",
+    "text": "This is the classical generating identity for the unsigned Stirling numbers of the first kind. The rising factorial $x^{(n\\uparrow)} = x(x+1)\\cdots(x+n-1)$, written `ascPochhammer R n` in Mathlib, expands into a polynomial whose coefficient of $x^k$ is the number of permutations of $n$ elements with exactly $k$ cycles. The proof works coefficient-by-coefficient: multiplying $x^{(n\\uparrow)}$ by $(x+n)$ to form $x^{((n+1)\\uparrow)}$ sends the coefficient sequence $a_k$ to $a_{k-1} + n\\,a_k$, which is precisely the Stirling recurrence.",
+    "proofStrategy": "Prove the coefficient identity (ascPochhammer R n).coeff k = c(n,k) by induction on n. The base case is coeff_one. In the inductive step, rewrite with ascPochhammer_succ_right to get ascPochhammer n · (X + n), distribute, and read off the two contributions: the X-multiplication shifts coeff k to coeff (k−1) (coeff_mul_X), and the (+n)-multiplication scales coeff k by n (coeff_mul_C after C_eq_natCast). Adding them and applying the induction hypothesis twice yields n·c(n,k) + c(n,k−1) = c(n+1,k) (Nat.stirlingFirst_succ_succ). The headline polynomial identity follows by Polynomial.ext, and the evaluation and row-sum forms by specialisation.",
+    "keyInsights": [
+      "The polynomial recurrence ascPochhammer (n+1) = ascPochhammer n · (X + n) IS the Stirling recurrence c(n+1,k) = c(n,k−1) + n·c(n,k), once read off coefficient-wise — multiplication by X shifts, multiplication by n scales.",
+      "Comparing coefficients (Polynomial.ext) is far cleaner than reindexing Finset sums with scalar multiplication; the coefficient form is the natural carrier of the induction.",
+      "The identity holds over an arbitrary commutative semiring, so no subtraction or signs are needed — these are the unsigned Stirling numbers, matching the rising (not falling) factorial.",
+      "Setting x = 1 collapses the generating function to the row sum ∑ c(n,k) = n!, giving a structural reproof of the purely combinatorial fact and confirming the two Mathlib definitions are consistent."
+    ],
+    "historicalContext": "Stirling numbers originate in James Stirling's Methodus Differentialis (1730), which studied exactly the conversion between the monomial basis xᵏ and the factorial bases. The unsigned Stirling numbers of the first kind are the change-of-basis coefficients from the rising-factorial basis to the monomial basis; the signed version performs the inverse change from falling factorials. The cycle interpretation (permutations with k cycles) was made precise much later in the combinatorial theory of the symmetric group.",
+    "prerequisites": [
+      "Stirling numbers of the first kind",
+      "The rising factorial / Pochhammer symbol",
+      "Polynomial coefficients and evaluation"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Module Overview and Imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports Mathlib and opens Polynomial and Finset. The docstring states the generating identity, explains the Mathlib gap (Nat.stirlingFirst is unused outside its defining file), and outlines the coefficient-comparison strategy.",
+      "mathContext": "Goal: $\\mathrm{ascPochhammer}\\,R\\,n = \\sum_{k=0}^{n} c(n,k)\\,X^k$, equivalently $(\\mathrm{ascPochhammer}\\,R\\,n).\\mathrm{coeff}\\,k = c(n,k)$."
+    },
+    {
+      "id": "coeff-form",
+      "title": "Coefficient Form by Induction",
+      "startLine": 45,
+      "endLine": 66,
+      "summary": "Proves coeff_ascPochhammer_eq_stirlingFirst: (ascPochhammer R n).coeff k = c(n,k) by induction on n generalizing k. The base uses coeff_one; the step rewrites ascPochhammer_succ_right and splits the constant term (no constant coefficient in p·X) from the general term, where coeff_mul_X and coeff_mul_C realise the Stirling recurrence.",
+      "mathContext": "Multiplying by $(X+n)$: $\\mathrm{coeff}\\,k \\mapsto \\mathrm{coeff}\\,(k-1) + n\\cdot\\mathrm{coeff}\\,k$, which equals $c(n,k-1) + n\\,c(n,k) = c(n+1,k)$."
+    },
+    {
+      "id": "headline-identity",
+      "title": "The Generating Identity",
+      "startLine": 68,
+      "endLine": 80,
+      "summary": "Proves ascPochhammer_eq_sum_stirlingFirst by Polynomial.ext: the j-th coefficient of the right-hand sum is c(n,j) (only the k = j term of ∑ C(c(n,k))·Xᵏ survives, via coeff_X_pow and Finset.sum_ite_eq), matching the coefficient form; for j > n both sides vanish (stirlingFirst_eq_zero_of_lt).",
+      "mathContext": "$\\left(\\sum_{k} c(n,k) X^k\\right).\\mathrm{coeff}\\,j = c(n,j)$ since $(X^k).\\mathrm{coeff}\\,j = [j=k]$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Evaluation and Row-Sum Corollaries",
+      "startLine": 82,
+      "endLine": 97,
+      "summary": "eval_ascPochhammer_eq_sum pushes eval through the generating identity to give x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ. sum_stirlingFirst_eq_factorial specialises to x = 1 over ℕ, using ascPochhammer_eval_one to obtain the row sum ∑ c(n,k) = n!.",
+      "mathContext": "At $x = 1$: $\\sum_k c(n,k) = (\\mathrm{ascPochhammer}\\,\\mathbb{N}\\,n).\\mathrm{eval}\\,1 = n!$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The unsigned Stirling numbers of the first kind are exactly the coefficients of the rising factorial: ascPochhammer R n = ∑ c(n,k) Xᵏ, proved over an arbitrary commutative semiring with 0 axioms and 0 sorries by matching the Pochhammer and Stirling recurrences coefficient-by-coefficient. The evaluation form and the row sum ∑ c(n,k) = n! follow by specialisation, the latter giving a structural reproof of the parent entry's combinatorial identity.",
+    "implications": [
+      "Bridges two previously disconnected Mathlib definitions, Nat.stirlingFirst and ascPochhammer, supplying the change-of-basis identity between the monomial and rising-factorial bases.",
+      "Provides the coefficient characterisation (ascPochhammer R n).coeff k = c(n,k) as reusable infrastructure for further identities (orthogonality with the second-kind numbers, log-concavity, unimodality).",
+      "Recovers the row-sum identity ∑ c(n,k) = n! as a one-line specialisation, showing the generating-function viewpoint subsumes the direct combinatorial argument."
+    ],
+    "openQuestions": [
+      "Prove the companion identity for the falling factorial using the signed Stirling numbers of the first kind, and combine with the second-kind generating identity to formalise that the two Stirling matrices are inverse.",
+      "Derive structural consequences of the coefficient identity: that row n is log-concave (hence unimodal), or the explicit value c(n,2) = (n−1)! · H_{n−1}.",
+      "Establish the generating identity for the unsigned numbers as a polynomial over ℤ and relate its coefficients to the elementary symmetric polynomials in {0,1,…,n−1}."
+    ]
+  },
+  "references": [
+    {
+      "title": "Stirling numbers of the first kind",
+      "url": "https://en.wikipedia.org/wiki/Stirling_numbers_of_the_first_kind",
+      "description": "Definition, recurrence, cycle interpretation, and the generating identity with the rising factorial."
+    },
+    {
+      "title": "Falling and rising factorials",
+      "url": "https://en.wikipedia.org/wiki/Falling_and_rising_factorials",
+      "description": "The Pochhammer symbols and their expansion in the monomial basis via Stirling numbers."
+    },
+    {
+      "title": "James Stirling, Methodus Differentialis (1730)",
+      "url": "https://en.wikipedia.org/wiki/Methodus_Differentialis",
+      "description": "Original source studying the conversion between monomial and factorial bases."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-first-kind-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's open question for the generating identity ∑ c(n,k) xᵏ = rising factorial, and reproves its row-sum identity ∑ c(n,k) = n! via the generating function at x = 1."
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "complementary",
+      "description": "The second-kind generating identity expands ordinary powers in the falling-factorial basis; together the two are the mutually inverse change-of-basis identities between monomials and factorials."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Proves the **generating identity** for the unsigned Stirling numbers of the first kind: they are exactly the coefficients of the rising factorial.

`proofs/Proofs/StirlingFirstKindOQ01OQ01.lean` (97 lines, 4 theorems, **verified, 0 axioms**).

Answers the open question of the parent entry `stirling-first-kind-oq-01` (which asks for `∑ c(n,k) xᵏ = rising factorial`).

## Mathlib gap

Mathlib defines `Nat.stirlingFirst` (`Combinatorics/Enumerative/Stirling.lean`) with its recurrences, and `ascPochhammer` (`RingTheory/Polynomial/Pochhammer.lean`) with the rising-factorial recurrence — but **never connects them**. `Nat.stirlingFirst` is not referenced anywhere outside its own defining file. This entry supplies the missing bridge.

## Results

- `coeff_ascPochhammer_eq_stirlingFirst` — coefficient form: `(ascPochhammer R n).coeff k = c(n,k)`.
- `ascPochhammer_eq_sum_stirlingFirst` — **headline**: `ascPochhammer R n = ∑_{k=0}^{n} C(c(n,k)) · Xᵏ`.
- `eval_ascPochhammer_eq_sum` — evaluation form: `x(x+1)⋯(x+n−1) = ∑ c(n,k) xᵏ`.
- `sum_stirlingFirst_eq_factorial` — row sum `∑ c(n,k) = n!`, recovered via the generating function at `x = 1` (a second, structural proof of the parent entry's combinatorial identity).

All over an arbitrary commutative semiring `R` (these are the *unsigned* numbers, matching the *rising* factorial — no signs needed).

## Approach

Induction on `n`, comparing coefficients. The Pochhammer recurrence `ascPochhammer R (n+1) = ascPochhammer R n * (X + n)` sends `coeff k ↦ coeff (k−1) + n · coeff k` — `coeff_mul_X` is the shift, `coeff_mul_C` the scaling — which is exactly the Stirling recurrence `c(n+1,k) = c(n,k−1) + n · c(n,k)` (`Nat.stirlingFirst_succ_succ`). The polynomial identity follows by `Polynomial.ext`; the eval and row-sum forms by specialisation.

## Verification

`#print axioms` on all four theorems returns only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Builds against Mathlib v4.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)