### PR TITLE
research(binomial-theorem-oq-03-oq-02-oq-03-oq-01): sharp bound (1+1/n)^n < e for all n≥1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03OQ01.lean
@@ -1,0 +1,84 @@
+/-
+  Sharp Bound: (1 + 1/n)^n < e for All n ≥ 1
+
+  OQ-03-OQ-02-OQ-03-OQ-01 derived from the exponential limit / monotonicity chain.
+
+  **Main theorem**: For every n ≥ 1, the strict bound
+      (1 + 1/n)^n < e
+  holds. This sharpens the parent's (1+1/n)^n < 3 bound and complements both the
+  limit (1+1/n)^n → e and the strict monotonicity result (parent OQ-03-OQ-02-OQ-03):
+  the increasing sequence (1+1/n)^n approaches e strictly from below.
+
+  **Proof strategy** (elementary, one-line core):
+  1. For x > 0 and n ≥ 1, since x/n ≠ 0 we have the strict tangent bound
+        1 + x/n < exp(x/n)      [Real.add_one_lt_exp]
+  2. Both sides are positive; raising to the n-th power preserves strict order:
+        (1 + x/n)^n < (exp(x/n))^n = exp(n · (x/n)) = exp(x).
+  3. Specialize x = 1 to get (1 + 1/n)^n < exp 1 = e.
+
+  We also record the elementary lower companion 2 ≤ (1+1/n)^n (Bernoulli), giving
+  the two-sided bound 2 ≤ (1+1/n)^n < e for all n ≥ 1.
+
+  **Key references**:
+  - Parent: BinomialTheoremOQ03OQ02OQ03 (strict monotonicity of (1+1/n)^n)
+  - Grandparent: BinomialTheoremOQ03OQ02 (limit (1+1/n)^n → e)
+  - Classic: Rudin, Principles of Mathematical Analysis, Chapter 3
+
+  **Axiom count**: 0
+  **Sorry count**: 0
+-/
+import Mathlib
+
+open Real
+
+namespace SharpEulerBound
+
+/-- General strict bound: for `x > 0` and `n ≥ 1`,
+    `(1 + x/n)^n < exp x`.
+
+    Core of the argument: `x/n ≠ 0`, so the strict tangent-line inequality
+    `1 + x/n < exp(x/n)` holds; raising both (positive) sides to the `n`-th power
+    and using `(exp (x/n))^n = exp (n · (x/n)) = exp x` gives the claim. -/
+theorem add_div_pow_lt_exp (x : ℝ) (hx : 0 < x) (n : ℕ) (hn : 1 ≤ n) :
+    (1 + x / n) ^ n < Real.exp x := by
+  have hn0 : (0 : ℝ) < n := by exact_mod_cast hn
+  have hxn_ne : x / n ≠ 0 := div_ne_zero hx.ne' hn0.ne'
+  -- Strict tangent bound 1 + x/n < exp(x/n).
+  have hbase : 1 + x / n < Real.exp (x / n) := by
+    have h := Real.add_one_lt_exp hxn_ne
+    linarith
+  have hbase_nonneg : (0 : ℝ) ≤ 1 + x / n := by positivity
+  -- Raise to the n-th power (strict order preserved on nonnegatives).
+  have hpow : (1 + x / n) ^ n < (Real.exp (x / n)) ^ n :=
+    pow_lt_pow_left₀ hbase hbase_nonneg (by omega)
+  -- (exp(x/n))^n = exp(n · (x/n)) = exp x.
+  rw [← Real.exp_nat_mul] at hpow
+  have hcancel : (n : ℝ) * (x / n) = x := by field_simp
+  rwa [hcancel] at hpow
+
+/-- **Main result**: `(1 + 1/n)^n < e` for all `n ≥ 1`. -/
+theorem add_inv_pow_lt_e (n : ℕ) (hn : 1 ≤ n) :
+    (1 + 1 / (n : ℝ)) ^ n < Real.exp 1 := by
+  simpa using add_div_pow_lt_exp 1 one_pos n hn
+
+/-- Lower companion (Bernoulli): `2 ≤ (1 + 1/n)^n` for all `n ≥ 1`. -/
+theorem two_le_add_inv_pow (n : ℕ) (hn : 1 ≤ n) :
+    2 ≤ (1 + 1 / (n : ℝ)) ^ n := by
+  have hn0 : (0 : ℝ) < n := by exact_mod_cast hn
+  have hge : (-2 : ℝ) ≤ 1 / n := by
+    have h0 : (0 : ℝ) ≤ 1 / (n : ℝ) := by positivity
+    linarith
+  have h := one_add_mul_le_pow hge n
+  have hcancel : 1 + (n : ℝ) * (1 / n) = 2 := by
+    rw [mul_one_div, div_self hn0.ne']; norm_num
+  rw [hcancel] at h
+  linarith
+
+/-- Two-sided bound: `2 ≤ (1 + 1/n)^n < e` for all `n ≥ 1`.
+    Together with the parent's strict monotonicity, the sequence increases
+    strictly toward `e` while staying in `[2, e)`. -/
+theorem add_inv_pow_bounds (n : ℕ) (hn : 1 ≤ n) :
+    2 ≤ (1 + 1 / (n : ℝ)) ^ n ∧ (1 + 1 / (n : ℝ)) ^ n < Real.exp 1 :=
+  ⟨two_le_add_inv_pow n hn, add_inv_pow_lt_e n hn⟩
+
+end SharpEulerBound

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+  "title": "Sharp Bound: (1 + 1/n)^n < e for All n ≥ 1",
+  "slug": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+  "description": "Proves the sharp strict upper bound (1 + 1/n)^n < e for every n ≥ 1, sharpening the parent's (1+1/n)^n < 3 and complementing both the limit (1+1/n)^n → e and the strict monotonicity result. The proof is elementary: the strict tangent inequality 1 + x/n < exp(x/n) (from Real.add_one_lt_exp, valid since x/n ≠ 0) raised to the n-th power gives (1+x/n)^n < exp(x); specializing x = 1 yields the bound. Also records the elementary lower companion 2 ≤ (1+1/n)^n (Bernoulli), for a two-sided 2 ≤ (1+1/n)^n < e. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Classical analysis; formalization by Lean Genius",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ03OQ02OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "exponential",
+      "inequality",
+      "euler-number",
+      "sequences",
+      "bernoulli-inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 84,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Euler introduced e in 1748 as the limit of (1 + 1/n)^n, a sequence Jacob Bernoulli had studied in the 1690s through the compound-interest problem. The textbook construction of e via bounded monotone convergence (e.g. Rudin, Principles of Mathematical Analysis, Theorem 3.31) shows the sequence is strictly increasing and bounded above. The crude bound (1+1/n)^n < 3 suffices for convergence, but the sharp statement is that e is itself the strict supremum: (1+1/n)^n < e for every n, with equality only in the limit. This sharp bound is the natural endpoint of the monotonicity story — the increasing sequence approaches e strictly from below — and follows in one line from the strict tangent-line inequality 1 + t < e^t (t ≠ 0), a hallmark of the strict convexity of the exponential.",
+    "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-03-OQ-01):** Prove the sharp upper bound (1 + 1/n)^n < e for all n ≥ 1, sharpening the parent's (1+1/n)^n < 3 bound.\n\n**Strategy**: Apply the strict tangent inequality 1 + x/n < exp(x/n) (valid since x/n ≠ 0) and raise both positive sides to the n-th power: (1 + x/n)^n < (exp(x/n))^n = exp(x). Specialize x = 1.",
+    "text": "Establishes (1 + 1/n)^n < e for all n ≥ 1. The general lemma add_div_pow_lt_exp proves (1 + x/n)^n < exp(x) for x > 0 and n ≥ 1; the main theorem add_inv_pow_lt_e specializes x = 1. A lower companion two_le_add_inv_pow gives 2 ≤ (1+1/n)^n via the Bernoulli inequality, and add_inv_pow_bounds packages the two-sided 2 ≤ (1+1/n)^n < e.",
+    "proofStrategy": "1. **General bound** (add_div_pow_lt_exp): For x > 0 and n ≥ 1, x/n ≠ 0, so Real.add_one_lt_exp gives the strict tangent inequality 1 + x/n < exp(x/n). Both sides are nonnegative, so pow_lt_pow_left₀ raises them to the n-th power strictly: (1 + x/n)^n < (exp(x/n))^n. Then Real.exp_nat_mul rewrites (exp(x/n))^n = exp(n·(x/n)) = exp(x).\n\n2. **Main theorem** (add_inv_pow_lt_e): Specialize x = 1, giving (1 + 1/n)^n < exp(1) = e.\n\n3. **Lower companion** (two_le_add_inv_pow): one_add_mul_le_pow with a = 1/n ≥ -2 gives 1 + n·(1/n) = 2 ≤ (1 + 1/n)^n.\n\n4. **Two-sided bound** (add_inv_pow_bounds): conjunction of 2 and 3.",
+    "keyInsights": [
+      "The sharp upper bound is strictly stronger than the parent's < 3 and is the genuine endpoint of the monotonicity story: the increasing sequence (1+1/n)^n approaches e strictly from below, so e is its supremum but never attained.",
+      "The entire argument is the single strict tangent inequality 1 + t < e^t for t ≠ 0 (Real.add_one_lt_exp), applied at t = 1/n and exponentiated — no logarithms, derivatives, or mean value theorem are needed, in contrast to the parent's monotonicity proof.",
+      "Strictness is essential and free: because 1/n ≠ 0, the tangent bound is strict, and pow_lt_pow_left₀ propagates strictness through the n-th power, so the final inequality is strict (not merely ≤).",
+      "The same lemma proves the more general (1 + x/n)^n < exp(x) for every x > 0, so the e-bound is just the x = 1 slice of a one-parameter family of exponential bounds.",
+      "The Bernoulli lower bound 2 ≤ (1+1/n)^n (from one_add_mul_le_pow) pins the sequence into the half-open interval [2, e), matching the parent's 2 < (1+1/n)^n < 3 but with the sharp upper endpoint."
+    ],
+    "prerequisites": [
+      "Real.add_one_lt_exp (strict tangent inequality: x ≠ 0 → x + 1 < exp(x))",
+      "pow_lt_pow_left₀ (strict monotonicity of x ↦ x^n on nonnegatives)",
+      "Real.exp_nat_mul (exp(n·x) = exp(x)^n)",
+      "one_add_mul_le_pow (Bernoulli inequality: -2 ≤ a → 1 + n·a ≤ (1+a)^n)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Docstring documenting the elementary one-line core (strict tangent inequality exponentiated). Imports Mathlib, opens Real, declares the SharpEulerBound namespace."
+    },
+    {
+      "id": "general-bound",
+      "title": "General Bound (1 + x/n)^n < exp(x)",
+      "startLine": 38,
+      "endLine": 65,
+      "summary": "add_div_pow_lt_exp: for x > 0 and n ≥ 1, the strict tangent bound 1 + x/n < exp(x/n) raised to the n-th power gives (1 + x/n)^n < exp(x).",
+      "mathContext": "Uses Real.add_one_lt_exp (x/n ≠ 0), pow_lt_pow_left₀ for strict exponentiation, and Real.exp_nat_mul to collapse (exp(x/n))^n = exp(x)."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: (1 + 1/n)^n < e",
+      "startLine": 66,
+      "endLine": 70,
+      "summary": "add_inv_pow_lt_e: specializing the general bound at x = 1 yields (1 + 1/n)^n < exp(1) = e for all n ≥ 1.",
+      "mathContext": "Direct specialization; e = Real.exp 1."
+    },
+    {
+      "id": "lower-and-two-sided",
+      "title": "Lower Companion and Two-Sided Bound",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "two_le_add_inv_pow: Bernoulli gives 2 ≤ (1+1/n)^n. add_inv_pow_bounds packages the two-sided 2 ≤ (1+1/n)^n < e.",
+      "mathContext": "one_add_mul_le_pow with a = 1/n gives 1 + n·(1/n) = 2 as a lower bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the sharp strict upper bound (1 + 1/n)^n < e for all n ≥ 1 with 0 axioms, 0 sorries, 4 theorems in 84 lines. The general lemma (1 + x/n)^n < exp(x) for x > 0 specializes to the e-bound at x = 1, and the Bernoulli lower companion gives the two-sided 2 ≤ (1+1/n)^n < e.",
+    "implications": "This answers the parent proof's first open question — sharpening (1+1/n)^n < 3 to the optimal (1+1/n)^n < e. Combined with the parent's strict monotonicity and the grandparent's limit (1+1/n)^n → e, the picture is complete: a strictly increasing sequence confined to [2, e) converging to its supremum e, which it never attains.",
+    "openQuestions": [
+      "Prove the complementary bound e < (1 + 1/n)^(n+1) for all n ≥ 1, giving the two-sided squeeze (1+1/n)^n < e < (1+1/n)^(n+1)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-03-oq-02-oq-03",
+      "relationship": "parent",
+      "description": "Strict Monotonicity: (1 + 1/n)^n is Strictly Increasing"
+    },
+    {
+      "targetId": "binomial-theorem-oq-03-oq-02",
+      "relationship": "foundational",
+      "description": "Classical Limit: (1+1/n)^n → e"
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "foundational",
+      "description": "Poisson Limit Theorem via Exponential Limit"
+    }
+  ],
+  "leanFile": {
+    "namespace": "SharpEulerBound",
+    "theoremCount": 4,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "lineCount": 84,
+    "path": "Proofs/BinomialTheoremOQ03OQ02OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **sharp strict upper bound** \`(1 + 1/n)^n < e\` for all \`n ≥ 1\`, answering the **first open question** of the parent proof (binomial-theorem-oq-03-oq-02-oq-03), which proved only the crude \`(1+1/n)^n < 3\`.

This is the genuine endpoint of the monotonicity story: the strictly increasing sequence \`(1+1/n)^n\` approaches \`e\` strictly **from below** — \`e\` is its supremum but is never attained.

## Main results (namespace \`SharpEulerBound\`)

- \`add_div_pow_lt_exp\`: general bound \`(1 + x/n)^n < exp x\` for \`x > 0\`, \`n ≥ 1\`.
- \`add_inv_pow_lt_e\`: **main** — \`(1 + 1/n)^n < e\` for all \`n ≥ 1\` (the \`x = 1\` slice).
- \`two_le_add_inv_pow\`: Bernoulli lower companion \`2 ≤ (1 + 1/n)^n\`.
- \`add_inv_pow_bounds\`: two-sided \`2 ≤ (1 + 1/n)^n < e\`.

## Proof

Entirely elementary — no logarithms, derivatives, or MVT (unlike the parent's monotonicity proof). Since \`x/n ≠ 0\`, the strict tangent inequality \`1 + x/n < exp(x/n)\` (\`Real.add_one_lt_exp\`) holds; raising both nonnegative sides to the \`n\`-th power with \`pow_lt_pow_left₀\` preserves strictness, and \`Real.exp_nat_mul\` collapses \`(exp(x/n))^n = exp(x)\`.

## Verification

- 4 theorems, 84 lines, **0 sorries, 0 axioms**.
- \`#print axioms\` on all four: only \`propext\`, \`Classical.choice\`, \`Quot.sound\`.
- Builds clean under \`lake env lean\` / \`lake build Proofs.BinomialTheoremOQ03OQ02OQ03OQ01\` (Mathlib 4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)