### PR TITLE
Enrich gallery entries: add annotations.json (Thomae/Baire, Tower Law)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-06/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-06/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "context",
+    "title": "The Tower Law for Subgroup Indices",
+    "content": "For a tower of subgroups $K \\le H \\le G$, the index is multiplicative: $[G:K] = [G:H]\\cdot[H:K]$, where $[H:K]$ is the *relative index* `K.relIndex H`. This is the index-theoretic refinement of Lagrange's theorem. Crucially it is stronger than the finite divisibility statement $|H| \\mid |G|$: by interpreting $[G:K] = \\mathrm{Nat.card}(G/K)$ as $0$ when the quotient is infinite, the identity holds in an **arbitrary, possibly infinite group**. Taking $K = \\bot$ recovers the classical $|G| = [G:H]\\cdot|H|$. The coset-bijection analytic content is delegated to Mathlib (`relIndex_mul_index`, `relIndex_mul_relIndex`); the contribution is packaging the law in standard index notation with its divisibility corollaries, a three-step chain rule, and the Lagrange specialisation.",
+    "mathContext": "$[G:K] = [G:H]\\cdot[H:K]$ for $K \\le H \\le G$, with $[G:K] = \\mathrm{Nat.card}(G/K)$ ($=0$ if infinite). $K=\\bot$ gives $|G| = [G:H]\\,|H|$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "subgroup index",
+      "relative index",
+      "coset decomposition"
+    ],
+    "prerequisites": [
+      "subgroups and cosets",
+      "index of a subgroup",
+      "quotient groups"
+    ]
+  },
+  {
+    "id": "ann-tower-law",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 42,
+      "endLine": 52
+    },
+    "type": "insight",
+    "title": "The Tower Law and its Relative Form",
+    "content": "`index_tower` states the core law $[G:K] = [G:H]\\cdot[H:K]$ for $K \\le H$, obtained by reorienting Mathlib's `relIndex_mul_index` (which gives $[H:K]\\cdot[G:H] = [G:K]$) via `mul_comm`. `relIndex_tower` is the fully relative version: for $K \\le H \\le L$, $[L:K] = [L:H]\\cdot[H:K]$, from `relIndex_mul_relIndex`. The relative form is the genuinely general statement — `index_tower` is its $L = \\top$ case — and is what makes iteration to longer towers immediate. Both reduce to a single Mathlib lemma plus commutativity, reflecting that the real work (the coset bijection $G/K \\cong (G/H) \\times (H/K)$) is already in the library.",
+    "mathContext": "$[G:K] = [G:H]\\cdot[H:K]$; relative: $[L:K] = [L:H]\\cdot[H:K]$ for $K \\le H \\le L$. Underlying bijection $G/K \\cong (G/H)\\times(H/K)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Subgroup.relIndex_mul_index",
+      "Subgroup.relIndex_mul_relIndex",
+      "coset bijection",
+      "multiplicativity of index"
+    ],
+    "prerequisites": [
+      "relative index",
+      "Mathlib subgroup index API"
+    ]
+  },
+  {
+    "id": "ann-divisibility",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 58,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "Divisibility Corollaries: Each Factor Divides the Total",
+    "content": "`index_dvd_tower` ($[G:H] \\mid [G:K]$) and `relIndex_dvd_tower` ($[H:K] \\mid [G:K]$) record that both factors of the tower law divide the total index — immediate consequences of the multiplicative identity. The larger subgroup $H$ has the smaller index, and that index divides the index of the contained $K$. These divisibilities are the index-theoretic generalisation of Lagrange's $|H| \\mid |G|$, valid even when the groups are infinite (where the statement becomes about the cardinal-zero convention).",
+    "mathContext": "$[G:H] \\mid [G:K]$ and $[H:K] \\mid [G:K]$ for $K \\le H$, since $[G:K] = [G:H]\\cdot[H:K]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "index_dvd_of_le",
+      "divisibility of indices",
+      "Lagrange divisibility"
+    ],
+    "prerequisites": [
+      "the tower law",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-chain-rule",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 73,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "The Three-Step Chain Rule",
+    "content": "`index_tower_three` iterates the law over a three-step tower $K_1 \\le K_2 \\le K_3 \\le G$: $[G:K_1] = [G:K_3]\\cdot[K_3:K_2]\\cdot[K_2:K_1]$. The proof applies `index_tower` to split off $[G:K_3]$ from $[K_3:K_1]$, then `relIndex_tower` to split the latter into $[K_3:K_2]\\cdot[K_2:K_1]$. This telescoping pattern extends to towers of any length and is the index analogue of the field-extension tower law $[E:F] = [E:K][K:F]$.",
+    "mathContext": "$[G:K_1] = [G:K_3]\\cdot[K_3:K_2]\\cdot[K_2:K_1]$ for $K_1 \\le K_2 \\le K_3 \\le G$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "iterated tower law",
+      "telescoping product",
+      "field extension tower law"
+    ],
+    "prerequisites": [
+      "index_tower",
+      "relIndex_tower"
+    ]
+  },
+  {
+    "id": "ann-lagrange",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 85,
+      "endLine": 96
+    },
+    "type": "concept",
+    "title": "Lagrange's Theorem as the K = ⊥ Specialisation",
+    "content": "`lagrange_from_tower` recovers the classical $|G| = [G:H]\\cdot|H|$ as the $K = \\bot$ case of the tower law, using $[G:\\bot] = |G|$ (`index_bot`) and $[H:\\bot] = |H|$ (`relIndex_bot_left`). `lagrange_index_form` confirms this agrees with Mathlib's existing `index_mul_card`. This exhibits Lagrange's theorem not as a standalone result but as one instance of a uniform family — the degenerate endpoint of the multiplicative index law.",
+    "mathContext": "$K = \\bot$: $[G:\\bot] = |G|$, $[H:\\bot] = |H|$, so the tower law becomes $|G| = [G:H]\\cdot|H|$ — Lagrange's theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "index_bot",
+      "Subgroup.index_mul_card",
+      "trivial subgroup"
+    ],
+    "prerequisites": [
+      "the tower law",
+      "index of the trivial subgroup"
+    ]
+  },
+  {
+    "id": "ann-degenerate",
+    "proofId": "lagrange-theorem-oq-06",
+    "range": {
+      "startLine": 103,
+      "endLine": 111
+    },
+    "type": "context",
+    "title": "Degenerate Endpoints",
+    "content": "Two consistency checks at the boundary. `relIndex_top_eq_index`: taking $H = \\top$ (the whole group) gives $[\\top:K] = [G:K]$, so the relative index over the top group is just the absolute index. `tower_self`: at $K = H$ the self-index $[H:H] = 1$ makes the tower law degenerate correctly to $[G:H] = [G:H]\\cdot 1$. These confirm the law behaves sensibly at both ends of a tower.",
+    "mathContext": "$[\\top:K] = [G:K]$; $[H:H] = 1$ so $[G:H] = [G:H]\\cdot[H:H]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "relIndex_top_right",
+      "self-index",
+      "boundary cases"
+    ],
+    "prerequisites": [
+      "the tower law",
+      "relIndex_self"
+    ]
+  }
+]

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 53
+    },
+    "type": "context",
+    "title": "Thomae's Function and the Baire-Category Dual of 'ℚ is Small'",
+    "content": "Thomae's (popcorn) function is continuous exactly at the irrationals and discontinuous exactly at the rationals. The measure-theoretic parent showed the discontinuity set ℚ is **null** (Lebesgue's criterion). This entry records the **Baire-category dual**: the continuity set (the irrationals) is a **dense Gδ**, hence comeagre/residual, while the discontinuity set ℚ is **meagre** and — sharply — **not** a Gδ. The punchline is an impossibility theorem: since the continuity set of *any* $f : \\mathbb{R} \\to \\mathbb{R}$ is a Gδ but ℚ is not, **no function is continuous exactly at the rationals**. Thomae's irrational-continuity therefore cannot be mirrored — the rational version is forbidden by topology itself.",
+    "mathContext": "Continuity set $= \\{x : \\text{Irrational } x\\}$, a dense Gδ (residual). Discontinuity set $= \\mathbb{Q}$, meagre and not Gδ. No $f$ is continuous exactly on ℚ.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Thomae's function",
+      "Baire category theorem",
+      "Gδ set",
+      "meagre / residual sets"
+    ],
+    "prerequisites": [
+      "continuity",
+      "rationals vs irrationals",
+      "Baire category"
+    ]
+  },
+  {
+    "id": "ann-discontinuous-at-rat",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 99
+    },
+    "type": "technique",
+    "title": "Discontinuity at Every Rational via an Irrational Sequence",
+    "content": "`thomae_discontinuous_at_rat` completes the sharp characterization by handling the rational direction the base module left open. The witness is the sequence $y_n = r + \\sqrt2/(n+1) \\to r$, which is irrational at every $n$ (sum of a rational and the irrational $\\sqrt2/(n+1)$). If Thomae were continuous at $r$, composing with $y_n$ would force $\\mathrm{thomae}(y_n) \\to \\mathrm{thomae}(r)$; but $\\mathrm{thomae}(y_n) = 0$ for all $n$ (Thomae vanishes on irrationals), so uniqueness of limits gives $\\mathrm{thomae}(r) = 0$, contradicting $\\mathrm{thomae}(r) = 1/r.\\mathrm{den} > 0$. The irrational approach sequence is the standard device for proving discontinuity at rationals.",
+    "mathContext": "$y_n = r + \\sqrt2/(n+1) \\to r$, all irrational; $\\mathrm{thomae}(y_n)=0 \\not\\to 1/r.\\mathrm{den} = \\mathrm{thomae}(r) > 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sequential continuity",
+      "irrational approximation",
+      "tendsto_nhds_unique",
+      "irrational_add_ratCast_iff"
+    ],
+    "prerequisites": [
+      "continuity via sequences",
+      "uniqueness of limits",
+      "irrationality of √2"
+    ]
+  },
+  {
+    "id": "ann-continuous-iff",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 101,
+      "endLine": 109
+    },
+    "type": "concept",
+    "title": "The Sharp Characterization: Continuous ⟺ Irrational",
+    "content": "`thomae_continuous_iff` assembles the two directions into the exact statement $\\mathrm{ContinuousAt\\ thomae}\\ x \\iff \\mathrm{Irrational}\\ x$. The hard direction (continuity at irrationals) is imported from the base module; the easy direction is the contrapositive of `thomae_discontinuous_at_rat`. This biconditional is the pivot on which the entire Baire-category development turns — every subsequent set-level statement is obtained by rewriting the continuity set as the irrationals through this lemma.",
+    "mathContext": "$\\mathrm{ContinuousAt}\\ \\mathrm{thomae}\\ x \\iff \\mathrm{Irrational}\\ x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "biconditional characterization",
+      "thomae_continuous_at_irrational",
+      "contrapositive"
+    ],
+    "prerequisites": [
+      "thomae_discontinuous_at_rat",
+      "continuity at irrationals"
+    ]
+  },
+  {
+    "id": "ann-meagre-infra",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 118,
+      "endLine": 139
+    },
+    "type": "technique",
+    "title": "Baire Infrastructure: Countable Sets Are Meagre",
+    "content": "Three reusable lemmas establish that countable sets are meagre in a perfect $T_1$ space (like $\\mathbb{R}$). `isMeagre_of_isNowhereDense`: a single nowhere-dense set is meagre (cover it by the one-element family $\\{t\\}$). `isNowhereDense_singleton`: in a perfect $T_1$ space a singleton is nowhere dense — it is closed and has empty interior because no point is isolated (`PerfectSpace`). `countable_isMeagre`: a countable set is a countable union of such nowhere-dense singletons, hence meagre (`isMeagre_iUnion`). The `PerfectSpace` hypothesis is essential — it is what rules out isolated points and makes singletons nowhere dense.",
+    "mathContext": "Perfect $T_1$ space: singletons are nowhere dense (closed, empty interior); a countable union of nowhere-dense sets is meagre.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nowhere dense",
+      "PerfectSpace",
+      "isMeagre_iUnion",
+      "first category"
+    ],
+    "prerequisites": [
+      "meagre sets",
+      "nowhere-dense sets",
+      "perfect spaces (no isolated points)"
+    ]
+  },
+  {
+    "id": "ann-continuity-set-dense-gdelta",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 165
+    },
+    "type": "insight",
+    "title": "The Continuity Set Is a Dense Gδ (Comeagre)",
+    "content": "The headline positive results: the continuity set of Thomae equals the irrationals (`thomae_continuitySet_eq_irrational`), which is a Gδ (`IsGδ.setOf_irrational` — the complement of the countable ℚ), is dense (`dense_irrational`), and is therefore **residual/comeagre** in the Baire space $\\mathbb{R}$ (`residual_of_dense_Gδ`). 'Comeagre' is the topological sense in which Thomae is continuous at *almost every* point — the category-theoretic counterpart to the measure-theoretic 'continuous almost everywhere'. The two notions of 'ℚ is negligible' (null and meagre) here coincide, but in general they are independent.",
+    "mathContext": "Irrationals $= \\mathbb{R} \\setminus \\mathbb{Q}$: a dense Gδ, hence residual (comeagre) by the Baire category theorem.",
+    "significance": "key",
+    "relatedConcepts": [
+      "dense Gδ",
+      "residual set",
+      "IsGδ.setOf_irrational",
+      "comeagre"
+    ],
+    "prerequisites": [
+      "thomae_continuous_iff",
+      "irrationals are a dense Gδ",
+      "Baire space"
+    ]
+  },
+  {
+    "id": "ann-discontinuity-meagre",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 169,
+      "endLine": 182
+    },
+    "type": "concept",
+    "title": "The Discontinuity Set Is Exactly ℚ, and Meagre",
+    "content": "`thomae_discontinuitySet_eq_rat` identifies the discontinuity set with $\\mathrm{range}\\ \\mathbb{Q}$ — using that `Irrational x` is definitionally $x \\notin \\mathrm{range}\\ \\mathbb{Q}$, so $\\neg\\,\\mathrm{Irrational}\\ x \\iff x \\in \\mathrm{range}\\ \\mathbb{Q}$ by `not_not`. `thomae_discontinuitySet_isMeagre` then concludes meagreness directly from `countable_isMeagre`, since ℚ is countable. This is the negative-side counterpart to the dense-Gδ continuity set.",
+    "mathContext": "$\\{x : \\neg\\mathrm{ContinuousAt\\ thomae}\\ x\\} = \\mathrm{range}\\ \\mathbb{Q}$, countable, hence meagre.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "meagre set",
+      "countability of ℚ",
+      "range of the rational cast"
+    ],
+    "prerequisites": [
+      "countable_isMeagre",
+      "thomae_continuous_iff"
+    ]
+  },
+  {
+    "id": "ann-impossibility",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 186,
+      "endLine": 214
+    },
+    "type": "insight",
+    "title": "The Impossibility Theorem: No Function Is Continuous Exactly on ℚ",
+    "content": "The capstone. `not_isGδ_range_rat`: ℚ is not a Gδ — if it were, being dense it would be a dense Gδ and thus non-meagre by Baire (`not_isMeagre_of_isGδ_of_dense`), contradicting its meagreness as a countable set. Hence `thomae_discontinuitySet_not_isGδ`, the sharp asymmetry: the discontinuity set is not Gδ even though the continuity set is. Most strikingly, `no_continuousAt_setOf_eq_rat` proves **no** $f : \\mathbb{R} \\to \\mathbb{R}$ can be continuous exactly at the rationals, because the continuity set of any function is a Gδ (`IsGδ.setOf_continuousAt`) while ℚ is not. `thomae_realizes_irrational_continuitySet` closes the loop: Thomae *realises* the irrationals as a continuity set precisely because they are Gδ — the mirror image is topologically forbidden.",
+    "mathContext": "Continuity set of any $f$ is Gδ; ℚ is dense + meagre $\\Rightarrow$ ℚ not Gδ $\\Rightarrow$ no $f$ continuous exactly on ℚ.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsGδ.setOf_continuousAt",
+      "Baire category theorem",
+      "impossibility theorem",
+      "dense Gδ non-meagre"
+    ],
+    "prerequisites": [
+      "continuity set is always Gδ",
+      "ℚ is meagre and dense",
+      "Baire category"
+    ]
+  }
+]


### PR DESCRIPTION
Adds the missing inline annotation layer to two gallery entries that shipped with rich meta.json but no annotations.json.

| Entry | Topic | Annotations |
|---|---|---|
| lebesgue-measure-oq-01-oq-01-oq-02-oq-02 | Thomae's function & Baire category (continuity set is a dense Gδ) | 7 |
| lagrange-theorem-oq-06 | The Tower Law for subgroup indices | 6 |

Each annotation covers one Lean construct group and carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All line ranges validate against the Lean source (resolver: 0 misaligned). meta.json integrity unchanged (both verified / 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)