### PR TITLE
research(bernoulli-inequality-oq-01-oq-01-oq-01): sharp left endpoint of strict Bernoulli [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ01.lean
@@ -1,0 +1,189 @@
+import Mathlib
+
+/-
+# Sharp Left Endpoint of the Strict Bernoulli Inequality
+
+**Open question (bernoulli-inequality-oq-01-oq-01).** The parent entry
+`bernoulli-inequality-oq-01-oq-01` (`BernoulliInequalityOQ01OQ01.lean`) proved the
+*strict* Bernoulli inequality `1 + n·a < (1 + a)ⁿ` on the entire weak domain
+`-2 ≤ a` (for `a ≠ 0`, `n ≥ 2`), matching the reach of Mathlib's
+`one_add_mul_le_pow`. It closed by asking:
+
+> *Is `-2` the true left endpoint of the strict inequality for fixed `n`, or does
+> the admissible range depend on `n` (e.g. does some `n` admit `a < -2`)?*
+
+**Answer: `-2` is NOT the left endpoint for any fixed `n`; the admissible range
+depends on the parity of `n`.** This file proves the four facts that pin it down.
+
+* `strict_even` — for **even** `n ≥ 2` and every `a ≠ 0`, `1 + n·a < (1 + a)ⁿ`.
+  There is *no* left endpoint at all: when `a < -1` the right side is a positive
+  even power while the left side is negative.
+* `cubic_iff` — for `n = 3` the strict inequality holds **iff** `a ≠ 0 ∧ -3 < a`,
+  because `(1+a)³ - (1+3a) = a²(a+3)`. The left endpoint is exactly `-3`, strictly
+  below `-2`.
+* `exists_lt_neg_two_strict` — consequently some `n` (e.g. `n = 3`, `a = -5/2`)
+  *does* admit `a < -2`, answering the parenthetical sub-question affirmatively.
+* `sharp_uniform` — `-2` is nonetheless sharp as the **uniform** (`n`-independent)
+  left endpoint: `(∀ n, 1 + n·a ≤ (1 + a)ⁿ) ↔ -2 ≤ a`. The forward direction is
+  Mathlib's `one_add_mul_le_pow`; the reverse direction shows that for every
+  `a < -2` some *odd* exponent violates the inequality, via a second-order
+  (quadratic) Bernoulli lower bound proved here as `quad_bernoulli`.
+
+**Why parity is the whole story.** For even `n`, `(1+a)ⁿ ≥ 0` everywhere, so the
+inequality is automatic once `1 + n·a < 0` (i.e. `a < -1`). For odd `n`, `(1+a)ⁿ`
+turns negative for `a < -1` and, being a degree-`n` power, eventually outruns the
+line `1 + n·a` downward — but only past a finite endpoint `a_n^* < -2` that creeps
+up toward `-2` as `n → ∞` (e.g. `a_3^* = -3`). Thus `-2 = sup_n a_n^*` is approached
+but never attained by any single `n`, which is exactly why it is the sharp uniform
+bound while being the endpoint of *no* individual `n`.
+
+This complements Mathlib (`one_add_mul_le_pow`, weak, `-2 ≤ a`) and the parent
+(strict, `-2 ≤ a`): neither addresses the per-`n` admissible range or the
+sharpness/optimality of the constant `-2`.
+-/
+
+namespace BernoulliInequalityOQ01OQ01OQ01
+
+variable {a x : ℝ}
+
+/-- Strict Bernoulli on the positive-factor range `a > -1`, by the standard
+`Nat.le_induction` (the inductive estimate is multiplied by `1 + a > 0`). Re-proved
+here to keep the file self-contained. -/
+theorem strict_pos (ha : -1 < a) (ha0 : a ≠ 0) :
+    ∀ {n : ℕ}, 2 ≤ n → 1 + (n : ℝ) * a < (1 + a) ^ n := by
+  have h1a : (0 : ℝ) < 1 + a := by linarith
+  have ha2 : (0 : ℝ) < a ^ 2 := by positivity
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base => push_cast; nlinarith [ha2]
+  | succ m hm ih =>
+      have hmpos : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast Nat.one_le_of_lt hm
+      have step : (1 + (m : ℝ) * a) * (1 + a) < (1 + a) ^ m * (1 + a) :=
+        mul_lt_mul_of_pos_right ih h1a
+      have hexp : 1 + ((m : ℝ) + 1) * a < (1 + (m : ℝ) * a) * (1 + a) := by
+        nlinarith [ha2, hmpos]
+      push_cast
+      calc 1 + ((m : ℝ) + 1) * a
+            < (1 + (m : ℝ) * a) * (1 + a) := hexp
+        _ < (1 + a) ^ m * (1 + a) := step
+        _ = (1 + a) ^ (m + 1) := by ring
+
+/-- **Even exponents have no left endpoint.** For every even `n ≥ 2` and every
+`a ≠ 0`, the strict Bernoulli inequality holds — even far below `-2`. For `a < -1`
+the right-hand side is a positive even power while the left-hand side is negative. -/
+theorem strict_even {n : ℕ} (hn : Even n) (hn2 : 2 ≤ n) (ha0 : a ≠ 0) :
+    1 + (n : ℝ) * a < (1 + a) ^ n := by
+  rcases lt_or_ge a (-1) with hlt | hge
+  · -- `a < -1`: `(1+a)ⁿ > 0` (even power, nonzero base) while `1 + n·a < 0`.
+    have hb : (1 + a) ≠ 0 := by intro h; linarith
+    have hpos : 0 < (1 + a) ^ n := hn.pow_pos hb
+    have hnr : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn2
+    have hna : (n : ℝ) * a ≤ -(n : ℝ) := by
+      have := mul_le_mul_of_nonneg_left hlt.le (Nat.cast_nonneg n : (0 : ℝ) ≤ n)
+      linarith [this]
+    have : 1 + (n : ℝ) * a < 0 := by linarith
+    linarith
+  · rcases eq_or_lt_of_le hge with heq | hgt
+    · -- `a = -1`: `(1+a)ⁿ = 0` while `1 + n·a = 1 - n ≤ -1`.
+      have hae : a = -1 := heq.symm
+      subst hae
+      have hnr : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn2
+      rw [show (1 : ℝ) + -1 = 0 by norm_num, zero_pow (show n ≠ 0 by omega)]
+      linarith
+    · exact strict_pos hgt ha0 hn2
+
+/-- **The cubic case has left endpoint exactly `-3`.** For `n = 3`, strict Bernoulli
+holds **iff** `a ≠ 0 ∧ -3 < a`, since `(1+a)³ - (1+3a) = a²(a+3)`. In particular the
+endpoint `-3` is strictly below `-2`. -/
+theorem cubic_iff : 1 + 3 * a < (1 + a) ^ 3 ↔ a ≠ 0 ∧ -3 < a := by
+  have hid : (1 + a) ^ 3 - (1 + 3 * a) = a ^ 2 * (a + 3) := by ring
+  constructor
+  · intro h
+    have key : 0 < a ^ 2 * (a + 3) := by linarith [hid]
+    refine ⟨?_, ?_⟩
+    · rintro rfl; norm_num at h
+    · nlinarith [sq_nonneg a, key]
+  · rintro ⟨ha0, ha3⟩
+    have ha2 : 0 < a ^ 2 := by positivity
+    have : 0 < a ^ 2 * (a + 3) := mul_pos ha2 (by linarith)
+    linarith [hid]
+
+/-- **Some exponent admits `a < -2`.** Concretely `n = 3`, `a = -5/2`: this answers
+the parenthetical sub-question of the open problem affirmatively. -/
+theorem exists_lt_neg_two_strict :
+    ∃ (a : ℝ) (n : ℕ), a < -2 ∧ 1 + (n : ℝ) * a < (1 + a) ^ n := by
+  refine ⟨-5 / 2, 3, by norm_num, ?_⟩
+  push_cast; norm_num
+
+/-- **Second-order (quadratic) Bernoulli bound.** For `x ≥ 0` and every `n`,
+`1 + n·x + C(n,2)·x² ≤ (1 + x)ⁿ`. The quadratic term is what lets a power beat a
+line; the first-order bound `one_add_mul_le_pow` is too weak for the sharpness
+argument below. -/
+theorem quad_bernoulli (hx : 0 ≤ x) (n : ℕ) :
+    1 + (n : ℝ) * x + ((n : ℝ) * ((n : ℝ) - 1) / 2) * x ^ 2 ≤ (1 + x) ^ n := by
+  induction n with
+  | zero => norm_num
+  | succ k ih =>
+      have h1x : (0 : ℝ) ≤ 1 + x := by linarith
+      have hstep := mul_le_mul_of_nonneg_right ih h1x
+      have hkk : (0 : ℝ) ≤ (k : ℝ) * ((k : ℝ) - 1) := by
+        rcases Nat.eq_zero_or_pos k with hk | hk
+        · simp [hk]
+        · have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+          nlinarith
+      have hx3 : (0 : ℝ) ≤ ((k : ℝ) * ((k : ℝ) - 1) / 2) * x ^ 3 :=
+        mul_nonneg (by linarith) (pow_nonneg hx 3)
+      rw [pow_succ (1 + x) k]
+      push_cast
+      nlinarith [hstep, hx3]
+
+/-- **`-2` is the sharp uniform left endpoint.** Bernoulli's inequality holds for
+*every* exponent simultaneously exactly on `-2 ≤ a`:
+`(∀ n, 1 + n·a ≤ (1 + a)ⁿ) ↔ -2 ≤ a`. The forward direction is Mathlib's
+`one_add_mul_le_pow`; the reverse shows every `a < -2` is violated by some odd
+exponent, using the quadratic Bernoulli bound to make a power outrun the line. -/
+theorem sharp_uniform :
+    (∀ n : ℕ, 1 + (n : ℝ) * a ≤ (1 + a) ^ n) ↔ -2 ≤ a := by
+  constructor
+  · intro h
+    by_contra hlt
+    push_neg at hlt
+    -- `hlt : a < -2`.  Set `s = -(1+a) > 1`, `c = s - 1 > 0`.
+    set s : ℝ := -1 - a with hs
+    have hs1 : 1 < s := by rw [hs]; linarith
+    set c : ℝ := s - 1 with hc
+    have hc0 : 0 < c := by rw [hc]; linarith
+    have hc2 : 0 < c ^ 2 := pow_pos hc0 2
+    have h4c : 0 < 4 / c ^ 2 := div_pos (by norm_num) hc2
+    obtain ⟨N, hN⟩ := exists_nat_gt (4 / c ^ 2)
+    have hNpos : 0 < N := by
+      have : (0 : ℝ) < (N : ℝ) := lt_trans h4c hN
+      exact_mod_cast this
+    set n : ℕ := 2 * N + 1 with hn
+    have hodd : Odd n := ⟨N, by omega⟩
+    have hn3 : 3 ≤ n := by omega
+    have hn3r : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn3
+    -- `4 < n · c²`.
+    have hNn : (N : ℝ) ≤ (n : ℝ) := by exact_mod_cast (show N ≤ n by omega)
+    have hnN : 4 / c ^ 2 < (n : ℝ) := by linarith
+    have hnc : (4 : ℝ) < (n : ℝ) * c ^ 2 := (div_lt_iff₀ hc2).mp hnN
+    -- Quadratic Bernoulli bound, transported to `s = 1 + c`.
+    have hsc : s = 1 + c := by rw [hc]; ring
+    have hb : 1 + (n : ℝ) * c + ((n : ℝ) * ((n : ℝ) - 1) / 2) * c ^ 2 ≤ s ^ n := by
+      have := quad_bernoulli hc0.le n
+      rwa [← hsc] at this
+    have hns : (n : ℝ) * s = (n : ℝ) * (1 + c) := by rw [hsc]
+    have hfac : 0 < ((n : ℝ) - 1) * ((n : ℝ) * c ^ 2 - 4) :=
+      mul_pos (by linarith) (by linarith)
+    have hsn : (n : ℝ) * s + (n : ℝ) - 1 < s ^ n := by nlinarith [hb, hns, hfac]
+    -- Evaluate at the odd exponent and derive the contradiction.
+    have hbase : (1 + a) = -s := by rw [hs]; ring
+    have hop : (1 + a) ^ n = -(s ^ n) := by rw [hbase, hodd.neg_pow]
+    have hla : 1 + (n : ℝ) * a = 1 - (n : ℝ) - (n : ℝ) * s := by rw [hs]; ring
+    have hcontra := h n
+    rw [hop, hla] at hcontra
+    linarith [hsn, hcontra]
+  · intro ha n
+    exact one_add_mul_le_pow ha n
+
+end BernoulliInequalityOQ01OQ01OQ01

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-01-oq-01",
+  "title": "Sharp Left Endpoint of the Strict Bernoulli Inequality",
+  "slug": "bernoulli-inequality-oq-01-oq-01-oq-01",
+  "description": "The parent entry established the strict Bernoulli inequality 1 + n·a < (1 + a)ⁿ on Mathlib's full weak domain −2 ≤ a and asked whether −2 is the true left endpoint for a fixed exponent n, or whether the admissible range depends on n. The answer is that −2 is the endpoint of NO fixed n: the admissible range is governed by the parity of n. For even n the inequality holds for every a ≠ 0 (no left endpoint at all, since (1+a)ⁿ ≥ 0 while 1 + n·a < 0 once a < −1); for n = 3 it holds iff a ≠ 0 ∧ −3 < a, so the endpoint is exactly −3 < −2; hence some n admit a < −2. Yet −2 remains sharp as the uniform (n-independent) left endpoint: 1 + n·a ≤ (1 + a)ⁿ holds for ALL n iff −2 ≤ a, the reverse direction proved via a second-order Bernoulli bound that makes an odd-exponent power outrun the line for every a < −2.",
+  "meta": {
+    "author": "Jacob Bernoulli (1689); per-exponent endpoint analysis and sharpness of the constant −2",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "1689",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "strict-inequality",
+      "sharp-constant",
+      "parity",
+      "binomial-bound",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "one_add_mul_le_pow",
+        "description": "Weak Bernoulli inequality for ℕ-powers: −2 ≤ a ⟹ 1 + n·a ≤ (1+a)ⁿ. Supplies the forward (⇐) direction of the uniform sharpness characterization sharp_uniform.",
+        "module": "Mathlib.Algebra.Order.Ring.Pow"
+      },
+      {
+        "theorem": "Odd.neg_pow",
+        "description": "For odd n, (−s)ⁿ = −(sⁿ). Used to evaluate (1+a)ⁿ = −(sⁿ) at the odd violating exponent in the reverse direction of sharp_uniform.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Even.pow_pos",
+        "description": "For even n and nonzero base, 0 < baseⁿ. Gives (1+a)ⁿ > 0 for a < −1 in strict_even, where 1 + n·a is already negative.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "exists_nat_gt",
+        "description": "Archimedean property: every real is below some natural number. Produces the threshold N with 4/c² < N, from which the odd violating exponent n = 2N+1 is built.",
+        "module": "Mathlib.Algebra.Order.Archimedean.Basic"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "Strict monotonicity of multiplication by a positive constant; drives the a > −1 induction in strict_pos.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "strict_even: for every even n ≥ 2 and every a ≠ 0, 1 + n·a < (1 + a)ⁿ — there is NO left endpoint for even exponents, since for a < −1 the right side is a positive even power while the left side is negative",
+      "cubic_iff: for n = 3 the strict inequality holds iff a ≠ 0 ∧ −3 < a, from the factorization (1+a)³ − (1+3a) = a²(a+3); the left endpoint is exactly −3, strictly below −2",
+      "exists_lt_neg_two_strict: an explicit witness (n = 3, a = −5/2) showing some exponents admit a < −2, answering the open question's parenthetical sub-question affirmatively",
+      "quad_bernoulli: the second-order Bernoulli lower bound 1 + n·x + C(n,2)·x² ≤ (1 + x)ⁿ for x ≥ 0 — the quadratic term is what lets a power eventually outrun the line 1 + n·a, which the first-order one_add_mul_le_pow cannot",
+      "sharp_uniform: the constant −2 is the sharp uniform (n-independent) left endpoint — (∀ n, 1 + n·a ≤ (1 + a)ⁿ) ↔ −2 ≤ a; for any a < −2, the odd exponent n = 2N+1 with N > 4/(−2−a)² violates it"
+    ],
+    "dateAdded": "2026-06-24",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 189,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (every theorem depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Bernoulli's inequality $1 + na \\le (1+a)^n$ (Jacob Bernoulli, 1689) is usually stated for $a \\ge -1$, but Mathlib's `one_add_mul_le_pow` proves the weak form on the larger domain $-2 \\le a$, and the parent gallery entry sharpened it to the strict inequality on that same domain. The natural next question is whether $-2$ is forced: is it the genuine left endpoint of strictness for each fixed exponent $n$, or merely a convenient bound that happens to work for all $n$ at once?",
+    "problemStatement": "**Open Question (OQ-01-OQ-01-OQ-01):** Is $-2$ the true left endpoint of the strict inequality $1 + na < (1+a)^n$ for a fixed $n$, or does the admissible range depend on $n$ — e.g. does some $n$ admit $a < -2$?\n\n**Answer:** $-2$ is the left endpoint of *no* fixed $n$. The admissible range is controlled by the parity of $n$: for even $n$ the strict inequality holds for **every** $a \\ne 0$ (no left endpoint); for $n = 3$ it holds iff $a \\ne 0 \\wedge -3 < a$, so the endpoint is exactly $-3 < -2$; consequently some exponents admit $a < -2$. Nevertheless $-2$ is sharp as the **uniform** endpoint: $1 + na \\le (1+a)^n$ holds for *all* $n$ if and only if $-2 \\le a$.",
+    "text": "The parent proved strict Bernoulli on the whole weak domain −2 ≤ a; this entry asks whether −2 is actually forced for any single exponent. It is not. Even exponents make (1+a)ⁿ a nonnegative quantity, so the inequality is automatic the moment 1 + n·a turns negative (a < −1) — no lower restriction survives. Odd exponents do have a finite left endpoint, but it lies strictly below −2: for n = 3 the difference factors as a²(a+3), giving the exact endpoint −3. The constant −2 reappears only as the supremum of these per-exponent endpoints — the unique cutoff below which SOME exponent eventually fails — which is exactly the content of the uniform characterization.",
+    "proofStrategy": "1. **Even exponents** (`strict_even`): split on $a$ versus $-1$. For $a > -1$ use the parent's induction (`strict_pos`). At $a = -1$ the power is $0$ while $1 + na = 1 - n < 0$. For $a < -1$, evenness gives $(1+a)^n > 0$ (via `Even.pow_pos`) while $a < -1$ forces $1 + na < 0$ — so the inequality holds with room to spare, for every $a \\ne 0$.\n2. **The cubic** (`cubic_iff`): the identity $(1+a)^3 - (1+3a) = a^2(a+3)$ makes the sign analysis immediate — strictness $\\Leftrightarrow a \\ne 0 \\wedge a + 3 > 0$.\n3. **Witness below $-2$** (`exists_lt_neg_two_strict`): $n = 3,\\ a = -5/2$.\n4. **Quadratic Bernoulli** (`quad_bernoulli`): induction gives $1 + nx + \\binom{n}{2}x^2 \\le (1+x)^n$ for $x \\ge 0$; the inductive step multiplies by $1+x \\ge 0$ and discards a nonnegative cubic remainder.\n5. **Uniform sharpness** (`sharp_uniform`): the $\\Leftarrow$ direction is `one_add_mul_le_pow`. For $\\Rightarrow$, given $a < -2$ set $s = -(1+a) > 1$, $c = s - 1 > 0$; pick $N > 4/c^2$ and the odd exponent $n = 2N+1$. The quadratic bound gives $s^n > ns + n - 1$, and since $n$ is odd $(1+a)^n = -s^n < 1 + na$, contradicting the assumed inequality at $n$.",
+    "keyInsights": [
+      "**Parity, not the value of $a$, is decisive.** Even exponents render $(1+a)^n$ nonnegative everywhere, so they impose no left endpoint; only odd exponents can fail, and they fail only far enough left.",
+      "**The per-exponent endpoints sit strictly below $-2$ and rise toward it.** For $n = 3$ the endpoint is $-3$; as the exponent grows the endpoint creeps up toward $-2$ but never reaches it — so $-2 = \\sup_n a_n^\\*$ is attained by no single $n$.",
+      "**$-2$ is a uniform, not a pointwise, phenomenon.** It is exactly the threshold below which *some* exponent eventually violates Bernoulli; that is the precise sense in which the parent's domain $-2 \\le a$ is sharp.",
+      "**A power beats a line only at second order.** The first-order bound $1 + na$ is precisely what Bernoulli compares against, so refuting it requires the quadratic term $\\binom{n}{2}x^2$ — the first-order `one_add_mul_le_pow` is structurally too weak to produce the violating exponent."
+    ],
+    "prerequisites": [
+      "The weak Bernoulli inequality one_add_mul_le_pow on −2 ≤ a",
+      "Sign of even versus odd integer powers (Even.pow_pos, Odd.neg_pow)",
+      "The Archimedean property (exists_nat_gt) to build the violating exponent",
+      "Induction for the second-order binomial lower bound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pos-range",
+      "title": "Positive-Factor Range a > −1",
+      "startLine": 52,
+      "endLine": 69,
+      "summary": "Re-proves strict Bernoulli for a > −1 by induction from n = 2, multiplying the hypothesis by 1 + a > 0; reused by the even-exponent case.",
+      "mathContext": "Strict 1 + n·a < (1+a)ⁿ for a > −1, a ≠ 0, n ≥ 2 via Nat.le_induction."
+    },
+    {
+      "id": "even-no-endpoint",
+      "title": "Even Exponents Have No Left Endpoint",
+      "startLine": 74,
+      "endLine": 93,
+      "summary": "For even n ≥ 2 and every a ≠ 0, the strict inequality holds. For a < −1 the right side (1+a)ⁿ > 0 (even power, nonzero base) while 1 + n·a < 0; a = −1 and a > −1 are handled directly.",
+      "mathContext": "Even n ≥ 2, a ≠ 0 ⟹ 1 + n·a < (1+a)ⁿ — admissible range is all a ≠ 0."
+    },
+    {
+      "id": "cubic-endpoint",
+      "title": "The Cubic Endpoint Is Exactly −3",
+      "startLine": 98,
+      "endLine": 109,
+      "summary": "Using (1+a)³ − (1+3a) = a²(a+3), strict Bernoulli at n = 3 holds iff a ≠ 0 ∧ −3 < a, so the left endpoint is −3, strictly below −2.",
+      "mathContext": "1 + 3·a < (1+a)³ ↔ a ≠ 0 ∧ −3 < a."
+    },
+    {
+      "id": "witness",
+      "title": "An Exponent Admitting a < −2",
+      "startLine": 113,
+      "endLine": 116,
+      "summary": "Explicit witness n = 3, a = −5/2 ∈ (−3, −2): some exponents strictly admit values below −2.",
+      "mathContext": "∃ a < −2, ∃ n, 1 + n·a < (1+a)ⁿ."
+    },
+    {
+      "id": "quad-bernoulli",
+      "title": "Second-Order Bernoulli Bound",
+      "startLine": 122,
+      "endLine": 138,
+      "summary": "Induction gives 1 + n·x + C(n,2)·x² ≤ (1+x)ⁿ for x ≥ 0; the inductive step multiplies by 1+x ≥ 0 and drops a nonnegative cubic remainder.",
+      "mathContext": "x ≥ 0 ⟹ 1 + n·x + (n(n−1)/2)·x² ≤ (1+x)ⁿ."
+    },
+    {
+      "id": "uniform-sharp",
+      "title": "−2 Is the Sharp Uniform Endpoint",
+      "startLine": 145,
+      "endLine": 187,
+      "summary": "(∀ n, 1 + n·a ≤ (1+a)ⁿ) ↔ −2 ≤ a. Forward is one_add_mul_le_pow; reverse builds, for a < −2, the odd exponent n = 2N+1 with N > 4/(−2−a)², where the quadratic bound makes −sⁿ drop below the line.",
+      "mathContext": "(∀ n, 1 + n·a ≤ (1+a)ⁿ) ↔ −2 ≤ a."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a fixed exponent n, −2 is not the left endpoint of strict Bernoulli: even n admit every a ≠ 0, and n = 3 admits exactly a > −3, so some exponents reach below −2. The constant −2 is sharp only as the uniform endpoint — 1 + n·a ≤ (1+a)ⁿ holds for all n iff −2 ≤ a, with violations for a < −2 produced at odd exponents via a second-order Bernoulli bound. Verified: 0 sorries, 0 axioms.",
+    "implications": "This pins down the exact role of the constant −2 in Mathlib's one_add_mul_le_pow and the parent strict entry: it is the sharp uniform (n-independent) bound, the supremum of per-exponent endpoints, rather than the endpoint of any single power. The quadratic Bernoulli bound quad_bernoulli is independently reusable wherever a power must be shown to outgrow its first-order tangent line.",
+    "openQuestions": [
+      "For each odd n, the left endpoint a_n^* is the unique real root < −1 of (tⁿ − n·t + (n−1))/(t−1)² shifted by 1; can a closed form or sharp asymptotic a_n^* = −2 − Θ(1/n) be formalized?",
+      "Does the same parity dichotomy and uniform-sharpness picture hold for the real-exponent (rpow) Bernoulli inequality, where evenness is unavailable?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves strict Bernoulli on the full weak domain −2 ≤ a and asks whether −2 is the true per-exponent left endpoint; this entry answers it (no — parity-dependent) and proves −2 is sharp only as the uniform endpoint"
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent proves strict Bernoulli for a > −1; this entry characterizes the admissible range for every fixed n, including the even-exponent case with no left endpoint"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BernoulliInequalityOQ01OQ01OQ01",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BernoulliInequalityOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Positiones Arithmeticae de Seriebus Infinitis",
+      "year": "1689",
+      "venue": "Basel",
+      "note": "Early use of the inequality 1 + nx ≤ (1+x)ⁿ in the study of infinite series"
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Standard reference on Bernoulli's inequality, its strict forms, and admissible domains"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry [`bernoulli-inequality-oq-01-oq-01`](src/data/proofs/bernoulli-inequality-oq-01-oq-01) **open question verbatim**:

> *Is −2 the true left endpoint of the strict inequality `1 + n·a < (1+a)ⁿ` for a fixed n, or does the admissible range depend on n (e.g. does some n admit a < −2)?*

**Answer: −2 is the left endpoint of *no* fixed n — the admissible range is governed by the parity of n.** −2 is sharp only as the *uniform* (n-independent) endpoint.

## Theorems (6, all 0-axiom)

| Theorem | Statement |
|---|---|
| `strict_even` | even `n ≥ 2`, `a ≠ 0` ⟹ `1 + n·a < (1+a)ⁿ` — **no left endpoint** (for `a < −1`, `(1+a)ⁿ > 0` while `1 + n·a < 0`) |
| `cubic_iff` | `1 + 3a < (1+a)³ ↔ a ≠ 0 ∧ −3 < a` — endpoint exactly **−3 < −2**, from `(1+a)³ − (1+3a) = a²(a+3)` |
| `exists_lt_neg_two_strict` | explicit witness `n = 3, a = −5/2` admitting `a < −2` |
| `quad_bernoulli` | `x ≥ 0` ⟹ `1 + n·x + C(n,2)·x² ≤ (1+x)ⁿ` (second-order bound) |
| `sharp_uniform` | `(∀ n, 1 + n·a ≤ (1+a)ⁿ) ↔ −2 ≤ a` — for `a < −2`, odd `n = 2N+1` with `N > 4/(−2−a)²` violates it |

## Why parity is the whole story

Even exponents make `(1+a)ⁿ` nonnegative everywhere, so Bernoulli is automatic once `1 + n·a` turns negative — no lower restriction survives. Odd exponents have a finite endpoint `a_n^* < −2` (e.g. `a_3^* = −3`) that creeps up toward −2 as `n → ∞`. Thus `−2 = sup_n a_n^*` is approached but attained by no single n — exactly why the parent's domain `−2 ≤ a` is sharp uniformly.

Refuting the first-order bound `1 + n·a` structurally requires the **quadratic** term, so Mathlib's first-order `one_add_mul_le_pow` is too weak; `quad_bernoulli` (proved here by induction) supplies it.

## Verification

- **0 axioms, 0 sorries.** Every theorem depends only on `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`), confirmed via `#print axioms`.
- Lean 4 / Mathlib v4.26.0. Self-contained (`import Mathlib`), 189 lines.
- New gallery entry: `src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)