### PR TITLE
Enrich Euler's Circumcenter–Excenter Formula (feuerbachs-theorem-defs-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01/annotations.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": "ann-feuerOQ0201-overview",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "Euler's Excenter Companion: OIₐ² = R² + 2Rrₐ",
+    "content": "Euler's 1765 study of the triangle produced two metric relations of the same shape. The famous one, OI² = R² − 2Rr, ties the circumcenter O to the incenter I and yields Euler's inequality R ≥ 2r. The less-quoted companion concerns the three excenters Iₐ, I_b, I_c (centers of the escribed circles). For the excenter opposite A one has OIₐ² = R² + 2Rrₐ — identical in form but with the sign of the 2Rr term flipped. Because the right side is now a sum of positive quantities, OIₐ > R for every triangle, in sharp contrast with the incenter (OI < R, inside the circumcircle). The sibling entry proved the incenter law; this file supplies the excenter law and isolates the one genuinely new fact the excenter case needs: the strict triangle inequality, which keeps the denominators −a+b+c, a−b+c, a+b−c positive.",
+    "mathContext": "$OI^2 = R^2 - 2Rr$ (incenter) and $OI_a^2 = R^2 + 2Rr_a$ (A-excenter) are Euler's paired 1765 center-distance laws; the sign flip encodes opposite inclusions $OI < R < OI_a$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euler's triangle formula",
+      "incenter vs excenter",
+      "circumradius and exradius",
+      "tritangent centers"
+    ],
+    "prerequisites": [
+      "Euclidean triangle geometry",
+      "circumcircle and excircles",
+      "barycentric / signed-weight coordinates"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-equidist",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 130
+    },
+    "type": "technique",
+    "title": "Circumcenter equidistance |A−O|² = |B−O|² = |C−O|² = R²",
+    "content": "The proof works with the three vectors A−O, B−O, C−O, each of squared length R². Because the parent file's equidistance lemmas are private, this section re-establishes them: the perpendicular-bisector condition that defines O is linear in O and closed by field_simp; ring, and the squared equidistances |B−O|² = |A−O|² and |C−O|² = |A−O|² then follow by nlinarith. These three equalities, together with the three pairwise dot products (A−O)·(B−O) = R² − c²/2 (cyclically), are the only facts about O the rest of the file consumes.",
+    "mathContext": "$O$ is equidistant from the vertices: $|A-O|^2 = |B-O|^2 = |C-O|^2 = R^2$. With the law of cosines this gives $(A-O)\\cdot(B-O) = R^2 - c^2/2$ and cyclically.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "circumcenter",
+      "polarization / dot product",
+      "law of cosines"
+    ],
+    "prerequisites": [
+      "inner product in ℝ²",
+      "circumcenter definition",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-triangleineq",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 193,
+      "endLine": 301
+    },
+    "type": "insight",
+    "title": "The genuinely new ingredient: strict triangle inequality a < b + c",
+    "content": "The incenter proof never needed the triangle inequality (its denominator a+b+c is manifestly positive), but the excenter denominators −a+b+c, a−b+c, a+b−c require it. strict_tri_ineq_a proves a < b + c from scratch: writing P = ⟨A−C, B−A⟩, the law of cosines gives a² = b² + c² + 2P, while the 2-D Lagrange identity gives b²c² − P² = D² where D is the non-degeneracy determinant. Since the triangle is non-degenerate, D ≠ 0, so P² < (bc)², hence P < bc, hence a² < (b+c)², hence a < b + c. The consequences pa_pos/pb_pos/pc_pos then certify each excenter denominator is positive. This is strict Cauchy–Schwarz realized geometrically: equality in C–S is exactly collinearity, i.e. degeneracy.",
+    "mathContext": "$a^2 = b^2 + c^2 + 2P$ with $P = \\langle A-C, B-A\\rangle$, and the Lagrange identity $b^2c^2 - P^2 = D^2 > 0$ gives $P < bc$, so $a^2 < (b+c)^2$ and $a < b+c$. Hence $p_a = -a+b+c > 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict Cauchy–Schwarz",
+      "Lagrange identity",
+      "law of cosines",
+      "non-degeneracy determinant"
+    ],
+    "prerequisites": [
+      "Cauchy–Schwarz inequality",
+      "2-D cross product / determinant",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-weighted",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 303,
+      "endLine": 339
+    },
+    "type": "insight",
+    "title": "The reusable weighted-norm master identity",
+    "content": "weighted_norm_sq_gen is the lemma that unifies the incenter and all three excenters: for arbitrary real weights wₐ, w_b, w_c, |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b·c² + w_bw_c·a² + w_cwₐ·b²). It is proved by a single linear_combination that substitutes the three equidistances and three dot products. Specializing the weights recovers every case: (a,b,c) gives the incenter (the sibling file's law), and (−a,b,c), (a,−b,c), (a,b,−c) give the A-, B-, C-excenters. One identity, four center-distance formulas.",
+    "mathContext": "$|w_a(A{-}O)+w_b(B{-}O)+w_c(C{-}O)|^2 = R^2(w_a{+}w_b{+}w_c)^2 - (w_aw_b c^2 + w_bw_c a^2 + w_cw_a b^2)$. The incenter is weights $(a,b,c)$; the excenters negate one weight each.",
+    "significance": "key",
+    "relatedConcepts": [
+      "barycentric coordinates",
+      "signed weights",
+      "polarization identity",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "inner product expansion",
+      "circumcenter equidistances",
+      "weighted averages of points"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-core",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 340,
+      "endLine": 375
+    },
+    "type": "technique",
+    "title": "The affine core: OIₐ² = R² + abc/(−a+b+c)",
+    "content": "OI_a_sq_eq_R2_add extracts the square-root-free heart of Euler's formula. The A-excenter is the signed-weight average Iₐ = (−a·A + b·B + c·C)/(−a+b+c), so pₐ(Iₐ−O) = −a(A−O) + b(B−O) + c(C−O). Feeding weights (−a,b,c) into the master identity collapses |pₐ(Iₐ−O)|² to R²pₐ² + abc·pₐ; since pₐ > 0 (from the strict triangle inequality) one cancels a single factor of pₐ via mul_right_cancel₀, giving dist²(O,Iₐ) = R² + abc/pₐ. No square roots appear — everything stays polynomial until the final exradius bridge.",
+    "mathContext": "$I_a = \\frac{-aA + bB + cC}{-a+b+c}$, so $p_a(I_a - O) = -a(A{-}O)+b(B{-}O)+c(C{-}O)$ and $|p_a(I_a{-}O)|^2 = R^2 p_a^2 + abc\\,p_a$, hence $\\mathrm{dist}^2(O,I_a) = R^2 + \\frac{abc}{p_a}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "excenter barycentric coordinates",
+      "weighted_norm_sq_gen",
+      "mul_right_cancel₀",
+      "affine combination"
+    ],
+    "prerequisites": [
+      "excenter formula",
+      "the master weighted-norm identity",
+      "field arithmetic over ℝ"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-bridge",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 376,
+      "endLine": 426
+    },
+    "type": "insight",
+    "title": "Law-of-sines bridge and Euler's formula euler_OI_a_formula",
+    "content": "The bridge turns the affine core into the exradius form. Since rₐ = Area/(s−a) = 2·Area/pₐ, one has 2Rrₐ = 4·R·Area/pₐ = abc/pₐ, where the key substitution 4·R·Area = abc is the law-of-sines identity four_R_area_eq_abc reused from the sibling file (avoiding a costly re-derivation of 16R²·Area² = a²b²c²). Substituting abc/pₐ = 2Rrₐ into the core gives the headline euler_OI_a_formula: dist²(O,Iₐ) = R² + 2Rrₐ. circumradius_pos and exradius_a_pos come cheaply from the same reused identity.",
+    "mathContext": "$r_a = \\frac{\\text{Area}}{s-a} = \\frac{2\\,\\text{Area}}{p_a}$, so $2Rr_a = \\frac{4R\\,\\text{Area}}{p_a} = \\frac{abc}{p_a}$ using $4R\\cdot\\text{Area} = abc$; hence $\\mathrm{dist}^2(O,I_a) = R^2 + 2Rr_a$.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "law of sines",
+      "exradius formula rₐ = Area/(s−a)",
+      "four_R_area_eq_abc",
+      "code reuse across sibling proofs"
+    ],
+    "prerequisites": [
+      "law of sines 4R·Area = abc",
+      "exradius definition",
+      "the affine core OI_a_sq_eq_R2_add"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-bc",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 427,
+      "endLine": 538
+    },
+    "type": "context",
+    "title": "The B- and C-excenter formulas by symmetry",
+    "content": "euler_OI_b_formula and euler_OI_c_formula carry the same machinery to the other two excenters using weights (a,−b,c) and (a,b,−c). Because the master identity weighted_norm_sq_gen is symmetric in the weights and the strict triangle inequalities hold cyclically (strict_tri_ineq_b, strict_tri_ineq_c with pb_pos, pc_pos), the affine cores OI_b_sq_eq_R2_add / OI_c_sq_eq_R2_add and bridges two_R_rb_eq / two_R_rc_eq are immediate analogues. The result OIₓ² = R² + 2Rrₓ holds uniformly for all three excenters x ∈ {a,b,c}.",
+    "mathContext": "By cyclic symmetry: $OI_b^2 = R^2 + 2Rr_b$ (weights $(a,-b,c)$, denominator $p_b = a-b+c$) and $OI_c^2 = R^2 + 2Rr_c$ (weights $(a,b,-c)$, denominator $p_c = a+b-c$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic symmetry",
+      "three excenters",
+      "weighted_norm_sq_gen"
+    ],
+    "prerequisites": [
+      "the A-excenter derivation",
+      "cyclic relabeling of vertices"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-consequence",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 539,
+      "endLine": 562
+    },
+    "type": "insight",
+    "title": "Strict consequence: R < OIₐ",
+    "content": "The plus sign pays an immediate geometric dividend. circumradius_sq_lt_OI_a_sq notes R² < R² + 2Rrₐ because R, rₐ > 0, and circumradius_lt_OI_a lifts this to the true distance R < OIₐ via monotonicity of Real.sqrt. So the circumcenter is always strictly farther from an excenter than the circumradius — the excenter lies outside the circumcircle — exactly the opposite of the incenter, whose minus sign gives OI < R (inside). One sign captures the dichotomy.",
+    "mathContext": "$R^2 < R^2 + 2Rr_a = OI_a^2$ since $R, r_a > 0$; applying $\\sqrt{\\cdot}$ (monotone) gives $R < OI_a$. Contrast $OI < R$ from the incenter's minus sign.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.sqrt monotonicity",
+      "Euler's inequality analogue",
+      "incircle vs excircle inclusion"
+    ],
+    "prerequisites": [
+      "Euler's excenter formula",
+      "monotonicity of square root"
+    ]
+  },
+  {
+    "id": "ann-feuerOQ0201-example",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01",
+    "range": {
+      "startLine": 563,
+      "endLine": 594
+    },
+    "type": "context",
+    "title": "Worked example: the 3-4-5 right triangle",
+    "content": "A concrete sanity check makes the formula tangible. For the 3-4-5 right triangle, triangle_345_excenter_a computes Iₐ = (6,6), triangle_345_exradius_a gives rₐ = 6, and triangle_345_OI_a_sq evaluates dist²(O,Iₐ) = 145/4. The final triangle_345_euler_a confirms this equals R² + 2Rrₐ = (5/2)² + 2·(5/2)·6 = 25/4 + 30 = 145/4, using the parent's computed circumcenter (3/2, 2), circumradius 5/2 and side lengths 5, 4, 3. The numbers close exactly, witnessing the general theorem.",
+    "mathContext": "$3$-$4$-$5$: $O = (3/2, 2)$, $R = 5/2$, $I_a = (6,6)$, $r_a = 6$, so $OI_a^2 = 145/4 = (5/2)^2 + 2\\cdot(5/2)\\cdot 6$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "3-4-5 right triangle",
+      "numerical verification",
+      "exradius computation"
+    ],
+    "prerequisites": [
+      "the general Euler excenter formula",
+      "coordinate computation in ℝ²"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-02-oq-01` — Euler's excenter formula OIₐ² = R² + 2Rrₐ.

## Gap closed
The entry had a rich `meta.json` (overview, 9 sections, conclusion, mainTheorems, crossReferences) but **no `annotations.json`** — zero inline annotation coverage. This PR adds 9 substantive annotations spanning the full 594-line Lean file.

## What was added
Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Overview** — Euler's incenter/excenter pair and the sign flip (OI < R < OIₐ)
2. **Circumcenter equidistance** — |A−O|² = |B−O|² = |C−O|² = R²
3. **Strict triangle inequality** — the new ingredient, via the 2-D Lagrange identity
4. **Weighted-norm master identity** — one lemma covering incenter + all 3 excenters
5. **Affine core** — OIₐ² = R² + abc/(−a+b+c)
6. **Law-of-sines bridge** — to `euler_OI_a_formula`
7. **B/C-excenter formulas** — by cyclic symmetry
8. **Strict consequence** — R < OIₐ
9. **3-4-5 worked example**

## Verification
- `pnpm build` passes
- JSON validated; `status: verified`, `axiomCount: 0` confirmed consistent with the Lean file (0 sorries, 0 axioms) — left intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)