### PR TITLE
research(erdos-83-oq-01): verified lower bound — the Complete Intersection bound is sharp [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -972,6 +972,7 @@ import Proofs.DivisibilityByThreeOQ02OQ01
 import Proofs.DivisibilityRules
 import Proofs.DivisibilityRulesOQ01
 import Proofs.DivisibilityRulesOQ01OQ02
+import Proofs.DivisibilityRulesOQ01OQ02OQ01
 import Proofs.DivisibilityRulesOQ01OQ01
 import Proofs.DivisibilityRulesOQ01OQ01OQ01
 import Proofs.DivisibilityRulesOQ02

--- a/proofs/Proofs/DivisibilityRulesOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/DivisibilityRulesOQ01OQ02OQ01.lean
@@ -1,0 +1,282 @@
+/-
+Alternating Digit-Sum Divisibility Rules: A Sharp Order Characterization
+(OQ-01-OQ-02-OQ-01 Extension)
+
+Sibling of `divisibility-rules-oq-01-oq-02`. The parent file settled the
+*digit-sum* rule: for EVERY modulus `d` coprime to 10 some power-of-10 base
+`10^k` validates `d ∣ n ↔ d ∣ (digits (10^k) n).sum`, with the valid exponents
+being exactly the multiples of `ord_d(10)`.
+
+This file treats the *alternating* digit-sum rule (the base-10 rule for 11:
+`10 ≡ -1 (mod 11)` makes `n ≡ d₀ - d₁ + d₂ - ⋯`).  Unlike the digit-sum rule,
+the alternating rule is **not universal**, and we pin down exactly which moduli
+admit one.
+
+Main results:
+
+* `altRule_base_iff` — a **genuine per-base iff**: the base-`10^k` alternating
+  rule holds for *all* `n` **iff** `(10 : ZMod d)^k = -1`.  The forward
+  direction is forced by the single test value `n = 10^k + 1` (digits `[1,1]`,
+  alternating sum `0`), so the rule holding forces `d ∣ 10^k + 1`.
+
+* `altRule_exists_iff` — the **sharp characterization**: for `d > 2` coprime to
+  10, a power-of-10 alternating rule exists **iff** `ord_d(10)` is even and
+  `10^{ord_d(10)/2} ≡ -1 (mod d)`.  Equivalently, `-1` is a power of `10` in
+  `ZMod d`.
+
+The forward arithmetic core is Mathlib's `Nat.dvd_iff_dvd_ofDigits` together
+with `Nat.ofDigits_neg_one` (which rewrites `ofDigits (-1)` as the alternating
+sum).  The order characterization is the cyclic-group fact that a cyclic group
+contains the order-two element `-1` iff its order is even, with `10^{m/2}` the
+unique such element.
+
+The file is self-contained and imports only Mathlib.
+
+Tags: number-theory, modular-arithmetic, divisibility, multiplicative-order, extension
+-/
+
+import Mathlib
+
+open Nat
+
+namespace DivisibilityRulesOQ01OQ02OQ01
+
+/-
+## Part I: The base condition `(10 : ZMod d)^k = -1`
+
+We work with the clean algebraic condition `(10 : ZMod d)^k = -1` and relate it
+to the integer divisibility `d ∣ 10^k + 1` that the digit machinery consumes.
+-/
+
+/-- `(10 : ZMod d)^k = -1` is exactly the integer statement `d ∣ 10^k + 1`. -/
+theorem pow_zmod_eq_neg_one_iff (d k : ℕ) :
+    (10 : ZMod d) ^ k = -1 ↔ (d : ℤ) ∣ (10 : ℤ) ^ k + 1 := by
+  rw [eq_neg_iff_add_eq_zero]
+  rw [show ((10 : ZMod d) ^ k + 1) = (((10 : ℤ) ^ k + 1 : ℤ) : ZMod d) by push_cast; ring]
+  exact ZMod.intCast_zmod_eq_zero_iff_dvd _ d
+
+/-- **Workhorse (sufficiency).** Whenever `(10 : ZMod d)^k = -1` — i.e.
+`10^k ≡ -1 (mod d)` — the base `B = 10^k` validates the alternating digit-sum
+rule for `d`: a number is divisible by `d` iff the alternating sum of its
+base-`10^k` digits is. -/
+theorem altRule_of_pow_neg_one (d k : ℕ) (hk : (10 : ZMod d) ^ k = -1) (n : ℕ) :
+    d ∣ n ↔
+      (d : ℤ) ∣ ((Nat.digits (10 ^ k) n).map (fun a : ℕ => (a : ℤ))).alternatingSum := by
+  have hdvd : (d : ℤ) ∣ (10 : ℤ) ^ k + 1 := (pow_zmod_eq_neg_one_iff d k).mp hk
+  -- `dvd_iff_dvd_ofDigits` needs `d ∣ (10^k : ℤ) - (-1) = 10^k + 1`.
+  have hsub : (d : ℤ) ∣ ((10 ^ k : ℕ) : ℤ) - (-1 : ℤ) := by
+    have : ((10 ^ k : ℕ) : ℤ) - (-1 : ℤ) = (10 : ℤ) ^ k + 1 := by push_cast; ring
+    rw [this]; exact hdvd
+  have t := Nat.dvd_iff_dvd_ofDigits d (10 ^ k) (-1 : ℤ) hsub n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-
+## Part II: A genuine per-base iff
+
+The alternating rule for base `10^k` (k ≥ 1) holds for *all* `n` precisely when
+`(10 : ZMod d)^k = -1`.  Sufficiency is the workhorse; necessity is forced by
+the single value `n = 10^k + 1`, whose base-`10^k` digits are `[1, 1]` and whose
+alternating sum is `0`.
+-/
+
+/-- The base-`10^k` digits of `10^k + 1` are `[1, 1]` (for `k ≥ 1`). -/
+theorem digits_pow_add_one (k : ℕ) (hk : 0 < k) :
+    Nat.digits (10 ^ k) (10 ^ k + 1) = [1, 1] := by
+  have hb : 1 < 10 ^ k := by
+    calc 1 < 10 ^ 1 := by norm_num
+    _ ≤ 10 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+  have hmod : (10 ^ k + 1) % 10 ^ k = 1 := by
+    rw [Nat.add_mod_left, Nat.mod_eq_of_lt hb]
+  have hdiv : (10 ^ k + 1) / 10 ^ k = 1 := by
+    rw [add_comm, Nat.add_div_right 1 (by positivity), Nat.div_eq_of_lt hb]
+  rw [Nat.digits_def' hb (by positivity), hmod, hdiv,
+    Nat.digits_of_lt (10 ^ k) 1 (by norm_num) hb]
+
+/-- **Per-base characterization (genuine iff).** For `k ≥ 1`, the base-`10^k`
+alternating digit-sum rule holds for every `n` iff `(10 : ZMod d)^k = -1`. -/
+theorem altRule_base_iff (d k : ℕ) (hk : 0 < k) :
+    (∀ n, d ∣ n ↔
+        (d : ℤ) ∣ ((Nat.digits (10 ^ k) n).map (fun a : ℕ => (a : ℤ))).alternatingSum)
+      ↔ (10 : ZMod d) ^ k = -1 := by
+  constructor
+  · intro hrule
+    -- Test the rule at `n = 10^k + 1`: alternating sum is `0`, so `d ∣ 10^k + 1`.
+    have h := hrule (10 ^ k + 1)
+    rw [digits_pow_add_one k hk] at h
+    -- `alternatingSum (map ↑ [1,1]) = 0`, and `d ∣ 0` is trivial.
+    have hdvdnat : d ∣ (10 ^ k + 1) := by rw [h]; simp [List.alternatingSum]
+    have hdvdint : (d : ℤ) ∣ (10 : ℤ) ^ k + 1 := by
+      have := Int.natCast_dvd_natCast.mpr hdvdnat
+      push_cast at this; exact this
+    exact (pow_zmod_eq_neg_one_iff d k).mpr hdvdint
+  · intro hk2 n; exact altRule_of_pow_neg_one d k hk2 n
+
+/-
+## Part III: The sharp order characterization
+
+`-1` is a power of `10` in `ZMod d` iff `ord_d(10)` is even and `10^{m/2} = -1`,
+where `m = ord_d(10)`.  This is the cyclic-group fact that the order-two element
+`-1` lies in `⟨10⟩` iff `|⟨10⟩| = m` is even, in which case `10^{m/2}` is the
+unique element of order two.
+-/
+
+/-- For `d ≥ 2` coprime to 10, the order of `10` in `ZMod d` is positive. -/
+theorem orderOf_ten_pos (d : ℕ) (hd : 2 ≤ d) (hcop : Nat.Coprime 10 d) :
+    0 < orderOf (10 : ZMod d) := by
+  have heuler : (10 : ZMod d) ^ d.totient = 1 := by
+    have h := Nat.ModEq.pow_totient hcop
+    have h2 : ((10 ^ d.totient : ℕ) : ZMod d) = ((1 : ℕ) : ZMod d) :=
+      (ZMod.natCast_eq_natCast_iff _ _ _).mpr h
+    push_cast at h2; exact h2
+  have hdvd : orderOf (10 : ZMod d) ∣ d.totient := orderOf_dvd_of_pow_eq_one heuler
+  have hφ : 0 < d.totient := Nat.totient_pos.mpr (by omega)
+  rcases Nat.eq_zero_or_pos (orderOf (10 : ZMod d)) with h | h
+  · rw [h] at hdvd; simp only [Nat.zero_dvd] at hdvd; omega
+  · exact h
+
+/-- In `ZMod d` with `d > 2`, `1 ≠ -1` (else `d ∣ 2`). -/
+theorem one_ne_neg_one (d : ℕ) (hd : 2 < d) : (1 : ZMod d) ≠ -1 := by
+  intro h
+  have h2 : (2 : ZMod d) = 0 := by linear_combination h
+  have hcast : ((2 : ℕ) : ZMod d) = 0 := by push_cast; exact h2
+  have hdvd : d ∣ 2 := (ZMod.natCast_eq_zero_iff 2 d).mp hcast
+  have : d ≤ 2 := Nat.le_of_dvd (by norm_num) hdvd
+  omega
+
+/-- **Sharp characterization of solvability.** For `d > 2` coprime to 10, `-1`
+is a power of `10` in `ZMod d` iff `ord_d(10)` is even and `10^{ord_d(10)/2} = -1`. -/
+theorem exists_pow_neg_one_iff_order (d : ℕ) (hd : 2 < d) (hcop : Nat.Coprime 10 d) :
+    (∃ k, (10 : ZMod d) ^ k = -1) ↔
+      Even (orderOf (10 : ZMod d)) ∧
+        (10 : ZMod d) ^ (orderOf (10 : ZMod d) / 2) = -1 := by
+  set m := orderOf (10 : ZMod d) with hm
+  have hpos : 0 < m := orderOf_ten_pos d (by omega) hcop
+  have hone : (10 : ZMod d) ^ m = 1 := orderOf_dvd_iff_pow_eq_one.mp dvd_rfl
+  constructor
+  · rintro ⟨k, hk⟩
+    -- From `10^k = -1`: square gives `10^(2k) = 1`, so `m ∣ 2k`.
+    have hsq : (10 : ZMod d) ^ (2 * k) = 1 := by
+      rw [show 2 * k = k * 2 from Nat.mul_comm 2 k, pow_mul, hk]; ring
+    have hdvd2k : m ∣ 2 * k := orderOf_dvd_of_pow_eq_one hsq
+    -- `m ∤ k`, else `10^k = 1 = -1`, contradicting `1 ≠ -1`.
+    have hnk : ¬ m ∣ k := by
+      intro hmk
+      have : (10 : ZMod d) ^ k = 1 := orderOf_dvd_iff_pow_eq_one.mp hmk
+      rw [this] at hk
+      exact one_ne_neg_one d hd hk
+    -- Hence `m` is even.
+    have hmeven : Even m := by
+      by_contra hodd
+      rw [Nat.not_even_iff_odd] at hodd
+      have hcop2 : Nat.Coprime m 2 := hodd.coprime_two_right
+      exact hnk (hcop2.dvd_of_dvd_mul_left hdvd2k)
+    refine ⟨hmeven, ?_⟩
+    -- Let `h = m/2`; then `2h = m`, `h ∣ k`, write `k = h*q`.
+    obtain ⟨h, hmh⟩ := hmeven           -- m = h + h
+    have h2h : m = 2 * h := by omega
+    have hhalf : m / 2 = h := by omega
+    rw [hhalf]
+    have hhk : h ∣ k := by
+      have : 2 * h ∣ 2 * k := by rwa [← h2h]
+      exact (mul_dvd_mul_iff_left (by norm_num : (2:ℕ) ≠ 0)).mp this
+    obtain ⟨q, hq⟩ := hhk
+    -- `y := 10^h` satisfies `y^2 = 1` and `y^q = -1`; deduce `y = -1`.
+    set y := (10 : ZMod d) ^ h with hy
+    have hysq : y ^ 2 = 1 := by rw [hy, ← pow_mul, show h * 2 = m from by omega]; exact hone
+    have hyq : y ^ q = -1 := by rw [hy, ← pow_mul, ← hq]; exact hk
+    -- `y^q = y^(q % 2)` since `y^2 = 1`.
+    have hred : y ^ q = y ^ (q % 2) := by
+      conv_lhs => rw [← Nat.div_add_mod q 2, pow_add, pow_mul, hysq, one_pow, one_mul]
+    -- `q % 2 = 1` (else `y^q = 1 ≠ -1`); then `y = y^1 = -1`.
+    have hcase : q % 2 = 0 ∨ q % 2 = 1 := by omega
+    rcases hcase with hr | hr
+    · exfalso; rw [hr, pow_zero] at hred; rw [hred] at hyq
+      exact one_ne_neg_one d hd hyq
+    · rw [hr, pow_one] at hred; rw [hred] at hyq; exact hyq
+  · rintro ⟨hmeven, hhalf⟩
+    exact ⟨m / 2, hhalf⟩
+
+/-
+## Part IV: Main theorem — when a power-of-10 alternating rule exists
+-/
+
+/-- **Main theorem (resolves the open question).** For a modulus `d > 2` coprime
+to 10, a power-of-10 alternating digit-sum divisibility rule exists **iff**
+`ord_d(10)` is even and `10^{ord_d(10)/2} ≡ -1 (mod d)`.  The witness base, when
+it exists, is `10^{ord_d(10)/2}`. -/
+theorem altRule_exists_iff (d : ℕ) (hd : 2 < d) (hcop : Nat.Coprime 10 d) :
+    (∃ k, 0 < k ∧ ∀ n, d ∣ n ↔
+        (d : ℤ) ∣ ((Nat.digits (10 ^ k) n).map (fun a : ℕ => (a : ℤ))).alternatingSum)
+      ↔ Even (orderOf (10 : ZMod d)) ∧
+          (10 : ZMod d) ^ (orderOf (10 : ZMod d) / 2) = -1 := by
+  have hpos : 0 < orderOf (10 : ZMod d) := orderOf_ten_pos d (by omega) hcop
+  constructor
+  · rintro ⟨k, hk, hrule⟩
+    have hkneg : (10 : ZMod d) ^ k = -1 := (altRule_base_iff d k hk).mp hrule
+    exact (exists_pow_neg_one_iff_order d hd hcop).mp ⟨k, hkneg⟩
+  · intro hcond
+    have hkneg : (10 : ZMod d) ^ (orderOf (10 : ZMod d) / 2) = -1 := hcond.2
+    refine ⟨orderOf (10 : ZMod d) / 2, ?_, ?_⟩
+    · -- `m` even and positive ⟹ `m ≥ 2` ⟹ `m/2 ≥ 1`.
+      obtain ⟨h, hmh⟩ := hcond.1
+      omega
+    · exact (altRule_base_iff d (orderOf (10 : ZMod d) / 2)
+        (by obtain ⟨h, hmh⟩ := hcond.1; omega)).mpr hkneg
+
+/-
+## Part V: Concrete instances
+
+Positive instances (rule exists), with the minimal witness exponent `k`:
+* `d = 11`: `10^1 ≡ -1 (mod 11)`           (classic alternating rule).
+* `d = 7` : `10^3 = 1000 ≡ -1 (mod 7)`     (`1001 = 7·143`).
+* `d = 13`: `10^3 = 1000 ≡ -1 (mod 13)`    (`1001 = 13·77`).
+
+Negative instances (no power-of-10 alternating rule exists):
+* `d = 3` : `10 ≡ 1`, so every power of `10` is `1 ≠ -1`.
+* `d = 37`: `10^3 ≡ 1` with `ord_37(10) = 3` odd; the three powers `{1, 10, 26}`
+  miss `-1 = 36`.
+-/
+
+/-- Divisibility by 11 via the alternating digit sum (`k = 1`, `10 ≡ -1 mod 11`). -/
+theorem eleven_altRule (n : ℕ) :
+    11 ∣ n ↔
+      (11 : ℤ) ∣ ((Nat.digits (10 ^ 1) n).map (fun a : ℕ => (a : ℤ))).alternatingSum :=
+  altRule_of_pow_neg_one 11 1 (by decide) n
+
+/-- Divisibility by 7 via the base-`10^3` alternating digit sum (`10^3 ≡ -1 mod 7`). -/
+theorem seven_altRule (n : ℕ) :
+    7 ∣ n ↔
+      (7 : ℤ) ∣ ((Nat.digits (10 ^ 3) n).map (fun a : ℕ => (a : ℤ))).alternatingSum :=
+  altRule_of_pow_neg_one 7 3 (by decide) n
+
+/-- Divisibility by 13 via the base-`10^3` alternating digit sum (`10^3 ≡ -1 mod 13`). -/
+theorem thirteen_altRule (n : ℕ) :
+    13 ∣ n ↔
+      (13 : ℤ) ∣ ((Nat.digits (10 ^ 3) n).map (fun a : ℕ => (a : ℤ))).alternatingSum :=
+  altRule_of_pow_neg_one 13 3 (by decide) n
+
+/-- **No alternating rule for 3.** Every power of `10` is `1` in `ZMod 3`, never
+`-1`. -/
+theorem three_no_altRule : ¬ ∃ k, (10 : ZMod 3) ^ k = -1 := by
+  rintro ⟨k, hk⟩
+  rw [show (10 : ZMod 3) = 1 by decide, one_pow] at hk
+  exact (by decide : (1 : ZMod 3) ≠ -1) hk
+
+/-- **No alternating rule for 37.** `ord_37(10) = 3` is odd; concretely the
+powers `10^k = 10^{k mod 3} ∈ {1, 10, 26}` never equal `-1 = 36`. -/
+theorem thirtyseven_no_altRule : ¬ ∃ k, (10 : ZMod 37) ^ k = -1 := by
+  rintro ⟨k, hk⟩
+  have h3 : (10 : ZMod 37) ^ 3 = 1 := by decide
+  have hred : (10 : ZMod 37) ^ k = (10 : ZMod 37) ^ (k % 3) := by
+    conv_lhs => rw [← Nat.div_add_mod k 3, pow_add, pow_mul, h3, one_pow, one_mul]
+  rw [hred] at hk
+  have hlt : k % 3 < 3 := Nat.mod_lt k (by norm_num)
+  interval_cases (k % 3) <;> revert hk <;> decide
+
+#check @altRule_base_iff
+#check @exists_pow_neg_one_iff_order
+#check @altRule_exists_iff
+#check @eleven_altRule
+#check @three_no_altRule
+
+end DivisibilityRulesOQ01OQ02OQ01

--- a/proofs/Proofs/Erdos83LowerBound.lean
+++ b/proofs/Proofs/Erdos83LowerBound.lean
@@ -1,0 +1,261 @@
+/-
+Erdős Problem #83 — Sharpness of the Complete Intersection bound (LOWER BOUND)
+
+The Ahlswede–Khachatrian Complete Intersection Theorem (1997, $500 Erdős prize)
+states that a family `F` of `2n`-subsets of `[4n]` with `|A ∩ B| ≥ 2` for all
+`A, B ∈ F` satisfies
+
+    |F| ≤ ½ (C(4n, 2n) − C(2n, n)²)  =: erdos83Bound n.
+
+The *upper* bound is the deep theorem (its "pushing–pulling" proof is correctly
+axiomatized in `Proofs/Erdos83Problem.lean`).  This file proves the *lower* bound
+— that the bound is **sharp** — by an elementary, fully machine-checked argument:
+
+    There exists a valid family achieving exactly `erdos83Bound n`.
+
+The witness is the **majority family**: fix a `2n`-element "core" `C ⊆ [4n]` and
+take all `2n`-subsets meeting `C` in at least `n + 1` elements.  Two such sets
+share `≥ (n+1) + (n+1) − 2n = 2` core elements (pigeonhole), so the family is
+`2`-intersecting; and a complement involution `S ↦ Sᶜ` pairs the "majority"
+sets with the "minority" sets, leaving the `C(2n,n)²` "balanced" sets in the
+middle, whence the count is `½ (C(4n,2n) − C(2n,n)²)`.
+
+This is a genuine, 0-axiom verification of the easy (achievability) direction of
+Erdős #83; it complements the axiomatized upper bound rather than reproving it.
+
+References:
+- Ahlswede, Khachatrian (1997), European J. Combin. 18, 125-136
+- https://erdosproblems.com/83
+-/
+
+import Mathlib
+
+open Finset Nat
+
+namespace Erdos83LowerBound
+
+variable {α : Type*} [DecidableEq α]
+
+/-- A family is `t`-intersecting if every pair of members meets in `≥ t` points. -/
+def IsTIntersecting (F : Finset (Finset α)) (t : ℕ) : Prop :=
+  ∀ A ∈ F, ∀ B ∈ F, t ≤ (A ∩ B).card
+
+/-- A family is `k`-uniform if every member has exactly `k` elements. -/
+def IsKUniform (F : Finset (Finset α)) (k : ℕ) : Prop :=
+  ∀ A ∈ F, A.card = k
+
+/-- The Erdős #83 admissibility predicate: a family of `2n`-subsets of `[4n]`
+with pairwise intersections of size at least `2`. -/
+def IsValidErdos83Family (n : ℕ) (F : Finset (Finset (Fin (4 * n)))) : Prop :=
+  IsKUniform F (2 * n) ∧ IsTIntersecting F 2
+
+/-- The Ahlswede–Khachatrian bound `½ (C(4n,2n) − C(2n,n)²)`. -/
+def erdos83Bound (n : ℕ) : ℕ :=
+  ((4 * n).choose (2 * n) - ((2 * n).choose n) ^ 2) / 2
+
+/-!
+## Pigeonhole: the majority family is `2`-intersecting
+-/
+
+/-- **Core pigeonhole.** If `A` and `B` each meet `C` in at least `s` points, then
+`2 s ≤ |A ∩ B| + |C|`.  (Specializing `s = n+1`, `|C| = 2n` gives `|A ∩ B| ≥ 2`.) -/
+theorem two_mul_le_card_inter_add_core {A B C : Finset α} {s : ℕ}
+    (hA : s ≤ (A ∩ C).card) (hB : s ≤ (B ∩ C).card) :
+    2 * s ≤ (A ∩ B).card + C.card := by
+  have hsub : (A ∩ C) ∪ (B ∩ C) ⊆ C := by
+    intro x hx
+    simp only [mem_union, mem_inter] at hx
+    tauto
+  have hle : ((A ∩ C) ∪ (B ∩ C)).card ≤ C.card := card_le_card hsub
+  have hue : ((A ∩ C) ∪ (B ∩ C)).card + ((A ∩ C) ∩ (B ∩ C)).card
+      = (A ∩ C).card + (B ∩ C).card := card_union_add_card_inter _ _
+  have hinter : (A ∩ C) ∩ (B ∩ C) ⊆ A ∩ B := by
+    intro x hx
+    simp only [mem_inter] at hx ⊢
+    tauto
+  have hle2 : ((A ∩ C) ∩ (B ∩ C)).card ≤ (A ∩ B).card := card_le_card hinter
+  omega
+
+/-!
+## Counting subsets by their intersection with the core
+-/
+
+/-- **Split count.** Inside a ground set `G`, the number of `k`-subsets meeting a
+fixed `C ⊆ G` in exactly `j` points is `C(|C|, j) · C(|G \ C|, k − j)`.
+Proved by the bijection `S ↦ (S ∩ C, S \ C)`. -/
+theorem card_filter_inter_card_eq {G C : Finset α} (hC : C ⊆ G) {k j : ℕ}
+    (hjk : j ≤ k) :
+    ((G.powersetCard k).filter (fun S => (S ∩ C).card = j)).card
+      = C.card.choose j * (G \ C).card.choose (k - j) := by
+  have hrhs : C.card.choose j * (G \ C).card.choose (k - j)
+      = ((C.powersetCard j) ×ˢ ((G \ C).powersetCard (k - j))).card := by
+    rw [card_product, card_powersetCard, card_powersetCard]
+  rw [hrhs]
+  apply card_nbij' (fun S => (S ∩ C, S \ C)) (fun p => p.1 ∪ p.2)
+  · -- forward maps to the product
+    intro S hS
+    simp only [mem_coe, mem_filter, mem_powersetCard] at hS
+    obtain ⟨⟨hSG, hScard⟩, hSj⟩ := hS
+    have hcard : (S ∩ C).card + (S \ C).card = k := by
+      rw [card_inter_add_card_sdiff, hScard]
+    have hsdiff : S \ C ⊆ G \ C := by
+      intro x hx
+      simp only [mem_sdiff] at hx ⊢
+      exact ⟨hSG hx.1, hx.2⟩
+    simp only [mem_coe, mem_product, mem_powersetCard]
+    refine ⟨⟨inter_subset_right, hSj⟩, hsdiff, ?_⟩
+    omega
+  · -- backward maps into the filtered powerset
+    intro p hp
+    simp only [mem_coe, mem_product, mem_powersetCard] at hp
+    obtain ⟨⟨hA, hAj⟩, hB, hBkj⟩ := hp
+    have hdisj : Disjoint p.1 p.2 := by
+      refine disjoint_left.2 ?_
+      intro x hx1 hx2
+      exact (mem_sdiff.1 (hB hx2)).2 (hA hx1)
+    have hinterC : (p.1 ∪ p.2) ∩ C = p.1 := by
+      ext x
+      simp only [mem_inter, mem_union]
+      constructor
+      · rintro ⟨h1 | h2, hxC⟩
+        · exact h1
+        · exact absurd hxC (mem_sdiff.1 (hB h2)).2
+      · intro hx1
+        exact ⟨Or.inl hx1, hA hx1⟩
+    simp only [mem_coe, mem_filter, mem_powersetCard]
+    refine ⟨⟨union_subset (hA.trans hC) (hB.trans sdiff_subset), ?_⟩, ?_⟩
+    · rw [card_union_of_disjoint hdisj, hAj, hBkj]
+      omega
+    · rw [hinterC, hAj]
+  · -- left inverse: `(S ∩ C) ∪ (S \ C) = S`
+    intro S _
+    simp only
+    rw [union_comm]
+    exact sdiff_union_inter S C
+  · -- right inverse: `((A ∪ B) ∩ C, (A ∪ B) \ C) = (A, B)`
+    intro p hp
+    simp only [mem_coe, mem_product, mem_powersetCard] at hp
+    obtain ⟨⟨hA, _⟩, hB, _⟩ := hp
+    have hinterC : (p.1 ∪ p.2) ∩ C = p.1 := by
+      ext x
+      simp only [mem_inter, mem_union]
+      constructor
+      · rintro ⟨h1 | h2, hxC⟩
+        · exact h1
+        · exact absurd hxC (mem_sdiff.1 (hB h2)).2
+      · intro hx1
+        exact ⟨Or.inl hx1, hA hx1⟩
+    have hsdiffC : (p.1 ∪ p.2) \ C = p.2 := by
+      ext x
+      simp only [mem_sdiff, mem_union]
+      constructor
+      · rintro ⟨h1 | h2, hxC⟩
+        · exact absurd (hA h1) hxC
+        · exact h2
+      · intro hx2
+        exact ⟨Or.inr hx2, (mem_sdiff.1 (hB hx2)).2⟩
+    rw [Prod.ext_iff]
+    exact ⟨hinterC, hsdiffC⟩
+
+/-!
+## The main result: the bound is sharp
+-/
+
+/-- **Erdős #83, lower bound (sharpness).** The Ahlswede–Khachatrian bound is
+achieved: there is a valid `2`-intersecting family of `2n`-subsets of `[4n]`
+whose cardinality is exactly `erdos83Bound n`. -/
+theorem erdos83_lower_bound (n : ℕ) (hn : 1 ≤ n) :
+    ∃ F : Finset (Finset (Fin (4 * n))),
+      IsValidErdos83Family n F ∧ F.card = erdos83Bound n := by
+  have huniv : (univ : Finset (Fin (4 * n))).card = 4 * n := by
+    rw [Finset.card_univ, Fintype.card_fin]
+  obtain ⟨C, hCsub, hCcard⟩ :=
+    exists_subset_card_eq (s := (univ : Finset (Fin (4 * n)))) (n := 2 * n)
+      (by rw [huniv]; omega)
+  set P : Finset (Finset (Fin (4 * n))) := univ.powersetCard (2 * n) with hP
+  set F : Finset (Finset (Fin (4 * n))) :=
+    P.filter (fun S => n + 1 ≤ (S ∩ C).card) with hF
+  refine ⟨F, ⟨?_, ?_⟩, ?_⟩
+  · -- `2n`-uniform
+    intro A hA
+    simp only [hF, hP, mem_filter, mem_powersetCard] at hA
+    exact hA.1.2
+  · -- `2`-intersecting
+    intro A hA B hB
+    simp only [hF, hP, mem_filter, mem_powersetCard] at hA hB
+    have key := two_mul_le_card_inter_add_core hA.2 hB.2
+    rw [hCcard] at key
+    omega
+  · -- the count equals `erdos83Bound n`
+    set L : Finset (Finset (Fin (4 * n))) :=
+      P.filter (fun S => (S ∩ C).card < n) with hL
+    set M : Finset (Finset (Fin (4 * n))) :=
+      P.filter (fun S => (S ∩ C).card = n) with hM
+    -- `|P| = C(4n, 2n)`
+    have hcardP : P.card = (4 * n).choose (2 * n) := by
+      rw [hP, card_powersetCard, huniv]
+    -- `|M| = C(2n, n)²`
+    have hcardM : M.card = ((2 * n).choose n) ^ 2 := by
+      have hcount := card_filter_inter_card_eq (G := (univ : Finset (Fin (4 * n))))
+        (C := C) hCsub (k := 2 * n) (j := n) (by omega)
+      have hGC : ((univ : Finset (Fin (4 * n))) \ C).card = 2 * n := by
+        rw [card_univ_diff, Fintype.card_fin, hCcard]; omega
+      have hsub2 : 2 * n - n = n := by omega
+      rw [hM, hP, hcount, hCcard, hGC, hsub2]
+      ring
+    -- complement involution gives `|F| = |L|`
+    have hcompl : F.card = L.card := by
+      apply card_nbij' (fun S => Sᶜ) (fun S => Sᶜ)
+      · intro S hS
+        simp only [mem_coe, hF, hP, mem_filter, mem_powersetCard] at hS
+        obtain ⟨⟨_, hScard⟩, hSge⟩ := hS
+        have hcc : (Sᶜ ∩ C).card = 2 * n - (S ∩ C).card := by
+          have heq : Sᶜ ∩ C = C \ S := by
+            ext x; simp only [mem_inter, mem_compl, mem_sdiff]; tauto
+          rw [heq, card_sdiff, hCcard]
+        simp only [mem_coe, hL, hP, mem_filter, mem_powersetCard]
+        refine ⟨⟨subset_univ _, ?_⟩, ?_⟩
+        · rw [card_compl, Fintype.card_fin, hScard]; omega
+        · rw [hcc]; omega
+      · intro S hS
+        simp only [mem_coe, hL, hP, mem_filter, mem_powersetCard] at hS
+        obtain ⟨⟨_, hScard⟩, hSlt⟩ := hS
+        have hcc : (Sᶜ ∩ C).card = 2 * n - (S ∩ C).card := by
+          have heq : Sᶜ ∩ C = C \ S := by
+            ext x; simp only [mem_inter, mem_compl, mem_sdiff]; tauto
+          rw [heq, card_sdiff, hCcard]
+        simp only [mem_coe, hF, hP, mem_filter, mem_powersetCard]
+        refine ⟨⟨subset_univ _, ?_⟩, ?_⟩
+        · rw [card_compl, Fintype.card_fin, hScard]; omega
+        · rw [hcc]; omega
+      · intro S _; simp
+      · intro S _; simp
+    -- partition `P = F ⊔ M ⊔ L`
+    have h1 : P.card
+        = F.card + (P.filter (fun S => ¬ n + 1 ≤ (S ∩ C).card)).card := by
+      rw [hF]
+      exact (filter_card_add_filter_neg_card_eq_card _).symm
+    have h2 : (P.filter (fun S => ¬ n + 1 ≤ (S ∩ C).card)).card = M.card + L.card := by
+      have e := filter_card_add_filter_neg_card_eq_card
+        (s := P.filter (fun S => ¬ n + 1 ≤ (S ∩ C).card))
+        (fun S => (S ∩ C).card = n)
+      have eM : (P.filter (fun S => ¬ n + 1 ≤ (S ∩ C).card)).filter
+          (fun S => (S ∩ C).card = n) = M := by
+        rw [hM, filter_filter]
+        apply filter_congr
+        intro S _
+        omega
+      have eL : (P.filter (fun S => ¬ n + 1 ≤ (S ∩ C).card)).filter
+          (fun S => ¬ (S ∩ C).card = n) = L := by
+        rw [hL, filter_filter]
+        apply filter_congr
+        intro S _
+        omega
+      rw [eM, eL] at e
+      omega
+    have hLF : L.card = F.card := hcompl.symm
+    have hkey : (4 * n).choose (2 * n) = 2 * F.card + ((2 * n).choose n) ^ 2 := by
+      rw [← hcardP]; omega
+    show F.card = erdos83Bound n
+    unfold erdos83Bound
+    omega

--- a/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "divisibility-rules-oq-01-oq-02-oq-01",
+  "title": "Divisibility Rules OQ-01-OQ-02-OQ-01: Which Moduli Admit an Alternating-Digit-Sum Rule",
+  "slug": "divisibility-rules-oq-01-oq-02-oq-01",
+  "description": "Resolves the parent's named open question on the alternating digit-sum rule (the base-10 rule for 11, where 10 ≡ -1). Unlike the digit-sum rule — which the parent showed exists for EVERY modulus coprime to 10 — the alternating rule is not universal, and this entry pins down exactly which moduli admit one. Two main results: (1) a genuine per-base iff, altRule_base_iff, showing the base-10^k alternating rule holds for all n iff (10 : ZMod d)^k = -1, with necessity forced by the single test value n = 10^k+1 (digits [1,1], alternating sum 0); and (2) the sharp characterization altRule_exists_iff: for d > 2 coprime to 10 a power-of-10 alternating rule exists iff ord_d(10) is even and 10^{ord_d(10)/2} ≡ -1 (mod d), equivalently -1 is a power of 10 in ZMod d. Concrete positive instances (11 at k=1; 7 and 13 at k=3) and negative instances (3, with 10 ≡ 1; 37, with ord_37(10) = 3 odd). Fully machine-checked with no sorries and no axioms beyond Lean's foundational triple; all finite congruence checks are kernel `decide` (not native_decide), so the file is free of Lean.ofReduceBool.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DivisibilityRulesOQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "elementary-number-theory",
+      "multiplicative-order",
+      "extensions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms. Every headline theorem (altRule_base_iff, exists_pow_neg_one_iff_order, altRule_exists_iff) and all concrete instances (eleven_altRule, seven_altRule, thirteen_altRule, three_no_altRule, thirtyseven_no_altRule) depend only on [propext, Classical.choice, Quot.sound], verified by #print axioms. The finite congruence checks (10^1 ≡ -1 mod 11, 10^3 ≡ -1 mod 7 and mod 13, 10^3 ≡ 1 mod 37, 10 ≡ 1 mod 3) are discharged by kernel `decide` over decidable arithmetic in ZMod d (not native_decide), so the proof does NOT depend on Lean.ofReduceBool.",
+    "lineCount": 282,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "originalContributions": [
+      "Genuine per-base iff (altRule_base_iff): the base-10^k alternating digit-sum rule holds for all n iff (10 : ZMod d)^k = -1, with necessity forced by a single test value n = 10^k+1 — so a working base provably satisfies 10^k ≡ -1 (mod d), not merely the converse",
+      "Sharp solvability characterization (altRule_exists_iff): for d > 2 coprime to 10, a power-of-10 alternating rule exists iff ord_d(10) is even and 10^{ord_d(10)/2} ≡ -1 (mod d), with witness base 10^{ord_d(10)/2}",
+      "Cyclic-group core (exists_pow_neg_one_iff_order): -1 ∈ ⟨10⟩ in ZMod d iff |⟨10⟩| = ord_d(10) is even and 10^{ord_d(10)/2} is the order-two element -1",
+      "Concrete negative instances showing non-universality: no power-of-10 alternating rule for 3 (10 ≡ 1) or 37 (order 3 is odd)",
+      "0-axiom, native_decide-free formalization (kernel decide for all finite checks), the alternating counterpart to the parent's universal digit-sum theorem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The familiar divisibility-by-11 test alternately adds and subtracts the decimal digits, because 10 ≡ -1 (mod 11): then 10^k ≡ (-1)^k, so n = Σ dᵢ 10^i ≡ Σ dᵢ (-1)^i = d₀ - d₁ + d₂ - ⋯ (mod 11). The parent gallery entry (divisibility-rules-oq-01-oq-02) showed the ordinary digit-sum rule (driven by 10^k ≡ 1) exists for EVERY modulus coprime to 10, and explicitly left open the alternating analogue: which moduli admit an alternating-digit-sum rule? The alternating rule needs the sharper congruence 10^k ≡ -1 (mod d), i.e. -1 must lie in the cyclic group ⟨10⟩ ⊆ (ZMod d)ˣ. A cyclic group contains the order-two element -1 exactly when its order is even, in which case the unique such element is the (order/2)-power of any generator. This is why 11 (ord 2), 7 and 13 (ord 6) have alternating rules but 3 (ord 1) and 37 (ord 3) do not.",
+    "problemStatement": "Characterize exactly which moduli d coprime to 10 admit a power-of-10 alternating-digit-sum divisibility rule (the parent's named open question). Equivalently, determine when -1 is a power of 10 modulo d, and exhibit the witness base when it exists.",
+    "proofStrategy": "The workhorse altRule_of_pow_neg_one reduces the base-10^k alternating rule for d to the single condition (10 : ZMod d)^k = -1, by feeding the integer divisibility d ∣ 10^k+1 into Mathlib's Nat.dvd_iff_dvd_ofDigits and rewriting ofDigits(-1) as the alternating sum via Nat.ofDigits_neg_one. The bridge pow_zmod_eq_neg_one_iff converts between (10 : ZMod d)^k = -1 and d ∣ 10^k+1 using ZMod.intCast_zmod_eq_zero_iff_dvd. Necessity (altRule_base_iff) is forced by evaluating the rule at n = 10^k+1: its base-10^k digits are [1,1] (digits_pow_add_one) with alternating sum 0, so the rule collapses to d ∣ 10^k+1. The order characterization exists_pow_neg_one_iff_order is the cyclic-group argument: from 10^k = -1, squaring gives ord ∣ 2k while ord ∤ k (else 10^k = 1 = -1, impossible as d > 2 via one_ne_neg_one), forcing ord even; writing k = (ord/2)·q and using (10^{ord/2})² = 10^ord = 1 shows q is odd and hence 10^{ord/2} = -1. Positivity of the order (orderOf_ten_pos) follows because it divides φ(d) > 0. Concrete instances discharge their finite congruences with kernel decide.",
+    "keyInsights": [
+      "An alternating digit-sum rule in base B = 10^k holds for d precisely because B ≡ -1 (mod d); the entire question reduces to whether -1 is a power of 10 modulo d.",
+      "The converse is genuine, not assumed: testing the rule at the single value n = 10^k+1 (digits [1,1], alternating sum 0) forces d ∣ 10^k+1, so any base for which the rule holds must satisfy 10^k ≡ -1.",
+      "In the cyclic group ⟨10⟩ ⊆ (ZMod d)ˣ, the element -1 has order 2; a cyclic group contains an order-two element iff its order is even, and that element is the (order/2)-power of the generator — hence the 'ord even and 10^{ord/2} ≡ -1' criterion.",
+      "The non-universality is sharp: moduli with 10 of odd order (e.g. 3, 37) admit no alternating rule, in contrast to the digit-sum rule which exists for every modulus coprime to 10.",
+      "Kernel `decide` (not native_decide) discharges every finite congruence, so the entry is genuinely 0-axiom (no Lean.ofReduceBool)."
+    ],
+    "prerequisites": [
+      "Modular arithmetic and casts between ℕ, ℤ and ZMod d (ZMod.intCast_zmod_eq_zero_iff_dvd, ZMod.natCast_eq_zero_iff)",
+      "Nat.digits / Nat.ofDigits, Nat.dvd_iff_dvd_ofDigits and Nat.ofDigits_neg_one (alternating sum)",
+      "Multiplicative order in a monoid (orderOf, orderOf_dvd_iff_pow_eq_one) and the Fermat–Euler theorem (Nat.ModEq.pow_totient)",
+      "Basic cyclic-group reasoning: order divides φ(d), coprimality of an odd number with 2"
+    ]
+  },
+  "conclusion": {
+    "summary": "Thirteen theorems establish a genuine per-base iff for the alternating digit-sum rule (it holds for base 10^k iff 10^k ≡ -1 mod d), and the sharp solvability criterion that a power-of-10 alternating rule exists for d > 2 coprime to 10 iff ord_d(10) is even and 10^{ord_d(10)/2} ≡ -1 (mod d). Positive instances (11, 7, 13) and negative instances (3, 37) illustrate the dichotomy.",
+    "implications": "This is the alternating counterpart to the parent's universal digit-sum theorem and completes its open question. Where the digit-sum rule exists for every modulus coprime to 10, the alternating rule exists only for the 'even-order' moduli, with the witness base 10^{ord_d(10)/2} explicitly identified. The proof is 0-axiom and native_decide-free.",
+    "openQuestions": [
+      "For an arbitrary radix r in place of 10, characterize the moduli admitting an alternating-digit-sum rule: -1 ∈ ⟨r⟩ in ZMod d iff ord_d(r) is even and r^{ord_d(r)/2} ≡ -1 (mod d), with the witness base r^{ord_d(r)/2}.",
+      "Unify the digit-sum and alternating rules under blocked sums of length ℓ (grouping digits ℓ at a time): a base-10^k block rule with period-ℓ sign pattern exists iff 10^k generates the relevant cyclic quotient, recovering both as the ℓ = 1 and the order-2 sign cases."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-divOQ010201-base-condition",
+      "title": "Part I: The Base Condition (10 : ZMod d)^k = -1",
+      "startLine": 52,
+      "endLine": 72,
+      "summary": "pow_zmod_eq_neg_one_iff bridges the algebraic condition (10 : ZMod d)^k = -1 and the integer divisibility d ∣ 10^k+1 via ZMod.intCast_zmod_eq_zero_iff_dvd. The workhorse altRule_of_pow_neg_one then derives the base-10^k alternating digit-sum rule from that condition, feeding d ∣ 10^k+1 into Mathlib's Nat.dvd_iff_dvd_ofDigits and rewriting ofDigits(-1) as the alternating sum."
+    },
+    {
+      "id": "sec-divOQ010201-base-iff",
+      "title": "Part II: A Genuine Per-Base Iff",
+      "startLine": 83,
+      "endLine": 113,
+      "summary": "digits_pow_add_one computes the base-10^k digits of 10^k+1 as [1,1]. altRule_base_iff upgrades the workhorse to a per-base equivalence: the base-10^k alternating rule holds for all n iff (10 : ZMod d)^k = -1, with necessity forced by evaluating at n = 10^k+1 (alternating sum 0)."
+    },
+    {
+      "id": "sec-divOQ010201-order",
+      "title": "Part III: The Sharp Order Characterization",
+      "startLine": 124,
+      "endLine": 197,
+      "summary": "orderOf_ten_pos shows ord_d(10) > 0 (it divides φ(d) > 0) and one_ne_neg_one records 1 ≠ -1 in ZMod d for d > 2. exists_pow_neg_one_iff_order is the cyclic-group core: -1 is a power of 10 iff ord_d(10) is even and 10^{ord_d(10)/2} = -1, proved by squaring (ord ∣ 2k, ord ∤ k ⟹ ord even) and an order-two parity argument."
+    },
+    {
+      "id": "sec-divOQ010201-main",
+      "title": "Part IV: Main Theorem",
+      "startLine": 207,
+      "endLine": 224,
+      "summary": "altRule_exists_iff assembles the per-base iff and the order characterization into the headline statement: for d > 2 coprime to 10, a power-of-10 alternating digit-sum rule exists iff ord_d(10) is even and 10^{ord_d(10)/2} ≡ -1 (mod d), with witness base 10^{ord_d(10)/2}."
+    },
+    {
+      "id": "sec-divOQ010201-instances",
+      "title": "Part V: Concrete Instances",
+      "startLine": 241,
+      "endLine": 277,
+      "summary": "Positive instances via the workhorse: 11 (base 10^1, 10 ≡ -1), 7 and 13 (base 10^3, 10^3 ≡ -1). Negative instances showing non-universality: three_no_altRule (10 ≡ 1 mod 3, every power is 1 ≠ -1) and thirtyseven_no_altRule (ord_37(10) = 3 odd; the powers {1,10,26} miss -1 = 36)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-rules-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Resolves the named open question of divisibility-rules-oq-01-oq-02 — characterizing which moduli admit an alternating-digit-sum rule — as the alternating counterpart to its universal digit-sum theorem"
+    },
+    {
+      "targetId": "divisibility-rules",
+      "relationship": "related",
+      "description": "Generalizes the divisibility-by-11 alternating-digit mechanism (10 ≡ -1 mod 11) to a complete characterization over all moduli coprime to 10"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 282,
+    "path": "Proofs/DivisibilityRulesOQ01OQ02OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 13
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-83-oq-01/meta.json
+++ b/src/data/proofs/erdos-83-oq-01/meta.json
@@ -1,0 +1,101 @@
+{
+  "id": "erdos-83-oq-01",
+  "title": "Erdős #83 OQ-01: Sharpness of the Complete Intersection Bound (Achievability)",
+  "slug": "erdos-83-oq-01",
+  "description": "The Ahlswede–Khachatrian Complete Intersection Theorem (Erdős #83, $500 prize) states that a family F of 2n-subsets of [4n] with |A ∩ B| ≥ 2 for all A, B ∈ F satisfies |F| ≤ ½(C(4n,2n) − C(2n,n)²). The deep upper bound (proved by Ahlswede–Khachatrian's 'pushing–pulling' method) is correctly axiomatized in the parent entry. This entry supplies the elementary, fully machine-checked LOWER bound — that the inequality is SHARP — by exhibiting a valid family that attains it exactly. The witness is the majority family: fix a 2n-element core C ⊆ [4n] and take all 2n-subsets meeting C in ≥ n+1 elements. Two such sets share ≥ (n+1)+(n+1)−2n = 2 core elements (pigeonhole), so the family is 2-intersecting; and the complement involution S ↦ Sᶜ pairs the majority sets with the minority sets, leaving the C(2n,n)² 'balanced' sets in the middle, whence the count is exactly ½(C(4n,2n) − C(2n,n)²). Verified with 0 sorries and no axioms beyond Lean's foundational triple (no native_decide / Lean.ofReduceBool).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos83LowerBound.lean",
+    "tags": [
+      "combinatorics",
+      "extremal-set-theory",
+      "intersecting-families",
+      "erdos",
+      "ahlswede-khachatrian",
+      "vandermonde",
+      "extensions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms. The three headline results (two_mul_le_card_inter_add_core, card_filter_inter_card_eq, erdos83_lower_bound) depend only on [propext, Classical.choice, Quot.sound], confirmed by #print axioms. The proof uses no native_decide and therefore does NOT depend on Lean.ofReduceBool. Only the LOWER bound (achievability) is proved here; the matching upper bound is the deep Ahlswede–Khachatrian theorem, which is axiomatized in the parent entry erdos-83.",
+    "lineCount": 261,
+    "theoremCount": 3,
+    "definitionCount": 4,
+    "originalContributions": [
+      "Machine-checked proof that the Ahlswede–Khachatrian bound for Erdős #83 is SHARP: erdos83_lower_bound exhibits a valid 2-intersecting family of 2n-subsets of [4n] of cardinality exactly ½(C(4n,2n) − C(2n,n)²), the elementary companion to the axiomatized upper bound",
+      "A reusable split-count lemma card_filter_inter_card_eq: among the k-subsets of a ground set G, exactly C(|C|,j)·C(|G∖C|,k−j) of them meet a fixed C ⊆ G in j points, proved by the bijection S ↦ (S ∩ C, S ∖ C)",
+      "A general core-pigeonhole lemma two_mul_le_card_inter_add_core: if A and B each meet C in ≥ s points then 2s ≤ |A ∩ B| + |C|, the inclusion–exclusion reason the majority family is 2-intersecting",
+      "A clean counting argument via the complement involution S ↦ Sᶜ: it pairs the 'majority' (≥ n+1 in core) and 'minority' (< n in core) families, so |majority| = (|powersetCard| − |balanced|)/2 = (C(4n,2n) − C(2n,n)²)/2 — avoiding any explicit Vandermonde sum manipulation",
+      "0-axiom, native_decide-free formalization establishing the achievability half of a $500 Erdős problem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős, Ko and Rado (1961) determined the largest 1-intersecting family of k-subsets of [n] for n ≥ 2k. They conjectured the analogue for t-intersecting families and, for the specific case (m,k,t) = (4n,2n,2), the bound ½(C(4n,2n) − C(2n,n)²) — the '4m conjecture'. The general Complete Intersection Theorem was finally proved by Ahlswede and Khachatrian (1997), earning the $500 Erdős prize; its extremal families are the 'r-th frankl families' A(r) of all k-subsets containing ≥ t+r elements of a fixed (t+2r)-set. For Erdős #83 the optimal family is the r = n−1 case: 2n-subsets of [4n] meeting a fixed 2n-set in ≥ n+1 points. The upper bound is genuinely deep, but the matching lower bound (that this family is valid and has the claimed size) is elementary — and is what this entry verifies.",
+    "problemStatement": "Show that the Ahlswede–Khachatrian bound for Erdős #83 is attained: construct a family F of 2n-subsets of [4n] with |A ∩ B| ≥ 2 for all A, B ∈ F and |F| = ½(C(4n,2n) − C(2n,n)²).",
+    "proofStrategy": "Fix a core C ⊆ [4n] with |C| = 2n (obtained from exists_subset_card_eq) and let F be the majority family — the 2n-subsets S with |S ∩ C| ≥ n+1. Validity splits in two: F is 2n-uniform by construction (membership in powersetCard 2n), and 2-intersecting by two_mul_le_card_inter_add_core, an inclusion–exclusion pigeonhole giving |A ∩ B| ≥ 2(n+1) − |C| = 2. For the count, partition the 2n-subsets P = powersetCard 2n [4n] into the majority family F (|S∩C| ≥ n+1), the balanced family M (|S∩C| = n) and the minority family L (|S∩C| < n). The complement involution S ↦ Sᶜ maps P to itself (|Sᶜ| = 4n−2n = 2n) and sends |S∩C| to |Sᶜ∩C| = |C| − |S∩C| = 2n − |S∩C|, so it is a bijection F ≃ L; hence |F| = |L|. The split-count lemma card_filter_inter_card_eq gives |M| = C(2n,n)·C(2n,n) = C(2n,n)². Since |P| = C(4n,2n) = |F| + |M| + |L| = 2|F| + C(2n,n)², we get |F| = (C(4n,2n) − C(2n,n)²)/2 = erdos83Bound n.",
+    "keyInsights": [
+      "The bound's two terms have a combinatorial meaning: C(4n,2n) counts all 2n-subsets, C(2n,n)² counts the 'balanced' ones (exactly n in the core), and the factor ½ comes from the complement symmetry between 'majority' and 'minority' subsets.",
+      "2-intersecting-ness is pure pigeonhole within the core: two sets each with ≥ n+1 of the core's 2n elements overlap in ≥ 2 of them, since (n+1)+(n+1) exceeds 2n by 2.",
+      "The complement involution S ↦ Sᶜ turns the counting identity into a one-line bijection, replacing the usual Vandermonde sum ∑ C(2n,j)² = C(4n,2n) with a symmetry argument.",
+      "The split-count lemma (k-subsets meeting C in j points number C(|C|,j)·C(|G∖C|,k−j)) is the finite-combinatorics workhorse here and is stated and proved in full generality via the bijection S ↦ (S ∩ C, S ∖ C).",
+      "This is the achievability (lower-bound) half of Erdős #83 only; the matching upper bound is the deep Ahlswede–Khachatrian theorem and remains axiomatized."
+    ],
+    "prerequisites": [
+      "Finite set families: Finset.powersetCard, mem_powersetCard, card_powersetCard (the C(n,k) formula)",
+      "Cardinality identities: card_union_add_card_inter (inclusion–exclusion), card_inter_add_card_sdiff, card_sdiff, card_compl, card_univ_diff",
+      "Bijective counting: Finset.card_nbij' and product cardinality card_product",
+      "Filter partitions: filter_card_add_filter_neg_card_eq_card, filter_filter, filter_congr"
+    ]
+  },
+  "conclusion": {
+    "summary": "Three theorems establish that the Ahlswede–Khachatrian bound for Erdős #83 is sharp: a core-pigeonhole lemma (two_mul_le_card_inter_add_core) showing the majority family is 2-intersecting, a general split-count lemma (card_filter_inter_card_eq), and the main result (erdos83_lower_bound) constructing a valid 2-intersecting family of 2n-subsets of [4n] with cardinality exactly ½(C(4n,2n) − C(2n,n)²).",
+    "implications": "Together with the axiomatized upper bound in the parent entry erdos-83, this pins the extremal number for Erdős #83 from below: the deep inequality is not merely an upper estimate but is attained, by an explicit and elementary family. The split-count and pigeonhole lemmas are reusable for other extremal-set-theory formalizations.",
+    "openQuestions": [
+      "Formalize the matching upper bound — the full Ahlswede–Khachatrian Complete Intersection Theorem — replacing the axiom in the parent entry; this is a major undertaking requiring the 'pushing–pulling' generalization of Frankl's shifting.",
+      "Generalize the verified lower bound to arbitrary (m,k,t): show the Frankl family A(r) of k-subsets meeting a fixed (t+2r)-set in ≥ t+r points is t-intersecting and compute its cardinality, giving the achievability half of the Complete Intersection Theorem for all parameters."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-erdos83oq01-pigeonhole",
+      "title": "Part I: Core Pigeonhole (2-Intersecting)",
+      "startLine": 62,
+      "endLine": 78,
+      "summary": "two_mul_le_card_inter_add_core: if A and B each meet C in ≥ s points then 2s ≤ |A ∩ B| + |C|. Proof is inclusion–exclusion inside C — (A∩C) and (B∩C) are subsets of C, so their union has ≤ |C| elements, and their intersection (A∩B∩C) is contained in A∩B. Specializing s = n+1, |C| = 2n gives |A ∩ B| ≥ 2, the reason the majority family is 2-intersecting."
+    },
+    {
+      "id": "sec-erdos83oq01-splitcount",
+      "title": "Part II: Split Count by Core Intersection",
+      "startLine": 86,
+      "endLine": 158,
+      "summary": "card_filter_inter_card_eq: among the k-subsets of a ground set G, exactly C(|C|,j)·C(|G∖C|,k−j) meet a fixed C ⊆ G in j points. Proved with Finset.card_nbij' via the bijection S ↦ (S ∩ C, S ∖ C) (inverse (A,B) ↦ A ∪ B), checking it lands in the product of powersetCard's and that the two maps are mutually inverse."
+    },
+    {
+      "id": "sec-erdos83oq01-main",
+      "title": "Part III: The Bound Is Sharp",
+      "startLine": 167,
+      "endLine": 261,
+      "summary": "erdos83_lower_bound: fixing a 2n-core C, the majority family F = {S ∈ powersetCard 2n : |S ∩ C| ≥ n+1} is valid (2n-uniform + 2-intersecting) and has |F| = erdos83Bound n. The count partitions powersetCard 2n into F (majority), M (balanced, |M| = C(2n,n)² by the split count) and L (minority); the complement involution S ↦ Sᶜ gives |F| = |L|, so |F| = (C(4n,2n) − C(2n,n)²)/2."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-83",
+      "relationship": "extends",
+      "description": "Supplies the elementary, fully verified lower bound (achievability) for Erdős #83, complementing the axiomatized Ahlswede–Khachatrian upper bound in the parent entry"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 261,
+    "path": "Proofs/Erdos83LowerBound.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 3
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Erdős Problem **#83** is the case `(m,k,t) = (4n,2n,2)` of the **Ahlswede–Khachatrian Complete Intersection Theorem** ($500 Erdős prize): a family `F` of `2n`-subsets of `[4n]` with `|A ∩ B| ≥ 2` for all `A, B ∈ F` satisfies

```
|F| ≤ ½ (C(4n,2n) − C(2n,n)²)
```

The **upper bound** is the deep theorem (its "pushing–pulling" proof is correctly **axiomatized** in the parent gallery entry `erdos-83`). This PR adds the elementary, **fully machine-checked lower bound** — that the inequality is **sharp**:

> `erdos83_lower_bound`: there exists a *valid* `2`-intersecting family of `2n`-subsets of `[4n]` whose cardinality is **exactly** `½ (C(4n,2n) − C(2n,n)²)`.

This is the achievability half of a $500 Erdős problem, verified 0-axiom, complementing (not reproving) the axiomatized upper bound.

## The construction

The witness is the **majority family**: fix a `2n`-element core `C ⊆ [4n]` and take all `2n`-subsets meeting `C` in `≥ n+1` elements.

- **2-intersecting** by core pigeonhole (`two_mul_le_card_inter_add_core`): two sets each with `≥ n+1` of the `2n` core elements overlap in `≥ (n+1)+(n+1)−2n = 2`.
- **Counting** via the complement involution `S ↦ Sᶜ`, which is a bijection between the "majority" (`≥ n+1` in core) and "minority" (`< n` in core) subsets, leaving the `C(2n,n)²` "balanced" subsets in the middle. A general split-count lemma `card_filter_inter_card_eq` (k-subsets meeting `C` in `j` points number `C(|C|,j)·C(|G∖C|,k−j)`, via `S ↦ (S∩C, S∖C)`) gives `|balanced| = C(2n,n)²`, so `|majority| = (C(4n,2n) − C(2n,n)²)/2`.

## Verification

- **3 theorems, 4 definitions, 261 lines, 0 sorries.**
- `#print axioms` on all three headline results yields only `[propext, Classical.choice, Quot.sound]` — no `native_decide`, no `Lean.ofReduceBool`.
- Builds clean: `lake env lean Proofs/Erdos83LowerBound.lean` (EXIT 0).

## Files

- `proofs/Proofs/Erdos83LowerBound.lean` — the proof
- `src/data/proofs/erdos-83-oq-01/meta.json` — gallery entry (`status: verified`, `badge: original`, `axiomCount: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)