### PR TITLE
research(law-of-cosines-oq-07-oq-02): sum of squared medians 4(mₐ²+m_b²+m_c²)=3(a²+b²+c²) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ07OQ02.lean
+++ b/proofs/Proofs/LawOfCosinesOQ07OQ02.lean
@@ -1,0 +1,88 @@
+import Mathlib
+import Proofs.LawOfCosinesOQ07
+
+/-
+# Law of Cosines — OQ-07-OQ-02: Sum of the squared medians of a triangle
+
+## Research Problem: law-of-cosines-oq-07-oq-02
+
+OQ: In any triangle with sides `a, b, c` and medians `mₐ, m_b, m_c`, the sum of
+the squares of the medians is exactly three quarters of the sum of the squares
+of the sides:
+
+    mₐ² + m_b² + m_c² = ¾ · (a² + b² + c²),
+
+equivalently `4·(mₐ² + m_b² + m_c²) = 3·(a² + b² + c²)`.
+
+This is the natural three-fold consequence of the parent's `median_length`
+formula (`law-of-cosines-oq-07`):
+
+    4·mₐ² = 2·b² + 2·c² − a²      (median from the `a`-vertex),
+
+applied cyclically to all three medians and summed. Each side-square appears in
+the running total with net coefficient `2 + 2 − 1 = 3`, while the median sum
+carries the factor `4`, yielding `4·∑m² = 3·∑s²`.
+
+Like the parent, the statement is **coordinate-free**: the vertices `a b c` are
+genuine points of a real inner-product affine space (`NormedAddTorsor`), the
+medians are `dist`s to honest `midpoint`s, and no scalar side-length
+parameterisation is introduced. The result therefore holds in every Euclidean
+affine space, of any dimension.
+
+DISTINCT from the parent `law-of-cosines-oq-07` (single median, Apollonius) and
+from `law-of-cosines-oq-04` (scalar Stewart/median-length algebra): here the
+content is the *global* relation across all three medians at once.
+
+Tags: geometry, median, apollonius, law-of-cosines
+-/
+
+open LawOfCosinesOQ07
+
+namespace LawOfCosinesOQ07OQ02
+
+variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+  [MetricSpace P] [NormedAddTorsor V P]
+
+/-- **Sum of squared medians** (metric / coordinate-free form).
+
+For a triangle with vertices `a b c` in a real inner-product affine space, write
+`mₐ = dist a (midpoint ℝ b c)`, `m_b = dist b (midpoint ℝ a c)`,
+`m_c = dist c (midpoint ℝ a b)` for the three medians. Then
+
+    4·(mₐ² + m_b² + m_c²) = 3·(ab² + bc² + ca²).
+
+Proof: sum the parent's `median_length` identity over the three vertices. After
+folding the `dist`-symmetries `dist b a = dist a b`, `dist a c = dist c a`,
+`dist c b = dist b c`, each side-square gathers coefficient `3` and the medians
+the factor `4`; `linear_combination` of the three instances closes the goal. -/
+theorem sum_sq_medians (a b c : P) :
+    4 * (dist a (midpoint ℝ b c) ^ 2
+        + dist b (midpoint ℝ a c) ^ 2
+        + dist c (midpoint ℝ a b) ^ 2)
+      = 3 * (dist a b ^ 2 + dist b c ^ 2 + dist c a ^ 2) := by
+  have ha := median_length a b c
+  have hb := median_length b a c
+  have hc := median_length c a b
+  simp only [dist_comm a c, dist_comm b a, dist_comm c b] at ha hb hc
+  linear_combination ha + hb + hc
+
+/-- **Sum of squared medians** in the `¾` ratio form: the median squares sum to
+three quarters of the side squares. A direct rescaling of `sum_sq_medians`. -/
+theorem sum_sq_medians_three_quarters (a b c : P) :
+    dist a (midpoint ℝ b c) ^ 2
+        + dist b (midpoint ℝ a c) ^ 2
+        + dist c (midpoint ℝ a b) ^ 2
+      = 3 / 4 * (dist a b ^ 2 + dist b c ^ 2 + dist c a ^ 2) := by
+  have h := sum_sq_medians a b c
+  linear_combination h / 4
+
+/-- Concrete instantiation in the Euclidean plane `EuclideanSpace ℝ (Fin 2)`:
+the abstract median identity holds in the standard model of plane geometry. -/
+example (a b c : EuclideanSpace ℝ (Fin 2)) :
+    4 * (dist a (midpoint ℝ b c) ^ 2
+        + dist b (midpoint ℝ a c) ^ 2
+        + dist c (midpoint ℝ a b) ^ 2)
+      = 3 * (dist a b ^ 2 + dist b c ^ 2 + dist c a ^ 2) :=
+  sum_sq_medians a b c
+
+end LawOfCosinesOQ07OQ02

--- a/src/data/proofs/law-of-cosines-oq-07-oq-02/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "law-of-cosines-oq-07-oq-02",
+  "title": "Sum of the Squared Medians of a Triangle",
+  "slug": "law-of-cosines-oq-07-oq-02",
+  "description": "The sum of the squares of the three medians of a triangle equals three quarters of the sum of the squares of its sides: 4·(mₐ² + m_b² + m_c²) = 3·(a² + b² + c²). Proved coordinate-free for points of an arbitrary real inner-product affine space by summing the parent's median-length identity over all three vertices. Answers the openQuestion of law-of-cosines-oq-07.",
+  "meta": {
+    "author": "Robb Walters (researcher-3)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ07OQ02.lean",
+    "tags": [
+      "geometry",
+      "median",
+      "apollonius",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 88,
+    "assumptions": "No axioms or sorries. Theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions).",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Sum-of-squared-medians identity 4·(mₐ² + m_b² + m_c²) = 3·(a² + b² + c²) stated coordinate-free for a triangle in an arbitrary NormedAddTorsor over a real inner product space",
+      "Derived purely from three cyclic applications of the parent's metric median-length formula plus dist-symmetry, closed by a single linear_combination",
+      "The ¾-ratio form mₐ² + m_b² + m_c² = ¾·(a² + b² + c²) as an immediate rescaling"
+    ],
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the three medians of a triangle satisfy mₐ² + m_b² + m_c² = ¾(a² + b² + c²) is a classical corollary of Apollonius's median theorem, known since antiquity and standard in Euclidean geometry. Each median length is governed by Apollonius's relation 4mₐ² = 2b² + 2c² − a²; summing the three instances cyclically, every side-square is counted with net weight 2 + 2 − 1 = 3, giving the global identity. Here the result is cast coordinate-free in an arbitrary real inner-product affine space, built directly on the parent entry law-of-cosines-oq-07.",
+    "problemStatement": "In any triangle with vertices $a, b, c$ and medians $m_a = \\operatorname{dist}(a, \\operatorname{midpoint}(b,c))$, $m_b$, $m_c$, prove the sum-of-squared-medians identity $4(m_a^2 + m_b^2 + m_c^2) = 3(\\operatorname{dist}(a,b)^2 + \\operatorname{dist}(b,c)^2 + \\operatorname{dist}(c,a)^2)$, equivalently $m_a^2 + m_b^2 + m_c^2 = \\tfrac34(a^2+b^2+c^2)$.",
+    "text": "Sums the parent's coordinate-free median-length formula over the three vertices of the triangle and collapses the result with linear_combination after folding dist-symmetry.",
+    "proofStrategy": "1. sum_sq_medians: instantiate the parent's median_length at (a b c), (b a c), (c a b), giving 4mₐ², 4m_b², 4m_c² in terms of the squared sides. Normalise the dist-symmetries (dist b a = dist a b, dist a c = dist c a, dist c b = dist b c) with simp only [dist_comm …], then close with linear_combination ha + hb + hc: each side-square accumulates coefficient 2 + 2 − 1 = 3 while the medians carry the factor 4. 2. sum_sq_medians_three_quarters: rescale by ¼ via linear_combination h / 4.",
+    "keyInsights": [
+      "The identity is the exact three-fold sum of Apollonius's median-length relation: the only arithmetic content is that each squared side appears once as the 'opposite' side (coefficient −1) and twice as an 'adjacent' side (coefficient +2 each), summing to 3.",
+      "Casting the statement coordinate-free (points and genuine midpoints in a NormedAddTorsor, not scalar side lengths) means it holds verbatim in every Euclidean affine space of any dimension, not just the plane.",
+      "Folding the three dist-symmetries with a single simp only is what lets linear_combination treat the squared sides as common ring atoms; without it the symmetric distances dist a b and dist b a would be distinct terms and the cancellation would not close.",
+      "The whole derivation is axiom-clean (only propext / Classical.choice / Quot.sound) and uses no decision procedure — just two linear_combination calls over the reals."
+    ],
+    "prerequisites": [
+      "Inner-product affine spaces (NormedAddTorsor over a real inner product space)",
+      "Apollonius's median-length identity (law-of-cosines-oq-07)",
+      "Symmetry of the metric (dist_comm)",
+      "Lean 4 tactic linear_combination"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-sum-medians",
+      "title": "Part I: Sum of Squared Medians",
+      "startLine": 44,
+      "endLine": 66,
+      "summary": "The identity 4·(mₐ² + m_b² + m_c²) = 3·(ab² + bc² + ca²) obtained by summing the parent's median_length over the three vertices and closing with linear_combination after folding dist-symmetry."
+    },
+    {
+      "id": "part2-three-quarters",
+      "title": "Part II: Three-Quarters Ratio Form",
+      "startLine": 68,
+      "endLine": 78,
+      "summary": "The rescaled form mₐ² + m_b² + m_c² = ¾·(ab² + bc² + ca²), a ¼-rescaling of Part I."
+    },
+    {
+      "id": "part3-instantiation",
+      "title": "Part III: Euclidean Plane Instantiation",
+      "startLine": 80,
+      "endLine": 88,
+      "summary": "Specialisation of the median-sum identity to the standard Euclidean plane EuclideanSpace ℝ (Fin 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The classical sum-of-squared-medians identity 4(mₐ² + m_b² + m_c²) = 3(a² + b² + c²) is proved coordinate-free in an arbitrary real inner-product affine space by summing the parent's metric median-length formula over the three vertices. Verified, 0 axioms, 0 sorries, no decision procedures. Directly answers the openQuestion posed by law-of-cosines-oq-07.",
+    "openQuestions": [
+      "The centroid g (intersection of the medians) satisfies dist(g,a)² + dist(g,b)² + dist(g,c)² = ⅓(a² + b² + c²), and more generally for any point p, ∑ dist(p, vertex)² = 3·dist(p,g)² + ∑ dist(g, vertex)² (Leibniz / Lagrange identity). Can the centroid version be derived from this median-sum entry together with the 2:1 median-ratio?"
+    ],
+    "implications": "Shows that a global metric relation across all three medians of a triangle is a one-line consequence of the single-median Apollonius identity, and that — like its parent — it lives naturally at the level of inner-product affine spaces rather than coordinatised side lengths."
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines-oq-07",
+      "relationship": "parent-problem",
+      "description": "Directly answers the parent's openQuestion: the sum-of-squared-medians identity 4(mₐ²+m_b²+m_c²)=3(a²+b²+c²) derived from three applications of the parent's median_length formula 4mₐ²=2b²+2c²−a²."
+    },
+    {
+      "targetId": "law-of-cosines-oq-04",
+      "relationship": "related",
+      "description": "Stewart's theorem (oq-04) is the scalar algebraic median-length identity; this entry sums the metric median length over all three vertices to obtain the global median-sum relation."
+    }
+  ],
+  "references": [
+    {
+      "author": "Apollonius of Perga",
+      "title": "Classical median theorem (Apollonius's theorem)",
+      "year": -200,
+      "note": "Source of the single-median identity that is summed here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.LawOfCosinesOQ07"
+    ],
+    "namespace": "LawOfCosinesOQ07OQ02",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/LawOfCosinesOQ07OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/law-of-cosines-oq-07-oq-02.json
+++ b/src/data/research/problems/law-of-cosines-oq-07-oq-02.json
@@ -1,0 +1,283 @@
+{
+  "slug": "law-of-cosines-oq-07-oq-02",
+  "title": "Apollonius Median-Sum Identity: 4(ma^2+mb^2+mc^2)=3(a^2+b^2+c^2)",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: In any triangle with sides a,b,c and medians ma,mb,mc, the sum of squared medians satisfies 4(ma^2+mb^2+mc^2)=3(a^2+b^2+c^2).",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-24T12:11:09.564Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 4(mₐ²+m_b²+m_c²)=3(a²+b²+c²) verified 0-axiom, answers parent oq-07 openQuestion",
+    "builtItems": [
+      "LawOfCosinesOQ07OQ02.sum_sq_medians (Proofs/LawOfCosinesOQ07OQ02.lean:58): 4(mₐ²+m_b²+m_c²)=3(ab²+bc²+ca²), coordinate-free in NormedAddTorsor, 0-axiom",
+      "LawOfCosinesOQ07OQ02.sum_sq_medians_three_quarters (:71): ¾-ratio form"
+    ],
+    "insights": [
+      "Sum-of-squared-medians is the exact cyclic sum of Apollonius median-length 4mₐ²=2b²+2c²−a²; each side-square nets coefficient 2+2−1=3, medians carry factor 4 → 4∑m²=3∑s²"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the single-median Apollonius lemma but no packaged three-median sum identity"
+    ],
+    "nextSteps": [
+      "Centroid/Leibniz form: ∑dist(g,vertex)²=⅓∑sides²; derive via 2:1 median ratio from this entry"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "geometry",
+    "triangle",
+    "inner-product-space",
+    "apollonius"
+  ],
+  "relatedProofs": [
+    "law-of-cosines",
+    "law-of-cosines-oq-01-oq-01",
+    "law-of-cosines-oq-01-oq-01-oq-01",
+    "law-of-cosines-oq-01-oq-01-oq-01-oq-02",
+    "law-of-cosines-oq-01-oq-01-oq-03",
+    "law-of-cosines-oq-01-oq-02",
+    "law-of-cosines-oq-01-oq-04",
+    "law-of-cosines-oq-01-oq-05",
+    "law-of-cosines-oq-03",
+    "law-of-cosines-oq-03-oq-02",
+    "law-of-cosines-oq-03-oq-03",
+    "law-of-cosines-oq-04",
+    "law-of-cosines-oq-04-oq-01",
+    "law-of-cosines-oq-04-oq-02",
+    "law-of-cosines-oq-07",
+    "law-of-cosines-oq-08"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T12:11:09.564Z",
+  "lastUpdate": "2026-06-24T12:11:09.564Z",
+  "significance": 5,
+  "tractability": 9,
+  "leanFiles": [
+    {
+      "path": "Proofs/LawOfCosines.lean",
+      "filename": "LawOfCosines.lean",
+      "lineCount": 281,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosines.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ01.lean",
+      "filename": "LawOfCosinesOQ01OQ01.lean",
+      "lineCount": 338,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ01OQ01.lean",
+      "filename": "LawOfCosinesOQ01OQ01OQ01.lean",
+      "lineCount": 65,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ01OQ01OQ02.lean",
+      "filename": "LawOfCosinesOQ01OQ01OQ01OQ02.lean",
+      "lineCount": 142,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ01OQ03.lean",
+      "filename": "LawOfCosinesOQ01OQ01OQ03.lean",
+      "lineCount": 547,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ02.lean",
+      "filename": "LawOfCosinesOQ01OQ02.lean",
+      "lineCount": 421,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ01OQ04.lean",
+      "filename": "LawOfCosinesOQ01OQ04.lean",
+      "lineCount": 191,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ03.lean",
+      "filename": "LawOfCosinesOQ03.lean",
+      "lineCount": 193,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ03.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ03OQ02.lean",
+      "filename": "LawOfCosinesOQ03OQ02.lean",
+      "lineCount": 265,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
+      "filename": "LawOfCosinesOQ03OQ03.lean",
+      "lineCount": 268,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ04.lean",
+      "filename": "LawOfCosinesOQ04.lean",
+      "lineCount": 157,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ04OQ01.lean",
+      "filename": "LawOfCosinesOQ04OQ01.lean",
+      "lineCount": 179,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ04OQ01Bisector.lean",
+      "filename": "LawOfCosinesOQ04OQ01Bisector.lean",
+      "lineCount": 148,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ01Bisector.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ04OQ02.lean",
+      "filename": "LawOfCosinesOQ04OQ02.lean",
+      "lineCount": 174,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ04OQ02OQ01.lean",
+      "filename": "LawOfCosinesOQ04OQ02OQ01.lean",
+      "lineCount": 195,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ04OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ05.lean",
+      "filename": "LawOfCosinesOQ05.lean",
+      "lineCount": 694,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ05.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ07.lean",
+      "filename": "LawOfCosinesOQ07.lean",
+      "lineCount": 107,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ07.lean"
+    },
+    {
+      "path": "Proofs/LawOfCosinesOQ08.lean",
+      "filename": "LawOfCosinesOQ08.lean",
+      "lineCount": 150,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawOfCosinesOQ08.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **openQuestion** posed by `law-of-cosines-oq-07`: the global *sum-of-squared-medians* identity

$$4(m_a^2 + m_b^2 + m_c^2) = 3(a^2 + b^2 + c^2),\qquad\text{equivalently}\qquad m_a^2 + m_b^2 + m_c^2 = \tfrac34(a^2+b^2+c^2).$$

Proved **coordinate-free** for a triangle with vertices `a b c` in an arbitrary real inner-product affine space (`NormedAddTorsor`), with the medians as genuine `dist`s to honest `midpoint`s.

## Approach

Sum the parent's metric median-length formula `4mₐ² = 2b² + 2c² − a²` over the three vertices: instantiate `median_length` at `(a b c)`, `(b a c)`, `(c a b)`, fold the three `dist`-symmetries with one `simp only [dist_comm …]`, and close with `linear_combination ha + hb + hc`. Each squared side gathers net coefficient `2 + 2 − 1 = 3` while the medians carry the factor `4`.

## Verification

- 2 theorems, 88 lines, **0 axioms** (`#print axioms` → `propext, Classical.choice, Quot.sound` only), 0 sorries, no decision procedures.
- Builds against Mathlib 4.26.0; reuses `Proofs.LawOfCosinesOQ07`.

## Files
- `proofs/Proofs/LawOfCosinesOQ07OQ02.lean`
- `src/data/proofs/law-of-cosines-oq-07-oq-02/meta.json`
- `src/data/research/problems/law-of-cosines-oq-07-oq-02.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)