### PR TITLE
Enrich Sharp Bound (1+1/n)^n < e (binomial-theorem-oq-03-oq-02-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "ann-tangent-inequality",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 50
+    },
+    "type": "insight",
+    "title": "Strict Tangent Inequality 1 + x/n < exp(x/n)",
+    "content": "The entire upper bound rests on a single strict inequality. Since x > 0 and n ≥ 1, the quotient x/n is nonzero, so Real.add_one_lt_exp gives the strict tangent-line bound (x/n) + 1 < exp(x/n); a linarith rearrangement yields 1 + x/n < exp(x/n). Geometrically, the line y = 1 + t is the tangent to y = exp(t) at t = 0, and strict convexity of the exponential forces the curve to lie strictly above the tangent everywhere except the point of tangency t = 0 — which is excluded here precisely because x/n ≠ 0.",
+    "mathContext": "Real.add_one_lt_exp: $t \\ne 0 \\Rightarrow 1 + t < e^{t}$, applied at $t = x/n$. The exclusion $t = 0$ is what makes the bound strict rather than the weak $1 + t \\le e^{t}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "tangent line inequality",
+      "strict convexity of exp",
+      "Bernoulli inequality"
+    ],
+    "prerequisites": [
+      "Real.add_one_lt_exp",
+      "div_ne_zero",
+      "linarith"
+    ]
+  },
+  {
+    "id": "ann-strict-exponentiation",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 53
+    },
+    "type": "technique",
+    "title": "Propagating Strictness Through the n-th Power",
+    "content": "Both sides of the tangent bound are nonnegative (positivity proves 0 ≤ 1 + x/n), so raising them to the n-th power preserves the strict order: pow_lt_pow_left₀ takes the strict base inequality, the nonnegativity of the smaller base, and n ≠ 0 (discharged by omega) and concludes (1 + x/n)^n < (exp(x/n))^n. Strictness is not automatic for monotone maps — x ↦ x^n is only strictly increasing on the nonnegatives and only for n ≥ 1, which is exactly why both side conditions are required here.",
+    "mathContext": "pow_lt_pow_left₀: $0 \\le a < b$ and $n \\ne 0 \\Rightarrow a^{n} < b^{n}$. Note the name is `pow_lt_pow_left₀` in Mathlib 4.26 (renamed from `pow_lt_pow_left`).",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict monotonicity of x^n",
+      "order-preserving maps",
+      "positivity"
+    ],
+    "prerequisites": [
+      "pow_lt_pow_left₀",
+      "positivity tactic"
+    ]
+  },
+  {
+    "id": "ann-exp-collapse",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 57
+    },
+    "type": "technique",
+    "title": "Collapsing (exp(x/n))^n = exp(x)",
+    "content": "The right-hand side (exp(x/n))^n is rewritten using Real.exp_nat_mul, which states exp(n·t) = (exp t)^n; reading it backwards turns (exp(x/n))^n into exp(n·(x/n)). The exponent n·(x/n) then simplifies to x via field_simp (legal since n ≠ 0), and rwa finishes by rewriting the hypothesis into the goal. This is the step that converts the per-term bound into the clean statement (1 + x/n)^n < exp(x).",
+    "mathContext": "Real.exp_nat_mul: $e^{n t} = (e^{t})^{n}$. Here $n \\cdot (x/n) = x$, so $(e^{x/n})^{n} = e^{x}$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "exponential of a product",
+      "field_simp",
+      "homomorphism property of exp"
+    ],
+    "prerequisites": [
+      "Real.exp_nat_mul",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-main-specialization",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 62
+    },
+    "type": "insight",
+    "title": "Main Theorem: Specializing x = 1",
+    "content": "The headline result (1 + 1/n)^n < e is the x = 1 slice of the general family. Plugging x = 1 (with one_pos) into add_div_pow_lt_exp gives (1 + 1/n)^n < exp 1, and simpa cleans up 1/(n:ℝ) and exp 1 = e. The general lemma proving (1 + x/n)^n < exp(x) for every x > 0 means the e-bound is not special — it is one point of a continuum of exponential bounds, with x = 1 chosen because exp 1 = e.",
+    "mathContext": "$e = \\exp(1)$, so the bound $(1 + 1/n)^n < \\exp(1)$ is exactly $(1 + 1/n)^n < e$. The family $(1 + x/n)^n < e^{x}$ specializes at $x = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's number e",
+      "specialization of a parameter family",
+      "supremum of (1+1/n)^n"
+    ],
+    "prerequisites": [
+      "add_div_pow_lt_exp",
+      "simpa"
+    ]
+  },
+  {
+    "id": "ann-bernoulli-lower",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 75
+    },
+    "type": "concept",
+    "title": "Lower Companion via Bernoulli: 2 ≤ (1 + 1/n)^n",
+    "content": "The elementary lower bound comes from the Bernoulli inequality one_add_mul_le_pow, which requires the base offset a ≥ -2 and gives 1 + n·a ≤ (1 + a)^n. With a = 1/n ≥ 0 ≥ -2 the hypothesis is trivially met, and the exponent collapses: 1 + n·(1/n) = 1 + 1 = 2 (the cancellation n·(1/n) = 1 needs n ≠ 0, handled by mul_one_div then div_self). Thus 2 ≤ (1 + 1/n)^n for every n ≥ 1, with equality at n = 1.",
+    "mathContext": "one_add_mul_le_pow: $-2 \\le a \\Rightarrow 1 + n a \\le (1 + a)^{n}$. At $a = 1/n$: $1 + n\\cdot\\frac{1}{n} = 2 \\le (1 + 1/n)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bernoulli inequality",
+      "lower bound",
+      "exact value at n = 1"
+    ],
+    "prerequisites": [
+      "one_add_mul_le_pow",
+      "mul_one_div",
+      "div_self"
+    ]
+  },
+  {
+    "id": "ann-two-sided",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Two-Sided Bound: 2 ≤ (1 + 1/n)^n < e",
+    "content": "Packaging the Bernoulli lower bound with the sharp exponential upper bound confines the sequence to the half-open interval [2, e). Combined with the parent result that (1 + 1/n)^n is strictly increasing and the grandparent's limit (1 + 1/n)^n → e, this completes the classical picture: a strictly increasing sequence trapped in [2, e), converging up to its supremum e, which it never attains. The bound mirrors the parent's coarser 2 < (1+1/n)^n < 3 but replaces 3 with the optimal upper endpoint.",
+    "mathContext": "$2 \\le (1 + 1/n)^n < e$ for all $n \\ge 1$. The interval $[2, e)$ is sharp: the value 2 is attained at $n=1$, and $e$ is the unattained supremum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone convergence",
+      "supremum",
+      "half-open interval"
+    ],
+    "prerequisites": [
+      "two_le_add_inv_pow",
+      "add_inv_pow_lt_e"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03-oq-01/meta.json
@@ -83,7 +83,8 @@
     "summary": "Proves the sharp strict upper bound (1 + 1/n)^n < e for all n ≥ 1 with 0 axioms, 0 sorries, 4 theorems in 84 lines. The general lemma (1 + x/n)^n < exp(x) for x > 0 specializes to the e-bound at x = 1, and the Bernoulli lower companion gives the two-sided 2 ≤ (1+1/n)^n < e.",
     "implications": "This answers the parent proof's first open question — sharpening (1+1/n)^n < 3 to the optimal (1+1/n)^n < e. Combined with the parent's strict monotonicity and the grandparent's limit (1+1/n)^n → e, the picture is complete: a strictly increasing sequence confined to [2, e) converging to its supremum e, which it never attains.",
     "openQuestions": [
-      "Prove the complementary bound e < (1 + 1/n)^(n+1) for all n ≥ 1, giving the two-sided squeeze (1+1/n)^n < e < (1+1/n)^(n+1)."
+      "Prove the complementary bound e < (1 + 1/n)^(n+1) for all n ≥ 1, giving the two-sided squeeze (1+1/n)^n < e < (1+1/n)^(n+1).",
+      "Quantify the gap: establish the sharp asymptotic e - (1 + 1/n)^n ~ e/(2n) as n → ∞ (from the expansion n·log(1+1/n) = 1 - 1/(2n) + O(1/n²)), turning the qualitative 'approaches from below' into a rate."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-03-oq-02-oq-03-oq-01`.

**Gaps filled:**
- Created the missing `annotations.json` (entry had none). Six annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Strict tangent inequality `1 + x/n < exp(x/n)` (the one-line core)
  2. Propagating strictness through the n-th power via `pow_lt_pow_left₀`
  3. Collapsing `(exp(x/n))^n = exp(x)` via `Real.exp_nat_mul`
  4. Main theorem: specializing `x = 1`
  5. Bernoulli lower companion `2 ≤ (1+1/n)^n`
  6. Two-sided bound `2 ≤ (1+1/n)^n < e`
- Added a second open question (sharp asymptotic `e - (1+1/n)^n ~ e/(2n)`) to the conclusion.

Verified annotation line ranges against the Lean source; cross-references confirmed to point at existing gallery entries. JSON validated; enrichment pipeline processes the entry cleanly.