### PR TITLE
research(sylvester-sequence-oq-02-oq-01): exact tail of reciprocal series = 1/(a_{n+1}-1)

### DIFF
--- a/proofs/Proofs/SylvesterSequenceOQ02OQ01.lean
+++ b/proofs/Proofs/SylvesterSequenceOQ02OQ01.lean
@@ -1,0 +1,130 @@
+import Mathlib
+import Proofs.SylvesterSequenceOQ02
+
+/-
+# Sylvester's sequence OQ-02-OQ-01: the exact tail of the reciprocal series
+
+Sylvester's sequence is `a₀ = 2`, `a_{n+1} = aₙ² - aₙ + 1`, giving `2, 3, 7, 43, 1807, …`.
+The parent entry `SylvesterSequenceOQ02` proves the closed-form **partial** sum
+`∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1} - 1)`, that the full series `∑' k, 1/aₖ = 1`, and that the
+error term `1/(a_{n+1}-1) → 0`. Its first listed open question asks whether the
+convergence can be made *quantitative*: an exact formula for the remainder after `n+1`
+terms. This file answers that — and more sharply than an inequality.
+
+We prove the **exact tail identity**: the remainder of the infinite series after the
+first `n+1` terms is *exactly* `1/(a_{n+1}-1)`,
+
+* `syl_tail_hasSum`  : `HasSum (fun m => 1/a_{m+(n+1)}) (1/(a_{n+1}-1))`,
+* `syl_tsum_tail`    : `∑' m, 1/a_{m+(n+1)} = 1/(a_{n+1}-1)`,
+* `syl_remainder_eq_tail` : `1 - ∑_{k≤n} 1/aₖ = ∑' m, 1/a_{m+(n+1)}` (remainder = tail),
+
+together with the underlying **product structure** that makes the tail so small:
+
+* `syl_prod_eq_pred` : `∏_{k≤n} aₖ = a_{n+1} - 1`  (so `a_{n+1} = 1 + ∏_{k≤n} aₖ`), and
+* `syl_tsum_tail_eq_inv_prod` : `∑' m, 1/a_{m+(n+1)} = 1 / ∏_{k≤n} aₖ`.
+
+The last form is the precise sense in which Sylvester's greedy Egyptian-fraction expansion
+of `1` converges as fast as possible: the entire infinite tail past `aₙ` is no larger than
+the reciprocal of the *product* of all preceding terms (which itself grows doubly
+exponentially).
+
+The proof reuses the parent's partial-sum closed form and `HasSum` statement; the tail is
+extracted by `hasSum_nat_add_iff`, which peels the first `n+1` terms off a convergent
+series. The product identity is a one-line induction on the recurrence
+`a_{n+1}-1 = aₙ(aₙ-1)`.
+
+No axioms, no sorries.
+-/
+
+namespace SylvesterSequenceOQ02OQ01
+
+open SylvesterSequenceOQ02
+
+/-! ## The product structure `a_{n+1} - 1 = ∏_{k≤n} aₖ` -/
+
+/-- **Euclid/Sylvester product identity (over `ℤ`).** The predecessor of the next term is
+the product of all terms so far: `∏_{k≤n} aₖ = a_{n+1} - 1`. Proved by induction from the
+recurrence `a_{n+1}-1 = aₙ² - aₙ = aₙ(aₙ-1)`: multiplying the running product by `aₙ` is
+exactly the step from `aₙ-1` to `a_{n+1}-1`. -/
+theorem syl_prod_eq_pred_int (n : ℕ) :
+    ∏ k ∈ Finset.range (n + 1), (syl k : ℤ) = (syl (n + 1) : ℤ) - 1 := by
+  induction n with
+  | zero =>
+    simp [show syl 0 = 2 from rfl, show syl 1 = 3 from rfl]
+  | succ m ih =>
+    rw [Finset.prod_range_succ, ih, syl_cast_succ (m + 1)]
+    ring
+
+/-- The product identity in `ℝ`: `∏_{k≤n} aₖ = a_{n+1} - 1`. -/
+theorem syl_prod_eq_pred_real (n : ℕ) :
+    ∏ k ∈ Finset.range (n + 1), (syl k : ℝ) = (syl (n + 1) : ℝ) - 1 := by
+  have h := syl_prod_eq_pred_int n
+  have h2 := congrArg (fun z : ℤ => (z : ℝ)) h
+  push_cast at h2
+  exact h2
+
+/-- Equivalent `ℕ` phrasing: each term is one more than the product of its predecessors,
+`a_{n+1} = 1 + ∏_{k≤n} aₖ` (the defining property of the greedy Euclid/Sylvester growth). -/
+theorem syl_succ_eq_prod_add_one (n : ℕ) :
+    syl (n + 1) = (∏ k ∈ Finset.range (n + 1), syl k) + 1 := by
+  have h := syl_prod_eq_pred_int n
+  have hcast : (∏ k ∈ Finset.range (n + 1), (syl k : ℤ))
+      = ((∏ k ∈ Finset.range (n + 1), syl k : ℕ) : ℤ) := by push_cast; ring
+  rw [hcast] at h
+  have hpos : 1 ≤ syl (n + 1) := le_trans (by norm_num) (two_le_syl (n + 1))
+  omega
+
+/-! ## The exact tail of the reciprocal series -/
+
+/-- **Exact tail identity (`HasSum` form).** The remainder of the reciprocal series after
+the first `n+1` terms is summable with sum exactly `1/(a_{n+1}-1)`:
+`HasSum (fun m => 1/a_{m+(n+1)}) (1/(a_{n+1}-1))`.
+
+Obtained by peeling the first `n+1` terms off the convergent full series
+(`syl_reciprocal_hasSum`, value `1`) with `hasSum_nat_add_iff`, then identifying the leading
+block with the parent's partial-sum closed form `1 - 1/(a_{n+1}-1)`. -/
+theorem syl_tail_hasSum (n : ℕ) :
+    HasSum (fun m => (1 : ℝ) / (syl (m + (n + 1)) : ℝ))
+      (1 / ((syl (n + 1) : ℝ) - 1)) := by
+  rw [hasSum_nat_add_iff (f := fun j => (1 : ℝ) / (syl j : ℝ)) (n + 1)]
+  have hps : (∑ i ∈ Finset.range (n + 1), (1 : ℝ) / (syl i : ℝ))
+      = 1 - 1 / ((syl (n + 1) : ℝ) - 1) := syl_real_partial_sum n
+  rw [hps]
+  have key : (1 : ℝ) / ((syl (n + 1) : ℝ) - 1) + (1 - 1 / ((syl (n + 1) : ℝ) - 1)) = 1 := by
+    ring
+  rw [key]
+  exact syl_reciprocal_hasSum
+
+/-- **Exact tail identity (`tsum` form):** `∑' m, 1/a_{m+(n+1)} = 1/(a_{n+1}-1)`. The
+infinite tail past the first `n+1` terms is precisely `1/(a_{n+1}-1)`. -/
+theorem syl_tsum_tail (n : ℕ) :
+    ∑' m, (1 : ℝ) / (syl (m + (n + 1)) : ℝ) = 1 / ((syl (n + 1) : ℝ) - 1) :=
+  (syl_tail_hasSum n).tsum_eq
+
+/-- **Remainder equals tail.** The gap between `1` and the `(n+1)`-term partial sum is the
+infinite tail — both equal `1/(a_{n+1}-1)`. This is the "quantitative convergence" statement
+the parent entry leaves open: the error after `n+1` terms is given *exactly*, not just
+bounded. -/
+theorem syl_remainder_eq_tail (n : ℕ) :
+    1 - ∑ k ∈ Finset.range (n + 1), (1 : ℝ) / (syl k : ℝ)
+      = ∑' m, (1 : ℝ) / (syl (m + (n + 1)) : ℝ) := by
+  rw [syl_tsum_tail n, syl_real_partial_sum n]
+  ring
+
+/-- **The tail as a reciprocal product:** `∑' m, 1/a_{m+(n+1)} = 1 / ∏_{k≤n} aₖ`. Combining
+the tail identity with the product structure exhibits the doubly-exponential speed of
+convergence: the entire infinite remainder past `aₙ` is the reciprocal of the product of all
+preceding terms. -/
+theorem syl_tsum_tail_eq_inv_prod (n : ℕ) :
+    ∑' m, (1 : ℝ) / (syl (m + (n + 1)) : ℝ)
+      = 1 / ∏ k ∈ Finset.range (n + 1), (syl k : ℝ) := by
+  rw [syl_tsum_tail n, syl_prod_eq_pred_real n]
+
+/-- Sanity check: the tail after the first term (`n = 0`) is `1/(a₁-1) = 1/2`, matching
+`1 - 1/a₀ = 1 - 1/2`. -/
+example : ∑' m, (1 : ℝ) / (syl (m + 1) : ℝ) = 1 / 2 := by
+  have h := syl_tsum_tail 0
+  norm_num [show syl 1 = 3 from rfl] at h
+  simpa using h
+
+end SylvesterSequenceOQ02OQ01

--- a/src/data/proofs/sylvester-sequence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/sylvester-sequence-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 42 },
+    "type": "concept",
+    "title": "From Convergence to an Exact Tail",
+    "content": "Sylvester's sequence $a_0 = 2$, $a_{n+1} = a_n^2 - a_n + 1$ (2, 3, 7, 43, 1807, …; OEIS A000058) is the greedy Egyptian-fraction expansion of $1$. The parent entry (oq-02) proves $\\sum'_k 1/a_k = 1$ and that the error term $1/(a_{n+1}-1)$ tends to $0$, but only as an asymptotic statement. This entry makes the convergence **exact**: the entire infinite tail past the first $n+1$ terms equals precisely $1/(a_{n+1}-1)$, which by the Euclid/Sylvester product identity is $1/\\prod_{k\\le n} a_k$.",
+    "mathContext": "$\\sum_{k\\ge n+1} 1/a_k = 1/(a_{n+1}-1) = 1/\\prod_{k\\le n} a_k.$",
+    "significance": "key",
+    "relatedConcepts": ["Egyptian fractions", "tail estimate", "quantitative convergence", "tsum / HasSum"],
+    "prerequisites": ["infinite series", "summability"]
+  },
+  {
+    "id": "ann-prod-int",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 43, "endLine": 57 },
+    "type": "technique",
+    "title": "The Euclid/Sylvester Product Identity",
+    "content": "`syl_prod_eq_pred_int` proves $\\prod_{k\\le n} a_k = a_{n+1} - 1$ over $\\mathbb{Z}$ by induction. The step rests on a single algebraic fact: $a_{n+1}-1 = a_n^2 - a_n = a_n(a_n-1)$, so multiplying the running product by $a_n$ advances $a_n - 1$ to $a_{n+1} - 1$ (Finset.prod_range_succ supplies the new factor; `ring` closes the recurrence after `syl_cast_succ`). Working over $\\mathbb{Z}$ sidesteps $\\mathbb{N}$'s truncated subtraction.",
+    "mathContext": "$a_{n+1}-1 = a_n(a_n-1) \\Rightarrow \\prod_{k\\le n} a_k = a_{n+1}-1.$",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's construction", "telescoping products", "induction"],
+    "prerequisites": ["finite products", "mathematical induction"]
+  },
+  {
+    "id": "ann-prod-real",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 59, "endLine": 75 },
+    "type": "technique",
+    "title": "Transporting the Identity to ℝ and ℕ",
+    "content": "`syl_prod_eq_pred_real` casts the $\\mathbb{Z}$ identity into $\\mathbb{R}$ (where the series lives) by `congrArg` followed by `push_cast`, which distributes the cast over the finite product. `syl_succ_eq_prod_add_one` restates the same fact in $\\mathbb{N}$ as $a_{n+1} = 1 + \\prod_{k\\le n} a_k$ — the defining greedy-growth property — discharged by `omega` from the cast identity and $a_{n+1}\\ge 1$.",
+    "mathContext": "$\\prod_{k\\le n} (a_k:\\mathbb{R}) = a_{n+1}-1;\\quad a_{n+1} = 1 + \\prod_{k\\le n} a_k.$",
+    "significance": "supporting",
+    "relatedConcepts": ["casting ℤ → ℝ", "push_cast", "omega"],
+    "prerequisites": ["coercions between number types"]
+  },
+  {
+    "id": "ann-tail-hassum",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 77, "endLine": 98 },
+    "type": "key-step",
+    "title": "Peeling the Leading Block: the Exact Tail",
+    "content": "`syl_tail_hasSum` is the heart of the entry. `hasSum_nat_add_iff` (with $k = n+1$) states that $\\mathrm{HasSum}\\ (m\\mapsto 1/a_{m+(n+1)})\\ a$ holds iff $\\mathrm{HasSum}\\ (1/a_\\bullet)\\ (a + \\sum_{i\\le n} 1/a_i)$. Substituting the parent's partial-sum closed form $\\sum_{i\\le n} 1/a_i = 1 - 1/(a_{n+1}-1)$, the target sum becomes $a + 1 - 1/(a_{n+1}-1)$; choosing $a = 1/(a_{n+1}-1)$ makes this equal $1$, which is exactly the parent's convergent total `syl_reciprocal_hasSum`. So the tail value is forced to $1/(a_{n+1}-1)$.",
+    "mathContext": "$\\tfrac{1}{a_{n+1}-1} + \\big(1 - \\tfrac{1}{a_{n+1}-1}\\big) = 1 = \\sum'_k 1/a_k.$",
+    "significance": "critical",
+    "relatedConcepts": ["hasSum_nat_add_iff", "tail of a series", "peeling leading terms"],
+    "prerequisites": ["HasSum", "convergent series"]
+  },
+  {
+    "id": "ann-tail-tsum",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 100, "endLine": 116 },
+    "type": "concept",
+    "title": "Tsum Form and Remainder = Tail",
+    "content": "`syl_tsum_tail` reads off the value $\\sum'_m 1/a_{m+(n+1)} = 1/(a_{n+1}-1)$ via `HasSum.tsum_eq`. `syl_remainder_eq_tail` then identifies the partial-sum error with the genuine infinite tail: $1 - \\sum_{k\\le n} 1/a_k = \\sum'_m 1/a_{m+(n+1)}$, since both sides equal $1/(a_{n+1}-1)$. This is the precise 'quantitative convergence' statement the parent leaves open — the error after $n+1$ terms is given exactly, not merely bounded.",
+    "mathContext": "$1 - \\sum_{k\\le n} 1/a_k = \\sum_{m} 1/a_{m+(n+1)} = 1/(a_{n+1}-1).$",
+    "significance": "key",
+    "relatedConcepts": ["tsum", "remainder of a series", "exact error term"],
+    "prerequisites": ["HasSum.tsum_eq"]
+  },
+  {
+    "id": "ann-inv-prod",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 118, "endLine": 123 },
+    "type": "concept",
+    "title": "The Tail as a Reciprocal Product",
+    "content": "Combining the tail identity with the product structure, `syl_tsum_tail_eq_inv_prod` gives $\\sum'_m 1/a_{m+(n+1)} = 1/\\prod_{k\\le n} a_k$. This exhibits the doubly-exponential speed of convergence: the entire infinite remainder past $a_n$ is the reciprocal of the product of every preceding term — Sylvester's greedy expansion converges as fast as any unit-fraction expansion of $1$ possibly can.",
+    "mathContext": "$\\sum_{m} 1/a_{m+(n+1)} = 1/\\prod_{k\\le n} a_k.$",
+    "significance": "key",
+    "relatedConcepts": ["doubly-exponential growth", "fastest unit-fraction convergence"],
+    "prerequisites": ["finite products"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "sylvester-sequence-oq-02-oq-01",
+    "range": { "startLine": 124, "endLine": 130 },
+    "type": "technique",
+    "title": "Numerical Sanity Check",
+    "content": "An `example` confirms the $n = 0$ instance: the tail past the first term is $\\sum'_m 1/a_{m+1} = 1/(a_1 - 1) = 1/(3-1) = 1/2$, matching $1 - 1/a_0 = 1 - 1/2$. A concrete check that the general formula specializes correctly.",
+    "mathContext": "$\\sum_{m} 1/a_{m+1} = 1/(3-1) = 1/2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "numerical verification"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/sylvester-sequence-oq-02-oq-01/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-02-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "sylvester-sequence-oq-02-oq-01",
+  "slug": "sylvester-sequence-oq-02-oq-01",
+  "title": "Sylvester's Sequence: The Exact Tail of the Reciprocal Series",
+  "description": "Sylvester's sequence a₀=2, a_{n+1}=aₙ²-aₙ+1 (2, 3, 7, 43, 1807, …) has reciprocals summing to exactly 1 (parent oq-02). This entry makes the convergence quantitative: it proves the EXACT tail identity ∑'_m 1/a_{m+(n+1)} = 1/(a_{n+1}-1) — the entire infinite remainder after the first n+1 terms equals exactly 1/(a_{n+1}-1), not merely a bound. It is derived (syl_tail_hasSum, syl_tsum_tail) by peeling the leading n+1 terms off the convergent series via hasSum_nat_add_iff and identifying the block with the parent's partial-sum closed form. The remainder-equals-tail statement (syl_remainder_eq_tail) confirms 1 − ∑_{k≤n} 1/aₖ equals this tail. The underlying product structure ∏_{k≤n} aₖ = a_{n+1}-1 (syl_prod_eq_pred_int, equivalently a_{n+1}=1+∏_{k≤n} aₖ) is proved by a one-line induction on a_{n+1}-1=aₙ(aₙ-1), giving the reciprocal-product form ∑'_m 1/a_{m+(n+1)} = 1/∏_{k≤n} aₖ (syl_tsum_tail_eq_inv_prod): the tail is the reciprocal of the product of all preceding terms. Fully machine-checked with 0 sorries and 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.SylvesterSequenceOQ02"],
+    "opens": ["SylvesterSequenceOQ02"],
+    "namespace": "SylvesterSequenceOQ02OQ01",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 5,
+    "trivialSpecializations": 1,
+    "definitionCount": 0,
+    "path": "Proofs/SylvesterSequenceOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "James Joseph Sylvester (1880)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence",
+    "date": "1880",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylvesterSequenceOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "infinite-series",
+      "egyptian-fractions",
+      "telescoping",
+      "convergence",
+      "tail-estimate",
+      "sylvester"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. The sequence is defined in ℕ in the parent module; all results here are proved over ℤ and ℝ from the recurrence, reusing the parent's partial-sum closed form and HasSum statement together with Mathlib's hasSum_nat_add_iff. No axioms and no structure-encoded hypotheses. #print axioms reports only the standard propext / Classical.choice / Quot.sound.",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      "hasSum_nat_add_iff",
+      "HasSum.tsum_eq",
+      "Finset.prod_range_succ",
+      "Finset.prod_range_one"
+    ],
+    "originalContributions": [
+      "Exact tail identity syl_tsum_tail: ∑'_m 1/a_{m+(n+1)} = 1/(a_{n+1}-1) — the infinite remainder after the first n+1 terms, given exactly rather than bounded",
+      "HasSum form syl_tail_hasSum: HasSum (fun m => 1/a_{m+(n+1)}) (1/(a_{n+1}-1)), obtained by peeling the leading n+1 terms off the convergent series with hasSum_nat_add_iff",
+      "Remainder-equals-tail syl_remainder_eq_tail: 1 − ∑_{k≤n} 1/aₖ = ∑'_m 1/a_{m+(n+1)}, identifying the partial-sum error with the genuine infinite tail",
+      "Product identity syl_prod_eq_pred_int: ∏_{k≤n} aₖ = a_{n+1}-1, the Euclid/Sylvester recurrence a_{n+1}-1 = aₙ(aₙ-1) integrated by induction",
+      "ℕ phrasing syl_succ_eq_prod_add_one: a_{n+1} = 1 + ∏_{k≤n} aₖ, the defining greedy-growth property",
+      "Reciprocal-product tail form syl_tsum_tail_eq_inv_prod: ∑'_m 1/a_{m+(n+1)} = 1/∏_{k≤n} aₖ, exhibiting the doubly-exponential convergence speed"
+    ],
+    "prerequisites": [
+      "Infinite series, summability, tsum and HasSum in a normed field",
+      "Peeling finitely many leading terms off a convergent series (hasSum_nat_add_iff)",
+      "Finite products and mathematical induction"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 130,
+    "relatedProblems": ["sylvester-sequence-oq-02", "sylvester-sequence-oq-01"],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Sylvester's sequence (OEIS A000058), studied by James Joseph Sylvester in 1880, is the greedy expansion of 1 as a sum of distinct unit fractions: at each step take the largest 1/m keeping the running total below 1. The denominators obey a₀ = 2, a_{n+1} = aₙ² - aₙ + 1, giving 2, 3, 7, 43, 1807, …, a doubly-exponentially growing sequence. A classical structural fact, going back to Euclid's construction of coprime integers, is that a_{n+1} = 1 + a₀a₁···aₙ: each term is one more than the product of all its predecessors. This is exactly what makes the greedy expansion converge as fast as any unit-fraction expansion possibly can.",
+    "problemStatement": "The parent entry (oq-02) proves the reciprocals sum to exactly 1 and that the error term 1/(a_{n+1}-1) tends to 0, leaving as its first open question whether the convergence can be made quantitative — an exact formula for the remainder after n+1 terms. Make it exact: prove that the infinite tail ∑_{k≥n+1} 1/aₖ equals precisely 1/(a_{n+1}-1), both as a HasSum statement and as a tsum value, and connect it to the product structure a_{n+1}-1 = ∏_{k≤n} aₖ so the tail reads as the reciprocal of the product of all preceding terms.",
+    "proofStrategy": "Two ingredients combine. (1) The exact tail: applying hasSum_nat_add_iff with k = n+1 to the convergent series ∑ 1/aₖ (parent syl_reciprocal_hasSum, value 1) shows HasSum (fun m => 1/a_{m+(n+1)}) a is equivalent to HasSum (1/a_•) (a + ∑_{i≤n} 1/aᵢ); substituting the parent's partial-sum closed form ∑_{i≤n} 1/aᵢ = 1 - 1/(a_{n+1}-1) and solving a + (1 - 1/(a_{n+1}-1)) = 1 forces a = 1/(a_{n+1}-1). The tsum value follows by HasSum.tsum_eq, and 1 − partial = tail by a one-line rewrite. (2) The product structure: ∏_{k≤n} aₖ = a_{n+1}-1 is proved by induction over ℤ from Finset.prod_range_succ and the recurrence a_{n+2}-1 = a_{n+1}(a_{n+1}-1) = a_{n+1}·(∏_{k≤n} aₖ); casting to ℝ and substituting rewrites the tail as 1/∏_{k≤n} aₖ.",
+    "keyInsights": [
+      "The error term 1/(a_{n+1}-1) the parent only bounds is in fact the EXACT value of the infinite tail — convergence is quantitative, not merely asymptotic.",
+      "hasSum_nat_add_iff turns 'sum of the tail' into 'total minus the leading block', so the tail value is read off directly from the already-known total (1) and partial sum (1 - 1/(a_{n+1}-1)).",
+      "The Euclid/Sylvester identity a_{n+1}-1 = ∏_{k≤n} aₖ follows from a single algebraic step a_{n+1}-1 = aₙ(aₙ-1): multiplying the running product by aₙ advances the predecessor of the next term.",
+      "Writing the tail as 1/∏_{k≤n} aₖ exposes the doubly-exponential convergence speed: the entire infinite remainder past aₙ is no larger than the reciprocal of the product of every preceding term.",
+      "Working the product identity over ℤ avoids ℕ's truncated subtraction; a clean push_cast transports it to ℝ where the series lives."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "syl_tsum_tail",
+      "statement": "∑' m, (1 : ℝ) / a_{m+(n+1)} = 1 / (a_{n+1} - 1)",
+      "description": "The exact tail: the infinite remainder of the reciprocal series after the first n+1 terms equals precisely 1/(a_{n+1}-1)."
+    },
+    {
+      "name": "syl_tail_hasSum",
+      "statement": "HasSum (fun m => (1 : ℝ) / a_{m+(n+1)}) (1 / (a_{n+1} - 1))",
+      "description": "The HasSum form of the tail identity, peeling the first n+1 terms off the convergent full series via hasSum_nat_add_iff."
+    },
+    {
+      "name": "syl_remainder_eq_tail",
+      "statement": "1 - ∑ k ∈ range (n+1), 1/aₖ = ∑' m, 1/a_{m+(n+1)}",
+      "description": "Remainder equals tail: the gap between 1 and the (n+1)-term partial sum is exactly the genuine infinite tail."
+    },
+    {
+      "name": "syl_prod_eq_pred_int",
+      "statement": "∏ k ∈ range (n+1), (aₖ : ℤ) = a_{n+1} - 1",
+      "description": "The Euclid/Sylvester product identity: the predecessor of the next term is the product of all terms so far."
+    },
+    {
+      "name": "syl_tsum_tail_eq_inv_prod",
+      "statement": "∑' m, (1 : ℝ) / a_{m+(n+1)} = 1 / ∏ k ∈ range (n+1), aₖ",
+      "description": "The tail as a reciprocal product, exhibiting the doubly-exponential convergence speed."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Imports Mathlib and the parent module Proofs.SylvesterSequenceOQ02, opens its namespace, and states the goal: promote the parent's 'error term → 0' to an EXACT tail formula. The docstring lists the three tail statements and the two product-structure statements the file establishes, all with 0 axioms and 0 sorries.",
+      "mathContext": "Goal: $\\sum_{k\\ge n+1} 1/a_k = 1/(a_{n+1}-1) = 1/\\prod_{k\\le n} a_k$."
+    },
+    {
+      "id": "product-structure",
+      "title": "The Product Structure a_{n+1}-1 = ∏ aₖ",
+      "startLine": 43,
+      "endLine": 76,
+      "summary": "syl_prod_eq_pred_int proves ∏_{k≤n} aₖ = a_{n+1}-1 over ℤ by induction (Finset.prod_range_succ plus the recurrence a_{n+2}-1 = a_{n+1}(a_{n+1}-1)); syl_prod_eq_pred_real transports it to ℝ via push_cast; syl_succ_eq_prod_add_one restates it in ℕ as a_{n+1} = 1 + ∏_{k≤n} aₖ.",
+      "mathContext": "$a_{n+1}-1 = a_n(a_n-1) \\Rightarrow \\prod_{k\\le n} a_k = a_{n+1}-1$."
+    },
+    {
+      "id": "exact-tail",
+      "title": "The Exact Tail of the Reciprocal Series",
+      "startLine": 77,
+      "endLine": 123,
+      "summary": "syl_tail_hasSum peels the first n+1 terms off the convergent series with hasSum_nat_add_iff and pins the tail value to 1/(a_{n+1}-1) using the parent partial-sum closed form; syl_tsum_tail is its tsum form; syl_remainder_eq_tail identifies 1 − partial with the tail; syl_tsum_tail_eq_inv_prod rewrites the tail as 1/∏_{k≤n} aₖ.",
+      "mathContext": "$\\sum_{m} 1/a_{m+(n+1)} = 1/(a_{n+1}-1) = 1/\\prod_{k\\le n} a_k$."
+    },
+    {
+      "id": "sanity",
+      "title": "Numerical Sanity Check",
+      "startLine": 124,
+      "endLine": 130,
+      "summary": "An example confirming the n = 0 tail: ∑'_m 1/a_{m+1} = 1/(a₁-1) = 1/2, matching 1 - 1/a₀ = 1 - 1/2.",
+      "mathContext": "$\\sum_{m} 1/a_{m+1} = 1/(3-1) = 1/2$."
+    }
+  ],
+  "references": [
+    {
+      "title": "Sylvester's sequence",
+      "url": "https://en.wikipedia.org/wiki/Sylvester%27s_sequence"
+    },
+    {
+      "title": "OEIS A000058 — Sylvester's sequence",
+      "url": "https://oeis.org/A000058"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sylvester-sequence-oq-02",
+      "relationship": "Answers the parent's first open question",
+      "description": "The parent proves ∑' 1/aₖ = 1 and 1/(a_{n+1}-1) → 0, asking whether the convergence can be made quantitative with an exact remainder formula. This entry supplies it: the tail after n+1 terms is exactly 1/(a_{n+1}-1) = 1/∏_{k≤n} aₖ."
+    },
+    {
+      "proofId": "sylvester-sequence-oq-01",
+      "relationship": "Builds on the partial-sum closed form",
+      "description": "The closed-form partial sum ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) introduced in the base entry is exactly what identifies the leading block when the tail is peeled off the convergent series."
+    }
+  ],
+  "conclusion": {
+    "summary": "The reciprocal tail of Sylvester's sequence after the first n+1 terms is shown to equal exactly 1/(a_{n+1}-1), both as HasSum (fun m => 1/a_{m+(n+1)}) (1/(a_{n+1}-1)) and as the tsum value, with the remainder 1 − ∑_{k≤n} 1/aₖ identified with this genuine infinite tail. The classical product structure ∏_{k≤n} aₖ = a_{n+1}-1 then recasts the tail as 1/∏_{k≤n} aₖ. Fully machine-checked with zero sorries and zero axioms.",
+    "implications": "This turns the parent's asymptotic statement (error term → 0) into an exact one: the convergence of Sylvester's greedy Egyptian-fraction expansion of unity is quantified term-by-term, and the tail's reciprocal-product form shows it shrinks doubly exponentially. The proof illustrates the standard move of extracting an exact tail value from a convergent series by peeling finitely many leading terms (hasSum_nat_add_iff) and reading the remainder off the known total and partial sum.",
+    "openQuestions": [
+      "Does the reciprocal-product tail identity ∑_{k≥n+1} 1/aₖ = 1/∏_{k≤n} aₖ generalize to arbitrary Euclid/Sylvester-style sequences defined by a_{n+1} = 1 + ∏_{k≤n} aₖ from any admissible seed, characterizing exactly which seeds give a telescoping unit-fraction expansion?",
+      "Can the same hasSum_nat_add_iff tail-extraction template produce exact tail formulas for related rapidly-converging series, e.g. ∑ 1/(2^{2^n}+1) for Fermat numbers or general Znám systems?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sylvester's sequence $a_0=2,\ a_{n+1}=a_n^2-a_n+1$ (2, 3, 7, 43, 1807, …). The parent entry **oq-02** proves the reciprocals sum to exactly 1 and that the error term $1/(a_{n+1}-1)\to 0$ — but only asymptotically. Its first listed open question asks whether convergence can be made **quantitative**, with an exact remainder formula. This entry answers it.

## Result

The infinite tail after the first $n+1$ terms is given **exactly**:
$$\sum_{k\ge n+1} \frac1{a_k} \;=\; \frac1{a_{n+1}-1} \;=\; \frac1{\prod_{k\le n} a_k}.$$

Theorems (`Proofs/SylvesterSequenceOQ02OQ01.lean`):
- **`syl_tail_hasSum` / `syl_tsum_tail`** — tail $=1/(a_{n+1}-1)$, obtained by peeling the leading $n+1$ terms off the convergent series with `hasSum_nat_add_iff` and reading the value off the parent's total (1) and partial-sum closed form.
- **`syl_remainder_eq_tail`** — $1-\sum_{k\le n}1/a_k$ equals the genuine infinite tail (the exact error term).
- **`syl_prod_eq_pred_int` / `syl_succ_eq_prod_add_one`** — the Euclid/Sylvester product identity $\prod_{k\le n}a_k=a_{n+1}-1$, i.e. $a_{n+1}=1+\prod_{k\le n}a_k$.
- **`syl_tsum_tail_eq_inv_prod`** — tail $=1/\prod_{k\le n}a_k$, exhibiting the doubly-exponential convergence speed.

## Verification

- 7 theorems, 130 lines, **0 sorries, 0 axioms**.
- `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`.
- Builds against the parent module `Proofs.SylvesterSequenceOQ02`.

Gallery: `src/data/proofs/sylvester-sequence-oq-02-oq-01/` (meta.json + 7 annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)