### PR TITLE
audit: batch-clear 594 unaudited entries [gallery-wide clean]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17857,8 +17857,3572 @@
       "lastAudited": "2026-06-24T03:40:00Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-11": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "algebraic-reals-meager-dense-gdelta-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "alternating-series-test-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-02-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "antitone-integral-sum-comparison-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "antitone-integral-sum-comparison-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "antitone-integral-sum-comparison-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-05-oq-03-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-04-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arithmetic-series-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arsinh-log-formula-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "arsinh-log-formula-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "automorphic-number-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "automorphic-number-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "automorphic-number-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "automorphic-number-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "baire-category-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "baire-category-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-02-oq-02-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-03-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "ballot-problem-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "banach-fixed-point-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "banach-fixed-point-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-01-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-08-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-08-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "basel-problem-oq-15": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bernoulli-inequality-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bernoulli-inequality-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bernoulli-inequality-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "beta-integral-recurrence-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-02-oq-02-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binary-gcd-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binary-gcd-oq-03-oq-02-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-03-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-03-oq-02-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "binomial-theorem-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "borsuk-ulam-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "british-flag-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "british-flag-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "brouwer-fixed-point-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "buffons-noodle-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "carnot-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "carnot-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "carnot-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "carnot-theorem-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "carnot-theorem-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-integral-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-integral-oq-02-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-01-oq-04-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-02-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-02-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cauchy-schwarz-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-04-backward-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-04-backward-incomplete-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-minpoly-oq-07": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayley-hamilton-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "central-limit-theorem-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-non-euclidean-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-non-euclidean-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-oq-02-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cevas-theorem-oq-04-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-bounds-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-bounds-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-bounds-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chevalley-warning-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chevalley-warning-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chinese-remainder-constructive-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chinese-remainder-constructive-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chinese-remainder-constructive-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "chinese-remainder-non-coprime-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "circumference-via-differentiation-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-05-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-04-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "combinations-formula-oq-07-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "compactness-finite-subcover-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "compactness-finite-subcover-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "compactness-finite-subcover-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "compactness-finite-subcover-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "compactness-finite-subcover-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "composition-parts-choose-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "conjugacy-class-equation-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "connected-space-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "connected-space-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cramers-rule-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cramers-rule-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-2-irrational-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-2-irrational-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "cube-root-3-irrational-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-05-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-05-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "derangements-convergence-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "derangements-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "descartes-rule-of-signs-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "dirichlet-approximation-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "divisibility-by-3-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "divisibility-by-3-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "divisibility-rules-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "egorov-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "egorov-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "eisenstein-criterion-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "eisenstein-criterion-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "eisenstein-criterion-oq-01-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "eisenstein-criterion-oq-01-oq-03-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1-oq-03-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-10-wip-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-100-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-100-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1000-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1000-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1000-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1002-oq-01-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1002-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1004-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1004-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1005-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1005-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1007-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-101-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1017-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1017-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1018-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1022-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1022-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1023-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1023-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1023-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1023-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1025-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1039-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1040-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1040-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1040-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1042-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-105-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-105-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1054-construction-d-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1054-construction-d-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1054-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1065-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-11-wip-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-11-wip-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-11-wip-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-1100-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-124-complete-sequences-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-124-complete-sequences-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-124-complete-sequences-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-128-wip-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-128-wip-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-128-wip-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-128-wip-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-179-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-2-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-220-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-220-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-286-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-309-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-396-oq-04-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-415-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-441-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-504-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-57-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-606-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-643-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-733-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-740-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-823-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-835-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-866-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-866-wip-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-978-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-982-thin-vertex": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-divisibility-pigeonhole-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-ko-rado-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "erdos-ko-rado-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-identity-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-identity-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-identity-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-polyhedral-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-07-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-09": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-09-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-10": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "factor-remainder-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "factor-remainder-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "factor-remainder-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "factor-remainder-theorem-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fatou-lemma-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fermat-two-squares-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fermat-two-squares-oq-07": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fodor-pressing-down-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "four-square-distribution-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "four-square-distribution-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "four-square-distribution-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fourier-series-oq-04-wip-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fourth-root-2-irrational": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "frobenius-endomorphism-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "frobenius-endomorphism-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "frobenius-number-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "fundamental-theorem-algebra-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "furstenberg-correspondence-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "furstenberg-correspondence-oq-01-incomplete-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "furstenberg-correspondence-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gamma-reflection-formula-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gamma-reflection-formula-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gcd-algorithm-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gcd-algorithm-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gcd-algorithm-oq-01-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gcd-algorithm-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-08-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-09-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-09-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-09-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "geometric-series-oq-09-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "godel-first-incompleteness-oq01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gram-linear-independence-iff-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "gram-linear-independence-iff-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "group-order-prime-squared-abelian-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "hall-marriage-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "halls-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "harmonic-divergence-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "harmonic-divergence-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "harmonic-divergence-oq-05-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "harmonic-divergence-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "hilbert-14-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "hilbert-14-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "hilbert-17-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "hilbert-5-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "inclusion-exclusion-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "inclusion-exclusion-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "inclusion-exclusion-oq-04-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "inclusion-exclusion-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "infinitude-primes-4k1-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "infinitude-primes-4k1-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "infinitude-primes-4k3-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "infinitude-primes-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "intermediate-value-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "intermediate-value-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "isoperimetric-theorem-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "isoperimetric-theorem-oq-02-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "isosceles-triangle-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jacobi-symbol-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "knights-tour-oblique-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "kummer-theorem-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lagrange-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lagrange-theorem-oq-07-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "law-of-cosines-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "law-of-cosines-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "law-of-cosines-oq-08": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "legendre-factorial-formula-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "legendre-factorial-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "legendre-factorial-formula-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "leibniz-pi-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lhopital-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lhopital-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "little-wedderburn-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "little-wedderburn-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lucas-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lucas-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lucas-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lucas-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "lucas-theorem-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mantel-theorem-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mantel-theorem-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "markov-equation": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "markov-equation-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "markov-equation-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "markov-equation-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "maschke-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mason-stothers-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mason-stothers-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mean-value-theorem-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "mean-value-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "menelaus-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "minkowski-fundamental-theorem-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "minkowski-fundamental-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "minkowski-fundamental-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "morleys-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "narcissistic-number-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pac-learning-bounds-oq-01-oq-07": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pascals-hexagon-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-06-oq-07": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-07": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-07-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pentagonal-number-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pentagonal-number-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "perfect-numbers-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "prime-gap-bounds-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "prob-method-applications-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "prob-method-expectation-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "prob-method-expectation-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "prob-method-lovasz-local-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "product-of-segments-of-chords-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "product-of-segments-of-chords-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "property-b-first-moment": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "property-b-first-moment-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "property-b-first-moment-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pythagorean-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pythagorean-triples-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "pythagorean-triples-oq-10": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "quadratic-gauss-sum-square-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "quadratic-gauss-sum-square-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "quadratic-reciprocity-algorithm-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "quadratic-reciprocity-algorithm-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "quadratic-reciprocity-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "ramseys-theorem-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "rearrangement-inequality-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "roth-theorem-k3-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "russell-1-plus-1-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "schroeder-bernstein-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "schroeder-bernstein-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "shannon-source-coding-oq-04-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-03-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "solution-of-cubic-oq-03-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "spectral-trace-det-eigenvalues-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sperner-simplicial-bridge-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "spherical-law-of-cosines-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "stirling-first-kind-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "stirling-first-kind-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "stirling-formula-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "stirling-formula-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "stirling-second-kind-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "subset-count-multiset-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "subset-count-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "subset-count-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "subset-count-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sum-of-divisors-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sum-of-kth-powers-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sum-of-kth-powers-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "summation-by-parts-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sylow-theorem-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sylow-theorem-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sylow-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sylvester-sequence-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "sylvester-sequence-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "tangent-addition-formula-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "taylor-sincos-convergence-oq-03-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "taylor-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "three-subgroups-lemma-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "tietze-extension-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "triangular-reciprocals-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "uniformbell-multinomial-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "urysohns-lemma-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "urysohns-lemma-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "vandermonde-interpolation-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "vandermonde-interpolation-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "vietas-formulas-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "weitzenbock-inequality-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-05-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-05-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-05-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
+    },
+    "wilsons-theorem-oq-06": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T12:27:19Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T02:18:44Z"
+  "lastUpdated": "2026-06-24T12:27:19Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Bulk integrity sweep of all 3448 gallery entries at \`origin/main\` (b498897).

**Result: gallery-wide clean.**

- Authoritative detector \`find-targets.ts --all\`: **0** detected issues
- Independent dangerous-direction cross-check (status \`verified\` paired with main-theorem sorries / literal axioms / True stubs / hidden major-Mathlib deps): **0**
- 205 raw count-mismatches inspected and confirmed benign (meta over-disclosing structure-encoded axioms per Axiom Integrity Policy; auxiliary/companion sorries where \`mainSorryCount == 0\`) — these are conservative, not overclaims.

Marked the **594** previously-unaudited tracker entries as \`clean\`. Audit queue now at 0 unaudited / 0 issues.

No meta.json content changes — tracker bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)