### PR TITLE
Enrich Sharp Left Endpoint of Strict Bernoulli (bernoulli-inequality-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "ann-bernOQ010101-overview",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Is −2 the True Left Endpoint of Strict Bernoulli?",
+    "content": "Bernoulli's inequality 1 + n·a ≤ (1+a)ⁿ is usually stated for a ≥ −1, but Mathlib's one_add_mul_le_pow proves it on the larger domain −2 ≤ a, and the parent entry sharpened it to a strict inequality there. This file answers the parent's open question: is −2 forced for each fixed exponent n? The answer is no, and the reason is parity. For even n the right side (1+a)ⁿ is a nonnegative even power, so the inequality is automatic the moment 1 + n·a turns negative (a < −1) — no left endpoint survives. For odd n there is a finite endpoint, but it lies strictly below −2 (exactly −3 for n = 3). The constant −2 reappears only as the supremum of these per-exponent endpoints: the threshold below which SOME exponent eventually fails — i.e. −2 is sharp as the uniform (n-independent) bound, attained by no single n.",
+    "mathContext": "$-2 = \\sup_n a_n^\\*$ where $a_n^\\*$ is the per-exponent endpoint ($a_3^\\* = -3$); $-2$ is approached but never attained by a single $n$, so it is the sharp uniform endpoint.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Bernoulli's inequality",
+      "sharp constants",
+      "parity of exponent",
+      "uniform vs pointwise bounds"
+    ],
+    "prerequisites": [
+      "real-analytic inequalities",
+      "powers and parity",
+      "one_add_mul_le_pow"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-strictpos",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 69
+    },
+    "type": "technique",
+    "title": "Strict Bernoulli on the positive-factor range a > −1",
+    "content": "strict_pos re-proves the strict inequality 1 + n·a < (1+a)ⁿ for a > −1, a ≠ 0, n ≥ 2, by Nat.le_induction starting at n = 2. The base case is closed by nlinarith using a² > 0. The inductive step multiplies the hypothesis by the positive factor 1 + a > 0 (mul_lt_mul_of_pos_right) and absorbs the gap 1 + (m+1)·a < (1 + m·a)(1+a) — itself an a² estimate — via a calc chain. Self-contained (it does not import the parent), and reused as the a > −1 branch of the even-exponent case.",
+    "mathContext": "For $a > -1$, $a \\ne 0$, $n \\ge 2$: $(1 + ma)(1+a) = 1 + (m+1)a + ma^2 > 1 + (m+1)a$ since $1+a > 0$, driving the induction $1 + na < (1+a)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.le_induction",
+      "mul_lt_mul_of_pos_right",
+      "strict monotonicity",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "induction on ℕ from a base",
+      "ordered field arithmetic"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-even",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 93
+    },
+    "type": "insight",
+    "title": "Even exponents have no left endpoint",
+    "content": "strict_even is the first half of the answer: for every even n ≥ 2 and every a ≠ 0, the strict inequality holds — with no lower restriction whatsoever. The proof splits on a versus −1. For a < −1, evenness gives (1+a)ⁿ > 0 (Even.pow_pos, nonzero base) while 1 + n·a < 0 (since n ≥ 2 and a < −1), so the inequality holds with room to spare. At a = −1 the power is 0 while 1 + n·a = 1 − n ≤ −1. For a > −1 it delegates to strict_pos. Because even powers are sign-blind, the admissible range is all a ≠ 0 — there is no endpoint to speak of.",
+    "mathContext": "Even $n \\ge 2$, $a \\ne 0$: if $a < -1$ then $(1+a)^n > 0$ (even power) and $1 + na < 0$, so $1 + na < (1+a)^n$ trivially. Admissible range $= \\{a \\ne 0\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Even.pow_pos",
+      "sign of even powers",
+      "case split on a vs −1",
+      "zero_pow"
+    ],
+    "prerequisites": [
+      "parity of natural numbers",
+      "sign analysis of powers",
+      "strict_pos"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-cubic",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "The cubic endpoint is exactly −3",
+    "content": "cubic_iff is the sharp odd-exponent example: for n = 3 the strict inequality holds IFF a ≠ 0 ∧ −3 < a. The whole proof rests on the algebraic identity (1+a)³ − (1+3a) = a²(a+3), which makes the sign analysis transparent — the difference is positive exactly when a ≠ 0 (so a² > 0) and a + 3 > 0. Thus the left endpoint of the cubic is precisely −3, strictly below −2. This is the concrete witness that odd exponents do have finite endpoints, and that those endpoints can lie below −2.",
+    "mathContext": "$(1+a)^3 - (1+3a) = a^2(a+3) > 0 \\iff a \\ne 0 \\wedge a > -3$. The cubic's left endpoint is $-3 < -2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "factorization identity",
+      "sign analysis",
+      "left endpoint",
+      "sq_nonneg"
+    ],
+    "prerequisites": [
+      "polynomial factoring",
+      "ring / nlinarith"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-witness",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 116
+    },
+    "type": "context",
+    "title": "An explicit exponent admitting a < −2",
+    "content": "exists_lt_neg_two_strict packages the cubic finding into a direct answer to the open question's parenthetical: some exponent really does admit a value below −2. The witness is n = 3, a = −5/2 ∈ (−3, −2), discharged by push_cast; norm_num. This single example settles the existential half of the question affirmatively — confirming −2 is not a universal per-exponent barrier.",
+    "mathContext": "$n = 3$, $a = -5/2$: $1 + 3a = -13/2$ while $(1+a)^3 = (-3/2)^3 = -27/8 > -13/2$, so the strict inequality holds though $a < -2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "existential witness",
+      "cubic_iff",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "concrete arithmetic verification"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-quad",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 138
+    },
+    "type": "insight",
+    "title": "Second-order (quadratic) Bernoulli bound",
+    "content": "quad_bernoulli is the technical engine for the sharpness argument: for x ≥ 0 and every n, 1 + n·x + C(n,2)·x² ≤ (1+x)ⁿ. The proof is induction on n; the successor step multiplies the hypothesis by 1 + x ≥ 0 and discards a nonnegative cubic remainder (n(n−1)/2·x³ ≥ 0), closed by nlinarith. The crucial point is altitude: a power beats a line only at SECOND order, so refuting the first-order Bernoulli line 1 + n·a requires the quadratic term C(n,2)·x² — the first-order one_add_mul_le_pow is structurally too weak to produce a violating exponent. This lemma is independently reusable wherever a power must be shown to outgrow its tangent line.",
+    "mathContext": "$1 + nx + \\binom{n}{2}x^2 \\le (1+x)^n$ for $x \\ge 0$. The quadratic term $\\binom{n}{2}x^2$ grows like $n^2$, letting the power eventually exceed any fixed multiple of the line $1 + nx$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial lower bound",
+      "second-order tangent",
+      "induction on exponent",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "induction on ℕ",
+      "nonnegativity of remainders"
+    ]
+  },
+  {
+    "id": "ann-bernOQ010101-uniform",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 187
+    },
+    "type": "insight",
+    "title": "Main theorem: −2 is the sharp uniform endpoint",
+    "content": "sharp_uniform is the headline: (∀ n, 1 + n·a ≤ (1+a)ⁿ) ↔ −2 ≤ a. The forward (⇐) direction is exactly Mathlib's one_add_mul_le_pow. The reverse (⇒) is the original work: assume a < −2 and build an odd exponent that violates Bernoulli. Set s = −(1+a) > 1 and c = s − 1 > 0; by the Archimedean property (exists_nat_gt) pick N > 4/c² and form the odd exponent n = 2N+1. The quadratic bound quad_bernoulli applied to s = 1 + c gives sⁿ > n·s + n − 1, and since n is odd, (1+a)ⁿ = −sⁿ < 1 + n·a — contradicting the assumed inequality at that n. So a < −2 cannot satisfy Bernoulli for all n, pinning −2 as the sharp uniform left endpoint.",
+    "mathContext": "$(\\forall n,\\ 1 + na \\le (1+a)^n) \\iff -2 \\le a$. For $a < -2$, with $s = -(1+a) > 1$ and odd $n = 2N+1$, $N > 4/(s-1)^2$: $(1+a)^n = -s^n < 1 + na$, the violation.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "one_add_mul_le_pow",
+      "Odd.neg_pow",
+      "exists_nat_gt (Archimedean)",
+      "sharp constant"
+    ],
+    "prerequisites": [
+      "the quadratic Bernoulli bound",
+      "Archimedean property",
+      "odd-power sign reversal",
+      "proof by contradiction"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-01` — sharp left endpoint of the strict Bernoulli inequality. (Recreated after a force-push left the prior PR #28989's head ref stale.)

## Gap closed
Rich `meta.json` (overview, 6 sections, conclusion, references, crossReferences) but **no `annotations.json`**. This PR adds 7 substantive annotations spanning the full Lean file.

## What was added
Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Overview** — parity, not the value of a, decides the endpoint; −2 = supₙ aₙ*
2. **strict_pos** — strict Bernoulli on a > −1 via induction
3. **strict_even** — even exponents have no left endpoint
4. **cubic_iff** — the cubic endpoint is exactly −3
5. **exists_lt_neg_two_strict** — explicit witness n=3, a=−5/2
6. **quad_bernoulli** — second-order bound; a power beats a line only at 2nd order
7. **sharp_uniform** — main theorem: −2 is the sharp uniform endpoint

## Verification
- `pnpm build` passes
- JSON validated; `status: verified`, `axiomCount: 0` consistent with the Lean file (0 sorries, 0 axioms) — left intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)