### PR TITLE
Enrich Signed Stirling Numbers of the First Kind (stirling-first-kind-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/stirling-first-kind-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-01-oq-02/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "ann-boundary-column",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "The Boundary Fact n·c(n,0) = 0",
+    "content": "A small but essential lemma that lets the generating recursion collapse cleanly. The product (n:R)·c(n,0) vanishes for two complementary reasons: at n = 0 the prefactor n is zero, and for n ≥ 1 the Stirling number c(n,0) is itself zero (no permutation of a nonempty set has zero cycles). The case split on n handles both with simp and Nat.stirlingFirst_succ_zero. Without this, the n = 0 column term would obstruct folding the recursion into the rising-factorial form (x+n)·F(n).",
+    "mathContext": "$(n) \\cdot c(n,0) = 0$ for all $n$: either $n = 0$, or $c(n,0) = 0$ since a nonempty set's permutation has $\\ge 1$ cycle.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Stirling numbers boundary values",
+      "case analysis on n",
+      "cycle decomposition"
+    ],
+    "prerequisites": [
+      "Nat.stirlingFirst_succ_zero"
+    ]
+  },
+  {
+    "id": "ann-unsigned-generating",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 114
+    },
+    "type": "concept",
+    "title": "Unsigned Generating Identity (Foundation)",
+    "content": "The load-bearing lemma: ∑ₖ c(n,k)·xᵏ = ∏_{i<n}(x+i), expressing the rising factorial in the monomial basis with the unsigned Stirling numbers as coefficients. Proved by induction on n. The inductive step peels the k=0 term with the index-shifted sum_range_succ', rewrites each c(n+1,k+1) via the defining recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k), splits the sum (sum_add_distrib), and folds it back to (x+n)·F(n) — using the boundary fact n·c(n,0)=0 to absorb the stray column. A self-contained re-proof so the signed identity needs no external generating lemma.",
+    "mathContext": "$\\sum_{k} c(n,k)\\,x^k = \\prod_{i<n}(x+i)$. The recursion $F(n+1) = (x+n)\\,F(n)$ mirrors the rising-factorial recurrence $x^{\\overline{n+1}} = x^{\\overline{n}}(x+n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rising factorial",
+      "generating functions",
+      "Stirling recurrence c(n+1,k+1)=n·c(n,k+1)+c(n,k)"
+    ],
+    "prerequisites": [
+      "Nat.stirlingFirst_succ_succ",
+      "Finset.sum_range_succ'",
+      "induction on n"
+    ]
+  },
+  {
+    "id": "ann-eval-descpochhammer",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 116,
+      "endLine": 125
+    },
+    "type": "concept",
+    "title": "Evaluating the Falling-Factorial Polynomial",
+    "content": "Bridges Mathlib's descPochhammer polynomial to the explicit product form: (descPochhammer R n).eval x = ∏_{i<n}(x−i). A short induction on the recurrence descPochhammer_succ_right (descPochhammer (n+1) = descPochhammer n · (X−n)) plus eval_mul/eval_sub. Mathlib defines descPochhammer but does not record this evaluated product directly, so this fills a small gap and lets the signed identity be restated in Mathlib's own vocabulary.",
+    "mathContext": "$(\\mathrm{descPochhammer}\\ R\\ n).\\mathrm{eval}\\ x = \\prod_{i<n}(x - i) = x^{\\underline{n}}$, the falling factorial.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "falling factorial",
+      "descPochhammer",
+      "polynomial evaluation"
+    ],
+    "prerequisites": [
+      "descPochhammer_succ_right",
+      "Polynomial.eval lemmas"
+    ]
+  },
+  {
+    "id": "ann-signed-generating",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 127,
+      "endLine": 166
+    },
+    "type": "insight",
+    "title": "Signed Identity: Signs Are the x ↦ −x Flip",
+    "content": "The headline result: ∑ₖ (−1)^{n−k} c(n,k)·xᵏ = ∏_{i<n}(x−i), the falling factorial, with the signed Stirling numbers s(n,k)=(−1)^{n−k}c(n,k) as its monomial coefficients. The whole proof is the unsigned identity composed with negation. The parity bridge (−1)^{n−k} = (−1)ⁿ(−1)ᵏ (valid for k≤n, established via (−1)ᵏ·(−1)ᵏ=1 and pow_add) rewrites each term as (−1)ⁿ·c(n,k)·(−x)ᵏ; factoring out (−1)ⁿ and applying the unsigned identity at −x gives (−1)ⁿ·∏(−x+i). Finally ∏(−x+i)=(−1)ⁿ∏(x−i) and the two (−1)ⁿ cancel.",
+    "mathContext": "$\\sum_k (-1)^{n-k} c(n,k)\\,x^k = \\prod_{i<n}(x-i)$. Key: $(-1)^{n-k} = (-1)^n(-1)^k$ for $k \\le n$, and $\\prod(-x+i) = (-1)^n\\prod(x-i)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "signed Stirling numbers",
+      "falling factorial",
+      "parity bridge",
+      "substitution x ↦ −x"
+    ],
+    "prerequisites": [
+      "stirlingFirst_generating",
+      "neg_pow",
+      "Finset.prod_mul_distrib"
+    ]
+  },
+  {
+    "id": "ann-descpochhammer-form",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 168,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Restatement via descPochhammer",
+    "content": "Combines the signed identity with the evaluated-product lemma to phrase the result purely in Mathlib's language: ∑ₖ (−1)^{n−k} c(n,k) xᵏ = (descPochhammer R n).eval x. This exhibits the signed Stirling numbers of the first kind as precisely the monomial coefficients of Mathlib's falling-factorial polynomial — the directly citable form for downstream use.",
+    "mathContext": "$\\sum_k (-1)^{n-k} c(n,k)\\,x^k = (\\mathrm{descPochhammer}\\ R\\ n).\\mathrm{eval}\\ x$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "descPochhammer",
+      "connection coefficients",
+      "monomial basis"
+    ],
+    "prerequisites": [
+      "stirlingFirst_generating_signed",
+      "eval_descPochhammer_eq_prod"
+    ]
+  },
+  {
+    "id": "ann-alternating-row-sum",
+    "proofId": "stirling-first-kind-oq-01-oq-02",
+    "range": {
+      "startLine": 175,
+      "endLine": 195
+    },
+    "type": "insight",
+    "title": "The Alternating Row Sum Vanishes Structurally",
+    "content": "The parent's open question, answered: ∑ₖ (−1)^{n−k} c(n,k) = [n ≤ 1]. Specializing the signed identity at x = 1 turns the left side into the alternating row sum and the right side into ∏_{i<n}(1−i) = (1)^{(n)}_↓. For n ∈ {0,1} this evaluates directly to 1; for n ≥ 2 the product carries the factor (1−1) = 0 at index i = 1, so Finset.prod_eq_zero forces the whole sum to 0. No cancellation bookkeeping is needed — the vanishing is structural, a single zero factor in the falling factorial.",
+    "mathContext": "$\\sum_k (-1)^{n-k} c(n,k) = [n \\le 1]$. At $x=1$: $(1)^{\\underline{n}} = 1\\cdot 0\\cdot(-1)\\cdots = 0$ for $n \\ge 2$ (zero factor at $i=1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating sum",
+      "structural vanishing",
+      "specialization at x = 1"
+    ],
+    "prerequisites": [
+      "stirlingFirst_generating_signed",
+      "Finset.prod_eq_zero"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `stirling-first-kind-oq-01-oq-02`.

**Gap filled:** the entry had no `annotations.json`. Added six annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every theorem:
1. `natCast_mul_stirlingFirst_zero_left` — the boundary fact n·c(n,0)=0
2. `stirlingFirst_generating` — unsigned rising-factorial foundation
3. `eval_descPochhammer_eq_prod` — evaluating the falling-factorial polynomial
4. `stirlingFirst_generating_signed` — the signed identity as the x↦−x flip
5. `stirlingFirst_generating_signed_descPochhammer` — restatement via descPochhammer
6. `stirlingFirst_alternating_row_sum` — structural vanishing of the alternating row sum

Annotation line ranges verified against the Lean source; cross-reference to `stirling-first-kind-oq-01` confirmed present. JSON validated. meta.json already complete (rich overview, 2 open questions, references) so left intact.