### PR TITLE
Enrich Tritangent-Center Centroid = Circumcenter (feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "ann-triangle-inequalities",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 155,
+      "endLine": 241
+    },
+    "type": "technique",
+    "title": "Strict Triangle Inequalities Keep the Excenter Denominators Positive",
+    "content": "The excenter coordinates carry the denominators pₐ = −a+b+c, p_b = a−b+c, p_c = a+b−c, which must be nonzero (in fact positive) for the Heron product to clear cleanly. These are exactly the strict triangle inequalities a < b+c (cyclically), reproved locally because the parent file declares them private. The proof routes through the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant: since D ≠ 0, P < bc, hence a² < (b+c)², hence a < b+c. The positivity lemmas pa_pos/pb_pos/pc_pos then guarantee the Heron product prodP > 0.",
+    "mathContext": "$a < b+c$ etc. via $a^2 = b^2+c^2+2P$ and $b^2c^2 - P^2 = D^2$ ($D \\ne 0 \\Rightarrow P < bc$). Hence $p_a, p_b, p_c > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle inequality",
+      "law of cosines",
+      "excenter denominators"
+    ],
+    "prerequisites": [
+      "law of cosines",
+      "Lagrange identity",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-heron-bridge",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 248,
+      "endLine": 303
+    },
+    "type": "concept",
+    "title": "The Heron Product Equals the Squared Circumcenter Determinant",
+    "content": "The pivotal bridge: prodP = p_s·pₐ·p_b·p_c is shown equal to d², the squared circumcenter determinant. Two independent computations of 16·Area² are equated — sixteen_area_sq gives 16·Area² = d² (the determinant d = 2·det is twice the signed area), and heron gives 16·Area² = prodP from the shoelace area in terms of the squared sides. Together prodP_eq_d_sq yields prodP = d². This single identification is what lets one common factor simultaneously clear the four tritangent reciprocal denominators (the p's) and the circumcenter denominator d, collapsing the whole problem to polynomial identities.",
+    "mathContext": "$16\\,\\mathrm{Area}^2 = d^2$ and $16\\,\\mathrm{Area}^2 = p_s p_a p_b p_c$, so $p_s p_a p_b p_c = d^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Heron's formula",
+      "shoelace area",
+      "circumcenter determinant"
+    ],
+    "prerequisites": [
+      "ring",
+      "field_simp",
+      "squared side lengths"
+    ]
+  },
+  {
+    "id": "ann-circumcenter-barycentric",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 305,
+      "endLine": 329
+    },
+    "type": "concept",
+    "title": "The Circumcenter Is Barycentric",
+    "content": "circ_bary_x/y establish that the coordinate circumcenter determinant numerator times d equals N, the barycentric numerator a²(b²+c²−a²)·A + b²(c²+a²−b²)·B + c²(a²+b²−c²)·C. This is the classical fact that O has unnormalized barycentric coordinates a²(b²+c²−a²) : b²(c²+a²−b²) : c²(a²+b²−c²). Proved as a pure coordinate ring identity after substituting a² = |BC|², etc. The same coefficients reappear in the tritangent telescoping, which is exactly why the centroid of the four centers lands on O.",
+    "mathContext": "$O$ has barycentric coordinates $a^2(b^2{+}c^2{-}a^2) : b^2(c^2{+}a^2{-}b^2) : c^2(a^2{+}b^2{-}c^2)$; the determinant numerator $\\times\\, d = N$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "barycentric coordinates",
+      "circumcenter",
+      "coordinate ring identity"
+    ],
+    "prerequisites": [
+      "ring",
+      "circumcenter coordinate formula"
+    ]
+  },
+  {
+    "id": "ann-telescoping",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 331,
+      "endLine": 362
+    },
+    "type": "insight",
+    "title": "The Tritangent Sum Telescopes in the Free Side Lengths",
+    "content": "The heart of the argument: tritangent_mul_heron_x/y show the tritangent coordinate sum, cleared by the Heron product, equals 4·N. Writing the incenter as (a·A+b·B+c·C)/p_s and each excenter with denominator pₐ, p_b, p_c, the coefficient of vertex A is a·(1/p_s − 1/pₐ + 1/p_b + 1/p_c). Multiplying by p_s·pₐ·p_b·p_c, the reciprocals telescope and the A-coefficient collapses to 4a²(b²+c²−a²) — an identity in the free side lengths, with no appeal to the coordinates. Only even powers of the sides survive (the half-telescoped 2a²(p_s pₐ − p_b p_c) equals 4a²(b²+c²−a²)), so no square roots ever appear and the step is a single ring call after field_simp.",
+    "mathContext": "Coefficient of $A$: $a\\left(\\tfrac{1}{p_s} - \\tfrac{1}{p_a} + \\tfrac{1}{p_b} + \\tfrac{1}{p_c}\\right) \\cdot p_s p_a p_b p_c = 4a^2(b^2+c^2-a^2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping",
+      "barycentric numerator",
+      "incenter and excenter coordinates"
+    ],
+    "prerequisites": [
+      "field_simp",
+      "ring",
+      "prodP_pos"
+    ]
+  },
+  {
+    "id": "ann-main-identity",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 365,
+      "endLine": 399
+    },
+    "type": "insight",
+    "title": "Main Identity I + Iₐ + I_b + I_c = 4O",
+    "content": "tritangent_centroid_x/y assemble the pieces. Multiplying the target by the Heron product, the left side becomes 4·N by the telescoping identity; the right side becomes 4·O·prodP = 4·O·d² = 4·(ux/d)·d² = 4·ux·d = 4·N by the barycentric identity. Since the Heron product is strictly positive, mul_right_cancel₀ removes it and yields the coordinatewise identity I + Iₐ + I_b + I_c = 4O for an arbitrary non-degenerate triangle.",
+    "mathContext": "$\\big(\\sum X\\big)\\cdot\\mathrm{prodP} = 4N = (4O)\\cdot\\mathrm{prodP}$, and $\\mathrm{prodP} > 0$, so $\\sum X = 4O$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "tritangent centers",
+      "centroid",
+      "mul_right_cancel₀"
+    ],
+    "prerequisites": [
+      "tritangent_mul_heron_x",
+      "circ_bary_x",
+      "prodP_eq_d_sq"
+    ]
+  },
+  {
+    "id": "ann-centroid-point-form",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 401,
+      "endLine": 413
+    },
+    "type": "insight",
+    "title": "Point Form: O Is the Centroid of the Four Tritangent Centers",
+    "content": "circumcenter_eq_tritangent_centroid restates the two coordinate identities as a single point equation: O = ((I+Iₐ+I_b+I_c).x / 4, (I+Iₐ+I_b+I_c).y / 4), assembled with Prod.ext. This is the affine companion of the sibling's metric law OI²+OIₐ²+OI_b²+OI_c² = 12R²: because the centroid G of the four centers equals O, Leibniz's parallel-axis identity Σ OX² = 4·OG² + Σ GX² reduces to OG = 0, making 12R² exactly the moment of inertia of the four centers about O. Equivalently, the circumcircle of ABC is the nine-point circle of the excentral triangle.",
+    "mathContext": "$O = \\tfrac{1}{4}(I + I_a + I_b + I_c)$. With $G = O$, Leibniz gives $\\sum OX^2 = \\sum GX^2 = 12R^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Leibniz parallel-axis identity",
+      "nine-point circle",
+      "orthocentric system",
+      "excentral triangle"
+    ],
+    "prerequisites": [
+      "tritangent_centroid_x",
+      "tritangent_centroid_y",
+      "Prod.ext"
+    ]
+  },
+  {
+    "id": "ann-345-example",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 416,
+      "endLine": 447
+    },
+    "type": "context",
+    "title": "Worked Example: the 3-4-5 Triangle",
+    "content": "A concrete instantiation grounds the identity. For the parent's 3-4-5 triangle (A=(0,0), B=(3,0), C=(0,4); sides a=5, b=4, c=3), the excenters evaluate to Iₐ=(6,6), I_b=(−3,3), I_c=(2,−2) and the incenter is (1,1). Their sum (6,8) equals 4·(3/2,2) = 4·O, confirming the general theorem at a fully explicit triangle. norm_num evaluates the weighted barycentric coordinates from the known side lengths.",
+    "mathContext": "$I=(1,1),\\ I_a=(6,6),\\ I_b=(-3,3),\\ I_c=(2,-2)$; sum $=(6,8)=4\\cdot(3/2,2)=4O$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "3-4-5 triangle",
+      "explicit excenters"
+    ],
+    "prerequisites": [
+      "norm_num",
+      "triangle_345"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01`.

**Gap filled:** the entry had no `annotations.json`. Added seven annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual declaration line ranges:
1. Strict triangle inequalities keeping the excenter denominators positive
2. Heron product = squared circumcenter determinant (the bridge)
3. The circumcenter is barycentric (circ_bary_x/y)
4. The tritangent sum telescopes in the free side lengths
5. Main identity I + Iₐ + I_b + I_c = 4O
6. Point form: O is the centroid of the four tritangent centers (Leibniz)
7. Worked 3-4-5 example

All four cross-references confirmed to point at existing gallery entries. JSON validated. meta.json was already complete (mainTheorems, six sections, three open questions, references) so left intact.