### PR TITLE
research(ptolemys-theorem-oq-05): Ptolemy's inequality in arbitrary real inner product spaces [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PtolemyInequalityInnerProduct.lean
+++ b/proofs/Proofs/PtolemyInequalityInnerProduct.lean
@@ -1,0 +1,153 @@
+import Mathlib
+
+/-
+# Ptolemy's Inequality in an Arbitrary Real Inner Product Space — OQ-05
+
+## Research Problem: ptolemys-theorem-oq-05
+
+Parent open question (ptolemys-theorem):
+  "Can Ptolemy's inequality (AC·BD ≤ AB·CD + AD·BC for arbitrary four points)
+   be formalized?"
+
+The gallery already answers this **in the plane**: `PtolemysComplexProof.lean`
+proves the inequality for four points of `ℂ` via the algebraic identity
+`(z₁-z₃)(z₂-z₄) = (z₁-z₂)(z₃-z₄) + (z₁-z₄)(z₂-z₃)` plus the triangle inequality
+for `|·|`.  Mathlib (`Mathlib.Geometry.Euclidean.Sphere.Ptolemy`) proves only the
+**equality** case for *cospherical* points.
+
+Neither covers the general metric statement: Ptolemy's inequality holds for any
+four points of an arbitrary real inner product space (any dimension), not just the
+Euclidean plane.  The complex-identity proof is intrinsically two-dimensional.
+
+This file proves the **general** statement via the *inversion-distance identity*
+(the classical proof by inversion), which works in every dimension:
+
+For nonzero `u w` in a real inner product space `V`,
+    ‖u‖ · ‖w‖ · ‖ (‖u‖²)⁻¹ • u − (‖w‖²)⁻¹ • w ‖ = ‖u − w‖,           (`inversion_dist`)
+i.e. the spherical inversion `x ↦ (‖x‖²)⁻¹ • x` (centred at the origin, radius 1)
+scales the distance between `u` and `w` by `1 / (‖u‖ ‖w‖)`.
+
+Applying the triangle inequality to the three inverted points and clearing
+denominators yields Ptolemy's inequality with the fourth vertex at the origin:
+
+    ‖x − z‖ · ‖y‖ ≤ ‖x − y‖ · ‖z‖ + ‖y − z‖ · ‖x‖                   (`ptolemy_origin`)
+
+for **all** `x y z : V`.  Translating to a `NormedAddTorsor` gives the four-point
+form
+
+    dist a c · dist b d ≤ dist a b · dist c d + dist b c · dist a d  (`ptolemy_dist`)
+
+valid for arbitrary points `a b c d` of any real inner-product affine space.
+
+DISTINCT from the gallery's `PtolemysComplexProof.lean` (ℂ only) and from
+Mathlib's cospherical equality: this is the inequality in arbitrary dimension.
+
+Tags: geometry, ptolemy, inner-product-space, inversion, inequality
+-/
+
+open RealInnerProductSpace
+
+namespace PtolemyInequalityInnerProduct
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- **Inversion distance identity.**  The spherical inversion `x ↦ (‖x‖²)⁻¹ • x`
+(centre `0`, radius `1`) sends two nonzero points `u`, `w` to points whose
+distance is `‖u − w‖ / (‖u‖ ‖w‖)`.  Stated in denominator-free product form. -/
+theorem inversion_dist (u w : V) (hu : u ≠ 0) (hw : w ≠ 0) :
+    ‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖ = ‖u - w‖ := by
+  have hu0 : (0 : ℝ) < ‖u‖ := norm_pos_iff.mpr hu
+  have hw0 : (0 : ℝ) < ‖w‖ := norm_pos_iff.mpr hw
+  -- Expand the two squared norms via the polarization identity.
+  have eab : ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖ ^ 2
+      = ‖(‖u‖ ^ 2)⁻¹ • u‖ ^ 2 - 2 * ⟪(‖u‖ ^ 2)⁻¹ • u, (‖w‖ ^ 2)⁻¹ • w⟫
+          + ‖(‖w‖ ^ 2)⁻¹ • w‖ ^ 2 :=
+    norm_sub_sq_real _ _
+  have euw : ‖u - w‖ ^ 2 = ‖u‖ ^ 2 - 2 * ⟪u, w⟫ + ‖w‖ ^ 2 := norm_sub_sq_real _ _
+  -- The pieces, as plain real expressions.
+  have iab : ⟪(‖u‖ ^ 2)⁻¹ • u, (‖w‖ ^ 2)⁻¹ • w⟫
+      = (‖u‖ ^ 2)⁻¹ * (‖w‖ ^ 2)⁻¹ * ⟪u, w⟫ := by
+    rw [real_inner_smul_left, real_inner_smul_right]; ring
+  have na : ‖(‖u‖ ^ 2)⁻¹ • u‖ = (‖u‖ ^ 2)⁻¹ * ‖u‖ := by
+    rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+  have nb : ‖(‖w‖ ^ 2)⁻¹ • w‖ = (‖w‖ ^ 2)⁻¹ * ‖w‖ := by
+    rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+  -- Squared equality, then take square roots (both sides nonnegative).
+  have key : (‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖) ^ 2 = ‖u - w‖ ^ 2 := by
+    have expand : (‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖) ^ 2
+        = ‖u‖ ^ 2 * ‖w‖ ^ 2 * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖ ^ 2 := by ring
+    rw [expand, eab, iab, na, nb, euw]
+    field_simp
+    ring
+  have hLnn : 0 ≤ ‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖ := by positivity
+  calc ‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖
+      = Real.sqrt ((‖u‖ * ‖w‖ * ‖(‖u‖ ^ 2)⁻¹ • u - (‖w‖ ^ 2)⁻¹ • w‖) ^ 2) :=
+        (Real.sqrt_sq hLnn).symm
+    _ = Real.sqrt (‖u - w‖ ^ 2) := by rw [key]
+    _ = ‖u - w‖ := Real.sqrt_sq (norm_nonneg _)
+
+/-- **Ptolemy's inequality, fourth vertex at the origin.**  For arbitrary vectors
+`x y z` of a real inner product space,
+    ‖x − z‖ · ‖y‖ ≤ ‖x − y‖ · ‖z‖ + ‖y − z‖ · ‖x‖.
+Any four-point configuration translates to this by moving the fourth point to `0`. -/
+theorem ptolemy_origin (x y z : V) :
+    ‖x - z‖ * ‖y‖ ≤ ‖x - y‖ * ‖z‖ + ‖y - z‖ * ‖x‖ := by
+  -- Degenerate cases: if any vertex coincides with the origin the inequality is
+  -- a (possibly trivial) triangle/identity statement.
+  rcases eq_or_ne x 0 with hx | hx
+  · subst hx
+    simp only [zero_sub, norm_neg, norm_zero, mul_zero, add_zero]
+    rw [mul_comm]
+  rcases eq_or_ne y 0 with hy | hy
+  · subst hy
+    simp only [norm_zero, mul_zero, sub_zero, zero_sub, norm_neg]
+    positivity
+  rcases eq_or_ne z 0 with hz | hz
+  · subst hz
+    simp only [sub_zero, norm_zero, mul_zero, zero_add]
+    rw [mul_comm]
+  -- Generic case: apply the triangle inequality to the inverted points.
+  set a : V := (‖x‖ ^ 2)⁻¹ • x with ha
+  set b : V := (‖y‖ ^ 2)⁻¹ • y with hb
+  set c : V := (‖z‖ ^ 2)⁻¹ • z with hc
+  -- Inversion distances.
+  have I_ac : ‖x‖ * ‖z‖ * ‖a - c‖ = ‖x - z‖ := inversion_dist x z hx hz
+  have I_ab : ‖x‖ * ‖y‖ * ‖a - b‖ = ‖x - y‖ := inversion_dist x y hx hy
+  have I_bc : ‖y‖ * ‖z‖ * ‖b - c‖ = ‖y - z‖ := inversion_dist y z hy hz
+  -- Triangle inequality for the inverted points, scaled by ‖x‖‖y‖‖z‖ > 0.
+  have tri : ‖a - c‖ ≤ ‖a - b‖ + ‖b - c‖ := by
+    have := dist_triangle a b c
+    simpa only [dist_eq_norm] using this
+  have scaled : ‖x‖ * ‖y‖ * ‖z‖ * ‖a - c‖
+      ≤ ‖x‖ * ‖y‖ * ‖z‖ * (‖a - b‖ + ‖b - c‖) :=
+    mul_le_mul_of_nonneg_left tri (by positivity)
+  -- Rewrite each scaled distance into a side product.
+  have L : ‖x‖ * ‖y‖ * ‖z‖ * ‖a - c‖ = ‖x - z‖ * ‖y‖ := by
+    rw [show ‖x‖ * ‖y‖ * ‖z‖ * ‖a - c‖ = (‖x‖ * ‖z‖ * ‖a - c‖) * ‖y‖ by ring, I_ac]
+  have R : ‖x‖ * ‖y‖ * ‖z‖ * (‖a - b‖ + ‖b - c‖)
+      = ‖x - y‖ * ‖z‖ + ‖y - z‖ * ‖x‖ := by
+    rw [mul_add,
+      show ‖x‖ * ‖y‖ * ‖z‖ * ‖a - b‖ = (‖x‖ * ‖y‖ * ‖a - b‖) * ‖z‖ by ring, I_ab,
+      show ‖x‖ * ‖y‖ * ‖z‖ * ‖b - c‖ = (‖y‖ * ‖z‖ * ‖b - c‖) * ‖x‖ by ring, I_bc]
+  rwa [L, R] at scaled
+
+/-- **Ptolemy's inequality for four arbitrary points** of a real inner-product
+affine space (a `NormedAddTorsor` over `V`).  For points `a b c d`,
+    dist a c · dist b d ≤ dist a b · dist c d + dist b c · dist a d.
+Valid in every dimension; the gallery's complex-number proof is two-dimensional. -/
+theorem ptolemy_dist {P : Type*} [MetricSpace P] [NormedAddTorsor V P]
+    (a b c d : P) :
+    dist a c * dist b d ≤ dist a b * dist c d + dist b c * dist a d := by
+  -- Translate so that `d` is the origin: set x = a -ᵥ d, y = b -ᵥ d, z = c -ᵥ d.
+  have h := ptolemy_origin (a -ᵥ d) (b -ᵥ d) (c -ᵥ d)
+  -- dist p q = ‖(p -ᵥ d) - (q -ᵥ d)‖, dist p d = ‖p -ᵥ d‖.
+  simp only [dist_eq_norm_vsub V, vsub_sub_vsub_cancel_right] at h ⊢
+  exact h
+
+/-- Concrete instantiation in `EuclideanSpace ℝ (Fin 3)`: Ptolemy's inequality
+holds in three dimensions, where the complex-number proof does not apply. -/
+example (a b c d : EuclideanSpace ℝ (Fin 3)) :
+    dist a c * dist b d ≤ dist a b * dist c d + dist b c * dist a d :=
+  ptolemy_dist a b c d
+
+end PtolemyInequalityInnerProduct

--- a/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-inversion-dist",
+    "proofId": "ptolemys-theorem-oq-05",
+    "range": { "startLine": 57, "endLine": 87 },
+    "type": "insight",
+    "title": "Inversion scales distances by 1/(‖u‖‖w‖)",
+    "content": "inversion_dist is the geometric engine of the whole proof. The spherical inversion x ↦ (‖x‖²)⁻¹•x (centre 0, radius 1) sends two nonzero points u, w to points whose distance is ‖u−w‖/(‖u‖‖w‖). The proof expands ‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖² by the real polarization identity norm_sub_sq_real: the diagonal terms become (‖u‖²)⁻¹ and (‖w‖²)⁻¹ and the cross term picks up ⟪u,w⟫ scaled by (‖u‖²)⁻¹(‖w‖²)⁻¹. Multiplying through by ‖u‖²‖w‖² recovers ‖u‖² − 2⟪u,w⟫ + ‖w‖² = ‖u−w‖², so the squared product identity holds; field_simp; ring closes it and a final square root (Real.sqrt_sq, both sides nonnegative) gives the stated form. Unlike the complex algebraic identity, this works in every dimension.",
+    "mathContext": "$\\lVert u\\rVert\\,\\lVert w\\rVert\\,\\lVert \\lVert u\\rVert^{-2}u - \\lVert w\\rVert^{-2}w\\rVert = \\lVert u-w\\rVert$, i.e. $\\lVert u'-w'\\rVert = \\lVert u-w\\rVert/(\\lVert u\\rVert\\lVert w\\rVert)$ for the inverted points $u',w'$.",
+    "significance": "key",
+    "relatedConcepts": ["spherical inversion", "polarization identity", "real inner product space", "conformal map"],
+    "prerequisites": ["inner product spaces", "norm and inner product relation"]
+  },
+  {
+    "id": "ann-ptolemy-origin",
+    "proofId": "ptolemys-theorem-oq-05",
+    "range": { "startLine": 93, "endLine": 132 },
+    "type": "insight",
+    "title": "Ptolemy = triangle inequality after inversion",
+    "content": "Placing the fourth vertex at the origin reduces Ptolemy to the three-vector inequality ‖x−z‖·‖y‖ ≤ ‖x−y‖·‖z‖ + ‖y−z‖·‖x‖. In the generic case (all three vectors nonzero) we apply the ordinary triangle inequality ‖a−c‖ ≤ ‖a−b‖ + ‖b−c‖ to the inverted points a=(‖x‖²)⁻¹•x, b, c, scale by ‖x‖‖y‖‖z‖ > 0, and rewrite each scaled distance with inversion_dist: ‖x‖‖y‖‖z‖·‖a−c‖ = ‖x−z‖·‖y‖, and similarly on the right. The degenerate cases (a vertex at the origin) cannot invert but hold directly — both sides vanish when y = 0, and Ptolemy becomes an equality when x = 0 or z = 0.",
+    "mathContext": "$\\lVert x-z\\rVert\\,\\lVert y\\rVert \\le \\lVert x-y\\rVert\\,\\lVert z\\rVert + \\lVert y-z\\rVert\\,\\lVert x\\rVert$.",
+    "significance": "key",
+    "relatedConcepts": ["triangle inequality", "Ptolemy's inequality", "translation invariance"],
+    "prerequisites": ["triangle inequality", "scaling inequalities by positive constants"]
+  },
+  {
+    "id": "ann-ptolemy-dist",
+    "proofId": "ptolemys-theorem-oq-05",
+    "range": { "startLine": 138, "endLine": 152 },
+    "type": "insight",
+    "title": "Dimension-free four-point form and a 3D witness",
+    "content": "ptolemy_dist transports the origin form to an arbitrary NormedAddTorsor over a real inner product space by translating the fourth point d to the origin (x = a−ᵥd, y = b−ᵥd, z = c−ᵥd): dist_eq_norm_vsub rewrites distances as norms of vsub differences and vsub_sub_vsub_cancel_right cancels the common d, after which ptolemy_origin closes it. The concrete instantiation in EuclideanSpace ℝ (Fin 3) exhibits Ptolemy's inequality in three dimensions — a configuration the gallery's complex-number proof, tied to the plane, cannot reach.",
+    "mathContext": "$\\operatorname{dist}(a,c)\\operatorname{dist}(b,d) \\le \\operatorname{dist}(a,b)\\operatorname{dist}(c,d) + \\operatorname{dist}(b,c)\\operatorname{dist}(a,d)$ for $a,b,c,d$ in any inner-product affine space.",
+    "significance": "high",
+    "relatedConcepts": ["NormedAddTorsor", "inner-product affine space", "EuclideanSpace"],
+    "prerequisites": ["affine spaces and torsors", "vsub and dist"]
+  }
+]

--- a/src/data/proofs/ptolemys-theorem-oq-05/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-05/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "ptolemys-theorem-oq-05",
+  "slug": "ptolemys-theorem-oq-05",
+  "title": "Ptolemy's Inequality in an Arbitrary Real Inner Product Space (via Inversion)",
+  "description": "Ptolemy's inequality dist(a,c)·dist(b,d) ≤ dist(a,b)·dist(c,d) + dist(b,c)·dist(a,d) for four arbitrary points of any real inner-product affine space (a NormedAddTorsor over a real inner product space), valid in every dimension. Proved by spherical inversion: the map x ↦ (‖x‖²)⁻¹·x scales distances by 1/(‖x‖‖y‖), so the ordinary triangle inequality for the three inverted points becomes Ptolemy after clearing denominators. This generalises the gallery's plane (ℂ) proof, whose complex algebraic identity is intrinsically two-dimensional, and complements Mathlib's cospherical equality case.",
+  "overview": {
+    "historicalContext": "Ptolemy of Alexandria (c. 100–170 AD) used the equality case AC·BD = AB·CD + AD·BC for cyclic quadrilaterals to build his table of chords, effectively the first trigonometric table. For four arbitrary (not necessarily concyclic) points the relation degrades to an inequality AC·BD ≤ AB·CD + AD·BC, with equality exactly when the points lie on a circle (or line) in the right cyclic order. While the planar inequality has an elegant complex-number proof, the statement is in fact metric and holds in any Euclidean space of any dimension. The standard dimension-free argument is by geometric inversion: inverting in a sphere centred at one of the four points sends the other three to points whose mutual distances are the original distances rescaled, turning Ptolemy's inequality into the ordinary triangle inequality among the images.",
+    "problemStatement": "Formalize Ptolemy's inequality for four ARBITRARY points of a real inner product space (any dimension): $\\operatorname{dist}(a,c)\\cdot\\operatorname{dist}(b,d) \\le \\operatorname{dist}(a,b)\\cdot\\operatorname{dist}(c,d) + \\operatorname{dist}(b,c)\\cdot\\operatorname{dist}(a,d)$, beyond the planar complex-number proof already in the gallery.",
+    "text": "Proves the inversion-distance identity ‖u‖·‖w‖·‖(‖u‖²)⁻¹·u − (‖w‖²)⁻¹·w‖ = ‖u−w‖ in any real inner product space, then derives Ptolemy's inequality with the fourth vertex at the origin and transports it to an arbitrary NormedAddTorsor.",
+    "proofStrategy": "1. inversion_dist: for nonzero u, w, show ‖u‖·‖w‖·‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖ by expanding both sides with the real polarization identity norm_sub_sq_real and real_inner_smul_{left,right}, proving the squared identity (‖u‖‖w‖‖a−b‖)² = ‖u−w‖² via field_simp; ring, then taking square roots (both sides nonnegative, Real.sqrt_sq). 2. ptolemy_origin: for vectors x y z, dispatch the degenerate cases where a vertex equals the origin (the inequality becomes an equality or a triviality), then in the generic case apply the triangle inequality ‖a−c‖ ≤ ‖a−b‖ + ‖b−c‖ to the inverted points a=(‖x‖²)⁻¹•x, b, c, scale by ‖x‖‖y‖‖z‖ > 0, and rewrite each scaled term using inversion_dist to obtain ‖x−z‖·‖y‖ ≤ ‖x−y‖·‖z‖ + ‖y−z‖·‖x‖. 3. ptolemy_dist: translate so the fourth point d is the origin (x = a−ᵥd, etc.), using dist_eq_norm_vsub and vsub_sub_vsub_cancel_right, and apply ptolemy_origin.",
+    "keyInsights": [
+      "The complex-number proof in the gallery (PtolemysComplexProof.lean) relies on the algebraic identity (z₁−z₃)(z₂−z₄) = (z₁−z₂)(z₃−z₄) + (z₁−z₄)(z₂−z₃) together with |z+w| ≤ |z|+|w|. That identity is special to a commutative ring of 'points' and so only proves Ptolemy in the plane ℂ. Inversion replaces it and works verbatim in every dimension.",
+      "The crux is the inversion-distance identity ‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖/(‖u‖‖w‖). Expanding the squared norm, the cross term picks up ⟪u,w⟫ scaled by (‖u‖²)⁻¹(‖w‖²)⁻¹ and the diagonal terms become (‖u‖²)⁻¹ and (‖w‖²)⁻¹; multiplying through by ‖u‖²‖w‖² recovers exactly ‖u‖² − 2⟪u,w⟫ + ‖w‖² = ‖u−w‖².",
+      "Placing the fourth vertex at the origin reduces the four-point statement to a three-vector inequality ‖x−z‖·‖y‖ ≤ ‖x−y‖·‖z‖ + ‖y−z‖·‖x‖. Every four-point configuration translates to this form, so no generality is lost; the NormedAddTorsor version is a one-line transport.",
+      "The degenerate cases (a vertex at the origin) cannot use inversion (the inverted point is undefined) but hold directly: if the second vertex is the origin both sides vanish, and if the first or third coincides with the origin Ptolemy becomes an equality between the two surviving products.",
+      "The development is axiom-clean (only propext / Classical.choice / Quot.sound) and dimension-free: the concrete instantiation in EuclideanSpace ℝ (Fin 3) exhibits a case the planar complex proof cannot reach."
+    ],
+    "prerequisites": [
+      "Real inner product spaces and the polarization identity",
+      "Spherical inversion and its distance-scaling property",
+      "NormedAddTorsor (inner-product affine space) and dist_eq_norm_vsub",
+      "Lean 4 tactics: field_simp, positivity, Real.sqrt_sq"
+    ]
+  },
+  "sections": [
+    {
+      "id": "inversion-dist",
+      "title": "The inversion-distance identity",
+      "startLine": 54,
+      "endLine": 87,
+      "summary": "For nonzero u, w, the inversion x ↦ (‖x‖²)⁻¹•x satisfies ‖u‖·‖w‖·‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖. Proved by the real polarization identity, a squared-norm computation closed by field_simp; ring, then a square root."
+    },
+    {
+      "id": "ptolemy-origin",
+      "title": "Ptolemy with the fourth vertex at the origin",
+      "startLine": 89,
+      "endLine": 132,
+      "summary": "For vectors x y z, ‖x−z‖·‖y‖ ≤ ‖x−y‖·‖z‖ + ‖y−z‖·‖x‖: degenerate cases by hand, generic case by scaling the triangle inequality for the three inverted points and rewriting via inversion_dist."
+    },
+    {
+      "id": "ptolemy-dist",
+      "title": "Ptolemy for four arbitrary points of an affine space",
+      "startLine": 134,
+      "endLine": 152,
+      "summary": "dist(a,c)·dist(b,d) ≤ dist(a,b)·dist(c,d) + dist(b,c)·dist(a,d) in any NormedAddTorsor over a real inner product space, by translating the fourth point to the origin; instantiated concretely in EuclideanSpace ℝ (Fin 3)."
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "namespace": "PtolemyInequalityInnerProduct",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/PtolemyInequalityInnerProduct.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Ptolemy (c. 150 AD); inversion proof classical",
+    "date": "2026",
+    "dateAdded": "2026-06-24",
+    "status": "verified",
+    "badge": "verified",
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "theoremCount": 3,
+    "lineCount": 153,
+    "sorries": 0,
+    "mathlib_version": "v4.26.0",
+    "proofRepoPath": "Proofs/PtolemyInequalityInnerProduct.lean",
+    "assumptions": [],
+    "tags": ["geometry", "ptolemy", "inner-product-space", "inversion", "inequality", "research"],
+    "originalContributions": [
+      "Ptolemy's inequality for four arbitrary points of an arbitrary real inner product space (any dimension), beyond the gallery's planar complex-number proof and Mathlib's cospherical equality case",
+      "The inversion-distance identity ‖u‖·‖w‖·‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖ in any real inner product space, the dimension-free engine of the proof",
+      "Transport of the inequality to an arbitrary NormedAddTorsor and a concrete EuclideanSpace ℝ (Fin 3) instantiation demonstrating a case the two-dimensional complex proof cannot reach"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "ptolemys-theorem-oq-01",
+      "relationship": "generalizes",
+      "description": "OQ-01 (built on PtolemysComplexProof.lean) proves Ptolemy's inequality for four points of the plane ℂ via the complex algebraic identity, a proof intrinsically two-dimensional. This entry proves the same inequality for arbitrary points of any real inner product space (any dimension) by inversion."
+    },
+    {
+      "targetId": "ptolemys-theorem",
+      "relationship": "answers-open-question",
+      "description": "Answers the parent open question 'Can Ptolemy's inequality (AC·BD ≤ AB·CD + AD·BC for arbitrary four points) be formalized?' in full dimension-free generality, not just in the plane."
+    }
+  ],
+  "references": [
+    {
+      "author": "Claudius Ptolemy",
+      "title": "Almagest (Ptolemy's theorem and the table of chords)",
+      "year": 150,
+      "note": "Classical source; the equality case for cyclic quadrilaterals underlies the chord table."
+    },
+    {
+      "author": "H. S. M. Coxeter and S. L. Greitzer",
+      "title": "Geometry Revisited",
+      "year": 1967,
+      "note": "Inversion proof of Ptolemy's inequality (Chapter 5)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Ptolemy's inequality is fundamentally a metric statement: for four arbitrary points of any real inner product space, dist(a,c)·dist(b,d) ≤ dist(a,b)·dist(c,d) + dist(b,c)·dist(a,d). The inversion-distance identity provides a dimension-free engine, replacing the gallery's two-dimensional complex-number proof.",
+    "implications": "Establishing Ptolemy's inequality by inversion shows that the result lives at the level of inner product spaces rather than the Euclidean plane, and isolates the reusable inversion-distance identity ‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖/(‖u‖‖w‖) as the geometric content. The same machinery underlies the proof that an inversion is a conformal map and the construction of Ptolemy/Cayley–Menger style metric inequalities.",
+    "openQuestions": [
+      "Can the equality case be characterized in this generality — that equality holds iff the four points are concyclic (or collinear) in cyclic order — recovering the cospherical equality of Mathlib as the boundary case?",
+      "Does the inversion-distance identity extend to a formalized proof that inversion is conformal (angle-preserving) in any real inner product space?"
+    ]
+  }
+}

--- a/src/data/research/problems/ptolemys-theorem-oq-05.json
+++ b/src/data/research/problems/ptolemys-theorem-oq-05.json
@@ -1,0 +1,144 @@
+{
+  "slug": "ptolemys-theorem-oq-05",
+  "title": "Ptolemy Inequality for Four Arbitrary Points via the Complex Identity",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: For any four points z1,z2,z3,z4 in C, |z1-z3|*|z2-z4| <= |z1-z2|*|z3-z4| + |z1-z4|*|z2-z3|.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-24T12:11:09.563Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Ptolemy inequality formalized for arbitrary real inner product spaces (any dimension) via inversion; verified, 0-axiom, 3 theorems.",
+    "builtItems": [
+      "inversion_dist (PtolemyInequalityInnerProduct.lean:57): ‖u‖‖w‖‖(‖u‖²)⁻¹•u−(‖w‖²)⁻¹•w‖=‖u−w‖ in any real inner product space",
+      "ptolemy_origin (PtolemyInequalityInnerProduct.lean:93): ‖x−z‖‖y‖ ≤ ‖x−y‖‖z‖+‖y−z‖‖x‖ for all x y z : V",
+      "ptolemy_dist (PtolemyInequalityInnerProduct.lean:138): dist a c·dist b d ≤ dist a b·dist c d + dist b c·dist a d in any NormedAddTorsor; verified 0-axiom"
+    ],
+    "insights": [
+      "Ptolemy is fundamentally a metric statement: it holds for four arbitrary points of ANY real inner product space, not just the plane. The gallery complex-number proof is intrinsically 2D (relies on a commutative-ring algebraic identity).",
+      "The dimension-free engine is the inversion-distance identity: inversion x ↦ (‖x‖²)⁻¹•x scales the distance between u,w by 1/(‖u‖‖w‖), turning the triangle inequality among inverted points into Ptolemy after clearing denominators.",
+      "Placing the 4th vertex at the origin reduces the 4-point inequality to a 3-vector inequality ‖x−z‖‖y‖ ≤ ‖x−y‖‖z‖ + ‖y−z‖‖x‖; every configuration translates to this, so no loss of generality."
+    ],
+    "mathlibGaps": [
+      "Mathlib has only the cospherical EQUALITY case (Geometry.Euclidean.Sphere.Ptolemy: mul_dist_add_mul_dist_eq_mul_dist_of_cospherical); no general Ptolemy INEQUALITY for arbitrary points exists in Mathlib."
+    ],
+    "nextSteps": [
+      "Characterize the equality case in this generality (concyclic/collinear in cyclic order), recovering Mathlib cospherical equality as the boundary.",
+      "Formalize that inversion is conformal in any real inner product space using the same inversion-distance machinery."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "geometry",
+    "complex-numbers",
+    "inequality"
+  ],
+  "relatedProofs": [
+    "ptolemys-theorem",
+    "ptolemys-theorem-oq-01",
+    "ptolemys-theorem-oq-01-incomplete-01",
+    "ptolemys-theorem-oq-01-oq-01",
+    "ptolemys-theorem-oq-01-oq-02",
+    "ptolemys-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T12:11:09.563Z",
+  "lastUpdate": "2026-06-24T12:11:09.563Z",
+  "significance": 6,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/PtolemysTheorem.lean",
+      "filename": "PtolemysTheorem.lean",
+      "lineCount": 241,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheorem.lean"
+    },
+    {
+      "path": "Proofs/PtolemysTheoremOQ01.lean",
+      "filename": "PtolemysTheoremOQ01.lean",
+      "lineCount": 471,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/PtolemysTheoremOQ01Incomplete01.lean",
+      "filename": "PtolemysTheoremOQ01Incomplete01.lean",
+      "lineCount": 490,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheoremOQ01Incomplete01.lean"
+    },
+    {
+      "path": "Proofs/PtolemysTheoremOQ01OQ01.lean",
+      "filename": "PtolemysTheoremOQ01OQ01.lean",
+      "lineCount": 289,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/PtolemysTheoremOQ01OQ02.lean",
+      "filename": "PtolemysTheoremOQ01OQ02.lean",
+      "lineCount": 271,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/PtolemysTheoremOQ04.lean",
+      "filename": "PtolemysTheoremOQ04.lean",
+      "lineCount": 166,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysTheoremOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **ptolemys-theorem** parent open question — *"Can Ptolemy's inequality (AC·BD ≤ AB·CD + AD·BC for arbitrary four points) be formalized?"* — in full **dimension-free generality**, beyond the gallery's existing planar proof.

**The gap.** The gallery's `PtolemysComplexProof.lean` (and OQ-01) proves Ptolemy's inequality only in the **plane ℂ**, via the algebraic identity `(z₁−z₃)(z₂−z₄) = (z₁−z₂)(z₃−z₄) + (z₁−z₄)(z₂−z₃)` — a proof intrinsically two-dimensional (it lives in a commutative ring of "points"). Mathlib (`Geometry.Euclidean.Sphere.Ptolemy`) proves only the **equality** case for *cospherical* points. Neither covers the inequality for arbitrary points in arbitrary dimension.

**This entry** proves, for four arbitrary points `a b c d` of **any** real inner-product affine space (a `NormedAddTorsor` over a real inner product space, any dimension):

```
dist a c · dist b d ≤ dist a b · dist c d + dist b c · dist a d
```

## Proof (classical inversion argument, dimension-free)

| Theorem | Statement |
|---------|-----------|
| `inversion_dist` | `‖u‖·‖w‖·‖(‖u‖²)⁻¹•u − (‖w‖²)⁻¹•w‖ = ‖u−w‖` — inversion `x ↦ (‖x‖²)⁻¹•x` scales distance by `1/(‖u‖‖w‖)` |
| `ptolemy_origin` | `‖x−z‖·‖y‖ ≤ ‖x−y‖·‖z‖ + ‖y−z‖·‖x‖` for all `x y z : V` (4th vertex at origin) |
| `ptolemy_dist` | the four-point form in any `NormedAddTorsor` |

The inversion-distance identity (proved by the real polarization identity + a squared-norm computation closed by `field_simp; ring`, then a square root) turns the ordinary **triangle inequality** among the three inverted points into Ptolemy after clearing denominators. Degenerate cases (a vertex at the origin) are handled directly. A concrete `EuclideanSpace ℝ (Fin 3)` instantiation exhibits a 3-dimensional case the complex proof cannot reach.

## Verification

- **3 theorems, 0 sorries, 0 axioms** (`#print axioms` → only `propext`/`Classical.choice`/`Quot.sound`)
- Builds against Mathlib v4.26.0
- Gallery entry: `src/data/proofs/ptolemys-theorem-oq-05/` (meta + annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)