### PR TITLE
research(repunit-oq-02-oq-01): gcd of b^n+1 governed by 2-adic valuations [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/RepunitDivisibilityOQ02OQ01.lean
+++ b/proofs/Proofs/RepunitDivisibilityOQ02OQ01.lean
@@ -1,0 +1,204 @@
+/-
+# Strong divisibility for the sequence `bⁿ + 1`
+
+The classical strong-divisibility law for repunits / Mersenne-type sequences states
+`gcd(bᵐ − 1, bⁿ − 1) = b^{gcd(m,n)} − 1` (`gcd_pow_sub_one` in the parent entry).
+The companion sequence `bⁿ + 1` is **not** a strong divisibility sequence: its gcd
+structure is governed by the **2-adic valuations** of the exponents.
+
+Write `d = gcd(m, n)` and let `a = m/d`, `c = n/d` (so `gcd(a, c) = 1`).
+
+* **Both cofactors odd** (equivalently `v₂(m) = v₂(n)`): `bᵈ + 1` is a greatest common
+  divisor of `bᵐ + 1` and `bⁿ + 1` — it divides both, and every common divisor divides
+  it (`isGCD_pow_add_one`). Over `ℤ`, `gcd(bᵐ + 1, bⁿ + 1) = b^{gcd(m,n)} + 1`
+  (`int_gcd_pow_add_one`).
+* **Some cofactor even**: every common divisor divides `2`
+  (`dvd_two_of_even_quotient`), so the gcd is `1` or `2`.
+
+The development lives over `ℤ`, where the alternating cofactor of `xᵏ + 1` for odd `k`
+is handled cleanly by the sign identity `(-1)ᵏ = -1`.
+
+## Engine
+
+The reverse ("every common divisor divides `bᵈ + 1`") direction rests on three facts:
+1. `bᵐ + 1 ∣ b^{2m} − 1`, so any common divisor `e` divides `b^{2m} − 1` and `b^{2n} − 1`;
+2. the universal divisor property of the `bⁿ − 1` sequence forces `e ∣ b^{2d} − 1`
+   (`dvd_pow_gcd_sub_one`, an Euclidean descent);
+3. since `m/d` is odd, `b^{2d} − 1 ∣ bᵐ − bᵈ`, so the linear combination
+   `(bᵐ + 1) − (bᵐ − bᵈ) = bᵈ + 1` is divisible by `e`.
+-/
+import Mathlib
+
+namespace RepunitPlusOne
+
+variable {b : ℤ}
+
+/-- For odd `k`, `x + 1` divides `xᵏ + 1`. This is the sign form of
+`(x − y) ∣ xᵏ − yᵏ` with `y = -1`. -/
+theorem add_one_dvd_pow_add_one (x : ℤ) {k : ℕ} (hk : Odd k) :
+    (x + 1) ∣ (x ^ k + 1) := by
+  have h := sub_dvd_pow_sub_pow x (-1) k
+  rw [hk.neg_one_pow] at h
+  simpa [sub_neg_eq_add] using h
+
+/-- If `j ∣ k` then `bʲ − 1 ∣ bᵏ − 1`. -/
+theorem pow_sub_one_dvd_pow_sub_one {j k : ℕ} (h : j ∣ k) :
+    (b ^ j - 1) ∣ (b ^ k - 1) := by
+  obtain ⟨t, rfl⟩ := h
+  rw [pow_mul]
+  simpa using sub_dvd_pow_sub_pow (b ^ j) 1 t
+
+/-- **Universal divisor property of the `bⁿ − 1` sequence.**
+Any common divisor of `bᵃ − 1` and `bᶜ − 1` divides `b^{gcd a c} − 1`.
+Proved by Euclidean descent on `(a, c)`. -/
+theorem dvd_pow_gcd_sub_one {e : ℤ} :
+    ∀ a c : ℕ, e ∣ b ^ a - 1 → e ∣ b ^ c - 1 → e ∣ b ^ Nat.gcd a c - 1 := by
+  intro a c
+  induction a, c using Nat.gcd.induction with
+  | H0 c => intro _ hc; simpa using hc
+  | H1 a c ha ih =>
+    intro ha1 hc1
+    rw [Nat.gcd_rec]
+    apply ih
+    · -- `e ∣ b ^ (c % a) - 1`
+      have hd1 : (b ^ a - 1) ∣ ((b ^ a) ^ (c / a) - 1) := by
+        simpa using sub_dvd_pow_sub_pow (b ^ a) 1 (c / a)
+      have he2 : e ∣ ((b ^ a) ^ (c / a) - 1) := ha1.trans hd1
+      have hkey : b ^ c - b ^ (c % a) = b ^ (c % a) * ((b ^ a) ^ (c / a) - 1) := by
+        rw [mul_sub, mul_one, ← pow_mul, ← pow_add, Nat.mod_add_div]
+      have hdiff : e ∣ b ^ c - b ^ (c % a) := by
+        rw [hkey]; exact he2.mul_left _
+      have hsub : e ∣ (b ^ c - 1) - (b ^ c - b ^ (c % a)) := dvd_sub hc1 hdiff
+      have heq : (b ^ c - 1) - (b ^ c - b ^ (c % a)) = b ^ (c % a) - 1 := by ring
+      rwa [heq] at hsub
+    · exact ha1
+
+/-- `bᵈ + 1` divides `bᵐ + 1` whenever `0 < d`, `d ∣ m`, and the cofactor `m / d`
+is odd. -/
+theorem pow_add_one_dvd_of_odd_quotient {d m : ℕ} (hd : 0 < d) (hdm : d ∣ m)
+    (hodd : Odd (m / d)) : (b ^ d + 1) ∣ (b ^ m + 1) := by
+  obtain ⟨q, rfl⟩ := hdm
+  have hq : Odd q := by rwa [Nat.mul_div_cancel_left q hd] at hodd
+  rw [pow_mul]
+  exact add_one_dvd_pow_add_one (b ^ d) hq
+
+/-- **Both cofactors odd.** When `m/d` and `n/d` are both odd (`d = gcd m n`),
+`bᵈ + 1` is a greatest common divisor of `bᵐ + 1` and `bⁿ + 1`: it divides both,
+and every common divisor divides it. -/
+theorem isGCD_pow_add_one {m n : ℕ} (hm : 0 < m) (_hn : 0 < n)
+    (hmo : Odd (m / Nat.gcd m n)) (hno : Odd (n / Nat.gcd m n)) :
+    (b ^ Nat.gcd m n + 1) ∣ (b ^ m + 1) ∧
+      (b ^ Nat.gcd m n + 1) ∣ (b ^ n + 1) ∧
+      (∀ e : ℤ, e ∣ (b ^ m + 1) → e ∣ (b ^ n + 1) → e ∣ (b ^ Nat.gcd m n + 1)) := by
+  set d := Nat.gcd m n with hd
+  have hdpos : 0 < d := Nat.gcd_pos_iff.mpr (Or.inl hm)
+  have hdm_le : d ≤ m := Nat.le_of_dvd hm (hd ▸ Nat.gcd_dvd_left m n)
+  refine ⟨pow_add_one_dvd_of_odd_quotient hdpos (hd ▸ Nat.gcd_dvd_left m n) hmo,
+    pow_add_one_dvd_of_odd_quotient hdpos (hd ▸ Nat.gcd_dvd_right m n) hno, ?_⟩
+  intro e he_m he_n
+  -- Step 1: `e` divides `b^{2m} - 1` and `b^{2n} - 1`.
+  have hm2 : e ∣ b ^ (2 * m) - 1 := he_m.trans (by
+    have hfac : b ^ (2 * m) - 1 = (b ^ m + 1) * (b ^ m - 1) := by
+      rw [two_mul, pow_add]; ring
+    rw [hfac]; exact dvd_mul_right _ _)
+  have hn2 : e ∣ b ^ (2 * n) - 1 := he_n.trans (by
+    have hfac : b ^ (2 * n) - 1 = (b ^ n + 1) * (b ^ n - 1) := by
+      rw [two_mul, pow_add]; ring
+    rw [hfac]; exact dvd_mul_right _ _)
+  -- Step 2: hence `e ∣ b^{2d} - 1`.
+  have hgcd2 : Nat.gcd (2 * m) (2 * n) = 2 * d := by rw [Nat.gcd_mul_left, ← hd]
+  have h2d : e ∣ b ^ (2 * d) - 1 := by
+    have := dvd_pow_gcd_sub_one (b := b) (2 * m) (2 * n) hm2 hn2
+    rwa [hgcd2] at this
+  -- Step 3: `2d ∣ m - d` because `m/d` is odd.
+  obtain ⟨a, hma⟩ : d ∣ m := hd ▸ Nat.gcd_dvd_left m n
+  have ha : a = m / d := by rw [hma, Nat.mul_div_cancel_left a hdpos]
+  have haodd : Odd a := ha ▸ hmo
+  have h2ddvd : (2 * d) ∣ (m - d) := by
+    obtain ⟨s, hs⟩ := haodd
+    refine ⟨s, ?_⟩
+    rw [hma, hs, show d * (2 * s + 1) = 2 * d * s + d from by ring, Nat.add_sub_cancel]
+  -- Step 4: `b^{2d} - 1 ∣ bᵐ - bᵈ`, so `e ∣ bᵐ - bᵈ`.
+  have hbd : (b ^ (2 * d) - 1) ∣ (b ^ m - b ^ d) := by
+    have h2 : b ^ m - b ^ d = b ^ d * (b ^ (m - d) - 1) := by
+      have hsum : d + (m - d) = m := by omega
+      rw [mul_sub, mul_one, ← pow_add, hsum]
+    rw [h2]
+    exact (pow_sub_one_dvd_pow_sub_one h2ddvd).mul_left _
+  -- Step 5: `e ∣ (bᵐ + 1) - (bᵐ - bᵈ) = bᵈ + 1`.
+  have hdiff : e ∣ b ^ m - b ^ d := h2d.trans hbd
+  have hsub : e ∣ (b ^ m + 1) - (b ^ m - b ^ d) := dvd_sub he_m hdiff
+  have heq : (b ^ m + 1) - (b ^ m - b ^ d) = b ^ d + 1 := by ring
+  rwa [heq] at hsub
+
+/-- **Some cofactor even.** If `m/d` is even (`d = gcd m n`), every common divisor
+of `bᵐ + 1` and `bⁿ + 1` divides `2` — so their gcd is `1` or `2`. -/
+theorem dvd_two_of_even_quotient {m n : ℕ} (hm : 0 < m)
+    (hmev : Even (m / Nat.gcd m n)) :
+    ∀ e : ℤ, e ∣ (b ^ m + 1) → e ∣ (b ^ n + 1) → e ∣ (2 : ℤ) := by
+  intro e he_m he_n
+  set d := Nat.gcd m n with hd
+  have hdpos : 0 < d := Nat.gcd_pos_iff.mpr (Or.inl hm)
+  -- `2d ∣ m` since `m/d` is even.
+  have h2dm : (2 * d) ∣ m := by
+    obtain ⟨a, hma⟩ : d ∣ m := hd ▸ Nat.gcd_dvd_left m n
+    have ha : a = m / d := by rw [hma, Nat.mul_div_cancel_left a hdpos]
+    obtain ⟨t, ht⟩ : Even a := ha ▸ hmev
+    exact ⟨t, by rw [hma, ht]; ring⟩
+  -- `e ∣ b^{2d} - 1` (same engine as the odd case).
+  have hm2 : e ∣ b ^ (2 * m) - 1 := he_m.trans (by
+    have hfac : b ^ (2 * m) - 1 = (b ^ m + 1) * (b ^ m - 1) := by
+      rw [two_mul, pow_add]; ring
+    rw [hfac]; exact dvd_mul_right _ _)
+  have hn2 : e ∣ b ^ (2 * n) - 1 := he_n.trans (by
+    have hfac : b ^ (2 * n) - 1 = (b ^ n + 1) * (b ^ n - 1) := by
+      rw [two_mul, pow_add]; ring
+    rw [hfac]; exact dvd_mul_right _ _)
+  have hgcd2 : Nat.gcd (2 * m) (2 * n) = 2 * d := by rw [Nat.gcd_mul_left, ← hd]
+  have h2d : e ∣ b ^ (2 * d) - 1 := by
+    have := dvd_pow_gcd_sub_one (b := b) (2 * m) (2 * n) hm2 hn2
+    rwa [hgcd2] at this
+  -- `b^{2d} - 1 ∣ bᵐ - 1`, so `e ∣ bᵐ - 1`, and `(bᵐ + 1) - (bᵐ - 1) = 2`.
+  have hbm : e ∣ b ^ m - 1 := h2d.trans (pow_sub_one_dvd_pow_sub_one h2dm)
+  have hsub : e ∣ (b ^ m + 1) - (b ^ m - 1) := dvd_sub he_m hbm
+  have heq : (b ^ m + 1) - (b ^ m - 1) = (2 : ℤ) := by ring
+  rwa [heq] at hsub
+
+/-- **Closed form for the gcd (both cofactors odd).** For `b ≥ 2`,
+`gcd(bᵐ + 1, bⁿ + 1) = b^{gcd(m,n)} + 1` when `m/gcd(m,n)` and `n/gcd(m,n)`
+are both odd. -/
+theorem int_gcd_pow_add_one {m n : ℕ} (hb : 2 ≤ b) (hm : 0 < m) (hn : 0 < n)
+    (hmo : Odd (m / Nat.gcd m n)) (hno : Odd (n / Nat.gcd m n)) :
+    (Int.gcd (b ^ m + 1) (b ^ n + 1) : ℤ) = b ^ Nat.gcd m n + 1 := by
+  obtain ⟨hA, hB, huniv⟩ := isGCD_pow_add_one (b := b) hm hn hmo hno
+  set A := b ^ m + 1 with hAdef
+  set B := b ^ n + 1 with hBdef
+  set g := b ^ Nat.gcd m n + 1 with hg
+  have hb0 : (0 : ℤ) ≤ b := by linarith
+  have hpos : (0 : ℤ) < g := by
+    have := pow_nonneg hb0 (Nat.gcd m n); rw [hg]; linarith
+  have hgcast : (g.toNat : ℤ) = g := Int.toNat_of_nonneg hpos.le
+  -- `↑gcd ∣ g` (every common divisor divides `bᵈ + 1`)
+  have hgcd_dvd : (Int.gcd A B : ℤ) ∣ g :=
+    huniv _ (Int.gcd_dvd_left _ _) (Int.gcd_dvd_right _ _)
+  -- `g ∣ ↑gcd` (`g` is a common divisor of `A` and `B`)
+  have hgdvd : g.toNat ∣ Int.gcd A B := by
+    apply Int.dvd_gcd
+    · rw [hgcast]; exact hA
+    · rw [hgcast]; exact hB
+  have hdvd : g ∣ (Int.gcd A B : ℤ) := by
+    have := Int.natCast_dvd_natCast.mpr hgdvd
+    rwa [hgcast] at this
+  have hgnn : (0 : ℤ) ≤ (Int.gcd A B : ℤ) := Int.natCast_nonneg _
+  exact Int.dvd_antisymm hgnn hpos.le hgcd_dvd hdvd
+
+/-- **The gcd is `1` or `2` (some cofactor even).** For `b ≥ 2`, if `m/gcd(m,n)`
+is even then `gcd(bᵐ + 1, bⁿ + 1) ∣ 2`. -/
+theorem int_gcd_pow_add_one_dvd_two {m n : ℕ} (hm : 0 < m)
+    (hmev : Even (m / Nat.gcd m n)) :
+    Int.gcd (b ^ m + 1) (b ^ n + 1) ∣ 2 := by
+  have h : (Int.gcd (b ^ m + 1) (b ^ n + 1) : ℤ) ∣ (2 : ℤ) :=
+    dvd_two_of_even_quotient (b := b) hm hmev _ (Int.gcd_dvd_left _ _) (Int.gcd_dvd_right _ _)
+  exact_mod_cast h
+
+end RepunitPlusOne

--- a/src/data/proofs/repunit-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/repunit-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Goal: the gcd of b^n + 1 is decided by 2-adic valuations",
+    "content": "The sibling entry repunit-oq-02 proves that b^n − 1 is a strong divisibility sequence: gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1. The companion sequence b^n + 1 is NOT a strong divisibility sequence — and this file pins down exactly how it fails. With d = gcd(m,n), the gcd of b^m + 1 and b^n + 1 is b^d + 1 when the cofactors m/d and n/d are both odd (equivalently v₂(m) = v₂(n)), and divides 2 otherwise. This answers the first open question of repunit-oq-02.",
+    "mathContext": "$\\gcd(b^m+1,b^n+1) = b^{\\gcd(m,n)}+1$ iff $v_2(m)=v_2(n)$; else it divides $2$.",
+    "significance": "key",
+    "relatedConcepts": ["2-adic valuation", "strong divisibility sequence", "cyclotomic factorization", "gcd"],
+    "prerequisites": ["divisibility over ℤ", "gcd", "the b^n − 1 strong-divisibility law"]
+  },
+  {
+    "id": "ann-sign-identity",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 38, "endLine": 43 },
+    "type": "technique",
+    "title": "Odd exponents: (x + 1) ∣ (x^k + 1)",
+    "content": "Working over ℤ lets the sign do the work: from the universal factorization (x − y) ∣ x^k − y^k, set y = −1. For odd k, (−1)^k = −1 (Odd.neg_one_pow), so x − (−1) = x + 1 divides x^k − (−1)^k = x^k + 1. This single lemma is the reason b^d + 1 divides b^m + 1 when the cofactor is odd, and it is precisely what would fail over ℕ where the alternating cofactor has no sign.",
+    "mathContext": "$x+1 = x-(-1) \\mid x^k-(-1)^k = x^k+1$ for odd $k$.",
+    "significance": "important",
+    "relatedConcepts": ["sign identity", "geometric factorization"],
+    "prerequisites": ["(x − y) ∣ x^k − y^k", "(−1)^k = −1 for odd k"]
+  },
+  {
+    "id": "ann-universal-divisor",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 76 },
+    "type": "technique",
+    "title": "Divisor-form of the b^n − 1 law by Euclidean descent",
+    "content": "dvd_pow_gcd_sub_one is the engine for the reverse direction: ANY common divisor e of b^a − 1 and b^c − 1 divides b^{gcd(a,c)} − 1. The proof is Nat.gcd.induction. In the H1 step, write c = a·(c/a) + c%a and factor b^c − b^{c%a} = b^{c%a}·((b^a)^{c/a} − 1); since e ∣ b^a − 1 ∣ (b^a)^{c/a} − 1, e divides b^c − b^{c%a}, hence e ∣ (b^c − 1) − (b^c − b^{c%a}) = b^{c%a} − 1. This reduces (a, c) to (c%a, a), matching Nat.gcd_rec exactly.",
+    "mathContext": "$e \\mid b^a-1,\\ b^c-1 \\Rightarrow e \\mid b^{\\gcd(a,c)}-1$ via $\\gcd(a,c)=\\gcd(c\\bmod a,a)$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean algorithm", "Nat.gcd.induction", "strong divisibility sequence"],
+    "prerequisites": ["gcd recursion", "geometric factorization", "divisor arithmetic"]
+  },
+  {
+    "id": "ann-odd-divisibility",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 78, "endLine": 86 },
+    "type": "lemma",
+    "title": "b^d + 1 ∣ b^m + 1 when m/d is odd",
+    "content": "pow_add_one_dvd_of_odd_quotient packages the forward direction: if d ∣ m and the cofactor m/d is odd, then b^d + 1 ∣ b^m + 1. Write m = d·q with q = m/d odd; then b^m + 1 = (b^d)^q + 1 and the sign lemma add_one_dvd_pow_add_one applies with x = b^d. This is the statement 'b^n + 1 divides b^{kn} + 1 exactly when k is odd', the elementary obstruction to strong divisibility.",
+    "mathContext": "$d \\mid m,\\ m/d$ odd $\\Rightarrow b^d+1 \\mid b^m+1$.",
+    "significance": "important",
+    "relatedConcepts": ["divisibility sequence", "odd exponents"],
+    "prerequisites": ["(x + 1) ∣ (x^k + 1) for odd k", "pow_mul"]
+  },
+  {
+    "id": "ann-both-odd",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 135 },
+    "type": "theorem",
+    "title": "Both cofactors odd: b^d + 1 is a greatest common divisor",
+    "content": "isGCD_pow_add_one is the heart, stated hypothesis-free over ℤ. Forward: b^d + 1 divides both b^m + 1 and b^n + 1 (odd cofactors). Reverse: for any common divisor e, b^m + 1 ∣ b^{2m} − 1 and b^n + 1 ∣ b^{2n} − 1, so the universal-divisor engine forces e ∣ b^{2d} − 1 (using gcd(2m,2n) = 2d). Since m/d is odd, m − d = d(m/d − 1) is a multiple of 2d, so b^{2d} − 1 ∣ b^m − b^d; then e ∣ (b^m + 1) − (b^m − b^d) = b^d + 1. Dividing both and being divisible by every common divisor makes b^d + 1 a gcd in the divisibility lattice.",
+    "mathContext": "$b^d+1 \\mid b^m+1,\\,b^n+1$ and $\\forall e,\\ e\\mid b^m+1 \\wedge e\\mid b^n+1 \\Rightarrow e\\mid b^d+1$.",
+    "significance": "key",
+    "relatedConcepts": ["greatest common divisor", "2-adic valuation", "b^{2k} − 1 = (b^k+1)(b^k−1)"],
+    "prerequisites": ["universal-divisor engine", "gcd(2m,2n) = 2·gcd(m,n)", "linear combinations of divisors"]
+  },
+  {
+    "id": "ann-even-case",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 136, "endLine": 168 },
+    "type": "theorem",
+    "title": "Some cofactor even: every common divisor divides 2",
+    "content": "dvd_two_of_even_quotient handles the failure regime. If m/d is even then 2d ∣ m, so b^{2d} − 1 ∣ b^m − 1. Any common divisor e of b^m + 1 and b^n + 1 still satisfies e ∣ b^{2d} − 1 (same engine), hence e ∣ b^m − 1; combined with e ∣ b^m + 1, e divides (b^m + 1) − (b^m − 1) = 2. So when the 2-adic valuations differ, the gcd cannot exceed 2.",
+    "mathContext": "$m/d$ even $\\Rightarrow 2d \\mid m \\Rightarrow e \\mid (b^m+1)-(b^m-1)=2$.",
+    "significance": "important",
+    "relatedConcepts": ["failure of strong divisibility", "2-adic valuation"],
+    "prerequisites": ["b^j − 1 ∣ b^k − 1 for j ∣ k", "universal-divisor engine"]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "repunit-oq-02-oq-01",
+    "range": { "startLine": 170, "endLine": 204 },
+    "type": "theorem",
+    "title": "Closed-form gcd over ℤ",
+    "content": "int_gcd_pow_add_one turns the 'is a gcd' statement into the named identity Int.gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1 for b ≥ 2: b^d + 1 is positive, the canonical Int.gcd is nonnegative, and the two divisibilities give equality by Int.dvd_antisymm. int_gcd_pow_add_one_dvd_two records the complementary Int.gcd ∣ 2 in the even case, so the gcd is exactly 1 or 2.",
+    "mathContext": "$\\gcd(b^m+1,b^n+1) = b^{\\gcd(m,n)}+1$ (both odd, $b\\ge2$); $\\gcd \\mid 2$ (some even).",
+    "significance": "key",
+    "relatedConcepts": ["Int.gcd", "antisymmetry of divisibility", "closed form"],
+    "prerequisites": ["Int.dvd_antisymm", "Int.dvd_gcd", "nonnegativity of Int.gcd"]
+  }
+]

--- a/src/data/proofs/repunit-oq-02-oq-01/index.ts
+++ b/src/data/proofs/repunit-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/RepunitDivisibilityOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const repunitOq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const repunitOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const repunitOq02Oq01Data: ProofData = {
+  proof: repunitOq02Oq01Proof,
+  annotations: repunitOq02Oq01Annotations,
+}

--- a/src/data/proofs/repunit-oq-02-oq-01/meta.json
+++ b/src/data/proofs/repunit-oq-02-oq-01/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "repunit-oq-02-oq-01",
+  "slug": "repunit-oq-02-oq-01",
+  "title": "The b^n + 1 Sequence: gcd Governed by 2-adic Valuations of the Exponents",
+  "description": "The repunit / Mersenne sequence b^n − 1 is a strong divisibility sequence: gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1 (entry repunit-oq-02). Its companion b^n + 1 is NOT — and this entry pins down exactly why, fully machine-checked with 0 sorries and 0 axioms over ℤ. Writing d = gcd(m,n), the gcd of b^m + 1 and b^n + 1 is decided by the parity of the cofactors m/d and n/d (equivalently, by whether v₂(m) = v₂(n)): if both cofactors are odd then b^d + 1 is a greatest common divisor of b^m + 1 and b^n + 1, so over ℤ gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1; if some cofactor is even then every common divisor divides 2, so the gcd is 1 or 2. This directly answers the open question posed by entry repunit-oq-02. The engine is a universal-divisor form of the b^n − 1 strong-divisibility law (any common divisor of b^{2m} − 1 and b^{2n} − 1 divides b^{2d} − 1, proved by Euclidean descent), combined with the sign identity (−1)^k = −1 for the odd-cofactor divisibility b^d + 1 ∣ b^m + 1.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "RepunitPlusOne",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "substantiveTheoremCount": 6,
+    "trivialSpecializations": 0,
+    "definitionCount": 0,
+    "path": "Proofs/RepunitDivisibilityOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Classical (cyclotomic / 2-adic structure of b^n ± 1; Aurifeuillian and Bang–Zsygmondy circle of ideas)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+    "date": "Classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RepunitDivisibilityOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "gcd",
+      "2-adic-valuation",
+      "euclidean-algorithm",
+      "strong-divisibility-sequence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All results are proved over ℤ from elementary divisibility, the Euclidean recursion (Nat.gcd.induction / Nat.gcd_rec), and the sign identity (−1)^k = −1 for odd k. No axioms, no native_decide, no structure-encoded hypotheses. The closed-form corollaries assume only b ≥ 2 (so that b^d + 1 > 0 pins the nonnegative Int.gcd); the divisibility characterizations hold for every b : ℤ.",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      "sub_dvd_pow_sub_pow",
+      "Odd.neg_one_pow",
+      "Nat.gcd.induction",
+      "Nat.gcd_rec",
+      "Nat.gcd_mul_left",
+      "Nat.mod_add_div",
+      "Int.dvd_gcd",
+      "Int.gcd_dvd_left",
+      "Int.dvd_antisymm"
+    ],
+    "originalContributions": [
+      "Closed form int_gcd_pow_add_one: for b ≥ 2, when m/gcd(m,n) and n/gcd(m,n) are both odd, gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1 over ℤ — the 'b^n + 1' analogue of the strong-divisibility law, but valid only under the 2-adic parity condition",
+      "Greatest-common-divisor characterization isGCD_pow_add_one: under the both-odd condition, b^{gcd(m,n)} + 1 divides both b^m + 1 and b^n + 1 and every common divisor divides it (the 'is a gcd' statement, free of any positivity hypothesis on b)",
+      "Collapse theorem dvd_two_of_even_quotient: if some cofactor m/gcd(m,n) is even then every common divisor of b^m + 1 and b^n + 1 divides 2, so int_gcd_pow_add_one_dvd_two gives gcd ∈ {1, 2}",
+      "Universal-divisor engine dvd_pow_gcd_sub_one: any common divisor of b^a − 1 and b^c − 1 divides b^{gcd(a,c)} − 1, proved by Euclidean descent on (a,c) along Nat.gcd.induction (the divisor-form of the b^n − 1 strong-divisibility law)",
+      "Odd-cofactor divisibility pow_add_one_dvd_of_odd_quotient: b^d + 1 ∣ b^m + 1 whenever d ∣ m and m/d is odd, via the sign identity add_one_dvd_pow_add_one: (x + 1) ∣ (x^k + 1) for odd k"
+    ],
+    "prerequisites": [
+      "The Euclidean algorithm and the gcd recursion gcd m n = gcd (n % m) m",
+      "The strong-divisibility law for b^n − 1 (in divisor form)",
+      "2-adic valuation / parity of integers, and the identity (−1)^k = −1 for odd k",
+      "Elementary divisibility arithmetic over ℤ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 204,
+    "relatedProblems": [
+      "repunit-oq-02",
+      "repunit-oq-01"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A strong divisibility sequence (SDS) satisfies $\\gcd(a_m, a_n) = a_{\\gcd(m,n)}$; the textbook example is $a_n = b^n - 1$, treated in entry repunit-oq-02. Its sign-twin $b^n + 1$ is a divisibility sequence only in a degenerate sense and is famously *not* an SDS: $b^n + 1$ divides $b^{kn} + 1$ exactly when $k$ is odd, so the gcd of $b^m + 1$ and $b^n + 1$ depends not just on $\\gcd(m,n)$ but on the *2-adic valuations* of $m$ and $n$. This parity phenomenon is the elementary shadow of cyclotomic factorization ($b^n + 1 = \\prod_{d \\mid 2n,\\, d \\nmid n} \\Phi_d(b)$) and underlies Aurifeuillian factorizations and tables of $b^n + 1$. Entry repunit-oq-02 proved the $b^n - 1$ SDS law and explicitly asked, as its first open question, whether the same Euclidean-descent template yields the $b^n + 1$ gcd with the dependence on parity made explicit. This entry answers that question.",
+    "problemStatement": "Fix $b \\in \\mathbb{Z}$ and let $d = \\gcd(m, n)$ with $m, n > 0$. Determine $\\gcd(b^m + 1, b^n + 1)$. Specifically: show that when the cofactors $m/d$ and $n/d$ are both odd (equivalently $v_2(m) = v_2(n)$), $b^d + 1$ is a greatest common divisor — so for $b \\ge 2$, $\\gcd(b^m + 1, b^n + 1) = b^{\\gcd(m,n)} + 1$ — and that otherwise every common divisor divides $2$, so the gcd is $1$ or $2$.",
+    "proofStrategy": "Work over $\\mathbb{Z}$, where the alternating cofactor of $x^k + 1$ is handled by $(-1)^k = -1$. Forward (both odd): $x + 1 \\mid x^k + 1$ for odd $k$ (from $(x - y) \\mid x^k - y^k$ with $y = -1$), hence $b^d + 1 \\mid b^m + 1$ and $b^d + 1 \\mid b^n + 1$. Reverse: let $e$ be any common divisor. Since $b^m + 1 \\mid b^{2m} - 1$ and $b^n + 1 \\mid b^{2n} - 1$, the universal-divisor form of the $b^n - 1$ law (Euclidean descent: any common divisor of $b^a - 1$, $b^c - 1$ divides $b^{\\gcd(a,c)} - 1$) forces $e \\mid b^{2d} - 1$ because $\\gcd(2m, 2n) = 2d$. As $m/d$ is odd, $m - d$ is a multiple of $2d$, so $b^{2d} - 1 \\mid b^m - b^d$; then $e \\mid (b^m + 1) - (b^m - b^d) = b^d + 1$. Thus $b^d + 1$ divides both and is divisible by every common divisor — a gcd. For $b \\ge 2$ it is positive, so it equals the canonical nonnegative $\\mathrm{Int.gcd}$ by antisymmetry. Even case: if $m/d$ is even then $2d \\mid m$, so $b^{2d} - 1 \\mid b^m - 1$, giving $e \\mid (b^m + 1) - (b^m - 1) = 2$.",
+    "keyInsights": [
+      "The $b^n + 1$ sequence is not a strong divisibility sequence; the correct invariant is the 2-adic valuation: the gcd collapses to $b^{\\gcd(m,n)} + 1$ exactly when $v_2(m) = v_2(n)$, i.e. when both cofactors $m/d$, $n/d$ are odd.",
+      "Passing to $b^{2k} - 1 = (b^k + 1)(b^k - 1)$ reduces every '+1' question to the already-understood '−1' strong-divisibility law: a common divisor of $b^m + 1$ and $b^n + 1$ is a common divisor of $b^{2m} - 1$ and $b^{2n} - 1$, hence divides $b^{\\gcd(2m,2n)} - 1 = b^{2d} - 1$.",
+      "The divisor-form (universal property) of the $b^n - 1$ law is exactly what the reverse direction needs — 'every common divisor divides $b^{2d} - 1$' — and it is proved by the same single Euclidean reduction as the gcd identity, with no modular arithmetic.",
+      "Odd cofactor is what makes $b^d + 1 \\mid b^m + 1$: $m - d = d(m/d - 1)$ is a multiple of $2d$ precisely because $m/d - 1$ is even, which is also what lets $b^{2d} - 1 \\mid b^m - b^d$ close the reverse direction.",
+      "Stating the result as 'is a gcd' (divides both; divisible by every common divisor) keeps the core hypothesis-free over all of $\\mathbb{Z}$; the named closed form $\\mathrm{Int.gcd} = b^d + 1$ is then a one-step antisymmetry corollary needing only $b \\ge 2$ for positivity."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "int_gcd_pow_add_one",
+      "statement": "2 ≤ b → 0 < m → 0 < n → Odd (m / gcd m n) → Odd (n / gcd m n) → (Int.gcd (b^m + 1) (b^n + 1) : ℤ) = b^{gcd m n} + 1",
+      "description": "Closed form: when both cofactors are odd, the gcd of b^m + 1 and b^n + 1 collapses to b^{gcd(m,n)} + 1, the b^n + 1 analogue of the strong-divisibility law (valid only under the 2-adic parity condition)."
+    },
+    {
+      "name": "isGCD_pow_add_one",
+      "statement": "0 < m → 0 < n → Odd (m / gcd m n) → Odd (n / gcd m n) → (b^{gcd m n} + 1 ∣ b^m + 1) ∧ (b^{gcd m n} + 1 ∣ b^n + 1) ∧ ∀ e, e ∣ b^m + 1 → e ∣ b^n + 1 → e ∣ b^{gcd m n} + 1",
+      "description": "The hypothesis-free heart: b^{gcd(m,n)} + 1 divides both b^m + 1 and b^n + 1 and is divisible by every common divisor — i.e. it is a greatest common divisor in the divisibility lattice of ℤ, for every b."
+    },
+    {
+      "name": "int_gcd_pow_add_one_dvd_two",
+      "statement": "0 < m → Even (m / gcd m n) → Int.gcd (b^m + 1) (b^n + 1) ∣ 2",
+      "description": "Collapse to {1,2}: if some cofactor is even, the gcd of b^m + 1 and b^n + 1 divides 2 — the sharp failure of strong divisibility when the 2-adic valuations differ."
+    },
+    {
+      "name": "dvd_pow_gcd_sub_one",
+      "statement": "∀ a c, e ∣ b^a − 1 → e ∣ b^c − 1 → e ∣ b^{gcd a c} − 1",
+      "description": "Universal-divisor engine: any common divisor of b^a − 1 and b^c − 1 divides b^{gcd(a,c)} − 1, proved by Euclidean descent along Nat.gcd.induction. The divisor-form of the b^n − 1 strong-divisibility law that drives the reverse direction."
+    },
+    {
+      "name": "pow_add_one_dvd_of_odd_quotient",
+      "statement": "0 < d → d ∣ m → Odd (m / d) → (b^d + 1) ∣ (b^m + 1)",
+      "description": "Odd-cofactor divisibility: b^d + 1 divides b^m + 1 exactly when d ∣ m with m/d odd, via the sign identity (x + 1) ∣ (x^k + 1) for odd k."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "import Mathlib and namespace RepunitPlusOne; the docstring contrasts the b^n − 1 strong-divisibility law with the b^n + 1 sequence (governed by 2-adic valuations) and outlines the three-fact engine for the reverse direction.",
+      "mathContext": "$\\gcd(b^m+1,b^n+1) = b^{\\gcd(m,n)}+1$ iff $v_2(m)=v_2(n)$; else $\\gcd \\mid 2$."
+    },
+    {
+      "id": "sign-and-power-helpers",
+      "title": "Sign Identity and Power-Difference Divisibility",
+      "startLine": 38,
+      "endLine": 53,
+      "summary": "add_one_dvd_pow_add_one: (x + 1) ∣ (x^k + 1) for odd k, the sign form of (x − y) ∣ x^k − y^k with y = −1 and (−1)^k = −1; and pow_sub_one_dvd_pow_sub_one: j ∣ k → b^j − 1 ∣ b^k − 1 from sub_dvd_pow_sub_pow.",
+      "mathContext": "$x+1 \\mid x^k+1$ for odd $k$; $b^j-1 \\mid b^k-1$ when $j \\mid k$."
+    },
+    {
+      "id": "universal-divisor",
+      "title": "Universal Divisor Property of b^n − 1",
+      "startLine": 54,
+      "endLine": 77,
+      "summary": "dvd_pow_gcd_sub_one: any common divisor of b^a − 1 and b^c − 1 divides b^{gcd(a,c)} − 1, by Nat.gcd.induction. The H1 step writes c = a·(c/a) + c%a, factors b^c − b^{c%a} = b^{c%a}((b^a)^{c/a} − 1), and reduces e ∣ b^c − 1 to e ∣ b^{c%a} − 1, matching Nat.gcd_rec.",
+      "mathContext": "Divisor-form of the $b^n-1$ SDS law: $e \\mid b^a-1,\\ b^c-1 \\Rightarrow e \\mid b^{\\gcd(a,c)}-1$."
+    },
+    {
+      "id": "odd-divisibility",
+      "title": "Odd-Cofactor Divisibility",
+      "startLine": 78,
+      "endLine": 87,
+      "summary": "pow_add_one_dvd_of_odd_quotient: for 0 < d, d ∣ m, and m/d odd, b^d + 1 ∣ b^m + 1, by writing m = d·q (q = m/d odd) and applying add_one_dvd_pow_add_one with x = b^d.",
+      "mathContext": "$b^d+1 \\mid b^m+1$ when $d \\mid m$ and $m/d$ is odd."
+    },
+    {
+      "id": "both-odd",
+      "title": "Both Cofactors Odd: b^d + 1 Is a gcd",
+      "startLine": 88,
+      "endLine": 135,
+      "summary": "isGCD_pow_add_one: forward via pow_add_one_dvd_of_odd_quotient; reverse for any common divisor e via e ∣ b^{2m} − 1, b^{2n} − 1 ⇒ e ∣ b^{2d} − 1 (dvd_pow_gcd_sub_one with gcd(2m,2n) = 2d), then 2d ∣ m − d (m/d odd) gives b^{2d} − 1 ∣ b^m − b^d, so e ∣ (b^m + 1) − (b^m − b^d) = b^d + 1.",
+      "mathContext": "$b^d+1 \\mid b^m+1,\\ b^n+1$ and every common divisor divides $b^d+1$."
+    },
+    {
+      "id": "even-case",
+      "title": "Some Cofactor Even: gcd Divides 2",
+      "startLine": 136,
+      "endLine": 169,
+      "summary": "dvd_two_of_even_quotient: if m/d is even then 2d ∣ m, so b^{2d} − 1 ∣ b^m − 1; combined with e ∣ b^{2d} − 1 (same engine), e ∣ (b^m + 1) − (b^m − 1) = 2.",
+      "mathContext": "$m/d$ even $\\Rightarrow$ every common divisor divides $2$."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Closed-Form gcd Corollaries over ℤ",
+      "startLine": 170,
+      "endLine": 204,
+      "summary": "int_gcd_pow_add_one: for b ≥ 2 the both-odd case gives Int.gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1 by Int.dvd_antisymm of the two nonnegative divisibilities; int_gcd_pow_add_one_dvd_two: the even case gives Int.gcd ∣ 2.",
+      "mathContext": "$\\gcd(b^m+1,b^n+1) = b^{\\gcd(m,n)}+1$ (both odd, $b\\ge2$); $\\mid 2$ (some even)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Cyclotomic polynomial",
+      "url": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial"
+    },
+    {
+      "title": "Aurifeuillian factorization",
+      "url": "https://en.wikipedia.org/wiki/Aurifeuillean_factorization"
+    },
+    {
+      "title": "Divisibility sequence",
+      "url": "https://en.wikipedia.org/wiki/Divisibility_sequence"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "repunit-oq-02",
+      "relationship": "Answers the parent's first open question",
+      "description": "repunit-oq-02 proves the b^n − 1 strong-divisibility law gcd(b^m − 1, b^n − 1) = b^{gcd(m,n)} − 1 and asks whether the same Euclidean-descent template gives the b^n + 1 gcd with the dependence on 2-adic valuations made explicit. This entry supplies that result: the gcd collapses to b^{gcd(m,n)} + 1 exactly when v₂(m) = v₂(n), and divides 2 otherwise, reusing the b^n − 1 law in divisor form as its engine."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over ℤ, the gcd of b^m + 1 and b^n + 1 is governed by the 2-adic valuations of the exponents, fully machine-checked with zero sorries and zero axioms: with d = gcd(m,n), if the cofactors m/d and n/d are both odd then b^d + 1 is a greatest common divisor (so gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1 for b ≥ 2), and if some cofactor is even then every common divisor divides 2.",
+    "implications": "The result makes precise the standard fact that b^n + 1 is not a strong divisibility sequence: strong divisibility holds exactly on the locus v₂(m) = v₂(n). It specializes at b = 2 to the gcd of Fermat-type numbers 2^m + 1 and at general b to the structure behind Aurifeuillian factorizations, and it reuses the b^n − 1 strong-divisibility law (in divisor form) as a black-box engine — illustrating how the '+1' theory reduces to the '−1' theory via b^{2k} − 1 = (b^k + 1)(b^k − 1).",
+    "openQuestions": [
+      "Can the two regimes be unified into a single closed form Int.gcd(b^m + 1, b^n + 1) = (b^{gcd(m,n)} + 1) / gcd(b^{gcd(m,n)} + 1, 2)^{[v₂(m) ≠ v₂(n)]}, i.e. an explicit formula valid for all m, n without case split?",
+      "Does the same b^{2k} − 1 reduction give the mixed gcd gcd(b^m − 1, b^n + 1), completing the 2×2 table of ± strong-divisibility interactions?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question of `repunit-oq-02`** (the `b^n − 1` strong-divisibility law): *"Does the same Euclidean-descent template give gcd identities for `b^n + 1`, where the gcd depends on the 2-adic valuations of `m` and `n`?"*

The companion sequence `b^n + 1` is **not** a strong divisibility sequence. With `d = gcd(m,n)`:
- if `m/d` and `n/d` are **both odd** (equivalently `v₂(m) = v₂(n)`), then `gcd(b^m + 1, b^n + 1) = b^{gcd(m,n)} + 1`;
- if **some cofactor is even**, every common divisor divides `2`, so the gcd is `1` or `2`.

Fully machine-checked over ℤ, **0 sorries, 0 axioms** (`#print axioms` → only `propext`/`Classical.choice`/`Quot.sound`).

## Main results (`proofs/Proofs/RepunitDivisibilityOQ02OQ01.lean`, 8 theorems / 204 lines)

| Theorem | Statement |
|---|---|
| `isGCD_pow_add_one` | both odd ⟹ `b^d+1` divides both and every common divisor divides it (hypothesis-free over ℤ) |
| `int_gcd_pow_add_one` | `b ≥ 2`, both odd ⟹ `Int.gcd (b^m+1) (b^n+1) = b^{gcd m n} + 1` |
| `dvd_two_of_even_quotient` / `int_gcd_pow_add_one_dvd_two` | some cofactor even ⟹ gcd `∣ 2` |
| `dvd_pow_gcd_sub_one` | universal-divisor form of the `b^n−1` law, by Euclidean descent (`Nat.gcd.induction`) |
| `pow_add_one_dvd_of_odd_quotient` | `b^d+1 ∣ b^m+1` when `d ∣ m`, `m/d` odd |

## Engine

The reverse direction reduces every `+1` question to the known `−1` theory via `b^{2k} − 1 = (b^k + 1)(b^k − 1)`: a common divisor of `b^m + 1` and `b^n + 1` divides `b^{2m} − 1` and `b^{2n} − 1`, hence `b^{2d} − 1` (`gcd(2m,2n) = 2d`). Odd cofactor ⟹ `2d ∣ m − d` ⟹ `b^{2d} − 1 ∣ b^m − b^d`, so `(b^m + 1) − (b^m − b^d) = b^d + 1` is divisible by it. The odd-cofactor divisibility uses the sign identity `(−1)^k = −1`.

## Verification

```
LAKE_UNSAFE=1 lake env lean Proofs/RepunitDivisibilityOQ02OQ01.lean   # clean, no warnings
#print axioms int_gcd_pow_add_one  # propext, Classical.choice, Quot.sound
```

Gallery entry added at `src/data/proofs/repunit-oq-02-oq-01/` (meta + annotations + index), cross-referenced to `repunit-oq-02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)