### PR TITLE
Enrich Excentral Triangle Circumradius 2R, Circumcenter 2O−I (feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-excentral-circumcenter-def",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 94
+    },
+    "type": "definition",
+    "title": "The Excentral Circumcenter O' = 2O − I",
+    "content": "The whole proof hinges on a single named point: Triangle.excentralCircumcenter = 2O − I, the reflection of the incenter I in the circumcenter O. Rather than solving for the excentral circumcenter from three perpendicular bisectors, the file guesses this reflection and verifies it is equidistant from all three excenters. The definition is supplied as reusable 0-axiom triangle-center infrastructure (placed in the FeuerbachsTheorem namespace).",
+    "mathContext": "$O' = 2O - I$, the reflection of the incenter in the circumcenter; $O$ is then the midpoint of $I$ and $O'$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflection of a point",
+      "triangle centers",
+      "excentral triangle"
+    ],
+    "prerequisites": [
+      "circumcenter and incenter coordinates"
+    ]
+  },
+  {
+    "id": "ann-equidistance",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 96,
+      "endLine": 149
+    },
+    "type": "technique",
+    "title": "Circumcenter Equidistance from the Vertices",
+    "content": "The circumcenter lies on the perpendicular bisectors of the sides (pb_AB, pb_AC), hence equidist_B and equidist_C give |B−O|² = |C−O|² = |A−O|² = R². These are reproved locally because the parent declares them private. They supply the R² = |X−O|² facts that the weighted-norm master identity consumes, and feed the pairwise dot products ⟨X−O, Y−O⟩ = R² − (opposite side)²/2.",
+    "mathContext": "$|A-O|^2 = |B-O|^2 = |C-O|^2 = R^2$; the circumcenter is on each perpendicular bisector.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "perpendicular bisector",
+      "circumradius",
+      "equidistance"
+    ],
+    "prerequisites": [
+      "circumcenter coordinate formula",
+      "ring"
+    ]
+  },
+  {
+    "id": "ann-triangle-inequalities",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 214,
+      "endLine": 308
+    },
+    "type": "technique",
+    "title": "Strict Triangle Inequalities and Denominator Positivity",
+    "content": "strict_tri_ineq_a/b/c (a < b+c, cyclically) and pa_pos/pb_pos/pc_pos establish that the excenter denominators −a+b+c, a−b+c, a+b−c are positive. Proved via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant (D ≠ 0 ⟹ P < bc ⟹ a < b+c). These guarantee the common factor (pₐp_s)² is nonzero, which is exactly what licenses the final cancellation step.",
+    "mathContext": "$a < b+c$ etc.; $p_a = -a+b+c > 0$, so $(p_a p_s)^2 \\ne 0$ for mul_right_cancel₀.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle inequality",
+      "law of cosines",
+      "excenter denominators"
+    ],
+    "prerequisites": [
+      "Lagrange identity",
+      "nlinarith"
+    ]
+  },
+  {
+    "id": "ann-master-identity",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 309,
+      "endLine": 352
+    },
+    "type": "insight",
+    "title": "The Weighted-Norm Master Identity",
+    "content": "weighted_norm_sq_gen is the reusable engine: |wₐ(A−O)+w_b(B−O)+w_c(C−O)|² = R²(wₐ+w_b+w_c)² − (wₐw_b c²+w_b w_c a²+w_c wₐ b²). Expanding the squared weighted sum and substituting the pairwise dot products ⟨X−O,Y−O⟩ = R² − (opposite side)²/2 (from equidistance and the squared sides) gives this closed form. Choosing the weights selects each excenter's displacement, reducing every squared-distance computation to two ring identities about the weights.",
+    "mathContext": "$\\left|\\sum_X w_X (X-O)\\right|^2 = R^2\\left(\\sum_X w_X\\right)^2 - (w_a w_b c^2 + w_b w_c a^2 + w_c w_a b^2)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weighted barycentric vectors",
+      "inner product expansion",
+      "circumradius identity"
+    ],
+    "prerequisites": [
+      "equidist_B / equidist_C",
+      "side length squares",
+      "ring"
+    ]
+  },
+  {
+    "id": "ann-squared-distance",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 354,
+      "endLine": 474
+    },
+    "type": "insight",
+    "title": "dist²(O', Iₓ) = 4R² and the Two Weight Miracles",
+    "content": "excentral_dist_a_sq/_b_sq/_c_sq prove the squared distance from O' = 2O − I to each excenter is exactly 4R². For excenter a, the displacement Iₐ + I − 2O cleared over (pₐp_s)² equals the weighted vector 2[−a²(A−O) + b(b+c)(B−O) + c(b+c)(C−O)]. Two ring identities make it collapse: the weights (−a², b(b+c), c(b+c)) sum to (−a+b+c)(a+b+c) = pₐp_s (so the O-term cancels), and the master cross-term wₐw_b c²+w_b w_c a²+w_c wₐ b² vanishes identically. Feeding both into the master identity gives R²(pₐp_s)², so dist²·(pₐp_s)² = 4R²(pₐp_s)² and mul_right_cancel₀ yields 4R². The b- and c-excenters are the same after cyclic weight changes.",
+    "mathContext": "Weights $(-a^2, b(b{+}c), c(b{+}c))$: $\\sum w = p_a p_s$ and $w_a w_b c^2 + w_b w_c a^2 + w_c w_a b^2 = 0$, so $|\\mathrm{displacement}|^2 = R^2(p_a p_s)^2 \\Rightarrow \\mathrm{dist}^2(O',I_a) = 4R^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weighted collapse",
+      "vanishing cross-term",
+      "mul_right_cancel₀"
+    ],
+    "prerequisites": [
+      "weighted_norm_sq_gen",
+      "field_simp",
+      "ring",
+      "pa_pos / perimeter_pos"
+    ]
+  },
+  {
+    "id": "ann-circumradius-2R",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 475,
+      "endLine": 553
+    },
+    "type": "insight",
+    "title": "Circumradius 2R, the Nine-Point Center, and the 3-4-5 Example",
+    "content": "Taking square roots turns the 4R² facts into distances: excentral_circumradius_a/b/c and the combined excentral_circumradius_eq_two_R give dist(O', Iₓ) = √(4R²) = 2R (using Real.sqrt_sq and R ≥ 0). So O' is equidistant 2R from all three excenters — the excentral circumcenter — and the excentral circumradius is twice that of ABC. circumcenter_is_excentral_ninePointCenter records O = ½(I + O'), placing O as the nine-point center of the excentral triangle (incenter I being its orthocenter). triangle_345_excentral_circumradius instantiates everything: O' = (2,3) and each squared distance is 25 = 4·(5/2)² = 4R².",
+    "mathContext": "$\\mathrm{dist}(O', I_x) = \\sqrt{4R^2} = 2R$; $O = \\tfrac{1}{2}(I + O')$ is the excentral nine-point center.",
+    "significance": "key",
+    "relatedConcepts": [
+      "nine-point center",
+      "orthocentric system",
+      "Real.sqrt_sq",
+      "Euler line of the tritangent system"
+    ],
+    "prerequisites": [
+      "excentral_dist_a_sq",
+      "Real.sqrt_sq",
+      "circumradius_nonneg"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01`.

**Gap filled:** the entry had no `annotations.json`. Added six annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual declaration line ranges:
1. The excentral circumcenter O' = 2O − I (the reflection mechanism)
2. Circumcenter equidistance from the vertices
3. Strict triangle inequalities and denominator positivity
4. The weighted-norm master identity (reusable engine)
5. dist²(O', Iₓ) = 4R² via the two weight miracles (sum = p·p_s, cross-term = 0)
6. Circumradius 2R, the nine-point center O = ½(I+O'), and the 3-4-5 example

All five cross-references confirmed to point at existing gallery entries. JSON validated. meta.json already complete (mainTheorems, six sections, three open questions, references) so left intact.