### PR TITLE
Enrich Sum of the Squared Medians of a Triangle (law-of-cosines-oq-07-oq-02)

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-coordinate-free-setup",
+    "proofId": "law-of-cosines-oq-07-oq-02",
+    "range": {
+      "startLine": 39,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "Coordinate-Free Setup: an Inner-Product Affine Space",
+    "content": "The vertices a, b, c live in an arbitrary real inner-product affine space — a NormedAddTorsor P over an InnerProductSpace ℝ V — not in coordinatized ℝ². Medians are genuine dist's to honest midpoint ℝ's, and no scalar side-length parameterization is introduced. As a result the identity holds verbatim in every Euclidean affine space of any dimension, inheriting the parent's coordinate-free framing.",
+    "mathContext": "$P$ a NormedAddTorsor over a real inner-product space $V$; $m_a = \\mathrm{dist}(a, \\mathrm{midpoint}_{\\mathbb{R}}(b,c))$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "inner-product affine space",
+      "NormedAddTorsor",
+      "coordinate-free geometry"
+    ],
+    "prerequisites": [
+      "InnerProductSpace",
+      "NormedAddTorsor",
+      "midpoint"
+    ]
+  },
+  {
+    "id": "ann-sum-sq-medians",
+    "proofId": "law-of-cosines-oq-07-oq-02",
+    "range": {
+      "startLine": 46,
+      "endLine": 62
+    },
+    "type": "insight",
+    "title": "Sum of Squared Medians: 4(mₐ²+m_b²+m_c²) = 3(a²+b²+c²)",
+    "content": "The headline result, stated metrically. Summing the parent's single-median Apollonius identity 4mₐ² = 2b²+2c²−a² over the three vertices produces the global relation: the median sum carries the factor 4, while each squared side accumulates the net coefficient 2+2−1 = 3 (twice as an 'adjacent' side, once as the 'opposite' side). This is the classical mₐ²+m_b²+m_c² = ¾(a²+b²+c²) recast as an affine-space identity.",
+    "mathContext": "$4(m_a^2+m_b^2+m_c^2) = 3(a^2+b^2+c^2)$, summing $4m_a^2 = 2b^2+2c^2-a^2$ cyclically; each side-square gets weight $2+2-1=3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Apollonius median theorem",
+      "median length identity",
+      "sum of squares"
+    ],
+    "prerequisites": [
+      "median_length (law-of-cosines-oq-07)"
+    ]
+  },
+  {
+    "id": "ann-distcomm-linearcombination",
+    "proofId": "law-of-cosines-oq-07-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 67
+    },
+    "type": "technique",
+    "title": "Folding dist-Symmetry to Close with linear_combination",
+    "content": "The proof instantiates median_length at the three vertex orderings (a b c), (b a c), (c a b), then normalizes the metric symmetries dist b a = dist a b, dist a c = dist c a, dist c b = dist b c with a single simp only [dist_comm …]. This folding is essential: without it dist a b and dist b a would be distinct ring atoms and the three squared sides would not cancel. Once unified, linear_combination ha + hb + hc closes the goal in one line over the reals — no decision procedure, keeping the proof axiom-clean.",
+    "mathContext": "After $\\mathrm{dist}\\,b\\,a = \\mathrm{dist}\\,a\\,b$ etc., the three Apollonius instances combine linearly: $\\mathrm{linear\\_combination}\\ h_a + h_b + h_c$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dist_comm",
+      "linear_combination tactic",
+      "ring normalization"
+    ],
+    "prerequisites": [
+      "dist_comm",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-three-quarters",
+    "proofId": "law-of-cosines-oq-07-oq-02",
+    "range": {
+      "startLine": 69,
+      "endLine": 77
+    },
+    "type": "concept",
+    "title": "The ¾-Ratio Form",
+    "content": "sum_sq_medians_three_quarters restates the identity in its familiar classical ratio form mₐ²+m_b²+m_c² = ¾(a²+b²+c²), a direct ¼-rescaling of the previous theorem via linear_combination h / 4. This is the form most commonly quoted in Euclidean geometry texts.",
+    "mathContext": "$m_a^2 + m_b^2 + m_c^2 = \\tfrac{3}{4}(a^2+b^2+c^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rescaling",
+      "classical median identity"
+    ],
+    "prerequisites": [
+      "sum_sq_medians",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-euclidean-instantiation",
+    "proofId": "law-of-cosines-oq-07-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 86
+    },
+    "type": "context",
+    "title": "Instantiation in the Euclidean Plane",
+    "content": "A worked specialization confirms the abstract identity holds in the standard model of plane geometry, EuclideanSpace ℝ (Fin 2). Because the theorem is stated over an arbitrary inner-product affine space, the plane instance is literally sum_sq_medians a b c with no extra work — demonstrating that the coordinate-free statement subsumes the concrete planar one.",
+    "mathContext": "The identity in $\\mathrm{EuclideanSpace}\\ \\mathbb{R}\\ (\\mathrm{Fin}\\ 2)$ is the abstract theorem applied directly.",
+    "significance": "context",
+    "relatedConcepts": [
+      "EuclideanSpace",
+      "specialization",
+      "plane geometry"
+    ],
+    "prerequisites": [
+      "sum_sq_medians"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-07-oq-02`.

**Gap filled:** the entry had no `annotations.json`. Added five annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual line ranges:
1. Coordinate-free setup (inner-product affine space)
2. The headline identity 4(mₐ²+m_b²+m_c²) = 3(a²+b²+c²) and the 2+2−1=3 coefficient
3. Folding dist-symmetry to close with linear_combination
4. The ¾-ratio classical form
5. Euclidean-plane instantiation

Cross-references to `law-of-cosines-oq-07` and `law-of-cosines-oq-04` confirmed present. JSON validated. meta.json already complete (rich overview, open question, references) so left intact.