### PR TITLE
Enrich Incenter Is the Orthocenter of the Excentral Triangle (feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-squared-sides",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "Squared Side Lengths and Positivity",
+    "content": "side_a_sq/b/c express a² = |BC|² etc., dropping the Real.sqrt in the side-length definition via Real.sq_sqrt; side_a_pos/b/c and perimeter_pos record the positivity from vertex distinctness (non-degeneracy). These squared-side identities are exactly what collapses the cleared inner product to zero in Part III: the proof substitutes |B−A|² = c² and |C−A|² = b², so they must be available as rewrites.",
+    "mathContext": "$a^2 = |BC|^2$ (via Real.sq_sqrt); sides and perimeter strictly positive by non-degeneracy.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "squared side lengths",
+      "Real.sq_sqrt",
+      "non-degeneracy"
+    ],
+    "prerequisites": [
+      "Real.sq_sqrt",
+      "side_a/b/c definitions"
+    ]
+  },
+  {
+    "id": "ann-triangle-inequalities",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 145,
+      "endLine": 241
+    },
+    "type": "technique",
+    "title": "Strict Triangle Inequalities Keep the Denominators Nonzero",
+    "content": "strict_tri_ineq_a/b/c (a < b+c, cyclically) and pa_pos/pb_pos/pc_pos establish that the four tritangent denominators (−a+b+c)(a+b+c)(a+b−c)(a−b+c) are nonzero. Proved via the law of cosines a² = b²+c²+2P and the Lagrange identity b²c² − P² = D² with D the non-degeneracy determinant (D ≠ 0 ⟹ P < bc ⟹ a < b+c). This positivity is what licenses cancelling the denominator product after the inner product has been cleared.",
+    "mathContext": "$a < b+c$ etc.; $p_a = -a+b+c > 0$, so the denominator product is nonzero and can be cancelled (mul_eq_zero).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle inequality",
+      "law of cosines",
+      "Lagrange identity"
+    ],
+    "prerequisites": [
+      "nlinarith",
+      "non-degeneracy determinant"
+    ]
+  },
+  {
+    "id": "ann-altitudes-perp",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 243,
+      "endLine": 352
+    },
+    "type": "insight",
+    "title": "The Three Altitudes: Perpendicularity Forced by Side-Length Weights",
+    "content": "incenter_altitude_perp_a/b/c prove ⟨Iₐ−I, I_c−I_b⟩ = ⟨I_b−I, I_c−Iₐ⟩ = ⟨I_c−I, I_b−Iₐ⟩ = 0 — the line from the incenter through each excenter (an internal angle bisector) is perpendicular to the opposite excentral side (along external bisectors). The mechanism: clearing the four tritangent denominators turns the inner product into 4a²(b²·|B−A|² − c²·|C−A|²), a pure rational identity (field_simp; ring). Writing u = b(B−A), v = c(C−A), the displacement is proportional to u+v and the opposite side to u−v, so the inner product is ⟨u+v, u−v⟩ = |u|² − |v|². Substituting |B−A|² = c², |C−A|² = b² gives b²c² − c²b² = 0; cancelling the nonzero denominator finishes. No angle-chasing, no circumcenter — perpendicularity is forced by the weights alone.",
+    "mathContext": "$\\langle u+v, u-v\\rangle = |u|^2 - |v|^2 = b^2|B{-}A|^2 - c^2|C{-}A|^2 = b^2c^2 - c^2b^2 = 0$, with $u = b(B{-}A)$, $v = c(C{-}A)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "internal/external angle bisectors",
+      "perpendicularity",
+      "|u|² − |v| identity"
+    ],
+    "prerequisites": [
+      "field_simp",
+      "ring",
+      "linear_combination",
+      "side_a_sq / pa_pos"
+    ]
+  },
+  {
+    "id": "ann-orthocenter",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 354,
+      "endLine": 366
+    },
+    "type": "insight",
+    "title": "I Is the Orthocenter of the Excentral Triangle",
+    "content": "incenter_is_excentral_orthocenter bundles the three perpendicularities. Each line I Iₐ, I I_b, I I_c is an altitude of the excentral triangle (perpendicular from a vertex to the opposite side), and all three pass through the single point I, so they concur there — that is the definition of the orthocenter. Equivalently {I, Iₐ, I_b, I_c} is an orthocentric system: each of the four tritangent centers is the orthocenter of the triangle formed by the other three, and they share one nine-point circle. This is the dot-product fact the circumradius-2R sibling entry asserted but never proved while calling O the excentral nine-point center.",
+    "mathContext": "All three altitudes of $I_aI_bI_c$ pass through $I$, so $I$ is its orthocenter; $\\{I, I_a, I_b, I_c\\}$ is an orthocentric system.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthocenter",
+      "orthocentric system",
+      "nine-point circle"
+    ],
+    "prerequisites": [
+      "incenter_altitude_perp_a",
+      "incenter_altitude_perp_b",
+      "incenter_altitude_perp_c"
+    ]
+  },
+  {
+    "id": "ann-345-example",
+    "proofId": "feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 368,
+      "endLine": 408
+    },
+    "type": "context",
+    "title": "Worked Example: the 3-4-5 Orthocentric System",
+    "content": "triangle_345_excenter_a/b/c evaluate the three excenters to (6,6), (−3,3), (2,−2), and triangle_345_orthocentric_system checks the three perpendicularities for the incenter I=(1,1) of the 3-4-5 right triangle. Because all coordinates are rational, the dot products evaluate to 0 by norm_num, confirming concretely that I is the orthocenter of the excentral triangle.",
+    "mathContext": "$I=(1,1),\\ I_a=(6,6),\\ I_b=(-3,3),\\ I_c=(2,-2)$; the three opposite-connector dot products vanish.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "3-4-5 triangle",
+      "explicit excenters"
+    ],
+    "prerequisites": [
+      "norm_num",
+      "triangle_345"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01`.

**Gap filled:** the entry had no `annotations.json`. Added five annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual declaration line ranges:
1. Squared side lengths and positivity
2. Strict triangle inequalities keeping the denominators nonzero
3. The three altitudes — perpendicularity forced by side-length weights via ⟨u+v,u−v⟩ = |u|²−|v|²
4. I is the orthocenter of the excentral triangle (orthocentric system)
5. Worked 3-4-5 orthocentric-system example

All five cross-references confirmed to point at existing gallery entries. JSON validated. meta.json already complete (mainTheorems, five sections, two open questions, references) so left intact.