### PR TITLE
Enrich Exact Equidistribution of Reduced Residues — density 1/φ(d) skeleton (infinitude-primes-4k3-oq-02)

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3-oq-02/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-02/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "ann-count-class-eq",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 87
+    },
+    "type": "insight",
+    "title": "Exact Per-Class Count: Every Residue Class Gets Exactly N",
+    "content": "count_class_eq is the per-class half of the equidistribution skeleton: over a whole number N of periods [0, N·d), every residue class mod d (coprime or not) contains exactly N integers. The proof specializes Mathlib's Nat.count_modEq_card, which counts n < b with n ≡ v (mod d) as b/d + [v%d < b%d]. For b = N·d the modulus divides b, so (N·d)%d = 0, the Iverson correction term [v%d < 0] is false, and the count collapses to N·d/d = N — with equality and no error term, for every v.",
+    "mathContext": "$\\mathrm{count}(\\cdot \\equiv v \\bmod d)(Nd) = \\lfloor Nd/d\\rfloor + [v\\%d < (Nd)\\%d] = N + [v\\%d < 0] = N$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "equidistribution",
+      "residue classes",
+      "Iverson bracket"
+    ],
+    "prerequisites": [
+      "Nat.count_modEq_card",
+      "divisibility d ∣ N·d"
+    ]
+  },
+  {
+    "id": "ann-count-coprime-eq",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 88,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "Exact Coprime Count N·φ(d) via Block Induction",
+    "content": "count_coprime_eq gives the 'total' half: exactly N·φ(d) integers in [0, N·d) are coprime to d. Proved by induction on N — the window [0, (N+1)·d) splits as the disjoint prefix [0, N·d) (N·φ(d) coprimes by the inductive hypothesis) and a single fresh period [N·d, N·d+d) contributing φ(d) by Nat.filter_coprime_Ico_eq_totient. This periodicity of coprimality (φ(d) reduced residues per period) is the entire engine; it supplies the denominator of the relative density.",
+    "mathContext": "$\\#\\{x < Nd : \\gcd(d,x)=1\\} = N\\cdot\\varphi(d)$; each of the $N$ periods contributes $\\varphi(d)$ coprimes.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler totient",
+      "periodicity of coprimality",
+      "induction on periods"
+    ],
+    "prerequisites": [
+      "Nat.filter_coprime_Ico_eq_totient",
+      "disjoint-union cardinality"
+    ]
+  },
+  {
+    "id": "ann-class-subset-coprime",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 124
+    },
+    "type": "concept",
+    "title": "Reduced Classes Lie Entirely in the Coprimes",
+    "content": "class_subset_coprime justifies the word 'reduced': when gcd(d,v) = 1, the entire residue class v within the window consists of integers coprime to d. The proof uses Nat.gcd_rec — gcd(d,x) = gcd(d, x mod d) — so coprimality is a property of the residue alone: x ≡ v (mod d) ⟹ gcd(d,x) = gcd(d,v) = 1. This makes each reduced class genuinely one of the φ(d) equal pieces partitioning the coprime integers, and it is what makes the coprimality conjunct automatic in coprime_class_card_eq.",
+    "mathContext": "$x \\equiv v\\ (\\bmod\\ d),\\ \\gcd(d,v)=1 \\Rightarrow \\gcd(d,x) = \\gcd(d, x\\%d) = \\gcd(d,v) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "reduced residue system",
+      "residue-invariance of gcd",
+      "Nat.gcd_rec"
+    ],
+    "prerequisites": [
+      "Nat.gcd_rec"
+    ]
+  },
+  {
+    "id": "ann-reduced-class-density",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 145
+    },
+    "type": "insight",
+    "title": "Exact Relative Density 1/φ(d) — for Every Finite N",
+    "content": "reduced_class_density is the headline: the proportion of coprime integers in [0, N·d) lying in a fixed class v is exactly 1/φ(d), valid for every finite N ≥ 1 and every v, independent of both. Substituting the two counts (numerator N from count_class_eq, denominator N·φ(d) from count_coprime_eq) into the ratio over ℚ and cancelling N (legal since N ≥ 1, φ(d) > 0) leaves 1/φ(d), closed by field_simp + ring. This is the precise, elementary, machine-checked meaning of 'density 1/φ(d)' for coprime integers — exact at every finite scale, no error term.",
+    "mathContext": "$\\dfrac{N}{N\\cdot\\varphi(d)} = \\dfrac{1}{\\varphi(d)}$; the OQ-02 prime statement replaces 'coprime integers' with 'primes' and needs the unformalized analytic input.",
+    "significance": "key",
+    "relatedConcepts": [
+      "relative density",
+      "Dirichlet equidistribution",
+      "exact vs asymptotic"
+    ],
+    "prerequisites": [
+      "count_class_eq",
+      "count_coprime_eq",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-equipartition",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 146,
+      "endLine": 248
+    },
+    "type": "insight",
+    "title": "Sharp Equipartition: Each Reduced Class Carries Exactly N Coprimes",
+    "content": "This block sharpens the density ratio into an equal-pieces statement. coprime_class_card_eq: for gcd(v,d)=1, exactly N integers in [0, N·d) are both coprime to d and ≡ v (mod d) — the coprimality conjunct is automatic by class_subset_coprime, so the count reduces to count_class_card_eq = N. coprime_partition_card: the coprime integers decompose as the disjoint union over the φ(d) reduced residues via Finset.card_eq_sum_card_fiberwise along x ↦ x % d (residues preserve coprimality). coprime_card_eq_totient_mul: re-derives #coprime = φ(d)·N from the equipartition (φ(d) classes × N each), an independent cross-check of the block induction. reduced_class_density_coprime: the honest density 1/φ(d) with both numerator and denominator restricted to coprime integers.",
+    "mathContext": "Each reduced class carries exactly $N$ coprimes; the coprimes split into $\\varphi(d)$ equinumerous classes — the finite exact avatar of density $1/\\varphi(d)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "equipartition",
+      "fiberwise cardinality",
+      "totient_eq_card_coprime"
+    ],
+    "prerequisites": [
+      "Finset.card_eq_sum_card_fiberwise",
+      "coprime_class_card_eq",
+      "class_subset_coprime"
+    ]
+  },
+  {
+    "id": "ann-worked-examples",
+    "proofId": "infinitude-primes-4k3-oq-02",
+    "range": {
+      "startLine": 249,
+      "endLine": 264
+    },
+    "type": "context",
+    "title": "Worked Examples: Modulus d = 4",
+    "content": "The modulus-4 instance ties the abstract skeleton to the parent entry (φ(4) = 2, reduced residues 1 and 3). Over [0, 20): class 3 (mod 4) has exactly 5 members; there are 10 coprime integers total; the relative density is 1/φ(4) = 1/2; and the equipartition form gives exactly 5 integers both coprime to 4 and ≡ 3 (mod 4) — namely 3, 7, 11, 15, 19 — for an honest density 1/2. The examples discharge by applying the proved theorems, with small closed coprimality side-goals by kernel decide (no native_decide, so the entry stays axiom-free).",
+    "mathContext": "$d=4$: classes $\\equiv 1, 3\\ (\\bmod\\ 4)$ each carry density $1/2$ among coprimes; the prime analogue is the deep PNT-for-APs statement.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "modulus 4",
+      "decidability"
+    ],
+    "prerequisites": [
+      "reduced_class_density",
+      "coprime_class_card_eq",
+      "decide"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-4k3-oq-02`.

**Gap filled:** the entry had no `annotations.json`. Added six annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual declaration line ranges:
1. Exact per-class count (every residue class gets exactly N)
2. Exact coprime count N·φ(d) via block induction
3. Reduced classes lie entirely in the coprimes
4. Exact relative density 1/φ(d) for every finite N
5. Sharp equipartition block (each reduced class carries exactly N coprimes)
6. Modulus d = 4 worked examples

JSON validated. meta.json already complete (mainTheorems, seven sections, references, open questions) so left intact.