### PR TITLE
Enrich Additive Finite Group Annihilation: n·x = 0 (lagrange-theorem-oq-07-oq-02)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-07-oq-02/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-core-annihilation",
+    "proofId": "lagrange-theorem-oq-07-oq-02",
+    "range": {
+      "startLine": 39,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "Core: |G|·x = 0 from Additive Lagrange",
+    "content": "Part I is the additive image of the parent's pow_card_eq_one. addOrderOf_dvd_groupCard is the to_additive image of orderOf_dvd_card (the additive order of any element divides |G|); combined with addOrderOf_dvd_iff_nsmul_eq_zero this gives card_nsmul_eq_zero_of_lagrange: |G|·x = 0 for every x. card_nsmul_eq_zero_agrees confirms by rfl that this matches Mathlib's library lemma card_nsmul_eq_zero, and nsmul_natCard_eq_zero gives the Nat.card form valid even without finiteness (infinite G ⟹ Nat.card G = 0 and 0·g = 0 vacuously).",
+    "mathContext": "$\\mathrm{addOrderOf}(g) \\mid |G| \\Rightarrow |G| \\cdot g = 0$; the additive image of $g^{|G|} = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "additive Lagrange",
+      "to_additive",
+      "additive order"
+    ],
+    "prerequisites": [
+      "addOrderOf_dvd_card",
+      "addOrderOf_dvd_iff_nsmul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-exponent-divides",
+    "proofId": "lagrange-theorem-oq-07-oq-02",
+    "range": {
+      "startLine": 69,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "The Additive Exponent Divides the Order",
+    "content": "Part II descends from the per-element annihilation to the group invariant. The additive exponent is the least N > 0 with N·g = 0 for all g; card_is_common_period shows |G| is one such common period, so addExponent_dvd_card (= AddGroup.exponent_dvd_card) gives exponent G ∣ |G|. addExponent_dvd_card_via_universal makes the logic explicit through the universal property AddMonoid.exponent_dvd_iff_forall_nsmul_eq_zero — the exponent divides |G| precisely because |G| annihilates everything.",
+    "mathContext": "$|G|$ is a common period for all $g$, so $\\mathrm{exponent}(G) \\mid |G|$ (the exponent is the least such period).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "AddMonoid.exponent",
+      "universal property",
+      "common period"
+    ],
+    "prerequisites": [
+      "AddGroup.exponent_dvd_card",
+      "AddMonoid.exponent_dvd_iff_forall_nsmul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-zmod-recovery",
+    "proofId": "lagrange-theorem-oq-07-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 121
+    },
+    "type": "insight",
+    "title": "Concrete Recovery in ZMod n and Sharpness",
+    "content": "Part III instantiates at the canonical order-n abelian group ZMod n. zmod_nsmul_eq_zero specializes the core theorem with |ZMod n| = n (ZMod.card) to give the recovery n·x = 0 the open question asks for. addExponent_zmod proves AddMonoid.exponent (ZMod n) = n exactly, by antisymmetry: it divides n by Part II, and n = addOrderOf(1) divides it since the exponent annihilates 1 — so the bound exponent ∣ card is sharp for cyclic groups. comm_card_nsmul_eq_zero restates the recovery for an arbitrary finite abelian group of order n (commutativity is not actually needed).",
+    "mathContext": "$n \\cdot x = 0$ in $\\mathbb{Z}/n$; $\\mathrm{exponent}(\\mathbb{Z}/n) = n$ exactly (sharp), since $\\mathrm{addOrderOf}(1) = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ZMod n",
+      "cyclic group",
+      "sharp exponent"
+    ],
+    "prerequisites": [
+      "ZMod.card",
+      "ZMod.addOrderOf_one",
+      "Nat.dvd_antisymm"
+    ]
+  },
+  {
+    "id": "ann-multiplicative-bridge",
+    "proofId": "lagrange-theorem-oq-07-oq-02",
+    "range": {
+      "startLine": 123,
+      "endLine": 144
+    },
+    "type": "technique",
+    "title": "Structural Bridge: the Additive Theorem IS the Parent's",
+    "content": "Part IV makes the open question's 'same argument' claim literal. card_nsmul_eq_zero_via_multiplicative reproves Part I without re-invoking Lagrange — it transports the parent's pow_card_eq_one read on the type tag Multiplicative G. Via Fintype.card_multiplicative and ←ofAdd_nsmul, the multiplicative identity (ofAdd g)^|G| = 1 becomes ofAdd(|G|·g) = ofAdd 0; injectivity of Multiplicative.ofAdd then gives |G|·g = 0. This exhibits the additive and multiplicative theorems as one statement under to_additive / Multiplicative.",
+    "mathContext": "$(\\mathrm{ofAdd}\\,g)^{|G|} = 1 \\Rightarrow \\mathrm{ofAdd}(|G|\\cdot g) = \\mathrm{ofAdd}\\,0 \\Rightarrow |G|\\cdot g = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Multiplicative type tag",
+      "to_additive",
+      "ofAdd_nsmul"
+    ],
+    "prerequisites": [
+      "pow_card_eq_one",
+      "Fintype.card_multiplicative",
+      "Multiplicative.ofAdd.injective"
+    ]
+  },
+  {
+    "id": "ann-chain",
+    "proofId": "lagrange-theorem-oq-07-oq-02",
+    "range": {
+      "startLine": 146,
+      "endLine": 156
+    },
+    "type": "context",
+    "title": "The End-to-End Chain",
+    "content": "Part V bundles the whole story in one statement, paralleling the parent's chain_lagrange_to_euler. chain_lagrange_to_zmod ties the foundation (additive Lagrange addOrderOf x ∣ |ZMod n|) to the apex (the concrete recovery n·x = 0), making the logical descent from Lagrange to the order-n annihilation a single citable result.",
+    "mathContext": "$(\\mathrm{addOrderOf}\\,x \\mid |\\mathbb{Z}/n|) \\wedge n\\cdot x = 0$ — foundation to apex in one statement.",
+    "significance": "context",
+    "relatedConcepts": [
+      "proof chain",
+      "Lagrange to annihilation"
+    ],
+    "prerequisites": [
+      "addOrderOf_dvd_card",
+      "zmod_nsmul_eq_zero"
+    ]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-07-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-07-oq-02/meta.json
@@ -188,7 +188,8 @@
     "summary": "The additive annihilation identity n · x = 0 in a finite group of order n is machine-checked, derived from additive Lagrange, sharpened on ZMod n where the additive exponent equals n, and shown to be the parent's multiplicative theorem transported through Multiplicative.",
     "implications": "Confirms that the finite-group exponent identity and its additive image are a single fact under to_additive, and recovers the elementary char-n statement n · x = 0 in ℤ/nℤ as a special case.",
     "openQuestions": [
-      "Can the structure theorem for finite abelian groups be used to compute the additive exponent of an arbitrary finite abelian group as the lcm of the orders of its cyclic factors, sharpening exponent ∣ card to an exact value?"
+      "Can the structure theorem for finite abelian groups be used to compute the additive exponent of an arbitrary finite abelian group as the lcm of the orders of its cyclic factors, sharpening exponent ∣ card to an exact value?",
+      "Characterize exactly when the additive exponent equals the order (exponent G = |G|): for finite abelian groups this is precisely cyclicity, so a formalized 'exponent = card ↔ IsAddCyclic' would turn the ZMod n sharpness shown here into a complete criterion."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-07-oq-02`.

**Gaps filled:** the entry had no `annotations.json`. Added five annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, anchored to the actual declaration line ranges:
1. Core |G|·x = 0 from additive Lagrange
2. The additive exponent divides the order
3. Concrete recovery in ZMod n and sharpness (exponent = n)
4. Structural bridge: the additive theorem IS the parent's (via Multiplicative)
5. The end-to-end chain

Also added a second open question (exponent = card ↔ IsAddCyclic criterion). Both cross-references confirmed present. JSON validated. meta.json was otherwise complete.