### PR TITLE
research(erdos-10-oq-04): foundations for the lower density of S₁ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos10S1Density.lean
+++ b/proofs/Proofs/Erdos10S1Density.lean
@@ -1,0 +1,181 @@
+/-
+# Erdős Problem #10, Open Question 4 — The lower density of `S₁`
+
+Erdős Problem #10 asks whether there is a constant `k` such that every
+sufficiently large integer is the sum of a prime and at most `k` powers of 2.
+Writing `Sₖ` for the set of such representable integers, the fourth open
+question recorded for the problem is:
+
+> **What is the exact lower density `d̲(S₁)`?  What are the best bounds?**
+
+Here `S₁` is the `k = 1` set: integers of the form `p` or `p + 2ᵃ` with `p`
+prime.  Romanoff (1934) proved `d̲(S₁) > 0`; the *exact* value is unknown and
+the question is open.
+
+This file does **not** resolve the open question.  Instead it builds the
+verified, 0-axiom foundation that any density argument must rest on, none of
+which was previously formalized (the parent `Erdos10Problem.lean` contains
+definitions only and *no* theorems):
+
+* a clean computable characterization of membership in `S₁`
+  (`mem_sumPrimeAndTwoPows_one_iff`);
+* monotonicity of the family `Sₖ` in `k` (`sumPrimeAndTwoPows_mono`), so that
+  `d̲(S₁) ≤ d̲(Sₖ)` for every `k ≥ 1` — the elementary lower edge of
+  Gallagher's theorem `d̲(Sₖ) → 1`;
+* every prime lies in every `Sₖ`, and `1` lies in none;
+* the basic analytic properties of `Set.lowerDensity`: it is monotone and
+  always lies in `[0, 1]`, hence `d̲(S₁) ∈ [0, 1]`.
+
+The hard bounds (`d̲(S₁) > 0`, Romanoff; the conjectural exact value) are
+recorded as documentation only.
+-/
+
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Real
+import Mathlib.Order.Filter.AtTopBot.Group
+
+open Set Filter Classical
+
+namespace Erdos10S1Density
+
+/- ## Core definitions (mirroring `Erdos10Problem.lean`) -/
+
+/-- The set of natural numbers expressible as a prime plus at most `k`
+powers of 2; the exponents form a multiset of cardinality `≤ k`. -/
+def sumPrimeAndTwoPows (k : ℕ) : Set ℕ :=
+  { n | ∃ (p : ℕ) (pows : Multiset ℕ),
+    p.Prime ∧ pows.card ≤ k ∧ n = p + (pows.map (2 ^ ·)).sum }
+
+/-- The finite counting ratio `|S ∩ [0,n]| / (n+1)`. -/
+noncomputable def densityFn (S : Set ℕ) (n : ℕ) : ℝ :=
+  (↑(Finset.card (Finset.filter (· ∈ S) (Finset.range (n + 1)))) : ℝ) / (↑(n + 1) : ℝ)
+
+/-- Lower asymptotic density: the `liminf` of `|S ∩ [0,n]| / (n+1)`. -/
+noncomputable def lowerDensity (S : Set ℕ) : ℝ :=
+  Filter.liminf (densityFn S) atTop
+
+/- ## Structure of `S₁` -/
+
+/-- A clean, quantifier-light description of the `k = 1` case: `n ∈ S₁`
+iff `n` is prime or `n = p + 2ᵃ` for some prime `p` and exponent `a`. -/
+theorem mem_sumPrimeAndTwoPows_one_iff (n : ℕ) :
+    n ∈ sumPrimeAndTwoPows 1 ↔ n.Prime ∨ ∃ p a : ℕ, p.Prime ∧ n = p + 2 ^ a := by
+  constructor
+  · rintro ⟨p, pows, hp, hcard, rfl⟩
+    rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hcard with h0 | h1
+    · -- empty multiset: the value is the prime `p`
+      rw [Multiset.card_eq_zero] at h0
+      subst h0
+      simp only [Multiset.map_zero, Multiset.sum_zero, add_zero]
+      exact Or.inl hp
+    · -- singleton multiset `{a}`: the value is `p + 2 ^ a`
+      obtain ⟨a, rfl⟩ := Multiset.card_eq_one.mp h1
+      refine Or.inr ⟨p, a, hp, ?_⟩
+      simp [Multiset.map_singleton, Multiset.sum_singleton]
+  · rintro (hp | ⟨p, a, hp, rfl⟩)
+    · exact ⟨n, 0, hp, by simp, by simp⟩
+    · exact ⟨p, {a}, hp, by simp, by simp [Multiset.map_singleton, Multiset.sum_singleton]⟩
+
+/-- The family `Sₖ` is monotone in `k`: more allowed powers can only add
+representable integers. -/
+theorem sumPrimeAndTwoPows_mono : Monotone sumPrimeAndTwoPows := by
+  intro j k hjk n
+  rintro ⟨p, pows, hp, hcard, rfl⟩
+  exact ⟨p, pows, hp, hcard.trans hjk, rfl⟩
+
+/-- Every prime belongs to every `Sₖ` (take the empty multiset of powers). -/
+theorem prime_mem_sumPrimeAndTwoPows {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    p ∈ sumPrimeAndTwoPows k :=
+  ⟨p, 0, hp, by simp, by simp⟩
+
+/-- `1` is never a sum of a prime and powers of 2: the prime already forces
+the value to be at least `2`. -/
+theorem one_not_mem_sumPrimeAndTwoPows (k : ℕ) : 1 ∉ sumPrimeAndTwoPows k := by
+  rintro ⟨p, pows, hp, -, h⟩
+  have h2 : 2 ≤ p := hp.two_le
+  have : p ≤ 1 := by
+    calc p ≤ p + (pows.map (2 ^ ·)).sum := Nat.le_add_right _ _
+      _ = 1 := h.symm
+  omega
+
+/-- Concrete witnesses showing the `p + 2ᵃ` shape really occurs in `S₁`. -/
+example : 4 ∈ sumPrimeAndTwoPows 1 := by
+  rw [mem_sumPrimeAndTwoPows_one_iff]
+  exact Or.inr ⟨2, 1, Nat.prime_two, by norm_num⟩
+
+example : 9 ∈ sumPrimeAndTwoPows 1 := by
+  rw [mem_sumPrimeAndTwoPows_one_iff]
+  exact Or.inr ⟨7, 1, by norm_num, by norm_num⟩
+
+/- ## Lower density: basic analytic properties -/
+
+/-- The counting ratio `densityFn S n` lies in `[0, 1]`. -/
+theorem densityFn_mem_Icc (S : Set ℕ) (n : ℕ) : densityFn S n ∈ Set.Icc (0 : ℝ) 1 := by
+  unfold densityFn
+  constructor
+  · positivity
+  · rw [div_le_one (by positivity)]
+    have : Finset.card (Finset.filter (· ∈ S) (Finset.range (n + 1))) ≤ n + 1 := by
+      calc Finset.card (Finset.filter (· ∈ S) (Finset.range (n + 1)))
+          ≤ Finset.card (Finset.range (n + 1)) := Finset.card_filter_le _ _
+        _ = n + 1 := Finset.card_range _
+    exact_mod_cast this
+
+/-- `densityFn S` is bounded below (by `0`). -/
+private theorem isBoundedUnder_ge_densityFn (S : Set ℕ) :
+    IsBoundedUnder (· ≥ ·) atTop (densityFn S) :=
+  isBoundedUnder_of_eventually_ge (Filter.Eventually.of_forall fun n => (densityFn_mem_Icc S n).1)
+
+/-- `densityFn S` is cobounded under `≥` (since it is bounded above by `1`). -/
+private theorem isCoboundedUnder_ge_densityFn (S : Set ℕ) :
+    IsCoboundedUnder (· ≥ ·) atTop (densityFn S) :=
+  isCoboundedUnder_ge_of_le atTop (fun n => (densityFn_mem_Icc S n).2)
+
+/-- Lower density is monotone with respect to set inclusion. -/
+theorem lowerDensity_mono {A B : Set ℕ} (h : A ⊆ B) : lowerDensity A ≤ lowerDensity B := by
+  apply Filter.liminf_le_liminf
+  · refine Filter.Eventually.of_forall fun n => ?_
+    have hsub : Finset.filter (· ∈ A) (Finset.range (n + 1))
+        ⊆ Finset.filter (· ∈ B) (Finset.range (n + 1)) := by
+      intro x hx
+      rw [Finset.mem_filter] at hx ⊢
+      exact ⟨hx.1, h hx.2⟩
+    have hcard := Finset.card_le_card hsub
+    unfold densityFn
+    gcongr
+  · exact isBoundedUnder_ge_densityFn A
+  · exact isCoboundedUnder_ge_densityFn B
+
+/-- Lower density is always nonnegative. -/
+theorem lowerDensity_nonneg (S : Set ℕ) : 0 ≤ lowerDensity S := by
+  unfold lowerDensity
+  rw [show (0 : ℝ) = liminf (fun _ : ℕ => (0 : ℝ)) atTop from (Filter.liminf_const 0).symm]
+  apply Filter.liminf_le_liminf
+  · exact Filter.Eventually.of_forall fun n => (densityFn_mem_Icc S n).1
+  · exact isBoundedUnder_of_eventually_ge (Filter.Eventually.of_forall fun _ => le_refl (0 : ℝ))
+  · exact isCoboundedUnder_ge_densityFn S
+
+/-- Lower density never exceeds `1`. -/
+theorem lowerDensity_le_one (S : Set ℕ) : lowerDensity S ≤ 1 := by
+  unfold lowerDensity
+  rw [show (1 : ℝ) = liminf (fun _ : ℕ => (1 : ℝ)) atTop from (Filter.liminf_const 1).symm]
+  apply Filter.liminf_le_liminf
+  · exact Filter.Eventually.of_forall fun n => (densityFn_mem_Icc S n).2
+  · exact isBoundedUnder_ge_densityFn S
+  · exact isCoboundedUnder_ge_of_le atTop (fun _ => le_refl (1 : ℝ))
+
+/-- Consequently `d̲(S₁) ∈ [0, 1]`. -/
+theorem lowerDensity_S1_mem_Icc :
+    lowerDensity (sumPrimeAndTwoPows 1) ∈ Set.Icc (0 : ℝ) 1 :=
+  ⟨lowerDensity_nonneg _, lowerDensity_le_one _⟩
+
+/-- **Lower edge of Gallagher's theorem.**  Because `S₁ ⊆ Sₖ` for every
+`k ≥ 1`, the lower density of `S₁` is a lower bound for every `d̲(Sₖ)`.
+Gallagher (1975) proved `d̲(Sₖ) → 1`; the *exact* value of `d̲(S₁)` (the base
+of this increasing chain) is the content of the open question. -/
+theorem lowerDensity_S1_le {k : ℕ} (hk : 1 ≤ k) :
+    lowerDensity (sumPrimeAndTwoPows 1) ≤ lowerDensity (sumPrimeAndTwoPows k) :=
+  lowerDensity_mono (sumPrimeAndTwoPows_mono hk)
+
+end Erdos10S1Density

--- a/src/data/proofs/erdos-10-oq-04/annotations.json
+++ b/src/data/proofs/erdos-10-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "OQ-04: the exact lower density of S₁ is open — what is and is not formalized",
+    "content": "Erdős Problem #10 asks for a finite k with every large integer a prime plus at most k powers of 2. The k = 1 set is S₁ = {p} ∪ {p + 2ᵃ}. The fourth open question asks for the exact lower density d̲(S₁). This is genuinely unknown: Romanoff (1934) proved d̲(S₁) > 0 and Erdős (1950, covering congruences) gave d̲(S₁) < 1, but neither the exact value nor the sharpest explicit bounds are known. This file deliberately does NOT claim the open question. It supplies the verified, 0-axiom scaffolding the parent file was missing entirely (the parent has definitions and zero theorems): a clean membership characterization, monotonicity of the family Sₖ, and the order/analytic facts about lower density.",
+    "mathContext": "S₁ = { n : n = p or n = p + 2ᵃ, p prime }. Known: 0 < d̲(S₁) < 1. Open: the exact value of d̲(S₁)."
+  },
+  {
+    "id": "ann-def-sumprimepows-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "definition",
+    "title": "The representable family Sₖ",
+    "content": "`sumPrimeAndTwoPows k` is the set of n of the form p + Σ 2^{aᵢ} where p is prime and the exponents form a multiset of cardinality at most k. Using a multiset (rather than a finite set) of exponents allows repeated powers, matching the parent file's definition exactly so the two formalizations interoperate.",
+    "mathContext": "Sₖ = { n : ∃ p prime, ∃ pows : Multiset ℕ, |pows| ≤ k ∧ n = p + Σ 2^{aᵢ} }."
+  },
+  {
+    "id": "ann-def-lowerdensity-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 50, "endLine": 56 },
+    "type": "definition",
+    "title": "Lower density via liminf of counting ratios",
+    "content": "`densityFn S n = |S ∩ [0,n]| / (n+1)` is the finite counting ratio (factored out so its boundedness can be reused), and `lowerDensity S` is its liminf along `atTop`. The liminf — rather than a plain limit — is used because the limit need not exist; the lower density is exactly what Romanoff's and Gallagher's theorems bound.",
+    "mathContext": "d̲(S) = liminf_{n→∞} |S ∩ [0,n]| / (n+1)."
+  },
+  {
+    "id": "ann-thm-memiff-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 60, "endLine": 78 },
+    "type": "theorem",
+    "title": "Membership in S₁ collapses to 'prime or p + 2ᵃ'",
+    "content": "For k = 1 the exponent multiset has cardinality 0 or 1. The cardinality-0 case (`Multiset.card_eq_zero`) gives n = p, a prime; the cardinality-1 case (`Multiset.card_eq_one`) gives a singleton {a}, whose mapped sum is 2ᵃ, so n = p + 2ᵃ. The proof unpacks both directions, turning the abstract multiset definition into a usable, quantifier-light disjunction.",
+    "mathContext": "n ∈ S₁ ⇔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2ᵃ."
+  },
+  {
+    "id": "ann-thm-mono-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 80, "endLine": 85 },
+    "type": "theorem",
+    "title": "The family Sₖ is monotone in k",
+    "content": "If j ≤ k then any witness for membership in Sⱼ (a prime and a multiset of ≤ j powers) is also a witness for Sₖ, since |pows| ≤ j ≤ k. Combined with monotonicity of lower density, this yields d̲(S₁) ≤ d̲(Sₖ) for every k ≥ 1 — the elementary lower edge of Gallagher's theorem d̲(Sₖ) → 1.",
+    "mathContext": "Monotone (fun k => Sₖ); hence j ≤ k ⇒ Sⱼ ⊆ Sₖ."
+  },
+  {
+    "id": "ann-thm-onenotmem-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 92, "endLine": 100 },
+    "type": "theorem",
+    "title": "1 is never representable",
+    "content": "Any element of Sₖ is at least the prime p ≥ 2 added to a nonnegative power sum, so it cannot equal 1. This is the smallest non-member and shows S₁ ≠ ℕ.",
+    "mathContext": "1 ∉ Sₖ for every k, since p ≥ 2 forces p + Σ2^{aᵢ} ≥ 2."
+  },
+  {
+    "id": "ann-thm-densitymono-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 135, "endLine": 148 },
+    "type": "theorem",
+    "title": "Lower density is monotone under inclusion",
+    "content": "If A ⊆ B then on each window [0,n] the filtered count for A is at most that for B (`Finset.card_le_card` on the filtered subset), so densityFn A n ≤ densityFn B n pointwise. The result follows from `Filter.liminf_le_liminf`, discharging its boundedness side-conditions from the [0,1] bound on counting ratios.",
+    "mathContext": "A ⊆ B ⇒ d̲(A) ≤ d̲(B)."
+  },
+  {
+    "id": "ann-thm-s1le-erdos10oq04",
+    "proofId": "erdos-10-oq-04",
+    "range": { "startLine": 173, "endLine": 179 },
+    "type": "theorem",
+    "title": "Lower edge of Gallagher's theorem",
+    "content": "Since S₁ ⊆ Sₖ for k ≥ 1, lower density's monotonicity gives d̲(S₁) ≤ d̲(Sₖ). Gallagher (1975) proved d̲(Sₖ) → 1; d̲(S₁) sits at the base of this increasing chain, and its exact value is the open question.",
+    "mathContext": "1 ≤ k ⇒ d̲(S₁) ≤ d̲(Sₖ)."
+  }
+]

--- a/src/data/proofs/erdos-10-oq-04/meta.json
+++ b/src/data/proofs/erdos-10-oq-04/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "erdos-10-oq-04",
+  "title": "Erdős #10 OQ-04: Foundations for the Lower Density of S₁",
+  "slug": "erdos-10-oq-04",
+  "description": "Erdős Problem #10 asks for a k such that every large integer is a prime plus at most k powers of 2. The fourth open question records: what is the exact lower density d̲(S₁) of the k=1 set? This entry does not resolve that open question; it builds the verified, 0-axiom foundation it rests on — a clean membership characterization of S₁, monotonicity of the family Sₖ (so d̲(S₁) ≤ d̲(Sₖ), the elementary lower edge of Gallagher's theorem), and the basic properties of lower density (monotone, valued in [0,1]), giving d̲(S₁) ∈ [0,1].",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://erdosproblems.com/10",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos10S1Density.lean",
+    "tags": [
+      "number-theory",
+      "erdos",
+      "primes",
+      "powers-of-2",
+      "additive-combinatorics",
+      "density",
+      "liminf"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 181,
+    "assumptions": "0 axioms, 0 sorries. All theorems depend only on the standard foundational axioms (propext, Classical.choice, Quot.sound) — verified via #print axioms on host Lean (LAKE_UNSAFE=1 lake env lean) at the v4.26.0 pin; no sorryAx and no Lean.ofReduceBool. The open question itself — the exact value of d̲(S₁) — is NOT proved or assumed: Romanoff's theorem d̲(S₁) > 0 and the conjectural exact value are documented in source comments only. What is proved is the surrounding structure: the membership characterization of S₁, monotonicity of Sₖ in k, primes ⊆ Sₖ, 1 ∉ Sₖ, and the elementary properties of Set.lowerDensity (monotone under inclusion, valued in [0,1]).",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #10 asks whether some finite k makes every sufficiently large integer a sum of a prime and at most k powers of 2; Erdős called it 'probably unattackable' and, with Graham, conjectured no such k exists. The k = 1 set S₁ = {p} ∪ {p + 2ᵃ} is the smallest case. Romanoff (1934) proved that S₁ already has positive lower density d̲(S₁) > 0, one of the first results on primes as an additive basis with a lacunary companion sequence. Erdős (1950), via covering congruences, showed the complement also has positive density, so 0 < d̲(S₁) < 1. The exact value of d̲(S₁) — and the best explicit bounds — remain open, which is the content of this open question.",
+    "problemStatement": "What is the exact lower density d̲(S₁) of the set S₁ = { n : n = p or n = p + 2ᵃ, p prime }? What are the best known bounds?",
+    "text": "The exact value of d̲(S₁) is unknown. This formalization establishes the verified foundation any density argument must use, and records the known bounds (Romanoff: d̲(S₁) > 0) as documentation.",
+    "proofStrategy": "We mirror the parent file's definitions of Sₖ (a prime plus a multiset of at most k powers of 2) and of lower density (the liminf of |S ∩ [0,n]|/(n+1)), then prove the structural and analytic facts that were previously absent (the parent Erdos10Problem.lean contains definitions and zero theorems). The membership characterization unfolds the multiset of cardinality ≤ 1 into the disjunction 'prime or p + 2ᵃ'. Monotonicity of Sₖ is immediate from the cardinality bound. The lower-density lemmas are obtained from Filter.liminf_le_liminf together with the boundedness of the counting ratio in [0,1].",
+    "keyInsights": [
+      "**Membership of S₁ is elementary**: n ∈ S₁ ⇔ n is prime or n = p + 2ᵃ for a prime p — the multiset-of-≤1-powers definition collapses to a clean disjunction (`mem_sumPrimeAndTwoPows_one_iff`).",
+      "**Monotone family**: Sⱼ ⊆ Sₖ whenever j ≤ k (`sumPrimeAndTwoPows_mono`), so d̲(S₁) ≤ d̲(Sₖ) for every k ≥ 1. Gallagher (1975) proved d̲(Sₖ) → 1; d̲(S₁) is the base of this increasing chain.",
+      "**Lower density is well-behaved**: it is monotone under set inclusion and always lies in [0,1] (`lowerDensity_mono`, `lowerDensity_nonneg`, `lowerDensity_le_one`), hence d̲(S₁) ∈ [0,1] (`lowerDensity_S1_mem_Icc`).",
+      "**The hard content stays open**: Romanoff's lower bound d̲(S₁) > 0 (a sieve/Cauchy–Schwarz argument) and the exact value are *not* proved — they require machinery beyond what is formalized here and are recorded only as references."
+    ],
+    "prerequisites": [
+      "Prime numbers (Nat.Prime)",
+      "Multisets and their sums",
+      "liminf of a real sequence (Filter.liminf) and boundedness under a filter",
+      "Asymptotic (lower) density of sets of natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Core Definitions",
+      "startLine": 42,
+      "endLine": 56,
+      "summary": "Mirrors the parent's `sumPrimeAndTwoPows k` (a prime plus a multiset of ≤ k powers of 2), factors the counting ratio `densityFn S n = |S ∩ [0,n]| / (n+1)`, and defines `lowerDensity S` as its liminf along `atTop`.",
+      "mathContext": "Sₖ = { n : ∃ p prime, ∃ pows : Multiset ℕ, |pows| ≤ k ∧ n = p + Σ 2^{aᵢ} }; d̲(S) = liminf_{n→∞} |S ∩ [0,n]| / (n+1)."
+    },
+    {
+      "id": "structure",
+      "title": "Structure of S₁",
+      "startLine": 58,
+      "endLine": 109,
+      "summary": "Characterizes membership in S₁ as 'prime or p + 2ᵃ', proves the family Sₖ is monotone in k, shows every prime lies in every Sₖ and 1 lies in none, and gives concrete witnesses (4 = 2 + 2¹, 9 = 7 + 2¹).",
+      "mathContext": "n ∈ S₁ ⇔ n.Prime ∨ ∃ p a, p.Prime ∧ n = p + 2ᵃ; Monotone Sₖ; p prime ⇒ p ∈ Sₖ; 1 ∉ Sₖ."
+    },
+    {
+      "id": "density",
+      "title": "Lower Density: Basic Properties",
+      "startLine": 111,
+      "endLine": 181,
+      "summary": "Proves the counting ratio lies in [0,1], that lower density is monotone under inclusion and valued in [0,1], hence d̲(S₁) ∈ [0,1], and finally the lower-edge bound d̲(S₁) ≤ d̲(Sₖ) for k ≥ 1.",
+      "mathContext": "0 ≤ d̲(S) ≤ 1; A ⊆ B ⇒ d̲(A) ≤ d̲(B); d̲(S₁) ∈ [0,1]; 1 ≤ k ⇒ d̲(S₁) ≤ d̲(Sₖ)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry adds the first verified theorems to the formal treatment of Erdős #10's k = 1 set S₁: a membership characterization, monotonicity of the family Sₖ, the inclusion facts (primes ⊆ Sₖ, 1 ∉ Sₖ), and the basic analytic properties of lower density, culminating in d̲(S₁) ∈ [0,1] and d̲(S₁) ≤ d̲(Sₖ). It does not determine the exact value d̲(S₁), which remains open.",
+    "implications": "The exact lower density d̲(S₁) is unknown; Romanoff (1934) gives d̲(S₁) > 0 and Erdős (1950) gives d̲(S₁) < 1, but the precise value and best explicit bounds are open. The formalized monotonicity d̲(S₁) ≤ d̲(Sₖ) places S₁ at the base of the increasing chain whose limit is Gallagher's 1 (1975); pinning d̲(S₁) would require the sieve machinery behind Romanoff's theorem, which is recorded here as documentation rather than formalized.",
+    "openQuestions": [
+      "What is the exact value of d̲(S₁)? (The open question; only 0 < d̲(S₁) < 1 is known.)",
+      "What are the best explicit numerical lower and upper bounds for d̲(S₁)?",
+      "Can Romanoff's lower bound d̲(S₁) > 0 be formalized in Lean (the sieve / Cauchy–Schwarz second-moment argument)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-10",
+      "relationship": "extends",
+      "description": "Parent: Erdős #10 (a prime plus powers of 2); supplies the definitions this entry mirrors and proves theorems about."
+    },
+    {
+      "targetId": "erdos-10-oq-02",
+      "relationship": "related",
+      "description": "Sibling OQ-02: the Granville–Soundararajan k=3 decidable foundation for Sₖ membership."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Romanoff, N.P.",
+      "title": "Über einige Sätze der additiven Zahlentheorie",
+      "year": "1934",
+      "venue": "Mathematische Annalen 109:668–678",
+      "note": "Proved d̲(S₁) > 0: a positive proportion of integers are a prime plus a power of 2."
+    },
+    {
+      "authors": "Erdős, P.",
+      "title": "On integers of the form 2^k + p and some related problems",
+      "year": "1950",
+      "venue": "Summa Brasiliensis Mathematicae 2:113–123",
+      "note": "Covering-congruence construction: the complement of S₁ also has positive density, so d̲(S₁) < 1."
+    },
+    {
+      "authors": "Gallagher, P.X.",
+      "title": "Primes and powers of 2",
+      "year": "1975",
+      "venue": "Inventiones Mathematicae 29:125–142",
+      "note": "d̲(Sₖ) → 1 as k → ∞; S₁ is the base of this increasing chain."
+    },
+    {
+      "authors": "Erdős, P., Graham, R.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "venue": "Monographies de L'Enseignement Mathématique 28",
+      "note": "Survey context for the problem and its density questions."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Topology.Algebra.InfiniteSum.Real",
+      "Mathlib.Order.Filter.AtTopBot.Group"
+    ],
+    "namespace": "Erdos10S1Density",
+    "lineCount": 181,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "path": "Proofs/Erdos10S1Density.lean",
+    "sorries": 0,
+    "definitionCount": 3
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Erdős Problem #10 ("sums of a prime and powers of 2") **open question OQ-04** asks: *what is the exact lower density $\underline{d}(S_1)$ of the $k=1$ set* $S_1 = \{p\} \cup \{p + 2^a\}$? This value is **genuinely open** — Romanoff (1934) proved $\underline{d}(S_1) > 0$ and Erdős (1950, covering congruences) gave $\underline{d}(S_1) < 1$, but the exact value and best explicit bounds are unknown.

**This PR does not resolve the open question.** It adds the verified, 0-axiom foundation the parent file was missing entirely — `Erdos10Problem.lean` contains definitions and *zero* theorems. New file `Proofs/Erdos10S1Density.lean` (12 theorems, 3 defs, 181 lines):

- `mem_sumPrimeAndTwoPows_one_iff`: $n \in S_1 \iff n$ prime $\lor\ \exists p\,a,\ p$ prime $\land\ n = p + 2^a$ (the multiset-of-≤1-powers definition collapses to a clean disjunction)
- `sumPrimeAndTwoPows_mono`: $S_j \subseteq S_k$ for $j \le k$
- `prime_mem_…`, `one_not_mem_…`: primes $\subseteq S_k$, and $1 \notin S_k$
- `lowerDensity_mono`, `lowerDensity_nonneg`, `lowerDensity_le_one`: lower density is monotone under inclusion and valued in $[0,1]$
- `lowerDensity_S1_mem_Icc`, `lowerDensity_S1_le`: $\underline{d}(S_1) \in [0,1]$ and $\underline{d}(S_1) \le \underline{d}(S_k)$ for $k \ge 1$ — the elementary lower edge of Gallagher's $\underline{d}(S_k) \to 1$

## Verification

- Typechecks at the v4.26.0 pin (host `lake env lean`).
- `#print axioms` on every result: depends only on `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. 0 axioms, 0 sorries.

Romanoff's $\underline{d}(S_1) > 0$ and the conjectural exact value remain documented references, not formalized — status `verified` reflects only what is proved.

## Gallery
New entry `src/data/proofs/erdos-10-oq-04/` (meta.json + annotations.json), schema-matched to sibling `erdos-10-oq-02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)