### PR TITLE
Enrich Additive Finite Group Annihilation (lagrange-theorem-oq-07-oq-02)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-07-oq-02/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-07-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ07OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOQ07OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOQ07OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOQ07OQ02Data: ProofData = {
+  proof: lagrangeTheoremOQ07OQ02Proof,
+  annotations: lagrangeTheoremOQ07OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-07-oq-02` (quality 45, pass 0).

## Critical fix
- **Added missing `index.ts`** — without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered 'proof not found' on the live site despite appearing in the gallery listing.

## Annotation coverage (new `annotations.json`)
Added 6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. Overview — the additive image of g^|G|=1 under `to_additive`
2. Core — |G|·x=0 from additive Lagrange
3. Exponent descent — additive exponent is least period, divides |G|
4. ZMod n recovery — n·x=0 with sharp exponent (ZMod n)=n
5. Bridge — the additive theorem IS the parent's via `Multiplicative` transport
6. End-to-end chain

## Axiom integrity
Verified meta.json claims against the Lean source: `status: verified`, `axiomCount: 0`, no `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Claims are accurate.