### PR TITLE
research(chebyshev-polynomials-oq-01-oq-01): Chebyshev addition formulas + Pell identity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevPolynomialsOQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevPolynomialsOQ01OQ01.lean
@@ -1,0 +1,135 @@
+/-
+  Addition formulas for Chebyshev polynomials of the first and second kind.
+
+  The parent file (`Proofs.ChebyshevPolynomialsOQ01`) records the *composition*
+  law `T_{m·n} = T_m ∘ T_n` and the commuting-family structure it generates.
+  Mathlib supplements this with the *product-to-sum* identity
+  `T_mul_T : 2·T_m·T_k = T_{m+k} + T_{m−k}`.  What Mathlib does **not** record is
+  the genuine **angle-addition formula** — the polynomial shadow of
+  `cos(α+β) = cos α cos β − sin α sin β`:
+
+      **T_{m+n} = T_m · T_n − (1 − X²) · U_{m−1} · U_{n−1}.**
+
+  Here `U` is the Chebyshev polynomial of the second kind, and the factor
+  `(1 − X²)` plays the role of `sin²`, since `Uₖ(cos θ)·sin θ = sin((k+1)θ)`.
+  This file proves that identity (`T_add`), together with:
+
+  * `T_sub`           — the matching subtraction formula
+                        `T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1}`
+                        (the `cos(α−β)` analog);
+  * `T_sq_add`        — the Pell / Pythagorean identity obtained at `m = n`,
+                        `Tₙ² + (1−X²)·U_{n−1}² = 1`
+                        (the polynomial `cos² + sin² = 1`);
+  * `U_add`           — the second-kind addition formula
+                        `U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}`
+                        (the polynomial `sin(α+β) = sin α cos β + cos α sin β`),
+                        which Mathlib likewise omits.
+
+  All identities hold over an arbitrary commutative ring `R` and for all integer
+  indices `m, n : ℤ`, with the usual conventions `U_{-1} = 0`, `T_0 = 1`.
+
+  The proofs use Mathlib's two-step integer induction principle
+  `Polynomial.Chebyshev.induct`, exactly as `T_mul_T` does: the second-order
+  recurrences `T_add_two`/`U_add_two` (and their downward `_sub_two` forms)
+  collapse each inductive step, discharged by `linear_combination`.  The `n = 1`
+  base cases are precisely Mathlib's mixed recurrences
+  `T_eq_X_mul_T_sub_pol_U` and `U_eq_X_mul_U_add_T`.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace ChebyshevPolynomialsOQ01OQ01
+
+open Polynomial.Chebyshev
+
+variable (R : Type*) [CommRing R]
+
+/-- **Addition formula** for Chebyshev polynomials of the first kind:
+`T_{m+n} = T_m · T_n − (1 − X²) · U_{m−1} · U_{n−1}`.
+
+This is the polynomial form of `cos(α+β) = cos α cos β − sin α sin β`: writing
+`x = cos θ`, the factor `1 − x²` is `sin² θ` and `U_{k−1}(x)·sin θ = sin(k θ)`.
+Mathlib records only the product-to-sum identity `T_mul_T`, not this. -/
+theorem T_add (m n : ℤ) :
+    T R (m + n) = T R m * T R n - (1 - X ^ 2) * U R (m - 1) * U R (n - 1) := by
+  induction n using Polynomial.Chebyshev.induct with
+  | zero => simp [T_zero, U_neg_one]
+  | one =>
+      have h := T_eq_X_mul_T_sub_pol_U R (m - 1)
+      rw [show m - 1 + 2 = m + 1 from by ring, show m - 1 + 1 = m from by ring] at h
+      simp only [T_one, sub_self, U_zero, mul_one]
+      linear_combination h
+  | add_two k ih1 ih2 =>
+      have h₁ := T_add_two R (m + k)
+      have hT := T_add_two R k
+      have hU := U_add_two R (k - 1)
+      linear_combination (norm := ring_nf)
+        h₁ + 2 * (X : R[X]) * ih1 - ih2 - T R m * hT
+          + (1 - (X : R[X]) ^ 2) * U R (m - 1) * hU
+  | neg_add_one k ih1 ih2 =>
+      have h₁ := T_sub_two R (m + (-(k : ℤ) + 1))
+      have hT := T_sub_two R (-(k : ℤ) + 1)
+      have hU := U_sub_two R (-(k : ℤ))
+      linear_combination (norm := ring_nf)
+        h₁ + 2 * (X : R[X]) * ih1 - ih2 - T R m * hT
+          + (1 - (X : R[X]) ^ 2) * U R (m - 1) * hU
+
+/-- **Subtraction formula** for the first kind:
+`T_{m−n} = T_m · T_n + (1 − X²) · U_{m−1} · U_{n−1}` — the `cos(α−β)` analog.
+Obtained from `T_add` at `−n` using `T_{-n} = Tₙ` and `U_{-n-1} = −U_{n-1}`. -/
+theorem T_sub (m n : ℤ) :
+    T R (m - n) = T R m * T R n + (1 - X ^ 2) * U R (m - 1) * U R (n - 1) := by
+  have h := T_add R m (-n)
+  rw [T_neg R n, U_neg_sub_one R n] at h
+  linear_combination (norm := ring_nf) h
+
+/-- **Pell / Pythagorean identity**: `Tₙ² + (1 − X²)·U_{n−1}² = 1`.
+This is the polynomial `cos²(nθ) + sin²(nθ) = 1`, and exhibits `(Tₙ, U_{n−1})`
+as a solution of the Pell equation `T² − (X² − 1)·U² = 1`.  It is the diagonal
+`m = n` of the subtraction formula, since `T_0 = 1`. -/
+theorem T_sq_add (n : ℤ) :
+    T R n ^ 2 + (1 - X ^ 2) * U R (n - 1) ^ 2 = 1 := by
+  have h := T_sub R n n
+  rw [sub_self, T_zero] at h
+  linear_combination (norm := ring_nf) -h
+
+/-- **Addition formula** for Chebyshev polynomials of the second kind:
+`U_{m+n} = U_m · T_n + T_{m+1} · U_{n−1}` — the polynomial form of
+`sin(α+β) = sin α cos β + cos α sin β`.  Mathlib does not record this. -/
+theorem U_add (m n : ℤ) :
+    U R (m + n) = U R m * T R n + T R (m + 1) * U R (n - 1) := by
+  induction n using Polynomial.Chebyshev.induct with
+  | zero => simp [T_zero, U_neg_one]
+  | one =>
+      have h := U_eq_X_mul_U_add_T R m
+      simp only [T_one, sub_self, U_zero, mul_one]
+      linear_combination h
+  | add_two k ih1 ih2 =>
+      have h₁ := U_add_two R (m + k)
+      have hT := T_add_two R k
+      have hU := U_add_two R (k - 1)
+      linear_combination (norm := ring_nf)
+        h₁ + 2 * (X : R[X]) * ih1 - ih2 - U R m * hT - T R (m + 1) * hU
+  | neg_add_one k ih1 ih2 =>
+      have h₁ := U_sub_two R (m + (-(k : ℤ) + 1))
+      have hT := T_sub_two R (-(k : ℤ) + 1)
+      have hU := U_sub_two R (-(k : ℤ))
+      linear_combination (norm := ring_nf)
+        h₁ + 2 * (X : R[X]) * ih1 - ih2 - U R m * hT - T R (m + 1) * hU
+
+/-! ### Concrete instances -/
+
+/-- `T_{2+3} = T₂·T₃ − (1 − X²)·U_{2−1}·U_{3−1}` over `ℤ`: the addition formula
+at `m = 2, n = 3`, stated with the indices exactly as the theorem produces them. -/
+example : T ℤ (2 + 3) = T ℤ 2 * T ℤ 3 - (1 - X ^ 2) * U ℤ (2 - 1) * U ℤ (3 - 1) :=
+  T_add ℤ 2 3
+
+/-- `U_{2+2} = U₂·T₂ + T_{2+1}·U_{2−1}` over `ℤ`: the second-kind addition formula
+at `m = n = 2`. -/
+example : U ℤ (2 + 2) = U ℤ 2 * T ℤ 2 + T ℤ (2 + 1) * U ℤ (2 - 1) :=
+  U_add ℤ 2 2
+
+end ChebyshevPolynomialsOQ01OQ01

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "chebyshev-polynomials-oq-01-oq-01",
+  "slug": "chebyshev-polynomials-oq-01-oq-01",
+  "title": "Chebyshev addition formulas: T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, and the second-kind companion",
+  "description": "The angle-addition formula for Chebyshev polynomials, the polynomial shadow of cos(α+β) = cos α cos β − sin α sin β: T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, over any commutative ring and for all integer indices. Mathlib records only the product-to-sum identity T_mul_T (2·T_m·T_k = T_{m+k} + T_{m−k}), not this addition law. The entry also proves the matching subtraction formula T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1}, the second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1} (the sin(α+β) analog, likewise absent from Mathlib), and the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1 obtained on the diagonal.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial", "Polynomial.Chebyshev"],
+    "namespace": "ChebyshevPolynomialsOQ01OQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPolynomialsOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "T_add",
+      "statement": "T R (m + n) = T R m * T R n - (1 - X^2) * U R (m-1) * U R (n-1)",
+      "description": "The Chebyshev addition formula of the first kind: the polynomial form of cos(α+β) = cos α cos β − sin α sin β, with (1−X²) playing the role of sin² and U_{k−1}(cos θ)·sin θ = sin(kθ). Proved by Mathlib's two-step integer induction Polynomial.Chebyshev.induct, the n=1 base being exactly T_eq_X_mul_T_sub_pol_U. Absent from Mathlib (which records only the product-to-sum T_mul_T)."
+    },
+    {
+      "name": "T_sub",
+      "statement": "T R (m - n) = T R m * T R n + (1 - X^2) * U R (m-1) * U R (n-1)",
+      "description": "The matching subtraction formula (the cos(α−β) analog), obtained from T_add at −n via T_{-n} = Tₙ (T_neg) and U_{-n-1} = −U_{n-1} (U_neg_sub_one)."
+    },
+    {
+      "name": "T_sq_add",
+      "statement": "T R n ^ 2 + (1 - X^2) * U R (n-1) ^ 2 = 1",
+      "description": "The Pell / Pythagorean identity, the polynomial cos²(nθ) + sin²(nθ) = 1. It exhibits (Tₙ, U_{n−1}) as a solution of the Pell equation T² − (X²−1)·U² = 1, and is the diagonal m = n of the subtraction formula since T_0 = 1."
+    },
+    {
+      "name": "U_add",
+      "statement": "U R (m + n) = U R m * T R n + T R (m+1) * U R (n-1)",
+      "description": "The Chebyshev addition formula of the second kind, the polynomial form of sin(α+β) = sin α cos β + cos α sin β. Proved by the same two-step induction, the n=1 base being exactly U_eq_X_mul_U_add_T. Likewise absent from Mathlib."
+    }
+  ],
+  "meta": {
+    "author": "Pafnuty Chebyshev (1854)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPolynomialsOQ01OQ01.lean",
+    "tags": [
+      "polynomials",
+      "chebyshev-polynomials",
+      "ring-theory",
+      "trigonometry",
+      "addition-formula",
+      "pell-equation",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.induct",
+        "description": "Two-step integer induction principle for Chebyshev polynomials (cases 0, 1, n+2 from n+1 and n, and the negative branch); the backbone of both addition formulas, used exactly as in Mathlib's own T_mul_T.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_add_two",
+        "description": "T R (n+2) = 2·X·T R (n+1) − T R n; the second-order recurrence collapsing the first-kind inductive step (with T_sub_two for the downward branch).",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_add_two",
+        "description": "U R (n+2) = 2·X·U R (n+1) − U R n; the second-kind recurrence (with U_sub_two for the downward branch).",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_eq_X_mul_T_sub_pol_U",
+        "description": "T R (n+2) = X·T R (n+1) − (1−X²)·U R n; reindexed at n = m−1 it is exactly the n=1 base case of the first-kind addition formula.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_eq_X_mul_U_add_T",
+        "description": "U R (n+1) = X·U R n + T R (n+1); exactly the n=1 base case of the second-kind addition formula.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_neg",
+        "description": "T R (−n) = T R n; lets the subtraction formula be derived from the addition formula at −n.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.U_neg_sub_one",
+        "description": "U R (−n−1) = −U R (n−1); the second-kind reflection that completes the addition→subtraction passage.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_mul_T",
+        "description": "2·T R m·T R k = T R (m+k) + T R (m−k); Mathlib's product-to-sum identity — the closest existing relative, and the one the addition formula complements.",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      }
+    ],
+    "originalContributions": [
+      "T_add: the first-kind angle-addition formula T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, absent from Mathlib (which has only the product-to-sum T_mul_T) — the polynomial cos(α+β) = cos α cos β − sin α sin β.",
+      "U_add: the second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}, the polynomial sin(α+β) = sin α cos β + cos α sin β, also absent from Mathlib.",
+      "T_sub: the subtraction formula T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1}, the cos(α−β) analog.",
+      "T_sq_add: the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1, exhibiting (Tₙ, U_{n−1}) as a solution of T² − (X²−1)·U² = 1 — the polynomial cos² + sin² = 1.",
+      "Concrete instances over ℤ: T_{2+3} and U_{2+2} expanded via the formulas."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. All four theorems depend only on propext, Classical.choice, Quot.sound. No native_decide, so no Lean.ofReduceBool.",
+    "lineCount": 135,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial", "Polynomial.Chebyshev"],
+    "namespace": "ChebyshevPolynomialsOQ01OQ01",
+    "path": "Proofs/ChebyshevPolynomialsOQ01OQ01.lean"
+  },
+  "overview": {
+    "historicalContext": "The Chebyshev polynomials of the first and second kind, Tₙ and Uₙ, are defined by Tₙ(cos θ) = cos(nθ) and Uₙ(cos θ)·sin θ = sin((n+1)θ). Their addition formulas are the algebraic encodings of the classical angle-sum identities for sine and cosine, and they underlie the Chebyshev recurrences, the Pell-equation connection (Tₙ² − (x²−1)Uₙ₋₁² = 1), and the use of Chebyshev polynomials throughout approximation theory and numerical analysis. The parent entry recorded the composition law T_{mn} = T_m ∘ T_n; this entry records the complementary additive structure.",
+    "problemStatement": "Mathlib's Chebyshev API (Mathlib.RingTheory.Polynomial.Chebyshev) includes the recurrences, the product-to-sum identity T_mul_T (2·T_m·T_k = T_{m+k} + T_{m−k}), and the composition law T_mul, but no genuine angle-addition formula expressing T_{m+n} (or U_{m+n}) directly in terms of the m-th and n-th polynomials. Supply these.\n\n**Answer:** T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} and U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}, over any commutative ring R and all integers m, n, together with the subtraction formula and the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1.",
+    "proofStrategy": "1. T_add: induct on n with Polynomial.Chebyshev.induct. The n=0 base uses T_0 = 1 and U_{−1} = 0; the n=1 base is exactly T_eq_X_mul_T_sub_pol_U reindexed at m−1. Each second-order step is closed by linear_combination over the recurrences T_add_two (on the shifted index m+k) and U_add_two, mirroring Mathlib's own T_mul_T proof; the downward branch uses T_sub_two / U_sub_two. ring_nf normalizes the integer indices appearing inside T R (·) and U R (·).\n2. U_add: the same induction, with U_add_two for the head and the n=1 base U_eq_X_mul_U_add_T.\n3. T_sub: specialize T_add at −n and simplify with T_neg and U_neg_sub_one.\n4. T_sq_add: take T_sub on the diagonal m = n, where the left side collapses to T_0 = 1.",
+    "keyInsights": [
+      "**The factor (1 − X²) is sin².** Under x = cos θ, 1 − x² = sin² θ, and Mathlib's U_real_cos gives U_{k−1}(cos θ)·sin θ = sin(kθ). So (1−X²)·U_{m−1}·U_{n−1} evaluated at cos θ is exactly sin(mθ)·sin(nθ), and T_add is the polynomial cos(α+β) = cos α cos β − sin α sin β. This is why the second term cannot be written in T alone — it is genuinely a second-kind (sine) contribution.",
+      "**Mathlib has product-to-sum but not addition.** T_mul_T gives T_{m+k} + T_{m−k} coupled together; isolating T_{m+n} from it reintroduces T_{m−n}. The addition formula here is the decoupled form, expressing T_{m+n} purely from the m-th and n-th data — the form needed for, e.g., a single-step angle increment.",
+      "**Both formulas reduce to a Mathlib mixed recurrence at n = 1.** The whole induction rests on two facts Mathlib already proves: T_eq_X_mul_T_sub_pol_U and U_eq_X_mul_U_add_T are precisely the n=1 instances, so no new base-case computation is needed.",
+      "**The diagonal is the Pell/Pythagorean identity.** Setting m = n in the subtraction formula and using T_0 = 1 yields Tₙ² + (1−X²)·U_{n−1}² = 1, i.e. Tₙ² − (X²−1)·U_{n−1}² = 1 — the defining Pell relation of the Chebyshev pair and the polynomial cos² + sin² = 1."
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first and second kind over a commutative ring",
+      "The integer-indexed Chebyshev recurrences",
+      "The sine and cosine angle-addition identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports Mathlib, opens Polynomial and Polynomial.Chebyshev, fixes a commutative ring R, and states the goal: supply the angle-addition formulas Mathlib omits, namely T_{m+n} and U_{m+n} in terms of the m-th and n-th polynomials, plus the subtraction and Pell/Pythagorean corollaries.",
+      "mathContext": "$T_{m+n} = T_mT_n - (1-X^2)U_{m-1}U_{n-1}$, the polynomial $\\cos(\\alpha+\\beta)=\\cos\\alpha\\cos\\beta-\\sin\\alpha\\sin\\beta$."
+    },
+    {
+      "id": "t-add",
+      "title": "First-kind Addition Formula",
+      "startLine": 50,
+      "endLine": 81,
+      "summary": "T_add proves T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} by Polynomial.Chebyshev.induct on n. Base cases: n=0 via T_0=1, U_{−1}=0; n=1 via the reindexed T_eq_X_mul_T_sub_pol_U. Inductive steps close by linear_combination over T_add_two/U_add_two (and T_sub_two/U_sub_two on the negative branch), with ring_nf normalizing the integer indices.",
+      "mathContext": "$T_{m+n} = T_mT_n - (1-X^2)U_{m-1}U_{n-1}$."
+    },
+    {
+      "id": "t-sub-sq",
+      "title": "Subtraction Formula and Pell Identity",
+      "startLine": 82,
+      "endLine": 100,
+      "summary": "T_sub derives T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1} from T_add at −n using T_neg and U_neg_sub_one. T_sq_add specializes the subtraction formula to the diagonal m = n, where the left side becomes T_0 = 1, giving the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1.",
+      "mathContext": "$T_n^2 + (1-X^2)U_{n-1}^2 = 1$, equivalently $T_n^2 - (X^2-1)U_{n-1}^2 = 1$."
+    },
+    {
+      "id": "u-add",
+      "title": "Second-kind Addition Formula",
+      "startLine": 101,
+      "endLine": 122,
+      "summary": "U_add proves U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1} by the same two-step induction, with the n=1 base supplied directly by Mathlib's U_eq_X_mul_U_add_T. This is the polynomial form of sin(α+β) = sin α cos β + cos α sin β.",
+      "mathContext": "$U_{m+n} = U_mT_n + T_{m+1}U_{n-1}$, the polynomial $\\sin(\\alpha+\\beta)$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "startLine": 123,
+      "endLine": 135,
+      "summary": "Two examples over ℤ instantiating the formulas at small indices: T_{2+3} = T₂·T₃ − (1−X²)·U₁·U₂ and U_{2+2} = U₂·T₂ + T₃·U₁, each closed by the corresponding theorem.",
+      "mathContext": "$T_5 = T_2T_3 - (1-X^2)U_1U_2$; $U_4 = U_2T_2 + T_3U_1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Chebyshev angle-addition formulas are established over an arbitrary commutative ring and all integer indices: T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} for the first kind and U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1} for the second, together with the subtraction formula and the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1. Fully machine-checked, 0 sorries, 0 axioms.",
+    "implications": "Mathlib's Chebyshev API carries the recurrences, the product-to-sum identity T_mul_T, and the composition law, but no decoupled addition formula expressing T_{m+n} (or U_{m+n}) from the m-th and n-th polynomials directly. These fill that gap and make the trigonometric origin explicit: under x = cos θ the (1−X²) factor is sin² θ and U_{k−1}(cos θ)·sin θ = sin(kθ), so the identities are precisely the polynomial cos and sin angle-sum laws. The diagonal Pell identity packages the Chebyshev pair as the canonical solution of T² − (X²−1)U² = 1. The proofs reuse Mathlib's own induction template (the same one behind T_mul_T), so the cost is a short linear_combination per case.",
+    "openQuestions": [
+      "Does the matrix form [[T_{m+n}, ·],[·, ·]] = [[T_m, ·],[·, ·]]·[[T_n, ·],[·, ·]] (the 2×2 'Chebyshev rotation' whose powers generate T and U) admit a clean Lean statement, packaging T_add, U_add and the Pell identity as a single SL₂-style multiplicativity?",
+      "Can the addition formulas be promoted to a generating-function or exponential identity ∑ Tₙ tⁿ relating the first- and second-kind families, recovering the closed forms (1−Xt)/(1−2Xt+t²) and 1/(1−2Xt+t²)?"
+    ]
+  },
+  "references": [
+    {
+      "title": "Chebyshev polynomials — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev_polynomials"
+    },
+    {
+      "title": "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Polynomial/Chebyshev.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Chebyshev angle-addition formulas (Mathlib gap)

Follow-up to **chebyshev-polynomials-oq-01** (composition law). Mathlib's Chebyshev API has the recurrences, the product-to-sum identity `T_mul_T` (`2·T_m·T_k = T_{m+k} + T_{m−k}`), and the composition law `T_mul`, but **no genuine angle-addition formula** expressing `T_{m+n}` / `U_{m+n}` directly from the m-th and n-th polynomials. This entry supplies them.

| theorem | statement | trig analog |
|---|---|---|
| `T_add` | `T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}` | `cos(α+β)=cosα cosβ − sinα sinβ` |
| `U_add` | `U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}` | `sin(α+β)=sinα cosβ + cosα sinβ` |
| `T_sub` | `T_{m−n} = T_m·T_n + (1−X²)·U_{m−1}·U_{n−1}` | `cos(α−β)` |
| `T_sq_add` | `Tₙ² + (1−X²)·U_{n−1}² = 1` | `cos²+sin²=1` (Pell `T²−(X²−1)U²=1`) |

The `(1−X²)` factor is `sin²` under `x=cos θ`, since `U_{k−1}(cos θ)·sin θ = sin(kθ)`.

### Proof
Two-step integer induction `Polynomial.Chebyshev.induct` (the same template Mathlib uses for `T_mul_T`), each step closed by `linear_combination` over `T_add_two`/`U_add_two` (and `T_sub_two`/`U_sub_two` on the negative branch); `ring_nf` normalizes the integer indices inside `T R (·)`/`U R (·)`. The `n=1` base cases are exactly Mathlib's mixed recurrences `T_eq_X_mul_T_sub_pol_U` and `U_eq_X_mul_U_add_T`, so no new base computation is needed. `T_sub` follows from `T_add` at `−n`; `T_sq_add` is its diagonal.

### Verification
Over any `CommRing R`, all integer indices. **4 theorems, 135 lines, 0 sorries, 0 axioms** (depends only on `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`). Built via `lake env lean` (docker unavailable); `#print axioms` confirms all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)