### PR TITLE
research(burnside-counting-oq-04-oq-01-oq-01): unconditional bracelet counts b(5)=8, b(6)=13 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ01OQ01.lean
@@ -1,0 +1,191 @@
+import Mathlib
+
+/-
+# Burnside Counting, OQ-04-OQ-01-OQ-01: unconditional bracelet counts `b(5) = 8`, `b(6) = 13`
+
+## What This Proves
+
+The grandparent `burnside-counting-oq-04` reduced dihedral *bracelet* counting to cyclic
+*necklace* counting via the index-2 folding identity, and the parent
+`burnside-counting-oq-04-oq-01` (`BurnsideCountingOQ04OQ01.lean`) built a *concrete* dihedral
+action on the binary colourings of the `4`-cycle and discharged the length-`4` bracelet count
+`6` unconditionally (kernel `decide`, no `native_decide`, no axioms beyond the foundational
+three).  Its open question OQ-01 asks for the obvious next instances — the binary bracelet
+counts for `n = 5` and `n = 6`, the first two lengths where the dihedral group genuinely
+exceeds the cyclic one (odd `5`, even `6` exercise both reflection types).
+
+This file answers it.  Rather than hard-code one length, we build the dihedral action of
+`DihedralGroup n` on the colourings `ZMod n → Fin 2` **generically in `n`**, prove it is a
+genuine `MulAction` (so Burnside's lemma applies for every `n`), and then read off
+
+      `Fintype.card (orbitRel.Quotient (DihedralGroup 5) (Coloring 5)) = 8`
+      `Fintype.card (orbitRel.Quotient (DihedralGroup 6) (Coloring 6)) = 13`
+
+by evaluating the Burnside fixed-point sum with *kernel* `decide`.  These are the values
+`A000029(5) = 8` and `A000029(6) = 13` of the OEIS "number of binary bracelets" sequence.
+
+## How
+
+The action is the faithful permutation representation of `D_n` on its `n` vertices,
+  `r i  ↦  (x ↦ x + i)`        (rotation by `i`),
+  `sr i ↦  (x ↦ -i - x)`       (reflection),
+lifted to colourings by `(g • c) p = c ((ρ g)⁻¹ p)`.  That `ρ : D_n → Perm (ZMod n)` is a
+homomorphism is checked against Mathlib's dihedral multiplication table (`r_mul_r`,
+`r_mul_sr`, `sr_mul_r`, `sr_mul_sr`), giving the `MulAction` laws on the nose — **for all `n`**.
+
+Burnside's lemma (`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`) then reads
+
+      `∑_{g ∈ D_n} |Fix(g)|  =  |Coloring / D_n| · |D_n|`,
+
+and `|D_n| = 2n` (`DihedralGroup.card`).  The fixed-point sum is `80` for `n = 5`
+(`= 8 · 10`) and `156` for `n = 6` (`= 13 · 12`), each discharged by kernel `decide`
+(`10` group elements × `32` colourings; `12` × `64`), so the orbit counts are `8` and `13`.
+
+## Honesty / Scope
+
+The mathematical content is the *generic* concrete dihedral action (the parent built only the
+single length-`4` instance) plus the two unconditional, axiom-free (kernel-`decide`, not
+`native_decide`) bracelet counts.  Burnside's lemma is Mathlib's; the folding identity is the
+grandparent's.  `#print axioms` on each headline confirms only `propext`, `Classical.choice`,
+`Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
+-/
+
+namespace BurnsideBracelets
+
+open Finset MulAction
+
+/-! ## Part I: the generic dihedral permutation representation -/
+
+/-- A binary colouring of the `n` vertices of the `n`-cycle. There are `2^n` of them. -/
+abbrev Coloring (n : ℕ) : Type := ZMod n → Fin 2
+
+/-- The faithful permutation representation of `DihedralGroup n` on the `n` vertices
+(`ZMod n`): rotations `r i` act by `x ↦ x + i`, reflections `sr i` act by `x ↦ -i - x`. The
+reflection form `-i - x` (rather than `i - x`) is what makes the assignment a *homomorphism*
+for Mathlib's dihedral convention `sr i * sr j = r (j - i)`. -/
+def posPerm {n : ℕ} : DihedralGroup n → Equiv.Perm (ZMod n)
+  | .r i => Equiv.addRight i
+  | .sr i => Equiv.subLeft (-i)
+
+@[simp] theorem posPerm_r {n : ℕ} (i : ZMod n) : posPerm (.r i) = Equiv.addRight i := rfl
+@[simp] theorem posPerm_sr {n : ℕ} (i : ZMod n) : posPerm (.sr i) = Equiv.subLeft (-i) := rfl
+
+/-- `posPerm` sends the identity to the identity permutation. -/
+theorem posPerm_one {n : ℕ} : posPerm (1 : DihedralGroup n) = 1 := by
+  ext x
+  show (Equiv.addRight (0 : ZMod n)) x = x
+  simp
+
+/-- **`posPerm` is multiplicative.** Checked case-by-case against Mathlib's dihedral
+multiplication table; every case reduces to a `ZMod n` arithmetic identity after `ext`. -/
+theorem posPerm_mul {n : ℕ} (g h : DihedralGroup n) :
+    posPerm (g * h) = posPerm g * posPerm h := by
+  cases g with
+  | r i =>
+    cases h with
+    | r j => ext x; simp [DihedralGroup.r_mul_r, add_comm, add_left_comm]
+    | sr j => ext x; simp [DihedralGroup.r_mul_sr]; ring
+  | sr i =>
+    cases h with
+    | r j => ext x; simp [DihedralGroup.sr_mul_r]; ring
+    | sr j => ext x; simp [DihedralGroup.sr_mul_sr]; ring
+
+/-- The bundled homomorphism `ρ : DihedralGroup n →* Equiv.Perm (ZMod n)`. -/
+def ρ {n : ℕ} : DihedralGroup n →* Equiv.Perm (ZMod n) where
+  toFun := posPerm
+  map_one' := posPerm_one
+  map_mul' := posPerm_mul
+
+/-! ## Part II: the induced action on colourings -/
+
+/-- The dihedral action on colourings: a symmetry `g` relabels positions by `ρ g`, sending the
+colouring `c` to `p ↦ c ((ρ g)⁻¹ p)`.  This is a genuine left `MulAction` because `ρ` is a
+homomorphism — and it is defined uniformly in `n`. -/
+instance instMulAction {n : ℕ} : MulAction (DihedralGroup n) (Coloring n) where
+  smul g c := fun p => c ((ρ g).symm p)
+  one_smul c := by
+    funext p; show c ((ρ (1 : DihedralGroup n)).symm p) = c p; rw [ρ.map_one]; rfl
+  mul_smul g h c := by
+    funext p
+    show c ((ρ (g * h)).symm p) = c ((ρ h).symm ((ρ g).symm p))
+    rw [ρ.map_mul]; rfl
+
+/-- Unfold the action pointwise (handy for the fixed-point computations). -/
+theorem smul_apply {n : ℕ} (g : DihedralGroup n) (c : Coloring n) (p : ZMod n) :
+    (g • c) p = c ((ρ g).symm p) := rfl
+
+/-! ## Part III: Fintype / decidability instances for Burnside's lemma -/
+
+instance decFixed {n : ℕ} [NeZero n] (g : DihedralGroup n) :
+    DecidablePred (fun c : Coloring n => g • c = c) := fun c => decEq (g • c) c
+
+instance fintypeFixedBy {n : ℕ} [NeZero n] (g : DihedralGroup n) :
+    Fintype (fixedBy (Coloring n) g) := Subtype.fintype _
+
+instance decOrbitRel {n : ℕ} [NeZero n] :
+    DecidableRel (orbitRel (DihedralGroup n) (Coloring n)).r := fun a b =>
+  decidable_of_iff (∃ g : DihedralGroup n, g • b = a) MulAction.mem_orbit_iff.symm
+
+noncomputable instance fintypeQuot {n : ℕ} [NeZero n] :
+    Fintype (orbitRel.Quotient (DihedralGroup n) (Coloring n)) := by
+  letI s : Setoid (Coloring n) := orbitRel (DihedralGroup n) (Coloring n)
+  haveI : DecidableRel (α := Coloring n) (· ≈ ·) := fun a b =>
+    decidable_of_iff (∃ g : DihedralGroup n, g • b = a) MulAction.mem_orbit_iff.symm
+  exact Quotient.fintype _
+
+/-! ## Part IV: the generic Burnside reduction -/
+
+/-- **Generic Burnside count.** If the dihedral fixed-point sum equals `S`, then the bracelet
+count (number of orbits) satisfies `bracelets · 2n = S`.  Specialising `S` and dividing by
+`2n` yields the individual counts below. -/
+theorem bracelet_count_mul {n : ℕ} [NeZero n] (S : ℕ)
+    (hS : ∑ g : DihedralGroup n, Fintype.card (fixedBy (Coloring n) g) = S) :
+    Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n)) * (2 * n) = S := by
+  have hb :
+      ∑ g : DihedralGroup n, Fintype.card (fixedBy (Coloring n) g)
+        = Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n))
+            * Fintype.card (DihedralGroup n) :=
+    MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (DihedralGroup n) (Coloring n)
+  rw [hS, DihedralGroup.card] at hb
+  omega
+
+/-! ## Part V: the two unconditional bracelet counts -/
+
+/-- The Burnside fixed-point sum for `n = 5` is `80`, by *kernel* `decide`
+(`10` dihedral symmetries × `32` binary colourings of the pentagon: the identity fixes `32`,
+the four non-trivial rotations fix `2` each, the five reflections fix `2^3 = 8` each;
+`32 + 4·2 + 5·8 = 80`). -/
+theorem fixed_sum_five :
+    ∑ g : DihedralGroup 5, Fintype.card (fixedBy (Coloring 5) g) = 80 := by
+  decide
+
+/-- **There are exactly `8` binary bracelets of length `5`** — unconditionally
+(`A000029(5) = 8`).  Burnside turns the fixed-point sum `80` and `|D₅| = 10` into the orbit
+count `80 / 10 = 8`. -/
+theorem bracelet_five :
+    Fintype.card (orbitRel.Quotient (DihedralGroup 5) (Coloring 5)) = 8 := by
+  have h := bracelet_count_mul 80 fixed_sum_five
+  omega
+
+/-- The Burnside fixed-point sum for `n = 6` is `156`, by *kernel* `decide`
+(`12` dihedral symmetries × `64` binary colourings of the hexagon: rotations contribute
+`64 + 2 + 4 + 8 + 4 + 2 = 84`, the three vertex-axis reflections fix `2^4 = 16` each and the
+three edge-axis reflections fix `2^3 = 8` each, `84 + 3·16 + 3·8 = 156`). -/
+theorem fixed_sum_six :
+    ∑ g : DihedralGroup 6, Fintype.card (fixedBy (Coloring 6) g) = 156 := by
+  decide
+
+/-- **There are exactly `13` binary bracelets of length `6`** — unconditionally
+(`A000029(6) = 13`).  Burnside turns the fixed-point sum `156` and `|D₆| = 12` into the orbit
+count `156 / 12 = 13`. -/
+theorem bracelet_six :
+    Fintype.card (orbitRel.Quotient (DihedralGroup 6) (Coloring 6)) = 13 := by
+  have h := bracelet_count_mul 156 fixed_sum_six
+  omega
+
+end BurnsideBracelets
+
+-- Axiom audit: only the standard foundational axioms, in particular no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideBracelets.bracelet_five
+#print axioms BurnsideBracelets.bracelet_six

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "burnside-counting-oq-04-oq-01-oq-01",
+  "title": "Unconditional Binary Bracelet Counts b(5) = 8, b(6) = 13 via a Generic Dihedral Action",
+  "slug": "burnside-counting-oq-04-oq-01-oq-01",
+  "description": "Answers the first open question of burnside-counting-oq-04-oq-01: generalise its concrete length-4 dihedral action and kernel-decided fixed-point sum to D_n, recovering the binary bracelet counts b(5) = 8 and b(6) = 13 unconditionally (OEIS A000029). Where the parent hard-codes n = 4, this entry builds the faithful permutation representation ρ : DihedralGroup n →* Equiv.Perm (ZMod n), r i ↦ (x ↦ x + i) and sr i ↦ (x ↦ -i - x), GENERICALLY in n — the reflection form -i-x (not i-x) is what makes ρ a homomorphism for Mathlib's dihedral convention sr i * sr j = r (j - i) — and lifts it to colourings Coloring n = ZMod n → Fin 2 by (g • c) p = c ((ρ g)⁻¹ p), a genuine MulAction for every n because ρ is a hom. A single generic lemma bracelet_count_mul packages Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) with DihedralGroup.card to give bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)|. Specialising, the fixed-point sums are 80 for n = 5 (= 8 · 10) and 156 for n = 6 (= 13 · 12), each discharged by KERNEL decide (10 symmetries × 32 colourings; 12 × 64), so the orbit counts are 8 and 13. The n = 5 case (odd) exercises the single reflection type, n = 6 (even) both vertex- and edge-axis reflections. #print axioms on both headlines confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius (researcher-7)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "necklaces",
+      "orbit-counting",
+      "kernel-decide",
+      "native-decide-free",
+      "oeis-a000029"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside's lemma: Σ_{g∈G} |Fix(g)| = |X/G|·|G|. Instantiated at the generic dihedral action to convert each kernel-decided fixed-point sum into the bracelet (orbit) count.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "DihedralGroup.r_mul_r / r_mul_sr / sr_mul_r / sr_mul_sr",
+        "description": "The dihedral multiplication table, against which posPerm_mul (homomorphism property of ρ) is verified case by case, for general n.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      },
+      {
+        "theorem": "DihedralGroup.card",
+        "description": "|DihedralGroup n| = 2n (needs NeZero n), used as |D₅| = 10 and |D₆| = 12 in the Burnside divisions 80 = b(5)·10 and 156 = b(6)·12.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      },
+      {
+        "theorem": "Equiv.addRight / Equiv.subLeft",
+        "description": "The concrete permutations of ZMod n realising rotations (x ↦ x + i) and reflections (x ↦ -i - x); their kernel-reducible application is what lets decide evaluate the fixed-point counts at n = 5 and n = 6.",
+        "module": "Mathlib.Algebra.Group.Equiv.Basic"
+      },
+      {
+        "theorem": "Quotient.fintype",
+        "description": "Builds the Fintype on the orbit quotient from the finite colouring carrier and the decidable orbit relation, so the bracelet count Fintype.card is well-defined.",
+        "module": "Mathlib.Data.Fintype.Quotient"
+      }
+    ],
+    "originalContributions": [
+      "posPerm / ρ generalised to all n: a concrete faithful representation DihedralGroup n →* Equiv.Perm (ZMod n), r i ↦ (x ↦ x+i), sr i ↦ (x ↦ -i-x), with the homomorphism property posPerm_mul proved case-by-case against the dihedral multiplication table — the parent oq-04-oq-01 built only the single n = 4 instance",
+      "the induced generic MulAction (DihedralGroup n) (ZMod n → Fin 2) lifting the position permutation to colourings by (g • c) p = c ((ρ g)⁻¹ p), with one_smul / mul_smul discharged from ρ being a hom, for every n",
+      "bracelet_count_mul: a single generic Burnside reduction bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)|, so each individual count is one decide plus one omega",
+      "fixed_sum_five / bracelet_five: Σ_{g ∈ D₅} |Fix(g)| = 80 by KERNEL decide (10 × 32) ⇒ Fintype.card (orbitRel.Quotient (DihedralGroup 5) (ZMod 5 → Fin 2)) = 8 = A000029(5), 0 axioms beyond propext / Classical.choice / Quot.sound",
+      "fixed_sum_six / bracelet_six: Σ_{g ∈ D₆} |Fix(g)| = 156 by KERNEL decide (12 × 64) ⇒ Fintype.card (orbitRel.Quotient (DihedralGroup 6) (ZMod 6 → Fin 2)) = 13 = A000029(6), exercising both vertex-axis and edge-axis reflection types, 0 axioms beyond the foundational three"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, and no native_decide: each fixed-point sum (80 for n=5, 156 for n=6) is discharged by kernel decide, so both headline theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — in particular no Lean.ofReduceBool and no sorryAx).",
+    "lineCount": 191,
+    "theoremCount": 8,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts orbits of a finite group action as the average number of fixed points. For the cyclic rotation group ℤ/nℤ on the beads of an n-cycle it yields the necklace numbers; for the dihedral group D_n, which adjoins the n reflections, it yields the bracelet numbers (OEIS A000029: 1, 2, 3, 4, 6, 8, 13, 18, 30, … for n = 0, 1, 2, …). The parent burnside-counting-oq-04-oq-01 built a concrete dihedral action only for n = 4 and recovered b(4) = 6 by an axiom-free kernel computation; its open question asks for the next instances n = 5 and n = 6 — the first lengths where odd and even reflection behaviour genuinely differ. Making the construction generic in n and reading off b(5) = 8 and b(6) = 13 by kernel decide is the natural completion.",
+    "problemStatement": "Generalise the concrete dihedral action and kernel-decided fixed-point sum of burnside-counting-oq-04-oq-01 from n = 4 to general n, and recover the binary bracelet counts b(5) = 8 and b(6) = 13 unconditionally — without native_decide (kernel decide only).",
+    "text": "With ρ : DihedralGroup n →* Equiv.Perm (ZMod n) the faithful representation r i ↦ (·+i), sr i ↦ (-i-·), and the colouring action (g • c) p = c ((ρ g)⁻¹ p), Burnside gives bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)|. Kernel decide evaluates the sum to 80 at n = 5 (so b(5) = 8) and to 156 at n = 6 (so b(6) = 13).",
+    "proofStrategy": "Build the permutation representation ρ once, generically in n: rotations r i act on positions by x ↦ x + i and reflections sr i by x ↦ -i - x; the form -i-x is dictated by Mathlib's convention sr i * sr j = r (j - i), and posPerm_mul checks the homomorphism property in all four (r/sr)×(r/sr) cases by ext + ZMod arithmetic. Lift to colourings via (g • c) p = c ((ρ g)⁻¹ p); one_smul and mul_smul follow from ρ.map_one and ρ.map_mul. Register DecidablePred / Fintype instances for the fixed-point sets (needing NeZero n for DecidableEq of the function colourings) and a decidable orbit relation for the quotient Fintype. A single generic lemma bracelet_count_mul applies Burnside and rewrites |D_n| = 2n via DihedralGroup.card to give bracelets · 2n = Σ |Fix(g)|. Then for n = 5 and n = 6 the fixed-point sum is the only computation: kernel decide returns 80 (10 symmetries × 32 colourings) and 156 (12 × 64), and omega divides out to b(5) = 8 and b(6) = 13. The orbit quotient itself is never enumerated by decide — only the cheap fixed-point sum is — which keeps the computation within kernel reach.",
+    "keyInsights": [
+      "The whole construction is uniform in n: posPerm, the homomorphism ρ, and the MulAction are stated once for DihedralGroup n acting on ZMod n → Fin 2, so each new bracelet count costs only one kernel decide of the fixed-point sum plus one omega division — the parent's per-n hand-build is unnecessary",
+      "Burnside avoids enumerating the orbit quotient (the expensive step the grandparent closed with native_decide): only the fixed-point sum needs evaluation, and that stays light enough for kernel decide even at n = 6 (12 × 64 colourings over Fin-based data)",
+      "n = 5 (odd) and n = 6 (even) are the smallest cases separating the two reflection regimes — odd n has n axes each through one vertex (fixing 2^((n+1)/2)), even n has n/2 vertex-axes (fixing 2^(n/2+1)) and n/2 edge-axes (fixing 2^(n/2)) — and both fall out of the same generic sum",
+      "DecidableEq of the colourings ZMod n → Fin 2 requires Fintype (ZMod n), hence the NeZero n hypothesis on the decidability instances; representing positions as ZMod n and colours as Fin 2 keeps every object Fin-based so kernel reduction stays cheap"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
+      "The dihedral group DihedralGroup n and its multiplication table",
+      "Decidable equality and Fintype enumeration for kernel decide"
+    ]
+  },
+  "sections": [
+    {
+      "id": "representation",
+      "title": "The Generic Faithful Dihedral Representation ρ",
+      "startLine": 57,
+      "endLine": 97,
+      "summary": "posPerm sends r i ↦ (x ↦ x+i) and sr i ↦ (x ↦ -i-x) on ZMod n; posPerm_mul verifies the homomorphism property against the dihedral multiplication table for all n, packaged as ρ : DihedralGroup n →* Equiv.Perm (ZMod n).",
+      "mathContext": "$\\rho(r_i)(x) = x + i,\\quad \\rho(s r_i)(x) = -i - x \\quad (\\text{in } \\mathbb{Z}/n).$"
+    },
+    {
+      "id": "action",
+      "title": "The Induced Generic Action on Colourings",
+      "startLine": 99,
+      "endLine": 134,
+      "summary": "(g • c) p = c ((ρ g)⁻¹ p) is a genuine MulAction of D_n on Coloring n = ZMod n → Fin 2 because ρ is a homomorphism; DecidablePred / Fintype instances (needing NeZero n) and a decidable orbit relation follow.",
+      "mathContext": "$(g \\cdot c)(p) = c\\big((\\rho g)^{-1} p\\big).$"
+    },
+    {
+      "id": "count",
+      "title": "Burnside Reduction and the Counts b(5), b(6)",
+      "startLine": 136,
+      "endLine": 188,
+      "summary": "bracelet_count_mul gives bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)| from Burnside and DihedralGroup.card; kernel decide evaluates the sum to 80 at n = 5 and 156 at n = 6, so b(5) = 80/10 = 8 and b(6) = 156/12 = 13.",
+      "mathContext": "$\\sum_{g \\in D_n} |\\mathrm{Fix}(g)| = b(n)\\cdot 2n;\\ 80 = 8\\cdot 10,\\ 156 = 13\\cdot 12.$"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral bracelet counts (OEIS A000029)"
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A000029: Number of necklaces (bracelets) with n beads of 2 colors, allowing turning over",
+      "year": "2024",
+      "note": "b(5) = 8, b(6) = 13 are the n = 5, 6 terms"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04-oq-01",
+      "relationship": "answers",
+      "description": "Answers the first open question of oq-04-oq-01: generalises its single length-4 concrete dihedral action and kernel-decided fixed-point sum to D_n and recovers b(5) = 8 and b(6) = 13 unconditionally."
+    },
+    {
+      "targetId": "burnside-counting-oq-04",
+      "relationship": "extends",
+      "description": "Extends the index-2 folding bracelet count of oq-04 to concrete unconditional values at n = 5 and n = 6 via the generic dihedral action, with no assumed necklace or reflection totals."
+    }
+  ],
+  "conclusion": {
+    "summary": "Making the concrete dihedral action ρ : DihedralGroup n →* Equiv.Perm (ZMod n) generic in n turns the parent's single length-4 bracelet count into a uniform machine: Burnside plus one kernel-decided fixed-point sum gives b(5) = 80/10 = 8 and b(6) = 156/12 = 13 unconditionally, with no native_decide and 0 axioms beyond propext / Classical.choice / Quot.sound.",
+    "implications": "Each binary bracelet number b(n) is now one kernel decide away, as long as the fixed-point sum stays within kernel reach; the generic action also makes the framework reusable for k-colour bracelets (Fin k) and for combining with the rotation/reflection fixed-point formulas toward a closed form.",
+    "openQuestions": [
+      "Push the kernel-decided fixed-point sum to larger n (n = 7, 8, …) and chart precisely where kernel decide stops being feasible and native_decide (or a symbolic per-element fixed-point formula) becomes necessary.",
+      "Replace the per-n kernel decide by a proof that Σ_{g ∈ D_n} |Fix(g)| = Σ_{r} 2^{gcd(n,r)} + (reflection contribution), giving a closed form for b(n) = A000029(n) with no computation at all."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction"
+    ],
+    "namespace": "BurnsideBracelets",
+    "lineCount": 191,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/BurnsideCountingOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `burnside-counting-oq-04-oq-01`: generalise its concrete length-4 dihedral action and kernel-decided fixed-point sum to `D_n`, recovering the binary bracelet counts **b(5) = 8** and **b(6) = 13** unconditionally (OEIS A000029).

## What's new vs. the parent

The parent hard-codes `n = 4`. This entry builds the faithful representation **generically in n**:

```
ρ : DihedralGroup n →* Equiv.Perm (ZMod n),   r i ↦ (x ↦ x + i),   sr i ↦ (x ↦ -i - x)
```

lifted to colourings `Coloring n = ZMod n → Fin 2` by `(g • c) p = c ((ρ g)⁻¹ p)` — a genuine `MulAction` for every `n` because `ρ` is a homomorphism (`posPerm_mul` checks all four (r/sr)×(r/sr) cases against Mathlib's dihedral table). A single generic lemma `bracelet_count_mul` packages Burnside's lemma with `DihedralGroup.card` to give `bracelets · 2n = Σ_{g ∈ D_n} |Fix(g)|`.

Specialising, the fixed-point sums are **80** for n=5 (= 8·10) and **156** for n=6 (= 13·12), each discharged by **kernel `decide`** (10×32 and 12×64). The n=5 case (odd) exercises the single reflection type; n=6 (even) both vertex- and edge-axis reflections.

## Verification

- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.
- **No `native_decide`** — fixed-point sums use kernel `decide`.
- `#print axioms` on both `bracelet_five` and `bracelet_six`: only `propext`, `Classical.choice`, `Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
- Type-checked against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)