### PR TITLE
Enrich Binary Bracelet Counts b(5)=8, b(6)=13 (burnside-counting-oq-04-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BurnsideCountingOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const burnsideCountingOQ04OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const burnsideCountingOQ04OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const burnsideCountingOQ04OQ01OQ01Data: ProofData = {
+  proof: burnsideCountingOQ04OQ01OQ01Proof,
+  annotations: burnsideCountingOQ04OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04-oq-01-oq-01` (quality 39, pass 0).

## Critical fix
- **Added missing `index.ts`** — without the Vite entry point the proof page renders 'proof not found' on the live site.

## Annotation coverage (new `annotations.json`)
5 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Overview — from a hard-coded n=4 to a generic dihedral action
2. The generic faithful dihedral representation ρ
3. The induced action on colourings and its decidability
4. The generic Burnside reduction
5. The two unconditional counts b(5)=8, b(6)=13

## Axiom integrity (checked)
The Lean file uses **kernel `decide`** (no `native_decide`) for the fixed-point sums, with an in-file `#print axioms` audit. So `status: verified`, `badge: verified`, `axiomCount: 0` is honest — only propext / Classical.choice / Quot.sound, no Lean.ofReduceBool, no sorryAx. Meta claims accurate.