### PR TITLE
audit: mark 8 recent merges clean (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21451,6 +21451,54 @@
       "lastAudited": "2026-06-24T12:47:36Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq-02-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "birthday-problem-oq-02-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "burnside-counting-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq-01-oq-01-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-polynomials-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-10-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ptolemys-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "repunit-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:09:13Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 8 never-audited recent merges. All confirmed honest against Lean source.

| Proof | status/badge | sorry | axiom | True-stub | native_decide | verdict |
|-------|-------------|-------|-------|-----------|---------------|---------|
| binomial-theorem-oq-02-oq-02-oq-01-oq-03 | verified/original | 0 | 0 | 0 | 0 | clean |
| birthday-problem-oq-02-oq-01-oq-02-oq-01 | verified/original | 0 | 0 | 0 | 0 | clean |
| burnside-counting-oq-04-oq-01-oq-01 | verified/verified | 0 | 0 | 0 | 0* | clean |
| catalan-numbers-oq-01-oq-01-oq-02-oq-04 | verified/original | 0 | 0 | 0 | 0 | clean |
| chebyshev-polynomials-oq-01-oq-01 | verified/mathlib | 0 | 0 | 0 | 0 | clean |
| erdos-10-oq-04 | verified/original | 0 | 0 | 0 | 0 | clean |
| ptolemys-theorem-oq-05 | verified/verified | 0 | 0 | 0 | 0 | clean |
| repunit-oq-02-oq-01 | verified/original | 0 | 0 | 0 | 0 | clean |

\* burnside: grep flagged 3 `native_decide` tokens, all in **comment prose** disclaiming it ("no native_decide", "not native_decide"). The actual tactic is kernel `decide` on small fixed-point sums (80, 156), consistent with the meta's `assumptions` field. No `Lean.ofReduceBool` introduced.

**Gallery-wide**: `find-targets.ts --all --json` reports 3461 entries, 0 detected issues, 0 critical.

Only the audit tracker changes; no proof content modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)