### PR TITLE
research(hall-marriage-theorem-oq-01-oq-02): König–Egerváry max matching = min vertex cover from defect Hall [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/HallMarriageTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/HallMarriageTheoremOQ01OQ02.lean
@@ -1,0 +1,186 @@
+import Mathlib
+import Proofs.HallMarriageTheoremOQ01OQ01
+
+/-
+# König's theorem from defect Hall (OQ-01 → OQ-02)
+
+The companion entry `HallMarriageTheoremOQ01OQ01` proves the **defect** (Ore)
+form of Hall's marriage theorem: for a finite family `t : ι → Finset α`, a
+matching saturating all but `d` indices exists iff every sub-family `s` obeys
+`#s ≤ #(s.biUnion t) + d`.
+
+This file derives the **König–Egerváry theorem** — the min–max duality at the
+heart of bipartite combinatorial optimisation — directly from that defect form:
+
+> In a bipartite graph the **maximum matching** size equals the **minimum vertex
+> cover** size.
+
+## Set-system encoding
+
+We model a bipartite graph by its left-neighbourhood family `t : ι → Finset α`:
+the left vertices are `ι`, the right vertices are `α`, and the edges are the
+pairs `(i, a)` with `a ∈ t i`.
+
+* A **matching** is a set `J ⊆ ι` with an injective-on-`J` choice `f` landing in
+  the target sets (`f i ∈ t i`); its size is `#J` (`IsMatching`).
+* A **vertex cover** is a pair `(A, B)`, `A ⊆ ι`, `B ⊆ α`, that meets every edge
+  (`i ∈ A ∨ a ∈ B` whenever `a ∈ t i`); its size is `#A + #B` (`IsVertexCover`).
+
+## What is proved
+
+* `matching_card_le_cover` — **weak duality**: every matching is at most every
+  cover. Elementary: a matched index is covered on its left endpoint (landing in
+  `A`) or, injectively through `f`, on its right endpoint (landing in `B`).
+* `konig` — **the König theorem, certificate form**: there exist a matching and a
+  vertex cover *of equal size*, and (consequently) that matching is maximum and
+  that cover is minimum. The cover is read off the **deficiency-minimising**
+  subset `s`, namely `(ι \ s, s.biUnion t)`, while the matching of matching size
+  `#ι − (#s − #(s.biUnion t))` comes from the defect Hall theorem.
+
+The crucial bridge is that the size of the cover `(ι \ s, s.biUnion t)` is exactly
+`#ι − (#s − #(s.biUnion t))` once `s` minimises the cover size — minimality forces
+`#(s.biUnion t) ≤ #s`, so the natural-number subtraction never truncates.
+
+Mathlib has Hall's theorem but, at the time of writing, no König–Egerváry duality
+for set systems; this file fills that gap from the gallery's own defect Hall.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no
+`native_decide`.
+-/
+
+open Finset Function
+
+namespace HallKonig
+
+variable {ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α]
+
+/-- A **matching** of the bipartite family `t : ι → Finset α`: a set `J ⊆ ι` and
+a choice `f` injective on `J` with `f i ∈ t i` for `i ∈ J`. Its size is `J.card`. -/
+def IsMatching (t : ι → Finset α) (J : Finset ι) (f : ι → α) : Prop :=
+  Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i
+
+/-- A **vertex cover** of `t`: a pair `(A, B)` of vertex sets meeting every edge,
+i.e. for every `i` and every `a ∈ t i` either `i ∈ A` or `a ∈ B`. Its size is
+`A.card + B.card`. -/
+def IsVertexCover (t : ι → Finset α) (A : Finset ι) (B : Finset α) : Prop :=
+  ∀ i, ∀ a ∈ t i, i ∈ A ∨ a ∈ B
+
+/-- The **cover size** of the canonical cover attached to a subset `s ⊆ ι`,
+namely `(ι \ s, s.biUnion t)`. The König minimum is the minimum of this over all
+`s`. -/
+def coverSize (t : ι → Finset α) (s : Finset ι) : ℕ :=
+  (univ \ s).card + (s.biUnion t).card
+
+omit [Fintype ι] [Nonempty α] in
+/-- **Weak duality.** Every matching is no larger than every vertex cover. Map a
+matched index `i` to its covering vertex: `Sum.inl i` if `i ∈ A`, else
+`Sum.inr (f i)` (which lies in `B` because the edge `(i, f i)` must be covered).
+This map is injective on `J`, landing in `A ⊕ B`, so `#J ≤ #A + #B`. -/
+theorem matching_card_le_cover {t : ι → Finset α} {J : Finset ι} {f : ι → α}
+    {A : Finset ι} {B : Finset α} (hM : IsMatching t J f) (hC : IsVertexCover t A B) :
+    J.card ≤ A.card + B.card := by
+  classical
+  obtain ⟨hInj, hMem⟩ := hM
+  set g : ι → ι ⊕ α := fun i => if i ∈ A then Sum.inl i else Sum.inr (f i) with hgdef
+  have hbound : J.card ≤ (A.image Sum.inl ∪ B.image Sum.inr).card := by
+    apply Finset.card_le_card_of_injOn g
+    · -- the map lands in `A ⊕ B`
+      intro i hi
+      rw [Finset.mem_coe] at hi
+      rw [Finset.mem_coe]
+      simp only [hgdef]
+      by_cases hiA : i ∈ A
+      · rw [if_pos hiA]
+        exact Finset.mem_union_left _ (Finset.mem_image_of_mem _ hiA)
+      · rw [if_neg hiA]
+        have hfB : f i ∈ B := by
+          rcases hC i (f i) (hMem i hi) with h | h
+          · exact absurd h hiA
+          · exact h
+        exact Finset.mem_union_right _ (Finset.mem_image_of_mem _ hfB)
+    · -- the map is injective on `J`
+      intro i hi j hj hij
+      simp only [hgdef] at hij
+      by_cases hiA : i ∈ A <;> by_cases hjA : j ∈ A
+      · rw [if_pos hiA, if_pos hjA] at hij; exact Sum.inl.inj hij
+      · rw [if_pos hiA, if_neg hjA] at hij; exact (Sum.inl_ne_inr hij).elim
+      · rw [if_neg hiA, if_pos hjA] at hij; exact (Sum.inr_ne_inl hij).elim
+      · rw [if_neg hiA, if_neg hjA] at hij
+        exact hInj hi hj (Sum.inr.inj hij)
+  have htarget : (A.image Sum.inl ∪ B.image Sum.inr).card ≤ A.card + B.card := by
+    calc (A.image Sum.inl ∪ B.image Sum.inr).card
+        ≤ (A.image Sum.inl).card + (B.image Sum.inr).card := Finset.card_union_le _ _
+      _ = A.card + B.card := by
+          rw [Finset.card_image_of_injective _ Sum.inl_injective,
+            Finset.card_image_of_injective _ Sum.inr_injective]
+  exact le_trans hbound htarget
+
+/-- **König–Egerváry theorem (certificate form).** For every finite bipartite
+family `t : ι → Finset α` there are a matching `(J, f)` and a vertex cover
+`(A, B)` of **equal size** `#J = #A + #B`; consequently `(J, f)` is a *maximum*
+matching and `(A, B)` is a *minimum* cover (final two clauses). Hence the maximum
+matching size equals the minimum vertex cover size. -/
+theorem konig (t : ι → Finset α) :
+    ∃ (J : Finset ι) (f : ι → α) (A : Finset ι) (B : Finset α),
+      IsMatching t J f ∧ IsVertexCover t A B ∧ J.card = A.card + B.card ∧
+      (∀ J' f', IsMatching t J' f' → J'.card ≤ J.card) ∧
+      (∀ A' B', IsVertexCover t A' B' → A.card + B.card ≤ A'.card + B'.card) := by
+  classical
+  -- choose `s` minimising the cover size over all subsets of `ι`
+  obtain ⟨s, -, hs⟩ :=
+    Finset.exists_min_image univ.powerset (coverSize t) ⟨∅, by simp⟩
+  have hmem : ∀ s' : Finset ι, coverSize t s ≤ coverSize t s' := fun s' =>
+    hs s' (Finset.mem_powerset.mpr (Finset.subset_univ s'))
+  -- `#(ι \ s') = #ι − #s'`
+  have hcompl : ∀ s' : Finset ι, (univ \ s').card = Fintype.card ι - s'.card := by
+    intro s'
+    rw [← Finset.compl_eq_univ_sdiff, Finset.card_compl]
+  have hle : ∀ s' : Finset ι, s'.card ≤ Fintype.card ι := fun s' => Finset.card_le_univ s'
+  -- at the minimiser, `#(s.biUnion t) ≤ #s` (else `s = ∅` would be smaller)
+  have hNS : (s.biUnion t).card ≤ s.card := by
+    have h0 := hmem ∅
+    simp only [coverSize, Finset.sdiff_empty, Finset.biUnion_empty, Finset.card_empty,
+      add_zero, Finset.card_univ] at h0
+    rw [hcompl s] at h0
+    have := hle s
+    omega
+  -- the deficiency `d` realised by `s`
+  set d : ℕ := s.card - (s.biUnion t).card with hd
+  -- defect Hall hypothesis holds for this `d`, by minimality of `s`
+  have Hd : ∀ s' : Finset ι, s'.card ≤ (s'.biUnion t).card + d := by
+    intro s'
+    have h1 := hmem s'
+    simp only [coverSize] at h1
+    rw [hcompl s, hcompl s'] at h1
+    have := hle s'; have := hle s; have := hNS
+    omega
+  -- extract the matching of size `≥ #ι − d`
+  obtain ⟨J, f, hJcard, hInj, hMem⟩ := HallDefect.exists_matching_of_deficiency_le Hd
+  have hMatch : IsMatching t J f := ⟨hInj, hMem⟩
+  -- the canonical cover `(ι \ s, s.biUnion t)`
+  have hCover : IsVertexCover t (univ \ s) (s.biUnion t) := by
+    intro i a ha
+    by_cases hi : i ∈ s
+    · exact Or.inr (mem_biUnion.mpr ⟨i, hi, ha⟩)
+    · exact Or.inl (Finset.mem_sdiff.mpr ⟨mem_univ i, hi⟩)
+  -- its size equals `#ι − d`
+  have hCcard : (univ \ s).card + (s.biUnion t).card = Fintype.card ι - d := by
+    rw [hcompl s, hd]
+    have := hle s; have := hNS
+    omega
+  -- so the matching is at least as large as the cover
+  have hge : (univ \ s).card + (s.biUnion t).card ≤ J.card := by
+    rw [hCcard]; exact hJcard
+  -- weak duality pins the matching size to the cover size
+  have heq : J.card = (univ \ s).card + (s.biUnion t).card :=
+    le_antisymm (matching_card_le_cover hMatch hCover) hge
+  refine ⟨J, f, univ \ s, s.biUnion t, hMatch, hCover, heq, ?_, ?_⟩
+  · -- the matching is maximum
+    intro J' f' hM'
+    exact le_trans (matching_card_le_cover hM' hCover) heq.ge
+  · -- the cover is minimum
+    intro A' B' hC'
+    calc (univ \ s).card + (s.biUnion t).card = J.card := heq.symm
+      _ ≤ A'.card + B'.card := matching_card_le_cover hMatch hC'
+
+end HallKonig

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "hall-marriage-theorem-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 55 },
+    "type": "context",
+    "title": "König–Egerváry from Defect Hall",
+    "content": "The docstring sets up the König–Egerváry min–max theorem in the set-system idiom. A bipartite graph is encoded by its left-neighbourhood family $t : \\iota \\to \\mathrm{Finset}\\,\\alpha$: left vertices $\\iota$, right vertices $\\alpha$, edges $(i,a)$ with $a \\in t\\,i$. The goal is the duality $\\max\\,\\#\\text{matching} = \\min\\,\\#\\text{vertex cover}$, derived directly from the defect (Ore) form of Hall's theorem proved in the companion entry. This answers an open question posed there.",
+    "mathContext": "Maximum matching size $=$ minimum vertex cover size for a bipartite set system.",
+    "significance": "context",
+    "relatedConcepts": ["König–Egerváry theorem", "LP duality", "defect Hall theorem", "bipartite matching"],
+    "prerequisites": ["Hall's marriage theorem", "matchings and vertex covers", "finite cardinality"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "hall-marriage-theorem-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 72 },
+    "type": "definition",
+    "title": "Matchings, Vertex Covers, Cover Size",
+    "content": "Three definitions fix the objects. `IsMatching t J f` is $\\mathrm{Set.InjOn}\\,f\\,\\uparrow\\!J \\wedge \\forall i \\in J,\\ f\\,i \\in t\\,i$: a set $J \\subseteq \\iota$ with a choice $f$ injective on $J$ landing in the targets (size $\\#J$). `IsVertexCover t A B` is $\\forall i,\\ \\forall a \\in t\\,i,\\ i \\in A \\vee a \\in B$: a pair $(A,B) \\subseteq \\iota \\times \\alpha$ meeting every edge (size $\\#A + \\#B$). `coverSize t s = \\#(\\mathrm{univ} \\setminus s) + \\#(s.\\mathrm{biUnion}\\,t)$ is the size of the *canonical cover* $(\\iota \\setminus s,\\ s.\\mathrm{biUnion}\\,t)$ attached to a subset $s$ — the family the König minimum is taken over.",
+    "mathContext": "Cover of $s$: take all of $\\iota$ outside $s$ on the left, all neighbours of $s$ on the right.",
+    "significance": "key",
+    "relatedConcepts": ["Set.InjOn", "Finset.biUnion", "vertex cover", "neighbourhood"],
+    "prerequisites": ["Finset operations", "injective-on-a-set"]
+  },
+  {
+    "id": "ann-weak-duality",
+    "proofId": "hall-marriage-theorem-oq-01-oq-02",
+    "range": { "startLine": 74, "endLine": 116 },
+    "type": "theorem",
+    "title": "Weak Duality: Every Matching ≤ Every Cover",
+    "content": "`matching_card_le_cover` is the easy half of the min–max identity, proved with no appeal to Hall. Each matched index $i \\in J$ is covered on exactly one endpoint, so map it there: $g\\,i = \\mathrm{Sum.inl}\\,i$ if $i \\in A$, else $\\mathrm{Sum.inr}\\,(f\\,i)$ — and in the second case the edge $(i, f\\,i)$ forces $f\\,i \\in B$. This $g$ is injective on $J$ (an `inl` and an `inr` never collide; within each summand injectivity comes from set-injectivity of identity resp. of $f$) and lands in $A.\\mathrm{image}\\,\\mathrm{inl} \\cup B.\\mathrm{image}\\,\\mathrm{inr}$, whose cardinality is $\\#A + \\#B$. Hence $\\#J \\le \\#A + \\#B$.",
+    "mathContext": "Inject matched indices into the disjoint sum $A \\oplus B$; $\\#J \\le \\#A + \\#B$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_le_card_of_injOn", "Sum.inl/inr injectivity", "card_image_of_injective", "weak LP duality"],
+    "prerequisites": ["sum types", "injections bound cardinality"]
+  },
+  {
+    "id": "ann-konig",
+    "proofId": "hall-marriage-theorem-oq-01-oq-02",
+    "range": { "startLine": 118, "endLine": 186 },
+    "type": "theorem",
+    "title": "König–Egerváry: The Equal-Size Certificate",
+    "content": "`konig` produces a matching and a vertex cover of *equal* size, certifying both optimal. Minimise $\\mathrm{coverSize}\\,t$ over $\\mathrm{univ.powerset}$ via `Finset.exists_min_image`, obtaining $s$. Comparing with $s = \\varnothing$ forces $\\#(s.\\mathrm{biUnion}\\,t) \\le \\#s$, so with $d = \\#s - \\#(s.\\mathrm{biUnion}\\,t)$ the cover size is exactly $\\#\\iota - d$ (the $\\mathbb{N}$-subtraction never truncates). Comparing with an arbitrary $s'$ yields the defect hypothesis $\\forall s',\\ \\#s' \\le \\#(s'.\\mathrm{biUnion}\\,t) + d$; feeding it to `HallDefect.exists_matching_of_deficiency_le` gives a matching with $\\#J \\ge \\#\\iota - d$. The canonical cover $(\\iota \\setminus s,\\ s.\\mathrm{biUnion}\\,t)$ has size $\\#\\iota - d \\le \\#J$, and weak duality gives $\\#J \\le \\#\\iota - d$, so they are equal. Maximality of the matching and minimality of the cover then follow from weak duality applied to the common value.",
+    "mathContext": "A matching of size $\\#\\iota - d$ meets a cover of the same size — a primal–dual optimality certificate.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.exists_min_image", "defect Hall theorem", "deficiency minimiser", "primal–dual certificate"],
+    "prerequisites": ["min over a finite family", "natural-number subtraction", "le_antisymm"]
+  }
+]

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallMarriageTheoremOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallMarriageTheoremOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallMarriageTheoremOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallMarriageTheoremOQ01OQ02Data: ProofData = {
+  proof: hallMarriageTheoremOQ01OQ02Proof,
+  annotations: hallMarriageTheoremOQ01OQ02Annotations,
+}

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "hall-marriage-theorem-oq-01-oq-02",
+  "title": "König–Egerváry theorem from defect Hall: max matching = min vertex cover",
+  "slug": "hall-marriage-theorem-oq-01-oq-02",
+  "description": "The König–Egerváry min–max duality of bipartite combinatorial optimisation — maximum matching size equals minimum vertex cover size — derived directly from the defect (Ore) form of Hall's marriage theorem proved in the companion entry hall-marriage-theorem-oq-01-oq-01. A bipartite graph is encoded by its left-neighbourhood family t : ι → Finset α (left vertices ι, right vertices α, edges (i,a) with a ∈ t i). A matching is a set J ⊆ ι with an injective-on-J choice f landing in the targets; a vertex cover is a pair (A,B) ⊆ ι × α meeting every edge (i ∈ A ∨ a ∈ B whenever a ∈ t i). The theorem is proved in certificate form: there exist a matching and a vertex cover of EQUAL size, hence that matching is maximum and that cover is minimum. The cover is read off the deficiency-minimising subset s as (ι \\ s, s.biUnion t); the matching of size #ι − (#s − #(s.biUnion t)) comes from the defect Hall theorem. The bridge is that minimality of s forces #(s.biUnion t) ≤ #s, so the cover size is exactly #ι − deficiency and the natural-number subtraction never truncates. Weak duality (every matching ≤ every cover) is an elementary injection of matched indices into A ⊕ B. Mathlib has Hall's theorem but, at the time of writing, no König–Egerváry duality for set systems; this answers an open question of the companion entry.",
+  "meta": {
+    "author": "Dénes König (1931), Jenő Egerváry (1931); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HallMarriageTheoremOQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "hall-marriage",
+      "matching",
+      "vertex-cover",
+      "konig",
+      "min-max-duality",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_min_image",
+        "description": "A nonempty Finset attains a minimum of any ℕ-valued function. Applied to univ.powerset and the cover-size function coverSize t to select the deficiency-minimising subset s whose canonical cover is the König minimum.",
+        "module": "Mathlib.Data.Finset.Max"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection-on bounds cardinalities. Drives weak duality: the map sending a matched index to Sum.inl i (if i ∈ A) or Sum.inr (f i) (else) is injective on J and lands in A.image inl ∪ B.image inr.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_compl",
+        "description": "#sᶜ = Fintype.card α − #s. With univ \\ s = sᶜ this gives #(ι \\ s) = #ι − #s, the left-part size of the canonical cover and the term that makes the cover size equal #ι − deficiency.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "#(s.image f) = #s for injective f. Used with Sum.inl_injective / Sum.inr_injective to evaluate #(A.image inl) + #(B.image inr) = #A + #B in the weak-duality bound.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "konig: the König–Egerváry theorem for set systems in certificate (good-characterization) form — a matching and a vertex cover of equal size, together with explicit maximality of the matching and minimality of the cover. Equivalent to the classical 'max matching = min vertex cover' min–max identity. Not present in Mathlib.",
+      "matching_card_le_cover: weak duality — every matching is no larger than every vertex cover — by an explicit injection of matched indices into the disjoint sum A ⊕ B (left endpoint into A, or right endpoint f i into B).",
+      "The deficiency-minimising cover construction: choosing s to minimise coverSize t s = #(ι \\ s) + #(s.biUnion t), proving minimality forces #(s.biUnion t) ≤ #s, and reading off (ι \\ s, s.biUnion t) as the optimal cover of size exactly #ι − (#s − #(s.biUnion t)).",
+      "The bridge to defect Hall: minimality of s yields the d-deficiency hypothesis ∀ s', #s' ≤ #(s'.biUnion t) + d for d = #s − #(s.biUnion t), feeding HallDefect.exists_matching_of_deficiency_le to produce a matching matching the cover size."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None beyond the foundational axioms propext, Classical.choice, Quot.sound (verified by #print axioms on both konig and matching_card_le_cover; no sorryAx, no Lean.ofReduceBool, no native_decide). 0 `axiom` declarations, 0 sorries. The typeclass hypothesis [Nonempty α] is inherited from the imported defect-Hall lemma (it packages a partial matching as a total function f : ι → α) and excludes only the degenerate empty-right-vertex-set case; [Fintype ι], [DecidableEq ι], [DecidableEq α] are the standard finiteness/decidability instances.",
+    "lineCount": 186,
+    "theoremCount": 2,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The König–Egerváry theorem (König 1931, Egerváry 1931) states that in a bipartite graph the maximum size of a matching equals the minimum size of a vertex cover. It is the combinatorial archetype of linear-programming duality (matching is the primal, vertex cover the dual), the basis of the Hungarian algorithm, and a cornerstone of polyhedral combinatorics. It is equivalent to Hall's marriage theorem and to its quantitative defect (Ore) form: the maximum matching has size #ι − δ where δ = maxₛ(#s − #N(s)) is the deficiency, and the minimising subset furnishes an explicit minimum cover.",
+    "problemStatement": "The companion entry hall-marriage-theorem-oq-01-oq-01 proved the defect form of Hall's theorem and explicitly asked, as an open question, whether König's min-cover = max-matching identity could be derived directly from that defect theorem. This entry answers it: yes, and constructively, with the optimal cover read off the deficiency-minimising subset.",
+    "text": "Encode the bipartite graph by its neighbourhood family t. Weak duality (any matching ≤ any cover) is an elementary injection. For the matching side, minimise the cover size #(ι \\ s) + #(s.biUnion t) over subsets s; minimality forces #(s.biUnion t) ≤ #s and supplies the defect-Hall hypothesis for d = #s − #(s.biUnion t), yielding a matching of size #ι − d = the minimum cover size. The two coincide, certifying both optimality and the min–max identity.",
+    "proofStrategy": "1. IsMatching / IsVertexCover / coverSize: define matchings, covers, and the canonical cover-size function on subsets.\n2. matching_card_le_cover (weak duality): map each matched i to Sum.inl i if i ∈ A, else Sum.inr (f i) (which lies in B since the edge (i, f i) must be covered). This is injective on J and lands in A.image inl ∪ B.image inr, so #J ≤ #A + #B.\n3. Pick s minimising coverSize t over univ.powerset via Finset.exists_min_image.\n4. Minimality vs s = ∅ gives #(s.biUnion t) ≤ #s (so the cover size #(ι \\ s) + #(s.biUnion t) = #ι − d with d = #s − #(s.biUnion t), no truncation).\n5. Minimality vs arbitrary s' gives the defect hypothesis ∀ s', #s' ≤ #(s'.biUnion t) + d; HallDefect.exists_matching_of_deficiency_le yields a matching with #J ≥ #ι − d.\n6. The canonical cover (ι \\ s, s.biUnion t) has size #ι − d ≤ #J; weak duality gives #J ≤ that cover, so they are equal. Maximality/minimality follow from weak duality applied to the common value.",
+    "keyInsights": [
+      "**Duality without a separate min–max machine.** König is packaged in certificate form — exhibit a matching and a cover of equal size — so the 'maximum' and 'minimum' are certified by weak duality alone, sidestepping any explicit construction of the optimisation values.",
+      "**The optimal cover sits at the deficiency minimiser.** Minimising the cover size #(ι \\ s) + #N(s) over subsets s simultaneously (i) produces the smallest cover and (ii) hands the defect-Hall theorem the exact deficiency parameter d = #s − #N(s) needed to match it.",
+      "**Minimality kills the ℕ-subtraction trap.** A priori #N(s) − #s could truncate in ℕ; but the minimiser satisfies #N(s) ≤ #s (else s = ∅ would be a strictly smaller cover), so cover size = #ι − d is an exact identity rather than an inequality.",
+      "**Weak duality is a one-line injection.** Each matched index is covered on exactly one endpoint; sending it to that endpoint (left into A, or right through the injective f into B) is injective into A ⊕ B, giving #matching ≤ #cover with no case explosion."
+    ],
+    "exampleSections": [
+      {
+        "title": "Primal–dual certificate",
+        "mathContext": "A matching and a vertex cover of equal cardinality form a primal–dual optimality certificate: no matching can exceed any cover (weak duality), so equality forces the matching to be maximum and the cover minimum simultaneously — the combinatorial shadow of LP strong duality."
+      }
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "konig",
+      "type": "main",
+      "description": "The König–Egerváry theorem (certificate form): for every finite bipartite family there are a matching and a vertex cover of equal size, and that matching is maximum and that cover is minimum. Hence max matching size = min vertex cover size. Not in Mathlib.",
+      "leanType": "(t : ι → Finset α) : ∃ (J : Finset ι) (f : ι → α) (A : Finset ι) (B : Finset α), IsMatching t J f ∧ IsVertexCover t A B ∧ J.card = A.card + B.card ∧ (∀ J' f', IsMatching t J' f' → J'.card ≤ J.card) ∧ (∀ A' B', IsVertexCover t A' B' → A.card + B.card ≤ A'.card + B'.card)"
+    },
+    {
+      "name": "matching_card_le_cover",
+      "type": "main",
+      "description": "Weak duality: every matching is no larger than every vertex cover, by injecting matched indices into the disjoint sum A ⊕ B (left endpoint into A, or right endpoint f i into B). The easy half of the min–max identity and the engine that promotes the equal-size certificate to optimality.",
+      "leanType": "{t : ι → Finset α} {J : Finset ι} {f : ι → α} {A : Finset ι} {B : Finset α} (hM : IsMatching t J f) (hC : IsVertexCover t A B) : J.card ≤ A.card + B.card"
+    },
+    {
+      "name": "IsMatching",
+      "type": "definition",
+      "description": "A matching of the bipartite family t: a set J ⊆ ι together with a choice f injective on J and landing in the prescribed targets (f i ∈ t i for i ∈ J). Its size is J.card.",
+      "leanType": "(t : ι → Finset α) (J : Finset ι) (f : ι → α) : Prop := Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i"
+    },
+    {
+      "name": "IsVertexCover",
+      "type": "definition",
+      "description": "A vertex cover of t: a pair (A, B) of vertex sets meeting every edge — for every i and every a ∈ t i, either i ∈ A or a ∈ B. Its size is A.card + B.card.",
+      "leanType": "(t : ι → Finset α) (A : Finset ι) (B : Finset α) : Prop := ∀ i, ∀ a ∈ t i, i ∈ A ∨ a ∈ B"
+    },
+    {
+      "name": "coverSize",
+      "type": "definition",
+      "description": "The size of the canonical cover (ι \\ s, s.biUnion t) attached to a subset s ⊆ ι. The König minimum is the minimum of coverSize over all s, and the minimiser furnishes the optimal cover.",
+      "leanType": "(t : ι → Finset α) (s : Finset ι) : ℕ := (univ \\ s).card + (s.biUnion t).card"
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Setup: bipartite set systems, matchings, covers",
+      "startLine": 4,
+      "endLine": 55,
+      "summary": "Module docstring: encode a bipartite graph by its neighbourhood family t : ι → Finset α, state the König–Egerváry min–max identity, and fix the variable block {ι α} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α].",
+      "mathContext": "Max matching size = min vertex cover size."
+    },
+    {
+      "id": "definitions",
+      "title": "Matchings, vertex covers, and cover size",
+      "startLine": 57,
+      "endLine": 72,
+      "summary": "IsMatching (J ⊆ ι with f injective on J landing in the targets), IsVertexCover (a pair (A,B) meeting every edge), and coverSize s = #(ι \\ s) + #(s.biUnion t), the size of the canonical cover attached to s.",
+      "mathContext": "Cover size of (ι \\ s, s.biUnion t) is #(ι \\ s) + #(s.biUnion t)."
+    },
+    {
+      "id": "weak-duality",
+      "title": "Weak duality: every matching ≤ every cover",
+      "startLine": 74,
+      "endLine": 116,
+      "summary": "matching_card_le_cover: send each matched i to Sum.inl i (if i ∈ A) else Sum.inr (f i) (forced into B by the cover property); this is injective on J into A.image inl ∪ B.image inr, whose card is #A + #B, giving #J ≤ #A + #B.",
+      "mathContext": "Matched indices inject into the disjoint sum A ⊕ B."
+    },
+    {
+      "id": "konig",
+      "title": "König–Egerváry: the equal-size certificate",
+      "startLine": 118,
+      "endLine": 186,
+      "summary": "konig: minimise coverSize over univ.powerset (Finset.exists_min_image); minimality forces #(s.biUnion t) ≤ #s and the defect hypothesis for d = #s − #(s.biUnion t); HallDefect.exists_matching_of_deficiency_le gives a matching of size #ι − d, which equals the canonical cover size, so weak duality pins them equal and certifies optimality of both.",
+      "mathContext": "Matching of size #ι − d meets the cover (ι \\ s, s.biUnion t) of the same size."
+    }
+  ],
+  "conclusion": {
+    "summary": "The König–Egerváry theorem for set systems is formalized in certificate form (konig): a matching and a vertex cover of equal size, with explicit maximality of the matching and minimality of the cover, hence max matching = min vertex cover. Weak duality (matching_card_le_cover) is an elementary injection of matched indices into A ⊕ B; the optimal cover is the canonical cover at the deficiency-minimising subset, and the matching of matching size comes from the companion defect-Hall theorem (HallDefect.exists_matching_of_deficiency_le). Verified with 0 axioms and 0 sorries.",
+    "implications": "Answers the open question posed by hall-marriage-theorem-oq-01-oq-01 (derive König's min-cover = max-matching identity directly from the defect theorem). Supplies, in the reusable set-system idiom, the primal–dual certificate at the root of bipartite optimisation: the Hungarian algorithm's optimality proof, the matching/vertex-cover LP duality, and (via complementation) Dilworth-type results.",
+    "openQuestions": [
+      "Can König–Egerváry be transported to Mathlib's SimpleGraph bipartite-matching API (SimpleGraph.IsMatching / Subgraph), proving max matching = min vertex cover for an actual bipartite SimpleGraph rather than a neighbourhood family?",
+      "Does the same deficiency-minimiser route yield the weighted refinement (Egerváry's theorem / the assignment problem: max-weight matching = min-weight cover) once the defect theorem is upgraded to capacities?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "hall-marriage-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the defect (Ore) form of Hall's theorem, exists_matching_of_deficiency_le. This entry answers its lead open question by deriving König's min-cover = max-matching identity directly from that defect theorem, with the optimal cover read off the deficiency-minimising subset."
+    },
+    {
+      "targetId": "hall-marriage-theorem-oq-01",
+      "relationship": "related",
+      "description": "Grandparent entry: Hall's marriage biconditional and the all-or-nothing deficiency obstruction. König–Egerváry is the min–max dual of Hall's criterion."
+    }
+  ],
+  "references": [
+    {
+      "authors": "König, Dénes",
+      "title": "Gráfok és mátrixok",
+      "year": "1931",
+      "note": "Mat. Fiz. Lapok 38, 116–119 — in a bipartite graph the maximum matching equals the minimum vertex cover."
+    },
+    {
+      "authors": "Egerváry, Jenő",
+      "title": "Matrixok kombinatorikus tulajdonságairól",
+      "year": "1931",
+      "note": "Mat. Fiz. Lapok 38, 16–28 — the weighted generalisation underlying the assignment problem and the Hungarian algorithm."
+    },
+    {
+      "authors": "Schrijver, Alexander",
+      "title": "Combinatorial Optimization: Polyhedra and Efficiency",
+      "year": "2003",
+      "note": "Volume A, Chapter 16 — König–Egerváry, its equivalence with Hall's theorem and the defect form, and its role as the bipartite case of LP duality."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Derives the **König–Egerváry theorem** — in a bipartite graph the maximum matching size equals the minimum vertex cover size — directly from the **defect (Ore) form of Hall's marriage theorem** proved in the companion entry `hall-marriage-theorem-oq-01-oq-01`. This answers an open question posed verbatim there ("deriving König's min-cover = max-matching identity directly from this defect theorem").

A bipartite graph is encoded by its left-neighbourhood family `t : ι → Finset α` (left vertices `ι`, right vertices `α`, edges `(i,a)` with `a ∈ t i`).

## What's proved

- **`matching_card_le_cover`** — weak duality: every matching is no larger than every vertex cover, by an explicit injection of matched indices into the disjoint sum `A ⊕ B` (left endpoint into `A`, or right endpoint `f i` into `B`).
- **`konig`** — the König–Egerváry theorem in **certificate form**: there exist a matching and a vertex cover of *equal size*, and (consequently) that matching is maximum and that cover is minimum. Hence max matching = min vertex cover.

## Proof engine

Minimise `coverSize t s = #(ι \ s) + #(s.biUnion t)` over `univ.powerset` (`Finset.exists_min_image`). Minimality vs `s = ∅` forces `#(s.biUnion t) ≤ #s`, so the canonical cover `(ι \ s, s.biUnion t)` has size exactly `#ι − d` with `d = #s − #(s.biUnion t)` (the ℕ-subtraction never truncates). Minimality vs arbitrary `s'` gives the defect hypothesis `∀ s', #s' ≤ #(s'.biUnion t) + d`, which `HallDefect.exists_matching_of_deficiency_le` turns into a matching of size `#ι − d`. Weak duality pins matching and cover sizes equal.

## Verification

- 2 theorems, 3 definitions, 186 lines
- `#print axioms konig` / `matching_card_le_cover` → `propext, Classical.choice, Quot.sound` only
- 0 `axiom` declarations, 0 sorries, no `native_decide` (no `Lean.ofReduceBool`)
- Compiles against the existing `HallMarriageTheoremOQ01OQ01` defect-Hall machinery; Mathlib has Hall but no König–Egerváry for set systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)