### PR TITLE
Enrich Catalan-triangle Row Sums (catalan-numbers-oq-01-oq-01-oq-02-oq-04)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-catalanoq01010204-header",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "concept",
+    "title": "Row sums of the Catalan triangle",
+    "content": "The parent entry introduced the generalized ballot number / Catalan-triangle entry B(p,q) = C(p+q,q) − C(p+q,p+1), with its closed form, diagonal value B(n,n) = catalan n, and boundary facts. This file proves the classical ROW-SUM identity ∑_{q=0}^{p} B(p,q) = catalan(p+1): the q-th row of the Catalan triangle sums to a Catalan number (row 3 is 1,3,5,5 and 1+3+5+5 = 14 = catalan 4). The proof is deliberately INDEPENDENT of the Catalan-triangle recurrence — it splits B(p,q) into its two binomial pieces, evaluates each diagonal sum in closed form via the hockey-stick (Zhu Shijie) identity, and reconciles them with one application of Pascal's rule. Mathlib has the Catalan numbers and the hockey-stick identity but neither the Catalan triangle nor this relation.",
+    "mathContext": "$\\sum_{q=0}^{p} B(p,q) = \\mathrm{catalan}(p+1)$, where $B(p,q)=\\binom{p+q}{q}-\\binom{p+q}{p+1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan triangle", "ballot numbers", "hockey-stick identity", "Catalan numbers", "Pascal's rule"],
+    "prerequisites": ["the parent ballot/Catalan-triangle entry", "binomial coefficients over ℕ", "finite sums over range"]
+  },
+  {
+    "id": "ann-catalanoq01010204-diag",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 53, "endLine": 69 },
+    "type": "key-step",
+    "title": "Diagonal binomial sum (first hockey stick)",
+    "content": "sum_choose_diag proves ∑_{q=0}^{p} C(p+q,q) = C(2p+1,p+1). It first rewrites each term by the symmetry C(p+q,q) = C(p+q,p) (Nat.choose_symm_add), turning the sum into ∑ C(m,p) for m in a shifted range. Reindexing m = p+q via Finset.sum_Ico_eq_sum_range gives the index set Ico p (2p+1) = Icc p (2p) (Nat.Ico_succ_right), and the hockey-stick identity Nat.sum_Icc_choose evaluates ∑_{m=p}^{2p} C(m,p) = C(2p+1,p+1) in closed form. This is the sum of the C(p+q,q) pieces of the row.",
+    "mathContext": "$\\sum_{q=0}^{p}\\binom{p+q}{q}=\\sum_{m=p}^{2p}\\binom{m}{p}=\\binom{2p+1}{p+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.choose_symm_add", "Finset.sum_Ico_eq_sum_range", "Nat.sum_Icc_choose", "hockey-stick identity", "reindexing"],
+    "prerequisites": ["binomial symmetry", "sum reindexing over Ico/Icc", "the hockey-stick identity"]
+  },
+  {
+    "id": "ann-catalanoq01010204-upper",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 71, "endLine": 90 },
+    "type": "key-step",
+    "title": "Upper-index binomial sum (second hockey stick)",
+    "content": "sum_choose_upper proves ∑_{q=0}^{p} C(p+q,p+1) = C(2p+1,p+2). The q=0 term C(p,p+1) vanishes (p < p+1, Nat.choose_eq_zero_of_lt), peeled off with Finset.sum_range_succ'; the remaining summand reindexes to ((p+1)+q).choose(p+1), i.e. m = (p+1)+q over Ico (p+1) (2p+1) = Icc (p+1) (2p), where Nat.sum_Icc_choose again gives the closed form C(2p+1,p+2). This is the sum of the subtracted C(p+q,p+1) pieces.",
+    "mathContext": "$\\sum_{q=0}^{p}\\binom{p+q}{p+1}=\\sum_{m=p+1}^{2p}\\binom{m}{p+1}=\\binom{2p+1}{p+2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_range_succ'", "Nat.choose_eq_zero_of_lt", "Nat.sum_Icc_choose", "vanishing endpoint", "reindexing"],
+    "prerequisites": ["peeling a zero term off a sum", "sum reindexing", "the hockey-stick identity"]
+  },
+  {
+    "id": "ann-catalanoq01010204-pascal",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 92, "endLine": 122 },
+    "type": "technique",
+    "title": "Catalan via Pascal's rule",
+    "content": "catalan_succ_eq_choose_sub reconciles the two closed forms: catalan(p+1) + C(2p+1,p+2) = C(2p+1,p+1). It starts from the parent's diagonal facts at (p+1,p+1) — ballot_genuine (the subtraction is genuine) and ballot_diag (catalan(p+1) = C(2p+2,p+1) − C(2p+2,p+2)) — then expands both C(2p+2,·) coefficients via Pascal's rule Nat.choose_succ_succ and applies the symmetry C(2p+1,p) = C(2p+1,p+1) (Nat.choose_symm), so omega closes the arithmetic over ℕ. This is the single Pascal step that links the Catalan number to the two hockey-stick values.",
+    "mathContext": "$\\mathrm{catalan}(p+1)+\\binom{2p+1}{p+2}=\\binom{2p+1}{p+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.choose_succ_succ", "Pascal's rule", "ballot_diag", "ballot_genuine", "Nat.choose_symm", "omega"],
+    "prerequisites": ["the parent's diagonal ballot facts", "Pascal's rule", "binomial symmetry"]
+  },
+  {
+    "id": "ann-catalanoq01010204-rowsum",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 124, "endLine": 148 },
+    "type": "insight",
+    "title": "The row-sum identity",
+    "content": "ballot_row_sum assembles the pieces into ∑_{q=0}^{p} B(p,q) = catalan(p+1). The termwise genuine partition B(p,q) + C(p+q,p+1) = C(p+q,q) (valid since q ≤ p throughout the range, from the parent's ballot_genuine) sums via Finset.sum_add_distrib to S + ∑ C(p+q,p+1) = ∑ C(p+q,q); rewriting the two right-hand sums by sum_choose_upper and sum_choose_diag gives S + C(2p+1,p+2) = C(2p+1,p+1). Comparing with catalan_succ_eq_choose_sub (which has the identical left structure) and closing by omega yields S = catalan(p+1). The whole computation stays inside ℕ because the partition keeps every subtraction genuine.",
+    "mathContext": "$S+\\binom{2p+1}{p+2}=\\binom{2p+1}{p+1}=\\mathrm{catalan}(p+1)+\\binom{2p+1}{p+2}\\Rightarrow S=\\mathrm{catalan}(p+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_add_distrib", "genuine partition", "ballot_genuine", "ℕ subtraction", "omega"],
+    "prerequisites": ["the two hockey-stick sums", "the Pascal reconciliation", "termwise additive partition"]
+  },
+  {
+    "id": "ann-catalanoq01010204-examples",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02-oq-04",
+    "range": { "startLine": 150, "endLine": 157 },
+    "type": "context",
+    "title": "Concrete sanity checks",
+    "content": "Two kernel-decide examples verify the identity at small p: row 3 sums to 14 = catalan 4 and row 4 sums to 42 = catalan 5. Both are closed by kernel `decide` on Nat.choose computations — NOT native_decide — so they add no Lean.ofReduceBool axiom and the entry remains genuinely 0-axiom.",
+    "mathContext": "$\\sum_{q=0}^{3}B(3,q)=14=\\mathrm{catalan}\\,4$; $\\sum_{q=0}^{4}B(4,q)=42=\\mathrm{catalan}\\,5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "Catalan numbers 14, 42", "sanity check", "axiom-free computation"],
+    "prerequisites": ["the row-sum identity", "small Catalan numbers"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02-oq-04/index.ts
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CatalanNumbersOQ01OQ01OQ02OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const catalanNumbersOQ01OQ01OQ02OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const catalanNumbersOQ01OQ01OQ02OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const catalanNumbersOQ01OQ01OQ02OQ04Data: ProofData = {
+  proof: catalanNumbersOQ01OQ01OQ02OQ04Proof,
+  annotations: catalanNumbersOQ01OQ01OQ02OQ04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-01-oq-02-oq-04` (quality 45, pass 0).

## Critical fix
- **Added missing `index.ts`** — without the Vite entry point the proof page renders 'proof not found' on the live site.

## Annotation coverage (new `annotations.json`)
6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Overview — row sums of the Catalan triangle
2. Diagonal binomial sum (first hockey stick)
3. Upper-index binomial sum (second hockey stick)
4. Catalan via Pascal's rule
5. The row-sum identity
6. Concrete kernel-decide sanity checks

## Axiom integrity
Verified against the Lean source: `status: verified`, `badge: original`, `axiomCount: 0` — examples use **kernel `decide`** (no `native_decide`, no Lean.ofReduceBool), no `axiom`, no `sorry`. Claims accurate.