### PR TITLE
Enrich Euclid Doubly-Exponential Prime Bound (infinitude-primes-oq-06)

### DIFF
--- a/src/data/proofs/infinitude-primes-oq-06/index.ts
+++ b/src/data/proofs/infinitude-primes-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/InfinitudePrimesOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const infinitudePrimesOQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const infinitudePrimesOQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const infinitudePrimesOQ06Data: ProofData = {
+  proof: infinitudePrimesOQ06Proof,
+  annotations: infinitudePrimesOQ06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-oq-06` (quality 45, pass 0).

## Critical fix
- **Added missing `index.ts`** — without the Vite entry point the proof page renders 'proof not found' on the live site.

## Annotation coverage (new `annotations.json`)
6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Overview — the quantitative content of Euclid's proof
2. The n-th prime via Nat.nth
3. The Euclid recurrence
4. Exponent telescoping
5. The doubly-exponential bound
6. Prime-existence restatement

## Axiom integrity
Verified against the Lean source: `status: verified`, `badge: original`, `axiomCount: 0` — no `axiom`, no `sorry`, no `native_decide`. Claims accurate.