### PR TITLE
Enrich Euclid's doubly-exponential prime bound pₙ ≤ 2^(2ⁿ) (infinitude-primes-oq-06): add annotations.json

### DIFF
--- a/src/data/proofs/infinitude-primes-oq-06/annotations.json
+++ b/src/data/proofs/infinitude-primes-oq-06/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-infprimesoq06-overview",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 5, "endLine": 59 },
+    "type": "context",
+    "title": "Euclid's Proof Made Quantitative",
+    "content": "Euclid's infinitude proof is usually read as pure existence: given primes p₀,…,pₙ, the number p₀⋯pₙ + 1 has a prime factor different from all of them. But the same construction is quantitative — it bounds how far one must look for the next prime. Iterating the Euclid recurrence p_{n+1} ≤ p₀⋯pₙ + 1 yields the explicit doubly-exponential ceiling pₙ ≤ 2^(2ⁿ) on the n-th prime (pₙ = Nat.nth Nat.Prime n, with p₀ = 2). This is the classical first effective bound on prime growth — vastly weaker than the prime number theorem's pₙ ∼ n ln n, but completely elementary: no analysis, no sieve.",
+    "mathContext": "$p_n = \\texttt{Nat.nth Nat.Prime}\\,n$ (so $p_0=2, p_1=3, p_2=5,\\dots$), and the claim is $p_n \\le 2^{2^n}$, derived from $p_{n+1} \\le \\prod_{i\\le n} p_i + 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Euclid's theorem", "n-th prime", "explicit prime bounds", "prime number theorem (contrast)"],
+    "prerequisites": ["infinitude of primes", "divisibility in ℕ", "the n-th prime enumeration"]
+  },
+  {
+    "id": "ann-infprimesoq06-defs",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 61, "endLine": 75 },
+    "type": "definition",
+    "title": "The n-th Prime via Nat.nth",
+    "content": "primes_infinite records that the prime set is infinite (Mathlib's Nat.infinite_setOf_prime) — the hypothesis that makes the enumeration total. p n := Nat.nth Nat.Prime n is the n-th prime in increasing order; p_prime n shows each p n is prime (Nat.nth_mem_of_infinite), and p_zero gives p 0 = 2. Representing primes through Nat.nth (rather than an ad hoc recursive sequence) is what lets the order-theoretic glue lemmas nth_count / nth_le_nth do the heavy lifting later.",
+    "mathContext": "$p$ enumerates the primes monotonically: $p\\,0=2,\\ p\\,1=3,\\ p\\,2=5,\\dots$, well-defined because $\\{p : \\texttt{Nat.Prime}\\,p\\}$ is infinite.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.nth", "Nat.infinite_setOf_prime", "Nat.nth_mem_of_infinite", "monotone enumeration"],
+    "prerequisites": ["Nat.nth / Nat.count API", "infinitude of the prime set"]
+  },
+  {
+    "id": "ann-infprimesoq06-recurrence",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 77, "endLine": 113 },
+    "type": "insight",
+    "title": "The Euclid Recurrence p_{n+1} ≤ ∏ pᵢ + 1",
+    "content": "p_succ_le_prod is the heart of the bound. The Euclid number N = ∏_{i≤n} pᵢ + 1 is ≥ 2, so it has a prime factor q (Nat.exists_prime_and_dvd). That q is NONE of p₀,…,pₙ: if q = pᵢ then q divides both N and the product, hence q ∣ (N − ∏) = 1, impossible. The delicate step is purely order-theoretic — because Nat.nth enumerates ALL primes in increasing order, a prime outside the first n+1 primes has Nat.count Nat.Prime q ≥ n+1, so by strict monotonicity (nth_le_nth) p_{n+1} ≤ p(count q) = q ≤ N. The Nat.nth/Nat.count pair is exactly the bridge between 'q is a prime outside a finite initial segment' and 'p_{n+1} ≤ q'.",
+    "mathContext": "$N = \\prod_{i\\le n} p_i + 1$, prime factor $q \\mid N$; $q = p_i \\Rightarrow q \\mid \\gcd(N, \\prod) = 1$, contradiction. So $\\texttt{count}\\,q \\ge n+1$, giving $p_{n+1} \\le p_{\\texttt{count}\\,q} = q \\le N$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid number", "Nat.nth_count", "Nat.nth_le_nth", "Finset.dvd_prod_of_mem"],
+    "prerequisites": ["a prime factor of N∉{p₀,…,pₙ}", "monotonicity of Nat.nth", "Nat.exists_prime_and_dvd"]
+  },
+  {
+    "id": "ann-infprimesoq06-telescope",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "technique",
+    "title": "Exponent Telescoping ∏ 2^(2ⁱ) = 2^(2ⁿ−1)",
+    "content": "prod_two_pow_two_pow collapses the product of bounds by adding exponents: ∏_{i<n} 2^(2ⁱ) = 2^(∑_{i<n} 2ⁱ) = 2^(2ⁿ−1), since the geometric sum ∑_{i<n} 2ⁱ = 2ⁿ − 1. Proved by induction with prod_range_succ + ←pow_add, the exponent arithmetic 2^(k+1) = 2·2^k discharged by omega. This identity is what makes the strong induction's product of inductive bounds close in one telescoped exponent.",
+    "mathContext": "$\\prod_{i<n} 2^{2^i} = 2^{\\sum_{i<n} 2^i} = 2^{2^n - 1}$, using $\\sum_{i<n} 2^i = 2^n - 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric sum 2ⁿ−1", "pow_add", "Finset.prod_range_succ"],
+    "prerequisites": ["finite products", "induction", "exponent arithmetic"]
+  },
+  {
+    "id": "ann-infprimesoq06-mainbound",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 127, "endLine": 154 },
+    "type": "insight",
+    "title": "The Doubly-Exponential Bound pₙ ≤ 2^(2ⁿ)",
+    "content": "nth_prime_le_double_exp assembles the bound by strong induction (Nat.strongRecOn). The base case p₀ = 2 = 2^(2⁰). For the step, the Euclid recurrence bounds p_{m+1} by the product ∏_{i≤m} pᵢ + 1; bounding each factor termwise by the inductive hypothesis (Finset.prod_le_prod') and telescoping gives ∏ ≤ 2^(2^{m+1}−1), so p_{m+1} ≤ 2^(2^{m+1}−1) + 1. The +1 is absorbed because 2^A = 2·2^(A−1) makes 2^(A−1) + 1 ≤ 2^A (with A = 2^{m+1}), closing at p_{m+1} ≤ 2^(2^{m+1}). Strong (not ordinary) induction is needed because every earlier prime appears in the product.",
+    "mathContext": "Step: $p_{m+1} \\le \\prod_{i\\le m} p_i + 1 \\le 2^{2^{m+1}-1} + 1 \\le 2^{2^{m+1}}$, the last via $2^{A} = 2\\cdot 2^{A-1} \\Rightarrow 2^{A-1}+1 \\le 2^{A}$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "Finset.prod_le_prod'", "termwise bounding", "absorbing the +1"],
+    "prerequisites": ["the Euclid recurrence", "the telescoping identity", "Nat.strongRecOn"]
+  },
+  {
+    "id": "ann-infprimesoq06-restatement",
+    "proofId": "infinitude-primes-oq-06",
+    "range": { "startLine": 156, "endLine": 161 },
+    "type": "context",
+    "title": "Prime-Existence Restatement",
+    "content": "exists_prime_doubly_exp_bound repackages the bound as an existence statement: for every n there is a prime q (namely p n) exceeding all earlier primes pₖ (k < n, via nth_lt_nth) with q ≤ 2^(2ⁿ). This is the effective form of Euclid's theorem — it certifies that the next prime beyond the first n is found within a doubly-exponential search window, making the infinitude constructive with an explicit ceiling.",
+    "mathContext": "$\\exists q$ prime with $p_k < q$ for all $k < n$ and $q \\le 2^{2^n}$ — Euclid's infinitude with a concrete search bound.",
+    "significance": "context",
+    "relatedConcepts": ["effective bounds", "Nat.nth_lt_nth", "constructive infinitude"],
+    "prerequisites": ["the main bound", "strict monotonicity of Nat.nth"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-oq-06`. Adds the missing `annotations.json` (6 annotations) covering the quantitative-Euclid overview, the `Nat.nth` n-th-prime definitions, the Euclid recurrence `p_succ_le_prod`, the exponent telescoping `prod_two_pow_two_pow`, the strong-induction bound `nth_prime_le_double_exp`, and the prime-existence restatement. Each annotation has mathContext (LaTeX), significance, relatedConcepts, prerequisites. Annotation line ranges validated via `scripts/annotations/build.ts` (clean for this entry). No meta.json changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)