### PR TITLE
audit: re-verify area-of-circle-oq-01 clean (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -379,9 +379,9 @@
       "result": "clean"
     },
     "area-of-circle-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-24T13:21:26Z",
       "result": "clean"
     },
     "area-of-circle-oq-01-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `area-of-circle-oq-01` — Circumference Formula via Area Differentiation
**Result**: ✅ CLEAN (re-audit; auditCount 5→6)

### Verification (meta.json vs Lean source `Proofs/CircumferenceFromArea.lean`)

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| lineCount | 162 | 162 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 structure fields | ✓ |
| theoremCount | 18 | 18 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| badge | `mathlib` | core via `hasDerivAt_pow` | ✓ honest |
| native_decide | — | 0 (no `Lean.ofReduceBool`) | ✓ |
| True stubs | — | 0 | ✓ |

### Classification
Correctly-classified **Tier B** (formalized using a Mathlib theorem). Badge `mathlib` is honest — the core derivative result comes from Mathlib's power rule `hasDerivAt_pow`, openly credited in the description. `originalContributions` are scoped to pedagogical packaging and corollaries (differentiability, scaling, monotonicity, `C² = 4πA` identity), not an independent proof of the power rule. No overclaiming detected.

Only cosmetic nit (not an integrity issue, left as-is): `conclusion.summary` prose mentions "163 lines" while both structured `lineCount` fields correctly read 162.

---
Discovered during gallery integrity audit. Tracker updated: `src/data/proofs/audit-tracker.json`.