### PR TITLE
research(euler-totient-oq-01-oq-02-oq-03): Carmichael λ(n) as maximal order; primitive root ⟺ λ(n)=φ(n)

### DIFF
--- a/proofs/Proofs/EulerTotientOQ01OQ02OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ02OQ03.lean
@@ -1,0 +1,126 @@
+import Mathlib.NumberTheory.ArithmeticFunction.Carmichael
+import Mathlib.RingTheory.ZMod.UnitsCyclic
+import Mathlib.Tactic
+
+/-
+# Euler totient OQ-01 → OQ-02 → OQ-03: the Carmichael function as the maximal order, and primitive roots
+
+The parent entry (`euler-totient-oq-01-oq-02`) packages Mathlib's prime-power values of the
+Carmichael function `λ` (the exponent of the unit group `(ℤ/nℤ)ˣ`). Its closing open
+questions ask to
+
+> *assemble the full formula `λ(n) = lcm` of the prime-power values, and to formalize the
+> application that the maximal multiplicative order modulo `n` equals `λ(n)`, characterizing
+> the `n` for which primitive roots exist.*
+
+This file answers both. The point of `λ(n)` is **two-fold**:
+
+* it is an **upper bound** on the multiplicative order of every unit: `aᵏ ≡ 1` for `k = λ(n)`,
+  so `orderOf a ∣ λ(n)` (`orderOf_dvd_carmichael`); and
+* it is **attained** — there is a unit whose order is *exactly* `λ(n)`
+  (`exists_orderOf_eq_carmichael`).
+
+Together these say `λ(n)` is the **maximal multiplicative order** modulo `n`. A *primitive
+root* mod `n` is a unit of maximal possible order `φ(n)`; combining the two halves shows one
+exists **iff** `λ(n) = φ(n)** (`exists_primitiveRoot_iff_carmichael_eq_totient`), iff the unit
+group is cyclic (`isCyclic_units_iff_carmichael_eq_totient`). Since `λ(n) ∣ φ(n)` always and
+`λ` can be a proper divisor (e.g. `λ(15) = 4 < 8 = φ(15)`), primitive roots fail to exist for
+many `n` — the classical fact that `(ℤ/nℤ)ˣ` is cyclic only for `n ∈ {1,2,4,pᵏ,2pᵏ}`.
+
+## Main results
+
+* `carmichael_factorization'` : `λ(n) = lcm` over prime powers `p^{vₚ(n)}` of `λ(p^{vₚ(n)})`
+  (the closed form, OQ-1).
+* `orderOf_dvd_carmichael`, `orderOf_le_carmichael` : `λ(n)` bounds every unit's order.
+* `exists_orderOf_eq_carmichael` : `λ(n)` is attained — the maximal order.
+* `carmichael_le_totient` : `λ(n) ≤ φ(n)`.
+* `isCyclic_units_iff_carmichael_eq_totient` : `(ℤ/nℤ)ˣ` cyclic `↔ λ(n) = φ(n)`.
+* `exists_primitiveRoot_iff_carmichael_eq_totient` : a primitive root mod `n` exists `↔ λ(n) = φ(n)`.
+* `carmichael_fifteen`, `not_exists_primitiveRoot_fifteen` : `λ(15) = 4 < 8 = φ(15)`, no primitive root mod 15.
+* `exists_primitiveRoot_seven` : `λ(7) = 6 = φ(7)`, a primitive root mod 7 exists.
+-/
+
+namespace EulerTotientOQ01OQ02OQ03
+
+open ArithmeticFunction Nat
+
+/-- **The Carmichael function is positive** for `n ≠ 0`: it is the exponent of a finite group. -/
+theorem carmichael_pos (n : ℕ) [NeZero n] : 0 < Carmichael n := by
+  rw [carmichael_eq_exponent']
+  exact Monoid.ExponentExists.of_finite.exponent_pos
+
+/-- **Closed form (OQ-1).** `λ(n)` is the least common multiple, over the primes `p` dividing
+    `n`, of the prime-power values `λ(p^{vₚ(n)})`. Combined with the parent's prime-power
+    identities (`λ(2ᵏ) = 2ᵏ⁻²`, `λ(pᵏ) = φ(pᵏ)` for odd `p`) this determines `λ` for every `n`.
+    (A restatement of Mathlib's `carmichael_factorization`.) -/
+theorem carmichael_factorization' (n : ℕ) [NeZero n] :
+    Carmichael n = n.primeFactors.lcm fun p ↦ Carmichael (p ^ n.factorization p) :=
+  ArithmeticFunction.carmichael_factorization n
+
+/-- **Upper bound (divisibility).** The order of every unit `a` modulo `n` divides `λ(n)`:
+    `a^{λ(n)} = 1`, so `λ(n)` is a universal exponent. -/
+theorem orderOf_dvd_carmichael {n : ℕ} [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ∣ Carmichael n := by
+  rw [carmichael_eq_exponent']
+  exact Monoid.order_dvd_exponent a
+
+/-- **Upper bound (size).** Hence the order of every unit is at most `λ(n)`. -/
+theorem orderOf_le_carmichael {n : ℕ} [NeZero n] (a : (ZMod n)ˣ) :
+    orderOf a ≤ Carmichael n :=
+  Nat.le_of_dvd (carmichael_pos n) (orderOf_dvd_carmichael a)
+
+/-- **The maximal order is attained.** There is a unit modulo `n` whose multiplicative order is
+    exactly `λ(n)`. Together with `orderOf_le_carmichael` this characterises `λ(n)` as the
+    **maximal multiplicative order** modulo `n` — the application requested by the OQ. -/
+theorem exists_orderOf_eq_carmichael (n : ℕ) [NeZero n] :
+    ∃ a : (ZMod n)ˣ, orderOf a = Carmichael n := by
+  rw [carmichael_eq_exponent']
+  exact Monoid.exists_orderOf_eq_exponent Monoid.ExponentExists.of_finite
+
+/-- **`λ(n) ≤ φ(n)`.** Euler's theorem factors through the smaller exponent `λ`. -/
+theorem carmichael_le_totient (n : ℕ) [NeZero n] : Carmichael n ≤ n.totient :=
+  Nat.le_of_dvd (Nat.totient_pos.mpr (NeZero.pos n)) (ArithmeticFunction.carmichael_dvd_totient n)
+
+/-- **Cyclicity criterion.** The unit group `(ℤ/nℤ)ˣ` is cyclic **iff** `λ(n) = φ(n)`: the
+    maximal order equals the group order exactly when some element generates the whole group. -/
+theorem isCyclic_units_iff_carmichael_eq_totient (n : ℕ) [NeZero n] :
+    IsCyclic (ZMod n)ˣ ↔ Carmichael n = n.totient := by
+  rw [carmichael_eq_exponent', IsCyclic.iff_exponent_eq_card, Nat.card_eq_fintype_card,
+    ZMod.card_units_eq_totient]
+
+/-- **Primitive-root characterisation (the OQ's headline).** A *primitive root* modulo `n` is a
+    unit of maximal possible order `φ(n)` (a generator of `(ℤ/nℤ)ˣ`). One exists **iff**
+    `λ(n) = φ(n)`, i.e. iff the Carmichael function meets the totient. -/
+theorem exists_primitiveRoot_iff_carmichael_eq_totient (n : ℕ) [NeZero n] :
+    (∃ a : (ZMod n)ˣ, orderOf a = n.totient) ↔ Carmichael n = n.totient := by
+  rw [← isCyclic_units_iff_carmichael_eq_totient, isCyclic_iff_exists_orderOf_eq_natCard,
+    Nat.card_eq_fintype_card, ZMod.card_units_eq_totient]
+
+/-- `λ(15) = 4`. Since `15 = 3·5` with `3,5` coprime, `λ(15) = lcm(λ(3), λ(5)) = lcm(2, 4) = 4`. -/
+theorem carmichael_fifteen : Carmichael 15 = 4 := by
+  have h3 : Carmichael 3 = 2 := by
+    have := carmichael_pow_of_prime_ne_two (p := 3) 1 (by norm_num) (by norm_num)
+    simpa using this
+  have h5 : Carmichael 5 = 4 := by
+    have := carmichael_pow_of_prime_ne_two (p := 5) 1 (by norm_num) (by norm_num)
+    simpa using this
+  have : (15 : ℕ) = 3 * 5 := by norm_num
+  rw [this, ArithmeticFunction.carmichael_mul (by decide), h3, h5]
+  decide
+
+/-- **No primitive root modulo 15.** `λ(15) = 4 < 8 = φ(15)`, so by the characterisation no
+    unit attains order `φ(15)` — the failure of `λ = φ` is exactly the obstruction. -/
+theorem not_exists_primitiveRoot_fifteen :
+    ¬ ∃ a : (ZMod 15)ˣ, orderOf a = (15 : ℕ).totient := by
+  rw [exists_primitiveRoot_iff_carmichael_eq_totient, carmichael_fifteen]
+  norm_num [show (15 : ℕ).totient = 8 by decide]
+
+/-- **A primitive root modulo 7 exists.** `7` is prime, so `(ℤ/7ℤ)ˣ` is cyclic and
+    `λ(7) = φ(7) = 6`; some unit has order `6`. -/
+theorem exists_primitiveRoot_seven :
+    ∃ a : (ZMod 7)ˣ, orderOf a = (7 : ℕ).totient := by
+  rw [exists_primitiveRoot_iff_carmichael_eq_totient]
+  have := carmichael_pow_of_prime_ne_two (p := 7) 1 (by norm_num) (by norm_num)
+  simpa using this
+
+end EulerTotientOQ01OQ02OQ03

--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-maximal-order",
+    "proofId": "euler-totient-oq-01-oq-02-oq-03",
+    "range": {
+      "startLine": 62,
+      "endLine": 79
+    },
+    "type": "insight",
+    "title": "λ(n) Is the Maximal Multiplicative Order",
+    "content": "Two facts together pin λ(n) as the maximal multiplicative order modulo n. orderOf_dvd_carmichael is the upper bound: every unit a satisfies a^{λ(n)} = 1, so orderOf a ∣ λ(n) (hence orderOf a ≤ λ(n)). exists_orderOf_eq_carmichael is attainment: a finite abelian group always contains an element whose order equals its exponent, so some unit has order exactly λ(n). Both route through carmichael_eq_exponent' (λ(n) = exponent (ℤ/nℤ)ˣ) and Mathlib's exponent API (Monoid.order_dvd_exponent, Monoid.exists_orderOf_eq_exponent on the finite, hence ExponentExists, unit group)."
+  },
+  {
+    "id": "ann-primitive-root",
+    "proofId": "euler-totient-oq-01-oq-02-oq-03",
+    "range": {
+      "startLine": 81,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Primitive Root Exists ⟺ λ(n) = φ(n)",
+    "content": "A primitive root mod n is a unit of order φ(n) — a generator of (ℤ/nℤ)ˣ. Since the maximal order is λ(n) and λ(n) ∣ φ(n) always (carmichael_le_totient), a generator exists exactly when λ(n) reaches φ(n). isCyclic_units_iff_carmichael_eq_totient states this for cyclicity (rewriting IsCyclic.iff_exponent_eq_card with |units| = φ(n)), and exists_primitiveRoot_iff_carmichael_eq_totient is the headline existential form (via isCyclic_iff_exists_orderOf_eq_natCard). This is the computable form of Gauss's primitive-root theorem expressed through the Carmichael function — a bridge Mathlib states the classification for but never phrases via λ."
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "euler-totient-oq-01-oq-02-oq-03",
+    "range": {
+      "startLine": 100,
+      "endLine": 124
+    },
+    "type": "concept",
+    "title": "Concrete Certificates: 15 (no) vs 7 (yes)",
+    "content": "carmichael_fifteen computes λ(15) = lcm(λ(3), λ(5)) = lcm(2, 4) = 4 (via carmichael_mul on coprime 3·5 and the odd-prime-power identity λ(p) = φ(p)). Because 4 ≠ 8 = φ(15), not_exists_primitiveRoot_fifteen concludes there is no primitive root modulo 15 — the proper divisor λ(15) < φ(15) is the obstruction, reflecting (ℤ/15ℤ)ˣ ≅ ℤ/2 × ℤ/4. By contrast exists_primitiveRoot_seven gives λ(7) = φ(7) = 6, so a primitive root exists mod 7. These are explicit yes/no certificates produced directly by the λ = φ criterion."
+  }
+]

--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "euler-totient-oq-01-oq-02-oq-03",
+  "title": "The Carmichael Function as the Maximal Order, and Primitive Roots: λ(n) = φ(n) ⟺ a primitive root exists",
+  "slug": "euler-totient-oq-01-oq-02-oq-03",
+  "description": "The grandparent chain (euler-totient → OQ-01 → OQ-02) packages the prime-power values of the Carmichael function λ(n) = exponent of (ℤ/nℤ)ˣ. Its closing open questions ask for (1) the closed form λ(n) = lcm of prime-power values, and (2) the application that the maximal multiplicative order modulo n equals λ(n), characterizing the n with primitive roots. This entry answers both: λ(n) bounds every unit's order (orderOf a ∣ λ(n)) and is attained (some unit has order exactly λ(n)), so λ(n) is the maximal multiplicative order; consequently (ℤ/nℤ)ˣ is cyclic and a primitive root exists iff λ(n) = φ(n). Since λ(n) ∣ φ(n) can be proper (λ(15) = 4 < 8 = φ(15)), primitive roots fail for many n. Fully verified, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Primitive_root_modulo_n",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ01OQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "carmichael-function",
+      "euler-totient",
+      "primitive-root",
+      "unit-group",
+      "multiplicative-order",
+      "cyclic-group",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.carmichael_eq_exponent'",
+        "description": "λ(n) = exponent of the unit group (ℤ/nℤ)ˣ",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "Monoid.exists_orderOf_eq_exponent",
+        "description": "A finite commutative monoid has an element whose order equals the exponent",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.order_dvd_exponent",
+        "description": "Every element's order divides the group exponent",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "IsCyclic.iff_exponent_eq_card",
+        "description": "A finite commutative group is cyclic iff its exponent equals its order",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "isCyclic_iff_exists_orderOf_eq_natCard",
+        "description": "A finite group is cyclic iff it has an element of order equal to its cardinality",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "ArithmeticFunction.carmichael_factorization",
+        "description": "λ(n) = lcm over primes p ∣ n of λ(p^{vₚ(n)})",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "ArithmeticFunction.carmichael_mul",
+        "description": "λ(ab) = lcm(λ(a), λ(b)) for coprime a, b",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "ZMod.card_units_eq_totient",
+        "description": "|(ℤ/nℤ)ˣ| = φ(n)",
+        "module": "Mathlib.Data.Nat.Totient"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's theorem says a^{φ(n)} ≡ 1 (mod n) for every a coprime to n. The optimal exponent is not φ(n) but the Carmichael function λ(n) — the exponent of the unit group (ℤ/nℤ)ˣ — which always divides φ(n) and is often strictly smaller. The multiplicative order of any single unit divides λ(n), and λ(n) is exactly the largest order that occurs (a finite abelian group always contains an element of order equal to its exponent). A primitive root modulo n is a unit of maximal possible order φ(n), i.e. a generator of (ℤ/nℤ)ˣ; one exists precisely when the group is cyclic, equivalently when the maximal order λ(n) reaches the group order φ(n). The classical theorem of Gauss identifies these n as 1, 2, 4, pᵏ, and 2pᵏ for odd primes p; for all other n (such as 8, 15, 24) there is no primitive root because λ(n) is a proper divisor of φ(n).\n\nMathlib defines λ = ArithmeticFunction.Carmichael as the group exponent and provides the cyclicity classification ZMod.isCyclic_units_iff, but it does not phrase the connection through the Carmichael function. This entry supplies that bridge: λ(n) is the maximal multiplicative order, and the primitive-root criterion is exactly λ(n) = φ(n).",
+    "problemStatement": "Formalize the closed form λ(n) = lcm of its prime-power values, and the application that the maximal multiplicative order modulo n equals λ(n): show λ(n) bounds and is attained by unit orders, deduce that (ℤ/nℤ)ˣ is cyclic — equivalently a primitive root exists — iff λ(n) = φ(n), and exhibit the divisor gap (λ(15) = 4 < 8 = φ(15), no primitive root mod 15) against the prime case (λ(7) = 6 = φ(7), a primitive root mod 7).",
+    "proofStrategy": "Everything routes through carmichael_eq_exponent' : λ(n) = exponent (ℤ/nℤ)ˣ. The upper bound orderOf a ∣ λ(n) is Monoid.order_dvd_exponent; attainment is Monoid.exists_orderOf_eq_exponent applied to the finite (hence ExponentExists) unit group — together these make λ(n) the maximal order. The cyclicity criterion rewrites IsCyclic.iff_exponent_eq_card with card units = φ(n) (ZMod.card_units_eq_totient) into λ(n) = φ(n); the primitive-root version rewrites isCyclic_iff_exists_orderOf_eq_natCard the same way, turning 'cyclic' into 'an element of order φ(n) exists'. The closed form restates carmichael_factorization. The concrete λ(15) = 4 uses carmichael_mul on 15 = 3·5 with λ(3) = 2, λ(5) = 4 from the odd-prime-power identity, and λ(7) = 6 is the same identity at p = 7.",
+    "keyInsights": [
+      "λ(n) plays two roles at once: it is an upper bound on every unit's multiplicative order (orderOf a ∣ λ(n)) and is attained by some unit — so it is exactly the maximal multiplicative order modulo n.",
+      "A primitive root is a unit of order φ(n); since the maximal order is λ(n) and λ(n) ∣ φ(n) always, a primitive root exists iff λ(n) = φ(n), i.e. iff the unit group is cyclic.",
+      "The criterion λ(n) = φ(n) makes the obstruction visible: whenever the unit group factors as a product of two nontrivial cyclic groups (e.g. n = 15, 8, 24), λ is a proper divisor of φ and no primitive root exists.",
+      "λ(15) = lcm(λ(3), λ(5)) = lcm(2, 4) = 4 is a strict divisor of φ(15) = 8 — a concrete certificate that there is no primitive root modulo 15, while λ(7) = φ(7) = 6 gives one modulo 7.",
+      "The same exponent machinery that defines λ for prime powers extends to all n via carmichael_factorization (λ = lcm of prime-power values), completing the closed form requested by the parent's first open question."
+    ],
+    "prerequisites": [
+      "The unit group (ℤ/nℤ)ˣ, its order φ(n), and multiplicative order of an element",
+      "The exponent of a finite group and the Carmichael function λ as that exponent",
+      "A finite abelian group contains an element of order equal to its exponent",
+      "Cyclic groups: cyclic ⟺ exponent equals order ⟺ a generator exists",
+      "Gauss's classification of n admitting a primitive root (1, 2, 4, pᵏ, 2pᵏ)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "maximal-order",
+      "title": "Section I: λ(n) is the Maximal Multiplicative Order",
+      "startLine": 48,
+      "endLine": 79,
+      "summary": "carmichael_pos (λ(n) > 0), the closed form carmichael_factorization' (λ(n) = lcm of prime-power values, OQ-1), the upper bounds orderOf_dvd_carmichael / orderOf_le_carmichael, and exists_orderOf_eq_carmichael — some unit has order exactly λ(n). Bound plus attainment make λ(n) the maximal order.",
+      "mathContext": "Routing λ = exponent (ℤ/nℤ)ˣ through Monoid.order_dvd_exponent and Monoid.exists_orderOf_eq_exponent on the finite unit group."
+    },
+    {
+      "id": "primitive-root-criterion",
+      "title": "Section II: Cyclicity and the Primitive-Root Criterion",
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "carmichael_le_totient (λ(n) ≤ φ(n)), isCyclic_units_iff_carmichael_eq_totient (the unit group is cyclic ⟺ λ(n) = φ(n)), and the headline exists_primitiveRoot_iff_carmichael_eq_totient — a primitive root mod n exists ⟺ λ(n) = φ(n).",
+      "mathContext": "Rewriting IsCyclic.iff_exponent_eq_card and isCyclic_iff_exists_orderOf_eq_natCard with |units| = φ(n)."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Section III: Concrete Certificates (15 vs 7)",
+      "startLine": 100,
+      "endLine": 124,
+      "summary": "carmichael_fifteen (λ(15) = 4 via carmichael_mul and the odd-prime values), not_exists_primitiveRoot_fifteen (no primitive root mod 15, since 4 ≠ 8 = φ(15)), and exists_primitiveRoot_seven (λ(7) = φ(7) = 6, so a primitive root mod 7 exists).",
+      "mathContext": "Turning the λ = φ criterion into explicit yes/no certificates for primitive roots."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 126 lines and 11 theorems characterizing the Carmichael function λ(n) as the maximal multiplicative order modulo n — λ(n) bounds every unit's order (orderOf a ∣ λ(n)) and is attained — and deducing that the unit group (ℤ/nℤ)ˣ is cyclic, equivalently a primitive root exists, iff λ(n) = φ(n). It includes the closed form λ(n) = lcm of prime-power values and concrete certificates: λ(15) = 4 < 8 = φ(15) (no primitive root mod 15) versus λ(7) = 6 = φ(7) (primitive root mod 7).",
+    "implications": "This answers both of the parent OQ-01-OQ-02's open questions: the closed form via carmichael_factorization, and the application identifying λ(n) as the maximal order and λ(n) = φ(n) as the primitive-root criterion. It connects Mathlib's Carmichael function to its cyclicity classification of unit groups, which the library states (ZMod.isCyclic_units_iff) but never phrases through λ. The criterion λ(n) = φ(n) is the computable form of Gauss's primitive-root theorem: a primitive root exists exactly when the reduced totient meets the totient.",
+    "openQuestions": [
+      "Combine isCyclic_units_iff_carmichael_eq_totient with Mathlib's ZMod.isCyclic_units_iff to prove the explicit equivalence λ(n) = φ(n) ⟺ n ∈ {1, 2, 4, pᵏ, 2pᵏ}, recovering Gauss's classification directly in terms of the Carmichael function.",
+      "Quantify the gap: characterize or bound φ(n)/λ(n) (the number of cyclic factors of the unit group) and relate it to the count of distinct prime factors and the power of 2 dividing n."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Carmichael",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["ArithmeticFunction", "Nat"],
+    "namespace": "EulerTotientOQ01OQ02OQ03",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/EulerTotientOQ01OQ02OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the Carmichael function on prime powers. This entry answers its two closing open questions — the closed form λ(n) = lcm of prime-power values, and the application that λ(n) is the maximal multiplicative order, with primitive roots existing iff λ(n) = φ(n)."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "extends",
+      "description": "Grandparent chain: Euler's totient φ. This entry pins down exactly when Euler's theorem is optimal (a generator/primitive root exists), namely λ(n) = φ(n)."
+    }
+  ],
+  "references": [
+    {
+      "key": "Carmichael1910",
+      "citation": "Carmichael, R.D., Note on a new number theory function, Bull. Amer. Math. Soc. 16 (1910), 232–238.",
+      "type": "paper"
+    },
+    {
+      "key": "HardyWright",
+      "citation": "Hardy, G.H. and Wright, E.M., An Introduction to the Theory of Numbers, 6th ed., Oxford University Press (2008), §6–7 (primitive roots).",
+      "type": "book"
+    },
+    {
+      "key": "PrimitiveRootWiki",
+      "citation": "Primitive root modulo n, Wikipedia.",
+      "type": "web"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **both** open questions of the parent `euler-totient-oq-01-oq-02` (the Carmichael function on prime powers):

1. **Closed form (OQ-1):** `carmichael_factorization'` — `λ(n) = lcm` over prime powers `p^{vₚ(n)}` of `λ(p^{vₚ(n)})`.
2. **Application (OQ-2):** `λ(n)` is the **maximal multiplicative order** modulo `n`, and a **primitive root exists ⟺ λ(n) = φ(n)**.

The genuinely-new content is the bridge from Mathlib's Carmichael function to multiplicative order and the primitive-root criterion. Mathlib has the cyclicity classification (`ZMod.isCyclic_units_iff`) but never phrases it through `λ`.

## Main results (11 theorems, 126 lines)

- `orderOf_dvd_carmichael` / `orderOf_le_carmichael` — `λ(n)` bounds every unit's order (`a^{λ(n)} = 1`).
- `exists_orderOf_eq_carmichael` — `λ(n)` is **attained** by some unit; with the bound, `λ(n)` is the maximal order.
- `carmichael_le_totient` — `λ(n) ≤ φ(n)`.
- `isCyclic_units_iff_carmichael_eq_totient` — `(ℤ/nℤ)ˣ` cyclic `⟺ λ(n) = φ(n)`.
- `exists_primitiveRoot_iff_carmichael_eq_totient` — **a primitive root mod `n` exists `⟺ λ(n) = φ(n)`** (headline).
- `carmichael_fifteen`, `not_exists_primitiveRoot_fifteen` — `λ(15) = 4 < 8 = φ(15)`, so **no** primitive root mod 15.
- `exists_primitiveRoot_seven` — `λ(7) = 6 = φ(7)`, so a primitive root mod 7 exists.

## Verification

- **0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; **no `native_decide`** — `decide` uses kernel reduction only).
- Built on host via `lake env lean` (docker down) against Mathlib 4.26.0; `#print axioms` confirmed on the headline theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)