### PR TITLE
Enrich Negative Pell x²−2y²=−1 (ζ-powers): add index.ts + annotations

### DIFF
--- a/src/data/proofs/pell-equation-oq-06-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Supplying the ring structure the parent only gestured at",
+    "content": "The parent entry (`pell-equation-oq-06`) generates solutions of the negative Pell equation `x² − 2y² = −1` by the elementary substitution `(x,y) ↦ (3x+4y, 2x+3y)` and remarks — without formalizing — that this map 'is multiplication by 3 + 2√2 in ℤ[√2]'. This file makes that ring-theoretic claim precise inside Mathlib's quadratic-integer ring `ℤ√2 = Zsqrtd 2`. The fundamental unit `ζ = 1 + √2 = ⟨1,1⟩` has norm −1; its square `ζ² = 3 + 2√2` is the classical norm-+1 Pell unit; and the parent's chain is realized exactly by the odd powers `⟨xₙ,yₙ⟩ = ζ^(2n+1)`. Multiplicativity of the norm then re-derives the parent's term-by-term identity in one computation and exposes the full norm dichotomy.",
+    "mathContext": "$\\mathbb{Z}[\\sqrt2]=\\texttt{Zsqrtd}\\,2$ with $N(\\langle a,b\\rangle)=a^2-2b^2$; $\\zeta=1+\\sqrt2$, $N(\\zeta)=-1$, $\\zeta^2=3+2\\sqrt2$, $N(\\zeta^2)=+1$.",
+    "significance": "key",
+    "relatedConcepts": ["negative Pell equation", "ℤ[√2] = Zsqrtd 2", "fundamental unit", "norm multiplicativity", "Brahmagupta composition"],
+    "prerequisites": ["Pell's equation", "quadratic integer rings", "Diophantine equations"]
+  },
+  {
+    "id": "ann-zeta-def",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 69, "endLine": 75 },
+    "type": "definition",
+    "title": "The fundamental unit ζ = 1 + √2 and its norm",
+    "content": "`ζ : ℤ√2 := ⟨1,1⟩` casts the parent's fundamental solution `(1,1)` as the quadratic integer `1 + √2`. `norm_ζ` computes `N(ζ) = 1² − 2·1² = −1` by unfolding `Zsqrtd.norm_def`. The sign is the whole point: norm −1 means ζ solves the *negative* Pell equation, not the classical positive one, so ζ sits outside Mathlib's `Pell.Solution₁` API which models only the norm-+1 case.",
+    "mathContext": "$\\zeta = \\langle 1,1\\rangle = 1+\\sqrt2$, $\\;N(\\zeta) = 1^2 - 2\\cdot 1^2 = -1$.",
+    "significance": "key",
+    "relatedConcepts": ["Zsqrtd norm form", "negative Pell fundamental solution", "quadratic integers"],
+    "prerequisites": ["norm of a quadratic field", "Mathlib Zsqrtd"]
+  },
+  {
+    "id": "ann-isunit",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 77, "endLine": 81 },
+    "type": "technique",
+    "title": "ζ is a unit — the criterion |N| = 1",
+    "content": "`isUnit_ζ` proves ζ is a unit of ℤ[√2] by rewriting with `Zsqrtd.norm_eq_one_iff` (a quadratic integer is a unit iff `|N| = 1`) and then `norm_ζ`, leaving the decidable goal `|−1| = 1` discharged by kernel `decide`. Because the unit group of ℤ[√2] has rank 1 (Dirichlet's unit theorem), being a unit of minimal norm makes ζ the *fundamental* unit: every unit is `±ζᵏ`.",
+    "mathContext": "$z\\in\\mathbb{Z}[\\sqrt d]^\\times \\iff |N(z)|=1$; here $|N(\\zeta)|=|-1|=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit group of ℤ[√d]", "Dirichlet unit theorem", "norm_eq_one_iff", "kernel decide"],
+    "prerequisites": ["units in a commutative ring", "Dirichlet's unit theorem"]
+  },
+  {
+    "id": "ann-zeta-sq",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 83, "endLine": 92 },
+    "type": "insight",
+    "title": "ζ² = 3 + 2√2 — squaring norm −1 into the norm +1 Pell unit",
+    "content": "`ζ_sq` proves `ζ² = ⟨3,2⟩ = 3 + 2√2` by `pow_two` then matching real and imaginary parts via `Zsqrtd.ext` with `Zsqrtd.re_mul` / `Zsqrtd.im_mul`. `norm_ζ_sq` records `N(ζ²) = +1`. This is the conceptual hinge: starting from a norm −1 element and advancing by its square (norm +1) keeps the running norm at −1, while ζ² is precisely the classical fundamental unit `3 + 2√2` that drives the *positive* Pell equation. Squaring is the bridge between the two equations.",
+    "mathContext": "$\\zeta^2 = (1+\\sqrt2)^2 = 3+2\\sqrt2 = \\langle 3,2\\rangle$, $\\;N(\\zeta^2)=3^2-2\\cdot2^2=1$.",
+    "significance": "key",
+    "relatedConcepts": ["Zsqrtd multiplication", "Zsqrtd.ext", "positive Pell fundamental unit", "norm dichotomy"],
+    "prerequisites": ["complex/quadratic multiplication", "component extensionality"]
+  },
+  {
+    "id": "ann-norm-pow",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 94, "endLine": 102 },
+    "type": "technique",
+    "title": "Norm multiplicativity under powers — Brahmagupta's engine",
+    "content": "`norm_pow` proves `N(zᵏ) = N(z)ᵏ` for any `z ∈ ℤ√d` by a two-line induction off `Zsqrtd.norm_mul`. This is the formal content of Brahmagupta's composition law (628 CE): the norm is a monoid homomorphism `ℤ[√d] → ℤ`, so it carries products to products and powers to powers. It is the single engine that collapses the parent's term-by-term induction into one computation downstream.",
+    "mathContext": "$N(z^k)=N(z)^k$; the norm is multiplicative ($N(zw)=N(z)N(w)$, Brahmagupta).",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative norm", "Brahmagupta composition", "Zsqrtd.norm_mul", "induction on exponent"],
+    "prerequisites": ["monoid homomorphisms", "induction"]
+  },
+  {
+    "id": "ann-step-eq-mul",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "insight",
+    "title": "The parent's step map IS multiplication by ζ²",
+    "content": "`negPellSeq_succ_eq_mul` proves the parent's recurrence `(x,y) ↦ (3x+4y, 2x+3y)` equals `· * ζ²` in ℤ[√2]. Under the `Zsqrtd` product `⟨x,y⟩·⟨3,2⟩ = ⟨3x + 2·2y, 2x + 3y⟩ = ⟨3x+4y, 2x+3y⟩` — the `2·2y` term comes from the `d = 2` in the ring's multiplication rule. The proof rewrites `ζ_sq` and the parent's `negPellSeq_succ`, then matches components with `Zsqrtd.ext` and closes with `ring`. This turns an ad hoc integer substitution into a single algebraic operation.",
+    "mathContext": "$\\langle x,y\\rangle\\cdot\\langle 3,2\\rangle = \\langle 3x+4y,\\,2x+3y\\rangle$ in $\\texttt{Zsqrtd}\\,2$.",
+    "significance": "key",
+    "relatedConcepts": ["unit group action", "Zsqrtd.re_mul / im_mul", "recurrence as multiplication", "step map"],
+    "prerequisites": ["Zsqrtd multiplication rule", "polynomial identities"]
+  },
+  {
+    "id": "ann-eq-pow",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 116, "endLine": 126 },
+    "type": "insight",
+    "title": "The bridge: the chain is the odd powers of ζ",
+    "content": "`negPellSeq_eq_pow` is the central identity: `⟨xₙ,yₙ⟩ = ζ^(2n+1)` as elements of ℤ[√2]. The induction uses `2(n+1)+1 = (2n+1)+2`, so `ζ^(2(n+1)+1) = ζ^(2n+1)·ζ²`; by the inductive hypothesis the left factor is `⟨xₙ,yₙ⟩`, and multiplication by ζ² is the parent's step (the previous lemma), reproducing `⟨xₙ₊₁,yₙ₊₁⟩`. Starting at a norm −1 element (exponent 1) and stepping by ζ² (which adds 2 to the exponent) keeps the exponent odd forever — so the negative-Pell chain is exactly the *odd half* of the powers of the fundamental unit.",
+    "mathContext": "$\\langle x_n,y_n\\rangle = (1+\\sqrt2)^{2n+1}$; the step adds $2$ to a starting exponent of $1$, keeping it odd.",
+    "significance": "key",
+    "relatedConcepts": ["powers of the fundamental unit", "induction on exponent", "odd powers", "orbit of the unit group"],
+    "prerequisites": ["induction", "exponent arithmetic", "Zsqrtd"]
+  },
+  {
+    "id": "ann-norm-via-unit",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 132, "endLine": 141 },
+    "type": "insight",
+    "title": "Conceptual re-derivation of x² − 2y² = −1",
+    "content": "`negPellSeq_norm_via_unit` re-proves the parent's `negPellSeq_norm` not by a term-by-term induction but in a single computation. After identifying the `Zsqrtd` norm of `⟨xₙ,yₙ⟩` with `xₙ² − 2yₙ²` (`Zsqrtd.norm_def` + `ring`), it rewrites by the bridge `negPellSeq_eq_pow`, then `norm_pow` and `norm_ζ` give `N(ζ)^(2n+1) = (−1)^(2n+1)`, finished by `Odd.neg_one_pow` (with the witness `2n+1 = 2·n+1`). The work shifts entirely from arithmetic on each term to a structural property of the single unit ζ.",
+    "mathContext": "$x_n^2-2y_n^2 = N\\big((1+\\sqrt2)^{2n+1}\\big) = N(\\zeta)^{2n+1} = (-1)^{2n+1} = -1$.",
+    "significance": "key",
+    "relatedConcepts": ["Odd.neg_one_pow", "norm_def", "conceptual vs computational proof", "structural reasoning"],
+    "prerequisites": ["parity of exponents", "norm multiplicativity"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 143, "endLine": 156 },
+    "type": "concept",
+    "title": "The norm dichotomy: odd vs even powers",
+    "content": "`norm_ζ_pow_odd` (`N(ζ^(2n+1)) = −1`) and `norm_ζ_pow_even` (`N(ζ^(2n)) = +1`) make explicit the structural fact invisible to the elementary parent: the powers of the fundamental unit split by parity into the two Pell equations. Odd powers solve `x² − 2y² = −1` (the negative-Pell chain), while even powers `ζ^(2n) = (3+2√2)ⁿ` solve `x² − 2y² = +1` — exactly the case modeled by Mathlib's `Pell.Solution₁`. The odd proof uses `Odd.neg_one_pow`; the even proof uses `pow_mul` so `(N(ζ)²)ⁿ = 1ⁿ`.",
+    "mathContext": "Odd: $N(\\zeta^{2n+1})=(-1)^{2n+1}=-1$. Even: $N(\\zeta^{2n})=((-1)^2)^n=1$.",
+    "significance": "key",
+    "relatedConcepts": ["parity dichotomy", "Pell.Solution₁", "positive vs negative Pell", "unit group structure"],
+    "prerequisites": ["parity", "power laws"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "pell-equation-oq-06-oq-02",
+    "range": { "startLine": 158, "endLine": 179 },
+    "type": "context",
+    "title": "Explicit small powers as sanity checks",
+    "content": "The closing examples confirm the abstract identities on concrete data: `ζ¹ = ⟨1,1⟩`, `ζ³ = ⟨7,5⟩`, `ζ⁵ = ⟨41,29⟩` (matching the parent's chain `(1,1)→(7,5)→(41,29)`), each by kernel `decide`. The norm checks `(ζ¹).norm = −1`, `(ζ³).norm = −1`, `(ζ²).norm = +1`, `(ζ⁴).norm = +1` instantiate the dichotomy lemmas. The `#check` block documents the public API of the file.",
+    "mathContext": "$\\zeta^1=\\langle1,1\\rangle,\\ \\zeta^3=\\langle7,5\\rangle,\\ \\zeta^5=\\langle41,29\\rangle$ — the parent's chain as odd powers.",
+    "significance": "context",
+    "relatedConcepts": ["sanity checks", "kernel decide", "worked examples", "the parent chain"],
+    "prerequisites": ["decidable evaluation"]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-06-oq-02/index.ts
+++ b/src/data/proofs/pell-equation-oq-06-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ06OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOq06Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOq06Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOq06Oq02Data: ProofData = {
+  proof: pellEquationOq06Oq02Proof,
+  annotations: pellEquationOq06Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-06-oq-02`.

**Critical fix:** the entry was missing `index.ts`, so Vite's `import.meta.glob` could not discover it and the page rendered **"proof not found"** on the live site despite appearing in the gallery listing. Added the standard `index.ts`.

**Annotation coverage:** added `annotations.json` with 10 annotations spanning the whole file (header → fundamental unit ζ=1+√2 → norm multiplicativity → step-map-is-·ζ² → the chain=odd-powers bridge → conceptual norm re-derivation → odd/even norm dichotomy → sanity checks). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

Existing meta.json overview/conclusion were already rich and were left intact. `status: verified`, `axiomCount: 0` confirmed accurate against the Lean source (three `decide` uses are kernel decide, no `native_decide`/`Lean.ofReduceBool`).

`pnpm build` passes.