### PR TITLE
research(frobenius-number-oq-01-oq-03-oq-01): type one ⟹ symmetric — generator-agnostic converse [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean
@@ -1,0 +1,285 @@
+/-
+  OQ-01-OQ-03-OQ-01: Type One ⟹ Symmetric — the converse, generator-agnostic
+  (frobenius-number-oq-01-oq-03-oq-01)
+
+  The parent `frobenius-number-oq-01-oq-03` proves, for the *specific* two-generator
+  semigroup `⟨a, b⟩`, that it is **symmetric** and has **type one**
+  (`pseudoFrobenius_setOf_eq : PF = {g}`).  Its docstring leaves open the converse:
+
+  > *"Prove the converse: a numerical semigroup of type 1 (`|PF(S)| = 1`) is
+  >  symmetric, completing the 'symmetric ⟺ type one' equivalence in a
+  >  generator-agnostic setting."*
+
+  This file supplies exactly that — and both directions — for an **arbitrary**
+  numerical semigroup `S ⊆ ℕ` (closed under addition, containing `0`, with finite
+  complement), with no reference to generators.  The headline is the classical
+  Kunz / Gorenstein equivalence
+
+  > `S` is symmetric  ⟺  `S` has type one  (`|PF(S)| = 1`).
+
+  ## Statements (all generator-agnostic, `S : Set ℕ`)
+
+  * `IsFrobeniusNumber S g` — `g` is the largest gap: `g ∉ S` and everything above
+    `g` lies in `S`.  Proved **unique** (`isFrobeniusNumber_unique`) and **existent**
+    for any proper numerical semigroup (`exists_isFrobeniusNumber`).
+  * `IsSymmetric S g` — the gap/element duality `k ∈ S ↔ g - k ∉ S` on `0 ≤ k ≤ g`.
+  * `IsPF S x` — `x` is pseudo-Frobenius: a gap all of whose translates by nonzero
+    semigroup elements re-enter `S`.  `{x | IsPF S x}.ncard` is the **type**.
+
+  ## Main results
+
+  * `gap_dominated` — every gap is `⪯`-dominated by a pseudo-Frobenius number
+    (the structural engine of the converse): the finite set of gaps `y ≥ x` with
+    `y - x ∈ S` has a maximum, and that maximum is pseudo-Frobenius.
+  * `isPF_setOf_eq_of_isSymmetric` — **symmetric ⟹ type one**: `{x | IsPF S x} = {g}`.
+  * `isSymmetric_of_isPF_ncard_one` — **type one ⟹ symmetric** (the open converse):
+    if `g` is the unique pseudo-Frobenius number then `S` is symmetric.
+  * `isSymmetric_iff_isPF_ncard_one` — the full equivalence `IsSymmetric ↔ type = 1`.
+
+  ## Subsumes the parent
+
+  The two-generator semigroup `{n | Representable a b n}` is shown to be a numerical
+  semigroup with Frobenius number `frobeniusNumber a b` (`representable_*`), so the
+  general equivalence recovers the parent's symmetric/type-one results
+  (`representable_type_one`) from a single source.
+
+  ## Status: 0 sorries, 0 axioms (built on the verified parent chain).
+-/
+import Mathlib
+import Proofs.FrobeniusNumber
+import Proofs.FrobeniusNumberOQ01OQ03
+
+namespace FrobeniusNumberOQ01OQ03OQ01
+
+open scoped Classical
+
+/-! ## Generator-agnostic numerical semigroups -/
+
+/-- A **numerical semigroup**: a set of naturals containing `0`, closed under
+addition, with finite (and nonempty) complement.  The last two conditions say the
+gap set `ℕ \ S` is a nonempty finite set — exactly when a Frobenius number exists. -/
+def IsNumericalSemigroup (S : Set ℕ) : Prop :=
+  0 ∈ S ∧ (∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) ∧ {n | n ∉ S}.Finite ∧ (∃ n, n ∉ S)
+
+/-- `g` is the **Frobenius number** of `S`: the largest gap.  Equivalently `g ∉ S`
+and every `n > g` is in `S`. -/
+def IsFrobeniusNumber (S : Set ℕ) (g : ℕ) : Prop :=
+  g ∉ S ∧ ∀ n, g < n → n ∈ S
+
+/-- `S` is **symmetric** with respect to its Frobenius number `g`: for every
+`k ≤ g`, exactly one of `k`, `g - k` is representable. -/
+def IsSymmetric (S : Set ℕ) (g : ℕ) : Prop :=
+  ∀ k ≤ g, k ∈ S ↔ g - k ∉ S
+
+/-- `x` is a **pseudo-Frobenius number** of `S`: a gap such that `x + s ∈ S` for
+every nonzero `s ∈ S`.  The cardinality of `{x | IsPF S x}` is the **type** of `S`. -/
+def IsPF (S : Set ℕ) (x : ℕ) : Prop :=
+  x ∉ S ∧ ∀ s ∈ S, 0 < s → x + s ∈ S
+
+/-! ## The Frobenius number: existence and uniqueness -/
+
+/-- The Frobenius number, when it exists, is **unique**. -/
+theorem isFrobeniusNumber_unique {S : Set ℕ} {g₁ g₂ : ℕ}
+    (h₁ : IsFrobeniusNumber S g₁) (h₂ : IsFrobeniusNumber S g₂) : g₁ = g₂ := by
+  rcases lt_trichotomy g₁ g₂ with h | h | h
+  · exact absurd (h₁.2 g₂ h) h₂.1
+  · exact h
+  · exact absurd (h₂.2 g₁ h) h₁.1
+
+/-- Every proper numerical semigroup **has** a Frobenius number: the maximum of the
+nonempty finite gap set. -/
+theorem exists_isFrobeniusNumber {S : Set ℕ} (hfin : {n | n ∉ S}.Finite)
+    (hproper : ∃ n, n ∉ S) : ∃ g, IsFrobeniusNumber S g := by
+  classical
+  obtain ⟨n₀, hn₀⟩ := hproper
+  have hne : hfin.toFinset.Nonempty := ⟨n₀, by rw [Set.Finite.mem_toFinset]; exact hn₀⟩
+  refine ⟨hfin.toFinset.max' hne, ?_, ?_⟩
+  · have := hfin.toFinset.max'_mem hne
+    rwa [Set.Finite.mem_toFinset] at this
+  · intro n hn
+    by_contra hnS
+    have hmem : n ∈ hfin.toFinset := by rw [Set.Finite.mem_toFinset]; exact hnS
+    have := hfin.toFinset.le_max' n hmem
+    omega
+
+/-! ## Pseudo-Frobenius basics -/
+
+/-- The Frobenius number is itself pseudo-Frobenius: it is a gap, and adding any
+positive semigroup element lands strictly above `g`, hence back inside `S`. -/
+theorem frobeniusNumber_isPF {S : Set ℕ} {g : ℕ} (hg : IsFrobeniusNumber S g) :
+    IsPF S g :=
+  ⟨hg.1, fun s _ hspos => hg.2 (g + s) (by omega)⟩
+
+/-- Every pseudo-Frobenius number is `≤ g`: it is a gap, and nothing above `g` is a
+gap. -/
+theorem isPF_le_frobeniusNumber {S : Set ℕ} {g x : ℕ} (hg : IsFrobeniusNumber S g)
+    (hx : IsPF S x) : x ≤ g := by
+  by_contra h
+  exact hx.1 (hg.2 x (by omega))
+
+/-! ## The structural engine: every gap is dominated by a pseudo-Frobenius number -/
+
+/-- **Domination lemma.**  For any gap `x`, the finite set of gaps `y ≥ x` with
+`y - x ∈ S` has a maximum `m`, and `m` is pseudo-Frobenius.  Thus every gap sits
+below some pseudo-Frobenius number in the order `u ⪯ v ⟺ v - u ∈ S`.  This is the
+heart of the converse `type one ⟹ symmetric`. -/
+theorem gap_dominated {S : Set ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    {x : ℕ} (hx : x ∉ S) : ∃ m, IsPF S m ∧ x ≤ m ∧ m - x ∈ S := by
+  classical
+  -- `T` : gaps `y ≥ x` whose distance to `x` is in `S`.
+  set T : Set ℕ := {y | y ∉ S ∧ x ≤ y ∧ y - x ∈ S} with hT
+  have hTsub : T ⊆ {n | n ∉ S} := fun y hy => hy.1
+  have hTfin : T.Finite := hfin.subset hTsub
+  have hxT : x ∈ T := ⟨hx, le_rfl, by rw [Nat.sub_self]; exact h0⟩
+  have hFne : hTfin.toFinset.Nonempty := ⟨x, by rw [Set.Finite.mem_toFinset]; exact hxT⟩
+  -- Take the maximum `m` of `T`.
+  set m : ℕ := hTfin.toFinset.max' hFne with hm
+  have hmT : m ∈ T := by
+    have := hTfin.toFinset.max'_mem hFne
+    rwa [Set.Finite.mem_toFinset] at this
+  obtain ⟨hm_notS, hxm, hmx_S⟩ := hmT
+  have hmax : ∀ y ∈ T, y ≤ m := by
+    intro y hy
+    apply Finset.le_max'
+    rw [Set.Finite.mem_toFinset]; exact hy
+  refine ⟨m, ⟨hm_notS, ?_⟩, hxm, hmx_S⟩
+  -- `m` is pseudo-Frobenius: any `m + s` (`s ∈ S`, `s > 0`) is in `S`, else it would
+  -- be a strictly larger member of `T`.
+  intro s hs hspos
+  by_contra hms
+  have hmsT : m + s ∈ T := by
+    refine ⟨hms, by omega, ?_⟩
+    have hsub : (m + s) - x = (m - x) + s := by omega
+    rw [hsub]; exact hadd _ hmx_S _ hs
+  have := hmax _ hmsT
+  omega
+
+/-! ## Direction 1: symmetric ⟹ type one -/
+
+/-- **Symmetric ⟹ type one.**  If `S` is symmetric then its set of pseudo-Frobenius
+numbers is the singleton `{g}`: any pseudo-Frobenius `x < g` would, by symmetry, have
+`g - x ∈ S` positive, forcing `x + (g - x) = g ∈ S` — impossible. -/
+theorem isPF_setOf_eq_of_isSymmetric {S : Set ℕ} {g : ℕ} (hg : IsFrobeniusNumber S g)
+    (hsym : IsSymmetric S g) : {x | IsPF S x} = {g} := by
+  ext x
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · intro hx
+    rcases eq_or_lt_of_le (isPF_le_frobeniusNumber hg hx) with heq | hlt
+    · exact heq
+    · exfalso
+      -- `x` is a gap, `x < g`, so by symmetry `g - x ∈ S`.
+      have hgx : g - x ∈ S := by
+        by_contra hgxnot
+        exact hx.1 ((hsym x (le_of_lt hlt)).mpr hgxnot)
+      have hpos : 0 < g - x := by omega
+      have hmem : x + (g - x) ∈ S := hx.2 (g - x) hgx hpos
+      rw [show x + (g - x) = g by omega] at hmem
+      exact hg.1 hmem
+  · rintro rfl; exact frobeniusNumber_isPF hg
+
+/-! ## Direction 2: type one ⟹ symmetric (the open converse) -/
+
+/-- **Type one ⟹ symmetric** (the converse left open by the parent).  If the only
+pseudo-Frobenius number is `g`, then `S` is symmetric.  The reverse inclusion uses
+`gap_dominated`: a gap `k` is dominated by a pseudo-Frobenius number, which must be
+`g`, so `g - k ∈ S`. -/
+theorem isSymmetric_of_isPF_ncard_one {S : Set ℕ} {g : ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    (hg : IsFrobeniusNumber S g) (htype : {x | IsPF S x}.ncard = 1) :
+    IsSymmetric S g := by
+  classical
+  -- From `ncard = 1` and `g ∈ PF`, the set of pseudo-Frobenius numbers is `{g}`.
+  obtain ⟨a, ha⟩ := Set.ncard_eq_one.mp htype
+  have hg_pf : g ∈ {x | IsPF S x} := frobeniusNumber_isPF hg
+  have hga : a = g := by rw [ha, Set.mem_singleton_iff] at hg_pf; exact hg_pf.symm
+  subst hga
+  intro k hk
+  constructor
+  · -- `k ∈ S → g - k ∉ S`: else `k + (g - k) = g ∈ S`, contradicting `g ∉ S`.
+    intro hkS hgkS
+    have hmem : k + (a - k) ∈ S := hadd k hkS (a - k) hgkS
+    rw [show k + (a - k) = a by omega] at hmem
+    exact hg.1 hmem
+  · -- `g - k ∉ S → k ∈ S`, contrapositive: a gap `k` has `g - k ∈ S`.
+    intro hgk
+    by_contra hkS
+    obtain ⟨m, hm_pf, _, hmk⟩ := gap_dominated h0 hadd hfin hkS
+    have hmS : m ∈ {x | IsPF S x} := hm_pf
+    rw [ha, Set.mem_singleton_iff] at hmS
+    subst hmS
+    exact hgk hmk
+
+/-! ## The equivalence -/
+
+/-- **Symmetric ⟺ type one** for any numerical semigroup with Frobenius number `g`. -/
+theorem isSymmetric_iff_isPF_ncard_one {S : Set ℕ} {g : ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    (hg : IsFrobeniusNumber S g) :
+    IsSymmetric S g ↔ {x | IsPF S x}.ncard = 1 :=
+  ⟨fun hsym => by
+      rw [isPF_setOf_eq_of_isSymmetric hg hsym, Set.ncard_singleton],
+    isSymmetric_of_isPF_ncard_one h0 hadd hfin hg⟩
+
+/-- Packaged for a bundled `IsNumericalSemigroup`. -/
+theorem isSymmetric_iff_type_one {S : Set ℕ} (hS : IsNumericalSemigroup S) {g : ℕ}
+    (hg : IsFrobeniusNumber S g) :
+    IsSymmetric S g ↔ {x | IsPF S x}.ncard = 1 :=
+  isSymmetric_iff_isPF_ncard_one hS.1 hS.2.1 hS.2.2.1 hg
+
+/-! ## Subsuming the parent: the two-generator semigroup `⟨a, b⟩` -/
+
+section TwoGenerator
+
+open FrobeniusNumber
+
+variable {a b : ℕ}
+
+/-- The set of representable numbers `{n | Representable a b n}` is a numerical
+semigroup: it contains `0`, is closed under addition, and (by Sylvester) has all of
+`{n | n > g}` inside it, so only finitely many gaps. -/
+theorem representable_isNumericalSemigroup (hab : Nat.Coprime a b) (ha : 2 ≤ a)
+    (hb : 2 ≤ b) : IsNumericalSemigroup {n | Representable a b n} := by
+  obtain ⟨_, hgnot, hmax⟩ := sylvester_frobenius hab ha hb
+  refine ⟨representable_zero a b, ?_, ?_, ?_⟩
+  · -- closure under addition
+    rintro x ⟨px, qx, rfl⟩ y ⟨py, qy, rfl⟩
+    exact ⟨px + py, qx + qy, by ring⟩
+  · -- finitely many gaps: all gaps are `≤ g`
+    apply Set.Finite.subset (Set.finite_Iic (frobeniusNumber a b))
+    intro n hn
+    simp only [Set.mem_Iic]
+    by_contra h
+    exact hn (hmax n (by omega))
+  · exact ⟨frobeniusNumber a b, hgnot⟩
+
+/-- `frobeniusNumber a b` is the Frobenius number of `⟨a, b⟩` in the general sense. -/
+theorem representable_isFrobeniusNumber (hab : Nat.Coprime a b) (ha : 2 ≤ a)
+    (hb : 2 ≤ b) :
+    IsFrobeniusNumber {n | Representable a b n} (frobeniusNumber a b) := by
+  obtain ⟨_, hgnot, hmax⟩ := sylvester_frobenius hab ha hb
+  exact ⟨hgnot, fun n hn => hmax n hn⟩
+
+/-- `⟨a, b⟩` is symmetric in the general sense (re-export of the parent's
+`symmetric_le_frobenius`). -/
+theorem representable_isSymmetric (hab : Nat.Coprime a b) (ha : 2 ≤ a) (hb : 2 ≤ b) :
+    IsSymmetric {n | Representable a b n} (frobeniusNumber a b) := by
+  intro k hk
+  exact FrobeniusNumberOQ01OQ03.symmetric_le_frobenius ha hb hab hk
+
+/-- **The general equivalence recovers the parent's type-one theorem.**  Feeding the
+two-generator symmetry into `isSymmetric_iff_type_one` yields `|PF(⟨a,b⟩)| = 1`
+without re-running the parent's pseudo-Frobenius computation. -/
+theorem representable_type_one (hab : Nat.Coprime a b) (ha : 2 ≤ a) (hb : 2 ≤ b) :
+    {x | IsPF {n | Representable a b n} x}.ncard = 1 :=
+  (isSymmetric_iff_type_one (representable_isNumericalSemigroup hab ha hb)
+    (representable_isFrobeniusNumber hab ha hb)).mp
+    (representable_isSymmetric hab ha hb)
+
+/-- Concrete sanity check: `⟨3, 5⟩` has Frobenius number `7`. -/
+example : frobeniusNumber 3 5 = 7 := by decide
+
+end TwoGenerator
+
+end FrobeniusNumberOQ01OQ03OQ01

--- a/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "frobenius-number-oq-01-oq-03-oq-01",
+  "title": "Type One ⟹ Symmetric: the Generator-Agnostic Converse for Numerical Semigroups",
+  "slug": "frobenius-number-oq-01-oq-03-oq-01",
+  "description": "Closes the 'symmetric ⟺ type one' equivalence for an ARBITRARY numerical semigroup S ⊆ ℕ (closed under +, contains 0, finite complement), answering the explicit open question of parent frobenius-number-oq-01-oq-03 (which proved only the two-generator instance). With no reference to generators: IsFrobeniusNumber S g (largest gap) is shown unique and existent; the converse isSymmetric_of_isPF_ncard_one proves that if g is the UNIQUE pseudo-Frobenius number (|PF(S)| = 1) then S is symmetric (k ∈ S ⟺ g − k ∉ S). The structural engine is gap_dominated: the finite set of gaps y ≥ x with y − x ∈ S has a maximum, and that maximum is pseudo-Frobenius — so every gap is ⪯-dominated by a pseudo-Frobenius number, which type one forces to be g, giving g − k ∈ S. Combined with the easy forward direction (symmetric ⟹ |PF| = 1, isPF_setOf_eq_of_isSymmetric) this yields the full equivalence isSymmetric_iff_isPF_ncard_one. The general framework is then shown to SUBSUME the parent: the two-generator set {n | Representable a b n} is a numerical semigroup with Frobenius number frobeniusNumber a b, and representable_type_one recovers PF(⟨a,b⟩) = {g} from the general equivalence. 13 theorems + 4 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean",
+      "Proofs/FrobeniusNumberOQ01OQ03.lean"
+    ],
+    "tags": [
+      "number-theory",
+      "frobenius",
+      "coin-problem",
+      "numerical-semigroups",
+      "symmetric-semigroup",
+      "pseudo-frobenius",
+      "gorenstein",
+      "type-invariant",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 285,
+    "theoremCount": 13,
+    "definitionCount": 4,
+    "assumptions": "None beyond the definition of a numerical semigroup. All results are universally quantified over S : Set ℕ satisfying the four numerical-semigroup conditions (0 ∈ S, additive closure, finite complement, properness), passed as ordinary theorem hypotheses (not structure-encoded axioms). #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound for isSymmetric_iff_isPF_ncard_one, isSymmetric_of_isPF_ncard_one, gap_dominated, and representable_type_one; no sorryAx, no native_decide, no Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Finite.toFinset / Finset.max'",
+        "description": "Realizes the Frobenius number as the maximum of the finite nonempty gap set, and the dominating pseudo-Frobenius number as the maximum of the finite set of gaps above a given gap.",
+        "module": "Mathlib.Data.Set.Finite, Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Set.ncard_eq_one",
+        "description": "Turns the type-one hypothesis |PF(S)| = 1 into PF(S) = {a} for some a; combined with g ∈ PF(S) gives PF(S) = {g}.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Set.ncard_singleton",
+        "description": "The forward direction: PF(S) = {g} ⟹ |PF(S)| = 1.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Set.finite_Iic",
+        "description": "Iic g is finite — used to show the two-generator semigroup has finitely many gaps (all gaps are ≤ g).",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      }
+    ],
+    "originalContributions": [
+      "IsNumericalSemigroup / IsFrobeniusNumber / IsSymmetric / IsPF: a generator-agnostic encoding of numerical semigroups over S : Set ℕ. The numerical-semigroup conditions and the Frobenius/symmetric/pseudo-Frobenius notions are expressed for an arbitrary additively-closed cofinite subset of ℕ, decoupling the theory from the parent's Representable a b.",
+      "isFrobeniusNumber_unique + exists_isFrobeniusNumber: the Frobenius number of any proper numerical semigroup exists (max of the finite nonempty gap set) and is unique.",
+      "gap_dominated (structural engine): for any gap x, the finite set { y | y ∉ S ∧ x ≤ y ∧ y − x ∈ S } has a maximum m, and m is pseudo-Frobenius. The maximality argument shows m + s ∈ S for every positive s ∈ S (else m + s would be a strictly larger member). This realizes the order-theoretic fact 'every gap lies below a maximal gap' constructively, without invoking abstract poset machinery.",
+      "isSymmetric_of_isPF_ncard_one: THE OPEN CONVERSE. If |PF(S)| = 1 then PF(S) = {g}; the forward implication k ∈ S ⟹ g − k ∉ S is closure-of-S; the reverse g − k ∉ S ⟹ k ∈ S is the contrapositive 'a gap k has g − k ∈ S', delivered by gap_dominated (k is dominated by a pseudo-Frobenius number, necessarily g).",
+      "isPF_setOf_eq_of_isSymmetric: the forward direction symmetric ⟹ PF(S) = {g}, generalizing the parent's two-generator pseudoFrobenius_setOf_eq to arbitrary S.",
+      "isSymmetric_iff_isPF_ncard_one / isSymmetric_iff_type_one: the full Kunz equivalence S symmetric ⟺ type(S) = 1, packaged both with bare hypotheses and with the bundled IsNumericalSemigroup predicate.",
+      "representable_isNumericalSemigroup / representable_isFrobeniusNumber / representable_isSymmetric / representable_type_one: the two-generator semigroup ⟨a,b⟩ is exhibited as an instance of the general framework, and the parent's type-one result PF(⟨a,b⟩) = {g} is RE-DERIVED as a corollary of the general equivalence applied to the parent's symmetry — demonstrating that the general theorem subsumes the special case."
+    ],
+    "prerequisites": [
+      "frobenius-number-oq-01-oq-03 (parent: two-generator symmetric of type one; supplies symmetric_le_frobenius reused for the instance)",
+      "frobenius-number (Representable, frobeniusNumber = ab − a − b, sylvester_frobenius maximality)",
+      "Numerical semigroups: gaps, Frobenius number, pseudo-Frobenius numbers, type (Rosales–García-Sánchez Ch. 4)",
+      "Set.Finite.toFinset, Finset.max', Set.ncard_eq_one / Set.ncard_singleton"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "A numerical semigroup $S \\subseteq \\mathbb{N}$ (additively closed, containing $0$, with finite complement) is **symmetric** when $k \\in S \\Leftrightarrow g - k \\notin S$ for its Frobenius number $g$ (the largest gap). Kunz (1970) proved that symmetry of $S$ is equivalent to the **Gorenstein** property of the coordinate ring $k[\\![t^S]\\!]$, and that both are equivalent to $S$ having **type one** — the set $\\mathrm{PF}(S)$ of *pseudo-Frobenius numbers* (the maximal gaps under $u \\preceq v \\Leftrightarrow v - u \\in S$) being the singleton $\\{g\\}$. The parent entry established the *easy half* of this for the two-generator case by exhibiting $\\mathrm{PF}(\\langle a,b\\rangle) = \\{g\\}$. This entry proves the **converse**, $\\text{type}(S) = 1 \\Rightarrow S$ symmetric, for an arbitrary numerical semigroup, completing the equivalence $\\text{symmetric} \\Leftrightarrow \\text{type one}$ without any appeal to generators.",
+    "problemStatement": "Let $S \\subseteq \\mathbb{N}$ be a numerical semigroup with Frobenius number $g$. Prove the equivalence: $S$ is symmetric ($\\forall k \\le g,\\ k \\in S \\Leftrightarrow g - k \\notin S$) if and only if $S$ has type one ($|\\mathrm{PF}(S)| = 1$, equivalently $\\mathrm{PF}(S) = \\{g\\}$). In particular prove the converse direction left open by the parent: type one $\\Rightarrow$ symmetric, generator-agnostically.",
+    "text": "For any numerical semigroup, being symmetric is equivalent to having a single pseudo-Frobenius number (type one). The converse — type one forces symmetry — follows because every gap is dominated by a pseudo-Frobenius number, which type one pins to the Frobenius number g.",
+    "proofStrategy": "**Setup.** Work with `S : Set ℕ` satisfying `0 ∈ S`, additive closure, finite complement, and properness. `IsFrobeniusNumber S g := g ∉ S ∧ ∀ n > g, n ∈ S` is proved unique (trichotomy) and existent (max of the finite gap set). `IsPF S x := x ∉ S ∧ ∀ s ∈ S, 0 < s → x + s ∈ S`; `frobeniusNumber_isPF` shows `g ∈ PF(S)`. **Forward (symmetric ⟹ type one).** Any `x ∈ PF(S)` has `x ≤ g`; if `x < g` then symmetry gives `g − x ∈ S` with `g − x > 0`, and the pseudo-Frobenius closure yields `x + (g − x) = g ∈ S`, contradicting `g ∉ S`. So `PF(S) = {g}` and `ncard = 1`. **Converse (type one ⟹ symmetric).** From `ncard = 1` and `g ∈ PF(S)`, `PF(S) = {g}`. Fix `k ≤ g`. `k ∈ S ⟹ g − k ∉ S` is additive closure (`k + (g − k) = g`). `g − k ∉ S ⟹ k ∈ S` is the contrapositive 'gap `k` has `g − k ∈ S'`: by `gap_dominated`, the maximum `m` of `{ y gap : y ≥ k, y − k ∈ S }` is pseudo-Frobenius, hence `m = g`, so `g − k = m − k ∈ S`. **Engine `gap_dominated`.** That maximum `m` is pseudo-Frobenius because if some `m + s` (`s ∈ S`, `s > 0`) were a gap, then `(m + s) − k = (m − k) + s ∈ S` would put `m + s` in the set, contradicting maximality of `m`. **Subsumption.** `{n | Representable a b n}` is shown to be a numerical semigroup with Frobenius number `ab − a − b`, and `representable_type_one` recovers the parent's `PF(⟨a,b⟩) = {g}` from the general equivalence applied to the parent's symmetry.",
+    "keyInsights": [
+      "**The converse is an order-theoretic fact made constructive.** Pseudo-Frobenius numbers are the maximal elements of the finite poset of gaps under $u \\preceq v \\Leftrightarrow v - u \\in S$. Every element of a finite poset lies below a maximal one; `gap_dominated` realizes this by taking an explicit Finset maximum, so no abstract Zorn/maximality API is needed.",
+      "**Type one collapses 'some maximal gap' to 'the maximal gap'.** The domination lemma gives, for each gap $k$, a pseudo-Frobenius number above it. Type one ($\\mathrm{PF}(S) = \\{g\\}$) forces that number to be $g$, so $g - k \\in S$ — exactly the missing half of symmetry. The hypothesis is used at precisely one point.",
+      "**Generator-agnosticism is what makes it a real converse.** The parent's `Representable a b` carries the two-generator structure; phrasing everything over an abstract `S : Set ℕ` proves the theorem where it actually lives (Kunz's equivalence holds for all numerical semigroups, most of which need ≥ 3 generators and have no closed-form $g$).",
+      "**The general theorem subsumes the special case, verified.** `representable_type_one` derives the parent's headline `PF(⟨a,b⟩) = {g}` by feeding the parent's symmetry into the general equivalence — a machine-checked demonstration that the abstract framework recovers the concrete result, not merely resembles it."
+    ],
+    "prerequisites": [
+      "Numerical semigroups, gaps, Frobenius number, and the maximality $\\forall n > g,\\ n \\in S$",
+      "Pseudo-Frobenius numbers and the type invariant (Rosales–García-Sánchez, Ch. 4)",
+      "Two-generator symmetry $\\text{Rep}(k) \\Leftrightarrow \\neg\\text{Rep}(g-k)$ on $[0,g]$ (parent `frobenius-number-oq-01-oq-03`)",
+      "Finite-set maxima ($\\texttt{Finset.max'}$) and $\\mathrm{ncard}$ of a singleton"
+    ]
+  },
+  "conclusion": {
+    "summary": "In 285 lines, 0 sorries, 0 axioms, the Kunz equivalence symmetric ⟺ type one is proved for an arbitrary numerical semigroup S ⊆ ℕ, closing the converse left open by the parent. The structural engine gap_dominated shows every gap is dominated by a pseudo-Frobenius number; type one forces that number to be the Frobenius number g, delivering g − k ∈ S for every gap k and hence symmetry. The two-generator semigroup ⟨a,b⟩ is realized as an instance, and the parent's PF(⟨a,b⟩) = {g} is re-derived as a corollary.",
+    "implications": "This completes the elementary invariant theory of the symmetric (Gorenstein) condition begun in the parent family: the genus (sibling OQ-01), the interior duality (sibling OQ-02), the two-generator type-one computation (parent OQ-01-OQ-03), and now the generator-agnostic equivalence symmetric ⟺ type one. The abstract IsNumericalSemigroup / IsPF scaffolding is the natural launch point for the genuinely harder ≥ 3-generator theory, where the type can be arbitrarily large and the symmetric case is the exception rather than the rule.",
+    "openQuestions": [
+      "Characterise PSEUDO-symmetric numerical semigroups (g even, type two with PF(S) = {g/2, g}) in the same generator-agnostic framework, proving the analogue 'pseudo-symmetric ⟺ PF(S) = {g/2, g}'.",
+      "Give the Apéry-set characterisation of the type: type(S) = |{maximal elements of Ap(S, n) under ⪯}| for any nonzero n ∈ S, linking PF(S) to the Apéry set and recovering type one for symmetric semigroups."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Parent: proved the FORWARD/easy half (two-generator ⟨a,b⟩ has PF = {g}, hence type one) and explicitly posed this converse as its open question. This entry proves the converse type one ⟹ symmetric for arbitrary S, reuses the parent's symmetric_le_frobenius for the two-generator instance, and re-derives the parent's type-one result from the general equivalence."
+    },
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "related",
+      "description": "The interior symmetry of OQ-02, completed to [0,g] by the parent, is the symmetry hypothesis that — via the general equivalence — yields the two-generator type-one corollary here."
+    },
+    {
+      "targetId": "frobenius-number",
+      "relationship": "foundational",
+      "description": "Supplies Representable, frobeniusNumber = ab − a − b, and sylvester_frobenius (the maximality ∀ n > g, Rep n) used to show {n | Representable a b n} is a numerical semigroup with Frobenius number ab − a − b."
+    }
+  ],
+  "references": [
+    {
+      "title": "The value-semigroup of a one-dimensional Gorenstein ring",
+      "author": "Ernst Kunz",
+      "year": "1970",
+      "venue": "Proceedings of the American Mathematical Society 25, 748–751",
+      "description": "Proves a numerical semigroup is symmetric iff its coordinate ring is Gorenstein iff it has type one — the equivalence whose converse this entry formalizes."
+    },
+    {
+      "title": "Numerical Semigroups",
+      "author": "J. C. Rosales, P. A. García-Sánchez",
+      "year": "2009",
+      "venue": "Springer Developments in Mathematics 20",
+      "description": "Chapter 4 develops pseudo-Frobenius numbers, the type, and the symmetric/pseudo-symmetric classification; Proposition 4.4 is the symmetric ⟺ type one equivalence."
+    },
+    {
+      "title": "On numerical semigroups",
+      "author": "R. Fröberg, C. Gottlieb, R. Häggkvist",
+      "year": "1987",
+      "venue": "Semigroup Forum 35, 63–83",
+      "description": "Foundational treatment of the type, pseudo-Frobenius numbers, and the symmetric/pseudo-symmetric dichotomy for numerical semigroups."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "filename": "FrobeniusNumberOQ01OQ03OQ01.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.FrobeniusNumber",
+      "Proofs.FrobeniusNumberOQ01OQ03"
+    ],
+    "namespace": "FrobeniusNumberOQ01OQ03OQ01",
+    "lineCount": 285,
+    "theoremCount": 13,
+    "axiomCount": 0,
+    "definitionCount": 4,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean",
+      "Proofs/FrobeniusNumberOQ01OQ03.lean"
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-01-oq-01",
+      "question": "Characterise pseudo-symmetric numerical semigroups (g even, type two with PF(S) = {g/2, g}) in the same generator-agnostic framework: prove pseudo-symmetric ⟺ PF(S) = {g/2, g}.",
+      "significance": "medium"
+    },
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-01-oq-02",
+      "question": "Give the Apéry-set characterisation type(S) = |maximal elements of Ap(S, n)| for nonzero n ∈ S, linking PF(S) to the Apéry set.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **explicit open question** of parent `frobenius-number-oq-01-oq-03` (listed in its meta `openQuestions`, significance *high*):

> *Prove the converse: a numerical semigroup of type 1 (`|PF(S)| = 1`) is symmetric, completing the 'symmetric ⟺ type one' equivalence in a generator-agnostic setting.*

The parent proved only the **forward/easy half** for the *two-generator* semigroup `⟨a,b⟩` (`PF(⟨a,b⟩) = {g}`). This entry proves the **converse**, and the full equivalence, for an **arbitrary** numerical semigroup `S ⊆ ℕ` (additively closed, contains 0, finite complement) — the Kunz / Gorenstein characterization `symmetric ⟺ type one`.

## Key results (all generator-agnostic, `S : Set ℕ`)

- **`gap_dominated`** — structural engine: for any gap `x`, the finite set of gaps `y ≥ x` with `y − x ∈ S` has a maximum `m`, and `m` is pseudo-Frobenius. (Every gap lies below a maximal gap, made constructive via `Finset.max'`.)
- **`isSymmetric_of_isPF_ncard_one`** — *the open converse*: if `|PF(S)| = 1` then `PF(S) = {g}`; a gap `k` is dominated by a pseudo-Frobenius number, which must be `g`, so `g − k ∈ S` — giving symmetry.
- **`isPF_setOf_eq_of_isSymmetric`** — forward half: `symmetric ⟹ PF(S) = {g}`.
- **`isSymmetric_iff_isPF_ncard_one`** / **`isSymmetric_iff_type_one`** — the full equivalence.
- **`isFrobeniusNumber_unique`** / **`exists_isFrobeniusNumber`** — the Frobenius number of a proper numerical semigroup is unique and exists.
- **`representable_*`** — `{n | Representable a b n}` is shown to be a numerical semigroup with Frobenius number `ab − a − b`, and `representable_type_one` **re-derives the parent's `PF(⟨a,b⟩) = {g}`** from the general equivalence (machine-checked subsumption).

## Verification

- **13 theorems + 4 definitions, 285 lines, 0 sorries, 0 axioms.**
- `#print axioms` on the headline theorems reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `native_decide` / `Lean.ofReduceBool`.
- Builds on the verified parent chain (`FrobeniusNumber`, `FrobeniusNumberOQ02`, `FrobeniusNumberOQ01OQ03`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)