### PR TITLE
audit: clear backlog — 4 entries clean (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21499,6 +21499,30 @@
       "lastAudited": "2026-06-24T13:09:13Z",
       "result": "clean",
       "issues": []
+    },
+    "automorphic-number-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:37:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-convergence-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:37:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:37:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hall-marriage-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:37:51Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Cleared the 4 remaining unaudited gallery entries. All re-verify **clean**.

| Entry | status/badge | sorry | axiom | True-stub | Verdict |
|-------|--------------|-------|-------|-----------|---------|
| automorphic-number-oq-01-oq-03-oq-02 | verified/original | 0 | 0 | 0 | clean |
| derangements-convergence-oq-05 | verified/original | 0 | 0 | 0 | clean |
| euler-totient-oq-01-oq-02-oq-03 | verified/original | 0 | 0 | 0 | clean |
| hall-marriage-theorem-oq-01-oq-02 | verified/mathlib | 0 | 0 | 0 | clean |

### Notes
- **Hall-Marriage** `grep` flags `sorry:1` + `native_decide:1` — both are **docstring prose false-positives** (lines 47-48: "0 `sorry`, 0 `axiom`, no `native_decide`"). Actual proof is clean.
- Hall `badge=mathlib` is honest: König–Egerváry duality derived from the gallery's own defect Hall (`HallMarriageTheoremOQ01OQ01`) + Mathlib's Hall theorem.

**Gallery: 3465/3465 audited, 0 issues, 0 critical.**

---
Discovered during autonomous gallery integrity audit.