### PR TITLE
research(lagrange-theorem-oq-09): center dichotomy |Z(G)| ∈ {1,pq} for groups of order pq [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ09.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ09.lean
@@ -1,0 +1,160 @@
+/-
+  Center Dichotomy for Groups of Order pq (lagrange-theorem-oq-09)
+
+  This answers OQ-09 from Lagrange's Theorem: pinning down the possible sizes of
+  the center Z(G) of a finite group G of order p·q, where p and q are distinct
+  primes.
+
+  **Open Question**: For |G| = pq with p ≠ q primes, what are the possible
+  orders of the center Z(G)?
+
+  **Answer**: |Z(G)| ∈ {1, pq}. The center is either trivial or all of G; the
+  intermediate divisors p and q are impossible.
+
+  **Why the middle is forbidden**: By Lagrange, |Z(G)| divides pq, so it is one
+  of 1, p, q, pq. If |Z(G)| = p then the index [G : Z(G)] = q is prime, so the
+  quotient G/Z(G) is cyclic; but a group whose central quotient is cyclic is
+  abelian, forcing Z(G) = G and |Z(G)| = pq — contradicting |Z(G)| = p (as
+  q > 1). The case |Z(G)| = q is symmetric.
+
+  **Consequences**: A nonabelian group of order pq has trivial center. This is
+  the structural starting point for the Sylow-based classification carried out in
+  the sibling entry `lagrange-theorem-oq-01-oq-01`, which never touches the
+  center directly. Mathlib's `card_center_eq_prime_pow` covers prime-power orders
+  only, not this two-distinct-prime case.
+
+  Verified, 0 axioms (beyond Lean's foundational propext/Classical.choice/Quot.sound).
+-/
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Subgroup.Center
+import Mathlib.Algebra.Group.Subgroup.Finite
+import Mathlib.Tactic
+
+namespace LagrangeTheoremOQ09
+
+open Subgroup
+
+/-! ## A divisor lemma for products of two distinct primes
+
+The only divisors of `p * q`, with `p` and `q` distinct primes, are
+`1, p, q, p*q`. We obtain this from `n = gcd n p * gcd n q` (valid because `p`
+and `q` are coprime and `n ∣ p*q`), since each gcd factor divides a prime. -/
+
+/-- Every divisor of a product of two distinct primes is `1`, one of the primes,
+or the product itself. -/
+theorem divisors_of_prime_mul_prime {p q n : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (hn : n ∣ p * q) :
+    n = 1 ∨ n = p ∨ n = q ∨ n = p * q := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr hpq
+  -- `n = gcd n (p*q) = gcd n p * gcd n q`.
+  have hsplit : n = Nat.gcd n p * Nat.gcd n q := by
+    rw [← Nat.Coprime.gcd_mul n hcop, Nat.gcd_eq_left hn]
+  -- each gcd factor divides a prime, hence is `1` or that prime
+  have hdp : Nat.gcd n p = 1 ∨ Nat.gcd n p = p :=
+    hp.eq_one_or_self_of_dvd _ (Nat.gcd_dvd_right n p)
+  have hdq : Nat.gcd n q = 1 ∨ Nat.gcd n q = q :=
+    hq.eq_one_or_self_of_dvd _ (Nat.gcd_dvd_right n q)
+  rcases hdp with hp1 | hpp <;> rcases hdq with hq1 | hqq
+  · -- gcd n p = 1, gcd n q = 1 ⟹ n = 1
+    left; rw [hsplit, hp1, hq1, mul_one]
+  · -- gcd n p = 1, gcd n q = q ⟹ n = q
+    right; right; left; rw [hsplit, hp1, hqq, one_mul]
+  · -- gcd n p = p, gcd n q = 1 ⟹ n = p
+    right; left; rw [hsplit, hpp, hq1, mul_one]
+  · -- gcd n p = p, gcd n q = q ⟹ n = p*q
+    right; right; right; rw [hsplit, hpp, hqq]
+
+/-! ## Central quotient of prime index forces commutativity -/
+
+variable {G : Type*} [Group G]
+
+/-- If the central quotient `G ⧸ Z(G)` has prime order, then `G` is abelian
+(every pair of elements commutes). This packages
+`isCyclic_of_prime_card` with `commutative_of_cyclic_center_quotient`. -/
+theorem mul_comm_of_center_index_prime {r : ℕ} [Fact r.Prime]
+    (h : (center G).index = r) (a b : G) : a * b = b * a := by
+  haveI : IsCyclic (G ⧸ center G) :=
+    isCyclic_of_prime_card (p := r) (by rwa [← Subgroup.index_eq_card])
+  exact commutative_of_cyclic_center_quotient (QuotientGroup.mk' (center G))
+    (QuotientGroup.ker_mk' (center G)).le a b
+
+/-- A group whose central quotient has prime order is its own center. -/
+theorem center_eq_top_of_index_prime {r : ℕ} [Fact r.Prime]
+    (h : (center G).index = r) : center G = ⊤ := by
+  rw [eq_top_iff']
+  intro x
+  exact mem_center_iff.mpr fun g => mul_comm_of_center_index_prime h g x
+
+/-! ## The center dichotomy -/
+
+/-- **Center dichotomy for groups of order `pq`.** For a finite group `G` with
+`|G| = p·q` where `p ≠ q` are primes, the center `Z(G)` has order either `1`
+or `pq`: it can never be `p` or `q`. -/
+theorem center_card_dichotomy {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (hG : Nat.card G = p * q) :
+    Nat.card (center G) = 1 ∨ Nat.card (center G) = p * q := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  -- By Lagrange the center order divides `pq`.
+  have hdvd : Nat.card (center G) ∣ p * q := hG ▸ Subgroup.card_subgroup_dvd_card _
+  -- Relation `|Z| · [G:Z] = |G|`.
+  have hmul : Nat.card (center G) * (center G).index = p * q := by
+    rw [Subgroup.card_mul_index, hG]
+  rcases divisors_of_prime_mul_prime hp hq hpq hdvd with h1 | hpc | hqc | hpqc
+  · exact Or.inl h1
+  · -- `|Z| = p` ⟹ index `= q`, prime ⟹ `Z = ⊤` ⟹ `|Z| = pq`, contradicting `|Z| = p`.
+    exfalso
+    have hidx : (center G).index = q := by
+      have := hmul
+      rw [hpc] at this
+      exact Nat.eq_of_mul_eq_mul_left hp.pos this
+    have htop : center G = ⊤ := center_eq_top_of_index_prime (r := q) hidx
+    have : Nat.card (center G) = p * q := by rw [htop, Subgroup.card_top, hG]
+    rw [hpc] at this
+    -- `p = p * q` with `q > 1` is impossible
+    exact (Nat.ne_of_lt (lt_mul_of_one_lt_right hp.pos hq.one_lt)) this
+  · -- symmetric: `|Z| = q` ⟹ index `= p`, prime ⟹ contradiction
+    exfalso
+    have hidx : (center G).index = p := by
+      have := hmul
+      rw [hqc, mul_comm p q] at this
+      exact Nat.eq_of_mul_eq_mul_left hq.pos this
+    have htop : center G = ⊤ := center_eq_top_of_index_prime (r := p) hidx
+    have : Nat.card (center G) = p * q := by rw [htop, Subgroup.card_top, hG]
+    rw [hqc] at this
+    -- `q = p * q` with `p > 1` is impossible
+    exact (Nat.ne_of_lt (lt_mul_of_one_lt_left hq.pos hp.one_lt)) this
+  · exact Or.inr hpqc
+
+/-! ## Corollaries -/
+
+/-- A nonabelian group of order `pq` (distinct primes) has trivial center. -/
+theorem center_trivial_of_nonabelian {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (hG : Nat.card G = p * q)
+    (hnonab : ∃ a b : G, a * b ≠ b * a) :
+    Nat.card (center G) = 1 := by
+  haveI : Finite G := Nat.finite_of_card_ne_zero (by rw [hG]; exact (Nat.mul_pos hp.pos hq.pos).ne')
+  rcases center_card_dichotomy hp hq hpq hG with h1 | hfull
+  · exact h1
+  · -- if `|Z| = pq = |G|` then `Z = ⊤`, so `G` is abelian — contradiction
+    exfalso
+    obtain ⟨a, b, hab⟩ := hnonab
+    have htop : center G = ⊤ := by
+      apply Subgroup.eq_top_of_card_eq
+      rw [hfull, hG]
+    have ha : a ∈ center G := htop ▸ Subgroup.mem_top a
+    exact hab (mem_center_iff.mp ha b).symm
+
+/-- Restated as a dichotomy: the center of an order-`pq` group is trivial or
+everything. -/
+theorem center_eq_bot_or_top {p q : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (hG : Nat.card G = p * q) :
+    center G = ⊥ ∨ center G = ⊤ := by
+  haveI : Finite G := Nat.finite_of_card_ne_zero (by rw [hG]; exact (Nat.mul_pos hp.pos hq.pos).ne')
+  rcases center_card_dichotomy hp hq hpq hG with h1 | hfull
+  · exact Or.inl (Subgroup.eq_bot_of_card_eq _ h1)
+  · refine Or.inr (Subgroup.eq_top_of_card_eq _ ?_)
+    rw [hfull, hG]
+
+end LagrangeTheoremOQ09

--- a/src/data/proofs/lagrange-theorem-oq-09/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-09/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-oq09-divisors",
+    "proofId": "lagrange-theorem-oq-09",
+    "range": { "startLine": 44, "endLine": 66 },
+    "type": "insight",
+    "title": "Divisors of p·q via the Coprime gcd Split",
+    "content": "The divisor structure of p·q is obtained without case-bashing on factorizations: for any n | p·q one has n = gcd(n,p)·gcd(n,q), because p and q are coprime (Nat.Coprime.gcd_mul) and gcd(n, p·q) = n. Each factor gcd(n,p), gcd(n,q) divides a prime, so is 1 or that prime, leaving exactly the four products 1, q, p, p·q.",
+    "mathContext": "$n = \\gcd(n, pq) = \\gcd(n,p)\\,\\gcd(n,q)$ since $\\gcd(p,q)=1$; each $\\gcd(n,p)\\in\\{1,p\\}$, $\\gcd(n,q)\\in\\{1,q\\}$ as $p,q$ are prime.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.Coprime.gcd_mul",
+      "Nat.Prime.eq_one_or_self_of_dvd",
+      "Nat.gcd_eq_left"
+    ],
+    "prerequisites": ["coprimality", "prime divisors"]
+  },
+  {
+    "id": "ann-oq09-cyclic-quotient",
+    "proofId": "lagrange-theorem-oq-09",
+    "range": { "startLine": 72, "endLine": 87 },
+    "type": "insight",
+    "title": "Prime Index ⟹ Cyclic Central Quotient ⟹ Abelian",
+    "content": "The engine of the whole argument. If the index [G:Z(G)] is a prime r, then the quotient G/Z(G) has order r, hence is cyclic (isCyclic_of_prime_card). A group whose quotient by its center is cyclic is abelian — Mathlib's commutative_of_cyclic_center_quotient, applied to the canonical projection QuotientGroup.mk' whose kernel is exactly the center. So prime index abelianizes G, which means Z(G) is everything.",
+    "mathContext": "$[G:Z(G)] = r$ prime $\\Rightarrow G/Z(G)$ cyclic $\\Rightarrow G$ abelian $\\Rightarrow Z(G) = G$. Note $G/Z(G)$ is never nontrivial cyclic for a nonabelian $G$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "isCyclic_of_prime_card",
+      "commutative_of_cyclic_center_quotient",
+      "QuotientGroup.ker_mk'",
+      "Subgroup.index_eq_card"
+    ],
+    "prerequisites": ["quotient groups", "cyclic groups", "center of a group"]
+  },
+  {
+    "id": "ann-oq09-dichotomy",
+    "proofId": "lagrange-theorem-oq-09",
+    "range": { "startLine": 91, "endLine": 130 },
+    "type": "insight",
+    "title": "Killing the Middle Divisors",
+    "content": "Lagrange gives |Z(G)| | pq, so the divisor lemma leaves |Z(G)| ∈ {1, p, q, pq}. The two middle values fall: if |Z(G)| = p then |Z(G)|·[G:Z(G)] = pq forces [G:Z(G)] = q, prime, so by the cyclic-quotient engine G is abelian and |Z(G)| = pq — impossible since q > 1 makes pq ≠ p. The case |Z(G)| = q is symmetric with index p. Only the extremes 1 and pq remain.",
+    "mathContext": "$|Z|=p \\Rightarrow [G:Z]=q$ prime $\\Rightarrow Z=G \\Rightarrow |Z|=pq\\neq p$. Symmetric for $|Z|=q$. Hence $|Z(G)|\\in\\{1,pq\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Subgroup.card_mul_index",
+      "Subgroup.card_subgroup_dvd_card",
+      "Subgroup.card_top",
+      "Nat.eq_of_mul_eq_mul_left"
+    ],
+    "prerequisites": ["Lagrange's theorem", "index of a subgroup"]
+  },
+  {
+    "id": "ann-oq09-corollaries",
+    "proofId": "lagrange-theorem-oq-09",
+    "range": { "startLine": 132, "endLine": 160 },
+    "type": "concept",
+    "title": "Trivial Center of the Nonabelian Group",
+    "content": "The dichotomy specializes to the structural fact behind the pq-classification: a nonabelian group of order pq has trivial center. If |Z(G)| were pq it would equal |G|, making Z(G) = ⊤ and G abelian — contradicting nonabelianness. center_eq_bot_or_top restates the dichotomy at the subgroup level: Z(G) = ⊥ or Z(G) = ⊤.",
+    "mathContext": "Nonabelian $\\Rightarrow |Z(G)|\\neq pq \\Rightarrow |Z(G)|=1$. Abelian $\\Leftrightarrow Z(G)=G$. So the center separates the two isomorphism types of order $pq$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Subgroup.eq_top_of_card_eq",
+      "Subgroup.eq_bot_of_card_eq",
+      "Subgroup.mem_center_iff"
+    ],
+    "prerequisites": ["center of a group", "abelian groups"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-09/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-09/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ09.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOQ09Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOQ09Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOQ09Data: ProofData = {
+  proof: lagrangeTheoremOQ09Proof,
+  annotations: lagrangeTheoremOQ09Annotations,
+}

--- a/src/data/proofs/lagrange-theorem-oq-09/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-09/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "lagrange-theorem-oq-09",
+  "title": "Center Dichotomy for Groups of Order pq",
+  "slug": "lagrange-theorem-oq-09",
+  "description": "For a finite group G of order p·q with p ≠ q prime, the center Z(G) has order either 1 or pq — never the intermediate divisors p or q. By Lagrange |Z(G)| divides pq; if it were p (resp. q) the central quotient G/Z(G) would have prime order q (resp. p), hence be cyclic, forcing G abelian and Z(G) = G — a contradiction. This pins the center to the two extremes and yields: a nonabelian group of order pq has trivial center.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ09.lean",
+    "tags": [
+      "group-theory",
+      "lagrange-theorem",
+      "center",
+      "class-equation",
+      "cyclic-quotient",
+      "groups-of-order-pq"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 160,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (depends only on the foundational axioms propext, Classical.choice, Quot.sound).",
+    "originalContributions": [
+      "divisors_of_prime_mul_prime: every divisor of p·q (p ≠ q prime) is one of 1, p, q, p·q — proved cleanly from n = gcd(n,p)·gcd(n,q) via coprimality, each factor dividing a prime",
+      "mul_comm_of_center_index_prime: if the central quotient G/Z(G) has prime order then G is abelian — packaging isCyclic_of_prime_card with commutative_of_cyclic_center_quotient",
+      "center_eq_top_of_index_prime: the same hypothesis forces Z(G) = ⊤ (the whole group is its own center)",
+      "center_card_dichotomy: the headline — |Z(G)| ∈ {1, pq} for |G| = pq, ruling out the middle divisors via the prime-index abelianization argument",
+      "center_trivial_of_nonabelian: a nonabelian group of order pq has trivial center (the structural starting point for the pq classification)",
+      "center_eq_bot_or_top: the dichotomy restated at the subgroup level — Z(G) = ⊥ or Z(G) = ⊤"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Groups of order pq (p < q distinct primes) are among the first families fully classified in any algebra course: there is the cyclic group ℤ/pq always, and a unique nonabelian group exactly when p | q − 1. The sibling entry lagrange-theorem-oq-01-oq-01 carries out that Sylow-based classification but never mentions the center. Yet the center is the cleanest structural invariant separating the two cases: the abelian group is its own center, the nonabelian one has trivial center. The dichotomy here — |Z(G)| can only be 1 or pq — is the lemma that makes that separation precise, and it predates the Sylow machinery, resting only on Lagrange's theorem and the elementary 'G/Z cyclic ⟹ G abelian' fact.",
+    "problemStatement": "Let G be a finite group with |G| = p·q where p and q are distinct primes. Determine the possible orders of the center Z(G). Claim: |Z(G)| ∈ {1, pq}; the intermediate divisors p and q are impossible. Equivalently, Z(G) = ⊥ or Z(G) = ⊤, and a nonabelian group of order pq has trivial center.",
+    "proofStrategy": "**Divisor structure.** By Lagrange |Z(G)| divides pq. Since p, q are distinct primes they are coprime, so for any divisor n of pq one has n = gcd(n,p)·gcd(n,q); each gcd divides a prime and is therefore 1 or that prime, giving n ∈ {1, p, q, pq}.\n\n**Ruling out the middle.** Suppose |Z(G)| = p. From |Z(G)|·[G:Z(G)] = |G| = pq we get index [G:Z(G)] = q, a prime. A group of prime order is cyclic (isCyclic_of_prime_card), so G/Z(G) is cyclic; but if the central quotient is cyclic then G is abelian (commutative_of_cyclic_center_quotient), forcing Z(G) = G and |Z(G)| = pq. Since q > 1, pq ≠ p, a contradiction. The case |Z(G)| = q is symmetric (index p).\n\n**Conclusion.** Only 1 and pq survive. The nonabelian corollary follows because |Z(G)| = pq would make Z(G) = ⊤, i.e. G abelian.",
+    "keyInsights": [
+      "The whole result is 'Lagrange + (G/Z cyclic ⟹ abelian)'. The class equation is not actually needed: prime index alone makes the quotient cyclic, and that single fact abelianizes G.",
+      "The forbidden orders p and q are exactly the ones whose cofactor (the index) is prime — that is precisely when the cyclic-quotient lemma fires. So the middle divisors are unstable for a deep reason, not by accident.",
+      "Distinctness of p and q is used only in the divisor enumeration (to know the proper nontrivial divisors are the primes themselves); the abelianization step is indifferent to which prime is which, giving a clean symmetric pair of cases.",
+      "The center cleanly distinguishes the two isomorphism types of order-pq groups: abelian ⟺ Z(G) = G, nonabelian ⟺ Z(G) = 1, with nothing in between — a sharper statement than counting Sylow subgroups."
+    ],
+    "prerequisites": [
+      "Subgroup.card_subgroup_dvd_card: Lagrange's theorem (|H| divides |G|)",
+      "Subgroup.card_mul_index and Subgroup.index_eq_card: |H|·[G:H] = |G| and [G:H] = |G/H|",
+      "isCyclic_of_prime_card: a group of prime order is cyclic",
+      "commutative_of_cyclic_center_quotient: if G/Z(G) is cyclic then G is abelian",
+      "Nat.Coprime.gcd_mul and Nat.Prime.eq_one_or_self_of_dvd: divisor structure of a product of coprime primes",
+      "Lagrange's Theorem (parent) and the Sylow pq-classification (sibling lagrange-theorem-oq-01-oq-01)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring stating the dichotomy |Z(G)| ∈ {1, pq} and the prime-index/cyclic-quotient mechanism. Imports the cyclic-group, index, and center theory from Mathlib; opens the Subgroup namespace."
+    },
+    {
+      "id": "divisor-lemma",
+      "title": "Divisors of a Product of Two Distinct Primes",
+      "startLine": 38,
+      "endLine": 66,
+      "summary": "divisors_of_prime_mul_prime: every n dividing p·q is 1, p, q, or p·q. Proof via n = gcd(n,p)·gcd(n,q) (coprimality) with each gcd factor dividing a prime."
+    },
+    {
+      "id": "cyclic-quotient",
+      "title": "Prime-Index Central Quotient Forces Commutativity",
+      "startLine": 68,
+      "endLine": 87,
+      "summary": "mul_comm_of_center_index_prime: if [G:Z(G)] is prime, the quotient G/Z(G) is cyclic (isCyclic_of_prime_card) and so G is abelian (commutative_of_cyclic_center_quotient). center_eq_top_of_index_prime repackages this as Z(G) = ⊤."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Center Dichotomy",
+      "startLine": 89,
+      "endLine": 130,
+      "summary": "center_card_dichotomy: |Z(G)| ∈ {1, pq}. Lagrange gives |Z(G)| | pq; the divisor lemma leaves four cases; the cases p and q are killed because the resulting prime index abelianizes G, forcing |Z(G)| = pq and contradicting q > 1 (resp. p > 1)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Trivial Center and Subgroup Form",
+      "startLine": 132,
+      "endLine": 160,
+      "summary": "center_trivial_of_nonabelian: a nonabelian group of order pq has |Z(G)| = 1. center_eq_bot_or_top: the dichotomy as a subgroup statement Z(G) = ⊥ ∨ Z(G) = ⊤."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved that the center of a finite group of order pq (p ≠ q prime) has order exactly 1 or pq — the intermediate divisors p and q are impossible — together with the subgroup-level restatement Z(G) = ⊥ ∨ Z(G) = ⊤ and the corollary that a nonabelian group of order pq has trivial center. 160 lines, 6 theorems, 0 sorries, 0 axioms.",
+    "implications": "The center is the sharpest single invariant separating the two isomorphism types of order-pq groups: abelian ⟺ Z(G) = G, nonabelian ⟺ Z(G) = 1, with no middle ground. This is the structural starting point for the semidirect-product description of the nonabelian case and complements the sibling Sylow classification, which counts Sylow subgroups but never inspects the center.",
+    "openQuestions": [
+      "Generalize to |G| = p²q or squarefree order: characterize exactly which divisors of |G| can occur as |Z(G)|, and identify the orders for which the 'no middle divisor' phenomenon persists.",
+      "Conclude the classification from the center: show that trivial center plus a normal Sylow q-subgroup forces G to be the unique nonabelian semidirect product ℤ/q ⋊ ℤ/p when p | q − 1."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling. Classifies groups of order pq via Sylow counts but never touches the center; this entry supplies the complementary center-based separation of the abelian and nonabelian cases."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "extends",
+      "description": "Parent. Lagrange's theorem (|H| divides |G|) is the divisibility input that constrains |Z(G)| to a divisor of pq."
+    }
+  ],
+  "leanFile": {
+    "namespace": "LagrangeTheoremOQ09",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ09.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **lagrange-theorem-oq-09**: for a finite group $G$ of order $p\cdot q$ with $p \neq q$ prime, the center $Z(G)$ has order **exactly 1 or $pq$** — never the intermediate divisors $p$ or $q$.

## Proof

- By Lagrange, $|Z(G)| \mid pq$, and since $p,q$ are distinct primes the divisors are exactly $\{1, p, q, pq\}$ (proved via $n = \gcd(n,p)\gcd(n,q)$).
- If $|Z(G)| = p$ then $[G:Z(G)] = q$ is prime, so $G/Z(G)$ is cyclic (`isCyclic_of_prime_card`), forcing $G$ abelian (`commutative_of_cyclic_center_quotient`) and $Z(G) = G$, i.e. $|Z(G)| = pq \neq p$ — contradiction. The case $|Z(G)| = q$ is symmetric.
- **Corollary:** a nonabelian group of order $pq$ has trivial center; equivalently $Z(G) = \bot$ or $Z(G) = \top$.

This complements the sibling `lagrange-theorem-oq-01-oq-01` (Sylow classification of order-$pq$ groups), which never inspects the center. Mathlib's `card_center_eq_prime_pow` covers only prime-power orders.

## Verification

- 6 theorems, 160 lines, **0 sorries, 0 axioms** (`#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`).
- Gallery entry added (`meta.json` + `annotations.json` + `index.ts`); `annotations:validate` clean for this proofId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)