### PR TITLE
research(cauchy-schwarz-oq-05): Lagrange's identity — exact Cauchy-Schwarz defect [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -615,6 +615,7 @@ import Proofs.CauchySchwarzOQ03OQ02
 import Proofs.CauchySchwarzOQ03OQ02OQ01
 import Proofs.CauchySchwarzOQ04
 import Proofs.CauchySchwarzOQ04OQ01
+import Proofs.CauchySchwarzOQ05
 import Proofs.CauchySchwarzOQ06
 import Proofs.CauchySchwarzOQ06OQ01
 import Proofs.CauchySchwarzOQ07

--- a/proofs/Proofs/CauchySchwarzOQ05.lean
+++ b/proofs/Proofs/CauchySchwarzOQ05.lean
@@ -1,0 +1,128 @@
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Data.Finset.Prod
+import Mathlib.Tactic
+
+/-!
+# Lagrange's Identity — the Exact Cauchy–Schwarz Defect (cauchy-schwarz-oq-05)
+
+## What This Proves
+
+For finite real sequences `a, b` indexed by a `Finset` over a linearly ordered type,
+Lagrange's identity gives the *exact* gap in the Cauchy–Schwarz inequality as a sum of
+squared `2 × 2` minors over strictly ordered index pairs:
+
+  (∑ aᵢ²)(∑ bᵢ²) − (∑ aᵢbᵢ)² = ∑_{i<j} (aᵢbⱼ − aⱼbᵢ)².
+
+Because the right-hand side is a sum of squares it is `≥ 0`, which makes the Cauchy–Schwarz
+inequality an immediate corollary, and it is `= 0` exactly when every minor `aᵢbⱼ − aⱼbᵢ`
+vanishes — the proportionality / equality characterization.
+
+This is the discrete shadow of `‖u‖²‖v‖² − ⟨u,v⟩² = ‖u ∧ v‖²`.
+
+## Relation to the Parent
+
+`CauchySchwarzOQ03.lean` records the **symmetric, doubled** form
+`∑ᵢ∑ⱼ (aᵢbⱼ − aⱼbᵢ)² = 2·defect` (a full double sum, with a factor of 2). The result here is
+the canonical **strict-upper-triangle** form: the defect equals the sum over `i < j` only, with
+no factor of 2, exhibiting it directly as a sum over the distinct `2 × 2` minors. The bridge is a
+general triangle-doubling lemma (`sum_offDiag_eq_two_mul_sum_filter_lt`) for symmetric kernels.
+
+## Status
+- [x] Triangle-doubling lemma for symmetric kernels
+- [x] Lagrange's identity (strict-upper-triangle form)
+- [x] Cauchy–Schwarz inequality as a corollary
+- [x] Equality characterization via vanishing minors
+
+Verified, 0-axiom (`propext` / `Classical.choice` / `Quot.sound` only).
+-/
+
+open Finset
+
+namespace LagrangeIdentityCS
+
+variable {ι : Type*} [LinearOrder ι]
+
+/-- **Triangle-doubling for a symmetric kernel.**
+Summing a symmetric function `F` over all *distinct* ordered pairs of `s` (the off-diagonal)
+counts each unordered pair twice, so it equals twice the sum over strictly increasing pairs. -/
+theorem sum_offDiag_eq_two_mul_sum_filter_lt (s : Finset ι) (F : ι → ι → ℝ)
+    (hsymm : ∀ i j, F i j = F j i) :
+    ∑ p ∈ s.offDiag, F p.1 p.2
+      = 2 * ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2), F p.1 p.2 := by
+  rw [← Finset.sum_filter_add_sum_filter_not s.offDiag (fun p => p.1 < p.2), two_mul]
+  congr 1
+  -- The `¬ (i < j)` part of the off-diagonal is the strictly-decreasing part, which the
+  -- swap `(i, j) ↦ (j, i)` carries bijectively onto the strictly-increasing part.
+  refine Finset.sum_nbij' (fun p => (p.2, p.1)) (fun p => (p.2, p.1)) ?_ ?_ ?_ ?_ ?_
+  · rintro ⟨i, j⟩ hp
+    simp only [mem_filter, mem_offDiag] at hp ⊢
+    obtain ⟨⟨hi, hj, hij⟩, hlt⟩ := hp
+    exact ⟨⟨hj, hi, fun h => hij h.symm⟩, lt_of_le_of_ne (not_lt.1 hlt) hij.symm⟩
+  · rintro ⟨i, j⟩ hp
+    simp only [mem_filter, mem_offDiag] at hp ⊢
+    obtain ⟨⟨hi, hj, hij⟩, hlt⟩ := hp
+    exact ⟨⟨hj, hi, fun h => hij h.symm⟩, not_lt.2 hlt.le⟩
+  · rintro ⟨i, j⟩ _; rfl
+  · rintro ⟨i, j⟩ _; rfl
+  · rintro ⟨i, j⟩ _; exact hsymm i j
+
+/-- **Lagrange's identity.** The Cauchy–Schwarz defect equals the sum of squared `2 × 2`
+minors over strictly increasing index pairs. -/
+theorem lagrange_identity (s : Finset ι) (a b : ι → ℝ) :
+    (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2
+      = ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2),
+          (a p.1 * b p.2 - a p.2 * b p.1) ^ 2 := by
+  set F : ι → ι → ℝ := fun i j => (a i * b j - a j * b i) ^ 2 with hF
+  -- The symmetric double sum equals twice the defect (the "doubled" Lagrange identity).
+  have hdouble : ∑ i ∈ s, ∑ j ∈ s, F i j
+      = 2 * ((∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2) := by
+    simp only [hF, sub_sq, Finset.sum_add_distrib, Finset.sum_sub_distrib]
+    have ha : ∑ i ∈ s, ∑ j ∈ s, (a i * b j) ^ 2 =
+        (∑ i ∈ s, a i ^ 2) * (∑ j ∈ s, b j ^ 2) := by
+      simp_rw [mul_pow, ← Finset.mul_sum, ← Finset.sum_mul]
+    have hc : ∑ i ∈ s, ∑ j ∈ s, (a j * b i) ^ 2 =
+        (∑ j ∈ s, a j ^ 2) * (∑ i ∈ s, b i ^ 2) := by
+      rw [Finset.sum_comm]; simp_rw [mul_pow, ← Finset.mul_sum, ← Finset.sum_mul]
+    have hb : ∑ i ∈ s, ∑ j ∈ s, 2 * (a i * b j) * (a j * b i) =
+        2 * (∑ i ∈ s, a i * b i) ^ 2 := by
+      simp_rw [sq, Finset.sum_mul, Finset.mul_sum]
+      congr 1; ext i; congr 1; ext j; ring
+    rw [ha, hc, hb]; ring
+  -- The same double sum, split into diagonal (zero) + off-diagonal (doubled upper triangle).
+  have hsplit : ∑ i ∈ s, ∑ j ∈ s, F i j
+      = 2 * ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2), F p.1 p.2 := by
+    have hprod : ∑ i ∈ s, ∑ j ∈ s, F i j = ∑ p ∈ s ×ˢ s, F p.1 p.2 := by
+      rw [Finset.sum_product']
+    rw [hprod, ← diag_union_offDiag s, Finset.sum_union (disjoint_diag_offDiag s),
+        Finset.sum_diag]
+    have hdiag : ∑ i ∈ s, F i i = 0 := by
+      simp only [hF]; apply Finset.sum_eq_zero; intro i _; ring
+    rw [hdiag, zero_add,
+        sum_offDiag_eq_two_mul_sum_filter_lt s F (fun i j => by simp only [hF]; ring)]
+  have hupper : 2 * ((∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2)
+      = 2 * ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2), F p.1 p.2 := by
+    rw [← hdouble, hsplit]
+  have := mul_left_cancel₀ (two_ne_zero) hupper
+  simpa only [hF] using this
+
+/-- **Cauchy–Schwarz inequality** as an immediate corollary: the defect is a sum of squares,
+hence non-negative. -/
+theorem cauchy_schwarz (s : Finset ι) (a b : ι → ℝ) :
+    (∑ i ∈ s, a i * b i) ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) := by
+  have h := lagrange_identity s a b
+  have hnn : 0 ≤ ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2),
+      (a p.1 * b p.2 - a p.2 * b p.1) ^ 2 :=
+    Finset.sum_nonneg fun _ _ => sq_nonneg _
+  linarith
+
+/-- **Equality characterization.** Cauchy–Schwarz holds with equality iff every `2 × 2`
+minor over a strictly increasing pair vanishes (the proportionality condition). -/
+theorem cauchy_schwarz_eq_iff (s : Finset ι) (a b : ι → ℝ) :
+    (∑ i ∈ s, a i * b i) ^ 2 = (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2)
+      ↔ ∀ p ∈ s.offDiag.filter (fun p => p.1 < p.2), a p.1 * b p.2 - a p.2 * b p.1 = 0 := by
+  have h := lagrange_identity s a b
+  rw [eq_comm, ← sub_eq_zero, h,
+      Finset.sum_eq_zero_iff_of_nonneg (fun _ _ => sq_nonneg _)]
+  exact forall_congr' fun p => imp_congr_right fun _ => pow_eq_zero_iff (by norm_num)
+
+end LagrangeIdentityCS

--- a/src/data/proofs/cauchy-schwarz-oq-05/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-cauchyschwarzoq05-overview",
+    "proofId": "cauchy-schwarz-oq-05",
+    "range": { "startLine": 6, "endLine": 46 },
+    "type": "concept",
+    "title": "Lagrange's identity: the exact Cauchy-Schwarz defect",
+    "content": "Cauchy-Schwarz says (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²). Lagrange's identity says exactly by how much: the gap equals a sum of squared 2×2 minors, (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² = ∑_{i<j}(aᵢbⱼ − aⱼbᵢ)². This file proves that identity over an arbitrary Finset on a linearly ordered index type, and reads off two corollaries: the inequality itself (the right side is a sum of squares, hence ≥ 0) and the exact equality case (the gap is 0 iff every minor vanishes, i.e. a and b are proportional). It is the discrete shadow of ‖u‖²‖v‖² − ⟨u,v⟩² = ‖u ∧ v‖²: the minors aᵢbⱼ − aⱼbᵢ are the components of the wedge u ∧ v. The whole development is axiom-free, resting only on the nonnegativity of squares and the reindexing of finite sums.",
+    "mathContext": "$(\\sum_i a_i^2)(\\sum_i b_i^2) - (\\sum_i a_ib_i)^2 = \\sum_{i<j}(a_ib_j - a_jb_i)^2$.",
+    "significance": "context",
+    "relatedConcepts": ["Lagrange identity", "Cauchy-Schwarz inequality", "2×2 minors", "wedge product", "Binet–Cauchy identity"],
+    "prerequisites": ["finite sums over a Finset", "nonnegativity of squares", "linear orders"]
+  },
+  {
+    "id": "ann-cauchyschwarzoq05-triangle",
+    "proofId": "cauchy-schwarz-oq-05",
+    "range": { "startLine": 48, "endLine": 69 },
+    "type": "key-step",
+    "title": "Triangle-doubling for symmetric kernels",
+    "content": "sum_offDiag_eq_two_mul_sum_filter_lt is the combinatorial engine. For ANY symmetric kernel F (F i j = F j i), summing over all distinct ordered pairs (the off-diagonal of s ×ˢ s) counts each unordered pair twice, so it equals 2·∑_{i<j} F. The proof splits the off-diagonal on the predicate p.1 < p.2 via Finset.sum_filter_add_sum_filter_not, then matches the not-< half against the < half through the swap involution (i,j) ↦ (j,i) using Finset.sum_nbij'. The membership side-conditions — that the swap carries strictly-decreasing pairs to strictly-increasing ones — are exactly where the LinearOrder is used: from ¬(i<j) and i≠j, trichotomy (lt_of_le_of_ne ∘ not_lt) gives j<i. The value condition F p.1 p.2 = F (swap p).1 (swap p).2 is precisely the symmetry hypothesis. This lemma is independent of Cauchy-Schwarz and applies to any symmetric double sum.",
+    "mathContext": "$\\sum_{(i,j)\\in\\mathrm{offDiag}} F\\,i\\,j = 2\\sum_{i<j} F\\,i\\,j$ when $F\\,i\\,j = F\\,j\\,i$.",
+    "significance": "key",
+    "relatedConcepts": ["swap involution", "Finset.sum_nbij'", "Finset.sum_filter_add_sum_filter_not", "LinearOrder trichotomy", "off-diagonal sum"],
+    "prerequisites": ["reindexing sums along bijections", "filtering finite sums by a predicate", "trichotomy of a linear order"]
+  },
+  {
+    "id": "ann-cauchyschwarzoq05-identity",
+    "proofId": "cauchy-schwarz-oq-05",
+    "range": { "startLine": 71, "endLine": 108 },
+    "type": "key-step",
+    "title": "The identity: doubled form, diagonal split, cancel the 2",
+    "content": "lagrange_identity assembles the result from two views of the same symmetric double sum ∑ᵢ∑ⱼ(aᵢbⱼ − aⱼbᵢ)². First view (hdouble): expand (aᵢbⱼ − aⱼbᵢ)² and collect via sum_mul / mul_sum into 2·[(∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)²] — the parent's 'doubled' Lagrange identity. Second view (hsplit): rewrite the double sum as a sum over s ×ˢ s, decompose s ×ˢ s = diag ⊎ offDiag (diag_union_offDiag + disjoint_diag_offDiag), note the kernel vanishes on the diagonal (aᵢbᵢ − aᵢbᵢ = 0 by ring), and apply the triangle-doubling lemma to the off-diagonal — giving 2·∑_{i<j}. Equating the two views yields 2·defect = 2·∑_{i<j}; mul_left_cancel₀ two_ne_zero removes the factor of 2, leaving the canonical strict-upper-triangle identity with no factor of 2.",
+    "mathContext": "$\\sum_i\\sum_j(a_ib_j - a_jb_i)^2 = 2\\,\\mathrm{defect} = 2\\sum_{i<j}(a_ib_j - a_jb_i)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["doubled Lagrange identity", "diag_union_offDiag", "Finset.sum_product'", "mul_left_cancel₀", "sum_mul / mul_sum"],
+    "prerequisites": ["diagonal/off-diagonal split of a finite product", "the triangle-doubling lemma", "cancellation by a nonzero scalar"]
+  },
+  {
+    "id": "ann-cauchyschwarzoq05-corollaries",
+    "proofId": "cauchy-schwarz-oq-05",
+    "range": { "startLine": 110, "endLine": 128 },
+    "type": "technique",
+    "title": "Cauchy-Schwarz and the equality case as corollaries",
+    "content": "Both corollaries fall straight out of the sum-of-squares form. cauchy_schwarz: the defect equals ∑_{i<j}(minor)² ≥ 0 by Finset.sum_nonneg and sq_nonneg, so (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²) is one linarith step. cauchy_schwarz_eq_iff: rewrite the equality (∑aᵢbᵢ)² = (∑aᵢ²)(∑bᵢ²) as defect = 0 (eq_comm + sub_eq_zero), substitute the identity to get ∑_{i<j}(minor)² = 0, then Finset.sum_eq_zero_iff_of_nonneg turns this into 'every (minor)² = 0', and pow_eq_zero_iff into 'every minor = 0'. The vanishing of all 2×2 minors is exactly proportionality (linear dependence) of a and b — the classical equality condition, obtained here with no separate residual-norm argument.",
+    "mathContext": "$(\\sum a_ib_i)^2 = (\\sum a_i^2)(\\sum b_i^2) \\iff \\forall\\, i<j,\\ a_ib_j - a_jb_i = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_nonneg", "Finset.sum_eq_zero_iff_of_nonneg", "pow_eq_zero_iff", "proportionality / linear dependence", "equality characterization"],
+    "prerequisites": ["Lagrange's identity", "sum of nonnegatives is zero iff each term is zero", "x² = 0 ↔ x = 0"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-05/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOQ05Data: ProofData = {
+  proof: cauchySchwarzOQ05Proof,
+  annotations: cauchySchwarzOQ05Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-05/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-05/meta.json
@@ -1,0 +1,223 @@
+{
+  "id": "cauchy-schwarz-oq-05",
+  "title": "Lagrange's Identity: the Exact Cauchy-Schwarz Defect",
+  "slug": "cauchy-schwarz-oq-05",
+  "description": "Lagrange's identity (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² = ∑_{i<j}(aᵢbⱼ − aⱼbᵢ)² over an arbitrary Finset on a linearly ordered index type: the Cauchy-Schwarz defect equals a sum of squared 2×2 minors over strictly increasing index pairs. Yields Cauchy-Schwarz as an immediate corollary and the exact equality characterization (all minors vanish). Built on a general triangle-doubling lemma for symmetric kernels.",
+  "meta": {
+    "author": "Lagrange (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange%27s_identity",
+    "date": "1773",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "algebra",
+      "cauchy-schwarz",
+      "lagrange-identity",
+      "finset",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "Splits a Finset sum by a decidable predicate into the matching and non-matching parts",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_nbij'",
+        "description": "Reindexes a Finset sum along a bijection given with an explicit inverse",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.diag_union_offDiag",
+        "description": "s ×ˢ s decomposes as the disjoint union of its diagonal and off-diagonal",
+        "module": "Mathlib.Data.Finset.Prod"
+      },
+      {
+        "theorem": "Finset.sum_diag",
+        "description": "A sum over the diagonal of s ×ˢ s reduces to a single sum over s",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "A sum of nonnegative terms is zero iff every term is zero",
+        "module": "Mathlib.Algebra.BigOperators.Order"
+      }
+    ],
+    "originalContributions": [
+      "sum_offDiag_eq_two_mul_sum_filter_lt: general triangle-doubling lemma — a symmetric kernel summed over the off-diagonal equals twice its sum over strictly increasing pairs (swap involution + LinearOrder trichotomy)",
+      "lagrange_identity: the strict-upper-triangle Lagrange identity (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² = ∑_{i<j}(aᵢbⱼ − aⱼbᵢ)² over an arbitrary Finset",
+      "cauchy_schwarz: the finite Cauchy-Schwarz inequality as an immediate corollary (defect is a sum of squares)",
+      "cauchy_schwarz_eq_iff: exact equality characterization — Cauchy-Schwarz is tight iff every 2×2 minor over a strictly increasing pair vanishes"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 128,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext / Classical.choice / Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Lagrange's identity appears in Joseph-Louis Lagrange's 1773 *Recherches d'arithmétique* on quadratic forms, decades before the inequality that now bears Cauchy's and Schwarz's names. Where Cauchy's 1821 *Cours d'Analyse* records the discrete inequality (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²), Lagrange's identity records the *exact gap*: the difference is a sum of squared 2×2 minors aᵢbⱼ − aⱼbᵢ. It is the algebraic precursor of the inequality and the special case n = 2 of the Binet–Cauchy identity for products of determinants. Geometrically it is the discrete shadow of ‖u‖²‖v‖² − ⟨u,v⟩² = ‖u ∧ v‖², the squared norm of the wedge product, so the minors are the components of u ∧ v in the standard basis. Mathlib carries `inner_mul_le_norm_mul_norm` and the Chebyshev/rearrangement sum inequalities but no named sum-form Lagrange identity.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-05)**: For finite real sequences a, b, express the exact Cauchy-Schwarz defect as a sum over 2×2 minors.\n\n**Result**: Over an arbitrary `Finset` on a linearly ordered index type, (∑ᵢ aᵢ²)(∑ᵢ bᵢ²) − (∑ᵢ aᵢbᵢ)² = ∑_{i<j} (aᵢbⱼ − aⱼbᵢ)². The right-hand side is a sum over strictly increasing pairs (no factor of 2), exhibiting the defect directly as a sum of squared 2×2 minors. Cauchy-Schwarz follows immediately (RHS ≥ 0), and equality holds iff every minor vanishes.",
+    "text": "Lagrange's identity gives the exact Cauchy-Schwarz defect as a sum of squared 2×2 minors over strictly increasing index pairs, yielding the inequality and its equality case as corollaries.",
+    "proofStrategy": "**Proof Strategy: triangle-doubling of a symmetric kernel**\n\n1. **Doubled form.** Expand the symmetric double sum ∑ᵢ∑ⱼ (aᵢbⱼ − aⱼbᵢ)² over all ordered pairs and collect terms to get 2·[(∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)²] — the parent's 'doubled' Lagrange identity.\n2. **Triangle-doubling lemma.** For any symmetric kernel F (F i j = F j i), the off-diagonal sum ∑_{i≠j} F equals 2·∑_{i<j} F: the swap (i,j) ↦ (j,i) is a bijection from the strictly-decreasing pairs onto the strictly-increasing ones, and a `LinearOrder` supplies the trichotomy needed for membership.\n3. **Split the double sum.** Decompose s ×ˢ s = diag ⊎ offDiag. The kernel vanishes on the diagonal (aᵢbᵢ − aᵢbᵢ = 0), so ∑ᵢ∑ⱼ F = 2·∑_{i<j} F.\n4. **Cancel the 2.** Equating steps 1 and 3 gives 2·defect = 2·∑_{i<j} F; cancel to obtain the identity.\n5. **Corollaries.** The RHS is a sum of squares, so the defect is ≥ 0 (Cauchy-Schwarz); and the defect is 0 iff each squared minor is 0 iff each minor is 0 (`sum_eq_zero_iff_of_nonneg` + `pow_eq_zero_iff`)."
+    ,
+    "keyInsights": [
+      "**Strict-upper-triangle vs doubled form**: The parent records the symmetric double sum ∑ᵢ∑ⱼ(aᵢbⱼ − aⱼbᵢ)² = 2·defect. The canonical Lagrange identity drops the factor of 2 and sums over i < j only, exhibiting the defect as a sum over the *distinct* 2×2 minors — the textbook statement.",
+      "**One reusable combinatorial lemma**: The entire bridge is a single general fact, sum_offDiag_eq_two_mul_sum_filter_lt, about any symmetric kernel on a linearly ordered index set; the Lagrange identity is its specialization to F i j = (aᵢbⱼ − aⱼbᵢ)².",
+      "**The swap involution needs only a linear order**: Halving the off-diagonal sum uses the bijection (i,j) ↦ (j,i) between strictly-increasing and strictly-decreasing pairs; `LinearOrder` trichotomy (lt_of_le_of_ne) is exactly what certifies the membership conditions.",
+      "**Minors are wedge components**: aᵢbⱼ − aⱼbᵢ is the (i,j) component of u ∧ v, so the identity is the coordinate form of ‖u‖²‖v‖² − ⟨u,v⟩² = ‖u ∧ v‖²; the equality case 'all minors vanish' is exactly 'u ∧ v = 0', i.e. proportionality.",
+      "**Equality case for free**: Because the defect is now literally a sum of squares, the equality characterization is immediate — sum-of-nonnegatives-is-zero forces every minor to vanish, with no separate residual-norm argument."
+    ],
+    "prerequisites": [
+      "Finite sums over a `Finset` and the product `s ×ˢ s`",
+      "Diagonal / off-diagonal decomposition of a finite product",
+      "Reindexing sums along bijections (`Finset.sum_nbij'`)",
+      "Linear orders and trichotomy",
+      "Nonnegativity of squares"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring stating Lagrange's identity, its relation to the parent's doubled form, imports, the LagrangeIdentityCS namespace, `open Finset`, and the linearly ordered index variable.",
+      "mathContext": "Index type ι with `[LinearOrder ι]`; sequences a, b : ι → ℝ summed over a `Finset ι`. The strict-upper-triangle index set is `s.offDiag.filter (fun p => p.1 < p.2)`."
+    },
+    {
+      "id": "triangle-doubling",
+      "title": "Triangle-Doubling for Symmetric Kernels",
+      "startLine": 48,
+      "endLine": 69,
+      "summary": "sum_offDiag_eq_two_mul_sum_filter_lt: for a symmetric F, the off-diagonal sum equals twice the strictly-increasing-pair sum. Splits the off-diagonal by the predicate p.1 < p.2 and matches the two halves through the swap bijection (i,j) ↦ (j,i).",
+      "mathContext": "For F i j = F j i: ∑_{(i,j) ∈ offDiag} F i j = 2·∑_{i<j} F i j. The swap maps {j < i} bijectively onto {i < j}; `lt_of_le_of_ne` and `not_lt` discharge the membership side-conditions using the linear order."
+    },
+    {
+      "id": "lagrange-identity",
+      "title": "Lagrange's Identity",
+      "startLine": 71,
+      "endLine": 108,
+      "summary": "lagrange_identity: (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² = ∑_{i<j}(aᵢbⱼ − aⱼbᵢ)². Expands the symmetric double sum to 2·defect, splits s ×ˢ s into diagonal (zero) and off-diagonal (twice the upper triangle), and cancels the factor of 2.",
+      "mathContext": "Doubled form: ∑ᵢ∑ⱼ(aᵢbⱼ − aⱼbᵢ)² = 2·[(∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)²] via `sum_mul`/`mul_sum` bookkeeping. Combined with the triangle-doubling lemma and the vanishing diagonal, `mul_left_cancel₀ two_ne_zero` yields the identity."
+    },
+    {
+      "id": "cauchy-schwarz",
+      "title": "Cauchy-Schwarz as a Corollary",
+      "startLine": 110,
+      "endLine": 118,
+      "summary": "cauchy_schwarz: (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²). The defect equals the upper-triangle sum of squares, which is nonnegative, so the inequality is one `linarith` step away.",
+      "mathContext": "Since (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² = ∑_{i<j}(aᵢbⱼ − aⱼbᵢ)² ≥ 0 by `Finset.sum_nonneg` and `sq_nonneg`, the Cauchy-Schwarz inequality follows immediately."
+    },
+    {
+      "id": "equality",
+      "title": "Equality Characterization",
+      "startLine": 120,
+      "endLine": 128,
+      "summary": "cauchy_schwarz_eq_iff: Cauchy-Schwarz is tight iff every minor aᵢbⱼ − aⱼbᵢ over a strictly increasing pair vanishes. Rewrites the equality as defect = 0, identifies the defect with the sum of squares, and applies sum-of-nonnegatives-is-zero pointwise.",
+      "mathContext": "(∑aᵢbᵢ)² = (∑aᵢ²)(∑bᵢ²) ↔ ∀ i<j, aᵢbⱼ − aⱼbᵢ = 0, via `sub_eq_zero`, the Lagrange identity, `Finset.sum_eq_zero_iff_of_nonneg`, and `pow_eq_zero_iff`. The vanishing of all 2×2 minors is the proportionality (linear dependence) condition."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "extends",
+      "description": "Promotes the base finite Cauchy-Schwarz inequality to an exact identity: the defect is realized as an explicit sum of squared 2×2 minors, from which the inequality and its equality case both follow"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 pins the exact proportionality constant in the equality case via residual-norm decomposition; this entry derives the same equality condition (all minors vanish) directly from the sum-of-squares form of the defect"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 records the symmetric doubled identity ∑ᵢ∑ⱼ(aᵢbⱼ − aⱼbᵢ)² = 2·defect inside its Cauchy-Schwarz proof; this entry sharpens it to the strict-upper-triangle form over i<j with no factor of 2"
+    },
+    {
+      "targetId": "gram-linear-independence-iff",
+      "relationship": "related",
+      "description": "The vanishing of all 2×2 minors is the n = 2 Gram/Hadamard degeneracy condition; Lagrange's identity is the wedge-product computation ‖u‖²‖v‖² − ⟨u,v⟩² = ‖u ∧ v‖² underlying Gram determinant inequalities"
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) formalization of Lagrange's identity in its canonical strict-upper-triangle form over an arbitrary Finset: the Cauchy-Schwarz defect equals the sum of squared 2×2 minors aᵢbⱼ − aⱼbᵢ over strictly increasing index pairs. The Cauchy-Schwarz inequality and its exact equality characterization (all minors vanish) drop out as one-line corollaries.",
+    "implications": "The proof factors through a reusable general lemma — a symmetric kernel summed over the off-diagonal equals twice its strictly-increasing-pair sum — which applies to any symmetric bilinear-type double sum (Gram matrices, variance/covariance sums, pairwise-interaction energies). Exhibiting the defect as a literal sum of squares makes both the inequality and the proportionality equality case immediate, bypassing the residual-norm machinery used in the abstract inner-product setting.",
+    "openQuestions": [
+      "Does the identity extend to a weighted inner product ∑ wᵢ aᵢ bᵢ with weighted minors √(wᵢwⱼ)(aᵢbⱼ − aⱼbᵢ)?",
+      "Can the strict-upper-triangle form be derived as the n = 2 case of a formalized Binet–Cauchy identity for products of determinants?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Data.Finset.Prod",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LagrangeIdentityCS",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ05.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "sum_offDiag_eq_two_mul_sum_filter_lt",
+      "type": "supporting",
+      "description": "Triangle-doubling for a symmetric kernel: summing F over all distinct ordered pairs of s counts each unordered pair twice, so it equals twice the sum over strictly increasing pairs. The combinatorial engine of the file; proved by splitting the off-diagonal on the predicate p.1 < p.2 and matching the two halves through the swap involution (i,j) ↦ (j,i), with `LinearOrder` trichotomy certifying the membership conditions.",
+      "leanType": "∀ {ι : Type*} [inst : LinearOrder ι] (s : Finset ι) (F : ι → ι → ℝ), (∀ i j, F i j = F j i) → ∑ p ∈ s.offDiag, F p.1 p.2 = 2 * ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2), F p.1 p.2"
+    },
+    {
+      "name": "lagrange_identity",
+      "type": "core",
+      "description": "**The headline result.** Lagrange's identity over an arbitrary Finset: the Cauchy-Schwarz defect (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)² equals the sum of squared 2×2 minors (aᵢbⱼ − aⱼbᵢ)² taken over strictly increasing index pairs i < j. Combines the doubled symmetric expansion with the triangle-doubling lemma and cancels the factor of 2.",
+      "leanType": "∀ {ι : Type*} [inst : LinearOrder ι] (s : Finset ι) (a b : ι → ℝ), (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) - (∑ i ∈ s, a i * b i) ^ 2 = ∑ p ∈ s.offDiag.filter (fun p => p.1 < p.2), (a p.1 * b p.2 - a p.2 * b p.1) ^ 2"
+    },
+    {
+      "name": "cauchy_schwarz",
+      "type": "core",
+      "description": "The finite Cauchy-Schwarz inequality (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²) as an immediate corollary of Lagrange's identity: the defect is exhibited as a sum of squares, hence nonnegative.",
+      "leanType": "∀ {ι : Type*} [inst : LinearOrder ι] (s : Finset ι) (a b : ι → ℝ), (∑ i ∈ s, a i * b i) ^ 2 ≤ (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2)"
+    },
+    {
+      "name": "cauchy_schwarz_eq_iff",
+      "type": "core",
+      "description": "Exact equality characterization: Cauchy-Schwarz holds with equality iff every 2×2 minor aᵢbⱼ − aⱼbᵢ over a strictly increasing pair vanishes — the proportionality (linear dependence) condition. Reads straight off the sum-of-squares form of the defect.",
+      "leanType": "∀ {ι : Type*} [inst : LinearOrder ι] (s : Finset ι) (a b : ι → ℝ), (∑ i ∈ s, a i * b i) ^ 2 = (∑ i ∈ s, a i ^ 2) * (∑ i ∈ s, b i ^ 2) ↔ ∀ p ∈ s.offDiag.filter (fun p => p.1 < p.2), a p.1 * b p.2 - a p.2 * b p.1 = 0"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Recherches d'arithmétique",
+      "year": "1773",
+      "venue": "Nouveaux Mémoires de l'Académie royale des Sciences et Belles-Lettres de Berlin",
+      "note": "Contains the identity ∑(aᵢbⱼ − aⱼbᵢ)² = (∑aᵢ²)(∑bᵢ²) − (∑aᵢbᵢ)², the algebraic precursor of the Cauchy-Schwarz inequality"
+    },
+    {
+      "authors": "Cauchy, Augustin-Louis",
+      "title": "Cours d'Analyse de l'École Royale Polytechnique",
+      "year": "1821",
+      "venue": "Paris",
+      "note": "Original discrete inequality (∑aᵢbᵢ)² ≤ (∑aᵢ²)(∑bᵢ²), of which Lagrange's identity is the exact-defect refinement"
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press, MAA Problem Books Series",
+      "note": "Chapter 4 develops the Lagrange identity and the cross-term (minor) vanishing condition for equality used here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **Lagrange's identity** in its canonical strict-upper-triangle form over an arbitrary `Finset` on a linearly ordered index type:

$$\left(\sum_i a_i^2\right)\left(\sum_i b_i^2\right) - \left(\sum_i a_ib_i\right)^2 = \sum_{i<j}(a_ib_j - a_jb_i)^2$$

The Cauchy–Schwarz defect is exhibited as a sum of squared $2\times2$ minors over **strictly increasing pairs** (no factor of 2) — the textbook form, the discrete shadow of $\|u\|^2\|v\|^2 - \langle u,v\rangle^2 = \|u\wedge v\|^2$.

**Relation to the parent:** `CauchySchwarzOQ03` already records the *symmetric doubled* form $\sum_i\sum_j(a_ib_j-a_jb_i)^2 = 2\cdot\text{defect}$ (a full double sum, factor of 2). The genuinely-new content here is dropping the factor of 2 and summing over $i<j$ only, exhibiting the defect over the *distinct* minors.

## What's proved (`Proofs/CauchySchwarzOQ05.lean`, 128 lines, 4 theorems)

- `sum_offDiag_eq_two_mul_sum_filter_lt` — reusable **triangle-doubling lemma**: any symmetric kernel summed over the off-diagonal equals twice its sum over strictly increasing pairs (swap involution $(i,j)\mapsto(j,i)$ + `LinearOrder` trichotomy).
- `lagrange_identity` — the headline identity.
- `cauchy_schwarz` — the finite inequality as an immediate corollary (defect is a sum of squares).
- `cauchy_schwarz_eq_iff` — exact equality characterization: tight iff every $2\times2$ minor vanishes (proportionality).

## Verification

Built via host `lake env lean` (Docker down). `#print axioms` on all four theorems lists only `propext / Classical.choice / Quot.sound` — **verified, 0-axiom, 0-sorry**.

Gallery entry `src/data/proofs/cauchy-schwarz-oq-05/` (meta.json + annotations.json + index.ts); 0 annotation-validation errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)