### PR TITLE
audit: clear backlog — 4 recent merges verified clean (3465/3465)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21499,6 +21499,30 @@
       "lastAudited": "2026-06-24T13:09:13Z",
       "result": "clean",
       "issues": []
+    },
+    "automorphic-number-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:44:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-convergence-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:44:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-totient-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:44:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hall-marriage-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:44:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Cleared the 4 unaudited recent-merge entries. **All claims match Lean source — 0 issues.**

| Entry | Tier | Verdict |
|-------|------|---------|
| automorphic-number-oq-01-oq-03-oq-02 | verified/original | clean — only plain `decide` (Nat.Coprime 2 5), no `Lean.ofReduceBool` |
| derangements-convergence-oq-05 | verified/original | clean — 0 sorry/axiom, no decide |
| euler-totient-oq-01-oq-02-oq-03 | verified/original | clean — `decide` hits are plain kernel decide + comment |
| hall-marriage-theorem-oq-01-oq-02 | verified/mathlib | clean — sorry/native_decide grep = docstring prose; mathlib badge correct |

### Checks performed
- **Sorry/axiom counts**: all 0, matching meta.json.
- **`native_decide`**: none present (HallMarriage's hit is docstring text on lines 47–48, not a tactic). No `Lean.ofReduceBool` exposure.
- **Plain `decide`**: kernel-checked only (coprimality / small finite facts) → no axiom impact, `axiomCount:0` honest.
- **Structure-encoded assumptions**: no `structure`/`class` declarations in any of the 4 files.
- **Badge tiers**: hall-marriage correctly `mathlib` (König–Egerváry bridge over the gallery's own defect-Hall companion); the other three correctly `original`.

Gallery now **3465/3465 audited, 0 issues, 0 critical**.

---
Discovered during autonomous gallery integrity audit.