### PR TITLE
research(fibonacci-identities-oq-05): Fibonacci product-sum closed form via Cassini [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ05.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ05.lean
@@ -1,0 +1,114 @@
+import Mathlib
+
+/-!
+# Fibonacci product-sum identity (the "staircase of consecutive products")
+
+The parent file `FibonacciIdentities.lean` records the classical **sum of squares**
+telescoping identity `F₀² + F₁² + ⋯ + Fₙ² = Fₙ · Fₙ₊₁`. This entry supplies the
+*product* analogue: the partial sums of the **consecutive products** `Fₖ · Fₖ₊₁`.
+
+Unlike the sum-of-squares identity, the product sum is **parity governed**:
+
+* `fib_prod_sum` — the unified closed form, stated additively to stay inside `ℕ`:
+  `Fₙ₊₁² = (F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁) + [n even]`,
+  where `[n even]` contributes `1` when `n` is even and `0` when `n` is odd.
+
+* `fib_prod_sum_even` / `fib_prod_sum_odd` — the two explicit branches:
+  `∑ = Fₙ₊₁² − 1` for even `n`, and `∑ = Fₙ₊₁²` for odd `n`.
+
+The engine is **Cassini's identity** `Fₙ₊₂² = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹`, which Mathlib does
+not record for `Nat.fib`; we prove it here in `ℤ` by a short induction off the defining
+recurrence `Nat.fib_add_two`, then read off the two natural-number Cassini specializations
+by parity. The main identity is then a single induction whose step is closed by `omega`
+once Cassini supplies the quadratic relation between `Fₙ₊₁²` and `Fₙ₊₂²`.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ05
+
+open Finset
+
+/-- **Cassini's identity** (integer form).
+`Fₙ₊₂² = Fₙ₊₁ · Fₙ₊₃ + (−1)ⁿ⁺¹`. Proved by induction off `Nat.fib_add_two`. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) ^ 2 = Nat.fib (n + 1) * Nat.fib (n + 3) + (-1) ^ (n + 1) := by
+  induction n with
+  | zero => norm_num [Nat.fib]
+  | succ k ih =>
+    have e1 : (Nat.fib (k + 3) : ℤ) = Nat.fib (k + 1) + Nat.fib (k + 2) := by
+      rw [show k + 3 = (k + 1) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+    have e2 : (Nat.fib (k + 4) : ℤ) = Nat.fib (k + 2) + Nat.fib (k + 3) := by
+      rw [show k + 4 = (k + 2) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+    -- Goal: fib (k+3)^2 = fib (k+2) * fib (k+4) + (-1)^(k+2)
+    rw [show k + 1 + 3 = k + 4 from rfl, show k + 1 + 2 = k + 3 from rfl,
+      show k + 1 + 1 = k + 2 from rfl, e2]
+    have hsign : (-1 : ℤ) ^ (k + 2) = -((-1) ^ (k + 1)) := by ring
+    rw [hsign]
+    linear_combination -ih + (Nat.fib (k + 3) : ℤ) * e1
+
+/-- Even-index Cassini specialization (natural numbers):
+for even `k` the index `k+1` is odd, so `Fₖ₊₁ · Fₖ₊₃ = Fₖ₊₂² + 1`. -/
+theorem cassini_nat_even {k : ℕ} (hk : Even k) :
+    Nat.fib (k + 1) * Nat.fib (k + 3) = Nat.fib (k + 2) ^ 2 + 1 := by
+  have h := fib_cassini k
+  rw [(hk.add_one).neg_one_pow] at h
+  -- h : (Nat.fib (k+2) : ℤ)^2 = Nat.fib (k+1) * Nat.fib (k+3) + (-1)
+  zify
+  linarith [h]
+
+/-- Odd-index Cassini specialization (natural numbers):
+for odd `k` the index `k+1` is even, so `Fₖ₊₂² = Fₖ₊₁ · Fₖ₊₃ + 1`. -/
+theorem cassini_nat_odd {k : ℕ} (hk : Odd k) :
+    Nat.fib (k + 2) ^ 2 = Nat.fib (k + 1) * Nat.fib (k + 3) + 1 := by
+  have h := fib_cassini k
+  rw [(hk.add_one).neg_one_pow] at h
+  -- h : (Nat.fib (k+2) : ℤ)^2 = Nat.fib (k+1) * Nat.fib (k+3) + 1
+  zify
+  linarith [h]
+
+/-- **Fibonacci product-sum identity** (unified, additive form).
+`Fₙ₊₁² = (F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁) + [n even]`. -/
+theorem fib_prod_sum (n : ℕ) :
+    Nat.fib (n + 1) ^ 2
+      = (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 1))
+        + (if Even n then 1 else 0) := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.sum_range_succ]
+    have he1 : Nat.fib (k + 3) = Nat.fib (k + 1) + Nat.fib (k + 2) := by
+      rw [show k + 3 = (k + 1) + 2 from rfl, Nat.fib_add_two]
+    rcases Nat.even_or_odd k with hk | hk
+    · -- k even, so k+1 is odd
+      have hc := cassini_nat_even hk
+      rw [he1, mul_add, ← pow_two] at hc
+      -- hc : Fₖ₊₁² + Fₖ₊₁·Fₖ₊₂ = Fₖ₊₂² + 1
+      rw [if_pos hk] at ih
+      have hodd : ¬ Even (k + 1) := by simp [Nat.even_add_one, hk]
+      rw [show k + 1 + 1 = k + 2 from rfl, if_neg hodd]
+      omega
+    · -- k odd, so k+1 is even
+      have hc := cassini_nat_odd hk
+      rw [he1, mul_add, ← pow_two] at hc
+      -- hc : Fₖ₊₂² = Fₖ₊₁² + Fₖ₊₁·Fₖ₊₂ + 1
+      rw [if_neg (by simpa [Nat.not_even_iff_odd] using hk)] at ih
+      have heven : Even (k + 1) := hk.add_one
+      rw [show k + 1 + 1 = k + 2 from rfl, if_pos heven]
+      omega
+
+/-- Even branch: `F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − 1` when `n` is even. -/
+theorem fib_prod_sum_even {n : ℕ} (hn : Even n) :
+    (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 1)) = Nat.fib (n + 1) ^ 2 - 1 := by
+  have h := fib_prod_sum n
+  rw [if_pos hn] at h
+  omega
+
+/-- Odd branch: `F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁²` when `n` is odd. -/
+theorem fib_prod_sum_odd {n : ℕ} (hn : Odd n) :
+    (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 1)) = Nat.fib (n + 1) ^ 2 := by
+  have h := fib_prod_sum n
+  rw [if_neg (by simpa [Nat.not_even_iff_odd] using hn)] at h
+  omega
+
+end FibonacciIdentitiesOQ05

--- a/src/data/proofs/fibonacci-identities-oq-05/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05/annotations.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "ann-fiboq05-1",
+    "proofId": "fibonacci-identities-oq-05",
+    "range": { "startLine": 3, "endLine": 26 },
+    "type": "context",
+    "title": "The Product Analogue of the Sum of Squares",
+    "content": "**Module framing.** The parent entry proves the telescoping identity $F_0^2 + F_1^2 + \\cdots + F_n^2 = F_n F_{n+1}$. This file supplies the *product* companion: the partial sums of consecutive products $F_k F_{k+1}$. The crucial difference is **parity**. The sum of squares lands exactly on a single product; the product sum instead oscillates by one about the perfect square $F_{n+1}^2$ — landing on $F_{n+1}^2$ for odd $n$ and $F_{n+1}^2 - 1$ for even $n$. That oscillation is Cassini's alternating sign $(-1)^n$, which is why the proof needs Cassini's identity rather than a clean telescope.",
+    "mathContext": "$F_{n+1}^2 = (F_0F_1 + F_1F_2 + \\cdots + F_nF_{n+1}) + [n\\text{ even}]$, using 0-indexed $\\mathtt{Nat.fib}$ ($F_0 = 0$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Sum of squares of Fibonacci numbers (parent entry)",
+      "Cassini's identity and the alternating sign",
+      "Parity-governed closed forms"
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib",
+      "Classical Fibonacci summation identities"
+    ],
+    "tags": ["module-header", "framing", "fibonacci"]
+  },
+  {
+    "id": "ann-fiboq05-2",
+    "proofId": "fibonacci-identities-oq-05",
+    "range": { "startLine": 32, "endLine": 50 },
+    "type": "insight",
+    "title": "Cassini's Identity for Nat.fib, from Scratch",
+    "content": "**`fib_cassini`** establishes $F_{n+2}^2 = F_{n+1}\\,F_{n+3} + (-1)^{n+1}$ over $\\mathbb{Z}$. Mathlib records Cassini only for the two-sided `Int.fib`, so the `Nat.fib` form is proved here directly by induction off the recurrence `Nat.fib_add_two`. The base case is `norm_num [Nat.fib]`; the step expands $F_{k+3}$ and $F_{k+4}$ by the recurrence (as cast equations `e1`, `e2`) and closes with a single `linear_combination -ih + (F_{k+3})\\cdot e1` — the coefficient $F_{k+3}$ on the recurrence absorbs the quadratic cross-term, and the alternating sign flips via `(-1)^{k+2} = -(-1)^{k+1}`.",
+    "mathContext": "$F_{n+2}^2 = F_{n+1}F_{n+3} + (-1)^{n+1}$; equivalently $F_{n+1}F_{n+3} - F_{n+2}^2 = (-1)^{n+2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Nat.fib_add_two recurrence",
+      "linear_combination tactic"
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence",
+      "Induction over ℕ and casting to ℤ"
+    ],
+    "tags": ["cassini", "engine", "linear_combination"]
+  },
+  {
+    "id": "ann-fiboq05-3",
+    "proofId": "fibonacci-identities-oq-05",
+    "range": { "startLine": 52, "endLine": 70 },
+    "type": "insight",
+    "title": "Quarantining the Sign by Parity",
+    "content": "**`cassini_nat_even` / `cassini_nat_odd`** turn the signed integer Cassini into two *sign-free* natural-number relations. For even $k$ the exponent $k+1$ is odd, so `Odd.neg_one_pow` rewrites $(-1)^{k+1}$ to $-1$, giving $F_{k+1}F_{k+3} = F_{k+2}^2 + 1$; for odd $k$ the index $k+1$ is even, giving $F_{k+2}^2 = F_{k+1}F_{k+3} + 1$. Each closes by `zify; linarith`. Separating the two parities here is what lets the main induction stay entirely in $\\mathbb{N}$ — no subtraction, no casting in the step.",
+    "mathContext": "Even $k$: $F_{k+1}F_{k+3} = F_{k+2}^2 + 1$. Odd $k$: $F_{k+2}^2 = F_{k+1}F_{k+3} + 1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Even.neg_one_pow / Odd.neg_one_pow",
+      "zify and linarith",
+      "Parity case analysis"
+    ],
+    "prerequisites": [
+      "fib_cassini",
+      "Evenness/oddness of n and n+1"
+    ],
+    "tags": ["parity", "cassini", "zify"]
+  },
+  {
+    "id": "ann-fiboq05-4",
+    "proofId": "fibonacci-identities-oq-05",
+    "range": { "startLine": 72, "endLine": 99 },
+    "type": "insight",
+    "title": "The Main Induction: omega Finishes Once Cassini Lands",
+    "content": "**`fib_prod_sum`** proves the unified additive identity by induction on $n$. After `Finset.sum_range_succ` peels off the last product $F_{k+1}F_{k+2}$, the proof splits on `Nat.even_or_odd k`. In each branch it rewrites $F_{k+3} = F_{k+1} + F_{k+2}$ into the matching Cassini specialization (via `mul_add`, `← pow_two`), turning it into a relation among the three opaque atoms $F_{k+1}^2$, $F_{k+1}F_{k+2}$, $F_{k+2}^2$, evaluates the parity `if`, and calls `omega`. Treating the quadratic terms and the partial sum as non-negative integers, the goal is a *linear* consequence of the inductive hypothesis and the Cassini relation — no further Fibonacci reasoning is needed.",
+    "mathContext": "Step goal (even $k$): $F_{k+2}^2 = \\big(\\sum_{i\\le k} F_iF_{i+1}\\big) + F_{k+1}F_{k+2}$, given IH $F_{k+1}^2 = \\sum_{i\\le k} F_iF_{i+1} + 1$ and $F_{k+1}^2 + F_{k+1}F_{k+2} = F_{k+2}^2 + 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "Nat.even_or_odd case split",
+      "omega over opaque nonlinear atoms"
+    ],
+    "prerequisites": [
+      "cassini_nat_even / cassini_nat_odd",
+      "Induction with partial sums"
+    ],
+    "tags": ["induction", "omega", "main-theorem"]
+  },
+  {
+    "id": "ann-fiboq05-5",
+    "proofId": "fibonacci-identities-oq-05",
+    "range": { "startLine": 101, "endLine": 113 },
+    "type": "insight",
+    "title": "Reading Off the Two Closed Forms",
+    "content": "**`fib_prod_sum_even` / `fib_prod_sum_odd`** present the human-facing answers. Specializing the unified identity by evaluating the parity bracket and rearranging with `omega` gives $\\sum_{i=0}^{n} F_iF_{i+1} = F_{n+1}^2 - 1$ for even $n$ and $= F_{n+1}^2$ for odd $n$. The truncated subtraction in the even branch is harmless precisely because the unified form was stated additively, so $F_{n+1}^2 \\ge 1$ is automatic.",
+    "mathContext": "$\\sum_{i=0}^{n} F_iF_{i+1} = F_{n+1}^2 - 1$ (even $n$), $\\;= F_{n+1}^2$ (odd $n$).",
+    "significance": "important",
+    "relatedConcepts": [
+      "Truncated subtraction in ℕ",
+      "Specialization by parity",
+      "omega"
+    ],
+    "prerequisites": [
+      "fib_prod_sum"
+    ],
+    "tags": ["corollaries", "closed-form", "presentation"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-05/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ05Data: ProofData = {
+  proof: fibonacciIdentitiesOQ05Proof,
+  annotations: fibonacciIdentitiesOQ05Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-05/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "fibonacci-identities-oq-05",
+  "title": "Fibonacci Product-Sum: the Staircase of Consecutive Products",
+  "slug": "fibonacci-identities-oq-05",
+  "description": "The parent file FibonacciIdentities.lean records the sum-of-squares telescoping identity F₀² + F₁² + ⋯ + Fₙ² = Fₙ·Fₙ₊₁. This entry supplies its product analogue: the partial sums of the consecutive products Fₖ·Fₖ₊₁. Unlike the sum of squares, the product sum is parity governed — fib_prod_sum gives the unified additive closed form Fₙ₊₁² = (F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁) + [n even], with the bracket contributing 1 for even n and 0 for odd n; the two explicit branches fib_prod_sum_even (∑ = Fₙ₊₁² − 1) and fib_prod_sum_odd (∑ = Fₙ₊₁²) follow. The engine is Cassini's identity Fₙ₊₂² = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹, which Mathlib does not record for Nat.fib; it is proved here in ℤ by a short induction off Nat.fib_add_two and then read off as two natural-number specializations by parity. The main identity is a single induction whose step is closed by omega once Cassini supplies the quadratic relation between Fₙ₊₁² and Fₙ₊₂². Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Lucas; Fibonacci summation folklore); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence",
+    "date": "1876",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "summation-identity",
+      "telescoping",
+      "parity",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence; the only Fibonacci-specific fact, used to prove Cassini and to expand fib (k+3) = fib (k+1) + fib (k+2) in the induction step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the last consecutive product Fₙ·Fₙ₊₁ off the partial sum in the inductive step",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)ⁿ = 1 for even n and −1 for odd n — collapses the alternating sign in Cassini to the concrete constant matching each parity branch",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.even_or_odd",
+        "description": "every natural number is even or odd — drives the two-way case split that selects the correct Cassini specialization in the induction step",
+        "module": "Mathlib.Algebra.Parity"
+      }
+    ],
+    "originalContributions": [
+      "fib_prod_sum: ∀ n, Nat.fib (n+1)^2 = (∑ i ∈ range (n+1), Nat.fib i · Nat.fib (i+1)) + (if Even n then 1 else 0) — the unified, subtraction-free closed form for the partial sums of consecutive Fibonacci products, absent from Mathlib",
+      "fib_prod_sum_even: ∀ n, Even n → ∑ i ∈ range (n+1), Nat.fib i · Nat.fib (i+1) = Nat.fib (n+1)^2 − 1 — the even branch",
+      "fib_prod_sum_odd: ∀ n, Odd n → ∑ i ∈ range (n+1), Nat.fib i · Nat.fib (i+1) = Nat.fib (n+1)^2 — the odd branch",
+      "fib_cassini: ∀ n, (Nat.fib (n+2) : ℤ)^2 = Nat.fib (n+1) · Nat.fib (n+3) + (−1)^(n+1) — Cassini's identity for Nat.fib (Mathlib records it only over Int.fib), proved here directly and used as the engine"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 114,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Lucas and his contemporaries catalogued the elementary Fibonacci summation identities in the 1870s. The sum of squares F₀² + ⋯ + Fₙ² = Fₙ·Fₙ₊₁ is the most famous — its geometric reading dissects an Fₙ×Fₙ₊₁ rectangle into squares — and the parent entry FibonacciIdentities.lean formalizes it. The sum of consecutive products F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁ is its close relative, but with a twist: where the sum of squares lands exactly on a single product, the product sum oscillates by one about the perfect square Fₙ₊₁², landing on Fₙ₊₁² for odd n and Fₙ₊₁² − 1 for even n. That oscillation is precisely Cassini's alternating sign (−1)ⁿ, which is why Cassini's identity — and not mere telescoping — is the engine of the proof.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-05)**: Establish the closed form for the partial sums of the consecutive Fibonacci products Fₖ·Fₖ₊₁, the product analogue of the parent file's sum-of-squares identity.\n\n**Result**: fib_prod_sum, the unified additive identity Fₙ₊₁² = (∑ FₖFₖ₊₁) + [n even], together with the explicit even and odd branches.",
+    "text": "Using Mathlib's 0-indexed Nat.fib (F₀ = 0, F₁ = 1), for every n the partial sum F₀F₁ + F₁F₂ + ⋯ + FₙFₙ₊₁ equals Fₙ₊₁² − 1 when n is even and Fₙ₊₁² when n is odd. Equivalently, and without leaving ℕ: Fₙ₊₁² = (∑_{i=0}^{n} Fᵢ·Fᵢ₊₁) + [n even].",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Cassini for Nat.fib (`fib_cassini`).** Prove Fₙ₊₂² = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹ over ℤ by induction. The base case is `norm_num [Nat.fib]`; the step expands fib (k+3) and fib (k+4) by the recurrence and closes with `linear_combination -ih + (fib (k+3))·e1`, where e1 is the recurrence as a cast equation. This is the only place the Fibonacci recurrence enters.\n2. **Parity specializations (`cassini_nat_even`, `cassini_nat_odd`).** For even k the index k+1 is odd, so (−1)^(k+1) = −1 and Cassini becomes the pure ℕ identity Fₖ₊₁·Fₖ₊₃ = Fₖ₊₂² + 1; for odd k it becomes Fₖ₊₂² = Fₖ₊₁·Fₖ₊₃ + 1. Each is obtained by rewriting the sign via Even/Odd.neg_one_pow and discharging with `zify; linarith`.\n3. **Main induction (`fib_prod_sum`).** Induct on n. The base is `simp`. In the step, peel the last term with Finset.sum_range_succ, split on Nat.even_or_odd k, rewrite fib (k+3) = fib (k+1) + fib (k+2) into the matching Cassini specialization (turning it into a relation among the atoms Fₖ₊₁², Fₖ₊₁·Fₖ₊₂, Fₖ₊₂²), evaluate the `if` by parity, and close with `omega`: treating the three quadratic terms and the partial sum as opaque non-negative integers, the goal is a linear consequence of the inductive hypothesis and the Cassini relation.\n4. **Explicit branches.** fib_prod_sum_even and fib_prod_sum_odd specialize the unified form by evaluating the `if` and rearranging with `omega`.",
+    "keyInsights": [
+      "**Cassini, not telescoping, is the engine.** The sum of squares telescopes because Fₙ·Fₙ₊₁ − Fₙ₋₁·Fₙ = Fₙ²; the product sum has no such clean telescope. Instead the per-step increment is governed by Cassini's identity, and its alternating sign (−1)ⁿ is exactly what produces the even/odd dichotomy in the answer.",
+      "**A subtraction-free statement keeps the proof in ℕ.** Phrasing the unified identity as Fₙ₊₁² = (∑) + [n even] — rather than ∑ = Fₙ₊₁² − [n even] — avoids ℕ truncated subtraction entirely, so the inductive step closes by `omega` over the natural numbers with no casting.",
+      "**omega finishes once the nonlinearity is quarantined.** After Cassini supplies the single quadratic relation among Fₖ₊₁², Fₖ₊₁·Fₖ₊₂ and Fₖ₊₂², every remaining obligation is linear in those opaque atoms plus the partial sum, so `omega` discharges the step without any further Fibonacci-specific reasoning.",
+      "**Beyond Mathlib at both levels.** Mathlib records Cassini only over Int.fib; the Nat.fib Cassini here is proved from scratch, and the product-sum identity it powers is absent from Mathlib entirely — the natural product companion to the parent's sum-of-squares entry."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "Cassini's identity and its parity-driven sign (−1)ⁿ",
+      "Induction with Finset.sum_range_succ and the omega decision procedure for linear arithmetic over ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring framing the product sum as the parity-governed analogue of the parent's sum-of-squares identity, naming Cassini's identity as the engine, and the import/namespace setup (open Finset).",
+      "mathContext": "$F_{n+1}^2 = (F_0F_1 + F_1F_2 + \\cdots + F_nF_{n+1}) + [n \\text{ even}]$."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini's Identity for Nat.fib",
+      "startLine": 34,
+      "endLine": 50,
+      "summary": "fib_cassini: Fₙ₊₂² = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹ over ℤ, proved by induction off the recurrence and closed with linear_combination. Mathlib records Cassini only over Int.fib, so this Nat.fib form is supplied directly.",
+      "mathContext": "$F_{n+2}^2 = F_{n+1}F_{n+3} + (-1)^{n+1}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "specializations",
+      "title": "Parity Specializations of Cassini",
+      "startLine": 52,
+      "endLine": 70,
+      "summary": "cassini_nat_even and cassini_nat_odd: collapse the alternating sign by parity (Even/Odd.neg_one_pow) to obtain the two pure ℕ relations Fₖ₊₁·Fₖ₊₃ = Fₖ₊₂² + 1 (even k) and Fₖ₊₂² = Fₖ₊₁·Fₖ₊₃ + 1 (odd k), via zify; linarith.",
+      "mathContext": "Even $k$: $F_{k+1}F_{k+3} = F_{k+2}^2 + 1$; odd $k$: $F_{k+2}^2 = F_{k+1}F_{k+3} + 1$."
+    },
+    {
+      "id": "main",
+      "title": "The Product-Sum Identity",
+      "startLine": 72,
+      "endLine": 99,
+      "summary": "fib_prod_sum: the unified additive closed form, by induction on n. The step peels the last product with Finset.sum_range_succ, splits on parity, feeds the matching Cassini specialization (with fib (k+3) expanded by the recurrence), and closes by omega.",
+      "mathContext": "$F_{n+1}^2 = \\left(\\sum_{i=0}^{n} F_i F_{i+1}\\right) + [n \\text{ even}]$."
+    },
+    {
+      "id": "branches",
+      "title": "Explicit Even and Odd Branches",
+      "startLine": 101,
+      "endLine": 113,
+      "summary": "fib_prod_sum_even (∑ = Fₙ₊₁² − 1 for even n) and fib_prod_sum_odd (∑ = Fₙ₊₁² for odd n): the two human-facing closed forms, obtained from the unified identity by evaluating the parity bracket and rearranging with omega.",
+      "mathContext": "$\\sum_{i=0}^{n} F_iF_{i+1} = F_{n+1}^2 - 1$ (even $n$) or $F_{n+1}^2$ (odd $n$)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "complements",
+      "description": "The base entry FibonacciIdentities.lean proves the sum-of-squares telescoping identity F₀² + ⋯ + Fₙ² = Fₙ·Fₙ₊₁; this entry is its product analogue ∑ FₖFₖ₊₁, which — unlike the sum of squares — is parity governed and requires Cassini's identity rather than mere telescoping."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-04",
+      "relationship": "relatedTo",
+      "description": "The oq-04 entry formalizes Cassini's identity over Int.fib as a corollary of Vajda's identity; here Cassini is reproved directly over Nat.fib and used as the engine of a summation identity rather than as a product identity in its own right."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of the partial-sum closed form for consecutive Fibonacci products: the unified additive identity Fₙ₊₁² = (∑ FₖFₖ₊₁) + [n even], together with its explicit even (Fₙ₊₁² − 1) and odd (Fₙ₊₁²) branches. Cassini's identity for Nat.fib is supplied as a reusable byproduct.",
+    "implications": "Adds the product companion to the parent's sum-of-squares identity to the formalized record, both absent from Mathlib, and demonstrates that the answer's even/odd dichotomy is exactly Cassini's alternating sign. The subtraction-free phrasing keeps the entire argument inside ℕ, with omega discharging each inductive step.",
+    "openQuestions": [
+      "Find and prove the closed form for the alternating product sum ∑ (−1)ᵏ Fₖ Fₖ₊₁, and for the weighted sum ∑ k Fₖ Fₖ₊₁.",
+      "Generalize the product-sum identity to the Lucas numbers Lₖ Lₖ₊₁ and to general Gibonacci (Horadam) sequences, tracking how the parity constant becomes a discriminant.",
+      "Prove the companion identity for products at a fixed gap, ∑ Fₖ Fₖ₊₂, and relate its closed form to Fₙ₊₁ Fₙ₊₂."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ05",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Foundational catalogue of elementary Fibonacci summation and product identities"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Sum of consecutive products and the Cassini-governed parity dichotomy"
+    },
+    {
+      "authors": "Vorobiev, Nicolai N.",
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser",
+      "note": "Summation identities for the Fibonacci sequence and their inductive proofs"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/fibonacci-identities-oq-05.json
+++ b/src/data/research/problems/fibonacci-identities-oq-05.json
@@ -1,0 +1,239 @@
+{
+  "slug": "fibonacci-identities-oq-05",
+  "title": "Fibonacci Staircase — Partial Sum of Consecutive Products",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\sum_{k=1}^{m} F_k\\,F_{k+1} =\n\\begin{cases} F_{m+1}^{2} - 1, & m \\text{ even},\\\\ F_{m+1}^{2}, & m \\text{ odd}.\\end{cases}",
+    "plain": "Add up the products of consecutive Fibonacci numbers, $F_1F_2 + F_2F_3 + \\cdots + F_mF_{m+1}$. The running total has a clean closed form: it is a Fibonacci number squared, with a $-1$ correction on even steps. This is the multiplicative companion to the parent file's additive identity $\\sum F_k^2 = F_n F_{n+1}$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T06:09:40-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Proved the Fibonacci product-sum closed form ∑_{i≤n} F_i·F_{i+1} = F_{n+1}^2 - [n even] (verified, 0 axioms, 5 theorems, 114 lines). Engine = Cassini for Nat.fib (proved from scratch; Mathlib has it only over Int.fib).",
+    "builtItems": [
+      "fib_cassini: (Nat.fib (n+2):ℤ)^2 = Nat.fib (n+1)*Nat.fib (n+3) + (-1)^(n+1) — Cassini for Nat.fib (Proofs/FibonacciIdentitiesOQ05.lean:34)",
+      "cassini_nat_even / cassini_nat_odd: sign-free ℕ Cassini specializations by parity (FibonacciIdentitiesOQ05.lean:52,62)",
+      "fib_prod_sum: Nat.fib (n+1)^2 = (∑ i ∈ range (n+1), Nat.fib i*Nat.fib (i+1)) + (if Even n then 1 else 0) (FibonacciIdentitiesOQ05.lean:72)",
+      "fib_prod_sum_even / fib_prod_sum_odd: explicit branches ∑ = F_{n+1}^2 - 1 / F_{n+1}^2 (FibonacciIdentitiesOQ05.lean:101,108)"
+    ],
+    "insights": [
+      "The product sum ∑ F_k·F_{k+1} is parity-governed (= F_{n+1}^2 for odd n, F_{n+1}^2 - 1 for even n) — unlike the parent sum-of-squares which telescopes exactly onto F_n·F_{n+1}.",
+      "The even/odd dichotomy in the answer is exactly Cassini's alternating sign (-1)^n; the per-step increment is a Cassini relation, not a clean telescope.",
+      "Stating the unified identity additively as F_{n+1}^2 = (∑) + [n even] avoids ℕ truncated subtraction, keeping the whole induction inside ℕ so omega closes each step.",
+      "Once Cassini supplies the one quadratic relation among F_{k+1}^2, F_{k+1}F_{k+2}, F_{k+2}^2, the inductive step is linear in those opaque atoms — omega finishes with no further Fibonacci reasoning."
+    ],
+    "mathlibGaps": [
+      "Mathlib records Cassini's identity only over Int.fib (Int.fib_succ_mul_fib_pred_sub_fib_sq), not over Nat.fib — reproved here directly.",
+      "Mathlib has no closed form for partial sums of consecutive Fibonacci products ∑ F_k·F_{k+1}."
+    ],
+    "nextSteps": [
+      "Alternating/weighted product sums ∑ (-1)^k F_k F_{k+1} and ∑ k F_k F_{k+1}.",
+      "Fixed-gap product sum ∑ F_k F_{k+2} and its relation to F_{n+1} F_{n+2}.",
+      "Lucas / Gibonacci (Horadam) generalization where the parity constant becomes a discriminant."
+    ],
+    "markdown": "# Knowledge Base: fibonacci-identities-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "fibonacci",
+    "telescoping"
+  ],
+  "relatedProofs": [
+    "fibonacci-identities",
+    "fibonacci-identities-oq-01",
+    "fibonacci-identities-oq-01-oq-02",
+    "fibonacci-identities-oq-01-oq-02-oq-01",
+    "fibonacci-identities-oq-02",
+    "fibonacci-identities-oq-02-oq-01",
+    "fibonacci-identities-oq-02-oq-01-oq-01",
+    "fibonacci-identities-oq-03",
+    "fibonacci-identities-oq-03-oq-01",
+    "fibonacci-identities-oq-03-oq-02",
+    "fibonacci-identities-oq-03-oq-03",
+    "fibonacci-identities-oq-04",
+    "fibonacci-identities-oq-04-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T13:16:33.841Z",
+  "lastUpdate": "2026-06-24",
+  "leanFiles": [
+    {
+      "path": "Proofs/FibonacciIdentities.lean",
+      "filename": "FibonacciIdentities.lean",
+      "lineCount": 71,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentities.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ01.lean",
+      "filename": "FibonacciIdentitiesOQ01.lean",
+      "lineCount": 99,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ01OQ02.lean",
+      "filename": "FibonacciIdentitiesOQ01OQ02.lean",
+      "lineCount": 120,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ01OQ02OQ01.lean",
+      "lineCount": 172,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ02.lean",
+      "filename": "FibonacciIdentitiesOQ02.lean",
+      "lineCount": 110,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ02.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ02OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ02OQ01.lean",
+      "lineCount": 267,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ02OQ01OQ01.lean",
+      "lineCount": 188,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ03.lean",
+      "filename": "FibonacciIdentitiesOQ03.lean",
+      "lineCount": 77,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ03.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ03OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ03OQ01.lean",
+      "lineCount": 82,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ03OQ02.lean",
+      "filename": "FibonacciIdentitiesOQ03OQ02.lean",
+      "lineCount": 98,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ03OQ03.lean",
+      "filename": "FibonacciIdentitiesOQ03OQ03.lean",
+      "lineCount": 144,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ04.lean",
+      "filename": "FibonacciIdentitiesOQ04.lean",
+      "lineCount": 103,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ04.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ04OQ01.lean",
+      "filename": "FibonacciIdentitiesOQ04OQ01.lean",
+      "lineCount": 213,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/FibonacciIdentitiesOQ05.lean",
+      "filename": "FibonacciIdentitiesOQ05.lean",
+      "lineCount": 115,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FibonacciIdentitiesOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves **fibonacci-identities-oq-05**: the closed form for partial sums of the consecutive Fibonacci products `F_k·F_{k+1}` — the product analogue of the parent entry's sum-of-squares identity `F_0² + ⋯ + F_n² = F_n·F_{n+1}`.

Unlike the sum of squares, which telescopes exactly onto a single product, the product sum is **parity governed** — it oscillates by one about the perfect square `F_{n+1}²`:

| theorem | statement |
|---|---|
| `fib_prod_sum` | `F_{n+1}² = (∑_{i≤n} F_i·F_{i+1}) + [n even]` (additive, stays in ℕ) |
| `fib_prod_sum_even` | `∑ = F_{n+1}² − 1` for even `n` |
| `fib_prod_sum_odd` | `∑ = F_{n+1}²` for odd `n` |

## Engine: Cassini for `Nat.fib`

The even/odd dichotomy is exactly Cassini's alternating sign `(−1)ⁿ`, so the proof needs Cassini's identity rather than a clean telescope. Mathlib records Cassini only over the two-sided `Int.fib`, so `fib_cassini : F_{n+2}² = F_{n+1}·F_{n+3} + (−1)^{n+1}` is proved here from scratch by induction off `Nat.fib_add_two` (closed with `linear_combination`), then specialized by parity to two sign-free ℕ relations. Phrasing the main identity additively avoids ℕ truncated subtraction, so each inductive step closes by `omega` once Cassini quarantines the lone nonlinearity.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all five theorems. No `native_decide`/`decide`.
- 5 theorems, 0 definitions, 114 lines.
- Gallery: `meta.json` + `annotations.json` + `index.ts` added; `pnpm annotations:validate` reports zero issues for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)