### PR TITLE
Enrich 10-adic automorphic idempotent towers (automorphic-number-oq-01-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-autonum-oq010302-model",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 38,
+      "endLine": 46
+    },
+    "type": "definition",
+    "title": "Modelling the 10-adic integers as ℤ₂ × ℤ₅",
+    "content": "Because 10 = 2·5 is composite, ℤ₁₀ is not a single PadicInt — Mathlib's ℤ_[p] requires p prime. The correct object is the product ℤ_[2] × ℤ_[5], here named TenAdic. This is legitimate: for each k the Chinese Remainder Theorem gives ZMod (10ᵏ) ≅ ZMod (2ᵏ) × ZMod (5ᵏ), so the inverse limit of the left side is the product of the inverse limits ℤ₂ × ℤ₅. The two Fact (Nat.Prime _) instances unlock the entire p-adic API (toZModPow, the norm, completeness) for the two factors.",
+    "mathContext": "$\\mathbb{Z}_{10}\\;\\cong\\;\\varprojlim_k \\mathbb{Z}/10^k\\;\\cong\\;\\mathbb{Z}_2\\times\\mathbb{Z}_5$, the special case $n=10$ of $\\widehat{\\mathbb{Z}}_n\\cong\\prod_{p\\mid n}\\mathbb{Z}_p$.",
+    "significance": "context",
+    "relatedConcepts": ["p-adic integers", "inverse limit", "Chinese Remainder Theorem", "10-adic integers", "profinite completion"],
+    "prerequisites": ["p-adic integers", "Chinese Remainder Theorem", "direct products of rings"]
+  },
+  {
+    "id": "ann-autonum-oq010302-padic-idem",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 56
+    },
+    "type": "technique",
+    "title": "Idempotents of a p-adic domain are only 0 and 1",
+    "content": "An idempotent satisfies e·e = e, equivalently e·(e−1) = 0. Since ℤ_[p] is an integral domain (it has no zero divisors), a product is zero only if a factor is, so e = 0 or e = 1. The Lean proof rearranges e·e = e into e·(e−1) = 0 with ring_nf/linear_combination, then splits on mul_eq_zero. This per-factor fact is the engine behind the whole idempotent count of the 10-adic integers.",
+    "mathContext": "In a domain, $e^2=e\\iff e(e-1)=0\\iff e\\in\\{0,1\\}$. The only idempotents are the trivial ones.",
+    "significance": "key",
+    "relatedConcepts": ["idempotent", "integral domain", "zero divisors", "local ring"],
+    "prerequisites": ["integral domains", "idempotent elements"]
+  },
+  {
+    "id": "ann-autonum-oq010302-idem-iff",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "The four idempotents of ℤ₁₀ = ℤ₂ × ℤ₅",
+    "content": "Multiplication in a product ring is componentwise, so e = (e₁, e₂) is idempotent iff each eᵢ is idempotent in its factor (Prod.ext_iff applied to e·e = e). Combined with the previous lemma — each factor is 0 or 1 — the idempotents of ℤ₂ × ℤ₅ are exactly the four pairs over {0,1}²: (0,0), (1,0), (0,1), (1,1). The forward direction case-splits both factors; the reverse direction checks each of the four pairs is idempotent by ext + simp. This is the limit set of the automorphic towers: every coherent automorphic thread converges to one of these four points.",
+    "mathContext": "$\\{e\\in\\mathbb{Z}_2\\times\\mathbb{Z}_5 : e^2=e\\}=\\{0,1\\}^2$, four elements — matching $2^{\\omega(10)}=4$ idempotents at every finite level $\\mathbb{Z}/10^k$.",
+    "significance": "key",
+    "relatedConcepts": ["idempotent", "product ring", "componentwise operations", "automorphic number", "2^ω(n) count"],
+    "prerequisites": ["product rings", "idempotent elements"]
+  },
+  {
+    "id": "ann-autonum-oq010302-nontrivial",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 96
+    },
+    "type": "concept",
+    "title": "The two non-trivial idempotents e5, e6 as an orthogonal complementary pair",
+    "content": "Among the four idempotents, the two non-trivial ones are e5 = (1,0) and e6 = (0,1). They are orthogonal and complementary: e5 + e6 = 1 and e5·e6 = 0 (proved componentwise by ext/simp). This mirrors the parent entry's complementary pair a, 1−a of base-10 automorphic residues — here e6 = 1 − e5. e5 is the 10-adic limit of the …5 tower 5, 25, 625, 90625, … (residues ≡ 1 mod 2ᵏ, ≡ 0 mod 5ᵏ) and e6 the limit of the …6 tower 6, 76, 376, 9376, … (≡ 0 mod 2ᵏ, ≡ 1 mod 5ᵏ). e5_ne_zero/e5_ne_one confirm e5 is genuinely non-trivial.",
+    "mathContext": "$e_5=(1,0),\\;e_6=(0,1),\\quad e_5+e_6=1,\\;e_5e_6=0,\\;e_6=1-e_5$ — a complete orthogonal idempotent decomposition of $\\mathbb{Z}_{10}$.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal idempotents", "Peirce decomposition", "complementary idempotent", "automorphic number", "ring decomposition"],
+    "prerequisites": ["idempotent elements", "product rings"]
+  },
+  {
+    "id": "ann-autonum-oq010302-reductions-determine",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "Inverse-limit uniqueness: reductions determine the limit",
+    "content": "PadicInt.ext_of_toZModPow says a p-adic integer is completely determined by its tower of finite reductions toZModPow k : ℤ_[p] → ZMod (pᵏ) — the defining universal property of ℤ_[p] as the inverse limit lim_k ZMod (pᵏ). Applied factorwise (Prod.ext over the two components), it shows two 10-adic integers with identical reduction towers in each factor are equal. This is the FIRST honest sense of convergence: a coherent tower of k-digit automorphic residues has AT MOST ONE 10-adic limit. The towers do not merely have a limit — the limit is unique.",
+    "mathContext": "$(\\forall k,\\;\\rho_k x=\\rho_k y)\\Rightarrow x=y$: the inverse-limit separation property. $\\mathbb{Z}_2\\times\\mathbb{Z}_5$ is the genuine $\\varprojlim_k \\mathbb{Z}/10^k$.",
+    "significance": "key",
+    "relatedConcepts": ["inverse limit", "universal property", "profinite integers", "toZModPow", "separation"],
+    "prerequisites": ["inverse limits", "p-adic integers"]
+  },
+  {
+    "id": "ann-autonum-oq010302-crt-bridge",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 131
+    },
+    "type": "technique",
+    "title": "The CRT bridge ρₖ : ℤ₁₀ →+* ZMod (10ᵏ)",
+    "content": "To connect the abstract 10-adic limit back to concrete k-digit residues, the proof builds the reduction ρₖ in two steps. digit k = (toZModPow k).prodMap (toZModPow k) reduces a 10-adic integer to its CRT components in ZMod (2ᵏ) × ZMod (5ᵏ). crt k is the CRT isomorphism ZMod (10ᵏ) ≅ ZMod (2ᵏ) × ZMod (5ᵏ), assembled from ZMod.ringEquivCongr (transporting along 10ᵏ = 2ᵏ·5ᵏ, ten_pow_eq) and ZMod.chineseRemainder (using coprime_two_five_pow). Composing the inverse of crt k with digit k gives red10 k = ρₖ, a genuine ring homomorphism. digit_e5 computes that e5 reduces to (1,0) in every CRT factor.",
+    "mathContext": "$\\rho_k=\\mathrm{crt}_k^{-1}\\circ(\\mathrm{toZModPow}_k\\times\\mathrm{toZModPow}_k):\\;\\mathbb{Z}_2\\times\\mathbb{Z}_5\\to \\mathbb{Z}/10^k$, with $\\gcd(2^k,5^k)=1$ so CRT applies.",
+    "significance": "supporting",
+    "relatedConcepts": ["Chinese Remainder Theorem", "ring homomorphism", "coprimality", "ZMod", "reduction map"],
+    "prerequisites": ["Chinese Remainder Theorem", "ring homomorphisms", "ZMod"]
+  },
+  {
+    "id": "ann-autonum-oq010302-red10-ne",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 133,
+      "endLine": 157
+    },
+    "type": "insight",
+    "title": "ρₖ e5 is a genuine non-trivial automorphic residue",
+    "content": "Two facts pin down the image of e5 at each finite level. red10_e5_idem: ρₖ e5 is idempotent in ZMod (10ᵏ) — i.e. a genuine automorphic residue — because ring homs preserve idempotents (map_mul + e5_idem). red10_e5_ne: for k ≥ 1, ρₖ e5 is neither 0 nor 1, using Nontrivial-ness of ZMod (2ᵏ) and ZMod (5ᵏ) to separate its CRT image (1,0) from (0,0) and (1,1). Together they certify ρₖ e5 is one of the two NON-trivial k-digit residues of the …5 tower, confirming e5 really is the limit of 5, 25, 625, 90625, … and not a trivial idempotent.",
+    "mathContext": "$\\rho_k(e_5)^2=\\rho_k(e_5)$ and $\\rho_k(e_5)\\notin\\{0,1\\}$ for $k\\ge1$: the abstract limit reduces to a concrete non-trivial automorphic number at every level.",
+    "significance": "supporting",
+    "relatedConcepts": ["idempotent", "automorphic number", "Nontrivial", "ring homomorphism", "reduction map"],
+    "prerequisites": ["ring homomorphisms", "ZMod", "idempotent elements"]
+  },
+  {
+    "id": "ann-autonum-oq010302-inv-pow",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 161,
+      "endLine": 183
+    },
+    "type": "technique",
+    "title": "The norm bound p^(−k) → 0 driving metric convergence",
+    "content": "The metric half of convergence rests on two private lemmas. tendsto_inv_pow: for b > 1, the sequence b^(−k) → 0 (reindexed from the geometric tendsto_pow_atTop_nhds_zero_of_lt_one on b⁻¹). tendsto_padic_of_dvd: an integer sequence f with pᵏ ∣ (f k − a) converges to a in ℤ_[p]. The proof uses tendsto_iff_norm_sub_tendsto_zero, then squeeze_zero against p^(−k): the key inequality ‖(f k − a : ℤ_[p])‖ ≤ p^(−k) is exactly PadicInt.norm_int_le_pow_iff_dvd applied to the divisibility hypothesis. The p-adic norm turns the arithmetic congruence pᵏ ∣ (f k − a) directly into geometric decay.",
+    "mathContext": "$p^k\\mid(f_k-a)\\iff\\lVert f_k-a\\rVert_p\\le p^{-k}\\to0$, hence $f_k\\to a$ in $\\mathbb{Z}_p$. Divisibility IS smallness in the p-adic metric.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic norm", "ultrametric", "squeeze theorem", "geometric sequence", "convergence"],
+    "prerequisites": ["p-adic norm", "limits in normed groups", "squeeze theorem"]
+  },
+  {
+    "id": "ann-autonum-oq010302-tendsto",
+    "proofId": "automorphic-number-oq-01-oq-03-oq-02",
+    "range": {
+      "startLine": 185,
+      "endLine": 213
+    },
+    "type": "insight",
+    "title": "Genuine metric convergence of the …5 and …6 towers",
+    "content": "tendsto_e5 and tendsto_e6 are the headline results: the integer truncations actually CONVERGE in the 10-adic metric. For the 5-tower, any integer sequence f with f k ≡ 1 mod 2ᵏ and f k ≡ 0 mod 5ᵏ (e.g. 5, 25, 625, 90625, …) tends to e5 = (1,0). The proof runs tendsto_padic_of_dvd in each factor — the divisibility 2ᵏ ∣ (f k − 1) gives convergence to 1 in ℤ₂, and 5ᵏ ∣ f k gives convergence to 0 in ℤ₅ — then assembles them with Filter.Tendsto.prodMk_nhds into convergence in the product to (1,0). tendsto_e6 is the symmetric statement for the 6-tower → e6 = (0,1). This is the SECOND honest sense of convergence — a literal limit in the metric, not just inverse-limit uniqueness.",
+    "mathContext": "$\\big((f_k\\bmod2^k),(f_k\\bmod5^k)\\big)\\to(1,0)=e_5$ in $\\mathbb{Z}_2\\times\\mathbb{Z}_5$ whenever $f_k\\equiv1\\ (2^k)$, $f_k\\equiv0\\ (5^k)$ — the automorphic congruences are exactly the convergence hypotheses.",
+    "significance": "key",
+    "relatedConcepts": ["metric convergence", "p-adic limit", "product topology", "automorphic number", "Tendsto"],
+    "prerequisites": ["convergence in metric spaces", "product topology", "p-adic integers"]
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/index.ts
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AutomorphicNumberOQ01OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const automorphicNumberOQ01OQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const automorphicNumberOQ01OQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const automorphicNumberOQ01OQ03OQ02Data: ProofData = {
+  proof: automorphicNumberOQ01OQ03OQ02Proof,
+  annotations: automorphicNumberOQ01OQ03OQ02Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `automorphic-number-oq-01-oq-03-oq-02`

This entry (convergence of the automorphic idempotent towers in ℤ₁₀ = ℤ₂ × ℤ₅) had a rich meta.json but was **missing `index.ts` and `annotations.json`** — without `index.ts` the page renders "proof not found" on the live site.

### Changes
- **`index.ts`** — Vite entry point so the proof loads (mirrors sibling `automorphic-number-oq-01-oq-03` naming).
- **`annotations.json`** — 9 annotations covering all five proof parts, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Modelling ℤ₁₀ as ℤ₂ × ℤ₅
  2. Idempotents of a p-adic domain are only 0,1
  3. The four idempotents of ℤ₂ × ℤ₅
  4. The non-trivial orthogonal complementary pair e5, e6
  5. Inverse-limit uniqueness (reductions determine the limit)
  6. The CRT bridge ρₖ : ℤ₁₀ →+* ZMod(10ᵏ)
  7. ρₖ e5 is a genuine non-trivial automorphic residue
  8. The norm bound p^(−k) → 0
  9. Genuine metric convergence of the …5 and …6 towers

### Validation
- JSON parses; `pnpm annotations:validate` (strict) reports **0 errors for this entry** (line ranges map to real Lean constructs).
- Data-pipeline stages (`annotations:build`, `research:build`, `research:enrich`) pass. The `tsc -b`/`vite` step fails only on a pre-existing native-module env issue (better-sqlite3 vs node v26), unrelated to this content.
- Axiom integrity unchanged: meta already declares `verified` / 0 axioms / 0 sorries, consistent with the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)