### PR TITLE
research(gcd-algorithm-oq-01-oq-04): binary GCD vs Euclidean unbounded step-count gap [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GCDAlgorithmOQ01OQ04.lean
+++ b/proofs/Proofs/GCDAlgorithmOQ01OQ04.lean
@@ -1,0 +1,178 @@
+/-
+GCD Algorithm OQ-01-OQ-04: Binary GCD vs Euclidean — an unbounded step-count gap
+
+The parent file `BinaryGcdOQ01` proves matching *upper* bounds for the step
+counts of the Euclidean algorithm (`euclidSteps`) and Stein's binary GCD
+algorithm (`binaryGcdSteps`): both are O(log) in the inputs.  Upper bounds
+alone do not settle which algorithm is faster, and the parent's concrete
+examples already show that neither dominates the other pointwise
+(e.g. `euclidSteps 12 8 = 2 < 5 = binaryGcdSteps 12 8`, but
+`euclidSteps 89 55 = 9 > 8 = binaryGcdSteps 89 55`).
+
+This file pins down a *sharp separation* on the diagonal `a = a`:
+
+  * The Euclidean algorithm finishes in a single step:  `euclidSteps a a = 1`.
+  * Binary GCD takes `ν₂(a) + 1` steps, where `ν₂(a) = a.factorization 2`
+    is the 2-adic valuation (number of trailing zero bits):
+    `binaryGcdSteps a a = a.factorization 2 + 1`.
+
+Consequently the step-count gap `binaryGcdSteps a a - euclidSteps a a = ν₂(a)`
+is **unbounded**: taking `a = 2 ^ n` makes binary GCD spend `n` extra steps
+removing factors of two that the Euclidean algorithm never sees.  This is a
+formal worst-case witness that, in the division-step model, binary GCD is not
+within any additive (or multiplicative) constant of the Euclidean algorithm.
+
+References:
+  - Stein (1967); Knuth, TAOCP Vol. 2, §4.5.2 (Algorithm B)
+  - Lamé (1844) for the Euclidean worst case
+-/
+
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Tactic
+import Proofs.BinaryGcdOQ01
+
+open Nat
+
+namespace GCDAlgorithmOQ01OQ04
+
+open BinaryGcdOQ01
+
+/-! ## Euclidean algorithm on equal inputs
+
+On `a = a` the Euclidean algorithm performs one division `a % a = 0` and stops. -/
+
+/-- **Euclidean diagonal.** For positive `a`, `euclidSteps a a = 1`. -/
+theorem euclidSteps_self {a : ℕ} (ha : 0 < a) : euclidSteps a a = 1 := by
+  obtain ⟨a', rfl⟩ : ∃ k, a = k + 1 := ⟨a - 1, by omega⟩
+  rw [euclidSteps.eq_3]
+  -- The guard `b' + 1 ≤ a'`, i.e. `a' + 1 ≤ a'`, is false, so we take the
+  -- `else` branch: `1 + euclidSteps (a'+1) ((a'+1) % (a'+1))`.
+  rw [if_neg (by omega), Nat.mod_self]
+  simp [euclidSteps]
+
+/-! ## Binary GCD on equal inputs
+
+One step of binary GCD on `a = a`:
+* if `a` is even, both arguments are halved and the count drops by one;
+* if `a` is odd, the subtraction `a - a = 0` terminates after one step. -/
+
+/-- Even/even unfolding of one binary-GCD step. -/
+private theorem binaryGcdSteps_even_even {a b : ℕ} (ha : 0 < a) (hb : 0 < b)
+    (hae : a % 2 = 0) (hbe : b % 2 = 0) :
+    binaryGcdSteps a b = 1 + binaryGcdSteps (a / 2) (b / 2) := by
+  obtain ⟨a', rfl⟩ : ∃ k, a = k + 1 := ⟨a - 1, by omega⟩
+  obtain ⟨b', rfl⟩ : ∃ k, b = k + 1 := ⟨b - 1, by omega⟩
+  rw [binaryGcdSteps.eq_3, if_pos hae, if_pos hbe]
+
+/-- Binary GCD on an odd diagonal finishes in one step: `binaryGcdSteps a a = 1`. -/
+private theorem binaryGcdSteps_self_odd {a : ℕ} (hao : a % 2 = 1) :
+    binaryGcdSteps a a = 1 := by
+  obtain ⟨a', rfl⟩ : ∃ k, a = k + 1 := ⟨a - 1, by omega⟩
+  rw [binaryGcdSteps.eq_3, if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- `else` branch: `1 + binaryGcdSteps (a'+1) ((a'+1 - (a'+1)) / 2)`.
+  rw [show (a' + 1 - (a' + 1)) / 2 = 0 from by omega, binaryGcdSteps_zero_right]
+
+/-- **Binary GCD diagonal, valuation form (powers of two times an odd number).**
+For odd `m`, `binaryGcdSteps (2^v * m) (2^v * m) = v + 1`: each of the `v`
+factors of two costs one halving step, then the odd core finishes in one. -/
+private theorem binaryGcdSteps_two_pow_mul_self (v m : ℕ) (hm : m % 2 = 1) :
+    binaryGcdSteps (2 ^ v * m) (2 ^ v * m) = v + 1 := by
+  induction v with
+  | zero =>
+      simpa using binaryGcdSteps_self_odd hm
+  | succ v ih =>
+      have hmpos : 0 < m := by omega
+      have hpos : 0 < 2 ^ (v + 1) * m := by positivity
+      have heven : (2 ^ (v + 1) * m) % 2 = 0 := by
+        have h2 : 2 ∣ 2 ^ (v + 1) * m :=
+          (dvd_pow_self 2 (Nat.succ_ne_zero v)).mul_right m
+        omega
+      have hhalf : (2 ^ (v + 1) * m) / 2 = 2 ^ v * m := by
+        rw [pow_succ, Nat.mul_comm (2 ^ v) 2, Nat.mul_assoc,
+          Nat.mul_div_cancel_left _ (by norm_num)]
+      rw [binaryGcdSteps_even_even hpos hpos heven heven, hhalf, ih]
+      omega
+
+/-- **Binary GCD diagonal.** For positive `a`, the number of binary-GCD steps on
+`a = a` equals the 2-adic valuation of `a` plus one. -/
+theorem binaryGcdSteps_self (a : ℕ) (ha : 0 < a) :
+    binaryGcdSteps a a = a.factorization 2 + 1 := by
+  -- Write `a = 2 ^ ν₂(a) * m` with `m = a / 2 ^ ν₂(a)` (the odd core) odd.
+  have hne : a ≠ 0 := by omega
+  set v := a.factorization 2 with hv
+  set m := a / 2 ^ v with hm
+  have hsplit : a = 2 ^ v * m := by
+    rw [hm, hv]
+    exact (Nat.ordProj_mul_ordCompl_eq_self a 2).symm
+  have hmodd : m % 2 = 1 := by
+    have hnd : ¬ (2 ∣ m) := by
+      rw [hm, hv]; exact Nat.not_dvd_ordCompl (by norm_num) hne
+    omega
+  calc binaryGcdSteps a a
+      = binaryGcdSteps (2 ^ v * m) (2 ^ v * m) := by rw [← hsplit]
+    _ = v + 1 := binaryGcdSteps_two_pow_mul_self v m hmodd
+
+/-! ## The separation -/
+
+/-- **Pointwise gap on the diagonal.** Binary GCD spends exactly `ν₂(a)` more
+division steps than the Euclidean algorithm on the input `(a, a)`. -/
+theorem diagonal_gap (a : ℕ) (ha : 0 < a) :
+    binaryGcdSteps a a = euclidSteps a a + a.factorization 2 := by
+  rw [binaryGcdSteps_self a ha, euclidSteps_self ha]; ring
+
+/-- On powers of two the Euclidean algorithm still uses a single step. -/
+theorem euclidSteps_two_pow (n : ℕ) : euclidSteps (2 ^ n) (2 ^ n) = 1 :=
+  euclidSteps_self (by positivity)
+
+/-- Binary GCD on `(2^n, 2^n)` uses exactly `n + 1` steps. -/
+theorem binaryGcdSteps_two_pow (n : ℕ) : binaryGcdSteps (2 ^ n) (2 ^ n) = n + 1 := by
+  have := binaryGcdSteps_two_pow_mul_self n 1 (by norm_num)
+  simpa using this
+
+/-- **Unbounded separation.** For every `N` there is a positive input on which
+binary GCD takes at least `N` more steps than the Euclidean algorithm.  Hence no
+additive (let alone multiplicative) constant bounds `binaryGcdSteps` in terms of
+`euclidSteps`: the witness `a = 2 ^ N` forces an `N`-step overhead. -/
+theorem gap_unbounded (N : ℕ) :
+    ∃ a : ℕ, 0 < a ∧ binaryGcdSteps a a ≥ euclidSteps a a + N := by
+  refine ⟨2 ^ N, by positivity, ?_⟩
+  rw [euclidSteps_two_pow, binaryGcdSteps_two_pow]
+  omega
+
+/-- **Ratio form.** On `(2^n, 2^n)` binary GCD uses `n + 1` times as many steps
+as the Euclidean algorithm, so the ratio is unbounded. -/
+theorem diagonal_ratio (n : ℕ) :
+    binaryGcdSteps (2 ^ n) (2 ^ n) = (n + 1) * euclidSteps (2 ^ n) (2 ^ n) := by
+  rw [euclidSteps_two_pow, binaryGcdSteps_two_pow]; ring
+
+/-! ## Sanity checks
+
+These specialise the general theorems above (all kernel-checked, no
+`native_decide`, hence no `Lean.ofReduceBool` dependency):
+* `binaryGcdSteps 8 8 = 4`  since `ν₂(8) = 3`  (`binaryGcdSteps_two_pow 3`);
+* `euclidSteps 8 8 = 1`      (`euclidSteps_self`);
+* `binaryGcdSteps 12 12 = 3` since `12 = 2² · 3`, `ν₂(12) = 2`. -/
+
+example : binaryGcdSteps 8 8 = 4 := by
+  have := binaryGcdSteps_two_pow 3; norm_num at this ⊢; exact this
+
+example : euclidSteps 8 8 = 1 := euclidSteps_self (by norm_num)
+
+example : binaryGcdSteps 12 12 = 3 := by
+  have := binaryGcdSteps_two_pow_mul_self 2 3 (by norm_num); norm_num at this; exact this
+
+/-! ## Summary
+
+**Proved (0 axioms, 0 sorries):**
+1. `euclidSteps_self` : Euclidean steps on `(a, a)` equal `1`.
+2. `binaryGcdSteps_self` : binary GCD steps on `(a, a)` equal `ν₂(a) + 1`.
+3. `diagonal_gap` : the pointwise gap is exactly `ν₂(a)`.
+4. `gap_unbounded` : the gap is unbounded (witness `a = 2^N`).
+5. `diagonal_ratio` : the step ratio on `(2^n, 2^n)` is `n + 1`.
+
+Together with the parent's O(log) upper bounds, this shows the two algorithms'
+division-step counts are genuinely incomparable: binary GCD can be a Θ(log a)
+factor slower on highly-even inputs.
+-/
+
+end GCDAlgorithmOQ01OQ04

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-04/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-04/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "gcd-algorithm-oq-01-oq-04",
+  "title": "Binary GCD vs Euclidean: An Unbounded Step-Count Gap on the Diagonal",
+  "slug": "gcd-algorithm-oq-01-oq-04",
+  "description": "A sharp complexity separation between Stein's Binary GCD and the Euclidean algorithm in the division-step model. On equal inputs (a, a) the Euclidean algorithm always finishes in one step, euclidSteps a a = 1, while Binary GCD takes binaryGcdSteps a a = ν₂(a) + 1 steps, where ν₂(a) = a.factorization 2 is the 2-adic valuation. Hence the pointwise gap is exactly ν₂(a), and it is unbounded (witness a = 2^N), so no additive or multiplicative constant bounds Binary GCD in terms of the Euclidean algorithm. This complements the parent's matching O(log) upper bounds.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Binary_GCD_algorithm",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "complexity",
+      "binary-gcd",
+      "euclidean-algorithm",
+      "2-adic-valuation",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/GCDAlgorithmOQ01OQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 178,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.ordProj_mul_ordCompl_eq_self",
+        "description": "n = ordProj[p] n * ordCompl[p] n, i.e. p^(n.factorization p) * (n / p^(n.factorization p)) = n",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.not_dvd_ordCompl",
+        "description": "For prime p and n ≠ 0, p does not divide ordCompl[p] n (the odd core is coprime to p)",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left",
+        "description": "Cancellation a * b / a = b for a ≠ 0, used to compute (2^(v+1) * m) / 2 = 2^v * m",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "dvd_pow_self",
+        "description": "a ∣ a^n for n ≠ 0, used to show 2 ∣ 2^(v+1) * m",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "euclidSteps_self: the Euclidean algorithm finishes equal inputs in one step — euclidSteps a a = 1 for a > 0 (single division a % a = 0).",
+      "binaryGcdSteps_even_even: even/even one-step unfolding binaryGcdSteps a b = 1 + binaryGcdSteps (a/2) (b/2).",
+      "binaryGcdSteps_self_odd: an odd diagonal finishes in one step (the subtraction a - a = 0 terminates).",
+      "binaryGcdSteps_two_pow_mul_self: for odd m, binaryGcdSteps (2^v · m) (2^v · m) = v + 1 (each factor of two costs one halving step).",
+      "binaryGcdSteps_self: the headline — binaryGcdSteps a a = ν₂(a) + 1 = a.factorization 2 + 1, via the ordProj/ordCompl decomposition into a power of two times an odd core.",
+      "diagonal_gap: the pointwise gap binaryGcdSteps a a = euclidSteps a a + ν₂(a).",
+      "gap_unbounded: ∀ N, ∃ a > 0 with binaryGcdSteps a a ≥ euclidSteps a a + N (witness a = 2^N), so no constant bounds one in terms of the other.",
+      "diagonal_ratio: binaryGcdSteps (2^n) (2^n) = (n + 1) · euclidSteps (2^n) (2^n) — the step ratio is unbounded."
+    ],
+    "assumptions": "None. All theorems are kernel-checked and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (confirmed by #print axioms). No native_decide is used in any theorem (the sanity-check examples are specialisations of the general theorems, not native_decide). 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Josef Stein introduced the Binary GCD algorithm in 1967 (*Journal of Computational Physics* 1:397–405) as a hardware-friendly alternative to Euclid's algorithm: it replaces division by shifts and subtractions. Both algorithms run in $O(\\log\\max(a,b))$ steps — see Knuth, *TAOCP* Vol. 2, §4.5.2 for the upper bounds, and Lamé (1844) for the Euclidean worst case (consecutive Fibonacci numbers).\n\nUpper bounds alone do not settle which algorithm is faster, and indeed neither dominates the other pointwise: in the parent file BinaryGcdOQ01 one has $\\text{euclidSteps}(12,8)=2<5=\\text{binaryGcdSteps}(12,8)$ but $\\text{euclidSteps}(89,55)=9>8=\\text{binaryGcdSteps}(89,55)$. This entry isolates a clean, infinite family where the *Euclidean* algorithm is dramatically faster: the diagonal $a = a$. Euclid performs a single division $a \\bmod a = 0$ and halts, whereas Binary GCD must strip every factor of two from $a$ one shift at a time before the odd core terminates. The overhead is therefore exactly the 2-adic valuation $\\nu_2(a)$ — the number of trailing zero bits — which is unbounded.",
+    "problemStatement": "**Open question OQ-04 of the GCD-algorithm complexity thread**: go beyond the matching $O(\\log)$ *upper* bounds for the Euclidean and Binary GCD step counts and pin down a *separation* showing the two cost models are genuinely incomparable. Concretely, exhibit an explicit family on which one algorithm beats the other by an unbounded margin, with the exact gap computed in closed form.",
+    "text": "On equal inputs the Euclidean algorithm takes one step but Binary GCD takes ν₂(a)+1 steps, so the worst-case step-count gap between the two algorithms is unbounded.",
+    "proofStrategy": "**Euclidean diagonal** (`euclidSteps_self`): unfold `euclidSteps.eq_3` on $(a'+1, a'+1)$; the guard $a'+1 \\le a'$ is false, so one step is taken with remainder $(a'+1) \\bmod (a'+1) = 0$, and `euclidSteps _ 0 = 0`.\n\n**Binary GCD diagonal** (`binaryGcdSteps_self`): write $a = 2^{\\nu_2(a)} \\cdot m$ with $m = \\text{ordCompl}[2]\\,a$ odd (via `Nat.ordProj_mul_ordCompl_eq_self` and `Nat.not_dvd_ordCompl`). Then induct on the valuation: the base case is `binaryGcdSteps_self_odd` (one subtraction step on an odd diagonal), and the step case uses `binaryGcdSteps_even_even` to peel one factor of two, with $(2^{v+1}m)/2 = 2^v m$. This yields $\\text{binaryGcdSteps}(2^v m,\\,2^v m) = v + 1$, hence $\\text{binaryGcdSteps}(a,a) = \\nu_2(a) + 1$.\n\n**Separation**: subtracting gives `diagonal_gap` ($\\text{gap} = \\nu_2(a)$); specialising to $a = 2^N$ gives `gap_unbounded` and the ratio statement `diagonal_ratio`.",
+    "keyInsights": [
+      "On the diagonal a = a the Euclidean algorithm sees a single remainder a mod a = 0 and stops — the step count is 1 regardless of a.",
+      "Binary GCD, by contrast, cannot subtract until both arguments are odd, so it must halve a exactly ν₂(a) times before the odd core (a / 2^ν₂(a)) finishes in one subtraction step.",
+      "Writing a = 2^ν₂(a) · (odd) via the ordProj/ordCompl decomposition turns the valuation into an explicit induction variable, making binaryGcdSteps a a = ν₂(a) + 1 a clean two-case induction.",
+      "Because ν₂(2^N) = N is unbounded, no additive (let alone multiplicative) constant relates the two step counts — a separation the matching O(log) upper bounds cannot detect.",
+      "The separation is specific to the division-step cost model: in a bit-operation model the halvings are cheap, which is exactly why Binary GCD remains competitive in practice."
+    ],
+    "prerequisites": [
+      "BinaryGcdOQ01.lean (euclidSteps and binaryGcdSteps definitions, binaryGcdSteps.eq_3, euclidSteps.eq_3, binaryGcdSteps_zero_right)",
+      "2-adic valuation ν₂(n) = n.factorization 2 and the ordProj/ordCompl decomposition of a natural number into a prime power times a coprime core"
+    ]
+  },
+  "sections": [
+    {
+      "id": "euclid-diagonal",
+      "title": "Euclidean algorithm on equal inputs",
+      "startLine": 36,
+      "endLine": 50,
+      "summary": "euclidSteps a a = 1 for positive a: a single division a mod a = 0 terminates the algorithm.",
+      "mathContext": "One unfolding of euclidSteps.eq_3 takes the else-branch; Nat.mod_self collapses the recursive call to euclidSteps _ 0 = 0."
+    },
+    {
+      "id": "binary-step-lemmas",
+      "title": "One-step unfoldings of Binary GCD",
+      "startLine": 52,
+      "endLine": 76,
+      "summary": "Even/even halving (binaryGcdSteps_even_even) and the odd-diagonal terminator (binaryGcdSteps_self_odd).",
+      "mathContext": "Resolves the four-branch recursion binaryGcdSteps.eq_3 via if_pos / if_neg according to the parities of the arguments."
+    },
+    {
+      "id": "valuation-form",
+      "title": "Binary GCD diagonal equals the 2-adic valuation plus one",
+      "startLine": 78,
+      "endLine": 117,
+      "summary": "binaryGcdSteps_two_pow_mul_self proves binaryGcdSteps (2^v m) (2^v m) = v + 1 for odd m; binaryGcdSteps_self lifts it to all a via the ordProj/ordCompl split.",
+      "mathContext": "Induction on the valuation v: peel a factor of two each step until the odd core finishes in one subtraction."
+    },
+    {
+      "id": "separation",
+      "title": "The separation",
+      "startLine": 119,
+      "endLine": 150,
+      "summary": "diagonal_gap (gap = ν₂(a)), gap_unbounded (witness 2^N), and diagonal_ratio (ratio n+1 on powers of two).",
+      "mathContext": "Combines euclidSteps_self = 1 with binaryGcdSteps_self = ν₂(a)+1; the unboundedness follows from ν₂(2^N) = N."
+    },
+    {
+      "id": "sanity",
+      "title": "Sanity checks",
+      "startLine": 152,
+      "endLine": 178,
+      "summary": "Worked instances (8,8)→4, (8,8)→1, (12,12)→3 derived from the general theorems without native_decide.",
+      "mathContext": "12 = 2²·3 so ν₂(12) = 2 and binaryGcdSteps 12 12 = 3, matching the closed form."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binary-gcd-oq-01",
+      "relationship": "extends",
+      "description": "BinaryGcdOQ01 proves matching O(log) upper bounds for euclidSteps and binaryGcdSteps and notes that neither dominates pointwise. This entry turns that observation into a sharp, infinite separation on the diagonal a = a."
+    },
+    {
+      "targetId": "binary-gcd-oq-01-oq-04",
+      "relationship": "related",
+      "description": "BinaryGcdOQ01OQ04 establishes the Binary GCD worst case (1, 2^n - 1) takes exactly n steps (tightness of its own upper bound). This entry instead compares Binary GCD against the Euclidean algorithm, witnessing an unbounded gap in favour of Euclid."
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "depends-on",
+      "description": "Provides Stein's Binary GCD recursion (binaryGcdSteps, binaryGcdSteps.eq_3) and the Euclidean step counter (euclidSteps) that this file analyzes."
+    }
+  ],
+  "conclusion": {
+    "summary": "On equal inputs the Euclidean algorithm always takes one step while Binary GCD takes ν₂(a) + 1, so binaryGcdSteps a a = euclidSteps a a + ν₂(a). The gap is unbounded (a = 2^N forces an N-step overhead). Proved with a single valuation induction; 0 sorries, 0 axioms.",
+    "implications": "Together with the parent's matching O(log) upper bounds, this shows the division-step counts of Binary GCD and the Euclidean algorithm are genuinely incomparable: Binary GCD can be a Θ(log a) factor slower on highly-even inputs. The separation is a feature of the step-count model — in a bit-operation model the halving steps are cheap — which clarifies why Binary GCD remains competitive in practice despite this worst case."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Tactic",
+      "Proofs.BinaryGcdOQ01"
+    ],
+    "opens": [
+      "Nat",
+      "BinaryGcdOQ01"
+    ],
+    "namespace": "GCDAlgorithmOQ01OQ04",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GCDAlgorithmOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Stein, J.",
+      "title": "Computational problems associated with Racah algebra",
+      "year": "1967",
+      "note": "Journal of Computational Physics 1(3), 397-405. Original Binary GCD algorithm."
+    },
+    {
+      "authors": "Knuth, D.E.",
+      "title": "The Art of Computer Programming, Vol. 2: Seminumerical Algorithms",
+      "year": "1998",
+      "note": "Section 4.5.2 (Algorithm B). O(log) step bounds for Euclid and Binary GCD."
+    },
+    {
+      "authors": "Lamé, G.",
+      "title": "Note sur la limite du nombre des divisions dans la recherche du plus grand commun diviseur entre deux nombres entiers",
+      "year": "1844",
+      "note": "Comptes Rendus 19. Worst case of the Euclidean algorithm (consecutive Fibonacci numbers)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "binaryGcdSteps_self",
+      "type": "core",
+      "description": "Binary GCD on equal inputs takes ν₂(a) + 1 steps",
+      "leanType": "(a : ℕ) → 0 < a → binaryGcdSteps a a = a.factorization 2 + 1"
+    },
+    {
+      "name": "euclidSteps_self",
+      "type": "core",
+      "description": "The Euclidean algorithm finishes equal inputs in one step",
+      "leanType": "0 < a → euclidSteps a a = 1"
+    },
+    {
+      "name": "diagonal_gap",
+      "type": "core",
+      "description": "The pointwise step-count gap on (a, a) is exactly the 2-adic valuation ν₂(a)",
+      "leanType": "(a : ℕ) → 0 < a → binaryGcdSteps a a = euclidSteps a a + a.factorization 2"
+    },
+    {
+      "name": "gap_unbounded",
+      "type": "corollary",
+      "description": "The gap is unbounded: for every N some input forces an N-step overhead (witness 2^N)",
+      "leanType": "(N : ℕ) → ∃ a, 0 < a ∧ binaryGcdSteps a a ≥ euclidSteps a a + N"
+    },
+    {
+      "name": "diagonal_ratio",
+      "type": "corollary",
+      "description": "On (2^n, 2^n) Binary GCD uses n + 1 times as many steps as the Euclidean algorithm",
+      "leanType": "(n : ℕ) → binaryGcdSteps (2^n) (2^n) = (n + 1) * euclidSteps (2^n) (2^n)"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

A sharp **complexity separation** between Stein's Binary GCD and the Euclidean algorithm in the division-step model defined by the parent `BinaryGcdOQ01`. The parent proves matching `O(log)` *upper* bounds for both step counters but notes neither dominates pointwise. This entry pins down an explicit **infinite family with an unbounded gap**.

On the diagonal `a = a`:

- **Euclidean** finishes in one step: `euclidSteps a a = 1` (one division `a % a = 0`).
- **Binary GCD** takes `binaryGcdSteps a a = ν₂(a) + 1`, where `ν₂(a) = a.factorization 2` is the 2-adic valuation (number of trailing zero bits) — it must strip every factor of two before the odd core terminates.

Hence:
- `diagonal_gap`: `binaryGcdSteps a a = euclidSteps a a + ν₂(a)`.
- `gap_unbounded`: `∀ N, ∃ a > 0, binaryGcdSteps a a ≥ euclidSteps a a + N` (witness `a = 2^N`) — no additive *or* multiplicative constant relates the two step counts.
- `diagonal_ratio`: on `(2^n, 2^n)` Binary GCD uses `n + 1` times as many steps as Euclid.

## Proof engine

Write `a = 2^ν₂(a) · m` with `m` odd via `Nat.ordProj_mul_ordCompl_eq_self` and `Nat.not_dvd_ordCompl`, then induct on the valuation: `binaryGcdSteps_even_even` peels one factor of two per halving step down to the odd-diagonal terminator `binaryGcdSteps_self_odd`.

## Verification

- **10 theorems / 0 defs / 178 lines**, 0 sorries.
- `#print axioms` on all five headline theorems: foundational axioms only (`propext`, `Classical.choice`, `Quot.sound`). **No `native_decide` in any theorem** (sanity-check examples are specialisations of the general results).
- Status: **verified**, 0 axioms. Builds clean against Mathlib (Lean 4.26.0).

## Interpretation

The separation is specific to the division-step model: in a bit-operation model the halvings are cheap, which is exactly why Binary GCD remains competitive in practice. Together with the parent's upper bounds, this shows the two cost models are genuinely incomparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)