### PR TITLE
Enrich derangements-convergence-oq-05: add index.ts + annotations

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-05/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-05/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-derangements-oq05-header",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 6, "endLine": 36 },
+    "type": "context",
+    "title": "Open Question: the full fixed-point distribution",
+    "content": "The module docstring records the open question inherited from the parent entry: what is the limit of D_k(n)/n!, the proportion of permutations of an n-set with exactly k fixed points? The parent handled only k = 0 (derangements, D(n)/n! → e⁻¹). This file proves the answer for every k is the Poisson(1) mass e⁻¹/k!, with the exact count D_k(n) = C(n,k)·D(n−k). It imports the three Mathlib derangement modules (Basic for the subtype bijection, Finite for the cardinality, Exponential for the 1/e limit) plus Tactic.",
+    "mathContext": "$\\dfrac{D_k(n)}{n!} \\to \\dfrac{e^{-1}}{k!}$ as $n \\to \\infty$, the Poisson$(1)$ probability mass at $k$, with $D_k(n) = \\binom{n}{k}\\,D(n-k)$.",
+    "significance": "context",
+    "relatedConcepts": ["Poisson distribution", "derangements", "rencontres problem", "Poisson approximation"],
+    "prerequisites": ["random permutations", "asymptotic enumeration"]
+  },
+  {
+    "id": "ann-derangements-oq05-count-def",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 45, "endLine": 49 },
+    "type": "definition",
+    "title": "Defining D_k(n): permutations with exactly k fixed points",
+    "content": "fixedPointCount n k counts the permutations σ of Fin n whose set of fixed points {i : σ i = i} has cardinality exactly k. It is defined as the cardinality of a filter over the full symmetric group — a purely combinatorial object on which the later bijection and asymptotic results are built. The inner filter univ.filter (σ i = i) materialises the fixed-point set so its size can be measured.",
+    "mathContext": "$D_k(n) = \\#\\{\\sigma \\in \\mathrm{Sym}(n) : |\\mathrm{Fix}(\\sigma)| = k\\}$, where $\\mathrm{Fix}(\\sigma) = \\{i : \\sigma(i) = i\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric group", "fixed points", "Finset.filter cardinality"],
+    "prerequisites": ["permutations", "finite cardinality"]
+  },
+  {
+    "id": "ann-derangements-oq05-fibre",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 51, "endLine": 74 },
+    "type": "technique",
+    "title": "Core bijection: prescribed fixed set ↔ derangements of the complement",
+    "content": "The pivotal lemma card_perm_fixedSet_eq fixes a target set S and counts permutations whose fixed-point set is exactly S. The key move rephrases the condition 'Fix(σ) = S' as the predicate Mathlib's derangements.subtypeEquiv expects: ¬(a ∈ Sᶜ) ↔ a ∈ fixedPoints σ. This turns a 'fixed exactly on S' constraint into a 'no fixed points on Sᶜ' one, exhibiting the bijection {σ : Fix(σ) = S} ≃ derangements(↥Sᶜ). The cardinality then follows from card_derangements_eq_numDerangements together with |Sᶜ| = n − |S|. This bijection is not present in Mathlib and is the reusable infrastructure the entry contributes.",
+    "mathContext": "$\\#\\{\\sigma : \\mathrm{Fix}(\\sigma) = S\\} = \\#\\,\\mathrm{derangements}(S^c) = D(n - |S|)$, since a permutation fixing exactly $S$ deranges the complement.",
+    "significance": "key",
+    "relatedConcepts": ["derangements.subtypeEquiv", "subtypeEquivRight", "bijective counting", "complement"],
+    "prerequisites": ["Equiv (type bijections)", "derangements", "subtype cardinality"]
+  },
+  {
+    "id": "ann-derangements-oq05-fiberwise",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 76, "endLine": 90 },
+    "type": "technique",
+    "title": "Partitioning Sym(n) by fixed-point set",
+    "content": "The main count fixedPointCount_eq applies Finset.card_eq_sum_card_fiberwise with the fibre map σ ↦ Fix(σ) landing in powersetCard k univ (the k-element subsets). Every permutation with exactly k fixed points has a fixed-point set that is one such k-subset, so the count splits into a sum of fibre cardinalities, one per candidate set S. The MapsTo obligation — that each counted σ really lands in a k-subset — is discharged by filter_subset together with the |Fix(σ)| = k hypothesis.",
+    "mathContext": "$D_k(n) = \\sum_{\\substack{S \\subseteq [n] \\\\ |S| = k}} \\#\\{\\sigma : \\mathrm{Fix}(\\sigma) = S\\}$, grouping permutations by which $k$-set they fix.",
+    "significance": "supporting",
+    "relatedConcepts": ["fiberwise counting", "powersetCard", "Finset.MapsTo"],
+    "prerequisites": ["double counting", "Finset partitions"]
+  },
+  {
+    "id": "ann-derangements-oq05-count",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 91, "endLine": 108 },
+    "type": "insight",
+    "title": "Collapsing the fibres: D_k(n) = C(n,k)·D(n−k)",
+    "content": "Within each fibre the redundant constraint |Fix(σ)| = k is absorbed (filter_congr / and_iff_right_iff_imp): once Fix(σ) = S and |S| = k, the cardinality condition is automatic. Each fibre therefore has exactly numDerangements(n − k) elements by the core lemma, independent of which k-subset S is chosen. Summing C(n,k) identical terms — there are card_powersetCard = C(n,k) of them — yields the closed form. This decouples the 'which points are fixed' choice from the 'derange the rest' constraint.",
+    "mathContext": "$D_k(n) = \\sum_{|S|=k} D(n-k) = \\binom{n}{k}\\,D(n-k)$ — the binomial coefficient counts the choices of fixed set, $D(n-k)$ deranges the remainder.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficient", "numDerangements", "card_powersetCard", "decoupling"],
+    "prerequisites": ["binomial coefficients", "derangement numbers"]
+  },
+  {
+    "id": "ann-derangements-oq05-sum",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 110, "endLine": 127 },
+    "type": "insight",
+    "title": "Completeness check: the counts sum to n!",
+    "content": "sum_fixedPointCount confirms the count partitions the whole symmetric group: ∑_{k=0}^n D_k(n) = n!. The same fiberwise lemma is used, now grouping all of Sym(n) by the number of fixed points (a value in range(n+1)), and Fintype.card_perm supplies |Sym(n)| = n!. Beyond a sanity check this is the discrete shadow of the Poisson masses summing to 1: ∑_k e⁻¹/k! = 1.",
+    "mathContext": "$\\sum_{k=0}^{n} D_k(n) = |\\mathrm{Sym}(n)| = n!$, the discrete analogue of $\\sum_{k\\ge 0} \\dfrac{e^{-1}}{k!} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.card_perm", "partition of unity", "rencontres polynomial"],
+    "prerequisites": ["factorial", "symmetric group order"]
+  },
+  {
+    "id": "ann-derangements-oq05-prob-eq",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 129, "endLine": 148 },
+    "type": "technique",
+    "title": "Reducing the probability to a single derangement ratio",
+    "content": "fixedPointProb n k = D_k(n)/n!. Substituting the closed form and using Nat.choose_mul_factorial_mul_factorial (C(n,k)·k!·(n−k)! = n! for k ≤ n), the binomial coefficient cancels n!/(n−k)! and leaves D_k(n)/n! = (1/k!)·(D(n−k)/(n−k)!). All of the n-dependence is concentrated in the single derangement ratio D(n−k)/(n−k)!; the factor 1/k! is a constant. The cast-to-ℝ identity is cleared by field_simp followed by a one-line linear_combination.",
+    "mathContext": "$\\dfrac{D_k(n)}{n!} = \\dfrac{1}{k!}\\cdot\\dfrac{D(n-k)}{(n-k)!}$ for $k \\le n$ — the binomial coefficient cancels against $n!/(n-k)!$.",
+    "significance": "key",
+    "relatedConcepts": ["choose_mul_factorial_mul_factorial", "field_simp", "linear_combination", "probability mass function"],
+    "prerequisites": ["factorial identities", "real-number casts"]
+  },
+  {
+    "id": "ann-derangements-oq05-limit",
+    "proofId": "derangements-convergence-oq-05",
+    "range": { "startLine": 150, "endLine": 167 },
+    "type": "insight",
+    "title": "The Poisson(1) limit via the shift n ↦ n−k",
+    "content": "fixedPointProb_tendsto is the analytic headline. Since n ↦ n − k tends to infinity, composing Mathlib's numDerangements_tendsto_inv_e with this shift gives D(n−k)/(n−k)! → e⁻¹. Scaling by the constant 1/k! (const_mul) and transferring along the eventual equality (valid once n ≥ k, supplied by eventually_ge_atTop and congr') produces D_k(n)/n! → e⁻¹/k!. Setting k = 0 recovers the parent's derangement convergence D(n)/n! → e⁻¹, so this is a strict generalisation rather than a variant.",
+    "mathContext": "$\\dfrac{D_k(n)}{n!} \\to \\dfrac{e^{-1}}{k!}$: the inner ratio $\\to e^{-1}$ by Mathlib, the factor $1/k!$ is constant, giving the Poisson$(1)$ mass at $k$.",
+    "significance": "key",
+    "relatedConcepts": ["numDerangements_tendsto_inv_e", "Tendsto.comp", "Filter.Tendsto.congr'", "Poisson(1) limit"],
+    "prerequisites": ["filter limits", "limit composition", "eventual equality"]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-05/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const derangementsConvergenceOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const derangementsConvergenceOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const derangementsConvergenceOQ05Data: ProofData = {
+  proof: derangementsConvergenceOQ05Proof,
+  annotations: derangementsConvergenceOQ05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for **derangements-convergence-oq-05** (Fixed-Point Count Distribution: D_k(n)/n! → e⁻¹/k!).

The research pipeline shipped this entry with only `meta.json`, so the proof was **unloadable** on the live site ("proof not found") and had no inline annotations. This PR fills both gaps.

## Changes
- **`index.ts`** (new): the Vite entry point importing `meta.json`, `annotations.json`, and the raw Lean source so `import.meta.glob` can discover the proof.
- **`annotations.json`** (new): 8 substantive annotations covering the full file:
  - module header / open question
  - `fixedPointCount` definition (D_k(n))
  - core bijection `card_perm_fixedSet_eq` (prescribed fixed set ↔ derangements of the complement — Mathlib-absent infrastructure)
  - fiberwise partition of Sym(n) by fixed-point set
  - the C(n,k)·D(n−k) collapse
  - completeness identity ∑ D_k(n) = n!
  - probability reduction to a single derangement ratio
  - the Poisson(1) limit via the shift n ↦ n−k

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. All ranges align with real Lean constructs — **0 errors for this proofId** in `pnpm annotations:validate`.

The rich `meta.json` (overview, keyInsights, sections, conclusion, references) was already present and is left intact. Status/badge/axiomCount verified accurate (verified / original / 0 axioms — depends only on propext, Classical.choice, Quot.sound).