### PR TITLE
research(arsinh-log-formula-oq-01-oq-02-oq-01): arcosh antiderivative ∫1/√(t²−1)=arcosh t+C [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -231,6 +231,7 @@ import Proofs.ArithmeticSeriesOQ04OQ01
 import Proofs.ArithmeticSeriesOQ04OQ03
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.ArsinhLogFormulaOQ01OQ01
+import Proofs.ArsinhLogFormulaOQ01OQ02OQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02

--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean
@@ -1,0 +1,151 @@
+/-
+# Antiderivative of `1/√(t² − 1)`: the `arcosh` calculus capstone
+
+Research: arsinh-log-formula-oq-01-oq-02-oq-01
+Parent:   arsinh-log-formula-oq-01-oq-02 (logarithmic form + addition law of `arcosh`)
+
+The parent entry established the algebraic theory of `Real.arcosh` — its
+logarithmic closed form `arcosh t = log(t + √(t² − 1))`, the addition /
+subtraction / doubling laws, and concrete values `arcosh (5/4) = log 2`,
+`arcosh (5/3) = log 3`.  A sibling open question supplied the calculus side for
+`arsinh`: that `arsinh` is an antiderivative of `1/√(1 + t²)`.
+
+This file supplies the **`cosh`-side calculus counterpart**: that `arcosh` is an
+antiderivative of `1/√(t² − 1)` on the domain `t > 1`, where the radicand is
+positive.  Concretely it provides:
+
+* `hasDerivAt_arcosh` — the antiderivative fact
+  `HasDerivAt Real.arcosh (1/√(t² − 1)) t` for `t > 1`.  **Mathlib's `Arcosh`
+  file has no derivative lemma at all**, so this is built from scratch by
+  differentiating the logarithmic form via the chain rule.
+* `deriv_arcosh` — the same as a `deriv` equation.
+* `integral_one_div_sqrt_sq_sub_one` — the Fundamental Theorem of Calculus
+  evaluation `∫_a^b 1/√(t² − 1) dt = arcosh b − arcosh a` for `1 < a, b`.
+* `integral_eq_log_sub_log` — its logarithmic closed form.
+* `integral_five_quarters_to_five_thirds` — the concrete value
+  `∫_{5/4}^{5/3} 1/√(t² − 1) dt = log (3/2)`, reusing the parent's evaluations.
+
+All results are `0`-axiom and machine-checked.  Unlike the `arsinh` companion,
+which restates Mathlib's `Real.hasDerivAt_arsinh`, the derivative here is genuinely
+new: Mathlib provides `Real.arcosh` and its inverse facts but no derivative.
+-/
+import Mathlib
+
+namespace ArsinhLogFormulaOQ01OQ02OQ01
+
+open Real intervalIntegral MeasureTheory
+
+/-- For `t > 1` the radicand `t² − 1` is strictly positive, hence `√(t² − 1) > 0`. -/
+theorem sqrt_sq_sub_one_pos {x : ℝ} (hx : 1 < x) : 0 < Real.sqrt (x ^ 2 - 1) :=
+  Real.sqrt_pos.mpr (by nlinarith)
+
+/-- **Antiderivative fact (the open question).** `arcosh` is an antiderivative of
+`1/√(t² − 1)` on `(1, ∞)`: `HasDerivAt Real.arcosh (1/√(t² − 1)) t` for `t > 1`.
+
+Mathlib's `Mathlib.Analysis.SpecialFunctions.Arcosh` defines `Real.arcosh` and
+records its inverse facts (`cosh_arcosh`, `sinh_arcosh`, …) but supplies **no
+derivative lemma**.  We build it directly from the logarithmic form
+`arcosh t = log(t + √(t² − 1))` by the chain rule:
+
+* `d/dt √(t² − 1) = t/√(t² − 1)`,
+* so `d/dt (t + √(t² − 1)) = (√(t² − 1) + t)/√(t² − 1)`,
+* and `arcosh' t = [d/dt (t + √(t² − 1))] / (t + √(t² − 1)) = 1/√(t² − 1)`,
+
+the last step because the numerator equals `t + √(t² − 1)`, the denominator. -/
+theorem hasDerivAt_arcosh {x : ℝ} (hx : 1 < x) :
+    HasDerivAt Real.arcosh (1 / Real.sqrt (x ^ 2 - 1)) x := by
+  have hpos : (0 : ℝ) < x ^ 2 - 1 := by nlinarith
+  have hs : (0 : ℝ) < Real.sqrt (x ^ 2 - 1) := Real.sqrt_pos.mpr hpos
+  have hg : (0 : ℝ) < x + Real.sqrt (x ^ 2 - 1) := by linarith [hs]
+  -- derivative of the inner polynomial `t² − 1`
+  have h1 : HasDerivAt (fun y : ℝ => y ^ 2 - 1) (2 * x) x := by
+    simpa using (hasDerivAt_pow 2 x).sub_const 1
+  -- chain rule through `√·`
+  have h2 : HasDerivAt (fun y : ℝ => Real.sqrt (y ^ 2 - 1))
+      (2 * x / (2 * Real.sqrt (x ^ 2 - 1))) x := h1.sqrt hpos.ne'
+  -- add the identity term
+  have h3 : HasDerivAt (fun y : ℝ => y + Real.sqrt (y ^ 2 - 1))
+      (1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) x := (hasDerivAt_id x).add h2
+  -- chain rule through `log·`; the function is definitionally `arcosh`
+  have h4 : HasDerivAt (fun y : ℝ => Real.log (y + Real.sqrt (y ^ 2 - 1)))
+      ((1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) / (x + Real.sqrt (x ^ 2 - 1))) x :=
+    h3.log hg.ne'
+  -- the messy derivative collapses to `1/√(x² − 1)` (no `√·² = ·` needed)
+  have hval : (1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) / (x + Real.sqrt (x ^ 2 - 1))
+      = 1 / Real.sqrt (x ^ 2 - 1) := by
+    field_simp
+    ring
+  rw [hval] at h4
+  exact h4
+
+/-- The `deriv` form of the antiderivative fact: `(arcosh)' t = 1/√(t² − 1)` for `t > 1`. -/
+theorem deriv_arcosh {x : ℝ} (hx : 1 < x) :
+    deriv Real.arcosh x = 1 / Real.sqrt (x ^ 2 - 1) :=
+  (hasDerivAt_arcosh hx).deriv
+
+/-- On any interval `[a, b] ⊂ (1, ∞)` the integrand `t ↦ 1/√(t² − 1)` is
+continuous (the denominator stays strictly positive). -/
+theorem continuousOn_integrand {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    ContinuousOn (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1)) (Set.uIcc a b) := by
+  apply ContinuousOn.div continuousOn_const
+  · exact (Real.continuous_sqrt.comp (by continuity)).continuousOn
+  · intro t ht
+    have h1t : 1 < t := by
+      rcases Set.mem_uIcc.mp ht with ⟨h, _⟩ | ⟨h, _⟩ <;> linarith
+    exact (sqrt_sq_sub_one_pos h1t).ne'
+
+/-- Consequently the integrand is interval-integrable on `[a, b] ⊂ (1, ∞)`. -/
+theorem intervalIntegrable_integrand {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    IntervalIntegrable (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1)) volume a b :=
+  (continuousOn_integrand ha hb).intervalIntegrable
+
+/-- **Fundamental Theorem of Calculus for `arcosh`.**
+`∫_a^b 1/√(t² − 1) dt = arcosh b − arcosh a` for `1 < a, b`.
+
+This is the definite-integral incarnation of the antiderivative `arcosh`, and the
+precise meaning of "`∫ 1/√(t² − 1) dt = arcosh t + C`" on `(1, ∞)`. -/
+theorem integral_one_div_sqrt_sq_sub_one {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    ∫ t in a..b, 1 / Real.sqrt (t ^ 2 - 1) = Real.arcosh b - Real.arcosh a := by
+  apply intervalIntegral.integral_eq_sub_of_hasDerivAt
+  · intro x hx
+    have h1x : 1 < x := by
+      rcases Set.mem_uIcc.mp hx with ⟨h, _⟩ | ⟨h, _⟩ <;> linarith
+    exact hasDerivAt_arcosh h1x
+  · exact intervalIntegrable_integrand ha hb
+
+/-- **Logarithmic closed form of the integral.**
+`∫_a^b 1/√(t² − 1) dt = log(b + √(b² − 1)) − log(a + √(a² − 1))`, obtained by
+unfolding `arcosh` to its parent logarithmic form. -/
+theorem integral_eq_log_sub_log {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    ∫ t in a..b, 1 / Real.sqrt (t ^ 2 - 1) =
+      Real.log (b + Real.sqrt (b ^ 2 - 1)) -
+        Real.log (a + Real.sqrt (a ^ 2 - 1)) := by
+  rw [integral_one_div_sqrt_sq_sub_one ha hb]
+  rfl
+
+/-- Helper evaluation: `arcosh (5/3) = log 3`, since `√((5/3)² − 1) = 4/3`. -/
+theorem arcosh_five_thirds : Real.arcosh (5 / 3) = Real.log 3 := by
+  have h : Real.sqrt ((5 / 3 : ℝ) ^ 2 - 1) = 4 / 3 := by
+    rw [show ((5 / 3 : ℝ) ^ 2 - 1) = (4 / 3) ^ 2 by norm_num]
+    exact Real.sqrt_sq (by norm_num)
+  show Real.log ((5 / 3 : ℝ) + Real.sqrt ((5 / 3) ^ 2 - 1)) = Real.log 3
+  rw [h, show (5 / 3 + 4 / 3 : ℝ) = 3 by norm_num]
+
+/-- Helper evaluation: `arcosh (5/4) = log 2`, since `√((5/4)² − 1) = 3/4`. -/
+theorem arcosh_five_quarters : Real.arcosh (5 / 4) = Real.log 2 := by
+  have h : Real.sqrt ((5 / 4 : ℝ) ^ 2 - 1) = 3 / 4 := by
+    rw [show ((5 / 4 : ℝ) ^ 2 - 1) = (3 / 4) ^ 2 by norm_num]
+    exact Real.sqrt_sq (by norm_num)
+  show Real.log ((5 / 4 : ℝ) + Real.sqrt ((5 / 4) ^ 2 - 1)) = Real.log 2
+  rw [h, show (5 / 4 + 3 / 4 : ℝ) = 2 by norm_num]
+
+/-- **Concrete evaluation.** `∫_{5/4}^{5/3} 1/√(t² − 1) dt = log (3/2)`,
+combining the FTC statement with the parent's values `arcosh (5/3) = log 3` and
+`arcosh (5/4) = log 2`. -/
+theorem integral_five_quarters_to_five_thirds :
+    ∫ t in (5 / 4 : ℝ)..(5 / 3), 1 / Real.sqrt (t ^ 2 - 1) = Real.log (3 / 2) := by
+  rw [integral_one_div_sqrt_sq_sub_one (by norm_num) (by norm_num),
+    arcosh_five_thirds, arcosh_five_quarters,
+    Real.log_div (by norm_num) (by norm_num)]
+
+end ArsinhLogFormulaOQ01OQ02OQ01

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "arsinh-log-formula-oq-01-oq-02-oq-01",
+  "slug": "arsinh-log-formula-oq-01-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "ArsinhLogFormulaOQ01OQ02OQ01",
+    "lineCount": 151,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The arcosh Antiderivative: ∫ 1/√(t²−1) dt = arcosh t + C",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "special-functions",
+      "hyperbolic-functions",
+      "inverse-hyperbolic",
+      "arcosh",
+      "antiderivative",
+      "fundamental-theorem-of-calculus",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 151,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasDerivAt_arcosh: the antiderivative fact HasDerivAt Real.arcosh (1/√(t²−1)) t for t > 1. Mathlib's Analysis.SpecialFunctions.Arcosh file defines Real.arcosh and records its inverse facts (cosh_arcosh, sinh_arcosh, arcosh_cosh) and monotonicity, but contains NO derivative lemma whatsoever. The derivative is therefore built from scratch here by differentiating the logarithmic form log(t + √(t²−1)) via the chain rule (HasDerivAt.sqrt and HasDerivAt.log), distinguishing this entry from its arsinh sibling, which merely restates Mathlib's existing Real.hasDerivAt_arsinh.",
+      "deriv_arcosh: the deriv-form restatement deriv Real.arcosh t = 1/√(t²−1) for t > 1.",
+      "integral_one_div_sqrt_sq_sub_one: the Fundamental Theorem of Calculus evaluation ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b, the definite-integral incarnation of the antiderivative on (1, ∞).",
+      "integral_eq_log_sub_log: the logarithmic closed form ∫_a^b 1/√(t²−1) dt = log(b + √(b²−1)) − log(a + √(a²−1)), obtained by unfolding arcosh to its definitional logarithm.",
+      "continuousOn_integrand / intervalIntegrable_integrand: the integrand t ↦ 1/√(t²−1) is continuous (hence interval-integrable) on any [a,b] ⊂ (1,∞), where the denominator stays strictly positive away from the singularity at t = 1.",
+      "integral_five_quarters_to_five_thirds: the concrete value ∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2), combining the FTC statement with the (3,4,5)-triple evaluations arcosh(5/3) = log 3 and arcosh(5/4) = log 2."
+    ],
+    "prerequisites": [
+      "Mathlib's definition Real.arcosh x = log(x + √(x² − 1))",
+      "The chain-rule lemmas HasDerivAt.sqrt and HasDerivAt.log, together with hasDerivAt_pow and hasDerivAt_id",
+      "The Fundamental Theorem of Calculus intervalIntegral.integral_eq_sub_of_hasDerivAt and ContinuousOn.intervalIntegrable",
+      "Real.sqrt_pos, Real.sqrt_sq for handling the radicand on the domain t > 1"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "HasDerivAt.sqrt",
+        "description": "If f has derivative f' at x and f x ≠ 0, then √(f ·) has derivative f'/(2√(f x)) at x — the chain-rule step that differentiates √(t²−1) to t/√(t²−1).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "HasDerivAt.log",
+        "description": "If f has derivative f' at x and f x ≠ 0, then log(f ·) has derivative f'/(f x) at x — the outer chain-rule step that differentiates arcosh = log(t + √(t²−1)).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+        "description": "The Fundamental Theorem of Calculus: if F has derivative f' on [a,b] and f' is interval-integrable, then ∫_a^b f' = F b − F a — used with F = arcosh to evaluate the definite integral.",
+        "module": "Mathlib.MeasureTheory.Integral.FundThmCalculus"
+      },
+      {
+        "theorem": "ContinuousOn.intervalIntegrable",
+        "description": "A function continuous on [a,b] is interval-integrable there — supplies the integrability hypothesis of the FTC from continuity of 1/√(t²−1) away from t = 1.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      },
+      {
+        "theorem": "Real.arcosh",
+        "description": "Mathlib defines Real.arcosh x = log(x + √(x² − 1)) but records no derivative lemma; the derivative HasDerivAt fact proved here is the missing calculus content.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arcosh"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral ∫ dt/√(t²−1) = arcosh t + C is a standard entry in every calculus table of integrals, the cosh-side companion of ∫ dt/√(1+t²) = arsinh t + C. The parent entry established the algebraic theory of arcosh (logarithmic form and addition calculus), and a sibling open question supplied the arsinh antiderivative. This entry completes the symmetric pair on the calculus side. A notable difference from the arsinh case: Mathlib provides Real.hasDerivAt_arsinh, so the arsinh antiderivative was a one-line restatement, whereas Mathlib's arcosh development stops at the inverse facts and has no derivative lemma at all — so the derivative must be constructed from scratch.",
+    "problemStatement": "Prove that arcosh is an antiderivative of 1/√(t²−1) on the domain t > 1: establish HasDerivAt Real.arcosh (1/√(t²−1)) t (building the derivative from the logarithmic form, since Mathlib lacks it), restate it as a deriv equation, package it as the Fundamental Theorem of Calculus evaluation ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b, give its logarithmic closed form, and tie back to the parent with the concrete value ∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2).",
+    "proofStrategy": "Differentiate the definitional logarithmic form arcosh t = log(t + √(t²−1)) by the chain rule. First hasDerivAt_pow gives d/dt(t²−1) = 2t; then HasDerivAt.sqrt (valid since t²−1 > 0 for t > 1) gives d/dt √(t²−1) = 2t/(2√(t²−1)); adding the identity term gives d/dt(t + √(t²−1)) = 1 + 2t/(2√(t²−1)); finally HasDerivAt.log (valid since t + √(t²−1) > 0) gives arcosh' t = [1 + 2t/(2√(t²−1))]/(t + √(t²−1)). This messy quotient collapses to 1/√(t²−1) by a purely algebraic field_simp; ring — remarkably, the identity √(t²−1)·√(t²−1) = t²−1 is NOT needed, because the numerator t + √(t²−1) already equals the denominator after clearing fractions. The FTC evaluation then follows from integral_eq_sub_of_hasDerivAt, with interval-integrability supplied by continuity of the integrand on [a,b] ⊂ (1,∞).",
+    "keyInsights": [
+      "Mathlib formalises Real.arcosh and its inverse-pair lemmas but — unlike the arsinh case, where Real.hasDerivAt_arsinh exists — provides NO derivative lemma for arcosh. The headline result here fills that gap directly.",
+      "The whole derivative is three chain-rule applications (pow, sqrt, log) stacked on the logarithmic form; the only analytic content is the domain restriction t > 1 that keeps both the radicand t²−1 and the argument t + √(t²−1) strictly positive, so HasDerivAt.sqrt and HasDerivAt.log apply.",
+      "The derivative simplification (1 + 2t/(2√))/(t + √) = 1/√ is a pure algebraic identity in √ := √(t²−1): after clearing denominators it reduces to (√ + t)·√ = √·(t + √), true by ring without ever using √² = t²−1.",
+      "The integrand 1/√(t²−1) is singular at t = 1, so the FTC evaluation is restricted to intervals [a,b] ⊂ (1,∞); on such intervals the radicand is bounded below by min(a,b)²−1 > 0 and the integrand is continuous, hence interval-integrable.",
+      "The (3,4,5) Pythagorean triple rationalises the surd in the concrete value: √((5/3)²−1) = 4/3 and √((5/4)²−1) = 3/4 give arcosh(5/3) = log 3 and arcosh(5/4) = log 2, so the integral over [5/4,5/3] is log 3 − log 2 = log(3/2)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: the arcosh Calculus Capstone",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "States the open question (the arcosh antiderivative ∫ 1/√(t²−1) dt = arcosh t + C, the cosh-side counterpart of the sibling's arsinh antiderivative) and enumerates the supplied theorems, emphasising that Mathlib has no arcosh derivative so it is built from scratch.",
+      "mathContext": "$\\frac{d}{dt}\\operatorname{arcosh} t = \\frac{1}{\\sqrt{t^2-1}}$ for $t > 1$."
+    },
+    {
+      "id": "derivative",
+      "title": "The Derivative of arcosh (built from scratch)",
+      "startLine": 39,
+      "endLine": 86,
+      "summary": "sqrt_sq_sub_one_pos (the radicand is positive for t > 1), hasDerivAt_arcosh (the antiderivative fact, via the chain rule on the logarithmic form), and deriv_arcosh (its deriv-form restatement).",
+      "mathContext": "$\\operatorname{arcosh}'(t) = \\frac{1}{\\sqrt{t^2-1}}$, $t > 1$."
+    },
+    {
+      "id": "integrability",
+      "title": "Continuity and Interval-Integrability",
+      "startLine": 88,
+      "endLine": 105,
+      "summary": "continuousOn_integrand (1/√(t²−1) is continuous on any [a,b] ⊂ (1,∞)) and intervalIntegrable_integrand (hence interval-integrable there), supplying the integrability hypothesis of the FTC.",
+      "mathContext": "$t \\mapsto 1/\\sqrt{t^2-1}$ continuous on $[a,b] \\subset (1,\\infty)$."
+    },
+    {
+      "id": "ftc",
+      "title": "Fundamental Theorem of Calculus and Log Form",
+      "startLine": 107,
+      "endLine": 125,
+      "summary": "integral_one_div_sqrt_sq_sub_one (∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a,b) and integral_eq_log_sub_log (its logarithmic closed form).",
+      "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b - \\operatorname{arcosh} a$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Evaluation",
+      "startLine": 127,
+      "endLine": 151,
+      "summary": "arcosh_five_thirds (arcosh(5/3) = log 3) and arcosh_five_quarters (arcosh(5/4) = log 2), then integral_five_quarters_to_five_thirds (∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2)).",
+      "mathContext": "$\\int_{5/4}^{5/3} \\frac{dt}{\\sqrt{t^2-1}} = \\log(3/2)$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+      "question": "Does the symmetric antiderivative ∫ 1/(t·√(t²−1)) dt = arcsec t (equivalently arccos(1/t)) admit the same chain-rule treatment, completing the table of inverse-trig/hyperbolic surd integrals?",
+      "significance": "low"
+    },
+    {
+      "id": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-02",
+      "question": "Can the FTC evaluation be extended to an improper-integral statement ∫_1^b 1/√(t²−1) dt = arcosh b, taking the limit a → 1⁺ across the singularity at t = 1?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "The parent develops the algebraic theory of arcosh (logarithmic form, addition/subtraction/doubling laws, concrete values) and explicitly poses this antiderivative as its open question. This entry answers it, supplying the calculus side."
+    },
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "The sibling entry proves the arsinh antiderivative ∫ 1/√(1+t²) dt = arsinh t + C. This entry is its cosh-side counterpart; unlike the sibling (which restates Mathlib's Real.hasDerivAt_arsinh), the arcosh derivative here is built from scratch because Mathlib has no arcosh derivative lemma."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Arcosh",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.arcosh (defined as log(x + √(x² − 1))) and its inverse-pair lemmas; notably it records no derivative lemma, the gap this entry fills."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.FundThmCalculus",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of intervalIntegral.integral_eq_sub_of_hasDerivAt, the Fundamental Theorem of Calculus used to turn the derivative into the definite-integral evaluation."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Answers the parent's open question: the cosh-side counterpart of the sibling's arsinh antiderivative. arcosh is shown to be an antiderivative of 1/√(t²−1) on (1,∞). Because Mathlib supplies no derivative lemma for Real.arcosh (in contrast to Real.hasDerivAt_arsinh), the derivative HasDerivAt Real.arcosh (1/√(t²−1)) t is built from scratch by differentiating the logarithmic form log(t + √(t²−1)) through three chain-rule steps (pow, sqrt, log); the resulting quotient collapses to 1/√(t²−1) by a pure algebraic field_simp; ring. The Fundamental Theorem of Calculus then gives ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b (the singularity at t = 1 restricting the domain), with its logarithmic closed form and the concrete value ∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2). 151 lines, 10 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The entry completes the symmetric pair of inverse-hyperbolic antiderivatives anchored by the arsinh-log-formula family, and contributes a genuinely missing piece of Mathlib's special-functions calculus: a derivative for Real.arcosh. The construction is reusable for any further calculus on arcosh (Taylor expansions, improper integrals across the t = 1 singularity).",
+    "openQuestions": [
+      "Extend to the improper integral ∫_1^b 1/√(t²−1) dt = arcosh b by taking a → 1⁺ across the singularity.",
+      "Apply the same chain-rule template to ∫ 1/(t√(t²−1)) dt = arcsec t to round out the surd-integral table."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's open question (`arsinh-log-formula-oq-01-oq-02`): the **cosh-side counterpart** of the sibling's arsinh antiderivative. Proves that `arcosh` is an antiderivative of `1/√(t²−1)` on `(1,∞)`.

**Key point — genuinely new vs. the arsinh sibling:** Mathlib's `Analysis.SpecialFunctions.Arcosh` defines `Real.arcosh` and records its inverse facts (`cosh_arcosh`, `sinh_arcosh`, monotonicity) but contains **no derivative lemma at all**. So unlike the arsinh case — where the sibling simply restated Mathlib's existing `Real.hasDerivAt_arsinh` — the derivative here is **built from scratch** by differentiating the logarithmic form `log(t + √(t²−1))` through three chain-rule steps (`hasDerivAt_pow`, `HasDerivAt.sqrt`, `HasDerivAt.log`).

A neat detail: the resulting quotient `(1 + 2t/(2√))/(t+√)` collapses to `1/√(t²−1)` by a **pure algebraic `field_simp; ring`** — the identity `√(t²−1)·√(t²−1)=t²−1` is *not* needed, because the numerator already equals the denominator after clearing fractions.

## Results (10 theorems, 151 lines, 0 def, 0 axioms, 0 sorries)

- `hasDerivAt_arcosh` — `HasDerivAt Real.arcosh (1/√(t²−1)) t` for `t > 1` (headline, built from scratch)
- `deriv_arcosh` — the `deriv`-form restatement
- `continuousOn_integrand` / `intervalIntegrable_integrand` — integrand continuous/integrable on `[a,b] ⊂ (1,∞)`
- `integral_one_div_sqrt_sq_sub_one` — FTC: `∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a` for `1 < a,b`
- `integral_eq_log_sub_log` — its logarithmic closed form
- `arcosh_five_thirds` / `arcosh_five_quarters` — `arcosh(5/3)=log 3`, `arcosh(5/4)=log 2` via the (3,4,5) triple
- `integral_five_quarters_to_five_thirds` — concrete `∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2)`

The singularity at `t=1` restricts the FTC domain to intervals inside `(1,∞)`.

## Verification

Compiles clean on host (`lake env lean`, docker down). `#print axioms` on all main theorems → only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms, which do not count). **Verified, 0-axiom.**

## Gallery

- `proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean`
- `src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/meta.json` (badge `original` — fills a genuine Mathlib gap)
- single import line added to `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)