### PR TITLE
audit: batch-clean 4 recent merges verified clean (3469/3469)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21523,6 +21523,30 @@
       "lastAudited": "2026-06-24T13:44:14Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:54:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:54:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gcd-algorithm-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:54:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-09": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T13:54:24Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Re-verified 4 newly-merged gallery entries against their Lean sources. **All clean** — backlog cleared to **3469/3469 audited, 0 issues**.

| Entry | Badge | Result |
|-------|-------|--------|
| cauchy-schwarz-oq-05 | verified/original | clean — Lagrange identity proved from scratch via Finset sum reindexing (Mathlib Cauchy–Schwarz NOT used); 0 ax/sorry/True-stub |
| fibonacci-identities-oq-05 | verified/mathlib | clean — Cassini + parity over `Nat.fib`; 0 ax/sorry |
| gcd-algorithm-oq-01-oq-04 | verified/verified | clean — ordProj/ordCompl factorization; 0 ax/sorry |
| lagrange-theorem-oq-09 | verified/original | clean — 0 mathlib deps, 0 ax/sorry |

### Checks performed
- **Literal axioms**: 0 in all 4 (`grep -c '^axiom '`)
- **Sorries**: 0 real (no non-comment `sorry`); meta `sorries: 0` matches
- **True stubs**: 0 in all 4
- **native_decide**: grep hits in fibonacci (line 25) and gcd (line 151) are **docstring prose explicitly disclaiming native_decide** ("No axioms, no `native_decide`, no sorries" / "no `native_decide`, hence no `Lean.ofReduceBool` dependency") — false positives. No real `native_decide` in any theorem, so `Lean.ofReduceBool` correctly absent.
- **Badges**: all honest. cauchy-schwarz `original` justified (deps are generic sum-manipulation infrastructure, not the core result). fibonacci `mathlib` is conservative.

Tracker-only change (`audit-tracker.json`). No source edits.

---
Discovered during autonomous gallery integrity audit.