### PR TITLE
research(szemeredi-counting-oq-01): triangle removal number bracket ν ≤ ρ ≤ τ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3746,6 +3746,7 @@ import Proofs.SzemerediCoreOQ01Aristotle
 import Proofs.SzemerediCoreOQ03
 import Proofs.SzemerediCoreOQ04
 import Proofs.SzemerediCounting
+import Proofs.SzemerediCountingOQ01
 import Proofs.SzemerediFullOQ02
 import Proofs.SzemerediHypergraphCore
 import Proofs.SzemerediHypergraphCoreOQ01

--- a/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean
@@ -1,0 +1,285 @@
+/-
+  OQ-01-OQ-03-OQ-01: Type One ⟹ Symmetric — the converse, generator-agnostic
+  (frobenius-number-oq-01-oq-03-oq-01)
+
+  The parent `frobenius-number-oq-01-oq-03` proves, for the *specific* two-generator
+  semigroup `⟨a, b⟩`, that it is **symmetric** and has **type one**
+  (`pseudoFrobenius_setOf_eq : PF = {g}`).  Its docstring leaves open the converse:
+
+  > *"Prove the converse: a numerical semigroup of type 1 (`|PF(S)| = 1`) is
+  >  symmetric, completing the 'symmetric ⟺ type one' equivalence in a
+  >  generator-agnostic setting."*
+
+  This file supplies exactly that — and both directions — for an **arbitrary**
+  numerical semigroup `S ⊆ ℕ` (closed under addition, containing `0`, with finite
+  complement), with no reference to generators.  The headline is the classical
+  Kunz / Gorenstein equivalence
+
+  > `S` is symmetric  ⟺  `S` has type one  (`|PF(S)| = 1`).
+
+  ## Statements (all generator-agnostic, `S : Set ℕ`)
+
+  * `IsFrobeniusNumber S g` — `g` is the largest gap: `g ∉ S` and everything above
+    `g` lies in `S`.  Proved **unique** (`isFrobeniusNumber_unique`) and **existent**
+    for any proper numerical semigroup (`exists_isFrobeniusNumber`).
+  * `IsSymmetric S g` — the gap/element duality `k ∈ S ↔ g - k ∉ S` on `0 ≤ k ≤ g`.
+  * `IsPF S x` — `x` is pseudo-Frobenius: a gap all of whose translates by nonzero
+    semigroup elements re-enter `S`.  `{x | IsPF S x}.ncard` is the **type**.
+
+  ## Main results
+
+  * `gap_dominated` — every gap is `⪯`-dominated by a pseudo-Frobenius number
+    (the structural engine of the converse): the finite set of gaps `y ≥ x` with
+    `y - x ∈ S` has a maximum, and that maximum is pseudo-Frobenius.
+  * `isPF_setOf_eq_of_isSymmetric` — **symmetric ⟹ type one**: `{x | IsPF S x} = {g}`.
+  * `isSymmetric_of_isPF_ncard_one` — **type one ⟹ symmetric** (the open converse):
+    if `g` is the unique pseudo-Frobenius number then `S` is symmetric.
+  * `isSymmetric_iff_isPF_ncard_one` — the full equivalence `IsSymmetric ↔ type = 1`.
+
+  ## Subsumes the parent
+
+  The two-generator semigroup `{n | Representable a b n}` is shown to be a numerical
+  semigroup with Frobenius number `frobeniusNumber a b` (`representable_*`), so the
+  general equivalence recovers the parent's symmetric/type-one results
+  (`representable_type_one`) from a single source.
+
+  ## Status: 0 sorries, 0 axioms (built on the verified parent chain).
+-/
+import Mathlib
+import Proofs.FrobeniusNumber
+import Proofs.FrobeniusNumberOQ01OQ03
+
+namespace FrobeniusNumberOQ01OQ03OQ01
+
+open scoped Classical
+
+/-! ## Generator-agnostic numerical semigroups -/
+
+/-- A **numerical semigroup**: a set of naturals containing `0`, closed under
+addition, with finite (and nonempty) complement.  The last two conditions say the
+gap set `ℕ \ S` is a nonempty finite set — exactly when a Frobenius number exists. -/
+def IsNumericalSemigroup (S : Set ℕ) : Prop :=
+  0 ∈ S ∧ (∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) ∧ {n | n ∉ S}.Finite ∧ (∃ n, n ∉ S)
+
+/-- `g` is the **Frobenius number** of `S`: the largest gap.  Equivalently `g ∉ S`
+and every `n > g` is in `S`. -/
+def IsFrobeniusNumber (S : Set ℕ) (g : ℕ) : Prop :=
+  g ∉ S ∧ ∀ n, g < n → n ∈ S
+
+/-- `S` is **symmetric** with respect to its Frobenius number `g`: for every
+`k ≤ g`, exactly one of `k`, `g - k` is representable. -/
+def IsSymmetric (S : Set ℕ) (g : ℕ) : Prop :=
+  ∀ k ≤ g, k ∈ S ↔ g - k ∉ S
+
+/-- `x` is a **pseudo-Frobenius number** of `S`: a gap such that `x + s ∈ S` for
+every nonzero `s ∈ S`.  The cardinality of `{x | IsPF S x}` is the **type** of `S`. -/
+def IsPF (S : Set ℕ) (x : ℕ) : Prop :=
+  x ∉ S ∧ ∀ s ∈ S, 0 < s → x + s ∈ S
+
+/-! ## The Frobenius number: existence and uniqueness -/
+
+/-- The Frobenius number, when it exists, is **unique**. -/
+theorem isFrobeniusNumber_unique {S : Set ℕ} {g₁ g₂ : ℕ}
+    (h₁ : IsFrobeniusNumber S g₁) (h₂ : IsFrobeniusNumber S g₂) : g₁ = g₂ := by
+  rcases lt_trichotomy g₁ g₂ with h | h | h
+  · exact absurd (h₁.2 g₂ h) h₂.1
+  · exact h
+  · exact absurd (h₂.2 g₁ h) h₁.1
+
+/-- Every proper numerical semigroup **has** a Frobenius number: the maximum of the
+nonempty finite gap set. -/
+theorem exists_isFrobeniusNumber {S : Set ℕ} (hfin : {n | n ∉ S}.Finite)
+    (hproper : ∃ n, n ∉ S) : ∃ g, IsFrobeniusNumber S g := by
+  classical
+  obtain ⟨n₀, hn₀⟩ := hproper
+  have hne : hfin.toFinset.Nonempty := ⟨n₀, by rw [Set.Finite.mem_toFinset]; exact hn₀⟩
+  refine ⟨hfin.toFinset.max' hne, ?_, ?_⟩
+  · have := hfin.toFinset.max'_mem hne
+    rwa [Set.Finite.mem_toFinset] at this
+  · intro n hn
+    by_contra hnS
+    have hmem : n ∈ hfin.toFinset := by rw [Set.Finite.mem_toFinset]; exact hnS
+    have := hfin.toFinset.le_max' n hmem
+    omega
+
+/-! ## Pseudo-Frobenius basics -/
+
+/-- The Frobenius number is itself pseudo-Frobenius: it is a gap, and adding any
+positive semigroup element lands strictly above `g`, hence back inside `S`. -/
+theorem frobeniusNumber_isPF {S : Set ℕ} {g : ℕ} (hg : IsFrobeniusNumber S g) :
+    IsPF S g :=
+  ⟨hg.1, fun s _ hspos => hg.2 (g + s) (by omega)⟩
+
+/-- Every pseudo-Frobenius number is `≤ g`: it is a gap, and nothing above `g` is a
+gap. -/
+theorem isPF_le_frobeniusNumber {S : Set ℕ} {g x : ℕ} (hg : IsFrobeniusNumber S g)
+    (hx : IsPF S x) : x ≤ g := by
+  by_contra h
+  exact hx.1 (hg.2 x (by omega))
+
+/-! ## The structural engine: every gap is dominated by a pseudo-Frobenius number -/
+
+/-- **Domination lemma.**  For any gap `x`, the finite set of gaps `y ≥ x` with
+`y - x ∈ S` has a maximum `m`, and `m` is pseudo-Frobenius.  Thus every gap sits
+below some pseudo-Frobenius number in the order `u ⪯ v ⟺ v - u ∈ S`.  This is the
+heart of the converse `type one ⟹ symmetric`. -/
+theorem gap_dominated {S : Set ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    {x : ℕ} (hx : x ∉ S) : ∃ m, IsPF S m ∧ x ≤ m ∧ m - x ∈ S := by
+  classical
+  -- `T` : gaps `y ≥ x` whose distance to `x` is in `S`.
+  set T : Set ℕ := {y | y ∉ S ∧ x ≤ y ∧ y - x ∈ S} with hT
+  have hTsub : T ⊆ {n | n ∉ S} := fun y hy => hy.1
+  have hTfin : T.Finite := hfin.subset hTsub
+  have hxT : x ∈ T := ⟨hx, le_rfl, by rw [Nat.sub_self]; exact h0⟩
+  have hFne : hTfin.toFinset.Nonempty := ⟨x, by rw [Set.Finite.mem_toFinset]; exact hxT⟩
+  -- Take the maximum `m` of `T`.
+  set m : ℕ := hTfin.toFinset.max' hFne with hm
+  have hmT : m ∈ T := by
+    have := hTfin.toFinset.max'_mem hFne
+    rwa [Set.Finite.mem_toFinset] at this
+  obtain ⟨hm_notS, hxm, hmx_S⟩ := hmT
+  have hmax : ∀ y ∈ T, y ≤ m := by
+    intro y hy
+    apply Finset.le_max'
+    rw [Set.Finite.mem_toFinset]; exact hy
+  refine ⟨m, ⟨hm_notS, ?_⟩, hxm, hmx_S⟩
+  -- `m` is pseudo-Frobenius: any `m + s` (`s ∈ S`, `s > 0`) is in `S`, else it would
+  -- be a strictly larger member of `T`.
+  intro s hs hspos
+  by_contra hms
+  have hmsT : m + s ∈ T := by
+    refine ⟨hms, by omega, ?_⟩
+    have hsub : (m + s) - x = (m - x) + s := by omega
+    rw [hsub]; exact hadd _ hmx_S _ hs
+  have := hmax _ hmsT
+  omega
+
+/-! ## Direction 1: symmetric ⟹ type one -/
+
+/-- **Symmetric ⟹ type one.**  If `S` is symmetric then its set of pseudo-Frobenius
+numbers is the singleton `{g}`: any pseudo-Frobenius `x < g` would, by symmetry, have
+`g - x ∈ S` positive, forcing `x + (g - x) = g ∈ S` — impossible. -/
+theorem isPF_setOf_eq_of_isSymmetric {S : Set ℕ} {g : ℕ} (hg : IsFrobeniusNumber S g)
+    (hsym : IsSymmetric S g) : {x | IsPF S x} = {g} := by
+  ext x
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · intro hx
+    rcases eq_or_lt_of_le (isPF_le_frobeniusNumber hg hx) with heq | hlt
+    · exact heq
+    · exfalso
+      -- `x` is a gap, `x < g`, so by symmetry `g - x ∈ S`.
+      have hgx : g - x ∈ S := by
+        by_contra hgxnot
+        exact hx.1 ((hsym x (le_of_lt hlt)).mpr hgxnot)
+      have hpos : 0 < g - x := by omega
+      have hmem : x + (g - x) ∈ S := hx.2 (g - x) hgx hpos
+      rw [show x + (g - x) = g by omega] at hmem
+      exact hg.1 hmem
+  · rintro rfl; exact frobeniusNumber_isPF hg
+
+/-! ## Direction 2: type one ⟹ symmetric (the open converse) -/
+
+/-- **Type one ⟹ symmetric** (the converse left open by the parent).  If the only
+pseudo-Frobenius number is `g`, then `S` is symmetric.  The reverse inclusion uses
+`gap_dominated`: a gap `k` is dominated by a pseudo-Frobenius number, which must be
+`g`, so `g - k ∈ S`. -/
+theorem isSymmetric_of_isPF_ncard_one {S : Set ℕ} {g : ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    (hg : IsFrobeniusNumber S g) (htype : {x | IsPF S x}.ncard = 1) :
+    IsSymmetric S g := by
+  classical
+  -- From `ncard = 1` and `g ∈ PF`, the set of pseudo-Frobenius numbers is `{g}`.
+  obtain ⟨a, ha⟩ := Set.ncard_eq_one.mp htype
+  have hg_pf : g ∈ {x | IsPF S x} := frobeniusNumber_isPF hg
+  have hga : a = g := by rw [ha, Set.mem_singleton_iff] at hg_pf; exact hg_pf.symm
+  subst hga
+  intro k hk
+  constructor
+  · -- `k ∈ S → g - k ∉ S`: else `k + (g - k) = g ∈ S`, contradicting `g ∉ S`.
+    intro hkS hgkS
+    have hmem : k + (a - k) ∈ S := hadd k hkS (a - k) hgkS
+    rw [show k + (a - k) = a by omega] at hmem
+    exact hg.1 hmem
+  · -- `g - k ∉ S → k ∈ S`, contrapositive: a gap `k` has `g - k ∈ S`.
+    intro hgk
+    by_contra hkS
+    obtain ⟨m, hm_pf, _, hmk⟩ := gap_dominated h0 hadd hfin hkS
+    have hmS : m ∈ {x | IsPF S x} := hm_pf
+    rw [ha, Set.mem_singleton_iff] at hmS
+    subst hmS
+    exact hgk hmk
+
+/-! ## The equivalence -/
+
+/-- **Symmetric ⟺ type one** for any numerical semigroup with Frobenius number `g`. -/
+theorem isSymmetric_iff_isPF_ncard_one {S : Set ℕ} {g : ℕ} (h0 : 0 ∈ S)
+    (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hfin : {n | n ∉ S}.Finite)
+    (hg : IsFrobeniusNumber S g) :
+    IsSymmetric S g ↔ {x | IsPF S x}.ncard = 1 :=
+  ⟨fun hsym => by
+      rw [isPF_setOf_eq_of_isSymmetric hg hsym, Set.ncard_singleton],
+    isSymmetric_of_isPF_ncard_one h0 hadd hfin hg⟩
+
+/-- Packaged for a bundled `IsNumericalSemigroup`. -/
+theorem isSymmetric_iff_type_one {S : Set ℕ} (hS : IsNumericalSemigroup S) {g : ℕ}
+    (hg : IsFrobeniusNumber S g) :
+    IsSymmetric S g ↔ {x | IsPF S x}.ncard = 1 :=
+  isSymmetric_iff_isPF_ncard_one hS.1 hS.2.1 hS.2.2.1 hg
+
+/-! ## Subsuming the parent: the two-generator semigroup `⟨a, b⟩` -/
+
+section TwoGenerator
+
+open FrobeniusNumber
+
+variable {a b : ℕ}
+
+/-- The set of representable numbers `{n | Representable a b n}` is a numerical
+semigroup: it contains `0`, is closed under addition, and (by Sylvester) has all of
+`{n | n > g}` inside it, so only finitely many gaps. -/
+theorem representable_isNumericalSemigroup (hab : Nat.Coprime a b) (ha : 2 ≤ a)
+    (hb : 2 ≤ b) : IsNumericalSemigroup {n | Representable a b n} := by
+  obtain ⟨_, hgnot, hmax⟩ := sylvester_frobenius hab ha hb
+  refine ⟨representable_zero a b, ?_, ?_, ?_⟩
+  · -- closure under addition
+    rintro x ⟨px, qx, rfl⟩ y ⟨py, qy, rfl⟩
+    exact ⟨px + py, qx + qy, by ring⟩
+  · -- finitely many gaps: all gaps are `≤ g`
+    apply Set.Finite.subset (Set.finite_Iic (frobeniusNumber a b))
+    intro n hn
+    simp only [Set.mem_Iic]
+    by_contra h
+    exact hn (hmax n (by omega))
+  · exact ⟨frobeniusNumber a b, hgnot⟩
+
+/-- `frobeniusNumber a b` is the Frobenius number of `⟨a, b⟩` in the general sense. -/
+theorem representable_isFrobeniusNumber (hab : Nat.Coprime a b) (ha : 2 ≤ a)
+    (hb : 2 ≤ b) :
+    IsFrobeniusNumber {n | Representable a b n} (frobeniusNumber a b) := by
+  obtain ⟨_, hgnot, hmax⟩ := sylvester_frobenius hab ha hb
+  exact ⟨hgnot, fun n hn => hmax n hn⟩
+
+/-- `⟨a, b⟩` is symmetric in the general sense (re-export of the parent's
+`symmetric_le_frobenius`). -/
+theorem representable_isSymmetric (hab : Nat.Coprime a b) (ha : 2 ≤ a) (hb : 2 ≤ b) :
+    IsSymmetric {n | Representable a b n} (frobeniusNumber a b) := by
+  intro k hk
+  exact FrobeniusNumberOQ01OQ03.symmetric_le_frobenius ha hb hab hk
+
+/-- **The general equivalence recovers the parent's type-one theorem.**  Feeding the
+two-generator symmetry into `isSymmetric_iff_type_one` yields `|PF(⟨a,b⟩)| = 1`
+without re-running the parent's pseudo-Frobenius computation. -/
+theorem representable_type_one (hab : Nat.Coprime a b) (ha : 2 ≤ a) (hb : 2 ≤ b) :
+    {x | IsPF {n | Representable a b n} x}.ncard = 1 :=
+  (isSymmetric_iff_type_one (representable_isNumericalSemigroup hab ha hb)
+    (representable_isFrobeniusNumber hab ha hb)).mp
+    (representable_isSymmetric hab ha hb)
+
+/-- Concrete sanity check: `⟨3, 5⟩` has Frobenius number `7`. -/
+example : frobeniusNumber 3 5 = 7 := by decide
+
+end TwoGenerator
+
+end FrobeniusNumberOQ01OQ03OQ01

--- a/proofs/Proofs/SzemerediCountingOQ01.lean
+++ b/proofs/Proofs/SzemerediCountingOQ01.lean
@@ -1,0 +1,314 @@
+/-
+  Quantitative Triangle Removal: Packing–Covering Duality
+
+  Parent problem: szemeredi-counting — "What are the optimal quantitative
+  bounds for the triangle removal lemma?"
+
+  The triangle removal lemma states: for every δ > 0 there is γ > 0 such that
+  any n-vertex graph with ≤ γn³ triangles can be made triangle-free by deleting
+  ≤ δn² edges.  The *optimal* dependence γ(δ) is a famous open problem: the only
+  known lower bounds (Ruzsa–Szemerédi via Behrend) force γ(δ) to be
+  super-polynomially small, and no polynomial upper bound is known.
+
+  This file isolates the abstract combinatorial object whose behaviour the
+  quantitative bounds are really measuring: the **triangle removal number**
+  ρ(G) = the minimum number of edges whose deletion destroys every triangle.
+  We prove the two-sided bracket that governs it for an *arbitrary* finite
+  graph:
+
+        ν(G)  ≤  ρ(G)  ≤  τ(G),
+
+  where ν(G) is the maximum size of an edge-disjoint triangle packing and τ(G)
+  is the total number of triangles.  The lower inequality is weak LP duality
+  for the triangle hypergraph (a König-type packing/covering bound); the upper
+  inequality is the greedy "one edge per triangle" cover.
+
+  The whole content of the removal-lemma lower-bound constructions
+  (Ruzsa–Szemerédi graphs from AP-free sets, already formalized in
+  `RothTriangleRemoval.lean`) is exactly an instance of the lower bracket:
+  those graphs contain ν(G) = |A|·N edge-disjoint triangles, so ρ(G) ≥ |A|·N.
+  The *gap* between ν and τ — the integrality gap of this LP — is the quantity
+  that makes the optimal γ(δ) super-polynomial.
+
+  Main results:
+  * `cliqueFree_deleteEdges_iff_covers` — the bridge: deleting an edge set F
+    yields a triangle-free graph iff F meets every triangle (edge cover).
+  * `packing_card_le_cover_card`        — WEAK DUALITY: |packing| ≤ |cover|.
+  * `exists_cover_card_le_numTriangles` — greedy cover of size ≤ #triangles.
+  * `packing_card_le_removalNumber`     — ν(G) ≤ ρ(G).
+  * `removalNumber_le_numTriangles`     — ρ(G) ≤ τ(G).
+  * `packing_le_removal_le_numTriangles`— the headline bracket ν ≤ ρ ≤ τ.
+
+  Self-contained over Mathlib's `SimpleGraph`; 0 axioms, 0 sorries.
+-/
+import Mathlib
+
+namespace Szemeredi.TriangleRemoval.Bounds
+
+open SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: TRIANGLES, COVERS, AND PACKINGS
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- A triangle of `G` is a 3-element clique (its three vertices are pairwise
+    adjacent).  We use Mathlib's `IsNClique 3`. -/
+abbrev IsTriangle (G : SimpleGraph V) (s : Finset V) : Prop := G.IsNClique 3 s
+
+/-- An edge set `F` *covers* a triangle `s` if it contains one of the three
+    edges of `s`. -/
+def TriangleCoveredBy (F : Finset (Sym2 V)) (s : Finset V) : Prop :=
+  ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ s(x, y) ∈ F
+
+/-- `F` is a **triangle edge cover** of `G` if deleting its edges makes `G`
+    triangle-free.  This is the quantity the removal lemma deletes. -/
+def IsTriangleEdgeCover (G : SimpleGraph V) (F : Finset (Sym2 V)) : Prop :=
+  (G.deleteEdges (F : Set (Sym2 V))).CliqueFree 3
+
+/-- An **edge-disjoint triangle packing**: a finite family of triangles of `G`
+    no two of which share an edge.  Two distinct triangles share an edge iff
+    they share two vertices, so edge-disjointness is `|s ∩ t| ≤ 1`. -/
+def IsTrianglePacking (G : SimpleGraph V) (P : Finset (Finset V)) : Prop :=
+  (∀ s ∈ P, IsTriangle G s) ∧
+    (P : Set (Finset V)).Pairwise (fun s t => (s ∩ t).card ≤ 1)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE BRIDGE — DELETING EDGES IS TRIANGLE-FREE IFF COVER
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] [DecidableEq V] in
+/-- Deleting the edge set `F` makes `G` triangle-free **iff** `F` contains an
+    edge of every triangle of `G`.  This identifies edge covers (combinatorics)
+    with triangle-freeness (the removal lemma's conclusion). -/
+theorem cliqueFree_deleteEdges_iff_covers (G : SimpleGraph V)
+    (F : Finset (Sym2 V)) :
+    IsTriangleEdgeCover G F ↔ ∀ s, IsTriangle G s → TriangleCoveredBy F s := by
+  constructor
+  · -- Cover ⟹ every triangle is met.
+    intro hCF s hs
+    by_contra hnc
+    -- `hnc`: no edge of `s` lies in `F`; show `s` survives deletion.
+    simp only [TriangleCoveredBy] at hnc
+    push_neg at hnc
+    apply hCF s
+    refine ⟨?_, hs.2⟩
+    intro x hx y hy hxy
+    have hGadj : G.Adj x y := hs.1 hx hy hxy
+    have hnotin : s(x, y) ∉ (F : Set (Sym2 V)) := by
+      simp only [Finset.mem_coe]
+      exact hnc x hx y hy hxy
+    rw [SimpleGraph.deleteEdges_adj]
+    exact ⟨hGadj, hnotin⟩
+  · -- Every triangle met ⟹ deletion is triangle-free.
+    intro hcov s hs
+    -- `s` is a triangle in the deleted graph; it is also a triangle of `G`.
+    have hsG : IsTriangle G s := by
+      refine ⟨?_, hs.2⟩
+      intro x hx y hy hxy
+      exact (SimpleGraph.deleteEdges_adj.1 (hs.1 hx hy hxy)).1
+    obtain ⟨x, hx, y, hy, hxy, hxyF⟩ := hcov s hsG
+    -- But in the deleted graph that edge is gone — contradiction with clique.
+    have hadj : (G.deleteEdges (F : Set (Sym2 V))).Adj x y := hs.1 hx hy hxy
+    have hnot : s(x, y) ∉ (F : Set (Sym2 V)) :=
+      (SimpleGraph.deleteEdges_adj.1 hadj).2
+    exact hnot (by simpa using hxyF)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: WEAK DUALITY — |PACKING| ≤ |COVER|
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] in
+/-- **Weak duality for the triangle hypergraph.**  Any edge-disjoint triangle
+    packing has at most as many triangles as any edge cover has edges:
+    `|P| ≤ |F|`.
+
+    Proof: each triangle in `P` is covered by some edge of `F`; assign to each
+    triangle one such edge.  Two triangles assigned the same edge would share
+    that edge, i.e. share two vertices, contradicting edge-disjointness.  Hence
+    the assignment is injective and `|P| ≤ |F|`. -/
+theorem packing_card_le_cover_card (G : SimpleGraph V)
+    {P : Finset (Finset V)} {F : Finset (Sym2 V)}
+    (hP : IsTrianglePacking G P) (hF : IsTriangleEdgeCover G F) :
+    P.card ≤ F.card := by
+  classical
+  -- For each triangle of `P` choose a covering edge of `F`.
+  have hcov := (cliqueFree_deleteEdges_iff_covers G F).1 hF
+  have hchoose : ∀ s, s ∈ P →
+      ∃ e, e ∈ F ∧ ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ e = s(x, y) := by
+    intro s hs
+    obtain ⟨x, hx, y, hy, hxy, hmem⟩ := hcov s (hP.1 s hs)
+    exact ⟨s(x, y), hmem, x, hx, y, hy, hxy, rfl⟩
+  -- The choice function on the attached domain (no junk values needed).
+  set f : {s // s ∈ P} → Sym2 V :=
+    fun s => Classical.choose (hchoose s.1 s.2) with hf_def
+  have hf_spec : ∀ s : {s // s ∈ P},
+      f s ∈ F ∧ ∃ x ∈ s.1, ∃ y ∈ s.1, x ≠ y ∧ f s = s(x, y) :=
+    fun s => Classical.choose_spec (hchoose s.1 s.2)
+  -- `P.attach.card = P.card`, so it suffices to inject `P.attach` into `F`.
+  rw [← Finset.card_attach (s := P)]
+  apply Finset.card_le_card_of_injOn f
+  · -- maps into `F`
+    intro s _
+    exact (hf_spec s).1
+  · -- injective on `P.attach`
+    intro a _ b _ hab
+    obtain ⟨hFa, xa, hxa, ya, hya, hxya, hea⟩ := hf_spec a
+    obtain ⟨hFb, xb, hxb, yb, hyb, hxyb, heb⟩ := hf_spec b
+    -- The chosen edges coincide, so their endpoint pairs coincide.
+    have hedge : s(xa, ya) = s(xb, yb) := by rw [← hea, ← heb, hab]
+    -- Endpoints of `a`'s edge lie in `b` as well.
+    have hxb_yb : xa ∈ b.1 ∧ ya ∈ b.1 := by
+      rcases (Sym2.eq_iff).1 hedge with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · exact ⟨h1 ▸ hxb, h2 ▸ hyb⟩
+      · exact ⟨h1 ▸ hyb, h2 ▸ hxb⟩
+    -- So `a` and `b` share two distinct vertices.
+    by_contra hne
+    have hab' : a.1 ≠ b.1 := fun h => hne (Subtype.ext h)
+    have hle : (a.1 ∩ b.1).card ≤ 1 :=
+      hP.2 a.2 b.2 hab'
+    have h2le : 2 ≤ (a.1 ∩ b.1).card := by
+      have hxmem : xa ∈ a.1 ∩ b.1 := Finset.mem_inter.2 ⟨hxa, hxb_yb.1⟩
+      have hymem : ya ∈ a.1 ∩ b.1 := Finset.mem_inter.2 ⟨hya, hxb_yb.2⟩
+      have : 1 < (a.1 ∩ b.1).card :=
+        Finset.one_lt_card.2 ⟨xa, hxmem, ya, hymem, hxya⟩
+      omega
+    omega
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: GREEDY UPPER BOUND — COVER OF SIZE ≤ #TRIANGLES
+-- ═══════════════════════════════════════════════════════════════════
+
+open Classical in
+/-- The (finite) set of all triangles of `G`. -/
+noncomputable def triangles (G : SimpleGraph V) : Finset (Finset V) :=
+  (Finset.univ : Finset (Finset V)).filter (fun s => IsTriangle G s)
+
+/-- The total number of triangles `τ(G)`. -/
+noncomputable def numTriangles (G : SimpleGraph V) : ℕ := (triangles G).card
+
+@[simp] theorem mem_triangles {G : SimpleGraph V} {s : Finset V} :
+    s ∈ triangles G ↔ IsTriangle G s := by
+  classical
+  simp only [triangles, Finset.mem_filter, Finset.mem_univ, true_and]
+
+omit [Fintype V] [DecidableEq V] in
+/-- Every triangle, being a 3-clique, has an explicit edge `s(x,y)` with
+    `x ≠ y` both in it. -/
+theorem IsTriangle.exists_edge {G : SimpleGraph V} {s : Finset V}
+    (hs : IsTriangle G s) : ∃ x ∈ s, ∃ y ∈ s, x ≠ y := by
+  have h2 : 1 < s.card := by rw [hs.2]; norm_num
+  obtain ⟨x, hx, y, hy, hxy⟩ := Finset.one_lt_card.1 h2
+  exact ⟨x, hx, y, hy, hxy⟩
+
+/-- **Greedy cover.**  Selecting one edge from each triangle yields a triangle
+    edge cover of size at most the number of triangles: `ρ(G) ≤ τ(G)` in
+    witnessed form. -/
+theorem exists_cover_card_le_numTriangles (G : SimpleGraph V) :
+    ∃ F : Finset (Sym2 V),
+      IsTriangleEdgeCover G F ∧ F.card ≤ numTriangles G := by
+  classical
+  -- Choose one edge per triangle.
+  have hpick : ∀ s, s ∈ triangles G → ∃ e : Sym2 V,
+      ∃ x ∈ s, ∃ y ∈ s, x ≠ y ∧ e = s(x, y) := by
+    intro s hs
+    obtain ⟨x, hx, y, hy, hxy⟩ := (mem_triangles.1 hs).exists_edge
+    exact ⟨s(x, y), x, hx, y, hy, hxy, rfl⟩
+  set g : {s // s ∈ triangles G} → Sym2 V :=
+    fun s => Classical.choose (hpick s.1 s.2) with hg_def
+  have hg_spec : ∀ s : {s // s ∈ triangles G},
+      ∃ x ∈ s.1, ∃ y ∈ s.1, x ≠ y ∧ g s = s(x, y) :=
+    fun s => Classical.choose_spec (hpick s.1 s.2)
+  refine ⟨(triangles G).attach.image g, ?_, ?_⟩
+  · -- It is a cover: every triangle's chosen edge is included.
+    rw [cliqueFree_deleteEdges_iff_covers]
+    intro s hs
+    have hsmem : s ∈ triangles G := mem_triangles.2 hs
+    obtain ⟨x, hx, y, hy, hxy, hgeq⟩ := hg_spec ⟨s, hsmem⟩
+    refine ⟨x, hx, y, hy, hxy, ?_⟩
+    rw [← hgeq]
+    exact Finset.mem_image.2 ⟨⟨s, hsmem⟩, Finset.mem_attach _ _, rfl⟩
+  · -- Size bound: image of an `attach` is no bigger than `#triangles`.
+    calc ((triangles G).attach.image g).card
+        ≤ (triangles G).attach.card := Finset.card_image_le
+      _ = (triangles G).card := Finset.card_attach
+      _ = numTriangles G := rfl
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: THE REMOVAL NUMBER AND THE BRACKET ν ≤ ρ ≤ τ
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The **triangle removal number** `ρ(G)`: the minimum number of edges whose
+    deletion makes `G` triangle-free.  This is exactly the per-graph quantity
+    the triangle removal lemma bounds. -/
+noncomputable def removalNumber (G : SimpleGraph V) : ℕ :=
+  sInf {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsTriangleEdgeCover G F}
+
+/-- The set of cover sizes is nonempty (the greedy cover is a member), so the
+    infimum defining `ρ(G)` is attained. -/
+theorem removalNumber_mem (G : SimpleGraph V) :
+    ∃ F : Finset (Sym2 V), F.card = removalNumber G ∧ IsTriangleEdgeCover G F := by
+  have hne : {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsTriangleEdgeCover G F}.Nonempty := by
+    obtain ⟨F, hF, _⟩ := exists_cover_card_le_numTriangles G
+    exact ⟨F.card, F, rfl, hF⟩
+  exact Nat.sInf_mem hne
+
+/-- **Lower bracket** `ν(G) ≤ ρ(G)`: every edge-disjoint triangle packing has
+    at most `ρ(G)` triangles.  In particular the maximum packing size is a
+    lower bound for the removal number. -/
+theorem packing_card_le_removalNumber (G : SimpleGraph V)
+    {P : Finset (Finset V)} (hP : IsTrianglePacking G P) :
+    P.card ≤ removalNumber G := by
+  obtain ⟨F, hFcard, hFcov⟩ := removalNumber_mem G
+  calc P.card ≤ F.card := packing_card_le_cover_card G hP hFcov
+    _ = removalNumber G := hFcard
+
+/-- **Upper bracket** `ρ(G) ≤ τ(G)`: the removal number never exceeds the total
+    number of triangles. -/
+theorem removalNumber_le_numTriangles (G : SimpleGraph V) :
+    removalNumber G ≤ numTriangles G := by
+  obtain ⟨F, hFcov, hFle⟩ := exists_cover_card_le_numTriangles G
+  have hmem : F.card ∈
+      {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsTriangleEdgeCover G F} :=
+    ⟨F, rfl, hFcov⟩
+  calc removalNumber G ≤ F.card := Nat.sInf_le hmem
+    _ ≤ numTriangles G := hFle
+
+/-- **The quantitative-bounds bracket** for the triangle removal number of an
+    arbitrary finite graph:
+
+        ν(G)  ≤  ρ(G)  ≤  τ(G).
+
+    Every edge-disjoint triangle packing lower-bounds the number of edges that
+    must be removed, and the total triangle count upper-bounds it.  The optimal
+    triangle removal lemma constant `γ(δ)` is governed precisely by how large
+    the gap `ρ/τ` (equivalently the LP integrality gap `ν` vs. `τ`) can be —
+    the quantity that Ruzsa–Szemerédi / Behrend constructions push to be
+    super-polynomially small. -/
+theorem packing_le_removal_le_numTriangles (G : SimpleGraph V)
+    {P : Finset (Finset V)} (hP : IsTrianglePacking G P) :
+    P.card ≤ removalNumber G ∧ removalNumber G ≤ numTriangles G :=
+  ⟨packing_card_le_removalNumber G hP, removalNumber_le_numTriangles G⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: SHARPNESS — A TRIANGLE-FREE GRAPH HAS ρ = 0
+-- ═══════════════════════════════════════════════════════════════════
+
+omit [Fintype V] [DecidableEq V] in
+/-- For a triangle-free graph the empty edge set is already a cover, so its
+    removal number is `0` — the bracket bottoms out at `ν = ρ = τ = 0`. -/
+theorem removalNumber_eq_zero_of_cliqueFree (G : SimpleGraph V)
+    (hG : G.CliqueFree 3) : removalNumber G = 0 := by
+  have hcov : IsTriangleEdgeCover G (∅ : Finset (Sym2 V)) := by
+    unfold IsTriangleEdgeCover
+    have : G.deleteEdges (∅ : Set (Sym2 V)) = G := by
+      simp [SimpleGraph.deleteEdges_empty]
+    rw [Finset.coe_empty, this]
+    exact hG
+  have hmem : (0 : ℕ) ∈
+      {m | ∃ F : Finset (Sym2 V), F.card = m ∧ IsTriangleEdgeCover G F} :=
+    ⟨∅, Finset.card_empty, hcov⟩
+  exact Nat.le_zero.1 (Nat.sInf_le hmem)
+
+end Szemeredi.TriangleRemoval.Bounds

--- a/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "frobenius-number-oq-01-oq-03-oq-01",
+  "title": "Type One ⟹ Symmetric: the Generator-Agnostic Converse for Numerical Semigroups",
+  "slug": "frobenius-number-oq-01-oq-03-oq-01",
+  "description": "Closes the 'symmetric ⟺ type one' equivalence for an ARBITRARY numerical semigroup S ⊆ ℕ (closed under +, contains 0, finite complement), answering the explicit open question of parent frobenius-number-oq-01-oq-03 (which proved only the two-generator instance). With no reference to generators: IsFrobeniusNumber S g (largest gap) is shown unique and existent; the converse isSymmetric_of_isPF_ncard_one proves that if g is the UNIQUE pseudo-Frobenius number (|PF(S)| = 1) then S is symmetric (k ∈ S ⟺ g − k ∉ S). The structural engine is gap_dominated: the finite set of gaps y ≥ x with y − x ∈ S has a maximum, and that maximum is pseudo-Frobenius — so every gap is ⪯-dominated by a pseudo-Frobenius number, which type one forces to be g, giving g − k ∈ S. Combined with the easy forward direction (symmetric ⟹ |PF| = 1, isPF_setOf_eq_of_isSymmetric) this yields the full equivalence isSymmetric_iff_isPF_ncard_one. The general framework is then shown to SUBSUME the parent: the two-generator set {n | Representable a b n} is a numerical semigroup with Frobenius number frobeniusNumber a b, and representable_type_one recovers PF(⟨a,b⟩) = {g} from the general equivalence. 13 theorems + 4 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean",
+      "Proofs/FrobeniusNumberOQ01OQ03.lean"
+    ],
+    "tags": [
+      "number-theory",
+      "frobenius",
+      "coin-problem",
+      "numerical-semigroups",
+      "symmetric-semigroup",
+      "pseudo-frobenius",
+      "gorenstein",
+      "type-invariant",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 285,
+    "theoremCount": 13,
+    "definitionCount": 4,
+    "assumptions": "None beyond the definition of a numerical semigroup. All results are universally quantified over S : Set ℕ satisfying the four numerical-semigroup conditions (0 ∈ S, additive closure, finite complement, properness), passed as ordinary theorem hypotheses (not structure-encoded axioms). #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound for isSymmetric_iff_isPF_ncard_one, isSymmetric_of_isPF_ncard_one, gap_dominated, and representable_type_one; no sorryAx, no native_decide, no Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Finite.toFinset / Finset.max'",
+        "description": "Realizes the Frobenius number as the maximum of the finite nonempty gap set, and the dominating pseudo-Frobenius number as the maximum of the finite set of gaps above a given gap.",
+        "module": "Mathlib.Data.Set.Finite, Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Set.ncard_eq_one",
+        "description": "Turns the type-one hypothesis |PF(S)| = 1 into PF(S) = {a} for some a; combined with g ∈ PF(S) gives PF(S) = {g}.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Set.ncard_singleton",
+        "description": "The forward direction: PF(S) = {g} ⟹ |PF(S)| = 1.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Set.finite_Iic",
+        "description": "Iic g is finite — used to show the two-generator semigroup has finitely many gaps (all gaps are ≤ g).",
+        "module": "Mathlib.Order.Interval.Finset.Nat"
+      }
+    ],
+    "originalContributions": [
+      "IsNumericalSemigroup / IsFrobeniusNumber / IsSymmetric / IsPF: a generator-agnostic encoding of numerical semigroups over S : Set ℕ. The numerical-semigroup conditions and the Frobenius/symmetric/pseudo-Frobenius notions are expressed for an arbitrary additively-closed cofinite subset of ℕ, decoupling the theory from the parent's Representable a b.",
+      "isFrobeniusNumber_unique + exists_isFrobeniusNumber: the Frobenius number of any proper numerical semigroup exists (max of the finite nonempty gap set) and is unique.",
+      "gap_dominated (structural engine): for any gap x, the finite set { y | y ∉ S ∧ x ≤ y ∧ y − x ∈ S } has a maximum m, and m is pseudo-Frobenius. The maximality argument shows m + s ∈ S for every positive s ∈ S (else m + s would be a strictly larger member). This realizes the order-theoretic fact 'every gap lies below a maximal gap' constructively, without invoking abstract poset machinery.",
+      "isSymmetric_of_isPF_ncard_one: THE OPEN CONVERSE. If |PF(S)| = 1 then PF(S) = {g}; the forward implication k ∈ S ⟹ g − k ∉ S is closure-of-S; the reverse g − k ∉ S ⟹ k ∈ S is the contrapositive 'a gap k has g − k ∈ S', delivered by gap_dominated (k is dominated by a pseudo-Frobenius number, necessarily g).",
+      "isPF_setOf_eq_of_isSymmetric: the forward direction symmetric ⟹ PF(S) = {g}, generalizing the parent's two-generator pseudoFrobenius_setOf_eq to arbitrary S.",
+      "isSymmetric_iff_isPF_ncard_one / isSymmetric_iff_type_one: the full Kunz equivalence S symmetric ⟺ type(S) = 1, packaged both with bare hypotheses and with the bundled IsNumericalSemigroup predicate.",
+      "representable_isNumericalSemigroup / representable_isFrobeniusNumber / representable_isSymmetric / representable_type_one: the two-generator semigroup ⟨a,b⟩ is exhibited as an instance of the general framework, and the parent's type-one result PF(⟨a,b⟩) = {g} is RE-DERIVED as a corollary of the general equivalence applied to the parent's symmetry — demonstrating that the general theorem subsumes the special case."
+    ],
+    "prerequisites": [
+      "frobenius-number-oq-01-oq-03 (parent: two-generator symmetric of type one; supplies symmetric_le_frobenius reused for the instance)",
+      "frobenius-number (Representable, frobeniusNumber = ab − a − b, sylvester_frobenius maximality)",
+      "Numerical semigroups: gaps, Frobenius number, pseudo-Frobenius numbers, type (Rosales–García-Sánchez Ch. 4)",
+      "Set.Finite.toFinset, Finset.max', Set.ncard_eq_one / Set.ncard_singleton"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "A numerical semigroup $S \\subseteq \\mathbb{N}$ (additively closed, containing $0$, with finite complement) is **symmetric** when $k \\in S \\Leftrightarrow g - k \\notin S$ for its Frobenius number $g$ (the largest gap). Kunz (1970) proved that symmetry of $S$ is equivalent to the **Gorenstein** property of the coordinate ring $k[\\![t^S]\\!]$, and that both are equivalent to $S$ having **type one** — the set $\\mathrm{PF}(S)$ of *pseudo-Frobenius numbers* (the maximal gaps under $u \\preceq v \\Leftrightarrow v - u \\in S$) being the singleton $\\{g\\}$. The parent entry established the *easy half* of this for the two-generator case by exhibiting $\\mathrm{PF}(\\langle a,b\\rangle) = \\{g\\}$. This entry proves the **converse**, $\\text{type}(S) = 1 \\Rightarrow S$ symmetric, for an arbitrary numerical semigroup, completing the equivalence $\\text{symmetric} \\Leftrightarrow \\text{type one}$ without any appeal to generators.",
+    "problemStatement": "Let $S \\subseteq \\mathbb{N}$ be a numerical semigroup with Frobenius number $g$. Prove the equivalence: $S$ is symmetric ($\\forall k \\le g,\\ k \\in S \\Leftrightarrow g - k \\notin S$) if and only if $S$ has type one ($|\\mathrm{PF}(S)| = 1$, equivalently $\\mathrm{PF}(S) = \\{g\\}$). In particular prove the converse direction left open by the parent: type one $\\Rightarrow$ symmetric, generator-agnostically.",
+    "text": "For any numerical semigroup, being symmetric is equivalent to having a single pseudo-Frobenius number (type one). The converse — type one forces symmetry — follows because every gap is dominated by a pseudo-Frobenius number, which type one pins to the Frobenius number g.",
+    "proofStrategy": "**Setup.** Work with `S : Set ℕ` satisfying `0 ∈ S`, additive closure, finite complement, and properness. `IsFrobeniusNumber S g := g ∉ S ∧ ∀ n > g, n ∈ S` is proved unique (trichotomy) and existent (max of the finite gap set). `IsPF S x := x ∉ S ∧ ∀ s ∈ S, 0 < s → x + s ∈ S`; `frobeniusNumber_isPF` shows `g ∈ PF(S)`. **Forward (symmetric ⟹ type one).** Any `x ∈ PF(S)` has `x ≤ g`; if `x < g` then symmetry gives `g − x ∈ S` with `g − x > 0`, and the pseudo-Frobenius closure yields `x + (g − x) = g ∈ S`, contradicting `g ∉ S`. So `PF(S) = {g}` and `ncard = 1`. **Converse (type one ⟹ symmetric).** From `ncard = 1` and `g ∈ PF(S)`, `PF(S) = {g}`. Fix `k ≤ g`. `k ∈ S ⟹ g − k ∉ S` is additive closure (`k + (g − k) = g`). `g − k ∉ S ⟹ k ∈ S` is the contrapositive 'gap `k` has `g − k ∈ S'`: by `gap_dominated`, the maximum `m` of `{ y gap : y ≥ k, y − k ∈ S }` is pseudo-Frobenius, hence `m = g`, so `g − k = m − k ∈ S`. **Engine `gap_dominated`.** That maximum `m` is pseudo-Frobenius because if some `m + s` (`s ∈ S`, `s > 0`) were a gap, then `(m + s) − k = (m − k) + s ∈ S` would put `m + s` in the set, contradicting maximality of `m`. **Subsumption.** `{n | Representable a b n}` is shown to be a numerical semigroup with Frobenius number `ab − a − b`, and `representable_type_one` recovers the parent's `PF(⟨a,b⟩) = {g}` from the general equivalence applied to the parent's symmetry.",
+    "keyInsights": [
+      "**The converse is an order-theoretic fact made constructive.** Pseudo-Frobenius numbers are the maximal elements of the finite poset of gaps under $u \\preceq v \\Leftrightarrow v - u \\in S$. Every element of a finite poset lies below a maximal one; `gap_dominated` realizes this by taking an explicit Finset maximum, so no abstract Zorn/maximality API is needed.",
+      "**Type one collapses 'some maximal gap' to 'the maximal gap'.** The domination lemma gives, for each gap $k$, a pseudo-Frobenius number above it. Type one ($\\mathrm{PF}(S) = \\{g\\}$) forces that number to be $g$, so $g - k \\in S$ — exactly the missing half of symmetry. The hypothesis is used at precisely one point.",
+      "**Generator-agnosticism is what makes it a real converse.** The parent's `Representable a b` carries the two-generator structure; phrasing everything over an abstract `S : Set ℕ` proves the theorem where it actually lives (Kunz's equivalence holds for all numerical semigroups, most of which need ≥ 3 generators and have no closed-form $g$).",
+      "**The general theorem subsumes the special case, verified.** `representable_type_one` derives the parent's headline `PF(⟨a,b⟩) = {g}` by feeding the parent's symmetry into the general equivalence — a machine-checked demonstration that the abstract framework recovers the concrete result, not merely resembles it."
+    ],
+    "prerequisites": [
+      "Numerical semigroups, gaps, Frobenius number, and the maximality $\\forall n > g,\\ n \\in S$",
+      "Pseudo-Frobenius numbers and the type invariant (Rosales–García-Sánchez, Ch. 4)",
+      "Two-generator symmetry $\\text{Rep}(k) \\Leftrightarrow \\neg\\text{Rep}(g-k)$ on $[0,g]$ (parent `frobenius-number-oq-01-oq-03`)",
+      "Finite-set maxima ($\\texttt{Finset.max'}$) and $\\mathrm{ncard}$ of a singleton"
+    ]
+  },
+  "conclusion": {
+    "summary": "In 285 lines, 0 sorries, 0 axioms, the Kunz equivalence symmetric ⟺ type one is proved for an arbitrary numerical semigroup S ⊆ ℕ, closing the converse left open by the parent. The structural engine gap_dominated shows every gap is dominated by a pseudo-Frobenius number; type one forces that number to be the Frobenius number g, delivering g − k ∈ S for every gap k and hence symmetry. The two-generator semigroup ⟨a,b⟩ is realized as an instance, and the parent's PF(⟨a,b⟩) = {g} is re-derived as a corollary.",
+    "implications": "This completes the elementary invariant theory of the symmetric (Gorenstein) condition begun in the parent family: the genus (sibling OQ-01), the interior duality (sibling OQ-02), the two-generator type-one computation (parent OQ-01-OQ-03), and now the generator-agnostic equivalence symmetric ⟺ type one. The abstract IsNumericalSemigroup / IsPF scaffolding is the natural launch point for the genuinely harder ≥ 3-generator theory, where the type can be arbitrarily large and the symmetric case is the exception rather than the rule.",
+    "openQuestions": [
+      "Characterise PSEUDO-symmetric numerical semigroups (g even, type two with PF(S) = {g/2, g}) in the same generator-agnostic framework, proving the analogue 'pseudo-symmetric ⟺ PF(S) = {g/2, g}'.",
+      "Give the Apéry-set characterisation of the type: type(S) = |{maximal elements of Ap(S, n) under ⪯}| for any nonzero n ∈ S, linking PF(S) to the Apéry set and recovering type one for symmetric semigroups."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Parent: proved the FORWARD/easy half (two-generator ⟨a,b⟩ has PF = {g}, hence type one) and explicitly posed this converse as its open question. This entry proves the converse type one ⟹ symmetric for arbitrary S, reuses the parent's symmetric_le_frobenius for the two-generator instance, and re-derives the parent's type-one result from the general equivalence."
+    },
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "related",
+      "description": "The interior symmetry of OQ-02, completed to [0,g] by the parent, is the symmetry hypothesis that — via the general equivalence — yields the two-generator type-one corollary here."
+    },
+    {
+      "targetId": "frobenius-number",
+      "relationship": "foundational",
+      "description": "Supplies Representable, frobeniusNumber = ab − a − b, and sylvester_frobenius (the maximality ∀ n > g, Rep n) used to show {n | Representable a b n} is a numerical semigroup with Frobenius number ab − a − b."
+    }
+  ],
+  "references": [
+    {
+      "title": "The value-semigroup of a one-dimensional Gorenstein ring",
+      "author": "Ernst Kunz",
+      "year": "1970",
+      "venue": "Proceedings of the American Mathematical Society 25, 748–751",
+      "description": "Proves a numerical semigroup is symmetric iff its coordinate ring is Gorenstein iff it has type one — the equivalence whose converse this entry formalizes."
+    },
+    {
+      "title": "Numerical Semigroups",
+      "author": "J. C. Rosales, P. A. García-Sánchez",
+      "year": "2009",
+      "venue": "Springer Developments in Mathematics 20",
+      "description": "Chapter 4 develops pseudo-Frobenius numbers, the type, and the symmetric/pseudo-symmetric classification; Proposition 4.4 is the symmetric ⟺ type one equivalence."
+    },
+    {
+      "title": "On numerical semigroups",
+      "author": "R. Fröberg, C. Gottlieb, R. Häggkvist",
+      "year": "1987",
+      "venue": "Semigroup Forum 35, 63–83",
+      "description": "Foundational treatment of the type, pseudo-Frobenius numbers, and the symmetric/pseudo-symmetric dichotomy for numerical semigroups."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "filename": "FrobeniusNumberOQ01OQ03OQ01.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.FrobeniusNumber",
+      "Proofs.FrobeniusNumberOQ01OQ03"
+    ],
+    "namespace": "FrobeniusNumberOQ01OQ03OQ01",
+    "lineCount": 285,
+    "theoremCount": 13,
+    "axiomCount": 0,
+    "definitionCount": 4,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean",
+    "additionalFiles": [
+      "Proofs/FrobeniusNumber.lean",
+      "Proofs/FrobeniusNumberOQ02.lean",
+      "Proofs/FrobeniusNumberOQ01OQ03.lean"
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-01-oq-01",
+      "question": "Characterise pseudo-symmetric numerical semigroups (g even, type two with PF(S) = {g/2, g}) in the same generator-agnostic framework: prove pseudo-symmetric ⟺ PF(S) = {g/2, g}.",
+      "significance": "medium"
+    },
+    {
+      "id": "frobenius-number-oq-01-oq-03-oq-01-oq-02",
+      "question": "Give the Apéry-set characterisation type(S) = |maximal elements of Ap(S, n)| for nonzero n ∈ S, linking PF(S) to the Apéry set.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/szemeredi-counting-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "szemeredi-counting-oq-01",
+  "title": "Quantitative Triangle Removal: the Packing–Covering Bracket ν ≤ ρ ≤ τ",
+  "slug": "szemeredi-counting-oq-01",
+  "description": "Isolates the abstract combinatorial object whose behaviour the optimal quantitative bounds of the triangle removal lemma actually measure: the triangle removal number ρ(G), the minimum number of edges whose deletion makes a finite graph G triangle-free. For an ARBITRARY finite graph the entry proves the two-sided bracket ν(G) ≤ ρ(G) ≤ τ(G), where ν is the maximum size of an edge-disjoint triangle packing and τ is the total number of triangles. The lower inequality is weak LP duality for the triangle hypergraph (a König-type packing/covering bound, packing_card_le_cover_card): assign to each packed triangle a covering edge; edge-disjointness forces the assignment injective, so |packing| ≤ |cover|. The upper inequality is the greedy one-edge-per-triangle cover (exists_cover_card_le_numTriangles). The technical bridge cliqueFree_deleteEdges_iff_covers identifies 'deleting F makes G triangle-free' with 'F meets every triangle', tying the removal-lemma conclusion to edge covers. The Ruzsa–Szemerédi lower-bound graphs already formalized in RothTriangleRemoval.lean are exactly an instance of the lower bracket (ν = |A|·N edge-disjoint triangles), and the gap ρ/τ — the LP integrality gap — is precisely what makes the optimal γ(δ) super-polynomial. 10 theorems + 7 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SzemerediCountingOQ01.lean",
+    "additionalFiles": [],
+    "tags": [
+      "szemeredi",
+      "combinatorics",
+      "graph-theory",
+      "triangle-removal",
+      "regularity",
+      "packing-covering",
+      "lp-duality",
+      "extremal-graph-theory",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 314,
+    "theoremCount": 10,
+    "definitionCount": 7,
+    "assumptions": "None beyond a finite vertex type. All results are universally quantified over a SimpleGraph G on a Fintype V with DecidableEq V, with edge sets, packings, and covers passed as ordinary Finset hypotheses (no structure-encoded axioms, no DecidableRel on G.Adj required — decidability of the triangle predicate is supplied classically). #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound for packing_le_removal_le_numTriangles, packing_card_le_cover_card, exists_cover_card_le_numTriangles, cliqueFree_deleteEdges_iff_covers, and removalNumber_eq_zero_of_cliqueFree; no sorryAx, no native_decide, no Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.deleteEdges / SimpleGraph.deleteEdges_adj",
+        "description": "Removing an edge set from a graph; the adjacency characterisation (G.deleteEdges s).Adj v w ↔ G.Adj v w ∧ s(v,w) ∉ s drives the cover ↔ triangle-free bridge.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.DeleteEdges"
+      },
+      {
+        "theorem": "SimpleGraph.CliqueFree / SimpleGraph.IsNClique / SimpleGraph.IsClique",
+        "description": "Triangles are 3-cliques (IsNClique 3); triangle-freeness is CliqueFree 3. Clique membership is unfolded to pairwise adjacency to test survival under edge deletion.",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Clique"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "The weak-duality injection: P.attach injects into the cover F via the chosen covering edges, giving |P| ≤ |F|.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Sym2.eq_iff",
+        "description": "s(x,y) = s(z,w) ↔ (x=z ∧ y=w) ∨ (x=w ∧ y=z) — extracts that two triangles assigned the same covering edge share both of its endpoints.",
+        "module": "Mathlib.Data.Sym.Sym2"
+      },
+      {
+        "theorem": "Nat.sInf_mem / Nat.sInf_le",
+        "description": "The removal number is the infimum of cover sizes; nonemptiness (the greedy cover) makes the infimum attained, feeding both brackets.",
+        "module": "Mathlib.Order.Bounds.Basic / Mathlib.Data.Nat.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "IsTriangle / TriangleCoveredBy / IsTriangleEdgeCover / IsTrianglePacking: a self-contained vocabulary for the triangle removal number over Mathlib's SimpleGraph. A triangle is an IsNClique 3; an edge cover F is one whose deletion yields CliqueFree 3; an edge-disjoint packing is a family of triangles pairwise sharing ≤ 1 vertex (the combinatorial form of edge-disjointness for 3-cliques).",
+      "cliqueFree_deleteEdges_iff_covers (the bridge): (G.deleteEdges ↑F).CliqueFree 3 ↔ every triangle of G has an edge in F. Forward: an uncovered triangle survives every deletion; reverse: a surviving triangle is uncovered. This is the precise translation between the removal lemma's deletion conclusion and the hitting-set/cover formulation.",
+      "packing_card_le_cover_card (WEAK DUALITY, the core): every edge-disjoint triangle packing P and every edge cover F satisfy |P| ≤ |F|. Each packed triangle is mapped to one of its covering edges in F via a junk-free choice on P.attach; if two distinct triangles map to the same edge they share that edge's two endpoints, contradicting the ≤ 1 shared-vertex condition, so the map is injective.",
+      "exists_cover_card_le_numTriangles (greedy upper bound): selecting one edge from each triangle yields a cover of size ≤ τ(G), witnessing ρ(G) ≤ τ(G).",
+      "removalNumber (ρ(G)): the minimum number of edges whose deletion makes G triangle-free, defined as sInf of the cover-size set; removalNumber_mem shows the infimum is attained by an actual cover.",
+      "packing_card_le_removalNumber (ν ≤ ρ) and removalNumber_le_numTriangles (ρ ≤ τ): the two halves of the bracket, obtained by instantiating weak duality at the optimal cover and the greedy bound at the infimum respectively.",
+      "packing_le_removal_le_numTriangles (the headline ν ≤ ρ ≤ τ): the quantitative-bounds bracket for the removal number of any finite graph — the LP integrality gap ρ/τ (equivalently ν vs. τ) is exactly the quantity Ruzsa–Szemerédi / Behrend constructions push to be super-polynomially small, which is what governs the optimal triangle removal constant γ(δ).",
+      "removalNumber_eq_zero_of_cliqueFree: sharpness at the bottom — a triangle-free graph already has the empty set as a cover, so ν = ρ = τ = 0."
+    ],
+    "prerequisites": [
+      "szemeredi-counting (parent: the quantitative triangle removal lemma γ(δ) and the counting lemma)",
+      "Triangle removal lemma and its optimal-bounds open problem (Fox 2011; Ruzsa–Szemerédi 1978)",
+      "SimpleGraph, IsNClique/CliqueFree, and deleteEdges in Mathlib",
+      "Weak LP duality / König-type packing–covering inequalities for hypergraphs"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The triangle removal lemma (Ruzsa–Szemerédi 1978) states that for every $\\delta > 0$ there is $\\gamma > 0$ such that any $n$-vertex graph with at most $\\gamma n^3$ triangles can be made triangle-free by deleting at most $\\delta n^2$ edges. Deriving it from the Szemerédi regularity lemma forces $\\gamma(\\delta)$ to be a tower of height polynomial in $1/\\delta$; Fox (2011) improved this to a tower of bounded height, but the **optimal** dependence of $\\gamma$ on $\\delta$ remains a famous open problem. The only known lower bounds come from Ruzsa–Szemerédi graphs built on Behrend's large AP-free sets, which force $\\gamma(\\delta)$ to be super-polynomially small. This entry strips the question down to its combinatorial skeleton: the per-graph triangle **removal number** $\\rho(G)$ — the minimum number of edges to delete to kill every triangle — and the two parameters that bracket it, the edge-disjoint triangle **packing number** $\\nu(G)$ and the total triangle count $\\tau(G)$.",
+    "problemStatement": "For a finite graph $G$ let $\\rho(G)$ be the minimum number of edges whose deletion makes $G$ triangle-free, $\\nu(G)$ the maximum number of pairwise edge-disjoint triangles, and $\\tau(G)$ the number of triangles. Prove the bracket $\\nu(G) \\le \\rho(G) \\le \\tau(G)$ for an arbitrary finite graph, via the bridge identifying triangle-freeness of $G$ minus an edge set with that set being a triangle edge cover.",
+    "text": "The minimum number of edges to delete to make a graph triangle-free (its removal number ρ) is sandwiched between the maximum edge-disjoint triangle packing ν and the total triangle count τ: ν ≤ ρ ≤ τ. The gap between these bounds — the integrality gap of the triangle hypergraph LP — is exactly what governs the optimal constant in the triangle removal lemma.",
+    "proofStrategy": "**Setup.** Work over a `SimpleGraph G` on a `Fintype V`. A triangle is `G.IsNClique 3 s`; an edge set `F : Finset (Sym2 V)` is a cover when `(G.deleteEdges ↑F).CliqueFree 3`; a packing is a `Finset (Finset V)` of triangles pairwise sharing ≤ 1 vertex. **Bridge.** `cliqueFree_deleteEdges_iff_covers`: deleting `F` is triangle-free iff `F` meets every triangle. Forward — if a triangle `s` had no edge in `F`, all three of its pairs survive deletion (via `deleteEdges_adj`), so `s` is still a 3-clique, contradicting `CliqueFree`. Reverse — a 3-clique surviving deletion has all its edges outside `F`, contradicting that `F` meets it. **Lower bracket (weak duality).** Given a packing `P` and a cover `F`, choose for each triangle of `P` a covering edge of `F` (a junk-free `Classical.choose` on `P.attach`). The assignment maps into `F`; if two triangles `a ≠ b` map to the same edge `e`, then `Sym2.eq_iff` puts both endpoints of `e` in `a ∩ b`, so `|a ∩ b| ≥ 2`, contradicting the packing's ≤ 1 condition. Hence injective and `|P| ≤ |F|` (`packing_card_le_cover_card`). **Upper bracket (greedy).** Picking one edge per triangle gives a cover that is the image of `triangles G` under a choice map, so its size is ≤ `τ(G)` (`exists_cover_card_le_numTriangles`). **Bracket.** `removalNumber G := sInf {|F| : F a cover}` is attained (`Nat.sInf_mem`, the set is nonempty by the greedy cover); weak duality at the optimal cover gives `ν ≤ ρ`, and `Nat.sInf_le` at the greedy cover gives `ρ ≤ τ` — combined in `packing_le_removal_le_numTriangles`.",
+    "keyInsights": [
+      "**The removal lemma is a hitting-set problem.** `cliqueFree_deleteEdges_iff_covers` shows that 'delete few edges to kill all triangles' is exactly 'find a small edge set meeting every triangle' — a vertex-cover/hitting-set on the triangle hypergraph. This reframing is what lets purely combinatorial packing–covering bounds speak to the analytic removal constant.",
+      "**Edge-disjointness for triangles is a vertex condition.** Two distinct 3-cliques share an edge iff they share two vertices, so the awkward 'no common edge in Sym2 V' becomes the clean Finset condition |s ∩ t| ≤ 1 — and the injectivity in weak duality falls out of `Sym2.eq_iff` plus `Finset.one_lt_card`.",
+      "**Weak duality is the whole lower-bound mechanism, abstracted.** The Ruzsa–Szemerédi proof's 'each edge lies in exactly one triangle ⇒ need ≥ |A|N deletions' is precisely `packing_card_le_cover_card` applied to a packing of |A|N edge-disjoint triangles. The abstract lemma proves once what the construction-specific lower bound proves by hand.",
+      "**The optimal γ(δ) is an integrality gap.** ν ≤ ρ ≤ τ holds for every graph; the removal lemma's strength is governed by how far ρ can sit above ν and below τ — the integrality gap of the triangle-hypergraph covering LP. Behrend/Ruzsa–Szemerédi constructions are exactly the graphs that push this gap to be super-polynomial, which is why no polynomial γ(δ) is known."
+    ],
+    "prerequisites": [
+      "Triangles as 3-cliques and triangle-freeness as CliqueFree 3 in Mathlib",
+      "Edge deletion SimpleGraph.deleteEdges and its adjacency lemma",
+      "Weak LP duality / König-type packing–covering for hypergraphs",
+      "The triangle removal lemma and the open problem of its optimal quantitative bounds"
+    ]
+  },
+  "conclusion": {
+    "summary": "In 314 lines, 0 sorries, 0 axioms, the entry proves the bracket ν(G) ≤ ρ(G) ≤ τ(G) for the triangle removal number of an arbitrary finite graph. The bridge cliqueFree_deleteEdges_iff_covers recasts triangle-freeness-after-deletion as an edge cover; weak duality packing_card_le_cover_card delivers the lower bracket via an injection from any edge-disjoint packing into any cover; and the greedy one-edge-per-triangle cover delivers the upper bracket. The removal number is defined as the infimum of cover sizes and shown attained.",
+    "implications": "This places the quantitative triangle removal lemma on a clean combinatorial footing: its optimal constant γ(δ) is governed by the integrality gap of the triangle-hypergraph covering LP, the quantity ν-vs-τ that Ruzsa–Szemerédi / Behrend constructions exploit. The abstract weak-duality lemma proves once, for all graphs, the lower-bound mechanism that RothTriangleRemoval.lean carries out by hand for the specific AP-free construction (ν = |A|·N edge-disjoint triangles). The scaffolding generalises verbatim to K_r-removal (clique covers/packings) and is the natural setting for formalising explicit lower bounds on γ once Behrend's construction is available.",
+    "openQuestions": [
+      "Prove the matching K_r version: for the minimum number of edges to delete to make G K_r-free, the same bracket νᵣ(G) ≤ ρᵣ(G) ≤ τᵣ(G) holds, with the shared-vertex bound |s ∩ t| ≤ r − 2 for edge-disjoint r-cliques.",
+      "Combine this bracket with a formalised Behrend construction to prove a super-polynomial lower bound on the optimal triangle removal constant γ(δ): exhibit graphs with ν(G) = ρ(G) yet ρ(G) super-polynomially larger than any polynomial in the triangle density.",
+      "Formalise the corresponding fractional relaxation and show ρ equals the integral covering number while the fractional cover equals the fractional packing, isolating the integrality gap as the exact obstruction to a polynomial γ(δ)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-counting",
+      "relationship": "extends",
+      "description": "Parent: formalises the quantitative triangle removal lemma γ(δ) from regularity + counting. This entry isolates the per-graph removal number ρ(G) that the lemma bounds and brackets it ν ≤ ρ ≤ τ, exposing the integrality gap that governs the optimal γ(δ)."
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "related",
+      "description": "The Ruzsa–Szemerédi construction (formalised in RothTriangleRemoval.lean) that proves Roth's theorem via triangle removal is exactly an instance of the lower bracket: an AP-free set A yields |A|·N edge-disjoint triangles, so ρ ≥ ν = |A|·N — a special case of packing_card_le_cover_card."
+    }
+  ],
+  "references": [
+    {
+      "title": "Triple systems with no six points carrying three triangles",
+      "author": "I. Z. Ruzsa, E. Szemerédi",
+      "year": "1978",
+      "venue": "Combinatorics (Keszthely 1976), Coll. Math. Soc. J. Bolyai 18, 939–945",
+      "description": "Introduces the (6,3)-theorem and the triangle removal lemma; the induced-matching / edge-disjoint-triangle mechanism is the lower-bracket weak duality formalised here."
+    },
+    {
+      "title": "A new proof of the graph removal lemma",
+      "author": "Jacob Fox",
+      "year": "2011",
+      "venue": "Annals of Mathematics 174, 561–579",
+      "description": "Proves the best known quantitative bounds (tower of bounded height) for the triangle/graph removal lemma; the optimal dependence γ(δ) — the integrality gap this entry isolates — remains open."
+    },
+    {
+      "title": "On sets of integers containing no three terms in arithmetical progression",
+      "author": "Felix A. Behrend",
+      "year": "1946",
+      "venue": "Proceedings of the National Academy of Sciences 32, 331–332",
+      "description": "Large AP-free sets that, fed through the Ruzsa–Szemerédi construction, push the packing-vs-count gap to be super-polynomial — the source of the only known lower bounds on the optimal removal constant."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SzemerediCountingOQ01.lean",
+    "filename": "SzemerediCountingOQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Szemeredi.TriangleRemoval.Bounds",
+    "lineCount": 314,
+    "theoremCount": 10,
+    "axiomCount": 0,
+    "definitionCount": 7,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCountingOQ01.lean",
+    "additionalFiles": []
+  },
+  "openQuestions": [
+    {
+      "id": "szemeredi-counting-oq-01-oq-01",
+      "question": "Prove the matching K_r version: for the minimum number of edges to delete to make G K_r-free, the bracket νᵣ(G) ≤ ρᵣ(G) ≤ τᵣ(G) holds, with edge-disjoint r-cliques sharing ≤ r − 2 vertices.",
+      "significance": "medium"
+    },
+    {
+      "id": "szemeredi-counting-oq-01-oq-02",
+      "question": "Combine this bracket with a formalised Behrend construction to prove a super-polynomial lower bound on the optimal triangle removal constant γ(δ).",
+      "significance": "high"
+    },
+    {
+      "id": "szemeredi-counting-oq-01-oq-03",
+      "question": "Formalise the fractional relaxation and identify the integrality gap between the integral removal number ρ and the fractional cover/packing as the exact obstruction to a polynomial γ(δ).",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Parent **szemeredi-counting** asks: *what are the optimal quantitative bounds for the triangle removal lemma?* — a famous open problem. This entry isolates the combinatorial object those bounds actually measure: the per-graph **triangle removal number** ρ(G), the minimum number of edges whose deletion makes a finite graph triangle-free, and proves the two-sided bracket that governs it for an **arbitrary** finite graph:

$$\nu(G) \;\le\; \rho(G) \;\le\; \tau(G),$$

where ν(G) is the maximum size of an edge-disjoint triangle packing and τ(G) is the total triangle count.

## What's proved (10 theorems, 7 definitions, 314 lines)

- **`cliqueFree_deleteEdges_iff_covers`** — the bridge: deleting an edge set F makes G triangle-free **iff** F meets every triangle (an edge cover). Recasts the removal lemma's conclusion as a hitting-set problem on the triangle hypergraph.
- **`packing_card_le_cover_card`** — WEAK DUALITY (König-type): any edge-disjoint triangle packing P and any edge cover F satisfy `|P| ≤ |F|`. Assign each packed triangle a covering edge; `Sym2.eq_iff` + the ≤1 shared-vertex condition force the assignment injective.
- **`exists_cover_card_le_numTriangles`** — greedy one-edge-per-triangle cover, giving ρ ≤ τ.
- **`removalNumber`** (= sInf of cover sizes, shown attained), **`packing_card_le_removalNumber`** (ν ≤ ρ), **`removalNumber_le_numTriangles`** (ρ ≤ τ).
- **`packing_le_removal_le_numTriangles`** — the headline bracket ν ≤ ρ ≤ τ.
- **`removalNumber_eq_zero_of_cliqueFree`** — sharpness: a triangle-free graph has ρ = 0.

## Why this is the right angle on the open question

The Ruzsa–Szemerédi lower-bound graphs already formalized in `RothTriangleRemoval.lean` are exactly an **instance of the lower bracket**: an AP-free set A yields |A|·N edge-disjoint triangles, so ρ ≥ ν = |A|·N. The abstract weak-duality lemma proves *once, for all graphs*, the lower-bound mechanism that file carries out by hand. The gap ρ/τ — the **integrality gap** of the triangle-hypergraph covering LP — is precisely the quantity Behrend / Ruzsa–Szemerédi constructions push to be super-polynomially small, which is why no polynomial γ(δ) is known.

## Verification

- Self-contained over Mathlib's `SimpleGraph` (imports only `Mathlib`).
- `#print axioms` on all main theorems reports only `propext`, `Classical.choice`, `Quot.sound` — **0-axiom, 0 sorries**. No `sorryAx`, no `native_decide`, no `Lean.ofReduceBool`.
- Compiles clean (no warnings) under Lean `v4.26.0` via host `lake env lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)