### PR TITLE
research(prob-method-second-moment-oq-01-oq-01): measure-theoretic Paley–Zygmund [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3448,6 +3448,7 @@ import Proofs.ProbMethodExpectationOQ01
 import Proofs.ProbMethodLovaszLocalOQ02
 import Proofs.ProbMethodSecondMoment
 import Proofs.ProbMethodSecondMomentOQ01
+import Proofs.ProbMethodSecondMomentOQ01OQ01
 import Proofs.ProbMethodSecondMomentOQ02
 import Proofs.ProductOfSegmentsOfChords
 import Proofs.ProductOfSegmentsOfChordsConverse

--- a/proofs/Proofs/ProbMethodSecondMomentOQ01OQ01.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ01OQ01.lean
@@ -1,0 +1,159 @@
+/-
+  Quantitative Paley–Zygmund Inequality in the MeasureTheory.Lp Setting
+
+  This file recasts the quantitative Paley–Zygmund inequality (proved over a
+  finite Finset model in `ProbMethodSecondMomentOQ01.lean`) into Mathlib's
+  native measure-theoretic framework, over a genuine probability space and
+  Bochner integrals.
+
+  For a nonnegative random variable `X ∈ L²(μ)` on a probability space and a
+  threshold `0 ≤ θ ≤ 1`, the probability that `X` exceeds the fraction `θ` of
+  its mean is bounded below:
+
+      μ({X > θ · 𝔼X}) · 𝔼[X²]  ≥  (1 - θ)² · (𝔼X)².
+
+  Equivalently, when `𝔼[X²] > 0`,
+
+      μ({X > θ · 𝔼X})  ≥  (1 - θ)² · (𝔼X)² / 𝔼[X²].
+
+  The proof follows the classical second-moment argument:
+    * split  𝔼X = ∫_A X + ∫_{Aᶜ} X  with  A = {X > θ 𝔼X};
+    * on `Aᶜ` we have `X ≤ θ 𝔼X`, so `∫_{Aᶜ} X ≤ θ 𝔼X`, giving `∫_A X ≥ (1-θ)𝔼X`;
+    * Cauchy–Schwarz: `(∫_A X)² ≤ 𝔼[X²] · μ(A)`.
+
+  Combining yields the bound.  The core integral Cauchy–Schwarz step is packaged
+  as `sq_integral_mul_le`, derived from Mathlib's Hölder inequality for the
+  conjugate pair `(2, 2)`.
+
+  Paley–Zygmund is not currently in Mathlib; this provides a measure-theoretic
+  formalization reusing only standard `MeasureTheory` / `ProbabilityTheory` API.
+-/
+import Mathlib
+
+set_option linter.unusedVariables false
+
+open MeasureTheory
+open scoped ENNReal NNReal
+
+namespace ProbMethod.SecondMoment.MeasureTheoretic
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Integral Cauchy–Schwarz (squared form).**  For nonnegative `L²` functions
+`f, g`, the square of the integral of their product is bounded by the product of
+their second moments:
+
+    (∫ f · g)²  ≤  (∫ f²) · (∫ g²).
+
+This is the special case `p = q = 2` of Hölder's inequality, squared. -/
+theorem sq_integral_mul_le {f g : Ω → ℝ} (hf : MemLp f 2 μ) (hg : MemLp g 2 μ)
+    (hfn : 0 ≤ᵐ[μ] f) (hgn : 0 ≤ᵐ[μ] g) :
+    (∫ a, f a * g a ∂μ) ^ 2 ≤ (∫ a, f a ^ 2 ∂μ) * (∫ a, g a ^ 2 ∂μ) := by
+  have hf' : MemLp f (ENNReal.ofReal 2) μ := by rw [ENNReal.ofReal_ofNat]; exact hf
+  have hg' : MemLp g (ENNReal.ofReal 2) μ := by rw [ENNReal.ofReal_ofNat]; exact hg
+  have hcs := integral_mul_le_Lp_mul_Lq_of_nonneg Real.HolderConjugate.two_two hfn hgn hf' hg'
+  simp only [Real.rpow_two] at hcs
+  rw [← Real.sqrt_eq_rpow, ← Real.sqrt_eq_rpow] at hcs
+  have hA : 0 ≤ ∫ a, f a ^ 2 ∂μ := integral_nonneg fun a => sq_nonneg _
+  have hB : 0 ≤ ∫ a, g a ^ 2 ∂μ := integral_nonneg fun a => sq_nonneg _
+  have hfg : 0 ≤ ∫ a, f a * g a ∂μ :=
+    integral_nonneg_of_ae (by filter_upwards [hfn, hgn] with a ha hb using mul_nonneg ha hb)
+  calc (∫ a, f a * g a ∂μ) ^ 2
+      ≤ (Real.sqrt (∫ a, f a ^ 2 ∂μ) * Real.sqrt (∫ a, g a ^ 2 ∂μ)) ^ 2 :=
+        pow_le_pow_left₀ hfg hcs 2
+    _ = (∫ a, f a ^ 2 ∂μ) * (∫ a, g a ^ 2 ∂μ) := by
+        rw [mul_pow, Real.sq_sqrt hA, Real.sq_sqrt hB]
+
+/-- **Quantitative Paley–Zygmund inequality (measure-theoretic form).**
+
+For a nonnegative `X ∈ L²(μ)` on a probability space and `0 ≤ θ ≤ 1`:
+
+    (1 - θ)² · (𝔼X)²  ≤  μ({X > θ 𝔼X}) · 𝔼[X²].
+
+(Here `μ.real s = (μ s).toReal` is the real-valued measure and `∫ ω, X ω ∂μ` is
+the expectation.) -/
+theorem paley_zygmund [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) {θ : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * (∫ ω, X ω ∂μ) ^ 2
+      ≤ μ.real {ω | θ * (∫ ω, X ω ∂μ) < X ω} * ∫ ω, X ω ^ 2 ∂μ := by
+  set m := ∫ ω, X ω ∂μ with hm
+  set A := {ω | θ * m < X ω} with hA_def
+  -- `A` is the preimage of an open ray, hence measurable.
+  have hA_meas : MeasurableSet A := hXm measurableSet_Ioi
+  -- Integrability facts from `X ∈ L²` on a finite measure.
+  have hXint : Integrable X μ := hX.integrable (by norm_num)
+  have hm_nonneg : 0 ≤ m := integral_nonneg_of_ae hXnn
+  -- The constant-`1` indicator of `A` lives in `L²`.
+  have hg_mem : MemLp (A.indicator (fun _ => (1 : ℝ))) 2 μ :=
+    memLp_indicator_const 2 hA_meas 1 (Or.inr (measure_ne_top μ A))
+  have hg_nn : 0 ≤ᵐ[μ] A.indicator (fun _ => (1 : ℝ)) :=
+    Filter.Eventually.of_forall fun ω => Set.indicator_nonneg (fun _ _ => zero_le_one) ω
+  -- Step 1: 𝔼X = ∫_A X + ∫_{Aᶜ} X.
+  have hsplit : (∫ ω in A, X ω ∂μ) + (∫ ω in Aᶜ, X ω ∂μ) = m :=
+    integral_add_compl hA_meas hXint
+  -- Step 2: on `Aᶜ`, `X ≤ θ 𝔼X`, so `∫_{Aᶜ} X ≤ θ 𝔼X`.
+  have hcompl_le : (∫ ω in Aᶜ, X ω ∂μ) ≤ θ * m := by
+    have hpt : ∀ ω ∈ Aᶜ, X ω ≤ θ * m := by
+      intro ω hω
+      simp only [hA_def, Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hω
+      exact hω
+    calc (∫ ω in Aᶜ, X ω ∂μ)
+        ≤ ∫ _ in Aᶜ, θ * m ∂μ :=
+          setIntegral_mono_on hXint.integrableOn integrableOn_const hA_meas.compl hpt
+      _ = μ.real Aᶜ * (θ * m) := by rw [setIntegral_const, smul_eq_mul]
+      _ ≤ 1 * (θ * m) :=
+          mul_le_mul_of_nonneg_right measureReal_le_one (mul_nonneg hθ0 hm_nonneg)
+      _ = θ * m := one_mul _
+  -- Step 3: hence `∫_A X ≥ (1-θ) 𝔼X`.
+  have habove_ge : (1 - θ) * m ≤ ∫ ω in A, X ω ∂μ := by
+    have hrw : (∫ ω in A, X ω ∂μ) = m - ∫ ω in Aᶜ, X ω ∂μ := by linarith [hsplit]
+    have hexp : (1 - θ) * m = m - θ * m := by ring
+    rw [hrw, hexp]; linarith [hcompl_le]
+  -- Step 4: Cauchy–Schwarz `(∫_A X)² ≤ 𝔼[X²] · μ(A)`.
+  have hind : (∫ ω in A, X ω ∂μ) = ∫ ω, X ω * A.indicator (fun _ => (1 : ℝ)) ω ∂μ := by
+    rw [← integral_indicator hA_meas]
+    apply integral_congr_ae
+    filter_upwards with ω
+    by_cases hω : ω ∈ A <;> simp [Set.indicator_of_mem, hω]
+  have hsq_ind : (∫ ω, (A.indicator (fun _ => (1 : ℝ)) ω) ^ 2 ∂μ) = μ.real A := by
+    have hfun : (fun ω => (A.indicator (fun _ => (1 : ℝ)) ω) ^ 2)
+        = A.indicator (fun _ => (1 : ℝ)) := by
+      funext ω; by_cases hω : ω ∈ A <;>
+        simp [Set.indicator_of_mem, hω]
+    rw [hfun, integral_indicator hA_meas, setIntegral_const, smul_eq_mul, mul_one]
+  have hcs0 := sq_integral_mul_le hX hg_mem hXnn hg_nn
+  rw [← hind, hsq_ind] at hcs0
+  -- Step 5: combine.
+  have h1mθ_nn : 0 ≤ (1 - θ) * m := mul_nonneg (by linarith) hm_nonneg
+  have hstep : ((1 - θ) * m) ^ 2 ≤ (∫ ω in A, X ω ∂μ) ^ 2 :=
+    pow_le_pow_left₀ h1mθ_nn habove_ge 2
+  calc (1 - θ) ^ 2 * m ^ 2
+      = ((1 - θ) * m) ^ 2 := by ring
+    _ ≤ (∫ ω in A, X ω ∂μ) ^ 2 := hstep
+    _ ≤ (∫ ω, X ω ^ 2 ∂μ) * μ.real A := hcs0
+    _ = μ.real A * ∫ ω, X ω ^ 2 ∂μ := by ring
+
+/-- **Probability form.**  When the second moment is positive,
+
+    μ({X > θ 𝔼X})  ≥  (1 - θ)² · (𝔼X)² / 𝔼[X²]. -/
+theorem paley_zygmund_prob [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) {θ : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1)
+    (hX2pos : 0 < ∫ ω, X ω ^ 2 ∂μ) :
+    (1 - θ) ^ 2 * (∫ ω, X ω ∂μ) ^ 2 / (∫ ω, X ω ^ 2 ∂μ)
+      ≤ μ.real {ω | θ * (∫ ω, X ω ∂μ) < X ω} := by
+  rw [div_le_iff₀ hX2pos]
+  exact paley_zygmund hXm hX hXnn hθ0 hθ1
+
+/-- **Qualitative corollary (`θ = 0`).**  The second-moment lower bound on the
+probability that `X` is strictly positive:
+
+    (𝔼X)²  ≤  μ({X > 0}) · 𝔼[X²].
+
+In particular, if `𝔼X > 0` then `μ({X > 0}) > 0`. -/
+theorem paley_zygmund_pos [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) :
+    (∫ ω, X ω ∂μ) ^ 2 ≤ μ.real {ω | 0 < X ω} * ∫ ω, X ω ^ 2 ∂μ := by
+  have h := paley_zygmund hXm hX hXnn (le_refl (0 : ℝ)) zero_le_one
+  simpa using h
+
+end ProbMethod.SecondMoment.MeasureTheoretic

--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "prob-method-second-moment-oq-01-oq-01",
+  "title": "Quantitative Paley–Zygmund in the MeasureTheory.Lp Setting",
+  "slug": "prob-method-second-moment-oq-01-oq-01",
+  "description": "Recasts and proves the quantitative Paley–Zygmund inequality in Mathlib's measure-theoretic framework: for a nonnegative X ∈ L²(μ) on a probability space and threshold θ ∈ [0,1], μ({X > θ·𝔼X}) · 𝔼[X²] ≥ (1-θ)²·(𝔼X)². Answers the parent's open question of generalizing the finite Finset form to genuine probability spaces with Bochner integrals.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ01OQ01.lean",
+    "tags": [
+      "probability",
+      "measure-theory",
+      "second-moment-method",
+      "paley-zygmund",
+      "Lp",
+      "cauchy-schwarz"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated hypotheses (probability measure, X measurable, X ∈ L², X ≥ 0 a.e., 0 ≤ θ ≤ 1). 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
+    "originalContributions": [
+      "sq_integral_mul_le: integral Cauchy–Schwarz in squared form, (∫ f·g)² ≤ (∫ f²)(∫ g²), for nonnegative L² functions — derived from Mathlib's Hölder inequality at the conjugate pair (2,2)",
+      "paley_zygmund: measure-theoretic Paley–Zygmund, (1-θ)²(𝔼X)² ≤ μ({X > θ𝔼X})·𝔼[X²] over a probability space",
+      "paley_zygmund_prob: division/probability form, μ({X > θ𝔼X}) ≥ (1-θ)²(𝔼X)²/𝔼[X²] when 𝔼[X²] > 0",
+      "paley_zygmund_pos: θ=0 corollary, (𝔼X)² ≤ μ({X>0})·𝔼[X²] — the qualitative second moment method"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_mul_le_Lp_mul_Lq_of_nonneg",
+        "description": "Hölder's inequality for nonnegative functions α → ℝ; specialized to the conjugate pair (2,2) it is the integral Cauchy–Schwarz inequality",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "integral_add_compl",
+        "description": "Decompose an integral as the sum of the set integral over A and over its complement",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
+      },
+      {
+        "theorem": "setIntegral_mono_on",
+        "description": "Monotonicity of the set integral from a pointwise bound on the set — used to bound ∫_{Aᶜ} X by θ·𝔼X",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
+      },
+      {
+        "theorem": "MemLp.integrable_sq",
+        "description": "If X ∈ L² then X² is integrable — supplies the finite second moment",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      },
+      {
+        "theorem": "memLp_indicator_const",
+        "description": "The constant-1 indicator of a finite-measure set lies in Lᵖ — used as the second argument to Cauchy–Schwarz",
+        "module": "Mathlib.MeasureTheory.Function.LpSeminorm.Basic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Paley–Zygmund inequality was proved by Raymond Paley and Antoni Zygmund in 1932 in their study of lacunary trigonometric series. It strengthens the qualitative second moment method by giving an explicit lower bound on the probability that a nonnegative random variable exceeds a fraction θ of its mean: P[X > θ𝔼X] ≥ (1-θ)²(𝔼X)²/𝔼[X²]. The gallery's parent entry (ProbMethodSecondMomentOQ01) proves the finite/discrete form over Finsets of ℚ-valued functions, which avoids measure theory but is not directly usable over continuous probability spaces. This entry closes the parent's explicit open question — 'Can this be generalized to the measure-theoretic MeasureTheory.Lp setting?' — by proving the inequality natively over a Mathlib probability space with Bochner integrals, the form actually needed for the probabilistic method over continuous spaces. Paley–Zygmund is not currently in Mathlib.",
+    "problemStatement": "For a nonnegative random variable X ∈ L²(μ) on a probability space (μ a probability measure) and a threshold 0 ≤ θ ≤ 1, prove the measure-theoretic quantitative Paley–Zygmund inequality (1-θ)²·(∫ X dμ)² ≤ μ({ω : θ·∫ X dμ < X ω})·∫ X² dμ, together with its division form and the θ=0 qualitative corollary.",
+    "text": "Proves the quantitative Paley–Zygmund inequality over a genuine probability space, recasting the gallery's finite-sum result into Mathlib's MeasureTheory/Bochner-integral framework. The proof packages the integral Cauchy–Schwarz step as a reusable squared-form lemma and reuses the classical above/below decomposition over set integrals.",
+    "proofStrategy": "Let m = 𝔼X and A = {X > θm}. (1) Split m = ∫_A X + ∫_{Aᶜ} X via integral_add_compl. (2) On Aᶜ, X ≤ θm pointwise, so ∫_{Aᶜ} X ≤ θm·μ.real(Aᶜ) ≤ θm by setIntegral_mono_on, setIntegral_const and measureReal_le_one. (3) Hence ∫_A X ≥ (1-θ)m. (4) Integral Cauchy–Schwarz against the constant-1 indicator of A gives (∫_A X)² ≤ 𝔼[X²]·μ.real(A). (5) Since 0 ≤ (1-θ)m ≤ ∫_A X, squaring and chaining the two inequalities yields (1-θ)²m² ≤ μ.real(A)·𝔼[X²].",
+    "keyInsights": [
+      "**ℝ-valued Bochner route with L² hypotheses**: Stating the result for X : Ω → ℝ with `MemLp X 2 μ`, `Measurable X` and `0 ≤ᵐ[μ] X` keeps everything inside Mathlib's standard expectation `∫ ω, X ω ∂μ` while the L² hypothesis supplies exactly the integrability needed (X integrable via MemLp.integrable, X² integrable via MemLp.integrable_sq).",
+      "**Cauchy–Schwarz as squared Hölder**: The bespoke `sq_integral_mul_le` lemma derives (∫ f·g)² ≤ (∫ f²)(∫ g²) from Mathlib's `integral_mul_le_Lp_mul_Lq_of_nonneg` at the Hölder-conjugate pair (2,2), converting the rpow `^(1/2)` factors back to `Real.sqrt` and squaring with `Real.sq_sqrt`. This isolates the only analytic ingredient in one reusable statement.",
+      "**Indicator as the second Cauchy–Schwarz argument**: Taking g = A.indicator 1 turns ∫ X·g into the set integral ∫_A X and ∫ g² into μ.real(A) (indicator is idempotent under squaring), so the abstract product inequality becomes exactly the (∫_A X)² ≤ 𝔼[X²]·μ(A) needed.",
+      "**Measurability replaces the discrete hypotheses**: Where the parent uses `hpos` and `hnn` over a Finset, the measure-theoretic form needs `Measurable X` (so the threshold set A = X⁻¹(Ioi θm) is measurable) plus a.e. nonnegativity; the probability-measure assumption gives μ.real(Aᶜ) ≤ 1 and finiteness of all measures involved.",
+      "**θ=0 recovers the qualitative method**: Specializing θ=0 collapses the bound to (𝔼X)² ≤ μ({X>0})·𝔼[X²], which forces μ({X>0}) > 0 whenever 𝔼X > 0 — the continuous-space analogue of the parent's `paley_zygmund_at_zero`."
+    ],
+    "prerequisites": [
+      "Integral Cauchy–Schwarz / Hölder inequality (integral_mul_le_Lp_mul_Lq_of_nonneg)",
+      "Bochner set integrals and set-integral decomposition (integral_add_compl, setIntegral_mono_on)",
+      "Lp membership and integrability (MemLp.integrable, MemLp.integrable_sq, memLp_indicator_const)",
+      "Quantitative Paley–Zygmund, finite form (parent entry: ProbMethodSecondMomentOQ01)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete Lean 4 formalization of the quantitative Paley–Zygmund inequality over a probability space, with 4 theorems and 0 axioms. The proof reuses the classical above/below decomposition over Bochner set integrals and packages the integral Cauchy–Schwarz step as the reusable lemma sq_integral_mul_le.",
+    "implications": "Provides the measure-theoretic form of Paley–Zygmund needed for the probabilistic method over continuous probability spaces, connecting the gallery's combinatorial second-moment results to Mathlib's MeasureTheory.Lp / ProbabilityTheory API. The squared integral Cauchy–Schwarz lemma is independently reusable.",
+    "openQuestions": [
+      "Can the a.e.-nonnegativity / measurability hypotheses be relaxed to AEStronglyMeasurable throughout?",
+      "Does an L¹–L^∞ (Hölder) variant give a one-sided tail bound under weaker moment assumptions?",
+      "Can this measure-theoretic Paley–Zygmund be contributed upstream to Mathlib?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: proves the quantitative Paley–Zygmund inequality in the finite Finset model. This entry answers its open question by recasting the result over a measure-theoretic probability space."
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "Grandparent qualitative second moment method, recovered here as the θ=0 corollary paley_zygmund_pos."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Paley, R.E.A.C.",
+        "Zygmund, A."
+      ],
+      "title": "On some series of functions",
+      "year": "1932",
+      "venue": "Proceedings of the Cambridge Philosophical Society 26, pp. 337-357",
+      "note": "Original Paley–Zygmund inequality"
+    },
+    {
+      "authors": [
+        "Alon, N.",
+        "Spencer, J.H."
+      ],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 4: Second moment method and Paley–Zygmund inequality"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory"
+    ],
+    "namespace": "ProbMethod.SecondMoment.MeasureTheoretic",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ProbMethodSecondMomentOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Quantitative Paley–Zygmund in the MeasureTheory.Lp Setting

Recasts and proves the quantitative Paley–Zygmund inequality in Mathlib's **measure-theoretic** framework — over a genuine probability space with Bochner integrals — answering the explicit open question of the parent entry `prob-method-second-moment-oq-01` (which proves only the finite Finset/ℚ form).

For a nonnegative `X ∈ L²(μ)` on a probability space and threshold `0 ≤ θ ≤ 1`:

> **(1 − θ)² · (𝔼X)²  ≤  μ({X > θ·𝔼X}) · 𝔼[X²]**

Paley–Zygmund is **not currently in Mathlib**.

### Theorems (4 total · 0 axioms · 0 sorries · verified)
- **`sq_integral_mul_le`** — squared integral Cauchy–Schwarz `(∫ f·g)² ≤ (∫ f²)(∫ g²)` for nonnegative L² functions, derived from Mathlib's Hölder inequality at the conjugate pair `(2,2)`.
- **`paley_zygmund`** — the measure-theoretic inequality above.
- **`paley_zygmund_prob`** — division form: `μ({X > θ𝔼X}) ≥ (1−θ)²(𝔼X)²/𝔼[X²]` when `𝔼[X²] > 0`.
- **`paley_zygmund_pos`** — θ=0 corollary: `(𝔼X)² ≤ μ({X>0})·𝔼[X²]` (qualitative second moment method).

### Proof engine
Classical above/below decomposition realized over Bochner **set integrals**:
1. `𝔼X = ∫_A X + ∫_{Aᶜ} X` via `integral_add_compl`, with `A = {X > θ𝔼X}`.
2. On `Aᶜ`, `X ≤ θ𝔼X`, so `∫_{Aᶜ} X ≤ θ𝔼X` (`setIntegral_mono_on`, `setIntegral_const`, `measureReal_le_one`); hence `∫_A X ≥ (1−θ)𝔼X`.
3. Integral Cauchy–Schwarz against the constant-1 indicator of `A` gives `(∫_A X)² ≤ 𝔼[X²]·μ(A)`.
4. Square and chain (`0 ≤ (1−θ)𝔼X ≤ ∫_A X`).

The `MemLp X 2 μ` hypothesis supplies all integrability cleanly (`MemLp.integrable`, `MemLp.integrable_sq`); `Measurable X` makes the threshold set measurable.

### Verification
- `#print axioms` on all 4 theorems → only `propext`, `Classical.choice`, `Quot.sound` (0 custom axioms).
- Compiles against Mathlib 4.26.0 (`Proofs/ProbMethodSecondMomentOQ01OQ01.lean`, 159 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)