### PR TITLE
research(bezout-identity-oq-02-oq-01-oq-01-oq-02): explicit Fermat/Frobenius factorization over 𝔽_p and ℚ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -322,6 +322,7 @@ import Proofs.BezoutIdentityOQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ01
+import Proofs.BezoutIdentityOQ02OQ01OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ04
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02

--- a/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean
@@ -1,0 +1,128 @@
+import Mathlib
+
+/-
+Explicit Factorization over Finite Fields and ℚ
+(bezout-identity-oq-02-oq-01-oq-01-oq-02)
+
+Open question from BezoutIdentityOQ02OQ01OQ01 (unique factorization in
+polynomial rings): make the abstract factorization *explicit* over the two
+concrete settings the parent advertises — `ℚ` and `𝔽_p`.
+
+Mathlib records the **root set** of `X^q - X` over a finite field
+(`roots (X^q - X) = univ.val`, i.e. every field element is a simple root),
+but it does not package the corresponding **product factorization**
+`X^q - X = ∏_{a} (X - a)`. That explicit closed form is the centerpiece here.
+
+**Main Results**:
+1. `fermat_factorization` — over any finite field `K`,
+     `X^|K| - X = ∏_{a : K} (X - a)`  (complete split into distinct linear factors).
+2. `fermat_factorization_zmod` — the `𝔽_p` specialization `X^p - X = ∏_{a} (X - a)`.
+3. `frobenius_factorization` — over `𝔽_p`, the binomial collapses to a perfect
+     `p`-th power of a single linear factor: `X^p - a = (X - a)^p`.
+4. `frobenius_one` — corollary `X^p - 1 = (X - 1)^p`.
+5. Explicit `ℚ` vs `𝔽_p` contrast: `2` is a root of `X^5 - X` over `𝔽_5`
+     (Fermat) but not over `ℚ` (where it evaluates to `30`).
+
+**Why this is new (not a Mathlib re-export)**: Mathlib has the *multiset of
+roots* of `X^q - X`; the equational product form here is assembled from it via
+`prod_multiset_X_sub_C_of_monic_of_roots_card_eq`. The Frobenius collapse is a
+direct `sub_pow_char` + `ZMod.pow_card` computation. The two together exhibit
+the qualitative split between separable (distinct-root) factorization over a
+finite field and the inseparable single-root factorization of `X^p - a`.
+
+**Status**: 0 sorries, 0 axioms.
+-/
+
+open Polynomial
+
+namespace BezoutFactorizationFp
+
+/-!
+## Section I: Fermat factorization over a finite field
+
+The polynomial `X^|K| - X` has every element of `K` as a simple root, so it
+splits into the product of all the linear factors `X - a`.
+-/
+
+/-- **Fermat factorization**: over any finite field `K`, the polynomial
+    `X^|K| - X` is the product of all linear factors `X - a`, `a ∈ K`.
+    This is the explicit polynomial form of Fermat's little theorem
+    (`a^|K| = a` for every `a`): each element is a root, with multiplicity one. -/
+theorem fermat_factorization (K : Type*) [Field K] [Fintype K] :
+    (X ^ (Fintype.card K) - X : K[X]) = ∏ a : K, (X - C a) := by
+  classical
+  -- `X^q - X` is monic (its top term `X^q` dominates `X` since `q = |K| ≥ 2`).
+  have hmonic : (X ^ (Fintype.card K) - X : K[X]).Monic := by
+    apply monic_X_pow_sub
+    rw [degree_X]
+    exact_mod_cast Fintype.one_lt_card
+  -- It has degree `q` and exactly `q` roots, namely all of `K`.
+  have hdeg : (X ^ (Fintype.card K) - X : K[X]).natDegree = Fintype.card K :=
+    FiniteField.X_pow_card_sub_X_natDegree_eq K Fintype.one_lt_card
+  have hroots : roots (X ^ (Fintype.card K) - X : K[X]) = Finset.univ.val :=
+    FiniteField.roots_X_pow_card_sub_X K
+  have hcard : Multiset.card (roots (X ^ (Fintype.card K) - X : K[X]))
+      = (X ^ (Fintype.card K) - X : K[X]).natDegree := by
+    rw [hroots, hdeg]; rfl
+  -- A monic polynomial with `deg`-many roots equals `∏ (X - root)`.
+  have hprod := prod_multiset_X_sub_C_of_monic_of_roots_card_eq hmonic hcard
+  rw [hroots] at hprod
+  rw [← hprod]
+  rfl
+
+/-- **Fermat factorization over `𝔽_p`**: for a prime `p`,
+    `X^p - X = ∏_{a : 𝔽_p} (X - a)` in `(ZMod p)[X]`. -/
+theorem fermat_factorization_zmod (p : ℕ) [Fact p.Prime] :
+    (X ^ p - X : (ZMod p)[X]) = ∏ a : ZMod p, (X - C a) := by
+  have h := fermat_factorization (ZMod p)
+  rwa [ZMod.card p] at h
+
+/-!
+## Section II: Frobenius (Artin–Schreier) collapse over `𝔽_p`
+
+In characteristic `p` the Frobenius endomorphism makes `X^p - a` an exact
+`p`-th power. So `X^p - a` has the single root `a` with multiplicity `p` —
+the opposite extreme from the squarefree split of `X^p - X`.
+-/
+
+/-- **Frobenius factorization**: over `𝔽_p`, the binomial `X^p - a` is a perfect
+    `p`-th power of one linear factor: `X^p - a = (X - a)^p`.
+    (`(X - a)^p = X^p - a^p` by the freshman's dream, and `a^p = a` by Fermat.) -/
+theorem frobenius_factorization (p : ℕ) [Fact p.Prime] (a : ZMod p) :
+    (X ^ p - C a : (ZMod p)[X]) = (X - C a) ^ p := by
+  rw [sub_pow_char, ← C_pow, ZMod.pow_card]
+
+/-- Corollary `X^p - 1 = (X - 1)^p` over `𝔽_p`: the binomial whose roots are the
+    `p`-th roots of unity collapses to a single root at `1` in characteristic `p`. -/
+theorem frobenius_one (p : ℕ) [Fact p.Prime] :
+    (X ^ p - 1 : (ZMod p)[X]) = (X - 1) ^ p := by
+  have h := frobenius_factorization p 1
+  simpa using h
+
+/-!
+## Section III: Explicit factorization over `ℚ` and the `ℚ` vs `𝔽_p` contrast
+
+Over a field of characteristic `0`, Fermat factorization fails: `X^q - X` no
+longer has every scalar as a root, so it does not split into linear factors.
+The discriminating witness below is `2`.
+-/
+
+/-- Over `ℚ`, the small case `X^3 - X` happens to split completely into the
+    distinct linear factors `X · (X - 1) · (X + 1)` (roots `0, 1, -1 ∈ ℚ`). -/
+example : (X ^ 3 - X : ℚ[X]) = X * (X - 1) * (X + 1) := by ring
+
+/-- Over `ℚ`, `2` is **not** a root of `X^5 - X`: it evaluates to `30`.
+    Hence `X^5 - X` does not split into linear factors over `ℚ`. -/
+theorem not_root_two_Q : (X ^ 5 - X : ℚ[X]).eval 2 = 30 := by
+  simp only [eval_sub, eval_pow, eval_X]
+  norm_num
+
+/-- Over `𝔽_5`, by contrast, `2` **is** a root of `X^5 - X` (Fermat: `2^5 = 2`).
+    Every element of `𝔽_5` is a root — that is exactly `fermat_factorization_zmod`. -/
+theorem root_two_F5 : (X ^ 5 - X : (ZMod 5)[X]).IsRoot 2 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  simp only [IsRoot.def, eval_sub, eval_pow, eval_X]
+  rw [ZMod.pow_card]
+  ring
+
+end BezoutFactorizationFp

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "ann-bezout-fp-fermat",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 51, "endLine": 73 },
+    "type": "insight",
+    "title": "From Root Multiset to Product Factorization",
+    "content": "Mathlib stops at roots (X^q − X) = univ.val: it knows every field element is a simple root, but never writes the polynomial as a product. The gap is bridged by prod_multiset_X_sub_C_of_monic_of_roots_card_eq, which upgrades 'monic with as many roots as its degree' into the closed product ∏ over the root multiset. Three facts feed it: monicity (monic_X_pow_sub, since deg X = 1 < q = |K|), natDegree = q, and #roots = q. The resulting ∏ over univ.val is definitionally ∏_{a:K} (X − C a).",
+    "mathContext": "$X^{|K|} - X = \\prod_{a \\in K} (X - a)$. Equivalent to Fermat's little theorem $a^{|K|} = a$ for all $a$, read as 'every $a$ is a root'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "FiniteField.roots_X_pow_card_sub_X",
+      "Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq",
+      "Polynomial.monic_X_pow_sub",
+      "FiniteField.X_pow_card_sub_X_natDegree_eq"
+    ],
+    "prerequisites": ["finite fields", "polynomial roots", "monic polynomials"]
+  },
+  {
+    "id": "ann-bezout-fp-frobenius",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 100 },
+    "type": "insight",
+    "title": "The Frobenius Collapse: One Root, Multiplicity p",
+    "content": "Where X^q − X is maximally separable (q distinct roots), X^p − a is maximally inseparable. In characteristic p the freshman's dream sub_pow_char gives (X − a)^p = X^p − a^p; Fermat's a^p = a (ZMod.pow_card) then collapses a^p back to a, so X^p − a = (X − a)^p — a single root a of multiplicity p. The same one-line computation with a = 1 yields X^p − 1 = (X − 1)^p, the p-th-roots-of-unity binomial degenerating in characteristic p.",
+    "mathContext": "$X^p - a = (X - a)^p$ over $\\mathbb{F}_p$, since $(X-a)^p = X^p - a^p$ and $a^p = a$. False in characteristic $0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sub_pow_char",
+      "ZMod.pow_card",
+      "Polynomial.C_pow",
+      "frobenius"
+    ],
+    "prerequisites": ["characteristic p", "Frobenius endomorphism", "Fermat's little theorem"]
+  },
+  {
+    "id": "ann-bezout-fp-contrast",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 128 },
+    "type": "insight",
+    "title": "Where Fermat Factorization Fails: ℚ vs 𝔽_p",
+    "content": "Fermat factorization is a characteristic-p phenomenon. The scalar 2 makes this concrete: over 𝔽_5, ZMod.pow_card forces 2^5 = 2 so 2 is a root of X^5 − X (as is every element); over ℚ, evaluating gives 2^5 − 2 = 30 ≠ 0, so 2 is not a root and the all-linear split cannot survive. The small case X^3 − X = X(X − 1)(X + 1) does split over ℚ — but only because its roots 0, ±1 happen to be rational; for X^5 − X the rational roots are exhausted by 0, ±1 and the rest stay irreducible over ℚ.",
+    "mathContext": "$\\operatorname{eval}_2 (X^5 - X) = 30$ over $\\mathbb{Q}$, but $= 0$ over $\\mathbb{F}_5$. Fermat factorization needs $\\operatorname{char} = p$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.eval",
+      "Polynomial.IsRoot",
+      "ZMod.pow_card"
+    ],
+    "prerequisites": ["polynomial evaluation", "rational vs finite fields"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bezoutIdentityOQ02OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOQ02OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOQ02OQ01OQ01OQ02Data: ProofData = {
+  proof: bezoutIdentityOQ02OQ01OQ01OQ02Proof,
+  annotations: bezoutIdentityOQ02OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+  "title": "Explicit Factorization over Finite Fields and ℚ",
+  "slug": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+  "description": "Makes the abstract polynomial factorization of the parent entry explicit over the two concrete settings it advertises — 𝔽_p and ℚ. Mathlib records the root multiset of X^q − X over a finite field (every element is a simple root) but not the corresponding product factorization; here X^|K| − X = ∏_{a∈K}(X − a) is assembled as a closed equation. The Frobenius collapse X^p − a = (X − a)^p exhibits the opposite extreme — a single root of multiplicity p — and the ℚ witness 2 (a root of X^5 − X over 𝔽_5 but not over ℚ) pins down where Fermat factorization fails in characteristic 0.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean",
+    "tags": [
+      "bezout-identity",
+      "polynomial-factorization",
+      "finite-fields",
+      "fermat-little-theorem",
+      "frobenius",
+      "characteristic-p",
+      "rational-polynomials"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 128,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-verified from Mathlib (depends only on the foundational axioms propext, Classical.choice, Quot.sound).",
+    "originalContributions": [
+      "fermat_factorization: the explicit product factorization X^|K| − X = ∏_{a:K} (X − a) over any finite field K. Mathlib supplies only the root multiset (roots (X^q − X) = univ.val); this packages it as a closed equation via prod_multiset_X_sub_C_of_monic_of_roots_card_eq after establishing monicity and the degree = #roots count.",
+      "fermat_factorization_zmod: the 𝔽_p specialization X^p − X = ∏_{a:ZMod p} (X − a), obtained by rewriting the cardinality |ZMod p| = p.",
+      "frobenius_factorization: over 𝔽_p the binomial X^p − a is a perfect p-th power (X − a)^p — the inseparable extreme of one root with multiplicity p — proved by the freshman's dream sub_pow_char plus Fermat's a^p = a (ZMod.pow_card).",
+      "frobenius_one: the corollary X^p − 1 = (X − 1)^p, the p-th-roots-of-unity binomial collapsing to a single root at 1 in characteristic p.",
+      "not_root_two_Q / root_two_F5: a sharp characteristic contrast — 2 is a root of X^5 − X over 𝔽_5 (Fermat) but evaluates to 30 over ℚ, witnessing that Fermat factorization into linear factors fails over ℚ."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry proves that K[X] is a unique factorization domain and that the abstract Bézout → Euclid → UFD argument transports from ℤ to K[X]. That is an existence statement: factorizations exist and are unique. What it does not give is the factorization in closed form for any concrete polynomial. The two cleanest closed forms in all of algebra are exactly the finite-field ones: X^q − X splits into every linear factor (Fermat's little theorem, read polynomially), and X^p − a is a perfect p-th power in characteristic p (Frobenius / Artin–Schreier). Together they bracket the qualitative spectrum — fully separable versus fully inseparable — that the parent's abstract UFD language cannot see.",
+    "problemStatement": "Over the two settings the parent advertises (ℚ and 𝔽_p), exhibit explicit factorizations rather than abstract existence. (1) Show X^|K| − X = ∏_{a∈K}(X − a) over any finite field K. (2) Show X^p − a = (X − a)^p over 𝔽_p. (3) Quantify the failure of Fermat factorization in characteristic 0 with an explicit witness.",
+    "proofStrategy": "**Fermat factorization.** X^q − X (q = |K|) is monic (its degree-q lead dominates the degree-1 subtrahend since q ≥ 2) and Mathlib's roots_X_pow_card_sub_X gives roots = univ.val, a multiset of card q = natDegree. The lemma prod_multiset_X_sub_C_of_monic_of_roots_card_eq then turns 'monic with deg-many roots' into the product ∏ over the root multiset, which is definitionally ∏_{a:K}(X − a). Specializing K = ZMod p and rewriting |ZMod p| = p yields the 𝔽_p form.\n\n**Frobenius collapse.** In characteristic p the freshman's dream sub_pow_char gives (X − C a)^p = X^p − (C a)^p; pushing the power through C and applying Fermat a^p = a (ZMod.pow_card) collapses (C a)^p back to C a, so X^p − a = (X − a)^p. Setting a = 1 gives X^p − 1 = (X − 1)^p.\n\n**Characteristic contrast.** Evaluating X^5 − X at 2 gives 2^5 − 2 = 30 ≠ 0 over ℚ, so 2 is not a root there; over 𝔽_5, ZMod.pow_card forces 2^5 = 2 and hence 2 is a root — the same scalar separates the two factorization behaviours.",
+    "keyInsights": [
+      "Fermat's little theorem and the explicit factorization of X^q − X are the same statement read two ways: 'every a satisfies a^q = a' is exactly 'every a is a root of X^q − X', and once you know a monic polynomial has as many roots as its degree, the product form is forced.",
+      "X^q − X and X^p − a sit at opposite ends of separability: the first has q distinct simple roots (squarefree), the second has one root of multiplicity p (maximally inseparable). Both factorizations are completely explicit, and both are invisible to the abstract UFD existence statement of the parent.",
+      "Characteristic p is doing all the work in the Frobenius case: sub_pow_char is false in characteristic 0, which is precisely why X^p − a does not collapse over ℚ.",
+      "The witness 2 is not arbitrary — over 𝔽_5 every element is a root of X^5 − X by Fermat, so any non-trivial scalar (here 2) certifies that the all-linear split cannot survive the move to ℚ."
+    ],
+    "prerequisites": [
+      "FiniteField.roots_X_pow_card_sub_X: roots (X^q − X) = univ.val over a finite field",
+      "FiniteField.X_pow_card_sub_X_natDegree_eq: natDegree (X^q − X) = q",
+      "Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq: a monic polynomial with deg-many roots equals ∏ (X − root)",
+      "Polynomial.monic_X_pow_sub: monicity of X^n − p when deg p < n",
+      "sub_pow_char: the freshman's dream (x − y)^p = x^p − y^p in characteristic p",
+      "ZMod.pow_card: Fermat's little theorem a^p = a over 𝔽_p",
+      "Parent bezout-identity-oq-02-oq-01-oq-01 (polynomial UFD) and grandparent bezout-identity-oq-02-oq-01 (FTA from Euclid's lemma)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring contrasting the abstract UFD existence of the parent with the explicit closed-form factorizations proved here. Imports Mathlib and opens the Polynomial namespace."
+    },
+    {
+      "id": "fermat",
+      "title": "Fermat Factorization over a Finite Field",
+      "startLine": 40,
+      "endLine": 78,
+      "summary": "fermat_factorization: X^|K| − X = ∏_{a:K}(X − a). Monicity from monic_X_pow_sub, the root multiset and degree from the FiniteField lemmas, and prod_multiset_X_sub_C_of_monic_of_roots_card_eq to assemble the product. fermat_factorization_zmod specializes to 𝔽_p by rewriting |ZMod p| = p."
+    },
+    {
+      "id": "frobenius",
+      "title": "Frobenius (Artin–Schreier) Collapse over 𝔽_p",
+      "startLine": 80,
+      "endLine": 100,
+      "summary": "frobenius_factorization: X^p − a = (X − a)^p via sub_pow_char and ZMod.pow_card — a single root of multiplicity p. frobenius_one is the corollary X^p − 1 = (X − 1)^p."
+    },
+    {
+      "id": "rational-contrast",
+      "title": "Explicit Factorization over ℚ and the ℚ vs 𝔽_p Contrast",
+      "startLine": 102,
+      "endLine": 128,
+      "summary": "An explicit ℚ split X^3 − X = X(X − 1)(X + 1); not_root_two_Q showing X^5 − X evaluates to 30 at 2 over ℚ; and root_two_F5 showing 2 is a root over 𝔽_5 — the same scalar separating the two factorization behaviours."
+    }
+  ],
+  "conclusion": {
+    "summary": "Turned the parent's abstract polynomial UFD into explicit closed-form factorizations over 𝔽_p and ℚ: the full linear split X^|K| − X = ∏_{a}(X − a) of Fermat's theorem, the perfect-power Frobenius collapse X^p − a = (X − a)^p, and an explicit characteristic-0 obstruction. 128 lines, 6 theorems, 0 sorries, 0 axioms.",
+    "implications": "These two factorizations are the canonical examples of separable and inseparable behaviour and underlie the construction of finite fields (𝔽_{p^n} as the splitting field of X^{p^n} − X) and Artin–Schreier extensions (roots of X^p − X − a). The explicit product form is also the natural target for verified factorization algorithms over 𝔽_p, where X^q − X is the gcd test for the product of all degree-1 factors.",
+    "openQuestions": [
+      "Prove the distinct-degree factorization identity gcd(X^{p^d} − X, f) collects exactly the irreducible factors of f of degree dividing d — the first stage of the Cantor–Zassenhaus / Berlekamp factorization algorithm over 𝔽_p.",
+      "Formalize an explicit irreducibility certificate over ℚ (e.g. X^2 − 2 via the irrationality of √2) to complement the finite-field splitting results with a genuine non-factorization over ℚ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. Proves K[X] is a UFD and that factorizations exist and are unique; this entry supplies the explicit closed-form factorizations the parent leaves abstract, over its advertised settings 𝔽_p and ℚ."
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Grandparent. Derives the Fundamental Theorem of Arithmetic from Euclid's lemma; the Fermat factorization here is the polynomial analogue of 'every prime residue is a root', specialised to 𝔽_p."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BezoutFactorizationFp",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Child of `bezout-identity-oq-02-oq-01-oq-01` (unique factorization in K[X]). The parent proves factorizations *exist and are unique* but never exhibits one in closed form. This entry makes the factorization **explicit** over the two settings the parent advertises — `𝔽_p` and `ℚ` — and brackets the qualitative spectrum from fully separable to fully inseparable.

## Main results (6 theorems, 128 lines, 0 sorries, 0 axioms)

- **`fermat_factorization`** — over any finite field `K`, `X^|K| − X = ∏_{a:K} (X − a)`. Mathlib supplies only the *root multiset* (`roots (X^q − X) = univ.val`); this packages it as a closed equation via `prod_multiset_X_sub_C_of_monic_of_roots_card_eq` after establishing monicity and `deg = #roots`. The separable extreme: every element a simple root.
- **`fermat_factorization_zmod`** — the `𝔽_p` specialization `X^p − X = ∏_{a:ZMod p} (X − a)`.
- **`frobenius_factorization`** — over `𝔽_p`, `X^p − a = (X − a)^p` (freshman's dream `sub_pow_char` + Fermat `ZMod.pow_card`). The inseparable extreme: one root of multiplicity `p`.
- **`frobenius_one`** — corollary `X^p − 1 = (X − 1)^p`.
- **`not_root_two_Q` / `root_two_F5`** — sharp characteristic contrast: `2` is a root of `X^5 − X` over `𝔽_5` but evaluates to `30` over `ℚ`, witnessing where Fermat factorization fails in characteristic 0.

## Verification

Built on host (docker down); `#print axioms` on all 6 theorems lists only `propext, Classical.choice, Quot.sound` — genuinely 0-axiom, 0-sorry. `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)