### PR TITLE
Enrich frobenius-number-oq-01-oq-03-oq-01: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-frob-oq010301-header",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "The open converse, stated generator-agnostically",
+    "content": "The docstring records the open question from the parent frobenius-number-oq-01-oq-03: it proved that the two-generator semigroup ⟨a,b⟩ is symmetric and type one, but left open the converse type one ⟹ symmetric in a generator-free setting. This file proves BOTH directions of the Kunz/Gorenstein equivalence (symmetric ⟺ type one) for an arbitrary numerical semigroup S ⊆ ℕ, and then exhibits ⟨a,b⟩ as an instance to re-derive the parent's result.",
+    "mathContext": "$S$ symmetric $\\iff |\\mathrm{PF}(S)| = 1$ (type one), for any numerical semigroup $S \\subseteq \\mathbb{N}$ with Frobenius number $g$.",
+    "significance": "context",
+    "relatedConcepts": ["numerical semigroup", "Kunz equivalence", "Gorenstein property", "pseudo-Frobenius number"],
+    "prerequisites": ["numerical semigroups", "Frobenius number"]
+  },
+  {
+    "id": "ann-frob-oq010301-defs",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 56, "endLine": 77 },
+    "type": "definition",
+    "title": "Generator-agnostic definitions",
+    "content": "Four definitions encode the theory over a bare set S : Set ℕ, with no generators. IsNumericalSemigroup: 0 ∈ S, additive closure, finite complement, properness. IsFrobeniusNumber S g: g is the largest gap (g ∉ S and everything above g is in S). IsSymmetric S g: the gap/element duality k ∈ S ↔ g − k ∉ S on [0,g]. IsPF S x: x is pseudo-Frobenius — a gap whose every translate by a positive semigroup element re-enters S; the cardinality of {x | IsPF S x} is the type.",
+    "mathContext": "$\\mathrm{IsPF}(S,x) :\\equiv x \\notin S \\wedge \\forall s \\in S,\\ s > 0 \\Rightarrow x + s \\in S$; the type is $|\\{x : \\mathrm{IsPF}(S,x)\\}|$.",
+    "significance": "key",
+    "relatedConcepts": ["pseudo-Frobenius number", "type of a semigroup", "symmetric semigroup", "gaps"],
+    "prerequisites": ["set-theoretic predicates", "additive closure"]
+  },
+  {
+    "id": "ann-frob-oq010301-frob-exist",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 79, "endLine": 118 },
+    "type": "technique",
+    "title": "Frobenius number: unique and existent; g is pseudo-Frobenius",
+    "content": "isFrobeniusNumber_unique uses trichotomy: if g₁ < g₂ then g₂ > g₁ forces g₂ ∈ S, contradicting g₂ being a gap. exists_isFrobeniusNumber realizes g as the Finset maximum of the nonempty finite gap set. frobeniusNumber_isPF shows g itself is pseudo-Frobenius (adding a positive element lands above g, hence in S), and isPF_le_frobeniusNumber shows every pseudo-Frobenius number is ≤ g (nothing above g is a gap).",
+    "mathContext": "$g = \\max(\\mathbb{N} \\setminus S)$ exists and is unique; $g \\in \\mathrm{PF}(S)$ and $\\mathrm{PF}(S) \\subseteq [0, g]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.max'", "trichotomy", "finite gap set", "Set.Finite.toFinset"],
+    "prerequisites": ["finite-set maxima", "well-ordering"]
+  },
+  {
+    "id": "ann-frob-oq010301-gap-dominated",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 120, "endLine": 156 },
+    "type": "insight",
+    "title": "The structural engine: every gap is dominated by a pseudo-Frobenius number",
+    "content": "gap_dominated is the heart of the converse. For a gap x, form T = {y | y ∉ S, y ≥ x, y − x ∈ S} (gaps above x in the order u ⪯ v ⟺ v−u ∈ S); T is finite (subset of the gaps) and nonempty (x ∈ T since x − x = 0 ∈ S). Its Finset maximum m is pseudo-Frobenius: if some m+s (s ∈ S, s>0) were a gap, then (m+s)−x = (m−x)+s ∈ S would place m+s in T, contradicting maximality of m. This realizes the order-theoretic 'every element lies below a maximal one' constructively, with no Zorn/abstract-poset machinery.",
+    "mathContext": "For each gap $x$, $\\exists m \\in \\mathrm{PF}(S)$ with $x \\preceq m$ (i.e. $m - x \\in S$): take $m = \\max\\{y \\notin S : y \\ge x,\\ y - x \\in S\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["maximal elements", "finite poset", "Finset.le_max'", "constructive maximality"],
+    "prerequisites": ["finite-set maxima", "partial order on gaps"]
+  },
+  {
+    "id": "ann-frob-oq010301-forward",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 158, "endLine": 180 },
+    "type": "technique",
+    "title": "Direction 1: symmetric ⟹ type one",
+    "content": "isPF_setOf_eq_of_isSymmetric proves {x | IsPF S x} = {g}. Any pseudo-Frobenius x satisfies x ≤ g; if x < g then symmetry gives g − x ∈ S (positive), so the pseudo-Frobenius closure forces x + (g − x) = g ∈ S — contradicting g being a gap. Hence x = g, and the reverse inclusion is frobeniusNumber_isPF. Taking ncard gives type = 1 (the easy half), generalizing the parent's two-generator pseudoFrobenius_setOf_eq.",
+    "mathContext": "$S$ symmetric $\\Rightarrow \\mathrm{PF}(S) = \\{g\\}$: a smaller pseudo-Frobenius $x$ would force $g = x + (g-x) \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric semigroup", "singleton characterization", "proof by contradiction"],
+    "prerequisites": ["the symmetric duality", "pseudo-Frobenius closure"]
+  },
+  {
+    "id": "ann-frob-oq010301-converse",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 182, "endLine": 212 },
+    "type": "insight",
+    "title": "Direction 2: type one ⟹ symmetric (the open converse)",
+    "content": "isSymmetric_of_isPF_ncard_one is the previously-open direction. From |PF(S)| = 1 and g ∈ PF(S), Set.ncard_eq_one collapses PF(S) to {g}. For k ≤ g: the forward half k ∈ S ⟹ g − k ∉ S is additive closure (else k + (g−k) = g ∈ S). The reverse g − k ∉ S ⟹ k ∈ S is the crux — its contrapositive says a gap k has g − k ∈ S, delivered by gap_dominated: k is dominated by a pseudo-Frobenius number m, which type one forces to equal g, so g − k = m − k ∈ S. Type one is used at exactly this one point.",
+    "mathContext": "$|\\mathrm{PF}(S)| = 1 \\Rightarrow S$ symmetric: gap $k \\preceq m \\in \\mathrm{PF}(S) = \\{g\\}$, so $m = g$ and $g - k \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.ncard_eq_one", "contrapositive", "gap domination", "type invariant"],
+    "prerequisites": ["the domination lemma", "cardinality-one sets"]
+  },
+  {
+    "id": "ann-frob-oq010301-equiv-subsume",
+    "proofId": "frobenius-number-oq-01-oq-03-oq-01",
+    "range": { "startLine": 214, "endLine": 283 },
+    "type": "insight",
+    "title": "The equivalence, and subsuming the two-generator parent",
+    "content": "isSymmetric_iff_isPF_ncard_one packages both directions into the full Kunz equivalence, with isSymmetric_iff_type_one the bundled-hypothesis form. The TwoGenerator section then verifies the framework subsumes the parent: representable_isNumericalSemigroup shows {n | Representable a b n} is a numerical semigroup (closure by adding representations; finite gaps since all gaps ≤ frobeniusNumber a b via Sylvester), representable_isFrobeniusNumber and representable_isSymmetric instantiate the predicates, and representable_type_one re-derives the parent's PF(⟨a,b⟩) = {g} by feeding the parent's symmetry into the general equivalence — a machine-checked subsumption.",
+    "mathContext": "$\\{n : \\mathrm{Representable}\\,a\\,b\\,n\\}$ is a numerical semigroup with $g = ab - a - b$; the general equivalence recovers $\\mathrm{PF}(\\langle a,b\\rangle) = \\{g\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Kunz equivalence", "Sylvester–Frobenius", "two-generator semigroup", "specialization"],
+    "prerequisites": ["the full equivalence", "the parent's symmetry result"]
+  }
+]

--- a/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FrobeniusNumberOQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const frobeniusNumberOQ01OQ03OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const frobeniusNumberOQ01OQ03OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const frobeniusNumberOQ01OQ03OQ01Data: ProofData = {
+  proof: frobeniusNumberOQ01OQ03OQ01Proof,
+  annotations: frobeniusNumberOQ01OQ03OQ01Annotations,
+}

--- a/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-03-oq-01/meta.json
@@ -97,6 +97,64 @@
       "Give the Apéry-set characterisation of the type: type(S) = |{maximal elements of Ap(S, n) under ⪯}| for any nonzero n ∈ S, linking PF(S) to the Apéry set and recovering type one for symmetric semigroups."
     ]
   },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Generator-Agnostic Numerical Semigroups",
+      "startLine": 56,
+      "endLine": 77,
+      "summary": "Four definitions over a bare S : Set ℕ — IsNumericalSemigroup (0 ∈ S, additive closure, finite cofinite complement, properness), IsFrobeniusNumber (largest gap), IsSymmetric (k ∈ S ↔ g − k ∉ S on [0,g]), and IsPF (pseudo-Frobenius: a gap whose positive translates re-enter S, with type = |{x | IsPF S x}|).",
+      "mathContext": "$\\mathrm{IsPF}(S,x) :\\equiv x \\notin S \\wedge \\forall s \\in S,\\ s>0 \\Rightarrow x+s \\in S$; the type is $|\\{x : \\mathrm{IsPF}(S,x)\\}|$."
+    },
+    {
+      "id": "frobenius-exist-unique",
+      "title": "The Frobenius Number: Existence, Uniqueness, and g ∈ PF",
+      "startLine": 79,
+      "endLine": 118,
+      "summary": "isFrobeniusNumber_unique (trichotomy) and exists_isFrobeniusNumber (max of the finite gap set) establish g; frobeniusNumber_isPF shows g is pseudo-Frobenius and isPF_le_frobeniusNumber bounds every pseudo-Frobenius number by g.",
+      "mathContext": "$g = \\max(\\mathbb{N}\\setminus S)$ is unique; $g \\in \\mathrm{PF}(S) \\subseteq [0,g]$."
+    },
+    {
+      "id": "gap-dominated",
+      "title": "Structural Engine: Every Gap Is Dominated by a Pseudo-Frobenius Number",
+      "startLine": 120,
+      "endLine": 156,
+      "summary": "gap_dominated: for a gap x, the finite nonempty set T = {y ∉ S : y ≥ x, y − x ∈ S} has a maximum m, and m is pseudo-Frobenius (a larger m + s would re-enter T, contradicting maximality). Constructive 'every element lies below a maximal one'.",
+      "mathContext": "For each gap $x$, $\\exists m \\in \\mathrm{PF}(S)$ with $m - x \\in S$, taking $m = \\max\\{y \\notin S : y \\ge x,\\ y-x \\in S\\}$."
+    },
+    {
+      "id": "direction-symmetric-to-type-one",
+      "title": "Direction 1: Symmetric ⟹ Type One",
+      "startLine": 158,
+      "endLine": 180,
+      "summary": "isPF_setOf_eq_of_isSymmetric proves {x | IsPF S x} = {g}: a pseudo-Frobenius x < g would, by symmetry, have g − x ∈ S positive, forcing g = x + (g − x) ∈ S, impossible.",
+      "mathContext": "$S$ symmetric $\\Rightarrow \\mathrm{PF}(S) = \\{g\\}$, hence type one."
+    },
+    {
+      "id": "direction-type-one-to-symmetric",
+      "title": "Direction 2: Type One ⟹ Symmetric (the open converse)",
+      "startLine": 182,
+      "endLine": 212,
+      "summary": "isSymmetric_of_isPF_ncard_one: from |PF(S)| = 1 and g ∈ PF(S), PF(S) = {g}; a gap k is dominated (gap_dominated) by a pseudo-Frobenius number forced to be g, so g − k ∈ S. Type one is used at exactly one point.",
+      "mathContext": "$|\\mathrm{PF}(S)| = 1 \\Rightarrow S$ symmetric: gap $k \\preceq m \\in \\{g\\}$, so $g - k \\in S$."
+    },
+    {
+      "id": "equivalence",
+      "title": "The Full Kunz Equivalence",
+      "startLine": 214,
+      "endLine": 229,
+      "summary": "isSymmetric_iff_isPF_ncard_one combines both directions into S symmetric ⟺ |PF(S)| = 1; isSymmetric_iff_type_one is the bundled-IsNumericalSemigroup form.",
+      "mathContext": "$\\mathrm{IsSymmetric}(S,g) \\iff |\\{x : \\mathrm{IsPF}(S,x)\\}| = 1$."
+    },
+    {
+      "id": "two-generator-subsumption",
+      "title": "Subsuming the Parent: the Two-Generator Semigroup ⟨a,b⟩",
+      "startLine": 231,
+      "endLine": 283,
+      "summary": "{n | Representable a b n} is shown to be a numerical semigroup with Frobenius number ab − a − b (representable_isNumericalSemigroup / _isFrobeniusNumber), is symmetric (re-export of the parent), and representable_type_one re-derives PF(⟨a,b⟩) = {g} from the general equivalence — a verified subsumption.",
+      "mathContext": "$\\{n : \\mathrm{Representable}\\,a\\,b\\,n\\}$ is a numerical semigroup, $g = ab-a-b$, $\\mathrm{PF}(\\langle a,b\\rangle) = \\{g\\}$."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "frobenius-number-oq-01-oq-03",


### PR DESCRIPTION
Enrichment pass for **frobenius-number-oq-01-oq-03-oq-01** (Type One ⟹ Symmetric: the Generator-Agnostic Converse for Numerical Semigroups).

The research pipeline shipped this entry with only `meta.json`, so the proof was **unloadable** on the live site ("proof not found"), had no inline annotations, and had an **empty `sections` array**. This PR fixes all three.

## Changes
- **`index.ts`** (new): Vite entry point importing `meta.json`, `annotations.json`, and the raw Lean source.
- **`annotations.json`** (new): 7 substantive annotations covering the open-converse framing, the four generator-agnostic definitions, Frobenius existence/uniqueness (`g ∈ PF`), the `gap_dominated` structural engine, both directions of the Kunz equivalence (symmetric ⟺ type one), and the two-generator subsumption.
- **`meta.json`**: populated the previously-empty `sections` array with 7 sections covering the full 285-line file (definitions, existence/uniqueness, gap domination, each direction, the equivalence, subsumption).

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Ranges align with real Lean constructs — **0 errors for this proofId** in `pnpm annotations:validate`. Status/badge/axiomCount verified accurate (verified / original / 0 axioms; hypotheses passed as ordinary theorem arguments, not structure-encoded — confirmed via #print axioms reporting only propext/Classical.choice/Quot.sound).