### PR TITLE
research(euler-totient-oq-09-oq-02): explicit growth bounds for prime-power totients [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2744,6 +2744,7 @@ import Proofs.EulerTotientOQ07OQ04
 import Proofs.EulerTotientOQ10
 import Proofs.EulerTotientOQ09
 import Proofs.EulerTotientOQ09OQ01
+import Proofs.EulerTotientOQ09OQ02
 import Proofs.FactorRemainderNullstellensatzOQ01
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem

--- a/proofs/Proofs/EulerTotientOQ09OQ02.lean
+++ b/proofs/Proofs/EulerTotientOQ09OQ02.lean
@@ -1,0 +1,123 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+/-
+# Explicit growth bounds for the totient of a prime power
+
+**Open question (`euler-totient-oq-09-oq-02`).** The parent entry
+`euler-totient-oq-09` establishes the power law `φ(nᵏ) = nᵏ⁻¹·φ(n)`, and Mathlib
+records the exact prime-power *value*
+`Nat.totient_prime_pow_succ : φ(p^(n+1)) = pⁿ·(p−1)`.  What neither states is how
+fast a prime-power totient actually *grows* — its density relative to `pᵏ`, its
+multiplicative growth rate, and the two-sided envelope trapping it.  This entry
+collects those quantitative facts.
+
+For a prime `p` and exponent `k = n + 1 ≥ 1` we prove:
+
+* **Exact density** `p · φ(pᵏ) = (p−1) · pᵏ`, i.e. `φ(pᵏ)/pᵏ = 1 − 1/p`
+  (`totient_prime_pow_density`).
+* **Density is independent of the exponent**: the cross-ratio
+  `p^j · φ(pᵏ) = pᵏ · φ(pʲ)` holds for all `j, k ≥ 1`
+  (`totient_density_independent_of_exponent`) — the relative size `1 − 1/p`
+  does not depend on how high the power is.
+* **Geometric growth** with ratio exactly `p`: `φ(p^(k+1)) = p · φ(pᵏ)`
+  (`totient_prime_pow_ratio`).
+* **Two-sided envelope** `pᵏ ≤ 2·φ(pᵏ)` and `φ(pᵏ) < pᵏ`
+  (`two_mul_totient_prime_pow_ge`, `totient_prime_pow_lt`): the totient sits in
+  the band `[pᵏ/2, pᵏ)`.
+* **Base-power floor** `pᵏ⁻¹ ≤ φ(pᵏ)` (`base_pow_le_totient_prime_pow`).
+* **Square-root floor** `pᵏ ≤ φ(pᵏ)²` for `k ≥ 2`
+  (`sq_prime_pow_le_totient_sq`): for genuine prime powers `φ(pᵏ) ≥ √(pᵏ)`,
+  the classical `φ(m) ≥ √m` bound specialised to prime powers.
+
+Everything reduces to `Nat.totient_prime_pow_succ` plus elementary arithmetic, so
+the whole file is machine-checked with 0 sorries and 0 axioms.
+
+`φ` is `Nat.totient` throughout.
+-/
+
+namespace EulerTotientOQ09OQ02
+
+open Nat
+
+variable {p : ℕ}
+
+/-- **Exact density.** For a prime `p` and any exponent `k = n+1 ≥ 1`,
+`p · φ(pᵏ) = (p−1) · pᵏ`; equivalently the density `φ(pᵏ)/pᵏ = (p−1)/p = 1 − 1/p`.
+The right-hand side has no dependence on `n` beyond the leading `pᵏ`, so the
+density is the constant `1 − 1/p` for every exponent. -/
+theorem totient_prime_pow_density (hp : p.Prime) (n : ℕ) :
+    p * φ (p ^ (n + 1)) = (p - 1) * p ^ (n + 1) := by
+  rw [totient_prime_pow_succ hp]
+  ring
+
+/-- **The density is independent of the exponent.** For a prime `p` and exponents
+`j+1, k+1 ≥ 1`, the cross-ratio `p^(j+1) · φ(p^(k+1)) = p^(k+1) · φ(p^(j+1))`
+holds, i.e. `φ(p^(k+1))/p^(k+1) = φ(p^(j+1))/p^(j+1)`. Both sides equal
+`p^(j+k+1)·(p−1)`. The relative size of the totient does not grow with the power. -/
+theorem totient_density_independent_of_exponent (hp : p.Prime) (j k : ℕ) :
+    p ^ (j + 1) * φ (p ^ (k + 1)) = p ^ (k + 1) * φ (p ^ (j + 1)) := by
+  rw [totient_prime_pow_succ hp, totient_prime_pow_succ hp]
+  ring
+
+/-- **Geometric growth with ratio exactly `p`.** `φ(p^(k+1)) = p · φ(pᵏ)`:
+raising the exponent by one multiplies the totient by `p`. -/
+theorem totient_prime_pow_ratio (hp : p.Prime) (n : ℕ) :
+    φ (p ^ (n + 2)) = p * φ (p ^ (n + 1)) := by
+  rw [totient_prime_pow_succ hp, totient_prime_pow_succ hp]
+  ring
+
+/-- **Lower envelope `pᵏ/2`.** `pᵏ ≤ 2·φ(pᵏ)` for any exponent `k = n+1 ≥ 1`.
+Since `φ(pᵏ) = pᵏ⁻¹(p−1)` and `p ≥ 2` forces `p ≤ 2(p−1)`, the totient never drops
+below half of `pᵏ`. -/
+theorem two_mul_totient_prime_pow_ge (hp : p.Prime) (n : ℕ) :
+    p ^ (n + 1) ≤ 2 * φ (p ^ (n + 1)) := by
+  rw [totient_prime_pow_succ hp]
+  have h2 : 2 ≤ p := hp.two_le
+  calc p ^ (n + 1) = p ^ n * p := by ring
+    _ ≤ p ^ n * (2 * (p - 1)) := by gcongr; omega
+    _ = 2 * (p ^ n * (p - 1)) := by ring
+
+/-- **Strict upper envelope.** `φ(pᵏ) < pᵏ` for any exponent `k = n+1 ≥ 1`,
+directly from `Nat.totient_lt` since `pᵏ > 1`. -/
+theorem totient_prime_pow_lt (hp : p.Prime) (n : ℕ) :
+    φ (p ^ (n + 1)) < p ^ (n + 1) :=
+  Nat.totient_lt _ (Nat.one_lt_pow (Nat.succ_ne_zero n) hp.one_lt)
+
+/-- **Base-power floor.** `pᵏ⁻¹ ≤ φ(pᵏ)` for `k = n+1 ≥ 1`: the totient is at least
+the next-lower power, since `φ(pᵏ) = pᵏ⁻¹(p−1)` and `p − 1 ≥ 1`. -/
+theorem base_pow_le_totient_prime_pow (hp : p.Prime) (n : ℕ) :
+    p ^ n ≤ φ (p ^ (n + 1)) := by
+  rw [totient_prime_pow_succ hp]
+  have h2 : 2 ≤ p := hp.two_le
+  calc p ^ n = p ^ n * 1 := (mul_one _).symm
+    _ ≤ p ^ n * (p - 1) := by gcongr; omega
+
+/-- **Square-root floor.** For exponent `k = n+2 ≥ 2`, `pᵏ ≤ φ(pᵏ)²`, i.e.
+`φ(pᵏ) ≥ √(pᵏ)`. This is the classical lower bound `φ(m) ≥ √m` (valid for
+`m ≠ 2, 6`) specialised to genuine prime powers. The proof chains the base-power
+floor `pᵏ⁻¹ ≤ φ(pᵏ)` with `pᵏ ≤ (pᵏ⁻¹)²` (which holds because `k ≤ 2(k−1)` once
+`k ≥ 2`). -/
+theorem sq_prime_pow_le_totient_sq (hp : p.Prime) (n : ℕ) :
+    p ^ (n + 2) ≤ φ (p ^ (n + 2)) ^ 2 := by
+  have h2 : 2 ≤ p := hp.two_le
+  have hbase : p ^ (n + 1) ≤ φ (p ^ (n + 2)) := base_pow_le_totient_prime_pow hp (n + 1)
+  calc p ^ (n + 2)
+      ≤ (p ^ (n + 1)) ^ 2 := by
+        rw [← pow_mul]
+        exact Nat.pow_le_pow_right (by omega) (by omega)
+    _ ≤ φ (p ^ (n + 2)) ^ 2 := Nat.pow_le_pow_left hbase 2
+
+/-- **Numeric sanity check.** `φ(2¹⁰) = 512 = 2⁹·(2−1)`. -/
+theorem totient_two_pow_ten : φ (2 ^ 10) = 512 := by
+  rw [show (10 : ℕ) = 9 + 1 from rfl, totient_prime_pow_succ Nat.prime_two]
+  norm_num
+
+/-- **Numeric sanity check.** `φ(3⁴) = 54 = 3³·(3−1)`, and `54² = 2916 ≥ 81 = 3⁴`
+illustrates the square-root floor. -/
+theorem totient_three_pow_four : φ (3 ^ 4) = 54 := by
+  rw [show (4 : ℕ) = 3 + 1 from rfl, totient_prime_pow_succ (by norm_num)]
+  norm_num
+
+end EulerTotientOQ09OQ02

--- a/src/data/proofs/euler-totient-oq-09-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-09-oq-02/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "totient-oq0902-ann-header",
+    "proofId": "euler-totient-oq-09-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "Growth Bounds for Prime-Power Totients",
+    "content": "Mathlib gives the exact value φ(p^(n+1)) = pⁿ·(p−1) and the parent oq-09 lifts it to the general power law, but neither describes the magnitude of φ(pᵏ). This file collects the quantitative facts: the exact density φ(pᵏ)/pᵏ = 1 − 1/p and its independence from the exponent, geometric growth with ratio p, the two-sided envelope [pᵏ/2, pᵏ), the base-power floor pᵏ⁻¹ ≤ φ(pᵏ), and the square-root floor φ(pᵏ) ≥ √(pᵏ) for k ≥ 2. Imports Totient/Prime.Basic/Tactic; opens Nat so φ = Nat.totient and fixes the prime base p.",
+    "mathContext": "$\\varphi(p^k) = p^{k-1}(p-1), \\qquad \\tfrac{\\varphi(p^k)}{p^k} = 1 - \\tfrac1p, \\qquad \\tfrac{p^k}{2} \\le \\varphi(p^k) < p^k.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's totient",
+      "prime powers",
+      "growth bounds",
+      "density"
+    ],
+    "prerequisites": [
+      "totient function",
+      "prime-power value",
+      "natural-number inequalities"
+    ]
+  },
+  {
+    "id": "totient-oq0902-ann-density",
+    "proofId": "euler-totient-oq-09-oq-02",
+    "range": {
+      "startLine": 46,
+      "endLine": 62
+    },
+    "type": "lemma",
+    "title": "Exact Density, Independent of the Exponent",
+    "content": "`totient_prime_pow_density` states p·φ(pᵏ) = (p−1)·pᵏ — the cross-multiplied form of φ(pᵏ)/pᵏ = 1 − 1/p — and `totient_density_independent_of_exponent` states the cross-ratio p^(j+1)·φ(p^(k+1)) = p^(k+1)·φ(p^(j+1)), so the relative size 1 − 1/p is the same at every exponent (both sides equal p^(j+k+1)·(p−1)). After substituting `Nat.totient_prime_pow_succ` each goal is a polynomial identity in p and pⁿ with (p−1) treated as an atom, closed by `ring` (which normalises pⁿ·p = pⁿ⁺¹).",
+    "mathContext": "$p\\,\\varphi(p^k) = (p-1)\\,p^k; \\qquad p^{\\,j}\\,\\varphi(p^k) = p^k\\,\\varphi(p^{\\,j}).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "density",
+      "exponent independence",
+      "ring normalisation"
+    ],
+    "prerequisites": [
+      "prime-power totient value",
+      "ring tactic over ℕ"
+    ]
+  },
+  {
+    "id": "totient-oq0902-ann-growth-envelope",
+    "proofId": "euler-totient-oq-09-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 110
+    },
+    "type": "lemma",
+    "title": "Geometric Growth and the Two-Sided Envelope",
+    "content": "`totient_prime_pow_ratio`: φ(p^(k+1)) = p·φ(pᵏ), so each extra factor of p multiplies the totient by exactly p. `two_mul_totient_prime_pow_ge`: pᵏ ≤ 2·φ(pᵏ), the lower half-bound — after the rewrite, pⁿ·p ≤ pⁿ·(2(p−1)) reduces by `gcongr` to p ≤ 2(p−1), discharged by `omega` from p ≥ 2. `totient_prime_pow_lt`: φ(pᵏ) < pᵏ, immediate from `Nat.totient_lt` once `Nat.one_lt_pow` supplies pᵏ > 1. `base_pow_le_totient_prime_pow`: pᵏ⁻¹ ≤ φ(pᵏ), since p − 1 ≥ 1. `sq_prime_pow_le_totient_sq`: for k ≥ 2, pᵏ ≤ φ(pᵏ)² — chain pᵏ ≤ (pᵏ⁻¹)² = p^(2(k−1)) (`Nat.pow_le_pow_right`, k ≤ 2(k−1)) with the base-power floor squared (`Nat.pow_le_pow_left`), giving φ(pᵏ) ≥ √(pᵏ).",
+    "mathContext": "$\\varphi(p^{k+1}) = p\\,\\varphi(p^k); \\qquad \\tfrac{p^k}{2} \\le \\varphi(p^k) < p^k; \\qquad p^{k-1} \\le \\varphi(p^k); \\qquad p^k \\le \\varphi(p^k)^2\\ (k \\ge 2).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "geometric growth",
+      "two-sided bound",
+      "square-root lower bound",
+      "pow monotonicity"
+    ],
+    "prerequisites": [
+      "prime-power totient value",
+      "Nat.totient_lt",
+      "monotonicity of pow",
+      "gcongr / omega"
+    ]
+  },
+  {
+    "id": "totient-oq0902-ann-numeric",
+    "proofId": "euler-totient-oq-09-oq-02",
+    "range": {
+      "startLine": 112,
+      "endLine": 123
+    },
+    "type": "example",
+    "title": "Numeric Sanity Checks",
+    "content": "`totient_two_pow_ten`: φ(2¹⁰) = 512 = 2⁹·(2−1), confirming the geometric form on the prime 2. `totient_three_pow_four`: φ(3⁴) = 54 = 3³·(3−1); since 54² = 2916 ≥ 81 = 3⁴ this also illustrates the square-root floor. Each proof rewrites the literal exponent as n+1, applies `Nat.totient_prime_pow_succ`, and finishes with `norm_num`.",
+    "mathContext": "$\\varphi(2^{10}) = 512, \\qquad \\varphi(3^4) = 54.$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "numeric verification",
+      "prime-power totient value"
+    ],
+    "prerequisites": [
+      "prime-power totient value",
+      "norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-09-oq-02/index.ts
+++ b/src/data/proofs/euler-totient-oq-09-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ09OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOQ09OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOQ09OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOQ09OQ02Data: ProofData = {
+  proof: eulerTotientOQ09OQ02Proof,
+  annotations: eulerTotientOQ09OQ02Annotations,
+}

--- a/src/data/proofs/euler-totient-oq-09-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-09-oq-02/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "euler-totient-oq-09-oq-02",
+  "title": "Explicit Growth Bounds for the Totient of a Prime Power",
+  "slug": "euler-totient-oq-09-oq-02",
+  "description": "Quantifies how fast a prime-power totient grows, a question left open by the parent `euler-totient-oq-09` (which proved the power law φ(nᵏ) = nᵏ⁻¹·φ(n)) and not addressed by Mathlib's exact value `Nat.totient_prime_pow_succ : φ(p^(n+1)) = pⁿ·(p−1)`. For a prime p and exponent k = n+1 ≥ 1 the entry collects: the exact density p·φ(pᵏ) = (p−1)·pᵏ (so φ(pᵏ)/pᵏ = 1 − 1/p); the fact that this density is independent of the exponent, in the cross-ratio form p^j·φ(pᵏ) = pᵏ·φ(pʲ); geometric growth with ratio exactly p, φ(p^(k+1)) = p·φ(pᵏ); the two-sided envelope pᵏ ≤ 2·φ(pᵏ) and φ(pᵏ) < pᵏ trapping the totient in the band [pᵏ/2, pᵏ); the base-power floor pᵏ⁻¹ ≤ φ(pᵏ); and the square-root floor pᵏ ≤ φ(pᵏ)² for k ≥ 2 (i.e. φ(pᵏ) ≥ √(pᵏ), the classical φ(m) ≥ √m bound specialised to genuine prime powers). Everything reduces to `Nat.totient_prime_pow_succ` plus elementary arithmetic. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Euler); growth bounds for prime-power totients formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ09OQ02.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "prime-powers",
+      "growth-bounds",
+      "inequalities",
+      "multiplicative-functions",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 123,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (no native_decide). Every result reduces to Mathlib's exact prime-power value `Nat.totient_prime_pow_succ` together with elementary `ℕ` arithmetic (`ring`, `gcongr`, `omega`, monotonicity of `pow`), and the strict upper bound uses `Nat.totient_lt`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_prime_pow_succ",
+        "description": "`p.Prime → φ(p^(n+1)) = pⁿ·(p−1)`. The exact value of a prime-power totient; every growth bound in this entry is obtained by substituting this closed form and bounding the elementary expression pⁿ·(p−1).",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_lt",
+        "description": "`1 < n → φ(n) < n`. Gives the strict upper envelope φ(pᵏ) < pᵏ directly, once pᵏ > 1 is supplied by `Nat.one_lt_pow`.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.one_lt_pow",
+        "description": "`n ≠ 0 → 1 < m → 1 < m^n`. Certifies pᵏ > 1 for k ≥ 1 and prime p, the hypothesis of `Nat.totient_lt`.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_right",
+        "description": "`1 ≤ b → m ≤ n → b^m ≤ b^n`. Monotonicity of the power in the exponent, used in the square-root floor to compare pᵏ with p^(2(k−1)).",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_left",
+        "description": "`a ≤ b → a^k ≤ b^k`. Monotonicity of the power in the base, used to square the base-power floor pᵏ⁻¹ ≤ φ(pᵏ) into the square-root floor.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "`totient_prime_pow_density`: the exact density p·φ(pᵏ) = (p−1)·pᵏ for k = n+1 ≥ 1, i.e. φ(pᵏ)/pᵏ = 1 − 1/p — the integer (cross-multiplied) form of the relative size of a prime-power totient.",
+      "`totient_density_independent_of_exponent`: the cross-ratio p^(j+1)·φ(p^(k+1)) = p^(k+1)·φ(p^(j+1)), expressing that the density φ(pᵏ)/pᵏ = 1 − 1/p does not depend on the exponent k — both sides equal p^(j+k+1)·(p−1).",
+      "`totient_prime_pow_ratio`: geometric growth with ratio exactly p, φ(p^(k+1)) = p·φ(pᵏ); raising the exponent by one multiplies the totient by p.",
+      "`two_mul_totient_prime_pow_ge` and `totient_prime_pow_lt`: the two-sided envelope pᵏ ≤ 2·φ(pᵏ) and φ(pᵏ) < pᵏ, trapping the totient in the band [pᵏ/2, pᵏ).",
+      "`base_pow_le_totient_prime_pow`: the base-power floor pᵏ⁻¹ ≤ φ(pᵏ).",
+      "`sq_prime_pow_le_totient_sq`: the square-root floor pᵏ ≤ φ(pᵏ)² for k ≥ 2, i.e. φ(pᵏ) ≥ √(pᵏ) — the classical lower bound φ(m) ≥ √m (m ≠ 2, 6) specialised to genuine prime powers, derived by squaring the base-power floor.",
+      "Numeric checks `totient_two_pow_ten` (φ(2¹⁰) = 512) and `totient_three_pow_four` (φ(3⁴) = 54)."
+    ],
+    "prerequisites": [
+      "Euler's totient function φ(n) = |(ℤ/nℤ)ˣ|",
+      "The exact prime-power value φ(p^(n+1)) = pⁿ·(p−1)",
+      "Monotonicity of natural-number powers in base and exponent",
+      "Elementary inequality reasoning over ℕ"
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "euler-totient-oq-09",
+        "relationship": "Parent: oq-09 proved the power law φ(n^k) = n^(k−1)·φ(n) for a general base. This entry zooms in on the prime-power case and quantifies its growth — density, growth ratio, and a two-sided envelope — which the parent's exact value left implicit."
+      },
+      {
+        "id": "euler-totient-oq-09-oq-01",
+        "relationship": "Sibling: oq-09-oq-01 settled the general (non-coprime) product law and the sharp prime-support characterization of clean scaling. This entry is the complementary quantitative leaf, bounding the size of φ on prime powers rather than characterizing equalities."
+      },
+      {
+        "id": "euler-totient",
+        "relationship": "Ancestor: the gallery family on Euler's totient and his generalization of Fermat's little theorem; this entry adds the basic growth estimates for prime-power totients."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 123,
+    "path": "Proofs/EulerTotientOQ09OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 9
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Euler's totient φ(n) = |(ℤ/nℤ)ˣ| has the classical product formula φ(n) = n·∏_{p∣n}(1 − 1/p), from which the ratio φ(n)/n depends only on the prime support of n. On a prime power pᵏ the support is the single prime p, so the density collapses to the constant 1 − 1/p — independent of the exponent — and the totient is φ(pᵏ) = pᵏ⁻¹(p−1). Mathlib records this exact value (`Nat.totient_prime_pow_succ`) and the parent gallery entry oq-09 lifts it to the general power law φ(nᵏ) = nᵏ⁻¹·φ(n). What neither states is how the value behaves as a magnitude: its density relative to pᵏ, its multiplicative growth rate as the exponent increases, and the elementary two-sided bounds that pin it down. These are exactly the estimates one reaches for when totients of prime-power moduli appear in counting and density arguments.",
+    "problemStatement": "**Open Question (euler-totient-oq-09-oq-02):** give explicit growth bounds for φ(pᵏ) — its density relative to pᵏ, its growth ratio as k increases, and a two-sided envelope — beyond the bare exact value.",
+    "text": "For a prime p and exponent k = n+1 ≥ 1: p·φ(pᵏ) = (p−1)·pᵏ (density 1 − 1/p, independent of k); φ(p^(k+1)) = p·φ(pᵏ) (geometric growth, ratio p); pᵏ ≤ 2·φ(pᵏ) and φ(pᵏ) < pᵏ (band [pᵏ/2, pᵏ)); pᵏ⁻¹ ≤ φ(pᵏ); and for k ≥ 2, pᵏ ≤ φ(pᵏ)² (φ(pᵏ) ≥ √(pᵏ)).",
+    "proofStrategy": "Each result substitutes Mathlib's exact value `Nat.totient_prime_pow_succ : φ(p^(n+1)) = pⁿ·(p−1)` and then bounds the elementary expression pⁿ·(p−1). The two density identities (`totient_prime_pow_density`, `totient_density_independent_of_exponent`) and the growth ratio (`totient_prime_pow_ratio`) are closed by `ring` after the rewrite, treating (p−1) as an atom; the exponent algebra pⁿ·p = pⁿ⁺¹ is handled by `ring`. The lower envelope `two_mul_totient_prime_pow_ge` factors pⁿ·p ≤ pⁿ·(2(p−1)) by `gcongr`, reducing to p ≤ 2(p−1), which `omega` discharges from p ≥ 2. The upper envelope `totient_prime_pow_lt` is `Nat.totient_lt` applied to pᵏ > 1 (`Nat.one_lt_pow`). The base-power floor `base_pow_le_totient_prime_pow` factors pⁿ = pⁿ·1 ≤ pⁿ·(p−1) by `gcongr` (p − 1 ≥ 1). The square-root floor `sq_prime_pow_le_totient_sq` chains pᵏ ≤ (pᵏ⁻¹)² = p^(2(k−1)) — by `Nat.pow_le_pow_right` since k ≤ 2(k−1) for k ≥ 2 — with the base-power floor squared via `Nat.pow_le_pow_left`. The numeric checks rewrite the literal exponent as n+1 and finish with `norm_num`.",
+    "keyInsights": [
+      "**The density is a constant, independent of the exponent.** Because φ(pᵏ)/pᵏ = 1 − 1/p for every k ≥ 1, raising the power does not dilute the totient relative to its modulus — captured cleanly in ℕ by the cross-ratio p^j·φ(pᵏ) = pᵏ·φ(pʲ).",
+      "**Growth is purely geometric.** Each extra factor of p in the modulus multiplies the totient by exactly p: φ(p^(k+1)) = p·φ(pᵏ). The totient of a prime power is pᵏ⁻¹(p−1), a geometric sequence in k with ratio p and leading coefficient (p−1).",
+      "**A clean two-sided envelope.** Since p ≥ 2 gives p ≤ 2(p−1), the totient never drops below half the modulus, and `Nat.totient_lt` keeps it strictly below: pᵏ/2 ≤ φ(pᵏ) < pᵏ. The lower half-bound follows immediately from the single prime factor of pᵏ — the density 1 − 1/p ≥ 1/2.",
+      "**√n for genuine powers.** For k ≥ 2 the base-power floor pᵏ⁻¹ ≤ φ(pᵏ) squares to pᵏ ≤ φ(pᵏ)², recovering the classical φ(m) ≥ √m (m ≠ 2, 6) on prime powers without invoking the general theorem."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",
+      "The exact prime-power value φ(p^(n+1)) = pⁿ·(p−1)",
+      "Monotonicity of pow in base and exponent over ℕ",
+      "Elementary inequalities and `omega`/`gcongr` reasoning"
+    ]
+  },
+  "conclusion": {
+    "summary": "For a prime p and exponent k = n+1 ≥ 1: the density is exactly 1 − 1/p (p·φ(pᵏ) = (p−1)·pᵏ) and is independent of k (p^j·φ(pᵏ) = pᵏ·φ(pʲ)); growth is geometric with ratio p (φ(p^(k+1)) = p·φ(pᵏ)); the totient is trapped in [pᵏ/2, pᵏ) (pᵏ ≤ 2·φ(pᵏ) < 2·pᵏ); it is bounded below by the next-lower power (pᵏ⁻¹ ≤ φ(pᵏ)); and for k ≥ 2 it exceeds √(pᵏ) (pᵏ ≤ φ(pᵏ)²). 9 theorems, 123 lines, 0 sorries, 0 axioms (no native_decide), all reduced to `Nat.totient_prime_pow_succ`.",
+    "implications": "These are the workhorse estimates for prime-power totients: the constant density 1 − 1/p and the geometric growth ratio p describe the magnitude exactly, while the envelope [pᵏ/2, pᵏ) and the √(pᵏ) floor give the quick bounds used in density and counting arguments. Together with the parent's power law and the sibling's product characterization they round out the gallery's quantitative picture of φ on prime powers and their products.",
+    "openQuestions": [
+      "Aggregate to general n: from φ(pᵏ)/pᵏ = 1 − 1/p derive the multiplicative bounds on φ(n)/n = ∏_{p∣n}(1 − 1/p), e.g. the classical φ(n) ≥ n/(eᵞ log log n + …) lower envelope, and the sharp constant for φ(n)/n over n with a bounded number of prime factors.",
+      "Sharpen the √ floor: characterize exactly which prime powers satisfy φ(pᵏ) ≥ pᵏ⁻¹·c for a given c < p−1, and locate the prime powers minimizing φ(pᵏ)/pᵏ among all moduli below a bound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the goal — explicit growth bounds for φ(pᵏ) beyond the exact value — and listing the seven quantitative facts proved. Imports `Mathlib.Data.Nat.Totient`, `Mathlib.Data.Nat.Prime.Basic`, `Mathlib.Tactic`; opens namespace `EulerTotientOQ09OQ02` and `Nat` so `φ` denotes `Nat.totient`; fixes a variable `p : ℕ` (the prime base)."
+    },
+    {
+      "id": "density",
+      "title": "Exact Density and Its Independence from the Exponent",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "`totient_prime_pow_density`: p·φ(pᵏ) = (p−1)·pᵏ, the cross-multiplied form of φ(pᵏ)/pᵏ = 1 − 1/p. `totient_density_independent_of_exponent`: the cross-ratio p^(j+1)·φ(p^(k+1)) = p^(k+1)·φ(p^(j+1)), showing the density 1 − 1/p is the same for every exponent (both sides equal p^(j+k+1)·(p−1)). Both close by `ring` after substituting `Nat.totient_prime_pow_succ`."
+    },
+    {
+      "id": "growth-envelope",
+      "title": "Geometric Growth and the Two-Sided Envelope",
+      "startLine": 64,
+      "endLine": 110,
+      "summary": "`totient_prime_pow_ratio`: φ(p^(k+1)) = p·φ(pᵏ), geometric growth with ratio exactly p. `two_mul_totient_prime_pow_ge`: pᵏ ≤ 2·φ(pᵏ) (lower half-bound, from p ≤ 2(p−1) via `gcongr`/`omega`). `totient_prime_pow_lt`: φ(pᵏ) < pᵏ (strict upper bound, `Nat.totient_lt` with pᵏ > 1). `base_pow_le_totient_prime_pow`: pᵏ⁻¹ ≤ φ(pᵏ) (since p − 1 ≥ 1). `sq_prime_pow_le_totient_sq`: pᵏ ≤ φ(pᵏ)² for k ≥ 2, i.e. φ(pᵏ) ≥ √(pᵏ), by squaring the base-power floor (`Nat.pow_le_pow_left`) and comparing exponents (`Nat.pow_le_pow_right`)."
+    },
+    {
+      "id": "numeric-checks",
+      "title": "Numeric Sanity Checks",
+      "startLine": 112,
+      "endLine": 123,
+      "summary": "`totient_two_pow_ten`: φ(2¹⁰) = 512 = 2⁹·(2−1). `totient_three_pow_four`: φ(3⁴) = 54 = 3³·(3−1) (with 54² = 2916 ≥ 81 = 3⁴ illustrating the square-root floor). Each rewrites the literal exponent as n+1, applies `Nat.totient_prime_pow_succ`, and finishes with `norm_num`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-09",
+      "relationship": "parent",
+      "description": "oq-09 proved the power law φ(n^k) = n^(k−1)·φ(n) for a general base via its exact prime-power value. This entry specialises to prime powers and quantifies the growth the parent left implicit: density, growth ratio, and a two-sided envelope."
+    },
+    {
+      "targetId": "euler-totient-oq-09-oq-01",
+      "relationship": "related",
+      "description": "The sibling leaf settled the non-coprime product law and the sharp prime-support characterization of clean scaling; this entry is the complementary quantitative result, bounding the magnitude of φ on prime powers."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "The ancestor gallery family develops Euler's totient and his generalization of Fermat's little theorem; this entry contributes the basic growth estimates for prime-power totients."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds gallery entry **euler-totient-oq-09-oq-02** — *Explicit Growth Bounds for the Totient of a Prime Power* — answering an open question of the parent `euler-totient-oq-09` (power law φ(nᵏ)=nᵏ⁻¹·φ(n)). Mathlib records the exact *value* `Nat.totient_prime_pow_succ : φ(p^(n+1)) = pⁿ·(p−1)` but none of the growth/magnitude bounds; this entry supplies them.

For a prime `p` and exponent `k = n+1 ≥ 1`:

| Result | Statement |
|---|---|
| Exact density | `p·φ(pᵏ) = (p−1)·pᵏ`  (φ(pᵏ)/pᵏ = 1 − 1/p) |
| Density independent of exponent | `p^j·φ(pᵏ) = pᵏ·φ(pʲ)` |
| Geometric growth | `φ(p^(k+1)) = p·φ(pᵏ)`  (ratio exactly p) |
| Lower envelope | `pᵏ ≤ 2·φ(pᵏ)`  (band [pᵏ/2, pᵏ)) |
| Upper envelope | `φ(pᵏ) < pᵏ` |
| Base-power floor | `pᵏ⁻¹ ≤ φ(pᵏ)` |
| Square-root floor (k≥2) | `pᵏ ≤ φ(pᵏ)²`  (φ(pᵏ) ≥ √(pᵏ)) |

Plus numeric checks φ(2¹⁰)=512, φ(3⁴)=54.

## Verification
- **9 theorems, 123 lines, 0 sorries, 0 axioms** (no `native_decide`).
- `#print axioms` on all 9 theorems lists only `propext, Classical.choice, Quot.sound`.
- Everything reduces to `Nat.totient_prime_pow_succ` plus elementary arithmetic (`ring`, `gcongr`, `omega`, pow monotonicity) and `Nat.totient_lt`.
- Type-checks via `lake env lean Proofs/EulerTotientOQ09OQ02.lean`.
- Annotations validate (no errors for this proof id); meta.json / annotations.json mirror the sibling oq-09-oq-01 schema.

## Files
- `proofs/Proofs/EulerTotientOQ09OQ02.lean` (new)
- `proofs/Proofs.lean` (import line)
- `src/data/proofs/euler-totient-oq-09-oq-02/{meta.json,annotations.json,index.ts}` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)