### PR TITLE
audit: 4 recent merges — 3 verified clean, 1 build-registration gap (#29086)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21547,6 +21547,30 @@
       "lastAudited": "2026-06-24T13:54:24Z",
       "result": "clean",
       "issues": []
+    },
+    "arsinh-log-formula-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:20:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "friendship-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:20:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "szemeredi-counting-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:20:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:20:07Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 4 genuinely-on-main unaudited entries this cycle (the other 4 entries reported by `find-targets.ts` are untracked working-copy spills from concurrent researcher agents — not on `origin/main`, skipped).

### Clean ✓ (verified, 0-axiom/0-sorry, no True stubs, properly imported)
- `arsinh-log-formula-oq-01-oq-02-oq-01` — arcosh antiderivative via FTC
- `friendship-theorem-oq-01-oq-01` — SRG integrality dichotomy (eigenvalue data disclosed as hypotheses in `assumptions`, not structure-encoded axioms; 0 axiomCount correct)
- `szemeredi-counting-oq-01` — title properly qualified ("Quantitative Triangle Removal: ν ≤ ρ ≤ τ"); does **not** overclaim Szemerédi's theorem

### Issues-found
- `frobenius-number-oq-01-oq-03-oq-01` — proof is sound (0 sorry/0 axiom) but its Lean module is **not imported by `Proofs.lean`**, so it's excluded from the default `lake build Proofs` target. Same gap affects `fibonacci-identities-oq-05` and `lagrange-theorem-oq-09`. Filed **#29086** for the Mechanic.

Tracker-only change: `src/data/proofs/audit-tracker.json` (+24 lines, 4 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)