### PR TITLE
Enrich arcosh antiderivative: add index.ts + annotations

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "arcosh-radicand-pos",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 38, "endLine": 40 },
+    "type": "lemma",
+    "title": "Positivity of the Radicand for t > 1",
+    "content": "The technical gatekeeper for the whole development: for t > 1 the radicand t² − 1 is strictly positive, hence √(t² − 1) > 0. This single fact is what licenses every later step — HasDerivAt.sqrt needs the radicand nonzero, HasDerivAt.log needs the argument positive, and the integrand 1/√(t² − 1) is only defined (and continuous) away from the singularity at t = 1. nlinarith discharges 0 < x² − 1 from 1 < x.",
+    "mathContext": "$x > 1 \\;\\Longrightarrow\\; \\sqrt{x^2 - 1} > 0$",
+    "significance": "supporting",
+    "prerequisites": ["Real.sqrt_pos", "nlinarith"],
+    "relatedConcepts": ["domain of definition", "branch point", "nonnegativity of square roots"]
+  },
+  {
+    "id": "arcosh-hasderivat",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 42, "endLine": 79 },
+    "type": "theorem",
+    "title": "The arcosh Derivative, Built From Scratch",
+    "content": "The headline result and the genuinely new content: HasDerivAt Real.arcosh (1/√(t²−1)) t for t > 1. Mathlib defines Real.arcosh and its inverse facts but provides NO derivative lemma (unlike Real.hasDerivAt_arsinh on the sinh side), so the derivative is constructed from the definitional logarithmic form arcosh t = log(t + √(t²−1)) by stacking three chain-rule steps: hasDerivAt_pow for d/dt(t²−1) = 2t, HasDerivAt.sqrt for d/dt√(t²−1) = 2t/(2√(t²−1)), and HasDerivAt.log for the outer logarithm. The function fed to .log is definitionally arcosh, so no rewriting of the head symbol is needed.",
+    "mathContext": "$\\frac{d}{dt}\\operatorname{arcosh} t = \\frac{1}{\\sqrt{t^2-1}}, \\quad t > 1$",
+    "significance": "critical",
+    "prerequisites": ["chain rule (HasDerivAt.comp)", "HasDerivAt.sqrt", "HasDerivAt.log", "hasDerivAt_pow", "Real.arcosh logarithmic form"],
+    "relatedConcepts": ["inverse hyperbolic functions", "logarithmic differentiation", "Mathlib gap-filling", "Real.hasDerivAt_arsinh (sibling)"]
+  },
+  {
+    "id": "arcosh-deriv-collapse",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 78 },
+    "type": "insight",
+    "title": "The Quotient Collapses Without √² = t² − 1",
+    "content": "The chain rule produces a messy quotient (1 + 2t/(2√(t²−1)))/(t + √(t²−1)), which must simplify to 1/√(t²−1). Remarkably this is a pure algebraic identity in the symbol s := √(t²−1): clearing denominators reduces it to (s + t)·s = s·(t + s), true by ring alone. The identity √(t²−1)² = t²−1 is NEVER invoked — the numerator t + √(t²−1) already coincides with the denominator after field_simp. This is why a single field_simp; ring closes the step.",
+    "mathContext": "$\\frac{1 + \\frac{2t}{2s}}{t + s} = \\frac{1}{s}, \\quad s := \\sqrt{t^2-1} \\;\\;(\\text{by } (s+t)s = s(t+s))$",
+    "significance": "key",
+    "prerequisites": ["field_simp", "ring", "treating √ as an opaque variable"],
+    "relatedConcepts": ["algebraic simplification", "logarithmic derivative cancellation", "opaque-symbol reasoning"]
+  },
+  {
+    "id": "arcosh-deriv-form",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 81, "endLine": 84 },
+    "type": "theorem",
+    "title": "deriv-Form Restatement",
+    "content": "deriv_arcosh repackages the HasDerivAt fact as a plain deriv equation deriv Real.arcosh t = 1/√(t²−1), via (hasDerivAt_arcosh hx).deriv. The HasDerivAt form is the strong (existence-plus-value) statement needed for the FTC; the deriv form is the convenient calculus-table restatement that quotes the derivative value directly.",
+    "mathContext": "$\\operatorname{arcosh}'(t) = \\dfrac{1}{\\sqrt{t^2-1}}, \\quad t > 1$",
+    "significance": "supporting",
+    "prerequisites": ["HasDerivAt.deriv", "deriv vs HasDerivAt"],
+    "relatedConcepts": ["derivative as a function", "calculus tables"]
+  },
+  {
+    "id": "arcosh-continuity",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 100 },
+    "type": "lemma",
+    "title": "Continuity and Interval-Integrability of the Integrand",
+    "content": "continuousOn_integrand shows t ↦ 1/√(t²−1) is continuous on uIcc a b ⊂ (1,∞): ContinuousOn.div with constant numerator, the composite √∘(·²−1) for the denominator, and the crucial nonvanishing supplied by sqrt_sq_sub_one_pos at each point of the interval. intervalIntegrable_integrand then upgrades continuity to interval-integrability via ContinuousOn.intervalIntegrable — exactly the hypothesis the FTC requires. The interval must avoid t = 1, where the integrand blows up.",
+    "mathContext": "$t \\mapsto \\frac{1}{\\sqrt{t^2-1}} \\text{ continuous on } [a,b] \\subset (1,\\infty)$",
+    "significance": "key",
+    "prerequisites": ["ContinuousOn.div", "ContinuousOn.intervalIntegrable", "Set.uIcc membership"],
+    "relatedConcepts": ["interval integrability", "improper integral singularity", "continuity of compositions"]
+  },
+  {
+    "id": "arcosh-ftc",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 102, "endLine": 114 },
+    "type": "theorem",
+    "title": "Fundamental Theorem of Calculus for arcosh",
+    "content": "The definite-integral incarnation of the antiderivative: ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b. intervalIntegral.integral_eq_sub_of_hasDerivAt consumes two hypotheses — that arcosh has the right derivative at every point of [a,b] (from hasDerivAt_arcosh, with 1 < x extracted from interval membership) and that the integrand is interval-integrable (the previous lemma). This is the precise meaning of '∫ 1/√(t²−1) dt = arcosh t + C' on (1,∞).",
+    "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b - \\operatorname{arcosh} a, \\quad 1 < a,b$",
+    "significance": "critical",
+    "prerequisites": ["Fundamental Theorem of Calculus", "intervalIntegral.integral_eq_sub_of_hasDerivAt", "antiderivatives"],
+    "relatedConcepts": ["FTC second form", "definite integral evaluation", "Newton–Leibniz formula"]
+  },
+  {
+    "id": "arcosh-log-form",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 116, "endLine": 124 },
+    "type": "theorem",
+    "title": "Logarithmic Closed Form of the Integral",
+    "content": "integral_eq_log_sub_log unfolds arcosh to its definitional logarithm, expressing the integral as log(b + √(b²−1)) − log(a + √(a²−1)). After the FTC rewrite the equation closes by rfl, because arcosh is definitionally that logarithm — a clean illustration of how Mathlib's definitional unfolding gives the elementary closed form for free.",
+    "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{t^2-1}} = \\log\\!\\big(b + \\sqrt{b^2-1}\\big) - \\log\\!\\big(a + \\sqrt{a^2-1}\\big)$",
+    "significance": "supporting",
+    "prerequisites": ["definitional unfolding (rfl)", "Real.arcosh definition"],
+    "relatedConcepts": ["closed-form antiderivative", "logarithmic form of inverse hyperbolic functions"]
+  },
+  {
+    "id": "arcosh-345-evals",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 126, "endLine": 140 },
+    "type": "lemma",
+    "title": "Pythagorean (3,4,5) Evaluations: arcosh(5/3) = log 3, arcosh(5/4) = log 2",
+    "content": "The (3,4,5) right triangle rationalises the surd: √((5/3)²−1) = √(16/9) = 4/3 and √((5/4)²−1) = √(9/16) = 3/4. Hence arcosh(5/3) = log(5/3 + 4/3) = log 3 and arcosh(5/4) = log(5/4 + 3/4) = log 2. Real.sqrt_sq turns each perfect-square radicand into its rational root after norm_num verifies the square, and the show tactic exposes arcosh's definitional logarithm so the final value rewrites cleanly.",
+    "mathContext": "$\\operatorname{arcosh}\\tfrac{5}{3} = \\log 3, \\qquad \\operatorname{arcosh}\\tfrac{5}{4} = \\log 2$",
+    "significance": "key",
+    "prerequisites": ["Real.sqrt_sq", "norm_num", "Pythagorean triples"],
+    "relatedConcepts": ["(3,4,5) triple", "rationalising surds", "concrete special-function values"]
+  },
+  {
+    "id": "arcosh-concrete-integral",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+    "range": { "startLine": 142, "endLine": 150 },
+    "type": "theorem",
+    "title": "Concrete Evaluation: ∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2)",
+    "content": "The capstone tying the calculus back to the parent's algebra. Applying the FTC over [5/4, 5/3] gives arcosh(5/3) − arcosh(5/4) = log 3 − log 2, and Real.log_div collapses the difference of logs to log(3/2). A fully closed-form, axiom-free numeric value for a nontrivial definite integral of an inverse-hyperbolic surd.",
+    "mathContext": "$\\int_{5/4}^{5/3} \\frac{dt}{\\sqrt{t^2-1}} = \\log 3 - \\log 2 = \\log\\tfrac{3}{2}$",
+    "significance": "key",
+    "prerequisites": ["Real.log_div", "FTC application", "the (3,4,5) evaluations"],
+    "relatedConcepts": ["definite integral value", "log subtraction law", "worked example"]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arsinhLogFormulaOq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arsinhLogFormulaOq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arsinhLogFormulaOq01Oq02Oq01Data: ProofData = {
+  proof: arsinhLogFormulaOq01Oq02Oq01Proof,
+  annotations: arsinhLogFormulaOq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "arsinh-log-formula-oq-01-oq-02-oq-01",
   "slug": "arsinh-log-formula-oq-01-oq-02-oq-01",
+  "description": "The arcosh antiderivative ∫ 1/√(t²−1) dt = arcosh t + C, proved on the domain t > 1 and packaged via the Fundamental Theorem of Calculus as ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b. Because Mathlib defines Real.arcosh and its inverse facts but supplies no derivative lemma (in contrast to the sinh side, where Real.hasDerivAt_arsinh exists), the derivative HasDerivAt Real.arcosh (1/√(t²−1)) t is built from scratch by differentiating the logarithmic form log(t + √(t²−1)) through three chain-rule steps (pow, sqrt, log); the resulting quotient collapses to 1/√(t²−1) by a pure algebraic field_simp; ring with no appeal to √² = t²−1. Includes the logarithmic closed form and the concrete (3,4,5)-triple value ∫_{5/4}^{5/3} 1/√(t²−1) dt = log(3/2). Verified, 0 axioms, 0 sorries, 10 theorems.",
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-02-oq-01` (The arcosh Antiderivative ∫ 1/√(t²−1) dt = arcosh t + C).

## Gaps fixed
- **Missing `index.ts`** — no Vite entry point, so the page rendered as *'proof not found'* on the live site. Added it (Lean source `ArsinhLogFormulaOQ01OQ02OQ01.lean`).
- **Missing `annotations.json`** — added **9 inline annotations** covering all five sections.
- **Missing top-level `description`** in meta.json — added.

## Annotation coverage
Each carries `mathContext` (LaTeX), `significance`, `prerequisites`, `relatedConcepts`:
1. `sqrt_sq_sub_one_pos` — positivity of the radicand for t > 1 (the gatekeeper)
2. `hasDerivAt_arcosh` — the from-scratch arcosh derivative (Mathlib has none)
3. The quotient-collapse insight: simplifies by `field_simp; ring` **without** √² = t²−1
4. `deriv_arcosh` — deriv-form restatement
5. continuity + interval-integrability of the integrand
6. `integral_one_div_sqrt_sq_sub_one` — FTC evaluation
7. `integral_eq_log_sub_log` — logarithmic closed form
8. the (3,4,5)-triple evaluations arcosh(5/3)=log 3, arcosh(5/4)=log 2
9. concrete value ∫_{5/4}^{5/3} = log(3/2)

meta.json was already rich (overview, keyInsights, conclusion, cross-references) and is otherwise intact. Axiom status verified accurate: `verified`, 0 axioms, 0 sorries.

`pnpm build` passes.