### PR TITLE
Fix: register 3 orphaned verified proofs in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2820,6 +2820,7 @@ import Proofs.FibonacciIdentitiesOQ03OQ03
 import Proofs.FibonacciIdentitiesOQ04
 import Proofs.FibonacciIdentitiesOQ04OQ01
 import Proofs.FibonacciIdentitiesOQ04OQ03
+import Proofs.FibonacciIdentitiesOQ05
 import Proofs.FiveColorTheorem
 import Proofs.FodorPressingDown
 import Proofs.FourColorTheorem
@@ -2868,6 +2869,7 @@ import Proofs.FrobeniusEndomorphismOQ01OQ02
 import Proofs.FrobeniusEndomorphismOQ02
 import Proofs.FrobeniusNumber
 import Proofs.FrobeniusNumberOQ01
+import Proofs.FrobeniusNumberOQ01OQ03OQ01
 import Proofs.FrobeniusNumberOQ02
 import Proofs.FrobeniusNumberOQ03
 import Proofs.FrobeniusNumberOQ04
@@ -3210,6 +3212,7 @@ import Proofs.LagrangeTheoremOQ05
 import Proofs.LagrangeTheoremOQ06
 import Proofs.LagrangeTheoremOQ07
 import Proofs.LagrangeTheoremOQ07OQ02
+import Proofs.LagrangeTheoremOQ09
 import Proofs.LawOfCosines
 import Proofs.LawOfCosinesOQ01OQ01
 import Proofs.LawOfCosinesOQ01OQ01OQ01


### PR DESCRIPTION
## Fix

Add the 3 missing `import` lines to `proofs/Proofs.lean` so the orphaned-but-verified entries are reachable from the default `lake build Proofs` target (and Docker CI), closing the build-registration gap flagged by the auditor.

## Evidence

**Before**: these tracked files were not imported (directly or transitively) by `Proofs.lean`, so they were excluded from the build graph — not continuously machine-checked despite `status: verified`:
- `Proofs.FibonacciIdentitiesOQ05` (`fibonacci-identities-oq-05`)
- `Proofs.LagrangeTheoremOQ09` (`lagrange-theorem-oq-09`)
- `Proofs.FrobeniusNumberOQ01OQ03OQ01` (`frobenius-number-oq-01-oq-03-oq-01`)

**After**: each import added alphabetically alongside its siblings. All three verified to compile cleanly against pinned Mathlib v4.26.0 via host `lake env lean` (Docker unavailable this cycle):

```
FibonacciIdentitiesOQ05      -> RC=0 errors=0
LagrangeTheoremOQ09          -> RC=0 errors=0
FrobeniusNumberOQ01OQ03OQ01  -> RC=0 errors=0
```

No regression — the registration now guards against silent future drift. Diff is exactly 3 lines.

Closes #29086

---
Automated fix by lean-mechanic agent.