### PR TITLE
Enrich fibonacci-identities-oq-04-oq-03: populate annotations

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-fib-oq0403-header",
+    "proofId": "fibonacci-identities-oq-04-oq-03",
+    "range": { "startLine": 4, "endLine": 33 },
+    "type": "context",
+    "title": "Lifting Gelin–Cesàro to the Gibonacci family",
+    "content": "The docstring recalls that the Fibonacci Gelin–Cesàro identity F(n−2)F(n−1)F(n+1)F(n+2) − Fₙ⁴ = −1 was proved in the parent as a difference of squares (Cassini × Catalan r=2). This entry lifts it to the two-parameter Gibonacci/Horadam family G(n) = a·Fₙ + b·Fₙ₋₁ with discriminant μ = a²−ab−b², where the constant becomes −μ². The odd-in-n sign factor (−1)^|n| that would obstruct a naive generalisation is annihilated by the difference of squares. Specialises to Fibonacci (μ=1, −1) and Lucas (μ=−5, −25).",
+    "mathContext": "$G(n-2)G(n-1)G(n+1)G(n+2) - G(n)^4 = -\\mu^2$, with $\\mu = a^2 - ab - b^2$ over $\\mathbb{Z}$.",
+    "significance": "context",
+    "relatedConcepts": ["Gelin–Cesàro identity", "Horadam sequences", "Cassini identity", "discriminant μ"],
+    "prerequisites": ["Fibonacci/Lucas numbers", "the parent Gibonacci identities"]
+  },
+  {
+    "id": "ann-fib-oq0403-statement",
+    "proofId": "fibonacci-identities-oq-04-oq-03",
+    "range": { "startLine": 47, "endLine": 49 },
+    "type": "concept",
+    "title": "The Gibonacci Gelin–Cesàro identity, stated",
+    "content": "gib_gelin_cesaro asserts the degree-four product identity for every Gibonacci sequence and every integer index n (the carrier gib a b n = a·Fₙ + b·Fₙ₋₁ is two-sided over Int.fib, so the identity holds at negative indices too). The right-hand side −μ² is index-independent: the discriminant μ = a²−ab−b² is the same quantity that governs the parent's Cassini, Catalan, and Vajda identities, now appearing squared.",
+    "mathContext": "$\\forall a,b,n \\in \\mathbb{Z}:\\ G(n-2)G(n-1)G(n+1)G(n+2) - G(n)^4 = -(a^2-ab-b^2)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["degree-four identity", "characteristic discriminant", "two-sided integer sequence"],
+    "prerequisites": ["Gibonacci carrier", "polynomial identities over ℤ"]
+  },
+  {
+    "id": "ann-fib-oq0403-proof",
+    "proofId": "fibonacci-identities-oq-04-oq-03",
+    "range": { "startLine": 47, "endLine": 83 },
+    "type": "technique",
+    "title": "Difference of squares: how the sign cancels",
+    "content": "The proof needs no new induction — only two instances of the parent's infrastructure. Recentring gib_cassini at base n−1 (with sign_flip turning (−1)^|n−1| into −(−1)^|n|) gives G(n−1)G(n+1) = G(n)² + (−1)^|n|·μ. The gib_catalan r=2 instance at base n−2 (using Int.fib 2 = 1 and two sign-flips so (−1)^|n−2| = (−1)^|n|) gives G(n−2)G(n+2) = G(n)² − (−1)^|n|·μ. These two factors are symmetric about G(n)²; multiplying them is (X − s)(X + s) = X² − s² with s = (−1)^|n|·μ. Since ((−1)^|n|)² = 1 the sign squares away (he2), leaving G(n)⁴ − μ², closed by a calc and one linear_combination.",
+    "mathContext": "$(G(n)^2 - (-1)^{|n|}\\mu)(G(n)^2 + (-1)^{|n|}\\mu) = G(n)^4 - \\mu^2$, since $((-1)^{|n|})^2 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["difference of squares", "gib_cassini", "gib_catalan", "sign_flip", "linear_combination"],
+    "prerequisites": ["recentring index identities", "parity of (−1)^|n|", "Catalan r=2 instance"]
+  },
+  {
+    "id": "ann-fib-oq0403-fib",
+    "proofId": "fibonacci-identities-oq-04-oq-03",
+    "range": { "startLine": 87, "endLine": 91 },
+    "type": "insight",
+    "title": "Fibonacci specialisation (μ = 1)",
+    "content": "fib_gelin_cesaro recovers the classical Fibonacci Gelin–Cesàro identity by instantiating the seed (a,b) = (1,0), for which gib 1 0 = Int.fib and μ = 1² − 1·0 − 0² = 1, so −μ² = −1. A single simpa on the master result closes it — confirming the Gibonacci generalisation is structural, not ad hoc.",
+    "mathContext": "$(a,b)=(1,0):\\ \\mu=1,\\ F_{n-2}F_{n-1}F_{n+1}F_{n+2} - F_n^4 = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "specialization", "μ = 1"],
+    "prerequisites": ["the master identity", "gib 1 0 = Int.fib"]
+  },
+  {
+    "id": "ann-fib-oq0403-lucas",
+    "proofId": "fibonacci-identities-oq-04-oq-03",
+    "range": { "startLine": 95, "endLine": 100 },
+    "type": "insight",
+    "title": "Lucas specialisation (μ = −5, constant −25)",
+    "content": "lucas_gelin_cesaro instantiates the seed (a,b) = (1,2): lucas = gib 1 2 and μ = 1² − 1·2 − 2² = 1 − 2 − 4 = −5, so −μ² = −25. The Lucas discriminant 5 — the discriminant of x² − x − 1 — reappears squared in the constant. Obtained by norm_num + simpa on the master result.",
+    "mathContext": "$(a,b)=(1,2):\\ \\mu=-5,\\ L_{n-2}L_{n-1}L_{n+1}L_{n+2} - L_n^4 = -25$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "discriminant of x²−x−1", "μ = −5"],
+    "prerequisites": ["the master identity", "lucas = gib 1 2"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for **fibonacci-identities-oq-04-oq-03** (The Gibonacci Gelin–Cesàro Identity).

This entry already had `index.ts` and a rich `meta.json` (overview, keyInsights, sections, conclusion, references), but its `annotations.json` was an empty `[]` — no inline annotations on the proof page.

## Changes
- **`annotations.json`**: filled with 5 substantive annotations:
  - the Gelin–Cesàro → Gibonacci lift framing (header)
  - the degree-four identity statement (constant −μ², μ = a²−ab−b²)
  - the difference-of-squares proof: how the (−1)^|n| sign cancels via the recentred Cassini factor × the Catalan r=2 factor
  - the Fibonacci specialisation (μ = 1, constant −1)
  - the Lucas specialisation (μ = −5, constant −25)

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Ranges land on real Lean constructs — **0 errors for this proofId** in `pnpm annotations:validate`. Status/badge/axiomCount untouched and verified accurate (verified / original / 0 axioms; single `decide` is kernel, no native_decide).