### PR TITLE
Enrich bernoulli-inequality-oq-01-oq-01-oq-02: add index.ts + annotations

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-bern-oq010102-header",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 50 },
+    "type": "context",
+    "title": "Abstracting the parent's hard-case size argument",
+    "content": "The docstring records the open question: the parent proved strict Bernoulli 1 + n·a < (1+a)ⁿ on the full weak domain −2 ≤ a, but over the hard subrange −2 ≤ a ≤ −1 the positive-factor induction collapses (1+a ≤ 0) and the proof fell back to an ad hoc size argument — |1+a| ≤ 1 traps (1+a)ⁿ ≥ −1 while the line 1 + n·a sinks below −1. This file extracts that mechanism as a Bernoulli-independent 'line escapes a bounded power' theory, recovering the parent's hard range as a one-line corollary.",
+    "mathContext": "Every power of a magnitude-$\\le 1$ base lies in $[-1,1]$, so any line of nonzero slope eventually escapes the band and crosses every such power.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli's inequality", "bounded power", "reusable lemma extraction", "Archimedean escape"],
+    "prerequisites": ["the parent strict-Bernoulli entry", "absolute value bounds"]
+  },
+  {
+    "id": "ann-bern-oq010102-trap",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 68 },
+    "type": "concept",
+    "title": "The trap: powers of a magnitude-≤1 base stay in [−1,1]",
+    "content": "abs_pow_le_one uses abs_pow (|xⁿ| = |x|ⁿ) and pow_le_one₀ to show |x| ≤ 1 ⟹ |xⁿ| ≤ 1. Splitting that absolute-value bound with abs_le gives the two walls neg_one_le_pow (−1 ≤ xⁿ) and pow_le_one (xⁿ ≤ 1). Crucially this needs only the magnitude bound — no sign hypothesis on x — so it applies to oscillating bases.",
+    "mathContext": "$|x| \\le 1 \\Rightarrow |x^n| = |x|^n \\le 1 \\Rightarrow -1 \\le x^n \\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["abs_pow", "pow_le_one₀", "abs_le", "bounded band"],
+    "prerequisites": ["absolute value of a power", "splitting |y| ≤ c"]
+  },
+  {
+    "id": "ann-bern-oq010102-engine",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 70, "endLine": 81 },
+    "type": "technique",
+    "title": "The escape engine: below −1 loses, above 1 wins",
+    "content": "lt_pow_of_lt_neg_one chains c < −1 ≤ xⁿ by transitivity: anything below the band is strictly beaten by every power — exactly the parent's hand-rolled size argument, now a one-line standalone lemma. pow_lt_of_one_lt is its mirror: xⁿ ≤ 1 < c, so anything above the band strictly beats every power. These are the reusable drop-in tools the open question asked for.",
+    "mathContext": "$|x| \\le 1 \\wedge c < -1 \\Rightarrow c < x^n$;\\quad $|x| \\le 1 \\wedge 1 < c \\Rightarrow x^n < c$.",
+    "significance": "key",
+    "relatedConcepts": ["transitivity", "comparison lemma", "the trap walls"],
+    "prerequisites": ["the trap", "order transitivity"]
+  },
+  {
+    "id": "ann-bern-oq010102-asymptotic",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 83, "endLine": 113 },
+    "type": "insight",
+    "title": "Asymptotic escape with an explicit Archimedean threshold",
+    "content": "eventually_line_lt_pow promotes the engine to an asymptotic statement: a negative-slope line b + n·s eventually drops strictly below every power xⁿ. The threshold is built explicitly — exists_nat_gt picks N > (b+1)/(−s), then div_lt_iff₀ turns N ≤ n into b + 1 < n·(−s), i.e. b + n·s < −1, and the engine finishes. eventually_pow_lt_line is the symmetric positive-slope version with threshold N > (1−b)/s. The qualitative 'eventually' becomes a usable crossover bound.",
+    "mathContext": "$s<0 \\Rightarrow \\exists N,\\forall n\\ge N,\\ b+ns < x^n$ at $N > (b+1)/(-s)$; $s>0 \\Rightarrow \\exists N,\\forall n\\ge N,\\ x^n < b+ns$.",
+    "significance": "key",
+    "relatedConcepts": ["Archimedean property", "exists_nat_gt", "div_lt_iff₀", "explicit threshold"],
+    "prerequisites": ["the escape engine", "real division inequalities"]
+  },
+  {
+    "id": "ann-bern-oq010102-oscillating",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "insight",
+    "title": "Oscillating base x = −1/2: beyond the parent's reach",
+    "content": "example_oscillating_base instantiates the negative-slope statement at x = −1/2, b = 10, s = −1: the powers (−1/2)ⁿ alternate in sign yet stay trapped in [−1,1], so the descending line 10 − n still escapes below them. This is exactly the regime the parent's positive-factor induction cannot handle — boundedness, not monotonicity, is what drives the escape, so dropping the sign hypothesis on the base is the real generalisation.",
+    "mathContext": "$\\exists N,\\forall n\\ge N,\\ 10 - n < (-1/2)^n$, despite $(-1/2)^n$ oscillating in sign.",
+    "significance": "supporting",
+    "relatedConcepts": ["oscillating powers", "boundedness vs monotonicity", "negative base"],
+    "prerequisites": ["eventually_line_lt_pow"]
+  },
+  {
+    "id": "ann-bern-oq010102-bernoulli",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+    "range": { "startLine": 127, "endLine": 142 },
+    "type": "insight",
+    "title": "Bernoulli's hard negative range as one engine call",
+    "content": "one_add_mul_lt_pow_neg recovers strict Bernoulli on −2 ≤ a ≤ −1 (n ≥ 3): setting x = 1 + a gives |1+a| ≤ 1, and since n·a ≤ 3a ≤ −3 (mul_le_mul_of_nonpos_right, as a ≤ 0) the line 1 + n·a < −1, so lt_pow_of_lt_neg_one closes it in a single call. The parent's bespoke negative-range argument collapses to this corollary — confirming the abstraction reduces the original estimate.",
+    "mathContext": "$-2 \\le a \\le -1,\\ n \\ge 3 \\Rightarrow 1 + na \\le 1 - n < -1 \\le (1+a)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["strict Bernoulli", "mul_le_mul_of_nonpos_right", "corollary reduction"],
+    "prerequisites": ["the escape engine", "sign reversal under nonpositive multiplication"]
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BernoulliInequalityOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bernoulliInequalityOQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bernoulliInequalityOQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bernoulliInequalityOQ01OQ01OQ02Data: ProofData = {
+  proof: bernoulliInequalityOQ01OQ01OQ02Proof,
+  annotations: bernoulliInequalityOQ01OQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for **bernoulli-inequality-oq-01-oq-01-oq-02** (The Line-Escapes-a-Bounded-Power Lemma).

The research pipeline shipped this entry with only `meta.json`, so the proof was **unloadable** on the live site ("proof not found") and had no inline annotations.

## Changes
- **`index.ts`** (new): Vite entry point importing `meta.json`, `annotations.json`, and the raw Lean source.
- **`annotations.json`** (new): 6 substantive annotations covering the abstraction of the parent's hard-case size argument, the [−1,1] trap (`abs_pow_le_one`/`neg_one_le_pow`/`pow_le_one`), the escape engine (`lt_pow_of_lt_neg_one` / `pow_lt_of_one_lt`), the asymptotic escape with explicit Archimedean thresholds, the oscillating base x = −1/2, and Bernoulli's hard negative range recovered in one engine call.

Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Ranges land on real Lean constructs (`/-!` markers and theorem lines) — **0 errors for this proofId** in `pnpm annotations:validate`. Existing rich `meta.json` (overview, sections, conclusion, references) left intact; status/badge/axiomCount verified accurate (verified / original / 0 axioms).