### PR TITLE
research(arsinh-log-formula-oq-01-oq-01-oq-01): catenary arc-length & antiderivative of √(1+t²)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -231,6 +231,7 @@ import Proofs.ArithmeticSeriesOQ04OQ01
 import Proofs.ArithmeticSeriesOQ04OQ03
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.ArsinhLogFormulaOQ01OQ01
+import Proofs.ArsinhLogFormulaOQ01OQ01OQ01
 import Proofs.ArsinhLogFormulaOQ01OQ02OQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01

--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean
@@ -1,0 +1,143 @@
+/-
+# Catenary arc-length and the antiderivative of `√(1 + t²)`
+
+Research: arsinh-log-formula-oq-01-oq-01-oq-01
+Parent:   arsinh-log-formula-oq-01-oq-01 (antiderivative of `1/√(1 + t²)` is `arsinh`)
+
+The parent file proved the calculus capstone for the integrand `1/√(1 + t²)`:
+that `arsinh` is its antiderivative and the resulting FTC evaluations.  This
+child supplies the *companion* arc-length facts, which run the same machinery on
+the conjugate integrand `√(1 + t²)`:
+
+* `hasDerivAt_sqrtAntideriv` — the genuinely new derivative computation
+  `d/dt [½(t·√(1 + t²) + arsinh t)] = √(1 + t²)`.  Mathlib has the `arsinh`
+  derivative but supplies *no* antiderivative for `√(1 + t²)`, so this is built
+  from scratch (product + chain rule on `√`, plus `Real.hasDerivAt_arsinh`).
+* `integral_sqrt_one_add_sq` — the FTC evaluation
+  `∫_a^b √(1 + t²) dt = ½(b·√(1+b²) + arsinh b) − ½(a·√(1+a²) + arsinh a)`,
+  obtained through the hyperbolic substitution `t = sinh u` whose antiderivative
+  is the closed form above.
+* `integral_sqrt_one_add_sq_zero_to` — the `∫_0^b` normalisation
+  `= ½(b·√(1+b²) + arsinh b)`.
+* `sqrt_one_add_sinh_sq` — the Pythagorean simplification
+  `√(1 + sinh²x) = cosh x` that identifies the catenary arc-length integrand.
+* `integral_cosh_zero_to` — `∫_0^b cosh x dx = sinh b`.
+* `catenary_arclength` — the headline geometric statement: the arc length of the
+  catenary `y = cosh x` over `[0, b]` is `sinh b`, since
+  `√(1 + (cosh)'²) = √(1 + sinh²) = cosh`.
+* `integral_sqrt_one_add_sq_zero_to_one` — the concrete value
+  `∫_0^1 √(1 + t²) dt = ½(√2 + arsinh 1)`.
+
+All results are `0`-axiom and machine-checked.
+-/
+import Mathlib
+
+namespace ArsinhLogFormulaOQ01OQ01OQ01
+
+open Real intervalIntegral MeasureTheory
+
+/-- The radicand `1 + t²` is strictly positive, hence `√(1 + t²) > 0`. -/
+theorem sqrt_one_add_sq_pos (t : ℝ) : 0 < Real.sqrt (1 + t ^ 2) :=
+  Real.sqrt_pos.mpr (by positivity)
+
+/-- The square of `√(1 + t²)` is `1 + t²` (the radicand is nonnegative). -/
+theorem sq_sqrt_one_add_sq (t : ℝ) : Real.sqrt (1 + t ^ 2) ^ 2 = 1 + t ^ 2 :=
+  Real.sq_sqrt (by positivity)
+
+/-- **The new antiderivative.** `F(t) = ½(t·√(1 + t²) + arsinh t)` is an
+antiderivative of `√(1 + t²)`:
+
+`d/dt [½(t·√(1 + t²) + arsinh t)] = √(1 + t²)`.
+
+Mathlib provides `Real.hasDerivAt_arsinh` (the derivative of `arsinh`) but no
+antiderivative for the conjugate integrand `√(1 + t²)`; we build it here from the
+product rule, the chain rule for `√`, and the `arsinh` derivative.  The algebra
+collapses because `(t² + 1)/√(1+t²) = √(1+t²)`, doubling the leading term. -/
+theorem hasDerivAt_sqrtAntideriv (t : ℝ) :
+    HasDerivAt (fun x : ℝ => (x * Real.sqrt (1 + x ^ 2) + Real.arsinh x) / 2)
+      (Real.sqrt (1 + t ^ 2)) t := by
+  have h1pos : (0 : ℝ) < 1 + t ^ 2 := by positivity
+  have hne : (1 + t ^ 2) ≠ 0 := ne_of_gt h1pos
+  -- d/dt (1 + t²) = 2t
+  have hquad : HasDerivAt (fun x : ℝ => 1 + x ^ 2) (2 * t) t := by
+    simpa using (hasDerivAt_pow 2 t).const_add (1 : ℝ)
+  -- d/dt √(1 + t²) = (2t) / (2·√(1 + t²))
+  have hsqrt : HasDerivAt (fun x : ℝ => Real.sqrt (1 + x ^ 2))
+      (2 * t / (2 * Real.sqrt (1 + t ^ 2))) t := hquad.sqrt hne
+  -- product rule for t·√(1 + t²)
+  have hprod : HasDerivAt (fun x : ℝ => x * Real.sqrt (1 + x ^ 2))
+      (1 * Real.sqrt (1 + t ^ 2) + t * (2 * t / (2 * Real.sqrt (1 + t ^ 2)))) t :=
+    (hasDerivAt_id t).mul hsqrt
+  -- add the arsinh term, then divide by 2
+  have hsum := (hprod.add (Real.hasDerivAt_arsinh t)).div_const 2
+  convert hsum using 1
+  -- value equality: √(1+t²) = ((1·√ + t·(2t/(2√))) + (√)⁻¹)/2
+  have hs : Real.sqrt (1 + t ^ 2) ^ 2 = 1 + t ^ 2 := sq_sqrt_one_add_sq t
+  have hpos : 0 < Real.sqrt (1 + t ^ 2) := sqrt_one_add_sq_pos t
+  field_simp
+  nlinarith [hs, hpos]
+
+/-- The integrand `t ↦ √(1 + t²)` is continuous everywhere. -/
+theorem continuous_sqrt_integrand :
+    Continuous (fun t : ℝ => Real.sqrt (1 + t ^ 2)) := by
+  fun_prop
+
+/-- The integrand `t ↦ √(1 + t²)` is interval-integrable on every `[a, b]`. -/
+theorem intervalIntegrable_sqrt_integrand (a b : ℝ) :
+    IntervalIntegrable (fun t : ℝ => Real.sqrt (1 + t ^ 2)) volume a b :=
+  continuous_sqrt_integrand.intervalIntegrable a b
+
+/-- **FTC for `√(1 + t²)`.** Definite integral over `[a, b]` via the antiderivative
+`F(t) = ½(t·√(1+t²) + arsinh t)`:
+
+`∫_a^b √(1 + t²) dt = ½(b·√(1+b²) + arsinh b) − ½(a·√(1+a²) + arsinh a)`. -/
+theorem integral_sqrt_one_add_sq (a b : ℝ) :
+    ∫ t in a..b, Real.sqrt (1 + t ^ 2)
+      = (b * Real.sqrt (1 + b ^ 2) + Real.arsinh b) / 2
+        - (a * Real.sqrt (1 + a ^ 2) + Real.arsinh a) / 2 := by
+  rw [intervalIntegral.integral_eq_sub_of_hasDerivAt
+        (fun t _ => hasDerivAt_sqrtAntideriv t)
+        (intervalIntegrable_sqrt_integrand a b)]
+
+/-- The `∫_0^b` normalisation (the antiderivative with `C = 0`):
+`∫_0^b √(1 + t²) dt = ½(b·√(1+b²) + arsinh b)`. -/
+theorem integral_sqrt_one_add_sq_zero_to (b : ℝ) :
+    ∫ t in (0 : ℝ)..b, Real.sqrt (1 + t ^ 2)
+      = (b * Real.sqrt (1 + b ^ 2) + Real.arsinh b) / 2 := by
+  rw [integral_sqrt_one_add_sq]
+  simp [Real.arsinh_zero]
+
+/-- **Pythagorean simplification of the catenary integrand.**
+`√(1 + sinh²x) = cosh x`, since `cosh²x = 1 + sinh²x` and `cosh x > 0`. -/
+theorem sqrt_one_add_sinh_sq (x : ℝ) :
+    Real.sqrt (1 + Real.sinh x ^ 2) = Real.cosh x := by
+  have h : 1 + Real.sinh x ^ 2 = Real.cosh x ^ 2 := by
+    have := Real.cosh_sq x
+    linarith
+  rw [h, Real.sqrt_sq (Real.cosh_pos x).le]
+
+/-- `∫_0^b cosh x dx = sinh b`, the FTC evaluation for the catenary integrand. -/
+theorem integral_cosh_zero_to (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, Real.cosh x = Real.sinh b := by
+  rw [intervalIntegral.integral_eq_sub_of_hasDerivAt
+        (fun x _ => Real.hasDerivAt_sinh x)
+        (Real.continuous_cosh.intervalIntegrable 0 b),
+      Real.sinh_zero, sub_zero]
+
+/-- **Catenary arc length.** The arc length of the catenary `y = cosh x` over
+`[0, b]` is `sinh b`.
+
+The arc-length integrand is `√(1 + (cosh)'²) = √(1 + sinh²x) = cosh x`, so the
+length integral collapses to `∫_0^b cosh x dx = sinh b`. -/
+theorem catenary_arclength (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, Real.sqrt (1 + Real.sinh x ^ 2) = Real.sinh b := by
+  simp_rw [sqrt_one_add_sinh_sq]
+  exact integral_cosh_zero_to b
+
+/-- Concrete value: `∫_0^1 √(1 + t²) dt = ½(√2 + arsinh 1)`. -/
+theorem integral_sqrt_one_add_sq_zero_to_one :
+    ∫ t in (0 : ℝ)..1, Real.sqrt (1 + t ^ 2) = (Real.sqrt 2 + Real.arsinh 1) / 2 := by
+  rw [integral_sqrt_one_add_sq_zero_to]
+  norm_num
+
+end ArsinhLogFormulaOQ01OQ01OQ01

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "arsinh-log-formula-oq-01-oq-01-oq-01",
+  "slug": "arsinh-log-formula-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "ArsinhLogFormulaOQ01OQ01OQ01",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Catenary Arc-Length and the Antiderivative of √(1 + t²)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "hyperbolic-functions",
+      "inverse-hyperbolic",
+      "arsinh",
+      "catenary",
+      "arc-length",
+      "integration",
+      "fundamental-theorem-of-calculus",
+      "antiderivative",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 143,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasDerivAt_sqrtAntideriv: the genuinely new derivative computation d/dt [½(t·√(1+t²) + arsinh t)] = √(1+t²). Mathlib supplies the arsinh derivative (Real.hasDerivAt_arsinh) but NO antiderivative for the conjugate integrand √(1+t²); this is built from scratch via the product rule, the chain rule for √ (HasDerivAt.sqrt), and Real.hasDerivAt_arsinh, with the algebra collapsing because (t²+1)/√(1+t²) = √(1+t²) doubles the leading term.",
+      "integral_sqrt_one_add_sq: the Fundamental-Theorem-of-Calculus evaluation ∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a) — the closed form requested by the parent's open question, obtained by the hyperbolic substitution t = sinh u.",
+      "integral_sqrt_one_add_sq_zero_to: the normalised antiderivative (C = 0) ∫_0^b √(1+t²) dt = ½(b√(1+b²)+arsinh b), anchoring the constant at the antiderivative's value at 0.",
+      "sqrt_one_add_sinh_sq: the Pythagorean simplification √(1 + sinh²x) = cosh x (from cosh²x = 1 + sinh²x and cosh x > 0) that identifies the catenary arc-length integrand √(1 + (cosh)'²).",
+      "integral_cosh_zero_to: ∫_0^b cosh x dx = sinh b, the FTC evaluation for the catenary length element.",
+      "catenary_arclength: the headline geometric statement — the arc length of the catenary y = cosh x over [0, b] equals sinh b, since √(1 + sinh²x) = cosh x collapses the length integral to ∫_0^b cosh x dx = sinh b.",
+      "integral_sqrt_one_add_sq_zero_to_one: the concrete value ∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1), specialising the closed form.",
+      "sqrt_one_add_sq_pos / sq_sqrt_one_add_sq / continuous_sqrt_integrand / intervalIntegrable_sqrt_integrand: the supporting analytic API (the radicand is positive, its square root squares back to the radicand, and the integrand is continuous and hence interval-integrable) needed to differentiate and to apply the FTC."
+    ],
+    "prerequisites": [
+      "Mathlib's derivative Real.hasDerivAt_arsinh : HasDerivAt arsinh (√(1 + x²))⁻¹ x",
+      "The chain rule for square roots HasDerivAt.sqrt and the power derivative hasDerivAt_pow",
+      "Mathlib's derivative Real.hasDerivAt_sinh : HasDerivAt sinh (cosh x) x and the identity Real.cosh_sq : cosh x ^ 2 = sinh x ^ 2 + 1 with Real.cosh_pos",
+      "The Fundamental Theorem of Calculus intervalIntegral.integral_eq_sub_of_hasDerivAt and Continuous.intervalIntegrable for interval integrability"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasDerivAt_arsinh",
+        "description": "HasDerivAt arsinh (√(1 + x²))⁻¹ x — the arsinh derivative, one summand of the new antiderivative's derivative.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arsinh"
+      },
+      {
+        "theorem": "HasDerivAt.sqrt",
+        "description": "Chain rule for √: if HasDerivAt f f' x and f x ≠ 0 then HasDerivAt (√ ∘ f) (f'/(2√(f x))) x. Applied to f = 1 + t² to differentiate √(1 + t²).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.hasDerivAt_sinh",
+        "description": "HasDerivAt sinh (cosh x) x — used as the antiderivative of cosh to evaluate the catenary length integral ∫_0^b cosh x dx = sinh b via the FTC.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp"
+      },
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+        "description": "The Fundamental Theorem of Calculus: if HasDerivAt f (f' x) x on the interval and f' is interval-integrable, then ∫_a^b f' = f b − f a. Applied with the new √(1+t²) antiderivative and with sinh.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus"
+      },
+      {
+        "theorem": "Real.cosh_sq / Real.cosh_pos",
+        "description": "cosh x ^ 2 = sinh x ^ 2 + 1 and 0 < cosh x — give √(1 + sinh²x) = √(cosh²x) = cosh x, the catenary integrand simplification.",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The catenary y = cosh x is the shape of a hanging chain, and one of its most celebrated features is the strikingly simple closed form of its arc length: the length over [0, b] is exactly sinh b. This is because the arc-length element √(1 + (y')²) = √(1 + sinh²x) collapses to cosh x by the hyperbolic Pythagorean identity, so the length integral is ∫_0^b cosh x dx = sinh b. The companion fact is the generic arc-length integrand √(1 + t²), whose antiderivative ½(t√(1+t²) + arsinh t) is the canonical worked example of the hyperbolic substitution t = sinh u (turning √(1+t²) into cosh u). The parent chain developed the algebra of arsinh and then, in arsinh-log-formula-oq-01-oq-01, the antiderivative of the conjugate integrand 1/√(1+t²); this entry closes the geometric loop with the arc-length facts. Mathlib has the arsinh and sinh derivatives but no antiderivative for √(1+t²), so the central derivative computation is built here from scratch.",
+    "problemStatement": "Derive the catenary arc-length formula — the length of y = cosh x over [0, b] equals sinh b — and re-express the generic arc-length integral via the arsinh substitution to obtain ∫_0^b √(1 + t²) dt = ½(b√(1+b²) + arsinh b). Concretely: build the new derivative d/dt [½(t√(1+t²)+arsinh t)] = √(1+t²), turn it into the FTC evaluation ∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a) and its ∫_0^b normalisation, prove √(1 + sinh²x) = cosh x and ∫_0^b cosh x dx = sinh b, assemble the catenary arc length ∫_0^b √(1 + sinh²x) dx = sinh b, and record the concrete value ∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1).",
+    "proofStrategy": "The crux is hasDerivAt_sqrtAntideriv. Differentiate t√(1+t²) by the product rule, using HasDerivAt.sqrt (with f = 1 + t² ≠ 0) for d/dt √(1+t²) = (2t)/(2√(1+t²)); add Real.hasDerivAt_arsinh for the arsinh summand; divide by 2. The resulting derivative ½(√(1+t²) + t·(2t/(2√(1+t²))) + (√(1+t²))⁻¹) simplifies to √(1+t²): clearing denominators with √(1+t²) > 0 and using √(1+t²)² = 1+t² (so (t²+1)/√(1+t²) = √(1+t²)), the leading term doubles and halves back to √(1+t²) (field_simp then nlinarith). The integrand is continuous (fun_prop), hence interval-integrable, so intervalIntegral.integral_eq_sub_of_hasDerivAt gives the FTC evaluation; setting a = 0 with arsinh 0 = 0 normalises it. For the catenary, Real.cosh_sq gives 1 + sinh²x = cosh²x and Real.cosh_pos makes √(cosh²x) = cosh x; Real.hasDerivAt_sinh plus the FTC give ∫_0^b cosh x dx = sinh b; rewriting the arc-length integrand by sqrt_one_add_sinh_sq finishes catenary_arclength.",
+    "keyInsights": [
+      "The antiderivative of √(1+t²) is not in Mathlib (unlike its conjugate 1/√(1+t²), whose antiderivative arsinh Mathlib differentiates). The whole entry hinges on one hand-built derivative, after which both the closed-form integral and the catenary length follow by the FTC.",
+      "The algebraic collapse is the heart of the computation: (t²+1)/√(1+t²) = √(1+t²), so the product-rule term t·(t/√(1+t²)) combines with the surviving √(1+t²) to double it; halving recovers √(1+t²) exactly. This is why the messy three-term derivative simplifies to the clean integrand.",
+      "The catenary's simplicity is the hyperbolic Pythagorean identity in disguise: cosh²x = 1 + sinh²x means the arc-length element √(1 + (cosh)'²) is just cosh x, so the length integral is an elementary ∫ cosh = sinh — no surd survives once the identity is applied.",
+      "Two conjugate integrands, one substitution: ∫ 1/√(1+t²) (the parent) and ∫ √(1+t²) (here) are the two faces of the substitution t = sinh u, integrating to arsinh and to ½(t√(1+t²)+arsinh t) respectively; together they complete the arsinh calculus table.",
+      "Anchoring at 0 (arsinh 0 = 0, sinh 0 = 0) pins the constant of integration: ∫_0^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) with no free constant, and the catenary length is literally sinh b − sinh 0 = sinh b."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Catenary Arc Length",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "States the parent's open question (catenary arc length = sinh b and ∫_0^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) via the arsinh substitution) and enumerates the supplied theorems: the new √(1+t²) antiderivative, its FTC evaluation and normalisation, the Pythagorean integrand simplification, ∫ cosh = sinh, the catenary arc length, and a concrete value.",
+      "mathContext": "$\\int_0^b \\sqrt{1+t^2}\\,dt = \\tfrac12\\left(b\\sqrt{1+b^2} + \\operatorname{arsinh} b\\right)$ and arc length of $y=\\cosh x$ over $[0,b]$ is $\\sinh b$."
+    },
+    {
+      "id": "antiderivative",
+      "title": "The New Antiderivative of √(1 + t²)",
+      "startLine": 40,
+      "endLine": 92,
+      "summary": "sqrt_one_add_sq_pos and sq_sqrt_one_add_sq (radicand positivity and the √² identity), hasDerivAt_sqrtAntideriv (the from-scratch derivative d/dt [½(t√(1+t²)+arsinh t)] = √(1+t²) via product + √-chain + arsinh rules), and continuous_sqrt_integrand / intervalIntegrable_sqrt_integrand (the analytic API the FTC consumes).",
+      "mathContext": "$\\dfrac{d}{dt}\\left[\\tfrac12\\left(t\\sqrt{1+t^2} + \\operatorname{arsinh} t\\right)\\right] = \\sqrt{1+t^2}$."
+    },
+    {
+      "id": "ftc-evaluation",
+      "title": "FTC Evaluation of ∫ √(1 + t²)",
+      "startLine": 94,
+      "endLine": 110,
+      "summary": "integral_sqrt_one_add_sq (∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a)) and integral_sqrt_one_add_sq_zero_to (the normalised ∫_0^b = ½(b√(1+b²)+arsinh b), using arsinh 0 = 0).",
+      "mathContext": "$\\int_0^b \\sqrt{1+t^2}\\,dt = \\tfrac12\\left(b\\sqrt{1+b^2} + \\operatorname{arsinh} b\\right)$."
+    },
+    {
+      "id": "catenary",
+      "title": "Catenary Arc Length",
+      "startLine": 112,
+      "endLine": 143,
+      "summary": "sqrt_one_add_sinh_sq (√(1 + sinh²x) = cosh x), integral_cosh_zero_to (∫_0^b cosh x dx = sinh b), catenary_arclength (the arc length of y = cosh x over [0, b] equals sinh b), and integral_sqrt_one_add_sq_zero_to_one (∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1)).",
+      "mathContext": "$\\int_0^b \\sqrt{1+\\sinh^2 x}\\,dx = \\int_0^b \\cosh x\\,dx = \\sinh b$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
+      "question": "Generalise the arc-length identity to an arbitrary smooth curve via the arsinh substitution: for a differentiable f with continuous derivative, express ∫_a^b √(1 + f'(t)²) dt and, in the affine case f'(t) = m, recover the closed form ½ scaled by √(1+m²); more ambitiously, formalise the surface-area-of-revolution integral 2π ∫ cosh x √(1+sinh²x) dx for the catenoid.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent supplies the antiderivative of the conjugate integrand 1/√(1+t²) (namely arsinh) and lists the catenary arc-length formula as its open question. This entry answers it: it builds the antiderivative of √(1+t²) and derives the catenary arc length sinh b."
+    },
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "The arcosh companion builds the antiderivative of 1/√(t²−1) from a hand-rolled arcosh derivative; this entry similarly hand-builds the (absent-from-Mathlib) antiderivative of √(1+t²)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Arsinh",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.arsinh and its derivative Real.hasDerivAt_arsinh, one summand of the new antiderivative's derivative."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Trigonometric.DerivHyp",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.hasDerivAt_sinh : HasDerivAt sinh (cosh x) x, used to evaluate the catenary length integral via the FTC."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.IntervalIntegral.FundThmCalculus",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of intervalIntegral.integral_eq_sub_of_hasDerivAt, the Fundamental Theorem of Calculus turning the derivative facts into the integral evaluations."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Answers the parent's open question with the catenary arc-length facts. The core contribution hasDerivAt_sqrtAntideriv builds, from scratch, the antiderivative of √(1+t²): d/dt [½(t√(1+t²)+arsinh t)] = √(1+t²) (product rule + √-chain rule + Real.hasDerivAt_arsinh, with the algebra collapsing via (t²+1)/√(1+t²) = √(1+t²)). The FTC then gives ∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a) and its ∫_0^b normalisation. On the geometric side, √(1 + sinh²x) = cosh x (from cosh²x = 1 + sinh²x, cosh x > 0) and ∫_0^b cosh x dx = sinh b assemble the headline catenary_arclength: the arc length of y = cosh x over [0, b] is sinh b. A concrete value ∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1) closes the file. 143 lines, 11 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib differentiates arsinh and sinh and supplies the FTC, but the antiderivative of √(1+t²), the closed-form integral, the Pythagorean integrand simplification, and the catenary arc length are new to the gallery (hence the original badge). Together with the parent (antiderivative of 1/√(1+t²)) this completes the two conjugate arsinh-substitution integrals and connects the arsinh logarithmic theory to its canonical geometric application.",
+    "openQuestions": [
+      "Generalise the arc-length identity to arbitrary smooth curves via the arsinh substitution, and formalise the catenoid surface-area-of-revolution integral 2π ∫ cosh x √(1+sinh²x) dx."
+    ]
+  },
+  "description": "The arc length of the catenary y = cosh x over [0, b] is the strikingly simple sinh b, because the length element √(1 + sinh²x) = cosh x integrates to sinh. Starting from a hand-built derivative — d/dt [½(t√(1+t²)+arsinh t)] = √(1+t²), the antiderivative of the conjugate integrand that Mathlib lacks — this entry derives the closed form ∫_0^b √(1+t²) dt = ½(b√(1+b²)+arsinh b), proves √(1 + sinh²x) = cosh x and ∫_0^b cosh x dx = sinh b, and assembles the catenary arc length sinh b, plus the concrete value ∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1). Answers the parent's open question. Fully verified, 0 axioms, 0 sorries."
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question (`arsinh-log-formula-oq-01-oq-01`): derive the **catenary arc-length** formula and the closed form for the conjugate arsinh-substitution integral `∫ √(1+t²)`.

The core contribution is a **from-scratch derivative** that Mathlib lacks:
$$\frac{d}{dt}\left[\tfrac12\!\left(t\sqrt{1+t^2}+\operatorname{arsinh}t\right)\right]=\sqrt{1+t^2},$$
built from the product rule, the `√`-chain rule, and `Real.hasDerivAt_arsinh` — the algebra collapsing because `(t²+1)/√(1+t²)=√(1+t²)`. From it:

- `integral_sqrt_one_add_sq` — FTC: `∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a)`
- `integral_sqrt_one_add_sq_zero_to` — the `∫_0^b` normalisation
- `sqrt_one_add_sinh_sq` — `√(1+sinh²x) = cosh x` (catenary length element)
- `integral_cosh_zero_to` — `∫_0^b cosh x dx = sinh b`
- `catenary_arclength` — **arc length of `y=cosh x` over `[0,b]` is `sinh b`**
- `integral_sqrt_one_add_sq_zero_to_one` — concrete `∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1)`

Complements the parent (antiderivative of `1/√(1+t²)` = arsinh): the two conjugate integrands are the two faces of the substitution `t = sinh u`.

## Verification
- 143 lines, 11 theorems, 0 definitions, **0 axioms, 0 sorries**
- `#print axioms` → only `propext, Classical.choice, Quot.sound`
- Badge: `original` (the `√(1+t²)` antiderivative and catenary arc length are not in Mathlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)