### PR TITLE
research(seeker): 3 Tietze/Urysohn leaf problems (pool replenish 13→16)

### DIFF
--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/literature/README.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for urysohns-lemma-oq-01-oq-01-oq-01-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,122 @@
+# Problem: Sharp Norm Equality ‖G‖ = ‖f‖ from the Sup-Norm Tietze Series
+
+**Slug**: urysohns-lemma-oq-01-oq-01-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+Strengthen the sup-norm **bound** of the self-contained series extension to the sharp
+**equality**: for $f \in C(s, \mathbb{R})$ on a closed $s \subseteq X$ ($X$ normal), with
+$G = \sum_i g_i \in X \to^{b} \mathbb{R}$ the explicit Urysohn correction series of the parent,
+
+$$
+\|G\|_\infty \;=\; \|f\|_\infty .
+$$
+
+### Plain Language
+
+The sibling proof `urysohns-lemma-oq-01-oq-01-oq-01` extends $f$ to $G$ as an explicit infinite
+sum of Urysohn corrections and shows $\|G\| \le \|f\|$ up to the construction's geometric
+constant. This problem asks to track the partial-sum norms carefully enough to land on the
+**sharp** norm-preserving form $\|G\| = \|f\|$ — recovering the textbook statement of Tietze
+("the extension can be chosen with the same sup-norm as the original") directly from the
+hand-built series, rather than from Mathlib's `TietzeExtension` closure.
+
+> **Note for the researcher (dedup):** the *companion* entry
+> `urysohns-lemma-oq-01-oq-01-oq-02` already proves a norm-preserving Tietze extension, but via
+> a **different** construction (a norm-preserving correction series). The point of *this*
+> problem is to obtain $\|G\| = \|f\|$ from the **sup-norm construction of
+> `...-oq-01-oq-01-oq-01`** by tracking its partial-sum norms — i.e. show that branch *also*
+> yields equality, not just $\le$. If, on inspection, the sup-norm series cannot be made sharp
+> without effectively rebuilding the companion's construction, record that and pivot to proving
+> the precise constant it *does* achieve. Confirm the exact inequality the sibling currently
+> states before claiming.
+
+### Why This Matters
+
+The sharp norm bound is the quantitatively strongest form of the Tietze extension and the one
+used in applications (e.g. extending without amplifying magnitude, partitions of unity with
+controlled size). Deriving it from the explicit series — tracking how the partial sums'
+sup-norms behave — exposes *why* norm preservation holds at the level of the construction, which
+is exactly the pedagogical content a hand-built proof is supposed to make visible. It also
+completes the sup-norm branch of the Urysohn-series family so both branches reach the sharp form.
+
+## Known Results
+
+### What's Already Proven
+
+- `urysohns-lemma-oq-01-oq-01-oq-01` (sibling/parent) — the self-contained sup-norm Tietze
+  extension assembled as an explicit `tsum`, with a sup-norm **bound** on $G$.
+- `urysohns-lemma-oq-01-oq-01-oq-02` (companion) — a norm-preserving Tietze extension
+  $\|G\| = \|f\|$ via a *different*, norm-tracking correction series (reference construction).
+- `urysohn_approx_step` / `urysohn_approx_iterate` (`Proofs/UrysohnsLemmaOQ01OQ01.lean`) — the
+  one-step correction bounded by $M/3$ and its geometric iterate.
+- Mathlib: `BoundedContinuousFunction` norm API (`norm_le`, `norm_coe_le_norm`), `tsum` norm
+  bounds (`norm_tsum_le_tsum_norm`), and geometric series sums.
+
+### What's Still Open
+
+- Tracking the partial-sum sup-norms of the *sup-norm* construction so the limit norm equals
+  $\|f\|$ exactly (matching lower bound $\|G\| \ge \|f\|$ from $G|_s = f$, and the sharp upper
+  bound from the corrections).
+- A clean Lean statement `tietze_sup_series_norm_eq` giving the equality.
+
+### Our Goal
+
+Prove `‖G‖ = ‖f‖` for the sup-norm series $G$ of `urysohns-lemma-oq-01-oq-01-oq-01`: the lower
+bound from $G|_s = f$ (restriction can only shrink norm), the upper bound by tracking the
+partial-sum norms / geometric corrections — without invoking `ContinuousMap.exists_restrict_eq`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| urysohns-lemma-oq-01-oq-01-oq-01 | Direct parent; supplies the sup-norm series $G$ whose norm we sharpen to equality. | Explicit `tsum` in $X\to^b\mathbb{R}$, geometric bounds |
+| urysohns-lemma-oq-01-oq-01-oq-02 | Companion already achieving $\|G\|=\|f\|$ by a different construction; reference + dedup boundary. | Norm-tracking correction series |
+| urysohns-lemma-oq-01-oq-01 | Engine: one-step Urysohn correction and iterate. | One-step approximation, geometric decay |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — two-sided squeeze**: Lower bound $\|G\| \ge \|G|_s\| = \|f\|$ from
+   `norm_restrict_le` reasoning (restriction to $s$ cannot increase norm, and $G|_s = f$); upper
+   bound $\|G\| \le \|f\|$ by summing the corrected partial-sum norm bounds.
+   - Why it might work: the lower bound is immediate from $G|_s = f$; the upper bound reuses the
+     geometric per-term estimates.
+   - Risk: the sup-norm construction's corrections may only give $\|G\| \le c\,\|f\|$ with
+     $c > 1$ unless the step is the norm-preserving variant — this is the crux to check first.
+
+2. **Approach B — import the companion's norm bookkeeping**: Adapt the partial-sum norm
+   tracking from `...-oq-01-oq-01-oq-02` into this branch.
+   - Why it might work: reuses a proven technique.
+   - Risk: may collapse into the companion (dedup concern) — only pursue if it genuinely
+     sharpens *this* construction.
+
+### Key Difficulties
+
+- Establishing the upper bound $\|G\| \le \|f\|$ exactly (constant $1$) for the sup-norm series.
+- Avoiding duplication of the companion entry's already-proven equality.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $\|G\| \ge \|f\|$ from $G|_s = f$ and restriction-shrinks-norm.
+- Key lemma 2: partial-sum sup-norm bound that sums to $\le \|f\|$ in the limit.
+- Technical requirements: `BoundedContinuousFunction.norm_le`, `norm_tsum_le_tsum_norm`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Reuses an existing series and the companion as a template for the norm-preserving argument.
+- The lower bound is immediate; the upper bound is a controlled geometric sum.
+- Main risk is conceptual (dedup vs. companion), not technical.
+
+**Estimated Effort**:
+- Exploration: a few hours to confirm the sibling's exact current bound and the crux constant.
+- Formalization: about one day if the sup-norm step is sharpenable to constant $1$.

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: urysohns-lemma-oq-01-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T07:26:34-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/literature/README.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for urysohns-lemma-oq-01-oq-01-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/problem.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/problem.md
@@ -1,0 +1,118 @@
+# Problem: Banach-Space-Valued Norm-Preserving Tietze via the Explicit Urysohn Series
+
+**Slug**: urysohns-lemma-oq-01-oq-01-oq-02-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+For a normal space $X$, closed $s \subseteq X$, and a finite-dimensional (or interval-valued)
+target — concretely $f \in C(s, \mathbb{R}^d)$ componentwise, or $f \in C(s, [a,b])$ —
+
+$$
+\exists\, G \in C(X, V)\ \text{with}\ G|_s = f \ \text{and}\ \|G\|_\infty = \|f\|_\infty ,
+$$
+
+obtained by running the explicit Urysohn correction series of the parent in each coordinate of
+the value space $V$.
+
+### Plain Language
+
+The parent (`urysohns-lemma-oq-01-oq-01-oq-02`) gives a *norm-preserving* Tietze extension for
+**real-valued** data, assembled as an explicit geometric series of Urysohn corrections. This
+problem asks whether that exact construction carries through when the function takes values in
+something richer than $\mathbb{R}$ — first the concrete finite-dimensional case $\mathbb{R}^d$
+(extend each coordinate, control the joint norm), and the interval-constrained case $[a,b]$
+(extend without leaving the interval). The geometric majorant and Banach-space completeness
+argument should survive verbatim; the new content is a *vector-valued Urysohn correction step*
+and the bookkeeping that keeps the sup-norm sharp, $\|G\| = \|f\|$.
+
+### Why This Matters
+
+Real-valued Tietze is the base case; the genuinely useful statements in analysis are
+vector-valued (extending maps into $\mathbb{R}^d$, into Banach spaces, or into a fixed interval
+without overshoot). Showing the *explicit-series* construction — not Mathlib's black-box
+closed-embedding routine — generalizes cleanly demonstrates that the hand-built engine is
+robust, not an artifact of the scalar case. It also produces reusable infrastructure (a
+vector-valued one-step correction) that downstream extension and approximation results can
+build on, and it keeps the norm-preservation that the scalar parent worked hard to establish.
+
+## Known Results
+
+### What's Already Proven
+
+- `urysohns-lemma-oq-01-oq-01-oq-02` (parent) — the **scalar** norm-preserving Tietze extension
+  built as an explicit `tsum` of corrections, with $\|G\| = \|f\|$.
+- `urysohn_approx_step` / `urysohn_approx_iterate` (`Proofs/UrysohnsLemmaOQ01OQ01.lean`) — the
+  scalar one-step correction and its geometric iterate.
+- Mathlib: `BoundedContinuousFunction` into a complete normed space is complete; componentwise
+  continuity for $\mathbb{R}^d$ (`continuous_pi` / `continuous_apply`), and the interval-valued
+  Tietze data via `Set.Icc` membership are all available.
+
+### What's Still Open
+
+- A vector-valued Urysohn correction step: given $f$ valued in $\mathbb{R}^d$ (resp. $[a,b]$),
+  produce a single global correction reducing the residual by the same $2/3$ factor while
+  respecting the value constraint.
+- Assembling the per-coordinate series into one $V$-valued extension and proving the joint
+  sup-norm is preserved (not merely bounded coordinatewise).
+
+### Our Goal
+
+State and prove a Lean theorem extending the parent to $V \in \{\mathbb{R}^d, [a,b]\}$:
+$G|_s = f$ with $\|G\| = \|f\|$, reusing the scalar engine in each coordinate and avoiding
+`ContinuousMap.exists_restrict_eq`. The $\mathbb{R}^d$ case is the primary deliverable; the
+interval case is a stretch goal.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| urysohns-lemma-oq-01-oq-01-oq-02 | Scalar parent; the construction this problem lifts to vector-valued data. | Explicit `tsum`, geometric bounds, norm preservation |
+| urysohns-lemma-oq-01-oq-01-oq-01 | Sibling self-contained scalar extension (sup-norm form). | `tsum` in $X\to^b\mathbb{R}$, completeness |
+| urysohns-lemma-oq-01-oq-01 | Engine providing the one-step correction to be vectorized. | One-step Urysohn approximation |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — coordinatewise reduction for $\mathbb{R}^d$**: Extend each component $f_j$ by
+   the scalar parent, set $G = (G_1, \dots, G_d)$. Continuity is `continuous_pi`; the residual
+   shrinks by $2/3$ in each coordinate.
+   - Why it might work: $\mathbb{R}^d$ separates into scalars, reusing the whole engine.
+   - Risk: the joint sup-norm $\|G\|=\max_j\|G_j\|$ may only give $\|G\|=\|f\|$ if the maximizing
+     coordinate is handled carefully; coordinatewise norm preservation need not give joint
+     preservation without an argument.
+
+2. **Approach B — genuine vector-valued one-step lemma**: Replace `urysohn_approx_step` with a
+   $V$-valued version using a single scalar Urysohn function as a multiplier toward the value.
+   - Why it might work: keeps one series rather than $d$, easing the norm bookkeeping.
+   - Risk: constructing the vector-valued step in Mathlib without a ready-made lemma.
+
+### Key Difficulties
+
+- Joint sup-norm preservation for $\mathbb{R}^d$ (vs. merely coordinatewise bounds).
+- The interval case must keep values in $[a,b]$ throughout the iteration (clamping vs. sharpness).
+
+### What Would a Proof Need?
+
+- Key lemma 1: scalar parent extension, applied per coordinate.
+- Key lemma 2: $\|(G_1,\dots,G_d)\|_\infty$ control in terms of the $\|G_j\|$ and $\|f_j\|$.
+- Technical requirements: `continuous_pi`, `Pi.norm` / `pi_norm_le`, `Set.Icc` membership for the
+  interval variant.
+
+## Tractability Assessment
+
+**Difficulty**: Medium-High
+
+**Justification**:
+- The $\mathbb{R}^d$ coordinatewise route is mostly engineering over the proven scalar parent.
+- Sharp joint norm preservation and the interval-valued variant add genuine new content.
+- Mathlib has the product-space continuity and norm APIs needed for the finite-dimensional case.
+
+**Estimated Effort**:
+- Exploration: about one day to scope the vector step and norm bookkeeping.
+- Formalization: a few days for the $\mathbb{R}^d$ case with sharp norm preservation.

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: urysohns-lemma-oq-01-oq-01-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T07:26:33-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/knowledge.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-02-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/literature/README.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for urysohns-lemma-oq-01-oq-01-oq-02-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/problem.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/problem.md
@@ -1,0 +1,116 @@
+# Problem: Explicit Modulus of Convergence for the Norm-Preserving Tietze Series
+
+**Slug**: urysohns-lemma-oq-01-oq-01-oq-02-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: proof-suggestion <!-- gallery-gap | proof-suggestion | user-request | external -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\Big\| G - \sum_{i < n} g_i \Big\|_\infty \;\le\; \left(\tfrac{2}{3}\right)^{n} M ,
+\qquad M = \|f\|_\infty ,
+$$
+
+where $G = \sum_{i} g_i \in X \to^{b} \mathbb{R}$ is the explicit Urysohn correction series
+realizing the norm-preserving Tietze extension of $f \in C(s,\mathbb{R})$ from a closed
+$s \subseteq X$ on a normal space $X$.
+
+### Plain Language
+
+The parent gallery proof (`urysohns-lemma-oq-01-oq-01-oq-02`) builds the Tietze extension $G$
+as an *infinite sum* of geometrically shrinking continuous corrections $g_i$, and shows the sum
+both converges and preserves the sup-norm, $\|G\| = \|f\|$. What it does **not** do is record
+*how fast* the partial sums approach $G$. This problem asks for the explicit, quantitative
+convergence rate: after summing the first $n$ corrections, the remaining error is at most
+$(2/3)^n M$. In other words, we want a concrete *modulus of uniform convergence* for the series,
+turning "the series converges" into "the series converges at this verified geometric rate."
+
+### Why This Matters
+
+A modulus of convergence is the computational content of the extension theorem: it tells you
+exactly how many Urysohn steps suffice to approximate the extension to a prescribed tolerance,
+making the construction effective rather than merely existential. Because each correction is
+bounded by $\tfrac13(2/3)^i M$, the tail $\sum_{i \ge n} \|g_i\|$ is a geometric remainder, so
+the bound is sharp up to the constant and follows directly from the engine lemmas already in
+the parent. Establishing it upgrades the entry from "an extension exists" to "here is its
+explicit rate of approximation," which is the pedagogically illuminating payoff of building
+Tietze by hand instead of invoking Mathlib's closed-embedding machinery.
+
+## Known Results
+
+### What's Already Proven
+
+- `urysohns-lemma-oq-01-oq-01-oq-02` (parent) — the norm-preserving Tietze extension assembled
+  as an explicit `tsum` of corrections $g_i \in X \to^{b}\mathbb{R}$ with $\|G\| = \|f\|$.
+- `urysohn_approx_step` / `urysohn_approx_iterate` (grandparent file
+  `Proofs/UrysohnsLemmaOQ01OQ01.lean`) — the one-step correction bounded by $M/3$ that reduces
+  the residual to $(2/3)M$, and its $n$-fold iterate giving residual $(2/3)^n M$ on $s$.
+- Mathlib `BoundedContinuousFunction` is a complete normed space; `tsum`, `Summable`,
+  `summable_of_summable_norm`, and the geometric-series remainder estimates
+  (`tsum_geometric_of_lt_one`, summable-tail bounds for a series majorized in norm) are
+  available.
+
+### What's Still Open
+
+- A clean statement and proof that the $n$-th partial sum $\sum_{i<n} g_i$ differs from the
+  limit $G$ by at most $(2/3)^n M$ in sup-norm.
+- Packaging this as a reusable rate/modulus lemma keyed to the parent's correction sequence.
+
+### Our Goal
+
+Prove a Lean lemma `tietze_series_tail_le` (or similar) stating
+$\big\| G - \sum_{i<n} g_i \big\|_\infty \le (2/3)^n M$, derived purely from the per-term bound
+$\|g_i\| \le \tfrac13 (2/3)^i M$ and the geometric tail estimate, with no appeal to
+`ContinuousMap.exists_restrict_eq`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| urysohns-lemma-oq-01-oq-01-oq-02 | Direct parent; supplies the correction sequence $g_i$ and the norm-preserving sum $G$. | Explicit `tsum` in $X\to^b\mathbb{R}$, geometric sup-norm bounds, completeness |
+| urysohns-lemma-oq-01-oq-01 | Engine: the one-step Urysohn correction and its $(2/3)^n$ iterate. | One-step approximation, geometric error decay |
+| urysohns-lemma-oq-01 | Grandparent recording the "Tietze from Urysohn" open question. | Urysohn separation by continuous functions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A — geometric tail of the per-term bound**: Use $\|g_i\| \le \tfrac13(2/3)^i M$
+   together with the summable-tail estimate to bound
+   $\|G - \sum_{i<n}g_i\| = \|\sum_{i \ge n} g_i\| \le \sum_{i\ge n}\tfrac13(2/3)^i M = (2/3)^n M$.
+   - Why it might work: the constant $\tfrac13 \cdot \tfrac{1}{1-2/3} = 1$ makes the tail close
+     in one geometric-series computation.
+   - Risk: matching Mathlib's exact tail-bound API (norm of a tsum tail vs. partial-sum distance).
+
+2. **Approach B — re-derive from `urysohn_approx_iterate` residuals**: Show the partial sum
+   equals the $n$-step iterate up to bookkeeping, then quote the iterate's $(2/3)^n M$ residual.
+   - Why it might work: the residual bound is already proven for the iterate.
+   - Risk: aligning the partial-sum indexing with the iterate's recursion.
+
+### Key Difficulties
+
+- Selecting the right Mathlib lemma relating a partial sum to the `tsum` tail in a Banach space.
+- Keeping the $\tfrac13$ vs. $\tfrac{2}{3}$ constants exact so the final bound is clean $(2/3)^n M$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: per-correction sup-norm bound $\|g_i\| \le \tfrac13(2/3)^i M$ (from the parent).
+- Key lemma 2: tail of a summable series bounded by the tail of its norm-majorant.
+- Technical requirements: geometric series sum `tsum_geometric_of_lt_one` with ratio $2/3$.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The hard analytic content (summability, completeness, norm preservation) is already done in
+  the parent; this is a quantitative tail estimate over an existing series.
+- Closely parallels standard Mathlib geometric-remainder arguments.
+- All needed APIs (`BoundedContinuousFunction`, geometric tsum) are in Mathlib.
+
+**Estimated Effort**:
+- Exploration: a few hours to locate the tail-bound lemma.
+- Formalization: about one day for a clean reusable statement.

--- a/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: urysohns-lemma-oq-01-oq-01-oq-02-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T07:26:33-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-01-oq-01.json
@@ -1,0 +1,47 @@
+{
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01",
+  "title": "Sharp Norm Equality ‖G‖ = ‖f‖ from the Sup-Norm Tietze Series",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\|G\\|_\\infty \\;=\\; \\|f\\|_\\infty .",
+    "plain": "The sibling proof `urysohns-lemma-oq-01-oq-01-oq-01` extends $f$ to $G$ as an explicit infinite",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T07:26:34-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T07:26:34-07:00"
+}

--- a/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,47 @@
+{
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+  "title": "Banach-Space-Valued Norm-Preserving Tietze via the Explicit Urysohn Series",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\exists\\, G \\in C(X, V)\\ \\text{with}\\ G|_s = f \\ \\text{and}\\ \\|G\\|_\\infty = \\|f\\|_\\infty ,",
+    "plain": "The parent (`urysohns-lemma-oq-01-oq-01-oq-02`) gives a *norm-preserving* Tietze extension for",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T07:26:33-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T07:26:33-07:00"
+}

--- a/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/urysohns-lemma-oq-01-oq-01-oq-02-oq-02.json
@@ -1,0 +1,47 @@
+{
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-02-oq-02",
+  "title": "Explicit Modulus of Convergence for the Norm-Preserving Tietze Series",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\Big\\| G - \\sum_{i < n} g_i \\Big\\|_\\infty \\;\\le\\; \\left(\\tfrac{2}{3}\\right)^{n} M ,\n\\qquad M = \\|f\\|_\\infty ,",
+    "plain": "The parent gallery proof (`urysohns-lemma-oq-01-oq-01-oq-02`) builds the Tietze extension $G$",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T07:26:33-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: urysohns-lemma-oq-01-oq-01-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T07:26:33-07:00"
+}


### PR DESCRIPTION
## Summary

Seeker pool replenishment. Available candidate pool had dropped to **13** (below the threshold of 15). This adds three fresh, well-scoped open-question leaves harvested off the **verified** Urysohn-series Tietze gallery entries, plus a runtime flip of one already-clean surveyed candidate.

## New problems

| Slug | Theme | Parent (verified) |
|------|-------|-------------------|
| `urysohns-lemma-oq-01-oq-01-oq-02-oq-02` | Explicit modulus of convergence `(2/3)^n·M` for the norm-preserving Tietze series | oq-01-oq-01-oq-02 |
| `urysohns-lemma-oq-01-oq-01-oq-02-oq-01` | Banach-space-valued (ℝ^d / interval) norm-preserving Tietze via the explicit series | oq-01-oq-01-oq-02 |
| `urysohns-lemma-oq-01-oq-01-oq-01-oq-01` | Sharpen the sup-norm bound to the equality `‖G‖=‖f‖` (dedup note vs. companion included) | oq-01-oq-01-oq-01 |

Also flipped `tietze-extension-theorem-oq-01-oq-02` surveyed→available in the runtime pool (already `available` in the DB; no tracked file change). Pool restored to **16 available**.

## Verification
- All three stubs pass `validate-seeker-stubs.ts` (no template placeholders in problem.md or site JSON).
- Site JSON generated via `scripts/research/build.ts`.
- Staleness-checked: no open PRs, branches, or untracked `.lean` files for these slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)