### PR TITLE
Enrich Property B (first moment): add index.ts + annotations

### DIFF
--- a/src/data/proofs/property-b-first-moment/annotations.json
+++ b/src/data/proofs/property-b-first-moment/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "pb-mono-def",
+    "proofId": "property-b-first-moment",
+    "range": { "startLine": 31, "endLine": 36 },
+    "type": "definition",
+    "title": "Monochromatic Edges and Their Decidability",
+    "content": "A 2-coloring c : V → Bool is monochromatic on an edge e if some single color b is taken by every vertex of e (Mono e c := ∃ b, ∀ x ∈ e, c x = b). Property B (2-colorability) of a hypergraph is the existence of a coloring with no monochromatic edge. The Decidable instance — derived automatically since the sample space V → Bool is finite — is what lets the whole argument run as exact finite counting over the concrete sample space rather than over an abstract probability measure.",
+    "mathContext": "$\\mathrm{Mono}(e,c) \\iff \\exists b \\in \\{0,1\\},\\ \\forall x \\in e,\\ c(x) = b$",
+    "significance": "key",
+    "prerequisites": ["hypergraph 2-coloring", "Property B", "Decidable instances on finite function types"],
+    "relatedConcepts": ["proper coloring", "hypergraph colorability", "Erdős Property B", "indicator-based counting"]
+  },
+  {
+    "id": "pb-first-moment",
+    "proofId": "property-b-first-moment",
+    "range": { "startLine": 38, "endLine": 55 },
+    "type": "theorem",
+    "title": "First Moment Principle (Existence of a Zero)",
+    "content": "The probabilistic-method workhorse, stated combinatorially and proved self-contained: if a nonnegative integer statistic f sums to strictly less than the number of outcomes |s|, then some outcome takes the value 0. Contrapositive: if every outcome had f ≥ 1, the sum would be ≥ |s|. This is exactly 'if the expected number of bad events is < 1, a perfect outcome exists' — the averaging argument with no measure theory, just ∑ f < |s| ⟹ ∃ a, f a = 0.",
+    "mathContext": "$\\sum_{a \\in s} f(a) < |s| \\;\\Longrightarrow\\; \\exists a \\in s,\\ f(a) = 0$",
+    "significance": "critical",
+    "prerequisites": ["pigeonhole / averaging", "first moment method", "expectation E[X] < 1 ⟹ P(X=0) > 0", "Finset.sum_le_sum"],
+    "relatedConcepts": ["first moment method", "probabilistic method", "expectation argument", "averaging principle"]
+  },
+  {
+    "id": "pb-card-const-on",
+    "proofId": "property-b-first-moment",
+    "range": { "startLine": 57, "endLine": 98 },
+    "type": "theorem",
+    "title": "Counting Crux: Colorings Constant on an Edge = 2^(n−|e|)",
+    "content": "card_const_on counts the colorings pinned to a fixed value b on every vertex of e: the colors off e are free, giving 2^(n−|e|). The filtered set is recognized as a Fintype.piFinset — value forced to the singleton {b} on e, ranging over univ off e — and Fintype.card_piFinset turns the count into a product ∏_x #(choices at x). Each factor is 2^(if x∈e then 0 else 1), and the exponent sum ∑(1 off e) collapses to n − |e| via card_univ_diff. This exact product count is the analytic heart that replaces the '2^{1−k} probability per vertex' of the textbook proof.",
+    "mathContext": "$\\#\\{c : c|_e \\equiv b\\} = 2^{\\,n - |e|}, \\quad n = |V|$",
+    "significance": "key",
+    "prerequisites": ["Fintype.piFinset", "Fintype.card_piFinset", "Finset.prod_pow_eq_pow_sum", "Finset.card_univ_diff"],
+    "relatedConcepts": ["product counting", "free coordinates", "independent choices", "cardinality of function spaces"]
+  },
+  {
+    "id": "pb-card-mono",
+    "proofId": "property-b-first-moment",
+    "range": { "startLine": 100, "endLine": 135 },
+    "type": "theorem",
+    "title": "Exact Count of Monochromatic Colorings = 2·2^(n−|e|)",
+    "content": "card_mono counts the colorings monochromatic on a nonempty edge e: split 'monochromatic' into all-true-on-e ⊔ all-false-on-e. These two sets are disjoint (a vertex of e cannot be both true and false — this is where nonemptiness of e is used), so by card_union_of_disjoint and two applications of card_const_on the total is 2^(n−|e|) + 2^(n−|e|) = 2·2^(n−|e|). Choose the common color (2 ways) times the free colors off e. This is the per-edge contribution to the first-moment sum.",
+    "mathContext": "$\\#\\{c : \\mathrm{Mono}(e,c)\\} = 2 \\cdot 2^{\\,n - |e|}$",
+    "significance": "key",
+    "prerequisites": ["Finset.card_union_of_disjoint", "disjointness from a witness vertex", "Bool case analysis"],
+    "relatedConcepts": ["inclusion of disjoint cases", "two color choices", "monochromatic count", "union of fibers"]
+  },
+  {
+    "id": "pb-main",
+    "proofId": "property-b-first-moment",
+    "range": { "startLine": 137, "endLine": 201 },
+    "type": "theorem",
+    "title": "Erdős 1963: Small k-Uniform Hypergraphs Are 2-Colorable",
+    "content": "The headline theorem: a k-uniform hypergraph (k ≥ 1) with fewer than 2^(k−1) edges has Property B. After dispatching the empty-edge-family case, the (coloring, monochromatic edge) incidence sum is computed by Fubini (sum_comm): ∑_c #{mono edges} = |E|·2·2^(n−k) using card_mono on each k-edge. The key strict inequality |E|·2 < 2^k (from |E| < 2^(k−1) = 2^k/2) multiplies up to |E|·2·2^(n−k) < 2^k·2^(n−k) = 2^n = |Ω|. The first moment principle then yields a coloring c with zero monochromatic edges, i.e. a proper 2-coloring.",
+    "mathContext": "$|E| < 2^{k-1} \\;\\Longrightarrow\\; \\exists c,\\ \\forall e \\in E,\\ \\neg\\,\\mathrm{Mono}(e,c)$",
+    "significance": "critical",
+    "prerequisites": ["first moment method", "Fubini / Finset.sum_comm", "Fintype.card_fun (|V→Bool| = 2^n)", "the counting lemmas card_mono / card_const_on"],
+    "relatedConcepts": ["Erdős Property B", "m(k) lower bound 2^{k-1}", "probabilistic existence proof", "Fano plane (k=3 sharpness)", "union bound"]
+  }
+]

--- a/src/data/proofs/property-b-first-moment/index.ts
+++ b/src/data/proofs/property-b-first-moment/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PropertyBFirstMoment.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const propertyBFirstMomentProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const propertyBFirstMomentAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const propertyBFirstMomentData: ProofData = {
+  proof: propertyBFirstMomentProof,
+  annotations: propertyBFirstMomentAnnotations,
+}


### PR DESCRIPTION
Enrichment pass for `property-b-first-moment` (Property B (Erdős 1963): Small k-Uniform Hypergraphs Are 2-Colorable).

## Gaps fixed
- **Missing `index.ts`** — no Vite entry point, so the page rendered as *'proof not found'* on the live site. Added it (Lean source `PropertyBFirstMoment.lean`).
- **Empty `annotations.json`** (was `[]`) — added **5 inline annotations** covering all five parts.

## Annotation coverage
Each carries `mathContext` (LaTeX), `significance`, `prerequisites`, `relatedConcepts`:
1. `Mono` definition + decidability (finite sample space V → Bool)
2. `exists_zero_of_sum_lt_card` — the first moment principle, proved self-contained
3. `card_const_on` — counting crux: colorings constant on an edge = 2^(n−|e|) (via piFinset)
4. `card_mono` — exact count of monochromatic colorings = 2·2^(n−|e|)
5. `property_b_two_colorable` — Erdős' theorem: |E| < 2^(k−1) ⟹ 2-colorable (Fubini + first moment)

meta.json was already rich (overview, sections, conclusion, cross-references) and is intact. Axiom status verified accurate: `verified`, 0 axioms, 0 sorries.

`pnpm build` passes.