### PR TITLE
research(gram-linear-independence-iff-oq-01-oq-02): Gramian as squared volume — volume(parallelepiped v) = √(det gram v)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2964,6 +2964,7 @@ import Proofs.GoemansWilliamsonMaxCut
 import Proofs.GramLinearIndependenceOQ01
 import Proofs.GramLinearIndependenceOQ01OQ01
 import Proofs.GramLinearIndependenceOQ01OQ01OQ02OQ01
+import Proofs.GramLinearIndependenceOQ01OQ02
 import Proofs.GraphCore
 import Proofs.GreensTheorem
 import Proofs.GreensTheoremOQ01

--- a/proofs/Proofs/GramLinearIndependenceOQ01OQ02.lean
+++ b/proofs/Proofs/GramLinearIndependenceOQ01OQ02.lean
@@ -1,0 +1,121 @@
+import Mathlib
+
+/-
+# The Gramian as a squared volume: `√(det gram v)` is the parallelepiped volume
+
+For a finite family of vectors `v : ι → F` in a real inner product space, the parent entry
+`GramLinearIndependenceOQ01` established the **Gramian criterion**: the Gram determinant
+`det (gram ℝ v)` is nonnegative and is strictly positive exactly when `v` is linearly
+independent.  The sibling entry `…OQ01OQ01` quantified it from above (Hadamard's inequality
+`det (gram ℝ v) ≤ ∏ ‖v i‖²`).  This entry supplies the **geometric meaning** of the Gramian,
+answering the parent's second open question:
+
+> Identify `√(det gram v)` with the volume of the parallelepiped spanned by `v`, connecting
+> the Gramian criterion to the volume / exterior-power picture of linear independence.
+
+The headline result is
+
+* `volume_parallelepiped_eq_sqrt_det_gram` :
+  `volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v)))`
+
+for a top-dimensional family in a finite-dimensional inner product space (`b` ranges over an
+orthonormal basis indexed by `ι`, equivalently `finrank ℝ F = card ι`), together with the
+concrete instance `volume_parallelepiped_euclidean` on `EuclideanSpace ℝ ι`.
+
+Mathlib has the two ends of the bridge — `Basis.det`, the coordinate machinery, and
+`MeasureTheory.Measure.addHaar_parallelepiped` (`b.addHaar (parallelepiped v) = ofReal |b.det v|`),
+together with `OrthonormalBasis.addHaar_eq_volume` — but **not** the identification of the
+volume with the Gramian.  The link is the matrix factorisation in an orthonormal basis:
+
+1. `gram_eq_transpose_mul` : in an orthonormal basis `b`, writing `B := b.toMatrix v` for the
+   coordinate matrix `B k i = ⟪b k, v i⟫`, completeness gives `gram ℝ v = Bᵀ * B`.
+2. `det_gram_eq_basis_det_sq` : hence `det (gram ℝ v) = (b.det v)²`, the **squared** signed
+   volume.
+3. `sqrt_det_gram_eq_abs_det` : so `√(det (gram ℝ v)) = |b.det v|`, the unsigned volume of the
+   coordinate determinant — and `addHaar_parallelepiped` turns `|b.det v|` into the measure of
+   the parallelepiped.
+
+As a corollary, `volume_parallelepiped_pos_iff_linearIndependent` recovers the parent's
+criterion in geometric form: the parallelepiped has positive volume iff `v` is independent.
+
+Everything is fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace GramLinearIndependenceOQ01OQ02
+
+open Matrix Finset MeasureTheory
+open scoped InnerProductSpace
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+/-! ## The Gram matrix as `Bᵀ B` in an orthonormal basis -/
+
+omit [DecidableEq ι] in
+/-- In an orthonormal basis `b`, the Gram matrix of `v` factors through the coordinate matrix
+`B := b.toMatrix v` (with `B k i = ⟪b k, v i⟫`) as `gram ℝ v = Bᵀ * B`.  This is exactly
+completeness of the orthonormal basis: `⟪v i, v j⟫ = ∑ k, ⟪b k, v i⟫ ⟪b k, v j⟫`. -/
+theorem gram_eq_transpose_mul (b : OrthonormalBasis ι ℝ F) (v : ι → F) :
+    gram ℝ v = (b.toBasis.toMatrix v)ᵀ * (b.toBasis.toMatrix v) := by
+  ext i j
+  simp only [gram_apply, Matrix.mul_apply, Matrix.transpose_apply, Module.Basis.toMatrix_apply,
+    OrthonormalBasis.coe_toBasis_repr_apply, OrthonormalBasis.repr_apply_apply]
+  rw [← b.sum_inner_mul_inner (v i) (v j)]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [real_inner_comm (v i) (b k)]
+
+/-! ## The Gramian is the squared signed volume -/
+
+/-- The Gram determinant equals the square of the basis determinant `b.det v` (the signed
+volume of `v` read in the orthonormal basis `b`): `det (gram ℝ v) = (b.det v)²`. -/
+theorem det_gram_eq_basis_det_sq (b : OrthonormalBasis ι ℝ F) (v : ι → F) :
+    (gram ℝ v).det = (b.toBasis.det v) ^ 2 := by
+  rw [gram_eq_transpose_mul b v, Matrix.det_mul, Matrix.det_transpose, Module.Basis.det_apply]
+  ring
+
+/-- The square root of the Gramian is the unsigned volume `|b.det v|`. -/
+theorem sqrt_det_gram_eq_abs_det (b : OrthonormalBasis ι ℝ F) (v : ι → F) :
+    Real.sqrt ((gram ℝ v).det) = |b.toBasis.det v| := by
+  rw [det_gram_eq_basis_det_sq b v, Real.sqrt_sq_eq_abs]
+
+/-! ## The volume identity -/
+
+/-- **The Gramian is a squared volume.** For a top-dimensional family `v : ι → F` in a
+finite-dimensional real inner product space (`b` an orthonormal basis indexed by `ι`), the
+Lebesgue–Haar volume of the parallelepiped spanned by `v` is the square root of the Gram
+determinant:
+`volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v)))`. -/
+theorem volume_parallelepiped_eq_sqrt_det_gram
+    [MeasurableSpace F] [BorelSpace F] [FiniteDimensional ℝ F]
+    (b : OrthonormalBasis ι ℝ F) (v : ι → F) :
+    volume (parallelepiped v) = ENNReal.ofReal (Real.sqrt ((gram ℝ v).det)) := by
+  have hvol := MeasureTheory.Measure.addHaar_parallelepiped b.toBasis v
+  rw [b.addHaar_eq_volume] at hvol
+  rw [hvol, sqrt_det_gram_eq_abs_det b v]
+
+/-- Concrete form of the volume identity on `EuclideanSpace ℝ ι`, where the standard basis
+`EuclideanSpace.basisFun` is orthonormal and all measure-theoretic instances are canonical. -/
+theorem volume_parallelepiped_euclidean (v : ι → EuclideanSpace ℝ ι) :
+    volume (parallelepiped v) = ENNReal.ofReal (Real.sqrt ((gram ℝ v).det)) :=
+  volume_parallelepiped_eq_sqrt_det_gram (EuclideanSpace.basisFun ι ℝ) v
+
+/-! ## Geometric form of the linear-independence criterion -/
+
+/-- The parallelepiped spanned by `v` has positive volume iff `v` is linearly independent —
+the parent's Gramian criterion (`det (gram ℝ v) > 0 ↔ LinearIndependent`) read geometrically.
+The Gram matrix is positive **definite** exactly when `v` is independent (Mathlib's
+`posDef_gram_iff_linearIndependent`), and a positive definite matrix has positive determinant,
+which by the volume identity is the squared volume. -/
+theorem volume_parallelepiped_pos_iff_linearIndependent
+    [MeasurableSpace F] [BorelSpace F] [FiniteDimensional ℝ F]
+    (b : OrthonormalBasis ι ℝ F) (v : ι → F) :
+    0 < volume (parallelepiped v) ↔ LinearIndependent ℝ v := by
+  rw [volume_parallelepiped_eq_sqrt_det_gram b v, ENNReal.ofReal_pos, Real.sqrt_pos,
+    ← Matrix.posDef_gram_iff_linearIndependent]
+  constructor
+  · intro hdpos
+    rw [(Matrix.posSemidef_gram ℝ v).posDef_iff_isUnit]
+    exact (Matrix.isUnit_iff_isUnit_det _).mpr (isUnit_iff_ne_zero.mpr hdpos.ne')
+  · exact fun hpd => hpd.det_pos
+
+end GramLinearIndependenceOQ01OQ02

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-02/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "gram-linear-independence-iff-oq-01-oq-02",
+  "slug": "gram-linear-independence-iff-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Finset",
+      "MeasureTheory",
+      "InnerProductSpace"
+    ],
+    "namespace": "GramLinearIndependenceOQ01OQ02",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GramLinearIndependenceOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Gramian as a Squared Volume: √(det Gram) is the Parallelepiped Volume",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GramLinearIndependenceOQ01OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-space",
+      "gram-matrix",
+      "determinant",
+      "volume",
+      "measure-theory",
+      "parallelepiped",
+      "haar-measure",
+      "geometry-of-numbers",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 121,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "volume_parallelepiped_eq_sqrt_det_gram: the geometric identification of the Gramian — for a top-dimensional family v : ι → F in a finite-dimensional real inner product space, volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v))). This identifies the square root of the Gram determinant with the Lebesgue–Haar volume of the spanned parallelepiped, a connection absent from Mathlib",
+      "gram_eq_transpose_mul: the driving factorisation gram ℝ v = Bᵀ * B where B = b.toMatrix v is the coordinate matrix B k i = ⟪b k, v i⟫ in an orthonormal basis b, obtained from completeness ⟪v i, v j⟫ = ∑ k, ⟪b k, v i⟫ ⟪b k, v j⟫ (OrthonormalBasis.sum_inner_mul_inner)",
+      "det_gram_eq_basis_det_sq: the Gramian is the squared signed volume det (gram ℝ v) = (b.det v)², from det(BᵀB) = (det B)² and Basis.det_apply — the algebraic heart of the volume identity",
+      "sqrt_det_gram_eq_abs_det: √(det (gram ℝ v)) = |b.det v|, the unsigned coordinate volume, via Real.sqrt_sq_eq_abs",
+      "volume_parallelepiped_euclidean: the concrete instance on EuclideanSpace ℝ ι, where EuclideanSpace.basisFun is orthonormal and all measure-theoretic instances are canonical",
+      "volume_parallelepiped_pos_iff_linearIndependent: the parent's Gramian criterion read geometrically — the parallelepiped has positive volume iff v is linearly independent, combining the volume identity with Mathlib's posDef_gram_iff_linearIndependent and PosSemidef.posDef_iff_isUnit"
+    ],
+    "prerequisites": [
+      "Gram matrix Matrix.gram 𝕜 v with entries ⟪v i, v j⟫ and its positive semidefiniteness/linear-independence criterion (parent entry gram-linear-independence-iff-oq-01)",
+      "Mathlib's orthonormal-basis machinery: OrthonormalBasis.repr_apply_apply (b.repr v i = ⟪b i, v⟫), OrthonormalBasis.sum_inner_mul_inner (completeness), and Basis.toMatrix / Basis.det",
+      "Haar-measure volume of a parallelepiped: MeasureTheory.Measure.addHaar_parallelepiped (b.addHaar (parallelepiped v) = ENNReal.ofReal |b.det v|) and OrthonormalBasis.addHaar_eq_volume (an orthonormal basis induces the canonical volume measure)",
+      "The canonical MeasureSpace on a finite-dimensional inner product space (measureSpaceOfInnerProductSpace) so that volume resolves consistently with addHaar_eq_volume",
+      "Determinant algebra Matrix.det_mul, Matrix.det_transpose and Real.sqrt_sq_eq_abs"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.Measure.addHaar_parallelepiped",
+        "description": "For a basis b, the Haar measure of the parallelepiped spanned by v is b.addHaar (parallelepiped v) = ENNReal.ofReal |b.det v| — the bridge from the coordinate determinant to a measure.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar"
+      },
+      {
+        "theorem": "OrthonormalBasis.addHaar_eq_volume",
+        "description": "An orthonormal basis of a finite-dimensional inner product space induces the canonical volume measure: b.toBasis.addHaar = volume. This lets the basis-relative Haar measure be replaced by the canonical volume.",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace"
+      },
+      {
+        "theorem": "OrthonormalBasis.sum_inner_mul_inner",
+        "description": "Completeness of an orthonormal basis: ∑ k, ⟪x, b k⟫ * ⟪b k, y⟫ = ⟪x, y⟫, giving the factorisation gram ℝ v = Bᵀ B of the Gram matrix through the coordinate matrix.",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Module.Basis.det_apply",
+        "description": "The basis determinant equals the determinant of the coordinate matrix, b.det v = det (b.toMatrix v) — identifying (b.det v)² with the Gramian.",
+        "module": "Mathlib.LinearAlgebra.Determinant"
+      },
+      {
+        "theorem": "Matrix.PosSemidef.posDef_iff_isUnit / Matrix.posDef_gram_iff_linearIndependent",
+        "description": "A positive semidefinite matrix is positive definite iff it is a unit, and the Gram matrix is positive definite iff the family is linearly independent — combining to det(gram v) > 0 ↔ LinearIndependent, the engine of the positive-volume criterion.",
+        "module": "Mathlib.Analysis.Matrix.Order / Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Gram determinant of a family of vectors is, classically, the square of the volume of the parallelepiped they span: this is the geometric content behind the Gramian criterion for linear independence (the volume is nonzero exactly when the vectors are independent) and behind Hadamard's inequality (the box of fixed edge lengths has maximal volume when its edges are orthogonal). The identity √(det Gram) = volume is the foundation of the geometry of numbers (Minkowski's lattice-point theorem measures fundamental domains by √det of the Gram matrix of a lattice basis), of integration on submanifolds (the area/volume element is √det of the first fundamental form), and of statistics (the volume of a confidence ellipsoid). Mathlib formalises the Gram matrix and its positive-definiteness criterion, the Haar measure of a parallelepiped in terms of a basis determinant, and the fact that an orthonormal basis induces the canonical volume — but it does not connect the parallelepiped's volume to the Gram determinant. This entry supplies that bridge, answering the parent's second open question by realising √(det gram v) as the parallelepiped volume.",
+    "problemStatement": "For a top-dimensional family v : ι → F in a finite-dimensional real inner product space F (an orthonormal basis indexed by ι, equivalently finrank ℝ F = card ι), identify the Lebesgue–Haar volume of the parallelepiped spanned by v with the square root of the Gram determinant: volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v))). Deduce the geometric form of the independence criterion (positive volume iff independent) and give a concrete instance on EuclideanSpace ℝ ι.",
+    "proofStrategy": "Fix an orthonormal basis b of F indexed by ι and let B := b.toMatrix v be the coordinate matrix, B k i = b.repr (v i) k = ⟪b k, v i⟫ (OrthonormalBasis.repr_apply_apply). Completeness of b gives ⟪v i, v j⟫ = ∑ k, ⟪b k, v i⟫ ⟪b k, v j⟫ (OrthonormalBasis.sum_inner_mul_inner, with real_inner_comm to match the orientation), i.e. gram ℝ v = Bᵀ * B (gram_eq_transpose_mul). Taking determinants, det (gram ℝ v) = det(Bᵀ) · det(B) = (det B)² = (b.det v)² (det_gram_eq_basis_det_sq, via Matrix.det_transpose, Matrix.det_mul, Basis.det_apply), so √(det (gram ℝ v)) = |b.det v| (sqrt_det_gram_eq_abs_det, Real.sqrt_sq_eq_abs). Finally, Mathlib's addHaar_parallelepiped computes b.toBasis.addHaar (parallelepiped v) = ENNReal.ofReal |b.det v|, and OrthonormalBasis.addHaar_eq_volume identifies b.toBasis.addHaar with the canonical volume, yielding volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v))) (volume_parallelepiped_eq_sqrt_det_gram). The EuclideanSpace corollary instantiates b = EuclideanSpace.basisFun. The positive-volume criterion rewrites along the volume identity, reduces 0 < ENNReal.ofReal (√·) to 0 < det via ENNReal.ofReal_pos and Real.sqrt_pos, and bridges det > 0 ↔ LinearIndependent using posDef_gram_iff_linearIndependent together with PosSemidef.posDef_iff_isUnit and the field fact det ≠ 0 ↔ IsUnit det.",
+    "keyInsights": [
+      "The volume identity is one matrix factorisation away from the Gramian criterion: in an orthonormal basis the Gram matrix is exactly BᵀB for the coordinate matrix B, so the Gram determinant is (det B)² — the square of the signed volume — and its square root is the unsigned volume |det B| that Mathlib already equates with the Haar measure of the parallelepiped.",
+      "Orthonormality is what makes the coordinate determinant the volume: for a general basis the Haar measure of the parallelepiped is |det B| relative to that basis, but only an orthonormal basis induces the canonical (isometry-invariant) volume, so OrthonormalBasis.addHaar_eq_volume is the step that turns a basis-relative statement into a canonical geometric one.",
+      "Squaring then square-rooting handles the sign cleanly: det B can be negative (orientation), but det(gram v) = (det B)² is manifestly nonnegative and √ recovers |det B|, exactly the unsigned volume — no orientation hypothesis is needed.",
+      "The positive-volume criterion is the geometry-of-numbers reading of the parent: a parallelepiped is degenerate (zero volume) precisely when its edges are linearly dependent, which here is det(gram v) = 0, i.e. the Gram matrix is positive semidefinite but not positive definite (not a unit).",
+      "Matching measure instances matters: Mathlib's measureSpaceOfInnerProductSpace supplies the canonical volume from MeasurableSpace + BorelSpace + FiniteDimensional, so the theorem must not assume an unrelated MeasureSpace instance, or the volume in the goal would not be the one OrthonormalBasis.addHaar_eq_volume produces."
+    ]
+  },
+  "sections": [
+    {
+      "id": "factorisation",
+      "title": "The Gram Matrix as BᵀB in an Orthonormal Basis",
+      "startLine": 50,
+      "endLine": 67,
+      "summary": "gram_eq_transpose_mul proves gram ℝ v = (b.toMatrix v)ᵀ * (b.toMatrix v) for an orthonormal basis b, by expanding the matrix product, rewriting the coordinate entries as inner products ⟪b k, v i⟫ (OrthonormalBasis.repr_apply_apply), and applying completeness OrthonormalBasis.sum_inner_mul_inner.",
+      "mathContext": "$\\mathrm{Gram}(v) = B^{\\mathsf T} B$, $B_{ki} = \\langle b_k, v_i\\rangle$ in an orthonormal basis $b$."
+    },
+    {
+      "id": "squared-volume",
+      "title": "The Gramian is the Squared Signed Volume",
+      "startLine": 69,
+      "endLine": 84,
+      "summary": "det_gram_eq_basis_det_sq gives det (gram ℝ v) = (b.det v)² from det(BᵀB) = (det B)² and Basis.det_apply; sqrt_det_gram_eq_abs_det then yields √(det (gram ℝ v)) = |b.det v| via Real.sqrt_sq_eq_abs.",
+      "mathContext": "$\\det\\mathrm{Gram}(v) = (\\det B)^2$, so $\\sqrt{\\det\\mathrm{Gram}(v)} = \\lvert\\det B\\rvert$."
+    },
+    {
+      "id": "volume-identity",
+      "title": "The Volume Identity",
+      "startLine": 86,
+      "endLine": 104,
+      "summary": "volume_parallelepiped_eq_sqrt_det_gram combines addHaar_parallelepiped (Haar measure = ofReal |b.det v|) with OrthonormalBasis.addHaar_eq_volume (orthonormal basis ⇒ canonical volume) and the square-root identity to give volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v))). volume_parallelepiped_euclidean specialises to EuclideanSpace ℝ ι.",
+      "mathContext": "$\\mathrm{vol}(\\mathrm{parallelepiped}\\,v) = \\sqrt{\\det\\mathrm{Gram}(v)}$."
+    },
+    {
+      "id": "positive-volume",
+      "title": "Positive Volume iff Independent",
+      "startLine": 106,
+      "endLine": 121,
+      "summary": "volume_parallelepiped_pos_iff_linearIndependent rewrites along the volume identity, reduces 0 < ofReal(√·) to 0 < det(gram v) (ENNReal.ofReal_pos, Real.sqrt_pos), and bridges to linear independence via posDef_gram_iff_linearIndependent, PosSemidef.posDef_iff_isUnit and isUnit_iff_ne_zero.",
+      "mathContext": "$\\mathrm{vol}(\\mathrm{parallelepiped}\\,v) > 0 \\iff v \\text{ linearly independent}$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-02-oq-01",
+      "question": "Extend the volume identity from the top-dimensional (square) case to a lower-dimensional family k < n via Cauchy–Binet: prove det(gram v) = ∑ over k-subsets S of the squared minors det(B_S)², identifying √(det gram v) with the k-dimensional Hausdorff content of the parallelepiped inside its span.",
+      "significance": "high"
+    },
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-02-oq-02",
+      "question": "Combine the volume identity with Hadamard's inequality (sibling entry oq-01-oq-01) to obtain the sharp geometric statement vol(parallelepiped v) ≤ ∏ ‖v i‖ with equality iff the edges are pairwise orthogonal — the isoperimetric characterisation of the box.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gram-linear-independence-iff-oq-01",
+      "relationship": "extends",
+      "description": "The parent established the Gramian criterion (det(gram v) > 0 iff independent). This entry gives its geometric meaning: √(det gram v) is the parallelepiped volume, and positive volume iff independent (volume_parallelepiped_pos_iff_linearIndependent)."
+    },
+    {
+      "targetId": "gram-linear-independence-iff-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "The sibling entry bounded the Gramian from above (Hadamard's inequality det(gram v) ≤ ∏ ‖v i‖²). Reading both through the volume identity gives vol ≤ ∏ ‖v i‖, the statement that the box of fixed edge lengths is largest when orthogonal."
+    },
+    {
+      "targetId": "minkowski-theorem",
+      "relationship": "supports",
+      "description": "Minkowski's geometry of numbers measures the covolume of a lattice by √det of the Gram matrix of a basis; the volume identity proved here is precisely the bridge between that Gram determinant and the actual volume of the fundamental parallelepiped."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Measure.Lebesgue.EqHaar",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of addHaar_parallelepiped (b.addHaar (parallelepiped v) = ofReal |b.det v|), the measure-theoretic half of the volume identity."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Measure.Haar.InnerProductSpace",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of OrthonormalBasis.addHaar_eq_volume and measureSpaceOfInnerProductSpace, identifying the orthonormal-basis Haar measure with the canonical volume."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a top-dimensional family v : ι → F in a finite-dimensional real inner product space, the Lebesgue–Haar volume of the parallelepiped spanned by v equals the square root of the Gram determinant: volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v))) (volume_parallelepiped_eq_sqrt_det_gram), with the concrete instance volume_parallelepiped_euclidean on EuclideanSpace ℝ ι. The proof factors the Gram matrix as gram ℝ v = BᵀB through the coordinate matrix in an orthonormal basis (gram_eq_transpose_mul), so det(gram v) = (b.det v)² is the squared signed volume (det_gram_eq_basis_det_sq) and √det = |b.det v| (sqrt_det_gram_eq_abs_det); Mathlib's addHaar_parallelepiped and OrthonormalBasis.addHaar_eq_volume then turn |b.det v| into the canonical volume of the parallelepiped. The geometric form of the independence criterion follows: the parallelepiped has positive volume iff v is linearly independent (volume_parallelepiped_pos_iff_linearIndependent). 121 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "This answers the parent entry's second open question and supplies to the gallery the geometric reading of the Gram determinant as a squared volume — the link underlying the geometry of numbers, integration on submanifolds, and the volume interpretation of Hadamard's inequality. The factorisation gram = BᵀB and the squared-volume identity are reusable for the Cauchy–Binet / k-dimensional content refinement and the volumetric form of Hadamard's bound recorded as open questions.",
+    "openQuestions": [
+      "Lower-dimensional (k < n) version via Cauchy–Binet: det(gram v) = ∑ squared minors, identifying √det with the k-dimensional content.",
+      "Volumetric Hadamard: vol(parallelepiped v) ≤ ∏ ‖v i‖ with equality iff orthogonal, combining this identity with the sibling Hadamard inequality."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `gram-linear-independence-iff-oq-01`: identify `√(det gram v)` with the **volume of the parallelepiped** spanned by `v`. This is the geometric meaning of the Gram determinant — the missing link Mathlib does not provide.

**Headline:** for a top-dimensional family `v : ι → F` in a finite-dimensional real inner product space,
```
volume (parallelepiped v) = ENNReal.ofReal (√(det (gram ℝ v)))
```

## Results (6 theorems, 0 def, 0 axioms, 0 sorries, 121 lines)

- `gram_eq_transpose_mul` — in an orthonormal basis `b`, `gram ℝ v = Bᵀ B` where `B = b.toMatrix v` (`B k i = ⟪b k, v i⟫`), from completeness `OrthonormalBasis.sum_inner_mul_inner`.
- `det_gram_eq_basis_det_sq` — `det (gram ℝ v) = (b.det v)²`, the squared signed volume.
- `sqrt_det_gram_eq_abs_det` — `√(det (gram ℝ v)) = |b.det v|`.
- `volume_parallelepiped_eq_sqrt_det_gram` — the volume identity (via `addHaar_parallelepiped` + `OrthonormalBasis.addHaar_eq_volume`).
- `volume_parallelepiped_euclidean` — concrete `EuclideanSpace ℝ ι` instance.
- `volume_parallelepiped_pos_iff_linearIndependent` — the parent's Gramian criterion read geometrically: positive volume ⟺ linearly independent.

## Distinctness

The sibling entry `…OQ01OQ01` already proves Hadamard's inequality `det(gram v) ≤ ∏‖vᵢ‖²` and the algebraic squared-volume `det(gram v) = ‖det B‖²`. This entry is **complementary**: the genuinely-new content is the **measure-theoretic** identity tying the Gramian to the Lebesgue–Haar `volume` of the parallelepiped, which is in neither Mathlib nor the gallery.

## Verification

`./bin/lake env lean Proofs/GramLinearIndependenceOQ01OQ02.lean` compiles clean (exit 0, no warnings). `#print axioms` on the headline results lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Gallery `annotations:validate` reports no errors for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)