### PR TITLE
Enrich Hilbert 17 univariate PSD=SOS: add index.ts, annotations, schema fixes

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-04/annotations.json
@@ -1,1 +1,74 @@
-{}
+[
+  {
+    "id": "h17-psd-def",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 34, "endLine": 37 },
+    "type": "definition",
+    "title": "Positive-Semidefinite Polynomials",
+    "content": "IsPSD p is the non-negativity predicate ∀ x : ℝ, 0 ≤ p.eval x — the hypothesis side of Hilbert's 17th. It is deliberately defined to be definitionally equal to the parent entry hilbert-17's IsPositiveSemidefinite, which is what lets the final theorem discharge the parent's axiom by exact reference rather than by a wrapping lemma.",
+    "mathContext": "$\\mathrm{IsPSD}(p) \\iff \\forall x \\in \\mathbb{R},\\ p(x) \\ge 0$",
+    "significance": "key",
+    "prerequisites": ["polynomial evaluation Polynomial.eval", "positive-semidefinite polynomials"],
+    "relatedConcepts": ["nonnegative polynomial", "Hilbert's 17th problem", "sum of squares (SOS)", "definitional equality"]
+  },
+  {
+    "id": "h17-brahmagupta",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 39, "endLine": 43 },
+    "type": "theorem",
+    "title": "Brahmagupta–Fibonacci Two-Square Identity",
+    "content": "The algebraic recombination engine: a product of two sums of two squares is again a sum of two squares, (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)². Over the polynomial ring ℝ[X] it is a pure ring identity (proved by ring). It is exactly what keeps the running product a sum of TWO squares as conjugate-pair quadratic factors are multiplied in during the induction — the same identity that underlies Gaussian-integer norms and the n=2 case of composition algebras.",
+    "mathContext": "$(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$",
+    "significance": "key",
+    "prerequisites": ["ring tactic", "commutative ring identities"],
+    "relatedConcepts": ["Brahmagupta–Fibonacci identity", "Gaussian integer norm", "two-square theorem", "composition algebra"]
+  },
+  {
+    "id": "h17-continuity-helper",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 45, "endLine": 52 },
+    "type": "lemma",
+    "title": "One-Sided Continuity Helper",
+    "content": "nonneg_of_forall_gt: if f is continuous at r and f ≥ 0 just to the right of r, then f r ≥ 0. Proved by restricting the limit to the right-neighbourhood filter 𝓝[>] r (mono_left of nhdsWithin_le_nhds) and applying ge_of_tendsto with self_mem_nhdsWithin. This is the right-hand half of the sign argument; the symmetric left-hand bound is inlined in the crux. The only genuinely analytic ingredient in the whole file.",
+    "mathContext": "$f \\text{ cts at } r,\\ (\\forall x > r,\\ f(x) \\ge 0) \\;\\Longrightarrow\\; f(r) \\ge 0$",
+    "significance": "supporting",
+    "prerequisites": ["nhdsWithin (one-sided neighbourhood filter)", "ge_of_tendsto", "ContinuousAt.tendsto", "filter_upwards"],
+    "relatedConcepts": ["one-sided limits", "continuity", "closed condition under limits", "sign preservation"]
+  },
+  {
+    "id": "h17-crux",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 54, "endLine": 91 },
+    "type": "theorem",
+    "title": "Analytic Crux: Real Roots Have Multiplicity ≥ 2",
+    "content": "sq_dvd_of_psd_root: a real root r of a non-negative p ≠ 0 satisfies (X − C r)² ∣ p. The proof is by contradiction on le_rootMultiplicity_iff: if the multiplicity were exactly 1, factor p = (X − C r)·g with g r ≠ 0 (exists_eq_pow_rootMultiplicity_mul_and_not_dvd). Then for x > r, p(x) = (x−r)·g(x) ≥ 0 with x−r > 0 forces g(x) ≥ 0, so g r ≥ 0 by the continuity helper; for x < r, x−r < 0 forces g(x) ≤ 0, so g r ≤ 0. Hence g r = 0, contradicting g r ≠ 0. This is the sign-change obstruction: a non-negative polynomial cannot cross zero with odd multiplicity.",
+    "mathContext": "$p \\ge 0,\\ p(r) = 0 \\;\\Longrightarrow\\; (X - r)^2 \\mid p$",
+    "significance": "critical",
+    "prerequisites": ["rootMultiplicity", "le_rootMultiplicity_iff", "exists_eq_pow_rootMultiplicity_mul_and_not_dvd", "one-sided limits", "mul_nonneg_iff_of_pos_left"],
+    "relatedConcepts": ["even multiplicity of PSD roots", "sign change at a root", "order of vanishing", "factor theorem"]
+  },
+  {
+    "id": "h17-induction",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 93, "endLine": 196 },
+    "type": "theorem",
+    "title": "Strong-Induction Engine: PSD ⟹ u² + v²",
+    "content": "psd_eq_sq_add_sq_aux: by strong induction on natDegree, every PSD polynomial is a sum of exactly two squares. Base cases: p = 0 gives 0²+0²; a constant c ≥ 0 gives (√c)²+0² (Real.sq_sqrt). For deg ≥ 1 the FTA (Complex.exists_root) yields a complex root z. If z.im = 0 (real root r = z.re): the crux gives (X−C r)² ∣ p, write p = (X−C r)²·q, show q is PSD (the (x−r)² factor is positive off r and the value at r is recovered by continuity), recurse on q (strictly smaller degree), and (X−C r)²(u²+v²) is two squares. If z.im ≠ 0: the everywhere-positive quadratic Q = (X−C z.re)²+(C z.im)² divides p (quadratic_dvd_of_aeval_eq_zero_im_ne_zero), q = p/Q is PSD of smaller degree, and Brahmagupta–Fibonacci turns Q·(u²+v²) into two squares.",
+    "mathContext": "$\\deg p = d,\\ p \\ge 0 \\;\\Longrightarrow\\; \\exists\\, u, v \\in \\mathbb{R}[X],\\ p = u^2 + v^2$",
+    "significance": "critical",
+    "prerequisites": ["Nat.strongRecOn", "fundamental theorem of algebra (Complex.exists_root)", "quadratic_dvd_of_aeval_eq_zero_im_ne_zero", "natDegree of products", "the analytic crux and Brahmagupta identity"],
+    "relatedConcepts": ["strong induction on degree", "FTA root extraction", "conjugate root pairs", "positive-definite quadratic", "degree reduction"]
+  },
+  {
+    "id": "h17-main",
+    "proofId": "hilbert-17-oq-03-oq-04",
+    "range": { "startLine": 198, "endLine": 207 },
+    "type": "theorem",
+    "title": "Hilbert's 17th, Univariate Case (Hilbert 1888)",
+    "content": "univariate_psd_is_sos: the headline theorem in the Hilbert-17 SOS form ∃ m (q : Fin m → ℝ[X]), p = ∑ i, q i². It instantiates the two-square engine with m = 2 and q = ![u, v] (Fin.sum_univ_two). Because IsPSD and this SOS predicate are definitionally equal to the parent hilbert-17 entry's, this 0-axiom proof discharges the parent's axiom univariate_psd_is_sos_aux, cutting the parent's axiom count from 3 to 2 — leaving only the multivariate-deep quadratic_psd_is_sos_aux and pfister_bound_aux.",
+    "mathContext": "$p \\ge 0 \\;\\Longrightarrow\\; \\exists\\, m\\ (q : \\mathrm{Fin}\\,m \\to \\mathbb{R}[X]),\\ p = \\sum_i q_i^2$",
+    "significance": "critical",
+    "prerequisites": ["Fin.sum_univ_two", "Matrix.cons vector notation ![·]", "the strong-induction engine"],
+    "relatedConcepts": ["Hilbert's 17th problem", "sum of squares", "Artin's theorem", "axiom discharge", "univariate vs multivariate gap"]
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-03-oq-04/index.ts
+++ b/src/data/proofs/hilbert-17-oq-03-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert17UnivariatePSDSOS.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert17Oq03Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert17Oq03Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert17Oq03Oq04Data: ProofData = {
+  proof: hilbert17Oq03Oq04Proof,
+  annotations: hilbert17Oq03Oq04Annotations,
+}

--- a/src/data/proofs/hilbert-17-oq-03-oq-04/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-04/meta.json
@@ -133,7 +133,18 @@
       "leanType": "ContinuousAt f r → (∀ x, r < x → 0 ≤ f x) → 0 ≤ f r"
     }
   ],
-  "overview": "Hilbert's 17th problem asks whether every polynomial that is non-negative on all of ℝⁿ is a sum of squares — of polynomials, or at least of rational functions. The univariate case n = 1 is both the historical starting point (Hilbert, 1888) and the only case where the strong, polynomial-valued conclusion holds: a non-negative p ∈ ℝ[X] is always a sum of two squares of real polynomials. (For n ≥ 2 the Motzkin and Robinson polynomials, siblings in this gallery, show one must allow rational functions.) The parent entry hilbert-17 carried the univariate result as the axiom univariate_psd_is_sos_aux; this follow-up proves it from scratch with 0 axioms, reducing the parent's axiom count from 3 to 2. The argument is a strong induction on degree with three moves. (1) Base: a non-negative constant c equals (√c)² + 0². (2) Real root: by the fundamental theorem of algebra a non-constant p has a complex root; if it is real, a non-negative polynomial must vanish there to even multiplicity — the analytic crux, proved by writing p = (x − r)·g for a simple root and using one-sided limits of g to force the contradictory signs g(r) ≥ 0 and g(r) ≤ 0 — so (X − C r)² divides p and the quotient is non-negative of smaller degree; then (X − C r)²·(u² + v²) is a sum of two squares. (3) Conjugate pair: if the root is non-real, the positive real quadratic Q = (X − C z.re)² + (C z.im)² divides p, the quotient is non-negative of smaller degree, and the Brahmagupta–Fibonacci identity turns Q·(u² + v²) into two squares. The formalization's only analytic ingredient is continuity of polynomial evaluation; everything else is the FTA (Complex.exists_root), the real-quadratic divisibility lemma, and root-multiplicity bookkeeping from Mathlib.",
+  "overview": {
+    "historicalContext": "Hilbert's 17th problem asks whether every polynomial that is non-negative on all of ℝⁿ is a sum of squares — of polynomials, or at least of rational functions. The univariate case n = 1 is both the historical starting point (Hilbert, 1888) and the only case where the strong, polynomial-valued conclusion holds: a non-negative p ∈ ℝ[X] is always a sum of two squares of real polynomials. For n ≥ 2 the Motzkin (1967) and Robinson polynomials — siblings in this gallery — are non-negative yet provably NOT sums of squares of polynomials, which is exactly why Hilbert had to weaken the conclusion to 'sum of squares of rational functions' (proved in general by Artin, 1927). The two-squares sharpness in one variable goes back to Hilbert's original 1888 memoir.",
+    "problemStatement": "Prove the univariate case of Hilbert's 17th problem with no axioms: every positive-semidefinite real univariate polynomial p ∈ ℝ[X] (one with p.eval x ≥ 0 for all x ∈ ℝ) is a sum of squares of real polynomials — in fact a sum of exactly two squares, p = u² + v². This discharges the parent entry hilbert-17's axiom univariate_psd_is_sos_aux, reducing its axiom count from 3 to 2.",
+    "proofStrategy": "Strong induction on degree, with three moves. (1) Base: a non-negative constant c equals (√c)² + 0². (2) Real root: by the fundamental theorem of algebra a non-constant p has a complex root; if it is real, a non-negative polynomial must vanish there to even multiplicity — the analytic crux sq_dvd_of_psd_root, proved by writing p = (x − r)·g for a hypothetical simple root and using one-sided limits of g to force the contradictory signs g(r) ≥ 0 (from the right) and g(r) ≤ 0 (from the left) — so (X − C r)² divides p and the quotient is non-negative of strictly smaller degree; then (X − C r)²·(u² + v²) is a sum of two squares. (3) Conjugate pair: if the root is non-real, the positive real quadratic Q = (X − C z.re)² + (C z.im)² divides p (Mathlib's quadratic_dvd_of_aeval_eq_zero_im_ne_zero), the quotient is non-negative of smaller degree, and the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)² turns Q·(u² + v²) into two squares. The only analytic ingredient is continuity of polynomial evaluation; everything else is the FTA (Complex.exists_root) plus root-multiplicity and divisibility bookkeeping from Mathlib.",
+    "keyInsights": [
+      "One variable is special: PSD ⟺ sum of (two) squares of polynomials holds for n = 1 but fails for n ≥ 2, where the Motzkin/Robinson polynomials force the passage to rational functions. This entry is the positive counterpart to those negative sibling examples.",
+      "The analytic crux is purely a sign argument: a real root of a non-negative polynomial cannot have odd multiplicity, because an odd factor (x − r)^odd changes sign across r. Formalized via one-sided limits of the quotient g, with no derivatives or Sturm sequences.",
+      "Two squares always suffice. Real roots are removed two at a time as (X − C r)², conjugate pairs as a single positive quadratic, and the Brahmagupta–Fibonacci identity keeps the running product a sum of exactly two squares throughout the induction.",
+      "The induction never leaves ℝ[X] except to borrow the FTA over ℂ: the complex root z is immediately split into the real-root and conjugate-pair cases by testing z.im = 0, and each case produces a real polynomial factor.",
+      "This is an axiom-discharging entry: the PSD and SOS predicates are definitionally equal to the parent hilbert-17's, so proving univariate_psd_is_sos here removes the parent's univariate_psd_is_sos_aux axiom by exact reference, leaving only the genuinely deep quadratic_psd_is_sos_aux (Gram/Cholesky) and pfister_bound_aux (Pfister's 2ⁿ bound)."
+    ]
+  },
   "conclusion": {
     "summary": "A 208-line, 0-sorry, 0-axiom formalization of the univariate case of Hilbert's 17th problem: every non-negative real univariate polynomial is a sum of two squares of polynomials. Discharges the parent entry's axiom univariate_psd_is_sos_aux (parent axiom count 3 → 2).",
     "implications": "This is the positive counterpart to the Motzkin and Robinson entries: in one variable, non-negativity and 'sum of squares of polynomials' coincide, so no passage to rational functions is needed. The proof is fully elementary — induction on degree, the FTA, even multiplicity of real roots via one-sided limits, and the two-square identity — with no real-closed-field, Gram-matrix, or Positivstellensatz machinery. It leaves the parent entry with just two genuinely deep axioms: quadratic_psd_is_sos_aux (Gram/Cholesky) and pfister_bound_aux (Pfister's 2ⁿ bound)."
@@ -154,17 +165,56 @@
   ],
   "crossReferences": [
     {
-      "slug": "hilbert-17",
-      "relation": "Parent entry; this discharges its axiom univariate_psd_is_sos_aux (axiom count 3 → 2)."
+      "proofId": "hilbert-17",
+      "relationship": "discharges-axiom-of",
+      "description": "Parent entry: states Artin's theorem and carried the univariate case as the axiom univariate_psd_is_sos_aux. This entry proves exactly that statement with 0 axioms, discharging the axiom by reference (parent axiom count 3 → 2)."
     },
     {
-      "slug": "hilbert-17-oq-03-oq-02",
-      "relation": "Sibling: the Motzkin polynomial, a multivariate PSD polynomial that is NOT a sum of squares of polynomials."
+      "proofId": "hilbert-17-oq-03-oq-02",
+      "relationship": "contrasts-with",
+      "description": "Sibling (multivariate, negative side): the Motzkin polynomial is non-negative but NOT a sum of squares of polynomials. Contrasts with this entry, which shows the polynomial conclusion DOES hold in one variable."
     },
     {
-      "slug": "hilbert-17-oq-03-oq-03",
-      "relation": "Sibling: the Robinson polynomial, the ternary PSD-but-not-polynomial-SOS counterexample."
+      "proofId": "hilbert-17-oq-03-oq-03",
+      "relationship": "contrasts-with",
+      "description": "Sibling (multivariate, negative side): the Robinson polynomial is the analogous ternary PSD-but-not-polynomial-SOS counterexample, the other witness that 'sum of squares of polynomials' must be weakened to rational functions for n ≥ 2."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "PSD Definition and the Brahmagupta–Fibonacci Identity",
+      "startLine": 30,
+      "endLine": 43,
+      "summary": "Defines IsPSD p (p.eval x ≥ 0 for all real x), definitionally equal to the parent entry's IsPositiveSemidefinite, and proves the Brahmagupta–Fibonacci two-square identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)² for polynomials by ring — the recombination engine for the conjugate-pair case."
+    },
+    {
+      "id": "continuity-helper",
+      "title": "One-Sided Continuity Helper",
+      "startLine": 45,
+      "endLine": 52,
+      "summary": "nonneg_of_forall_gt: a function continuous at r and non-negative just to the right of r has f r ≥ 0, via the half-neighbourhood limit 𝓝[>] r and ge_of_tendsto. The right-hand half of the sign argument behind the even-multiplicity crux."
+    },
+    {
+      "id": "analytic-crux",
+      "title": "Analytic Crux: Real Roots Have Even Multiplicity",
+      "startLine": 54,
+      "endLine": 91,
+      "summary": "sq_dvd_of_psd_root: a real root of a non-negative p ≠ 0 has multiplicity ≥ 2, so (X − C r)² ∣ p. If the multiplicity were 1, p = (X − C r)·g with g r ≠ 0; one-sided limits force g r ≥ 0 (from the right) and g r ≤ 0 (from the left), contradicting g r ≠ 0."
+    },
+    {
+      "id": "induction-engine",
+      "title": "Strong-Induction Engine: PSD ⟹ Sum of Two Squares",
+      "startLine": 93,
+      "endLine": 196,
+      "summary": "psd_eq_sq_add_sq_aux: strong induction on degree. Base cases p = 0 and constant (√c)²+0². For deg ≥ 1 the FTA gives a complex root: if real, divide by (X − C r)² (crux) and recurse; if non-real, divide by the everywhere-positive quadratic Q = (X − C z.re)² + (C z.im)² and recombine via Brahmagupta–Fibonacci. Both branches strictly drop the degree."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Hilbert's 17th, Univariate Case",
+      "startLine": 198,
+      "endLine": 208,
+      "summary": "univariate_psd_is_sos: packages the two-square engine into the Hilbert-17 form ∃ m (q : Fin m → ℝ[X]), p = ∑ q i² with m = 2 and q = ![u, v]. This is definitionally the parent's univariate_psd_is_sos_aux, discharging that axiom with 0 axioms."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-03-oq-04` (Hilbert's 17th: Every Non-Negative Univariate Polynomial Is a Sum of Squares). This entry had quality 10 — several structural gaps:

## Gaps fixed
- **Missing `index.ts`** — no Vite entry point → *'proof not found'* on the live site. Added (Lean source `Hilbert17UnivariatePSDSOS.lean`).
- **`annotations.json` was `{}`** (not even a valid array) — replaced with **6 inline annotations** covering all parts.
- **`overview` was a flat string** — the `ProofOverview` type expects an object; converted to `{ historicalContext, problemStatement, proofStrategy, keyInsights[] }` (5 key insights).
- **`crossReferences` used wrong field names** `{slug, relation}` — fixed to the typed `{proofId, relationship, description}`.
- **`sections` was empty** — populated 5 sections covering the 208-line file.

## Annotation coverage
`IsPSD` definition · Brahmagupta–Fibonacci identity · one-sided continuity helper · the even-multiplicity analytic crux (`sq_dvd_of_psd_root`) · the strong-induction engine (FTA + real/conjugate split) · the main theorem `univariate_psd_is_sos` (discharges the parent's axiom, 3→2).

Axiom status verified accurate: `verified`, 0 axioms, 0 sorries. `pnpm build` passes.