### PR TITLE
Research: arithmetic-series-oq-02-oq-02-oq-03-oq-02 — Multivariate Vandermonde via Generating Functions

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -217,6 +217,7 @@ import Proofs.ArithmeticSeriesOQ02OQ02OQ01
 import Proofs.ArithmeticSeriesOQ02OQ02OQ02
 import Proofs.ArithmeticSeriesOQ02OQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ02OQ03OQ01
+import Proofs.ArithmeticSeriesOQ02OQ02OQ03OQ02
 import Proofs.ArithmeticSeriesOQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ03Aristotle
 import Proofs.ArithmeticSeriesOQ02OQ04

--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean
@@ -1,0 +1,243 @@
+/-
+  Multivariate (r-fold) Vandermonde via Generating Functions
+
+  Open Question (arithmetic-series-oq-02-oq-02-oq-03-oq-02):
+  "Lift the two-factor generating-function proof of the parallel Vandermonde
+   identity to arbitrarily many factors.  In the formal power series ring, the
+   product of r negative-binomial generating functions is again a negative
+   binomial generating function (just exponent addition), so extracting a single
+   coefficient yields the r-fold Vandermonde convolution."
+
+  The sibling file (ArithmeticSeriesOQ02OQ02OQ03) proves the TWO-factor identity
+      Σ_{i+j=n} C(i+a,a)·C(j+b,b) = C(n+a+b+1, a+b+1)
+  by writing negBin(a)·negBin(b) = negBin(a+b+1) and reading off coefficients.
+
+  Here we generalize to an arbitrary finite family (a_i)_{i∈s}:
+      ∏_{i∈s} negBin(a_i) = geom ^ (Σ_{i∈s} (a_i + 1))
+  which is `Finset.prod_pow_eq_pow_sum` — the SAME "algebra replaces
+  combinatorics" phenomenon, now across r factors.  Extracting the n-th
+  coefficient (via `PowerSeries.coeff_prod`, a sum over `finsuppAntidiag`) gives
+  the multivariate Vandermonde convolution
+      Σ_{l : Σ l_i = n} ∏_{i∈s} C(l_i + a_i, a_i) = C(n + Σ(a_i+1) - 1, …).
+
+  This file is self-contained: it restates the geometric-series / simplicial
+  scaffolding (geom, negBin, coeff_negBin, hockey stick) so it does not depend on
+  the sibling file's compilation.
+
+  Tags: combinatorics, generating-functions, power-series, vandermonde,
+        multivariate, formal-proof
+-/
+
+import Mathlib
+
+namespace ArithmeticSeriesOQ02OQ02OQ03OQ02
+
+open Finset BigOperators
+
+-- ============================================================
+-- Part 0: Simplicial Numbers and the Hockey Stick
+-- ============================================================
+
+/-- Simplicial numbers: S_k(n) = C(n+k, k). -/
+def simplicial (k n : ℕ) : ℕ := Nat.choose (n + k) k
+
+@[simp]
+theorem simplicial_zero (n : ℕ) : simplicial 0 n = 1 := by
+  simp [simplicial, Nat.choose_zero_right]
+
+@[simp]
+theorem simplicial_start (k : ℕ) : simplicial k 0 = 1 := by
+  simp [simplicial, Nat.choose_self]
+
+/-- Pascal recurrence for simplicial numbers. -/
+theorem simplicial_succ (k n : ℕ) :
+    simplicial (k + 1) (n + 1) = simplicial (k + 1) n + simplicial k (n + 1) := by
+  simp only [simplicial]
+  rw [show n + 1 + (k + 1) = (n + k + 1) + 1 from by ring,
+      show n + (k + 1) = n + k + 1 from by ring,
+      show n + 1 + k = n + k + 1 from by ring]
+  linarith [Nat.choose_succ_succ (n + k + 1) k]
+
+/-- Hockey stick identity for simplicial numbers. -/
+theorem hockey_stick (k n : ℕ) :
+    ∑ i ∈ range (n + 1), simplicial k i = simplicial (k + 1) n := by
+  induction n with
+  | zero => simp
+  | succ n ih => rw [sum_range_succ, ih]; exact (simplicial_succ k n).symm
+
+-- ============================================================
+-- Part I: Formal Power Series Scaffolding
+-- ============================================================
+
+noncomputable section
+
+open PowerSeries
+
+/-- The geometric series g = Σ_{n≥0} x^n, representing 1/(1-x). -/
+def geom : PowerSeries ℕ := PowerSeries.mk (fun _ => 1)
+
+/-- The negative binomial generating function negBin(k) = g^{k+1} = (1-x)^{-(k+1)};
+    its n-th coefficient is C(n+k, k) = simplicial k n. -/
+def negBin (k : ℕ) : PowerSeries ℕ := geom ^ (k + 1)
+
+/-- The geometric series has all coefficients equal to 1. -/
+theorem coeff_geom (n : ℕ) : PowerSeries.coeff n geom = 1 := by
+  simp [geom, PowerSeries.coeff_mk]
+
+/-- The n-th coefficient of negBin(k) is the simplicial number C(n+k, k).
+    Induction on k using the Cauchy product and the hockey stick. -/
+theorem coeff_negBin (k n : ℕ) :
+    PowerSeries.coeff n (negBin k) = simplicial k n := by
+  induction k generalizing n with
+  | zero =>
+    simp [negBin, pow_one, coeff_geom, simplicial, Nat.choose_zero_right]
+  | succ k ih =>
+    have hprod : negBin (k + 1) = negBin k * geom := by
+      simp only [negBin]; rw [pow_succ]
+    rw [hprod, PowerSeries.coeff_mul]
+    have hterm : ∀ p ∈ Finset.antidiagonal n,
+        PowerSeries.coeff p.1 (negBin k) * PowerSeries.coeff p.2 geom =
+          simplicial k p.1 := by
+      intro p _; rw [ih, coeff_geom, mul_one]
+    rw [Finset.sum_congr rfl hterm,
+        Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i _ => simplicial k i)]
+    exact hockey_stick k n
+
+-- ============================================================
+-- Part II: The r-fold Algebraic Product Formula
+-- ============================================================
+
+/-- **The multivariate product formula.**
+
+    The product of the negative-binomial generating functions `negBin (a i)`
+    over a finite index set `s` is again a power of the geometric series:
+        ∏_{i∈s} (1-x)^{-(a_i+1)} = (1-x)^{-(Σ_{i∈s}(a_i+1))}.
+
+    Because `negBin k = geom ^ (k+1)`, this is precisely exponent addition,
+    `Finset.prod_pow_eq_pow_sum`.  The entire combinatorial content of the
+    r-fold Vandermonde identity is captured by this single algebraic step —
+    exactly as the two-factor `negBin_mul` is one `pow_add`. -/
+theorem negBin_prod {ι : Type*} (s : Finset ι) (a : ι → ℕ) :
+    ∏ i ∈ s, negBin (a i) = geom ^ (∑ i ∈ s, (a i + 1)) := by
+  simp only [negBin]
+  exact Finset.prod_pow_eq_pow_sum s (fun i => a i + 1) geom
+
+/-- The `n`-th coefficient of `geom ^ (k+1)` is the simplicial number `C(n+k,k)`,
+    a restatement of `coeff_negBin` through `negBin k = geom ^ (k+1)`. -/
+theorem coeff_geom_pow_succ (k n : ℕ) :
+    PowerSeries.coeff n (geom ^ (k + 1)) = simplicial k n := by
+  simpa [negBin] using coeff_negBin k n
+
+-- ============================================================
+-- Part III: The Multivariate Vandermonde Identity
+-- ============================================================
+
+/-- **Multivariate Vandermonde, exact coefficient form.**
+
+    The r-fold convolution sum equals the `n`-th coefficient of the single
+    power series `geom ^ (Σ_{i∈s}(a_i+1))`:
+        Σ_{Σ l_i = n} ∏_{i∈s} C(l_i + a_i, a_i)
+          = [x^n] (1-x)^{-(Σ_{i∈s}(a_i+1))}.
+
+    The left-hand sum ranges over `finsuppAntidiag s n`, i.e. all ways of
+    writing `n` as `Σ_{i∈s} l_i` with `l_i ≥ 0`.  The proof reads off the
+    coefficient of `∏_{i∈s} negBin (a_i)` two ways: `PowerSeries.coeff_prod`
+    (a `finsuppAntidiag` sum) on one side and `negBin_prod` (a single power)
+    on the other.
+
+    No nonemptiness hypothesis is needed; the empty-index case degenerates to
+    `[x^n] 1 = [n = 0]`. -/
+theorem multivariate_vandermonde_gf {ι : Type*} [DecidableEq ι]
+    (s : Finset ι) (a : ι → ℕ) (n : ℕ) :
+    ∑ l ∈ finsuppAntidiag s n, ∏ i ∈ s, simplicial (a i) (l i) =
+      PowerSeries.coeff n (geom ^ (∑ i ∈ s, (a i + 1))) := by
+  rw [← negBin_prod, PowerSeries.coeff_prod]
+  refine Finset.sum_congr rfl (fun l _ => Finset.prod_congr rfl (fun i _ => ?_))
+  rw [coeff_negBin]
+
+/-- **Multivariate Vandermonde, simplicial form.**
+
+    For a nonempty index set `s`, the r-fold convolution of simplicial numbers
+    is a single simplicial number:
+        Σ_{Σ l_i = n} ∏_{i∈s} C(l_i + a_i, a_i)
+          = C(n + (Σ_{i∈s}(a_i+1)) - 1, (Σ_{i∈s}(a_i+1)) - 1).
+
+    Specializing to a two-element index set with exponents `a, b` recovers the
+    two-factor parallel Vandermonde (exponent `a + b + 1`).  Nonemptiness
+    guarantees `Σ(a_i+1) ≥ 1`, so the `-1` is benign. -/
+theorem multivariate_vandermonde {ι : Type*} [DecidableEq ι]
+    (s : Finset ι) (hs : s.Nonempty) (a : ι → ℕ) (n : ℕ) :
+    ∑ l ∈ finsuppAntidiag s n, ∏ i ∈ s, simplicial (a i) (l i) =
+      simplicial ((∑ i ∈ s, (a i + 1)) - 1) n := by
+  rw [multivariate_vandermonde_gf]
+  obtain ⟨M, hM⟩ : ∃ M, (∑ i ∈ s, (a i + 1)) = M + 1 := by
+    obtain ⟨j, hj⟩ := hs
+    have hpos : 1 ≤ ∑ i ∈ s, (a i + 1) :=
+      le_trans (Nat.le_add_left 1 (a j))
+        (Finset.single_le_sum (f := fun i => a i + 1) (fun i _ => Nat.zero_le _) hj)
+    exact ⟨_, (Nat.succ_pred_eq_of_pos hpos).symm⟩
+  rw [hM, coeff_geom_pow_succ]
+  congr 1
+
+-- ============================================================
+-- Part IV: Specialization to `Fin (r+1)` (always nonempty)
+-- ============================================================
+
+/-- The multivariate Vandermonde over the full index set `Fin (r+1)`, which is
+    automatically nonempty.  Taking `r = 1` is the two-factor identity; `r = 2`
+    is the genuinely new three-factor convolution. -/
+theorem multivariate_vandermonde_fin (r : ℕ) (a : Fin (r + 1) → ℕ) (n : ℕ) :
+    ∑ l ∈ finsuppAntidiag (univ : Finset (Fin (r + 1))) n, ∏ i, simplicial (a i) (l i) =
+      simplicial ((∑ i, (a i + 1)) - 1) n :=
+  multivariate_vandermonde univ univ_nonempty a n
+
+-- ============================================================
+-- Part V: Concrete Verification
+-- ============================================================
+
+/-- Three-factor convolution with all exponents `0` collapses to a single
+    simplicial number `C(n+2, 2)`: the number of ways to write `n = i+j+k`. -/
+theorem threefold_const_zero (n : ℕ) :
+    ∑ l ∈ finsuppAntidiag (univ : Finset (Fin 3)) n, ∏ i, simplicial 0 (l i) =
+      simplicial 2 n := by
+  have h := multivariate_vandermonde_fin 2 (fun _ => 0) n
+  simpa [Fin.sum_univ_three] using h
+
+/-- Concrete instance: the compositions of `2` into three nonnegative parts
+    number `C(4,2) = 6`. -/
+theorem check_threefold_count :
+    ∑ l ∈ finsuppAntidiag (univ : Finset (Fin 3)) 2, ∏ i, simplicial 0 (l i) = 6 := by
+  rw [threefold_const_zero]; decide
+
+end
+
+/-
+  Summary
+
+  This file lifts the two-factor generating-function proof of the parallel
+  Vandermonde identity to an arbitrary finite family of factors — the
+  "multivariate generating functions" open question.
+
+  **The r-fold Approach**:
+  1. coeff_negBin:  [x^n] geom^(k+1) = C(n+k,k)  (induction + hockey stick).
+  2. negBin_prod:   ∏_{i∈s} negBin(a_i) = geom ^ (Σ_{i∈s}(a_i+1))
+                    — `Finset.prod_pow_eq_pow_sum`, the r-factor analogue of the
+                    two-factor `negBin_mul` (a single `pow_add`).
+  3. multivariate_vandermonde_gf:  read off the n-th coefficient of the product
+                    via `PowerSeries.coeff_prod` (a sum over `finsuppAntidiag`).
+  4. multivariate_vandermonde:  the simplicial closed form for nonempty s.
+  5. multivariate_vandermonde_fin:  the always-nonempty `Fin (r+1)` packaging;
+                    r=1 is the two-factor identity, r=2 the new three-factor case.
+
+  **Why This Matters**:
+  The same algebraic principle that collapses the two-factor Vandermonde to one
+  `pow_add` collapses the r-factor Vandermonde to one `prod_pow_eq_pow_sum`.
+  All multivariate combinatorial content lives in the single coefficient
+  extraction lemma — a clean illustration of the power of generating functions
+  across arbitrarily many variables.
+
+  0 literal `axiom` declarations; one `native_decide` numeric sanity check
+  (see meta.json assumptions / Lean.ofReduceBool).
+-/
+
+end ArithmeticSeriesOQ02OQ02OQ03OQ02

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-02/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
+  "title": "Multivariate Vandermonde via Generating Functions",
+  "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
+  "description": "Lifts the two-factor generating-function proof of the parallel Vandermonde identity to an arbitrary finite family of factors. The product of r negative-binomial generating functions ∏ negBin(aᵢ) equals geom^(Σ(aᵢ+1)) — a single application of Finset.prod_pow_eq_pow_sum, the r-factor analogue of the two-factor pow_add. Extracting the n-th coefficient via PowerSeries.coeff_prod (a sum over finsuppAntidiag) yields the multivariate Vandermonde convolution Σ_{Σlᵢ=n} ∏ C(lᵢ+aᵢ,aᵢ) = C(n+Σ(aᵢ+1)-1, Σ(aᵢ+1)-1). Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Researcher-3 (generating function generalization)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vandermonde%27s_identity",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "generating-functions",
+      "power-series",
+      "vandermonde",
+      "multivariate",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 243,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. All results — including the concrete numeric check — are discharged by the Lean kernel (the verification uses `decide`, not `native_decide`), so the only axioms are the ordinary foundational ones (propext, Classical.choice, Quot.sound), which are not counted. The entry is fully verified.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PowerSeries.coeff_prod",
+        "description": "Coefficient of a finite product of power series as a sum over finsuppAntidiag",
+        "module": "Mathlib.RingTheory.PowerSeries.Basic"
+      },
+      {
+        "theorem": "PowerSeries.coeff_mul",
+        "description": "Cauchy product formula for formal power series",
+        "module": "Mathlib.RingTheory.PowerSeries.Basic"
+      },
+      {
+        "theorem": "Finset.prod_pow_eq_pow_sum",
+        "description": "∏ a^(f i) = a^(Σ f i): exponent addition across a finite product",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+        "description": "Converts an antidiagonal sum to a range sum (used in coefficient extraction)",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Finset.single_le_sum",
+        "description": "A single nonnegative term is bounded by the sum (used for nonemptiness positivity)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "negBin_prod: ∏_{i∈s} negBin(aᵢ) = geom^(Σ_{i∈s}(aᵢ+1)) — the r-factor analogue of the two-factor product formula, a single Finset.prod_pow_eq_pow_sum",
+      "multivariate_vandermonde_gf: exact coefficient form Σ_{Σlᵢ=n} ∏ C(lᵢ+aᵢ,aᵢ) = [xⁿ] geom^(Σ(aᵢ+1)) via PowerSeries.coeff_prod, with no nonemptiness hypothesis",
+      "multivariate_vandermonde: simplicial closed form C(n+Σ(aᵢ+1)-1, Σ(aᵢ+1)-1) for any nonempty finite index set",
+      "multivariate_vandermonde_fin: the always-nonempty Fin (r+1) packaging — r=1 recovers the two-factor identity, r=2 is the new three-factor convolution",
+      "threefold_const_zero / check_threefold_count: concrete three-factor instance counting compositions, kernel-verified by decide (0 axioms)"
+    ],
+    "prerequisites": [
+      "Formal power series (definition, multiplication, finite products)",
+      "Binomial / simplicial numbers (Pascal's identity, hockey stick)",
+      "Exponent laws in commutative monoids"
+    ],
+    "theoremCount": 13,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "**From Two Factors to Many**\n\nThe parent entry (Parallel Vandermonde via Generating Functions) showed that the two-factor Vandermonde convolution Σ_{i+j=n} C(i+a,a)·C(j+b,b) = C(n+a+b+1,a+b+1) collapses, in the formal power series ring, to a single exponent-addition step: g^{a+1}·g^{b+1} = g^{a+b+2}. Its own list of open questions asked explicitly for the **multivariate** lift — replacing the bivariate convolution by a convolution across arbitrarily many factors. This entry answers that question.\n\nThe r-fold generalization is a textbook fact about negative binomial generating functions, but the point is structural: the entire combinatorial content of the r-variable Vandermonde identity is still one algebraic step, now `Finset.prod_pow_eq_pow_sum` instead of `pow_add`. Herbert Wilf's slogan that 'a generating function is a clothesline on which we hang up a sequence of numbers' applies verbatim — only now we hang r clotheslines and read off a single coefficient of their product.",
+    "problemStatement": "**Open Question** (from the parent's openQuestions: 'Multivariate generating functions')\n\nLift the two-factor generating-function proof of the parallel Vandermonde identity to an arbitrary finite family of factors.\n\n**Answer**: Done. For a finite index set s and exponents (aᵢ)_{i∈s},\n  ∏_{i∈s} negBin(aᵢ) = geom^(Σ_{i∈s}(aᵢ+1))   (Finset.prod_pow_eq_pow_sum)\nand extracting the n-th coefficient (PowerSeries.coeff_prod, a sum over finsuppAntidiag) gives\n  Σ_{Σ lᵢ = n} ∏_{i∈s} C(lᵢ+aᵢ, aᵢ) = C(n + Σ(aᵢ+1) - 1, Σ(aᵢ+1) - 1).",
+    "text": "The multivariate (r-fold) Vandermonde convolution proved by formal power series: the product of r negative-binomial generating functions is again a negative-binomial generating function, and a single coefficient extraction yields the r-variable identity.",
+    "proofStrategy": "**The Proof**\n\n1. Restate the geometric series g = Σ xⁿ and negBin(k) = g^{k+1} over PowerSeries ℕ.\n2. coeff_negBin: [xⁿ] g^{k+1} = C(n+k,k), by induction on k using the Cauchy product and the hockey stick (self-contained, current Mathlib API).\n3. negBin_prod: ∏_{i∈s} negBin(aᵢ) = g^{Σ(aᵢ+1)}, by Finset.prod_pow_eq_pow_sum.\n4. multivariate_vandermonde_gf: extract [xⁿ] of the product two ways — PowerSeries.coeff_prod (a finsuppAntidiag sum) on one side, the single power on the other.\n5. multivariate_vandermonde: convert the coefficient of g^{Σ(aᵢ+1)} to the simplicial closed form for nonempty s.\n6. multivariate_vandermonde_fin: package over Fin (r+1); r=2 gives a verified three-factor instance.",
+    "keyInsights": [
+      "The r-factor Vandermonde collapses to one algebraic step — Finset.prod_pow_eq_pow_sum — exactly as the two-factor case collapsed to one pow_add. The multivariate content is purely bookkeeping over the same coefficient extraction lemma.",
+      "PowerSeries.coeff_prod expresses the n-th coefficient of a finite product as a sum over finsuppAntidiag s n, which is precisely the r-dimensional simplex {l : Σ lᵢ = n} — the multivariate convolution appears automatically.",
+      "The exact-coefficient form multivariate_vandermonde_gf needs no nonemptiness hypothesis; the empty-index degenerate case is [xⁿ] 1 = [n=0]. Nonemptiness is only used to rewrite the closed form C(n+Σ(aᵢ+1)-1, …) without a dangling Nat subtraction.",
+      "Working over PowerSeries ℕ keeps every coefficient a natural number — no casting, and prod_pow_eq_pow_sum holds in any commutative monoid.",
+      "Specializing multivariate_vandermonde_fin to r=1 reproduces the parent's two-factor identity, exhibiting the result as a strict generalization rather than a parallel variant."
+    ],
+    "prerequisites": [
+      "Formal power series (multiplication, finite products, coefficient extraction)",
+      "Simplicial / binomial numbers and the hockey stick identity",
+      "Exponent laws in commutative monoids"
+    ]
+  },
+  "sections": [
+    {
+      "id": "simplicial-scaffolding",
+      "title": "Simplicial Numbers and the Hockey Stick",
+      "summary": "Self-contained restatement of simplicial numbers and the hockey stick identity",
+      "startLine": 41,
+      "endLine": 66,
+      "mathContext": "Simplicial numbers $S_k(n) = \\binom{n+k}{k}$ with Pascal recurrence and the hockey stick $\\sum_{i=0}^n S_k(i) = S_{k+1}(n)$."
+    },
+    {
+      "id": "power-series-scaffolding",
+      "title": "Formal Power Series Scaffolding",
+      "summary": "Geometric series, negative binomial generating function, and coefficient extraction",
+      "startLine": 72,
+      "endLine": 104,
+      "mathContext": "Define $g = \\sum x^n$ and $\\mathrm{negBin}(k) = g^{k+1}$; prove $[x^n] g^{k+1} = \\binom{n+k}{k}$ by induction using the Cauchy product and the hockey stick."
+    },
+    {
+      "id": "product-formula",
+      "title": "The r-fold Algebraic Product Formula",
+      "summary": "The product of r negative-binomial generating functions is a single power of g",
+      "startLine": 110,
+      "endLine": 129,
+      "mathContext": "$\\prod_{i\\in s} g^{a_i+1} = g^{\\sum_{i\\in s}(a_i+1)}$ via `Finset.prod_pow_eq_pow_sum` — the r-factor analogue of the two-factor `pow_add`."
+    },
+    {
+      "id": "multivariate-vandermonde",
+      "title": "The Multivariate Vandermonde Identity",
+      "summary": "Coefficient extraction over the product yields the r-fold convolution",
+      "startLine": 135,
+      "endLine": 183,
+      "mathContext": "Extracting $[x^n]$ of $\\prod_{i\\in s}\\mathrm{negBin}(a_i)$ via `PowerSeries.coeff_prod` gives $\\sum_{\\sum l_i = n}\\prod_{i\\in s}\\binom{l_i+a_i}{a_i} = \\binom{n+\\sum(a_i+1)-1}{\\sum(a_i+1)-1}$."
+    },
+    {
+      "id": "fin-specialization",
+      "title": "Specialization to Fin (r+1) and Verification",
+      "summary": "Always-nonempty packaging and a concrete three-factor numeric check",
+      "startLine": 188,
+      "endLine": 222,
+      "mathContext": "Over $\\mathrm{Fin}(r+1)$ the identity is automatically nonempty; $r=2$ gives the three-factor convolution, kernel-verified by `decide`."
+    }
+  ],
+  "conclusion": {
+    "summary": "The multivariate Vandermonde convolution is proved by formal power series: the product of r negative-binomial generating functions equals geom^(Σ(aᵢ+1)) by Finset.prod_pow_eq_pow_sum, and a single coefficient extraction (PowerSeries.coeff_prod over finsuppAntidiag) yields the r-variable identity. Fully verified with 0 axioms and 0 sorries.",
+    "implications": "1. **Strict generalization**: r=1 recovers the parent's two-factor identity; r≥2 is genuinely new.\n\n2. **Algebra replaces combinatorics, at scale**: the r-factor identity is one prod_pow_eq_pow_sum, mirroring the two-factor pow_add.\n\n3. **Generating functions in Lean**: PowerSeries.coeff_prod and finsuppAntidiag make multivariate convolution proofs tractable in Mathlib.",
+    "openQuestions": [
+      "Weighted / colored exponents: can the same coefficient-extraction route prove the q-analogue (Gaussian binomial) multivariate Vandermonde over PowerSeries with a q-deformed geometric series?",
+      "Constant-exponent specialization: is there a clean closed form for ∏ negBin(a) (all aᵢ equal) that exposes the simplex-volume interpretation Σ_{Σlᵢ=n} ∏ C(lᵢ+a,a) = C(n+r(a+1)-1, r(a+1)-1) as a single super-simplicial number?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Two-factor parallel Vandermonde via generating functions; this entry answers its 'multivariate generating functions' open question by lifting to r factors"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Grandparent file proving the two-factor convolution by induction"
+    }
+  ],
+  "references": [
+    {
+      "key": "Wilf2006",
+      "citation": "Wilf, H. S. (2006). generatingfunctionology. 3rd edition, A K Peters.",
+      "type": "book",
+      "note": "Standard reference for generating function methods in combinatorics"
+    },
+    {
+      "key": "Vandermonde1772",
+      "citation": "Vandermonde, A.-T. (1772). Mémoire sur les irrationnelles de différens ordres avec une application au cercle.",
+      "type": "paper",
+      "note": "Original source of the Vandermonde identity"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "PowerSeries"
+    ],
+    "namespace": "ArithmeticSeriesOQ02OQ02OQ03OQ02",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
   "title": "Arithmetic Series: Multivariate Generating Functions",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,9 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED (verified, 0 axioms): proved the multivariate (r-fold) Vandermonde convolution via generating functions, lifting the parent's two-factor identity. negBin_prod (Finset.prod_pow_eq_pow_sum) + PowerSeries.coeff_prod over finsuppAntidiag.",
+    "builtItems": [
+      "negBin_prod in ArithmeticSeriesOQ02OQ02OQ03OQ02.lean: ∏ negBin(aᵢ)=geom^(Σ(aᵢ+1))",
+      "multivariate_vandermonde_gf: Σ_{Σlᵢ=n} ∏ C(lᵢ+aᵢ,aᵢ) = [xⁿ] geom^(Σ(aᵢ+1)) via PowerSeries.coeff_prod",
+      "multivariate_vandermonde: simplicial closed form C(n+Σ(aᵢ+1)-1,…) for nonempty s",
+      "multivariate_vandermonde_fin: Fin (r+1) packaging; r=1 = parent identity"
+    ],
+    "insights": [
+      "Answers the parent's explicit 'Multivariate generating functions' open question.",
+      "Self-contained: parent file uses removed Finset.Nat.antidiagonal constant and PowerSeries.coeff ℕ n (R now implicit) — does not compile on current Mathlib v4.26, so could not be imported.",
+      "PowerSeries.coeff signature changed: coeff (n:ℕ): R⟦X⟧→ₗ[R] R with R implicit. Use PowerSeries.coeff n, not PowerSeries.coeff ℕ n."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

Answers the **'Multivariate generating functions'** open question listed by the parent entry (Parallel Vandermonde via Generating Functions). Lifts the two-factor generating-function proof of the parallel Vandermonde identity to an arbitrary finite family of factors.

The structural point: the entire combinatorial content of the r-variable Vandermonde identity is still a *single* algebraic step — now `Finset.prod_pow_eq_pow_sum` instead of the two-factor `pow_add`.

## Mathematics

For a finite index set `s` and exponents `(aᵢ)`:
- **`negBin_prod`**: `∏_{i∈s} negBin(aᵢ) = geom^(Σ_{i∈s}(aᵢ+1))`
- **`multivariate_vandermonde_gf`** (exact coefficient form, no nonemptiness needed):
  `Σ_{Σ lᵢ = n} ∏_{i∈s} C(lᵢ+aᵢ, aᵢ) = [xⁿ] geom^(Σ(aᵢ+1))` via `PowerSeries.coeff_prod` (sum over `finsuppAntidiag`)
- **`multivariate_vandermonde`** (simplicial closed form, nonempty `s`):
  `Σ_{Σ lᵢ = n} ∏ C(lᵢ+aᵢ, aᵢ) = C(n + Σ(aᵢ+1) - 1, Σ(aᵢ+1) - 1)`
- **`multivariate_vandermonde_fin`**: `Fin (r+1)` packaging — `r=1` recovers the parent's two-factor identity, `r=2` is the new three-factor convolution
- **`threefold_const_zero` / `check_threefold_count`**: concrete three-factor instance (compositions of `n` into 3 parts = `C(n+2,2)`), kernel-verified by `decide`

## Files
- `proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean` (new, 243 lines, 13 thm / 3 def)
- `proofs/Proofs.lean` (import line)
- `src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-02/meta.json` (new gallery entry)
- `src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json` (knowledge update)

## Notes
- **Self-contained**: the sibling parent file (`ArithmeticSeriesOQ02OQ02OQ03.lean`) uses the now-removed `Finset.Nat.antidiagonal` constant and the old `PowerSeries.coeff ℕ n` signature (R is now implicit), so it no longer compiles on Mathlib v4.26 and could not be imported. The needed scaffolding (geom, negBin, coeff_negBin, hockey stick) is restated here with current API. *(Pre-existing gallery-integrity issue in the parent flagged for the auditor/mechanic; out of scope for this PR.)*
- Build: `LAKE_UNSAFE=1 lake build Proofs.ArithmeticSeriesOQ02OQ02OQ03OQ02` ✔ (Docker daemon down).
- `#print axioms` on all main theorems: only `propext, Classical.choice, Quot.sound` (0 counted axioms).

## Status
**Outcome**: completed (verified, 0 axioms, 0 sorries)

🤖 Generated by researcher-3