### PR TITLE
research(alternating-series-test-oq-01-oq-02-oq-01): two-sided Jordan-decomposition Abel trap [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -64,6 +64,7 @@ import Proofs.AlgebraicRealsMeagerOQ03
 import Proofs.AlgebraicRealsNull
 import Proofs.AlternatingSeriesTestOQ01
 import Proofs.AlternatingSeriesTestOQ01OQ01
+import Proofs.AlternatingSeriesTestOQ01OQ02OQ01
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02OQ01OQ01
 import Proofs.AmgmInequalityOQ02Aristotle

--- a/proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean
@@ -1,0 +1,196 @@
+import Mathlib
+
+/-
+# A Two-Sided (Jordan-Decomposition) Abel Trap for Alternating Series
+
+The parent file `AlternatingSeriesTestOQ01OQ02` proves, via summation by parts, a
+**symmetric** Abel/Dirichlet error bound for the alternating block sum
+`∑_{i∈[N,M)} (-1)^i a i` of an *arbitrary* (non-monotone) real sequence:
+
+`|∑_{i∈[N,M)} (-1)^i a i| ≤ |a (M-1)| + ∑_{i∈[N,M-1)} |a (i+1) - a i|`.
+
+The right-hand side is a boundary term plus the **total variation** of `a`. The proof
+discards sign information twice: it bounds the sign partial sums by `|∑_{i<k}(-1)^i| ≤ 1`,
+and it bounds each increment by its absolute value `|a(i+1)-a i|`.
+
+This file sharpens that estimate to a genuinely **two-sided, asymmetric trap**. The key
+observation is that the sign partial sums are not merely bounded in absolute value — they
+lie in the unit interval:
+
+`0 ≤ ∑_{i<k} (-1)^i ≤ 1`     (they are exactly `0` or `1`, `neg_one_geom_sum`).
+
+A multiplier `B ∈ [0,1]` maps a real number `x` into the *order interval*
+`[min x 0, max x 0]` (not the symmetric `[-|x|, |x|]`). Feeding this into Abel's
+transformation traps the canonical alternating sum `∑_{j<n} (-1)^j c j` between the
+**positive and negative variations** of `c` separately (its Jordan decomposition):
+
+* upper bound uses only the *downward* steps `(c j - c (j+1))⁺`;
+* lower bound uses only the *upward*  steps `(c (j+1) - c j)⁺`;
+* the boundary term `c (n-1)` enters two-sidedly as `max (c (n-1)) 0` / `min (c (n-1)) 0`,
+  absorbing the parent's separate `|a (M-1)|` term.
+
+The bound is strictly tighter than the parent's symmetric one whenever the increments have
+mixed signs. As a sanity check it **recovers the classical Leibniz bracket**
+`0 ≤ ∑_{j<n} (-1)^j c j ≤ c 0` for antitone `c ≥ 0` (`leibniz_bracket`): the upward
+variation vanishes and the downward variation telescopes.
+
+All results are over `ℝ` and build on `Finset.sum_range_by_parts`. The asymmetric
+Jordan-decomposition trap is absent from Mathlib and from the parent file.
+-/
+
+namespace AlternatingSeriesTestOQ01OQ02OQ01
+
+open Finset
+
+/-! ### The sign partial sums lie in `[0,1]` -/
+
+/-- The partial sums of the sign sequence `(-1)^i` are nonnegative: they are `0` or `1`. -/
+theorem signSum_nonneg (k : ℕ) : 0 ≤ ∑ i ∈ range k, (-1 : ℝ) ^ i := by
+  rw [neg_one_geom_sum]; split <;> norm_num
+
+/-- The partial sums of the sign sequence `(-1)^i` are at most `1`: they are `0` or `1`.
+This is the *positivity* refinement of the parent's `|∑ (-1)^i| ≤ 1`. -/
+theorem signSum_le_one (k : ℕ) : ∑ i ∈ range k, (-1 : ℝ) ^ i ≤ 1 := by
+  rw [neg_one_geom_sum]; split <;> norm_num
+
+/-! ### Multiplying by a number in `[0,1]` lands in the order interval `[min x 0, max x 0]` -/
+
+/-- For `B ∈ [0,1]`, the product `x * B` never exceeds `max x 0`. (If `x ≥ 0` then
+`x * B ≤ x`; if `x < 0` then `x * B ≤ 0`.) -/
+theorem mul_le_max (x : ℝ) {B : ℝ} (h0 : 0 ≤ B) (h1 : B ≤ 1) : x * B ≤ max x 0 := by
+  rcases le_total 0 x with hx | hx
+  · rw [max_eq_left hx]; nlinarith [mul_le_mul_of_nonneg_left h1 hx]
+  · rw [max_eq_right hx]; nlinarith [mul_nonneg (neg_nonneg.2 hx) h0]
+
+/-- For `B ∈ [0,1]`, the product `x * B` is never below `min x 0`. (If `x ≥ 0` then
+`x * B ≥ 0`; if `x < 0` then `x * B ≥ x`.) -/
+theorem min_le_mul (x : ℝ) {B : ℝ} (h0 : 0 ≤ B) (h1 : B ≤ 1) : min x 0 ≤ x * B := by
+  rcases le_total 0 x with hx | hx
+  · rw [min_eq_right hx]; exact mul_nonneg hx h0
+  · rw [min_eq_left hx]; nlinarith [mul_nonneg (neg_nonneg.2 hx) (by linarith : (0 : ℝ) ≤ 1 - B)]
+
+/-! ### Abel transformation of the canonical alternating sum -/
+
+/-- **Summation by parts** for the canonical alternating sum, specialised to the sign
+sequence `g j = (-1)^j` (whose partial sums are the `signSum`s). For any real `c` and `n`:
+
+`∑_{i<n} (-1)^i c i = c (n-1) · (∑_{i<n} (-1)^i) − ∑_{j<n-1} (c (j+1) − c j) · (∑_{i<j+1} (-1)^i)`. -/
+private theorem abel_sub_identity (c : ℕ → ℝ) (n : ℕ) :
+    ∑ i ∈ range n, (-1 : ℝ) ^ i * c i
+      = c (n - 1) * (∑ i ∈ range n, (-1 : ℝ) ^ i)
+        - ∑ j ∈ range (n - 1), (c (j + 1) - c j) * (∑ i ∈ range (j + 1), (-1 : ℝ) ^ i) := by
+  have h := Finset.sum_range_by_parts (fun j => c j) (fun j => (-1 : ℝ) ^ j) n
+  simp only [smul_eq_mul] at h
+  rw [show (∑ i ∈ range n, c i * (-1 : ℝ) ^ i) = ∑ i ∈ range n, (-1 : ℝ) ^ i * c i from
+      Finset.sum_congr rfl fun i _ => by ring] at h
+  exact h
+
+/-! ### The asymmetric two-sided trap -/
+
+/-- **Upper half of the Abel trap.** The canonical alternating sum is bounded above by the
+positive part of the boundary coefficient plus the **downward variation** of `c`:
+
+`∑_{i<n} (-1)^i c i ≤ max (c (n-1)) 0 + ∑_{j<n-1} max (c j - c (j+1)) 0`.
+
+Only the steps where `c` *decreases* contribute. No monotonicity is assumed. -/
+theorem alternating_range_le (c : ℕ → ℝ) (n : ℕ) :
+    ∑ i ∈ range n, (-1 : ℝ) ^ i * c i
+      ≤ max (c (n - 1)) 0 + ∑ j ∈ range (n - 1), max (c j - c (j + 1)) 0 := by
+  rw [abel_sub_identity c n]
+  have hbd : c (n - 1) * (∑ i ∈ range n, (-1 : ℝ) ^ i) ≤ max (c (n - 1)) 0 :=
+    mul_le_max _ (signSum_nonneg n) (signSum_le_one n)
+  -- The subtracted sum dominates `-(downward variation)`, proved termwise after pairing.
+  have hSlow : (0 : ℝ) ≤ (∑ j ∈ range (n - 1), max (c j - c (j + 1)) 0)
+      + ∑ j ∈ range (n - 1), (c (j + 1) - c j) * (∑ i ∈ range (j + 1), (-1 : ℝ) ^ i) := by
+    rw [← Finset.sum_add_distrib]
+    refine Finset.sum_nonneg fun j _ => ?_
+    have hterm := mul_le_max (c j - c (j + 1)) (signSum_nonneg (j + 1)) (signSum_le_one (j + 1))
+    have heq : (c (j + 1) - c j) * (∑ i ∈ range (j + 1), (-1 : ℝ) ^ i)
+        = -((c j - c (j + 1)) * (∑ i ∈ range (j + 1), (-1 : ℝ) ^ i)) := by ring
+    rw [heq]; linarith
+  linarith
+
+/-- **Lower half of the Abel trap.** The canonical alternating sum is bounded below by the
+negative part of the boundary coefficient minus the **upward variation** of `c`:
+
+`min (c (n-1)) 0 - ∑_{j<n-1} max (c (j+1) - c j) 0 ≤ ∑_{i<n} (-1)^i c i`.
+
+Only the steps where `c` *increases* contribute. No monotonicity is assumed. -/
+theorem alternating_range_ge (c : ℕ → ℝ) (n : ℕ) :
+    min (c (n - 1)) 0 - ∑ j ∈ range (n - 1), max (c (j + 1) - c j) 0
+      ≤ ∑ i ∈ range n, (-1 : ℝ) ^ i * c i := by
+  rw [abel_sub_identity c n]
+  have hbd : min (c (n - 1)) 0 ≤ c (n - 1) * (∑ i ∈ range n, (-1 : ℝ) ^ i) :=
+    min_le_mul _ (signSum_nonneg n) (signSum_le_one n)
+  have hSup : ∑ j ∈ range (n - 1), (c (j + 1) - c j) * (∑ i ∈ range (j + 1), (-1 : ℝ) ^ i)
+      ≤ ∑ j ∈ range (n - 1), max (c (j + 1) - c j) 0 :=
+    Finset.sum_le_sum fun j _ =>
+      mul_le_max _ (signSum_nonneg (j + 1)) (signSum_le_one (j + 1))
+  linarith
+
+/-- **The two-sided trap, packaged.** The canonical alternating sum lies in the closed
+interval cut out by the upper and lower variation bounds. -/
+theorem alternating_range_mem_Icc (c : ℕ → ℝ) (n : ℕ) :
+    (∑ i ∈ range n, (-1 : ℝ) ^ i * c i) ∈
+      Set.Icc (min (c (n - 1)) 0 - ∑ j ∈ range (n - 1), max (c (j + 1) - c j) 0)
+              (max (c (n - 1)) 0 + ∑ j ∈ range (n - 1), max (c j - c (j + 1)) 0) :=
+  ⟨alternating_range_ge c n, alternating_range_le c n⟩
+
+/-! ### Recovering the classical Leibniz bracket -/
+
+/-- **Classical Leibniz trap as the monotone special case.** For an antitone, nonnegative
+sequence `c` the upward variation vanishes and the downward variation telescopes, collapsing
+the asymmetric trap to the textbook bracket
+
+`0 ≤ ∑_{j<n} (-1)^j c j ≤ c 0`.
+
+This shows the asymmetric bound *contains* the classical one. -/
+theorem leibniz_bracket (c : ℕ → ℝ) (hanti : Antitone c) (hpos : ∀ i, 0 ≤ c i) (n : ℕ) :
+    (∑ i ∈ range n, (-1 : ℝ) ^ i * c i) ∈ Set.Icc (0 : ℝ) (c 0) := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp [hpos 0]
+  constructor
+  · -- lower: `min (c (n-1)) 0 = 0` and the upward variation is `0`.
+    refine le_trans ?_ (alternating_range_ge c n)
+    have hmin : min (c (n - 1)) 0 = 0 := min_eq_right (hpos _)
+    have hup : ∑ j ∈ range (n - 1), max (c (j + 1) - c j) 0 = 0 := by
+      refine Finset.sum_eq_zero fun j _ => ?_
+      exact max_eq_right (by linarith [hanti (Nat.le_succ j)])
+    rw [hmin, hup]; norm_num
+  · -- upper: `max (c (n-1)) 0 = c (n-1)` and the downward variation telescopes to `c 0 - c (n-1)`.
+    refine le_trans (alternating_range_le c n) ?_
+    have hmax : max (c (n - 1)) 0 = c (n - 1) := max_eq_left (hpos _)
+    have hdown : ∑ j ∈ range (n - 1), max (c j - c (j + 1)) 0
+        = c 0 - c (n - 1) := by
+      have hpt : ∀ j ∈ range (n - 1), max (c j - c (j + 1)) 0 = c j - c (j + 1) := by
+        intro j _; exact max_eq_left (by linarith [hanti (Nat.le_succ j)])
+      rw [Finset.sum_congr rfl hpt, Finset.sum_range_sub' c (n - 1)]
+    rw [hmax, hdown]; linarith
+
+/-! ### Partial-sum (Cauchy-difference) form, even truncation point -/
+
+/-- **Two-sided trap for partial-sum differences at an even truncation point.** Writing
+`S_k = ∑_{i<k} (-1)^i a i`, for `N` even and `N < M` the difference `S_M - S_N` equals the
+canonical block `∑_{j<M-N} (-1)^j a (N+j)`, so the asymmetric trap applies verbatim with
+the boundary coefficient `a (M-1)` entering two-sidedly via `max`/`min`. This refines the
+parent's symmetric `|S_M - S_N| ≤ |a (M-1)| + (total variation)`. -/
+theorem partialSum_diff_mem_Icc (a : ℕ → ℝ) {N M : ℕ} (hN : Even N) (hNM : N < M) :
+    ((∑ i ∈ range M, (-1 : ℝ) ^ i * a i) - ∑ i ∈ range N, (-1 : ℝ) ^ i * a i) ∈
+      Set.Icc
+        (min (a (M - 1)) 0
+          - ∑ j ∈ range (M - N - 1), max (a (N + (j + 1)) - a (N + j)) 0)
+        (max (a (M - 1)) 0
+          + ∑ j ∈ range (M - N - 1), max (a (N + j) - a (N + (j + 1))) 0) := by
+  -- Reindex the block `[N,M)` to `range (M-N)`; the constant sign `(-1)^N = 1` drops out.
+  have hblock : (∑ i ∈ range M, (-1 : ℝ) ^ i * a i) - ∑ i ∈ range N, (-1 : ℝ) ^ i * a i
+      = ∑ j ∈ range (M - N), (-1 : ℝ) ^ j * a (N + j) := by
+    rw [← Finset.sum_Ico_eq_sub _ (le_of_lt hNM), Finset.sum_Ico_eq_sum_range]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [pow_add, hN.neg_one_pow, one_mul]
+  set c : ℕ → ℝ := fun j => a (N + j) with hc
+  -- `c j = a (N+j)` definitionally; only the boundary index needs `c (M-N-1) = a (M-1)`.
+  have hlast : c (M - N - 1) = a (M - 1) := by simp only [hc]; congr 1; omega
+  rw [hblock, ← hlast]
+  exact alternating_range_mem_Icc c (M - N)
+
+end AlternatingSeriesTestOQ01OQ02OQ01

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "alternating-series-test-oq-01-oq-02-oq-01",
+  "title": "A Two-Sided Jordan-Decomposition Abel Trap for Alternating Series",
+  "slug": "alternating-series-test-oq-01-oq-02-oq-01",
+  "description": "Sharpens the parent's symmetric Abel/Dirichlet error bound into a genuinely two-sided, asymmetric trap. The parent (alternating-series-test-oq-01-oq-02) bounds the alternating block sum of an arbitrary real sequence by |a(M−1)| + (total variation), discarding sign information by taking absolute values. This entry observes that the sign partial sums are not merely bounded in absolute value but lie in the unit interval: 0 ≤ ∑_{i<k} (-1)^i ≤ 1 (they are exactly 0 or 1, neg_one_geom_sum). A multiplier B ∈ [0,1] therefore maps a real x into the order interval [min x 0, max x 0] — not the symmetric [−|x|, |x|]. Feeding this positivity into Abel's transformation (Finset.sum_range_by_parts) traps the canonical alternating sum ∑_{j<n} (-1)^j c_j between the POSITIVE and NEGATIVE variations of c separately (its Jordan decomposition): the upper bound uses only the downward steps max(c_j − c_{j+1}, 0), the lower bound only the upward steps max(c_{j+1} − c_j, 0), and the boundary coefficient c_{n−1} enters two-sidedly via max(c_{n−1},0) / min(c_{n−1},0), absorbing the parent's separate |a(M−1)| term. The bound is strictly tighter than the parent's symmetric one whenever the increments have mixed signs. As a consistency check it recovers the classical Leibniz bracket 0 ≤ ∑_{j<n} (-1)^j c_j ≤ c_0 for antitone c ≥ 0: the upward variation vanishes and the downward variation telescopes. A partial-sum (Cauchy-difference) corollary at an even truncation point N applies the trap verbatim to S_M − S_N. This directly answers the parent entry's first open question: whether the |a(M−1)| boundary term can be absorbed into a clean two-sided trap for bounded-variation coefficients. The asymmetric Jordan-decomposition trap is absent from Mathlib and from the parent file.",
+  "meta": {
+    "author": "Abel/Dirichlet (summation by parts); asymmetric Jordan-decomposition trap formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "convergence",
+      "alternating-series",
+      "error-bound",
+      "summation-by-parts",
+      "abel-summation",
+      "dirichlet-test",
+      "bounded-variation",
+      "jordan-decomposition",
+      "two-sided-bound",
+      "leibniz-bracket"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_by_parts",
+        "description": "Summation by parts (Abel transformation): rewrites ∑ (-1)^j c_j as a boundary term minus a sum of coefficient-differences each weighted by a sign partial sum",
+        "module": "Mathlib.Algebra.BigOperators.Module"
+      },
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "∑_{i<n} (-1)^i = if Even n then 0 else 1 — the key positivity input: every sign partial sum lies in {0,1} ⊆ [0,1], not merely |·| ≤ 1",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Monotonicity of finite sums: lifts the termwise multiplier bound x·B ≤ max x 0 to the upward-variation sum for the lower trap",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Additivity of finite sums: pairs the downward-variation sum with the Abel remainder to prove the −variation ≤ remainder inequality termwise via sum_nonneg for the upper trap",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_sub'",
+        "description": "Telescoping sum identity, used to collapse the downward variation to c_0 − c_{n−1} in the antitone Leibniz-bracket recovery",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sub",
+        "description": "∑_{i ∈ [N,M)} f i = (∑_{i<M} f i) − (∑_{i<N} f i): converts the partial-sum difference S_M − S_N into the block sum for the even-truncation corollary",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Even.neg_one_pow",
+        "description": "(-1)^N = 1 for even N: drops the constant block sign when reindexing [N,M) to range (M−N)",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "alternating_range_le: the UPPER half of the asymmetric Abel trap — ∑_{i<n} (-1)^i c_i ≤ max(c_{n−1},0) + ∑_{j<n−1} max(c_j − c_{j+1}, 0), controlled by the boundary positive part plus only the DOWNWARD variation of c; no monotonicity assumed; absent from Mathlib",
+      "alternating_range_ge: the LOWER half — min(c_{n−1},0) − ∑_{j<n−1} max(c_{j+1} − c_j, 0) ≤ ∑_{i<n} (-1)^i c_i, controlled by the boundary negative part minus only the UPWARD variation",
+      "alternating_range_mem_Icc: the two halves packaged as membership in a closed interval [lower, upper] — the trap proper; strictly tighter than the parent's symmetric |·|-bound when increments have mixed signs",
+      "leibniz_bracket: recovery of the classical Leibniz trap 0 ≤ ∑_{j<n} (-1)^j c_j ≤ c_0 for antitone c ≥ 0 (upward variation vanishes, downward variation telescopes), exhibiting the asymmetric bound as a strict refinement that CONTAINS the textbook estimate",
+      "partialSum_diff_mem_Icc: the Cauchy-difference form at an even truncation point N — S_M − S_N lies in the trap interval with the boundary coefficient a(M−1) entering two-sidedly via max/min, absorbing the parent's separate |a(M−1)| boundary term",
+      "mul_le_max / min_le_mul: the order-interval multiplier lemmas — for B ∈ [0,1], min x 0 ≤ x·B ≤ max x 0 — the positivity mechanism that replaces the parent's symmetric |x·B| ≤ |x|"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms propext, Classical.choice, Quot.sound on all five headline theorems (alternating_range_le, alternating_range_ge, alternating_range_mem_Icc, leibniz_bracket, partialSum_diff_mem_Icc).",
+    "lineCount": 196,
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Leibniz alternating series test brackets the limit of an alternating series with antitone coefficients between consecutive partial sums, a genuinely two-sided trap of width a_N. Once monotonicity is dropped, the Dirichlet test (via Abel's summation by parts) still controls convergence, but the standard quantitative output is a SYMMETRIC absolute-value bound by the total variation — the two-sidedness of the Leibniz bracket is lost. The total variation of a sequence splits into its positive variation (sum of upward jumps) and negative variation (sum of downward jumps): this is the discrete Jordan decomposition. The present entry shows that keeping these two halves separate, rather than summing them into one total-variation bound, restores an asymmetric two-sided trap even for non-monotone coefficients.",
+    "problemStatement": "The parent entry alternating-series-test-oq-01-oq-02 asks (open question 1): can the boundary term |a(M−1)| be absorbed to give a clean two-sided trap — both upper and lower bounds — for bounded-variation coefficients, mirroring the antitone two-term trap of the sibling entry?\n\n**Answer:** ∑_{i<n} (-1)^i c_i ∈ [ min(c_{n−1},0) − ∑_{j<n−1} max(c_{j+1} − c_j, 0),  max(c_{n−1},0) + ∑_{j<n−1} max(c_j − c_{j+1}, 0) ]. The upper bound uses only the downward variation, the lower only the upward variation, and the boundary coefficient enters two-sidedly via its positive/negative parts — absorbing the parent's separate |a(M−1)| term. For antitone c ≥ 0 this collapses to the Leibniz bracket 0 ≤ ∑ (-1)^j c_j ≤ c_0.",
+    "text": "Because the sign partial sums lie in [0,1] (not merely bounded by 1 in absolute value), Abel summation traps the alternating sum between the positive and negative variations of the coefficient sequence separately — an asymmetric two-sided refinement of the parent's symmetric total-variation bound that recovers the classical Leibniz bracket in the monotone case.",
+    "proofStrategy": "The order-interval multiplier lemmas mul_le_max and min_le_mul establish that for B ∈ [0,1], min x 0 ≤ x·B ≤ max x 0 (by cases on the sign of x). Specialise summation by parts (Finset.sum_range_by_parts) to g_j = (-1)^j, whose partial sums are the signSums in [0,1] (signSum_nonneg, signSum_le_one, both from neg_one_geom_sum). This expresses ∑_{i<n} (-1)^i c_i as a boundary term c_{n−1}·(signSum n) minus a sum of increments (c_{j+1} − c_j)·(signSum (j+1)). Apply the multiplier lemmas to each weighted term: the boundary term is trapped in [min(c_{n−1},0), max(c_{n−1},0)]; for the upper bound the subtracted increment sum is bounded below by −(downward variation) via a sum_add_distrib + sum_nonneg pairing, and for the lower bound it is bounded above by the upward variation via sum_le_sum. For the Leibniz recovery, antitone c ≥ 0 makes every upward step ≤ 0 (so max(·,0)=0, upward variation vanishes) and every downward step ≥ 0 (so the downward variation telescopes via Finset.sum_range_sub' to c_0 − c_{n−1}, cancelling the boundary max(c_{n−1},0)=c_{n−1}). The even-truncation corollary reindexes [N,M) to range (M−N) using Even.neg_one_pow to drop the constant sign (-1)^N = 1.",
+    "keyInsights": [
+      "The sign sequence (-1)^i has partial sums in {0,1} ⊆ [0,1] — a POSITIVITY fact, strictly stronger than the parent's |∑ (-1)^i| ≤ 1, and it is exactly this positivity that restores two-sidedness",
+      "Multiplying by B ∈ [0,1] lands a real x in the order interval [min x 0, max x 0], not the symmetric [−|x|, |x|]: the asymmetry of the trap comes directly from the asymmetry of this interval",
+      "Keeping the positive variation (upward jumps) and negative variation (downward jumps) separate — the discrete Jordan decomposition — yields a tighter, sign-aware bound than the single total-variation estimate of the parent",
+      "The classical Leibniz bracket is the special case where one variation vanishes and the other telescopes, so the asymmetric trap CONTAINS the textbook two-sided estimate while extending it to non-monotone coefficients"
+    ],
+    "prerequisites": [
+      "Summation by parts (Abel's transformation) and the Dirichlet test",
+      "Total variation and its Jordan decomposition into positive and negative variation",
+      "Order intervals [min x 0, max x 0] and positive/negative parts of a real number",
+      "The parent entry's symmetric Abel/Dirichlet total-variation error bound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "signsum-positivity",
+      "title": "Positivity of the Sign Partial Sums",
+      "startLine": 46,
+      "endLine": 55,
+      "summary": "signSum_nonneg and signSum_le_one: 0 ≤ ∑_{i<k} (-1)^i ≤ 1, since the geometric partial sum (neg_one_geom_sum) is 0 or 1. This positivity refinement of the parent's |·| ≤ 1 is what powers the asymmetric trap.",
+      "mathContext": "$0 \\le \\sum_{i<k}(-1)^i \\le 1$."
+    },
+    {
+      "id": "order-interval-multiplier",
+      "title": "Order-Interval Multiplier Lemmas",
+      "startLine": 57,
+      "endLine": 76,
+      "summary": "mul_le_max and min_le_mul: for B ∈ [0,1], min x 0 ≤ x·B ≤ max x 0, by cases on the sign of x. A multiplier in the unit interval lands x in its order interval, not the symmetric absolute-value interval.",
+      "mathContext": "$B \\in [0,1] \\Rightarrow \\min(x,0) \\le xB \\le \\max(x,0)$."
+    },
+    {
+      "id": "abel-identity",
+      "title": "Abel Transformation of the Canonical Alternating Sum",
+      "startLine": 78,
+      "endLine": 91,
+      "summary": "abel_sub_identity: ∑_{i<n} (-1)^i c_i = c_{n−1}·(∑_{i<n} (-1)^i) − ∑_{j<n−1} (c_{j+1} − c_j)·(∑_{i<j+1} (-1)^i), specialising Finset.sum_range_by_parts to the sign sequence.",
+      "mathContext": "$\\sum_{i<n}(-1)^i c_i = c_{n-1}\\,S_n - \\sum_{j<n-1}(c_{j+1}-c_j)\\,S_{j+1}$."
+    },
+    {
+      "id": "two-sided-trap",
+      "title": "The Asymmetric Two-Sided Trap",
+      "startLine": 93,
+      "endLine": 146,
+      "summary": "alternating_range_le (upper, downward variation), alternating_range_ge (lower, upward variation), and alternating_range_mem_Icc packaging both as interval membership. The boundary coefficient enters two-sidedly via max/min, absorbing the parent's |a(M−1)| term.",
+      "mathContext": "$\\sum_{i<n}(-1)^i c_i \\in [\\min(c_{n-1},0) - V^+,\\ \\max(c_{n-1},0) + V^-]$, $V^\\pm$ the up/down variation."
+    },
+    {
+      "id": "leibniz-recovery",
+      "title": "Recovering the Classical Leibniz Bracket",
+      "startLine": 148,
+      "endLine": 175,
+      "summary": "leibniz_bracket: for antitone c ≥ 0 the upward variation vanishes and the downward variation telescopes, collapsing the trap to 0 ≤ ∑_{j<n} (-1)^j c_j ≤ c_0 — the textbook two-sided estimate.",
+      "mathContext": "antitone $c \\ge 0 \\Rightarrow 0 \\le \\sum_{j<n}(-1)^j c_j \\le c_0$."
+    },
+    {
+      "id": "partial-sum-form",
+      "title": "Cauchy-Difference Form at an Even Truncation Point",
+      "startLine": 177,
+      "endLine": 194,
+      "summary": "partialSum_diff_mem_Icc: for even N < M, S_M − S_N equals the canonical block ∑_{j<M−N} (-1)^j a(N+j) (since (-1)^N = 1), so the trap applies verbatim with boundary coefficient a(M−1) entering two-sidedly.",
+      "mathContext": "$N$ even $\\Rightarrow S_M - S_N \\in [\\min(a_{M-1},0) - V^+,\\ \\max(a_{M-1},0) + V^-]$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Abel, N. H.",
+      "title": "Untersuchungen über die Reihe ...",
+      "year": "1826",
+      "note": "Summation by parts (Abel's transformation)"
+    },
+    {
+      "authors": "Jordan, C.",
+      "title": "Sur la série de Fourier",
+      "year": "1881",
+      "note": "Functions of bounded variation and their decomposition into positive and negative variation"
+    },
+    {
+      "authors": "Rudin, W.",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "Summation by parts (Theorem 3.41), Dirichlet and Abel tests (Theorem 3.42), alternating series test (Theorem 3.43)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-test-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: proves the symmetric Abel/Dirichlet bound |S_M − S_N| ≤ |a(M−1)| + (total variation) for arbitrary coefficients, and asks (open question 1) whether the boundary term can be absorbed into a clean two-sided trap. This entry answers that question, splitting the total variation into its positive and negative parts to produce an asymmetric two-sided trap and absorbing the boundary coefficient via max/min."
+    },
+    {
+      "targetId": "alternating-series-test-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling entry: the two-sided two-term trap for ANTITONE coefficients. This entry recovers that bracket (leibniz_bracket) as the monotone special case while extending the trap to bounded-variation coefficients."
+    }
+  ],
+  "conclusion": {
+    "summary": "Exploiting that the sign partial sums lie in [0,1] (not merely |·| ≤ 1), Abel summation traps the alternating sum ∑_{i<n} (-1)^i c_i in the interval [min(c_{n−1},0) − upward variation, max(c_{n−1},0) + downward variation], proved with 0 axioms. This asymmetric, sign-aware bound is strictly tighter than the parent's symmetric total-variation estimate when increments have mixed signs, absorbs the boundary term two-sidedly, and recovers the classical Leibniz bracket 0 ≤ ∑ (-1)^j c_j ≤ c_0 for antitone c ≥ 0.",
+    "implications": "Answers the parent entry's open question on absorbing the boundary term into a clean two-sided trap. Shows that the two-sidedness of the Leibniz bracket survives the loss of monotonicity provided the total variation is split into its Jordan components: the upward variation controls the lower bound and the downward variation the upper bound. Unifies the monotone Leibniz trap and the non-monotone Abel estimate under a single asymmetric interval bound.",
+    "openQuestions": [
+      "Does the asymmetric trap extend from the sign sequence (-1)^i to a general weight sequence b_i whose partial sums lie in a fixed interval [m, M], replacing max/min(x,0) by the corresponding support-function bounds?",
+      "Can the even-truncation restriction in the partial-sum corollary be removed by tracking the (-1)^N sign, yielding a parity-uniform two-sided trap on S_M − S_N for all N?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AlternatingSeriesTestOQ01OQ02OQ01",
+    "lineCount": 196,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `alternating-series-test-oq-01-oq-02`:

> *Can the boundary term `|a(M−1)|` be absorbed to give a clean two-sided trap (both upper and lower bounds) for bounded-variation coefficients, mirroring the antitone two-term trap of the sibling entry?*

**Answer:** `∑_{i<n} (-1)^i c_i ∈ [ min(c_{n−1},0) − V⁺,  max(c_{n−1},0) + V⁻ ]`, where `V⁺ = ∑ max(c_{j+1}−c_j, 0)` (upward variation) and `V⁻ = ∑ max(c_j−c_{j+1}, 0)` (downward variation).

## Mathematical content

The parent bounds the alternating block sum **symmetrically** by `|a(M−1)| + (total variation)`, discarding sign information via absolute values. The key new observation: the sign partial sums are not merely bounded in absolute value but lie in the **unit interval**

`0 ≤ ∑_{i<k} (-1)^i ≤ 1`   (they are exactly `0` or `1`, `neg_one_geom_sum`).

A multiplier `B ∈ [0,1]` therefore maps `x` into the **order interval** `[min x 0, max x 0]` — not the symmetric `[−|x|, |x|]`. Feeding this positivity into Abel's transformation traps the alternating sum between the **positive and negative variations separately** (the discrete Jordan decomposition):

- upper bound uses only the *downward* steps;
- lower bound uses only the *upward* steps;
- the boundary coefficient enters two-sidedly via `max`/`min`, absorbing the parent's separate `|a(M−1)|` term.

Strictly tighter than the parent's symmetric bound when increments have mixed signs. Recovers the classical **Leibniz bracket** `0 ≤ ∑ (-1)^j c_j ≤ c_0` for antitone `c ≥ 0` (`leibniz_bracket`): the upward variation vanishes, the downward variation telescopes.

## Verification

- **9 theorems, 196 lines, 0 sorries, 0 axioms.**
- `#print axioms` on all five headline theorems reports only `propext`, `Classical.choice`, `Quot.sound`.
- Self-contained on Mathlib (`Finset.sum_range_by_parts`, `neg_one_geom_sum`); does not depend on the parent's olean.
- Built via host `lake env lean` (docker unavailable).

## Files
- `proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean` (new)
- `src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/meta.json` (new)
- `proofs/Proofs.lean` (import registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)