### PR TITLE
research(minkowski-theorem-oq-04-oq-03): Sharpness of the Blichfeldt volume threshold [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3318,6 +3318,7 @@ import Proofs.MinkowskiTheoremOQ02OQ01
 import Proofs.MinkowskiTheoremOQ02OQ03
 import Proofs.MinkowskiTheoremOQ03
 import Proofs.MinkowskiTheoremOQ04
+import Proofs.MinkowskiTheoremOQ04OQ03
 import Proofs.MinkowskiTheoremOQ05
 import Proofs.MinpolyCharpoly
 import Proofs.MinpolyCharpolyOQ01

--- a/proofs/Proofs/MinkowskiTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04OQ03.lean
@@ -1,0 +1,215 @@
+import Mathlib.Algebra.Module.ZLattice.Basic
+import Mathlib.MeasureTheory.Group.GeometryOfNumbers
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Proofs.MinkowskiTheoremOQ04
+import Mathlib.Tactic
+
+/-
+# Sharpness of the Blichfeldt Volume Threshold (Minkowski OQ-04-OQ-03)
+
+## What This Proves
+
+The parent file `MinkowskiTheoremOQ04` proves **Blichfeldt's theorem**: a measurable
+set `S ⊆ ℝⁿ` of Lebesgue measure **strictly greater than `k`** contains `k+1` distinct
+points that are pairwise congruent modulo the integer lattice `ℤⁿ`
+(`BlichfeldtTheorem.blichfeldt_general`; the `k = 1` case is
+`BlichfeldtTheorem.blichfeldt_basic`).
+
+This file shows the threshold is **sharp**: the strict inequality `k < volume S`
+cannot be weakened to `k ≤ volume S`. Concretely we exhibit, for every `k`, a
+measurable set of volume **exactly `k`** that contains **no** `k+1` pairwise
+`ℤⁿ`-congruent distinct points.
+
+* `k = 1` witness — the half-open unit cube `[0,1)ⁿ = stdFundDomain n` itself:
+    - volume exactly `1` (`stdLattice_covolume`), yet
+    - no two distinct points are `ℤⁿ`-congruent (`stdFundDomain_congruent_eq`).
+  Hence Blichfeldt's `blichfeldt_basic` hypothesis `1 < volume S` is sharp
+  (`blichfeldt_basic_threshold_not_le`).
+
+* general `k` witness — the box `[0,k) × [0,1)ⁿ⁻¹` (`box n k`):
+    - volume exactly `k` (`volume_box`), yet
+    - it holds at most `k` mutually `ℤⁿ`-congruent points, so the Blichfeldt
+      conclusion (`k+1` congruent points) fails (`blichfeldt_general_threshold_sharp`).
+
+## Key Idea
+
+`ℤⁿ`-congruent points have **equal fractional parts** (`ZSpan.fract_eq_fract`), and a
+point of a half-open box is **determined** by its fractional part together with its
+integer floor in the one "long" coordinate. The floor lives in `{0, …, k-1}`, so a box
+of volume `k` can hold at most `k` mutually congruent points — pigeonhole then rules out
+`k+1`.
+
+## Axioms
+
+Zero axioms beyond Mathlib's foundational set; `#print axioms` lists only
+`propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+open MeasureTheory Set MinkowskiProved
+
+namespace BlichfeldtSharpness
+
+variable (n : ℕ) [NeZero n]
+
+-- ============================================================
+-- PART 1: k = 1 — the fundamental domain is the sharp witness
+-- ============================================================
+
+/-- **Pointwise uniqueness of fundamental-domain representatives.**
+Two points of the half-open unit cube `[0,1)ⁿ = stdFundDomain n` that are congruent
+modulo the integer lattice `ℤⁿ` are equal.  This is the heart of sharpness for `k = 1`:
+the unit cube — a set of volume exactly `1` — carries no `ℤⁿ`-congruent pair. -/
+omit [NeZero n] in
+theorem stdFundDomain_congruent_eq {x y : Fin n → ℝ}
+    (hx : x ∈ stdFundDomain n) (hy : y ∈ stdFundDomain n)
+    (hcong : x - y ∈ (stdLattice n : Set (Fin n → ℝ))) : x = y := by
+  -- Points of the fundamental domain are fixed by `fract`.
+  have hfx : ZSpan.fract (stdBasis n) x = x := (ZSpan.fract_eq_self (b := stdBasis n)).mpr hx
+  have hfy : ZSpan.fract (stdBasis n) y = y := (ZSpan.fract_eq_self (b := stdBasis n)).mpr hy
+  -- Congruence `x - y ∈ ℤⁿ` gives equal fractional parts.
+  have hmem : -y + x ∈ Submodule.span ℤ (Set.range (stdBasis n)) := by
+    have h : x - y ∈ stdLattice n := by simpa using hcong
+    rw [neg_add_eq_sub]; exact h
+  have hff : ZSpan.fract (stdBasis n) y = ZSpan.fract (stdBasis n) x :=
+    (ZSpan.fract_eq_fract (stdBasis n) y x).mpr hmem
+  rw [hfx, hfy] at hff
+  exact hff.symm
+
+/-- **Sharpness of Blichfeldt's threshold (k = 1).**
+There is a measurable set of volume exactly `1` containing no two distinct
+`ℤⁿ`-congruent points: the half-open unit cube `[0,1)ⁿ`. -/
+theorem blichfeldt_threshold_sharp :
+    ∃ S : Set (Fin n → ℝ), MeasurableSet S ∧ volume S = 1 ∧
+      ¬ ∃ x y : Fin n → ℝ, x ∈ S ∧ y ∈ S ∧ x ≠ y ∧
+        x - y ∈ (stdLattice n : Set (Fin n → ℝ)) := by
+  refine ⟨stdFundDomain n, stdFundDomain_measurableSet n, stdLattice_covolume n, ?_⟩
+  rintro ⟨x, y, hx, hy, hne, hcong⟩
+  exact hne (stdFundDomain_congruent_eq n hx hy hcong)
+
+/-- **The hypothesis `1 < volume S` of `blichfeldt_basic` cannot be weakened to
+`1 ≤ volume S`.**  The unit cube has volume `1` (so `1 ≤ volume`) yet fails the
+Blichfeldt conclusion of a congruent pair. -/
+theorem blichfeldt_basic_threshold_not_le :
+    ∃ S : Set (Fin n → ℝ), MeasurableSet S ∧ (1 : ENNReal) ≤ volume S ∧
+      ¬ ∃ x y : Fin n → ℝ, x ∈ S ∧ y ∈ S ∧ x ≠ y ∧
+        x - y ∈ (stdLattice n : Set (Fin n → ℝ)) := by
+  obtain ⟨S, hmeas, hvol, hno⟩ := blichfeldt_threshold_sharp n
+  exact ⟨S, hmeas, hvol.ge, hno⟩
+
+-- ============================================================
+-- PART 2: general k — the box [0,k) × [0,1)ⁿ⁻¹
+-- ============================================================
+
+/-- The box `[0,k) × [0,1)ⁿ⁻¹` in `ℝⁿ`: the first coordinate ranges over `[0,k)`,
+all other coordinates over `[0,1)`.  Its volume is exactly `k`. -/
+def box (k : ℕ) : Set (Fin n → ℝ) :=
+  Set.pi Set.univ (fun i => Set.Ico (0 : ℝ) (if i = 0 then (k : ℝ) else 1))
+
+theorem box_measurableSet (k : ℕ) : MeasurableSet (box n k) :=
+  MeasurableSet.univ_pi (fun _ => measurableSet_Ico)
+
+/-- The box has volume exactly `k`. -/
+theorem volume_box (k : ℕ) : volume (box n k) = (k : ENNReal) := by
+  rw [box, volume_pi_pi]
+  rw [Finset.prod_eq_single (0 : Fin n)]
+  · rw [if_pos rfl, Real.volume_Ico, sub_zero, ENNReal.ofReal_natCast]
+  · intro i _ hi
+    rw [if_neg hi, Real.volume_Ico, sub_zero, ENNReal.ofReal_one]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- Coordinatewise formula for the `ZSpan` fractional part in the standard basis:
+`(fract x) i = Int.fract (x i)`.  (The standard basis `Pi.basisFun` has the identity
+`repr`.) -/
+omit [NeZero n] in
+theorem stdFract_coord (x : Fin n → ℝ) (i : Fin n) :
+    ZSpan.fract (stdBasis n) x i = Int.fract (x i) := by
+  have h := ZSpan.repr_fract_apply (stdBasis n) x i
+  unfold stdBasis at h ⊢
+  rwa [Pi.basisFun_repr, Pi.basisFun_repr] at h
+
+/-- Congruent points share their fractional part in every coordinate. -/
+theorem congruent_fract_coord {x y : Fin n → ℝ}
+    (hcong : x - y ∈ (stdLattice n : Set (Fin n → ℝ))) (i : Fin n) :
+    Int.fract (x i) = Int.fract (y i) := by
+  have hmem : -y + x ∈ Submodule.span ℤ (Set.range (stdBasis n)) := by
+    have h : x - y ∈ stdLattice n := by simpa using hcong
+    rw [neg_add_eq_sub]; exact h
+  have hff : ZSpan.fract (stdBasis n) y = ZSpan.fract (stdBasis n) x :=
+    (ZSpan.fract_eq_fract (stdBasis n) y x).mpr hmem
+  have hco := congrFun hff i
+  rw [stdFract_coord, stdFract_coord] at hco
+  exact hco.symm
+
+/-- **Sharpness of Blichfeldt's threshold (general `k`).**
+There is a measurable set of volume exactly `k` for which the Blichfeldt conclusion
+fails: no injective family of `k+1` pairwise `ℤⁿ`-congruent points exists in it.
+Hence the strict inequality `k < volume S` of `blichfeldt_general` is sharp. -/
+theorem blichfeldt_general_threshold_sharp (k : ℕ) :
+    ∃ S : Set (Fin n → ℝ), MeasurableSet S ∧ volume S = (k : ENNReal) ∧
+      ¬ ∃ pts : Fin (k + 1) → Fin n → ℝ,
+          Function.Injective pts ∧ (∀ i, pts i ∈ S) ∧
+          ∀ i j, pts i - pts j ∈ (stdLattice n : Set (Fin n → ℝ)) := by
+  refine ⟨box n k, box_measurableSet n k, volume_box n k, ?_⟩
+  rintro ⟨pts, hinj, hmem, hcong⟩
+  -- Coordinate bounds from box membership.
+  have hbound : ∀ m : Fin (k + 1), ∀ i : Fin n,
+      0 ≤ pts m i ∧ pts m i < (if i = 0 then (k : ℝ) else 1) := by
+    intro m i
+    have := (Set.mem_univ_pi.mp (hmem m)) i
+    rw [Set.mem_Ico] at this
+    exact this
+  -- The map sending each point to ⌊(coordinate 0)⌋ as an element of `Fin k`.
+  have hk_pos : 0 < k := by
+    rcases Nat.eq_zero_or_pos k with hk | hk
+    · -- k = 0: box has volume 0, but pts 0 ∈ box forces coordinate 0 ∈ [0,0) = ∅.
+      exfalso
+      subst hk
+      have h2 := (hbound 0 0).2
+      rw [if_pos rfl, Nat.cast_zero] at h2
+      linarith [(hbound 0 0).1]
+    · exact hk
+  -- floor of the first coordinate lies in {0, …, k-1}.
+  have hfloor_lt : ∀ m : Fin (k + 1), (⌊pts m 0⌋).toNat < k := by
+    intro m
+    have h0 := hbound m 0
+    rw [if_pos rfl] at h0
+    have hfl_nonneg : 0 ≤ ⌊pts m 0⌋ := Int.floor_nonneg.mpr h0.1
+    have hfl_lt : ⌊pts m 0⌋ < (k : ℤ) := by
+      rw [Int.floor_lt]; exact_mod_cast h0.2
+    omega
+  set g : Fin (k + 1) → Fin k := fun m => ⟨(⌊pts m 0⌋).toNat, hfloor_lt m⟩ with hg
+  -- g is injective: a point of the box is determined by ⌊·0⌋ and its (shared) fract.
+  have hg_inj : Function.Injective g := by
+    intro a b hab
+    apply hinj
+    -- equal floors in coordinate 0
+    have hfloor_eq : ⌊pts a 0⌋ = ⌊pts b 0⌋ := by
+      have : (⌊pts a 0⌋).toNat = (⌊pts b 0⌋).toNat := by
+        have := congrArg Fin.val hab; simpa [hg] using this
+      have ha := (hbound a 0); rw [if_pos rfl] at ha
+      have hb := (hbound b 0); rw [if_pos rfl] at hb
+      have hna : 0 ≤ ⌊pts a 0⌋ := Int.floor_nonneg.mpr ha.1
+      have hnb : 0 ≤ ⌊pts b 0⌋ := Int.floor_nonneg.mpr hb.1
+      omega
+    -- prove the two points are equal coordinatewise
+    funext i
+    by_cases hi : i = 0
+    · subst hi
+      -- coordinate 0: same floor and same fractional part
+      have hfr := congruent_fract_coord n (hcong a b) 0
+      have ea : (⌊pts a 0⌋ : ℝ) + Int.fract (pts a 0) = pts a 0 := Int.floor_add_fract _
+      have eb : (⌊pts b 0⌋ : ℝ) + Int.fract (pts b 0) = pts b 0 := Int.floor_add_fract _
+      rw [← ea, ← eb, hfr, hfloor_eq]
+    · -- coordinate i ≠ 0: both lie in [0,1), so equal to their (shared) fractional part
+      have hfr := congruent_fract_coord n (hcong a b) i
+      have ha := hbound a i; rw [if_neg hi] at ha
+      have hb := hbound b i; rw [if_neg hi] at hb
+      have ea : Int.fract (pts a i) = pts a i := Int.fract_eq_self.mpr ⟨ha.1, ha.2⟩
+      have eb : Int.fract (pts b i) = pts b i := Int.fract_eq_self.mpr ⟨hb.1, hb.2⟩
+      rw [← ea, ← eb, hfr]
+  -- pigeonhole: an injection Fin (k+1) ↪ Fin k is impossible.
+  have hcard := Fintype.card_le_of_injective g hg_inj
+  simp only [Fintype.card_fin] at hcard
+  omega
+
+end BlichfeldtSharpness

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-03/meta.json
@@ -1,0 +1,88 @@
+{
+  "id": "minkowski-theorem-oq-04-oq-03",
+  "title": "Sharpness of the Blichfeldt Volume Threshold",
+  "slug": "minkowski-theorem-oq-04-oq-03",
+  "description": "Blichfeldt's theorem needs measure STRICTLY greater than k to force k+1 lattice-congruent points. This entry shows the threshold is sharp: for every k there is a measurable set of volume exactly k with no k+1 pairwise ℤⁿ-congruent points, so the strict inequality cannot be weakened to ≥. The k=1 witness is the half-open unit cube [0,1)ⁿ itself.",
+  "meta": {
+    "id": "minkowski-theorem-oq-04-oq-03",
+    "title": "Sharpness of the Blichfeldt Volume Threshold",
+    "slug": "minkowski-theorem-oq-04-oq-03",
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Blichfeldt%27s_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MinkowskiTheoremOQ04OQ03.lean",
+    "tags": [
+      "number-theory",
+      "geometry",
+      "lattice",
+      "geometry-of-numbers",
+      "measure-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 215,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZSpan.fract_eq_fract",
+        "description": "Two points have equal ZSpan fractional parts iff they are congruent modulo the lattice — converts ℤⁿ-congruence into equal fractional parts.",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "ZSpan.fract_eq_self",
+        "description": "A point of the fundamental domain is its own fractional part — yields pointwise uniqueness of representatives.",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "ZSpan.repr_fract_apply",
+        "description": "Coordinatewise formula b.repr(fract x) i = Int.fract(b.repr x i); with Pi.basisFun_repr gives (fract x) i = Int.fract(x i).",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.volume_pi_pi",
+        "description": "Volume of a product box equals the product of factor volumes — used to compute vol(box) = k.",
+        "module": "Mathlib.MeasureTheory.Constructions.Pi"
+      },
+      {
+        "theorem": "MinkowskiProved.stdFundDomain",
+        "description": "The fundamental domain F = [0,1)ⁿ for ℤⁿ, used as the k=1 sharpness witness.",
+        "module": "Proofs.MinkowskiFundamentalTheorem"
+      },
+      {
+        "theorem": "BlichfeldtTheorem.blichfeldt_basic",
+        "description": "The k=1 Blichfeldt theorem (parent): vol(S) > 1 forces a congruent pair. This entry proves its threshold is sharp.",
+        "module": "Proofs.MinkowskiTheoremOQ04"
+      }
+    ],
+    "originalContributions": [
+      "stdFundDomain_congruent_eq: pointwise uniqueness of fundamental-domain representatives — two points of the half-open unit cube [0,1)ⁿ that are ℤⁿ-congruent are equal. Proved via ZSpan.fract_eq_self (points of the domain are fixed by fract) + ZSpan.fract_eq_fract (congruent points share fract). This is the geometric heart of k=1 sharpness.",
+      "blichfeldt_threshold_sharp: the unit cube [0,1)ⁿ is a measurable set of volume exactly 1 with no two distinct ℤⁿ-congruent points — exhibiting that Blichfeldt's strict threshold is attained at the boundary.",
+      "blichfeldt_basic_threshold_not_le: the hypothesis 1 < vol(S) of blichfeldt_basic cannot be weakened to 1 ≤ vol(S).",
+      "box / volume_box: the box [0,k) × [0,1)ⁿ⁻¹ has volume exactly k, computed via volume_pi_pi + Finset.prod_eq_single isolating the long coordinate.",
+      "stdFract_coord: the ZSpan fractional part in the standard basis is coordinatewise Int.fract — (fract x) i = Int.fract(x i) — via Pi.basisFun's identity repr.",
+      "congruent_fract_coord: ℤⁿ-congruent points share Int.fract in every coordinate.",
+      "blichfeldt_general_threshold_sharp: for every k the box of volume exactly k contains no injective family of k+1 pairwise ℤⁿ-congruent points; hence the strict inequality k < vol(S) of blichfeldt_general is sharp. A point of the box is determined by its (shared) fractional part together with the integer floor ⌊·₀⌋ ∈ {0,…,k-1} of its long coordinate, giving an injection into Fin k — pigeonhole rules out k+1."
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "ZSpan fundamental domains and fractional parts (ZSpan.fract)",
+      "Lebesgue measure on ℝⁿ and product (Fubini) volume of boxes",
+      "Integer lattices ℤⁿ as ℤ-submodules of ℝⁿ",
+      "Blichfeldt's theorem (the statement whose threshold is shown sharp)"
+    ],
+    "relatedProofs": [
+      "minkowski-theorem-oq-04",
+      "minkowski-theorem-oq-02",
+      "minkowski-theorem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Blichfeldt's 1914 theorem strengthens Minkowski's geometry of numbers: any measurable set of volume strictly greater than k holds k+1 distinct points that are pairwise congruent modulo ℤⁿ. A natural companion question is whether the strict inequality is necessary. It is: the half-open unit cube [0,1)ⁿ is a fundamental domain for ℤⁿ, so it has volume exactly 1 yet meets each lattice coset in a single point. This is the canonical demonstration that the volume threshold cannot be relaxed from `> k` to `≥ k`.",
+    "problemStatement": "Is the strict inequality in Blichfeldt's theorem necessary? Equivalently, for each k is there a measurable set of volume exactly k that contains no k+1 pairwise ℤⁿ-congruent points?",
+    "text": "Yes — the threshold is sharp (status `verified`, 0 axioms, 0 sorries). For k=1 the witness is the half-open unit cube F = [0,1)ⁿ = stdFundDomain n: it is measurable, has volume exactly 1 (stdLattice_covolume), and carries no two distinct ℤⁿ-congruent points (stdFundDomain_congruent_eq), so the blichfeldt_basic hypothesis 1 < vol(S) cannot be weakened to ≤. For general k the witness is the box [0,k) × [0,1)ⁿ⁻¹ of volume exactly k, which holds at most k mutually congruent points, contradicting any k+1 family — so the strict inequality of blichfeldt_general is also sharp.",
+    "proofStrategy": "The key conversion (ZSpan.fract_eq_fract) turns ℤⁿ-congruence into equality of fractional parts. (1) k=1: a point of the fundamental domain equals its own fractional part (ZSpan.fract_eq_self), so two congruent points of [0,1)ⁿ have equal fractional parts and are therefore equal. (2) general k: in the box [0,k) × [0,1)ⁿ⁻¹ every coordinate i≠0 lies in [0,1) and so equals its fractional part, while the long coordinate satisfies x₀ = ⌊x₀⌋ + Int.fract(x₀) with ⌊x₀⌋ ∈ {0,…,k-1}. Congruent points share all fractional parts, so a point is determined by ⌊x₀⌋ alone — an injection into Fin k. Volume k is computed by volume_pi_pi. Pigeonhole (Fintype.card_le_of_injective) then forbids k+1 distinct pairwise-congruent points."
+  }
+}


### PR DESCRIPTION
## Summary

The parent **Blichfeldt's theorem** (`MinkowskiTheoremOQ04`) states that a measurable set `S ⊆ ℝⁿ` of Lebesgue measure **strictly greater than `k`** must contain `k+1` distinct points that are pairwise congruent modulo the integer lattice `ℤⁿ`. This entry answers the natural companion open question: **is the strict inequality necessary?** It is — the volume threshold is **sharp** and cannot be weakened from `> k` to `≥ k`.

## Results (`proofs/Proofs/MinkowskiTheoremOQ04OQ03.lean`)

**k = 1 — the half-open unit cube is the sharp witness**
- `stdFundDomain_congruent_eq` — two points of `[0,1)ⁿ = stdFundDomain n` that are `ℤⁿ`-congruent are equal (the geometric heart). Proof: a point of the fundamental domain is fixed by `ZSpan.fract` (`fract_eq_self`), and congruent points share their fractional part (`fract_eq_fract`).
- `blichfeldt_threshold_sharp` — `[0,1)ⁿ` is measurable, has volume exactly `1`, and has **no** two distinct `ℤⁿ`-congruent points.
- `blichfeldt_basic_threshold_not_le` — `blichfeldt_basic`'s hypothesis `1 < vol(S)` cannot be weakened to `1 ≤ vol(S)`.

**general k — the box `[0,k) × [0,1)ⁿ⁻¹`**
- `box`, `volume_box` — the box has volume **exactly `k`** (`volume_pi_pi` + `Finset.prod_eq_single`).
- `stdFract_coord`, `congruent_fract_coord` — coordinatewise fractional-part machinery in the standard basis.
- `blichfeldt_general_threshold_sharp` — the box holds **no** injective family of `k+1` pairwise `ℤⁿ`-congruent points, so the strict inequality `k < vol(S)` of `blichfeldt_general` is sharp. A point of the box is determined by its (shared) fractional part together with `⌊·₀⌋ ∈ {0,…,k-1}`, giving an injection into `Fin k`; pigeonhole rules out `k+1`.

## Verification

- **status:** `verified`, **0 sorries**, **0 axioms** (`#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`).
- 8 theorems, 1 definition, 215 lines.
- Built against Mathlib 4.26.0 via the host `lake` fallback (Docker daemon down this session); dependency chain `MinkowskiFundamentalTheorem → MinkowskiTheoremOQ04 → MinkowskiTheoremOQ04OQ03` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)