### PR TITLE
Enrich Chebyshev semigroup law over 𝔽_p: add index.ts + annotations + sections

### DIFF
--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "dm-eval-comp",
+    "proofId": "de-moivre-oq-01-oq-03-oq-02",
+    "range": { "startLine": 45, "endLine": 50 },
+    "type": "theorem",
+    "title": "Evaluation-Map Composition Law C_{mn}(x) = C_m(C_n(x))",
+    "content": "The basic semigroup law in evaluation form, over an arbitrary commutative ring R. Mathlib already proves the polynomial-level identity C_mul: C R (m·n) = (C R m).comp (C R n); this lemma applies Polynomial.eval_comp to turn polynomial composition .comp into function nesting of evaluations. The file deliberately does NOT reprove C_mul — its contribution is exactly the packaging the open question asks for, turning the polynomial identity into the usable map-nesting statement.",
+    "mathContext": "$C_{mn}(x) = C_m\\big(C_n(x)\\big)$",
+    "significance": "critical",
+    "prerequisites": ["Polynomial.Chebyshev.C_mul", "Polynomial.eval_comp", "Chebyshev polynomials of the first kind"],
+    "relatedConcepts": ["Chebyshev composition law", "functional iteration", "polynomial composition .comp", "De Moivre identity"]
+  },
+  {
+    "id": "dm-comm",
+    "proofId": "de-moivre-oq-01-oq-03-oq-02",
+    "range": { "startLine": 52, "endLine": 56 },
+    "type": "theorem",
+    "title": "Commuting Family C_m(C_n x) = C_n(C_m x)",
+    "content": "Commutativity of the Chebyshev maps under composition, derived immediately from the evaluation law applied both ways plus mul_comm on the integer indices (m·n = n·m). This C_a ∘ C_b = C_b ∘ C_a is the algebraic trapdoor behind Chebyshev / Lucas-sequence public-key exchange: two parties applying C_a and C_b in either order reach the same shared value.",
+    "mathContext": "$C_m\\big(C_n(x)\\big) = C_n\\big(C_m(x)\\big)$",
+    "significance": "key",
+    "prerequisites": ["the evaluation composition law", "commutativity of integer multiplication"],
+    "relatedConcepts": ["commuting polynomials", "Chebyshev key exchange", "Ritt's theorem on commuting polynomials", "Lucas sequences"]
+  },
+  {
+    "id": "dm-pow-conjugacy",
+    "proofId": "de-moivre-oq-01-oq-03-oq-02",
+    "range": { "startLine": 58, "endLine": 68 },
+    "type": "theorem",
+    "title": "Power-Map Conjugacy on the Unit Circle z·w = 1",
+    "content": "The genuine structural insight: on the 'unit circle' z·w = 1, the Chebyshev nesting law is the shadow of the power-law (zⁿ)ᵐ = z^{mn}. Both C_{mn}(z+w) and C_m(C_n(z+w)) equal (zⁿ)ᵐ + (wⁿ)ᵐ, because zⁿ·wⁿ = (z·w)ⁿ = 1 keeps the pair on the circle. Reusing the parent identity chebyshevC_eval_add (C_n(z+w) = zⁿ + wⁿ), this exhibits the parametrization z ↦ z + z⁻¹ as a conjugacy carrying the power monoid n ↦ (·ⁿ) onto the Chebyshev family n ↦ C_n — the abstract reason the C_n compose like exponents.",
+    "mathContext": "$z w = 1 \\;\\Rightarrow\\; C_{mn}(z + w) = (z^n)^m + (w^n)^m = z^{mn} + w^{mn}$",
+    "significance": "critical",
+    "prerequisites": ["the parent identity chebyshevC_eval_add", "exponent laws (zⁿ)ᵐ = z^{mn}", "the substitution z ↦ z + z⁻¹"],
+    "relatedConcepts": ["semiconjugacy", "z + 1/z parametrization", "cos(nθ) via De Moivre", "power monoid", "Dickson polynomials"]
+  },
+  {
+    "id": "dm-end-hom",
+    "proofId": "de-moivre-oq-01-oq-03-oq-02",
+    "range": { "startLine": 70, "endLine": 109 },
+    "type": "definition",
+    "title": "The Monoid Homomorphism (ℤ, ·) →* (End 𝔽_p, ∘)",
+    "content": "chebyshevEnd p n bundles the evaluation map x ↦ C_n(x) as an element of the composition monoid Function.End (ZMod p). chebyshevHom packages n ↦ chebyshevEnd p n into an actual MonoidHom (ℤ, ·) →* (End (ZMod p), ∘): map_one' is C_1 = X = id (the identity endomorphism), and map_mul' is precisely the evaluation composition law C_{mn} = C_m ∘ C_n. chebyshevEnd_comm restates the commuting family as an equation of endomorphisms. This is the exact 'state it as a monoid homomorphism' deliverable the open question requested; for prime p the image is the commutative submonoid behind Chebyshev key exchange.",
+    "mathContext": "$\\mathrm{chebyshevHom} : (\\mathbb{Z}, \\cdot) \\to^* (\\mathrm{End}\\,\\mathbb{F}_p, \\circ), \\quad n \\mapsto (x \\mapsto C_n(x))$",
+    "significance": "key",
+    "prerequisites": ["Function.End as a composition monoid", "MonoidHom structure (map_one, map_mul)", "ZMod p", "C_one = X"],
+    "relatedConcepts": ["monoid homomorphism", "endomorphism monoid", "structure-preserving packaging", "multiplicative monoid (ℤ, ·)"]
+  },
+  {
+    "id": "dm-finite-field-pow",
+    "proofId": "de-moivre-oq-01-oq-03-oq-02",
+    "range": { "startLine": 111, "endLine": 124 },
+    "type": "theorem",
+    "title": "Power-Map Conjugacy over the Finite Field 𝔽_p",
+    "content": "chebyshevEnd_eval_pow specializes the conjugacy to 𝔽_p = ZMod p with p prime: for z ≠ 0, the nested Chebyshev endomorphism evaluated at the unit-circle point z + z⁻¹ realizes the (m·n)-th power map, equalling (zⁿ)ᵐ + (z⁻ⁿ)ᵐ = z^{mn} + z^{-mn}. This is the step that genuinely needs the field structure — mul_inv_cancel₀ requires z ≠ 0 to be invertible — making 𝔽_p (not just an arbitrary ZMod p) the relevant setting, and matching the cryptographically interesting case.",
+    "mathContext": "$z \\ne 0 \\;\\Rightarrow\\; C_{mn}(z + z^{-1}) = z^{mn} + z^{-mn} \\text{ in } \\mathbb{F}_p$",
+    "significance": "key",
+    "prerequisites": ["mul_inv_cancel₀ (field inverse)", "Fact p.Prime ⟹ ZMod p is a field", "the unit-circle power conjugacy"],
+    "relatedConcepts": ["finite field 𝔽_p", "multiplicative group 𝔽_p^×", "discrete-log trapdoor", "Chebyshev cryptosystem"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/index.ts
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DeMoivreOQ01OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const deMoivreOq01Oq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const deMoivreOq01Oq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const deMoivreOq01Oq03Oq02Data: ProofData = {
+  proof: deMoivreOq01Oq03Oq02Proof,
+  annotations: deMoivreOq01Oq03Oq02Annotations,
+}

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-02/meta.json
@@ -142,5 +142,35 @@
       "description": "Builds on the De Moivre/Chebyshev connection over finite fields"
     }
   ],
+  "sections": [
+    {
+      "id": "evaluation-law",
+      "title": "Evaluation-Map Composition Law",
+      "startLine": 45,
+      "endLine": 56,
+      "summary": "chebyshevC_evalComp: the evaluation form C_{mn}(x) = C_m(C_n(x)) over any commutative ring, a one-line corollary of Mathlib's polynomial identity C_mul (C R (m·n) = (C R m).comp (C R n)) via eval_comp. chebyshevC_evalComp_comm then derives the commuting family C_m(C_n x) = C_n(C_m x) from mul_comm on the index."
+    },
+    {
+      "id": "power-conjugacy",
+      "title": "Power-Map Conjugacy on the Unit Circle",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "chebyshevC_evalComp_pow: on the 'unit circle' z·w = 1, the nesting law is the shadow of (zⁿ)ᵐ = z^{mn} — both C_{mn}(z+w) and C_m(C_n(z+w)) equal (zⁿ)ᵐ + (wⁿ)ᵐ, since zⁿwⁿ = (zw)ⁿ = 1 keeps the pair on the circle. Reuses the parent's chebyshevC_eval_add. The structural insight: via z ↦ z + z⁻¹, the family n ↦ C_n is conjugate to the power monoid n ↦ (·ⁿ)."
+    },
+    {
+      "id": "monoid-hom",
+      "title": "Monoid Homomorphism over ZMod p",
+      "startLine": 70,
+      "endLine": 109,
+      "summary": "chebyshevEnd packages x ↦ C_n(x) as an element of the composition monoid Function.End (ZMod p), and chebyshevHom bundles n ↦ (x ↦ C_n x) into a monoid homomorphism (ℤ, ·) →* (End (ZMod p), ∘): map_one is C_1 = X = id, and map_mul is exactly the semigroup law. chebyshevEnd_comm restates the commuting family as endomorphism equality — the trapdoor behind Chebyshev/Lucas key exchange."
+    },
+    {
+      "id": "finite-field",
+      "title": "Power-Map Conjugacy over the Finite Field 𝔽_p",
+      "startLine": 111,
+      "endLine": 124,
+      "summary": "chebyshevEnd_eval_pow: for z ≠ 0 in 𝔽_p, the nested Chebyshev endomorphism at z + z⁻¹ realizes the (m·n)-th power map, equalling z^{mn} + z^{-mn}. This is the genuinely finite-field step (mul_inv_cancel₀ uses the field structure), exhibiting n ↦ C_n as the shadow of the power monoid under z ↦ z + z⁻¹."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-01-oq-03-oq-02` (Chebyshev semigroup law over 𝔽_p: C_{mn} = C_m ∘ C_n as a monoid homomorphism).

## Gaps fixed
- **Missing `index.ts`** → *'proof not found'* on the live site. Added (Lean source `DeMoivreOQ01OQ03OQ02.lean`).
- **Missing `annotations.json`** — added **5 inline annotations** covering all parts.
- **Missing `sections` array** (the key was absent entirely) — added 4 sections covering the 126-line file.

## Annotation coverage
Each carries `mathContext` (LaTeX), `significance`, `prerequisites`, `relatedConcepts`:
1. `chebyshevC_evalComp` — evaluation composition law C_{mn}(x) = C_m(C_n(x)) (eval form of Mathlib's C_mul)
2. `chebyshevC_evalComp_comm` — commuting family (the Chebyshev/Lucas key-exchange trapdoor)
3. `chebyshevC_evalComp_pow` — power-map conjugacy on the unit circle z·w=1 (the structural insight)
4. `chebyshevHom` — the bundled monoid homomorphism (ℤ,·) →* (End 𝔽_p, ∘)
5. `chebyshevEnd_eval_pow` — finite-field power conjugacy (uses mul_inv_cancel₀)

overview/crossReferences were already well-formed and are intact. Axiom status verified accurate: `verified`, 0 axioms, 0 sorries. `pnpm build` passes.