### PR TITLE
audit: register 2 orphaned verified Hilbert17 proofs in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3052,7 +3052,9 @@ import Proofs.Hilbert17MotzkinRationalSOS
 import Proofs.Hilbert17MotzkinNotSOS
 import Proofs.Hilbert17OQ01
 import Proofs.Hilbert17QuadraticGram
+import Proofs.Hilbert17RobinsonNotSOS
 import Proofs.Hilbert17SumOfSquares
+import Proofs.Hilbert17UnivariatePSDSOS
 import Proofs.Hilbert19OQ03
 import Proofs.Hilbert19Regularity
 import Proofs.Hilbert20BoundaryValue

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21601,6 +21601,42 @@
       "lastAudited": "2026-06-24T14:25:35Z",
       "result": "clean",
       "issues": []
+    },
+    "arsinh-log-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1012-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:40Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gram-linear-independence-iff-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-17-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-17-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:41Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "hilbert-17-oq-03-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T14:45:41Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Fix

Two gallery proofs were committed and claimed `verified` / `original` / 0-axiom but were **never imported into `proofs/Proofs.lean`**, leaving them out of the build graph (not machine-checked during gallery builds):

- `Hilbert17RobinsonNotSOS` — `robinson_not_sos` (hilbert-17-oq-03-oq-03)
- `Hilbert17UnivariatePSDSOS` — `univariate_psd_is_sos` (hilbert-17-oq-03-oq-04)

This is the same orphaned-proof class as #29086.

## Verification

Both files type-check cleanly via `lake env lean` (rc=0), and `#print axioms` on each main theorem reports only the standard foundational axioms:

```
'Hilbert17RobinsonNotSOS.robinson_not_sos' depends on axioms: [propext, Classical.choice, Quot.sound]
'Hilbert17UnivariatePSDSOS.univariate_psd_is_sos' depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `native_decide`, no `Lean.ofReduceBool` — so the `verified` / 0-axiom meta claims are accurate. The fix simply restores them to the build graph with two `import` lines (alphabetical placement).

---
Discovered during gallery integrity audit.