### PR TITLE
research(bounded-prime-gaps-oq-04-oq-01-wip-01): geometric exponential sum bound (Pólya–Vinogradov ingredient) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -454,6 +454,7 @@ import Proofs.BoundedPrimeGapsOQ03OQ02
 import Proofs.BoundedPrimeGapsOQ03OQ03
 import Proofs.BoundedPrimeGapsOQ04
 import Proofs.BoundedPrimeGapsOQ04OQ01
+import Proofs.BoundedPrimeGapsOQ04OQ01WIP01
 import Proofs.BoundedPrimeGapsOQ04OQ01Aristotle
 import Proofs.BoundedPrimeGapsOQ04OQ02
 import Proofs.BoundedPrimeGapsSieve

--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ01WIP01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ01WIP01.lean
@@ -1,0 +1,130 @@
+/-
+  # The Geometric Exponential Sum Bound (Pólya–Vinogradov ingredient)
+
+  The companion file `BoundedPrimeGapsOQ04OQ01` sets up the Pólya–Vinogradov
+  inequality `|∑_{n} χ(n)| ≤ √q·log q` for Dirichlet characters, leaving four
+  analytic `sorry`s. Its key technical ingredient — and the only one that is a
+  clean, self-contained classical estimate — is the bound on a **partial geometric
+  sum of an exponential with unit-modulus ratio**:
+
+      |∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1 / |sin(πθ)|    (θ ∉ ℤ).
+
+  This file proves exactly that, fully machine-checked. (The companion file is a
+  work-in-progress that does not currently parse against Mathlib — it uses the
+  retired `∑ x in s` syntax — so this entry re-establishes the small set of
+  supporting lemmas and the main bound from scratch, with modern syntax.)
+
+  The estimate is the heart of Pólya–Vinogradov: writing the character sum via its
+  Gauss-sum Fourier expansion turns it into a combination of such exponential sums,
+  and `1/|sin(πθ)|` is precisely the factor that the cotangent sum then aggregates.
+
+  ## Results
+  * `norm_one_sub_exp_two_pi_I` : `|1 − e^{2πiθ}| = 2|sin(πθ)|` (the chord-length
+    identity on the unit circle).
+  * `geom_partial_sum_bound` : the headline `|∑_{M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)|`.
+  * `geom_partial_sum_bound_zero` : the `M = 0` special case over `Icc 1 N`.
+
+  ## Proof
+  With `z = e^{2πiθ}` on the unit circle, the partial sum is
+  `z^{M+1}·∑_{k<N} z^k = z^{M+1}·(z^N − 1)/(z − 1)`. Then `|z^{M+1}| = 1`,
+  `|z^N − 1| ≤ 2` (triangle inequality), and `|z − 1| = 2|sin(πθ)|` (chord length),
+  giving `2 / (2|sin(πθ)|) = 1/|sin(πθ)|`.
+
+  Tags: analytic-number-theory, character-sums, polya-vinogradov, geometric-sum,
+        exponential-sum
+-/
+import Mathlib
+
+namespace BoundedPrimeGapsOQ04OQ01WIP01
+
+open Finset Complex Real
+
+/-- `sin(πθ) ≠ 0` when `θ` is not an integer. -/
+lemma sin_pi_mul_ne_zero (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k) :
+    Real.sin (π * θ) ≠ 0 := by
+  intro h
+  rw [Real.sin_eq_zero_iff] at h
+  obtain ⟨k, hk⟩ := h
+  have hπ : (π : ℝ) ≠ 0 := ne_of_gt Real.pi_pos
+  rw [mul_comm] at hk
+  exact hθ k (mul_left_cancel₀ hπ hk).symm
+
+/-- `|1 − z^n| ≤ 2` when `|z| = 1` (triangle inequality on the unit circle). -/
+lemma norm_one_sub_pow_le_two (z : ℂ) (hz : ‖z‖ = 1) (n : ℕ) :
+    ‖(1 : ℂ) - z ^ n‖ ≤ 2 := by
+  calc ‖(1 : ℂ) - z ^ n‖ ≤ ‖(1 : ℂ)‖ + ‖z ^ n‖ := norm_sub_le _ _
+    _ = 1 + ‖z ^ n‖ := by rw [norm_one]
+    _ = 1 + 1 := by rw [norm_pow, hz, one_pow]
+    _ = 2 := by ring
+
+/-- The chord-length identity `|1 − e^{2πiθ}| = 2|sin(πθ)|`. -/
+lemma norm_one_sub_exp_two_pi_I (θ : ℝ) :
+    ‖(1 : ℂ) - exp (2 * ↑π * I * ↑θ)‖ = 2 * |Real.sin (π * θ)| := by
+  have harg : (2 : ℂ) * ↑π * I * ↑θ = ↑(2 * π * θ) * I := by push_cast; ring
+  rw [harg, Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin]
+  have hdiff : (1 : ℂ) - (↑(Real.cos (2 * π * θ)) + ↑(Real.sin (2 * π * θ)) * I) =
+      ↑(1 - Real.cos (2 * π * θ)) + ↑(-Real.sin (2 * π * θ)) * I := by push_cast; ring
+  rw [hdiff, Complex.norm_add_mul_I]
+  have h_sq : (1 - Real.cos (2 * π * θ)) ^ 2 + (-Real.sin (2 * π * θ)) ^ 2 =
+      (2 * |Real.sin (π * θ)|) ^ 2 := by
+    rw [mul_pow, sq_abs, neg_sq]
+    have h1 := Real.sin_sq_add_cos_sq (2 * π * θ)
+    have h2 := Real.cos_two_mul (π * θ)
+    have h2arg : 2 * (π * θ) = 2 * π * θ := by ring
+    rw [h2arg] at h2
+    have h3 := Real.sin_sq_add_cos_sq (π * θ)
+    linear_combination h1 - 2 * h2 - 4 * h3
+  rw [h_sq, Real.sqrt_sq (by positivity)]
+
+/-- **Geometric exponential sum bound.** For `θ ∉ ℤ`,
+    `|∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)|`. The key estimate behind the
+    Pólya–Vinogradov inequality. -/
+theorem geom_partial_sum_bound (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k) (M N : ℕ) :
+    ‖∑ n ∈ Finset.Icc (M + 1) (M + N), exp (2 * ↑π * I * ↑θ * (n : ℂ))‖ ≤
+    1 / |Real.sin (π * θ)| := by
+  set z : ℂ := exp (2 * ↑π * I * ↑θ) with hz_def
+  -- `|z| = 1`.
+  have hzI : (2 : ℂ) * ↑π * I * ↑θ = ↑(2 * π * θ) * I := by push_cast; ring
+  have hznorm1 : ‖z‖ = 1 := by rw [hz_def, hzI]; exact norm_exp_ofReal_mul_I (2 * π * θ)
+  -- `sin(πθ) ≠ 0` and `|1 − z| = 2|sin(πθ)|`.
+  have hsin : Real.sin (π * θ) ≠ 0 := sin_pi_mul_ne_zero θ hθ
+  have h1z : ‖(1 : ℂ) - z‖ = 2 * |Real.sin (π * θ)| := by
+    rw [hz_def]; exact norm_one_sub_exp_two_pi_I θ
+  -- Hence `z ≠ 1`.
+  have hz1 : z ≠ 1 := by
+    intro h
+    rw [h, sub_self, norm_zero] at h1z
+    exact hsin (abs_eq_zero.mp (by linarith))
+  -- Each summand is `z^n`.
+  have hpow : ∀ n : ℕ, exp (2 * ↑π * I * ↑θ * (n : ℂ)) = z ^ n := by
+    intro n
+    rw [hz_def, ← Complex.exp_nat_mul]
+    congr 1
+    ring
+  simp_rw [hpow]
+  -- Geometric partial sum: `∑_{n=M+1}^{M+N} z^n = z^{M+1}·∑_{k<N} z^k`.
+  have hgeom : ∑ n ∈ Finset.Icc (M + 1) (M + N), z ^ n
+      = z ^ (M + 1) * ∑ k ∈ Finset.range N, z ^ k := by
+    rw [← Finset.Ico_succ_right_eq_Icc, Order.succ_eq_add_one,
+      Finset.sum_Ico_eq_sum_range, Finset.mul_sum]
+    apply Finset.sum_congr
+    · congr 1; omega
+    · intro k _; rw [pow_add]
+  have h1z' : ‖z - 1‖ = 2 * |Real.sin (π * θ)| := by rw [norm_sub_rev]; exact h1z
+  rw [hgeom, geom_sum_eq hz1, norm_mul, norm_pow, hznorm1, one_pow, one_mul, norm_div, h1z']
+  -- Combine `|z^N − 1| ≤ 2` with `|z − 1| = 2|sin(πθ)|`.
+  have hsinpos : (0 : ℝ) < |Real.sin (π * θ)| := abs_pos.mpr hsin
+  have hne : |Real.sin (π * θ)| ≠ 0 := ne_of_gt hsinpos
+  have hnum : ‖z ^ N - 1‖ ≤ 2 := by
+    rw [norm_sub_rev]; exact norm_one_sub_pow_le_two z hznorm1 N
+  calc ‖z ^ N - 1‖ / (2 * |Real.sin (π * θ)|)
+      ≤ 2 / (2 * |Real.sin (π * θ)|) := by gcongr
+    _ = 1 / |Real.sin (π * θ)| := by field_simp
+
+/-- The `M = 0` special case: `|∑_{n=1}^{N} e^{2πiθn}| ≤ 1/|sin(πθ)|`. -/
+theorem geom_partial_sum_bound_zero (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k) (N : ℕ) :
+    ‖∑ n ∈ Finset.Icc 1 N, exp (2 * ↑π * I * ↑θ * (n : ℂ))‖ ≤
+    1 / |Real.sin (π * θ)| := by
+  simpa using geom_partial_sum_bound θ hθ 0 N
+
+end BoundedPrimeGapsOQ04OQ01WIP01

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-wip-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-wip-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "bounded-prime-gaps-oq-04-oq-01-wip-01",
+  "title": "The Geometric Exponential Sum Bound (Pólya–Vinogradov Ingredient)",
+  "slug": "bounded-prime-gaps-oq-04-oq-01-wip-01",
+  "description": "Proves, fully verified, the key technical estimate behind the Pólya–Vinogradov inequality: for θ not an integer, the partial geometric exponential sum |∑_{n=M+1}^{M+N} e^{2πiθn}| is bounded by 1/|sin(πθ)|. Establishes the unit-circle chord-length identity |1 − e^{2πiθ}| = 2|sin(πθ)|, the triangle bound |1 − zⁿ| ≤ 2 on the unit circle, and combines them with the geometric series closed form. The companion WIP file (bounded-prime-gaps-oq-04-oq-01) leaves this and three other analytic facts as sorries and currently does not parse against Mathlib (retired ∑-in syntax); this entry completes the cleanest ingredient as a standalone 0-axiom result.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/P%C3%B3lya%E2%80%93Vinogradov_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BoundedPrimeGapsOQ04OQ01WIP01.lean",
+    "tags": [
+      "analytic-number-theory",
+      "character-sums",
+      "polya-vinogradov",
+      "geometric-sum",
+      "exponential-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 130,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-24",
+    "originalContributions": [
+      "geom_partial_sum_bound: |∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)| for θ ∉ ℤ — the central exponential-sum estimate of Pólya–Vinogradov",
+      "geom_partial_sum_bound_zero: the M = 0 special case over Icc 1 N",
+      "norm_one_sub_exp_two_pi_I: the chord-length identity |1 − e^{2πiθ}| = 2|sin(πθ)| (Euler's formula + double-angle)",
+      "norm_one_sub_pow_le_two: |1 − zⁿ| ≤ 2 for |z| = 1 (triangle inequality on the unit circle)",
+      "sin_pi_mul_ne_zero: sin(πθ) ≠ 0 for non-integer θ"
+    ],
+    "prerequisites": [
+      "BoundedPrimeGapsOQ04OQ01 (companion WIP): states Pólya–Vinogradov and identifies this geometric sum bound as its key ingredient (left as a sorry there)",
+      "geom_sum_eq: closed form ∑_{i<n} xⁱ = (xⁿ − 1)/(x − 1) for x ≠ 1",
+      "Complex.norm_exp_ofReal_mul_I: |e^{ix}| = 1 for real x"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_eq",
+        "description": "∑_{i ∈ range n} xⁱ = (xⁿ − 1)/(x − 1) for x ≠ 1 — the geometric series closed form",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      },
+      {
+        "theorem": "Complex.norm_exp_ofReal_mul_I",
+        "description": "‖exp (x · I)‖ = 1 for real x — the exponential ratio lies on the unit circle",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Complex.exp_nat_mul",
+        "description": "exp (n · x) = (exp x)ⁿ — turns each summand into a power of the ratio",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sum_range",
+        "description": "Reindexes ∑ over Ico m n to ∑ over range (n − m) — used to factor the partial sum",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Complex.norm_add_mul_I",
+        "description": "‖a + b·I‖ = √(a² + b²) — evaluates the chord length |1 − e^{2πiθ}|",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      }
+    ],
+    "theoremCount": 5,
+    "relatedProblems": [
+      {
+        "id": "bounded-prime-gaps-oq-04-oq-01",
+        "relationship": "Companion WIP: states the full Pólya–Vinogradov inequality with four analytic sorries. This entry verifies its key geometric exponential-sum ingredient."
+      },
+      {
+        "id": "bounded-prime-gaps-oq-04",
+        "relationship": "Ancestor: Pólya–Vinogradov is a prerequisite for the Bombieri–Vinogradov machinery in the bounded-prime-gaps OQ04 line."
+      }
+    ],
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Pólya–Vinogradov inequality (1918) bounds incomplete character sums |∑_{n=M+1}^{M+N} χ(n)| ≤ √q·log q and is the foundational tool for studying the distribution of characters over short intervals. Its proof expands χ via its Gauss-sum Fourier series, reducing the character sum to a combination of partial exponential sums ∑ e^{2πian/q}. The bound on those exponential sums — the content of this entry — is the analytic heart of the argument; the rest is the algebra of Gauss sums and the aggregation of the resulting 1/|sin| factors.",
+    "keyInsight": "A partial sum of e^{2πiθn} is a partial geometric series with ratio z = e^{2πiθ} on the unit circle. Its modulus telescopes to |z^{M+1}|·|zⁿ − 1|/|z − 1|; the numerator is at most 2 by the triangle inequality, and the denominator is exactly the chord length 2|sin(πθ)|. So the whole sum is bounded by 1/|sin(πθ)| — independent of how many terms N are summed.",
+    "significance": "This is the one ingredient of Pólya–Vinogradov that is a clean, self-contained classical estimate, and it is reusable throughout analytic number theory (exponential sums, equidistribution, discrepancy). Verifying it 0-axiom turns the companion's central sorry into machine-checked mathematics."
+  },
+  "sections": [
+    {
+      "id": "helpers",
+      "title": "Helper lemmas",
+      "startLine": 43,
+      "endLine": 79,
+      "summary": "sin(πθ) ≠ 0 for non-integer θ; |1 − zⁿ| ≤ 2 on the unit circle; and the chord-length identity |1 − e^{2πiθ}| = 2|sin(πθ)| via Euler's formula and the double-angle identity.",
+      "mathContext": "The chord-length identity is the geometric crux: the distance from 1 to e^{2πiθ} on the unit circle is twice the sine of the half-angle πθ."
+    },
+    {
+      "id": "main",
+      "title": "The geometric exponential sum bound",
+      "startLine": 81,
+      "endLine": 123,
+      "summary": "geom_partial_sum_bound: factor the partial sum as z^{M+1}·∑_{k<N} zᵏ, apply the geometric closed form, and combine |z^{M+1}| = 1, |zⁿ − 1| ≤ 2, |z − 1| = 2|sin(πθ)| to get the bound 1/|sin(πθ)|.",
+      "mathContext": "Each summand e^{2πiθn} = zⁿ; the geometric series is summed in closed form (valid since z ≠ 1 by the chord-length identity), and the modulus estimate is purely the triangle inequality plus the chord length."
+    },
+    {
+      "id": "corollary",
+      "title": "M = 0 special case",
+      "startLine": 124,
+      "endLine": 129,
+      "summary": "geom_partial_sum_bound_zero specialises the bound to the interval Icc 1 N.",
+      "mathContext": "The form most directly invoked when summing e^{2πian/q} over a residue interval starting at 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The partial exponential sum ∑_{n=M+1}^{M+N} e^{2πiθn} has modulus at most 1/|sin(πθ)|, uniformly in M and N. The proof rests on the chord-length identity |1 − e^{2πiθ}| = 2|sin(πθ)| and the geometric series closed form, and is fully machine-checked and 0-axiom. This completes the central analytic ingredient that the companion Pólya–Vinogradov file leaves open.",
+    "futureWork": "Use this bound, together with the Gauss-sum norm |τ(χ)| = √q and the cotangent sum estimate, to discharge the remaining Pólya–Vinogradov sorries; and modernise the companion file's retired ∑-in syntax so the pieces can be assembled in place."
+  },
+  "crossReferences": [
+    {
+      "targetId": "bounded-prime-gaps-oq-04-oq-01",
+      "relationship": "parent",
+      "description": "Companion WIP entry stating the full Pólya–Vinogradov inequality. This entry verifies its key geometric exponential-sum ingredient."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "geom_partial_sum_bound",
+      "type": "core",
+      "description": "For non-integer θ, the partial geometric exponential sum is bounded by 1/|sin(πθ)|, uniformly in the offset M and length N.",
+      "leanType": "(∀ k : ℤ, θ ≠ ↑k) → ‖∑ n ∈ Finset.Icc (M+1) (M+N), exp (2·π·I·θ·n)‖ ≤ 1 / |Real.sin (π·θ)|"
+    },
+    {
+      "name": "norm_one_sub_exp_two_pi_I",
+      "type": "core",
+      "description": "The unit-circle chord-length identity |1 − e^{2πiθ}| = 2|sin(πθ)|.",
+      "leanType": "‖(1 : ℂ) - exp (2·π·I·θ)‖ = 2 * |Real.sin (π·θ)|"
+    },
+    {
+      "name": "geom_partial_sum_bound_zero",
+      "type": "supporting",
+      "description": "The M = 0 special case over the interval Icc 1 N.",
+      "leanType": "(∀ k : ℤ, θ ≠ ↑k) → ‖∑ n ∈ Finset.Icc 1 N, exp (2·π·I·θ·n)‖ ≤ 1 / |Real.sin (π·θ)|"
+    },
+    {
+      "name": "norm_one_sub_pow_le_two",
+      "type": "supporting",
+      "description": "|1 − zⁿ| ≤ 2 for any z on the unit circle.",
+      "leanType": "‖z‖ = 1 → ‖(1 : ℂ) - z ^ n‖ ≤ 2"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "George Pólya"
+      ],
+      "title": "Über die Verteilung der quadratischen Reste und Nichtreste",
+      "year": "1918",
+      "venue": "Nachrichten der Gesellschaft der Wissenschaften zu Göttingen, pp. 21–29",
+      "note": "One of the two independent 1918 derivations of the character-sum bound; the geometric exponential sum estimate proved here is its analytic core."
+    },
+    {
+      "authors": [
+        "Ivan M. Vinogradov"
+      ],
+      "title": "Über die Verteilung der quadratischen Reste und Nichtreste",
+      "year": "1918",
+      "venue": "Journal of the Physico-Mathematical Society of Perm, vol. 1, pp. 94–98",
+      "note": "The second independent 1918 derivation of the inequality that bears both names."
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Complex",
+      "Real"
+    ],
+    "namespace": "BoundedPrimeGapsOQ04OQ01WIP01",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/BoundedPrimeGapsOQ04OQ01WIP01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Proves, fully verified, the **key technical estimate behind the Pólya–Vinogradov inequality**:

> For θ not an integer, `|∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)|` — uniformly in the offset M and length N.

This is the one ingredient of Pólya–Vinogradov that is a clean, self-contained classical estimate (the rest is Gauss-sum algebra and aggregating the resulting `1/|sin|` factors).

**Gallery entry:** `bounded-prime-gaps-oq-04-oq-01-wip-01` — *verified, 0-axiom, 130 lines, 5 declarations (3 helper lemmas + 2 theorems), 0 sorries.*

### Results
- `geom_partial_sum_bound` — the headline bound.
- `geom_partial_sum_bound_zero` — the `M = 0` special case over `Icc 1 N`.
- `norm_one_sub_exp_two_pi_I` — the unit-circle chord-length identity `|1 − e^{2πiθ}| = 2|sin(πθ)|`.
- `norm_one_sub_pow_le_two`, `sin_pi_mul_ne_zero` — supporting lemmas.

### Proof
With `z = e^{2πiθ}` on the unit circle, the partial sum factors as `z^{M+1}·∑_{k<N} zᵏ = z^{M+1}·(zᴺ − 1)/(z − 1)`. Then `|z^{M+1}| = 1`, `|zᴺ − 1| ≤ 2` (triangle inequality), and `|z − 1| = 2|sin(πθ)|` (chord length), giving `2/(2|sin πθ|) = 1/|sin πθ|`.

## Verification
- Compiled standalone against Mathlib 4.26.0 (host `lake env lean`; Docker unavailable).
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` — **0-axiom / verified** (no `sorryAx`).

## Notes
- The companion WIP file `BoundedPrimeGapsOQ04OQ01.lean` leaves this and three other analytic facts (Gauss sum norm, cotangent sum, full Pólya–Vinogradov) as sorries, and **currently does not parse** against Mathlib 4.26 — it uses the retired `∑ x in s` notation (now `∑ x ∈ s`). To stay verified end-to-end, this entry re-establishes the small set of supporting lemmas with modern syntax and proves the geometric bound from scratch, rather than editing the non-parsing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)