### PR TITLE
Enrich directed handshake lemma & tournament scores: add index.ts + annotations

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1012-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dh-digraph-defs",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 55, "endLine": 78 },
+    "type": "definition",
+    "title": "Digraph, Degrees, and Arc Count",
+    "content": "A Digraph is a loopless arc relation arc : V → V → Prop (no v → v). outDegree v counts targets u with v → u; inDegree v counts sources u with u → v; arcCount is the total number of ordered arc pairs. These mirror the companion file Erdos1012OQ03 verbatim so this file stands alone and is machine-checked end to end. Decidability of the arc relation is supplied classically (Classical.decPred), which is why the degree definitions are noncomputable.",
+    "mathContext": "$d^+(v) = \\#\\{u : v \\to u\\},\\quad d^-(v) = \\#\\{u : u \\to v\\},\\quad |A| = \\#\\{(u,v) : u \\to v\\}$",
+    "significance": "supporting",
+    "prerequisites": ["directed graphs / digraphs", "Fintype.card of a subtype", "Classical.decPred"],
+    "relatedConcepts": ["out-degree / in-degree", "loopless relation", "tournament", "arc count"]
+  },
+  {
+    "id": "dh-filter-reformulation",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 80, "endLine": 97 },
+    "type": "lemma",
+    "title": "Degrees and Arc Count as Filter Cardinalities",
+    "content": "outDegree_eq_card_filter, inDegree_eq_card_filter, and arcCount_eq_card_filter rewrite each subtype-cardinality as the cardinality of a Finset.filter over univ (resp. univ ×ˢ univ). This bridges the definitional Fintype.card {u // arc v u} with the Finset world where Fubini-style sum manipulations (sum_product, sum_comm) are available — the technical move that makes the handshake counting go through.",
+    "mathContext": "$d^+(v) = |\\{u \\in V : v \\to u\\}|,\\quad |A| = |\\{(u,v) : u \\to v\\}|$",
+    "significance": "supporting",
+    "prerequisites": ["Fintype.card_subtype", "Finset.filter", "Finset.card"],
+    "relatedConcepts": ["cardinality as filtered count", "subtype vs Finset", "indicator counting"]
+  },
+  {
+    "id": "dh-handshake",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 99, "endLine": 123 },
+    "type": "theorem",
+    "title": "The Directed Handshake Lemma: ∑ d⁺ = |A| = ∑ d⁻",
+    "content": "The central result. sum_outDegree_eq_arcCount: summing out-degrees counts every arc exactly once, recovering arcCount — proved by expanding to filter cardinalities and applying Finset.sum_product over univ ×ˢ univ. sum_inDegree_eq_arcCount is the same with an extra Finset.sum_comm (swap the order of the double sum). Together (sum_outDegree_eq_sum_inDegree) they give conservation of degree: total out-degree = total in-degree, the directed analogue of Euler's handshake lemma — each arc leaves exactly one vertex and enters exactly one.",
+    "mathContext": "$\\sum_{v} d^+(v) = |A| = \\sum_{v} d^-(v)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_product (Fubini for double sums)", "Finset.sum_comm", "Finset.univ_product_univ"],
+    "relatedConcepts": ["handshake lemma", "Euler degree-sum", "double counting", "conservation of flow"]
+  },
+  {
+    "id": "dh-tournament-degree",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 125, "endLine": 156 },
+    "type": "theorem",
+    "title": "Tournament Local Identity: d⁺(v) + d⁻(v) = n − 1",
+    "content": "tournament_outDegree_add_inDegree: in a tournament each vertex either beats or loses to every other vertex, so its out- and in-neighborhoods are disjoint and their union is univ.erase v. Hence d⁺(v) + d⁻(v) = |univ.erase v| = n − 1. The proof shows disjointness from the tournament's exactly-one-arc property and identifies the union with the complement of {v} via the same dichotomy.",
+    "mathContext": "$D \\text{ tournament} \\;\\Rightarrow\\; d^+(v) + d^-(v) = n - 1$",
+    "significance": "key",
+    "prerequisites": ["Finset.card_union_of_disjoint", "Finset.card_erase_of_mem", "tournament dichotomy", "Finset.disjoint_left"],
+    "relatedConcepts": ["tournament", "round-robin", "complete digraph orientation", "score sequence"]
+  },
+  {
+    "id": "dh-landau",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 158, "endLine": 173 },
+    "type": "theorem",
+    "title": "Landau's Score-Sum Identity: 2·∑ d⁺ = n(n−1)",
+    "content": "Summing the local identity d⁺(v) + d⁻(v) = n − 1 over all vertices and using ∑ d⁺ = ∑ d⁻ = |A| gives 2·|A| = n(n−1) (tournament_two_mul_arcCount) — a tournament on n vertices has exactly n(n−1)/2 = C(n,2) arcs, one per unordered pair. Restated for scores, 2·∑ d⁺(v) = n(n−1): the score sequence sums to C(n,2). Everything is kept multiplicative (2·X = …) to stay in ℕ and avoid division.",
+    "mathContext": "$2|A| = n(n-1), \\qquad 2\\sum_v d^+(v) = n(n-1) = 2\\binom{n}{2}$",
+    "significance": "key",
+    "prerequisites": ["the handshake lemma", "the tournament local identity", "Finset.sum_const", "ℕ multiplicative bookkeeping"],
+    "relatedConcepts": ["Landau's theorem", "score sequence", "binomial coefficient C(n,2)", "Erdős–Gallai-type counting"]
+  },
+  {
+    "id": "dh-averaging",
+    "proofId": "erdos-1012-oq-03-oq-02",
+    "range": { "startLine": 175, "endLine": 190 },
+    "type": "theorem",
+    "title": "Averaging / Pigeonhole: Some Vertex Beats the Average",
+    "content": "exists_outDegree_ge_average: some vertex v has n·d⁺(v) ≥ |A|, i.e. d⁺(v) is at least the average out-degree |A|/n. Take the vertex of maximum out-degree (univ.exists_max_image); then ∑_u d⁺(u) ≤ ∑_u d⁺(v) = n·d⁺(v), and the left side is |A| by the handshake lemma. This elementary averaging step is exactly what opens degree-threshold Hamiltonicity arguments (Ghouila–Houri, Moon–Moser) in the companion file.",
+    "mathContext": "$\\exists v,\\ n \\cdot d^+(v) \\ge |A| \\quad (\\text{i.e. } d^+(v) \\ge \\text{average})$",
+    "significance": "key",
+    "prerequisites": ["Finset.exists_max_image", "Finset.sum_le_sum", "the handshake lemma", "averaging / pigeonhole"],
+    "relatedConcepts": ["pigeonhole principle", "max ≥ average", "degree-threshold Hamiltonicity", "Ghouila–Houri theorem"]
+  }
+]

--- a/src/data/proofs/erdos-1012-oq-03-oq-02/index.ts
+++ b/src/data/proofs/erdos-1012-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1012OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1012Oq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1012Oq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1012Oq03Oq02Data: ProofData = {
+  proof: erdos1012Oq03Oq02Proof,
+  annotations: erdos1012Oq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1012-oq-03-oq-02` (The Directed Handshake Lemma and Tournament Score Sums).

## Gaps fixed
- **Missing `index.ts`** → *'proof not found'* on the live site. Added (Lean source `Erdos1012OQ03OQ02.lean`).
- **Missing `annotations.json`** — added **6 inline annotations** covering all four sections.

## Annotation coverage
Each carries `mathContext` (LaTeX), `significance`, `prerequisites`, `relatedConcepts`:
1. Digraph / degree / arc-count definitions
2. Degrees & arc count as `Finset.filter` cardinalities (the bridge to Fubini)
3. The directed handshake lemma ∑ d⁺ = |A| = ∑ d⁻ (conservation of degree)
4. Tournament local identity d⁺(v) + d⁻(v) = n − 1
5. Landau's score-sum identity 2·∑ d⁺ = n(n−1) = 2·C(n,2)
6. Averaging / pigeonhole: some vertex beats the average (opens degree-threshold Hamiltonicity)

overview, sections, crossReferences were already well-formed and are intact. Axiom status verified accurate: `verified`, 0 axioms, 0 sorries. `pnpm build` passes.