### PR TITLE
research(fourier-series-oq-04-wip-01-oq-01): orthonormality of the n-torus Fourier characters [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2848,6 +2848,7 @@ import Proofs.FourierSeriesOQ02OQ04
 import Proofs.FourierSeriesOQ03
 import Proofs.FourierSeriesOQ04
 import Proofs.FourierSeriesOQ04WIP01
+import Proofs.FourierSeriesOQ04WIP01OQ01
 import Proofs.FourierSeriesOQ04OQ01
 import Proofs.FourthRoot2Degree4
 import Proofs.FriendshipTheorem

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3448,6 +3448,7 @@ import Proofs.ProbMethodExpectationOQ01
 import Proofs.ProbMethodLovaszLocalOQ02
 import Proofs.ProbMethodSecondMoment
 import Proofs.ProbMethodSecondMomentOQ01
+import Proofs.ProbMethodSecondMomentOQ01OQ01
 import Proofs.ProbMethodSecondMomentOQ02
 import Proofs.ProductOfSegmentsOfChords
 import Proofs.ProductOfSegmentsOfChordsConverse

--- a/proofs/Proofs/FourierSeriesOQ04WIP01OQ01.lean
+++ b/proofs/Proofs/FourierSeriesOQ04WIP01OQ01.lean
@@ -1,0 +1,108 @@
+/-
+# Orthonormality of the n-dimensional Fourier characters on the torus
+
+Research: fourier-series-oq-04-wip-01-oq-01
+Parent:   fourier-series-oq-04-wip-01 (the genuine multi-dimensional Fourier coefficient)
+
+The parent built the `n`-dimensional Fourier character
+`e_k(x) = ∏ᵢ fourier (kᵢ) (xᵢ)` on the torus `Tⁿ = (ℝ/ℤ)ⁿ = Fin n → AddCircle 1`
+and the genuine Fourier coefficient `f̂(k) = ∫_{Tⁿ} f(x)·conj(e_k(x))`, proving the
+*algebraic* facts (the character is a unimodular homomorphism `(ℤⁿ,+) → (ℂ,×)`).
+
+What was missing — and what the parent's open question asks for as the heart of any
+Parseval/Plancherel statement — is the **orthonormality** of these characters with
+respect to the `L²(Tⁿ)` inner product:
+
+  `∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}`   (`torusChar_orthonormal`).
+
+This is the genuinely multi-dimensional analytic fact. It is proved by reducing to
+Mathlib's one-dimensional orthonormality (`orthonormal_fourier`, the orthonormal
+basis `fourier n` of `L²(AddCircle 1)`) along **two** bridges:
+
+* **Fubini / product measure** (`MeasureTheory.integral_fintype_prod_volume_eq_prod`):
+  the integral of the tensor product `∏ᵢ gᵢ(xᵢ)` over the product torus factors as
+  the product `∏ᵢ ∫ gᵢ` of one-dimensional integrals.
+* **The 1-D orthogonality relation** (`char1d_integral`): the concrete-integral form
+  `∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b}`, extracted from Mathlib's
+  `orthonormal_fourier` via `ContinuousMap.inner_toLp` (and `volume = haarAddCircle`
+  on the unit circle, since `T = 1`).
+
+The product of one-dimensional Kronecker deltas `∏ᵢ δ_{jᵢ,kᵢ}` collapses to the
+multi-index delta `δ_{j,k}` (a factor vanishes as soon as two coordinates differ).
+
+This is the orthonormality core of Parseval; the full Plancherel identity
+`∑_{k∈ℤⁿ} |f̂(k)|² = ∫_{Tⁿ} |f|²` additionally requires *completeness* of the
+character system on `Tⁿ` (a tensor-product Hilbert-basis construction not yet in
+Mathlib), recorded as the follow-up open question.
+-/
+import Mathlib
+import Proofs.FourierSeriesOQ04WIP01
+
+namespace FourierSeriesOQ04WIP01OQ01
+
+open FourierSeriesOQ04WIP01 MeasureTheory Complex Finset AddCircle
+open scoped Real
+open ComplexConjugate
+
+/-- **One-dimensional orthogonality, concrete-integral form.**
+`∫_{AddCircle 1} fourier a (x) · conj(fourier b (x)) dx = δ_{a,b}`.
+
+This is the content of Mathlib's `orthonormal_fourier` (the monomials `fourier n`
+form an orthonormal family in `L²`) made explicit as an integral against `volume`
+(which equals the Haar probability measure `haarAddCircle` on the unit circle, as
+`T = 1`), via `ContinuousMap.inner_toLp`. -/
+theorem char1d_integral (a b : ℤ) :
+    ∫ x : AddCircle (1 : ℝ), fourier a x * conj (fourier b x) = if a = b then 1 else 0 := by
+  haveI : Fact (0 < (1 : ℝ)) := ⟨one_pos⟩
+  have hvol : (volume : Measure (AddCircle (1 : ℝ))) = haarAddCircle := by
+    rw [volume_eq_smul_haarAddCircle]; simp
+  have ho := (orthonormal_iff_ite.mp (orthonormal_fourier (T := (1 : ℝ)))) b a
+  rw [ContinuousMap.inner_toLp] at ho
+  -- ho : ∫ x, fourier a x * conj (fourier b x) ∂haarAddCircle = if b = a then 1 else 0
+  rw [hvol, ho]
+  by_cases h : a = b
+  · simp [h]
+  · simp [h, Ne.symm h]
+
+/-- **Orthonormality of the n-dimensional Fourier characters.**
+`∫_{Tⁿ} e_j(x) · conj(e_k(x)) dx = δ_{j,k}`, where `e_k = torusChar k` and the integral
+is over the product (Haar = `volume`) measure on `Tⁿ = Fin n → AddCircle 1`.
+
+The tensor character splits the integrand into a product over coordinates; Fubini
+factors the integral into one-dimensional integrals, each evaluated by
+`char1d_integral`; the resulting product of Kronecker deltas collapses to the
+multi-index delta. -/
+theorem torusChar_orthonormal {n : ℕ} (j k : MultiIndex n) :
+    ∫ x : Torus n, torusChar j x * conj (torusChar k x) = if j = k then 1 else 0 := by
+  -- pointwise: the integrand is a product over coordinates
+  have hpt : ∀ x : Torus n, torusChar j x * conj (torusChar k x)
+      = ∏ i, fourier (j i) (x i) * conj (fourier (k i) (x i)) := by
+    intro x
+    unfold torusChar
+    rw [map_prod, ← Finset.prod_mul_distrib]
+  simp_rw [hpt]
+  -- Fubini: integral of a tensor product factors
+  rw [integral_fintype_prod_volume_eq_prod
+        (fun i (x : AddCircle (1 : ℝ)) => fourier (j i) x * conj (fourier (k i) x))]
+  -- each factor is a 1-D orthogonality relation
+  rw [show (∏ i, ∫ x : AddCircle (1 : ℝ), fourier (j i) x * conj (fourier (k i) x))
+        = ∏ i, (if j i = k i then (1 : ℂ) else 0) from
+      Finset.prod_congr rfl (fun i _ => char1d_integral (j i) (k i))]
+  -- product of coordinate-wise deltas is the multi-index delta
+  by_cases hjk : j = k
+  · subst hjk; simp
+  · rw [if_neg hjk]
+    obtain ⟨i, hi⟩ := Function.ne_iff.mp hjk
+    exact Finset.prod_eq_zero (Finset.mem_univ i) (if_neg hi)
+
+/-- **Restated as the Fourier coefficient of a character.** The `j`-th Fourier
+coefficient of the character `e_k` is `δ_{j,k}`: `fourierCoeffND (torusChar k) j = δ_{j,k}`.
+This is the orthonormality relation phrased through the parent's coefficient
+`fourierCoeffND`, the precise sense in which the characters are "an orthonormal system
+read off by the Fourier transform". -/
+theorem fourierCoeffND_torusChar {n : ℕ} (j k : MultiIndex n) :
+    fourierCoeffND (torusChar k) j = if k = j then 1 else 0 := by
+  unfold fourierCoeffND
+  rw [torusChar_orthonormal k j]
+
+end FourierSeriesOQ04WIP01OQ01

--- a/proofs/Proofs/ProbMethodSecondMomentOQ01OQ01.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ01OQ01.lean
@@ -1,0 +1,159 @@
+/-
+  Quantitative Paley–Zygmund Inequality in the MeasureTheory.Lp Setting
+
+  This file recasts the quantitative Paley–Zygmund inequality (proved over a
+  finite Finset model in `ProbMethodSecondMomentOQ01.lean`) into Mathlib's
+  native measure-theoretic framework, over a genuine probability space and
+  Bochner integrals.
+
+  For a nonnegative random variable `X ∈ L²(μ)` on a probability space and a
+  threshold `0 ≤ θ ≤ 1`, the probability that `X` exceeds the fraction `θ` of
+  its mean is bounded below:
+
+      μ({X > θ · 𝔼X}) · 𝔼[X²]  ≥  (1 - θ)² · (𝔼X)².
+
+  Equivalently, when `𝔼[X²] > 0`,
+
+      μ({X > θ · 𝔼X})  ≥  (1 - θ)² · (𝔼X)² / 𝔼[X²].
+
+  The proof follows the classical second-moment argument:
+    * split  𝔼X = ∫_A X + ∫_{Aᶜ} X  with  A = {X > θ 𝔼X};
+    * on `Aᶜ` we have `X ≤ θ 𝔼X`, so `∫_{Aᶜ} X ≤ θ 𝔼X`, giving `∫_A X ≥ (1-θ)𝔼X`;
+    * Cauchy–Schwarz: `(∫_A X)² ≤ 𝔼[X²] · μ(A)`.
+
+  Combining yields the bound.  The core integral Cauchy–Schwarz step is packaged
+  as `sq_integral_mul_le`, derived from Mathlib's Hölder inequality for the
+  conjugate pair `(2, 2)`.
+
+  Paley–Zygmund is not currently in Mathlib; this provides a measure-theoretic
+  formalization reusing only standard `MeasureTheory` / `ProbabilityTheory` API.
+-/
+import Mathlib
+
+set_option linter.unusedVariables false
+
+open MeasureTheory
+open scoped ENNReal NNReal
+
+namespace ProbMethod.SecondMoment.MeasureTheoretic
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-- **Integral Cauchy–Schwarz (squared form).**  For nonnegative `L²` functions
+`f, g`, the square of the integral of their product is bounded by the product of
+their second moments:
+
+    (∫ f · g)²  ≤  (∫ f²) · (∫ g²).
+
+This is the special case `p = q = 2` of Hölder's inequality, squared. -/
+theorem sq_integral_mul_le {f g : Ω → ℝ} (hf : MemLp f 2 μ) (hg : MemLp g 2 μ)
+    (hfn : 0 ≤ᵐ[μ] f) (hgn : 0 ≤ᵐ[μ] g) :
+    (∫ a, f a * g a ∂μ) ^ 2 ≤ (∫ a, f a ^ 2 ∂μ) * (∫ a, g a ^ 2 ∂μ) := by
+  have hf' : MemLp f (ENNReal.ofReal 2) μ := by rw [ENNReal.ofReal_ofNat]; exact hf
+  have hg' : MemLp g (ENNReal.ofReal 2) μ := by rw [ENNReal.ofReal_ofNat]; exact hg
+  have hcs := integral_mul_le_Lp_mul_Lq_of_nonneg Real.HolderConjugate.two_two hfn hgn hf' hg'
+  simp only [Real.rpow_two] at hcs
+  rw [← Real.sqrt_eq_rpow, ← Real.sqrt_eq_rpow] at hcs
+  have hA : 0 ≤ ∫ a, f a ^ 2 ∂μ := integral_nonneg fun a => sq_nonneg _
+  have hB : 0 ≤ ∫ a, g a ^ 2 ∂μ := integral_nonneg fun a => sq_nonneg _
+  have hfg : 0 ≤ ∫ a, f a * g a ∂μ :=
+    integral_nonneg_of_ae (by filter_upwards [hfn, hgn] with a ha hb using mul_nonneg ha hb)
+  calc (∫ a, f a * g a ∂μ) ^ 2
+      ≤ (Real.sqrt (∫ a, f a ^ 2 ∂μ) * Real.sqrt (∫ a, g a ^ 2 ∂μ)) ^ 2 :=
+        pow_le_pow_left₀ hfg hcs 2
+    _ = (∫ a, f a ^ 2 ∂μ) * (∫ a, g a ^ 2 ∂μ) := by
+        rw [mul_pow, Real.sq_sqrt hA, Real.sq_sqrt hB]
+
+/-- **Quantitative Paley–Zygmund inequality (measure-theoretic form).**
+
+For a nonnegative `X ∈ L²(μ)` on a probability space and `0 ≤ θ ≤ 1`:
+
+    (1 - θ)² · (𝔼X)²  ≤  μ({X > θ 𝔼X}) · 𝔼[X²].
+
+(Here `μ.real s = (μ s).toReal` is the real-valued measure and `∫ ω, X ω ∂μ` is
+the expectation.) -/
+theorem paley_zygmund [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) {θ : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1) :
+    (1 - θ) ^ 2 * (∫ ω, X ω ∂μ) ^ 2
+      ≤ μ.real {ω | θ * (∫ ω, X ω ∂μ) < X ω} * ∫ ω, X ω ^ 2 ∂μ := by
+  set m := ∫ ω, X ω ∂μ with hm
+  set A := {ω | θ * m < X ω} with hA_def
+  -- `A` is the preimage of an open ray, hence measurable.
+  have hA_meas : MeasurableSet A := hXm measurableSet_Ioi
+  -- Integrability facts from `X ∈ L²` on a finite measure.
+  have hXint : Integrable X μ := hX.integrable (by norm_num)
+  have hm_nonneg : 0 ≤ m := integral_nonneg_of_ae hXnn
+  -- The constant-`1` indicator of `A` lives in `L²`.
+  have hg_mem : MemLp (A.indicator (fun _ => (1 : ℝ))) 2 μ :=
+    memLp_indicator_const 2 hA_meas 1 (Or.inr (measure_ne_top μ A))
+  have hg_nn : 0 ≤ᵐ[μ] A.indicator (fun _ => (1 : ℝ)) :=
+    Filter.Eventually.of_forall fun ω => Set.indicator_nonneg (fun _ _ => zero_le_one) ω
+  -- Step 1: 𝔼X = ∫_A X + ∫_{Aᶜ} X.
+  have hsplit : (∫ ω in A, X ω ∂μ) + (∫ ω in Aᶜ, X ω ∂μ) = m :=
+    integral_add_compl hA_meas hXint
+  -- Step 2: on `Aᶜ`, `X ≤ θ 𝔼X`, so `∫_{Aᶜ} X ≤ θ 𝔼X`.
+  have hcompl_le : (∫ ω in Aᶜ, X ω ∂μ) ≤ θ * m := by
+    have hpt : ∀ ω ∈ Aᶜ, X ω ≤ θ * m := by
+      intro ω hω
+      simp only [hA_def, Set.mem_compl_iff, Set.mem_setOf_eq, not_lt] at hω
+      exact hω
+    calc (∫ ω in Aᶜ, X ω ∂μ)
+        ≤ ∫ _ in Aᶜ, θ * m ∂μ :=
+          setIntegral_mono_on hXint.integrableOn integrableOn_const hA_meas.compl hpt
+      _ = μ.real Aᶜ * (θ * m) := by rw [setIntegral_const, smul_eq_mul]
+      _ ≤ 1 * (θ * m) :=
+          mul_le_mul_of_nonneg_right measureReal_le_one (mul_nonneg hθ0 hm_nonneg)
+      _ = θ * m := one_mul _
+  -- Step 3: hence `∫_A X ≥ (1-θ) 𝔼X`.
+  have habove_ge : (1 - θ) * m ≤ ∫ ω in A, X ω ∂μ := by
+    have hrw : (∫ ω in A, X ω ∂μ) = m - ∫ ω in Aᶜ, X ω ∂μ := by linarith [hsplit]
+    have hexp : (1 - θ) * m = m - θ * m := by ring
+    rw [hrw, hexp]; linarith [hcompl_le]
+  -- Step 4: Cauchy–Schwarz `(∫_A X)² ≤ 𝔼[X²] · μ(A)`.
+  have hind : (∫ ω in A, X ω ∂μ) = ∫ ω, X ω * A.indicator (fun _ => (1 : ℝ)) ω ∂μ := by
+    rw [← integral_indicator hA_meas]
+    apply integral_congr_ae
+    filter_upwards with ω
+    by_cases hω : ω ∈ A <;> simp [Set.indicator_of_mem, hω]
+  have hsq_ind : (∫ ω, (A.indicator (fun _ => (1 : ℝ)) ω) ^ 2 ∂μ) = μ.real A := by
+    have hfun : (fun ω => (A.indicator (fun _ => (1 : ℝ)) ω) ^ 2)
+        = A.indicator (fun _ => (1 : ℝ)) := by
+      funext ω; by_cases hω : ω ∈ A <;>
+        simp [Set.indicator_of_mem, hω]
+    rw [hfun, integral_indicator hA_meas, setIntegral_const, smul_eq_mul, mul_one]
+  have hcs0 := sq_integral_mul_le hX hg_mem hXnn hg_nn
+  rw [← hind, hsq_ind] at hcs0
+  -- Step 5: combine.
+  have h1mθ_nn : 0 ≤ (1 - θ) * m := mul_nonneg (by linarith) hm_nonneg
+  have hstep : ((1 - θ) * m) ^ 2 ≤ (∫ ω in A, X ω ∂μ) ^ 2 :=
+    pow_le_pow_left₀ h1mθ_nn habove_ge 2
+  calc (1 - θ) ^ 2 * m ^ 2
+      = ((1 - θ) * m) ^ 2 := by ring
+    _ ≤ (∫ ω in A, X ω ∂μ) ^ 2 := hstep
+    _ ≤ (∫ ω, X ω ^ 2 ∂μ) * μ.real A := hcs0
+    _ = μ.real A * ∫ ω, X ω ^ 2 ∂μ := by ring
+
+/-- **Probability form.**  When the second moment is positive,
+
+    μ({X > θ 𝔼X})  ≥  (1 - θ)² · (𝔼X)² / 𝔼[X²]. -/
+theorem paley_zygmund_prob [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) {θ : ℝ} (hθ0 : 0 ≤ θ) (hθ1 : θ ≤ 1)
+    (hX2pos : 0 < ∫ ω, X ω ^ 2 ∂μ) :
+    (1 - θ) ^ 2 * (∫ ω, X ω ∂μ) ^ 2 / (∫ ω, X ω ^ 2 ∂μ)
+      ≤ μ.real {ω | θ * (∫ ω, X ω ∂μ) < X ω} := by
+  rw [div_le_iff₀ hX2pos]
+  exact paley_zygmund hXm hX hXnn hθ0 hθ1
+
+/-- **Qualitative corollary (`θ = 0`).**  The second-moment lower bound on the
+probability that `X` is strictly positive:
+
+    (𝔼X)²  ≤  μ({X > 0}) · 𝔼[X²].
+
+In particular, if `𝔼X > 0` then `μ({X > 0}) > 0`. -/
+theorem paley_zygmund_pos [IsProbabilityMeasure μ] {X : Ω → ℝ} (hXm : Measurable X)
+    (hX : MemLp X 2 μ) (hXnn : 0 ≤ᵐ[μ] X) :
+    (∫ ω, X ω ∂μ) ^ 2 ≤ μ.real {ω | 0 < X ω} * ∫ ω, X ω ^ 2 ∂μ := by
+  have h := paley_zygmund hXm hX hXnn (le_refl (0 : ℝ)) zero_le_one
+  simpa using h
+
+end ProbMethod.SecondMoment.MeasureTheoretic

--- a/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "fourier-series-oq-04-wip-01-oq-01",
+  "slug": "fourier-series-oq-04-wip-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FourierSeriesOQ04WIP01"
+    ],
+    "opens": [
+      "FourierSeriesOQ04WIP01",
+      "MeasureTheory",
+      "Complex",
+      "Finset",
+      "AddCircle",
+      "ComplexConjugate"
+    ],
+    "namespace": "FourierSeriesOQ04WIP01OQ01",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/FourierSeriesOQ04WIP01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Orthonormality of the n-Dimensional Fourier Characters on the Torus",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourierSeriesOQ04WIP01OQ01.lean",
+    "tags": [
+      "analysis",
+      "harmonic-analysis",
+      "fourier-series",
+      "n-torus",
+      "orthonormality",
+      "parseval",
+      "product-measure",
+      "fubini",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 108,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "torusChar_orthonormal: the orthonormality relation ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k} for the n-dimensional tensor Fourier characters e_k = ∏ᵢ fourier(kᵢ)(xᵢ) on the torus Tⁿ = (Fin n → AddCircle 1). This is the genuinely multi-dimensional analytic fact at the heart of Parseval/Plancherel, and is NOT in Mathlib (which has only the one-dimensional orthonormal_fourier).",
+      "char1d_integral: the concrete-integral form of one-dimensional orthogonality, ∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b}, extracted from Mathlib's abstract L²-orthonormality orthonormal_fourier via ContinuousMap.inner_toLp and the identity volume = haarAddCircle on the unit circle (T = 1). Mathlib states orthonormality only through the Lp inner product; this re-exposes it as an explicit integral usable under Fubini.",
+      "fourierCoeffND_torusChar: the orthonormality relation read through the parent's Fourier coefficient — fourierCoeffND (torusChar k) j = δ_{k,j}, i.e. the Fourier transform of a character is the Kronecker delta at that character.",
+      "The Fubini bridge: the proof factors the torus integral of the tensor product ∏ᵢ gᵢ(xᵢ) into ∏ᵢ ∫ gᵢ via MeasureTheory.integral_fintype_prod_volume_eq_prod, then collapses the resulting product of coordinate-wise Kronecker deltas ∏ᵢ δ_{jᵢ,kᵢ} to the multi-index delta δ_{j,k} (a single differing coordinate kills the product)."
+    ],
+    "prerequisites": [
+      "The parent's tensor character torusChar k x = ∏ᵢ fourier (kᵢ) (xᵢ) and coefficient fourierCoeffND (Proofs.FourierSeriesOQ04WIP01)",
+      "Mathlib's one-dimensional orthonormality orthonormal_fourier : Orthonormal ℂ (fourierLp 2) and ContinuousMap.inner_toLp (the L² inner product as an integral)",
+      "MeasureTheory.integral_fintype_prod_volume_eq_prod (Fubini for product measures on a finite-index Pi type)",
+      "AddCircle.volume_eq_smul_haarAddCircle and IsProbabilityMeasure haarAddCircle (volume = Haar on the unit circle since T = 1)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "orthonormal_fourier",
+        "description": "The monomials fourier n form an orthonormal family in L²(AddCircle T); the one-dimensional orthonormality from which the concrete 1-D integral relation is extracted.",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      },
+      {
+        "theorem": "ContinuousMap.inner_toLp",
+        "description": "For continuous functions on a compact finite-measure space, ⟪toLp f, toLp g⟫ = ∫ g·conj(f); the bridge turning the abstract L² inner product of orthonormal_fourier into the explicit integral ∫ fourier a · conj(fourier b).",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      },
+      {
+        "theorem": "MeasureTheory.integral_fintype_prod_volume_eq_prod",
+        "description": "Fubini's theorem for the product (volume) measure on a finite-index Pi type: ∫ x, ∏ᵢ fᵢ(xᵢ) = ∏ᵢ ∫ fᵢ. Factors the torus integral into one-dimensional integrals.",
+        "module": "Mathlib.MeasureTheory.Integral.Pi"
+      },
+      {
+        "theorem": "AddCircle.volume_eq_smul_haarAddCircle",
+        "description": "volume = ENNReal.ofReal T • haarAddCircle on AddCircle T; for T = 1 this gives volume = haarAddCircle, letting the orthonormal_fourier computation (stated for haarAddCircle) apply to the volume-based torus integral.",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The characters e_k(x) = e^{2πi k·x}, k ∈ ℤⁿ, form the orthonormal basis underlying Fourier analysis on the n-torus Tⁿ = (ℝ/ℤ)ⁿ, and their orthonormality ∫_{Tⁿ} e_j conj(e_k) = δ_{j,k} is the identity that makes the Fourier coefficients f̂(k) = ⟨f, e_k⟩ behave like coordinates: it is the orthonormality half of the Parseval/Plancherel theorem ∑_k |f̂(k)|² = ∫ |f|². Mathlib formalises the one-dimensional theory completely — the monomials fourier n are an orthonormal Hilbert basis of L²(AddCircle T) — but has no multi-dimensional (tensor-product) version. The parent entry built the genuine n-dimensional character and Fourier coefficient as honest definitions (no placeholders); this entry supplies their orthonormality, the first genuinely multi-dimensional analytic theorem in the chain.",
+    "problemStatement": "Prove the orthonormality of the n-dimensional tensor Fourier characters on the torus: ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}, where e_k(x) = ∏ᵢ fourier(kᵢ)(xᵢ), using Mathlib's one-dimensional orthonormality of the fourierBasis and Fubini for the product measure on Tⁿ = Fin n → AddCircle 1.",
+    "proofStrategy": "First extract the concrete one-dimensional orthogonality ∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b} from Mathlib's orthonormal_fourier: orthonormal_iff_ite gives ⟪fourierLp b, fourierLp a⟫ = δ_{b,a}, ContinuousMap.inner_toLp rewrites the inner product as ∫ fourier a · conj(fourier b) ∂haarAddCircle, and volume = haarAddCircle (T = 1) converts to the volume integral. Then, for the n-dimensional statement: conj distributes over the product (map_prod) and the two products merge (Finset.prod_mul_distrib), so the integrand becomes ∏ᵢ [fourier(jᵢ)(xᵢ)·conj(fourier(kᵢ)(xᵢ))]; Fubini (integral_fintype_prod_volume_eq_prod) factors the torus integral into ∏ᵢ ∫ fourier(jᵢ)·conj(fourier(kᵢ)) = ∏ᵢ δ_{jᵢ,kᵢ}; and this product of deltas collapses to δ_{j,k} (if j = k all factors are 1; otherwise Function.ne_iff supplies a coordinate where jᵢ ≠ kᵢ, making that factor — and the product — zero).",
+    "keyInsights": [
+      "Orthonormality on the torus is a Fubini fact: the tensor structure of the character e_k = ∏ᵢ fourier(kᵢ) means the n-dimensional integral is literally the product of n one-dimensional integrals, so the multi-dimensional orthonormality reduces to Mathlib's 1-D orthonormality coordinate by coordinate — no new analytic estimate is needed, only the product-measure Fubini theorem.",
+      "Mathlib records 1-D orthonormality only abstractly (orthonormal_fourier, an Orthonormal predicate in the Lp space); to use it under Fubini one needs the explicit integral ∫ fourier a · conj(fourier b) = δ_{a,b}, which ContinuousMap.inner_toLp delivers — the inner product literally IS that integral.",
+      "On the unit circle (T = 1) the Lebesgue volume coincides with the normalised Haar probability measure (volume_eq_smul_haarAddCircle with ofReal 1 = 1), so the parent's volume-based coefficient and Mathlib's haar-based orthonormality are about the same integral.",
+      "The product of Kronecker deltas ∏ᵢ δ_{jᵢ,kᵢ} is the multi-index delta δ_{j,k}: two multi-indices agree iff they agree in every coordinate, and a single disagreement annihilates the product — the discrete shadow of the tensor structure."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Torus Character Orthonormality",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "States the open question (orthonormality of the n-dimensional characters as the heart of Parseval) and the two-bridge strategy: Fubini for the product measure plus the 1-D orthogonality relation extracted from orthonormal_fourier. Notes that full Plancherel additionally needs completeness (a tensor Hilbert-basis construction not yet in Mathlib).",
+      "mathContext": "$\\int_{T^n} e_j(x)\\,\\overline{e_k(x)}\\,dx = \\delta_{j,k}$."
+    },
+    {
+      "id": "one-dimensional",
+      "title": "One-Dimensional Orthogonality (concrete integral)",
+      "startLine": 49,
+      "endLine": 73,
+      "summary": "char1d_integral: ∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b}, extracted from orthonormal_fourier via orthonormal_iff_ite and ContinuousMap.inner_toLp, with volume = haarAddCircle on the unit circle.",
+      "mathContext": "$\\int_{\\mathbb{R}/\\mathbb{Z}} e^{2\\pi i a x}\\,e^{-2\\pi i b x}\\,dx = \\delta_{a,b}$."
+    },
+    {
+      "id": "n-dimensional",
+      "title": "n-Dimensional Orthonormality and the Fourier-Coefficient Form",
+      "startLine": 74,
+      "endLine": 108,
+      "summary": "torusChar_orthonormal: the torus orthonormality ∫_{Tⁿ} e_j conj(e_k) = δ_{j,k} via conj/product distribution, Fubini, char1d_integral, and the delta-product collapse; fourierCoeffND_torusChar: the same relation read through the parent's coefficient as fourierCoeffND (torusChar k) j = δ_{k,j}.",
+      "mathContext": "$\\prod_i \\delta_{j_i,k_i} = \\delta_{j,k}$; $\\widehat{e_k}(j) = \\delta_{k,j}$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "fourier-series-oq-04-wip-01-oq-01-oq-01",
+      "question": "Complete the Parseval/Plancherel identity ∑_{k∈ℤⁿ} |f̂(k)|² = ∫_{Tⁿ} |f|² for f ∈ L²(Tⁿ) by establishing COMPLETENESS of the tensor character system — e.g. by constructing the n-fold tensor product of Mathlib's 1-D fourierBasis as a HilbertBasis of L²(Tⁿ), of which the orthonormality proved here is the easy half.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fourier-series-oq-04-wip-01",
+      "relationship": "parent",
+      "description": "The parent built the genuine n-dimensional Fourier character torusChar and coefficient fourierCoeffND (replacing the scaffold's placeholder) and proved their algebraic homomorphism/unimodularity properties. This entry supplies the analytic orthonormality ∫ e_j conj(e_k) = δ_{j,k}, the core of Parseval, and re-expresses it through fourierCoeffND."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.Fourier.AddCircle",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the one-dimensional Fourier theory: fourier, orthonormal_fourier, fourierBasis, haarAddCircle, and volume_eq_smul_haarAddCircle."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.Pi",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_fintype_prod_volume_eq_prod, the product-measure Fubini theorem used to factor the torus integral coordinate by coordinate."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Proves the orthonormality of the n-dimensional tensor Fourier characters on the torus Tⁿ = (Fin n → AddCircle 1): ∫_{Tⁿ} e_j(x)·conj(e_k(x)) dx = δ_{j,k}, where e_k = torusChar k = ∏ᵢ fourier(kᵢ)(xᵢ). The proof extracts the concrete 1-D orthogonality ∫ fourier a · conj(fourier b) = δ_{a,b} from Mathlib's orthonormal_fourier (via ContinuousMap.inner_toLp and volume = haarAddCircle), factors the torus integral by Fubini (integral_fintype_prod_volume_eq_prod), and collapses the product of coordinate-wise Kronecker deltas to the multi-index delta. It also reads the relation through the parent's coefficient: fourierCoeffND (torusChar k) j = δ_{k,j}. 108 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The one-dimensional orthonormality, the L²-inner-product-as-integral bridge, and the product-measure Fubini theorem are all Mathlib's (hence the mathlib badge), but the n-dimensional orthonormality of the tensor characters — and its concrete-integral 1-D form usable under Fubini — are new to the gallery and not available as named Mathlib lemmas. This is the orthonormality half of Parseval on the n-torus, completing the analytic foundation begun by the parent's character/coefficient definitions; the remaining half (completeness, via a tensor Hilbert basis) is recorded as the follow-up open question.",
+    "openQuestions": [
+      "Establish completeness of the tensor character system to obtain the full Parseval/Plancherel identity ∑_{k∈ℤⁿ} |f̂(k)|² = ∫_{Tⁿ} |f|²."
+    ]
+  },
+  "description": "On the n-torus Tⁿ = (ℝ/ℤ)ⁿ the tensor Fourier characters e_k(x) = ∏ᵢ e^{2πi kᵢ xᵢ} are orthonormal: ∫_{Tⁿ} e_j conj(e_k) = δ_{j,k}. Building on the parent's genuine n-dimensional character and coefficient, this entry proves that orthonormality by extracting the concrete 1-D relation ∫ fourier a · conj(fourier b) = δ_{a,b} from Mathlib's orthonormal_fourier (via ContinuousMap.inner_toLp and volume = haarAddCircle), factoring the torus integral by Fubini, and collapsing the product of coordinate deltas to the multi-index delta. The orthonormality core of Parseval on the torus; full Plancherel awaits completeness. Verified, 0 axioms, 0 sorries."
+}

--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "prob-method-second-moment-oq-01-oq-01",
+  "title": "Quantitative Paley–Zygmund in the MeasureTheory.Lp Setting",
+  "slug": "prob-method-second-moment-oq-01-oq-01",
+  "description": "Recasts and proves the quantitative Paley–Zygmund inequality in Mathlib's measure-theoretic framework: for a nonnegative X ∈ L²(μ) on a probability space and threshold θ ∈ [0,1], μ({X > θ·𝔼X}) · 𝔼[X²] ≥ (1-θ)²·(𝔼X)². Answers the parent's open question of generalizing the finite Finset form to genuine probability spaces with Bochner integrals.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ01OQ01.lean",
+    "tags": [
+      "probability",
+      "measure-theory",
+      "second-moment-method",
+      "paley-zygmund",
+      "Lp",
+      "cauchy-schwarz"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated hypotheses (probability measure, X measurable, X ∈ L², X ≥ 0 a.e., 0 ≤ θ ≤ 1). 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
+    "originalContributions": [
+      "sq_integral_mul_le: integral Cauchy–Schwarz in squared form, (∫ f·g)² ≤ (∫ f²)(∫ g²), for nonnegative L² functions — derived from Mathlib's Hölder inequality at the conjugate pair (2,2)",
+      "paley_zygmund: measure-theoretic Paley–Zygmund, (1-θ)²(𝔼X)² ≤ μ({X > θ𝔼X})·𝔼[X²] over a probability space",
+      "paley_zygmund_prob: division/probability form, μ({X > θ𝔼X}) ≥ (1-θ)²(𝔼X)²/𝔼[X²] when 𝔼[X²] > 0",
+      "paley_zygmund_pos: θ=0 corollary, (𝔼X)² ≤ μ({X>0})·𝔼[X²] — the qualitative second moment method"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_mul_le_Lp_mul_Lq_of_nonneg",
+        "description": "Hölder's inequality for nonnegative functions α → ℝ; specialized to the conjugate pair (2,2) it is the integral Cauchy–Schwarz inequality",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "integral_add_compl",
+        "description": "Decompose an integral as the sum of the set integral over A and over its complement",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
+      },
+      {
+        "theorem": "setIntegral_mono_on",
+        "description": "Monotonicity of the set integral from a pointwise bound on the set — used to bound ∫_{Aᶜ} X by θ·𝔼X",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Set"
+      },
+      {
+        "theorem": "MemLp.integrable_sq",
+        "description": "If X ∈ L² then X² is integrable — supplies the finite second moment",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      },
+      {
+        "theorem": "memLp_indicator_const",
+        "description": "The constant-1 indicator of a finite-measure set lies in Lᵖ — used as the second argument to Cauchy–Schwarz",
+        "module": "Mathlib.MeasureTheory.Function.LpSeminorm.Basic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Paley–Zygmund inequality was proved by Raymond Paley and Antoni Zygmund in 1932 in their study of lacunary trigonometric series. It strengthens the qualitative second moment method by giving an explicit lower bound on the probability that a nonnegative random variable exceeds a fraction θ of its mean: P[X > θ𝔼X] ≥ (1-θ)²(𝔼X)²/𝔼[X²]. The gallery's parent entry (ProbMethodSecondMomentOQ01) proves the finite/discrete form over Finsets of ℚ-valued functions, which avoids measure theory but is not directly usable over continuous probability spaces. This entry closes the parent's explicit open question — 'Can this be generalized to the measure-theoretic MeasureTheory.Lp setting?' — by proving the inequality natively over a Mathlib probability space with Bochner integrals, the form actually needed for the probabilistic method over continuous spaces. Paley–Zygmund is not currently in Mathlib.",
+    "problemStatement": "For a nonnegative random variable X ∈ L²(μ) on a probability space (μ a probability measure) and a threshold 0 ≤ θ ≤ 1, prove the measure-theoretic quantitative Paley–Zygmund inequality (1-θ)²·(∫ X dμ)² ≤ μ({ω : θ·∫ X dμ < X ω})·∫ X² dμ, together with its division form and the θ=0 qualitative corollary.",
+    "text": "Proves the quantitative Paley–Zygmund inequality over a genuine probability space, recasting the gallery's finite-sum result into Mathlib's MeasureTheory/Bochner-integral framework. The proof packages the integral Cauchy–Schwarz step as a reusable squared-form lemma and reuses the classical above/below decomposition over set integrals.",
+    "proofStrategy": "Let m = 𝔼X and A = {X > θm}. (1) Split m = ∫_A X + ∫_{Aᶜ} X via integral_add_compl. (2) On Aᶜ, X ≤ θm pointwise, so ∫_{Aᶜ} X ≤ θm·μ.real(Aᶜ) ≤ θm by setIntegral_mono_on, setIntegral_const and measureReal_le_one. (3) Hence ∫_A X ≥ (1-θ)m. (4) Integral Cauchy–Schwarz against the constant-1 indicator of A gives (∫_A X)² ≤ 𝔼[X²]·μ.real(A). (5) Since 0 ≤ (1-θ)m ≤ ∫_A X, squaring and chaining the two inequalities yields (1-θ)²m² ≤ μ.real(A)·𝔼[X²].",
+    "keyInsights": [
+      "**ℝ-valued Bochner route with L² hypotheses**: Stating the result for X : Ω → ℝ with `MemLp X 2 μ`, `Measurable X` and `0 ≤ᵐ[μ] X` keeps everything inside Mathlib's standard expectation `∫ ω, X ω ∂μ` while the L² hypothesis supplies exactly the integrability needed (X integrable via MemLp.integrable, X² integrable via MemLp.integrable_sq).",
+      "**Cauchy–Schwarz as squared Hölder**: The bespoke `sq_integral_mul_le` lemma derives (∫ f·g)² ≤ (∫ f²)(∫ g²) from Mathlib's `integral_mul_le_Lp_mul_Lq_of_nonneg` at the Hölder-conjugate pair (2,2), converting the rpow `^(1/2)` factors back to `Real.sqrt` and squaring with `Real.sq_sqrt`. This isolates the only analytic ingredient in one reusable statement.",
+      "**Indicator as the second Cauchy–Schwarz argument**: Taking g = A.indicator 1 turns ∫ X·g into the set integral ∫_A X and ∫ g² into μ.real(A) (indicator is idempotent under squaring), so the abstract product inequality becomes exactly the (∫_A X)² ≤ 𝔼[X²]·μ(A) needed.",
+      "**Measurability replaces the discrete hypotheses**: Where the parent uses `hpos` and `hnn` over a Finset, the measure-theoretic form needs `Measurable X` (so the threshold set A = X⁻¹(Ioi θm) is measurable) plus a.e. nonnegativity; the probability-measure assumption gives μ.real(Aᶜ) ≤ 1 and finiteness of all measures involved.",
+      "**θ=0 recovers the qualitative method**: Specializing θ=0 collapses the bound to (𝔼X)² ≤ μ({X>0})·𝔼[X²], which forces μ({X>0}) > 0 whenever 𝔼X > 0 — the continuous-space analogue of the parent's `paley_zygmund_at_zero`."
+    ],
+    "prerequisites": [
+      "Integral Cauchy–Schwarz / Hölder inequality (integral_mul_le_Lp_mul_Lq_of_nonneg)",
+      "Bochner set integrals and set-integral decomposition (integral_add_compl, setIntegral_mono_on)",
+      "Lp membership and integrability (MemLp.integrable, MemLp.integrable_sq, memLp_indicator_const)",
+      "Quantitative Paley–Zygmund, finite form (parent entry: ProbMethodSecondMomentOQ01)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete Lean 4 formalization of the quantitative Paley–Zygmund inequality over a probability space, with 4 theorems and 0 axioms. The proof reuses the classical above/below decomposition over Bochner set integrals and packages the integral Cauchy–Schwarz step as the reusable lemma sq_integral_mul_le.",
+    "implications": "Provides the measure-theoretic form of Paley–Zygmund needed for the probabilistic method over continuous probability spaces, connecting the gallery's combinatorial second-moment results to Mathlib's MeasureTheory.Lp / ProbabilityTheory API. The squared integral Cauchy–Schwarz lemma is independently reusable.",
+    "openQuestions": [
+      "Can the a.e.-nonnegativity / measurability hypotheses be relaxed to AEStronglyMeasurable throughout?",
+      "Does an L¹–L^∞ (Hölder) variant give a one-sided tail bound under weaker moment assumptions?",
+      "Can this measure-theoretic Paley–Zygmund be contributed upstream to Mathlib?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: proves the quantitative Paley–Zygmund inequality in the finite Finset model. This entry answers its open question by recasting the result over a measure-theoretic probability space."
+    },
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "related",
+      "description": "Grandparent qualitative second moment method, recovered here as the θ=0 corollary paley_zygmund_pos."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Paley, R.E.A.C.",
+        "Zygmund, A."
+      ],
+      "title": "On some series of functions",
+      "year": "1932",
+      "venue": "Proceedings of the Cambridge Philosophical Society 26, pp. 337-357",
+      "note": "Original Paley–Zygmund inequality"
+    },
+    {
+      "authors": [
+        "Alon, N.",
+        "Spencer, J.H."
+      ],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 4: Second moment method and Paley–Zygmund inequality"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory"
+    ],
+    "namespace": "ProbMethod.SecondMoment.MeasureTheoretic",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ProbMethodSecondMomentOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **fourier-series-oq-04-wip-01**'s open question by proving the **orthonormality of the n-dimensional tensor Fourier characters** on the torus `Tⁿ = (ℝ/ℤ)ⁿ = Fin n → AddCircle 1`:

$$\int_{T^n} e_j(x)\,\overline{e_k(x)}\,dx = \delta_{j,k}, \qquad e_k(x) = \prod_i \mathrm{fourier}(k_i)(x_i).$$

This is the **orthonormality core of Parseval/Plancherel** on the torus and is **not in Mathlib**, which has only the one-dimensional `orthonormal_fourier`.

## Theorems (3, all verified / 0-axiom)

- **`char1d_integral`** — concrete 1-D orthogonality `∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b}`, extracted from Mathlib's abstract `orthonormal_fourier` via `ContinuousMap.inner_toLp` and `volume = haarAddCircle` (since `T = 1`).
- **`torusChar_orthonormal`** — the n-dimensional relation `∫_{Tⁿ} e_j·conj(e_k) = δ_{j,k}`, via conj/product distribution, Fubini (`integral_fintype_prod_volume_eq_prod`), and collapse of the product of coordinate-wise Kronecker deltas to the multi-index delta.
- **`fourierCoeffND_torusChar`** — the relation read through the parent's coefficient: `fourierCoeffND (torusChar k) j = δ_{k,j}`.

## Proof idea

The tensor structure makes orthonormality a **Fubini fact**: the n-dimensional integral of `∏ᵢ gᵢ(xᵢ)` is the product of n one-dimensional integrals, so the multi-dimensional orthonormality reduces coordinate-by-coordinate to Mathlib's 1-D orthonormality. No new analytic estimate is needed.

## Verification

- `108` lines, `3` theorems, `0` definitions (reuses the parent's `torusChar`/`fourierCoeffND`).
- `#print axioms` on all three: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom / verified**.
- Builds against the parent `Proofs.FourierSeriesOQ04WIP01`.

## Follow-up open question

Full Plancherel `∑_{k∈ℤⁿ} |f̂(k)|² = ∫_{Tⁿ} |f|²` additionally requires **completeness** of the character system (a tensor-product `HilbertBasis` construction not yet in Mathlib), of which the orthonormality proved here is the easy half. Recorded in `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)