### PR TITLE
research(hilbert-17-oq-03): verified 0-axiom homogeneous quadratic PSD=SOS

### DIFF
--- a/proofs/Proofs/Hilbert17QuadraticGram.lean
+++ b/proofs/Proofs/Hilbert17QuadraticGram.lean
@@ -21,10 +21,7 @@
   in `research/problems/hilbert-17-oq-03/knowledge.md`; this file supplies the
   algebraic heart that any such bridge will call.
 -/
-import Mathlib.Analysis.Matrix.Order
-import Mathlib.LinearAlgebra.Matrix.PosDef
-import Mathlib.Algebra.MvPolynomial.Funext
-import Mathlib.Tactic
+import Mathlib
 
 namespace Hilbert17
 
@@ -105,5 +102,225 @@ theorem posSemidef_matrixQuadratic_isSumSq {M : Matrix (Fin n) (Fin n) ℝ}
   refine Finset.sum_congr rfl (fun i _ => ?_)
   rw [Finset.mul_sum]
   exact Finset.sum_congr rfl (fun j _ => by ring)
+
+/-! ## The polynomial → matrix bridge for *homogeneous* quadratics
+
+The lemmas above take a PSD matrix and produce an SOS polynomial.  This section
+goes the other way for the genuinely interesting object: an arbitrary
+**homogeneous degree-2 polynomial** `Q`.  We read off its symmetric Gram matrix
+`quadMatrix Q`, prove `Q = ∑ i j, (quadMatrix Q) i j · Xᵢ Xⱼ`, show that PSD of
+`Q` forces `quadMatrix Q` to be a PSD matrix, and feed that to the engine above.
+The result (`homogeneous_quadratic_psd_isSumSq`) is the full
+**homogeneous case** of Hilbert's "PSD = SOS for quadratics", in any number of
+variables, with zero axioms.  (The remaining step for the *affine*
+`totalDegree = 2` axiom `quadratic_psd_is_sos_aux` is the standard
+homogenisation by one extra coordinate.) -/
+
+open MvPolynomial
+
+/-- A degree-2 exponent vector is either `Finsupp.single k 2` (a pure square) or
+    `Finsupp.single a 1 + Finsupp.single b 1` with `a ≠ b` (a genuine cross term). -/
+lemma degree_two_cases {d : Fin n →₀ ℕ} (hd : d.degree = 2) :
+    (∃ k, d = Finsupp.single k 2) ∨ (∃ a b, a ≠ b ∧ d = Finsupp.single a 1 + Finsupp.single b 1) := by
+  have hsum : ∑ i ∈ d.support, d i = 2 := by rw [← Finsupp.degree_apply]; exact hd
+  have hpos : ∀ i ∈ d.support, 1 ≤ d i := fun i hi =>
+    Nat.one_le_iff_ne_zero.mpr (Finsupp.mem_support_iff.mp hi)
+  have hcard : d.support.card ≤ 2 := by
+    calc d.support.card = ∑ _i ∈ d.support, 1 := by simp
+      _ ≤ ∑ i ∈ d.support, d i := Finset.sum_le_sum hpos
+      _ = 2 := hsum
+  have hcard0 : d.support.card ≠ 0 := by
+    intro h0
+    rw [Finset.card_eq_zero] at h0
+    rw [h0, Finset.sum_empty] at hsum
+    omega
+  interval_cases hc : d.support.card
+  · exact absurd rfl hcard0
+  · obtain ⟨k, hk⟩ := Finset.card_eq_one.mp hc
+    left; refine ⟨k, ?_⟩
+    have hdk : d k = 2 := by rw [hk, Finset.sum_singleton] at hsum; exact hsum
+    ext m
+    by_cases hm : m = k
+    · subst hm; simp [hdk]
+    · have hms : m ∉ d.support := by rw [hk]; simp [hm]
+      rw [Finsupp.notMem_support_iff.mp hms]
+      simp [Finsupp.single_apply, Ne.symm hm]
+  · obtain ⟨a, b, hab, hs⟩ := Finset.card_eq_two.mp hc
+    right; refine ⟨a, b, hab, ?_⟩
+    rw [hs, Finset.sum_pair hab] at hsum
+    have hap : 1 ≤ d a := hpos a (by rw [hs]; simp)
+    have hbp : 1 ≤ d b := hpos b (by rw [hs]; simp)
+    have hda : d a = 1 := by omega
+    have hdb : d b = 1 := by omega
+    ext m
+    by_cases hma : m = a
+    · subst hma; simp [hda, Finsupp.add_apply, Ne.symm hab]
+    by_cases hmb : m = b
+    · subst hmb; simp [hdb, Finsupp.add_apply, hab]
+    · have hms : m ∉ d.support := by rw [hs]; simp [hma, hmb]
+      rw [Finsupp.notMem_support_iff.mp hms]
+      simp [Finsupp.add_apply, Ne.symm hma, Ne.symm hmb]
+
+/-- `Finsupp.single i 1 + Finsupp.single j 1 = Finsupp.single k 2` exactly when `i = j = k`. -/
+lemma match_diag {i j k : Fin n} :
+    (Finsupp.single i 1 + Finsupp.single j 1 : Fin n →₀ ℕ) = Finsupp.single k 2 ↔ i = k ∧ j = k := by
+  constructor
+  · intro h
+    have hk := DFunLike.congr_fun h k
+    simp only [Finsupp.add_apply, Finsupp.single_apply] at hk
+    by_cases hik : i = k <;> by_cases hjk : j = k <;> simp_all
+  · rintro ⟨rfl, rfl⟩; rw [← Finsupp.single_add]
+
+/-- For `a ≠ b`, `Finsupp.single i 1 + Finsupp.single j 1 = Finsupp.single a 1 + Finsupp.single b 1` exactly when
+    `(i,j)` is `(a,b)` or `(b,a)`. -/
+lemma match_offdiag {i j a b : Fin n} (hab : a ≠ b) :
+    (Finsupp.single i 1 + Finsupp.single j 1 : Fin n →₀ ℕ) = Finsupp.single a 1 + Finsupp.single b 1 ↔
+      (i = a ∧ j = b) ∨ (i = b ∧ j = a) := by
+  constructor
+  · intro h
+    have ha : (if i = a then 1 else 0) + (if j = a then (1:ℕ) else 0) = 1 := by
+      have := DFunLike.congr_fun h a
+      simpa [Finsupp.add_apply, Finsupp.single_apply, hab, Ne.symm hab] using this
+    have hb : (if i = b then 1 else 0) + (if j = b then (1:ℕ) else 0) = 1 := by
+      have := DFunLike.congr_fun h b
+      simpa [Finsupp.add_apply, Finsupp.single_apply, hab, Ne.symm hab] using this
+    by_cases hia : i = a
+    · refine Or.inl ⟨hia, ?_⟩
+      have hib : i ≠ b := by rw [hia]; exact hab
+      rw [if_neg hib, zero_add] at hb
+      by_contra hjb; rw [if_neg hjb] at hb; simp at hb
+    · rw [if_neg hia, zero_add] at ha
+      have hja : j = a := by by_contra hja; rw [if_neg hja] at ha; simp at ha
+      refine Or.inr ⟨?_, hja⟩
+      have hjb : j ≠ b := by rw [hja]; exact hab
+      rw [if_neg hjb, add_zero] at hb
+      by_contra hib; rw [if_neg hib] at hb; simp at hb
+  · rintro (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
+    · rfl
+    · rw [add_comm]
+
+/-- Collapse the diagonal coefficient double sum: only `(k,k)` survives. -/
+lemma sum_ite_diag (f : Fin n → Fin n → ℝ) (k : Fin n) :
+    ∑ i, ∑ j, (if (Finsupp.single i 1 + Finsupp.single j 1 : Fin n →₀ ℕ) = Finsupp.single k 2 then f i j else 0)
+      = f k k := by
+  rw [← Finset.sum_product', ← Finset.sum_filter]
+  rw [show (Finset.univ ×ˢ Finset.univ).filter
+        (fun p : Fin n × Fin n => (Finsupp.single p.1 1 + Finsupp.single p.2 1 : Fin n →₀ ℕ) = Finsupp.single k 2)
+        = {(k, k)} from ?_]
+  · rw [Finset.sum_singleton]
+  · ext p
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_univ, true_and,
+      Finset.mem_singleton]
+    rw [match_diag]
+    constructor
+    · rintro ⟨h1, h2⟩; exact Prod.ext h1 h2
+    · rintro rfl; exact ⟨rfl, rfl⟩
+
+/-- Collapse the off-diagonal coefficient double sum: `(a,b)` and `(b,a)` survive. -/
+lemma sum_ite_offdiag (f : Fin n → Fin n → ℝ) {a b : Fin n} (hab : a ≠ b) :
+    ∑ i, ∑ j, (if (Finsupp.single i 1 + Finsupp.single j 1 : Fin n →₀ ℕ) = Finsupp.single a 1 + Finsupp.single b 1
+        then f i j else 0) = f a b + f b a := by
+  rw [← Finset.sum_product', ← Finset.sum_filter]
+  rw [show (Finset.univ ×ˢ Finset.univ).filter
+        (fun p : Fin n × Fin n =>
+          (Finsupp.single p.1 1 + Finsupp.single p.2 1 : Fin n →₀ ℕ) = Finsupp.single a 1 + Finsupp.single b 1)
+        = {(a, b), (b, a)} from ?_]
+  · rw [Finset.sum_pair (by simp [Prod.ext_iff, hab, Ne.symm hab])]
+  · ext p
+    simp only [Finset.mem_filter, Finset.mem_product, Finset.mem_univ, true_and,
+      Finset.mem_insert, Finset.mem_singleton]
+    rw [match_offdiag hab]
+    constructor
+    · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩)
+      · exact Or.inl (Prod.ext h1 h2)
+      · exact Or.inr (Prod.ext h1 h2)
+    · rintro (rfl | rfl)
+      · exact Or.inl ⟨rfl, rfl⟩
+      · exact Or.inr ⟨rfl, rfl⟩
+
+/-- **The symmetric Gram matrix of a quadratic polynomial.**  Diagonal entry is
+    the pure-square coefficient; off-diagonal entry is half the cross-term
+    coefficient (so the pair `(i,j),(j,i)` reconstitutes the full cross term). -/
+noncomputable def quadMatrix (Q : MvPolynomial (Fin n) ℝ) : Matrix (Fin n) (Fin n) ℝ :=
+  Matrix.of fun i j =>
+    if i = j then Q.coeff (Finsupp.single i 2)
+    else (Q.coeff (Finsupp.single i 1 + Finsupp.single j 1)) / 2
+
+@[simp] lemma quadMatrix_apply (Q : MvPolynomial (Fin n) ℝ) (i j : Fin n) :
+    quadMatrix Q i j =
+      if i = j then Q.coeff (Finsupp.single i 2)
+      else (Q.coeff (Finsupp.single i 1 + Finsupp.single j 1)) / 2 := rfl
+
+/-- `quadMatrix Q` is symmetric. -/
+lemma quadMatrix_transpose (Q : MvPolynomial (Fin n) ℝ) :
+    (quadMatrix Q)ᵀ = quadMatrix Q := by
+  ext i j
+  simp only [Matrix.transpose_apply, quadMatrix_apply]
+  by_cases h : i = j
+  · subst h; rfl
+  · rw [if_neg (Ne.symm h), if_neg h, add_comm (Finsupp.single j 1) (Finsupp.single i 1)]
+
+/-- **Representation theorem.** A homogeneous degree-2 polynomial equals the
+    quadratic form of its Gram matrix: `Q = ∑ i j, (quadMatrix Q) i j · Xᵢ Xⱼ`. -/
+lemma quad_repr (Q : MvPolynomial (Fin n) ℝ) (hhom : Q.IsHomogeneous 2) :
+    Q = ∑ i, ∑ j, C (quadMatrix Q i j) * X i * X j := by
+  ext d
+  have hR : coeff d (∑ i, ∑ j, C (quadMatrix Q i j) * X i * X j)
+      = ∑ i, ∑ j, (if (Finsupp.single i 1 + Finsupp.single j 1 : Fin n →₀ ℕ) = d
+          then quadMatrix Q i j else 0) := by
+    rw [coeff_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [coeff_sum]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    rw [mul_assoc, coeff_C_mul,
+      show (X i * X j : MvPolynomial (Fin n) ℝ) = monomial (Finsupp.single i 1 + Finsupp.single j 1) 1 from by
+        rw [← pow_one (X i), ← pow_one (X j), X_pow_eq_monomial, X_pow_eq_monomial,
+            monomial_mul, one_mul],
+      coeff_monomial]
+    split_ifs <;> simp
+  rw [hR]
+  by_cases hdeg : d.degree = 2
+  · rcases degree_two_cases hdeg with ⟨k, rfl⟩ | ⟨a, b, hab, rfl⟩
+    · rw [sum_ite_diag]; simp [quadMatrix_apply]
+    · rw [sum_ite_offdiag _ hab]
+      simp only [quadMatrix_apply, if_neg hab, if_neg (Ne.symm hab)]
+      rw [add_comm (Finsupp.single b 1) (Finsupp.single a 1)]; ring
+  · rw [hhom.coeff_eq_zero hdeg]
+    symm
+    apply Finset.sum_eq_zero; intro i _
+    apply Finset.sum_eq_zero; intro j _
+    rw [if_neg]
+    intro hcontra
+    apply hdeg
+    rw [← hcontra, map_add, Finsupp.degree_single, Finsupp.degree_single]
+
+/-- **Homogeneous Hilbert 17 for quadratics, fully verified (0 axioms).**
+
+    Every positive-semidefinite *homogeneous* real quadratic form in `n`
+    variables is an honest polynomial sum of squares of linear forms.  The
+    witnesses are the rows of `√(quadMatrix Q)`.  This is the polynomial-level
+    homogeneous case of `quadratic_psd_is_sos_aux`; only the affine
+    homogenisation step remains. -/
+theorem homogeneous_quadratic_psd_isSumSq (Q : MvPolynomial (Fin n) ℝ)
+    (hhom : Q.IsHomogeneous 2) (hpsd : ∀ x : Fin n → ℝ, 0 ≤ MvPolynomial.eval x Q) :
+    ∃ (m : ℕ) (q : Fin m → MvPolynomial (Fin n) ℝ), Q = ∑ i, q i ^ 2 := by
+  have hrepr := quad_repr Q hhom
+  have hM : (quadMatrix Q).PosSemidef := by
+    rw [Matrix.posSemidef_iff_dotProduct_mulVec]
+    refine ⟨?_, fun x => ?_⟩
+    · show (quadMatrix Q)ᴴ = quadMatrix Q
+      rw [conjTranspose_eq_transpose_of_trivial]
+      exact quadMatrix_transpose Q
+    · have hstar : (star x : Fin n → ℝ) = x := by ext i; simp
+      have heval : x ⬝ᵥ ((quadMatrix Q) *ᵥ x) = MvPolynomial.eval x Q := by
+        conv_rhs => rw [hrepr]
+        simp only [map_sum, map_mul, eval_C, eval_X, dotProduct, mulVec]
+        refine Finset.sum_congr rfl (fun i _ => ?_)
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl (fun j _ => by ring)
+      rw [hstar, heval]
+      exact hpsd x
+  obtain ⟨m, q, hq⟩ := posSemidef_matrixQuadratic_isSumSq hM
+  exact ⟨m, q, hrepr.trans hq⟩
 
 end Hilbert17

--- a/proofs/Proofs/Hilbert17SumOfSquares.lean
+++ b/proofs/Proofs/Hilbert17SumOfSquares.lean
@@ -349,13 +349,18 @@ theorem univariate_psd_is_sos (p : Polynomial ℝ) (h : IsPositiveSemidefinite p
     - Spectral theorem / Cholesky decomposition for PSD matrices
     - Matrix algebra and polynomial evaluation
 
-    PROGRESS: the *matrix-level* heart of this argument is now proved with
-    zero axioms in `Proofs.Hilbert17QuadraticGram`
-    (`Hilbert17.posSemidef_quadratic_isSumSq`): for a PSD real matrix `M`,
-    `x ⬝ᵥ (M *ᵥ x) = ∑ i, ((√M *ᵥ x) i)²`, an explicit SOS of linear forms via
-    the symmetric Gram factorization `M = (√M)ᵀ (√M)`.  What remains (the
-    un-Mathlib'd "bridge") is the polynomial coefficient-extraction
-    `Q ↦ M` for `totalDegree Q = 2` and the homogenisation/PSD transfer; see
+    PROGRESS: the entire **homogeneous** case is now proved with zero axioms in
+    `Proofs.Hilbert17QuadraticGram` (`Hilbert17.homogeneous_quadratic_psd_isSumSq`):
+    every PSD *homogeneous* degree-2 polynomial in any number of variables is a
+    genuine polynomial sum of squares of linear forms.  The chain is
+    `quad_repr` (read off the symmetric Gram matrix `quadMatrix Q` and prove
+    `Q = ∑ i j, (quadMatrix Q) i j · Xᵢ Xⱼ`), then PSD of `Q` forces
+    `quadMatrix Q` to be a PSD matrix, then the Gram engine
+    `posSemidef_quadratic_isSumSq` (`x ⬝ᵥ (M *ᵥ x) = ∑ i, ((√M *ᵥ x) i)²` via
+    `M = (√M)ᵀ (√M)`).  What remains for the *affine* `totalDegree = 2` axiom
+    below is only the standard homogenisation by one extra coordinate (lift to a
+    homogeneous quadratic in `n+1` variables, transfer PSD via a scaling limit,
+    apply the homogeneous result, set the homogenising coordinate to 1); see
     `research/problems/hilbert-17-oq-03/knowledge.md`. -/
 axiom quadratic_psd_is_sos_aux {n : ℕ} (Q : MvPolynomial (Fin n) ℝ)
     (hQ : MvPolynomial.totalDegree Q = 2)

--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -371,3 +371,72 @@ The polynomial↔matrix coefficient extraction (`Q : MvPolynomial (Fin n) ℝ`,
 `totalDegree = 2` ↦ symmetric `M`) + homogenisation/PSD transfer + reassembly
 into `IsSumOfSquaresMvPolynomial`. The Gram engine above is what that bridge
 will call. `pfister_bound_aux` still genuinely hard.
+
+## Session 2026-06-24 (researcher-1) — HOMOGENEOUS quadratic PSD=SOS PROVED (polynomial level)
+Completed the entire **homogeneous** case of `quadratic_psd_is_sos_aux` at the
+polynomial level, 0 axioms, extending `Hilbert17QuadraticGram.lean` (now 325 L).
+The prior Gram work only had the *matrix-given* form
+(`posSemidef_matrixQuadratic_isSumSq`: given a PSD matrix M, `∑ᵢⱼ C(Mᵢⱼ)XᵢXⱼ` is
+SOS). This session built the missing **polynomial → matrix bridge** for arbitrary
+homogeneous degree-2 `Q`:
+
+- `homogeneous_quadratic_psd_isSumSq` (HEADLINE): `Q.IsHomogeneous 2` ∧
+  `(∀x, 0 ≤ eval x Q)` ⟹ `∃ q, Q = ∑ qᵢ²`. Every PSD homogeneous real quadratic
+  form in n variables is a polynomial SOS of linear forms. `#print axioms` →
+  propext/Classical.choice/Quot.sound only.
+- `quad_repr`: `Q.IsHomogeneous 2 ⟹ Q = ∑ᵢⱼ C(quadMatrix Q i j)·Xᵢ·Xⱼ` where
+  `quadMatrix Q i j = if i=j then coeff(single i 2)Q else coeff(single i 1+single j 1)Q/2`
+  (symmetric Gram matrix). Proved by `MvPolynomial.ext` coeff comparison.
+- Supporting: `degree_two_cases` (a deg-2 exponent vector is `single k 2` or
+  `single a 1+single b 1`, a≠b), `match_diag`/`match_offdiag` (which (i,j) realize
+  a given deg-2 monomial), `sum_ite_diag`/`sum_ite_offdiag` (collapse the coeff
+  double sums via product+filter = singleton/pair), `quadMatrix_transpose` (symm).
+
+Assembly of the headline: `quad_repr` gives `Q = ∑ᵢⱼ C(Mᵢⱼ)XᵢXⱼ`; then
+`x ⬝ᵥ (M *ᵥ x) = eval x Q ≥ 0` ⟹ `M.PosSemidef`; then
+`posSemidef_matrixQuadratic_isSumSq` finishes. `M = quadMatrix Q`.
+
+### Why this does NOT yet discharge the parent axiom (honest)
+`quadratic_psd_is_sos_aux` is stated for **affine** `totalDegree Q = 2` (allows
+degree 1 and 0 terms), NOT homogeneous. So parent axiomCount stays at **2**
+(`quadratic_psd_is_sos_aux`, `pfister_bound_aux`). What remains is the standard
+homogenisation: lift Q to a homogeneous quadratic Q* in n+1 vars (add x₀,
+multiply the degree-1 part by x₀ and the constant by x₀²), show Q* PSD (the
+degree-2 top part must be PSD by a scaling limit; the rest is t²Q(x/t)≥0), apply
+`homogeneous_quadratic_psd_isSumSq` to Q*, then set x₀=1 (a ring hom
+`MvPolynomial (Fin (n+1)) → MvPolynomial (Fin n)`) to dehomogenise the linear
+forms into affine-linear polynomials. Estimate: 1 more focused session (the
+Fin n ↔ Fin (n+1) index juggling + the scaling-limit PSD transfer are the work).
+
+### Lean techniques / gotchas (v4.26)
+- `Matrix.PosSemidef` now quantifies over `x : n →₀ R` (Finsupp!), so its second
+  field is `x.sum fun i xi => x.sum fun j xj => star xi * M i j * xj`. Do NOT
+  `refine ⟨_, fun x => _⟩` expecting a plain vector — use
+  `rw [Matrix.posSemidef_iff_dotProduct_mulVec]` first to get the
+  `∀ x : n → R, 0 ≤ star x ⬝ᵥ (M *ᵥ x)` form.
+- `quadMatrix` MUST return `Matrix (Fin n) (Fin n) ℝ` (via `Matrix.of`), not a
+  bare `Fin n → Fin n → ℝ`, or `.PosSemidef` / `ᵀ` dot-notation fails
+  ("environment does not contain Function.PosSemidef"). Add a `@[simp]
+  quadMatrix_apply ... := rfl` to unfold entries.
+- In `heval`, `rw [hrepr]` rewrites EVERY `Q` including the one inside
+  `quadMatrix Q` → garbage. Use `conv_rhs => rw [hrepr]` to touch only `eval x Q`.
+- `open Matrix` + `open Finsupp` ⟹ `single` is AMBIGUOUS (Matrix.single vs
+  Finsupp.single). Either don't open Finsupp and write `Finsupp.single`, or be
+  careful. "singleton"/"single_apply" don't clash (no space after "single").
+- degree of a sum: `Finsupp.degree` is an `AddMonoidHom`, so use `map_add`
+  (the old `Finsupp.degree_add` is a deprecated alias); `Finsupp.degree_single a r = r`.
+- `import Mathlib` (not the narrow imports) needed for `Finsupp.degree` /
+  `MvPolynomial.IsHomogeneous` in this file.
+- `X i * X j = monomial (single i 1 + single j 1) 1` via
+  `← pow_one (X i), ← pow_one (X j), X_pow_eq_monomial, X_pow_eq_monomial, monomial_mul, one_mul`.
+- BUILD: docker DOWN, Aristotle DOWN (404). Verified via MAIN cache:
+  `cd <MAIN>/proofs && cp worktree-file Proofs/ && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/F.lean`.
+  CRITICAL: `cmd | grep | head; echo $PIPESTATUS` gave a FALSE PASS (empty exit);
+  use `lake env lean F > /tmp/out 2>&1; echo RC=$?` then `grep -i error`. MAIN's
+  copy of the Gram file gets fleet-wiped to the 109-line origin version
+  repeatedly — re-`cp` from worktree before every compile, trust the worktree
+  commit + the `#print axioms` from the run that actually compiled.
+
+## Still open (parent hilbert-17, 2 axioms remain)
+- `quadratic_psd_is_sos_aux` — homogeneous case DONE; only affine homogenisation left.
+- `pfister_bound_aux` — Pfister's 2ⁿ bound; genuinely deep, no short Mathlib path.


### PR DESCRIPTION
## Summary

Completes the **homogeneous** case of Hilbert's 17th "PSD = SOS for quadratic forms" at the *polynomial* level, in any number of variables, with **zero axioms**. Extends `proofs/Proofs/Hilbert17QuadraticGram.lean`.

Prior Gram work proved only the matrix-given form: given a PSD matrix `M`, the form `∑ᵢⱼ C(Mᵢⱼ)·Xᵢ·Xⱼ` is SOS. This PR adds the missing **polynomial → matrix bridge** for an arbitrary homogeneous degree-2 polynomial `Q`.

## What's new (all 0-axiom)

- `degree_two_cases` — a degree-2 exponent vector is `single k 2` (pure square) or `single a 1 + single b 1`, `a ≠ b` (cross term).
- `match_diag` / `match_offdiag` — which `(i,j)` pairs realize a given degree-2 monomial.
- `sum_ite_diag` / `sum_ite_offdiag` — collapse the coefficient double sums (product + filter = singleton / pair).
- `quadMatrix` + `quad_repr` — read off the symmetric Gram matrix and prove `Q = ∑ i j, (quadMatrix Q) i j · Xᵢ Xⱼ`.
- **`homogeneous_quadratic_psd_isSumSq`** (headline) — every PSD homogeneous real quadratic form in `n` variables is a polynomial sum of squares of linear forms.

`#print axioms homogeneous_quadratic_psd_isSumSq` ⇒ `propext / Classical.choice / Quot.sound` only.

## Honesty / scope

This does **not** discharge the parent axiom `quadratic_psd_is_sos_aux`, which is stated for the *affine* `totalDegree = 2` case (degree-1 and constant terms allowed). Parent `axiomCount` stays at **2**. What remains is the standard homogenisation by one extra coordinate (lift to a homogeneous quadratic in `n+1` vars, transfer PSD via a scaling limit, apply this result, set the homogenising coordinate to 1) — documented in `research/problems/hilbert-17-oq-03/knowledge.md`.

## Verification

Built against Mathlib cache (`lake env lean`), `RC=0`, `#print axioms` confirmed for the headline, `quad_repr`, and `degree_two_cases`. Docker and Aristotle were down this session; everything proved manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)