### PR TITLE
research(urysohns-lemma-oq-01-oq-01-oq-02-oq-02): explicit modulus of uniform convergence for the Urysohn–Tietze series [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3912,6 +3912,7 @@ import Proofs.UrysohnsLemmaOQ01
 import Proofs.UrysohnsLemmaOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ02
+import Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ02
 import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,166 @@
+import Mathlib
+import Proofs.UrysohnsLemmaOQ01OQ01OQ02
+
+/-!
+# An Explicit Modulus of Uniform Convergence for the Urysohn–Tietze Series
+
+The grandparent entry (`urysohns-lemma-oq-01-oq-01-oq-01`) builds the Tietze
+extension **by hand** as a genuinely convergent series
+
+    G  =  ∑' n, gₙ          in the Banach space  BoundedContinuousFunction X ℝ
+
+and the parent entry (`urysohns-lemma-oq-01-oq-01-oq-02`) tracks the sup-norm of
+the *partial sums* to recover the sharp norm-preserving form `‖G‖ = ‖f‖`.
+
+This entry answers the parent's second open question:
+
+> *Expose an explicit modulus of uniform convergence by bounding the tail*
+> `‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ · M`, *quantifying how fast the partial sums
+> approach the norm-preserving extension.*
+
+The partial-sum bound `partialSum_norm_le` of the parent only says each partial
+sum stays inside `[-M, M]`; it does **not** say the partial sums converge, nor
+how fast.  Here we make the rate explicit.  The mechanism is the geometric
+*tail*: writing `G − ∑_{i<n} gᵢ = ∑' i, g_{i+n}` (the tail of a summable series in
+a complete space), the majorant `‖g_{i+n}‖ ≤ (2/3)^{i+n}·(M/3)` sums to
+
+    ∑' i, (2/3)^{i+n}·(M/3) = (2/3)ⁿ · ∑' i, (2/3)ⁱ·(M/3) = (2/3)ⁿ · M.
+
+So the truncation error decays geometrically with explicit ratio `2/3`, and the
+partial sums converge **uniformly** (in sup-norm) to `G`.
+
+## Main results
+
+* `TietzeTsum.tsum_geo_tail` — the shifted geometric majorant sums to
+  `(2/3)ⁿ · M`.
+* `TietzeTsum.norm_tsum_sub_partialSum_le` — the headline tail bound
+  `‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ · M`.
+* `TietzeTsum.tendsto_partialSum` — the partial sums converge uniformly to the
+  series, with the explicit `(2/3)ⁿ·M → 0` modulus.
+* `tietze_extension_explicit_modulus` — the packaged statement: the
+  norm-preserving Tietze extension `G` is the uniform limit of the explicit
+  correction series with truncation error `≤ (2/3)ⁿ·‖f‖`.
+
+Everything is machine-checked with no `sorry`, building only on the parent's
+explicit series and never on Mathlib's `TietzeExtension` machinery.
+-/
+
+open Set Function Filter Topology
+
+namespace TietzeTsum
+
+variable {X : Type*} [TopologicalSpace X] [NormalSpace X] {s : Set X}
+  (hs : IsClosed s) (f : C(s, ℝ)) {M : ℝ} (hM : 0 ≤ M) (hf : ∀ x : s, |f x| ≤ M)
+
+/-- The shifted geometric majorant is summable: shifting the index of a summable
+series leaves it summable. -/
+lemma summable_geo_shift (n : ℕ) :
+    Summable (fun i : ℕ => (2 / 3 : ℝ) ^ (i + n) * (M / 3)) :=
+  (summable_nat_add_iff n).2 (summable_geo (M := M))
+
+/-- **The shifted geometric majorant sums to `(2/3)ⁿ · M`.**  Factoring the common
+power `(2/3)ⁿ` out of the tail `∑' i, (2/3)^{i+n}·(M/3)` reduces it to the full
+geometric sum `∑' i, (2/3)ⁱ·(M/3) = M`, scaled by `(2/3)ⁿ`. -/
+lemma tsum_geo_tail (n : ℕ) :
+    ∑' i : ℕ, (2 / 3 : ℝ) ^ (i + n) * (M / 3) = (2 / 3 : ℝ) ^ n * M := by
+  have e : ∀ i : ℕ,
+      (2 / 3 : ℝ) ^ (i + n) * (M / 3) = (2 / 3 : ℝ) ^ i * ((2 / 3 : ℝ) ^ n * (M / 3)) := by
+    intro i; rw [pow_add]; ring
+  rw [tsum_congr e, tsum_mul_right,
+    tsum_geometric_of_lt_one (by norm_num : (0:ℝ) ≤ 2 / 3) (by norm_num : (2 / 3 : ℝ) < 1),
+    show (1 - 2 / 3 : ℝ)⁻¹ = 3 by norm_num]
+  ring
+
+/-- **Explicit modulus of uniform convergence.**  The truncation error of the
+explicit Urysohn correction series decays geometrically:
+
+    ‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ · M.
+
+The tail `(∑' i, gᵢ) − ∑_{i<n} gᵢ` equals the shifted series `∑' i, g_{i+n}`
+(the series is summable in the complete space of bounded continuous functions),
+whose norm is bounded by the shifted geometric majorant `∑' i, (2/3)^{i+n}·(M/3)`,
+which sums to `(2/3)ⁿ·M` by `tsum_geo_tail`. -/
+lemma norm_tsum_sub_partialSum_le (n : ℕ) :
+    ‖(∑' i, gbcf hs f hM hf i) - ∑ i ∈ Finset.range n, gbcf hs f hM hf i‖
+      ≤ (2 / 3 : ℝ) ^ n * M := by
+  have hsum : Summable (gbcf hs f hM hf) := summable_gbcf hs f hM hf
+  -- Identify the truncation error with the shifted tail series.
+  have htail : (∑' i, gbcf hs f hM hf i) - ∑ i ∈ Finset.range n, gbcf hs f hM hf i
+      = ∑' i, gbcf hs f hM hf (i + n) := by
+    have h := Summable.sum_add_tsum_nat_add n hsum
+    rw [← h]; abel
+  -- Summability of the shifted families (in norm, and the majorant).
+  have hsum_norm_tail : Summable (fun i => ‖gbcf hs f hM hf (i + n)‖) :=
+    (summable_nat_add_iff n).2 (summable_norm_gbcf hs f hM hf)
+  rw [htail]
+  calc
+    ‖∑' i, gbcf hs f hM hf (i + n)‖
+        ≤ ∑' i, ‖gbcf hs f hM hf (i + n)‖ := norm_tsum_le_tsum_norm hsum_norm_tail
+    _ ≤ ∑' i, (2 / 3 : ℝ) ^ (i + n) * (M / 3) :=
+          hsum_norm_tail.tsum_le_tsum (fun i => gbcf_norm_le hs f hM hf (i + n))
+            (summable_geo_shift (M := M) n)
+    _ = (2 / 3 : ℝ) ^ n * M := tsum_geo_tail (M := M) n
+
+/-- **Uniform convergence of the partial sums, with explicit rate.**  The partial
+sums `∑_{i<n} gᵢ` converge to the series `∑' i, gᵢ` in sup-norm, the truncation
+error being squeezed to `0` by the geometric modulus `(2/3)ⁿ·M`. -/
+lemma tendsto_partialSum :
+    Tendsto (fun n => ∑ i ∈ Finset.range n, gbcf hs f hM hf i) atTop
+      (𝓝 (∑' i, gbcf hs f hM hf i)) := by
+  -- The geometric modulus tends to `0`.
+  have hpow : Tendsto (fun n => (2 / 3 : ℝ) ^ n * M) atTop (𝓝 0) := by
+    simpa using
+      (tendsto_pow_atTop_nhds_zero_of_lt_one (by norm_num : (0:ℝ) ≤ 2 / 3)
+        (by norm_num : (2 / 3 : ℝ) < 1)).mul_const M
+  rw [tendsto_iff_dist_tendsto_zero]
+  refine squeeze_zero (fun n => dist_nonneg) (fun n => ?_) hpow
+  rw [dist_eq_norm, norm_sub_rev]
+  exact norm_tsum_sub_partialSum_le hs f hM hf n
+
+end TietzeTsum
+
+/-- **The norm-preserving Tietze extension with an explicit convergence modulus.**
+
+For a closed set `s` in a normal space `X` and a *bounded* continuous
+`f : s →ᵇ ℝ`, the explicit Urysohn correction series `g : ℕ → (X →ᵇ ℝ)` — built
+entirely from Urysohn's lemma, with no appeal to Mathlib's `TietzeExtension`
+machinery — assembles into a bounded continuous extension `G = ∑' n, gₙ` of `f`
+that is simultaneously:
+
+* an extension: `G = f` on `s`;
+* norm-preserving: `‖G‖ = ‖f‖`;
+* the *uniform* limit of its partial sums with an **explicit geometric modulus**:
+
+    ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ · ‖f‖.
+
+The last clause quantifies exactly how fast the explicit construction converges,
+turning the parent's qualitative "partial sums stay bounded" into a sharp,
+computable error estimate. -/
+theorem tietze_extension_explicit_modulus {X : Type*} [TopologicalSpace X] [NormalSpace X]
+    {s : Set X} (hs : IsClosed s) (f : BoundedContinuousFunction s ℝ) :
+    ∃ (G : BoundedContinuousFunction X ℝ) (g : ℕ → BoundedContinuousFunction X ℝ),
+      (∀ x : s, G (x : X) = f x) ∧ ‖G‖ = ‖f‖ ∧ G = ∑' n, g n ∧
+      (∀ n, ‖G - ∑ i ∈ Finset.range n, g i‖ ≤ (2 / 3 : ℝ) ^ n * ‖f‖) := by
+  -- Specialise the parent's explicit series to the sharp bound `M = ‖f‖`.
+  have hM : (0 : ℝ) ≤ ‖f‖ := norm_nonneg f
+  have hf : ∀ x : s, |f.toContinuousMap x| ≤ ‖f‖ := by
+    intro x
+    simpa [Real.norm_eq_abs] using f.norm_coe_le_norm x
+  -- The norm-preserving extension and its identification as the explicit series.
+  obtain ⟨G, hGeq, hGtsum, hGle⟩ :=
+    tietze_extension_via_tsum hs f.toContinuousMap hM hf
+  refine ⟨G, TietzeTsum.gbcf hs f.toContinuousMap hM hf, hGeq, ?_, hGtsum, ?_⟩
+  · -- `‖G‖ = ‖f‖`: antisymmetry, exactly as in the parent's norm-preserving theorem.
+    refine le_antisymm ?_ ?_
+    · -- `‖G‖ ≤ ‖f‖`: the parent's sharp bound `|G y| ≤ ‖f‖` everywhere.
+      refine (BoundedContinuousFunction.norm_le hM).2 (fun y => ?_)
+      simpa [Real.norm_eq_abs] using hGle y
+    · -- `‖f‖ ≤ ‖G‖`: `G` extends `f`, so each `|f x| = |G x| ≤ ‖G‖`.
+      refine (BoundedContinuousFunction.norm_le (norm_nonneg G)).2 (fun x => ?_)
+      have hx : (f x : ℝ) = G (x : X) := (hGeq x).symm
+      rw [hx]
+      exact G.norm_coe_le_norm (x : X)
+  · -- Explicit modulus: the tail bound with `M = ‖f‖`.
+    intro n
+    rw [hGtsum]
+    exact TietzeTsum.norm_tsum_sub_partialSum_le hs f.toContinuousMap hM hf n

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "urysohns-lemma-oq-01-oq-01-oq-02-oq-02",
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.UrysohnsLemmaOQ01OQ01OQ02"
+    ],
+    "opens": [
+      "Set",
+      "Function",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "TietzeTsum",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "title": "An Explicit Modulus of Uniform Convergence for the Urysohn–Tietze Series",
+  "description": "Quantifies the convergence of the hand-built Tietze extension of the grandparent entry urysohns-lemma-oq-01-oq-01-oq-01, answering the parent's second open question: the truncation error of the explicit Urysohn correction series decays geometrically, ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M. The grandparent assembles the extension by hand as a convergent series G = ∑' n, gₙ in the Banach space BoundedContinuousFunction X ℝ, with each correction bounded by ‖gₙ‖ ≤ (2/3)ⁿ·(M/3); the parent urysohns-lemma-oq-01-oq-01-oq-02 tracks the partial sums to recover the sharp norm-preserving form ‖G‖ = ‖f‖ but says nothing about the rate at which the partial sums approach G. This entry supplies that rate. The mechanism is the geometric tail: because the series is summable in the complete space of bounded continuous functions, the truncation error equals the shifted tail series, G − ∑_{i<n} gᵢ = ∑' i, g_{i+n} (Summable.sum_add_tsum_nat_add). Its sup-norm is dominated by the shifted geometric majorant ∑' i, (2/3)^{i+n}·(M/3), which factors as (2/3)ⁿ·∑' i, (2/3)ⁱ·(M/3) = (2/3)ⁿ·M (tsum_geo_tail). The headline norm_tsum_sub_partialSum_le delivers ‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M, and tendsto_partialSum upgrades this to genuine uniform (sup-norm) convergence of the partial sums to G by squeezing the error to 0. The packaged theorem tietze_extension_explicit_modulus combines the parent's norm-preserving extension with this explicit modulus: a single G that is an extension of f, satisfies ‖G‖ = ‖f‖, equals the explicit series, and converges with truncation error ≤ (2/3)ⁿ·‖f‖. No part of Mathlib's TietzeExtension machinery is used.",
+  "overview": {
+    "historicalContext": "In the classical textbook derivation of the Tietze extension theorem from Urysohn's lemma (Munkres, §35), the extension is the uniform limit of partial sums of a geometric correction series whose terms shrink by the factor 2/3 at each step. The proof of *convergence* there is precisely a geometric-tail estimate: after n corrections the residual is bounded by (2/3)ⁿ·M, so the partial sums form a uniformly Cauchy sequence converging to the extension. The grandparent gallery entry urysohns-lemma-oq-01-oq-01 isolated the per-step Urysohn engine and its geometric rate; the parent entry urysohns-lemma-oq-01-oq-01-oq-01 assembled the limit explicitly as a tsum in BoundedContinuousFunction X ℝ; and urysohns-lemma-oq-01-oq-01-oq-02 sharpened the sup-bound to the norm-preserving equality ‖G‖ = ‖f‖. What remained implicit in all of these is the *rate* — the explicit modulus of uniform convergence that the textbook estimate provides. This entry makes the rate a theorem, recovering the geometric truncation bound ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M directly from the summability of the series and the geometric majorant, with no appeal to Mathlib's TietzeExtension API.",
+    "problemStatement": "Expose an explicit modulus of uniform convergence for the explicit Urysohn correction series: bound the truncation error ‖G − ∑_{i<n} gᵢ‖ of the partial sums by the geometric tail (2/3)ⁿ·M, and upgrade this to genuine sup-norm convergence of the partial sums to the extension G = ∑' n, gₙ. Package the result with the parent's norm-preserving extension so that a single G is simultaneously an extension of f, norm-preserving (‖G‖ = ‖f‖), and the uniform limit of its explicit partial sums with truncation error ≤ (2/3)ⁿ·‖f‖.",
+    "proofStrategy": "The truncation error is the tail of a summable series. Since the correction series gₙ is summable in the complete space BoundedContinuousFunction X ℝ (the parent's summable_gbcf), Summable.sum_add_tsum_nat_add gives (∑_{i<n} gᵢ) + ∑' i, g_{i+n} = ∑' i, gᵢ, hence (∑' i, gᵢ) − ∑_{i<n} gᵢ = ∑' i, g_{i+n} (rearranged with abel). The norm of this tail is bounded by ∑' i, ‖g_{i+n}‖ (norm_tsum_le_tsum_norm, using that the shifted norm series is summable via summable_nat_add_iff), then by the shifted geometric majorant ∑' i, (2/3)^{i+n}·(M/3) (Summable.tsum_le_tsum with the parent's per-term bound gbcf_norm_le). The helper tsum_geo_tail evaluates that shifted majorant: factoring (2/3)^{i+n} = (2/3)ⁱ·(2/3)ⁿ and pulling the constant out (tsum_mul_right) leaves (2/3)ⁿ·∑' i, (2/3)ⁱ·(M/3) = (2/3)ⁿ·M via tsum_geometric_of_lt_one with (1−2/3)⁻¹ = 3. This proves norm_tsum_sub_partialSum_le. For uniform convergence, tendsto_partialSum rewrites convergence as the error tending to 0 (tendsto_iff_dist_tendsto_zero), squeezes the distance ‖G − Sₙ‖ between 0 and (2/3)ⁿ·M, and uses tendsto_pow_atTop_nhds_zero_of_lt_one to send the modulus to 0. The packaged theorem tietze_extension_explicit_modulus feeds M = ‖f‖ into the parent's tietze_extension_via_tsum and reuses the parent's antisymmetry argument for ‖G‖ = ‖f‖.",
+    "keyInsights": [
+      "The truncation error is literally the tail of the series. The single identity G − ∑_{i<n} gᵢ = ∑' i, g_{i+n} (Summable.sum_add_tsum_nat_add, valid because the space of bounded continuous functions is complete) reduces the modulus question to estimating a shifted infinite sum — no new analysis, just the algebra of summable series in a Banach space.",
+      "Shifting the index pulls out the geometric factor exactly. The shifted majorant ∑' i, (2/3)^{i+n}·(M/3) factors as (2/3)ⁿ·∑' i, (2/3)ⁱ·(M/3), and the inner full sum is the same M that bounds ‖G‖. So the tail bound is (2/3)ⁿ·M: the n-th truncation error is the bound on the whole extension, scaled by the n-th power of the contraction ratio.",
+      "The geometric rate gives uniform convergence for free. Once ‖G − Sₙ‖ ≤ (2/3)ⁿ·M and (2/3)ⁿ·M → 0, a squeeze converts the qualitative summability into a quantitative, sup-norm (i.e. uniform) convergence statement tendsto_partialSum with an explicit modulus — strengthening the parent's bounded-partial-sums lemma to an actual rate of approach.",
+      "The modulus and the sharp norm bound coexist on the same G. tietze_extension_explicit_modulus exhibits one extension that is an extension of f, norm-preserving (‖G‖ = ‖f‖), and converges with truncation error ≤ (2/3)ⁿ·‖f‖. The contraction ratio 2/3 governs both the per-step decay and the global convergence speed.",
+      "Everything stays inside the hand-built construction. The tail bound uses only the parent's summable_gbcf, gbcf_norm_le and summable_geo together with generic summable-series API; Mathlib's TietzeExtension machinery is never invoked, so the entire chain Urysohn ⇒ explicit series ⇒ norm-preserving extension ⇒ explicit convergence rate is self-contained."
+    ]
+  },
+  "sections": [
+    {
+      "id": "geometric-tail",
+      "title": "The Shifted Geometric Majorant",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "summable_geo_shift records that shifting the index leaves the geometric majorant summable (summable_nat_add_iff applied to the parent's summable_geo). tsum_geo_tail evaluates the shifted majorant: factoring (2/3)^{i+n} = (2/3)ⁱ·(2/3)ⁿ and pulling the constant out with tsum_mul_right reduces it to (2/3)ⁿ·∑' i, (2/3)ⁱ·(M/3) = (2/3)ⁿ·M via tsum_geometric_of_lt_one and (1−2/3)⁻¹ = 3.",
+      "mathContext": "$\\sum_{i}(2/3)^{i+n}\\tfrac M3 = (2/3)^n\\sum_{i}(2/3)^i\\tfrac M3 = (2/3)^n M.$"
+    },
+    {
+      "id": "tail-bound",
+      "title": "The Explicit Truncation Bound",
+      "startLine": 74,
+      "endLine": 102,
+      "summary": "norm_tsum_sub_partialSum_le proves ‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M. The truncation error is identified with the shifted tail ∑' i, g_{i+n} via Summable.sum_add_tsum_nat_add (and abel), bounded by ∑' i, ‖g_{i+n}‖ (norm_tsum_le_tsum_norm), then by the shifted geometric majorant (Summable.tsum_le_tsum with gbcf_norm_le), which equals (2/3)ⁿ·M by tsum_geo_tail.",
+      "mathContext": "$\\bigl\\|G - \\textstyle\\sum_{i<n} g_i\\bigr\\| = \\bigl\\|\\sum_i g_{i+n}\\bigr\\| \\le \\sum_i (2/3)^{i+n}\\tfrac M3 = (2/3)^n M.$"
+    },
+    {
+      "id": "uniform-convergence",
+      "title": "Uniform Convergence with Explicit Rate",
+      "startLine": 104,
+      "endLine": 119,
+      "summary": "tendsto_partialSum upgrades the tail bound to genuine sup-norm convergence: the partial sums ∑_{i<n} gᵢ tend to ∑' i, gᵢ in BoundedContinuousFunction X ℝ. Convergence is rewritten as the distance tending to 0 (tendsto_iff_dist_tendsto_zero), and the distance is squeezed between 0 and (2/3)ⁿ·M, the latter tending to 0 by tendsto_pow_atTop_nhds_zero_of_lt_one.",
+      "mathContext": "$\\textstyle\\sum_{i<n} g_i \\to G$ uniformly, with error $\\le (2/3)^n M \\to 0.$"
+    },
+    {
+      "id": "packaged-modulus",
+      "title": "Norm-Preserving Extension with Modulus",
+      "startLine": 122,
+      "endLine": 166,
+      "summary": "tietze_extension_explicit_modulus packages everything for bounded continuous data f : s →ᵇ ℝ: feeding M = ‖f‖ into the parent's tietze_extension_via_tsum yields G = ∑' n, gₙ with G = f on s; the parent's antisymmetry argument gives ‖G‖ = ‖f‖; and norm_tsum_sub_partialSum_le supplies the explicit modulus ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·‖f‖.",
+      "mathContext": "$\\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\|G\\| = \\|f\\| \\ \\wedge\\ \\|G - \\textstyle\\sum_{i<n} g_i\\| \\le (2/3)^n\\|f\\|.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's second open question verbatim: the explicit Urysohn correction series converges to the Tietze extension with the geometric truncation bound ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M. The truncation error is the tail of a summable series in the complete space of bounded continuous functions, equal to the shifted series ∑' i, g_{i+n}, whose sup-norm is dominated by the shifted geometric majorant ∑' i, (2/3)^{i+n}·(M/3) = (2/3)ⁿ·M. The bound upgrades to genuine uniform convergence (tendsto_partialSum) by squeezing the error to 0, and combines with the parent's norm-preserving extension in tietze_extension_explicit_modulus, exhibiting one G that extends f, satisfies ‖G‖ = ‖f‖, and converges with truncation error ≤ (2/3)ⁿ·‖f‖. 166 lines, 5 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; all results depend only on propext / Classical.choice / Quot.sound, and none of Mathlib's TietzeExtension machinery is used.",
+    "implications": "The chain from Urysohn's lemma to the Tietze extension is now complete and fully quantitative inside the gallery: the grandparent supplies the engine and per-step rate, the parent the explicit limit and the sharp norm-preserving bound, and this entry the explicit modulus of uniform convergence. The contraction ratio 2/3 is shown to govern both the per-step residual decay and the global convergence speed, recovering the textbook geometric-tail estimate as a formal theorem independent of Mathlib.Topology.TietzeExtension. The explicit modulus is the natural input for effective/constructive variants of the extension and for transferring quantitative regularity (moduli of continuity) from the data to the extension.",
+    "openQuestions": [
+      "Is the ratio 2/3 sharp for this construction, and can a tunable Urysohn split θ ∈ (0,1) — partitioning the residual asymmetrically rather than into thirds — yield the rate (1−θ/3)ⁿ or similar, trading per-step correction amplitude against convergence speed while preserving ‖G‖ = ‖f‖?",
+      "Does the explicit series transfer a modulus of continuity, not just the sup-norm: if f is uniformly continuous (or Lipschitz) on s with a given modulus, does the geometric-tail control yield a quantitative modulus of continuity for the extension G, giving a modulus-preserving Tietze theorem from the same construction?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry. It tracks the partial sums of the explicit Urysohn series to recover the sharp norm-preserving bound ‖G‖ = ‖f‖, but does not quantify the rate of convergence. This entry supplies the missing explicit modulus ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M and upgrades it to uniform convergence, reusing the parent's tietze_extension_via_tsum, tietze_extension_norm_preserving, gbcf_norm_le and summable_geo."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent entry that builds the Tietze extension by hand as a convergent series G = ∑' n, gₙ with per-term bound ‖gₙ‖ ≤ (2/3)ⁿ·(M/3) and proves summability in the Banach space of bounded continuous functions. This entry estimates the tail of that series to expose the geometric convergence rate."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Ancestor entry isolating the one-step Urysohn approximation engine and its geometric iterate — the source of the contraction ratio 2/3 that governs the modulus proved here."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ02.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "urysohns-lemma",
+      "tietze-extension",
+      "bounded-continuous-function",
+      "banach-space",
+      "uniform-convergence",
+      "modulus-of-convergence",
+      "geometric-series",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 166,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "assumptions": "0 axioms, 0 sorries. All results (tietze_extension_explicit_modulus, TietzeTsum.norm_tsum_sub_partialSum_le, TietzeTsum.tendsto_partialSum, TietzeTsum.tsum_geo_tail, TietzeTsum.summable_geo_shift) depend only on Mathlib's standard foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Classical.choice enters through the parent's per-step Urysohn correction. The proof builds on the parent/grandparent explicit series (tietze_extension_via_tsum, tietze_extension_norm_preserving, summable_gbcf, gbcf_norm_le, summable_geo) plus generic summable-series API (Summable.sum_add_tsum_nat_add, summable_nat_add_iff, norm_tsum_le_tsum_norm, Summable.tsum_le_tsum, tsum_geometric_of_lt_one) and basic limit lemmas; it does NOT use any theorem from Mathlib.Topology.TietzeExtension.",
+    "originalContributions": [
+      "TietzeTsum.norm_tsum_sub_partialSum_le: the explicit geometric truncation bound ‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M for the hand-built Urysohn–Tietze series — the explicit modulus of uniform convergence requested by the parent's open question, obtained by identifying the truncation error with the shifted tail series and dominating it by the shifted geometric majorant",
+      "TietzeTsum.tendsto_partialSum: genuine sup-norm (uniform) convergence of the explicit partial sums to the extension, squeezed to 0 by the geometric modulus (2/3)ⁿ·M — strengthening the parent's bounded-partial-sums lemma to an actual rate of approach",
+      "TietzeTsum.tsum_geo_tail: the shifted geometric tail evaluation ∑' i, (2/3)^{i+n}·(M/3) = (2/3)ⁿ·M, the quantitative core showing the n-th truncation error equals the global bound scaled by the n-th power of the contraction ratio",
+      "tietze_extension_explicit_modulus: the packaged statement exhibiting one bounded continuous extension G of f that is simultaneously norm-preserving (‖G‖ = ‖f‖) and the uniform limit of its explicit correction series with truncation error ≤ (2/3)ⁿ·‖f‖, all with no appeal to Mathlib's TietzeExtension machinery"
+    ],
+    "prerequisites": [
+      "The parent/grandparent explicit Tietze series tietze_extension_via_tsum, its summability summable_gbcf, per-term bound gbcf_norm_le and geometric majorant summable_geo, and the norm-preserving theorem tietze_extension_norm_preserving (Proofs.UrysohnsLemmaOQ01OQ01OQ01 / OQ02)",
+      "The tail-of-a-summable-series identity in a complete normed group: Summable.sum_add_tsum_nat_add giving (∑_{i<n} f i) + ∑' i, f (i+n) = ∑' i, f i, and summable_nat_add_iff for shift-invariance of summability",
+      "Triangle inequality for infinite sums (norm_tsum_le_tsum_norm) and monotonicity of tsum (Summable.tsum_le_tsum), together with the geometric series value (tsum_geometric_of_lt_one, tsum_mul_right)",
+      "Convergence via squeeze: tendsto_iff_dist_tendsto_zero, squeeze_zero, and tendsto_pow_atTop_nhds_zero_of_lt_one for the modulus (2/3)ⁿ → 0"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Summable.sum_add_tsum_nat_add",
+        "description": "(∑ i ∈ range k, f i) + ∑' i, f (i + k) = ∑' i, f i for a summable f in a complete topological additive group; identifies the truncation error of the partial sums with the shifted tail series ∑' i, g_{i+n}.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "norm_tsum_le_tsum_norm",
+        "description": "‖∑' i, f i‖ ≤ ∑' i, ‖f i‖ when the norm series is summable; bounds the tail series by its majorant of norms.",
+        "module": "Mathlib.Analysis.Normed.Order.Lattice"
+      },
+      {
+        "theorem": "Summable.tsum_le_tsum",
+        "description": "Monotonicity of tsum: termwise ≤ between two summable series passes to their sums; bounds ∑' i, ‖g_{i+n}‖ by the shifted geometric majorant.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Order"
+      },
+      {
+        "theorem": "tsum_geometric_of_lt_one",
+        "description": "Closed form ∑' n, rⁿ = (1 − r)⁻¹ for 0 ≤ r < 1; with tsum_mul_right gives ∑' i, (2/3)ⁱ·(M/3) = M, the inner sum of the shifted tail.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one",
+        "description": "rⁿ → 0 for 0 ≤ r < 1; sends the modulus (2/3)ⁿ·M to 0, giving uniform convergence of the partial sums by a squeeze.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-02-oq-02-oq-01",
+      "question": "Is the ratio 2/3 sharp for this construction, and can a tunable Urysohn split θ ∈ (0,1) — partitioning the residual asymmetrically rather than into thirds — yield a faster geometric rate while preserving the norm-preserving equality ‖G‖ = ‖f‖?",
+      "significance": "low"
+    },
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-02-oq-02-oq-02",
+      "question": "Does the explicit series transfer a modulus of continuity, not just the sup-norm: if f is uniformly continuous or Lipschitz on s, does the geometric-tail control yield a quantitative modulus of continuity for the extension G, giving a modulus-preserving Tietze theorem from the same construction?",
+      "significance": "medium"
+    }
+  ],
+  "references": [
+    {
+      "title": "Tietze extension theorem",
+      "url": "https://en.wikipedia.org/wiki/Tietze_extension_theorem"
+    },
+    {
+      "title": "Urysohn's lemma",
+      "url": "https://en.wikipedia.org/wiki/Urysohn%27s_lemma"
+    },
+    {
+      "title": "Mathlib: infinite sums over ℕ (sum_add_tsum_nat_add, tail of a series)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Algebra/InfiniteSum/NatInt.html"
+    }
+  ],
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the second open question of `urysohns-lemma-oq-01-oq-01-oq-02`:

> *Expose an explicit modulus of uniform convergence by bounding the tail `‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M`, quantifying how fast the partial sums approach the norm-preserving extension.*

The grandparent (`urysohns-lemma-oq-01-oq-01-oq-01`) builds the Tietze extension by hand as a convergent series `G = ∑' n, gₙ` in `BoundedContinuousFunction X ℝ` with `‖gₙ‖ ≤ (2/3)ⁿ·(M/3)`; the parent recovers the sharp norm-preserving form `‖G‖ = ‖f‖` but never quantifies the **rate**. This entry supplies it.

## Results

- **`norm_tsum_sub_partialSum_le`** — the headline geometric truncation bound `‖(∑' i, gᵢ) − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M`. The truncation error is identified with the shifted tail series `∑' i, g_{i+n}` (`Summable.sum_add_tsum_nat_add`, valid in the complete space of bounded continuous functions) and dominated by the shifted geometric majorant.
- **`tsum_geo_tail`** — `∑' i, (2/3)^{i+n}·(M/3) = (2/3)ⁿ·M`: the n-th truncation error is the global bound scaled by the n-th power of the contraction ratio.
- **`tendsto_partialSum`** — genuine sup-norm (uniform) convergence of the partial sums to `G`, squeezed by the modulus `(2/3)ⁿ·M → 0`.
- **`tietze_extension_explicit_modulus`** — one extension `G` of `f` that is norm-preserving (`‖G‖ = ‖f‖`) **and** converges with explicit truncation error `≤ (2/3)ⁿ·‖f‖`.

## Verification

- 166 lines, 5 lemmas/theorems, 0 definitions, **0 sorries, 0 axioms**.
- `#print axioms` on all results: `propext / Classical.choice / Quot.sound` only (no `sorryAx`, no `Lean.ofReduceBool`).
- Builds on the parent's explicit series (`tietze_extension_via_tsum`, `gbcf_norm_le`, `summable_geo`); **no Mathlib `TietzeExtension` machinery used.**
- `./bin/lake build Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ02` completes successfully.

Generates two follow-up open questions (sharpness of the ratio 2/3 under a tunable Urysohn split; modulus-of-continuity transfer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)