### PR TITLE
Enrich double-factorial half-integer Gamma form (oq-01-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "context",
+    "title": "Two Equivalent Closed Forms for the Half-Integer Gamma",
+    "content": "The parent GammaReflectionFormulaOQ01OQ03 proves the central-binomial closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!). This file re-packages it through the odd double factorial (2n-1)‼ = 1·3·5·⋯·(2n-1), the genuinely half-integer object, giving Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. The two forms are connected by the purely combinatorial identity (2n)! = (2n-1)‼·2ⁿ·n!, which is exactly what the open question asks for. Mathlib holds the two halves of this identity — the even double factorial (2n)‼ = 2ⁿ·n! and the factorial split (n+1)! = (n+1)‼·n‼ — but never their product, nor the odd-double-factorial Gamma value; both are supplied here.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n)!\\,\\sqrt{\\pi}}{4^{n}\\,n!} = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$, bridged by $(2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$.",
+    "significance": "context",
+    "relatedConcepts": ["Gamma function", "double factorial", "central binomial coefficient", "half-integer values"],
+    "prerequisites": ["Euler Gamma function", "factorials and double factorials"]
+  },
+  {
+    "id": "ann-two-mul-factorial-eq",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 50, "endLine": 62 },
+    "type": "theorem",
+    "title": "two_mul_factorial_eq: The Integer Identity (2n)! = (2n-1)‼·2ⁿ·n!",
+    "content": "The combinatorial heart of the file. (2n)! splits as the product of its even and odd double factorials, (2n)! = (2n)‼·(2n-1)‼, via Nat.factorial_eq_mul_doubleFactorial applied at index 2k+1 (so that (2k+1)+1 = 2(k+1)); the even factor then collapses to 2^(k+1)·(k+1)! by Nat.doubleFactorial_two_mul. No induction is required — the recursion already lives inside factorial_eq_mul_doubleFactorial — so a single case split on n suffices, its only job being to expose 2(k+1)-1 = 2k+1 over ℕ's truncated subtraction (omega discharges e1). The base case n = 0 is rfl since (2·0)! = 1 = 1·1·1.",
+    "mathContext": "$(2n)! = (2n)!!\\,(2n-1)!! = 2^{n}\\,n!\\,(2n-1)!!$; the case split exposes $2(k{+}1)-1 = 2k+1$ over $\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.factorial_eq_mul_doubleFactorial", "Nat.doubleFactorial_two_mul", "even/odd double-factorial split", "omega"],
+    "prerequisites": ["factorial recursion", "double factorial", "natural-number subtraction"]
+  },
+  {
+    "id": "ann-central-eq-odd",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 64, "endLine": 77 },
+    "type": "technique",
+    "title": "central_eq_oddDoubleFactorial: Casting the Bridge to ℝ",
+    "content": "The integer identity is transported to the reals to give the rational equivalence (2n)!/(4ⁿ·n!) = (2n-1)‼/2ⁿ that the open question requests. push_cast moves two_mul_factorial_eq across the cast; the only genuinely non-formal step is supplying 4ⁿ = 2ⁿ·2ⁿ explicitly (h4), because ring treats 4ⁿ and 2ⁿ as independent atoms and will not relate them on its own. With the nonvanishing facts n! ≠ 0 (from Nat.factorial_ne_zero) and 2ⁿ ≠ 0 (positivity) in hand, field_simp clears the denominators and closes the goal.",
+    "mathContext": "$\\dfrac{(2n)!}{4^{n}\\,n!} = \\dfrac{(2n-1)!!}{2^{n}}$, using $4^{n} = 2^{n}\\cdot 2^{n}$ as the only added fact.",
+    "significance": "supporting",
+    "relatedConcepts": ["push_cast", "field_simp", "positivity", "cast of factorials"],
+    "prerequisites": ["field arithmetic", "casting ℕ to ℝ"]
+  },
+  {
+    "id": "ann-gamma-double-factorial",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "theorem",
+    "title": "gamma_nat_add_half_doubleFactorial: The Double-Factorial Gamma Value",
+    "content": "The headline result: Γ(n+1/2) = (2n-1)‼·√π/2ⁿ for every n : ℕ. The proof opens by rewriting with the parent's verified central form gamma_nat_add_half, reducing the goal to the same rational equivalence as central_eq_oddDoubleFactorial but with the √π factor carried along. The identical machinery — cast two_mul_factorial_eq, expand 4ⁿ = 2ⁿ·2ⁿ, then field_simp against the nonvanishing denominators — discharges it. This is the natural form for downstream use: the odd double factorial, not the central binomial coefficient, is what appears in Gaussian moments and n-ball volumes.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.Gamma", "odd double factorial", "Gaussian moments", "volume of the n-ball"],
+    "prerequisites": ["Gamma function", "the parent central-binomial closed form"]
+  },
+  {
+    "id": "ann-gamma-ratio",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 97, "endLine": 103 },
+    "type": "insight",
+    "title": "gamma_nat_add_half_div_sqrt_pi_doubleFactorial: The Quotient to Γ(1/2)",
+    "content": "Dividing the double-factorial form by Γ(1/2) = √π strips away the transcendental factor and leaves a purely rational ratio Γ(n+1/2)/√π = (2n-1)‼/2ⁿ. This exhibits the entire half-integer Gamma sequence, relative to its base value √π, as the odd double factorial scaled by 2⁻ⁿ — the half-integer analogue of how Γ(n+1)/Γ(1) = n! measures the integer Gamma sequence against its base value 1. With √π ≠ 0 (positivity), field_simp finishes.",
+    "mathContext": "$\\dfrac{\\Gamma(n+\\tfrac12)}{\\sqrt{\\pi}} = \\dfrac{(2n-1)!!}{2^{n}}$, the half-integer analogue of $\\Gamma(n+1)/\\Gamma(1) = n!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Γ(1/2) = √π", "rational ratio", "normalization"],
+    "prerequisites": ["Gamma function", "field arithmetic"]
+  },
+  {
+    "id": "ann-spot-checks",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 119 },
+    "type": "technique",
+    "title": "Spot Checks: Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4",
+    "content": "Two concrete evaluations confirm the general form. Specialising gamma_nat_add_half_doubleFactorial at n = 1 gives Γ(3/2) = (1)‼·√π/2 = √π/2 (since (1)‼ = 1), and at n = 2 gives Γ(5/2) = (3)‼·√π/4 = 3√π/4 (since (3)‼ = 3). In each case norm_num evaluates the double factorial and powers in the hypothesis h before exact h closes the goal — a deliberately lightweight cross-check that the abstract closed form reproduces the classically tabulated small-argument values.",
+    "mathContext": "$\\Gamma(3/2) = \\dfrac{\\sqrt{\\pi}}{2}$ (at $n=1$, $1!!=1$); $\\Gamma(5/2) = \\dfrac{3\\sqrt{\\pi}}{4}$ (at $n=2$, $3!!=3$).",
+    "significance": "technical",
+    "relatedConcepts": ["norm_num", "specialization", "tabulated Gamma values"],
+    "prerequisites": ["double factorial evaluation", "Gamma function"]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gammaReflectionFormulaOq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gammaReflectionFormulaOq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gammaReflectionFormulaOq01Oq03Oq01Data: ProofData = {
+  proof: gammaReflectionFormulaOq01Oq03Oq01Proof,
+  annotations: gammaReflectionFormulaOq01Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `gamma-reflection-formula-oq-01-oq-03-oq-01`.

**Highest-impact gap fixed:** the directory had only `meta.json` — no `index.ts`, so the page rendered as 'proof not found' on the live site despite appearing in the gallery listing. Added the Vite entry point.

**Annotations:** added `annotations.json` with 6 annotations, each carrying `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the full Lean file:
- docstring: the two equivalent half-integer closed forms and the bridge
- `two_mul_factorial_eq`: the integer identity (2n)! = (2n-1)‼·2ⁿ·n! via the even/odd double-factorial split (no induction; single case split)
- `central_eq_oddDoubleFactorial`: cast to ℝ, the 4ⁿ = 2ⁿ·2ⁿ subtlety
- `gamma_nat_add_half_doubleFactorial`: the headline Γ(n+1/2) = (2n-1)‼·√π/2ⁿ
- `gamma_nat_add_half_div_sqrt_pi_doubleFactorial`: the rational ratio to Γ(1/2)
- spot checks Γ(3/2) = √π/2, Γ(5/2) = 3√π/4

Axiom integrity: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 axioms, 0 sorries, no assumption-carrying structures). `annotations:validate` reports no errors for this entry.