### PR TITLE
research(urysohns-lemma-oq-01-oq-01-oq-01-oq-01): norm-preserving (sharp) Tietze extension ‖G‖=‖f‖ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3917,6 +3917,7 @@ import Proofs.UniformBellMultinomialOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01
 import Proofs.UrysohnsLemmaOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ01
+import Proofs.UrysohnsLemmaOQ01OQ01OQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ02
 import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,86 @@
+import Mathlib
+import Proofs.UrysohnsLemmaOQ01OQ01OQ01
+
+/-
+# The Norm-Preserving (Sharp) Tietze Extension  (urysohns-lemma-oq-01-oq-01-oq-01-oq-01)
+
+The parent entry **urysohns-lemma-oq-01-oq-01-oq-01** builds the Tietze extension of a
+bounded continuous `f` on a closed set `s ⊆ X` (`X` normal) as an explicit, absolutely
+convergent series of Urysohn corrections `G = ∑' n, gₙ`, and proves the *sup-bound*
+`|G| ≤ M` for any bound `M` with `|f| ≤ M` (`tietze_extension_via_tsum`).
+
+Its declared open question asks to **sharpen the bound to an equality**:
+
+  `‖G‖ = ‖f‖`,
+
+recovering the standard *norm-preserving* form of the Tietze theorem directly from the
+construction.  This entry settles it.
+
+## Method
+
+Two halves, each elementary once the parent's construction is in hand.
+
+* **Upper bound `‖G‖ ≤ ‖f‖`.** Instantiate the parent's free bound `M` at the *exact*
+  sup-norm `M = ‖f‖` (legitimate because `|f x| = ‖f x‖ ≤ ‖f‖` for a bounded continuous
+  `f`).  The parent then delivers `|G y| ≤ ‖f‖` for every `y`, i.e. `‖G‖ ≤ ‖f‖`.
+
+* **Lower bound `‖f‖ ≤ ‖G‖`.** This half needs *nothing* about the construction: it holds
+  for **every** extension `E` of `f` (`norm_ge_of_extends`).  Indeed for `x ∈ s` we have
+  `‖f x‖ = ‖E x‖ ≤ ‖E‖`, and taking the supremum over `s` gives `‖f‖ ≤ ‖E‖`.  So `‖f‖`
+  is a *universal lower bound* on the norm of any extension, and our `G` attains it — `G`
+  is a **norm-minimal** extension.
+
+Combining the two halves gives the sharp equality `‖G‖ = ‖f‖`.  Because the lower bound is
+universal, the result also says the parent's series construction is optimal: no continuous
+extension can have smaller sup-norm than `f` itself.
+-/
+
+open scoped BoundedContinuousFunction
+
+namespace UrysohnsLemmaOQ01OQ01OQ01OQ01
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- **Universal lower bound on extensions.** Any bounded continuous `E : X →ᵇ ℝ` that
+restricts to `f` on `s` has norm at least `‖f‖`. No normality or construction is needed —
+this is just "the sup over `X` dominates the sup over `s`". -/
+theorem norm_ge_of_extends {s : Set X} (f : BoundedContinuousFunction s ℝ)
+    (E : BoundedContinuousFunction X ℝ) (hE : ∀ x : s, E (x : X) = f x) :
+    ‖f‖ ≤ ‖E‖ := by
+  refine (BoundedContinuousFunction.norm_le (norm_nonneg E)).2 (fun x => ?_)
+  calc ‖f x‖ = ‖E (x : X)‖ := by rw [hE x]
+    _ ≤ ‖E‖ := E.norm_coe_le_norm (x : X)
+
+variable [NormalSpace X]
+
+/-- **The norm-preserving (sharp) Tietze extension.**
+
+For a closed set `s` in a normal space `X` and a bounded continuous `f : s →ᵇ ℝ`, the
+explicit-series extension `G` of the parent entry can be taken with the *same norm*:
+`‖G‖ = ‖f‖`. The upper bound comes from instantiating the parent's construction at the
+exact sup-norm `M = ‖f‖`; the lower bound is the universal `norm_ge_of_extends`. -/
+theorem tietze_norm_preserving {s : Set X} (hs : IsClosed s)
+    (f : BoundedContinuousFunction s ℝ) :
+    ∃ G : BoundedContinuousFunction X ℝ,
+      (∀ x : s, G (x : X) = f x) ∧ ‖G‖ = ‖f‖ := by
+  -- Run the parent's series construction with the *sharp* bound `M = ‖f‖`.
+  obtain ⟨G, hext, _hGeq, hbound⟩ :=
+    tietze_extension_via_tsum hs f.toContinuousMap (norm_nonneg f)
+      (fun x => by simpa [Real.norm_eq_abs] using f.norm_coe_le_norm x)
+  have hext' : ∀ x : s, G (x : X) = f x := fun x => by simpa using hext x
+  refine ⟨G, hext', le_antisymm ?_ (norm_ge_of_extends f G hext')⟩
+  -- `‖G‖ ≤ ‖f‖`: every value of `G` is bounded by `‖f‖` (the parent's `hbound`).
+  refine (BoundedContinuousFunction.norm_le (norm_nonneg f)).2 (fun y => ?_)
+  simpa [Real.norm_eq_abs] using hbound y
+
+/-- **Restatement: the construction is norm-minimal.** The norm of the parent's extension
+equals the smallest norm achievable by *any* continuous extension of `f`, namely `‖f‖`. -/
+theorem exists_minimal_norm_extension {s : Set X} (hs : IsClosed s)
+    (f : BoundedContinuousFunction s ℝ) :
+    ∃ G : BoundedContinuousFunction X ℝ,
+      (∀ x : s, G (x : X) = f x) ∧
+      ∀ E : BoundedContinuousFunction X ℝ, (∀ x : s, E (x : X) = f x) → ‖G‖ ≤ ‖E‖ := by
+  obtain ⟨G, hext, hnorm⟩ := tietze_norm_preserving hs f
+  exact ⟨G, hext, fun E hE => hnorm.le.trans (norm_ge_of_extends f E hE)⟩
+
+end UrysohnsLemmaOQ01OQ01OQ01OQ01

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,104 @@
+{
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01",
+  "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Norm-Preserving (Sharp) Tietze Extension: ‖G‖ = ‖f‖",
+  "parent": "urysohns-lemma-oq-01-oq-01-oq-01",
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "sorries": 0,
+  "description": "Sharpens the parent's sup-bound |G| ≤ M to the norm-preserving equality ‖G‖ = ‖f‖ for the explicit-series Tietze extension, and shows the construction is norm-minimal: ‖f‖ is a universal lower bound on the norm of any continuous extension.",
+  "conclusion": "For a closed set s in a normal space X and a bounded continuous f : s →ᵇ ℝ, the parent's explicit-series extension G can be taken with ‖G‖ = ‖f‖. The lower bound ‖f‖ ≤ ‖E‖ holds for every extension E (norm_ge_of_extends), so G attains the minimum possible sup-norm.",
+  "overview": "The parent entry urysohns-lemma-oq-01-oq-01-oq-01 builds the Tietze extension G = ∑' n, gₙ of a bounded continuous f on a closed set s ⊆ X (X normal) as an explicit absolutely-convergent series of Urysohn corrections, and proves the sup-bound |G| ≤ M for any bound M ≥ |f|. Its open question asks to sharpen this to the norm-preserving equality ‖G‖ = ‖f‖, the standard form of the Tietze theorem. This entry settles it in two elementary halves. (1) Upper bound: instantiate the parent's free bound M at the exact sup-norm M = ‖f‖ (legitimate since |f x| = ‖f x‖ ≤ ‖f‖); the parent then gives |G y| ≤ ‖f‖ everywhere, i.e. ‖G‖ ≤ ‖f‖. (2) Lower bound: this half needs nothing about the construction — for any extension E and any x ∈ s, ‖f x‖ = ‖E x‖ ≤ ‖E‖, so taking the sup over s gives ‖f‖ ≤ ‖E‖ (norm_ge_of_extends). Thus ‖f‖ is a universal lower bound and G attains it. Combining the halves gives ‖G‖ = ‖f‖, and the universality of the lower bound shows G is a norm-minimal extension (exists_minimal_norm_extension).",
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "question": "Quantify uniqueness: is the minimal-norm extension unique when X is e.g. a metric space, or characterize the family of all extensions attaining ‖f‖ via the slack in each Urysohn correction step?",
+      "significance": "medium"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.UrysohnsLemmaOQ01OQ01OQ01"
+    ],
+    "opens": [
+      "BoundedContinuousFunction"
+    ],
+    "namespace": "UrysohnsLemmaOQ01OQ01OQ01OQ01",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    "urysohns-lemma-oq-01-oq-01-oq-01"
+  ],
+  "references": [
+    {
+      "title": "Tietze extension theorem",
+      "url": "https://en.wikipedia.org/wiki/Tietze_extension_theorem"
+    }
+  ],
+  "sections": [
+    {
+      "title": "The universal lower bound",
+      "content": "For any bounded continuous E : X →ᵇ ℝ that restricts to f on s, the norm of E is at least ‖f‖. This is purely the statement that the supremum of |E| over all of X dominates its supremum over the subset s, which equals ‖f‖. No normality, no series, and no choice are involved — it holds for every extension whatsoever (norm_ge_of_extends)."
+    },
+    {
+      "title": "Instantiating the construction at the sharp bound",
+      "content": "Running the parent's series construction tietze_extension_via_tsum with the free bound M set to the exact sup-norm ‖f‖ yields an extension G with |G y| ≤ ‖f‖ for every y, hence ‖G‖ ≤ ‖f‖. The hypothesis |f x| ≤ ‖f‖ is just BoundedContinuousFunction.norm_coe_le_norm."
+    },
+    {
+      "title": "The sharp equality and norm-minimality",
+      "content": "Combining the upper bound ‖G‖ ≤ ‖f‖ with the universal lower bound ‖f‖ ≤ ‖G‖ gives ‖G‖ = ‖f‖ (tietze_norm_preserving). Because the lower bound applies to every extension, G simultaneously achieves the smallest sup-norm possible among all continuous extensions of f (exists_minimal_norm_extension): the parent's by-hand series is optimal."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "tietze-extension",
+      "bounded-continuous-function",
+      "sup-norm",
+      "norm-preserving",
+      "extremal",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 86,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "original",
+    "assumptions": "0 axioms, 0 sorries. All three theorems depend only on Mathlib's standard foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Classical.choice is inherited solely through the parent's series construction; norm_ge_of_extends itself uses no choice beyond the foundational set.",
+    "originalContributions": [
+      "tietze_norm_preserving: the sharp norm-preserving Tietze extension ‖G‖ = ‖f‖, obtained by instantiating the parent's free sup-bound at the exact norm ‖f‖ (upper bound) and the universal lower bound (lower bound) — the standard norm-preserving form recovered directly from the explicit series construction",
+      "norm_ge_of_extends: the universal lower bound ‖f‖ ≤ ‖E‖ for every bounded continuous extension E of f, proved from BoundedContinuousFunction.norm_le and norm_coe_le_norm with no appeal to normality, choice, or the construction",
+      "exists_minimal_norm_extension: a restatement that the parent's construction is norm-minimal — its sup-norm equals the infimum of sup-norms over all continuous extensions of f"
+    ],
+    "prerequisites": [
+      "The parent's explicit-series Tietze extension tietze_extension_via_tsum (Proofs.UrysohnsLemmaOQ01OQ01OQ01)",
+      "The sup-norm characterization BoundedContinuousFunction.norm_le : ‖f‖ ≤ C ↔ ∀ x, ‖f x‖ ≤ C (for C ≥ 0)",
+      "The pointwise bound BoundedContinuousFunction.norm_coe_le_norm : ‖f x‖ ≤ ‖f‖"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "BoundedContinuousFunction.norm_le",
+        "description": "‖f‖ ≤ C ↔ ∀ x, ‖f x‖ ≤ C for C ≥ 0; the antisymmetric pair of applications gives both the upper bound ‖G‖ ≤ ‖f‖ and the lower bound ‖f‖ ≤ ‖E‖.",
+        "module": "Mathlib.Topology.ContinuousMap.Bounded.Normed"
+      },
+      {
+        "theorem": "BoundedContinuousFunction.norm_coe_le_norm",
+        "description": "‖f x‖ ≤ ‖f‖; supplies both the |f x| ≤ ‖f‖ hypothesis for the construction and the pointwise step ‖E x‖ ≤ ‖E‖ in the universal lower bound.",
+        "module": "Mathlib.Topology.ContinuousMap.Bounded.Basic"
+      }
+    ]
+  }
+}

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/meta.json
@@ -162,7 +162,8 @@
     {
       "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01",
       "question": "Strengthen the sup-norm bound to the sharp norm-preserving equality ‖G‖ = ‖f‖ by tracking the partial-sum norms in the explicit series, recovering the standard norm-preserving Tietze form directly from the construction.",
-      "significance": "medium"
+      "significance": "medium",
+      "answeredBy": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01"
     },
     {
       "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-02",


### PR DESCRIPTION
## Summary

Answers the parent entry **urysohns-lemma-oq-01-oq-01-oq-01**'s own declared open question: sharpen the explicit-series Tietze extension's sup-bound `|G| ≤ M` to the **norm-preserving equality `‖G‖ = ‖f‖`**, recovering the standard norm-preserving form of the Tietze theorem directly from the construction.

## Mathematical content

For a closed set `s` in a normal space `X` and a bounded continuous `f : s →ᵇ ℝ`:

- **`norm_ge_of_extends`** — universal lower bound `‖f‖ ≤ ‖E‖` for *every* bounded continuous extension `E` of `f`. Pure "sup over `X` ≥ sup over `s`"; uses no normality, no choice beyond the foundational set, and nothing about the construction.
- **`tietze_norm_preserving`** — instantiate the parent's free bound `M` at the exact sup-norm `M = ‖f‖` (legitimate via `norm_coe_le_norm`) to get the upper bound `‖G‖ ≤ ‖f‖`; combine with the universal lower bound to obtain the sharp equality `‖G‖ = ‖f‖`.
- **`exists_minimal_norm_extension`** — the parent's by-hand series is **norm-minimal**: its sup-norm equals the infimum over all continuous extensions of `f`.

## Verification

- **86 lines, 3 theorems, 0 definitions, 0 sorries.**
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only — **0-axiom verified** (no `sorryAx`, no `Lean.ofReduceBool`).
- Type-checked against the parent's compiled oleans (Docker unavailable; host `lake env lean`, exit 0).

## Files

- `proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ01OQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01-oq-01/meta.json` (new gallery entry)
- `src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/meta.json` (mark open question answered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)