### PR TITLE
Enrich Fourier torus orthonormality (fourier-series-oq-04-wip-01-oq-01)

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fourier-series-oq-04-wip-01-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "Orthonormality: the analytic heart of Parseval on the torus",
+    "content": "The parent entry built the genuine n-dimensional Fourier character `e_k(x) = ∏ᵢ fourier(kᵢ)(xᵢ)` on `Tⁿ = (ℝ/ℤ)ⁿ = Fin n → AddCircle 1` and the Fourier coefficient `f̂(k) = ∫ f·conj(e_k)`, but proved only the *algebraic* facts (the character is a unimodular homomorphism `(ℤⁿ,+) → (ℂ,×)`). This entry supplies the missing *analytic* fact: the characters are orthonormal in `L²(Tⁿ)`, `∫_{Tⁿ} e_j·conj(e_k) = δ_{j,k}`. Orthonormality is the half of Parseval/Plancherel that makes Fourier coefficients behave like coordinates `f̂(k) = ⟨f, e_k⟩`. Mathlib has the complete one-dimensional theory but no tensor-product (multi-dimensional) version, so this is the first genuinely n-dimensional analytic theorem in the chain. The remaining half — completeness of the character system — is recorded as the follow-up open question.",
+    "mathContext": "$\\int_{T^n} e_j(x)\\,\\overline{e_k(x)}\\,dx = \\delta_{j,k}$, where $e_k(x)=\\prod_i e^{2\\pi i k_i x_i}$ and $\\delta_{j,k}=1$ iff $j=k$ as multi-indices.",
+    "significance": "key",
+    "relatedConcepts": ["Fourier series", "Parseval/Plancherel theorem", "orthonormal basis", "n-torus", "tensor product of characters"],
+    "prerequisites": ["L² inner product", "Fourier analysis on the circle", "product measures"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "fourier-series-oq-04-wip-01-oq-01",
+    "range": { "startLine": 41, "endLine": 45 },
+    "type": "context",
+    "title": "Namespace and the inherited parent definitions",
+    "content": "The file imports the parent module `Proofs.FourierSeriesOQ04WIP01` and opens `FourierSeriesOQ04WIP01` to reuse its definitions — `torusChar`, `fourierCoeffND`, the index type `MultiIndex n = (Fin n → ℤ)`, and the torus `Torus n = (Fin n → AddCircle 1)`. Opening `MeasureTheory`, `Complex`, `Finset`, and `AddCircle` brings the integral, conjugation, finite-product, and circle-measure APIs into scope; `ComplexConjugate` provides the `conj` notation that the orthonormality integrand depends on. No new definitions are introduced here — the file is purely three theorems building on the parent's scaffold.",
+    "mathContext": "$\\texttt{MultiIndex } n = (\\mathrm{Fin}\\,n \\to \\mathbb{Z}) = \\mathbb{Z}^n$, $\\;\\texttt{Torus } n = (\\mathrm{Fin}\\,n \\to \\mathrm{AddCircle}\\,1) = (\\mathbb{R}/\\mathbb{Z})^n$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib AddCircle", "MeasureTheory namespace", "ComplexConjugate", "Pi types as tori"],
+    "prerequisites": ["Lean namespaces and imports"]
+  },
+  {
+    "id": "ann-char1d",
+    "proofId": "fourier-series-oq-04-wip-01-oq-01",
+    "range": { "startLine": 47, "endLine": 65 },
+    "type": "technique",
+    "title": "Extracting the concrete 1-D orthogonality integral from Mathlib",
+    "content": "`char1d_integral` proves `∫_{AddCircle 1} fourier a · conj(fourier b) = δ_{a,b}`. Mathlib records 1-D orthonormality only abstractly, as the predicate `orthonormal_fourier : Orthonormal ℂ (fourierLp 2)` in the `L²` space — not as an explicit integral. The bridge is `ContinuousMap.inner_toLp`, which says the `L²` inner product of two continuous functions literally IS the integral `∫ g·conj f`. Applying `orthonormal_iff_ite` turns the abstract orthonormality into `⟪fourierLp b, fourierLp a⟫ = if b = a then 1 else 0`, then `inner_toLp` rewrites it as the desired integral against `haarAddCircle`. The final ingredient is `volume = haarAddCircle` on the unit circle (`volume_eq_smul_haarAddCircle` with `ofReal 1 = 1`), since `T = 1` makes Lebesgue volume equal to the normalized Haar probability measure — letting the parent's volume-based integral and Mathlib's Haar-based orthonormality refer to the same number.",
+    "mathContext": "$\\int_{\\mathbb{R}/\\mathbb{Z}} e^{2\\pi i a x}\\,\\overline{e^{2\\pi i b x}}\\,dx = \\int e^{2\\pi i (a-b)x}\\,dx = \\delta_{a,b}$; on $T=1$, $\\mathrm{volume} = \\mathrm{haarAddCircle}$.",
+    "significance": "key",
+    "relatedConcepts": ["orthonormal_fourier", "ContinuousMap.inner_toLp", "haarAddCircle", "L² inner product as integral", "AddCircle.volume_eq_smul_haarAddCircle"],
+    "prerequisites": ["Hilbert space inner products", "Haar measure on compact groups", "Mathlib Fourier API"]
+  },
+  {
+    "id": "ann-torus-orthonormal",
+    "proofId": "fourier-series-oq-04-wip-01-oq-01",
+    "range": { "startLine": 67, "endLine": 96 },
+    "type": "insight",
+    "title": "n-D orthonormality is a Fubini fact: tensor integral factors coordinate-by-coordinate",
+    "content": "`torusChar_orthonormal` proves `∫_{Tⁿ} e_j·conj(e_k) = δ_{j,k}`. The key structural observation is that the multi-dimensional integral needs no new analytic estimate — the tensor structure `e_k = ∏ᵢ fourier(kᵢ)` reduces it to the 1-D case in each coordinate. The proof has three moves: (1) **pointwise factorization** — `map_prod` distributes `conj` over the product and `Finset.prod_mul_distrib` merges the two products, turning the integrand into `∏ᵢ [fourier(jᵢ)(xᵢ)·conj(fourier(kᵢ)(xᵢ))]`; (2) **Fubini** — `integral_fintype_prod_volume_eq_prod` factors the torus integral of a tensor product into `∏ᵢ ∫ ...`, each factor evaluated by `char1d_integral` to `δ_{jᵢ,kᵢ}`; (3) **delta collapse** — the product of coordinate-wise Kronecker deltas `∏ᵢ δ_{jᵢ,kᵢ}` equals the multi-index delta `δ_{j,k}`: if `j = k` all factors are `1`, otherwise `Function.ne_iff` produces a coordinate `i` with `jᵢ ≠ kᵢ` and `Finset.prod_eq_zero` annihilates the whole product.",
+    "mathContext": "$\\int_{T^n}\\prod_i g_i(x_i)\\,dx = \\prod_i \\int_{T} g_i = \\prod_i \\delta_{j_i,k_i} = \\delta_{j,k}$; a single coordinate disagreement zeros the product.",
+    "significance": "key",
+    "relatedConcepts": ["Fubini's theorem", "product measure", "tensor product structure", "MeasureTheory.integral_fintype_prod_volume_eq_prod", "Finset.prod_eq_zero", "Function.ne_iff"],
+    "prerequisites": ["Fubini–Tonelli theorem", "finite products in a commutative ring", "Kronecker delta"]
+  },
+  {
+    "id": "ann-coeff-form",
+    "proofId": "fourier-series-oq-04-wip-01-oq-01",
+    "range": { "startLine": 98, "endLine": 107 },
+    "type": "insight",
+    "title": "Reading orthonormality through the Fourier coefficient",
+    "content": "`fourierCoeffND_torusChar` restates the orthonormality through the parent's coefficient: `fourierCoeffND (torusChar k) j = δ_{k,j}`. Since `fourierCoeffND f j = ∫ f·conj(e_j)` by definition, applying it to `f = torusChar k` is exactly `torusChar_orthonormal k j` after `unfold`. This is the conceptually cleanest packaging of the result: the Fourier transform of a pure character `e_k` is the Kronecker delta supported at `k` — the discrete analogue of the fact that the Fourier transform diagonalizes the character system. It is the precise sense in which the characters form 'an orthonormal system read off by the Fourier transform', and it is the form most directly usable in a future Parseval/Plancherel argument.",
+    "mathContext": "$\\widehat{e_k}(j) = \\int_{T^n} e_k\\,\\overline{e_j} = \\delta_{k,j}$ — the Fourier transform of a character is a Kronecker delta.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fourier coefficient", "Kronecker delta", "Fourier transform of a character", "Parseval identity"],
+    "prerequisites": ["definition of Fourier coefficients"]
+  }
+]

--- a/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/index.ts
+++ b/src/data/proofs/fourier-series-oq-04-wip-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourierSeriesOQ04WIP01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourierSeriesOq04Wip01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourierSeriesOq04Wip01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourierSeriesOq04Wip01Oq01Data: ProofData = {
+  proof: fourierSeriesOq04Wip01Oq01Proof,
+  annotations: fourierSeriesOq04Wip01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `fourier-series-oq-04-wip-01-oq-01` (Orthonormality of the n-Dimensional Fourier Characters on the Torus).

**Gap fixed:** the entry was missing both `index.ts` and `annotations.json`. Without `index.ts` the proof page renders 'proof not found' on the live site.

**Added:**
- `index.ts` — Vite entry point sourcing `Proofs/FourierSeriesOQ04WIP01OQ01.lean`.
- `annotations.json` — 5 annotations with full file coverage, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Header: orthonormality as the analytic heart of Parseval
  - Namespace/inherited parent definitions
  - `char1d_integral` — extracting the concrete 1-D integral from `orthonormal_fourier` via `ContinuousMap.inner_toLp`
  - `torusChar_orthonormal` — n-D orthonormality as a Fubini factorization + Kronecker-delta collapse
  - `fourierCoeffND_torusChar` — orthonormality read through the Fourier coefficient

**Verification:** `pnpm annotations:validate` reports 0 errors for this id; JSON parses; meta.json (`verified`, `mathlib` badge, 0 axioms) left unchanged and consistent with the Lean source.