### PR TITLE
research(area-of-circle-oq-07-oq-05-oq-01): general even moment of the Gaussian by IBP induction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -206,6 +206,7 @@ import Proofs.AreaOfCircleOQ07OQ02
 import Proofs.AreaOfCircleOQ07OQ03
 import Proofs.AreaOfCircleOQ07OQ04
 import Proofs.AreaOfCircleOQ07OQ05
+import Proofs.AreaOfCircleOQ07OQ05OQ01
 import Proofs.ArithmeticSeries
 import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01

--- a/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01.lean
@@ -1,0 +1,188 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation
+import Mathlib.Data.Nat.Factorial.DoubleFactorial
+import Mathlib.Tactic
+
+/-
+# The General Even Moment of the Gaussian  (area-of-circle-oq-07-oq-05-oq-01)
+
+## Open Question (area-of-circle-oq-07-oq-05-oq-01)
+"Evaluate the general even moment
+`∫_ℝ x^{2n} e^{-x²} dx = (2n-1)!!·√π / 2^n` by induction on `n`, with the
+second moment (`n = 1`) as the base case, exhibiting the double-factorial
+recursion that integration by parts generates."
+
+## Answer
+
+For every `n : ℕ`,
+
+  `∫_{-∞}^{∞} x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2^n`.
+
+The parent entry `area-of-circle-oq-07-oq-05` evaluated the second moment
+(`n = 1`, value `√π/2`) by a single integration by parts on the whole line.
+This entry lifts that one computation to **all** `n` by isolating the
+double-factorial recursion it generates:
+
+  `∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}`     (`gaussian_even_moment_recursion`)
+
+obtained by integrating `x^{2n+1} · (x e^{-x²})` by parts (with `x e^{-x²}` the
+derivative of `-½ e^{-x²}`, boundary terms killed by Gaussian decay).  Folding
+this recursion into the base value `∫ e^{-x²} = √π` and matching the
+double-factorial step `(2(n+1)-1)‼ = (2n+1)·(2n-1)‼` gives the closed form
+(`gaussian_even_moment`).
+
+As a corollary the integral equals the half-integer Gamma special value
+`Γ(n + 1/2)` (`gaussian_even_moment_eq_Gamma`): Mathlib records `Γ(n+1/2)` as a
+double-factorial expression (`Real.Gamma_nat_add_half`), and our integral hits
+exactly the same value — so the IBP-derived moment is the Gaussian integral
+representation of that Gamma value.
+
+No new axioms: every step is a routine consequence of existing Mathlib results
+(`integral_gaussian`, the integration-by-parts lemma on `(-∞,∞)`, Gaussian-decay
+`tendsto`, and the double-factorial API).
+-/
+
+open Real MeasureTheory Filter Topology Set
+open scoped Nat
+
+namespace AreaOfCircleOQ07OQ05OQ01
+
+/-- **Integrability of `x^k e^{-x²}` for every natural power `k`.**
+A power weight never beats the Gaussian decay, so each polynomial weighting of
+the Gaussian is integrable over the whole line. -/
+theorem integrable_pow_mul_gaussian (k : ℕ) :
+    Integrable (fun x : ℝ => x ^ k * Real.exp (-x ^ 2)) := by
+  have hk : (-1 : ℝ) < (k : ℝ) := by
+    have : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    linarith
+  have h := integrable_rpow_mul_exp_neg_mul_sq (b := 1) one_pos (s := (k : ℝ)) hk
+  refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+  simp only [Real.rpow_natCast, neg_one_mul]
+
+/-- **Gaussian decay of a polynomial weight.** For every power `m`, the function
+`x ↦ x^m e^{-x²}` tends to `0` at both ends of the real line, because the
+Gaussian factor decays faster than any polynomial. This supplies the boundary
+terms that vanish in the integration-by-parts recursion. -/
+theorem tendsto_pow_mul_gaussian_cocompact (m : ℕ) :
+    Tendsto (fun x : ℝ => x ^ m * Real.exp (-x ^ 2)) (cocompact ℝ) (𝓝 0) := by
+  have h := tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact (a := 1) one_pos (m : ℝ)
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  refine h.congr (fun x => ?_)
+  rw [norm_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_pow,
+    abs_of_pos (Real.exp_pos _), Real.rpow_natCast, neg_one_mul]
+
+/-- **The even-moment recursion.**
+`∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}`, the double-factorial step
+produced by integrating `x^{2n+1} · (x e^{-x²})` by parts on `(-∞, ∞)`. -/
+theorem gaussian_even_moment_recursion (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * (n + 1)) * Real.exp (-x ^ 2)
+      = (2 * (n : ℝ) + 1) / 2 * ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) := by
+  -- `u = x^(2n+1)`, `u' = (2n+1) x^(2n)`.
+  have hu : ∀ x : ℝ, HasDerivAt (fun y : ℝ => y ^ (2 * n + 1))
+      ((2 * (n : ℝ) + 1) * x ^ (2 * n)) x := by
+    intro x
+    simpa using hasDerivAt_pow (2 * n + 1) x
+  -- `v = -½ e^{-x²}`, `v' = x e^{-x²}`.
+  have hv : ∀ x : ℝ, HasDerivAt (fun y : ℝ => -(2 : ℝ)⁻¹ * Real.exp (-y ^ 2))
+      (x * Real.exp (-x ^ 2)) x := by
+    intro x
+    have hsq : HasDerivAt (fun y : ℝ => -y ^ 2) (-(2 * x)) x := by
+      simpa using (hasDerivAt_pow 2 x).neg
+    have hexp := hsq.exp
+    have hfin := hexp.const_mul (-(2 : ℝ)⁻¹)
+    convert hfin using 1
+    ring
+  -- Integrability of `u·v' = x^{2n+2} e^{-x²}`.
+  have huv' : Integrable (fun x : ℝ => x ^ (2 * n + 1) * (x * Real.exp (-x ^ 2))) := by
+    have h := integrable_pow_mul_gaussian (2 * n + 2)
+    refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+    simp only []
+    ring
+  -- Integrability of `u'·v = (2n+1) x^{2n} · (-½ e^{-x²})`.
+  have hu'v : Integrable (fun x : ℝ =>
+      (2 * (n : ℝ) + 1) * x ^ (2 * n) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2))) := by
+    have h := (integrable_pow_mul_gaussian (2 * n)).const_mul
+      ((2 * (n : ℝ) + 1) * -(2 : ℝ)⁻¹)
+    refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+    simp only []
+    ring
+  -- Boundary terms vanish at ±∞.
+  have hbot : Tendsto (fun x : ℝ => x ^ (2 * n + 1) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)))
+      atBot (𝓝 0) := by
+    have hb : atBot ≤ cocompact ℝ := by rw [cocompact_eq_atBot_atTop]; exact le_sup_left
+    have h := ((tendsto_pow_mul_gaussian_cocompact (2 * n + 1)).mono_left hb).const_mul
+      (-(2 : ℝ)⁻¹)
+    rw [mul_zero] at h
+    refine Filter.Tendsto.congr (fun x => ?_) h
+    ring
+  have htop : Tendsto (fun x : ℝ => x ^ (2 * n + 1) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)))
+      atTop (𝓝 0) := by
+    have ht : atTop ≤ cocompact ℝ := by rw [cocompact_eq_atBot_atTop]; exact le_sup_right
+    have h := ((tendsto_pow_mul_gaussian_cocompact (2 * n + 1)).mono_left ht).const_mul
+      (-(2 : ℝ)⁻¹)
+    rw [mul_zero] at h
+    refine Filter.Tendsto.congr (fun x => ?_) h
+    ring
+  -- Integration by parts on `(-∞, ∞)`.
+  have key := integral_mul_deriv_eq_deriv_mul (a' := (0 : ℝ)) (b' := (0 : ℝ))
+    hu hv huv' hu'v hbot htop
+  -- Pull the constants out of the remaining integral.
+  have hev : ∫ x : ℝ,
+      (2 * (n : ℝ) + 1) * x ^ (2 * n) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2))
+      = ((2 * (n : ℝ) + 1) * -(2 : ℝ)⁻¹) * ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) := by
+    rw [← integral_const_mul]
+    refine integral_congr_ae (Filter.Eventually.of_forall (fun x => ?_))
+    simp only []
+    ring
+  calc ∫ x : ℝ, x ^ (2 * (n + 1)) * Real.exp (-x ^ 2)
+      = ∫ x : ℝ, x ^ (2 * n + 1) * (x * Real.exp (-x ^ 2)) := by
+        refine integral_congr_ae (Filter.Eventually.of_forall (fun x => ?_))
+        simp only []
+        ring
+    _ = (0 : ℝ) - 0 - ∫ x : ℝ,
+          (2 * (n : ℝ) + 1) * x ^ (2 * n) * (-(2 : ℝ)⁻¹ * Real.exp (-x ^ 2)) := key
+    _ = (2 * (n : ℝ) + 1) / 2 * ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) := by
+        rw [hev]; ring
+
+/-- **The general even moment of the standard Gaussian (closed form).**
+`∫_{-∞}^{∞} x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2^n`, proved by induction on `n`
+folding the integration-by-parts recursion into the base value `√π`. -/
+theorem gaussian_even_moment (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2)
+      = ((2 * n - 1)‼ : ℝ) * Real.sqrt Real.pi / 2 ^ n := by
+  induction n with
+  | zero =>
+    have hg : ∫ x : ℝ, x ^ (2 * 0) * Real.exp (-x ^ 2) = Real.sqrt Real.pi := by
+      simp only [Nat.mul_zero, pow_zero, one_mul]
+      have := integral_gaussian 1
+      simpa [neg_one_mul, div_one] using this
+    rw [hg]
+    norm_num [Nat.doubleFactorial]
+  | succ n ih =>
+    rw [gaussian_even_moment_recursion, ih]
+    have hdf : ((2 * (n + 1) - 1)‼ : ℝ) = (2 * (n : ℝ) + 1) * ((2 * n - 1)‼ : ℝ) := by
+      have h1 : 2 * (n + 1) - 1 = 2 * n + 1 := by omega
+      rw [h1, Nat.doubleFactorial_add_one]
+      push_cast
+      ring
+    rw [hdf, pow_succ]
+    ring
+
+/-- **The even moment is the half-integer Gamma special value.**
+`∫_{-∞}^{∞} x^{2n} e^{-x²} dx = Γ(n + 1/2)`. Mathlib records the right-hand side
+as the double-factorial expression `(2n-1)‼ √π / 2^n` (`Real.Gamma_nat_add_half`);
+our integration-by-parts moment hits exactly that value, so this integral is the
+Gaussian representation of `Γ(n + 1/2)`. -/
+theorem gaussian_even_moment_eq_Gamma (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = Real.Gamma (n + 1 / 2) := by
+  rw [gaussian_even_moment, Real.Gamma_nat_add_half]
+
+/-- Sanity check: the `n = 1` instance recovers the parent's second moment
+`∫ x² e^{-x²} = √π / 2`. -/
+theorem gaussian_second_moment :
+    ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = Real.sqrt Real.pi / 2 := by
+  have h := gaussian_even_moment 1
+  norm_num [Nat.doubleFactorial] at h
+  simpa using h
+
+end AreaOfCircleOQ07OQ05OQ01

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "area-of-circle-oq-07-oq-05-oq-01",
+  "slug": "area-of-circle-oq-07-oq-05-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation",
+      "Mathlib.Data.Nat.Factorial.DoubleFactorial",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ05OQ01",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The General Even Moment of the Gaussian ∫ x^{2n} e^{-x²} = (2n-1)‼·√π / 2ⁿ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ05OQ01.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "integration-by-parts",
+      "special-functions",
+      "measure-theory",
+      "double-factorial",
+      "gamma-function",
+      "induction",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 188,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_even_moment: ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼·√π / 2ⁿ for every n : ℕ — the closed form for all even moments of the standard Gaussian weight, proved by induction on n. The parent entry area-of-circle-oq-07-oq-05 evaluated only the second moment (n = 1); this entry lifts that single integration by parts to the whole family by isolating the recursion it generates and folding it into the zeroth-moment base value √π. The double-factorial step is matched via Nat.doubleFactorial_add_one: (2(n+1)-1)‼ = (2n+1)·(2n-1)‼.",
+      "gaussian_even_moment_recursion: ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²} — the double-factorial recursion produced by one integration by parts on (-∞, ∞). Writing the integrand as x^{2n+1}·(x e^{-x²}) with x e^{-x²} = d/dx(-½ e^{-x²}), the boundary term x^{2n+1}·(-½ e^{-x²}) vanishes at ±∞ and the integral drops by two powers, picking up the factor (2n+1)/2. This is the engine of the induction.",
+      "gaussian_even_moment_eq_Gamma: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + 1/2) — identifies the IBP-derived integral with the half-integer Gamma special value. Mathlib records Γ(n+1/2) = (2n-1)‼·√π / 2ⁿ (Real.Gamma_nat_add_half) but only as a Gamma evaluation; this corollary exhibits the integral as its Gaussian representation, tying the elementary integration-by-parts recursion to the Gamma function for all n at once (the n-general companion to sibling oq-05-oq-02's n = 1 Gamma identity).",
+      "integrable_pow_mul_gaussian / tendsto_pow_mul_gaussian_cocompact: the integrability of x^k e^{-x²} for every natural power k and the Gaussian-decay vanishing x^m e^{-x²} → 0 at ±∞ for every power m. These generalize the parent's s = 1, 2 instances to arbitrary powers, supplying the integrability and boundary hypotheses the recursion needs at every step (packaged from integrable_rpow_mul_exp_neg_mul_sq and tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact via Real.rpow_natCast)."
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Integration by parts on (-∞, ∞): MeasureTheory.integral_mul_deriv_eq_deriv_mul",
+      "The zeroth moment base case: integral_gaussian (∫ e^{-b x²} = √(π/b))",
+      "Gaussian decay of polynomial weights: tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
+      "Integrability of x^s e^{-b x²}: integrable_rpow_mul_exp_neg_mul_sq",
+      "Double factorial API: Nat.doubleFactorial_add_one, Real.Gamma_nat_add_half",
+      "Parent: area-of-circle-oq-07-oq-05 (the second moment ∫ x² e^{-x²} = √π/2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_mul_deriv_eq_deriv_mul",
+        "description": "Integration by parts on (-∞, ∞): ∫ u v' = b' - a' - ∫ u' v, given the derivatives, integrability of u·v' and u'·v, and convergence of the boundary product u·v at ±∞. Applied with u = x^{2n+1}, v = -½ e^{-x²} to produce the even-moment recursion.",
+        "module": "Mathlib.MeasureTheory.Integral.IntegralEqImproper"
+      },
+      {
+        "theorem": "integral_gaussian",
+        "description": "∫ x : ℝ, e^{-b x²} = √(π/b). At b = 1 this is the zeroth moment √π, the base case of the induction.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
+        "description": "|x|^s e^{-a x²} → 0 along the cocompact filter for a > 0 — Gaussian decay beats any power. Specialized to s = 2n+1 to kill the boundary term x^{2n+1}·(-½ e^{-x²}) at ±∞.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.PoissonSummation"
+      },
+      {
+        "theorem": "integrable_rpow_mul_exp_neg_mul_sq",
+        "description": "x^s e^{-b x²} is integrable over ℝ for b > 0 and s > -1. Specialized to s = 2n, 2n+2 (via Real.rpow_natCast) to supply integrability of u·v' and u'·v in the integration-by-parts step.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Real.Gamma_nat_add_half",
+        "description": "Γ(k + 1/2) = (2k-1)‼·√π / 2^k, the half-integer Gamma special value in double-factorial form. Combined with the closed-form integral it yields ∫ x^{2n} e^{-x²} = Γ(n+1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Nat.doubleFactorial_add_one",
+        "description": "(n+1)‼ = (n+1)·(n-1)‼. At n = 2k this is the recurrence (2k+1)‼ = (2k+1)·(2k-1)‼ that matches the analytic factor (2k+1) appearing in the integration-by-parts recursion, closing the induction.",
+        "module": "Mathlib.Data.Nat.Factorial.DoubleFactorial"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+      "question": "Evaluate the odd moments ∫_ℝ x^{2n+1} e^{-x²} dx = 0 by the even-symmetry of the integrand, and combine with the even-moment formula to give the full moment sequence ∫_ℝ x^k e^{-x²} dx for all k.",
+      "significance": "low"
+    },
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+      "question": "Generalize to the scaled Gaussian ∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼·√(π/a) / (2a)^n for a > 0, tracking how the double-factorial recursion picks up powers of a under the substitution x ↦ x/√a.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-05",
+      "relationship": "extends",
+      "description": "Parent. The second moment ∫_ℝ x² e^{-x²} = √π/2 is exactly the n = 1 instance of this entry's closed form (recovered here as gaussian_second_moment), and its single integration by parts is the n = 0 → 1 step of this entry's recursion."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "Grandparent. The zeroth moment ∫_ℝ e^{-x²} = √π (integral_gaussian) is the base case of the induction (n = 0)."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The Gaussian integral family. This entry completes the gallery's even-moment collection, giving every ∫ x^{2n} e^{-x²} in closed form and tying them to the Gamma function."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian, integrable_rpow_mul_exp_neg_mul_sq, and Real.Gamma_nat_add_half (the half-integer Gamma special value in double-factorial form)."
+    },
+    {
+      "title": "Fourier Analysis",
+      "author": "Elias M. Stein and Rami Shakarchi",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "description": "Classical treatment of Gaussian moments ∫ x^{2n} e^{-x²} and the integration-by-parts recursion formalized here in full generality."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For every n : ℕ the even moment of the standard Gaussian weight is ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼·√π / 2ⁿ (gaussian_even_moment). The proof isolates the double-factorial recursion ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2·∫ x^{2n} e^{-x²} (gaussian_even_moment_recursion) — one integration by parts on (-∞, ∞) with u = x^{2n+1}, v = -½ e^{-x²}, boundary term killed by Gaussian decay — and folds it by induction into the base value ∫ e^{-x²} = √π, matching the arithmetic factor (2n+1) to the double-factorial step (2(n+1)-1)‼ = (2n+1)·(2n-1)‼ (Nat.doubleFactorial_add_one). A corollary identifies the integral with the half-integer Gamma value Γ(n+1/2) (gaussian_even_moment_eq_Gamma). 188 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This closes the even-moment family the parent's second moment opened: every ∫ x^{2n} e^{-x²} now has a machine-checked closed form, and the recursion makes explicit how each integration by parts lowers the power by two while accumulating the odd factor 2n+1. Tying the integral to Γ(n+1/2) shows the elementary IBP recursion computes the same half-integer Gamma values Mathlib records combinatorially, giving a Gaussian integral representation of those special values for all n at once.",
+    "openQuestions": [
+      "Add the vanishing odd moments ∫ x^{2n+1} e^{-x²} = 0 to give the full moment sequence.",
+      "Generalize to the scaled Gaussian ∫ x^{2n} e^{-a x²} = (2n-1)‼·√(π/a)/(2a)^n."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's own open question **area-of-circle-oq-07-oq-05-oq-01**: evaluate the *general* even moment of the standard Gaussian weight by induction, exhibiting the double-factorial recursion that integration by parts generates.

For every `n : ℕ`:

```
∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ
```

The parent entry `area-of-circle-oq-07-oq-05` did only the second moment (`n = 1`, value `√π/2`) via a single integration by parts. This entry lifts that one computation to the whole family.

## What's new

- **`gaussian_even_moment_recursion`** — `∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}`: the engine, one IBP on `(-∞,∞)` with `u = x^{2n+1}`, `v = -½ e^{-x²}`; boundary term `x^{2n+1}·(-½ e^{-x²})` killed by Gaussian decay.
- **`gaussian_even_moment`** — the closed form for all `n`, by induction folding the recursion into the base value `∫ e^{-x²} = √π`. The arithmetic factor `(2n+1)` matches the double-factorial step `(2(n+1)-1)‼ = (2n+1)·(2n-1)‼` via `Nat.doubleFactorial_add_one`.
- **`gaussian_even_moment_eq_Gamma`** — `∫ x^{2n} e^{-x²} = Γ(n + 1/2)`: ties the IBP-derived integral to the half-integer Gamma special value. Mathlib records `Γ(n+1/2)` combinatorially (`Real.Gamma_nat_add_half`) but only as a Gamma evaluation; this exhibits the integral as its Gaussian representation for all `n`.
- **`integrable_pow_mul_gaussian` / `tendsto_pow_mul_gaussian_cocompact`** — integrability and Gaussian-decay vanishing of `x^k e^{-x²}` for every natural power, generalizing the parent's `s = 1, 2` instances.
- **`gaussian_second_moment`** — sanity check recovering the parent's `√π/2` as the `n = 1` instance.

Mathlib has the Gamma special value `Real.Gamma_nat_add_half` but **not** the even moment in integral form — this fills that gap.

## Verification

- 6 theorems, 0 definitions, 188 lines, 0 sorries
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom / verified**
- Built against Mathlib (Lean 4.26.0) via host `lake env lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)