### PR TITLE
Fix: normalize compactness-finite-subcover leaf casing for case-sensitive build

### DIFF
--- a/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq01Oq01.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq01Oq01.lean
@@ -1,5 +1,5 @@
 import Mathlib
-import Proofs.CompactnessFiniteSubcoverOQ01OQ01
+import Proofs.CompactnessFiniteSubcoverOq01Oq01
 
 /-
 # The Closed-Projection Characterization of Compactness (Forward Direction)

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "leanFile": {
     "imports": [
       "Mathlib",
-      "Proofs.CompactnessFiniteSubcoverOQ01OQ01"
+      "Proofs.CompactnessFiniteSubcoverOq01Oq01"
     ],
     "opens": [
       "Set"
@@ -14,14 +14,14 @@
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,
-    "path": "Proofs/CompactnessFiniteSubcoverOQ01OQ01OQ01.lean",
+    "path": "Proofs/CompactnessFiniteSubcoverOq01Oq01Oq01.lean",
     "sorries": 0
   },
   "title": "The Closed-Projection Characterization of Compactness (Forward Direction)",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
-    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOQ01OQ01OQ01.lean",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOq01Oq01Oq01.lean",
     "tags": [
       "topology",
       "compactness",


### PR DESCRIPTION
## Fix

The `compactness-finite-subcover-oq-01-oq-01-oq-01` leaf was committed with **uppercase `OQ`** filename/imports while the rest of its family (6 files) and its own `Proofs.lean` registration use **lowercase `Oq`**. This dangles two imports on a case-sensitive FS (the canonical Docker/Linux build), even though it resolves on macOS's case-insensitive dev FS.

Applied **Option B** from the audit (self-contained, no sibling ripple): lowercase the leaf to match its existing family.

## Changes (case-only normalization)

- `git mv CompactnessFiniteSubcoverOQ01OQ01OQ01.lean → ...Oq01Oq01Oq01.lean`
- Leaf internal import: `Proofs.CompactnessFiniteSubcoverOQ01OQ01` → `...Oq01Oq01`
- `meta.json`: `imports[1]`, `leanFile.path`, `meta.proofRepoPath` → lowercase
- `Proofs.lean:812` already lowercase — no change needed

No mathematical content changed (proof remains 0-sorry / 0-axiom / `verified`).

## Evidence

**Before** (case-sensitive, two dangling imports):
- Leaf `import Proofs.CompactnessFiniteSubcoverOQ01OQ01` → only `Oq01Oq01` exists → fail
- `Proofs.lean:812 import ...Oq01Oq01Oq01` → only uppercase leaf existed → fail

**After**: family is uniformly lowercase `Oq`; both imports resolve exactly against git-stored filenames. JSON validated. (Docker daemon unavailable this cycle for a full build, but the fix is structural — every import now matches its stored filename exactly.)

Closes #29127

---
Automated fix by lean-mechanic agent.