### PR TITLE
research(basel-problem-oq-09-oq-01): Dirichlet lambda parity split λ(s)=(1−2⁻ˢ)ζ(s), λ(4)=π⁴/96 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -296,6 +296,7 @@ import Proofs.BaselProblemOQ08
 import Proofs.BaselProblemOQ08OQ02
 import Proofs.BaselProblemOQ08OQ02OQ01
 import Proofs.BaselProblemOQ09
+import Proofs.BaselProblemOQ09OQ01
 import Proofs.BaselProblemOQ10
 import Proofs.BaselProblemOQ11
 import Proofs.BaselProblemOQ12

--- a/proofs/Proofs/BaselProblemOQ09OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ09OQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.Topology.Algebra.InfiniteSum.Ring
+import Mathlib.Tactic
+
+/-
+# The Dirichlet Lambda Parity Split: λ(s) = (1 − 2⁻ˢ)·ζ(s)
+
+## What This Proves
+For **every** exponent `s` and **every** value `Z` realising the zeta-type sum
+`∑_{n≥1} 1/nˢ = Z`, the reciprocals of the *odd* powers carry exactly the
+fraction `(1 − 2⁻ˢ)` of the mass:
+
+  λ(s) := ∑_{k≥0} 1/(2k+1)ˢ = (1 − 1/2ˢ) · ζ(s),
+
+while the *even* powers carry the complementary `2⁻ˢ`:
+
+  ∑_{k≥1} 1/(2k)ˢ = (1/2ˢ) · ζ(s).
+
+Specialising to the explicit even zeta values from Mathlib gives
+
+  λ(2) = (1 − 1/4)·(π²/6) = π²/8       (recovers `basel-problem-oq-09`)
+  λ(4) = (1 − 1/16)·(π⁴/90) = π⁴/96    (new)
+
+## Approach
+The parent entry `basel-problem-oq-09` carried out the even/odd decomposition
+only for the single exponent `s = 2`. Here we abstract the argument over an
+arbitrary exponent `s` and an arbitrary realised sum `Z`:
+
+1. The even subseries `k ↦ 1/(2k)ˢ` is a rescaled copy of the whole series,
+   because `(2k)ˢ = 2ˢ·kˢ`; hence it has sum `(1/2ˢ)·Z`.
+2. The odd subseries is an injective reindexing of a summable series, so it is
+   summable and has *some* sum.
+3. `HasSum.even_add_odd` recombines the two subseries into the full series, and
+   uniqueness of sums forces the odd value to be `Z − (1/2ˢ)·Z = (1 − 1/2ˢ)·Z`.
+
+Nothing in steps 1–3 uses the *value* `Z`, so the lemma is fully general; the
+concrete `π²/8` and `π⁴/96` are one-line specialisations against
+`hasSum_zeta_two` and `hasSum_zeta_four`.
+
+## Provenance
+- Foundations: `hasSum_zeta_two`, `hasSum_zeta_four`
+  (`Mathlib.NumberTheory.ZetaValues`).
+- Split: `HasSum.even_add_odd` (`Mathlib.Topology.Algebra.InfiniteSum.NatInt`).
+- Rescaling: `HasSum.mul_left`; summability via `Summable.comp_injective`;
+  value identification via `HasSum.unique`.
+
+This entry answers the open question `basel-problem-oq-09-oq-01`.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms.
+
+Original formalization for Lean Genius.
+-/
+
+namespace BaselProblemOQ09OQ01
+
+open Real Filter Topology
+
+/-! ## The general parity split (arbitrary exponent and realised sum) -/
+
+/-- **The even part, general form.** If `∑ₙ 1/nˢ = Z`, then the even-power
+subseries sums to `(1/2ˢ)·Z`, because `(2k)ˢ = 2ˢ·kˢ`. -/
+theorem hasSum_even_of_hasSum {s : ℕ} {Z : ℝ}
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ s) Z) :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ)) ^ s) ((1 / 2 ^ s) * Z) := by
+  have hfun : (fun k : ℕ => 1 / (2 * (k : ℝ)) ^ s)
+            = (fun k : ℕ => (1 / 2 ^ s) * (1 / (k : ℝ) ^ s)) := by
+    funext k; rw [mul_pow]; ring
+  rw [hfun]
+  exact hZ.mul_left _
+
+/-- **The odd part, general form — the parity split.** If `∑ₙ 1/nˢ = Z`, then
+the odd-power subseries sums to `(1 − 1/2ˢ)·Z`. This is the statement
+`λ(s) = (1 − 2⁻ˢ)·ζ(s)` for any realised zeta value. -/
+theorem hasSum_odd_of_hasSum {s : ℕ} {Z : ℝ}
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ s) Z) :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ s) ((1 - 1 / 2 ^ s) * Z) := by
+  set f : ℕ → ℝ := fun n => 1 / (n : ℝ) ^ s with hf
+  -- Even part in the `f (2*k)` shape required by `even_add_odd`.
+  have heven : HasSum (fun k : ℕ => f (2 * k)) ((1 / 2 ^ s) * Z) := by
+    have hfun : (fun k : ℕ => f (2 * k))
+              = (fun k : ℕ => (1 / 2 ^ s) * f k) := by
+      funext k; simp only [hf]; push_cast; rw [mul_pow]; ring
+    rw [hfun]; exact hZ.mul_left _
+  -- The odd subseries is summable (injective reindexing of a summable series).
+  have hinj : Function.Injective (fun k : ℕ => 2 * k + 1) := by
+    intro a b h; dsimp only at h; omega
+  have hodd_sum : Summable (fun k : ℕ => f (2 * k + 1)) := by
+    have h := hZ.summable.comp_injective hinj
+    simpa [Function.comp] using h
+  have hodd : HasSum (fun k : ℕ => f (2 * k + 1)) (∑' k, f (2 * k + 1)) :=
+    hodd_sum.hasSum
+  -- Recombine even + odd into the full series, then identify the odd value.
+  have hcomb : HasSum f ((1 / 2 ^ s) * Z + ∑' k, f (2 * k + 1)) :=
+    heven.even_add_odd hodd
+  have huniq : (1 / 2 ^ s) * Z + ∑' k, f (2 * k + 1) = Z := hcomb.unique hZ
+  have hval : (∑' k, f (2 * k + 1)) = (1 - 1 / 2 ^ s) * Z := by
+    have hstep : (∑' k, f (2 * k + 1)) = Z - (1 / 2 ^ s) * Z := by linarith
+    rw [hstep]; ring
+  -- Bridge the local `f`-form to the clean statement.
+  rw [hval] at hodd
+  have hbridge : (fun k : ℕ => f (2 * k + 1))
+               = (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ s) := by
+    funext k; simp only [hf]; push_cast; ring
+  rw [hbridge] at hodd
+  exact hodd
+
+/-! ## Concrete even zeta values
+
+The explicit `λ(2m)` follow by feeding Mathlib's closed forms into the general
+lemma; each is a one-line numeric simplification of `(1 − 1/2^{2m})·ζ(2m)`. -/
+
+/-- **λ(2) = π²/8.** Recovers the parent result `basel-problem-oq-09`. -/
+theorem hasSum_lambda_two :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) (π ^ 2 / 8) := by
+  have h := hasSum_odd_of_hasSum (s := 2) hasSum_zeta_two
+  have heq : (1 - 1 / (2 : ℝ) ^ 2) * (π ^ 2 / 6) = π ^ 2 / 8 := by ring
+  rwa [heq] at h
+
+/-- **λ(4) = π⁴/96.** The new result: `(1 − 1/16)·(π⁴/90) = π⁴/96`. -/
+theorem hasSum_lambda_four :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 4) (π ^ 4 / 96) := by
+  have h := hasSum_odd_of_hasSum (s := 4) hasSum_zeta_four
+  have heq : (1 - 1 / (2 : ℝ) ^ 4) * (π ^ 4 / 90) = π ^ 4 / 96 := by ring
+  rwa [heq] at h
+
+/-! ## tsum forms and summability -/
+
+/-- `∑' k, 1/(2k+1)² = π²/8`. -/
+theorem tsum_lambda_two : ∑' k : ℕ, 1 / (2 * (k : ℝ) + 1) ^ 2 = π ^ 2 / 8 :=
+  hasSum_lambda_two.tsum_eq
+
+/-- `∑' k, 1/(2k+1)⁴ = π⁴/96`. -/
+theorem tsum_lambda_four : ∑' k : ℕ, 1 / (2 * (k : ℝ) + 1) ^ 4 = π ^ 4 / 96 :=
+  hasSum_lambda_four.tsum_eq
+
+/-- The odd fourth-power series is summable. -/
+theorem summable_lambda_four :
+    Summable (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 4) :=
+  hasSum_lambda_four.summable
+
+/-! ## Sanity checks on the parity factor and values -/
+
+/-- The even and odd fourth-power masses recombine to ζ(4) = π⁴/90:
+`π⁴/720 + π⁴/96 = π⁴/90` (even mass `(1/16)·π⁴/90 = π⁴/1440`… check via ζ). -/
+theorem lambda_four_decomposition :
+    (1 / 2 ^ 4 : ℝ) * (π ^ 4 / 90) + π ^ 4 / 96 = π ^ 4 / 90 := by ring
+
+/-- The parity factor at `s` and `s` complementary parts sum to one:
+`1/2ˢ + (1 − 1/2ˢ) = 1`. -/
+theorem parity_factor_complement (s : ℕ) :
+    (1 / 2 ^ s : ℝ) + (1 - 1 / 2 ^ s) = 1 := by ring
+
+/-- λ(4) is positive. -/
+theorem lambda_four_pos : (0 : ℝ) < π ^ 4 / 96 := by positivity
+
+/-- The first odd fourth-power term is `1/1⁴ = 1`. -/
+example : (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 4) 0 = 1 := by norm_num
+
+/-- The second odd fourth-power term is `1/3⁴ = 1/81`. -/
+example : (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 4) 1 = 1 / 81 := by norm_num
+
+end BaselProblemOQ09OQ01

--- a/src/data/proofs/basel-problem-oq-09-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-09-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "basel-problem-oq-09-oq-01",
+  "title": "The Dirichlet Lambda Parity Split: λ(s) = (1 − 2⁻ˢ)·ζ(s), with λ(4) = π⁴/96",
+  "slug": "basel-problem-oq-09-oq-01",
+  "description": "Abstracts the parent's even/odd split of the Basel sum into a single reusable lemma valid for an arbitrary exponent s and any realised zeta value Z: the odd-power subseries ∑ 1/(2k+1)ˢ sums to (1 − 1/2ˢ)·Z and the even-power subseries ∑ 1/(2k)ˢ to (1/2ˢ)·Z, because (2k)ˢ = 2ˢ·kˢ and HasSum.even_add_odd recombines the halves. Nothing in the argument uses the value Z, so feeding Mathlib's closed forms gives the odd-index (Dirichlet lambda) values as one-line specialisations: λ(2) = (1 − 1/4)(π²/6) = π²/8 (recovering the parent) and the new λ(4) = (1 − 1/16)(π⁴/90) = π⁴/96. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ09OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "dirichlet-lambda",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 165,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "ζ(2): HasSum (fun n => 1/n²) (π²/6); specialised to λ(2) = π²/8",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_four",
+        "description": "ζ(4): HasSum (fun n => 1/n⁴) (π⁴/90); specialised to λ(4) = π⁴/96",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Recombine the even- and odd-indexed subseries into the full sum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "HasSum.mul_left",
+        "description": "Scale a HasSum by 1/2ˢ to obtain the even part as (1/2ˢ)·Z",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd subseries via the injection k ↦ 2k+1",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "HasSum.unique",
+        "description": "Uniqueness of sums, pinning the odd part to (1 − 1/2ˢ)·Z",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_odd_of_hasSum: the parity-split lemma λ(s) = (1 − 1/2ˢ)·ζ(s) for ANY exponent s and ANY realised zeta value Z — the abstraction the parent left at the single case s = 2",
+      "hasSum_even_of_hasSum: the complementary even-power lemma ∑ 1/(2k)ˢ = (1/2ˢ)·Z",
+      "hasSum_lambda_four / tsum_lambda_four / summable_lambda_four: the new value λ(4) = π⁴/96 = (1 − 1/16)(π⁴/90) from hasSum_zeta_four, with tsum form and summability",
+      "hasSum_lambda_two: λ(2) = π²/8 recovered as the s = 2 specialisation of the general lemma",
+      "lambda_four_decomposition / parity_factor_complement: the ζ(4) even+odd recombination and the identity 1/2ˢ + (1 − 1/2ˢ) = 1"
+    ],
+    "prerequisites": [
+      "Parent basel-problem-oq-09 (even/odd split of ζ(2))",
+      "Explicit even zeta values ζ(2) = π²/6, ζ(4) = π⁴/90 (Mathlib)",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.NatInt",
+      "Mathlib.Topology.Algebra.InfiniteSum.Ring",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real", "Filter", "Topology"],
+    "namespace": "BaselProblemOQ09OQ01",
+    "path": "Proofs/BaselProblemOQ09OQ01.lean",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The odd-index (Dirichlet lambda) function λ(s) = ∑_{k≥0} 1/(2k+1)^s satisfies λ(s) = (1 − 2^{-s})ζ(s), because the even-indexed terms of ζ(s) reassemble a 2^{-s}-scaled copy of ζ(s) itself. At the even integers this turns Euler's closed forms ζ(2) = π²/6 and ζ(4) = π⁴/90 into λ(2) = π²/8 and λ(4) = π⁴/96 with no further analysis. The parent entry basel-problem-oq-09 proved only the s = 2 instance; this entry isolates the parity split as a single exponent-agnostic lemma.",
+    "problemStatement": "Generalize the even/odd parity split of the Basel sum to a reusable lemma: for any exponent s and any Z with ∑ 1/nˢ = Z, the odd-power subseries sums to (1 − 1/2ˢ)·Z. Then derive λ(2) = π²/8 (recovering the parent) and the new λ(4) = π⁴/96 from Mathlib's hasSum_zeta_four, with 0 sorries and 0 axioms.",
+    "text": "λ(s) = (1 − 2⁻ˢ)·ζ(s) as an exponent-agnostic HasSum lemma, specialised to λ(2) = π²/8 and λ(4) = π⁴/96.",
+    "proofStrategy": "Parametrise the parent argument over s and Z. (1) hasSum_even_of_hasSum: rewrite 1/(2k)ˢ = (1/2ˢ)(1/kˢ) via mul_pow + ring (valid at k = 0 in ℝ) and scale the hypothesis by 1/2ˢ (HasSum.mul_left), giving even sum (1/2ˢ)·Z. (2) hasSum_odd_of_hasSum: the odd subseries fun k ↦ f(2k+1) is summable (Summable.comp_injective with k ↦ 2k+1), so HasSum.even_add_odd reassembles the full series and HasSum.unique forces (1/2ˢ)·Z + odd = Z, hence odd = (1 − 1/2ˢ)·Z (a linarith over the atoms Z, (1/2ˢ)·Z, odd, then ring to fold the factor). (3) The concrete values are rwa after a `ring` proof that (1 − 1/2²)(π²/6) = π²/8 and (1 − 1/2⁴)(π⁴/90) = π⁴/96.",
+    "keyInsights": [
+      "**The parity split never touches the value.** Because the even part is a 2⁻ˢ-scaled copy of the whole series, the odd value (1 − 2⁻ˢ)·Z drops out of uniqueness alone — so the lemma is stated over an arbitrary realised sum Z, and every concrete λ(2m) is a one-line specialisation.",
+      "**Exponent-agnostic rescaling.** (2k)ˢ = 2ˢ·kˢ holds for every nat s and every real k (mul_pow), and 1/(2ˢkˢ) = (1/2ˢ)(1/kˢ) is a field identity valid even at k = 0; one `rw [mul_pow]; ring` discharges the rescale for all s at once, where the parent hard-coded s = 2.",
+      "**λ(4) = π⁴/96 is pure arithmetic on ζ(4).** Feeding hasSum_zeta_four (ζ(4) = π⁴/90) into the lemma yields (1 − 1/16)(π⁴/90); a single `ring` confirms this equals π⁴/96. No new summation or analytic estimate is introduced beyond Mathlib's ζ(4).",
+      "**Uniqueness over a nonlinear atom.** With (1/2ˢ)·Z treated as an opaque product, the value step is linear: from (1/2ˢ)·Z + odd = Z conclude odd = Z − (1/2ˢ)·Z by linarith, then `ring` refolds it as (1 − 1/2ˢ)·Z.",
+      "**The factor is a genuine probability split.** parity_factor_complement records 1/2ˢ + (1 − 1/2ˢ) = 1: the even indices carry fraction 2⁻ˢ of ζ(s) and the odd indices the rest, recovering the parent's 'three quarters is odd' at s = 2 and 'fifteen sixteenths is odd' at s = 4."
+    ],
+    "prerequisites": [
+      "Parent even/odd split of ζ(2) (basel-problem-oq-09)",
+      "Explicit even zeta values ζ(2) = π²/6, ζ(4) = π⁴/90",
+      "Even/odd decomposition of infinite sums (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Documents the exponent-agnostic parity split λ(s) = (1 − 2⁻ˢ)ζ(s) and its specialisations; imports Mathlib's ZetaValues for hasSum_zeta_two and hasSum_zeta_four.",
+      "mathContext": "The odd-index zeta λ(s) carries fraction (1 − 2⁻ˢ) of ζ(s)."
+    },
+    {
+      "id": "general-split",
+      "title": "The general parity split — hasSum_even_of_hasSum / hasSum_odd_of_hasSum",
+      "startLine": 58,
+      "endLine": 110,
+      "summary": "The exponent- and value-agnostic lemmas: even part (1/2ˢ)·Z via mul_pow rescaling + HasSum.mul_left; odd part (1 − 1/2ˢ)·Z via even_add_odd recombination and HasSum.unique.",
+      "mathContext": "λ(s) = (1 − 2⁻ˢ)ζ(s) for any realised zeta value."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete even zeta values — λ(2) = π²/8 and λ(4) = π⁴/96",
+      "startLine": 112,
+      "endLine": 130,
+      "summary": "Specialise the general lemma against hasSum_zeta_two and hasSum_zeta_four; each value is a one-line `ring` simplification of (1 − 1/2^{2m})·ζ(2m).",
+      "mathContext": "λ(2) = (1 − 1/4)(π²/6) = π²/8; λ(4) = (1 − 1/16)(π⁴/90) = π⁴/96."
+    },
+    {
+      "id": "corollaries",
+      "title": "tsum forms, summability, and sanity checks",
+      "startLine": 132,
+      "endLine": 165,
+      "summary": "tsum and summability corollaries for λ(4); the ζ(4) even+odd recombination, the parity-factor complement 1/2ˢ + (1 − 1/2ˢ) = 1, positivity, and numerical checks of the first two odd terms.",
+      "mathContext": "The even and odd masses of ζ(4) recombine to π⁴/90."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Dirichlet lambda parity split λ(s) = (1 − 2⁻ˢ)·ζ(s) is formalized as a single exponent-agnostic HasSum lemma over an arbitrary realised zeta value, with 0 axioms and 0 sorries. Specialising against Mathlib's explicit even zeta values recovers the parent λ(2) = π²/8 and proves the new λ(4) = π⁴/96, both as one-line arithmetic on ζ(2m).",
+    "implications": "Replaces the parent's single hard-coded exponent with a reusable lemma: any future λ(2m) value follows immediately from the corresponding hasSum_zeta_* (or from any other realised ∑ 1/nˢ). The same recombination underlies the Dirichlet eta values η(s) = (1 − 2^{1−s})ζ(s), so η(2) = π²/12 and η(4) = 7π⁴/720 are now one subtraction away.",
+    "openQuestions": [
+      {
+        "id": "basel-problem-oq-09-oq-01-oq-01",
+        "question": "Derive the Dirichlet eta values η(2) = π²/12 and η(4) = 7π⁴/720 from the same machinery, using η(s) = ζ(s) − 2·(even part) = (1 − 2^{1−s})ζ(s), and verify the consistency relation λ(s) − η(s) = 2⁻ˢζ(s).",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-09",
+      "relationship": "extends",
+      "description": "Parent entry proves the s = 2 case λ(2) = π²/8; this entry abstracts the split over arbitrary s and adds λ(4) = π⁴/96."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "Root Basel entry ζ(2) = π²/6; the parity factor (1 − 2⁻ˢ) selects the odd indices of ζ(s)."
+    },
+    {
+      "targetId": "basel-problem-oq-11",
+      "relationship": "related",
+      "description": "The Dirichlet eta companion η(2) = π²/12 uses the same even/odd splitting machinery."
+    }
+  ],
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of ζ(2) and ζ(4); the odd-index values λ(2m) follow by separating each sum by parity."
+    },
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops ζ and its companions, the Dirichlet lambda and eta functions, whose even-integer values follow from the parity split used here."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-09-oq-01-oq-01",
+      "question": "Derive the Dirichlet eta values η(2) = π²/12 and η(4) = 7π⁴/720 from the same machinery via η(s) = (1 − 2^{1−s})ζ(s), and verify λ(s) − η(s) = 2⁻ˢζ(s).",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's **own** open question `basel-problem-oq-09-oq-01`. The parent `basel-problem-oq-09` proved the even/odd parity split of the Basel sum only for the single exponent $s=2$ (λ(2)=π²/8). This entry abstracts the argument into one **exponent-agnostic** lemma valid for any exponent $s$ and any realised zeta value $Z$:

```
hasSum_odd_of_hasSum  : ∑ₖ 1/(2k+1)ˢ = (1 − 1/2ˢ)·Z      -- the parity split λ(s)=(1−2⁻ˢ)ζ(s)
hasSum_even_of_hasSum : ∑ₖ 1/(2k)ˢ   = (1/2ˢ)·Z
```

The value $Z$ never enters the proof — it falls out of `HasSum.unique` after `HasSum.even_add_odd` recombines the halves — so the concrete odd-index (Dirichlet lambda) values are one-line specialisations of Mathlib's closed forms:

| value | derivation | result |
|-------|-----------|--------|
| λ(2) | (1 − 1/4)·(π²/6) | **π²/8** (recovers parent) |
| λ(4) | (1 − 1/16)·(π⁴/90) from `hasSum_zeta_four` | **π⁴/96** (new) |

## Proof engine
- $(2k)^s = 2^s k^s$ (`mul_pow`) makes the even subseries a $2^{-s}$-scaled copy → `HasSum.mul_left`; the rescale identity $1/(2^s k^s) = (1/2^s)(1/k^s)$ is a field identity valid even at $k=0$, closed by `rw [mul_pow]; ring` for **all** $s$ at once.
- Odd subseries summable via `Summable.comp_injective` ($k ↦ 2k+1$ injective).
- `HasSum.even_add_odd` + `HasSum.unique`: $(1/2^s)Z + \text{odd} = Z ⟹ \text{odd} = (1−1/2^s)Z$.
- Concrete values: `rwa` after a one-line `ring` arithmetic on ζ(2m).

## Verification
- **10 theorems, 165 lines, 0 sorries, 0 axioms.**
- `#print axioms` on the main results lists only `propext, Classical.choice, Quot.sound`.
- Built with host `lake env lean` (docker daemon down); exit 0, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)