### PR TITLE
research(pythagorean-triples-oq-06-oq-01-oq-01): 60 ∣ xyz for every Pythagorean triple [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3508,6 +3508,7 @@ import Proofs.PythagoreanTriplesOQ04
 import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ06
 import Proofs.PythagoreanTriplesOQ06OQ01
+import Proofs.PythagoreanTriplesOQ06OQ01OQ01
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
 import Proofs.PythagoreanTriplesOQ09

--- a/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean
@@ -1,0 +1,115 @@
+import Mathlib
+
+/-!
+# The full divisibility package for Pythagorean triples: `60 ∣ xyz`
+
+A **Pythagorean triple** is a triple of integers `(x, y, z)` with `x² + y² = z²`.  The parent
+entry `pythagorean-triples-oq-06-oq-01` (`PythTriplesParity`) records the parity structure of
+*primitive* triples — one leg even, the even leg divisible by `4`, the hypotenuse odd.  This
+file answers its recorded open question
+`pythagorean-triples-oq-06-oq-01-oq-01`:
+
+> *Strengthen to the divisibility package: the even leg is divisible by `4`, exactly one leg
+> is divisible by `3`, one side by `5`, hence `60 ∣ xyz` for every triple.*
+
+The headline result `sixty_dvd_prod` — **`60 ∣ x·y·z` for every Pythagorean triple** — needs
+no primitivity hypothesis at all: it holds for *every* integer solution of `x² + y² = z²`.
+
+## Method
+
+The three prime-power factors `3`, `4`, `5` of `60` are each forced by a **finite congruence
+obstruction**, checked by `decide` on the appropriate `ZMod`:
+
+* `3 ∣ xyz` and `5 ∣ xyz`: the squares modulo `3` (resp. `5`) are `{0,1}` (resp. `{0,1,4}`),
+  and a direct finite check shows that any solution of `a²+b²=c²` over `ZMod 3` / `ZMod 5`
+  already has `a·b·c = 0`.  So one of the three sides is divisible by `3`, and one by `5`.
+* `4 ∣ xyz`: modulo `4` this is *false* (e.g. residues `(1,2,1)` satisfy `1+0=1` with product
+  `2`), so we work modulo `8`, where `a²+b²=c²` rules those out (`1+4=5` is not a square mod
+  `8`).  The finite check is run for the composite map `ZMod 8 → ZMod 4`, certifying that the
+  product reduces to `0` in `ZMod 4`, i.e. `4 ∣ xyz`.
+
+Combining the three with pairwise coprimality of `3, 4, 5` gives `60 ∣ xyz`.
+
+Mathlib has the `m²-n²`, `2mn`, `m²+n²` classification of triples but no divisibility package;
+this entry supplies it.  The proof is `0`-axiom and uses only `decide` over small `ZMod`s plus
+`IsCoprime.mul_dvd`.
+-/
+
+namespace PythagoreanTriples60
+
+/-- Transport an integer Pythagorean relation `x²+y²=z²` to the ring `ZMod n`. -/
+theorem zmod_rel (n : ℕ) {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) :
+    (x : ZMod n) ^ 2 + (y : ZMod n) ^ 2 = (z : ZMod n) ^ 2 := by
+  exact_mod_cast congrArg (fun t : ℤ => (t : ZMod n)) h
+
+/-- **Direct congruence obstruction.**  If over `ZMod n` every solution of `a²+b²=c²` has
+`a·b·c = 0`, then `n ∣ x·y·z` for every integer Pythagorean triple.  Used for `n = 3, 5`. -/
+theorem dvd_prod_of_zmod {n : ℕ} {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2)
+    (key : ∀ a b c : ZMod n, a ^ 2 + b ^ 2 = c ^ 2 → a * b * c = 0) :
+    (n : ℤ) ∣ x * y * z := by
+  have hzero : ((x * y * z : ℤ) : ZMod n) = 0 := by
+    push_cast
+    exact key _ _ _ (zmod_rel n h)
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ n).1 hzero
+
+/-- **`3 ∣ xyz`** for every Pythagorean triple: one of the three sides is a multiple of `3`. -/
+theorem three_dvd_prod {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) : (3 : ℤ) ∣ x * y * z := by
+  have key : ∀ a b c : ZMod 3, a ^ 2 + b ^ 2 = c ^ 2 → a * b * c = 0 := by decide
+  exact_mod_cast dvd_prod_of_zmod h key
+
+/-- **`5 ∣ xyz`** for every Pythagorean triple: one of the three sides is a multiple of `5`. -/
+theorem five_dvd_prod {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) : (5 : ℤ) ∣ x * y * z := by
+  have key : ∀ a b c : ZMod 5, a ^ 2 + b ^ 2 = c ^ 2 → a * b * c = 0 := by decide
+  exact_mod_cast dvd_prod_of_zmod h key
+
+/-- **`4 ∣ xyz`** for every Pythagorean triple.  This is not visible modulo `4` (the residues
+`(1,2,1)` give product `2`), so the obstruction is read off modulo `8`: there the relation
+`a²+b²=c²` forces the product to reduce to `0` in `ZMod 4`. -/
+theorem four_dvd_prod {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) : (4 : ℤ) ∣ x * y * z := by
+  -- Finite check modulo `8`, landing in `ZMod 4` via the canonical ring map.
+  have key : ∀ a b c : ZMod 8, a ^ 2 + b ^ 2 = c ^ 2 →
+      (ZMod.castHom (show (4 : ℕ) ∣ 8 by norm_num) (ZMod 4)) (a * b * c) = 0 := by decide
+  have h8 := key _ _ _ (zmod_rel 8 h)
+  have e : (x : ZMod 8) * (y : ZMod 8) * (z : ZMod 8) = ((x * y * z : ℤ) : ZMod 8) := by
+    push_cast; ring
+  rw [e, map_intCast] at h8
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ 4).1 h8
+
+/-- **The divisibility package.**  `60 ∣ x·y·z` for *every* Pythagorean triple `x²+y²=z²`,
+combining the `3`-, `4`- and `5`-obstructions through pairwise coprimality. -/
+theorem sixty_dvd_prod {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) : (60 : ℤ) ∣ x * y * z := by
+  have h3 := three_dvd_prod h
+  have h4 := four_dvd_prod h
+  have h5 := five_dvd_prod h
+  -- `3` and `4` are coprime, so `12 ∣ xyz`; `12` and `5` are coprime, so `60 ∣ xyz`.
+  have h12 : (12 : ℤ) ∣ x * y * z := by
+    have hcop : IsCoprime (3 : ℤ) 4 := by
+      rw [Int.isCoprime_iff_gcd_eq_one]; decide
+    have := hcop.mul_dvd h3 h4
+    norm_num at this; exact this
+  have hcop : IsCoprime (12 : ℤ) 5 := by
+    rw [Int.isCoprime_iff_gcd_eq_one]; decide
+  have := hcop.mul_dvd h12 h5
+  norm_num at this; exact this
+
+/-- The same package phrased through Mathlib's `PythagoreanTriple` structure. -/
+theorem sixty_dvd_prod_of_pythagoreanTriple {x y z : ℤ} (h : PythagoreanTriple x y z) :
+    (60 : ℤ) ∣ x * y * z :=
+  sixty_dvd_prod (by have := h.eq; ring_nf; ring_nf at this; linarith)
+
+/-! ### Concrete instances -/
+
+/-- `(3,4,5)`: the product `60` is exactly divisible by `60`. -/
+theorem example_3_4_5 : (60 : ℤ) ∣ 3 * 4 * 5 := sixty_dvd_prod (by norm_num)
+
+/-- `(5,12,13)`: `60 ∣ 5·12·13 = 780`. -/
+theorem example_5_12_13 : (60 : ℤ) ∣ 5 * 12 * 13 := sixty_dvd_prod (by norm_num)
+
+/-- `(8,15,17)`: `60 ∣ 8·15·17 = 2040`. -/
+theorem example_8_15_17 : (60 : ℤ) ∣ 8 * 15 * 17 := sixty_dvd_prod (by norm_num)
+
+/-- `(20,21,29)`: `60 ∣ 20·21·29`, an instance where no side is a multiple of `5`'s neighbour
+yet the package still applies (here `5 ∣ 20`). -/
+theorem example_20_21_29 : (60 : ℤ) ∣ 20 * 21 * 29 := sixty_dvd_prod (by norm_num)
+
+end PythagoreanTriples60

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "pythagorean-triples-oq-06-oq-01-oq-01",
+  "slug": "pythagorean-triples-oq-06-oq-01-oq-01",
+  "title": "The full divisibility package for Pythagorean triples: 60 ∣ xyz",
+  "description": "Every Pythagorean triple x² + y² = z² satisfies 60 ∣ x·y·z, with no primitivity hypothesis. The factors 3, 4, 5 of 60 are each forced by a finite congruence obstruction checked by `decide` over ZMod 3, ZMod 8 → ZMod 4, and ZMod 5.",
+  "overview": "The parent entry pythagorean-triples-oq-06-oq-01 records the parity structure of primitive triples — one leg even, the even leg divisible by 4, the hypotenuse odd. This entry answers its open question by assembling the full divisibility package: the product of the three sides of any Pythagorean triple is divisible by 60.\n\nThe key observation is that each prime-power factor of 60 = 4·3·5 is forced by a *finite congruence obstruction*, decidable by exhaustive check over a small residue ring:\n\n• Modulo 3, the squares are {0, 1}; a finite check shows every solution of a² + b² = c² over ZMod 3 already has a·b·c = 0. Hence 3 divides one of the three sides.\n• Modulo 5, the squares are {0, 1, 4}; the same finite check over ZMod 5 gives a·b·c = 0, so 5 divides one side.\n• The factor 4 is invisible modulo 4 (the residues (1, 2, 1) satisfy 1 + 0 = 1 with product 2), so the obstruction is read modulo 8, where 1 + 4 = 5 is not a square and rules those residues out. The finite check is run for the composite ring map ZMod 8 → ZMod 4, certifying that the product reduces to 0 in ZMod 4, i.e. 4 ∣ xyz.\n\nCombining the three divisibilities through the pairwise coprimality of 3, 4, 5 (via IsCoprime.mul_dvd) yields 60 ∣ xyz. The whole argument is 0-axiom and uses only kernel `decide` over small ZMod rings plus elementary coprimality.",
+  "conclusion": "Mathlib has the m²−n², 2mn, m²+n² classification of Pythagorean triples but no divisibility package; this entry supplies the headline 60 ∣ xyz together with its three prime-power components, all without any primitivity hypothesis. The proof exemplifies the 'finite congruence obstruction' technique: a number-theoretic divisibility that holds for all integer solutions of a quadratic relation is reduced to a decidable check over a finite residue ring — including the subtlety that the factor 4 requires lifting from ZMod 4 to ZMod 8.",
+  "sections": [
+    {
+      "title": "Transporting the relation to ZMod n",
+      "content": "`zmod_rel` casts an integer Pythagorean relation x² + y² = z² into the ring ZMod n via the canonical ring homomorphism, which preserves addition and squaring. This is the bridge from the Diophantine equation to the finite decidable checks."
+    },
+    {
+      "title": "The direct obstructions: 3 and 5",
+      "content": "`dvd_prod_of_zmod` packages the pattern: if over ZMod n every solution of a² + b² = c² has a·b·c = 0, then n ∣ xyz. For n = 3 and n = 5 the hypothesis is closed by `decide` (27 and 125 triples respectively), giving `three_dvd_prod` and `five_dvd_prod`."
+    },
+    {
+      "title": "The factor 4 via ZMod 8",
+      "content": "`four_dvd_prod` handles the subtle factor. Because 4 ∣ xyz is false at the level of ZMod 4, the check is performed over ZMod 8, where a² + b² = c² excludes the offending residues, and the product is certified to vanish in ZMod 4 through the ring map ZMod 8 → ZMod 4 (ZMod.castHom). The conclusion 4 ∣ xyz follows from ZMod.intCast_zmod_eq_zero_iff_dvd."
+    },
+    {
+      "title": "Assembling 60 ∣ xyz",
+      "content": "`sixty_dvd_prod` combines the three components: 3 and 4 are coprime so 12 ∣ xyz, and 12 and 5 are coprime so 60 ∣ xyz (IsCoprime.mul_dvd). A `PythagoreanTriple`-structure wrapper and four concrete instances — (3,4,5), (5,12,13), (8,15,17), (20,21,29) — round out the file."
+    }
+  ],
+  "references": [
+    {
+      "title": "Pythagorean triple — divisibility properties",
+      "url": "https://en.wikipedia.org/wiki/Pythagorean_triple"
+    },
+    {
+      "title": "Mathlib: Mathlib.NumberTheory.PythagoreanTriples",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/PythagoreanTriples.html"
+    }
+  ],
+  "crossReferences": [
+    "pythagorean-triples-oq-06-oq-01"
+  ],
+  "openQuestions": [
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+      "question": "Refine the package structurally for primitive triples: prove that 3 and 5 never divide the hypotenuse z (so the obstruction always falls on a leg), and that the even leg is divisible by 4 — pinning the location of each prime factor rather than only its presence in the product.",
+      "significance": "medium"
+    },
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-02",
+      "question": "Identify the largest constant C such that C ∣ xyz for every Pythagorean triple, and prove 60 is sharp by exhibiting a triple whose product is not divisible by any prime power beyond those in 60 (e.g. (3,4,5) with xyz = 60).",
+      "significance": "low"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "imports": ["Mathlib"],
+    "lineCount": 115,
+    "namespace": "PythagoreanTriples60",
+    "opens": [],
+    "path": "Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean",
+    "sorries": 0,
+    "theoremCount": 11
+  },
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "pythagorean-triples",
+      "divisibility",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 115,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "An integer's cast to ZMod n vanishes iff n divides it — turns each finite ZMod check into an integer divisibility statement",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.castHom",
+        "description": "The canonical ring map ZMod 8 → ZMod 4 (since 4 ∣ 8), used to read the 4-obstruction off the level-8 check",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "IsCoprime.mul_dvd",
+        "description": "Coprime divisors multiply: combines 3 ∣ xyz, 4 ∣ xyz, 5 ∣ xyz into 60 ∣ xyz",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "PythagoreanTriple.eq",
+        "description": "Unfolds Mathlib's PythagoreanTriple structure to x*x + y*y = z*z for the structure-level wrapper",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      }
+    ],
+    "originalContributions": [
+      "sixty_dvd_prod: 60 ∣ x·y·z for every Pythagorean triple x²+y²=z² — the headline divisibility package, not present in Mathlib, requiring no primitivity hypothesis",
+      "four_dvd_prod: 4 ∣ xyz proved via the ZMod 8 → ZMod 4 lift, correctly handling the fact that the factor 4 is invisible modulo 4 alone",
+      "three_dvd_prod / five_dvd_prod: the 3- and 5-obstructions as finite ZMod checks via the reusable dvd_prod_of_zmod packaging",
+      "dvd_prod_of_zmod: a reusable lemma converting a decidable congruence obstruction over ZMod n into an integer divisibility of the product",
+      "Concrete instances (3,4,5), (5,12,13), (8,15,17), (20,21,29) exercising the general theorem"
+    ],
+    "prerequisites": [
+      "Pythagorean triples (integer solutions of x² + y² = z²)",
+      "Modular arithmetic and quadratic residues modulo 3, 5, and 8",
+      "ZMod ring homomorphisms and the intCast-is-zero divisibility criterion",
+      "Coprimality and combining divisors (IsCoprime.mul_dvd)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of `pythagorean-triples-oq-06-oq-01` (*"strengthen to the divisibility package … hence 60 ∣ xyz"*) with the headline result:

> **`sixty_dvd_prod` — `60 ∣ x·y·z` for every Pythagorean triple `x² + y² = z²`** (no primitivity hypothesis).

Mathlib has the `m²−n²`, `2mn`, `m²+n²` classification but **no divisibility package**; this supplies it.

## Method — finite congruence obstructions

Each prime-power factor of `60 = 4·3·5` is forced by a decidable check over a small residue ring (kernel `decide`, **not** `native_decide` — 0 axioms beyond `propext`/`Classical.choice`/`Quot.sound`):

| factor | ring | why |
|--------|------|-----|
| `3 ∣ xyz` | `ZMod 3` | squares are `{0,1}`; any `a²+b²=c²` has `a·b·c=0` |
| `5 ∣ xyz` | `ZMod 5` | squares are `{0,1,4}`; likewise `a·b·c=0` |
| `4 ∣ xyz` | `ZMod 8 → ZMod 4` | invisible mod 4 (residues `(1,2,1)` give product `2`); mod 8 excludes them since `1+4=5` is a non-square |

Combined via `IsCoprime.mul_dvd` (3, 4, 5 pairwise coprime).

## Contents

- `zmod_rel`, `dvd_prod_of_zmod` — reusable obstruction packaging
- `three_dvd_prod`, `four_dvd_prod`, `five_dvd_prod`, `sixty_dvd_prod`
- `sixty_dvd_prod_of_pythagoreanTriple` — `PythagoreanTriple`-structure wrapper
- Instances: `(3,4,5)`, `(5,12,13)`, `(8,15,17)`, `(20,21,29)`

## Verification

- 11 theorems / 115 lines, **0 sorries, 0 axioms** (`#print axioms sixty_dvd_prod` → `[propext, Classical.choice, Quot.sound]`)
- Builds clean via host `lake env lean`
- badge: `original`, status: `verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)