### PR TITLE
research(cantor-diagonalization-oq-04-oq-01-oq-01-oq-01): Cantor & presheaf fixed points as instances of Lawvere's CCC theorem [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -544,6 +544,7 @@ import Proofs.CantorDiagonalizationOQ03OQ01OQ04
 import Proofs.CantorDiagonalizationOQ04
 import Proofs.CantorDiagonalizationOQ04OQ01
 import Proofs.CantorDiagonalizationOQ04OQ01OQ01
+import Proofs.CantorDiagonalizationOQ04OQ01OQ01OQ01
 import Proofs.CantorDiagonalizationOQ04OQ01OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03
 import Proofs.CantorDiagonalizationOQ04OQ03Aristotle

--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean
@@ -1,0 +1,159 @@
+import Mathlib
+import Proofs.CantorDiagonalizationOQ04OQ01OQ01
+
+/-
+# Instantiating Lawvere's Fixed-Point Theorem in `Type` and Presheaf Topoi
+
+## Open Question (cantor-diagonalization-oq-04-oq-01-oq-01-oq-01)
+"Instantiate this CCC theorem in concrete categories: derive Cantor's theorem in
+`Type` (no surjection `A → (A → Bool)`) and the fixed-point form in a presheaf
+topos as corollaries of `lawvere_fixedPoint`, by exhibiting the `CartesianClosed`
+instances and a fixed-point-free `t`."
+
+## Answer: YES.
+
+The parent entry (`cantor-diagonalization-oq-04-oq-01-oq-01`) proves
+`LawvereCCC.lawvere_fixedPoint` at full categorical generality: in *any* cartesian
+closed category, a point-surjective `φ : A ⟶ (A ⟹ B)` forces every endomorphism
+`t : B ⟶ B` to have a fixed global point.  This file cashes that abstract theorem
+out in the two standard models.
+
+### The bridge: categorical point-surjectivity is honest surjectivity in `Type`
+
+The only real work is translating the categorical vocabulary into set-theoretic
+language for `C = Type u`, where Mathlib supplies `CartesianClosed (Type u)`:
+
+* the monoidal unit is `𝟙_ (Type u) = PUnit`, so a **global point** `𝟙_ ⟶ A` is
+  literally a function `PUnit → A`, i.e. an element `a PUnit.unit : A`;
+* the exponential is `A ⟹ B = (A → B)`, and **evaluation** `exp.ev` is honest
+  function application `(a, h) ↦ h a` (`ev_apply`);
+* hence `uncurry g (a, y) = g y a` (`uncurry_apply`), and the *name* of `f : A → B`
+  evaluates to `f` itself: `name f PUnit.unit = f` (`name_apply`).
+
+These collapse `LawvereCCC.PointSurjective φ` to `Function.Surjective φ`
+(`pointSurjective_iff_surjective`).  Feeding a **fixed-point-free** endomorphism
+through `lawvere_cantor` then yields the diagonal theorems.
+
+### Results
+* `ev_apply`, `uncurry_apply`, `name_apply` — the computational bridge in `Type`.
+* `pointSurjective_iff_surjective` — `PointSurjective φ ↔ Function.Surjective φ`.
+* `no_surjective_of_fixedPointFree` — for any `t : B → B` with no fixed point there
+  is no surjection `A → (A → B)`.  This is Lawvere's diagonal in `Type`.
+* `cantor_no_surjective` — **Cantor**: no surjection `A → (A → Bool)`, from the
+  fixed-point-free `t = (!·)`.
+* `lawvere_fixedPoint_presheaf`, `lawvere_cantor_presheaf` — the fixed-point form
+  and its contrapositive in a presheaf topos `C ⥤ Type u`, using Mathlib's
+  `CartesianClosed (C ⥤ Type u)` instance.
+
+Everything is machine-checked with no `sorry` and no new axioms.
+-/
+
+universe u v
+
+open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
+open CategoryTheory.MonoidalCategory CategoryTheory.CartesianMonoidalCategory
+open CategoryTheory.CartesianClosed
+open LawvereCCC
+
+namespace LawvereType
+
+section TypeBridge
+
+variable {A B X Y : Type u}
+
+/-- **Evaluation in `Type` is honest application.**  The cartesian-closed
+evaluation `exp.ev A` is, on the model `A ⟹ X = (A → X)`, the map
+`(a, h) ↦ h a`. -/
+lemma ev_apply (a : A) (h : A ⟹ X) : (exp.ev A).app X (a, h) = h a := rfl
+
+/-- **Uncurrying in `Type` is honest application.**  For `g : Y ⟶ (A ⟹ X)`,
+`uncurry g (a, y) = g y a`. -/
+lemma uncurry_apply (g : Y ⟶ (A ⟹ X)) (a : A) (y : Y) :
+    (CartesianClosed.uncurry g) (a, y) = g y a := by
+  rw [CartesianClosed.uncurry_eq, types_comp_apply, whiskerLeft_apply, ev_apply]
+
+/-- **The name of `f` evaluates to `f`.**  In `Type`, the categorical *name*
+`name f : 𝟙_ ⟶ (A ⟹ B)` of a function `f : A → B` is the global point picking out
+`f` itself: `name f PUnit.unit = f`. -/
+lemma name_apply (f : A ⟶ B) : (name f) PUnit.unit = f := by
+  funext a
+  have h1 : CartesianClosed.uncurry (name f) = (ρ_ A).hom ≫ f := by
+    rw [name_def, uncurry_curry]
+  have h2 := congrFun h1 (a, PUnit.unit)
+  rw [uncurry_apply] at h2
+  rw [types_comp_apply, rightUnitor_hom_apply] at h2
+  exact h2
+
+/-- **Categorical point-surjectivity is honest surjectivity in `Type`.**  For a
+function `φ : A → (A → B)`, viewed as a morphism `A ⟶ (A ⟹ B)`, the categorical
+`PointSurjective φ` is equivalent to `Function.Surjective φ`. -/
+theorem pointSurjective_iff_surjective (φ : A ⟶ (A ⟹ B)) :
+    PointSurjective φ ↔ Function.Surjective φ := by
+  constructor
+  · intro hφ h
+    obtain ⟨a, ha⟩ := hφ h
+    refine ⟨a PUnit.unit, ?_⟩
+    have := congrFun ha PUnit.unit
+    rwa [types_comp_apply, name_apply] at this
+  · intro hsurj f
+    obtain ⟨a, ha⟩ := hsurj f
+    refine ⟨fun _ => a, ?_⟩
+    funext u
+    have hu : u = PUnit.unit := rfl
+    rw [types_comp_apply, hu, name_apply]
+    exact ha
+
+/-- **Lawvere's diagonal argument in `Type`.**  If `t : B → B` has no fixed point,
+then there is no surjection `A → (A → B)`.  This is the decategorification of
+`lawvere_cantor`: the diagonal `f a = t (φ a a)` would be a value `φ a` of a
+surjection, but then `t` would fix `f a`. -/
+theorem no_surjective_of_fixedPointFree {t : B → B} (ht : ∀ b, t b ≠ b)
+    (φ : A → (A → B)) : ¬ Function.Surjective φ := by
+  have hcat : ∀ s : 𝟙_ (Type u) ⟶ B, ¬ IsFixedPoint (t : B ⟶ B) s := by
+    intro s hs
+    have h := congrFun hs PUnit.unit
+    rw [types_comp_apply] at h
+    exact ht (s PUnit.unit) h
+  intro hsurj
+  exact lawvere_cantor hcat φ ((pointSurjective_iff_surjective φ).mpr hsurj)
+
+end TypeBridge
+
+/-- **Cantor's theorem, as a corollary of Lawvere.**  There is no surjection
+`A → (A → Bool)`, because `t = (!·)` is a fixed-point-free endomorphism of `Bool`.
+This recovers the classical diagonal `Function.cantor_surjective` purely from the
+categorical fixed-point theorem. -/
+theorem cantor_no_surjective (A : Type) (φ : A → (A → Bool)) :
+    ¬ Function.Surjective φ :=
+  no_surjective_of_fixedPointFree (t := fun b => !b) Bool.not_ne_self φ
+
+/-- **Existence of a missed map.**  Restating Cantor: for every `φ : A → (A → Bool)`
+some `g : A → Bool` lies outside its image — the diagonal complement. -/
+theorem cantor_exists_missed (A : Type) (φ : A → (A → Bool)) :
+    ∃ g : A → Bool, ∀ a, φ a ≠ g := by
+  by_contra h
+  push_neg at h
+  exact cantor_no_surjective A φ h
+
+section Presheaf
+
+variable {C : Type u} [SmallCategory C] {A B : C ⥤ Type u}
+
+/-- **Lawvere's fixed-point theorem in a presheaf topos.**  Mathlib provides
+`CartesianClosed (C ⥤ Type u)`, so the abstract theorem applies verbatim: a
+point-surjective `φ : A ⟶ (A ⟹ B)` of presheaves forces every endomorphism
+`t : B ⟶ B` to have a fixed global point. -/
+theorem lawvere_fixedPoint_presheaf {φ : A ⟶ (A ⟹ B)} (hφ : PointSurjective φ)
+    (t : B ⟶ B) : ∃ s : 𝟙_ (C ⥤ Type u) ⟶ B, IsFixedPoint t s :=
+  lawvere_fixedPoint hφ t
+
+/-- **The Cantor obstruction in a presheaf topos.**  If a presheaf endomorphism
+`t : B ⟶ B` is fixed-point free, no `φ : A ⟶ (A ⟹ B)` can be point-surjective. -/
+theorem lawvere_cantor_presheaf {t : B ⟶ B}
+    (ht : ∀ s : 𝟙_ (C ⥤ Type u) ⟶ B, ¬ IsFixedPoint t s)
+    (φ : A ⟶ (A ⟹ B)) : ¬ PointSurjective φ :=
+  lawvere_cantor ht φ
+
+end Presheaf
+
+end LawvereType

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+  "slug": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CantorDiagonalizationOQ04OQ01OQ01"
+    ],
+    "opens": [
+      "CategoryTheory",
+      "CategoryTheory.Category",
+      "CategoryTheory.Limits",
+      "CategoryTheory.MonoidalCategory",
+      "CategoryTheory.CartesianMonoidalCategory",
+      "CategoryTheory.CartesianClosed",
+      "LawvereCCC"
+    ],
+    "namespace": "LawvereType",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Cantor and Presheaf Fixed Points as Instances of Lawvere's Theorem",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean",
+    "tags": [
+      "category-theory",
+      "cartesian-closed-category",
+      "lawvere",
+      "cantor",
+      "diagonal-argument",
+      "fixed-point",
+      "presheaf-topos",
+      "type-theory",
+      "instantiation",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 159,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "pointSurjective_iff_surjective: the categorical-to-set bridge — in Type u, LawvereCCC.PointSurjective φ is equivalent to honest Function.Surjective φ, collapsing global points 𝟙_ ⟶ A to elements and the exponential A ⟹ B to A → B",
+      "ev_apply / uncurry_apply: the cartesian-closed evaluation exp.ev and uncurrying in Type are honest function application ((a, h) ↦ h a, uncurry g (a, y) = g y a), proved from Mathlib's Types.tensorProductAdjunction",
+      "name_apply: the categorical name 𝟙_ ⟶ (A ⟹ B) of f : A → B evaluates back to f itself (name f PUnit.unit = f)",
+      "no_surjective_of_fixedPointFree: Lawvere's diagonal in Type — any fixed-point-free t : B → B forbids a surjection A → (A → B), derived as a corollary of the parent's lawvere_cantor",
+      "cantor_no_surjective: Cantor's theorem (no surjection A → (A → Bool)) recovered from the categorical fixed-point theorem via the fixed-point-free negation t = (!·)",
+      "lawvere_fixedPoint_presheaf / lawvere_cantor_presheaf: the fixed-point form and its Cantor obstruction in a presheaf topos C ⥤ Type u, via Mathlib's CartesianClosed (C ⥤ Type u) instance",
+      "Answers the parent's headline open question by instantiating the abstract CCC Lawvere theorem in the two standard models (Type and presheaf topoi)"
+    ],
+    "prerequisites": [
+      "Parent: CantorDiagonalizationOQ04OQ01OQ01 (Lawvere's fixed-point theorem in any CCC)",
+      "Cartesian closed structure on Type (Mathlib.CategoryTheory.Monoidal.Closed.Types): the adjunction tensorLeft A ⊣ coyoneda.obj (op A)",
+      "Cartesian closed structure on presheaf categories C ⥤ Type u",
+      "Monoidal structure on Type: 𝟙_ (Type u) = PUnit, X ⊗ Y = X × Y, evaluation as application",
+      "Cantor's diagonal argument (1891); Lawvere's fixed-point theorem (1969)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "CategoryTheory.CartesianClosed (Type v₁)",
+        "description": "The cartesian closed instance on Type, built from Types.tensorProductAdjunction; supplies the exponential A ⟹ B = (A → B) and evaluation",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Types"
+      },
+      {
+        "theorem": "CategoryTheory.CartesianClosed (C ⥤ Type v₁)",
+        "description": "The cartesian closed instance on presheaf categories, used to apply the abstract Lawvere theorem in a topos",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Types"
+      },
+      {
+        "theorem": "CartesianClosed.uncurry_eq",
+        "description": "uncurry g = (A ◁ g) ≫ (exp.ev A).app X — reduces uncurrying to whiskering followed by evaluation, the key step in uncurry_apply",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Cartesian"
+      },
+      {
+        "theorem": "CartesianClosed.uncurry_curry",
+        "description": "uncurry (curry f) = f — turns the named diagonal back into a morphism for name_apply",
+        "module": "Mathlib.CategoryTheory.Monoidal.Closed.Cartesian"
+      },
+      {
+        "theorem": "CategoryTheory.types_comp_apply",
+        "description": "(f ≫ g) x = g (f x) — composition in Type is function composition, used throughout the bridge",
+        "module": "Mathlib.CategoryTheory.Types"
+      },
+      {
+        "theorem": "Bool.not_ne_self",
+        "description": "(!b) ≠ b — the fixed-point-free witness on Bool that drives Cantor's theorem",
+        "module": "Mathlib.Data.Bool.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01-oq-01",
+      "question": "Give a genuinely non-Type presheaf instance: pick a small category C and a presheaf B ∈ C ⥤ Type with a concrete fixed-point-free endomorphism (computed on global sections, i.e. natural transformations 𝟙_ ⟶ B), and exhibit the resulting Cantor obstruction explicitly rather than only abstractly.",
+      "significance": "medium"
+    },
+    {
+      "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01-oq-02",
+      "question": "Strengthen pointSurjective_iff_surjective to other concrete CCCs (e.g. the category of pointed sets, or G-sets for a group G), identifying for each model what 'global point' and 'point-surjective' decode to, and which Cantor-type obstructions survive.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cantor-diagonalization-oq-04-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: Lawvere's fixed-point theorem in an arbitrary cartesian closed category. This file cashes out that abstract theorem in the two standard models — Type and presheaf topoi — by proving the categorical-to-set bridge pointSurjective_iff_surjective and feeding fixed-point-free endomorphisms through lawvere_cantor."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "specializes-to",
+      "description": "cantor_no_surjective is the original Cantor diagonal: no surjection A → (A → Bool). Here it is obtained purely as the C = Type instance of the categorical lawvere_cantor with the fixed-point-free negation t = (!·)."
+    },
+    {
+      "targetId": "cantor-diagonalization-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Grandparent setoid generalization. The Type bridge here makes precise the decategorification the grandparent gestured at: global points 𝟙_ ⟶ A are elements and name is the curry isomorphism."
+    }
+  ],
+  "references": [
+    {
+      "title": "Diagonal arguments and cartesian closed categories",
+      "author": "F. William Lawvere",
+      "year": "1969",
+      "venue": "Lecture Notes in Mathematics, Vol. 92, Springer, pp. 134–145",
+      "description": "Original source. The Type and presheaf instances formalized here are exactly the corollaries Lawvere highlights: Cantor in Set and the topos-theoretic fixed-point phenomenon."
+    },
+    {
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "author": "Georg Cantor",
+      "year": "1891",
+      "venue": "Jahresbericht der DMV 1, 75–78",
+      "description": "Cantor's diagonal argument |Y| < |2^Y|; recovered as cantor_no_surjective."
+    },
+    {
+      "title": "A universal approach to self-referential paradoxes, incompleteness and fixed points",
+      "author": "Noson S. Yanofsky",
+      "year": "2003",
+      "venue": "Bulletin of Symbolic Logic 9(3), 362–386",
+      "description": "Exposition of the point-surjectivity formulation; the Type-level reading PointSurjective ↔ Surjective made formal here follows Yanofsky."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The abstract Lawvere fixed-point theorem of the parent entry is instantiated in its two standard models. For C = Type u, a short computational bridge identifies the categorical data with set-theoretic data: the monoidal unit is PUnit so global points 𝟙_ ⟶ A are elements, the exponential A ⟹ B is the function type A → B, and evaluation/uncurrying are honest application (ev_apply, uncurry_apply); consequently the name of f evaluates back to f (name_apply), and categorical point-surjectivity coincides with honest surjectivity (pointSurjective_iff_surjective). Feeding a fixed-point-free t : B → B through lawvere_cantor yields no_surjective_of_fixedPointFree, of which Cantor's theorem cantor_no_surjective (no surjection A → (A → Bool), via t = negation) is the headline instance. For presheaf topoi C ⥤ Type u, Mathlib's CartesianClosed instance lets the abstract theorem apply verbatim (lawvere_fixedPoint_presheaf, lawvere_cantor_presheaf). 159 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This resolves the parent's headline open question. The single non-formal modelling choice in the parent — using point-surjectivity and global points rather than Lean-level surjections and elements — is here shown to be a faithful one in Type: the categorical hypothesis decodes exactly to the classical one, so Cantor's theorem is literally a corollary of the categorical Lawvere theorem, not merely an analogue. The presheaf instances confirm the same machine applies unchanged in a genuine topos, isolating the Cantor/Russell/Gödel/Tarski/Turing diagonal as one categorical statement.",
+    "openQuestions": [
+      "Exhibit a concrete non-Type presheaf B with a fixed-point-free endomorphism on global sections and the explicit Cantor obstruction it produces.",
+      "Decode pointSurjective_iff_surjective in other concrete cartesian closed categories (pointed sets, G-sets), identifying the surviving Cantor-type obstructions.",
+      "Upstream candidate: the Type bridge (ev_apply, uncurry_apply, pointSurjective_iff_surjective) alongside the parent's lawvere_fixedPoint for Mathlib's CategoryTheory.Closed namespace."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's headline open question (`cantor-diagonalization-oq-04-oq-01-oq-01`) by **instantiating the abstract Lawvere fixed-point theorem in its two standard models** — `Type` and presheaf topoi — as genuine corollaries of `LawvereCCC.lawvere_fixedPoint` / `lawvere_cantor`.

## The Type bridge (the only real work)

In `Type u`, Mathlib's `CartesianClosed (Type u)` decodes the categorical data set-theoretically:
- the monoidal unit is `𝟙_ (Type u) = PUnit`, so a **global point** `𝟙_ ⟶ A` is an element `a PUnit.unit : A`;
- the exponential is `A ⟹ B = (A → B)`, and **evaluation** `exp.ev` / uncurrying are honest application — `ev_apply`, `uncurry_apply`;
- hence the categorical *name* of `f` evaluates back to `f` — `name_apply`.

These collapse `PointSurjective φ` to `Function.Surjective φ`:
- **`pointSurjective_iff_surjective`** — `PointSurjective φ ↔ Function.Surjective φ` in `Type`.

Feeding a fixed-point-free endomorphism through the parent's `lawvere_cantor`:
- **`no_surjective_of_fixedPointFree`** — any `t : B → B` with no fixed point forbids a surjection `A → (A → B)`;
- **`cantor_no_surjective`** — **Cantor's theorem**: no surjection `A → (A → Bool)`, from `t = (!·)`;
- **`cantor_exists_missed`** — the diagonal-complement restatement.

## Presheaf topos

Mathlib's `CartesianClosed (C ⥤ Type u)` lets the abstract theorem apply verbatim:
- **`lawvere_fixedPoint_presheaf`**, **`lawvere_cantor_presheaf`** — the fixed-point form and its Cantor obstruction in a presheaf topos.

## Significance

The parent left the modelling choice (point-surjectivity + global points vs. Lean surjections + elements) un-validated. Here it is shown **faithful in `Type`**: the categorical hypothesis decodes exactly to the classical one, so Cantor is *literally* a corollary of the categorical Lawvere theorem, not merely an analogue.

## Verification

- 159 lines, 9 theorems, 0 definitions, **0 axioms, 0 sorries**
- `#print axioms` on all headline theorems → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`)
- Builds on `Proofs.CantorDiagonalizationOQ04OQ01OQ01` (host `lake env lean`, EXIT 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)