### PR TITLE
Enrich catenary arc-length / √(1+t²) antiderivative (arsinh-log-formula-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "concept",
+    "title": "Closing the arsinh calculus loop with the catenary",
+    "content": "The parent entry `arsinh-log-formula-oq-01-oq-01` proved that `arsinh` is the antiderivative of `1/√(1+t²)`. This child runs the same machinery on the *conjugate* integrand `√(1+t²)` and harvests the geometric payoff: the arc length of the catenary `y = cosh x` over `[0,b]` is the strikingly simple `sinh b`. The two integrands `1/√(1+t²)` and `√(1+t²)` are the two faces of the hyperbolic substitution `t = sinh u` (under which `√(1+t²) = cosh u`), so together the parent and this entry complete the elementary arsinh-substitution table. The catch is that Mathlib supplies the `arsinh` and `sinh` derivatives but NO antiderivative for `√(1+t²)`, so the central derivative is hand-built here; everything else follows from the Fundamental Theorem of Calculus.",
+    "mathContext": "$\\int_0^b \\sqrt{1+t^2}\\,dt = \\tfrac12\\big(b\\sqrt{1+b^2}+\\operatorname{arsinh} b\\big)$; arc length of $y=\\cosh x$ over $[0,b]$ is $\\sinh b$.",
+    "significance": "key",
+    "relatedConcepts": ["catenary", "arc length", "hyperbolic substitution", "arsinh", "antiderivatives"],
+    "prerequisites": ["integral calculus", "hyperbolic functions", "the Fundamental Theorem of Calculus"]
+  },
+  {
+    "id": "ann-radicand-api",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 45 },
+    "type": "technique",
+    "title": "Radicand API: positivity and the √² identity",
+    "content": "Two small but load-bearing facts about the radicand `1 + t²`. `sqrt_one_add_sq_pos` proves `√(1+t²) > 0` (the radicand is `≥ 1 > 0`, so `Real.sqrt_pos` applies) — needed both to invoke the chain rule for `√` (which requires the inner function nonzero) and to clear denominators safely. `sq_sqrt_one_add_sq` proves `(√(1+t²))² = 1+t²` via `Real.sq_sqrt` on the nonnegative radicand — the identity that lets the messy derivative collapse algebraically. Neither is deep, but both are exactly the side conditions the later `field_simp`/`nlinarith` steps consume.",
+    "mathContext": "$1+t^2 \\ge 1 > 0 \\Rightarrow \\sqrt{1+t^2} > 0$ and $(\\sqrt{1+t^2})^2 = 1+t^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sqrt_pos", "Real.sq_sqrt", "positivity", "side conditions"],
+    "prerequisites": ["properties of the real square root"]
+  },
+  {
+    "id": "ann-antiderivative",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 78 },
+    "type": "insight",
+    "title": "The hand-built antiderivative: d/dt[½(t√(1+t²)+arsinh t)] = √(1+t²)",
+    "content": "`hasDerivAt_sqrtAntideriv` is the crux of the entire file — the derivative computation Mathlib does not provide. Starting from `F(t) = ½(t·√(1+t²) + arsinh t)`, three rules are composed: `hasDerivAt_pow` gives `d/dt(1+t²)=2t`; `HasDerivAt.sqrt` (the chain rule for `√`, valid since `1+t²≠0`) gives `d/dt √(1+t²) = 2t/(2√(1+t²))`; the product rule `(id).mul hsqrt` differentiates `t·√(1+t²)`; and `Real.hasDerivAt_arsinh` supplies `d/dt arsinh t = 1/√(1+t²)`. After `.div_const 2`, the raw derivative is `½(√(1+t²) + t·(2t/(2√(1+t²))) + (√(1+t²))⁻¹)`. The **algebraic collapse** is the key: using `(√(1+t²))² = 1+t²`, the term `t²/√(1+t²)` combines with `√(1+t²)` to give `(t²+1)/√(1+t²) = √(1+t²)`, doubling the leading term; the `(√(1+t²))⁻¹` cancels the leftover, and halving recovers exactly `√(1+t²)`. `field_simp` then `nlinarith [hs, hpos]` discharge this.",
+    "mathContext": "$F'(t) = \\tfrac12\\Big(\\sqrt{1+t^2} + \\dfrac{t\\cdot 2t}{2\\sqrt{1+t^2}} + \\dfrac{1}{\\sqrt{1+t^2}}\\Big) = \\tfrac12\\cdot\\dfrac{2(1+t^2)}{\\sqrt{1+t^2}} = \\sqrt{1+t^2}$.",
+    "significance": "key",
+    "relatedConcepts": ["product rule", "chain rule for √", "HasDerivAt.sqrt", "Real.hasDerivAt_arsinh", "field_simp / nlinarith"],
+    "prerequisites": ["differentiation rules", "HasDerivAt in Mathlib", "algebraic manipulation of surds"]
+  },
+  {
+    "id": "ann-integrability",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 88 },
+    "type": "context",
+    "title": "Continuity and interval-integrability of the integrand",
+    "content": "`continuous_sqrt_integrand` proves `t ↦ √(1+t²)` is continuous everywhere (discharged by `fun_prop`, Mathlib's continuity/differentiability automation), and `intervalIntegrable_sqrt_integrand` upgrades this to interval-integrability on every `[a,b]` via `Continuous.intervalIntegrable`. This is the second hypothesis the FTC (`integral_eq_sub_of_hasDerivAt`) requires alongside the antiderivative: the derivative being integrated must be interval-integrable. Continuity is the cleanest sufficient condition and `fun_prop` makes it a one-liner.",
+    "mathContext": "$t\\mapsto\\sqrt{1+t^2}$ continuous $\\Rightarrow$ interval-integrable on every $[a,b]$ (a continuous function on a compact interval is integrable).",
+    "significance": "context",
+    "relatedConcepts": ["continuity", "interval integrability", "fun_prop", "Continuous.intervalIntegrable"],
+    "prerequisites": ["continuous functions are integrable on compact intervals"]
+  },
+  {
+    "id": "ann-ftc-eval",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 108 },
+    "type": "insight",
+    "title": "FTC evaluation and the C = 0 normalisation",
+    "content": "`integral_sqrt_one_add_sq` applies the Fundamental Theorem of Calculus `intervalIntegral.integral_eq_sub_of_hasDerivAt` with the hand-built antiderivative and the integrability lemma to obtain the closed form `∫_a^b √(1+t²) dt = ½(b√(1+b²)+arsinh b) − ½(a√(1+a²)+arsinh a)` — exactly the formula the parent's open question requested. `integral_sqrt_one_add_sq_zero_to` then anchors the constant at `a = 0`: since `arsinh 0 = 0` (and the `0·√` term vanishes), the lower endpoint contributes nothing, giving the normalised `∫_0^b √(1+t²) dt = ½(b√(1+b²)+arsinh b)`. This is the antiderivative with `C = 0`, the standard reference form.",
+    "mathContext": "$\\int_a^b \\sqrt{1+t^2}\\,dt = F(b)-F(a)$ with $F(t)=\\tfrac12(t\\sqrt{1+t^2}+\\operatorname{arsinh} t)$; $F(0)=0$ gives $\\int_0^b = F(b)$.",
+    "significance": "key",
+    "relatedConcepts": ["Fundamental Theorem of Calculus", "closed-form integral", "constant of integration", "arsinh_zero"],
+    "prerequisites": ["the FTC", "definite integrals"]
+  },
+  {
+    "id": "ann-pythagorean",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 117 },
+    "type": "insight",
+    "title": "Why the catenary is simple: √(1 + sinh²x) = cosh x",
+    "content": "`sqrt_one_add_sinh_sq` is the identity that makes the catenary's arc length elementary. The hyperbolic Pythagorean identity `cosh²x = 1 + sinh²x` (`Real.cosh_sq`) rewrites the radicand `1 + sinh²x` as `cosh²x`, and since `cosh x > 0` (`Real.cosh_pos`), `√(cosh²x) = cosh x` exactly (`Real.sqrt_sq`). The geometric meaning: for the catenary `y = cosh x` the arc-length element `√(1 + (y')²) = √(1 + sinh²x)` is *just* `cosh x` — no surd survives. This is the single fact behind the catenary's famously clean length formula.",
+    "mathContext": "$\\sqrt{1+\\sinh^2 x} = \\sqrt{\\cosh^2 x} = \\cosh x$ (using $\\cosh^2 x = 1+\\sinh^2 x$ and $\\cosh x > 0$).",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic Pythagorean identity", "Real.cosh_sq", "Real.cosh_pos", "arc-length element"],
+    "prerequisites": ["hyperbolic identities", "Real.sqrt_sq"]
+  },
+  {
+    "id": "ann-catenary",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 119, "endLine": 135 },
+    "type": "insight",
+    "title": "The headline: catenary arc length over [0,b] is sinh b",
+    "content": "`integral_cosh_zero_to` evaluates `∫_0^b cosh x dx = sinh b` by the FTC, using `Real.hasDerivAt_sinh` (`sinh' = cosh`) and `sinh 0 = 0`. `catenary_arclength` then assembles the headline: rewriting the arc-length integrand by `sqrt_one_add_sinh_sq` turns `∫_0^b √(1 + sinh²x) dx` into `∫_0^b cosh x dx = sinh b`. The whole geometric statement reduces to the Pythagorean simplification plus an elementary integral — the catenary's arc length is literally `sinh b − sinh 0 = sinh b`. This answers the parent entry's open question.",
+    "mathContext": "$\\text{arclength} = \\int_0^b \\sqrt{1+\\sinh^2 x}\\,dx = \\int_0^b \\cosh x\\,dx = \\sinh b - \\sinh 0 = \\sinh b$.",
+    "significance": "key",
+    "relatedConcepts": ["catenary arc length", "Real.hasDerivAt_sinh", "∫ cosh = sinh", "FTC"],
+    "prerequisites": ["the FTC", "derivative of sinh"]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 142 },
+    "type": "context",
+    "title": "A concrete value: ∫₀¹ √(1+t²) dt = ½(√2 + arsinh 1)",
+    "content": "`integral_sqrt_one_add_sq_zero_to_one` specializes the normalised closed form at `b = 1`: `∫_0^1 √(1+t²) dt = ½(√2 + arsinh 1)` (since `√(1+1²) = √2`), closed by `norm_num`. It is a sanity-check instance — a definite number the abstract formula must produce — and the kind of concrete evaluation a reader can verify against tables (numerically `≈ 1.1478`, with `arsinh 1 = ln(1+√2)`).",
+    "mathContext": "$\\int_0^1\\sqrt{1+t^2}\\,dt = \\tfrac12\\big(\\sqrt2 + \\operatorname{arsinh} 1\\big) = \\tfrac12\\big(\\sqrt2 + \\ln(1+\\sqrt2)\\big) \\approx 1.1478$.",
+    "significance": "context",
+    "relatedConcepts": ["concrete evaluation", "arsinh 1 = ln(1+√2)", "norm_num"],
+    "prerequisites": ["the normalised closed form"]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arsinhLogFormulaOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arsinhLogFormulaOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arsinhLogFormulaOq01Oq01Oq01Data: ProofData = {
+  proof: arsinhLogFormulaOq01Oq01Oq01Proof,
+  annotations: arsinhLogFormulaOq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01-oq-01` (Catenary Arc-Length and the Antiderivative of √(1+t²)).

**Gap fixed:** the entry was missing both `index.ts` and `annotations.json`. Without `index.ts` the proof page renders 'proof not found' on the live site.

**Added:**
- `index.ts` — Vite entry point sourcing `Proofs/ArsinhLogFormulaOQ01OQ01OQ01.lean`.
- `annotations.json` — 8 annotations with full file coverage, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Header: closing the arsinh calculus loop via the catenary
  - radicand positivity / √² API
  - `hasDerivAt_sqrtAntideriv` — the hand-built antiderivative and its algebraic collapse `(t²+1)/√(1+t²)=√(1+t²)`
  - continuity / interval-integrability
  - FTC evaluation + C=0 normalisation
  - `sqrt_one_add_sinh_sq` — the Pythagorean catenary simplification
  - `integral_cosh_zero_to` + `catenary_arclength` — arc length = sinh b
  - the concrete ∫₀¹ value

**Verification:** `pnpm annotations:validate` reports 0 errors for this id; JSON parses; meta.json (`verified`, `original` badge, 0 axioms) left unchanged and consistent with the Lean source.