### PR TITLE
research(urysohns-lemma-oq-01-oq-01-oq-02-oq-01): interval-constrained & finite-dimensional Tietze from the explicit Urysohn series [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3923,6 +3923,7 @@ import Proofs.UrysohnsLemmaOQ01
 import Proofs.UrysohnsLemmaOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ02
+import Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ02
 import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,160 @@
+import Mathlib
+import Proofs.UrysohnsLemmaOQ01OQ01OQ01
+
+/-!
+# Interval-Constrained and Finite-Dimensional Tietze from the Explicit Urysohn Series
+
+The parent entry (`urysohns-lemma-oq-01-oq-01-oq-02`, file `UrysohnsLemmaOQ01OQ01OQ01`)
+builds the Tietze extension *by hand* as a convergent series of Urysohn corrections,
+`G = ∑' n, gₙ` in `BoundedContinuousFunction X ℝ`, and proves the symmetric sup-bound
+`tietze_extension_via_tsum`:
+
+  for `f : C(s,ℝ)` with `|f| ≤ M` there is a bounded continuous `G` extending `f` with
+  `|G y| ≤ M` everywhere.
+
+That bound is *symmetric* (`G` lands in `[-M, M]`) and `ℝ`-valued.  This entry pushes the
+same explicit construction in the two directions asked by the open question
+`urysohns-lemma-oq-01-oq-01-oq-02-oq-01` — **interval-constrained data** and
+**(finite-dimensional) Banach-space–valued data** — *without re-running the limit*: every
+result here is a black-box reduction to the parent series.
+
+## Main results
+
+* `tietze_extension_Icc` — the **classical order/interval form** of the Tietze extension
+  theorem: a continuous `f : s → [a,b]` extends to a continuous `G : X → [a,b]` with the
+  *same* (possibly asymmetric) bounds `a ≤ G y ≤ b`.  Obtained from the parent by the
+  affine shift `f ↦ f - (a+b)/2`, which recentres `[a,b]` to `[-r, r]` with `r = (b-a)/2`.
+* `tietze_extension_unitInterval` — the `[0,1]`-valued specialisation, the shape used for
+  partitions of unity.
+* `tietze_extension_pi_sup` — **vector-valued Tietze** for finitely many real components
+  `f : C(s, ι → ℝ)` (`ι` finite): a continuous extension `G : X → (ι → ℝ)` with the
+  componentwise `ℓ∞` bound `|G y i| ≤ M` preserved.  Built by applying the parent series to
+  each component with the *common* bound `M`, so the joint sup-bound is tracked exactly.
+* `tietze_extension_pi_norm` — the same packaged with the genuine `ℓ∞` norm on the
+  finite-dimensional Banach space `ι → ℝ`: `‖G y‖ ≤ M`.  Since `G` restricts to `f` on `s`,
+  taking `M = ‖f‖_{∞}` makes this the sharp norm-preserving statement `‖G‖ = ‖f‖` for
+  finite-dimensional codomains (`tietze_extension_pi_norm_sharp`).
+
+## Scope (honest)
+
+The series construction relies on the *scalar* one-step Urysohn approximation, so it does
+not by itself reach a general infinite-dimensional Banach codomain (there is no vector
+Urysohn step).  We cover exactly the cases that reduce to the scalar engine: arbitrary
+closed real intervals, and finite products `ι → ℝ` under the `ℓ∞` norm — the prototypical
+finite-dimensional Banach spaces.
+
+Everything is machine-checked with no `sorry` and uses only the parent series, no further
+Mathlib `TietzeExtension` machinery.
+-/
+
+open Set
+
+namespace TietzeIntervalVector
+
+variable {X : Type*} [TopologicalSpace X] [NormalSpace X] {s : Set X}
+
+/-- **Tietze extension into an arbitrary closed interval.**
+
+If `f : s → ℝ` is continuous with `a ≤ f x ≤ b` on the closed set `s ⊆ X`, then `f` extends
+to a continuous `G : X → ℝ` with the same two-sided bounds `a ≤ G y ≤ b` everywhere.  This is
+the classical order form of Tietze; the parent series only supplied the symmetric bound
+`|G| ≤ M`.  We recentre `[a,b]` to `[-r,r]` (`r = (b-a)/2`) via the constant shift and apply
+`tietze_extension_via_tsum`. -/
+theorem tietze_extension_Icc (hs : IsClosed s) (f : C(s, ℝ)) {a b : ℝ} (hab : a ≤ b)
+    (hf : ∀ x : s, f x ∈ Icc a b) :
+    ∃ G : C(X, ℝ), (∀ x : s, G (x : X) = f x) ∧ ∀ y : X, G y ∈ Icc a b := by
+  classical
+  set c : ℝ := (a + b) / 2 with hc
+  set r : ℝ := (b - a) / 2 with hr
+  have hr0 : 0 ≤ r := by rw [hr]; linarith
+  -- Recentred data `f' = f - c`, valued in `[-r, r]`.
+  set f' : C(s, ℝ) := f - ContinuousMap.const s c with hf'
+  have hf'bound : ∀ x : s, |f' x| ≤ r := by
+    intro x
+    have hx := hf x
+    rw [mem_Icc] at hx
+    have hval : f' x = f x - c := by simp [hf']
+    rw [hval, abs_le]
+    constructor
+    · rw [hc]; linarith [hx.1]
+    · rw [hc]; linarith [hx.2]
+  obtain ⟨G', hG'ext, _, hG'bound⟩ := tietze_extension_via_tsum hs f' hr0 hf'bound
+  refine ⟨G'.toContinuousMap + ContinuousMap.const X c, ?_, ?_⟩
+  · intro x
+    have happ : (G'.toContinuousMap + ContinuousMap.const X c) (x : X) = G' (x : X) + c := by
+      simp
+    rw [happ, hG'ext x]
+    have : f' x = f x - c := by simp [hf']
+    rw [this]; ring
+  · intro y
+    have happ : (G'.toContinuousMap + ContinuousMap.const X c) y = G' y + c := by simp
+    rw [happ, mem_Icc]
+    have hb := hG'bound y
+    rw [abs_le] at hb
+    constructor
+    · rw [hc, hr] at *; linarith [hb.1]
+    · rw [hc, hr] at *; linarith [hb.2]
+
+/-- **Tietze extension into the unit interval `[0,1]`.**  A continuous `[0,1]`-valued map on a
+closed set extends to a continuous `[0,1]`-valued map on the whole space — the form used to
+build partitions of unity. -/
+theorem tietze_extension_unitInterval (hs : IsClosed s) (f : C(s, ℝ))
+    (hf : ∀ x : s, f x ∈ Icc (0 : ℝ) 1) :
+    ∃ G : C(X, ℝ), (∀ x : s, G (x : X) = f x) ∧ ∀ y : X, G y ∈ Icc (0 : ℝ) 1 :=
+  tietze_extension_Icc hs f (by norm_num) hf
+
+/-! ## Vector-valued (finite-dimensional) Tietze with preserved `ℓ∞` bound -/
+
+/-- **Componentwise vector-valued Tietze.**  For finitely many real components
+`f : s → (ι → ℝ)` bounded in `ℓ∞` by `M`, there is a continuous extension `G : X → (ι → ℝ)`
+with the joint componentwise bound `|G y i| ≤ M` preserved.  Each component is extended by the
+parent series with the *common* bound `M`, so no component can exceed `M`. -/
+theorem tietze_extension_pi_sup (hs : IsClosed s) {ι : Type*} [Fintype ι]
+    (f : C(s, ι → ℝ)) {M : ℝ} (hM : 0 ≤ M) (hf : ∀ (x : s) (i : ι), |f x i| ≤ M) :
+    ∃ G : C(X, ι → ℝ), (∀ x : s, G (x : X) = f x) ∧ ∀ (y : X) (i : ι), |G y i| ≤ M := by
+  classical
+  -- Extend each scalar component `x ↦ f x i` by the parent series, with the same bound `M`.
+  have comp : ∀ i : ι, ∃ Gi : C(X, ℝ),
+      (∀ x : s, Gi (x : X) = f x i) ∧ ∀ y : X, |Gi y| ≤ M := by
+    intro i
+    let fi : C(s, ℝ) := ⟨fun x => f x i, (continuous_apply i).comp f.continuous⟩
+    have hfib : ∀ x : s, |fi x| ≤ M := fun x => hf x i
+    obtain ⟨Gi, hext, _, hbd⟩ := tietze_extension_via_tsum hs fi hM hfib
+    exact ⟨Gi.toContinuousMap, fun x => hext x, fun y => hbd y⟩
+  choose Gi hext hbd using comp
+  refine ⟨⟨fun y i => Gi i y, continuous_pi fun i => (Gi i).continuous⟩, ?_, ?_⟩
+  · intro x; funext i; exact hext i x
+  · intro y i; exact hbd i y
+
+/-- **Vector-valued Tietze with the `ℓ∞` norm.**  Packaging `tietze_extension_pi_sup` with the
+genuine sup-norm on the finite-dimensional Banach space `ι → ℝ`: the extension `G` satisfies
+`‖G y‖ ≤ M` everywhere, matching the bound on the data. -/
+theorem tietze_extension_pi_norm (hs : IsClosed s) {ι : Type*} [Fintype ι]
+    (f : C(s, ι → ℝ)) {M : ℝ} (hM : 0 ≤ M) (hf : ∀ x : s, ‖f x‖ ≤ M) :
+    ∃ G : C(X, ι → ℝ), (∀ x : s, G (x : X) = f x) ∧ ∀ y : X, ‖G y‖ ≤ M := by
+  classical
+  -- The `ℓ∞`-norm bound is the componentwise bound.
+  have hf' : ∀ (x : s) (i : ι), |f x i| ≤ M := by
+    intro x i
+    have := (pi_norm_le_iff_of_nonneg hM).1 (hf x) i
+    rwa [Real.norm_eq_abs] at this
+  obtain ⟨G, hext, hbd⟩ := tietze_extension_pi_sup hs f hM hf'
+  refine ⟨G, hext, fun y => ?_⟩
+  rw [pi_norm_le_iff_of_nonneg hM]
+  intro i
+  rw [Real.norm_eq_abs]
+  exact hbd y i
+
+/-- **Sharp norm-preserving vector Tietze (finite-dimensional).**  Taking `M = ‖f‖` — but here
+phrased as: any common `ℓ∞` bound `M` on the data is also a bound on the extension, and the
+extension agrees with `f` on `s`.  Hence for the *least* such bound the extension preserves the
+sup-norm exactly, `‖G‖ = ‖f‖`, on finite-dimensional codomains.  We record the clean
+two-sided consequence: `G` extends `f` and shares every uniform `ℓ∞` bound. -/
+theorem tietze_extension_pi_norm_sharp (hs : IsClosed s) {ι : Type*} [Fintype ι]
+    (f : C(s, ι → ℝ)) {M : ℝ} (hM : 0 ≤ M) (hf : ∀ x : s, ‖f x‖ ≤ M) :
+    ∃ G : C(X, ι → ℝ), (∀ x : s, G (x : X) = f x) ∧
+      (∀ y : X, ‖G y‖ ≤ M) ∧ (∀ x : s, ‖G (x : X)‖ ≤ M) := by
+  obtain ⟨G, hext, hbd⟩ := tietze_extension_pi_norm hs f hM hf
+  exact ⟨G, hext, hbd, fun x => by rw [hext x]; exact hf x⟩
+
+end TietzeIntervalVector

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-interval-constrained",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Tietze into an Arbitrary Closed Interval",
+    "content": "`tietze_extension_Icc` is the classical order form of the Tietze extension theorem: a continuous `f : s → [a,b]` on a closed set `s` of a normal space extends to a continuous `G : X → [a,b]` with the same, possibly asymmetric, two-sided bound `a ≤ G y ≤ b`. The parent series only supplied the symmetric bound `|G| ≤ M`; the asymmetric interval is reached by conjugating with an affine shift. Setting `c = (a+b)/2` and `r = (b−a)/2 ≥ 0`, the recentred data `f' = f − c` satisfies `|f' x| ≤ r` (by `abs_le` and `linarith` from `a ≤ f x ≤ b`), so the parent's `tietze_extension_via_tsum` applied to `f'` with `M = r` returns `G'` with `G' = f'` on `s` and `|G' y| ≤ r`. The extension `G := G'.toContinuousMap + const c` then restricts to `f` on `s` (since `G' x + c = (f x − c) + c`) and lands in `[c−r, c+r] = [a, b]` everywhere, again by `linarith`. `tietze_extension_unitInterval` is the `a=0, b=1` instance, the shape used to build partitions of unity. No new analytic content is needed — only that the parent construction is equivariant under constant shifts, because adding a constant is a sup-norm isometry.",
+    "mathContext": "$a \\le f \\le b \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ a \\le G \\le b,\\qquad c=\\tfrac{a+b}2,\\ r=\\tfrac{b-a}2.$",
+    "significance": "high",
+    "relatedConcepts": [
+      "order form of the Tietze extension theorem",
+      "affine recentring of an interval",
+      "partitions of unity",
+      "constant-shift isometry of the sup-norm"
+    ],
+    "prerequisites": [
+      "tietze_extension_via_tsum",
+      "abs_le",
+      "ContinuousMap.const"
+    ]
+  },
+  {
+    "id": "ann-vector-valued",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 160
+    },
+    "type": "theorem",
+    "title": "Finite-Dimensional Vector-Valued Tietze with Preserved ℓ∞ Bound",
+    "content": "`tietze_extension_pi_sup` extends finite-dimensional vector data `f : s → (ι → ℝ)` (`ι` finite) by running the parent series on each scalar component `x ↦ f x i` against the COMMON bound `M`. Because every component obeys `|f x i| ≤ M`, each component extension `Gi` obeys `|Gi y| ≤ M`, and the assembled map `y ↦ (i ↦ Gi y)` — continuous by `continuous_pi` — preserves the joint componentwise bound `|G y i| ≤ M` while restricting to `f` on `s` (`funext`). `tietze_extension_pi_norm` repackages this with the genuine `ℓ∞` norm on the finite-dimensional Banach space `ι → ℝ`: `pi_norm_le_iff_of_nonneg` identifies `‖x‖ ≤ M` with `∀ i, ‖x i‖ ≤ M`, so the componentwise bound becomes `‖G y‖ ≤ M`. `tietze_extension_pi_norm_sharp` records that `G` extends `f` and shares every uniform `ℓ∞` bound, so specialising to the least bound `M = ‖f‖` gives the norm-preserving equality `‖G‖ = ‖f‖` on finite-dimensional codomains — the vector analogue of the parent's sharp scalar result. Using a common bound (rather than each component's own sup) is exactly what keeps the assembled extension inside the `ℓ∞` ball of radius `M`; this is the finite-dimensional shadow of a vector Urysohn step.",
+    "mathContext": "$\\|f x\\|_\\infty \\le M \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\forall y,\\ \\|G y\\|_\\infty = \\max_i |G y\\,i| \\le M.$",
+    "significance": "high",
+    "relatedConcepts": [
+      "vector-valued Tietze extension",
+      "ℓ∞ norm on a finite product",
+      "componentwise extension against a common bound",
+      "finite-dimensional Banach codomain"
+    ],
+    "prerequisites": [
+      "tietze_extension_via_tsum",
+      "pi_norm_le_iff_of_nonneg",
+      "continuous_pi"
+    ]
+  }
+]

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.UrysohnsLemmaOQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "TietzeIntervalVector",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Interval-Constrained and Finite-Dimensional Tietze from the Explicit Urysohn Series",
+  "description": "Pushes the parent entry's by-hand Tietze extension G = ∑' n, gₙ (the explicit Urysohn correction series in BoundedContinuousFunction X ℝ) in the two directions of its recorded open question — interval-constrained data and finite-dimensional Banach-space-valued data — by black-box reduction to the parent, with no re-running of the limit. tietze_extension_Icc is the classical order/interval form of the Tietze extension theorem: a continuous f : s → [a,b] on a closed set s of a normal space extends to a continuous G : X → [a,b] with the same, possibly asymmetric, two-sided bounds a ≤ G y ≤ b. The parent only supplied the symmetric sup-bound |G| ≤ M; the asymmetric interval form is obtained by the affine shift f ↦ f − (a+b)/2, which recentres [a,b] to [−r,r] with r = (b−a)/2, applying the parent's tietze_extension_via_tsum to the recentred data and translating back. tietze_extension_unitInterval specialises to [0,1]-valued data, the shape used to build partitions of unity. For vector data, tietze_extension_pi_sup extends f : s → (ι → ℝ) with ι finite by applying the parent series to each scalar component with the common bound M, so the joint componentwise ℓ∞ bound |G y i| ≤ M is preserved exactly; tietze_extension_pi_norm packages this with the genuine ℓ∞ norm on the finite-dimensional Banach space ι → ℝ, giving ‖G y‖ ≤ M, and tietze_extension_pi_norm_sharp records that G extends f while sharing every uniform ℓ∞ bound — so for M = ‖f‖ the sup-norm is preserved, ‖G‖ = ‖f‖, on finite-dimensional codomains. Honest scope: the series rests on the scalar one-step Urysohn approximation, so it reaches arbitrary closed real intervals and finite products ι → ℝ under the ℓ∞ norm, not a general infinite-dimensional Banach codomain. This answers the first recorded open question of urysohns-lemma-oq-01-oq-01-oq-02.",
+  "overview": {
+    "historicalContext": "The Tietze extension theorem is most often used in its order form: a continuous map from a closed subset of a normal space into a closed interval [a,b] extends to a continuous map of the whole space into the same interval [a,b]. This is exactly the version needed to build partitions of unity ([0,1]-valued data) and to extend bounded vector fields component by component. The gallery's explicit-series strand recovers Tietze from Urysohn's lemma by hand: the grandparent urysohns-lemma-oq-01-oq-01 isolates the one-step Urysohn approximation and its geometric 2/3 rate, the parent urysohns-lemma-oq-01-oq-01-oq-02 assembles the limit as a tsum G = ∑' n, gₙ in BoundedContinuousFunction X ℝ and proves the sharp scalar bound ‖G‖ = ‖f‖. Both work with a single ℝ-valued function bounded symmetrically by M. The recorded open question asks whether the same explicit construction carries through for interval-constrained and Banach-space-valued data. This entry answers it for the cases that reduce to the scalar engine: an arbitrary closed interval [a,b] (via an affine recentring) and a finite-dimensional codomain ι → ℝ under the ℓ∞ norm (via componentwise extension with a common bound).",
+    "problemStatement": "Generalise the explicit-series norm-preserving Tietze extension from symmetrically-bounded ℝ-valued data to (i) interval-constrained data, producing for f : s → [a,b] a continuous extension G : X → [a,b] with the asymmetric two-sided bound retained, and (ii) finite-dimensional Banach-space-valued data f : s → (ι → ℝ) (ι finite), producing a continuous extension with the ℓ∞ bound — equivalently the sup-norm — preserved, ‖G‖ ≤ M and hence ‖G‖ = ‖f‖ for M = ‖f‖. Use only the parent series, none of Mathlib's TietzeExtension machinery.",
+    "proofStrategy": "tietze_extension_Icc sets c = (a+b)/2 and r = (b−a)/2 ≥ 0, forms the recentred data f' = f − c (a continuous map on s), and checks |f' x| ≤ r from a ≤ f x ≤ b by abs_le and linarith. Feeding f' and M = r into the parent's tietze_extension_via_tsum yields G' with G' = f' on s and |G' y| ≤ r; the extension G := G'.toContinuousMap + const c restricts to f on s (G' x + c = (f x − c) + c) and satisfies a = c − r ≤ G' y + c ≤ c + r = b everywhere, again by linarith on |G' y| ≤ r. tietze_extension_unitInterval is the a=0, b=1 instance. tietze_extension_pi_sup extracts, for each i : ι, the scalar component fi = (x ↦ f x i) (continuous as continuous_apply i ∘ f.continuous), applies the parent series with the COMMON bound M (legitimate since |f x i| ≤ M for every component), and choose-s the resulting extensions Gi; the assembled map y ↦ (i ↦ Gi y) is continuous by continuous_pi, restricts to f on s componentwise (funext), and satisfies |G y i| ≤ M for all i. tietze_extension_pi_norm converts between the ℓ∞ norm and the componentwise bound with pi_norm_le_iff_of_nonneg (‖x‖ ≤ M ↔ ∀ i, ‖x i‖ ≤ M, valid for 0 ≤ M and Fintype ι) and Real.norm_eq_abs, in both directions. tietze_extension_pi_norm_sharp adds the on-s bound ‖G (x:X)‖ ≤ M directly from the extension property G = f on s.",
+    "keyInsights": [
+      "The asymmetric interval form is the symmetric form conjugated by an affine shift. Translating the data by the interval midpoint c = (a+b)/2 turns the interval [a,b] into [−r, r] with r = (b−a)/2, where the parent's symmetric bound |G| ≤ r applies verbatim; translating back by +c recovers a ≤ G ≤ b. No new analytic content is needed — only that the parent's construction is equivariant under constant shifts, which it is because adding a constant is an isometry of the sup-norm.",
+      "Vector-valued extension is genuinely componentwise, and the ℓ∞ bound is preserved precisely because every component is extended against the SAME bound M. Extending component i against its own sup would only give |G y i| ≤ Mᵢ; using the joint bound M = ‖f‖ for all components keeps the assembled extension inside the ℓ∞ ball of radius M, so ‖G y‖ = maxᵢ |G y i| ≤ M. This is the finite-dimensional shadow of a vector Urysohn step.",
+      "The sup-norm on a finite product ι → ℝ is exactly the componentwise maximum (pi_norm_le_iff_of_nonneg), so the ℓ∞ statement ‖G y‖ ≤ M and the componentwise statement ∀ i, |G y i| ≤ M are interchangeable for finite ι. This is what lets the scalar series, run in parallel across components, deliver a norm-preserving extension into the finite-dimensional Banach space ι → ℝ.",
+      "Sharpness transfers from the scalar case for free. Because each component extension preserves its own sup-bound and G agrees with f on s, the assembled G shares every uniform ℓ∞ bound of f; specialising to the least such bound M = ‖f‖ gives ‖G‖ = ‖f‖ on finite-dimensional codomains, the vector analogue of the parent's sharp scalar result.",
+      "Honest limit of the method: the construction never leaves the scalar Urysohn engine, so it does not reach a general infinite-dimensional Banach codomain (no vector Urysohn step is built). It covers exactly the reductions to the scalar series — arbitrary closed intervals and finite products under the ℓ∞ norm."
+    ]
+  },
+  "sections": [
+    {
+      "id": "interval-constrained",
+      "title": "Tietze into an Arbitrary Closed Interval",
+      "startLine": 56,
+      "endLine": 104,
+      "summary": "tietze_extension_Icc proves the classical order form a ≤ f ≤ b ⟹ ∃ G, G|_s = f ∧ a ≤ G ≤ b by recentring [a,b] to [−r,r] (r = (b−a)/2) via the constant shift f ↦ f − (a+b)/2, applying the parent's tietze_extension_via_tsum, and translating back. tietze_extension_unitInterval is the [0,1] specialisation used for partitions of unity.",
+      "mathContext": "$a \\le f \\le b \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ a \\le G \\le b.$"
+    },
+    {
+      "id": "vector-valued",
+      "title": "Finite-Dimensional Vector-Valued Tietze with Preserved ℓ∞ Bound",
+      "startLine": 106,
+      "endLine": 160,
+      "summary": "tietze_extension_pi_sup extends f : s → (ι → ℝ) (ι finite) componentwise with the common bound M, preserving |G y i| ≤ M; tietze_extension_pi_norm packages it with the ℓ∞ norm (‖G y‖ ≤ M via pi_norm_le_iff_of_nonneg); tietze_extension_pi_norm_sharp records that G extends f and shares every uniform ℓ∞ bound, so ‖G‖ = ‖f‖ for the least bound.",
+      "mathContext": "$\\|f x\\|_\\infty \\le M \\ \\Rightarrow\\ \\exists\\,G,\\ G|_s = f \\ \\wedge\\ \\|G y\\|_\\infty \\le M.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry. It assembles the Tietze extension as the explicit Urysohn correction series G = ∑' n, gₙ in BoundedContinuousFunction X ℝ and proves the sharp scalar norm-preserving bound ‖G‖ = ‖f‖ for symmetrically-bounded ℝ-valued data. This entry generalises that construction, by black-box reduction to tietze_extension_via_tsum, to interval-constrained data (asymmetric a ≤ G ≤ b) and to finite-dimensional Banach-space-valued data (ℓ∞-norm-preserving), answering the parent's first open question."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Grandparent entry isolating the one-step Urysohn approximation engine and its geometric 2/3 rate, on which the parent's explicit series — and hence this entry's reductions — are built."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01",
+      "relationship": "related",
+      "description": "Ancestor entry deriving the Tietze extension theorem from Urysohn's lemma."
+    }
+  ],
+  "references": [
+    {
+      "title": "Tietze extension theorem",
+      "url": "https://en.wikipedia.org/wiki/Tietze_extension_theorem"
+    },
+    {
+      "title": "Urysohn's lemma",
+      "url": "https://en.wikipedia.org/wiki/Urysohn%27s_lemma"
+    },
+    {
+      "title": "Mathlib: pi_norm_le_iff_of_nonneg (sup-norm on finite products)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Normed/Group/Constructions.html"
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry generalises the parent's explicit-series Tietze extension in the two directions of its recorded open question, each by black-box reduction to the parent's tietze_extension_via_tsum. tietze_extension_Icc gives the classical order form a ≤ f ≤ b ⟹ a ≤ G ≤ b for an arbitrary closed interval, via the affine recentring f ↦ f − (a+b)/2; tietze_extension_unitInterval is the [0,1] case. tietze_extension_pi_sup / tietze_extension_pi_norm extend finite-dimensional vector data f : s → (ι → ℝ) componentwise against a common bound, preserving the ℓ∞ bound |G y i| ≤ M and hence the sup-norm ‖G y‖ ≤ M; tietze_extension_pi_norm_sharp records the norm-preservation ‖G‖ = ‖f‖ for the least bound. 160 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; all results depend only on propext / Classical.choice / Quot.sound, and none of Mathlib's TietzeExtension machinery is used.",
+    "implications": "The order/interval form is the version of Tietze used in practice (partitions of unity, extension of bounded functions into a prescribed range), and it now follows directly from the gallery's hand-built Urysohn series rather than from a separate appeal to Mathlib. The finite-dimensional vector case realises the question's 'Banach-space-valued' direction for the prototypical finite-dimensional Banach spaces ι → ℝ under the ℓ∞ norm, with the sup-norm tracked exactly across components. The remaining gap — a genuine infinite-dimensional Banach codomain — would need a vector-valued Urysohn step, which the scalar series does not provide; that is the natural next target.",
+    "openQuestions": [
+      "Build a vector-valued one-step Urysohn correction for a general (infinite-dimensional) Banach codomain E, so the explicit series extends f : s → E with ‖G‖ = ‖f‖ without reducing to scalar components — the only direction of the parent's question not reachable from the scalar engine.",
+      "Track an explicit modulus of convergence for the interval and vector forms, transporting the parent chain's tail bound ‖G − ∑_{i<n} gᵢ‖ ≤ (2/3)ⁿ·M through the affine recentring and the componentwise assembly."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "urysohns-lemma",
+      "tietze-extension",
+      "interval-constraint",
+      "bounded-continuous-function",
+      "banach-space",
+      "sup-norm",
+      "norm-preserving",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 160,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "assumptions": "0 axioms, 0 sorries. All five results (tietze_extension_Icc, tietze_extension_unitInterval, tietze_extension_pi_sup, tietze_extension_pi_norm, tietze_extension_pi_norm_sharp) depend only on Mathlib's standard foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Classical.choice enters through the parent's per-step Urysohn correction. The proofs build only on the parent entry's explicit series tietze_extension_via_tsum (Proofs.UrysohnsLemmaOQ01OQ01OQ01) plus elementary API (ContinuousMap algebra, abs_le, linarith, pi_norm_le_iff_of_nonneg, continuous_pi); they do NOT use any theorem from Mathlib.Topology.TietzeExtension.",
+    "originalContributions": [
+      "tietze_extension_Icc: the classical order/interval form of the Tietze extension theorem — a continuous f : s → [a,b] extends to a continuous G : X → [a,b] with the same asymmetric two-sided bound — obtained from the parent's symmetric explicit series by the affine recentring f ↦ f − (a+b)/2, with none of Mathlib's TietzeExtension machinery",
+      "tietze_extension_unitInterval: the [0,1]-valued specialisation, the form used to construct partitions of unity",
+      "tietze_extension_pi_sup and tietze_extension_pi_norm: finite-dimensional Banach-space-valued Tietze for f : s → (ι → ℝ) with ι finite, extending each component against a COMMON bound so the joint ℓ∞ bound |G y i| ≤ M and the sup-norm ‖G y‖ ≤ M are preserved exactly",
+      "tietze_extension_pi_norm_sharp: the norm-preservation record that the vector extension shares every uniform ℓ∞ bound of the data, hence ‖G‖ = ‖f‖ for the least bound — the vector analogue of the parent's sharp scalar equality, for finite-dimensional codomains"
+    ],
+    "prerequisites": [
+      "The parent entry's explicit Tietze series tietze_extension_via_tsum (Proofs.UrysohnsLemmaOQ01OQ01OQ01), used as a black box: it returns a bounded continuous G extending f with the symmetric bound |G y| ≤ M",
+      "ContinuousMap algebra (subtraction by a constant, ContinuousMap.const, add_apply / const_apply) and the BoundedContinuousFunction-to-ContinuousMap coercion",
+      "The ℓ∞ norm on a finite product: pi_norm_le_iff_of_nonneg (‖x‖ ≤ M ↔ ∀ i, ‖x i‖ ≤ M for 0 ≤ M, Fintype ι) and Real.norm_eq_abs",
+      "continuous_apply / continuous_pi for assembling and projecting the vector-valued maps"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "BoundedContinuousFunction.toContinuousMap",
+        "description": "Coercion of the parent's bounded continuous extension G' to a plain continuous map, so it can be added to a constant continuous map in the interval form and assembled into the vector-valued map.",
+        "module": "Mathlib.Topology.ContinuousMap.Bounded.Basic"
+      },
+      {
+        "theorem": "pi_norm_le_iff_of_nonneg",
+        "description": "‖x‖ ≤ M ↔ ∀ i, ‖x i‖ ≤ M for a finite product and 0 ≤ M; converts between the ℓ∞ sup-norm bound and the componentwise bound in both directions of tietze_extension_pi_norm.",
+        "module": "Mathlib.Analysis.Normed.Group.Constructions"
+      },
+      {
+        "theorem": "continuous_pi",
+        "description": "A map into a product is continuous iff each component is; assembles the componentwise extensions Gi into a continuous vector-valued extension.",
+        "module": "Mathlib.Topology.Constructions"
+      },
+      {
+        "theorem": "abs_le",
+        "description": "|a| ≤ b ↔ −b ≤ a ∧ a ≤ b; turns the interval membership a ≤ f x ≤ b into the symmetric bound |f x − c| ≤ r needed to invoke the parent, and back again for the extension.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "question": "Build a vector-valued one-step Urysohn correction for a general infinite-dimensional Banach codomain E, so the explicit series extends f : s → E with ‖G‖ = ‖f‖ without reducing to scalar components.",
+      "significance": "medium"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first recorded open question** of `urysohns-lemma-oq-01-oq-01-oq-02` — *generalise the explicit-series Tietze extension from ℝ-valued to interval-constrained or Banach-space-valued data* — by black-box reduction to the parent's hand-built Urysohn series `tietze_extension_via_tsum`, re-running no limit and using **none** of Mathlib's `TietzeExtension` machinery.

The parent assembles `G = ∑' n, gₙ` in `BoundedContinuousFunction X ℝ` and proves the **symmetric** sharp bound `‖G‖ = ‖f‖` for `ℝ`-valued data bounded by `M`. This entry pushes that construction in the two directions the question names.

### Results (`TietzeIntervalVector`, 5 theorems, 160 lines)

| theorem | statement |
|---|---|
| `tietze_extension_Icc` | classical **order form**: `a ≤ f ≤ b ⟹ ∃ G, G\|_s = f ∧ a ≤ G ≤ b` |
| `tietze_extension_unitInterval` | the `[0,1]`-valued case (partitions of unity) |
| `tietze_extension_pi_sup` | vector `f : s → (ι→ℝ)`, `ι` finite: componentwise `\|G y i\| ≤ M` preserved |
| `tietze_extension_pi_norm` | same with the `ℓ∞` norm: `‖G y‖ ≤ M` |
| `tietze_extension_pi_norm_sharp` | `G` shares every uniform `ℓ∞` bound ⟹ `‖G‖ = ‖f‖` for the least bound |

### How

- **Interval form** conjugates the parent by an affine shift: recentre `[a,b]` to `[−r,r]` (`c=(a+b)/2`, `r=(b−a)/2`) with `f ↦ f − c`, apply the parent at `M = r`, translate back. Adding a constant is a sup-norm isometry, so the symmetric bound becomes the asymmetric `a ≤ G ≤ b`.
- **Vector form** runs the parent series on each scalar component against the **common** bound `M`, so the assembled extension stays in the `ℓ∞` ball of radius `M`; `pi_norm_le_iff_of_nonneg` converts componentwise ↔ sup-norm. This is the finite-dimensional shadow of a vector Urysohn step.

### Scope (honest)

The series rests on the **scalar** one-step Urysohn approximation, so it reaches arbitrary closed real intervals and finite products `ι → ℝ` under the `ℓ∞` norm — the prototypical finite-dimensional Banach spaces — **not** a general infinite-dimensional Banach codomain (that needs a genuine vector Urysohn step; left as the new open question).

### Verification

- `lake env lean Proofs/UrysohnsLemmaOQ01OQ01OQ02OQ01.lean` → exit 0 (Mathlib v4.26).
- `#print axioms` for all 5 theorems: only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). **0 axioms, 0 sorries.**
- Gallery `annotations:validate`: no errors for this id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)