### PR TITLE
audit: batch-clear 10 unaudited gallery proofs (9 clean, 1 issues-found)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21604,38 +21604,20 @@
     },
     "hilbert-17-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:37:13Z",
+      "lastAudited": "2026-06-24T14:45:41Z",
       "result": "clean",
       "issues": []
     },
     "hilbert-17-oq-03-oq-04": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:37:13Z",
-      "result": "clean",
+      "lastAudited": "2026-06-24T14:45:41Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "hilbert-17-oq-03-oq-03": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:37:13Z",
+      "lastAudited": "2026-06-24T14:45:41Z",
       "result": "issues-fixed",
-      "issues": []
-    },
-    "arsinh-log-formula-oq-01-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T14:38:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "erdos-1012-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T14:38:01Z",
-      "result": "clean",
-      "issues": []
-    },
-    "gram-linear-independence-iff-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-24T14:38:01Z",
-      "result": "clean",
       "issues": []
     },
     "arsinh-log-formula-oq-01-oq-01-oq-01": {
@@ -21656,23 +21638,67 @@
       "result": "clean",
       "issues": []
     },
-    "hilbert-17-oq-03-oq-02": {
+    "algebraic-numbers-countable-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:45:41Z",
+      "lastAudited": "2026-06-24T15:11:28Z",
       "result": "clean",
       "issues": []
     },
-    "hilbert-17-oq-03-oq-03": {
+    "alternating-series-test-oq-01-oq-02-oq-01": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:45:41Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
       "issues": []
     },
-    "hilbert-17-oq-03-oq-04": {
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-06-24T14:45:41Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq-04-oq-01-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "de-moivre-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-04-wip-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-theorem-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-second-moment-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "compactness-finite-subcover-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:11:29Z",
+      "result": "issues-found",
+      "issues": [
+        "#29127: OQ/Oq casing mismatch breaks case-sensitive (Docker/Linux) build; fix PR #29131 open"
+      ]
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 10 never-audited gallery proofs served by `find-targets`, verifying each meta.json claim (status/badge/sorries/axiomCount/assumptions) against the Lean source, plus build-graph registration in `Proofs.lean`.

### Clean (9)
| Proof | Notes |
|-------|-------|
| algebraic-numbers-countable-oq-01 | verified/original — 0 sorry, 0 axiom, registered |
| alternating-series-test-oq-01-oq-02-oq-01 | verified/verified — foundational axioms only |
| arithmetic-series-oq-02-oq-02-oq-03-oq-02 | verified/original — code uses kernel `decide` (not `native_decide`); 0-axiom claim honest. (Lean docstring line 239 loosely says "native_decide" but the actual tactic is `decide` — cosmetic only) |
| bounded-prime-gaps-oq-04-oq-01-wip-01 | verified/original — the lone `sorry` grep hit is in a docstring |
| de-moivre-oq-01-oq-03-oq-02 | verified/original — reliance on Mathlib `Polynomial.Chebyshev.C_mul` fully disclosed in `assumptions`; contribution is the bundled MonoidHom packaging |
| fourier-series-oq-04-wip-01-oq-01 | verified/**mathlib** — correct conservative badge for orthonormality via Mathlib characters |
| minkowski-theorem-oq-04-oq-03 | verified/original — honestly scoped to *Blichfeldt sharpness*, not Minkowski's theorem |
| prob-method-second-moment-oq-01-oq-01 | verified/original — Paley–Zygmund in Lp, hypotheses stated |
| urysohns-lemma-oq-01-oq-01-oq-02-oq-02 | verified/original — `sorry` grep hit is in a docstring |

### Issues-found (1) — already tracked, not duplicated
**compactness-finite-subcover-oq-01-oq-01-oq-01**: committed as `CompactnessFiniteSubcoverOQ01OQ01OQ01.lean` (uppercase `OQ`) but `Proofs.lean:812` imports it as `...Oq01Oq01Oq01` and the leaf's own line-2 parent import is `...OQ01OQ01` while the parent file is `...Oq01Oq01.lean` (family convention is lowercase `Oq`). Resolves on case-insensitive macOS APFS but **breaks case-sensitive Docker/Linux builds**, so the `verified` claim is not reproducible. Already covered by **issue #29127** (open) and **fix PR #29131** (open) — no duplicate filed.

### Also noted (out of audit scope)
`zeckendorf-representation-oq-01` has `annotations.json` but **no meta.json** — it does not render in the gallery and is correctly excluded by `find-targets`. No public claim to verify; flagging for enricher/mechanic follow-up.

Tracker: 9 marked `clean`, 1 marked `issues-found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)