### PR TITLE
research(seeker): replenish candidate pool with 3 verified-parent leaves

### DIFF
--- a/research/problems/combinations-formula-oq-07-oq-04-oq-02/problem.md
+++ b/research/problems/combinations-formula-oq-07-oq-04-oq-02/problem.md
@@ -1,0 +1,109 @@
+# Problem: Falling-Factorial Second Moment of Squared Binomials
+
+**Slug**: combinations-formula-oq-07-oq-04-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent computes the second moment $\sum_{k} k^2 \binom{n}{k}^2$ of the squares
+of binomial coefficients. This leaf asks for the **falling-factorial** second
+moment, which has a cleaner single-term closed form via double absorption:
+
+$$
+\sum_{k=0}^{n} k(k-1)\binom{n}{k}^2 \;=\; n(n-1)\binom{2n-2}{\,n-2\,}.
+$$
+
+The key step is iterating the absorption identity $k\binom{n}{k} = n\binom{n-1}{k-1}$
+twice, giving $k(k-1)\binom{n}{k}^2 = n(n-1)\binom{n-2}{k-2}\binom{n}{k}$, then
+applying Vandermonde to the resulting convolution. The falling-factorial form yields
+the variance of the hypergeometric-type distribution directly, without recombining
+raw moments. Prove it in Lean 4.
+
+### Plain Language
+
+The parent measures the "spread" of squared binomial coefficients using $k^2$. Using
+the falling factorial $k(k-1)$ instead makes the algebra telescope: two applications
+of the absorption rule collapse the whole sum to a single central binomial
+coefficient $n(n-1)\binom{2n-2}{n-2}$. This is the natural quantity for reading off
+the variance.
+
+### Why This Matters
+
+Shows that the right basis for binomial-coefficient moments is the falling factorial,
+not ordinary powers — a standard but instructive simplification, and a clean Lean
+exercise in the absorption + Vandermonde toolkit.
+
+## Known Results
+
+### What's Already Proven
+
+- `combinations-formula-oq-07-oq-04` (verified) — second moment $\sum k^2 \binom{n}{k}^2$.
+- Mathlib: `Nat.succ_mul_choose_eq` (absorption), Vandermonde / `Nat.add_choose_le` API.
+
+### What's Still Open
+
+- The falling-factorial closed form (this problem).
+
+### Our Goal
+
+Prove $\sum_{k} k(k-1)\binom{n}{k}^2 = n(n-1)\binom{2n-2}{n-2}$ by double absorption
++ Vandermonde, then optionally derive the variance.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| combinations-formula-oq-07-oq-04 | direct parent | second moment, absorption |
+| vandermonde-interpolation-oq-01 | Vandermonde convolution | binomial convolution |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Double absorption then Vandermonde**: rewrite the summand and reindex.
+   - Why it might work: each absorption is a Mathlib one-liner; Vandermonde is in Mathlib.
+   - Risk: index-shift bookkeeping ($k-2$ shift, boundary terms $k<2$ vanish).
+
+### Key Difficulties
+
+- Handling the $k = 0, 1$ boundary terms (they vanish under $k(k-1)$) cleanly.
+- Matching Mathlib's Vandermonde statement to the shifted convolution.
+
+### What Would a Proof Need?
+
+- Absorption applied twice to $k(k-1)\binom{n}{k}$.
+- Vandermonde / Cauchy convolution for central binomial.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Pure `Nat.choose` algebra; parent already navigated the squared-binomial moment.
+- Main cost is reindexing discipline, not new mathematics.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–3 days
+
+## References
+
+### Mathlib
+- `Mathlib.Combinatorics.Choose.*` — absorption, Vandermonde.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - binomial-coefficients
+related_proofs:
+  - combinations-formula-oq-07-oq-04
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/combinations-formula-oq-07-oq-04-oq-02/state.md
+++ b/research/problems/combinations-formula-oq-07-oq-04-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: combinations-formula-oq-07-oq-04-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:10:12-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/fibonacci-identities-oq-05-oq-01/problem.md
+++ b/research/problems/fibonacci-identities-oq-05-oq-01/problem.md
@@ -1,0 +1,109 @@
+# Problem: Fibonacci Product-Sum — Alternating and Weighted Variants
+
+**Slug**: fibonacci-identities-oq-05-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent proves the telescoping product-sum identity for consecutive Fibonacci
+products $\sum_{k=1}^{n} F_k F_{k+1}$. This problem asks for the two natural
+variants listed as its first open question:
+
+1. **Alternating product sum.** Find and prove a closed form for
+$$\sum_{k=1}^{n} (-1)^k F_k F_{k+1}.$$
+
+2. **Weighted (linear) product sum.** Find and prove a closed form for
+$$\sum_{k=1}^{n} k\, F_k F_{k+1}.$$
+
+Both closed forms should be expressed in terms of Fibonacci numbers $F_m$ (and at
+most a linear polynomial in $n$), and proved by induction in Lean 4.
+
+### Plain Language
+
+The parent identity sums consecutive Fibonacci products $F_k F_{k+1}$. Here we
+twist the same sum two ways: alternate the sign of each term, and weight each term
+by its index $k$. Each variant collapses to a clean expression in Fibonacci
+numbers; the goal is to discover the exact form and certify it in Lean.
+
+### Why This Matters
+
+Demonstrates that the same telescoping machinery behind the parent identity is
+robust under sign-twisting and linear weighting — a recurring pattern in the
+combinatorics of linear recurrences (Cassini / d'Ocagne family).
+
+## Known Results
+
+### What's Already Proven
+
+- `fibonacci-identities-oq-05` (verified, 0-axiom) — base product-sum staircase.
+- Mathlib `Nat.fib`, `Nat.fib_add_two`, Cassini/d'Ocagne identities.
+
+### What's Still Open
+
+- The two closed forms above (this problem).
+
+### Our Goal
+
+State both identities over `ℤ` and prove them by `Finset.range` induction.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| fibonacci-identities-oq-05 | direct parent | telescoping product-sum |
+| fibonacci-identities-oq-04-oq-03 | Gibonacci Gelin–Cesàro | recurrence algebra |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct induction**: `Finset.sum_range_succ` + `Nat.fib_add_two`, close step with `ring`.
+   - Why it might work: each term is polynomial in shifted Fibonacci values.
+   - Risk: discovering the exact closed form first (conjecture from data).
+
+2. **Abel summation** for the weighted sum against the parent's telescoped partials.
+
+### Key Difficulties
+
+- Sign handling forces working over `ℤ` (cast from `Nat.fib`).
+- Conjecturing the precise closed form before proving.
+
+### What Would a Proof Need?
+
+- Key lemma: parent product-sum closed form (import or re-derive).
+- Numerical conjecture of both forms from first 6–8 partial sums.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- Pure `Nat.fib` induction, no transcendental input.
+- Mathlib has the full Fibonacci identity API.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Algebra.BigOperators.Fib` / `Nat.fib` — Fibonacci API.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - combinatorics
+  - fibonacci
+related_proofs:
+  - fibonacci-identities-oq-05
+difficulty: low
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/fibonacci-identities-oq-05-oq-01/state.md
+++ b/research/problems/fibonacci-identities-oq-05-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: fibonacci-identities-oq-05-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:10:12-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/mean-value-theorem-oq-02-oq-01-oq-02/problem.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-01-oq-02/problem.md
@@ -1,0 +1,110 @@
+# Problem: Taylor Series Convergence for sin and cos on all of ℝ
+
+**Slug**: mean-value-theorem-oq-02-oq-01-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The parent establishes Taylor remainder estimates converting derivative control to
+function-value control, and proves convergence of the exponential Taylor series.
+This leaf asks for the analogous result for the trigonometric functions, where the
+uniform derivative bound is globally $M = 1$:
+
+$$
+\left\lvert \sin x - \sum_{k=0}^{n-1} \frac{(-1)^{k}}{(2k+1)!}\,x^{2k+1} \right\rvert
+\;\le\; \frac{|x|^{n}}{n!} \xrightarrow[n\to\infty]{} 0
+\quad\text{for every } x \in \mathbb{R},
+$$
+
+and likewise for $\cos$. Concretely: prove `sin_taylor_tendsto` and
+`cos_taylor_tendsto` — the Taylor partial sums converge to $\sin$ / $\cos$ on all
+of $\mathbb{R}$ — directly from the parent's `taylorPolynomial_tendsto` using the
+global bound $\lvert \sin^{(n)} \rvert, \lvert \cos^{(n)} \rvert \le 1$.
+
+### Plain Language
+
+Every derivative of sine and cosine is again $\pm\sin$ or $\pm\cos$, so they are all
+bounded by 1 everywhere. The parent already shows that a uniform bound $M$ on all
+derivatives forces the Taylor series to converge; plugging in $M = 1$ gives global
+convergence on the whole real line, with no interval restriction.
+
+### Why This Matters
+
+Sine/cosine are the cleanest instance of the parent's general convergence theorem
+(the exp case needs $M$ growing with the interval; trig needs none). It closes the
+trig branch of the parent's open questions.
+
+## Known Results
+
+### What's Already Proven
+
+- `mean-value-theorem-oq-02-oq-01` (verified) — Taylor remainder estimates + exp convergence.
+- Mathlib: `Real.sin`, `Real.cos`, iterated-derivative lemmas, `taylor_mean_remainder`.
+
+### What's Still Open
+
+- The trig convergence statements (this problem).
+
+### Our Goal
+
+Instantiate the parent's `taylorPolynomial_tendsto` with $M = 1$ for sin and cos.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| mean-value-theorem-oq-02-oq-01 | direct parent | Taylor remainder, derivative→value control |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Reuse parent theorem**: supply the global derivative bound $M=1$ and a tendsto
+   of $|x|^n/n!$ to 0.
+   - Why it might work: the parent already did the hard analytic work.
+   - Risk: matching Mathlib's iterated-derivative form for sin/cos.
+
+### Key Difficulties
+
+- Expressing $\sin^{(n)}$ uniformly bounded by 1 in Mathlib's API.
+
+### What Would a Proof Need?
+
+- Bound: `‖iteratedDeriv n sin‖ ≤ 1` (and cos).
+- Squeeze: $|x|^n/n! \to 0$ (Mathlib).
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The parent did the analysis; this is instantiation + a uniform bound lemma.
+- Mathlib has factorial-decay and trig-derivative lemmas.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv` — trig derivatives.
+- `Mathlib.Analysis.SpecificLimits.Basic` — `|x|^n / n! → 0`.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - calculus
+  - taylor-series
+related_proofs:
+  - mean-value-theorem-oq-02-oq-01
+difficulty: low
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/mean-value-theorem-oq-02-oq-01-oq-02/state.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-01-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: mean-value-theorem-oq-02-oq-01-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:10:12-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Seeker replenishment cycle. Pool showed 15 available (=threshold) but one entry, `pythagorean-triples-oq-06-oq-01-oq-01`, is in-flight (its leaf `.lean` is present uncommitted in the working tree), leaving **14 genuine < 15**. De-listed the stale entry and added 3 tractable leaves drawn from **verified, 0-axiom** parents:

| Leaf | Parent | What |
|------|--------|------|
| `fibonacci-identities-oq-05-oq-01` | fibonacci-identities-oq-05 | closed forms for ∑(−1)ᵏFₖFₖ₊₁ and ∑ k·FₖFₖ₊₁ |
| `mean-value-theorem-oq-02-oq-01-oq-02` | mean-value-theorem-oq-02-oq-01 | Taylor convergence of sin/cos on all ℝ (global M=1) |
| `combinations-formula-oq-07-oq-04-oq-02` | combinations-formula-oq-07-oq-04 | ∑ k(k−1)C(n,k)² = n(n−1)C(2n−2,n−2) (double absorption) |

Each answers a listed `openQuestion` of its verified parent and is Mathlib-friendly. All stubs pass `validate-seeker-stubs.ts` (no template placeholders).

The knowledge DB and `.lean/state/candidate-pool.json` reservoir were updated out-of-band (both gitignored); only the workspace stubs are in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)