### PR TITLE
research(basel-problem-oq-13-oq-01): Dirichlet eta value η(4)=7π⁴/720 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -300,6 +300,7 @@ import Proofs.BaselProblemOQ10
 import Proofs.BaselProblemOQ11
 import Proofs.BaselProblemOQ12
 import Proofs.BaselProblemOQ13
+import Proofs.BaselProblemOQ13OQ01
 import Proofs.BaselProblemOQ14
 import Proofs.BaselProblemOQ15
 import Proofs.BellNumbersOQ01

--- a/proofs/Proofs/BaselProblemOQ13OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ13OQ01.lean
@@ -1,0 +1,110 @@
+/-
+  # Dirichlet eta value η(4) = ∑_{n≥1} (-1)^(n+1)/n⁴ = 7π⁴/720
+  # (basel-problem-oq-13-oq-01)
+
+  ## The Open Question (from basel-problem-oq-13)
+
+  > Derive the Dirichlet eta value η(4) = 7π⁴/720 by combining λ(4) = π⁴/96
+  > with the even-fourth-power sum π⁴/1440.
+
+  ## The parity decomposition of η(4)
+
+  The Dirichlet eta function η(s) = ∑_{n≥1} (-1)^(n+1)/nˢ is the alternating
+  companion of ζ(s). Splitting the alternating sum by parity, the odd indices
+  carry a `+` sign and the even indices a `−` sign:
+
+      η(4) = (∑_{k≥0} 1/(2k+1)⁴) − (∑_{k≥1} 1/(2k)⁴)
+           = λ(4) − (even-fourth-power sum)
+           = π⁴/96 − π⁴/1440
+           = (15π⁴ − π⁴)/1440 = 14π⁴/1440 = 7π⁴/720.
+
+  Both ingredients are already proved (axiom-free) in the parent file
+  `BaselProblemOQ13`:
+
+    * `hasSum_even_zeta_four` : ∑_k 1/(2k)⁴ = π⁴/1440,
+    * `hasSum_odd_zeta_four`  : ∑_k 1/(2k+1)⁴ = π⁴/96.
+
+  The only new ingredient here is the *alternating* sign, threaded through
+  `HasSum.even_add_odd`: with f n = (-1)^(n+1)/n⁴ we have f(2k) = -1/(2k)⁴ and
+  f(2k+1) = +1/(2k+1)⁴, so η(4) = (−even part) + (odd part). No new analytic
+  input.
+
+  ## Axiom count: 0
+-/
+
+import Proofs.BaselProblemOQ13
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real
+
+namespace BaselEtaFour
+
+open BaselOddZetaFour
+
+/-- The even-indexed terms of η(4): with the alternating sign, `f(2k) = -1/(2k)⁴`,
+    summing to `-π⁴/1440` (the negative of the even-fourth-power sum). -/
+theorem hasSum_eta_four_even :
+    HasSum (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1) / ((2 * k : ℕ) : ℝ) ^ 4)
+      (-(π ^ 4 / 1440)) := by
+  have hfun : (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1) / ((2 * k : ℕ) : ℝ) ^ 4)
+      = (fun k : ℕ => -(1 / ((2 * k : ℕ) : ℝ) ^ 4)) := by
+    funext k
+    have hsign : (-1 : ℝ) ^ (2 * k + 1) = -1 := by
+      rw [pow_succ, pow_mul]; norm_num
+    rw [hsign]; ring
+  rw [hfun]
+  exact hasSum_even_zeta_four.neg
+
+/-- The odd-indexed terms of η(4): with the alternating sign, `f(2k+1) = +1/(2k+1)⁴`,
+    summing to `π⁴/96` (the odd-fourth-power / lambda value λ(4)). -/
+theorem hasSum_eta_four_odd :
+    HasSum (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1 + 1) / ((2 * k + 1 : ℕ) : ℝ) ^ 4)
+      (π ^ 4 / 96) := by
+  have hfun : (fun k : ℕ => (-1 : ℝ) ^ (2 * k + 1 + 1) / ((2 * k + 1 : ℕ) : ℝ) ^ 4)
+      = (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ 4) := by
+    funext k
+    have hsign : (-1 : ℝ) ^ (2 * k + 1 + 1) = 1 := by
+      rw [pow_succ, pow_succ, pow_mul]; norm_num
+    rw [hsign]
+  rw [hfun]
+  exact hasSum_odd_zeta_four
+
+/-- **Dirichlet eta value η(4)** as a `HasSum`:
+    `∑_{n} (-1)^(n+1)/n⁴ = 7π⁴/720`.
+
+    Assembled from the parent's even/odd fourth-power sums via the parity split
+    `HasSum.even_add_odd`: η(4) = (−π⁴/1440) + π⁴/96 = 7π⁴/720. The `n = 0` term
+    is `(-1)^1 / 0^4 = 0` (division by zero), so it contributes nothing. -/
+theorem hasSum_eta_four :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4) (7 * π ^ 4 / 720) := by
+  have h := HasSum.even_add_odd
+    (f := fun n : ℕ => (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4)
+    hasSum_eta_four_even hasSum_eta_four_odd
+  convert h using 1
+  ring
+
+/-- **Dirichlet eta value η(4)** in `tsum` form: `∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720`. -/
+theorem tsum_eta_four :
+    ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4 = 7 * π ^ 4 / 720 :=
+  hasSum_eta_four.tsum_eq
+
+end BaselEtaFour
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `hasSum_eta_four_even` | ∑ (-1)^(2k+1)/(2k)⁴ = -π⁴/1440 |
+  | `hasSum_eta_four_odd`  | ∑ (-1)^(2k+2)/(2k+1)⁴ = π⁴/96 |
+  | `hasSum_eta_four`      | ∑ (-1)^(n+1)/n⁴ = 7π⁴/720 (HasSum) |
+  | `tsum_eta_four`        | ∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720 |
+
+  Built entirely from the parent `BaselProblemOQ13`'s even/odd fourth-power sums
+  (`hasSum_even_zeta_four`, `hasSum_odd_zeta_four`) and the parity split
+  `HasSum.even_add_odd`.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "eta-even",
+    "proofId": "basel-problem-oq-13-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Even Part: ∑ (-1)^(2k+1)/(2k)⁴ = -π⁴/1440",
+    "content": "hasSum_eta_four_even isolates the even-indexed terms of the alternating series f n = (-1)^(n+1)/n⁴. At an even index the exponent is (2k)+1 = 2k+1, which is odd, so (-1)^(2k+1) = -1 (collapsed by pow_succ, pow_mul, norm_num). Hence f(2k) = -1/(2k)⁴, and the subseries is exactly the negation of the parent's even-fourth-power sum: HasSum.neg applied to hasSum_even_zeta_four gives -π⁴/1440. This negative sign is precisely what distinguishes the alternating eta value from the lambda value.",
+    "mathContext": "$\\displaystyle\\sum_{k}\\frac{(-1)^{2k+1}}{(2k)^4} = -\\sum_{k\\ge 1}\\frac{1}{(2k)^4} = -\\frac{\\pi^4}{1440}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.neg",
+      "even-indexed subseries",
+      "alternating sign by parity",
+      "even-fourth-power sum π⁴/1440"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "parity of exponents",
+      "negation of convergent sums"
+    ]
+  },
+  {
+    "id": "eta-odd",
+    "proofId": "basel-problem-oq-13-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Odd Part: ∑ (-1)^(2k+2)/(2k+1)⁴ = π⁴/96",
+    "content": "hasSum_eta_four_odd isolates the odd-indexed terms. At an odd index the exponent is (2k+1)+1 = 2k+2, which is even, so (-1)^(2k+2) = +1. Hence f(2k+1) = +1/(2k+1)⁴, and the subseries is exactly the parent's lambda value: hasSum_odd_zeta_four gives π⁴/96 with no sign change. The odd terms of an alternating series ∑(-1)^(n+1)/n⁴ are the ones that stay positive.",
+    "mathContext": "$\\displaystyle\\sum_{k}\\frac{(-1)^{2k+2}}{(2k+1)^4} = \\sum_{k}\\frac{1}{(2k+1)^4} = \\lambda(4) = \\frac{\\pi^4}{96}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "lambda value λ(4)",
+      "odd-indexed subseries",
+      "alternating sign by parity",
+      "odd-fourth-power sum π⁴/96"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "parity of exponents"
+    ]
+  },
+  {
+    "id": "eta-value",
+    "proofId": "basel-problem-oq-13-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "The Main Result: η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720",
+    "content": "hasSum_eta_four recombines the two signed subseries via HasSum.even_add_odd with f n = (-1)^(n+1)/n⁴ supplied explicitly (so the even/odd reconstruction unifies without higher-order search). The resulting value is (-π⁴/1440) + π⁴/96, and a single `ring` step evaluates it: π⁴/96 = 15π⁴/1440, so the total is 14π⁴/1440 = 7π⁴/720. The n = 0 term (-1)^1/0⁴ is 0 under Lean's division-by-zero convention, so it does not perturb the value. tsum_eta_four records the ∑' form. This is the s = 4 case of η(s) = (1 - 2^{1-s})ζ(s) = λ(s) - 2^{-s}ζ(s).",
+    "mathContext": "$\\displaystyle\\eta(4) = \\sum_{n=1}^{\\infty}\\frac{(-1)^{n+1}}{n^4} = \\lambda(4) - \\frac{\\pi^4}{1440} = \\frac{\\pi^4}{96} - \\frac{\\pi^4}{1440} = \\frac{7\\pi^4}{720}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.even_add_odd",
+      "Dirichlet eta function",
+      "η(s) = (1 - 2^{1-s})ζ(s)",
+      "parity decomposition"
+    ],
+    "prerequisites": [
+      "even/odd splitting of infinite sums",
+      "uniqueness of sums",
+      "tsum API"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-13-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-13-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "basel-problem-oq-13-oq-01",
+  "title": "Dirichlet eta value η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720",
+  "slug": "basel-problem-oq-13-oq-01",
+  "description": "Answers the open question of basel-problem-oq-13: derive the Dirichlet eta value η(4) = ∑_{n≥1} (-1)^(n+1)/n⁴ = 7π⁴/720 by combining the lambda value λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440. The alternating sum is split by parity through HasSum.even_add_odd applied to f n = (-1)^(n+1)/n⁴: the odd indices contribute +λ(4) = +π⁴/96 and the even indices contribute -(even sum) = -π⁴/1440, so η(4) = π⁴/96 - π⁴/1440 = 7π⁴/720. Both ingredients are reused verbatim from the parent's verified HasSum lemmas; the only new content is threading the alternating sign. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ13OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "eta-function",
+      "zeta-values",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 110,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Reassemble the alternating sum f from its even-indexed (f(2k)) and odd-indexed (f(2k+1)) subseries",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "HasSum.neg",
+        "description": "Negate the even-fourth-power sum, contributing -π⁴/1440 to η(4)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "HasSum.tsum_eq",
+        "description": "Pass from the HasSum statement to the ∑' form of η(4)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_eta_four_even: the even-indexed terms of the alternating series, f(2k) = (-1)^(2k+1)/(2k)⁴ = -1/(2k)⁴, sum to -π⁴/1440 (the negated parent even-fourth-power sum)",
+      "hasSum_eta_four_odd: the odd-indexed terms f(2k+1) = (-1)^(2k+2)/(2k+1)⁴ = +1/(2k+1)⁴ sum to π⁴/96 (the parent lambda value λ(4))",
+      "hasSum_eta_four: the Dirichlet eta value η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720, assembled by HasSum.even_add_odd with value (-π⁴/1440) + π⁴/96",
+      "tsum_eta_four: the tsum form ∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720"
+    ],
+    "prerequisites": [
+      "Odd-fourth-power sum λ(4) = π⁴/96 (parent basel-problem-oq-13: hasSum_odd_zeta_four)",
+      "Even-fourth-power sum π⁴/1440 (parent basel-problem-oq-13: hasSum_even_zeta_four)",
+      "Even/odd parity splitting of an infinite sum (HasSum.even_add_odd)",
+      "Sign of (-1)^n by parity of the exponent"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.BaselProblemOQ13",
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real"],
+    "namespace": "BaselEtaFour",
+    "path": "Proofs/BaselProblemOQ13OQ01.lean",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet eta function η(s) = ∑_{n≥1} (-1)^(n+1)/nˢ is the alternating analogue of the Riemann zeta function, related to it by η(s) = (1 - 2^{1-s})ζ(s). Unlike ζ, the series for η converges (conditionally) for Re(s) > 0, which makes η a standard tool for the analytic continuation of ζ. At even integers the eta values inherit Euler's closed forms: η(2) = π²/12 and η(4) = (1 - 2^{-3})ζ(4) = (7/8)(π⁴/90) = 7π⁴/720. This entry formalizes η(4), reusing the machine-checked fourth-power sums of the parent entry.",
+    "problemStatement": "Formalize, with 0 sorries and 0 axioms, the Dirichlet eta value\n\n$$\\eta(4) = \\sum_{n=1}^{\\infty} \\frac{(-1)^{n+1}}{n^4} = \\frac{7\\pi^4}{720},$$\n\nby combining the lambda value λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440 from basel-problem-oq-13.",
+    "text": "The alternating fourth-power sum η(4) = 7π⁴/720, obtained by splitting the alternating series by parity: odd indices give +λ(4) = +π⁴/96, even indices give -π⁴/1440.",
+    "proofStrategy": "Apply HasSum.even_add_odd to f n = (-1)^(n+1)/n⁴. The even subseries f(2k) = (-1)^(2k+1)/(2k)⁴ has sign (-1)^(2k+1) = -1, so it equals -1/(2k)⁴ and sums to -(π⁴/1440) via HasSum.neg of the parent's hasSum_even_zeta_four. The odd subseries f(2k+1) = (-1)^(2k+2)/(2k+1)⁴ has sign +1, so it equals 1/(2k+1)⁴ and sums to π⁴/96 by the parent's hasSum_odd_zeta_four. The parity reassembly yields η(4) = (-π⁴/1440) + π⁴/96, and a single `ring` step evaluates this to 7π⁴/720. A tsum corollary records the ∑' form.",
+    "keyInsights": [
+      "**η(4) = λ(4) - (even part) is the s = 4 case of η(s) = λ(s) - 2^{-s}ζ(s).** Splitting the alternating series by parity, the odd-indexed terms keep a + sign (n odd ⟹ (-1)^(n+1) = +1) and the even-indexed terms flip to - (n even ⟹ (-1)^(n+1) = -1), so η(4) = π⁴/96 - π⁴/1440 = 7π⁴/720.",
+      "**No new analytic input is needed — only the alternating sign.** Both numerical ingredients (the odd sum π⁴/96 and the even sum π⁴/1440) are imported verbatim from the parent's verified HasSum lemmas; this entry contributes the sign bookkeeping that turns ζ-type sums into the eta value.",
+      "**The sign is decided purely by the parity of the exponent.** (-1)^(2k+1) = -1 and (-1)^(2k+2) = 1 follow from pow_succ / pow_mul + norm_num, collapsing the alternating summand to ±1/m⁴ before the parent lemmas apply.",
+      "**HasSum.even_add_odd unifies f := (fun n => (-1)^(n+1)/n⁴) directly.** Supplying f explicitly lets the even/odd reconstruction match the two subseries lemmas, avoiding higher-order unification; the n = 0 term (-1)^1/0⁴ = 0 contributes nothing under Lean's division-by-zero convention.",
+      "**Same parity template as λ(4) and η(2).** Even part = (signed) scaled ζ, odd part = (signed) λ, recombined by even_add_odd with no per-term case analysis — the idiom that yields η(2) = π²/12 carries over unchanged to exponent 4."
+    ],
+    "prerequisites": [
+      "Lambda value λ(4) = π⁴/96 and even-fourth-power sum π⁴/1440 (parent basel-problem-oq-13)",
+      "Dirichlet eta function and η(s) = (1 - 2^{1-s})ζ(s)",
+      "Even/odd decomposition of infinite sums (HasSum.even_add_odd)",
+      "HasSum / tsum API in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Documents the parity decomposition η(4) = λ(4) - (even sum) = π⁴/96 - π⁴/1440 = 7π⁴/720; imports the parent BaselProblemOQ13 (for the two fourth-power sums) plus Mathlib's ZetaValues and Tactic.",
+      "mathContext": "η(4) is the value at 4 of the Dirichlet eta function, the alternating companion of ζ."
+    },
+    {
+      "id": "even-part",
+      "title": "hasSum_eta_four_even — ∑ (-1)^(2k+1)/(2k)⁴ = -π⁴/1440",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "Reduces the even-indexed alternating sign (-1)^(2k+1) to -1, then applies HasSum.neg to the parent's even-fourth-power sum.",
+      "mathContext": "The even-indexed terms of the alternating series carry a negative sign and contribute -π⁴/1440."
+    },
+    {
+      "id": "odd-part",
+      "title": "hasSum_eta_four_odd — ∑ (-1)^(2k+2)/(2k+1)⁴ = π⁴/96",
+      "startLine": 64,
+      "endLine": 79,
+      "summary": "Reduces the odd-indexed alternating sign (-1)^(2k+2) to +1, recovering the parent's lambda value λ(4) directly.",
+      "mathContext": "The odd-indexed terms keep a positive sign and contribute +π⁴/96."
+    },
+    {
+      "id": "eta-value",
+      "title": "hasSum_eta_four / tsum_eta_four — η(4) = 7π⁴/720",
+      "startLine": 81,
+      "endLine": 100,
+      "summary": "Recombines the even and odd subseries via HasSum.even_add_odd with f n = (-1)^(n+1)/n⁴, evaluates (-π⁴/1440) + π⁴/96 = 7π⁴/720 by `ring`, and records the tsum form.",
+      "mathContext": "The Dirichlet eta value η(4), assembled from its signed parity halves."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Dirichlet eta value η(4) = ∑ (-1)^(n+1)/n⁴ = 7π⁴/720 is formalized with 0 axioms and 0 sorries, answering the open question of basel-problem-oq-13. The proof reuses the parent's verified even-fourth-power sum (π⁴/1440) and lambda value λ(4) = π⁴/96, threading the alternating sign through HasSum.even_add_odd so that η(4) = -π⁴/1440 + π⁴/96 = 7π⁴/720.",
+    "implications": "Completes the eta-value analogue of the parent's lambda value, demonstrating that the even/odd parity split converts ζ-type and λ-type sums into alternating eta values with only sign bookkeeping. The same template applies to η(2) = π²/12 from ζ(2), and to higher even eta values η(2k) = (1 - 2^{1-2k})ζ(2k) via Mathlib's hasSum_zeta_nat.",
+    "openQuestions": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-13",
+      "relationship": "extends",
+      "description": "Parent entry: provides the odd-fourth-power sum λ(4) = π⁴/96 and the even-fourth-power sum π⁴/1440 reused here. This leaf answers its open question by assembling η(4)."
+    },
+    {
+      "targetId": "basel-problem-oq-08",
+      "relationship": "extends",
+      "description": "ζ(4) = π⁴/90; η(4) = (1 - 1/8)ζ(4) = 7π⁴/720 is its alternating restriction."
+    }
+  ],
+  "references": [
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet lambda and eta functions λ(s) = (1 - 2^{-s})ζ(s) and η(s) = (1 - 2^{1-s})ζ(s) as restrictions of the Riemann zeta function."
+    },
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of the even zeta values ζ(2k) = (rational)·π^{2k}, including ζ(4) = π⁴/90, from which the eta values η(2k) follow."
+    }
+  ],
+  "openQuestions": [],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of **basel-problem-oq-13**: derive the Dirichlet eta value

$$\eta(4) = \sum_{n=1}^{\infty} \frac{(-1)^{n+1}}{n^4} = \frac{7\pi^4}{720}$$

by combining the lambda value λ(4) = π⁴/96 with the even-fourth-power sum π⁴/1440.

## Approach

Split the alternating series `f n = (-1)^(n+1)/n⁴` by parity via `HasSum.even_add_odd`:

- **Even indices** `f(2k)`: exponent `2k+1` is odd ⟹ `(-1)^(2k+1) = -1`, so `f(2k) = -1/(2k)⁴`. Summing gives `-(π⁴/1440)` (`HasSum.neg` of the parent's `hasSum_even_zeta_four`).
- **Odd indices** `f(2k+1)`: exponent `2k+2` is even ⟹ `(-1)^(2k+2) = +1`, so `f(2k+1) = +1/(2k+1)⁴`, recovering λ(4) = π⁴/96 unchanged (parent's `hasSum_odd_zeta_four`).
- Recombine: η(4) = −π⁴/1440 + π⁴/96 = **7π⁴/720** by a single `ring` step.

Both numerical ingredients are reused verbatim from the parent's verified `HasSum` lemmas; the only new content is the alternating-sign bookkeeping. This is the s=4 case of η(s) = (1 − 2^{1−s})ζ(s) = λ(s) − 2^{−s}ζ(s).

## Results

| Theorem | Statement |
|---------|-----------|
| `hasSum_eta_four_even` | ∑ (-1)^(2k+1)/(2k)⁴ = -π⁴/1440 |
| `hasSum_eta_four_odd`  | ∑ (-1)^(2k+2)/(2k+1)⁴ = π⁴/96 |
| `hasSum_eta_four`      | ∑ (-1)^(n+1)/n⁴ = 7π⁴/720 (HasSum) |
| `tsum_eta_four`        | ∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720 |

## Verification

- **4 theorems, 110 lines, 0 sorries, 0 axioms**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Built via host `lean` (docker daemon down); parent `BaselProblemOQ13` rebuilt as dependency
- Gallery integration: `meta.json` + `annotations.json` (auto-discovery, matches parent format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)