### PR TITLE
Enrich 2-adic unit group structure theorem: add index.ts + annotations

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/index.ts
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ01OQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOq01Oq02Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOq01Oq02Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOq01Oq02Oq03Data: ProofData = {
+  proof: eulerTotientOq01Oq02Oq03Proof,
+  annotations: eulerTotientOq01Oq02Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-02-oq-03` (The 2-adic Unit Group as an Internal Direct Product: (ℤ/2ᵏℤ)ˣ = ⟨−1⟩ × ⟨5⟩).

## What was missing
The entry had a rich meta.json but **no `index.ts`** (so the page renders 'proof not found' on the live site) and **no `annotations.json`** (passes: 0, quality: 41).

## Changes
- **index.ts**: created from the standard template so Vite `import.meta.glob` discovers the proof.
- **annotations.json**: 9 annotations covering the full 166-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - Context: the exceptional 2-power case vs. cyclic odd-prime-powers
  - The generator 5 and its order 2ⁿ⁺¹ (transported from `ZMod.orderOf_five`)
  - The reduction-mod-4 homomorphism `red` — the lens separating −1 from powers of 5
  - orderOf(−1) = 2
  - **The crux**: −1 ∉ ⟨5⟩ (the one step absent from Mathlib)
  - Disjointness via parity split
  - Order count |(ℤ/2ⁿ⁺³ℤ)ˣ| = 2ⁿ⁺²
  - **The structure theorem** `isComplement'_neg_one_five`
  - Carmichael recovery λ(2ᵏ) = 2ᵏ⁻²

## Verification
- JSON parses; annotation validator reports **0 errors for this proof** (all startLines land on a `/-` docstring or declaration). Pre-existing gallery-wide validator noise is unrelated.
- Axiom integrity preserved: meta already records verified / 0-axiom / kernel `decide` (not native_decide), consistent with the Lean source.