### PR TITLE
research(gamma-reflection-oq-01-oq-03-oq-01): double-factorial half-integer Γ form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2914,6 +2914,7 @@ import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ03
+import Proofs.GammaReflectionFormulaOQ01OQ03OQ01
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean
@@ -1,0 +1,119 @@
+/-
+# Gamma Reflection OQ-01-OQ-03-OQ-01: The double-factorial half-integer form `Γ(n+1/2) = (2n-1)‼·√π / 2ⁿ`
+
+**Open question (parent `GammaReflectionFormulaOQ01OQ03`).** The parent file proves the
+half-integer closed form
+
+> `Γ(n + 1/2) = (2n)! · √π / (4ⁿ · n!)`.
+
+The natural next packaging replaces the central-binomial bookkeeping by the **odd double
+factorial** `(2n-1)‼ = 1·3·5·⋯·(2n-1)`, the genuinely "half-integer" object:
+
+> `Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ`.
+
+The bridge between the two presentations is the purely combinatorial identity
+
+> `(2n)! / (4ⁿ · n!) = (2n-1)‼ / 2ⁿ`,   equivalently   `(2n)! = (2n-1)‼ · 2ⁿ · n!`,
+
+which is exactly the request of the open question.
+
+## What is new
+
+Mathlib records the two halves of the bridge separately — the *even* double factorial
+`Nat.doubleFactorial_two_mul : (2n)‼ = 2ⁿ·n!` and the factorial split
+`Nat.factorial_eq_mul_doubleFactorial : (n+1)! = (n+1)‼·n‼` — but it does **not** record
+their product `(2n)! = (2n-1)‼·2ⁿ·n!`, nor the resulting odd-double-factorial form of the
+half-integer `Γ`. Both are derived here.
+
+## Method
+
+`(2n)! = (2n)‼ · (2n-1)‼` (factorial split at `2n = (2n-1)+1`) and `(2n)‼ = 2ⁿ·n!` give the
+integer identity `two_mul_factorial_eq` in a single case split on `n`. Casting to `ℝ` and
+clearing `4ⁿ = 2ⁿ·2ⁿ` yields the rational equivalence; substituting it into the parent's
+closed form yields the double-factorial `Γ` value.
+
+## References
+
+* Mathlib: `Mathlib/Data/Nat/Factorial/DoubleFactorial.lean`,
+  `Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean`.
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.14.
+-/
+import Mathlib
+import Proofs.GammaReflectionFormulaOQ01OQ03
+
+namespace GammaReflectionFormulaOQ01OQ03OQ01
+
+open scoped Real Nat
+
+/-! ## The combinatorial bridge -/
+
+/-- **Factorial in terms of the odd double factorial.**
+`(2n)! = (2n-1)‼ · 2ⁿ · n!` for every `n : ℕ`. Combines the factorial split
+`(2n)! = (2n)‼·(2n-1)‼` with `(2n)‼ = 2ⁿ·n!`. -/
+theorem two_mul_factorial_eq (n : ℕ) :
+    (2 * n)! = (2 * n - 1)‼ * 2 ^ n * n ! := by
+  cases n with
+  | zero => rfl
+  | succ k =>
+    have e1 : 2 * (k + 1) - 1 = 2 * k + 1 := by omega
+    have e2 : 2 * (k + 1) = (2 * k + 1) + 1 := by ring
+    rw [e1, e2, Nat.factorial_eq_mul_doubleFactorial (2 * k + 1),
+      show (2 * k + 1) + 1 = 2 * (k + 1) by ring, Nat.doubleFactorial_two_mul (k + 1)]
+    ring
+
+/-- **The rational equivalence requested by the open question.**
+`(2n)! / (4ⁿ · n!) = (2n-1)‼ / 2ⁿ`. -/
+theorem central_eq_oddDoubleFactorial (n : ℕ) :
+    ((2 * n).factorial : ℝ) / (4 ^ n * (n.factorial : ℝ))
+      = ((2 * n - 1)‼ : ℝ) / 2 ^ n := by
+  have hcast : ((2 * n).factorial : ℝ)
+      = ((2 * n - 1)‼ : ℝ) * 2 ^ n * (n.factorial : ℝ) := by
+    rw [two_mul_factorial_eq]; push_cast; ring
+  have hfac : (n.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  have h2 : (2 : ℝ) ^ n ≠ 0 := by positivity
+  have h4 : (4 : ℝ) ^ n = 2 ^ n * 2 ^ n := by
+    rw [show (4 : ℝ) = 2 * 2 by norm_num, mul_pow]
+  rw [hcast, h4]
+  field_simp
+
+/-! ## The double-factorial half-integer Gamma value -/
+
+/-- **Double-factorial closed form of `Γ` at half-integers.**
+`Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ` for every `n : ℕ`. Obtained from the parent's central
+form `Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!)` by the combinatorial bridge. -/
+theorem gamma_nat_add_half_doubleFactorial (n : ℕ) :
+    Real.Gamma (n + 1 / 2) = ((2 * n - 1)‼ : ℝ) * Real.sqrt π / 2 ^ n := by
+  rw [GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half n]
+  have hcast : ((2 * n).factorial : ℝ)
+      = ((2 * n - 1)‼ : ℝ) * 2 ^ n * (n.factorial : ℝ) := by
+    rw [two_mul_factorial_eq]; push_cast; ring
+  have hfac : (n.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  have h2 : (2 : ℝ) ^ n ≠ 0 := by positivity
+  have h4 : (4 : ℝ) ^ n = 2 ^ n * 2 ^ n := by
+    rw [show (4 : ℝ) = 2 * 2 by norm_num, mul_pow]
+  rw [hcast, h4]
+  field_simp
+
+/-- **Ratio to `Γ(1/2) = √π`.** `Γ(n+1/2)/√π = (2n-1)‼/2ⁿ`: the half-integer Gamma quotient
+is the odd double factorial scaled by `2⁻ⁿ`. -/
+theorem gamma_nat_add_half_div_sqrt_pi_doubleFactorial (n : ℕ) :
+    Real.Gamma (n + 1 / 2) / Real.sqrt π = ((2 * n - 1)‼ : ℝ) / 2 ^ n := by
+  rw [gamma_nat_add_half_doubleFactorial]
+  have hπ : Real.sqrt π ≠ 0 := by positivity
+  field_simp
+
+/-! ## Spot checks -/
+
+/-- `Γ(3/2) = √π/2` read off the double-factorial form at `n = 1` (here `(1)‼ = 1`). -/
+theorem gamma_three_half_doubleFactorial : Real.Gamma (3 / 2) = Real.sqrt π / 2 := by
+  have h := gamma_nat_add_half_doubleFactorial 1
+  norm_num at h
+  exact h
+
+/-- `Γ(5/2) = 3√π/4` read off the double-factorial form at `n = 2` (here `(3)‼ = 3`). -/
+theorem gamma_five_half_doubleFactorial : Real.Gamma (5 / 2) = 3 * Real.sqrt π / 4 := by
+  have h := gamma_nat_add_half_doubleFactorial 2
+  norm_num at h
+  exact h
+
+end GammaReflectionFormulaOQ01OQ03OQ01

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+  "slug": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GammaReflectionFormulaOQ01OQ03"
+    ],
+    "opens": [
+      "scoped Real Nat"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ03OQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Double-Factorial Half-Integer Form Γ(n+1/2) = (2n-1)‼·√π / 2ⁿ",
+  "description": "Recasts the parent's central-binomial closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) through the odd double factorial (2n-1)‼ = 1·3·5·⋯·(2n-1), giving Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. The bridge is the combinatorial identity requested by the open question, (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ, equivalently (2n)! = (2n-1)‼·2ⁿ·n!, proved in a single case split from the factorial split (2n)! = (2n)‼·(2n-1)‼ (Nat.factorial_eq_mul_doubleFactorial) and the even double factorial (2n)‼ = 2ⁿ·n! (Nat.doubleFactorial_two_mul). Casting to ℝ and clearing 4ⁿ = 2ⁿ·2ⁿ yields the rational equivalence; substituting into the parent's verified closed form yields the double-factorial Gamma value, the ratio Γ(n+1/2)/√π = (2n-1)‼/2ⁿ, and the spot checks Γ(3/2) = √π/2, Γ(5/2) = 3√π/4. Mathlib records the even double factorial and the factorial split separately but not their product (2n)! = (2n-1)‼·2ⁿ·n! nor the odd-double-factorial Gamma form. 119 lines, 6 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "factorial",
+      "double-factorial",
+      "combinatorial-identity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "two_mul_factorial_eq: the integer identity (2n)! = (2n-1)‼·2ⁿ·n! for all n : ℕ, the heart of the open question. Proved in a single case split on n by combining the factorial split (2n)! = (2n)‼·(2n-1)‼ (Nat.factorial_eq_mul_doubleFactorial) with the even double factorial (2n)‼ = 2ⁿ·n! (Nat.doubleFactorial_two_mul). Mathlib records the two factors separately but not their product.",
+      "central_eq_oddDoubleFactorial: the rational equivalence requested by the open question, (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ over ℝ, obtained from two_mul_factorial_eq by clearing 4ⁿ = 2ⁿ·2ⁿ.",
+      "gamma_nat_add_half_doubleFactorial: the double-factorial closed form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ for all n : ℕ, obtained by substituting the bridge into the parent's verified central form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!).",
+      "gamma_nat_add_half_div_sqrt_pi_doubleFactorial: the ratio to Γ(1/2), Γ(n+1/2)/√π = (2n-1)‼/2ⁿ, exhibiting the half-integer Gamma quotient as the odd double factorial scaled by 2⁻ⁿ.",
+      "gamma_three_half_doubleFactorial: the spot-check value Γ(3/2) = √π/2 read off the double-factorial form at n = 1, where (1)‼ = 1.",
+      "gamma_five_half_doubleFactorial: the spot-check value Γ(5/2) = 3√π/4 read off the double-factorial form at n = 2, where (3)‼ = 3."
+    ],
+    "prerequisites": [
+      "The parent's half-integer closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) (GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half)",
+      "Nat.doubleFactorial and its notation n‼, with the even-index value (2n)‼ = 2ⁿ·n!",
+      "The factorial split (n+1)! = (n+1)‼·n! (Nat.factorial_eq_mul_doubleFactorial)",
+      "Basic real-field manipulation (field_simp / ring) to clear factorial denominators and 4ⁿ = 2ⁿ·2ⁿ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.doubleFactorial_two_mul",
+        "description": "(2n)‼ = 2ⁿ·n! — the even double factorial in terms of the factorial; one of the two halves of the combinatorial bridge.",
+        "module": "Mathlib.Data.Nat.Factorial.DoubleFactorial"
+      },
+      {
+        "theorem": "Nat.factorial_eq_mul_doubleFactorial",
+        "description": "(n+1)! = (n+1)‼·n‼ — the factorial split; at index 2n it gives (2n)! = (2n)‼·(2n-1)‼, the other half of the bridge.",
+        "module": "Mathlib.Data.Nat.Factorial.DoubleFactorial"
+      },
+      {
+        "theorem": "GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half",
+        "description": "The parent's verified central closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!), substituted into to obtain the double-factorial form.",
+        "module": "Proofs.GammaReflectionFormulaOQ01OQ03"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+      "question": "Combine the double-factorial Gamma value with the Legendre duplication formula Γ(z)Γ(z+1/2) = 2^(1-2z)√π·Γ(2z) to give an independent derivation of (2n)! = (2n-1)‼·2ⁿ·n! at z = n+1, identifying the duplication formula at half-integers with the even/odd double-factorial split of (2n)!.",
+      "significance": "low"
+    },
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-02",
+      "question": "Use the double-factorial form to evaluate the half-line Gaussian moments ∫₀^∞ x^(2n) e^(-x²) dx = (2n-1)‼·√π/2^(n+1), and conversely recover Γ(n+1/2) = (2n-1)‼·√π/2ⁿ from the moment integral via the substitution u = x².",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The parent proves the central-binomial closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!); this entry recasts it through the odd double factorial via the combinatorial bridge (2n)! = (2n-1)‼·2ⁿ·n!."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The root entry establishes Euler's reflection formula and Γ(1/2) = √π, the source of all half-integer Gamma values recast here."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Data.Nat.Factorial.DoubleFactorial",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.doubleFactorial, the even-index value (2n)‼ = 2ⁿ·n! (doubleFactorial_two_mul), and the factorial split (n+1)! = (n+1)‼·n! (factorial_eq_mul_doubleFactorial)."
+    },
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "Classical reference for half-integer values of the Gamma function and the double-factorial bookkeeping (§12.14)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The half-integer values of Euler's Gamma function admit two equivalent closed forms. The central-binomial form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) packages the bookkeeping through factorials and powers of four; the double-factorial form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ uses the odd double factorial (2n-1)‼ = 1·3·5·⋯·(2n-1), the genuinely 'half-integer' object that appears directly in the Gaussian moments ∫ x^(2n) e^(-x²) dx, the volume of the n-ball, and the Wallis product. The two are connected by the elementary identity (2n)! = (2n-1)‼·2ⁿ·n!, itself the product of the even/odd double-factorial split (2n)! = (2n)‼·(2n-1)‼ with (2n)‼ = 2ⁿ·n!. Mathlib records the even double factorial and the factorial split but not their product, nor the odd-double-factorial Gamma value; both are supplied here.",
+    "problemStatement": "Recast the parent's closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) through the odd double factorial as Γ(n+1/2) = (2n-1)‼·√π/2ⁿ, and prove the underlying combinatorial equivalence (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ.",
+    "proofStrategy": "Prove the integer identity (2n)! = (2n-1)‼·2ⁿ·n! by a single case split on n: the case n = 0 is rfl, and for n = k+1 the factorial split (2k+2)! = (2k+2)‼·(2k+1)‼ (Nat.factorial_eq_mul_doubleFactorial at index 2k+1) together with (2k+2)‼ = 2^(k+1)·(k+1)! (Nat.doubleFactorial_two_mul) gives the claim after recognising 2(k+1)-1 = 2k+1. Cast this identity to ℝ; clearing 4ⁿ = 2ⁿ·2ⁿ with field_simp yields the rational equivalence (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ. Substituting the cast identity into the parent's verified closed form and clearing denominators yields the double-factorial Gamma value; dividing by √π gives the ratio form, and norm_num evaluation at n = 1, 2 recovers the spot checks.",
+    "keyInsights": [
+      "The whole bridge is one integer identity, (2n)! = (2n-1)‼·2ⁿ·n!, which factors as the even/odd double-factorial split (2n)! = (2n)‼·(2n-1)‼ composed with (2n)‼ = 2ⁿ·n!.",
+      "No induction is needed for the identity: Nat.factorial_eq_mul_doubleFactorial at index 2k+1 already encodes the recursion, so a single case split on n (to expose 2(k+1)-1 = 2k+1 over ℕ's truncated subtraction) suffices.",
+      "The conversion 4ⁿ = 2ⁿ·2ⁿ is the only non-formal step over ℝ: ring treats 4ⁿ and 2ⁿ as independent atoms, so it must be supplied explicitly before field_simp.",
+      "The odd double factorial (2n-1)‼ is the more natural carrier of half-integer data than the central binomial coefficient: it is exactly the product of odd numbers up to 2n-1 and appears directly in Gaussian moments and n-ball volumes.",
+      "The badge is original: Mathlib has (2n)‼ = 2ⁿ·n! and the factorial split (n+1)! = (n+1)‼·n! but not their product (2n)! = (2n-1)‼·2ⁿ·n! nor the resulting odd-double-factorial Gamma value."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Double-Factorial Form",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "States the open question — recast Γ(n+1/2) through the odd double factorial and prove (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ — identifies the two Mathlib facts (doubleFactorial_two_mul, factorial_eq_mul_doubleFactorial) whose product is missing, and outlines the case-split method.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$, with $(2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$."
+    },
+    {
+      "id": "combinatorial-bridge",
+      "title": "The Combinatorial Bridge",
+      "startLine": 48,
+      "endLine": 78,
+      "summary": "two_mul_factorial_eq proves (2n)! = (2n-1)‼·2ⁿ·n! by a single case split, combining the factorial split with the even double factorial. central_eq_oddDoubleFactorial casts it to ℝ and clears 4ⁿ = 2ⁿ·2ⁿ to give the rational equivalence (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ.",
+      "mathContext": "$(2n)! = (2n)!!\\,(2n-1)!! = 2^{n} n!\\,(2n-1)!!$."
+    },
+    {
+      "id": "double-factorial-gamma",
+      "title": "The Double-Factorial Half-Integer Gamma Value",
+      "startLine": 79,
+      "endLine": 104,
+      "summary": "gamma_nat_add_half_doubleFactorial substitutes the bridge into the parent's central form to give Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. gamma_nat_add_half_div_sqrt_pi_doubleFactorial divides by √π for the rational ratio (2n-1)‼/2ⁿ.",
+      "mathContext": "$\\dfrac{\\Gamma(n+\\tfrac12)}{\\sqrt{\\pi}} = \\dfrac{(2n-1)!!}{2^{n}}$."
+    },
+    {
+      "id": "spot-checks",
+      "title": "Spot Checks at Small Half-Integers",
+      "startLine": 105,
+      "endLine": 119,
+      "summary": "gamma_three_half_doubleFactorial and gamma_five_half_doubleFactorial read Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4 off the double-factorial form at n = 1 (where (1)‼ = 1) and n = 2 (where (3)‼ = 3).",
+      "mathContext": "$\\Gamma(3/2) = \\sqrt{\\pi}/2$, $\\Gamma(5/2) = 3\\sqrt{\\pi}/4$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The double-factorial closed form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ is obtained from the parent's central form via the integer identity (2n)! = (2n-1)‼·2ⁿ·n!, proved in one case split from the even/odd double-factorial split and (2n)‼ = 2ⁿ·n!. The rational equivalence (2n)!/(4ⁿ n!) = (2n-1)‼/2ⁿ requested by the open question, the ratio Γ(n+1/2)/√π = (2n-1)‼/2ⁿ, and the spot checks Γ(3/2) = √π/2, Γ(5/2) = 3√π/4 all follow. 119 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib has the even double factorial (2n)‼ = 2ⁿ·n! and the factorial split (n+1)! = (n+1)‼·n! but not their product (2n)! = (2n-1)‼·2ⁿ·n! nor the odd-double-factorial Gamma value — hence the original badge. The double-factorial form is the natural input for Gaussian moments and n-ball volumes.",
+    "openQuestions": [
+      "Reprove (2n)! = (2n-1)‼·2ⁿ·n! from the Legendre duplication formula at half-integers.",
+      "Use the double-factorial form to evaluate the half-line Gaussian moments ∫₀^∞ x^(2n) e^(-x²) dx = (2n-1)‼·√π/2^(n+1)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of `gamma-reflection-formula-oq-01-oq-03` (parent verified, 0-ax): recast the half-integer Gamma value through the **odd double factorial**.

> `Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ`   for all `n : ℕ`,

and prove the combinatorial equivalence requested verbatim:

> `(2n)! / (4ⁿ · n!) = (2n-1)‼ / 2ⁿ`,   equivalently   `(2n)! = (2n-1)‼ · 2ⁿ · n!`.

## What is new

The heart is the integer identity `two_mul_factorial_eq : (2n)! = (2n-1)‼·2ⁿ·n!`, proved in a **single case split** by composing two Mathlib facts that exist only in isolation:
- `Nat.factorial_eq_mul_doubleFactorial` — the split `(2n)! = (2n)‼·(2n-1)‼`,
- `Nat.doubleFactorial_two_mul` — the even value `(2n)‼ = 2ⁿ·n!`.

Mathlib records both factors but **not** their product, nor the resulting odd-double-factorial `Γ` value. Casting to `ℝ` and clearing `4ⁿ = 2ⁿ·2ⁿ` gives the rational equivalence; substituting into the parent's verified closed form `Γ(n+1/2) = (2n)!√π/(4ⁿn!)` gives the double-factorial form, the ratio `Γ(n+1/2)/√π = (2n-1)‼/2ⁿ`, and the spot checks `Γ(3/2)=√π/2`, `Γ(5/2)=3√π/4`.

## Verification

- 6 theorems, 119 lines, **0 axioms, 0 sorries**.
- `#print axioms` lists only `propext`/`Classical.choice`/`Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
- Built with `lake env lean Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean` (Docker daemon unavailable this session; host Lean against the shared Mathlib build, parent olean present).

## Files
- `proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01.lean` (new)
- `proofs/Proofs.lean` (register import)
- `src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01/meta.json` (gallery entry, badge `original`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)