### PR TITLE
Enrich closed-projection characterization of compactness: add index.ts + annotations

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cfsc010101-overview",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 60 },
+    "type": "context",
+    "title": "The Closed-Projection Characterization of Compactness",
+    "content": "The module docstring frames the result: Kuratowski's characterization says Y is compact iff for every space X the projection X × Y → X is closed. This file proves the forward direction (Y compact ⟹ projection closed) and, crucially, does so through the tube lemma the parent entry built by hand from the bare finite-subcover (Heine–Borel) definition — deliberately NOT citing Mathlib's filter-based isClosedMap_fst_of_compactSpace. The converse (closed projection for all X ⟹ Y compact) is genuinely harder, needing a witnessing space like the one-point compactification or an ultrafilter argument, and is deferred to a future leaf.",
+    "mathContext": "$Y \\text{ compact} \\iff \\forall X,\\ \\mathrm{Prod.fst}:X\\times Y\\to X \\text{ is a closed map}$.",
+    "significance": "context",
+    "relatedConcepts": ["compactness", "closed map", "product topology", "tube lemma", "Kuratowski characterization"],
+    "prerequisites": ["point-set topology", "compact spaces", "the parent's tube lemma"]
+  },
+  {
+    "id": "ann-cfsc010101-headline",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 68, "endLine": 92 },
+    "type": "insight",
+    "title": "The Headline: Closed Image via the Tube Lemma",
+    "content": "isClosed_fst_image_of_compactSpace is the substance of the file. To show Prod.fst '' C is closed for a closed C ⊆ X × Y, the proof rewrites the goal as openness of the complement (isOpen_compl_iff, isOpen_iff_forall_mem_open). Fix x₀ outside the image: then (x₀, y) ∉ C for every y, so the entire vertical slice {x₀} × Y lies in the open set Cᶜ (C closed ⟹ Cᶜ open). The parent's tube_lemma_compactSpace upgrades this fibre-wide miss to an open tube W ×ˢ univ ⊆ Cᶜ around x₀, and that base W is the required neighbourhood disjoint from the image — if some x' ∈ W projected from (a, b) ∈ C, then (x', b) ∈ W ×ˢ univ ⊆ Cᶜ would contradict (a, b) ∈ C.",
+    "mathContext": "$x_0 \\notin \\mathrm{fst}(C) \\Rightarrow \\{x_0\\}\\times Y \\subseteq C^c \\Rightarrow W \\times Y \\subseteq C^c$, so $W$ misses $\\mathrm{fst}(C)$.",
+    "significance": "key",
+    "relatedConcepts": ["tube lemma", "open complement", "image of a set", "neighbourhood basis"],
+    "prerequisites": ["isOpen_iff_forall_mem_open", "IsClosed.isOpen_compl", "tube_lemma_compactSpace"]
+  },
+  {
+    "id": "ann-cfsc010101-isclosedmap",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 94, "endLine": 108 },
+    "type": "technique",
+    "title": "IsClosedMap Packaging and the Symmetric Statement",
+    "content": "isClosedMap_fst_via_tube repackages the headline in the bundled IsClosedMap form for a compact second factor. isClosedMap_snd_via_tube then derives the symmetric statement — Prod.snd : X × Y → Y is closed when the FIRST factor X is compact — with no new topological work: Prod.snd factors definitionally as Prod.fst ∘ (Homeomorph.prodComm X Y), and a composite of closed maps is closed (IsClosedMap.comp), the swap homeomorphism being a closed map. A clean reuse rather than a re-proof.",
+    "mathContext": "$Y \\text{ compact} \\Rightarrow \\mathrm{fst} \\text{ closed}$; $\\ X \\text{ compact} \\Rightarrow \\mathrm{snd} = \\mathrm{fst} \\circ \\mathrm{swap} \\text{ closed}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsClosedMap", "Homeomorph.prodComm", "composition of closed maps", "duality of projections"],
+    "prerequisites": ["closed maps", "homeomorphisms as closed maps", "IsClosedMap.comp"]
+  },
+  {
+    "id": "ann-cfsc010101-existential",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 124 },
+    "type": "insight",
+    "title": "Existential Projection as Quantifier Elimination",
+    "content": "isClosed_exists_of_compactSpace recasts the headline in logical dress: the 'shadow' {x | ∃ y, (x, y) ∈ C} of a closed set is closed when the bound variable ranges over a compact space — because that shadow is exactly Prod.fst '' C. This exposes the result as a topological quantifier elimination: an existential over a COMPACT variable preserves closedness. It is the elementary shadow of properness and of the compactness step in quantifier elimination for real-closed fields.",
+    "mathContext": "$\\{x \\mid \\exists y,\\ (x,y) \\in C\\} = \\mathrm{Prod.fst}\\,''\\,C$ is closed when $Y$ is compact.",
+    "significance": "key",
+    "relatedConcepts": ["quantifier elimination", "proper map", "projection shadow", "closedness under ∃"],
+    "prerequisites": ["set-builder/image identities", "the headline lemma"]
+  },
+  {
+    "id": "ann-cfsc010101-emptyfibre",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 126, "endLine": 140 },
+    "type": "concept",
+    "title": "The Dual: Empty-Fibre Set Is Open",
+    "content": "isOpen_emptyFibre_of_compactSpace is the dual of the existential corollary: the set of base points whose fibre over C is empty, {x | ∀ y, (x, y) ∉ C}, is open. It equals the complement of Prod.fst '' C, so its openness is immediate from the headline's closedness. Where ∃ over a compact variable preserves closedness, ∀ over a compact variable preserves openness — the two faces of the same projection fact.",
+    "mathContext": "$\\{x \\mid \\forall y,\\ (x,y) \\notin C\\} = (\\mathrm{Prod.fst}\\,''\\,C)^c$ is open.",
+    "significance": "supporting",
+    "relatedConcepts": ["open complement", "universal quantifier", "duality ∃/∀", "empty fibre"],
+    "prerequisites": ["IsClosed.isOpen_compl", "the headline lemma"]
+  },
+  {
+    "id": "ann-cfsc010101-instance",
+    "proofId": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+    "range": { "startLine": 142, "endLine": 146 },
+    "type": "concept",
+    "title": "Concrete Instance: ℝ × [0,1] → ℝ Is Closed",
+    "content": "isClosedMap_fst_real_unitInterval instantiates the abstract result at the compact fibre unitInterval = [0,1], showing the projection ℝ × [0,1] → ℝ is a closed map. The contrast with the non-compact case is the moral of the theorem: the closed hyperbola {(x, y) : xy = 1} ⊆ ℝ × ℝ projects onto the NON-closed set ℝ \\ {0}, so compactness of the fibre is genuinely necessary — it is what promotes a pointwise miss to a uniform one.",
+    "mathContext": "$\\mathrm{Prod.fst}:\\mathbb{R}\\times[0,1]\\to\\mathbb{R}$ is closed; cf. $\\{xy=1\\}$ projecting to $\\mathbb{R}\\setminus\\{0\\}$ (non-closed) for the non-compact fibre $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit interval", "compact subspace", "counterexample", "necessity of compactness"],
+    "prerequisites": ["compactness of [0,1]", "the IsClosedMap packaging"]
+  }
+]

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CompactnessFiniteSubcoverOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const compactnessFiniteSubcoverOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const compactnessFiniteSubcoverOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const compactnessFiniteSubcoverOq01Oq01Oq01Data: ProofData = {
+  proof: compactnessFiniteSubcoverOq01Oq01Oq01Proof,
+  annotations: compactnessFiniteSubcoverOq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-01-oq-01/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "compactness-finite-subcover-oq-01-oq-01-oq-01",
   "slug": "compactness-finite-subcover-oq-01-oq-01-oq-01",
+  "description": "The forward half of the closed-projection (Kuratowski) characterization of compactness: if Y is compact then for every space X the projection Prod.fst : X × Y → X is a closed map. Answering the parent's first open question, the proof runs entirely through the tube lemma that the parent built by hand from the finite-subcover (Heine–Borel) definition — no appeal to Mathlib's filter-based isClosedMap_fst_of_compactSpace. To show Prod.fst '' C is closed for a closed C, its complement is shown open: a base point x₀ outside the image has its whole fibre {x₀} × Y inside the open Cᶜ, and the tube lemma thickens that fibre-wide miss to a tube W ×ˢ univ ⊆ Cᶜ whose base W misses the image. Packaged as IsClosedMap, mirrored to a compact first factor via the swap homeomorphism, and shipped with existential-projection / empty-fibre corollaries and a concrete ℝ × [0,1] → ℝ instance. Verified, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib",


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-01-oq-01-oq-01` (The Closed-Projection Characterization of Compactness, Forward Direction).

## What was missing
Rich meta.json but **no `index.ts`** (page renders 'proof not found' on the live site), **no `annotations.json`**, and **no top-level `description`** field (passes: 0, quality: 45).

## Changes
- **index.ts**: created from the standard template (import filename `CompactnessFiniteSubcoverOQ01OQ01OQ01`) so Vite discovers the proof.
- **meta.json**: added the missing top-level `description`.
- **annotations.json**: 6 annotations covering the full 146-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Overview: Kuratowski's characterization; forward direction via the parent's hand-built tube lemma
  - **The headline** `isClosed_fst_image_of_compactSpace` — closed image via the tube lemma
  - IsClosedMap packaging + the compact-first-factor symmetry via the swap homeomorphism
  - Existential projection as topological quantifier elimination
  - The empty-fibre dual (∀ over a compact variable preserves openness)
  - Concrete ℝ × [0,1] → ℝ instance, with the non-compact hyperbola counterexample

## Verification
- JSON parses; annotation validator reports **0 errors for this proof** (all startLines land on a `/-`/`/--` docstring). Pre-existing gallery-wide validator noise is unrelated.
- Axiom integrity preserved: verified / 0-axiom / 0-sorry, consistent with the Lean source.