### PR TITLE
Enrich negative-Pell best √2 approximations (pell-equation-oq-06-oq-04)

### DIFF
--- a/src/data/proofs/pell-equation-oq-06-oq-04/annotations.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "The analytic meaning of the negative-Pell chain",
+    "content": "The parent `pell-equation-oq-06` builds the chain `(1,1) → (7,5) → (41,29) → (239,169) → …` of solutions of `x² − 2y² = −1`, and earlier siblings give its *algebraic* structure (descent, powers of `1+√2`, the order-2 recurrence `uₙ₊₂ = 6uₙ₊₁ − uₙ`). This entry records the chain's *analytic* meaning: the ratios `xₙ/yₙ` are the best rational approximations to `√2` arising from this equation, and they converge to `√2`. Because `xₙ² − 2yₙ² = −1 < 0`, every ratio *underestimates* `√2` (approximation from below). The defining identity factors over ℝ as `(xₙ − yₙ√2)(xₙ + yₙ√2) = −1`, giving the exact error `√2 − xₙ/yₙ = 1/(yₙ(xₙ+yₙ√2))`, bounded by the classical Diophantine estimate `|xₙ/yₙ − √2| < 1/yₙ²`. Classically these are the odd-indexed convergents of the continued fraction of `√2`.",
+    "mathContext": "$\\dfrac{x_n}{y_n} < \\sqrt2,\\qquad \\left|\\dfrac{x_n}{y_n}-\\sqrt2\\right| < \\dfrac{1}{y_n^2},\\qquad \\dfrac{x_n}{y_n}\\to\\sqrt2.$",
+    "significance": "key",
+    "relatedConcepts": ["negative Pell equation", "Diophantine approximation", "continued fraction convergents", "best rational approximation", "√2"],
+    "prerequisites": ["Pell's equation", "rational approximation", "limits of sequences"]
+  },
+  {
+    "id": "ann-y-grows",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 55, "endLine": 78 },
+    "type": "technique",
+    "title": "The denominators grow without bound",
+    "content": "`negPellSeq_snd_strictMono` shows the second coordinates strictly increase: `yₙ₊₁ = 2xₙ + 3yₙ > yₙ` since `xₙ, yₙ ≥ 1` (via the parent's `negPellSeq_succ` and positivity, closed by `linarith`). `negPellSeq_snd_lower` upgrades this to the linear lower bound `n + 1 ≤ yₙ` by induction. This is exactly what is needed downstream: the Diophantine error is `< 1/yₙ²`, so driving `yₙ → ∞` forces the error to `0` and hence convergence. Monotonicity of the denominators is the analytic engine that turns a per-index error bound into a convergence statement.",
+    "mathContext": "$y_{n+1} = 2x_n + 3y_n > y_n$ and $n+1 \\le y_n$, so $y_n \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict monotonicity", "strictMono_nat_of_lt_succ", "linear lower bound", "divergence to infinity"],
+    "prerequisites": ["monotone sequences", "induction"]
+  },
+  {
+    "id": "ann-approx-core",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 80, "endLine": 144 },
+    "type": "insight",
+    "title": "The engine: the factorization that yields the exact error",
+    "content": "`approx_core` is the analytic heart, packaging three facts per index `n` from a single factorization. Writing `a = xₙ`, `b = yₙ`, `s = √2`, the norm `a² − 2b² = −1` factors as `(a + bs)(a − bs) = −1` (using `s² = 2`). Since `a + bs > 0`, the conjugate `a − bs = −1/(a+bs) < 0`, which immediately gives **approximation from below** `a < bs`, i.e. `xₙ/yₙ < √2`. Rearranging yields the *exact* ratio error `|a/b − s| = 1/(b(a+bs))`, from which two reciprocal bounds follow: `≤ b⁻¹` (with `a + bs ≥ 1`, used for the squeeze in convergence) and `< 1/b²` (the Diophantine quality bound, since `a + bs > b` as `a ≥ 1` and `s > 1`). The algebra is discharged by `linear_combination`, `field_simp`, and `nlinarith`. Everything public is a projection of this one lemma.",
+    "mathContext": "$(a+bs)(a-bs) = a^2 - 2b^2 = -1 \\Rightarrow s - \\dfrac{a}{b} = \\dfrac{1}{b(a+bs)} \\in \\big(0,\\;\\tfrac{1}{b^2}\\big].$",
+    "significance": "key",
+    "relatedConcepts": ["conjugate factorization", "norm form", "exact error identity", "linear_combination", "nlinarith"],
+    "prerequisites": ["difference of squares", "inequalities over ℝ", "real square roots"]
+  },
+  {
+    "id": "ann-public-theorems",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 146, "endLine": 173 },
+    "type": "insight",
+    "title": "Underestimation and the Diophantine quality bound",
+    "content": "The public per-index theorems are projections of `approx_core`. `negPellSeq_fst_lt_snd_mul_sqrt2` (`xₙ < yₙ√2`) and its division form `negPellSeq_ratio_lt_sqrt2` (`xₙ/yₙ < √2`) record that the chain approximates `√2` strictly from below — a direct consequence of the norm being `−1` (negative). `negPellSeq_approx_bound` is the Diophantine quality bound `|xₙ/yₙ − √2| < 1/yₙ²`, the hallmark of continued-fraction convergents: rationals `p/q` with `|p/q − √2| < 1/q²` are exactly the convergents (by Legendre's theorem). That the negative-Pell solutions meet this bound confirms they are the odd-indexed convergents of `√2`.",
+    "mathContext": "$\\dfrac{x_n}{y_n} < \\sqrt2$ and $\\left|\\dfrac{x_n}{y_n}-\\sqrt2\\right| < \\dfrac{1}{y_n^2}$ (Legendre's convergent criterion).",
+    "significance": "key",
+    "relatedConcepts": ["Legendre's theorem", "convergents", "approximation from below", "Diophantine quality"],
+    "prerequisites": ["continued fractions", "the approx_core engine"]
+  },
+  {
+    "id": "ann-convergence",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 175, "endLine": 199 },
+    "type": "insight",
+    "title": "Convergence xₙ/yₙ → √2 by squeezing the error",
+    "content": "`negPellSeq_snd_tendsto_atTop` pushes `yₙ → +∞` (over ℝ) from the linear lower bound `n + 1 ≤ yₙ` via `tendsto_atTop_mono` against `tendsto_natCast_atTop_atTop`. `negPellSeq_ratio_tendsto_sqrt2` then concludes `xₙ/yₙ → √2`: rewriting convergence as `dist(xₙ/yₙ, √2) → 0`, a squeeze (`squeeze_zero`) bounds the distance between `0` and `yₙ⁻¹` (from `approx_core`'s `≤ b⁻¹` bound), and `yₙ⁻¹ → 0` because `yₙ → ∞` (`tendsto_inv_atTop_zero`). The two ingredients — a per-index error `≤ 1/yₙ` and divergent denominators — combine into the limit, exactly the analytic content the parent's algebraic chain was missing.",
+    "mathContext": "$0 \\le \\mathrm{dist}\\!\\left(\\tfrac{x_n}{y_n}, \\sqrt2\\right) \\le y_n^{-1} \\to 0$ since $y_n\\to\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["squeeze_zero", "tendsto_inv_atTop_zero", "convergence in ℝ", "tendsto_atTop_mono"],
+    "prerequisites": ["limits", "the squeeze theorem"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "pell-equation-oq-06-oq-04",
+    "range": { "startLine": 201, "endLine": 209 },
+    "type": "context",
+    "title": "Sanity checks: the first ratios below √2",
+    "content": "The closing examples confirm the first ratios lie below `√2`: `x₁/y₁ = 7/5 = 1.4` and `x₂/y₂ = 41/29 ≈ 1.4138`, both `< √2 ≈ 1.41421356…`, instances of `negPellSeq_ratio_lt_sqrt2`. They make concrete the abstract 'approximation from below' claim and illustrate the rapid (quadratic) convergence: each step roughly doubles the number of correct digits, consistent with the `1/yₙ²` error bound and the denominators `1, 5, 29, 169, …` growing geometrically.",
+    "mathContext": "$\\tfrac{7}{5}=1.4,\\;\\tfrac{41}{29}\\approx1.4138 < \\sqrt2\\approx1.41421356$; denominators $1,5,29,169,\\dots$ grow geometrically.",
+    "significance": "context",
+    "relatedConcepts": ["concrete verification", "quadratic convergence", "geometric growth of denominators"],
+    "prerequisites": ["arithmetic verification"]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-06-oq-04/index.ts
+++ b/src/data/proofs/pell-equation-oq-06-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ06OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOq06Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOq06Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOq06Oq04Data: ProofData = {
+  proof: pellEquationOq06Oq04Proof,
+  annotations: pellEquationOq06Oq04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-06-oq-04` (Negative Pell x²−2y²=−1: The Chain Gives the Best Rational Approximations to √2).

**Gap fixed:** the entry was missing both `index.ts` and `annotations.json`. Without `index.ts` the proof page renders 'proof not found' on the live site.

**Added:**
- `index.ts` — Vite entry point sourcing `Proofs/PellEquationOQ06OQ04.lean`.
- `annotations.json` — 6 annotations with full file coverage, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Header: the analytic meaning of the negative-Pell chain
  - denominator growth yₙ→∞
  - `approx_core` — the conjugate factorization giving the exact error
  - underestimation + the Diophantine bound |xₙ/yₙ−√2|<1/yₙ²
  - convergence xₙ/yₙ→√2 by squeeze
  - sanity checks (7/5, 41/29 below √2)

**Verification:** `pnpm annotations:validate` reports 0 errors for this id; JSON parses; meta.json (`verified`, 0 axioms) left unchanged and consistent with the Lean source.