### PR TITLE
research(hilbert-17): discharge quadratic_psd_is_sos_aux — affine quadratic PSD=SOS (parent axiom 2→1)

### DIFF
--- a/proofs/Proofs/Hilbert17QuadraticGram.lean
+++ b/proofs/Proofs/Hilbert17QuadraticGram.lean
@@ -323,4 +323,161 @@ theorem homogeneous_quadratic_psd_isSumSq (Q : MvPolynomial (Fin n) ℝ)
   obtain ⟨m, q, hq⟩ := posSemidef_matrixQuadratic_isSumSq hM
   exact ⟨m, q, hrepr.trans hq⟩
 
+/-! ## Affine homogenisation — the full `totalDegree ≤ 2` case
+
+Given an arbitrary `Q : MvPolynomial (Fin n) ℝ` with `totalDegree Q ≤ 2` that is
+positive semidefinite, we homogenise by one extra coordinate `x₀ = X 0`: each
+monomial `X^d` of `Q` (necessarily of degree `≤ 2`) is replaced by
+`x₀^{2 - deg d} · X^d`, lifted to `Fin (n+1)` via `Finsupp.cons`.  The result
+`homogenize Q` is a genuine *homogeneous* quadratic form in `n+1` variables.
+
+* `homogenize_isHomogeneous` — it really is homogeneous of degree 2;
+* `eval_cons_one_homogenize` — setting `x₀ = 1` recovers `Q` at the value level;
+* `homogenize_nonneg` — PSD transfers: on `{x₀ ≠ 0}` by a homogeneity scaling
+  identity, and at `x₀ = 0` by continuity (polynomial evaluation is continuous);
+* `affine_quadratic_psd_isSumSq` — feed the homogeneous theorem and dehomogenise
+  the resulting linear forms (`bind₁ (Fin.cons 1 X)`) back to affine forms in `n`
+  variables.  This is the full affine case of `quadratic_psd_is_sos_aux`. -/
+
+/-- Degree of a `Finsupp.cons`: the new head coordinate adds to the tail degree. -/
+lemma degree_cons (y : ℕ) (s : Fin n →₀ ℕ) :
+    (Finsupp.cons y s).degree = y + s.degree := by
+  rw [Finsupp.degree_eq_sum, Finsupp.degree_eq_sum, Fin.sum_univ_succ]
+  simp [Finsupp.cons_zero, Finsupp.cons_succ]
+
+/-- **Homogenisation by one extra coordinate.**  Each monomial `X^d` of `Q`
+    becomes `X 0 ^ (2 - deg d) · X^d`, the variables shifted up by one index via
+    `Finsupp.cons`.  For `totalDegree Q ≤ 2` every term lands in degree exactly 2. -/
+noncomputable def homogenize (Q : MvPolynomial (Fin n) ℝ) : MvPolynomial (Fin (n + 1)) ℝ :=
+  ∑ d ∈ Q.support, monomial (Finsupp.cons (2 - d.degree) d) (Q.coeff d)
+
+/-- For `totalDegree Q ≤ 2`, the homogenisation is homogeneous of degree 2. -/
+lemma homogenize_isHomogeneous (Q : MvPolynomial (Fin n) ℝ) (hQ : Q.totalDegree ≤ 2) :
+    (homogenize Q).IsHomogeneous 2 := by
+  apply IsHomogeneous.sum
+  intro d hd
+  apply isHomogeneous_monomial
+  rw [degree_cons]
+  have hdle : d.degree ≤ 2 := by
+    calc d.degree = d.sum (fun _ e => e) := rfl
+      _ ≤ Q.totalDegree := le_totalDegree hd
+      _ ≤ 2 := hQ
+  omega
+
+/-- **Scaling identity for homogeneous quadratics.**  For a homogeneous degree-2
+    polynomial, evaluation scales as `eval (c • x) p = c² · eval x p`. -/
+lemma eval_smul_homogeneous {m : ℕ} {p : MvPolynomial (Fin m) ℝ} (hp : p.IsHomogeneous 2)
+    (c : ℝ) (x : Fin m → ℝ) : eval (c • x) p = c ^ 2 * eval x p := by
+  conv_lhs => rw [p.as_sum]
+  conv_rhs => rw [p.as_sum]
+  rw [map_sum, map_sum, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  rw [eval_monomial, eval_monomial,
+      Finsupp.prod_fintype _ _ (fun i => pow_zero _),
+      Finsupp.prod_fintype _ _ (fun i => pow_zero _)]
+  have hdeg : d.degree = 2 := by
+    by_contra h; exact (mem_support_iff.mp hd) (hp.coeff_eq_zero h)
+  simp only [Pi.smul_apply, smul_eq_mul, mul_pow]
+  rw [Finset.prod_mul_distrib, Finset.prod_pow_eq_pow_sum, ← Finsupp.degree_eq_sum, hdeg]
+  ring
+
+/-- **Setting `x₀ = 1` recovers `Q`** (value level): evaluating `homogenize Q` at
+    `Fin.cons 1 w` gives `eval w Q`.  The head factor `1 ^ (2 - deg d) = 1`
+    disappears and the shifted variables `X (j+1)` read off `w j`. -/
+lemma eval_cons_one_homogenize (Q : MvPolynomial (Fin n) ℝ) (w : Fin n → ℝ) :
+    eval (Fin.cons (1 : ℝ) w) (homogenize Q) = eval w Q := by
+  rw [homogenize, map_sum]
+  conv_rhs => rw [Q.as_sum, map_sum]
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  rw [eval_monomial, eval_monomial,
+      Finsupp.prod_fintype _ _ (fun i => pow_zero _),
+      Finsupp.prod_fintype _ _ (fun i => pow_zero _)]
+  congr 1
+  rw [Fin.prod_univ_succ]
+  simp [Finsupp.cons_zero, Finsupp.cons_succ, Fin.cons_zero, Fin.cons_succ]
+
+/-- PSD on the dense slice `{x₀ ≠ 0}`: rescale to `x₀ = 1` and use the scaling
+    identity together with `eval_cons_one_homogenize`. -/
+lemma homogenize_nonneg_pos {Q : MvPolynomial (Fin n) ℝ}
+    (hpsd : ∀ x : Fin n → ℝ, 0 ≤ eval x Q) (hQ : Q.totalDegree ≤ 2)
+    (y : Fin (n + 1) → ℝ) (hy : y 0 ≠ 0) : 0 ≤ eval y (homogenize Q) := by
+  set c := y 0 with hc
+  have hc0 : c ≠ 0 := hy
+  set w : Fin n → ℝ := fun j => y (Fin.succ j) * c⁻¹ with hw
+  have hyeq : y = c • (Fin.cons (1 : ℝ) w : Fin (n + 1) → ℝ) := by
+    funext i
+    refine Fin.cases ?_ ?_ i
+    · simp [Fin.cons_zero, hc]
+    · intro j
+      simp only [Pi.smul_apply, Fin.cons_succ, smul_eq_mul, hw]
+      field_simp
+  rw [hyeq, eval_smul_homogeneous (homogenize_isHomogeneous Q hQ),
+      eval_cons_one_homogenize]
+  exact mul_nonneg (sq_nonneg c) (hpsd w)
+
+/-- **PSD transfers to the homogenisation.**  If `Q` is PSD then so is
+    `homogenize Q` — nonnegativity holds on the dense set `x₀ ≠ 0`
+    (`homogenize_nonneg_pos`) and extends to `x₀ = 0` by continuity of polynomial
+    evaluation. -/
+lemma homogenize_nonneg {Q : MvPolynomial (Fin n) ℝ}
+    (hpsd : ∀ x : Fin n → ℝ, 0 ≤ eval x Q) (hQ : Q.totalDegree ≤ 2)
+    (y : Fin (n + 1) → ℝ) : 0 ≤ eval y (homogenize Q) := by
+  by_cases hy : y 0 = 0
+  · have hupd : Continuous fun t : ℝ => Function.update y 0 t :=
+      Continuous.update continuous_const 0 continuous_id
+    have hcont : Continuous fun t : ℝ => eval (Function.update y 0 t) (homogenize Q) :=
+      (MvPolynomial.continuous_eval (p := homogenize Q)).comp hupd
+    have htend : Filter.Tendsto (fun t : ℝ => eval (Function.update y 0 t) (homogenize Q))
+        (nhdsWithin 0 {0}ᶜ) (nhds (eval (Function.update y 0 (0 : ℝ)) (homogenize Q))) :=
+      (hcont.tendsto 0).mono_left nhdsWithin_le_nhds
+    have hpos : ∀ᶠ t in nhdsWithin (0 : ℝ) {0}ᶜ,
+        0 ≤ eval (Function.update y 0 t) (homogenize Q) := by
+      filter_upwards [self_mem_nhdsWithin] with t ht
+      refine homogenize_nonneg_pos hpsd hQ _ ?_
+      simpa using ht
+    have h0 : 0 ≤ eval (Function.update y 0 (0 : ℝ)) (homogenize Q) := ge_of_tendsto htend hpos
+    have hself : Function.update y 0 (0 : ℝ) = y := by
+      rw [← hy]; exact Function.update_eq_self 0 y
+    rwa [hself] at h0
+  · exact homogenize_nonneg_pos hpsd hQ y hy
+
+/-- `eval` of a `bind₁` substitution at `Fin.cons 1 X` equals evaluation at the
+    augmented point `Fin.cons 1 w`. -/
+lemma eval_cons_bind₁ (P : MvPolynomial (Fin (n + 1)) ℝ) (w : Fin n → ℝ) :
+    eval w (bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) P)
+      = eval (Fin.cons (1 : ℝ) w) P := by
+  have h := aeval_bind₁ w (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) P
+  simp only [aeval_eq_eval] at h
+  rw [h]
+  have hfun : (fun i => eval w
+        ((Fin.cons (1 : MvPolynomial (Fin n) ℝ) X : Fin (n + 1) → MvPolynomial (Fin n) ℝ) i))
+      = (Fin.cons (1 : ℝ) w : Fin (n + 1) → ℝ) := by
+    funext i
+    refine Fin.cases ?_ ?_ i
+    · simp [Fin.cons_zero]
+    · intro j; simp [Fin.cons_succ]
+  rw [hfun]
+
+/-- **Affine case of Hilbert 17 for quadratics, fully verified (0 axioms).**
+
+    Every positive-semidefinite polynomial `Q` of `totalDegree ≤ 2` in `n`
+    variables is an honest polynomial sum of squares — of *affine*-linear forms.
+    Homogenise to `homogenize Q` (a PSD homogeneous quadratic in `n+1`
+    variables), apply `homogeneous_quadratic_psd_isSumSq`, then dehomogenise the
+    linear forms by setting `X 0 = 1` (`bind₁ (Fin.cons 1 X)`). -/
+theorem affine_quadratic_psd_isSumSq (Q : MvPolynomial (Fin n) ℝ)
+    (hQ : Q.totalDegree ≤ 2) (hpsd : ∀ x : Fin n → ℝ, 0 ≤ eval x Q) :
+    ∃ (m : ℕ) (q : Fin m → MvPolynomial (Fin n) ℝ), Q = ∑ i, q i ^ 2 := by
+  obtain ⟨m, q, hq⟩ := homogeneous_quadratic_psd_isSumSq (homogenize Q)
+    (homogenize_isHomogeneous Q hQ) (homogenize_nonneg hpsd hQ)
+  have hdeh : bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) (homogenize Q) = Q := by
+    apply MvPolynomial.funext
+    intro w
+    rw [eval_cons_bind₁, eval_cons_one_homogenize]
+  refine ⟨m, fun k => bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) (q k), ?_⟩
+  calc Q = bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) (homogenize Q) := hdeh.symm
+    _ = bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) (∑ k, q k ^ 2) := by rw [hq]
+    _ = ∑ k, (bind₁ (Fin.cons (1 : MvPolynomial (Fin n) ℝ) X) (q k)) ^ 2 := by
+        rw [map_sum]; simp_rw [map_pow]
+
 end Hilbert17

--- a/proofs/Proofs/Hilbert17SumOfSquares.lean
+++ b/proofs/Proofs/Hilbert17SumOfSquares.lean
@@ -7,6 +7,7 @@ import Mathlib.Tactic
 import Proofs.Hilbert17MotzkinNotSOS
 import Proofs.Hilbert17RobinsonNotSOS
 import Proofs.Hilbert17UnivariatePSDSOS
+import Proofs.Hilbert17QuadraticGram
 
 /-!
 # Hilbert's 17th Problem: Sum of Squares Representation
@@ -334,38 +335,34 @@ giving explicit examples. Motzkin (1967) gave the first explicit counterexample.
 theorem univariate_psd_is_sos (p : Polynomial ℝ) (h : IsPositiveSemidefinite p) :
     IsSumOfSquaresPolynomial p := univariate_psd_is_sos_aux p h
 
-/-- **Axiom: Quadratic PSD is Polynomial-SOS**
+/-- **Quadratic PSD is Polynomial-SOS** (the `totalDegree = 2` case of Hilbert's
+    PSD = SOS classification), fully machine-checked with zero axioms.
 
-    Every quadratic form that is PSD can be written as a sum of squares of linear forms.
+    Every PSD polynomial of total degree 2 — affine quadratics included — is an
+    honest sum of squares of affine-linear forms.  The full proof lives in
+    `Proofs/Hilbert17QuadraticGram.lean`
+    (`Hilbert17.affine_quadratic_psd_isSumSq`):
 
-    The proof uses the Gram matrix approach:
-    - Write Q(x) = x^T A x for symmetric matrix A
-    - Q >= 0 everywhere iff A is positive semidefinite
-    - A positive semidefinite iff A = B^T B for some matrix B
-    - This gives Q = ||Bx||^2, a sum of squares of linear forms
+    * the **homogeneous** core (`homogeneous_quadratic_psd_isSumSq`) reads off the
+      symmetric Gram matrix `quadMatrix Q`, shows PSD of `Q` forces it to be a PSD
+      matrix, and applies the Gram engine `posSemidef_quadratic_isSumSq`
+      (`x ⬝ᵥ (M *ᵥ x) = ∑ i, ((√M *ᵥ x) i)²` via `M = (√M)ᵀ (√M)`);
+    * the **affine** case homogenises by one extra coordinate `x₀`
+      (`homogenize Q`, a PSD homogeneous quadratic in `n+1` variables — PSD
+      transfers on `{x₀ ≠ 0}` by a scaling identity and to `x₀ = 0` by continuity
+      of evaluation), applies the homogeneous core, and dehomogenises the linear
+      forms by setting `x₀ = 1` (`bind₁ (Fin.cons 1 X)`).
 
-    Axiomatized because the proof requires:
-    - Correspondence between quadratic polynomials and symmetric matrices
-    - Spectral theorem / Cholesky decomposition for PSD matrices
-    - Matrix algebra and polynomial evaluation
+    The parent's `IsPositiveSemidefiniteMv` / `IsSumOfSquaresMvPolynomial` are
+    definitionally equal to the child's predicates, so the proof transfers by
+    `exact` (with `totalDegree = 2 ⟹ ≤ 2`).
 
-    PROGRESS: the entire **homogeneous** case is now proved with zero axioms in
-    `Proofs.Hilbert17QuadraticGram` (`Hilbert17.homogeneous_quadratic_psd_isSumSq`):
-    every PSD *homogeneous* degree-2 polynomial in any number of variables is a
-    genuine polynomial sum of squares of linear forms.  The chain is
-    `quad_repr` (read off the symmetric Gram matrix `quadMatrix Q` and prove
-    `Q = ∑ i j, (quadMatrix Q) i j · Xᵢ Xⱼ`), then PSD of `Q` forces
-    `quadMatrix Q` to be a PSD matrix, then the Gram engine
-    `posSemidef_quadratic_isSumSq` (`x ⬝ᵥ (M *ᵥ x) = ∑ i, ((√M *ᵥ x) i)²` via
-    `M = (√M)ᵀ (√M)`).  What remains for the *affine* `totalDegree = 2` axiom
-    below is only the standard homogenisation by one extra coordinate (lift to a
-    homogeneous quadratic in `n+1` variables, transfer PSD via a scaling limit,
-    apply the homogeneous result, set the homogenising coordinate to 1); see
-    `research/problems/hilbert-17-oq-03/knowledge.md`. -/
-axiom quadratic_psd_is_sos_aux {n : ℕ} (Q : MvPolynomial (Fin n) ℝ)
+    (Formerly the axiom `quadratic_psd_is_sos_aux`; now fully machine-checked.) -/
+theorem quadratic_psd_is_sos_aux {n : ℕ} (Q : MvPolynomial (Fin n) ℝ)
     (hQ : MvPolynomial.totalDegree Q = 2)
     (h : IsPositiveSemidefiniteMv Q) :
-    IsSumOfSquaresMvPolynomial Q
+    IsSumOfSquaresMvPolynomial Q :=
+  affine_quadratic_psd_isSumSq Q hQ.le h
 
 /-- **Case 2: Quadratic forms that are PSD are polynomial-SOS**
 

--- a/research/problems/hilbert-17-oq-03/knowledge.md
+++ b/research/problems/hilbert-17-oq-03/knowledge.md
@@ -437,6 +437,64 @@ Fin n ↔ Fin (n+1) index juggling + the scaling-limit PSD transfer are the work
   repeatedly — re-`cp` from worktree before every compile, trust the worktree
   commit + the `#print axioms` from the run that actually compiled.
 
-## Still open (parent hilbert-17, 2 axioms remain)
-- `quadratic_psd_is_sos_aux` — homogeneous case DONE; only affine homogenisation left.
-- `pfister_bound_aux` — Pfister's 2ⁿ bound; genuinely deep, no short Mathlib path.
+## Session 2026-06-24 (researcher-1) — AFFINE quadratic PSD=SOS DONE (parent axiom 2 → 1)
+Completed the affine homogenisation, discharging `quadratic_psd_is_sos_aux`
+entirely. Extended `Hilbert17QuadraticGram.lean` (now 483 L, 0 axioms) with the
+headline `affine_quadratic_psd_isSumSq`: every PSD `Q : MvPolynomial (Fin n) ℝ`
+with `totalDegree Q ≤ 2` (affine quadratics included) is a polynomial SOS of
+affine-linear forms. Wired into the parent (`import Proofs.Hilbert17QuadraticGram`;
+`theorem quadratic_psd_is_sos_aux Q hQ h := affine_quadratic_psd_isSumSq Q hQ.le h`
+— parent predicates are defeq to the child's). **Parent axiomCount 2 → 1**
+(only `pfister_bound_aux` remains). Both `quadratic_psd_is_sos_aux` and
+`quadratic_psd_is_sos` `#print axioms` → propext/Classical.choice/Quot.sound.
+
+### The construction (cleaner than the prior "scaling-limit" sketch)
+`homogenize Q := ∑ d ∈ Q.support, monomial (Finsupp.cons (2 - d.degree) d) (coeff d Q)`
+— each monomial `X^d` (deg ≤ 2) becomes `X 0 ^ (2 - deg d) · X^d`, variables
+shifted up one index by `Finsupp.cons`. Then:
+1. `homogenize_isHomogeneous` (deg 2): `IsHomogeneous.sum` + `isHomogeneous_monomial`,
+   degree via `degree_cons : (cons y s).degree = y + s.degree`; `2 - deg d + deg d = 2`
+   since `deg d ≤ totalDegree Q ≤ 2` (`le_totalDegree`).
+2. `eval_cons_one_homogenize`: `eval (Fin.cons 1 w) (homogenize Q) = eval w Q`
+   — the head factor `1 ^ (2-deg d) = 1` vanishes; per-monomial via `eval_monomial`,
+   `Finsupp.prod_fintype`, `Fin.prod_univ_succ`, `cons_zero/cons_succ`. **No
+   division / negative-exponent juggling** (the key simplification vs the t⁻¹ route).
+3. PSD transfer (`homogenize_nonneg`): on `{x₀ ≠ 0}` write `y = c • Fin.cons 1 w`
+   (`c = y 0`, `w j = y (succ j)/c`) and use the **homogeneity scaling identity**
+   `eval_smul_homogeneous : p.IsHomogeneous 2 → eval (c•x) p = c² · eval x p`
+   (proved by `as_sum` + `prod_pow_eq_pow_sum`, `deg d = 2`) ⟹ `= c² · eval w Q ≥ 0`.
+   At `x₀ = 0`: **continuity** — `g t := eval (update y 0 t) (homogenize Q)` is
+   continuous (`MvPolynomial.continuous_eval ∘ Continuous.update`), `≥0` for `t≠0`,
+   so `g 0 = eval y (homogenize Q) ≥ 0` via `ge_of_tendsto` on `𝓝[≠] 0`
+   (`NeBot` for ℝ; `update y 0 0 = y` by `Function.update_eq_self`).
+4. Assembly: apply `homogeneous_quadratic_psd_isSumSq (homogenize Q)` ⟹ `= ∑ qₖ²`,
+   then dehomogenise with `bind₁ (Fin.cons 1 X)` (set `x₀ = 1`):
+   `bind₁ (cons 1 X) (homogenize Q) = Q` by `MvPolynomial.funext` + `eval_cons_bind₁`
+   (= `aeval_bind₁` + `aeval_eq_eval`), and `bind₁` is an alg hom so it pushes
+   through `∑ ()²` (`map_sum`, `map_pow`). Witnesses `qₖ' = bind₁ (cons 1 X) qₖ`.
+
+### Lean gotchas (v4.26, this session)
+- `Fin.cons (1 : T) X` and `c • Fin.cons 1 w` need explicit type ascriptions
+  (`: Fin (n+1) → T`) — the dependent-`cons` motive otherwise fails to synthesise
+  (HSMul/`?m i` typeclass timeout, "argument w expected (i:Fin ?) → ? i.succ").
+- `le_of_tendsto` puts the bound on the RIGHT (`f c ≤ b ⟹ a ≤ b`); for `0 ≤ f`
+  use **`ge_of_tendsto`**.
+- `Continuous.update continuous_const 0 continuous_id` needs the const pinned by
+  the `have`'s explicit type (`Continuous fun t => Function.update y 0 t`) else the
+  constant `?m` is unsolved.
+- `rw [aeval_eq_eval] at h` leaves the RHS `aeval (fun i => …)` un-rewritten (head
+  function differs) → `congr 1` then sees `→ₐ` vs `→+*`; use
+  `simp only [aeval_eq_eval] at h` (rewrites all occurrences), and rewrite the
+  inner substitution function by a separate `have hfun … := by funext; Fin.cases`.
+- BUILD: docker DOWN, Aristotle DOWN (404) again. Verified via MAIN mathlib cache:
+  `cp` worktree sources to `<MAIN>/proofs/Proofs/`, build child oleans
+  (`LAKE_UNSAFE=1 ./bin/lake env lean F.lean -o .lake/build/lib/lean/Proofs/F.olean`)
+  for Gram (new) + Univariate (its olean was MISSING), then `lake env lean` the
+  parent (reads Motzkin/Robinson/Gram/Univariate oleans). `git checkout` the MAIN
+  sources after to leave it clean.
+
+## Still open (parent hilbert-17, 1 axiom remains)
+- `pfister_bound_aux` — Pfister's 2ⁿ bound; genuinely deep (Pfister forms over
+  formally real fields), no short Mathlib path. This is the last axiom; the
+  PSD=SOS *classification* cases (univariate, quadratic-forms) are now all
+  machine-checked 0-axiom, as are both PSD⊋SOS counterexamples (Motzkin, Robinson).

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-17",
   "title": "Hilbert's 17th Problem: Sum of Squares",
   "slug": "hilbert-17",
-  "description": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample). UPDATE: the non-negativity of both classical counterexamples — Motzkin M(x,y)=x⁴y²+x²y⁴−3x²y²+1 (via AM–GM) and Robinson R(x,y,z) (which equals Schur's expression in x²,y²,z²) — is now machine-checked via nlinarith with explicit square certificates, eliminating the axioms motzkin_nonneg_aux and robinson_nonneg_aux (axiom count 10 → 8). FURTHER UPDATE: the non-SOS direction for Motzkin — that M is not a sum of squares of polynomials — is now machine-checked by a fully elementary 0-axiom degree/coefficient argument (Proofs/Hilbert17MotzkinNotSOS.lean), wired into this file so motzkin_not_sos_polynomial is no longer an axiom wrapper (axiom count 8 → 7). FURTHER UPDATE: the univariate case of Artin's theorem — every PSD univariate real polynomial is a sum of squares of polynomials (in fact a sum of two squares) — is now machine-checked by a fully elementary 0-axiom proof (Proofs/Hilbert17UnivariatePSDSOS.lean): strong induction on degree, the fundamental theorem of algebra, even multiplicity of real roots of a non-negative polynomial, and the Brahmagupta–Fibonacci identity. This discharges univariate_psd_is_sos_aux (axiom count 3 → 2; the two remaining axioms are quadratic_psd_is_sos_aux and pfister_bound_aux).",
+  "description": "Artin's theorem: every non-negative polynomial is a sum of squares of rational functions, but not necessarily polynomials (Motzkin's counterexample). UPDATE: the non-negativity of both classical counterexamples — Motzkin M(x,y)=x⁴y²+x²y⁴−3x²y²+1 (via AM–GM) and Robinson R(x,y,z) (which equals Schur's expression in x²,y²,z²) — is now machine-checked via nlinarith with explicit square certificates, eliminating the axioms motzkin_nonneg_aux and robinson_nonneg_aux (axiom count 10 → 8). FURTHER UPDATE: the non-SOS direction for Motzkin — that M is not a sum of squares of polynomials — is now machine-checked by a fully elementary 0-axiom degree/coefficient argument (Proofs/Hilbert17MotzkinNotSOS.lean), wired into this file so motzkin_not_sos_polynomial is no longer an axiom wrapper (axiom count 8 → 7). FURTHER UPDATE: the univariate case of Artin's theorem — every PSD univariate real polynomial is a sum of squares of polynomials (in fact a sum of two squares) — is now machine-checked by a fully elementary 0-axiom proof (Proofs/Hilbert17UnivariatePSDSOS.lean): strong induction on degree, the fundamental theorem of algebra, even multiplicity of real roots of a non-negative polynomial, and the Brahmagupta–Fibonacci identity. This discharges univariate_psd_is_sos_aux (axiom count 3 → 2). FURTHER UPDATE: the quadratic-forms case — every PSD polynomial of total degree 2 (affine quadratics included) is a sum of squares of affine-linear forms — is now machine-checked by a fully elementary 0-axiom proof (Proofs/Hilbert17QuadraticGram.lean): the homogeneous Gram/Cholesky core (a PSD symmetric matrix factors as M = (√M)ᵀ√M, giving x·Mx = Σ((√M x)ᵢ)²) plus affine homogenisation by one extra coordinate x₀ (PSD transfers on {x₀≠0} by a scaling identity and to x₀=0 by continuity of evaluation; dehomogenise by setting x₀=1). This discharges quadratic_psd_is_sos_aux (axiom count 2 → 1; the single remaining axiom is pfister_bound_aux, Pfister's 2ⁿ bound).",
   "meta": {
     "proofRepoPath": "Proofs/Hilbert17SumOfSquares.lean",
     "author": "Emil Artin (1927)",
@@ -44,16 +44,15 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 17,
-    "axiomCount": 2,
-    "lineCount": 579,
+    "axiomCount": 1,
+    "lineCount": 590,
     "assumptions": [
-      "quadratic_psd_is_sos_aux: Every PSD quadratic form is a sum of squares of polynomials (Gram matrix / Cholesky)",
       "pfister_bound_aux: At most 2^n rational function squares needed for n-variable PSD polynomials (Pfister forms)"
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 11,
     "definitionCount": 8,
-    "description": "Axiom-reduction history: three axioms were redundant restatements of deeper ones and are now derived theorems (artin_hilbert17 and cassels_bound_bivariate from pfister_bound_aux; artin_univariate from univariate_psd_is_sos_aux), and three more have been fully discharged by elementary 0-axiom child proofs — motzkin_not_sos_polynomial_aux (Hilbert17MotzkinNotSOS.lean), robinson_not_sos_aux (Hilbert17RobinsonNotSOS.lean), and univariate_psd_is_sos_aux (Hilbert17UnivariatePSDSOS.lean). The two remaining independent axioms are quadratic_psd_is_sos_aux (PSD quadratic forms are SOS, via Gram/Cholesky) and pfister_bound_aux (Pfister's 2ⁿ bound)."
+    "description": "Axiom-reduction history: three axioms were redundant restatements of deeper ones and are now derived theorems (artin_hilbert17 and cassels_bound_bivariate from pfister_bound_aux; artin_univariate from univariate_psd_is_sos_aux), and four more have been fully discharged by elementary 0-axiom child proofs — motzkin_not_sos_polynomial_aux (Hilbert17MotzkinNotSOS.lean), robinson_not_sos_aux (Hilbert17RobinsonNotSOS.lean), univariate_psd_is_sos_aux (Hilbert17UnivariatePSDSOS.lean), and quadratic_psd_is_sos_aux (Hilbert17QuadraticGram.lean: the homogeneous Gram/Cholesky core plus affine homogenisation by one extra coordinate). The single remaining independent axiom is pfister_bound_aux (Pfister's 2ⁿ bound)."
   },
   "overview": {
     "historicalContext": "Hilbert's 17th Problem emerged from a long investigation into the relationship between non-negativity and sums of squares. In 1888, Hilbert proved a remarkable non-constructive result: there exist non-negative polynomials that are not sums of squares of polynomials. He showed this happens in all but three exceptional cases — univariate polynomials, quadratic forms, and bivariate quartics — but gave no explicit example.\n\nIn his famous 1900 Paris lecture, Hilbert posed Problem 17: even if polynomial squares don't suffice, can every non-negative polynomial be written as a sum of squares of rational functions (quotients of polynomials)? This seemingly modest weakening turns out to be exactly right.\n\nEmil Artin resolved the problem affirmatively in 1927, as an application of his theory of formally real fields and real closures. The proof is a triumph of abstract algebra: if a non-negative polynomial were not a sum of squares of rational functions, one could construct an ordering of the function field making it negative, which contradicts non-negativity via the transfer principle for real closed fields.\n\nNearly 40 years after Hilbert's non-constructive existence proof, Theodore Motzkin (1967) gave the first explicit counterexample to polynomial SOS: M(x,y) = x⁴y² + x²y⁴ - 3x²y² + 1 is non-negative everywhere (by AM-GM) but cannot be decomposed as a sum of squared polynomials (by degree analysis). In the same year, Albrecht Pfister proved that at most 2^n rational function squares are needed for n-variable polynomials.",
@@ -112,7 +111,7 @@
       "title": "Part IV: Hilbert's 1888 Classification",
       "startLine": 269,
       "endLine": 343,
-      "summary": "Axiomatizes univariate_psd_is_sos (complex factorization) and quadratic_psd_is_sos (Gram matrix / Cholesky) — the two tractable cases from Hilbert's classification.",
+      "summary": "Both tractable cases are now machine-checked, zero axioms: univariate_psd_is_sos (complex factorization, Hilbert17UnivariatePSDSOS.lean) and quadratic_psd_is_sos (Gram/Cholesky core plus affine homogenisation, Hilbert17QuadraticGram.lean).",
       "mathContext": "**Hilbert 1888**: PSD = polynomial-SOS in exactly 3 cases: (1) univariate ($n=1$, any degree), (2) quadratic forms (any $n$, degree 2), (3) bivariate quartics ($n=2$, degree 4). **Univariate**: $f(x) \\geq 0 \\Rightarrow f = g^2 + h^2$ via $f = c\\prod(x-\\alpha_i)(x-\\bar{\\alpha}_i)$. **Quadratic**: PSD $\\iff$ Gram matrix $Q \\succeq 0$ $\\iff$ Cholesky $Q = L^TL$."
     },
     {
@@ -214,9 +213,9 @@
       "RatFunc"
     ],
     "namespace": "Hilbert17",
-    "lineCount": 579,
-    "axiomCount": 2,
-    "theoremCount": 10,
+    "lineCount": 590,
+    "axiomCount": 1,
+    "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Hilbert17SumOfSquares.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Discharges the axiom **`quadratic_psd_is_sos_aux`** in `Hilbert17SumOfSquares.lean` with a fully elementary, **0-axiom** proof — completing the quadratic-forms case of Hilbert's PSD = SOS classification. **Parent `hilbert-17` axiomCount 2 → 1** (only `pfister_bound_aux`, Pfister's 2ⁿ bound, remains).

The prior session proved the *homogeneous* quadratic case; this session adds the **affine homogenisation** that was the only remaining gap, and wires it into the parent.

## New headline (zero axioms)

`Hilbert17.affine_quadratic_psd_isSumSq` — every PSD `Q : MvPolynomial (Fin n) ℝ` with `totalDegree Q ≤ 2` (affine quadratics, not just homogeneous forms) is a genuine polynomial sum of squares of affine-linear forms.

## Construction

1. **`homogenize Q`** — lift each monomial `X^d` (degree ≤ 2) to `X 0 ^ (2 - deg d) · X^d` in `Fin (n+1)` via `Finsupp.cons`; homogeneous of degree 2 (`homogenize_isHomogeneous`).
2. **`eval_cons_one_homogenize`** — `eval (Fin.cons 1 w) (homogenize Q) = eval w Q` (the head factor `1 ^ (2-deg d)` disappears); avoids any division / negative-exponent reindexing.
3. **`homogenize_nonneg`** — PSD transfers from `Q` to `homogenize Q`: on the dense set `{x₀ ≠ 0}` via the homogeneity scaling identity `eval (c • x) p = c² · eval x p`, and at `x₀ = 0` by continuity of polynomial evaluation (`ge_of_tendsto` on `𝓝[≠] 0`).
4. Apply the homogeneous Gram core `homogeneous_quadratic_psd_isSumSq`, then **dehomogenise** the resulting linear forms with `bind₁ (Fin.cons 1 X)` (set `x₀ = 1`).

## Verification

`#print axioms` for both `quadratic_psd_is_sos_aux` and `quadratic_psd_is_sos` → `propext / Classical.choice / Quot.sound` only. Built against the Mathlib cache (`lake env lean`); docker and Aristotle were both unavailable this session, so all proofs are manual.

## Files
- `proofs/Proofs/Hilbert17QuadraticGram.lean` — +157 L (the affine homogenisation section)
- `proofs/Proofs/Hilbert17SumOfSquares.lean` — axiom → theorem; `import Proofs.Hilbert17QuadraticGram`
- `src/data/proofs/hilbert-17/meta.json` — axiomCount 2 → 1, assumptions/prose
- `research/problems/hilbert-17-oq-03/knowledge.md` — session notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)