### PR TITLE
Enrich Blichfeldt threshold sharpness: add index.ts + annotations + sections/conclusion

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/index.ts
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ01OQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOq01Oq02Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOq01Oq02Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOq01Oq02Oq03Data: ProofData = {
+  proof: eulerTotientOq01Oq02Oq03Proof,
+  annotations: eulerTotientOq01Oq02Oq03Annotations,
+}

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-mink0403-overview",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 7, "endLine": 46 },
+    "type": "context",
+    "title": "Why the Strict Threshold Cannot Be Relaxed",
+    "content": "The parent file proves Blichfeldt's theorem: a measurable set S ⊆ ℝⁿ of volume strictly greater than k contains k+1 distinct points that are pairwise congruent modulo ℤⁿ. The natural companion question is whether the strict inequality is necessary. This file answers yes by exhibiting, for every k, a measurable set of volume exactly k with no k+1 pairwise congruent points — so the hypothesis k < vol(S) cannot be weakened to k ≤ vol(S). The k=1 witness is the half-open unit cube [0,1)ⁿ (a fundamental domain for ℤⁿ); the general witness is the box [0,k) × [0,1)ⁿ⁻¹. Zero axioms beyond Mathlib's foundational set.",
+    "mathContext": "Blichfeldt: $\\mathrm{vol}(S) > k \\Rightarrow \\exists\\,k{+}1$ pairwise $\\mathbb{Z}^n$-congruent points. Sharpness: a witness of volume exactly $k$ with none.",
+    "significance": "context",
+    "relatedConcepts": ["Blichfeldt's theorem", "geometry of numbers", "lattice congruence", "fundamental domain", "sharpness of a bound"],
+    "prerequisites": ["Lebesgue measure on ℝⁿ", "integer lattices", "Blichfeldt's theorem"]
+  },
+  {
+    "id": "ann-mink0403-congruent-eq",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 58, "endLine": 76 },
+    "type": "insight",
+    "title": "The Heart of k=1: Fundamental-Domain Representatives Are Unique",
+    "content": "stdFundDomain_congruent_eq is the geometric core of k=1 sharpness: two points x, y of the half-open unit cube [0,1)ⁿ that are ℤⁿ-congruent (x − y ∈ ℤⁿ) must be equal. The argument runs through fractional parts: a point of the fundamental domain is fixed by ZSpan.fract (ZSpan.fract_eq_self), and ℤⁿ-congruent points share their fractional part (ZSpan.fract_eq_fract). So x = fract x = fract y = y. The unit cube meets each lattice coset in exactly one point — the defining property of a fundamental domain.",
+    "mathContext": "$x, y \\in [0,1)^n$, $x - y \\in \\mathbb{Z}^n \\Rightarrow x = \\mathrm{fract}(x) = \\mathrm{fract}(y) = y$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental domain", "fractional part", "ZSpan.fract", "coset representative"],
+    "prerequisites": ["ZSpan.fract_eq_self", "ZSpan.fract_eq_fract", "lattice cosets"]
+  },
+  {
+    "id": "ann-mink0403-k1-sharp",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 78, "endLine": 97 },
+    "type": "concept",
+    "title": "k=1 Sharpness: The Unit Cube Is the Witness",
+    "content": "blichfeldt_threshold_sharp packages the k=1 witness: the unit cube [0,1)ⁿ is measurable, has volume exactly 1 (stdLattice_covolume), and (by the uniqueness lemma) contains no two distinct ℤⁿ-congruent points. blichfeldt_basic_threshold_not_le then states the consequence in the form that matters: the hypothesis 1 < vol(S) of the parent's blichfeldt_basic cannot be weakened to 1 ≤ vol(S), since the unit cube satisfies 1 ≤ vol but fails the congruent-pair conclusion.",
+    "mathContext": "$\\mathrm{vol}([0,1)^n) = 1$ exactly, yet no two distinct points are $\\mathbb{Z}^n$-congruent; so $1 \\le \\mathrm{vol}(S)$ does not force a pair.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit cube", "covolume", "tightness of a hypothesis", "measurable witness"],
+    "prerequisites": ["stdLattice_covolume", "the uniqueness lemma"]
+  },
+  {
+    "id": "ann-mink0403-box-volume",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 103, "endLine": 118 },
+    "type": "definition",
+    "title": "The General Witness: A Box of Volume Exactly k",
+    "content": "box n k is the half-open box [0,k) × [0,1)ⁿ⁻¹: the first ('long') coordinate ranges over [0,k), all others over [0,1). volume_box computes its volume as exactly k via volume_pi_pi (product/Fubini volume), with Finset.prod_eq_single isolating coordinate 0 (which contributes k) from the others (each contributing 1). This box is the general-k analogue of the unit cube — stretched k-fold in one direction so it can hold up to k mutually congruent points but no more.",
+    "mathContext": "$\\mathrm{box} = [0,k) \\times [0,1)^{n-1}$, $\\ \\mathrm{vol} = k \\cdot 1^{n-1} = k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["product measure", "Fubini volume", "half-open box", "volume_pi_pi"],
+    "prerequisites": ["product of Lebesgue measures", "Finset.prod_eq_single", "Real.volume_Ico"]
+  },
+  {
+    "id": "ann-mink0403-fract-coord",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 120, "endLine": 141 },
+    "type": "technique",
+    "title": "Congruent Points Share Every Coordinate's Fractional Part",
+    "content": "stdFract_coord identifies the ZSpan fractional part in the standard basis with the coordinatewise real fractional part: (fract x) i = Int.fract(x i), using that Pi.basisFun has the identity repr. congruent_fract_coord then transports ZSpan.fract_eq_fract to coordinates: ℤⁿ-congruent points x, y satisfy Int.fract(x i) = Int.fract(y i) in every coordinate i. This coordinatewise control is what lets the general-k argument reconstruct a point from its floor plus its (shared) fractional part.",
+    "mathContext": "$(\\mathrm{fract}\\,x)_i = \\{x_i\\}$; $\\ x - y \\in \\mathbb{Z}^n \\Rightarrow \\{x_i\\} = \\{y_i\\}\\ \\forall i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fractional part", "standard basis", "Pi.basisFun", "coordinatewise congruence"],
+    "prerequisites": ["ZSpan.repr_fract_apply", "Int.fract", "ZSpan.fract_eq_fract"]
+  },
+  {
+    "id": "ann-mink0403-general-sharp",
+    "proofId": "minkowski-theorem-oq-04-oq-03",
+    "range": { "startLine": 143, "endLine": 213 },
+    "type": "insight",
+    "title": "General k Sharpness via Floor + Pigeonhole",
+    "content": "blichfeldt_general_threshold_sharp shows the box of volume k holds no injective family of k+1 pairwise ℤⁿ-congruent points. The key: a point of the box is DETERMINED by its (shared) fractional part together with the integer floor of its long coordinate. For coordinates i ≠ 0 the point lies in [0,1) and equals its fractional part; for coordinate 0 it equals ⌊x₀⌋ + Int.fract(x₀) with ⌊x₀⌋ ∈ {0,…,k−1}. Since congruent points share all fractional parts, the map m ↦ ⌊(pts m)₀⌋ ∈ Fin k is injective on the family. An injection Fin (k+1) ↪ Fin k is impossible (Fintype.card_le_of_injective + omega) — exactly the pigeonhole that caps the box at k mutually congruent points and proves Blichfeldt's strict threshold sharp for all k.",
+    "mathContext": "Point $\\leftrightarrow$ $(\\lfloor x_0\\rfloor, \\{x\\})$ with $\\lfloor x_0\\rfloor \\in \\{0,\\dots,k-1\\}$; congruent points share $\\{x\\}$, giving an injection into $\\mathrm{Fin}\\,k$, so $\\le k$ of them.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "integer floor", "injective map", "Fintype.card_le_of_injective", "Blichfeldt sharpness"],
+    "prerequisites": ["Int.floor_add_fract", "congruent_fract_coord", "pigeonhole on Fin"]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-03/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MinkowskiTheoremOQ04OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const minkowskiTheoremOq04Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const minkowskiTheoremOq04Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const minkowskiTheoremOq04Oq03Data: ProofData = {
+  proof: minkowskiTheoremOq04Oq03Proof,
+  annotations: minkowskiTheoremOq04Oq03Annotations,
+}

--- a/src/data/proofs/minkowski-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04-oq-03/meta.json
@@ -83,6 +83,113 @@
     "historicalContext": "Blichfeldt's 1914 theorem strengthens Minkowski's geometry of numbers: any measurable set of volume strictly greater than k holds k+1 distinct points that are pairwise congruent modulo ℤⁿ. A natural companion question is whether the strict inequality is necessary. It is: the half-open unit cube [0,1)ⁿ is a fundamental domain for ℤⁿ, so it has volume exactly 1 yet meets each lattice coset in a single point. This is the canonical demonstration that the volume threshold cannot be relaxed from `> k` to `≥ k`.",
     "problemStatement": "Is the strict inequality in Blichfeldt's theorem necessary? Equivalently, for each k is there a measurable set of volume exactly k that contains no k+1 pairwise ℤⁿ-congruent points?",
     "text": "Yes — the threshold is sharp (status `verified`, 0 axioms, 0 sorries). For k=1 the witness is the half-open unit cube F = [0,1)ⁿ = stdFundDomain n: it is measurable, has volume exactly 1 (stdLattice_covolume), and carries no two distinct ℤⁿ-congruent points (stdFundDomain_congruent_eq), so the blichfeldt_basic hypothesis 1 < vol(S) cannot be weakened to ≤. For general k the witness is the box [0,k) × [0,1)ⁿ⁻¹ of volume exactly k, which holds at most k mutually congruent points, contradicting any k+1 family — so the strict inequality of blichfeldt_general is also sharp.",
-    "proofStrategy": "The key conversion (ZSpan.fract_eq_fract) turns ℤⁿ-congruence into equality of fractional parts. (1) k=1: a point of the fundamental domain equals its own fractional part (ZSpan.fract_eq_self), so two congruent points of [0,1)ⁿ have equal fractional parts and are therefore equal. (2) general k: in the box [0,k) × [0,1)ⁿ⁻¹ every coordinate i≠0 lies in [0,1) and so equals its fractional part, while the long coordinate satisfies x₀ = ⌊x₀⌋ + Int.fract(x₀) with ⌊x₀⌋ ∈ {0,…,k-1}. Congruent points share all fractional parts, so a point is determined by ⌊x₀⌋ alone — an injection into Fin k. Volume k is computed by volume_pi_pi. Pigeonhole (Fintype.card_le_of_injective) then forbids k+1 distinct pairwise-congruent points."
-  }
+    "proofStrategy": "The key conversion (ZSpan.fract_eq_fract) turns ℤⁿ-congruence into equality of fractional parts. (1) k=1: a point of the fundamental domain equals its own fractional part (ZSpan.fract_eq_self), so two congruent points of [0,1)ⁿ have equal fractional parts and are therefore equal. (2) general k: in the box [0,k) × [0,1)ⁿ⁻¹ every coordinate i≠0 lies in [0,1) and so equals its fractional part, while the long coordinate satisfies x₀ = ⌊x₀⌋ + Int.fract(x₀) with ⌊x₀⌋ ∈ {0,…,k-1}. Congruent points share all fractional parts, so a point is determined by ⌊x₀⌋ alone — an injection into Fin k. Volume k is computed by volume_pi_pi. Pigeonhole (Fintype.card_le_of_injective) then forbids k+1 distinct pairwise-congruent points.",
+    "keyInsights": [
+      "Sharpness is the statement that a bound is best possible: Blichfeldt forces k+1 congruent points only above volume k, and the half-open witnesses of volume exactly k show the 'k' cannot be lowered — the open boundary case genuinely behaves differently from the strict one.",
+      "A fundamental domain is precisely a set that meets every lattice coset exactly once, so by definition it carries no two congruent points. The unit cube [0,1)ⁿ being a fundamental domain of volume 1 is therefore the cleanest possible k=1 counterexample to a weakened (≤) threshold.",
+      "ℤⁿ-congruence is equality of fractional parts (ZSpan.fract_eq_fract). This single conversion reduces a lattice-theoretic statement to coordinatewise real arithmetic and powers both the k=1 uniqueness and the general-k floor argument.",
+      "The half-open box stretches the cube k-fold in one coordinate. A point is then pinned down by its shared fractional part plus the floor ⌊x₀⌋ ∈ {0,…,k−1} of the long coordinate — an injection of any congruent family into Fin k, so pigeonhole caps it at k and rules out k+1.",
+      "Half-openness is essential: closing the box to [0,k] × [0,1]ⁿ⁻¹ would glue opposite faces under congruence and reintroduce congruent pairs, breaking sharpness. The Ico (left-closed, right-open) intervals are exactly what make each coset representative unique."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Sharpness of Blichfeldt's Threshold",
+      "startLine": 7,
+      "endLine": 46,
+      "summary": "States the goal — the strict inequality k < vol(S) in Blichfeldt's theorem cannot be weakened to ≤ — and previews the two witnesses (the unit cube for k=1, the box [0,k)×[0,1)ⁿ⁻¹ for general k) plus the key idea: congruent points share fractional parts, and a box point is fixed by its fractional part and one floor.",
+      "mathContext": "Blichfeldt needs $\\mathrm{vol}(S) > k$; the witnesses have volume exactly $k$ with no $k{+}1$ congruent points."
+    },
+    {
+      "id": "k1-uniqueness",
+      "title": "Part 1: k=1 — Uniqueness in the Fundamental Domain",
+      "startLine": 58,
+      "endLine": 97,
+      "summary": "stdFundDomain_congruent_eq: two ℤⁿ-congruent points of [0,1)ⁿ are equal (each is its own fractional part, and congruent points share fractional parts). blichfeldt_threshold_sharp packages the unit cube as a volume-1 witness with no congruent pair, and blichfeldt_basic_threshold_not_le concludes 1 < vol(S) cannot be weakened to 1 ≤ vol(S).",
+      "mathContext": "$x,y \\in [0,1)^n,\\ x-y \\in \\mathbb{Z}^n \\Rightarrow x = y$."
+    },
+    {
+      "id": "box-volume",
+      "title": "Part 2: The Box and Its Volume",
+      "startLine": 103,
+      "endLine": 118,
+      "summary": "box n k = [0,k) × [0,1)ⁿ⁻¹ with box_measurableSet, and volume_box: its volume is exactly k via volume_pi_pi and Finset.prod_eq_single isolating the long coordinate (contributing k) from the unit coordinates (each 1).",
+      "mathContext": "$\\mathrm{vol}([0,k)\\times[0,1)^{n-1}) = k$."
+    },
+    {
+      "id": "fract-coordinates",
+      "title": "Part 2: Coordinatewise Fractional Parts",
+      "startLine": 120,
+      "endLine": 141,
+      "summary": "stdFract_coord: (ZSpan.fract x) i = Int.fract(x i) in the standard basis (Pi.basisFun has identity repr). congruent_fract_coord: ℤⁿ-congruent points share Int.fract in every coordinate — the coordinatewise form of ZSpan.fract_eq_fract.",
+      "mathContext": "$(\\mathrm{fract}\\,x)_i = \\{x_i\\}$, and congruence $\\Rightarrow \\{x_i\\} = \\{y_i\\}$."
+    },
+    {
+      "id": "general-pigeonhole",
+      "title": "Part 2: General k via Floor and Pigeonhole",
+      "startLine": 143,
+      "endLine": 215,
+      "summary": "blichfeldt_general_threshold_sharp: the box of volume k holds no k+1 pairwise congruent points. A point is determined by its shared fractional part plus ⌊x₀⌋ ∈ {0,…,k−1}; the map to Fin k is injective on any congruent family, and Fin (k+1) ↪ Fin k is impossible (Fintype.card_le_of_injective + omega).",
+      "mathContext": "Injection into $\\mathrm{Fin}\\,k$ $\\Rightarrow$ at most $k$ mutually congruent points."
+    }
+  ],
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Module.ZLattice.Basic",
+      "Mathlib.MeasureTheory.Group.GeometryOfNumbers",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Proofs.MinkowskiTheoremOQ04",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["MeasureTheory", "Set", "MinkowskiProved"],
+    "namespace": "BlichfeldtSharpness",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/MinkowskiTheoremOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "A fully verified (0 axioms, 0 sorries) demonstration that Blichfeldt's volume threshold is sharp. For k=1 the half-open unit cube [0,1)ⁿ — a fundamental domain of volume exactly 1 — carries no two distinct ℤⁿ-congruent points (stdFundDomain_congruent_eq), so the hypothesis 1 < vol(S) cannot be weakened to ≤ (blichfeldt_basic_threshold_not_le). For general k the box [0,k) × [0,1)ⁿ⁻¹ of volume exactly k holds at most k mutually congruent points (blichfeldt_general_threshold_sharp), via the floor-plus-fractional-part injection into Fin k and pigeonhole. 215 lines, 8 theorems, 1 definition.",
+    "implications": "This pins down the exact boundary of Blichfeldt's theorem (and hence of the Minkowski geometry-of-numbers circle): the result holds for volume strictly above k and provably fails at volume exactly k. The witnesses are the most natural objects available — a fundamental domain and its k-fold stretch — underscoring that the strictness is not a technical artifact but reflects the geometry of how lattice cosets tile space. The half-open (Ico) structure is what keeps coset representatives unique.",
+    "openQuestions": [
+      "Characterize all volume-exactly-k measurable sets with no k+1 pairwise ℤⁿ-congruent points: are they precisely the (essentially) fundamental-domain-like sets, up to measure-zero modifications?",
+      "Extend the sharpness analysis to a general lattice L (not just ℤⁿ) and to the symmetric-convex-body form of Minkowski's theorem, identifying the analogous boundary witnesses.",
+      "Quantify the failure just below threshold: for vol(S) = k − ε, what is the maximal number of guaranteed pairwise congruent points as a function of ε?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Parent: proves Blichfeldt's theorem (vol(S) > k forces k+1 pairwise ℤⁿ-congruent points). This entry proves the strict threshold there is sharp."
+    },
+    {
+      "targetId": "minkowski-theorem-oq-02",
+      "relationship": "builds-on",
+      "description": "Sibling in the Minkowski geometry-of-numbers cluster developing lattice-point counting and volume bounds."
+    },
+    {
+      "targetId": "minkowski-theorem",
+      "relationship": "builds-on",
+      "description": "Root entry: Minkowski's convex body theorem, the geometry-of-numbers result that Blichfeldt's theorem generalizes."
+    }
+  ],
+  "references": [
+    {
+      "key": "Blichfeldt1914",
+      "citation": "Blichfeldt, H.F., A new principle in the geometry of numbers, with some applications, Trans. Amer. Math. Soc. 15 (1914), 227–235.",
+      "type": "paper"
+    },
+    {
+      "key": "Cassels1959",
+      "citation": "Cassels, J.W.S., An Introduction to the Geometry of Numbers, Springer (1959), Ch. III.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `minkowski-theorem-oq-04-oq-03` (Sharpness of the Blichfeldt Volume Threshold). This was the lowest-quality target (quality 10): meta.json had only an overview, no `index.ts`, no `annotations.json`, no sections/conclusion/keyInsights.

## Changes
- **index.ts**: created from the standard template (import `MinkowskiTheoremOQ04OQ03`) so the page loads.
- **annotations.json**: 6 annotations over the full 215-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Overview: why the strict threshold can't be relaxed
  - **k=1 heart**: fundamental-domain representatives are unique (`stdFundDomain_congruent_eq`)
  - k=1 sharpness witness (the unit cube) and `blichfeldt_basic_threshold_not_le`
  - The general witness `box n k` and its volume = k
  - Coordinatewise fractional parts (`stdFract_coord`, `congruent_fract_coord`)
  - **General k**: floor + pigeonhole injection into `Fin k`
- **meta.json**: added 5 `keyInsights`, 5 `sections` covering the file, a `conclusion` (summary + implications + 3 open questions), 3 `crossReferences`, 2 `references`, and the top-level `status`/`badge`/`leanFile` block.

## Verification
- JSON parses; annotation validator reports **0 errors for this proof** (all startLines land on a `/-`/`/--` docstring). Pre-existing gallery-wide validator noise is unrelated.
- Axiom integrity preserved: verified / 0-axiom / 0-sorry, consistent with the Lean source (`#print axioms` lists only propext/Classical.choice/Quot.sound).