### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02): Palindromy of the Eulerian numbers from the explicit alternating sum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2945,6 +2945,7 @@ import Proofs.GeometricSeriesOQ07OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ03
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ03OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,180 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02
+
+/-
+# Palindromic symmetry of the Eulerian numbers, from the explicit alternating sum
+
+The parent entry **geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02** established the explicit
+inclusion–exclusion closed form of the Eulerian numbers,
+
+  `⟨n,k⟩ = eulerianExplicit n k = ∑_{i=0}^{k} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ`     (`eulerian_eq_explicit`).
+
+This entry settles its declared open question **oq-02**: derive the **palindromic symmetry**
+
+  `⟨n,k⟩ = ⟨n, n-1-k⟩`        (for `k < n`)
+
+directly from the alternating sum, by the substitution `i ↦ n+1-i`.  This is an *analytic*
+proof, complementary to the coefficient-extraction proof of palindromy recorded elsewhere in the
+Eulerian lineage (sibling oq-05): it manipulates the explicit finite sum rather than the
+generating polynomial.
+
+## Method
+
+The engine is the **finite-difference vanishing lemma** (`full_alt_sum_zero`):
+
+  `∑_{i=0}^{n+1} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ = 0`.
+
+This is the `(n+1)`-st forward difference of the degree-`n` polynomial `x ↦ (k+1-x)ⁿ`, which
+vanishes because the differencing order exceeds the degree
+(`Polynomial.fwdDiff_iter_eq_zero_of_degree_lt`, expanded via `fwdDiff_iter_eq_sum_shift`).  The
+*full* alternating sum runs `i = 0 … n+1`; its head `i = 0 … k` is exactly `eulerianExplicit n k`.
+Splitting the sum at `k+1` and reflecting the tail `i ↦ n+1-i` (`Finset.sum_range_reflect`) turns
+the tail into `-eulerianExplicit n (n-1-k)` — the binomial symmetry `C(n+1,n+1-i)=C(n+1,i)`
+supplies the reflected coefficients, `(k+1-(n+1-i)) = -((n-1-k)+1-i)` supplies the reflected base,
+the parity factors collapse, and the single overhang term carries a factor `0ⁿ = 0` (using
+`1 ≤ n`).  Hence `eulerianExplicit n k - eulerianExplicit n (n-1-k) = 0`.
+
+As immediate corollaries we obtain the **non-negativity** of the explicit alternating sum
+(`eulerianExplicit_nonneg`, the easy half of the sibling open question oq-01, since the sum equals
+the cast of the natural-number count `⟨n,k⟩`), and the palindromy of the combinatorial Eulerian
+numbers themselves (`eulerian_palindrome`).
+
+Everything is machine-checked with no `sorry` and no new axioms.
+-/
+
+open Finset
+open GeometricSeriesOQ07OQ01OQ01OQ01 GeometricSeriesOQ07OQ01OQ01OQ01OQ02
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02
+
+/-- **Non-negativity of the explicit Eulerian sum.** The alternating inclusion–exclusion sum
+`∑_{i=0}^{k} (-1)ⁱ C(n+1,i)(k+1-i)ⁿ` is `≥ 0`, because it equals the cast of the combinatorial
+count `⟨n,k⟩ : ℕ` (`eulerian_eq_explicit`). This is the easy half of the sibling open question
+oq-01: the deeper "equals the number of permutations with `k` descents" remains a separate
+combinatorial statement. -/
+theorem eulerianExplicit_nonneg (n k : ℕ) : 0 ≤ eulerianExplicit n k := by
+  rw [← eulerian_eq_explicit]
+  exact_mod_cast Nat.zero_le _
+
+/-- **Finite-difference vanishing.** The *full* alternating binomial sum (running all the way to
+`i = n+1`, one past the support of `eulerianExplicit`) vanishes:
+
+  `∑_{i=0}^{n+1} (-1)ⁱ · C(n+1,i) · (k+1-i)ⁿ = 0`.
+
+It is the `(n+1)`-st forward difference of the degree-`n` polynomial `x ↦ (k+1-x)ⁿ`. -/
+theorem full_alt_sum_zero (n k : ℕ) :
+    ∑ i ∈ range (n + 2),
+        (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n = 0 := by
+  -- The polynomial `P x = (k+1 - x)ⁿ`, of degree `n < n+1`.
+  set P : Polynomial ℤ := (Polynomial.C ((k : ℤ) + 1) - Polynomial.X) ^ n with hP
+  have hdeg : P.natDegree < n + 1 := by
+    have hlin : (Polynomial.C ((k : ℤ) + 1) - Polynomial.X).natDegree = 1 := by
+      rw [show Polynomial.C ((k : ℤ) + 1) - Polynomial.X
+            = -(Polynomial.X - Polynomial.C ((k : ℤ) + 1)) from by ring,
+          Polynomial.natDegree_neg, Polynomial.natDegree_X_sub_C]
+    rw [hP, Polynomial.natDegree_pow, hlin, mul_one]
+    omega
+  -- Its `(n+1)`-st forward difference is the zero function.
+  have hzero : (fwdDiff (1 : ℤ))^[n + 1] P.eval = 0 :=
+    Polynomial.fwdDiff_iter_eq_zero_of_degree_lt hdeg
+  -- Expand that difference at `0` as the alternating shift-sum.
+  have hsum := fwdDiff_iter_eq_sum_shift (h := (1 : ℤ)) P.eval (n + 1) 0
+  -- Identify the shift-sum (with sign `(-1)^(n+1-i)`) with a clean alternating sum.
+  have hS' : (∑ i ∈ range (n + 2),
+      (-1 : ℤ) ^ (n + 1 - i) * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n) = 0 := by
+    have hval : (fwdDiff (1 : ℤ))^[n + 1] P.eval 0 = 0 := by rw [hzero]; rfl
+    rw [hsum] at hval
+    refine Eq.trans ?_ hval
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [hP]
+    simp only [zero_add, nsmul_eq_mul, mul_one, smul_eq_mul, Polynomial.eval_pow,
+      Polynomial.eval_sub, Polynomial.eval_C, Polynomial.eval_X]
+  -- Reinsert the global sign `(-1)^(n+1)` to recover the target sign `(-1)^i`.
+  have hconv : (∑ i ∈ range (n + 2),
+        (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n)
+      = (-1 : ℤ) ^ (n + 1) * ∑ i ∈ range (n + 2),
+        (-1 : ℤ) ^ (n + 1 - i) * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun i hi => ?_)
+    have hile : i ≤ n + 1 := by simp only [mem_range] at hi; omega
+    have hsign : (-1 : ℤ) ^ (n + 1) * (-1 : ℤ) ^ (n + 1 - i) = (-1 : ℤ) ^ i := by
+      rw [← pow_add, show n + 1 + (n + 1 - i) = i + 2 * (n + 1 - i) from by omega,
+        pow_add, pow_mul]
+      norm_num
+    rw [← hsign]; ring
+  rw [hconv, hS', mul_zero]
+
+/-- **Palindromy of the explicit Eulerian sum** (the analytic, reindexing proof of oq-02).
+For `k < n`, the explicit alternating sum is symmetric under `k ↦ n-1-k`:
+
+  `eulerianExplicit n k = eulerianExplicit n (n-1-k)`. -/
+theorem eulerianExplicit_palindrome (n k : ℕ) (hk : k < n) :
+    eulerianExplicit n k = eulerianExplicit n (n - 1 - k) := by
+  -- Abbreviate the summand.
+  set T : ℕ → ℤ := fun i => (-1 : ℤ) ^ i * ((n + 1).choose i : ℤ) * ((k : ℤ) + 1 - i) ^ n with hT
+  -- The full sum vanishes; split it at `k+1`.
+  have hfull : (∑ i ∈ range (n + 2), T i) = 0 := full_alt_sum_zero n k
+  rw [show n + 2 = (k + 1) + (n + 1 - k) from by omega, Finset.sum_range_add] at hfull
+  -- Head sum is exactly `eulerianExplicit n k`.
+  have hhead : (∑ i ∈ range (k + 1), T i) = eulerianExplicit n k := rfl
+  -- Tail sum, after reflecting `i ↦ (n-k) - i` (i.e. the summand index `↦ n+1-i`).
+  have htail : (∑ i ∈ range (n + 1 - k), T (k + 1 + i))
+      = - eulerianExplicit n (n - 1 - k) := by
+    rw [← Finset.sum_range_reflect (fun i => T (k + 1 + i)) (n + 1 - k)]
+    -- The top reflected term (`i = n-k`) carries a factor `0ⁿ = 0`; drop it.
+    rw [show n + 1 - k = (n - k) + 1 from by omega, Finset.sum_range_succ]
+    have hdrop : T (k + 1 + ((n - k) + 1 - 1 - (n - k))) = 0 := by
+      have : k + 1 + ((n - k) + 1 - 1 - (n - k)) = k + 1 := by omega
+      rw [this, hT]
+      simp only []
+      have : ((k : ℤ) + 1 - (k + 1 : ℕ)) = 0 := by push_cast; ring
+      rw [this, zero_pow (by omega : n ≠ 0), mul_zero]
+    rw [hdrop, add_zero]
+    -- Match the reflected tail with `- eulerianExplicit n (n-1-k)` termwise.
+    rw [eulerianExplicit, show n - 1 - k + 1 = n - k from by omega, ← Finset.sum_neg_distrib]
+    refine Finset.sum_congr rfl (fun i hi => ?_)
+    have hin : i ≤ n - k := by simp only [mem_range] at hi; omega
+    have hile : i ≤ n + 1 := by omega
+    -- Reduce the reflected index `k + 1 + ((n-k)+1-1-i)` to `n + 1 - i`.
+    have hidx : k + 1 + ((n - k) + 1 - 1 - i) = n + 1 - i := by omega
+    rw [hT]
+    simp only [hidx]
+    -- Binomial reflection `C(n+1,n+1-i) = C(n+1,i)`.
+    have hchoose : (n + 1).choose (n + 1 - i) = (n + 1).choose i := Nat.choose_symm hile
+    -- Base reflection `(k+1) - (n+1-i) = -((n-1-k)+1-i)`.
+    have hbase : ((k : ℤ) + 1 - ((n + 1 - i : ℕ) : ℤ))
+        = -(((n - 1 - k : ℕ) : ℤ) + 1 - i) := by
+      have h1 : ((n + 1 - i : ℕ) : ℤ) = (n : ℤ) + 1 - i := by
+        push_cast [Nat.cast_sub hile]; ring
+      have h2 : ((n - 1 - k : ℕ) : ℤ) = (n : ℤ) - 1 - k := by
+        have e1 : (1 : ℕ) ≤ n := by omega
+        have e2 : k ≤ n - 1 := by omega
+        push_cast [Nat.cast_sub e2, Nat.cast_sub e1]
+        ring
+      rw [h1, h2]; ring
+    -- Combined parity collapse `(-1)^(n+1-i) · (-1)ⁿ = -(-1)ⁱ`.
+    have hsign2 : (-1 : ℤ) ^ (n + 1 - i) * (-1 : ℤ) ^ n = -((-1 : ℤ) ^ i) := by
+      rw [← pow_add, show (n + 1 - i) + n = (i + 1) + 2 * (n - i) from by omega,
+        pow_add, pow_mul, pow_succ]
+      simp
+    -- Expand the reflected base power `(-β)ⁿ = (-1)ⁿ · βⁿ` (targeting the base, not the sign).
+    have hbpow : (-(((n - 1 - k : ℕ) : ℤ) + 1 - (i : ℤ))) ^ n
+        = (-1 : ℤ) ^ n * (((n - 1 - k : ℕ) : ℤ) + 1 - (i : ℤ)) ^ n := neg_pow _ _
+    rw [hchoose, hbase, hbpow]
+    linear_combination
+      (((n + 1).choose i : ℤ) * (((n - 1 - k : ℕ) : ℤ) + 1 - (i : ℤ)) ^ n) * hsign2
+  rw [hhead, htail] at hfull
+  linarith
+
+/-- **Palindromy of the combinatorial Eulerian numbers.** For `k < n`,
+
+  `⟨n,k⟩ = ⟨n, n-1-k⟩`,
+
+obtained from the alternating-sum palindromy via the parent identity `eulerian_eq_explicit`. -/
+theorem eulerian_palindrome (n k : ℕ) (hk : k < n) :
+    eulerian n k = eulerian n (n - 1 - k) := by
+  have h : (eulerian n k : ℤ) = (eulerian n (n - 1 - k) : ℤ) := by
+    rw [eulerian_eq_explicit, eulerian_eq_explicit, eulerianExplicit_palindrome n k hk]
+  exact_mod_cast h
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "eul-palin-nonneg",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 55, "endLine": 57 },
+    "type": "theorem",
+    "title": "Non-negativity of the explicit Eulerian sum",
+    "content": "`eulerianExplicit_nonneg` records that $\\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n \\ge 0$. Although the summand alternates in sign, the whole sum is non-negative because — by the parent's identity `eulerian_eq_explicit` — it equals the cast of the natural number $\\langle n,k\\rangle$, which counts something and is therefore $\\ge 0$. This settles the *easy* half of the sibling open question oq-01; the genuinely combinatorial half (that the sum equals the number of permutations with exactly $k$ descents) is left as a follow-up."
+  },
+  {
+    "id": "eul-palin-fdiff",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 65, "endLine": 107 },
+    "type": "theorem",
+    "title": "Finite-difference vanishing: the full alternating sum is zero",
+    "content": "`full_alt_sum_zero` is the engine of the palindromy proof: the alternating sum extended *one term past* the support of `eulerianExplicit`, $\\sum_{i=0}^{n+1}(-1)^i\\binom{n+1}{i}(k+1-i)^n$, vanishes. The reason is that this is precisely the $(n+1)$-st forward difference of the polynomial $P(x)=(k+1-x)^n$, whose degree $n$ is strictly less than the differencing order $n+1$; an order-$(n+1)$ finite difference annihilates any degree-$n$ polynomial. The proof builds $P$ as `(C (k+1) - X)^n`, invokes Mathlib's `Polynomial.fwdDiff_iter_eq_zero_of_degree_lt`, expands the difference with `fwdDiff_iter_eq_sum_shift`, and reconciles that lemma's sign $(-1)^{n+1-i}$ with the target $(-1)^i$ by factoring out the global sign $(-1)^{n+1}$."
+  },
+  {
+    "id": "eul-palin-explicit",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 111, "endLine": 172 },
+    "type": "theorem",
+    "title": "Palindromy of the explicit sum, by reflection i ↦ n+1−i",
+    "content": "`eulerianExplicit_palindrome` proves $\\text{eulerianExplicit}\\,n\\,k = \\text{eulerianExplicit}\\,n\\,(n-1-k)$ for $k<n$. The full vanishing sum splits (`Finset.sum_range_add`) as `head + tail = 0`, where the head $i=0\\dots k$ is by definition `eulerianExplicit n k`. Reflecting the tail via $i\\mapsto n+1-i$ (`Finset.sum_range_reflect`) restores the coefficient through the binomial symmetry $\\binom{n+1}{n+1-i}=\\binom{n+1}{i}$, reflects the base via $(k+1)-(n+1-i)=-\\big((n-1-k)+1-i\\big)$, and collapses the parity to a single sign by $(-1)^{n+1-i}\\cdot(-1)^n=-(-1)^i$. The length-mismatch overhang term is killed by $0^n=0$ (valid since $k<n\\Rightarrow n\\ge 1$), so the tail equals $-\\text{eulerianExplicit}\\,n\\,(n-1-k)$ and palindromy follows."
+  },
+  {
+    "id": "eul-palin-combinatorial",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 174, "endLine": 180 },
+    "type": "theorem",
+    "title": "Palindromy of the combinatorial Eulerian numbers",
+    "content": "`eulerian_palindrome` transfers the symmetry to the combinatorial numbers themselves: $\\langle n,k\\rangle=\\langle n,n-1-k\\rangle$ for $k<n$. This is a one-line consequence of the explicit-sum palindromy and the parent's identity `eulerian_eq_explicit`, casting the $\\mathbb{Z}$-identity back to $\\mathbb{N}$. Combinatorially it is the descent/ascent duality: reversing a permutation of $\\{1,\\dots,n\\}$ turns its $k$ descents into $n-1-k$ descents."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ02"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02",
+    "lineCount": 180,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Palindromy of the Eulerian Numbers from the Explicit Alternating Sum: ⟨n,k⟩ = ⟨n,n−1−k⟩",
+  "description": "Settles the parent entry's open question oq-02: an analytic, reindexing proof of the palindromic symmetry of the Eulerian numbers ⟨n,k⟩ = ⟨n,n−1−k⟩ (for k < n), derived directly from the explicit inclusion–exclusion formula by the substitution i ↦ n+1−i. The engine is a finite-difference vanishing lemma — the full alternating binomial sum ∑_{i=0}^{n+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0, which is the (n+1)-st forward difference of the degree-n polynomial x ↦ (k+1−x)ⁿ (Mathlib's Polynomial.fwdDiff_iter_eq_zero_of_degree_lt). The head i=0..k of this full sum is exactly eulerianExplicit n k; splitting at k+1 and reflecting the tail i ↦ n+1−i (Finset.sum_range_reflect), using the binomial symmetry C(n+1,n+1−i)=C(n+1,i), the base reflection (k+1−(n+1−i)) = −((n−1−k)+1−i), a parity collapse, and the overhang term killed by 0ⁿ=0, turns the tail into −eulerianExplicit n (n−1−k). As corollaries the non-negativity of the explicit alternating sum (the easy half of the sibling open question oq-01) and palindromy of the combinatorial Eulerian numbers follow. 180 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨n,k⟩ — introduced by Euler in 1755 and counting the permutations of {1,…,n} with exactly k descents — satisfy the well-known palindromic symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩, reflecting the descent/ascent duality of permutations (reversing a permutation swaps descents and ascents). At the level of the generating polynomial this is the functional equation A_n(t) = t^{n−1}·A_n(1/t). The Eulerian lineage in this gallery already records a palindromy proof via coefficient extraction on the polynomial; the parent entry (the explicit inclusion–exclusion formula) flagged as its open question oq-02 the complementary ANALYTIC proof — obtaining the symmetry directly from the finite alternating sum by the reindexing i ↦ n+1−i. This entry supplies that proof. The underlying mechanism — that the explicit formula is the (n+1)-st finite difference of the monomial tⁿ, and that an order-(n+1) difference annihilates a degree-n polynomial — is exactly the finite-difference fact behind Euler's original study of series. Mathlib contains neither the Eulerian numbers nor their palindromy, but it does provide the forward-difference calculus (Mathlib.Algebra.Group.ForwardDiff) used here as the engine.",
+    "problemStatement": "Given the combinatorial Eulerian numbers ⟨n,k⟩ and their explicit alternating-sum form eulerianExplicit n k = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ from the parent entry, prove the palindromic symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩ (equivalently eulerianExplicit n k = eulerianExplicit n (n−1−k)) for k < n by an analytic manipulation of the explicit sum, with 0 axioms and 0 sorries.",
+    "proofStrategy": "First prove the finite-difference vanishing lemma full_alt_sum_zero: the FULL alternating sum ∑_{i=0}^{n+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0, by realizing it as the (n+1)-st forward difference at 0 of the polynomial P(x) = (k+1−x)ⁿ (degree n < n+1), via Polynomial.fwdDiff_iter_eq_zero_of_degree_lt and the alternating shift-sum expansion fwdDiff_iter_eq_sum_shift, reconciling the lemma's sign (−1)^{n+1−i} with the target (−1)ⁱ by factoring the global sign (−1)^{n+1}. The head i=0..k of this full sum is, by definition, eulerianExplicit n k. Split range(n+2) = range(k+1) ⊎ Ico(k+1)(n+2) with Finset.sum_range_add, and reflect the tail with Finset.sum_range_reflect (the substitution i ↦ n+1−i). On the reflected tail use the binomial symmetry C(n+1,n+1−i)=C(n+1,i), the base reflection (k+1−(n+1−i)) = −((n−1−k)+1−i), a single combined parity identity (−1)^{n+1−i}·(−1)ⁿ = −(−1)ⁱ, and discard the overhang term (which carries a factor 0ⁿ = 0). The tail equals −eulerianExplicit n (n−1−k); since head + tail = 0, palindromy follows. The combinatorial statement ⟨n,k⟩ = ⟨n,n−1−k⟩ is then a cast away via the parent's eulerian_eq_explicit.",
+    "keyInsights": [
+      "Palindromy is read off the FULL alternating sum, not the truncated one: extending the inclusion–exclusion sum one term past its support (to i = n+1) makes it the (n+1)-st finite difference of a degree-n polynomial, which vanishes identically — and the truncated head is exactly the Eulerian number.",
+      "The finite-difference vanishing ∑_{i=0}^{n+1}(−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0 is supplied for free by Mathlib's forward-difference calculus: Polynomial.fwdDiff_iter_eq_zero_of_degree_lt applied to (k+1−x)ⁿ, expanded by fwdDiff_iter_eq_sum_shift.",
+      "Reflecting the tail i ↦ n+1−i turns its contribution into −eulerianExplicit n (n−1−k): binomial symmetry restores the coefficient C(n+1,i), the base reflects to −((n−1−k)+1−i), and the parity factors collapse to a single sign by (−1)^{n+1−i}·(−1)ⁿ = −(−1)ⁱ.",
+      "The bookkeeping overhang — the reflected sum runs one term longer than eulerianExplicit n (n−1−k) — is harmless because that extra term carries a factor 0ⁿ, which vanishes precisely because k < n forces n ≥ 1.",
+      "Non-negativity of the explicit alternating sum is immediate (it equals the cast of the ℕ-valued count ⟨n,k⟩), settling the easy half of the sibling open question oq-01 and leaving the descent-counting interpretation as the genuinely combinatorial remainder."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context and method",
+      "startLine": 4,
+      "endLine": 47,
+      "summary": "Docstring situating the entry as the analytic settlement of the parent's open question oq-02, stating the palindromy target and the finite-difference engine, and outlining the split-and-reflect method."
+    },
+    {
+      "id": "nonneg",
+      "title": "Non-negativity (eulerianExplicit_nonneg)",
+      "startLine": 49,
+      "endLine": 58,
+      "summary": "0 ≤ eulerianExplicit n k, since the alternating sum equals the cast of the ℕ-valued combinatorial count ⟨n,k⟩ (parent's eulerian_eq_explicit) — the easy half of the sibling open question oq-01."
+    },
+    {
+      "id": "fdiff-vanishing",
+      "title": "Finite-difference vanishing (full_alt_sum_zero)",
+      "startLine": 60,
+      "endLine": 108,
+      "summary": "The full alternating sum ∑_{i=0}^{n+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0, as the (n+1)-st forward difference of P(x)=(k+1−x)ⁿ via Polynomial.fwdDiff_iter_eq_zero_of_degree_lt and fwdDiff_iter_eq_sum_shift, with the sign (−1)^{n+1−i} converted to (−1)ⁱ by factoring (−1)^{n+1}."
+    },
+    {
+      "id": "palindromy-explicit",
+      "title": "Palindromy of the explicit sum (eulerianExplicit_palindrome)",
+      "startLine": 109,
+      "endLine": 172,
+      "summary": "eulerianExplicit n k = eulerianExplicit n (n−1−k) for k < n: split the vanishing full sum at k+1 (Finset.sum_range_add), reflect the tail (Finset.sum_range_reflect), and identify it with −eulerianExplicit n (n−1−k) via binomial symmetry, base reflection, a parity collapse, and the 0ⁿ overhang."
+    },
+    {
+      "id": "palindromy-combinatorial",
+      "title": "Palindromy of the Eulerian numbers (eulerian_palindrome)",
+      "startLine": 174,
+      "endLine": 180,
+      "summary": "⟨n,k⟩ = ⟨n,n−1−k⟩ for k < n, obtained from the explicit-sum palindromy by casting through the parent's identity eulerian_eq_explicit."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "palindromy",
+      "symmetry",
+      "finite-differences",
+      "forward-difference",
+      "inclusion-exclusion",
+      "binomial-coefficients",
+      "descent-statistic",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 180,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_palindrome / eulerianExplicit_palindrome: THE MAIN RESULT — the palindromic symmetry of the Eulerian numbers ⟨n,k⟩ = ⟨n,n−1−k⟩ (for k < n), proved analytically from the explicit alternating sum by the reindexing i ↦ n+1−i. This is the complementary proof requested by the parent's open question oq-02, distinct from the coefficient-extraction proof recorded elsewhere in the Eulerian lineage. Mathlib has neither the Eulerian numbers nor their palindromy.",
+      "full_alt_sum_zero: the finite-difference vanishing lemma ∑_{i=0}^{n+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0 — the FULL alternating sum (one term past the support of eulerianExplicit) vanishes, being the (n+1)-st forward difference of the degree-n polynomial (k+1−x)ⁿ. This is the reusable engine of the palindromy proof and makes explicit the finite-difference reading of the inclusion–exclusion formula. Proved via Mathlib's Polynomial.fwdDiff_iter_eq_zero_of_degree_lt and fwdDiff_iter_eq_sum_shift, with a global-sign reconciliation between the forward-difference sign (−1)^{n+1−i} and the formula's (−1)ⁱ.",
+      "eulerianExplicit_nonneg: 0 ≤ ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ — non-negativity of the explicit alternating Eulerian sum, the easy half of the sibling open question oq-01, immediate from the parent identity eulerian_eq_explicit since the alternating sum equals the cast of the ℕ-valued combinatorial count.",
+      "Reflection mechanics: the tail of the full vanishing sum is identified with −eulerianExplicit n (n−1−k) by reflecting i ↦ n+1−i (Finset.sum_range_reflect), restoring the coefficient with the binomial symmetry C(n+1,n+1−i)=C(n+1,i), reflecting the base via (k+1)−(n+1−i) = −((n−1−k)+1−i), collapsing the parity to a single sign through (−1)^{n+1−i}·(−1)ⁿ = −(−1)ⁱ, and discarding the length-mismatch overhang term using 0ⁿ = 0 (valid since k < n ⟹ n ≥ 1)."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02 (the explicit inclusion–exclusion formula) — supplies eulerianExplicit and the identity eulerian_eq_explicit reused here",
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies the eulerian triangle whose palindromy is the headline statement",
+      "Mathlib's forward-difference calculus (Mathlib.Algebra.Group.ForwardDiff): fwdDiff_iter_eq_sum_shift and Polynomial.fwdDiff_iter_eq_zero_of_degree_lt for the finite-difference vanishing engine",
+      "Finset reindexing: Finset.sum_range_add (split), Finset.sum_range_reflect (the i ↦ n+1−i substitution), Finset.sum_range_succ, Finset.sum_neg_distrib; binomial symmetry Nat.choose_symm; casting ℕ subtraction to ℤ (Nat.cast_sub, push_cast)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.fwdDiff_iter_eq_zero_of_degree_lt",
+        "description": "The n-th forward difference of a polynomial of degree < n is the zero function. Applied to P(x) = (k+1−x)ⁿ (degree n) with order n+1, this gives the vanishing of the full alternating sum.",
+        "module": "Mathlib.Algebra.Group.ForwardDiff"
+      },
+      {
+        "theorem": "fwdDiff_iter_eq_sum_shift",
+        "description": "Expresses the n-th forward difference as the alternating shift-sum Δ_[h]^[n] f y = ∑_{k} (−1)^{n−k}·C(n,k)·f(y+k·h). Expands the vanishing difference of (k+1−x)ⁿ into the explicit alternating binomial sum.",
+        "module": "Mathlib.Algebra.Group.ForwardDiff"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑_{i<n} f(n−1−i) = ∑_{i<n} f i. Implements the reindexing i ↦ n+1−i that turns the tail of the full vanishing sum into −eulerianExplicit n (n−1−k).",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "The binomial symmetry n.choose (n−k) = n.choose k (for k ≤ n). Restores the coefficient C(n+1,i) after the tail reflection sends C(n+1,i) to C(n+1,n+1−i).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01OQ02.eulerian_eq_explicit",
+        "description": "The parent's identity ⟨n,k⟩ = eulerianExplicit n k. Transfers the analytic palindromy of the explicit sum to the combinatorial Eulerian numbers, and gives non-negativity of the explicit sum for free.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+      "question": "Complete the descent interpretation left open by the sibling oq-01: define the descent statistic on Equiv.Perm (Fin n), prove that the number of permutations with exactly k descents satisfies the Eulerian triangle recurrence (by the insertion argument), and identify it with ⟨n,k⟩ — upgrading the integer inclusion–exclusion count to the combinatorial descent model.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02-oq-02",
+      "question": "Generalize the finite-difference vanishing lemma full_alt_sum_zero to a reusable statement ∑_{i=0}^{N} (−1)ⁱ·C(N,i)·p(i) = 0 for any polynomial p of degree < N, and use it to give uniform analytic proofs of the other alternating-sum identities in the Eulerian/Stirling lineage.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent (the explicit inclusion–exclusion formula). The parent proves ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ and defines eulerianExplicit. This entry answers the parent's open question oq-02: the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ proved analytically from that explicit sum by the substitution i ↦ n+1−i, reusing eulerianExplicit and eulerian_eq_explicit."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent (the combinatorial Eulerian numbers). Supplies the eulerian triangle whose palindromic symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩ is the headline combinatorial statement established here."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, the explicit formula, palindromy and the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian-number palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ and the explicit closed form manipulated here."
+    },
+    {
+      "title": "Mathlib4: Algebra.Group.ForwardDiff",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the forward-difference calculus (fwdDiff_iter_eq_sum_shift, Polynomial.fwdDiff_iter_eq_zero_of_degree_lt) that supplies the finite-difference vanishing engine full_alt_sum_zero."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's explicit inclusion–exclusion formula for the Eulerian numbers, this entry settles the parent's open question oq-02: the palindromic symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩ (for k < n), proved analytically from the explicit alternating sum by the reindexing i ↦ n+1−i — complementary to the coefficient-extraction proof recorded elsewhere in the Eulerian lineage. The engine is the finite-difference vanishing lemma full_alt_sum_zero: the FULL alternating sum ∑_{i=0}^{n+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ = 0, being the (n+1)-st forward difference of the degree-n polynomial (k+1−x)ⁿ (Mathlib's Polynomial.fwdDiff_iter_eq_zero_of_degree_lt, expanded via fwdDiff_iter_eq_sum_shift). The head i=0..k of this sum is exactly eulerianExplicit n k; splitting at k+1 and reflecting the tail i ↦ n+1−i — restoring the coefficient with the binomial symmetry C(n+1,n+1−i)=C(n+1,i), reflecting the base via (k+1)−(n+1−i)=−((n−1−k)+1−i), collapsing the parity to a single sign, and discarding the 0ⁿ overhang — identifies the tail with −eulerianExplicit n (n−1−k). Non-negativity of the explicit sum (the easy half of the sibling open question oq-01) follows immediately. 180 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The proof exhibits palindromy as a finite-difference phenomenon: extending the inclusion–exclusion sum one term past its support makes it an order-(n+1) difference of a degree-n polynomial, which vanishes, and the truncated head is the Eulerian number — so the symmetry of the numbers is the reflection symmetry of that vanishing sum. The reusable lemma full_alt_sum_zero packages the underlying finite-difference fact and can drive analytic proofs of further alternating-sum identities in the Eulerian/Stirling lineage. The descent-counting interpretation of ⟨n,k⟩ — the deeper, genuinely combinatorial half of the sibling open question oq-01 — remains open and is recorded as a follow-up.",
+    "openQuestions": [
+      "Complete the descent interpretation: define descents on Equiv.Perm (Fin n), prove the descent count obeys the Eulerian recurrence by the insertion argument, and identify it with ⟨n,k⟩.",
+      "Abstract full_alt_sum_zero to a reusable ∑_{i=0}^{N}(−1)ⁱ·C(N,i)·p(i) = 0 for deg p < N, and apply it across the Eulerian/Stirling alternating-sum identities."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Settles the parent entry's open question **oq-02**: an *analytic, reindexing* proof of the **palindromic symmetry of the Eulerian numbers**

$$\langle n,k\rangle = \langle n,\,n-1-k\rangle \qquad (k < n),$$

derived directly from the explicit inclusion–exclusion formula by the substitution $i \mapsto n+1-i$. This is the proof the parent explicitly requested as complementary to the coefficient-extraction proof recorded elsewhere in the Eulerian lineage.

## Method

The engine is a **finite-difference vanishing lemma** (`full_alt_sum_zero`):

$$\sum_{i=0}^{n+1} (-1)^i \binom{n+1}{i}(k+1-i)^n = 0,$$

which is the $(n+1)$-st forward difference of the degree-$n$ polynomial $(k+1-x)^n$. Mathlib supplies this for free via `Polynomial.fwdDiff_iter_eq_zero_of_degree_lt`, expanded by `fwdDiff_iter_eq_sum_shift`.

The head $i=0\dots k$ of this *full* sum is exactly `eulerianExplicit n k`. Splitting at $k+1$ (`Finset.sum_range_add`) and reflecting the tail $i \mapsto n+1-i$ (`Finset.sum_range_reflect`) — using the binomial symmetry $\binom{n+1}{n+1-i}=\binom{n+1}{i}$, the base reflection $(k+1)-(n+1-i)=-((n-1-k)+1-i)$, a single parity collapse $(-1)^{n+1-i}(-1)^n=-(-1)^i$, and the overhang term killed by $0^n=0$ — turns the tail into $-\,$`eulerianExplicit n (n-1-k)`. Hence head $+$ tail $=0$ gives palindromy. The combinatorial statement follows by casting through the parent's `eulerian_eq_explicit`.

## Results

- `eulerian_palindrome` / `eulerianExplicit_palindrome` — the headline palindromy (answers **oq-02**).
- `full_alt_sum_zero` — the reusable finite-difference vanishing engine.
- `eulerianExplicit_nonneg` — $0 \le$ the explicit alternating sum (the *easy* half of sibling **oq-01**).

The descent-count interpretation of $\langle n,k\rangle$ — the substantive half of oq-01 — remains open and is recorded as a follow-up; Mathlib lacks a permutation descent-statistic count.

## Verification

- Builds against Mathlib (`Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ02`).
- **180 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries.**
- `#print axioms` for all four theorems = `{propext, Classical.choice, Quot.sound}` — no `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)