### PR TITLE
Enrich measure-theoretic Paley–Zygmund: add index.ts + annotations + sections

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-pz0101-overview",
+    "proofId": "prob-method-second-moment-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "Paley–Zygmund Over a Genuine Probability Space",
+    "content": "The parent entry proves the quantitative Paley–Zygmund inequality in a finite Finset model of ℚ-valued functions — clean, but not usable over continuous probability spaces. This file answers the parent's explicit open question by recasting the result into Mathlib's measure-theoretic framework: for a nonnegative X ∈ L²(μ) on a probability space and threshold 0 ≤ θ ≤ 1, μ({X > θ𝔼X})·𝔼[X²] ≥ (1−θ)²(𝔼X)². The proof follows the classical second-moment argument (split the mean over A = {X > θ𝔼X} and its complement, then Cauchy–Schwarz). Paley–Zygmund is not currently in Mathlib, so this is a fresh measure-theoretic formalization built only from standard MeasureTheory / ProbabilityTheory API.",
+    "mathContext": "$\\mu(\\{X > \\theta\\mathbb{E}X\\})\\cdot\\mathbb{E}[X^2] \\ge (1-\\theta)^2(\\mathbb{E}X)^2$ for $X \\in L^2$, $X \\ge 0$, $0 \\le \\theta \\le 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Paley–Zygmund inequality", "second moment method", "probabilistic method", "Bochner integral", "L² space"],
+    "prerequisites": ["measure theory", "probability spaces", "the finite-form parent entry"]
+  },
+  {
+    "id": "ann-pz0101-cauchy-schwarz",
+    "proofId": "prob-method-second-moment-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 65 },
+    "type": "technique",
+    "title": "Integral Cauchy–Schwarz as Squared Hölder",
+    "content": "sq_integral_mul_le isolates the single analytic ingredient: for nonnegative L² functions f, g, (∫ f·g)² ≤ (∫ f²)(∫ g²). It is derived from Mathlib's general Hölder inequality integral_mul_le_Lp_mul_Lq_of_nonneg at the conjugate pair (2,2) — the only case where Hölder IS Cauchy–Schwarz. The proof converts Mathlib's rpow ^(1/2) factors back to Real.sqrt, then squares using Real.sq_sqrt (legal because both second moments are nonnegative). Packaging it as a standalone lemma keeps the main proof free of analysis and makes the lemma independently reusable.",
+    "mathContext": "$\\left(\\int fg\\right)^2 \\le \\left(\\int f^2\\right)\\left(\\int g^2\\right)$, the Hölder pair $(p,q)=(2,2)$ squared.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy–Schwarz inequality", "Hölder inequality", "conjugate exponents", "L² inner product"],
+    "prerequisites": ["integral_mul_le_Lp_mul_Lq_of_nonneg", "Real.sqrt and rpow", "MemLp"]
+  },
+  {
+    "id": "ann-pz0101-split",
+    "proofId": "prob-method-second-moment-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 111 },
+    "type": "technique",
+    "title": "The Above/Below Split of the Mean",
+    "content": "The heart of the second-moment argument. With m = 𝔼X and A = {X > θm} (measurable as the preimage of an open ray X⁻¹(Ioi θm)), the mean splits as m = ∫_A X + ∫_{Aᶜ} X via integral_add_compl. On the complement Aᶜ the bound X ≤ θm holds pointwise, so setIntegral_mono_on plus setIntegral_const and measureReal_le_one give ∫_{Aᶜ} X ≤ θm·μ(Aᶜ) ≤ θm. Subtracting yields the key lower bound ∫_A X ≥ (1−θ)m — the mass that must concentrate on the high-value set A.",
+    "mathContext": "$m = \\int_A X + \\int_{A^c} X$; $\\ \\int_{A^c} X \\le \\theta m \\Rightarrow \\int_A X \\ge (1-\\theta)m$.",
+    "significance": "key",
+    "relatedConcepts": ["set integral decomposition", "monotonicity of integrals", "threshold set", "probability measure ≤ 1"],
+    "prerequisites": ["integral_add_compl", "setIntegral_mono_on", "measurability of preimages"]
+  },
+  {
+    "id": "ann-pz0101-combine",
+    "proofId": "prob-method-second-moment-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 134 },
+    "type": "insight",
+    "title": "Indicator Trick and the Final Combination",
+    "content": "Cauchy–Schwarz is applied with g = A.indicator 1: then ∫ X·g = ∫_A X (set integral) and ∫ g² = μ(A) (the indicator is idempotent under squaring), so sq_integral_mul_le specializes to (∫_A X)² ≤ 𝔼[X²]·μ(A). Chaining with the lower bound (1−θ)m ≤ ∫_A X — squaring is valid because 0 ≤ (1−θ)m — gives (1−θ)²m² ≤ (∫_A X)² ≤ μ(A)·𝔼[X²], the quantitative Paley–Zygmund inequality.",
+    "mathContext": "$g = \\mathbf{1}_A$: $\\ (\\int_A X)^2 \\le \\mathbb{E}[X^2]\\mu(A)$ and $((1-\\theta)m)^2 \\le (\\int_A X)^2$ chain to the result.",
+    "significance": "key",
+    "relatedConcepts": ["indicator function", "idempotence under squaring", "monotonicity of squaring", "second moment"],
+    "prerequisites": ["set integral as indicator integral", "the Cauchy–Schwarz lemma", "the above/below split"]
+  },
+  {
+    "id": "ann-pz0101-corollaries",
+    "proofId": "prob-method-second-moment-oq-01-oq-01",
+    "range": { "startLine": 136, "endLine": 159 },
+    "type": "concept",
+    "title": "Division Form and the θ=0 Qualitative Method",
+    "content": "paley_zygmund_prob rearranges the main inequality into the probability form μ({X > θ𝔼X}) ≥ (1−θ)²(𝔼X)²/𝔼[X²] when 𝔼[X²] > 0 (via div_le_iff₀). paley_zygmund_pos specializes θ=0 to recover the qualitative second moment method: (𝔼X)² ≤ μ({X>0})·𝔼[X²], which forces μ({X>0}) > 0 whenever 𝔼X > 0 — the continuous-space analogue of the parent's qualitative corollary. The quantitative bound thus subsumes the classical statement that a positive-mean nonnegative variable is positive with positive probability.",
+    "mathContext": "$\\mu(\\{X>\\theta\\mathbb{E}X\\}) \\ge \\dfrac{(1-\\theta)^2(\\mathbb{E}X)^2}{\\mathbb{E}[X^2]}$; $\\ \\theta=0:\\ (\\mathbb{E}X)^2 \\le \\mu(\\{X>0\\})\\mathbb{E}[X^2]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second moment method", "tail bound", "positivity with positive probability", "division form"],
+    "prerequisites": ["div_le_iff₀", "the main Paley–Zygmund inequality"]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-01/index.ts
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ProbMethodSecondMomentOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const probMethodSecondMomentOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const probMethodSecondMomentOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const probMethodSecondMomentOq01Oq01Data: ProofData = {
+  proof: probMethodSecondMomentOq01Oq01Proof,
+  annotations: probMethodSecondMomentOq01Oq01Annotations,
+}

--- a/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01-oq-01/meta.json
@@ -78,6 +78,40 @@
       "Quantitative Paley–Zygmund, finite form (parent entry: ProbMethodSecondMomentOQ01)"
     ]
   },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Measure-Theoretic Paley–Zygmund",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "States the goal — recast the finite-form quantitative Paley–Zygmund inequality into Mathlib's probability-space / Bochner-integral framework — and previews the classical argument (split the mean over A = {X > θ𝔼X} and its complement, bound the complement, apply Cauchy–Schwarz). Notes Paley–Zygmund is not yet in Mathlib.",
+      "mathContext": "$\\mu(\\{X > \\theta\\mathbb{E}X\\})\\cdot\\mathbb{E}[X^2] \\ge (1-\\theta)^2(\\mathbb{E}X)^2$."
+    },
+    {
+      "id": "cauchy-schwarz",
+      "title": "Integral Cauchy–Schwarz (Squared Form)",
+      "startLine": 42,
+      "endLine": 65,
+      "summary": "sq_integral_mul_le: (∫ f·g)² ≤ (∫ f²)(∫ g²) for nonnegative L² functions, derived from Mathlib's Hölder inequality at the conjugate pair (2,2) by converting rpow ^(1/2) factors to Real.sqrt and squaring. The sole analytic ingredient, isolated as a reusable lemma.",
+      "mathContext": "$(\\int fg)^2 \\le (\\int f^2)(\\int g^2)$."
+    },
+    {
+      "id": "paley-zygmund",
+      "title": "The Main Inequality: Split + Cauchy–Schwarz",
+      "startLine": 67,
+      "endLine": 134,
+      "summary": "paley_zygmund: with m = 𝔼X and A = {X > θm}, the mean splits as ∫_A X + ∫_{Aᶜ} X; on Aᶜ, X ≤ θm gives ∫_{Aᶜ} X ≤ θm and hence ∫_A X ≥ (1−θ)m. Cauchy–Schwarz against the indicator of A gives (∫_A X)² ≤ 𝔼[X²]·μ(A). Chaining yields (1−θ)²(𝔼X)² ≤ μ(A)·𝔼[X²].",
+      "mathContext": "$\\int_A X \\ge (1-\\theta)m$ and $(\\int_A X)^2 \\le \\mathbb{E}[X^2]\\mu(A)$ combine to the bound."
+    },
+    {
+      "id": "corollaries",
+      "title": "Probability Form and θ=0 Corollary",
+      "startLine": 136,
+      "endLine": 159,
+      "summary": "paley_zygmund_prob: the division form μ({X > θ𝔼X}) ≥ (1−θ)²(𝔼X)²/𝔼[X²] when 𝔼[X²] > 0. paley_zygmund_pos: the θ=0 specialization (𝔼X)² ≤ μ({X>0})·𝔼[X²], recovering the qualitative second moment method over continuous spaces.",
+      "mathContext": "$\\mu(\\{X>\\theta\\mathbb{E}X\\}) \\ge \\frac{(1-\\theta)^2(\\mathbb{E}X)^2}{\\mathbb{E}[X^2]}$; $\\theta=0$ recovers $(\\mathbb{E}X)^2 \\le \\mu(\\{X>0\\})\\mathbb{E}[X^2]$."
+    }
+  ],
   "conclusion": {
     "summary": "A complete Lean 4 formalization of the quantitative Paley–Zygmund inequality over a probability space, with 4 theorems and 0 axioms. The proof reuses the classical above/below decomposition over Bochner set integrals and packages the integral Cauchy–Schwarz step as the reusable lemma sq_integral_mul_le.",
     "implications": "Provides the measure-theoretic form of Paley–Zygmund needed for the probabilistic method over continuous probability spaces, connecting the gallery's combinatorial second-moment results to Mathlib's MeasureTheory.Lp / ProbabilityTheory API. The squared integral Cauchy–Schwarz lemma is independently reusable.",


### PR DESCRIPTION
Enrichment pass for `prob-method-second-moment-oq-01-oq-01` (Quantitative Paley–Zygmund in the MeasureTheory.Lp Setting).

## What was missing
Rich meta.json (keyInsights, conclusion, references already present) but **no `index.ts`** (page renders 'proof not found'), **no `annotations.json`**, and **no `sections`** array.

## Changes
- **index.ts**: created from the standard template (import `ProbMethodSecondMomentOQ01OQ01`).
- **annotations.json**: 5 annotations over the full 159-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - Overview: Paley–Zygmund over a genuine probability space (answers parent's open question)
  - Integral Cauchy–Schwarz as squared Hölder(2,2) (`sq_integral_mul_le`)
  - The above/below split of the mean over A = {X > θ𝔼X}
  - The indicator trick + final combination
  - Division form and the θ=0 qualitative second-moment recovery
- **meta.json**: added the 4-entry `sections` array covering the docstring, the Cauchy–Schwarz lemma, the main inequality, and the corollaries.

## Verification
- JSON parses; annotation validator reports **0 errors for this proof** (all startLines land on a `/-`/`/--` docstring). Pre-existing gallery-wide validator noise is unrelated.
- Axiom integrity preserved: verified / 0-axiom / 0-sorry, consistent with the Lean source.