### PR TITLE
Enrich half-line Gaussian moments (area-of-circle-oq-07-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 4, "endLine": 37 },
+    "type": "context",
+    "title": "Climbing the Half-Line Gaussian Moment Ladder",
+    "content": "The parent area-of-circle-oq-07-oq-02 evaluates the zeroth half-line Gaussian moment ∫_(0,∞) e^(−bx²) dx = √(π/b)/2. This file computes the next two rungs: the first moment ∫_(0,∞) x·e^(−bx²) dx = 1/(2b) and the second ∫_(0,∞) x²·e^(−bx²) dx = √(π/b)/(4b). The half-line is essential — the full-line first moment vanishes by odd symmetry, so the value 1/(2b) is genuinely new information. These are precisely the unnormalized first and second moments of the half-normal distribution; dividing by the total mass √(π/b)/2 recovers its mean 1/√(πb) and second moment 1/(2b).",
+    "mathContext": "$\\int_0^\\infty x\\,e^{-bx^2}\\,dx = \\dfrac{1}{2b}, \\qquad \\int_0^\\infty x^2 e^{-bx^2}\\,dx = \\dfrac{1}{4b}\\sqrt{\\tfrac{\\pi}{b}}$.",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian integral", "moments of a distribution", "half-normal distribution", "improper integral"],
+    "prerequisites": ["Lebesgue integration on Ioi", "the parent zeroth moment √(π/b)/2"]
+  },
+  {
+    "id": "ann-decay-lemmas",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 42, "endLine": 50 },
+    "type": "technique",
+    "title": "Exponential Decay of the Primitive at +∞",
+    "content": "Two private auxiliaries supply the boundary behaviour that the FTC engine needs. neg_b_sq_tendsto_atBot shows −b·x² → −∞ along atTop (a positive coefficient times x² driven negative), and exp_neg_b_sq_tendsto_zero composes this with Real.tendsto_exp_atBot to get e^(−bx²) → 0. This vanishing-at-infinity fact is what makes the boundary term of the half-line fundamental theorem of calculus well defined for the first moment.",
+    "mathContext": "$-bx^2 \\to -\\infty$ and hence $e^{-bx^2} \\to 0$ as $x \\to \\infty$, for $b > 0$.",
+    "significance": "technical",
+    "relatedConcepts": ["tendsto_exp_atBot", "limit at infinity", "exponential decay"],
+    "prerequisites": ["filters and limits", "composition of tendsto"]
+  },
+  {
+    "id": "ann-mul-decay",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 65 },
+    "type": "technique",
+    "title": "mul_exp_neg_b_sq_tendsto_zero: The Integration-by-Parts Boundary Term",
+    "content": "The second moment's integration by parts has boundary function g(x) = −(2b)⁻¹·x·e^(−bx²); legitimacy requires x·e^(−bx²) → 0 at +∞. Rather than re-deriving polynomial-times-exponential decay, the proof borrows Mathlib's linear-exponent result tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero at exponent s = 1/2 and precomposes it with x ↦ x², using (x²)^(1/2) = x for x ≥ 0 (established eventually via filter_upwards and rpow_mul). This is the only place super-polynomial decay enters, and reusing the rpow form keeps it to a few lines.",
+    "mathContext": "$x\\,e^{-bx^2} = (x^2)^{1/2} e^{-b x^2} \\to 0$, from $x^s e^{-bx} \\to 0$ at $s = \\tfrac12$ precomposed with $x \\mapsto x^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tendsto_rpow_mul_exp_neg_mul_atTop_nhds_zero", "super-polynomial decay", "rpow", "filter_upwards"],
+    "prerequisites": ["real power functions", "eventual equality of functions"]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 67, "endLine": 90 },
+    "type": "theorem",
+    "title": "first_half_moment: ∫₀^∞ x·e^(−bx²) = 1/(2b)",
+    "content": "The first moment is elementary because x·e^(−bx²) is an exact derivative: the primitive −(2b)⁻¹·e^(−bx²) has derivative x·e^(−bx²) (built from hasDerivAt_pow, const_mul, exp, then closed by field_simp; ring). The half-line FTC integral_Ioi_of_hasDerivAt_of_tendsto' returns the boundary value m − f(0) where m = lim at +∞ = 0 and f(0) = −(2b)⁻¹, giving (2b)⁻¹ = 1/(2b). Integrability of x·e^(−bx²) is supplied by Mathlib's integrable_mul_exp_neg_mul_sq. Unlike the full-line first moment (which is 0 by odd symmetry), this is a non-trivial finite value.",
+    "mathContext": "$\\frac{d}{dx}\\!\\left[-\\tfrac{1}{2b}e^{-bx^2}\\right] = x\\,e^{-bx^2}$, so $\\int_0^\\infty = 0 - \\left(-\\tfrac{1}{2b}\\right) = \\tfrac{1}{2b}$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of calculus", "explicit primitive", "integral_Ioi_of_hasDerivAt_of_tendsto'", "odd symmetry"],
+    "prerequisites": ["HasDerivAt calculus", "improper integral on a half-line"]
+  },
+  {
+    "id": "ann-second-moment",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 92, "endLine": 142 },
+    "type": "theorem",
+    "title": "second_half_moment: One Integration by Parts Back to the Zeroth Moment",
+    "content": "The second moment is reached by a single integration by parts. The primitive g(x) = −(2b)⁻¹·x·e^(−bx²) has derivative g'(x) = x²·e^(−bx²) − (2b)⁻¹·e^(−bx²) and vanishes at both endpoints (0 trivially, +∞ by mul_exp_neg_b_sq_tendsto_zero). So ∫_(0,∞) g' = g(+∞) − g(0) = 0, i.e. ∫_(0,∞) x²·e^(−bx²) = (2b)⁻¹·∫_(0,∞) e^(−bx²). The right side is the parent's zeroth moment integral_gaussian_Ioi = √(π/b)/2, yielding √(π/b)/(4b). Integrability of the x² piece is transported from integrableOn_rpow_mul_exp_neg_mul_sq at s = 2 (rewriting x^2 as the rpow). This realizes the recursion 'one integration by parts lowers the exponent by two'.",
+    "mathContext": "$\\int_0^\\infty x^2 e^{-bx^2} = \\tfrac{1}{2b}\\int_0^\\infty e^{-bx^2} = \\tfrac{1}{2b}\\cdot\\tfrac{1}{2}\\sqrt{\\tfrac{\\pi}{b}} = \\tfrac{1}{4b}\\sqrt{\\tfrac{\\pi}{b}}$.",
+    "significance": "key",
+    "relatedConcepts": ["integration by parts", "moment recursion", "integral_gaussian_Ioi", "integrableOn_rpow_mul_exp_neg_mul_sq"],
+    "prerequisites": ["integration by parts via primitives", "the zeroth Gaussian moment"]
+  },
+  {
+    "id": "ann-packaging",
+    "proofId": "area-of-circle-oq-07-oq-02-oq-02",
+    "range": { "startLine": 144, "endLine": 163 },
+    "type": "concept",
+    "title": "Packaged Forms and the Half-Normal Mean",
+    "content": "Three corollaries package the results for reuse. half_line_moments bundles both moments into a single conjunction. first_half_moment_one specializes b = 1 to the clean value ∫_(0,∞) x·e^(−x²) = 1/2. half_normal_mean_relation states the half-normal mean cleanly without division: multiplying the first moment by √(π/b) equals (1/(2b))·√(π/b), the cross-multiplied form of 'mean = first moment / total mass = 1/√(πb)'. Avoiding the literal quotient keeps the statement free of nonvanishing-denominator side conditions.",
+    "mathContext": "Half-normal mean $= \\dfrac{\\int_0^\\infty x e^{-bx^2}}{\\int_0^\\infty e^{-bx^2}} = \\dfrac{1/(2b)}{\\tfrac12\\sqrt{\\pi/b}} = \\dfrac{1}{\\sqrt{\\pi b}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["half-normal distribution", "mean", "normalization", "cross-multiplication"],
+    "prerequisites": ["probability moments", "the two moment values"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq02Oq02Data: ProofData = {
+  proof: areaOfCircleOq07Oq02Oq02Proof,
+  annotations: areaOfCircleOq07Oq02Oq02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-02-oq-02/meta.json
@@ -21,6 +21,7 @@
     "sorries": 0
   },
   "title": "Half-Line Gaussian Moments",
+  "description": "Climbs the half-line Gaussian moment ladder two rungs above the parent's zeroth moment √(π/b)/2: the first moment ∫_(0,∞) x·e^(−bx²) dx = 1/(2b) (elementary, via the explicit primitive −(2b)⁻¹·e^(−bx²)) and the second moment ∫_(0,∞) x²·e^(−bx²) dx = √(π/b)/(4b) (one integration by parts back down to the zeroth moment). These are the unnormalized first and second moments of the half-normal distribution. 163 lines, 8 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -80,6 +81,52 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^(−x²) dx = √π is among the most-used results in analysis and probability; restricting it to the half-line (0,∞) halves the zeroth moment to √(π/b)/2, the normalization of the half-normal distribution. The moments of e^(−bx²) on (0,∞) have a clean split: even-order moments inherit the √π through the zeroth moment, while odd-order moments are elementary rationals in 1/b with no √π at all — a dichotomy invisible on the full line, where every odd moment vanishes by symmetry. This entry computes the first two moments and exhibits the integration-by-parts recursion that generates all of them.",
+    "problemStatement": "For b > 0, evaluate the first and second half-line Gaussian moments ∫_(0,∞) x·e^(−bx²) dx and ∫_(0,∞) x²·e^(−bx²) dx, and connect them to the mean and variance of the half-normal distribution.",
+    "proofStrategy": "Both moments are evaluated by the half-line fundamental theorem of calculus (integral_Ioi_of_hasDerivAt_of_tendsto'), which returns lim_(x→∞) f(x) − f(0) once a primitive f with the integrand as derivative and a known limit at +∞ is supplied. For the first moment the primitive is −(2b)⁻¹·e^(−bx²), giving 1/(2b) directly. For the second moment the primitive g(x) = −(2b)⁻¹·x·e^(−bx²) has derivative x²·e^(−bx²) − (2b)⁻¹·e^(−bx²) and vanishes at both endpoints, so the integral of that difference is 0; splitting it shows the second moment equals (2b)⁻¹ times the parent's zeroth moment √(π/b)/2 = √(π/b)/(4b). The only analytic input beyond the primitives is the decay x·e^(−bx²) → 0, borrowed from Mathlib's rpow·exp decay lemma.",
+    "keyInsights": [
+      "The half-line first moment 1/(2b) is genuinely new information: on the full line the first moment is 0 by odd symmetry, so the symmetry shortcut that handles the zeroth moment gives no leverage here — an explicit primitive is required.",
+      "Even and odd half-line moments are fundamentally different objects: x·e^(−bx²) is an exact derivative (the first moment is elementary, with no √π), whereas the second moment must be reduced to the transcendental zeroth moment and so carries the √π.",
+      "A single integration by parts is the entire recursion engine: g(x) = −(2b)⁻¹·x·e^(−bx²) lowers the exponent by two, expressing the second moment in terms of the zeroth — the same step iterates to give all higher moments (the medium-significance open question).",
+      "Both evaluations reduce to a boundary term because the primitives vanish at +∞; the only real analytic content is the super-polynomial decay x·e^(−bx²) → 0, reused from Mathlib rather than re-derived.",
+      "Dividing the unnormalized moments by the total mass √(π/b)/2 yields the half-normal mean 1/√(πb) and second moment 1/(2b), hence variance (1/2 − 1/π)/b — making these integrals the computational backbone of the half-normal distribution."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Moment Ladder",
+      "startLine": 4,
+      "endLine": 37,
+      "summary": "States the open question and the two target values, situates them above the parent's zeroth moment √(π/b)/2, and previews the methods: an explicit primitive for the first moment and one integration by parts for the second. Notes the half-normal connection and that no new axioms are introduced.",
+      "mathContext": "$\\int_0^\\infty x\\,e^{-bx^2} = \\tfrac{1}{2b}$, $\\ \\int_0^\\infty x^2 e^{-bx^2} = \\tfrac{1}{4b}\\sqrt{\\pi/b}$."
+    },
+    {
+      "id": "decay-auxiliaries",
+      "title": "Decay Auxiliaries",
+      "startLine": 42,
+      "endLine": 65,
+      "summary": "Three private lemmas establish the limits the FTC needs at +∞: −bx² → −∞, hence e^(−bx²) → 0, and x·e^(−bx²) → 0 (the latter from Mathlib's rpow·exp decay at exponent 1/2 precomposed with x ↦ x²). These supply the vanishing boundary terms for both moment evaluations.",
+      "mathContext": "$e^{-bx^2} \\to 0$ and $x\\,e^{-bx^2} \\to 0$ as $x \\to \\infty$ for $b > 0$."
+    },
+    {
+      "id": "first-and-second-moments",
+      "title": "The First and Second Moments",
+      "startLine": 67,
+      "endLine": 142,
+      "summary": "first_half_moment evaluates ∫_(0,∞) x·e^(−bx²) = 1/(2b) from the explicit primitive −(2b)⁻¹·e^(−bx²). second_half_moment evaluates ∫_(0,∞) x²·e^(−bx²) = √(π/b)/(4b) by integrating the primitive g(x) = −(2b)⁻¹·x·e^(−bx²), reducing to (2b)⁻¹ times the parent's zeroth moment integral_gaussian_Ioi.",
+      "mathContext": "$\\frac{d}{dx}\\!\\left[-\\tfrac{1}{2b}xe^{-bx^2}\\right] = x^2 e^{-bx^2} - \\tfrac{1}{2b}e^{-bx^2}$."
+    },
+    {
+      "id": "packaging-and-half-normal",
+      "title": "Packaged Forms and the Half-Normal Mean",
+      "startLine": 144,
+      "endLine": 164,
+      "summary": "half_line_moments bundles both moments; first_half_moment_one gives the b = 1 value 1/2; half_normal_mean_relation states the half-normal mean 1/√(πb) in cross-multiplied (division-free) form.",
+      "mathContext": "Half-normal mean $= \\dfrac{1/(2b)}{\\tfrac12\\sqrt{\\pi/b}} = \\dfrac{1}{\\sqrt{\\pi b}}$."
+    }
+  ],
   "openQuestions": [
     {
       "id": "area-of-circle-oq-07-oq-02-oq-02-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-02-oq-02` (quality 15 → enriched).

**Highest-impact gap fixed:** the directory had only `meta.json` — no `index.ts`, so the page rendered as 'proof not found' on the live site. Added the Vite entry point.

**Added:**
- `annotations.json` — 6 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering all 163 lines (docstring, the decay auxiliaries, the boundary-term lemma, `first_half_moment`, `second_half_moment`, and the packaged half-normal corollaries).
- top-level `description` and a full `overview` block (historicalContext, problemStatement, proofStrategy, 5 keyInsights) — meta previously had **no overview at all**.
- `sections` — 4 sections spanning the full file (was absent).

Axiom integrity: status `verified`, badge `verified`, axiomCount 0 — consistent with the Lean docstring (no native_decide; depends only on propext / Classical.choice / Quot.sound). `annotations:validate` reports no errors for this entry.