### PR TITLE
research(geometric-series-oq-07-oq-02): mean, second moment & variance of the geometric distribution [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2953,6 +2953,7 @@ import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ03OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ03
+import Proofs.GeometricSeriesOQ07OQ02
 import Proofs.GeometricSeriesOQ08
 import Proofs.GeometricSeriesOQ08OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ07OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ02.lean
@@ -1,0 +1,140 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+import Proofs.GeometricSeriesOQ07
+
+/-
+# The Geometric Distribution: Mean, Second Moment, and Variance
+
+This file answers the **probabilistic corollary** open question of the verified
+parent `geometric-series-oq-07` (*The Second Moment of the Geometric Series*,
+`∑ n² rⁿ = r(1+r)/(1-r)³`).
+
+Let `0 ≤ r < 1` and consider the random variable `X` on `ℕ` with probability mass
+function
+
+  `P(X = n) = (1 - r) · rⁿ`.
+
+This is the geometric distribution (number of failures before the first success,
+with success probability `1 - r`). From the closed-form moment sums of the parent
+we read off, by a single multiplication by `(1 - r)` and elementary field algebra:
+
+  * **Normalisation**  `∑ₙ (1-r)·rⁿ = 1`            (`P` is a genuine pmf),
+  * **Mean**           `E[X] = r / (1-r)`,
+  * **Second moment**  `E[X²] = r(1+r) / (1-r)²`,
+  * **Variance**       `Var(X) = E[X²] − E[X]² = r / (1-r)²`,
+
+and finally we verify that the *centred* second moment — the honest definition of
+the variance, `∑ₙ (n − E[X])²·P(X=n)` — also equals `r/(1-r)²`, obtained by
+linearity of `HasSum` from the three moment sums.
+
+Everything is a black-box consequence of the parent's `hasSum_sq_mul_geometric`
+together with Mathlib's `hasSum_geometric_of_norm_lt_one` and
+`hasSum_coe_mul_geometric_of_norm_lt_one`. No new analysis is performed: the
+content is the translation of the analytic moment formulas into the language of a
+probability distribution, plus the cancellation that produces the variance.
+
+## Main results
+
+* `geometric_pmf_hasSum`     — `HasSum (fun n => (1-r)·rⁿ) 1`.
+* `geometric_expectation`    — `HasSum (fun n => n·(1-r)·rⁿ) (r/(1-r))`.
+* `geometric_second_moment`  — `HasSum (fun n => n²·(1-r)·rⁿ) (r(1+r)/(1-r)²)`.
+* `geometric_variance_identity` — `r(1+r)/(1-r)² − (r/(1-r))² = r/(1-r)²`.
+* `geometric_variance`       — `HasSum (fun n => (n − r/(1-r))²·(1-r)·rⁿ) (r/(1-r)²)`.
+-/
+
+open scoped Topology
+
+namespace GeometricSeriesOQ07OQ02
+
+variable {r : ℝ}
+
+/-- From `0 ≤ r < 1` we have `‖r‖ < 1`, the hypothesis the moment sums need. -/
+lemma norm_lt_one (hr0 : 0 ≤ r) (hr1 : r < 1) : ‖r‖ < 1 := by
+  rw [Real.norm_eq_abs, abs_of_nonneg hr0]; exact hr1
+
+/-- `1 - r ≠ 0` whenever `r < 1`. -/
+lemma one_sub_ne_zero (hr1 : r < 1) : (1 : ℝ) - r ≠ 0 := by
+  have : (0 : ℝ) < 1 - r := by linarith
+  exact ne_of_gt this
+
+/-- **Normalisation.** `P(X = n) = (1-r)·rⁿ` is a genuine probability mass
+function: the masses sum to `1`. This is the geometric series `∑ rⁿ = (1-r)⁻¹`
+scaled by `(1-r)`. -/
+theorem geometric_pmf_hasSum (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    HasSum (fun n : ℕ => (1 - r) * r ^ n) 1 := by
+  have h := (hasSum_geometric_of_norm_lt_one (norm_lt_one hr0 hr1)).mul_left (1 - r)
+  have hval : (1 - r) * (1 - r)⁻¹ = (1 : ℝ) :=
+    mul_inv_cancel₀ (one_sub_ne_zero hr1)
+  rwa [hval] at h
+
+/-- **Mean / first moment.** `E[X] = ∑ₙ n·(1-r)·rⁿ = r/(1-r)`, the parent's
+first moment `∑ n·rⁿ = r/(1-r)²` scaled by `(1-r)`. -/
+theorem geometric_expectation (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) * ((1 - r) * r ^ n)) (r / (1 - r)) := by
+  have h := (hasSum_coe_mul_geometric_of_norm_lt_one
+    (norm_lt_one hr0 hr1)).mul_left (1 - r)
+  -- `h : HasSum (fun n => (1-r) * (n * rⁿ)) ((1-r) * (r/(1-r)²))`
+  have hne := one_sub_ne_zero hr1
+  have hfun : (fun n : ℕ => (1 - r) * ((n : ℝ) * r ^ n))
+      = (fun n : ℕ => (n : ℝ) * ((1 - r) * r ^ n)) := by
+    funext n; ring
+  have hval : (1 - r) * (r / (1 - r) ^ 2) = r / (1 - r) := by
+    field_simp
+  rw [hfun, hval] at h
+  exact h
+
+/-- **Second moment.** `E[X²] = ∑ₙ n²·(1-r)·rⁿ = r(1+r)/(1-r)²`, the parent's
+second moment `∑ n²·rⁿ = r(1+r)/(1-r)³` scaled by `(1-r)`. -/
+theorem geometric_second_moment (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    HasSum (fun n : ℕ => (n : ℝ) ^ 2 * ((1 - r) * r ^ n))
+      (r * (1 + r) / (1 - r) ^ 2) := by
+  have h := (GeometricSeriesOQ07.hasSum_sq_mul_geometric
+    (norm_lt_one hr0 hr1)).mul_left (1 - r)
+  have hne := one_sub_ne_zero hr1
+  have hfun : (fun n : ℕ => (1 - r) * ((n : ℝ) ^ 2 * r ^ n))
+      = (fun n : ℕ => (n : ℝ) ^ 2 * ((1 - r) * r ^ n)) := by
+    funext n; ring
+  have hval : (1 - r) * (r * (1 + r) / (1 - r) ^ 3) = r * (1 + r) / (1 - r) ^ 2 := by
+    field_simp
+  rw [hfun, hval] at h
+  exact h
+
+/-- **Variance, algebraic form.** `Var(X) = E[X²] − E[X]² = r/(1-r)²`. This is the
+pure field cancellation `r(1+r)/(1-r)² − (r/(1-r))² = r/(1-r)²`. -/
+theorem geometric_variance_identity (hr1 : r < 1) :
+    r * (1 + r) / (1 - r) ^ 2 - (r / (1 - r)) ^ 2 = r / (1 - r) ^ 2 := by
+  have h := one_sub_ne_zero hr1
+  field_simp
+  ring
+
+/-- **Variance, centred second moment.** The honest definition of the variance,
+`Var(X) = ∑ₙ (n − E[X])²·P(X=n)`, also equals `r/(1-r)²`. Obtained from the three
+moment sums by linearity of `HasSum`, using `(n − μ)² = n² − 2μ·n + μ²`. -/
+theorem geometric_variance (hr0 : 0 ≤ r) (hr1 : r < 1) :
+    HasSum (fun n : ℕ => ((n : ℝ) - r / (1 - r)) ^ 2 * ((1 - r) * r ^ n))
+      (r / (1 - r) ^ 2) := by
+  set μ : ℝ := r / (1 - r) with hμ
+  -- The three moment sums.
+  have hE2 := geometric_second_moment hr0 hr1
+  have hE1 := geometric_expectation hr0 hr1
+  have hE0 := geometric_pmf_hasSum hr0 hr1
+  -- Linear combination: E[X²] − 2μ·E[X] + μ²·1.
+  have h := (hE2.sub (hE1.mul_left (2 * μ))).add (hE0.mul_left (μ ^ 2))
+  -- Rewrite the summand into the centred form `(n − μ)²·P(n)`.
+  have hfun :
+      (fun n : ℕ => (n : ℝ) ^ 2 * ((1 - r) * r ^ n)
+          - 2 * μ * ((n : ℝ) * ((1 - r) * r ^ n)) + μ ^ 2 * ((1 - r) * r ^ n))
+      = (fun n : ℕ => ((n : ℝ) - μ) ^ 2 * ((1 - r) * r ^ n)) := by
+    funext n; ring
+  -- Rewrite the total into `r/(1-r)²`.
+  have hval :
+      r * (1 + r) / (1 - r) ^ 2 - 2 * μ * (r / (1 - r)) + μ ^ 2 * 1
+        = r / (1 - r) ^ 2 := by
+    rw [hμ]
+    have hne := one_sub_ne_zero hr1
+    field_simp
+    ring
+  rw [hfun, hval] at h
+  exact h
+
+end GeometricSeriesOQ07OQ02

--- a/src/data/proofs/geometric-series-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-02/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "geom-rv-pmf",
+    "proofId": "geometric-series-oq-07-oq-02",
+    "range": { "startLine": 63, "endLine": 68 },
+    "type": "theorem",
+    "title": "Normalisation: P is a probability mass function",
+    "content": "`geometric_pmf_hasSum` proves $\\sum_{n} (1-r)\\,r^n = 1$, so $P(X=n) = (1-r)\\,r^n$ is a genuine probability mass function on $\\mathbb{N}$ (the geometric law with success probability $p = 1-r$). The proof is one line of structure: take Mathlib's $\\sum_n r^n = (1-r)^{-1}$ (`hasSum_geometric_of_norm_lt_one`), scale by $(1-r)$ with `HasSum.mul_left`, and simplify the value $(1-r)(1-r)^{-1}=1$ via `mul_inv_cancel₀` (using $1-r\\neq 0$ from $r<1$)."
+  },
+  {
+    "id": "geom-rv-mean",
+    "proofId": "geometric-series-oq-07-oq-02",
+    "range": { "startLine": 72, "endLine": 84 },
+    "type": "theorem",
+    "title": "Mean: E[X] = r/(1−r)",
+    "content": "`geometric_expectation` proves the first moment $E[X] = \\sum_n n\\,(1-r)\\,r^n = \\dfrac{r}{1-r}$. It is Mathlib's first weighted geometric sum $\\sum_n n\\,r^n = \\dfrac{r}{(1-r)^2}$ (`hasSum_coe_mul_geometric_of_norm_lt_one`) scaled by the success probability $(1-r)$: the summand $n\\big((1-r)r^n\\big)$ is matched to $(1-r)\\big(n\\,r^n\\big)$ by `ring`, and the value $(1-r)\\cdot\\dfrac{r}{(1-r)^2}=\\dfrac{r}{1-r}$ collapses under `field_simp`. With $p = 1-r$ this is the familiar $E[X]=\\dfrac{1-p}{p}$."
+  },
+  {
+    "id": "geom-rv-second-moment",
+    "proofId": "geometric-series-oq-07-oq-02",
+    "range": { "startLine": 88, "endLine": 100 },
+    "type": "theorem",
+    "title": "Second moment: E[X²] = r(1+r)/(1−r)²",
+    "content": "`geometric_second_moment` proves $E[X^2] = \\sum_n n^2\\,(1-r)\\,r^n = \\dfrac{r(1+r)}{(1-r)^2}$. This is the parent entry's analytic second moment $\\sum_n n^2 r^n = \\dfrac{r(1+r)}{(1-r)^3}$ (`GeometricSeriesOQ07.hasSum_sq_mul_geometric`) scaled by $(1-r)$ via `HasSum.mul_left`, with the summand reconciled by `ring` and the value $(1-r)\\cdot\\dfrac{r(1+r)}{(1-r)^3}=\\dfrac{r(1+r)}{(1-r)^2}$ simplified by `field_simp`."
+  },
+  {
+    "id": "geom-rv-variance-identity",
+    "proofId": "geometric-series-oq-07-oq-02",
+    "range": { "startLine": 104, "endLine": 108 },
+    "type": "theorem",
+    "title": "Variance, algebraic form: E[X²] − E[X]² = r/(1−r)²",
+    "content": "`geometric_variance_identity` records the bookkeeping cancellation $\\dfrac{r(1+r)}{(1-r)^2} - \\Big(\\dfrac{r}{1-r}\\Big)^2 = \\dfrac{r}{(1-r)^2}$, i.e. $E[X^2] - E[X]^2 = \\dfrac{r}{(1-r)^2}$. The numerator simplifies as $r(1+r) - r^2 = r$, so the variance is $\\dfrac{r}{(1-r)^2}$ — with $p=1-r$ the textbook $\\mathrm{Var}(X)=\\dfrac{1-p}{p^2}$. A pure field identity, discharged by `field_simp; ring` using $1-r\\neq 0$."
+  },
+  {
+    "id": "geom-rv-variance",
+    "proofId": "geometric-series-oq-07-oq-02",
+    "range": { "startLine": 113, "endLine": 138 },
+    "type": "theorem",
+    "title": "Variance as the centred second moment",
+    "content": "`geometric_variance` proves the honest definition of the variance, $\\sum_n \\big(n - E[X]\\big)^2 (1-r)\\,r^n = \\dfrac{r}{(1-r)^2}$, where $E[X]=\\mu=\\dfrac{r}{1-r}$. Expanding $(n-\\mu)^2 = n^2 - 2\\mu n + \\mu^2$, the centred series is the linear combination $E[X^2] - 2\\mu\\,E[X] + \\mu^2\\cdot 1$ of the second, first and zeroth moment sums, assembled by `HasSum.sub`, `HasSum.add` and `HasSum.mul_left` (no new convergence argument — the three series are summable). The combined summand rewrites to $(n-\\mu)^2 P(n)$ by `ring`, and the combined value $\\dfrac{r(1+r)}{(1-r)^2} - 2\\mu\\cdot\\dfrac{r}{1-r} + \\mu^2 = \\dfrac{r}{(1-r)^2}$ collapses by `field_simp; ring`, agreeing with the algebraic form."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-02/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "geometric-series-oq-07-oq-02",
+  "slug": "geometric-series-oq-07-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic",
+      "Proofs.GeometricSeriesOQ07"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ07OQ02",
+    "lineCount": 140,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Geometric Distribution: Mean, Second Moment, and Variance",
+  "description": "Settles the parent entry's open question oq-02 (the probabilistic corollary of the geometric-series moment sums): for the geometric random variable X on ℕ with probability mass function P(X = n) = (1 − r)·rⁿ (0 ≤ r < 1), derive E[X] = r/(1−r), E[X²] = r(1+r)/(1−r)², and Var(X) = r/(1−r)² directly from the parent's closed-form moment series. Each moment statement is the corresponding analytic sum scaled by the normalising factor (1 − r): the parent's ∑ rⁿ = (1−r)⁻¹, ∑ n·rⁿ = r/(1−r)², and ∑ n²·rⁿ = r(1+r)/(1−r)³ become, after multiplication by (1 − r), the pmf normalisation ∑ (1−r)rⁿ = 1, the mean r/(1−r), and the second moment r(1+r)/(1−r)². The variance is obtained both algebraically (E[X²] − E[X]² = r/(1−r)²) and as an honest centred second moment ∑ (n − E[X])²·P(X = n) = r/(1−r)², the latter assembled from the three moment sums by linearity of HasSum via (n − μ)² = n² − 2μ·n + μ². 140 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The geometric distribution is one of the first discrete distributions encountered in probability: with success probability p = 1 − r, the number X of failures before the first success has P(X = n) = p·(1−p)ⁿ = (1 − r)·rⁿ, and its mean and variance — E[X] = (1−p)/p = r/(1−r) and Var(X) = (1−p)/p² = r/(1−r)² — are textbook formulas. They are exactly the moment sums of the geometric series, normalised: the parent entry (geometric-series-oq-07, 'The Second Moment of the Geometric Series') proves the analytic series ∑ rⁿ, ∑ n·rⁿ and ∑ n²·rⁿ in closed form and flagged as its open question oq-02 the probabilistic restatement, i.e. reading those sums as the moments of the geometric law. Mathlib has the geometric series and its first two weighted moments (hasSum_geometric_of_norm_lt_one, hasSum_coe_mul_geometric_of_norm_lt_one) but does not record the geometric distribution's mean and variance as such; this entry supplies them as a thin probabilistic layer over the parent's analytic results.",
+    "problemStatement": "For 0 ≤ r < 1, treating P(X = n) = (1 − r)·rⁿ as the probability mass function of a random variable X on ℕ, prove (i) ∑ₙ (1 − r)·rⁿ = 1 (P is a genuine pmf), (ii) the mean E[X] = ∑ₙ n·(1 − r)·rⁿ = r/(1 − r), (iii) the second moment E[X²] = ∑ₙ n²·(1 − r)·rⁿ = r(1 + r)/(1 − r)², and (iv) the variance Var(X) = E[X²] − E[X]² = ∑ₙ (n − E[X])²·(1 − r)·rⁿ = r/(1 − r)², with 0 axioms and 0 sorries.",
+    "proofStrategy": "Each moment is the corresponding analytic series scaled by (1 − r), using HasSum.mul_left. (i) From Mathlib's hasSum_geometric_of_norm_lt_one (∑ rⁿ = (1−r)⁻¹), scaling by (1 − r) gives value (1 − r)·(1 − r)⁻¹ = 1 by mul_inv_cancel₀. (ii) From Mathlib's hasSum_coe_mul_geometric_of_norm_lt_one (∑ n·rⁿ = r/(1−r)²), scaling gives (1 − r)·r/(1−r)² = r/(1 − r); the summand n·((1−r)rⁿ) is matched to (1−r)·(n·rⁿ) by ring and the value simplified by field_simp. (iii) From the parent's hasSum_sq_mul_geometric (∑ n²·rⁿ = r(1+r)/(1−r)³), scaling gives r(1+r)/(1−r)². (iv) The algebraic variance is the field identity r(1+r)/(1−r)² − (r/(1−r))² = r/(1−r)² (field_simp; ring). The centred second moment is built from the three moment HasSums: writing (n − μ)² = n² − 2μ·n + μ² with μ = r/(1−r), the combination hE2.sub (hE1.mul_left (2μ)) |>.add (hE0.mul_left (μ²)) is a HasSum whose summand rewrites (by ring) to (n − μ)²·P(n) and whose value rewrites (by field_simp; ring) to r/(1−r)². The hypothesis 0 ≤ r < 1 enters only to give ‖r‖ < 1 (the analytic hypothesis) and 1 − r ≠ 0 (for the cancellations); no new analysis or summability argument is performed.",
+    "keyInsights": [
+      "The moments of the geometric distribution ARE the moment sums of the geometric series, normalised: multiplying the parent's ∑ rⁿ, ∑ n·rⁿ, ∑ n²·rⁿ by the success probability (1 − r) turns analytic identities into probabilistic ones, with HasSum.mul_left doing all the work.",
+      "Normalisation is the geometric series itself: ∑ (1 − r)·rⁿ = (1 − r)·(1 − r)⁻¹ = 1, so P(X = n) = (1 − r)·rⁿ is automatically a probability mass function — no separate summability or positivity argument is needed.",
+      "The variance is computed two ways that must agree: the bookkeeping identity Var = E[X²] − E[X]² = r(1+r)/(1−r)² − r²/(1−r)² = r/(1−r)² (a pure field cancellation), and the honest centred sum ∑ (n − E[X])²·P(X = n), the latter obtained by linearity of HasSum from the three moment series using (n − μ)² = n² − 2μ·n + μ².",
+      "HasSum is linear: HasSum.sub, HasSum.add and HasSum.mul_left combine the zeroth, first and second moment sums into the centred second moment without ever re-establishing convergence — the three series are summable, so their linear combination converges to the corresponding combination of limits."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context and method",
+      "startLine": 5,
+      "endLine": 43,
+      "summary": "Docstring situating the entry as the probabilistic settlement of the parent's open question oq-02, defining the geometric pmf P(X = n) = (1 − r)·rⁿ and outlining the 'scale the moment series by (1 − r)' method plus the two variance computations."
+    },
+    {
+      "id": "helpers",
+      "title": "Hypothesis helpers (norm_lt_one, one_sub_ne_zero)",
+      "startLine": 51,
+      "endLine": 58,
+      "summary": "From 0 ≤ r < 1 derive ‖r‖ < 1 (the analytic hypothesis the moment sums require) and 1 − r ≠ 0 (used in the field cancellations)."
+    },
+    {
+      "id": "pmf",
+      "title": "Normalisation (geometric_pmf_hasSum)",
+      "startLine": 60,
+      "endLine": 68,
+      "summary": "HasSum (fun n => (1 − r)·rⁿ) 1: the masses sum to 1, the geometric series ∑ rⁿ = (1 − r)⁻¹ scaled by (1 − r) and simplified by mul_inv_cancel₀, so P is a genuine probability mass function."
+    },
+    {
+      "id": "mean",
+      "title": "Mean / first moment (geometric_expectation)",
+      "startLine": 70,
+      "endLine": 84,
+      "summary": "E[X] = ∑ₙ n·(1 − r)·rⁿ = r/(1 − r), from Mathlib's hasSum_coe_mul_geometric_of_norm_lt_one (∑ n·rⁿ = r/(1−r)²) scaled by (1 − r), with the summand matched by ring and the value simplified by field_simp."
+    },
+    {
+      "id": "second-moment",
+      "title": "Second moment (geometric_second_moment)",
+      "startLine": 86,
+      "endLine": 100,
+      "summary": "E[X²] = ∑ₙ n²·(1 − r)·rⁿ = r(1 + r)/(1 − r)², from the parent's hasSum_sq_mul_geometric (∑ n²·rⁿ = r(1+r)/(1−r)³) scaled by (1 − r)."
+    },
+    {
+      "id": "variance-identity",
+      "title": "Variance, algebraic form (geometric_variance_identity)",
+      "startLine": 102,
+      "endLine": 108,
+      "summary": "The field cancellation Var(X) = E[X²] − E[X]² = r(1 + r)/(1 − r)² − (r/(1 − r))² = r/(1 − r)² (field_simp; ring)."
+    },
+    {
+      "id": "variance-centred",
+      "title": "Variance, centred second moment (geometric_variance)",
+      "startLine": 110,
+      "endLine": 138,
+      "summary": "The honest variance ∑ₙ (n − E[X])²·(1 − r)·rⁿ = r/(1 − r)², assembled from the three moment HasSums by linearity (HasSum.sub/add/mul_left) using (n − μ)² = n² − 2μ·n + μ² with μ = r/(1 − r); the summand and total are reconciled by ring and field_simp."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ02.lean",
+    "tags": [
+      "probability",
+      "geometric-series",
+      "geometric-distribution",
+      "expectation",
+      "variance",
+      "second-moment",
+      "moments",
+      "hassum",
+      "summability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 140,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "geometric_expectation: the mean E[X] = ∑ₙ n·(1 − r)·rⁿ = r/(1 − r) of the geometric distribution, as a HasSum statement, obtained by scaling Mathlib's first weighted moment ∑ n·rⁿ = r/(1 − r)² by the success probability (1 − r).",
+      "geometric_second_moment: the second moment E[X²] = ∑ₙ n²·(1 − r)·rⁿ = r(1 + r)/(1 − r)², by scaling the parent's hasSum_sq_mul_geometric (∑ n²·rⁿ = r(1 + r)/(1 − r)³) by (1 − r).",
+      "geometric_variance: THE HEADLINE — the variance Var(X) = ∑ₙ (n − E[X])²·(1 − r)·rⁿ = r/(1 − r)², the honest centred second moment, assembled from the zeroth/first/second moment sums by linearity of HasSum using (n − μ)² = n² − 2μ·n + μ². Mathlib records neither the geometric distribution's variance nor this centred-sum identity.",
+      "geometric_pmf_hasSum: ∑ₙ (1 − r)·rⁿ = 1, confirming P(X = n) = (1 − r)·rⁿ is a genuine probability mass function (the geometric series scaled by 1 − r).",
+      "geometric_variance_identity: the algebraic variance bookkeeping r(1 + r)/(1 − r)² − (r/(1 − r))² = r/(1 − r)², the field cancellation that makes Var = E[X²] − E[X]² explicit and agrees with the centred sum."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07 (The Second Moment of the Geometric Series) — supplies hasSum_sq_mul_geometric (∑ n²·rⁿ = r(1 + r)/(1 − r)³), the second moment scaled here.",
+      "Mathlib's geometric-series moment sums: hasSum_geometric_of_norm_lt_one (∑ rⁿ = (1 − r)⁻¹) and hasSum_coe_mul_geometric_of_norm_lt_one (∑ n·rⁿ = r/(1 − r)²).",
+      "Linearity of HasSum: HasSum.mul_left, HasSum.sub, HasSum.add, used to scale and combine the moment series; field_simp/ring for the rational-function cancellations."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "∑ₙ rⁿ = (1 − r)⁻¹ for ‖r‖ < 1. Scaled by (1 − r) it gives the pmf normalisation ∑ (1 − r)·rⁿ = 1.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_coe_mul_geometric_of_norm_lt_one",
+        "description": "∑ₙ n·rⁿ = r/(1 − r)² for ‖r‖ < 1. Scaled by (1 − r) it gives the mean E[X] = r/(1 − r).",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07.hasSum_sq_mul_geometric",
+        "description": "The parent's second moment ∑ₙ n²·rⁿ = r(1 + r)/(1 − r)³ for ‖r‖ < 1. Scaled by (1 − r) it gives E[X²] = r(1 + r)/(1 − r)².",
+        "module": "Proofs.GeometricSeriesOQ07"
+      },
+      {
+        "theorem": "HasSum.mul_left",
+        "description": "If HasSum f a then HasSum (fun n => c·f n) (c·a). The single tool that turns each analytic moment sum into the corresponding probabilistic moment by scaling with the success probability c = 1 − r.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-02-oq-01",
+      "question": "Recast these moments in Mathlib's measure-theoretic probability framework (PMF.geometric / a Measure on ℕ), proving E[X] and Var(X) as the integral/variance of the corresponding PMF rather than as bare HasSum identities, and connect to MeasureTheory.variance.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-02-oq-02",
+      "question": "Derive the moment generating function M(t) = (1 − r)/(1 − r·eᵗ) of the geometric distribution (for eᵗ·r < 1) and recover E[X] = M'(0) and E[X²] = M''(0), giving a generating-function route to all moments uniformly.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07",
+      "relationship": "extends",
+      "description": "Parent (The Second Moment of the Geometric Series). The parent proves the analytic moment sums ∑ rⁿ, ∑ n·rⁿ, ∑ n²·rⁿ in closed form and flagged the probabilistic corollary as its open question oq-02. This entry answers it: reading those sums (scaled by the success probability 1 − r) as the normalisation, mean and second moment of the geometric distribution, and deriving the variance r/(1 − r)²."
+    }
+  ],
+  "references": [
+    {
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. 1 (the geometric distribution; mean and variance)",
+      "author": "William Feller",
+      "year": "1968",
+      "venue": "Wiley",
+      "description": "Standard reference for the geometric distribution P(X = n) = p(1 − p)ⁿ and its moments E[X] = (1 − p)/p, Var(X) = (1 − p)/p²."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the geometric-series moment sums hasSum_geometric_of_norm_lt_one and hasSum_coe_mul_geometric_of_norm_lt_one scaled here to obtain the distribution's normalisation and mean."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Building on the parent entry's closed-form geometric-series moment sums, this entry settles its open question oq-02 — the probabilistic corollary. For the geometric random variable X on ℕ with P(X = n) = (1 − r)·rⁿ (0 ≤ r < 1) it proves, as HasSum identities, the pmf normalisation ∑ (1 − r)·rⁿ = 1, the mean E[X] = r/(1 − r), the second moment E[X²] = r(1 + r)/(1 − r)², and the variance Var(X) = r/(1 − r)² — the last both as the algebraic cancellation E[X²] − E[X]² and as the honest centred second moment ∑ (n − E[X])²·P(X = n), assembled from the three moment series by linearity of HasSum. Each moment is the corresponding analytic series scaled by the success probability (1 − r) via HasSum.mul_left; the hypothesis 0 ≤ r < 1 enters only to supply ‖r‖ < 1 and 1 − r ≠ 0. 140 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry exhibits the textbook moments of the geometric distribution as a thin probabilistic layer over the analytic geometric-series sums: normalising by the success probability turns ∑ rⁿ, ∑ n·rⁿ, ∑ n²·rⁿ into 1, E[X], E[X²], and linearity of HasSum turns those into the centred variance with no new convergence argument. The two variance computations (bookkeeping E[X²] − E[X]² and centred ∑ (n − E[X])²·P) agree, providing a self-check. Natural follow-ups recast these in Mathlib's measure-theoretic probability framework and derive the moment generating function for a uniform route to all moments.",
+    "openQuestions": [
+      "Recast the moments in Mathlib's PMF / Measure framework and connect to MeasureTheory.variance.",
+      "Derive the moment generating function M(t) = (1 − r)/(1 − r·eᵗ) and recover the moments as its derivatives at 0."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **open question oq-02** of the verified/0-axiom parent **`geometric-series-oq-07`** (*The Second Moment of the Geometric Series*) — its declared *probabilistic corollary*: read the geometric-series moment sums as the moments of the **geometric distribution**.

For the random variable `X` on `ℕ` with pmf `P(X = n) = (1 − r)·rⁿ` (`0 ≤ r < 1`, success probability `p = 1 − r`):

| result | statement |
|---|---|
| `geometric_pmf_hasSum` | `∑ₙ (1−r)·rⁿ = 1`  (P is a genuine pmf) |
| `geometric_expectation` | `E[X] = ∑ₙ n·(1−r)·rⁿ = r/(1−r)` |
| `geometric_second_moment` | `E[X²] = ∑ₙ n²·(1−r)·rⁿ = r(1+r)/(1−r)²` |
| `geometric_variance_identity` | `E[X²] − E[X]² = r/(1−r)²` |
| `geometric_variance` | `∑ₙ (n − E[X])²·(1−r)·rⁿ = r/(1−r)²` |

## Method

Each moment is the corresponding **analytic series scaled by the success probability `(1 − r)`** via `HasSum.mul_left`:
- zeroth: Mathlib `hasSum_geometric_of_norm_lt_one` (`∑ rⁿ = (1−r)⁻¹`) → normalisation `1`;
- first: Mathlib `hasSum_coe_mul_geometric_of_norm_lt_one` (`∑ n·rⁿ = r/(1−r)²`) → mean `r/(1−r)`;
- second: the **parent's** `hasSum_sq_mul_geometric` (`∑ n²·rⁿ = r(1+r)/(1−r)³`) → `r(1+r)/(1−r)²`.

The **variance** is given two ways that agree: the algebraic cancellation `E[X²] − E[X]²` (a field identity), and the honest **centred second moment** `∑ (n − E[X])²·P(X=n)`, assembled from the three moment `HasSum`s by linearity (`HasSum.sub/add/mul_left`) using `(n − μ)² = n² − 2μn + μ²` with `μ = r/(1−r)`. No new analysis or summability argument is performed.

## Verification

- **140 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries.**
- `#print axioms` for all five headline results = `{propext, Classical.choice, Quot.sound}` (no `sorryAx`, no `Lean.ofReduceBool`).
- Builds against the parent `Proofs.GeometricSeriesOQ07` and Mathlib (host `lake env lean`; Docker unavailable this cycle).

## Files
- `proofs/Proofs/GeometricSeriesOQ07OQ02.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/geometric-series-oq-07-oq-02/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)