### PR TITLE
research(gamma-reflection-formula-oq-01-oq-01-oq-01): general symmetric Beta value B(s,1−s)=π/sin(πs) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2919,6 +2919,7 @@ import Proofs.GCDAlgorithmOQ01OQ03OQ01OQ01
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01
+import Proofs.GammaReflectionFormulaOQ01OQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GammaReflectionFormulaOQ01OQ03OQ01
 import Proofs.GaussLemmaPrimitiveOQ01

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ01OQ01.lean
@@ -1,0 +1,95 @@
+/-
+# Gamma Reflection OQ-01-OQ-01-OQ-01: The general symmetric Beta value `B(s, 1-s) = π/sin(πs)`
+
+**Open Question (parent `GammaReflectionFormulaOQ01OQ01`, openQuestions[0]).** The parent
+entry evaluates the single symmetric Beta value `B(1/2, 1/2) = π`. This file proves the
+**general** symmetric reflection identity
+
+> `B(s, 1-s) = π / sin(π s)`   (for `0 < Re s < 1`),
+
+by combining the **Beta–Gamma relation** `Γ(s)·Γ(t) = Γ(s+t)·B(s,t)` with **Euler's
+reflection formula** `Γ(s)·Γ(1-s) = π / sin(π s)`. At `s + (1-s) = 1` the denominator
+collapses to `Γ(1) = 1`, so the Beta integral equals the reflection constant directly.
+
+The parent's special value `B(1/2, 1/2) = π` is recovered as the case `s = 1/2`
+(`sin(π/2) = 1`), and a second concrete value `Γ(1/3)·Γ(2/3) = 2π/√3`
+(`sin(π/3) = √3/2`) illustrates that the formula genuinely depends on `s`.
+
+## What is new
+
+Mathlib has the Beta integral `Complex.betaIntegral`, the Beta–Gamma identity
+`Complex.Gamma_mul_Gamma_eq_betaIntegral`, and Euler's reflection formula
+`Complex.Gamma_mul_Gamma_one_sub` / `Real.Gamma_mul_Gamma_one_sub`, but it does **not**
+evaluate the symmetric Beta integral `B(s, 1-s)` in closed form. That closed form is
+derived here as a single clean reflection statement, with the parent's `π` recovered as
+one specialization and `2π/√3` as another.
+
+## Method
+
+`Complex.Gamma_mul_Gamma_eq_betaIntegral` gives `Γ(s)·Γ(1-s) = Γ(1)·B(s, 1-s)`. With
+`Γ(1) = 1` the right side is just `B(s, 1-s)`; with the reflection formula the left side
+is `π / sin(π s)`. Equate. The real-Gamma ratio form and the concrete values follow by
+specialization and the standard sine values `sin(π/2)`, `sin(π/3)`.
+
+## References
+
+* Mathlib: `Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean`
+  (`Gamma_mul_Gamma_eq_betaIntegral`, `Gamma_mul_Gamma_one_sub`).
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.14 (the Beta function and the
+  reflection formula).
+-/
+import Mathlib
+
+namespace GammaReflectionFormulaOQ01OQ01OQ01
+
+open scoped Real
+
+/-! ## The general symmetric Beta value -/
+
+/-- **The symmetric Beta value `B(s, 1-s) = π / sin(π s)`** for `0 < Re s < 1`.
+
+From the Beta–Gamma relation `Γ(s)·Γ(1-s) = Γ(s + (1-s))·B(s, 1-s)`, the argument
+`s + (1-s) = 1` gives `Γ(1) = 1`, so the right side is `B(s, 1-s)`. Euler's reflection
+formula rewrites the left side as `π / sin(π s)`. -/
+theorem betaIntegral_one_sub_eq {s : ℂ} (hs0 : 0 < s.re) (hs1 : s.re < 1) :
+    Complex.betaIntegral s (1 - s) = (π : ℂ) / Complex.sin (π * s) := by
+  have ht : 0 < (1 - s).re := by
+    rw [Complex.sub_re, Complex.one_re]; linarith
+  have h := Complex.Gamma_mul_Gamma_eq_betaIntegral hs0 ht
+  rw [show s + (1 - s) = 1 by ring, Complex.Gamma_one, one_mul] at h
+  rw [Complex.Gamma_mul_Gamma_one_sub] at h
+  exact h.symm
+
+/-- **Recovering the parent value `B(1/2, 1/2) = π`** from the general formula at
+`s = 1/2`, where `sin(π · (1/2)) = sin(π/2) = 1`. -/
+theorem betaIntegral_half_half :
+    Complex.betaIntegral (1 / 2) (1 / 2) = (π : ℂ) := by
+  have h := betaIntegral_one_sub_eq (s := (1 / 2 : ℂ)) (by norm_num) (by norm_num)
+  rw [show (1 - 1 / 2 : ℂ) = 1 / 2 by norm_num] at h
+  rw [h, show ((π : ℂ) * (1 / 2)) = ((π / 2 : ℝ) : ℂ) by push_cast; ring,
+    ← Complex.ofReal_sin, Real.sin_pi_div_two]
+  norm_num
+
+/-! ## Real-Gamma ratio form and a second concrete value -/
+
+/-- **The Beta–Gamma reflection identity over the real Gamma function:**
+`Γ(s)·Γ(1-s) / Γ(1) = π / sin(π s)`. This is the textbook ratio form `B(s,1-s) =
+Γ(s)Γ(1-s)/Γ(1)`, evaluated by Euler's reflection formula. -/
+theorem beta_gamma_ratio_reflection (s : ℝ) :
+    Real.Gamma s * Real.Gamma (1 - s) / Real.Gamma 1 = π / Real.sin (π * s) := by
+  rw [Real.Gamma_one, div_one, Real.Gamma_mul_Gamma_one_sub]
+
+/-- **A second concrete symmetric value:** `Γ(1/3)·Γ(2/3) = 2π/√3`.
+
+Euler's reflection formula at `s = 1/3` gives `π / sin(π/3)`, and `sin(π/3) = √3/2`,
+so the value is `π / (√3/2) = 2π/√3`. Unlike the symmetric midpoint `s = 1/2`, here the
+sine denominator is genuinely nontrivial. -/
+theorem gamma_one_third_mul_two_thirds :
+    Real.Gamma (1 / 3) * Real.Gamma (2 / 3) = 2 * π / Real.sqrt 3 := by
+  have h := Real.Gamma_mul_Gamma_one_sub (1 / 3)
+  rw [show (1 - 1 / 3 : ℝ) = 2 / 3 by norm_num] at h
+  rw [h, show ((π : ℝ) * (1 / 3)) = π / 3 by ring, Real.sin_pi_div_three,
+    div_div_eq_mul_div]
+  ring
+
+end GammaReflectionFormulaOQ01OQ01OQ01

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-gamma-refl-oq010101-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 40
+    },
+    "type": "context",
+    "title": "From One Beta Value to the Whole Family",
+    "content": "The docstring answers the parent's open question: generalize the single symmetric Beta value B(1/2,1/2) = π to the full family B(s,1−s) = π/sin(πs). The method puts together Euler's two Gamma identities. The Beta–Gamma relation B(x,y) = Γ(x)Γ(y)/Γ(x+y), applied on the diagonal y = 1−x, has argument sum x + (1−x) = 1, so the normalising factor Γ(1) = 1 vanishes and B(s,1−s) = Γ(s)Γ(1−s). Euler's reflection formula then evaluates Γ(s)Γ(1−s) = π/sin(πs). Mathlib has both inputs but not the symmetric Beta value they produce.",
+    "mathContext": "$B(s,1-s) = \\Gamma(s)\\Gamma(1-s)/\\Gamma(1) = \\pi/\\sin(\\pi s)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Beta function",
+      "Gamma function",
+      "Euler reflection formula",
+      "Beta–Gamma relation",
+      "special functions"
+    ],
+    "prerequisites": [
+      "the Gamma and Beta functions",
+      "Euler's Beta–Gamma relation",
+      "Euler's reflection formula"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq010101-general",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 72
+    },
+    "type": "key-step",
+    "title": "B(s,1−s) = π/sin(πs) and the Recovered Midpoint",
+    "content": "betaIntegral_one_sub_eq instantiates the Beta–Gamma relation Γ(s)·Γ(t) = Γ(s+t)·B(s,t) at t = 1−s. The hypotheses 0 < Re s and Re s < 1 give 0 < Re(1−s); the argument sum s + (1−s) = 1 makes Γ(s+t) = Γ(1) = 1, so the relation reads Γ(s)·Γ(1−s) = B(s,1−s). Rewriting the left side by Euler's reflection formula Complex.Gamma_mul_Gamma_one_sub yields B(s,1−s) = π/sin(πs). betaIntegral_half_half then specializes s = 1/2: π·(1/2) = π/2 (recast through Complex.ofReal_sin), sin(π/2) = 1, so B(1/2,1/2) = π/1 = π — exactly the parent's value.",
+    "mathContext": "$\\Gamma(s)\\Gamma(1-s) = \\Gamma(1)B(s,1-s)$, $\\Gamma(1)=1$, $\\Gamma(s)\\Gamma(1-s)=\\pi/\\sin(\\pi s)$; at $s=1/2$, $\\sin(\\pi/2)=1$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Beta–Gamma relation",
+      "Euler reflection formula",
+      "complex Beta integral",
+      "special values"
+    ],
+    "prerequisites": [
+      "Complex.Gamma_mul_Gamma_eq_betaIntegral",
+      "Complex.Gamma_mul_Gamma_one_sub",
+      "sin(π/2) = 1"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq010101-ratio-concrete",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 95
+    },
+    "type": "key-step",
+    "title": "Real Ratio Form and Γ(1/3)·Γ(2/3) = 2π/√3",
+    "content": "beta_gamma_ratio_reflection states the identity in the textbook ratio form B(s,1−s) = Γ(s)Γ(1−s)/Γ(1) = π/sin(πs) over the real Gamma function, immediate from Real.Gamma_one and the real reflection formula Real.Gamma_mul_Gamma_one_sub. gamma_one_third_mul_two_thirds evaluates the family away from the symmetric midpoint: at s = 1/3 the reflection formula gives π/sin(π/3), and sin(π/3) = √3/2, so Γ(1/3)·Γ(2/3) = π/(√3/2) = 2π/√3. This non-trivial sine denominator shows the family genuinely depends on s.",
+    "mathContext": "$B(s,1-s)=\\Gamma(s)\\Gamma(1-s)/\\Gamma(1)=\\pi/\\sin(\\pi s)$; $\\Gamma(1/3)\\Gamma(2/3)=\\pi/(\\sqrt3/2)=2\\pi/\\sqrt3$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Euler reflection formula",
+      "real Gamma function",
+      "special values",
+      "sin(π/3)"
+    ],
+    "prerequisites": [
+      "Real.Gamma_mul_Gamma_one_sub",
+      "sin(π/3) = √3/2"
+    ]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+  "slug": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped Real"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ01OQ01",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The General Symmetric Beta Value B(s,1−s) = π/sin(πs)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "beta-function",
+      "reflection-formula",
+      "euler-reflection",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 95,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "betaIntegral_one_sub_eq: the general symmetric Beta value B(s,1−s) = π/sin(πs) for 0 < Re s < 1, obtained by feeding t = 1−s into Mathlib's Beta–Gamma relation Γ(s)·Γ(t) = Γ(s+t)·B(s,t) — so the right Gamma factor collapses to Γ(1) = 1 — and rewriting the left side Γ(s)·Γ(1−s) by Euler's reflection formula. Mathlib evaluates neither the Beta integral B(s,1−s) nor its closed form.",
+      "betaIntegral_half_half: the parent's special value B(1/2,1/2) = π recovered as the case s = 1/2 of the general formula, where sin(π·(1/2)) = sin(π/2) = 1.",
+      "beta_gamma_ratio_reflection: the textbook ratio form B(s,1−s) = Γ(s)Γ(1−s)/Γ(1) = π/sin(πs) over the real Gamma function, packaging the reflection identity in the form most used in computations.",
+      "gamma_one_third_mul_two_thirds: the concrete second value Γ(1/3)·Γ(2/3) = 2π/√3, evaluating the reflection formula at s = 1/3 with sin(π/3) = √3/2 — a genuinely non-trivial sine denominator, in contrast to the symmetric midpoint s = 1/2."
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma / Complex.Gamma and Mathlib's Beta integral Complex.betaIntegral",
+      "the Beta–Gamma relation Complex.Gamma_mul_Gamma_eq_betaIntegral",
+      "Euler's reflection formula Complex.Gamma_mul_Gamma_one_sub / Real.Gamma_mul_Gamma_one_sub",
+      "the standard sine values sin(π/2) = 1 and sin(π/3) = √3/2"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.Gamma_mul_Gamma_eq_betaIntegral",
+        "description": "Γ(s)·Γ(t) = Γ(s+t)·B(s,t) for s,t of positive real part — Euler's Beta–Gamma integral relation, here with t = 1−s so that Γ(s+t) = Γ(1) = 1.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_mul_Gamma_one_sub",
+        "description": "Euler's reflection formula Γ(z)·Γ(1−z) = π/sin(πz) over ℂ, supplying the closed form of the left-hand Gamma product.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.Gamma_mul_Gamma_one_sub",
+        "description": "The real version Γ(s)·Γ(1−s) = π/sin(πs), used for the real ratio form and the concrete value Γ(1/3)·Γ(2/3).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.sin_pi_div_two",
+        "description": "sin(π/2) = 1, collapsing the reflection denominator at s = 1/2 to recover B(1/2,1/2) = π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_pi_div_three",
+        "description": "sin(π/3) = √3/2, giving the second concrete value Γ(1/3)·Γ(2/3) = π/(√3/2) = 2π/√3.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent evaluates the single symmetric Beta value B(1/2,1/2) = π; this entry proves the general formula B(s,1−s) = π/sin(πs) and recovers B(1/2,1/2) = π as the case s = 1/2."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "uses",
+      "description": "Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs), established in the grandparent entry, is the engine that supplies the sine denominator in the general Beta value."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral, the Beta–Gamma relation Gamma_mul_Gamma_eq_betaIntegral, and Euler's reflection formula Gamma_mul_Gamma_one_sub."
+    },
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "Classical reference for the Beta function, the relation B(x,y) = Γ(x)Γ(y)/Γ(x+y), and Euler's reflection formula (§12.14)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Euler joined the Beta and Gamma functions through the integral identity B(x,y) = Γ(x)Γ(y)/Γ(x+y), and separately discovered the reflection formula Γ(s)Γ(1−s) = π/sin(πs). Combining the two on the diagonal y = 1−x produces the symmetric Beta value B(s,1−s) = π/sin(πs): the argument sum x + (1−x) = 1 makes the denominator Γ(1) = 1 disappear, so the Beta integral is exactly the reflection constant. The parent entry computed only the midpoint B(1/2,1/2) = π; this entry supplies the whole one-parameter family, of which the midpoint (sin(π/2) = 1) and the value at s = 1/3 (sin(π/3) = √3/2, giving 2π/√3) are representative points. Mathlib formalises both the Beta–Gamma relation and the reflection formula but does not record the symmetric Beta value that results from putting them together.",
+    "problemStatement": "Prove the general symmetric Beta value B(s,1−s) = π/sin(πs) for 0 < Re s < 1 by combining the Beta–Gamma relation with Euler's reflection formula, recover the parent's B(1/2,1/2) = π as the case s = 1/2, and exhibit a second concrete value Γ(1/3)·Γ(2/3) = 2π/√3.",
+    "proofStrategy": "Instantiate the Beta–Gamma relation Γ(s)·Γ(t) = Γ(s+t)·B(s,t) at t = 1−s: since s + (1−s) = 1 and Γ(1) = 1, the right side reduces to B(s,1−s). Euler's reflection formula rewrites the left side Γ(s)·Γ(1−s) as π/sin(πs), giving the closed form directly (one positivity hypothesis 0 < Re s and its mirror 0 < Re(1−s), i.e. Re s < 1). Specializing s = 1/2 and evaluating sin(π/2) = 1 recovers B(1/2,1/2) = π; the real ratio form follows from Real.Gamma_one and the real reflection formula; and s = 1/3 with sin(π/3) = √3/2 yields Γ(1/3)·Γ(2/3) = 2π/√3.",
+    "keyInsights": [
+      "The symmetric Beta value is the cleanest meeting point of Euler's two great Gamma identities: the Beta–Gamma relation contributes the Γ(1) = 1 collapse, and the reflection formula contributes the π/sin(πs).",
+      "The diagonal y = 1−x is special precisely because it forces the argument sum to 1, the unique point where the Gamma normalising factor in the Beta–Gamma relation vanishes — so no Gamma value other than Γ(1) is needed.",
+      "The midpoint s = 1/2 is the degenerate case where the sine denominator is 1; the family is genuinely s-dependent, as the value Γ(1/3)·Γ(2/3) = 2π/√3 shows.",
+      "The badge is original: Mathlib supplies both input identities but neither the symmetric Beta value B(s,1−s) = π/sin(πs) nor its concrete specializations."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Combining the Beta–Gamma Relation and Reflection",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "States the open question — the general symmetric Beta value B(s,1−s) = π/sin(πs) — and the method: feed t = 1−s into the Beta–Gamma relation so the right Gamma factor is Γ(1) = 1, then rewrite the left Gamma product by Euler's reflection formula. Names the Mathlib inputs and the recovered/concrete special values.",
+      "mathContext": "$B(s,1-s) = \\Gamma(s)\\Gamma(1-s)/\\Gamma(1) = \\pi/\\sin(\\pi s)$."
+    },
+    {
+      "id": "general-value",
+      "title": "The General Symmetric Beta Value",
+      "startLine": 47,
+      "endLine": 72,
+      "summary": "betaIntegral_one_sub_eq proves B(s,1−s) = π/sin(πs) for 0 < Re s < 1 from the Beta–Gamma relation (with Γ(1) = 1) and Euler's reflection formula. betaIntegral_half_half specializes to s = 1/2, where sin(π/2) = 1, recovering the parent's B(1/2,1/2) = π.",
+      "mathContext": "$\\Gamma(s)\\Gamma(1-s) = \\Gamma(1)\\,B(s,1-s)$ with $\\Gamma(1)=1$ and $\\Gamma(s)\\Gamma(1-s)=\\pi/\\sin(\\pi s)$."
+    },
+    {
+      "id": "ratio-and-concrete",
+      "title": "Real Ratio Form and a Second Concrete Value",
+      "startLine": 73,
+      "endLine": 95,
+      "summary": "beta_gamma_ratio_reflection records the textbook ratio form B(s,1−s) = Γ(s)Γ(1−s)/Γ(1) = π/sin(πs) over ℝ. gamma_one_third_mul_two_thirds evaluates the family at s = 1/3, giving Γ(1/3)·Γ(2/3) = π/(√3/2) = 2π/√3.",
+      "mathContext": "$\\Gamma(1/3)\\Gamma(2/3) = \\pi/\\sin(\\pi/3) = \\pi/(\\sqrt3/2) = 2\\pi/\\sqrt3$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The general symmetric Beta value B(s,1−s) = π/sin(πs) (for 0 < Re s < 1) is derived by combining Mathlib's Beta–Gamma relation Γ(s)Γ(t) = Γ(s+t)B(s,t) at t = 1−s (where Γ(s+t) = Γ(1) = 1) with Euler's reflection formula Γ(s)Γ(1−s) = π/sin(πs). The parent's B(1/2,1/2) = π is recovered as the case s = 1/2 (sin(π/2) = 1), the real ratio form is recorded, and a second concrete value Γ(1/3)·Γ(2/3) = 2π/√3 (sin(π/3) = √3/2) exhibits the s-dependence. 95 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Both input identities — the Beta–Gamma relation and the reflection formula — are Mathlib's, but the symmetric Beta value B(s,1−s) = π/sin(πs) that results from putting them together, together with its specializations, is new; hence the original badge. The entry generalizes the parent's single midpoint value to the full one-parameter family.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent `gamma-reflection-formula-oq-01-oq-01` (which evaluated only the midpoint **B(1/2,1/2) = π**) by proving the **general symmetric Beta value**

> **B(s, 1−s) = π / sin(π s)**   for 0 < Re s < 1.

The proof is the clean meeting point of Euler's two Gamma identities. Mathlib's Beta–Gamma relation `Γ(s)·Γ(t) = Γ(s+t)·B(s,t)`, applied with `t = 1−s`, has argument sum `s + (1−s) = 1`, so the normalising factor `Γ(1) = 1` disappears and `B(s,1−s) = Γ(s)·Γ(1−s)`. Euler's reflection formula then evaluates `Γ(s)·Γ(1−s) = π/sin(π s)`.

## Theorems (4, all verified, 0 axioms, 0 sorries)

- `betaIntegral_one_sub_eq` — the main result: `B(s,1−s) = π/sin(πs)` for 0 < Re s < 1.
- `betaIntegral_half_half` — recovers the parent's `B(1/2,1/2) = π` as the case s = 1/2 (sin(π/2) = 1).
- `beta_gamma_ratio_reflection` — textbook real ratio form `Γ(s)Γ(1−s)/Γ(1) = π/sin(πs)`.
- `gamma_one_third_mul_two_thirds` — concrete second value `Γ(1/3)·Γ(2/3) = 2π/√3` (sin(π/3) = √3/2), a genuinely non-trivial denominator unlike the midpoint.

## What is new

Mathlib supplies both inputs — the Beta–Gamma relation (`Complex.Gamma_mul_Gamma_eq_betaIntegral`) and Euler's reflection formula (`Complex/Real.Gamma_mul_Gamma_one_sub`) — but does **not** evaluate the symmetric Beta integral `B(s,1−s)`. The closed form and its specializations are the original contribution. Badge: `original`.

## Verification

- Built with host `lake env lean` (docker unavailable): exit 0, no errors/warnings.
- `#print axioms` on all four theorems: only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)