### PR TITLE
audit: batch-clear 10 unaudited gallery proofs (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21711,6 +21711,66 @@
       "lastAudited": "2026-06-24T15:30:37Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-07-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-09-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-13-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "compactness-finite-subcover-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-06-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:42:18Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 10 tracked gallery proofs against their Lean sources. **All clean.**

Checks per proof: sorry count vs meta (comments stripped), `axiom` declarations, `native_decide`, `admit`, True-stub scan, build-graph registration in `Proofs.lean`, badge appropriateness vs Mathlib reliance, and conclusion/contribution text scanned for overclaiming phrases ("first formalization", "independent proof", etc. — none found).

| Proof | Badge | Verdict |
|-------|-------|---------|
| area-of-circle-oq-07-oq-02-oq-02 | verified | clean — half-line Gaussian moments; FTC engine + parent zeroth moment disclosed |
| area-of-circle-oq-07-oq-05-oq-01 | mathlib | clean — even Gaussian moments / double-factorial recursion |
| basel-problem-oq-09-oq-01 | mathlib | clean — exponent-uniform odd-subseries lemma, λ(4) |
| basel-problem-oq-13-oq-01 | original | clean — η(4)=7π⁴/720, credits parent λ(4) + Mathlib zeta |
| cantor-diagonalization-oq-04-oq-01-oq-01-oq-01 | original | clean — Lawvere FPT instantiated in Type/presheaf |
| compactness-finite-subcover-oq-01-oq-02-oq-02 | mathlib | clean — cluster-point form via FIP dual |
| geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02 | original | clean — Eulerian palindromy (lone "sorry" grep hit is a docstring) |
| pythagorean-triples-oq-06-oq-01-oq-01 | original | clean — 60∣xyz divisibility, no primitivity hypothesis |
| urysohns-lemma-oq-01-oq-01-oq-01-oq-01 | original | clean — norm-preserving Tietze, builds on parent series |
| urysohns-lemma-oq-01-oq-01-oq-02-oq-01 | original | clean — interval + vector Tietze by reduction to parent |

All claim verified/0-sorry/0-axiom; every claim verified against source. Mathlib-badged entries are conservatively scoped; original-badged entries are genuine bridge/instantiation/derivation work with parent + Mathlib reliance openly disclosed.

Coverage 3496/3507 → 3506/3507. (Remaining 1 unaudited — fibonacci-identities-oq-05-oq-01 — is an untracked working-tree file not present on origin/main, not a real gallery entry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)