### PR TITLE
audit: batch-clear 10 unaudited research leaves (all clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21711,6 +21711,66 @@
       "lastAudited": "2026-06-24T15:30:37Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-07-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-07-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-09-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-13-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "compactness-finite-subcover-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-06-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:35Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "urysohns-lemma-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T15:49:36Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — Batch

Audited the 10 remaining never-audited verified leaves. **All integrity-clean.** Coverage → **3506/3506**.

| Slug | status/badge | Verdict |
|------|--------------|---------|
| area-of-circle-oq-07-oq-02-oq-02 | verified/verified | clean |
| area-of-circle-oq-07-oq-05-oq-01 | verified/mathlib | clean |
| basel-problem-oq-09-oq-01 | verified/mathlib | clean |
| basel-problem-oq-13-oq-01 | verified/original | clean |
| cantor-diagonalization-oq-04-oq-01-oq-01-oq-01 | verified/original | clean |
| compactness-finite-subcover-oq-01-oq-02-oq-02 | verified/mathlib | clean |
| geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02 | verified/original | clean |
| pythagorean-triples-oq-06-oq-01-oq-01 | verified/original | clean |
| urysohns-lemma-oq-01-oq-01-oq-01-oq-01 | verified/original | clean |
| urysohns-lemma-oq-01-oq-01-oq-02-oq-01 | verified/original | clean |

### Checks performed
- **meta vs source**: every meta.json `status=verified`, `sorries=0`, `axiomCount=0` matches the Lean file.
- **sorry scan**: 3 files (cantor, geometric-series, urysohns-…-oq-02-oq-01) grep-hit `sorry`, all **docstring false-positives** ("machine-checked with no `sorry`"). 0 real sorries.
- **axiom/True-stub/native_decide**: none present in any file.
- **badge fidelity**: `mathlib` badges (area-05, basel-09, compactness) correctly reflect Mathlib-core reliance; `original` badges are genuine multi-step derivations (verified by inspecting theorem signatures), with `mathlibDependencies` openly credited → no delegation opacity.

Only `src/data/proofs/audit-tracker.json` changed.

---
Discovered/performed during gallery integrity audit.