### PR TITLE
Enrich Pythagorean triples 60 ∣ xyz (oq-06-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pyth60-overview",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 36 },
+    "type": "context",
+    "title": "The 60 ∣ xyz Divisibility Package",
+    "content": "The module docstring states the headline result — 60 ∣ x·y·z for every integer Pythagorean triple x²+y²=z², with no primitivity hypothesis — and explains the method. The constant 60 = 2²·3·5 factors into three independent prime-power obstructions, each a finite congruence condition: modulo 3 the squares are {0,1}, modulo 5 they are {0,1,4}, and in both rings every solution of a²+b²=c² forces the product a·b·c to vanish. The factor 4 is the subtle one: it is invisible modulo 4 (the residues (1,2,1) form a solution with product 2), so the check must be lifted to ZMod 8. This answers the parent entry's recorded open question, upgrading its parity catalogue to the full divisibility package. Mathlib has Euclid's m²−n²/2mn/m²+n² classification but no such package.",
+    "mathContext": "$60 = 2^2\\cdot 3\\cdot 5$; for all $(x,y,z)\\in\\mathbb{Z}^3$ with $x^2+y^2=z^2$, $\\ 60 \\mid xyz$.",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triples", "divisibility", "quadratic residues", "Euclid's parametrization"],
+    "prerequisites": ["integer solutions of x²+y²=z²", "modular arithmetic"]
+  },
+  {
+    "id": "ann-pyth60-zmod-transport",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 40, "endLine": 53 },
+    "type": "technique",
+    "title": "Transporting the Relation and the Reusable Obstruction Lemma",
+    "content": "Two infrastructure lemmas. `zmod_rel` casts the integer relation x²+y²=z² into ZMod n through the canonical ring homomorphism, which commutes with addition and squaring (exact_mod_cast on congrArg). `dvd_prod_of_zmod` then packages the central pattern: if over ZMod n *every* solution of a²+b²=c² has a·b·c = 0, then n ∣ x·y·z. The proof pushes the cast through the product, applies the ZMod hypothesis to the reduced triple, and concludes via ZMod.intCast_zmod_eq_zero_iff_dvd (an integer's cast vanishes in ZMod n iff n divides it). This converts a universally-quantified congruence — a finite, decidable statement — into an integer divisibility, and is reused verbatim for n = 3 and n = 5.",
+    "mathContext": "$\\big(\\forall a,b,c\\in\\mathbb{Z}/n,\\ a^2+b^2=c^2 \\to abc=0\\big)\\Rightarrow n\\mid xyz$, via $\\overline{xyz}=0 \\iff n\\mid xyz$.",
+    "significance": "key",
+    "relatedConcepts": ["ring homomorphism", "reduction mod n", "ZMod.intCast_zmod_eq_zero_iff_dvd", "decidability"],
+    "prerequisites": ["ZMod ring structure", "integer casts into finite rings"]
+  },
+  {
+    "id": "ann-pyth60-obstructions-3-5",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 63 },
+    "type": "concept",
+    "title": "The Direct Obstructions: 3 and 5",
+    "content": "`three_dvd_prod` and `five_dvd_prod` are one-line corollaries of dvd_prod_of_zmod whose congruence hypotheses are discharged by `decide` — an exhaustive kernel check over the 27 triples in (ZMod 3)³ and the 125 in (ZMod 5)³. Mathematically: since the quadratic residues mod 3 are {0,1}, the only way a²+b²=c² can hold is if at least one of a,b,c is ≡ 0, so 3 divides one of the three sides; mod 5 the residues are {0,1,4} and the same exhaustive verification forces 5 to divide one side. Because the obstruction is checked over all residues, it needs no primitivity hypothesis. Using `decide` (kernel reduction, not native_decide) keeps the proof 0-axiom — it does not invoke Lean.ofReduceBool.",
+    "mathContext": "Squares mod 3: $\\{0,1\\}$; mod 5: $\\{0,1,4\\}$. In each, $a^2+b^2=c^2 \\Rightarrow 3\\mid abc$ (resp. $5\\mid abc$).",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residues", "exhaustive verification", "decide tactic", "second moment of residues"],
+    "prerequisites": ["squares modulo a prime", "Decidable instances on ZMod"]
+  },
+  {
+    "id": "ann-pyth60-factor-4",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "insight",
+    "title": "The Factor 4: Why ZMod 8 Is Needed",
+    "content": "The most interesting step. The divisibility 4 ∣ xyz is *false* at the level of ZMod 4: the residues (1,2,1) satisfy 1+0=1 with product 2 ≠ 0, so no ZMod 4 check could prove it. The obstruction only becomes visible one level up, modulo 8, where 1+4=5 is not a square and the offending residues are excluded. The lemma runs `decide` over (ZMod 8)³, certifying that for every solution there the image of a·b·c under the canonical ring map ZMod 8 → ZMod 4 (ZMod.castHom, valid since 4 ∣ 8) is 0. Transporting via map_intCast and ZMod.intCast_zmod_eq_zero_iff_dvd yields 4 ∣ xyz. The lesson: the correct modulus for a 2-adic obstruction can exceed the divisor it certifies.",
+    "mathContext": "$(1,2,1)$ solves $a^2+b^2=c^2$ in $\\mathbb{Z}/4$ with product $2\\neq 0$; lift to $\\mathbb{Z}/8$ where it is excluded, then map $\\mathbb{Z}/8\\to\\mathbb{Z}/4$.",
+    "significance": "key",
+    "relatedConcepts": ["2-adic obstruction", "lifting the exponent", "ZMod.castHom", "ring map compatibility"],
+    "prerequisites": ["powers of 2 and quadratic residues", "ring homomorphisms ZMod 8 → ZMod 4"]
+  },
+  {
+    "id": "ann-pyth60-assemble",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 78, "endLine": 98 },
+    "type": "technique",
+    "title": "Assembling 60 ∣ xyz by Coprimality",
+    "content": "`sixty_dvd_prod` combines the three components without any single large check. Since 3 and 4 are coprime, IsCoprime.mul_dvd promotes 3 ∣ xyz and 4 ∣ xyz to 12 ∣ xyz; since 12 and 5 are coprime, a second application gives 60 ∣ xyz. The coprimality facts themselves are decided through Int.isCoprime_iff_gcd_eq_one and `decide`. Keeping the obstructions modular (largest check is 8³ = 512 cases) rather than verifying directly modulo 120 is what makes the whole proof cheap. `sixty_dvd_prod_of_pythagoreanTriple` then rephrases the result for Mathlib's bundled PythagoreanTriple structure, unfolding it to x*x+y*y=z*z via PythagoreanTriple.eq.",
+    "mathContext": "$3\\perp 4\\Rightarrow 12\\mid xyz$; $\\ 12\\perp 5\\Rightarrow 60\\mid xyz$, using $\\gcd$-based coprimality.",
+    "significance": "key",
+    "relatedConcepts": ["coprime divisors", "IsCoprime.mul_dvd", "CRT-style assembly", "PythagoreanTriple structure"],
+    "prerequisites": ["coprimality of integers", "IsCoprime.mul_dvd"]
+  },
+  {
+    "id": "ann-pyth60-instances",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 113 },
+    "type": "context",
+    "title": "Concrete Instances",
+    "content": "Four worked examples exercise the general theorem, each discharged by `sixty_dvd_prod (by norm_num)` after norm_num verifies the Pythagorean relation: (3,4,5) with product exactly 60 (the sharp case), (5,12,13) with 780, (8,15,17) with 2040, and (20,21,29) — an instance where 5 divides a leg (20) rather than appearing through a small side. These confirm the package applies uniformly and illustrate that 60 is the exact gcd of all such products (witnessed by xyz = 60 for (3,4,5)).",
+    "mathContext": "$60\\mid 3{\\cdot}4{\\cdot}5=60,\\ 5{\\cdot}12{\\cdot}13=780,\\ 8{\\cdot}15{\\cdot}17=2040,\\ 20{\\cdot}21{\\cdot}29=12180$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "sharpness of 60", "norm_num"],
+    "prerequisites": ["the main theorem sixty_dvd_prod"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq06Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq06Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq06Oq01Oq01Data: ProofData = {
+  proof: pythagoreanTriplesOq06Oq01Oq01Proof,
+  annotations: pythagoreanTriplesOq06Oq01Oq01Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01/meta.json
@@ -3,24 +3,82 @@
   "slug": "pythagorean-triples-oq-06-oq-01-oq-01",
   "title": "The full divisibility package for Pythagorean triples: 60 ∣ xyz",
   "description": "Every Pythagorean triple x² + y² = z² satisfies 60 ∣ x·y·z, with no primitivity hypothesis. The factors 3, 4, 5 of 60 are each forced by a finite congruence obstruction checked by `decide` over ZMod 3, ZMod 8 → ZMod 4, and ZMod 5.",
-  "overview": "The parent entry pythagorean-triples-oq-06-oq-01 records the parity structure of primitive triples — one leg even, the even leg divisible by 4, the hypotenuse odd. This entry answers its open question by assembling the full divisibility package: the product of the three sides of any Pythagorean triple is divisible by 60.\n\nThe key observation is that each prime-power factor of 60 = 4·3·5 is forced by a *finite congruence obstruction*, decidable by exhaustive check over a small residue ring:\n\n• Modulo 3, the squares are {0, 1}; a finite check shows every solution of a² + b² = c² over ZMod 3 already has a·b·c = 0. Hence 3 divides one of the three sides.\n• Modulo 5, the squares are {0, 1, 4}; the same finite check over ZMod 5 gives a·b·c = 0, so 5 divides one side.\n• The factor 4 is invisible modulo 4 (the residues (1, 2, 1) satisfy 1 + 0 = 1 with product 2), so the obstruction is read modulo 8, where 1 + 4 = 5 is not a square and rules those residues out. The finite check is run for the composite ring map ZMod 8 → ZMod 4, certifying that the product reduces to 0 in ZMod 4, i.e. 4 ∣ xyz.\n\nCombining the three divisibilities through the pairwise coprimality of 3, 4, 5 (via IsCoprime.mul_dvd) yields 60 ∣ xyz. The whole argument is 0-axiom and uses only kernel `decide` over small ZMod rings plus elementary coprimality.",
-  "conclusion": "Mathlib has the m²−n², 2mn, m²+n² classification of Pythagorean triples but no divisibility package; this entry supplies the headline 60 ∣ xyz together with its three prime-power components, all without any primitivity hypothesis. The proof exemplifies the 'finite congruence obstruction' technique: a number-theoretic divisibility that holds for all integer solutions of a quadratic relation is reduced to a decidable check over a finite residue ring — including the subtlety that the factor 4 requires lifting from ZMod 4 to ZMod 8.",
+  "overview": {
+    "historicalContext": "That the product of the sides of a Pythagorean triple is always divisible by 60 is a classical observation in elementary number theory, going back to the systematic study of triples descended from Euclid's parametrization (m²−n², 2mn, m²+n²). The constant 60 = 2²·3·5 splits into three independent prime-power obstructions: every triple has a side divisible by 3, a side divisible by 5, and a leg divisible by 4. Mathlib formalizes Euclid's classification (Mathlib.NumberTheory.PythagoreanTriples) but carries no divisibility package; this entry supplies the headline 60 ∣ xyz and its three components. It answers the recorded open question of the parent entry pythagorean-triples-oq-06-oq-01, which had only catalogued the parity structure of primitive triples (one leg even, the even leg divisible by 4, the hypotenuse odd).",
+    "problemStatement": "For every integer Pythagorean triple, i.e. every (x, y, z) ∈ ℤ³ with x² + y² = z² (no primitivity assumption), prove 60 ∣ x·y·z, together with the three prime-power components 3 ∣ xyz, 4 ∣ xyz, and 5 ∣ xyz.",
+    "proofStrategy": "Each prime-power factor of 60 = 4·3·5 is forced by a finite congruence obstruction, decidable by exhaustive check over a small residue ring. (1) A helper `zmod_rel` casts x²+y²=z² into ZMod n. (2) `dvd_prod_of_zmod` packages the pattern 'if over ZMod n every solution of a²+b²=c² has a·b·c = 0, then n ∣ xyz', closing the ZMod hypothesis by `decide`. (3) For n = 3 and n = 5 the squares are {0,1} and {0,1,4}; the finite check (27 and 125 cases) gives 3 ∣ xyz and 5 ∣ xyz directly. (4) The factor 4 is invisible mod 4 — residues (1,2,1) satisfy 1+0=1 with product 2 — so the check is lifted to ZMod 8, where 1+4=5 is not a square, and the product is certified to vanish in ZMod 4 through the ring map ZMod 8 → ZMod 4. (5) Pairwise coprimality of 3, 4, 5 via IsCoprime.mul_dvd assembles 60 ∣ xyz.",
+    "keyInsights": [
+      "**Finite congruence obstruction**: a divisibility that holds for all integer solutions of a quadratic relation is reduced to a `decide` over a finite residue ring — the Diophantine universal statement becomes a closed, terminating computation over ZMod n.",
+      "**The factor 4 needs ZMod 8, not ZMod 4**: 4 ∣ xyz is literally false at the level of ZMod 4 (the residues (1,2,1) form a solution with product 2 ≠ 0). The obstruction only becomes visible one level up, modulo 8, and is then transported back down to ZMod 4 via ZMod.castHom — a clean illustration that the right modulus for a 2-adic obstruction can exceed the divisor itself.",
+      "**Reusable packaging**: `dvd_prod_of_zmod` abstracts the cast-and-decide pattern once, so the 3- and 5-obstructions are one-line corollaries; only the genuinely different 4-case needs bespoke handling.",
+      "**Coprime assembly**: the three obstructions are combined not by a single mega-check but by IsCoprime.mul_dvd, 12 = 3·4 then 60 = 12·5 — keeping each decidable check small (≤ 8³ cases) rather than checking modulo 120 directly.",
+      "**No primitivity hypothesis**: because the argument runs over all residues, it applies to every triple including non-primitive ones (e.g. (6,8,10)); primitivity is needed only to *locate* which side each factor divides, not to prove the product divisibility."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete 0-axiom Lean 4 formalization that 60 ∣ x·y·z for every Pythagorean triple, with the three prime-power components 3 ∣ xyz, 4 ∣ xyz, 5 ∣ xyz proved as finite congruence obstructions over ZMod 3, ZMod 8 → ZMod 4, and ZMod 5, assembled by coprimality. Includes a PythagoreanTriple-structure wrapper and four concrete instances.",
+    "implications": "Supplies the headline divisibility package missing from Mathlib's Pythagorean-triple library, without any primitivity hypothesis. The proof exemplifies the 'finite congruence obstruction' technique — reducing a Diophantine divisibility to a decidable check over a finite ring — including the subtlety that the 2-adic factor 4 must be read off modulo 8. The reusable lemma dvd_prod_of_zmod can certify other congruence obstructions on quadratic relations.",
+    "openQuestions": [
+      "Refine the package structurally for primitive triples: prove that 3 and 5 never divide the hypotenuse z (so the obstruction always falls on a leg), and that the even leg is divisible by 4 — pinning the location of each prime factor rather than only its presence in the product.",
+      "Identify the largest constant C such that C ∣ xyz for every Pythagorean triple, and prove 60 is sharp by exhibiting a triple whose product is divisible by no prime power beyond those in 60 (e.g. (3,4,5) with xyz = 60)."
+    ]
+  },
   "sections": [
     {
+      "id": "header",
+      "title": "Header & Method",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring stating the headline result 60 ∣ xyz for every Pythagorean triple (no primitivity needed) and outlining the method: each prime-power factor of 60 is a finite congruence obstruction checked by `decide` over a ZMod, with the factor 4 requiring a lift to ZMod 8. Imports Mathlib.",
+      "mathContext": "$60 = 2^2 \\cdot 3 \\cdot 5$; obstructions over $\\mathbb{Z}/3$, $\\mathbb{Z}/8 \\to \\mathbb{Z}/4$, $\\mathbb{Z}/5$."
+    },
+    {
+      "id": "zmod-rel",
       "title": "Transporting the relation to ZMod n",
-      "content": "`zmod_rel` casts an integer Pythagorean relation x² + y² = z² into the ring ZMod n via the canonical ring homomorphism, which preserves addition and squaring. This is the bridge from the Diophantine equation to the finite decidable checks."
+      "startLine": 38,
+      "endLine": 43,
+      "summary": "`zmod_rel` casts an integer Pythagorean relation x²+y²=z² into the ring ZMod n via the canonical ring homomorphism, which preserves addition and squaring. This is the bridge from the Diophantine equation to the finite decidable checks.",
+      "mathContext": "$x^2+y^2=z^2 \\text{ in } \\mathbb{Z} \\Rightarrow \\bar x^2+\\bar y^2=\\bar z^2 \\text{ in } \\mathbb{Z}/n$."
     },
     {
+      "id": "dvd-prod-of-zmod",
+      "title": "The reusable obstruction lemma",
+      "startLine": 45,
+      "endLine": 53,
+      "summary": "`dvd_prod_of_zmod` packages the pattern: if over ZMod n every solution of a²+b²=c² has a·b·c = 0, then n ∣ xyz. It pushes the cast through the product and applies ZMod.intCast_zmod_eq_zero_iff_dvd. Reused verbatim for n = 3 and n = 5.",
+      "mathContext": "$\\big(\\forall a,b,c \\in \\mathbb{Z}/n,\\ a^2+b^2=c^2 \\to abc=0\\big) \\Rightarrow n \\mid xyz$."
+    },
+    {
+      "id": "obstructions-3-5",
       "title": "The direct obstructions: 3 and 5",
-      "content": "`dvd_prod_of_zmod` packages the pattern: if over ZMod n every solution of a² + b² = c² has a·b·c = 0, then n ∣ xyz. For n = 3 and n = 5 the hypothesis is closed by `decide` (27 and 125 triples respectively), giving `three_dvd_prod` and `five_dvd_prod`."
+      "startLine": 55,
+      "endLine": 63,
+      "summary": "`three_dvd_prod` and `five_dvd_prod` close the ZMod hypothesis by `decide` (27 and 125 triples respectively), giving 3 ∣ xyz and 5 ∣ xyz. The squares mod 3 are {0,1} and mod 5 are {0,1,4}; in both rings every solution of a²+b²=c² forces a·b·c = 0.",
+      "mathContext": "Squares mod 3: $\\{0,1\\}$; mod 5: $\\{0,1,4\\}$. Both force $abc \\equiv 0$."
     },
     {
+      "id": "obstruction-4",
       "title": "The factor 4 via ZMod 8",
-      "content": "`four_dvd_prod` handles the subtle factor. Because 4 ∣ xyz is false at the level of ZMod 4, the check is performed over ZMod 8, where a² + b² = c² excludes the offending residues, and the product is certified to vanish in ZMod 4 through the ring map ZMod 8 → ZMod 4 (ZMod.castHom). The conclusion 4 ∣ xyz follows from ZMod.intCast_zmod_eq_zero_iff_dvd."
+      "startLine": 65,
+      "endLine": 76,
+      "summary": "`four_dvd_prod` handles the subtle factor. Because 4 ∣ xyz is false at the level of ZMod 4, the check runs over ZMod 8, where a²+b²=c² excludes the offending residues, and the product is certified to vanish in ZMod 4 through the ring map ZMod 8 → ZMod 4 (ZMod.castHom). The conclusion follows from ZMod.intCast_zmod_eq_zero_iff_dvd.",
+      "mathContext": "$(1,2,1)$ solves $a^2+b^2=c^2$ in $\\mathbb{Z}/4$ with product $2$; lift to $\\mathbb{Z}/8$, where $1+4=5$ is not a square."
     },
     {
+      "id": "assemble-60",
       "title": "Assembling 60 ∣ xyz",
-      "content": "`sixty_dvd_prod` combines the three components: 3 and 4 are coprime so 12 ∣ xyz, and 12 and 5 are coprime so 60 ∣ xyz (IsCoprime.mul_dvd). A `PythagoreanTriple`-structure wrapper and four concrete instances — (3,4,5), (5,12,13), (8,15,17), (20,21,29) — round out the file."
+      "startLine": 78,
+      "endLine": 98,
+      "summary": "`sixty_dvd_prod` combines the three components: 3 and 4 are coprime so 12 ∣ xyz, and 12 and 5 are coprime so 60 ∣ xyz (IsCoprime.mul_dvd). `sixty_dvd_prod_of_pythagoreanTriple` rephrases the package through Mathlib's PythagoreanTriple structure via PythagoreanTriple.eq.",
+      "mathContext": "$3 \\perp 4 \\Rightarrow 12 \\mid xyz$; $\\ 12 \\perp 5 \\Rightarrow 60 \\mid xyz$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete instances",
+      "startLine": 100,
+      "endLine": 115,
+      "summary": "Four worked instances exercise the general theorem: (3,4,5) with xyz = 60, (5,12,13) with 780, (8,15,17) with 2040, and (20,21,29) — each discharged by `sixty_dvd_prod (by norm_num)`.",
+      "mathContext": "$60 \\mid 3{\\cdot}4{\\cdot}5,\\ 5{\\cdot}12{\\cdot}13,\\ 8{\\cdot}15{\\cdot}17,\\ 20{\\cdot}21{\\cdot}29$."
     }
   ],
   "references": [
@@ -34,7 +92,11 @@
     }
   ],
   "crossReferences": [
-    "pythagorean-triples-oq-06-oq-01"
+    {
+      "targetId": "pythagorean-triples-oq-06-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: records the parity structure of primitive triples (one leg even, the even leg divisible by 4, the hypotenuse odd). This entry answers its recorded open question by proving the full divisibility package 60 ∣ xyz for every triple."
+    }
   ],
   "openQuestions": [
     {


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-06-oq-01-oq-01` (quality 8, 0 prior passes).

The entry had rich research content but was stored in the raw researcher schema — it was **missing `index.ts`** (so the proof page showed "proof not found" on the live site), had **no `annotations.json`**, and its `overview`/`conclusion`/`sections`/`crossReferences` were not in the canonical rendered shape.

## Changes
- **Added `index.ts`** (the required Vite entry point) so the proof loads on the site.
- **Added `annotations.json`**: 6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. They walk through the ZMod transport + reusable obstruction lemma, the direct 3/5 obstructions, the subtle factor-4 lift to ZMod 8, the coprime assembly, and the concrete instances.
- **Normalized `meta.json`** to the canonical schema rendered by the gallery:
  - `overview` string → object (`historicalContext`, `problemStatement`, `proofStrategy`, 5 `keyInsights`).
  - `conclusion` string → object (`summary`, `implications`, 2 `openQuestions`).
  - `sections` given `id`/`startLine`/`endLine`/`summary`/`mathContext` (7 sections covering all 115 lines).
  - `crossReferences` string array → `CrossReference` objects.
  - Preserved the structured research `openQuestions` leaves and all original prose.

## Verification
- JSON validates; `pnpm annotations:validate` reports **0 errors** for this entry (all 6 annotations anchor to real Lean constructs).
- Content faithful to `PythagoreanTriplesOQ06OQ01OQ01.lean`: 11 theorems, 0 axioms, 0 sorries — `status: verified`, `badge: original` confirmed. The `decide` checks use kernel reduction (not `native_decide`), so the 0-axiom claim is honest (no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)