### PR TITLE
research(fibonacci-identities-oq-01-oq-03): Cassini via the Fibonacci Q-matrix det(Qⁿ)=(−1)ⁿ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2825,6 +2825,7 @@ import Proofs.FibonacciIdentities
 import Proofs.FibonacciIdentitiesOQ01
 import Proofs.FibonacciIdentitiesOQ01OQ02
 import Proofs.FibonacciIdentitiesOQ01OQ02OQ01
+import Proofs.FibonacciIdentitiesOQ01OQ03
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ02OQ01
 import Proofs.FibonacciIdentitiesOQ03

--- a/proofs/Proofs/FibonacciIdentitiesOQ01OQ03.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01OQ03.lean
@@ -1,0 +1,110 @@
+/-
+# Cassini's Identity via the Fibonacci Q-matrix
+
+This file answers the third open question of `fibonacci-identities-oq-01`
+(Cassini's identity): **derive Cassini matrix-theoretically** as
+`det (Q ^ n) = (-1) ^ n`, where `Q = !![1, 1; 1, 0]` is the Fibonacci
+Q-matrix.
+
+The mechanism is the classical observation that powers of `Q` collect
+consecutive Fibonacci numbers,
+
+  `Q ^ (n + 1) = !![F (n+2), F (n+1); F (n+1), F n]`,
+
+proved by a single induction using only the Fibonacci recurrence
+`Nat.fib_add_two` and the explicit two-by-two product `Matrix.mul_fin_two`.
+Taking determinants two ways then forces Cassini's identity:
+
+  * multiplicativity of `det` gives `det (Q ^ (n+1)) = (det Q) ^ (n+1) = (-1) ^ (n+1)`;
+  * the explicit entries give `det (Q ^ (n+1)) = F (n+2) · F n − F (n+1) ^ 2`.
+
+Equating the two yields `F (n+2) · F n − F (n+1) ^ 2 = (-1) ^ (n+1)`
+(`fib_cassini_matrix`), and re-indexing recovers the parent's named form
+`F (n+1) · F (n-1) − F n ^ 2 = (-1) ^ n` for `n ≥ 1` (`fib_cassini`).
+
+Mathlib carries Cassini's identity over `ℤ` directly
+(`Int.fib_add_one_mul_fib_sub_one_sub_fib_sq` style), but **not** the
+Q-matrix derivation: there is no `Q ^ n = fib`-matrix lemma in Mathlib, so
+the matrix engine here (`Q_pow_succ`) is an original contribution.
+
+Worked numerics: `det (Q^3) = F 4 · F 2 − F 3 ^ 2 = 3·1 − 2² = -1 = (-1)^3`;
+`det (Q^4) = F 5 · F 3 − F 4 ^ 2 = 5·2 − 3² = 1 = (-1)^4`.
+-/
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Tactic
+
+namespace FibonacciIdentitiesOQ01OQ03
+
+open Nat Matrix
+
+/-- The Fibonacci **Q-matrix** `Q = !![1, 1; 1, 0]` over `ℤ`. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- Congruence helper: two explicit `2×2` matrices agree when their entries do. -/
+private theorem mateq {a b c d e f g h : ℤ}
+    (h₁ : a = e) (h₂ : b = f) (h₃ : c = g) (h₄ : d = h) :
+    !![a, b; c, d] = !![e, f; g, h] := by
+  rw [h₁, h₂, h₃, h₄]
+
+/-- `det Q = -1`: the Q-matrix has determinant `-1`. -/
+theorem det_Q : Q.det = -1 := by
+  simp [Q, Matrix.det_fin_two_of]
+
+/-- **Q-matrix engine.** Powers of the Fibonacci Q-matrix carry consecutive
+Fibonacci numbers:
+`Q ^ (n + 1) = !![F (n+2), F (n+1); F (n+1), F n]`.
+
+This is the matrix fact absent from Mathlib; everything else follows from it
+by taking determinants. Proved by induction on `n` using only the Fibonacci
+recurrence and the explicit two-by-two product. -/
+theorem Q_pow_succ (n : ℕ) :
+    Q ^ (n + 1)
+      = !![(fib (n + 2) : ℤ), (fib (n + 1) : ℤ);
+           (fib (n + 1) : ℤ), (fib n : ℤ)] := by
+  induction n with
+  | zero =>
+      rw [Nat.zero_add, pow_one, Q]
+      apply mateq <;> simp [Nat.fib_zero, Nat.fib_one, Nat.fib_two]
+  | succ n ih =>
+      have e2 : (fib (n + 2) : ℤ) = fib n + fib (n + 1) := by
+        have : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+        exact_mod_cast this
+      have e3 : (fib (n + 3) : ℤ) = fib (n + 1) + fib (n + 2) := by
+        have : Nat.fib (n + 3) = Nat.fib (n + 1) + Nat.fib (n + 2) := Nat.fib_add_two
+        exact_mod_cast this
+      rw [pow_succ, ih, Q, Matrix.mul_fin_two]
+      apply mateq
+      · rw [show n + 1 + 2 = n + 3 from rfl, e3]; ring
+      · rw [show n + 1 + 1 = n + 2 from rfl]; ring
+      · rw [show n + 1 + 1 = n + 2 from rfl, e2]; ring
+      · ring
+
+/-- Determinant of `Q ^ (n+1)` via multiplicativity: `det (Q^(n+1)) = (-1)^(n+1)`. -/
+theorem det_Q_pow (n : ℕ) : (Q ^ (n + 1)).det = (-1 : ℤ) ^ (n + 1) := by
+  rw [Matrix.det_pow, det_Q]
+
+/-- **Cassini's identity, matrix-theoretic form.**
+Computing `det (Q ^ (n+1))` two ways forces
+`F (n+2) · F n − F (n+1) ^ 2 = (-1) ^ (n+1)`. -/
+theorem fib_cassini_matrix (n : ℕ) :
+    (fib (n + 2) : ℤ) * fib n - (fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  have h := det_Q_pow n
+  rw [Q_pow_succ, Matrix.det_fin_two_of] at h
+  rw [← h]; ring
+
+/-- **Cassini's identity, named form** (the parent statement), recovered from the
+matrix derivation: for `n ≥ 1`,
+`F (n+1) · F (n-1) − F n ^ 2 = (-1) ^ n`. -/
+theorem fib_cassini (n : ℕ) (hn : 1 ≤ n) :
+    (fib (n + 1) : ℤ) * fib (n - 1) - (fib n : ℤ) ^ 2 = (-1) ^ n := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.one_le_iff_ne_zero.mp hn)
+  simpa [Nat.add_sub_cancel] using fib_cassini_matrix m
+
+/-! ### Numeric sanity checks -/
+
+example : (Q ^ 3).det = (-1 : ℤ) ^ 3 := by decide
+example : (fib 4 : ℤ) * fib 2 - (fib 3 : ℤ) ^ 2 = (-1) ^ 3 := by decide
+example : (fib 5 : ℤ) * fib 3 - (fib 4 : ℤ) ^ 2 = (-1) ^ 4 := by decide
+
+end FibonacciIdentitiesOQ01OQ03

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-03/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "fibonacci-identities-oq-01-oq-03",
+  "title": "Cassini's Identity via the Fibonacci Q-matrix",
+  "slug": "fibonacci-identities-oq-01-oq-03",
+  "description": "The matrix-theoretic derivation of Cassini's identity: with Q = !![1,1;1,0] the Fibonacci Q-matrix over ℤ, computing det(Qⁿ) two ways yields Cassini. The engine is the classical fact that powers of Q collect consecutive Fibonacci numbers, Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)], proved by a single induction using only the recurrence Nat.fib_add_two and the explicit 2×2 product Matrix.mul_fin_two. Taking determinants: multiplicativity gives det(Q^(n+1)) = (det Q)^(n+1) = (−1)^(n+1), while the explicit entries give det(Q^(n+1)) = F(n+2)·F(n) − F(n+1)². Equating forces F(n+2)·F(n) − F(n+1)² = (−1)^(n+1) (fib_cassini_matrix), and a one-line re-index recovers the parent's named form F(n+1)·F(n−1) − F(n)² = (−1)ⁿ for n ≥ 1 (fib_cassini). Mathlib carries Cassini's identity over ℤ directly but has no Q^n = fib-matrix lemma, so the Q-matrix engine Q_pow_succ is an original contribution. This answers the third open question of fibonacci-identities-oq-01.",
+  "meta": {
+    "author": "Classical (Q-matrix / golden-ratio matrix); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "matrix",
+      "determinant",
+      "q-matrix",
+      "linear-algebra",
+      "induction",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the Fibonacci recurrence, cast to ℤ to advance the two new entries at the inductive step of Q_pow_succ",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Matrix.mul_fin_two",
+        "description": "Explicit product of two 2×2 matrices in !![…] notation — turns Q^(n+1)·Q into a literal whose entries are Fibonacci sums",
+        "module": "Mathlib.LinearAlgebra.Matrix.Notation"
+      },
+      {
+        "theorem": "Matrix.det_pow",
+        "description": "det (M ^ n) = (det M) ^ n — multiplicativity of the determinant, the source of the (−1)^(n+1) sign",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a, b; c, d] = a·d − b·c — evaluates both det Q (= −1) and det of the Fibonacci-entry matrix (= F(n+2)·F(n) − F(n+1)²)",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Nat.exists_eq_succ_of_ne_zero",
+        "description": "From n ≠ 0 write n = m + 1, transporting the matrix Cassini form to the named n ≥ 1 statement F(n+1)·F(n−1) − F(n)² = (−1)ⁿ",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Q_pow_succ: ∀ n, Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)] over ℤ — the Fibonacci Q-matrix power law, the matrix engine that is absent from Mathlib; proved by one induction using only the recurrence and the explicit 2×2 product",
+      "fib_cassini_matrix: ∀ n, F(n+2)·F(n) − F(n+1)² = (−1)^(n+1) — Cassini's identity obtained by evaluating det(Q^(n+1)) two ways (multiplicativity vs explicit entries)",
+      "fib_cassini: ∀ n ≥ 1, F(n+1)·F(n−1) − F(n)² = (−1)ⁿ — the parent's named Cassini form recovered from the matrix derivation by re-indexing"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 110,
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms beyond Lean/Mathlib's foundational propext / Classical.choice / Quot.sound. The main theorems use no decide/native_decide; only the trailing numeric sanity-check examples use kernel `decide` (which contributes no extra axioms).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity (Giovanni Cassini, 1680) states that for consecutive Fibonacci numbers Fₙ₋₁·Fₙ₊₁ − Fₙ² = (−1)ⁿ. Its cleanest structural explanation is linear-algebraic: the Fibonacci Q-matrix Q = [[1,1],[1,0]] satisfies Qⁿ = [[Fₙ₊₁, Fₙ],[Fₙ, Fₙ₋₁]], so Cassini is nothing but det(Qⁿ) = (det Q)ⁿ = (−1)ⁿ. This Q-matrix viewpoint is the engine behind fast-doubling Fibonacci computation and the addition formulas, and it makes the alternating sign a one-line consequence of determinant multiplicativity rather than an induction with a hand-tracked sign.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01, Q3)**: Derive Cassini matrix-theoretically as det([[1,1],[1,0]]ⁿ) = (−1)ⁿ.\n\n**Result**: Q_pow_succ establishes the Fibonacci Q-matrix power law; det(Q^(n+1)) computed two ways gives fib_cassini_matrix (F(n+2)·F(n) − F(n+1)² = (−1)^(n+1)); fib_cassini re-derives the parent's named form for n ≥ 1.",
+    "text": "Over ℤ, with Q = !![1,1;1,0] and Fₙ = Nat.fib n, the determinant of the n-th power of the Fibonacci Q-matrix equals (−1)ⁿ. Because Qⁿ carries consecutive Fibonacci numbers on its entries, equating det(Qⁿ) computed by multiplicativity with det(Qⁿ) computed from the entries reproduces Cassini's identity.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Define the Q-matrix Q = !![1,1;1,0] over ℤ and record det Q = −1 (Matrix.det_fin_two_of).\n2. Prove the power law Q_pow_succ: Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)] by induction on n. Base case n = 0: Q¹ = Q = !![F2, F1; F1, F0] = !![1,1;1,0]. Successor step: rewrite Q^(n+2) = Q^(n+1)·Q via pow_succ and the induction hypothesis, expand the product with Matrix.mul_fin_two, and discharge the four entries — two are immediate, the other two are exactly the Fibonacci recurrence Nat.fib_add_two cast to ℤ, closed by ring.\n3. det(Q^(n+1)) = (det Q)^(n+1) = (−1)^(n+1) by Matrix.det_pow and det Q.\n4. det(Q^(n+1)) = F(n+2)·F(n) − F(n+1)² by rewriting with Q_pow_succ and Matrix.det_fin_two_of. Equating with step 3 gives fib_cassini_matrix.\n5. Re-index: for n ≥ 1 write n = m + 1 (Nat.exists_eq_succ_of_ne_zero); fib_cassini_matrix at m is exactly the named Cassini form F(n+1)·F(n−1) − F(n)² = (−1)ⁿ, recovering the parent.",
+    "keyInsights": [
+      "**Cassini = determinant multiplicativity.** Once Qⁿ is known to carry consecutive Fibonacci numbers, the alternating sign (−1)ⁿ is not tracked by hand through an induction — it is simply (det Q)ⁿ, delivered by Matrix.det_pow. The sign is a structural fact about the matrix, not an artifact of the proof.",
+      "**The only inductive content is the power law.** All Fibonacci-specific work lives in Q_pow_succ; the rest is determinant bookkeeping. The induction itself uses nothing but Nat.fib_add_two — no closed form, Binet formula, or Catalan/d'Ocagne identity.",
+      "**Index hygiene via the (n+1) form.** Stating the power law as Q^(n+1) = !![F(n+2),F(n+1);F(n+1),F(n)] sidesteps the F(n−1) (natural-number subtraction) that a bare Qⁿ form would introduce, keeping the induction subtraction-free; the named F(n−1) form is recovered once at the end.",
+      "**Not in Mathlib.** Mathlib proves Cassini's identity over ℤ directly but has no Q^n = fib-matrix lemma, so the Q-matrix engine Q_pow_succ is an original contribution that also supplies the matrix scaffolding for the Fibonacci addition/doubling formulas.",
+      "**A faithful derivation of the parent.** fib_cassini reproduces the parent's exact statement F(n+1)·F(n−1) − F(n)² = (−1)ⁿ, certifying that the matrix route genuinely answers the open question rather than proving a cosmetically different identity."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and base values fib 0, fib 1, fib 2",
+      "2×2 matrices in Mathlib: the !![…] notation, Matrix.mul_fin_two, and Matrix.det_fin_two_of",
+      "Multiplicativity of the determinant Matrix.det_pow",
+      "Induction over ℕ, casting ℕ → ℤ, and eliminating n−1 via Nat.exists_eq_succ_of_ne_zero"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring deriving Cassini from det(Qⁿ) = (−1)ⁿ, the Q-matrix power law, and worked numerics; imports of Fibonacci basics, 2×2 determinant lemmas, and tactics; namespace and open Nat Matrix.",
+      "mathContext": "$Q=\\begin{pmatrix}1&1\\\\1&0\\end{pmatrix}$, $\\det(Q^n)=(\\det Q)^n=(-1)^n$."
+    },
+    {
+      "id": "qmatrix",
+      "title": "The Q-matrix and its determinant",
+      "startLine": 42,
+      "endLine": 59,
+      "summary": "Definition of Q = !![1,1;1,0] over ℤ, a small congruence helper mateq for proving equality of explicit 2×2 matrices entrywise, and det_Q : det Q = −1.",
+      "mathContext": "$\\det\\begin{pmatrix}1&1\\\\1&0\\end{pmatrix}=1\\cdot0-1\\cdot1=-1$."
+    },
+    {
+      "id": "power-law",
+      "title": "Q-matrix power law (engine)",
+      "startLine": 61,
+      "endLine": 82,
+      "summary": "Q_pow_succ: Q^(n+1) = !![F(n+2),F(n+1);F(n+1),F(n)] by induction on n — base case by the fib base values, successor step by pow_succ + Matrix.mul_fin_two, with the two nontrivial entries closed by Nat.fib_add_two and ring.",
+      "mathContext": "$Q^{n+1}=\\begin{pmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{pmatrix}$."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini via the determinant",
+      "startLine": 84,
+      "endLine": 102,
+      "summary": "det_Q_pow: det(Q^(n+1)) = (−1)^(n+1) by Matrix.det_pow; fib_cassini_matrix equates the two evaluations to give F(n+2)·F(n) − F(n+1)² = (−1)^(n+1); fib_cassini re-indexes to the parent's named form for n ≥ 1.",
+      "mathContext": "$F_{n+2}F_n-F_{n+1}^2=(-1)^{n+1}$, equivalently $F_{n+1}F_{n-1}-F_n^2=(-1)^n$."
+    },
+    {
+      "id": "examples",
+      "title": "Numeric sanity checks",
+      "startLine": 104,
+      "endLine": 110,
+      "summary": "Kernel-decidable checks that det(Q³) = (−1)³ and the entry form at (n=2,3): F4·F2 − F3² = −1, F5·F3 − F4² = 1.",
+      "mathContext": "$F_5 F_3 - F_4^2 = 5\\cdot2 - 3^2 = 1 = (-1)^4$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "answers",
+      "description": "Derives Cassini's identity matrix-theoretically as det([[1,1],[1,0]]ⁿ) = (−1)ⁿ — the third open question of the parent — and re-derives the parent's named form F(n+1)·F(n−1) − F(n)² = (−1)ⁿ via fib_cassini"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-02",
+      "relationship": "related",
+      "description": "d'Ocagne's identity (sibling leaf) is the two-index companion; the Q-matrix viewpoint here is the structural source of both, via entry comparison in Q^m = Q^n·Q^(m−n)"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) matrix-theoretic derivation of Cassini's identity: the Fibonacci Q-matrix power law Q^(n+1) = !![F(n+2),F(n+1);F(n+1),F(n)] (an original lemma absent from Mathlib) combined with determinant multiplicativity gives F(n+2)·F(n) − F(n+1)² = (−1)^(n+1), and re-indexing recovers the parent's named Cassini form for n ≥ 1.",
+    "implications": "Supplies the Fibonacci Q-matrix scaffolding — det(Qⁿ) = (−1)ⁿ and the explicit power law — as universally quantified Lean theorems, the structural backbone behind fast-doubling Fibonacci computation, the addition formulas, and the unified treatment of Cassini/Catalan/d'Ocagne identities.",
+    "openQuestions": [
+      "Extend the Q-matrix engine to the addition law Q^(m+n) = Q^m·Q^n, yielding F(m+n) = F(m)·F(n+1) + F(m−1)·F(n) and the fast-doubling formulas directly from matrix multiplication.",
+      "Recover Catalan's identity F(n−r)·F(n+r) − F(n)² = (−1)^(n−r)·F(r)² from the same Q-matrix by comparing entries of Q^(n−r)·Q^(2r), unifying Cassini, Catalan, and d'Ocagne under one determinant/entry-comparison lemma."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Matrix"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01OQ03",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cassini, Giovanni Domenico",
+      "title": "Une nouvelle progression de nombres (Cassini's identity)",
+      "year": "1680",
+      "venue": "Académie Royale des Sciences",
+      "note": "Original statement Fₙ₋₁·Fₙ₊₁ − Fₙ² = (−1)ⁿ"
+    },
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "The Q-matrix Q = [[1,1],[1,0]], Qⁿ = [[Fₙ₊₁,Fₙ],[Fₙ,Fₙ₋₁]], and Cassini as det(Qⁿ)"
+    },
+    {
+      "authors": "Knuth, Donald E.",
+      "title": "The Art of Computer Programming, Vol. 1",
+      "year": "1997",
+      "venue": "Addison-Wesley",
+      "note": "Fibonacci Q-matrix and fast-doubling via matrix powers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `fibonacci-identities-oq-01` (Cassini's identity): *derive Cassini matrix-theoretically as* `det([[1,1],[1,0]]ⁿ) = (−1)ⁿ`.

The proof establishes the Fibonacci **Q-matrix power law** and then computes a determinant two ways:

- **Engine** (`Q_pow_succ`): `Q^(n+1) = !![F(n+2), F(n+1); F(n+1), F(n)]` over ℤ, by one induction using only the recurrence `Nat.fib_add_two` and the explicit 2×2 product `Matrix.mul_fin_two`.
- **Multiplicativity**: `det(Q^(n+1)) = (det Q)^(n+1) = (−1)^(n+1)`.
- **Explicit entries**: `det(Q^(n+1)) = F(n+2)·F(n) − F(n+1)²`.
- Equating (`fib_cassini_matrix`): `F(n+2)·F(n) − F(n+1)² = (−1)^(n+1)`.
- Re-index (`fib_cassini`): the parent's named form `F(n+1)·F(n−1) − F(n)² = (−1)ⁿ` for `n ≥ 1`.

## Originality

Mathlib carries Cassini's identity over ℤ **scalar-ly** but has **no** `Q^n = fib`-matrix lemma. The Q-matrix power law `Q_pow_succ` — the structural backbone behind fast-doubling and the addition formulas — is the original contribution; everything else is determinant bookkeeping. Badge: `original`.

## Verification

- **5 theorems, 1 definition, 110 lines.**
- **0 sorries, 0 axioms** beyond foundational `propext` / `Classical.choice` / `Quot.sound` (confirmed via `#print axioms`).
- Main theorems use **no** `decide`/`native_decide`; kernel `decide` appears only in the trailing numeric sanity-check examples (contributes no extra axioms).
- Built with host `lean` (Docker unavailable), Mathlib v4.26.0, exit 0.

## Files
- `proofs/Proofs/FibonacciIdentitiesOQ01OQ03.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/fibonacci-identities-oq-01-oq-03/meta.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)