### PR TITLE
research(euler-totient-oq-03-oq-03): exact GCD–totient sharpening + general power formula

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2752,6 +2752,7 @@ import Proofs.EulerTotientOQ01OQ03Minimal
 import Proofs.EulerTotientOQ02
 import Proofs.EulerTotientOQ02OQ01
 import Proofs.EulerTotientOQ03
+import Proofs.EulerTotientOQ03OQ03
 import Proofs.EulerTotientOQ04
 import Proofs.EulerTotientOQ04OQ01
 import Proofs.EulerTotientOQ05

--- a/proofs/Proofs/EulerTotientOQ03OQ03.lean
+++ b/proofs/Proofs/EulerTotientOQ03OQ03.lean
@@ -1,0 +1,134 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Tactic
+
+/-
+# Exact Consequences of the GCD–Totient Identity
+
+## Parent Open Question (euler-totient-oq-03)
+
+> Can the super-multiplicativity inequality φ(a)·φ(b) ≤ φ(ab) be *sharpened*
+> to an exact equality
+>
+>     φ(a)·φ(b)·gcd(a,b) / φ(gcd(a,b)) = φ(ab)
+>
+> via the GCD–totient identity?
+
+The parent entry states the identity itself,
+
+    φ(gcd(a,b)) · φ(ab) = φ(a) · φ(b) · gcd(a,b)          (★)
+
+(`Nat.totient_gcd_mul_totient_mul` in Mathlib). This leaf answers the open
+question by *using* (★) to extract its quantitative consequences.
+
+## What This Proves (new content beyond the identity)
+
+1. **Exact division form** (`totient_mul_eq_div`): the literal sharpening the
+   question asks for — solving (★) for φ(ab) as an exact ℕ-division.
+2. **Coprime collapse** (`totient_mul_coprime`): gcd = 1 recovers ordinary
+   multiplicativity φ(ab) = φ(a)·φ(b).
+3. **Divisibility collapse** (`totient_mul_of_dvd`): a ∣ b gives the exact
+   value φ(ab) = a·φ(b).
+4. **General power formula** (`totient_pow_succ`, `totient_pow`, `totient_sq`):
+   for *every* base n (not just primes),
+
+       φ(nᵏ⁺¹) = nᵏ · φ(n).
+
+   Mathlib only provides this for prime bases (`Nat.totient_prime_pow`); the
+   general statement is derived here by induction from (★).
+
+## Key Insight
+
+The single identity (★) is the exact form of super-multiplicativity: the gap
+between φ(a)·φ(b) and φ(ab) is governed precisely by the factor
+gcd(a,b) / φ(gcd(a,b)) ≥ 1. Specializing the two arguments collapses (★) to
+the multiplicative, divisibility, and prime-power laws — and an induction on
+the exponent upgrades the divisibility case to the full power formula for an
+arbitrary base.
+-/
+
+open Nat
+
+namespace EulerTotientOQ03OQ03
+
+/-- The GCD–totient identity (Mathlib / parent entry), restated as the
+foundation for this file:
+`φ(gcd(a,b)) · φ(ab) = φ(a) · φ(b) · gcd(a,b)`. -/
+theorem totient_gcd_identity (a b : ℕ) :
+    φ (Nat.gcd a b) * φ (a * b) = φ a * φ b * Nat.gcd a b :=
+  Nat.totient_gcd_mul_totient_mul a b
+
+/-- **Exact sharpening of super-multiplicativity** — the literal form requested
+by the open question. Whenever `gcd(a,b) > 0` (i.e. `a, b` not both zero),
+`φ(ab)` is recovered as an exact natural-number division:
+`φ(a)·φ(b)·gcd(a,b) / φ(gcd(a,b)) = φ(ab)`. -/
+theorem totient_mul_eq_div (a b : ℕ) (h : 0 < Nat.gcd a b) :
+    φ a * φ b * Nat.gcd a b / φ (Nat.gcd a b) = φ (a * b) := by
+  have hφ : 0 < φ (Nat.gcd a b) := Nat.totient_pos.mpr h
+  exact Nat.div_eq_of_eq_mul_left hφ (by rw [← totient_gcd_identity]; ring)
+
+/-- **Coprime collapse.** When `gcd(a,b) = 1`, the identity reduces to ordinary
+multiplicativity `φ(ab) = φ(a)·φ(b)`. -/
+theorem totient_mul_coprime {a b : ℕ} (h : Nat.Coprime a b) :
+    φ (a * b) = φ a * φ b := by
+  have key := totient_gcd_identity a b
+  rw [Nat.Coprime] at h
+  rw [h] at key
+  simpa using key
+
+/-- **Divisibility collapse.** When `a ∣ b` (and `a > 0`), `gcd(a,b) = a` and the
+identity gives the exact value `φ(ab) = a·φ(b)`. -/
+theorem totient_mul_of_dvd {a b : ℕ} (ha : 0 < a) (h : a ∣ b) :
+    φ (a * b) = a * φ b := by
+  have key := totient_gcd_identity a b
+  rw [Nat.gcd_eq_left h] at key
+  have hφ : 0 < φ a := Nat.totient_pos.mpr ha
+  apply Nat.eq_of_mul_eq_mul_left hφ
+  rw [key]; ring
+
+/-- **General power formula.** For *every* base `n`,
+`φ(nᵏ⁺¹) = nᵏ · φ(n)`. Proved by induction on `k`, using the divisibility case
+of the GCD–totient identity at each step. Mathlib only supplies this for prime
+bases (`Nat.totient_prime_pow`). -/
+theorem totient_pow_succ (n k : ℕ) : φ (n ^ (k + 1)) = n ^ k * φ n := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn; simp
+    · have hgcd : Nat.gcd (n ^ (k + 1)) n = n :=
+        Nat.gcd_eq_right (dvd_pow_self n (Nat.succ_ne_zero k))
+      have key := Nat.totient_gcd_mul_totient_mul (n ^ (k + 1)) n
+      rw [hgcd, ← pow_succ, ih] at key
+      have hφ : 0 < φ n := Nat.totient_pos.mpr hn
+      apply Nat.eq_of_mul_eq_mul_left hφ
+      rw [key]; ring
+
+/-- The general power formula in `k - 1` form: for `k ≥ 1` and any base `n`,
+`φ(nᵏ) = nᵏ⁻¹ · φ(n)`. -/
+theorem totient_pow {n k : ℕ} (hk : 1 ≤ k) : φ (n ^ k) = n ^ (k - 1) * φ n := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  simpa using totient_pow_succ n j
+
+/-- **Square case** of the power formula: `φ(n²) = n · φ(n)` for every `n`. -/
+theorem totient_sq (n : ℕ) : φ (n ^ 2) = n * φ n := by
+  simpa using totient_pow_succ n 1
+
+-- ============================================================================
+-- Sanity checks (no computation: these are direct specializations)
+-- ============================================================================
+
+/-- φ(3²) = 3·φ(3): instance of the general power formula at a non-prime exponent
+of a prime base. -/
+example : φ (3 ^ 2) = 3 * φ 3 := totient_sq 3
+
+/-- φ(6²) = 6·φ(6): the power formula at a composite base (where Mathlib's
+prime-power lemma does not apply). -/
+example : φ (6 ^ 2) = 6 * φ 6 := totient_sq 6
+
+/-- Coprime collapse recovers φ(15) = φ(3)·φ(5). -/
+example : φ (3 * 5) = φ 3 * φ 5 := totient_mul_coprime (by decide)
+
+/-- Divisibility collapse: φ(2 · 6) = 2 · φ(6) since 2 ∣ 6. -/
+example : φ (2 * 6) = 2 * φ 6 := totient_mul_of_dvd (by norm_num) (by norm_num)
+
+end EulerTotientOQ03OQ03

--- a/src/data/proofs/euler-totient-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-03/annotations.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "ann-exact-sharpening",
+    "proofId": "euler-totient-oq-03-oq-03",
+    "range": {
+      "startLine": 60,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "The 'Sharpening' Is the Identity Solved for φ(ab)",
+    "content": "The open question asks whether super-multiplicativity `φ(a)·φ(b) ≤ φ(ab)` can be sharpened to the exact equality\n```\nφ(a)·φ(b)·gcd(a,b) / φ(gcd(a,b)) = φ(ab).\n```\nThis is *literally* the GCD–totient identity\n```\nφ(gcd(a,b))·φ(ab) = φ(a)·φ(b)·gcd(a,b)\n```\nsolved for `φ(ab)`. Over ℕ the division is delicate, but it is **exact** (remainder-free): `φ(gcd(a,b))` divides the numerator because the identity says the numerator equals `φ(gcd(a,b))·φ(ab)`. The Lean proof feeds this to `Nat.div_eq_of_eq_mul_left`, whose only hypothesis is `0 < φ(gcd(a,b))` — supplied by `Nat.totient_pos` from `0 < gcd(a,b)` (i.e. a, b not both zero).\n\nThe defect factor `gcd(a,b)/φ(gcd(a,b)) ≥ 1` measures exactly how far φ is from multiplicative, and equals 1 precisely when `gcd(a,b) = 1`.",
+    "mathContext": "$\\varphi(ab)=\\dfrac{\\varphi(a)\\varphi(b)\\gcd(a,b)}{\\varphi(\\gcd(a,b))}$ for $\\gcd(a,b)>0$. Equivalently $\\dfrac{\\varphi(ab)}{\\varphi(a)\\varphi(b)}=\\dfrac{\\gcd(a,b)}{\\varphi(\\gcd(a,b))}\\ge 1$, the multiplicative defect, $=1$ iff $\\gcd(a,b)=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.totient_gcd_mul_totient_mul",
+      "Nat.div_eq_of_eq_mul_left",
+      "Nat.totient_pos",
+      "super-multiplicativity"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  },
+  {
+    "id": "ann-two-collapses",
+    "proofId": "euler-totient-oq-03-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "One Identity, Two Classical Laws",
+    "content": "Both the multiplicative and the divisibility behaviour of φ are special cases of the *same* identity:\n\n**Coprime collapse** (`totient_mul_coprime`): set `gcd(a,b) = 1`. Then `φ(1) = 1` and the identity becomes `φ(ab) = φ(a)·φ(b)` — ordinary multiplicativity, recovered by `simp` after substituting `Nat.Coprime`.\n\n**Divisibility collapse** (`totient_mul_of_dvd`): if `a ∣ b` then `gcd(a,b) = a` (`Nat.gcd_eq_left`), so the identity reads `φ(a)·φ(ab) = φ(a)·φ(b)·a`. Cancelling `φ(a) > 0` (`Nat.eq_of_mul_eq_mul_left` with `Nat.totient_pos`) gives the exact value `φ(ab) = a·φ(b)`.\n\nThe only side conditions are non-vanishing of the cancelled argument — there is no separate machinery for either law.",
+    "mathContext": "Coprime case: $\\gcd=1\\Rightarrow\\varphi(ab)=\\varphi(a)\\varphi(b)$. Divisibility case: $a\\mid b\\Rightarrow\\gcd(a,b)=a\\Rightarrow\\varphi(ab)=a\\,\\varphi(b)$ after cancelling $\\varphi(a)>0$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.Coprime",
+      "Nat.gcd_eq_left",
+      "Nat.eq_of_mul_eq_mul_left",
+      "Nat.totient_mul"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  },
+  {
+    "id": "ann-general-power-formula",
+    "proofId": "euler-totient-oq-03-oq-03",
+    "range": {
+      "startLine": 88,
+      "endLine": 114
+    },
+    "type": "insight",
+    "title": "φ(nᵏ⁺¹) = nᵏ·φ(n) for EVERY Base — Beyond Mathlib's Prime Case",
+    "content": "Mathlib's `Nat.totient_prime_pow` computes `φ(p^k) = p^(k-1)(p-1)` only when `p` is **prime**. The general scaling law\n```\nφ(n^(k+1)) = n^k · φ(n)   for every n\n```\nis proved here by induction on `k`. The successor step applies the GCD–totient identity to the pair `(n^(k+1), n)`:\n- `gcd(n^(k+1), n) = n`, since `n ∣ n^(k+1)` (`dvd_pow_self`, `Nat.gcd_eq_right`);\n- rewriting `n^(k+1)·n = n^(k+2)` (`pow_succ`) and applying the induction hypothesis turns the identity into `φ(n)·φ(n^(k+2)) = φ(n)·(n^(k+1)·φ(n))`;\n- cancelling `φ(n) > 0` (positive-base case) gives the result; the `n = 0` case is closed by `simp`.\n\n`totient_pow` restates this in `k − 1` form for `k ≥ 1`, and `totient_sq` is the `k = 1` instance `φ(n²) = n·φ(n)`. The composite-base sanity check `φ(6²) = 6·φ(6)` (= `totient_sq 6`) exercises exactly the regime Mathlib's prime-power lemma cannot reach.",
+    "mathContext": "$\\varphi(n^{k+1})=n^k\\varphi(n)$ for all $n,k$. Induction step uses $\\gcd(n^{k+1},n)=n$ in $\\varphi(\\gcd)\\varphi(n^{k+1}\\cdot n)=\\varphi(n^{k+1})\\varphi(n)\\gcd$, the inductive hypothesis $\\varphi(n^{k+1})=n^k\\varphi(n)$, and cancellation of $\\varphi(n)>0$. Generalizes `Nat.totient_prime_pow` from prime to arbitrary base.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.totient_prime_pow",
+      "Nat.gcd_eq_right",
+      "dvd_pow_self",
+      "pow_succ",
+      "induction"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-03-oq-03/meta.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-03/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "euler-totient-oq-03-oq-03",
+  "title": "Exact Consequences of the GCD–Totient Identity",
+  "slug": "euler-totient-oq-03-oq-03",
+  "description": "Answers the parent open question by sharpening super-multiplicativity φ(a)·φ(b) ≤ φ(ab) into the exact division form φ(a)·φ(b)·gcd(a,b)/φ(gcd(a,b)) = φ(ab). Specializes the GCD–totient identity to recover the coprime law φ(ab)=φ(a)φ(b) and the divisibility law φ(ab)=a·φ(b), and upgrades the latter by induction to the general power formula φ(nᵏ⁺¹)=nᵏ·φ(n) for EVERY base n — a statement Mathlib provides only for prime bases. 0 sorries, 0 axioms.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "multiplicative-functions",
+      "totient",
+      "gcd",
+      "product-formula"
+    ],
+    "proofRepoPath": "Proofs/EulerTotientOQ03OQ03.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. All seven theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (not counted). The example sanity checks use kernel `decide`/`norm_num` only — no `native_decide`, so `Lean.ofReduceBool` is NOT introduced. Built against Mathlib's `Nat.totient` API; the central identity `Nat.totient_gcd_mul_totient_mul` is from Mathlib, and the consequences derived here (exact division form, coprime/divisibility collapses, general power formula) are proved from it.",
+    "lineCount": 134,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "Euler's totient function $\\varphi$ is *multiplicative*: $\\varphi(ab)=\\varphi(a)\\varphi(b)$ whenever $\\gcd(a,b)=1$. When $a$ and $b$ share factors the equality fails, but the *direction* of failure is fixed — $\\varphi$ is **super-multiplicative**, $\\varphi(a)\\varphi(b)\\le\\varphi(ab)$. The precise gap is captured by the GCD–totient identity\n$$\\varphi(\\gcd(a,b))\\cdot\\varphi(ab)=\\varphi(a)\\,\\varphi(b)\\,\\gcd(a,b),$$\nwhich appears in Mathlib as `Nat.totient_gcd_mul_totient_mul`. This single relation simultaneously encodes multiplicativity (the $\\gcd=1$ case) and the behaviour of $\\varphi$ on powers (the divisibility case). It is the natural home for any 'exact' statement about how $\\varphi$ interacts with products.",
+    "problemStatement": "**Open Question (OQ-03-OQ-03)**: Can the super-multiplicativity inequality $\\varphi(a)\\varphi(b)\\le\\varphi(ab)$ be *sharpened* into the exact equality\n$$\\frac{\\varphi(a)\\,\\varphi(b)\\,\\gcd(a,b)}{\\varphi(\\gcd(a,b))}=\\varphi(ab)$$\nvia the GCD–totient identity, and what concrete laws does this exact form yield?\n\n**Answer: YES.** Solving the identity for $\\varphi(ab)$ gives the requested division form as an exact natural-number division whenever $\\gcd(a,b)>0$. Specializing the two arguments collapses the identity to the coprime law $\\varphi(ab)=\\varphi(a)\\varphi(b)$ and the divisibility law $\\varphi(ab)=a\\,\\varphi(b)$ (for $a\\mid b$); an induction on the exponent then promotes the divisibility law to the **general power formula** $\\varphi(n^{k+1})=n^k\\,\\varphi(n)$ valid for every base $n$, not only primes.",
+    "proofStrategy": "The file is organized around one Mathlib relation and four exact consequences.\n\n**Foundation:** `totient_gcd_identity` restates $\\varphi(\\gcd(a,b))\\varphi(ab)=\\varphi(a)\\varphi(b)\\gcd(a,b)$ (a thin wrapper of `Nat.totient_gcd_mul_totient_mul`) as the basis for the rest.\n\n**Exact sharpening:** `totient_mul_eq_div` solves the identity for $\\varphi(ab)$ using `Nat.div_eq_of_eq_mul_left`, valid once $\\varphi(\\gcd(a,b))>0$ — exactly the form the open question requests.\n\n**Collapses:** `totient_mul_coprime` substitutes $\\gcd=1$ to recover multiplicativity; `totient_mul_of_dvd` substitutes $\\gcd(a,b)=a$ (from $a\\mid b$) and cancels $\\varphi(a)>0$ to get $\\varphi(ab)=a\\varphi(b)$.\n\n**General power formula:** `totient_pow_succ` proves $\\varphi(n^{k+1})=n^k\\varphi(n)$ by induction on $k$. The successor step applies the identity to $(n^{k+1},n)$ — where $\\gcd(n^{k+1},n)=n$ — and cancels $\\varphi(n)$ in the positive-base case (the $n=0$ case is closed by `simp`). `totient_pow` and `totient_sq` repackage this as $\\varphi(n^k)=n^{k-1}\\varphi(n)$ and $\\varphi(n^2)=n\\varphi(n)$.",
+    "keyInsights": [
+      "The GCD–totient identity is precisely the exact form of super-multiplicativity: the multiplicative defect is the single rational factor gcd(a,b)/φ(gcd(a,b)) ≥ 1, which equals 1 exactly when a, b are coprime. The 'sharpening' the open question asks for is therefore just the identity solved for φ(ab).",
+      "The general power formula φ(n^(k+1)) = n^k·φ(n) holds for EVERY base, not only primes. Mathlib's Nat.totient_prime_pow is restricted to prime bases; the composite-base statement is obtained here by feeding the divisibility case gcd(n^(k+1), n) = n into the identity and inducting on the exponent.",
+      "Two specializations of one identity recover two classical laws: gcd = 1 gives multiplicativity φ(ab) = φ(a)φ(b), and a ∣ b gives φ(ab) = a·φ(b). The cancellation of φ(gcd) (resp. φ(a)) is licensed by Nat.totient_pos, so the only side condition is non-vanishing of the relevant argument.",
+      "Working in ℕ, the exact 'division' form requires care: φ(a)φ(b)gcd(a,b)/φ(gcd(a,b)) is an exact (remainder-free) natural division because φ(gcd) divides φ(a)φ(b)gcd exactly, a fact that is itself just the identity. Nat.div_eq_of_eq_mul_left converts the multiplicative identity into the division statement."
+    ],
+    "prerequisites": [
+      "Euler's totient function and its multiplicativity (euler-totient-oq-02)",
+      "The GCD–totient identity Nat.totient_gcd_mul_totient_mul (parent euler-totient-oq-03)",
+      "Nat.totient_pos and cancellation of positive natural factors",
+      "Induction on the exponent and Nat.gcd_eq_left / gcd_eq_right",
+      "Exact natural-number division (Nat.div_eq_of_eq_mul_left)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "foundation",
+      "title": "Foundation: The GCD–Totient Identity",
+      "startLine": 53,
+      "endLine": 58,
+      "summary": "Restates φ(gcd(a,b))·φ(ab) = φ(a)·φ(b)·gcd(a,b) (Nat.totient_gcd_mul_totient_mul) as the basis for the exact consequences below.",
+      "mathContext": "$\\varphi(\\gcd(a,b))\\cdot\\varphi(ab)=\\varphi(a)\\varphi(b)\\gcd(a,b)$. The parent entry states this identity; here it is the single input from which every other theorem in the file is derived."
+    },
+    {
+      "id": "exact-sharpening",
+      "title": "Exact Sharpening of Super-Multiplicativity",
+      "startLine": 60,
+      "endLine": 67,
+      "summary": "totient_mul_eq_div: φ(a)·φ(b)·gcd(a,b) / φ(gcd(a,b)) = φ(ab) as an exact ℕ-division, valid when gcd(a,b) > 0. This is the literal form the open question requests.",
+      "mathContext": "$\\dfrac{\\varphi(a)\\varphi(b)\\gcd(a,b)}{\\varphi(\\gcd(a,b))}=\\varphi(ab)$ for $\\gcd(a,b)>0$. Proved via `Nat.div_eq_of_eq_mul_left` applied to the identity; the division is exact because $\\varphi(\\gcd(a,b))$ divides the numerator by the identity itself."
+    },
+    {
+      "id": "collapses",
+      "title": "Coprime and Divisibility Collapses",
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "totient_mul_coprime (gcd = 1 ⟹ φ(ab) = φ(a)φ(b)) and totient_mul_of_dvd (a ∣ b, a > 0 ⟹ φ(ab) = a·φ(b)) recover the two classical laws as specializations of the identity.",
+      "mathContext": "Substituting $\\gcd(a,b)=1$ yields multiplicativity $\\varphi(ab)=\\varphi(a)\\varphi(b)$; substituting $\\gcd(a,b)=a$ (from $a\\mid b$, via `Nat.gcd_eq_left`) and cancelling $\\varphi(a)>0$ yields $\\varphi(ab)=a\\,\\varphi(b)$."
+    },
+    {
+      "id": "power-formula",
+      "title": "The General Power Formula (Every Base)",
+      "startLine": 88,
+      "endLine": 114,
+      "summary": "totient_pow_succ: φ(n^(k+1)) = n^k·φ(n) for all n, by induction using gcd(n^(k+1), n) = n. totient_pow and totient_sq repackage it as φ(n^k)=n^(k-1)φ(n) and φ(n²)=n·φ(n). Mathlib has this for prime bases only.",
+      "mathContext": "$\\varphi(n^{k+1})=n^k\\varphi(n)$ for every $n$. Induction on $k$: the step applies the identity to $(n^{k+1},n)$ with $\\gcd(n^{k+1},n)=n$ and cancels $\\varphi(n)>0$ when $n>0$ (the $n=0$ case is immediate). Compare `Nat.totient_prime_pow`, which assumes $p$ prime."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks (No Computation)",
+      "startLine": 116,
+      "endLine": 132,
+      "summary": "Direct specializations — φ(3²)=3·φ(3), φ(6²)=6·φ(6) (composite base), φ(15)=φ(3)φ(5), φ(12)=2·φ(6) — type-check from the theorems, using kernel decide/norm_num only (no native_decide, so 0 axioms preserved).",
+      "mathContext": "These examples instantiate the general theorems rather than recomputing φ; e.g. $\\varphi(6^2)=6\\varphi(6)$ is `totient_sq 6` at a composite base where Mathlib's prime-power lemma does not apply."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered affirmatively: super-multiplicativity φ(a)φ(b) ≤ φ(ab) sharpens to the exact division form φ(a)φ(b)gcd(a,b)/φ(gcd(a,b)) = φ(ab). The same identity collapses to the coprime law φ(ab)=φ(a)φ(b) and the divisibility law φ(ab)=a·φ(b), and induction upgrades the latter to the general power formula φ(n^(k+1))=n^k·φ(n) for every base n — a result Mathlib supplies only for primes. All 7 theorems are machine-verified with 0 sorries and 0 axioms.",
+    "implications": "The exact form makes the multiplicative defect of $\\varphi$ fully explicit: $\\varphi(ab)/(\\varphi(a)\\varphi(b))=\\gcd(a,b)/\\varphi(\\gcd(a,b))\\ge 1$, with equality iff $a,b$ are coprime. The general power formula $\\varphi(n^{k+1})=n^k\\varphi(n)$ gives, for arbitrary $n$, the same scaling that the prime-power formula gives for primes, and immediately yields $\\varphi(n^2)=n\\varphi(n)$. These are the building blocks for computing $\\varphi$ on arbitrary integers once a factorization is known.",
+    "openQuestions": [
+      "Does the exact defect factor gcd(a,b)/φ(gcd(a,b)) admit a clean closed form in terms of the shared prime factors of a and b — e.g. ∏_{p | gcd(a,b)} p/(p-1) for squarefree gcd — and can this be formalized?",
+      "Can the general power formula φ(n^(k+1)) = n^k·φ(n) be packaged as a Mathlib contribution generalizing Nat.totient_prime_pow to arbitrary bases?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-03",
+      "relationship": "extends",
+      "description": "Answers the third open question of the parent: sharpening super-multiplicativity to exact equality via the GCD–totient identity it states."
+    },
+    {
+      "targetId": "euler-totient-oq-02-oq-01",
+      "relationship": "complements",
+      "description": "The product formula entry computes φ via prime factorizations; this entry gives the exact pairwise law φ(ab) and the general power scaling φ(n^(k+1))=n^k φ(n)."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "uses",
+      "description": "Builds on the basic totient API (positivity, multiplicativity) established by the root entry."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G.H. and Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "venue": "Oxford University Press",
+      "note": "Chapter 5 develops the totient function and its multiplicativity. The GCD–totient identity φ(gcd)φ(ab)=φ(a)φ(b)gcd is the exact form of super-multiplicativity discussed there."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Nat.totient_gcd_mul_totient_mul and Nat.totient_prime_pow",
+      "year": "2025",
+      "venue": "Mathlib4, Mathlib/Data/Nat/Totient.lean",
+      "note": "The GCD–totient identity used as the foundation, and the prime-power totient formula that the general power formula proved here extends to arbitrary bases."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 134,
+    "path": "Proofs/EulerTotientOQ03OQ03.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `euler-totient-oq-03`:

> Can super-multiplicativity φ(a)·φ(b) ≤ φ(ab) be *sharpened* to the exact equality
> φ(a)·φ(b)·gcd(a,b)/φ(gcd(a,b)) = φ(ab) via the GCD–totient identity?

**Answer: yes** — and the same identity yields a family of exact laws.

## What's proved (`Proofs/EulerTotientOQ03OQ03.lean`, 7 theorems, 0 sorries, 0 axioms)

| Theorem | Statement |
|---|---|
| `totient_gcd_identity` | φ(gcd a b)·φ(ab) = φ(a)·φ(b)·gcd a b (foundation; wraps `Nat.totient_gcd_mul_totient_mul`) |
| `totient_mul_eq_div` | **φ(a)·φ(b)·gcd(a,b) / φ(gcd(a,b)) = φ(ab)** — the exact sharpening (gcd > 0) |
| `totient_mul_coprime` | gcd = 1 ⟹ φ(ab) = φ(a)·φ(b) |
| `totient_mul_of_dvd` | a ∣ b, a > 0 ⟹ φ(ab) = a·φ(b) |
| `totient_pow_succ` | **φ(nᵏ⁺¹) = nᵏ·φ(n) for EVERY base n** (Mathlib has prime bases only) |
| `totient_pow` | φ(nᵏ) = nᵏ⁻¹·φ(n) for k ≥ 1 |
| `totient_sq` | φ(n²) = n·φ(n) |

## Why it's more than a re-export

The parent already states the GCD–totient identity. The genuine new content here is its **exact consequences**: the division-form sharpening the question asks for, and the **general power formula φ(nᵏ⁺¹)=nᵏ·φ(n) for arbitrary base** — proved by induction from the divisibility case, which Mathlib's `Nat.totient_prime_pow` does not cover (prime bases only). The composite-base check `φ(6²)=6·φ(6)` exercises exactly that regime.

## Verification

- Built with host `lake env lean` against Mathlib 4.26.0 (Docker unavailable).
- `#print axioms` on all 7 theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- Sanity-check `example`s use kernel `decide`/`norm_num` — **no `native_decide`**, so `Lean.ofReduceBool` is not introduced. Status: `verified`, badge `verified`, axiomCount 0.
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)