### PR TITLE
research(seeker): replenish candidate pool with 4 verified-parent leaves

### DIFF
--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: binomial-theorem-oq-04-oq-02-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-03/literature/README.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for binomial-theorem-oq-04-oq-02-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-03/problem.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-03/problem.md
@@ -1,0 +1,123 @@
+# Problem: Central binomial as a sum of squared binomials
+
+**Slug**: binomial-theorem-oq-04-oq-02-oq-03
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\binom{2n}{n} = \sum_{k=0}^{n} \binom{n}{k}^2 \qquad (n \in \mathbb{N})
+$$
+
+### Plain Language
+
+The central binomial coefficient counts the number of ways to choose $n$ items
+from $2n$. Splitting the $2n$ items into two halves of size $n$ and summing over
+how many come from the first half gives the right-hand sum, where
+$\binom{n}{k}^2 = \binom{n}{k}\binom{n}{n-k}$. The goal is a machine-checked,
+axiom-free proof of this identity (the diagonal case of the Chu–Vandermonde
+identity).
+
+### Why This Matters
+
+This is one of the most-cited combinatorial identities: it underlies the
+asymptotics of $\binom{2n}{n}\sim 4^n/\sqrt{\pi n}$, the theory of Catalan
+numbers, and random-walk return probabilities. It is a clean, self-contained
+sibling of the parent gallery proof (binomial-theorem-oq-04-oq-02) and a good
+showcase of Mathlib's `Nat.choose` API.
+
+## Known Results
+
+### What's Already Proven
+
+- Chu–Vandermonde / Vandermonde's identity in Mathlib: `Nat.add_choose_eq`
+  (and `Nat.choose_symm`, `Nat.choose_symm_diff`).
+- The parent gallery proof `binomial-theorem-oq-04-oq-02` establishes the
+  surrounding binomial-coefficient machinery (verified, 0-axiom).
+
+### What's Still Open
+
+- A direct, registered Lean statement
+  `∑ k in range (n+1), (n.choose k)^2 = (2*n).choose n`.
+- Optionally, the bijective / double-counting narrative alongside the algebraic
+  Vandermonde route.
+
+### Our Goal
+
+Produce a verified, 0-axiom Lean proof of
+`∑ k ∈ Finset.range (n+1), (Nat.choose n k)^2 = Nat.choose (2*n) n`,
+reducing it to `Nat.add_choose_eq` with `a = b = n`, `k = n` and rewriting
+`n.choose (n-k) = n.choose k` via `Nat.choose_symm`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| binomial-theorem-oq-04-oq-02 | Direct parent; Vandermonde scaffolding | binomial coefficients |
+| combinations-formula-oq-02-oq-01 | Catalan generating function uses central binomials | generating functions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Vandermonde specialization**: instantiate `Nat.add_choose_eq` at $a=b=n$,
+   $k=n$; convert $\binom{n}{n-k}$ into $\binom{n}{k}$ with `Nat.choose_symm`.
+   - Why it might work: Mathlib already proves the general convolution.
+   - Risk: index bookkeeping over `Finset.antidiagonal` vs `Finset.range`.
+
+2. **Generating functions**: extract $[x^n]$ from $(1+x)^n(1+x)^n=(1+x)^{2n}$.
+   - Why it might work: matches the parent proof's polynomial framing.
+   - Risk: heavier `PowerSeries`/`Polynomial.coeff` plumbing than needed.
+
+### Key Difficulties
+
+- Reconciling the antidiagonal form of Mathlib's Vandermonde with the
+  `range (n+1)` summation index.
+- Keeping everything in $\mathbb{N}$ (no subtraction traps) or casting cleanly
+  to $\mathbb{Z}$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `Nat.add_choose_eq` (Vandermonde convolution).
+- Key lemma 2: `Nat.choose_symm` to turn $\binom{n}{n-k}$ into $\binom{n}{k}$.
+- Technical requirements: a reindexing lemma between `antidiagonal n` and
+  `range (n+1)`.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The general Vandermonde identity is already in Mathlib; this is its diagonal.
+- Similar diagonal/symmetry identities have been formalized in the gallery.
+- All required lemmas (`Nat.add_choose_eq`, `Nat.choose_symm`) exist.
+
+**Estimated Effort**:
+- Exploration: a few hours
+- If tractable: 1–2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Combinatorics.Choose.Vandermonde` — `Nat.add_choose_eq`.
+- `Mathlib.Data.Nat.Choose.Basic` — `Nat.choose_symm`, `Nat.choose_symm_diff`.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - binomial-coefficients
+  - vandermonde
+  - classic
+related_proofs:
+  - binomial-theorem-oq-04-oq-02
+  - combinations-formula-oq-02-oq-01
+difficulty: low
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/binomial-theorem-oq-04-oq-02-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-04-oq-02-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: binomial-theorem-oq-04-oq-02-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:43:16-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: combinations-formula-oq-01-oq-01-oq-01-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/literature/README.md
+++ b/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for combinations-formula-oq-01-oq-01-oq-01-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/problem.md
+++ b/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/problem.md
@@ -1,0 +1,121 @@
+# Problem: Lucas analogue of Cassini's identity
+
+**Slug**: combinations-formula-oq-01-oq-01-oq-01-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+L_{n-1}\,L_{n+1} - L_n^{\,2} = (-1)^{n-1}\cdot 5 \qquad (n \ge 1)
+$$
+
+where $L_n$ are the Lucas numbers $L_0 = 2,\; L_1 = 1,\; L_{n+2} = L_{n+1} + L_n$.
+
+### Plain Language
+
+Cassini's identity for Fibonacci numbers says $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$.
+The Lucas numbers satisfy the same recurrence but with seeds $2, 1$, and their
+Cassini-type identity carries an extra factor of $5$ (because the "discriminant"
+of the Lucas sequence is $5$): $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\cdot 5$. The
+goal is an axiom-free Lean proof over $\mathbb{Z}$.
+
+### Why This Matters
+
+The Lucas Cassini identity is the companion of the classical Fibonacci Cassini
+identity already in the gallery; the factor of $5$ encodes the link
+$L_n^2 - 5F_n^2 = 4(-1)^n$ between the two sequences. It is a clean induction
+that strengthens the gallery's Fibonacci/Lucas coverage.
+
+## Known Results
+
+### What's Already Proven
+
+- Mathlib has Fibonacci numbers (`Nat.fib`) and the Fibonacci Cassini identity
+  (`Nat.fib_add_two`, `Int` Cassini variants in the gallery).
+- The parent gallery proof `combinations-formula-oq-01-oq-01-oq-01` establishes
+  the diagonal-sum Lucas framework (verified, 0-axiom).
+
+### What's Still Open
+
+- A registered Lean definition of Lucas numbers over $\mathbb{Z}$ (or reuse of
+  `2 * fib (n+1) - fib n`) and a proof of the Cassini-with-5 identity.
+
+### Our Goal
+
+Define $L_n$ (directly by recurrence over $\mathbb{Z}$, or via
+$L_n = F_{n-1} + F_{n+1} = 2F_{n+1} - F_n$) and prove
+$L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\cdot 5$ for $n \ge 1$ by two-step induction
+(or by reducing to the Fibonacci Cassini identity plus $L_n^2 - 5F_n^2 = 4(-1)^n$).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| combinations-formula-oq-01-oq-01-oq-01 | Direct parent; Lucas diagonal sums | Pascal diagonals |
+| fibonacci-identities-oq-01-oq-03 | Fibonacci Cassini via Q-matrix determinant | matrix determinant |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Two-step induction on the recurrence**: track
+   $L_{n-1}L_{n+1} - L_n^2$ and show it flips sign each step.
+   - Why it might work: the recurrence makes the difference telescope to
+     $-(L_{n-2}L_n - L_{n-1}^2)$.
+   - Risk: base-case sign bookkeeping for $(-1)^{n-1}$.
+
+2. **Reduce to Fibonacci**: use $L_n = F_{n-1}+F_{n+1}$ and the known Fibonacci
+   Cassini identity plus $L_n^2 - 5F_n^2 = 4(-1)^n$.
+   - Why it might work: leverages Mathlib's `Nat.fib` Cassini machinery.
+   - Risk: casting `Nat.fib` to $\mathbb{Z}$ and managing $n-1$ index shifts.
+
+### Key Difficulties
+
+- Handling the $(-1)^{n-1}$ sign cleanly (work over $\mathbb{Z}$, not $\mathbb{N}$).
+- Index shifts at $n = 1$ when $L_{n-1} = L_0 = 2$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: a Lucas recurrence lemma `L (n+2) = L (n+1) + L n`.
+- Key lemma 2: the Fibonacci Cassini identity over $\mathbb{Z}$ (or a direct
+  inductive invariant).
+- Technical requirements: `Int`, `ring`, two-step (strong) induction.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- Pure recurrence induction; no deep Mathlib dependency required.
+- The Fibonacci Cassini analogue has already been formalized in the gallery.
+- `ring`/`omega`/`Int.induction`-style tactics handle the algebra.
+
+**Estimated Effort**:
+- Exploration: a few hours
+- If tractable: 1 day
+
+## References
+
+### Mathlib
+- `Mathlib.Data.Nat.Fib.Basic` — `Nat.fib`, recurrence and identities.
+- `Mathlib.Tactic.Ring` — closing the algebraic step.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - fibonacci
+  - lucas-numbers
+  - cassini
+related_proofs:
+  - combinations-formula-oq-01-oq-01-oq-01
+  - fibonacci-identities-oq-01-oq-03
+difficulty: low
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/state.md
+++ b/research/problems/combinations-formula-oq-01-oq-01-oq-01-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: combinations-formula-oq-01-oq-01-oq-01-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:43:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/de-moivre-oq-02-oq-03-oq-02/knowledge.md
+++ b/research/problems/de-moivre-oq-02-oq-03-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: de-moivre-oq-02-oq-03-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/de-moivre-oq-02-oq-03-oq-02/literature/README.md
+++ b/research/problems/de-moivre-oq-02-oq-03-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for de-moivre-oq-02-oq-03-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/de-moivre-oq-02-oq-03-oq-02/problem.md
+++ b/research/problems/de-moivre-oq-02-oq-03-oq-02/problem.md
@@ -1,0 +1,131 @@
+# Problem: Degree and leading coefficient of Chebyshev polynomials
+
+**Slug**: de-moivre-oq-02-oq-03-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For the Chebyshev polynomials of the first kind $T_n$ (defined by
+$T_0 = 1$, $T_1 = X$, $T_{n+2} = 2X\,T_{n+1} - T_n$):
+
+$$
+\deg T_n = n \quad\text{and}\quad \operatorname{lead}(T_n) = 2^{\,n-1}
+\qquad (n \ge 1).
+$$
+
+### Plain Language
+
+Chebyshev polynomials arise from de Moivre's formula via
+$\cos(n\theta) = T_n(\cos\theta)$. Each $T_n$ is a genuine degree-$n$ polynomial,
+and its top coefficient is $2^{n-1}$ for $n \ge 1$ (and $1$ for $n = 0$). The
+goal is an axiom-free Lean proof of the degree and leading-coefficient formulas
+straight from the recurrence.
+
+### Why This Matters
+
+These two facts are the gateway to the rest of Chebyshev theory: the minimax /
+equioscillation property, orthogonality, and the monic rescaling
+$2^{1-n}T_n$ that minimizes the sup norm on $[-1,1]$. They are a clean,
+self-contained companion to the parent de Moivre gallery proof and a good test of
+Mathlib's `Polynomial.Chebyshev` API.
+
+## Known Results
+
+### What's Already Proven
+
+- Mathlib defines `Polynomial.Chebyshev.T R n` with the defining recurrence
+  (`Polynomial.Chebyshev.T_add_two`).
+- Mathlib has `Polynomial.Chebyshev.natDegree_T` and leading-coefficient lemmas
+  in characteristic-zero / suitable rings (to be confirmed and reused).
+- Gallery parent `de-moivre-oq-02-oq-03` establishes the
+  $\cos(n\theta) = T_n(\cos\theta)$ bridge (verified, 0-axiom).
+
+### What's Still Open
+
+- A registered, self-contained statement of `natDegree (T ℤ n) = n` and
+  `leadingCoeff (T ℤ n) = 2^(n-1)` for $n \ge 1$, even if it merely repackages
+  existing Mathlib lemmas with the recurrence.
+
+### Our Goal
+
+Prove, over $\mathbb{Z}$ (or a general ordered/char-zero commutative ring):
+- `(Polynomial.Chebyshev.T ℤ n).natDegree = n` for all $n$ (with the $n = 0$ edge
+  case handled);
+- `(Polynomial.Chebyshev.T ℤ n).leadingCoeff = 2^(n-1)` for $n \ge 1$,
+  by strong/two-step induction on the recurrence $T_{n+2} = 2X T_{n+1} - T_n$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| de-moivre-oq-02-oq-03 | Direct parent; cos(nθ) = Tₙ(cos θ) bridge | de Moivre, induction |
+| de-moivre-oq-02-oq-03-oq-02 (this) | degree/leading-coeff base for minimax | polynomial degree |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Induction on the recurrence**: in $2X\,T_{n+1} - T_n$, the degree of the
+   first term ($1 + \deg T_{n+1} = n+2$) dominates $\deg T_n = n$, so degrees add
+   and the leading coefficient doubles each step.
+   - Why it might work: the recurrence makes both claims a one-step induction
+     once the dominance is established.
+   - Risk: ensuring `Polynomial.natDegree_add_eq_left_of_natDegree_lt` hypotheses
+     (no cancellation) hold at the top degree.
+
+2. **Reuse Mathlib lemmas** if `natDegree_T` / leading-coeff lemmas already exist,
+   reducing the task to packaging and the $2^{n-1}$ closed form.
+   - Why it might work: minimal new proof obligation.
+   - Risk: Mathlib may state these only over specific rings; may need a cast.
+
+### Key Difficulties
+
+- The $n = 0$ vs $n \ge 1$ split for the $2^{n-1}$ formula.
+- Degree-dominance bookkeeping so leading terms do not cancel in $2X T_{n+1}-T_n$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `Polynomial.Chebyshev.T_add_two` (the recurrence).
+- Key lemma 2: `Polynomial.natDegree_add_eq_left_of_natDegree_lt`,
+  `Polynomial.leadingCoeff` / `Polynomial.coeff_natDegree`.
+- Technical requirements: two-step induction, `ring`, degree lemmas over
+  $\mathbb{Z}$.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Mathlib already provides the Chebyshev recurrence and degree machinery.
+- The induction is short; the main care is the no-cancellation degree argument.
+- Similar polynomial degree/leading-coefficient inductions exist in the gallery.
+
+**Estimated Effort**:
+- Exploration: half a day
+- If tractable: 2–3 days
+
+## References
+
+### Mathlib
+- `Mathlib.RingTheory.Polynomial.Chebyshev` — `Polynomial.Chebyshev.T`,
+  `T_add_two`, degree lemmas.
+- `Mathlib.Algebra.Polynomial.Degree.Lemmas` — degree-of-sum / leading-coeff API.
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - polynomials
+  - chebyshev
+  - de-moivre
+related_proofs:
+  - de-moivre-oq-02-oq-03
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/de-moivre-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/de-moivre-oq-02-oq-03-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: de-moivre-oq-02-oq-03-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:43:19-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/pythagorean-triples-oq-08-oq-01/knowledge.md
+++ b/research/problems/pythagorean-triples-oq-08-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: pythagorean-triples-oq-08-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/pythagorean-triples-oq-08-oq-01/literature/README.md
+++ b/research/problems/pythagorean-triples-oq-08-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for pythagorean-triples-oq-08-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/pythagorean-triples-oq-08-oq-01/problem.md
+++ b/research/problems/pythagorean-triples-oq-08-oq-01/problem.md
@@ -1,0 +1,132 @@
+# Problem: Per-leg divisibility in primitive Pythagorean triples
+
+**Slug**: pythagorean-triples-oq-08-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a primitive Pythagorean triple $(a, b, c)$ with $a^2 + b^2 = c^2$,
+$\gcd(a,b) = 1$:
+
+$$
+\bigl(4 \mid a \ \veebar\ 4 \mid b\bigr) \quad\text{and}\quad
+\bigl(3 \mid a \ \veebar\ 3 \mid b\bigr),
+$$
+
+i.e. **exactly one** leg is divisible by $4$ and **exactly one** leg is
+divisible by $3$ (the stronger, per-leg form, not merely $12 \mid ab$).
+
+### Plain Language
+
+It is classical that in a primitive Pythagorean triple the product of the legs
+is divisible by $12$ (indeed $60 \mid abc$). The sharper statement pins this down
+to individual legs: one specific leg is a multiple of $4$ and one specific leg is
+a multiple of $3$ (these may or may not be the same leg). The goal is a verified,
+axiom-free Lean proof of this per-leg refinement.
+
+### Why This Matters
+
+The product divisibility ($12 \mid ab$, $60 \mid abc$) is already in the gallery;
+this leaf upgrades it to the precise per-leg statement, which is what one actually
+uses when reasoning about the $m, n$ parametrization
+$a = m^2 - n^2,\; b = 2mn,\; c = m^2 + n^2$. It exercises Mathlib's
+`PythagoreanTriple` API and `ZMod` case analysis.
+
+## Known Results
+
+### What's Already Proven
+
+- Mathlib `PythagoreanTriple` with the primitive classification
+  `PythagoreanTriple.isPrimitiveClassified` ($a = m^2-n^2$, $b = 2mn$ up to swap).
+- Gallery parent `pythagorean-triples-oq-08` (and `-oq-06-*`) establishes the
+  product-divisibility results ($12 \mid ab$, $60 \mid xyz$), verified, 0-axiom.
+
+### What's Still Open
+
+- The per-leg form: a registered statement that one **named** leg is divisible
+  by $4$ and one **named** leg by $3$ (exclusive-or over the two legs).
+
+### Our Goal
+
+Using the primitive parametrization, prove:
+- exactly one of $a, b$ is even and in fact divisible by $4$ (the $2mn$ leg,
+  since one of $m, n$ is even);
+- exactly one of $a, b$ is divisible by $3$ (case analysis on $m, n \bmod 3$).
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| pythagorean-triples-oq-08 | Direct parent; product-divisibility base | parametrization |
+| pythagorean-triples-oq-06-oq-01-oq-01 | $60 \mid xyz$ via ZMod case analysis | ZMod, decide |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Parametrize then ZMod case-split**: reduce to
+   $a = m^2-n^2,\; b = 2mn$ with $\gcd(m,n)=1$, $m \not\equiv n \pmod 2$, then
+   analyze residues mod $4$ and mod $3$.
+   - Why it might work: Mathlib supplies the classification; residue analysis is
+     `decide`/`omega`-friendly.
+   - Risk: the swap ambiguity ($a \leftrightarrow b$) requires careful "exactly
+     one leg" phrasing.
+
+2. **Direct ZMod 4 / ZMod 3 argument** from $a^2 + b^2 = c^2$ and coprimality,
+   without the full parametrization.
+   - Why it might work: squares mod 4 are $\{0,1\}$, mod 3 are $\{0,1\}$.
+   - Risk: extracting which specific leg carries the factor needs primitivity.
+
+### Key Difficulties
+
+- Phrasing "exactly one leg" (`Xor'` / exclusive-or) so the swap symmetry is
+  respected.
+- Bridging Mathlib's `PythagoreanTriple.isPrimitiveClassified` data to the
+  divisibility conclusions.
+
+### What Would a Proof Need?
+
+- Key lemma 1: primitive classification of the triple ($m, n$ with parity and
+  coprimality conditions).
+- Key lemma 2: squares mod $4$ and mod $3$ lie in $\{0,1\}$ (via `ZMod`/`decide`).
+- Technical requirements: `ZMod 4`, `ZMod 3`, `Int.emod`, `omega`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The product-divisibility cousins are already verified in the gallery.
+- Mathlib's `PythagoreanTriple` classification removes the hard number theory.
+- Remaining work is finite residue case analysis amenable to `decide`/`omega`.
+
+**Estimated Effort**:
+- Exploration: half a day
+- If tractable: 2–3 days
+
+## References
+
+### Mathlib
+- `Mathlib.NumberTheory.Pythagoras` / `Mathlib.NumberTheory.PythagoreanTriples`
+  — `PythagoreanTriple`, `isPrimitiveClassified`.
+- `Mathlib.Data.ZMod.Basic` — residue case analysis.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - pythagorean-triples
+  - divisibility
+  - modular-arithmetic
+related_proofs:
+  - pythagorean-triples-oq-08
+  - pythagorean-triples-oq-06-oq-01-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/pythagorean-triples-oq-08-oq-01/state.md
+++ b/research/problems/pythagorean-triples-oq-08-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: pythagorean-triples-oq-08-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T08:43:18-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Seeker pool replenishment. The Researcher candidate pool (`.lean/state/candidate-pool.json`) read 17 available, but 3 entries are now actively contested by live worktrees mining the same parent ids:

- `combinations-formula-oq-07-04-02` ← `r3-combi-thirdmoment`
- `fibonacci-identities-oq-05-01` ← `researcher-2` (weighted-alt-prod-oq0501)
- `geometric-series-…-oq-02-oq-01` (Eulerian descent count) ← `r5-eulerian-descent` (noted intractable, no Mathlib perm-descent API)

Net genuine-available ≈14 < threshold 15. This PR adds **4 fresh, tractable, verified-parent leaves**, bringing the pool to 18 available:

| Leaf | Statement | Engine |
|------|-----------|--------|
| `binomial-theorem-oq-04-oq-02-oq-03` | C(2n,n) = Σₖ C(n,k)² | `Nat.add_choose_eq` (diagonal Vandermonde) + `Nat.choose_symm` |
| `combinations-formula-oq-01-oq-01-oq-01-oq-02` | Lucas Cassini: L(n−1)L(n+1)−L(n)² = (−1)ⁿ⁻¹·5 | two-step induction / `Nat.fib` Cassini bridge |
| `pythagorean-triples-oq-08-oq-01` | primitive triple: exactly one leg ÷4, exactly one ÷3 | `PythagoreanTriple.isPrimitiveClassified` + ZMod case-split |
| `de-moivre-oq-02-oq-03-oq-02` | Chebyshev Tₙ: natDegree = n, leadingCoeff = 2ⁿ⁻¹ | `Polynomial.Chebyshev.T_add_two` induction |

Each parent proof is **verified / 0-axiom**; each leaf reduces to existing Mathlib infrastructure. All four `problem.md` stubs pass `validate-seeker-stubs.ts`.

## Notes
- DB (`knowledge.db`) and pool JSON (`.lean/state`, `research/candidate-pool.json`) are gitignored and already updated in the working tree so Researchers see the new candidates immediately; only the tracked `research/problems/<slug>/` stubs are in this PR.
- No `loom:review-requested` (math PR — deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)