### PR TITLE
research(divisibility-rules-oq-01-oq-01-oq-02): base-b digit-sum divisibility rule [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -992,6 +992,7 @@ import Proofs.DivisibilityRulesOQ01OQ02
 import Proofs.DivisibilityRulesOQ01OQ02OQ01
 import Proofs.DivisibilityRulesOQ01OQ01
 import Proofs.DivisibilityRulesOQ01OQ01OQ01
+import Proofs.DivisibilityRulesOQ01OQ01OQ02
 import Proofs.DivisibilityRulesOQ02
 import Proofs.DivisibilityRulesOQ04
 import Proofs.DivisibilityRulesOQ04OQ01

--- a/proofs/Proofs/DivisibilityRulesOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/DivisibilityRulesOQ01OQ01OQ02.lean
@@ -1,0 +1,132 @@
+/-
+# Base-b Divisibility Rule for Moduli Coprime to the Base
+
+OQ-02 follow-up to DivisibilityRulesOQ01OQ01 (divisibility-rules-oq-01-oq-01).
+
+The parent proof established, **in base 10**, that every `d > 1` coprime to `10`
+admits a digit-sum divisibility rule: there is some `k > 0` with
+
+  d ∣ n ↔ d ∣ (sum of the base-`10^k` digits of n).
+
+The argument was entirely base-agnostic — it only used that `10` is a unit
+modulo `d`, so that Euler's theorem forces `10^φ(d) ≡ 1 (mod d)`.  This file
+makes that observation explicit and proves the rule for an **arbitrary base**
+`b ≥ 2` coprime to `d`:
+
+  ∀ b ≥ 2, ∀ d > 1 with gcd(d, b) = 1, ∃ k > 0 such that
+    d ∣ n ↔ d ∣ (sum of digits of n in base b^k).
+
+The base-10 parent is recovered as the special case `b = 10`.
+
+## Proof Strategy
+
+For any unit `u` in `(ZMod d)ˣ`, Euler's theorem (`ZMod.pow_totient`) gives
+`u^φ(d) = 1`.  Taking `u = ZMod.unitOfCoprime b hcop.symm`, whose coercion is
+`(b : ZMod d)`, yields `(b : ZMod d)^φ(d) = 1`, i.e. `b^φ(d) ≡ 1 (mod d)`.
+Then `Nat.modEq_digits_sum` (working in base `b^φ(d)`) delivers the digit-sum
+rule.  None of these steps depends on the value `10`.
+
+## Results
+
+1. `pow_totient_mod_eq_one` — Euler's theorem in `ℕ` form:
+   `b^φ(d) % d = 1` whenever `1 < d` and `gcd(d, b) = 1` (any base `b`).
+2. `general_base_divisibility_rule_exists` — the headline generalization:
+   a digit-sum rule in base `b^k` exists for every base `b ≥ 2` and every
+   `d > 1` coprime to `b`.
+3. `general_divisibility_rule_base_ten` — the base-10 parent recovered as a
+   corollary (`b = 10`).
+
+## Tags
+number-theory, divisibility, modular-arithmetic, multiplicative-order,
+Euler-theorem, generalization
+-/
+
+import Mathlib.Data.Nat.Digits.Defs
+import Mathlib.Data.Nat.Digits.Lemmas
+import Mathlib.Data.ZMod.Units
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+namespace DivisibilityRulesOQ01OQ01OQ02
+
+open Nat BigOperators
+
+/-! ## Euler's theorem gives `b^φ(d) ≡ 1 (mod d)` for any base coprime to `d` -/
+
+/-- **Euler's theorem, `ℕ` form.** When `gcd(d, b) = 1` and `d > 1`,
+`b^φ(d) % d = 1`.  This is the base-agnostic engine of every digit-sum
+divisibility rule: it generalizes the parent's `10^φ(d) % d = 1`. -/
+theorem pow_totient_mod_eq_one {d b : ℕ} (hd : 1 < d) (hcop : Nat.Coprime d b) :
+    b ^ d.totient % d = 1 := by
+  -- `ZMod.pow_totient` needs `NeZero d`.
+  haveI hne : NeZero d := ⟨by omega⟩
+  -- View `b` as a unit of `ZMod d`.
+  let u := ZMod.unitOfCoprime b hcop.symm
+  -- Euler's theorem in the unit group: `u^φ(d) = 1`.
+  have hpow_unit : u ^ d.totient = 1 := ZMod.pow_totient u
+  -- Push down to `ZMod d`: `(u : ZMod d)^φ(d) = 1`.
+  have hpow : (u : ZMod d) ^ d.totient = 1 := by
+    have := congr_arg Units.val hpow_unit
+    simp only [Units.val_pow_eq_pow_val, Units.val_one] at this
+    exact this
+  -- The unit's coercion is exactly `(b : ZMod d)`.
+  have hcoe : (u : ZMod d) = b := by
+    simp [u, ZMod.unitOfCoprime]
+  rw [hcoe] at hpow
+  -- Lift back to a `ℕ` congruence `b^φ(d) ≡ 1 [MOD d]`.
+  have hmod : ((b ^ d.totient : ℕ) : ZMod d) = ((1 : ℕ) : ZMod d) := by
+    push_cast; exact hpow
+  rw [ZMod.natCast_eq_natCast_iff] at hmod
+  -- `1 % d = 1` since `d > 1`.
+  simp only [Nat.ModEq, Nat.mod_eq_of_lt hd] at hmod
+  exact hmod
+
+/-! ## Main Theorem: General Base-b Divisibility Rule Existence -/
+
+/-- **General base-`b` divisibility rule.** For every base `b ≥ 2` and every
+`d > 1` coprime to `b`, there exists `k > 0` such that `d ∣ n` iff `d` divides
+the sum of the base-`b^k` digits of `n`.
+
+The choice `k = φ(d)` always works: `b^φ(d) ≡ 1 (mod d)` by Euler's theorem
+(`pow_totient_mod_eq_one`), and `Nat.modEq_digits_sum` turns this into the
+digit-sum rule.  Taking `b = 10` recovers the classical decimal rule. -/
+theorem general_base_divisibility_rule_exists {b d : ℕ} (_hb : 2 ≤ b) (hd : 1 < d)
+    (hcop : Nat.Coprime d b) :
+    ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (b ^ k) n).sum := by
+  refine ⟨d.totient, Nat.totient_pos.mpr (by omega), fun n => ?_⟩
+  exact Nat.ModEq.dvd_iff
+    (Nat.modEq_digits_sum d (b ^ d.totient) (pow_totient_mod_eq_one hd hcop) n)
+    (dvd_refl d)
+
+/-! ## The base-10 parent recovered as a corollary -/
+
+/-- **Parent recovered (`b = 10`).** Specializing the general theorem to base
+`10` reproduces `DivisibilityRulesOQ01OQ01.general_divisibility_rule_exists`:
+every `d > 1` coprime to `10` has a decimal digit-sum rule. -/
+theorem general_divisibility_rule_base_ten {d : ℕ} (hd : 1 < d)
+    (hcop : Nat.Coprime d 10) :
+    ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (10 ^ k) n).sum :=
+  general_base_divisibility_rule_exists (by norm_num) hd hcop
+
+/-! ## Explicit witnesses across several bases -/
+
+/-- Base 2, modulus 3: `2^2 = 4 ≡ 1 (mod 3)`, so `k = 2` works. -/
+example : ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, 3 ∣ n ↔ 3 ∣ (Nat.digits (2 ^ k) n).sum :=
+  ⟨2, by omega, fun n => Nat.ModEq.dvd_iff
+    (Nat.modEq_digits_sum 3 (2 ^ 2) (by decide) n) (dvd_refl 3)⟩
+
+/-- Base 7, modulus 4: `gcd(4,7)=1` and `7^2 = 49 ≡ 1 (mod 4)`, so `k = 2`
+works (note `7 ≡ 3 (mod 4)`, so the single-digit `k = 1` rule fails). -/
+example : ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, 4 ∣ n ↔ 4 ∣ (Nat.digits (7 ^ k) n).sum :=
+  ⟨2, by omega, fun n => Nat.ModEq.dvd_iff
+    (Nat.modEq_digits_sum 4 (7 ^ 2) (by decide) n) (dvd_refl 4)⟩
+
+/-- Base 16, modulus 5: `16 ≡ 1 (mod 5)`, so `k = 1` works — the hexadecimal
+analogue of casting out nines. -/
+example : ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, 5 ∣ n ↔ 5 ∣ (Nat.digits (16 ^ k) n).sum :=
+  ⟨1, by omega, fun n => Nat.ModEq.dvd_iff
+    (Nat.modEq_digits_sum 5 (16 ^ 1) (by decide) n) (dvd_refl 5)⟩
+
+#check @general_base_divisibility_rule_exists
+
+end DivisibilityRulesOQ01OQ01OQ02

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-divr-oq01-oq01-oq02-header",
+    "proofId": "divisibility-rules-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "File Context: OQ-02 — Generalizing the Base-10 Rule to Arbitrary Bases",
+    "content": "This file is a follow-up (OQ-02) to DivisibilityRulesOQ01OQ01, which proved the digit-sum divisibility rule for base 10. The parent's own conclusion listed the open question 'Can the rule be extended to bases other than 10?' — and answered it informally ('Yes: replace 10 with any base b'). This file makes that precise and machine-checked: for any base b ≥ 2 and any d > 1 coprime to b, a base-b^k digit-sum rule exists, with k = φ(d). The parent is recovered as the b = 10 corollary.",
+    "mathContext": "The reduction $d \\mid n \\iff d \\mid (\\text{Nat.digits}(b^k, n)).\\text{sum}$ holds iff $b^k \\equiv 1 \\pmod d$, by `Nat.modEq_digits_sum`. Since $\\gcd(d,b)=1$, $b$ is a unit in $(\\mathbb{Z}/d\\mathbb{Z})^\\times$ and $b^{\\varphi(d)} = 1$ by Euler's theorem, so $k = \\varphi(d)$ works for every base.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "divisibility-rules-oq-01-oq-01",
+      "Nat.modEq_digits_sum",
+      "Euler's theorem",
+      "multiplicative order",
+      "DivisibilityRulesOQ01OQ01OQ02 namespace"
+    ],
+    "prerequisites": [
+      "DivisibilityRulesOQ01OQ01 parent proof",
+      "Nat.digits representation",
+      "modular congruences"
+    ]
+  },
+  {
+    "id": "ann-divr-oq01-oq01-oq02-euler",
+    "proofId": "divisibility-rules-oq-01-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 84 },
+    "type": "key-step",
+    "title": "Base-Agnostic Euler's Theorem: b^φ(d) ≡ 1 (mod d)",
+    "content": "pow_totient_mod_eq_one is the parent's ten_pow_totient_mod_eq_one with 10 replaced by a variable base b. It builds u = ZMod.unitOfCoprime b hcop.symm, applies ZMod.pow_totient to get u^φ(d) = 1, coerces through Units.val to (b : ZMod d)^φ(d) = 1, then casts back to ℕ via ZMod.natCast_eq_natCast_iff and simplifies 1 % d = 1 (using d > 1). The value of the base never enters — only its unit status does.",
+    "mathContext": "Euler's theorem: $(\\mathbb{Z}/d\\mathbb{Z})^\\times$ has order $\\varphi(d)$, so any unit $u$ satisfies $u^{\\varphi(d)} = 1$. With $u = b$ this is $b^{\\varphi(d)} \\equiv 1 \\pmod d$. The only base-specific fact, $(u : \\mathbb{Z}/d\\mathbb{Z}) = b$, holds for every $b$, so the lemma is fully general.",
+    "significance": "essential",
+    "relatedConcepts": ["ZMod.pow_totient", "ZMod.unitOfCoprime", "Euler's totient theorem"],
+    "prerequisites": ["ZMod units", "Euler's theorem"]
+  },
+  {
+    "id": "ann-divr-oq01-oq01-oq02-main",
+    "proofId": "divisibility-rules-oq-01-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 101 },
+    "type": "key-step",
+    "title": "Main Theorem: General Base-b Existence",
+    "content": "general_base_divisibility_rule_exists takes k = φ(d) (positive by Nat.totient_pos since d > 1) and closes the inner equivalence d ∣ n ↔ d ∣ (digits(b^k, n)).sum by feeding the base-agnostic Euler lemma to Nat.modEq_digits_sum and then Nat.ModEq.dvd_iff. The hypothesis 2 ≤ b is carried as a domain precondition for 'base b' to be meaningful but is unused in the proof (hence underscored).",
+    "mathContext": "`Nat.modEq_digits_sum d (b^{\\varphi(d)}) hb n` gives $n \\equiv (\\text{digits}(b^{\\varphi(d)}, n)).\\text{sum} \\pmod d$ once $b^{\\varphi(d)} \\% d = 1$; `Nat.ModEq.dvd_iff` upgrades the congruence to the divisibility equivalence.",
+    "significance": "essential",
+    "relatedConcepts": ["Nat.modEq_digits_sum", "Nat.ModEq.dvd_iff", "Nat.totient_pos"],
+    "prerequisites": ["digit sum congruences", "Euler's theorem"]
+  },
+  {
+    "id": "ann-divr-oq01-oq01-oq02-corollary",
+    "proofId": "divisibility-rules-oq-01-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 109 },
+    "type": "concept",
+    "title": "Recovering the Base-10 Parent as a Corollary",
+    "content": "general_divisibility_rule_base_ten instantiates the general theorem at b = 10 (with 2 ≤ 10 by norm_num), reproducing the parent's general_divisibility_rule_exists in one line. This certifies the generalization is faithful: it strictly contains the base-10 result.",
+    "mathContext": "Specialization $b := 10$ collapses the base-$b^k$ statement to the classical decimal digit-block rule. The generalization adds no axioms and loses no strength at $b = 10$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility-rules-oq-01-oq-01", "specialization"],
+    "prerequisites": ["main existence theorem"]
+  },
+  {
+    "id": "ann-divr-oq01-oq01-oq02-witnesses",
+    "proofId": "divisibility-rules-oq-01-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 128 },
+    "type": "example",
+    "title": "Cross-Base Witnesses: bases 2, 7, 16",
+    "content": "Three concrete non-decimal instances: base 2 mod 3 (k=2, since 4 ≡ 1 mod 3), base 7 mod 4 (k=2, since 49 ≡ 1 mod 4), and base 16 mod 5 (k=1, since 16 ≡ 1 mod 5 — the hexadecimal analogue of casting out nines). Each congruence b^k % d = 1 is discharged by kernel `decide` rather than `native_decide`, so the file introduces no Lean.ofReduceBool and remains genuinely 0-axiom.",
+    "mathContext": "The minimal k is the multiplicative order ord_d(b): ord_3(2) = 2, ord_4(7) = 2, ord_5(16) = 1. These illustrate that the universal witness k = φ(d) from the existence theorem is sufficient but generally not minimal.",
+    "significance": "illustrative",
+    "relatedConcepts": ["multiplicative order", "casting out nines", "kernel decide"],
+    "prerequisites": ["main existence theorem"]
+  }
+]

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "divisibility-rules-oq-01-oq-01-oq-02",
+  "title": "Base-b Divisibility Rule for Moduli Coprime to the Base",
+  "slug": "divisibility-rules-oq-01-oq-01-oq-02",
+  "description": "Generalizes the parent's base-10 digit-sum divisibility rule to an arbitrary base b ≥ 2. For every b ≥ 2 and every d > 1 with gcd(d, b) = 1, there exists k > 0 such that d ∣ n ↔ d ∣ (sum of the base-b^k digits of n). The witness k = φ(d) is given by Euler's theorem: b^φ(d) ≡ 1 (mod d). The base-10 parent is recovered as the special case b = 10. This answers the parent's listed open question: 'Can the rule be extended to bases other than 10?'",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DivisibilityRulesOQ01OQ01OQ02.lean",
+    "parentProofId": "divisibility-rules-oq-01-oq-01",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "multiplicative-order",
+      "Euler-theorem",
+      "generalization",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Fully machine-verified. All three theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — no Lean.ofReduceBool, since the illustrative base witnesses use kernel `decide` rather than `native_decide`).",
+    "dateAdded": "2026-06-24",
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.pow_totient",
+        "description": "Euler's theorem: a^φ(n) = 1 for any unit a in (ZMod n)ˣ",
+        "module": "Mathlib.Data.ZMod.Units"
+      },
+      {
+        "theorem": "ZMod.unitOfCoprime",
+        "description": "Constructs a unit in (ZMod n)ˣ from a coprimeness proof",
+        "module": "Mathlib.Data.ZMod.Units"
+      },
+      {
+        "theorem": "Nat.modEq_digits_sum",
+        "description": "When b' ≡ 1 (mod d), n ≡ (digits b' n).sum (mod d)",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.ModEq.dvd_iff",
+        "description": "Divisibility equivalence via modular congruence",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "General base-b existence theorem: ∀ b ≥ 2, ∀ d > 1 coprime to b, ∃ k > 0 such that d ∣ n ↔ d ∣ (digits(b^k, n)).sum",
+      "Base-agnostic Euler lemma: b^φ(d) % d = 1 for any base b coprime to d (the parent's 10^φ(d) % d = 1 is the b=10 slice)",
+      "Recovery of the base-10 parent as a one-line corollary (general_divisibility_rule_base_ten)",
+      "Cross-base witnesses: base 2 mod 3 (k=2), base 7 mod 4 (k=2), base 16 mod 5 (k=1, hexadecimal casting-out-nines), all via kernel decide"
+    ],
+    "prerequisites": [
+      "Euler's theorem and Euler's totient function",
+      "ZMod units and coprimeness",
+      "Nat.digits and digit sum congruences"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Digit-sum divisibility rules are classically tied to base 10 — 'casting out nines' exploits 10 ≡ 1 (mod 9), and Fibonacci's alternating-digit rule for 11 exploits 10 ≡ -1 (mod 11). But the underlying mechanism is base-independent: in any positional base b, the value of a numeral is congruent modulo d to a weighted sum of its digits, and when b ≡ 1 (mod d) those weights all collapse to 1, giving a plain digit-sum rule. Euler's totient theorem (1763) supplies the missing ingredient for arbitrary bases: whenever gcd(d, b) = 1, b^φ(d) ≡ 1 (mod d), so the base-b^φ(d) digit sum is always a valid test. Familiar non-decimal instances include the hexadecimal analogue of casting out nines (16 ≡ 1 mod 5, and mod 3), used historically in hand-checking hex arithmetic. This leaf (OQ-02) answers the explicit open question posed by the parent OQ-01 proof: 'Can the rule be extended to bases other than 10?'",
+    "problemStatement": "Prove that for every base b ≥ 2 and every d > 1 with gcd(d, b) = 1, there exists k > 0 such that for all n ∈ ℕ, d ∣ n ↔ d ∣ (Nat.digits (b^k) n).sum.",
+    "text": "For any base b ≥ 2 and any d > 1 coprime to b, a base-b^k digit-sum divisibility rule exists, with witness k = φ(d). Base 10 is the special case.",
+    "proofStrategy": "The parent's argument is reused verbatim with 10 replaced by a variable base b. By Euler's theorem (ZMod.pow_totient), the element b (as a unit in (ZMod d)ˣ via ZMod.unitOfCoprime b hcop.symm) satisfies b^φ(d) = 1 in ZMod d. Converting via ZMod.natCast_eq_natCast_iff gives b^φ(d) ≡ 1 (mod d) in ℕ. Then Nat.modEq_digits_sum (in base b^φ(d)) gives n ≡ (digits(b^k, n)).sum (mod d), and Nat.ModEq.dvd_iff turns this into the divisibility equivalence. The b = 10 specialization reproduces the parent.",
+    "keyInsights": [
+      "The parent's Euler-theorem argument never used the value 10 — only that 10 is a unit mod d. Replacing 10 by a variable base b is therefore immediate.",
+      "Euler's theorem gives b^φ(d) ≡ 1 (mod d) for ANY base b coprime to d (pow_totient_mod_eq_one).",
+      "Nat.modEq_digits_sum connects the congruence b^k ≡ 1 (mod d) to a base-b^k digit-sum rule.",
+      "The optimal k is the multiplicative order ord_d(b), which divides φ(d) by Lagrange; using k = φ(d) is sufficient.",
+      "b ≥ 2 is a domain precondition for 'base b' to be meaningful, but is not needed in the proof (the b = 1 case degenerates to the trivial identity d ∣ n ↔ d ∣ n).",
+      "Cross-base witnesses: base 16 mod 5 with k=1 is the hexadecimal analogue of casting out nines."
+    ],
+    "prerequisites": [
+      "Euler's theorem and totient function",
+      "ZMod units and coprimeness",
+      "Nat.digits representation",
+      "Modular congruences and divisibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "euler-engine",
+      "title": "Base-Agnostic Euler's Theorem b^φ(d) ≡ 1 (mod d)",
+      "startLine": 56,
+      "endLine": 84,
+      "summary": "pow_totient_mod_eq_one generalizes the parent's ten_pow_totient_mod_eq_one by replacing 10 with a variable base b. Constructs the NeZero instance, builds u = ZMod.unitOfCoprime b hcop.symm, applies ZMod.pow_totient, coerces through Units.val, casts back to ℕ via ZMod.natCast_eq_natCast_iff, and simplifies 1 % d = 1.",
+      "mathContext": "The group (ZMod d)ˣ has order φ(d). `ZMod.unitOfCoprime b hcop.symm` realizes b as a unit when gcd(b, d) = 1, and `ZMod.pow_totient u` gives u^φ(d) = 1. The coercion (u : ZMod d) = b is the only place the base enters, and it works for any b. Casting yields the ℕ statement b^φ(d) % d = 1."
+    },
+    {
+      "id": "main-existence",
+      "title": "Main Theorem: General Base-b Existence",
+      "startLine": 86,
+      "endLine": 101,
+      "summary": "general_base_divisibility_rule_exists provides witness k = φ(d) (positive by Nat.totient_pos) and closes the inner iff d ∣ n ↔ d ∣ (digits(b^k, n)).sum via Nat.ModEq.dvd_iff applied to Nat.modEq_digits_sum with the base-agnostic Euler lemma.",
+      "mathContext": "`Nat.modEq_digits_sum d (b^φ(d)) hb n` gives n ≡ (Nat.digits (b^φ(d)) n).sum (mod d) once hb : (b^φ(d)) % d = 1. `Nat.ModEq.dvd_iff` converts the congruence into the divisibility equivalence. The 2 ≤ b hypothesis is carried for statement hygiene (underscored, unused in the proof)."
+    },
+    {
+      "id": "parent-corollary",
+      "title": "Recovering the Base-10 Parent",
+      "startLine": 103,
+      "endLine": 109,
+      "summary": "general_divisibility_rule_base_ten specializes the general theorem to b = 10, reproducing the parent DivisibilityRulesOQ01OQ01.general_divisibility_rule_exists as a one-line corollary.",
+      "mathContext": "Instantiating b := 10 (with 2 ≤ 10 by norm_num) collapses the general statement to the classical decimal digit-block rule, demonstrating the generalization is faithful — it strictly contains the parent."
+    },
+    {
+      "id": "cross-base-witnesses",
+      "title": "Cross-Base Witnesses (bases 2, 7, 16)",
+      "startLine": 111,
+      "endLine": 128,
+      "summary": "Three illustrative instances in non-decimal bases: base 2 mod 3 (k=2, since 4 ≡ 1 mod 3), base 7 mod 4 (k=2, since 49 ≡ 1 mod 4), base 16 mod 5 (k=1, since 16 ≡ 1 mod 5). Each congruence is checked by kernel `decide` (keeping the file free of Lean.ofReduceBool).",
+      "mathContext": "These exhibit the multiplicative order ord_d(b) as the optimal block length: ord_3(2)=2, ord_4(7)=2, ord_5(16)=1. The base-16 mod 5 case is the hexadecimal analogue of casting out nines."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-rules-oq-01-oq-01",
+      "relationship": "follow-up",
+      "description": "Answers the parent's open question: can the base-10 digit-sum rule be extended to other bases? Yes — to any base b ≥ 2 coprime to d, with k = φ(d)."
+    },
+    {
+      "targetId": "divisibility-rules-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent: existence of a decimal digit-block rule for every d coprime to 10."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, base-independent proof that every d > 1 coprime to a base b ≥ 2 admits a base-b^k digit-sum divisibility rule, with k = φ(d) as a universal witness. The base-10 parent is the b = 10 corollary. 0 sorries, 0 axioms.",
+    "implications": "Unifies all positional digit-sum divisibility tests under a single Euler-theorem mechanism, independent of the choice of numeral base.",
+    "openQuestions": [
+      "For a fixed d and base b, what is the minimal block length? (It is the multiplicative order ord_d(b), which divides φ(d).)",
+      "When b ≡ -1 (mod d) for some power, one gets an alternating-block rule (as for 11 in base 10). Can the alternating variant be formalized in general base form?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "pow_totient_mod_eq_one",
+      "type": "core",
+      "description": "Base-agnostic Euler's theorem: b^φ(d) ≡ 1 (mod d) for any d > 1 coprime to b",
+      "leanType": "{d b : ℕ} → 1 < d → Nat.Coprime d b → b ^ d.totient % d = 1"
+    },
+    {
+      "name": "general_base_divisibility_rule_exists",
+      "type": "core",
+      "description": "Existence of a base-b^k digit-sum divisibility rule for any base b ≥ 2 and any d coprime to b",
+      "leanType": "{b d : ℕ} → 2 ≤ b → 1 < d → Nat.Coprime d b → ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (b ^ k) n).sum"
+    },
+    {
+      "name": "general_divisibility_rule_base_ten",
+      "type": "corollary",
+      "description": "Base-10 parent recovered: every d coprime to 10 has a decimal digit-block rule",
+      "leanType": "{d : ℕ} → 1 < d → Nat.Coprime d 10 → ∃ k : ℕ, 0 < k ∧ ∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (10 ^ k) n).sum"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Digits.Defs",
+      "Mathlib.Data.Nat.Digits.Lemmas",
+      "Mathlib.Data.ZMod.Units",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "BigOperators"
+    ],
+    "namespace": "DivisibilityRulesOQ01OQ01OQ02",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityRulesOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the parent **DivisibilityRulesOQ01OQ01** (digit-sum divisibility rule in base 10) to an **arbitrary base `b ≥ 2`**. This directly answers the parent proof's own listed open question:

> *"Can the rule be extended to bases other than 10? (Yes: replace 10 with any base b and take k = ord_d(b).)"*

**Main theorem** `general_base_divisibility_rule_exists`:
For every base `b ≥ 2` and every `d > 1` with `gcd(d, b) = 1`, there exists `k > 0` such that
```
d ∣ n  ↔  d ∣ (Nat.digits (b ^ k) n).sum
```
The witness `k = φ(d)` always works, since Euler's theorem gives `b^φ(d) ≡ 1 (mod d)`.

## Contents (3 theorems, 132 lines)

1. `pow_totient_mod_eq_one` — base-agnostic Euler's theorem `b^φ(d) % d = 1` (the parent's `10^φ(d) % d = 1` is the `b = 10` slice).
2. `general_base_divisibility_rule_exists` — the headline base-`b` existence theorem.
3. `general_divisibility_rule_base_ten` — the base-10 parent recovered as a one-line corollary (faithfulness check).

Plus cross-base witnesses: base 2 mod 3 (k=2), base 7 mod 4 (k=2), base 16 mod 5 (k=1, the hexadecimal analogue of casting out nines).

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all three theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- Cross-base witnesses use kernel `decide` (not `native_decide`), so **no `Lean.ofReduceBool`** is introduced.
- Built locally via host `lake env lean` against Mathlib (docker unavailable this session); compiles clean with no warnings.

## Gallery
`src/data/proofs/divisibility-rules-oq-01-oq-01-oq-02/` (meta.json + annotations.json), registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)