### PR TITLE
audit: clear 2 unaudited research leaves (euler-totient, fibonacci-cassini) — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21771,6 +21771,18 @@
       "lastAudited": "2026-06-24T15:49:36Z",
       "result": "clean",
       "issues": []
+    },
+    "euler-totient-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:12:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:12:18Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Batch-clears the 2 genuinely-tracked unaudited proofs at \`932befd3c09\`. Both **clean** — verified against Lean source.

| Proof | status/badge | Verdict |
|-------|-------------|---------|
| euler-totient-oq-03-oq-03 | verified/verified | ✅ clean |
| fibonacci-identities-oq-01-oq-03 | verified/original | ✅ clean |

### euler-totient-oq-03-oq-03
General composite-base totient power formula `φ(nᵏ⁺¹)=nᵏ·φ(n)` derived by induction on top of Mathlib's `Nat.totient_gcd_mul_totient_mul` (Mathlib only supplies the prime-base case `Nat.totient_prime_pow`). The foundational identity is openly credited in the docstring ("Mathlib / parent entry, restated"). No delegation opacity. 0 sorries, 0 axioms, 0 True stubs.

### fibonacci-identities-oq-01-oq-03
Cassini's identity `F(n+1)·F(n−1)−F(n)²=(−1)ⁿ` derived via an **original Q-matrix determinant engine**: `Q_pow_succ` (Fibonacci Q-matrix power law, proved by induction — absent from Mathlib) + determinant computed two ways. `mathlibDependencies` honestly lists the building blocks (`Nat.fib_add_two`, `Matrix.det_pow`, `det_fin_two_of`). Badge `original` justified by the novel matrix engine. Numeric checks use kernel `decide` (not `native_decide`) → no `Lean.ofReduceBool`. 0 sorries, 0 axioms.

### Not audited
- `bernoulli-inequality-oq-01-oq-02-oq-01` — untracked working-tree pollution (`meta.json` not in `origin/main`), correctly excluded.

Coverage → 3508/3509.

---
Discovered during autonomous gallery integrity audit. Tracker-only change (1 file).