### PR TITLE
research(fibonacci-identities-oq-02-oq-01-oq-01-oq-02): Fibonacci–Lucas sum-of-squares Lₙ²+5Fₙ²=2L₂ₙ & cross identity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2827,6 +2827,7 @@ import Proofs.FibonacciIdentitiesOQ01OQ02
 import Proofs.FibonacciIdentitiesOQ01OQ02OQ01
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ02OQ01
+import Proofs.FibonacciIdentitiesOQ02OQ01OQ01OQ02
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ03OQ01
 import Proofs.FibonacciIdentitiesOQ03OQ02

--- a/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02.lean
@@ -1,0 +1,110 @@
+import Proofs.FibonacciIdentitiesOQ02OQ01OQ01
+import Mathlib.Tactic
+
+/-
+# The Degree-2 Fibonacci–Lucas Relations
+
+## Open Question OQ-02-OQ-01-OQ-01-OQ-02
+
+The parent (OQ-02-OQ-01-OQ-01) established the *difference* of squares
+`Lₙ² − 5·Fₙ² = 4·(−1)ⁿ` (`lucas_sq_sub_five_fib_sq`) and used it to bound
+`gcd(Fₙ, Lₙ) ∣ 2`.  Its second open question asks for the **companion
+sum-of-squares identity** and the **cross identity**, together forming the full
+set of degree-2 relations between the Fibonacci and Lucas sequences:
+
+  Lₙ² + 5·Fₙ² = 2·L₂ₙ                        (sum of squares)            (★)
+  Lₙ · Fₙ     =   F₂ₙ                        (cross / doubling)          (✦)
+
+## Why (★) needs no sign
+
+The parent's difference identity `Lₙ² − 5Fₙ² = 4(−1)ⁿ` is *sign governed*: its
+right-hand side flips with the parity of `n`.  The **sum** (★), by contrast, is a
+pure polynomial identity in `Fₙ` and `Fₙ₊₁` with **no `(−1)ⁿ`** at all.  Writing
+`Lₙ = 2Fₙ₊₁ − Fₙ` (`lucas_eq_int`) and expanding the Lucas doubling
+`L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁` (from `fib_two_mul` and `fib_two_mul_add_one`),
+both sides of (★) collapse to the same quadratic `4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ²`.  So
+the sum-of-squares relation is the "sign-free half" of the degree-2 algebra, while
+the parent's difference carries all of the parity information.
+
+## A bridge back to the parent's sign
+
+Combining (★) with the parent's `Lₙ² = 5Fₙ² + 4(−1)ⁿ` recovers the classical
+**Lucas doubling formula** `L₂ₙ = Lₙ² − 2(−1)ⁿ` (`lucas_two_mul_eq_neg_one_pow`),
+showing (★) and the parent's difference identity are two faces of one fact.
+
+## Results
+
+1. `fib_two_mul_int` — the integer doubling `F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ)`, a cast of
+   Mathlib's `Nat.fib_two_mul` with the truncated subtraction discharged.
+2. `lucas_mul_fib` — the cross identity (✦) `Lₙ · Fₙ = F₂ₙ`.
+3. `lucas_two_mul_eq` — the Lucas doubling in `Fₙ, Fₙ₊₁` form
+   `L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁`.
+4. `lucas_sq_add_five_fib_sq` — the sum-of-squares identity (★) `Lₙ² + 5Fₙ² = 2L₂ₙ`.
+5. `lucas_two_mul_eq_neg_one_pow` — the Lucas doubling `L₂ₙ = Lₙ² − 2(−1)ⁿ`,
+   the bridge tying (★) to the parent's sign-carrying difference identity.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace FibonacciIdentitiesOQ02OQ01OQ01OQ02
+
+open Nat FibonacciIdentitiesOQ02OQ01OQ01
+
+/-- **Integer Fibonacci doubling.** `F₂ₙ = Fₙ · (2Fₙ₊₁ − Fₙ)` over `ℤ`.  This is
+    Mathlib's `Nat.fib_two_mul` with its truncated `ℕ` subtraction lifted to `ℤ`;
+    the side condition `Fₙ ≤ 2Fₙ₊₁` holds since `Fₙ ≤ Fₙ₊₁`. -/
+theorem fib_two_mul_int (n : ℕ) :
+    (fib (2 * n) : ℤ) = fib n * (2 * fib (n + 1) - fib n) := by
+  have h1 : fib n ≤ fib (n + 1) := fib_mono (show n ≤ n + 1 by omega)
+  have hle : fib n ≤ 2 * fib (n + 1) := by omega
+  have h := Nat.fib_two_mul n
+  zify [hle] at h
+  linarith [h]
+
+/-- **Integer Fibonacci odd doubling.** `F₂ₙ₊₁ = Fₙ₊₁² + Fₙ²` over `ℤ`, a cast of
+    Mathlib's `Nat.fib_two_mul_add_one` (which is already subtraction-free). -/
+theorem fib_two_mul_add_one_int (n : ℕ) :
+    (fib (2 * n + 1) : ℤ) = (fib (n + 1)) ^ 2 + (fib n) ^ 2 := by
+  exact_mod_cast Nat.fib_two_mul_add_one n
+
+/-- **Cross identity (✦).** `Lₙ · Fₙ = F₂ₙ`.  Immediate from `Lₙ = 2Fₙ₊₁ − Fₙ`
+    and the integer doubling `F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ)`. -/
+theorem lucas_mul_fib (n : ℕ) :
+    (lucas n : ℤ) * fib n = fib (2 * n) := by
+  rw [lucas_eq_int n, fib_two_mul_int n]; ring
+
+/-- **Lucas doubling in `Fₙ, Fₙ₊₁` form.**
+    `L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁`.  Expand `L₂ₙ = 2F₂ₙ₊₁ − F₂ₙ`
+    (`lucas_eq_int`) using the two integer doublings. -/
+theorem lucas_two_mul_eq (n : ℕ) :
+    (lucas (2 * n) : ℤ)
+      = 2 * (fib (n + 1)) ^ 2 + 3 * (fib n) ^ 2 - 2 * fib n * fib (n + 1) := by
+  rw [lucas_eq_int (2 * n), fib_two_mul_add_one_int n, fib_two_mul_int n]; ring
+
+/-- **Sum-of-squares identity (★).** `Lₙ² + 5·Fₙ² = 2·L₂ₙ`.  Unlike the parent's
+    *difference* `Lₙ² − 5Fₙ² = 4(−1)ⁿ`, the sum carries no sign: both sides reduce
+    to `4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ²`. -/
+theorem lucas_sq_add_five_fib_sq (n : ℕ) :
+    (lucas n : ℤ) ^ 2 + 5 * (fib n) ^ 2 = 2 * (lucas (2 * n)) := by
+  rw [lucas_eq_int n, lucas_two_mul_eq n]; ring
+
+/-- **Lucas doubling formula** `L₂ₙ = Lₙ² − 2(−1)ⁿ`.  The bridge between the
+    sign-free sum (★) and the parent's sign-carrying difference `Lₙ² = 5Fₙ² + 4(−1)ⁿ`
+    (`lucas_sq_eq`): substituting `5Fₙ² = Lₙ² − 4(−1)ⁿ` into (★) gives
+    `2L₂ₙ = 2Lₙ² − 4(−1)ⁿ`. -/
+theorem lucas_two_mul_eq_neg_one_pow (n : ℕ) :
+    (lucas (2 * n) : ℤ) = (lucas n) ^ 2 - 2 * (-1) ^ n := by
+  have h1 := lucas_sq_add_five_fib_sq n
+  have h2 := lucas_sq_eq n
+  linarith
+
+/-- Sanity check of (★) at `n = 5`: `L₅² + 5·F₅² = 11² + 5·25 = 246 = 2·123 = 2·L₁₀`. -/
+example : (lucas 5 : ℤ) ^ 2 + 5 * (fib 5) ^ 2 = 2 * (lucas 10) := by decide
+
+/-- Sanity check of the cross identity (✦) at `n = 6`: `L₆·F₆ = 18·8 = 144 = F₁₂`. -/
+example : (lucas 6 : ℤ) * fib 6 = fib 12 := by decide
+
+/-- Sanity check of the Lucas doubling at `n = 5` (odd): `L₁₀ = L₅² − 2(−1)⁵ = 121 + 2 = 123`. -/
+example : (lucas 10 : ℤ) = (lucas 5) ^ 2 - 2 * (-1) ^ 5 := by decide
+
+end FibonacciIdentitiesOQ02OQ01OQ01OQ02

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "fib-lucas-deg2-context",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "concept",
+    "title": "Completing the Degree-2 Fibonacci–Lucas Trio",
+    "content": "The parent proved the sign-carrying difference Lₙ² − 5Fₙ² = 4(−1)ⁿ. This entry adds its two companions — the sum-of-squares identity Lₙ² + 5Fₙ² = 2L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ — to complete the classical trio of quadratic relations between the Fibonacci and Lucas sequences. The three are the P = 1, Q = −1, D = 5 case of the general Lucas-sequence relations Vₙ² − D·Uₙ² = 4Qⁿ. Mathlib has no Lucas sequence, so the parent defines `lucas` from scratch and this file works over ℤ throughout."
+  },
+  {
+    "id": "fib-lucas-deg2-doubling-cast",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 62 },
+    "type": "technique",
+    "title": "Lifting Truncated ℕ Subtraction to ℤ",
+    "content": "Mathlib's Nat.fib_two_mul reads F₂ₙ = Fₙ·(2Fₙ₊₁ − Fₙ), but its subtraction is truncated ℕ subtraction. To use it inside an integer ring computation, fib_two_mul_int discharges the side condition Fₙ ≤ 2Fₙ₊₁ — itself from Fₙ ≤ Fₙ₊₁ (fib_mono) — and applies `zify [hle]` so the subtraction becomes honest integer subtraction. This cast is the only non-algebraic step in the whole file."
+  },
+  {
+    "id": "fib-lucas-deg2-signfree",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 84, "endLine": 90 },
+    "type": "insight",
+    "title": "Why the Sum Carries No Sign",
+    "content": "Substituting Lₙ = 2Fₙ₊₁ − Fₙ and the Fₙ, Fₙ₊₁ form of L₂ₙ, both sides of Lₙ² + 5Fₙ² = 2L₂ₙ collapse to the same quadratic 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ². No (−1)ⁿ ever appears — `ring` closes it outright. All of the parity information lives in the parent's difference identity; the sum is its sign-free dual."
+  },
+  {
+    "id": "fib-lucas-deg2-bridge",
+    "proofId": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "insight",
+    "title": "Sum and Difference Are One Fact",
+    "content": "Adding the sign-free sum Lₙ² + 5Fₙ² = 2L₂ₙ to the parent's sign-carrying difference Lₙ² = 5Fₙ² + 4(−1)ⁿ and cancelling the 5Fₙ² term returns the classical Lucas doubling formula L₂ₙ = Lₙ² − 2(−1)ⁿ. The two degree-2 identities are therefore two faces of a single relation, with `linarith` performing the recombination."
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+  "title": "The Degree-2 Fibonacci–Lucas Relations: Sum of Squares and Cross Identity",
+  "slug": "fibonacci-identities-oq-02-oq-01-oq-01-oq-02",
+  "description": "Answers the parent (OQ-02-OQ-01-OQ-01)'s own open question by completing the degree-2 algebra of the Fibonacci and Lucas sequences. The parent proved the sign-carrying difference Lₙ² − 5Fₙ² = 4(−1)ⁿ; this entry supplies its two companions: the sum-of-squares identity Lₙ² + 5Fₙ² = 2·L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ. The sum-of-squares relation is, strikingly, sign-free — written in Fₙ, Fₙ₊₁ via Lₙ = 2Fₙ₊₁ − Fₙ and the Mathlib doublings F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ), F₂ₙ₊₁ = Fₙ₊₁² + Fₙ², both sides collapse to 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ², with no (−1)ⁿ. Recombining the sum with the parent's difference recovers the classical Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ, exhibiting (★) and the parent's identity as two faces of one degree-2 fact.",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 110,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. All identities hold for every n : ℕ and are fully machine-checked over ℤ. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "fibonacci",
+      "lucas-numbers",
+      "sum-of-squares",
+      "fibonacci-doubling",
+      "degree-two-identity",
+      "number-theory",
+      "closed-form"
+    ],
+    "dateAdded": "2026-06-24",
+    "originalContributions": [
+      "lucas_sq_add_five_fib_sq: the sum-of-squares identity Lₙ² + 5·Fₙ² = 2·L₂ₙ, the sign-free companion to the parent's difference Lₙ² − 5Fₙ² = 4(−1)ⁿ, absent from Mathlib (which has no Lucas numbers)",
+      "lucas_mul_fib: the cross / doubling identity Lₙ · Fₙ = F₂ₙ over ℤ",
+      "lucas_two_mul_eq: the Lucas doubling in Fₙ, Fₙ₊₁ form L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁, the bridge expression that makes (★) a pure polynomial identity",
+      "lucas_two_mul_eq_neg_one_pow: the classical Lucas doubling formula L₂ₙ = Lₙ² − 2(−1)ⁿ, recovered by combining (★) with the parent's sign-carrying difference, showing the two are faces of one degree-2 fact",
+      "fib_two_mul_int: Mathlib's Nat.fib_two_mul lifted to ℤ with its truncated subtraction discharged (F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ)), the reusable casting step",
+      "Worked checks L₅² + 5·F₅² = 246 = 2·L₁₀, L₆·F₆ = 144 = F₁₂, and L₁₀ = L₅² + 2"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.lucas_eq_int",
+        "description": "The parent's bridge Lₙ = 2Fₙ₊₁ − Fₙ over ℤ, the definition that turns every Lucas occurrence into Fibonacci data so the identities become polynomial in Fₙ, Fₙ₊₁.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      },
+      {
+        "theorem": "FibonacciIdentitiesOQ02OQ01OQ01.lucas_sq_eq",
+        "description": "The parent's difference identity in the form Lₙ² = 5Fₙ² + 4(−1)ⁿ. Substituting it into the sign-free sum (★) is what recovers the classical Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ.",
+        "module": "Proofs.FibonacciIdentitiesOQ02OQ01OQ01"
+      },
+      {
+        "theorem": "Nat.fib_two_mul",
+        "description": "F₂ₙ = Fₙ·(2Fₙ₊₁ − Fₙ). Cast to ℤ (lifting the truncated subtraction with the side condition Fₙ ≤ 2Fₙ₊₁) it gives both the cross identity and the even half of the Lucas doubling.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_two_mul_add_one",
+        "description": "F₂ₙ₊₁ = Fₙ₊₁² + Fₙ², already subtraction-free. Supplies the odd half of L₂ₙ = 2F₂ₙ₊₁ − F₂ₙ.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_mono",
+        "description": "Monotonicity of Fibonacci, used to discharge the side condition Fₙ ≤ 2Fₙ₊₁ when lifting Nat.fib_two_mul's truncated subtraction to ℤ.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/FibonacciIdentitiesOQ02OQ01OQ01OQ02.lean",
+    "namespace": "FibonacciIdentitiesOQ02OQ01OQ01OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 110,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci and Lucas sequences satisfy a small algebra of quadratic relations. The classical trio at degree two is Lₙ² − 5Fₙ² = 4(−1)ⁿ, Lₙ² + 5Fₙ² = 2L₂ₙ, and LₙFₙ = F₂ₙ — the first carries the parity sign, the second is its sign-free dual, and the third is the doubling map. They are the P = 1, Q = −1, D = 5 case of the general Lucas-sequence relations Vₙ² − D·Uₙ² = 4Qⁿ. Mathlib formalizes Fibonacci (Nat.fib) with the doubling formulas but has no Lucas sequence at all, so the parent supplied a self-contained `lucas` and proved the difference identity; this entry completes the degree-2 trio. Because Mathlib's fib_two_mul and fib_two_mul_add_one express F₂ₙ and F₂ₙ₊₁ directly in Fₙ, Fₙ₊₁, all three relations reduce to polynomial algebra once Lₙ is rewritten via the parent's lucas_eq_int.",
+    "problemStatement": "Open Question OQ-02-OQ-01-OQ-01 (second open question of the parent): establish the companion sum-of-squares identity Lₙ² + 5·Fₙ² = 2·L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ together as the full set of degree-2 Fibonacci–Lucas relations, complementing the parent's difference identity Lₙ² − 5Fₙ² = 4(−1)ⁿ.",
+    "proofStrategy": "Rewrite every Lucas term through the parent's lucas_eq_int (Lₙ = 2Fₙ₊₁ − Fₙ) and expand the doublings via Mathlib. fib_two_mul gives F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ), cast to ℤ as fib_two_mul_int after discharging Fₙ ≤ 2Fₙ₊₁ (from fib_mono) so the truncated ℕ subtraction lifts cleanly; fib_two_mul_add_one gives F₂ₙ₊₁ = Fₙ₊₁² + Fₙ². The cross identity LₙFₙ = F₂ₙ is then one ring step. Expanding L₂ₙ = 2F₂ₙ₊₁ − F₂ₙ yields the Fₙ, Fₙ₊₁ form L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁ (lucas_two_mul_eq); substituting into Lₙ² + 5Fₙ² and into 2L₂ₙ, both sides reduce to 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ² and ring closes the sum-of-squares identity with no sign appearing. Finally, combining the sign-free sum with the parent's lucas_sq_eq (Lₙ² = 5Fₙ² + 4(−1)ⁿ) via linarith recovers the classical Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ.",
+    "keyInsights": [
+      "The sum-of-squares identity is sign-free where the parent's difference is sign-carrying: Lₙ² + 5Fₙ² = 2L₂ₙ has no (−1)ⁿ because, in Fₙ, Fₙ₊₁ coordinates, both sides are literally the same quadratic 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ². All the parity information lives in the parent's difference.",
+      "Mathlib's two doubling formulas are exactly the coordinate change needed: F₂ₙ and F₂ₙ₊₁ become polynomials in Fₙ, Fₙ₊₁, so every degree-2 Fibonacci–Lucas relation becomes a polynomial identity that ring discharges — no induction, no Cassini, no generating functions.",
+      "The only non-algebraic step is casting Nat.fib_two_mul's truncated subtraction 2Fₙ₊₁ − Fₙ to ℤ; the side condition Fₙ ≤ 2Fₙ₊₁ follows from monotonicity, after which zify makes the whole computation an integer ring identity.",
+      "Sum and difference are dual faces of one fact: adding the sign-free sum to the parent's sign-carrying difference and cancelling 5Fₙ² returns the Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ, the standard recurrence for doubling the index in a Lucas sequence.",
+      "Together with the parent, this pins down all three degree-2 relations, the D = 5 instance of Vₙ² − D·Uₙ² = 4Qⁿ — the natural next generalization to arbitrary Lucas sequences (P, Q)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Degree-2 Trio",
+      "startLine": 4,
+      "endLine": 47,
+      "summary": "Header stating OQ-02-OQ-01-OQ-01-OQ-02: the companion sum-of-squares identity Lₙ² + 5Fₙ² = 2L₂ₙ and cross identity LₙFₙ = F₂ₙ, why the sum is sign-free where the parent's difference carries (−1)ⁿ, and the bridge back to the parent via the Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ."
+    },
+    {
+      "id": "doublings",
+      "title": "Integer Fibonacci Doublings",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "fib_two_mul_int: F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ) over ℤ, lifting Mathlib's Nat.fib_two_mul by discharging the truncated subtraction with Fₙ ≤ 2Fₙ₊₁ (fib_mono); fib_two_mul_add_one_int: F₂ₙ₊₁ = Fₙ₊₁² + Fₙ², a direct cast. These are the coordinate change into Fₙ, Fₙ₊₁."
+    },
+    {
+      "id": "cross",
+      "title": "The Cross Identity",
+      "startLine": 70,
+      "endLine": 74,
+      "summary": "lucas_mul_fib: LₙFₙ = F₂ₙ over ℤ, one ring step from Lₙ = 2Fₙ₊₁ − Fₙ (lucas_eq_int) and the integer doubling fib_two_mul_int."
+    },
+    {
+      "id": "lucas-doubling",
+      "title": "The Lucas Doubling in Fibonacci Coordinates",
+      "startLine": 76,
+      "endLine": 82,
+      "summary": "lucas_two_mul_eq: L₂ₙ = 2Fₙ₊₁² + 3Fₙ² − 2FₙFₙ₊₁, obtained by expanding L₂ₙ = 2F₂ₙ₊₁ − F₂ₙ through the two integer doublings. This is the bridge expression that makes the sum-of-squares identity purely polynomial."
+    },
+    {
+      "id": "sum-of-squares",
+      "title": "The Sum-of-Squares Identity and the Sign Bridge",
+      "startLine": 84,
+      "endLine": 99,
+      "summary": "lucas_sq_add_five_fib_sq: Lₙ² + 5Fₙ² = 2L₂ₙ, where both sides reduce to 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ² (no sign); lucas_two_mul_eq_neg_one_pow: L₂ₙ = Lₙ² − 2(−1)ⁿ, recovered by combining the sign-free sum with the parent's lucas_sq_eq, plus numeric checks at n = 5, 6."
+    }
+  ],
+  "conclusion": {
+    "summary": "5 theorems, 0 sorries, 0 axioms. The sum-of-squares identity Lₙ² + 5·Fₙ² = 2·L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ complete the degree-2 Fibonacci–Lucas algebra begun by the parent's difference Lₙ² − 5Fₙ² = 4(−1)ⁿ. Every relation reduces, via the parent's Lₙ = 2Fₙ₊₁ − Fₙ and Mathlib's two Fibonacci doubling formulas, to a polynomial identity in Fₙ, Fₙ₊₁ that ring discharges; the sum-of-squares relation is sign-free, and recombining it with the parent's difference returns the classical Lucas doubling L₂ₙ = Lₙ² − 2(−1)ⁿ.",
+    "implications": "Completes the quadratic Fibonacci–Lucas relations that Mathlib omits (it has no Lucas sequence), packaging sum, difference, and product as one coherent degree-2 set. The proof template — rewrite Lucas via the linear bridge, expand index-doubling with Mathlib's fib_two_mul / fib_two_mul_add_one, then ring — extends verbatim to higher index identities (d'Ocagne, Vajda) and is the cleanest route to mechanizing Lucas-sequence algebra without a dedicated Lucas API. The D = 5 instance of Vₙ² − D·Uₙ² = 4Qⁿ sits one generalization away.",
+    "openQuestions": [
+      "Generalize the trio to an arbitrary Lucas sequence (P, Q) with discriminant D = P² − 4Q: prove Vₙ² − D·Uₙ² = 4Qⁿ, Vₙ² + D·Uₙ² = 2V₂ₙ, and VₙUₙ = U₂ₙ uniformly, recovering the present identities at P = 1, Q = −1, D = 5.",
+      "Prove the exact gcd value gcd(Fₙ, Lₙ) = 2 ⟺ 3 ∣ n (the parent's first open question), now that the cross identity LₙFₙ = F₂ₙ and the sum-of-squares relation pin down the even/odd structure of L₂ₙ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01-oq-01",
+      "relationship": "parent — proved the sign-carrying difference Lₙ² − 5Fₙ² = 4(−1)ⁿ and posed this sum-of-squares-plus-cross identity as its second open question; supplies lucas_eq_int and lucas_sq_eq, which this entry reuses for the sign-free sum and the Lucas-doubling bridge"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-02-oq-01",
+      "relationship": "grandparent — establishes the Fibonacci–Lucas bridge and doubling context from which the degree-2 relations descend"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **fibonacci-identities-oq-02-oq-01-oq-01**'s own second open question, completing the **degree-2 Fibonacci–Lucas algebra**.

The parent proved the *sign-carrying difference* `Lₙ² − 5Fₙ² = 4(−1)ⁿ`. This entry supplies its two companions:

- **Sum of squares (★):** `Lₙ² + 5·Fₙ² = 2·L₂ₙ` — strikingly **sign-free**: in Fₙ, Fₙ₊₁ coordinates both sides reduce to the same quadratic `4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ²`.
- **Cross identity (✦):** `Lₙ · Fₙ = F₂ₙ`.

Recombining (★) with the parent's difference recovers the classical **Lucas doubling** `L₂ₙ = Lₙ² − 2(−1)ⁿ`, showing the two are faces of one fact.

## Method

Rewrite Lucas via the parent's `lucas_eq_int` (`Lₙ = 2Fₙ₊₁ − Fₙ`) and expand index-doubling with Mathlib's `Nat.fib_two_mul` / `Nat.fib_two_mul_add_one`; every relation becomes a polynomial identity `ring` discharges. The only non-algebraic step lifts `fib_two_mul`'s truncated ℕ subtraction to ℤ (side condition `Fₙ ≤ 2Fₙ₊₁` from `fib_mono`).

## Verification

- **5 theorems, 0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; numeric checks use kernel `decide`, no `native_decide`/`ofReduceBool`).
- Compiles via `lake env lean` against the parent + Mathlib; `#print axioms` confirmed clean.
- Gallery: `meta.json` + `annotations.json` added; `annotations:validate --strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)