### PR TITLE
research(seeker): replenish candidate pool with 5 verified-parent leaves

### DIFF
--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/knowledge.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: area-of-circle-oq-07-oq-05-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/literature/README.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/literature/README.md
@@ -1,0 +1,17 @@
+# Literature for area-of-circle-oq-07-oq-05-oq-01-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- area-of-circle-oq-07-oq-05-oq-01 — parent; even Gaussian moments
+- area-of-circle-oq-07-oq-05-oq-01-oq-02 — sibling; scaled even moments
+- area-of-circle-oq-07-oq-02-oq-02 — cousin; half-line Gaussian moments
+
+## External References
+
+- Mathlib odd-function integral lemma; Gaussian integrability
+- Moments of the standard normal distribution

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/problem.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/problem.md
@@ -1,0 +1,121 @@
+# Problem: Vanishing of the odd Gaussian moments ∫ x^{2n+1} e^{-x²} dx = 0
+
+**Slug**: area-of-circle-oq-07-oq-05-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For every $n \in \mathbb{N}$,
+$$
+\int_{-\infty}^{\infty} x^{2n+1} e^{-x^2}\, dx \;=\; 0,
+$$
+and hence the full moment sequence is
+$$
+\int_{-\infty}^{\infty} x^{k} e^{-x^2}\, dx \;=\;
+\begin{cases} (k-1)!!\,\sqrt{\pi}/2^{k/2}, & k \text{ even},\\[2pt] 0, & k \text{ odd}.\end{cases}
+$$
+
+### Plain Language
+
+The parent entry (`area-of-circle-oq-07-oq-05-oq-01`) computes the **even** Gaussian moments
+$\int_{\mathbb R} x^{2n} e^{-x^2}\,dx = (2n-1)!!\sqrt\pi/2^n$. This leaf handles the **odd** moments:
+the integrand $x^{2n+1} e^{-x^2}$ is an odd function, so its integral over the whole line vanishes by
+symmetry. Combined with the parent, this gives the complete moment sequence for all $k$.
+
+### Why This Matters
+
+The odd moments vanishing is the analytic reason the centered Gaussian has zero mean and zero
+skewness (and all odd central moments zero). Together with the parent's even-moment formula it closes
+the full moment table $\int_{\mathbb R} x^k e^{-x^2}\,dx$ for every $k$ — the complete moment data of
+the (unnormalized) standard Gaussian.
+
+### Why the integral is $0$
+
+$f(x) = x^{2n+1} e^{-x^2}$ satisfies $f(-x) = -f(x)$ (odd power times the even Gaussian factor).
+The integral of an odd, integrable function over a symmetric domain $\mathbb R$ is $0$.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `area-of-circle-oq-07-oq-05-oq-01`: even moments $\int_{\mathbb R} x^{2n} e^{-x^2}\,dx = (2n-1)!!\sqrt\pi/2^n$ (verified).
+- Sibling `area-of-circle-oq-07-oq-05-oq-01-oq-02`: scaled even moments with rate $a > 0$.
+- Mathlib: integrability of Gaussian-weighted polynomials and `MeasureTheory.integral_eq_zero_of_odd` (odd-function integral lemma).
+
+### What's Still Open
+
+- The odd-moment vanishing and the assembled full moment sequence (this entry).
+
+### Our Goal
+
+Prove $\int_{\mathbb R} x^{2n+1} e^{-x^2}\,dx = 0$ from oddness of the integrand (Mathlib's
+odd-function integral lemma plus integrability of $x^{2n+1}e^{-x^2}$), then state the combined
+even/odd moment sequence as a corollary of the parent.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| area-of-circle-oq-07-oq-05-oq-01 | Direct parent; even Gaussian moments | double factorial, IBP recursion |
+| area-of-circle-oq-07-oq-05-oq-01-oq-02 | Sibling; scaled even moments | change of variables |
+| area-of-circle-oq-07-oq-02-oq-02 | Cousin; half-line Gaussian moments | integral_Ioi |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Odd-function symmetry**: show $x \mapsto x^{2n+1} e^{-x^2}$ is odd and integrable, then apply
+   Mathlib's `integral_eq_zero_of_odd` (or `MeasureTheory.integral_comp_neg` + antisymmetry).
+   - Why it might work: the vanishing is purely a symmetry statement; Mathlib has a direct lemma.
+   - Risk: discharging the integrability side condition for $x^{2n+1} e^{-x^2}$ (Gaussian decay
+     dominates any polynomial — `integrable_polynomial_mul_exp_neg_sq` style lemma).
+
+### Key Difficulties
+
+- Verifying integrability of the polynomial-times-Gaussian integrand to license the odd-integral lemma.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $f(x) = x^{2n+1} e^{-x^2}$ is odd (`Odd`/`Function.Odd`).
+- Key lemma 2: $f$ is integrable over $\mathbb R$ (Gaussian decay).
+- Key lemma 3: odd integrable function ⟹ integral $0$.
+- Corollary: assemble the full even/odd moment sequence with the parent.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- A one-step symmetry argument over an established Mathlib lemma; the only real work is the
+  integrability side condition, which has standard Gaussian-decay support.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1 day
+
+## References
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` — Gaussian integrability lemmas.
+- `Mathlib.MeasureTheory.Integral.*` — `integral_eq_zero_of_odd` / odd-function integral over ℝ.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - gaussian-integral
+  - moments
+  - symmetry
+related_proofs:
+  - area-of-circle-oq-07-oq-05-oq-01
+  - area-of-circle-oq-07-oq-05-oq-01-oq-02
+  - area-of-circle-oq-07-oq-02-oq-02
+difficulty: low
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: area-of-circle-oq-07-oq-05-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T09:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/knowledge.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: area-of-circle-oq-07-oq-05-oq-01-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/literature/README.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/literature/README.md
@@ -1,0 +1,17 @@
+# Literature for area-of-circle-oq-07-oq-05-oq-01-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- area-of-circle-oq-07-oq-05-oq-01 — parent; unit-scale even Gaussian moment
+- area-of-circle-oq-07-oq-02-oq-02 — sibling; half-line Gaussian moments
+- area-of-circle-oq-07 — ancestor; Gaussian integral √π
+
+## External References
+
+- Mathlib `integral_gaussian`, scaled Gaussian integrals, change-of-variables API
+- Standard normal-distribution moment formulas

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/problem.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/problem.md
@@ -1,0 +1,122 @@
+# Problem: Scaled Gaussian even moments ∫ x^{2n} e^{-a x²} dx = (2n-1)‼·√(π/a) / (2a)^n
+
+**Slug**: area-of-circle-oq-07-oq-05-oq-01-oq-02
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For $a > 0$ and $n \in \mathbb{N}$,
+$$
+\int_{-\infty}^{\infty} x^{2n} e^{-a x^2}\, dx \;=\; (2n-1)!!\,\sqrt{\frac{\pi}{a}}\,\frac{1}{(2a)^n}.
+$$
+
+### Plain Language
+
+The parent entry (`area-of-circle-oq-07-oq-05-oq-01`) proves the unit-scale even moment
+$\int_{\mathbb R} x^{2n} e^{-x^2}\,dx = (2n-1)!!\,\sqrt{\pi}/2^n$. This leaf generalizes the
+exponent rate to an arbitrary $a > 0$, tracking how the double-factorial recursion picks up powers
+of $a$ under the substitution $x \mapsto x/\sqrt{a}$.
+
+### Why This Matters
+
+The scaled Gaussian moment is the workhorse identity behind Gaussian-integral normalization,
+moment-generating functions of the normal distribution, and heat-kernel computations. Exhibiting the
+clean dependence on the rate $a$ — total mass $\sqrt{\pi/a}$ scaled by $(2n-1)!!/(2a)^n$ — completes
+the moment table started by the parent and the half-line sibling.
+
+### Why $(2n-1)!!\,\sqrt{\pi/a}/(2a)^n$
+
+Substitute $u = \sqrt{a}\,x$, so $x = u/\sqrt a$, $dx = du/\sqrt a$, and
+$x^{2n} = u^{2n} a^{-n}$. Then $\int x^{2n} e^{-a x^2}dx = a^{-n}\cdot a^{-1/2}\int u^{2n} e^{-u^2}du
+= a^{-n-1/2}\,(2n-1)!!\,\sqrt{\pi}/2^n = (2n-1)!!\,\sqrt{\pi/a}/(2a)^n$.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `area-of-circle-oq-07-oq-05-oq-01`: $\int_{\mathbb R} x^{2n} e^{-x^2}\,dx = (2n-1)!!\sqrt\pi/2^n$ (verified).
+- Sibling `area-of-circle-oq-07-oq-02-oq-02`: half-line Gaussian first/second moments (verified).
+- Mathlib: `integral_gaussian`, `integral_rpow_mul_exp_neg_mul_sq`, and the change-of-variables API.
+
+### What's Still Open
+
+- The arbitrary-rate generalization $a > 0$ via the rescaling substitution (this entry).
+
+### Our Goal
+
+Prove the scaled even-moment formula for all $a > 0$ by reducing to the parent's $a = 1$ case through
+the substitution $x \mapsto x/\sqrt a$ (Mathlib `MeasureTheory.integral_comp_smul` / `Measure.integral_comp_mul_left`
+style), then collecting the $a$-powers with `field_simp`/`ring` and `Real.sqrt` lemmas.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| area-of-circle-oq-07-oq-05-oq-01 | Direct parent; unit-scale even moment | double factorial, IBP recursion |
+| area-of-circle-oq-07-oq-02-oq-02 | Sibling; half-line Gaussian moments | integral_Ioi, change of variables |
+| area-of-circle-oq-07 | Ancestor; Gaussian integral √π | integral_gaussian |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Rescaling substitution to the parent's $a=1$ moment**: change variables $u=\sqrt a\,x$ and pull
+   out $a^{-n-1/2}$.
+   - Why it might work: the parent fully handles the double-factorial structure; only the scaling
+     bookkeeping is new.
+   - Risk: getting the `Real.sqrt`/`rpow` algebra right ($a^{-1/2} = 1/\sqrt a$, $(2a)^n = 2^n a^n$)
+     and matching Mathlib's change-of-variables lemma orientation.
+
+2. **Direct induction via integration by parts** mirroring the parent, carrying $a$ through the
+   recurrence $I_n = \tfrac{2n-1}{2a} I_{n-1}$.
+   - Fallback if the substitution route is awkward in Lean.
+
+### Key Difficulties
+
+- `Real.sqrt` arithmetic on $\sqrt{\pi/a} = \sqrt\pi/\sqrt a$ and combining with the $2^n a^n$ denominator.
+- Choosing the correct Mathlib change-of-variables lemma for the linear rescale.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the parent even moment at $a = 1$.
+- Key lemma 2: linear change of variables $u = \sqrt a\, x$ for the Gaussian integrand.
+- Final: `field_simp`/`ring` plus `Real.sqrt_div`/`Real.sqrt_mul` to assemble the closed form.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The hard analytic core (double-factorial even moment) is inherited verified; the new content is a
+  single rescaling substitution plus square-root algebra.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–3 days
+
+## References
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral` — `integral_gaussian`, scaled Gaussian integrals.
+- `Mathlib.MeasureTheory.Integral.*` — change-of-variables / `integral_comp_mul_left`.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - gaussian-integral
+  - moments
+  - double-factorial
+related_proofs:
+  - area-of-circle-oq-07-oq-05-oq-01
+  - area-of-circle-oq-07-oq-02-oq-02
+  - area-of-circle-oq-07
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/state.md
+++ b/research/problems/area-of-circle-oq-07-oq-05-oq-01-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: area-of-circle-oq-07-oq-05-oq-01-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T09:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/basel-problem-oq-10-oq-01/knowledge.md
+++ b/research/problems/basel-problem-oq-10-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: basel-problem-oq-10-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/basel-problem-oq-10-oq-01/literature/README.md
+++ b/research/problems/basel-problem-oq-10-oq-01/literature/README.md
@@ -1,0 +1,17 @@
+# Literature for basel-problem-oq-10-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- basel-problem-oq-10 — parent; Leibniz series = π/4, conditional convergence
+- basel-problem-oq-09-oq-01 — sibling; alternating zeta / parity split
+- basel-problem-oq-13 — cousin; λ(4) odd-power sum
+
+## External References
+
+- Alternating-series estimation theorem (Mathlib)
+- arctan/Leibniz series for π/4

--- a/research/problems/basel-problem-oq-10-oq-01/problem.md
+++ b/research/problems/basel-problem-oq-10-oq-01/problem.md
@@ -1,0 +1,120 @@
+# Problem: Explicit error bound for the Leibniz approximation of π/4
+
+**Slug**: basel-problem-oq-10-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For every $k \in \mathbb{N}$,
+$$
+\left| \sum_{i=0}^{k-1} \frac{(-1)^i}{2i+1} \;-\; \frac{\pi}{4} \right| \;\le\; \frac{1}{2k+1}.
+$$
+
+### Plain Language
+
+The parent entry (`basel-problem-oq-10`) shows that Leibniz's series
+$\sum_{i\ge0} \tfrac{(-1)^i}{2i+1} = \tfrac{\pi}{4}$ converges only conditionally. This leaf
+**quantifies** that convergence: the $k$-th partial sum differs from $\pi/4$ by at most
+$\tfrac{1}{2k+1}$, the standard alternating-series remainder bound, giving an explicit (and famously
+slow) rate for approximating $\pi/4$.
+
+### Why This Matters
+
+The bound makes the conditional convergence concrete and is the canonical worked example of the
+alternating-series estimation theorem: the tail of an alternating series with terms decreasing to $0$
+is bounded by the first omitted term $\tfrac{1}{2(k)+1}$. It quantifies exactly *why* Leibniz's
+series is useless for fast numerical computation of $\pi$.
+
+### Why the bound is $1/(2k+1)$
+
+The first omitted term after summing $i = 0,\dots,k-1$ is $\tfrac{(-1)^k}{2k+1}$, whose absolute
+value is $\tfrac{1}{2k+1}$. The alternating-series estimate says the remainder is bounded in absolute
+value by exactly this first dropped term.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `basel-problem-oq-10`: Leibniz series $\sum (-1)^i/(2i+1) = \pi/4$ converges conditionally (verified).
+- Mathlib: `Real.tendsto_sum_pi_div_four` (or the arctan/Leibniz `HasSum`), and alternating-series
+  estimate lemmas (`Antitone`/`tendsto_zero` ⟹ remainder bound).
+
+### What's Still Open
+
+- The explicit partial-sum error bound $\le 1/(2k+1)$ (this entry).
+
+### Our Goal
+
+Prove $\bigl|\sum_{i<k}(-1)^i/(2i+1) - \pi/4\bigr| \le 1/(2k+1)$ by instantiating Mathlib's
+alternating-series estimation theorem with $a_i = 1/(2i+1)$ (antitone, tending to $0$) and the
+parent's identification of the limit as $\pi/4$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| basel-problem-oq-10 | Direct parent; Leibniz series = π/4, conditional | arctan series, conditional convergence |
+| basel-problem-oq-09-oq-01 | Sibling cluster; alternating zeta values | HasSum, parity split |
+| basel-problem-oq-13 | Cousin; λ(4) odd-power sum | HasSum |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Apply the alternating-series estimation theorem**: with $a_i = \tfrac{1}{2i+1}$ antitone and
+   $a_i \to 0$, Mathlib bounds the remainder $|S - S_k|$ by $a_k = \tfrac{1}{2k+1}$. Combine with the
+   parent's limit value $S = \pi/4$.
+   - Why it might work: Mathlib has the alternating-series bound; the antitonicity and limit-zero of
+     $1/(2i+1)$ are routine `norm_num`/`gcongr` facts.
+   - Risk: matching the exact statement form of Mathlib's alternating bound lemma (which partial-sum
+     convention, `Finset.range` vs `∑'` tail) and aligning indices ($2k+1$ vs first-dropped-term).
+
+### Key Difficulties
+
+- Locating and matching the precise Mathlib alternating-series remainder lemma and its index/sign
+  conventions; converting between the tail sum and the partial-sum error.
+
+### What Would a Proof Need?
+
+- Key lemma 1: $a_i = 1/(2i+1)$ is antitone and tends to $0$.
+- Key lemma 2: alternating-series remainder bound $|S - S_k| \le a_k$ (Mathlib).
+- Key lemma 3: parent's $S = \pi/4$.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The limit value is inherited from the verified parent; the remaining work is applying a standard
+  Mathlib alternating-series estimate to an explicit antitone sequence.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Analysis.SpecificLimits.Basic` / alternating-series estimation lemmas.
+- `Mathlib.Analysis.SpecialFunctions.Trigonometric.ArctanDeriv` — arctan/Leibniz series for π/4.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - alternating-series
+  - pi
+  - error-bounds
+related_proofs:
+  - basel-problem-oq-10
+  - basel-problem-oq-09-oq-01
+  - basel-problem-oq-13
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/basel-problem-oq-10-oq-01/state.md
+++ b/research/problems/basel-problem-oq-10-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: basel-problem-oq-10-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T09:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/basel-problem-oq-14-oq-01/knowledge.md
+++ b/research/problems/basel-problem-oq-14-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: basel-problem-oq-14-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/basel-problem-oq-14-oq-01/literature/README.md
+++ b/research/problems/basel-problem-oq-14-oq-01/literature/README.md
@@ -1,0 +1,17 @@
+# Literature for basel-problem-oq-14-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- basel-problem-oq-14 — parent; η(4) = 7π⁴/720
+- basel-problem-oq-13-oq-01 — sibling; η(4) via odd/even split
+- basel-problem-oq-09-oq-01 — sibling; exponent-agnostic parity abstraction
+
+## External References
+
+- Mathlib `hasSum_zeta_nat`, general even-zeta values
+- Dirichlet eta function and its relation to the Riemann zeta function

--- a/research/problems/basel-problem-oq-14-oq-01/problem.md
+++ b/research/problems/basel-problem-oq-14-oq-01/problem.md
@@ -1,0 +1,125 @@
+# Problem: Uniform Dirichlet eta values η(2m) = (1 − 2^{1−2m}) ζ(2m)
+
+**Slug**: basel-problem-oq-14-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For every $m \ge 1$,
+$$
+\eta(2m) \;=\; \sum_{n=1}^{\infty} \frac{(-1)^{n+1}}{n^{2m}} \;=\; \bigl(1 - 2^{1-2m}\bigr)\,\zeta(2m),
+$$
+recovering $\eta(2) = \tfrac{\pi^2}{12}$, $\eta(4) = \tfrac{7\pi^4}{720}$, $\eta(6) = \tfrac{31\pi^6}{30240}$, …
+uniformly.
+
+### Plain Language
+
+The parent entry (`basel-problem-oq-14`) and its cluster derive specific Dirichlet eta values
+(e.g. $\eta(4) = 7\pi^4/720$) one exponent at a time. This leaf **abstracts the parity split into a
+single exponent-agnostic statement**: for *all* even arguments $2m$, the alternating zeta equals
+$(1 - 2^{1-2m})$ times the Riemann zeta, derived once from `hasSum_zeta_nat`. The individual values
+then fall out as one-line specializations.
+
+### Why This Matters
+
+A single uniform lemma $\eta(2m) = (1 - 2^{1-2m})\zeta(2m)$ replaces an open-ended family of
+per-exponent derivations and is the natural general form of the even/odd splitting argument. It
+demonstrates that the value $\zeta(2m)$ never enters the relation — the factor $(1 - 2^{1-2m})$ comes
+purely from removing the even-index sub-series $\sum_k (2k)^{-2m} = 2^{-2m}\zeta(2m)$.
+
+### Why the factor is $(1 − 2^{1−2m})$
+
+Split $\sum_n n^{-2m} = \sum_{\text{odd}} + \sum_{\text{even}}$ and
+$\eta(2m) = \sum_{\text{odd}} - \sum_{\text{even}}$. Since $\sum_{\text{even}} = 2^{-2m}\zeta(2m)$ and
+$\sum_{\text{odd}} = (1 - 2^{-2m})\zeta(2m)$, we get
+$\eta(2m) = (1 - 2^{-2m})\zeta(2m) - 2^{-2m}\zeta(2m) = (1 - 2\cdot 2^{-2m})\zeta(2m) = (1 - 2^{1-2m})\zeta(2m)$.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `basel-problem-oq-14`: $\eta(4) = 7\pi^4/720$ (verified).
+- Sibling `basel-problem-oq-13-oq-01`: $\eta(4)$ via the odd/even split (verified).
+- Sibling `basel-problem-oq-09-oq-01`: parity split λ(s) = (1 − 2^{−s})·Z exponent-agnostic abstraction (verified).
+- Mathlib: `riemannZeta`, `hasSum_zeta_nat` (general $\zeta(2k)$), and `HasSum` even/odd splitting.
+
+### What's Still Open
+
+- The single uniform statement $\eta(2m) = (1 - 2^{1-2m})\zeta(2m)$ for all $m$ (this entry).
+
+### Our Goal
+
+Prove the uniform relation parameterized by $m$ by an even/odd `HasSum` regrouping of the alternating
+zeta, with the even-index sub-series factored as $2^{-2m}\zeta(2m)$ — keeping $\zeta(2m)$ abstract so
+that the concrete values $\eta(2), \eta(4), \eta(6)$ are immediate corollaries via `hasSum_zeta_nat`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| basel-problem-oq-14 | Direct parent; η(4) = 7π⁴/720 | HasSum, parity split |
+| basel-problem-oq-13-oq-01 | Sibling; η(4) via odd/even split | hasSum_zeta_four |
+| basel-problem-oq-09-oq-01 | Sibling; exponent-agnostic λ(s) parity abstraction | HasSum even/odd |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Exponent-agnostic even/odd `HasSum` split**: model $\eta(2m)$ as $\sum_n (-1)^{n+1}n^{-2m}$,
+   split into even and odd indices via `hasSum_even_add_odd`, factor $2^{-2m}$ out of the even part,
+   and keep $\zeta(2m) = Z$ symbolic.
+   - Why it might work: sibling `basel-problem-oq-09-oq-01` already did the same abstraction for the
+     $\lambda$ relation; this is the eta analogue with the $(1 - 2^{1-2m})$ coefficient.
+   - Risk: handling the general exponent $2m$ in the `(2k)^{-2m} = 2^{-2m} k^{-2m}` factorization
+     (`mul_rpow`/`mul_pow` with even exponent) and the `HasSum` reindexing for arbitrary $m$.
+
+### Key Difficulties
+
+- Keeping the proof uniform in $m$ rather than specializing — the even-index factorization
+  $(2k)^{2m} = 2^{2m}k^{2m}$ must hold symbolically.
+- Aligning with `hasSum_zeta_nat` so the concrete π-power values specialize cleanly.
+
+### What Would a Proof Need?
+
+- Key lemma 1: even/odd `HasSum` split of $\sum_n (-1)^{n+1} n^{-2m}$.
+- Key lemma 2: $\sum_{k\ge1}(2k)^{-2m} = 2^{-2m} Z$ where $Z = \zeta(2m)$.
+- Key lemma 3: assemble $\eta(2m) = (1 - 2^{1-2m})Z$; specialize via `hasSum_zeta_nat`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The sibling λ-abstraction (`oq-09-oq-01`) provides a near-template; the new work is the eta sign
+  pattern and keeping the general even exponent $2m$ symbolic.
+
+**Estimated Effort**:
+- Exploration: hours–day
+- If tractable: 2–4 days
+
+## References
+
+### Mathlib
+- `Mathlib.NumberTheory.ZetaValues` — `hasSum_zeta_nat`, general even-zeta values.
+- `Mathlib.Topology.Algebra.InfiniteSum.*` — `HasSum` even/odd splitting and reindexing.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - zeta-function
+  - eta-function
+  - basel
+related_proofs:
+  - basel-problem-oq-14
+  - basel-problem-oq-13-oq-01
+  - basel-problem-oq-09-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/basel-problem-oq-14-oq-01/state.md
+++ b/research/problems/basel-problem-oq-14-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: basel-problem-oq-14-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T09:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/beta-integral-recurrence-oq-01-oq-01/knowledge.md
+++ b/research/problems/beta-integral-recurrence-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: beta-integral-recurrence-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/beta-integral-recurrence-oq-01-oq-01/literature/README.md
+++ b/research/problems/beta-integral-recurrence-oq-01-oq-01/literature/README.md
@@ -1,0 +1,17 @@
+# Literature for beta-integral-recurrence-oq-01-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- beta-integral-recurrence-oq-01 — parent; integer closed form of B(m,k)
+- gamma-reflection-formula-oq-01-oq-01-oq-01 — symmetric Beta values
+- combinations-formula-oq-02-oq-01 — central binomial / Catalan generating function
+
+## External References
+
+- Mathlib `Real.betaIntegral`, Beta–Gamma relation
+- Wallis product and central binomial coefficient identities

--- a/research/problems/beta-integral-recurrence-oq-01-oq-01/problem.md
+++ b/research/problems/beta-integral-recurrence-oq-01-oq-01/problem.md
@@ -1,0 +1,117 @@
+# Problem: Central-binomial closed form of the symmetric Beta integral B(n+1,n+1)
+
+**Slug**: beta-integral-recurrence-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+B(n+1,\,n+1) \;=\; \int_0^1 t^n (1-t)^n \, dt \;=\; \frac{(n!)^2}{(2n+1)!} \;=\; \frac{1}{(2n+1)\binom{2n}{n}}.
+$$
+
+### Plain Language
+
+The parent entry (`beta-integral-recurrence-oq-01`) establishes the Beta integral recurrence and its
+integer closed form $B(m,k) = \tfrac{(m-1)!\,(k-1)!}{(m+k-1)!}$. This leaf specializes to the
+**symmetric diagonal** $m = k = n+1$, giving the central-binomial / Wallis-type value
+$B(n+1,n+1) = \tfrac{(n!)^2}{(2n+1)!}$, and rewrites it in terms of the central binomial coefficient
+as $\tfrac{1}{(2n+1)\binom{2n}{n}}$.
+
+### Why This Matters
+
+The symmetric Beta integral $B(n+1,n+1)$ is exactly the normalizing constant of the symmetric
+$\mathrm{Beta}(n+1,n+1)$ density on $[0,1]$ (a polynomial bump concentrated at $t=\tfrac12$). The
+closed form ties the analytic integral to the discrete central binomial coefficient $\binom{2n}{n}$,
+and the $\tfrac{1}{(2n+1)\binom{2n}{n}}$ form is the cleanest bridge to Wallis-product and
+catalan-number identities.
+
+### Why $(n!)^2/(2n+1)!$
+
+From the integer closed form with $m=k=n+1$: $B(n+1,n+1)=\tfrac{n!\,n!}{(2n+1)!}$. Using
+$(2n+1)! = (2n+1)\cdot(2n)!$ and $\binom{2n}{n}=\tfrac{(2n)!}{(n!)^2}$, this equals
+$\tfrac{1}{(2n+1)}\cdot\tfrac{(n!)^2}{(2n)!} = \tfrac{1}{(2n+1)\binom{2n}{n}}$.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `beta-integral-recurrence-oq-01`: integer closed form $B(m,k)=\tfrac{(m-1)!(k-1)!}{(m+k-1)!}$ (verified).
+- Mathlib: `Real.betaIntegral`, `Real.Beta`, the Beta–Gamma relation, and `Nat.choose`/factorial API.
+
+### What's Still Open
+
+- The symmetric specialization and its central-binomial rewrite (this entry).
+
+### Our Goal
+
+Prove $B(n+1,n+1) = \tfrac{(n!)^2}{(2n+1)!} = \tfrac{1}{(2n+1)\binom{2n}{n}}$ by specializing the
+parent's closed form, then discharging the central-binomial rewrite with `Nat.choose` factorial
+identities (`Nat.choose_mul_factorial_le` / `Nat.add_choose` style) and `field_simp`/`ring`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| beta-integral-recurrence-oq-01 | Direct parent; integer closed form of B(m,k) | betaIntegral, Beta–Gamma |
+| gamma-reflection-formula-oq-01-oq-01-oq-01 | Symmetric Beta values B(s,1-s) | Gamma reflection |
+| combinations-formula-oq-02-oq-01 | Central binomial / Catalan generating function | binomial coefficients |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Specialize the parent closed form**: set $m=k=n+1$ in $B(m,k)=\tfrac{(m-1)!(k-1)!}{(m+k-1)!}$
+   and simplify $(n+1+n+1-1)! = (2n+1)!$.
+   - Why it might work: the parent already did the hard analytic work; this is arithmetic.
+   - Risk: the central-binomial rewrite needs $\binom{2n}{n}(n!)^2 = (2n)!$ as a `Nat` identity,
+     then casting to `ℝ` with `Nat.cast_*` lemmas before `field_simp`.
+
+### Key Difficulties
+
+- Converting the factorial closed form into the $\tfrac{1}{(2n+1)\binom{2n}{n}}$ form requires the
+  central-binomial factorial identity and careful `Nat` → `ℝ` casts (avoid division-by-zero traps).
+
+### What Would a Proof Need?
+
+- Key lemma 1: $B(n+1,n+1) = \tfrac{(n!)^2}{(2n+1)!}$ from the parent (direct specialization).
+- Key lemma 2: $\binom{2n}{n}\cdot (n!)^2 = (2n)!$ and $(2n+1)! = (2n+1)(2n)!$.
+- Final: `field_simp`/`ring` (or `norm_num`) to combine into $\tfrac{1}{(2n+1)\binom{2n}{n}}$.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The analytic content is inherited from the verified parent; the remaining work is factorial/binomial
+  algebra with established Mathlib lemmas.
+
+**Estimated Effort**:
+- Exploration: hours
+- If tractable: 1–2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Analysis.SpecialFunctions.Gamma.Beta` — `Real.betaIntegral`, Beta–Gamma relation.
+- `Mathlib.Data.Nat.Choose.Basic` / `Mathlib.Data.Nat.Factorial.BigOperators` — central binomial identities.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - beta-function
+  - binomial-coefficients
+  - wallis
+related_proofs:
+  - beta-integral-recurrence-oq-01
+  - gamma-reflection-formula-oq-01-oq-01-oq-01
+  - combinations-formula-oq-02-oq-01
+difficulty: medium
+source: gallery-gap
+created: 2026-06-24
+```

--- a/research/problems/beta-integral-recurrence-oq-01-oq-01/state.md
+++ b/research/problems/beta-integral-recurrence-oq-01-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: beta-integral-recurrence-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T09:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
## Summary

Seeker pool replenishment. The pool reported the 15-problem threshold, but `sync_pool` had already reclassified several contested candidates out, dropping the genuine available count to **11**, and a remaining entry (**Lucas–Cassini** `combinations-formula-oq-01-oq-01-oq-01-oq-02`) is still nominally available yet contested by a live researcher worktree.

This PR adds **5 fresh leaf problems**, each building directly on a **verified** parent gallery entry:

| Slug | Deliverable | Parent |
|------|-------------|--------|
| `beta-integral-recurrence-oq-01-oq-01` | B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) | beta-integral-recurrence-oq-01 |
| `area-of-circle-oq-07-oq-05-oq-01-oq-02` | ∫ x^{2n} e^{−a x²} dx = (2n−1)‼·√(π/a)/(2a)^n | area-of-circle-oq-07-oq-05-oq-01 |
| `area-of-circle-oq-07-oq-05-oq-01-oq-01` | ∫ x^{2n+1} e^{−x²} dx = 0 (odd symmetry), full moment sequence | area-of-circle-oq-07-oq-05-oq-01 |
| `basel-problem-oq-10-oq-01` | \|∑_{i<k}(−1)^i/(2i+1) − π/4\| ≤ 1/(2k+1) | basel-problem-oq-10 |
| `basel-problem-oq-14-oq-01` | η(2m) = (1−2^{1−2m})ζ(2m), uniform in m | basel-problem-oq-14 |

Each leaf answers an explicit open question listed on its verified parent's `meta.json`, is tractable with existing Mathlib API (Beta–Gamma, scaled/odd Gaussian integrals, alternating-series estimate, `hasSum_zeta_nat`), and spans diverse families (Beta/binomial, Gaussian moments, π approximation, eta values).

## Validation

`validate-seeker-stubs.ts` passes on all 5 slugs (no template placeholders).

Stub-only (no Lean/gallery files); candidate-pool JSON and the knowledge DB are regenerated locally by the seeker loop and are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)