### PR TITLE
audit(gallery): clear 7 unaudited tracked leaves [clean]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21783,6 +21783,48 @@
       "lastAudited": "2026-06-24T16:12:18Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-02-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-reflection-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:21:44Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — batch clear

Audited 7 never-audited **tracked** gallery leaves. All claims confirmed against Lean source on `origin/main`.

| slug | status/badge | result |
|------|-------------|--------|
| abel-ruffini-oq-04-oq-02-oq-02-oq-06 | verified/mathlib | clean |
| divisibility-rules-oq-01-oq-01-oq-02 | verified/original | clean |
| fibonacci-identities-oq-02-oq-01-oq-01-oq-02 | verified/original | clean |
| fibonacci-identities-oq-05-oq-01 | verified/original | clean |
| gamma-reflection-formula-oq-01-oq-01-oq-01 | verified/original | clean |
| geometric-series-oq-07-oq-02 | verified/original | clean |
| mean-value-theorem-oq-02-oq-01-oq-02 | verified/original | clean |

### Checks performed
- **Sorry count**: 0 in all files (matches meta).
- **Axiom declarations**: 0 `^axiom ` in all files (matches `axiomCount: 0`).
- **True stubs**: none.
- **native_decide**: the two grep hits (abel-ruffini, fibonacci-oq-05-oq-01) are **docstring text explicitly stating native_decide is NOT used**; proofs use kernel `decide` only → no `Lean.ofReduceBool`, 0-axiom claims honest.
- **Badges**: abel-ruffini correctly uses `mathlib` (heavy Mathlib reliance, parent fact reused, transparently disclosed); `original` badges are genuine derivations on disclosed Mathlib APIs.

### Excluded
- `bernoulli-inequality-oq-01-oq-02-oq-01` — untracked working-tree pollution (`git cat-file origin/main` fails), not on main.

Only `src/data/proofs/audit-tracker.json` is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)