### PR TITLE
research(combinations-formula-oq-01-oq-01-oq-01-oq-02): Lucas analogue of Cassini's identity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -795,6 +795,7 @@ import Proofs.CombinationsFormula
 import Proofs.CombinationsFormulaOQ01
 import Proofs.CombinationsFormulaOQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01
+import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle

--- a/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,118 @@
+/-
+Lucas analogue of Cassini's identity (OQ-01-OQ-01-OQ-01-OQ-02)
+
+Parent entry `combinations-formula-oq-01-oq-01-oq-01`
+("Companion Lucas-Number Shallow-Diagonal Identities") introduces the Lucas
+sequence `L 0 = 2, L 1 = 1, L (n+2) = L n + L (n+1)` (Mathlib has `Nat.fib` but
+no Lucas numbers) and the Lucas–Fibonacci bridge `L n + F n = 2·F(n+1)`.  It
+leaves open the *quantitative* second-order identities for the Lucas sequence.
+
+This file answers the **Lucas analogue of Cassini's identity**:
+
+  `L(n-1)·L(n+1) − L(n)² = (−1)^(n−1)·5`.
+
+Working over `ℤ` to accommodate the alternating sign, we prove:
+
+* `lucas_cassini`        — the subtraction-free shifted form
+                           `L n · L(n+2) − L(n+1)² = 5·(−1)^n`, by induction on
+                           the determinant alternation `D(n+1) = −D(n)`.
+* `lucas_cassini_pred`   — the literal predecessor form
+                           `L(n-1)·L(n+1) − L(n)² = (−1)^(n-1)·5` for `n ≥ 1`.
+* `fib_cassini`          — Cassini's identity for the Fibonacci numbers
+                           `F n · F(n+2) − F(n+1)² = (−1)^(n+1)` (Mathlib lacks it).
+* `lucas_sq_sub_five_fib_sq` — the companion `L(n)² − 5·F(n)² = 4·(−1)^n`, which
+                           exhibits where the constant `5` in Lucas–Cassini comes
+                           from: it is the discriminant of `x² − x − 1`.
+
+The Lucas sequence and the bridge `lucas_add_fib` are imported from the parent.
+Everything is axiom-free.
+-/
+
+import Mathlib
+import Proofs.CombinationsFormulaOQ01OQ01OQ01
+
+namespace CombinationsFormulaOQ01OQ01OQ01OQ02
+
+open CombinationsFormulaOQ01OQ01OQ01
+
+/-! ### Cassini's identity for the Lucas numbers -/
+
+/-- **Lucas analogue of Cassini's identity (shifted, subtraction-free form).**
+
+  `L n · L(n+2) − L(n+1)² = 5·(−1)^n`.
+
+For any sequence obeying `a(n+2) = a(n) + a(n+1)`, the "second-order determinant"
+`D(n) = a n · a(n+2) − a(n+1)²` satisfies `D(n+1) = −D(n)`; the proof is a direct
+induction using that alternation, with base value `D(0) = 2·3 − 1² = 5`. -/
+theorem lucas_cassini (n : ℕ) :
+    (lucas n : ℤ) * lucas (n + 2) - (lucas (n + 1) : ℤ) ^ 2 = 5 * (-1) ^ n := by
+  induction n with
+  | zero => norm_num [lucas]
+  | succ k ih =>
+      -- normalise the goal's index shapes `k+1+1 → k+2`, `k+1+2 → k+3`
+      simp only [show k + 1 + 1 = k + 2 from rfl, show k + 1 + 2 = k + 3 from rfl]
+      have e2 : (lucas (k + 2) : ℤ) = (lucas k : ℤ) + lucas (k + 1) := by
+        exact_mod_cast lucas_add_two k
+      have e3 : (lucas (k + 3) : ℤ) = (lucas (k + 1) : ℤ) + lucas (k + 2) := by
+        have h := lucas_add_two (k + 1)
+        simp only [show k + 1 + 2 = k + 3 from rfl, show k + 1 + 1 = k + 2 from rfl] at h
+        exact_mod_cast h
+      rw [e2] at ih
+      rw [e3, e2, pow_succ]
+      linear_combination -ih
+
+/-- **Lucas analogue of Cassini's identity (literal predecessor form).**
+
+  `L(n-1)·L(n+1) − L(n)² = (−1)^(n-1)·5`  for `n ≥ 1`. -/
+theorem lucas_cassini_pred (n : ℕ) (hn : 1 ≤ n) :
+    (lucas (n - 1) : ℤ) * lucas (n + 1) - (lucas n : ℤ) ^ 2 = (-1) ^ (n - 1) * 5 := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  show (lucas m : ℤ) * lucas (m + 2) - (lucas (m + 1) : ℤ) ^ 2 = (-1) ^ (m + 1 - 1) * 5
+  rw [Nat.add_sub_cancel]
+  linear_combination lucas_cassini m
+
+/-! ### Cassini's identity for the Fibonacci numbers
+
+Mathlib provides `Nat.fib` and `Nat.fib_add_two` but no Cassini identity, so we
+prove it here over `ℤ`; it is used below to locate the `5` in Lucas–Cassini. -/
+
+/-- **Cassini's identity for the Fibonacci numbers.**
+
+  `F n · F(n+2) − F(n+1)² = (−1)^(n+1)`.
+
+Same determinant alternation as the Lucas case, base value `F 0·F 2 − F 1² = −1`. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib n : ℤ) * Nat.fib (n + 2) - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  induction n with
+  | zero => norm_num
+  | succ k ih =>
+      have h2 : (Nat.fib (k + 1 + 1) : ℤ) = (Nat.fib k : ℤ) + Nat.fib (k + 1) := by
+        exact_mod_cast Nat.fib_add_two
+      have h3 : (Nat.fib (k + 1 + 2) : ℤ) = (Nat.fib (k + 1) : ℤ) + Nat.fib (k + 1 + 1) := by
+        exact_mod_cast Nat.fib_add_two
+      have h2' : (Nat.fib (k + 2) : ℤ) = (Nat.fib k : ℤ) + Nat.fib (k + 1) := by
+        exact_mod_cast Nat.fib_add_two
+      rw [h2'] at ih
+      rw [h3, h2, pow_succ]
+      linear_combination -ih
+
+/-! ### Where the `5` comes from -/
+
+/-- **Lucas–Fibonacci "Pell-like" companion.**  `L(n)² − 5·F(n)² = 4·(−1)^n`.
+
+This identity explains the constant `5` appearing in `lucas_cassini`: it is the
+discriminant `b² − 4·(−1)` for the recurrence `x² = x + 1` (i.e. of `x² − x − 1`),
+and here it links the Lucas and Fibonacci Cassini determinants.  Derived purely
+algebraically from the bridge `L n + F n = 2·F(n+1)` and `fib_cassini`. -/
+theorem lucas_sq_sub_five_fib_sq (n : ℕ) :
+    (lucas n : ℤ) ^ 2 - 5 * (Nat.fib n : ℤ) ^ 2 = 4 * (-1) ^ n := by
+  have hb : (lucas n : ℤ) + Nat.fib n = 2 * Nat.fib (n + 1) := by
+    exact_mod_cast lucas_add_fib n
+  have hf2 : (Nat.fib (n + 2) : ℤ) = (Nat.fib n : ℤ) + Nat.fib (n + 1) := by
+    exact_mod_cast Nat.fib_add_two
+  have hc := fib_cassini n
+  rw [hf2, pow_succ] at hc
+  linear_combination
+    ((lucas n : ℤ) + 2 * (Nat.fib (n + 1) : ℤ) - (Nat.fib n : ℤ)) * hb - 4 * hc
+
+end CombinationsFormulaOQ01OQ01OQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "combfml-oq01010102-ann-header",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "The Lucas–Cassini open question",
+    "content": "The parent entry introduces the Lucas numbers and the Lucas–Fibonacci bridge $L_n + F_n = 2F_{n+1}$, and lists the Lucas analogue of Cassini's identity, $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$, as an open question. This file answers it over $\\mathbb{Z}$, proving the subtraction-free shifted form, the literal predecessor form, Cassini's identity for the Fibonacci numbers, and the companion $L_n^2 - 5F_n^2 = 4(-1)^n$ that explains the constant $5$.",
+    "mathContext": "$L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$",
+    "significance": "key",
+    "relatedConcepts": ["Lucas numbers", "Cassini's identity", "second-order recurrence"],
+    "prerequisites": ["Lucas sequence", "Fibonacci sequence"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-lucas-cassini",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 62 },
+    "type": "theorem",
+    "title": "Lucas–Cassini via determinant alternation",
+    "content": "`lucas_cassini` proves the shifted, subtraction-free form $L_n L_{n+2} - L_{n+1}^2 = 5(-1)^n$. The engine is that for any sequence with $a_{n+2}=a_n+a_{n+1}$ the determinant $D(n)=a_n a_{n+2}-a_{n+1}^2$ satisfies $D(n+1)=-D(n)$; with $D(0)=2\\cdot 3-1^2=5$, one induction suffices. The inductive step substitutes the Lucas recurrence (`lucas_add_two`) into both the goal and the hypothesis and closes with `linear_combination -ih`. Index forms `k+1+1`, `k+1+2` are first normalised to `k+2`, `k+3` so the ring normaliser sees one atom per Lucas value.",
+    "mathContext": "$D(n) = L_n L_{n+2} - L_{n+1}^2,\\quad D(n+1) = -D(n),\\quad D(0)=5$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "linear recurrence determinant", "linear_combination"],
+    "prerequisites": ["induction on ℕ", "casting to ℤ"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-pred",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "theorem",
+    "title": "The literal predecessor form",
+    "content": "`lucas_cassini_pred` gives the classical statement $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$ for $n\\ge 1$. Writing $n = m+1$ turns natural-number subtraction $n-1$ into $m$, after which the goal is definitionally the shifted form `lucas_cassini m` (up to commuting $5\\cdot(-1)^m$), discharged by `linear_combination`.",
+    "mathContext": "$L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5,\\quad n\\ge 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["re-indexing", "ℕ subtraction avoidance"],
+    "prerequisites": ["lucas_cassini"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-fib-cassini",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 74, "endLine": 97 },
+    "type": "theorem",
+    "title": "Cassini's identity for the Fibonacci numbers",
+    "content": "`fib_cassini` proves $F_n F_{n+2} - F_{n+1}^2 = (-1)^{n+1}$ over $\\mathbb{Z}$ by the same determinant alternation, with base value $F_0 F_2 - F_1^2 = -1$. Mathlib provides `Nat.fib` and `Nat.fib_add_two` but no Cassini identity, so this is a reusable addition. It is also the lever for locating the constant $5$ in the Lucas case.",
+    "mathContext": "$F_n F_{n+2} - F_{n+1}^2 = (-1)^{n+1}$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "Fibonacci numbers", "Nat.fib_add_two"],
+    "prerequisites": ["induction on ℕ", "casting to ℤ"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-five",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 99, "endLine": 118 },
+    "type": "theorem",
+    "title": "Where the 5 comes from",
+    "content": "`lucas_sq_sub_five_fib_sq` proves the companion $L_n^2 - 5F_n^2 = 4(-1)^n$. Using the bridge in the form $L_n = 2F_{n+1} - F_n$ together with Fibonacci–Cassini, a single `linear_combination` reduces $L_n^2 - 5F_n^2$ to $4(F_{n+1}^2 - F_nF_{n+1} - F_n^2) = 4(-1)^n$. This makes explicit that the $5$ in Lucas–Cassini is the discriminant $1 - 4\\cdot(-1)$ of the characteristic polynomial $x^2 - x - 1$.",
+    "mathContext": "$L_n^2 - 5F_n^2 = 4(-1)^n;\\quad \\operatorname{disc}(x^2-x-1)=5$",
+    "significance": "key",
+    "relatedConcepts": ["discriminant", "Lucas–Fibonacci bridge", "linear_combination"],
+    "prerequisites": ["fib_cassini", "lucas_add_fib"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: combinationsFormulaOQ01OQ01OQ01OQ02Proof,
+  annotations: combinationsFormulaOQ01OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "title": "Lucas Analogue of Cassini's Identity",
+  "slug": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's listed open question: the Lucas analogue of Cassini's identity L(n-1)·L(n+1) − L(n)² = (−1)^(n−1)·5, over ℤ. The Lucas sequence and the Lucas–Fibonacci bridge are imported from the parent. We prove the subtraction-free shifted form L(n)·L(n+2) − L(n+1)² = 5·(−1)^n by induction on the determinant alternation D(n+1) = −D(n), recover the literal predecessor form, prove Cassini's identity for the Fibonacci numbers (absent from Mathlib), and give the companion identity L(n)² − 5·F(n)² = 4·(−1)^n that locates the constant 5 as the discriminant of x² − x − 1. Axiom-free.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "lucas-numbers",
+      "cassini-identity",
+      "second-order-recurrence",
+      "finite-sums"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext and Quot.sound for all four named results (no Classical.choice, no sorryAx, no native_decide / Lean.ofReduceBool). No axiom declarations and no sorries.",
+    "lineCount": 118,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "lucas_cassini: the Lucas analogue of Cassini's identity in subtraction-free shifted form, L(n)·L(n+2) − L(n+1)² = 5·(−1)^n, proved by induction on the determinant alternation D(n+1) = −D(n)",
+      "lucas_cassini_pred: the literal predecessor form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 for n ≥ 1",
+      "fib_cassini: Cassini's identity for the Fibonacci numbers, F(n)·F(n+2) − F(n+1)² = (−1)^(n+1), proved over ℤ (Mathlib has Nat.fib and Nat.fib_add_two but no Cassini identity)",
+      "lucas_sq_sub_five_fib_sq: the companion identity L(n)² − 5·F(n)² = 4·(−1)^n, derived algebraically from the Lucas–Fibonacci bridge and fib_cassini, exhibiting the constant 5 as the discriminant of x² − x − 1"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity F(n−1)·F(n+1) − F(n)² = (−1)^n (Cassini 1680, rediscovered by Simson) is the prototypical second-order Fibonacci identity. Its Lucas counterpart L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 carries an extra factor of 5 — the discriminant of the characteristic polynomial x² − x − 1 of the Fibonacci/Lucas recurrence. The parent entry (combinations-formula-oq-01-oq-01-oq-01) introduced the Lucas numbers in Lean (Mathlib has Nat.fib but no Lucas sequence) and posed the Lucas–Cassini identity as one of its open questions.",
+    "problemStatement": "Prove the Lucas analogue of Cassini's identity over ℤ, reusing the parent's Lucas sequence and Lucas–Fibonacci bridge, and explain the appearance of the constant 5.",
+    "text": "Writing D(n) = L(n)·L(n+2) − L(n+1)² for the second-order determinant of the Lucas sequence, the recurrence L(n+2) = L(n) + L(n+1) forces the alternation D(n+1) = −D(n): substituting the recurrence into D(n+1) and into D(n) shows both equal ±(L(n+1)² − L(n)·L(n+1) − L(n)²). With base value D(0) = 2·3 − 1² = 5, a single induction gives the subtraction-free shifted form L(n)·L(n+2) − L(n+1)² = 5·(−1)^n; specialising at the predecessor index recovers the classical statement L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 for n ≥ 1. The same determinant alternation, with base value F(0)·F(2) − F(1)² = −1, proves Cassini's identity for the Fibonacci numbers F(n)·F(n+2) − F(n+1)² = (−1)^(n+1) — which Mathlib does not provide. Finally, the bridge L(n) + F(n) = 2·F(n+1) (so L(n) = 2F(n+1) − F(n)) combined with Fibonacci–Cassini yields the companion L(n)² − 5·F(n)² = 4·(−1)^n by a purely algebraic linear combination, making explicit that the 5 in Lucas–Cassini is the discriminant 1 − 4·(−1) of x² − x − 1.",
+    "proofStrategy": "Prove the shifted Lucas–Cassini identity by one-step induction on the determinant alternation D(n+1) = −D(n), discharging the inductive step with linear_combination against the hypothesis after substituting the Lucas recurrence; derive the predecessor form by re-indexing; prove Fibonacci–Cassini the same way; and obtain the L² − 5F² companion as a linear combination of the Lucas–Fibonacci bridge and Fibonacci–Cassini.",
+    "keyInsights": [
+      "For any sequence satisfying a(n+2) = a(n) + a(n+1), the second-order determinant D(n) = a(n)·a(n+2) − a(n+1)² alternates: D(n+1) = −D(n). Both Cassini identities are this single fact with different base values (5 for Lucas, −1 for Fibonacci).",
+      "Working over ℤ (casting the natural-number Lucas and Fibonacci values) is what lets the alternating sign (−1)^n be expressed directly; the shifted form L(n)·L(n+2) − L(n+1)² avoids natural-number subtraction entirely.",
+      "The constant 5 in Lucas–Cassini is the discriminant of x² − x − 1: the companion identity L(n)² − 5·F(n)² = 4·(−1)^n makes this precise, and follows from the bridge L(n) = 2F(n+1) − F(n) together with Fibonacci–Cassini by a one-line linear_combination.",
+      "Index bookkeeping (k+1+1 vs k+2, k+1+2 vs k+3) is handled by rewriting with definitional equalities so that linear_combination's ring normaliser sees a single atom per Lucas/Fibonacci value."
+    ],
+    "prerequisites": [
+      "The parent's Lucas sequence lucas, its recurrence lucas_add_two, and the Lucas–Fibonacci bridge lucas_add_fib (L(n) + F(n) = 2·F(n+1))",
+      "Mathlib's Fibonacci numbers Nat.fib and the recurrence Nat.fib_add_two",
+      "The linear_combination tactic for polynomial identities over ℤ"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Lucas analogue of Cassini's identity is proved over ℤ in both the subtraction-free shifted form L(n)·L(n+2) − L(n+1)² = 5·(−1)^n and the literal predecessor form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5. Cassini's identity for the Fibonacci numbers is proved alongside (Mathlib lacks it), and the companion L(n)² − 5·F(n)² = 4·(−1)^n identifies the constant 5 as the discriminant of x² − x − 1. 4 theorems, 118 lines, axiom-free.",
+    "implications": "Resolves the parent's listed Lucas–Cassini open question and adds the Fibonacci Cassini identity to the gallery as a reusable ℤ-level lemma. The unifying determinant alternation D(n+1) = −D(n) packages all three identities under one mechanism.",
+    "openQuestions": [
+      "Prove the Catalan–Cassini generalisation L(n−r)·L(n+r) − L(n)² = (−1)^(n−r)·5·F(r)² (and its Fibonacci counterpart F(n−r)·F(n+r) − F(n)² = (−1)^(n−r+1)·F(r)²), recovering Cassini at r = 1.",
+      "Formalise the matrix/determinant viewpoint: express both Cassini identities as det of the 2×2 'shift matrix' raised to the n-th power, deriving the sign from det = −1."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CombinationsFormulaOQ01OQ01OQ01OQ02",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: introduces the Lucas sequence and the Lucas–Fibonacci bridge L(n)+F(n)=2·F(n+1), and lists the Lucas analogue of Cassini's identity as an open question. This entry answers it and reuses the bridge."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "related",
+      "description": "Fibonacci summation and product identities; this entry adds Cassini's identity for the Fibonacci numbers (F(n)·F(n+2)−F(n+1)²=(−1)^(n+1)) and its Lucas counterpart."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "States the goal — the parent's Lucas–Cassini open question — and lists the four results: the shifted and predecessor Lucas–Cassini forms, Fibonacci–Cassini, and the L²−5F² companion. Imports Mathlib and the parent file."
+    },
+    {
+      "title": "Lucas analogue of Cassini's identity",
+      "startLine": 38,
+      "endLine": 72,
+      "summary": "lucas_cassini: the subtraction-free shifted form L(n)·L(n+2)−L(n+1)²=5·(−1)^n, by induction on the determinant alternation D(n+1)=−D(n) with base D(0)=5; the index forms are normalised so linear_combination closes the step. lucas_cassini_pred: the literal predecessor form L(n−1)·L(n+1)−L(n)²=(−1)^(n−1)·5 for n≥1, by re-indexing."
+    },
+    {
+      "title": "Cassini's identity for the Fibonacci numbers",
+      "startLine": 74,
+      "endLine": 97,
+      "summary": "fib_cassini: F(n)·F(n+2)−F(n+1)²=(−1)^(n+1), proved over ℤ by the same determinant alternation with base F(0)·F(2)−F(1)²=−1. Mathlib provides Nat.fib and Nat.fib_add_two but no Cassini identity."
+    },
+    {
+      "title": "Where the 5 comes from",
+      "startLine": 99,
+      "endLine": 118,
+      "summary": "lucas_sq_sub_five_fib_sq: L(n)²−5·F(n)²=4·(−1)^n, derived from the bridge L(n)=2·F(n+1)−F(n) and fib_cassini by a single linear_combination, exhibiting the 5 in Lucas–Cassini as the discriminant of x²−x−1."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (`combinations-formula-oq-01-oq-01-oq-01`, "Companion Lucas-Number Shallow-Diagonal Identities") **listed open question**: the Lucas analogue of Cassini's identity, over ℤ. Reuses the parent's Lucas sequence and Lucas–Fibonacci bridge.

## Results (4 theorems, axiom-free)

- **`lucas_cassini`** — subtraction-free shifted form `L(n)·L(n+2) − L(n+1)² = 5·(−1)^n`, proved by induction on the determinant alternation `D(n+1) = −D(n)` with base `D(0) = 2·3 − 1² = 5`.
- **`lucas_cassini_pred`** — the literal classical form `L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5` for `n ≥ 1`, by re-indexing.
- **`fib_cassini`** — Cassini's identity for the Fibonacci numbers `F(n)·F(n+2) − F(n+1)² = (−1)^(n+1)`, proved over ℤ (Mathlib has `Nat.fib` and `Nat.fib_add_two` but no Cassini identity).
- **`lucas_sq_sub_five_fib_sq`** — companion `L(n)² − 5·F(n)² = 4·(−1)^n`, derived from the bridge and `fib_cassini`, exhibiting the constant `5` as the discriminant of `x² − x − 1`.

## Key idea

For any sequence with `a(n+2) = a(n) + a(n+1)`, the second-order determinant `D(n) = a(n)·a(n+2) − a(n+1)²` alternates: `D(n+1) = −D(n)`. Both Cassini identities are this single fact with different base values (5 for Lucas, −1 for Fibonacci). The companion `L² − 5F² = 4(−1)^n` pins the appearance of `5` to the recurrence's discriminant.

## Verification

- Built with host Lean (`lake env lean`) against a freshly rebuilt parent olean; Docker unavailable this cycle.
- `#print axioms` for all four theorems: `[propext, Quot.sound]` only — no `Classical.choice`, no `sorryAx`, no `Lean.ofReduceBool`.
- 118 lines, 4 theorems, 0 definitions, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)