### PR TITLE
research(combinations-formula-oq-01-oq-01-oq-01-oq-02): Lucas analogue of Cassini's identity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -795,6 +795,7 @@ import Proofs.CombinationsFormula
 import Proofs.CombinationsFormulaOQ01
 import Proofs.CombinationsFormulaOQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01
+import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle

--- a/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,120 @@
+/-
+Lucas analogue of Cassini's identity (OQ-01-OQ-01-OQ-01-OQ-02)
+
+The parent entry `combinations-formula-oq-01-oq-01-oq-01` ("Companion Lucas-number
+shallow-diagonal identities") introduces the Lucas sequence
+
+  `L 0 = 2, L 1 = 1, L (n+2) = L n + L (n+1)`   (`2, 1, 3, 4, 7, 11, …`)
+
+together with the Lucas–Fibonacci bridge `L n + F n = 2·F(n+1)`, and leaves as one of
+its open questions:
+
+  *Establish the Lucas analogue of Cassini's identity,
+   `L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5`, over ℤ.*
+
+This file answers it.  Working over ℤ (the right-hand side alternates sign), we prove:
+
+* `fib_catalan_int`          — the Fibonacci Catalan/Cassini identity
+                               `F(n+1)² − F n·F(n+2) = (−1)^n` over ℤ.  Mathlib has no
+                               such lemma, so it is proved here by a one-step
+                               sign-flipping induction.
+* `lucas_cassini_int`        — the reindexed Lucas Cassini identity
+                               `L n·L(n+2) − L(n+1)² = (−1)^n·5` (subtraction-free
+                               indices), the mathematical heart of the result.
+* `lucas_cassini`            — the literal open-question form
+                               `L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5` for `n ≥ 1`,
+                               obtained from `lucas_cassini_int` by reindexing.
+* `lucas_sq_sub_five_fib_sq` — the structural consequence
+                               `L(n)² − 5·F(n)² = 4·(−1)^n`, the discriminant identity
+                               linking the Lucas Cassini constant `5` to the
+                               characteristic equation `x² = x + 1` (discriminant `5`).
+                               Derived from the Fibonacci Catalan identity and the
+                               parent's bridge `L n = 2·F(n+1) − F n`.
+
+The Lucas constant `5` is exactly `(±1)·5`, mirroring the Fibonacci Cassini constant
+`±1` but scaled by the discriminant of `x² − x − 1`; the constant gap `5` is the Lucas
+sequence's signature.  Everything is axiom-free and reuses the parent's `lucas`.
+-/
+
+import Mathlib
+import Proofs.CombinationsFormulaOQ01OQ01OQ01
+
+namespace CombinationsFormulaOQ01OQ01OQ01OQ02
+
+open CombinationsFormulaOQ01OQ01OQ01
+
+/-! ### Fibonacci Catalan/Cassini identity (helper)
+
+Mathlib provides `Nat.fib` and its recurrence but no Cassini/Catalan determinant
+identity.  We prove the integer form `F(n+1)² − F n·F(n+2) = (−1)^n` directly; the
+proof is the classic observation that the determinant flips sign at each step. -/
+
+/-- **Fibonacci Catalan identity.** `F(n+1)² − F n·F(n+2) = (−1)^n` over ℤ. -/
+theorem fib_catalan_int (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - (Nat.fib n : ℤ) * Nat.fib (n + 2) = (-1) ^ n := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+      -- Expand the two Fibonacci recurrences as integer identities.
+      have h2 : (Nat.fib (n + 2) : ℤ) = Nat.fib n + Nat.fib (n + 1) := by
+        rw [Nat.fib_add_two]; push_cast; ring
+      have h3 : (Nat.fib (n + 3) : ℤ) = Nat.fib (n + 1) + Nat.fib (n + 2) := by
+        rw [show n + 3 = (n + 1) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+      rw [h2] at ih
+      rw [show n + 1 + 2 = n + 3 from rfl, h3, h2, pow_succ]
+      linear_combination -ih
+
+/-! ### The Lucas analogue of Cassini's identity -/
+
+/-- **Lucas Cassini identity (reindexed).** `L n·L(n+2) − L(n+1)² = (−1)^n·5` over ℤ.
+Subtraction-free indices; the literal `n−1` form is `lucas_cassini` below.  Proved by
+the same one-step sign-flipping induction as the Fibonacci case, using the parent's
+Lucas recurrence `L(n+2) = L n + L(n+1)`. -/
+theorem lucas_cassini_int (n : ℕ) :
+    (lucas n : ℤ) * lucas (n + 2) - (lucas (n + 1) : ℤ) ^ 2 = (-1) ^ n * 5 := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+      have h2 : (lucas (n + 2) : ℤ) = lucas n + lucas (n + 1) := by
+        rw [lucas_add_two]; push_cast; ring
+      have h3 : (lucas (n + 3) : ℤ) = lucas (n + 1) + lucas (n + 2) := by
+        rw [show n + 3 = (n + 1) + 2 from rfl, lucas_add_two]; push_cast; ring
+      rw [h2] at ih
+      rw [show n + 1 + 2 = n + 3 from rfl, h3, h2, pow_succ]
+      linear_combination -ih
+
+/-- **Lucas Cassini identity (open-question form).** For `n ≥ 1`,
+`L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5` over ℤ.  This is the exact statement of the
+parent's open question; it is `lucas_cassini_int` reindexed to start at `n−1`. -/
+theorem lucas_cassini {n : ℕ} (hn : 1 ≤ n) :
+    (lucas (n - 1) : ℤ) * lucas (n + 1) - (lucas n : ℤ) ^ 2 = (-1) ^ (n - 1) * 5 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  have e1 : 1 + m - 1 = m := by omega
+  have e2 : 1 + m + 1 = m + 2 := by omega
+  have e3 : 1 + m = m + 1 := by omega
+  rw [e1, e2, e3]
+  exact lucas_cassini_int m
+
+/-! ### Structural consequence: the discriminant identity -/
+
+/-- **Lucas–Fibonacci discriminant identity.** `L(n)² − 5·F(n)² = 4·(−1)^n` over ℤ.
+The constant `5` is the discriminant of the characteristic polynomial `x² − x − 1`,
+so this is the algebraic shadow of the Lucas Cassini constant.  Derived from the
+Fibonacci Catalan identity `fib_catalan_int` and the parent's bridge
+`L n = 2·F(n+1) − F n`. -/
+theorem lucas_sq_sub_five_fib_sq (n : ℕ) :
+    (lucas n : ℤ) ^ 2 - 5 * (Nat.fib n : ℤ) ^ 2 = 4 * (-1) ^ n := by
+  -- Bridge in subtraction form: L n = 2·F(n+1) − F n.
+  have hb : (lucas n : ℤ) = 2 * Nat.fib (n + 1) - Nat.fib n := by
+    have h : (lucas n : ℤ) + Nat.fib n = 2 * Nat.fib (n + 1) := by
+      exact_mod_cast lucas_add_fib n
+    omega
+  -- Fibonacci Catalan identity with F(n+2) expanded.
+  have hc := fib_catalan_int n
+  have hf : (Nat.fib (n + 2) : ℤ) = Nat.fib n + Nat.fib (n + 1) := by
+    rw [Nat.fib_add_two]; push_cast; ring
+  rw [hf] at hc
+  rw [hb]
+  linear_combination 4 * hc
+
+end CombinationsFormulaOQ01OQ01OQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "combfml-oq01010102-ann-header",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "The Lucas analogue of Cassini's identity — the open question answered",
+    "content": "Cassini's identity $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$ records that $\\det\\begin{psmallmatrix}F_{n+1}&F_n\\\\F_n&F_{n-1}\\end{psmallmatrix} = \\pm 1$. The Lucas numbers $L_n = \\varphi^n + \\psi^n$ obey the analogue $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$, the parent's open question. Working over $\\mathbb{Z}$ (the sign alternates), this file reuses the parent's Lucas sequence and proves the identity in both reindexed and literal forms, plus the discriminant identity $L_n^2 - 5F_n^2 = 4(-1)^n$.",
+    "mathContext": "Parent: Lucas sequence $L_0=2,\\,L_1=1,\\,L_{n+2}=L_n+L_{n+1}$ and the bridge $L_n+F_n=2F_{n+1}$. Goal: $L_{n-1}L_{n+1}-L_n^2=(-1)^{n-1}\\cdot 5$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "Lucas numbers", "Fibonacci numbers", "determinant identities"],
+    "prerequisites": ["Fibonacci sequence", "Lucas sequence", "integer arithmetic"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-fib-catalan",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 65 },
+    "type": "technique",
+    "title": "Fibonacci Catalan identity by a sign-flipping induction",
+    "content": "`fib_catalan_int` proves $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$ over $\\mathbb{Z}$. Mathlib has no Cassini/Catalan determinant lemma, so this is built directly. The inductive step substitutes $F_{n+2}=F_n+F_{n+1}$ and $F_{n+3}=F_{n+1}+F_{n+2}$ into the goal and the hypothesis, after which the determinant negates: the residual is exactly $-\\text{ih}$, discharged by `linear_combination -ih`.",
+    "mathContext": "$D(n)=F_{n+1}^2-F_nF_{n+2}$ satisfies $D(n+1)=-D(n)$, $D(0)=1$, hence $D(n)=(-1)^n$.",
+    "significance": "important",
+    "relatedConcepts": ["Catalan's identity", "Cassini's identity", "induction"],
+    "prerequisites": ["Nat.fib_add_two", "linear_combination"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-lucas-cassini-int",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 84 },
+    "type": "key-step",
+    "title": "The Lucas Cassini identity, subtraction-free form",
+    "content": "`lucas_cassini_int` proves $L_n L_{n+2} - L_{n+1}^2 = (-1)^n\\cdot 5$. Reindexing to start at $n$ (rather than $n-1$) avoids natural-number subtraction during the induction. The step uses the parent's `lucas_add_two` to substitute the recurrence; just as for Fibonacci the quantity negates each step ($D(0)=2\\cdot 3-1^2=5$), so the proof is again `linear_combination -ih`.",
+    "mathContext": "$D(n)=L_nL_{n+2}-L_{n+1}^2$, $D(n+1)=-D(n)$, $D(0)=5$, so $D(n)=(-1)^n\\cdot 5$.",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "Lucas numbers", "reindexing"],
+    "prerequisites": ["Lucas recurrence", "linear_combination"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-lucas-cassini",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 96 },
+    "type": "key-step",
+    "title": "Recovering the literal n−1 form",
+    "content": "`lucas_cassini` states the open question verbatim: $L_{n-1}L_{n+1}-L_n^2=(-1)^{n-1}\\cdot 5$ for $n\\ge 1$. Writing $n = 1 + m$ via `Nat.exists_eq_add_of_le` turns $n-1$ into $m$, $n$ into $m+1$, $n+1$ into $m+2$; `omega` proves the three index equalities and the goal becomes exactly `lucas_cassini_int m`.",
+    "mathContext": "Substituting $m = n-1$ identifies the literal statement with the subtraction-free form.",
+    "significance": "supporting",
+    "relatedConcepts": ["reindexing", "natural-number subtraction"],
+    "prerequisites": ["Nat.exists_eq_add_of_le", "omega"]
+  },
+  {
+    "id": "combfml-oq01010102-ann-discriminant",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 120 },
+    "type": "key-step",
+    "title": "The discriminant identity L² − 5F² = 4(−1)ⁿ",
+    "content": "`lucas_sq_sub_five_fib_sq` proves $L_n^2 - 5F_n^2 = 4(-1)^n$, exhibiting the Cassini constant $5$ as the discriminant of $x^2-x-1$. It follows algebraically: the parent's bridge gives $L_n = 2F_{n+1}-F_n$, so $L_n^2 - 5F_n^2 = 4(F_{n+1}^2 - F_n F_{n+2}) = 4(-1)^n$ by `fib_catalan_int`. The whole derivation is `linear_combination 4*hc` once the bridge and $F_{n+2}=F_n+F_{n+1}$ are substituted.",
+    "mathContext": "$L_n=2F_{n+1}-F_n \\Rightarrow L_n^2-5F_n^2 = 4(F_{n+1}^2-F_nF_{n+2}) = 4(-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["discriminant", "characteristic polynomial", "Pell-like identity", "Fibonacci–Lucas relations"],
+    "prerequisites": ["fib_catalan_int", "Lucas–Fibonacci bridge", "linear_combination"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: combinationsFormulaOQ01OQ01OQ01OQ02Proof,
+  annotations: combinationsFormulaOQ01OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "title": "Lucas Analogue of Cassini's Identity",
+  "slug": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's open question: the Lucas analogue of Cassini's identity, L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5, over ℤ. Reusing the parent's Lucas sequence L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1) (absent from Mathlib), the entry proves the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5 by a one-step sign-flipping induction, the literal open-question form for n ≥ 1 by reindexing, and the structural discriminant identity L(n)² − 5·F(n)² = 4·(−1)^n linking the Cassini constant 5 to the discriminant of x²−x−1. A helper Fibonacci Catalan identity F(n+1)² − F(n)·F(n+2) = (−1)^n (also absent from Mathlib) is proved en route. Axiom-free.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "lucas-numbers",
+      "cassini",
+      "determinant-identity",
+      "integer-sequences"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext and Quot.sound for all four named results (no Classical.choice). No axiom declarations, no sorries, and no native_decide (the two base cases use decide on concrete integer values, which reduces in the kernel without ofReduceBool).",
+    "lineCount": 120,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "fib_catalan_int: the Fibonacci Catalan/Cassini determinant identity F(n+1)² − F(n)·F(n+2) = (−1)^n over ℤ, absent from Mathlib, proved by a one-step sign-flipping induction",
+      "lucas_cassini_int: the subtraction-free reindexed Lucas Cassini identity L(n)·L(n+2) − L(n+1)² = (−1)^n·5",
+      "lucas_cassini: the literal open-question form L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5 for n ≥ 1",
+      "lucas_sq_sub_five_fib_sq: the discriminant identity L(n)² − 5·F(n)² = 4·(−1)^n, derived from the Fibonacci Catalan identity and the parent's bridge L(n) = 2·F(n+1) − F(n)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity F(n−1)·F(n+1) − F(n)² = (−1)^n (1680) is the prototype of the Fibonacci determinant identities: it records that the matrix [[F(n+1), F(n)], [F(n), F(n−1)]] has determinant ±1. The Lucas numbers L_n = φ^n + ψ^n, the second canonical solution of the Fibonacci recurrence (L_0=2, L_1=1), satisfy the analogous identity L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5, where the constant 5 is the discriminant of the characteristic polynomial x²−x−1. The parent entry (combinations-formula-oq-01-oq-01-oq-01) introduced the Lucas sequence to Lean (Mathlib has Nat.fib but no Lucas numbers) and posed this Cassini analogue as an open question. Mathlib also lacks any Fibonacci Cassini/Catalan determinant lemma, so both must be developed here.",
+    "problemStatement": "Establish the Lucas analogue of Cassini's identity, L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5, over ℤ, reusing the parent's Lucas sequence.",
+    "text": "Working over ℤ (the right-hand side alternates sign), we first prove the Fibonacci Catalan identity F(n+1)² − F(n)·F(n+2) = (−1)^n by induction: the inductive step substitutes the two Fibonacci recurrences and the residual collapses to the negation of the inductive hypothesis (linear_combination -ih), the classic observation that the 2×2 determinant flips sign at each step. The same one-step sign-flipping induction, now using the parent's Lucas recurrence L(n+2)=L(n)+L(n+1), gives the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5. The literal open-question form L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5 for n ≥ 1 follows by writing n = 1 + m and normalising indices with omega. Finally the discriminant identity L(n)² − 5·F(n)² = 4·(−1)^n is read off algebraically from the Fibonacci Catalan identity and the parent's subtraction-free bridge L(n) = 2·F(n+1) − F(n): expanding (2F(n+1)−F(n))² − 5F(n)² yields 4(F(n+1)² − F(n)·F(n+2)) = 4·(−1)^n (linear_combination 4·hc).",
+    "proofStrategy": "Prove the Fibonacci and Lucas Cassini/Catalan identities by the same one-step induction whose step is 'determinant negates' (linear_combination -ih after substituting the recurrences); obtain the literal n−1 form by reindexing with omega; derive the discriminant identity L²−5F²=4(−1)^n algebraically from the Fibonacci Catalan identity and the parent's bridge.",
+    "keyInsights": [
+      "The Cassini/Catalan identities for both Fibonacci and Lucas reduce to a single algebraic fact — the 2×2 determinant negates under one step of the recurrence — so each inductive step is exactly 'linear_combination -ih' after substituting L(n+2)=L(n)+L(n+1) (resp. F(n+2)=F(n)+F(n+1)).",
+      "Reindexing to the subtraction-free form L(n)·L(n+2) − L(n+1)² = (−1)^n·5 avoids natural-number subtraction during the induction; the literal n−1 statement is recovered afterwards by writing n = 1 + m and letting omega normalise the indices.",
+      "The Lucas Cassini constant 5 is the discriminant of x²−x−1: the identity L(n)² − 5·F(n)² = 4·(−1)^n makes this explicit, and it follows for free from the Fibonacci Catalan identity once the parent's bridge L(n)=2·F(n+1)−F(n) eliminates L in favour of F.",
+      "Mathlib has neither a Lucas sequence nor any Fibonacci Cassini/Catalan determinant lemma, so the Fibonacci helper fib_catalan_int is genuinely new infrastructure, not a wrapper around an existing result.",
+      "Casting the integer recurrences once (push_cast; ring) lets every subsequent step be pure ring/linear_combination over ℤ, keeping the proofs free of cast bookkeeping."
+    ],
+    "prerequisites": [
+      "The parent's Lucas sequence lucas, its recurrence lucas_add_two, and the bridge lucas_add_fib : L(n)+F(n)=2·F(n+1)",
+      "Fibonacci numbers Nat.fib and the recurrence Nat.fib_add_two",
+      "Integer ring reasoning via linear_combination and omega for index normalisation"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Lucas analogue of Cassini's identity is proved over ℤ in both the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5 and the literal open-question form L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5 (n ≥ 1). En route, the Fibonacci Catalan determinant identity F(n+1)² − F(n)·F(n+2) = (−1)^n (absent from Mathlib) is established, and the discriminant identity L(n)² − 5·F(n)² = 4·(−1)^n is derived, exhibiting the Cassini constant 5 as the discriminant of x²−x−1. 4 theorems, 120 lines, axiom-free.",
+    "implications": "Resolves the parent's Cassini open question and supplies the gallery's first Fibonacci/Lucas determinant identities, packaged for reuse (the Fibonacci Catalan identity is independent of the Lucas content).",
+    "openQuestions": [
+      "Prove the d'Ocagne / Catalan-style mixed identity F(m)·L(n) − ... or the Vajda identity unifying the Fibonacci and Lucas Cassini relations as special cases.",
+      "Establish the matrix form: L(n) = tr(Q^n) for Q = [[1,1],[1,0]], and deduce the Lucas Cassini identity from det(Q^n) = (−1)^n together with the Cayley–Hamilton relation tr(Q^n)² − ... ."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CombinationsFormulaOQ01OQ01OQ01OQ02",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: introduces the Lucas sequence and the bridge L(n)+F(n)=2·F(n+1). This entry answers its open question — the Lucas analogue of Cassini's identity — reusing the Lucas recurrence and the bridge."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "related",
+      "description": "Fibonacci summation and determinant identities; this entry adds the Fibonacci Catalan/Cassini identity F(n+1)²−F(n)·F(n+2)=(−1)^n and the Lucas discriminant identity L(n)²−5·F(n)²=4·(−1)^n."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "States the goal — the parent's open question on the Lucas analogue of Cassini's identity — notes that Mathlib has neither a Lucas sequence nor a Fibonacci Cassini/Catalan lemma, lists the four results, and imports the parent."
+    },
+    {
+      "title": "Fibonacci Catalan/Cassini identity (helper)",
+      "startLine": 46,
+      "endLine": 65,
+      "summary": "fib_catalan_int: F(n+1)² − F(n)·F(n+2) = (−1)^n over ℤ, proved by a one-step induction whose step substitutes both Fibonacci recurrences and collapses to the negation of the inductive hypothesis (linear_combination -ih)."
+    },
+    {
+      "title": "The Lucas analogue of Cassini's identity",
+      "startLine": 67,
+      "endLine": 96,
+      "summary": "lucas_cassini_int: the subtraction-free reindexed form L(n)·L(n+2) − L(n+1)² = (−1)^n·5, by the same sign-flipping induction using the parent's lucas_add_two. lucas_cassini: the literal n−1 open-question form for n ≥ 1, obtained by writing n = 1 + m and normalising indices with omega."
+    },
+    {
+      "title": "Structural consequence: the discriminant identity",
+      "startLine": 98,
+      "endLine": 120,
+      "summary": "lucas_sq_sub_five_fib_sq: L(n)² − 5·F(n)² = 4·(−1)^n, derived algebraically from fib_catalan_int and the parent's bridge L(n)=2·F(n+1)−F(n) via linear_combination, exhibiting the Cassini constant 5 as the discriminant of x²−x−1."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the parent entry `combinations-formula-oq-01-oq-01-oq-01`'s open question: **the Lucas analogue of Cassini's identity**, `L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5`, over ℤ.

The parent introduced the Lucas sequence (`L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1)` — absent from Mathlib) and the bridge `L(n)+F(n)=2·F(n+1)`. This leaf reuses both and proves four results:

| Theorem | Statement |
|---|---|
| `fib_catalan_int` | `F(n+1)² − F(n)·F(n+2) = (−1)^n` (Mathlib has **no** Fibonacci Cassini/Catalan lemma) |
| `lucas_cassini_int` | `L(n)·L(n+2) − L(n+1)² = (−1)^n·5` (subtraction-free reindexed form) |
| `lucas_cassini` | `L(n−1)·L(n+1) − L(n)² = (−1)^{n−1}·5` for `n ≥ 1` (literal open question) |
| `lucas_sq_sub_five_fib_sq` | `L(n)² − 5·F(n)² = 4·(−1)^n` (discriminant identity) |

## Method

Each Cassini/Catalan identity is the same one-step **sign-flipping induction**: substitute the recurrences and the determinant negates, so the inductive step is exactly `linear_combination -ih`. The literal `n−1` form is recovered by writing `n = 1 + m` and normalising indices with `omega`. The discriminant identity (exhibiting the Cassini constant `5` as the discriminant of `x²−x−1`) follows algebraically from `fib_catalan_int` and the parent's bridge via `linear_combination 4*hc`.

## Verification

- `#print axioms` on all four theorems reports only `propext, Quot.sound` — **0-axiom, verified**.
- 0 sorries, no `native_decide` (base cases use kernel `decide` on concrete integer values).
- 4 theorems, 0 new definitions (reuses parent's `lucas`), 120 lines.
- Type-checked via `lake env lean` against the current Mathlib + parent olean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)