### PR TITLE
research(combinations-formula-oq-01-oq-01-oq-01-oq-02): Lucas Cassini via the Q-matrix det(Qⁿ·M₀)=(−1)ⁿ·5 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -795,6 +795,7 @@ import Proofs.CombinationsFormula
 import Proofs.CombinationsFormulaOQ01
 import Proofs.CombinationsFormulaOQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01
+import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle

--- a/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,138 @@
+/-
+# Lucas analogue of Cassini's identity via the Q-matrix
+
+This file answers the **second open question** of
+`combinations-formula-oq-01-oq-01-oq-01`
+("Companion Lucas-number shallow-diagonal identities"):
+
+  *Establish the Lucas analogue of Cassini's identity,
+   `L (n-1) · L (n+1) − L n ^ 2 = (-1) ^ (n-1) · 5`, over `ℤ`.*
+
+Mathlib has Fibonacci numbers (`Nat.fib`) and even Cassini's identity for
+Fibonacci, but **no Lucas numbers at all** (only the unrelated Lucas–Lehmer
+primality test).  We therefore introduce the integer Lucas sequence
+`L 0 = 2, L 1 = 1, L (n+2) = L n + L (n+1)` and prove its Cassini identity
+**matrix-theoretically**, mirroring the gallery's Fibonacci Q-matrix entry
+`fibonacci-identities-oq-01-oq-03`.
+
+The mechanism: the **same** Fibonacci Q-matrix `Q = !![1, 1; 1, 0]` advances
+the Lucas state, so multiplying the seed `M₀ = !![3, 1; 1, 2] = !![L 2, L 1; L 1, L 0]`
+on the left by `Q ^ n` collects consecutive Lucas numbers:
+
+  `Q ^ n * M₀ = !![L (n+2), L (n+1); L (n+1), L n]`   (`Q_pow_mul_seed`).
+
+Taking determinants two ways forces Cassini:
+
+  * multiplicativity gives `det (Q^n * M₀) = (det Q)^n · det M₀ = (-1)^n · 5`;
+  * the explicit entries give `det (Q^n * M₀) = L (n+2) · L n − L (n+1) ^ 2`.
+
+Equating yields `L (n+2) · L n − L (n+1) ^ 2 = (-1) ^ n · 5`
+(`lucas_cassini_matrix`); re-indexing recovers the parent's named form
+`L (n-1) · L (n+1) − L n ^ 2 = (-1) ^ (n-1) · 5` for `n ≥ 1` (`lucas_cassini`).
+
+The contrast with Fibonacci is the constant: the Fibonacci seed `Q` has
+determinant `-1`, while the Lucas seed `M₀` has determinant `5`, so the
+"discriminant" `5` of the Lucas sequence is exactly `det M₀`.
+
+Worked numerics: `det (Q^2 * M₀) = L 4 · L 2 − L 3 ^ 2 = 7·3 − 4² = 5 = (-1)^2·5`;
+`L 3 · L 1 − L 2 ^ 2 = 4·1 − 3² = -5 = (-1)^3·5`.
+
+Everything is axiom-free.
+-/
+import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
+import Mathlib.Tactic
+
+namespace CombinationsFormulaOQ01OQ01OQ01OQ02
+
+open Matrix
+
+/-! ### The integer Lucas sequence -/
+
+/-- The **Lucas numbers** over `ℤ`: `L 0 = 2`, `L 1 = 1`, `L (n+2) = L n + L (n+1)`,
+i.e. `2, 1, 3, 4, 7, 11, 18, …`.  Mathlib has `Nat.fib` but no Lucas sequence; we
+work over `ℤ` so the alternating sign in Cassini's identity is expressible. -/
+def L : ℕ → ℤ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => L n + L (n + 1)
+
+@[simp] theorem L_zero : L 0 = 2 := rfl
+@[simp] theorem L_one : L 1 = 1 := rfl
+
+/-- The Lucas recurrence `L (n+2) = L n + L (n+1)`. -/
+theorem L_add_two (n : ℕ) : L (n + 2) = L n + L (n + 1) := rfl
+
+/-! ### The Q-matrix engine -/
+
+/-- The Fibonacci **Q-matrix** `Q = !![1, 1; 1, 0]` over `ℤ`.  The same matrix that
+advances the Fibonacci state also advances the Lucas state. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- The Lucas **seed matrix** `M₀ = !![3, 1; 1, 2] = !![L 2, L 1; L 1, L 0]`. -/
+def M0 : Matrix (Fin 2) (Fin 2) ℤ := !![3, 1; 1, 2]
+
+/-- Congruence helper: two explicit `2×2` matrices agree when their entries do. -/
+private theorem mateq {a b c d e f g h : ℤ}
+    (h₁ : a = e) (h₂ : b = f) (h₃ : c = g) (h₄ : d = h) :
+    !![a, b; c, d] = !![e, f; g, h] := by
+  rw [h₁, h₂, h₃, h₄]
+
+/-- `det Q = -1`. -/
+theorem det_Q : Q.det = -1 := by
+  simp [Q, Matrix.det_fin_two_of]
+
+/-- `det M₀ = 5`: the determinant of the Lucas seed is the sequence's discriminant. -/
+theorem det_M0 : M0.det = 5 := by
+  simp [M0, Matrix.det_fin_two_of]
+
+/-- **Lucas Q-matrix engine.** Left-multiplying the seed by powers of the Fibonacci
+Q-matrix collects consecutive Lucas numbers:
+`Q ^ n * M₀ = !![L (n+2), L (n+1); L (n+1), L n]`.
+
+This is the matrix fact absent from Mathlib (Mathlib has neither Lucas numbers nor a
+`Q ^ n`-Lucas lemma); everything else follows by taking determinants.  Proved by
+induction on `n` using only the Lucas recurrence and the explicit `2×2` product. -/
+theorem Q_pow_mul_seed (n : ℕ) :
+    Q ^ n * M0 = !![L (n + 2), L (n + 1); L (n + 1), L n] := by
+  induction n with
+  | zero =>
+      rw [pow_zero, one_mul, M0]
+      apply mateq <;> decide
+  | succ n ih =>
+      have e2 : L (n + 2) = L n + L (n + 1) := L_add_two n
+      have e3 : L (n + 3) = L (n + 1) + L (n + 2) := rfl
+      rw [pow_succ', Matrix.mul_assoc, ih, Q, Matrix.mul_fin_two]
+      apply mateq
+      · rw [show n + 1 + 2 = n + 3 from rfl, e3]; ring
+      · rw [show n + 1 + 1 = n + 2 from rfl, e2]; ring
+      · rw [show n + 1 + 1 = n + 2 from rfl]; ring
+      · ring
+
+/-! ### Cassini's identity for Lucas numbers -/
+
+/-- **Lucas Cassini, matrix-theoretic form.** Computing `det (Q ^ n * M₀)` two ways
+forces `L (n+2) · L n − L (n+1) ^ 2 = (-1) ^ n · 5`. -/
+theorem lucas_cassini_matrix (n : ℕ) :
+    L (n + 2) * L n - L (n + 1) ^ 2 = (-1) ^ n * 5 := by
+  have h : (Q ^ n * M0).det = (-1 : ℤ) ^ n * 5 := by
+    rw [Matrix.det_mul, Matrix.det_pow, det_Q, det_M0]
+  rw [Q_pow_mul_seed, Matrix.det_fin_two_of] at h
+  rw [← h]; ring
+
+/-- **Lucas Cassini, named form** (the parent's open question), recovered from the
+matrix derivation: for `n ≥ 1`,
+`L (n-1) · L (n+1) − L n ^ 2 = (-1) ^ (n-1) · 5`. -/
+theorem lucas_cassini (n : ℕ) (hn : 1 ≤ n) :
+    L (n - 1) * L (n + 1) - L n ^ 2 = (-1) ^ (n - 1) * 5 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.one_le_iff_ne_zero.mp hn)
+  have h := lucas_cassini_matrix m
+  show L m * L (m + 2) - L (m + 1) ^ 2 = (-1) ^ m * 5
+  linear_combination h
+
+/-! ### Numeric sanity checks -/
+
+example : (Q ^ 2 * M0).det = (-1 : ℤ) ^ 2 * 5 := by decide
+example : L 4 * L 2 - L 3 ^ 2 = (-1 : ℤ) ^ 2 * 5 := by decide
+example : L 3 * L 1 - L 2 ^ 2 = (-1 : ℤ) ^ 3 * 5 := by decide
+
+end CombinationsFormulaOQ01OQ01OQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "combfml-oq01010101oq02-ann-header",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "The Lucas Cassini identity — the open question answered",
+    "content": "The parent (combinations-formula-oq-01-oq-01-oq-01) introduces the Lucas sequence and leaves as its second open question the Lucas analogue of Cassini's identity, $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$, over $\\mathbb{Z}$. This file proves it matrix-theoretically, mirroring the gallery's Fibonacci Q-matrix entry: the same matrix $Q=\\bigl(\\begin{smallmatrix}1&1\\\\1&0\\end{smallmatrix}\\bigr)$ advances the Lucas state, so $\\det(Q^n M_0)$ computed two ways forces Cassini, with the constant $5 = \\det M_0$.",
+    "mathContext": "$L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$, with $5 = \\det M_0$ the discriminant of $x^2-x-1$.",
+    "significance": "key",
+    "relatedConcepts": ["Lucas numbers", "Cassini's identity", "Q-matrix", "determinant multiplicativity"],
+    "prerequisites": ["Fibonacci Q-matrix Cassini", "Lucas sequence"]
+  },
+  {
+    "id": "combfml-oq01010101oq02-ann-lucas-def",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 51, "endLine": 66 },
+    "type": "definition",
+    "title": "The integer Lucas sequence",
+    "content": "Defines $L$ over $\\mathbb{Z}$ by $L_0=2,\\ L_1=1,\\ L_{n+2}=L_n+L_{n+1}$ (giving $2,1,3,4,7,11,18,\\dots$). Mathlib has no Lucas sequence (its 'Lucas' is the unrelated Lucas–Lehmer test). Working over $\\mathbb{Z}$ rather than $\\mathbb{N}$ is essential: the right-hand side of Cassini alternates in sign, which natural numbers cannot express. The base-value `simp` lemmas and the `rfl`-true `L_add_two` expose the recurrence to the inductive engine.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$ over $\\mathbb{Z}$",
+    "significance": "supporting",
+    "relatedConcepts": ["linear recurrence", "Lucas numbers", "integer sequences"],
+    "prerequisites": ["recursive definitions in Lean"]
+  },
+  {
+    "id": "combfml-oq01010101oq02-ann-engine",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 110 },
+    "type": "tactic",
+    "title": "The Q-matrix engine: Qⁿ·M₀ collects Lucas numbers",
+    "content": "The crux. `Q_pow_mul_seed` proves $Q^n M_0 = \\bigl(\\begin{smallmatrix}L_{n+2}&L_{n+1}\\\\L_{n+1}&L_n\\end{smallmatrix}\\bigr)$ by induction on $n$, where $Q=\\bigl(\\begin{smallmatrix}1&1\\\\1&0\\end{smallmatrix}\\bigr)$ is the Fibonacci Q-matrix and $M_0=\\bigl(\\begin{smallmatrix}3&1\\\\1&2\\end{smallmatrix}\\bigr)=\\bigl(\\begin{smallmatrix}L_2&L_1\\\\L_1&L_0\\end{smallmatrix}\\bigr)$ is the Lucas seed. The step uses `pow_succ'` ($Q^{n+1}=Q\\cdot Q^n$), associativity, the induction hypothesis, and the explicit product `Matrix.mul_fin_two`; the four entries close by the Lucas recurrence and `ring`. The key realisation: $Q$ encodes the *recurrence*, not the initial values, so the only Lucas-specific datum is the seed $M_0$.",
+    "mathContext": "$Q^n M_0 = \\begin{pmatrix} L_{n+2} & L_{n+1} \\\\ L_{n+1} & L_n \\end{pmatrix}$",
+    "significance": "key",
+    "relatedConcepts": ["matrix powers", "2×2 matrix product", "induction", "companion matrix"],
+    "prerequisites": ["Matrix.mul_fin_two", "pow_succ'", "matrix associativity"]
+  },
+  {
+    "id": "combfml-oq01010101oq02-ann-det",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "insight",
+    "title": "The Cassini constant 5 is a seed determinant",
+    "content": "`det_Q` gives $\\det Q = -1$ and `det_M0` gives $\\det M_0 = 5$. By multiplicativity, $\\det(Q^n M_0) = (\\det Q)^n \\cdot \\det M_0 = (-1)^n\\cdot 5$. This exhibits the Cassini constant structurally: where the Fibonacci Cassini constant $\\pm 1$ is $\\det Q$, the Lucas Cassini constant $5$ is $\\det M_0$ — exactly the discriminant of $x^2-x-1$. The two identities differ only in which determinant the matrix power is anchored to.",
+    "mathContext": "$\\det(Q^n M_0) = (\\det Q)^n \\det M_0 = (-1)^n\\cdot 5$",
+    "significance": "key",
+    "relatedConcepts": ["determinant multiplicativity", "discriminant", "Fibonacci–Lucas contrast"],
+    "prerequisites": ["Matrix.det_mul", "Matrix.det_pow"]
+  },
+  {
+    "id": "combfml-oq01010101oq02-ann-cassini",
+    "proofId": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 131 },
+    "type": "tactic",
+    "title": "Cassini from the determinant computed two ways",
+    "content": "`lucas_cassini_matrix` equates the two determinant evaluations: multiplicativity gives $(-1)^n\\cdot 5$, while `Matrix.det_fin_two_of` on the explicit entries gives $L_{n+2}L_n - L_{n+1}^2$. Hence $L_{n+2}L_n - L_{n+1}^2 = (-1)^n\\cdot 5$. `lucas_cassini` then recovers the parent's classical centred form $L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$ for $n\\ge 1$ by substituting $n=m+1$ — the substitution makes the natural-subtraction $n-1$ disappear, and `linear_combination` absorbs the commuted product.",
+    "mathContext": "$L_{n+2}L_n - L_{n+1}^2 = (-1)^n\\cdot 5 \\;\\Longrightarrow\\; L_{n-1}L_{n+1} - L_n^2 = (-1)^{n-1}\\cdot 5$",
+    "significance": "key",
+    "relatedConcepts": ["determinant two ways", "re-indexing", "Cassini's identity"],
+    "prerequisites": ["Matrix.det_fin_two_of", "linear_combination"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: combinationsFormulaOQ01OQ01OQ01OQ02Proof,
+  annotations: combinationsFormulaOQ01OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "title": "Lucas Analogue of Cassini's Identity via the Q-matrix",
+  "slug": "combinations-formula-oq-01-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's second open question: the Lucas analogue of Cassini's identity, L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5, over ℤ. Mathlib has no Lucas numbers, so this entry introduces the integer Lucas sequence L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1) and proves Cassini matrix-theoretically, mirroring the gallery's Fibonacci Q-matrix entry. The same Fibonacci Q-matrix Q=!![1,1;1,0] advances the Lucas state, so left-multiplying the seed M₀=!![3,1;1,2]=!![L2,L1;L1,L0] by Qⁿ collects consecutive Lucas numbers: Qⁿ·M₀ = !![L(n+2),L(n+1);L(n+1),L n]. Taking determinants two ways — multiplicativity gives det(Q)ⁿ·det(M₀)=(−1)ⁿ·5, the explicit entries give L(n+2)·L n − L(n+1)² — forces Cassini. The contrast with Fibonacci is the constant: the Fibonacci seed Q has determinant −1, the Lucas seed M₀ has determinant 5, so the sequence's discriminant 5 is exactly det M₀. Axiom-free.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "lucas-numbers",
+      "fibonacci",
+      "cassini",
+      "matrix-determinant",
+      "q-matrix"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound for lucas_cassini_matrix and lucas_cassini. No axiom declarations, no sorries, and no native_decide — the base case and the three numeric sanity checks use decide on concrete integer values, which reduces in the kernel without ofReduceBool.",
+    "lineCount": 138,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "originalContributions": [
+      "L: the integer Lucas sequence L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1) over ℤ, absent from Mathlib (which has only the unrelated Lucas–Lehmer primality test)",
+      "Q_pow_mul_seed: the Lucas Q-matrix engine Qⁿ·M₀ = !![L(n+2),L(n+1);L(n+1),L n], absent from Mathlib (no Lucas numbers, no Qⁿ-Lucas lemma)",
+      "det_M0: det of the Lucas seed M₀=!![3,1;1,2] equals 5, identifying the sequence's discriminant with a determinant",
+      "lucas_cassini_matrix: the Lucas Cassini identity L(n+2)·L n − L(n+1)² = (−1)ⁿ·5, derived by computing det(Qⁿ·M₀) two ways",
+      "lucas_cassini: the parent's named form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 for n ≥ 1, recovered by re-indexing"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cassini's identity F(n−1)·F(n+1) − F(n)² = (−1)ⁿ (1680) is the prototypical second-order Fibonacci identity; the gallery's fibonacci-identities-oq-01-oq-03 derives it matrix-theoretically as det(Qⁿ)=(−1)ⁿ with Q=!![1,1;1,0]. The Lucas numbers L_n = φⁿ + ψⁿ are the second canonical solution of the Fibonacci recurrence (L_0=2, L_1=1) and satisfy the analogous Cassini identity L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5, where the constant 5 is the discriminant of x²−x−1. The parent entry (combinations-formula-oq-01-oq-01-oq-01) introduced the Lucas sequence and posed this identity over ℤ as its second open question. Mathlib formalizes F (Nat.fib) but not L.",
+    "problemStatement": "Establish the Lucas analogue of Cassini's identity, L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5, over ℤ, with a derivation that exposes the structural reason for the constant 5.",
+    "text": "We define the integer Lucas sequence L by its two-step recurrence and prove Cassini through the determinant of a matrix power, reusing the same Fibonacci Q-matrix Q=!![1,1;1,0] that drives the gallery's Fibonacci entry. The single engine lemma Q_pow_mul_seed shows, by induction on n, that left-multiplying the seed M₀=!![3,1;1,2] by Qⁿ collects consecutive Lucas numbers: Qⁿ·M₀ = !![L(n+2),L(n+1);L(n+1),L n]. The inductive step uses pow_succ' (Qⁿ⁺¹ = Q·Qⁿ), associativity, the induction hypothesis, and the explicit 2×2 product Matrix.mul_fin_two, with the four entries discharged by the Lucas recurrence and ring. Cassini then follows by computing det(Qⁿ·M₀) two ways: multiplicativity (Matrix.det_mul, Matrix.det_pow) gives det(Q)ⁿ·det(M₀) = (−1)ⁿ·5, while the explicit entries (Matrix.det_fin_two_of) give L(n+2)·L n − L(n+1)². Equating yields lucas_cassini_matrix; substituting n = m+1 recovers the parent's named form lucas_cassini for n ≥ 1.",
+    "proofStrategy": "Encode the Lucas state in a 2×2 matrix, advance it by the Fibonacci Q-matrix, and read Cassini off the determinant computed two ways (multiplicativity versus explicit entries). One induction (the Q-matrix engine) and one determinant comparison.",
+    "keyInsights": [
+      "The Fibonacci Q-matrix advances the Lucas state as well — the recurrence, not the initial values, is what Q encodes — so the only Lucas-specific datum is the seed M₀ = !![L2,L1;L1,L0] = !![3,1;1,2].",
+      "The Cassini constant 5 is precisely det M₀ (the discriminant of x²−x−1), exactly as the Fibonacci Cassini constant ±1 is det Q; the two identities differ only in which determinant the matrix power is anchored to.",
+      "Multiplicativity of det turns the entire identity into det(Qⁿ·M₀) = det(Q)ⁿ·det(M₀), collapsing the induction to the single statement that Qⁿ·M₀ has Lucas entries.",
+      "Working over ℤ (not ℕ) is essential: the right-hand side alternates in sign, which natural numbers cannot express; the integer Lucas sequence is the right setting.",
+      "Re-indexing n ↦ m+1 converts the clean matrix form L(n+2)·L n − L(n+1)² = (−1)ⁿ·5 into the classical centred form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 without any natural-subtraction friction (the substitution makes m−1 disappear)."
+    ],
+    "prerequisites": [
+      "The Fibonacci Q-matrix Cassini derivation (fibonacci-identities-oq-01-oq-03)",
+      "Determinant multiplicativity Matrix.det_mul, Matrix.det_pow and the 2×2 formula Matrix.det_fin_two_of",
+      "The explicit 2×2 product Matrix.mul_fin_two and matrix power identity pow_succ'",
+      "The integer Lucas sequence and its recurrence (parent combinations-formula-oq-01-oq-01-oq-01)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Lucas analogue of Cassini's identity is proved over ℤ matrix-theoretically: the integer Lucas sequence is introduced, the engine Qⁿ·M₀ = !![L(n+2),L(n+1);L(n+1),L n] is established by induction, and det computed two ways forces L(n+2)·L n − L(n+1)² = (−1)ⁿ·5 (lucas_cassini_matrix), re-indexed to the parent's named form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 (lucas_cassini). 9 theorems, 3 definitions, 138 lines, axiom-free.",
+    "implications": "Resolves the parent's second open question and extends the gallery's Q-matrix Cassini technique from Fibonacci to Lucas, exhibiting the Cassini constant as a seed determinant (5 = det M₀ versus ±1 = det Q).",
+    "openQuestions": [
+      "Unify both Cassini identities by proving the general companion-sequence Cassini W(n+2)·W(n) − W(n+1)² = (W2·W0 − W1²)·(−1)ⁿ for any sequence W obeying the Fibonacci recurrence, with Fibonacci (constant −1) and Lucas (constant 5) as instances.",
+      "Derive the Lucas analogue of Catalan's identity L(n)² − L(n−r)·L(n+r) = (−1)^(n−r)·5·F(r)² from the same matrix machinery."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CombinationsFormulaOQ01OQ01OQ01OQ02",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "path": "Proofs/CombinationsFormulaOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: introduces the Lucas sequence and the companion shallow-diagonal identities, posing the Lucas Cassini identity over ℤ as its second open question — answered here."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Fibonacci Cassini via det(Qⁿ)=(−1)ⁿ; this entry reuses the same Q-matrix and determinant technique for the Lucas sequence, with the Cassini constant 5 appearing as det of the Lucas seed."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "States the goal — the parent's second open question, the Lucas Cassini identity over ℤ — and the strategy: the same Fibonacci Q-matrix advances the Lucas state, so det(Qⁿ·M₀) computed two ways forces Cassini, with the constant 5 = det M₀."
+    },
+    {
+      "title": "The integer Lucas sequence",
+      "startLine": 51,
+      "endLine": 66,
+      "summary": "Defines L over ℤ by L(0)=2, L(1)=1, L(n+2)=L(n)+L(n+1), with base evaluations and the recurrence L_add_two as definitional (rfl) facts. Working over ℤ makes the alternating sign expressible."
+    },
+    {
+      "title": "The Q-matrix engine",
+      "startLine": 68,
+      "endLine": 110,
+      "summary": "Defines the Fibonacci Q-matrix Q=!![1,1;1,0] and the Lucas seed M₀=!![3,1;1,2], computes det Q = −1 and det M₀ = 5, and proves the engine Q_pow_mul_seed: Qⁿ·M₀ = !![L(n+2),L(n+1);L(n+1),L n] by induction using pow_succ', Matrix.mul_fin_two, and the Lucas recurrence."
+    },
+    {
+      "title": "Cassini's identity for Lucas numbers",
+      "startLine": 112,
+      "endLine": 131,
+      "summary": "lucas_cassini_matrix: L(n+2)·L n − L(n+1)² = (−1)ⁿ·5, from det(Qⁿ·M₀) two ways. lucas_cassini: the parent's named centred form L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5 for n ≥ 1, recovered by substituting n = m+1."
+    },
+    {
+      "title": "Numeric sanity checks",
+      "startLine": 133,
+      "endLine": 138,
+      "summary": "Three decide-checked instances: det(Q²·M₀) = (−1)²·5, L4·L2 − L3² = 5, and L3·L1 − L2² = −5, all reducing in the kernel (no native_decide)."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent entry `combinations-formula-oq-01-oq-01-oq-01` ("Companion Lucas-Number Shallow-Diagonal Identities"):

> *Establish the Lucas analogue of Cassini's identity, `L(n−1)·L(n+1) − L(n)² = (−1)^(n−1)·5`, over ℤ.*

## Approach — the Q-matrix, mirroring the Fibonacci entry

Mathlib has **no Lucas numbers** (only the unrelated Lucas–Lehmer test), so this introduces the integer Lucas sequence `L 0 = 2, L 1 = 1, L (n+2) = L n + L (n+1)` over ℤ and proves Cassini **matrix-theoretically**, reusing the same machinery as the gallery's Fibonacci Q-matrix Cassini entry (`fibonacci-identities-oq-01-oq-03`).

The same Fibonacci Q-matrix `Q = !![1,1;1,0]` advances the Lucas state — `Q` encodes the *recurrence*, not the initial values — so the only Lucas-specific datum is the seed `M₀ = !![3,1;1,2] = !![L 2, L 1; L 1, L 0]`. The engine lemma proves by induction:

```
Q_pow_mul_seed :  Qⁿ · M₀ = !![L (n+2), L (n+1); L (n+1), L n]
```

Taking `det (Qⁿ · M₀)` two ways forces Cassini:
- multiplicativity: `(det Q)ⁿ · det M₀ = (−1)ⁿ · 5`;
- explicit entries: `L (n+2) · L n − L (n+1)²`.

Equating gives `lucas_cassini_matrix : L (n+2)·L n − L (n+1)² = (−1)ⁿ·5`; substituting `n = m+1` recovers the parent's centred form `lucas_cassini : L (n−1)·L (n+1) − L n² = (−1)^(n−1)·5` for `n ≥ 1`.

**Structural payoff:** the Cassini constant `5` is exactly `det M₀` (the discriminant of `x²−x−1`), precisely as the Fibonacci Cassini constant `±1` is `det Q`. The two identities differ only in which determinant the matrix power is anchored to.

## Verification

- **9 theorems, 3 definitions, 138 lines.**
- `#print axioms lucas_cassini_matrix` / `lucas_cassini` → only `propext, Classical.choice, Quot.sound`.
- No `axiom` declarations, no `sorry`, **no `native_decide`** — the base case and three numeric sanity checks use `decide`, which reduces in the kernel (no `Lean.ofReduceBool`).
- Compiles under Lean v4.26.0 / Mathlib (`lake env lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)