### PR TITLE
research(combinations-formula-oq-07-oq-04-oq-02): variance of the squared-binomial distribution [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -809,6 +809,7 @@ import Proofs.CombinationsFormulaOQ07OQ02
 import Proofs.CombinationsFormulaOQ07OQ03
 import Proofs.CombinationsFormulaOQ07OQ04OQ01
 import Proofs.CombinationsFormulaOQ07OQ04OQ01OQ02
+import Proofs.CombinationsFormulaOQ07OQ04OQ02
 import Proofs.CombinationsFormulaOQ07OQ05
 import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09

--- a/proofs/Proofs/CombinationsFormulaOQ07OQ04OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ04OQ02.lean
@@ -1,0 +1,154 @@
+import Mathlib
+import Proofs.CombinationsFormulaOQ07
+import Proofs.CombinationsFormulaOQ07OQ03
+import Proofs.CombinationsFormulaOQ07OQ04
+
+/-
+# The Variance of the Squared-Binomial (Vandermonde) Distribution
+
+## Open Question OQ-07-OQ-04-OQ-02
+
+Reading `C(n, k)² / C(2n, n)` as a probability distribution on `{0, …, n}` — the
+law of the size of one half of a Vandermonde split of a `2n`-set into two `n`-sets —
+the parent file (OQ-07-OQ-04) computed its raw first and second moments,
+
+  ∑ k · C(n,k)²  = n · C(2n−1, n−1),        ∑ k² · C(n,k)²  = n² · C(2n−2, n−1),
+
+and observed (but did not prove) that together they pin the **mean** at `n / 2` and the
+**variance** at `n² / (4(2n − 1))`.  This file formalises that variance claim.
+
+To stay inside the integers we record the variance in its *cleared, centred* form.
+Writing the deviation as `2k − n` (twice the deviation `k − n/2` from the mean, so that
+it is an integer), the centred second moment satisfies the single closed identity
+
+  (2n − 1) · ∑_{k=0}^{n} (2k − n)² · C(n,k)²  =  n² · C(2n, n).                     (★)
+
+Dividing by `4 · (2n−1) · C(2n, n)` turns the left-hand side into
+`∑ (k − n/2)² · C(n,k)²/C(2n,n) = Var`, recovering `Var = n² / (4(2n − 1))` exactly.
+
+## The proof
+
+Expanding `(2k − n)² = 4k² − 4nk + n²` and summing term by term reduces (★) to the
+three raw moments already in the gallery:
+
+  ∑ (2k−n)²·C(n,k)² = 4·∑ k²C² − 4n·∑ kC² + n²·∑ C²
+                    = 4·n²·C(2n−2,n−1) − 4n·n·C(2n−1,n−1) + n²·C(2n,n).
+
+The remaining identity is pure binomial bookkeeping.  Two relations from the parent
+files close it:
+
+  * the **halving** `C(2n, n) = 2 · C(2n−1, n−1)`   (`central_binom_two_mul_pred`), and
+  * the **recurrence** `n · C(2n, n) = 2(2n−1) · C(2n−2, n−1)`  (`central_binom_recurrence`).
+
+With `a = C(2n−1, n−1)`, `b = C(2n−2, n−1)`, `c = C(2n, n)` these read `c = 2a` and
+`n·c = 2(2n−1)·b`; substituting collapses the centred moment to `n²·c`, so (★) is a
+single `linear_combination` of the two relations.
+
+## Results
+
+1. `centred_second_moment` — the cleared variance identity (★)
+   `(2n − 1) · ∑ (2k − n)² · C(n,k)² = n² · C(2n, n)`.
+2. `variance_eq` — the rational variance in lowest terms,
+   `(∑ (k − n/2)² · C(n,k)²) / C(2n, n) = n² / (4(2n − 1))`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ04OQ02
+
+open Finset
+
+/-- **The cleared variance identity** `(★)`.  For `n ≥ 1`,
+
+      (2n − 1) · ∑_{k=0}^{n} (2k − n)² · C(n,k)²  =  n² · C(2n, n).
+
+    Expand `(2k−n)²` into the three raw moments (sum of squares, first and second
+    weighted moments) already proved in this OQ family, then close with the halving
+    and recurrence relations for the central binomial coefficient. -/
+theorem centred_second_moment (n : ℕ) (hn : 1 ≤ n) :
+    (2 * (n : ℤ) - 1) *
+        ∑ k ∈ range (n + 1), (2 * (k : ℤ) - n) ^ 2 * ((n.choose k : ℤ)) ^ 2
+      = (n : ℤ) ^ 2 * ((2 * n).choose n : ℤ) := by
+  -- Expand the centred square term by term into the three raw moments.
+  have hexpand :
+      ∑ k ∈ range (n + 1), (2 * (k : ℤ) - n) ^ 2 * ((n.choose k : ℤ)) ^ 2
+        = 4 * (∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * ((n.choose k : ℤ)) ^ 2)
+          - 4 * n * (∑ k ∈ range (n + 1), (k : ℤ) * ((n.choose k : ℤ)) ^ 2)
+          + n ^ 2 * (∑ k ∈ range (n + 1), ((n.choose k : ℤ)) ^ 2) := by
+    rw [Finset.mul_sum, Finset.mul_sum, Finset.mul_sum, ← Finset.sum_sub_distrib,
+        ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun k _ => by ring)
+  -- Cast the three raw-moment closed forms to ℤ.
+  have hS0 : ∑ k ∈ range (n + 1), ((n.choose k : ℤ)) ^ 2 = ((2 * n).choose n : ℤ) := by
+    have h := CombinationsFormulaOQ07.central_binom_eq_sum_sq n
+    exact_mod_cast h.symm
+  have hS1 : ∑ k ∈ range (n + 1), (k : ℤ) * ((n.choose k : ℤ)) ^ 2
+      = (n : ℤ) * (((2 * n - 1).choose (n - 1) : ℕ) : ℤ) := by
+    exact_mod_cast CombinationsFormulaOQ07OQ03.sum_weighted_sq n hn
+  have hS2 : ∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * ((n.choose k : ℤ)) ^ 2
+      = (n : ℤ) ^ 2 * (((2 * (n - 1)).choose (n - 1) : ℕ) : ℤ) := by
+    exact_mod_cast CombinationsFormulaOQ07OQ04.sum_sq_weighted_sq n
+  -- The two central-binomial relations, cast to ℤ.
+  have hR1 : ((2 * n).choose n : ℤ) = 2 * (((2 * n - 1).choose (n - 1) : ℕ) : ℤ) := by
+    exact_mod_cast CombinationsFormulaOQ07OQ03.central_binom_two_mul_pred n hn
+  have hR2 : (n : ℤ) * ((2 * n).choose n : ℤ)
+      = 2 * (2 * (n : ℤ) - 1) * (((2 * (n - 1)).choose (n - 1) : ℕ) : ℤ) := by
+    have e : ((2 * n - 1 : ℕ) : ℤ) = 2 * (n : ℤ) - 1 := by omega
+    have h := CombinationsFormulaOQ07OQ04.central_binom_recurrence n hn
+    calc (n : ℤ) * ((2 * n).choose n : ℤ)
+        = ((n * (2 * n).choose n : ℕ) : ℤ) := by push_cast; ring
+      _ = ((2 * (2 * n - 1) * (2 * (n - 1)).choose (n - 1) : ℕ) : ℤ) := by rw [h]
+      _ = 2 * ((2 * n - 1 : ℕ) : ℤ) * (((2 * (n - 1)).choose (n - 1) : ℕ) : ℤ) := by
+            push_cast; ring
+      _ = 2 * (2 * (n : ℤ) - 1) * (((2 * (n - 1)).choose (n - 1) : ℕ) : ℤ) := by rw [e]
+  rw [hexpand, hS2, hS1, hS0]
+  linear_combination (2 * (n : ℤ) ^ 2 * (2 * (n : ℤ) - 1)) * hR1 + (-2 * (n : ℤ) ^ 2) * hR2
+
+/-- **The variance in lowest terms.** Dividing the cleared identity `(★)` by
+    `4 · (2n − 1) · C(2n, n)` gives the variance of the distribution
+    `k ↦ C(n,k)² / C(2n, n)`:
+
+      (∑_{k=0}^{n} (k − n/2)² · C(n,k)²) / C(2n, n)  =  n² / (4(2n − 1)).
+
+    Stated over `ℚ`, with `(k − n/2)² = (2k − n)² / 4`. -/
+theorem variance_eq (n : ℕ) (hn : 1 ≤ n) :
+    (∑ k ∈ range (n + 1), ((k : ℚ) - n / 2) ^ 2 * ((n.choose k : ℚ)) ^ 2)
+        / ((2 * n).choose n : ℚ)
+      = (n : ℚ) ^ 2 / (4 * (2 * (n : ℚ) - 1)) := by
+  have hc : ((2 * n).choose n : ℚ) ≠ 0 := by
+    have : 0 < (2 * n).choose n := Nat.choose_pos (by omega)
+    positivity
+  have h2n1 : (2 * (n : ℚ) - 1) ≠ 0 := by
+    have : (1 : ℚ) ≤ n := by exact_mod_cast hn
+    nlinarith
+  -- Bring the centred identity (★) into ℚ.
+  have hkey : (2 * (n : ℚ) - 1) *
+      ∑ k ∈ range (n + 1), (2 * (k : ℚ) - n) ^ 2 * ((n.choose k : ℚ)) ^ 2
+        = (n : ℚ) ^ 2 * ((2 * n).choose n : ℚ) := by
+    have h := centred_second_moment n hn
+    have hcast := congrArg (fun z : ℤ => (z : ℚ)) h
+    push_cast at hcast
+    convert hcast using 2
+  -- Rewrite (k − n/2)² = (2k − n)²/4 inside the sum.
+  have hsum : ∑ k ∈ range (n + 1), ((k : ℚ) - n / 2) ^ 2 * ((n.choose k : ℚ)) ^ 2
+      = (∑ k ∈ range (n + 1), (2 * (k : ℚ) - n) ^ 2 * ((n.choose k : ℚ)) ^ 2) / 4 := by
+    rw [Finset.sum_div]
+    exact Finset.sum_congr rfl (fun k _ => by ring)
+  rw [hsum]
+  field_simp
+  nlinarith [hkey]
+
+/-- Sanity check of `(★)` at `n = 3`:
+    `5 · ∑ (2k−3)²·C(3,k)² = 5·36 = 180 = 9·20 = 3²·C(6,3)`. -/
+example :
+    (2 * (3 : ℤ) - 1) *
+        ∑ k ∈ range 4, (2 * (k : ℤ) - 3) ^ 2 * (((3 : ℕ).choose k : ℤ)) ^ 2
+      = (3 : ℤ) ^ 2 * ((2 * 3).choose 3 : ℤ) := by decide
+
+/-- Sanity check at `n = 2`: `3 · (4 + 0 + 4) = 24 = 4·6 = 2²·C(4,2)`. -/
+example :
+    (2 * (2 : ℤ) - 1) *
+        ∑ k ∈ range 3, (2 * (k : ℤ) - 2) ^ 2 * (((2 : ℕ).choose k : ℤ)) ^ 2
+      = (2 : ℤ) ^ 2 * ((2 * 2).choose 2 : ℤ) := by decide
+
+end CombinationsFormulaOQ07OQ04OQ02

--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "variance-context",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "concept",
+    "title": "Formalizing the Variance of the Squared-Binomial Law",
+    "content": "Reading p_k = C(n,k)²/C(2n,n) as a probability distribution on {0,…,n} — the size of one half of a uniform Vandermonde split of a 2n-set, i.e. the hypergeometric law H(2n,n,n) — the OQ-07 family computed its zeroth moment ∑ C(n,k)² = C(2n,n), its mean n/2 (OQ-03), and its raw second moment ∑ k²·C(n,k)² = n²·C(2n−2,n−1) (parent OQ-04). Both OQ-03 and OQ-04 remark that these determine the variance n²/(4(2n−1)) but neither proves it. This entry supplies the variance, first as the cleared integer identity (2n−1)·∑ (2k−n)²·C(n,k)² = n²·C(2n,n) and then as the lowest-terms rational value n²/(4(2n−1)).",
+    "mathContext": "$p_k = \\binom{n}{k}^2/\\binom{2n}{n}$, $\\mathbb{E}[k] = n/2$, $\\operatorname{Var}(k) = \\dfrac{n^2}{4(2n-1)}$ — the variance of the hypergeometric law $H(2n,n,n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "variance / second central moment",
+      "hypergeometric distribution H(2n,n,n)",
+      "Vandermonde split",
+      "raw moments of binomial-square sums",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "the family's raw moments (zeroth, first, second)",
+      "the central-binomial halving and recurrence"
+    ]
+  },
+  {
+    "id": "centred-moment-thm",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "The Cleared Variance Identity",
+    "content": "centred_second_moment establishes (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) for n ≥ 1, entirely over ℤ. Expanding (2k−n)² = 4k² − 4nk + n² and distributing the sum reduces the left side to 4·∑ k²C² − 4n·∑ kC² + n²·∑ C²; casting the three ℕ moment closed forms (OQ-07 zeroth, OQ-03 first, OQ-04 second) to ℤ via exact_mod_cast turns it into 4n²·C(2n−2,n−1) − 4n²·C(2n−1,n−1) + n²·C(2n,n). With c = C(2n,n), a = C(2n−1,n−1), b = C(2n−2,n−1), the halving c = 2a and the recurrence n·c = 2(2n−1)·b collapse (2n−1)·(that) to n²·c in a single linear_combination.",
+    "mathContext": "Centring on the integer deviation $2k-n$ (twice $k-n/2$) keeps everything in $\\mathbb{Z}$. The identity $(2n-1)\\sum_k (2k-n)^2\\binom{n}{k}^2 = n^2\\binom{2n}{n}$ is the variance cleared of denominators.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "centred second moment",
+      "moment expansion (2k−n)² = 4k² − 4nk + n²",
+      "casting ℕ identities to ℤ",
+      "linear_combination",
+      "central-binomial halving and recurrence"
+    ],
+    "prerequisites": [
+      "sum_sq_weighted_sq, sum_weighted_sq, central_binom_eq_sum_sq",
+      "central_binom_two_mul_pred, central_binom_recurrence",
+      "Finset.mul_sum / sum_sub_distrib / sum_add_distrib"
+    ]
+  },
+  {
+    "id": "variance-eq-thm",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 140
+    },
+    "type": "theorem",
+    "title": "The Variance in Lowest Terms",
+    "content": "variance_eq establishes (∑_{k=0}^{n} (k − n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) for n ≥ 1, over ℚ. It pushes the integer identity centred_second_moment into ℚ, rewrites the centred square (k − n/2)² = (2k − n)²/4 termwise inside the sum (Finset.sum_div), and clears denominators with field_simp and nlinarith using C(2n,n) ≠ 0 (Nat.choose_pos) and 2n−1 ≠ 0. The result is the variance of the squared-binomial law in reduced rational form — the hypergeometric variance n·(K/N)·(1−K/N)·(N−n)/(N−1) at N = 2n, K = n.",
+    "mathContext": "$\\dfrac{\\sum_{k=0}^{n}(k-n/2)^2\\binom{n}{k}^2}{\\binom{2n}{n}} = \\dfrac{n^2}{4(2n-1)}$, with $(k-n/2)^2 = (2k-n)^2/4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "variance in lowest terms",
+      "rational normalization over ℚ",
+      "field_simp / nlinarith",
+      "hypergeometric variance",
+      "Nat.choose_pos"
+    ],
+    "prerequisites": [
+      "centred_second_moment (the cleared integer identity)",
+      "Finset.sum_div",
+      "field_simp, nlinarith"
+    ]
+  },
+  {
+    "id": "numeric-checks",
+    "proofId": "combinations-formula-oq-07-oq-04-oq-02",
+    "range": {
+      "startLine": 141,
+      "endLine": 153
+    },
+    "type": "example",
+    "title": "Numeric Checks",
+    "content": "Two kernel-decide checks confirm the cleared identity: at n = 3, (2·3−1)·∑_k (2k−3)²·C(3,k)² = 5·36 = 180 = 9·20 = 3²·C(6,3); at n = 2, (2·2−1)·∑_k (2k−2)²·C(2,k)² = 3·8 = 24 = 4·6 = 2²·C(4,2). These use kernel `decide` (not native_decide), so they add no axioms beyond the foundational propext, Classical.choice, Quot.sound.",
+    "mathContext": "$n=3$: $5\\cdot 36 = 180 = 3^2\\binom{6}{3}$. $n=2$: $3\\cdot 8 = 24 = 2^2\\binom{4}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "numeric verification",
+      "axiom hygiene"
+    ],
+    "prerequisites": [
+      "Finset.sum over an explicit range",
+      "Nat.choose evaluation"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04-oq-02/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "combinations-formula-oq-07-oq-04-oq-02",
+  "title": "The Variance of the Squared-Binomial (Vandermonde) Distribution",
+  "slug": "combinations-formula-oq-07-oq-04-oq-02",
+  "description": "Formalizes the variance the parent (OQ-07-OQ-04) computes the raw moments for but only states verbally. Reading C(n,k)²/C(2n,n) as the law of one half of a Vandermonde split of a 2n-set, the cleared, centred identity (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) holds for n ≥ 1; dividing by 4·(2n−1)·C(2n,n) yields the variance n²/(4(2n−1)) in lowest terms. The proof expands (2k−n)² = 4k² − 4nk + n² into the three raw moments already in the gallery — ∑ C(n,k)² = C(2n,n), ∑ k·C(n,k)² = n·C(2n−1,n−1) (OQ-03), ∑ k²·C(n,k)² = n²·C(2n−2,n−1) (parent OQ-04) — and closes by a single linear_combination of the halving C(2n,n) = 2·C(2n−1,n−1) and the recurrence n·C(2n,n) = 2(2n−1)·C(2n−2,n−1).",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ04OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "None. The cleared integer identity (2n−1)·∑ (2k−n)²·C(n,k)² = n²·C(2n,n) and the rational variance n²/(4(2n−1)) are stated for n ≥ 1 (the variance is only meaningful there) and are fully machine-checked over ℤ and ℚ respectively. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "sum-of-squares",
+      "weighted-sum",
+      "variance",
+      "second-moment",
+      "central-binomial",
+      "hypergeometric-variance",
+      "vandermonde"
+    ],
+    "dateAdded": "2026-06-24",
+    "originalContributions": [
+      "centred_second_moment: the cleared variance identity (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) for n ≥ 1, the integer form of the variance that the parent OQ-04 states but does not prove",
+      "variance_eq: the rational variance in lowest terms, (∑_{k=0}^{n} (k−n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) for n ≥ 1, formalizing over ℚ the value the OQ-03/OQ-04 family only computed verbally",
+      "The reduction of the centred second moment to the three raw moments of the family by expanding (2k−n)² = 4k² − 4nk + n² and casting each ℕ moment identity to ℤ, then collapsing via the central-binomial halving and recurrence in a single linear_combination",
+      "Worked checks (2·3−1)·∑_{k}(2k−3)²·C(3,k)² = 5·36 = 180 = 3²·C(6,3) and (2·2−1)·∑_{k}(2k−2)²·C(2,k)² = 3·8 = 24 = 2²·C(4,2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "CombinationsFormulaOQ07OQ04.sum_sq_weighted_sq",
+        "description": "The raw second moment ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) (parent OQ-04). Cast to ℤ it supplies the 4k² part of the centred-square expansion.",
+        "module": "Proofs.CombinationsFormulaOQ07OQ04"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07OQ03.sum_weighted_sq",
+        "description": "The first moment ∑_{k=0}^{n} k·C(n,k)² = n·C(2n−1,n−1) (OQ-03). Cast to ℤ it supplies the −4nk part of the centred-square expansion.",
+        "module": "Proofs.CombinationsFormulaOQ07OQ03"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07.central_binom_eq_sum_sq",
+        "description": "The zeroth moment C(2n,n) = ∑_{k=0}^{n} C(n,k)² (grandparent OQ-07). Cast to ℤ it supplies the +n² part of the centred-square expansion.",
+        "module": "Proofs.CombinationsFormulaOQ07"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07OQ03.central_binom_two_mul_pred",
+        "description": "The halving C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 (OQ-03). One of the two relations whose linear_combination closes the cleared identity.",
+        "module": "Proofs.CombinationsFormulaOQ07OQ03"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07OQ04.central_binom_recurrence",
+        "description": "The recurrence n·C(2n,n) = 2·(2n−1)·C(2n−2,n−1) for n ≥ 1 (parent OQ-04). The second relation in the closing linear_combination; together with the halving it collapses the centred moment to n²·C(2n,n).",
+        "module": "Proofs.CombinationsFormulaOQ07OQ04"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "Splits ∑ (f − g) = ∑ f − ∑ g (with sum_add_distrib and mul_sum) to separate the expanded centred square (2k−n)² = 4k² − 4nk + n² into the three raw moment sums.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ04OQ02.lean",
+    "namespace": "CombinationsFormulaOQ07OQ04OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The squared-binomial law p_k = C(n,k)²/C(2n,n) on {0,…,n} is the distribution of the overlap of two halves of a 2n-set under a uniform Vandermonde split, and it is the hypergeometric law H(2n, n, n). The OQ-07 family computed its zeroth moment ∑ C(n,k)² = C(2n,n) (the diagonal of Vandermonde's convolution), OQ-03 its first moment (mean n/2), and OQ-04 its raw second moment ∑ k²·C(n,k)² = n²·C(2n−2,n−1). Both OQ-03 and OQ-04 observe that these pin the variance at n²/(4(2n−1)), but neither states it as a theorem. This entry supplies the missing variance, both as a cleared integer identity over ℤ and as a reduced rational equality over ℚ. The value n²/(4(2n−1)) is the classical variance of the hypergeometric distribution H(2n,n,n) (population 2n, n draws, n successes), here obtained purely from the OQ-family's own moment identities.",
+    "problemStatement": "Open Question OQ-07-OQ-04-OQ-02 (posed by OQ-04): OQ-04 computes the raw moments of C(n,k)²/C(2n,n) and remarks that, together with OQ-03's mean n/2, they determine the variance n²/(4(2n−1)). Formalize that variance. State a machine-checked identity for the centred second moment ∑ (k − n/2)²·C(n,k)² and reduce it to the lowest-terms rational value n²/(4(2n−1)).",
+    "proofStrategy": "Work the cleared, integer form first. Over ℤ, expand the centred square (2k−n)² = 4k² − 4nk + n² and distribute the sum (Finset.mul_sum, sum_sub_distrib, sum_add_distrib) to get ∑ (2k−n)²·C(n,k)² = 4·∑ k²C² − 4n·∑ kC² + n²·∑ C². Cast the three ℕ moment closed forms (OQ-07 zeroth, OQ-03 first, OQ-04 second) to ℤ via exact_mod_cast. With a = C(2n−1,n−1), b = C(2n−2,n−1), c = C(2n,n), the centred moment becomes 4n²b − 4n²a + n²c; the halving c = 2a (central_binom_two_mul_pred) and recurrence n·c = 2(2n−1)b (central_binom_recurrence), themselves cast to ℤ, collapse (2n−1)·(4n²b − 4n²a + n²c) to n²c in a single linear_combination. For the rational form, push the integer identity into ℚ, rewrite (k − n/2)² = (2k − n)²/4 inside the sum, and clear denominators (field_simp, nlinarith) using C(2n,n) ≠ 0 and 2n−1 ≠ 0.",
+    "keyInsights": [
+      "Centring on 2k − n rather than k − n/2 keeps the whole computation inside ℤ: the deviation 2k − n is an integer even though the mean n/2 may be a half-integer, so the variance identity can be stated and proved without leaving the integers until the final rational read-off.",
+      "The variance needs nothing new: expanding the centred square reduces it to exactly the three raw moments the family already proved (zeroth, first, second), so the entire content is the algebraic collapse of their linear combination.",
+      "That collapse is governed by just two central-binomial relations — the halving c = 2a and the recurrence n·c = 2(2n−1)b — and is a single linear_combination once both are cast to ℤ; no new combinatorial lemma is required.",
+      "Truncated ℕ subtraction in 2n−1 is handled once, by omega, when casting the recurrence to ℤ (for n ≥ 1, (2n−1 : ℕ) coerces to 2n−1 over ℤ); the choose indices 2n−1, n−1, 2n−2 stay as opaque ℕ expressions throughout.",
+      "Dividing the cleared identity by 4·(2n−1)·C(2n,n) gives the variance n²/(4(2n−1)) in lowest terms — the standard hypergeometric variance n·(K/N)·(1−K/N)·(N−n)/(N−1) specialised to N = 2n, K = n, draws n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Header stating OQ-07-OQ-04-OQ-02: the variance of the squared-binomial law C(n,k)²/C(2n,n), the cleared centred identity (2n−1)·∑ (2k−n)²·C(n,k)² = n²·C(2n,n), the reduction to the family's three raw moments, and the lowest-terms variance n²/(4(2n−1))."
+    },
+    {
+      "id": "centred-moment",
+      "title": "The Cleared Variance Identity",
+      "startLine": 61,
+      "endLine": 105,
+      "summary": "centred_second_moment: (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) for n ≥ 1. Expands (2k−n)² into the three raw moments (cast from ℕ via exact_mod_cast), then closes with a single linear_combination of the halving C(2n,n) = 2·C(2n−1,n−1) and the recurrence n·C(2n,n) = 2(2n−1)·C(2n−2,n−1)."
+    },
+    {
+      "id": "variance",
+      "title": "The Variance in Lowest Terms",
+      "startLine": 107,
+      "endLine": 140,
+      "summary": "variance_eq: (∑_{k=0}^{n} (k − n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) for n ≥ 1, over ℚ. Pushes the integer identity into ℚ, rewrites (k − n/2)² = (2k − n)²/4 inside the sum, and clears denominators using C(2n,n) ≠ 0 and 2n−1 ≠ 0."
+    },
+    {
+      "id": "checks",
+      "title": "Numeric Checks",
+      "startLine": 141,
+      "endLine": 153,
+      "summary": "Kernel-decide checks of the cleared identity at n = 3 (5·36 = 180 = 3²·C(6,3)) and n = 2 (3·8 = 24 = 2²·C(4,2))."
+    }
+  ],
+  "conclusion": {
+    "summary": "2 theorems, 0 sorries, 0 axioms. The cleared variance identity (2n−1)·∑_{k=0}^{n} (2k−n)²·C(n,k)² = n²·C(2n,n) (over ℤ, n ≥ 1) and its lowest-terms rational form (∑ (k−n/2)²·C(n,k)²)/C(2n,n) = n²/(4(2n−1)) (over ℚ) formalize the variance of the squared-binomial law C(n,k)²/C(2n,n). The whole proof expands the centred square into the family's three already-proved raw moments and collapses their combination via the central-binomial halving and recurrence in a single linear_combination.",
+    "implications": "Completes the moment computation of the OQ-07-OQ-04 family by formalizing the variance the parent only stated verbally. The technique — centre on the integer deviation 2k − n to stay in ℤ, expand into known raw moments, and collapse via the two central-binomial relations — is a reusable route to variances of symmetric binomial-square sums. The value n²/(4(2n−1)) is the variance of the hypergeometric distribution H(2n,n,n), now derived inside Lean from the family's own identities rather than imported.",
+    "openQuestions": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07-oq-04",
+      "relationship": "parent — OQ-04 computes the raw second moment ∑ k²·C(n,k)² = n²·C(2n−2,n−1) and states (without proof) the variance n²/(4(2n−1)); this entry supplies the variance, reusing OQ-04's second moment and central_binom_recurrence"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-03",
+      "relationship": "uncle — supplies the first moment ∑ k·C(n,k)² = n·C(2n−1,n−1) and the halving C(2n,n) = 2·C(2n−1,n−1), both used in the centred-moment reduction"
+    },
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "grandparent — proves the zeroth moment C(2n,n) = ∑ C(n,k)², the +n² term of the centred-square expansion"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-04-oq-01",
+      "relationship": "sibling — computes the general r-th falling-factorial moment ∑ (k)_r·C(n,k)² = (n)_r·C(2n−r,n−r); this entry complements it with the variance (the second central moment)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **variance** of the squared-binomial (Vandermonde) distribution `p_k = C(n,k)²/C(2n,n)` — the value the parent **OQ-07-OQ-04** computes raw moments for and states verbally (`n²/(4(2n−1))`) but never proves as a theorem.

Two verified theorems (over ℤ then ℚ):

1. **`centred_second_moment`** — the cleared integer identity, for `n ≥ 1`:
   ```
   (2n − 1) · ∑_{k=0}^{n} (2k − n)² · C(n,k)²  =  n² · C(2n, n)
   ```
2. **`variance_eq`** — the lowest-terms rational variance, for `n ≥ 1`:
   ```
   (∑_{k=0}^{n} (k − n/2)² · C(n,k)²) / C(2n, n)  =  n² / (4(2n − 1))
   ```
   the variance of the hypergeometric law `H(2n, n, n)`.

## Proof

Centring on the **integer** deviation `2k − n` keeps the whole computation in ℤ. Expanding `(2k−n)² = 4k² − 4nk + n²` reduces the centred moment to the family's three already-proved raw moments:

- `∑ C(n,k)² = C(2n,n)` (OQ-07, zeroth),
- `∑ k·C(n,k)² = n·C(2n−1,n−1)` (OQ-03, first),
- `∑ k²·C(n,k)² = n²·C(2n−2,n−1)` (parent OQ-04, second).

Casting each to ℤ, the centred moment collapses to `n²·C(2n,n)` via the central-binomial **halving** `C(2n,n)=2·C(2n−1,n−1)` and **recurrence** `n·C(2n,n)=2(2n−1)·C(2n−2,n−1)` in a single `linear_combination`. The rational form follows by `(k−n/2)² = (2k−n)²/4` and clearing denominators.

This is distinct from the sibling **OQ-04-OQ-01** (general r-th *falling-factorial* moment): this entry supplies the **second central moment / variance** in lowest terms, completing the family's moment computation.

## Verification

- **2 theorems, 154 lines, 0 sorries, 0 axioms.**
- `#print axioms` on both theorems: only `propext`, `Classical.choice`, `Quot.sound`. Numeric checks use kernel `decide` (no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`).
- Compiles against the existing OQ-07 family oleans (`lake env lean`).
- Gallery `meta.json` + `annotations.json` added; `annotations:validate` clean for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)