### PR TITLE
Enrich Cantor/Lawvere Type & presheaf instances (oq-04-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-lawtype-overview",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 49 },
+    "type": "context",
+    "title": "Cashing Out the Abstract Lawvere Theorem in Two Models",
+    "content": "The docstring frames the open question: the parent entry proved Lawvere's fixed-point theorem at full categorical generality (in any cartesian closed category, a point-surjective φ : A ⟶ (A ⟹ B) forces every endomorphism t : B ⟶ B to have a fixed global point). This file instantiates it in the two standard models — the category Type of sets and presheaf topoi C ⥤ Type — recovering Cantor's theorem as a literal corollary. The crux is a computational 'bridge' showing that in Type the categorical vocabulary (global points, exponentials, evaluation, point-surjectivity) decodes exactly to the set-theoretic notions (elements, function types, application, surjectivity), so the categorical hypothesis is not merely analogous to the classical one but identical to it.",
+    "mathContext": "Lawvere: point-surjective $\\varphi : A \\to (A \\Rightarrow B) \\Rightarrow$ every $t : B \\to B$ has a fixed point. Cantor is the case $B = \\mathrm{Bool}$, $t = \\lnot$.",
+    "significance": "context",
+    "relatedConcepts": ["Lawvere fixed-point theorem", "Cantor's diagonal argument", "cartesian closed category", "presheaf topos"],
+    "prerequisites": ["category theory basics", "cartesian closed categories", "the parent CCC Lawvere theorem"]
+  },
+  {
+    "id": "ann-lawtype-bridge",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 85 },
+    "type": "technique",
+    "title": "The Type Bridge: Evaluation, Uncurrying, and Names Are Honest Application",
+    "content": "Three lemmas translate the cartesian-closed structure on Type into ordinary set theory. `ev_apply`: the categorical evaluation (exp.ev A).app X (a, h) is literally h a — true by rfl on Mathlib's model A ⟹ X = (A → X). `uncurry_apply`: uncurrying g : Y ⟶ (A ⟹ X) gives (uncurry g)(a,y) = g y a, unfolded via CartesianClosed.uncurry_eq, types_comp_apply, and whiskerLeft_apply. `name_apply`: the categorical *name* of f : A → B — the global point name f : 𝟙_ ⟶ (A ⟹ B) — picks out f itself, name f PUnit.unit = f, proved from uncurry_curry and the right-unitor. Together these strip the categorical wrapper off every operation the Lawvere theorem uses.",
+    "mathContext": "$\\mathrm{ev}(a,h) = h\\,a$; $\\ \\mathrm{uncurry}\\,g\\,(a,y) = g\\,y\\,a$; $\\ \\mathrm{name}\\,f\\,(\\ast) = f$.",
+    "significance": "key",
+    "relatedConcepts": ["cartesian closed structure on Type", "evaluation and currying", "Types.tensorProductAdjunction", "monoidal unit PUnit"],
+    "prerequisites": ["exponential objects", "uncurry/curry adjunction", "Mathlib CategoryTheory.Monoidal.Closed.Types"]
+  },
+  {
+    "id": "ann-lawtype-pointsurj",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 104 },
+    "type": "insight",
+    "title": "Categorical Point-Surjectivity = Honest Surjectivity",
+    "content": "`pointSurjective_iff_surjective` is the heart of the bridge: for φ : A ⟶ (A ⟹ B), the categorical PointSurjective φ (every global point of A ⟹ B factors through φ after naming) is equivalent to Function.Surjective φ. The forward direction uses name_apply to convert a categorical witness into a set-theoretic preimage (evaluating the naming square at PUnit.unit); the reverse builds a constant global point fun _ => a from a set-theoretic preimage and checks the naming condition via name_apply again. This equivalence is exactly the 'single non-formal modelling choice' of the parent — point-surjectivity vs. Lean surjectivity — shown to be faithful in Type, so the categorical hypothesis decodes precisely to the classical one.",
+    "mathContext": "$\\mathrm{PointSurjective}\\,\\varphi \\iff \\mathrm{Surjective}\\,\\varphi$ for $\\varphi : A \\to (A \\to B)$.",
+    "significance": "key",
+    "relatedConcepts": ["point-surjectivity", "global points", "decategorification", "surjectivity"],
+    "prerequisites": ["name_apply", "global points as elements"]
+  },
+  {
+    "id": "ann-lawtype-diagonal",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 118 },
+    "type": "insight",
+    "title": "Lawvere's Diagonal in Type",
+    "content": "`no_surjective_of_fixedPointFree`: any fixed-point-free t : B → B forbids a surjection A → (A → B). The proof translates a set-theoretic fixed-point-free hypothesis into the categorical form — a global point s : 𝟙_ ⟶ B fixed by t would give t (s PUnit.unit) = s PUnit.unit, contradicting ht — and then feeds the surjection through the parent's lawvere_cantor, converting it to point-surjectivity via pointSurjective_iff_surjective. This is the decategorified Lawvere diagonal: the would-be diagonal value f a = t (φ a a) cannot be in the image of a surjection.",
+    "mathContext": "$(\\forall b,\\ t\\,b \\neq b) \\Rightarrow$ no surjection $A \\to (A \\to B)$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "fixed-point-free endomorphism", "lawvere_cantor", "self-reference"],
+    "prerequisites": ["the parent lawvere_cantor", "pointSurjective_iff_surjective"]
+  },
+  {
+    "id": "ann-lawtype-cantor",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 136 },
+    "type": "concept",
+    "title": "Cantor's Theorem as a One-Line Corollary",
+    "content": "`cantor_no_surjective` recovers the classical Cantor diagonal — no surjection A → (A → Bool) — by instantiating no_surjective_of_fixedPointFree at the fixed-point-free negation t = (!·), whose fixed-point-freeness is Bool.not_ne_self. `cantor_exists_missed` restates it existentially: some g : A → Bool lies outside the image of any φ (the diagonal complement), proved by contradiction. The significance: Cantor's theorem is here literally a special case of the categorical Lawvere theorem, not merely an analogue — the same diagonal that underlies Russell, Gödel, Tarski, and Turing.",
+    "mathContext": "No surjection $A \\to (A \\to \\mathrm{Bool})$, since $b \\mapsto \\lnot b$ has no fixed point; equivalently $|A| < |2^A|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cantor's theorem", "negation as fixed-point-free map", "Russell/Gödel/Tarski/Turing diagonal", "power set"],
+    "prerequisites": ["no_surjective_of_fixedPointFree", "Bool.not_ne_self"]
+  },
+  {
+    "id": "ann-lawtype-presheaf",
+    "proofId": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 142, "endLine": 157 },
+    "type": "concept",
+    "title": "The Presheaf-Topos Instance",
+    "content": "`lawvere_fixedPoint_presheaf` and `lawvere_cantor_presheaf` apply the abstract theorem in a presheaf topos C ⥤ Type u, where Mathlib already provides the CartesianClosed instance. Because the parent's theorem is stated for an arbitrary CCC, no bridge is needed here — the abstract statements apply verbatim: a point-surjective φ : A ⟶ (A ⟹ B) of presheaves forces a fixed global point of any t, and dually a fixed-point-free t blocks point-surjectivity. This confirms the same categorical machine runs unchanged in a genuine topos, isolating the diagonal phenomenon as one statement spanning sets and toposes.",
+    "mathContext": "In $C \\Rightarrow \\mathbf{Type}$: point-surjective $\\varphi \\Rightarrow t$ has a fixed global section; fixed-point-free $t \\Rightarrow \\varphi$ not point-surjective.",
+    "significance": "supporting",
+    "relatedConcepts": ["presheaf topos", "CartesianClosed (C ⥤ Type)", "topos theory", "generality of CCC theorems"],
+    "prerequisites": ["presheaf categories", "the abstract lawvere_fixedPoint / lawvere_cantor"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ04OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cantorDiagonalizationOq04Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq04Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq04Oq01Oq01Oq01Data: ProofData = {
+  proof: cantorDiagonalizationOq04Oq01Oq01Oq01Proof,
+  annotations: cantorDiagonalizationOq04Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
   "slug": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",
+  "description": "Instantiates the parent's abstract Lawvere fixed-point theorem (in any cartesian closed category) in its two standard models — the category Type of sets and presheaf topoi C ⥤ Type — recovering Cantor's theorem (no surjection A → (A → Bool)) as a literal corollary via a computational bridge that identifies categorical point-surjectivity with honest surjectivity.",
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -148,6 +149,68 @@
     }
   ],
   "sorries": 0,
+  "overview": {
+    "historicalContext": "Cantor's 1891 diagonal argument (no surjection from a set onto its power set, |A| < |2^A|) and the family of self-referential results it anticipates — Russell's paradox, Gödel's incompleteness, Tarski's undefinability, Turing's halting problem — were unified by F. William Lawvere in 1969 into a single categorical statement: in any cartesian closed category, a point-surjective morphism A ⟶ (A ⟹ B) forces every endomorphism of B to have a fixed point. The parent entry cantor-diagonalization-oq-04-oq-01-oq-01 formalized this abstract theorem; the open question it left was to verify that the abstraction is faithful — that the categorical hypotheses really do specialize to the classical ones in concrete models. This entry does exactly that for the category of sets (Type) and for presheaf topoi, following the point-surjectivity exposition of Yanofsky (2003).",
+    "problemStatement": "Instantiate the parent's CCC Lawvere theorem in concrete categories: derive Cantor's theorem in Type (no surjection A → (A → Bool)) and the fixed-point form in a presheaf topos C ⥤ Type as corollaries of lawvere_fixedPoint, by exhibiting the CartesianClosed instances and a fixed-point-free endomorphism, and by proving that categorical point-surjectivity coincides with honest surjectivity in Type.",
+    "proofStrategy": "For C = Type u, Mathlib supplies CartesianClosed (Type u) with monoidal unit PUnit, exponential A ⟹ B = (A → B), and evaluation as application. A three-lemma bridge (ev_apply, uncurry_apply, name_apply) shows every categorical operation is honest function application; in particular the name of f : A → B evaluates back to f. These collapse LawvereCCC.PointSurjective φ to Function.Surjective φ (pointSurjective_iff_surjective). Feeding a fixed-point-free t : B → B through the parent's lawvere_cantor then yields no_surjective_of_fixedPointFree, of which Cantor's theorem cantor_no_surjective (via t = negation, fixed-point-free by Bool.not_ne_self) is the headline instance. For presheaf topoi C ⥤ Type u, Mathlib's CartesianClosed instance lets the abstract theorem apply verbatim with no bridge (lawvere_fixedPoint_presheaf, lawvere_cantor_presheaf).",
+    "keyInsights": [
+      "**The modelling choice is faithful, not just analogous**: the parent stated its theorem with categorical point-surjectivity and global points rather than Lean-level surjections and elements. pointSurjective_iff_surjective proves these decode *exactly* to each other in Type, so Cantor's theorem is literally a corollary of the Lawvere theorem — not a parallel result.",
+      "**Global points are elements because the unit is PUnit**: in Type the monoidal unit 𝟙_ is PUnit, so a global point 𝟙_ ⟶ A is a function PUnit → A, i.e. a single element a PUnit.unit. This single fact is what turns categorical 'points' into set elements throughout the bridge.",
+      "**The name of f evaluates to f**: name_apply (name f PUnit.unit = f) is the linchpin that lets a categorical naming square be read off as an ordinary equation of functions, powering both directions of the point-surjectivity equivalence.",
+      "**Negation is the engine of Cantor**: the entire force of Cantor's theorem is packed into the fixed-point-free witness t = (!·) on Bool (Bool.not_ne_self). Lawvere's abstraction makes explicit that 'the diagonal element differs from every row' is exactly 'the flipping endomorphism has no fixed point'.",
+      "**One machine, two models**: because the parent's theorem holds in any CCC, the presheaf-topos instances need no new work — they apply verbatim, demonstrating that the same diagonal phenomenon governs both sets and toposes from a single categorical statement."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header: Instantiating Lawvere in Type and Presheaves",
+      "startLine": 4,
+      "endLine": 49,
+      "summary": "Module docstring stating the open question — derive Cantor in Type and the fixed-point form in a presheaf topos as corollaries of the parent's lawvere_fixedPoint — and answering YES. Outlines the Type bridge (point-surjectivity = surjectivity) and lists the nine results. Imports Mathlib and the parent module.",
+      "mathContext": "Point-surjective $\\varphi : A \\to (A \\Rightarrow B) \\Rightarrow$ every $t : B \\to B$ has a fixed point."
+    },
+    {
+      "id": "type-bridge",
+      "title": "The Type Bridge: ev / uncurry / name",
+      "startLine": 60,
+      "endLine": 85,
+      "summary": "ev_apply, uncurry_apply, name_apply: the three computational lemmas identifying cartesian-closed evaluation, uncurrying, and naming in Type with honest function application. ev_apply is rfl; uncurry_apply unfolds via uncurry_eq + whiskerLeft; name_apply (name f PUnit.unit = f) uses uncurry_curry and the right-unitor.",
+      "mathContext": "$\\mathrm{ev}(a,h)=h\\,a$, $\\ \\mathrm{uncurry}\\,g\\,(a,y)=g\\,y\\,a$, $\\ \\mathrm{name}\\,f\\,(\\ast)=f$."
+    },
+    {
+      "id": "point-surjective",
+      "title": "Point-Surjectivity = Surjectivity",
+      "startLine": 87,
+      "endLine": 104,
+      "summary": "`pointSurjective_iff_surjective`: for φ : A ⟶ (A ⟹ B), categorical PointSurjective φ ↔ Function.Surjective φ. Both directions hinge on name_apply (forward: a categorical witness gives a preimage; reverse: a preimage gives a constant global point). The decategorification that makes Cantor a literal corollary.",
+      "mathContext": "$\\mathrm{PointSurjective}\\,\\varphi \\iff \\mathrm{Surjective}\\,\\varphi$."
+    },
+    {
+      "id": "lawvere-diagonal",
+      "title": "Lawvere's Diagonal in Type",
+      "startLine": 106,
+      "endLine": 120,
+      "summary": "`no_surjective_of_fixedPointFree`: a fixed-point-free t : B → B forbids any surjection A → (A → B). Converts the set-level fixed-point-free hypothesis into the categorical form on global points and feeds the surjection through the parent's lawvere_cantor via pointSurjective_iff_surjective.",
+      "mathContext": "$(\\forall b,\\ t\\,b \\neq b) \\Rightarrow$ no surjection $A \\to (A \\to B)$."
+    },
+    {
+      "id": "cantor",
+      "title": "Cantor's Theorem as a Corollary",
+      "startLine": 122,
+      "endLine": 136,
+      "summary": "`cantor_no_surjective`: no surjection A → (A → Bool), from the fixed-point-free negation t = (!·) (Bool.not_ne_self). `cantor_exists_missed`: the existential restatement — some g : A → Bool is missed by every φ (the diagonal complement).",
+      "mathContext": "No surjection $A \\to (A \\to \\mathrm{Bool})$; equivalently $|A| < |2^A|$."
+    },
+    {
+      "id": "presheaf",
+      "title": "The Presheaf-Topos Instance",
+      "startLine": 138,
+      "endLine": 159,
+      "summary": "`lawvere_fixedPoint_presheaf` and `lawvere_cantor_presheaf`: the fixed-point form and its Cantor obstruction in a presheaf topos C ⥤ Type u, applying the abstract theorem verbatim through Mathlib's CartesianClosed (C ⥤ Type u) instance — no bridge needed.",
+      "mathContext": "Same theorem in $C \\Rightarrow \\mathbf{Type}$: point-surjective $\\varphi \\Rightarrow$ fixed global section of $t$."
+    }
+  ],
   "conclusion": {
     "summary": "The abstract Lawvere fixed-point theorem of the parent entry is instantiated in its two standard models. For C = Type u, a short computational bridge identifies the categorical data with set-theoretic data: the monoidal unit is PUnit so global points 𝟙_ ⟶ A are elements, the exponential A ⟹ B is the function type A → B, and evaluation/uncurrying are honest application (ev_apply, uncurry_apply); consequently the name of f evaluates back to f (name_apply), and categorical point-surjectivity coincides with honest surjectivity (pointSurjective_iff_surjective). Feeding a fixed-point-free t : B → B through lawvere_cantor yields no_surjective_of_fixedPointFree, of which Cantor's theorem cantor_no_surjective (no surjection A → (A → Bool), via t = negation) is the headline instance. For presheaf topoi C ⥤ Type u, Mathlib's CartesianClosed instance lets the abstract theorem apply verbatim (lawvere_fixedPoint_presheaf, lawvere_cantor_presheaf). 159 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "This resolves the parent's headline open question. The single non-formal modelling choice in the parent — using point-surjectivity and global points rather than Lean-level surjections and elements — is here shown to be a faithful one in Type: the categorical hypothesis decodes exactly to the classical one, so Cantor's theorem is literally a corollary of the categorical Lawvere theorem, not merely an analogue. The presheaf instances confirm the same machine applies unchanged in a genuine topos, isolating the Cantor/Russell/Gödel/Tarski/Turing diagonal as one categorical statement.",


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-04-oq-01-oq-01-oq-01` (quality 15, 0 prior passes).

The entry had a rich `meta` block and object-schema `conclusion`/`crossReferences`, but was **missing `index.ts`** (so the page showed "proof not found" on the live site), **no `annotations.json`**, **no `overview`**, **no `sections`**, and **no top-level `description`**.

## Changes
- **Added `index.ts`** (required Vite entry point) so the proof loads.
- **Added `annotations.json`**: 6 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — the Type bridge (ev/uncurry/name), point-surjectivity ↔ surjectivity, Lawvere's diagonal in Type, Cantor as a corollary, and the presheaf-topos instance.
- **Added `overview`** object: historicalContext (Cantor 1891 → Lawvere 1969 → Russell/Gödel/Tarski/Turing unification), problemStatement, proofStrategy, 5 keyInsights.
- **Added `sections`**: 6 sections with line ranges + mathContext covering all 159 lines.
- **Added top-level `description`**. Preserved existing conclusion, crossReferences, openQuestions, references, and meta block unchanged.

## Verification
- JSON validates; `pnpm annotations:validate` reports **0 errors** for this entry (all 6 annotations anchor to real Lean constructs).
- Content faithful to `CantorDiagonalizationOQ04OQ01OQ01OQ01.lean`: 9 theorems/lemmas, 0 axioms, 0 sorries — `status: verified`, `badge: original` confirmed (depends only on propext / Classical.choice / Quot.sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)