### PR TITLE
audit: clear 7 unaudited research leaves — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21783,6 +21783,48 @@
       "lastAudited": "2026-06-24T16:12:18Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-02-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fibonacci-identities-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-reflection-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:25:02Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — batch of 7

All 7 previously-unaudited leaves verified **CLEAN**. meta.json claims (status=verified, sorries=0, axiomCount=0) match Lean source exactly.

| Leaf | Badge | Result |
|------|-------|--------|
| abel-ruffini-oq-04-oq-02-oq-02-oq-06 | mathlib | clean (Tier B, mathlibDeps disclosed) |
| divisibility-rules-oq-01-oq-01-oq-02 | original | clean |
| fibonacci-identities-oq-02-oq-01-oq-01-oq-02 | original | clean |
| fibonacci-identities-oq-05-oq-01 | original | clean |
| gamma-reflection-formula-oq-01-oq-01-oq-01 | original | clean |
| geometric-series-oq-07-oq-02 | original | clean |
| mean-value-theorem-oq-02-oq-01-oq-02 | original | clean |

### Checks performed (per file)
- **0 real sorries** (grep, excluding comments)
- **0 `axiom` declarations**
- **0 real `native_decide`** — the 3 grep hits in abel-ruffini (×2) and fibonacci-oq-05-oq-01 (×1) are all docstring lines stating *"no native_decide"* / *"uses kernel `decide` only"*, confirmed via `grep -n`. No `Lean.ofReduceBool` dependency.
- **0 True stubs / admit**
- **0 structure/class declarations** → no structure-encoded assumptions
- Badges appropriate: abel-ruffini correctly `mathlib` (core via Mathlib derivedSeries/solvable machinery, all deps disclosed); the other 6 are genuine `original` derivations from parent + Mathlib lemmas, all dependencies disclosed in `mathlibDependencies`.

Coverage: 3508 → 3515 audited. (Remaining 1 unaudited = `bernoulli-inequality-oq-01-oq-02-oq-01`, untracked working-tree pollution not in origin/main — excluded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)