### PR TITLE
research(pythagorean-triples-oq-08-oq-01): per-leg divisibility by 3 and 4 in a primitive triple [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3528,6 +3528,7 @@ import Proofs.PythagoreanTriplesOQ06OQ01
 import Proofs.PythagoreanTriplesOQ06OQ01OQ01
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
+import Proofs.PythagoreanTriplesOQ08OQ01
 import Proofs.PythagoreanTriplesOQ09
 import Proofs.PythagoreanTriplesOQ10
 import Proofs.QuadraticGaussSumDiagonal

--- a/proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean
@@ -1,0 +1,138 @@
+/-
+  # Per-Leg Divisibility in a Primitive Pythagorean Triple
+  # (pythagorean-triples-oq-08-oq-01)
+
+  ## The Open Question
+
+  The parent entry `pythagorean-triples-oq-08` proves the *product*-level
+  divisibilities `3 ∣ x·y`, `4 ∣ x·y` and `60 ∣ x·y·z` for **every** Pythagorean
+  triple. Its first listed open question asks to *sharpen* this:
+
+  > In a primitive triple exactly one leg is divisible by `4` and exactly one leg
+  > by `3` (not merely the product). Can the per-leg statement be formalised?
+
+  This file answers it. Under the primitivity hypothesis `IsCoprime x y`:
+
+  * **`exactly_one_leg_div_four`** — exactly one of the legs `x`, `y` is divisible
+    by `4`. (The product result `4 ∣ x·y` only says the legs *together* carry four
+    factors of two; it does not pin them onto one leg.)
+
+  * **`exactly_one_leg_div_three`** — exactly one of the legs is divisible by `3`.
+
+  ## Why primitivity is essential
+
+  Both sharpenings *fail* without coprimality. For the scaled triple `(6, 8, 10)`
+  (= `2·(3,4,5)`) both legs are even and `4 ∣ 6·8`, yet `4 ∣ 8` while `4 ∤ 6` — here
+  it still happens to be one leg, but for `(9, 12, 15)` we have `3 ∣ 9` *and*
+  `3 ∣ 12`, so the per-leg "exactly one" statement is genuinely false without
+  primitivity. The coprimality hypothesis forbids a common factor and forces the
+  obstruction onto a single leg.
+
+  ## Proof idea
+
+  Everything reduces to the parent's product divisibilities plus the key
+  consequence of `IsCoprime x y`: a prime cannot divide both legs (else it would be
+  a unit). Concretely, for the factor `4`:
+
+  * `4 ∣ x·y` ⟹ `2 ∣ x·y` ⟹ (prime `2`) one leg is even;
+  * coprimality ⟹ the other leg is odd, hence coprime to `4`;
+  * cancelling the odd leg out of `4 ∣ x·y` lands all four factors of two on the
+    even leg, giving `4 ∣` (even leg) and `4 ∤` (odd leg).
+
+  For `3` the argument is the bare prime/coprime split of `3 ∣ x·y`.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib
+import Proofs.PythagoreanTriplesOQ08
+
+namespace PythagoreanTriplesPerLeg
+
+open PythagoreanTriple PythagoreanTriplesSixty
+
+variable {x y z : ℤ}
+
+/-- In a primitive triple a prime cannot divide both legs: it would have to be a
+unit, but `2` and `3` (and indeed every prime of `ℤ`) are non-units. -/
+theorem not_dvd_both_of_coprime {p : ℤ} (hp : Prime p) (hcop : IsCoprime x y) :
+    ¬ (p ∣ x ∧ p ∣ y) := by
+  rintro ⟨hx, hy⟩
+  exact hp.not_unit (hcop.isUnit_of_dvd' hx hy)
+
+/-! ## Divisibility by three -/
+
+/-- **Exactly one leg is divisible by `3`** in a primitive Pythagorean triple.
+The parent gives `3 ∣ x·y`; primitivity forbids `3` from dividing both legs. -/
+theorem exactly_one_leg_div_three
+    (h : PythagoreanTriple x y z) (hcop : IsCoprime x y) :
+    (3 ∣ x ∧ ¬ (3 ∣ y)) ∨ (¬ (3 ∣ x) ∧ 3 ∣ y) := by
+  have h3 : (3 : ℤ) ∣ x * y := three_dvd_legs h
+  have hnb : ¬ ((3 : ℤ) ∣ x ∧ (3 : ℤ) ∣ y) := not_dvd_both_of_coprime Int.prime_three hcop
+  rcases Int.prime_three.dvd_or_dvd h3 with hx | hy
+  · exact Or.inl ⟨hx, fun hy => hnb ⟨hx, hy⟩⟩
+  · exact Or.inr ⟨fun hx => hnb ⟨hx, hy⟩, hy⟩
+
+/-! ## Divisibility by four -/
+
+/-- The even leg of a primitive triple is divisible by `4`, the odd one is not.
+This is the heart of the `4`-sharpening: cancelling the odd (hence `4`-coprime) leg
+out of `4 ∣ x·y` forces all four factors of two onto the even leg. -/
+theorem four_dvd_even_leg
+    (h4 : (4 : ℤ) ∣ x * y) (hodd : ¬ (2 : ℤ) ∣ y) :
+    (4 : ℤ) ∣ x := by
+  -- `2` is coprime to the odd leg `y`, hence so is `4 = 2·2`.
+  have hc2 : IsCoprime (2 : ℤ) y := (Int.prime_two.coprime_iff_not_dvd).mpr hodd
+  have hc4 : IsCoprime (4 : ℤ) y := by
+    have : (4 : ℤ) = 2 * 2 := by norm_num
+    rw [this]; exact hc2.mul_left hc2
+  exact hc4.dvd_of_dvd_mul_right h4
+
+/-- **Exactly one leg is divisible by `4`** in a primitive Pythagorean triple.
+The parent gives `4 ∣ x·y`; primitivity forces the four factors of two onto the
+single even leg. -/
+theorem exactly_one_leg_div_four
+    (h : PythagoreanTriple x y z) (hcop : IsCoprime x y) :
+    (4 ∣ x ∧ ¬ (4 ∣ y)) ∨ (¬ (4 ∣ x) ∧ 4 ∣ y) := by
+  have h4 : (4 : ℤ) ∣ x * y := four_dvd_legs h
+  -- At least one leg is even.
+  have h2 : (2 : ℤ) ∣ x * y := dvd_trans (by norm_num) h4
+  have hnb : ¬ ((2 : ℤ) ∣ x ∧ (2 : ℤ) ∣ y) := not_dvd_both_of_coprime Int.prime_two hcop
+  -- `4 ∣ a` forces `2 ∣ a`, so an odd leg is never divisible by `4`.
+  have not_four : ∀ {a : ℤ}, ¬ (2 : ℤ) ∣ a → ¬ (4 : ℤ) ∣ a :=
+    fun hodd hd => hodd (dvd_trans (by norm_num) hd)
+  rcases Int.prime_two.dvd_or_dvd h2 with hx2 | hy2
+  · -- `x` even ⟹ `y` odd ⟹ `4 ∣ x`, `4 ∤ y`.
+    have hy_odd : ¬ (2 : ℤ) ∣ y := fun hy => hnb ⟨hx2, hy⟩
+    exact Or.inl ⟨four_dvd_even_leg h4 hy_odd, not_four hy_odd⟩
+  · -- `y` even ⟹ `x` odd ⟹ `4 ∣ y`, `4 ∤ x`.
+    have hx_odd : ¬ (2 : ℤ) ∣ x := fun hx => hnb ⟨hx, hy2⟩
+    have h4y : (4 : ℤ) ∣ y := four_dvd_even_leg (by rwa [mul_comm] at h4) hx_odd
+    exact Or.inr ⟨not_four hx_odd, h4y⟩
+
+/-! ## Capstone -/
+
+/-- **Per-leg sharpening of the parent product divisibilities.** In a primitive
+Pythagorean triple exactly one leg is divisible by `4` and exactly one by `3`. -/
+theorem per_leg_div_four_and_three
+    (h : PythagoreanTriple x y z) (hcop : IsCoprime x y) :
+    ((4 ∣ x ∧ ¬ (4 ∣ y)) ∨ (¬ (4 ∣ x) ∧ 4 ∣ y)) ∧
+    ((3 ∣ x ∧ ¬ (3 ∣ y)) ∨ (¬ (3 ∣ x) ∧ 3 ∣ y)) :=
+  ⟨exactly_one_leg_div_four h hcop, exactly_one_leg_div_three h hcop⟩
+
+/-! ## A concrete instance
+
+For the primitive triple `(3, 4, 5)`: the leg `4` carries the factor of four and
+the leg `3` carries the factor of three — the two obstructions sit on *different*
+legs here, but the theorem allows them to coincide as well. -/
+
+/-- `(3, 4, 5)` is a primitive Pythagorean triple. -/
+theorem coprime_345 : IsCoprime (3 : ℤ) 4 := by
+  rw [Int.isCoprime_iff_gcd_eq_one]; decide
+
+example :
+    ((4 ∣ (3 : ℤ) ∧ ¬ (4 ∣ (4 : ℤ))) ∨ (¬ (4 ∣ (3 : ℤ)) ∧ 4 ∣ (4 : ℤ))) ∧
+    ((3 ∣ (3 : ℤ) ∧ ¬ (3 ∣ (4 : ℤ))) ∨ (¬ (3 ∣ (3 : ℤ)) ∧ 3 ∣ (4 : ℤ))) :=
+  per_leg_div_four_and_three triple_345 coprime_345
+
+end PythagoreanTriplesPerLeg

--- a/src/data/proofs/pythagorean-triples-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-08-oq-01/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "ann-pythag-oq08-oq01-header",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "File Context: OQ-01 — Per-Leg Sharpening of the Parent's Product Divisibilities",
+    "content": "This file answers the first open question of PythagoreanTriplesOQ08 (which proved the product-level 3 ∣ x·y, 4 ∣ x·y, 60 ∣ x·y·z for every triple). The parent's results are agnostic about which leg carries the factor — 4 ∣ x·y is compatible with 2 ∣ x and 2 ∣ y. Under primitivity (IsCoprime x y) the obstructions localise: exactly one leg is divisible by 4 and exactly one by 3. The file imports the parent and reuses three_dvd_legs / four_dvd_legs directly.",
+    "mathContext": "Primitivity is essential and the file documents the failure mode: for the scaled triple $(9,12,15)$ both legs are divisible by $3$, so 'exactly one' is false without $\\gcd(x,y)=1$. The coprimality hypothesis forbids a common prime factor and forces each obstruction onto a single leg.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pythagorean-triples-oq-08",
+      "PythagoreanTriple",
+      "IsCoprime",
+      "PythagoreanTriplesPerLeg namespace"
+    ],
+    "prerequisites": [
+      "PythagoreanTriplesOQ08 parent proof",
+      "coprimality in ℤ",
+      "Euclid's lemma"
+    ]
+  },
+  {
+    "id": "ann-pythag-oq08-oq01-coprime-engine",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 54, "endLine": 64 },
+    "type": "key-step",
+    "title": "Coprimality Engine: No Prime Divides Both Legs",
+    "content": "not_dvd_both_of_coprime is the one place primitivity is used. If a prime p divided both legs, IsCoprime.isUnit_of_dvd' would make p a unit, contradicting Prime.not_unit. Specialised to p = 2 and p = 3 it powers both per-leg theorems.",
+    "mathContext": "IsCoprime x y means $\\exists u,v.\\ ux + vy = 1$, so any common divisor divides $1$ and is a unit. Since $2$ and $3$ are non-units in $\\mathbb{Z}$, neither can divide both coprime legs.",
+    "significance": "essential",
+    "relatedConcepts": ["IsCoprime.isUnit_of_dvd'", "Prime.not_unit", "units in ℤ"],
+    "prerequisites": ["coprimality", "units"]
+  },
+  {
+    "id": "ann-pythag-oq08-oq01-three",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 66, "endLine": 78 },
+    "type": "key-step",
+    "title": "Exactly One Leg Divisible by 3",
+    "content": "exactly_one_leg_div_three: the parent's three_dvd_legs gives 3 ∣ x·y; Prime.dvd_or_dvd (Int.prime_three) puts the factor on a leg, and not_dvd_both_of_coprime excludes the other. This is the clean prime/coprime split — Euclid's lemma for 'at least one', primitivity for 'not both'.",
+    "mathContext": "Euclid's lemma plus primitivity gives an exclusive disjunction: $(3 \\mid x \\wedge 3 \\nmid y) \\vee (3 \\nmid x \\wedge 3 \\mid y)$.",
+    "significance": "essential",
+    "relatedConcepts": ["Prime.dvd_or_dvd", "Int.prime_three", "three_dvd_legs"],
+    "prerequisites": ["Euclid's lemma", "parent product divisibility"]
+  },
+  {
+    "id": "ann-pythag-oq08-oq01-even-leg",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 80, "endLine": 92 },
+    "type": "key-step",
+    "title": "The Even Leg Carries the Full Factor of 4",
+    "content": "four_dvd_even_leg is the crux of the 4-sharpening. From 4 ∣ x·y and an odd leg y, Prime.coprime_iff_not_dvd gives IsCoprime 2 y, hence IsCoprime 4 y (= IsCoprime (2·2) y via IsCoprime.mul_left); then IsCoprime.dvd_of_dvd_mul_right cancels y, yielding 4 ∣ x.",
+    "mathContext": "Cancelling a coprime factor out of a divisibility is the integer analogue of clearing it from a fraction: since $\\gcd(4,y)=1$, all four factors of two in $x\\cdot y$ must reside in $x$.",
+    "significance": "essential",
+    "relatedConcepts": ["IsCoprime.dvd_of_dvd_mul_right", "Prime.coprime_iff_not_dvd", "IsCoprime.mul_left"],
+    "prerequisites": ["coprime cancellation", "prime/coprime duality"]
+  },
+  {
+    "id": "ann-pythag-oq08-oq01-four",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 93, "endLine": 114 },
+    "type": "key-step",
+    "title": "Exactly One Leg Divisible by 4",
+    "content": "exactly_one_leg_div_four: 4 ∣ x·y ⟹ 2 ∣ x·y ⟹ (prime 2) one leg even; coprimality makes the other odd; four_dvd_even_leg sends the full 4 to the even leg, while 4 ∤ (odd leg) since 2 ∤ it. The two parity branches are symmetric (mul_comm rewrites x·y for the y-even case).",
+    "mathContext": "Unlike the parent's mod-8 *product* result, this pins the entire factor of $4$ onto a specific (even) leg, with the other leg odd — the genuine per-leg statement the open question asked for.",
+    "significance": "essential",
+    "relatedConcepts": ["four_dvd_even_leg", "Int.prime_two", "four_dvd_legs"],
+    "prerequisites": ["prime divides product", "parity from coprimality"]
+  },
+  {
+    "id": "ann-pythag-oq08-oq01-capstone",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 116, "endLine": 137 },
+    "type": "result",
+    "title": "Capstone and the (3,4,5) Instance",
+    "content": "per_leg_div_four_and_three bundles both sharpenings into the exact statement of the parent's open question. coprime_345 (kernel decide via Int.isCoprime_iff_gcd_eq_one) and the worked example confirm that for (3,4,5) the factor 4 sits on leg 4 and the factor 3 on leg 3 — distinct legs, though the disjunctions allow coincidence.",
+    "mathContext": "The instance witnesses that the per-leg disjunctions are inhabited by a concrete primitive triple, guarding against a vacuous statement.",
+    "significance": "essential",
+    "relatedConcepts": ["per_leg_div_four_and_three", "triple_345", "Int.isCoprime_iff_gcd_eq_one"],
+    "prerequisites": ["the two per-leg theorems"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-08-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-08-oq-01/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "pythagorean-triples-oq-08-oq-01",
+  "title": "Per-Leg Divisibility by 3 and 4 in a Primitive Pythagorean Triple",
+  "slug": "pythagorean-triples-oq-08-oq-01",
+  "description": "Sharpens the parent's product-level divisibilities to the individual legs. For a primitive Pythagorean triple (IsCoprime x y), exactly one leg is divisible by 4 and exactly one leg is divisible by 3 — not merely the product x·y. The parent proves 4 ∣ x·y and 3 ∣ x·y for every triple; primitivity forces each obstruction onto a single leg (a prime cannot divide both coprime legs, and cancelling the odd leg out of 4 ∣ x·y lands all four factors of two on the even leg). Both sharpenings fail without coprimality, e.g. 3 ∣ 9 and 3 ∣ 12 in the scaled triple (9,12,15). This answers the parent's first listed open question.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ08OQ01.lean",
+    "parentProofId": "pythagorean-triples-oq-08",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "divisibility",
+      "modular-arithmetic",
+      "coprimality",
+      "diophantine",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Fully machine-verified. All theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — no Lean.ofReduceBool, since the parent's residue lemmas and the (3,4,5) coprimality witness use kernel `decide`, not `native_decide`).",
+    "dateAdded": "2026-06-24",
+    "lineCount": 138,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple",
+        "description": "The predicate x*x + y*y = z*z over ℤ",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "IsCoprime.isUnit_of_dvd'",
+        "description": "If IsCoprime a b and x ∣ a, x ∣ b then IsUnit x — a prime dividing both coprime legs would be a unit",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "IsCoprime.dvd_of_dvd_mul_right",
+        "description": "IsCoprime k z → k ∣ y * z → k ∣ y — cancels the odd (4-coprime) leg out of 4 ∣ x·y",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "Prime.coprime_iff_not_dvd",
+        "description": "Over a PID, IsCoprime p n ↔ ¬ p ∣ n — supplies IsCoprime 2 (odd leg)",
+        "module": "Mathlib.RingTheory.PrincipalIdealDomain"
+      },
+      {
+        "theorem": "Prime.dvd_or_dvd",
+        "description": "Prime p → p ∣ a * b → p ∣ a ∨ p ∣ b — splits 3 ∣ x·y and 2 ∣ x·y onto a leg",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Int.prime_two / Int.prime_three",
+        "description": "2 and 3 are prime in ℤ",
+        "module": "Mathlib.Data.Nat.Prime.Int"
+      }
+    ],
+    "originalContributions": [
+      "not_dvd_both_of_coprime: in a primitive triple no prime divides both legs (it would be a non-unit unit) — the coprimality engine for both sharpenings",
+      "exactly_one_leg_div_three: exactly one leg is divisible by 3 (parent gives only 3 ∣ x·y)",
+      "four_dvd_even_leg: the even leg of a primitive triple is divisible by 4, obtained by cancelling the 4-coprime odd leg out of 4 ∣ x·y",
+      "exactly_one_leg_div_four: exactly one leg is divisible by 4 — the per-leg form the parent's mod-8 product result could not pin down",
+      "per_leg_div_four_and_three: combined capstone (exactly one leg by 4 AND exactly one by 3)",
+      "Worked (3,4,5) instance showing the two obstructions can sit on different legs"
+    ],
+    "prerequisites": [
+      "Pythagorean triples and the PythagoreanTriple predicate",
+      "Coprimality (IsCoprime) and units in ℤ",
+      "Prime divisibility (Euclid's lemma) in ℤ"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "That the legs of a Pythagorean triangle obey strong divisibility constraints is classical (Sierpiński, Pythagorean Triangles): one leg is divisible by 3, one by 4, and one side by 5, so 60 divides the product of the sides. The parent entry (oq-08) formalises the product-level statements 3 ∣ x·y, 4 ∣ x·y, 60 ∣ x·y·z for every triple, with no coprimality hypothesis. But the textbook claim is sharper: in a primitive triangle the obstructions sit on *individual legs* — exactly one leg is divisible by 4 and exactly one by 3. The parent's product results cannot see this (4 ∣ x·y is compatible with 2 ∣ x and 2 ∣ y), and it lists the per-leg sharpening as its first open question. This leaf supplies it, the missing ingredient being primitivity: coprimality forbids a prime from dividing both legs.",
+    "problemStatement": "Prove that for a primitive Pythagorean triple (PythagoreanTriple x y z with IsCoprime x y), exactly one of the legs x, y is divisible by 4, and exactly one of the legs is divisible by 3.",
+    "text": "Under primitivity, the parent's product divisibilities 4 ∣ x·y and 3 ∣ x·y each localise to a single leg: exactly one leg is divisible by 4 and exactly one by 3.",
+    "proofStrategy": "Everything reduces to two facts: the parent's product divisibilities (three_dvd_legs, four_dvd_legs) and the consequence of IsCoprime x y that a prime cannot divide both legs (not_dvd_both_of_coprime, via IsCoprime.isUnit_of_dvd' and the non-unitality of 2 and 3). For 3: Prime.dvd_or_dvd splits 3 ∣ x·y onto a leg, and coprimality rules out the other, giving exactly one. For 4: 4 ∣ x·y gives 2 ∣ x·y, so (prime 2) one leg is even; coprimality makes the other odd, hence coprime to 4 = 2·2; IsCoprime.dvd_of_dvd_mul_right cancels it out of 4 ∣ x·y, landing 4 on the even leg, while 4 ∤ (odd leg) since 2 ∤ it.",
+    "keyInsights": [
+      "The parent's product results 4 ∣ x·y and 3 ∣ x·y are agnostic about *which* leg carries the factor; primitivity is exactly what localises them.",
+      "Coprimality enters through a single lemma: no prime divides both legs, because it would be a unit (IsCoprime.isUnit_of_dvd'), and 2, 3 are non-units in ℤ.",
+      "The 4-case needs the extra step that the odd leg is coprime to 4 = 2·2, so cancelling it from 4 ∣ x·y forces all four factors of two onto the even leg.",
+      "Both sharpenings genuinely require primitivity: in (9,12,15) both legs are divisible by 3, so 'exactly one' fails for the scaled triple.",
+      "No use of the m,n parametrisation (oq-06) is needed — the argument is a pure prime/coprime cancellation on top of the parent's residue obstructions."
+    ],
+    "prerequisites": [
+      "Pythagorean triples and the parent product divisibilities (oq-08)",
+      "Coprimality and units in ℤ",
+      "Euclid's lemma (prime divides a product)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "coprime-engine",
+      "title": "Coprimality Engine: No Prime Divides Both Legs",
+      "startLine": 54,
+      "endLine": 64,
+      "summary": "not_dvd_both_of_coprime: if IsCoprime x y then no prime p divides both legs, because IsCoprime.isUnit_of_dvd' would make p a unit, contradicting Prime.not_unit. This single lemma carries the primitivity hypothesis into both sharpenings.",
+      "mathContext": "IsCoprime a b means ∃ u v, u·a + v·b = 1, so any common divisor divides 1 and is a unit. In ℤ the primes 2 and 3 are non-units, so they cannot divide both coprime legs — the obstruction is forced onto a single leg."
+    },
+    {
+      "id": "div-three",
+      "title": "Exactly One Leg Divisible by 3",
+      "startLine": 66,
+      "endLine": 78,
+      "summary": "exactly_one_leg_div_three: the parent's three_dvd_legs gives 3 ∣ x·y; Prime.dvd_or_dvd (Int.prime_three) puts the factor on a leg, and not_dvd_both_of_coprime excludes the other, yielding (3∣x ∧ ¬3∣y) ∨ (¬3∣x ∧ 3∣y).",
+      "mathContext": "This is the bare prime/coprime split of 3 ∣ x·y: Euclid's lemma gives 'at least one', primitivity gives 'not both', so exactly one."
+    },
+    {
+      "id": "even-leg-four",
+      "title": "The Even Leg Carries the Factor 4",
+      "startLine": 80,
+      "endLine": 92,
+      "summary": "four_dvd_even_leg: from 4 ∣ x·y and an odd leg y, IsCoprime 2 y (Prime.coprime_iff_not_dvd) gives IsCoprime 4 y = IsCoprime (2·2) y, and IsCoprime.dvd_of_dvd_mul_right cancels y to yield 4 ∣ x. This is the crux of the 4-sharpening.",
+      "mathContext": "Cancelling a unit-coprime factor out of a divisibility is the integer analogue of clearing it from a fraction: since gcd(4, y) = 1, all four factors of two in x·y must reside in x."
+    },
+    {
+      "id": "div-four",
+      "title": "Exactly One Leg Divisible by 4",
+      "startLine": 93,
+      "endLine": 114,
+      "summary": "exactly_one_leg_div_four: 4 ∣ x·y ⟹ 2 ∣ x·y ⟹ (prime 2) one leg even; coprimality makes the other odd; four_dvd_even_leg sends 4 to the even leg while 4 ∤ (odd leg). Both parity branches handled symmetrically (mul_comm for the y-even case).",
+      "mathContext": "Unlike the mod-8 product result of the parent, this pins the full factor of 4 onto a specific (even) leg, with the other leg odd — the genuine per-leg statement."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone and (3,4,5) Instance",
+      "startLine": 116,
+      "endLine": 137,
+      "summary": "per_leg_div_four_and_three bundles both sharpenings. coprime_345 (kernel decide via Int.isCoprime_iff_gcd_eq_one) and the worked example show that for (3,4,5) the factor 4 sits on leg 4 and the factor 3 on leg 3 — distinct legs, though the theorem allows coincidence.",
+      "mathContext": "The capstone is the exact statement of the parent's open question. The instance is a sanity check that the disjunctions are inhabited by a concrete primitive triple."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-08",
+      "relationship": "follow-up",
+      "description": "Answers the parent's first open question: sharpen the product divisibilities 3 ∣ x·y, 4 ∣ x·y to per-leg statements. Imports and builds directly on three_dvd_legs and four_dvd_legs."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "related",
+      "description": "oq-07 proves a primitive triple has exactly one even leg and asks whether that even leg is divisible by 4; this entry proves precisely that, plus the per-leg 3-divisibility."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "oq-06 gives the m,n parametrisation of primitive triples; this entry reaches the per-leg divisibilities without it, using only prime/coprime cancellation over the parent's residue obstructions."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete proof that in a primitive Pythagorean triple exactly one leg is divisible by 4 and exactly one by 3, sharpening the parent's product-level 3 ∣ x·y and 4 ∣ x·y. The only new ingredient over the parent is primitivity, used through the single lemma that no prime divides both coprime legs. 0 sorries, 0 axioms.",
+    "implications": "Localises the classical 3-, 4-divisibility of a Pythagorean triangle to individual legs, completing the per-leg refinement that the product-level results (and the naive mod-4/mod-8 arguments) cannot reach.",
+    "openQuestions": [
+      "Identify which leg is which from the m,n parametrisation: the even leg 2mn is the 4-divisible one — can the per-leg statement be re-derived constructively from oq-06's classification and matched against this prime/coprime proof?",
+      "Generalise to the per-side 5-divisibility: in a primitive triple exactly one side (possibly the hypotenuse) is divisible by 5 — formalise the 'exactly one of x, y, z' trichotomy."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "exactly_one_leg_div_four",
+      "type": "core",
+      "description": "In a primitive Pythagorean triple, exactly one leg is divisible by 4",
+      "leanType": "{x y z : ℤ} → PythagoreanTriple x y z → IsCoprime x y → (4 ∣ x ∧ ¬ 4 ∣ y) ∨ (¬ 4 ∣ x ∧ 4 ∣ y)"
+    },
+    {
+      "name": "exactly_one_leg_div_three",
+      "type": "core",
+      "description": "In a primitive Pythagorean triple, exactly one leg is divisible by 3",
+      "leanType": "{x y z : ℤ} → PythagoreanTriple x y z → IsCoprime x y → (3 ∣ x ∧ ¬ 3 ∣ y) ∨ (¬ 3 ∣ x ∧ 3 ∣ y)"
+    },
+    {
+      "name": "per_leg_div_four_and_three",
+      "type": "capstone",
+      "description": "Combined per-leg sharpening: exactly one leg divisible by 4 and exactly one by 3",
+      "leanType": "{x y z : ℤ} → PythagoreanTriple x y z → IsCoprime x y → (((4 ∣ x ∧ ¬ 4 ∣ y) ∨ (¬ 4 ∣ x ∧ 4 ∣ y)) ∧ ((3 ∣ x ∧ ¬ 3 ∣ y) ∨ (¬ 3 ∣ x ∧ 3 ∣ y)))"
+    },
+    {
+      "name": "four_dvd_even_leg",
+      "type": "lemma",
+      "description": "The even leg is divisible by 4: cancel the odd (4-coprime) leg out of 4 ∣ x·y",
+      "leanType": "{x y : ℤ} → (4 : ℤ) ∣ x * y → ¬ (2 : ℤ) ∣ y → (4 : ℤ) ∣ x"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.PythagoreanTriplesOQ08"
+    ],
+    "opens": [
+      "PythagoreanTriple",
+      "PythagoreanTriplesSixty"
+    ],
+    "namespace": "PythagoreanTriplesPerLeg",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ08OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `pythagorean-triples-oq-08` ("Sixty Divides the Product of a Pythagorean Triple's Sides"). The parent proves the **product-level** divisibilities `3 ∣ x·y`, `4 ∣ x·y`, `60 ∣ x·y·z` for every triple. Those results are agnostic about *which* leg carries the factor. This leaf **sharpens them per-leg** under primitivity:

- **`exactly_one_leg_div_three`** — in a primitive triple (`IsCoprime x y`), exactly one leg is divisible by 3.
- **`exactly_one_leg_div_four`** — exactly one leg is divisible by 4.
- **`per_leg_div_four_and_three`** — combined capstone (the exact statement of the parent's open question).

## Why primitivity is essential

Both sharpenings fail without coprimality: in the scaled triple `(9,12,15)` both legs are divisible by 3, so "exactly one" is false. Coprimality is the only new ingredient over the parent.

## Proof idea

The whole argument rests on one consequence of `IsCoprime x y`: **no prime divides both legs** (`not_dvd_both_of_coprime`, via `IsCoprime.isUnit_of_dvd'` + non-unitality of 2, 3).

- **3:** `three_dvd_legs` (parent) gives `3 ∣ x·y`; `Prime.dvd_or_dvd` puts the factor on a leg; coprimality excludes the other ⟹ exactly one.
- **4:** `four_dvd_legs` (parent) gives `4 ∣ x·y` ⟹ `2 ∣ x·y` ⟹ one leg even; coprimality makes the other odd, hence coprime to `4 = 2·2`; `IsCoprime.dvd_of_dvd_mul_right` cancels it (`four_dvd_even_leg`), landing the full factor of four on the even leg while `4 ∤` the odd leg.

No use of the `m,n` parametrisation (oq-06) — pure prime/coprime cancellation over the parent's residue obstructions. The file **imports the parent** and reuses `three_dvd_legs` / `four_dvd_legs` directly.

## Verification

- 6 theorems, 0 sorries, **0 axioms**.
- `#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only — **no `Lean.ofReduceBool`** (the (3,4,5) coprimality witness and the parent's residue lemmas use kernel `decide`, not `native_decide`).
- Compiled on host `lake env lean` against Mathlib 4.26.0 (Docker unavailable this session).

## Files

- `proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean` (new, 138 lines)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/pythagorean-triples-oq-08-oq-01/{meta.json,annotations.json}` (gallery entry, 6 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)