### PR TITLE
Enrich The General Even Moment of the Gaussian

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/annotations.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 6, "endLine": 43 },
+    "type": "context",
+    "title": "From One Moment to the Whole Family",
+    "content": "The parent entry area-of-circle-oq-07-oq-05 evaluated the single second moment ∫ x² e^{-x²} = √π/2 by one integration by parts. This file lifts that lone computation to all n at once by isolating the recursion it generates: integrating by parts lowers the power by two and multiplies by (2n+1)/2, so iterating from the base value √π produces the closed form (2n-1)‼·√π/2ⁿ. The closing observation is that this elementary recursion lands exactly on the half-integer Gamma value Γ(n+1/2), giving the integral a special-function interpretation for every n.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n} e^{-x^2}\\,dx = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^n} = \\Gamma\\!\\left(n+\\tfrac12\\right)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gaussian integral",
+      "moments of a distribution",
+      "double factorial",
+      "Gamma function",
+      "integration by parts"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ",
+      "the parent second moment ∫ x² e^{-x²} = √π/2"
+    ]
+  },
+  {
+    "id": "ann-integrable",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 50, "endLine": 60 },
+    "type": "technique",
+    "title": "Integrability of Every Polynomial Weight",
+    "content": "Establishes that x^k e^{-x²} is integrable over the whole line for every natural power k. The Gaussian decay e^{-x²} dominates any polynomial, so each weighted Gaussian is L¹. The proof specializes Mathlib's real-power lemma integrable_rpow_mul_exp_neg_mul_sq (valid for exponents s > -1, here at b = 1) and rewrites the rpow to a natural power via Real.rpow_natCast, noting (k : ℝ) > -1 for any natural k. This single lemma supplies the integrability hypotheses required at every step of the integration-by-parts recursion.",
+    "mathContext": "$x^k e^{-x^2} \\in L^1(\\mathbb{R})$ for all $k\\in\\mathbb{N}$, since $\\int_{-\\infty}^{\\infty} |x|^k e^{-x^2}\\,dx < \\infty$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integrability",
+      "Gaussian decay",
+      "L¹ functions",
+      "rpow vs natural power"
+    ],
+    "prerequisites": [
+      "Lebesgue integrability",
+      "integrable_rpow_mul_exp_neg_mul_sq"
+    ]
+  },
+  {
+    "id": "ann-decay",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 62, "endLine": 72 },
+    "type": "technique",
+    "title": "Gaussian Decay Kills the Boundary Terms",
+    "content": "For every power m, x^m e^{-x²} → 0 at both ends of the real line — the Gaussian factor decays faster than any polynomial grows. This is the fact that makes integration by parts legitimate at every level of the induction: the boundary product of the parts formula must vanish at ±∞. The proof reduces to the norm via tendsto_zero_iff_norm_tendsto_zero and matches Mathlib's tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact, again converting rpow to a natural power. The cocompact filter on ℝ packages both x → +∞ and x → -∞ simultaneously.",
+    "mathContext": "$\\lim_{|x|\\to\\infty} x^m e^{-x^2} = 0$ for every $m\\in\\mathbb{N}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cocompact filter",
+      "asymptotic decay",
+      "boundary terms",
+      "exponential dominance"
+    ],
+    "prerequisites": [
+      "filters and Tendsto",
+      "tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact"
+    ]
+  },
+  {
+    "id": "ann-recursion",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 74, "endLine": 145 },
+    "type": "insight",
+    "title": "The Engine: One Integration by Parts",
+    "content": "The heart of the file: ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}. The integrand x^{2n+2} e^{-x²} is rewritten as x^{2n+1} · (x e^{-x²}), where the second factor is the exact derivative of -½ e^{-x²}. Taking u = x^{2n+1} (so u' = (2n+1)x^{2n}) and v = -½ e^{-x²}, the integration-by-parts lemma integral_mul_deriv_eq_deriv_mul on (-∞, ∞) gives [u·v]_{-∞}^{∞} - ∫ u'·v. The boundary term vanishes by the Gaussian-decay lemma (hbot, htop), and pulling the constant -½ out of ∫ (2n+1)x^{2n}·(-½ e^{-x²}) leaves the factor (2n+1)/2 times the lower moment. Choosing this particular antiderivative v is the crux that makes the boundary term decay.",
+    "mathContext": "$\\int x^{2(n+1)} e^{-x^2} = \\Big[\\,x^{2n+1}\\!\\cdot\\!\\big(-\\tfrac12 e^{-x^2}\\big)\\Big]_{-\\infty}^{\\infty} + \\tfrac{2n+1}{2}\\int x^{2n} e^{-x^2} = \\tfrac{2n+1}{2}\\int x^{2n} e^{-x^2}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "integration by parts",
+      "HasDerivAt",
+      "antiderivative choice",
+      "recursion / reduction formula"
+    ],
+    "prerequisites": [
+      "integration by parts on the whole line",
+      "derivatives of products and compositions",
+      "the integrability and decay lemmas above"
+    ]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 147, "endLine": 169 },
+    "type": "insight",
+    "title": "Folding the Recursion into a Closed Form",
+    "content": "The induction itself. Base case n = 0: integral_gaussian 1 gives ∫ e^{-x²} = √π, and (2·0-1)‼ = (-1)‼ = 1, so the formula reads √π/2⁰ = √π. Successor step: rewrite by gaussian_even_moment_recursion and the induction hypothesis, then match the arithmetic to the double factorial. The analytic factor (2n+1) produced by integration by parts is precisely the factor in the recurrence (2(n+1)-1)‼ = (2n+1)·(2n-1)‼ (Nat.doubleFactorial_add_one); pow_succ handles the 2ⁿ → 2ⁿ⁺¹ in the denominator and ring closes the goal. The key is that the recursion's arithmetic is the double factorial's arithmetic — the proof never expands (2n-1)‼ explicitly.",
+    "mathContext": "$\\int x^{2(n+1)} e^{-x^2} = \\tfrac{2n+1}{2}\\cdot\\tfrac{(2n-1)!!\\sqrt\\pi}{2^n} = \\tfrac{(2n+1)!!\\sqrt\\pi}{2^{n+1}}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "mathematical induction",
+      "double factorial",
+      "reduction formula",
+      "Nat.doubleFactorial_add_one"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "the even-moment recursion",
+      "double factorial recurrence"
+    ]
+  },
+  {
+    "id": "ann-gamma",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 171, "endLine": 178 },
+    "type": "concept",
+    "title": "The Integral Is a Half-Integer Gamma Value",
+    "content": "A one-line corollary: ∫ x^{2n} e^{-x²} = Γ(n + 1/2). Mathlib records Real.Gamma_nat_add_half : Γ(k + 1/2) = (2k-1)‼·√π / 2^k purely as a special-function evaluation; rewriting the closed form by it shows the Gaussian integral computes exactly those half-integer Gamma values. This is the substitution x² = t in disguise — ∫_0^∞ x^{2n} e^{-x²} dx = ½ Γ(n+½) — but here it falls out of the elementary integration-by-parts recursion rather than the Gamma integral, bridging an analytic computation and a combinatorial special-function table for all n simultaneously.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n} e^{-x^2}\\,dx = \\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n-1)!!\\,\\sqrt\\pi}{2^n}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gamma function",
+      "Legendre duplication formula",
+      "special values",
+      "Real.Gamma_nat_add_half"
+    ],
+    "prerequisites": [
+      "the Gamma function",
+      "half-integer Gamma values"
+    ]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01",
+    "range": { "startLine": 180, "endLine": 188 },
+    "type": "context",
+    "title": "Sanity Check: n = 1 Recovers the Parent",
+    "content": "Specializing the general formula at n = 1 gives ∫ x² e^{-x²} = (2·1-1)‼·√π/2¹ = 1·√π/2 = √π/2, exactly the parent entry's second moment. This confirms the general theorem is consistent with the previously verified special case and that no off-by-one error crept into the double-factorial bookkeeping.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\dfrac{1!!\\,\\sqrt\\pi}{2} = \\dfrac{\\sqrt\\pi}{2}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "specialization",
+      "consistency check",
+      "second moment"
+    ],
+    "prerequisites": [
+      "the general closed form"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ05OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq05Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq05Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq05Oq01Data: ProofData = {
+  proof: areaOfCircleOq07Oq05Oq01Proof,
+  annotations: areaOfCircleOq07Oq05Oq01Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01/meta.json
@@ -24,6 +24,7 @@
     "sorries": 0
   },
   "title": "The General Even Moment of the Gaussian ∫ x^{2n} e^{-x²} = (2n-1)‼·√π / 2ⁿ",
+  "description": "Lifts the parent's single second moment to the whole even-moment family: for every n the standard Gaussian even moment is ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼·√π / 2ⁿ. The proof isolates the double-factorial recursion ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²} from one integration by parts on (-∞, ∞), then folds it by induction into the base value ∫ e^{-x²} = √π. A corollary identifies the integral with the half-integer Gamma value Γ(n+1/2). 188 lines, 6 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -93,6 +94,76 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The even moments of the Gaussian weight, ∫_{-∞}^{∞} x^{2n} e^{-x²} dx = (2n-1)‼·√π / 2ⁿ, are among the oldest computed integrals of analysis. The base value ∫ e^{-x²} dx = √π was found by Laplace and Gauss around 1809–1812 in the theory of least-squares errors; Poisson's celebrated squaring-and-polar-coordinates trick (1820s) gave the slick evaluation now standard. The higher even moments follow by repeated integration by parts, a recursion already exploited by Laplace. Recast through the substitution x² = t, the same integral is Euler's Gamma function: ∫_0^∞ x^{2n} e^{-x²} dx = ½Γ(n+½), and Legendre's duplication formula expresses Γ(n+½) via the double factorial (2n-1)‼ = 1·3·5···(2n-1). These moments are the raw material of the Hermite polynomials and the harmonic-oscillator eigenfunctions of quantum mechanics, and of every Gaussian expectation E[X^{2n}] = (2n-1)!! in probability. This entry formalizes the classical induction in full generality, having previously been carried out only for the second moment (n = 1) in the parent entry.",
+    "problemStatement": "Prove that for every natural number $n$, $\\displaystyle\\int_{-\\infty}^{\\infty} x^{2n}\\,e^{-x^2}\\,dx = \\frac{(2n-1)!!\\,\\sqrt{\\pi}}{2^n}$, by induction on $n$ with the zeroth moment $\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$ as the base case, exhibiting the double-factorial recursion that integration by parts generates. Here $(2n-1)!! = 1\\cdot 3\\cdot 5\\cdots(2n-1)$ with the convention $(-1)!! = 1$.",
+    "proofStrategy": "The argument has three layers. (1) Uniform analytic infrastructure: x^k e^{-x²} is integrable for every power k (integrable_pow_mul_gaussian) and x^m e^{-x²} → 0 along the cocompact filter (tendsto_pow_mul_gaussian_cocompact), both specialized from Mathlib's rpow-indexed Gaussian-decay lemmas via Real.rpow_natCast — these supply the integrability and boundary hypotheses needed at every step. (2) The recursion: one integration by parts on (-∞, ∞) with u = x^{2n+1}, v = -½ e^{-x²} (so v' = x e^{-x²}) yields ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}; the boundary product x^{2n+1}·(-½ e^{-x²}) vanishes at both ±∞ by Gaussian decay (gaussian_even_moment_recursion). (3) The induction: starting from ∫ e^{-x²} = √π and applying the recursion n times, the accumulated arithmetic factors (2n+1) are matched to the double-factorial step (2(n+1)-1)‼ = (2n+1)·(2n-1)‼ (Nat.doubleFactorial_add_one), and pow_succ handles the 2ⁿ in the denominator, closing the closed form (gaussian_even_moment). A final corollary equates the integral with Γ(n+1/2) via Real.Gamma_nat_add_half.",
+    "keyInsights": [
+      "The whole even-moment family is governed by a single two-step recursion. Each integration by parts lowers the power by two and multiplies by the odd factor (2n+1)/2; the entire content of the theorem is isolating this one step (gaussian_even_moment_recursion) and folding it into the base value √π.",
+      "The arithmetic of the recursion is exactly the arithmetic of the double factorial. The factor (2n+1) picked up analytically by integration by parts is the same (2n+1) in the recurrence (2n+1)‼ = (2n+1)·(2n-1)‼; matching them (Nat.doubleFactorial_add_one) is what makes the induction close cleanly without ever expanding the double factorial.",
+      "Choosing the antiderivative v = -½ e^{-x²} is the crux: it converts the awkward weight x^{2n+2} e^{-x²} into x^{2n+1} · (x e^{-x²}), where the second factor is an exact derivative, so the boundary term inherits the Gaussian decay that kills it at ±∞.",
+      "Gaussian decay beats any polynomial. The boundary terms x^{2n+1}·(-½ e^{-x²}) vanish at ±∞ for every n because e^{-x²} decays faster than x^{2n+1} grows — the single fact that legitimizes the integration by parts at every level of the induction.",
+      "The elementary integration-by-parts recursion computes the same numbers Mathlib stores combinatorially as Γ(n+1/2). The corollary gaussian_even_moment_eq_Gamma exhibits the integral as the Gaussian representation of the half-integer Gamma special value, bridging an analytic computation and a special-function table entry for all n at once."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Open Question and Strategy",
+      "startLine": 6,
+      "endLine": 43,
+      "summary": "States the open question — evaluate the general even moment ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ by induction — and outlines the answer: isolate the double-factorial recursion produced by one integration by parts, fold it into the base value √π, and identify the result with Γ(n+1/2). Notes the parent computed only n = 1 and that no new axioms are introduced.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n} e^{-x^2}\\,dx = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^n}$"
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability of Polynomial-Weighted Gaussians",
+      "startLine": 50,
+      "endLine": 60,
+      "summary": "theorem integrable_pow_mul_gaussian: x^k e^{-x²} is integrable over ℝ for every natural power k. Specialized from Mathlib's integrable_rpow_mul_exp_neg_mul_sq (s > -1, b = 1) via Real.rpow_natCast, since any natural k satisfies k > -1.",
+      "mathContext": "$x^k e^{-x^2} \\in L^1(\\mathbb{R})$ for all $k \\in \\mathbb{N}$"
+    },
+    {
+      "id": "decay",
+      "title": "Gaussian Decay of Polynomial Weights",
+      "startLine": 62,
+      "endLine": 72,
+      "summary": "theorem tendsto_pow_mul_gaussian_cocompact: x^m e^{-x²} → 0 along the cocompact filter for every power m, because the Gaussian factor decays faster than any polynomial. Derived from tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact through tendsto_zero_iff_norm_tendsto_zero. Supplies the vanishing boundary terms for the recursion.",
+      "mathContext": "$x^m e^{-x^2} \\to 0$ as $|x| \\to \\infty$"
+    },
+    {
+      "id": "recursion",
+      "title": "The Even-Moment Recursion (Integration by Parts)",
+      "startLine": 74,
+      "endLine": 145,
+      "summary": "theorem gaussian_even_moment_recursion: ∫ x^{2(n+1)} e^{-x²} = (2n+1)/2 · ∫ x^{2n} e^{-x²}. One integration by parts on (-∞, ∞) with u = x^{2n+1}, v = -½ e^{-x²}. Establishes the derivatives (hu, hv), the integrability of u·v' and u'·v (huv', hu'v), and the vanishing of the boundary product at ±∞ (hbot, htop), then applies integral_mul_deriv_eq_deriv_mul and pulls the constants out. The engine of the induction.",
+      "mathContext": "$\\int x^{2(n+1)} e^{-x^2} = \\dfrac{2n+1}{2}\\int x^{2n} e^{-x^2}$"
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form by Induction",
+      "startLine": 147,
+      "endLine": 169,
+      "summary": "theorem gaussian_even_moment: ∫ x^{2n} e^{-x²} = (2n-1)‼·√π / 2ⁿ. Base case n = 0 uses integral_gaussian 1 to get √π and norm_num for (−1)‼ = 1; the successor step rewrites by the recursion and the hypothesis, matches (2(n+1)-1)‼ = (2n+1)·(2n-1)‼ via Nat.doubleFactorial_add_one, and closes with pow_succ and ring.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n} e^{-x^2}\\,dx = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^n}$"
+    },
+    {
+      "id": "gamma",
+      "title": "Identification with the Half-Integer Gamma Value",
+      "startLine": 171,
+      "endLine": 178,
+      "summary": "theorem gaussian_even_moment_eq_Gamma: ∫ x^{2n} e^{-x²} = Γ(n + 1/2). A one-line corollary rewriting the closed form by Real.Gamma_nat_add_half, exhibiting the integral as the Gaussian representation of the half-integer Gamma special value.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n} e^{-x^2}\\,dx = \\Gamma\\!\\left(n + \\tfrac{1}{2}\\right)$"
+    },
+    {
+      "id": "sanity-check",
+      "title": "Sanity Check: Recovering the Second Moment",
+      "startLine": 180,
+      "endLine": 188,
+      "summary": "theorem gaussian_second_moment: ∫ x² e^{-x²} = √π / 2, the n = 1 instance, recovering the parent entry's value as a specialization of the general formula and confirming consistency.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\dfrac{\\sqrt{\\pi}}{2}$"
+    }
+  ],
   "openQuestions": [
     {
       "id": "area-of-circle-oq-07-oq-05-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01` (quality 15, pass 0).

## Why this entry needed work
The directory had **only** `meta.json` — no `index.ts` (so the page would render *"proof not found"* on the live site), no `annotations.json`, and no `overview`/`sections` blocks.

## Changes
- **`index.ts`** — created from the standard template (`areaOfCircleOq07Oq05Oq01*` exports, source from `Proofs/AreaOfCircleOQ07OQ05OQ01.lean`). Fixes the missing page.
- **`annotations.json`** — 7 new annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the docstring and all 6 theorems (integrability, Gaussian decay, the IBP recursion engine, the inductive closed form, the Γ(n+½) corollary, and the n=1 sanity check).
- **`meta.json`** — added top-level `description`; added `overview` with a substantive `historicalContext` (Laplace/Gauss/Poisson, Hermite polynomials, Legendre duplication), `problemStatement`, `proofStrategy`, and 5 `keyInsights`; added a `sections` array covering the full 188-line file.

## Verification
- `pnpm build` passes (tsc + vite).
- JSON validated with `jq`.
- Axiom integrity confirmed: badge `mathlib`, status `verified`, `axiomCount: 0` — the Lean file has 0 `axiom` declarations, 0 sorries, no `native_decide`, and no assumption-carrying structures. Consistent with the source.