### PR TITLE
research(bernoulli-inequality-oq-01-oq-02-oq-01): degree-k binomial truncation bound and its sharp equality case [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -311,6 +311,7 @@ import Proofs.BernoulliInequalityOQ01
 import Proofs.BernoulliInequalityOQ01OQ01
 import Proofs.BernoulliInequalityOQ01OQ01OQ02
 import Proofs.BernoulliInequalityOQ01OQ02
+import Proofs.BernoulliInequalityOQ01OQ02OQ01
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04

--- a/proofs/Proofs/BernoulliInequalityOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ02OQ01.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Degree-`k` binomial truncation lower bound for `(1 + a)ⁿ`
+
+**Open question (bernoulli-inequality-oq-01-oq-02-oq-01).** The parent entry
+`BernoulliInequalityOQ01OQ02` proves the *second-order* Bernoulli inequality
+`1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ` (for `a ≥ 0`) together with its sharp equality
+characterization (equality iff `a = 0 ∨ n ≤ 2`).  The natural next question is
+the **arbitrary-degree** refinement: for each truncation order `k`,
+
+  `∑_{i=0}^{k} C(n,i) · aⁱ  ≤  (1 + a)ⁿ`   for `a ≥ 0`,
+
+with its own sharp equality boundary.  This entry settles it.
+
+The mechanism is uniform and elementary: by the binomial theorem
+`(1+a)ⁿ = ∑_{i=0}^{n} C(n,i) aⁱ`, the truncated sum `∑_{i≤k}` is, after padding
+to a common range, a sub-sum of the full expansion whose discarded tail terms
+`C(n,i) aⁱ` are all nonnegative.  The bound therefore holds for **every** `k`
+(no relation between `k` and `n` is needed), and it is an *equality* exactly when
+nothing positive is discarded:
+
+* `binom_trunc_le`       : `0 ≤ a → ∑_{i≤k} C(n,i) aⁱ ≤ (1+a)ⁿ`.
+* `binom_trunc_strict`   : `0 < a → k < n → ∑_{i≤k} C(n,i) aⁱ < (1+a)ⁿ`.
+* `binom_trunc_eq_iff`   : for `0 ≤ a`, equality holds **iff** `a = 0 ∨ n ≤ k`.
+
+The threshold `n ≤ k` says the truncation is exact precisely once it captures the
+whole expansion; for `a > 0` the bound becomes strict as soon as a genuine tail
+term `C(n,k+1) a^{k+1} > 0` is dropped, i.e. `k < n`.
+
+This single family subsumes the earlier entries as the special cases `k = 1`
+(first-order Bernoulli `1 + n·a ≤ (1+a)ⁿ`) and `k = 2` (the parent's second-order
+bound), recorded below as `bernoulli_first_order` and `bernoulli_second_order`.
+
+**Relation to Mathlib.** Mathlib has the first-order weak Bernoulli inequality
+`one_add_mul_le_pow` and the full binomial theorem `add_pow`, but no
+general-degree truncation bound with an equality characterization.
+-/
+
+namespace BernoulliInequalityOQ01OQ02OQ01
+
+open Finset
+
+variable {a : ℝ}
+
+/-- The `i`-th term of the binomial expansion of `(1+a)ⁿ`, `C(n,i)·aⁱ`. -/
+private def term (n i : ℕ) (a : ℝ) : ℝ := (n.choose i : ℝ) * a ^ i
+
+private theorem term_nonneg (ha : 0 ≤ a) (n i : ℕ) : 0 ≤ term n i a :=
+  mul_nonneg (Nat.cast_nonneg _) (pow_nonneg ha i)
+
+/-- The binomial theorem in the orientation we need:
+`(1 + a)ⁿ = ∑_{i=0}^{n} C(n,i) · aⁱ`. -/
+private theorem full_expansion (n : ℕ) :
+    (1 + a) ^ n = ∑ i ∈ range (n + 1), term n i a := by
+  rw [add_comm, add_pow]
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  simp [term, one_pow, mul_comm]
+
+/-- **Degree-`k` binomial truncation lower bound.**  For `a ≥ 0` and any `n, k`,
+the partial sum of the first `k+1` binomial terms is dominated by the full power:
+`∑_{i=0}^{k} C(n,i) aⁱ ≤ (1+a)ⁿ`.  No relation between `k` and `n` is assumed. -/
+theorem binom_trunc_le (ha : 0 ≤ a) (n k : ℕ) :
+    ∑ i ∈ range (k + 1), (n.choose i : ℝ) * a ^ i ≤ (1 + a) ^ n := by
+  -- Pad both sides to the common range `range (N+1)` with `N = max k n`.
+  set N := max k n with hN
+  have hkN : k + 1 ≤ N + 1 := by omega
+  have hnN : n + 1 ≤ N + 1 := by omega
+  have hsub_k : range (k + 1) ⊆ range (N + 1) := Finset.range_subset_range.mpr hkN
+  have hsub_n : range (n + 1) ⊆ range (N + 1) := Finset.range_subset_range.mpr hnN
+  -- The padded full expansion still equals `(1+a)ⁿ` (extra terms vanish: `C(n,i)=0`).
+  have hpad : (1 + a) ^ n = ∑ i ∈ range (N + 1), term n i a := by
+    rw [full_expansion n]
+    refine Finset.sum_subset hsub_n ?_
+    intro i _ hi
+    have : n < i := by simpa [Nat.lt_iff_add_one_le] using (Finset.mem_range.not.mp hi)
+    simp [term, Nat.choose_eq_zero_of_lt this]
+  calc
+    ∑ i ∈ range (k + 1), (n.choose i : ℝ) * a ^ i
+        = ∑ i ∈ range (k + 1), term n i a := rfl
+    _ ≤ ∑ i ∈ range (N + 1), term n i a :=
+          Finset.sum_le_sum_of_subset_of_nonneg hsub_k
+            (fun i _ _ => term_nonneg ha n i)
+    _ = (1 + a) ^ n := hpad.symm
+
+/-- **Strict truncation bound.**  For `a > 0` and `k < n` a genuine positive tail
+term is discarded, so the inequality is strict. -/
+theorem binom_trunc_strict (ha : 0 < a) {n k : ℕ} (hkn : k < n) :
+    ∑ i ∈ range (k + 1), (n.choose i : ℝ) * a ^ i < (1 + a) ^ n := by
+  have hsub : range (k + 1) ⊆ range (n + 1) := Finset.range_subset_range.mpr (by omega)
+  have hmem : k + 1 ∈ range (n + 1) := Finset.mem_range.mpr (by omega)
+  have hnotmem : k + 1 ∉ range (k + 1) := by simp
+  have hpos : 0 < term n (k + 1) a :=
+    mul_pos (by exact_mod_cast Nat.choose_pos (by omega : k + 1 ≤ n)) (pow_pos ha (k + 1))
+  have hlt :
+      ∑ i ∈ range (k + 1), term n i a < ∑ i ∈ range (n + 1), term n i a :=
+    Finset.sum_lt_sum_of_subset hsub hmem hnotmem hpos
+      (fun i _ _ => term_nonneg ha.le n i)
+  calc
+    ∑ i ∈ range (k + 1), (n.choose i : ℝ) * a ^ i
+        = ∑ i ∈ range (k + 1), term n i a := rfl
+    _ < ∑ i ∈ range (n + 1), term n i a := hlt
+    _ = (1 + a) ^ n := (full_expansion n).symm
+
+/-- **Sharp equality characterization.**  For `a ≥ 0`, the degree-`k` truncation is
+*exact* — `∑_{i=0}^{k} C(n,i) aⁱ = (1+a)ⁿ` — if and only if `a = 0` (only the
+constant term survives on both sides) or `n ≤ k` (the truncation already captures
+the entire expansion). -/
+theorem binom_trunc_eq_iff (ha : 0 ≤ a) (n k : ℕ) :
+    (∑ i ∈ range (k + 1), (n.choose i : ℝ) * a ^ i = (1 + a) ^ n) ↔ a = 0 ∨ n ≤ k := by
+  constructor
+  · intro h
+    by_contra hc
+    push_neg at hc
+    obtain ⟨ha0, hk⟩ := hc
+    have hapos : 0 < a := ha.lt_of_ne (Ne.symm ha0)
+    have hkn : k < n := by omega
+    exact (binom_trunc_strict hapos hkn).ne h
+  · rintro (rfl | hnk)
+    · -- `a = 0`: every term with `i ≥ 1` vanishes, leaving the constant `C(n,0)=1`.
+      have hzero : ∑ i ∈ range (k + 1), (n.choose i : ℝ) * (0 : ℝ) ^ i = 1 := by
+        rw [Finset.sum_eq_single_of_mem 0 (Finset.mem_range.mpr (by omega))]
+        · simp
+        · intro i _ hi
+          simp [zero_pow hi]
+      simpa using hzero
+    · -- `n ≤ k`: range `n+1 ⊆ k+1` and the extra terms vanish, so the sums agree.
+      rw [full_expansion n]
+      refine (Finset.sum_subset (Finset.range_subset_range.mpr (by omega)) ?_).symm
+      intro i _ hi
+      have : n < i := by simpa [Nat.lt_iff_add_one_le] using (Finset.mem_range.not.mp hi)
+      simp [Nat.choose_eq_zero_of_lt this]
+
+/-- **First-order Bernoulli** as the `k = 1` instance: `1 + n·a ≤ (1+a)ⁿ` for `a ≥ 0`. -/
+theorem bernoulli_first_order (ha : 0 ≤ a) (n : ℕ) :
+    1 + (n : ℝ) * a ≤ (1 + a) ^ n := by
+  have h := binom_trunc_le ha n 1
+  simpa [Finset.sum_range_succ, Nat.choose_one_right] using h
+
+/-- **Second-order Bernoulli** (the parent entry's bound) as the `k = 2` instance:
+`1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ` for `a ≥ 0`. -/
+theorem bernoulli_second_order (ha : 0 ≤ a) (n : ℕ) :
+    1 + (n : ℝ) * a + (n.choose 2 : ℝ) * a ^ 2 ≤ (1 + a) ^ n := by
+  have h := binom_trunc_le ha n 2
+  simpa [Finset.sum_range_succ, Nat.choose_one_right] using h
+
+end BernoulliInequalityOQ01OQ02OQ01

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-bern-oq010201-header",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 38 },
+    "type": "context",
+    "title": "The parent's open question, posed and answered",
+    "content": "The docstring states the parent's first listed open question verbatim: does the degree-k truncation ∑_{i≤k} C(n,i)aⁱ ≤ (1+a)ⁿ hold for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k? This file answers it for every k at once. The key reframing is that the proof needs no Pascal induction (the parent's tool) at all — the truncation is literally a sub-sum of the binomial expansion, so the bound, its strictness, and its equality case all follow from nonnegativity of the discarded terms.",
+    "mathContext": "$\\sum_{i=0}^{k} \\binom{n}{i} a^i \\le (1+a)^n$ for all $a \\ge 0$, every $k$, with equality iff $a = 0 \\vee n \\le k$.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli's inequality", "binomial theorem", "truncation", "open question"],
+    "prerequisites": ["the parent second-order Bernoulli entry", "binomial expansion"]
+  },
+  {
+    "id": "ann-bern-oq010201-expansion",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 46, "endLine": 59 },
+    "type": "technique",
+    "title": "Orienting the binomial theorem to match the truncation",
+    "content": "term n i a := C(n,i)·aⁱ packages the summand and term_nonneg gives its nonnegativity for a ≥ 0. full_expansion rewrites (1+a)ⁿ with add_pow then normalizes each summand (add_comm puts a first so the 1^{n-i} factor disappears) into ∑_{i ∈ range (n+1)} term n i a — exactly the orientation in which the truncation ∑_{i ∈ range (k+1)} is a literal initial segment.",
+    "mathContext": "$(1+a)^n = \\sum_{i=0}^{n} \\binom{n}{i} a^i$, summand $\\binom{n}{i} a^i \\ge 0$.",
+    "significance": "standard",
+    "relatedConcepts": ["add_pow", "Finset.range", "sum_congr"],
+    "prerequisites": ["the binomial theorem", "Finset sums"]
+  },
+  {
+    "id": "ann-bern-oq010201-padding",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 85 },
+    "type": "key",
+    "title": "Padding to a common range, then one subset-sum comparison",
+    "content": "binom_trunc_le sets N = max k n and pads BOTH the truncation range (k+1) and the expansion range (n+1) into range (N+1). Padding the expansion is harmless: the extra coefficients vanish by Nat.choose_eq_zero_of_lt (i > n ⟹ C(n,i) = 0), proved through Finset.sum_subset. With both sums over the same superset range, Finset.sum_le_sum_of_subset_of_nonneg compares them in a single step using termwise nonnegativity — no induction on k, and no relation between k and n.",
+    "mathContext": "$N = \\max(k,n)$; $\\sum_{\\mathrm{range}(k+1)} \\le \\sum_{\\mathrm{range}(N+1)} = (1+a)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_le_sum_of_subset_of_nonneg", "Finset.range_subset_range", "Nat.choose_eq_zero_of_lt", "Finset.sum_subset"],
+    "prerequisites": ["subset-monotonicity of sums of nonnegative terms", "vanishing binomial coefficients"]
+  },
+  {
+    "id": "ann-bern-oq010201-strict",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 87, "endLine": 104 },
+    "type": "key",
+    "title": "Strictness is the first dropped term",
+    "content": "binom_trunc_strict assumes k < n. Then k+1 ∈ range (n+1) but k+1 ∉ range (k+1), so it is a genuinely omitted index; its term C(n,k+1)a^{k+1} is strictly positive (Nat.choose_pos since k+1 ≤ n, times pow_pos for a > 0). Finset.sum_lt_sum_of_subset converts one strictly positive omitted term plus nonnegativity of the rest into a strict inequality against the full expansion.",
+    "mathContext": "$0 < \\binom{n}{k+1} a^{k+1}$ for $a > 0,\\ k < n \\Rightarrow \\sum_{i=0}^{k} \\binom{n}{i} a^i < (1+a)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_lt_sum_of_subset", "Nat.choose_pos", "pow_pos"],
+    "prerequisites": ["strict subset-sum comparison", "positivity of powers"]
+  },
+  {
+    "id": "ann-bern-oq010201-eqiff",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 133 },
+    "type": "concept",
+    "title": "The equality threshold: a = 0 or the truncation already captures everything",
+    "content": "binom_trunc_eq_iff proves equality ↔ a = 0 ∨ n ≤ k. Forward is the contrapositive of strictness: a ≠ 0 with a ≥ 0 gives a > 0, and ¬(n ≤ k) gives k < n, so binom_trunc_strict rules out equality. Reverse splits: a = 0 collapses every i ≥ 1 summand (zero_pow) leaving the constant C(n,0) = 1; n ≤ k makes range (n+1) ⊆ range (k+1) with the extra terms vanishing, so the truncation already equals the full expansion. The threshold n ≤ k is exactly 'range (k+1) contains range (n+1)'.",
+    "mathContext": "For $a \\ge 0$: $\\sum_{i=0}^{k} \\binom{n}{i} a^i = (1+a)^n \\iff a = 0 \\vee n \\le k$.",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "Finset.sum_eq_single_of_mem", "zero_pow", "Finset.sum_subset"],
+    "prerequisites": ["the strict bound", "collapsing a sum to one term"]
+  },
+  {
+    "id": "ann-bern-oq010201-special",
+    "proofId": "bernoulli-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 135, "endLine": 146 },
+    "type": "context",
+    "title": "Recovering the classical and second-order Bernoulli inequalities",
+    "content": "bernoulli_first_order (k = 1) and bernoulli_second_order (k = 2) instantiate the general bound and unfold the short truncated sum with Finset.sum_range_succ and Nat.choose_one_right, recovering 1 + n·a ≤ (1+a)ⁿ and the parent's 1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ as one-line corollaries — confirming the family genuinely subsumes the earlier entries.",
+    "mathContext": "$k=1$: $1 + na \\le (1+a)^n$;\\quad $k=2$: $1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$.",
+    "significance": "standard",
+    "relatedConcepts": ["Finset.sum_range_succ", "Nat.choose_one_right", "specialization"],
+    "prerequisites": ["the general truncation bound"]
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BernoulliInequalityOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bernoulliInequalityOQ01OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bernoulliInequalityOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bernoulliInequalityOQ01OQ02OQ01Data: ProofData = {
+  proof: bernoulliInequalityOQ01OQ02OQ01Proof,
+  annotations: bernoulliInequalityOQ01OQ02OQ01Annotations,
+}

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-02-oq-01",
+  "title": "Degree-k Binomial Truncation Bound (1+a)ⁿ ≥ Σ_{i≤k} C(n,i)aⁱ and Its Sharp Equality Case",
+  "slug": "bernoulli-inequality-oq-01-oq-02-oq-01",
+  "description": "The parent entry settles the second-order Bernoulli inequality 1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ (for a ≥ 0) and its equality case, and explicitly asks whether the pattern continues to every truncation order. This entry answers that open question: for each degree k, the partial sum of the first k+1 binomial terms is a lower bound, ∑_{i=0}^{k} C(n,i)·aⁱ ≤ (1+a)ⁿ for all a ≥ 0, with a uniform sharp equality characterization — equality holds iff a = 0 ∨ n ≤ k. The mechanism is a single elementary argument rather than an order-by-order induction: the binomial theorem expands (1+a)ⁿ = ∑_{i=0}^{n} C(n,i)aⁱ, the truncated sum is a sub-sum over range (k+1) ⊆ range (max k n + 1), and the discarded tail terms C(n,i)aⁱ are all nonnegative; strictness occurs exactly when a genuine positive tail term C(n,k+1)a^{k+1} > 0 is dropped, i.e. a > 0 and k < n. The first- and second-order Bernoulli inequalities are recovered as the k = 1 and k = 2 specializations.",
+  "meta": {
+    "author": "Jacob Bernoulli (1689); arbitrary-degree binomial truncation refinement and equality classification",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "1689",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "binomial-theorem",
+      "equality-case",
+      "finset-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "add_pow",
+        "description": "The binomial theorem (x + y)ⁿ = ∑_{i} C(n,i) xⁱ y^{n-i}; specialized at x = a, y = 1 it gives the full expansion (1+a)ⁿ = ∑_{i=0}^{n} C(n,i)aⁱ that the truncation cuts off.",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset_of_nonneg",
+        "description": "A sum over a subset is dominated by a sum over the superset when the extra summands are nonnegative; this is the core comparison turning the truncation into a lower bound for the full expansion.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_lt_sum_of_subset",
+        "description": "Strict version of the subset sum comparison: with one strictly positive omitted term and the rest nonnegative, the subset sum is strictly smaller; drives the strict bound when k < n.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "Two sums over nested ranges agree when the extra terms vanish; used both to pad the expansion to a common range (C(n,i) = 0 for i > n) and for the n ≤ k equality branch.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(n,i) = 0 when n < i; the binomial coefficients of the padding terms vanish, so padding the expansion to range (max k n + 1) does not change its value.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_pos",
+        "description": "C(n,i) > 0 when i ≤ n; certifies that the first discarded tail term C(n,k+1)a^{k+1} has a positive coefficient, hence is strictly positive for a > 0.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.range_subset_range",
+        "description": "range n ⊆ range m ↔ n ≤ m; supplies the subset relations range (k+1) ⊆ range (max k n + 1) and range (n+1) ⊆ range (k+1) used in the comparisons.",
+        "module": "Mathlib.Data.Finset.Range"
+      }
+    ],
+    "originalContributions": [
+      "binom_trunc_le: the arbitrary-degree binomial truncation lower bound ∑_{i=0}^{k} C(n,i)aⁱ ≤ (1+a)ⁿ for all a ≥ 0 and all n, k, with no relation assumed between the truncation order k and the exponent n — the general Bernoulli-type bound that the parent's first listed open question asks for, absent from Mathlib",
+      "binom_trunc_strict: the strict form ∑_{i=0}^{k} C(n,i)aⁱ < (1+a)ⁿ for a > 0 and k < n, isolating the regime where a genuine positive tail term C(n,k+1)a^{k+1} is discarded",
+      "binom_trunc_eq_iff: the uniform sharp equality characterization on a ≥ 0 — equality iff a = 0 ∨ n ≤ k — which subsumes the first-order threshold (n ≤ 1) and the parent's second-order threshold (n ≤ 2) as the cases k = 1, 2 and exhibits the general principle that the degree-k truncation is exact exactly when it already captures the whole expansion",
+      "A single subset-sum mechanism replacing the order-by-order Pascal induction: by viewing the truncation as a sub-sum of the binomial expansion over nested Finset ranges, the bound, its strictness, and its equality case all follow from nonnegativity of the omitted terms, uniformly in k",
+      "bernoulli_first_order and bernoulli_second_order: the classical 1 + n·a ≤ (1+a)ⁿ and the parent's 1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ recovered as one-line k = 1 and k = 2 instances of the general bound"
+    ],
+    "dateAdded": "2026-06-24",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Bernoulli's inequality 1 + na ≤ (1+a)ⁿ (Jacob Bernoulli, 1689) keeps only the constant and linear terms of the binomial expansion (1+a)ⁿ = ∑_{i} C(n,i)aⁱ. For a ≥ 0 every binomial term is nonnegative, so each successive truncation of the expansion is again a lower bound. Mathlib provides the first-order form `one_add_mul_le_pow` and the binomial theorem `add_pow`, and a sibling gallery entry proves the second-order truncation 1 + na + C(n,2)a² ≤ (1+a)ⁿ; but the general degree-k truncation bound and its equality characterization were absent.",
+    "problemStatement": "**Open Question (OQ-01-OQ-02-OQ-01), posed verbatim by the parent entry:** \"Does the degree-k binomial truncation ∑_{i≤k} C(n,i)aⁱ ≤ (1+a)ⁿ hold for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k, by the same Pascal induction?\"\n\n**Answer:** Yes for all a ≥ 0, and no relation between k and n is required. Equality holds iff a = 0 ∨ n ≤ k, and the inequality is strict iff a > 0 ∧ k < n. The natural proof is not order-by-order Pascal induction but a single subset-sum comparison: the truncation is a sub-sum of the full binomial expansion, and the discarded tail terms are all nonnegative.",
+    "text": "Write (1+a)ⁿ = ∑_{i=0}^{n} C(n,i)aⁱ by the binomial theorem. The degree-k truncation ∑_{i=0}^{k} C(n,i)aⁱ is the same sum restricted to range (k+1). Padding both sides to the common range range (max k n + 1) — harmless because C(n,i) = 0 for i > n — exhibits the truncation as a sub-sum of the full expansion over nested Finset ranges. Since every term C(n,i)aⁱ is nonnegative for a ≥ 0, dropping the tail can only decrease the sum, giving the lower bound for every k at once. The bound is tight exactly when nothing positive is discarded: either a = 0 (only the constant term survives on both sides) or n ≤ k (the truncation already contains the entire expansion). As soon as a > 0 and k < n, the first omitted term C(n,k+1)a^{k+1} is strictly positive and the inequality is strict.",
+    "proofStrategy": "1. **Full expansion** (`full_expansion`): rewrite (1+a)ⁿ via `add_pow` into ∑_{i ∈ range (n+1)} C(n,i)aⁱ, in the orientation matching the truncation.\n2. **Lower bound** (`binom_trunc_le`): set N = max k n and pad both ranges to range (N+1). The padded full expansion still equals (1+a)ⁿ because the extra binomial coefficients vanish (`Nat.choose_eq_zero_of_lt` via `Finset.sum_subset`). Then `Finset.sum_le_sum_of_subset_of_nonneg` with `range (k+1) ⊆ range (N+1)` (`Finset.range_subset_range`) and termwise nonnegativity closes it.\n3. **Strict bound** (`binom_trunc_strict`): for k < n the index k+1 lies in range (n+1) but not range (k+1); the omitted term C(n,k+1)a^{k+1} is strictly positive (`Nat.choose_pos`, `pow_pos`), so `Finset.sum_lt_sum_of_subset` gives the strict inequality against the full expansion.\n4. **Equality iff** (`binom_trunc_eq_iff`): the forward direction is the contrapositive — if a ≠ 0 and n > k then `binom_trunc_strict` forbids equality; conversely a = 0 collapses every i ≥ 1 term leaving the constant 1, and n ≤ k makes range (n+1) ⊆ range (k+1) with the extra terms vanishing, so the sums agree.\n5. **Specializations** (`bernoulli_first_order`, `bernoulli_second_order`): expand `Finset.sum_range_succ` at k = 1 and k = 2 with `Nat.choose_one_right` to recover the classical and second-order Bernoulli bounds.",
+    "keyInsights": [
+      "**The whole family is one subset-sum, not a tower of inductions.** The parent proved each truncation order by a separate Pascal induction discarding a single tail term. Viewing the truncation as a sub-sum of the binomial expansion collapses the entire family into one comparison `Finset.sum_le_sum_of_subset_of_nonneg`, uniform in k and requiring no relation between k and n.",
+      "**The equality threshold is exactly 'the truncation has captured everything'.** Equality iff a = 0 ∨ n ≤ k. The increment from the first-order threshold n ≤ 1 to the second-order n ≤ 2 to the general n ≤ k is not a coincidence of the induction depth — it is precisely the statement that range (k+1) already contains range (n+1).",
+      "**Strictness is governed entirely by the first dropped term.** The inequality becomes strict the instant a single genuinely positive tail term C(n,k+1)a^{k+1} is discarded; this is why the strict regime is exactly a > 0 ∧ k < n, with no dependence on the higher tail.",
+      "**Padding to a common range is the technical key.** Both the lower bound and the n ≤ k equality branch hinge on `Nat.choose_eq_zero_of_lt`: extending a binomial sum past degree n adds only zeros, so ranges can be enlarged freely to make the subset relation literal."
+    ],
+    "prerequisites": [
+      "The binomial theorem and Bernoulli's first-order inequality",
+      "Finite sums over Finset ranges and subset-monotonicity of sums of nonnegative terms",
+      "Vanishing of binomial coefficients C(n,i) = 0 for i > n",
+      "Basic ordering of real powers (nonnegativity, positivity)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "expansion",
+      "title": "Binomial Expansion and Term Setup",
+      "startLine": 46,
+      "endLine": 59,
+      "summary": "term n i a := C(n,i)·aⁱ with its nonnegativity (term_nonneg), and full_expansion: (1+a)ⁿ = ∑_{i ∈ range (n+1)} C(n,i)aⁱ via add_pow in the orientation the truncation needs.",
+      "mathContext": "$(1+a)^n = \\sum_{i=0}^{n} \\binom{n}{i} a^i$."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Degree-k Truncation Lower Bound",
+      "startLine": 61,
+      "endLine": 85,
+      "summary": "binom_trunc_le: for a ≥ 0 and any n, k, ∑_{i=0}^{k} C(n,i)aⁱ ≤ (1+a)ⁿ. Pad both ranges to range (max k n + 1) and apply Finset.sum_le_sum_of_subset_of_nonneg.",
+      "mathContext": "$\\sum_{i=0}^{k} \\binom{n}{i} a^i \\le (1+a)^n$ for $a \\ge 0$."
+    },
+    {
+      "id": "strict-bound",
+      "title": "Strict Truncation Bound",
+      "startLine": 87,
+      "endLine": 104,
+      "summary": "binom_trunc_strict: for a > 0 and k < n the omitted term C(n,k+1)a^{k+1} is positive, so Finset.sum_lt_sum_of_subset gives a strict inequality.",
+      "mathContext": "$\\sum_{i=0}^{k} \\binom{n}{i} a^i < (1+a)^n$ for $a > 0$, $k < n$."
+    },
+    {
+      "id": "eq-iff",
+      "title": "Sharp Equality Characterization",
+      "startLine": 106,
+      "endLine": 133,
+      "summary": "binom_trunc_eq_iff: for a ≥ 0, equality holds iff a = 0 ∨ n ≤ k. Forward via the contrapositive of strictness; reverse by collapsing the i ≥ 1 terms (a = 0) or absorbing the vanishing tail (n ≤ k).",
+      "mathContext": "For $a \\ge 0$: equality iff $a = 0 \\vee n \\le k$."
+    },
+    {
+      "id": "specializations",
+      "title": "First- and Second-Order Specializations",
+      "startLine": 135,
+      "endLine": 146,
+      "summary": "bernoulli_first_order (k = 1): 1 + n·a ≤ (1+a)ⁿ; bernoulli_second_order (k = 2): 1 + n·a + C(n,2)·a² ≤ (1+a)ⁿ — both one-line instances via Finset.sum_range_succ.",
+      "mathContext": "$k=1$: $1 + na \\le (1+a)^n$; $k=2$: $1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a ≥ 0 the degree-k binomial truncation is a valid Bernoulli-type lower bound ∑_{i=0}^{k} C(n,i)aⁱ ≤ (1+a)ⁿ, holding for every k with no relation to n, with equality iff a = 0 ∨ n ≤ k and strictness iff a > 0 ∧ k < n. This answers the parent's first open question affirmatively and generalizes both the classical first-order threshold (n ≤ 1) and the second-order threshold (n ≤ 2) to the uniform n ≤ k. Verified: 0 sorries, 0 axioms.",
+    "implications": "The order-by-order Pascal inductions used for the first and second order entries are subsumed by a single subset-sum comparison on the binomial expansion. Mathlib has the binomial theorem and the first-order Bernoulli inequality but no general-degree truncation bound with an equality characterization; this entry supplies the whole family at once and pins the exact threshold n ≤ k separating exactness from strict inequality.",
+    "openQuestions": [
+      "On −1 < a < 0 the binomial terms alternate in sign, so successive truncations bracket (1+a)ⁿ from opposite sides; can one prove a sharp two-sided enclosure ∑_{i≤2m+1} C(n,i)aⁱ ≤ (1+a)ⁿ ≤ ∑_{i≤2m} C(n,i)aⁱ with its own equality cases?",
+      "Does the same subset-sum mechanism give a degree-k truncation remainder bound — e.g. 0 ≤ (1+a)ⁿ − ∑_{i≤k} C(n,i)aⁱ ≤ C(n,k+1)a^{k+1}·(something) — quantifying the gap rather than only its sign?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves the second-order truncation and explicitly asks whether the degree-k truncation holds for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k; this entry answers that question in full generality."
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Settles the first-order equality case on the weak domain −2 ≤ a; recovered here as the k = 1 specialization on a ≥ 0."
+    },
+    {
+      "targetId": "binomial-theorem-oq-05",
+      "relationship": "related",
+      "description": "Proves the first-order strict Bernoulli inequality for a > 0; the degree-k truncation here uses the full binomial expansion of which that is the leading term."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BernoulliInequalityOQ01OQ02OQ01",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/BernoulliInequalityOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Positiones Arithmeticae de Seriebus Infinitis",
+      "year": "1689",
+      "venue": "Basel",
+      "note": "Origin of the inequality 1 + nx ≤ (1+x)ⁿ; the present entry generalizes it to every binomial truncation order."
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Standard reference on Bernoulli's inequality and its higher-order refinements."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (**bernoulli-inequality-oq-01-oq-02**) first listed open question, posed verbatim there:

> *"Does the degree-k binomial truncation ∑_{i≤k} C(n,i)aⁱ ≤ (1+a)ⁿ hold for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k, by the same Pascal induction?"*

**Answer: yes — for every `k`, with no relation assumed between `k` and `n`.** For `a ≥ 0`:

- `binom_trunc_le`     : `∑_{i=0}^{k} C(n,i)aⁱ ≤ (1+a)ⁿ`
- `binom_trunc_strict` : `0 < a → k < n →` the bound is strict
- `binom_trunc_eq_iff` : equality `↔ a = 0 ∨ n ≤ k`

## Method

The natural proof is **not** the parent's order-by-order Pascal induction but a **single subset-sum comparison**: by the binomial theorem the truncation is a sub-sum of the full expansion `(1+a)ⁿ = ∑_{i=0}^{n} C(n,i)aⁱ` over nested `Finset` ranges (padded to `range (max k n + 1)`, harmless since `C(n,i)=0` for `i>n`). All discarded tail terms are nonnegative, so `Finset.sum_le_sum_of_subset_of_nonneg` gives the bound for all `k` at once. Strictness is exactly the first dropped positive term `C(n,k+1)a^{k+1}`. The equality threshold `n ≤ k` is precisely *"`range (k+1)` already contains `range (n+1)`"*.

The classical first-order (`k=1`) and the parent's second-order (`k=2`) Bernoulli inequalities are recovered as one-line specializations (`bernoulli_first_order`, `bernoulli_second_order`).

## Verification

- **148 lines**, 7 theorems, 1 definition; self-contained on Mathlib (`import Mathlib`).
- **0 sorries, 0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`.
- Built on the host with `lake env lean` against Mathlib v4.26.0 (Docker unavailable this session); clean, no errors or warnings.
- A `Finset.range_subset → Finset.range_subset_range` rename in the current Mathlib pin was applied (the `range n ⊆ range m ↔ n ≤ m` form moved to `range_subset_range`).
- Gallery data added (`meta.json`, `annotations.json`, `index.ts`); `pnpm annotations:validate` reports no errors for this proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)