### PR TITLE
research(lhopital-oq-02-incomplete-01): growth limits via the ∞/∞ L'Hôpital rule [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3195,6 +3195,7 @@ import Proofs.LHopital
 import Proofs.LHopitalOQ01
 import Proofs.LHopitalOQ02
 import Proofs.LHopitalOQ02Aristotle
+import Proofs.LHopitalOQ02Incomplete01
 import Proofs.LHopitalOQ03
 import Proofs.LHopitalOQ05
 import Proofs.LagrangeFourSquares

--- a/proofs/Proofs/LHopitalOQ02Incomplete01.lean
+++ b/proofs/Proofs/LHopitalOQ02Incomplete01.lean
@@ -1,0 +1,122 @@
+import Mathlib.Analysis.SpecialFunctions.Log.Deriv
+import Mathlib.Analysis.SpecialFunctions.Exp
+import Mathlib.Analysis.SpecialFunctions.Exponential
+import Proofs.LHopitalOQ02
+
+/-
+# Logarithmic and Exponential Growth Limits via the ∞/∞ L'Hôpital Rule (OQ-02 leaf)
+
+## What This Proves
+
+The parent entry (`LHopitalOQ02`) establishes the ∞/∞ form of L'Hôpital's rule —
+content that Mathlib does **not** provide (Mathlib's 26 L'Hôpital variants only
+cover the 0/0 form). That entry, however, only states the abstract rule. This leaf
+puts the rule to work, deriving three classic growth-comparison limits as direct
+corollaries of `LHopitalInfty.lhopital_infty_atTop`:
+
+1. `log_div_id_atTop`:        (log x) / x      → 0   as x → +∞   (logarithm grows slower than the identity)
+2. `id_div_exp_atTop`:        x / eˣ           → 0   as x → +∞   (the identity grows slower than the exponential)
+3. `id_add_log_div_id_atTop`: (x + log x) / x  → 1   as x → +∞   (the nonzero-limit case c = 1)
+
+The first two are the c = 0 instances of the rule; the third exercises the
+general c ≠ 0 statement, confirming that the parent theorem handles a genuinely
+nonzero target limit and is not silently specialised to vanishing ratios.
+
+## Proof Strategy
+
+Each limit is an `∞/∞` indeterminate form `f / g` with `g → +∞`. We supply the
+derivatives `f'`, `g'`, check `g' ≠ 0`, verify `g → atTop`, and compute the easy
+limit of `f'/g'`; the parent rule then delivers the conclusion. Concretely:
+
+| limit            | f         | g    | f'        | g'   | f'/g'      → |
+|------------------|-----------|------|-----------|------|--------------|
+| (log x)/x        | log       | id   | x⁻¹       | 1    | x⁻¹      → 0 |
+| x/eˣ             | id        | exp  | 1         | eˣ   | (eˣ)⁻¹   → 0 |
+| (x + log x)/x    | x + log x | id   | 1 + x⁻¹   | 1    | 1 + x⁻¹  → 1 |
+
+The auxiliary `f'/g'` limits are themselves elementary (`tendsto_inv_atTop_zero`,
+`Real.tendsto_exp_atTop`), so the whole derivation reduces the hard ∞/∞ behaviour
+to a single application of the parent's rule.
+
+## Status
+- [x] (log x)/x → 0
+- [x] x/eˣ → 0
+- [x] (x + log x)/x → 1 (nonzero limit, general c form)
+
+## Difficulty: Medium
+The mathematical depth lives in the parent rule; here the work is assembling the
+hypotheses (derivative lemmas, non-vanishing denominators, the auxiliary limits)
+and discharging the routine `f'/g'` computations.
+-/
+
+namespace LHopitalOQ02Incomplete01
+
+open Set Filter Topology Real
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+COROLLARY 1: (log x) / x → 0  —  the logarithm grows slower than the identity
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **(log x) / x → 0 as x → +∞.**
+
+The classic statement that the natural logarithm is dominated by the identity,
+obtained as the `c = 0` case of the ∞/∞ L'Hôpital rule with `f = log`, `g = id`,
+`f' = x⁻¹`, `g' = 1`. The ratio `f'/g' = x⁻¹ → 0`, and `g = id → +∞`. -/
+theorem log_div_id_atTop :
+    Tendsto (fun x : ℝ => Real.log x / x) atTop (𝓝 0) := by
+  have hff' : ∀ x ∈ Ioi (0 : ℝ), HasDerivAt Real.log x⁻¹ x :=
+    fun x hx => Real.hasDerivAt_log (ne_of_gt hx)
+  have hgg' : ∀ x ∈ Ioi (0 : ℝ), HasDerivAt (fun x : ℝ => x) (1 : ℝ) x :=
+    fun x _ => hasDerivAt_id' x
+  have hg' : ∀ x ∈ Ioi (0 : ℝ), (1 : ℝ) ≠ 0 := fun _ _ => one_ne_zero
+  have hgTop : Tendsto (fun x : ℝ => x) atTop atTop := tendsto_id
+  have hdiv : Tendsto (fun x : ℝ => x⁻¹ / 1) atTop (𝓝 0) := by
+    simpa using tendsto_inv_atTop_zero
+  exact LHopitalInfty.lhopital_infty_atTop hff' hgg' hg' hgTop hdiv
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+COROLLARY 2: x / eˣ → 0  —  the identity grows slower than the exponential
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **x / eˣ → 0 as x → +∞.**
+
+The exponential dominates every polynomial; here the degree-one case, as the
+`c = 0` instance of the ∞/∞ rule with `f = id`, `g = exp`, `f' = 1`, `g' = eˣ`.
+The ratio `f'/g' = (eˣ)⁻¹ → 0`, and `g = exp → +∞`. -/
+theorem id_div_exp_atTop :
+    Tendsto (fun x : ℝ => x / Real.exp x) atTop (𝓝 0) := by
+  have hff' : ∀ x ∈ Ioi (0 : ℝ), HasDerivAt (fun x : ℝ => x) (1 : ℝ) x :=
+    fun x _ => hasDerivAt_id' x
+  have hgg' : ∀ x ∈ Ioi (0 : ℝ), HasDerivAt Real.exp (Real.exp x) x :=
+    fun x _ => Real.hasDerivAt_exp x
+  have hg' : ∀ x ∈ Ioi (0 : ℝ), Real.exp x ≠ 0 := fun x _ => (Real.exp_pos x).ne'
+  have hgTop : Tendsto Real.exp atTop atTop := Real.tendsto_exp_atTop
+  have hdiv : Tendsto (fun x : ℝ => (1 : ℝ) / Real.exp x) atTop (𝓝 0) := by
+    simpa only [one_div] using tendsto_inv_atTop_zero.comp Real.tendsto_exp_atTop
+  exact LHopitalInfty.lhopital_infty_atTop hff' hgg' hg' hgTop hdiv
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+COROLLARY 3: (x + log x) / x → 1  —  the nonzero-limit (c = 1) case
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **(x + log x) / x → 1 as x → +∞.**
+
+A worked instance of the *general* `c ≠ 0` form of the rule, confirming the parent
+theorem is not silently restricted to vanishing ratios. Here `f = x + log x`,
+`g = id`, `f' = 1 + x⁻¹`, `g' = 1`, so `f'/g' = 1 + x⁻¹ → 1`, and `g → +∞`. -/
+theorem id_add_log_div_id_atTop :
+    Tendsto (fun x : ℝ => (x + Real.log x) / x) atTop (𝓝 1) := by
+  have hff' : ∀ x ∈ Ioi (0 : ℝ),
+      HasDerivAt (fun x : ℝ => x + Real.log x) (1 + x⁻¹) x :=
+    fun x hx => (hasDerivAt_id' x).add (Real.hasDerivAt_log (ne_of_gt hx))
+  have hgg' : ∀ x ∈ Ioi (0 : ℝ), HasDerivAt (fun x : ℝ => x) (1 : ℝ) x :=
+    fun x _ => hasDerivAt_id' x
+  have hg' : ∀ x ∈ Ioi (0 : ℝ), (1 : ℝ) ≠ 0 := fun _ _ => one_ne_zero
+  have hgTop : Tendsto (fun x : ℝ => x) atTop atTop := tendsto_id
+  have hdiv : Tendsto (fun x : ℝ => (1 + x⁻¹) / 1) atTop (𝓝 1) := by
+    have : Tendsto (fun x : ℝ => 1 + x⁻¹) atTop (𝓝 (1 + 0)) :=
+      tendsto_const_nhds.add tendsto_inv_atTop_zero
+    simpa using this
+  exact LHopitalInfty.lhopital_infty_atTop hff' hgg' hg' hgTop hdiv
+
+end LHopitalOQ02Incomplete01

--- a/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "lhop02inc-ann-01",
+    "proofId": "lhopital-oq-02-incomplete-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 86
+    },
+    "type": "result",
+    "title": "(ln x)/x → 0 from the ∞/∞ rule",
+    "content": "log_div_id_atTop instantiates the parent's LHopitalInfty.lhopital_infty_atTop with f = log, g = id. The derivative hypotheses are Real.hasDerivAt_log (ne_of_gt hx) (giving f' x = x⁻¹ on Ioi 0) and hasDerivAt_id' (giving g' = 1). The denominator derivative 1 is nonzero, g = id diverges (tendsto_id), and the easy ratio f'/g' = x⁻¹/1 → 0 is supplied by tendsto_inv_atTop_zero (after a `simpa` to clear the /1). The parent rule then returns (log x)/x → 0.",
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{\\ln x}{x}=0$: the logarithm grows slower than the identity (the $c=0$ case)."
+  },
+  {
+    "id": "lhop02inc-ann-02",
+    "proofId": "lhopital-oq-02-incomplete-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 108
+    },
+    "type": "result",
+    "title": "x/eˣ → 0: exponential dominance",
+    "content": "id_div_exp_atTop uses f = id, g = exp. Derivatives come from hasDerivAt_id' (f' = 1) and Real.hasDerivAt_exp (g' x = eˣ). The denominator derivative eˣ is nonzero via (Real.exp_pos x).ne', and g = exp diverges by Real.tendsto_exp_atTop. The auxiliary ratio f'/g' = 1/eˣ = (eˣ)⁻¹ → 0 is obtained by composing tendsto_inv_atTop_zero with Real.tendsto_exp_atTop and rewriting 1/eˣ via one_div. The parent rule yields x/eˣ → 0 — the canonical ∞/∞ example the parent file only mentioned in commentary.",
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x}{e^x}=0$: the exponential dominates the identity (the $c=0$ case)."
+  },
+  {
+    "id": "lhop02inc-ann-03",
+    "proofId": "lhopital-oq-02-incomplete-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 122
+    },
+    "type": "technique",
+    "title": "(x + ln x)/x → 1: the nonzero-limit case",
+    "content": "id_add_log_div_id_atTop exercises the general c ≠ 0 form with f = x + log x, g = id. The derivative of f is assembled by (hasDerivAt_id' x).add (Real.hasDerivAt_log (ne_of_gt hx)), giving f' x = 1 + x⁻¹; g' = 1. The ratio f'/g' = 1 + x⁻¹ → 1 + 0 = 1 via tendsto_const_nhds.add tendsto_inv_atTop_zero (a `simpa` normalizes 1 + 0 to 1). With g = id → +∞, the parent rule returns (x + log x)/x → 1, confirming the theorem handles a genuinely nonzero target limit rather than only vanishing ratios.",
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x+\\ln x}{x}=1$: the leading term $x$ dominates (the general $c\\ne 0$ case, here $c=1$)."
+  }
+]

--- a/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "lhopital-oq-02-incomplete-01",
+  "title": "Growth Limits via the ∞/∞ L'Hôpital Rule: ln x/x, x/eˣ, (x+ln x)/x",
+  "slug": "lhopital-oq-02-incomplete-01",
+  "description": "Three classic growth-comparison limits derived as direct corollaries of the parent's ∞/∞ L'Hôpital rule: (ln x)/x → 0, x/eˣ → 0 (the c = 0 cases), and (x + ln x)/x → 1 (a worked c ≠ 0 instance).",
+  "meta": {
+    "author": "Robb Walters (Lean Genius researcher)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ02Incomplete01.lean",
+    "tags": [
+      "calculus",
+      "limits",
+      "lhopital",
+      "real-analysis",
+      "indeterminate-forms",
+      "growth-rates"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasDerivAt_log",
+        "description": "Derivative of the natural logarithm: HasDerivAt log x⁻¹ x for x ≠ 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Real.hasDerivAt_exp",
+        "description": "Derivative of the exponential: HasDerivAt exp (exp x) x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Real.tendsto_exp_atTop",
+        "description": "exp → +∞ as x → +∞, supplying the divergent denominator for x/eˣ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "tendsto_inv_atTop_zero",
+        "description": "x⁻¹ → 0 as x → +∞, the auxiliary f'/g' limit for the c = 0 cases",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      }
+    ],
+    "originalContributions": [
+      "(ln x)/x → 0 derived as the c = 0 instance of the parent ∞/∞ L'Hôpital rule (f = log, g = id, f'/g' = x⁻¹ → 0)",
+      "x/eˣ → 0 derived as the c = 0 instance (f = id, g = exp, f'/g' = (eˣ)⁻¹ → 0), showing exponential dominance over the identity",
+      "(x + ln x)/x → 1 derived as a worked c ≠ 0 instance (f'/g' = 1 + x⁻¹ → 1), confirming the parent rule handles a genuinely nonzero target limit",
+      "Demonstrates the parent's abstract ∞/∞ theorem is usable: the hard divergence behaviour is reduced to elementary derivative lemmas and an inverse-limit computation"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "0 axioms, 0 sorries. All three limits fully machine-checked (only the standard foundational axioms propext / Classical.choice / Quot.sound). Depends on the parent entry lhopital-oq-02 for the ∞/∞ L'Hôpital rule (LHopitalInfty.lhopital_infty_atTop), itself 0-axiom.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Module docstring framing the leaf as worked corollaries of the parent ∞/∞ rule, a per-limit f/g/f'/g' table, and the status checklist. Imports Log.Deriv, Exp, Exponential, and the parent module Proofs.LHopitalOQ02; opens Set Filter Topology Real.",
+      "mathContext": "Each limit is an ∞/∞ indeterminate form f/g with g → +∞. The parent rule LHopitalInfty.lhopital_infty_atTop reduces the limit of f/g to the easy limit of f'/g'."
+    },
+    {
+      "id": "log-over-id",
+      "title": "Corollary 1: (ln x)/x → 0",
+      "startLine": 65,
+      "endLine": 86,
+      "summary": "log_div_id_atTop: with f = log, g = id, derivatives x⁻¹ and 1, the ratio f'/g' = x⁻¹ → 0 (tendsto_inv_atTop_zero) and g = id → +∞ (tendsto_id), so the parent rule yields (log x)/x → 0.",
+      "mathContext": "The logarithm grows slower than any positive power of x; the degree-one statement is the canonical illustration of the ∞/∞ rule with target c = 0."
+    },
+    {
+      "id": "id-over-exp",
+      "title": "Corollary 2: x/eˣ → 0",
+      "startLine": 87,
+      "endLine": 108,
+      "summary": "id_div_exp_atTop: with f = id, g = exp, derivatives 1 and eˣ, the ratio f'/g' = (eˣ)⁻¹ → 0 (tendsto_inv_atTop_zero ∘ tendsto_exp_atTop) and g = exp → +∞, so the parent rule yields x/eˣ → 0.",
+      "mathContext": "The exponential dominates every polynomial; the degree-one case x/eˣ → 0 is the classic ∞/∞ example named in the parent entry's commentary, here proved rather than annotated."
+    },
+    {
+      "id": "nonzero-limit",
+      "title": "Corollary 3: (x + ln x)/x → 1 (the c ≠ 0 case)",
+      "startLine": 109,
+      "endLine": 122,
+      "summary": "id_add_log_div_id_atTop: with f = x + log x, g = id, derivatives 1 + x⁻¹ and 1, the ratio f'/g' = 1 + x⁻¹ → 1 (tendsto_const_nhds.add tendsto_inv_atTop_zero) and g → +∞, so the parent rule yields (x + ln x)/x → 1.",
+      "mathContext": "Exercises the general c ≠ 0 form of the parent rule, confirming it is not silently specialised to vanishing ratios. The leading-order term x dominates, so the ratio tends to 1."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The parent entry (lhopital-oq-02) fills a gap in Mathlib by formalizing the ∞/∞ form of L'Hôpital's rule, which Mathlib's 26 L'Hôpital variants (as of v4.26.0) do not cover. That entry states the abstract rule and lists x/eˣ → 0 only as commentary. This leaf turns the rule into a working tool, deriving three textbook growth-comparison limits that historically motivated L'Hôpital's ∞/∞ form: the logarithm losing to the identity, the identity losing to the exponential, and a nonzero-limit ratio. These growth hierarchies (log ≪ polynomial ≪ exponential) underpin asymptotic analysis and the analysis of algorithms.",
+    "problemStatement": "Derive concrete growth-comparison limits as corollaries of the ∞/∞ L'Hôpital rule: (i) (ln x)/x → 0, (ii) x/eˣ → 0, and (iii) (x + ln x)/x → 1, all as x → +∞.",
+    "text": "Apply the parent's ∞/∞ L'Hôpital rule to obtain three classic limits, exercising both the c = 0 and c ≠ 0 cases.",
+    "proofStrategy": "For each limit f/g (with g → +∞) supply the derivatives f', g', verify g' ≠ 0 on Ioi 0, verify g → atTop, and compute the elementary limit of f'/g'; LHopitalInfty.lhopital_infty_atTop then delivers the conclusion. The auxiliary f'/g' limits are x⁻¹ → 0, (eˣ)⁻¹ → 0, and 1 + x⁻¹ → 1, all immediate from tendsto_inv_atTop_zero.",
+    "keyInsights": [
+      "An abstract L'Hôpital theorem becomes useful only when the hypotheses (derivative lemmas, non-vanishing denominator, divergence of g, and the f'/g' limit) can be assembled mechanically — these three corollaries demonstrate that for the parent rule",
+      "The c = 0 cases (log/x and x/eˣ) and the c ≠ 0 case ((x+log x)/x → 1) together confirm the parent theorem handles both vanishing and nonzero target limits",
+      "x/eˣ → 0 was listed only as commentary in the parent file; deriving it formally closes the loop between statement and application",
+      "The hard part — the ∞/∞ divergence behaviour — is entirely delegated to the parent's two-variable Cauchy-MVT argument, leaving only routine inverse-limit computations here"
+    ],
+    "conclusion": "All three growth limits are fully machine-checked with no sorries and no extra axioms, depending only on the parent's 0-axiom ∞/∞ L'Hôpital rule and standard Mathlib derivative/limit lemmas."
+  },
+  "conclusion": {
+    "summary": "Three classic growth-comparison limits — (ln x)/x → 0, x/eˣ → 0, and (x + ln x)/x → 1 — are derived as direct corollaries of the parent's ∞/∞ L'Hôpital rule (LHopitalInfty.lhopital_infty_atTop). 0 sorries, 0 axioms; verified with Lean 4.26.0.",
+    "implications": "Demonstrates that the parent's abstract ∞/∞ theorem is genuinely usable: it reduces hard divergent-ratio limits to elementary derivative and inverse-limit computations. The c = 0 cases cover logarithmic and exponential growth dominance, while the c ≠ 0 case shows the general statement is not accidentally restricted to vanishing limits. These corollaries form a small template for deriving further asymptotic limits from the rule.",
+    "openQuestions": [
+      "Can the higher-degree cases (xⁿ/eˣ → 0 for n ≥ 2, or (ln x)/xˢ → 0 for s > 0) be derived by iterating the ∞/∞ rule, and is there a clean inductive packaging of the polynomial-vs-exponential hierarchy?",
+      "Should these limits be phrased as IsLittleO statements (log =o[atTop] id, id =o[atTop] exp) to connect with Mathlib's asymptotics API?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Parent entry: formalizes the ∞/∞ L'Hôpital rule (LHopitalInfty.lhopital_infty_atTop) that this leaf applies to derive concrete growth limits",
+      "sharedConcepts": [
+        "lhopital",
+        "limits",
+        "derivatives",
+        "indeterminate-forms"
+      ],
+      "targetId": "lhopital-oq-02"
+    },
+    {
+      "relationship": "Sibling: the base L'Hôpital entry formalizing the 0/0 form (Wiedijk #64)",
+      "sharedConcepts": [
+        "lhopital",
+        "limits",
+        "derivatives"
+      ],
+      "targetId": "lhopital"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/lhopital-oq-02-incomplete-01.json
+++ b/src/data/research/problems/lhopital-oq-02-incomplete-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "lhopital-oq-02-incomplete-01",
   "title": "L Hopital Rule: Infinity/Infinity Form",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETE",
     "since": "2026-04-03T09:13:03.072Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Derived three growth limits as corollaries of the parent infinity/infinity L'Hopital rule; verified 0-axiom.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Done - shipped in PR #29199.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Completed: derived (ln x)/x -> 0, x/e^x -> 0, and (x+ln x)/x -> 1 as direct corollaries of the parent infinity/infinity L'Hopital theorem (LHopitalInfty.lhopital_infty_atTop). 3 theorems, 122 lines, 0 sorries, 0 axioms (Lean 4.26.0). Shipped in PR #29199.",
+    "builtItems": [
+      "log_div_id_atTop : Tendsto (fun x => Real.log x / x) atTop (nhds 0) - c=0 case, f=log/g=id, f'/g'=x^-1 -> 0",
+      "id_div_exp_atTop : Tendsto (fun x => x / Real.exp x) atTop (nhds 0) - c=0 case, f=id/g=exp, f'/g'=(e^x)^-1 -> 0",
+      "id_add_log_div_id_atTop : Tendsto (fun x => (x + Real.log x) / x) atTop (nhds 1) - general c<>0 case (c=1), f'/g'=1+x^-1 -> 1"
+    ],
+    "insights": [
+      "The parent infinity/infinity theorem is genuinely usable: each divergent ratio reduces to elementary derivative lemmas (Real.hasDerivAt_log/exp, hasDerivAt_id') plus an inverse-limit computation (tendsto_inv_atTop_zero).",
+      "Both the c=0 (log/x, x/e^x) and the c<>0 ((x+log x)/x -> 1) cases work, confirming the parent rule is not silently restricted to vanishing ratios.",
+      "x/e^x -> 0 appeared only as commentary in the parent file; formalizing it closes the gap between the abstract statement and its canonical application.",
+      "The hard infinity/infinity divergence behaviour is entirely delegated to the parent two-variable Cauchy-MVT argument; the leaf only assembles hypotheses."
+    ],
+    "mathlibGaps": [
+      "Mathlib (v4.26.0) provides 26 L'Hopital variants, all for the 0/0 form; the infinity/infinity rule used here comes from the parent entry, not Mathlib."
+    ],
+    "nextSteps": [
+      "Generalize to x^n/e^x -> 0 (n>=2) and (ln x)/x^s -> 0 (s>0) by iterating the infinity/infinity rule.",
+      "Restate the limits as IsLittleO facts (log =o[atTop] id, id =o[atTop] exp) to connect with Mathlib asymptotics."
+    ]
   },
   "tags": [
     "analysis",
@@ -51,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T09:13:03.072Z",
-  "lastUpdate": "2026-04-03T09:13:03.072Z",
+  "lastUpdate": "2026-06-24",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Leaf of **lhopital-oq-02** (L'Hôpital's Rule: ∞/∞ Form). The parent formalizes the abstract ∞/∞ rule — content Mathlib lacks — but only *states* it (and mentions `x/eˣ → 0` as commentary). This leaf turns it into a working tool, deriving three classic growth-comparison limits as direct corollaries of `LHopitalInfty.lhopital_infty_atTop`:

| theorem | limit | case |
|---|---|---|
| `log_div_id_atTop` | $(\ln x)/x \to 0$ | $c=0$ — log ≪ id |
| `id_div_exp_atTop` | $x/e^x \to 0$ | $c=0$ — id ≪ exp |
| `id_add_log_div_id_atTop` | $(x+\ln x)/x \to 1$ | general $c\ne 0$ |

## Method

Each limit is an $\infty/\infty$ form $f/g$ with $g\to+\infty$. We supply the derivatives $f',g'$, check $g'\ne 0$ on `Ioi 0`, verify $g\to\texttt{atTop}$, and compute the elementary ratio limit ($x^{-1}\to 0$, $(e^x)^{-1}\to 0$, $1+x^{-1}\to 1$); the parent rule delivers the conclusion. The hard divergence behaviour is entirely delegated to the parent's two-variable Cauchy-MVT argument.

The $c\ne 0$ corollary confirms the parent theorem handles a genuinely nonzero target limit, not only vanishing ratios.

## Verification

- **3 theorems, 122 lines, 0 sorries, 0 axioms** (`#print axioms` → only `propext` / `Classical.choice` / `Quot.sound`)
- Built on host with Lean 4.26.0 / Mathlib (Docker unavailable this cycle); parent olean rebuilt and leaf compiles clean.
- Depends on the parent entry's 0-axiom `lhopital_infty_atTop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)