### PR TITLE
research(pythagorean-triples-oq-08-oq-01): per-leg divisibility in primitive triples [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3528,6 +3528,7 @@ import Proofs.PythagoreanTriplesOQ06OQ01
 import Proofs.PythagoreanTriplesOQ06OQ01OQ01
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08
+import Proofs.PythagoreanTriplesOQ08OQ01
 import Proofs.PythagoreanTriplesOQ09
 import Proofs.PythagoreanTriplesOQ10
 import Proofs.QuadraticGaussSumDiagonal

--- a/proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean
@@ -1,0 +1,200 @@
+/-
+  # Per-leg divisibility in primitive Pythagorean triples
+  # (pythagorean-triples-oq-08-oq-01)
+
+  ## The Open Question
+
+  The parent entry `pythagorean-triples-oq-08` proves that for *every* Pythagorean
+  triple `x² + y² = z²` the product `x · y` is divisible by `12 = 4 · 3` (one leg by
+  `4`, one leg by `3`, established only at the level of the **product** `x · y`).
+
+  Its first listed open question asks to *sharpen* this to a per-leg statement for
+  **primitive** triples:
+
+  > In a primitive triple, exactly one leg is divisible by `4` and exactly one leg is
+  > divisible by `3` (not merely the product) — can the per-leg statement be
+  > formalised?
+
+  ## What is proved
+
+  For a primitive triple (`Int.gcd x y = 1`):
+
+  * **`exactly_one_leg_div_four`** — exactly one of the two legs `x, y` is divisible
+    by `4`; the other is not. (The even leg is `2mn` with `m, n` of opposite parity,
+    hence divisible by `4`; the odd leg `m² − n²` is odd, so not even divisible by `2`.)
+
+  * **`exactly_one_leg_div_three`** — exactly one of the two legs is divisible by `3`;
+    the other is not. (A finite `ZMod 3` check shows that, away from the excluded case
+    `3 ∣ m ∧ 3 ∣ n` — impossible by coprimality — precisely one of `m² − n²`, `2mn`
+    vanishes mod `3`.)
+
+  * **`twelve_dvd_mul`** — the primitive consequence `12 ∣ x · y`, recovered from the
+    two per-leg facts via coprimality of `4` and `3`.
+
+  ## Why primitivity is essential
+
+  Without it the per-leg statement is false: `(6, 8, 10) = 2·(3,4,5)` has *both* legs
+  even, so the "exactly one leg divisible by 4" claim fails (`4 ∣ 8` and `4 ∤ 6` is
+  still fine here, but `(9, 12, 15) = 3·(3,4,5)` has `3 ∣ 9` and `3 ∣ 12`, so "exactly
+  one leg divisible by 3" fails). The parent's product-level `12 ∣ x·y` survives
+  scaling; the per-leg refinement does not — it is genuinely a statement about
+  *primitive* triples.
+
+  ## Method
+
+  Everything is read off Mathlib's Euclid parametrization
+  `PythagoreanTriple.coprime_classification`: a primitive triple is, up to swapping the
+  legs, `(m² − n², 2mn, ±(m² + n²))` with `Int.gcd m n = 1` and `m, n` of opposite
+  parity. The `4`-divisibility is pure algebra on `2mn` and `m² − n²`; the
+  `3`-divisibility is a single `decide` over `ZMod 3` transported by
+  `ZMod.intCast_zmod_eq_zero_iff_dvd`.
+
+  ## Axiom count: 0  (the `decide` is a kernel decision over `ZMod 3`, no `native_decide`)
+-/
+
+import Mathlib
+
+namespace PythagoreanPerLeg
+
+open PythagoreanTriple
+
+variable {x y z : ℤ}
+
+/-! ## Parametrized helpers
+
+The Euclid form has legs `2mn` (even) and `m² − n²` (odd) when `m, n` have opposite
+parity, and coprime `m, n`. -/
+
+/-- The even leg `2mn` is divisible by `4`: opposite parity forces one of `m, n` even,
+so `mn` is even and `2mn` is a multiple of `4`. -/
+theorem four_dvd_two_mul_mul {m n : ℤ}
+    (hpar : m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :
+    (4 : ℤ) ∣ 2 * m * n := by
+  rcases hpar with ⟨hm, _⟩ | ⟨_, hn⟩
+  · obtain ⟨a, ha⟩ := Int.dvd_of_emod_eq_zero hm
+    exact ⟨a * n, by rw [ha]; ring⟩
+  · obtain ⟨b, hb⟩ := Int.dvd_of_emod_eq_zero hn
+    exact ⟨m * b, by rw [hb]; ring⟩
+
+/-- The odd leg `m² − n²` is odd, hence not even divisible by `2`, a fortiori not by
+`4`. -/
+theorem not_four_dvd_sq_sub {m n : ℤ}
+    (hpar : m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :
+    ¬ (4 : ℤ) ∣ (m ^ 2 - n ^ 2) := by
+  have hodd : Odd (m ^ 2 - n ^ 2) := by
+    rcases hpar with ⟨hm, hn⟩ | ⟨hm, hn⟩
+    · have em : Even (m ^ 2) := by rw [pow_two]; exact (Int.even_iff.mpr hm).mul_right m
+      have on : Odd (n ^ 2) := (Int.odd_iff.mpr hn).pow
+      exact em.sub_odd on
+    · have om : Odd (m ^ 2) := (Int.odd_iff.mpr hm).pow
+      have en : Even (n ^ 2) := by rw [pow_two]; exact (Int.even_iff.mpr hn).mul_right n
+      exact om.sub_even en
+  rintro ⟨c, hc⟩
+  have hpar2 := Int.odd_iff.mp hodd
+  omega
+
+/-- Exactly one of the parametrized legs is divisible by `3`. A finite `ZMod 3` check:
+away from the (coprimality-excluded) case `3 ∣ m ∧ 3 ∣ n`, precisely one of
+`m² − n²`, `2mn` vanishes mod `3`. -/
+theorem three_dvd_exactly_one {m n : ℤ} (hco : Int.gcd m n = 1) :
+    ((3 : ℤ) ∣ (m ^ 2 - n ^ 2) ∧ ¬ (3 : ℤ) ∣ (2 * m * n)) ∨
+      (¬ (3 : ℤ) ∣ (m ^ 2 - n ^ 2) ∧ (3 : ℤ) ∣ (2 * m * n)) := by
+  have dvd_iff : ∀ k : ℤ, (3 : ℤ) ∣ k ↔ ((k : ZMod 3) = 0) := by
+    intro k; rw [ZMod.intCast_zmod_eq_zero_iff_dvd]; norm_num
+  have cast1 : ((m ^ 2 - n ^ 2 : ℤ) : ZMod 3) = (m : ZMod 3) ^ 2 - (n : ZMod 3) ^ 2 := by
+    push_cast; ring
+  have cast2 : ((2 * m * n : ℤ) : ZMod 3) = 2 * (m : ZMod 3) * (n : ZMod 3) := by
+    push_cast; ring
+  have hnot : ¬ ((3 : ℤ) ∣ m ∧ (3 : ℤ) ∣ n) := by
+    rintro ⟨h1, h2⟩
+    have hu : IsUnit (3 : ℤ) := (Int.isCoprime_iff_gcd_eq_one.mpr hco).isUnit_of_dvd' h1 h2
+    rw [Int.isUnit_iff] at hu
+    rcases hu with h | h <;> norm_num at h
+  have hab : ((m : ZMod 3) ≠ 0 ∨ (n : ZMod 3) ≠ 0) := by
+    by_contra h; push_neg at h
+    exact hnot ⟨(dvd_iff m).mpr h.1, (dvd_iff n).mpr h.2⟩
+  have key : ∀ a b : ZMod 3, (a ≠ 0 ∨ b ≠ 0) →
+      ((a ^ 2 - b ^ 2 = 0 ∧ 2 * a * b ≠ 0) ∨ (a ^ 2 - b ^ 2 ≠ 0 ∧ 2 * a * b = 0)) := by
+    decide
+  rcases key (m : ZMod 3) (n : ZMod 3) hab with ⟨hA, hB⟩ | ⟨hA, hB⟩
+  · left
+    refine ⟨(dvd_iff _).mpr (by rw [cast1]; exact hA), ?_⟩
+    intro hd
+    exact hB (by have := (dvd_iff _).mp hd; rwa [cast2] at this)
+  · right
+    refine ⟨?_, (dvd_iff _).mpr (by rw [cast2]; exact hB)⟩
+    intro hd
+    exact hA (by have := (dvd_iff _).mp hd; rwa [cast1] at this)
+
+/-! ## Main per-leg theorems -/
+
+/-- **Exactly one leg divisible by 4.** In a primitive Pythagorean triple, exactly one
+of the two legs `x, y` is divisible by `4` (the even leg), and the other is not. -/
+theorem exactly_one_leg_div_four (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    ((4 : ℤ) ∣ x ∧ ¬ (4 : ℤ) ∣ y) ∨ (¬ (4 : ℤ) ∣ x ∧ (4 : ℤ) ∣ y) := by
+  obtain ⟨m, n, hxy, _, _, hpar⟩ := PythagoreanTriple.coprime_classification.mp ⟨h, hc⟩
+  rcases hxy with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · right
+    rw [hx, hy]
+    exact ⟨not_four_dvd_sq_sub hpar, four_dvd_two_mul_mul hpar⟩
+  · left
+    rw [hx, hy]
+    exact ⟨four_dvd_two_mul_mul hpar, not_four_dvd_sq_sub hpar⟩
+
+/-- **Exactly one leg divisible by 3.** In a primitive Pythagorean triple, exactly one
+of the two legs `x, y` is divisible by `3`, and the other is not. -/
+theorem exactly_one_leg_div_three (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    ((3 : ℤ) ∣ x ∧ ¬ (3 : ℤ) ∣ y) ∨ (¬ (3 : ℤ) ∣ x ∧ (3 : ℤ) ∣ y) := by
+  obtain ⟨m, n, hxy, _, hco, _⟩ := PythagoreanTriple.coprime_classification.mp ⟨h, hc⟩
+  rcases hxy with ⟨hx, hy⟩ | ⟨hx, hy⟩
+  · rw [hx, hy]; exact three_dvd_exactly_one hco
+  · rw [hx, hy]
+    rcases three_dvd_exactly_one hco with ⟨hA, hB⟩ | ⟨hA, hB⟩
+    · right; exact ⟨hB, hA⟩
+    · left; exact ⟨hB, hA⟩
+
+/-- **Primitive consequence `12 ∣ x · y`.** Combining the two per-leg facts (one leg
+divisible by `4`, one by `3`) via coprimality of `4` and `3`. The parent proves this
+for *all* triples; here it is recovered as a corollary of the sharper per-leg
+statement. -/
+theorem twelve_dvd_mul (h : PythagoreanTriple x y z) (hc : Int.gcd x y = 1) :
+    (12 : ℤ) ∣ x * y := by
+  have d4 : (4 : ℤ) ∣ x * y := by
+    rcases exactly_one_leg_div_four h hc with ⟨a, _⟩ | ⟨_, a⟩
+    · exact a.mul_right y
+    · exact a.mul_left x
+  have d3 : (3 : ℤ) ∣ x * y := by
+    rcases exactly_one_leg_div_three h hc with ⟨a, _⟩ | ⟨_, a⟩
+    · exact a.mul_right y
+    · exact a.mul_left x
+  have hcop : IsCoprime (4 : ℤ) 3 := Int.isCoprime_iff_gcd_eq_one.mpr (by decide)
+  have h12 := hcop.mul_dvd d4 d3
+  norm_num at h12
+  exact h12
+
+/-- Sanity check on the smallest primitive triple `(3, 4, 5)`: leg `4` is the unique
+leg divisible by `4`, and leg `3` is the unique leg divisible by `3`. -/
+example : (¬ (4 : ℤ) ∣ 3 ∧ (4 : ℤ) ∣ 4) ∧ ((3 : ℤ) ∣ 3 ∧ ¬ (3 : ℤ) ∣ 4) :=
+  ⟨⟨by norm_num, by norm_num⟩, ⟨by norm_num, by norm_num⟩⟩
+
+end PythagoreanPerLeg
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `four_dvd_two_mul_mul`     | opposite parity ⟹ `4 ∣ 2mn` (the even leg) |
+  | `not_four_dvd_sq_sub`      | opposite parity ⟹ `4 ∤ m² − n²` (the odd leg) |
+  | `three_dvd_exactly_one`    | coprime `m, n` ⟹ exactly one of `m²−n²`, `2mn` is `3`-divisible |
+  | `exactly_one_leg_div_four` | primitive triple ⟹ exactly one leg divisible by `4` |
+  | `exactly_one_leg_div_three`| primitive triple ⟹ exactly one leg divisible by `3` |
+  | `twelve_dvd_mul`           | primitive consequence `12 ∣ x·y` |
+
+  Answers the first open question of `pythagorean-triples-oq-08`: the per-leg
+  refinement of the product-level `12 ∣ x·y`, valid for primitive triples and false
+  without primitivity.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/pythagorean-triples-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-08-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "pyth-oq0801-ann-four-even",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "technique",
+    "title": "The even leg 2mn is divisible by 4",
+    "content": "In the Euclid form, the even leg is 2mn with m, n of opposite parity, so exactly one of m, n is even. Whichever it is, mn is even — write the even factor as 2·a — and then 2mn = 4·(a·(other factor)). The witness for 4 ∣ 2mn is produced directly (⟨a*n, by rw [ha]; ring⟩), no mod-8 case analysis is needed once the parametrization is available.",
+    "mathContext": "$2mn$ with one of $m,n$ even is $4 \\cdot (\\text{integer})$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid parametrization", "parity", "divisibility witness"],
+    "prerequisites": ["opposite parity of m, n in primitive triples"]
+  },
+  {
+    "id": "pyth-oq0801-ann-odd-leg",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 81, "endLine": 97 },
+    "type": "insight",
+    "title": "The odd leg m²−n² is not even, a fortiori not divisible by 4",
+    "content": "With m, n of opposite parity, m²−n² is even−odd or odd−even, hence odd (Even.sub_odd / Odd.sub_even applied to the squares). An odd integer is not divisible by 2, so it cannot be divisible by 4. Closing with omega from `(m²−n²) % 2 = 1` and `m²−n² = 4c` (treating m², n² as atoms) gives the contradiction. This pins the 4-divisibility to a unique leg.",
+    "mathContext": "Odd $\\Rightarrow \\neg 2 \\mid \\Rightarrow \\neg 4 \\mid$.",
+    "significance": "important",
+    "relatedConcepts": ["parity of squares", "omega", "Even/Odd lemmas"],
+    "prerequisites": ["parity arithmetic"]
+  },
+  {
+    "id": "pyth-oq0801-ann-three-decide",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 99, "endLine": 131 },
+    "type": "technique",
+    "title": "Exactly one leg divisible by 3 via a single ZMod 3 decide",
+    "content": "Cast m, n into ZMod 3 and run one finite decide over all nine residue pairs: away from (0,0), exactly one of a²−b², 2ab is zero (an XOR, stated as a disjunction of conjunctions). The excluded (0,0) corresponds to 3 ∣ m ∧ 3 ∣ n, impossible by coprimality (IsCoprime.isUnit_of_dvd' would make 3 a unit). Transport each ZMod equality to integer divisibility through ZMod.intCast_zmod_eq_zero_iff_dvd and push_cast.",
+    "mathContext": "Over $\\mathbb{Z}/3$, with $(a,b)\\neq(0,0)$: exactly one of $a^2-b^2$, $2ab$ vanishes.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod decide", "quadratic residues mod 3", "coprimality", "intCast_zmod_eq_zero_iff_dvd"],
+    "prerequisites": ["modular arithmetic", "squares modulo 3"]
+  },
+  {
+    "id": "pyth-oq0801-ann-main",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 133, "endLine": 157 },
+    "type": "insight",
+    "title": "Per-leg theorems from the coprime classification",
+    "content": "PythagoreanTriple.coprime_classification gives the primitive triple, up to swapping the legs, as (m²−n², 2mn) with Int.gcd m n = 1 and opposite parity. The leg-swap disjunction is handled by rcases and a relabelling, so both theorems state the clean 'exactly one of x, y' form (an Or of And) with no preferred leg. The z-sign disjunction from the classification is discarded — the divisibility of the legs does not see it.",
+    "mathContext": "Up to $x \\leftrightarrow y$: exactly one of $x,y$ is divisible by $4$, exactly one by $3$.",
+    "significance": "key",
+    "relatedConcepts": ["coprime_classification", "leg symmetry", "primitive triples"],
+    "prerequisites": ["Euclid parametrization"]
+  },
+  {
+    "id": "pyth-oq0801-ann-primitivity",
+    "proofId": "pythagorean-triples-oq-08-oq-01",
+    "range": { "startLine": 159, "endLine": 178 },
+    "type": "insight",
+    "title": "Why primitivity is indispensable",
+    "content": "Recovering 12 ∣ x·y from the two per-leg facts (via IsCoprime.mul_dvd on the coprime 4 and 3) shows the per-leg statement implies the parent's product form. But the converse fails: (9,12,15) = 3·(3,4,5) has 3 ∣ 9 and 3 ∣ 12, so 'exactly one leg divisible by 3' is false for this non-primitive triple. The parent's 12 ∣ x·y survives scaling; the per-leg refinement does not. The (3,4,5) instance confirms leg 4 is the unique 4-leg and leg 3 the unique 3-leg.",
+    "mathContext": "$(9,12,15)$ breaks per-leg; $(3,4,5)$ is the minimal witness with $4\\mid4,\\,3\\mid3$.",
+    "significance": "important",
+    "relatedConcepts": ["primitivity", "IsCoprime.mul_dvd", "scaling invariance"],
+    "prerequisites": ["coprimality of 4 and 3"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-08-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-08-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ08OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOQ08OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOQ08OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOQ08OQ01Data: ProofData = {
+  proof: pythagoreanTriplesOQ08OQ01Proof,
+  annotations: pythagoreanTriplesOQ08OQ01Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-08-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-08-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "pythagorean-triples-oq-08-oq-01",
+  "title": "Per-Leg Divisibility in Primitive Pythagorean Triples",
+  "slug": "pythagorean-triples-oq-08-oq-01",
+  "description": "In a primitive Pythagorean triple x²+y²=z², exactly one leg is divisible by 4 and exactly one leg is divisible by 3 (and the other leg by neither). This sharpens the parent's product-level 12 ∣ x·y to a per-leg statement that is true only for primitive triples. The even leg 2mn is divisible by 4 and the odd leg m²−n² is not even; a single ZMod 3 decide pins the 3-divisibility to exactly one leg.",
+  "meta": {
+    "author": "researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ08OQ01.lean",
+    "tags": [
+      "number-theory",
+      "pythagorean-triples",
+      "divisibility",
+      "modular-arithmetic",
+      "primitive-triples",
+      "diophantine"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "PythagoreanTriple.coprime_classification",
+        "description": "A primitive triple is, up to swapping legs and the sign of z, the Euclid form (m²−n², 2mn, m²+n²) with Int.gcd m n = 1 and m, n of opposite parity",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(↑a : ZMod b) = 0 ↔ (b : ℤ) ∣ a — transports the ZMod 3 decide to integer divisibility",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Int.isCoprime_iff_gcd_eq_one",
+        "description": "IsCoprime m n ↔ Int.gcd m n = 1 — used to exclude 3 ∣ m ∧ 3 ∣ n and to combine 4 and 3",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "IsCoprime.mul_dvd",
+        "description": "IsCoprime a b → a ∣ n → b ∣ n → a * b ∣ n — combines the 4- and 3-divisibility into 12 ∣ x·y",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "four_dvd_two_mul_mul: the even leg 2mn is divisible by 4 (opposite parity makes mn even)",
+      "not_four_dvd_sq_sub: the odd leg m²−n² is odd, hence not divisible by 2 — a fortiori not by 4",
+      "three_dvd_exactly_one: a single ZMod 3 decide shows exactly one of m²−n², 2mn vanishes mod 3, given Int.gcd m n = 1",
+      "exactly_one_leg_div_four: primitive triple ⟹ exactly one leg divisible by 4 (the even leg), the other not",
+      "exactly_one_leg_div_three: primitive triple ⟹ exactly one leg divisible by 3, the other not",
+      "twelve_dvd_mul: the primitive corollary 12 ∣ x·y recovered from the two per-leg facts"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The ZMod 3 step uses `decide` (kernel reduction, not `native_decide`), so no Lean.ofReduceBool. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound. The mathematical hypothesis is primitivity (Int.gcd x y = 1), which is part of the statement, not an axiom.",
+    "lineCount": 200,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical Euclid parametrization of primitive Pythagorean triples — (m²−n², 2mn, m²+n²) with m, n coprime of opposite parity — encodes fine divisibility structure of the legs that the product-level statements hide. That exactly one leg of a primitive triple is divisible by 4 and exactly one by 3 is the per-leg refinement of the elementary fact that 12 divides the product of the legs. It is a standard exercise in Sierpiński's 'Pythagorean Triangles', and crucially is true only for primitive triples: scaling destroys it.",
+    "problemStatement": "The parent entry pythagorean-triples-oq-08 proves 12 ∣ x·y at the level of the product. Its first open question asks: can the per-leg statement — exactly one leg divisible by 4, exactly one by 3 — be formalised for primitive triples?\n\n**Answer: Yes.** Reading off Mathlib's Euclid parametrization, the even leg 2mn is divisible by 4 while the odd leg m²−n² is not even; and a finite ZMod 3 check pins the 3-divisibility to exactly one leg, using coprimality to exclude the case 3 ∣ m ∧ 3 ∣ n.",
+    "text": "In a primitive Pythagorean triple, exactly one leg is divisible by 4 and exactly one leg by 3 — the per-leg sharpening of the parent's 12 ∣ x·y.",
+    "proofStrategy": "Apply PythagoreanTriple.coprime_classification to write the primitive triple, up to swapping the legs, as (m²−n², 2mn) with Int.gcd m n = 1 and m, n of opposite parity. (1) Divisibility by 4: opposite parity makes one of m, n even, so 2mn is a multiple of 4; meanwhile m²−n² is even−odd (or odd−even) = odd, so it is not divisible by 2, hence not by 4. (2) Divisibility by 3: cast m, n into ZMod 3 and run a single decide over all residue pairs (excluding 0,0, impossible by coprimality) showing exactly one of m²−n², 2mn is zero; transport via ZMod.intCast_zmod_eq_zero_iff_dvd. (3) Combine the two per-leg facts via IsCoprime.mul_dvd to recover 12 ∣ x·y for primitive triples.",
+    "keyInsights": [
+      "Primitivity is essential and the statement is false without it: (9,12,15) = 3·(3,4,5) has 3 ∣ 9 and 3 ∣ 12, so 'exactly one leg divisible by 3' fails — only the parent's scale-invariant product statement survives scaling",
+      "The 4-divisibility is sharp at the level of the parametrization: the even leg is 2mn and opposite parity gives an extra factor of 2, so 4 ∣ 2mn with no mod-8 case analysis needed once the Euclid form is in hand",
+      "The odd leg m²−n² is genuinely odd, so it fails even 2-divisibility — the 4-divisibility lands on a unique leg",
+      "The 3-divisibility is a single finite ZMod 3 decide: away from the coprimality-excluded (0,0), exactly one of m²−n², 2mn vanishes mod 3 across all nine residue pairs",
+      "Coprimality enters twice: to exclude 3 ∣ m ∧ 3 ∣ n (via IsCoprime.isUnit_of_dvd') and to combine the coprime factors 4 and 3 into 12"
+    ],
+    "prerequisites": [
+      "The Euclid parametrization of primitive Pythagorean triples",
+      "Modular arithmetic and residues (ZMod n)",
+      "Divisibility and coprimality over ℤ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "parametrized-helpers",
+      "title": "Parametrized Leg Helpers",
+      "startLine": 70,
+      "endLine": 97,
+      "summary": "From opposite parity: 4 ∣ 2mn (the even leg) and 4 ∤ m²−n² (the odd leg is odd).",
+      "mathContext": "$2mn$ with one of $m,n$ even is a multiple of $4$; $m^2-n^2$ is odd."
+    },
+    {
+      "id": "three-divisibility",
+      "title": "Exactly One Leg Divisible by 3",
+      "startLine": 99,
+      "endLine": 131,
+      "summary": "A ZMod 3 decide: away from the coprimality-excluded (0,0), exactly one of m²−n², 2mn is ≡ 0 mod 3.",
+      "mathContext": "Squares are $\\{0,1\\}$ mod 3; with $\\gcd(m,n)=1$ precisely one of $m^2-n^2$, $2mn$ vanishes."
+    },
+    {
+      "id": "per-leg-theorems",
+      "title": "Per-Leg Divisibility Theorems",
+      "startLine": 133,
+      "endLine": 157,
+      "summary": "exactly_one_leg_div_four and exactly_one_leg_div_three, read off the Euclid form up to swapping the legs.",
+      "mathContext": "Exactly one of $x,y$ is divisible by $4$; exactly one by $3$."
+    },
+    {
+      "id": "corollary-and-instance",
+      "title": "Primitive 12 ∣ x·y and the (3,4,5) Instance",
+      "startLine": 159,
+      "endLine": 178,
+      "summary": "Recover 12 ∣ x·y from the two per-leg facts, and check (3,4,5): leg 4 is the unique 4-leg, leg 3 the unique 3-leg.",
+      "mathContext": "$\\gcd(4,3)=1 \\Rightarrow 12 \\mid xy$; for $(3,4,5)$: $4\\mid 4,\\ 3\\mid 3$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Sierpiński, Wacław",
+      "title": "Pythagorean Triangles",
+      "year": "1962",
+      "note": "Divisibility properties of the legs of primitive Pythagorean triangles via the Euclid parametrization"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "note": "Standard reference on the classification of Pythagorean triples"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-08",
+      "relationship": "extends",
+      "description": "Sharpens the parent's product-level 12 ∣ x·y to a per-leg statement (exactly one leg divisible by 4, exactly one by 3), answering its first open question. Unlike the parent, the per-leg form requires primitivity."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-06",
+      "relationship": "related",
+      "description": "oq-06 establishes the Euclid m,n parametrization of primitive triples that this entry uses to read off the per-leg divisibility."
+    },
+    {
+      "targetId": "pythagorean-triples-oq-07",
+      "relationship": "related",
+      "description": "oq-07 proves exactly one leg is even; this entry refines that even leg to being divisible by 4, and adds the 3-divisibility of a unique leg."
+    }
+  ],
+  "conclusion": {
+    "summary": "In a primitive Pythagorean triple, exactly one leg is divisible by 4 (the even leg) and exactly one leg by 3, machine-checked at 0 axioms via Mathlib's Euclid parametrization and a single ZMod 3 decide. This per-leg refinement of the parent's 12 ∣ x·y is true only for primitive triples.",
+    "implications": "Shows that the per-leg divisibility structure — invisible at the product level — is read directly off the coprime classification, and isolates exactly where primitivity is indispensable.",
+    "openQuestions": [
+      "Per-leg modulo other primes: for which primes p, and under what congruence condition on the triple, does exactly one leg (or side) carry the factor p in a primitive triple?",
+      "Quantify the joint distribution: among primitive triples with hypotenuse below N, what is the density of those whose even leg is divisible by 8 (rather than just 4)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "PythagoreanTriple"
+    ],
+    "namespace": "PythagoreanPerLeg",
+    "lineCount": 200,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/PythagoreanTriplesOQ08OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of parent `pythagorean-triples-oq-08` (which proves the product-level `12 ∣ x·y`):

> In a primitive triple, exactly one leg is divisible by 4 and exactly one leg by 3 (not merely the product) — can the per-leg statement be formalised?

**Yes.** For a primitive Pythagorean triple (`Int.gcd x y = 1`):

| Theorem | Statement |
|---------|-----------|
| `exactly_one_leg_div_four` | exactly one of `x, y` is divisible by `4` (the even leg), the other not |
| `exactly_one_leg_div_three` | exactly one of `x, y` is divisible by `3`, the other not |
| `twelve_dvd_mul` | primitive corollary `12 ∣ x·y`, from the two per-leg facts |

Supporting: `four_dvd_two_mul_mul` (`4 ∣ 2mn`), `not_four_dvd_sq_sub` (`4 ∤ m²−n²`), `three_dvd_exactly_one` (ZMod 3 decide).

## Method

Everything is read off Mathlib's Euclid parametrization `PythagoreanTriple.coprime_classification`: a primitive triple is, up to swapping legs and the sign of `z`, the form `(m²−n², 2mn, ±(m²+n²))` with `Int.gcd m n = 1` and `m, n` of opposite parity.

- **÷4**: opposite parity ⟹ one of `m, n` even ⟹ `4 ∣ 2mn`; meanwhile `m²−n²` is odd, so not even divisible by `2`.
- **÷3**: a single `decide` over `ZMod 3` shows that away from the coprimality-excluded `(0,0)`, exactly one of `m²−n²`, `2mn` vanishes mod 3; transported via `ZMod.intCast_zmod_eq_zero_iff_dvd`.

## Why primitivity is essential

The per-leg form is **false** without it: `(9,12,15) = 3·(3,4,5)` has `3 ∣ 9` and `3 ∣ 12`. Only the parent's scale-invariant product statement survives scaling.

## Verification

- **0 sorries, 0 axioms** — the ZMod 3 step uses kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool`).
- 6 theorems, 200 lines; typechecks against Mathlib 4.26.0.
- Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)