### PR TITLE
research(seeker): replenish candidate pool with 4 verified-parent leaves

### DIFF
--- a/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: arsinh-log-formula-oq-01-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/literature/README.md
+++ b/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/literature/README.md
@@ -1,0 +1,13 @@
+# Literature for arsinh-log-formula-oq-01-oq-01-oq-01
+
+This directory collects related papers, Mathlib pointers, and sibling gallery
+proofs relevant to the problem.
+
+## Related Gallery Proofs and Mathlib API
+
+arsinh-log-formula-oq-01-oq-01 (parent: arsinh antiderivative + log form); arsinh-log-formula-oq-01 (root). Mathlib: Real.arsinh, Real.cosh_sq, intervalIntegral.integral_eq_sub_of_hasDerivAt.
+
+## External References
+
+- Standard graduate texts covering the topic (see the parent entry's references).
+- Mathlib4 source and docs for the API names listed in problem.md.

--- a/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,65 @@
+# Problem: Catenary Arc Length via the arsinh Substitution
+
+**Slug**: arsinh-log-formula-oq-01-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\int_0^b \sqrt{1 + t^2}\,\mathrm{d}t \;=\; \tfrac{1}{2}\Bigl(b\sqrt{1+b^2} + \operatorname{arsinh} b\Bigr),
+\qquad b \ge 0,
+$$
+
+equivalently, with $\operatorname{arsinh} b = \log\bigl(b + \sqrt{1+b^2}\bigr)$,
+
+$$
+\int_0^b \sqrt{1 + t^2}\,\mathrm{d}t \;=\; \tfrac{1}{2}\,b\sqrt{1+b^2} + \tfrac{1}{2}\log\bigl(b + \sqrt{1+b^2}\bigr).
+$$
+
+### Plain Language
+
+The graph of the hyperbolic cosine (a hanging chain, or *catenary*) has an arc length that, after the standard reduction, is governed by the integral of $\sqrt{1+t^2}$. This problem asks for a fully machine-checked closed form for that integral on $[0,b]$. The natural route is the substitution $t = \sinh u$, under which $\sqrt{1+t^2} = \cosh u$ and the integrand becomes $\cosh^2 u = \tfrac12(1+\cosh 2u)$, integrating to the stated half-sum of an algebraic term and an $\operatorname{arsinh}$ term.
+
+### Why This Matters
+
+This is the canonical "capstone" application of the parent entry's antiderivative of $1/\sqrt{1+x^2}$: it closes the loop from the derivative side (arsinh as an antiderivative) to the dual integral $\int\sqrt{1+x^2}$ that appears in every arc-length and surface-area computation involving hyperbolic geometry. It also exercises Mathlib's `Real.arsinh`/`Real.sinh`/`Real.cosh` API together with the fundamental theorem of calculus, providing a reusable lemma for catenary, parabola, and conic arc-length entries.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `arsinh-log-formula-oq-01-oq-01` (verified): the antiderivative identity for $1/\sqrt{1+x^2}$ and the logarithmic form $\operatorname{arsinh} x = \log(x+\sqrt{1+x^2})$.
+- Mathlib: `Real.arsinh`, `Real.sinh`, `Real.cosh`, `Real.cosh_sq`, `Real.sinh_arsinh`, `Real.cosh_arsinh`, and `Real.arsinh` differentiability lemmas.
+- Mathlib: `intervalIntegral.integral_eq_sub_of_hasDerivAt` (FTC-2) for evaluating the integral once an antiderivative is exhibited.
+
+### What's Still Open
+
+- A Lean statement and proof of $\int_0^b \sqrt{1+t^2}\,\mathrm{d}t = \tfrac12(b\sqrt{1+b^2} + \operatorname{arsinh} b)$.
+- The bridge to the literal catenary arc length $\int_0^b \cosh u\,\mathrm{d}u$ form, if desired as a corollary.
+
+### Our Goal
+
+Define the antiderivative $F(x) = \tfrac12\bigl(x\sqrt{1+x^2} + \operatorname{arsinh} x\bigr)$, prove $F'(x) = \sqrt{1+x^2}$ by differentiation (product rule plus the known derivative of arsinh), and conclude via FTC-2 that the definite integral equals $F(b) - F(0) = F(b)$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| arsinh-log-formula-oq-01-oq-01 | Direct parent; arsinh antiderivative and log form | hyperbolic calculus, FTC |
+| arsinh-log-formula-oq-01 | Root entry; defining identity for arsinh | inverse hyperbolic functions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Exhibit the antiderivative and apply FTC-2.** Set $F(x) = \tfrac12(x\sqrt{1+x^2} + \operatorname{arsinh} x)$, show `HasDerivAt F (sqrt (1+x^2)) x` via the product/chain rules, then `intervalIntegral.integral_eq_sub_of_hasDerivAt`.
+   - Why it might work: every ingredient (derivative of arsinh, derivative of $x\sqrt{1+x^2}$) is in Mathlib; the algebra $F'=\sqrt{1+x^2}$ reduces to a `field_simp`/`ring` identity after clearing $\sqrt{1+x^2}>0$.
+   - Risk: managing the $\sqrt{1+x^2}$ denominators and the positivity side-goals; `Real.sqrt` derivative bookkeeping.
+
+2. **Substitution $t = \sinh u$ directly.** Change variables to reduce to $\int_0^{\operatorname{arsinh} b}\cosh^2 u\,\mathrm{d}u$ and use $\cosh^2 = \tfrac12(1+\cosh 2u)$.
+   - Why it might work: mirrors the textbook derivation closely.
+   - Risk: Mathlib's change-of-variables (`intervalIntegral.integral_comp_smul_deriv` and friends) is more bookkeeping-heavy than the direct antiderivative route.

--- a/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/arsinh-log-formula-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,24 @@
+# Research State: arsinh-log-formula-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T16:43:04+0000
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: euler-totient-oq-01-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/literature/README.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/literature/README.md
@@ -1,0 +1,13 @@
+# Literature for euler-totient-oq-01-oq-01-oq-01
+
+This directory collects related papers, Mathlib pointers, and sibling gallery
+proofs relevant to the problem.
+
+## Related Gallery Proofs and Mathlib API
+
+euler-totient-oq-01-oq-01 (parent: prime-power groundwork); euler-totient-oq-01 (root). Mathlib: Monoid.exponent, Monoid.exponent_prod, ZMod CRT unit-group equivalence, Nat.lcm.
+
+## External References
+
+- Standard graduate texts covering the topic (see the parent entry's references).
+- Mathlib4 source and docs for the API names listed in problem.md.

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,62 @@
+# Problem: Carmichael Function as the lcm of Prime-Power Carmichael Values
+
+**Slug**: euler-totient-oq-01-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For $n = \prod_i p_i^{k_i}$ with distinct primes $p_i$, the Carmichael function $\lambda$ satisfies
+
+$$
+\lambda(n) \;=\; \operatorname{lcm}_i \,\lambda\bigl(p_i^{k_i}\bigr),
+$$
+
+where $\lambda(m)$ is the exponent of the unit group $(\mathbb{Z}/m\mathbb{Z})^\times$ — the least $e \ge 1$ with $a^e \equiv 1 \pmod m$ for every $a$ coprime to $m$. This is the universal-exponent refinement of Euler's theorem: $\lambda(n) \mid \varphi(n)$, and $a^{\lambda(n)} \equiv 1 \pmod n$ for all $\gcd(a,n)=1$.
+
+### Plain Language
+
+Euler's theorem guarantees $a^{\varphi(n)} \equiv 1 \pmod n$ for $a$ coprime to $n$, but $\varphi(n)$ is usually not the *smallest* exponent that works for all such $a$. The smallest universal exponent is the Carmichael function $\lambda(n)$, the exponent of the group of units mod $n$. By the Chinese Remainder Theorem the unit group factors as a product over the prime powers dividing $n$, so its exponent is the lcm of the exponents of the factors: $\lambda(n) = \operatorname{lcm}_i \lambda(p_i^{k_i})$. This problem asks to complete the induction over the prime-power factorization and state that lcm identity as a single Lean theorem.
+
+### Why This Matters
+
+The Carmichael function is the sharp constant in Euler's theorem and the right tool for primality testing, the structure of $(\mathbb{Z}/n\mathbb{Z})^\times$, and Carmichael numbers. The multiplicative-via-lcm law is its defining structural property; formalizing it converts the parent entry's per-prime-power groundwork into the general multiplicative statement and gives downstream entries (group exponents, RSA-style order bounds) a clean lemma to cite.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `euler-totient-oq-01-oq-01` (verified): prime-power / multiplicative groundwork for the totient and unit-group exponent.
+- Mathlib: `ZMod.unitsEquivProdUnits`-style CRT decomposition of $(\mathbb{Z}/n)^\times$, `Monoid.exponent`, `Monoid.exponent_prod`, `Nat.lcm`, and `Nat.Coprime`.
+- Classical: $\lambda$ is the exponent of $(\mathbb{Z}/n)^\times$; $\lambda(\prod p_i^{k_i}) = \operatorname{lcm}\lambda(p_i^{k_i})$ and $a^{\lambda(n)}\equiv 1$ for coprime $a$.
+
+### What's Still Open
+
+- A Lean definition of $\lambda(n) = \texttt{Monoid.exponent }(\mathbb{Z}/n)^\times$ (or an equivalent), and the theorem $\lambda(n) = \operatorname{lcm}_i \lambda(p_i^{k_i})$ via the CRT product decomposition.
+- The corollary $\lambda(n) \mid \varphi(n)$ and the universal-exponent property $a^{\lambda(n)} \equiv 1 \pmod n$.
+
+### Our Goal
+
+Identify $\lambda$ with `Monoid.exponent` of the unit group, push the CRT factorization $(\mathbb{Z}/n)^\times \cong \prod_i (\mathbb{Z}/p_i^{k_i})^\times$ through `Monoid.exponent_prod` (exponent of a product $=$ lcm of exponents), and conclude the lcm identity by induction over the factorization.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| euler-totient-oq-01-oq-01 | Direct parent; prime-power totient/exponent groundwork | multiplicative number theory |
+| euler-totient-oq-01 | Root entry; Euler's totient and its multiplicativity | $(\mathbb{Z}/n)^\times$, CRT |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Exponent-of-a-product via CRT.** Define $\lambda(n) = \texttt{Monoid.exponent }(\mathbb{Z}/n\mathbb{Z})^\times$, transport `Monoid.exponent` across the CRT group isomorphism, and apply `Monoid.exponent_prod` to get the lcm over coprime factors; induct on the factorization to reach individual prime powers.
+   - Why it might work: Mathlib already has `Monoid.exponent_prod` (or `exponent` of a `Pi`/product) and the CRT unit-group equivalence; the lcm structure falls out directly.
+   - Risk: the exact name/shape of the product-exponent lemma and threading the finite factorization (`Nat.factorization`) into a clean lcm.
+
+2. **Direct order-theoretic lcm.** Prove $\lambda(n)$ is the lcm of the $\lambda(p_i^{k_i})$ by showing it is a common multiple (Euler per factor) that also divides any common universal exponent (CRT witness achieving each factor's exponent).
+   - Why it might work: matches the textbook "least common universal exponent" argument; avoids depending on a specific product-exponent lemma name.
+   - Risk: constructing the CRT witness element that realizes a given factor's exponent requires care.

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,24 @@
+# Research State: euler-totient-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T16:43:04+0000
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.

--- a/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: hall-marriage-theorem-oq-01-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/literature/README.md
+++ b/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/literature/README.md
@@ -1,0 +1,13 @@
+# Literature for hall-marriage-theorem-oq-01-oq-01-oq-01
+
+This directory collects related papers, Mathlib pointers, and sibling gallery
+proofs relevant to the problem.
+
+## Related Gallery Proofs and Mathlib API
+
+hall-marriage-theorem-oq-01-oq-01 (parent: deficiency matching); hall-marriage-theorem-oq-01 (root). Mathlib: Finset.all_card_le_biUnion_card_iff_exists_injective, Finset.sup, Finset.biUnion.
+
+## External References
+
+- Standard graduate texts covering the topic (see the parent entry's references).
+- Mathlib4 source and docs for the API names listed in problem.md.

--- a/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/problem.md
+++ b/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/problem.md
@@ -1,0 +1,68 @@
+# Problem: Closed-Form Maximum Partial Transversal Size via Hall Deficiency
+
+**Slug**: hall-marriage-theorem-oq-01-oq-01-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a finite family $t : \iota \to \text{Finset}\,\alpha$, define the **deficiency**
+
+$$
+\delta \;=\; \max_{s \subseteq \iota} \bigl( |s| - |\textstyle\bigcup_{i \in s} t(i)| \bigr) .
+$$
+
+Then the maximum size of a partial transversal (a partial system of distinct representatives, i.e. an injective partial choice function) equals
+
+$$
+\max\text{-partial-transversal size} \;=\; |\iota| - \delta .
+$$
+
+Equivalently, packaging the deficiency as an explicit `Finset.sup` over the powerset turns Mathlib's `Finset.all_card_le_biUnion_card_iff_exists_injective` / deficiency form of Hall's theorem into a closed-form cardinality statement.
+
+### Plain Language
+
+Hall's marriage theorem says a perfect matching (a full system of distinct representatives) exists exactly when **no** subset $s$ of the index set has its combined neighbourhood smaller than $s$ itself. The *deficiency* version refines this: even when a perfect matching fails, the largest partial matching you can achieve falls short of the ideal $|\iota|$ by exactly the worst-case shortfall $\delta = \max_s(|s| - |\bigcup_{i\in s} t(i)|)$. This problem asks to formalize that closed form — that the maximum number of indices you can simultaneously and distinctly represent is precisely $|\iota| - \delta$ — with $\delta$ written as a concrete `Finset.sup` so the bound is computable.
+
+### Why This Matters
+
+The deficiency formula is the quantitative heart of matching theory (König–Egerváry, defect Hall) and underlies flow/assignment bounds throughout combinatorial optimization. The qualitative Hall criterion is already in Mathlib; turning it into the explicit "$|\iota| - \delta$" maximum gives an immediately reusable, decidable bound and makes the parent entry's `deficiency_matching_iff` into a self-contained extremal statement rather than a conditional one.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `hall-marriage-theorem-oq-01-oq-01` (verified): a `deficiency_matching_iff`-style characterization of when a full matching exists.
+- Mathlib: `Finset.all_card_le_biUnion_card_iff_exists_injective` (Hall's theorem), `Finset.biUnion`, `Finset.sup`, and powerset machinery.
+- Classical: the defect form of Hall's theorem (maximum matching $= |\iota| - \max_s(|s| - |N(s)|)$).
+
+### What's Still Open
+
+- A Lean definition of $\delta$ as `Finset.sup (Finset.powerset Finset.univ) (fun s => |s| - |s.biUnion t|)` (over $\mathbb{Z}$ to avoid truncated subtraction), and the theorem `maxPartialTransversal t = Fintype.card ι - δ`.
+- Connecting the closed form back to the parent's `deficiency_matching_iff` ($\delta = 0 \iff$ full matching).
+
+### Our Goal
+
+Define the deficiency as an explicit `Finset.sup` over the powerset of $\iota$ (in $\mathbb{Z}$), then prove the maximum partial-transversal cardinality equals $|\iota| - \delta$, recovering the parent's matching criterion as the special case $\delta = 0$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| hall-marriage-theorem-oq-01-oq-01 | Direct parent; deficiency matching criterion | Hall's theorem, biUnion bounds |
+| hall-marriage-theorem-oq-01 | Root entry; Hall's marriage theorem | systems of distinct representatives |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Reduce to an augmented Hall instance.** Add $\delta$ "universal" dummy targets so that the augmented family satisfies Hall's condition exactly; a full matching of the augmented family restricts to a maximum partial transversal of size $|\iota| - \delta$.
+   - Why it might work: this is the standard defect-Hall reduction and lets us reuse Mathlib's existing existence theorem as a black box.
+   - Risk: constructing the augmented target family in `Finset` form and tracking cardinalities through the reduction.
+
+2. **Direct `Finset.sup` bookkeeping.** Define $\delta$ over $\mathbb{Z}$ (signed, to dodge `Nat` subtraction), prove the upper bound $\text{size} \le |\iota| - \delta$ from the witnessing worst-case $s$, and the matching lower bound by induction mirroring the parent's proof.
+   - Why it might work: keeps everything in one file and aligned with the parent's induction.
+   - Risk: the lower bound essentially re-runs the Hall induction; may duplicate the parent's effort.

--- a/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,24 @@
+# Research State: hall-marriage-theorem-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T16:43:04+0000
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.

--- a/research/problems/wilsons-theorem-oq-02-ext-oq-01/knowledge.md
+++ b/research/problems/wilsons-theorem-oq-02-ext-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: wilsons-theorem-oq-02-ext-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/wilsons-theorem-oq-02-ext-oq-01/literature/README.md
+++ b/research/problems/wilsons-theorem-oq-02-ext-oq-01/literature/README.md
@@ -1,0 +1,13 @@
+# Literature for wilsons-theorem-oq-02-ext-oq-01
+
+This directory collects related papers, Mathlib pointers, and sibling gallery
+proofs relevant to the problem.
+
+## Related Gallery Proofs and Mathlib API
+
+wilsons-theorem-oq-02-ext (parent: two-involution trick); wilsons-theorem-oq-01 (Wilson core). Mathlib: Finset.prod_involution, Finset.prod_univ, ZMod unit groups.
+
+## External References
+
+- Standard graduate texts covering the topic (see the parent entry's references).
+- Mathlib4 source and docs for the API names listed in problem.md.

--- a/research/problems/wilsons-theorem-oq-02-ext-oq-01/problem.md
+++ b/research/problems/wilsons-theorem-oq-02-ext-oq-01/problem.md
@@ -1,0 +1,64 @@
+# Problem: Product of a Finite Abelian Group is the Identity when It Has At Least Three Involutions
+
+**Slug**: wilsons-theorem-oq-02-ext-oq-01
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $G$ be a finite abelian group. Then
+
+$$
+\prod_{x \in G} x \;=\; 1
+\qquad\text{whenever}\qquad
+\bigl|\{\, x \in G : x^2 = 1 \,\}\bigr| \;\ge\; 3 .
+$$
+
+More precisely, the product of all elements of a finite abelian group equals the product of its involutions (elements of order dividing $2$), and that product is the identity unless the set of involutions is exactly a single nontrivial element, in which case it equals that element.
+
+### Plain Language
+
+In the full product $\prod_{x\in G} x$, every element pairs off with its inverse, and a pair $\{x, x^{-1}\}$ contributes $x\cdot x^{-1} = 1$ unless $x = x^{-1}$, i.e. $x^2 = 1$. So only the involutions survive, and the whole product collapses to the product of the elements satisfying $x^2=1$. This problem asks to formalize the resulting general theorem: once there are three or more such self-paired elements (equivalently, the $2$-torsion subgroup is not cyclic of order $\le 2$), their product is forced to be the identity. This abstracts the two-involution pairing trick that underlies Wilson's theorem into a clean statement about finite abelian groups.
+
+### Why This Matters
+
+Wilson's theorem $(p-1)! \equiv -1 \pmod p$ is exactly the instance $G = (\mathbb{Z}/p\mathbb{Z})^\times$, where the only involutions are $\pm 1$ and the product is $-1$. The general lemma isolates the *reason* Wilson's theorem works and supplies a reusable building block: it immediately gives the product-of-units result for $(\mathbb{Z}/n\mathbb{Z})^\times$ (Gauss's generalization of Wilson's theorem) by counting solutions of $x^2 \equiv 1$. It is also a clean showcase of Mathlib's `Finset.prod_involution` / `Finset.prod_univ` machinery and the structure of the $2$-torsion subgroup.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `wilsons-theorem-oq-02-ext` (verified): the two-involution pairing argument specialized to Wilson's theorem.
+- Mathlib: `Finset.prod_univ`, `Finset.prod_involution`, `Finset.prod_eq_prod_of_...` pairing lemmas; `ZMod` unit groups.
+- Mathlib: the $2$-torsion / elementary-abelian structure lemmas (`orderOf`, `Monoid.IsTorsion`, subgroup of square-one elements).
+
+### What's Still Open
+
+- A standalone Lean theorem: for a finite abelian group $G$, $\prod_{x\in G} x = \prod_{x : x^2=1} x$, and the latter equals $1$ when the involution set has cardinality $\ge 3$.
+- The corollary recovering Gauss's generalization of Wilson's theorem for $(\mathbb{Z}/n\mathbb{Z})^\times$.
+
+### Our Goal
+
+State and prove $\prod_{x\in G} x = 1$ for a finite abelian group with at least three square-one elements, via the inverse-pairing involution on $G \setminus \{x : x^2 = 1\}$, then reduce the surviving product over the (elementary abelian) $2$-torsion subgroup to the identity using its non-cyclic structure.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| wilsons-theorem-oq-02-ext | Direct parent; two-involution trick | inverse pairing, finite products |
+| wilsons-theorem-oq-01 | Wilson's theorem core | modular arithmetic, $(\mathbb{Z}/p)^\times$ |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Pairing involution via `Finset.prod_involution`.** Use $x \mapsto x^{-1}$ as the involution; fixed points are exactly the square-one elements, so the product reduces to $\prod_{x^2=1} x$. Then argue the residual product is $1$.
+   - Why it might work: `Finset.prod_involution` is purpose-built; commutativity makes the residual a product over the elementary-abelian $2$-group $\{x : x^2 = 1\}$.
+   - Risk: discharging the hypotheses of `prod_involution` (well-definedness, non-fixed cancellation) and handling the residual product cleanly.
+
+2. **Reduce to the $2$-torsion subgroup $H = \{x : x^2 = 1\}$.** Show $\prod G = \prod H$ and that an elementary abelian $2$-group with $|H| \ge 3$ (hence $\ge 4$, non-cyclic) has trivial element-product by pairing each nonidentity $h$ with a complementary basis partner.
+   - Why it might work: an elementary abelian $2$-group is a vector space over $\mathbb{F}_2$; the sum of all vectors is $0$ once the dimension is $\ge 2$.
+   - Risk: bridging "product over $H$" to the $\mathbb{F}_2$-vector-space sum argument formally.

--- a/research/problems/wilsons-theorem-oq-02-ext-oq-01/state.md
+++ b/research/problems/wilsons-theorem-oq-02-ext-oq-01/state.md
@@ -1,0 +1,24 @@
+# Research State: wilsons-theorem-oq-02-ext-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-06-24T16:43:04+0000
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.


### PR DESCRIPTION
## Summary

Seeker replenishment: the candidate pool researchers read (`.lean/state/candidate-pool.json`) had dropped to **14 available**, below the 15 threshold. This adds **4 tractable openQuestion leaves** from verified parents, diverse across domains, restoring the effective pool to **18 available**.

| Slug | Domain | The leaf |
|------|--------|----------|
| `arsinh-log-formula-oq-01-oq-01-oq-01` | analysis / integration | Catenary arc length ∫₀ᵇ√(1+t²)dt = ½(b√(1+b²)+arsinh b) via FTC + arsinh antiderivative |
| `wilsons-theorem-oq-02-ext-oq-01` | finite group theory | ∏G = 1 for a finite abelian G with ≥3 involutions — abstracts the Wilson two-involution pairing |
| `hall-marriage-theorem-oq-01-oq-01-oq-01` | combinatorics | Max partial-transversal size = \|ι\| − δ with Hall deficiency δ as an explicit `Finset.sup` |
| `euler-totient-oq-01-oq-01-oq-01` | number theory | Carmichael λ(n) = lcm λ(pᵢ^kᵢ) via CRT exponent-of-product |

## Quality gate

- All four parents are `verified`.
- Each leaf is a real `conclusion.openQuestions` entry of its parent.
- Each leaf confirmed **absent** from the knowledge DB (not `completed`/`in-progress`/`graduated`) and **uncontested** by any active research worktree (an earlier candidate set — burnside, cayley, alternating-series — was rejected by exactly this check after the DB flagged them completed/in-progress).
- Pentagonal (Franklin involution), Pell distribution, and Simson deltoid candidates were rejected as too hard for single leaves.
- All four stubs pass `validate-seeker-stubs.ts` (no template placeholders).

DB (`research/db/knowledge.db`) and both candidate-pool JSONs were updated locally; only the tracked `research/problems/<slug>/` stubs are in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)