### PR TITLE
research(area-of-circle-oq-07-oq-05-oq-01-oq-02): scaled Gaussian even moment [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -208,6 +208,7 @@ import Proofs.AreaOfCircleOQ07OQ03
 import Proofs.AreaOfCircleOQ07OQ04
 import Proofs.AreaOfCircleOQ07OQ05
 import Proofs.AreaOfCircleOQ07OQ05OQ01
+import Proofs.AreaOfCircleOQ07OQ05OQ01OQ02
 import Proofs.ArithmeticSeries
 import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01

--- a/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ02.lean
@@ -1,0 +1,119 @@
+import Proofs.AreaOfCircleOQ07OQ05OQ01
+import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+import Mathlib.Tactic
+
+/-
+# The Scaled General Even Moment of the Gaussian  (area-of-circle-oq-07-oq-05-oq-01-oq-02)
+
+## Open Question (area-of-circle-oq-07-oq-05-oq-01-oq-02)
+"Generalize to the scaled Gaussian
+`∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼ · √(π/a) / (2a)^n`."
+
+## Answer
+
+For every `n : ℕ` and every `a > 0`,
+
+  `∫_{-∞}^{∞} x^{2n} e^{-a x²} dx = (2n-1)‼ · √(π/a) / (2a)^n`.
+
+The parent entry `area-of-circle-oq-07-oq-05-oq-01` evaluated the **unscaled**
+even moment `∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2^n` by an integration-by-parts
+induction.  This entry lifts that single result to **all** scales `a > 0` by one
+linear change of variables, with no further analysis.
+
+Write `s = √a` (so `s > 0` and `s² = a`).  Applying Mathlib's dilation rule for
+real integrals (`integral_comp_mul_left`) to the unscaled integrand
+`g y = y^{2n} e^{-y²}` gives
+
+  `∫_x g(s·x) = |s⁻¹| · ∫_y g y`.
+
+The left side is `aⁿ · ∫_x x^{2n} e^{-a x²}` (because `(s·x)^{2n} = aⁿ x^{2n}` and
+`(s·x)² = a x²`), and the right side is `s⁻¹ · (2n-1)‼·√π/2^n` by the parent
+moment.  Solving for the scaled integral and simplifying
+`√(π/a) = √π / √a` and `(2a)^n = 2^n aⁿ` produces the closed form
+(`scaled_gaussian_even_moment`).
+
+No new axioms: the proof is the parent moment, the standard dilation rule for
+the Lebesgue integral, and elementary `√`/power bookkeeping.
+-/
+
+open Real MeasureTheory
+open scoped Nat
+
+namespace AreaOfCircleOQ07OQ05OQ01OQ02
+
+/-- **Integrability of `x^{2n} e^{-a x²}` for `a > 0`.**  The same Gaussian-decay
+argument as the unscaled case, after absorbing `a` into the exponent. -/
+theorem integrable_pow_mul_scaled_gaussian (n : ℕ) {a : ℝ} (ha : 0 < a) :
+    Integrable (fun x : ℝ => x ^ (2 * n) * Real.exp (-a * x ^ 2)) := by
+  have h := integrable_rpow_mul_exp_neg_mul_sq (b := a) ha (s := (2 * n : ℕ)) ?_
+  · refine h.congr (Filter.Eventually.of_forall (fun x => ?_))
+    simp only [Real.rpow_natCast]
+  · have : (0 : ℝ) ≤ ((2 * n : ℕ) : ℝ) := Nat.cast_nonneg _
+    linarith
+
+/-- **The scaled general even moment of the Gaussian (closed form).**
+`∫_{-∞}^{∞} x^{2n} e^{-a x²} dx = (2n-1)‼ · √(π/a) / (2a)^n` for every `a > 0`,
+obtained from the unscaled parent moment by the dilation `x ↦ √a · x`. -/
+theorem scaled_gaussian_even_moment (n : ℕ) {a : ℝ} (ha : 0 < a) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-a * x ^ 2)
+      = ((2 * n - 1)‼ : ℝ) * Real.sqrt (Real.pi / a) / (2 * a) ^ n := by
+  -- `s = √a`, the dilation factor.
+  set s : ℝ := Real.sqrt a with hs
+  have hspos : 0 < s := Real.sqrt_pos.mpr ha
+  have hssq : s ^ 2 = a := Real.sq_sqrt ha.le
+  -- The unscaled integrand.
+  set g : ℝ → ℝ := fun y => y ^ (2 * n) * Real.exp (-y ^ 2) with hg
+  -- Dilation rule: `∫ g(s·x) = |s⁻¹| · ∫ g`.
+  have hdil := Measure.integral_comp_mul_left g s
+  -- Identify `g (s·x) = aⁿ · (x^{2n} e^{-a x²})` pointwise.
+  have hpt : ∀ x : ℝ, g (s * x) = a ^ n * (x ^ (2 * n) * Real.exp (-a * x ^ 2)) := by
+    intro x
+    simp only [hg]
+    have h1 : (s * x) ^ (2 * n) = a ^ n * x ^ (2 * n) := by
+      rw [mul_pow, pow_mul, hssq]
+    have h2 : -(s * x) ^ 2 = -a * x ^ 2 := by
+      rw [mul_pow, hssq]; ring
+    rw [h1, h2]; ring
+  -- Rewrite the dilated integral as `aⁿ · I`, where `I` is the target integral.
+  have hleft : (∫ x : ℝ, g (s * x))
+      = a ^ n * ∫ x : ℝ, x ^ (2 * n) * Real.exp (-a * x ^ 2) := by
+    rw [← integral_const_mul]
+    exact integral_congr_ae (Filter.Eventually.of_forall hpt)
+  -- The right side of the dilation rule, via the parent moment.
+  have hpar := AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment n
+  have hright : (|s⁻¹| • ∫ y : ℝ, g y)
+      = s⁻¹ * (((2 * n - 1)‼ : ℝ) * Real.sqrt Real.pi / 2 ^ n) := by
+    rw [hg, hpar, smul_eq_mul, abs_of_pos (inv_pos.mpr hspos)]
+  -- Assemble: `aⁿ · I = s⁻¹ · (parent value)`.
+  rw [hleft, hright] at hdil
+  -- Solve for `I` and match the closed form.
+  have hanpos : (0 : ℝ) < a ^ n := pow_pos ha n
+  have hI : ∫ x : ℝ, x ^ (2 * n) * Real.exp (-a * x ^ 2)
+      = s⁻¹ * (((2 * n - 1)‼ : ℝ) * Real.sqrt Real.pi / 2 ^ n) / a ^ n := by
+    field_simp at hdil ⊢
+    linarith [hdil]
+  rw [hI]
+  -- Closed-form bookkeeping: `√(π/a) = √π / s` and `(2a)^n = 2^n aⁿ`.
+  have hsqrt : Real.sqrt (Real.pi / a) = Real.sqrt Real.pi / s := by
+    rw [hs, Real.sqrt_div Real.pi_pos.le]
+  rw [hsqrt, mul_pow]
+  field_simp
+
+/-- Sanity check: `a = 1` recovers the parent's unscaled even moment. -/
+theorem scaled_gaussian_even_moment_one (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-(1 : ℝ) * x ^ 2)
+      = ((2 * n - 1)‼ : ℝ) * Real.sqrt Real.pi / 2 ^ n := by
+  have h := scaled_gaussian_even_moment n (a := 1) one_pos
+  simpa using h
+
+/-- Sanity check: the second moment (`n = 1`) of the scaled Gaussian is
+`√(π/a) / (2a)` — twice the half-line value `√(π/a)/(4a)` of sibling
+`area-of-circle-oq-07-oq-02-oq-02`, as the whole line doubles the `(0,∞)` half. -/
+theorem scaled_gaussian_second_moment {a : ℝ} (ha : 0 < a) :
+    ∫ x : ℝ, x ^ 2 * Real.exp (-a * x ^ 2)
+      = Real.sqrt (Real.pi / a) / (2 * a) := by
+  have h := scaled_gaussian_even_moment 1 ha
+  norm_num [Nat.doubleFactorial] at h
+  simpa using h
+
+end AreaOfCircleOQ07OQ05OQ01OQ02

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+  "slug": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Proofs.AreaOfCircleOQ07OQ05OQ01",
+      "Mathlib.MeasureTheory.Measure.Haar.NormedSpace",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ05OQ01OQ02",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ05OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Scaled Even Moment of the Gaussian ∫ x^{2n} e^{-a x²} = (2n-1)‼·√(π/a) / (2a)ⁿ",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ05OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "change-of-variables",
+      "special-functions",
+      "measure-theory",
+      "double-factorial",
+      "dilation",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "scaled_gaussian_even_moment: ∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼·√(π/a)/(2a)ⁿ for every n : ℕ and every a > 0 — the closed form for all even moments of the scaled Gaussian weight. The parent entry area-of-circle-oq-07-oq-05-oq-01 evaluated only the unscaled case a = 1 (by an integration-by-parts induction); this entry lifts that single family to all scales a > 0 by one linear change of variables x ↦ √a·x, with no further analysis. The substitution is Mathlib's dilation rule MeasureTheory.Measure.integral_comp_mul_left applied to the unscaled integrand, turning the parent moment into the scaled one.",
+      "Mechanism: writing s = √a (so s² = a), the dilated integrand g(s·x) = (s·x)^{2n} e^{-(s·x)²} equals aⁿ·x^{2n} e^{-a x²}, so ∫ g(s·x) = aⁿ·(scaled integral). The dilation rule equates this to |s⁻¹|·∫ g = s⁻¹·(parent value). Solving for the scaled integral and simplifying √(π/a) = √π/√a and (2a)ⁿ = 2ⁿaⁿ recovers the closed form, exhibiting exactly how the double-factorial moment picks up the scale factor a^{-(n+1/2)} = √(π/a)/(2a)ⁿ ÷ ((2n-1)‼·√π).",
+      "scaled_gaussian_second_moment: ∫_ℝ x² e^{-a x²} dx = √(π/a)/(2a), the n = 1 instance. This is exactly twice the half-line value √(π/a)/(4a) of sibling area-of-circle-oq-07-oq-02-oq-02, confirming the whole-line moment doubles the (0,∞) half by even symmetry.",
+      "integrable_pow_mul_scaled_gaussian: integrability of x^{2n} e^{-a x²} over ℝ for a > 0, the scaled companion of the parent's a = 1 integrability, obtained directly from integrable_rpow_mul_exp_neg_mul_sq."
+    ],
+    "prerequisites": [
+      "Parent: area-of-circle-oq-07-oq-05-oq-01 (the unscaled even moment ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ)",
+      "The dilation rule for Lebesgue integrals on ℝ: MeasureTheory.Measure.integral_comp_mul_left",
+      "Integrability of x^s e^{-b x²}: integrable_rpow_mul_exp_neg_mul_sq",
+      "Square-root algebra: Real.sq_sqrt, Real.sqrt_div"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.Measure.integral_comp_mul_left",
+        "description": "The dilation rule ∫ x, g (a·x) = |a⁻¹| • ∫ y, g y for a real integral. Applied with a = √a and g the unscaled integrand y^{2n} e^{-y²}, it converts the parent's unscaled moment directly into the scaled one.",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.NormedSpace"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√a)² = a for a ≥ 0, used to identify (√a·x)^{2n} = aⁿ x^{2n} and (√a·x)² = a x² after the substitution.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sqrt_div",
+        "description": "√(x/y) = √x/√y for x ≥ 0, used to simplify √(π/a) = √π/√a so the dilated value matches the stated closed form.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "integrable_rpow_mul_exp_neg_mul_sq",
+        "description": "x^s e^{-b x²} is integrable over ℝ for b > 0 and s > -1; specialized to s = 2n, b = a for the scaled integrability lemma.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01-oq-02-oq-01",
+      "question": "Combine the scaled even moments with the (vanishing) scaled odd moments to read off the moment generating function ∫_ℝ e^{t x} e^{-a x²} dx = √(π/a) e^{t²/(4a)}, recovering the full Gaussian Laplace/Fourier transform from the moment sequence.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Parent. Its unscaled even moment ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ is the a = 1 instance of this entry's closed form, recovered here as scaled_gaussian_even_moment_one, and is the input the dilation rule transforms into every scaled moment."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Sibling half-line moments. Its second moment ∫_{(0,∞)} x² e^{-b x²} = √(π/b)/(4b) is exactly half of this entry's whole-line value √(π/a)/(2a) (scaled_gaussian_second_moment), the even-symmetry doubling made explicit."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The Gaussian integral family. This entry parameterizes the even-moment collection by the scale a > 0, completing the scaled even-moment sequence."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Measure.Haar.NormedSpace",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of MeasureTheory.Measure.integral_comp_mul_left, the dilation rule ∫ g(a·x) = |a⁻¹|·∫ g that drives the change of variables."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_gaussian and integrable_rpow_mul_exp_neg_mul_sq underlying the parent moment and the scaled integrability lemma."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For every n : ℕ and every a > 0 the scaled Gaussian even moment is ∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼·√(π/a)/(2a)ⁿ (scaled_gaussian_even_moment). The proof is one linear change of variables x ↦ √a·x: Mathlib's dilation rule MeasureTheory.Measure.integral_comp_mul_left turns the parent entry's unscaled moment ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ into the scaled one, with the dilated integrand g(√a·x) = aⁿ·x^{2n} e^{-a x²} supplying the factor aⁿ and the rule's Jacobian |s⁻¹| = 1/√a supplying the missing half-power, so the integral picks up exactly a^{-(n+1/2)} = √(π/a)/(2a)ⁿ ÷ ((2n-1)‼√π). The second moment specializes to √(π/a)/(2a), twice the half-line sibling value. 119 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This parameterizes the gallery's even-moment family by the Gaussian scale a > 0: every ∫ x^{2n} e^{-a x²} now has a machine-checked closed form, obtained for free from the unscaled case by a single dilation rather than re-running the integration-by-parts induction at each scale. It isolates the algebraic content of scaling a Gaussian — the moment of order 2n acquires the factor a^{-(n+1/2)} — and connects the whole-line moments to their half-line counterparts by even symmetry.",
+    "openQuestions": [
+      "Assemble the scaled moment generating function ∫_ℝ e^{t x} e^{-a x²} = √(π/a) e^{t²/(4a)} from the full moment sequence."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-02** of `area-of-circle-oq-07-oq-05-oq-01` (medium significance): generalize the unscaled Gaussian even moment to **all scales** `a > 0`.

For every `n : ℕ` and `a > 0`:

```
∫_ℝ x^{2n} e^{-a x²} dx = (2n-1)‼ · √(π/a) / (2a)ⁿ
```

## Approach

One linear change of variables `x ↦ √a·x`, no re-running of the parent's integration-by-parts induction. Writing `s = √a`, Mathlib's dilation rule `MeasureTheory.Measure.integral_comp_mul_left` gives `∫ g(s·x) = |s⁻¹|·∫ g` for the unscaled integrand `g y = y^{2n} e^{-y²}`. The left side is `aⁿ·(scaled integral)` (since `(s·x)^{2n} = aⁿ x^{2n}`, `(s·x)² = a x²`) and the right side is `s⁻¹·(parent value)`. Solving and simplifying `√(π/a) = √π/√a`, `(2a)ⁿ = 2ⁿaⁿ` gives the closed form — the moment picks up exactly `a^{-(n+1/2)}`.

Reuses the parent `AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment` directly (imported).

## Theorems (4)

- `scaled_gaussian_even_moment` — the closed form for all `n`, `a > 0`
- `scaled_gaussian_even_moment_one` — `a = 1` recovers the parent's unscaled moment
- `scaled_gaussian_second_moment` — `∫ x² e^{-a x²} = √(π/a)/(2a)`, twice the half-line sibling `oq-07-oq-02-oq-02` value `√(π/b)/(4b)` (even-symmetry doubling)
- `integrable_pow_mul_scaled_gaussian` — scaled integrability companion

## Verification

- Builds clean against Mathlib v4.26.0 (`lake env lean`)
- `#print axioms`: `[propext, Classical.choice, Quot.sound]` only — **0 axioms, 0 sorries, verified**
- 119 lines, 4 theorems, 0 definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)