### PR TITLE
research(arithmetic-series-oq-00-oq-02-oq-02): uniform power-sum recurrence generating Faulhaber closed forms [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -213,6 +213,7 @@ import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01
 import Proofs.ArithmeticSeriesOQ00OQ02
 import Proofs.ArithmeticSeriesOQ00OQ02OQ01
+import Proofs.ArithmeticSeriesOQ00OQ02OQ02
 import Proofs.ArithmeticSeriesOQ02
 import Proofs.ArithmeticSeriesOQ02OQ01
 import Proofs.ArithmeticSeriesOQ02OQ01OQ01

--- a/proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean
@@ -1,0 +1,134 @@
+import Mathlib
+
+/-!
+# A uniform recurrence generating every Faulhaber power-sum closed form
+
+This file answers the open question raised by `arithmetic-series-oq-00-oq-02`
+(the Nicomachus generalization study):
+
+> *Can the Nicomachus identity be generalized to power sums:
+>  ∑ₖ kʳ = f(n, r) for some pattern?*
+
+The gallery already records the **closed forms** for individual exponents
+(`arithmetic-series-oq-04` proves p = 1, 2, 3 via Bernoulli numbers and
+`arithmetic-series-oq-04-oq-01` extends to p = 4, 5, 6 plus the triangular
+structure of odd powers).  Those entries answer the question one exponent at a
+time.
+
+Here we give the complementary, **uniform** answer: a single recurrence, valid
+for *all* exponents simultaneously, that mechanically generates each closed form
+from the lower ones.  Writing `S p n = ∑_{k=0}^{n-1} kᵖ`, the recurrence is
+
+  ∑_{j=0}^{p}  C(p+1, j) · S_j(n)  =  n^{p+1}.                         (★)
+
+Solving (★) for its top term gives the standard descent
+
+  (p+1) · S_p(n)  =  n^{p+1}  −  ∑_{j=0}^{p-1} C(p+1, j) · S_j(n),
+
+which determines `S_p` from `S_0, …, S_{p-1}`.  Thus the answer to "is there a
+pattern?" is: **yes — the pattern is exactly (★)**, and the closed forms in the
+sibling entries are its first few outputs.
+
+The proof of (★) is elementary and Bernoulli-free.  It is the telescoping
+identity `∑_{k<n} ((k+1)^{p+1} − k^{p+1}) = n^{p+1}` combined with the binomial
+expansion of the forward difference `(k+1)^{p+1} − k^{p+1}`, followed by an
+interchange of summation.
+
+All results are over `ℚ` with 0 sorries and 0 axioms.
+-/
+
+namespace ArithmeticSeriesOQ00OQ02OQ02
+
+open Finset
+
+/-- The power sum `S p n = 0ᵖ + 1ᵖ + ⋯ + (n-1)ᵖ`, taken over `ℚ`. -/
+def S (p n : ℕ) : ℚ := ∑ k ∈ range n, (k : ℚ) ^ p
+
+@[simp] lemma S_def (p n : ℕ) : S p n = ∑ k ∈ range n, (k : ℚ) ^ p := rfl
+
+/-- The forward difference `(k+1)^{p+1} − k^{p+1}` expands, by the binomial
+theorem, as a `C(p+1, j)`-weighted combination of the powers `kʲ` for `j ≤ p`.
+The top binomial term `k^{p+1}` cancels against the subtracted `k^{p+1}`. -/
+lemma diff_pow_expand (p k : ℕ) :
+    ((k : ℚ) + 1) ^ (p + 1) - (k : ℚ) ^ (p + 1)
+      = ∑ j ∈ range (p + 1), (Nat.choose (p + 1) j : ℚ) * (k : ℚ) ^ j := by
+  have hb := add_pow (k : ℚ) 1 (p + 1)
+  -- hb : (k+1)^(p+1) = ∑ m ∈ range (p+2), k^m * 1^(p+1-m) * C(p+1, m)
+  simp only [one_pow, mul_one] at hb
+  rw [Finset.sum_range_succ, Nat.choose_self, Nat.cast_one, mul_one] at hb
+  -- hb : (k+1)^(p+1) = (∑ m ∈ range (p+1), k^m * C(p+1, m)) + k^(p+1)
+  rw [hb, add_sub_cancel_right]
+  exact Finset.sum_congr rfl (fun m _ => mul_comm _ _)
+
+/-- **Power-sum recurrence (★).**  For every exponent `p` and bound `n`,
+`∑_{j=0}^{p} C(p+1, j) · S_j(n) = n^{p+1}`.
+
+This single identity holds for *all* `p` at once; the individual Faulhaber
+closed forms are recovered by reading it as a recurrence for the top term
+(see `power_sum_solved` and the corollaries below). -/
+theorem power_sum_recurrence (p n : ℕ) :
+    ∑ j ∈ range (p + 1), (Nat.choose (p + 1) j : ℚ) * S j n = (n : ℚ) ^ (p + 1) := by
+  -- Rewrite the single sum over `j` as a double sum over `(j, k)`.
+  have h1 : ∑ j ∈ range (p + 1), (Nat.choose (p + 1) j : ℚ) * S j n
+      = ∑ j ∈ range (p + 1), ∑ k ∈ range n,
+          (Nat.choose (p + 1) j : ℚ) * (k : ℚ) ^ j := by
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    rw [S, Finset.mul_sum]
+  rw [h1, Finset.sum_comm]
+  -- Collapse the inner sum over `j` via the binomial expansion of the difference.
+  have h2 : ∀ k : ℕ, ∑ j ∈ range (p + 1), (Nat.choose (p + 1) j : ℚ) * (k : ℚ) ^ j
+      = ((k : ℚ) + 1) ^ (p + 1) - (k : ℚ) ^ (p + 1) :=
+    fun k => (diff_pow_expand p k).symm
+  rw [Finset.sum_congr rfl (fun k _ => h2 k)]
+  -- What remains is a telescoping sum.
+  have h3 := Finset.sum_range_sub (fun k => (k : ℚ) ^ (p + 1)) n
+  simpa using h3
+
+/-- **Descent form of the recurrence.**  Isolating the top term of (★) expresses
+`S_p` in terms of the strictly lower power sums:
+`(p+1) · S_p(n) = n^{p+1} − ∑_{j<p} C(p+1, j) · S_j(n)`. -/
+theorem power_sum_solved (p n : ℕ) :
+    ((p : ℚ) + 1) * S p n
+      = (n : ℚ) ^ (p + 1) - ∑ j ∈ range p, (Nat.choose (p + 1) j : ℚ) * S j n := by
+  have h := power_sum_recurrence p n
+  rw [Finset.sum_range_succ, Nat.choose_succ_self_right] at h
+  push_cast at h
+  linarith
+
+/-! ## The recurrence in action
+
+The corollaries below run (★) for `p = 0, 1, 2`, recovering the familiar closed
+forms.  Each is derived purely from `power_sum_solved` and the previous case —
+no separate induction — illustrating that the recurrence is a self-contained
+generator of the Faulhaber polynomials. -/
+
+/-- Base case `p = 0`: `S₀(n) = n` (there are `n` terms, each equal to `1`). -/
+@[simp] theorem S_zero (n : ℕ) : S 0 n = (n : ℚ) := by
+  simp [S]
+
+/-- `p = 1`: the recurrence yields the triangular number `S₁(n) = n(n-1)/2`. -/
+theorem S_one (n : ℕ) : S 1 n = ((n : ℚ) ^ 2 - n) / 2 := by
+  have h := power_sum_solved 1 n
+  rw [Finset.sum_range_one, Nat.choose_zero_right, Nat.cast_one, one_mul, S_zero] at h
+  push_cast at h
+  linarith
+
+/-- `p = 2`: the recurrence yields `S₂(n) = n(n-1)(2n-1)/6 = (2n³ − 3n² + n)/6`. -/
+theorem S_two (n : ℕ) : S 2 n = (2 * (n : ℚ) ^ 3 - 3 * (n : ℚ) ^ 2 + n) / 6 := by
+  have h := power_sum_solved 2 n
+  rw [Finset.sum_range_succ, Finset.sum_range_one] at h
+  -- the two surviving terms are `C(3,0)·S₀ + C(3,1)·S₁`
+  rw [Nat.choose_zero_right, Nat.cast_one, one_mul, S_zero] at h
+  rw [show Nat.choose 3 1 = 3 from rfl, S_one] at h
+  push_cast at h
+  linarith
+
+/-- Sanity check: the descent (★) is consistent with the standard Nicomachus
+companion `S₂` being a genuine cubic with leading coefficient `1/3`, matching the
+general fact that `S_p` has leading term `n^{p+1}/(p+1)` read off from the top of
+(★). -/
+theorem S_two_leading (n : ℕ) :
+    3 * S 2 n - (n : ℚ) ^ 3 = (-3 * (n : ℚ) ^ 2 + n) / 2 := by
+  rw [S_two]; ring
+
+end ArithmeticSeriesOQ00OQ02OQ02

--- a/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-02/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-power-sum-def",
+    "proofId": "arithmetic-series-oq-00-oq-02-oq-02",
+    "range": { "startLine": 44, "endLine": 47 },
+    "type": "definition",
+    "title": "S: The Power Sum S(p,n) = ∑_{k=0}^{n-1} kᵖ",
+    "content": "The definition `S p n = ∑ k ∈ range n, (k : ℚ)^p` is the power sum over the half-open range {0, …, n-1}, taken over ℚ. Using Mathlib's `Finset.range n` (rather than `Ico 1 (n+1)`) is deliberate: the telescoping argument in Section III evaluates ∑_{k<n}(f(k+1) − f(k)) = f(n) − f(0) via `Finset.sum_range_sub`, which is stated exactly for `range n`. For p ≥ 1 the k=0 term vanishes, so S p n agrees with the classical ∑_{k=1}^{n-1} kᵖ. The `@[simp] lemma S_def` exposes the underlying sum so later rewrites (e.g. Finset.mul_sum) can fire.",
+    "mathContext": "$S_p(n) = \\sum_{k=0}^{n-1} k^p \\in \\mathbb{Q}$. The choice of the half-open range matches the telescoping lemma; the closed forms are the standard Faulhaber polynomials with $n$ shifted by the half-open convention ($S_1(n) = n(n-1)/2$ rather than $n(n+1)/2$).",
+    "significance": "important",
+    "prerequisites": [
+      "Finset.range n as the index set {0,…,n-1}",
+      "ℚ-valued finite sums (Finset.sum)"
+    ],
+    "relatedConcepts": [
+      "power_sum_recurrence",
+      "Finset.sum_range_sub",
+      "Faulhaber polynomials"
+    ]
+  },
+  {
+    "id": "ann-diff-pow-expand",
+    "proofId": "arithmetic-series-oq-00-oq-02-oq-02",
+    "range": { "startLine": 49, "endLine": 65 },
+    "type": "theorem",
+    "title": "diff_pow_expand: Binomial Expansion of the Forward Difference",
+    "content": "Proves (k+1)^{p+1} − k^{p+1} = ∑_{j=0}^{p} C(p+1,j)·kʲ. The proof starts from the binomial theorem `add_pow (k:ℚ) 1 (p+1)`, giving (k+1)^{p+1} = ∑_{m ∈ range(p+2)} k^m · 1^{p+1-m} · C(p+1,m); `simp only [one_pow, mul_one]` clears the powers of 1. Then `Finset.sum_range_succ` peels off the top term m = p+1, whose coefficient C(p+1,p+1) = 1 (`Nat.choose_self`) makes it exactly k^{p+1}. Substituting and applying `add_sub_cancel_right` cancels that top term against the subtracted k^{p+1}, leaving the sum over j = 0,…,p. A final `Finset.sum_congr` with `mul_comm` matches the C·kʲ ordering. This forward-difference identity is the discrete analogue of d/dx[x^{p+1}] = (p+1)x^p (plus lower-order corrections) and is the engine of the whole recurrence.",
+    "mathContext": "$(k+1)^{p+1} - k^{p+1} = \\sum_{j=0}^{p} \\binom{p+1}{j} k^j$. The top binomial term $\\binom{p+1}{p+1}k^{p+1} = k^{p+1}$ cancels the subtrahend; the surviving terms are the lower powers with their binomial weights.",
+    "significance": "critical",
+    "prerequisites": [
+      "add_pow (binomial theorem) from Mathlib.Data.Nat.Choose.Sum",
+      "Finset.sum_range_succ to split off the last term",
+      "Nat.choose_self : C(n,n) = 1",
+      "add_sub_cancel_right"
+    ],
+    "relatedConcepts": [
+      "power_sum_recurrence",
+      "telescoping sums",
+      "discrete derivative"
+    ]
+  },
+  {
+    "id": "ann-power-sum-recurrence",
+    "proofId": "arithmetic-series-oq-00-oq-02-oq-02",
+    "range": { "startLine": 67, "endLine": 88 },
+    "type": "theorem",
+    "title": "power_sum_recurrence: The Uniform Recurrence ∑ⱼ C(p+1,j)·Sⱼ(n) = n^{p+1}",
+    "content": "The headline result, holding for ALL exponents p at once. Step 1 (h1): rewrite the single sum ∑_j C(p+1,j)·S_j(n) as a double sum ∑_j ∑_k C(p+1,j)·kʲ by unfolding S and pulling the constant inside with `Finset.mul_sum`. Step 2: swap the order of summation with `Finset.sum_comm`, giving ∑_k ∑_j C(p+1,j)·kʲ. Step 3 (h2): collapse the inner j-sum using diff_pow_expand, turning each k-summand into the telescoping difference (k+1)^{p+1} − k^{p+1}. Step 4 (h3): evaluate the telescoping k-sum with `Finset.sum_range_sub (fun k => (k:ℚ)^{p+1}) n`, which gives n^{p+1} − 0^{p+1} = n^{p+1} (the `simpa` discharges the 0^{p+1} = 0 boundary term). The result is Bernoulli-free — no Bernoulli numbers and no Mathlib `sum_range_pow`, only the binomial theorem and a telescoping sum.",
+    "mathContext": "$\\sum_{j=0}^{p}\\binom{p+1}{j}S_j(n) = n^{p+1}$. Summing the forward-difference identity over $k<n$ telescopes to $n^{p+1}$ on one side, while Fubini regroups the other side as a binomial combination of the lower power sums $S_0,\\dots,S_p$. This single identity is the structural 'pattern' the parent open question asks for.",
+    "significance": "critical",
+    "prerequisites": [
+      "diff_pow_expand (forward-difference binomial expansion)",
+      "Finset.mul_sum and Finset.sum_comm (Fubini for finite sums)",
+      "Finset.sum_range_sub (telescoping)",
+      "ℚ as a commutative ring (subtraction needed for telescoping)"
+    ],
+    "relatedConcepts": [
+      "power_sum_solved",
+      "Faulhaber's formula",
+      "Pascal's power-sum recurrence",
+      "arithmetic-series-oq-04"
+    ]
+  },
+  {
+    "id": "ann-power-sum-solved",
+    "proofId": "arithmetic-series-oq-00-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 104 },
+    "type": "theorem",
+    "title": "power_sum_solved: Descent Form (p+1)·Sₚ = n^{p+1} − ∑_{j<p} C(p+1,j)·Sⱼ",
+    "content": "Isolates the top term of the recurrence to express S_p in terms of the strictly lower power sums. The proof takes `power_sum_recurrence p n`, splits off the j = p term with `Finset.sum_range_succ`, and identifies its binomial coefficient C(p+1,p) = p+1 via `Nat.choose_succ_self_right`. After `push_cast` normalizes the cast (↑(p+1) ↦ (p:ℚ)+1), `linarith` rearranges to the stated descent form. The coefficient p+1 of the top term is exactly the divisor that produces the Faulhaber leading coefficient 1/(p+1); reading this recurrence top-down generates every closed form.",
+    "mathContext": "$(p+1)S_p(n) = n^{p+1} - \\sum_{j=0}^{p-1}\\binom{p+1}{j}S_j(n)$. Because $\\binom{p+1}{p} = p+1$, dividing through expresses $S_p$ as a $\\mathbb{Q}$-combination of the lower power sums — a genuine recurrence, not merely a closed form.",
+    "significance": "critical",
+    "prerequisites": [
+      "power_sum_recurrence",
+      "Finset.sum_range_succ",
+      "Nat.choose_succ_self_right : C(n+1,n) = n+1",
+      "push_cast, linarith"
+    ],
+    "relatedConcepts": [
+      "S_one",
+      "S_two",
+      "Faulhaber leading coefficient 1/(p+1)"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "arithmetic-series-oq-00-oq-02-oq-02",
+    "range": { "startLine": 105, "endLine": 134 },
+    "type": "theorem",
+    "title": "S_zero / S_one / S_two: The Recurrence Generating the Faulhaber Polynomials",
+    "content": "These corollaries run the descent for p = 0, 1, 2 and recover the classical closed forms with NO separate induction — each follows from `power_sum_solved` and the previous case by `linarith`. S_zero: S_0(n) = n (n terms equal to 1, by simp). S_one: feeding p=1 into the descent gives 2·S_1 = n² − C(2,0)·S_0 = n² − n, hence S_1 = (n²−n)/2 = n(n−1)/2 (the triangular number). S_two: p=2 gives 3·S_2 = n³ − [C(3,0)·S_0 + C(3,1)·S_1] = n³ − [n + 3·(n²−n)/2], hence S_2 = (2n³−3n²+n)/6 = n(n−1)(2n−1)/6. S_two_leading records 3·S_2 − n³ = (−3n²+n)/2, exhibiting the cubic with leading coefficient 1/3. Together they demonstrate that the recurrence is a self-contained generator of the Faulhaber family — the uniform answer to the parent's 'is there a pattern?'.",
+    "mathContext": "$S_0 = n$, $S_1 = \\tfrac{n(n-1)}{2}$, $S_2 = \\tfrac{n(n-1)(2n-1)}{6}$. These are the first three Faulhaber polynomials, produced mechanically by the descent rather than guessed and verified per exponent.",
+    "significance": "important",
+    "prerequisites": [
+      "power_sum_solved (the descent recurrence)",
+      "Finset.sum_range_succ / Finset.sum_range_one to expand the lower-power sum",
+      "Nat.choose_zero_right, the concrete C(3,1) = 3",
+      "linarith for the linear back-substitution"
+    ],
+    "relatedConcepts": [
+      "Nicomachus's theorem",
+      "triangular numbers",
+      "arithmetic-series-oq-04-oq-01"
+    ]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-02/meta.json
@@ -1,0 +1,239 @@
+{
+  "id": "arithmetic-series-oq-00-oq-02-oq-02",
+  "title": "A Uniform Recurrence Generating Every Faulhaber Power-Sum Closed Form",
+  "slug": "arithmetic-series-oq-00-oq-02-oq-02",
+  "description": "Answers the parent's open question 'Can the Nicomachus identity be generalized to power sums ∑k^r = f(n,r) for some pattern?' with the complementary, uniform answer to the per-exponent closed forms in the oq-04 subtree: a single Bernoulli-free recurrence ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1}, valid for ALL exponents at once. Its descent form (p+1)·S_p = n^{p+1} − ∑_{j<p} C(p+1,j)·S_j determines each power sum from the lower ones; the corollaries run it for p = 0,1,2 to recover n, n(n-1)/2, n(n-1)(2n-1)/6. The proof is the telescoping identity ∑((k+1)^{p+1}−k^{p+1}) = n^{p+1} plus the binomial expansion of the forward difference and an interchange of summation.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "arithmetic-series",
+      "faulhaber",
+      "power-sums",
+      "recurrence",
+      "binomial-theorem",
+      "telescoping",
+      "nicomachus",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over ℚ; depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 134,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "originalContributions": [
+      "power_sum_recurrence: the uniform recurrence ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1}, holding for every exponent p simultaneously — a single statement subsuming the per-exponent closed forms",
+      "diff_pow_expand: binomial expansion of the forward difference (k+1)^{p+1} − k^{p+1} = ∑_{j≤p} C(p+1,j)·k^j, the engine behind the recurrence",
+      "power_sum_solved: descent form (p+1)·S_p(n) = n^{p+1} − ∑_{j<p} C(p+1,j)·S_j(n), exhibiting S_p as determined by the strictly lower power sums",
+      "S_one, S_two: closed forms n(n-1)/2 and n(n-1)(2n-1)/6 derived purely from the recurrence (no separate induction), demonstrating it generates the Faulhaber polynomials"
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Binomial theorem `add_pow` (Mathlib.Data.Nat.Choose.Sum)",
+      "Telescoping sum `Finset.sum_range_sub`",
+      "`Finset.sum_comm` for interchanging the order of a double sum",
+      "`Finset.mul_sum`, `Finset.sum_range_succ`, `Nat.choose_self`, `Nat.choose_succ_self_right`",
+      "Mathlib tactics: push_cast, linarith, ring, simp"
+    ]
+  },
+  "parent": "arithmetic-series-oq-00-oq-02",
+  "openQuestion": "Can the Nicomachus identity be generalized to power sums: ∑_{k=1}^n k^r = f(n,r) for some pattern?",
+  "overview": {
+    "historicalContext": "Nicomachus of Gerasa (ca. 100 CE) recorded ∑_{k=1}^n k³ = (∑_{k=1}^n k)², the p=3 case of the general theory of power sums. The closed forms for arbitrary exponent p are the subject of Faulhaber's formulas (Academia Algebrae, 1631), put on a rigorous footing by Jacob Bernoulli (Ars Conjectandi, 1713) via Bernoulli numbers. The gallery already records the Bernoulli/closed-form route in the arithmetic-series-oq-04 subtree (oq-04: p = 1,2,3; oq-04-oq-01: p = 4,5,6 and the triangular structure of odd powers). The parent open question of THIS branch — 'is there a pattern for ∑k^r?' — admits a second, complementary answer that predates Bernoulli numbers entirely: a single recurrence relating the power sums of all exponents. It goes back to Pascal's 1654 treatise on the arithmetical triangle, which derived ∑k^p from lower power sums precisely by telescoping (k+1)^{p+1} − k^{p+1} and expanding by the binomial theorem.",
+    "problemStatement": "Is there a uniform pattern f(n,r) for the power sums S_r(n) = ∑_{k=0}^{n-1} k^r, valid across all exponents r — as opposed to a separate closed form proved for each r individually?",
+    "proofStrategy": "Telescoping: ∑_{k<n} ((k+1)^{p+1} − k^{p+1}) = n^{p+1} − 0^{p+1} = n^{p+1} (Finset.sum_range_sub). Expand each summand by the binomial theorem: (k+1)^{p+1} − k^{p+1} = ∑_{j=0}^{p} C(p+1,j)·k^j (the top term k^{p+1} cancels). Interchange summation (Finset.sum_comm) to pull the k-sum inside, turning ∑_k ∑_j C(p+1,j)·k^j into ∑_j C(p+1,j)·S_j(n). Equate with n^{p+1} to get the recurrence (★). Isolating the j=p term (whose coefficient is C(p+1,p) = p+1) gives the descent form, and feeding p = 0,1,2 into the descent recovers the familiar closed forms.",
+    "keyInsights": [
+      "The recurrence ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1} is a SINGLE statement quantified over all exponents p, in contrast to the per-exponent closed forms (p = 1,…,6) recorded elsewhere in the gallery. It answers 'is there a pattern?' structurally rather than by enumeration.",
+      "It is Bernoulli-free: no Bernoulli numbers, no Bernoulli polynomials, no Mathlib `sum_range_pow`. The only ingredients are the binomial theorem and a telescoping sum — both entirely elementary.",
+      "The forward-difference identity (k+1)^{p+1} − k^{p+1} = ∑_{j≤p} C(p+1,j)·k^j is the discrete analogue of d/dx[x^{p+1}] = (p+1)x^p; summing it over k is discrete integration, and the telescoping is the discrete fundamental theorem of calculus.",
+      "The coefficient of the top term S_p in (★) is C(p+1,p) = p+1, which is exactly the (p+1) one divides by to read off the closed form — the same (p+1) that appears as the leading coefficient 1/(p+1) of the Faulhaber polynomial.",
+      "Running the descent for p = 0,1,2 recovers S_0 = n, S_1 = n(n-1)/2, S_2 = n(n-1)(2n-1)/6 with NO new induction — each follows by linear arithmetic from the previous, illustrating that the recurrence is a self-contained generator of the Faulhaber family.",
+      "Working with S_p(n) = ∑_{k=0}^{n-1} k^p (Mathlib's natural `range n` object) keeps the telescoping clean; the k=0 term vanishes for p ≥ 1, so the closed forms are the standard ones shifted to the half-open range."
+    ],
+    "prerequisites": [
+      "Binomial theorem (x+y)^n = ∑ C(n,m) x^m y^{n-m}",
+      "Telescoping sums ∑_{k<n} (f(k+1) − f(k)) = f(n) − f(0)",
+      "Interchanging the order of a finite double sum (Fubini for Finset)",
+      "Pascal's identity / basic binomial coefficient facts C(p+1,p+1)=1, C(p+1,p)=p+1",
+      "Nicomachus's theorem ∑k³ = (∑k)² as the motivating p=3 special case (parent gallery family)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "I. The Power Sum S(p,n)",
+      "startLine": 42,
+      "endLine": 48,
+      "summary": "Defines S p n = ∑_{k=0}^{n-1} k^p over ℚ and the unfolding simp lemma S_def. Working over the half-open range {0,…,n-1} is Mathlib's natural Finset.range object and makes the telescoping in Section III clean.",
+      "mathContext": "$S_p(n) = \\sum_{k=0}^{n-1} k^p \\in \\mathbb{Q}$. For $p \\geq 1$ the $k=0$ term vanishes, so $S_p(n)$ equals the classical $\\sum_{k=1}^{n-1} k^p$."
+    },
+    {
+      "id": "forward-difference",
+      "title": "II. Binomial Expansion of the Forward Difference",
+      "startLine": 49,
+      "endLine": 66,
+      "summary": "Proves diff_pow_expand: (k+1)^{p+1} − k^{p+1} = ∑_{j=0}^{p} C(p+1,j)·k^j. From the binomial theorem `add_pow`, the top term (j = p+1, coefficient C(p+1,p+1) = 1) is exactly k^{p+1}, which cancels the subtracted k^{p+1}; the remaining terms run j = 0,…,p.",
+      "mathContext": "$(k+1)^{p+1} - k^{p+1} = \\sum_{j=0}^{p} \\binom{p+1}{j} k^j$. This is the discrete analogue of $\\frac{d}{dx}x^{p+1} = (p+1)x^p$ together with its lower-order corrections."
+    },
+    {
+      "id": "recurrence",
+      "title": "III. The Uniform Recurrence (★)",
+      "startLine": 67,
+      "endLine": 88,
+      "summary": "Proves power_sum_recurrence: ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1}. Rewrites the single j-sum as a double (j,k)-sum (Finset.mul_sum), swaps the order (Finset.sum_comm), collapses the inner j-sum via diff_pow_expand, and evaluates the resulting telescoping k-sum with Finset.sum_range_sub.",
+      "mathContext": "$\\sum_{j=0}^{p} \\binom{p+1}{j} S_j(n) = n^{p+1}$. Summing the forward-difference identity over $k < n$ telescopes the left side to $n^{p+1} - 0^{p+1} = n^{p+1}$, while Fubini regroups it as a binomial combination of the lower power sums."
+    },
+    {
+      "id": "descent",
+      "title": "IV. Descent Form",
+      "startLine": 89,
+      "endLine": 104,
+      "summary": "Proves power_sum_solved: (p+1)·S_p(n) = n^{p+1} − ∑_{j<p} C(p+1,j)·S_j(n). Splits off the top term of (★) via Finset.sum_range_succ; its binomial coefficient is C(p+1,p) = p+1 (Nat.choose_succ_self_right), so dividing by p+1 expresses S_p in terms of the strictly lower power sums.",
+      "mathContext": "$(p+1) S_p(n) = n^{p+1} - \\sum_{j=0}^{p-1} \\binom{p+1}{j} S_j(n)$. The coefficient $\\binom{p+1}{p} = p+1$ of the top term is the same $p+1$ giving the Faulhaber leading coefficient $1/(p+1)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "V. The Recurrence in Action",
+      "startLine": 105,
+      "endLine": 134,
+      "summary": "Runs the descent for p = 0,1,2: S_zero (S_0 = n), S_one (S_1 = (n²−n)/2), S_two (S_2 = (2n³−3n²+n)/6), each derived from power_sum_solved and the previous case by linear arithmetic — no separate induction. S_two_leading records the leading-term consistency 3·S_2 − n³ = (−3n²+n)/2.",
+      "mathContext": "$S_0 = n$, $S_1 = \\tfrac{n(n-1)}{2}$, $S_2 = \\tfrac{n(n-1)(2n-1)}{6}$ — the Faulhaber polynomials, generated mechanically by (★) rather than guessed and verified per exponent."
+    }
+  ],
+  "conclusion": {
+    "summary": "Yes — the pattern is the single recurrence ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1}, valid for every exponent p at once and proved Bernoulli-free from the binomial theorem and a telescoping sum (0 sorries, 0 axioms over ℚ). Its descent form determines each power sum from the lower ones, and the corollaries generate S_0, S_1, S_2 from it directly.",
+    "implications": "This complements the gallery's per-exponent Faulhaber closed forms (arithmetic-series-oq-04 and oq-04-oq-01) with a uniform structural answer to the parent open question: the Faulhaber polynomials are not an unrelated list but the orbit of one recurrence. The Bernoulli-free derivation also makes explicit that the (p+1) dividing the top term — i.e. the leading coefficient 1/(p+1) — comes directly from the binomial coefficient C(p+1,p), not from any property of Bernoulli numbers.",
+    "openQuestions": [
+      "Can the descent be packaged as a formal `Polynomial ℚ`-valued function n ↦ S_p(n), proving by strong induction on p that it is monic-up-to-scaling of degree p+1 with leading coefficient 1/(p+1) — i.e. extracting the structural Faulhaber theorem from (★) over all p at once?",
+      "Does the same telescoping-plus-binomial engine yield the Bernoulli numbers themselves, by specializing the recurrence at the formal level and matching coefficients, thereby connecting this elementary route to the arithmetic-series-oq-04 Bernoulli formulation?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-00-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry (Nicomachus generalization study) whose open question 'can ∑k^r be generalized to a pattern f(n,r)?' this file answers with the uniform recurrence."
+    },
+    {
+      "targetId": "arithmetic-series-oq-04",
+      "relationship": "related",
+      "description": "Provides the complementary, per-exponent Faulhaber closed forms (p = 1,2,3) via Bernoulli numbers; this file gives the single recurrence that generates them, Bernoulli-free."
+    },
+    {
+      "targetId": "arithmetic-series-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Extends the per-exponent closed forms to p = 4,5,6 and the triangular structure of odd powers; the recurrence here mechanically produces those same polynomials."
+    },
+    {
+      "targetId": "arithmetic-series-oq-00",
+      "relationship": "related",
+      "description": "Nicomachus's theorem ∑k³ = (∑k)² is the motivating p = 3 special case of the power-sum pattern."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "S",
+      "type": "definition",
+      "description": "The power sum S p n = 0^p + 1^p + ⋯ + (n−1)^p, taken over ℚ. Uses Mathlib's half-open Finset.range n; for p ≥ 1 the k=0 term vanishes so S p n = ∑_{k=1}^{n-1} k^p.",
+      "leanType": "(p n : ℕ) → ℚ"
+    },
+    {
+      "name": "diff_pow_expand",
+      "type": "core",
+      "description": "Binomial expansion of the forward difference: (k+1)^{p+1} − k^{p+1} = ∑_{j=0}^{p} C(p+1,j)·k^j. Proved from `add_pow`; the top binomial term (coefficient C(p+1,p+1)=1) is k^{p+1} and cancels the subtracted k^{p+1}. This is the engine of the recurrence.",
+      "leanType": "(p k : ℕ) → ((k:ℚ)+1)^(p+1) − (k:ℚ)^(p+1) = ∑ j ∈ range (p+1), (Nat.choose (p+1) j : ℚ) * (k:ℚ)^j"
+    },
+    {
+      "name": "power_sum_recurrence",
+      "type": "core",
+      "description": "**The uniform recurrence (★)**: ∑_{j=0}^{p} C(p+1,j)·S_j(n) = n^{p+1}, for every exponent p and bound n simultaneously. Proved by rewriting as a double sum, interchanging summation (Finset.sum_comm), collapsing the inner sum via diff_pow_expand, and telescoping with Finset.sum_range_sub. Bernoulli-free.",
+      "leanType": "(p n : ℕ) → ∑ j ∈ range (p+1), (Nat.choose (p+1) j : ℚ) * S j n = (n:ℚ)^(p+1)"
+    },
+    {
+      "name": "power_sum_solved",
+      "type": "core",
+      "description": "**Descent form**: (p+1)·S_p(n) = n^{p+1} − ∑_{j<p} C(p+1,j)·S_j(n). Isolates the top term of (★), whose coefficient is C(p+1,p) = p+1 (Nat.choose_succ_self_right), expressing S_p in terms of the strictly lower power sums — the recurrence that generates all Faulhaber closed forms.",
+      "leanType": "(p n : ℕ) → ((p:ℚ)+1) * S p n = (n:ℚ)^(p+1) − ∑ j ∈ range p, (Nat.choose (p+1) j : ℚ) * S j n"
+    },
+    {
+      "name": "S_zero",
+      "type": "supporting",
+      "description": "Base case S_0(n) = n: there are n terms each equal to 1. Marked @[simp]; used to seed the descent.",
+      "leanType": "(n : ℕ) → S 0 n = (n:ℚ)"
+    },
+    {
+      "name": "S_one",
+      "type": "core",
+      "description": "p = 1 output of the descent: S_1(n) = (n² − n)/2 = n(n−1)/2, the triangular number. Derived from power_sum_solved and S_zero by linear arithmetic — no separate induction.",
+      "leanType": "(n : ℕ) → S 1 n = ((n:ℚ)^2 − n)/2"
+    },
+    {
+      "name": "S_two",
+      "type": "core",
+      "description": "p = 2 output of the descent: S_2(n) = (2n³ − 3n² + n)/6 = n(n−1)(2n−1)/6. Derived from power_sum_solved together with S_zero and S_one, illustrating that each closed form follows mechanically from the previous via (★).",
+      "leanType": "(n : ℕ) → S 2 n = (2*(n:ℚ)^3 − 3*(n:ℚ)^2 + n)/6"
+    },
+    {
+      "name": "S_two_leading",
+      "type": "supporting",
+      "description": "Leading-term consistency check: 3·S_2(n) − n³ = (−3n² + n)/2, exhibiting the cubic S_2 with leading coefficient 1/3 = 1/(p+1) at p = 2, matching the general Faulhaber leading coefficient read off the top of (★).",
+      "leanType": "(n : ℕ) → 3 * S 2 n − (n:ℚ)^3 = (−3*(n:ℚ)^2 + n)/2"
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Blaise Pascal"],
+      "title": "Traité du triangle arithmétique (Potestatum Numericarum Summa)",
+      "year": "1654",
+      "venue": "Published 1665, Paris",
+      "note": "Pascal's derivation of ∑k^p from the lower power sums by telescoping (k+1)^{p+1} − k^{p+1} and expanding via the arithmetical triangle — exactly the recurrence formalized here, predating Bernoulli numbers."
+    },
+    {
+      "authors": ["Johann Faulhaber"],
+      "title": "Academia Algebrae",
+      "year": "1631",
+      "venue": "Augsburg",
+      "note": "Faulhaber's closed-form polynomials for ∑_{k=1}^n k^p of degree p+1. The corollaries S_1, S_2 of this file are the first outputs of the recurrence that produces Faulhaber's polynomials."
+    },
+    {
+      "authors": ["Jacob Bernoulli"],
+      "title": "Ars Conjectandi",
+      "year": "1713",
+      "venue": "Part II, Ch. III. Basel, Thurnisius (posthumous)",
+      "note": "Bernoulli's rigorization of Faulhaber via Bernoulli numbers — the route taken by the sibling entry arithmetic-series-oq-04. This file gives the complementary Bernoulli-free recurrence."
+    },
+    {
+      "authors": ["Nicomachus of Gerasa"],
+      "title": "Introduction to Arithmetic",
+      "year": "ca. 100 CE",
+      "venue": "Book II, Ch. 20. Trans. M. L. D'Ooge (1926)",
+      "note": "The p=3 special case ∑k³ = (∑k)² that motivates the parent open question on generalizing to arbitrary power sums."
+    },
+    {
+      "authors": ["The Mathlib Community"],
+      "title": "Mathlib4: A Unified Library of Mathematics Formalized in Lean 4",
+      "year": "2024",
+      "venue": "https://github.com/leanprover-community/mathlib4",
+      "note": "Provides `add_pow` (binomial theorem), `Finset.sum_range_sub` (telescoping), `Finset.sum_comm`, `Finset.mul_sum`, `Nat.choose_self`, `Nat.choose_succ_self_right`, and tactics push_cast, linarith, ring."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean",
+    "namespace": "ArithmeticSeriesOQ00OQ02OQ02",
+    "imports": [
+      "Mathlib"
+    ],
+    "axiomCount": 0,
+    "lineCount": 134,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent **arithmetic-series-oq-00-oq-02** (Nicomachus generalization study):

> *Can the Nicomachus identity be generalized to power sums ∑ₖ kʳ = f(n,r) for some pattern?*

The gallery already records the **per-exponent** Faulhaber closed forms via Bernoulli numbers (`arithmetic-series-oq-04`: p=1,2,3; `oq-04-oq-01`: p=4,5,6 + triangular structure). This entry gives the complementary **uniform** answer: a single Bernoulli-free recurrence valid for *all* exponents simultaneously.

**The recurrence (★):**  ∑_{j=0}^{p} C(p+1, j) · Sⱼ(n) = n^(p+1),  where Sₚ(n) = ∑_{k=0}^{n-1} kᵖ.

**Descent form:**  (p+1)·Sₚ(n) = n^(p+1) − ∑_{j<p} C(p+1, j) · Sⱼ(n) — determines each power sum from the lower ones.

## Theorems (8 thm, 1 def, 134 lines)

- `diff_pow_expand` — (k+1)^(p+1) − k^(p+1) = ∑_{j≤p} C(p+1,j)·kʲ (binomial theorem; top term cancels)
- `power_sum_recurrence` — the uniform recurrence (★) (telescoping `sum_range_sub` + Fubini `sum_comm`)
- `power_sum_solved` — descent form (coefficient C(p+1,p) = p+1)
- `S_zero` / `S_one` / `S_two` — n, n(n−1)/2, n(n−1)(2n−1)/6 generated *from the descent*, no separate induction
- `S_two_leading` — leading-coefficient 1/3 consistency check

## Method

Telescoping ∑_{k<n}((k+1)^(p+1) − k^(p+1)) = n^(p+1) combined with the binomial expansion of the forward difference, then an interchange of summation. No Bernoulli numbers, no `sum_range_pow` — the Pascal (1654) route, predating Bernoulli's rigorization.

## Verification

- **0 sorries, 0 axioms** (`axiomCount: 0`)
- `#print axioms` on the main theorems lists only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`
- Built clean against Mathlib 4.26.0 via `lake env lean`
- Status: `verified`, badge `original`

## Originality

Distinct from the oq-04 subtree: those prove individual closed forms via Bernoulli numbers; this proves the single recurrence that *generates* them, by elementary telescoping. The corollaries deliberately re-derive S₁, S₂ from the recurrence (not by induction) to demonstrate the generative pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)