### PR TITLE
Enrich Taylor series of sin/cos converge on ℝ

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 6, "endLine": 42 },
+    "type": "context",
+    "title": "Why sin and cos Beat exp: A Global Derivative Bound",
+    "content": "The parent entry distilled the Lagrange remainder into a convergence engine, taylorPolynomial_tendsto: if one constant M bounds every iterated derivative of f on (a,b), the Taylor polynomials Tₙ(b) converge to f(b). But the parent only reached exp for x > 0, because exp's derivative bound exp x is interval-dependent and the engine requires the evaluation point to lie to the right of the center. What makes sin and cos qualitatively different is that all their iterated derivatives are globally bounded by the single point-independent constant M = 1. This file supplies that global bound (Part I), upgrades the engine to a two-sided criterion that reaches negative arguments by reflection (Part II), and concludes that the Taylor series of sin and cos converge on all of ℝ (Part III). No limit is computed by hand — everything funnels through the parent's remainder estimate.",
+    "mathContext": "$|\\,f^{(n)}(x)| \\le M \\text{ on } \\mathbb{R} \\ \\Longrightarrow\\ T_n(b) \\to f(b)\\ \\ \\forall b\\in\\mathbb{R}$, with $M = 1$ for $\\sin,\\cos$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Taylor's theorem",
+      "Lagrange remainder",
+      "uniform derivative bound",
+      "series convergence"
+    ],
+    "prerequisites": [
+      "the parent convergence engine taylorPolynomial_tendsto",
+      "iterated derivatives"
+    ]
+  },
+  {
+    "id": "ann-sin-bound",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 71 },
+    "type": "technique",
+    "title": "The Global Bound M = 1 for sin",
+    "content": "abs_iteratedDeriv_sin_le_one: |sin⁽ⁿ⁾(x)| ≤ 1 for every n and every x. Differentiating sin cycles through the four-periodic pattern sin, cos, -sin, -cos, so every iterated derivative is a unit scalar (±1) times sin or cos. The proof splits n into even (2m) or odd (2m+1) via Nat.even_or_odd', rewrites with Mathlib's closed forms iteratedDeriv (2m) sin = (-1)ᵐ·sin and iteratedDeriv (2m+1) sin = (-1)ᵐ·cos, then |(-1)ᵐ · sin x| = |sin x| ≤ 1 (and likewise for cos). The point-independence of this bound — the same 1 works at every x — is precisely what exp lacks.",
+    "mathContext": "$\\sin^{(2m)} = (-1)^m\\sin,\\quad \\sin^{(2m+1)} = (-1)^m\\cos \\ \\Rightarrow\\ |\\sin^{(n)}(x)| \\le 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "iterated derivatives of trigonometric functions",
+      "parity case split",
+      "absolute value bounds",
+      "Nat.even_or_odd'"
+    ],
+    "prerequisites": [
+      "iteratedDeriv_even_sin / iteratedDeriv_odd_sin",
+      "|sin| ≤ 1, |cos| ≤ 1"
+    ]
+  },
+  {
+    "id": "ann-cos-bound",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 89 },
+    "type": "technique",
+    "title": "The Global Bound M = 1 for cos",
+    "content": "abs_iteratedDeriv_cos_le_one: |cos⁽ⁿ⁾(x)| ≤ 1 for every n and x, by the same even/odd argument as for sin. The closed forms here are iteratedDeriv (2m) cos = (-1)ᵐ·cos and iteratedDeriv (2m+1) cos = (-1)ᵐ⁺¹·sin; the extra sign in the odd case is harmless once the absolute value strips it. This and the sin bound are the two inputs the two-sided engine consumes with M = 1.",
+    "mathContext": "$\\cos^{(2m)} = (-1)^m\\cos,\\quad \\cos^{(2m+1)} = (-1)^{m+1}\\sin \\ \\Rightarrow\\ |\\cos^{(n)}(x)| \\le 1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "iterated derivatives of trigonometric functions",
+      "parity case split",
+      "absolute value bounds"
+    ],
+    "prerequisites": [
+      "iteratedDeriv_even_cos / iteratedDeriv_odd_cos",
+      "|sin| ≤ 1, |cos| ≤ 1"
+    ]
+  },
+  {
+    "id": "ann-reflect",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 114 },
+    "type": "insight",
+    "title": "Reflection Identity: Two Sign Factors Cancel",
+    "content": "reflect_taylor_eq: the n-th Taylor polynomial of t ↦ f(-t) at -b equals the n-th Taylor polynomial of f at b. This is the trick that turns the parent's one-sided engine into a two-sided one. Termwise, the k-th coefficient of the reflected polynomial involves iteratedDeriv k (fun x => f(-x)) 0 = (-1)ᵏ · iteratedDeriv k f 0 (the chain-rule sign, iteratedDeriv_comp_neg) multiplied by (-b)ᵏ. The two sign factors combine as (-1)ᵏ·(-b)ᵏ = bᵏ, so the reflected term at -b reproduces the original term at b. The proof closes each term with a linear_combination identity. No analysis here — it is pure algebra of the polynomial coefficients.",
+    "mathContext": "$T_n\\big(t\\mapsto f(-t),\\,0\\big)(-b) = T_n(f,0)(b)$ because $(-1)^k(-b)^k = b^k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Taylor polynomial",
+      "function reflection",
+      "chain rule sign",
+      "iteratedDeriv_comp_neg"
+    ],
+    "prerequisites": [
+      "Taylor polynomial coefficients",
+      "iterated derivative under x ↦ -x"
+    ]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 116, "endLine": 155 },
+    "type": "insight",
+    "title": "The Two-Sided Convergence Engine",
+    "content": "taylorPolynomial_tendsto_globalBound: if f is C^∞ and one constant M bounds every iterated derivative at every real point, then Tₙ(b) → f(b) for EVERY real b — no order constraint between center 0 and evaluation point. The proof is a trichotomy on b. For b > 0 the parent's one-sided engine applies verbatim (restricting the global bound to (0,b)). For b = 0 the Taylor polynomial collapses to its constant term f 0 (every positive power of (b−0) vanishes), so the sequence is constant and convergence is trivial. For b < 0 the reflection g(t) = f(-t) inherits the same global bound (the chain-rule sign has absolute value 1), the parent applies to g at -b > 0 giving Tₙ(g,0,-b) → g(-b) = f(b), and reflect_taylor_eq identifies that with Tₙ(f,0,b). The negative half-line is thus packaged without re-running any analytic estimate.",
+    "mathContext": "$|f^{(n)}(x)| \\le M\\ \\forall n,x \\ \\Longrightarrow\\ T_n(b)\\to f(b)\\ \\forall b\\in\\mathbb{R}$ (trichotomy: parent / constant / reflection).",
+    "significance": "key",
+    "relatedConcepts": [
+      "trichotomy on the real line",
+      "reflection through the origin",
+      "Filter.Tendsto",
+      "reusable convergence criterion"
+    ],
+    "prerequisites": [
+      "the parent engine taylorPolynomial_tendsto",
+      "the reflection identity reflect_taylor_eq",
+      "ContDiff smoothness"
+    ]
+  },
+  {
+    "id": "ann-payoff",
+    "proofId": "mean-value-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 163, "endLine": 178 },
+    "type": "concept",
+    "title": "Payoff: sin and cos Equal Their Taylor Series on ℝ",
+    "content": "sin_taylor_tendsto and cos_taylor_tendsto: for every real x, the Taylor polynomials of sin and cos centered at 0 converge to sin x and cos x. Each is a one-line instantiation of the two-sided engine with M = 1, the smoothness facts contDiff_sin / contDiff_cos, and the global bounds from Part I. This is the direct answer to the parent's open question and is qualitatively stronger than the parent's exp result, which only reached x > 0. It is the standard certification that sin and cos are entire functions equal to their power series — here obtained from differential data (a uniform derivative bound) rather than from the power-series definition.",
+    "mathContext": "$\\displaystyle\\forall x\\in\\mathbb{R}:\\ T_n(x)\\to\\sin x \\ \\text{ and }\\ T_n(x)\\to\\cos x.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "entire functions",
+      "power series of sin and cos",
+      "Taylor series convergence",
+      "contDiff_sin / contDiff_cos"
+    ],
+    "prerequisites": [
+      "the two-sided engine taylorPolynomial_tendsto_globalBound",
+      "the global bounds abs_iteratedDeriv_sin/cos_le_one"
+    ]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-02/index.ts
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MeanValueTheoremOQ02OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const meanValueTheoremOq02Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const meanValueTheoremOq02Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const meanValueTheoremOq02Oq01Oq02Data: ProofData = {
+  proof: meanValueTheoremOq02Oq01Oq02Proof,
+  annotations: meanValueTheoremOq02Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `mean-value-theorem-oq-02-oq-01-oq-02` (quality 41, pass 0).

## Why this entry needed work
The directory had a rich `meta.json` (overview, sections, conclusion, mainTheorems, references) but **no `index.ts`** — so the page rendered *"proof not found"* on the live site — and **no `annotations.json`**.

## Changes
- **`index.ts`** — created from the standard template (`meanValueTheoremOq02Oq01Oq02*` exports, source from `Proofs/MeanValueTheoremOQ02OQ01OQ02.lean`). Fixes the missing page.
- **`annotations.json`** — 6 new annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the docstring and all six theorems: the global derivative bounds `M = 1` for sin and cos (the key contrast with exp), the reflection identity `reflect_taylor_eq`, the two-sided convergence engine `taylorPolynomial_tendsto_globalBound`, and the `sin_taylor_tendsto` / `cos_taylor_tendsto` payoff.
- `meta.json` left intact — it was already high quality.

## Verification
- `pnpm build` passes (tsc + vite).
- JSON validated with `jq`.
- Axiom integrity confirmed: badge `original`, status `verified`, `axiomCount: 0` — the Lean file has 0 `axiom` declarations, 0 sorries, no `native_decide`, and no assumption-carrying structures. The reused parent engine `taylorPolynomial_tendsto` is itself 0-axiom. Consistent with the meta `assumptions` field.