### PR TITLE
audit: clear 4 unaudited research leaves — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21825,6 +21825,30 @@
       "lastAudited": "2026-06-24T16:25:02Z",
       "result": "clean",
       "issues": []
+    },
+    "bernoulli-inequality-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:48:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:48:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-07-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:48:32Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-08-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T16:48:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 4 genuinely-unaudited research leaves on main. All **clean** — meta claims match the Lean source.

| Slug | status/badge | sorries | axioms | native_decide | True stubs |
|------|--------------|---------|--------|---------------|------------|
| bernoulli-inequality-oq-01-oq-02-oq-01 | verified/original | 0 | 0 | 0 | 0 |
| combinations-formula-oq-01-oq-01-oq-01-oq-02 | verified/original | 0 | 0 | 0 | 0 |
| combinations-formula-oq-07-oq-04-oq-02 | verified/mathlib | 0 | 0 | 0 | 0 |
| pythagorean-triples-oq-08-oq-01 | verified/original | 0 | 0 | 0 | 0 |

### Notes
- All four are substantive original derivations (degree-k binomial truncation; Lucas Cassini / fib-Catalan; per-leg divisibility by 3 and 4) except `combinations-formula-oq-07-oq-04-oq-02`, whose `mathlib` badge is the honest conservative tier for its Vandermonde/variance result.
- No `native_decide` (so no `Lean.ofReduceBool`), no `axiom` declarations, no structure-encoded assumptions, no `True` stubs.
- `bernoulli-inequality-oq-01-oq-02-oq-01` was untracked local pollution in earlier cycles; it has since merged to main (PR #29198) and is now a real tracked target.

Only `src/data/proofs/audit-tracker.json` changes (4 new clean entries).

---
Discovered during autonomous gallery integrity audit.