### PR TITLE
research(basel-problem-oq-14-oq-01): uniform Dirichlet eta η(2m)=(1−2^(1−2m))ζ(2m) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -305,6 +305,7 @@ import Proofs.BaselProblemOQ12
 import Proofs.BaselProblemOQ13
 import Proofs.BaselProblemOQ13OQ01
 import Proofs.BaselProblemOQ14
+import Proofs.BaselProblemOQ14OQ01
 import Proofs.BaselProblemOQ15
 import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01

--- a/proofs/Proofs/BaselProblemOQ14OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ14OQ01.lean
@@ -1,0 +1,166 @@
+/-
+  # Uniform Dirichlet eta values: η(2m) = (1 − 2^{1−2m}) ζ(2m)
+  # (basel-problem-oq-14-oq-01)
+
+  ## The Open Question
+
+  The parent entry `basel-problem-oq-14` proved the single Dirichlet eta value
+  η(4) = ∑ (-1)^{n+1}/n⁴ = 7π⁴/720 by an even/odd split of the series. Its open
+  question asks to **abstract that parity split into one reusable lemma**
+
+      η(2m) = (1 − 2^{1−2m}) ζ(2m),      ζ(2m) = ∑_{n≥1} 1/n^{2m},
+
+  parameterized over the exponent 2m, so that η(2), η(4), η(6), … all follow
+  uniformly from Mathlib's `hasSum_zeta_nat`.
+
+  ## The abstraction
+
+  The relation is a pure series identity, valid for *any* convergent zeta series
+  (no closed form for ζ needed). Writing the alternating series via
+  `HasSum.even_add_odd`:
+
+    * even part:  ∑_k (-1)^{2k+1}/(2k)^{2m} = −∑_k 1/(2k)^{2m} = −2^{−2m} ζ(2m),
+    * odd part:   ∑_k (-1)^{2k+2}/(2k+1)^{2m} = ∑_k 1/(2k+1)^{2m}
+                  = ζ(2m) − 2^{−2m} ζ(2m)   (the odd half of ζ),
+
+  whose sum is ζ(2m) − 2·2^{−2m} ζ(2m) = (1 − 2^{1−2m}) ζ(2m).
+
+  The master lemma `hasSum_eta_of_zeta` takes an arbitrary `HasSum` witness `Z`
+  for the zeta series at exponent `2m` and returns the eta `HasSum`. Feeding it
+  `hasSum_zeta_nat` gives the uniform closed form `hasSum_eta_nat`; specialising
+  to `m = 1, 2` recovers η(2) = π²/12 (new) and η(4) = 7π⁴/720 (the parent).
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real
+
+namespace BaselEtaZeta
+
+/-- The summand of the Dirichlet eta value η(2m): `(-1)^(n+1) / n^(2m)`.
+    (At `n = 0` this is `±1/0 = 0` in ℝ, so the series starts effectively at n = 1.) -/
+noncomputable def etaSummand (m n : ℕ) : ℝ := (-1) ^ (n + 1) / (n : ℝ) ^ (2 * m)
+
+/-- The even-indexed half of the zeta series collapses by the scaling
+    `1/(2k)^(2m) = (1/2)^(2m) · 1/k^(2m)`:
+    `∑_k 1/(2k)^(2m) = (1/2)^(2m) · ζ(2m)`. -/
+theorem hasSum_even_zeta (m : ℕ) (Z : ℝ)
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * m)) Z) :
+    HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ (2 * m)) ((1 / 2 : ℝ) ^ (2 * m) * Z) := by
+  have h := hZ.mul_left ((1 / 2 : ℝ) ^ (2 * m))
+  have hfe : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ (2 * m))
+      = (fun k : ℕ => (1 / 2 : ℝ) ^ (2 * m) * (1 / (k : ℝ) ^ (2 * m))) := by
+    funext k
+    rw [show ((2 * k : ℕ) : ℝ) = 2 * (k : ℝ) by push_cast; ring, mul_pow, div_pow, one_pow,
+      div_mul_div_comm, one_mul]
+  rw [hfe]; exact h
+
+/-- **Master parity-split lemma.** For any `HasSum` witness `Z` of the zeta series
+    `∑ 1/n^(2m)`, the alternating (Dirichlet eta) series satisfies
+    `η(2m) = (1 − 2·(1/2)^(2m)) · Z = (1 − 2^{1−2m}) ζ(2m)`.
+    The identity needs no closed form for `Z`. -/
+theorem hasSum_eta_of_zeta (m : ℕ) (Z : ℝ)
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * m)) Z) :
+    HasSum (etaSummand m) ((1 - 2 * (1 / 2 : ℝ) ^ (2 * m)) * Z) := by
+  -- Even half of ζ.
+  have heven : HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ (2 * m)) ((1 / 2 : ℝ) ^ (2 * m) * Z) :=
+    hasSum_even_zeta m Z hZ
+  -- The odd half is summable (restriction of ζ along an injection).
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ (2 * m)) :=
+    hZ.summable.comp_injective (fun a b h => by omega)
+  -- ζ = even + odd, so the odd half equals ζ − (even half).
+  have hsplit : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ (2 * m))
+      ((1 / 2 : ℝ) ^ (2 * m) * Z + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ (2 * m)) :=
+    HasSum.even_add_odd heven hodd_summable.hasSum
+  have hodd_val : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ (2 * m) = Z - (1 / 2 : ℝ) ^ (2 * m) * Z := by
+    have := hsplit.unique hZ; linarith
+  have hodd : HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ (2 * m))
+      (Z - (1 / 2 : ℝ) ^ (2 * m) * Z) := by
+    rw [← hodd_val]; exact hodd_summable.hasSum
+  -- Eta even half: (-1)^(2k+1)/(2k)^(2m) = -1/(2k)^(2m).
+  have ha_even : HasSum (fun k : ℕ => etaSummand m (2 * k)) (-((1 / 2 : ℝ) ^ (2 * m) * Z)) := by
+    have hfe : (fun k : ℕ => etaSummand m (2 * k))
+        = (fun k : ℕ => -(1 / ((2 * k : ℕ) : ℝ) ^ (2 * m))) := by
+      funext k
+      simp only [etaSummand]
+      rw [Odd.neg_one_pow (⟨k, by ring⟩ : Odd (2 * k + 1))]
+      ring
+    rw [hfe]; exact heven.neg
+  -- Eta odd half: (-1)^(2k+2)/(2k+1)^(2m) = 1/(2k+1)^(2m).
+  have ha_odd : HasSum (fun k : ℕ => etaSummand m (2 * k + 1)) (Z - (1 / 2 : ℝ) ^ (2 * m) * Z) := by
+    have hfo : (fun k : ℕ => etaSummand m (2 * k + 1))
+        = (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ (2 * m)) := by
+      funext k
+      simp only [etaSummand]
+      rw [Even.neg_one_pow (⟨k + 1, by ring⟩ : Even (2 * k + 1 + 1))]
+    rw [hfo]; exact hodd
+  have ha : HasSum (etaSummand m)
+      (-((1 / 2 : ℝ) ^ (2 * m) * Z) + (Z - (1 / 2 : ℝ) ^ (2 * m) * Z)) :=
+    HasSum.even_add_odd ha_even ha_odd
+  have hval : -((1 / 2 : ℝ) ^ (2 * m) * Z) + (Z - (1 / 2 : ℝ) ^ (2 * m) * Z)
+      = (1 - 2 * (1 / 2 : ℝ) ^ (2 * m)) * Z := by ring
+  rwa [hval] at ha
+
+/-- The eta coefficient in its recognizable form: `1 − 2·(1/2)^(2m) = 1 − 2^{1−2m}`
+    (real zpow with the negative integer exponent `1 − 2m`). -/
+theorem eta_coeff_eq (m : ℕ) :
+    (1 - 2 * (1 / 2 : ℝ) ^ (2 * m)) = 1 - (2 : ℝ) ^ ((1 : ℤ) - 2 * (m : ℤ)) := by
+  have h2 : (2 : ℝ) ≠ 0 := two_ne_zero
+  congr 1
+  rw [show (1 : ℤ) - 2 * (m : ℤ) = 1 - ((2 * m : ℕ) : ℤ) by push_cast; ring, zpow_sub₀ h2,
+    zpow_one, zpow_natCast, one_div, inv_pow, div_eq_mul_inv]
+
+/-- **Uniform Dirichlet eta value.** Composing the parity-split lemma with Mathlib's
+    `hasSum_zeta_nat` gives, for every `m ≥ 1`,
+    `η(2m) = (1 − 2^{1−2m}) ζ(2m)` with `ζ(2m) = ∑ 1/n^(2m)`. -/
+theorem hasSum_eta_nat (m : ℕ) (hm : m ≠ 0) :
+    HasSum (etaSummand m)
+      ((1 - 2 * (1 / 2 : ℝ) ^ (2 * m)) * ∑' n : ℕ, 1 / (n : ℝ) ^ (2 * m)) :=
+  hasSum_eta_of_zeta m _ (hasSum_zeta_nat hm).summable.hasSum
+
+/-- **η(2) = π²/12**, the alternating sum of inverse squares, re-derived uniformly
+    from the master lemma (cf. `basel-problem-oq-11`). -/
+theorem hasSum_eta_two : HasSum (etaSummand 1) (π ^ 2 / 12) := by
+  have h := hasSum_eta_of_zeta 1 _ hasSum_zeta_two
+  have hc : (1 - 2 * (1 / 2 : ℝ) ^ (2 * 1)) * (π ^ 2 / 6) = π ^ 2 / 12 := by norm_num; ring
+  rwa [hc] at h
+
+/-- **η(4) = 7π⁴/720** — recovers the parent entry `basel-problem-oq-14`. -/
+theorem hasSum_eta_four : HasSum (etaSummand 2) (7 * π ^ 4 / 720) := by
+  have h := hasSum_eta_of_zeta 2 _ hasSum_zeta_four
+  have hc : (1 - 2 * (1 / 2 : ℝ) ^ (2 * 2)) * (π ^ 4 / 90) = 7 * π ^ 4 / 720 := by norm_num; ring
+  rwa [hc] at h
+
+/-- η(2) in `tsum` form: `∑' n, (-1)^(n+1)/n² = π²/12`. -/
+theorem tsum_eta_two : ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 2 = π ^ 2 / 12 :=
+  hasSum_eta_two.tsum_eq
+
+/-- η(4) in `tsum` form: `∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720`. -/
+theorem tsum_eta_four : ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4 = 7 * π ^ 4 / 720 :=
+  hasSum_eta_four.tsum_eq
+
+end BaselEtaZeta
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `hasSum_even_zeta`   | ∑_k 1/(2k)^(2m) = (1/2)^(2m) · ζ(2m) |
+  | `hasSum_eta_of_zeta` | master: η(2m) = (1 − 2·(1/2)^(2m)) · Z for any zeta witness Z |
+  | `eta_coeff_eq`       | 1 − 2·(1/2)^(2m) = 1 − 2^{1−2m} |
+  | `hasSum_eta_nat`     | uniform: η(2m) = (1 − 2^{1−2m}) ζ(2m) via `hasSum_zeta_nat` |
+  | `hasSum_eta_two`     | η(2) = π²/12 (uniform re-derivation; cf. oq-11) |
+  | `hasSum_eta_four`    | η(4) = 7π⁴/720 (recovers parent oq-14) |
+  | `tsum_eta_two/four`  | tsum forms |
+
+  Built entirely from Mathlib's `hasSum_zeta_nat` family and the even/odd series
+  split `HasSum.even_add_odd`. The parity split is captured once, abstractly, in
+  `hasSum_eta_of_zeta`; everything else is specialisation.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-14-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-14-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "eta-summand",
+    "proofId": "basel-problem-oq-14-oq-01",
+    "range": { "startLine": 45, "endLine": 45 },
+    "type": "definition",
+    "title": "The exponent-indexed eta summand etaSummand m n = (-1)^(n+1)/n^(2m)",
+    "content": "Unlike the parent entry, whose summand is fixed at exponent 4, etaSummand carries the exponent parameter m. Defining it as a top-level named function (rather than an inline lambda) is what later lets HasSum.even_add_odd infer f := etaSummand m from the pattern f (2*k); an anonymous lambda would block that higher-order unification. At n = 0 the value is ±1/0 = 0 in ℝ, so the series effectively starts at n = 1.",
+    "mathContext": "$\\displaystyle\\eta(2m) = \\sum_{n\\ge 1}\\frac{(-1)^{n+1}}{n^{2m}}.$",
+    "significance": "standard",
+    "relatedConcepts": ["Dirichlet eta function", "alternating series", "parameterization over exponent"],
+    "prerequisites": ["infinite series", "real powers"]
+  },
+  {
+    "id": "even-half",
+    "proofId": "basel-problem-oq-14-oq-01",
+    "range": { "startLine": 50, "endLine": 63 },
+    "type": "theorem",
+    "title": "hasSum_even_zeta — the even half is a scaled copy of ζ",
+    "content": "For any HasSum witness Z of ∑ 1/n^(2m), the even-indexed subseries satisfies ∑_k 1/(2k)^(2m) = (1/2)^(2m)·Z. The scaling 1/(2k)^(2m) = (1/2)^(2m)·(1/k^(2m)) is established at symbolic exponent 2m with mul_pow, div_pow, one_pow and div_mul_div_comm (the parent could use plain `ring` only because its exponent 4 was a literal). The result is HasSum.mul_left applied to Z. The rewrite is valid even at k = 0, where both sides are 0 in ℝ.",
+    "mathContext": "$\\displaystyle\\sum_{k\\ge 1}\\frac{1}{(2k)^{2m}} = \\left(\\tfrac12\\right)^{2m}\\zeta(2m) = 2^{-2m}\\zeta(2m).$",
+    "significance": "key",
+    "relatedConcepts": ["HasSum.mul_left", "even-indexed subseries", "symbolic exponent algebra"],
+    "prerequisites": ["infinite series", "scaling of sums", "power arithmetic"]
+  },
+  {
+    "id": "master-lemma",
+    "proofId": "basel-problem-oq-14-oq-01",
+    "range": { "startLine": 65, "endLine": 107 },
+    "type": "theorem",
+    "title": "hasSum_eta_of_zeta — the parity-split master lemma",
+    "content": "The core contribution. From any zeta witness Z at exponent 2m: the odd half ∑_k 1/(2k+1)^(2m) is summable (Summable.comp_injective along k ↦ 2k+1), and reassembling Z = even + odd via HasSum.even_add_odd then applying HasSum.unique pins the odd half to Z − (1/2)^(2m)·Z. For the alternating series, the even-indexed terms carry (-1)^(2k+1) = -1 (Odd.neg_one_pow) and sum to −(1/2)^(2m)·Z; the odd-indexed terms carry (-1)^(2k+2) = 1 (Even.neg_one_pow) and sum to the odd half. HasSum.even_add_odd combines them and `ring` gives the coefficient: −(1/2)^(2m)Z + (Z − (1/2)^(2m)Z) = (1 − 2·(1/2)^(2m))·Z. Crucially, no closed form for ζ is ever used — the identity is purely about parity of indices.",
+    "mathContext": "$\\displaystyle\\eta(2m) = \\bigl(1 - 2\\cdot 2^{-2m}\\bigr)\\zeta(2m) = \\bigl(1 - 2^{1-2m}\\bigr)\\zeta(2m).$",
+    "significance": "critical",
+    "relatedConcepts": ["HasSum.even_add_odd", "HasSum.unique", "Summable.comp_injective", "Odd.neg_one_pow / Even.neg_one_pow", "parity split"],
+    "prerequisites": ["infinite series", "even/odd decomposition", "uniqueness of sums", "parity of exponents"]
+  },
+  {
+    "id": "coefficient-identity",
+    "proofId": "basel-problem-oq-14-oq-01",
+    "range": { "startLine": 109, "endLine": 117 },
+    "type": "theorem",
+    "title": "eta_coeff_eq — 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m)",
+    "content": "Certifies that the coefficient produced by the proof equals the textbook eta-zeta factor. The real integer power 2^(1−2m) is reduced via zpow_sub₀ (2 ≠ 0), zpow_one and zpow_natCast to 2/2^(2m), which div_eq_mul_inv matches against 2·(2^(2m))⁻¹ = 2·(1/2)^(2m). This makes the recognizable form 1 − 2^(1−2m) itself machine-checked rather than merely asserted in prose.",
+    "mathContext": "$\\displaystyle 1 - 2\\left(\\tfrac12\\right)^{2m} = 1 - 2^{\\,1-2m}.$",
+    "significance": "standard",
+    "relatedConcepts": ["zpow_sub₀", "zpow_natCast", "real integer powers"],
+    "prerequisites": ["real zpow", "power arithmetic"]
+  },
+  {
+    "id": "uniform-and-values",
+    "proofId": "basel-problem-oq-14-oq-01",
+    "range": { "startLine": 119, "endLine": 144 },
+    "type": "theorem",
+    "title": "hasSum_eta_nat and the concrete values η(2) = π²/12, η(4) = 7π⁴/720",
+    "content": "Because the master lemma only needs a HasSum witness, composing it with Mathlib's general hasSum_zeta_nat (k ≠ 0) yields hasSum_eta_nat: η(2m) = (1 − 2·(1/2)^(2m))·ζ(2m) for every m ≥ 1, the uniform family the open question requested. Specializing through hasSum_zeta_two and hasSum_zeta_four — with a one-line norm_num/ring coefficient computation (1 − 1/2 = 1/2 and 1 − 1/8 = 7/8) — recovers η(2) = π²/12 (cf. oq-11) and η(4) = 7π⁴/720 (the parent value). tsum_eta_two and tsum_eta_four restate these in ∑'-form.",
+    "mathContext": "$\\displaystyle\\eta(2) = \\frac{\\pi^2}{12},\\qquad \\eta(4) = \\frac{7\\pi^4}{720}.$",
+    "significance": "key",
+    "relatedConcepts": ["hasSum_zeta_nat", "hasSum_zeta_two", "hasSum_zeta_four", "uniform specialization", "tsum"],
+    "prerequisites": ["Euler's even zeta values", "infinite series", "specialization of parameterized lemmas"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-14-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-14-oq-01/meta.json
@@ -1,0 +1,201 @@
+{
+  "id": "basel-problem-oq-14-oq-01",
+  "title": "Uniform Dirichlet eta values: η(2m) = (1 − 2^(1−2m)) ζ(2m)",
+  "slug": "basel-problem-oq-14-oq-01",
+  "description": "Abstracts the even/odd parity split used for the single value η(4) (parent basel-problem-oq-14) into one reusable lemma parameterized over the exponent 2m: for any HasSum witness Z of the zeta series ∑ 1/n^(2m), the alternating Dirichlet eta series satisfies η(2m) = (1 − 2·(1/2)^(2m))·Z = (1 − 2^(1−2m))·ζ(2m). The proof needs no closed form for ζ — it is a pure even/odd series identity via HasSum.even_add_odd. Composing the master lemma with Mathlib's hasSum_zeta_nat yields the eta values uniformly for every m ≥ 1; specializing to m = 1, 2 recovers η(2) = π²/12 and η(4) = 7π⁴/720 (the parent value). A separate lemma certifies the coefficient identity 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m) using real zpow. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ14OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "dirichlet-eta",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 166,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "Closed form for the even zeta values ζ(2k) = ∑ 1/n^(2k); the master lemma is composed with this to get the eta values uniformly",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_two / hasSum_zeta_four",
+        "description": "ζ(2) = π²/6 and ζ(4) = π⁴/90, used to recover η(2) = π²/12 and η(4) = 7π⁴/720 as concrete specializations",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Reassembles a series from its even- and odd-indexed subseries; used both to split ζ and to split the alternating eta series",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd-indexed subseries (k ↦ 2k+1) from summability of the full zeta series",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow / Even.neg_one_pow",
+        "description": "(-1)^(2k+1) = -1 and (-1)^(2k+2) = 1, fixing the alternating signs on each subseries",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "zpow_sub₀ / zpow_natCast",
+        "description": "Real integer-power arithmetic certifying 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m)",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_eta_of_zeta: the master parity-split lemma — for any zeta witness Z at exponent 2m, η(2m) = (1 − 2·(1/2)^(2m))·Z, parameterized over m with no closed form for ζ required",
+      "hasSum_even_zeta: ∑_k 1/(2k)^(2m) = (1/2)^(2m)·ζ(2m), the scaled even half, proved at general exponent 2m",
+      "eta_coeff_eq: certifies the recognizable coefficient form 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m) via real zpow",
+      "hasSum_eta_nat: η(2m) = (1 − 2^(1−2m))·ζ(2m) for all m ≥ 1, obtained uniformly by composing the master lemma with Mathlib's hasSum_zeta_nat",
+      "hasSum_eta_two / hasSum_eta_four (+ tsum forms): η(2) = π²/12 and η(4) = 7π⁴/720 recovered as one-line specializations, the latter matching the parent entry basel-problem-oq-14"
+    ],
+    "prerequisites": [
+      "Even zeta values ζ(2m) (Mathlib hasSum_zeta_nat)",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique) and summability under reindexing (Summable.comp_injective)",
+      "Real integer powers (zpow) for the coefficient identity"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BaselEtaZeta",
+    "path": "Proofs/BaselProblemOQ14OQ01.lean",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet eta function η(s) = ∑_{n≥1} (-1)^(n+1)/n^s is the alternating companion of the Riemann zeta function, related by η(s) = (1 − 2^(1−s)) ζ(s). This relation analytically continues ζ across the line Re s = 1 and, at the even integers s = 2m, expresses every alternating sum η(2m) as a fixed rational multiple of Euler's closed value ζ(2m) = (rational)·π^(2m). The parent entry basel-problem-oq-14 formalized the single value η(4) = 7π⁴/720 by hand; this entry abstracts the same parity argument into one exponent-parameterized lemma so that the entire family η(2), η(4), η(6), … follows from Mathlib's hasSum_zeta_nat by specialization.",
+    "problemStatement": "Abstract the even/odd parity split of basel-problem-oq-14 into a single reusable lemma\n\n$$\\eta(2m) = (1 - 2^{1-2m})\\,\\zeta(2m), \\qquad \\zeta(2m) = \\sum_{n=1}^{\\infty}\\frac{1}{n^{2m}},$$\n\nparameterized over the exponent 2m, with 0 sorries and 0 axioms, deriving η(2), η(4), η(6), … uniformly from Mathlib's `hasSum_zeta_nat`.",
+    "text": "One lemma for the whole alternating zeta family: η(2m) = (1 − 2^(1−2m)) ζ(2m), proved by an even/odd series split that needs no closed form for ζ, then instantiated at m = 1, 2 to give η(2) = π²/12 and η(4) = 7π⁴/720.",
+    "proofStrategy": "The master lemma hasSum_eta_of_zeta takes an arbitrary HasSum witness Z of ∑ 1/n^(2m). (1) The even half of ζ is a scaled copy: 1/(2k)^(2m) = (1/2)^(2m)·(1/k^(2m)), so ∑_k 1/(2k)^(2m) = (1/2)^(2m)·Z (hasSum_even_zeta, via HasSum.mul_left). (2) The odd half is summable (Summable.comp_injective with k ↦ 2k+1); reassembling Z = even + odd by HasSum.even_add_odd and applying HasSum.unique forces the odd half to Z − (1/2)^(2m)·Z. (3) For the alternating series, the even-indexed terms carry (-1)^(2k+1) = -1 (Odd.neg_one_pow) and sum to −(1/2)^(2m)·Z; the odd-indexed terms carry (-1)^(2k+2) = 1 (Even.neg_one_pow) and sum to the odd half. HasSum.even_add_odd combines them and ring simplifies −(1/2)^(2m)Z + (Z − (1/2)^(2m)Z) = (1 − 2·(1/2)^(2m))·Z. Composing with hasSum_zeta_nat gives hasSum_eta_nat for all m; hasSum_zeta_two/four give the concrete η(2), η(4). eta_coeff_eq rewrites the coefficient into the textbook form 1 − 2^(1−2m) with real zpow.",
+    "keyInsights": [
+      "**The eta-zeta relation is a parity identity, not a special value.** hasSum_eta_of_zeta proves η(2m) = (1 − 2·(1/2)^(2m))·Z for *any* zeta witness Z — the closed form of ζ never enters. This is what makes the single lemma cover all exponents at once.",
+      "**The factor 1 − 2^(1−2m) is 1 (full ζ) minus 2·2^(−2m) (twice the even half).** The even-indexed alternating terms contribute −(1/2)^(2m)Z and the odd-indexed terms contribute Z − (1/2)^(2m)Z; their sum nets 2·(1/2)^(2m) = 2^(1−2m) subtracted from ζ.",
+      "**Parameterizing over m forces robust exponent algebra.** Unlike the exponent-4 parent (where `ring` clears literal fourth powers), the scaling 1/(2k)^(2m) = (1/2)^(2m)/k^(2m) is handled with mul_pow + div_pow + div_mul_div_comm so it holds for symbolic 2m (and at k = 0, where both sides are 0 in ℝ).",
+      "**Uniform derivation from hasSum_zeta_nat.** Because the master lemma only needs a HasSum witness, feeding it Mathlib's general hasSum_zeta_nat (k ≠ 0) instantly yields η(2m) for every m, while hasSum_zeta_two/four recover the two best-known concrete values with a one-line coefficient computation.",
+      "**The coefficient identity is certified, not assumed.** eta_coeff_eq proves 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m) by reducing the real zpow 2^(1−2m) through zpow_sub₀ and zpow_natCast, so the file's recognizable textbook coefficient is itself machine-checked."
+    ],
+    "prerequisites": [
+      "Riemann zeta and Dirichlet eta functions; the relation η(s) = (1 − 2^(1−s))ζ(s)",
+      "Euler's even zeta values ζ(2m) = (rational)·π^(2m)",
+      "Even/odd decomposition of infinite sums and the HasSum / tsum API",
+      "Real integer powers (zpow)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header, Imports, and the Eta Summand",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Documents the abstraction of the parity split to general exponent 2m; imports Mathlib's ZetaValues (for hasSum_zeta_nat); defines the exponent-indexed summand etaSummand m n = (-1)^(n+1)/n^(2m).",
+      "mathContext": "η(2m) is the value at the even integer 2m of the Dirichlet eta function."
+    },
+    {
+      "id": "even-half",
+      "title": "hasSum_even_zeta — ∑ 1/(2k)^(2m) = (1/2)^(2m)·ζ(2m)",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "Rewrites 1/(2k)^(2m) = (1/2)^(2m)·(1/k^(2m)) with mul_pow/div_pow and scales the zeta witness by (1/2)^(2m).",
+      "mathContext": "The even-indexed terms form a (1/2)^(2m)-scaled copy of the zeta series."
+    },
+    {
+      "id": "master",
+      "title": "hasSum_eta_of_zeta — the parity-split master lemma",
+      "startLine": 64,
+      "endLine": 107,
+      "summary": "From any zeta witness Z: odd half = Z − (1/2)^(2m)Z by uniqueness; alternating even terms sum to −(1/2)^(2m)Z, odd terms to the odd half; HasSum.even_add_odd + ring give η(2m) = (1 − 2·(1/2)^(2m))·Z.",
+      "mathContext": "The constructive content of η(2m) = (1 − 2^(1−2m))ζ(2m), valid for any convergent zeta series."
+    },
+    {
+      "id": "coefficient",
+      "title": "eta_coeff_eq — 1 − 2·(1/2)^(2m) = 1 − 2^(1−2m)",
+      "startLine": 108,
+      "endLine": 118,
+      "summary": "Reduces the real zpow 2^(1−2m) via zpow_sub₀, zpow_one, zpow_natCast to the nat-power form, certifying the textbook coefficient.",
+      "mathContext": "Identifies the proof's coefficient with the classical eta-zeta factor."
+    },
+    {
+      "id": "uniform-and-values",
+      "title": "hasSum_eta_nat and the concrete values η(2), η(4)",
+      "startLine": 119,
+      "endLine": 166,
+      "summary": "Composes the master lemma with hasSum_zeta_nat for all m; specializes via hasSum_zeta_two/four to η(2) = π²/12 and η(4) = 7π⁴/720, with tsum corollaries.",
+      "mathContext": "η(2), η(4), η(6), … derived uniformly; η(4) recovers the parent entry."
+    }
+  ],
+  "conclusion": {
+    "summary": "The eta-zeta parity split is captured once, abstractly, in hasSum_eta_of_zeta: for any HasSum witness Z of ∑ 1/n^(2m), the alternating series sums to (1 − 2·(1/2)^(2m))·Z = (1 − 2^(1−2m))·ζ(2m). Composing with Mathlib's hasSum_zeta_nat derives the full family η(2m) uniformly; m = 1, 2 give η(2) = π²/12 and η(4) = 7π⁴/720 (the parent value). The coefficient form 1 − 2^(1−2m) is itself certified. Verified with 0 axioms and 0 sorries.",
+    "implications": "Replaces the per-value, per-exponent parity computation (as done for η(4) in the parent) with one reusable lemma, so any even zeta value Mathlib provides immediately yields its alternating companion. The abstraction generalizes the gallery's η(2) (oq-11) and η(4) (oq-14) entries into a single parameterized statement.",
+    "openQuestions": [
+      {
+        "id": "basel-problem-oq-14-oq-01-oq-01",
+        "question": "Extend the abstraction to the Dirichlet lambda values λ(2m) = ∑ 1/(2k+1)^(2m) = (1 − 2^(−2m)) ζ(2m), unifying the (ζ, η, λ) triple of even-exponent sums under one parity-split lemma.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-14",
+      "relationship": "extends",
+      "description": "Parent entry: formalized the single value η(4) = 7π⁴/720 by an explicit even/odd split. This entry abstracts that split into the exponent-parameterized master lemma and recovers η(4) as a one-line specialization."
+    },
+    {
+      "targetId": "basel-problem-oq-11",
+      "relationship": "generalizes",
+      "description": "η(2) = π²/12; here it is one instance (m = 1) of the uniform family η(2m) = (1 − 2^(1−2m))ζ(2m)."
+    },
+    {
+      "targetId": "basel-problem-oq-13",
+      "relationship": "related",
+      "description": "λ(4) = ∑ 1/(2k+1)⁴ = π⁴/96 (odd-power sum); the same even/odd machinery used here produces the lambda values, the subject of the follow-up question."
+    }
+  ],
+  "references": [
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of the even zeta values ζ(2m) = (rational)·π^(2m), from which all alternating eta values follow."
+    },
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet eta function η(s) = (1 − 2^(1−s))ζ(s) as the alternating series continuing ζ past Re s = 1."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-14-oq-01-oq-01",
+      "question": "Extend the abstraction to the Dirichlet lambda values λ(2m) = (1 − 2^(−2m)) ζ(2m), unifying the (ζ, η, λ) triple under one parity-split lemma.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **basel-problem-oq-14**'s own open question: abstract the even/odd parity split (used there for the single value η(4)) into one reusable lemma parameterized over the exponent 2m, deriving η(2), η(4), η(6), … uniformly from Mathlib's `hasSum_zeta_nat`.

## Result

**Master lemma** `hasSum_eta_of_zeta`: for any `HasSum` witness `Z` of the zeta series ∑ 1/n^(2m),
60345\eta(2m) = \bigl(1 - 2\cdot(1/2)^{2m}\bigr)\,Z = \bigl(1 - 2^{1-2m}\bigr)\,\zeta(2m).60345
The identity is a **pure even/odd series fact** — no closed form for ζ is used. Composing with `hasSum_zeta_nat` gives `hasSum_eta_nat` for all m ≥ 1; specializing through `hasSum_zeta_two`/`hasSum_zeta_four` recovers η(2)=π²/12 (cf. oq-11) and η(4)=7π⁴/720 (the parent value). `eta_coeff_eq` certifies the textbook coefficient form 1−2^(1−2m) via real zpow.

## Proof engine
- Even half is a scaled copy: 1/(2k)^(2m) = (1/2)^(2m)·(1/k^(2m)) → `HasSum.mul_left` (robust symbolic-exponent algebra, not literal `ring`).
- Odd half summable via `Summable.comp_injective` (k ↦ 2k+1); pinned by `HasSum.even_add_odd` + `HasSum.unique`.
- Alternating signs fixed by `Odd.neg_one_pow` / `Even.neg_one_pow`; combined with `HasSum.even_add_odd`.

## Verification
- 8 theorems, 1 definition, 166 lines
- **0 sorries, 0 axioms** (`#print axioms` → only propext / Classical.choice / Quot.sound)
- Builds against Mathlib v4.26 (`lake env lean Proofs/BaselProblemOQ14OQ01.lean`, clean)
- Registered in `proofs/Proofs.lean`; gallery entry (meta.json + annotations.json) added

🤖 Generated with [Claude Code](https://claude.com/claude-code)