### PR TITLE
research(beta-integral-recurrence-oq-01-oq-01): diagonal Beta value = central binomial reciprocal

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -317,6 +317,7 @@ import Proofs.BertrandsPostulateOQ03OQ04
 import Proofs.BertrandsPostulateOQ03OQ04Aristotle
 import Proofs.BertrandsPostulateOQ03OQ04OQ01
 import Proofs.BertrandsPostulateOQ03OQ04OQ03
+import Proofs.BetaCentralBinomial
 import Proofs.BetaIntegralHalfValue
 import Proofs.BetaIntegralRecurrence
 import Proofs.BezoutIdentity

--- a/proofs/Proofs/BetaCentralBinomial.lean
+++ b/proofs/Proofs/BetaCentralBinomial.lean
@@ -1,0 +1,98 @@
+import Proofs.BetaIntegralRecurrence
+import Mathlib.Tactic
+
+/-
+# The Symmetric Beta Value as a Central Binomial Reciprocal
+
+## What This Proves
+
+The parent entry establishes the integer closed form of the Euler Beta integral,
+`B(m+1, n+1) = m!·n!/(m+n+1)!`. On the **diagonal** `m = n` this collapses to a
+single Wallis-type quantity governed by the central binomial coefficient:
+
+  **`betaIntegral_diag_central_binom`**:
+    `B(n+1, n+1) = 1 / ((2n+1) · C(2n, n))`.
+
+Equivalently `B(n+1, n+1) = (n!)² / (2n+1)!`, the reciprocal of the integer
+`(2n+1)·\binom{2n}{n}`. This is exactly the normalization constant of the
+symmetric Beta(n+1, n+1) density on `[0,1]`: the probability density
+`x^n (1-x)^n / B(n+1,n+1)` integrates to one, so the total mass `B(n+1,n+1)` is
+the reciprocal of `(2n+1)\binom{2n}{n}`.
+
+The analytic content is entirely inherited from the parent's
+`betaIntegral_nat_nat`; the new ingredient is the elementary factorial identity
+
+  **`factorial_two_mul_succ`**:  `(2n+1)! = (2n+1) · C(2n,n) · (n!·n!)`,
+
+which rewrites the diagonal value `(n!)²/(2n+1)!` as `1/((2n+1)·C(2n,n))`.
+
+## Relation to Mathlib
+
+Mathlib has the central binomial coefficient `Nat.centralBinom n = (2n).choose n`
+and the factorial/choose factorization `Nat.choose_mul_factorial_mul_factorial`,
+but it does not state this Beta value. We assemble it from the parent entry.
+-/
+
+namespace BetaCentralBinomial
+
+open Complex
+
+/-- **Factorial factorization (new).** `(2n+1)! = (2n+1) · C(2n,n) · (n!·n!)`.
+
+This is the multiplicative bridge between the factorial form `(n!)²/(2n+1)!` and
+the central-binomial form `1/((2n+1)·C(2n,n))`. It follows from the basic
+identity `C(2n,n)·n!·n! = (2n)!` (specializing
+`Nat.choose_mul_factorial_mul_factorial`) and one step of `Nat.factorial_succ`. -/
+theorem factorial_two_mul_succ (n : ℕ) :
+    Nat.factorial (2 * n + 1)
+      = (2 * n + 1) * (2 * n).choose n * (Nat.factorial n * Nat.factorial n) := by
+  have hle : n ≤ 2 * n := by omega
+  have h := Nat.choose_mul_factorial_mul_factorial hle
+  rw [show 2 * n - n = n by omega] at h
+  -- h : (2*n).choose n * n ! * n ! = (2*n)!
+  rw [Nat.factorial_succ (2 * n), ← h]
+  ring
+
+/-- **Diagonal Beta value as a central binomial reciprocal (new).**
+
+  `B(n+1, n+1) = 1 / ((2n+1) · C(2n, n))`.
+
+This is the total mass of the symmetric Beta(n+1, n+1) density on `[0,1]`. -/
+theorem betaIntegral_diag_central_binom (n : ℕ) :
+    betaIntegral ((n : ℂ) + 1) ((n : ℂ) + 1)
+      = 1 / (((2 * n + 1) * (2 * n).choose n : ℕ) : ℂ) := by
+  have hd1 : ((Nat.factorial (2 * n + 1) : ℕ) : ℂ) ≠ 0 := by
+    exact_mod_cast (Nat.factorial_pos _).ne'
+  have hd2 : (((2 * n + 1) * (2 * n).choose n : ℕ) : ℂ) ≠ 0 := by
+    have hpos : 0 < (2 * n + 1) * (2 * n).choose n := by
+      have := Nat.choose_pos (show n ≤ 2 * n by omega); positivity
+    exact_mod_cast hpos.ne'
+  have key : Nat.factorial n * Nat.factorial n * ((2 * n + 1) * (2 * n).choose n)
+      = Nat.factorial (2 * n + 1) := by
+    rw [factorial_two_mul_succ]; ring
+  rw [BetaIntegralRecurrence.betaIntegral_nat_nat n n,
+      show n + n + 1 = 2 * n + 1 by ring,
+      div_eq_div_iff hd1 hd2, one_mul, ← Nat.cast_mul, ← Nat.cast_mul, key]
+
+/-- The same value phrased with Mathlib's `Nat.centralBinom`:
+`B(n+1, n+1) = 1 / ((2n+1) · centralBinom n)`. -/
+theorem betaIntegral_diag_centralBinom (n : ℕ) :
+    betaIntegral ((n : ℂ) + 1) ((n : ℂ) + 1)
+      = 1 / (((2 * n + 1) * Nat.centralBinom n : ℕ) : ℂ) := by
+  rw [betaIntegral_diag_central_binom]; rfl
+
+/-- `B(1,1) = 1` recovered from the central-binomial form (`n = 0`:
+`(2·0+1)·C(0,0) = 1`). -/
+theorem betaIntegral_one_one_central : betaIntegral 1 1 = 1 := by
+  have h := betaIntegral_diag_central_binom 0
+  norm_num at h
+  simpa using h
+
+/-- `B(2,2) = 1/6` from the central-binomial form (`n = 1`:
+`(2·1+1)·C(2,1) = 3·2 = 6`). -/
+theorem betaIntegral_two_two : betaIntegral 2 2 = 1 / 6 := by
+  have h := betaIntegral_diag_central_binom 1
+  norm_num [Nat.choose] at h
+  simpa using h
+
+end BetaCentralBinomial

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "beta-integral-recurrence-oq-01-oq-01",
+  "slug": "beta-integral-recurrence-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.BetaIntegralRecurrence",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex"
+    ],
+    "namespace": "BetaCentralBinomial",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BetaCentralBinomial.lean",
+    "sorries": 0
+  },
+  "title": "The Diagonal Beta Value as a Central Binomial Reciprocal: B(n+1,n+1) = 1/((2n+1)·C(2n,n))",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaCentralBinomial.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "beta-function",
+      "combinatorics",
+      "central-binomial",
+      "factorials",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 98,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "betaIntegral_diag_central_binom: the diagonal Euler Beta value B(n+1,n+1) = 1/((2n+1)·C(2n,n)) for every natural n — the reciprocal of the integer (2n+1)·binom(2n,n), and the normalization constant (total mass) of the symmetric Beta(n+1,n+1) density on [0,1]. Mathlib has neither this value nor the symmetric-density normalization; the analytic input is inherited from the parent's integer closed form B(m+1,n+1) = m!·n!/(m+n+1)! and the new content is the combinatorial collapse of the diagonal (n!)²/(2n+1)! to the central binomial reciprocal.",
+      "factorial_two_mul_succ: the elementary factorial factorization (2n+1)! = (2n+1)·C(2n,n)·(n!·n!), the multiplicative bridge between the factorial form (n!)²/(2n+1)! and the central-binomial form 1/((2n+1)·C(2n,n)). Derived from Nat.choose_mul_factorial_mul_factorial (giving C(2n,n)·n!·n! = (2n)!) and one step of Nat.factorial_succ.",
+      "betaIntegral_diag_centralBinom: the same value phrased with Mathlib's Nat.centralBinom, B(n+1,n+1) = 1/((2n+1)·centralBinom n), linking the Beta normalization to the standard combinatorial constant.",
+      "betaIntegral_two_two: the instance B(2,2) = 1/6 read off the central-binomial form at n = 1 ((2·1+1)·C(2,1) = 6), complementing the parent's B(3,3) = 1/30 (the n = 2 instance)."
+    ],
+    "prerequisites": [
+      "Euler Beta integral Complex.betaIntegral u v = ∫₀¹ tᵘ⁻¹ (1−t)ᵛ⁻¹ dt",
+      "Parent integer closed form BetaIntegralRecurrence.betaIntegral_nat_nat: B(m+1,n+1) = m!·n!/(m+n+1)!",
+      "Central binomial coefficient C(2n,n) = (2n).choose n and Nat.centralBinom",
+      "Factorial/choose factorization Nat.choose_mul_factorial_mul_factorial: C(n,k)·k!·(n−k)! = n!",
+      "Nat.factorial_succ: (m+1)! = (m+1)·m!"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(n,k)·k!·(n−k)! = n! for k ≤ n; specialized at n = 2n, k = n to give C(2n,n)·n!·n! = (2n)!, the heart of the factorial factorization.",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(m+1)! = (m+1)·m!, used once to peel (2n+1)! = (2n+1)·(2n)!.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.centralBinom",
+        "description": "The central binomial coefficient centralBinom n = (2n).choose n, used to restate the Beta value in standard combinatorial form.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Complex.betaIntegral_eq_Gamma_mul_div",
+        "description": "Beta–Gamma division formula B(u,v) = Γu·Γv/Γ(u+v), the analytic engine used (via the parent entry) to evaluate the diagonal integer Beta value.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The symmetric Beta(α,α) density x^(α−1)(1−x)^(α−1)/B(α,α) on [0,1] is the workhorse distribution of Bayesian statistics (the conjugate prior for a Bernoulli parameter) and, for integer α = n+1, the order statistics of uniform samples: the gap between the (n+1)-st smallest of 2n+1 i.i.d. uniforms has this law. Its normalization constant — the total mass B(n+1,n+1) of the unnormalized density x^n(1−x)^n — is the Wallis-type quantity (n!)²/(2n+1)!. Writing it through the central binomial coefficient gives the strikingly clean B(n+1,n+1) = 1/((2n+1)·C(2n,n)), the reciprocal of an integer. The same numbers (2n+1)·C(2n,n) appear in the Wallis product for π and in the Catalan-number generating function, tying this elementary normalization to a web of classical identities.",
+    "problemStatement": "Building on the parent entry's integer closed form B(m+1,n+1) = m!·n!/(m+n+1)!, derive the diagonal central-binomial / Wallis-type identity B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) as a function of n, and connect it to the normalization of the symmetric Beta(n+1,n+1) density on [0,1]. This answers open question oq-01 of the parent entry.",
+    "proofStrategy": "The analytic value is taken verbatim from the parent's betaIntegral_nat_nat at m = n: B(n+1,n+1) = (n!)²/(n+n+1)!. The new work is purely combinatorial. factorial_two_mul_succ proves (2n+1)! = (2n+1)·C(2n,n)·(n!·n!) by specializing Nat.choose_mul_factorial_mul_factorial at n = 2n, k = n (yielding C(2n,n)·n!·n! = (2n)!) and peeling one factorial with Nat.factorial_succ. betaIntegral_diag_central_binom then equates the two fractions (n!)²/(2n+1)! and 1/((2n+1)·C(2n,n)) via div_eq_div_iff with both denominators positive (Nat.factorial_pos, Nat.choose_pos), reducing the goal to the natural-number identity n!·n!·((2n+1)·C(2n,n)) = (2n+1)! supplied by the factorization. betaIntegral_diag_centralBinom restates this with Nat.centralBinom, and betaIntegral_two_two reads off the n = 1 instance B(2,2) = 1/6.",
+    "keyInsights": [
+      "The diagonal of the integer Beta lattice is a single central binomial reciprocal: B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)). The factorials of the parent's two-variable form collapse, on the diagonal, into one combinatorial integer (2n+1)·C(2n,n).",
+      "The combinatorial bridge is the factorization (2n+1)! = (2n+1)·C(2n,n)·(n!)², a one-line consequence of C(2n,n)·n!·n! = (2n)! — no analysis is reused beyond the parent's value, so the proof is an exact-rational reindexing, not a new integral evaluation.",
+      "B(n+1,n+1) is the total mass of the unnormalized symmetric density x^n(1−x)^n on [0,1]; its reciprocal (2n+1)·C(2n,n) is therefore the normalizing constant of the Beta(n+1,n+1) distribution, making the identity the exact density normalization the open question asks for.",
+      "Consistency across the family: n = 0 gives B(1,1) = 1/((1)·C(0,0)) = 1, n = 1 gives B(2,2) = 1/(3·2) = 1/6, and n = 2 gives B(3,3) = 1/(5·6) = 1/30 — matching the parent entry's independently computed B(1,1) = 1 and B(3,3) = 1/30.",
+      "The 'original' badge is honest: while the Beta–Gamma engine and the factorial/choose identity are Mathlib's, the named diagonal value B(n+1,n+1) = 1/((2n+1)·C(2n,n)) and its identification as the symmetric Beta density normalization are not in Mathlib and are assembled here."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Diagonal Beta Value and Central Binomials",
+      "startLine": 4,
+      "endLine": 35,
+      "summary": "States the diagonal collapse B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) as the normalization of the symmetric Beta(n+1,n+1) density, identifies the analytic input as the parent's integer closed form, and announces the new combinatorial ingredient factorial_two_mul_succ.",
+      "mathContext": "$B(n+1,n+1) = \\frac{(n!)^2}{(2n+1)!} = \\frac{1}{(2n+1)\\binom{2n}{n}}$."
+    },
+    {
+      "id": "factorization",
+      "title": "The Factorial Factorization",
+      "startLine": 37,
+      "endLine": 60,
+      "summary": "factorial_two_mul_succ proves (2n+1)! = (2n+1)·C(2n,n)·(n!·n!) from Nat.choose_mul_factorial_mul_factorial (C(2n,n)·n!·n! = (2n)!) and one Nat.factorial_succ step, the bridge between the factorial and central-binomial forms.",
+      "mathContext": "$(2n+1)! = (2n+1)\\,\\binom{2n}{n}\\,(n!)^2$."
+    },
+    {
+      "id": "diagonal-value",
+      "title": "The Central Binomial Reciprocal",
+      "startLine": 61,
+      "endLine": 80,
+      "summary": "betaIntegral_diag_central_binom equates the parent's diagonal value (n!)²/(2n+1)! with 1/((2n+1)·C(2n,n)) via div_eq_div_iff (both denominators positive) reduced to the natural-number identity from the factorization; betaIntegral_diag_centralBinom restates it with Nat.centralBinom.",
+      "mathContext": "$B(n+1,n+1) = \\dfrac{1}{(2n+1)\\binom{2n}{n}}$."
+    },
+    {
+      "id": "instances",
+      "title": "Numerical Instances",
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "betaIntegral_one_one_central (B(1,1) = 1, n = 0) and betaIntegral_two_two (B(2,2) = 1/6, n = 1) read the central-binomial form at small n, consistent with the parent entry's B(1,1) = 1 and B(3,3) = 1/30.",
+      "mathContext": "$B(1,1) = 1,\\ B(2,2) = 1/6$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-01-oq-01",
+      "question": "Prove the Wallis-product / asymptotic consequence: B(n+1,n+1) = 1/((2n+1)·C(2n,n)) ~ √(πn)/(2n+1)·4^(−n), exhibiting the exponential decay of the symmetric Beta normalization and its link to the central limit scaling of the Beta(n+1,n+1) density toward a Gaussian.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry evaluates the two-variable integer Beta lattice B(m+1,n+1) = m!·n!/(m+n+1)!; this entry collapses its diagonal m = n into the single central-binomial reciprocal B(n+1,n+1) = 1/((2n+1)·C(2n,n)) and identifies it as the symmetric Beta-density normalization. It answers the parent's open question oq-01 verbatim."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling answering the parent's oq-02: where that entry evaluates the half-integer diagonal B(1/2,1/2) = π (π-driven), this entry evaluates the integer diagonal B(n+1,n+1) = 1/((2n+1)·C(2n,n)) (purely rational/combinatorial). Together they describe the full diagonal of the Beta function on the integer and half-integer lattices."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Data.Nat.Choose.Factorization and Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.choose_mul_factorial_mul_factorial, Nat.factorial_succ, Nat.centralBinom, and (via the parent entry) Complex.betaIntegral_eq_Gamma_mul_div."
+    },
+    {
+      "title": "Special Functions (Beta and Gamma functions)",
+      "author": "Andrews, Askey, Roy",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "description": "Standard reference for the Beta integral, its integer closed form, and the central binomial / Wallis connections of the diagonal values."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The diagonal of the integer Euler Beta lattice is evaluated in closed form: B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) for every natural n. The analytic value is inherited from the parent's betaIntegral_nat_nat at m = n; the new content is the factorial factorization factorial_two_mul_succ ((2n+1)! = (2n+1)·C(2n,n)·(n!)²) and the resulting central-binomial reciprocal betaIntegral_diag_central_binom, with the Nat.centralBinom restatement and the instances B(1,1) = 1, B(2,2) = 1/6. 98 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The result supplies the exact normalization constant (2n+1)·C(2n,n) of the symmetric Beta(n+1,n+1) density on [0,1], answering the parent's open question oq-01. The Beta–Gamma engine and the factorial/choose identity are Mathlib's (so only those are delegated); the named diagonal value and its density interpretation are assembled here, justifying the original badge. Consistency with the parent's independently computed B(1,1) = 1 and B(3,3) = 1/30 cross-checks both entries.",
+    "openQuestions": [
+      "Establish the Wallis/asymptotic decay B(n+1,n+1) ~ √(πn)/(2n+1)·4^(−n) and connect it to the Gaussian limit of the symmetric Beta density."
+    ]
+  },
+  "description": "A closed form for the diagonal of the integer Euler Beta lattice: B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)), the reciprocal of an integer and the exact normalization constant of the symmetric Beta(n+1,n+1) density on [0,1]. The analytic value comes from the parent entry's integer closed form at m = n; the new ingredient is the factorial factorization (2n+1)! = (2n+1)·C(2n,n)·(n!)², which collapses the diagonal to a central binomial reciprocal. Restated with Nat.centralBinom and checked at B(1,1) = 1, B(2,2) = 1/6 (consistent with the parent's B(3,3) = 1/30). Answers open question oq-01 of the parent recurrence entry. 5 theorems, 0 sorries, 0 axioms."
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-01** of the Beta Integral Recurrence entry: derive the diagonal closed form
**B(n+1, n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n))** and connect it to the normalization of the symmetric Beta(n+1,n+1) density on [0,1].

The analytic value is inherited from the parent's `betaIntegral_nat_nat` (B(m+1,n+1)=m!·n!/(m+n+1)!) at m=n; the **new content is purely combinatorial**:

- `factorial_two_mul_succ`: `(2n+1)! = (2n+1)·C(2n,n)·(n!·n!)` — the bridge between the factorial form and the central-binomial form, from `Nat.choose_mul_factorial_mul_factorial` + one `Nat.factorial_succ`.
- `betaIntegral_diag_central_binom`: `B(n+1,n+1) = 1/((2n+1)·C(2n,n))` — the reciprocal of an integer, i.e. the exact normalization constant of the symmetric Beta(n+1,n+1) density.
- `betaIntegral_diag_centralBinom`: same value via Mathlib's `Nat.centralBinom`.
- Instances `B(1,1)=1` (n=0), `B(2,2)=1/6` (n=1) — consistent with the parent's independently computed `B(1,1)=1`, `B(3,3)=1/30` (n=2).

## Verification

- Builds clean with `lake env lean Proofs/BetaCentralBinomial.lean` (exit 0).
- `#print axioms` on all results: only `propext, Classical.choice, Quot.sound` (the ordinary foundational axioms) — **0 `axiom` declarations, 0 structure-encoded assumptions, 0 sorries, no `native_decide`**. Status: `verified`, badge `original`.

## Files

- `proofs/Proofs/BetaCentralBinomial.lean` (98 lines, 5 theorems)
- `proofs/Proofs.lean` (register module)
- `src/data/proofs/beta-integral-recurrence-oq-01-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)