### PR TITLE
research(area-of-circle-oq-07-oq-05-oq-01-oq-01): vanishing odd Gaussian moments + full moment sequence [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -219,6 +219,7 @@ import Proofs.AreaOfCircleOQ07OQ03
 import Proofs.AreaOfCircleOQ07OQ04
 import Proofs.AreaOfCircleOQ07OQ05
 import Proofs.AreaOfCircleOQ07OQ05OQ01
+import Proofs.AreaOfCircleOQ07OQ05OQ01OQ01
 import Proofs.AreaOfCircleOQ07OQ05OQ01OQ02
 import Proofs.AreaOfCircleOQ07OQ05OQ02
 import Proofs.ArithmeticSeries

--- a/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ01.lean
@@ -1,0 +1,98 @@
+import Proofs.AreaOfCircleOQ07OQ05OQ01
+import Mathlib.Tactic
+
+/-
+# Vanishing of the Odd Gaussian Moments  (area-of-circle-oq-07-oq-05-oq-01-oq-01)
+
+## Open Question (area-of-circle-oq-07-oq-05-oq-01-oq-01)
+"Add the vanishing odd moments `∫_ℝ x^{2n+1} e^{-x²} dx = 0` to give the full
+moment sequence."
+
+## Answer
+
+For every `n : ℕ`,
+
+  `∫_{-∞}^{∞} x^{2n+1} e^{-x²} dx = 0`.
+
+The parent entry `area-of-circle-oq-07-oq-05-oq-01` evaluated the *even* moments
+`∫ x^{2n} e^{-x²} = (2n-1)‼ √π / 2^n` by an integration-by-parts recursion.  The
+moment sequence of the standard Gaussian is completed by the **odd** moments,
+which all vanish.
+
+The vanishing is a pure symmetry statement, not an artefact of non-integrability:
+the integrand `x^{2n+1} e^{-x²}` is genuinely Lebesgue integrable (parent's
+`integrable_pow_mul_gaussian`), yet its integral is zero because the integrand is
+an **odd** function and Lebesgue measure on `ℝ` is invariant under `x ↦ -x`.
+Concretely, writing `f x = x^{2n+1} e^{-x²}`,
+
+  `∫ f = ∫ x, f(-x)`   (`integral_neg_eq_self`, negation-invariance of volume)
+       `= ∫ x, -f(x)`   (`f` is odd: `(-x)^{2n+1} = -x^{2n+1}`, `(-x)² = x²`)
+       `= -∫ f`,
+
+so `∫ f = -∫ f`, forcing `∫ f = 0` (`gaussian_odd_moment`).
+
+Folding the new odd-moment vanishing together with the parent's even-moment
+closed form gives the **full moment sequence** indexed by a single natural number
+`m` (`gaussian_moment`):
+
+  `∫_ℝ x^m e^{-x²} dx = if Even m then (m-1)‼ √π / 2^{m/2} else 0`.
+
+No new axioms: the odd-moment vanishing is `integral_neg_eq_self` together with
+oddness of the integrand; the full sequence merely case-splits on the parity of
+`m` and reuses the parent's even-moment evaluation.
+-/
+
+open Real MeasureTheory
+open scoped Nat
+
+namespace AreaOfCircleOQ07OQ05OQ01OQ01
+
+/-- **The odd moments of the standard Gaussian vanish.**
+`∫_{-∞}^{∞} x^{2n+1} e^{-x²} dx = 0`.
+
+The integrand is odd and Lebesgue measure on `ℝ` is negation-invariant, so the
+integral equals its own negation and must be zero. -/
+theorem gaussian_odd_moment (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n + 1) * Real.exp (-x ^ 2) = 0 := by
+  set f : ℝ → ℝ := fun x => x ^ (2 * n + 1) * Real.exp (-x ^ 2) with hf
+  -- `f` is odd: `(-x)^{2n+1} = -(x^{2n+1})` and `(-x)² = x²`.
+  have hodd : ∀ x : ℝ, f (-x) = -f x := by
+    intro x
+    simp only [hf]
+    rw [Odd.neg_pow ⟨n, rfl⟩, neg_sq]
+    ring
+  -- Negation-invariance of volume: `∫ f(-x) = ∫ f`.
+  have h1 : ∫ x : ℝ, f (-x) = ∫ x : ℝ, f x := integral_neg_eq_self f volume
+  -- Oddness rewrites the same integral as `∫ -f = -∫ f`.
+  have h2 : ∫ x : ℝ, f (-x) = -∫ x : ℝ, f x := by
+    rw [show (fun x : ℝ => f (-x)) = (fun x : ℝ => -f x) from funext hodd, integral_neg]
+  -- Hence `∫ f = -∫ f`, so `∫ f = 0`.
+  have : ∫ x : ℝ, f x = -∫ x : ℝ, f x := h1 ▸ h2
+  linarith [this]
+
+/-- Sanity check: the first odd moment `∫ x e^{-x²} = 0` (the `n = 0` case). -/
+theorem gaussian_first_odd_moment :
+    ∫ x : ℝ, x * Real.exp (-x ^ 2) = 0 := by
+  have h := gaussian_odd_moment 0
+  simpa using h
+
+/-- **The full moment sequence of the standard Gaussian.**
+`∫_{-∞}^{∞} x^m e^{-x²} dx = (m-1)‼ √π / 2^{m/2}` when `m` is even, and `0` when
+`m` is odd.  This unifies the parent's even-moment evaluation
+(`AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment`) with the odd-moment vanishing
+above into one statement indexed by a single natural number. -/
+theorem gaussian_moment (m : ℕ) :
+    ∫ x : ℝ, x ^ m * Real.exp (-x ^ 2)
+      = if Even m then ((m - 1)‼ : ℝ) * Real.sqrt Real.pi / 2 ^ (m / 2) else 0 := by
+  rcases Nat.even_or_odd m with h | h
+  · -- `m = k + k` even.
+    obtain ⟨k, rfl⟩ := h
+    have hdiv : (k + k) / 2 = k := by omega
+    have hpow : k + k = 2 * k := by ring
+    rw [if_pos ⟨k, rfl⟩, hdiv, hpow,
+      AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment k]
+  · -- `m = 2k + 1` odd.
+    obtain ⟨k, rfl⟩ := h
+    rw [if_neg (Nat.not_even_iff_odd.mpr ⟨k, rfl⟩), gaussian_odd_moment k]
+
+end AreaOfCircleOQ07OQ05OQ01OQ01

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Completing the Moment Table by Symmetry",
+    "content": "The parent entry evaluated the even moments ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ by an integration-by-parts recursion. The odd moments need no such work: x^{2n+1} e^{-x²} is an odd function, and Lebesgue measure on ℝ is invariant under x ↦ -x, so the integral equals its own negation and must vanish. The subtle point made explicit here is that this is genuine cancellation of an integrable function — the integrand is in L¹ — not a divergence artefact. Folding the vanishing odd moments together with the parent's even formula gives the complete moment sequence in one parity-indexed statement.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n+1} e^{-x^2}\\,dx = 0$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gaussian integral",
+      "odd function",
+      "symmetry of the integral",
+      "moments of a distribution",
+      "negation-invariant measure"
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ",
+      "negation-invariance of volume"
+    ]
+  },
+  {
+    "id": "ann-odd-moment",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 71
+    },
+    "type": "key-step",
+    "title": "Odd Symmetry Forces the Integral to Vanish",
+    "content": "Set f x = x^{2n+1} e^{-x²}. The function is odd: (-x)^{2n+1} = -(x^{2n+1}) because 2n+1 is odd (Odd.neg_pow with witness ⟨n, rfl⟩ : Odd (2n+1)) and (-x)² = x² (neg_sq), so f(-x) = -f(x). Negation-invariance of volume gives ∫ x, f(-x) = ∫ x, f x (integral_neg_eq_self). Rewriting the same integral through oddness, ∫ x, f(-x) = ∫ x, -f x = -∫ x, f x (integral_neg). Equating the two evaluations yields ∫ f = -∫ f, hence 2∫ f = 0 and ∫ f = 0 (linarith). Notably no integrability hypothesis is required: both integral_neg_eq_self and integral_neg are unconditional, so the argument is purely about symmetry.",
+    "mathContext": "$\\int f = \\int f(-x) = \\int(-f) = -\\int f \\;\\Rightarrow\\; \\int f = 0$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Odd.neg_pow",
+      "integral_neg_eq_self",
+      "integral_neg",
+      "odd function"
+    ],
+    "prerequisites": [
+      "negation-invariance of volume on ℝ",
+      "oddness of odd integer powers"
+    ]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "The First Odd Moment",
+    "content": "The n = 0 instance ∫_ℝ x e^{-x²} = 0 is recorded as a sanity check — the simplest odd moment, obtained from gaussian_odd_moment 0 by simp.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x\\, e^{-x^2}\\,dx = 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "odd function",
+      "first moment"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-full-sequence",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 97
+    },
+    "type": "key-step",
+    "title": "Assembling the Full Moment Sequence",
+    "content": "gaussian_moment unifies even and odd moments into one statement keyed on the parity of k: ∫_ℝ x^k e^{-x²} = if Even k then (k-1)‼·√π/2^{k/2} else 0. The proof case-splits on Nat.even_or_odd k. In the even branch k = k'+k', after rewriting (k'+k')/2 = k' (omega) and k'+k' = 2k' (ring), the goal matches the parent's gaussian_even_moment k'. In the odd branch k = 2k'+1, the if-condition is discharged by Nat.not_even_iff_odd.mpr ⟨k', rfl⟩ and the integral reduces to gaussian_odd_moment k' = 0. This is the explicit deliverable the parent open question asked for: the complete moment table of the standard Gaussian in a single closed form.",
+    "mathContext": "$\\int_{-\\infty}^{\\infty} x^{k} e^{-x^2}\\,dx = \\begin{cases}(k-1)!!\\,\\sqrt{\\pi}/2^{k/2} & k\\text{ even}\\\\ 0 & k\\text{ odd}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.even_or_odd",
+      "parity case split",
+      "double factorial",
+      "moment sequence"
+    ],
+    "prerequisites": [
+      "parent even-moment closed form",
+      "odd-moment vanishing"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ05OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq05Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq05Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq05Oq01Oq01Data: ProofData = {
+  proof: areaOfCircleOq07Oq05Oq01Oq01Proof,
+  annotations: areaOfCircleOq07Oq05Oq01Oq01Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+  "slug": "area-of-circle-oq-07-oq-05-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Proofs.AreaOfCircleOQ07OQ05OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ05OQ01OQ01",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Vanishing of the Odd Gaussian Moments and the Full Moment Sequence ∫ x^{2n+1} e^{-x²} = 0",
+  "description": "Completes the moment sequence of the standard Gaussian weight opened by the parent's even moments. For every n the odd moment vanishes, ∫_ℝ x^{2n+1} e^{-x²} dx = 0, by a pure symmetry argument: the integrand is odd and Lebesgue measure on ℝ is negation-invariant (integral_neg_eq_self), so the integral equals its own negation. The vanishing is genuine, not an artefact of non-integrability — the integrand is Lebesgue integrable. Folding this with the parent's even-moment closed form gives the full moment sequence ∫_ℝ x^k e^{-x²} dx = (k-1)‼·√π/2^{k/2} for even k and 0 for odd k, indexed by a single natural number. 98 lines, 3 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ05OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "odd-function",
+      "symmetry",
+      "special-functions",
+      "measure-theory",
+      "moments",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 98,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_odd_moment: ∫_ℝ x^{2n+1} e^{-x²} dx = 0 for every n : ℕ — the odd moments of the standard Gaussian weight all vanish. The proof is a pure symmetry argument: setting f x = x^{2n+1} e^{-x²}, oddness of f ((-x)^{2n+1} = -(x^{2n+1}) via Odd.neg_pow, (-x)² = x²) together with negation-invariance of Lebesgue measure (integral_neg_eq_self) gives ∫ f = ∫ f(-x) = ∫ -f = -∫ f, forcing ∫ f = 0. No integrability hypothesis is needed because integral_neg_eq_self and integral_neg are unconditional.",
+      "gaussian_moment: ∫_ℝ x^k e^{-x²} dx = if Even k then (k-1)‼·√π / 2^{k/2} else 0 — the full moment sequence of the standard Gaussian, indexed by a single natural number k. Unifies the parent's even-moment evaluation (AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment) with the odd-moment vanishing above by case-splitting on the parity of k (Nat.even_or_odd), the even branch matching (k/2 = k', (k-1)‼) and the odd branch reducing to gaussian_odd_moment. This is the parent open question's explicit deliverable: the complete moment table in one statement.",
+      "gaussian_first_odd_moment: ∫_ℝ x e^{-x²} dx = 0 — the n = 0 instance, the first odd moment, recorded as a sanity check."
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Negation-invariance of volume on ℝ: integral_neg_eq_self (additive form of integral_inv_eq_self, IsNegInvariant)",
+      "Oddness of integer powers: Odd.neg_pow, neg_sq",
+      "Parity case split: Nat.even_or_odd, Nat.not_even_iff_odd",
+      "Parent: area-of-circle-oq-07-oq-05-oq-01 (the even moments ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_neg_eq_self",
+        "description": "∫ x, f (-x) ∂μ = ∫ x, f x ∂μ for a negation-invariant measure μ (the additive form, via @[to_additive], of integral_inv_eq_self). Volume on ℝ is IsNegInvariant, so the substitution x ↦ -x leaves the integral unchanged; combined with oddness this is the whole proof of the odd-moment vanishing.",
+        "module": "Mathlib.MeasureTheory.Group.Integral"
+      },
+      {
+        "theorem": "Odd.neg_pow",
+        "description": "(-a)^n = -(a^n) when n is odd. Applied with the odd exponent 2n+1 (witness ⟨n, rfl⟩ : Odd (2n+1)) to show the integrand x^{2n+1} e^{-x²} is odd.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "integral_neg",
+        "description": "∫ x, -f x = -∫ x, f x, the linearity step that turns the oddness rewrite ∫ f(-x) = ∫ -f into ∫ f(-x) = -∫ f.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      },
+      {
+        "theorem": "AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment",
+        "description": "Parent entry: ∫_ℝ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ. Supplies the even branch of the unified full moment sequence gaussian_moment.",
+        "module": "Proofs.AreaOfCircleOQ07OQ05OQ01"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The moments of the Gaussian weight, ∫_{-∞}^{∞} x^k e^{-x²} dx, are a cornerstone of analysis and probability: the even ones encode the variance, kurtosis, and all higher even cumulants of the normal distribution, while the odd ones all vanish. The vanishing of the odd moments is the prototype of the elementary but powerful principle that the integral of an odd function over a symmetric domain is zero — a fact already used implicitly by Gauss and Laplace and made routine by every subsequent analysis text. In probability it is the statement that a centered symmetric distribution has zero skewness and zero odd central moments E[X^{2n+1}] = 0; in physics it is why the dipole and all odd multipole expectations of a ground-state harmonic oscillator vanish. The parent entry computed the even moments by an integration-by-parts recursion; this entry supplies the complementary odd moments by symmetry, completing the full moment table.",
+    "problemStatement": "Prove that for every natural number $n$, $\\displaystyle\\int_{-\\infty}^{\\infty} x^{2n+1}\\,e^{-x^2}\\,dx = 0$, using the odd symmetry of the integrand, and combine this with the even-moment formula to obtain the full moment sequence $\\displaystyle\\int_{-\\infty}^{\\infty} x^{k}\\,e^{-x^2}\\,dx = \\begin{cases}(k-1)!!\\,\\sqrt{\\pi}/2^{k/2} & k \\text{ even}\\\\ 0 & k \\text{ odd}\\end{cases}$ for all $k \\in \\mathbb{N}$.",
+    "proofStrategy": "The odd-moment vanishing (gaussian_odd_moment) is a three-line symmetry argument. Write f(x) = x^{2n+1} e^{-x²}. (1) f is odd: (-x)^{2n+1} = -(x^{2n+1}) since 2n+1 is odd (Odd.neg_pow) and (-x)² = x² (neg_sq), so f(-x) = -f(x). (2) Lebesgue measure on ℝ is invariant under x ↦ -x, so ∫ f(-x) = ∫ f (integral_neg_eq_self). (3) But ∫ f(-x) = ∫ (-f) = -∫ f (integral_neg). Chaining gives ∫ f = -∫ f, hence ∫ f = 0 (linarith). No integrability hypothesis enters — both Mathlib lemmas hold unconditionally — which is exactly the point: the vanishing is symmetry, not divergence (the integrand is in fact integrable, parent's integrable_pow_mul_gaussian). The full moment sequence (gaussian_moment) case-splits on the parity of k via Nat.even_or_odd: the even branch k = k' + k' reduces, after rewriting k'+k' = 2k' and (k'+k')/2 = k', to the parent's gaussian_even_moment; the odd branch k = 2k'+1 reduces to gaussian_odd_moment with the if-condition discharged by Nat.not_even_iff_odd.",
+    "keyInsights": [
+      "Odd symmetry alone forces the integral to vanish — no value computation is needed. The entire content is that f(-x) = -f(x) and that the measure is negation-invariant, so the integral is its own negative.",
+      "The vanishing is symmetry, not non-integrability. A naive reading might attribute ∫ = 0 to the integral failing to converge, but x^{2n+1} e^{-x²} is genuinely Lebesgue integrable (parent's integrable_pow_mul_gaussian); the integral converges and its value is exactly 0 because positive and negative halves cancel.",
+      "integral_neg_eq_self is the clean encapsulation of the symmetry. Rather than splitting ℝ into (-∞,0] and [0,∞) and substituting, the single negation-invariance lemma (the additive image of integral_inv_eq_self for IsNegInvariant measures) does all the work in one rewrite.",
+      "Even and odd moments assemble into one parity-indexed statement. gaussian_moment puts the parent's combinatorial even formula and this entry's vanishing odd formula under a single if Even k, giving the complete moment table E[X^k]·√π-normalization in one theorem keyed on k."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Open Question and Symmetry Strategy",
+      "startLine": 4,
+      "endLine": 43,
+      "summary": "States the open question — add the vanishing odd moments to complete the Gaussian moment sequence — and outlines the symmetry argument: the integrand is odd and Lebesgue measure on ℝ is negation-invariant, so the integral equals its own negation and must be zero. Emphasizes that the vanishing is genuine symmetry, not non-integrability, and that folding it with the parent's even moments yields the full parity-indexed sequence.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n+1} e^{-x^2}\\,dx = 0$"
+    },
+    {
+      "id": "odd-moment",
+      "title": "The Odd Moments Vanish",
+      "startLine": 50,
+      "endLine": 71,
+      "summary": "theorem gaussian_odd_moment: ∫_ℝ x^{2n+1} e^{-x²} = 0. Sets f x = x^{2n+1} e^{-x²}, proves oddness f(-x) = -f(x) via Odd.neg_pow and neg_sq, then chains integral_neg_eq_self (∫ f(-x) = ∫ f) with the oddness rewrite ∫ f(-x) = -∫ f (integral_neg) to get ∫ f = -∫ f, closed by linarith. Unconditional — no integrability needed.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{2n+1} e^{-x^2}\\,dx = 0$"
+    },
+    {
+      "id": "first-moment",
+      "title": "Sanity Check: The First Odd Moment",
+      "startLine": 73,
+      "endLine": 77,
+      "summary": "theorem gaussian_first_odd_moment: ∫_ℝ x e^{-x²} = 0, the n = 0 instance, confirming the general formula on the simplest case.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x\\, e^{-x^2}\\,dx = 0$"
+    },
+    {
+      "id": "full-sequence",
+      "title": "The Full Moment Sequence",
+      "startLine": 79,
+      "endLine": 97,
+      "summary": "theorem gaussian_moment: ∫_ℝ x^k e^{-x²} = if Even k then (k-1)‼·√π/2^{k/2} else 0. Case-splits on Nat.even_or_odd k; the even branch k = k'+k' rewrites to the parent's gaussian_even_moment (using (k'+k')/2 = k' and k'+k' = 2k'), the odd branch k = 2k'+1 reduces to gaussian_odd_moment with the parity discharged by Nat.not_even_iff_odd.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^{k} e^{-x^2}\\,dx = \\begin{cases}(k-1)!!\\sqrt{\\pi}/2^{k/2} & k\\text{ even}\\\\ 0 & k\\text{ odd}\\end{cases}$"
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-05-oq-01-oq-01-oq-01",
+      "question": "Package the entire moment sequence into the Gaussian moment generating function ∫_ℝ e^{tx} e^{-x²} dx = √π·e^{t²/4}, recovering both the even moments (as the even Taylor coefficients) and the odd-moment vanishing (as the absence of odd-degree terms after completing the square) from one closed form.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Parent. Computed the even moments ∫ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ; this entry supplies the complementary odd moments (all zero) and assembles both into the full parity-indexed moment sequence gaussian_moment."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-05",
+      "relationship": "related",
+      "description": "Grandparent. The second moment ∫ x² e^{-x²} = √π/2 is the first nontrivial even moment; together with the vanishing first odd moment ∫ x e^{-x²} = 0 proved here it illustrates the even/odd dichotomy."
+    },
+    {
+      "targetId": "gaussian-integral",
+      "relationship": "related",
+      "description": "The Gaussian integral family. With the even moments already in the gallery, this entry's odd-moment vanishing completes the full moment table of the standard Gaussian weight."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Group.Integral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_neg_eq_self (the additive, negation-invariant form of integral_inv_eq_self) used to encode the odd symmetry."
+    },
+    {
+      "title": "Fourier Analysis",
+      "author": "Elias M. Stein and Rami Shakarchi",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "description": "Classical treatment of Gaussian moments and the odd-function symmetry that kills the odd ones."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For every n : ℕ the odd moment of the standard Gaussian weight vanishes, ∫_ℝ x^{2n+1} e^{-x²} dx = 0 (gaussian_odd_moment), by a pure symmetry argument: the integrand is odd and Lebesgue measure on ℝ is negation-invariant (integral_neg_eq_self), so the integral equals its own negation. Combined with the parent's even-moment closed form, this gives the full moment sequence ∫_ℝ x^k e^{-x²} dx = (k-1)‼·√π/2^{k/2} for even k and 0 for odd k (gaussian_moment). 98 lines, 3 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This completes the moment table of the standard Gaussian weight that the parent's even moments opened: every ∫ x^k e^{-x²} now has a machine-checked value, and the odd cases are handled uniformly by symmetry rather than computation. The key methodological point — that the vanishing is genuine cancellation of an integrable odd function, not a divergence artefact — is made explicit by deriving the result from the unconditional negation-invariance lemma.",
+    "openQuestions": [
+      "Package the entire moment sequence into the Gaussian moment generating function ∫_ℝ e^{tx} e^{-x²} = √π·e^{t²/4}, from which both the even moments and the odd-moment vanishing fall out by completing the square."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's open question (`area-of-circle-oq-07-oq-05-oq-01`): the **odd moments** of the standard Gaussian weight all vanish, and combined with the parent's even-moment closed form this yields the **full moment sequence**.

- `gaussian_odd_moment (n)`: `∫_ℝ x^{2n+1} e^{-x²} dx = 0` for every `n : ℕ`.
- `gaussian_moment (k)`: `∫_ℝ x^k e^{-x²} dx = if Even k then (k-1)‼·√π/2^{k/2} else 0` — the complete moment table in one parity-indexed statement.
- `gaussian_first_odd_moment`: the `n = 0` sanity check `∫_ℝ x e^{-x²} = 0`.

## Method

A pure **symmetry** argument, not a value computation. Writing `f x = x^{2n+1} e^{-x²}`:
- `f` is odd: `(-x)^{2n+1} = -(x^{2n+1})` (`Odd.neg_pow`) and `(-x)² = x²` (`neg_sq`);
- Lebesgue measure on `ℝ` is negation-invariant, so `∫ f(-x) = ∫ f` (`integral_neg_eq_self`);
- oddness rewrites the same integral as `∫ -f = -∫ f` (`integral_neg`);
- hence `∫ f = -∫ f`, forcing `∫ f = 0`.

No integrability hypothesis is needed — both Mathlib lemmas are unconditional — which makes explicit that the vanishing is genuine cancellation of an integrable function, not a divergence artefact. The full sequence case-splits on `Nat.even_or_odd`, the even branch reusing the parent's `gaussian_even_moment`.

## Verification

- **3 theorems, 98 lines, 0 definitions, 0 axioms, 0 sorries.**
- `#print axioms` for all three theorems: `[propext, Classical.choice, Quot.sound]` only.
- Built on host with Lean v4.26.0 / Mathlib (docker unavailable this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)