### PR TITLE
Enrich A Two-Sided Jordan-Decomposition Abel Trap for Alternating Series

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ast-oq010201-ann-header",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 39 },
+    "type": "context",
+    "title": "From a Symmetric Bound to an Asymmetric Two-Sided Trap",
+    "content": "The parent file AlternatingSeriesTestOQ01OQ02 controls the alternating block sum of an arbitrary real sequence by a SYMMETRIC absolute-value estimate |∑ (−1)ⁱ aᵢ| ≤ |a(M−1)| + (total variation). That proof throws away sign information twice: it bounds the sign partial sums by |∑(−1)ⁱ| ≤ 1, and it bounds each increment by |a(i+1) − a(i)|. This file recovers the lost sign information. The decisive upgrade is that the sign partial sums are not merely bounded in modulus but POSITIVE — they lie in the unit interval [0,1], being exactly 0 or 1. A multiplier B ∈ [0,1] sends a real x into the asymmetric order interval [min x 0, max x 0] rather than the symmetric [−|x|, |x|]. Feeding this positivity through Abel's transformation traps the canonical alternating sum between the positive and negative variations of the coefficient sequence SEPARATELY — its discrete Jordan decomposition — and absorbs the boundary term two-sidedly via max/min. The result answers the parent's first open question.",
+    "mathContext": "$0 \\le \\sum_{i<k}(-1)^i \\le 1 \\Rightarrow \\sum_{i<n}(-1)^i c_i \\in [\\min(c_{n-1},0) - V^+,\\ \\max(c_{n-1},0) + V^-]$",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation", "Dirichlet test", "Jordan decomposition", "total variation", "two-sided trap", "Leibniz bracket"],
+    "prerequisites": ["summation by parts", "the parent symmetric total-variation bound", "positive and negative parts of a real number"]
+  },
+  {
+    "id": "ast-oq010201-ann-signsum",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 45, "endLine": 55 },
+    "type": "technique",
+    "title": "Positivity of the Sign Partial Sums",
+    "content": "signSum_nonneg and signSum_le_one establish 0 ≤ ∑_{i<k} (−1)ⁱ ≤ 1. Both follow in one line from neg_one_geom_sum, which evaluates the finite geometric sum to 0 (even k) or 1 (odd k); a `split <;> norm_num` discharges each case. This is the single fact that distinguishes this entry from its parent: the parent only needs the modulus bound |∑(−1)ⁱ| ≤ 1, whereas the asymmetric trap needs the strictly stronger POSITIVITY ∑(−1)ⁱ ≥ 0. Membership in [0,1] (rather than [−1,1]) is exactly what makes the order-interval multiplier lemmas below produce a sign-aware, two-sided result.",
+    "mathContext": "$\\sum_{i<k}(-1)^i = \\begin{cases}0 & k\\text{ even}\\\\ 1 & k\\text{ odd}\\end{cases} \\in [0,1]$",
+    "significance": "key",
+    "relatedConcepts": ["neg_one_geom_sum", "finite geometric series", "parity", "Dirichlet boundedness"],
+    "prerequisites": ["finite geometric sums", "parity of natural numbers"]
+  },
+  {
+    "id": "ast-oq010201-ann-multiplier",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 70 },
+    "type": "technique",
+    "title": "Order-Interval Multiplier Lemmas",
+    "content": "mul_le_max and min_le_mul prove that for B ∈ [0,1], min x 0 ≤ x·B ≤ max x 0, each by a sign split on x. If x ≥ 0 then x·B ∈ [0, x]; if x < 0 then x·B ∈ [x, 0]. In both cases the product is trapped in the order interval [min x 0, max x 0]. This is the precise mechanism replacing the parent's symmetric |x·B| ≤ |x|: a multiplier confined to the UNIT interval (not just the unit ball) preserves and exploits the sign of x. The asymmetry of the eventual trap is inherited directly from the asymmetry of this order interval, which collapses to {0,x} endpoints rather than the symmetric ±|x|.",
+    "mathContext": "$B \\in [0,1] \\Rightarrow \\min(x,0) \\le x\\,B \\le \\max(x,0)$",
+    "significance": "key",
+    "relatedConcepts": ["order interval", "positive part", "negative part", "monotonicity of multiplication"],
+    "prerequisites": ["sign analysis", "ordered fields"]
+  },
+  {
+    "id": "ast-oq010201-ann-abel",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 72, "endLine": 86 },
+    "type": "theorem",
+    "title": "Abel Transformation of the Canonical Alternating Sum",
+    "content": "abel_sub_identity specialises Finset.sum_range_by_parts (summation by parts) to the sign sequence g_j = (−1)ʲ, whose partial sums are the signSums. It rewrites ∑_{i<n} (−1)ⁱ cᵢ as a boundary term c(n−1)·(∑_{i<n}(−1)ⁱ) minus a sum of increments (c(j+1) − c_j)·(∑_{i<j+1}(−1)ⁱ). Every factor multiplying a coefficient quantity is now a signSum lying in [0,1], so the order-interval multiplier lemmas apply term by term. A small `sum_congr … ring` normalises cᵢ·(−1)ⁱ to (−1)ⁱ·cᵢ to match the canonical orientation. This identity is the algebraic backbone shared by both halves of the trap.",
+    "mathContext": "$\\sum_{i<n}(-1)^i c_i = c_{n-1}\\,S_n - \\sum_{j<n-1}(c_{j+1}-c_j)\\,S_{j+1},\\quad S_k=\\sum_{i<k}(-1)^i$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_range_by_parts", "Abel transformation", "summation by parts", "telescoping structure"],
+    "prerequisites": ["summation by parts", "reindexing finite sums"]
+  },
+  {
+    "id": "ast-oq010201-ann-upper",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 111 },
+    "type": "theorem",
+    "title": "Upper Half: Boundary Positive Part plus Downward Variation",
+    "content": "alternating_range_le proves ∑_{i<n} (−1)ⁱ cᵢ ≤ max(c(n−1),0) + ∑_{j<n−1} max(c_j − c(j+1), 0). The boundary term is bounded by max(c(n−1),0) via mul_le_max. For the increment sum, each term (c(j+1) − c_j)·S(j+1) is paired with max(c_j − c(j+1), 0) and shown to sum to something nonnegative: rewriting (c(j+1) − c_j)·S = −(c_j − c(j+1))·S and applying mul_le_max to (c_j − c(j+1)) makes each paired term ≥ 0, so Finset.sum_add_distrib + sum_nonneg closes it. Only the DOWNWARD steps (where c decreases) contribute to the upper bound; no monotonicity is assumed.",
+    "mathContext": "$\\sum_{i<n}(-1)^i c_i \\le \\max(c_{n-1},0) + \\sum_{j<n-1}\\max(c_j - c_{j+1},\\,0)$",
+    "significance": "key",
+    "relatedConcepts": ["negative variation", "downward variation", "Finset.sum_add_distrib", "sum_nonneg"],
+    "prerequisites": ["the Abel identity", "order-interval multiplier lemmas"]
+  },
+  {
+    "id": "ast-oq010201-ann-lower",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 129 },
+    "type": "theorem",
+    "title": "Lower Half: Boundary Negative Part minus Upward Variation",
+    "content": "alternating_range_ge proves min(c(n−1),0) − ∑_{j<n−1} max(c(j+1) − c_j, 0) ≤ ∑_{i<n} (−1)ⁱ cᵢ. The boundary term is bounded below by min(c(n−1),0) via min_le_mul. The increment sum is bounded ABOVE termwise: each (c(j+1) − c_j)·S(j+1) ≤ max(c(j+1) − c_j, 0) by mul_le_max, so Finset.sum_le_sum lifts it to the upward variation. A single `linarith` combines the boundary and increment estimates. Only the UPWARD steps (where c increases) contribute to the lower bound — the mirror image of the upper half. Together with alternating_range_le this exhibits the full asymmetric trap.",
+    "mathContext": "$\\min(c_{n-1},0) - \\sum_{j<n-1}\\max(c_{j+1} - c_j,\\,0) \\le \\sum_{i<n}(-1)^i c_i$",
+    "significance": "key",
+    "relatedConcepts": ["positive variation", "upward variation", "Finset.sum_le_sum", "monotonicity of sums"],
+    "prerequisites": ["the Abel identity", "order-interval multiplier lemmas"]
+  },
+  {
+    "id": "ast-oq010201-ann-icc",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 131, "endLine": 137 },
+    "type": "insight",
+    "title": "Packaging the Two Halves as Interval Membership",
+    "content": "alternating_range_mem_Icc bundles alternating_range_ge and alternating_range_le into a single Set.Icc membership: the alternating sum lies in [min(c(n−1),0) − V⁺, max(c(n−1),0) + V⁻], where V⁺ is the upward variation and V⁻ the downward variation. This is the trap proper. The interval is asymmetric — its lower endpoint is governed entirely by the upward jumps and its upper endpoint entirely by the downward jumps — and it is strictly tighter than the parent's symmetric ±(|a(M−1)| + total variation) whenever the increments have mixed signs, because V⁺ + V⁻ = total variation but each half alone is smaller.",
+    "mathContext": "$\\sum_{i<n}(-1)^i c_i \\in \\mathrm{Icc}\\big(\\min(c_{n-1},0) - V^+,\\ \\max(c_{n-1},0) + V^-\\big)$",
+    "significance": "key",
+    "relatedConcepts": ["Set.Icc", "Jordan decomposition", "bounded variation", "interval trap"],
+    "prerequisites": ["the upper and lower half-bounds"]
+  },
+  {
+    "id": "ast-oq010201-ann-leibniz",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 168 },
+    "type": "insight",
+    "title": "Recovering the Classical Leibniz Bracket",
+    "content": "leibniz_bracket shows the asymmetric trap CONTAINS the textbook estimate. For antitone c ≥ 0, every upward step c(j+1) − c_j ≤ 0, so max(·,0) = 0 and the upward variation vanishes — the lower bound collapses to min(c(n−1),0) = 0. Every downward step c_j − c(j+1) ≥ 0, so the downward variation equals the genuine telescoping sum ∑(c_j − c(j+1)) = c_0 − c(n−1) (Finset.sum_range_sub'), which cancels the boundary max(c(n−1),0) = c(n−1) to leave c_0. Hence 0 ≤ ∑_{j<n} (−1)ʲ c_j ≤ c_0 — the classical Leibniz two-sided bracket, here exhibited as the special case of the asymmetric trap where one Jordan component vanishes and the other telescopes.",
+    "mathContext": "antitone $c \\ge 0:\\quad 0 \\le \\sum_{j<n}(-1)^j c_j \\le c_0$",
+    "significance": "key",
+    "relatedConcepts": ["Leibniz alternating series test", "telescoping sum", "Finset.sum_range_sub'", "specialisation"],
+    "prerequisites": ["the packaged trap", "antitone sequences"]
+  },
+  {
+    "id": "ast-oq010201-ann-partialsum",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 170, "endLine": 195 },
+    "type": "theorem",
+    "title": "Cauchy-Difference Form at an Even Truncation Point",
+    "content": "partialSum_diff_mem_Icc applies the trap to the partial-sum difference S_M − S_N. Writing S_k = ∑_{i<k} (−1)ⁱ aᵢ, for even N < M the difference reindexes from the block [N,M) to range(M−N) using Finset.sum_Ico_eq_sub and Finset.sum_Ico_eq_sum_range; the constant sign (−1)^N = 1 drops out (Even.neg_one_pow), so S_M − S_N = ∑_{j<M−N} (−1)ʲ a(N+j). Setting c j = a(N+j), the boundary index satisfies c(M−N−1) = a(M−1) (one `omega`), and alternating_range_mem_Icc applies verbatim. The boundary coefficient a(M−1) now enters two-sidedly via max/min, absorbing the parent's separate |a(M−1)| term — directly answering the parent's open question.",
+    "mathContext": "$N$ even, $N<M:\\quad S_M - S_N \\in \\mathrm{Icc}\\big(\\min(a_{M-1},0) - V^+,\\ \\max(a_{M-1},0) + V^-\\big)$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_Ico_eq_sub", "Even.neg_one_pow", "reindexing", "Cauchy difference", "boundary term absorption"],
+    "prerequisites": ["the packaged trap", "reindexing finite sums", "parity"]
+  }
+]

--- a/src/data/proofs/stern-brocot-tree-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "sbtoq0101-ann-overview",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 48 },
+    "type": "context",
+    "title": "Run-Lengths Are the Partial Quotients",
+    "content": "The module docstring states the classical Stern–Brocot / continued-fraction dictionary. A path `p : List Bool` of left (`false = L`) and right (`true = R`) moves labels the reduced positive rational `sbNum p / sbDen p`. Reading the path as alternating runs $R^{q_0} L^{q_1} R^{q_2}\\cdots$, the run-lengths $q_0, q_1, q_2, \\dots$ are exactly the partial quotients of the continued fraction of that rational. Mathlib v4.26 has no Stern–Brocot development, so the whole correspondence is built from scratch on top of the parent entry.",
+    "mathContext": "$\\dfrac{\\mathrm{sbNum}\\,p}{\\mathrm{sbDen}\\,p} = q_0 + \\cfrac{1}{q_1 + \\cfrac{1}{q_2 + \\cdots}}$ where $q_0, q_1, \\dots$ are the run-lengths of $p$.",
+    "significance": "context",
+    "relatedConcepts": ["Stern–Brocot tree", "continued fractions", "run-length encoding", "mediants"],
+    "prerequisites": ["rational numbers", "binary trees", "Euclidean algorithm"]
+  },
+  {
+    "id": "sbtoq0101-ann-rrun-transfer",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "technique",
+    "title": "R-Run Transfer: One Shear Iterated n Times",
+    "content": "Prepending a run of `n` consecutive `R`-moves leaves the denominator fixed (`sbDen_replicate_true`) and adds `n·den` to the numerator (`sbNum_replicate_true`). Both are proved by induction on the run-length `n`, each inductive step invoking the parent's single-step recurrences `sbDen_true_cons` / `sbNum_true_cons`. The key observation is that one `R`-move is a fixed shear map $(num, den) \\mapsto (num + den, den)$; applying it `n` times accumulates `n·den`, so no new invariant is needed — the closed form falls straight out of the parent's per-move lemmas.",
+    "mathContext": "An $R$-run of length $n$ acts as $\\begin{pmatrix} num \\\\ den \\end{pmatrix} \\mapsto \\begin{pmatrix} num + n\\,den \\\\ den \\end{pmatrix}$, i.e. the matrix $\\begin{pmatrix} 1 & n \\\\ 0 & 1 \\end{pmatrix}$ — the $n$-th power of the single-step shear $\\begin{pmatrix} 1 & 1 \\\\ 0 & 1 \\end{pmatrix}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["shear transformation", "unipotent matrices", "structural induction", "List.replicate"],
+    "prerequisites": ["mathematical induction", "matrix multiplication"]
+  },
+  {
+    "id": "sbtoq0101-ann-lrun-transfer",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 86 },
+    "type": "technique",
+    "title": "L-Run Transfer: The Dual Shear",
+    "content": "Symmetrically, a run of `n` consecutive `L`-moves leaves the numerator fixed (`sbNum_replicate_false`) and adds `n·num` to the denominator (`sbDen_replicate_false`). This is the transpose of the R-run shear and corresponds to the lower-triangular unipotent matrix. The L/R alternation between these two dual shears is precisely the alternation between 'add the integer part' and 'take a reciprocal' in the continued-fraction algorithm — the structural reason the run-lengths recover the partial quotients.",
+    "mathContext": "An $L$-run of length $n$ acts via $\\begin{pmatrix} 1 & 0 \\\\ n & 1 \\end{pmatrix}$, the lower-triangular transpose of the $R$-run matrix. Alternating $R$- and $L$-runs builds the product $\\begin{pmatrix} 1 & q_0 \\\\ 0 & 1 \\end{pmatrix}\\begin{pmatrix} 1 & 0 \\\\ q_1 & 1 \\end{pmatrix}\\cdots$ — the matrix model of $[q_0; q_1, q_2, \\dots]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["transpose", "SL₂(ℤ)", "continued-fraction matrices", "duality"],
+    "prerequisites": ["mathematical induction", "linear algebra"]
+  },
+  {
+    "id": "sbtoq0101-ann-assembler",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 106 },
+    "type": "definition",
+    "title": "Path Assembler and Matrix Convergent",
+    "content": "`runsToPathFrom b` builds a Stern–Brocot path from a list of run-lengths, alternating the move symbol and starting with move `b`; `runsToPath` fixes the start to an `R`-run. In parallel, `cfValFrom` computes the continued-fraction convergent `(num, den)` over `ℤ × ℤ` by performing the very same affine steps directly on an integer pair — the empty list evaluates to the root `(1, 1)`. Defining both by structurally identical recursions is what makes the main theorem an induction with no arithmetic friction.",
+    "mathContext": "`cfValFrom true [] = (1,1)` (the root $1/1$); for a leading $R$-run, $\\mathrm{cfValFrom}\\,\\mathrm{true}\\,(n::ns) = (v_1 + n\\,v_2,\\; v_2)$ where $(v_1,v_2) = \\mathrm{cfValFrom}\\,\\mathrm{false}\\,ns$ — exactly the $R$-run shear applied to the tail's convergent.",
+    "significance": "key",
+    "relatedConcepts": ["2×2 matrix model", "convergents", "recursive definitions", "mediant"],
+    "prerequisites": ["recursion on lists", "ordered pairs"]
+  },
+  {
+    "id": "sbtoq0101-ann-main",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 108, "endLine": 141 },
+    "type": "insight",
+    "title": "Main Theorem: Label Equals Convergent",
+    "content": "`sb_runs_eq_cfVal` is the heart of the entry: the Stern–Brocot label `(sbNum, sbDen)` of a run-structured path equals the continued-fraction convergent `cfValFrom` of its run-lengths. The proof is induction on the run-length list, generalizing over the starting move `b`. The nil case lands on the shared root via `sb_root`; each cons case rewrites with the matching run-transfer lemma (R or L) and the inductive hypothesis. The takeaway is conceptual: the Stern–Brocot fold and the 2×2 matrix-product model of continued fractions are *literally the same computation*, not merely numerically equal. `sbNum_runs` and `sbDen_runs` extract the two components.",
+    "mathContext": "$\\big(\\mathrm{sbNum}(\\mathrm{runsToPathFrom}\\,b\\,qs),\\ \\mathrm{sbDen}(\\mathrm{runsToPathFrom}\\,b\\,qs)\\big) = \\mathrm{cfValFrom}\\,b\\,qs$ for all $b$ and all run-length lists $qs$.",
+    "significance": "key",
+    "relatedConcepts": ["continued-fraction convergents", "structural induction", "matrix model", "Stern–Brocot labelling"],
+    "prerequisites": ["induction on lists", "generalizing the induction hypothesis"]
+  },
+  {
+    "id": "sbtoq0101-ann-positivity",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 151 },
+    "type": "technique",
+    "title": "Positivity Transported from the Parent",
+    "content": "Both components of every convergent are strictly positive (`cfVal_fst_pos`, `cfVal_snd_pos`). Rather than re-establishing a positivity invariant for the new `cfValFrom` recursion, the proof transports the parent's `sbNum_pos` / `sbDen_pos` across the main identity `sbNum_runs` / `sbDen_runs`. This is a clean example of reusing structural work: a property proved once for the Stern–Brocot label is inherited for free by anything shown equal to it.",
+    "mathContext": "$0 < (\\mathrm{cfValFrom}\\,b\\,qs).1$ and $0 < (\\mathrm{cfValFrom}\\,b\\,qs).2$, since these equal $\\mathrm{sbNum}$ and $\\mathrm{sbDen}$ of the run-path, both already proved $\\ge 1$ in the parent.",
+    "significance": "technical",
+    "relatedConcepts": ["invariant transport", "positivity", "code reuse"],
+    "prerequisites": ["order on integers"]
+  },
+  {
+    "id": "sbtoq0101-ann-recurrence-int",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 153, "endLine": 181 },
+    "type": "insight",
+    "title": "The Continued-Fraction Recurrence over ℚ",
+    "content": "Lifting from the integer pair to the rational value `cfQFrom = num/den`, two peeling lemmas expose the continued-fraction structure: `cfQFrom_true_cons` shows that stripping a leading `R`-run of length `n` adds the integer part `n + (tail value)`, while `cfQFrom_false_cons` shows that stripping a leading `L`-run produces a reciprocal `1/(n + 1/(tail value))`. The positivity results guarantee the denominators are nonzero so `field_simp` / `add_div'` / `one_div_div` can clear them. This pairing — add then reciprocate — is the exact rhythm of the regular continued-fraction algorithm.",
+    "mathContext": "$\\mathrm{cfQ}(\\mathrm{true}, n{::}ns) = n + \\mathrm{cfQ}(\\mathrm{false}, ns)$ and $\\mathrm{cfQ}(\\mathrm{false}, n{::}ns) = \\dfrac{1}{n + \\frac{1}{\\mathrm{cfQ}(\\mathrm{true}, ns)}}$.",
+    "significance": "key",
+    "relatedConcepts": ["regular continued fractions", "reciprocals", "field_simp", "rational arithmetic"],
+    "prerequisites": ["field of rationals", "nonzero denominators"]
+  },
+  {
+    "id": "sbtoq0101-ann-two-cons",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 183, "endLine": 187 },
+    "type": "insight",
+    "title": "Two Quotients Unfold the Regular Continued Fraction",
+    "content": "`cfQFrom_two_cons` composes the two peeling lemmas into the canonical regular-continued-fraction shape `q₀ + 1/(q₁ + 1/(rest))`. This is the precise formal sense in which the run-lengths *are* the partial quotients: each pair of consecutive run-lengths contributes one integer part and one nested reciprocal, exactly as in `[q₀; q₁, q₂, …]`.",
+    "mathContext": "$\\mathrm{cfQ}(\\mathrm{true}, a_0{::}a_1{::}rest) = a_0 + \\cfrac{1}{a_1 + \\cfrac{1}{\\mathrm{cfQ}(\\mathrm{true}, rest)}}$.",
+    "significance": "key",
+    "relatedConcepts": ["partial quotients", "continued-fraction notation", "recurrence composition"],
+    "prerequisites": ["continued fractions"]
+  },
+  {
+    "id": "sbtoq0101-ann-instances",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 189, "endLine": 207 },
+    "type": "concept",
+    "title": "Concrete Witnesses: Integers and Fibonacci Ratios",
+    "content": "Two axiom-free `decide`/`norm_num` instances anchor the abstract theorems. `runs_singleton`: a single `R`-run of length `n` labels the integer `n + 1`, i.e. the trivial continued fraction `[n+1]`. `cfVal_fib` / `cfQ_fib`: the all-ones run-lengths `[1,1,1]` produce `5/3` — a consecutive Fibonacci ratio. The all-ones expansion is the slowest-converging continued fraction, and its limit is the golden ratio $\\varphi$, the 'most irrational' number; this entry exhibits the start of that sequence as a kernel-checked computation (no `native_decide`, so no `ofReduceBool` dependency).",
+    "mathContext": "$[\\,n+1\\,] = n+1$; the all-ones list of length $k$ gives the Fibonacci ratio $F_{k+2}/F_{k+1}$, here $[1,1,1] \\mapsto 5/3$, with $F_{k+2}/F_{k+1} \\to \\varphi = \\tfrac{1+\\sqrt5}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "golden ratio", "kernel decidability", "worst-case continued fractions"],
+    "prerequisites": ["Fibonacci sequence", "decidable equality"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01-oq-02-oq-01`.

## Gap addressed
The entry shipped with a complete, rich `meta.json` but **no `annotations.json`** — so the proof page had zero inline annotations. This PR adds them.

## What was added
9 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Header** — from a symmetric bound to an asymmetric two-sided trap
2. **signSum positivity** — `0 ≤ ∑(-1)ⁱ ≤ 1`, the positivity refinement that powers the trap
3. **Order-interval multiplier lemmas** — `B ∈ [0,1] ⇒ min x 0 ≤ x·B ≤ max x 0`
4. **Abel transformation** — summation by parts specialised to the sign sequence
5. **Upper half** — boundary positive part + downward variation
6. **Lower half** — boundary negative part − upward variation
7. **Icc packaging** — the asymmetric trap proper
8. **Leibniz recovery** — classical bracket as the monotone special case
9. **Cauchy-difference form** — even-truncation partial-sum trap

## Verification
- `pnpm build` passes (data-enrichment step validates the JSON; full TS build green)
- Only `annotations.json` changed; `meta.json` was already complete and accurate (verified status/badge/axiomCount=0 match the Lean file)