### PR TITLE
research(arithmetic-series-oq-04-oq-02): generating functions for Bernoulli and power sums [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -235,6 +235,7 @@ import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02
 import Proofs.ArithmeticSeriesOQ04
 import Proofs.ArithmeticSeriesOQ04OQ01
+import Proofs.ArithmeticSeriesOQ04OQ02
 import Proofs.ArithmeticSeriesOQ04OQ03
 import Proofs.ArsinhLogFormulaOQ01
 import Proofs.ArsinhLogFormulaOQ01OQ01

--- a/proofs/Proofs/ArithmeticSeriesOQ04OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ04OQ02.lean
@@ -1,0 +1,163 @@
+import Mathlib
+
+/-
+# Arithmetic Series OQ-04 / OQ-02: Generating functions for Bernoulli and power sums
+
+## The Open Question (parent OQ-04, second open question)
+
+Faulhaber's formula (OQ-04) writes the power sum `∑_{k=1}^n k^p` as a polynomial in `n` with
+Bernoulli-number coefficients.  The engine behind it is the **exponential generating function**
+of the Bernoulli numbers:
+$$\sum_{n=0}^{\infty} B_n \frac{x^n}{n!} \;=\; \frac{x}{e^x - 1}.$$
+
+> **Can we formalize this generating-function identity for the Bernoulli sums in Lean 4?**
+
+## Answer
+
+**Yes.**  As a formal power series over `ℚ`, the identity reads
+`bernoulliPowerSeries ℚ * (exp ℚ - 1) = X`, which is Mathlib's
+`bernoulliPowerSeries_mul_exp_sub_one`.  We restate it as `bernoulli_egf` to record the direct
+answer.
+
+The interesting content of this leaf is to take that generating function and make the
+**Faulhaber bridge** completely explicit at the level of generating functions — a derivation that
+is *not* in Mathlib:
+
+* `powerSum_egf` / `powerSum_egf'` — the **exponential generating function of the power sums**
+  `S_p(n) = ∑_{k=0}^{n-1} k^p`:
+  $$\Big(\sum_{p=0}^{\infty} S_p(n)\,\tfrac{x^p}{p!}\Big)\,(e^x - 1) \;=\; e^{nx} - 1,
+    \qquad\text{i.e.}\qquad \sum_{p} S_p(n)\,\tfrac{x^p}{p!} = \frac{e^{nx}-1}{e^x-1}.$$
+  This is the geometric-series identity `(∑_{k<n} (e^x)^k)(e^x - 1) = (e^x)^n - 1` read off
+  coefficient-by-coefficient via Mathlib's `exp_pow_sum`.
+
+* `faulhaber_bernoulli_egf` — multiplying the power-sum generating function by `x` equals
+  `(e^{nx} - 1)` times the **Bernoulli** generating function:
+  $$\Big(\sum_p S_p(n)\,\tfrac{x^p}{p!}\Big)\,x \;=\; (e^{nx} - 1)\,\frac{x}{e^x-1}.$$
+  This is the precise generating-function statement of "power sums = Bernoulli sums": it follows
+  purely formally from the two product identities above, with no series inversion required (the
+  factor `e^x - 1` is shared, so it cancels at the level of products in the commutative ring of
+  power series).
+
+## Why this is not just an alias
+
+`bernoulliPowerSeries_mul_exp_sub_one` is the *Bernoulli* generating function.  The power-sum
+generating function and the bridge connecting the two are assembled here from Mathlib's
+`exp_pow_sum`, `geom_sum_mul`, `exp_pow_eq_rescale_exp`, and `coeff_rescale`; neither the
+power-sum EGF nor the bridge is a Mathlib lemma.  Concrete coefficients (`S_1(4) = 6`,
+`S_2(4)/2! = 7`) are checked to ground the abstraction.
+
+## Convention
+
+`S_p(n) := ∑_{k ∈ range n} k^p = 0^p + 1^p + ⋯ + (n-1)^p` (upper index exclusive), matching the
+`Finset.range` convention used by Mathlib's `sum_range_pow_eq_bernoulli_sub`.  In particular
+`0^0 = 1`, so `S_0(n) = n`.
+
+Tags: number-theory, generating-functions, bernoulli, power-sums, faulhaber, power-series
+-/
+
+noncomputable section
+
+open Finset BigOperators PowerSeries Nat
+
+namespace ArithmeticSeriesOQ04OQ02
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+  1. The Bernoulli generating function (the direct answer)
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **The exponential generating function of the Bernoulli numbers.**
+As a formal power series over `ℚ`,
+`(∑ B_n X^n / n!) · (exp - 1) = X`, i.e. `∑ B_n X^n/n! = X/(exp - 1)`.
+This is the formalization asked for by the open question; it is Mathlib's
+`bernoulliPowerSeries_mul_exp_sub_one`, restated here as the headline answer. -/
+theorem bernoulli_egf :
+    bernoulliPowerSeries ℚ * (PowerSeries.exp ℚ - 1) = (PowerSeries.X : PowerSeries ℚ) :=
+  bernoulliPowerSeries_mul_exp_sub_one ℚ
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+  2. The exponential generating function of the power sums S_p(n)
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- The power-sum power series `∑_p S_p(n) X^p/p!` equals the finite geometric sum
+`∑_{k<n} (exp)^k`. This is exactly Mathlib's `exp_pow_sum`, with the `algebraMap ℚ ℚ`
+simplified away. -/
+theorem powerSumSeries_eq_geom (n : ℕ) :
+    (PowerSeries.mk fun p => ∑ k ∈ Finset.range n, (k : ℚ) ^ p / p !)
+      = ∑ k ∈ Finset.range n, PowerSeries.exp ℚ ^ k := by
+  rw [PowerSeries.exp_pow_sum]
+  simp [div_eq_mul_inv]
+
+/-- **Exponential generating function of the power sums (product form).**
+`(∑_p S_p(n) X^p/p!) · (exp - 1) = exp^n - 1`. -/
+theorem powerSum_egf (n : ℕ) :
+    (PowerSeries.mk fun p => ∑ k ∈ Finset.range n, (k : ℚ) ^ p / p !) * (PowerSeries.exp ℚ - 1)
+      = PowerSeries.exp ℚ ^ n - 1 := by
+  rw [powerSumSeries_eq_geom]
+  exact geom_sum_mul (PowerSeries.exp ℚ) n
+
+/-- **Exponential generating function of the power sums (closed form).**
+`(∑_p S_p(n) X^p/p!) · (exp - 1) = (∑_p n^p X^p/p!) - 1`, i.e.
+`∑_p S_p(n) X^p/p! = (e^{nx} - 1)/(e^x - 1)`. -/
+theorem powerSum_egf' (n : ℕ) :
+    (PowerSeries.mk fun p => ∑ k ∈ Finset.range n, (k : ℚ) ^ p / p !) * (PowerSeries.exp ℚ - 1)
+      = (PowerSeries.mk fun p => (n : ℚ) ^ p / p !) - 1 := by
+  rw [powerSum_egf]
+  congr 1
+  ext p
+  rw [PowerSeries.exp_pow_eq_rescale_exp, PowerSeries.coeff_rescale, PowerSeries.coeff_exp,
+    PowerSeries.coeff_mk]
+  simp [div_eq_mul_inv]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+  3. The Faulhaber bridge: power sums = Bernoulli sums (generating-function form)
+═══════════════════════════════════════════════════════════════════════════════
+-/
+
+/-- **The Faulhaber bridge at the level of generating functions.**
+Multiplying the power-sum generating function by `X` equals `(e^{nx} - 1)` times the Bernoulli
+generating function:
+`(∑_p S_p(n) X^p/p!) · X = ((∑_p n^p X^p/p!) - 1) · (∑_m B_m X^m/m!)`.
+
+This is the precise statement that the power sums are "Bernoulli sums": it follows purely formally
+from `bernoulli_egf` and `powerSum_egf'` — the common factor `exp - 1` cancels at the level of
+products, so no power-series inversion is needed. -/
+theorem faulhaber_bernoulli_egf (n : ℕ) :
+    (PowerSeries.mk fun p => ∑ k ∈ Finset.range n, (k : ℚ) ^ p / p !) * PowerSeries.X
+      = ((PowerSeries.mk fun p => (n : ℚ) ^ p / p !) - 1) * bernoulliPowerSeries ℚ := by
+  have hB := bernoulli_egf
+  have hS := powerSum_egf' n
+  rw [← hB, ← hS]
+  ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+  4. Concrete coefficients (grounding the abstraction)
+═══════════════════════════════════════════════════════════════════════════════
+  The coefficient of X^p in the power-sum generating function is S_p(n)/p!.
+  For n = 4: S_1(4) = 0+1+2+3 = 6 and S_2(4) = 0+1+4+9 = 14, so the X^2 coefficient is 14/2 = 7.
+-/
+
+/-- The `X^1` coefficient of the power-sum series for `n = 4` is `S_1(4)/1! = 6`. -/
+theorem coeff_one_powerSum_four :
+    (PowerSeries.coeff (R := ℚ) 1) (PowerSeries.mk fun p => ∑ k ∈ Finset.range 4, (k : ℚ) ^ p / p !) = 6 := by
+  rw [PowerSeries.coeff_mk]
+  norm_num [Finset.sum_range_succ]
+
+/-- The `X^2` coefficient of the power-sum series for `n = 4` is `S_2(4)/2! = 14/2 = 7`. -/
+theorem coeff_two_powerSum_four :
+    (PowerSeries.coeff (R := ℚ) 2) (PowerSeries.mk fun p => ∑ k ∈ Finset.range 4, (k : ℚ) ^ p / p !) = 7 := by
+  rw [PowerSeries.coeff_mk]
+  norm_num [Finset.sum_range_succ]
+
+/-- `S_0(n) = n`: the constant-coefficient (`X^0`) power sum counts the terms. -/
+theorem coeff_zero_powerSum (n : ℕ) :
+    (PowerSeries.coeff (R := ℚ) 0) (PowerSeries.mk fun p => ∑ k ∈ Finset.range n, (k : ℚ) ^ p / p !) = n := by
+  rw [PowerSeries.coeff_mk]
+  simp
+
+end ArithmeticSeriesOQ04OQ02

--- a/src/data/proofs/arithmetic-series-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-bernoulli-egf",
+    "proofId": "arithmetic-series-oq-04-oq-02",
+    "range": { "startLine": 70, "endLine": 77 },
+    "type": "concept",
+    "title": "The Bernoulli Generating Function as a Formal Power Series",
+    "content": "The open question asks to formalize ∑ Bₙxⁿ/n! = x/(eˣ−1). Analytically this is a statement about a meromorphic function with a removable singularity at 0; formally it is far cleaner. In the ring of formal power series ℚ⟦X⟧, eˣ−1 has zero constant term and so is NOT invertible, so one does not literally divide by it. Instead the identity is stated as a product: `bernoulliPowerSeries ℚ * (exp ℚ - 1) = X`. This is Mathlib's `bernoulliPowerSeries_mul_exp_sub_one`; we restate it as `bernoulli_egf` to record the direct answer to the open question.",
+    "mathContext": "$$\\Big(\\sum_{n=0}^{\\infty} B_n \\frac{X^n}{n!}\\Big)\\,(e^X - 1) = X \\quad\\Longleftrightarrow\\quad \\sum_{n=0}^{\\infty} B_n \\frac{x^n}{n!} = \\frac{x}{e^x - 1}.$$",
+    "significance": "core",
+    "relatedConcepts": ["Bernoulli numbers", "exponential generating function", "formal power series", "non-units in a power series ring"],
+    "prerequisites": ["PowerSeries.exp", "bernoulliPowerSeries"]
+  },
+  {
+    "id": "ann-powersum-geom",
+    "proofId": "arithmetic-series-oq-04-oq-02",
+    "range": { "startLine": 85, "endLine": 103 },
+    "type": "insight",
+    "title": "Power Sums Are a Geometric Series of Exponentials",
+    "content": "The power-sum generating function ∑ₚ Sₚ(n) Xᵖ/p!, where Sₚ(n) = ∑_{k<n} kᵖ, is nothing but the finite geometric sum ∑_{k<n} (eˣ)ᵏ read coefficientwise. Mathlib's `exp_pow_sum` states exactly this: ∑_{k<n}(exp)ᵏ = mk(p ↦ ∑_{k<n} kᵖ/p!). Once the power-sum series is recognized as a geometric sum, multiplying by (exp − 1) telescopes via `geom_sum_mul` to expⁿ − 1. The reindexing in `powerSumSeries_eq_geom` only has to discharge the cosmetic `algebraMap ℚ ℚ` and the `a/b` vs `a·b⁻¹` mismatch (closed by `simp [div_eq_mul_inv]`).",
+    "mathContext": "$$\\sum_{p\\ge 0}\\Big(\\sum_{k<n} k^p\\Big)\\frac{X^p}{p!} = \\sum_{k<n}\\sum_{p\\ge 0}\\frac{(kX)^p}{p!} = \\sum_{k<n}(e^X)^k, \\qquad \\Big(\\sum_{k<n}(e^X)^k\\Big)(e^X-1) = (e^X)^n - 1.$$",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "telescoping", "exponential generating function", "power sums"],
+    "prerequisites": ["PowerSeries.exp_pow_sum", "geom_sum_mul"]
+  },
+  {
+    "id": "ann-powersum-egf-closed",
+    "proofId": "arithmetic-series-oq-04-oq-02",
+    "range": { "startLine": 105, "endLine": 116 },
+    "type": "concept",
+    "title": "Closed Form: (eⁿˣ − 1)/(eˣ − 1)",
+    "content": "Rewriting expⁿ − 1 in explicit coefficient form via `exp_pow_eq_rescale_exp` (which says (eˣ)ⁿ = e^{nx}) and `coeff_rescale` gives expⁿ = mk(p ↦ nᵖ/p!). Hence the power-sum generating function equals (∑ₚ nᵖXᵖ/p!) − 1, the formal-power-series incarnation of (eⁿˣ − 1)/(eˣ − 1) — exactly the generating function whose Taylor coefficients are the Faulhaber power-sum polynomials.",
+    "mathContext": "$$\\sum_{p\\ge 0} S_p(n)\\,\\frac{x^p}{p!} = \\frac{e^{nx}-1}{e^x-1}.$$",
+    "significance": "key",
+    "relatedConcepts": ["rescale", "Faulhaber's formula", "exponential generating function"],
+    "prerequisites": ["PowerSeries.exp_pow_eq_rescale_exp", "PowerSeries.coeff_rescale"]
+  },
+  {
+    "id": "ann-faulhaber-bridge",
+    "proofId": "arithmetic-series-oq-04-oq-02",
+    "range": { "startLine": 124, "endLine": 138 },
+    "type": "insight",
+    "title": "The Faulhaber↔Bernoulli Bridge by Cancelling a Non-Unit",
+    "content": "The headline original result: multiplying the power-sum generating function by X gives (eⁿˣ − 1) times the Bernoulli generating function. The proof is purely formal. We have two product identities sharing the factor (exp − 1): the Bernoulli one S_B·(exp−1) = X and the power-sum one S_n·(exp−1) = (E_n − 1). Substituting X = S_B·(exp−1) into S_n·X and reassociating gives S_n·X = (S_n·(exp−1))·S_B = (E_n − 1)·S_B. Crucially, although (exp − 1) is not invertible, the common factor cancels *as a product* in the commutative ring ℚ⟦X⟧, so a single `rw [← bernoulli_egf, ← powerSum_egf']; ring` closes it. This is the precise sense in which 'power sums are Bernoulli sums': ∑ₚ Sₚ(n)xᵖ/p! = (eⁿˣ − 1)·x/(eˣ − 1)·(1/x).",
+    "mathContext": "$$\\Big(\\sum_p S_p(n)\\tfrac{x^p}{p!}\\Big)\\,x = (e^{nx}-1)\\sum_{m\\ge 0} B_m\\tfrac{x^m}{m!} = (e^{nx}-1)\\cdot\\frac{x}{e^x-1}.$$",
+    "significance": "core",
+    "relatedConcepts": ["Faulhaber's formula", "Bernoulli numbers", "cancellation of non-units", "commutative power-series ring"],
+    "prerequisites": ["bernoulli_egf", "powerSum_egf'", "ring tactic over ℚ⟦X⟧"]
+  },
+  {
+    "id": "ann-concrete-coefficients",
+    "proofId": "arithmetic-series-oq-04-oq-02",
+    "range": { "startLine": 140, "endLine": 164 },
+    "type": "concept",
+    "title": "Grounding the Abstraction in Computable Coefficients",
+    "content": "To check the abstract generating functions describe the intended object, three coefficients are computed directly with `coeff_mk` followed by `norm_num`/`simp`: the X¹ coefficient for n=4 is S₁(4)/1! = 0+1+2+3 = 6; the X² coefficient is S₂(4)/2! = (0+1+4+9)/2 = 7; and the constant coefficient S₀(n) = ∑_{k<n} k⁰ = n (using 0⁰ = 1 in this Finset.range convention).",
+    "mathContext": "$$[X^1]\\sum_p S_p(4)\\tfrac{X^p}{p!} = \\frac{S_1(4)}{1!} = 6, \\qquad [X^2] = \\frac{S_2(4)}{2!} = \\frac{14}{2} = 7, \\qquad [X^0] = S_0(n) = n.$$",
+    "significance": "supporting",
+    "relatedConcepts": ["PowerSeries.coeff_mk", "0^0 = 1 convention", "sanity check"],
+    "prerequisites": ["PowerSeries.coeff_mk", "Finset.sum_range_succ"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-04-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-02/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "arithmetic-series-oq-04-oq-02",
+  "title": "Generating Functions for Bernoulli and Power Sums",
+  "slug": "arithmetic-series-oq-04-oq-02",
+  "description": "Formalizes the exponential generating function of the Bernoulli numbers (∑ Bₙxⁿ/n! = x/(eˣ−1)) and uses it to build the generating function of the power sums Sₚ(n) = ∑_{k<n} kᵖ and the explicit Faulhaber↔Bernoulli bridge connecting the two — all as formal power series over ℚ.",
+  "meta": {
+    "author": "Classical (Euler, Bernoulli); formalized in Lean 4",
+    "date": "1755",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ04OQ02.lean",
+    "tags": [
+      "number-theory",
+      "generating-functions",
+      "bernoulli",
+      "power-sums",
+      "faulhaber",
+      "power-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). No literal axiom declarations, no structure-encoded assumptions, 0 sorries, and no native_decide (so Lean.ofReduceBool is not used). The headline Bernoulli generating function bernoulli_egf is a restatement of Mathlib's bernoulliPowerSeries_mul_exp_sub_one; the power-sum generating function and the Faulhaber↔Bernoulli bridge are assembled here from Mathlib's exp_pow_sum, geom_sum_mul, exp_pow_eq_rescale_exp, and coeff_rescale.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "bernoulliPowerSeries_mul_exp_sub_one",
+        "description": "The exponential generating function of the Bernoulli numbers: bernoulliPowerSeries A * (exp A - 1) = X",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "PowerSeries.exp_pow_sum",
+        "description": "∑_{k<n} (exp)^k = mk (p ↦ ∑_{k<n} k^p / p!), the geometric sum of exponential power series read coefficientwise",
+        "module": "Mathlib.RingTheory.PowerSeries.WellKnown"
+      },
+      {
+        "theorem": "geom_sum_mul",
+        "description": "(∑_{i<n} x^i) * (x - 1) = x^n - 1 in a commutative ring",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "PowerSeries.exp_pow_eq_rescale_exp",
+        "description": "(exp A)^k = rescale k (exp A), i.e. (e^x)^k = e^{kx}",
+        "module": "Mathlib.RingTheory.PowerSeries.WellKnown"
+      },
+      {
+        "theorem": "PowerSeries.coeff_rescale",
+        "description": "coeff n (rescale a f) = a^n * coeff n f",
+        "module": "Mathlib.RingTheory.PowerSeries.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "**Open Question (arithmetic-series-oq-04, second open question)**: Faulhaber's formula (OQ-04) writes the power sum ∑_{k=1}^n kᵖ as a polynomial in n with Bernoulli-number coefficients. The engine behind it is the exponential generating function of the Bernoulli numbers:\n\n$$\\sum_{n=0}^{\\infty} B_n \\frac{x^n}{n!} = \\frac{x}{e^x - 1}.$$\n\n**Can we formalize this generating-function identity for the Bernoulli sums in Lean 4?**\n\n**Answer: YES.** As a formal power series over ℚ the identity reads `bernoulliPowerSeries ℚ * (exp ℚ - 1) = X` (Mathlib's `bernoulliPowerSeries_mul_exp_sub_one`). This entry restates it as the direct answer and then makes the Faulhaber bridge explicit at the generating-function level.",
+    "historicalContext": "The generating function x/(eˣ−1) is the defining property of the Bernoulli numbers Bₙ: Euler used it systematically in the 1750s, and it is the modern starting point for almost every Bernoulli-number identity. Multiplying through by eˣ−1 and comparing coefficients yields the classical recurrence ∑_{k<n} C(n,k)Bₖ = [n=1] that computes the Bₙ; expanding (eⁿˣ−1)/(eˣ−1) recovers Faulhaber's power-sum polynomials. The Bernoulli numbers in turn appear in the Euler–Maclaurin formula, the Taylor series of tan and cot, the values ζ(−n) = −B_{n+1}/(n+1) of the Riemann zeta function, and the Todd class in algebraic geometry.",
+    "keyInsights": [
+      "The literal open question — the Bernoulli generating function ∑ Bₙxⁿ/n! = x/(eˣ−1) — is exactly Mathlib's `bernoulliPowerSeries_mul_exp_sub_one`, here recorded as `bernoulli_egf`.",
+      "The exponential generating function of the power sums Sₚ(n) = ∑_{k<n} kᵖ is just the finite geometric series ∑_{k<n}(eˣ)ᵏ read coefficientwise: by `exp_pow_sum` its X^p coefficient is ∑_{k<n} kᵖ/p!. Multiplying by (eˣ−1) telescopes to eⁿˣ−1 via `geom_sum_mul`, giving ∑ₚ Sₚ(n) xᵖ/p! = (eⁿˣ−1)/(eˣ−1).",
+      "The Faulhaber bridge `faulhaber_bernoulli_egf` — (∑ₚ Sₚ(n)xᵖ/p!)·x = (eⁿˣ−1)·(∑ Bₘxᵐ/m!) — follows purely formally from the two product identities: the shared factor eˣ−1 cancels at the level of products in the commutative ring of power series, so no series inversion is needed.",
+      "Working in formal power series over ℚ avoids all analytic convergence issues; `exp ℚ`, `rescale`, and `bernoulliPowerSeries` are Mathlib's algebraic surrogates for eˣ, e^{cx}, and the Bernoulli generating function.",
+      "Concrete coefficient checks (S₁(4)=6, S₂(4)/2!=7, S₀(n)=n) ground the abstract power-series identities in computable rational values."
+    ],
+    "significance": "Provides the generating-function foundation underneath the Faulhaber/Bernoulli circle of problems (OQ-04 and its siblings OQ-01 on higher power sums and OQ-03 on ζ at negative integers), and contributes a power-sum generating function and an explicit Faulhaber↔Bernoulli bridge that are not present in Mathlib."
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset", "BigOperators", "PowerSeries", "Nat"],
+    "namespace": "ArithmeticSeriesOQ04OQ02",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/ArithmeticSeriesOQ04OQ02.lean",
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "bernoulli_egf",
+        "type": "core",
+        "description": "The Bernoulli exponential generating function (the direct answer): (∑ Bₙ Xⁿ/n!)·(exp − 1) = X, i.e. ∑ Bₙ Xⁿ/n! = X/(exp − 1).",
+        "leanType": "bernoulliPowerSeries ℚ * (PowerSeries.exp ℚ - 1) = PowerSeries.X"
+      },
+      {
+        "name": "powerSum_egf'",
+        "type": "core",
+        "description": "Exponential generating function of the power sums Sₚ(n) = ∑_{k<n} kᵖ, closed form: (∑ₚ Sₚ(n)Xᵖ/p!)·(exp − 1) = (∑ₚ nᵖXᵖ/p!) − 1, i.e. ∑ₚ Sₚ(n)xᵖ/p! = (eⁿˣ − 1)/(eˣ − 1).",
+        "leanType": "(n : ℕ) → (mk fun p => ∑ k ∈ range n, (k:ℚ)^p / p!) * (exp ℚ - 1) = (mk fun p => (n:ℚ)^p / p!) - 1"
+      },
+      {
+        "name": "faulhaber_bernoulli_egf",
+        "type": "key",
+        "description": "The Faulhaber↔Bernoulli bridge at the generating-function level: multiplying the power-sum generating function by X equals (eⁿˣ − 1) times the Bernoulli generating function — the precise sense in which power sums are 'Bernoulli sums'.",
+        "leanType": "(n : ℕ) → (mk fun p => ∑ k ∈ range n, (k:ℚ)^p / p!) * X = ((mk fun p => (n:ℚ)^p / p!) - 1) * bernoulliPowerSeries ℚ"
+      },
+      {
+        "name": "powerSum_egf",
+        "type": "supporting",
+        "description": "Product form of the power-sum generating function: (∑ₚ Sₚ(n)Xᵖ/p!)·(exp − 1) = expⁿ − 1, obtained from the geometric series ∑_{k<n} expᵏ.",
+        "leanType": "(n : ℕ) → (mk fun p => ∑ k ∈ range n, (k:ℚ)^p / p!) * (exp ℚ - 1) = exp ℚ ^ n - 1"
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "Mathlib4: Mathlib.NumberTheory.Bernoulli",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/Bernoulli.html",
+      "description": "Definitions of bernoulli/bernoulli' and the generating function bernoulliPowerSeries_mul_exp_sub_one."
+    },
+    {
+      "title": "Mathlib4: Mathlib.RingTheory.PowerSeries.WellKnown",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/PowerSeries/WellKnown.html",
+      "description": "PowerSeries.exp, rescale, exp_pow_eq_rescale_exp, and exp_pow_sum."
+    },
+    {
+      "title": "Concrete Mathematics (Graham, Knuth, Patashnik), §6.5 / §7",
+      "url": "https://en.wikipedia.org/wiki/Faulhaber%27s_formula",
+      "description": "Generating-function derivation of Faulhaber's formula from x/(eˣ−1)."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of parent `arithmetic-series-oq-04` (Faulhaber's formula): *formalize the Bernoulli exponential generating function* `∑ Bₙxⁿ/n! = x/(eˣ−1)` in Lean 4.

**Answer: YES** — as a formal power series over ℚ. The literal identity is Mathlib's `bernoulliPowerSeries_mul_exp_sub_one` (restated as `bernoulli_egf`); the original content is the power-sum generating function and the explicit Faulhaber↔Bernoulli bridge built on top of it, neither of which is in Mathlib.

## Theorems (8 total, 0 defs, 163 lines)

- **`bernoulli_egf`** — the direct answer: `bernoulliPowerSeries ℚ * (exp ℚ − 1) = X`.
- **`powerSum_egf` / `powerSum_egf'`** — exponential generating function of the power sums `Sₚ(n) = ∑_{k<n} kᵖ`:
  `(∑ₚ Sₚ(n)Xᵖ/p!)·(exp−1) = expⁿ − 1 = (∑ₚ nᵖXᵖ/p!) − 1`, i.e. `∑ₚ Sₚ(n)xᵖ/p! = (eⁿˣ−1)/(eˣ−1)`.
  Recognizes the power-sum series as the geometric sum `∑_{k<n}(eˣ)ᵏ` (`exp_pow_sum`) and telescopes via `geom_sum_mul`.
- **`faulhaber_bernoulli_egf`** — the Faulhaber↔Bernoulli bridge:
  `(∑ₚ Sₚ(n)xᵖ/p!)·x = (eⁿˣ−1)·(∑ₘ Bₘxᵐ/m!)`. Follows purely formally — the shared factor `(eˣ−1)` cancels *as a product* in the commutative ring ℚ⟦X⟧, so no power-series inversion is needed (`rw [← bernoulli_egf, ← powerSum_egf']; ring`).
- Concrete coefficient checks grounding the abstraction: `S₁(4)=6`, `S₂(4)/2!=7`, `S₀(n)=n`.

## Verification

- Builds against Mathlib v4.26.0 (single-file `lake env lean`, Docker unavailable this cycle).
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms faulhaber_bernoulli_egf` / `powerSum_egf'` → `[propext, Classical.choice, Quot.sound]` only — genuinely 0-axiom.
- Status `verified`, badge `original`.

Mathlib engines: `bernoulliPowerSeries_mul_exp_sub_one`, `PowerSeries.exp_pow_sum`, `geom_sum_mul`, `PowerSeries.exp_pow_eq_rescale_exp`, `PowerSeries.coeff_rescale`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)