### PR TITLE
Enrich Scaled Even Moment of the Gaussian

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "aoc-oq07050102-ann-header",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+    "range": { "startLine": 5, "endLine": 37 },
+    "type": "context",
+    "title": "Scaling the Gaussian Even Moments by Change of Variables",
+    "content": "The parent entry area-of-circle-oq-07-oq-05-oq-01 evaluated the UNSCALED even moment ∫_ℝ x^{2n} e^{-x²} = (2n−1)‼·√π/2ⁿ by an integration-by-parts induction on n. This file lifts that single family to ALL scales a > 0 without re-running any analysis: it uses one linear change of variables x ↦ √a·x. Writing s = √a (so s² = a), the dilated unscaled integrand g(s·x) = (s·x)^{2n} e^{−(s·x)²} equals aⁿ·x^{2n} e^{−a x²}, so the dilation rule trades the parent's value for the scaled one and the moment of order 2n picks up exactly the factor a^{−(n+1/2)} = √(π/a)/(2a)ⁿ ÷ ((2n−1)‼√π). The strategy isolates the purely algebraic effect of dilating a Gaussian from the analytic work, which lives entirely in the parent.",
+    "mathContext": "$\\int_{\\mathbb R} x^{2n} e^{-a x^2}\\,dx = (2n-1)!!\\,\\dfrac{\\sqrt{\\pi/a}}{(2a)^n},\\quad a>0$",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian integral", "change of variables", "dilation", "double factorial", "even moments"],
+    "prerequisites": ["the unscaled parent even moment", "linear change of variables for Lebesgue integrals"]
+  },
+  {
+    "id": "aoc-oq07050102-ann-integrable",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+    "range": { "startLine": 44, "endLine": 52 },
+    "type": "technique",
+    "title": "Integrability of the Scaled Integrand",
+    "content": "integrable_pow_mul_scaled_gaussian establishes that x^{2n} e^{−a x²} is integrable over ℝ for a > 0. It specialises Mathlib's integrable_rpow_mul_exp_neg_mul_sq (x^s e^{−b x²} integrable for b > 0, s > −1) at s = 2n and b = a, then transports the real-power x^{(2n:ℝ)} statement to the natural-power x^{2n} pointwise via Real.rpow_natCast. The side goal s > −1 reduces to 2n ≥ 0, discharged by Nat.cast_nonneg + linarith. Integrability is the standing hypothesis that makes the change-of-variables manipulations of the integral valid.",
+    "mathContext": "$x^{2n} e^{-a x^2} \\in L^1(\\mathbb R)$ for $a>0$",
+    "significance": "supporting",
+    "relatedConcepts": ["integrable_rpow_mul_exp_neg_mul_sq", "Gaussian decay", "Real.rpow_natCast", "Lebesgue integrability"],
+    "prerequisites": ["integrability of Gaussian-type integrands", "real vs natural powers"]
+  },
+  {
+    "id": "aoc-oq07050102-ann-main",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+    "range": { "startLine": 54, "endLine": 100 },
+    "type": "theorem",
+    "title": "The Scaled Even Moment via the Dilation Rule",
+    "content": "scaled_gaussian_even_moment is the headline result. Set s = √a (s > 0, s² = a) and let g y = y^{2n} e^{−y²} be the unscaled integrand. Mathlib's dilation rule Measure.integral_comp_mul_left gives ∫ g(s·x) = |s⁻¹| · ∫ g. Two pointwise identities — (s·x)^{2n} = aⁿ x^{2n} (mul_pow + pow_mul + Real.sq_sqrt) and −(s·x)² = −a x² — show g(s·x) = aⁿ·(x^{2n} e^{−a x²}), so the left side is aⁿ·I where I is the target integral. The right side is s⁻¹·(parent value) via AreaOfCircleOQ07OQ05OQ01.gaussian_even_moment. Equating and solving aⁿ·I = s⁻¹·(2n−1)‼√π/2ⁿ with field_simp + linarith gives I; final √-bookkeeping (Real.sqrt_div: √(π/a) = √π/√a, and (2a)ⁿ = 2ⁿaⁿ) matches the stated closed form.",
+    "mathContext": "$a^n\\!\\int x^{2n}e^{-a x^2} = s^{-1}\\,(2n-1)!!\\dfrac{\\sqrt\\pi}{2^n},\\ s=\\sqrt a \\Rightarrow \\int x^{2n}e^{-a x^2}=(2n-1)!!\\dfrac{\\sqrt{\\pi/a}}{(2a)^n}$",
+    "significance": "key",
+    "relatedConcepts": ["Measure.integral_comp_mul_left", "Real.sq_sqrt", "Real.sqrt_div", "Jacobian", "summation by parts (parent)"],
+    "prerequisites": ["the integrability lemma", "the parent unscaled moment", "square-root algebra"]
+  },
+  {
+    "id": "aoc-oq07050102-ann-checks",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 117 },
+    "type": "insight",
+    "title": "Consistency Checks: Unscaled Case and Second Moment",
+    "content": "Two sanity-check corollaries confirm the closed form. scaled_gaussian_even_moment_one specialises a = 1 and recovers the parent's unscaled moment ∫ x^{2n} e^{−x²} = (2n−1)‼√π/2ⁿ verbatim, verifying the dilation introduced no spurious scale factor. scaled_gaussian_second_moment takes n = 1: since (2·1−1)‼ = 1‼ = 1, the formula collapses to ∫ x² e^{−a x²} = √(π/a)/(2a). This is exactly TWICE the half-line value √(π/a)/(4a) of sibling area-of-circle-oq-07-oq-02-oq-02 — the even-symmetry doubling of the (0,∞) half made explicit.",
+    "mathContext": "$\\int_{\\mathbb R} x^2 e^{-a x^2} = \\dfrac{\\sqrt{\\pi/a}}{2a} = 2\\cdot\\dfrac{\\sqrt{\\pi/a}}{4a}$ (half-line)",
+    "significance": "supporting",
+    "relatedConcepts": ["double factorial", "even symmetry", "half-line moments", "specialisation"],
+    "prerequisites": ["the scaled even-moment formula", "the half-line sibling entry"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-01-oq-02/meta.json
@@ -20,6 +20,58 @@
     "sorries": 0
   },
   "title": "The Scaled Even Moment of the Gaussian ∫ x^{2n} e^{-a x²} = (2n-1)‼·√(π/a) / (2a)ⁿ",
+  "description": "Lifts the parent entry's unscaled Gaussian even moment ∫_ℝ x^{2n} e^{-x²} = (2n−1)‼·√π/2ⁿ to every scale a > 0 by a single linear change of variables x ↦ √a·x. Mathlib's dilation rule MeasureTheory.Measure.integral_comp_mul_left applied to the unscaled integrand turns the parent value directly into the closed form ∫_ℝ x^{2n} e^{-a x²} = (2n−1)‼·√(π/a)/(2a)ⁿ, so the moment of order 2n acquires exactly the scale factor a^{-(n+1/2)} with no further analysis. Includes two consistency checks: a = 1 recovers the parent moment, and the n = 1 second moment √(π/a)/(2a) is twice the half-line sibling value √(π/a)/(4a) by even symmetry. Verified, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^{-x²} = √π and its polynomial-weighted relatives (the even moments) are the analytic backbone of the normal distribution, the heat kernel, and Hermite-polynomial theory. The even moments of the standard weight e^{-x²} are the double factorials times √π: ∫ x^{2n} e^{-x²} = (2n−1)‼·√π/2ⁿ, with the odd moments vanishing by symmetry. In probability the scaled weight e^{-a x²} corresponds to a centred Gaussian of variance 1/(2a); its even moments encode the moment sequence of that distribution, and their generating function is the Gaussian's Laplace/Fourier transform. The classical route evaluates each scaled moment afresh by integration by parts; the dilation viewpoint used here recognises that all scales are a single orbit of the change of variables x ↦ √a·x acting on one master integral.",
+    "problemStatement": "Open question of the parent entry area-of-circle-oq-07-oq-05-oq-01: generalize the unscaled even moment to the scaled Gaussian, proving ∫_ℝ x^{2n} e^{-a x²} dx = (2n−1)‼·√(π/a)/(2a)ⁿ for every n : ℕ and every a > 0.",
+    "proofStrategy": "Reduce the scaled moment to the parent's unscaled moment by one linear change of variables. Set s = √a (so s > 0, s² = a) and g y = y^{2n} e^{-y²}. Mathlib's dilation rule Measure.integral_comp_mul_left gives ∫ g(s·x) = |s⁻¹| · ∫ g. Pointwise, g(s·x) = aⁿ·(x^{2n} e^{-a x²}) because (s·x)^{2n} = aⁿ x^{2n} and (s·x)² = a x², so the left side is aⁿ·I with I the target integral and the right side is s⁻¹ times the parent value (2n−1)‼√π/2ⁿ. Solving aⁿ·I = s⁻¹·(parent value) and simplifying √(π/a) = √π/√a and (2a)ⁿ = 2ⁿaⁿ yields the closed form. Integrability of the scaled integrand comes from integrable_rpow_mul_exp_neg_mul_sq.",
+    "keyInsights": [
+      "All scaled Gaussian even moments lie on a single orbit of the dilation x ↦ √a·x acting on the one unscaled master integral — so they need no separate analysis, only a change of variables",
+      "The dilation rule's Jacobian |s⁻¹| = 1/√a supplies precisely the missing half-power: the integrand contributes aⁿ and the Jacobian contributes a^{-1/2}, combining to the scale factor a^{-(n+1/2)} = √(π/a)/(2a)ⁿ ÷ ((2n−1)‼√π)",
+      "Separating analytic content (the parent's integration-by-parts induction) from algebraic content (this entry's scaling) makes every scaled moment machine-checked for free from the a = 1 case",
+      "The second moment √(π/a)/(2a) is exactly twice the half-line value √(π/a)/(4a), exhibiting the even-symmetry doubling of the (0,∞) integral concretely"
+    ],
+    "prerequisites": [
+      "The unscaled parent even moment ∫ x^{2n} e^{-x²} = (2n−1)‼·√π/2ⁿ",
+      "The dilation rule for Lebesgue integrals on ℝ (change of variables x ↦ a·x)",
+      "Integrability of Gaussian-type integrands x^s e^{-b x²}",
+      "Square-root and power algebra: √(x/y) = √x/√y, (√a)² = a"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Scaling the Gaussian Even Moments",
+      "startLine": 5,
+      "endLine": 37,
+      "summary": "Statement of the open question and the strategy: lift the parent's unscaled even moment to all scales a > 0 by the single change of variables x ↦ √a·x, with the dilation rule supplying the scale factor and no further analysis.",
+      "mathContext": "$\\int_{\\mathbb R} x^{2n} e^{-a x^2} = (2n-1)!!\\,\\dfrac{\\sqrt{\\pi/a}}{(2a)^n}$"
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability of the Scaled Integrand",
+      "startLine": 44,
+      "endLine": 52,
+      "summary": "integrable_pow_mul_scaled_gaussian: x^{2n} e^{-a x²} is integrable over ℝ for a > 0, specialising integrable_rpow_mul_exp_neg_mul_sq at s = 2n, b = a and transporting from real to natural powers.",
+      "mathContext": "$x^{2n} e^{-a x^2} \\in L^1(\\mathbb R),\\ a>0$"
+    },
+    {
+      "id": "main-moment",
+      "title": "The Scaled Even Moment via Dilation",
+      "startLine": 54,
+      "endLine": 100,
+      "summary": "scaled_gaussian_even_moment: the headline closed form, proved by applying Measure.integral_comp_mul_left to the unscaled integrand, identifying g(√a·x) = aⁿ·(x^{2n} e^{-a x²}), substituting the parent value, and finishing with √/power bookkeeping.",
+      "mathContext": "$\\int x^{2n} e^{-a x^2} = (2n-1)!!\\,\\dfrac{\\sqrt{\\pi/a}}{(2a)^n}$"
+    },
+    {
+      "id": "consistency-checks",
+      "title": "Consistency Checks",
+      "startLine": 102,
+      "endLine": 117,
+      "summary": "scaled_gaussian_even_moment_one recovers the parent's a = 1 moment; scaled_gaussian_second_moment gives ∫ x² e^{-a x²} = √(π/a)/(2a), twice the half-line sibling value by even symmetry.",
+      "mathContext": "$\\int_{\\mathbb R} x^2 e^{-a x^2} = \\dfrac{\\sqrt{\\pi/a}}{2a}$"
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05-oq-01-oq-02`.

## Gaps addressed
The entry shipped with a rich `meta` block and `conclusion` but was **missing `annotations.json`, `overview`, `sections`, and a top-level `description`** — so the proof page had no inline annotations, no overview panel, and no section navigation.

## What was added
- **`annotations.json`** — 4 annotations (header / change-of-variables strategy, integrability lemma, the main dilation theorem, consistency checks), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`
- **`overview`** — `historicalContext` (Gaussian moments, normal distribution, dilation-as-orbit framing), `problemStatement`, `proofStrategy`, 4 `keyInsights`, `prerequisites`
- **`description`** — top-level summary of the result and method
- **`sections`** — 4 sections covering the full 119-line Lean file

## Verification
- `pnpm build` passes (data-enrichment validation + full TS build green)
- Axiom integrity: `status: verified`, `axiomCount: 0`, `sorries: 0` confirmed consistent with the Lean file (#print axioms reports only propext/Classical.choice/Quot.sound)