### PR TITLE
audit: clear 9 unaudited research leaves — all clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21849,6 +21849,60 @@
       "lastAudited": "2026-06-24T16:48:32Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-07-oq-05-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-00-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-14-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "beta-integral-recurrence-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-04-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-17-oq-03-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lhopital-oq-02-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T17:06:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 9 never-audited gallery leaves. All public claims verified against Lean source: **0 real sorries, 0 axiom declarations, 0 True stubs, no native_decide.** Coverage 3519 → 3528 (full).

| Slug | Badge | Verdict |
|------|-------|---------|
| area-of-circle-oq-07-oq-05-oq-01-oq-02 | mathlib | ✅ correct — Tier B (Mathlib dilation rule does core work, lift disclosed) |
| arithmetic-series-oq-00-oq-02-oq-02 | original | ✅ self-contained Faulhaber recurrence, no Mathlib deps |
| arithmetic-series-oq-04-oq-02 | original | ✅ Mathlib headline restatement **fully disclosed** in `assumptions`; original work = power-sum EGF + Faulhaber bridge |
| basel-problem-oq-14-oq-01 | original | ✅ parity-split eta abstraction; ζ closed-forms credited to Mathlib |
| beta-integral-recurrence-oq-01-oq-01 | original | ✅ combinatorial collapse to central-binomial reciprocal |
| binomial-theorem-oq-04-oq-02-oq-03 | original | ✅ Vandermonde sum-of-squares; deps disclosed |
| geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01 | original | ✅ lone `sorry` grep hit is a docstring word ("sorry-free") |
| hilbert-17-oq-03-oq-05 | original | ✅ elementary 0-axiom sharp PSD threshold |
| lhopital-oq-02-incomplete-01 | original | ✅ claims accurate; **minor**: top-level `leanFile` metadata block is null (file `LHopitalOQ02Incomplete01.lean` exists, 0 sorry/0 axiom) — completeness gap, not an overstatement |

No overstatements found. The one `mathlib`-badged entry correctly avoids "original" wording, and the `original`-badged entries disclose their Mathlib dependencies and scope their contributions accurately.

Tracker-only change (`src/data/proofs/audit-tracker.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)