### PR TITLE
Enrich Two-Sided Jordan-Decomposition Abel Trap for Alternating Series

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 39 },
+    "type": "context",
+    "title": "From a Symmetric Bound to a Two-Sided Trap",
+    "content": "The parent entry bounds the alternating block sum of an arbitrary real sequence by |a(M−1)| + (total variation), throwing away sign information twice — once by |∑(−1)ⁱ| ≤ 1, once by |a(i+1)−a(i)|. This file sharpens that to a genuinely two-sided, asymmetric trap. The pivotal observation: the sign partial sums are not just bounded in absolute value, they lie in [0,1] (they are exactly 0 or 1). A multiplier B ∈ [0,1] therefore sends x into the order interval [min x 0, max x 0] rather than the symmetric [−|x|, |x|]. Pushed through Abel's summation by parts, this traps ∑(−1)ʲcⱼ between the downward and upward variations of c separately — its Jordan decomposition — with the boundary coefficient entering two-sidedly. The trap is strictly tighter than the parent's symmetric bound whenever the increments change sign, and it contains the classical Leibniz bracket as the antitone special case.",
+    "mathContext": "$0 \\le \\sum_{i<k}(-1)^i \\le 1$, so $B\\in[0,1] \\Rightarrow xB \\in [\\min(x,0),\\max(x,0)]$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "summation by parts",
+      "Abel/Dirichlet test",
+      "bounded variation",
+      "Jordan decomposition",
+      "Leibniz alternating series"
+    ],
+    "prerequisites": [
+      "the parent symmetric Abel bound (alternating-series-test-oq-01-oq-02)",
+      "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-signsum",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 45, "endLine": 55 },
+    "type": "technique",
+    "title": "The Sign Partial Sums Lie in [0,1]",
+    "content": "signSum_nonneg and signSum_le_one: the partial sums ∑_{i<k} (−1)ⁱ are bounded between 0 and 1. Mathlib's neg_one_geom_sum gives the closed form (it is 0 when k is even, 1 when k is odd), so each bound reduces to a split-and-norm_num. This positivity — not merely |·| ≤ 1 — is the entire reason the resulting trap is asymmetric: it is what distinguishes the order interval [min x 0, max x 0] from the symmetric [−|x|, |x|] the parent used.",
+    "mathContext": "$\\sum_{i<k}(-1)^i = \\begin{cases} 0 & k \\text{ even} \\\\ 1 & k \\text{ odd} \\end{cases} \\in [0,1].$",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric sum",
+      "neg_one_geom_sum",
+      "sign sequence partial sums"
+    ],
+    "prerequisites": [
+      "finite geometric series"
+    ]
+  },
+  {
+    "id": "ann-multiplier",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 76 },
+    "type": "insight",
+    "title": "Order-Interval Multiplier Lemmas",
+    "content": "mul_le_max and min_le_mul: for B ∈ [0,1], the product x·B is trapped in the order interval [min x 0, max x 0]. The proofs case-split on the sign of x: if x ≥ 0 then 0 ≤ x·B ≤ x; if x < 0 then x ≤ x·B ≤ 0. This is the mechanism that replaces the parent's symmetric estimate |x·B| ≤ |x| — by keeping the sign of x, a positive multiplier can only shrink x toward 0, never flip it. Applying it to the boundary term and to each increment is what produces the one-sided (downward vs upward) variation bounds.",
+    "mathContext": "$B\\in[0,1] \\ \\Rightarrow\\ \\min(x,0) \\le x\\,B \\le \\max(x,0).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "order interval",
+      "sign-preserving multiplication",
+      "case analysis on sign"
+    ],
+    "prerequisites": [
+      "the sign-sum bounds in [0,1]",
+      "elementary real inequalities (nlinarith)"
+    ]
+  },
+  {
+    "id": "ann-abel",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 72, "endLine": 91 },
+    "type": "technique",
+    "title": "Abel's Summation by Parts",
+    "content": "abel_sub_identity specializes Mathlib's Finset.sum_range_by_parts to the sign sequence g(j) = (−1)ʲ, whose partial sums are the signSums. It rewrites ∑_{i<n}(−1)ⁱcᵢ as a boundary term c(n−1)·(∑(−1)ⁱ) minus a sum of increments (c(j+1)−c(j)) weighted by the sign partial sums ∑_{i<j+1}(−1)ⁱ. This is the structural rearrangement that exposes both the boundary coefficient and the increments as factors multiplied by something in [0,1], ready for the multiplier lemmas.",
+    "mathContext": "$\\sum_{i<n}(-1)^i c_i = c_{n-1}\\sum_{i<n}(-1)^i - \\sum_{j<n-1}(c_{j+1}-c_j)\\sum_{i<j+1}(-1)^i.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "summation by parts",
+      "Abel transformation",
+      "Finset.sum_range_by_parts"
+    ],
+    "prerequisites": [
+      "summation by parts identity"
+    ]
+  },
+  {
+    "id": "ann-trap",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 137 },
+    "type": "insight",
+    "title": "The Asymmetric Two-Sided Trap",
+    "content": "The headline result, in three pieces. alternating_range_le bounds the alternating sum ABOVE by max(c(n−1),0) plus the downward variation ∑ max(c(j)−c(j+1), 0) — only the steps where c decreases contribute, because each increment term is bounded above via mul_le_max. alternating_range_ge bounds it BELOW by min(c(n−1),0) minus the upward variation ∑ max(c(j+1)−c(j), 0). alternating_range_mem_Icc packages the two halves as membership in a closed interval. No monotonicity is assumed; the positive and negative variations of c (its Jordan decomposition) control the two sides independently, and the boundary coefficient enters two-sidedly through max/min — absorbing the parent's separate |a(M−1)| term. This trap is strictly tighter than the symmetric bound whenever the increments have mixed signs.",
+    "mathContext": "$\\sum_{i<n}(-1)^i c_i \\in \\Big[\\min(c_{n-1},0) - \\!\\!\\sum_{j<n-1}\\!(c_{j+1}-c_j)^+,\\ \\max(c_{n-1},0) + \\!\\!\\sum_{j<n-1}\\!(c_j-c_{j+1})^+\\Big].$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Jordan decomposition",
+      "positive and negative variation",
+      "order interval trap",
+      "bounded variation"
+    ],
+    "prerequisites": [
+      "the Abel identity",
+      "the order-interval multiplier lemmas"
+    ]
+  },
+  {
+    "id": "ann-leibniz",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 168 },
+    "type": "concept",
+    "title": "Recovering the Classical Leibniz Bracket",
+    "content": "leibniz_bracket shows the asymmetric trap contains the textbook estimate: for antitone, nonnegative c, the alternating sum lies in [0, c(0)]. In this monotone special case the upward variation vanishes entirely (every increment c(j+1)−c(j) ≤ 0, so its positive part is 0) and the downward variation telescopes (∑(c(j)−c(j+1)) = c(0)−c(n−1) via Finset.sum_range_sub'), while min(c(n−1),0)=0 and max(c(n−1),0)=c(n−1). The two-sided trap therefore collapses to 0 ≤ ∑(−1)ʲcⱼ ≤ c(0) — exactly the classical Leibniz bound, exhibited here as a strict refinement rather than a separate result.",
+    "mathContext": "$c \\text{ antitone},\\ c \\ge 0 \\ \\Rightarrow\\ 0 \\le \\sum_{j<n}(-1)^j c_j \\le c_0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Leibniz alternating series test",
+      "telescoping sum",
+      "antitone sequence",
+      "Finset.sum_range_sub'"
+    ],
+    "prerequisites": [
+      "the two-sided trap",
+      "monotone sequences"
+    ]
+  },
+  {
+    "id": "ann-partial-sum",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-01",
+    "range": { "startLine": 170, "endLine": 194 },
+    "type": "technique",
+    "title": "Cauchy-Difference Form at an Even Truncation Point",
+    "content": "partialSum_diff_mem_Icc applies the trap to a difference of partial sums S_M − S_N. For N even and N < M, reindexing the block [N,M) to range(M−N) makes the constant sign factor (−1)ᴺ = 1 drop out (Even.neg_one_pow), so the difference equals the canonical alternating block ∑_{j<M−N} (−1)ʲ a(N+j). Setting c(j) = a(N+j) and identifying the boundary index c(M−N−1) = a(M−1) (an omega arithmetic fact), the trap alternating_range_mem_Icc applies verbatim. This is the directly usable Cauchy-criterion refinement of the parent's symmetric |S_M − S_N| ≤ |a(M−1)| + (total variation), with a(M−1) now entering two-sidedly via max/min.",
+    "mathContext": "$S_M - S_N = \\sum_{j<M-N}(-1)^j a_{N+j}$ (for $N$ even), which then lies in the trap interval.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy criterion",
+      "partial sum difference",
+      "reindexing a block sum",
+      "Even.neg_one_pow"
+    ],
+    "prerequisites": [
+      "the two-sided trap",
+      "Finset.sum_Ico_eq_sub"
+    ]
+  }
+]

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const alternatingSeriesTestOq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const alternatingSeriesTestOq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const alternatingSeriesTestOq01Oq02Oq01Data: ProofData = {
+  proof: alternatingSeriesTestOq01Oq02Oq01Proof,
+  annotations: alternatingSeriesTestOq01Oq02Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01-oq-02-oq-01` (quality 43, pass 0).

## Why this entry needed work
Rich `meta.json` (overview, sections, conclusion) but **no `index.ts`** (page rendered *"proof not found"*) and **no `annotations.json`**.

## Changes
- **`index.ts`** — standard template (`alternatingSeriesTestOq01Oq02Oq01*` exports). Fixes the missing page.
- **`annotations.json`** — 7 annotations with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, covering the docstring, sign-sum positivity in [0,1] (the asymmetry source), the order-interval multiplier lemmas, Abel summation by parts, the three-piece asymmetric trap (Jordan decomposition), the Leibniz-bracket recovery, and the Cauchy-difference form.
- `meta.json` left intact.

## Verification
- `pnpm build` passes (tsc + vite); JSON validated with `jq`.
- Axiom integrity: badge `verified`, `axiomCount: 0` — 0 `axiom` declarations, 0 sorries, no `native_decide`, no assumption-carrying structures.