### PR TITLE
research(fundamental-arithmetic-oq-03): Euler's product for the Basel problem ∏ₚ(1-p⁻²)⁻¹=π²/6 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2904,6 +2904,7 @@ import Proofs.FundamentalArithmetic
 import Proofs.FundamentalArithmeticOQ01
 import Proofs.FundamentalArithmeticOQ01OQ01
 import Proofs.FundamentalArithmeticOQ02
+import Proofs.FundamentalArithmeticOQ03
 import Proofs.FundamentalTheoremAlgebra
 import Proofs.FundamentalTheoremAlgebraOQ02
 import Proofs.FundamentalTheoremAlgebraOQ04

--- a/proofs/Proofs/FundamentalArithmeticOQ03.lean
+++ b/proofs/Proofs/FundamentalArithmeticOQ03.lean
@@ -1,0 +1,103 @@
+/-
+  Euler's Product for the Basel Problem
+  =====================================
+
+  fundamental-arithmetic-oq-03
+
+  Open question (third open question of the Fundamental Theorem of Arithmetic
+  gallery entry):
+
+    "Can the connection to the Riemann zeta function Euler product
+     ζ(s) = ∏ₚ (1 - p^{-s})⁻¹ be formalized as a consequence of the FTA?"
+
+  Mathlib supplies the general Euler product `riemannZeta_eulerProduct_tprod`,
+  whose proof is exactly the Fundamental Theorem of Arithmetic reorganization of
+  the Dirichlet series ∑ₙ n^{-s} into a product over primes (the engine is
+  `EulerProduct.eulerProduct_completely_multiplicative`, which uses unique
+  factorization to identify the partial products over smooth numbers with the
+  partial sums).  What Mathlib does *not* record is the historically decisive
+  consequence: evaluating the Euler product at s = 2 and s = 4 against the
+  closed-form special values ζ(2) = π²/6 and ζ(4) = π⁴/90.
+
+  This is Euler's 1737 discovery — the first concrete payoff of the
+  FTA → Euler-product bridge — that the product of p²/(p²−1) over all primes
+  equals π²/6.  It ties three gallery threads together: the Fundamental Theorem
+  of Arithmetic (the bijection underlying the Euler product), the Basel problem
+  (the value π²/6), and the Riemann zeta function.
+
+  Everything here is fully verified (0 axioms, 0 sorries) and assembled from
+  Mathlib's `riemannZeta_eulerProduct_*` and `riemannZeta_two`/`riemannZeta_four`.
+-/
+import Mathlib
+
+open Real Complex Filter Topology
+
+namespace FundamentalArithmeticOQ03
+
+/-! ## s = 2 : Euler's product for the Basel value π²/6 -/
+
+/-- The convergence hypothesis `1 < (2 : ℂ).re` for the Euler product at `s = 2`. -/
+private lemma one_lt_re_two : 1 < (2 : ℂ).re := by norm_num
+
+/-- **Euler's product for the Basel problem.**
+
+The infinite product over the primes of `(1 - p^{-2})⁻¹` equals `π²/6`.
+Combining the FTA-driven Euler product (`riemannZeta_eulerProduct_tprod`) at
+`s = 2` with the Basel value `riemannZeta_two`. -/
+theorem euler_basel_product_tprod :
+    ∏' p : Nat.Primes, (1 - (p : ℂ) ^ (-(2 : ℂ)))⁻¹ = (π : ℂ) ^ 2 / 6 := by
+  rw [riemannZeta_eulerProduct_tprod one_lt_re_two, riemannZeta_two]
+
+/-- `HasProd` form of Euler's Basel product: the family `p ↦ (1 - p^{-2})⁻¹`
+has product `π²/6`.  This is the unconditional convergence statement (any
+reordering of the prime factors gives the same value). -/
+theorem euler_basel_product_hasProd :
+    HasProd (fun p : Nat.Primes ↦ (1 - (p : ℂ) ^ (-(2 : ℂ)))⁻¹) ((π : ℂ) ^ 2 / 6) := by
+  have h := riemannZeta_eulerProduct_hasProd one_lt_re_two
+  rwa [riemannZeta_two] at h
+
+/-- Finite partial-product form: the products `∏_{p < n} (1 - p^{-2})⁻¹` over the
+primes below `n` converge to `π²/6` as `n → ∞`.  This is the form closest to
+Euler's original computation. -/
+theorem euler_basel_product_tendsto :
+    Tendsto (fun n : ℕ ↦ ∏ p ∈ Nat.primesBelow n, (1 - (p : ℂ) ^ (-(2 : ℂ)))⁻¹)
+      atTop (𝓝 ((π : ℂ) ^ 2 / 6)) := by
+  have h := riemannZeta_eulerProduct one_lt_re_two
+  rwa [riemannZeta_two] at h
+
+/-! ## s = 4 : Euler's product for ζ(4) = π⁴/90 -/
+
+/-- The convergence hypothesis `1 < (4 : ℂ).re` for the Euler product at `s = 4`. -/
+private lemma one_lt_re_four : 1 < (4 : ℂ).re := by norm_num
+
+/-- **Euler's product at `s = 4`.**
+
+The infinite product over the primes of `(1 - p^{-4})⁻¹` equals `π⁴/90`,
+combining the Euler product at `s = 4` with `riemannZeta_four`. -/
+theorem euler_zeta_four_product_tprod :
+    ∏' p : Nat.Primes, (1 - (p : ℂ) ^ (-(4 : ℂ)))⁻¹ = (π : ℂ) ^ 4 / 90 := by
+  rw [riemannZeta_eulerProduct_tprod one_lt_re_four, riemannZeta_four]
+
+/-- `HasProd` form of the Euler product at `s = 4`. -/
+theorem euler_zeta_four_product_hasProd :
+    HasProd (fun p : Nat.Primes ↦ (1 - (p : ℂ) ^ (-(4 : ℂ)))⁻¹) ((π : ℂ) ^ 4 / 90) := by
+  have h := riemannZeta_eulerProduct_hasProd one_lt_re_four
+  rwa [riemannZeta_four] at h
+
+/-! ## Structural consequences
+
+The Euler product makes the non-vanishing of these special values transparent:
+a convergent product of nonzero factors is nonzero.  Here we record the values
+`π²/6` and `π⁴/90` as nonzero, witnessed through the zeta function. -/
+
+/-- `π²/6 ≠ 0`, seen through the Euler product / zeta non-vanishing for `Re s > 1`. -/
+theorem basel_value_ne_zero : ((π : ℂ) ^ 2 / 6) ≠ 0 := by
+  rw [← riemannZeta_two]
+  exact riemannZeta_ne_zero_of_one_lt_re one_lt_re_two
+
+/-- `π⁴/90 ≠ 0`, seen through the zeta non-vanishing for `Re s > 1`. -/
+theorem zeta_four_value_ne_zero : ((π : ℂ) ^ 4 / 90) ≠ 0 := by
+  rw [← riemannZeta_four]
+  exact riemannZeta_ne_zero_of_one_lt_re one_lt_re_four
+
+end FundamentalArithmeticOQ03

--- a/research/problems/fundamental-arithmetic-oq-03/knowledge.md
+++ b/research/problems/fundamental-arithmetic-oq-03/knowledge.md
@@ -6,16 +6,38 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+This problem is the parent FTA entry's **third open question**: formalize the
+Euler product ζ(s) = ∏ₚ(1-p⁻ˢ)⁻¹ as a consequence of the Fundamental Theorem of
+Arithmetic. Mathlib already supplies the general Euler product
+(`riemannZeta_eulerProduct_tprod`), whose proof IS unique factorization (the engine
+`EulerProduct.eulerProduct_completely_multiplicative` matches partial products over
+p-smooth numbers with partial sums). A bare re-export of that lemma would be
+low-value, so the entry instead records the historically decisive **consequence**
+that Mathlib does not state: combining the Euler product with the closed-form
+special values ζ(2)=π²/6 and ζ(4)=π⁴/90 to recover Euler's 1737 prime-product
+evaluations.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The Euler product is the analytic incarnation of the FTA. Expanding each factor
+  (1-p⁻ˢ)⁻¹ = 1 + p⁻ˢ + p⁻²ˢ + ⋯ and multiplying over primes reproduces ∑ₙ n⁻ˢ
+  because every n factors uniquely.
+- Once the convergence hypothesis 1 < Re s is supplied (trivial: `by norm_num`),
+  the famous special-value products reduce to a single `rw` chaining
+  `riemannZeta_eulerProduct_tprod` with `riemannZeta_two` / `riemannZeta_four`.
+- Three forms shipped: `tprod` (unordered product), `HasProd` (order-independent
+  convergence), and a `Tendsto` over `Nat.primesBelow n` (Euler's finite sieve).
+- Non-vanishing of π²/6 and π⁴/90 is free via `riemannZeta_ne_zero_of_one_lt_re`
+  (a convergent product of nonzero factors is nonzero).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **GOTCHA (not a dead end, a fix):** with only `open Complex`, the `π` notation is
+  not in scope, so Lean auto-bound `π` as a *free complex variable* and every
+  rewrite against Mathlib's `↑Real.pi` failed (`↑Real.pi ^ 2 / 6 = π ^ 2 / 6`
+  unsolved). Adding `open Real` makes `π = Real.pi`, so `(π : ℂ)` elaborates to the
+  same `↑Real.pi` Mathlib uses and the rewrites close by `rfl`.

--- a/research/problems/fundamental-arithmetic-oq-03/state.md
+++ b/research/problems/fundamental-arithmetic-oq-03/state.md
@@ -1,25 +1,27 @@
 # Research State: fundamental-arithmetic-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-04-05T23:12:43-07:00
-**Iteration**: 1
+**Since**: 2026-06-24
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Completed. Shipped verified Euler special-value products as a consequence of the
+FTA-driven Euler product.
 
 ## Active Approach
-None yet.
+Instantiate Mathlib's `riemannZeta_eulerProduct_tprod` at s = 2, 4 and rewrite the
+right-hand side with the closed-form special values `riemannZeta_two` / `riemannZeta_four`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — completed. Follow-ups (divergence at s=1; uniform ζ(2k) family) recorded as
+open questions in meta.json / research JSON.

--- a/src/data/proofs/fundamental-arithmetic-oq-03/annotations.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-03/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "fundamental-arithmetic-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "The Euler Product as the Analytic Form of Unique Factorization",
+    "content": "The docblock frames the entry: Mathlib's riemannZeta_eulerProduct_tprod already proves ζ(s) = ∏ₚ(1-p⁻ˢ)⁻¹ for Re s > 1, and its proof is precisely the Fundamental Theorem of Arithmetic — the engine EulerProduct.eulerProduct_completely_multiplicative identifies partial products over p-smooth numbers with partial sums via unique factorization. What this file contributes is the historically decisive specialisation that Mathlib does not state: combining the Euler product with the closed-form special values ζ(2)=π²/6 and ζ(4)=π⁴/90. The single import is Mathlib; opens are Real (for the π notation as Real.pi), Complex, Filter, and Topology.",
+    "mathContext": "The Euler product expresses $\\sum_{n\\ge 1} n^{-s} = \\prod_p (1-p^{-s})^{-1}$. Expanding each factor as a geometric series $(1-p^{-s})^{-1} = \\sum_{k\\ge 0} p^{-ks}$ and multiplying over all primes, the coefficient of $n^{-s}$ counts the number of ways to write $n = \\prod_p p^{k_p}$ — which is exactly one, by the Fundamental Theorem of Arithmetic.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "riemannZeta_eulerProduct_tprod",
+      "EulerProduct.eulerProduct_completely_multiplicative",
+      "Fundamental Theorem of Arithmetic",
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+    ],
+    "prerequisites": [
+      "Dirichlet series",
+      "infinite products (tprod / HasProd)",
+      "the Riemann zeta function for Re s > 1"
+    ]
+  },
+  {
+    "id": "ann-basel-product",
+    "proofId": "fundamental-arithmetic-oq-03",
+    "range": {
+      "startLine": 40,
+      "endLine": 67
+    },
+    "type": "insight",
+    "title": "Euler's Product for π²/6 in Three Forms",
+    "content": "The headline theorem euler_basel_product_tprod proves ∏'(p : Nat.Primes), (1-p⁻²)⁻¹ = π²/6 in a single rewrite: instantiate riemannZeta_eulerProduct_tprod at s=2 (using the trivial hypothesis 1 < (2:ℂ).re, discharged by norm_num in the private lemma one_lt_re_two) and rewrite the result with riemannZeta_two. Two further forms are given: euler_basel_product_hasProd packages it as a HasProd statement (asserting unconditional, order-independent convergence of the product), and euler_basel_product_tendsto states that the finite partial products ∏_{p < n}(1-p⁻²)⁻¹ over primesBelow n tend to π²/6 — the form closest to Euler's original sieve computation.",
+    "mathContext": "At $s=2$: $\\prod_p (1-p^{-2})^{-1} = \\prod_p \\frac{p^2}{p^2-1} = \\zeta(2) = \\frac{\\pi^2}{6}$ (Euler, 1737). The HasProd form records that the product is independent of the ordering of the primes; the Tendsto form expresses convergence of finite partial products indexed by Nat.primesBelow n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "riemannZeta_two",
+      "Basel problem",
+      "HasProd",
+      "Nat.primesBelow",
+      "Filter.Tendsto"
+    ],
+    "prerequisites": [
+      "ζ(2) = π²/6 (Basel problem)",
+      "complex cpow and the bound 1 < (2:ℂ).re"
+    ]
+  },
+  {
+    "id": "ann-zeta-four",
+    "proofId": "fundamental-arithmetic-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "The Same Recipe at s = 4: π⁴/90",
+    "content": "euler_zeta_four_product_tprod and euler_zeta_four_product_hasProd repeat the construction at s=4, combining the Euler product with riemannZeta_four : ζ(4) = π⁴/90 to obtain ∏ₚ(1-p⁻⁴)⁻¹ = π⁴/90. This demonstrates the uniformity of the method — any closed-form even-argument zeta value yields a corresponding closed-form product over primes — and points toward the general ζ(2k) family noted in the open questions.",
+    "mathContext": "At $s=4$: $\\prod_p (1-p^{-4})^{-1} = \\zeta(4) = \\frac{\\pi^4}{90}$. More generally $\\zeta(2k) = \\frac{(-1)^{k+1} B_{2k} (2\\pi)^{2k}}{2(2k)!}$, so every even argument produces an explicit prime-product identity.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "riemannZeta_four",
+      "Bernoulli numbers",
+      "even zeta values"
+    ],
+    "prerequisites": [
+      "ζ(4) = π⁴/90"
+    ]
+  },
+  {
+    "id": "ann-nonvanishing",
+    "proofId": "fundamental-arithmetic-oq-03",
+    "range": {
+      "startLine": 88,
+      "endLine": 103
+    },
+    "type": "insight",
+    "title": "Non-Vanishing of the Special Values via the Euler Product",
+    "content": "basel_value_ne_zero and zeta_four_value_ne_zero record that π²/6 ≠ 0 and π⁴/90 ≠ 0, proved by rewriting back through riemannZeta_two / riemannZeta_four and applying riemannZeta_ne_zero_of_one_lt_re. Conceptually this is the Euler-product viewpoint on non-vanishing: a convergent infinite product whose factors (1-p⁻ˢ)⁻¹ are each nonzero cannot itself vanish. This same non-vanishing of ζ on Re s > 1 (and its boundary refinement on Re s = 1) is the analytic input to the prime number theorem.",
+    "mathContext": "Each Euler factor $(1-p^{-s})^{-1}$ is a nonzero complex number for $\\mathrm{Re}\\,s > 1$, and the product converges; hence $\\zeta(s) \\neq 0$ there. Mathlib's riemannZeta_ne_zero_of_one_lt_re provides exactly this.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "riemannZeta_ne_zero_of_one_lt_re",
+      "non-vanishing of zeta",
+      "prime number theorem"
+    ],
+    "prerequisites": [
+      "convergent products of nonzero factors are nonzero"
+    ]
+  }
+]

--- a/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "fundamental-arithmetic-oq-03",
+  "title": "Euler's Product for the Basel Problem: ∏ₚ(1-p⁻²)⁻¹ = π²/6",
+  "slug": "fundamental-arithmetic-oq-03",
+  "description": "Euler's 1737 discovery — the first concrete consequence of the FTA-driven Euler product. Evaluating ζ(s)=∏ₚ(1-p⁻ˢ)⁻¹ at s=2 against the Basel value ζ(2)=π²/6 yields ∏ₚ(1-p⁻²)⁻¹=π²/6 (and the analogous ∏ₚ(1-p⁻⁴)⁻¹=π⁴/90 at s=4).",
+  "meta": {
+    "author": "Leonhard Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler_product",
+    "date": "1737 (Euler, Variae observationes circa series infinitas)",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "euler-product",
+      "riemann-zeta",
+      "basel-problem",
+      "classic"
+    ],
+    "proofRepoPath": "Proofs/FundamentalArithmeticOQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "lineCount": 103,
+    "mathlibDependencies": [
+      {
+        "theorem": "riemannZeta_eulerProduct_tprod",
+        "description": "The FTA-driven Euler product ∏ₚ(1-p⁻ˢ)⁻¹ = ζ(s) for Re s > 1",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "riemannZeta_two",
+        "description": "ζ(2) = π²/6 (the Basel problem value)",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_four",
+        "description": "ζ(4) = π⁴/90",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_ne_zero_of_one_lt_re",
+        "description": "ζ(s) ≠ 0 for Re s > 1 (non-vanishing in the half-plane)",
+        "module": "Mathlib.NumberTheory.LSeries.Dirichlet"
+      }
+    ],
+    "assumptions": [],
+    "definitionCount": 0
+  },
+  "parent": "fundamental-arithmetic",
+  "openQuestion": "Can the connection to the Riemann zeta function Euler product ζ(s) = Π(1-p^{-s})^{-1} be formalized as a consequence of the FTA?",
+  "significance": "The Euler product is the analytic incarnation of the Fundamental Theorem of Arithmetic: the identity ∑ₙ n⁻ˢ = ∏ₚ(1-p⁻ˢ)⁻¹ is precisely unique factorization, since expanding each geometric factor (1-p⁻ˢ)⁻¹ = 1 + p⁻ˢ + p⁻²ˢ + ⋯ and multiplying over all primes reconstructs each n⁻ˢ exactly once. Mathlib's general Euler product (riemannZeta_eulerProduct_tprod) encodes this bijection through eulerProduct_completely_multiplicative. This entry records the historically decisive consequence that Mathlib does not state directly: combining the Euler product with the closed-form special values ζ(2)=π²/6 and ζ(4)=π⁴/90 gives Euler's famous 1737 evaluations of products over primes, the first spectacular payoff of the FTA → Euler-product bridge and the result that launched analytic number theory.",
+  "overview": {
+    "historicalContext": "In 1737 Leonhard Euler published 'Variae observationes circa series infinitas', in which he proved the product formula ∑ₙ 1/nˢ = ∏ₚ 1/(1-p⁻ˢ) ranging over all primes p. The proof is a sieve: starting from ∑ 1/nˢ, multiply by (1-2⁻ˢ) to delete every even term, then by (1-3⁻ˢ) to delete multiples of 3, and so on; the Fundamental Theorem of Arithmetic guarantees that each integer is removed exactly once, leaving only the term n=1. Euler immediately applied this at s=2, where he had just solved the Basel problem (∑ 1/n² = π²/6), to obtain ∏ₚ p²/(p²-1) = π²/6 — a breathtaking identity linking the primes to π. The same machinery at s=4 gives ∏ₚ p⁴/(p⁴-1) = π⁴/90. Euler also used the divergence of the product at s=1 to give a new proof that there are infinitely many primes. These identities mark the birth of analytic number theory: they were the first to express a property of the prime numbers through the value of an analytic function, an idea that culminates in Riemann's 1859 study of ζ(s) and the prime number theorem.",
+    "problemStatement": "Formalize the Euler product ζ(s) = ∏ₚ(1-p⁻ˢ)⁻¹ as a consequence of unique factorization, and evaluate it at s=2 and s=4 to recover Euler's closed forms ∏ₚ(1-p⁻²)⁻¹ = π²/6 and ∏ₚ(1-p⁻⁴)⁻¹ = π⁴/90.",
+    "proofStrategy": "Mathlib already provides the FTA-driven Euler product riemannZeta_eulerProduct_tprod : for Re s > 1, ∏'(p : Primes), (1-p⁻ˢ)⁻¹ = ζ(s); its proof runs through eulerProduct_completely_multiplicative, which identifies partial products over p-smooth numbers with partial sums via unique factorization. The contribution here is to instantiate this at s=2 (using the trivial bound 1 < (2:ℂ).re) and rewrite the right-hand side with Mathlib's Basel value riemannZeta_two : ζ(2) = π²/6, yielding ∏ₚ(1-p⁻²)⁻¹ = π²/6 in a single rw. The same recipe at s=4 with riemannZeta_four gives π⁴/90. Three equivalent forms are provided — tprod (unordered infinite product), HasProd (unconditional convergence/reordering), and a Tendsto statement for the finite partial products over primesBelow n, closest to Euler's original sieve computation. Finally, non-vanishing of the values (π²/6 ≠ 0, π⁴/90 ≠ 0) is obtained directly from riemannZeta_ne_zero_of_one_lt_re, reflecting that a convergent product of nonzero factors cannot vanish.",
+    "keyInsights": [
+      "The Euler product IS the Fundamental Theorem of Arithmetic in analytic disguise: expanding ∏ₚ(1 + p⁻ˢ + p⁻²ˢ + ⋯) and collecting terms reproduces ∑ₙ n⁻ˢ precisely because every integer factors uniquely into prime powers — each n⁻ˢ appears exactly once",
+      "Mathlib's riemannZeta_eulerProduct_tprod packages this bijection (via eulerProduct_completely_multiplicative over p-smooth numbers), so the special-value identities reduce to a one-line rewrite once the Re s > 1 hypothesis is supplied",
+      "Euler's evaluation ∏ₚ(1-p⁻²)⁻¹ = π²/6 was the first time a property of the primes was expressed through the value of an analytic function — the conceptual seed of analytic number theory and the Riemann zeta function",
+      "Three forms (tprod, HasProd, Tendsto over primesBelow n) capture the identity at different levels of structure: the HasProd form encodes order-independence of the product, while the Tendsto form mirrors Euler's original sieve through finite partial products",
+      "Non-vanishing of π²/6 and π⁴/90 follows for free from the Euler product viewpoint: a convergent product whose factors are all nonzero is nonzero, recorded here through riemannZeta_ne_zero_of_one_lt_re"
+    ]
+  },
+  "sections": [
+    {
+      "id": "basel-product",
+      "title": "Euler's Product for the Basel Value π²/6",
+      "startLine": 34,
+      "endLine": 67,
+      "summary": "Instantiates the FTA-driven Euler product at s=2 and rewrites with ζ(2)=π²/6 to obtain ∏ₚ(1-p⁻²)⁻¹ = π²/6 in three equivalent forms: the unordered tprod, the HasProd statement (order-independent convergence), and a Tendsto statement for the finite partial products over the primes below n."
+    },
+    {
+      "id": "zeta-four-product",
+      "title": "Euler's Product at s = 4 for ζ(4) = π⁴/90",
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "The same recipe at s=4: combining the Euler product with riemannZeta_four yields ∏ₚ(1-p⁻⁴)⁻¹ = π⁴/90, in tprod and HasProd forms."
+    },
+    {
+      "id": "structural-consequences",
+      "title": "Non-Vanishing of the Special Values",
+      "startLine": 88,
+      "endLine": 103,
+      "summary": "Records π²/6 ≠ 0 and π⁴/90 ≠ 0, obtained through riemannZeta_ne_zero_of_one_lt_re — reflecting that a convergent Euler product of nonzero factors cannot vanish."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Euler's 1737 product evaluations as fully verified (0 sorries, 0 axioms) consequences of the FTA-driven Euler product. The headline results ∏ₚ(1-p⁻²)⁻¹ = π²/6 and ∏ₚ(1-p⁻⁴)⁻¹ = π⁴/90 combine Mathlib's general Euler product riemannZeta_eulerProduct_tprod (whose engine is unique factorization, via eulerProduct_completely_multiplicative) with the closed-form special values riemannZeta_two and riemannZeta_four. Each identity is given in tprod, HasProd, and (at s=2) finite-partial-product Tendsto form, and the non-vanishing of both values is recorded through zeta non-vanishing for Re s > 1.",
+    "implications": "Euler's product formula is the foundation of analytic number theory: it is the first bridge between the multiplicative structure of the integers (unique factorization, the primes) and the analytic value of a zeta/L-function. The same bridge underlies Dirichlet's theorem on primes in arithmetic progressions (via L-function Euler products, also in Mathlib), the prime number theorem (via the non-vanishing of ζ on Re s = 1), and the Riemann hypothesis. The concrete evaluation ∏ₚ p²/(p²-1) = π²/6 remains one of the most striking identities in mathematics, tying the discrete world of primes to the transcendental constant π.",
+    "openQuestions": [
+      "Can the divergence of the Euler product ∏ₚ(1-p⁻¹)⁻¹ at s=1 be formalized to give Euler's analytic proof of the infinitude of primes (and the divergence of ∑ 1/p)?",
+      "Can the general even-argument evaluation ζ(2k) = (-1)^{k+1} B_{2k} (2π)^{2k} / (2(2k)!) be combined with the Euler product to give a uniform family of prime-product identities ∏ₚ(1-p⁻²ᵏ)⁻¹ in closed form?",
+      "Can the logarithmic form log ζ(s) = ∑ₚ ∑ₖ p⁻ᵏˢ/k be formalized and specialized to relate ∑ₚ p⁻² to a series for log(π²/6)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "fundamental-arithmetic",
+      "relationship": "Parent theorem",
+      "description": "The Euler product is the analytic form of the Fundamental Theorem of Arithmetic: unique factorization is exactly what makes ∑ₙ n⁻ˢ = ∏ₚ(1-p⁻ˢ)⁻¹. This entry answers the parent's third open question."
+    },
+    {
+      "proofId": "fundamental-arithmetic-oq-01",
+      "relationship": "Sibling open question",
+      "description": "The multiplicative property of prime factorization (factorization(mn) = factorization(m) + factorization(n)) is the combinatorial heart of why the Euler product factors over primes."
+    },
+    {
+      "proofId": "fundamental-arithmetic-oq-02",
+      "relationship": "Sibling open question",
+      "description": "Where oq-02 exhibits the FAILURE of unique factorization in Z[√-5], this entry exploits its SUCCESS in Z to derive the Euler product and Euler's prime-product evaluations."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "FundamentalArithmeticOQ03",
+    "lineCount": 103,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/FundamentalArithmeticOQ03.lean"
+  }
+}

--- a/src/data/research/problems/fundamental-arithmetic-oq-03.json
+++ b/src/data/research/problems/fundamental-arithmetic-oq-03.json
@@ -1,45 +1,75 @@
 {
   "slug": "fundamental-arithmetic-oq-03",
-  "title": "[Problem Title]",
-  "phase": "OBSERVE",
-  "status": "active",
+  "title": "Euler's Product for the Basel Problem: prod_p (1-p^-2)^-1 = pi^2/6",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{[LaTeX formulation of the theorem/conjecture]}",
-    "plain": "[Explain what we're trying to prove in accessible terms]",
-    "whyMatters": []
+    "formal": "\\prod_{p\\ \\text{prime}} (1-p^{-2})^{-1} = \\zeta(2) = \\frac{\\pi^2}{6}, \\quad \\prod_p (1-p^{-4})^{-1} = \\zeta(4) = \\frac{\\pi^4}{90}",
+    "plain": "Formalize the Euler product zeta(s) = prod_p (1-p^-s)^-1 as a consequence of the Fundamental Theorem of Arithmetic, and evaluate it at s=2 and s=4 to recover Euler's closed forms prod_p (1-p^-2)^-1 = pi^2/6 and prod_p (1-p^-4)^-1 = pi^4/90.",
+    "whyMatters": [
+      "The Euler product is the analytic incarnation of unique factorization and the founding result of analytic number theory; Euler's 1737 evaluation prod_p p^2/(p^2-1) = pi^2/6 was the first time a property of the primes was expressed through the value of an analytic function."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Mathlib riemannZeta_eulerProduct_tprod: zeta(s) = prod_p (1-p^-s)^-1 for Re s > 1 (FTA-driven)",
+      "Mathlib riemannZeta_two: zeta(2) = pi^2/6",
+      "Mathlib riemannZeta_four: zeta(4) = pi^4/90",
+      "Mathlib riemannZeta_ne_zero_of_one_lt_re: zeta(s) != 0 for Re s > 1"
+    ],
+    "open": [
+      "Divergence of the Euler product at s=1 (Euler's analytic proof of infinitude of primes)",
+      "Uniform closed-form family for prod_p (1-p^-2k)^-1 from the general zeta(2k) formula"
+    ],
+    "goal": "State and verify the special-value Euler products prod_p (1-p^-2)^-1 = pi^2/6 and prod_p (1-p^-4)^-1 = pi^4/90 in tprod, HasProd, and partial-product (Tendsto) forms, with non-vanishing corollaries."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-04-05T23:12:43-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Shipped verified Euler special-value products; entry complete.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None - completed. Follow-ups recorded as open questions.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETED (verified, 0-axiom). Answered the parent FTA entry's third open question by formalizing Euler's 1737 product evaluations as consequences of Mathlib's FTA-driven Euler product. Headline results: prod_p (1-p^-2)^-1 = pi^2/6 and prod_p (1-p^-4)^-1 = pi^4/90, each instantiated from riemannZeta_eulerProduct_tprod at s=2,4 and rewritten with the closed-form special values riemannZeta_two / riemannZeta_four. 9 theorems / 0 axioms / 0 sorries / 103 lines.",
+    "builtItems": [
+      "euler_basel_product_tprod: prod'(p:Primes) (1-p^-2)^-1 = pi^2/6 (the Basel Euler product)",
+      "euler_basel_product_hasProd: HasProd form (order-independent convergence) of the Basel product",
+      "euler_basel_product_tendsto: finite partial products over primesBelow n tend to pi^2/6 (Euler's sieve form)",
+      "euler_zeta_four_product_tprod and euler_zeta_four_product_hasProd: prod_p (1-p^-4)^-1 = pi^4/90",
+      "basel_value_ne_zero and zeta_four_value_ne_zero: non-vanishing of pi^2/6 and pi^4/90 via zeta non-vanishing"
+    ],
+    "insights": [
+      "The Euler product IS the FTA in analytic disguise: Mathlib's riemannZeta_eulerProduct_tprod is proved through eulerProduct_completely_multiplicative, which uses unique factorization to match partial products over p-smooth numbers with partial sums.",
+      "Once the Re s > 1 hypothesis is supplied (trivial: 1 < (2:C).re by norm_num), the famous special-value products reduce to a single rw chaining the Euler product with riemannZeta_two / riemannZeta_four.",
+      "GOTCHA: with only 'open Complex', the pi notation is NOT in scope and Lean auto-bounds pi as a free complex variable, breaking the rewrite against Mathlib's (down-arrow Real.pi); adding 'open Real' makes pi = Real.pi so (pi:C) matches Mathlib's coerced form.",
+      "Three forms (tprod, HasProd, Tendsto over primesBelow n) expose the identity at different structural levels; the Tendsto form is the literal analogue of Euler's original finite-sieve computation.",
+      "Non-vanishing of pi^2/6 and pi^4/90 is free from the Euler-product viewpoint: a convergent product of nonzero factors is nonzero (riemannZeta_ne_zero_of_one_lt_re)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the general Euler product and the special values zeta(2),zeta(4) separately, but does NOT state the combined special-value prime-product identities prod_p (1-p^-2)^-1 = pi^2/6 etc. - that combination is this entry's contribution.",
+      "No formalized divergence of the s=1 Euler product / Euler's product-based proof of infinitude of primes."
+    ],
+    "nextSteps": [
+      "Formalize divergence of prod_p (1-p^-1)^-1 at s=1 for Euler's infinitude-of-primes proof.",
+      "Derive a uniform prod_p (1-p^-2k)^-1 family from the general even-argument zeta value formula."
+    ],
     "markdown": "# Knowledge Base: fundamental-arithmetic-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
-    "number-theory  # or: algebra, analysis, topology, combinatorics, etc.",
-    "prime-gaps",
-    "sieve-methods"
+    "number-theory",
+    "analytic-number-theory",
+    "euler-product",
+    "riemann-zeta",
+    "basel-problem"
   ],
   "relatedProofs": [
     "fundamental-arithmetic",
@@ -48,12 +78,18 @@
     "fundamental-arithmetic-oq-02"
   ],
   "references": {
-    "papers": [],
+    "papers": [
+      "L. Euler, Variae observationes circa series infinitas, Comm. Acad. Sci. Petrop. 9 (1737)"
+    ],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries (riemannZeta_eulerProduct_tprod / _hasProd / _eulerProduct)",
+      "Mathlib.NumberTheory.LSeries.HurwitzZetaValues (riemannZeta_two, riemannZeta_four)",
+      "Mathlib.NumberTheory.LSeries.Dirichlet (riemannZeta_ne_zero_of_one_lt_re)"
+    ]
   },
   "started": "2026-04-06T06:37:41.264Z",
-  "lastUpdate": "2026-04-12T21:07:23.998Z",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Answers the **third open question** of the Fundamental Theorem of Arithmetic gallery entry:

> *"Can the connection to the Riemann zeta function Euler product ζ(s) = ∏ₚ(1-p⁻ˢ)⁻¹ be formalized as a consequence of the FTA?"*

Mathlib already proves the general Euler product (`riemannZeta_eulerProduct_tprod`), and its proof **is** the Fundamental Theorem of Arithmetic — the engine `EulerProduct.eulerProduct_completely_multiplicative` uses unique factorization to match partial products over *p*-smooth numbers with partial sums. A bare re-export would be low-value, so this entry instead formalizes the **historically decisive consequence Mathlib does not state**: combining the Euler product with the closed-form special values gives **Euler's 1737 prime-product evaluations**.

## Results (verified, 0 axioms, 0 sorries, 103 lines, 9 theorems)

- `euler_basel_product_tprod` : `∏'(p : Nat.Primes), (1 - p^(-2))⁻¹ = π²/6` — **Euler's Basel product**
- `euler_basel_product_hasProd` : `HasProd` form (order-independent convergence)
- `euler_basel_product_tendsto` : finite partial products over `primesBelow n` → π²/6 (Euler's original sieve form)
- `euler_zeta_four_product_tprod` / `_hasProd` : `∏ₚ(1 - p^(-4))⁻¹ = π⁴/90`
- `basel_value_ne_zero` / `zeta_four_value_ne_zero` : non-vanishing via `riemannZeta_ne_zero_of_one_lt_re`

## Method

Instantiate `riemannZeta_eulerProduct_tprod` at `s = 2, 4` (convergence `1 < (2:ℂ).re` by `norm_num`) and rewrite the RHS with `riemannZeta_two` / `riemannZeta_four` — a single `rw` chain per identity.

**Gotcha recorded:** with only `open Complex`, the `π` notation is not in scope and Lean auto-bounds `π` as a free complex variable, breaking the rewrite against Mathlib's `↑Real.pi`; `open Real` fixes it.

## Verification

Type-checked host-side against Mathlib (`lake env lean`), clean build. Imports only `Mathlib`; deps are `riemannZeta_eulerProduct_tprod/_hasProd/_eulerProduct`, `riemannZeta_two`, `riemannZeta_four`, `riemannZeta_ne_zero_of_one_lt_re` (only `propext`/`Classical.choice`/`Quot.sound` — no `sorryAx`, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)