### PR TITLE
Enrich Diagonal Beta Value as a Central Binomial Reciprocal

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/annotations.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "beta-integral-recurrence-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 35 },
+    "type": "context",
+    "title": "The Beta Integral on Its Diagonal",
+    "content": "The parent entry established the integer closed form of the Euler Beta integral, B(m+1, n+1) = m!·n!/(m+n+1)!. This file specializes to the diagonal m = n, where the value collapses to a single Wallis-type quantity governed by the central binomial coefficient: B(n+1, n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)). This is precisely the normalization constant of the symmetric Beta(n+1,n+1) density xⁿ(1−x)ⁿ/B(n+1,n+1) on [0,1]: the density integrates to 1, so the total mass B(n+1,n+1) is the reciprocal of the integer (2n+1)·C(2n,n). All analytic content is inherited from the parent; the only new ingredient is an elementary factorial identity.",
+    "mathContext": "$B(n{+}1,n{+}1) = \\dfrac{(n!)^2}{(2n+1)!} = \\dfrac{1}{(2n+1)\\binom{2n}{n}}.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euler Beta integral",
+      "central binomial coefficient",
+      "Beta distribution normalization",
+      "Wallis integrals"
+    ],
+    "prerequisites": [
+      "the parent integer Beta closed form (betaIntegral_nat_nat)",
+      "factorials and binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-factorization",
+    "proofId": "beta-integral-recurrence-oq-01-oq-01",
+    "range": { "startLine": 40, "endLine": 54 },
+    "type": "technique",
+    "title": "The Factorial Factorization Bridge",
+    "content": "factorial_two_mul_succ is the one new fact: (2n+1)! = (2n+1)·C(2n,n)·(n!·n!). It is the multiplicative bridge that turns the factorial form (n!)²/(2n+1)! into the central-binomial form 1/((2n+1)·C(2n,n)). The proof specializes Mathlib's Nat.choose_mul_factorial_mul_factorial — which gives C(2n,n)·n!·(2n−n)! = (2n)!, simplified to C(2n,n)·n!·n! = (2n)! after rewriting 2n−n = n — and then peels one factor with Nat.factorial_succ, since (2n+1)! = (2n+1)·(2n)!.",
+    "mathContext": "$(2n+1)! = (2n+1)\\,\\binom{2n}{n}\\,(n!)^2,$ from $\\binom{2n}{n}(n!)^2 = (2n)!$ and $(2n+1)! = (2n+1)(2n)!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "factorial recurrence",
+      "binomial coefficient factorization",
+      "Nat.choose_mul_factorial_mul_factorial"
+    ],
+    "prerequisites": [
+      "factorials",
+      "Nat.factorial_succ"
+    ]
+  },
+  {
+    "id": "ann-diagonal",
+    "proofId": "beta-integral-recurrence-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 82 },
+    "type": "insight",
+    "title": "The Central Binomial Reciprocal",
+    "content": "betaIntegral_diag_central_binom is the headline: B(n+1, n+1) = 1/((2n+1)·C(2n,n)). It rewrites the parent's diagonal value betaIntegral_nat_nat n n = (n!)²/(2n+1)! and clears denominators with div_eq_div_iff, using the factorization key: n!·n!·((2n+1)·C(2n,n)) = (2n+1)!. The nonvanishing side conditions come from factorial positivity and Nat.choose_pos. The companion betaIntegral_diag_centralBinom restates the same value with Mathlib's Nat.centralBinom n = C(2n,n) — a definitional rfl rewrite — connecting the result to the library's named central binomial coefficient.",
+    "mathContext": "$B(n{+}1,n{+}1) = \\dfrac{1}{(2n+1)\\binom{2n}{n}} = \\dfrac{1}{(2n+1)\\,\\mathrm{centralBinom}\\,n}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Beta integral closed form",
+      "Nat.centralBinom",
+      "clearing denominators (div_eq_div_iff)",
+      "casting ℕ to ℂ"
+    ],
+    "prerequisites": [
+      "the factorial factorization",
+      "the parent betaIntegral_nat_nat"
+    ]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "beta-integral-recurrence-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 98 },
+    "type": "context",
+    "title": "Numerical Instances",
+    "content": "Two checks specialize the formula. betaIntegral_one_one_central: B(1,1) = 1 at n = 0, since (2·0+1)·C(0,0) = 1. betaIntegral_two_two: B(2,2) = 1/6 at n = 1, since (2·1+1)·C(2,1) = 3·2 = 6. Both are obtained by instantiating betaIntegral_diag_central_binom and simplifying with norm_num, confirming the general formula against directly computable small cases.",
+    "mathContext": "$B(1,1) = 1,\\qquad B(2,2) = \\dfrac{1}{6}.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "sanity check",
+      "specialization"
+    ],
+    "prerequisites": [
+      "the central binomial reciprocal formula"
+    ]
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/index.ts
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BetaCentralBinomial.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const betaIntegralRecurrenceOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const betaIntegralRecurrenceOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const betaIntegralRecurrenceOq01Oq01Data: ProofData = {
+  proof: betaIntegralRecurrenceOq01Oq01Proof,
+  annotations: betaIntegralRecurrenceOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-01` (quality 43, pass 0).

## Why this entry needed work
Rich `meta.json` (overview, sections, conclusion) but **no `index.ts`** (page rendered *"proof not found"*) and **no `annotations.json`**.

## Changes
- **`index.ts`** — standard template (`betaIntegralRecurrenceOq01Oq01*` exports, source from `Proofs/BetaCentralBinomial.lean`). Fixes the missing page.
- **`annotations.json`** — 4 annotations with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`, covering the docstring (Beta diagonal & the symmetric Beta density normalization), the factorial factorization `(2n+1)! = (2n+1)·C(2n,n)·(n!)²`, the central-binomial reciprocal result and its `Nat.centralBinom` phrasing, and the B(1,1)=1 / B(2,2)=1/6 instances.
- `meta.json` left intact.

## Verification
- `pnpm build` passes (tsc + vite); JSON validated with `jq`.
- Axiom integrity: badge `original`, status `verified`, `axiomCount: 0` — 0 `axiom` declarations, 0 sorries, no `native_decide`, no assumption-carrying structures.