### PR TITLE
research(euler-totient-oq-01-oq-01-oq-01): Carmichael function = lcm of prime-power values [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2755,6 +2755,7 @@ import Proofs.EulerTotientOQ01OQ02
 import Proofs.EulerTotientOQ01OQ02OQ01
 import Proofs.EulerTotientOQ01OQ02OQ03
 import Proofs.EulerTotientOQ01OQ01
+import Proofs.EulerTotientOQ01OQ01OQ01
 import Proofs.EulerTotientOQ01OQ03
 import Proofs.EulerTotientOQ01OQ03Keygen
 import Proofs.EulerTotientOQ01OQ03Minimal

--- a/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
@@ -1,0 +1,114 @@
+import Proofs.EulerTotientOQ01OQ01
+import Mathlib
+
+/-
+# Carmichael's Function as the lcm of its Prime-Power Values
+
+## Open Question (euler-totient-oq-01-oq-01-oq-01)
+
+The parent entry (`EulerTotientOQ01OQ01.lean`) proves the **keystone** of the
+structure theory of Carmichael's function: multiplicativity over coprime factors,
+  λ(m·n) = lcm(λ(m), λ(n))   whenever gcd(m, n) = 1
+(`CarmichaelMultiplicative.carmichael_mul_coprime`), and explicitly leaves the
+prime-power factorization formula
+  λ(n) = lcm_i λ(pᵢ^{kᵢ})
+"as a routine induction".  This file discharges that deferred corollary:
+
+  λ(n) = lcm_{p ∈ primeFactors n} λ(p^{vₚ(n)})        (`carmichael_eq_factorization_lcm`)
+
+where `vₚ(n) = n.factorization p` is the p-adic valuation, expressed as the
+finite `Finset.lcm` over the prime factors of `n`.
+
+## Proof
+
+Carmichael's function is `λ(n) = Monoid.exponent (ZMod n)ˣ` (the parent's
+definition, reused here).  We induct on `n` with `Nat.recOnPosPrimePosCoprime`,
+which reduces every positive `n` to its prime-power building blocks:
+
+* **n = 1.**  `(ZMod 1)ˣ` is trivial, so its exponent is `1`; the empty
+  `Finset.lcm` is also `1`.  (`carmichael_one`)
+
+* **n = p^k, p prime, k ≥ 1.**  The factorization is the single point
+  `vₚ(p^k) = k`, so the indexing set is `{p}` and the singleton lcm is exactly
+  `λ(p^k)`.
+
+* **n = a·b, a, b > 1 coprime.**  The parent keystone gives
+  `λ(a·b) = lcm(λ(a), λ(b))`.  The factorization splits additively over the
+  coprime (hence disjoint) prime supports, so the index set splits as a disjoint
+  union and `Finset.lcm` distributes over it (`Finset.lcm_union`).  On each part
+  the valuation `vₚ(a·b)` agrees with `vₚ(a)` (resp. `vₚ(b)`) because the other
+  factor contributes `0` at those primes, so the induction hypotheses apply
+  verbatim (`Finset.lcm_congr`).
+
+Since every `(ℤ/p^kℤ)*` is cyclic (`p` odd) or a product of at most two cyclic
+groups (`p = 2`), this expresses λ(n) as the lcm of the orders of the cyclic
+factors of the unit group — the full structural characterization the parent set
+out to reach.
+
+## Honesty note
+
+This is exactly the "routine induction" the parent flagged: no new mathematics,
+just the standard multiplicative-to-factorization bootstrap (`carmichael_mul_coprime`
++ `Nat.recOnPosPrimePosCoprime` + `Finset.lcm_union`).  The contribution is the
+explicit gallery statement of the prime-power formula, verified with zero axioms.
+-/
+
+open ZMod
+
+namespace CarmichaelFactorization
+
+open CarmichaelMultiplicative
+
+/-- The Carmichael function of `1` is `1`: `(ZMod 1)ˣ` is the trivial group, whose
+exponent is `1`. -/
+theorem carmichael_one : carmichael 1 = 1 := by
+  unfold carmichael
+  have h : ∀ g : (ZMod 1)ˣ, g ^ 1 = 1 := by
+    intro g; simp [Subsingleton.elim g 1]
+  exact Nat.dvd_one.mp (Monoid.exponent_dvd_of_forall_pow_eq_one h)
+
+/-- **Carmichael's function is the lcm of its prime-power values.**
+
+For every positive `n`,
+  `λ(n) = lcm_{p ∈ primeFactors n} λ(p^{vₚ(n)})`,
+the finite lcm taken over the prime factors of `n` (`vₚ(n) = n.factorization p`).
+
+This is the prime-power factorization formula deferred by the parent entry; it
+follows from coprime multiplicativity of `λ` by induction on the factorization. -/
+theorem carmichael_eq_factorization_lcm {n : ℕ} (hn : n ≠ 0) :
+    carmichael n
+      = n.factorization.support.lcm (fun p => carmichael (p ^ n.factorization p)) := by
+  induction n using Nat.recOnPosPrimePosCoprime with
+  | zero => exact absurd rfl hn
+  | one =>
+      simp [Nat.factorization_one, carmichael_one]
+  | prime_pow p k hp hk =>
+      simp only [hp.factorization_pow, Finsupp.support_single_ne_zero p hk.ne',
+        Finset.lcm_singleton, Finsupp.single_eq_same]
+      simp
+  | coprime a b ha hb hab iha ihb =>
+      have ha0 : a ≠ 0 := (zero_lt_one.trans ha).ne'
+      have hb0 : b ≠ 0 := (zero_lt_one.trans hb).ne'
+      have hdisj : Disjoint a.factorization.support b.factorization.support := by
+        simpa only [Nat.support_factorization] using hab.disjoint_primeFactors
+      have hsupp : (a * b).factorization.support
+          = a.factorization.support ∪ b.factorization.support := by
+        rw [Nat.factorization_mul ha0 hb0, Finsupp.support_add_eq hdisj]
+      have ea : a.factorization.support.lcm
+            (fun p => carmichael (p ^ (a * b).factorization p))
+          = a.factorization.support.lcm (fun p => carmichael (p ^ a.factorization p)) := by
+        refine Finset.lcm_congr rfl (fun p hp => ?_)
+        have hp0 : b.factorization p = 0 :=
+          Finsupp.notMem_support_iff.mp (Finset.disjoint_left.mp hdisj hp)
+        rw [Nat.factorization_mul ha0 hb0, Finsupp.add_apply, hp0, add_zero]
+      have eb : b.factorization.support.lcm
+            (fun p => carmichael (p ^ (a * b).factorization p))
+          = b.factorization.support.lcm (fun p => carmichael (p ^ b.factorization p)) := by
+        refine Finset.lcm_congr rfl (fun p hp => ?_)
+        have hp0 : a.factorization p = 0 :=
+          Finsupp.notMem_support_iff.mp (Finset.disjoint_right.mp hdisj hp)
+        rw [Nat.factorization_mul ha0 hb0, Finsupp.add_apply, hp0, zero_add]
+      rw [carmichael_mul_coprime hab, iha ha0, ihb hb0, hsupp, Finset.lcm_union, ea, eb,
+        lcm_eq_nat_lcm]
+
+end CarmichaelFactorization

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "euler-totient-oq-01-oq-01-oq-01",
+  "title": "Carmichael's Function as the lcm of its Prime-Power Values: λ(n) = lcm_i λ(p_i^{k_i})",
+  "slug": "euler-totient-oq-01-oq-01-oq-01",
+  "description": "Completes the prime-power factorization formula for Carmichael's function that the parent entry deferred: for every positive n, λ(n) = lcm over the prime factors p of λ(p^{v_p(n)}). Proved by inducting on the factorization with Nat.recOnPosPrimePosCoprime, using the parent's coprime keystone λ(m·n) = lcm(λ(m), λ(n)) at each step and distributing Finset.lcm over the disjoint prime supports.",
+  "meta": {
+    "author": "researcher-2 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carmichael_function",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "carmichael-function",
+      "group-theory",
+      "exponent",
+      "prime-factorization",
+      "lcm",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.recOnPosPrimePosCoprime",
+        "description": "induction reducing every natural to 0, 1, positive prime powers, and coprime products",
+        "module": "Mathlib.Data.Nat.Factorization.Induction"
+      },
+      {
+        "theorem": "Nat.factorization_mul",
+        "description": "(m*n).factorization = m.factorization + n.factorization for nonzero m, n",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.disjoint_primeFactors",
+        "description": "coprime numbers have disjoint sets of prime factors",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Finset.lcm_union",
+        "description": "the lcm over a union of finite sets is the lcm of the two partial lcms",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.lcm_congr",
+        "description": "lcm is unchanged when the indexed function is replaced by an equal one on the set",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.lcm_singleton",
+        "description": "the lcm over a singleton {b} is normalize (f b)",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Monoid.exponent_dvd_of_forall_pow_eq_one",
+        "description": "if every element satisfies g^n = 1 then the exponent divides n (used for the trivial group (ZMod 1)ˣ)",
+        "module": "Mathlib.GroupTheory.Exponent"
+      }
+    ],
+    "originalContributions": [
+      "carmichael_one: λ(1) = 1, since (ZMod 1)ˣ is the trivial group whose exponent is 1",
+      "carmichael_eq_factorization_lcm: the prime-power factorization formula λ(n) = lcm over n.primeFactors of λ(p^{v_p(n)}), the single-theorem statement the parent entry left 'as a routine induction'",
+      "Coprime split of the index set via Finset.lcm_union over disjoint prime supports, with Finset.lcm_congr realigning the (a*b)-valuations to the per-factor valuations so the induction hypotheses apply verbatim"
+    ],
+    "references": [
+      {
+        "authors": "Carmichael, Robert D.",
+        "title": "Note on a new number theory function",
+        "year": "1910",
+        "venue": "Bulletin of the American Mathematical Society",
+        "note": "Introduces λ(n) and its determination by prime-power values"
+      },
+      {
+        "authors": "Hardy, G. H.; Wright, E. M.",
+        "title": "An Introduction to the Theory of Numbers",
+        "year": "2008",
+        "venue": "Oxford University Press",
+        "note": "Structure of (Z/nZ)* and the universal exponent λ(n)"
+      }
+    ],
+    "prerequisites": [
+      "Carmichael's function λ(n) = exponent of (Z/nZ)* (parent entry euler-totient-oq-01)",
+      "Coprime multiplicativity λ(m·n) = lcm(λ(m), λ(n)) (parent entry euler-totient-oq-01-oq-01)",
+      "Prime factorization and the p-adic valuation v_p(n) = n.factorization p",
+      "Finite least common multiple Finset.lcm over a NormalizedGCDMonoid"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 114,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Carmichael's function λ(n), introduced in 1910, is the universal exponent of the unit group (Z/nZ)*: the least e with a^e ≡ 1 (mod n) for every a coprime to n. It divides Euler's totient φ(n) and is the exponent that actually governs modular exponentiation (the modulus in RSA's correctness). Classically λ is computed by reduction to prime powers: λ(n) = lcm over the prime powers p^k exactly dividing n of λ(p^k), with each λ(p^k) read off the cyclic (odd p) or near-cyclic (p = 2) structure of (Z/p^kZ)*.",
+    "problemStatement": "**Open Question (from parent proof euler-totient-oq-01-oq-01)**: 'Complete the induction over the prime-power factorization to state λ(n) = lcm_i λ(p_i^{k_i}) as a single theorem.' The parent proved the coprime keystone λ(m·n) = lcm(λ(m), λ(n)) and explicitly left the factorization corollary as a routine induction.\n\n**Resolution (this entry)**: Prove, for every positive n, λ(n) = lcm over the prime factors p of n of λ(p^{v_p(n)}), expressed as Finset.lcm over n.factorization.support.",
+    "text": "A compact, axiom-free development (2 theorems, 114 lines including documentation). carmichael n is the parent's Monoid.exponent (ZMod n)ˣ, reused by import. carmichael_one establishes the base value λ(1) = 1 from the triviality of (ZMod 1)ˣ. The main theorem carmichael_eq_factorization_lcm inducts on n with Nat.recOnPosPrimePosCoprime: the n = 1 case is the empty lcm; the prime-power case n = p^k collapses to the singleton {p} with value λ(p^k); and the coprime case n = a·b combines the parent keystone carmichael_mul_coprime with Finset.lcm_union over the disjoint prime supports of a and b, using Finset.lcm_congr to identify v_p(a·b) with v_p(a) (resp. v_p(b)) on each part.",
+    "proofStrategy": "Induction via Nat.recOnPosPrimePosCoprime. Base 1: rewrite with Nat.factorization_one (empty support, so the lcm is 1) and carmichael_one. Prime power p^k: simp with hp.factorization_pow (factorization is the single point p ↦ k), Finsupp.support_single_ne_zero ({p}), Finset.lcm_singleton and Finsupp.single_eq_same, reducing both sides to λ(p^k). Coprime a·b: rw carmichael_mul_coprime to get lcm(λ(a), λ(b)); rw the induction hypotheses; rewrite the index set with Nat.factorization_mul + Finsupp.support_add_eq (disjoint supports from Coprime.disjoint_primeFactors) to a.support ∪ b.support; split with Finset.lcm_union; and realign the valuations with Finset.lcm_congr (on a.support the b-valuation is 0 by Finsupp.notMem_support_iff). lcm_eq_nat_lcm aligns the lattice lcm with Nat.lcm.",
+    "keyInsights": [
+      "The factorization formula is a pure consequence of coprime multiplicativity plus the bookkeeping of prime supports — no new number theory beyond the parent keystone.",
+      "Nat.recOnPosPrimePosCoprime is precisely tailored: its prime-power and coprime-product cases are exactly the two facts available (singleton value and carmichael_mul_coprime).",
+      "Writing the answer as Finset.lcm over n.factorization.support makes the coprime step a clean Finset.lcm_union over disjoint supports.",
+      "On a's prime factors the coprime partner contributes valuation 0, so v_p(a·b) = v_p(a); Finset.lcm_congr applies this pointwise so the induction hypothesis transfers without modification.",
+      "λ(1) = 1 follows from (ZMod 1)ˣ being a subsingleton, matching the empty-lcm base case of the induction."
+    ],
+    "prerequisites": [
+      "Group theory (exponent of a finite abelian group; direct products)",
+      "Number theory (prime factorization, p-adic valuation, coprimality)",
+      "Carmichael's function and its coprime multiplicativity (parent entries euler-totient-oq-01, euler-totient-oq-01-oq-01)"
+    ]
+  },
+  "conclusion": {
+    "summary": "For every positive n, Carmichael's function satisfies λ(n) = lcm over the prime factors p of n of λ(p^{v_p(n)}). This is the single-theorem prime-power factorization formula the parent entry deferred, obtained by inducting on the factorization with the parent's coprime keystone and distributing Finset.lcm over the disjoint prime supports. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent keystone this reduces every value of λ to its prime-power values λ(p^k). Combined with the cyclicity of (Z/p^kZ)* for odd p (and the explicit 2-power structure), it yields the classical closed form 'λ(n) = lcm of the cyclic group orders of (Z/nZ)*', and underlies the use of λ as the minimal exponent in modular exponentiation.",
+    "openQuestions": [
+      "Prove λ(2^k) = 2^{k-2} for k ≥ 3 from (Z/2^kZ)* ≅ Z/2 × Z/2^{k-2}, giving the last prime-power value in closed form.",
+      "Identify each odd prime-power value λ(p^k) with the order of the cyclic group (Z/p^kZ)*, closing the full 'lcm of cyclic group orders' characterization."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Discharges the parent's first open question by completing the induction over the prime-power factorization into a single theorem λ(n) = lcm_i λ(p_i^{k_i})"
+    },
+    {
+      "targetId": "euler-totient-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry on Carmichael prime-power values λ(p^k); this entry is what assembles those values into λ(n)"
+    },
+    {
+      "targetId": "euler-totient-oq-01",
+      "relationship": "related",
+      "description": "Carmichael's function λ(n) as the exponent of (Z/nZ)*, the root entry of this cluster"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.EulerTotientOQ01OQ01",
+      "Mathlib"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "CarmichaelFactorization",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/EulerTotientOQ01OQ01OQ01.lean"
+  }
+}

--- a/src/data/research/problems/euler-totient-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-01-oq-01.json
@@ -1,0 +1,367 @@
+{
+  "slug": "euler-totient-oq-01-oq-01-oq-01",
+  "title": "Carmichael Function as the lcm of Prime-Power Carmichael Values",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\lambda(n) \\;=\\; \\operatorname{lcm}_i \\,\\lambda\\bigl(p_i^{k_i}\\bigr),",
+    "plain": "Euler's theorem guarantees $a^{\\varphi(n)} \\equiv 1 \\pmod n$ for $a$ coprime to $n$, but $\\varphi(n)$ is usually not the *smallest* exponent that works for all such $a$. The smallest universal exponent is the Carmichael function $\\lambda(n)$, the exponent of the group of units mod $n$. By the Chinese Remainder Theorem the unit group factors as a product over the prime powers dividing $n$, so its exponent is the lcm of the exponents of the factors: $\\lambda(n) = \\operatorname{lcm}_i \\lambda(p_i^{k_i})$. This problem asks to complete the induction over the prime-power factorization and state that lcm identity as a single Lean theorem.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T16:43:04+0000",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved λ(n) = lcm over prime factors of λ(p^{v_p(n)}), the prime-power factorization formula the parent (euler-totient-oq-01-oq-01) explicitly deferred. Verified, 0 axioms.",
+    "builtItems": [
+      "carmichael_one : carmichael 1 = 1 (Proofs/EulerTotientOQ01OQ01OQ01.lean:64)",
+      "carmichael_eq_factorization_lcm : λ(n) = n.factorization.support.lcm (fun p => carmichael (p ^ n.factorization p)) for n ≠ 0 (Proofs/EulerTotientOQ01OQ01OQ01.lean:78)",
+      "Coprime split argument via Finset.lcm_union + Finset.lcm_congr over disjoint prime supports (Proofs/EulerTotientOQ01OQ01OQ01.lean:89)"
+    ],
+    "insights": [
+      "λ is the group exponent of (ZMod n)ˣ, so its factorization formula follows purely from group-theoretic facts about exponents, not direct number theory.",
+      "The induction Nat.recOnPosPrimePosCoprime reduces every positive n to prime-power blocks p^k and coprime products, matching exactly the two facts available: carmichael_mul_coprime (coprime keystone) and the singleton prime-power value.",
+      "Expressing the result as Finset.lcm over n.factorization.support (= n.primeFactors) lets Finset.lcm_union split the index set along the disjoint prime supports of coprime factors.",
+      "For p in a.primeFactors, v_p(a*b) = v_p(a) since the coprime factor b contributes valuation 0 there; Finset.lcm_congr swaps the (a*b)-indexed values for the a-indexed ones so the induction hypothesis applies verbatim.",
+      "(ZMod 1)ˣ is a subsingleton, so carmichael 1 = 1 via exponent_dvd_of_forall_pow_eq_one with bound 1; this matches the empty Finset.lcm = 1 base case."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no named Carmichael function λ(n); it is reused here as Monoid.exponent (ZMod n)ˣ from the parent entry.",
+      "No prior lemma packaging a multiplicative-over-coprime function as a Finset.lcm over the prime factorization; assembled here from Nat.recOnPosPrimePosCoprime + Finset.lcm_union."
+    ],
+    "nextSteps": [
+      "Prove λ(2^k) = 2^{k-2} for k ≥ 3 from (ZMod 2^k)ˣ ≅ ZMod 2 × ZMod 2^{k-2}.",
+      "Combine with cyclicity of (ZMod p^k)ˣ for odd p to identify each prime-power value λ(p^k) with a single cyclic order, closing the full lcm-of-cyclic-orders characterization."
+    ],
+    "markdown": "# Knowledge Base: euler-totient-oq-01-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "euler-totient",
+    "euler-totient-oq-01",
+    "euler-totient-oq-01-oq-01",
+    "euler-totient-oq-01-oq-01-oq-01",
+    "euler-totient-oq-01-oq-02",
+    "euler-totient-oq-01-oq-02-oq-01",
+    "euler-totient-oq-01-oq-02-oq-03",
+    "euler-totient-oq-01-oq-03",
+    "euler-totient-oq-02",
+    "euler-totient-oq-02-oq-01",
+    "euler-totient-oq-03",
+    "euler-totient-oq-03-oq-03",
+    "euler-totient-oq-04",
+    "euler-totient-oq-05",
+    "euler-totient-oq-06",
+    "euler-totient-oq-06-oq-01",
+    "euler-totient-oq-07",
+    "euler-totient-oq-07-oq-04",
+    "euler-totient-oq-09",
+    "euler-totient-oq-09-oq-01",
+    "euler-totient-oq-09-oq-02",
+    "euler-totient-oq-10"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T17:05:24.936Z",
+  "lastUpdate": "2026-06-24",
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerTotient.lean",
+      "filename": "EulerTotient.lean",
+      "lineCount": 136,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotient.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01.lean",
+      "filename": "EulerTotientOQ01.lean",
+      "lineCount": 88,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ01.lean",
+      "filename": "EulerTotientOQ01OQ01.lean",
+      "lineCount": 77,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ01OQ01.lean",
+      "filename": "EulerTotientOQ01OQ01OQ01.lean",
+      "lineCount": 115,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ02.lean",
+      "filename": "EulerTotientOQ01OQ02.lean",
+      "lineCount": 76,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ02OQ01.lean",
+      "filename": "EulerTotientOQ01OQ02OQ01.lean",
+      "lineCount": 123,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ02OQ03.lean",
+      "filename": "EulerTotientOQ01OQ02OQ03.lean",
+      "lineCount": 167,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ03.lean",
+      "filename": "EulerTotientOQ01OQ03.lean",
+      "lineCount": 240,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ03Keygen.lean",
+      "filename": "EulerTotientOQ01OQ03Keygen.lean",
+      "lineCount": 78,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03Keygen.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ01OQ03Minimal.lean",
+      "filename": "EulerTotientOQ01OQ03Minimal.lean",
+      "lineCount": 55,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ03Minimal.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ02.lean",
+      "filename": "EulerTotientOQ02.lean",
+      "lineCount": 173,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ02.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ02OQ01.lean",
+      "filename": "EulerTotientOQ02OQ01.lean",
+      "lineCount": 208,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ03.lean",
+      "filename": "EulerTotientOQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ03OQ03.lean",
+      "filename": "EulerTotientOQ03OQ03.lean",
+      "lineCount": 135,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ04.lean",
+      "filename": "EulerTotientOQ04.lean",
+      "lineCount": 232,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ04OQ01.lean",
+      "filename": "EulerTotientOQ04OQ01.lean",
+      "lineCount": 165,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ05.lean",
+      "filename": "EulerTotientOQ05.lean",
+      "lineCount": 179,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ05.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ06.lean",
+      "filename": "EulerTotientOQ06.lean",
+      "lineCount": 83,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ06.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ06OQ01.lean",
+      "filename": "EulerTotientOQ06OQ01.lean",
+      "lineCount": 159,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ06OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ07.lean",
+      "filename": "EulerTotientOQ07.lean",
+      "lineCount": 107,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ07.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ07OQ04.lean",
+      "filename": "EulerTotientOQ07OQ04.lean",
+      "lineCount": 136,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ07OQ04.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ09.lean",
+      "filename": "EulerTotientOQ09.lean",
+      "lineCount": 122,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ09.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ09OQ01.lean",
+      "filename": "EulerTotientOQ09OQ01.lean",
+      "lineCount": 163,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ09OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ09OQ02.lean",
+      "filename": "EulerTotientOQ09OQ02.lean",
+      "lineCount": 124,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ09OQ02.lean"
+    },
+    {
+      "path": "Proofs/EulerTotientOQ10.lean",
+      "filename": "EulerTotientOQ10.lean",
+      "lineCount": 154,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ10.lean"
+    }
+  ],
+  "id": "euler-totient-oq-01-oq-01-oq-01",
+  "problemId": "euler-totient-oq-01-oq-01-oq-01",
+  "name": "Carmichael Function as the lcm of Prime-Power Carmichael Values"
+}


### PR DESCRIPTION
## Summary

Discharges the **first open question** the parent entry `euler-totient-oq-01-oq-01` explicitly deferred "as a routine induction":

> Complete the induction over the prime-power factorization to state λ(n) = lcm_i λ(p_i^{k_i}) as a single theorem.

For every positive `n`, Carmichael's function satisfies
```
λ(n) = lcm over the prime factors p of n of λ(p^{v_p(n)})
```
expressed as `Finset.lcm` over `n.factorization.support` (with `v_p(n) = n.factorization p`).

## Proof

`carmichael n` is the parent's `Monoid.exponent (ZMod n)ˣ` (reused by import). Induct on `n` with `Nat.recOnPosPrimePosCoprime`:

- **n = 1** — `(ZMod 1)ˣ` is trivial so `λ(1) = 1` (`carmichael_one`), matching the empty `Finset.lcm = 1`.
- **n = pᵏ** — the factorization is the single point `p ↦ k`; the index set collapses to `{p}` and the singleton lcm is exactly `λ(pᵏ)`.
- **n = a·b coprime** — the parent keystone `carmichael_mul_coprime` gives `λ(a·b) = lcm(λ(a), λ(b))`; the prime supports are disjoint (`Coprime.disjoint_primeFactors`), so the index set splits as a disjoint union and `Finset.lcm_union` distributes. `Finset.lcm_congr` realigns `v_p(a·b)` to `v_p(a)` (resp. `v_p(b)`) on each part — the other factor contributes valuation 0 — so the induction hypotheses apply verbatim.

## Verification

- **0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **0 sorries**, 2 theorems, 114 lines.
- Built with `lake env lean` against Mathlib 4.26.0; `#print axioms` confirms no `sorryAx` / `Lean.ofReduceBool`.

## Follow-ups (in meta)
- λ(2ᵏ) = 2^{k-2} for k ≥ 3 from `(Z/2ᵏZ)* ≅ Z/2 × Z/2^{k-2}`.
- Identify each odd prime-power value λ(pᵏ) with the order of the cyclic group `(Z/pᵏZ)*`, closing the full "lcm of cyclic group orders" characterization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)