### PR TITLE
research(euler-criterion-squares-oq-01-oq-01): exactly (p−1)/2 nonzero quadratic residues mod an odd prime (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs/EulerCriterionSquaresOQ01OQ01.lean
+++ b/proofs/Proofs/EulerCriterionSquaresOQ01OQ01.lean
@@ -1,0 +1,129 @@
+/-
+  Counting quadratic residues: an odd prime `p` has exactly `(p − 1)/2`
+  nonzero quadratic residues.
+
+  The classical count follows from the *squaring map* on the unit group.
+  The endomorphism `sq : (ZMod p)ˣ →* (ZMod p)ˣ`, `u ↦ u²`, is a group
+  homomorphism (the units of a commutative ring form a commutative group).
+  Its kernel is the set of square roots of `1`, namely `{1, −1}` — two
+  *distinct* elements precisely because `p` is odd — so the first
+  isomorphism theorem gives
+
+      |image of sq| = |(ZMod p)ˣ| / |ker sq| = (p − 1) / 2.
+
+  The image of `sq` is exactly the set of nonzero quadratic residues, so
+  there are `(p − 1)/2` of them.
+
+  This complements `EulerCriterionSquaresOQ01`: Euler's criterion identifies
+  the residues as the `+1`-values of `a ↦ a^((p−1)/2)`; here we instead count
+  them directly from the `2`-to-`1` squaring map and its kernel.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open ZMod
+
+namespace EulerCriterionSquaresOQ01OQ01
+
+variable (p : ℕ) [Fact p.Prime] [Fact (2 < p)]
+
+/-- The squaring endomorphism `u ↦ u²` of the unit group `(ZMod p)ˣ`. -/
+def sqHom : (ZMod p)ˣ →* (ZMod p)ˣ := powMonoidHom 2
+
+omit [Fact (2 < p)] in
+@[simp] theorem sqHom_apply (u : (ZMod p)ˣ) : sqHom p u = u ^ 2 := rfl
+
+/-- `1 ≠ −1` in `(ZMod p)ˣ` for an odd prime: otherwise `1 = −1` in `ZMod p`,
+forcing `p ∣ 2`. -/
+theorem one_ne_neg_one_units : (1 : (ZMod p)ˣ) ≠ -1 := by
+  intro h
+  have hz : (1 : ZMod p) = -1 := by
+    have := congrArg Units.val h; simpa using this
+  have h2 : ((2 : ℕ) : ZMod p) = 0 := by push_cast; linear_combination hz
+  rw [ZMod.natCast_eq_zero_iff] at h2
+  have := Nat.le_of_dvd (by norm_num) h2
+  have : 2 < p := Fact.out
+  omega
+
+omit [Fact (2 < p)] in
+/-- A unit lies in the kernel of squaring iff it is `±1`. -/
+theorem mem_sqHom_ker {u : (ZMod p)ˣ} : u ∈ (sqHom p).ker ↔ u = 1 ∨ u = -1 := by
+  rw [MonoidHom.mem_ker, sqHom_apply]
+  constructor
+  · intro h
+    have hv : (↑u : ZMod p) ^ 2 = 1 := by
+      have := congrArg Units.val h
+      simpa [Units.val_pow_eq_pow_val] using this
+    rcases sq_eq_one_iff.mp hv with h1 | h1
+    · exact Or.inl (Units.val_eq_one.mp h1)
+    · refine Or.inr ?_
+      apply Units.ext
+      rw [h1]; simp
+  · rintro (rfl | rfl)
+    · exact one_pow 2
+    · apply Units.ext; push_cast; ring
+
+/-- The kernel of squaring is `{1, −1}`, hence has cardinality `2`. -/
+theorem card_sqHom_ker : Nat.card (sqHom p).ker = 2 := by
+  have hset : ((sqHom p).ker : Set (ZMod p)ˣ) = {1, -1} := by
+    ext u
+    rw [SetLike.mem_coe, mem_sqHom_ker]
+    simp [Set.mem_insert_iff]
+  have heq : Nat.card (sqHom p).ker = ((sqHom p).ker : Set (ZMod p)ˣ).ncard := rfl
+  rw [heq, hset, Set.ncard_pair (one_ne_neg_one_units p)]
+
+/-- **Quadratic-residue count (units form).** The squaring map's image — the
+quadratic residues among the units — has cardinality `(p − 1)/2`. -/
+theorem card_sqHom_range : Nat.card (sqHom p).range = (p - 1) / 2 := by
+  have hcard : Nat.card (sqHom p).ker * Nat.card (sqHom p).range = Nat.card (ZMod p)ˣ := by
+    rw [← Subgroup.index_ker]; exact Subgroup.card_mul_index _
+  have hu : Nat.card (ZMod p)ˣ = p - 1 := by
+    rw [Nat.card_eq_fintype_card, ZMod.card_units]
+  rw [card_sqHom_ker, hu] at hcard
+  omega
+
+omit [Fact (2 < p)] in
+/-- A nonzero residue characterisation: for a unit `u`, the field element `↑u`
+is a square iff `u` is a square in the unit group (i.e. lies in the image of
+the squaring map). -/
+theorem isSquare_coe_iff_mem_range {u : (ZMod p)ˣ} :
+    IsSquare (↑u : ZMod p) ↔ u ∈ (sqHom p).range := by
+  rw [MonoidHom.mem_range]
+  constructor
+  · rintro ⟨r, hr⟩
+    have hr0 : r ≠ 0 := by
+      rintro rfl
+      simp only [mul_zero] at hr
+      exact u.ne_zero hr
+    obtain ⟨w, rfl⟩ := (isUnit_iff_ne_zero.mpr hr0)
+    refine ⟨w, ?_⟩
+    apply Units.ext
+    rw [sqHom_apply, Units.val_pow_eq_pow_val]
+    rw [hr]; ring
+  · rintro ⟨v, rfl⟩
+    exact ⟨↑v, by rw [sqHom_apply, Units.val_pow_eq_pow_val]; ring⟩
+
+/-- **Quadratic-residue count.** An odd prime `p` has exactly `(p − 1)/2`
+nonzero quadratic residues in `ZMod p`. -/
+theorem card_nonzero_quadratic_residues :
+    Nat.card {a : ZMod p // a ≠ 0 ∧ IsSquare a} = (p - 1) / 2 := by
+  rw [← card_sqHom_range p]
+  refine Nat.card_congr (Equiv.symm ?_)
+  refine (Equiv.subtypeEquivRight (fun u => (isSquare_coe_iff_mem_range p).symm)).trans ?_
+  refine (@Equiv.subtypeEquiv (ZMod p)ˣ {a : ZMod p // a ≠ 0}
+      (fun u => IsSquare (↑u : ZMod p)) (fun x => IsSquare (x : ZMod p))
+      unitsEquivNeZero (fun u => Iff.rfl)).trans ?_
+  exact Equiv.subtypeSubtypeEquivSubtypeInter (· ≠ (0 : ZMod p)) IsSquare
+
+/-! ### Concrete check modulo 7 -/
+
+/-- Mod `7` there are `(7−1)/2 = 3` nonzero quadratic residues, namely
+`{1, 2, 4}` (the squares `1², 2², 3²`). -/
+theorem card_residues_mod_seven :
+    Nat.card {a : ZMod 7 // a ≠ 0 ∧ IsSquare a} = 3 := by
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  haveI : Fact (2 < 7) := ⟨by norm_num⟩
+  exact card_nonzero_quadratic_residues 7
+
+end EulerCriterionSquaresOQ01OQ01

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "euler-criterion-squares-oq-01-oq-01",
+  "title": "Counting Quadratic Residues: Exactly (p−1)/2 Nonzero Residues mod an Odd Prime",
+  "slug": "euler-criterion-squares-oq-01-oq-01",
+  "description": "An odd prime p has exactly (p−1)/2 nonzero quadratic residues in ZMod p. The count is derived structurally from the squaring endomorphism sq : (ZMod p)ˣ →* (ZMod p)ˣ, u ↦ u²: its kernel is {1, −1} (the square roots of unity, two distinct elements since p is odd), so by the first isomorphism theorem the image — the quadratic residues among the units — has cardinality |(ZMod p)ˣ| / |ker| = (p−1)/2. A subtype equivalence then identifies the image with the nonzero squares of ZMod p, giving Nat.card {a : ZMod p // a ≠ 0 ∧ IsSquare a} = (p−1)/2. Confirmed concretely mod 7 (3 residues). 8 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Quadratic_residue",
+    "date": "Classical (Euler/Legendre, 18th century)",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "euler-criterion",
+      "finite-fields",
+      "group-theory",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EulerCriterionSquaresOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 8 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete check modulo 7 reuses the general theorem applied at p = 7, so no native_decide and no Lean.ofReduceBool is introduced.",
+    "originalContributions": [
+      "card_nonzero_quadratic_residues: the headline count — an odd prime p has exactly (p−1)/2 nonzero quadratic residues, Nat.card {a : ZMod p // a ≠ 0 ∧ IsSquare a} = (p−1)/2",
+      "sqHom: the squaring endomorphism u ↦ u² of the unit group (ZMod p)ˣ, with mem_sqHom_ker characterizing its kernel as {1, −1}",
+      "card_sqHom_ker: the kernel of squaring has cardinality 2 (= {1, −1}, distinct because p is odd), and card_sqHom_range: its image — the residues among the units — has cardinality (p−1)/2 via the first isomorphism theorem (Subgroup.card_mul_index / Subgroup.index_ker) and |(ZMod p)ˣ| = p − 1",
+      "isSquare_coe_iff_mem_range: bridges the unit-group image to field squares — for a unit u, ↑u is a square in ZMod p iff u lies in the image of the squaring map",
+      "card_residues_mod_seven: concrete confirmation that ZMod 7 has (7−1)/2 = 3 nonzero quadratic residues, obtained by applying the general theorem at p = 7"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 129,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "That an odd prime p has exactly (p−1)/2 quadratic residues and (p−1)/2 non-residues among the nonzero classes is one of the oldest facts of number theory, implicit in Euler's and Legendre's work on residuosity and reciprocity. It expresses that the squares form the unique index-2 subgroup of the cyclic group (ℤ/pℤ)ˣ. The classical analytic route counts the +1-values of Euler's criterion a^((p−1)/2); the structural route — taken here — counts the image of the squaring homomorphism, whose 2-to-1 nature is exactly the statement '±√a are the only square roots'.",
+    "problemStatement": "**Open Question (OQ-01-01, from euler-criterion-squares-oq-01)**: Derive the count of quadratic residues — exactly (p−1)/2 nonzero residues mod an odd prime — from the residue/non-residue structure.\n\n**Formalized**: card_nonzero_quadratic_residues, Nat.card {a : ZMod p // a ≠ 0 ∧ IsSquare a} = (p−1)/2, via the kernel/image decomposition of the squaring map on (ZMod p)ˣ.",
+    "text": "A 129-line, self-contained formalization (imports only Mathlib). The squaring map sqHom = powMonoidHom 2 on (ZMod p)ˣ is a group homomorphism; its kernel consists of the units squaring to 1, which mem_sqHom_ker identifies with {1, −1}. Because p is odd, 1 ≠ −1 in the unit group (one_ne_neg_one_units), so the kernel has exactly 2 elements (card_sqHom_ker). The first isomorphism theorem in cardinality form (Subgroup.card_mul_index together with Subgroup.index_ker) combined with |(ZMod p)ˣ| = p − 1 (ZMod.card_units) yields |image| = (p−1)/2 (card_sqHom_range). Finally isSquare_coe_iff_mem_range shows the image is precisely the nonzero field squares, and a chain of Equiv (subtypeEquiv via unitsEquivNeZero, subtypeSubtypeEquivSubtypeInter) transports the count to Nat.card {a : ZMod p // a ≠ 0 ∧ IsSquare a} = (p−1)/2. Everything compiles with 0 sorries and 0 axioms; the mod-7 instance is the general theorem specialized, so no native_decide.",
+    "proofStrategy": "**sqHom / sqHom_apply**: define u ↦ u² as powMonoidHom 2 on (ZMod p)ˣ.\n\n**one_ne_neg_one_units**: if 1 = −1 in (ZMod p)ˣ then 1 = −1 in ZMod p, forcing (2 : ZMod p) = 0, i.e. p ∣ 2, contradicting 2 < p (ZMod.natCast_eq_zero_iff, Nat.le_of_dvd, omega).\n\n**mem_sqHom_ker**: u² = 1 in the unit group iff (↑u)² = 1 in the field; by sq_eq_one_iff this means ↑u = ±1, i.e. u = ±1 (Units.ext).\n\n**card_sqHom_ker**: the kernel as a set equals {1, −1}; Set.ncard_pair with 1 ≠ −1 gives cardinality 2.\n\n**card_sqHom_range**: |ker| · |range| = |(ZMod p)ˣ| via Subgroup.index_ker and Subgroup.card_mul_index; substitute |ker| = 2 and |(ZMod p)ˣ| = p − 1, then omega solves 2 · x = p − 1 ⇒ x = (p−1)/2.\n\n**isSquare_coe_iff_mem_range**: a square ↑u = r² with r ≠ 0 lifts r to a unit w with w² = u (so u ∈ range); conversely an image element v² maps to a field square. Uses isUnit_iff_ne_zero and Units.val_pow_eq_pow_val.\n\n**card_nonzero_quadratic_residues**: assemble Equiv (ZMod p)ˣ-with-IsSquare ≃ {a ≠ 0 ∧ IsSquare a} from unitsEquivNeZero and subtypeSubtypeEquivSubtypeInter, then Nat.card_congr transports |range| = (p−1)/2.\n\n**card_residues_mod_seven**: instantiate the general theorem at p = 7 (Fact 7.Prime, Fact (2 < 7)).",
+    "keyInsights": [
+      "**Counting = the first isomorphism theorem**: the residue count is not an analytic accident but the index of the squares subgroup. |residues| = |(ZMod p)ˣ| / |ker(squaring)| = (p−1)/2 follows the instant you know the squaring map is 2-to-1.",
+      "**Why the kernel is exactly 2**: the square roots of unity in a field are ±1, and these are distinct precisely when p is odd. The single hypothesis 2 < p enters only through one_ne_neg_one_units — for p = 2 the kernel collapses and the count formula degenerates.",
+      "**Units vs field elements**: residues are most naturally counted in the unit group (where squaring is a homomorphism), then transported to the field's nonzero squares. The Equiv unitsEquivNeZero makes 'nonzero element' and 'unit' interchangeable, so |range(sqHom)| equals the count of nonzero squares with no recomputation.",
+      "**Complementary to Euler's criterion**: the parent entry detects residues analytically as the +1-values of a^((p−1)/2); here the same subgroup is counted structurally. The two views agree because both compute the index-2 subgroup of squares.",
+      "**0-axiom, including the numerics**: the mod-7 confirmation is the general theorem applied at p = 7, not a separate decide computation, so the file depends only on propext / Classical.choice / Quot.sound — no native_decide, no Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "The unit group (ZMod p)ˣ of a finite field and its cardinality p − 1 (ZMod.card_units)",
+      "Group homomorphisms, kernels and images, and the first isomorphism theorem in cardinality form (Subgroup.card_mul_index, Subgroup.index_ker)",
+      "Square roots of unity in a field: x² = 1 ↔ x = ±1 (sq_eq_one_iff)",
+      "Quadratic residues as IsSquare, and the equivalence between nonzero field elements and units (isUnit_iff_ne_zero, unitsEquivNeZero)",
+      "Cardinality transport along equivalences (Nat.card_congr) and subtype equivalences (Equiv.subtypeEquiv, Equiv.subtypeSubtypeEquivSubtypeInter)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "parent",
+      "description": "The parent establishes Euler's criterion and the ±1 dichotomy a^((p−1)/2) = ±1. This entry answers its first open question — counting the residues — but via the squaring map's kernel/image rather than the criterion's +1-values, giving an independent structural derivation of the same (p−1)/2."
+    },
+    {
+      "proofId": "primitive-roots-oq-03",
+      "relationship": "related",
+      "description": "Both concern the multiplicative structure of (ℤ/pℤ)ˣ. The squares form the index-2 subgroup counted here; a primitive root generates the whole cyclic group, of which the squares are the even powers."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "EulerCriterionSquaresOQ01OQ01",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/EulerCriterionSquaresOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "card_nonzero_quadratic_residues",
+      "type": "core",
+      "statement": "$p$ odd prime $\\Rightarrow$ $\\#\\{a \\in \\mathbb{Z}/p : a \\ne 0 \\wedge \\mathrm{IsSquare}\\,a\\} = (p-1)/2$",
+      "significance": "The headline count: an odd prime has exactly (p−1)/2 nonzero quadratic residues. Obtained by transporting the cardinality of the squaring map's image to the nonzero field squares.",
+      "description": "There are exactly (p−1)/2 nonzero quadratic residues mod an odd prime p."
+    },
+    {
+      "name": "card_sqHom_range",
+      "type": "core",
+      "statement": "$\\#\\,\\mathrm{range}(u \\mapsto u^2) = (p-1)/2$ in $(\\mathbb{Z}/p)^\\times$",
+      "significance": "The residues among the units number (p−1)/2 by the first isomorphism theorem: |range| = |units| / |kernel| = (p−1)/2. The structural heart of the count.",
+      "description": "The image of the squaring map on the unit group has cardinality (p−1)/2."
+    },
+    {
+      "name": "card_sqHom_ker",
+      "type": "core",
+      "statement": "$\\#\\,\\ker(u \\mapsto u^2) = 2$ in $(\\mathbb{Z}/p)^\\times$",
+      "significance": "The squaring map is 2-to-1: its kernel is {1, −1}, two distinct elements exactly because p is odd. This factor of 2 is what halves the unit count.",
+      "description": "The kernel of the squaring map is {1, −1}, of cardinality 2."
+    },
+    {
+      "name": "mem_sqHom_ker",
+      "type": "supporting",
+      "statement": "$u \\in \\ker(u \\mapsto u^2) \\iff u = 1 \\vee u = -1$",
+      "significance": "Identifies the kernel of squaring with the square roots of unity ±1, using that the only field solutions of x² = 1 are ±1.",
+      "description": "A unit squares to 1 iff it is ±1."
+    },
+    {
+      "name": "isSquare_coe_iff_mem_range",
+      "type": "supporting",
+      "statement": "for a unit $u$, $\\mathrm{IsSquare}(\\uparrow u) \\iff u \\in \\mathrm{range}(u \\mapsto u^2)$",
+      "significance": "Bridges the unit-group image to field squares, so the cardinality count on the unit group transfers to the nonzero quadratic residues of ZMod p.",
+      "description": "A unit is a field square iff it lies in the image of the squaring map."
+    },
+    {
+      "name": "one_ne_neg_one_units",
+      "type": "supporting",
+      "statement": "$(1 : (\\mathbb{Z}/p)^\\times) \\ne -1$ for an odd prime $p$",
+      "significance": "The distinctness that makes the kernel have 2 (not 1) elements. Fails for p = 2, which is why the formula needs an odd prime.",
+      "description": "1 ≠ −1 in the unit group of an odd prime."
+    },
+    {
+      "name": "card_residues_mod_seven",
+      "type": "supporting",
+      "statement": "$\\#\\{a \\in \\mathbb{Z}/7 : a \\ne 0 \\wedge \\mathrm{IsSquare}\\,a\\} = 3$",
+      "significance": "Concrete confirmation at p = 7: (7−1)/2 = 3 residues, namely {1, 2, 4}. Obtained by specializing the general theorem, so it adds no axioms.",
+      "description": "ZMod 7 has exactly 3 nonzero quadratic residues."
+    }
+  ],
+  "references": [
+    {
+      "text": "Quadratic residue — an odd prime has (p−1)/2 quadratic residues and (p−1)/2 non-residues among the nonzero classes.",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_residue"
+    },
+    {
+      "text": "Ireland, K. & Rosen, M. A Classical Introduction to Modern Number Theory. The squares as the index-2 subgroup of (ℤ/pℤ)ˣ.",
+      "url": "https://en.wikipedia.org/wiki/Legendre_symbol"
+    },
+    {
+      "text": "Mathlib4: ZMod.card_units, Subgroup.card_mul_index, Subgroup.index_ker, sq_eq_one_iff, unitsEquivNeZero, Equiv.subtypeSubtypeEquivSubtypeInter.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves that an odd prime p has exactly (p−1)/2 nonzero quadratic residues (card_nonzero_quadratic_residues). The argument is structural: the squaring endomorphism of (ZMod p)ˣ has kernel {1, −1} (card_sqHom_ker), so its image has cardinality (p−1)/2 by the first isomorphism theorem (card_sqHom_range); isSquare_coe_iff_mem_range identifies that image with the nonzero field squares, and an equivalence transports the count. Confirmed at p = 7 (card_residues_mod_seven). All 8 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The result pins down the squares as the index-2 subgroup of (ℤ/pℤ)ˣ — the structural fact underlying the Legendre symbol's surjectivity onto {±1}, the equal split of residues and non-residues, and the counting used in Gauss sums and quadratic reciprocity. The kernel/image method generalizes verbatim to higher powers (e.g. counting k-th power residues via the k-to-1 power map when k ∣ p − 1).",
+    "openQuestions": [
+      "Count k-th power residues for k ∣ p − 1: the map u ↦ u^k on (ZMod p)ˣ has kernel of size gcd(k, p−1) = k, so there are (p−1)/k nonzero k-th power residues — formalize this generalization.",
+      "Show the residues and non-residues each number (p−1)/2 simultaneously, as complementary subsets, and connect to the Legendre-symbol sum ∑_{a≠0} (a | p) = 0."
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/euler-criterion-squares-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-criterion-squares-oq-01-oq-01.json
@@ -1,0 +1,104 @@
+{
+  "slug": "euler-criterion-squares-oq-01-oq-01",
+  "title": "Counting Quadratic Residues: Exactly (p−1)/2 Nonzero Residues mod an Odd Prime",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "p \\text{ odd prime} \\;\\Rightarrow\\; \\#\\{a \\in \\mathbb{Z}/p : a \\ne 0 \\wedge \\mathrm{IsSquare}\\,a\\} = (p-1)/2.",
+    "plain": "An odd prime p has exactly (p−1)/2 nonzero quadratic residues. Derived from the squaring map u ↦ u² on the unit group: kernel {1,−1} (size 2) ⇒ image (the residues) has size |units|/2 = (p−1)/2 by the first isomorphism theorem.",
+    "whyMatters": [
+      "Pins the squares as the index-2 subgroup of (ℤ/pℤ)ˣ, the structural fact behind the Legendre symbol and quadratic reciprocity."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "card_nonzero_quadratic_residues: exactly (p−1)/2 nonzero quadratic residues mod an odd prime",
+      "card_sqHom_range: image of the squaring map has cardinality (p−1)/2",
+      "card_sqHom_ker: kernel of squaring is {1,−1}, cardinality 2"
+    ],
+    "open": [],
+    "goal": "Count the nonzero quadratic residues mod an odd prime."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T10:00:00-07:00",
+    "iteration": 1,
+    "focus": "Structural count via the squaring-map kernel/image and first isomorphism theorem.",
+    "blockers": [],
+    "nextAction": "Generalize to k-th power residues (kernel of u ↦ u^k has size gcd(k,p−1)).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved the (p−1)/2 quadratic-residue count structurally via the squaring homomorphism on (ZMod p)ˣ; 8 theorems, 1 def, 0 sorries, 0 axioms.",
+    "builtItems": [
+      "sqHom (Proofs/EulerCriterionSquaresOQ01OQ01.lean:32): squaring endomorphism powMonoidHom 2 on (ZMod p)ˣ",
+      "mem_sqHom_ker (Proofs/EulerCriterionSquaresOQ01OQ01.lean:51): kernel = {1,−1} via sq_eq_one_iff",
+      "card_sqHom_ker (Proofs/EulerCriterionSquaresOQ01OQ01.lean:68): |kernel| = 2 (Set.ncard_pair, one_ne_neg_one_units)",
+      "card_sqHom_range (Proofs/EulerCriterionSquaresOQ01OQ01.lean:78): |range| = (p−1)/2 via Subgroup.card_mul_index, Subgroup.index_ker, ZMod.card_units",
+      "isSquare_coe_iff_mem_range (Proofs/EulerCriterionSquaresOQ01OQ01.lean:90): unit is a field square iff in image of squaring",
+      "card_nonzero_quadratic_residues (Proofs/EulerCriterionSquaresOQ01OQ01.lean:109): headline count, transported via unitsEquivNeZero + subtypeSubtypeEquivSubtypeInter",
+      "card_residues_mod_seven (Proofs/EulerCriterionSquaresOQ01OQ01.lean:123): concrete instance at p = 7 → 3 residues"
+    ],
+    "insights": [
+      "The residue count is the index of the squares subgroup: |residues| = |(ZMod p)ˣ| / |ker(squaring)| = (p−1)/2 by the first isomorphism theorem in cardinality form.",
+      "The kernel has exactly 2 elements because the only square roots of unity in a field are ±1, distinct precisely when p is odd; the hypothesis 2 < p enters only through one_ne_neg_one_units.",
+      "Counting is cleanest in the unit group (where squaring is a homomorphism); unitsEquivNeZero transports |range| to the count of nonzero field squares without recomputation.",
+      "Independent of the parent's analytic route (Euler's criterion +1-values): both compute the same index-2 subgroup of squares.",
+      "The method generalizes to k-th power residues: u ↦ u^k has kernel of size gcd(k, p−1)."
+    ],
+    "mathlibGaps": [
+      "No single Mathlib lemma directly counts quadratic residues in ZMod p; assembled from Subgroup.card_mul_index / Subgroup.index_ker, ZMod.card_units, sq_eq_one_iff, and unitsEquivNeZero."
+    ],
+    "nextSteps": [
+      "Generalize to (p−1)/k nonzero k-th power residues for k ∣ p − 1 (kernel of u ↦ u^k has size gcd(k, p−1)).",
+      "Add the complementary non-residue count and relate to ∑_{a≠0} (a | p) = 0."
+    ],
+    "markdown": "# Knowledge Base: euler-criterion-squares-oq-01-oq-01\n\n## Problem\nCount the nonzero quadratic residues of an odd prime p: exactly (p−1)/2.\n\n## Approach (COMPLETE)\nStructural, via the squaring homomorphism sqHom : (ZMod p)ˣ →* (ZMod p)ˣ, u ↦ u².\n- Kernel = {1, −1}, cardinality 2 (distinct because p odd).\n- First isomorphism theorem ⇒ |image| = |(ZMod p)ˣ| / |kernel| = (p−1)/2.\n- isSquare_coe_iff_mem_range identifies the image with the nonzero field squares.\n- Nat.card_congr + unitsEquivNeZero + subtypeSubtypeEquivSubtypeInter transport the count.\n\nResult: card_nonzero_quadratic_residues, 8 theorems / 1 def, 0 sorries, 0 axioms, no native_decide. Confirmed at p = 7 (3 residues).\n\n## Dead Ends\nNone — the kernel/image route compiled directly.\n"
+  },
+  "tags": [
+    "number-theory",
+    "quadratic-residues",
+    "euler-criterion",
+    "finite-fields",
+    "group-theory"
+  ],
+  "relatedProofs": [
+    "euler-criterion-squares-oq-01",
+    "euler-criterion-squares-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Quadratic_residue"
+    ],
+    "mathlib": [
+      "ZMod.card_units",
+      "Subgroup.card_mul_index",
+      "Subgroup.index_ker",
+      "sq_eq_one_iff",
+      "unitsEquivNeZero"
+    ]
+  },
+  "started": "2026-06-24T17:00:00.000Z",
+  "lastUpdate": "2026-06-24T17:30:00.000Z",
+  "completed": "2026-06-24T17:30:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ01.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ01.lean",
+      "lineCount": 129,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `euler-criterion-squares-oq-01` (*"Derive the count of quadratic residues: exactly (p−1)/2 nonzero residues from the ±1 dichotomy"*).

For an odd prime `p`:
$$\#\{a \in \mathbb{Z}/p : a \ne 0 \wedge \mathrm{IsSquare}\,a\} = (p-1)/2.$$

## Approach — structural, not analytic

Where the parent detects residues via Euler's criterion (`a^((p−1)/2) = ±1`), this entry **counts** them via the squaring endomorphism `sqHom : (ZMod p)ˣ →* (ZMod p)ˣ`, `u ↦ u²`:

- **Kernel = {1, −1}** (`mem_sqHom_ker`, `card_sqHom_ker`): the square roots of unity, two *distinct* elements precisely because `p` is odd (`one_ne_neg_one_units`).
- **First isomorphism theorem** (`card_sqHom_range`): `|range| = |(ZMod p)ˣ| / |ker| = (p−1)/2`, using `Subgroup.card_mul_index`, `Subgroup.index_ker`, `ZMod.card_units`.
- **Bridge to field squares** (`isSquare_coe_iff_mem_range`) + an `Equiv` chain (`unitsEquivNeZero`, `subtypeSubtypeEquivSubtypeInter`) transport the count to the nonzero quadratic residues (`card_nonzero_quadratic_residues`).

Confirmed concretely at `p = 7` (3 residues) by specializing the general theorem — no `native_decide`.

## Verification

- **8 theorems, 1 definition, 129 lines**, self-contained (`import Mathlib`).
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext` / `Classical.choice` / `Quot.sound`. No `Lean.ofReduceBool`.
- Builds clean under the Lean 4.26 / Mathlib toolchain.

## Files

- `proofs/Proofs/EulerCriterionSquaresOQ01OQ01.lean`
- `src/data/proofs/euler-criterion-squares-oq-01-oq-01/meta.json`
- `src/data/research/problems/euler-criterion-squares-oq-01-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)