### PR TITLE
audit: fundamental-arithmetic-oq-03 badge original→mathlib (Tier B wrapper); clear 2 unaudited leaves

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21903,8 +21903,22 @@
       "lastAudited": "2026-06-24T17:06:45Z",
       "result": "clean",
       "issues": []
+    },
+    "basel-problem-oq-10-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T17:15:24Z",
+      "result": "clean"
+    },
+    "fundamental-arithmetic-oq-03": {
+      "auditCount": 1,
+      "issues": [
+        "badge 'original' overstated a pure Mathlib wrapper: every theorem is a 1-2 line composition of riemannZeta_eulerProduct_* and riemannZeta_two/_four (failure mode 5 / Tier B). Corrected badge to 'mathlib'."
+      ],
+      "lastAudited": "2026-06-24T17:15:24Z",
+      "result": "issues-fixed"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T12:27:19Z"
+  "lastUpdated": "2026-06-24T17:15:24Z"
 }

--- a/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
@@ -17,7 +17,7 @@
       "classic"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmeticOQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 9,


### PR DESCRIPTION
## Gallery integrity audit

Two never-audited leaves reviewed this cycle.

### fundamental-arithmetic-oq-03 — badge corrected (MEDIUM)

**Problem**: badge `"original"` on a pure Mathlib wrapper (failure mode 5 / Tier B).

`Proofs/FundamentalArithmeticOQ03.lean` proves Euler's product ∏ₚ(1-p⁻²)⁻¹ = π²/6 (and the s=4 analogue), but **every** theorem is a 1–2 line composition of Mathlib lemmas:

- `euler_basel_product_tprod`: `rw [riemannZeta_eulerProduct_tprod, riemannZeta_two]`
- `euler_basel_product_hasProd` / `_tendsto`: `riemannZeta_eulerProduct_*` + `riemannZeta_two`
- s=4 variants: same recipe with `riemannZeta_four`
- `basel_value_ne_zero` / `zeta_four_value_ne_zero`: `riemannZeta_ne_zero_of_one_lt_re`

There is no independent theorem-level content — `originalContributions` is empty and the file docstring already states it is "assembled from Mathlib's `riemannZeta_eulerProduct_*` and `riemannZeta_two`/`riemannZeta_four`". The contribution is the *synthesis* (instantiating the general Euler product at s=2,4 against the closed-form special values), which is legitimate gallery work but is a Mathlib bridge.

**Fix**: `badge: "original"` → `"mathlib"`. `status: "verified"` is accurate (0 sorries, 0 axioms, machine-checked) and left unchanged. Prose (description/proofStrategy) was already honest.

### basel-problem-oq-10-oq-01 — clean

Headline `leibniz_error_bound` is **not** a direct Mathlib call: Mathlib's packaged `alternating_series_error_bound` requires `Summable`, which the conditionally-convergent Leibniz family fails, so the file builds a genuinely new summability-free bound (`alternating_error_bound_of_tendsto`) from Mathlib's Tendsto-sandwich lemmas. `verified`/`original` is accurate. 0 sorries, 0 axioms.

Tracker updated for both. Coverage 3528 → 3530.

---
Discovered during gallery integrity audit.