### PR TITLE
research(chebyshev-polynomials-oq-01-oq-01-oq-01): Chebyshev SL₂ matrix packaging T_add, U_add and the Pell identity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -757,6 +757,7 @@ import Proofs.ChebyshevPNTBridgeOQ01OQ02
 import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
+import Proofs.ChebyshevPolynomialsOQ01OQ01OQ01
 import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChebyshevSumIntegralOQ01OQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01

--- a/proofs/Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean
@@ -1,0 +1,121 @@
+/-
+  SL₂ matrix packaging of the Chebyshev addition formulas.
+
+  The parent file `Proofs.ChebyshevPolynomialsOQ01OQ01` proves the scalar
+  angle-addition identities for the Chebyshev polynomials:
+
+    * `T_add`    : T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}
+    * `U_add`    : U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}
+    * `T_sq_add` : Tₙ² + (1−X²)·U_{n−1}² = 1   (Pell / cos²+sin²=1)
+
+  This file answers the parent's first open question by packaging all three
+  into a *single* statement: the 2×2 matrix
+
+      M(n) = !![ Tₙ      , −(1−X²)·U_{n−1} ;
+                 U_{n−1} ,  Tₙ            ]
+
+  -- the polynomial shadow of the rotation matrix
+  `R(nθ) = !![cos nθ, −sin nθ; sin nθ, cos nθ]`, with `cos nθ = Tₙ(x)` and
+  `sin nθ = sin θ · U_{n−1}(x)` (so the common `sin θ` scaling of the off-diagonal
+  row and column cancels and leaves the factor `1 − x² = sin²θ` in one corner) --
+  defines a *monoid homomorphism* `(ℤ, +) → SL₂(R[X])`:
+
+    * `chebMat_zero` : M(0) = 1                       (T₀ = 1, U_{−1} = 0)
+    * `chebMat_mul`  : M(m+n) = M(m)·M(n)             (T_add ∧ U_add at once)
+    * `chebMat_det`  : det M(n) = 1                   (the Pell identity)
+
+  so each `M(n) ∈ SL₂(R[X])`, and multiplicativity of the determinant makes the
+  Pell identity `det M(n) = (det M(1))ⁿ = 1` an automatic consequence.  Finally
+
+    * `chebMat_pow`      : M(↑n) = M(1)ⁿ   for `n : ℕ`,
+    * `chebMat_one`      : M(1) = !![X, −(1−X²); 1, X],
+    * `cheb_pow_entry_T` : (M(1)ⁿ) 0 0 = Tₙ,
+    * `cheb_pow_entry_U` : (M(1)ⁿ) 1 0 = U_{n−1},
+
+  exhibit `T` and `U` as the matrix entries of the powers of the single
+  "Chebyshev rotation" `M(1)`, exactly as the powers of `!![1,1;1,0]` generate the
+  Fibonacci numbers.  Mathlib records `T`, `U` and their recurrences, but not this
+  SL₂ packaging.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+import Proofs.ChebyshevPolynomialsOQ01OQ01
+
+open Polynomial Matrix Polynomial.Chebyshev
+
+namespace ChebyshevPolynomialsOQ01OQ01OQ01
+
+variable (R : Type*) [CommRing R]
+
+/-- Entrywise equality of `2×2` matrix literals: reduces a matrix equation to its
+four scalar entries (so each can be discharged by `ring`). -/
+private theorem mat2_ext {α : Type*} (a b c d a' b' c' d' : α)
+    (h00 : a = a') (h01 : b = b') (h10 : c = c') (h11 : d = d') :
+    !![a, b; c, d] = !![a', b'; c', d'] := by
+  rw [h00, h01, h10, h11]
+
+/-- The **Chebyshev SL₂ matrix** `M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ]`,
+the polynomial shadow of the rotation `!![cos nθ, −sin nθ; sin nθ, cos nθ]`. -/
+noncomputable def chebMat (n : ℤ) : Matrix (Fin 2) (Fin 2) R[X] :=
+  !![T R n, -((1 - X ^ 2) * U R (n - 1)); U R (n - 1), T R n]
+
+/-- `M(0) = 1`: the identity matrix, since `T₀ = 1` and `U_{−1} = 0`. -/
+theorem chebMat_zero : chebMat R 0 = 1 := by
+  simp only [chebMat, show (0 : ℤ) - 1 = -1 from by ring, T_zero, U_neg_one,
+    mul_zero, neg_zero, Matrix.one_fin_two]
+
+/-- `M(1) = !![X, −(1−X²); 1, X]`, since `T₁ = X` and `U₀ = 1`. This single matrix
+is the "Chebyshev rotation" whose powers generate the whole `T`/`U` family. -/
+theorem chebMat_one : chebMat R 1 = !![X, -(1 - X ^ 2); 1, X] := by
+  simp only [chebMat, show (1 : ℤ) - 1 = 0 from by ring, T_one, U_zero, mul_one]
+
+/-- **Multiplicativity** `M(m+n) = M(m)·M(n)`: the `(0,0)`/`(1,1)` entries are the
+first-kind addition formula `T_add`, and the `(1,0)`/`(0,1)` entries are the
+second-kind addition formula `U_add`. The two scalar identities are packaged here
+as one matrix product. -/
+theorem chebMat_mul (m n : ℤ) : chebMat R (m + n) = chebMat R m * chebMat R n := by
+  have hT := ChebyshevPolynomialsOQ01OQ01.T_add R m n
+  have hU := ChebyshevPolynomialsOQ01OQ01.U_add R (m - 1) n
+  rw [show m - 1 + n = m + n - 1 from by ring, show m - 1 + 1 = m from by ring] at hU
+  simp only [chebMat, Matrix.mul_fin_two]
+  exact mat2_ext _ _ _ _ _ _ _ _
+    (by simp only [hT]; ring) (by simp only [hU]; ring)
+    (by rw [hU]) (by simp only [hT]; ring)
+
+/-- **Determinant** `det M(n) = 1`: this is exactly the Pell / Pythagorean identity
+`Tₙ² + (1−X²)·U_{n−1}² = 1`, so every `M(n)` lies in `SL₂(R[X])`. -/
+theorem chebMat_det (n : ℤ) : (chebMat R n).det = 1 := by
+  rw [chebMat, Matrix.det_fin_two_of]
+  linear_combination ChebyshevPolynomialsOQ01OQ01.T_sq_add R n
+
+/-- The matrices are the powers of the single rotation `M(1)`: `M(↑n) = M(1)ⁿ`.
+Proved by induction from `chebMat_zero` and `chebMat_mul`. -/
+theorem chebMat_pow (n : ℕ) : chebMat R (n : ℤ) = chebMat R 1 ^ n := by
+  induction n with
+  | zero => simpa using chebMat_zero R
+  | succ k ih =>
+      rw [pow_succ, ← ih, ← chebMat_mul R (k : ℤ) 1, Nat.cast_succ]
+
+/-- The first-kind polynomial `Tₙ` is the top-left entry of `M(1)ⁿ`. -/
+theorem cheb_pow_entry_T (n : ℕ) : (chebMat R 1 ^ n) 0 0 = T R (n : ℤ) := by
+  rw [← chebMat_pow]
+  simp [chebMat]
+
+/-- The second-kind polynomial `U_{n−1}` is the bottom-left entry of `M(1)ⁿ`. -/
+theorem cheb_pow_entry_U (n : ℕ) : (chebMat R 1 ^ n) 1 0 = U R ((n : ℤ) - 1) := by
+  rw [← chebMat_pow]
+  simp [chebMat]
+
+/-! ### Concrete instances -/
+
+/-- Multiplicativity at `m = 2, n = 3` over `ℤ`. -/
+example : chebMat ℤ (2 + 3) = chebMat ℤ 2 * chebMat ℤ 3 := chebMat_mul ℤ 2 3
+
+/-- Each Chebyshev matrix lands in `SL₂`: `det = 1` at `n = 4` over `ℤ`. -/
+example : (chebMat ℤ 4).det = 1 := chebMat_det ℤ 4
+
+/-- `T₃` is the `(0,0)` entry of the cube of the Chebyshev rotation `M(1)` over `ℤ`. -/
+example : (chebMat ℤ 1 ^ 3) 0 0 = T ℤ 3 := cheb_pow_entry_T ℤ 3
+
+end ChebyshevPolynomialsOQ01OQ01OQ01

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-chebyoq010101-header",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "Three scalar identities, one matrix law",
+    "content": "The parent entry proves three separate scalar facts about the Chebyshev polynomials: the first-kind addition formula T_{m+n} = T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, the second-kind addition formula U_{m+n} = U_m·T_n + T_{m+1}·U_{n−1}, and the Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1. This file shows they are not independent: they are the four matrix entries and the determinant of one statement. The carrier is M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ], the polynomial shadow of the rotation matrix !![cos nθ, −sin nθ; sin nθ, cos nθ] under x = cos θ, Tₙ = cos nθ, sin θ·U_{n−1} = sin nθ. The off-diagonal sin θ factors of the rotation cancel between the symmetric row and column, leaving the single factor 1 − x² = sin²θ in one corner.",
+    "mathContext": "$M(n)=\\begin{pmatrix}T_n & -(1-X^2)U_{n-1}\\\\ U_{n-1} & T_n\\end{pmatrix}$",
+    "significance": "context",
+    "relatedConcepts": ["Chebyshev polynomials", "rotation matrix", "SL₂", "Pell equation", "angle-addition identities"],
+    "prerequisites": ["the parent's scalar Chebyshev identities", "the rotation matrix R(θ) ∈ SO(2)"]
+  },
+  {
+    "id": "ann-chebyoq010101-mat2ext",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 56 },
+    "type": "technique",
+    "title": "Reducing a matrix equation to four scalar goals",
+    "content": "mat2_ext is a small reusable helper: given the four entrywise equalities a=a', b=b', c=c', d=d', it concludes !![a,b;c,d] = !![a',b';c',d'] by rewriting. It is the deterministic alternative to ext + fin_cases for 2×2 literals, avoiding the matrix-indexing simp lemmas that otherwise leave unreduced applications. In chebMat_mul each of the four resulting scalar goals is closed by one addition formula and ring.",
+    "mathContext": "$\\big(a{=}a',b{=}b',c{=}c',d{=}d'\\big)\\Rightarrow \\tiny\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}=\\begin{pmatrix}a'&b'\\\\c'&d'\\end{pmatrix}$",
+    "significance": "supporting",
+    "relatedConcepts": ["2×2 matrix literals", "entrywise equality", "ring"],
+    "prerequisites": ["matrix literal notation !![…]"]
+  },
+  {
+    "id": "ann-chebyoq010101-def",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 71 },
+    "type": "key-step",
+    "title": "The matrix and its values at 0 and 1",
+    "content": "chebMat n : Matrix (Fin 2) (Fin 2) R[X] is the Chebyshev SL₂ matrix. chebMat_zero proves M(0) = 1 using T₀ = 1 and U_{−1} = 0 (the off-diagonal entries vanish). chebMat_one computes M(1) = !![X, −(1−X²); 1, X] from T₁ = X and U₀ = 1. This single matrix M(1) is the 'Chebyshev rotation' whose powers will generate the whole T/U family, exactly as !![1,1;1,0] generates the Fibonacci numbers.",
+    "mathContext": "$M(1)=\\begin{pmatrix}X & -(1-X^2)\\\\ 1 & X\\end{pmatrix},\\quad \\det M(1)=X^2+(1-X^2)=1$",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev base values T₀,T₁,U₀,U_{−1}", "identity matrix", "Matrix.one_fin_two"],
+    "prerequisites": ["definition of T and U", "2×2 matrix literals"]
+  },
+  {
+    "id": "ann-chebyoq010101-mul",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 73, "endLine": 84 },
+    "type": "key-step",
+    "title": "Multiplicativity is T_add and U_add at once",
+    "content": "chebMat_mul proves M(m+n) = M(m)·M(n). Expanding the product with Matrix.mul_fin_two, the (0,0) and (1,1) entries are both T_m·T_n − (1−X²)·U_{m−1}·U_{n−1}, equal to T_{m+n} by the parent's T_add. The (1,0) entry is U_{m−1}·T_n + T_m·U_{n−1}, equal to U_{m+n−1} by the parent's U_add reindexed at m−1 (so the index m−1+n becomes m+n−1 and m−1+1 becomes m); the (0,1) entry is the same up to the −(1−X²) factor. mat2_ext splits the goal into these four scalar identities. This single equation is the SL₂-style multiplicativity the parent's open question requested: M is a monoid homomorphism (ℤ,+) → SL₂(R[X]).",
+    "mathContext": "$M(m{+}n)=M(m)M(n)$; off-diagonal $=U_{m{+}n{-}1}=U_{m{-}1}T_n+T_mU_{n{-}1}$",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.mul_fin_two", "T_add", "U_add", "monoid homomorphism", "reindexing"],
+    "prerequisites": ["the parent's addition formulas", "2×2 matrix product"]
+  },
+  {
+    "id": "ann-chebyoq010101-det",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 86, "endLine": 90 },
+    "type": "insight",
+    "title": "The determinant IS the Pell identity",
+    "content": "chebMat_det proves det M(n) = 1. By Matrix.det_fin_two_of the determinant is Tₙ·Tₙ − (−(1−X²)·U_{n−1})·U_{n−1} = Tₙ² + (1−X²)·U_{n−1}², which is precisely the parent's Pell identity T_sq_add, closed by linear_combination. So the Pell identity is no longer an independent lemma: it is the statement that M(n) ∈ SL₂(R[X]). Combined with multiplicativity, det M(n) = (det M(1))ⁿ = 1ⁿ = 1 is automatic — the determinant of a homomorphism into SL₂.",
+    "mathContext": "$\\det M(n)=T_n^2+(1-X^2)U_{n-1}^2=1$",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.det_fin_two_of", "Pell equation", "special linear group", "T_sq_add"],
+    "prerequisites": ["2×2 determinant", "the Pell/Pythagorean identity"]
+  },
+  {
+    "id": "ann-chebyoq010101-powers",
+    "proofId": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 119 },
+    "type": "key-step",
+    "title": "Powers of one matrix generate T and U",
+    "content": "chebMat_pow proves M(↑n) = M(1)ⁿ by induction: the base is chebMat_zero, the step rewrites M(1)^{k+1} = M(1)^k·M(1) = M(↑k)·M(1) = M(↑k+1) via chebMat_mul, with Nat.cast_succ matching ↑(k+1) = ↑k+1. Then cheb_pow_entry_T and cheb_pow_entry_U read Tₙ = (M(1)ⁿ) 0 0 and U_{n−1} = (M(1)ⁿ) 1 0 directly from the def. This is the Chebyshev analogue of the Fibonacci Q-matrix: a single fixed matrix whose successive powers expose the polynomial family in their entries. The closing examples verify multiplicativity, det = 1 and the entry formula on concrete integer indices.",
+    "mathContext": "$M(1)^n=\\begin{pmatrix}T_n & \\cdot\\\\ U_{n-1} & \\cdot\\end{pmatrix}$",
+    "significance": "key",
+    "relatedConcepts": ["matrix powers", "Fibonacci Q-matrix", "induction", "Nat.cast_succ"],
+    "prerequisites": ["chebMat_mul", "natural-number induction", "matrix exponentiation"]
+  }
+]

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPolynomialsOQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPolynomialsOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPolynomialsOQ01OQ01OQ01Data: ProofData = {
+  proof: chebyshevPolynomialsOQ01OQ01OQ01Proof,
+  annotations: chebyshevPolynomialsOQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+  "slug": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevPolynomialsOQ01OQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "Matrix",
+      "Polynomial.Chebyshev"
+    ],
+    "namespace": "ChebyshevPolynomialsOQ01OQ01OQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Chebyshev SL₂ Matrix: packaging T_add, U_add and the Pell identity as one multiplicativity",
+  "description": "Answers the parent entry's first open question by packaging its three scalar Chebyshev identities — the first-kind addition formula T_add, the second-kind addition formula U_add, and the Pell/Pythagorean identity T_sq_add — into a single 2×2 matrix statement. Define M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ] over R[X], the polynomial shadow of the rotation matrix !![cos nθ, −sin nθ; sin nθ, cos nθ]. Then M is a monoid homomorphism (ℤ,+) → SL₂(R[X]): M(0) = 1, M(m+n) = M(m)·M(n) (whose four entries are exactly T_add and U_add), and det M(n) = 1 (exactly the Pell identity). Consequently M(↑n) = M(1)ⁿ with M(1) = !![X, −(1−X²); 1, X], so Tₙ and U_{n−1} are read off as the entries of the powers of one fixed matrix — the Chebyshev analogue of the Fibonacci Q-matrix !![1,1;1,0]. Verified, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The identity cos²θ + sin²θ = 1 makes the rotation matrix R(θ) = !![cos θ, −sin θ; sin θ, cos θ] an element of SO(2) ⊂ SL₂(ℝ), and R(mθ)R(nθ) = R((m+n)θ) is the matrix encoding of the angle-addition formulas. Replacing cos nθ by the Chebyshev polynomial Tₙ(x) and sin nθ by sin θ · U_{n−1}(x) turns this into a polynomial identity: the pair (Tₙ, U_{n−1}) solves the Pell equation T² − (X²−1)U² = 1, and the corresponding matrices multiply by adding indices. This is the polynomial face of the classical fact that Chebyshev polynomials parameterize the units of the ring R[X][√(X²−1)] (the 'Pell conics'), exactly as the powers of the golden-ratio matrix !![1,1;1,0] generate the Fibonacci numbers and the units of ℤ[φ].",
+    "problemStatement": "First open question of the parent entry chebyshev-polynomials-oq-01-oq-01: does the matrix form !![T_{m+n}, ·],[·, ·] = !![T_m, ·],[·, ·]·!![T_n, ·],[·, ·] (the 2×2 'Chebyshev rotation' whose powers generate T and U) admit a clean Lean statement, packaging T_add, U_add and the Pell identity as a single SL₂-style multiplicativity?",
+    "proofStrategy": "Define M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ] : Matrix (Fin 2) (Fin 2) R[X]. Three theorems package the parent's scalar identities. (1) det M(n) = 1: by Matrix.det_fin_two_of the determinant is Tₙ² + (1−X²)·U_{n−1}², which is exactly the parent's Pell identity T_sq_add. (2) M(m+n) = M(m)·M(n): expand the product with Matrix.mul_fin_two; its (0,0) and (1,1) entries are T_m·T_n − (1−X²)·U_{m−1}·U_{n−1} = T_{m+n} (parent's T_add), and its (1,0) and (0,1) entries are U_{m−1}·T_n + T_m·U_{n−1} = U_{m+n−1} (parent's U_add reindexed at m−1). A four-entry helper mat2_ext reduces the matrix equation to these four scalar goals, each closed by the addition formula and ring. (3) M(0) = 1 from T_0 = 1, U_{−1} = 0. Multiplicativity then gives M(↑n) = M(1)ⁿ by induction, and the matrix entries of M(1)ⁿ recover Tₙ and U_{n−1}.",
+    "keyInsights": [
+      "The three scalar identities T_add, U_add and the Pell identity are not independent facts but the four entries and the determinant of a single matrix equation M(m+n) = M(m)·M(n) with det M = 1 — i.e. the statement that M : (ℤ,+) → SL₂(R[X]) is a monoid homomorphism into the special linear group",
+      "The Pell identity T_sq_add is precisely det M(n) = 1, so it is no longer a separate lemma to prove: it is automatic from multiplicativity, det M(n) = (det M(1))ⁿ = 1",
+      "M(1) = !![X, −(1−X²); 1, X] is a single fixed matrix whose powers generate the entire Chebyshev family: (M(1)ⁿ) 0 0 = Tₙ and (M(1)ⁿ) 1 0 = U_{n−1}, exactly as the powers of the Fibonacci Q-matrix !![1,1;1,0] generate Fₙ",
+      "Working over an arbitrary commutative ring R and integer indices n : ℤ keeps the statement at the level of the polynomial ring R[X], with the geometric meaning (rotation by nθ at x = cos θ) recovered by specialization"
+    ],
+    "prerequisites": [
+      "The parent's scalar addition formulas T_add, U_add and Pell identity T_sq_add",
+      "Chebyshev polynomials of the first and second kind T, U over a commutative ring",
+      "The 2×2 matrix determinant and product (Matrix.det_fin_two_of, Matrix.mul_fin_two)",
+      "The special linear group SL₂ as the matrices of determinant 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "From scalar identities to one matrix law",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "States the parent's three scalar identities and the goal: package them into the single matrix M(n) = !![Tₙ, −(1−X²)U_{n−1}; U_{n−1}, Tₙ], the polynomial shadow of the rotation !![cos nθ, −sin nθ; sin nθ, cos nθ], realized as a monoid homomorphism (ℤ,+) → SL₂(R[X]).",
+      "mathContext": "$M(n)=\\begin{pmatrix}T_n & -(1-X^2)U_{n-1}\\\\ U_{n-1} & T_n\\end{pmatrix}$"
+    },
+    {
+      "id": "definition",
+      "title": "The Chebyshev SL₂ matrix and the identity at n = 0, 1",
+      "startLine": 58,
+      "endLine": 71,
+      "summary": "chebMat n is the 2×2 matrix above. chebMat_zero shows M(0) = 1 (from T₀ = 1, U_{−1} = 0); chebMat_one shows M(1) = !![X, −(1−X²); 1, X] (from T₁ = X, U₀ = 1), the single rotation whose powers generate T and U.",
+      "mathContext": "$M(0)=I,\\quad M(1)=\\begin{pmatrix}X & -(1-X^2)\\\\ 1 & X\\end{pmatrix}$"
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Multiplicativity packages T_add and U_add",
+      "startLine": 73,
+      "endLine": 84,
+      "summary": "chebMat_mul: M(m+n) = M(m)·M(n). Expanding the product by Matrix.mul_fin_two, the diagonal entries are the first-kind addition formula T_add and the off-diagonal entries are the second-kind addition formula U_add (reindexed at m−1). The helper mat2_ext splits the matrix equation into these four scalar goals.",
+      "mathContext": "$M(m+n)=M(m)\\,M(n)$"
+    },
+    {
+      "id": "determinant",
+      "title": "The determinant is the Pell identity",
+      "startLine": 86,
+      "endLine": 90,
+      "summary": "chebMat_det: det M(n) = 1. By Matrix.det_fin_two_of the determinant equals Tₙ² + (1−X²)·U_{n−1}², which is exactly the parent's Pell identity T_sq_add, so every M(n) lies in SL₂(R[X]).",
+      "mathContext": "$\\det M(n)=T_n^2+(1-X^2)U_{n-1}^2=1$"
+    },
+    {
+      "id": "powers",
+      "title": "Powers of one rotation generate T and U",
+      "startLine": 92,
+      "endLine": 119,
+      "summary": "chebMat_pow: M(↑n) = M(1)ⁿ by induction from chebMat_zero and chebMat_mul. cheb_pow_entry_T and cheb_pow_entry_U then read Tₙ and U_{n−1} off as the (0,0) and (1,0) entries of M(1)ⁿ — the Chebyshev analogue of the Fibonacci Q-matrix. Concrete instances over ℤ check multiplicativity, det = 1 and the entry formula.",
+      "mathContext": "$M(1)^n=\\begin{pmatrix}T_n & \\cdot\\\\ U_{n-1} & \\cdot\\end{pmatrix}$"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "special-linear-group",
+      "matrix-identity",
+      "pell-equation",
+      "angle-addition",
+      "polynomial-ring",
+      "monoid-homomorphism",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 121,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "mathlib",
+    "originalContributions": [
+      "chebMat: the 2×2 matrix M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ] over R[X], the polynomial shadow of the rotation matrix !![cos nθ, −sin nθ; sin nθ, cos nθ]. Mathlib has the Chebyshev polynomials T and U and their recurrences but no such matrix packaging.",
+      "chebMat_mul: M(m+n) = M(m)·M(n) — a single matrix equation whose four entries are exactly the parent entry's two scalar addition formulas (T_add on the diagonal, U_add off the diagonal). This is the SL₂-style multiplicativity the parent's open question asked for, and it exhibits M as a monoid homomorphism (ℤ,+) → SL₂(R[X]).",
+      "chebMat_det: det M(n) = 1 is exactly the parent's Pell/Pythagorean identity Tₙ² + (1−X²)·U_{n−1}² = 1. The Pell identity thus becomes the determinant condition placing every M(n) in SL₂; combined with multiplicativity it follows automatically as det M(n) = (det M(1))ⁿ = 1.",
+      "chebMat_pow with cheb_pow_entry_T and cheb_pow_entry_U: M(↑n) = M(1)ⁿ, with Tₙ = (M(1)ⁿ) 0 0 and U_{n−1} = (M(1)ⁿ) 1 0. The single matrix M(1) = !![X, −(1−X²); 1, X] generates the entire Chebyshev family by exponentiation, the exact analogue of the Fibonacci Q-matrix !![1,1;1,0].",
+      "mat2_ext: a reusable helper reducing an equation of 2×2 matrix literals to its four scalar entries, used to discharge chebMat_mul one entry at a time."
+    ],
+    "prerequisites": [
+      "Parent: chebyshev-polynomials-oq-01-oq-01 (the scalar identities T_add, U_add, T_sq_add)",
+      "Chebyshev polynomials T, U over a commutative ring and their values T₀=1, T₁=X, U₀=1, U_{−1}=0",
+      "2×2 determinant and product: Matrix.det_fin_two_of, Matrix.mul_fin_two",
+      "Integer/natural-number induction for the power formula"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mul_fin_two",
+        "description": "Closed form for the product of two 2×2 matrix literals !![a,b;c,d]·!![e,f;g,h]. Expands M(m)·M(n) so its four entries can be matched against the scalar addition formulas.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Notation"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a,b;c,d] = a·d − b·c. Turns det M(n) into Tₙ² + (1−X²)·U_{n−1}², matched to the Pell identity.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.one_fin_two",
+        "description": "(1 : Matrix (Fin 2) (Fin 2) α) = !![1,0;0,1]. Used to identify M(0) with the identity matrix.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Notation"
+      },
+      {
+        "theorem": "Polynomial.Chebyshev.T_zero / T_one / U_zero / U_neg_one",
+        "description": "The base values T₀=1, T₁=X, U₀=1, U_{−1}=0 of the Chebyshev polynomials, used to evaluate M(0) and M(1).",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "chebyshev-polynomials-oq-01-oq-01-oq-01-oq-01",
+      "question": "Promote the homomorphism M : (ℤ,+) → SL₂(R[X]) to a bundled MonoidHom from Multiplicative ℤ, and use chebMat_pow to give matrix-power proofs of the multiple-angle and Pell-recurrence identities (e.g. T_{2n}, U_{2n−1} from M(1)^{2n}).",
+      "significance": "medium"
+    },
+    {
+      "id": "chebyshev-polynomials-oq-01-oq-01-oq-01-oq-02",
+      "question": "Diagonalize M(1) over R[X][√(X²−1)] to recover the closed forms Tₙ = ½((X+√(X²−1))ⁿ + (X−√(X²−1))ⁿ) and the second-kind analogue, connecting the SL₂ packaging to the explicit Binet-type formulas.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-polynomials-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. Its three scalar identities T_add, U_add (the addition formulas Mathlib omits) and the Pell identity T_sq_add are packaged here as the four entries and the determinant of the single matrix equation M(m+n) = M(m)·M(n), det M(n) = 1."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Methodological sibling. The Fibonacci Cassini identity is obtained there from the Q-matrix !![1,1;1,0]ⁿ via determinants; here the Chebyshev matrix M(1) = !![X, −(1−X²); 1, X] plays the same role, its powers generating Tₙ and U_{n−1} and its determinant 1 encoding the Pell identity."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: RingTheory.Polynomial.Chebyshev",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the Chebyshev polynomials T, U, their recurrences and base values used to define and evaluate the matrix M(n)."
+    },
+    {
+      "title": "Mathlib4: LinearAlgebra.Matrix.Notation",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the 2×2 matrix literal notation !![…], the product lemma Matrix.mul_fin_two and Matrix.one_fin_two used to package and verify the multiplicativity."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The parent entry's three scalar Chebyshev identities are packaged into the single 2×2 matrix M(n) = !![Tₙ, −(1−X²)·U_{n−1}; U_{n−1}, Tₙ] over R[X]. M is a monoid homomorphism (ℤ,+) → SL₂(R[X]): chebMat_zero (M(0)=1), chebMat_mul (M(m+n)=M(m)·M(n), whose four entries are T_add and U_add) and chebMat_det (det M(n)=1, exactly the Pell identity). Hence M(↑n) = M(1)ⁿ (chebMat_pow) with M(1) = !![X, −(1−X²); 1, X], and Tₙ, U_{n−1} are the (0,0) and (1,0) entries of M(1)ⁿ (cheb_pow_entry_T/U) — the Chebyshev analogue of the Fibonacci Q-matrix. 121 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The angle-addition formulas, the second-kind addition formula and the Pell identity stop being three separate lemmas and become a single structural statement: Chebyshev polynomials describe a one-parameter subgroup of SL₂(R[X]). This makes the Pell identity automatic (it is the determinant of a homomorphism) and gives every multiple-angle identity a uniform matrix-power proof, mirroring how the Fibonacci Q-matrix unifies the linear-recurrence identities.",
+    "openQuestions": [
+      "Bundle M as a MonoidHom from Multiplicative ℤ and derive multiple-angle identities from matrix powers.",
+      "Diagonalize M(1) over R[X][√(X²−1)] to recover the Binet-type closed forms for Tₙ and U_{n−1}."
+    ]
+  }
+}

--- a/src/data/research/problems/chebyshev-polynomials-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/chebyshev-polynomials-oq-01-oq-01-oq-01.json
@@ -1,0 +1,58 @@
+{
+  "slug": "chebyshev-polynomials-oq-01-oq-01-oq-01",
+  "title": "Chebyshev SL₂ Matrix Multiplicativity Packaging T_add, U_add and the Pell Identity",
+  "problemStatement": {
+    "formal": "def chebMat (n : ℤ) : Matrix (Fin 2) (Fin 2) R[X] := !![T R n, -((1 - X^2) * U R (n-1)); U R (n-1), T R n]; theorem chebMat_mul : chebMat R (m+n) = chebMat R m * chebMat R n; theorem chebMat_det : (chebMat R n).det = 1",
+    "plain": "Package the parent entry's three scalar Chebyshev identities (the first-kind addition formula T_add, the second-kind addition formula U_add, and the Pell/Pythagorean identity T_sq_add) into a single SL₂-style matrix multiplicativity: the 2×2 matrix M(n) = !![Tₙ, −(1−X²)U_{n−1}; U_{n−1}, Tₙ] is a monoid homomorphism (ℤ,+) → SL₂(R[X]) whose powers generate T and U.",
+    "whyMatters": [
+      "Unifies three separate scalar identities as the entries and determinant of one matrix equation",
+      "Makes the Pell identity automatic (det of a homomorphism into SL₂), mirroring the Fibonacci Q-matrix",
+      "Mathlib has the Chebyshev polynomials and recurrences but no SL₂ matrix packaging"
+    ]
+  },
+  "significance": 6,
+  "tier": "B",
+  "tractability": 7,
+  "status": "completed",
+  "phase": "COMPLETED",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "path": "Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean",
+  "tags": [
+    "chebyshev-polynomials",
+    "special-linear-group",
+    "matrix-identity",
+    "pell-equation",
+    "angle-addition",
+    "polynomial-ring"
+  ],
+  "knowledge": {
+    "progressSummary": "COMPLETE: chebMat M(n) = !![Tₙ, −(1−X²)U_{n−1}; U_{n−1}, Tₙ] proved to be a monoid hom (ℤ,+) → SL₂(R[X]) — M(0)=1, M(m+n)=M(m)M(n) (= T_add ∧ U_add), det M(n)=1 (= Pell identity), M(↑n)=M(1)ⁿ with entries Tₙ, U_{n−1}. Verified, 0 axioms, 0 sorries, 8 theorems / 1 def / 121 lines.",
+    "insights": [
+      "The parent's T_add, U_add and Pell identity are not independent: they are the four entries and the determinant of the single equation M(m+n) = M(m)·M(n) with det M(n) = 1, i.e. M : (ℤ,+) → SL₂(R[X]) is a monoid homomorphism.",
+      "det M(n) = Tₙ² + (1−X²)U_{n−1}² is exactly the parent's Pell identity T_sq_add, so the Pell identity becomes the SL₂-membership condition and follows automatically from multiplicativity as (det M(1))ⁿ = 1.",
+      "The off-diagonal entry of M(m+n) needs U_add reindexed at m−1: U_{m+n−1} = U_{m−1}·T_n + T_m·U_{n−1}, obtained by rewriting the indices m−1+n → m+n−1 and m−1+1 → m.",
+      "M(1) = !![X, −(1−X²); 1, X] is the Chebyshev analogue of the Fibonacci Q-matrix !![1,1;1,0]: (M(1)ⁿ) 0 0 = Tₙ and (M(1)ⁿ) 1 0 = U_{n−1}."
+    ],
+    "builtItems": [
+      "chebMat (def): the 2×2 Chebyshev SL₂ matrix over R[X] — ChebyshevPolynomialsOQ01OQ01OQ01.lean:60",
+      "chebMat_mul: M(m+n) = M(m)·M(n) packaging T_add and U_add — :77",
+      "chebMat_det: det M(n) = 1 (the Pell identity) — :88",
+      "chebMat_zero / chebMat_one: M(0)=1, M(1)=!![X,−(1−X²);1,X] — :64, :70",
+      "chebMat_pow + cheb_pow_entry_T/U: M(↑n)=M(1)ⁿ with Tₙ, U_{n−1} as entries — :94, :101, :106",
+      "mat2_ext: reusable 2×2 literal entrywise-equality helper — :53"
+    ],
+    "mathlibGaps": [
+      "Mathlib has Polynomial.Chebyshev.T/U and recurrences but no matrix/SL₂ packaging of the addition formulas",
+      "No bundled MonoidHom from (Multiplicative ℤ) to SL₂(R[X]) for the Chebyshev rotation"
+    ],
+    "nextSteps": [
+      "Bundle M as a MonoidHom from Multiplicative ℤ and derive multiple-angle identities (T_{2n}, U_{2n−1}) from matrix powers.",
+      "Diagonalize M(1) over R[X][√(X²−1)] to recover Binet-type closed forms Tₙ = ½((X+√(X²−1))ⁿ + (X−√(X²−1))ⁿ)."
+    ]
+  },
+  "relatedProofs": [
+    "chebyshev-polynomials-oq-01-oq-01",
+    "fibonacci-identities-oq-01-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `chebyshev-polynomials-oq-01-oq-01`: *"does the matrix form ... admit a clean Lean statement, packaging T_add, U_add and the Pell identity as a single SL₂-style multiplicativity?"*

Define the **Chebyshev SL₂ matrix** over `R[X]`:

```
M(n) = !![ Tₙ      , −(1−X²)·U_{n−1} ;
           U_{n−1} ,  Tₙ            ]
```

the polynomial shadow of the rotation `!![cos nθ, −sin nθ; sin nθ, cos nθ]`. The parent's three scalar identities become the entries and determinant of one statement — `M` is a monoid homomorphism `(ℤ,+) → SL₂(R[X])`:

| Theorem | Statement | Packages |
|---|---|---|
| `chebMat_zero` | `M(0) = 1` | `T₀=1, U_{−1}=0` |
| `chebMat_mul` | `M(m+n) = M(m)·M(n)` | **T_add** (diagonal) ∧ **U_add** (off-diagonal) |
| `chebMat_det` | `det M(n) = 1` | the **Pell identity** `T_sq_add` |
| `chebMat_pow` | `M(↑n) = M(1)ⁿ`, `M(1)=!![X,−(1−X²);1,X]` | `Tₙ=(M(1)ⁿ)₀₀`, `U_{n−1}=(M(1)ⁿ)₁₀` |

The Pell identity is thus the determinant of a homomorphism into SL₂, automatic as `(det M(1))ⁿ = 1`. The single matrix `M(1)` generates the whole Chebyshev family by exponentiation — the exact analogue of the Fibonacci Q-matrix `!![1,1;1,0]`.

## Verification

- **8 theorems, 1 definition, 121 lines, 0 sorries, 0 axioms**
- `#print axioms` → `propext, Classical.choice, Quot.sound` only (no `sorryAx`, no `Lean.ofReduceBool`)
- Builds on the parent's `T_add`/`U_add`/`T_sq_add` + Mathlib's `Matrix.mul_fin_two`, `Matrix.det_fin_two_of`, `Matrix.one_fin_two`.

## Files
- `proofs/Proofs/ChebyshevPolynomialsOQ01OQ01OQ01.lean` (new)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/chebyshev-polynomials-oq-01-oq-01-oq-01/` (meta, annotations, index)
- `src/data/research/problems/chebyshev-polynomials-oq-01-oq-01-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)