### PR TITLE
research(catalan-numbers-oq-01-oq-01-oq-01-oq-01): generalized ballot count C(2n,n)−C(2n,n+k) via depth-k André reflection [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CatalanGeneralizedBallot.lean
+++ b/proofs/Proofs/CatalanGeneralizedBallot.lean
@@ -1,0 +1,259 @@
+import Mathlib
+import Proofs.CatalanAndreReflection
+
+/-
+# The generalized ballot / cycle-lemma count via André's reflection
+
+The parent file (`Proofs.CatalanAndreReflection`) realizes the Catalan
+reflection form `catalan n = C(2n, n) − C(2n, n+1)` as an explicit reflection
+bijection: monotone `n`-up lattice paths that dip to height `-1` (the *bad*
+paths) are matched with all `(n-1)`-up paths.
+
+Here we generalize the barrier from `-1` to an arbitrary depth `-k`.  A path
+(encoded, as in the parent, by its set `S : Finset (Fin (2n))` of up-step
+positions) **reaches depth `-k`** when some prefix has `k` more downs than ups,
+i.e. `j = 2 · preUps S j + k`.  The same André reflection — flip every step
+from the first descent to `-k` — is a bijection
+
+    { n-up paths reaching `-k` }  ≃  { (n-k)-up paths },
+
+because reflecting a path that first touches `-k` turns its `n` up-steps into
+`n - k` up-steps, and *every* `(n-k)`-up path reaches `-k` (it ends at height
+`-2k`).  Counting both sides gives the **generalized ballot number**
+
+    #{ n-up paths staying strictly above `-k` }
+        = C(2n, n) − C(2n, n+k),
+
+the number of paths that never dip to depth `k` below the axis.  At `k = 1`
+this is `catalan n`, recovering the parent's reflection form as a special case.
+
+The construction reuses the parent's barrier-independent infrastructure verbatim
+(`preUps`, `reflect`, `card_reflect_add`, `preUps_reflect_eq`, …); only the
+depth-`k` predicates and the first-descent cut point are re-derived.
+
+Verified: 0 sorries, 0 axioms.
+-/
+
+namespace CatalanGeneralizedBallot
+
+open Finset
+open CatalanAndreReflection
+
+variable {n : ℕ}
+
+/-! ### Depth-`k` descent predicates -/
+
+/-- The path `S` **reaches depth `-k`** at prefix length `j`: among the first
+`j` steps there are exactly `k` more downs than ups, i.e. `j = 2·preUps + k`.
+The parent's `hitsAt` is the case `k = 1`. -/
+def hitsAtK (S : Finset (Fin (2 * n))) (k j : ℕ) : Prop :=
+  j = 2 * preUps S j + k
+
+instance (S : Finset (Fin (2 * n))) (k j : ℕ) : Decidable (hitsAtK S k j) := by
+  unfold hitsAtK; infer_instance
+
+/-- The path reaches depth `-k` somewhere among its `2n` prefixes. -/
+def ReachesK (S : Finset (Fin (2 * n))) (k : ℕ) : Prop :=
+  ∃ j ∈ Finset.range (2 * n + 1), hitsAtK S k j
+
+instance (S : Finset (Fin (2 * n))) (k : ℕ) : Decidable (ReachesK S k) := by
+  unfold ReachesK; infer_instance
+
+/-! ### Discrete intermediate value at depth `k` -/
+
+/-- **Discrete IVT at depth `k`.** A path with at most `n − k` up-steps ends at
+height `≤ -2k`, so it must dip to depth exactly `-k` at some first prefix. -/
+lemma reachesK_of_card_add_le (S : Finset (Fin (2 * n))) (k : ℕ) (hk : 1 ≤ k)
+    (hcard : S.card + k ≤ n) : ReachesK S k := by
+  -- `P j` : the height `2·preUps − j` has reached `≤ -k` at prefix length `j`.
+  have hP : ∃ j, 2 * preUps S j + k ≤ j := by
+    refine ⟨2 * n, ?_⟩
+    rw [preUps_eq_card S (le_refl _)]; omega
+  classical
+  set j₀ := Nat.find hP with hj₀
+  have hspec : 2 * preUps S j₀ + k ≤ j₀ := Nat.find_spec hP
+  have hpos : 0 < j₀ := by
+    rcases Nat.eq_zero_or_pos j₀ with h | h
+    · rw [h, preUps_zero] at hspec; omega
+    · exact h
+  -- `j₀ - 1` has not yet reached depth `-k`.
+  have hprev : ¬ (2 * preUps S (j₀ - 1) + k ≤ j₀ - 1) :=
+    Nat.find_min hP (m := j₀ - 1) (by omega)
+  have hstep : preUps S j₀ = preUps S (j₀ - 1) + (S.filter (fun i => i.val = j₀ - 1)).card := by
+    conv_lhs => rw [show j₀ = (j₀ - 1) + 1 by omega]
+    rw [preUps_succ]
+  have hδ : (S.filter (fun i => i.val = j₀ - 1)).card ≤ 1 := card_filter_val_eq_le_one S _
+  -- The first descent to `≤ -k` lands exactly on `-k`: `hitsAtK S k j₀`.
+  refine ⟨j₀, Finset.mem_range.mpr ?_, ?_⟩
+  · have hle : j₀ ≤ 2 * n := Nat.find_le (by rw [preUps_eq_card S (le_refl _)]; omega)
+    omega
+  · show j₀ = 2 * preUps S j₀ + k
+    omega
+
+/-! ### The reflection is depth-`k`-aware: cut point and cardinality -/
+
+/-- `hitsAtK` agrees between `S` and `reflect S t` at every prefix up to `t`,
+since reflection does not change the prefix up-count below the cut. -/
+lemma hitsAtK_reflect_iff (S : Finset (Fin (2 * n))) (k t : ℕ) {j : ℕ} (hj : j ≤ t) :
+    hitsAtK (reflect S t) k j ↔ hitsAtK S k j := by
+  unfold hitsAtK
+  rw [preUps_reflect_eq S t hj]
+
+open scoped Classical in
+/-- The depth-`k` cut point: the first prefix length at which the path reaches
+depth `-k`. -/
+noncomputable def cutK (S : Finset (Fin (2 * n))) (k : ℕ) : ℕ := sInf {j | hitsAtK S k j}
+
+lemma cutK_hits {S : Finset (Fin (2 * n))} {k : ℕ} (h : ReachesK S k) :
+    hitsAtK S k (cutK S k) := by
+  obtain ⟨m, _, hm⟩ := h
+  have : sInf {j | hitsAtK S k j} ∈ {j | hitsAtK S k j} := Nat.sInf_mem ⟨m, hm⟩
+  exact this
+
+lemma cutK_min {S : Finset (Fin (2 * n))} {k j : ℕ} (hj : hitsAtK S k j) : cutK S k ≤ j :=
+  Nat.sInf_le hj
+
+lemma cutK_le {S : Finset (Fin (2 * n))} {k : ℕ} (h : ReachesK S k) : cutK S k ≤ 2 * n := by
+  obtain ⟨j, hjr, hj⟩ := h
+  exact le_trans (cutK_min hj) (by simpa using Nat.lt_succ_iff.mp (Finset.mem_range.mp hjr))
+
+/-- Reflecting a depth-`k` path at its own cut point keeps it a depth-`k` path. -/
+lemma reachesK_reflect {S : Finset (Fin (2 * n))} {k : ℕ} (h : ReachesK S k) :
+    ReachesK (reflect S (cutK S k)) k := by
+  refine ⟨cutK S k, Finset.mem_range.mpr (Nat.lt_succ_of_le (cutK_le h)), ?_⟩
+  exact (hitsAtK_reflect_iff S k (cutK S k) (le_refl _)).mpr (cutK_hits h)
+
+/-- The cut point is preserved by reflecting there: both words share the prefix
+up to the first descent, so they reach depth `-k` for the first time together. -/
+lemma cutK_reflect {S : Finset (Fin (2 * n))} {k : ℕ} (h : ReachesK S k) :
+    cutK (reflect S (cutK S k)) k = cutK S k := by
+  apply le_antisymm
+  · exact cutK_min ((hitsAtK_reflect_iff S k (cutK S k) (le_refl _)).mpr (cutK_hits h))
+  · by_contra hlt
+    push_neg at hlt
+    have hc : hitsAtK (reflect S (cutK S k)) k (cutK (reflect S (cutK S k)) k) :=
+      cutK_hits (reachesK_reflect h)
+    have hle : cutK (reflect S (cutK S k)) k ≤ cutK S k := le_of_lt hlt
+    have : hitsAtK S k (cutK (reflect S (cutK S k)) k) :=
+      (hitsAtK_reflect_iff S k (cutK S k) hle).mp hc
+    exact absurd (cutK_min this) (by omega)
+
+/-- Cardinality after reflecting at the depth-`k` cut point: subtraction-free
+form `#(reflect S) + #S + k = 2n`.  This is the single quantitative input of the
+generalized reflection bijection. -/
+lemma card_reflect_cutK {S : Finset (Fin (2 * n))} {k : ℕ} (h : ReachesK S k) :
+    (reflect S (cutK S k)).card + S.card + k = 2 * n := by
+  have hadd := card_reflect_add S (cutK S k) (cutK_le h)
+  have hhit : cutK S k = 2 * preUps S (cutK S k) + k := cutK_hits h
+  omega
+
+/-! ### The generalized reflection bijection and the ballot count -/
+
+variable (n) in
+/-- Monotone `n`-up paths that dip to depth `-k` (the depth-`k` *bad* paths). -/
+def BadPathsK (k : ℕ) : Finset (Finset (Fin (2 * n))) :=
+  Finset.univ.filter (fun S => S.card = n ∧ ReachesK S k)
+
+variable (n) in
+/-- All `(n-k)`-up paths (each automatically dips to depth `-k`). -/
+def LowPathsK (k : ℕ) : Finset (Finset (Fin (2 * n))) :=
+  Finset.univ.filter (fun S => S.card = n - k)
+
+variable (n) in
+/-- Monotone `n`-up paths that **never** dip to depth `-k`: the generalized Dyck
+/ ballot paths staying strictly above the line at height `-k`. -/
+def GoodPathsK (k : ℕ) : Finset (Finset (Fin (2 * n))) :=
+  Finset.univ.filter (fun S => S.card = n ∧ ¬ ReachesK S k)
+
+/-- **Generalized André reflection bijection.** For `1 ≤ k ≤ n`, reflecting at
+the first descent to depth `-k` is a bijection between depth-`k` bad `n`-up paths
+and all `(n-k)`-up paths. -/
+theorem card_badPathsK (k : ℕ) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    (BadPathsK n k).card = (LowPathsK n k).card := by
+  apply Finset.card_bij'
+    (fun S _ => reflect S (cutK S k)) (fun T _ => reflect T (cutK T k))
+  · -- bad ↦ low
+    intro S hS
+    simp only [BadPathsK, Finset.mem_filter, Finset.mem_univ, true_and] at hS
+    simp only [LowPathsK, Finset.mem_filter, Finset.mem_univ, true_and]
+    have := card_reflect_cutK hS.2
+    omega
+  · -- low ↦ bad
+    intro T hT
+    simp only [LowPathsK, Finset.mem_filter, Finset.mem_univ, true_and] at hT
+    simp only [BadPathsK, Finset.mem_filter, Finset.mem_univ, true_and]
+    have hreach : ReachesK T k := reachesK_of_card_add_le T k hk (by omega)
+    refine ⟨?_, reachesK_reflect hreach⟩
+    have := card_reflect_cutK hreach
+    omega
+  · -- left inverse
+    intro S hS
+    simp only [BadPathsK, Finset.mem_filter, Finset.mem_univ, true_and] at hS
+    rw [cutK_reflect hS.2, reflect_involutive]
+  · -- right inverse
+    intro T hT
+    simp only [LowPathsK, Finset.mem_filter, Finset.mem_univ, true_and] at hT
+    have hreach : ReachesK T k := reachesK_of_card_add_le T k hk (by omega)
+    rw [cutK_reflect hreach, reflect_involutive]
+
+/-- The depth-`k` bad-path count: `#BadPathsK = C(2n, n+k)`, for `1 ≤ k ≤ n`. -/
+theorem card_badPathsK_eq (k : ℕ) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    (BadPathsK n k).card = (2 * n).choose (n + k) := by
+  rw [card_badPathsK k hk hkn, LowPathsK, card_filter_card_eq]
+  rw [← Nat.choose_symm (by omega : n + k ≤ 2 * n)]
+  congr 1; omega
+
+/-- **Generalized ballot / cycle-lemma count.** For `1 ≤ k ≤ n`, the number of
+monotone `n`-up paths that stay strictly above depth `-k` is
+
+  `#GoodPathsK = C(2n, n) − C(2n, n+k)`
+
+(stated in subtraction-free additive form). -/
+theorem card_goodPathsK_add (k : ℕ) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    (GoodPathsK n k).card + (2 * n).choose (n + k) = (2 * n).choose n := by
+  have hsplit : (BadPathsK n k).card + (GoodPathsK n k).card
+      = (Finset.univ.filter (fun S : Finset (Fin (2 * n)) => S.card = n)).card := by
+    rw [GoodPathsK, BadPathsK, ← Finset.filter_filter, ← Finset.filter_filter]
+    exact Finset.filter_card_add_filter_neg_card_eq_card _
+  rw [card_filter_card_eq n, card_badPathsK_eq k hk hkn] at hsplit
+  omega
+
+/-- Subtraction form of the generalized ballot count over `ℤ`. -/
+theorem card_goodPathsK_sub (k : ℕ) (hk : 1 ≤ k) (hkn : k ≤ n) :
+    ((GoodPathsK n k).card : ℤ) = (2 * n).choose n - (2 * n).choose (n + k) := by
+  have h := card_goodPathsK_add k hk hkn
+  have : ((GoodPathsK n k).card : ℤ) + ((2 * n).choose (n + k) : ℤ)
+      = ((2 * n).choose n : ℤ) := by exact_mod_cast h
+  linarith
+
+/-! ### Recovering the Catalan reflection form as the `k = 1` case -/
+
+/-- At depth `k = 1`, the depth-`k` descent predicate is the parent's `Reaches`. -/
+lemma reachesK_one_iff (S : Finset (Fin (2 * n))) :
+    ReachesK S 1 ↔ CatalanAndreReflection.Reaches S := Iff.rfl
+
+/-- The generalized good paths at `k = 1` are exactly the parent's Dyck paths. -/
+lemma goodPathsK_one (n : ℕ) :
+    GoodPathsK n 1 = CatalanAndreReflection.GoodPaths n := by
+  unfold GoodPathsK CatalanAndreReflection.GoodPaths
+  ext S
+  simp only [Finset.mem_filter, reachesK_one_iff]
+
+/-- **Recovery of the parent's reflection form.** The generalized ballot count at
+`k = 1` is the Catalan number: `#GoodPathsK n 1 = catalan n`. -/
+theorem card_goodPathsK_one (n : ℕ) : (GoodPathsK n 1).card = catalan n := by
+  rw [goodPathsK_one]
+  exact CatalanAndreReflection.card_goodPaths_eq_catalan n
+
+/-! ### Concrete instance -/
+
+/-- For `n = 3`, `k = 2`: the number of `3`-up paths staying strictly above depth
+`-2` is `C(6,3) − C(6,5) = 20 − 6 = 14`. -/
+example : (GoodPathsK 3 2).card + 6 = 20 := by
+  have h := card_goodPathsK_add (n := 3) 2 (by norm_num) (by norm_num)
+  have e1 : (2 * 3).choose (3 + 2) = 6 := by decide
+  have e2 : (2 * 3).choose 3 = 20 := by decide
+  rw [e1, e2] at h
+  exact h
+
+end CatalanGeneralizedBallot

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+  "slug": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+  "title": "Generalized ballot / cycle-lemma count C(2n,n) − C(2n,n+k) via André's reflection",
+  "sorries": 0,
+  "description": "Generalizes the parent's André reflection bijection from barrier height −1 to arbitrary depth −k. A monotone n-up lattice path (encoded by its up-step position set S : Finset (Fin (2n))) reaches depth −k when some prefix has k more downs than ups, i.e. j = 2·preUps S j + k. The same reflection — complement every step from the first descent to −k — is an explicit bijection between depth-k 'bad' n-up paths and ALL (n−k)-up paths, giving #BadPathsK = C(2n,n+k); hence the generalized ballot number, the count of n-up paths staying strictly above −k, is exactly C(2n,n) − C(2n,n+k). At k = 1 this recovers the parent's #GoodPaths = catalan n. Reuses the parent's barrier-independent infrastructure (preUps, reflect, card_reflect_add) verbatim. Fully verified, 0 axioms, no native_decide.",
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.CatalanAndreReflection"],
+    "opens": ["Finset", "CatalanAndreReflection"],
+    "namespace": "CatalanGeneralizedBallot",
+    "lineCount": 259,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 6,
+    "path": "Proofs/CatalanGeneralizedBallot.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "problemStatement": "Generalize André's reflection bijection from the barrier height −1 (which yields catalan n = C(2n,n) − C(2n,n+1)) to an arbitrary depth −k, recovering the generalized ballot / cycle-lemma count C(2n,n) − C(2n,n+k) of monotone n-up lattice paths that never dip k below the axis, with the k = 1 case reproducing the parent's Catalan reflection form.",
+    "answer": "Yes. Keep the parent's encoding of a 2n-step path as its up-step position set S : Finset (Fin (2n)); the height after j steps is 2·preUps S j − j. A path reaches depth −k at prefix j exactly when j = 2·preUps S j + k (predicate hitsAtK). The parent's reflection reflect S t (complement membership at every position ≥ t) is barrier-independent, and its subtraction-free cardinality identity #(reflect S t) + #S + t = 2·preUps S t + 2n is reused verbatim. Cutting at cutK S k, the first descent to depth −k, gives an involution that fixes that descent (cutK preserved) and changes the up-count by exactly −k, so reflect S (cutK S k) is a bijection between depth-k bad n-up paths and all (n−k)-up paths. Every (n−k)-up path automatically reaches −k by a discrete intermediate-value argument (it ends at height −2k). Counting with Finset.powersetCard gives #BadPathsK = C(2n, n−k) = C(2n, n+k), so #GoodPathsK = C(2n,n) − C(2n,n+k). Specializing k = 1, GoodPathsK n 1 = GoodPaths n and the count is catalan n.",
+    "proofStrategy": "1. **Reuse the barrier-independent core.** Import the parent file: preUps, reflect, card_reflect_add (#(reflect S t) + #S + t = 2·preUps S t + 2n), preUps_succ/_eq_card/_zero, preUps_reflect_eq, reflect_involutive, card_filter_val_eq_le_one, card_filter_card_eq — none of these mention the barrier, so they apply at any depth k unchanged.\n2. **Depth-k predicates.** hitsAtK S k j := (j = 2·preUps S j + k) and ReachesK S k := ∃ j ≤ 2n, hitsAtK S k j. The parent's hitsAt is exactly hitsAtK · 1.\n3. **Discrete IVT at depth k (reachesK_of_card_add_le).** If S.card + k ≤ n the path ends at height ≤ −2k; the first prefix where 2·preUps + k ≤ j satisfies the hit equation j = 2·preUps + k (the ±1 step size forces the first crossing to land exactly on −k). Proved with Nat.find and omega.\n4. **First-passage involution.** preUps_reflect_eq (reused) gives hitsAtK_reflect_iff below the cut; hence cutK S k (= sInf {j | hitsAtK S k j}) is preserved by reflecting there (cutK_reflect) and reflect S (cutK S k) is again a depth-k path (reachesK_reflect).\n5. **The bijection.** card_badPathsK: Finset.card_bij' with the reflection both ways for 1 ≤ k ≤ n. Substituting cutK S k = 2·preUps + k into the parent's cardinality identity collapses it to #(reflect) + #S + k = 2n (card_reflect_cutK), so the up-count drops from n to n−k.\n6. **The count.** card_filter_card_eq + Nat.choose_symm give #LowPathsK = C(2n, n−k) = C(2n, n+k); splitting all n-up paths into good and bad yields the additive identity #GoodPathsK + C(2n,n+k) = C(2n,n) (card_goodPathsK_add), with the ℤ subtraction form card_goodPathsK_sub. Finally goodPathsK_one identifies GoodPathsK n 1 with the parent's GoodPaths and card_goodPathsK_one delivers catalan n.",
+    "keyInsights": [
+      "**The reflection is barrier-agnostic.** reflect and its cardinality identity #(reflect S t) + #S + t = 2·preUps S t + 2n never mention the barrier height, so the entire heavy core of the parent transfers to depth −k with no change; only the descent predicate and cut point carry the parameter k.",
+      "**Up-count drops by exactly k.** Substituting the depth-k hit equation cutK = 2·preUps + k into the reflection identity collapses it to #(reflect) + #S + k = 2n. With #S = n the reflected path has n − k up-steps — this single arithmetic fact is the whole bijection.",
+      "**Discrete IVT generalizes cleanly.** A path with at most n − k ups ends at height ≤ −2k, and ±1 steps force a first prefix landing exactly on −k; so every (n−k)-up path is a depth-k bad path and LowPathsK needs no side condition beyond 1 ≤ k ≤ n.",
+      "**k = 1 is definitionally the parent.** hitsAtK S 1 unfolds to the parent's hitsAt, so ReachesK S 1 ↔ Reaches S holds by Iff.rfl and GoodPathsK n 1 = GoodPaths n; the Catalan reflection form is literally the k = 1 slice, not a re-derivation.",
+      "**Closed difference form, not in Mathlib.** Mathlib has no generalized ballot / cycle-lemma count; the bijective C(2n,n) − C(2n,n+k) (the André–Bertrand ballot number) is the original content, extending the parent's k = 1 result to the full family."
+    ],
+    "historicalContext": "The ballot problem and its reflection solution are due to Désiré André (1887) and Joseph Bertrand: among monotone lattice paths, the number staying strictly on one side of a line at distance k is C(2n,n) − C(2n,n+k). The generalized statement is equivalent to the cycle lemma of Dvoretzky and Motzkin (1947) and underlies the enumeration of k-Dyck paths, the Catalan and Fuss–Catalan families, and first-passage results in random-walk theory. This entry formalizes the depth-k reflection bijection itself — building the explicit involution and counting both sides — rather than only its arithmetic shadow.",
+    "prerequisites": [
+      "The parent entry's reflection framework (preUps, reflect, the cardinality identity) on Finset (Fin (2n)) encodings",
+      "Catalan numbers and the central binomial coefficient (Mathlib catalan)",
+      "Finset cardinality, filtering, Finset.powersetCard, and Nat.choose_symm",
+      "Nat.sInf / Nat.find first-passage (least-witness) arguments"
+    ]
+  },
+  "conclusion": {
+    "summary": "The depth-k André reflection reflect S (cutK S k) is an explicit involution on up-step position sets that fixes the first descent to −k and drops the up-count by exactly k. This gives a Finset bijection between depth-k bad n-up paths and all (n−k)-up paths (1 ≤ k ≤ n), proving #BadPathsK = C(2n,n+k) and hence the generalized ballot count #GoodPathsK = C(2n,n) − C(2n,n+k). At k = 1 the good paths are the parent's Dyck paths and the count is catalan n. The parent's barrier-independent infrastructure is reused verbatim. Verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": [
+      "Realizes the generalized ballot / cycle-lemma number C(2n,n) − C(2n,n+k) as a constructed bijection, not just an arithmetic identity, for the whole family 1 ≤ k ≤ n.",
+      "Demonstrates that the parent's reflection core (reflect, card_reflect_add, preUps_reflect_eq) is genuinely barrier-independent and reusable across depths.",
+      "Recovers the parent's Catalan reflection form as the definitional k = 1 slice (GoodPathsK n 1 = GoodPaths n)."
+    ],
+    "openQuestions": [
+      "Promote the count to k-Dyck / Fuss–Catalan paths with up-steps of size larger than one, where the barrier has slope > 1 and the reflection becomes a rotation (cycle lemma).",
+      "Bridge GoodPathsK to a weighted ballot-number generating function, recovering the Catalan and ballot triangles as the coefficient array in k."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "catalan-numbers-oq-01-oq-01-oq-01",
+      "reason": "The parent entry: André's reflection bijection at barrier −1 (catalan n = C(2n,n) − C(2n,n+1)). This entry imports it and reuses preUps, reflect, card_reflect_add, preUps_reflect_eq and card_goodPaths_eq_catalan, generalizing the barrier to depth −k."
+    },
+    {
+      "id": "catalan-numbers-oq-01-oq-01",
+      "reason": "Grandparent: the arithmetic Catalan reflection form, of which the generalized ballot count C(2n,n) − C(2n,n+k) is the k-parameter family."
+    }
+  ],
+  "references": [
+    "André, D. (1887). Solution directe du problème résolu par M. Bertrand. C. R. Acad. Sci. Paris 105, 436–437.",
+    "Dvoretzky, A. & Motzkin, T. (1947). A problem of arrangements. Duke Math. J. 14, 305–313 (the cycle lemma).",
+    "Stanley, R. P. Enumerative Combinatorics, Vol. 2 — the ballot problem and the reflection principle.",
+    "Mathlib4: Mathlib.Combinatorics.Enumerative.Catalan"
+  ],
+  "meta": {
+    "author": "Désiré André / Joseph Bertrand (ballot reflection, 1887); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanGeneralizedBallot.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "ballot-problem",
+      "cycle-lemma",
+      "reflection-principle",
+      "bijective-combinatorics",
+      "lattice-paths",
+      "binomial-coefficients",
+      "enumerative-combinatorics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_bij'",
+        "description": "Cardinality equality from an explicit bijection with stated inverse. Carries the depth-k reflection bijection BadPathsK ≃ LowPathsK, with the reflection serving as its own inverse.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_powersetCard / card_filter_card_eq (parent)",
+        "description": "#(powersetCard k s) = s.card.choose k. Counts the (n−k)-up paths (LowPathsK) and all n-up paths as C(2n, ·) for free.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "k ≤ n → n.choose (n − k) = n.choose k. Gives C(2n, n−k) = C(2n, n+k), matching the LowPathsK count to the generalized ballot subtrahend.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "#(filter p s) + #(filter ¬p s) = #s. Splits all n-up paths into depth-k bad and good (generalized Dyck) paths.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.find / Nat.sInf_mem / Nat.sInf_le",
+        "description": "First-witness and least-element API; drive the discrete intermediate-value lemma reachesK_of_card_add_le and the first-descent cut point cutK S k = sInf {j | hitsAtK S k j}.",
+        "module": "Mathlib.Data.Nat.Find / Mathlib.Data.Nat.Lattice"
+      },
+      {
+        "theorem": "CatalanAndreReflection.card_reflect_add",
+        "description": "Parent lemma: #(reflect S t) + #S + t = 2·preUps S t + 2n, the barrier-independent reflection cardinality identity, reused verbatim at depth k (specialized via cutK = 2·preUps + k).",
+        "module": "Proofs.CatalanAndreReflection"
+      },
+      {
+        "theorem": "CatalanAndreReflection.card_goodPaths_eq_catalan",
+        "description": "Parent headline #GoodPaths = catalan n; reused to recover the k = 1 slice (card_goodPathsK_one) after identifying GoodPathsK n 1 = GoodPaths n.",
+        "module": "Proofs.CatalanAndreReflection"
+      }
+    ],
+    "originalContributions": [
+      "hitsAtK / ReachesK: the depth-k descent predicates (j = 2·preUps S j + k) generalizing the parent's barrier −1; with decidability instances.",
+      "reachesK_of_card_add_le: a depth-k discrete intermediate-value lemma — any path with at most n − k up-steps reaches depth −k exactly at some first prefix.",
+      "cutK / cutK_reflect / reachesK_reflect / card_reflect_cutK: the depth-k first-passage involution package, reusing the parent's barrier-independent preUps_reflect_eq, yielding the collapsed identity #(reflect) + #S + k = 2n.",
+      "card_badPathsK / card_badPathsK_eq: the generalized André reflection bijection BadPathsK ≃ LowPathsK (1 ≤ k ≤ n), giving #BadPathsK = C(2n, n+k).",
+      "card_goodPathsK_add / card_goodPathsK_sub: the headline generalized ballot count #GoodPathsK = C(2n,n) − C(2n,n+k), in additive (ℕ) and subtraction (ℤ) forms.",
+      "reachesK_one_iff / goodPathsK_one / card_goodPathsK_one: the k = 1 recovery, identifying the generalized good paths with the parent's Dyck paths (by Iff.rfl) and the count with catalan n."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries, no native_decide (the one concrete instance, GoodPathsK 3 2, is derived from the general theorem; the only decide calls reduce closed Nat.choose numerals via kernel reduction, not Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms on card_goodPathsK_add, card_badPathsK, card_goodPathsK_one, card_goodPathsK_sub).",
+    "lineCount": 259,
+    "theoremCount": 15,
+    "definitionCount": 6
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's (catalan-numbers-oq-01-oq-01-oq-01, André's reflection bijection) first open question: **generalize the reflection from barrier height −1 to arbitrary depth −k**, yielding the generalized ballot / cycle-lemma count.

For `1 ≤ k ≤ n`, the number of monotone `n`-up lattice paths that stay strictly above depth `−k` is
```
#GoodPathsK = C(2n, n) − C(2n, n+k)
```
the André–Bertrand ballot number. At `k = 1` this is exactly the parent's `catalan n`.

## Engine

The parent's reflection core is **barrier-independent**, so it is imported and reused verbatim:
- `preUps`, `reflect`, and the cardinality identity `#(reflect S t) + #S + t = 2·preUps S t + 2n` never mention the barrier.
- Only the depth-`k` descent predicate `hitsAtK S k j := (j = 2·preUps S j + k)` and the first-passage cut `cutK` are re-derived.

Substituting `cutK = 2·preUps + k` into the reflection identity collapses it to `#(reflect) + #S + k = 2n`, so reflecting an `n`-up bad path produces an `(n−k)`-up path — the whole bijection in one arithmetic step (`card_badPathsK`, via `Finset.card_bij'`). A depth-`k` discrete intermediate-value lemma (`reachesK_of_card_add_le`) shows every `(n−k)`-up path reaches `−k`. Counting both sides with `Finset.powersetCard` + `Nat.choose_symm` gives `#BadPathsK = C(2n, n+k)`.

The `k = 1` slice is **definitionally** the parent: `hitsAtK S 1 ≡ hitsAt`, so `ReachesK S 1 ↔ Reaches S` by `Iff.rfl`, `GoodPathsK n 1 = GoodPaths n`, and `card_goodPathsK_one = catalan n`.

## Verification

- **259 lines, 15 theorems/lemmas, 6 defs, 0 sorries, 0 axioms.**
- `#print axioms` on `card_goodPathsK_add`, `card_badPathsK`, `card_goodPathsK_one`, `card_goodPathsK_sub` → `[propext, Classical.choice, Quot.sound]` only. No `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.
- Built host-side with `lake env lean` (docker daemon down this session).

Mathlib has no generalized ballot / cycle-lemma count (only the Dyck-word tree recursion for `catalan`); the closed difference `C(2n,n) − C(2n,n+k)` for the full family is the original content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)