### PR TITLE
research(euler-totient-oq-01-oq-01-oq-01): explicit Carmichael closed form + λ(561)=80 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2757,6 +2757,7 @@ import Proofs.EulerTotientOQ01OQ02
 import Proofs.EulerTotientOQ01OQ02OQ01
 import Proofs.EulerTotientOQ01OQ02OQ03
 import Proofs.EulerTotientOQ01OQ01
+import Proofs.EulerTotientOQ01OQ01OQ01
 import Proofs.EulerTotientOQ01OQ03
 import Proofs.EulerTotientOQ01OQ03Keygen
 import Proofs.EulerTotientOQ01OQ03Minimal

--- a/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean
@@ -1,0 +1,136 @@
+import Mathlib
+
+/-
+# The Explicit Carmichael Function on the Prime-Power Factorization
+
+## Open question (euler-totient-oq-01-oq-01-oq-01)
+
+Parent `euler-totient-oq-01-oq-01` proves the keystone multiplicativity
+λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n, and asks to "complete the induction
+over the prime-power factorization to state λ(n) = lcm_i λ(pᵢ^kᵢ) as a single
+theorem".
+
+## Honesty note — what is and isn't new here
+
+The literal factorization identity is **already in Mathlib** as
+`ArithmeticFunction.carmichael_factorization`:
+
+    Carmichael n = n.primeFactors.lcm (fun p ↦ Carmichael (p ^ n.factorization p))
+
+together with the per-prime-power closed forms
+`carmichael_pow_of_prime_ne_two` (λ(p^k) = φ(p^k) for odd p) and
+`carmichael_two_pow_of_ne_two` (λ(2^k) = 2^{k-2}, k ≠ 2).  Re-deriving any of
+these would be a thin wrapper, so this file does **not** reprove them — it
+*cites* them and contributes the parts Mathlib leaves unassembled:
+
+1. The **explicit closed form** for odd n:
+       λ(n) = lcm_{p | n} p^{k_p - 1}·(p - 1),
+   obtained by collapsing each odd prime-power factor λ(p^{k}) = φ(p^{k})
+   to its textbook value p^{k-1}(p-1).  Mathlib has the factorization lemma
+   and the per-factor totient value separately; the single assembled formula
+   is not stated there.
+
+2. **Concrete evaluations** that are genuinely absent from Mathlib, including
+   the first Carmichael number 561 = 3·11·17:
+       λ(561) = lcm(2, 10, 16) = 80,  and  80 ∣ 560,
+   the Korselt-style divisibility λ(561) ∣ (561 − 1) that makes 561 a
+   Carmichael number.
+
+`Carmichael` is Mathlib's reduced totient (the exponent of (ℤ/nℤ)ˣ), the same
+function the parent file defines locally as `Monoid.exponent (ZMod n)ˣ`.
+-/
+
+open Nat ArithmeticFunction
+
+namespace EulerTotientOQ01OQ01OQ01
+
+/-! ## Explicit values on odd prime powers -/
+
+/-- For an odd prime `p`, the Carmichael value is `λ(p) = p - 1` (the unit group
+`(ℤ/pℤ)ˣ` is cyclic of order `p − 1`).  Specialises Mathlib's
+`carmichael_pow_of_prime_ne_two` at exponent 1. -/
+theorem carmichael_odd_prime {p : ℕ} (hp : p.Prime) (hp2 : p ≠ 2) :
+    Carmichael p = p - 1 := by
+  have h := carmichael_pow_of_prime_ne_two 1 hp hp2
+  rwa [pow_one, Nat.totient_prime hp] at h
+
+/-- For an odd prime `p` and `k ≥ 1`, the Carmichael value has the textbook
+closed form `λ(p^k) = p^{k-1}·(p-1) = φ(p^k)`.  Combines Mathlib's
+`carmichael_pow_of_prime_ne_two` with `Nat.totient_prime_pow`. -/
+theorem carmichael_odd_prime_pow {p k : ℕ} (hp : p.Prime) (hp2 : p ≠ 2)
+    (hk : 0 < k) : Carmichael (p ^ k) = p ^ (k - 1) * (p - 1) := by
+  rw [carmichael_pow_of_prime_ne_two k hp hp2, Nat.totient_prime_pow hp hk]
+
+/-! ## The explicit closed form for odd `n` -/
+
+/-- **Explicit Carmichael formula for odd `n`.**
+
+For odd `n ≠ 0` with prime factorisation `n = ∏ p^{k_p}` (every `p` odd),
+
+    λ(n) = lcm_{p ∈ primeFactors n} p^{k_p - 1}·(p - 1).
+
+This is the assembled textbook formula: Mathlib's `carmichael_factorization`
+reduces `λ(n)` to the lcm of the per-prime-power values `λ(p^{k_p})`, and each
+of those collapses to `p^{k_p-1}(p-1)` because every prime factor of an odd
+number is itself odd. -/
+theorem carmichael_odd_eq_lcm_explicit {n : ℕ} (hn : n ≠ 0) (hodd : Odd n) :
+    Carmichael n
+      = n.primeFactors.lcm (fun p => p ^ (n.factorization p - 1) * (p - 1)) := by
+  haveI : NeZero n := ⟨hn⟩
+  rw [carmichael_factorization n]
+  refine Finset.lcm_congr rfl (fun p hp => ?_)
+  have hpp : p.Prime := prime_of_mem_primeFactors hp
+  have hdvd : p ∣ n := dvd_of_mem_primeFactors hp
+  have hp2 : p ≠ 2 := by
+    rintro rfl
+    exact (Nat.not_even_iff_odd.mpr hodd) (even_iff_two_dvd.mpr hdvd)
+  have hk : 0 < n.factorization p := hpp.factorization_pos_of_dvd hn hdvd
+  rw [carmichael_odd_prime_pow hpp hp2 hk]
+
+/-! ## Euler's theorem, sharpened
+
+The universal-exponent property and the divisibility `λ(n) ∣ φ(n)` are exactly
+the content of Mathlib's `pow_carmichael` and `carmichael_dvd_totient`; we record
+them here as the headline corollaries that motivate the Carmichael function. -/
+
+/-- The universal exponent property (Mathlib `pow_carmichael`): every unit of
+`ℤ/nℤ` is killed by `λ(n)`, i.e. `a^{λ(n)} = 1`.  This is the sharp form of
+Euler's theorem `a^{φ(n)} ≡ 1`. -/
+theorem pow_carmichael_eq_one {n : ℕ} (a : (ZMod n)ˣ) :
+    a ^ Carmichael n = 1 := pow_carmichael a
+
+/-- `λ(n) ∣ φ(n)` (Mathlib `carmichael_dvd_totient`): the Carmichael exponent
+divides Euler's totient, so `λ(n)` is never larger than `φ(n)` and refines it. -/
+theorem carmichael_dvd_totient' (n : ℕ) : Carmichael n ∣ n.totient :=
+  carmichael_dvd_totient n
+
+/-! ## Concrete evaluations
+
+These specific values are not in Mathlib.  They exercise the multiplicative law
+on genuinely distinct primes. -/
+
+/-- `λ(15) = lcm(λ(3), λ(5)) = lcm(2, 4) = 4`. -/
+theorem carmichael_15 : Carmichael 15 = 4 := by
+  rw [show (15 : ℕ) = 3 * 5 from rfl, carmichael_mul (by decide),
+      carmichael_odd_prime (p := 3) (by norm_num) (by norm_num),
+      carmichael_odd_prime (p := 5) (by norm_num) (by norm_num)]
+  decide
+
+/-- **The first Carmichael number.** `561 = 3 · 11 · 17`, and
+`λ(561) = lcm(λ(3), λ(11), λ(17)) = lcm(2, 10, 16) = 80`. -/
+theorem carmichael_561 : Carmichael 561 = 80 := by
+  rw [show (561 : ℕ) = 3 * (11 * 17) from rfl,
+      carmichael_mul (by decide), carmichael_mul (by decide),
+      carmichael_odd_prime (p := 3) (by norm_num) (by norm_num),
+      carmichael_odd_prime (p := 11) (by norm_num) (by norm_num),
+      carmichael_odd_prime (p := 17) (by norm_num) (by norm_num)]
+  decide
+
+/-- **Korselt's criterion witness for 561.** Since `λ(561) = 80` divides
+`561 − 1 = 560`, every `a` coprime to 561 satisfies `a^{560} ≡ 1 (mod 561)`,
+which is exactly why 561 is a Carmichael (Fermat-pseudoprime-to-every-base)
+number. -/
+theorem carmichael_561_dvd_560 : Carmichael 561 ∣ 560 := by
+  rw [carmichael_561]; decide
+
+end EulerTotientOQ01OQ01OQ01

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/knowledge.md
@@ -6,16 +6,48 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent (`euler-totient-oq-01-oq-01`) proves the keystone λ(m·n)=lcm(λ(m),λ(n))
+for coprime m, n and asks to complete the induction to λ(n)=lcm_i λ(pᵢ^kᵢ).
+
+**Dedup finding:** that literal identity — and *all three* of the parent's stated
+open questions — are already in Mathlib's
+`Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean`:
+- `carmichael_factorization` : λ(n) = lcm over primeFactors of λ(p^{k_p})
+- `carmichael_pow_of_prime_ne_two` : λ(p^k) = φ(p^k) for odd p
+- `carmichael_two_pow_of_ne_two` : λ(2^k) = 2^{k-2} for k ≠ 2
+- plus `carmichael_mul`/`carmichael_lcm`, `pow_carmichael`, `carmichael_dvd_totient`.
+
+The parent file even reproved `carmichael_mul` locally. So a faithful re-proof
+of the open question is a thin wrapper. The honest contribution is the
+**explicit assembled closed form** and **concrete data** Mathlib does not state.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- For **odd n**, every prime factor is odd, so each factor λ(p^k)=φ(p^k)=p^{k-1}(p-1)
+  is a clean cyclic-group order; the prime 2 is the only obstruction to a single
+  power formula (non-cyclic units for k≥3), which is why the explicit statement is
+  cleanest restricted to odd n.
+- Engine for `carmichael_odd_eq_lcm_explicit`: `rw [carmichael_factorization n]`
+  then `Finset.lcm_congr rfl`; per factor use `prime_of_mem_primeFactors`,
+  `dvd_of_mem_primeFactors`, `Nat.Prime.factorization_pos_of_dvd`, and
+  `p ≠ 2` from `Odd n` (else `2 ∣ n` via `even_iff_two_dvd`,
+  contradicting `Nat.not_even_iff_odd.mpr hodd`).
+- Concrete Carmichael values are computable despite `Carmichael` being
+  noncomputable: iterate `carmichael_mul` over coprime prime factors down to
+  λ(p)=p−1, then `decide` the small nested `Nat.lcm`. `carmichael_mul` needs the
+  `Coprime` side-goals by `decide`.
+- λ(561)=lcm(2,10,16)=80 ∣ 560 is the Korselt witness making 561 the first
+  Carmichael number.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Reproving `carmichael_factorization` / `carmichael_mul` from scratch — pointless,
+  Mathlib already has them. Always grep
+  `.lake/packages/mathlib/Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean`
+  before formalizing a named Carmichael identity.
+- A single clean closed form valid for all n (including the 2-part) — blocked by
+  the piecewise λ(2^k); deferred to a follow-up.

--- a/research/problems/euler-totient-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/euler-totient-oq-01-oq-01-oq-01/state.md
@@ -1,24 +1,29 @@
 # Research State: euler-totient-oq-01-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-06-24T16:43:04+0000
+**Since**: 2026-06-24
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Completed. Shipped the explicit odd-n Carmichael closed form plus concrete
+Carmichael-number evaluations.
 
 ## Active Approach
-None yet.
+Cite Mathlib's `carmichael_factorization` (the literal open question) and assemble
+the unstated explicit form: collapse each odd prime-power factor λ(p^k) to
+p^{k-1}(p-1) via `Finset.lcm_congr`; evaluate concrete cases by iterating
+`carmichael_mul` + `decide`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
 None.
 
 ## Next Action
-Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm the Mathlib API names listed there, and draft the first Lean skeleton.
+None — completed. Follow-ups (general 2-part formula; Korselt criterion) recorded
+as open questions in meta.json / research JSON.

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "euler-totient-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Honesty Framing: What Mathlib Already Has vs. What This Adds",
+    "content": "The docblock is explicit that the parent's open question — λ(n) = lcm_i λ(p_i^{k_i}) as a single theorem — is already Mathlib's ArithmeticFunction.carmichael_factorization, alongside the per-prime-power closed forms carmichael_pow_of_prime_ne_two (odd p) and carmichael_two_pow_of_ne_two (p=2). Rather than reprove these as a thin wrapper, the file cites them and contributes the unassembled pieces: the explicit closed form for odd n and concrete Carmichael-number evaluations. Carmichael is Mathlib's reduced totient, the exponent of (ℤ/nℤ)ˣ — the same function the parent file defines locally as Monoid.exponent (ZMod n)ˣ.",
+    "mathContext": "The Carmichael function $\\lambda(n)$ is the exponent of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$: the least $e \\ge 1$ with $a^e \\equiv 1 \\pmod n$ for all $\\gcd(a,n)=1$. It satisfies $\\lambda(n) \\mid \\varphi(n)$ and, via CRT, $\\lambda(\\prod p_i^{k_i}) = \\operatorname{lcm}_i \\lambda(p_i^{k_i})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ArithmeticFunction.Carmichael",
+      "ArithmeticFunction.carmichael_factorization",
+      "Monoid.exponent",
+      "reduced totient"
+    ],
+    "prerequisites": [
+      "group exponent",
+      "unit group of ℤ/nℤ",
+      "Chinese Remainder Theorem"
+    ]
+  },
+  {
+    "id": "ann-odd-prime-power",
+    "proofId": "euler-totient-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "Odd Prime-Power Values: λ(p^k) = p^(k-1)(p-1)",
+    "content": "carmichael_odd_prime proves λ(p)=p−1 by specialising carmichael_pow_of_prime_ne_two at exponent 1 and rewriting with Nat.totient_prime. carmichael_odd_prime_pow gives the general λ(p^k)=p^{k-1}(p-1)=φ(p^k) for odd p and k≥1, combining carmichael_pow_of_prime_ne_two (which uses cyclicity of (ℤ/p^kℤ)ˣ for odd p) with Nat.totient_prime_pow. These are the cyclic-group orders that the lcm formula ranges over.",
+    "mathContext": "For an odd prime $p$, $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ is cyclic of order $\\varphi(p^k)=p^{k-1}(p-1)$, so its exponent equals its order: $\\lambda(p^k)=p^{k-1}(p-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "carmichael_pow_of_prime_ne_two",
+      "Nat.totient_prime_pow",
+      "cyclic unit group"
+    ],
+    "prerequisites": [
+      "(ℤ/p^kℤ)ˣ cyclic for odd p",
+      "exponent of a cyclic group = its order"
+    ]
+  },
+  {
+    "id": "ann-explicit-closed-form",
+    "proofId": "euler-totient-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "The Assembled Closed Form for Odd n",
+    "content": "carmichael_odd_eq_lcm_explicit is the entry's main assembled result: for odd n≠0, λ(n) = lcm over p ∈ primeFactors n of p^{k_p-1}(p-1). The proof rewrites Mathlib's carmichael_factorization (which yields lcm of λ(p^{k_p})) and applies Finset.lcm_congr to replace each factor by its explicit value, using that any prime factor p of an odd n cannot be 2 (else 2 ∣ n contradicts Odd n) and that p ∈ primeFactors forces k_p = n.factorization p ≥ 1 (Nat.Prime.factorization_pos_of_dvd).",
+    "mathContext": "Restricting to odd $n$ removes the prime 2 — the only prime whose unit group $(\\mathbb{Z}/2^k\\mathbb{Z})^\\times$ is non-cyclic for $k\\ge 3$ — so every factor contributes the clean cyclic order $p^{k_p-1}(p-1)$ and the formula is uniform.",
+    "significance": "key",
+    "relatedConcepts": [
+      "carmichael_factorization",
+      "Finset.lcm_congr",
+      "Nat.Prime.factorization_pos_of_dvd",
+      "Odd.not_two"
+    ],
+    "prerequisites": [
+      "prime factors of an odd number are odd",
+      "Finset.lcm congruence"
+    ]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "euler-totient-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 136
+    },
+    "type": "insight",
+    "title": "Euler Sharpened and the First Carmichael Number",
+    "content": "pow_carmichael_eq_one and carmichael_dvd_totient' re-export the universal exponent a^{λ(n)}=1 and λ(n) ∣ φ(n). The concrete block computes λ(15)=lcm(2,4)=4 and λ(561)=lcm(2,10,16)=80 (561=3·11·17, the first Carmichael number) by iterating carmichael_mul over the coprime prime factors, with carmichael_odd_prime giving each λ(p)=p−1 and the kernel (decide) reducing the nested lcm. carmichael_561_dvd_560 records the Korselt witness 80 ∣ 560=561−1 that makes 561 a Carmichael number.",
+    "mathContext": "Korselt's criterion: a squarefree composite $n$ is a Carmichael number iff $\\lambda(n) \\mid n-1$. For $n=561$, $\\lambda(561)=80 \\mid 560$, so $a^{560}\\equiv 1 \\pmod{561}$ for every $a$ coprime to 561 — 561 is a Fermat pseudoprime to every such base.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "carmichael_mul",
+      "pow_carmichael",
+      "carmichael_dvd_totient",
+      "Korselt's criterion",
+      "Carmichael number"
+    ],
+    "prerequisites": [
+      "lcm computation",
+      "Fermat's little theorem"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "euler-totient-oq-01-oq-01-oq-01",
+  "title": "The Explicit Carmichael Function: λ(n) = lcm_p p^(k-1)(p-1) and λ(561)=80",
+  "slug": "euler-totient-oq-01-oq-01-oq-01",
+  "description": "Assembles the textbook closed form of Carmichael's function for odd n — λ(n) = lcm over primes p|n of p^(k_p-1)(p-1) — from Mathlib's factorization lemma and per-prime-power totient values, and computes concrete Carmichael-number data: λ(561) = lcm(2,10,16) = 80 with the Korselt witness 80 ∣ 560.",
+  "meta": {
+    "author": "Robert Carmichael (1910); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carmichael_function",
+    "date": "1910 (Carmichael); 1899 (Korselt's criterion)",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "group-theory",
+      "carmichael-function",
+      "totient",
+      "carmichael-number",
+      "euler-theorem"
+    ],
+    "proofRepoPath": "Proofs/EulerTotientOQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "lineCount": 136,
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.carmichael_factorization",
+        "description": "λ(n) = lcm over primeFactors of λ(p^{k_p}) — the literal factorization identity (the open question itself)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "ArithmeticFunction.carmichael_pow_of_prime_ne_two",
+        "description": "λ(p^k) = φ(p^k) for odd primes p (the unit group is cyclic)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "ArithmeticFunction.carmichael_mul",
+        "description": "λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n (the parent's keystone, already in Mathlib)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Carmichael"
+      },
+      {
+        "theorem": "Nat.totient_prime_pow",
+        "description": "φ(p^k) = p^{k-1}(p-1) for prime p, k ≥ 1",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.lcm_congr",
+        "description": "Congruence for Finset.lcm under a pointwise rewrite of the function",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      }
+    ],
+    "assumptions": [],
+    "definitionCount": 0
+  },
+  "parent": "euler-totient-oq-01-oq-01",
+  "openQuestion": "Complete the induction over the prime-power factorization to state λ(n) = lcm_i λ(p_i^{k_i}) as a single theorem.",
+  "significance": "Carmichael's function λ(n) is the sharp universal exponent in Euler's theorem: it is the least e with a^e ≡ 1 (mod n) for every a coprime to n, and it divides φ(n). The parent entry proved the keystone multiplicativity λ(m·n)=lcm(λ(m),λ(n)). The literal factorization identity λ(n)=lcm_i λ(p_i^{k_i}) requested by the open question turns out to be already present in Mathlib (carmichael_factorization), so this entry does not reprove it — instead it contributes the parts Mathlib leaves unassembled: (1) the explicit textbook closed form for odd n, λ(n) = lcm_{p|n} p^{k_p-1}(p-1), obtained by collapsing each odd prime-power factor λ(p^k)=φ(p^k) to its closed value; and (2) concrete Carmichael-number evaluations, notably λ(561)=80 for the first Carmichael number 561=3·11·17, together with the Korselt-style divisibility 80 ∣ 560 = 561−1 that explains why 561 is a Fermat pseudoprime to every base coprime to it.",
+  "overview": {
+    "historicalContext": "Robert Daniel Carmichael introduced the function λ(n) in 1910 as the 'reduced totient', the smallest exponent that works uniformly in Euler's congruence a^{φ(n)} ≡ 1 (mod n). It is the exponent of the unit group (ℤ/nℤ)ˣ. By the Chinese Remainder Theorem this group splits over the prime-power factors of n, so λ is determined by its prime-power values through an lcm. For odd prime powers the unit group is cyclic, giving λ(p^k)=φ(p^k)=p^{k-1}(p-1); the prime 2 is the lone exception, where (ℤ/2^kℤ)ˣ ≅ ℤ/2 × ℤ/2^{k-2} for k ≥ 3 and λ(2^k)=2^{k-2}. The function is central to A. Korselt's 1899 criterion for Carmichael numbers — composite n with a^{n-1} ≡ 1 for all a coprime to n — which holds precisely when n is squarefree and λ(n) ∣ n−1. The smallest such number is 561 = 3·11·17, with λ(561)=lcm(2,10,16)=80 dividing 560.",
+    "problemStatement": "State the prime-power factorisation law for the Carmichael function λ as a single theorem and assemble the explicit closed form, then evaluate it on concrete inputs including the first Carmichael number 561.",
+    "proofStrategy": "Mathlib's ArithmeticFunction.Carmichael (the exponent of (ℤ/nℤ)ˣ, the same function the parent file defines locally) already provides carmichael_factorization (λ(n)=lcm of λ(p^{k_p})), carmichael_mul (the parent's keystone multiplicativity), carmichael_pow_of_prime_ne_two (λ(p^k)=φ(p^k) for odd p), pow_carmichael (the universal exponent) and carmichael_dvd_totient (λ(n) ∣ φ(n)). This entry cites those and adds: (a) carmichael_odd_prime_pow, collapsing λ(p^k) to p^{k-1}(p-1) via Nat.totient_prime_pow; (b) carmichael_odd_eq_lcm_explicit, which rewrites carmichael_factorization through Finset.lcm_congr, using that every prime factor of an odd n is itself odd (hence ≠ 2) so each factor takes the explicit value; (c) carmichael_15, carmichael_561 and carmichael_561_dvd_560, evaluated by iterating carmichael_mul on coprime prime factors and reducing the resulting nested lcm by kernel computation (decide).",
+    "keyInsights": [
+      "The literal open question λ(n)=lcm_i λ(p_i^{k_i}) is already Mathlib's carmichael_factorization, so the honest contribution is the explicit assembled closed form and concrete data, not a re-proof",
+      "For odd n every prime factor is odd, so each per-factor value λ(p^k)=φ(p^k)=p^{k-1}(p-1) is the cyclic-group order — the prime 2 is the only obstruction to a single clean power formula, which is why the explicit statement is cleanest restricted to odd n",
+      "The Carmichael function is the SHARP constant in Euler's theorem: λ(n) ∣ φ(n) and a^{λ(n)} ≡ 1 for all coprime a, with λ generally much smaller than φ — e.g. λ(561)=80 versus φ(561)=320",
+      "Korselt's criterion reads off directly from the explicit formula: 561=3·11·17 is squarefree and λ(561)=lcm(2,10,16)=80 divides 561−1=560, so 561 is a Carmichael number (Fermat pseudoprime to every coprime base)",
+      "Iterating the coprime multiplicativity law over distinct primes turns Carmichael-value computation into a finite nested-lcm calculation that the Lean kernel discharges by decide"
+    ]
+  },
+  "sections": [
+    {
+      "id": "odd-prime-power-values",
+      "title": "Explicit Values on Odd Prime Powers",
+      "startLine": 49,
+      "endLine": 73,
+      "summary": "carmichael_odd_prime (λ(p)=p−1) and carmichael_odd_prime_pow (λ(p^k)=p^{k-1}(p-1)) specialise Mathlib's carmichael_pow_of_prime_ne_two and Nat.totient_prime_pow to give the cyclic-group closed form for odd prime powers."
+    },
+    {
+      "id": "explicit-closed-form",
+      "title": "The Explicit Closed Form for Odd n",
+      "startLine": 75,
+      "endLine": 102,
+      "summary": "carmichael_odd_eq_lcm_explicit assembles λ(n) = lcm_{p|n} p^{k_p-1}(p-1) for odd n, rewriting Mathlib's carmichael_factorization through Finset.lcm_congr and the fact that every prime factor of an odd number is odd."
+    },
+    {
+      "id": "euler-sharpened",
+      "title": "Euler's Theorem, Sharpened",
+      "startLine": 104,
+      "endLine": 118,
+      "summary": "Records the universal-exponent property a^{λ(n)}=1 (pow_carmichael) and the divisibility λ(n) ∣ φ(n) (carmichael_dvd_totient) as the headline corollaries motivating the Carmichael function."
+    },
+    {
+      "id": "concrete-evaluations",
+      "title": "Concrete Evaluations and the First Carmichael Number",
+      "startLine": 120,
+      "endLine": 136,
+      "summary": "carmichael_15 (=4), carmichael_561 (=80 for 561=3·11·17, the first Carmichael number) and carmichael_561_dvd_560 (the Korselt witness 80 ∣ 560), evaluated by iterating carmichael_mul and reducing nested lcm by decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes the explicit prime-power form of Carmichael's function as a verified (0 sorries, 0 axioms) gallery result. Rather than reprove the literal factorization identity λ(n)=lcm_i λ(p_i^{k_i}), which is already Mathlib's carmichael_factorization, it assembles the textbook closed form λ(n)=lcm_{p|n} p^{k_p-1}(p-1) for odd n and computes concrete data: λ(15)=4, and λ(561)=80 for the first Carmichael number 561=3·11·17 together with the Korselt witness 80 ∣ 560. The universal-exponent property and λ(n) ∣ φ(n) are recorded as the Euler-theorem corollaries.",
+    "implications": "Carmichael's function is the right exponent for primality testing, the structure of (ℤ/nℤ)ˣ, and the theory of Carmichael numbers. The explicit closed form makes λ computable from the factorization, and the 561 evaluation is the canonical example of how λ(n) ∣ n−1 characterises Carmichael numbers via Korselt's criterion — the gateway to Alford–Granville–Pomerance (there are infinitely many Carmichael numbers).",
+    "openQuestions": [
+      "State the full explicit formula including the prime 2 (the piecewise λ(2^k)=2^{k-1} for k≤2, 2^{k-2} for k≥3) to remove the oddness restriction.",
+      "Formalize Korselt's criterion in general: a squarefree composite n is a Carmichael number iff λ(n) ∣ n−1, and derive that every Carmichael number is a product of at least three distinct odd primes.",
+      "Compute λ for further Carmichael numbers (1105, 1729) and verify the Korselt divisibility uniformly."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-totient-oq-01-oq-01",
+      "relationship": "Parent theorem",
+      "description": "The parent proves the keystone multiplicativity λ(m·n)=lcm(λ(m),λ(n)); this entry iterates it over the full factorization and assembles the explicit closed form, answering the parent's first open question."
+    },
+    {
+      "proofId": "euler-totient-oq-01",
+      "relationship": "Grandparent theorem",
+      "description": "Establishes λ(n) ∣ φ(n), the divisibility that makes the Carmichael function a sharp refinement of Euler's totient in Euler's theorem."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "ArithmeticFunction"
+    ],
+    "namespace": "EulerTotientOQ01OQ01OQ01",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/EulerTotientOQ01OQ01OQ01.lean"
+  }
+}

--- a/src/data/research/problems/euler-totient-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-01-oq-01.json
@@ -1,0 +1,94 @@
+{
+  "slug": "euler-totient-oq-01-oq-01-oq-01",
+  "title": "The Explicit Carmichael Function: lambda(n) = lcm_p p^(k-1)(p-1) and lambda(561)=80",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\lambda(n) = \\operatorname{lcm}_{p \\mid n} p^{k_p - 1}(p-1) \\text{ for odd } n; \\quad \\lambda(561) = \\operatorname{lcm}(2,10,16) = 80 \\mid 560",
+    "plain": "Carmichael's function lambda(n) is the smallest exponent with a^lambda(n) = 1 mod n for all a coprime to n (the exponent of the unit group of Z/nZ). The parent proved lambda(mn)=lcm(lambda m, lambda n) for coprime m,n. The open question asks to complete the induction to lambda(n)=lcm_i lambda(p_i^k_i). That identity is already in Mathlib (carmichael_factorization); the contribution here is the explicit textbook closed form for odd n and concrete Carmichael-number data.",
+    "whyMatters": ["Carmichael's function is the sharp universal exponent in Euler's theorem and the key tool for primality testing and Carmichael numbers; lambda(561)=80 dividing 560 is the canonical witness (Korselt's criterion) that 561 is the first Carmichael number."]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent euler-totient-oq-01-oq-01: lambda(mn)=lcm(lambda m, lambda n) for coprime m,n",
+      "Mathlib ArithmeticFunction.carmichael_factorization: lambda(n)=lcm over primeFactors of lambda(p^k) (the literal open question)",
+      "Mathlib carmichael_pow_of_prime_ne_two: lambda(p^k)=phi(p^k) for odd p; carmichael_two_pow_of_ne_two: lambda(2^k)=2^(k-2) for k != 2",
+      "Mathlib pow_carmichael (a^lambda(n)=1) and carmichael_dvd_totient (lambda(n) | phi(n))"
+    ],
+    "open": [
+      "Full explicit formula including the prime 2 (piecewise 2-part)",
+      "General Korselt criterion: squarefree composite n is Carmichael iff lambda(n) | n-1"
+    ],
+    "goal": "Assemble the explicit closed form lambda(n)=lcm_{p|n} p^(k_p-1)(p-1) for odd n from Mathlib's factorization lemma and per-prime-power totient values, and evaluate concrete cases (lambda(15)=4, lambda(561)=80, 80|560)."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "Shipped explicit odd-n Carmichael closed form + concrete Carmichael-number evaluations; entry complete.",
+    "blockers": [],
+    "nextAction": "None - completed. Follow-ups (general 2-part formula, Korselt criterion) recorded as open questions.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED (verified, 0-axiom). DEDUP FINDING: the parent's literal open question lambda(n)=lcm_i lambda(p_i^k_i) is ALREADY Mathlib's ArithmeticFunction.carmichael_factorization, and all three parent open questions (factorization, 2-power value, odd-prime-power cyclicity) are in Mathlib's Carmichael.lean. So rather than reprove a thin wrapper, this entry assembles what Mathlib leaves separate: (1) the explicit closed form for odd n, lambda(n)=lcm_{p|n} p^(k_p-1)(p-1); (2) concrete evaluations lambda(15)=4 and lambda(561)=80 for the first Carmichael number 561=3*11*17, plus the Korselt witness 80 | 560. 8 theorems / 0 axioms / 0 sorries / 136 lines.",
+    "builtItems": [
+      "carmichael_odd_prime: lambda(p)=p-1 for odd prime p (specialise carmichael_pow_of_prime_ne_two at exp 1 + totient_prime)",
+      "carmichael_odd_prime_pow: lambda(p^k)=p^(k-1)(p-1) for odd p, k>=1 (carmichael_pow_of_prime_ne_two + totient_prime_pow)",
+      "carmichael_odd_eq_lcm_explicit: for odd n, lambda(n)=lcm_{p in primeFactors} p^(k_p-1)(p-1) via carmichael_factorization + Finset.lcm_congr (each prime factor of odd n is != 2)",
+      "carmichael_15 = 4 and carmichael_561 = 80 (first Carmichael number 561=3*11*17) by iterating carmichael_mul over coprime primes + decide on nested lcm",
+      "carmichael_561_dvd_560: Korselt witness 80 | 560 = 561-1; pow_carmichael_eq_one + carmichael_dvd_totient' re-exported as Euler-sharpened corollaries"
+    ],
+    "insights": [
+      "DEDUP: Mathlib's NumberTheory/ArithmeticFunction/Carmichael.lean already has carmichael_factorization, carmichael_mul/_lcm, carmichael_pow_of_prime_ne_two, carmichael_two_pow_of_ne_two, pow_carmichael, carmichael_dvd_totient - the parent file even reproved carmichael_mul locally. Always grep Mathlib for the exact target before formalizing a named classical identity.",
+      "The prime 2 is the ONLY obstruction to a single clean power formula for lambda: (Z/2^kZ)^x is non-cyclic for k>=3, so lambda(2^k)=2^(k-2) not phi(2^k). Restricting the explicit closed form to ODD n makes every factor a clean cyclic order p^(k-1)(p-1).",
+      "Proof engine for the odd closed form: rw carmichael_factorization then Finset.lcm_congr rfl; per factor, prime_of_mem_primeFactors + dvd_of_mem_primeFactors give primality and divisibility, Odd n forces p != 2 (else 2|n), and Nat.Prime.factorization_pos_of_dvd gives k_p >= 1.",
+      "Concrete Carmichael values are computable despite Carmichael being noncomputable: iterate carmichael_mul on coprime prime factors to reduce to lambda(p)=p-1, then decide on the small nested Nat.lcm. carmichael_mul needs Coprime proofs by decide.",
+      "Korselt's criterion drops out: 561 squarefree and lambda(561)=80 | 560 means a^560=1 mod 561 for all coprime a (first Carmichael number)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has carmichael_factorization and per-prime-power values separately but does NOT state the single assembled explicit closed form lambda(n)=lcm_{p|n} p^(k-1)(p-1).",
+      "No concrete Carmichael-number evaluations (lambda(561)=80 etc.) and no formalized Korselt criterion."
+    ],
+    "nextSteps": [
+      "Add the prime-2 piecewise term to get the fully general explicit formula.",
+      "Formalize Korselt's criterion: squarefree composite n is Carmichael iff lambda(n) | n-1.",
+      "Evaluate lambda for 1105 and 1729 (next Carmichael numbers)."
+    ],
+    "markdown": "See research/problems/euler-totient-oq-01-oq-01-oq-01/knowledge.md"
+  },
+  "tags": ["number-theory", "group-theory", "carmichael-function", "totient", "carmichael-number"],
+  "relatedProofs": [
+    "euler-totient-oq-01-oq-01",
+    "euler-totient-oq-01",
+    "euler-totient"
+  ],
+  "references": {
+    "papers": ["R. D. Carmichael, Note on a new number theory function, Bull. AMS 16 (1910)", "A. Korselt, Probleme chinois, L'intermediaire des mathematiciens 6 (1899)"],
+    "urls": ["https://en.wikipedia.org/wiki/Carmichael_function", "https://en.wikipedia.org/wiki/Carmichael_number"],
+    "mathlib": ["Mathlib.NumberTheory.ArithmeticFunction.Carmichael (carmichael_factorization, carmichael_mul, carmichael_pow_of_prime_ne_two, pow_carmichael, carmichael_dvd_totient)", "Mathlib.Data.Nat.Totient (totient_prime, totient_prime_pow)", "Mathlib.Algebra.GCDMonoid.Finset (Finset.lcm_congr)"]
+  },
+  "started": "2026-06-24T00:00:00.000Z",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerTotientOQ01OQ01OQ01.lean",
+      "filename": "EulerTotientOQ01OQ01OQ01.lean",
+      "lineCount": 136,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ01OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Parent `euler-totient-oq-01-oq-01` asks to complete the induction to **λ(n) = lcm_i λ(pᵢ^kᵢ)** as a single theorem.

**Honest dedup finding:** that identity — and in fact *all three* of the parent's stated open questions — are **already in Mathlib** (`Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean`: `carmichael_factorization`, `carmichael_pow_of_prime_ne_two`, `carmichael_two_pow_of_ne_two`, plus `carmichael_mul`, `pow_carmichael`, `carmichael_dvd_totient`). The parent file even reproved `carmichael_mul` locally. Reproving any of these would be a thin wrapper, so this entry **cites** them and contributes the parts Mathlib leaves unassembled.

## Genuinely new content (verified, 0 axioms, 0 sorries, 136 lines, 8 theorems)

- **`carmichael_odd_eq_lcm_explicit`** — the assembled textbook closed form for odd *n*:
  `λ(n) = lcm_{p | n} p^(k_p − 1)·(p − 1)`, collapsing each odd prime-power factor `λ(p^k) = φ(p^k)` via `Finset.lcm_congr` (every prime factor of an odd number is odd, hence ≠ 2).
- **`carmichael_15 = 4`** and **`carmichael_561 = 80`** — the first Carmichael number `561 = 3·11·17`, `λ = lcm(2,10,16) = 80`, by iterating `carmichael_mul` over coprime primes and reducing the nested `lcm` by kernel `decide`.
- **`carmichael_561_dvd_560`** — the Korselt witness `80 ∣ 560 = 561 − 1`, i.e. `a^560 ≡ 1 (mod 561)` for every coprime `a` (why 561 is a Carmichael number).
- `carmichael_odd_prime`, `carmichael_odd_prime_pow` (explicit odd prime-power values), and the Euler-sharpened corollaries `pow_carmichael_eq_one`, `carmichael_dvd_totient'`.

## Verification

Type-checked host-side against Mathlib (`lake env lean`), clean build. Uses kernel-checked `decide` (not `native_decide`) for the small `lcm`/`Coprime`/`dvd` computations — no `sorryAx`, no `Lean.ofReduceBool`, 0 axioms. The file header and `meta.json` disclose that Mathlib provides all building blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)