### PR TITLE
research(hall-marriage-theorem-oq-01-oq-01-oq-01): closed-form maximum partial transversal = |ι| − deficiency [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,131 @@
+import Mathlib
+import Proofs.HallMarriageTheoremOQ01OQ01
+
+/-
+# Closed-form maximum partial-transversal size via the Hall deficiency
+
+The companion entry `HallMarriageTheoremOQ01OQ01` proves the **defect (Ore) form**
+of Hall's marriage theorem: a matching saturating all but `d` indices exists
+**iff** every sub-family `s` satisfies `#s ≤ #(s.biUnion t) + d`
+(`deficiency_matching_iff`).  The natural next question it records is whether the
+*sharp* threshold `d` can be packaged as an explicit number, turning the
+parametrised `iff` into a single closed-form optimum.
+
+This file does exactly that.  Define the **deficiency**
+
+  `δ(t) = maxₛ (#s − #(s.biUnion t))`
+
+as a `Finset.sup` over *all* sub-families `s : Finset ι` (truncated subtraction;
+the empty family contributes `0`, so `δ ≥ 0` automatically).  Then the set of
+attainable partial-transversal sizes has a greatest element, and it is exactly
+
+  **maximum partial-transversal size = `#ι − δ(t)`.**
+
+Both halves come straight from the parent defect theorem:
+
+* *Attainability.*  Since every local deficit `#s − #(s.biUnion t)` is `≤ δ`, the
+  family is at worst `δ`-deficient, so `exists_matching_of_deficiency_le` yields a
+  matching of size `≥ #ι − δ`; shrinking its domain gives one of size *exactly*
+  `#ι − δ`.
+* *Optimality.*  A matching of size `k` is, in particular, a matching saturating
+  all but `#ι − k` indices, so `deficiency_le_of_matching` forces `δ ≤ #ι − k`,
+  i.e. `k ≤ #ι − δ`.
+
+As a corollary, `δ = 0` is precisely Hall's condition, recovering the existence of
+a full system of distinct representatives.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+
+open Finset Function
+
+namespace HallDefect
+
+variable {ι α : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq α] [Nonempty α]
+
+/-- The **deficiency** of a finite family `t : ι → Finset α`: the largest amount by
+which some sub-family `s` outruns its neighbourhood,
+`δ = maxₛ (#s − #(s.biUnion t))` (truncated subtraction; the empty family
+contributes `0`, so `δ ≥ 0` automatically). -/
+def deficiency (t : ι → Finset α) : ℕ :=
+  (univ : Finset (Finset ι)).sup (fun s => s.card - (s.biUnion t).card)
+
+omit [DecidableEq ι] [Nonempty α] in
+/-- Each sub-family's local deficit is bounded by the global deficiency. -/
+theorem sub_card_le_deficiency (t : ι → Finset α) (s : Finset ι) :
+    s.card - (s.biUnion t).card ≤ deficiency t := by
+  rw [deficiency]
+  exact Finset.le_sup (f := fun s => s.card - (s.biUnion t).card) (mem_univ s)
+
+omit [DecidableEq ι] [Nonempty α] in
+/-- The deficiency bound in additive form: `#s ≤ #(s.biUnion t) + δ` for every
+sub-family `s`. This is exactly the "`t` is at worst `δ`-deficient" hypothesis the
+parent defect theorem consumes. -/
+theorem deficiency_spec (t : ι → Finset α) :
+    ∀ s : Finset ι, s.card ≤ (s.biUnion t).card + deficiency t := by
+  intro s
+  have := sub_card_le_deficiency t s
+  omega
+
+/-- The set of attainable partial-transversal sizes: a partial transversal is a set
+`J ⊆ ι` together with a choice function `f` injective on `J` with `f i ∈ t i` for
+`i ∈ J`, and its size is `#J`. -/
+def transversalSizes (t : ι → Finset α) : Set ℕ :=
+  { k | ∃ (J : Finset ι) (f : ι → α),
+      J.card = k ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i }
+
+/-- **Closed-form maximum partial transversal.**  The attainable partial-transversal
+sizes of `t` have a greatest element, equal to `#ι − δ(t)`.  In particular the
+maximum partial-transversal size is exactly `#ι` minus the deficiency. -/
+theorem isGreatest_transversalSizes (t : ι → Finset α) :
+    IsGreatest (transversalSizes t) (Fintype.card ι - deficiency t) := by
+  constructor
+  · -- A transversal of size *exactly* `#ι − δ` exists.
+    obtain ⟨J, f, hJcard, hinj, hmem⟩ :=
+      exists_matching_of_deficiency_le (deficiency_spec t)
+    obtain ⟨J', hJ'sub, hJ'card⟩ :=
+      Finset.exists_subset_card_eq hJcard
+    have hsub : (↑J' : Set ι) ⊆ ↑J := Finset.coe_subset.mpr hJ'sub
+    exact ⟨J', f, hJ'card, hinj.mono hsub, fun i hi => hmem i (hJ'sub hi)⟩
+  · -- `#ι − δ` is an upper bound for every attainable size.
+    rintro k ⟨J, f, rfl, hinj, hmem⟩
+    have hkle : J.card ≤ Fintype.card ι := by simpa using Finset.card_le_univ J
+    -- A size-`k` matching saturates all but `#ι − k` indices.
+    have hdef : ∀ s : Finset ι,
+        s.card ≤ (s.biUnion t).card + (Fintype.card ι - J.card) :=
+      deficiency_le_of_matching (d := Fintype.card ι - J.card) (by omega) hinj hmem
+    have hδ : deficiency t ≤ Fintype.card ι - J.card := by
+      rw [deficiency]
+      apply Finset.sup_le
+      intro s _
+      have := hdef s
+      omega
+    omega
+
+omit [DecidableEq ι] [Nonempty α] in
+/-- **Deficiency zero is Hall's condition.**  `δ(t) = 0` exactly when every
+sub-family satisfies Hall's inequality `#s ≤ #(s.biUnion t)`. -/
+theorem deficiency_eq_zero_iff (t : ι → Finset α) :
+    deficiency t = 0 ↔ ∀ s : Finset ι, s.card ≤ (s.biUnion t).card := by
+  constructor
+  · intro h s
+    have := sub_card_le_deficiency t s
+    omega
+  · intro h
+    rw [deficiency]
+    apply Nat.le_zero.mp
+    apply Finset.sup_le
+    intro s _
+    have := h s
+    omega
+
+/-- **Full SDR via vanishing deficiency.**  When `δ(t) = 0`, the maximum
+partial transversal has size `#ι`: a full system of distinct representatives
+exists. -/
+theorem maxTransversal_eq_card_of_deficiency_zero {t : ι → Finset α}
+    (h : deficiency t = 0) :
+    IsGreatest (transversalSizes t) (Fintype.card ι) := by
+  have := isGreatest_transversalSizes t
+  rwa [h, Nat.sub_zero] at this
+
+end HallDefect

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "hall-marriage-theorem-oq-01-oq-01-oq-01-module-header",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+    "type": "concept",
+    "range": { "startLine": 4, "endLine": 38 },
+    "title": "Module Header: From the Defect Biconditional to a Closed Form",
+    "content": "The companion entry proves the **defect (Ore) form** of Hall's theorem: a matching saturating all but $d$ indices exists **iff** every sub-family $s$ satisfies $\\#s \\le \\#(s.\\mathrm{biUnion}\\ t) + d$. This file pins the sharp $d$ to the **deficiency**\n$$\\delta(t) = \\max_{s}\\ \\bigl(\\#s - \\#(s.\\mathrm{biUnion}\\ t)\\bigr),$$\nturning the parametrised biconditional into a single optimum: **maximum partial-transversal size $= \\#\\iota - \\delta(t)$**. Attainability comes from the parent's $\\mathrm{exists\\_matching\\_of\\_deficiency\\_le}$, optimality from $\\mathrm{deficiency\\_le\\_of\\_matching}$; $\\delta = 0$ recovers Hall's full system of distinct representatives."
+  },
+  {
+    "id": "hall-marriage-theorem-oq-01-oq-01-oq-01-deficiency",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+    "type": "definition",
+    "range": { "startLine": 50, "endLine": 71 },
+    "title": "The Deficiency as a Finset-sup",
+    "content": "`deficiency t = (univ : Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t))`, a maximum over **all** sub-families using $\\mathbb{N}$ **truncated subtraction** — so the empty family contributes $0$ and $\\delta \\ge 0$ holds by construction, no separate proof needed.\n\n`sub_card_le_deficiency`: the per-subfamily bound $\\#s - \\#(s.\\mathrm{biUnion}\\ t) \\le \\delta$, a direct `Finset.le_sup`. `deficiency_spec`: its additive form $\\#s \\le \\#(s.\\mathrm{biUnion}\\ t) + \\delta$ (by `omega`) — exactly the '$t$ is at worst $\\delta$-deficient' hypothesis the parent defect theorem consumes."
+  },
+  {
+    "id": "hall-marriage-theorem-oq-01-oq-01-oq-01-transversal-sizes",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+    "type": "definition",
+    "range": { "startLine": 73, "endLine": 78 },
+    "title": "Attainable Partial-Transversal Sizes",
+    "content": "`transversalSizes t = { k | ∃ J f, #J = k ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i }`. A **partial transversal** is a set $J \\subseteq \\iota$ together with a choice function $f$ injective on $J$ with $f\\,i \\in t\\,i$ for $i \\in J$; its size is $\\#J$. The headline theorem characterises the greatest element of this set of sizes."
+  },
+  {
+    "id": "hall-marriage-theorem-oq-01-oq-01-oq-01-closed-form",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 80, "endLine": 107 },
+    "title": "Closed-Form Maximum: |ι| − δ",
+    "content": "`isGreatest_transversalSizes`: $\\mathrm{IsGreatest}\\ (\\mathrm{transversalSizes}\\ t)\\ (\\#\\iota - \\delta(t))$ — the optimum is both **attained** and an **upper bound**.\n\n*Attainability*: feed `deficiency_spec` into `exists_matching_of_deficiency_le` to get a matching on some $J$ with $\\#J \\ge \\#\\iota - \\delta$, then `Finset.exists_subset_card_eq` trims it to a sub-transversal of size **exactly** $\\#\\iota - \\delta$ (a subset of an injective partial transversal is again one).\n\n*Optimality*: any attainable $k = \\#J$ gives a matching saturating all but $\\#\\iota - \\#J$ indices, so `deficiency_le_of_matching` plus `Finset.sup_le` force $\\delta \\le \\#\\iota - \\#J$, hence $k \\le \\#\\iota - \\delta$ by `omega`."
+  },
+  {
+    "id": "hall-marriage-theorem-oq-01-oq-01-oq-01-hall-corollaries",
+    "proofId": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 108, "endLine": 131 },
+    "title": "Vanishing Deficiency Recovers Hall",
+    "content": "`deficiency_eq_zero_iff`: $\\delta(t) = 0 \\iff \\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\ t)$ — i.e. $\\delta = 0$ is **exactly Hall's condition** (via `Finset.sup_le` / `Nat.le_zero`).\n\n`maxTransversal_eq_card_of_deficiency_zero`: rewriting $\\delta = 0$ in the closed form collapses $\\#\\iota - \\delta$ to $\\#\\iota$, so the maximum partial transversal saturates all of $\\iota$ — a **full system of distinct representatives**, recovering the classical marriage theorem as the zero-deficiency slice."
+  }
+]

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallMarriageTheoremOQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallMarriageTheoremOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallMarriageTheoremOQ01OQ01OQ01Data: ProofData = {
+  proof: hallMarriageTheoremOQ01OQ01OQ01Proof,
+  annotations: hallMarriageTheoremOQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+  "title": "Closed-form maximum partial transversal: size = |ι| − deficiency",
+  "slug": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+  "description": "Packages the defect (Ore) form of Hall's marriage theorem into a single closed-form optimum, answering the lead open question of the companion entry hall-marriage-theorem-oq-01-oq-01. That entry proved the parametrised biconditional 'a matching saturating all but d indices exists ⟺ ∀ s, #s ≤ #(s.biUnion t) + d'. Here the deficiency δ(t) = maxₛ (#s − #(s.biUnion t)) is defined as an explicit Finset.sup over all sub-families (truncated subtraction, so δ ≥ 0 automatically), and the set of attainable partial-transversal sizes is shown to have a greatest element equal to #ι − δ(t): isGreatest_transversalSizes. Both halves follow from the parent defect theorem — attainability from exists_matching_of_deficiency_le (then shrink the domain to hit the size exactly), optimality from deficiency_le_of_matching. The corollary deficiency_eq_zero_iff identifies δ = 0 with Hall's condition, recovering a full system of distinct representatives. 5 theorems, 2 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem",
+    "date": "Philip Hall 1935; Øystein Ore 1955 (defect form)",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "hall-marriage",
+      "transversal",
+      "matching",
+      "deficiency",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 5 theorems verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide, so no Lean.ofReduceBool. Builds on the defect form proved in the companion entry hall-marriage-theorem-oq-01-oq-01, which in turn bootstraps Mathlib's Finset.all_card_le_biUnion_card_iff_exists_injective.",
+    "originalContributions": [
+      "deficiency: the Hall deficiency δ(t) = maxₛ (#s − #(s.biUnion t)) packaged as an explicit Finset.sup over the universe of sub-families, with truncated subtraction making δ ≥ 0 automatic (the empty family contributes 0)",
+      "isGreatest_transversalSizes: the closed-form optimum — the attainable partial-transversal sizes form a set with greatest element exactly #ι − δ(t). Attainability uses exists_matching_of_deficiency_le and Finset.exists_subset_card_eq to realise the size exactly; optimality uses deficiency_le_of_matching to bound every attainable size by #ι − δ",
+      "deficiency_spec / sub_card_le_deficiency: the deficiency in the additive form #s ≤ #(s.biUnion t) + δ consumed by the parent defect theorem, and the per-subfamily Finset.le_sup bound it comes from",
+      "deficiency_eq_zero_iff: δ(t) = 0 ⟺ Hall's condition (∀ s, #s ≤ #(s.biUnion t)) holds — the vanishing-deficiency characterisation",
+      "maxTransversal_eq_card_of_deficiency_zero: when δ = 0 the maximum partial transversal has size #ι, recovering a full system of distinct representatives as the δ = 0 specialisation of the closed form"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 131,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Hall's 1935 marriage theorem characterises when a finite family of finite sets admits a system of distinct representatives (an injective transversal). When the family fails Hall's condition, Øystein Ore's 1955 defect form quantifies how badly: a matching can still saturate all but δ of the indices, where δ is the deficiency. The deficiency is the discrete analogue of the rank-nullity 'defect' and is the bridge from Hall's theorem to the König–Egerváry min-max theorems of matching theory.",
+    "problemStatement": "**Open Question (OQ-01 of hall-marriage-theorem-oq-01-oq-01)**: Can the sharp deficiency threshold d of the defect form be packaged as an explicit number, turning the parametrised biconditional deficiency_matching_iff into a single closed-form optimum 'maximum partial-transversal size = #ι − δ', with δ = maxₛ (#s − #(s.biUnion t)) as a Finset-sup?\n\n**Formalized**: the deficiency δ as a Finset.sup, and isGreatest_transversalSizes establishing that the attainable partial-transversal sizes have greatest element #ι − δ, plus the δ = 0 ⟺ Hall and full-SDR corollaries.",
+    "text": "A 131-line companion to the defect-form entry. The deficiency δ(t) is defined as (univ : Finset (Finset ι)).sup (fun s => s.card − (s.biUnion t).card), a maximum over every sub-family using ℕ truncated subtraction so the empty family forces δ ≥ 0. Two cheap lemmas turn this Finset.sup into the additive deficiency bound #s ≤ #(s.biUnion t) + δ that the parent theorem consumes. The headline isGreatest_transversalSizes then reads off the optimum from the parent's two directions, and two corollaries handle the δ = 0 (Hall) case. All results compile with 0 sorries and 0 axioms.",
+    "proofStrategy": "**deficiency / sub_card_le_deficiency / deficiency_spec**: δ is a Finset.sup, so Finset.le_sup gives #s − #(s.biUnion t) ≤ δ for every s, and omega rewrites this as the additive bound #s ≤ #(s.biUnion t) + δ.\n\n**isGreatest_transversalSizes** (the closed form): IsGreatest has two parts.\n• *Membership / attainability*: feed deficiency_spec into the parent's exists_matching_of_deficiency_le to obtain a matching on some J with #J ≥ #ι − δ; Finset.exists_subset_card_eq trims J to a subset J' of size exactly #ι − δ, and InjOn/membership restrict to J', so #ι − δ is attainable.\n• *Upper bound / optimality*: given any attainable size k witnessed by a matching on J (so k = #J), the matching saturates all but #ι − #J indices, hence deficiency_le_of_matching gives ∀ s, #s ≤ #(s.biUnion t) + (#ι − #J); Finset.sup_le turns this into δ ≤ #ι − #J, and omega yields k ≤ #ι − δ.\n\n**deficiency_eq_zero_iff**: δ = 0 ⟺ every local deficit is 0 ⟺ Hall's inequality, via Finset.sup_le / Nat.le_zero and omega.\n\n**maxTransversal_eq_card_of_deficiency_zero**: rewrite δ = 0 in the closed form, so #ι − δ collapses to #ι (a full SDR).",
+    "keyInsights": [
+      "**One number replaces a quantifier**: the family of biconditionals 'matches all but d ⟺ d-deficiency bound' collapses to a single optimum once d is pinned to the sharp value δ = maxₛ (#s − #(s.biUnion t)). The Finset.sup is exactly the right packaging.",
+      "**Truncated subtraction does the sign bookkeeping**: defining δ with ℕ subtraction means the empty sub-family contributes 0 − 0 = 0, so δ ≥ 0 holds by construction and no separate non-negativity proof is needed.",
+      "**IsGreatest is the honest 'maximum'**: rather than asserting a max exists by fiat, the entry proves both that #ι − δ is attained (a transversal of that exact size exists) and that nothing larger is — the two directions of the defect theorem map precisely onto the two clauses of IsGreatest.",
+      "**Attaining the size exactly needs a shrink**: the parent yields a matching of size ≥ #ι − δ; Finset.exists_subset_card_eq then produces a sub-transversal of the exact size, since any subset of an injective partial transversal is again one.",
+      "**Hall is the δ = 0 slice**: deficiency_eq_zero_iff and maxTransversal_eq_card_of_deficiency_zero show the classical marriage theorem (full SDR) sitting inside the closed form as the zero-deficiency specialisation."
+    ],
+    "prerequisites": [
+      "Hall's marriage theorem / systems of distinct representatives (Mathlib Finset.all_card_le_biUnion_card_iff_exists_injective)",
+      "The defect (Ore) form of Hall's theorem from the companion entry hall-marriage-theorem-oq-01-oq-01 (exists_matching_of_deficiency_le, deficiency_le_of_matching, deficiency_matching_iff)",
+      "Finset.sup over a finite lattice and Finset.le_sup / Finset.sup_le",
+      "ℕ truncated subtraction and omega for the deficiency arithmetic",
+      "Finset.exists_subset_card_eq and Set.InjOn.mono for trimming a partial transversal to an exact size"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "hall-marriage-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The companion defect-form entry, whose two directions (exists_matching_of_deficiency_le and deficiency_le_of_matching) are the entire engine here. This entry turns its parametrised biconditional deficiency_matching_iff into the closed-form optimum it explicitly asked for."
+    },
+    {
+      "proofId": "hall-marriage-theorem-oq-01",
+      "relationship": "related",
+      "description": "The root entry proving Hall's biconditional. Its existence statement is recovered here as the δ = 0 case (maxTransversal_eq_card_of_deficiency_zero), where the maximum partial transversal saturates all of ι."
+    }
+  ],
+  "sections": [
+    {
+      "id": "deficiency-def",
+      "title": "The deficiency as a Finset-sup",
+      "startLine": 44,
+      "endLine": 71,
+      "summary": "deficiency t = (univ : Finset (Finset ι)).sup (fun s => #s − #(s.biUnion t)) with ℕ truncated subtraction. sub_card_le_deficiency is the per-subfamily Finset.le_sup bound; deficiency_spec restates it additively as #s ≤ #(s.biUnion t) + δ, the hypothesis the parent defect theorem consumes.",
+      "mathContext": "δ = maxₛ (#s − #(s.biUnion t)); ∀ s, #s ≤ #(s.biUnion t) + δ."
+    },
+    {
+      "id": "transversal-sizes",
+      "title": "Attainable partial-transversal sizes",
+      "startLine": 73,
+      "endLine": 78,
+      "summary": "transversalSizes t = { k | ∃ J f, #J = k ∧ Set.InjOn f ↑J ∧ ∀ i ∈ J, f i ∈ t i }: the sizes of partial transversals, i.e. sets J ⊆ ι carrying a choice function injective on J with f i ∈ t i.",
+      "mathContext": "A partial transversal is an InjOn choice function on some J ⊆ ι."
+    },
+    {
+      "id": "closed-form",
+      "title": "The closed-form maximum: |ι| − δ",
+      "startLine": 80,
+      "endLine": 107,
+      "summary": "isGreatest_transversalSizes: IsGreatest (transversalSizes t) (#ι − δ). Membership uses exists_matching_of_deficiency_le then Finset.exists_subset_card_eq to hit the size exactly; the upper bound uses deficiency_le_of_matching and Finset.sup_le, closed by omega.",
+      "mathContext": "max attainable #J = #ι − δ, proved as IsGreatest (both attained and bounding)."
+    },
+    {
+      "id": "hall-corollaries",
+      "title": "Vanishing deficiency recovers Hall",
+      "startLine": 108,
+      "endLine": 131,
+      "summary": "deficiency_eq_zero_iff: δ = 0 ⟺ ∀ s, #s ≤ #(s.biUnion t) (Hall's condition), via Finset.sup_le and Nat.le_zero. maxTransversal_eq_card_of_deficiency_zero: at δ = 0 the closed form gives max = #ι, a full system of distinct representatives.",
+      "mathContext": "δ = 0 ⟺ Hall ⟹ full SDR of size #ι."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isGreatest_transversalSizes",
+      "type": "main",
+      "statement": "$\\mathrm{IsGreatest}\\ (\\mathrm{transversalSizes}\\ t)\\ (\\#\\iota - \\delta(t))$",
+      "significance": "The closed-form answer to the open question: the maximum partial-transversal size of a finite family is exactly #ι minus the Hall deficiency. Proved as IsGreatest, so both attainable and optimal.",
+      "description": "The attainable partial-transversal sizes have greatest element #ι − δ(t)."
+    },
+    {
+      "name": "deficiency",
+      "type": "definition",
+      "statement": "$\\delta(t) = \\max_{s}\\ (\\#s - \\#(s.\\mathrm{biUnion}\\ t))$ as a $\\mathrm{Finset.sup}$",
+      "significance": "Packages the sharp defect threshold as an explicit number — a Finset.sup over all sub-families with truncated subtraction, so δ ≥ 0 holds by construction.",
+      "description": "The Hall deficiency of a finite family, as a Finset.sup."
+    },
+    {
+      "name": "deficiency_spec",
+      "type": "lemma",
+      "statement": "$\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\ t) + \\delta(t)$",
+      "significance": "The additive deficiency bound — exactly the 'at worst δ-deficient' hypothesis fed into the parent's exists_matching_of_deficiency_le to get attainability.",
+      "description": "Every sub-family is within δ of satisfying Hall's inequality."
+    },
+    {
+      "name": "deficiency_eq_zero_iff",
+      "type": "lemma",
+      "statement": "$\\delta(t) = 0 \\iff \\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\ t)$",
+      "significance": "Identifies vanishing deficiency with Hall's condition, locating the classical marriage theorem inside the closed form.",
+      "description": "δ = 0 exactly when Hall's condition holds."
+    },
+    {
+      "name": "maxTransversal_eq_card_of_deficiency_zero",
+      "type": "lemma",
+      "statement": "$\\delta(t) = 0 \\Rightarrow \\mathrm{IsGreatest}\\ (\\mathrm{transversalSizes}\\ t)\\ \\#\\iota$",
+      "significance": "The δ = 0 specialisation: a full system of distinct representatives of size #ι exists, recovering Hall's existence theorem.",
+      "description": "Zero deficiency gives a full SDR of size #ι."
+    }
+  ],
+  "references": [
+    {
+      "text": "Hall, P. (1935). On Representatives of Subsets. J. London Math. Soc. The marriage theorem and systems of distinct representatives.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem"
+    },
+    {
+      "text": "Ore, Ø. (1955). Graphs and matching theorems. Duke Math. J. The defect (deficiency) version of Hall's theorem.",
+      "url": "https://en.wikipedia.org/wiki/Deficiency_(graph_theory)"
+    },
+    {
+      "text": "Mathlib4: Finset.all_card_le_biUnion_card_iff_exists_injective (Combinatorics/Hall/Basic.lean), Finset.le_sup / Finset.sup_le, Finset.exists_subset_card_eq.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Defines the Hall deficiency δ(t) = maxₛ (#s − #(s.biUnion t)) as an explicit Finset.sup and proves isGreatest_transversalSizes: the attainable partial-transversal sizes of a finite family have greatest element exactly #ι − δ(t). Both clauses of IsGreatest come from the companion defect theorem — attainability (with an exact-size shrink) from exists_matching_of_deficiency_le, optimality from deficiency_le_of_matching. The corollaries deficiency_eq_zero_iff and maxTransversal_eq_card_of_deficiency_zero locate Hall's classical theorem as the δ = 0 case. 5 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "The closed form max partial transversal = #ι − δ is the matching-theoretic min-max identity in its sharpest scalar shape: it converts an existential over sub-families into a single optimum, and is the natural launch point for the König–Egerváry theorem (min vertex cover = max matching) and Ore's capacitated defect formula for b-matchings. Packaging the deficiency as a Finset.sup makes it directly computable on concrete families.",
+    "openQuestions": [
+      "Make the deficiency δ a computable/decidable quantity and evaluate the closed form on concrete explicit families, certifying a maximum partial transversal on a small bipartite example?",
+      "Generalise to the weighted / capacitated setting (Ore's defect formula for b-matchings), where each index i may be represented up to b(i) times."
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01.json
@@ -1,0 +1,91 @@
+{
+  "slug": "hall-marriage-theorem-oq-01-oq-01-oq-01",
+  "title": "Closed-Form Maximum Partial Transversal Size via Hall Deficiency",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\mathrm{IsGreatest}\\ (\\mathrm{transversalSizes}\\ t)\\ (\\#\\iota - \\delta(t)),\\quad \\delta(t) = \\max_s (\\#s - \\#(s.\\mathrm{biUnion}\\ t))",
+    "plain": "Package the Hall deficiency δ = maxₛ (#s − #(s.biUnion t)) as a Finset-sup and prove the maximum partial-transversal size equals #ι − δ.",
+    "whyMatters": [
+      "Turns the parent's parametrised defect biconditional into a single closed-form optimum (matching min-max identity).",
+      "Launch point for König–Egerváry (min cover = max matching) and Ore's capacitated defect formula."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "deficiency: δ(t) = (univ : Finset (Finset ι)).sup (#s − #(s.biUnion t)), Finset-sup with truncated subtraction (δ ≥ 0 automatic)",
+      "deficiency_spec: ∀ s, #s ≤ #(s.biUnion t) + δ (additive form consumed by parent defect theorem)",
+      "isGreatest_transversalSizes: IsGreatest (transversalSizes t) (#ι − δ) — the closed-form maximum partial transversal",
+      "deficiency_eq_zero_iff: δ = 0 ⟺ Hall's condition (∀ s, #s ≤ #(s.biUnion t))",
+      "maxTransversal_eq_card_of_deficiency_zero: δ = 0 ⟹ full SDR of size #ι"
+    ],
+    "open": [],
+    "goal": "Closed form: maximum partial-transversal size = #ι − δ(t), with δ as an explicit Finset-sup; recover Hall's full SDR as δ = 0."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T17:20:00.000Z",
+    "iteration": 1,
+    "focus": "Solved: deficiency Finset-sup + IsGreatest closed form, verified 0-axiom.",
+    "blockers": [],
+    "nextAction": "PR opened; entry complete.",
+    "attemptCounts": { "total": 0, "currentApproach": 0, "approachesTried": 0 }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: closed-form maximum partial transversal = #ι − δ proved via the parent defect theorem, δ packaged as a Finset.sup, verified 0-axiom (PR research/hall-deficiency-maxtransversal-oq01010101). Recovers Hall's full SDR at δ = 0.",
+    "builtItems": [
+      "Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean: 131 lines, 5 thm, 2 defs, 0 axioms, 0 sorries",
+      "deficiency: Hall deficiency as (univ : Finset (Finset ι)).sup (#s − #(s.biUnion t)), truncated subtraction makes δ ≥ 0 by construction",
+      "deficiency_spec / sub_card_le_deficiency: the additive #s ≤ #(s.biUnion t) + δ bound from Finset.le_sup",
+      "isGreatest_transversalSizes: IsGreatest closed form #ι − δ; attainability via exists_matching_of_deficiency_le + Finset.exists_subset_card_eq (exact-size shrink), optimality via deficiency_le_of_matching + Finset.sup_le",
+      "deficiency_eq_zero_iff + maxTransversal_eq_card_of_deficiency_zero: Hall recovered as the δ = 0 slice"
+    ],
+    "insights": [
+      "The entire engine is the companion defect theorem (exists_matching_of_deficiency_le, deficiency_le_of_matching); this leaf only packages the deficiency and reads off IsGreatest.",
+      "ℕ truncated subtraction in the Finset.sup makes δ ≥ 0 free — the empty sub-family contributes 0 − 0 = 0, no separate non-negativity proof.",
+      "IsGreatest is the honest 'maximum': both that #ι − δ is attained AND that nothing larger is; the two directions of the defect theorem map onto the two IsGreatest clauses.",
+      "Attaining the size EXACTLY (not just ≥) needs Finset.exists_subset_card_eq: a subset of an injective partial transversal is again one (InjOn.mono).",
+      "Mathlib has Hall's biconditional but neither the defect form nor this deficiency closed form."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the defect (Ore) form of Hall and the closed-form max-partial-transversal = #ι − δ (only the existence biconditional Finset.all_card_le_biUnion_card_iff_exists_injective)."
+    ],
+    "nextSteps": [
+      "Make δ computable/decidable and certify the closed form on concrete explicit families.",
+      "Generalise to the weighted / capacitated (b-matching) setting — Ore's defect formula."
+    ]
+  },
+  "tags": [
+    "combinatorics",
+    "graph-theory",
+    "hall-marriage",
+    "transversal",
+    "matching",
+    "deficiency",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "hall-marriage-theorem-oq-01",
+    "hall-marriage-theorem-oq-01-oq-01"
+  ],
+  "references": { "papers": [], "urls": [], "mathlib": [] },
+  "started": "2026-06-24T17:20:00.000Z",
+  "lastUpdate": "2026-06-24T17:30:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean",
+      "filename": "HallMarriageTheoremOQ01OQ01OQ01.lean",
+      "lineCount": 131,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the lead open question of the companion entry **hall-marriage-theorem-oq-01-oq-01** (the defect/Ore form of Hall's marriage theorem): can the sharp threshold `d` be pinned to an explicit number, turning the parametrised biconditional into a single closed-form optimum?

This entry does exactly that. It defines the **Hall deficiency**

```
δ(t) = maxₛ (#s − #(s.biUnion t))      -- as a Finset.sup, truncated subtraction ⇒ δ ≥ 0
```

and proves the headline closed form

```
isGreatest_transversalSizes : IsGreatest (transversalSizes t) (#ι − δ(t))
```

i.e. the **maximum partial-transversal size is exactly #ι − δ(t)** — both attained and optimal.

## Proof engine (all from the parent defect theorem)
- **Attainability**: `exists_matching_of_deficiency_le` (fed `deficiency_spec`) gives a matching of size ≥ #ι − δ; `Finset.exists_subset_card_eq` trims it to the size **exactly** (a subset of an injective partial transversal is again one).
- **Optimality**: any attainable size k = #J saturates all but #ι − #J indices, so `deficiency_le_of_matching` + `Finset.sup_le` force δ ≤ #ι − #J, hence k ≤ #ι − δ.
- **Corollaries**: `deficiency_eq_zero_iff` (δ = 0 ⟺ Hall's condition) and `maxTransversal_eq_card_of_deficiency_zero` (δ = 0 ⟹ full SDR of size #ι), locating the classical marriage theorem as the zero-deficiency slice.

## Verification
- **5 theorems, 2 definitions, 131 lines**
- **0 sorries, 0 axioms** (only propext / Classical.choice / Quot.sound; no `native_decide`, no `Lean.ofReduceBool`)
- Builds on `Proofs.HallMarriageTheoremOQ01OQ01`; host-verified with `lake env lean`.

## Files
- `proofs/Proofs/HallMarriageTheoremOQ01OQ01OQ01.lean`
- `src/data/proofs/hall-marriage-theorem-oq-01-oq-01-oq-01/` (meta.json, annotations.json, index.ts)
- `src/data/research/problems/hall-marriage-theorem-oq-01-oq-01-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)