### PR TITLE
research(combinations-formula-oq-02-oq-01): Catalan generating function C=1+X·C² and square-root form (2XC−1)²=1−4X [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -807,6 +807,7 @@ import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle
+import Proofs.CombinationsFormulaOQ02OQ01
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
 import Proofs.CombinationsFormulaOQ05

--- a/proofs/Proofs/CombinationsFormulaOQ02OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ02OQ01.lean
@@ -1,0 +1,83 @@
+/-
+# The Catalan Generating Function as a Formal Power Series
+
+This file answers the first open question of `combinations-formula-oq-02`:
+
+  > Prove the generating function `C(x) = (1 − √(1 − 4x)) / (2x)`.
+
+The literal closed form involves a square root, which is not an operation on a
+general formal power series ring.  Its rigorous, ring-theoretic content is the
+pair of algebraic identities the ordinary generating function
+
+  `C(X) = ∑ₙ catalanₙ · Xⁿ ∈ ℚ⟦X⟧`
+
+satisfies, from which the square-root formula is *derived* by solving a quadratic:
+
+  * `catalan_ogf_functional` — the defining **functional equation**
+        `C = 1 + X · C²`,
+    the formal-power-series shadow of the Catalan convolution recurrence
+    `catalanₙ₊₁ = ∑_{i+j=n} catalanᵢ · catalanⱼ` (Mathlib's `catalan_succ'`);
+
+  * `catalan_ogf_sq` — the **square-root form**
+        `(2·X·C − 1)² = 1 − 4·X`.
+    Reading this as `(2XC − 1)² = 1 − 4X` and taking the branch with
+    `C(0) = catalan 0 = 1` gives `2XC − 1 = −√(1 − 4X)`, i.e.
+    `C = (1 − √(1 − 4X)) / (2X)` — exactly the stated closed form, now phrased
+    entirely inside `ℚ⟦X⟧` with no square-root operation required.
+
+Mathlib records the Catalan convolution recurrence (`catalan_succ'`) but **not**
+the generating-function identity, so the power-series packaging here is original.
+
+Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open PowerSeries Finset
+
+namespace CombinationsFormulaOQ02OQ01
+
+/-- The **ordinary generating function** of the Catalan numbers,
+`C(X) = ∑ₙ catalanₙ · Xⁿ`, as a formal power series over `ℚ`. -/
+noncomputable def C : PowerSeries ℚ := PowerSeries.mk (fun n => (catalan n : ℚ))
+
+/-- The `n`-th coefficient of `C` is the `n`-th Catalan number. -/
+@[simp] theorem coeff_C (n : ℕ) : coeff n C = (catalan n : ℚ) := by
+  rw [C, coeff_mk]
+
+/-- **Functional equation of the Catalan generating function:** `C = 1 + X · C²`.
+
+This is the formal-power-series form of the Catalan convolution recurrence
+`catalanₙ₊₁ = ∑_{i+j=n} catalanᵢ · catalanⱼ`: comparing the coefficient of `Xⁿ⁺¹`
+on each side is exactly that recurrence, while the constant terms agree because
+`catalan 0 = 1`. -/
+theorem catalan_ogf_functional : C = 1 + PowerSeries.X * C ^ 2 := by
+  ext n
+  rw [map_add]
+  cases n with
+  | zero =>
+      rw [coeff_zero_X_mul, add_zero, coeff_one, if_pos rfl, coeff_C, catalan_zero,
+        Nat.cast_one]
+  | succ m =>
+      rw [coeff_one, if_neg (Nat.succ_ne_zero m), zero_add, coeff_succ_X_mul, sq,
+        coeff_mul, coeff_C]
+      simp only [coeff_C]
+      rw [catalan_succ']
+      push_cast
+      rfl
+
+/-- **Square-root form of the Catalan generating function:**
+`(2·X·C − 1)² = 1 − 4·X`.
+
+Solving this quadratic for `C` and selecting the branch fixed by
+`C(0) = catalan 0 = 1` yields `C = (1 − √(1 − 4X)) / (2X)`, the closed form of the
+open question, now stated entirely within `ℚ⟦X⟧`.  It is obtained from the
+functional equation `C = 1 + X·C²` by a single algebraic substitution
+`X·C² = C − 1`. -/
+theorem catalan_ogf_sq :
+    (2 * PowerSeries.X * C - 1) ^ 2 = 1 - 4 * PowerSeries.X := by
+  have hXC2 : PowerSeries.X * C ^ 2 = C - 1 := by
+    have h := catalan_ogf_functional
+    linear_combination -h
+  linear_combination (4 * PowerSeries.X) * hXC2
+
+end CombinationsFormulaOQ02OQ01

--- a/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
@@ -1,0 +1,51 @@
+{
+  "id": "combinations-formula-oq-02-oq-01",
+  "slug": "combinations-formula-oq-02-oq-01",
+  "title": "The Catalan Generating Function as a Formal Power Series",
+  "description": "Answers the first open question of combinations-formula-oq-02: prove the Catalan generating function C(x) = (1 - sqrt(1-4x))/(2x). Since the square root is not an operation on a general formal power series ring, the rigorous content is captured by two algebraic identities for the OGF C(X) = sum catalan_n X^n in the rational power series ring: the functional equation C = 1 + X*C^2 (the power-series form of the Catalan convolution catalan_succ'), and the square-root form (2*X*C - 1)^2 = 1 - 4*X, whose solution with branch C(0)=1 is exactly the stated closed form. Mathlib has the convolution recurrence but not the generating-function identity.",
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number#Generating_function",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "generating-functions",
+      "formal-power-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "",
+    "lineCount": 83,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "originalContributions": [
+      "C: the ordinary generating function sum catalan_n X^n in PowerSeries Q (definition)",
+      "coeff_C: the n-th coefficient of C is the n-th Catalan number",
+      "catalan_ogf_functional: the functional equation C = 1 + X*C^2 (power-series form of catalan_succ')",
+      "catalan_ogf_sq: the square-root form (2*X*C - 1)^2 = 1 - 4*X, the ring-theoretic content of C = (1 - sqrt(1-4x))/(2x)"
+    ]
+  },
+  "overview": {
+    "problem": "The classical Catalan generating function C(x) = (1 - sqrt(1-4x))/(2x) cannot be stated literally over a formal power series ring because the square root is not a ring operation. We formalize its exact algebraic content instead.",
+    "approach": "Define C = PowerSeries.mk (catalan) over Q. Compare coefficients to prove the functional equation C = 1 + X*C^2 directly from Mathlib's Catalan convolution catalan_succ' (the coefficient of X^(n+1) in X*C^2 is the antidiagonal convolution sum, matching catalan_succ' after a cast). Then a single algebraic substitution X*C^2 = C - 1 yields (2*X*C - 1)^2 = 1 - 4*X, which is the square-root closed form solved for C with the branch fixed by C(0) = catalan 0 = 1.",
+    "significance": "Provides the rigorous power-series statement and machine-checked proof of the Catalan generating function. Mathlib records the convolution recurrence but not the generating-function identity, so the packaging is original."
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "The Catalan ordinary generating function C(X) = sum catalan_n X^n over Q satisfies the functional equation C = 1 + X*C^2 and the square-root form (2*X*C - 1)^2 = 1 - 4*X. Together with the constant term C(0) = 1, these encode the closed form C = (1 - sqrt(1-4X))/(2X) entirely within the formal power series ring. Verified with 0 sorries and 0 axioms.",
+    "implications": [
+      "The functional equation C = 1 + X*C^2 is the formal-power-series shadow of the Catalan convolution and the standard route to all Catalan asymptotics.",
+      "The square-root identity (2XC-1)^2 = 1-4X is the precise ring-theoretic meaning of the textbook closed form, avoiding any square-root operation."
+    ],
+    "openQuestions": [
+      "Can a formal square root be defined on 1 - 4X in a completion or via PowerSeries inversion to recover the literal expression C = (1 - sqrt(1-4X))/(2X) as an equation of power series?",
+      "Does the same coefficient-comparison method yield the generating function 1/(1-2Xt+t^2) connections to Chebyshev/central-binomial families?"
+    ]
+  }
+}

--- a/src/data/research/problems/combinations-formula-oq-02-oq-01.json
+++ b/src/data/research/problems/combinations-formula-oq-02-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "combinations-formula-oq-02-oq-01",
   "title": "Generating Function of the Catalan Numbers C(x) = (1−√(1−4x))/(2x)",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -27,15 +27,7 @@
     ],
     "goal": "Formalize that the Catalan generating function satisfies x·C(x)²−C(x)+1=0 (hence C(x)=(1−√(1−4x))/(2x)), proving the quadratic functional equation from the convolution recurrence in PowerSeries ℚ."
   },
-  "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-06-24T00:00:00Z",
-    "iteration": 0,
-    "focus": "Seeker-seeded stub. Awaiting a Researcher to begin the OBSERVE phase: read problem.md, confirm Mathlib API names, and draft the first Lean skeleton.",
-    "blockers": [],
-    "nextAction": "Q1 (recommended, algebraic): Let C : PowerSeries ℚ be the Catalan OGF (coeff n C = catalan n). Prove the functional equation X * C^2 - C + 1 = 0 in PowerSeries ℚ, directly from the convolution recurrence via coeff_mul.",
-    "lastUpdate": "2026-06-24T00:00:00Z"
-  },
+  "currentState": "SOLVED (verified, 0-axiom). Catalan OGF formalized in PowerSeries Q: functional equation C = 1 + X*C^2 (catalan_ogf_functional) and square-root form (2XC-1)^2 = 1-4X (catalan_ogf_sq). Proofs/CombinationsFormulaOQ02OQ01.lean, 3 thm / 1 def / 83 L.",
   "tags": [
     "seeker-selected",
     "combinatorics",
@@ -65,8 +57,29 @@
     ]
   },
   "started": "2026-06-24T00:00:00Z",
-  "lastUpdate": "2026-06-24T00:00:00Z",
+  "lastUpdate": "2026-06-24",
   "significance": 7,
   "tractability": 5,
-  "leanFiles": []
+  "leanFiles": [],
+  "knowledge": {
+    "insights": [
+      "The literal closed form C(x)=(1-sqrt(1-4x))/(2x) is not directly statable over a formal power series ring (no sqrt operation); its rigorous content is the pair of algebraic identities C=1+X*C^2 and (2XC-1)^2=1-4X.",
+      "The functional equation C=1+X*C^2 follows by coefficient comparison: coeff(n+1) of X*C^2 is the antidiagonal convolution sum, which is exactly Mathlib catalan_succ after the cast N->Q; constant terms match via catalan 0 = 1.",
+      "The square-root form is one linear_combination away: substitute X*C^2 = C-1 into (2XC-1)^2 = 4X^2C^2 - 4XC + 1, with coefficient 4X."
+    ],
+    "builtItems": [
+      "C : PowerSeries Q (Catalan OGF) in Proofs/CombinationsFormulaOQ02OQ01.lean",
+      "coeff_C : coeff n C = catalan n",
+      "catalan_ogf_functional : C = 1 + X*C^2",
+      "catalan_ogf_sq : (2*X*C - 1)^2 = 1 - 4*X"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the Catalan convolution recurrence catalan_succ but NOT the generating-function identity C=1+X*C^2 nor the square-root form."
+    ],
+    "nextSteps": [
+      "Define a formal square root of 1-4X to recover the literal C=(1-sqrt(1-4X))/(2X) as a power-series equation.",
+      "Apply the same coeff-comparison method to the Motzkin/Schroeder generating functions."
+    ],
+    "progressSummary": "COMPLETE: Catalan generating function formalized as functional + square-root identities, verified 0-axiom."
+  }
 }


### PR DESCRIPTION
## Summary

Answers the **first open question** of `combinations-formula-oq-02`: *prove the Catalan generating function* `C(x) = (1 − √(1 − 4x)) / (2x)`.

The literal square root is not an operation on a general formal power series ring, so the rigorous content is captured by two algebraic identities for the ordinary generating function `C(X) = ∑ₙ catalanₙ · Xⁿ ∈ ℚ⟦X⟧`:

- **`catalan_ogf_functional`** — the functional equation `C = 1 + X · C²`, the power-series shadow of the Catalan convolution recurrence (Mathlib's `catalan_succ'`).
- **`catalan_ogf_sq`** — the square-root form `(2·X·C − 1)² = 1 − 4·X`. Solving this quadratic and selecting the branch fixed by `C(0) = catalan 0 = 1` gives `2XC − 1 = −√(1 − 4X)`, i.e. `C = (1 − √(1 − 4X)) / (2X)` — exactly the stated closed form, phrased entirely inside `ℚ⟦X⟧`.

## Engine

Coefficient comparison: the coefficient of `Xⁿ⁺¹` in `X · C²` is the antidiagonal convolution sum, which matches `catalan_succ'` after the `ℕ → ℚ` cast; constant terms agree because `catalan 0 = 1`. The square-root form is then one `linear_combination` from the functional equation via the substitution `X · C² = C − 1`.

Mathlib records the convolution recurrence but **not** the generating-function identity, so the power-series packaging is original.

## Verification

- **3 theorems / 1 definition / 83 lines** in `proofs/Proofs/CombinationsFormulaOQ02OQ01.lean`
- Builds cleanly (host `lake env lean`, exit 0)
- `#print axioms` on both headline theorems: `[propext, Classical.choice, Quot.sound]` only — **0 sorries, 0 axioms** (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)