### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-03): continuous integral Chebyshev inequality for monotone functions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevSumIntegralOQ0103.lean
+++ b/proofs/Proofs/ChebyshevSumIntegralOQ0103.lean
@@ -1,0 +1,212 @@
+import Mathlib
+
+/-
+# Chebyshev's sum inequality, continuous (integral) form for monotone functions
+
+The parent entry "Chebyshev's sum inequality in classical monotone-sequence form"
+records the discrete inequality
+
+  (∑ aᵢ)(∑ bᵢ) ≤ n · ∑ aᵢbᵢ                              (same monotonicity)
+
+for two finite sequences sorted the same way, together with the open question of
+formalising the **continuous (integral) Chebyshev inequality for monotone functions
+on an interval**:
+
+  (∫ₐᵇ f) (∫ₐᵇ g) ≤ (b − a) · ∫ₐᵇ f·g,                   (f, g both monotone)
+
+with the inequality reversing when one function is increasing and the other decreasing.
+
+## What this proves
+
+`chebyshev_integral_monotoneOn` and `chebyshev_integral_antitoneOn` establish exactly
+these two statements for `f g : ℝ → ℝ` that are both `MonotoneOn` (resp. `f` `MonotoneOn`,
+`g` `AntitoneOn`) on `Set.Icc a b`, stated with the Lebesgue interval integral `∫ x in a..b`.
+
+## Relation to the gallery
+
+The gallery already contains the *general* comonotone integral inequality
+(`chebyshev-sum-inequality-oq-01-oq-01-oq-01`, `chebyshev_integral_mul_le`): for a finite
+measure `μ` and **bounded measurable** functions satisfying the **global** comonotonicity
+hypothesis `∀ x y, 0 ≤ (f x − f y)(g x − g y)`, `(∫f)(∫g) ≤ μ(univ)·∫fg`. That statement
+does *not* directly give the classical monotone-functions-on-an-interval form posed by the
+parent's open question: a `MonotoneOn` function on `Icc a b` is monotone only *locally*
+(its comonotonicity holds only on the interval, not on all of `ℝ`), and need be neither
+globally bounded nor globally measurable. This entry supplies that form, discharging
+integrability and the comonotone sign directly from `MonotoneOn`, and packaging the result
+with the everyday interval integral `∫ x in a..b`.
+
+## Method
+
+Mathlib has Chebyshev's inequality for **finite sums** (`Mathlib/Algebra/Order/Chebyshev.lean`,
+via `MonovaryOn`) but **no integral version**. As in the general entry, the continuous
+statement follows from the classical two-variable identity
+
+  ∫∫_{[a,b]²} (f x − f y)(g x − g y) d(x,y) = 2 (b − a) ∫ f·g − 2 (∫ f)(∫ g),
+
+whose left-hand side is `≥ 0` because the integrand is pointwise nonnegative when `f` and
+`g` are monotone the same way (both factors share their sign). We realise the square as the
+product measure `μ.prod μ` with `μ = volume.restrict (Icc a b)` and evaluate the four
+cross terms with `MeasureTheory.integral_prod_mul`, `integral_fun_fst`, `integral_fun_snd`.
+The new ingredient over the general entry is the bridge from `MonotoneOn` to integrability
+(`MonotoneOn.integrableOn_of_measure_ne_top`, no boundedness hypothesis) and to the a.e.
+sign on the square (`Measure.prod_restrict`, `ae_restrict_iff'`).
+
+## Mathlib ingredients
+- `MeasureTheory.integral_prod_mul`, `integral_fun_fst`, `integral_fun_snd` (Fubini products)
+- `MonotoneOn.integrableOn_of_measure_ne_top` (monotone ⇒ integrable on a finite interval)
+- `MeasureTheory.Integrable.mul_prod`, `Integrable.comp_fst_iff`, `Integrable.comp_snd_iff`
+- `MeasureTheory.integral_nonneg_of_ae`, `Measure.prod_restrict`, `ae_restrict_iff'`
+
+All results are fully verified with no extra axioms.
+-/
+
+open MeasureTheory Set
+open scoped ENNReal
+
+namespace ChebyshevIntegralMonotone
+
+variable {a b : ℝ} {f g : ℝ → ℝ}
+
+/-- Pointwise nonnegativity of the symmetrised integrand for two functions that are
+monotone the same way: if `f` and `g` are both `MonotoneOn (Icc a b)` then
+`0 ≤ (f x − f y)(g x − g y)` for `x, y ∈ Icc a b`. -/
+theorem sub_mul_sub_nonneg_of_monotoneOn
+    (hf : MonotoneOn f (Icc a b)) (hg : MonotoneOn g (Icc a b))
+    {x y : ℝ} (hx : x ∈ Icc a b) (hy : y ∈ Icc a b) :
+    0 ≤ (f x - f y) * (g x - g y) := by
+  rcases le_total x y with h | h
+  · have hf' : f x ≤ f y := hf hx hy h
+    have hg' : g x ≤ g y := hg hx hy h
+    nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ f y - f x) (by linarith : (0:ℝ) ≤ g y - g x)]
+  · have hf' : f y ≤ f x := hf hy hx h
+    have hg' : g y ≤ g x := hg hy hx h
+    nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ f x - f y) (by linarith : (0:ℝ) ≤ g x - g y)]
+
+/-- A `MonotoneOn` function on `Icc a b` is bounded there by `max |f a| |f b|`. -/
+theorem norm_le_of_monotoneOn (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) :
+    ∀ᵐ x ∂(volume.restrict (Icc a b)), ‖f x‖ ≤ max |f a| |f b| := by
+  refine (ae_restrict_iff' measurableSet_Icc).mpr (Filter.Eventually.of_forall ?_)
+  intro x hx
+  have hfa : f a ≤ f x := hf (left_mem_Icc.mpr hab) hx hx.1
+  have hfb : f x ≤ f b := hf hx (right_mem_Icc.mpr hab) hx.2
+  rw [Real.norm_eq_abs, abs_le]
+  refine ⟨?_, ?_⟩
+  · calc -max |f a| |f b| ≤ -|f a| := neg_le_neg (le_max_left |f a| |f b|)
+      _ ≤ f a := neg_abs_le _
+      _ ≤ f x := hfa
+  · calc f x ≤ f b := hfb
+      _ ≤ |f b| := le_abs_self _
+      _ ≤ max |f a| |f b| := le_max_right _ _
+
+/-- **Continuous Chebyshev sum inequality (set-integral form).**
+If `f` and `g` are both monotone on `Icc a b` (and `a ≤ b`), then
+`(∫ f)(∫ g) ≤ (b − a) ∫ f·g`, the integrals being over `Icc a b`. -/
+theorem chebyshev_integral_monotoneOn_setIntegral
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : MonotoneOn g (Icc a b)) :
+    (∫ x in Icc a b, f x) * (∫ x in Icc a b, g x)
+      ≤ (b - a) * ∫ x in Icc a b, f x * g x := by
+  rcases eq_or_lt_of_le hab with heq | hlt
+  · -- Degenerate interval: every integral vanishes.
+    subst heq
+    have h0 : volume.restrict (Icc a a) = (0 : Measure ℝ) := by
+      rw [Measure.restrict_eq_zero, Real.volume_Icc, sub_self, ENNReal.ofReal_zero]
+    rw [h0]
+    simp
+  · -- Main case `a < b`.
+    set μ : Measure ℝ := volume.restrict (Icc a b) with hμdef
+    have hμtop : volume (Icc a b) ≠ ∞ := by rw [Real.volume_Icc]; exact ENNReal.ofReal_ne_top
+    haveI hfin : IsFiniteMeasure μ := by
+      refine ⟨?_⟩
+      rw [hμdef, Measure.restrict_apply_univ]
+      exact lt_top_iff_ne_top.mpr hμtop
+    have hmass : μ.real univ = b - a := by
+      rw [hμdef, measureReal_def, Measure.restrict_apply_univ, Real.volume_Icc,
+        ENNReal.toReal_ofReal (by linarith)]
+    have hμne : μ ≠ 0 := by
+      rw [hμdef, Ne, Measure.restrict_eq_zero, Real.volume_Icc, ENNReal.ofReal_eq_zero, not_le]
+      linarith
+    -- Integrability of `f`, `g`, `f·g` against `μ`.
+    have hfI : Integrable f μ :=
+      hf.integrableOn_of_measure_ne_top (isLeast_Icc hab) (isGreatest_Icc hab)
+        hμtop measurableSet_Icc
+    have hgI : Integrable g μ :=
+      hg.integrableOn_of_measure_ne_top (isLeast_Icc hab) (isGreatest_Icc hab)
+        hμtop measurableSet_Icc
+    have hfgI : Integrable (fun x => f x * g x) μ :=
+      hfI.mul_bdd hgI.aestronglyMeasurable (hμdef ▸ norm_le_of_monotoneOn hab hg)
+    -- Integrability of the four cross terms against the product measure.
+    have ip1 : Integrable (fun z : ℝ × ℝ => f z.1 * g z.1) (μ.prod μ) :=
+      (Integrable.comp_fst_iff hμne).mpr hfgI
+    have ip2 : Integrable (fun z : ℝ × ℝ => f z.1 * g z.2) (μ.prod μ) := hfI.mul_prod hgI
+    have ip3 : Integrable (fun z : ℝ × ℝ => g z.1 * f z.2) (μ.prod μ) := hgI.mul_prod hfI
+    have ip4 : Integrable (fun z : ℝ × ℝ => f z.2 * g z.2) (μ.prod μ) :=
+      (Integrable.comp_snd_iff hμne).mpr hfgI
+    -- The symmetrised double integral equals `2(b-a)∫fg − 2(∫f)(∫g)`.
+    have key : ∫ z, (f z.1 - f z.2) * (g z.1 - g z.2) ∂(μ.prod μ)
+        = 2 * ((b - a) * ∫ x, f x * g x ∂μ)
+          - 2 * ((∫ x, f x ∂μ) * (∫ x, g x ∂μ)) := by
+      have hexp : (fun z : ℝ × ℝ => (f z.1 - f z.2) * (g z.1 - g z.2))
+          = fun z => (f z.1 * g z.1 + f z.2 * g z.2) - (f z.1 * g z.2 + g z.1 * f z.2) := by
+        funext z; ring
+      have hF : Integrable (fun z : ℝ × ℝ => f z.1 * g z.1 + f z.2 * g z.2) (μ.prod μ) :=
+        ip1.add ip4
+      have hG : Integrable (fun z : ℝ × ℝ => f z.1 * g z.2 + g z.1 * f z.2) (μ.prod μ) :=
+        ip2.add ip3
+      rw [hexp, integral_sub hF hG, integral_add ip1 ip4, integral_add ip2 ip3,
+        integral_prod_mul (L := ℝ) f g, integral_prod_mul (L := ℝ) g f,
+        integral_fun_fst (fun x => f x * g x), integral_fun_snd (fun x => f x * g x),
+        hmass]
+      simp only [smul_eq_mul]
+      ring
+    -- The double integral is nonnegative since the integrand is.
+    have hae : 0 ≤ᵐ[μ.prod μ] fun z => (f z.1 - f z.2) * (g z.1 - g z.2) := by
+      rw [hμdef, Measure.prod_restrict]
+      refine (ae_restrict_iff' (measurableSet_Icc.prod measurableSet_Icc)).mpr
+        (Filter.Eventually.of_forall ?_)
+      intro z hz
+      exact sub_mul_sub_nonneg_of_monotoneOn hf hg hz.1 hz.2
+    have hnonneg : 0 ≤ ∫ z, (f z.1 - f z.2) * (g z.1 - g z.2) ∂(μ.prod μ) :=
+      integral_nonneg_of_ae hae
+    rw [key] at hnonneg
+    linarith
+
+/-- **Reverse Chebyshev sum inequality (set-integral form).**
+If `f` is monotone and `g` is antitone on `Icc a b` (and `a ≤ b`), then the inequality
+reverses: `(b − a) ∫ f·g ≤ (∫ f)(∫ g)`. Obtained from the monotone case applied to `f`
+and `-g`. -/
+theorem chebyshev_integral_antitoneOn_setIntegral
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc a b)) :
+    (b - a) * (∫ x in Icc a b, f x * g x)
+      ≤ (∫ x in Icc a b, f x) * (∫ x in Icc a b, g x) := by
+  have hgn : MonotoneOn (fun x => -g x) (Icc a b) := hg.neg
+  have h := chebyshev_integral_monotoneOn_setIntegral hab hf hgn
+  simp only [mul_neg, integral_neg] at h
+  linarith
+
+/-- **Continuous Chebyshev sum inequality, interval-integral form.**
+For monotone `f, g` on `[a,b]` with `a ≤ b`:
+`(∫ₐᵇ f)(∫ₐᵇ g) ≤ (b − a) ∫ₐᵇ f·g`. -/
+theorem chebyshev_integral_monotoneOn
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : MonotoneOn g (Icc a b)) :
+    (∫ x in a..b, f x) * (∫ x in a..b, g x)
+      ≤ (b - a) * ∫ x in a..b, f x * g x := by
+  rw [intervalIntegral.integral_of_le hab, intervalIntegral.integral_of_le hab,
+    intervalIntegral.integral_of_le hab,
+    ← integral_Icc_eq_integral_Ioc, ← integral_Icc_eq_integral_Ioc,
+    ← integral_Icc_eq_integral_Ioc]
+  exact chebyshev_integral_monotoneOn_setIntegral hab hf hg
+
+/-- **Reverse Chebyshev sum inequality, interval-integral form.**
+For `f` monotone and `g` antitone on `[a,b]` with `a ≤ b`:
+`(b − a) ∫ₐᵇ f·g ≤ (∫ₐᵇ f)(∫ₐᵇ g)`. -/
+theorem chebyshev_integral_antitoneOn
+    (hab : a ≤ b) (hf : MonotoneOn f (Icc a b)) (hg : AntitoneOn g (Icc a b)) :
+    (b - a) * (∫ x in a..b, f x * g x)
+      ≤ (∫ x in a..b, f x) * (∫ x in a..b, g x) := by
+  rw [intervalIntegral.integral_of_le hab, intervalIntegral.integral_of_le hab,
+    intervalIntegral.integral_of_le hab,
+    ← integral_Icc_eq_integral_Ioc, ← integral_Icc_eq_integral_Ioc,
+    ← integral_Icc_eq_integral_Ioc]
+  exact chebyshev_integral_antitoneOn_setIntegral hab hf hg
+
+end ChebyshevIntegralMonotone

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-cheby-oq0103-header",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 50 },
+    "type": "context",
+    "title": "The parent's open question: a continuous Chebyshev inequality",
+    "content": "The docstring poses verbatim the parent entry's open question — the continuous (integral) Chebyshev inequality for monotone functions on an interval: (∫ₐᵇ f)(∫ₐᵇ g) ≤ (b−a)∫ₐᵇ f·g, reversing when one function increases and the other decreases. Mathlib contains Chebyshev's inequality only for finite sums (the MonovaryOn lemmas the parent uses); there is no integral version, so this entry builds it.",
+    "mathContext": "$\\big(\\int_a^b f\\big)\\big(\\int_a^b g\\big) \\le (b-a)\\int_a^b f\\cdot g$ for monotone $f,g$.",
+    "significance": "context",
+    "relatedConcepts": ["Chebyshev's sum inequality", "integral inequalities", "monotone functions", "open question"],
+    "prerequisites": ["the parent discrete Chebyshev entry", "Lebesgue integration"]
+  },
+  {
+    "id": "ann-cheby-oq0103-sign",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03",
+    "range": { "startLine": 53, "endLine": 68 },
+    "type": "key",
+    "title": "The whole inequality lives in one sign",
+    "content": "sub_mul_sub_nonneg_of_monotoneOn is the engine: for x, y ∈ [a,b], 0 ≤ (f x − f y)(g x − g y). The proof case-splits on x ≤ y versus y ≤ x. When x ≤ y both differences are ≤ 0 (monotonicity), so their product is ≥ 0; when y ≤ x both are ≥ 0. This single pointwise fact — not any analytic estimate — is what makes the integral inequality true.",
+    "mathContext": "$x\\le y \\Rightarrow f(x)\\le f(y),\\, g(x)\\le g(y) \\Rightarrow (f x-f y)(g x-g y)\\ge 0$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["rearrangement", "monovariance", "sign analysis"],
+    "prerequisites": ["MonotoneOn", "products of reals with equal sign"]
+  },
+  {
+    "id": "ann-cheby-oq0103-integrability",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 130 },
+    "type": "technique",
+    "title": "Integrability from monotonicity alone — no continuity",
+    "content": "The statement assumes only monotonicity, so integrability must be derived. MonotoneOn.integrableOn_of_measure_ne_top gives f, g ∈ L¹(μ) on the finite-measure interval μ = volume.restrict (Icc a b). norm_le_of_monotoneOn bounds g by max|g a||g b|, so f·g is integrable (bounded × integrable). On the product measure the four cross-terms are integrable via Integrable.mul_prod (off-diagonal) and Integrable.comp_fst_iff / comp_snd_iff (diagonal).",
+    "mathContext": "Monotone on $[a,b]$ $\\Rightarrow$ measurable and bounded $\\Rightarrow$ integrable; $\\mu(\\,[a,b]\\,)=b-a<\\infty$.",
+    "significance": "standard",
+    "relatedConcepts": ["MonotoneOn.integrableOn_of_measure_ne_top", "Integrable.mul_bdd", "product measure"],
+    "prerequisites": ["L¹ integrability", "finite measures"]
+  },
+  {
+    "id": "ann-cheby-oq0103-fubini",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03",
+    "range": { "startLine": 131, "endLine": 159 },
+    "type": "key",
+    "title": "Evaluating the double integral by Fubini",
+    "content": "Expanding (f x − f y)(g x − g y) into the diagonal part f(x)g(x)+f(y)g(y) minus the cross part f(x)g(y)+g(x)f(y), the two diagonal terms evaluate via integral_fun_fst / integral_fun_snd to (b−a)·∫f·g each (the (b−a) is the total mass μ.real univ), and the two cross terms via integral_prod_mul to (∫f)(∫g) each. The double integral therefore equals 2(b−a)∫fg − 2(∫f)(∫g); since the integrand is a.e. ≥ 0 (transported to the square [a,b]² by Measure.prod_restrict), this difference is ≥ 0.",
+    "mathContext": "$\\iint (f x-f y)(g x-g y)\\,d(\\mu\\times\\mu)=2(b-a)\\!\\int\\! fg-2\\big(\\!\\int\\! f\\big)\\big(\\!\\int\\! g\\big)\\ge 0$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["integral_prod_mul", "integral_fun_fst", "integral_nonneg_of_ae", "Fubini's theorem"],
+    "prerequisites": ["product measures", "linearity of the integral"]
+  },
+  {
+    "id": "ann-cheby-oq0103-reverse",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-03",
+    "range": { "startLine": 161, "endLine": 195 },
+    "type": "technique",
+    "title": "Reverse inequality and interval-integral packaging",
+    "content": "For opposite monotonicity (f up, g down), −g is monotone, so applying the main theorem to (f, −g) and simplifying with mul_neg / integral_neg flips the inequality to (b−a)∫fg ≤ (∫f)(∫g). Finally both directions are restated with the everyday interval integral ∫ x in a..b via integral_of_le and integral_Icc_eq_integral_Ioc (Icc and Ioc agree up to a null set).",
+    "mathContext": "$f\\uparrow, g\\downarrow \\Rightarrow (b-a)\\int_a^b fg \\le \\big(\\int_a^b f\\big)\\big(\\int_a^b g\\big)$.",
+    "significance": "standard",
+    "relatedConcepts": ["AntitoneOn.neg", "intervalIntegral", "integral_neg"],
+    "prerequisites": ["interval integrals", "sign reversal under negation"]
+  }
+]

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/index.ts
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevSumIntegralOQ0103.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevSumInequalityOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevSumInequalityOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevSumInequalityOQ01OQ03Data: ProofData = {
+  proof: chebyshevSumInequalityOQ01OQ03Proof,
+  annotations: chebyshevSumInequalityOQ01OQ03Annotations,
+}

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-03/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-03",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-03",
+  "title": "Continuous (Integral) Chebyshev Sum Inequality for Monotone Functions",
+  "description": "The continuous analogue of Chebyshev's sum inequality: for f, g monotone the same way on [a,b], (∫f)(∫g) ≤ (b−a)∫fg, with the inequality reversing when one is increasing and the other decreasing. Proved from the symmetrised double integral ∫∫(f x−f y)(g x−g y) ≥ 0 via the product measure and Fubini, filling a gap Mathlib leaves open (it has only the discrete sum version).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["MeasureTheory", "Set"],
+    "namespace": "ChebyshevIntegralMonotone",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumIntegralOQ0103.lean",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "meta": {
+    "author": "Classical (Chebyshev); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+    "date": "1882",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "integration",
+      "measure-theory",
+      "chebyshev-sum-inequality",
+      "monotone",
+      "fubini"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevSumIntegralOQ0103.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 212,
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.integral_prod_mul",
+        "description": "∫ z, f z.1 * g z.2 ∂(μ.prod ν) = (∫ f ∂μ)(∫ g ∂ν): evaluates the two cross terms f(x)g(y), f(y)g(x) of the symmetrised integrand",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "MeasureTheory.integral_fun_fst / integral_fun_snd",
+        "description": "∫ z, φ z.1 ∂(μ.prod ν) = ν.real univ • ∫ φ ∂μ: evaluates the diagonal terms f(x)g(x), f(y)g(y), supplying the (b−a) factor as the total mass",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "MonotoneOn.integrableOn_of_measure_ne_top",
+        "description": "A monotone function on a finite-measure interval is integrable — the source of integrability of f, g without any continuity assumption",
+        "module": "Mathlib.MeasureTheory.Function.LocallyIntegrable"
+      },
+      {
+        "theorem": "MeasureTheory.Integrable.mul_prod / Integrable.comp_fst_iff / Integrable.comp_snd_iff",
+        "description": "Integrability of the four product cross-terms against the product measure μ.prod μ",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "MeasureTheory.integral_nonneg_of_ae",
+        "description": "A.e. nonnegative integrand ⇒ nonnegative integral — turns the pointwise sign of (f x−f y)(g x−g y) into the inequality",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.Measure.prod_restrict",
+        "description": "(μ.restrict s).prod (ν.restrict t) = (μ.prod ν).restrict (s ×ˢ t): localises the a.e. nonnegativity to the square [a,b]²",
+        "module": "Mathlib.MeasureTheory.Measure.Prod"
+      }
+    ],
+    "originalContributions": [
+      "chebyshev_integral_monotoneOn_setIntegral / chebyshev_integral_monotoneOn: the classical monotone-functions-on-an-interval Chebyshev inequality (∫f)(∫g) ≤ (b−a)∫fg for MonotoneOn f, g on Icc a b, stated with the interval integral ∫ x in a..b — the precise continuous analogue of the parent's monotone-sequence form, and the form the gallery's general comonotone entry (oq-01-oq-01-oq-01) does NOT directly provide (that one needs global comonotonicity + boundedness + measurability)",
+      "chebyshev_integral_antitoneOn_setIntegral / chebyshev_integral_antitoneOn: the reversed inequality (b−a)∫fg ≤ (∫f)(∫g) for f monotone, g antitone, derived by applying the monotone case to f and −g",
+      "The key bridge new over the general entry: integrability of f, g, f·g discharged purely from MonotoneOn (no boundedness assumed) and the comonotone sign transported to the square [a,b]² via Measure.prod_restrict — so the user supplies only monotonicity",
+      "sub_mul_sub_nonneg_of_monotoneOn: the pointwise rearrangement sign lemma; norm_le_of_monotoneOn: monotone ⇒ bounded on the interval. Mathlib still has no integral Chebyshev inequality of any form."
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "Chebyshev's sum inequality for finite sequences states that if a₁≤…≤aₙ and b₁≤…≤bₙ are sorted the same way then (∑aᵢ)(∑bᵢ) ≤ n·∑aᵢbᵢ. The parent entry formalises this discrete form via Mathlib's MonovaryOn machinery and poses, as an open question, its continuous counterpart: for monotone functions f, g on an interval [a,b], does (∫ₐᵇ f)(∫ₐᵇ g) ≤ (b−a)∫ₐᵇ f·g hold (reversing for opposite monotonicity)? Mathlib has no integral version of Chebyshev's inequality.",
+    "keyInsight": "The continuous inequality is the integral of a manifestly nonnegative two-variable function. Because (f x − f y) and (g x − g y) always share their sign when f and g are monotone the same way, the symmetrised integrand (f x − f y)(g x − g y) is everywhere ≥ 0 on the square [a,b]². Integrating it against the product measure and expanding gives exactly 2(b−a)∫f·g − 2(∫f)(∫g), so nonnegativity of the integral IS the inequality. No continuity is needed — monotone functions are automatically integrable on a finite interval.",
+    "approach": "Work with μ = volume.restrict (Icc a b), a finite measure of total mass b−a. Establish integrability of f, g (MonotoneOn.integrableOn_of_measure_ne_top) and of f·g (bounded × integrable). On the product μ.prod μ, expand (f x−f y)(g x−g y) into four product terms; evaluate the two diagonal terms with integral_fun_fst / integral_fun_snd (each contributing (b−a)∫f·g) and the two cross terms with integral_prod_mul (each (∫f)(∫g)). Pointwise nonnegativity of the integrand, transported to the square via Measure.prod_restrict, gives ∫∫ ≥ 0 and hence the inequality. The reverse inequality follows by applying the result to f and −g.",
+    "significance": "Gives the classical monotone-on-an-interval continuous Chebyshev inequality — the form a reader of the monotone-sequence parent expects — which the gallery's existing general comonotone integral entry does not directly yield (it assumes global comonotonicity, boundedness, and measurability). The contribution is the bridge from MonotoneOn to integrability and the comonotone sign, plus interval-integral packaging. Mathlib has no integral Chebyshev inequality of any kind.",
+    "difficulty": "intermediate",
+    "estimatedReadTime": 9,
+    "prerequisites": [
+      "Chebyshev's sum inequality (discrete form)",
+      "Lebesgue / Bochner integration on ℝ",
+      "product measures and Fubini's theorem",
+      "monotone functions are measurable and integrable on bounded intervals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sign-lemma",
+      "title": "Pointwise sign of the symmetrised integrand",
+      "startLine": 53,
+      "endLine": 86,
+      "summary": "sub_mul_sub_nonneg_of_monotoneOn: for x, y ∈ Icc a b, 0 ≤ (f x − f y)(g x − g y), by case-splitting on x ≤ y vs y ≤ x — both factors are ≤ 0 in one case and ≥ 0 in the other. norm_le_of_monotoneOn bounds a monotone function on [a,b] by max|f a||f b|, used to make f·g integrable.",
+      "mathContext": "$0 \\le (f(x)-f(y))(g(x)-g(y))$ when $f,g$ are monotone the same way."
+    },
+    {
+      "id": "core-identity",
+      "title": "The Fubini identity and the main inequality",
+      "startLine": 88,
+      "endLine": 159,
+      "summary": "chebyshev_integral_monotoneOn_setIntegral. After the degenerate a=b case, sets μ = volume.restrict (Icc a b) (mass b−a), proves integrability of f, g, f·g and of the four product cross-terms, then shows ∫∫(f x−f y)(g x−g y) d(μ×μ) = 2(b−a)∫fg − 2(∫f)(∫g) via integral_prod_mul / integral_fun_fst / integral_fun_snd; nonnegativity of the integrand closes it.",
+      "mathContext": "$\\iint (f(x)-f(y))(g(x)-g(y)) = 2(b-a)\\!\\int\\! fg - 2\\big(\\!\\int\\! f\\big)\\big(\\!\\int\\! g\\big) \\ge 0$."
+    },
+    {
+      "id": "reverse",
+      "title": "Reverse inequality for opposite monotonicity",
+      "startLine": 161,
+      "endLine": 171,
+      "summary": "chebyshev_integral_antitoneOn_setIntegral: with f monotone and g antitone, −g is monotone, so the main theorem applied to (f, −g) and simplified with mul_neg / integral_neg yields the reversed bound (b−a)∫fg ≤ (∫f)(∫g).",
+      "mathContext": "$f\\uparrow,\\ g\\downarrow \\;\\Rightarrow\\; (b-a)\\!\\int\\! fg \\le \\big(\\!\\int\\! f\\big)\\big(\\!\\int\\! g\\big)$."
+    },
+    {
+      "id": "interval-forms",
+      "title": "Interval-integral statements",
+      "startLine": 173,
+      "endLine": 195,
+      "summary": "chebyshev_integral_monotoneOn and chebyshev_integral_antitoneOn restate both inequalities with the familiar interval integral ∫ x in a..b, obtained from the set-integral forms via integral_of_le and integral_Icc_eq_integral_Ioc.",
+      "mathContext": "$\\big(\\int_a^b f\\big)\\big(\\int_a^b g\\big) \\le (b-a)\\int_a^b f\\cdot g$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The continuous Chebyshev sum inequality and its reverse are fully formalised for monotone/antitone functions on a bounded interval, with no axioms or sorries and no continuity hypothesis. The single nonnegative double integral ∫∫(f x−f y)(g x−g y) carries the entire argument; Mathlib's product-integral lemmas evaluate it in closed form.",
+    "futureWork": "Sharpen to an equality/rigidity statement (when does equality hold?), or extend to a general finite measure space with a measurable order-correlation hypothesis (a continuous analogue of MonovaryOn)."
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The discrete monotone-sequence Chebyshev inequality whose open question (continuous form for monotone functions) this entry answers"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The general comonotone integral Chebyshev inequality (bounded measurable functions, arbitrary finite measure, global comonotonicity); this entry gives the local MonotoneOn / interval-integral specialization it does not directly cover"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality",
+      "relationship": "related",
+      "description": "Root Chebyshev sum inequality entry"
+    }
+  ],
+  "references": [
+    {
+      "title": "Chebyshev's sum inequality",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+      "description": "Statement and the integral (continuous) form of the inequality"
+    },
+    {
+      "title": "Hardy, Littlewood, Pólya — Inequalities",
+      "url": "https://archive.org/details/Inequalities",
+      "description": "Classical reference; §2.17 treats the integral Chebyshev inequality for monotone functions"
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/research/problems/chebyshev-sum-inequality-oq-01-oq-03.json
+++ b/src/data/research/problems/chebyshev-sum-inequality-oq-01-oq-03.json
@@ -1,0 +1,78 @@
+{
+  "slug": "chebyshev-sum-inequality-oq-01-oq-03",
+  "title": "Continuous (Integral) Chebyshev Sum Inequality for Monotone Functions",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE | seeker-selected: extend averaged Chebyshev sum inequality to the integral form for monotone functions.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Continuous Chebyshev: (∫f)(∫g) ≤ (b−a)∫fg for MonotoneOn f,g on Icc a b (set-integral and interval-integral forms)",
+      "Reverse Chebyshev: (b−a)∫fg ≤ (∫f)(∫g) for f MonotoneOn, g AntitoneOn"
+    ],
+    "open": [],
+    "goal": "(∫f)(∫g) ≤ (b−a)∫fg for f,g monotone the same way on [a,b]; reversed for opposite monotonicity."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T17:05:24.939Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: 0-axiom Lean proof of the continuous Chebyshev inequality (both directions). Mathlib had only the discrete sum version.",
+    "builtItems": [
+      "ChebyshevSumIntegral.chebyshev_integral_monotoneOn_setIntegral in Proofs/ChebyshevSumIntegralOQ0103.lean",
+      "ChebyshevSumIntegral.chebyshev_integral_monotoneOn (interval-integral form)",
+      "ChebyshevSumIntegral.chebyshev_integral_antitoneOn_setIntegral / chebyshev_integral_antitoneOn (reverse)",
+      "ChebyshevSumIntegral.sub_mul_sub_nonneg_of_monotoneOn (pointwise sign lemma)",
+      "ChebyshevSumIntegral.norm_le_of_monotoneOn (boundedness for integrability)"
+    ],
+    "insights": [
+      "The inequality is the integral of (f x−f y)(g x−g y) ≥ 0 over the square; expanding gives 2(b−a)∫fg−2(∫f)(∫g).",
+      "No continuity needed: MonotoneOn.integrableOn_of_measure_ne_top gives integrability on a finite interval.",
+      "Diagonal terms f(x)g(x), f(y)g(y) evaluate via integral_fun_fst/snd (mass factor b−a); cross terms via integral_prod_mul.",
+      "Reverse direction is free: apply the monotone result to (f, −g) and simplify with mul_neg/integral_neg."
+    ],
+    "mathlibGaps": [
+      "Mathlib has Chebyshev sum inequality only for finite sums (MonovaryOn); no integral/continuous version."
+    ],
+    "nextSteps": [
+      "Equality/rigidity characterisation of the integral Chebyshev inequality.",
+      "Generalise to an arbitrary finite measure space with a measurable order-correlation (continuous MonovaryOn) hypothesis."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "inequalities",
+    "chebyshev-sum",
+    "integration",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "chebyshev-sum-inequality-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T17:05:24.938Z",
+  "lastUpdate": "2026-06-24T17:30:00.000Z",
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Answers the monotone-sequence parent's (`chebyshev-sum-inequality-oq-01`) open question **oq-03**: the classical **continuous (integral) Chebyshev inequality for monotone functions on an interval**

$$\left(\int_a^b f\right)\left(\int_a^b g\right) \le (b-a)\int_a^b f\cdot g \qquad (f,g\text{ both monotone}),$$

with the inequality reversing when one is increasing and the other decreasing. Stated for `MonotoneOn`/`AntitoneOn` on `Set.Icc a b` and with the interval integral `∫ x in a..b`.

## Relation to the existing gallery entry

The gallery already contains the **general comonotone** integral inequality (`chebyshev-sum-inequality-oq-01-oq-01-oq-01`, `chebyshev_integral_mul_le`) for bounded measurable functions on an arbitrary finite measure with a **global** comonotonicity hypothesis. That statement does **not** directly give the classical monotone-functions-on-an-interval form this entry targets — a `MonotoneOn` function on `[a,b]` is monotone only *locally* and need be neither globally bounded nor globally measurable.

**New content here:** the bridge from `MonotoneOn` to integrability (`MonotoneOn.integrableOn_of_measure_ne_top` — no boundedness assumption) and to the comonotone sign on the square (`Measure.prod_restrict`, `ae_restrict_iff'`), plus interval-integral packaging. The shared Fubini *method* is credited, not claimed as novel.

## Proof

The symmetrised double integral
$$\iint_{[a,b]^2}(f x-f y)(g x-g y)\,d(\mu\times\mu)=2(b-a)\!\int\! fg-2\Big(\!\int\! f\Big)\Big(\!\int\! g\Big)$$
is `≥ 0` because the integrand is pointwise nonnegative for monotone `f,g`. The four terms are evaluated with `integral_prod_mul` (cross) and `integral_fun_fst`/`integral_fun_snd` (diagonal, supplying the `b−a` mass factor). The reverse inequality follows by applying the monotone case to `f, −g`.

## Verification

- **6 theorems, 0 definitions, 212 lines**, `import Mathlib`.
- `#print axioms` of both headline theorems: `[propext, Classical.choice, Quot.sound]` only — **0-axiom / verified** (no `sorryAx`, no `Lean.ofReduceBool`).
- Builds with `lake env lean Proofs/ChebyshevSumIntegralOQ0103.lean` (host, Mathlib 4.26).
- Mathlib has no integral Chebyshev inequality of any kind (only the discrete `Finset`/`MonovaryOn` form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)