### PR TITLE
research(keith-number-oq-01-oq-02): Keith numbers in an arbitrary base [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3179,6 +3179,7 @@ import Proofs.JensenInequalityOQ01OQ01OQ01OQ01
 import Proofs.JensenInequalityOQ01OQ01OQ01OQ03
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
+import Proofs.KeithNumberOQ01OQ02
 import Proofs.KeplerConjecture
 import Proofs.KeplerConjectureOQ04
 import Proofs.KnightsTourOblique

--- a/proofs/Proofs/KeithNumberOQ01OQ02.lean
+++ b/proofs/Proofs/KeithNumberOQ01OQ02.lean
@@ -1,0 +1,117 @@
+/-
+# Keith numbers in an arbitrary base
+
+The parent entry `KeithNumberOQ01` defines a *Keith number* (repfigit) through a
+fuel-bounded sliding-window recurrence over its **decimal** digits and proves the
+smallest one is `14`. The base `10` is hard-wired into the digit extraction
+(`n % 10`, `n / 10`).
+
+This follow-up removes that hard-wiring. The Keith *recurrence* itself —
+"drop the oldest window term, append the window sum, stop when you reach the
+target" — never mentions a base; only the initial window (the digits of `n`)
+does. So we keep the parent's base-independent `step`/`reaches` and generalize
+only the digit extraction to an arbitrary base `b`:
+
+* **`lsdDigitsB` / `msdDigitsB`** : base-`b` digits, generalizing `lsdDigits` /
+  `msdDigits`.
+* **`IsKeithBase b n`** : `n` has at least two base-`b` digits (`b ≤ n`) and its
+  base-`b` digit recurrence reaches `n`.
+
+The base-`10` predicate is recovered exactly:
+
+* **`isKeithBase_ten`** : `IsKeithBase 10 n ↔ IsKeith n`, and hence
+* **`smallest_keithBase10`** : `IsLeast {n | IsKeithBase 10 n} 14` — the parent's
+  headline theorem re-derived through the general definition.
+
+Other bases admit their own small Keith numbers, which the decision procedure
+confirms directly:
+
+* **`keithBase4_five`** : `5 = (11)_4` is Keith in base `4` (`1,1,2,3,5`), and
+* **`smallest_keithBase4`** : `IsLeast {n | IsKeithBase 4 n} 5` — `5` is the
+  smallest base-`4` Keith number, the base-`4` analogue of `14` in base `10`.
+
+Like the parent, every result is axiom-free: the digit recurrence reduces in the
+kernel under `decide` (no `native_decide` / `Lean.ofReduceBool`).
+
+Reference: https://en.wikipedia.org/wiki/Keith_number
+-/
+import Mathlib
+import Proofs.KeithNumberOQ01
+
+namespace KeithNumberOQ01OQ02
+
+open KeithNumberOQ01
+
+/-- Base-`b` digits, least-significant first, via structural recursion on `fuel`
+(generalizing `KeithNumberOQ01.lsdDigits`, which fixes `b = 10`). Kept
+fuel-bounded so the kernel can reduce it under `decide`. With `fuel ≥ ⌈log_b n⌉`
+the result is exact; fuel `n` always suffices. -/
+def lsdDigitsB (b : ℕ) : ℕ → ℕ → List ℕ
+  | 0, _ => []
+  | _, 0 => []
+  | fuel + 1, n => n % b :: lsdDigitsB b fuel (n / b)
+
+/-- Base-`b` digits of `n`, most-significant first
+(so `msdDigitsB 4 5 = [1, 1]`). -/
+def msdDigitsB (b n : ℕ) : List ℕ := (lsdDigitsB b n n).reverse
+
+/-- `n` is a Keith number **in base `b`**: it has at least two base-`b` digits
+(`b ≤ n`) and its base-`b` digit recurrence reaches `n`. The window steps
+(`KeithNumberOQ01.step` / `reaches`) are inherited unchanged from the parent —
+only the initial window depends on the base. -/
+def IsKeithBase (b n : ℕ) : Prop := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true
+
+instance (b : ℕ) : DecidablePred (IsKeithBase b) :=
+  fun n => inferInstanceAs (Decidable (b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true))
+
+/- ## Recovering the decimal predicate -/
+
+/-- Base-`10` digit extraction agrees with the parent's decimal extraction. -/
+theorem lsdDigitsB_ten (fuel n : ℕ) : lsdDigitsB 10 fuel n = lsdDigits fuel n := by
+  induction fuel generalizing n with
+  | zero => rfl
+  | succ fuel ih =>
+    cases n with
+    | zero => rfl
+    | succ m => simp only [lsdDigitsB, lsdDigits, ih]
+
+theorem msdDigitsB_ten (n : ℕ) : msdDigitsB 10 n = msdDigits n := by
+  unfold msdDigitsB msdDigits
+  rw [lsdDigitsB_ten]
+
+/-- **Recovery of the decimal predicate.** Base-`10` Keith numbers are exactly the
+Keith numbers of the parent file. -/
+theorem isKeithBase_ten (n : ℕ) : IsKeithBase 10 n ↔ IsKeith n := by
+  unfold IsKeithBase IsKeith
+  rw [msdDigitsB_ten]
+
+theorem keithBase10_setOf_eq : {n | IsKeithBase 10 n} = {n | IsKeith n} := by
+  ext n; exact isKeithBase_ten n
+
+/-- **The parent's headline, re-derived through the general definition.** The
+smallest base-`10` Keith number is `14`. -/
+theorem smallest_keithBase10 : IsLeast {n | IsKeithBase 10 n} 14 := by
+  rw [keithBase10_setOf_eq]; exact smallest_keith
+
+/- ## Small Keith numbers in other bases -/
+
+/-- `5 = (11)_4` is a Keith number in base `4`: the window runs `1, 1, 2, 3, 5`. -/
+theorem keithBase4_five : IsKeithBase 4 5 := by decide
+
+/-- `13 = (11)_12` is a Keith number in base `12`: `1, 1, 2, 3, 5, 8, 13`. -/
+theorem keithBase12_thirteen : IsKeithBase 12 13 := by decide
+
+/-- No base-`4` number below `5` is Keith (`4 = (10)_4` overshoots without hitting
+itself; `n < 4` has fewer than two base-`4` digits). -/
+theorem not_keithBase4_below_five : ∀ n < 5, ¬ IsKeithBase 4 n := by decide
+
+/-- **The smallest base-`4` Keith number is `5`** — the base-`4` analogue of the
+parent's `14` in base `10`. -/
+theorem smallest_keithBase4 : IsLeast {n : ℕ | IsKeithBase 4 n} 5 := by
+  refine ⟨keithBase4_five, ?_⟩
+  intro n hn
+  by_contra h
+  push_neg at h
+  exact not_keithBase4_below_five n h hn
+
+end KeithNumberOQ01OQ02

--- a/src/data/proofs/keith-number-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/keith-number-oq-01-oq-02/annotations.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "keithb-ann-intro",
+    "proofId": "keith-number-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Keith Numbers in an Arbitrary Base",
+    "content": "The parent entry defines a **Keith number** through a sliding-window recurrence over its *decimal* digits and proves the smallest one is $14$. The recurrence itself — drop the oldest window term, append the window sum, stop when you hit the target — never mentions a base; only the seed digits do. So a base-$b$ Keith number is an $N$ with at least two base-$b$ digits whose base-$b$ digit recurrence reaches $N$.\n\nThis follow-up reparametrizes only the digit extraction: $\\texttt{lsdDigitsB}\\ b$ peels base-$b$ digits ($n \\bmod b$, $n / b$) while the window dynamics $\\texttt{step}/\\texttt{reaches}$ are inherited verbatim from the parent.",
+    "mathContext": "The parent (`keith-number-oq-01`) explicitly raised generalizing `IsKeith` to an arbitrary base as an open question; this entry answers it.",
+    "significance": "key",
+    "prerequisites": [
+      "positional (base-b) digit representations",
+      "Fibonacci-like linear recurrences",
+      "decidability and kernel `decide`"
+    ]
+  },
+  {
+    "id": "keithb-ann-def",
+    "proofId": "keith-number-oq-01-oq-02",
+    "range": {
+      "startLine": 49,
+      "endLine": 65
+    },
+    "type": "definition",
+    "title": "Base-b Digits and IsKeithBase",
+    "content": "$\\texttt{lsdDigitsB}\\ b\\ \\textit{fuel}\\ n$ extracts base-$b$ digits least-significant first by structural recursion on $\\textit{fuel}$, and $\\texttt{msdDigitsB}\\ b\\ n = (\\texttt{lsdDigitsB}\\ b\\ n\\ n).\\texttt{reverse}$. The predicate is\n$$\\texttt{IsKeithBase}\\ b\\ n \\;:=\\; b \\le n \\;\\wedge\\; \\texttt{reaches}\\ n\\ 40\\ (\\texttt{msdDigitsB}\\ b\\ n) = \\texttt{true},$$\nwhere $b \\le n$ is the 'at least two base-$b$ digits' condition. A `DecidablePred (IsKeithBase b)` instance is supplied so concrete claims reduce under `decide`.",
+    "mathContext": "Keeping `lsdDigitsB` fuel-bounded (rather than using Mathlib's well-founded `Nat.digits`) is what keeps the base-b decision procedure kernel-reducible and the result axiom-free.",
+    "significance": "key",
+    "prerequisites": []
+  },
+  {
+    "id": "keithb-ann-recovery",
+    "proofId": "keith-number-oq-01-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "Recovering the Decimal Predicate",
+    "content": "`lsdDigitsB 10` and the parent's `lsdDigits` are different recursive definitions, so their agreement is *proved*, not assumed: $\\texttt{lsdDigitsB\\_ten}$ shows $\\texttt{lsdDigitsB}\\ 10\\ \\textit{fuel}\\ n = \\texttt{lsdDigits}\\ \\textit{fuel}\\ n$ by induction on $\\textit{fuel}$. Lifting through the reverse gives $\\texttt{msdDigitsB\\_ten}$ and then the bridge $\\texttt{isKeithBase\\_ten} : \\texttt{IsKeithBase}\\ 10\\ n \\leftrightarrow \\texttt{IsKeith}\\ n$. The set equality $\\{n \\mid \\texttt{IsKeithBase}\\ 10\\ n\\} = \\{n \\mid \\texttt{IsKeith}\\ n\\}$ then transports the parent's theorem to $\\texttt{smallest\\_keithBase10} : \\texttt{IsLeast}\\ \\{n \\mid \\texttt{IsKeithBase}\\ 10\\ n\\}\\ 14$.",
+    "mathContext": "Confirms the generalization specializes correctly: the base-10 instance is exactly the classical Keith predicate.",
+    "significance": "key",
+    "prerequisites": [
+      "induction on a fuel parameter",
+      "set-builder equality and `IsLeast`"
+    ]
+  },
+  {
+    "id": "keithb-ann-otherbases",
+    "proofId": "keith-number-oq-01-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 116
+    },
+    "type": "observation",
+    "title": "Small Keith Numbers in Other Bases",
+    "content": "Other bases admit their own small Keith numbers, confirmed directly by `decide`: $5 = (11)_4$ runs the window $1,1,2,3,5$ and is Keith in base $4$ ($\\texttt{keithBase4\\_five}$), and $13 = (11)_{12}$ is Keith in base $12$. With $\\texttt{not\\_keithBase4\\_below\\_five}$ this yields $\\texttt{smallest\\_keithBase4} : \\texttt{IsLeast}\\ \\{n \\mid \\texttt{IsKeithBase}\\ 4\\ n\\}\\ 5$ — the base-4 analogue of $14$ in base $10$. The two-digit $(11)_b$ window is the Fibonacci sequence $1,1,2,3,5,8,\\dots$, so $(11)_b$ is Keith exactly when $b+1$ is a Fibonacci number (e.g. $4+1=5$, $12+1=13$).",
+    "mathContext": "The smallest base-b Keith number depends on b and can be far below the decimal minimum 14.",
+    "significance": "standard",
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/keith-number-oq-01-oq-02/meta.json
+++ b/src/data/proofs/keith-number-oq-01-oq-02/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "keith-number-oq-01-oq-02",
+  "title": "Keith Numbers in an Arbitrary Base",
+  "slug": "keith-number-oq-01-oq-02",
+  "description": "Generalizes the decimal Keith-number predicate of the parent entry to an arbitrary base b. The Keith sliding-window recurrence is base-independent; only the seed digits depend on the base. The base-10 predicate is recovered exactly (IsKeithBase 10 ↔ IsKeith), re-deriving the parent's `IsLeast {n | IsKeith n} 14`, and the framework exhibits the smallest base-4 Keith number (5 = (11)_4). Fully machine-checked by kernel `decide` with 0 axioms.",
+  "meta": {
+    "author": "Mike Keith (concept, 1987); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Keith_number",
+    "date": "1987 (Keith numbers introduced); base generalization is standard",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KeithNumberOQ01OQ02.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "digits",
+      "recurrence",
+      "decidability",
+      "recreational",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 117,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. The concrete base-b membership and minimality facts use kernel `decide` (not `native_decide`), so they carry no `Lean.ofReduceBool` axiom; `#print axioms` reports only the foundational `propext`/`Quot.sound`. The base-b digit recurrence reuses the parent's fuel-bounded `lsdDigits` pattern (generalized to `lsdDigitsB`) precisely so the kernel can reduce the decision procedure.",
+    "originalContributions": [
+      "Generalizes the parent's decimal Keith predicate to an arbitrary base: `lsdDigitsB`/`msdDigitsB` extract base-b digits and `IsKeithBase b n := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true`, reusing the parent's base-independent `step`/`reaches` window dynamics unchanged.",
+      "Proves the recovery bridge `isKeithBase_ten : IsKeithBase 10 n ↔ IsKeith n` by an induction (`lsdDigitsB_ten`) showing base-10 digit extraction agrees with the parent's `lsdDigits`, confirming the generalization specializes correctly.",
+      "Re-derives the parent's headline through the general definition: `smallest_keithBase10 : IsLeast {n | IsKeithBase 10 n} 14`, obtained from `smallest_keith` via the set equality `{n | IsKeithBase 10 n} = {n | IsKeith n}`.",
+      "Establishes the base-4 analogue `smallest_keithBase4 : IsLeast {n | IsKeithBase 4 n} 5` — 5 = (11)_4 is Keith in base 4 (window 1,1,2,3,5) and no smaller number is — plus a base-12 witness `keithBase12_thirteen`, demonstrating that other bases admit their own small Keith numbers.",
+      "Keeps the whole development axiom-free: every concrete claim reduces under kernel `decide`, never `native_decide`, so no `Lean.ofReduceBool` is introduced."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Keith numbers (repfigit numbers, Mike Keith 1987) are usually stated in base 10: an n-digit number N appears in the order-n linear recurrence seeded by its decimal digits. The notion is base-agnostic, though — the recurrence on the digit window never refers to the base, only the seed digits do. The parent entry `keith-number-oq-01` settled the smallest decimal Keith number (14) with a kernel-`decide`-friendly fuel-bounded digit recurrence and explicitly raised generalizing to an arbitrary base as an open question. This entry answers it: it parametrizes the digit extraction by base b, recovers the decimal predicate exactly, and identifies the smallest base-4 Keith number.",
+    "problemStatement": "Generalize `IsKeith` to an arbitrary base b and recover the base-10 predicate as a special case, then exhibit small Keith numbers in other bases. Formally: define `IsKeithBase b n`, prove `IsKeithBase 10 n ↔ IsKeith n` (hence `IsLeast {n | IsKeithBase 10 n} 14`), and prove `IsLeast {n | IsKeithBase 4 n} 5`.",
+    "text": "A Lean 4 / Mathlib formalization in 117 lines with 0 sorries and 0 axioms. The parent's window dynamics — `step w = w.tail ++ [w.sum]` and the fuel-bounded `reaches` — are imported and reused verbatim, since they are independent of the base. Only the seed changes: `lsdDigitsB b fuel n` peels base-b digits (`n % b`, `n / b`) by structural recursion on `fuel`, and `msdDigitsB b n = (lsdDigitsB b n n).reverse`. The predicate becomes `IsKeithBase b n := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true`, with a `DecidablePred (IsKeithBase b)` instance. The bridge `lsdDigitsB_ten` proves base-10 extraction equals the parent's `lsdDigits` by induction on fuel, giving `isKeithBase_ten : IsKeithBase 10 n ↔ IsKeith n` and the set equality that transports the parent's `smallest_keith` to `smallest_keithBase10`. New base-4 facts (`keithBase4_five`, `not_keithBase4_below_five`, `smallest_keithBase4`) and a base-12 witness are discharged by `decide`.",
+    "proofStrategy": "1. **Generalize the seed, keep the dynamics.** Replace the decimal `lsdDigits`/`msdDigits` by base-b `lsdDigitsB`/`msdDigitsB`; reuse `step`/`reaches` from the parent unchanged.\n\n2. **Predicate + decidability.** `IsKeithBase b n := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true`, with a `DecidablePred (IsKeithBase b)` instance from decidability of `≤` and `Bool` equality.\n\n3. **Recovery bridge.** `lsdDigitsB_ten : lsdDigitsB 10 fuel n = lsdDigits fuel n` by induction on `fuel` (with `n` generalized); lift to `msdDigitsB_ten` and then `isKeithBase_ten : IsKeithBase 10 n ↔ IsKeith n`.\n\n4. **Re-derive the parent.** `keithBase10_setOf_eq : {n | IsKeithBase 10 n} = {n | IsKeith n}` via `isKeithBase_ten`, then `smallest_keithBase10 := smallest_keith` rewritten through it.\n\n5. **Other bases.** `keithBase4_five`, `keithBase12_thirteen`, and `not_keithBase4_below_five` by `decide`; assemble `smallest_keithBase4 : IsLeast {n | IsKeithBase 4 n} 5` from membership and the bounded lower bound.",
+    "keyInsights": [
+      "**The Keith recurrence is base-independent; only the seed is not.** Dropping the oldest window term and appending the window sum makes no reference to the radix — the base enters solely through the initial digit list. So the generalization reuses the parent's `step`/`reaches` verbatim and reparametrizes only `lsdDigits`, a clean separation of concerns.",
+      "**Recovery is an honest induction, not a definitional coincidence.** `lsdDigitsB 10` and the parent's `lsdDigits` are syntactically different recursive definitions; `lsdDigitsB_ten` proves them equal by induction on fuel, so `IsKeithBase 10 ↔ IsKeith` is established rather than assumed, and the parent's `IsLeast … 14` transports through the equality.",
+      "**Small Keith numbers exist in every base, with base-dependent minima.** The base-4 minimum is 5 = (11)_4 (window 1,1,2,3,5), strictly smaller than the decimal minimum 14; base 12 already has 13 = (11)_12. Two-digit (11)_b candidates run the Fibonacci-like window 1,1,2,3,5,8,… and hit a Fibonacci number exactly when b+1 is Fibonacci, explaining 5=(11)_4 and 13=(11)_12.",
+      "**Kernel `decide` survives the generalization.** Because `lsdDigitsB` is fuel-bounded structural recursion (not Mathlib's well-founded `Nat.digits`), the base-b decision procedure still reduces in the kernel, so every concrete base-b claim stays axiom-free — no `native_decide`, no `Lean.ofReduceBool`."
+    ],
+    "prerequisites": [
+      "Positional (base-b) digit representations of natural numbers",
+      "Linear recurrences (Fibonacci-like sums)",
+      "Decidability and kernel `decide` in Lean 4",
+      "Induction on a fuel parameter; `IsLeast` and bounded quantifiers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Generalizing Keith Numbers to Base b",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring: the Keith recurrence is base-independent, so only the seed digits are reparametrized by base b. Lists the generalized definitions, the recovery bridge `isKeithBase_ten`, the re-derived `smallest_keithBase10`, and the new base-4 minimum.",
+      "mathContext": "A base-b Keith number is an ≥2-digit N appearing in the order-(#digits) recurrence seeded by its base-b digits; base 10 specializes to the classical notion."
+    },
+    {
+      "id": "digits-b",
+      "title": "Base-b Digits and the Keith Predicate",
+      "startLine": 49,
+      "endLine": 65,
+      "summary": "`lsdDigitsB b fuel n` peels base-b digits by structural recursion on fuel; `msdDigitsB b n = (lsdDigitsB b n n).reverse`. `IsKeithBase b n := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true`, with a `DecidablePred (IsKeithBase b)` instance.",
+      "mathContext": "The base enters only through the seed digit list; the window step `reaches` is inherited unchanged from the parent."
+    },
+    {
+      "id": "recovery",
+      "title": "Recovering the Decimal Predicate",
+      "startLine": 67,
+      "endLine": 96,
+      "summary": "`lsdDigitsB_ten` proves base-10 extraction equals the parent's `lsdDigits` by induction on fuel; `msdDigitsB_ten` and `isKeithBase_ten : IsKeithBase 10 n ↔ IsKeith n` follow. `keithBase10_setOf_eq` and `smallest_keithBase10 : IsLeast {n | IsKeithBase 10 n} 14` transport the parent's result.",
+      "mathContext": "Confirms the generalization specializes correctly: the base-10 instance is exactly the classical Keith predicate, smallest element 14."
+    },
+    {
+      "id": "other-bases",
+      "title": "Small Keith Numbers in Other Bases",
+      "startLine": 98,
+      "endLine": 116,
+      "summary": "`keithBase4_five : IsKeithBase 4 5` (window 1,1,2,3,5) and `keithBase12_thirteen` by `decide`; `not_keithBase4_below_five` by `decide`; `smallest_keithBase4 : IsLeast {n | IsKeithBase 4 n} 5` assembles the base-4 minimum.",
+      "mathContext": "Other bases admit small Keith numbers with base-dependent minima; 5 = (11)_4 is the base-4 analogue of 14 in base 10."
+    }
+  ],
+  "conclusion": {
+    "summary": "The decimal Keith predicate is generalized to an arbitrary base b by reparametrizing only the seed digits (`lsdDigitsB`/`msdDigitsB`) while reusing the parent's base-independent window recurrence. The base-10 instance is proved equal to the parent's predicate (`isKeithBase_ten`), re-deriving `IsLeast {n | IsKeith n} 14` as `smallest_keithBase10`, and the base-4 minimum is established: `IsLeast {n | IsKeithBase 4 n} 5`. Machine-checked by kernel `decide`, 0 sorries, 0 axioms.",
+    "implications": "Separating the base-dependent seed from the base-independent recurrence makes the generalization almost mechanical and keeps the whole development inside the kernel's reach, so concrete claims in any base stay axiom-free. The recovery bridge is a template for relating a hard-wired special case to its parametrized generalization by induction rather than by re-proving from scratch. The two-digit witnesses 5=(11)_4 and 13=(11)_12 hint at a clean sub-question: (11)_b is Keith exactly when b+1 is a Fibonacci number.",
+    "openQuestions": [
+      "Characterize the bases b for which (11)_b = b+1 is a Keith number — conjecturally exactly when b+1 is a Fibonacci number — and more generally describe the smallest base-b Keith number as a function of b.",
+      "Prove a base-uniform termination/monotonicity lemma for `reaches` giving an a-priori fuel bound as a function of the number of base-b digits, removing the hard-coded 40 across all bases.",
+      "Study density: for which bases are Keith numbers comparatively common, and is there a base in which they are provably infinite?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "keith-number-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry fixes base 10 and proves the smallest Keith number is 14. This follow-up answers its open question by generalizing the predicate to an arbitrary base, recovering the base-10 case exactly, and finding the smallest base-4 Keith number."
+    },
+    {
+      "targetId": "happy-number-oq-01",
+      "relationship": "related",
+      "description": "Another digit-defined integer family settled by a decidable predicate; like Keith numbers it admits a base-parametrized generalization where the digit dynamics are made kernel-reducible."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/KeithNumberOQ01OQ02.lean",
+    "namespace": "KeithNumberOQ01OQ02",
+    "imports": [
+      "Mathlib",
+      "Proofs.KeithNumberOQ01"
+    ],
+    "lineCount": 117,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 9,
+    "definitionCount": 3
+  },
+  "mainTheorems": [
+    {
+      "name": "smallest_keithBase4",
+      "type": "core",
+      "description": "IsLeast {n : ℕ | IsKeithBase 4 n} 5 — 5 = (11)_4 is the smallest base-4 Keith number (window 1,1,2,3,5), the base-4 analogue of 14 in base 10.",
+      "leanType": "IsLeast {n : ℕ | IsKeithBase 4 n} 5"
+    },
+    {
+      "name": "isKeithBase_ten",
+      "type": "core",
+      "description": "IsKeithBase 10 n ↔ IsKeith n — the base-10 generalized predicate is exactly the parent's decimal Keith predicate; the recovery bridge.",
+      "leanType": "∀ (n : ℕ), IsKeithBase 10 n ↔ IsKeith n"
+    },
+    {
+      "name": "smallest_keithBase10",
+      "type": "core",
+      "description": "IsLeast {n | IsKeithBase 10 n} 14 — the parent's headline re-derived through the general definition via the set equality {n | IsKeithBase 10 n} = {n | IsKeith n}.",
+      "leanType": "IsLeast {n | IsKeithBase 10 n} 14"
+    },
+    {
+      "name": "lsdDigitsB_ten",
+      "type": "supporting",
+      "description": "lsdDigitsB 10 fuel n = lsdDigits fuel n — base-10 digit extraction agrees with the parent's, by induction on fuel.",
+      "leanType": "∀ (fuel n : ℕ), lsdDigitsB 10 fuel n = lsdDigits fuel n"
+    },
+    {
+      "name": "keithBase4_five",
+      "type": "supporting",
+      "description": "IsKeithBase 4 5 — base-4 membership witnessed by the window 1,1,2,3,5; proved by kernel decide.",
+      "leanType": "IsKeithBase 4 5"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Mike Keith",
+      "title": "Repfigit Numbers",
+      "year": "1987",
+      "venue": "Journal of Recreational Mathematics, 19(2), 41–42",
+      "note": "Introduces Keith (repetitive Fibonacci-like digit) numbers; the base generalization is the natural radix-parametrized version."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A007629: Repfigit (REPetitive FIbonacci-like diGIT) numbers",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The base-10 Keith numbers 14, 19, 28, 47, 61, 75, …; this entry generalizes the underlying predicate to arbitrary bases."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question raised by the parent entry **keith-number-oq-01** (*The Smallest Keith Number is 14*): *"Generalize `IsKeith` to an arbitrary base b and recover the base-10 predicate as a special case, then study which bases admit small Keith numbers."*

The Keith sliding-window recurrence (`step`/`reaches`) never refers to the radix — only the seed digits do. So the generalization reuses the parent's window dynamics **verbatim** and reparametrizes only the digit extraction.

## What's proved (`Proofs/KeithNumberOQ01OQ02.lean`)

- **`lsdDigitsB` / `msdDigitsB`** — base-`b` digits, fuel-bounded so the kernel can reduce them under `decide`.
- **`IsKeithBase b n := b ≤ n ∧ reaches n 40 (msdDigitsB b n) = true`** with a `DecidablePred (IsKeithBase b)` instance.
- **`isKeithBase_ten : IsKeithBase 10 n ↔ IsKeith n`** — the recovery bridge. Base-10 extraction is *proved* equal to the parent's `lsdDigits` by induction on fuel (`lsdDigitsB_ten`), not assumed.
- **`smallest_keithBase10 : IsLeast {n | IsKeithBase 10 n} 14`** — the parent's headline re-derived through the general definition, via the set equality `{n | IsKeithBase 10 n} = {n | IsKeith n}`.
- **`smallest_keithBase4 : IsLeast {n | IsKeithBase 4 n} 5`** — `5 = (11)_4` is the smallest base-4 Keith number (window `1,1,2,3,5`), plus `keithBase12_thirteen` (`13 = (11)_12`). The two-digit `(11)_b` window is the Fibonacci sequence, so `(11)_b` is Keith exactly when `b+1` is Fibonacci.

## Verification

- **9 theorems / 3 defs / 117 lines.** Builds against Mathlib 4.26.0 (host `lake env lean`, clean).
- **Axiom-free.** Every concrete claim reduces under kernel `decide` (not `native_decide`), so no `Lean.ofReduceBool`. `#print axioms` on the main results reports only the foundational `propext` / `Quot.sound`.
- Registered in `proofs/Proofs.lean`; gallery data added under `src/data/proofs/keith-number-oq-01-oq-02/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)