### PR TITLE
Enrich Stern–Brocot run-lengths ↔ continued-fraction partial quotients

### DIFF
--- a/src/data/proofs/stern-brocot-tree-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "sbtoq0101-ann-overview",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 48 },
+    "type": "context",
+    "title": "Run-Lengths Are the Partial Quotients",
+    "content": "The module docstring states the classical Stern–Brocot / continued-fraction dictionary. A path `p : List Bool` of left (`false = L`) and right (`true = R`) moves labels the reduced positive rational `sbNum p / sbDen p`. Reading the path as alternating runs $R^{q_0} L^{q_1} R^{q_2}\\cdots$, the run-lengths $q_0, q_1, q_2, \\dots$ are exactly the partial quotients of the continued fraction of that rational. Mathlib v4.26 has no Stern–Brocot development, so the whole correspondence is built from scratch on top of the parent entry.",
+    "mathContext": "$\\dfrac{\\mathrm{sbNum}\\,p}{\\mathrm{sbDen}\\,p} = q_0 + \\cfrac{1}{q_1 + \\cfrac{1}{q_2 + \\cdots}}$ where $q_0, q_1, \\dots$ are the run-lengths of $p$.",
+    "significance": "context",
+    "relatedConcepts": ["Stern–Brocot tree", "continued fractions", "run-length encoding", "mediants"],
+    "prerequisites": ["rational numbers", "binary trees", "Euclidean algorithm"]
+  },
+  {
+    "id": "sbtoq0101-ann-rrun-transfer",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "technique",
+    "title": "R-Run Transfer: One Shear Iterated n Times",
+    "content": "Prepending a run of `n` consecutive `R`-moves leaves the denominator fixed (`sbDen_replicate_true`) and adds `n·den` to the numerator (`sbNum_replicate_true`). Both are proved by induction on the run-length `n`, each inductive step invoking the parent's single-step recurrences `sbDen_true_cons` / `sbNum_true_cons`. The key observation is that one `R`-move is a fixed shear map $(num, den) \\mapsto (num + den, den)$; applying it `n` times accumulates `n·den`, so no new invariant is needed — the closed form falls straight out of the parent's per-move lemmas.",
+    "mathContext": "An $R$-run of length $n$ acts as $\\begin{pmatrix} num \\\\ den \\end{pmatrix} \\mapsto \\begin{pmatrix} num + n\\,den \\\\ den \\end{pmatrix}$, i.e. the matrix $\\begin{pmatrix} 1 & n \\\\ 0 & 1 \\end{pmatrix}$ — the $n$-th power of the single-step shear $\\begin{pmatrix} 1 & 1 \\\\ 0 & 1 \\end{pmatrix}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["shear transformation", "unipotent matrices", "structural induction", "List.replicate"],
+    "prerequisites": ["mathematical induction", "matrix multiplication"]
+  },
+  {
+    "id": "sbtoq0101-ann-lrun-transfer",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 86 },
+    "type": "technique",
+    "title": "L-Run Transfer: The Dual Shear",
+    "content": "Symmetrically, a run of `n` consecutive `L`-moves leaves the numerator fixed (`sbNum_replicate_false`) and adds `n·num` to the denominator (`sbDen_replicate_false`). This is the transpose of the R-run shear and corresponds to the lower-triangular unipotent matrix. The L/R alternation between these two dual shears is precisely the alternation between 'add the integer part' and 'take a reciprocal' in the continued-fraction algorithm — the structural reason the run-lengths recover the partial quotients.",
+    "mathContext": "An $L$-run of length $n$ acts via $\\begin{pmatrix} 1 & 0 \\\\ n & 1 \\end{pmatrix}$, the lower-triangular transpose of the $R$-run matrix. Alternating $R$- and $L$-runs builds the product $\\begin{pmatrix} 1 & q_0 \\\\ 0 & 1 \\end{pmatrix}\\begin{pmatrix} 1 & 0 \\\\ q_1 & 1 \\end{pmatrix}\\cdots$ — the matrix model of $[q_0; q_1, q_2, \\dots]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["transpose", "SL₂(ℤ)", "continued-fraction matrices", "duality"],
+    "prerequisites": ["mathematical induction", "linear algebra"]
+  },
+  {
+    "id": "sbtoq0101-ann-assembler",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 106 },
+    "type": "definition",
+    "title": "Path Assembler and Matrix Convergent",
+    "content": "`runsToPathFrom b` builds a Stern–Brocot path from a list of run-lengths, alternating the move symbol and starting with move `b`; `runsToPath` fixes the start to an `R`-run. In parallel, `cfValFrom` computes the continued-fraction convergent `(num, den)` over `ℤ × ℤ` by performing the very same affine steps directly on an integer pair — the empty list evaluates to the root `(1, 1)`. Defining both by structurally identical recursions is what makes the main theorem an induction with no arithmetic friction.",
+    "mathContext": "`cfValFrom true [] = (1,1)` (the root $1/1$); for a leading $R$-run, $\\mathrm{cfValFrom}\\,\\mathrm{true}\\,(n::ns) = (v_1 + n\\,v_2,\\; v_2)$ where $(v_1,v_2) = \\mathrm{cfValFrom}\\,\\mathrm{false}\\,ns$ — exactly the $R$-run shear applied to the tail's convergent.",
+    "significance": "key",
+    "relatedConcepts": ["2×2 matrix model", "convergents", "recursive definitions", "mediant"],
+    "prerequisites": ["recursion on lists", "ordered pairs"]
+  },
+  {
+    "id": "sbtoq0101-ann-main",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 108, "endLine": 141 },
+    "type": "insight",
+    "title": "Main Theorem: Label Equals Convergent",
+    "content": "`sb_runs_eq_cfVal` is the heart of the entry: the Stern–Brocot label `(sbNum, sbDen)` of a run-structured path equals the continued-fraction convergent `cfValFrom` of its run-lengths. The proof is induction on the run-length list, generalizing over the starting move `b`. The nil case lands on the shared root via `sb_root`; each cons case rewrites with the matching run-transfer lemma (R or L) and the inductive hypothesis. The takeaway is conceptual: the Stern–Brocot fold and the 2×2 matrix-product model of continued fractions are *literally the same computation*, not merely numerically equal. `sbNum_runs` and `sbDen_runs` extract the two components.",
+    "mathContext": "$\\big(\\mathrm{sbNum}(\\mathrm{runsToPathFrom}\\,b\\,qs),\\ \\mathrm{sbDen}(\\mathrm{runsToPathFrom}\\,b\\,qs)\\big) = \\mathrm{cfValFrom}\\,b\\,qs$ for all $b$ and all run-length lists $qs$.",
+    "significance": "key",
+    "relatedConcepts": ["continued-fraction convergents", "structural induction", "matrix model", "Stern–Brocot labelling"],
+    "prerequisites": ["induction on lists", "generalizing the induction hypothesis"]
+  },
+  {
+    "id": "sbtoq0101-ann-positivity",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 143, "endLine": 151 },
+    "type": "technique",
+    "title": "Positivity Transported from the Parent",
+    "content": "Both components of every convergent are strictly positive (`cfVal_fst_pos`, `cfVal_snd_pos`). Rather than re-establishing a positivity invariant for the new `cfValFrom` recursion, the proof transports the parent's `sbNum_pos` / `sbDen_pos` across the main identity `sbNum_runs` / `sbDen_runs`. This is a clean example of reusing structural work: a property proved once for the Stern–Brocot label is inherited for free by anything shown equal to it.",
+    "mathContext": "$0 < (\\mathrm{cfValFrom}\\,b\\,qs).1$ and $0 < (\\mathrm{cfValFrom}\\,b\\,qs).2$, since these equal $\\mathrm{sbNum}$ and $\\mathrm{sbDen}$ of the run-path, both already proved $\\ge 1$ in the parent.",
+    "significance": "technical",
+    "relatedConcepts": ["invariant transport", "positivity", "code reuse"],
+    "prerequisites": ["order on integers"]
+  },
+  {
+    "id": "sbtoq0101-ann-recurrence-int",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 153, "endLine": 181 },
+    "type": "insight",
+    "title": "The Continued-Fraction Recurrence over ℚ",
+    "content": "Lifting from the integer pair to the rational value `cfQFrom = num/den`, two peeling lemmas expose the continued-fraction structure: `cfQFrom_true_cons` shows that stripping a leading `R`-run of length `n` adds the integer part `n + (tail value)`, while `cfQFrom_false_cons` shows that stripping a leading `L`-run produces a reciprocal `1/(n + 1/(tail value))`. The positivity results guarantee the denominators are nonzero so `field_simp` / `add_div'` / `one_div_div` can clear them. This pairing — add then reciprocate — is the exact rhythm of the regular continued-fraction algorithm.",
+    "mathContext": "$\\mathrm{cfQ}(\\mathrm{true}, n{::}ns) = n + \\mathrm{cfQ}(\\mathrm{false}, ns)$ and $\\mathrm{cfQ}(\\mathrm{false}, n{::}ns) = \\dfrac{1}{n + \\frac{1}{\\mathrm{cfQ}(\\mathrm{true}, ns)}}$.",
+    "significance": "key",
+    "relatedConcepts": ["regular continued fractions", "reciprocals", "field_simp", "rational arithmetic"],
+    "prerequisites": ["field of rationals", "nonzero denominators"]
+  },
+  {
+    "id": "sbtoq0101-ann-two-cons",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 183, "endLine": 187 },
+    "type": "insight",
+    "title": "Two Quotients Unfold the Regular Continued Fraction",
+    "content": "`cfQFrom_two_cons` composes the two peeling lemmas into the canonical regular-continued-fraction shape `q₀ + 1/(q₁ + 1/(rest))`. This is the precise formal sense in which the run-lengths *are* the partial quotients: each pair of consecutive run-lengths contributes one integer part and one nested reciprocal, exactly as in `[q₀; q₁, q₂, …]`.",
+    "mathContext": "$\\mathrm{cfQ}(\\mathrm{true}, a_0{::}a_1{::}rest) = a_0 + \\cfrac{1}{a_1 + \\cfrac{1}{\\mathrm{cfQ}(\\mathrm{true}, rest)}}$.",
+    "significance": "key",
+    "relatedConcepts": ["partial quotients", "continued-fraction notation", "recurrence composition"],
+    "prerequisites": ["continued fractions"]
+  },
+  {
+    "id": "sbtoq0101-ann-instances",
+    "proofId": "stern-brocot-tree-oq-01-oq-01",
+    "range": { "startLine": 189, "endLine": 207 },
+    "type": "concept",
+    "title": "Concrete Witnesses: Integers and Fibonacci Ratios",
+    "content": "Two axiom-free `decide`/`norm_num` instances anchor the abstract theorems. `runs_singleton`: a single `R`-run of length `n` labels the integer `n + 1`, i.e. the trivial continued fraction `[n+1]`. `cfVal_fib` / `cfQ_fib`: the all-ones run-lengths `[1,1,1]` produce `5/3` — a consecutive Fibonacci ratio. The all-ones expansion is the slowest-converging continued fraction, and its limit is the golden ratio $\\varphi$, the 'most irrational' number; this entry exhibits the start of that sequence as a kernel-checked computation (no `native_decide`, so no `ofReduceBool` dependency).",
+    "mathContext": "$[\\,n+1\\,] = n+1$; the all-ones list of length $k$ gives the Fibonacci ratio $F_{k+2}/F_{k+1}$, here $[1,1,1] \\mapsto 5/3$, with $F_{k+2}/F_{k+1} \\to \\varphi = \\tfrac{1+\\sqrt5}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "golden ratio", "kernel decidability", "worst-case continued fractions"],
+    "prerequisites": ["Fibonacci sequence", "decidable equality"]
+  }
+]

--- a/src/data/proofs/stern-brocot-tree-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01-oq-01/meta.json
@@ -122,7 +122,7 @@
       "id": "instances",
       "title": "Concrete Instances",
       "startLine": 192,
-      "endLine": 209,
+      "endLine": 207,
       "summary": "A single R-run of length n labels the integer n+1; the all-ones run-lengths give consecutive Fibonacci ratios ([1,1,1] ↦ 5/3), all axiom-free.",
       "mathContext": "Continued fraction $[n+1]$ is the integer $n+1$ (a single $R$-run). The all-ones expansion $[1;1,1,\\dots]$ gives the Fibonacci convergents $\\to \\varphi$; here $[1,1,1] \\mapsto 5/3$."
     }


### PR DESCRIPTION
Enrichment pass for `stern-brocot-tree-oq-01-oq-01` (quality 45, 0 prior passes).

## Gap closed
The entry had **no annotations.json** — the proof page rendered with zero inline annotations. This PR adds a complete, mathematically substantive annotations file plus a small accuracy fix.

## Changes
- **annotations.json** (new): 9 annotations spanning the full 207-line Lean proof:
  - Docstring / overview (run-length ↔ partial-quotient dictionary)
  - R-run and L-run transfer lemmas, framed as dual unipotent shears
  - Path assembler `runsToPathFrom` + integer-pair convergent `cfValFrom` (2×2 matrix model)
  - Main theorem `sb_runs_eq_cfVal` (label = convergent)
  - Positivity transported from the parent's invariant
  - ℚ continued-fraction recurrence (`cfQFrom_true_cons`/`_false_cons`/`_two_cons`)
  - Concrete instances: integers $[n+1]$ and Fibonacci/golden-ratio witness $[1,1,1]\mapsto 5/3$
  - Every annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **meta.json**: fixed final section `endLine` 209 → 207 (file is 207 lines).

## Verification
- Both JSON files parse; gallery prebuild regenerated the manifest/listings and registered the entry.
- `index.ts` intentionally omitted: post-#20992 the loader uses the data-manifest + runtime fetch (not `import.meta.glob`); the parent and ~93% of entries have none.
- Axiom integrity unchanged: `verified` / `original` / 0 axioms / 0 sorries, consistent with the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)