### PR TITLE
audit: euler-totient-oq-01-oq-01-oq-01 badge original→mathlib (Tier B); clear 5 unaudited leaves

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21917,8 +21917,38 @@
       ],
       "lastAudited": "2026-06-24T17:15:24Z",
       "result": "issues-fixed"
+    },
+    "catalan-numbers-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T18:02:41Z",
+      "result": "clean"
+    },
+    "chebyshev-polynomials-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T18:02:41Z",
+      "result": "clean"
+    },
+    "euler-criterion-squares-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T18:02:41Z",
+      "result": "clean"
+    },
+    "hall-marriage-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T18:02:41Z",
+      "result": "clean"
+    },
+    "euler-totient-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T18:02:41Z",
+      "result": "issues-fixed"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T17:15:24Z"
+  "lastUpdated": "2026-06-24T18:02:41Z"
 }

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "euler-theorem"
     ],
     "proofRepoPath": "Proofs/EulerTotientOQ01OQ01OQ01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 5 never-audited research leaves (current main). Result: **4 clean, 1 issue fixed**.

### Issue fixed — euler-totient-oq-01-oq-01-oq-01 (badge `original` → `mathlib`)

The meta badged this **original**, but it is a **Tier B** Mathlib bridge:

- The file's **own docstring** states the core results are already in Mathlib: `ArithmeticFunction.carmichael_factorization`, `carmichael_pow_of_prime_ne_two` — "this file does **not** reprove them — it *cites* them."
- Two of the "headline corollaries" are **literal one-line Mathlib aliases**:
  - `pow_carmichael_eq_one := pow_carmichael a`
  - `carmichael_dvd_totient' := carmichael_dvd_totient n`
- `originalContributions` is **empty** — internally inconsistent with an `original` badge.

This is Failure Modes 1 (delegation opacity) & 5 (0-sorries with hidden imports). The genuine local content (assembling the explicit odd-`n` formula + concrete 561/15 evaluations) is real but bridge-level — `mathlib` is the correct badge. `status: verified` retained (0 sorry / 0 axiom, fully machine-checked).

### Clean (badge confirmed appropriate)

| Leaf | Tier | Note |
|------|------|------|
| catalan-numbers-oq-01-oq-01-oq-01-oq-01 | A / `original` | Generalized ballot via André reflection on the project's own parent infra |
| chebyshev-polynomials-oq-01-oq-01-oq-01 | B / `mathlib` | SL₂ packaging of parent's scalar Chebyshev identities (conservative) |
| euler-criterion-squares-oq-01-oq-01 | A / `original` | Squaring hom, kernel {1,−1}, first isomorphism theorem; `native_decide` grep hit is a docstring false-positive |
| hall-marriage-theorem-oq-01-oq-01-oq-01 | B / `mathlib` | Closed-form deficiency `#ι − δ` on parent defect theorem (conservative) |

All five: 0 sorries, 0 axioms, no real `native_decide`.

### Excluded (not real gallery proofs on main)

- `keith-number-oq-01-oq-02` — untracked working-tree pollution; meta.json + `Proofs/KeithNumberOQ01OQ02.lean` are **not on origin/main** (find-targets scans the dirty tree).
- `lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02` — a phantom: an **openQuestion id** inside `…-oq-03-oq-01`'s meta, not a proof with its own dir/Lean file.

---
Discovered during autonomous gallery integrity audit.