### PR TITLE
fix(chebyshev-sum-inequality-oq-01-oq-03): import orphaned module into Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -762,6 +762,7 @@ import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevPolynomialsOQ01OQ01OQ01
 import Proofs.ChebyshevSumMonotoneOQ01
+import Proofs.ChebyshevSumIntegralOQ0103
 import Proofs.ChebyshevSumIntegralOQ01OQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01OQ02


### PR DESCRIPTION
## Problem

PR #29238 (`chebyshev-sum-inequality-oq-01-oq-03`, merged) added the verified module `proofs/Proofs/ChebyshevSumIntegralOQ0103.lean` and its gallery data, but **omitted the root import** in `proofs/Proofs.lean`. As a result the module is orphaned — it is never compiled by the gallery/CI build (`Proofs.lean` is the build root), so the proof is effectively unverified by the project build despite the merged entry claiming `verified, 0-axiom`.

## Fix

Add the single missing line `import Proofs.ChebyshevSumIntegralOQ0103` to `proofs/Proofs.lean` in alphabetical position.

## Verification

Built the module on host against the project's Mathlib cache — compiles with no errors. Axiom check:

```
'ChebyshevIntegralMonotone.chebyshev_integral_monotoneOn' depends on axioms: [propext, Classical.choice, Quot.sound]
'ChebyshevIntegralMonotone.chebyshev_integral_antitoneOn'  depends on axioms: [propext, Classical.choice, Quot.sound]
```

i.e. 0 counted axioms — consistent with the merged entry's `axiomCount: 0` / `status: verified` claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)