### PR TITLE
research(solution-of-cubic-oq-01-oq-01-oq-02): the cubic discriminant as the resultant Res(f, f′) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3667,6 +3667,7 @@ import Proofs.SkolemNoetherMatrixAutAristotle
 import Proofs.SolutionOfCubic
 import Proofs.SolutionOfCubicOQ01
 import Proofs.SolutionOfCubicOQ01OQ01
+import Proofs.SolutionOfCubicOQ01OQ01OQ02
 import Proofs.SolutionOfCubicOQ01OQ02
 import Proofs.SolutionOfCubicOQ01OQ04
 import Proofs.SolutionOfCubicOQ03

--- a/proofs/Proofs/SolutionOfCubicOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ01OQ01OQ02.lean
@@ -1,0 +1,190 @@
+import Proofs.SolutionOfCubicOQ01OQ01
+import Mathlib.RingTheory.Polynomial.Resultant.Basic
+import Mathlib.Tactic.ComputeDegree
+
+/-!
+# The Cubic Discriminant as the Resultant `Res(f, f')` (Solution of Cubic, OQ-01-OQ-01-OQ-02)
+
+## What This Proves
+
+The parent file `SolutionOfCubicOQ01OQ01` defines the **general cubic discriminant**
+
+  `Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`
+
+as a hand-written polynomial in the four coefficients, and proves it transforms correctly
+under the Tschirnhaus shift. That entry closed with the open question:
+
+  *"Derive the discriminant as the resultant `Res(f, f')` of the cubic and its derivative,
+  matching the coefficient formula and generalizing the construction to higher degree."*
+
+This file answers exactly that, using Mathlib's general resultant theory
+(`Polynomial.resultant`, `Polynomial.discr`). For the genuine cubic
+`f = a·X³ + b·X² + c·X + d` (`a ≠ 0`) we prove the two structural identities
+
+  `f.discr = Δ(a,b,c,d)`                          (`cubic_discr_eq_generalDiscriminant`)
+  `Res(f, f') = −a · Δ(a,b,c,d)`                  (`cubic_resultant_eq_neg_smul_discriminant`)
+
+The first identifies the parent's ad-hoc polynomial with Mathlib's intrinsic, basis-free
+discriminant (the determinant of the Sylvester matrix of `f` and `f'`, normalized by a sign).
+The second is the classical relation `Res(f, f') = (−1)^{n(n−1)/2}·aₙ·Δ`, specialized to a
+cubic where `(−1)^{3·2/2} = −1` and `aₙ = a`. As a consequence the **resultant of a cubic
+with its derivative vanishes exactly when the cubic has a repeated root**
+(`cubic_resultant_eq_zero_iff`), the eliminant characterization of the discriminant.
+
+## Original Contributions
+- `cubicPoly` — the cubic `a·X³ + b·X² + c·X + d` as an honest `Polynomial ℂ`, with its
+  degree, leading coefficient, coefficient, and derivative computed
+  (`cubicPoly_natDegree`, `cubicPoly_degree`, `cubicPoly_leadingCoeff`, `cubicPoly_coeff_*`,
+  `cubicPoly_derivative`).
+- `cubic_discr_eq_generalDiscriminant` — Mathlib's intrinsic `f.discr` equals the parent's
+  `generalDiscriminant a b c d`; the bridge the open question asked for.
+- `cubic_resultant_eq_neg_smul_discriminant` — the headline: `Res(f, f') = −a·Δ`, the
+  resultant/discriminant relation for the cubic.
+- `cubic_resultant_eq_zero_iff` / `cubic_resultant_eq_zero_iff_repeated_root` — the eliminant
+  criterion: the resultant vanishes iff `Δ = 0`, i.e. iff two roots coincide (via the parent's
+  `repeated_root_iff`).
+
+## Proof Techniques
+The coefficient and degree facts are `compute_degree` / `simp`. The discriminant bridge feeds
+the computed coefficients into Mathlib's `Polynomial.discr_of_degree_eq_three` and closes with
+`ring`. The resultant identity instantiates `Polynomial.resultant_deriv` at `natDegree = 3`,
+where the sign `(−1)^{3·2/2}` collapses to `−1`. Everything is over `ℂ` (matching the parent)
+and is `0`-axiom.
+-/
+
+namespace SolutionOfCubicOQ01OQ01OQ02
+
+open Polynomial SolutionOfCubicOQ01OQ01
+
+/-! ## Part 1: The cubic as a polynomial and its invariants
+
+We realize `a·X³ + b·X² + c·X + d` as an element of `ℂ[X]` and record its coefficients,
+degree, leading coefficient and derivative. -/
+
+/-- The general cubic `a·X³ + b·X² + c·X + d` as a `Polynomial ℂ`. -/
+noncomputable def cubicPoly (a b c d : ℂ) : ℂ[X] :=
+  C a * X ^ 3 + C b * X ^ 2 + C c * X + C d
+
+@[simp] theorem cubicPoly_coeff_zero (a b c d : ℂ) : (cubicPoly a b c d).coeff 0 = d := by
+  simp [cubicPoly, coeff_X_pow]
+
+@[simp] theorem cubicPoly_coeff_one (a b c d : ℂ) : (cubicPoly a b c d).coeff 1 = c := by
+  simp [cubicPoly, coeff_X_pow]
+
+@[simp] theorem cubicPoly_coeff_two (a b c d : ℂ) : (cubicPoly a b c d).coeff 2 = b := by
+  simp [cubicPoly, coeff_X_pow]
+
+@[simp] theorem cubicPoly_coeff_three (a b c d : ℂ) : (cubicPoly a b c d).coeff 3 = a := by
+  simp [cubicPoly, coeff_X_pow]
+
+/-- For `a ≠ 0` the cubic has `natDegree = 3`. -/
+theorem cubicPoly_natDegree (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).natDegree = 3 := by
+  unfold cubicPoly
+  compute_degree!
+
+/-- For `a ≠ 0` the cubic has `degree = 3`. -/
+theorem cubicPoly_degree (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).degree = 3 := by
+  unfold cubicPoly
+  compute_degree!
+
+/-- The leading coefficient of the cubic is `a`. -/
+theorem cubicPoly_leadingCoeff (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).leadingCoeff = a := by
+  rw [leadingCoeff, cubicPoly_natDegree a b c d ha, cubicPoly_coeff_three]
+
+/-- The derivative of the cubic is `3a·X² + 2b·X + c`. -/
+theorem cubicPoly_derivative (a b c d : ℂ) :
+    (cubicPoly a b c d).derivative = C (3 * a) * X ^ 2 + C (2 * b) * X + C c := by
+  simp only [cubicPoly, derivative_add, derivative_mul, derivative_C, derivative_X_pow,
+    derivative_X, zero_mul, add_zero, zero_add, mul_one]
+  rw [C_mul, C_mul]
+  ring
+
+/-! ## Part 2: The discriminant bridge
+
+Mathlib's intrinsic discriminant `f.discr` (the normalized Sylvester determinant of `f` and
+`f'`) coincides with the parent's coefficient polynomial `generalDiscriminant`. -/
+
+/-- **The discriminant bridge.** Mathlib's intrinsic `Polynomial.discr` of the cubic equals the
+parent's general cubic discriminant `Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`. This
+identifies the parent's hand-written polynomial with the determinant of the Sylvester matrix of
+`f` and `f'`, modulo the standard sign normalization. -/
+theorem cubic_discr_eq_generalDiscriminant (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).discr = generalDiscriminant a b c d := by
+  rw [discr_of_degree_eq_three (cubicPoly_degree a b c d ha), cubicPoly_coeff_zero,
+    cubicPoly_coeff_one, cubicPoly_coeff_two, cubicPoly_coeff_three, generalDiscriminant]
+  ring
+
+/-! ## Part 3: The resultant identity
+
+The resultant of the cubic with its derivative is `−a` times the discriminant — the classical
+relation `Res(f, f') = (−1)^{n(n−1)/2}·aₙ·Δ` for `n = 3`. -/
+
+/-- **The discriminant as a resultant.** For the genuine cubic `f = a·X³ + b·X² + c·X + d`
+(`a ≠ 0`), the resultant of `f` with its derivative `f'` is
+
+  `Res(f, f') = −a · Δ(a,b,c,d)`.
+
+This is the eliminant construction of the discriminant: `Res(f, f')` is the determinant of the
+`5 × 5` Sylvester matrix of `f` and `f'`, and it equals `(−1)^{3·2/2}·a·Δ = −a·Δ`. For the
+depressed cubic (`a = 1, b = 0`) this recovers the textbook value `4p³ + 27q²`. -/
+theorem cubic_resultant_eq_neg_smul_discriminant (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).resultant (cubicPoly a b c d).derivative 3 2
+      = -a * generalDiscriminant a b c d := by
+  have hpos : 0 < (cubicPoly a b c d).degree := by
+    rw [cubicPoly_degree a b c d ha]; norm_num
+  have hdeg : (cubicPoly a b c d).natDegree = 3 := cubicPoly_natDegree a b c d ha
+  have key := resultant_deriv hpos
+  rw [hdeg, cubicPoly_leadingCoeff a b c d ha,
+    cubic_discr_eq_generalDiscriminant a b c d ha] at key
+  norm_num at key
+  rw [key]; ring
+
+/-! ## Part 4: The eliminant criterion
+
+The resultant of a cubic with its derivative vanishes iff the cubic has a repeated root. -/
+
+/-- **The eliminant criterion (discriminant form).** `Res(f, f') = 0 ⟺ Δ = 0`. Since `a ≠ 0`,
+the resultant vanishes exactly when the discriminant does. -/
+theorem cubic_resultant_eq_zero_iff (a b c d : ℂ) (ha : a ≠ 0) :
+    (cubicPoly a b c d).resultant (cubicPoly a b c d).derivative 3 2 = 0
+      ↔ generalDiscriminant a b c d = 0 := by
+  rw [cubic_resultant_eq_neg_smul_discriminant a b c d ha, mul_eq_zero, neg_eq_zero]
+  constructor
+  · rintro (h | h)
+    · exact absurd h ha
+    · exact h
+  · intro h; exact Or.inr h
+
+/-- **The eliminant criterion (root form).** For a cubic given by Vieta data on roots
+`x₁, x₂, x₃` with `a ≠ 0`, the resultant `Res(f, f')` vanishes iff two of the roots coincide.
+This is the classical meaning of the discriminant as the eliminant of `f` and `f'`. -/
+theorem cubic_resultant_eq_zero_iff_repeated_root (a x₁ x₂ x₃ b c d : ℂ) (ha : a ≠ 0)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    (cubicPoly a b c d).resultant (cubicPoly a b c d).derivative 3 2 = 0
+      ↔ (x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃) := by
+  rw [cubic_resultant_eq_zero_iff a b c d ha, repeated_root_iff a x₁ x₂ x₃ b c d ha hb hc hd]
+
+/-! ## Part 5: Sanity checks -/
+
+/-- For the depressed cubic `X³ + p·X + q` the resultant with its derivative is the textbook
+`4p³ + 27q²` (the negative of the standard discriminant `−4p³ − 27q²`). -/
+example (p q : ℂ) :
+    (cubicPoly 1 0 p q).resultant (cubicPoly 1 0 p q).derivative 3 2 = 4 * p ^ 3 + 27 * q ^ 2 := by
+  rw [cubic_resultant_eq_neg_smul_discriminant 1 0 p q one_ne_zero, generalDiscriminant]; ring
+
+/-- A perfect cube `(X − 2)³ = X³ − 6X² + 12X − 8` has a triple root, so `Res(f, f') = 0`. -/
+example : (cubicPoly 1 (-6) 12 (-8)).resultant (cubicPoly 1 (-6) 12 (-8)).derivative 3 2 = 0 := by
+  rw [cubic_resultant_eq_zero_iff 1 (-6) 12 (-8) one_ne_zero, generalDiscriminant]; norm_num
+
+end SolutionOfCubicOQ01OQ01OQ02
+
+-- Summary of key results
+#check SolutionOfCubicOQ01OQ01OQ02.cubic_discr_eq_generalDiscriminant
+#check SolutionOfCubicOQ01OQ01OQ02.cubic_resultant_eq_neg_smul_discriminant
+#check SolutionOfCubicOQ01OQ01OQ02.cubic_resultant_eq_zero_iff
+#check SolutionOfCubicOQ01OQ01OQ02.cubic_resultant_eq_zero_iff_repeated_root

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-soc-oq010102-cubicpoly",
+    "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "Realizing the Cubic as a Polynomial",
+    "body": "To apply Mathlib's intrinsic resultant and discriminant, the cubic must be an honest element of ℂ[X]: cubicPoly a b c d = C a·X³ + C b·X² + C c·X + C d. Its coefficients (a, b, c, d at degrees 3, 2, 1, 0) fall out of simp with coeff_X_pow. The degree facts use compute_degree!, which proves natDegree = 3 and degree = 3 once the leading coefficient a is known nonzero. The leading coefficient is then coeff 3 = a, and the derivative is 3a·X² + 2b·X + c (combining the C-factors with C_mul before ring)."
+  },
+  {
+    "id": "ann-soc-oq010102-discr-bridge",
+    "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 131
+    },
+    "type": "insight",
+    "title": "Two Definitions of the Discriminant Coincide",
+    "body": "cubic_discr_eq_generalDiscriminant identifies Mathlib's intrinsic Polynomial.discr — defined as the determinant of the (normalized) Sylvester matrix of f and f′, times a sign — with the parent's hand-written coefficient polynomial generalDiscriminant a b c d. Mathlib's discr_of_degree_eq_three gives discr f in terms of f.coeff 0..3; substituting the computed coefficients and calling ring matches it to 18abcd − 4b³d + b²c² − 4ac³ − 27a²d². The ad-hoc polynomial and the basis-free Sylvester determinant are the same object."
+  },
+  {
+    "id": "ann-soc-oq010102-resultant",
+    "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 142,
+      "endLine": 159
+    },
+    "type": "insight",
+    "title": "Res(f, f′) = −a·Δ",
+    "body": "The headline cubic_resultant_eq_neg_smul_discriminant specializes Mathlib's resultant_deriv, Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·discr f, to the cubic. At n = natDegree = 3 the sign exponent is 3·2/2 = 3, so (−1)³ = −1; the leading coefficient aₙ is a; and discr f is Δ by the bridge. Hence Res(f, f′) = −a·Δ(a,b,c,d). For the depressed cubic X³ + p·X + q this is the textbook 4p³ + 27q² = −(−4p³ − 27q²)."
+  },
+  {
+    "id": "ann-soc-oq010102-eliminant",
+    "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 165,
+      "endLine": 180
+    },
+    "type": "technique",
+    "title": "The Resultant as an Eliminant",
+    "body": "Because a ≠ 0, the factor −a in Res(f, f′) = −a·Δ never vanishes, so cubic_resultant_eq_zero_iff gives Res(f, f′) = 0 ⟺ Δ = 0 (mul_eq_zero plus neg_eq_zero discard the −a branch). Chaining the parent's repeated_root_iff then yields cubic_resultant_eq_zero_iff_repeated_root: for a cubic given by Vieta data on roots x₁, x₂, x₃, the resultant of f with f′ vanishes iff two of the roots coincide — the classical statement that the discriminant is the eliminant of f and its derivative."
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "solution-of-cubic-oq-01-oq-01-oq-02",
+  "title": "The Cubic Discriminant as the Resultant Res(f, f′)",
+  "slug": "solution-of-cubic-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's open question by identifying the hand-written general cubic discriminant Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² with Mathlib's intrinsic discriminant (the normalized Sylvester determinant of f and f′), and derives the eliminant relation Res(f, f′) = −a·Δ for the cubic f = a·X³ + b·X² + c·X + d. As a consequence the resultant of a cubic with its derivative vanishes exactly when two roots coincide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Definition",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ01OQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "cubic-equations",
+      "discriminant",
+      "resultant",
+      "sylvester-matrix",
+      "eliminant",
+      "polynomial-arithmetic",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Polynomial.resultant",
+      "Polynomial.discr",
+      "Polynomial.resultant_deriv",
+      "Polynomial.discr_of_degree_eq_three"
+    ],
+    "originalContributions": [
+      "cubicPoly: the general cubic a·X³ + b·X² + c·X + d realized as an element of ℂ[X], with its coefficients, degree, leading coefficient and derivative (3a·X² + 2b·X + c) all computed",
+      "cubic_discr_eq_generalDiscriminant: the bridge identifying Mathlib's intrinsic Polynomial.discr of the cubic with the parent's hand-written generalDiscriminant a b c d — connecting an ad-hoc coefficient polynomial to the determinant of the Sylvester matrix of f and f′",
+      "cubic_resultant_eq_neg_smul_discriminant: the headline Res(f, f′) = −a·Δ(a,b,c,d), the classical relation Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·Δ specialized to the cubic (n = 3, sign = −1)",
+      "cubic_resultant_eq_zero_iff / cubic_resultant_eq_zero_iff_repeated_root: the eliminant criterion — the resultant of f with f′ vanishes iff Δ = 0, i.e. iff two of the roots coincide (via the parent's Vieta repeated_root_iff)"
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "The parent's general cubic discriminant generalDiscriminant a b c d (OQ-01-OQ-01)",
+      "Mathlib's resultant/discriminant theory: Sylvester matrix, Polynomial.resultant, Polynomial.discr",
+      "The resultant–discriminant relation resultant_deriv and the cubic discriminant formula discr_of_degree_eq_three"
+    ],
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-01-oq-01",
+        "relationship": "Parent: defines generalDiscriminant and its shift identity; its open question asked to derive the discriminant as the resultant Res(f, f′) — answered here."
+      },
+      {
+        "id": "solution-of-cubic-oq-01",
+        "relationship": "Grandparent: the Tschirnhaus shift reducing the general cubic to depressed form."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 190,
+    "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries, depending only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, no Lean.ofReduceBool. The core resultant–discriminant relation is supplied by Mathlib (Polynomial.resultant_deriv, discr_of_degree_eq_three); this entry contributes the explicit cubic construction and the bridge to the parent's coefficient discriminant.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial can be defined three equivalent ways: as a^(2n−2)·∏_{i<j}(xᵢ − xⱼ)² (root form), as the explicit coefficient polynomial, or as the resultant of f with its derivative f′ — the determinant of their Sylvester matrix. The resultant route, going back to Sylvester (1851) and developed by Cayley, is the one that makes the repeated-root criterion an elimination statement: Res(f, f′) is the polynomial in the coefficients of f that vanishes exactly when f and f′ have a common root, i.e. when f has a repeated root. The parent gallery entry built the cubic discriminant as a hand-written coefficient polynomial; this entry ties it to the intrinsic, basis-free resultant construction now available in Mathlib.",
+    "problemStatement": "Realize the general cubic a·X³ + b·X² + c·X + d as a polynomial, identify the parent's coefficient discriminant Δ(a,b,c,d) with Mathlib's intrinsic Polynomial.discr (the normalized Sylvester determinant of f and f′), derive the resultant identity Res(f, f′) = −a·Δ, and characterize its vanishing as the repeated-root condition.",
+    "proofStrategy": "The coefficients and degree of cubicPoly are obtained by simp and compute_degree. The discriminant bridge cubic_discr_eq_generalDiscriminant feeds these coefficients into Mathlib's discr_of_degree_eq_three and closes with ring against the parent's generalDiscriminant. The headline cubic_resultant_eq_neg_smul_discriminant instantiates Mathlib's resultant_deriv at the cubic: its sign (−1)^{n(n−1)/2} collapses to (−1)^3 = −1 at n = 3 and its leading coefficient is a, so Res(f, f′) = −a·discr f = −a·Δ. The eliminant criteria follow from a ≠ 0 and the parent's Vieta repeated_root_iff.",
+    "keyInsights": [
+      "Mathlib's intrinsic discriminant (a normalized Sylvester determinant) agrees on the nose with the parent's hand-written coefficient polynomial Δ(a,b,c,d) — the two definitions of 'the discriminant of a cubic' coincide.",
+      "The resultant–discriminant relation Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·Δ specializes for the cubic to the clean Res(f, f′) = −a·Δ, with the sign exponent 3·2/2 = 3 forcing the minus sign.",
+      "For the depressed cubic X³ + p·X + q this recovers the textbook value Res(f, f′) = 4p³ + 27q² = −(−4p³ − 27q²).",
+      "Because a ≠ 0, the resultant vanishes iff Δ does, which by the parent's root form holds iff two of the three roots coincide — the discriminant as an eliminant."
+    ],
+    "prerequisites": [
+      "The parent's generalDiscriminant and repeated_root_iff",
+      "Mathlib's Sylvester matrix, Polynomial.resultant and Polynomial.discr",
+      "The relations resultant_deriv and discr_of_degree_eq_three"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cubic-poly",
+      "title": "Part 1: The Cubic as a Polynomial and its Invariants",
+      "startLine": 53,
+      "endLine": 116,
+      "summary": "Defines cubicPoly a b c d = C a·X³ + C b·X² + C c·X + C d and computes its coefficients (a, b, c, d), natDegree and degree (3, for a ≠ 0), leading coefficient (a), and derivative (3a·X² + 2b·X + c).",
+      "mathContext": "Realizes the cubic as an honest element of ℂ[X] so that Mathlib's resultant and discriminant apply."
+    },
+    {
+      "id": "discr-bridge",
+      "title": "Part 2: The Discriminant Bridge",
+      "startLine": 117,
+      "endLine": 132,
+      "summary": "cubic_discr_eq_generalDiscriminant: Mathlib's intrinsic Polynomial.discr of the cubic equals the parent's generalDiscriminant a b c d, via discr_of_degree_eq_three and ring.",
+      "mathContext": "Identifies the parent's hand-written coefficient discriminant with the normalized Sylvester determinant."
+    },
+    {
+      "id": "resultant-identity",
+      "title": "Part 3: The Resultant Identity",
+      "startLine": 133,
+      "endLine": 159,
+      "summary": "cubic_resultant_eq_neg_smul_discriminant: Res(f, f′) = −a·Δ, instantiating Mathlib's resultant_deriv at natDegree 3 where the sign (−1)^{3·2/2} = −1.",
+      "mathContext": "The eliminant construction of the discriminant: the resultant of f with f′ is −a times the coefficient discriminant."
+    },
+    {
+      "id": "eliminant-criterion",
+      "title": "Part 4: The Eliminant Criterion",
+      "startLine": 160,
+      "endLine": 180,
+      "summary": "cubic_resultant_eq_zero_iff: Res(f, f′) = 0 ⟺ Δ = 0; cubic_resultant_eq_zero_iff_repeated_root: for Vieta data, ⟺ two roots coincide, via the parent's repeated_root_iff.",
+      "mathContext": "The classical meaning of the discriminant as the eliminant of f and f′."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 5: Sanity Checks",
+      "startLine": 181,
+      "endLine": 190,
+      "summary": "For the depressed cubic X³ + p·X + q the resultant is 4p³ + 27q²; for (X − 2)³ the resultant vanishes (triple root).",
+      "mathContext": "Concrete confirmations of the resultant identity and the eliminant criterion."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) bridge between the parent's hand-written cubic discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² and Mathlib's intrinsic resultant/discriminant theory: Mathlib's Polynomial.discr of the cubic equals Δ, and the resultant of the cubic with its derivative is Res(f, f′) = −a·Δ. The resultant vanishes iff Δ = 0, i.e. iff two roots coincide. 190 lines, 8 theorems, 1 definition.",
+    "implications": "This answers the parent OQ-01-OQ-01's second open question: the gallery now expresses the cubic discriminant as the resultant Res(f, f′), the eliminant of f and its derivative, and ties the parent's coefficient polynomial to Mathlib's basis-free Sylvester-determinant definition. The same construction (resultant_deriv) generalizes verbatim to higher degree.",
+    "openQuestions": [
+      "Lift the bridge to a general commutative ring and a symbolic leading coefficient, expressing Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·discr for the cubic over an arbitrary base.",
+      "Carry out the analogous resultant identity for the quartic, matching the sibling general-quartic discriminant entries."
+    ]
+  },
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "imports": [
+      "Proofs.SolutionOfCubicOQ01OQ01",
+      "Mathlib.RingTheory.Polynomial.Resultant.Basic",
+      "Mathlib.Tactic.ComputeDegree"
+    ],
+    "opens": [
+      "Polynomial",
+      "SolutionOfCubicOQ01OQ01"
+    ],
+    "namespace": "SolutionOfCubicOQ01OQ01OQ02",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/SolutionOfCubicOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent proof: defines generalDiscriminant and the repeated-root criterion. Its open question asked to derive the discriminant as the resultant Res(f, f′); this entry does exactly that, reusing the parent's generalDiscriminant and repeated_root_iff."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent proof: the Tschirnhaus shift reducing the general cubic to depressed form."
+    }
+  ],
+  "references": [
+    {
+      "key": "Sy1851",
+      "citation": "Sylvester, J.J., On a remarkable discovery in the theory of canonical forms and of hyperdeterminants, Philosophical Magazine, Ser. 4, vol. 2 (1851).",
+      "type": "article"
+    },
+    {
+      "key": "CLO15",
+      "citation": "Cox, D., Little, J., O'Shea, D., Ideals, Varieties, and Algorithms, 4th ed., Springer (2015), Chapter 3: resultants and discriminants.",
+      "type": "book"
+    },
+    {
+      "key": "GKZ94",
+      "citation": "Gelfand, I.M., Kapranov, M.M., Zelevinsky, A.V., Discriminants, Resultants, and Multidimensional Determinants, Birkhäuser (1994).",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **solution-of-cubic-oq-01-oq-01**'s second open question: *derive the discriminant as the resultant Res(f, f′) of the cubic and its derivative.*

The parent defines the general cubic discriminant `Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²` as a hand-written coefficient polynomial. This leaf ties it to Mathlib's intrinsic resultant/discriminant theory and derives the eliminant relation.

## Results (over ℂ, matching the parent)

- **`cubicPoly a b c d`** — `a·X³ + b·X² + c·X + d` as an element of `ℂ[X]`, with its coefficients, `natDegree`/`degree` (= 3 for `a ≠ 0`), leading coefficient (`a`), and derivative (`3a·X² + 2b·X + c`) all computed.
- **`cubic_discr_eq_generalDiscriminant`** — Mathlib's intrinsic `Polynomial.discr` of the cubic (the normalized Sylvester determinant of `f` and `f′`) equals the parent's `generalDiscriminant a b c d`.
- **`cubic_resultant_eq_neg_smul_discriminant`** (headline) — `Res(f, f′) = −a·Δ`, the classical relation `Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·Δ` specialized to the cubic, where the sign exponent `3·2/2 = 3` forces `−1`.
- **`cubic_resultant_eq_zero_iff` / `cubic_resultant_eq_zero_iff_repeated_root`** — the eliminant criterion: `Res(f, f′) = 0 ⟺ Δ = 0 ⟺` two roots coincide (via the parent's `repeated_root_iff`).

Sanity checks confirm the depressed cubic `X³ + p·X + q` gives the textbook `Res(f, f′) = 4p³ + 27q²`, and `(X − 2)³` gives `Res(f, f′) = 0`.

## Verification

- **Status:** verified · **Badge:** mathlib · **0 sorries, 0 axioms**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (no `native_decide`, no `Lean.ofReduceBool`).
- The core resultant–discriminant relation is supplied by Mathlib (`Polynomial.resultant_deriv`, `discr_of_degree_eq_three`); this entry contributes the explicit cubic construction and the bridge to the parent's coefficient discriminant — hence the `mathlib` badge.
- 190 lines, 8 theorems, 1 definition. Built against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)