### PR TITLE
Enrich Catalan Generating Function (combinations-formula-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cfoq0201-def-C",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 39, "endLine": 41 },
+    "type": "definition",
+    "title": "The Catalan Ordinary Generating Function",
+    "content": "Defines C as the formal power series whose n-th coefficient is the n-th Catalan number, built with PowerSeries.mk over the rationals. Working over Q (rather than N) lets us subtract, divide by 2 conceptually, and run linear_combination; the series is noncomputable because PowerSeries values are infinite coefficient sequences.",
+    "mathContext": "$C(X) = \\sum_{n\\ge 0} \\mathrm{catalan}_n\\, X^n \\in \\mathbb{Q}\\llbracket X\\rrbracket$",
+    "significance": "key",
+    "relatedConcepts": ["formal power series", "ordinary generating function", "Catalan numbers"],
+    "prerequisites": ["formal power series ring", "Catalan numbers"]
+  },
+  {
+    "id": "ann-cfoq0201-coeff-C",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 43, "endLine": 45 },
+    "type": "theorem",
+    "title": "Coefficient Extraction: coeff n C = catalan n",
+    "content": "A one-line bridge lemma: unfolding the definition and applying coeff_mk shows the n-th coefficient of C is exactly catalan n. Tagging it @[simp] lets later coefficient comparisons rewrite C automatically, which is what makes the functional-equation proof close cleanly.",
+    "mathContext": "$[X^n]\\,C = \\mathrm{catalan}_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["coefficient extraction", "PowerSeries.coeff", "simp lemma"],
+    "prerequisites": ["formal power series ring"]
+  },
+  {
+    "id": "ann-cfoq0201-functional-eq",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 47, "endLine": 66 },
+    "type": "theorem",
+    "title": "Functional Equation C = 1 + X·C²",
+    "content": "The central result: the generating function satisfies a single quadratic functional equation. The proof compares coefficients (ext n, then cases n). The constant term reduces to catalan 0 = 1; for the coefficient of X^(n+1), coeff_succ_X_mul peels off the X factor and coeff_mul expands C² into the antidiagonal convolution sum, which matches Mathlib's catalan_succ' verbatim after push_cast lifts the identity from N to Q. This is the power-series incarnation of the Segner convolution recurrence.",
+    "mathContext": "$C = 1 + X\\cdot C^2$, equivalently $\\mathrm{catalan}_{n+1} = \\sum_{i+j=n}\\mathrm{catalan}_i\\,\\mathrm{catalan}_j$",
+    "significance": "critical",
+    "relatedConcepts": ["functional equation", "Segner recurrence", "convolution", "antidiagonal"],
+    "prerequisites": ["formal power series multiplication", "Catalan convolution recurrence"]
+  },
+  {
+    "id": "ann-cfoq0201-coeff-mul-bridge",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 66 },
+    "type": "technique",
+    "title": "Coefficient Comparison via coeff_mul and catalan_succ'",
+    "content": "The engine of the functional-equation proof: coeff_mul turns [X^n](C²) into a sum over the antidiagonal {(i,j) : i+j=n} of catalan_i·catalan_j, which is precisely the right-hand side of Mathlib's catalan_succ'. Because the two sums are definitionally the same shape, no reindexing is needed — push_cast handles the N→Q coercion and the goal closes by rfl. This illustrates the general principle that multiplication of generating functions is convolution of coefficient sequences.",
+    "mathContext": "$[X^n](C^2) = \\sum_{i+j=n}\\mathrm{catalan}_i\\,\\mathrm{catalan}_j$",
+    "significance": "key",
+    "relatedConcepts": ["coeff_mul", "Cauchy product", "antidiagonal sum", "push_cast"],
+    "prerequisites": ["formal power series multiplication", "Finset.antidiagonal"]
+  },
+  {
+    "id": "ann-cfoq0201-sqrt-form",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 81 },
+    "type": "theorem",
+    "title": "Square-Root Form (2·X·C − 1)² = 1 − 4·X",
+    "content": "Encodes the textbook closed form C = (1 − √(1−4x))/(2x) as a polynomial identity. Since a general power series ring has no square root, the honest statement is the quadratic the closed form solves. The proof is pure ring algebra: rearrange the functional equation to X·C² = C − 1, then a single linear_combination (4·X)·hXC2 certifies (2XC−1)² = 1−4X. Choosing the branch fixed by C(0)=catalan 0=1 selects 2XC−1 = −√(1−4X), recovering the stated formula.",
+    "mathContext": "$(2XC-1)^2 = 1-4X \\;\\Longrightarrow\\; C = \\dfrac{1-\\sqrt{1-4X}}{2X}$ (branch $C(0)=1$)",
+    "significance": "critical",
+    "relatedConcepts": ["quadratic formula", "branch selection", "closed form", "linear_combination"],
+    "prerequisites": ["commutative ring identities", "formal power series ring"]
+  },
+  {
+    "id": "ann-cfoq0201-linear-combination",
+    "proofId": "combinations-formula-oq-02-oq-01",
+    "range": { "startLine": 78, "endLine": 81 },
+    "type": "tactic",
+    "title": "linear_combination over Q[[X]]",
+    "content": "Both steps of the square-root proof are discharged by linear_combination, which certifies a goal as a ring-linear combination of hypotheses: -h rearranges the functional equation into X·C² = C − 1, and (4·X)·hXC2 verifies the squared identity. Crucially this needs no analysis or convergence — Q[[X]] is just a commutative ring, so an analytic-looking statement becomes a mechanically checkable polynomial identity.",
+    "mathContext": "$(2XC-1)^2 - (1-4X) = 4X\\,\\bigl(XC^2 - (C-1)\\bigr) = 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["linear_combination tactic", "commutative ring", "polynomial identity"],
+    "prerequisites": ["ring tactics in Lean"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02-oq-01/meta.json
@@ -32,20 +32,91 @@
     ]
   },
   "overview": {
-    "problem": "The classical Catalan generating function C(x) = (1 - sqrt(1-4x))/(2x) cannot be stated literally over a formal power series ring because the square root is not a ring operation. We formalize its exact algebraic content instead.",
-    "approach": "Define C = PowerSeries.mk (catalan) over Q. Compare coefficients to prove the functional equation C = 1 + X*C^2 directly from Mathlib's Catalan convolution catalan_succ' (the coefficient of X^(n+1) in X*C^2 is the antidiagonal convolution sum, matching catalan_succ' after a cast). Then a single algebraic substitution X*C^2 = C - 1 yields (2*X*C - 1)^2 = 1 - 4*X, which is the square-root closed form solved for C with the branch fixed by C(0) = catalan 0 = 1.",
-    "significance": "Provides the rigorous power-series statement and machine-checked proof of the Catalan generating function. Mathlib records the convolution recurrence but not the generating-function identity, so the packaging is original."
+    "historicalContext": "The generating function of the Catalan numbers is one of the oldest worked examples of the method of generating functions, going back to the very origin of the sequence. Euler (1751), in correspondence with Goldbach, was led to the Catalan numbers $1, 2, 5, 14, 42, \\ldots$ while counting the triangulations of a convex polygon, and Segner (1758) gave the convolution recurrence $C_{n+1} = \\sum_{k} C_k C_{n-k}$ that bears his name. Translating that recurrence into a power series turns it into the single quadratic equation $C = 1 + X C^2$, whose solution by the quadratic formula gives the celebrated closed form $C(x) = \\frac{1 - \\sqrt{1 - 4x}}{2x}$. This is the template for the whole subject of analytic combinatorics (Flajolet--Sedgewick): a combinatorial decomposition becomes a functional equation, and the function's analytic behaviour near its dominant singularity (here the branch point at $x = 1/4$) yields the asymptotics $C_n \\sim 4^n / (n^{3/2}\\sqrt{\\pi})$. The square root in the formula is exactly the analytic fingerprint of a tree-like (algebraic) class of objects.",
+    "problemStatement": "Prove the Catalan generating function $C(x) = \\frac{1 - \\sqrt{1 - 4x}}{2x}$. The literal closed form involves $\\sqrt{1-4x}$, which is not an operation available on a general formal power series ring, so it cannot be stated verbatim over $\\mathbb{Q}\\llbracket X\\rrbracket$. We instead formalize its exact ring-theoretic content: the two algebraic identities satisfied by the ordinary generating function $C(X) = \\sum_n \\mathrm{catalan}_n\\, X^n \\in \\mathbb{Q}\\llbracket X\\rrbracket$ from which the closed form is derived by solving a quadratic.",
+    "proofStrategy": "**Definition.** Set $C = \\mathrm{PowerSeries.mk}\\,(\\lambda n.\\ \\mathrm{catalan}\\,n)$ over $\\mathbb{Q}$, so that $\\mathrm{coeff}_n\\,C = \\mathrm{catalan}\\,n$ by `coeff_mk`.\n\n**Functional equation $C = 1 + X\\,C^2$.** Prove by comparing coefficients (`ext n`, then `cases n`). The constant term reduces to $\\mathrm{catalan}\\,0 = 1$. For the coefficient of $X^{n+1}$, `coeff_succ_X_mul` strips one factor of $X$ and `coeff_mul` expands $C^2$ as the antidiagonal convolution $\\sum_{i+j=n}\\mathrm{catalan}_i\\,\\mathrm{catalan}_j$, which is *exactly* the right-hand side of Mathlib's `catalan_succ'`; a `push_cast` from $\\mathbb{N}$ to $\\mathbb{Q}$ closes the goal by `rfl`.\n\n**Square-root form $(2XC - 1)^2 = 1 - 4X$.** This is pure ring algebra over the functional equation. Rearranging $C = 1 + XC^2$ gives $X C^2 = C - 1$; then `linear_combination (4*X) * hXC2` verifies $(2XC-1)^2 = 4X^2C^2 - 4XC + 1 = 4X(C-1) - 4XC + 1 = 1 - 4X$. Reading this as $(2XC-1)^2 = 1-4X$ and choosing the branch fixed by $C(0) = \\mathrm{catalan}\\,0 = 1$ recovers $2XC - 1 = -\\sqrt{1-4X}$, i.e. the stated closed form.",
+    "keyInsights": [
+      "A formal power series ring $R\\llbracket X\\rrbracket$ has no square-root operation, so the textbook formula $C(x) = (1-\\sqrt{1-4x})/(2x)$ is not even *expressible* verbatim. Its honest content is the pair of polynomial identities $C = 1 + XC^2$ and $(2XC-1)^2 = 1-4X$; the latter is the quadratic the closed form solves, and the branch $C(0)=1$ selects the minus sign of the root.",
+      "The functional equation is the formal-power-series shadow of the Segner convolution $C_{n+1} = \\sum_{i+j=n} C_i C_j$. Multiplication of power series turns convolution into an ordinary product, so the entire recurrence collapses to the single algebraic relation $C = 1 + XC^2$ — this is precisely why generating functions linearize combinatorial recursions.",
+      "The proof of the functional equation is a coefficient-by-coefficient comparison in which `coeff_mul` produces Mathlib's antidiagonal sum and `catalan_succ'` provides the matching identity with no reindexing — the convolution sum on the power-series side is *definitionally* the sum in the Catalan recurrence after the $\\mathbb{N}\\hookrightarrow\\mathbb{Q}$ cast.",
+      "Once the functional equation is in hand, the square-root form needs no analysis at all: it is a one-line `linear_combination` certifying a polynomial identity in the commutative ring $\\mathbb{Q}\\llbracket X\\rrbracket$. Reducing an analytic-looking statement to a ring identity is what makes the closed form machine-checkable without any notion of convergence.",
+      "Analytically, the radius of convergence $1/4$ and the asymptotics $C_n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$ are governed by the square-root branch point of $\\sqrt{1-4x}$ at $x = 1/4$. The factor $n^{-3/2}$ is the universal signature of an algebraic (square-root) singularity and is shared by all simple tree families — the formal identity proved here is the algebraic core from which that analysis departs."
+    ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Ordinary Generating Function C(X)",
+      "startLine": 39,
+      "endLine": 45,
+      "summary": "Defines C = PowerSeries.mk (fun n => (catalan n : Q)) as the ordinary generating function of the Catalan numbers over Q, and records coeff_C: the n-th coefficient of C is catalan n (immediate from coeff_mk).",
+      "mathContext": "$C(X) = \\sum_{n} \\mathrm{catalan}_n\\, X^n \\in \\mathbb{Q}\\llbracket X\\rrbracket$, with $\\mathrm{coeff}_n\\, C = \\mathrm{catalan}\\,n$."
+    },
+    {
+      "id": "functional-equation",
+      "title": "The Functional Equation C = 1 + X·C²",
+      "startLine": 47,
+      "endLine": 66,
+      "summary": "Proves the defining functional equation by coefficient comparison. The constant term gives catalan 0 = 1; the coefficient of X^(n+1) is the antidiagonal convolution produced by coeff_mul, matched verbatim to Mathlib's catalan_succ' after a push_cast from N to Q.",
+      "mathContext": "$C = 1 + X\\cdot C^2$, the power-series form of $\\mathrm{catalan}_{n+1} = \\sum_{i+j=n} \\mathrm{catalan}_i\\,\\mathrm{catalan}_j$."
+    },
+    {
+      "id": "square-root-form",
+      "title": "The Square-Root Form (2·X·C − 1)² = 1 − 4·X",
+      "startLine": 68,
+      "endLine": 83,
+      "summary": "Derives the quadratic identity solved by the closed form. Rearranging the functional equation gives X·C² = C − 1, then a single linear_combination over the ring Q[[X]] certifies (2XC−1)² = 1−4X. The branch C(0)=catalan 0=1 selects 2XC−1 = −sqrt(1−4X), i.e. C = (1−sqrt(1−4X))/(2X).",
+      "mathContext": "$(2XC-1)^2 = 1-4X$; with $C(0)=1$ this gives $C = \\dfrac{1-\\sqrt{1-4X}}{2X}$."
+    }
+  ],
   "conclusion": {
-    "summary": "The Catalan ordinary generating function C(X) = sum catalan_n X^n over Q satisfies the functional equation C = 1 + X*C^2 and the square-root form (2*X*C - 1)^2 = 1 - 4*X. Together with the constant term C(0) = 1, these encode the closed form C = (1 - sqrt(1-4X))/(2X) entirely within the formal power series ring. Verified with 0 sorries and 0 axioms.",
+    "summary": "The Catalan ordinary generating function C(X) = sum catalan_n X^n over Q satisfies the functional equation C = 1 + X*C^2 and the square-root form (2*X*C - 1)^2 = 1 - 4*X. Together with the constant term C(0) = 1, these encode the closed form C = (1 - sqrt(1-4X))/(2X) entirely within the formal power series ring, with no square-root operation required. Verified with 0 sorries and 0 axioms.",
     "implications": [
-      "The functional equation C = 1 + X*C^2 is the formal-power-series shadow of the Catalan convolution and the standard route to all Catalan asymptotics.",
-      "The square-root identity (2XC-1)^2 = 1-4X is the precise ring-theoretic meaning of the textbook closed form, avoiding any square-root operation."
+      "The functional equation C = 1 + X*C^2 is the formal-power-series shadow of the Segner/Catalan convolution and the standard entry point to all Catalan asymptotics ($C_n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$), obtained from the square-root branch point of the closed form at $x = 1/4$.",
+      "The square-root identity $(2XC-1)^2 = 1-4X$ is the precise ring-theoretic meaning of the textbook closed form, reducing an analytic-looking statement to a polynomial identity that `linear_combination` discharges with no notion of convergence.",
+      "This packaging completes the gallery's Catalan story: the parent combinations-formula-oq-02 proves the convolution recurrence catalan_succ', and this entry lifts it to the generating-function identity Mathlib does not record."
     ],
     "openQuestions": [
-      "Can a formal square root be defined on 1 - 4X in a completion or via PowerSeries inversion to recover the literal expression C = (1 - sqrt(1-4X))/(2X) as an equation of power series?",
-      "Does the same coefficient-comparison method yield the generating function 1/(1-2Xt+t^2) connections to Chebyshev/central-binomial families?"
+      "Can a formal square root be defined on 1 - 4X (via a completion or PowerSeries inversion / Newton iteration) to recover the literal expression C = (1 - sqrt(1-4X))/(2X) as an equation of power series, rather than only its squared form?",
+      "Does the same coefficient-comparison method yield the bivariate generating function 1/(1-2Xt+t^2) for the Chebyshev / central-binomial families, linking this entry to the gallery's Chebyshev-polynomial work?",
+      "Can the asymptotic C_n ~ 4^n/(n^{3/2} sqrt(pi)) be formalized from the algebraic identity via singularity analysis (transfer theorems) in Lean?"
     ]
-  }
+  },
+  "leanFile": {
+    "namespace": "CombinationsFormulaOQ02OQ01",
+    "lineCount": 83,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/CombinationsFormulaOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: defines the Catalan numbers and proves the convolution recurrence catalan_succ', whose power-series form is the functional equation proved here. This entry answers its first open question."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01",
+      "relationship": "related",
+      "description": "Proves the O(1) holonomic linear recurrence (n+2)C(n+1) = 2(2n+1)C(n); an alternative characterization of the same sequence whose generating function is studied here."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Proves the central-binomial reflection form catalan n = C(2n,n) - C(2n,n+1), the closed coefficient formula complementary to the generating-function identity."
+    },
+    {
+      "targetId": "arithmetic-series-oq-04-oq-02",
+      "relationship": "related",
+      "description": "Also formalizes generating functions as formal power series (the EGF of the Bernoulli numbers and power sums), using the same PowerSeries coefficient-comparison machinery."
+    },
+    {
+      "targetId": "ballot-problem-oq-03",
+      "relationship": "related",
+      "description": "Connects the Catalan numbers to lattice-path / ballot counting, the combinatorial source of the convolution recurrence behind the functional equation."
+    }
+  ],
+  "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-02-oq-01` — *The Catalan Generating Function as a Formal Power Series*.

## Quality improvements
- **Overview restructured to the canonical schema.** The entry previously used non-standard `overview` keys (`problem`/`approach`/`significance`) that do not render. Replaced with `historicalContext` (Euler 1751 / Segner 1758 / analytic-combinatorics framing), `problemStatement`, `proofStrategy` (step-by-step Lean account), and 5 `keyInsights`.
- **Sections** (was empty): 3 sections now cover the full 83-line Lean file — the definition of `C`, the functional equation `C = 1 + X·C²`, and the square-root form `(2XC−1)² = 1−4X` — each with `mathContext`.
- **Annotations** (new file): 6 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the definition, coefficient lemma, functional equation, the `coeff_mul`/`catalan_succ'` bridge, the square-root theorem, and the `linear_combination` tactic.
- **Cross-references** (new): parent `combinations-formula-oq-02`, plus `catalan-numbers-oq-01`, `catalan-numbers-oq-01-oq-01`, `arithmetic-series-oq-04-oq-02`, and `ballot-problem-oq-03` (all verified to exist in the gallery).
- **leanFile** metadata block added; **conclusion** implications/open questions expanded.

## Axiom integrity
Unchanged and consistent: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` — matches the Lean source (kernel-checked, no `axiom` declarations, no assumption-carrying structures).

`npm run annotations:validate` reports no errors for this entry.