### PR TITLE
audit: 5 unaudited gallery leaves ALL CLEAN (chebyshev-sum/catalan-GF/keith/triangular/cubic-discriminant)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -21947,6 +21947,36 @@
       "issues": [],
       "lastAudited": "2026-06-24T18:02:41Z",
       "result": "issues-fixed"
+    },
+    "chebyshev-sum-inequality-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T18:19:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T18:19:37Z",
+      "result": "clean",
+      "issues": []
+    },
+    "keith-number-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T18:19:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T18:19:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T18:19:38Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 5 leaves, all clean

Audited the 5 never-audited gallery entries that exist on `origin/main`. Every meta.json claim matches the Lean source.

| Slug | status/badge | Verdict |
|------|--------------|---------|
| chebyshev-sum-inequality-oq-01-oq-03 | verified/original | CLEAN — Mathlib deps are Fubini/integrability infrastructure; headline integral Chebyshev inequality genuinely constructed (Mathlib has none). 0 sorry/axiom/native_decide. |
| combinations-formula-oq-02-oq-01 | verified/original | CLEAN — Catalan generating-function power-series identities. 0 sorry/axiom. |
| keith-number-oq-01-oq-02 | verified/original | CLEAN — Keith numbers in arbitrary base; kernel `decide` (not `native_decide`) → 0-axiom. 0 sorry. |
| lagrange-four-squares-waring-g2-oq-03-oq-01-oq-02 | verified/original | CLEAN — triangular 8n+1 perfect-square test; elementary Mathlib lemmas only. 0 sorry/axiom. |
| solution-of-cubic-oq-01-oq-01-oq-02 | verified/**mathlib** | CLEAN — cubic discriminant as resultant; badge correctly downgraded to `mathlib` (core relation is Mathlib's `resultant_deriv`/`discr_of_degree_eq_three`), assumptions disclosed. 0 sorry/axiom. |

### Notes
- `native_decide`/`sorry` grep hits in keith & triangular files are **docstring prose** ("no native_decide", "No sorry, no axiom") — not real code.
- 3 other find-targets "unaudited" slugs — `cube-root-2-irrational-oq-05-oq-02`, `erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02`, `hilbert-17-oq-03-oq-06` — are **untracked researcher pollution NOT on origin/main** (`git cat-file -e origin/main:...` fails). Excluded; not falsely audited. They'll enter the queue when their PRs merge.

Coverage 3535 → 3540.

---
Discovered during periodic gallery integrity audit.