### PR TITLE
research(lhopital-oq-05-oq-01): companion cosine limit (1−cos x)/x²→1/2 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3216,6 +3216,7 @@ import Proofs.LHopitalOQ02Aristotle
 import Proofs.LHopitalOQ02Incomplete01
 import Proofs.LHopitalOQ03
 import Proofs.LHopitalOQ05
+import Proofs.LHopitalOQ05OQ01
 import Proofs.LagrangeFourSquares
 import Proofs.LagrangeFourSquaresOQ01
 import Proofs.LagrangeFourSquaresOQ01OQ01

--- a/proofs/Proofs/LHopitalOQ05OQ01.lean
+++ b/proofs/Proofs/LHopitalOQ05OQ01.lean
@@ -1,0 +1,87 @@
+import Mathlib
+
+/-
+# The Companion Cosine Limit (OQ-05 / OQ-01)
+
+    lim_{x → 0} (1 - cos x) / x² = 1/2.
+
+This is the even-order companion of the cubic sine limit `(x - sin x)/x³ → 1/6`
+(`LHopitalOQ05`). Numerator and denominator both vanish to second order at `0`,
+and the leading nonzero Taylor term of `1 - cos x` is `x²/2`, so the ratio tends
+to `1/2`.
+
+Rather than apply L'Hôpital's rule twice, we use the explicit quadratic Taylor
+bound for cosine that already lives in Mathlib,
+
+    Real.cos_bound : |x| ≤ 1 → |cos x - (1 - x²/2)| ≤ |x|⁴ · (5/96).
+
+The error term has degree `4` while we divide by `x²`, so the deviation of
+`(1 - cos x)/x²` from `1/2` is controlled *quadratically* in `x`:
+
+    |(1 - cos x)/x² - 1/2| = |cos x - (1 - x²/2)| / |x|² ≤ (5/96)·|x|².
+
+This bound holds for every `0 < |x| ≤ 1`, and `(5/96)·|x|² → 0`, so a squeeze
+delivers the limit. The hypothesis `|x| ≤ 1` is automatically met on a punctured
+neighbourhood of `0`.
+
+This mirrors the cubic sine proof exactly, with `Real.cos_bound` in place of
+`Real.sin_bound` and one fewer power of `x` divided out.
+
+Self-contained: imports only Mathlib.
+-/
+
+namespace LHopitalOQ05OQ01
+
+open Filter Topology
+
+/-- **Quadratic deviation bound.** For `0 < |x| ≤ 1`, the difference quotient
+`(1 - cos x)/x²` differs from `1/2` by at most `(5/96)·|x|²`. This is exactly the
+quadratic Taylor bound `Real.cos_bound`, divided through by `|x|²`. -/
+theorem abs_sub_le (x : ℝ) (hx0 : x ≠ 0) (hx1 : |x| ≤ 1) :
+    |(1 - Real.cos x) / x ^ 2 - 1 / 2| ≤ 5 / 96 * |x| ^ 2 := by
+  have hb : (0 : ℝ) < |x| := abs_pos.mpr hx0
+  -- Recast the deviation as `-(cos x - (1 - x²/2)) / x²`.
+  have heq : (1 - Real.cos x) / x ^ 2 - 1 / 2
+      = -(Real.cos x - (1 - x ^ 2 / 2)) / x ^ 2 := by
+    field_simp
+    ring
+  rw [heq, abs_div, abs_neg, abs_pow, div_le_iff₀ (pow_pos hb 2)]
+  calc |Real.cos x - (1 - x ^ 2 / 2)|
+      ≤ |x| ^ 4 * (5 / 96) := Real.cos_bound hx1
+    _ = 5 / 96 * |x| ^ 2 * |x| ^ 2 := by ring
+
+/-- **The companion cosine limit.** `(1 - cos x)/x² → 1/2` as `x → 0` through
+nonzero `x`. Proved by squeezing the deviation `(1 - cos x)/x² - 1/2` between `0`
+and the quadratic bound `(5/96)·|x|²` of `abs_sub_le`. -/
+theorem tendsto_cosine_quadratic :
+    Tendsto (fun x => (1 - Real.cos x) / x ^ 2) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 2)) := by
+  rw [← tendsto_sub_nhds_zero_iff]
+  apply squeeze_zero_norm' (a := fun x => 5 / 96 * |x| ^ 2)
+  · -- eventual bound: holds wherever `x ≠ 0` and `|x| ≤ 1`
+    have hmem : Metric.closedBall (0 : ℝ) 1 ∈ 𝓝[≠] (0 : ℝ) :=
+      nhdsWithin_le_nhds (Metric.closedBall_mem_nhds 0 one_pos)
+    filter_upwards [self_mem_nhdsWithin, hmem] with x hx hxball
+    rw [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+    rw [Metric.mem_closedBall, Real.dist_eq, sub_zero] at hxball
+    rw [Real.norm_eq_abs]
+    exact abs_sub_le x hx hxball
+  · -- the bound tends to `0`
+    have habs : Tendsto (fun x : ℝ => |x| ^ 2) (𝓝 (0 : ℝ)) (𝓝 0) := by
+      simpa using (continuous_abs.tendsto (0 : ℝ)).pow 2
+    have h0 : Tendsto (fun x : ℝ => 5 / 96 * |x| ^ 2) (𝓝[≠] (0 : ℝ)) (𝓝 (5 / 96 * 0)) :=
+      (habs.mono_left nhdsWithin_le_nhds).const_mul (5 / 96)
+    simpa using h0
+
+/-- The limit value `1/2` is exactly the reciprocal of `2! = 2`, i.e. the second
+Taylor coefficient of `1 - cos x`. This packaging makes explicit that the
+companion cosine limit is the order-2 Taylor statement. -/
+theorem tendsto_cosine_quadratic_factorial :
+    Tendsto (fun x => (1 - Real.cos x) / x ^ 2) (𝓝[≠] (0 : ℝ))
+      (𝓝 (1 / (Nat.factorial 2 : ℝ))) := by
+  have h := tendsto_cosine_quadratic
+  norm_num [Nat.factorial] at h ⊢
+  exact h
+
+#check @tendsto_cosine_quadratic
+
+end LHopitalOQ05OQ01

--- a/src/data/proofs/lhopital-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-05-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-deviation-bound",
+    "proofId": "lhopital-oq-05-oq-01",
+    "range": {
+      "startLine": 38,
+      "endLine": 52
+    },
+    "type": "insight",
+    "title": "Divide the Taylor Remainder by x²",
+    "content": "abs_sub_le is the quantitative heart of the limit. Mathlib's Real.cos_bound says |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the quadratic Maclaurin remainder. Rewriting the deviation as −(cos x − (1 − x²/2))/x² (field_simp; ring), then using |a/b| = |a|/|b| and |x²| = |x|², the deviation equals |cos x − (1 − x²/2)|/|x|². Dividing the degree-4 numerator bound by the degree-2 denominator leaves (5/96)·|x|²: a bound that is quadratic in x and hence visibly vanishes. No differentiation, no L'Hôpital."
+  },
+  {
+    "id": "ann-the-limit",
+    "proofId": "lhopital-oq-05-oq-01",
+    "range": {
+      "startLine": 54,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "One Squeeze Finishes It",
+    "content": "tendsto_cosine_quadratic reduces the limit-to-1/2 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|². The bound |deviation| ≤ a x of abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x|² → 0 by continuity of absolute value squared. This is the exact even-order mirror of the sibling cubic sine squeeze."
+  },
+  {
+    "id": "ann-taylor-coefficient",
+    "proofId": "lhopital-oq-05-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 85
+    },
+    "type": "insight",
+    "title": "1/2 Is the Second Taylor Coefficient",
+    "content": "tendsto_cosine_quadratic_factorial restates the limit value 1/2 as 1/2!, exposing it as the second Maclaurin coefficient of 1 − cos x. Paired with the sibling's 1/3! for x − sin x, this makes the Taylor reading explicit: each indeterminate ratio (f(x) − Tₙ₋₁(x))/xⁿ converges to the leading nonvanishing coefficient f⁽ⁿ⁾(0)/n!."
+  }
+]

--- a/src/data/proofs/lhopital-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lhopital-oq-05-oq-01/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "lhopital-oq-05-oq-01",
+  "title": "The Companion Cosine Limit: (1 − cos x)/x² → 1/2",
+  "slug": "lhopital-oq-05-oq-01",
+  "description": "Answers the cubic sine limit entry's OQ-01 — evaluate the even-order companion limit lim_{x→0} (1 − cos x)/x² = 1/2 by the same divide-the-remainder argument. Instead of applying L'Hôpital twice, the proof uses Mathlib's explicit quadratic Taylor bound Real.cos_bound (|cos x − (1 − x²/2)| ≤ |x|⁴·(5/96)). Because the error term has degree 4 while the denominator is x², the deviation of (1 − cos x)/x² from 1/2 is bounded quadratically by (5/96)·|x|², and a squeeze gives the limit. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Taylor/Maclaurin); formalized in Lean 4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ05OQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "lhopital",
+      "taylor-series",
+      "limits",
+      "trigonometry",
+      "squeeze-theorem"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 87,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "abs_sub_le: the quadratic deviation bound — for 0 < |x| ≤ 1, |(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|². This is Mathlib's quadratic Taylor bound Real.cos_bound divided through by |x|²; the degree-4 error over the degree-2 denominator leaves an O(|x|²) bound, which is the quantitative heart of the limit.",
+      "tendsto_cosine_quadratic: the headline limit (1 − cos x)/x² → 1/2 as x → 0 (through nonzero x), obtained by squeezing the deviation between 0 and the quadratic bound (5/96)·|x|² with squeeze_zero_norm'. No iterated L'Hôpital, no Mean Value Theorem.",
+      "tendsto_cosine_quadratic_factorial: the same limit with the value written as 1/2!, making explicit that 1/2 is the second Taylor coefficient of 1 − cos x."
+    ],
+    "prerequisites": [
+      "The Maclaurin expansion cos x = 1 − x²/2 + O(x⁴) and its second-order truncation error",
+      "The squeeze (sandwich) theorem for limits, in its eventual/normed form squeeze_zero_norm'",
+      "Punctured-neighbourhood limits 𝓝[≠] 0 for an expression undefined at 0",
+      "Elementary absolute-value algebra: |a/b| = |a|/|b|, |xⁿ| = |x|ⁿ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.cos_bound",
+        "description": "|x| ≤ 1 → |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96): the explicit quadratic Taylor remainder bound for cosine, the only analytic input to the whole proof.",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "squeeze_zero_norm'",
+        "description": "If ‖f x‖ ≤ a x eventually and a → 0, then f → 0. Used with a x = (5/96)·|x|² to squeeze the deviation (1 − cos x)/x² − 1/2 to 0.",
+        "module": "Mathlib.Analysis.Normed.Group.Continuity"
+      },
+      {
+        "theorem": "tendsto_sub_nhds_zero_iff",
+        "description": "Tendsto (fun x => f x − c) l (𝓝 0) ↔ Tendsto f l (𝓝 c) — reduces the limit-to-1/2 statement to a limit-to-0 statement amenable to the squeeze.",
+        "module": "Mathlib.Topology.Algebra.Order.Group"
+      },
+      {
+        "theorem": "Metric.closedBall_mem_nhds",
+        "description": "The closed ball of positive radius is a neighbourhood of its centre — supplies the eventual hypothesis |x| ≤ 1 needed by Real.cos_bound on a punctured neighbourhood of 0.",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The limit lim_{x→0} (1 − cos x)/x² = 1/2 is, together with lim_{x→0} sin x/x = 1, one of the two foundational trigonometric limits of elementary calculus — the half that captures the curvature of the cosine at the origin. It is traditionally evaluated by two applications of L'Hôpital's rule, by the half-angle identity 1 − cos x = 2 sin²(x/2), or by the Maclaurin series cos x = 1 − x²/2 + x⁴/24 − ⋯. Subtracting the quadratic Taylor polynomial leaves a fourth-order tail, so 1 − cos x = x²/2 + O(x⁴) and the ratio tends to 1/2. This entry formalizes the Taylor route in the cleanest possible way, reusing Mathlib's already-proved quadratic bound on cosine rather than differentiating twice, exactly mirroring its sibling cubic sine limit (x − sin x)/x³ → 1/6.",
+    "problemStatement": "**Open Question (parent lhopital-oq-05, OQ-01)**: evaluate the companion cosine limit lim_{x→0} (1 − cos x)/x² = 1/2 via Real.cos_bound by the same divide-the-remainder argument used for the cubic sine limit.\n\n**This entry**: proves Tendsto (fun x => (1 − cos x)/x²) (𝓝[≠] 0) (𝓝 (1/2)) with zero axioms, via the explicit quadratic Taylor bound and a squeeze, with no iterated L'Hôpital and no Mean Value Theorem.",
+    "text": "An 87-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. The engine is abs_sub_le, which divides Mathlib's quadratic Taylor bound Real.cos_bound by |x|² to get the quadratic deviation estimate |(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|² valid for 0 < |x| ≤ 1. The headline tendsto_cosine_quadratic feeds this bound — which holds eventually on 𝓝[≠] 0 since |x| ≤ 1 there — into squeeze_zero_norm', and tendsto_cosine_quadratic_factorial repackages the value 1/2 as the second Taylor coefficient 1/2!.",
+    "proofStrategy": "abs_sub_le rewrites the deviation as −(cos x − (1 − x²/2))/x² (field_simp; ring), so by abs_div, abs_neg and |x²| = |x|² the deviation equals |cos x − (1 − x²/2)|/|x|²; clearing the positive denominator (div_le_iff₀) reduces the goal to Real.cos_bound, since |x|⁴·(5/96) = (5/96)·|x|²·|x|². tendsto_cosine_quadratic rewrites the target with tendsto_sub_nhds_zero_iff to a limit-to-0, then applies squeeze_zero_norm' with bound a x = (5/96)·|x|²: the eventual hypothesis ‖deviation‖ ≤ a x holds on the punctured neighbourhood because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds), giving |x| ≤ 1, and a x → 0 because |x|² → 0 (continuity of absolute value, squared) scaled by 5/96.",
+    "keyInsights": [
+      "The whole limit is quantitative: dividing the degree-4 Taylor error |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96) by the degree-2 denominator x² leaves a bound of order |x|², which visibly vanishes — no separate L'Hôpital machinery is needed.",
+      "Reusing Mathlib's Real.cos_bound sidesteps both iterated differentiation and any explicit Taylor-with-remainder theorem; the quadratic bound already packages exactly the second-order information the limit requires.",
+      "The proof is the even-order mirror of the cubic sine limit (x − sin x)/x³ → 1/6: the same deviation lemma / squeeze skeleton, with cos_bound in place of sin_bound and one fewer power of x divided out — leaving an O(|x|²) rather than O(|x|) tail.",
+      "The hypothesis |x| ≤ 1 demanded by Real.cos_bound is free on a punctured neighbourhood of 0: the closed unit ball is a neighbourhood of 0, so the bound holds 'eventually', which is precisely what the eventual squeeze squeeze_zero_norm' consumes.",
+      "Writing the answer as 1/2! exposes the limit as the second Maclaurin coefficient of 1 − cos x, completing the Taylor-coefficient reading begun by the sibling's 1/3!."
+    ]
+  },
+  "sections": [
+    {
+      "id": "deviation-bound",
+      "title": "The Quadratic Deviation Bound",
+      "startLine": 38,
+      "endLine": 52,
+      "summary": "abs_sub_le divides the quadratic Taylor bound Real.cos_bound by |x|² to obtain |(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|² for 0 < |x| ≤ 1.",
+      "mathContext": "A degree-4 error over a degree-2 denominator yields an O(|x|²) estimate."
+    },
+    {
+      "id": "the-limit",
+      "title": "The Companion Cosine Limit via Squeeze",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "tendsto_cosine_quadratic squeezes the deviation between 0 and (5/96)·|x|² using squeeze_zero_norm', with |x| ≤ 1 supplied eventually by the closed unit ball.",
+      "mathContext": "(1 − cos x)/x² → 1/2 as x → 0 through nonzero x, no iterated L'Hôpital."
+    },
+    {
+      "id": "taylor-coefficient",
+      "title": "The Value as a Taylor Coefficient",
+      "startLine": 75,
+      "endLine": 85,
+      "summary": "tendsto_cosine_quadratic_factorial restates the limit value 1/2 as 1/2!, the second Maclaurin coefficient of 1 − cos x.",
+      "mathContext": "1/2 = 1/2! identifies the limit with the leading nonvanishing Taylor term."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the cubic sine limit entry's OQ-01 by evaluating the companion cosine limit (1 − cos x)/x² → 1/2. The proof divides Mathlib's explicit quadratic Taylor bound Real.cos_bound by |x|² to bound the deviation from 1/2 quadratically in |x|, then squeezes — with zero axioms, no iterated L'Hôpital, and no Mean Value Theorem.",
+    "implications": "Together with the sibling cubic sine limit, this entry shows the divide-the-remainder skeleton (deviation lemma + normed squeeze) is uniform across orders: the only moving parts are the Mathlib Taylor bound chosen (cos_bound vs sin_bound) and how many powers of x are divided out. The abs_sub_le lemma here is the second-order instance of a reusable pattern for any indeterminate ratio governed by a fixed-order Taylor remainder.",
+    "openQuestions": [
+      "A unified second-order remainder lemma covering both (x − sin x)/x³ → 1/6 and (1 − cos x)/x² → 1/2 as instances of a single statement about dividing a degree-(n+1) Taylor error by xⁿ.",
+      "A general order-n bound: for f with f(x) − T_{n−1}(x) = O(x^{n+1}) given by an explicit remainder estimate, prove (f(x) − T_{n−1}(x))/xⁿ → f^{(n)}(0)/n! directly, generalising abs_sub_le beyond sine and cosine."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lhopital-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry: the cubic sine limit (x − sin x)/x³ → 1/6. This entry answers its OQ-01 — the companion cosine limit (1 − cos x)/x² → 1/2 — by the identical divide-the-remainder / squeeze argument with Real.cos_bound."
+    },
+    {
+      "targetId": "lhopital",
+      "relationship": "related",
+      "description": "Root L'Hôpital entry: proves the 0/0 rule via the Mean Value Theorem. This entry evaluates one of its canonical instances along the Taylor route, bypassing iterated differentiation entirely."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "LHopitalOQ05OQ01",
+    "lineCount": 87,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "tendsto_cosine_quadratic",
+        "type": "core",
+        "description": "The companion cosine limit: (1 − cos x)/x² → 1/2 as x → 0 through nonzero x, by squeezing the deviation with the quadratic Taylor bound.",
+        "leanType": "Tendsto (fun x => (1 - Real.cos x) / x ^ 2) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 2))"
+      },
+      {
+        "name": "abs_sub_le",
+        "type": "key",
+        "description": "The quadratic deviation bound: for 0 < |x| ≤ 1, |(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|², obtained from Real.cos_bound divided by |x|².",
+        "leanType": "(x : ℝ) → x ≠ 0 → |x| ≤ 1 → |(1 - Real.cos x) / x ^ 2 - 1 / 2| ≤ 5 / 96 * |x| ^ 2"
+      }
+    ],
+    "path": "Proofs/LHopitalOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "tendsto_cosine_quadratic",
+      "type": "core",
+      "description": "(1 − cos x)/x² → 1/2 as x → 0, via the quadratic Taylor bound and a squeeze; no iterated L'Hôpital.",
+      "leanType": "Tendsto (fun x => (1 - Real.cos x) / x ^ 2) (𝓝[≠] (0 : ℝ)) (𝓝 (1 / 2))"
+    },
+    {
+      "name": "abs_sub_le",
+      "type": "key",
+      "description": "Quadratic deviation bound |(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|² for 0 < |x| ≤ 1.",
+      "leanType": "(x : ℝ) → x ≠ 0 → |x| ≤ 1 → |(1 - Real.cos x) / x ^ 2 - 1 / 2| ≤ 5 / 96 * |x| ^ 2"
+    }
+  ],
+  "references": [
+    {
+      "authors": "de l'Hôpital, Guillaume (after Johann Bernoulli)",
+      "title": "Analyse des Infiniment Petits pour l'Intelligence des Lignes Courbes",
+      "year": "1696",
+      "venue": "Paris",
+      "note": "The original publication of the rule used for such 0/0 limits"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill (3rd ed.)",
+      "note": "Taylor's theorem with remainder, the basis for the quadratic bound on cosine"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the cubic sine limit entry's (`lhopital-oq-05`) **OQ-01** — its stated open question literally asks for *"the companion cosine limit lim_{x→0} (1 − cos x)/x² = 1/2 via Real.cos_bound by the same divide-the-remainder argument."* This entry delivers exactly that.

**Result:** `Tendsto (fun x => (1 - cos x) / x²) (𝓝[≠] 0) (𝓝 (1/2))`, verified, **0 axioms**, no `native_decide`.

## Approach

The even-order mirror of the parent's cubic sine proof:

- `abs_sub_le` — the quadratic deviation bound: for `0 < |x| ≤ 1`, `|(1 − cos x)/x² − 1/2| ≤ (5/96)·|x|²`. This is Mathlib's quadratic Taylor remainder `Real.cos_bound` (`|cos x − (1 − x²/2)| ≤ |x|⁴·(5/96)`) divided through by `|x|²` — a degree-4 error over a degree-2 denominator leaves an `O(|x|²)` tail.
- `tendsto_cosine_quadratic` — the headline limit, by squeezing the deviation between `0` and `(5/96)·|x|²` with `squeeze_zero_norm'`. The hypothesis `|x| ≤ 1` is free on a punctured neighbourhood of `0` (`Metric.closedBall_mem_nhds`). No iterated L'Hôpital, no Mean Value Theorem.
- `tendsto_cosine_quadratic_factorial` — repackages `1/2` as `1/2!`, the second Maclaurin coefficient of `1 − cos x` (mirroring the sibling's `1/3!`).

## Files

- `proofs/Proofs/LHopitalOQ05OQ01.lean` (87 lines, 3 theorems, 0 def, 0 sorries, 0 axioms)
- `src/data/proofs/lhopital-oq-05-oq-01/{meta.json,annotations.json}`
- `proofs/Proofs.lean` (import)

## Verification

`#print axioms` on both headline theorems → `[propext, Classical.choice, Quot.sound]` only (the foundational three; no `sorryAx`, no `Lean.ofReduceBool`). Compiles against current Mathlib via `lake env lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)