### PR TITLE
research(niven-theorem-oq-01-oq-03): sin(2π/n) rational ⟺ n ∈ {1,2,4,12} [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3410,6 +3410,7 @@ import Proofs.NewtonInductiveStepOQ03
 import Proofs.NewtonLogConcavity
 import Proofs.NewtonPowerSumIdentitiesOQ01
 import Proofs.NivenTheorem
+import Proofs.NivenTheoremOQ01OQ03
 import Proofs.NivenTheoremOQ02
 import Proofs.NivenTheoremOQ03
 import Proofs.NthRootIrrational

--- a/proofs/Proofs/NivenTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/NivenTheoremOQ01OQ03.lean
@@ -1,0 +1,210 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+import Mathlib.NumberTheory.Niven
+import Mathlib.Tactic
+
+/-
+# Niven's Theorem for Sine at the special angles `2π/n`
+
+## What This Proves
+For every positive integer `n`,
+
+    `sin (2π/n)` is rational  ⟺  `n ∈ {1, 2, 4, 12}`,
+
+with the explicit values
+
+    n:    1     2     4     12
+    sin:  0     0     1     1/2
+
+This is the *sine* companion of the crystallographic-restriction classification
+`cos(2π/n)` rational ⟺ `n ∈ {1, 2, 3, 4, 6}` (gallery entry
+`nth-root-irrational-oq-01-oq-01`, file `NthRootIrrationalOQ01OQ01CosRational.lean`).
+The exceptional set is *different* — `{1,2,4,12}` versus `{1,2,3,4,6}` — because the
+fixed numerator `2` interacts with the period of `sin` differently from that of
+`cos`.
+
+## Approach
+The forward direction combines two ingredients:
+
+1. **Niven's restriction for sine** (`sin_niven`, restated here so the file is
+   self-contained): if `θ` is a rational multiple of `π` and `sin θ` is rational,
+   then `sin θ ∈ {0, ±1/2, ±1}`. We delegate the deep algebraic-integer step to
+   Mathlib's `Real.isIntegral_two_mul_cos_rat_mul_pi` and pass to sine through the
+   co-function identity `cos (π/2 − θ) = sin θ`, exactly as the gallery's
+   `niven-theorem-oq-02`.
+
+2. **Injectivity of `sin` on `[-π/2, π/2]`** (`Real.strictMonoOn_sin.injOn`):
+   for `n ≥ 4` the angle `2π/n` lies in `(0, π/2]`, where `sin` is strictly
+   increasing. Positivity of `sin` on `(0, π)` discards the values `0, −1/2, −1`,
+   leaving `sin(2π/n) ∈ {1/2, 1}`; injectivity then pins `2π/n = π/6` (so `n = 12`)
+   or `2π/n = π/2` (so `n = 4`).
+
+   The small cases `n = 1, 2` give `sin = 0` (rational); `n = 3` gives
+   `sin(2π/3) = √3/2`, which is irrational (the arithmetic obstruction
+   `(s:ℝ)² ≠ 3`), so `3` is correctly excluded.
+
+The reverse direction is five elementary special-angle evaluations.
+
+## Mathlib Dependencies
+- `Real.isIntegral_two_mul_cos_rat_mul_pi`, `IsIntegral.exists_int_iff_exists_rat`
+  — Niven's algebraic-integer core (via the cosine helper).
+- `Real.cos_pi_div_two_sub` — co-function identity to pass cosine ⟶ sine.
+- `Real.strictMonoOn_sin` — `sin` strictly increasing on `[-π/2, π/2]`.
+- `Real.sin_pos_of_pos_of_lt_pi` — positivity of `sin` on `(0, π)`.
+- `Real.sin_two_pi`, `Real.sin_pi`, `Real.sin_pi_div_two`, `Real.sin_pi_div_six`,
+  `Real.sin_pi_div_three`, `Real.sin_pi_sub` — special-angle values.
+- `Nat.prime_three.irrational_sqrt` — `√3` is irrational.
+
+0 axioms, 0 sorries.
+-/
+
+namespace NivenTheoremOQ01OQ03
+
+open Real
+
+/-- **Cosine Niven (helper).** If `θ` is a rational multiple of `π` and `cos θ` is
+rational, then `cos θ ∈ {0, ±1/2, ±1}`. The deep step (`2 cos θ` is an algebraic
+integer) is delegated to Mathlib. Restated from `niven-theorem-oq-01` so this file
+is self-contained. -/
+theorem cos_niven (θ : ℝ) (m n : ℤ) (hn : n ≠ 0) (hθ : θ = (m / n : ℝ) * π)
+    (hcos : ∃ r : ℚ, Real.cos θ = r) :
+    Real.cos θ = 0 ∨ Real.cos θ = 1 / 2 ∨ Real.cos θ = -1 / 2 ∨
+      Real.cos θ = 1 ∨ Real.cos θ = -1 := by
+  obtain ⟨r, hr⟩ := hcos
+  have hq : θ = ((m / n : ℚ) : ℝ) * π := by rw [hθ]; push_cast; ring
+  have hint : IsIntegral ℤ (2 * Real.cos θ) := by
+    rw [hq]; exact Real.isIntegral_two_mul_cos_rat_mul_pi (m / n)
+  obtain ⟨k, hk⟩ :=
+    hint.exists_int_iff_exists_rat.mp ⟨2 * r, by rw [hr]; push_cast; ring⟩
+  have hub : Real.cos θ ≤ 1 := Real.cos_le_one θ
+  have hlb : -1 ≤ Real.cos θ := Real.neg_one_le_cos θ
+  have hkl : -2 ≤ k := by
+    have : (-2 : ℝ) ≤ (k : ℝ) := by linarith
+    exact_mod_cast this
+  have hku : k ≤ 2 := by
+    have : (k : ℝ) ≤ 2 := by linarith
+    exact_mod_cast this
+  interval_cases k <;> push_cast at hk
+  · right; right; right; right; linarith
+  · right; right; left; linarith
+  · left; linarith
+  · right; left; linarith
+  · right; right; right; left; linarith
+
+/-- **Niven's Theorem for sine (helper).** If `θ` is a rational multiple of `π` and
+`sin θ` is rational, then `sin θ ∈ {0, ±1/2, ±1}`. Derived from `cos_niven` via the
+co-function identity `cos (π/2 − θ) = sin θ`. -/
+theorem sin_niven (θ : ℝ) (m n : ℤ) (hn : n ≠ 0) (hθ : θ = (m / n : ℝ) * π)
+    (hsin : ∃ r : ℚ, Real.sin θ = r) :
+    Real.sin θ = 0 ∨ Real.sin θ = 1 / 2 ∨ Real.sin θ = -1 / 2 ∨
+      Real.sin θ = 1 ∨ Real.sin θ = -1 := by
+  set φ := π / 2 - θ with hφ
+  have hsc : Real.cos φ = Real.sin θ := by rw [hφ, Real.cos_pi_div_two_sub]
+  have hφeq : φ = ((↑(n - 2 * m) : ℝ) / (↑(2 * n) : ℝ)) * π := by
+    rw [hφ, hθ]
+    push_cast
+    field_simp
+  have h2n : (2 * n : ℤ) ≠ 0 := mul_ne_zero (by norm_num) hn
+  have hcosrat : ∃ r : ℚ, Real.cos φ = r := by
+    obtain ⟨r, hr⟩ := hsin
+    exact ⟨r, by rw [hsc, hr]⟩
+  have hcn := cos_niven φ (n - 2 * m) (2 * n) h2n hφeq hcosrat
+  rwa [hsc] at hcn
+
+/-- No rational number squares to `3`. Arithmetic obstruction ruling out
+`sin(2π/3) = √3/2 ∈ ℚ`. -/
+private theorem no_rat_sq_eq_three (s : ℚ) : (s : ℝ) ^ 2 ≠ 3 := by
+  intro h
+  have hsqrt : Real.sqrt 3 = |(s : ℝ)| := by rw [← h, Real.sqrt_sq_eq_abs]
+  have hirr : Irrational (Real.sqrt 3) := by simpa using (Nat.prime_three.irrational_sqrt)
+  exact hirr ⟨|s|, by rw [Rat.cast_abs]; exact hsqrt.symm⟩
+
+/-- `sin(2π/3) = √3/2` is irrational; this is why `n = 3` is excluded from the
+classification (it *is* in the cosine exceptional set `{1,2,3,4,6}`). -/
+theorem sin_two_pi_div_three_irrational : ¬ ∃ r : ℚ, Real.sin (2 * π / 3) = r := by
+  rintro ⟨r, hr⟩
+  have he : (2 * π / 3) = π - π / 3 := by ring
+  rw [he, Real.sin_pi_sub, Real.sin_pi_div_three] at hr
+  -- hr : √3 / 2 = ↑r
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hval : (2 : ℝ) * (r : ℝ) = Real.sqrt 3 := by rw [← hr]; ring
+  exact no_rat_sq_eq_three (2 * r) (by push_cast; rw [hval]; exact h3)
+
+/-- **Sine crystallographic-restriction classification.** For a positive integer
+`n`, the value `sin(2π/n)` is rational iff `n ∈ {1, 2, 4, 12}`. -/
+theorem sin_two_pi_div_rational_iff {n : ℕ} (hn : 1 ≤ n) :
+    (∃ r : ℚ, Real.sin (2 * π / n) = r) ↔ (n = 1 ∨ n = 2 ∨ n = 4 ∨ n = 12) := by
+  constructor
+  · -- Forward: rationality forces `n ∈ {1,2,4,12}`.
+    intro hsin
+    rcases lt_or_ge n 4 with hlt | hge
+    · -- `n ∈ {1, 2, 3}`.
+      interval_cases n
+      · exact Or.inl rfl
+      · exact Or.inr (Or.inl rfl)
+      · -- `n = 3` is impossible: `sin(2π/3)` is irrational.
+        exfalso
+        apply sin_two_pi_div_three_irrational
+        have h3 : (2 * π / ((3 : ℕ) : ℝ)) = 2 * π / 3 := by norm_num
+        rwa [h3] at hsin
+    · -- `n ≥ 4`: the angle `2π/n ∈ (0, π/2]`.
+      obtain ⟨r, hr⟩ := hsin
+      have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+      have hπ : (0 : ℝ) < π := Real.pi_pos
+      have hθpos : 0 < 2 * π / (n : ℝ) := by positivity
+      have hnge : (4 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hge
+      have hθle : 2 * π / (n : ℝ) ≤ π / 2 := by
+        rw [div_le_iff₀ hnR]
+        nlinarith [hπ, hnge, mul_nonneg hπ.le (by linarith : (0 : ℝ) ≤ (n : ℝ) - 4)]
+      have hθltpi : 2 * π / (n : ℝ) < π := by linarith
+      have hsinpos : 0 < Real.sin (2 * π / (n : ℝ)) :=
+        Real.sin_pos_of_pos_of_lt_pi hθpos hθltpi
+      have hnz : (n : ℤ) ≠ 0 := by exact_mod_cast (by omega : n ≠ 0)
+      have hθeq : (2 * π / (n : ℝ)) = ((2 : ℤ) : ℝ) / ((n : ℤ) : ℝ) * π := by
+        push_cast; ring
+      have hmemI : (2 * π / (n : ℝ)) ∈ Set.Icc (-(π / 2)) (π / 2) :=
+        ⟨by linarith, hθle⟩
+      have hni := sin_niven (2 * π / (n : ℝ)) 2 (n : ℤ) hnz hθeq ⟨r, hr⟩
+      rcases hni with h | h | h | h | h
+      · exact absurd h (by linarith)
+      · -- `sin = 1/2` ⟹ `2π/n = π/6` ⟹ `n = 12`.
+        have h6 : Real.sin (π / 6) = 1 / 2 := Real.sin_pi_div_six
+        have heq : Real.sin (2 * π / (n : ℝ)) = Real.sin (π / 6) := by rw [h, h6]
+        have hmem6 : (π / 6) ∈ Set.Icc (-(π / 2)) (π / 2) :=
+          ⟨by linarith, by linarith⟩
+        have hxeq := Real.strictMonoOn_sin.injOn hmemI hmem6 heq
+        rw [div_eq_div_iff hnR.ne' (by norm_num : (6 : ℝ) ≠ 0)] at hxeq
+        -- hxeq : 2 * π * 6 = π * ↑n
+        have h12 : π * 12 = π * (n : ℝ) := by linarith
+        have hn12 : (12 : ℝ) = (n : ℝ) := mul_left_cancel₀ Real.pi_ne_zero h12
+        have : n = 12 := by exact_mod_cast hn12.symm
+        exact Or.inr (Or.inr (Or.inr this))
+      · exact absurd h (by linarith)
+      · -- `sin = 1` ⟹ `2π/n = π/2` ⟹ `n = 4`.
+        have h2 : Real.sin (π / 2) = 1 := Real.sin_pi_div_two
+        have heq : Real.sin (2 * π / (n : ℝ)) = Real.sin (π / 2) := by rw [h, h2]
+        have hmem2 : (π / 2) ∈ Set.Icc (-(π / 2)) (π / 2) :=
+          ⟨by linarith, le_refl _⟩
+        have hxeq := Real.strictMonoOn_sin.injOn hmemI hmem2 heq
+        rw [div_eq_div_iff hnR.ne' (by norm_num : (2 : ℝ) ≠ 0)] at hxeq
+        -- hxeq : 2 * π * 2 = π * ↑n
+        have h4 : π * 4 = π * (n : ℝ) := by linarith
+        have hn4 : (4 : ℝ) = (n : ℝ) := mul_left_cancel₀ Real.pi_ne_zero h4
+        have : n = 4 := by exact_mod_cast hn4.symm
+        exact Or.inr (Or.inr (Or.inl this))
+      · exact absurd h (by linarith)
+  · -- Reverse: explicit special-angle evaluations.
+    intro hmem
+    rcases hmem with rfl | rfl | rfl | rfl
+    · exact ⟨0, by rw [Nat.cast_one, div_one, Real.sin_two_pi]; norm_num⟩
+    · refine ⟨0, ?_⟩
+      have h : (2 * π / ((2 : ℕ) : ℝ)) = π := by push_cast; ring
+      rw [h, Real.sin_pi]; norm_num
+    · refine ⟨1, ?_⟩
+      have h : (2 * π / ((4 : ℕ) : ℝ)) = π / 2 := by push_cast; ring
+      rw [h, Real.sin_pi_div_two]; norm_num
+    · refine ⟨1 / 2, ?_⟩
+      have h : (2 * π / ((12 : ℕ) : ℝ)) = π / 6 := by push_cast; ring
+      rw [h, Real.sin_pi_div_six]; norm_num
+
+end NivenTheoremOQ01OQ03

--- a/src/data/proofs/niven-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/niven-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "niven-theorem-oq-01-oq-03",
+  "title": "Niven at 2π/n for Sine: sin(2π/n) is rational ⟺ n ∈ {1, 2, 4, 12}",
+  "slug": "niven-theorem-oq-01-oq-03",
+  "description": "The sine companion of the crystallographic-restriction classification. For a positive integer n, sin(2π/n) is rational iff n ∈ {1, 2, 4, 12}, with values 0, 0, 1, 1/2. The exceptional set differs from the cosine case {1, 2, 3, 4, 6} (nth-root-irrational-oq-01-oq-01) because the fixed numerator 2 interacts with the period of sine differently than cosine; in particular n = 3 is rational for cosine (cos(2π/3) = −1/2) but irrational for sine (sin(2π/3) = √3/2). The forward direction combines Niven's restriction sin θ ∈ {0, ±1/2, ±1} with strict monotonicity of sine on [−π/2, π/2]; the reverse direction is five special-angle evaluations. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Ivan Niven (1956); crystallographic-restriction corollary formalized in Lean 4 over Mathlib's Niven theorem (Meiburg–Broshi 2025)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Niven%27s_theorem",
+    "date": "1956",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NivenTheoremOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "algebraic-integers",
+      "trigonometry",
+      "rational-multiples-of-pi",
+      "crystallographic-restriction",
+      "diophantine"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries (only propext, Classical.choice, Quot.sound — the standard foundational axioms — appear under #print axioms). The single hypothesis is n ≥ 1 (so that 2π/n is well-defined and nonzero; without it n = 0 yields 2π/0 = 0 with sin 0 = 0 rational). The deep algebraic-integer core is cited from Mathlib via the restated cosine helper; no assumptions are introduced by that delegation.",
+    "lineCount": 210,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.isIntegral_two_mul_cos_rat_mul_pi",
+        "description": "Niven's algebraic-integer core, used through the restated cosine helper: 2·cos(q·π) is integral over ℤ for any rational q. Reached for the sine via the complementary angle φ = π/2 − θ.",
+        "module": "Mathlib.NumberTheory.Niven"
+      },
+      {
+        "theorem": "Real.cos_pi_div_two_sub",
+        "description": "The co-function identity cos(π/2 − x) = sin x, the bridge transporting the cosine restriction sin θ ∈ {0, ±1/2, ±1} to the sine via a rational multiple of π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.strictMonoOn_sin",
+        "description": "Sine is strictly increasing on [−π/2, π/2], hence injective there. For n ≥ 4 the angle 2π/n lies in (0, π/2], so the Niven value uniquely determines 2π/n = π/6 (n = 12) or π/2 (n = 4).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_pos_of_pos_of_lt_pi",
+        "description": "sin is positive on (0, π). Since 2π/n ∈ (0, π/2] ⊂ (0, π) for n ≥ 4, this discards the Niven values 0, −1/2, −1, leaving only {1/2, 1}.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.irrational_sqrt",
+        "description": "√p is irrational for prime p. Applied to p = 3 to show sin(2π/3) = √3/2 is irrational, which is why n = 3 is excluded from the sine exceptional set even though it belongs to the cosine set.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      }
+    ],
+    "originalContributions": [
+      "The sine crystallographic-restriction classification sin(2π/n) rational ⟺ n ∈ {1, 2, 4, 12}, a result not present in the gallery (which had the cosine version cos(2π/n) ⟺ n ∈ {1, 2, 3, 4, 6}) and not packaged in Mathlib",
+      "An explicit contrast theorem: sin(2π/3) = √3/2 is irrational, isolating exactly why the sine exceptional set drops n = 3 (rational for cosine) and gains n = 12",
+      "A reusable forward-direction template combining Niven's bounded value set with strict monotonicity of sine on [−π/2, π/2] and positivity on (0, π) to pin the denominator n by injectivity, avoiding any case-by-case irrationality argument for the infinitely many excluded n ≥ 5"
+    ],
+    "relatedProblems": [
+      {
+        "id": "niven-theorem-oq-01",
+        "relationship": "Direct parent — proves the general cosine classification cos θ ∈ {0, ±1/2, ±1} at rational multiples of π. This entry specializes to the angles 2π/n for the sine and resolves the resulting exceptional set."
+      },
+      {
+        "id": "niven-theorem-oq-02",
+        "relationship": "Sibling — the general sine restriction sin θ ∈ {0, ±1/2, ±1}, restated here as the helper sin_niven and then specialized to 2π/n."
+      },
+      {
+        "id": "nth-root-irrational-oq-01-oq-01",
+        "relationship": "Cosine counterpart — proves cos(2π/n) rational ⟺ n ∈ {1, 2, 3, 4, 6}. This entry is the sine analogue, highlighting the different exceptional set."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Niven's 1956 theorem classifies the rational values of cosine at rational multiples of π as exactly {0, ±1/2, ±1}. Specializing the angle to 2π/n connects the theorem to the crystallographic restriction: the n-fold rotational symmetries compatible with a lattice are exactly n ∈ {1, 2, 3, 4, 6}, the values for which cos(2π/n) (equivalently, the trace 2·cos(2π/n) of the rotation) is an integer. The sine of the same angle — the off-diagonal entry of the rotation matrix — obeys its own classification, here shown to be rational exactly for n ∈ {1, 2, 4, 12}. The difference from the cosine set is instructive: n = 3 gives the rational cosine −1/2 but the irrational sine √3/2.",
+    "problemStatement": "For a positive integer n, determine exactly when sin(2π/n) is rational. Answer: sin(2π/n) ∈ ℚ ⟺ n ∈ {1, 2, 4, 12}, with sin(2π/1) = sin(2π/2) = 0, sin(2π/4) = 1, sin(2π/12) = 1/2.",
+    "proofStrategy": "Forward (rationality ⇒ n ∈ {1,2,4,12}): for n ∈ {1,2,3} check directly — n = 1, 2 give sin = 0 (in the set), and n = 3 gives sin(2π/3) = √3/2, ruled irrational by the obstruction (s:ℝ)² ≠ 3. For n ≥ 4 the angle 2π/n lies in (0, π/2]; Niven's restriction (helper sin_niven, via the cosine core and cos(π/2 − θ) = sin θ) gives sin(2π/n) ∈ {0, ±1/2, ±1}, positivity on (0, π) cuts this to {1/2, 1}, and strict monotonicity of sine on [−π/2, π/2] forces 2π/n = π/6 (n = 12) or 2π/n = π/2 (n = 4). Reverse: five special-angle evaluations using sin 2π, sin π, sin(π/2), sin(π/6).",
+    "keyInsights": [
+      "**Bounding the angle into an injectivity window.** For n ≥ 4, 2π/n ∈ (0, π/2], where sine is strictly increasing; this turns 'which n give this sine value' from an inversion over (0, 2π] into a single injective match.",
+      "**Positivity prunes half of Niven's set instantly.** On (0, π) the sine is positive, so the candidates 0, −1/2, −1 are impossible without any further work, leaving only {1/2, 1}.",
+      "**One irrationality fact distinguishes sine from cosine.** sin(2π/3) = √3/2 is irrational while cos(2π/3) = −1/2 is rational; this single contrast is the entire reason the exceptional sets differ at n = 3.",
+      "**No per-n irrationality grind.** The infinitely many excluded n ≥ 5 are handled uniformly by injectivity — the Niven value set never contains sin(2π/n) for those n — rather than by proving each sin(2π/n) irrational separately."
+    ],
+    "prerequisites": [
+      "Niven's theorem (cosine and sine forms) and its algebraic-integer core",
+      "Strict monotonicity and positivity of sine on subintervals of [0, π]",
+      "Irrationality of √3 and elementary rational arithmetic with π"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Imports (Trigonometric.Basic/Bounds, NumberTheory.Niven, Tactic) and the module docstring stating the classification sin(2π/n) ∈ ℚ ⟺ n ∈ {1,2,4,12}, the contrast with the cosine set {1,2,3,4,6}, and the two-ingredient strategy.",
+      "mathContext": "sin(2π/n) rational ⟺ n ∈ {1, 2, 4, 12}."
+    },
+    {
+      "id": "niven-helpers",
+      "title": "Cosine and Sine Niven (restated helpers)",
+      "startLine": 68,
+      "endLine": 113,
+      "summary": "cos_niven restates the cosine classification (delegating 2·cos θ ∈ algebraic-integers to Mathlib and finishing by interval_cases); sin_niven derives sin θ ∈ {0, ±1/2, ±1} for rational multiples of π via the complementary angle φ = π/2 − θ and cos(π/2 − θ) = sin θ.",
+      "mathContext": "θ = (m/n)π, sin θ ∈ ℚ ⇒ sin θ ∈ {0, ±1/2, ±1}."
+    },
+    {
+      "id": "irrational-three",
+      "title": "sin(2π/3) = √3/2 is Irrational",
+      "startLine": 114,
+      "endLine": 133,
+      "summary": "no_rat_sq_eq_three ((s:ℝ)² ≠ 3 via irrationality of √3) and sin_two_pi_div_three_irrational, which rewrites sin(2π/3) = sin(π − π/3) = sin(π/3) = √3/2 and squares to reach the obstruction. This is the case that excludes n = 3.",
+      "mathContext": "sin(2π/3) = √3/2 ∉ ℚ."
+    },
+    {
+      "id": "classification",
+      "title": "The Classification sin(2π/n) ⟺ n ∈ {1,2,4,12}",
+      "startLine": 134,
+      "endLine": 210,
+      "summary": "sin_two_pi_div_rational_iff: forward direction splits n < 4 (interval_cases, with n = 3 discharged by the irrationality lemma) and n ≥ 4 (angle in (0, π/2]; Niven + positivity ⇒ sin ∈ {1/2, 1}; strictMonoOn_sin.injOn pins 2π/n = π/6 ⇒ n = 12 or = π/2 ⇒ n = 4). Reverse direction evaluates the five special angles.",
+      "mathContext": "n ≥ 1 ⇒ (sin(2π/n) ∈ ℚ ⟺ n ∈ {1,2,4,12})."
+    }
+  ],
+  "conclusion": {
+    "summary": "The sine analogue of the crystallographic-restriction classification is formalized in Lean 4 with zero sorries and zero axioms: sin(2π/n) is rational exactly for n ∈ {1, 2, 4, 12}. The forward direction reuses Niven's bounded value set and the strict monotonicity of sine on [−π/2, π/2], so the infinitely many excluded n are dispatched by injectivity rather than individual irrationality proofs; the only bespoke irrationality input is sin(2π/3) = √3/2.",
+    "implications": "Side by side with the cosine result cos(2π/n) ⟺ n ∈ {1, 2, 3, 4, 6}, this pins down the rationality of both entries of the standard 2π/n rotation matrix and explains the n = 3 discrepancy. The proof template — bound the angle into a monotonicity window, prune by positivity, then match by injectivity — applies to other 'rational value of a periodic special function at a/n' questions.",
+    "openQuestions": [
+      "Classify the tangent at these angles: for which n is tan(2π/n) rational (and defined), combining the tangent Niven restriction tan θ ∈ {0, ±1} with the undefined points 2π/n = π/2 (n = 4) and 3π/2?",
+      "Generalize the numerator: for fixed coprime a, characterize the set of n with sin(2aπ/n) ∈ ℚ as a function of a, identifying how the exceptional set scales with gcd conditions."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "niven-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent cosine entry. This entry specializes Niven to the angles 2π/n for the sine and resolves the exceptional set {1, 2, 4, 12}."
+    },
+    {
+      "targetId": "nth-root-irrational-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Cosine counterpart cos(2π/n) rational ⟺ n ∈ {1, 2, 3, 4, 6}; this entry is the sine analogue with the contrasting set."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/NivenTheoremOQ01OQ03.lean",
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds",
+      "Mathlib.NumberTheory.Niven",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "NivenTheoremOQ01OQ03",
+    "lineCount": 210,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/niven-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/niven-theorem-oq-01-oq-03.json
@@ -1,0 +1,56 @@
+{
+  "slug": "niven-theorem-oq-01-oq-03",
+  "title": "Niven at 2π/n for sine: sin(2π/n) rational ⟺ n ∈ {1, 2, 4, 12}",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "leaf",
+  "tags": [
+    "number-theory",
+    "trigonometry",
+    "rational-multiples-of-pi",
+    "crystallographic-restriction",
+    "niven"
+  ],
+  "path": "Proofs/NivenTheoremOQ01OQ03.lean",
+  "leanFiles": [
+    "Proofs/NivenTheoremOQ01OQ03.lean"
+  ],
+  "problemStatement": "Characterize the positive integers n for which sin(2π/n) is rational. Answer: exactly n ∈ {1, 2, 4, 12}, the sine analogue of the cosine crystallographic-restriction set {1, 2, 3, 4, 6}.",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "knowledge": {
+    "progressSummary": "COMPLETE: sin(2π/n) rational ⟺ n ∈ {1,2,4,12} proved in Lean 4, 0 axioms / 0 sorries, 210 lines, 4 theorems. PR opened.",
+    "insights": [
+      "The sine exceptional set {1,2,4,12} differs from the cosine set {1,2,3,4,6}: n=3 has rational cosine (−1/2) but irrational sine (√3/2), and the sine alone reaches n=12 (sin(2π/12)=sin(π/6)=1/2).",
+      "Forward direction needs no per-n irrationality argument: for n≥4 the angle 2π/n falls in (0,π/2], so positivity on (0,π) plus strict monotonicity of sin on [−π/2,π/2] (injectivity) pin the denominator from Niven's finite value set {0,±1/2,±1}.",
+      "sin_niven (rational multiple of π ⇒ sin θ ∈ {0,±1/2,±1}) is obtained from the cosine core by the co-function identity cos(π/2−θ)=sin θ, reusing the algebraic-integer step delegated to Mathlib.",
+      "The lone bespoke irrationality input is sin(2π/3)=√3/2, handled via the obstruction (s:ℝ)²≠3 (irrationality of √3)."
+    ],
+    "builtItems": [
+      "Proofs/NivenTheoremOQ01OQ03.lean:135 sin_two_pi_div_rational_iff — the full classification (iff over n≥1)",
+      "Proofs/NivenTheoremOQ01OQ03.lean:124 sin_two_pi_div_three_irrational — sin(2π/3)=√3/2 irrational (the n=3 exclusion)",
+      "Proofs/NivenTheoremOQ01OQ03.lean:97 sin_niven — restated sine Niven restriction via complementary angle",
+      "Proofs/NivenTheoremOQ01OQ03.lean:69 cos_niven — restated cosine Niven core"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the cosine Niven core but no packaged classification of sin(2π/n) (or cos(2π/n)) rationality by exceptional n; supplied here."
+    ],
+    "nextSteps": [
+      "Tangent at 2π/n: combine tan Niven (tan θ ∈ {0,±1}) with undefined points (n=4 gives π/2).",
+      "Numerator generalization: characterize n with sin(2aπ/n) ∈ ℚ for fixed coprime a."
+    ],
+    "markdown": ""
+  },
+  "knownResults": [],
+  "references": [
+    "Niven, I. (1956). Irrational Numbers, Carus Mathematical Monographs.",
+    "https://en.wikipedia.org/wiki/Niven%27s_theorem",
+    "https://en.wikipedia.org/wiki/Crystallographic_restriction_theorem"
+  ],
+  "relatedProofs": [
+    "niven-theorem-oq-01",
+    "niven-theorem-oq-02",
+    "nth-root-irrational-oq-01-oq-01"
+  ],
+  "currentState": "SOLVED — verified, 0-axiom, gallery entry created."
+}


### PR DESCRIPTION
## Summary

Resolves the leaf **niven-theorem-oq-01-oq-03** — the **sine** companion of the crystallographic-restriction classification. For a positive integer `n`:

> `sin(2π/n)` is rational  ⟺  `n ∈ {1, 2, 4, 12}`

with values `sin(2π/1) = sin(2π/2) = 0`, `sin(2π/4) = 1`, `sin(2π/12) = 1/2`.

The exceptional set differs from the cosine case `cos(2π/n) ⟺ n ∈ {1,2,3,4,6}` (gallery entry `nth-root-irrational-oq-01-oq-01`): `n = 3` has **rational cosine** `−1/2` but **irrational sine** `√3/2`, and the sine alone reaches `n = 12` (`sin(π/6) = 1/2`).

## Proof

- **Forward** (`sin_two_pi_div_rational_iff`, `→`): for `n ∈ {1,2,3}` checked directly (`n=3` excluded by `sin_two_pi_div_three_irrational`: `sin(2π/3) = √3/2 ∉ ℚ` via `(s:ℝ)² ≠ 3`). For `n ≥ 4`, the angle `2π/n ∈ (0, π/2]`; Niven's restriction `sin θ ∈ {0,±1/2,±1}` (helper `sin_niven`, via `cos(π/2−θ)=sin θ` and the algebraic-integer core) combined with positivity of `sin` on `(0,π)` cuts the set to `{1/2,1}`, and strict monotonicity of `sin` on `[−π/2,π/2]` (`Real.strictMonoOn_sin.injOn`) pins `2π/n = π/6` (`n=12`) or `π/2` (`n=4`). The infinitely many excluded `n ≥ 5` are dispatched by injectivity — **no per-`n` irrationality grind**.
- **Reverse**: five special-angle evaluations.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms; no `sorryAx`/`Lean.ofReduceBool`).
- Single-file `lake env lean` green against Mathlib v4.26.0.
- 4 theorems, 210 lines.

## Files

- `proofs/Proofs/NivenTheoremOQ01OQ03.lean` (new)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/niven-theorem-oq-01-oq-03/meta.json` (new gallery entry, badge `original`)
- `src/data/research/problems/niven-theorem-oq-01-oq-03.json` (new knowledge record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)