### PR TITLE
research(divisibility-by-3-oq-03-oq-02-oq-01): iterative digital root equals its closed form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -992,6 +992,7 @@ import Proofs.DivisibilityBy3OQ02OQ01
 import Proofs.DivisibilityBy3OQ02OQ01OQ01
 import Proofs.DivisibilityBy3OQ03
 import Proofs.DivisibilityBy3OQ03OQ02
+import Proofs.DivisibilityBy3OQ03OQ02OQ01
 import Proofs.DivisibilityBy3OQ04
 import Proofs.DivisibilityBy3OQ04OQ02
 import Proofs.DivisibilityByThreeOQ01

--- a/proofs/Proofs/DivisibilityBy3OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ03OQ02OQ01.lean
@@ -1,0 +1,203 @@
+import Mathlib
+
+/-
+# Iterative Digital Root and its Closed Form (OQ-03-OQ-02-OQ-01)
+
+## Open Question
+
+The parent entry (`divisibility-by-3-oq-03-oq-02`) defined the base-`b` digital
+root by the *closed form*
+
+    dr_b(n) = 1 + ((n - 1) mod (b - 1))   for n > 0,   dr_b(0) = 0.
+
+This leaf formalizes the **iterative** digital root — the schoolbook process of
+repeatedly replacing `n` by the sum of its base-`b` digits until a single digit
+remains — and proves the two definitions coincide for every base `b ≥ 2`.
+
+## Main results (all 0-axiom, `sorry`-free, kernel-checked)
+
+* `digitSum_lt`             : for `2 ≤ b ≤ n`, `(digits b n).sum < n`.
+                             This strict drop is exactly the termination measure.
+* `digitalRootIter`         : the iterative digital root, by well-founded recursion.
+* `digitalRootIter_of_lt`   / `digitalRootIter_of_ge` : the defining equations.
+* `digitalRootIter_modEq`   : `digitalRootIter b n ≡ n [MOD b-1]`.
+* `digitalRootIter_lt_base` : the iterate really is a single digit (`< b`).
+* `digitalRootIter_eq_base` : **headline** — `digitalRootIter b n = digitalRootBase b n`.
+* `digitalRootIter_ten`     : the familiar base-10 specialization.
+
+## Proof strategy
+
+The only nontrivial ingredient is the strict bound `digitSum_lt`.  Writing the
+one-step digit-sum recursion `(digits b n).sum = n % b + (digits b (n/b)).sum`
+and bounding the tail by `digit_sum_le`, we get
+`(digits b n).sum ≤ n % b + n / b`, which is `< n` precisely because
+`(b-1)·(n/b) ≥ 1` when `b ≥ 2 ≤ n`.  This both justifies the well-founded
+definition and drives the strong-induction proof of the headline: a single
+digit-sum step is congruent mod `b-1` (`Nat.modEq_digits_sum`) and keeps the
+value positive (`getLast_digit_ne_zero`), and `digitalRootBase` depends only on
+the residue mod `b-1`, so the iterate and the closed form agree.
+
+This file is self-contained: it re-states the closed form `digitalRootBase`
+(the parent's own file is unchanged) so the equivalence is proved against an
+explicit definition.
+-/
+
+namespace DivisibilityBy3OQ03OQ02OQ01
+
+open Nat
+
+/-! ## Part I: Strict digit-sum bound (termination measure) -/
+
+/-- For `2 ≤ b ≤ n`, the base-`b` digit sum strictly decreases: `(digits b n).sum < n`.
+    This is the termination measure for the iterative digital root: the leading
+    place value `b^k ≥ b > 1` forces a strict loss when collapsing to the digit sum. -/
+theorem digitSum_lt (b n : ℕ) (hb : 2 ≤ b) (hn : b ≤ n) :
+    (Nat.digits b n).sum < n := by
+  have hb1 : 1 < b := hb
+  have hn0 : 0 < n := lt_of_lt_of_le (by omega) hn
+  have hsum : (Nat.digits b n).sum = n % b + (Nat.digits b (n / b)).sum := by
+    rw [Nat.digits_def' hb1 hn0, List.sum_cons]
+  have htail : (Nat.digits b (n / b)).sum ≤ n / b := Nat.digit_sum_le b (n / b)
+  have hdm : b * (n / b) + n % b = n := Nat.div_add_mod n b
+  have hqpos : 0 < n / b := Nat.div_pos hn (by omega)
+  have hmul : 2 * (n / b) ≤ b * (n / b) := Nat.mul_le_mul hb (Nat.le_refl _)
+  omega
+
+/-! ## Part II: The iterative digital root -/
+
+/-- The **iterative digital root** in base `b`: repeatedly replace `n` by the sum
+    of its base-`b` digits until the value is a single digit (`< b`).  Defined by
+    well-founded recursion on `n`; `digitSum_lt` supplies the decreasing measure.
+    For the degenerate bases `b < 2` (where digit sums do not decrease) the
+    function simply returns `n`. -/
+def digitalRootIter (b n : ℕ) : ℕ :=
+  if h : 2 ≤ b ∧ b ≤ n then
+    digitalRootIter b (Nat.digits b n).sum
+  else
+    n
+termination_by n
+decreasing_by exact digitSum_lt b n h.1 h.2
+
+/-- Below the base, the iterate is the identity (single-digit fixed point). -/
+theorem digitalRootIter_of_lt (b n : ℕ) (h : n < b) : digitalRootIter b n = n := by
+  rw [digitalRootIter]
+  exact dif_neg (by rintro ⟨_, hbn⟩; omega)
+
+/-- One unfolding step of the iteration, valid when `n` is not yet a single digit. -/
+theorem digitalRootIter_of_ge (b n : ℕ) (hb : 2 ≤ b) (hn : b ≤ n) :
+    digitalRootIter b n = digitalRootIter b (Nat.digits b n).sum := by
+  rw [digitalRootIter]
+  exact dif_pos ⟨hb, hn⟩
+
+/-! ## Part III: Invariants of one digit-sum step -/
+
+/-- For `b ≥ 3`, `b ≡ 1 (mod b-1)`. -/
+private lemma base_mod_pred (b : ℕ) (hb : 3 ≤ b) : b % (b - 1) = 1 := by
+  rw [Nat.mod_eq_sub_mod (by omega), show b - (b - 1) = 1 from by omega]
+  exact Nat.mod_eq_of_lt (by omega)
+
+/-- A single digit-sum step preserves the residue mod `b-1`. -/
+theorem sumDigits_modEq (b n : ℕ) (hb : 2 ≤ b) :
+    (Nat.digits b n).sum ≡ n [MOD (b - 1)] := by
+  rcases Nat.lt_or_ge b 3 with h | h
+  · -- `b = 2`: the modulus is `b - 1 = 1`, so everything is congruent.
+    have hb1 : b - 1 = 1 := by omega
+    rw [hb1]; exact Nat.modEq_one
+  · exact (Nat.modEq_digits_sum (b - 1) b (base_mod_pred b h) n).symm
+
+/-- The digit sum of a positive number is positive (the leading digit is nonzero). -/
+theorem sumDigits_pos (b n : ℕ) (hn : 0 < n) : 0 < (Nat.digits b n).sum := by
+  have hne : Nat.digits b n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr (by omega)
+  have hmem : (Nat.digits b n).getLast hne ∈ Nat.digits b n := List.getLast_mem hne
+  have hne0 : (Nat.digits b n).getLast hne ≠ 0 := Nat.getLast_digit_ne_zero b (by omega)
+  have hle : (Nat.digits b n).getLast hne ≤ (Nat.digits b n).sum := List.le_sum_of_mem hmem
+  omega
+
+/-! ## Part IV: The closed form and the equivalence -/
+
+/-- Closed form of the base-`b` digital root (re-stated from the parent entry
+    `divisibility-by-3-oq-03-oq-02`). -/
+def digitalRootBase (b n : ℕ) : ℕ :=
+  if n = 0 then 0 else 1 + (n - 1) % (b - 1)
+
+@[simp] theorem digitalRootBase_zero (b : ℕ) : digitalRootBase b 0 = 0 := rfl
+
+/-- For a single digit `n < b` (with `b ≥ 2`), the closed form is the identity. -/
+theorem digitalRootBase_of_lt (b n : ℕ) (hb : 2 ≤ b) (h : n < b) :
+    digitalRootBase b n = n := by
+  rcases Nat.eq_zero_or_pos n with rfl | hpos
+  · simp
+  · unfold digitalRootBase
+    rw [if_neg (by omega)]
+    have hmod : (n - 1) % (b - 1) = n - 1 := Nat.mod_eq_of_lt (by omega)
+    omega
+
+/-- The closed form depends only on the residue mod `b-1` (for positive inputs). -/
+theorem digitalRootBase_modEq_eq (b m n : ℕ) (hm : 0 < m) (hn : 0 < n)
+    (h : m ≡ n [MOD (b - 1)]) : digitalRootBase b m = digitalRootBase b n := by
+  unfold digitalRootBase
+  rw [if_neg (by omega), if_neg (by omega)]
+  congr 1
+  obtain ⟨m', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : m ≠ 0)
+  obtain ⟨n', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+  simp only [Nat.succ_sub_one]
+  exact Nat.ModEq.add_right_cancel' 1 h
+
+/-- The iterate is congruent to its input mod `b-1`. -/
+theorem digitalRootIter_modEq (b n : ℕ) (hb : 2 ≤ b) :
+    digitalRootIter b n ≡ n [MOD (b - 1)] := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases lt_or_ge n b with hlt | hge
+    · rw [digitalRootIter_of_lt b n hlt]
+    · rw [digitalRootIter_of_ge b n hb hge]
+      have hlt : (Nat.digits b n).sum < n := digitSum_lt b n hb hge
+      exact (ih _ hlt).trans (sumDigits_modEq b n hb)
+
+/-- **Headline.** The iterative digital root equals the closed form for every
+    base `b ≥ 2`: the schoolbook "keep summing digits" process computes
+    `1 + ((n-1) mod (b-1))`. -/
+theorem digitalRootIter_eq_base (b n : ℕ) (hb : 2 ≤ b) :
+    digitalRootIter b n = digitalRootBase b n := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases lt_or_ge n b with hlt | hge
+    · rw [digitalRootIter_of_lt b n hlt, digitalRootBase_of_lt b n hb hlt]
+    · rw [digitalRootIter_of_ge b n hb hge]
+      have hlt : (Nat.digits b n).sum < n := digitSum_lt b n hb hge
+      have hn0 : 0 < n := lt_of_lt_of_le (by omega) hge
+      have hS0 : 0 < (Nat.digits b n).sum := sumDigits_pos b n hn0
+      rw [ih _ hlt]
+      exact digitalRootBase_modEq_eq b _ n hS0 hn0 (sumDigits_modEq b n hb)
+
+/-- The iterative digital root is a single base-`b` digit. -/
+theorem digitalRootIter_lt_base (b n : ℕ) (hb : 2 ≤ b) : digitalRootIter b n < b := by
+  rw [digitalRootIter_eq_base b n hb]
+  unfold digitalRootBase
+  rcases Nat.eq_zero_or_pos n with rfl | hpos
+  · simp; omega
+  · rw [if_neg (by omega)]
+    have hmod : (n - 1) % (b - 1) < b - 1 := Nat.mod_lt _ (by omega)
+    omega
+
+/-! ## Part V: The decimal specialization -/
+
+/-- Base-10 instance: the familiar decimal digital root. -/
+theorem digitalRootIter_ten (n : ℕ) : digitalRootIter 10 n = digitalRootBase 10 n :=
+  digitalRootIter_eq_base 10 n (by norm_num)
+
+/-- Worked decimal example: `1 + 2 + 3 + 4 + 5 = 15 → 1 + 5 = 6`. -/
+theorem digitalRootIter_ten_12345 : digitalRootIter 10 12345 = 6 := by
+  rw [digitalRootIter_ten]; decide
+
+/-- A multiple of `9` has decimal digital root `9` (the casting-out-nines law). -/
+theorem digitalRootIter_ten_nine_mul (k : ℕ) (hk : 0 < k) :
+    digitalRootIter 10 (9 * k) = 9 := by
+  rw [digitalRootIter_ten]
+  have hmod : (9 * k) ≡ 9 [MOD (10 - 1)] := by
+    show (9 * k) % (10 - 1) = 9 % (10 - 1)
+    simp [Nat.mul_mod_right]
+  rw [digitalRootBase_modEq_eq 10 (9 * k) 9 (by positivity) (by norm_num) hmod]
+  decide
+
+end DivisibilityBy3OQ03OQ02OQ01

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,105 @@
+[
+  {
+    "id": "ann-digitsum-lt",
+    "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 66 },
+    "type": "technique",
+    "title": "Strict Digit-Sum Drop (Termination Measure)",
+    "content": "For $2 \\le b \\le n$, the base-$b$ digit sum strictly decreases: $(\\text{digits}_b\\,n).\\text{sum} < n$. The proof uses the one-step recursion $(\\text{digits}_b\\,n).\\text{sum} = n \\bmod b + (\\text{digits}_b\\,\\lfloor n/b\\rfloor).\\text{sum}$, bounds the tail by Mathlib's `Nat.digit_sum_le`, and finishes with `omega` once it knows $2\\cdot\\lfloor n/b\\rfloor \\le b\\cdot\\lfloor n/b\\rfloor$ and $\\lfloor n/b\\rfloor \\ge 1$. This single inequality is reused twice: as the well-founded measure for the iterative definition and as the descent step in the equivalence proof.",
+    "mathContext": "$(\\text{digits}_b\\,n).\\text{sum} \\le n\\bmod b + \\lfloor n/b\\rfloor < n$ because $n = b\\lfloor n/b\\rfloor + n\\bmod b$ and $(b-1)\\lfloor n/b\\rfloor \\ge 1$ when $b \\ge 2$ and $\\lfloor n/b\\rfloor \\ge 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.digit_sum_le",
+      "Nat.digits_def'",
+      "Nat.div_add_mod",
+      "omega"
+    ],
+    "relatedConcepts": [
+      "well-founded recursion",
+      "termination measures",
+      "positional number systems"
+    ]
+  },
+  {
+    "id": "ann-digitalrootiter-def",
+    "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 90 },
+    "type": "definition",
+    "title": "The Iterative Digital Root",
+    "content": "`digitalRootIter b n` formalizes the schoolbook process: if $n$ is already a single digit ($n < b$) return it, otherwise recurse on the digit sum. It is defined by well-founded recursion on $n$, with `digitSum_lt` discharging the `decreasing_by` obligation. The degenerate bases $b < 2$ (where digit sums never shrink) are guarded so the function stays total. The defining equations `digitalRootIter_of_lt` and `digitalRootIter_of_ge` expose the recursion for downstream proofs.",
+    "mathContext": "$\\mathrm{dr}^{\\text{iter}}_b(n) = n$ if $n<b$, else $\\mathrm{dr}^{\\text{iter}}_b\\big((\\text{digits}_b\\,n).\\text{sum}\\big)$.",
+    "significance": "key",
+    "prerequisites": [
+      "well-founded recursion",
+      "termination_by / decreasing_by",
+      "dite"
+    ],
+    "relatedConcepts": [
+      "digital root algorithm",
+      "fixed-point iteration",
+      "total functions"
+    ]
+  },
+  {
+    "id": "ann-digitalrootbase-modeq",
+    "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
+    "range": { "startLine": 136, "endLine": 145 },
+    "type": "lemma",
+    "title": "Closed Form Depends Only on the Residue mod (b-1)",
+    "content": "`digitalRootBase_modEq_eq`: if $m, n > 0$ and $m \\equiv n \\pmod{b-1}$ then $\\mathrm{dr}_b(m) = \\mathrm{dr}_b(n)$. The proof peels a successor off each positive input and cancels it with `Nat.ModEq.add_right_cancel'`, reducing $m \\equiv n$ to $(m-1) \\equiv (n-1)$ and hence $(m-1)\\bmod(b-1) = (n-1)\\bmod(b-1)$. This is the bridge that lets a residue-preserving digit-sum step leave the closed form unchanged.",
+    "mathContext": "$\\mathrm{dr}_b(n) = 1 + ((n-1)\\bmod(b-1))$ for $n>0$, so equal residues mod $b-1$ force equal digital roots.",
+    "significance": "important",
+    "prerequisites": [
+      "Nat.ModEq",
+      "Nat.ModEq.add_right_cancel'",
+      "Nat.exists_eq_succ_of_ne_zero"
+    ],
+    "relatedConcepts": [
+      "casting out nines",
+      "modular invariants",
+      "residue classes"
+    ]
+  },
+  {
+    "id": "ann-digitalrootiter-eq-base",
+    "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
+    "range": { "startLine": 160, "endLine": 172 },
+    "type": "theorem",
+    "title": "Headline: Iterative Process Equals the Closed Form",
+    "content": "`digitalRootIter_eq_base`: for every base $b \\ge 2$, the iterative digital root equals the closed form $1 + ((n-1)\\bmod(b-1))$. Proved by strong induction on $n$. Single-digit $n$ matches `digitalRootBase_of_lt`. For $n \\ge b$, one step recurses to the digit sum $S < n$ (so the induction hypothesis applies), and `digitalRootBase_modEq_eq` shows $\\mathrm{dr}_b(S) = \\mathrm{dr}_b(n)$ because $S \\equiv n \\pmod{b-1}$ (residue invariant) and $S > 0$ (digit-sum positivity). This is the precise statement that the informal 'keep summing digits' algorithm computes the digital root.",
+    "mathContext": "$\\mathrm{dr}^{\\text{iter}}_b(n) = \\mathrm{dr}_b(n) = 1 + ((n-1)\\bmod(b-1))$ for all $n$ when $b \\ge 2$.",
+    "significance": "key",
+    "prerequisites": [
+      "Nat.strong_induction_on",
+      "digitSum_lt",
+      "sumDigits_modEq",
+      "sumDigits_pos",
+      "digitalRootBase_modEq_eq"
+    ],
+    "relatedConcepts": [
+      "digital root",
+      "strong induction",
+      "algorithm verification"
+    ]
+  },
+  {
+    "id": "ann-casting-out-nines",
+    "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
+    "range": { "startLine": 194, "endLine": 203 },
+    "type": "theorem",
+    "title": "Casting Out Nines (Base-10 Specialization)",
+    "content": "`digitalRootIter_ten_nine_mul`: every positive multiple of $9$ has decimal digital root $9$. Since $9k \\equiv 9 \\pmod 9$ with both positive, `digitalRootBase_modEq_eq` collapses $\\mathrm{dr}_{10}(9k)$ to $\\mathrm{dr}_{10}(9) = 9$. Together with `digitalRootIter_ten` and the worked example `digitalRootIter_ten_12345` (= 6), this recovers the familiar casting-out-nines test as the $b = 10$ instance of the general theorem.",
+    "mathContext": "$9 \\mid n \\iff \\mathrm{dr}_{10}(n) = 9$ for $n > 0$; the digital root mod $9$ equals $n \\bmod 9$ shifted into $\\{1,\\dots,9\\}$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "digitalRootBase_modEq_eq",
+      "Nat.mul_mod_right",
+      "digitalRootIter_ten"
+    ],
+    "relatedConcepts": [
+      "casting out nines",
+      "divisibility by 9",
+      "decimal digital root"
+    ]
+  }
+]

--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,120 @@
+{
+  "id": "divisibility-by-3-oq-03-oq-02-oq-01",
+  "slug": "divisibility-by-3-oq-03-oq-02-oq-01",
+  "title": "The Iterative Digital Root Equals its Closed Form",
+  "parent": "divisibility-by-3-oq-03-oq-02",
+  "openQuestion": "Can Lean 4 formalize the iterative digital root (repeatedly sum the base-b digits until a single digit remains) and prove that it computes the closed form dr_b(n) = 1 + ((n-1) mod (b-1))?",
+  "significance": "The parent entry defined the base-b digital root only by its closed form dr_b(n) = 1 + ((n-1) mod (b-1)). This leaf supplies the missing half: a faithful formalization of the actual schoolbook *process* — keep replacing n by the sum of its base-b digits until one digit is left — together with a machine-checked proof that the process always terminates and computes exactly that closed form, for every base b >= 2. The crux is the strict bound (digits b n).sum < n for n >= b, which is both the well-founded termination measure for the iterative definition and the engine of the strong-induction equivalence proof. The result turns the informal 'digital root algorithm' into a verified function and recovers casting out nines (base 10) as the b = 10 instance.",
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "sorries": 0,
+  "overview": "We define digitalRootIter b n by well-founded recursion: if n is already a single digit (n < b) return n, otherwise recurse on the digit sum. Termination is justified by digitSum_lt: for 2 <= b <= n the base-b digit sum strictly decreases. We then prove the headline digitalRootIter_eq_base: digitalRootIter b n = digitalRootBase b n for all b >= 2, by strong induction. Each digit-sum step preserves the residue mod (b-1) (sumDigits_modEq, from Mathlib's Nat.modEq_digits_sum) and keeps the value positive (sumDigits_pos, from getLast_digit_ne_zero), while the closed form depends only on that residue (digitalRootBase_modEq_eq). Corollaries: the iterate is always a single digit (digitalRootIter_lt_base), is congruent to its input mod (b-1) (digitalRootIter_modEq), and base-10 specializes to the decimal digital root with casting out nines (digitalRootIter_ten_nine_mul).",
+  "conclusion": "The iterative digital root is a total, terminating function that provably computes the closed form 1 + ((n-1) mod (b-1)) in every base b >= 2. The single ingredient making both the definition and the proof go through is the strict digit-sum drop (digits b n).sum < n for n >= b. Everything is kernel-checked and axiom-free (no native_decide; only the standard propext / Classical.choice / Quot.sound).",
+  "leanFile": {
+    "path": "Proofs/DivisibilityBy3OQ03OQ02OQ01.lean",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 2,
+    "imports": ["Mathlib"],
+    "opens": ["Nat"],
+    "namespace": "DivisibilityBy3OQ03OQ02OQ01",
+    "sorries": 0
+  },
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/DivisibilityBy3OQ03OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "digital-root",
+      "modular-arithmetic",
+      "well-founded-recursion",
+      "termination",
+      "research"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 203,
+    "theoremCount": 15,
+    "definitionCount": 2,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.digit_sum_le",
+        "description": "(digits b n).sum <= n; sharpened here to a strict bound for n >= b",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "digits b n = (n % b) :: digits b (n / b) for 1 < b, 0 < n",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Nat.modEq_digits_sum",
+        "description": "n ≡ (digits b n).sum (mod d) when b ≡ 1 (mod d); supplies the residue invariant",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.getLast_digit_ne_zero",
+        "description": "the leading base-b digit of a positive number is nonzero; gives digit-sum positivity",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "strong induction used for the termination-driven equivalence proof",
+        "module": "Mathlib.Data.Nat.Init"
+      }
+    ],
+    "originalContributions": [
+      "Strict digit-sum bound digitSum_lt: (digits b n).sum < n for 2 <= b <= n (termination measure)",
+      "digitalRootIter: the iterative digital root by well-founded recursion, with defining equations digitalRootIter_of_lt / digitalRootIter_of_ge",
+      "Headline equivalence digitalRootIter_eq_base: iterative process = closed form 1 + ((n-1) mod (b-1)) for all b >= 2",
+      "Single-digit range (digitalRootIter_lt_base) and residue invariant (digitalRootIter_modEq)",
+      "Base-10 specialization including the casting-out-nines law digitalRootIter_ten_nine_mul"
+    ],
+    "assumptions": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-by-3-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "The parent defined the base-b digital root only by its closed form dr_b(n) = 1 + ((n-1) mod (b-1)). This entry formalizes the iterative digit-summing process and proves it computes that closed form. (The closed form is re-stated locally so the file is self-contained; the parent file is unchanged.)"
+    },
+    {
+      "targetId": "divisibility-by-3-oq-03",
+      "relationship": "related",
+      "description": "The base-10 grandparent; digitalRootIter_ten and digitalRootIter_ten_nine_mul recover the decimal digital root and casting out nines as the b = 10 instance."
+    },
+    {
+      "targetId": "divisibility-by-3",
+      "relationship": "related",
+      "description": "Foundational entry: 3 | n iff 3 | (digit sum). The residue invariant digitalRootIter_modEq mod (b-1) is the algebraic mechanism behind such digit-sum divisibility tests."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Fibonacci, Leonardo",
+      "title": "Liber Abaci",
+      "year": "1202",
+      "venue": "Manuscript; modern translation by L. Sigler, Springer, 2002",
+      "note": "Popularized casting out nines, the base-10 shadow of the iterative digital root."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1979",
+      "venue": "Oxford University Press, 5th edition",
+      "note": "Section 9.9: digital roots and the congruence n ≡ (digit sum) mod (b-1)."
+    },
+    {
+      "authors": "Averbach, Bonnie; Chein, Orin",
+      "title": "Problem Solving Through Recreational Mathematics",
+      "year": "2000",
+      "venue": "Dover Publications",
+      "note": "Treats the iterative digital root algorithm and its convergence to a single digit."
+    }
+  ]
+}

--- a/src/data/research/problems/divisibility-by-3-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/divisibility-by-3-oq-03-oq-02-oq-01.json
@@ -1,0 +1,49 @@
+{
+  "slug": "divisibility-by-3-oq-03-oq-02-oq-01",
+  "title": "The Iterative Digital Root Equals its Closed Form",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 6,
+  "significance": "Formalizes the actual iterative digital-root process (repeatedly sum base-b digits until one digit remains) and proves it terminates and computes the parent's closed form dr_b(n) = 1 + ((n-1) mod (b-1)) for every base b >= 2, recovering casting out nines as the base-10 case.",
+  "path": "Proofs/DivisibilityBy3OQ03OQ02OQ01.lean",
+  "problemStatement": "The parent entry (divisibility-by-3-oq-03-oq-02) defined the base-b digital root only by its closed form. Can Lean 4 formalize the iterative definition (repeatedly replace n by the sum of its base-b digits until a single digit remains) and prove it equals that closed form?",
+  "tags": [
+    "number-theory",
+    "divisibility",
+    "digital-root",
+    "modular-arithmetic",
+    "well-founded-recursion",
+    "termination",
+    "research"
+  ],
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "currentState": "SOLVED, build-verified, 0-axiom (only propext/Classical.choice/Quot.sound; no native_decide). 15 theorems, 2 definitions, 203 lines. PR opened.",
+  "knownResults": [
+    "Parent divisibility-by-3-oq-03-oq-02 proved the closed form dr_b(n) = 1 + ((n-1) mod (b-1)) and the congruence dr_b(n) ≡ n mod (b-1).",
+    "Mathlib provides Nat.digit_sum_le (non-strict), Nat.modEq_digits_sum, and Nat.getLast_digit_ne_zero."
+  ],
+  "knowledge": {
+    "insights": [
+      "The strict bound (digits b n).sum < n for 2 <= b <= n is the single ingredient that both makes the well-founded definition legal and drives the strong-induction equivalence proof.",
+      "A single digit-sum step is residue-preserving mod (b-1) (Nat.modEq_digits_sum) and value-positive (getLast_digit_ne_zero), and the closed form depends only on that residue — so the iterate and the closed form must agree.",
+      "The parent file DivisibilityBy3OQ03OQ02.lean is currently BROKEN on Lean v4.26.0 (omega failure at line ~128), so the leaf re-states the closed form locally and stays self-contained rather than importing the parent."
+    ],
+    "builtItems": [
+      "digitSum_lt: (digits b n).sum < n for 2 <= b <= n (termination measure) — DivisibilityBy3OQ03OQ02OQ01.lean:54",
+      "digitalRootIter: iterative digital root by well-founded recursion + equations digitalRootIter_of_lt/of_ge — DivisibilityBy3OQ03OQ02OQ01.lean:73",
+      "digitalRootIter_eq_base (headline): iterative process = closed form for all b >= 2 — DivisibilityBy3OQ03OQ02OQ01.lean:160",
+      "digitalRootIter_lt_base, digitalRootIter_modEq, digitalRootIter_ten_nine_mul (casting out nines) — DivisibilityBy3OQ03OQ02OQ01.lean:174,147,194"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the non-strict Nat.digit_sum_le but no strict digit-sum drop lemma; provided here as digitSum_lt.",
+      "Mathlib has no formalized iterative digital root / digital-root algorithm; provided here as digitalRootIter."
+    ],
+    "nextSteps": [
+      "Optional follow-up: prove the number of digit-sum iterations (additive persistence) and bound it by log_b log_b n.",
+      "Optional follow-up: file an issue / repair for the broken parent DivisibilityBy3OQ03OQ02.lean (omega failure ~line 128 on v4.26.0)."
+    ],
+    "progressSummary": "COMPLETE: iterative digital root defined by well-founded recursion and proved equal to the closed form dr_b(n) for all b >= 2; 0-axiom, build-verified."
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of **divisibility-by-3-oq-03-oq-02**: the parent defined the base-`b` digital root only by its *closed form* `dr_b(n) = 1 + ((n-1) mod (b-1))`. This leaf formalizes the actual **iterative** process — repeatedly replace `n` by the sum of its base-`b` digits until a single digit remains — and proves it computes that closed form for every base `b ≥ 2`.

## Key results (all 0-axiom, `sorry`-free, kernel-checked)

- `digitSum_lt` — for `2 ≤ b ≤ n`, `(digits b n).sum < n`. This strict drop is both the well-founded **termination measure** and the descent step in the equivalence proof.
- `digitalRootIter` — the iterative digital root, by well-founded recursion (with defining equations `digitalRootIter_of_lt` / `digitalRootIter_of_ge`).
- `digitalRootIter_eq_base` — **headline**: `digitalRootIter b n = digitalRootBase b n` for all `b ≥ 2`, by strong induction. A digit-sum step preserves the residue mod `b-1` (`Nat.modEq_digits_sum`) and stays positive (`getLast_digit_ne_zero`), and the closed form depends only on that residue.
- `digitalRootIter_lt_base` (single-digit range), `digitalRootIter_modEq` (residue invariant).
- `digitalRootIter_ten_nine_mul` — base-10 **casting out nines**: every positive multiple of 9 has decimal digital root 9; plus the worked example `digitalRootIter_ten_12345 = 6`.

## Notes

- **Self-contained.** The parent file `DivisibilityBy3OQ03OQ02.lean` is currently broken on Lean v4.26.0 (an `omega` failure ~line 128), so this entry re-states the closed form locally rather than importing it. The parent's own file is unchanged.
- 15 theorems, 2 definitions, 203 lines.
- Axioms: only `propext` / `Classical.choice` / `Quot.sound` (no `native_decide`, no `sorryAx`) → **verified / 0-axiom**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)