### PR TITLE
research(erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02): sharp central-binomial growth law C(2n,n) ∼ 4ⁿ/√(πn) via Stirling

### DIFF
--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,228 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-01 → OQ-02: the sharp central-binomial growth law `C(2n,n) ∼ 4ⁿ/√(πn)`
+
+The parent `Erdos396OQ04OQ01OQ01OQ01` telescopes the Catalan recurrence into a closed
+product and asks, as its second open question, whether the same recurrence yields the
+**central-binomial telescoping product** `C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1)` *and hence the
+matching growth law* `C(2n,n) ∼ 4ⁿ/√(πn)`.
+
+The telescoping product itself is already established (sibling entry
+`Erdos396OQ04OQ01OQ01OQ02OQ02OQ01`, "central binomial coefficient as a telescoping Wallis
+product"), which deliberately stops at the *elementary* bound `C(2n,n) < 4ⁿ` and uses **no
+Stirling estimate**. This entry supplies the remaining, genuinely analytic half — the
+**sharp asymptotic constant** — which is exactly the ingredient that needs Stirling's
+formula:
+
+* **`centralBinom_isEquivalent`** : `(C(2n,n) : ℝ) ~[atTop] 4ⁿ/√(πn)`,
+* **`centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one`** : `C(2n,n)·√(πn)/4ⁿ → 1`.
+
+The derivation is pure `Asymptotics.IsEquivalent` algebra on Mathlib's Stirling equivalence
+`Stirling.factorial_isEquivalent_stirling` (`n! ~ √(2nπ)·(n/e)ⁿ`): writing
+`C(2n,n) = (2n)!/(n!)²`, substituting Stirling into numerator and denominator, the `(n/e)`
+powers contribute `4ⁿ`, `√(4nπ)/(2nπ)` collapses to `1/√(πn)`, and the Stirling constants
+cancel to `1`.
+
+Two consequences:
+
+* **`succ_mul_catalan_eq_centralBinom`** : `C(2n,n) = (n+1)·catalan n` — the bridge to the
+  parent's Catalan product; together with the asymptotic it yields the **Catalan growth law**
+  the parent's docstring states but never proves,
+* **`catalan_isEquivalent`** : `(catalan n : ℝ) ~[atTop] 4ⁿ/(n·√(πn))` (i.e.
+  `catalan n ∼ 4ⁿ/(√π · n^{3/2})`), with limit form
+  **`catalan_mul_div_four_pow_tendsto_one`**.
+
+Finally the asymptotic upper rate is complemented by the elementary *effective* lower bound
+
+* **`four_pow_div_two_mul_le_centralBinom`** : `4ⁿ/(2n) ≤ C(2n,n)` (`n ≥ 1`),
+
+from Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom`, valid for every `n` (not just
+asymptotically), so `4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ`.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+
+open Filter Topology Real Nat Asymptotics
+
+namespace Erdos396OQ04OQ01OQ01OQ01OQ02
+
+/-- The Stirling approximation function for `n!`: `√(2nπ)·(n/e)ⁿ`. By Mathlib's
+    `Stirling.factorial_isEquivalent_stirling`, `n! ~[atTop] stirlingFn n`. -/
+noncomputable def stirlingFn (n : ℕ) : ℝ := Real.sqrt (2 * n * π) * (n / Real.exp 1) ^ n
+
+/- ## The central binomial coefficient as a quotient of factorials -/
+
+/-- `(C(2n,n) : ℝ) = (2n)! / (n! · n!)`. From `Nat.choose_mul_factorial_mul_factorial`
+    with `2n - n = n`. -/
+theorem centralBinom_eq_factorial_div (n : ℕ) :
+    (centralBinom n : ℝ) = (2 * n)! / (n ! * n !) := by
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  have h2 : 2 * n - n = n := by omega
+  rw [eq_div_iff (by positivity)]
+  have := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+  rw [h2] at this
+  push_cast [← this]; ring
+
+/- ## The key pointwise simplification of the Stirling quotient -/
+
+/-- For `n ≥ 1`, the Stirling quotient that governs `C(2n,n) = (2n)!/(n!)²` simplifies in
+    closed form: `stirlingFn (2n) / (stirlingFn n)² = 4ⁿ / √(πn)`. The `(n/e)` powers give
+    `4ⁿ`, `√(4nπ)/(2nπ)` collapses to `1/√(πn)`. -/
+theorem stirlingFn_quotient (n : ℕ) (hn : 1 ≤ n) :
+    stirlingFn (2 * n) / (stirlingFn n * stirlingFn n) = 4 ^ n / Real.sqrt (π * n) := by
+  have hnpos : (0 : ℝ) < n := by positivity
+  have he : Real.exp 1 ≠ 0 := Real.exp_ne_zero 1
+  have hsq : (Real.sqrt (2 * n * π)) ^ 2 = 2 * n * π := by rw [Real.sq_sqrt]; positivity
+  unfold stirlingFn
+  have hcast : ((2 * n : ℕ) : ℝ) = 2 * (n : ℝ) := by push_cast; ring
+  rw [hcast]
+  have h4 : Real.sqrt (2 * (2 * (n:ℝ)) * π) = 2 * Real.sqrt (n * π) := by
+    rw [show 2 * (2 * (n:ℝ)) * π = 4 * (n * π) by ring, show (4:ℝ) = 2 ^ 2 by norm_num,
+        Real.sqrt_mul (by positivity), Real.sqrt_sq (by norm_num)]
+  rw [h4]
+  have hpow : ((2 * (n:ℝ)) / Real.exp 1) ^ (2 * n)
+      = 4 ^ n * ((n:ℝ) / Real.exp 1) ^ (2 * n) := by
+    rw [show (2 * (n:ℝ)) / Real.exp 1 = 2 * ((n:ℝ) / Real.exp 1) by ring, mul_pow,
+        pow_mul, show ((2:ℝ)) ^ 2 = 4 by norm_num]
+  rw [hpow,
+      show (Real.sqrt (2 * (n:ℝ) * π) * ((n:ℝ) / Real.exp 1) ^ n)
+          * (Real.sqrt (2 * (n:ℝ) * π) * ((n:ℝ) / Real.exp 1) ^ n)
+        = (Real.sqrt (2 * (n:ℝ) * π)) ^ 2 * ((n:ℝ) / Real.exp 1) ^ (2 * n) by ring, hsq,
+      show Real.sqrt (π * n) = Real.sqrt (n * π) by rw [mul_comm]]
+  have hgne : ((n:ℝ) / Real.exp 1) ^ (2 * n) ≠ 0 := by positivity
+  have hnpisq : Real.sqrt (n * π) ^ 2 = n * π := by rw [Real.sq_sqrt]; positivity
+  field_simp
+  nlinarith [hnpisq, Real.sqrt_nonneg ((n:ℝ) * π)]
+
+/- ## The sharp central-binomial asymptotic -/
+
+/-- **The sharp growth law.** `(C(2n,n) : ℝ) ~[atTop] 4ⁿ/√(πn)`.
+
+    Writing `C(2n,n) = (2n)!/(n!)²` and substituting Mathlib's Stirling equivalence
+    `Stirling.factorial_isEquivalent_stirling` into numerator and denominator via
+    `IsEquivalent.comp_tendsto`, `IsEquivalent.mul` and `IsEquivalent.div`, then collapsing
+    the Stirling quotient by `stirlingFn_quotient`. This is the analytic half of the open
+    question that the elementary telescoping-product sibling left open. -/
+theorem centralBinom_isEquivalent :
+    (fun n : ℕ => (centralBinom n : ℝ)) ~[atTop] (fun n : ℕ => 4 ^ n / Real.sqrt (π * n)) := by
+  have hstir := Stirling.factorial_isEquivalent_stirling
+  have hφ : Tendsto (fun n : ℕ => 2 * n) atTop atTop :=
+    tendsto_atTop_mono (fun n => by simp only [id_eq]; omega) tendsto_id
+  have h1 : (fun n : ℕ => ((2 * n)! : ℝ)) ~[atTop] (fun n : ℕ => stirlingFn (2 * n)) :=
+    hstir.comp_tendsto hφ
+  have h2 : (fun n : ℕ => (n ! : ℝ) * (n ! : ℝ)) ~[atTop]
+      (fun n : ℕ => stirlingFn n * stirlingFn n) := hstir.mul hstir
+  have hdiv : (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ)))
+      ~[atTop] (fun n : ℕ => stirlingFn (2 * n) / (stirlingFn n * stirlingFn n)) := h1.div h2
+  have hcbL : (fun n : ℕ => (centralBinom n : ℝ))
+      = (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ))) := by
+    ext n; exact centralBinom_eq_factorial_div n
+  have hRHS : (fun n : ℕ => stirlingFn (2 * n) / (stirlingFn n * stirlingFn n))
+      =ᶠ[atTop] (fun n : ℕ => 4 ^ n / Real.sqrt (π * n)) := by
+    filter_upwards [eventually_ge_atTop 1] with n hn using stirlingFn_quotient n hn
+  rw [hcbL]
+  exact hdiv.trans hRHS.isEquivalent
+
+/-- **Limit form of the growth law.** `C(2n,n)·√(πn)/4ⁿ → 1`. -/
+theorem centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one :
+    Tendsto (fun n : ℕ => (centralBinom n : ℝ) * Real.sqrt (π * n) / 4 ^ n) atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, (4:ℝ) ^ n / Real.sqrt (π * n) ≠ 0 := by
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    have : (0:ℝ) < n := by positivity
+    positivity
+  have key := (Asymptotics.isEquivalent_iff_tendsto_one hz).mp centralBinom_isEquivalent
+  refine key.congr' ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div_eq_mul_div]
+
+/- ## Bridge to the parent's Catalan product, and the Catalan growth law -/
+
+/-- **Catalan bridge.** `C(2n,n) = (n+1)·catalan n`, from `catalan_eq_centralBinom_div` and
+    `Nat.succ_dvd_centralBinom`. This identifies the central-binomial product of the sibling
+    entry with the parent's Catalan product. -/
+theorem succ_mul_catalan_eq_centralBinom (n : ℕ) :
+    (n + 1) * catalan n = centralBinom n := by
+  rw [catalan_eq_centralBinom_div, Nat.mul_div_cancel' (Nat.succ_dvd_centralBinom n)]
+
+/-- `(n+1) ~[atTop] n`: the prefactor relating the Catalan and central-binomial products is
+    asymptotically negligible. -/
+theorem nat_succ_isEquivalent :
+    (fun n : ℕ => ((n : ℝ) + 1)) ~[atTop] (fun n : ℕ => (n : ℝ)) := by
+  refine (Asymptotics.isEquivalent_iff_tendsto_one ?_).2 ?_
+  · filter_upwards [eventually_ge_atTop 1] with n hn; positivity
+  · have h0 : Tendsto (fun n : ℕ => (1:ℝ) / (n:ℝ)) atTop (𝓝 0) :=
+      tendsto_one_div_atTop_nhds_zero_nat
+    have hsum : Tendsto (fun n : ℕ => 1 + (1:ℝ) / (n:ℝ)) atTop (𝓝 (1 + 0)) :=
+      tendsto_const_nhds.add h0
+    rw [add_zero] at hsum
+    refine hsum.congr' ?_
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    simp only [Pi.div_apply]
+    have : (n:ℝ) ≠ 0 := by positivity
+    field_simp
+
+/-- **The Catalan growth law** the parent's docstring states but never proves:
+    `(catalan n : ℝ) ~[atTop] 4ⁿ/(n·√(πn))`, i.e. `catalan n ∼ 4ⁿ/(√π · n^{3/2})`.
+    Immediate from `catalan n = C(2n,n)/(n+1)`, the central-binomial asymptotic, and
+    `(n+1) ~ n`. -/
+theorem catalan_isEquivalent :
+    (fun n : ℕ => (catalan n : ℝ)) ~[atTop]
+      (fun n : ℕ => 4 ^ n / ((n : ℝ) * Real.sqrt (π * n))) := by
+  have hcat : (fun n : ℕ => (catalan n : ℝ))
+      = (fun n : ℕ => (centralBinom n : ℝ) / ((n : ℝ) + 1)) := by
+    ext n
+    have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+    rw [eq_div_iff hne]
+    have : ((n : ℝ) + 1) * (catalan n : ℝ) = (centralBinom n : ℝ) := by
+      exact_mod_cast succ_mul_catalan_eq_centralBinom n
+    linarith [this]
+  rw [hcat]
+  have hdiv := centralBinom_isEquivalent.div nat_succ_isEquivalent
+  refine hdiv.trans ?_
+  refine Filter.EventuallyEq.isEquivalent ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div, mul_comm]
+
+/-- **Limit form of the Catalan growth law.** `catalan n · (n·√(πn)) / 4ⁿ → 1`. -/
+theorem catalan_mul_div_four_pow_tendsto_one :
+    Tendsto (fun n : ℕ => (catalan n : ℝ) * ((n : ℝ) * Real.sqrt (π * n)) / 4 ^ n)
+      atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, (4:ℝ) ^ n / ((n : ℝ) * Real.sqrt (π * n)) ≠ 0 := by
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    have : (0:ℝ) < n := by positivity
+    positivity
+  have key := (Asymptotics.isEquivalent_iff_tendsto_one hz).mp catalan_isEquivalent
+  refine key.congr' ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div_eq_mul_div]
+
+/- ## Effective elementary lower bound (valid for every `n`, not just asymptotically) -/
+
+/-- **Effective lower bound.** `4ⁿ/(2n) ≤ C(2n,n)` for `n ≥ 1`, from Mathlib's
+    `Nat.four_pow_le_two_mul_self_mul_centralBinom`. Together with the asymptotic and the
+    sibling's `C(2n,n) < 4ⁿ`, this brackets `4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ`. -/
+theorem four_pow_div_two_mul_le_centralBinom (n : ℕ) (hn : 1 ≤ n) :
+    (4 : ℝ) ^ n / (2 * n) ≤ (centralBinom n : ℝ) := by
+  have h := Nat.four_pow_le_two_mul_self_mul_centralBinom n hn
+  have hcast : (4 : ℝ) ^ n ≤ 2 * n * centralBinom n := by exact_mod_cast h
+  rw [div_le_iff₀ (by positivity : (0:ℝ) < 2 * n)]
+  calc (4 : ℝ) ^ n ≤ 2 * n * centralBinom n := hcast
+    _ = (centralBinom n : ℝ) * (2 * n) := by ring
+
+/- ## Sanity checks -/
+
+/-- `C(6,3) = 20`. -/
+example : centralBinom 3 = 20 := by decide
+
+/-- The Catalan bridge at `n = 3`: `C(6,3) = 4 · catalan 3 = 4 · 5 = 20`. -/
+example : centralBinom 3 = 4 * catalan 3 := by
+  have h := succ_mul_catalan_eq_centralBinom 3; omega
+
+/-- The factorial quotient at `n = 3`: `C(6,3) = 6!/(3!·3!) = 720/36 = 20`. -/
+example : (centralBinom 3 : ℝ) = (2 * 3)! / (3 ! * 3 !) := centralBinom_eq_factorial_div 3
+
+end Erdos396OQ04OQ01OQ01OQ01OQ02

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-factquot",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "The central binomial coefficient as a quotient of factorials",
+    "content": "`centralBinom_eq_factorial_div` proves $(C(2n,n):\\mathbb{R}) = (2n)!/(n!\\cdot n!)$ from `Nat.choose_mul_factorial_mul_factorial` with $2n-n=n$. This puts $C(2n,n)$ in the quotient-of-factorials form that lets Stirling's equivalence act on numerator and denominator independently.",
+    "mathContext": "$\\displaystyle C(2n,n) = \\frac{(2n)!}{(n!)^2}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-stirlingquot",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 100
+    },
+    "type": "key-step",
+    "title": "Closed-form simplification of the Stirling quotient",
+    "content": "`stirlingFn_quotient` proves the pointwise identity $\\mathrm{stirlingFn}(2n)/(\\mathrm{stirlingFn}\\,n)^2 = 4^n/\\sqrt{\\pi n}$ for $n \\ge 1$, where $\\mathrm{stirlingFn}\\,n = \\sqrt{2n\\pi}(n/e)^n$. The $(n/e)$ powers contribute $4^n$ (since $(2n/e)^{2n} = 4^n(n/e)^{2n}$), $\\sqrt{2\\cdot 2n\\cdot\\pi} = 2\\sqrt{n\\pi}$ and $(\\sqrt{2n\\pi})^2 = 2n\\pi$ collapse $\\sqrt{4n\\pi}/(2n\\pi)$ to $1/\\sqrt{\\pi n}$. This is the only hand computation in the entry; everything else is `IsEquivalent` algebra.",
+    "mathContext": "$\\dfrac{\\mathrm{stirlingFn}(2n)}{(\\mathrm{stirlingFn}\\,n)^2} = \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-asymp",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 126
+    },
+    "type": "key-step",
+    "title": "The sharp central-binomial growth law",
+    "content": "`centralBinom_isEquivalent` proves $(C(2n,n):\\mathbb{R}) \\sim_{atTop} 4^n/\\sqrt{\\pi n}$. Mathlib's Stirling equivalence $n! \\sim \\mathrm{stirlingFn}\\,n$ is composed with $n \\mapsto 2n$ (`IsEquivalent.comp_tendsto`) for the numerator $(2n)!$ and squared (`IsEquivalent.mul`) for $(n!)^2$, then divided (`IsEquivalent.div`); the resulting Stirling quotient is replaced by $4^n/\\sqrt{\\pi n}$ via `stirlingFn_quotient` (`EventuallyEq.isEquivalent`, `trans`). This is the analytic half of the parent's open question that the elementary telescoping-product sibling left open.",
+    "mathContext": "$C(2n,n) \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-bridge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 147
+    },
+    "type": "insight",
+    "title": "Bridge to the parent's Catalan product",
+    "content": "`succ_mul_catalan_eq_centralBinom` proves $C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$ from `catalan_eq_centralBinom_div` and `Nat.mul_div_cancel'` on `Nat.succ_dvd_centralBinom`. This identifies the central-binomial coefficient with the parent's Catalan number up to the $n+1$ prefactor, and is the conduit that carries the central-binomial asymptotic to the Catalan growth law.",
+    "mathContext": "$C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-catalan",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 170,
+      "endLine": 188
+    },
+    "type": "key-step",
+    "title": "The Catalan growth law the parent only asserted",
+    "content": "`catalan_isEquivalent` proves $(\\mathrm{catalan}\\,n:\\mathbb{R}) \\sim_{atTop} 4^n/(n\\sqrt{\\pi n}) = 4^n/(\\sqrt{\\pi}\\,n^{3/2})$. Using $\\mathrm{catalan}\\,n = C(2n,n)/(n+1)$, the central-binomial asymptotic, and $(n+1)\\sim n$ (`nat_succ_isEquivalent`, from $1+1/n \\to 1$), divided through `IsEquivalent.div`. This is the $n^{3/2}$ polynomial correction the parent's docstring asserts ($\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$) but never proves.",
+    "mathContext": "$\\mathrm{catalan}\\,n \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi}\\,n^{3/2}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-lower",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 208,
+      "endLine": 215
+    },
+    "type": "insight",
+    "title": "Effective lower bound for every n",
+    "content": "`four_pow_div_two_mul_le_centralBinom` proves $4^n/(2n) \\le C(2n,n)$ for $n \\ge 1$ by casting Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom` and dividing by $2n$. Unlike the asymptotic, this holds for every $n$, so together with the sibling's $C(2n,n) < 4^n$ it brackets $4^n/(2n) \\le C(2n,n) \\sim 4^n/\\sqrt{\\pi n} < 4^n$.",
+    "mathContext": "$\\dfrac{4^n}{2n} \\le C(2n,n) \\quad (n \\ge 1)$"
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-01 → OQ-02: The Sharp Central-Binomial Growth Law C(2n,n) ∼ 4ⁿ/√(πn)",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "description": "The parent's second open question asks whether the central-binomial recurrence telescopes to C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) AND yields the matching growth law C(2n,n) ∼ 4ⁿ/√(πn). The telescoping product is already established by a sibling entry that deliberately stops at the elementary bound C(2n,n) < 4ⁿ with no Stirling input. This entry supplies the remaining analytic half — the sharp asymptotic constant: C(2n,n) ~[atTop] 4ⁿ/√(πn) and the limit form C(2n,n)·√(πn)/4ⁿ → 1, derived by pure Asymptotics.IsEquivalent algebra on Mathlib's Stirling equivalence (n! ~ √(2nπ)·(n/e)ⁿ) via C(2n,n) = (2n)!/(n!)². The Catalan bridge C(2n,n) = (n+1)·catalan n then yields the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) the parent's docstring states but never proves. An effective lower bound 4ⁿ/(2n) ≤ C(2n,n) (valid for all n) brackets the rate.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "asymptotics",
+      "central-binomial-coefficient",
+      "catalan",
+      "stirling-formula",
+      "growth-bounds"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #396 concerns descending-factorial divisibility of central binomial coefficients, whose base case rests on the Catalan numbers catalan n = C(2n,n)/(n+1). The chain OQ-04 → OQ-01 → OQ-01 → OQ-01 reads the two-term Catalan recurrence multiplicatively, telescoping catalan n = ∏_{k<n} r k, and its second open question asks whether the same technique applied to the central-binomial recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) gives both the product form C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) AND the matching growth law C(2n,n) ∼ 4ⁿ/√(πn). The telescoping product (and the elementary bound C(2n,n) < 4ⁿ) was established by the sibling entry erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01, which uses no Stirling input by design. This entry completes the remaining, genuinely analytic half: the sharp asymptotic constant 1/√(πn).",
+    "problemStatement": "Establish the matching growth law C(2n,n) ∼ 4ⁿ/√(πn) for the central binomial coefficient (the analytic half of the parent's open question that the telescoping-product sibling left open), and deduce the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}).",
+    "text": "Writing C(2n,n) = (2n)!/(n!)² and substituting Mathlib's Stirling equivalence n! ~[atTop] √(2nπ)·(n/e)ⁿ into numerator and denominator, the (n/e) powers contribute 4ⁿ, √(4nπ)/(2nπ) collapses to 1/√(πn), and the Stirling constants cancel, giving C(2n,n) ~[atTop] 4ⁿ/√(πn), equivalently C(2n,n)·√(πn)/4ⁿ → 1. The bridge C(2n,n) = (n+1)·catalan n, together with (n+1) ~ n, transports this to catalan n ~[atTop] 4ⁿ/(n·√(πn)) = 4ⁿ/(√π·n^{3/2}). The asymptotic rate is complemented by the effective bound 4ⁿ/(2n) ≤ C(2n,n), valid for every n.",
+    "proofStrategy": "The core is pure Asymptotics.IsEquivalent algebra. centralBinom_eq_factorial_div gives (C(2n,n):ℝ) = (2n)!/(n!·n!) via Nat.choose_mul_factorial_mul_factorial. Mathlib's Stirling.factorial_isEquivalent_stirling (n! ~ stirlingFn n with stirlingFn n = √(2nπ)·(n/e)ⁿ) is composed with the index map n ↦ 2n (IsEquivalent.comp_tendsto along Tendsto (2·) atTop atTop) for the numerator and squared (IsEquivalent.mul) for the denominator, then divided (IsEquivalent.div). The resulting Stirling quotient is simplified pointwise for n ≥ 1 by stirlingFn_quotient: √(2·2n·π) = 2√(nπ) (Real.sqrt_mul, sqrt_sq), (2n/e)^{2n} = 4ⁿ·(n/e)^{2n} (mul_pow, pow_mul), (√(2nπ))² = 2nπ (Real.sq_sqrt), and field_simp/nlinarith collapse the ratio to 4ⁿ/√(πn); transferring through the eventual equality (IsEquivalent.trans, EventuallyEq.isEquivalent) gives centralBinom_isEquivalent. The limit form is isEquivalent_iff_tendsto_one with div_div_eq_mul_div. The Catalan bridge is catalan_eq_centralBinom_div with Nat.mul_div_cancel' on Nat.succ_dvd_centralBinom; combined with nat_succ_isEquivalent ((n+1)~n via 1+1/n → 1) and IsEquivalent.div it gives the Catalan asymptotic. The effective lower bound casts Nat.four_pow_le_two_mul_self_mul_centralBinom and divides by 2n (div_le_iff₀).",
+    "keyInsights": [
+      "**The sharp constant is exactly the Stirling-dependent ingredient.** The telescoping product and the elementary bound C(2n,n) < 4ⁿ need no analysis (the sibling entry proves them with no Stirling input); the asymptotic constant 1/√(πn) is the one piece that genuinely requires Stirling's formula, supplied here via Mathlib's Stirling.factorial_isEquivalent_stirling.",
+      "**IsEquivalent algebra makes the derivation structural, not computational.** Treating C(2n,n) = (2n)!/(n!)² as a quotient of equivalent sequences, the asymptotic follows from composing/​multiplying/​dividing Stirling equivalences; the only hand computation is the closed-form pointwise simplification stirlingFn(2n)/(stirlingFn n)² = 4ⁿ/√(πn), where √(4nπ)/(2nπ) = 1/√(πn) and the (n/e) powers contribute 4ⁿ.",
+      "**One asymptotic, two growth laws.** The bridge C(2n,n) = (n+1)·catalan n with (n+1) ~ n transports the central-binomial asymptotic to the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) — the n^{3/2} correction the parent's docstring asserts but never proves, now derived from the same Stirling input.",
+      "**Asymptotic rate plus an effective for-all-n bound.** Mathlib's 4ⁿ ≤ 2n·C(2n,n) gives the effective lower bound 4ⁿ/(2n) ≤ C(2n,n) holding for every n ≥ 1 (not merely asymptotically), bracketing 4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ."
+    ],
+    "prerequisites": [
+      "Central binomial coefficient C(2n,n) = Nat.centralBinom n and C(2n,n) = (2n)!/(n!)²",
+      "Stirling's formula as an asymptotic equivalence (Stirling.factorial_isEquivalent_stirling)",
+      "Asymptotics.IsEquivalent algebra (comp_tendsto, mul, div, isEquivalent_iff_tendsto_one)",
+      "Catalan numbers and catalan_eq_centralBinom_div"
+    ]
+  },
+  "conclusion": {
+    "summary": "The central binomial coefficient satisfies the sharp asymptotic C(2n,n) ~[atTop] 4ⁿ/√(πn) (limit form C(2n,n)·√(πn)/4ⁿ → 1), proved by pure Asymptotics.IsEquivalent algebra on Mathlib's Stirling equivalence applied to C(2n,n) = (2n)!/(n!)². The bridge C(2n,n) = (n+1)·catalan n transports this to the Catalan growth law catalan n ~[atTop] 4ⁿ/(n·√(πn)) = 4ⁿ/(√π·n^{3/2}). An effective lower bound 4ⁿ/(2n) ≤ C(2n,n) holds for every n ≥ 1. All nine theorems are machine-checked with no axioms or sorries.",
+    "implications": "This completes the analytic half of the parent's second open question: the telescoping-product sibling supplies the recurrence-level product and the elementary 4ⁿ bound with no Stirling input, and this entry supplies the sharp asymptotic constant 1/√(πn) that genuinely needs Stirling. The derivation also delivers the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) — long asserted in the parent's documentation but previously unproved in the gallery — from the same Stirling equivalence, isolating the n^{3/2} polynomial correction the multiplicative recurrence files only shadowed.",
+    "openQuestions": [
+      "Mathlib's Stirling equivalence yields the asymptotic but not an effective two-sided error bound; can the entry's effective lower bound 4ⁿ/(2n) ≤ C(2n,n) and the sibling's C(2n,n) < 4ⁿ be sharpened to explicit constants c₁,c₂ with c₁·4ⁿ/√n ≤ C(2n,n) ≤ c₂·4ⁿ/√n for all n, using sqrt_pi_le_stirlingSeq-style effective Stirling bounds?",
+      "Does the Catalan asymptotic catalan n ∼ 4ⁿ/(√π·n^{3/2}) combine with the parent's strictly decreasing normalized sequence catalan n/4ⁿ to give a monotone (not merely asymptotic) envelope c/n^{3/2} ≤ catalan n/4ⁿ at the recurrence level?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Real",
+      "Nat",
+      "Asymptotics"
+    ],
+    "namespace": "Erdos396OQ04OQ01OQ01OQ01OQ02",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: telescopes the Catalan recurrence into catalan n = ∏_{k<n} r k and tracks the strictly decreasing normalized sequence catalan n/4ⁿ. Its second open question asks for the central-binomial product and the matching growth law C(2n,n) ∼ 4ⁿ/√(πn); this entry supplies the sharp asymptotic (and the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) the parent only asserts)."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry that proves the central-binomial telescoping product C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) and its Wallis form, deliberately stopping at the elementary bound C(2n,n) < 4ⁿ with no Stirling input. This entry supplies the analytic half that sibling leaves open: the sharp asymptotic constant 1/√(πn)."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose growth law C(2n,n) ∼ 4ⁿ/√(πn) is established here."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,244 @@
+{
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "title": "Does the telescoping-product technique applied to the central-binomial recurr...",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "",
+    "plain": "This is an open question (technique) arising from the verified gallery proof",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T10:22:55-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved the sharp asymptotic C(2n,n) ~ 4^n/sqrt(pi n) (the Stirling-dependent analytic half the telescoping-product sibling left open) and the Catalan growth law catalan n ~ 4^n/(sqrt(pi) n^{3/2}); verified 0-axiom, 9 thm/1 def/228L.",
+    "builtItems": [
+      "centralBinom_isEquivalent : (C(2n,n):R) ~[atTop] 4^n/sqrt(pi n) (Erdos396OQ04OQ01OQ01OQ01OQ02.lean:107)",
+      "centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one : limit form -> 1 (line 128)",
+      "stirlingFn_quotient : closed-form Stirling-quotient simplification (line 72)",
+      "succ_mul_catalan_eq_centralBinom : C(2n,n)=(n+1) catalan n (line 145)",
+      "catalan_isEquivalent : (catalan n:R) ~[atTop] 4^n/(n sqrt(pi n)) (line 170)",
+      "four_pow_div_two_mul_le_centralBinom : effective 4^n/(2n) <= C(2n,n) (line 208)"
+    ],
+    "insights": [
+      "The telescoping product half of this open question was already established by sibling oq-04-oq-01-oq-01-oq-02-oq-02-oq-01 (PR #27516), which deliberately uses no Stirling input and stops at C(2n,n)<4^n; the genuinely-new contribution is the SHARP asymptotic constant 1/sqrt(pi n).",
+      "C(2n,n) ~ 4^n/sqrt(pi n) derives cleanly from Mathlib Stirling.factorial_isEquivalent_stirling (n! ~ sqrt(2 n pi)(n/e)^n) by pure Asymptotics.IsEquivalent algebra on C(2n,n)=(2n)!/(n!)^2: comp_tendsto (n->2n) for numerator, mul for denominator, div, then a single pointwise simplification.",
+      "The only hand computation is stirlingFn(2n)/(stirlingFn n)^2 = 4^n/sqrt(pi n): (2n/e)^{2n}=4^n(n/e)^{2n}, sqrt(4 n pi)/(2 n pi)=1/sqrt(pi n).",
+      "Catalan asymptotic catalan n ~ 4^n/(sqrt(pi) n^{3/2}) follows from the bridge C(2n,n)=(n+1) catalan n plus (n+1)~n; this is the n^{3/2} correction the parent docstring asserts but never proves."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no centralBinom asymptotic (only Stirling for n! and Bertrand bounds); derived here from factorial_isEquivalent_stirling.",
+      "Mathlib Stirling gives an asymptotic equivalence but no effective two-sided c1 4^n/sqrt n <= C <= c2 4^n/sqrt n for all n (would need sqrt_pi_le_stirlingSeq-style effective bounds)."
+    ],
+    "nextSteps": [
+      "Upgrade to effective two-sided constants using sqrt_pi_le_stirlingSeq effective Stirling lower bound.",
+      "Combine catalan asymptotic with parent strictly-decreasing catalan n/4^n for a monotone n^{-3/2} envelope."
+    ],
+    "markdown": "# Knowledge Base: erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "binomial-coefficients",
+    "telescoping"
+  ],
+  "relatedProofs": [
+    "erdos-3",
+    "erdos-39",
+    "erdos-396",
+    "erdos-396-oq-04",
+    "erdos-396-oq-04-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T18:10:26.102Z",
+  "lastUpdate": "2026-06-24T18:10:26.141Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos396OQ04.lean",
+      "filename": "Erdos396OQ04.lean",
+      "lineCount": 132,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01.lean",
+      "filename": "Erdos396OQ04OQ01.lean",
+      "lineCount": 188,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01.lean",
+      "lineCount": 134,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ01.lean",
+      "lineCount": 163,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02.lean",
+      "lineCount": 214,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+      "lineCount": 249,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean",
+      "lineCount": 207,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+      "lineCount": 251,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean",
+      "lineCount": 168,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ03.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ03.lean",
+      "lineCount": 129,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos396Problem.lean",
+      "filename": "Erdos396Problem.lean",
+      "lineCount": 103,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **analytic half** of the parent `erdos-396-oq-04-oq-01-oq-01-oq-01`'s second open question: the sharp central-binomial growth law **C(2n,n) ∼ 4ⁿ/√(πn)**.

The *telescoping-product* half of that question was already established by the sibling entry `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01` (PR #27516), which deliberately uses **no Stirling input** and stops at the elementary bound `C(2n,n) < 4ⁿ`. This entry supplies the remaining, genuinely analytic ingredient — the **sharp asymptotic constant 1/√(πn)** — which is exactly what needs Stirling's formula.

## Results (9 theorems, 1 def, 228 lines, 0 sorries, 0 axioms)

- **`centralBinom_isEquivalent`** — `(C(2n,n):ℝ) ~[atTop] 4ⁿ/√(πn)`, the headline asymptotic.
- **`centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one`** — limit form `C(2n,n)·√(πn)/4ⁿ → 1`.
- **`succ_mul_catalan_eq_centralBinom`** — bridge `C(2n,n) = (n+1)·catalan n`.
- **`catalan_isEquivalent`** — Catalan growth law `catalan n ∼ 4ⁿ/(√π·n^{3/2})`, the n^{3/2} correction the parent's docstring asserts but never proves.
- **`four_pow_div_two_mul_le_centralBinom`** — effective lower bound `4ⁿ/(2n) ≤ C(2n,n)` for all n≥1.

## Method

Pure `Asymptotics.IsEquivalent` algebra on Mathlib's Stirling equivalence `Stirling.factorial_isEquivalent_stirling` (`n! ~ √(2nπ)·(n/e)ⁿ`) applied to `C(2n,n) = (2n)!/(n!)²`: compose with `n ↦ 2n` (`comp_tendsto`) for the numerator, square (`mul`) the denominator, divide (`div`), and collapse the Stirling quotient by one closed-form pointwise simplification (`stirlingFn_quotient`: `√(4nπ)/(2nπ) = 1/√(πn)`, `(2n/e)^{2n} = 4ⁿ(n/e)^{2n}`).

## Verification

Built against Mathlib 4.26.0. `#print axioms` on the headline theorems lists only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. `status: verified`, `badge: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)