### PR TITLE
Enrich Tetrahedral Reciprocals (triangular-reciprocals-oq-04)

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-04/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-troq04-defs",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 39, "endLine": 44 },
+    "type": "definition",
+    "title": "The Summand and its Telescoping Antiderivative",
+    "content": "tetReciprocal n = 6/((n+1)(n+2)(n+3)) is the shifted reciprocal tetrahedral number 1/Tet_{n+1} (since Tet_m = m(m+1)(m+2)/6). gTele n = 3/((n+1)(n+2)) is the discrete 'antiderivative' chosen so that the summand equals the consecutive difference g(n) − g(n+1). Both are noncomputable real-valued because of the division.",
+    "mathContext": "$f(n) = \\dfrac{6}{(n+1)(n+2)(n+3)} = \\dfrac{1}{\\mathrm{Tet}_{n+1}}$, $\\quad g(n) = \\dfrac{3}{(n+1)(n+2)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tetrahedral numbers", "telescoping series", "partial fractions"],
+    "prerequisites": ["tetrahedral numbers", "rational functions"]
+  },
+  {
+    "id": "ann-troq04-partial-fraction",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 51, "endLine": 62 },
+    "type": "theorem",
+    "title": "Depth-2 Telescoping Partial Fraction",
+    "content": "tetrahedral_partial_fraction is the algebraic heart: 6/((n+1)(n+2)(n+3)) = 3/((n+1)(n+2)) − 3/((n+2)(n+3)), i.e. f(n) = g(n) − g(n+1). This is the depth-2 analogue of the classical depth-1 identity 2/(n(n+1)) = 2/n − 2/(n+1). After recording nonzero denominators (positivity) and normalizing the shifted casts (n+1)+1 = n+2 etc., field_simp + ring closes it mechanically.",
+    "mathContext": "$\\dfrac{6}{(n+1)(n+2)(n+3)} = \\dfrac{3}{(n+1)(n+2)} - \\dfrac{3}{(n+2)(n+3)} = g(n) - g(n+1)$.",
+    "significance": "critical",
+    "relatedConcepts": ["partial fraction decomposition", "telescoping", "consecutive differences"],
+    "prerequisites": ["partial fractions", "field_simp/ring tactics"]
+  },
+  {
+    "id": "ann-troq04-partial-sum",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 69, "endLine": 83 },
+    "type": "theorem",
+    "title": "Closed Form of the Partial Sum",
+    "content": "partial_sum_closed_form: ∑_{i<N} f(i) = 3/2 − 3/((N+1)(N+2)), proved by induction on N. The base case is simp; the step uses sum_range_succ then the telescoping cancellation g(0) − g(N) collapses everything but the endpoints, closed by field_simp + ring. The constant 3/2 = g(0) = 3/(1·2) is the first endpoint.",
+    "mathContext": "$\\sum_{i<N} f(i) = g(0) - g(N) = \\dfrac{3}{2} - \\dfrac{3}{(N+1)(N+2)}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "induction", "Finset.sum_range_succ"],
+    "prerequisites": ["mathematical induction", "finite sums"]
+  },
+  {
+    "id": "ann-troq04-tail",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 90, "endLine": 105 },
+    "type": "theorem",
+    "title": "The Tail Vanishes",
+    "content": "tail_to_zero shows 3/((N+1)(N+2)) → 0 by a squeeze (squeeze_zero) below 3/(N+1) → 0 (from tendsto_one_div_add_atTop_nhds_zero_nat scaled by 3). The dominating bound uses (N+1) ≤ (N+1)(N+2) (nlinarith) so 3/((N+1)(N+2)) ≤ 3/(N+1), and positivity gives the lower bound.",
+    "mathContext": "$\\dfrac{3}{(N+1)(N+2)} \\le \\dfrac{3}{N+1} \\to 0$ as $N \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["squeeze theorem", "limits", "convergence to zero"],
+    "prerequisites": ["limits of sequences", "squeeze theorem"]
+  },
+  {
+    "id": "ann-troq04-main",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 117, "endLine": 131 },
+    "type": "theorem",
+    "title": "Main Result: the Tetrahedral Reciprocals Sum to 3/2",
+    "content": "tetrahedral_reciprocals proves HasSum tetReciprocal (3/2). Since the terms are nonnegative (positivity), hasSum_iff_tendsto_nat_of_nonneg reduces summability to convergence of the partial sums. Rewriting them by partial_sum_closed_form and subtracting the vanishing tail (tendsto_const_nhds.sub tail_to_zero) gives the limit 3/2 − 0 = 3/2. Equivalently ∑_{m≥1} 1/Tet_m = 3/2.",
+    "mathContext": "$\\sum_{n=0}^{\\infty} \\dfrac{6}{(n+1)(n+2)(n+3)} = \\sum_{m=1}^{\\infty} \\dfrac{1}{\\mathrm{Tet}_m} = \\dfrac{3}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["HasSum", "infinite series", "telescoping series", "tetrahedral numbers"],
+    "prerequisites": ["convergence of series", "HasSum"]
+  },
+  {
+    "id": "ann-troq04-tsum",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 134, "endLine": 136 },
+    "type": "theorem",
+    "title": "tsum Restatement",
+    "content": "tetrahedral_reciprocals_tsum restates the result as ∑' n, tetReciprocal n = 3/2 using HasSum.tsum_eq, the form most convenient for downstream use where the unconditional tsum value is needed.",
+    "mathContext": "$\\sum'_{n}\\, f(n) = \\dfrac{3}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum", "unconditional sum"],
+    "prerequisites": ["tsum / tsum_eq"]
+  },
+  {
+    "id": "ann-troq04-examples",
+    "proofId": "triangular-reciprocals-oq-04",
+    "range": { "startLine": 143, "endLine": 147 },
+    "type": "concept",
+    "title": "Sanity Checks of the Closed Form",
+    "content": "Two concrete checks: the first term f(0) = 6/(1·2·3) = 1 = 1/Tet_1, and the two-term partial sum ∑_{i<2} f(i) = 5/4 (via partial_sum_closed_form: 3/2 − 3/(3·4) = 3/2 − 1/4). These confirm the telescoping closed form against direct computation.",
+    "mathContext": "$f(0) = 1$; $\\ \\sum_{i<2} f(i) = \\dfrac{3}{2} - \\dfrac{3}{12} = \\dfrac{5}{4}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sanity check", "concrete evaluation"],
+    "prerequisites": ["arithmetic of rationals"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `triangular-reciprocals-oq-04` — *Tetrahedral Reciprocals: Depth-2 Telescoping* (∑ 1/Tetₙ = 3/2).

## Quality improvements
- **Annotations** (new file): 7 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the summand/antiderivative definitions, the depth-2 telescoping partial fraction `6/((n+1)(n+2)(n+3)) = 3/((n+1)(n+2)) − 3/((n+2)(n+3))`, the closed-form partial sum (induction), the vanishing tail (squeeze), the `HasSum` main result, the `tsum` restatement, and the sanity checks.

  This closes the entry's only quality gap: it already had a complete canonical overview, conclusion, and cross-references but **no annotations** (annotation/mathContext/significance quality were all 0).

## Axiom integrity
Unchanged and consistent: `status: verified`, `axiomCount: 0`, `sorries: 0` — matches the Lean source (no `axiom` declarations, no assumption-carrying structures).

`npm run annotations:validate` reports no errors for this entry.