### PR TITLE
research(derangements-oq-03-oq-03-oq-01): expected number of fixed points of a random permutation is 1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4043,3 +4043,4 @@ import Proofs.CombinationsFormulaOQ05OQ01OQ01
 import Proofs.GeometricSeriesOQ09OQ01OQ01OQ02
 
 import Proofs.DerangementsOQ03OQ03
+import Proofs.DerangementsOQ03OQ03OQ01

--- a/proofs/Proofs/DerangementsOQ03OQ03OQ01.lean
+++ b/proofs/Proofs/DerangementsOQ03OQ03OQ01.lean
@@ -1,0 +1,157 @@
+/-
+# Expected number of fixed points of a random permutation is `1`
+  (derangements-oq-03-oq-03-oq-01)
+
+## Open Question (OQ-01 of derangements-oq-03-oq-03)
+The parent entry (`derangements-oq-03-oq-03`, *Derangement Permutation Matrices and
+the 1/e Law*) packages a uniformly random `n × n` permutation matrix `σ.permMatrix ℝ`
+and identifies its **trace** with the number of fixed points of `σ`
+(`Matrix.trace_permutation`: `trace (σ.permMatrix ℝ) = (fixedPoints σ).ncard`).  The
+derangement side of the story — the probability that the trace is *zero* — converges to
+`1/e`.  The parent left open the complementary first-moment question:
+
+> What is the **expected trace** of a random permutation matrix, i.e. the expected
+> number of fixed points of a uniformly random permutation of `Fin n`?
+
+## Answer: exactly `1`, for every `n ≥ 1`.
+
+This is the classical "expected number of fixed points = 1" fact.  We prove it not by
+linearity of indicators but through the **Cauchy–Frobenius / Burnside count**: summing the
+number of fixed points of `σ` over *all* permutations equals the number of orbits of the
+permutation action times the order of the group,
+
+  `∑_{σ ∈ Sₙ} |Fix σ|  =  (#orbits) · |Sₙ|`.
+
+The natural action of `Equiv.Perm (Fin n)` on `Fin n` is transitive for `n ≥ 1`, so there is
+exactly **one** orbit, and the sum collapses to `1 · n! = n!`.  Dividing by the number of
+permutations `|Sₙ| = n!` gives the expected value `1`.
+
+The trace bridge from the parent turns this into a statement about permutation matrices:
+the average trace of an `n × n` permutation matrix is `1`.
+
+## Status
+- `0` sorries, `0` axioms, no `native_decide`.
+- Reuses the parent's `permMatrix`/trace layer and Mathlib's `Matrix.trace_permutation`.
+- The only new analytic ingredient is the Burnside count
+  `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` specialised to the transitive
+  symmetric-group action, plus the orbit-count `= 1` from pretransitivity.
+-/
+
+import Mathlib
+import Proofs.DerangementsOQ03OQ03
+
+namespace DerangementsOQ03OQ03OQ01
+
+open Equiv (Perm)
+open scoped BigOperators
+
+variable {n : ℕ}
+
+/-- The orbit space of the symmetric-group action on `Fin n` is finite (it is a quotient of the
+    finite type `Fin n`), so it carries a `Fintype` structure — needed to state the Burnside
+    count and its orbit cardinality. -/
+noncomputable instance instFintypeOrbitQuotient (n : ℕ) :
+    Fintype (MulAction.orbitRel.Quotient (Perm (Fin n)) (Fin n)) :=
+  Fintype.ofFinite _
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  The set of points fixed by `σ` *as a group element* is its fixed-point set
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The Mathlib group-action notion `MulAction.fixedBy (Fin n) σ` (points moved nowhere by
+    the permutation `σ` acting on `Fin n`) coincides with the dynamical fixed-point set
+    `Function.fixedPoints σ`.  Both are `{x | σ x = x}`; the only content is unfolding the
+    `Equiv.Perm` scalar action `σ • x = σ x`. -/
+theorem fixedBy_eq_fixedPoints (σ : Perm (Fin n)) :
+    MulAction.fixedBy (Fin n) σ = Function.fixedPoints σ := by
+  ext x
+  simp only [MulAction.mem_fixedBy, Equiv.Perm.smul_def, Function.mem_fixedPoints,
+    Function.IsFixedPt]
+
+/-- The number of fixed points, counted with `Set.ncard` (as in the parent's trace formula),
+    equals the `Fintype.card` of the group-action fixed set used by Burnside's lemma. -/
+theorem ncard_fixedPoints_eq_card_fixedBy (σ : Perm (Fin n)) :
+    (Function.fixedPoints σ).ncard = Fintype.card (MulAction.fixedBy (Fin n) σ) := by
+  rw [← fixedBy_eq_fixedPoints, Set.ncard_eq_toFinset_card', Set.toFinset_card]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  The symmetric group acts transitively on `Fin n` — a single orbit
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- For `n ≥ 1` the natural action of `Sₙ = Perm (Fin n)` on `Fin n` is transitive, hence has
+    exactly one orbit. -/
+theorem card_orbits_eq_one (n : ℕ) [NeZero n] :
+    Fintype.card (MulAction.orbitRel.Quotient (Perm (Fin n)) (Fin n)) = 1 := by
+  haveI : Nonempty (Fin n) := ⟨0⟩
+  obtain ⟨u⟩ :=
+    (MulAction.pretransitive_iff_unique_quotient_of_nonempty (G := Perm (Fin n))
+      (α := Fin n)).mp inferInstance
+  haveI := u
+  exact Fintype.card_unique
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  The Burnside count — total fixed points over all permutations is `n!`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Total fixed points = `n!`.**  Summed over *all* `n!` permutations of `Fin n`, the number
+    of fixed points totals `n!`.  This is the Cauchy–Frobenius (Burnside) count
+    `∑_σ |Fix σ| = (#orbits)·|Sₙ|` for the transitive symmetric-group action, where the single
+    orbit makes the right side `1 · n! = n!`. -/
+theorem sum_card_fixedBy (n : ℕ) [NeZero n] :
+    ∑ σ : Perm (Fin n), Fintype.card (MulAction.fixedBy (Fin n) σ) = n.factorial := by
+  have h := MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Perm (Fin n)) (Fin n)
+  rw [h, card_orbits_eq_one, one_mul, Fintype.card_perm, Fintype.card_fin]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  Trace bridge and the expected value
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Per-permutation trace = number of fixed points** (as a real number).  Specialisation of
+    the parent's `Matrix.trace_permutation` recast through the Burnside fixed-set count. -/
+theorem trace_permMatrix_eq_card_fixedBy (σ : Perm (Fin n)) :
+    Matrix.trace (σ.permMatrix ℝ) = (Fintype.card (MulAction.fixedBy (Fin n) σ) : ℝ) := by
+  rw [Matrix.trace_permutation, ncard_fixedPoints_eq_card_fixedBy]
+
+/-- **Total trace over all permutation matrices = `n!`.**  Summing the trace of `σ.permMatrix ℝ`
+    over all `σ ∈ Sₙ` gives `n!` (the Burnside count, transported through the trace bridge). -/
+theorem sum_trace_permMatrix (n : ℕ) [NeZero n] :
+    ∑ σ : Perm (Fin n), Matrix.trace (σ.permMatrix ℝ) = (n.factorial : ℝ) := by
+  calc ∑ σ : Perm (Fin n), Matrix.trace (σ.permMatrix ℝ)
+      = ∑ σ : Perm (Fin n), (Fintype.card (MulAction.fixedBy (Fin n) σ) : ℝ) :=
+        Finset.sum_congr rfl (fun σ _ => trace_permMatrix_eq_card_fixedBy σ)
+    _ = ((∑ σ : Perm (Fin n), Fintype.card (MulAction.fixedBy (Fin n) σ) : ℕ) : ℝ) := by
+        rw [Nat.cast_sum]
+    _ = (n.factorial : ℝ) := by rw [sum_card_fixedBy]
+
+/-- **Expected trace of a random permutation matrix is `1`.**  Averaging the trace over the
+    `|Sₙ| = n!` permutation matrices (each equally likely) yields exactly `1`: the expected
+    number of fixed points of a uniformly random permutation of `Fin n` is `1` for every
+    `n ≥ 1`.  This is the first-moment companion of the parent's `1/e` derangement law. -/
+theorem expected_trace_eq_one (n : ℕ) [NeZero n] :
+    (∑ σ : Perm (Fin n), Matrix.trace (σ.permMatrix ℝ)) / (Fintype.card (Perm (Fin n)) : ℝ)
+      = 1 := by
+  rw [sum_trace_permMatrix, Fintype.card_perm, Fintype.card_fin,
+    div_self (by exact_mod_cast Nat.factorial_ne_zero n)]
+
+/-- The same statement with the denominator written explicitly as `n!`. -/
+theorem expected_fixed_points_eq_one (n : ℕ) [NeZero n] :
+    (∑ σ : Perm (Fin n), (Fintype.card (MulAction.fixedBy (Fin n) σ) : ℝ)) / (n.factorial : ℝ)
+      = 1 := by
+  rw [← Nat.cast_sum, sum_card_fixedBy, div_self (by exact_mod_cast Nat.factorial_ne_zero n)]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+VERIFICATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+#check @fixedBy_eq_fixedPoints
+#check @sum_card_fixedBy
+#check @sum_trace_permMatrix
+#check @expected_trace_eq_one
+#check @expected_fixed_points_eq_one
+
+end DerangementsOQ03OQ03OQ01

--- a/src/data/proofs/derangements-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/derangements-oq-03-oq-03-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-derangements-oq03-oq03-oq01-header",
+    "proofId": "derangements-oq-03-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "insight",
+    "title": "Header: Expected Fixed Points via Orbit Counting",
+    "content": "The parent (derangements-oq-03-oq-03) identifies the trace of a random permutation matrix with the number of fixed points of the underlying permutation and studies P(trace = 0) — the 1/e derangement law. This entry answers its complementary first-moment question: the expected trace, i.e. the expected number of fixed points, is exactly 1 for every n ≥ 1. The chosen route is not linearity of indicators but the Cauchy–Frobenius/Burnside count ∑_g |Fix g| = (#orbits)·|G|, specialised to the transitive natural action of Sₙ on Fin n, where the single orbit makes the total 1·n! = n!."
+  },
+  {
+    "id": "ann-derangements-oq03-oq03-oq01-fixedby",
+    "proofId": "derangements-oq-03-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 86 },
+    "type": "technique",
+    "title": "Reconciling Two Notions of Fixed Set",
+    "content": "The parent's trace formula counts fixed points with Set.ncard of Function.fixedPoints σ, while Burnside's lemma counts with Fintype.card of the group-action set MulAction.fixedBy (Fin n) σ. Both are {x | σ x = x}: fixedBy_eq_fixedPoints unfolds the Equiv.Perm scalar action σ • x = σ x to identify the sets, and ncard_fixedPoints_eq_card_fixedBy converts Set.ncard to Fintype.card through Set.ncard_eq_toFinset_card' and Set.toFinset_card. This makes the parent's trace bridge composable with the Burnside count."
+  },
+  {
+    "id": "ann-derangements-oq03-oq03-oq01-orbits",
+    "proofId": "derangements-oq-03-oq-03-oq-01",
+    "range": { "startLine": 93, "endLine": 110 },
+    "type": "insight",
+    "title": "Transitivity Gives a Single Orbit",
+    "content": "The natural action of Perm (Fin n) on Fin n is pretransitive (Mathlib's Equiv.Perm.applyMulAction instance: any point can be sent to any other). For n ≥ 1 the space is nonempty, so pretransitive_iff_unique_quotient_of_nonempty supplies a Unique structure on the orbit quotient, and card_orbits_eq_one reads off Fintype.card = 1. The expected number of fixed points is therefore literally the number of orbits of Sₙ on Fin n — a structural reading of the value 1."
+  },
+  {
+    "id": "ann-derangements-oq03-oq03-oq01-burnside",
+    "proofId": "derangements-oq-03-oq-03-oq-01",
+    "range": { "startLine": 117, "endLine": 134 },
+    "type": "technique",
+    "title": "The Burnside Count Collapses to n!",
+    "content": "sum_card_fixedBy applies MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group to the symmetric-group action: ∑_{σ ∈ Sₙ} |Fix σ| = (#orbits)·|Sₙ|. With #orbits = 1 (card_orbits_eq_one) and |Sₙ| = n! (Fintype.card_perm, Fintype.card_fin) the right side is 1·n! = n!. No per-point stabiliser computation is needed; the transitive action does the bookkeeping."
+  },
+  {
+    "id": "ann-derangements-oq03-oq03-oq01-expected",
+    "proofId": "derangements-oq-03-oq-03-oq-01",
+    "range": { "startLine": 136, "endLine": 157 },
+    "type": "insight",
+    "title": "From Total to Expected Value",
+    "content": "trace_permMatrix_eq_card_fixedBy recasts the parent's Matrix.trace_permutation through the fixedBy count, sum_trace_permMatrix sums it to (n! : ℝ), and expected_trace_eq_one divides by |Perm (Fin n)| = n! to land on 1. The denominator is written as the genuine count of permutations, so the statement is manifestly an average over the uniform distribution on Sₙ — the first-moment companion of the parent's 1/e derangement probability."
+  }
+]

--- a/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "derangements-oq-03-oq-03-oq-01",
+  "slug": "derangements-oq-03-oq-03-oq-01",
+  "title": "Expected Number of Fixed Points of a Random Permutation is 1",
+  "description": "Closes the first open question of derangements-oq-03-oq-03: the expected trace of a uniformly random n×n permutation matrix — equivalently, the expected number of fixed points of a uniformly random permutation of Fin n — is exactly 1 for every n ≥ 1, independent of n. The proof routes through the Cauchy–Frobenius/Burnside count: summing the number of fixed points over all n! permutations equals (number of orbits)·|Sₙ|, and the natural symmetric-group action on Fin n is transitive (a single orbit) for n ≥ 1, so the total is 1·n! = n!. Averaging over the n! permutations gives the expected value 1. The parent's trace bridge trace (σ.permMatrix ℝ) = (fixedPoints σ).ncard turns the combinatorial total into a statement about the average trace of a permutation matrix. 0 axioms, 0 sorries, no native_decide.",
+  "overview": "The parent entry (derangements-oq-03-oq-03) identifies the trace of a random n×n permutation matrix with the number of fixed points of the underlying permutation and studies the probability that this trace is zero (the derangement / 1/e law). It left open the complementary first-moment question: what is the expected trace? This entry answers it: exactly 1, for all n ≥ 1.\n\nRather than the usual linearity-of-indicators argument (each of the n positions is fixed with probability 1/n, giving n·(1/n) = 1), the proof uses the Cauchy–Frobenius lemma (Burnside's counting lemma): the sum over all group elements of the number of points each fixes equals the number of orbits times the order of the group. For the symmetric group Sₙ acting naturally on Fin n, the action is transitive whenever n ≥ 1, so there is exactly one orbit and the sum of fixed-point counts collapses to 1·n! = n!. Dividing by |Sₙ| = n! yields the expected value 1.\n\nThe bridge to the parent's matrix picture is Mathlib's Matrix.trace_permutation, which equates the trace of σ.permMatrix with the cardinality of the fixed-point set. So the result reads equivalently as: the average trace of an n×n permutation matrix is 1.",
+  "conclusion": {
+    "summary": "For every n ≥ 1, summing the number of fixed points over all n! permutations of Fin n gives exactly n! (the Burnside count for the transitive symmetric-group action: one orbit times |Sₙ|). Equivalently, the total trace over all n×n permutation matrices is n!, and the average trace — the expected number of fixed points of a uniformly random permutation — is exactly 1, independent of n. All theorems are fully proved with 0 axioms and 0 sorries.",
+    "implications": "**1. First-moment companion to the 1/e law**: The parent studies P(trace = 0) → 1/e; this entry pins down E(trace) = 1 exactly, the complementary first moment of the same fixed-point statistic.\n\n**2. Orbit-counting proof**: The value 1 is exhibited as the number of orbits of the symmetric-group action, a structural reading rather than an arithmetic coincidence — the expected number of fixed points equals the number of orbits of Sₙ on Fin n.\n\n**3. Trace bridge reused**: The parent's identification of trace with fixed-point count (via Mathlib's Matrix.trace_permutation) carries the combinatorial total directly into the language of random permutation matrices.",
+    "openQuestions": [
+      "Does the variance of the number of fixed points also equal 1 (so that the fixed-point count is asymptotically Poisson(1)), and can the factorial-moment identity E[(X)_k] = 1 for k ≤ n be formalized?",
+      "Can the orbit-counting argument be lifted to the expected number of k-cycles of a random permutation, recovering 1/k as the expected count?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsOQ03OQ03"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "DerangementsOQ03OQ03OQ01",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsOQ03OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "expected_trace_eq_one",
+      "type": "core",
+      "description": "(∑ σ, trace (σ.permMatrix ℝ)) / |Perm (Fin n)| = 1 — the expected trace of a random permutation matrix, i.e. the expected number of fixed points of a uniformly random permutation of Fin n, is exactly 1 for n ≥ 1."
+    },
+    {
+      "name": "sum_card_fixedBy",
+      "type": "core",
+      "description": "∑_{σ ∈ Sₙ} |Fix σ| = n! — the Burnside count of total fixed points over all permutations, equal to (number of orbits = 1)·|Sₙ|."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Fixed Set as a Group-Action Fixed Set"
+    },
+    {
+      "title": "Transitivity: a Single Orbit"
+    },
+    {
+      "title": "The Burnside Count: Total Fixed Points = n!"
+    },
+    {
+      "title": "Trace Bridge and the Expected Value"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, William",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "venue": "Cambridge University Press",
+      "note": "Source of the orbit-counting (Cauchy–Frobenius) lemma ∑_g |Fix g| = (#orbits)·|G| used here."
+    },
+    {
+      "authors": "de Montmort, Pierre Rémond",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris",
+      "note": "Origin of the matching/rencontre problem whose first moment (expected number of matches) is 1."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question. The parent identifies trace (σ.permMatrix ℝ) with the number of fixed points and studies P(trace = 0) (the 1/e derangement law); this entry computes the complementary first moment E(trace) = 1 via the Burnside count, reusing the parent's trace bridge."
+    }
+  ],
+  "sorries": 0,
+  "meta": {
+    "assumptions": [],
+    "author": "Burnside / Cauchy–Frobenius count, formalized in Lean 4",
+    "badge": "mathlib",
+    "status": "verified",
+    "originalContributions": [
+      "Identification of the parent's fixed-point set (Function.fixedPoints σ, counted by Set.ncard in the trace formula) with the group-action fixed set MulAction.fixedBy (Fin n) σ counted by Fintype.card",
+      "Orbit count = 1: the symmetric-group action on Fin n is transitive for n ≥ 1, so its orbit quotient is a singleton (card_orbits_eq_one)",
+      "Burnside total: ∑_{σ ∈ Sₙ} |Fix σ| = n!, specialising MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group to the transitive symmetric-group action",
+      "Trace bridge: total trace ∑_σ trace (σ.permMatrix ℝ) = n! and the expected trace (∑_σ trace)/|Sₙ| = 1, the first-moment companion of the parent's 1/e derangement law"
+    ],
+    "prerequisites": [
+      "Mathlib group-action API (MulAction.fixedBy, orbitRel.Quotient, IsPretransitive for Equiv.Perm)",
+      "Burnside / Cauchy–Frobenius lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
+      "Parent permutation-matrix trace bridge (Matrix.trace_permutation)",
+      "Fintype cardinality lemmas (Fintype.card_perm, Fintype.card_fin)"
+    ],
+    "tags": [
+      "combinatorics",
+      "linear-algebra",
+      "matrices",
+      "derangements",
+      "probability",
+      "group-actions",
+      "burnside"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside / Cauchy–Frobenius lemma: the sum over group elements of the number of fixed points equals the number of orbits times the order of the group",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MulAction.pretransitive_iff_unique_quotient_of_nonempty",
+        "description": "A nonempty action is pretransitive iff its orbit quotient is a singleton (Unique)",
+        "module": "Mathlib.GroupTheory.GroupAction.Basic"
+      },
+      {
+        "theorem": "Equiv.Perm.applyMulAction",
+        "description": "The natural (transitive) action of the symmetric group Perm α on α by evaluation",
+        "module": "Mathlib.Algebra.Group.Action.End"
+      },
+      {
+        "theorem": "Matrix.trace_permutation",
+        "description": "The trace of a permutation matrix equals the cardinality of the fixed-point set",
+        "module": "Mathlib.LinearAlgebra.Matrix.Permutation"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "The number of permutations of a finite type is the factorial of its cardinality",
+        "module": "Mathlib.Data.Fintype.Perm"
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/DerangementsOQ03OQ03OQ01.lean",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Random_permutation_statistics"
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **first open question** of `derangements-oq-03-oq-03` (*Derangement Permutation Matrices and the 1/e Law*):

> Can the expected number of fixed points (the expected trace of a random permutation matrix) be formalized as exactly 1 for all n ≥ 1, independent of n?

**Answer: yes — exactly 1, for every n ≥ 1.**

## Approach

Rather than linearity of indicators, the proof routes through the **Cauchy–Frobenius / Burnside count**:

```
∑_{σ ∈ Sₙ} |Fix σ|  =  (#orbits) · |Sₙ|
```

The natural action of `Perm (Fin n)` on `Fin n` is transitive for `n ≥ 1`, so there is exactly **one orbit** and the total collapses to `1 · n! = n!`. Averaging over the `n!` permutations gives the expected value `1`. The value `1` is thus exhibited as the *number of orbits* of Sₙ on Fin n — a structural reading, not an arithmetic coincidence.

The parent's trace bridge `Matrix.trace_permutation : trace (σ.permMatrix ℝ) = (fixedPoints σ).ncard` carries the combinatorial total into the language of random permutation matrices, so the headline reads equivalently as **the average trace of an n×n permutation matrix is 1**.

## Key theorems

- `sum_card_fixedBy` : `∑_{σ ∈ Sₙ} |Fix σ| = n!` (the Burnside count)
- `card_orbits_eq_one` : the transitive action has a single orbit
- `sum_trace_permMatrix` : `∑_σ trace (σ.permMatrix ℝ) = n!`
- `expected_trace_eq_one` : `(∑_σ trace (σ.permMatrix ℝ)) / |Perm (Fin n)| = 1`

## Verification

- **8 theorems, 1 instance, 157 lines**
- **0 axioms, 0 sorries, no `native_decide`** — `#print axioms` lists only `propext, Classical.choice, Quot.sound`
- Builds against the parent file `Proofs.DerangementsOQ03OQ03` and Mathlib's group-action API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)