### PR TITLE
research(leibniz-pi-oq-01-oq-02): geometric truncation rate for the arctangent series [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3311,6 +3311,7 @@ import Proofs.LegendrePartial
 import Proofs.LegendrePrimeGapSqrtBoundSuffices
 import Proofs.LeibnizPi
 import Proofs.LeibnizPiOQ01OQ01
+import Proofs.LeibnizPiOQ01OQ02
 import Proofs.LeibnizPiOQ02
 import Proofs.LeibnizPiOQ02Aristotle
 import Proofs.LeibnizPiOQ03

--- a/proofs/Proofs/LeibnizPiOQ01OQ02.lean
+++ b/proofs/Proofs/LeibnizPiOQ01OQ02.lean
@@ -1,0 +1,152 @@
+import Mathlib.Analysis.SpecialFunctions.Complex.Arctan
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Tactic
+
+/-
+  Geometric Truncation Rate for the Arctangent Power Series (leibniz-pi-oq-01-oq-02)
+
+  The parent entry ("Optimal Convergence Rate for Arctangent-Based Pi Series",
+  leibniz-pi-oq-01) proves that the Leibniz series π/4 = Σ (-1)ⁿ/(2n+1) — the
+  arctangent series evaluated at x = 1 — converges at the *boundary* rate Θ(1/N),
+  and *asserts informally* that "Machin-type formulas achieve exponential
+  O(1/m^(2N)) rates instead."
+
+  This entry makes that informal claim a theorem. For the arctangent series
+
+        arctan x = Σₙ (-1)ⁿ xⁿ⁺¹ / (2n+1)              (Real.hasSum_arctan)
+
+  evaluated at any 0 ≤ x < 1, we prove the explicit *geometric* truncation bound
+
+        |arctan x − Σ_{n<N} (-1)ⁿ x^(2n+1)/(2n+1)|  ≤  x^(2N+1) / (1 − x²).
+
+  Since the right-hand side is x^(2N+1)/(1−x²) = O((x²)ᴺ), the error decays
+  exponentially in N for every x strictly inside the unit interval. The Leibniz
+  case x = 1 sits exactly on the boundary where the factor (1 − x²)⁻¹ blows up,
+  which is precisely *why* the parent's Θ(1/N) rate is only achieved there and
+  Machin-type evaluations at small x are exponentially faster.
+
+  As a concrete corollary we bound the truncation error of Machin's formula
+  4·arctan(1/5) − arctan(1/239) = π/4 after N terms of each series, exhibiting
+  the (1/5)^(2N) decay.
+
+  Engine: `Real.hasSum_arctan` (the series), `hasSum_nat_add_iff'` (the tail as a
+  shifted HasSum), `hasSum_geometric_of_lt_one` (the dominating geometric series),
+  and `tsum_of_norm_bounded` (direct comparison). 0 axioms, 0 sorries, no
+  native_decide.
+-/
+
+namespace LeibnizPiOQ01OQ02
+
+open Finset Real
+
+set_option maxHeartbeats 800000
+
+/-- The `n`-th term of the arctangent power series, matching `Real.hasSum_arctan`. -/
+noncomputable def arctanTerm (x : ℝ) (n : ℕ) : ℝ :=
+  (-1) ^ n * x ^ (2 * n + 1) / ((2 * n + 1 : ℕ) : ℝ)
+
+/-- The `N`-term truncation (partial sum) of the arctangent series at `x`. -/
+noncomputable def arctanPartial (x : ℝ) (N : ℕ) : ℝ :=
+  ∑ n ∈ range N, arctanTerm x n
+
+/-- Each arctangent-series term is dominated in absolute value by `x^(2n+1)`
+(for `x ≥ 0`): the `1/(2n+1)` factor only shrinks it. -/
+theorem abs_arctanTerm_le {x : ℝ} (hx : 0 ≤ x) (n : ℕ) :
+    |arctanTerm x n| ≤ x ^ (2 * n + 1) := by
+  have hpow : (0 : ℝ) ≤ x ^ (2 * n + 1) := by positivity
+  have hden : (1 : ℝ) ≤ ((2 * n + 1 : ℕ) : ℝ) := by
+    exact_mod_cast Nat.one_le_iff_ne_zero.mpr (by omega)
+  calc |arctanTerm x n|
+      = x ^ (2 * n + 1) / ((2 * n + 1 : ℕ) : ℝ) := by
+        unfold arctanTerm
+        rw [abs_div, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul,
+          abs_of_nonneg hpow, abs_of_nonneg (by positivity)]
+    _ ≤ x ^ (2 * n + 1) := div_le_self hpow hden
+
+/-- The arctangent series has sum `arctan x` for `0 ≤ x < 1` (specialization of
+`Real.hasSum_arctan`). -/
+theorem hasSum_arctanTerm {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x < 1) :
+    HasSum (arctanTerm x) (arctan x) := by
+  have hnorm : ‖x‖ < 1 := by rw [Real.norm_eq_abs, abs_of_nonneg hx0]; exact hx1
+  exact Real.hasSum_arctan hnorm
+
+/-- The dominating geometric tail: `Σᵢ x^(2(i+N)+1) = x^(2N+1) · (1−x²)⁻¹`. -/
+theorem hasSum_geom_tail {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x < 1) (N : ℕ) :
+    HasSum (fun i : ℕ => x ^ (2 * (i + N) + 1))
+      (x ^ (2 * N + 1) * (1 - x ^ 2)⁻¹) := by
+  have hx2 : (0 : ℝ) ≤ x ^ 2 := sq_nonneg x
+  have hx2lt : x ^ 2 < 1 := by nlinarith
+  have hgeo : HasSum (fun i : ℕ => (x ^ 2) ^ i) (1 - x ^ 2)⁻¹ :=
+    hasSum_geometric_of_lt_one hx2 hx2lt
+  have hgeo' : HasSum (fun i : ℕ => x ^ (2 * N + 1) * (x ^ 2) ^ i)
+      (x ^ (2 * N + 1) * (1 - x ^ 2)⁻¹) := hgeo.mul_left _
+  have hfun : (fun i : ℕ => x ^ (2 * (i + N) + 1))
+      = (fun i : ℕ => x ^ (2 * N + 1) * (x ^ 2) ^ i) := by
+    funext i
+    rw [show 2 * (i + N) + 1 = (2 * N + 1) + 2 * i by ring, pow_add, pow_mul]
+  rw [hfun]
+  exact hgeo'
+
+/-- **Geometric truncation rate for the arctangent series.**
+For every `0 ≤ x < 1` and every `N`, the error of the `N`-term arctangent
+partial sum is bounded by a single geometric quantity:
+
+  `|arctan x − arctanPartial x N| ≤ x^(2N+1) / (1 − x²)`.
+
+The bound is `O((x²)ᴺ)`, i.e. exponential decay in `N` whenever `x < 1`. -/
+theorem arctan_series_error_bound {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x < 1) (N : ℕ) :
+    |arctan x - arctanPartial x N| ≤ x ^ (2 * N + 1) / (1 - x ^ 2) := by
+  -- The tail of the series, written as a shifted `HasSum`.
+  have htail : HasSum (fun i => arctanTerm x (i + N))
+      (arctan x - arctanPartial x N) :=
+    (hasSum_nat_add_iff' N).mpr (hasSum_arctanTerm hx0 hx1)
+  have heq : arctan x - arctanPartial x N = ∑' i, arctanTerm x (i + N) :=
+    htail.tsum_eq.symm
+  rw [heq, div_eq_mul_inv]
+  -- Dominate the tail term-by-term by the geometric tail.
+  have key : ‖∑' i, arctanTerm x (i + N)‖ ≤ x ^ (2 * N + 1) * (1 - x ^ 2)⁻¹ := by
+    refine tsum_of_norm_bounded (hasSum_geom_tail hx0 hx1 N) (fun i => ?_)
+    rw [Real.norm_eq_abs]
+    exact abs_arctanTerm_le hx0 (i + N)
+  rwa [Real.norm_eq_abs] at key
+
+/-- Machin's identity (Mathlib), restated for the `1/5`, `1/239` arguments. -/
+theorem machin_identity :
+    4 * arctan (1 / 5 : ℝ) - arctan (1 / 239 : ℝ) = π / 4 := by
+  simp only [one_div]
+  exact four_mul_arctan_inv_5_sub_arctan_inv_239
+
+/-- **Exponential rate of Machin's formula (the parent's informal claim, proved).**
+Truncating each arctangent series in `4·arctan(1/5) − arctan(1/239) = π/4` after
+`N` terms gives an error bounded by
+
+  `4·(1/5)^(2N+1)/(1 − (1/5)²) + (1/239)^(2N+1)/(1 − (1/239)²)`,
+
+which decays like `(1/5)^(2N)` — exponentially faster than the Leibniz series'
+`Θ(1/N)` at `x = 1`. -/
+theorem machin_partial_error_bound (N : ℕ) :
+    |π / 4 - (4 * arctanPartial (1 / 5) N - arctanPartial (1 / 239) N)|
+      ≤ 4 * ((1 / 5 : ℝ) ^ (2 * N + 1) / (1 - (1 / 5) ^ 2))
+        + (1 / 239 : ℝ) ^ (2 * N + 1) / (1 - (1 / 239) ^ 2) := by
+  have h5 : |arctan (1 / 5 : ℝ) - arctanPartial (1 / 5) N|
+      ≤ (1 / 5 : ℝ) ^ (2 * N + 1) / (1 - (1 / 5) ^ 2) :=
+    arctan_series_error_bound (by norm_num) (by norm_num) N
+  have h239 : |arctan (1 / 239 : ℝ) - arctanPartial (1 / 239) N|
+      ≤ (1 / 239 : ℝ) ^ (2 * N + 1) / (1 - (1 / 239) ^ 2) :=
+    arctan_series_error_bound (by norm_num) (by norm_num) N
+  -- Rewrite π/4 via Machin and split the error along the two series.
+  have hsplit : π / 4 - (4 * arctanPartial (1 / 5) N - arctanPartial (1 / 239) N)
+      = 4 * (arctan (1 / 5 : ℝ) - arctanPartial (1 / 5) N)
+        - (arctan (1 / 239 : ℝ) - arctanPartial (1 / 239) N) := by
+    rw [← machin_identity]; ring
+  rw [hsplit]
+  set a := arctan (1 / 5 : ℝ) - arctanPartial (1 / 5) N with ha
+  set b := arctan (1 / 239 : ℝ) - arctanPartial (1 / 239) N with hb
+  have htri : |4 * a - b| ≤ 4 * |a| + |b| := by
+    rw [abs_le]
+    constructor <;>
+      linarith [le_abs_self a, neg_abs_le a, le_abs_self b, neg_abs_le b]
+  linarith [htri, h5, h239]
+
+end LeibnizPiOQ01OQ02

--- a/src/data/proofs/leibniz-pi-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-leibniz0102-header",
+    "proofId": "leibniz-pi-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "Quantifying the parent's informal exponential-rate claim",
+    "content": "The parent entry (leibniz-pi-oq-01) proves the Leibniz/arctan series at $x=1$ converges at the sharp boundary rate $\\Theta(1/N)$ and *asserts* that 'Machin-type formulas achieve exponential $O(1/m^{2N})$ rates instead.' This entry turns that assertion into a theorem: for every $0 \\le x < 1$ the truncation error of the arctangent power series is bounded by the single geometric quantity $x^{2N+1}/(1-x^2)$, which is $O((x^2)^N)$. The Leibniz slowdown is exactly the $x \\to 1$ degeneration of this bound, where $(1-x^2)^{-1}$ diverges.",
+    "mathContext": "$\\arctan x = \\sum_n (-1)^n x^{2n+1}/(2n+1)$; truncation error $\\le x^{2N+1}/(1-x^2)$ for $0 \\le x < 1$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["arctan power series", "convergence rate", "Machin's formula", "Leibniz series", "geometric majorant"],
+    "prerequisites": ["Real.hasSum_arctan", "hasSum_geometric_of_lt_one"]
+  },
+  {
+    "id": "ann-leibniz0102-tail",
+    "proofId": "leibniz-pi-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 135 },
+    "type": "technique",
+    "title": "Remainder as a shifted HasSum, then geometric comparison",
+    "content": "The crux is `hasSum_nat_add_iff'`, which identifies the partial-sum remainder $\\arctan x - \\sum_{n<N} a_n$ with a genuine infinite sum $\\sum_i a_{i+N}$ of the shifted sequence. This converts a finite-truncation statement into an infinite-sum comparison closeable by `tsum_of_norm_bounded`: each tail term is dominated by $x^{2(i+N)+1}$ (the $1/(2n+1)$ factor only shrinks it), and the dominating series is geometric with closed-form sum $x^{2N+1}(1-x^2)^{-1}$.",
+    "mathContext": "$\\arctan x - \\sum_{n<N} a_n = \\sum_i a_{i+N}$, $|a_{i+N}| \\le x^{2(i+N)+1}$, $\\sum_i x^{2(i+N)+1} = x^{2N+1}(1-x^2)^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["series tail", "comparison test", "geometric series"],
+    "prerequisites": ["hasSum_nat_add_iff'", "tsum_of_norm_bounded"]
+  },
+  {
+    "id": "ann-leibniz0102-machin",
+    "proofId": "leibniz-pi-oq-01-oq-02",
+    "range": { "startLine": 136, "endLine": 152 },
+    "type": "concept",
+    "title": "Machin's exponential advantage as a corollary",
+    "content": "Rewriting $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$ (Mathlib's `four_mul_arctan_inv_5_sub_arctan_inv_239`) and splitting the error with the triangle inequality yields an explicit two-term bound on the $N$-term Machin truncation error. Because the dominant term decays like $(1/5)^{2N}$, each additional term buys a fixed number of digits — the precise sense in which Machin (1706) beat the Leibniz series.",
+    "mathContext": "$|\\pi/4 - (4 S_{1/5} - S_{1/239})| \\le 4\\frac{(1/5)^{2N+1}}{1-(1/5)^2} + \\frac{(1/239)^{2N+1}}{1-(1/239)^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Machin's formula", "pi computation", "exponential convergence"],
+    "prerequisites": ["four_mul_arctan_inv_5_sub_arctan_inv_239", "triangle inequality"]
+  }
+]

--- a/src/data/proofs/leibniz-pi-oq-01-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-01-oq-02/meta.json
@@ -1,0 +1,204 @@
+{
+  "id": "leibniz-pi-oq-01-oq-02",
+  "title": "Geometric Truncation Rate for the Arctangent Power Series",
+  "slug": "leibniz-pi-oq-01-oq-02",
+  "description": "Turns the parent's informal claim that 'Machin-type formulas achieve exponential O(1/m^(2N)) rates' into a theorem. For the arctangent power series arctan(x) = sum (-1)^n x^(2n+1)/(2n+1), we prove the explicit geometric truncation bound |arctan(x) - sum_{n<N} (-1)^n x^(2n+1)/(2n+1)| <= x^(2N+1)/(1-x^2) for every 0 <= x < 1. The bound is O((x^2)^N), so the error decays exponentially in N for every x strictly inside the unit interval; the Leibniz case x=1 sits exactly on the boundary where the factor (1-x^2)^{-1} blows up, which is precisely why the parent's Theta(1/N) rate is only achieved there. A concrete corollary bounds the truncation error of Machin's formula 4*arctan(1/5) - arctan(1/239) = pi/4 after N terms of each series, exhibiting the (1/5)^(2N) decay.",
+  "meta": {
+    "author": "Researcher agent (lean-genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inverse_trigonometric_functions#Infinite_series",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LeibnizPiOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "pi",
+      "arctangent",
+      "series",
+      "convergence-rate",
+      "error-bound",
+      "machin",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasSum_arctan",
+        "description": "The arctangent power series HasSum (fun n => (-1)^n x^(2n+1)/(2n+1)) (arctan x) for ‖x‖ < 1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arctan"
+      },
+      {
+        "theorem": "hasSum_nat_add_iff'",
+        "description": "Identifies the series tail as a shifted HasSum: HasSum (fun n => f (n+k)) (a - sum_{i<k} f i) iff HasSum f a",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "hasSum_geometric_of_lt_one",
+        "description": "The geometric series HasSum (fun n => r^n) (1-r)^{-1} for 0 <= r < 1, used to sum the dominating tail",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "tsum_of_norm_bounded",
+        "description": "Direct comparison test: ‖tsum f‖ <= a when HasSum g a and ‖f i‖ <= g i pointwise",
+        "module": "Mathlib.Analysis.Normed.Group.InfiniteSum"
+      },
+      {
+        "theorem": "four_mul_arctan_inv_5_sub_arctan_inv_239",
+        "description": "Machin's formula 4*arctan(5^{-1}) - arctan(239^{-1}) = pi/4",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan"
+      }
+    ],
+    "originalContributions": [
+      "arctan_series_error_bound: the explicit geometric truncation bound |arctan x - sum_{n<N} (-1)^n x^(2n+1)/(2n+1)| <= x^(2N+1)/(1-x^2) for 0 <= x < 1",
+      "machin_partial_error_bound: a concrete two-term bound on the N-term truncation error of Machin's formula, realizing the parent's informally-stated exponential (1/5)^(2N) rate",
+      "hasSum_geom_tail: packages the dominating geometric tail sum_i x^(2(i+N)+1) = x^(2N+1)(1-x^2)^{-1}",
+      "abs_arctanTerm_le: the term-domination estimate |(-1)^n x^(2n+1)/(2n+1)| <= x^(2n+1) for x >= 0"
+    ],
+    "references": [
+      {
+        "authors": "Machin, John",
+        "title": "Computation of pi to 100 digits via 4*arctan(1/5) - arctan(1/239) = pi/4",
+        "year": "1706",
+        "venue": "Philosophical Transactions of the Royal Society",
+        "note": "Original Machin formula; the source of the exponential-convergence advantage quantified here"
+      },
+      {
+        "authors": "Gregory, James; Leibniz, Gottfried",
+        "title": "The series arctan(x) = x - x^3/3 + x^5/5 - ...",
+        "year": "1671",
+        "venue": "historical",
+        "note": "The arctangent power series whose truncation rate is bounded in this entry"
+      }
+    ],
+    "prerequisites": [
+      "Power series for arctangent: arctan(x) = sum (-1)^n x^(2n+1)/(2n+1) for |x| < 1",
+      "Convergence of geometric series sum r^n = 1/(1-r) for |r| < 1",
+      "Comparison test for absolutely convergent series",
+      "Triangle inequality for the absolute value",
+      "Machin's formula pi/4 = 4*arctan(1/5) - arctan(1/239)"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 152,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Gregory-Leibniz series $\\arctan(x) = x - x^3/3 + x^5/5 - \\cdots$ (1671) is the workhorse behind every classical hand-computation of $\\pi$. Evaluated at $x = 1$ it gives the Leibniz formula $\\pi/4 = 1 - 1/3 + 1/5 - \\cdots$, whose error after $N$ terms is only $\\Theta(1/N)$ — the boundary of convergence, so slow that computing 10 correct digits would need billions of terms. The parent entry (leibniz-pi-oq-01) proves this $\\Theta(1/N)$ rate is sharp and observes informally that Machin-type evaluations at *small* arguments converge exponentially faster. This entry makes that observation precise: for any $0 \\le x < 1$ the truncation error is dominated by a single geometric quantity $x^{2N+1}/(1-x^2)$, decaying like $(x^2)^N$. John Machin (1706) exploited exactly this by writing $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$, where the series converge at rates $O(5^{-2N})$ and $O(239^{-2N})$ — yielding 100 digits of $\\pi$ where the Leibniz series gave a handful.",
+    "problemStatement": "**Open question (from the parent, leibniz-pi-oq-01):** the parent proves the Leibniz/arctan series at $x=1$ converges at the sharp boundary rate $\\Theta(1/N)$ and *asserts* that 'Machin-type formulas achieve exponential $O(1/m^{2N})$ rates instead.' Prove this exponential claim as a theorem and connect it to Machin's formula.\n\n**Resolution:** For $0 \\le x < 1$,\n$$\\left|\\arctan x - \\sum_{n<N} \\frac{(-1)^n x^{2n+1}}{2n+1}\\right| \\le \\frac{x^{2N+1}}{1-x^2},$$\nwhich is $O((x^2)^N)$. Applying this to $x = 1/5$ and $x = 1/239$ inside Machin's identity bounds the $N$-term truncation error of $\\pi/4$ by $4\\cdot\\frac{(1/5)^{2N+1}}{1-(1/5)^2} + \\frac{(1/239)^{2N+1}}{1-(1/239)^2}$, exhibiting the $(1/5)^{2N}$ decay.",
+    "text": "A six-theorem, 152-line entry (0 axioms, 0 sorries, no native_decide). Starting from Mathlib's `Real.hasSum_arctan`, the proof identifies the series tail $\\arctan x - \\sum_{n<N} a_n$ with the shifted infinite sum $\\sum_i a_{i+N}$ using `hasSum_nat_add_iff'`, dominates each tail term by $x^{2(i+N)+1}$ (the $1/(2n+1)$ factor only shrinks it, lemma `abs_arctanTerm_le`), sums the dominating geometric tail in closed form $x^{2N+1}(1-x^2)^{-1}$ (`hasSum_geom_tail` via `hasSum_geometric_of_lt_one`), and applies the comparison test `tsum_of_norm_bounded` to obtain the headline bound `arctan_series_error_bound`. A second theorem `machin_partial_error_bound` rewrites $\\pi/4$ through Mathlib's Machin identity and the triangle inequality to produce an explicit two-term geometric bound on the $N$-term Machin truncation error.",
+    "proofStrategy": "1. **Series and tail.** `Real.hasSum_arctan` gives `HasSum (arctanTerm x) (arctan x)` for $\\|x\\| < 1$. The additive lemma `hasSum_nat_add_iff'` turns the partial-sum remainder into a genuine `HasSum` of the shifted sequence, so $\\arctan x - \\text{arctanPartial}\\,x\\,N = \\sum_i \\text{arctanTerm}\\,x\\,(i+N)$.\n2. **Term domination.** For $x \\ge 0$, $\\left|(-1)^n x^{2n+1}/(2n+1)\\right| = x^{2n+1}/(2n+1) \\le x^{2n+1}$ since the denominator is $\\ge 1$ (`abs_arctanTerm_le`, via `div_le_self`).\n3. **Geometric tail.** $\\sum_i x^{2(i+N)+1} = x^{2N+1}\\sum_i (x^2)^i = x^{2N+1}(1-x^2)^{-1}$ using `hasSum_geometric_of_lt_one` with $0 \\le x^2 < 1$ (`hasSum_geom_tail`).\n4. **Comparison.** `tsum_of_norm_bounded` applied to the geometric `HasSum` and the pointwise bound yields $\\left|\\sum_i \\text{arctanTerm}\\,x\\,(i+N)\\right| \\le x^{2N+1}(1-x^2)^{-1}$, i.e. the headline error bound.\n5. **Machin corollary.** Rewrite $\\pi/4 = 4\\arctan(1/5) - \\arctan(1/239)$, split the error with the triangle inequality, and bound each arctangent error by step 4.",
+    "keyInsights": [
+      "The arctangent truncation error has a clean geometric majorant x^(2N+1)/(1-x^2) for every 0 <= x < 1 — no alternating-series monotonicity argument is needed, just term-by-term comparison to a geometric series.",
+      "The Leibniz Theta(1/N) rate is exactly the x -> 1 boundary degeneration of this bound: as x -> 1 the factor (1-x^2)^{-1} diverges, so the geometric estimate gives no information at x = 1 — explaining structurally why the parent's slow rate occurs only there.",
+      "Identifying the partial-sum remainder with a shifted HasSum (hasSum_nat_add_iff') is the key move: it converts a finite-truncation statement into an infinite-sum comparison that tsum_of_norm_bounded can close directly.",
+      "Dropping the 1/(2n+1) denominator (it is >= 1) loses nothing asymptotically and reduces the whole tail to a geometric series — the cheapest possible majorant.",
+      "Machin's exponential advantage is now a corollary, not folklore: each additional term of the 1/5 series contributes a fixed number of digits because the error is bounded by a constant times (1/5)^(2N)."
+    ],
+    "prerequisites": [
+      "Real analysis (power series, absolute convergence, comparison test)",
+      "Geometric series and their closed-form sums",
+      "Elementary properties of arctangent"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Imports, Module Documentation, and Definitions",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports Mathlib's complex/real arctan series API, specific limits, and tactics. The module docstring frames the result as the quantitative version of the parent's informal exponential-rate claim. Defines arctanTerm (matching Real.hasSum_arctan) and arctanPartial (the N-term truncation).",
+      "mathContext": "arctanTerm x n = $(-1)^n x^{2n+1}/(2n+1)$; arctanPartial x N = $\\sum_{n<N}$ arctanTerm x n."
+    },
+    {
+      "id": "term-bound",
+      "title": "Term Domination",
+      "startLine": 57,
+      "endLine": 78,
+      "summary": "abs_arctanTerm_le: for x >= 0, |arctanTerm x n| <= x^(2n+1), since the 1/(2n+1) factor (denominator >= 1) only shrinks the term. Proved via div_le_self.",
+      "mathContext": "$\\left|(-1)^n x^{2n+1}/(2n+1)\\right| = x^{2n+1}/(2n+1) \\le x^{2n+1}$ for $x \\ge 0$."
+    },
+    {
+      "id": "series-tail",
+      "title": "The Arctangent Series and its Geometric Tail",
+      "startLine": 79,
+      "endLine": 110,
+      "summary": "hasSum_arctanTerm specializes Real.hasSum_arctan to 0 <= x < 1. hasSum_geom_tail evaluates the dominating tail sum_i x^(2(i+N)+1) = x^(2N+1)(1-x^2)^{-1} by factoring out x^(2N+1) and summing the geometric series in x^2.",
+      "mathContext": "$\\sum_i x^{2(i+N)+1} = x^{2N+1}\\sum_i (x^2)^i = x^{2N+1}(1-x^2)^{-1}$ for $0 \\le x < 1$."
+    },
+    {
+      "id": "main-bound",
+      "title": "Geometric Truncation Rate (headline)",
+      "startLine": 111,
+      "endLine": 135,
+      "summary": "arctan_series_error_bound: |arctan x - arctanPartial x N| <= x^(2N+1)/(1-x^2). The remainder is identified with the shifted HasSum via hasSum_nat_add_iff', then bounded by the geometric tail using tsum_of_norm_bounded and the term domination.",
+      "mathContext": "$\\left|\\arctan x - \\sum_{n<N} \\frac{(-1)^n x^{2n+1}}{2n+1}\\right| \\le \\frac{x^{2N+1}}{1-x^2}$, an $O((x^2)^N)$ bound."
+    },
+    {
+      "id": "machin",
+      "title": "Exponential Rate of Machin's Formula",
+      "startLine": 136,
+      "endLine": 152,
+      "summary": "machin_identity restates Mathlib's Machin formula. machin_partial_error_bound bounds the N-term truncation error of 4*arctan(1/5) - arctan(1/239) = pi/4 by 4*(1/5)^(2N+1)/(1-(1/5)^2) + (1/239)^(2N+1)/(1-(1/239)^2), realizing the parent's exponential claim.",
+      "mathContext": "$\\left|\\pi/4 - (4\\,S_{1/5} - S_{1/239})\\right| \\le 4\\frac{(1/5)^{2N+1}}{1-(1/5)^2} + \\frac{(1/239)^{2N+1}}{1-(1/239)^2}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The arctangent power series truncation error obeys the explicit geometric bound x^(2N+1)/(1-x^2) for every 0 <= x < 1, an O((x^2)^N) exponential rate. The Leibniz Theta(1/N) rate is recovered as the x -> 1 boundary case where this bound degenerates. Applying the bound inside Machin's formula gives an explicit two-term estimate exhibiting (1/5)^(2N) decay. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This resolves the parent's informally-stated claim that Machin-type formulas converge exponentially: it is now a theorem with an explicit constant, not folklore. The headline bound is uniform in x and shows precisely where the Leibniz slowdown comes from — the vanishing of 1 - x^2 at the unit circle. The same comparison technique applies to any arctan-based pi formula, bounding its truncation error by a sum of geometric terms determined by the arguments.",
+    "openQuestions": [
+      "Sharpen the constant: the alternating-series bound gives the tighter |arctan x - S_N| <= x^(2N+1)/(2N+1) for 0 <= x <= 1; prove this and compare to the geometric bound (which is looser for x near 1 but trivial to state uniformly).",
+      "Derive a digit-accuracy corollary: how many terms N of the 1/5 and 1/239 series guarantee k correct decimal digits of pi from Machin's formula?",
+      "Generalize the geometric truncation bound to multi-term Machin-like formulas sum c_k arctan(1/m_k) = pi/4 and minimize the total work for fixed accuracy."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "leibniz-pi-oq-01",
+      "relationship": "resolves",
+      "description": "Proves the parent's informally-stated claim that Machin-type formulas achieve exponential O(1/m^(2N)) convergence, as an explicit geometric truncation bound"
+    },
+    {
+      "targetId": "leibniz-pi-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling proves Machin's identity from the arctan addition formula; this entry quantifies how fast the resulting series converges"
+    },
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "extends",
+      "description": "Quantifies the exponential alternative to the slowly-converging Leibniz series"
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "uses-concept",
+      "description": "The truncation error is dominated by a geometric series in x^2, summed in closed form"
+    },
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "uses-concept",
+      "description": "The arctangent power series whose truncation is bounded is a Taylor expansion"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Complex.Arctan",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Real"
+    ],
+    "namespace": "LeibnizPiOQ01OQ02",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/LeibnizPiOQ01OQ02.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Resolves **leibniz-pi-oq-01-oq-02** — turns the parent entry's *informal* claim ("Machin-type formulas achieve exponential O(1/m^(2N)) rates instead") into a theorem.

**Headline (`arctan_series_error_bound`).** For the arctangent power series `arctan x = Σ (-1)ⁿ x^(2n+1)/(2n+1)` and every `0 ≤ x < 1`:

```
|arctan x − Σ_{n<N} (-1)ⁿ x^(2n+1)/(2n+1)|  ≤  x^(2N+1) / (1 − x²)
```

This is `O((x²)ᴺ)` — exponential decay in `N` for every `x` strictly inside the unit interval. The parent's Leibniz `Θ(1/N)` rate is recovered as the `x → 1` **boundary** case, where the factor `(1−x²)⁻¹` blows up — structurally explaining *why* the slow rate occurs only there.

**Corollary (`machin_partial_error_bound`).** Inside Machin's identity `4·arctan(1/5) − arctan(1/239) = π/4`, truncating each series after `N` terms gives an explicit two-term bound

```
|π/4 − (4·S_{1/5} − S_{1/239})| ≤ 4·(1/5)^(2N+1)/(1−(1/5)²) + (1/239)^(2N+1)/(1−(1/239)²)
```

exhibiting the `(1/5)^(2N)` decay.

## Proof engine

- `Real.hasSum_arctan` — the power series (valid for ‖x‖ < 1)
- `hasSum_nat_add_iff'` — identifies the partial-sum remainder with a shifted `HasSum`
- `hasSum_geometric_of_lt_one` — sums the dominating geometric tail in closed form
- `tsum_of_norm_bounded` — direct comparison test

## Status

- **6 theorems, 2 definitions, 152 lines**
- **0 axioms, 0 sorries, no native_decide** (`#print axioms` → only propext / Classical.choice / Quot.sound)
- Builds against Mathlib 4.26.0
- Distinct from siblings: `leibniz-pi-oq-01-oq-01` (Machin *identity*) and `leibniz-pi-oq-01-oq-03` (arctan *addition law*) are identity-level; this entry is the first to bound the series *convergence rate*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)