### PR TITLE
research(stern-brocot-tree-oq-01-oq-01-oq-02): continued fraction of an arbitrary rational via Stern–Brocot surjectivity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3751,6 +3751,8 @@ import Proofs.StatementOnly_FourSquareDistributionOQ04_ArrangementCard
 import Proofs.StatementOnly_GreensOQ02_FTCofLipschitz
 import Proofs.SteinerLehmusTheoremOQ01
 import Proofs.SternBrocotTreeOQ01
+import Proofs.SternBrocotTreeOQ01OQ01
+import Proofs.SternBrocotTreeOQ01OQ01OQ02
 import Proofs.StirlingExpansion
 import Proofs.StirlingExpansionAristotle
 import Proofs.StirlingFirstKindOQ01

--- a/proofs/Proofs/SternBrocotTreeOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/SternBrocotTreeOQ01OQ01OQ02.lean
@@ -1,0 +1,143 @@
+import Mathlib
+import Proofs.SternBrocotTreeOQ01OQ01
+
+/-!
+# The continued fraction of an arbitrary rational, via Stern–Brocot
+(`stern-brocot-tree-oq-01-oq-01-oq-02`)
+
+## Open question (OQ-02 of `stern-brocot-tree-oq-01-oq-01`)
+The parent (`stern-brocot-tree-oq-01-oq-01`) proved the *forward* direction of the
+Stern–Brocot/continued-fraction correspondence: a run-length list `qs : List ℕ`
+produces the convergent `cfValFrom true qs : ℤ × ℤ`, and the rational
+`cfQFrom true qs : ℚ` unfolds as the regular continued fraction
+`q₀ + 1/(q₁ + 1/(q₂ + ⋯))` (`cfQFrom_two_cons`).  The grandparent
+(`stern-brocot-tree-oq-01`) established the bijection between Stern–Brocot paths
+`List Bool` and reduced positive rationals (`sb_surjective`, `sb_bijection`).
+
+What was *missing* is the **inverse**: does *every* positive rational arise this
+way?  Equivalently, does every `q ∈ ℚ`, `q > 0`, have a (finite) continued-fraction
+expansion captured by some run-length list?
+
+## Answer: YES — `cfQFrom true` is surjective onto the positive rationals.
+
+The headline `exists_cf_of_rat` shows that for every `r : ℚ` with `0 < r` there is a
+run-length list `qs` with `cfQFrom true qs = r`.  Together with the parent's recurrence
+`cfQFrom_two_cons`, the entries of `qs` *are* the continued-fraction partial quotients
+of `r`, so this literally produces the continued fraction of an arbitrary positive
+rational.
+
+## The bridge
+The only genuinely new ingredient is **run-length encoding** of a Stern–Brocot path:
+`path_eq_runs` shows every `p : List Bool` equals `runsToPathFrom b qs` for some start
+move `b` and run-lengths `qs`, and `exists_runs_true` normalises the start to an
+`R`-run (absorbing a leading `L`-run as the partial quotient `q₀ = 0`).  Chaining this
+with the grandparent's surjectivity (every reduced positive `a/b` is a path label) and
+`Rat.num_div_den` (an arbitrary `r` *is* `r.num / r.den` in lowest terms) closes the loop.
+
+Mathlib has **no** Stern–Brocot development (verified by the parent against the v4.26
+checkout); this result is obtained inside the parent's verified continued-fraction
+framework rather than re-derived through `Mathlib.Algebra.ContinuedFractions`.
+
+## Status
+All theorems proved with `0` sorries and `0` axioms (no `native_decide`).
+-/
+
+namespace SternBrocot
+
+/-! ## Part I: run-length encoding of an arbitrary path -/
+
+/-- **Run-length encoding.** Every Stern–Brocot path `p : List Bool` is the
+run-structured path of some start move `b` and run-length list `qs`:
+`runsToPathFrom b qs = p`.  Proved by structural induction, peeling one move at a
+time and either extending the leading run (`c = b`) or opening a fresh run
+(`c ≠ b`, where the previous start `b = !c`). -/
+theorem path_eq_runs :
+    ∀ p : List Bool, ∃ (b : Bool) (qs : List ℕ), runsToPathFrom b qs = p := by
+  intro p
+  induction p with
+  | nil => exact ⟨true, [], rfl⟩
+  | cons c p' ih =>
+    obtain ⟨b, qs, hpath⟩ := ih
+    by_cases hcb : c = b
+    · subst hcb
+      cases qs with
+      | nil =>
+        refine ⟨c, [1], ?_⟩
+        rw [← hpath]; simp [runsToPathFrom]
+      | cons n ns =>
+        refine ⟨c, (n + 1) :: ns, ?_⟩
+        rw [← hpath]
+        simp [runsToPathFrom, List.replicate_succ]
+    · refine ⟨c, 1 :: qs, ?_⟩
+      have hbc : (!c) = b := by cases c <;> cases b <;> simp_all
+      rw [← hpath]
+      simp [runsToPathFrom, hbc]
+
+/-- Normalised run-length encoding: every path is `runsToPathFrom true qs` for some
+`qs` (a leading `L`-run is absorbed as the partial quotient `q₀ = 0`). -/
+theorem exists_runs_true (p : List Bool) :
+    ∃ qs : List ℕ, runsToPathFrom true qs = p := by
+  obtain ⟨b, qs, hpath⟩ := path_eq_runs p
+  cases b with
+  | true => exact ⟨qs, hpath⟩
+  | false => exact ⟨0 :: qs, by rw [← hpath]; simp [runsToPathFrom]⟩
+
+/-! ## Part II: the continued-fraction value as a quotient of path labels -/
+
+/-- The rational value `cfQFrom true qs` is the quotient of the Stern–Brocot labels of
+the corresponding `R`-started run-structured path. -/
+theorem cfQFrom_true_eq_div (qs : List ℕ) :
+    cfQFrom true qs
+      = (sbNum (runsToPathFrom true qs) : ℚ) / (sbDen (runsToPathFrom true qs) : ℚ) := by
+  simp only [cfQFrom]
+  rw [sbNum_runs, sbDen_runs]
+
+/-! ## Part III: surjectivity onto the positive rationals -/
+
+/-- **Headline.** Every positive rational has a finite continued-fraction expansion
+recorded by a run-length list: for all `r : ℚ` with `0 < r`, there is `qs : List ℕ`
+with `cfQFrom true qs = r`.  By the parent's `cfQFrom_two_cons`, the entries of `qs`
+are the continued-fraction partial quotients of `r`. -/
+theorem exists_cf_of_rat (r : ℚ) (hr : 0 < r) :
+    ∃ qs : List ℕ, cfQFrom true qs = r := by
+  -- `r` is `r.num / r.den` in lowest terms, with positive numerator and denominator.
+  have h0 : 0 < r.num := Rat.num_pos.mpr hr
+  have hden : 0 < r.den := r.pos
+  have hcop : IsCoprime (r.num) (r.den : ℤ) := by
+    rw [Int.isCoprime_iff_gcd_eq_one]
+    simpa [Int.gcd, Int.natAbs_natCast] using r.reduced
+  -- Surjectivity of the Stern–Brocot tree gives a path with these labels.
+  obtain ⟨p, hp1, hp2⟩ :=
+    sb_surjective r.num (r.den : ℤ) (by omega) (by exact_mod_cast hden) hcop
+  -- Run-length encode the path and read off the continued fraction.
+  obtain ⟨qs, hqs⟩ := exists_runs_true p
+  refine ⟨qs, ?_⟩
+  rw [cfQFrom_true_eq_div, hqs, hp1, hp2]
+  exact_mod_cast Rat.num_div_den r
+
+/-! ## Part IV: concrete continued-fraction expansions -/
+
+/-- `1/2` is the value of the run-length list `[0, 1]`: a leading `q₀ = 0` (the value is
+`< 1`) followed by an `L`-run of length `1`.  Continued fraction `0 + 1/(1 + 1/1)`. -/
+theorem cfQ_half : cfQFrom true [0, 1] = 1 / 2 := by
+  have h : cfValFrom true [0, 1] = (1, 2) := by decide
+  rw [cfQFrom, h]; norm_num
+
+/-- `5/3` is the value of the all-ones run-length list `[1, 1, 1]` (the Fibonacci ratio,
+slowest continued fraction), matching the parent's `cfQ_fib`. -/
+theorem cfQ_five_thirds : cfQFrom true [1, 1, 1] = 5 / 3 := cfQ_fib
+
+/-- Sanity check on the headline: `7/5` does have a continued-fraction expansion. -/
+example : ∃ qs : List ℕ, cfQFrom true qs = 7 / 5 := exists_cf_of_rat _ (by norm_num)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+VERIFICATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+#check @path_eq_runs
+#check @exists_runs_true
+#check @cfQFrom_true_eq_div
+#check @exists_cf_of_rat
+
+end SternBrocot

--- a/src/data/proofs/stern-brocot-tree-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "sbtoq010102-ann-overview",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 44 },
+    "type": "context",
+    "title": "Every Positive Rational Has a Continued Fraction",
+    "content": "The module docstring frames the inverse problem. The parent entry built the forward map: a run-length list `qs` produces the convergent `cfValFrom true qs` and the rational `cfQFrom true qs`, which unfolds as a regular continued fraction. The grandparent built the bijection between Stern–Brocot paths and reduced positive rationals. What was missing is whether the forward map is onto — does every positive rational arise as `cfQFrom true qs`? The answer is yes, and the proof needs only one new ingredient: run-length encoding of a path.",
+    "mathContext": "For every $r \\in \\mathbb{Q}$ with $r > 0$ there is a run-length list $qs$ with $\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs = r$; the entries of $qs$ are the partial quotients of the continued fraction of $r$.",
+    "significance": "context",
+    "relatedConcepts": ["continued fractions", "Stern–Brocot tree", "surjectivity", "run-length encoding", "Euclidean algorithm"],
+    "prerequisites": ["rational numbers", "continued fractions", "structural induction"]
+  },
+  {
+    "id": "sbtoq010102-ann-path-eq-runs",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 74 },
+    "type": "technique",
+    "title": "Run-Length Encoding of a Path",
+    "content": "`path_eq_runs` shows every path `p : List Bool` is `runsToPathFrom b qs` for some start move `b` and run-length list `qs`. The proof is a structural induction on `p` that peels one move `c` at a time from a representation of the tail. If `c` matches the start move `b` of the tail's decomposition, the leading run is extended (`qs` becomes `(n+1) :: ns`, or `[1]` when the tail is empty); if `c` differs (so `b = !c`), a fresh run of length 1 is opened (`qs` becomes `1 :: qs`). No invariant beyond the definitional unfolding of `runsToPathFrom` is needed.",
+    "mathContext": "Prepending $c$ to $\\mathrm{runsToPathFrom}\\,b\\,qs$ gives $\\mathrm{runsToPathFrom}\\,c\\,qs'$ with $qs' = (n{+}1)::ns$ if $c = b$, else $qs' = 1 :: qs$.",
+    "significance": "key technique",
+    "relatedConcepts": ["run-length encoding", "structural induction", "list recursion"],
+    "prerequisites": ["List.replicate", "Boolean case analysis"]
+  },
+  {
+    "id": "sbtoq010102-ann-normalise",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 76, "endLine": 83 },
+    "type": "insight",
+    "title": "A Leading L-Run Is the Partial Quotient q₀ = 0",
+    "content": "`exists_runs_true` normalises the start move to an `R`-run, so every path is `runsToPathFrom true qs`. The case where a path begins with an `L`-run (a rational value `< 1`) is not an obstruction: since `runsToPathFrom true (0 :: qs) = runsToPathFrom false qs` definitionally, prepending the partial quotient `q₀ = 0` converts an `L`-started decomposition into an `R`-started one. This is the standard continued-fraction convention `[0; a₁, a₂, …]` for values below 1.",
+    "mathContext": "$\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,(0 :: qs) = \\mathrm{runsToPathFrom}\\,\\mathrm{false}\\,qs$, so a value $< 1$ is $[0; a_1, a_2, \\dots]$.",
+    "significance": "key insight",
+    "relatedConcepts": ["continued fraction normal form", "partial quotients"],
+    "prerequisites": ["run-length encoding"]
+  },
+  {
+    "id": "sbtoq010102-ann-value-quotient",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 85, "endLine": 94 },
+    "type": "technique",
+    "title": "Value as a Quotient of Path Labels",
+    "content": "`cfQFrom_true_eq_div` rewrites the ℚ-valued continued fraction `cfQFrom true qs` as `sbNum / sbDen` of the corresponding `R`-started run path, using the parent's `sbNum_runs` and `sbDen_runs` (which identify the integer fold `cfValFrom` with the path labels). This is the hinge that lets the surjectivity argument transfer the grandparent's integer-labelled result to the rational value.",
+    "mathContext": "$\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs = \\dfrac{\\mathrm{sbNum}(\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,qs)}{\\mathrm{sbDen}(\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,qs)}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["continued-fraction convergent", "Stern–Brocot label"],
+    "prerequisites": ["cfValFrom", "sbNum_runs / sbDen_runs"]
+  },
+  {
+    "id": "sbtoq010102-ann-headline",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 95, "endLine": 117 },
+    "type": "key-step",
+    "title": "Surjectivity: the Continued Fraction of an Arbitrary Rational",
+    "content": "`exists_cf_of_rat` is the headline. For `r > 0`, `Rat.num_div_den` says `r` already equals `r.num / r.den` in lowest terms, with `r.num ≥ 1`, `r.den ≥ 1`, and coprime (derived from `r.reduced` via `Int.isCoprime_iff_gcd_eq_one`). The grandparent's `sb_surjective` returns a path `p` with `sbNum p = r.num`, `sbDen p = r.den`; `exists_runs_true` encodes `p` as `runsToPathFrom true qs`; and `cfQFrom_true_eq_div` then gives `cfQFrom true qs = r.num / r.den = r`. By the parent's `cfQFrom_two_cons`, the entries of `qs` are exactly the partial quotients of the continued fraction of `r`.",
+    "mathContext": "$\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs = \\dfrac{\\mathrm{sbNum}\\,p}{\\mathrm{sbDen}\\,p} = \\dfrac{r.\\mathrm{num}}{r.\\mathrm{den}} = r$.",
+    "significance": "main result",
+    "relatedConcepts": ["surjectivity", "reduced fraction", "Stern–Brocot surjectivity", "Rat.num_div_den"],
+    "prerequisites": ["sb_surjective", "Rat.num_div_den", "Int.isCoprime_iff_gcd_eq_one"]
+  },
+  {
+    "id": "sbtoq010102-ann-instances",
+    "proofId": "stern-brocot-tree-oq-01-oq-01-oq-02",
+    "range": { "startLine": 118, "endLine": 143 },
+    "type": "example",
+    "title": "Worked Expansions: 1/2, 5/3, 7/5",
+    "content": "Concrete witnesses. `1/2 = cfQFrom true [0,1]`: a leading `q₀ = 0` (value below 1) followed by an `L`-run of length 1, computed by kernel `decide` on the ℤ × ℤ convergent. `5/3 = cfQFrom true [1,1,1]` is the all-ones list — the Fibonacci ratio and slowest continued fraction (convergent to the golden ratio), reusing the parent's `cfQ_fib`. A final example invokes the headline to exhibit an expansion of `7/5`, confirming the surjectivity statement on a value greater than 1.",
+    "mathContext": "$\\tfrac12 = \\mathrm{cfQFrom}\\,\\mathrm{true}\\,[0,1]$, $\\tfrac53 = \\mathrm{cfQFrom}\\,\\mathrm{true}\\,[1,1,1]$ (Fibonacci); $\\tfrac75$ has an expansion by the headline.",
+    "significance": "illustration",
+    "relatedConcepts": ["Fibonacci convergents", "golden ratio", "kernel decide"],
+    "prerequisites": ["cfValFrom", "cfQ_fib"]
+  }
+]

--- a/src/data/proofs/stern-brocot-tree-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stern-brocot-tree-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,218 @@
+{
+  "id": "stern-brocot-tree-oq-01-oq-01-oq-02",
+  "title": "The Continued Fraction of an Arbitrary Rational, via Stern–Brocot",
+  "slug": "stern-brocot-tree-oq-01-oq-01-oq-02",
+  "description": "A self-contained Lean 4 proof that every positive rational has a finite continued-fraction expansion recorded by a Stern–Brocot run-length list: the map cfQFrom true is surjective onto ℚ_{>0}. The parent entry proved the forward direction (a run-length list yields a continued fraction); this entry supplies the inverse. The bridge is a run-length encoding of an arbitrary path (path_eq_runs / exists_runs_true), chained with the grandparent's Stern–Brocot surjectivity and Rat.num_div_den. By the parent's recurrence cfQFrom_two_cons, the entries of the run-length list are exactly the continued-fraction partial quotients of the rational. This answers the second stated open question of the parent entry (the Rat.num/Rat.den half of obtaining the continued fraction of an arbitrary ℚ).",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "continued-fractions",
+      "stern-brocot",
+      "rational-numbers",
+      "euclidean-algorithm",
+      "run-length-encoding",
+      "surjectivity"
+    ],
+    "proofRepoPath": "Proofs/SternBrocotTreeOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Rat.num_div_den",
+        "description": "(r.num : ℚ) / (r.den : ℚ) = r — an arbitrary rational IS its numerator over its denominator in lowest terms; the bridge from the integer path labels back to r",
+        "module": "Mathlib.Data.Rat.Defs"
+      },
+      {
+        "theorem": "Rat.num_pos",
+        "description": "0 < r.num ↔ 0 < r — positivity of the numerator from positivity of r, needed to apply the Stern–Brocot surjectivity",
+        "module": "Mathlib.Data.Rat.Order"
+      },
+      {
+        "theorem": "Int.isCoprime_iff_gcd_eq_one",
+        "description": "IsCoprime m n ↔ Int.gcd m n = 1 — converts the reduced-fraction witness r.reduced into the IsCoprime hypothesis of sb_surjective",
+        "module": "Mathlib.RingTheory.Int.Basic"
+      },
+      {
+        "theorem": "List.replicate_succ",
+        "description": "replicate (n+1) a = a :: replicate n a — the inductive step of run-length encoding a path",
+        "module": "Init.Data.List.Basic"
+      }
+    ],
+    "originalContributions": [
+      "path_eq_runs: every Stern–Brocot path p : List Bool is the run-structured path runsToPathFrom b qs of some start move b and run-length list qs — the run-length encoding of a path, proved by structural induction (extend the leading run when the next move matches, open a fresh run otherwise)",
+      "exists_runs_true: the normalised form — every path equals runsToPathFrom true qs for some qs, absorbing a leading L-run as the partial quotient q₀ = 0",
+      "cfQFrom_true_eq_div: the rational value cfQFrom true qs equals the quotient of the Stern–Brocot labels sbNum/sbDen of the corresponding R-started run path, linking the ℚ-valued continued fraction to the integer fold",
+      "exists_cf_of_rat (headline): surjectivity of cfQFrom true onto the positive rationals — for every r : ℚ with 0 < r there is a run-length list qs with cfQFrom true qs = r, obtained by Stern–Brocot surjectivity (sb_surjective on r.num, r.den) + run-length encoding + Rat.num_div_den; with the parent's cfQFrom_two_cons the entries of qs are the continued-fraction partial quotients of r",
+      "Concrete expansions: 1/2 = cfQFrom true [0,1] (a leading q₀ = 0 since the value is < 1) and 5/3 = cfQFrom true [1,1,1] (the Fibonacci/golden-ratio convergent), plus a worked existence instance for 7/5"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 143,
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries; #print axioms reports only propext, Classical.choice, Quot.sound (no sorryAx, no native_decide / Lean.ofReduceBool). The concrete instance cfQ_half uses kernel decide on a closed ℤ × ℤ value. The result is obtained inside the parent's verified continued-fraction framework; the bridge to Mathlib's GenContFract API (the other half of the parent's OQ-02) is intentionally left open.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "That every positive rational has a finite regular continued-fraction expansion, and that this expansion is read off the Stern–Brocot path as the run-lengths of its L/R blocks, is classical (Graham–Knuth–Patashnik, Concrete Mathematics §4.5; Hardy–Wright Ch. X). The forward statement — a list of partial quotients determines a rational — is computational; the converse — every rational is reached — is the surjectivity of the encoding, equivalent to termination of the (subtractive) Euclidean algorithm. Mathlib v4.26 has no Stern–Brocot development, so neither direction is available there.",
+    "problemStatement": "**Open Question (stern-brocot-tree-oq-01-oq-01, OQ-02).** Connect cfValFrom to Rat.num / Rat.den (and, ideally, Mathlib's GenContFract convergents), obtaining the continued fraction of an arbitrary ℚ. This entry settles the Rat.num/Rat.den half: cfQFrom true is surjective onto the positive rationals.",
+    "text": "Every positive rational equals cfQFrom true qs for some run-length list qs — so every positive rational has a finite continued-fraction expansion captured by the Stern–Brocot framework.",
+    "proofStrategy": "The parent (Proofs/SternBrocotTreeOQ01OQ01.lean) gives the forward map: a run-length list qs produces the convergent cfValFrom true qs and the rational cfQFrom true qs, unfolding as the regular continued fraction. The grandparent (Proofs/SternBrocotTreeOQ01.lean) gives the bijection between Stern–Brocot paths and reduced positive rationals (sb_surjective).\n\nThe one missing ingredient is run-length encoding of a path. path_eq_runs proves, by structural induction on p : List Bool, that p = runsToPathFrom b qs for some start move b and run-lengths qs: prepending a move either extends the current leading run (matching move) or opens a fresh run of length 1 (opposite move). exists_runs_true normalises the start to an R-run, absorbing a possible leading L-run as q₀ = 0 (runsToPathFrom true (0 :: qs) = runsToPathFrom false qs).\n\nThe headline exists_cf_of_rat then assembles the loop: for r > 0, r = r.num / r.den in lowest terms with r.num ≥ 1, r.den ≥ 1, coprime; sb_surjective hands back a path p with sbNum p = r.num, sbDen p = r.den; exists_runs_true encodes p as runsToPathFrom true qs; and cfQFrom_true_eq_div together with Rat.num_div_den shows cfQFrom true qs = sbNum p / sbDen p = r.num / r.den = r. By the parent's cfQFrom_two_cons, the qs entries are the continued-fraction partial quotients.",
+    "keyInsights": [
+      "Surjectivity of the continued-fraction encoding is exactly run-length encoding of a path composed with Stern–Brocot surjectivity — no new arithmetic is needed, only a structural encoding lemma.",
+      "A leading L-run (value < 1) is not an obstruction: it is the partial quotient q₀ = 0, and runsToPathFrom true (0 :: qs) = runsToPathFrom false qs makes this definitional, so every path normalises to an R-started run list.",
+      "An arbitrary rational r need not be presented as a/b: Rat.num_div_den says r already IS r.num / r.den in lowest terms, so the reduced-fraction hypotheses of sb_surjective are met for free.",
+      "The result lives entirely inside the parent's verified continued-fraction layer; it certifies 'the continued fraction of an arbitrary rational' without re-deriving the convergent recurrence through Mathlib's GenContFract."
+    ],
+    "prerequisites": [
+      "The parent continued-fraction layer: runsToPathFrom / cfValFrom / cfQFrom and the identity sb_runs_eq_cfVal, sbNum_runs / sbDen_runs",
+      "The grandparent Stern–Brocot tree: paths as List Bool, the label sbNum/sbDen, and surjectivity sb_surjective onto reduced positive rationals",
+      "Run-length encoding of a binary string and structural induction over lists in Lean 4",
+      "The rational API: Rat.num, Rat.den, Rat.num_div_den, and reducedness"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring: the parent's forward continued-fraction map, the missing inverse, and the answer that cfQFrom true is surjective onto the positive rationals.",
+      "mathContext": "Every $r \\in \\mathbb{Q}$, $r > 0$, equals $\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs$ for some run-length list $qs$, whose entries are the partial quotients of the continued fraction of $r$."
+    },
+    {
+      "id": "run-length-encoding",
+      "title": "Run-Length Encoding of a Path",
+      "startLine": 45,
+      "endLine": 83,
+      "summary": "path_eq_runs encodes any path as runsToPathFrom b qs by structural induction; exists_runs_true normalises the start move to an R-run (leading L-run becomes q₀ = 0).",
+      "mathContext": "Every $p : \\mathrm{List}\\,\\mathrm{Bool}$ is $\\mathrm{runsToPathFrom}\\,b\\,qs$; normalising, $p = \\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,qs$ with $\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,(0 :: qs) = \\mathrm{runsToPathFrom}\\,\\mathrm{false}\\,qs$."
+    },
+    {
+      "id": "value-as-quotient",
+      "title": "The Value as a Quotient of Path Labels",
+      "startLine": 85,
+      "endLine": 94,
+      "summary": "cfQFrom_true_eq_div: the ℚ-value of a run list equals sbNum / sbDen of its R-started run path, via the parent's sbNum_runs / sbDen_runs.",
+      "mathContext": "$\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs = \\mathrm{sbNum}(\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,qs) / \\mathrm{sbDen}(\\mathrm{runsToPathFrom}\\,\\mathrm{true}\\,qs)$."
+    },
+    {
+      "id": "surjectivity",
+      "title": "Surjectivity onto the Positive Rationals",
+      "startLine": 95,
+      "endLine": 117,
+      "summary": "exists_cf_of_rat (headline): for every r > 0 there is a run-length list qs with cfQFrom true qs = r, by Stern–Brocot surjectivity + run-length encoding + Rat.num_div_den.",
+      "mathContext": "For $r > 0$: $\\mathrm{sb\\_surjective}$ on $(r.\\mathrm{num}, r.\\mathrm{den})$ gives a path $p$; encoding it gives $qs$; $\\mathrm{cfQFrom}\\,\\mathrm{true}\\,qs = r.\\mathrm{num}/r.\\mathrm{den} = r$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Continued-Fraction Expansions",
+      "startLine": 118,
+      "endLine": 143,
+      "summary": "1/2 = cfQFrom true [0,1] (leading q₀ = 0), 5/3 = cfQFrom true [1,1,1] (Fibonacci/golden-ratio convergent), and a worked existence instance for 7/5.",
+      "mathContext": "$1/2 = [0; 1, 1]$-style run list $[0,1]$; $5/3$ is the all-ones list $[1,1,1]$ (slowest continued fraction); existence holds for every positive rational, e.g. $7/5$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the parent's forward continued-fraction map and the grandparent's Stern–Brocot surjectivity, this entry proves the inverse: cfQFrom true is surjective onto the positive rationals (exists_cf_of_rat). The single new ingredient is run-length encoding of a path (path_eq_runs / exists_runs_true); composed with sb_surjective and Rat.num_div_den it shows every positive rational has a finite continued-fraction expansion recorded by a run-length list, whose entries are the partial quotients.",
+    "implications": "This settles the Rat.num/Rat.den half of the parent's second open question — 'obtaining the continued fraction of an arbitrary ℚ' — entirely within the verified Stern–Brocot framework. The run-length encoding lemma is the reusable core for the remaining work: a genuine Equiv between paths (equivalently run-length lists in canonical form) and reduced positive rationals, the converse via the subtractive Euclidean algorithm, and a bridge to Mathlib's GenContFract convergents.",
+    "openQuestions": [
+      "Bridge cfQFrom/cfValFrom to Mathlib's GenContFract.of and its convergents, identifying the run-length list with Mathlib's int-fraction-pair stream for a rational.",
+      "Package the encoding as an Equiv: paths (equivalently canonical-form run-length lists, no internal zeros) ≃ reduced positive rationals, upgrading surjectivity to a bijection on the ℚ side.",
+      "Prove the run-length list produced for a/b coincides with the partial-quotient list of the subtractive Euclidean algorithm on (a, b)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "stern-brocot-tree-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the forward direction — a run-length list yields a continued-fraction convergent (sb_runs_eq_cfVal) and the recurrence cfQFrom_two_cons — and explicitly leaves open connecting cfValFrom to Rat.num/Rat.den for an arbitrary ℚ. This entry supplies the inverse (surjectivity) using the parent's cfQFrom value layer and sbNum_runs / sbDen_runs."
+    },
+    {
+      "proofId": "stern-brocot-tree-oq-01",
+      "relationship": "depends",
+      "description": "Uses the grandparent's Stern–Brocot surjectivity sb_surjective: every reduced positive rational a/b is the label sbNum/sbDen of some path, which run-length encoding then turns into a run-length list (continued fraction)."
+    },
+    {
+      "proofId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Surjectivity of the continued-fraction encoding is equivalent to termination of the (subtractive) Euclidean algorithm: each Euclidean quotient is a run of identical Stern–Brocot moves, so reaching every rational corresponds to the algorithm terminating on every input."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SternBrocotTreeOQ01OQ01"
+    ],
+    "opens": [],
+    "namespace": "SternBrocot",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "structureCount": 0,
+    "path": "Proofs/SternBrocotTreeOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Graham, Ronald L.; Knuth, Donald E.; Patashnik, Oren",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "venue": "Addison-Wesley, 2nd edition, §4.5",
+      "note": "Stern–Brocot tree, the L/R representation, and its identity with the continued-fraction expansion of a rational"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition, Ch. X",
+      "note": "Every rational has a finite regular continued fraction; convergents and the Euclidean algorithm"
+    },
+    {
+      "authors": "Niqui, Milad",
+      "title": "Exact arithmetic on the Stern–Brocot tree",
+      "year": "2007",
+      "venue": "Journal of Discrete Algorithms 5(2), 356–379",
+      "note": "Continued fractions and Möbius/2×2-matrix maps on the Stern–Brocot tree"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "exists_cf_of_rat",
+      "type": "core",
+      "description": "Every positive rational has a finite continued-fraction expansion: cfQFrom true is surjective onto ℚ_{>0}.",
+      "leanType": "(r : ℚ) (hr : 0 < r) : ∃ qs : List ℕ, cfQFrom true qs = r"
+    },
+    {
+      "name": "path_eq_runs",
+      "type": "core",
+      "description": "Run-length encoding: every Stern–Brocot path is the run-structured path of some start move and run-length list.",
+      "leanType": "∀ p : List Bool, ∃ (b : Bool) (qs : List ℕ), runsToPathFrom b qs = p"
+    },
+    {
+      "name": "exists_runs_true",
+      "type": "supporting",
+      "description": "Normalised run-length encoding: every path is runsToPathFrom true qs (a leading L-run becomes q₀ = 0).",
+      "leanType": "(p : List Bool) : ∃ qs : List ℕ, runsToPathFrom true qs = p"
+    },
+    {
+      "name": "cfQFrom_true_eq_div",
+      "type": "supporting",
+      "description": "The ℚ-value of a run-length list is the quotient of the Stern–Brocot labels of its R-started run path.",
+      "leanType": "(qs : List ℕ) : cfQFrom true qs = (sbNum (runsToPathFrom true qs) : ℚ) / (sbDen (runsToPathFrom true qs) : ℚ)"
+    },
+    {
+      "name": "cfQ_half",
+      "type": "example",
+      "description": "1/2 is the value of the run-length list [0,1] (leading partial quotient 0).",
+      "leanType": "cfQFrom true [0, 1] = 1 / 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **Rat.num/Rat.den half of OQ-02** of the parent entry `stern-brocot-tree-oq-01-oq-01` (the parent literally lists: *"Connect cfValFrom to Mathlib's GenContFract convergents and to Rat.num / Rat.den, obtaining the continued fraction of an arbitrary ℚ."*).

The parent proved the **forward** direction — a run-length list `qs` yields a continued-fraction convergent and the rational `cfQFrom true qs`, unfolding as `q₀ + 1/(q₁ + 1/(…))`. This entry supplies the **inverse**:

> **`exists_cf_of_rat`** — for every `r : ℚ` with `0 < r`, there is a run-length list `qs` with `cfQFrom true qs = r`. So **every positive rational has a finite continued-fraction expansion** captured by the Stern–Brocot framework, and (by the parent's `cfQFrom_two_cons`) the entries of `qs` are its partial quotients.

## How

The one genuinely new ingredient is **run-length encoding of a path**:
- `path_eq_runs` — every path `p : List Bool` is `runsToPathFrom b qs` for some start move `b` and run-lengths `qs` (structural induction: extend the leading run, or open a fresh one).
- `exists_runs_true` — normalise the start to an `R`-run, absorbing a leading `L`-run as `q₀ = 0` (`runsToPathFrom true (0 :: qs) = runsToPathFrom false qs`).

Chained with the grandparent's Stern–Brocot surjectivity `sb_surjective` (every reduced positive `a/b` is a path label) and `Rat.num_div_den` (an arbitrary `r` *is* `r.num / r.den` in lowest terms), via `cfQFrom_true_eq_div`.

## Verification
- **6 theorems, 143 lines, 0 sorries, 0 axioms.** `#print axioms exists_cf_of_rat` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `native_decide` / `Lean.ofReduceBool`).
- Concrete witnesses: `1/2 = cfQFrom true [0,1]`, `5/3 = cfQFrom true [1,1,1]` (Fibonacci/golden-ratio), worked existence for `7/5`.
- Mathlib v4.26 has **no** Stern–Brocot development; the result lives inside the parent's verified continued-fraction layer. The bridge to Mathlib's `GenContFract` API (the other half of OQ-02) is **intentionally left open** and documented as such.

## Files
- `proofs/Proofs/SternBrocotTreeOQ01OQ01OQ02.lean` (new)
- `proofs/Proofs.lean` — register the new leaf **and** the parent `SternBrocotTreeOQ01OQ01` (was missing from the auto-generated imports)
- `src/data/proofs/stern-brocot-tree-oq-01-oq-01-oq-02/{meta.json,annotations.json}` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)