### PR TITLE
Enrich Hadwiger–Finsler inequality (weitzenbock-inequality-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/weitzenbock-inequality-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/weitzenbock-inequality-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-wb0101-defs",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 58 },
+    "type": "definition",
+    "title": "Heron Area, Finsler Excess, and the Functional L",
+    "content": "Three algebraic building blocks. heronArea16Sq encodes 16T² = 2a²b²+2b²c²+2c²a²−a⁴−b⁴−c⁴ (Heron, taken as the algebraic definition of squared area). finslerExcess = (a−b)²+(b−c)²+(c−a)² is the term by which Hadwiger–Finsler strengthens Weitzenböck. hadwigerL = 2(ab+bc+ca)−(a²+b²+c²) is the reduced functional: the target a²+b²+c² ≥ 4√3T + excess is equivalent to L ≥ 4√3T.",
+    "mathContext": "$16T^2 = 2a^2b^2+2b^2c^2+2c^2a^2-a^4-b^4-c^4$; $\\ \\mathrm{excess} = (a-b)^2+(b-c)^2+(c-a)^2$; $\\ L = 2(ab+bc+ca)-(a^2+b^2+c^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Heron's formula", "Finsler excess", "reduced functional"],
+    "prerequisites": ["triangle area", "algebraic identities"]
+  },
+  {
+    "id": "ann-wb0101-excess",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 79 },
+    "type": "theorem",
+    "title": "The Excess Is Nonnegative, Zero iff Equilateral",
+    "content": "finslerExcess_nonneg (positivity, a sum of squares) shows Hadwiger–Finsler is at least as strong as Weitzenböck. finslerExcess_eq_zero_iff pins down the degenerate case: the excess vanishes iff a = b = c — exactly when Hadwiger–Finsler collapses to Weitzenböck. The forward direction uses that a sum of squares is zero only when each square is (nlinarith + pow_eq_zero_iff).",
+    "mathContext": "$\\mathrm{excess}(a,b,c) \\ge 0$, with $=0 \\iff a=b=c$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of squares", "equilateral triangle", "equality conditions"],
+    "prerequisites": ["nonnegativity of squares"]
+  },
+  {
+    "id": "ann-wb0101-sub-excess",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 85 },
+    "type": "theorem",
+    "title": "Key Identity: a²+b²+c² − excess = L",
+    "content": "sub_excess_eq_L is the bookkeeping identity that turns the Hadwiger–Finsler target into a statement purely about L: (a²+b²+c²) − finslerExcess = hadwigerL, proved by ring. It is what lets the proof reduce the strengthened inequality to L ≥ 4√3T.",
+    "mathContext": "$(a^2+b^2+c^2) - \\mathrm{excess} = L = 2(ab+bc+ca)-(a^2+b^2+c^2)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["algebraic reduction", "ring identity"],
+    "prerequisites": ["polynomial arithmetic"]
+  },
+  {
+    "id": "ann-wb0101-L-nonneg",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 102 },
+    "type": "theorem",
+    "title": "L ≥ 0 via the Ravi Substitution",
+    "content": "hadwigerL_nonneg shows L is nonnegative on a genuine triangle. The Ravi substitution p = b+c−a, q = c+a−b, r = a+b−c (all ≥ 0 by the triangle inequalities) rewrites L = pq + qr + rp (ring), a sum of products of nonnegative reals. This is the standard device for converting triangle inequalities into unconstrained positivity.",
+    "mathContext": "With $p=b+c-a,\\,q=c+a-b,\\,r=a+b-c \\ge 0$: $\\ L = pq+qr+rp \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Ravi substitution", "triangle inequality", "positivity"],
+    "prerequisites": ["triangle inequalities", "Ravi substitution"]
+  },
+  {
+    "id": "ann-wb0101-sq",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 107, "endLine": 115 },
+    "type": "theorem",
+    "title": "Unconditional SOS: L² ≥ 48·T²",
+    "content": "hadwiger_sq is the analytic core. After substituting the Heron relation, L² − 48T² equals ½((pq−qr)²+(qr−rp)²+(rp−pq)²) ≥ 0 — a sum-of-squares certificate discharged by nlinarith with the three squared Ravi-product differences. Remarkably no triangle hypothesis is needed here; only the Heron definition of T. Squaring is what removes the √3.",
+    "mathContext": "$L^2 - 48T^2 = \\tfrac12\\big((pq-qr)^2+(qr-rp)^2+(rp-pq)^2\\big) \\ge 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["sum of squares (SOS)", "nlinarith", "Schur-like inequality"],
+    "prerequisites": ["SOS certificates", "Heron's formula"]
+  },
+  {
+    "id": "ann-wb0101-main",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 146 },
+    "type": "theorem",
+    "title": "The Hadwiger–Finsler Inequality",
+    "content": "hadwiger_finsler is the headline: a²+b²+c² ≥ 4√3T + (a−b)²+(b−c)²+(c−a)². Both 4√3T and L are nonnegative (positivity; hadwigerL_nonneg), so the squared bound L² ≥ 48T² = (4√3T)² is taken to the linear bound 4√3T ≤ L by monotonicity of √ (Real.sqrt_le_sqrt + sqrt_sq). The identity sub_excess_eq_L then converts L ≥ 4√3T into the stated form.",
+    "mathContext": "$a^2+b^2+c^2 \\ge 4\\sqrt3\\,T + (a-b)^2+(b-c)^2+(c-a)^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Hadwiger–Finsler inequality", "Weitzenböck inequality", "square root monotonicity"],
+    "prerequisites": ["monotonicity of sqrt", "the SOS bound"]
+  },
+  {
+    "id": "ann-wb0101-weitzenbock",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 150, "endLine": 156 },
+    "type": "theorem",
+    "title": "Recovering Weitzenböck",
+    "content": "weitzenbock_of_hadwiger recovers the classical Weitzenböck inequality a²+b²+c² ≥ 4√3T by simply dropping the nonnegative excess term (finslerExcess_nonneg + linarith). This makes precise the sense in which Hadwiger–Finsler is a sharpening: the excess is exactly the slack.",
+    "mathContext": "$a^2+b^2+c^2 \\ge 4\\sqrt3\\,T$ (Weitzenböck), the excess being the slack.",
+    "significance": "supporting",
+    "relatedConcepts": ["Weitzenböck inequality", "sharpening", "slack term"],
+    "prerequisites": ["Hadwiger–Finsler inequality"]
+  },
+  {
+    "id": "ann-wb0101-eq-iff",
+    "proofId": "weitzenbock-inequality-oq-01-oq-01",
+    "range": { "startLine": 162, "endLine": 240 },
+    "type": "theorem",
+    "title": "Equality iff Equilateral",
+    "content": "hadwiger_finsler_eq_iff characterizes the equality case. At equality 4√3T = L, so 48T² = L² and the SOS certificate vanishes; since a sum of three squares is zero each Ravi-product difference is zero (pow_eq_zero_iff). Factoring those differences as (side gap)·(side difference) and using positivity of the sides forces a = b = c. The reverse direction is a direct computation with T = √3·a²/4.",
+    "mathContext": "$a^2+b^2+c^2 = 4\\sqrt3\\,T + \\mathrm{excess} \\iff a=b=c$ (equilateral).",
+    "significance": "key",
+    "relatedConcepts": ["equality characterization", "vanishing SOS", "equilateral triangle"],
+    "prerequisites": ["sum of squares vanishing", "case analysis"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `weitzenbock-inequality-oq-01-oq-01` — *The Hadwiger–Finsler Inequality (Sharpening of Weitzenböck)*.

## Quality improvements
- **Annotations** (new file): 8 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the Heron/excess/L definitions, the nonnegative-excess equilateral characterization, the key reduction identity `a²+b²+c² − excess = L`, `L ≥ 0` via the Ravi substitution `L = pq+qr+rp`, the unconditional SOS bound `L² ≥ 48T²`, the main Hadwiger–Finsler inequality, the recovery of Weitzenböck by dropping the excess, and the equality-iff-equilateral case.

  This closes the entry's only quality gap: it already had a complete canonical overview, eight sections, and a full conclusion, but **no annotations** (annotation/mathContext/significance quality were all 0).

## Axiom integrity
Unchanged and consistent: `status: verified`, `axiomCount: 0`, `sorries: 0` — matches the Lean source (no `axiom` declarations, no assumption-carrying structures).

`npm run annotations:validate` reports no errors for this entry.