### PR TITLE
research(fundamental-theorem-algebra-oq-06-oq-01): real polynomial surjective ⟺ odd degree [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2920,6 +2920,7 @@ import Proofs.FundamentalTheoremAlgebraOQ02
 import Proofs.FundamentalTheoremAlgebraOQ04
 import Proofs.FundamentalTheoremAlgebraOQ04OQ04
 import Proofs.FundamentalTheoremAlgebraOQ06
+import Proofs.FundamentalTheoremAlgebraOQ06OQ01
 import Proofs.FundamentalTheoremCalculus
 import Proofs.FundamentalTheoremCalculusLebesgue
 import Proofs.FundamentalTheoremCalculusLebesgueOQ01

--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean
@@ -1,0 +1,207 @@
+import Mathlib
+
+/-
+# A Real Polynomial Function Is Surjective iff Its Degree Is Odd
+
+## What This Proves
+For every `P ∈ ℝ[X]`, the associated polynomial function `x ↦ P.eval x : ℝ → ℝ` is
+**surjective if and only if `P.natDegree` is odd**:
+
+  `Function.Surjective (fun x => P.eval x) ↔ Odd P.natDegree`.
+
+This is a sharp characterisation that sits directly on top of the parent entry's
+intermediate-value step ("every odd-degree real polynomial has a real root"). The parent
+proved that odd degree is *sufficient* for the existence of one root; here we upgrade that
+to surjectivity onto all of `ℝ` and, crucially, establish the **converse**: an even-degree
+(in particular, a constant) polynomial is never surjective, because it is bounded on one
+side. So odd degree is exactly the dividing line for surjectivity of real polynomial maps.
+
+## Approach
+- **(odd ⟹ surjective).** Given a target value `y`, the shifted polynomial `P - C y` has the
+  *same* degree as `P` (`natDegree_sub_C`), hence is still of odd degree, hence has a real
+  root `x` by the parent's odd-degree root theorem (re-derived here so the file is
+  self-contained). That root satisfies `P.eval x = y`.
+- **(surjective ⟹ odd), i.e. even ⟹ not surjective.** Split on `natDegree`:
+  - `natDegree = 0`: `P` is a constant `C c`, whose image is the single point `{c}`; the
+    value `c + 1` is never attained.
+  - `natDegree` even and positive: the leading term dominates with the *same* sign at both
+    `±∞` (an even power does not flip sign), so `P.eval` tends to `+∞` along the whole
+    `cocompact ℝ` filter when `leadingCoeff ≥ 0` (and to `−∞` when `leadingCoeff ≤ 0`). The
+    extreme value theorem (`Continuous.exists_forall_le`) then gives a global minimum `m`
+    (resp. maximum), and `m - 1` (resp. `m + 1`) lies outside the range.
+
+## Mathlib Ingredients
+- `Polynomial.natDegree_sub_C`, `Polynomial.eq_C_of_natDegree_eq_zero`
+- `Polynomial.tendsto_atTop_of_leadingCoeff_nonneg`, `intermediate_value_uIcc`
+- `Polynomial.leadingCoeff_comp`, `Polynomial.natDegree_comp`, `Polynomial.eval_comp`
+- `cocompact_eq_atBot_atTop`, `Filter.tendsto_neg_atBot_atTop`, `Continuous.exists_forall_le`
+
+The boundedness/extreme-value half is the genuinely new content: it turns the parent's
+one-sided existence statement into the two-sided "iff" that pins surjectivity to parity.
+-/
+
+open Polynomial Filter Topology
+
+namespace FTAOddDegreeSurjective
+
+/-! ### The odd-degree root theorem (self-contained, after the parent entry) -/
+
+/-- An odd-degree real polynomial takes both a strictly negative and a strictly positive
+value: the leading term dominates at `±∞` and an odd power flips sign. -/
+theorem exists_neg_and_pos_eval (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    (∃ a : ℝ, P.eval a < 0) ∧ (∃ b : ℝ, 0 < P.eval b) := by
+  obtain ⟨m, hm⟩ := hodd
+  have hpos_deg : 0 < P.natDegree := by omega
+  have hdeg : 0 < P.degree := natDegree_pos_iff_degree_pos.mp hpos_deg
+  set Q : ℝ[X] := P.comp (-X) with hQ
+  have hnd_negX : (-X : ℝ[X]).natDegree = 1 := by rw [natDegree_neg, natDegree_X]
+  have hlc_negX : (-X : ℝ[X]).leadingCoeff = -1 := by rw [leadingCoeff_neg, leadingCoeff_X]
+  have hne : (-X : ℝ[X]).natDegree ≠ 0 := by rw [hnd_negX]; norm_num
+  have hQdeg_nd : Q.natDegree = P.natDegree := by rw [hQ, natDegree_comp, hnd_negX, mul_one]
+  have hQdeg : 0 < Q.degree := by rw [← natDegree_pos_iff_degree_pos, hQdeg_nd]; exact hpos_deg
+  have hQlc : Q.leadingCoeff = -P.leadingCoeff := by
+    rw [hQ, leadingCoeff_comp hne, hlc_negX, Odd.neg_one_pow ⟨m, hm⟩]; ring
+  have hevalQ : ∀ x : ℝ, Q.eval x = P.eval (-x) := by intro x; rw [hQ, eval_comp]; simp
+  rcases le_total 0 P.leadingCoeff with hlc | hlc
+  · have hP : Tendsto (fun x => P.eval x) atTop atTop :=
+      P.tendsto_atTop_of_leadingCoeff_nonneg hdeg hlc
+    have hb : ∃ b : ℝ, 0 < P.eval b := (hP.eventually (eventually_gt_atTop 0)).exists
+    have hQlc_nonpos : Q.leadingCoeff ≤ 0 := by rw [hQlc]; linarith
+    have hQt : Tendsto (fun x => Q.eval x) atTop atBot :=
+      Q.tendsto_atBot_of_leadingCoeff_nonpos hQdeg hQlc_nonpos
+    obtain ⟨x, hx⟩ := (hQt.eventually (eventually_lt_atBot 0)).exists
+    rw [hevalQ] at hx
+    exact ⟨⟨-x, hx⟩, hb⟩
+  · have hP : Tendsto (fun x => P.eval x) atTop atBot :=
+      P.tendsto_atBot_of_leadingCoeff_nonpos hdeg hlc
+    have ha : ∃ a : ℝ, P.eval a < 0 := (hP.eventually (eventually_lt_atBot 0)).exists
+    have hQlc_nonneg : 0 ≤ Q.leadingCoeff := by rw [hQlc]; linarith
+    have hQt : Tendsto (fun x => Q.eval x) atTop atTop :=
+      Q.tendsto_atTop_of_leadingCoeff_nonneg hQdeg hQlc_nonneg
+    obtain ⟨x, hx⟩ := (hQt.eventually (eventually_gt_atTop 0)).exists
+    rw [hevalQ] at hx
+    exact ⟨ha, ⟨-x, hx⟩⟩
+
+/-- **Odd-degree real root theorem** (parent result, re-derived). Every real polynomial of
+odd degree has a real root. -/
+theorem odd_natDegree_has_real_root (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    ∃ x : ℝ, P.IsRoot x := by
+  obtain ⟨⟨a, ha⟩, ⟨b, hb⟩⟩ := exists_neg_and_pos_eval P hodd
+  have hcont : ContinuousOn (fun x => P.eval x) (Set.uIcc a b) := P.continuousOn
+  have h0mem : (0 : ℝ) ∈ Set.uIcc (P.eval a) (P.eval b) := by
+    rw [Set.mem_uIcc]; exact Or.inl ⟨le_of_lt ha, le_of_lt hb⟩
+  obtain ⟨c, _, hc⟩ := intermediate_value_uIcc hcont h0mem
+  exact ⟨c, hc⟩
+
+/-! ### Odd degree ⟹ surjective -/
+
+/-- **Odd degree is sufficient for surjectivity.** Every odd-degree real polynomial function
+is surjective: for any target `y`, the polynomial `P - C y` has the same (odd) degree as
+`P`, hence has a root, which is a preimage of `y`. -/
+theorem eval_surjective_of_odd_natDegree (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    Function.Surjective (fun x => P.eval x) := by
+  intro y
+  have hodd' : Odd (P - C y).natDegree := by rw [natDegree_sub_C]; exact hodd
+  obtain ⟨x, hx⟩ := odd_natDegree_has_real_root (P - C y) hodd'
+  refine ⟨x, ?_⟩
+  have hx' : P.eval x - y = 0 := by
+    have := hx; rwa [IsRoot, eval_sub, eval_C] at this
+  show P.eval x = y
+  linarith
+
+/-! ### Even degree ⟹ bounded ⟹ not surjective -/
+
+/-- An even, positive-degree real polynomial with nonnegative leading coefficient is
+**bounded below**: it tends to `+∞` along the whole `cocompact ℝ` filter (an even power keeps
+the sign of the leading term at both `±∞`), so the extreme value theorem yields a global
+minimum. -/
+theorem exists_forall_le_of_even (P : ℝ[X]) (hd : 0 < P.natDegree) (heven : Even P.natDegree)
+    (hlc : 0 ≤ P.leadingCoeff) : ∃ m : ℝ, ∀ x : ℝ, m ≤ P.eval x := by
+  have hdeg : 0 < P.degree := natDegree_pos_iff_degree_pos.mp hd
+  have hatTop : Tendsto (fun x => P.eval x) atTop atTop :=
+    P.tendsto_atTop_of_leadingCoeff_nonneg hdeg hlc
+  -- reflected polynomial Q(x) = P(-x)
+  set Q : ℝ[X] := P.comp (-X) with hQ
+  have hnd_negX : (-X : ℝ[X]).natDegree = 1 := by rw [natDegree_neg, natDegree_X]
+  have hlc_negX : (-X : ℝ[X]).leadingCoeff = -1 := by rw [leadingCoeff_neg, leadingCoeff_X]
+  have hne : (-X : ℝ[X]).natDegree ≠ 0 := by rw [hnd_negX]; norm_num
+  have hQdeg_nd : Q.natDegree = P.natDegree := by rw [hQ, natDegree_comp, hnd_negX, mul_one]
+  have hQdeg : 0 < Q.degree := by rw [← natDegree_pos_iff_degree_pos, hQdeg_nd]; exact hd
+  have hQlc : Q.leadingCoeff = P.leadingCoeff := by
+    rw [hQ, leadingCoeff_comp hne, hlc_negX, heven.neg_one_pow]; ring
+  have hQlc_nonneg : 0 ≤ Q.leadingCoeff := by rw [hQlc]; exact hlc
+  have hQatTop : Tendsto (fun x => Q.eval x) atTop atTop :=
+    Q.tendsto_atTop_of_leadingCoeff_nonneg hQdeg hQlc_nonneg
+  have hevalQ : ∀ x : ℝ, Q.eval x = P.eval (-x) := by intro x; rw [hQ, eval_comp]; simp
+  -- transport Q's behaviour at +∞ to P's behaviour at −∞
+  have hatBot : Tendsto (fun x => P.eval x) atBot atTop := by
+    have h := hQatTop.comp Filter.tendsto_neg_atBot_atTop
+    refine h.congr ?_
+    intro x
+    show Q.eval (-x) = P.eval x
+    rw [hevalQ, neg_neg]
+  have hcocompact : Tendsto (fun x => P.eval x) (cocompact ℝ) atTop := by
+    rw [cocompact_eq_atBot_atTop, tendsto_sup]; exact ⟨hatBot, hatTop⟩
+  obtain ⟨x₀, hx₀⟩ := P.continuous.exists_forall_le hcocompact
+  exact ⟨P.eval x₀, hx₀⟩
+
+/-- Dual of `exists_forall_le_of_even`: an even, positive-degree polynomial with nonpositive
+leading coefficient is **bounded above** (apply the previous lemma to `-P`). -/
+theorem exists_forall_ge_of_even (P : ℝ[X]) (hd : 0 < P.natDegree) (heven : Even P.natDegree)
+    (hlc : P.leadingCoeff ≤ 0) : ∃ M : ℝ, ∀ x : ℝ, P.eval x ≤ M := by
+  have hd' : 0 < (-P).natDegree := by rwa [natDegree_neg]
+  have heven' : Even (-P).natDegree := by rwa [natDegree_neg]
+  have hlc' : 0 ≤ (-P).leadingCoeff := by rw [leadingCoeff_neg]; linarith
+  obtain ⟨m, hm⟩ := exists_forall_le_of_even (-P) hd' heven' hlc'
+  refine ⟨-m, fun x => ?_⟩
+  have hx := hm x
+  rw [eval_neg] at hx
+  linarith
+
+/-- **Even degree is incompatible with surjectivity.** A positive even-degree polynomial is
+bounded below or above, so some real value is never attained. -/
+theorem not_surjective_of_even_natDegree (P : ℝ[X]) (hd : 0 < P.natDegree)
+    (heven : Even P.natDegree) : ¬ Function.Surjective (fun x => P.eval x) := by
+  rcases le_total 0 P.leadingCoeff with hlc | hlc
+  · obtain ⟨m, hm⟩ := exists_forall_le_of_even P hd heven hlc
+    intro hsurj
+    obtain ⟨x, hx⟩ := hsurj (m - 1)
+    have := hm x
+    simp only at hx
+    linarith
+  · obtain ⟨M, hM⟩ := exists_forall_ge_of_even P hd heven hlc
+    intro hsurj
+    obtain ⟨x, hx⟩ := hsurj (M + 1)
+    have := hM x
+    simp only at hx
+    linarith
+
+/-! ### The sharp characterisation -/
+
+/-- **Main theorem.** A real polynomial function `x ↦ P.eval x` is surjective onto `ℝ` if and
+only if `P` has odd degree. Odd degree forces a root of every shift `P - C y` (surjectivity);
+even degree (including the constant case `natDegree = 0`) makes `P` bounded on one side, so it
+misses values. -/
+theorem eval_surjective_iff_odd_natDegree (P : ℝ[X]) :
+    Function.Surjective (fun x => P.eval x) ↔ Odd P.natDegree := by
+  constructor
+  · intro hsurj
+    by_contra hodd
+    rw [Nat.not_odd_iff_even] at hodd
+    rcases Nat.eq_zero_or_pos P.natDegree with h0 | hpos
+    · -- constant polynomial: image is a single point
+      set c := P.coeff 0 with hc
+      have hPC : P = C c := eq_C_of_natDegree_eq_zero h0
+      obtain ⟨x, hx⟩ := hsurj (c + 1)
+      simp only [hPC, eval_C] at hx
+      linarith
+    · exact not_surjective_of_even_natDegree P hpos hodd hsurj
+  · exact eval_surjective_of_odd_natDegree P
+
+/-- Range form of the main theorem: an odd-degree real polynomial function has range all of
+`ℝ`. -/
+theorem range_eval_eq_univ_of_odd (P : ℝ[X]) (hodd : Odd P.natDegree) :
+    Set.range (fun x => P.eval x) = Set.univ :=
+  (eval_surjective_of_odd_natDegree P hodd).range_eq
+
+end FTAOddDegreeSurjective

--- a/src/data/proofs/fundamental-theorem-algebra-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fundamental-theorem-algebra-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "Goal: Surjectivity ⟺ Odd Degree",
+    "content": "The file imports `Mathlib` and opens `Polynomial`, `Filter`, `Topology`. It sharpens the parent entry: where the parent proved that an odd-degree real polynomial has at least one root, this entry pins down exactly when the polynomial *function* x ↦ P.eval x is surjective onto ℝ — precisely when the degree is odd. The forward direction is a short corollary of the parent; the even-degree converse (boundedness) is the new content.",
+    "mathContext": "Target: $\\forall P \\in \\mathbb{R}[X],\\ \\mathrm{Surjective}(P.\\mathrm{eval}) \\iff \\mathrm{Odd}(\\deg P)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["surjectivity", "polynomial degree", "fundamental theorem of algebra"],
+    "prerequisites": ["polynomial evaluation", "Lean 4 module system"]
+  },
+  {
+    "id": "ann-odd-root",
+    "proofId": "fundamental-theorem-algebra-oq-06-oq-01",
+    "range": { "startLine": 47, "endLine": 95 },
+    "type": "technique",
+    "title": "Re-deriving the Odd-Degree Root Theorem",
+    "content": "To keep the file self-contained, the parent's two lemmas are re-derived: `exists_neg_and_pos_eval` (an odd-degree polynomial takes both signs, via the reflected polynomial `Q = P.comp (-X)` whose leading coefficient is `(-1)^deg · lc P = -lc P`) and `odd_natDegree_has_real_root` (feed the two signs into `intermediate_value_uIcc`).",
+    "mathContext": "$\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P)$; for odd degree this is $-\\mathrm{leadingCoeff}(P)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["reflected polynomial", "intermediate value theorem", "end behaviour"],
+    "prerequisites": ["Filter.Tendsto", "leadingCoeff_comp"]
+  },
+  {
+    "id": "ann-odd-surjective",
+    "proofId": "fundamental-theorem-algebra-oq-06-oq-01",
+    "range": { "startLine": 96, "endLine": 111 },
+    "type": "key-idea",
+    "title": "Odd Degree ⟹ Surjective via Shifting",
+    "content": "`eval_surjective_of_odd_natDegree`: to attain a target `y`, apply the root theorem to the shifted polynomial `P - C y`. The key fact is `natDegree_sub_C`: subtracting a constant does not change the degree, so `P - C y` is still odd-degree and has a root `x`, which means `P.eval x = y`.",
+    "mathContext": "$\\mathrm{natDegree}(P - C\\,y) = \\mathrm{natDegree}\\,P$, so the shift inherits odd degree and a root $x$ with $P(x)=y$.",
+    "significance": "central",
+    "relatedConcepts": ["surjectivity", "polynomial shift", "natDegree_sub_C"],
+    "prerequisites": ["polynomial root", "IsRoot"]
+  },
+  {
+    "id": "ann-even-bounded",
+    "proofId": "fundamental-theorem-algebra-oq-06-oq-01",
+    "range": { "startLine": 112, "endLine": 178 },
+    "type": "key-idea",
+    "title": "Even Degree ⟹ Bounded ⟹ Not Surjective",
+    "content": "For even degree the reflected polynomial has the *same* leading coefficient (`Even.neg_one_pow`), so P tends to the same infinity at both ends. Combining the `atBot` and `atTop` limits via `cocompact ℝ = atBot ⊔ atTop` and applying the extreme value theorem `Continuous.exists_forall_le` gives a global minimum (or maximum via `-P`). `not_surjective_of_even_natDegree` then observes that `m - 1` (resp. `M + 1`) is never attained.",
+    "mathContext": "Even degree ⟹ $P \\to +\\infty$ (or $-\\infty$) along all of $\\mathrm{cocompact}\\,\\mathbb{R}$, hence bounded on one side; a value past the extremum has no preimage.",
+    "significance": "central",
+    "relatedConcepts": ["extreme value theorem", "cocompact filter", "coercivity"],
+    "prerequisites": ["Continuous.exists_forall_le", "cocompact_eq_atBot_atTop"]
+  },
+  {
+    "id": "ann-characterisation",
+    "proofId": "fundamental-theorem-algebra-oq-06-oq-01",
+    "range": { "startLine": 179, "endLine": 207 },
+    "type": "key-idea",
+    "title": "Assembling the Iff",
+    "content": "`eval_surjective_iff_odd_natDegree` combines the two halves: the reverse implication is `eval_surjective_of_odd_natDegree`; the forward implication is the contrapositive, splitting even degree into the constant case (`natDegree = 0`, image a single point) and the even positive-degree case (`not_surjective_of_even_natDegree`). `range_eval_eq_univ_of_odd` restates surjectivity as range = univ.",
+    "mathContext": "Surjective $\\iff$ Odd degree; the constant case is degenerate (image $\\{c\\}$, misses $c+1$).",
+    "significance": "central",
+    "relatedConcepts": ["characterisation", "contrapositive", "range"],
+    "prerequisites": ["eq_C_of_natDegree_eq_zero", "Function.Surjective"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-06-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-06-oq-01/meta.json
@@ -1,0 +1,254 @@
+{
+  "id": "fundamental-theorem-algebra-oq-06-oq-01",
+  "slug": "fundamental-theorem-algebra-oq-06-oq-01",
+  "title": "A Real Polynomial Function Is Surjective iff Its Degree Is Odd",
+  "description": "Sharpens the parent entry's odd-degree root theorem into a two-sided characterisation: the polynomial function x ↦ P.eval x : ℝ → ℝ is surjective if and only if P has odd degree. Odd degree forces a root of every shift P − C y (so every value is attained), while even degree — including the constant case natDegree = 0 — makes P bounded on one side (it tends to ±∞ with the same sign at both ends), so some value is missed. The boundedness half uses the extreme value theorem on the cocompact filter and is the new content; the forward half is a one-line corollary of the parent via natDegree_sub_C.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "FTAOddDegreeSurjective",
+    "lineCount": 207,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "eval_surjective_iff_odd_natDegree",
+        "type": "original",
+        "description": "A real polynomial function is surjective onto ℝ iff its degree is odd — the sharp characterisation",
+        "leanType": "(P : ℝ[X]) → (Function.Surjective (fun x => P.eval x) ↔ Odd P.natDegree)"
+      },
+      {
+        "name": "eval_surjective_of_odd_natDegree",
+        "type": "original",
+        "description": "Odd degree is sufficient for surjectivity: P − C y has the same odd degree as P, hence a root",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → Function.Surjective (fun x => P.eval x)"
+      },
+      {
+        "name": "not_surjective_of_even_natDegree",
+        "type": "original",
+        "description": "A positive even-degree polynomial is bounded below or above, so it is not surjective",
+        "leanType": "(P : ℝ[X]) → 0 < P.natDegree → Even P.natDegree → ¬ Function.Surjective (fun x => P.eval x)"
+      },
+      {
+        "name": "exists_forall_le_of_even",
+        "type": "original",
+        "description": "An even positive-degree polynomial with nonnegative leading coefficient is bounded below (global minimum via the extreme value theorem on cocompact ℝ)",
+        "leanType": "(P : ℝ[X]) → 0 < P.natDegree → Even P.natDegree → 0 ≤ P.leadingCoeff → ∃ m : ℝ, ∀ x : ℝ, m ≤ P.eval x"
+      },
+      {
+        "name": "exists_forall_ge_of_even",
+        "type": "original",
+        "description": "Dual: an even positive-degree polynomial with nonpositive leading coefficient is bounded above",
+        "leanType": "(P : ℝ[X]) → 0 < P.natDegree → Even P.natDegree → P.leadingCoeff ≤ 0 → ∃ M : ℝ, ∀ x : ℝ, P.eval x ≤ M"
+      },
+      {
+        "name": "range_eval_eq_univ_of_odd",
+        "type": "original",
+        "description": "Range form: an odd-degree real polynomial function has range all of ℝ",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → Set.range (fun x => P.eval x) = Set.univ"
+      },
+      {
+        "name": "odd_natDegree_has_real_root",
+        "type": "original",
+        "description": "Odd-degree real root theorem (parent result, re-derived for self-containment)",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → ∃ x : ℝ, P.IsRoot x"
+      },
+      {
+        "name": "exists_neg_and_pos_eval",
+        "type": "original",
+        "description": "An odd-degree polynomial takes both a strictly negative and a strictly positive value (parent lemma, re-derived)",
+        "leanType": "(P : ℝ[X]) → Odd P.natDegree → (∃ a : ℝ, P.eval a < 0) ∧ (∃ b : ℝ, 0 < P.eval b)"
+      }
+    ],
+    "path": "Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "surjectivity",
+      "intermediate-value-theorem",
+      "extreme-value-theorem",
+      "real-analysis",
+      "fundamental-theorem-of-algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 207,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on Mathlib's polynomial end-behaviour lemmas (tendsto_atTop_of_leadingCoeff_nonneg / tendsto_atBot_of_leadingCoeff_nonpos), the intermediate value theorem (intermediate_value_uIcc), and the extreme value theorem on the cocompact filter (Continuous.exists_forall_le with cocompact_eq_atBot_atTop). Mathlib has no standalone statement that real polynomial surjectivity is equivalent to odd degree, so the result is assembled here.",
+    "originalContributions": [
+      "eval_surjective_iff_odd_natDegree: the sharp characterisation — a real polynomial function is surjective iff its degree is odd — original headline result",
+      "eval_surjective_of_odd_natDegree: surjectivity from odd degree, obtained by applying the parent's root theorem to every shift P − C y (natDegree_sub_C keeps the degree odd) — original",
+      "exists_forall_le_of_even / exists_forall_ge_of_even: even positive degree is bounded below/above, via the reflected polynomial P(−x) = P.comp(−X) giving the same-sign limit at both infinities (Even.neg_one_pow) and the extreme value theorem on cocompact ℝ — original, the converse half",
+      "not_surjective_of_even_natDegree: a positive even-degree polynomial misses a value (m − 1 below the minimum or M + 1 above the maximum) — original",
+      "range_eval_eq_univ_of_odd: range form of surjectivity — original corollary"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.natDegree_sub_C",
+        "description": "Subtracting a constant does not change the degree: natDegree (p − C a) = natDegree p",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Operations"
+      },
+      {
+        "theorem": "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg",
+        "description": "A polynomial with positive degree and nonnegative leading coefficient tends to +∞ at +∞",
+        "module": "Mathlib.Analysis.Polynomial.Basic"
+      },
+      {
+        "theorem": "Continuous.exists_forall_le",
+        "description": "Extreme value theorem: a continuous function tending to +∞ along the cocompact filter attains a global minimum",
+        "module": "Mathlib.Topology.Order.Compact"
+      },
+      {
+        "theorem": "cocompact_eq_atBot_atTop",
+        "description": "On a suitable order, the cocompact filter is atBot ⊔ atTop (used to combine the two-ended limit)",
+        "module": "Mathlib.Topology.Order.Compact"
+      },
+      {
+        "theorem": "intermediate_value_uIcc",
+        "description": "Intermediate value theorem on an unordered interval [[a,b]]",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Polynomial evaluation, degree, and leading coefficient",
+      "Limits of functions at infinity (Filter.Tendsto, atTop/atBot, cocompact)",
+      "The intermediate value theorem and the extreme value theorem",
+      "Familiarity with Lean 4 and Mathlib"
+    ],
+    "wiedijkNumber": 2,
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
+    "date": "1849",
+    "relatedProblems": [
+      {
+        "id": "fundamental-theorem-algebra-oq-06",
+        "relationship": "Upgrades the parent's odd-degree root theorem to surjectivity and adds the even-degree converse, yielding a two-sided characterisation of polynomial surjectivity by parity of degree"
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "problemStatement": "For which real polynomials P is the function x ↦ P.eval x surjective onto ℝ? The parent entry showed that odd degree guarantees at least one root; this entry asks for the exact dividing line and proves that surjectivity holds precisely when the degree is odd.",
+    "text": "The forward direction is a short consequence of the parent. To hit a target value $y$, consider the shifted polynomial $P - C\\,y$: subtracting a constant leaves the degree unchanged ($\\mathrm{natDegree}(P - C\\,y) = \\mathrm{natDegree}\\,P$), so it is still of odd degree and therefore has a real root $x$ by the parent's theorem; that root satisfies $P(x) = y$. The converse is the new content. An even-degree polynomial behaves like $c\\,x^n$ with $n$ even, so the leading term keeps the *same* sign at both $+\\infty$ and $-\\infty$: the function tends to $+\\infty$ (if $\\mathrm{lc}\\ge 0$) or $-\\infty$ (if $\\mathrm{lc}\\le 0$) along the entire cocompact filter. The extreme value theorem then provides a global minimum (or maximum), and any value beyond it is never attained. The constant case ($\\mathrm{natDegree}=0$) is degenerate: the image is a single point.",
+    "proofStrategy": "Prove the iff by two implications. (odd ⟹ surjective): apply odd_natDegree_has_real_root to P − C y, using natDegree_sub_C. (surjective ⟹ odd): contrapositive. If the degree is even, split on natDegree = 0 (constant, image a single point, value c+1 missed) versus natDegree even and positive. In the latter case use the reflected polynomial Q(x)=P(−x)=P.comp(−X) — for even degree leadingCoeff Q = +leadingCoeff P (Even.neg_one_pow) — to get the same-sign limit at both ±∞, rewrite cocompact ℝ = atBot ⊔ atTop, and invoke Continuous.exists_forall_le for a global extremum that the missed value lies beyond.",
+    "keyInsights": [
+      "Surjectivity reduces to a root-existence statement for every shift: P attains y iff P − C y has a root, and natDegree_sub_C means the shift has the same parity of degree as P.",
+      "Parity of the degree controls the end behaviour: an even power keeps the sign of the leading term at both infinities, so an even-degree polynomial is coercive (bounded on one side) and cannot be surjective.",
+      "The two-ended limit is packaged cleanly by the cocompact filter: cocompact ℝ = atBot ⊔ atTop, and Tendsto along it feeds directly into the extreme value theorem Continuous.exists_forall_le.",
+      "The reflected polynomial P.comp(−X) converts atBot behaviour into atTop behaviour, so only Mathlib's atTop end-behaviour lemma is needed for both ends."
+    ],
+    "historicalContext": "That odd-degree real polynomials always have roots is the order-theoretic heart of Gauss's 1849 algebraic proof of the Fundamental Theorem of Algebra (and, abstractly, of the Artin–Schreier theory of real-closed fields). The surjectivity strengthening and its even-degree converse are the elementary analytic counterpart: they pin down exactly when a real polynomial map is onto, with even degree (the home of irreducible quadratics such as X²+1) being precisely the obstruction.",
+    "prerequisites": [
+      "Polynomial evaluation, degree, and leading coefficient",
+      "Limits at infinity and the cocompact filter",
+      "The intermediate value theorem and the extreme value theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Module Overview and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports Mathlib and opens Polynomial, Filter, and Topology. The docstring states the sharp characterisation and outlines both directions.",
+      "mathContext": "Goal: $\\forall P \\in \\mathbb{R}[X],\\ \\mathrm{Surjective}(P.\\mathrm{eval}) \\iff \\mathrm{Odd}(\\deg P)$."
+    },
+    {
+      "id": "odd-root",
+      "title": "The Odd-Degree Root Theorem (self-contained)",
+      "startLine": 47,
+      "endLine": 95,
+      "summary": "Re-derives the parent results exists_neg_and_pos_eval and odd_natDegree_has_real_root so the file stands alone: an odd-degree polynomial takes both signs (via the reflected polynomial and end behaviour) and hence has a root by the IVT.",
+      "mathContext": "$\\mathrm{leadingCoeff}(P\\circ(-X)) = (-1)^{\\deg P}\\,\\mathrm{leadingCoeff}(P) = -\\mathrm{leadingCoeff}(P)$ for odd degree; $0 \\in [[P(a),P(b)]]$ gives a root."
+    },
+    {
+      "id": "odd-surjective",
+      "title": "Odd Degree ⟹ Surjective",
+      "startLine": 96,
+      "endLine": 111,
+      "summary": "Proves eval_surjective_of_odd_natDegree: for any y, P − C y has the same odd degree (natDegree_sub_C), so it has a root x with P(x) = y.",
+      "mathContext": "$\\mathrm{natDegree}(P - C\\,y) = \\mathrm{natDegree}\\,P$, so the shift is odd-degree and has a root; that root is a preimage of $y$."
+    },
+    {
+      "id": "even-bounded",
+      "title": "Even Degree ⟹ Bounded",
+      "startLine": 112,
+      "endLine": 160,
+      "summary": "exists_forall_le_of_even shows an even positive-degree polynomial with leadingCoeff ≥ 0 is bounded below: the reflected polynomial gives Tendsto along atBot, combined with atTop into Tendsto along cocompact ℝ, then Continuous.exists_forall_le yields a global minimum. exists_forall_ge_of_even is the dual via −P.",
+      "mathContext": "Even degree ⟹ $\\mathrm{leadingCoeff}(P\\circ(-X)) = +\\mathrm{leadingCoeff}(P)$, so $P \\to +\\infty$ along both ends; $\\mathrm{cocompact}\\,\\mathbb{R} = \\mathrm{atBot}\\sqcup\\mathrm{atTop}$."
+    },
+    {
+      "id": "not-surjective-even",
+      "title": "Even Degree ⟹ Not Surjective",
+      "startLine": 161,
+      "endLine": 178,
+      "summary": "not_surjective_of_even_natDegree: case-split on the sign of the leading coefficient; the global minimum m (resp. maximum M) shows m − 1 (resp. M + 1) is never attained.",
+      "mathContext": "If $m \\le P(x)$ for all $x$ then $m-1$ has no preimage, contradicting surjectivity."
+    },
+    {
+      "id": "characterisation",
+      "title": "The Sharp Characterisation and Range Form",
+      "startLine": 179,
+      "endLine": 207,
+      "summary": "eval_surjective_iff_odd_natDegree combines the pieces: the forward direction is the contrapositive (even ⟹ not surjective, with the constant case handled directly), the reverse is eval_surjective_of_odd_natDegree. range_eval_eq_univ_of_odd restates surjectivity as range = univ.",
+      "mathContext": "Surjective $\\iff$ Odd degree; equivalently, an odd-degree polynomial has $\\mathrm{range} = \\mathbb{R}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "A real polynomial function is surjective onto ℝ if and only if its degree is odd, proved with 0 axioms and 0 sorries. Odd degree gives surjectivity by applying the parent's root theorem to each shift P − C y; even degree (and the constant case) makes the polynomial bounded on one side via the extreme value theorem, so it misses values.",
+    "implications": [
+      "Upgrades the parent's one-sided existence statement (odd degree ⟹ a root) to a two-sided characterisation of surjectivity.",
+      "Identifies even degree as exactly the obstruction to surjectivity, mirroring the way even degree is the obstruction to ℝ being algebraically closed.",
+      "Packages reusable coercivity infrastructure: even positive-degree real polynomials are bounded below/above (exists_forall_le_of_even / exists_forall_ge_of_even)."
+    ],
+    "openQuestions": [
+      "Characterise the image of an even-degree real polynomial as a closed half-line [m, ∞) or (−∞, M], identifying the endpoint with the attained global extremum.",
+      "Determine when a real polynomial map is bijective (not merely surjective): odd degree plus strict monotonicity, and relate this to the derivative having constant sign."
+    ]
+  },
+  "references": [
+    {
+      "title": "Fundamental theorem of algebra",
+      "url": "https://en.wikipedia.org/wiki/Fundamental_theorem_of_algebra",
+      "description": "Overview of FTA; the odd-degree real-root step underlies Gauss's algebraic proof and the surjectivity result here."
+    },
+    {
+      "title": "Extreme value theorem",
+      "url": "https://en.wikipedia.org/wiki/Extreme_value_theorem",
+      "description": "A continuous coercive function attains its extremum; used to show even-degree polynomials are bounded on one side."
+    },
+    {
+      "title": "Intermediate value theorem",
+      "url": "https://en.wikipedia.org/wiki/Intermediate_value_theorem",
+      "description": "Converts the sign change of an odd-degree polynomial into a root, giving surjectivity."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra-oq-06",
+      "relationship": "extends",
+      "description": "Strengthens the parent's odd-degree root theorem to surjectivity and supplies the even-degree converse, giving an iff."
+    },
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04",
+      "relationship": "complementary",
+      "description": "That entry exhibits ℝ as not algebraically closed via the even-degree X²+1; here even degree is likewise the obstruction, now to surjectivity of the polynomial map."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry **fundamental-theorem-algebra-oq-06** ("Every Odd-Degree Real Polynomial Has a Real Root") into a two-sided characterisation:

> A real polynomial function `x ↦ P.eval x : ℝ → ℝ` is **surjective iff `P.natDegree` is odd**.

The parent proved odd degree is *sufficient* for a root; this entry upgrades that to surjectivity onto all of ℝ and adds the **converse**.

## Mathematical content

- **Odd ⟹ surjective** (`eval_surjective_of_odd_natDegree`): to hit a target `y`, the shift `P − C y` has the same degree (`natDegree_sub_C`), hence is still odd-degree and has a root `x`, so `P.eval x = y`.
- **Even ⟹ not surjective** (`not_surjective_of_even_natDegree`, new content): the reflected polynomial `P.comp(−X)` has the *same* leading coefficient for even degree (`Even.neg_one_pow`), so `P` tends to the same infinity at both ends. Combining the two limits through `cocompact ℝ = atBot ⊔ atTop` and applying the extreme value theorem `Continuous.exists_forall_le` yields a global minimum/maximum, beyond which a value is never attained. The constant case `natDegree = 0` (image a single point) is handled directly.
- Headline `eval_surjective_iff_odd_natDegree` and range form `range_eval_eq_univ_of_odd`.

## Verification

- 8 theorems, 0 definitions, 207 lines, self-contained (imports only `Mathlib`).
- **0 sorries, 0 axiom declarations.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- Builds clean via `lake env lean Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean`.

## Files
- `proofs/Proofs/FundamentalTheoremAlgebraOQ06OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/fundamental-theorem-algebra-oq-06-oq-01/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)