### PR TITLE
research(cube-root-2-irrational-oq-05-oq-02): prime^(non-integer rational) irrational and ∛2+∛3 ∉ ℚ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -867,6 +867,7 @@ import Proofs.CubeRoot2IrrationalOQ03
 import Proofs.CubeRoot2IrrationalOQ05
 import Proofs.CubeRoot2IrrationalOQ05OQ01
 import Proofs.CubeRoot2IrrationalOQ05OQ01OQ01
+import Proofs.CubeRoot2IrrationalOQ05OQ02
 import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ01
 import Proofs.CubeRoot3IrrationalOQ01OQ02

--- a/proofs/Proofs/CubeRoot2IrrationalOQ05OQ02.lean
+++ b/proofs/Proofs/CubeRoot2IrrationalOQ05OQ02.lean
@@ -1,0 +1,143 @@
+/-
+# Cube Root of 2 OQ-05-OQ-02: rational non-integer exponents, and ∛2 + ∛3
+
+## Open Question (parent OQ-05, second listed)
+Two related irrationality results that go beyond the parent family `p ^ (1/n)`:
+
+1. **Rational non-integer exponents.** For a prime `p` and a *rational* exponent `q`
+   that is not an integer, the real power `p ^ q` is irrational. The parent OQ-05 handles
+   only unit-fraction exponents `1/n`; here the exponent is an arbitrary reduced fraction
+   `a/b` with `b ≥ 2`.
+2. **Sums of cube roots.** `∛2 + ∛3` is irrational.
+
+## Approach
+
+### Part 1 — prime to a non-integer rational power
+Write `q = a/b` in lowest terms (`a = q.num.natAbs`, `b = q.den`, `Nat.Coprime a b`,
+`b ≥ 2`). Then
+  `p ^ (q : ℝ) = p ^ (a · b⁻¹) = (p ^ a) ^ (b⁻¹) = (p ^ a) ^ (1/b)`,
+so by the sibling entry's rationality criterion (`irrational_rpow_inv_iff`) `p ^ q` is
+irrational **iff** `p ^ a` is not a perfect `b`-th power. A prime power `p ^ a` is a
+perfect `b`-th power iff `b ∣ a` (compare `p`-adic valuations:
+`(p^a).factorization p = a`, `(k^b).factorization p = b · k.factorization p`). Since
+`gcd a b = 1` and `b ≥ 2`, `b ∤ a`, so `p ^ q` is irrational.
+
+### Part 2 — `∛2 + ∛3`
+Let `s = ∛2 + ∛3`. Cubing and using `∛2·∛3 = ∛6` (`Real.mul_rpow`) gives the key identity
+  `s³ = 5 + 3·∛6·s`.
+If `s` were rational then `∛6 = (s³ - 5)/(3 s)` would be rational too (note `s > 0`),
+contradicting the sibling entry's `irrational_cbrt_six`. Hence `s` is irrational.
+
+Both parts reuse the sibling `CubeRoot2IrrationalOQ05OQ01`
+(`irrational_rpow_inv_iff`, `IsPerfectNthPow`, `rpow_inv_pow`, `irrational_cbrt_six`).
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+import Proofs.CubeRoot2IrrationalOQ05OQ01
+
+namespace CubeRoot2IrrationalOQ05OQ02
+
+open Real
+open CubeRoot2IrrationalOQ05OQ01 (IsPerfectNthPow irrational_rpow_inv_iff rpow_inv_pow
+  irrational_cbrt_six)
+
+/-! ## Part 1: prime raised to a non-integer rational power -/
+
+/-- **A prime power is a perfect `b`-th power only when `b ∣ a`.** If `b ∤ a`, then `p ^ a`
+is not a perfect `b`-th power. The proof compares `p`-adic valuations: from `p ^ a = k ^ b`
+we get `a = b · v_p(k)`, hence `b ∣ a`. -/
+theorem not_isPerfectNthPow_prime_pow {p a b : ℕ} (hp : p.Prime)
+    (hndvd : ¬ b ∣ a) : ¬ IsPerfectNthPow (p ^ a) b := by
+  rintro ⟨k, hk⟩
+  -- compare the `p`-adic valuation of both sides of `p ^ a = k ^ b`
+  have key : (p ^ a).factorization p = (k ^ b).factorization p := by rw [hk]
+  simp only [Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
+    hp.factorization_self, mul_one] at key
+  -- `key : a = b * k.factorization p`, so `b ∣ a`
+  exact hndvd ⟨k.factorization p, key⟩
+
+/-- **Irrationality of a prime raised to a non-integer rational power.** For a prime `p`
+and a positive rational `q` whose denominator is at least `2` (i.e. `q` is not an integer),
+the real power `p ^ q` is irrational. This generalizes the parent OQ-05 result
+`irrational_rpow_inv_prime` from unit-fraction exponents `1/n` to arbitrary reduced
+fractions `a/b`. -/
+theorem irrational_prime_rpow {p : ℕ} (hp : p.Prime) {q : ℚ} (hq : 0 < q)
+    (hden : 2 ≤ q.den) : Irrational ((p : ℝ) ^ (q : ℝ)) := by
+  set a : ℕ := q.num.natAbs with ha
+  set b : ℕ := q.den with hb
+  have hnum : 0 < q.num := Rat.num_pos.mpr hq
+  -- `(a : ℤ) = q.num` since `q.num ≥ 0`
+  have hacast : (a : ℤ) = q.num := by rw [ha]; exact Int.natAbs_of_nonneg hnum.le
+  have hp0 : (0 : ℝ) ≤ (p : ℝ) := by positivity
+  have hbne : (b : ℝ) ≠ 0 := by positivity
+  -- rewrite `p ^ q` as `(p ^ a) ^ (1/b)`
+  have hrw : (p : ℝ) ^ (q : ℝ) = ((p ^ a : ℕ) : ℝ) ^ ((b : ℝ)⁻¹) := by
+    rw [Rat.cast_def, ← hb]
+    have hqnum : ((q.num : ℝ)) = (a : ℝ) := by
+      rw [← hacast]; push_cast; ring
+    rw [hqnum, div_eq_mul_inv, Real.rpow_mul hp0, Real.rpow_natCast]
+    push_cast
+    ring
+  rw [hrw]
+  -- not a perfect `b`-th power, since `b ∤ a`
+  have hcop : Nat.Coprime a b := q.reduced
+  have hndvd : ¬ b ∣ a := by
+    intro hd
+    have hg1 : Nat.gcd a b = 1 := hcop
+    have hbg : b ∣ Nat.gcd a b := Nat.dvd_gcd hd dvd_rfl
+    rw [hg1] at hbg
+    have : b ≤ 1 := Nat.le_of_dvd one_pos hbg
+    omega
+  exact (irrational_rpow_inv_iff (m := p ^ a) (n := b) (by omega)).mpr
+    (not_isPerfectNthPow_prime_pow hp hndvd)
+
+/-- `2 ^ (2/3)` is irrational: a prime to a non-integer rational power. -/
+theorem irrational_two_rpow_two_thirds :
+    Irrational ((2 : ℝ) ^ ((2 / 3 : ℚ) : ℝ)) :=
+  irrational_prime_rpow (p := 2) (by norm_num) (by norm_num) (by norm_num)
+
+/-- `3 ^ (3/2)` is irrational: the exponent exceeds `1` yet is still non-integer. -/
+theorem irrational_three_rpow_three_halves :
+    Irrational ((3 : ℝ) ^ ((3 / 2 : ℚ) : ℝ)) :=
+  irrational_prime_rpow (p := 3) (by norm_num) (by norm_num) (by norm_num)
+
+/-! ## Part 2: irrationality of `∛2 + ∛3` -/
+
+/-- **`∛2 + ∛3` is irrational.** Cubing the sum and using `∛2·∛3 = ∛6` yields
+`(∛2+∛3)³ = 5 + 3·∛6·(∛2+∛3)`; were the sum rational, `∛6` would be rational too,
+contradicting `irrational_cbrt_six`. -/
+theorem irrational_cbrt_two_add_cbrt_three :
+    Irrational ((2 : ℝ) ^ ((3 : ℝ)⁻¹) + (3 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  set a : ℝ := (2 : ℝ) ^ ((3 : ℝ)⁻¹) with hadef
+  set c : ℝ := (3 : ℝ) ^ ((3 : ℝ)⁻¹) with hcdef
+  set s : ℝ := a + c with hsdef
+  -- the three real cube roots and their basic identities
+  have ha3 : a ^ 3 = 2 := by
+    have := rpow_inv_pow (m := 2) (n := 3) (by norm_num); simpa [hadef] using this
+  have hc3 : c ^ 3 = 3 := by
+    have := rpow_inv_pow (m := 3) (n := 3) (by norm_num); simpa [hcdef] using this
+  have hac : a * c = (6 : ℝ) ^ ((3 : ℝ)⁻¹) := by
+    rw [hadef, hcdef, ← Real.mul_rpow (by norm_num) (by norm_num)]
+    norm_num
+  -- positivity of the sum
+  have ha0 : 0 < a := by rw [hadef]; positivity
+  have hc0 : 0 < c := by rw [hcdef]; positivity
+  have hs0 : 0 < s := by rw [hsdef]; linarith
+  -- the key cubic identity `s³ = 5 + 3·∛6·s`
+  have hkey : s ^ 3 = 5 + 3 * ((6 : ℝ) ^ ((3 : ℝ)⁻¹)) * s := by
+    have hexp : s ^ 3 = a ^ 3 + c ^ 3 + 3 * (a * c) * (a + c) := by rw [hsdef]; ring
+    rw [hexp, ha3, hc3, hac, ← hsdef]; ring
+  -- if `s` were rational, `∛6` would be rational, contradicting `irrational_cbrt_six`
+  intro hmem
+  obtain ⟨r, hr⟩ := hmem
+  have hr0 : (r : ℝ) ≠ 0 := by rw [hr]; exact hs0.ne'
+  have hcbrt6 : (6 : ℝ) ^ ((3 : ℝ)⁻¹) = (((r ^ 3 - 5) / (3 * r) : ℚ) : ℝ) := by
+    have h3r : (3 : ℝ) * (r : ℝ) ≠ 0 := mul_ne_zero (by norm_num) hr0
+    rw [← hr] at hkey
+    push_cast
+    rw [eq_div_iff h3r]
+    linear_combination -hkey
+  exact irrational_cbrt_six ⟨(r ^ 3 - 5) / (3 * r), hcbrt6.symm⟩
+
+end CubeRoot2IrrationalOQ05OQ02

--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "cube-root-2-irrational-oq-05-oq-02",
+  "title": "Prime to a Non-Integer Rational Power Is Irrational, and ∛2 + ∛3 ∉ ℚ",
+  "slug": "cube-root-2-irrational-oq-05-oq-02",
+  "description": "Two irrationality results extending the parent's prime-root family p^(1/n). First, for a prime p and any rational exponent q that is not an integer (q.den ≥ 2), the real power p^q is irrational — the exponent is now an arbitrary reduced fraction a/b, not just a unit fraction 1/n. Second, ∛2 + ∛3 is irrational. Part 1 reuses the sibling's rationality criterion together with a p-adic valuation argument showing a prime power p^a is a perfect b-th power iff b ∣ a; since gcd(a,b)=1 and b ≥ 2 this never happens. Part 2 cubes the sum to obtain (∛2+∛3)³ = 5 + 3·∛6·(∛2+∛3), so rationality of the sum would force ∛6 ∈ ℚ, contradicting the sibling's irrational_cbrt_six.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Nth_root#Irrationality",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "nth-root",
+      "rational-exponent",
+      "rpow",
+      "perfect-power",
+      "factorization",
+      "real-analysis",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ05OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_pow",
+        "description": "(n^k).factorization = k • n.factorization — evaluated at p, turns p^a = k^b into a = b · v_p(k), hence b ∣ a",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Nat.Prime.factorization_self",
+        "description": "p.factorization p = 1 for a prime p — pins the p-adic valuation of p^a to a",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "0 ≤ x → x ^ (y * z) = (x ^ y) ^ z — rewrites p^(a/b) = p^(a·b⁻¹) as (p^a)^(1/b), reducing the rational exponent to a unit fraction",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.mul_rpow",
+        "description": "0 ≤ x → 0 ≤ y → (x*y)^z = x^z * y^z — gives ∛2·∛3 = ∛6, the cross term in the cubing identity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "Rat.cast_def",
+        "description": "(q : ℝ) = q.num / q.den — exposes the reduced numerator/denominator of the rational exponent",
+        "module": "Mathlib.Data.Rat.Cast.Defs"
+      }
+    ],
+    "originalContributions": [
+      "irrational_prime_rpow: for a prime p and a positive non-integer rational q (q.den ≥ 2), the real power p^q is irrational — the rational-exponent generalization of the parent's unit-fraction result irrational_rpow_inv_prime",
+      "not_isPerfectNthPow_prime_pow: a prime power p^a is not a perfect b-th power whenever b ∤ a, proved by comparing p-adic valuations of p^a = k^b",
+      "irrational_cbrt_two_add_cbrt_three: ∛2 + ∛3 is irrational, via the cubing identity (∛2+∛3)³ = 5 + 3·∛6·(∛2+∛3) and the irrationality of ∛6",
+      "irrational_two_rpow_two_thirds, irrational_three_rpow_three_halves: worked instances 2^(2/3) and 3^(3/2) of the rational-exponent theorem"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 143,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on Lean's foundational propext / Classical.choice / Quot.sound). No native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The irrationality of n-th roots of non-perfect-powers (Hardy & Wright, Theorem 44; Niven, Irrational Numbers) is the general form of the Pythagorean discovery that √2 is irrational. Two natural next steps lie beyond the unit-fraction case: arbitrary rational exponents p^(a/b), and arithmetic combinations of distinct radicals such as ∛2 + ∛3. The first follows the same valuation principle — a prime power is a perfect b-th power only when b divides the exponent. The second is the simplest non-trivial sum of independent cube roots; its classical irrationality proof, recast here, cubes the sum and reduces to the irrationality of ∛6.",
+    "problemStatement": "**Open Question (cube-root-2-irrational-oq-05, second listed)**: Extend the prime-root irrationality to (1) rational non-integer exponents p^q, and (2) sums such as ∛2 + ∛3.\n\n**Result**: irrational_prime_rpow settles (1) for every prime base and non-integer rational exponent; irrational_cbrt_two_add_cbrt_three settles (2).",
+    "text": "For a prime p and a non-integer rational q, p^q is irrational; and ∛2 + ∛3 is irrational.",
+    "proofStrategy": "**Proof Strategy.**\n\n**Part 1 (rational exponents).** Write the reduced exponent q = a/b with a = q.num.natAbs, b = q.den, gcd(a,b) = 1 and b ≥ 2. Real-power arithmetic gives p^q = p^(a·b⁻¹) = (p^a)^(1/b) (Real.rpow_mul, Real.rpow_natCast for the nonnegative base p). The sibling's criterion irrational_rpow_inv_iff then reduces irrationality of (p^a)^(1/b) to: p^a is not a perfect b-th power. The lemma not_isPerfectNthPow_prime_pow proves this from p∤b-divisibility: if p^a = k^b, comparing p-adic valuations (Nat.factorization_pow, Nat.Prime.factorization_self) yields a = b · v_p(k), so b ∣ a — impossible since gcd(a,b)=1 and b ≥ 2.\n\n**Part 2 (∛2 + ∛3).** Put s = ∛2 + ∛3. Cubing and using ∛2·∛3 = ∛6 (Real.mul_rpow) gives s³ = 2 + 3 + 3·∛6·s = 5 + 3·∛6·s. If s were rational, say s = r ∈ ℚ, then ∛6 = (r³ − 5)/(3r) would be rational (s > 0 so r ≠ 0), contradicting the sibling's irrational_cbrt_six. Hence s is irrational.",
+    "keyInsights": [
+      "**A rational exponent is still a unit-fraction problem.** Real.rpow_mul collapses p^(a/b) to (p^a)^(1/b), so the only new ingredient over the parent is deciding when the integer p^a is a perfect b-th power.",
+      "**Valuation makes the perfect-power test trivial.** Reading p^a = k^b at the prime p gives a = b · v_p(k) directly; coprimality of a and b (the defining property of a reduced fraction) then forbids b ∣ a for b ≥ 2.",
+      "**Cubing linearizes a sum of cube roots.** (∛2+∛3)³ expands so that the only surviving radical is the single cross term ∛2·∛3 = ∛6; the sum's rationality is thus equivalent to ∛6's, which is already settled.",
+      "**Composite radicand handled for free.** ∛6 — not reachable by the prime corollary — is exactly the obstruction that powers the ∛2 + ∛3 argument, tying the two parts together."
+    ],
+    "prerequisites": [
+      "The sibling rationality criterion m^(1/n) ∈ ℚ ⟺ m is a perfect n-th power (cube-root-2-irrational-oq-05-oq-01)",
+      "p-adic valuation / Nat.factorization arithmetic on prime powers",
+      "Real power (rpow) arithmetic: rpow_mul, rpow_natCast, mul_rpow for nonnegative base",
+      "Reduced-fraction facts for ℚ: q.num, q.den, coprimality (q.reduced)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "perfect-power-obstruction",
+      "title": "Prime Powers and Perfect b-th Powers",
+      "startLine": 45,
+      "endLine": 58,
+      "summary": "not_isPerfectNthPow_prime_pow: if b ∤ a then p^a is not a perfect b-th power. Comparing p-adic valuations of p^a = k^b (Nat.factorization_pow, Nat.Prime.factorization_self) yields a = b · v_p(k), i.e. b ∣ a.",
+      "mathContext": "$p^a = k^b \\implies a = b\\,v_p(k) \\implies b \\mid a$."
+    },
+    {
+      "id": "rational-exponent",
+      "title": "Prime to a Non-Integer Rational Power",
+      "startLine": 60,
+      "endLine": 103,
+      "summary": "irrational_prime_rpow: for prime p and rational q with q.den ≥ 2, p^q is irrational. Rewrites p^q = (p^a)^(1/b) via Real.rpow_mul, applies the sibling criterion, and uses coprimality of a = q.num.natAbs and b = q.den to rule out b ∣ a. Instances 2^(2/3), 3^(3/2).",
+      "mathContext": "$p^{a/b} = (p^a)^{1/b} \\notin \\mathbb{Q}$ when $\\gcd(a,b)=1,\\ b \\ge 2$."
+    },
+    {
+      "id": "sum-of-cube-roots",
+      "title": "Irrationality of ∛2 + ∛3",
+      "startLine": 105,
+      "endLine": 143,
+      "summary": "irrational_cbrt_two_add_cbrt_three: cubes s = ∛2 + ∛3 to s³ = 5 + 3·∛6·s (using ∛2·∛3 = ∛6 from Real.mul_rpow); rationality of s would make ∛6 = (s³−5)/(3s) rational, contradicting irrational_cbrt_six.",
+      "mathContext": "$(\\sqrt[3]{2}+\\sqrt[3]{3})^3 = 5 + 3\\sqrt[3]{6}\\,(\\sqrt[3]{2}+\\sqrt[3]{3})$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-2-irrational-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Reuses the rationality criterion irrational_rpow_inv_iff and the worked instance irrational_cbrt_six; generalizes the exponent from unit fractions 1/n to arbitrary reduced fractions a/b"
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-05",
+      "relationship": "extends",
+      "description": "Answers the parent's second open question: rational non-integer exponents and sums of cube roots, beyond the parent's prime p^(1/n) family"
+    },
+    {
+      "targetId": "cube-root-2-irrational",
+      "relationship": "related",
+      "description": "∛2, the base entry, appears here both as a base of a rational-exponent power and as a summand of the irrational ∛2 + ∛3"
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) extension of the prime-root irrationality line in two directions: every prime raised to a non-integer rational power is irrational, and ∛2 + ∛3 is irrational. The first reduces a rational exponent to a unit fraction plus a one-line p-adic valuation test; the second cubes the sum and bottoms out at the irrationality of ∛6.",
+    "implications": "The rational-exponent theorem closes the exponent variable of the parent family (1/n → a/b), and the valuation lemma is the clean general obstruction to a prime power being a perfect power. The ∛2 + ∛3 result demonstrates the cubing technique for sums of independent radicals, reducing such questions to single-radical irrationality already decided by the criterion.",
+    "openQuestions": [
+      "Generalize to arbitrary natural (non-prime) bases m^q: m^(a/b) is rational iff m is a perfect (b/gcd)-th power after reducing a/b — replacing the prime valuation step with full factorization.",
+      "Irrationality of ∛p + ∛q for distinct primes, or ⁿ√p + ⁿ√q for n ≥ 3, via the analogous power-expansion-and-reduce technique."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CubeRoot2IrrationalOQ05OQ01"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CubeRoot2IrrationalOQ05OQ02",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CubeRoot2IrrationalOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Theorem 44 and surrounding material on irrationality of roots of non-perfect-powers"
+    },
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs, MAA",
+      "note": "Classical irrationality of n-th roots and sums of radicals"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the second open question of parent **cube-root-2-irrational-oq-05** ("Extend to sums such as ∛2 + ∛3 and to irrationality of p^q for rational non-integer exponents q"). Two irrationality results that go beyond the parent family `p^(1/n)`:

1. **`irrational_prime_rpow`** — for a prime `p` and a positive rational `q` with denominator `≥ 2` (i.e. `q` not an integer), `p^q` is irrational. Writing `q = a/b` in lowest terms, `p^q = (p^a)^(1/b)`; by the sibling's rationality criterion `irrational_rpow_inv_iff`, this is irrational iff `p^a` is not a perfect `b`-th power. A `p`-adic valuation comparison (`a = b·v_p(k)` from `p^a = k^b`) forces `b ∣ a`, contradicting `gcd(a,b)=1, b≥2`. Concrete instances: `2^(2/3)`, `3^(3/2)`.
2. **`irrational_cbrt_two_add_cbrt_three`** — `∛2 + ∛3` is irrational. Cubing the sum and using `∛2·∛3 = ∛6` gives `s³ = 5 + 3·∛6·s`; were `s` rational, `∛6 = (s³−5)/(3s)` would be rational too, contradicting the sibling's `irrational_cbrt_six`.

Reuses `CubeRoot2IrrationalOQ05OQ01` (`IsPerfectNthPow`, `irrational_rpow_inv_iff`, `rpow_inv_pow`, `irrational_cbrt_six`).

## Verification
- **5 theorems, 1 file (143 lines), 0 sorries, 0 axioms**, no `native_decide`.
- `#print axioms` on the headline results lists only `propext` / `Classical.choice` / `Quot.sound`.
- Builds against the parent/sibling oleans via `lake env lean`.

## Provenance
This recovers an **orphaned, untracked, complete** proof left on `main` by a crashed researcher (dead claim lock, no branch/PR, not imported in `Proofs.lean`). I verified it builds and is axiom-free, then integrated it into `Proofs.lean` and added the gallery entry.

## Files
- `proofs/Proofs/CubeRoot2IrrationalOQ05OQ02.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/cube-root-2-irrational-oq-05-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)