### PR TITLE
Enrich: Weighted Chebyshev Sum Inequality (rearrangement-inequality-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/rearrangement-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/rearrangement-inequality-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-rcw-identity",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 55 },
+    "type": "definition",
+    "title": "The Weighted Covariance Identity",
+    "content": "The engine of the whole file: for ANY real weights w and sequences f, g, the symmetric double sum ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) equals 2((∑w)(∑wfg) − (∑wf)(∑wg)). The proof rewrites each summand by `ring` into the four-product form (wᵢfᵢgᵢ)wⱼ + wᵢ(wⱼfⱼgⱼ) − (wᵢfᵢ)(wⱼgⱼ) − (wᵢgᵢ)(wⱼfⱼ), then simp_rw with Finset.mul_sum / sum_mul collapses each double sum into a product of single sums. Crucially NO order or sign hypothesis is used — this is a pure algebraic identity.",
+    "mathContext": "$\\sum_i\\sum_j w_iw_j(f_i-f_j)(g_i-g_j) = 2\\big((\\textstyle\\sum w_i)(\\sum w_if_ig_i) - (\\sum w_if_i)(\\sum w_ig_i)\\big)$, the finite unnormalised analogue of $2W^2\\mathrm{Cov}_w(f,g)$.",
+    "significance": "key",
+    "relatedConcepts": ["covariance", "double sum", "Finset.mul_sum", "Lagrange-type identity"],
+    "prerequisites": ["finite sums over Finset", "ring normalization"]
+  },
+  {
+    "id": "ann-rcw-term-nonneg",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 73 },
+    "type": "technique",
+    "title": "Termwise Nonnegativity under Monovariance",
+    "content": "Each summand factors as (wᵢwⱼ)·((fᵢ−fⱼ)(gᵢ−gⱼ)). The weight factor is ≥ 0 by mul_nonneg; the order factor (fᵢ−fⱼ)(gᵢ−gⱼ) is ≥ 0 by a trichotomy on gᵢ vs gⱼ. When gᵢ < gⱼ the MonovaryOn hypothesis forces fᵢ ≤ fⱼ, so both factors are ≤ 0 and their product ≥ 0 (nlinarith); the gᵢ = gⱼ case is immediate; gᵢ > gⱼ is symmetric. This is the same sign argument as the unweighted parent, now carrying the weights along.",
+    "mathContext": "$w_i,w_j \\ge 0$ and $f,g$ monovary $\\implies w_iw_j(f_i-f_j)(g_i-g_j) \\ge 0$, since $(f_i-f_j)$ and $(g_i-g_j)$ share sign.",
+    "significance": "key",
+    "relatedConcepts": ["MonovaryOn", "sign trichotomy", "mul_nonneg", "comonotonicity"],
+    "prerequisites": ["monovariance", "ordered fields"]
+  },
+  {
+    "id": "ann-rcw-inequality",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 86 },
+    "type": "theorem",
+    "title": "The Weighted Chebyshev Sum Inequality",
+    "content": "A one-line corollary: the double sum is a sum of nonnegative terms (Finset.sum_nonneg applied twice with weighted_term_nonneg), hence ≥ 0; substituting the covariance identity and calling linarith yields (∑wf)(∑wg) ≤ (∑w)(∑wfg). The inequality is thus a direct sign reading of the identity — all the analytic content was front-loaded into the algebraic identity and the termwise sign.",
+    "mathContext": "$\\big(\\textstyle\\sum w_if_i\\big)\\big(\\sum w_ig_i\\big) \\le \\big(\\sum w_i\\big)\\big(\\sum w_if_ig_i\\big)$ for nonnegative weights and monovarying $f,g$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev sum inequality", "Finset.sum_nonneg", "weighted average", "Jensen-type bound"],
+    "prerequisites": ["the covariance identity", "termwise nonnegativity"]
+  },
+  {
+    "id": "ann-rcw-eq-iff",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 127 },
+    "type": "insight",
+    "title": "Exact Equality: a Support-Aware Pairwise Condition",
+    "content": "Equality means the nonnegative double sum vanishes. Finset.sum_eq_zero_iff_of_nonneg (applied to the outer then inner sum) forces every term wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) = 0. The converse is unconditional — if every pair satisfies the disjunction, each term is 0 by `ring` after substituting the vanishing factor. The headline subtlety: the wᵢ = 0 ∨ wⱼ = 0 disjuncts mean variation of f, g at weight-zero indices is INVISIBLE — only the support of w constrains equality, a genuine refinement of the unweighted parent.",
+    "mathContext": "Equality $\\iff \\forall i,j \\in s:\\ w_i=0 \\lor w_j=0 \\lor f_i=f_j \\lor g_i=g_j$ — no strictly-comonotone pair on $\\mathrm{supp}(w)$.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "sum_eq_zero_iff_of_nonneg", "support of a measure", "rigidity"],
+    "prerequisites": ["vanishing of nonnegative sums", "monovariance"]
+  },
+  {
+    "id": "ann-rcw-mul-eq-zero",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 117 },
+    "type": "technique",
+    "title": "Splitting a Vanishing Product into Four Disjuncts",
+    "content": "Once a term wᵢ·wⱼ·(fᵢ−fⱼ)·(gᵢ−gⱼ) = 0 is established, nested mul_eq_zero peels the left-associated product apart: the outermost split isolates (gᵢ−gⱼ), the next (fᵢ−fⱼ), the next wⱼ, leaving wᵢ. sub_eq_zero converts fᵢ−fⱼ = 0 into fᵢ = fⱼ. The careful Or-nesting reassembles exactly the four-way disjunction wᵢ = 0 ∨ wⱼ = 0 ∨ fᵢ = fⱼ ∨ gᵢ = gⱼ.",
+    "mathContext": "$abcd = 0 \\iff a=0 \\lor b=0 \\lor c=0 \\lor d=0$ in an integral domain.",
+    "significance": "supporting",
+    "relatedConcepts": ["mul_eq_zero", "sub_eq_zero", "integral domain", "case analysis"],
+    "prerequisites": ["no zero divisors in ℝ"]
+  },
+  {
+    "id": "ann-rcw-const-dichotomy",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 129, "endLine": 170 },
+    "type": "theorem",
+    "title": "Strictly Positive Weights: the Textbook Dichotomy",
+    "content": "For strictly positive weights the wᵢ = 0 disjuncts are impossible, so equality reduces to: every pair has fᵢ = fⱼ or gᵢ = gⱼ. The extreme-pair argument promotes this to 'f constant on s OR g constant on s': assuming neither, pick witnesses a,b with fₐ ≠ f_b and c,d with g_c ≠ g_d, then monotonicity squeezes f and g between their values at min' s and max' s to show f(min') ≠ f(max') AND g(min') ≠ g(max') — but the (min', max') pair must satisfy the disjunction, a contradiction. This recovers the unweighted parent's equality case verbatim.",
+    "mathContext": "Strictly positive $w$, monotone $f,g$: equality $\\iff f$ constant on $s$ $\\lor$ $g$ constant on $s$.",
+    "significance": "key",
+    "relatedConcepts": ["extreme-pair argument", "Finset.min'/max'", "monotone functions", "constant on a set"],
+    "prerequisites": ["linear order on index type", "monotonicity", "extremal elements"]
+  },
+  {
+    "id": "ann-rcw-unit-weight",
+    "proofId": "rearrangement-inequality-oq-01-oq-02",
+    "range": { "startLine": 172, "endLine": 184 },
+    "type": "context",
+    "title": "Unit Weights Recover the Parent Identity",
+    "content": "Setting wᵢ ≡ 1 specializes the weighted identity: ∑w collapses to #s and the weighted sums become plain sums, giving ∑ᵢ∑ⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) = 2(#s·∑fᵢgᵢ − (∑fᵢ)(∑gᵢ)) — exactly the parent RearrangementChebyshevEq.covariance_identity. The proof is a single `simpa` after instantiating w := fun _ => 1. This confirms the weighted result is a strict generalization that subsumes, rather than parallels, the parent.",
+    "mathContext": "$w_i\\equiv 1$: $\\sum_i\\sum_j (f_i-f_j)(g_i-g_j) = 2\\big(|s|\\sum f_ig_i - (\\sum f_i)(\\sum g_i)\\big)$.",
+    "significance": "context",
+    "relatedConcepts": ["specialization", "generalization", "unweighted Chebyshev", "Finset.card"],
+    "prerequisites": ["the weighted identity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `rearrangement-inequality-oq-01-oq-02`.

## Quality improvements
- **Added `annotations.json`** (was missing — the standard gap on researcher-produced entries): 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. They cover:
  1. the order-free weighted covariance identity that drives everything,
  2. termwise nonnegativity under `MonovaryOn` (the sign trichotomy),
  3. the one-line weighted Chebyshev inequality corollary,
  4. the support-aware exact equality case (weight-zero indices are invisible),
  5. the nested `mul_eq_zero` split into the four disjuncts,
  6. the strictly-positive-weight extreme-pair (`min'`/`max'`) dichotomy, and
  7. the unit-weight specialization recovering the parent identity.

## Verification
- `pnpm annotations:build` runs clean for this entry (no "No Lean construct" warnings; `listings.json` regenerates with 3546 proofs).
- Axiom integrity confirmed accurate: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries, no assumption-carrying structures.
- The entry's existing rich meta (overview, 5 sections, conclusion, crossReferences, top-level description) was already present and is untouched; this pass only adds the missing annotations.