### PR TITLE
research(liouville-theorem-oq-03): Jarník–Besicovitch dimension of well-approximable sets; Liouville numbers have dimension 0 [axiomatized]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3320,6 +3320,7 @@ import Proofs.LeibnizPiOQ03
 import Proofs.LiftingTheExponentOQ01
 import Proofs.LiftingTheExponentOQ02
 import Proofs.LiouvilleTheorem
+import Proofs.LiouvilleTheoremOQ03
 import Proofs.LiouvilleTheoremOQ04
 import Proofs.LiouvilleTheoremOQ05
 import Proofs.LittleWedderburnOQ01

--- a/proofs/Proofs/LiouvilleTheoremOQ03.lean
+++ b/proofs/Proofs/LiouvilleTheoremOQ03.lean
@@ -1,0 +1,210 @@
+import Mathlib
+
+/-
+# Hausdorff Dimension of Sets with Given Irrationality Measure (Jarník–Besicovitch)
+
+## Open Question: liouville-theorem-oq-03
+
+For a real exponent `τ`, the **τ-well-approximable set** is
+
+  `W(τ) = { x : ℝ | ∃ C, for infinitely many q, ∃ p, |x - p/q| < C / q^τ }`,
+
+which is exactly Mathlib's `{ x | LiouvilleWith τ x }`. The
+**Jarník–Besicovitch theorem** (Jarník 1931, Besicovitch 1934) computes its
+Hausdorff dimension:
+
+  `dimH (W τ) = 2 / τ`   for every `τ ≥ 2`.
+
+This is one of the foundational results of metric Diophantine approximation. Its
+proof has two halves: an upper bound `≤ 2/τ` by an efficient covering of the
+approximating intervals (a convergence/Borel–Cantelli argument), and a lower
+bound `≥ 2/τ` by constructing a Cantor-like subset carrying a mass distribution
+(the mass distribution principle / Frostman's lemma). Mathlib currently has the
+`LiouvilleWith` predicate and the full `dimH` Hausdorff-dimension API, but **not**
+the Jarník–Besicovitch dimension formula itself, which depends on Hausdorff
+measure estimates for these specific sets that are not yet formalized.
+
+## What this entry does
+
+We formalize the statement and its structural surroundings, separating the
+machine-checkable content from the one deep input:
+
+* **Verified, 0-axiom** (genuine Mathlib derivations):
+  - the well-approximable sets are *antitone* in the exponent
+    (`wellApprox_antitone`), so `dimH (W τ)` is monotone — proved from
+    `LiouvilleWith.mono`;
+  - every Liouville number lies in *every* `W τ`
+    (`liouville_subset_wellApprox`) — proved from `Liouville.liouvilleWith`;
+  - hence `dimH {Liouville} ≤ dimH (W τ)` for all `τ` (`dimH_liouville_le_wellApprox`);
+  - `W τ = univ` for `τ ≤ 1` (`wellApprox_le_one`);
+  - elementary properties of the dimension exponent `τ ↦ 2/τ`.
+
+* **The Jarník–Besicovitch formula** enters as the single `axiom`
+  `dimH_wellApprox` (`dimH (W τ) = ENNReal.ofReal (2/τ)` for `τ ≥ 2`), the known
+  deep theorem not yet in Mathlib.
+
+* **Derived from the axiom** (real consequences, not restatements):
+  - `dimH_wellApprox_two`: `dimH (W 2) = 1`;
+  - `dimH_liouville_le`: `dimH {Liouville} ≤ 2/τ` for every `τ ≥ 2`;
+  - **`dimH_liouville_eq_zero`**: the Liouville numbers have Hausdorff dimension
+    `0` — squeezed from the bound as `τ → ∞`. This recovers the classical fact
+    that the Liouville set, while uncountable, is dimensionally negligible.
+
+## References
+  * V. Jarník, "Über die simultanen diophantischen Approximationen" (Math. Z. 33, 1931).
+  * A.S. Besicovitch, "Sets of fractional dimensions (IV)" (J. London Math. Soc. 9, 1934).
+  * Y. Bugeaud, *Approximation by Algebraic Numbers* (Cambridge, 2004), Ch. 1.
+
+**Axiom count**: 1 (the Jarník–Besicovitch dimension formula).  **Sorry count**: 0
+-/
+
+open Filter Set Topology
+open scoped ENNReal
+
+namespace LiouvilleTheoremOQ03
+
+/-! ## Part I: The well-approximable sets `W τ` -/
+
+/-- The τ-well-approximable set `W τ = { x | LiouvilleWith τ x }`: reals
+approximable by rationals `p/q` to within `C/q^τ` for infinitely many `q`. -/
+def wellApprox (τ : ℝ) : Set ℝ := {x : ℝ | LiouvilleWith τ x}
+
+@[simp] theorem mem_wellApprox {τ x : ℝ} : x ∈ wellApprox τ ↔ LiouvilleWith τ x := Iff.rfl
+
+/-- **Antitone in the exponent.** A larger approximation exponent is a stronger
+demand, so `W` shrinks: `σ ≤ τ → W τ ⊆ W σ`. Proved from `LiouvilleWith.mono`. -/
+theorem wellApprox_antitone {σ τ : ℝ} (h : σ ≤ τ) : wellApprox τ ⊆ wellApprox σ :=
+  fun _ hx => hx.mono h
+
+/-- For exponent `τ ≤ 1` every real is well-approximable: `W τ = univ`. -/
+theorem wellApprox_le_one {τ : ℝ} (h : τ ≤ 1) : wellApprox τ = Set.univ := by
+  ext x
+  simp only [mem_wellApprox, Set.mem_univ, iff_true]
+  exact (liouvilleWith_one x).mono h
+
+/-- In particular `W 1 = univ`. -/
+theorem wellApprox_one : wellApprox 1 = Set.univ := wellApprox_le_one le_rfl
+
+/-- **Every Liouville number is well-approximable to every order.**
+`{x | Liouville x} ⊆ W τ` for all `τ`. Proved from `Liouville.liouvilleWith`. -/
+theorem liouville_subset_wellApprox (τ : ℝ) : {x : ℝ | Liouville x} ⊆ wellApprox τ :=
+  fun _ hx => hx.liouvilleWith τ
+
+/-! ## Part II: Monotonicity of the Hausdorff dimension -/
+
+/-- The Hausdorff dimension of `W τ` is antitone in `τ`: `σ ≤ τ → dimH (W τ) ≤ dimH (W σ)`.
+A purely structural consequence of `wellApprox_antitone` and `dimH_mono`. -/
+theorem dimH_wellApprox_antitone {σ τ : ℝ} (h : σ ≤ τ) :
+    dimH (wellApprox τ) ≤ dimH (wellApprox σ) :=
+  dimH_mono (wellApprox_antitone h)
+
+/-- The Liouville set has dimension below that of every `W τ`. -/
+theorem dimH_liouville_le_wellApprox (τ : ℝ) :
+    dimH {x : ℝ | Liouville x} ≤ dimH (wellApprox τ) :=
+  dimH_mono (liouville_subset_wellApprox τ)
+
+/-! ## Part III: The dimension exponent `τ ↦ 2/τ` -/
+
+/-- The Jarník–Besicovitch dimension exponent `d(τ) = 2/τ`. -/
+noncomputable def jbDim (τ : ℝ) : ℝ := 2 / τ
+
+/-- `d(2) = 1`: the well-approximable set at the natural threshold `τ = 2` is
+full-dimensional in ℝ. -/
+@[simp] theorem jbDim_two : jbDim 2 = 1 := by unfold jbDim; norm_num
+
+/-- `d(τ) > 0` for `τ > 0`. -/
+theorem jbDim_pos {τ : ℝ} (h : 0 < τ) : 0 < jbDim τ := by
+  unfold jbDim; positivity
+
+/-- `d(τ) ≤ 1` for `τ ≥ 2`: above the threshold the dimension drops to a proper
+fraction of the line. -/
+theorem jbDim_le_one {τ : ℝ} (h : 2 ≤ τ) : jbDim τ ≤ 1 := by
+  unfold jbDim
+  rw [div_le_one (by linarith)]
+  linarith
+
+/-- `d(τ) < 1` strictly for `τ > 2`. -/
+theorem jbDim_lt_one {τ : ℝ} (h : 2 < τ) : jbDim τ < 1 := by
+  unfold jbDim
+  rw [div_lt_one (by linarith)]
+  linarith
+
+/-- `d` is antitone on the positive reals: `0 < σ ≤ τ → d(τ) ≤ d(σ)`. -/
+theorem jbDim_antitone {σ τ : ℝ} (hσ : 0 < σ) (h : σ ≤ τ) : jbDim τ ≤ jbDim σ := by
+  unfold jbDim
+  gcongr
+
+/-! ## Part IV: The Jarník–Besicovitch theorem (axiomatized) -/
+
+/-- **Jarník–Besicovitch theorem.** For every exponent `τ ≥ 2`, the
+τ-well-approximable set has Hausdorff dimension `2/τ`:
+
+  `dimH (W τ) = 2 / τ`.
+
+This is the deep result of metric Diophantine approximation (Jarník 1931,
+Besicovitch 1934). It is not yet available in Mathlib — the upper bound needs a
+covering/Borel–Cantelli estimate and the lower bound a mass-distribution
+(Frostman) construction on a Cantor subset — so it is recorded here as the single
+axiom of this entry. The constant `C` in `LiouvilleWith` does not affect the
+dimension (countable stability of `dimH` over `C ∈ ℕ`). -/
+axiom dimH_wellApprox (τ : ℝ) (hτ : 2 ≤ τ) :
+    dimH (wellApprox τ) = ENNReal.ofReal (2 / τ)
+
+/-- At the threshold `τ = 2` the well-approximable set has full dimension `1`. -/
+theorem dimH_wellApprox_two : dimH (wellApprox 2) = 1 := by
+  rw [dimH_wellApprox 2 le_rfl, show (2 : ℝ) / 2 = 1 by norm_num, ENNReal.ofReal_one]
+
+/-- The Hausdorff dimension of `W τ` matches the exponent `d(τ) = 2/τ`. -/
+theorem dimH_wellApprox_eq_jbDim (τ : ℝ) (hτ : 2 ≤ τ) :
+    dimH (wellApprox τ) = ENNReal.ofReal (jbDim τ) :=
+  dimH_wellApprox τ hτ
+
+/-! ## Part V: Liouville numbers have Hausdorff dimension zero -/
+
+/-- For every `τ ≥ 2`, the Liouville set is dimension-bounded by `2/τ`.
+Combines the subset relation with the Jarník–Besicovitch formula. -/
+theorem dimH_liouville_le {τ : ℝ} (hτ : 2 ≤ τ) :
+    dimH {x : ℝ | Liouville x} ≤ ENNReal.ofReal (2 / τ) :=
+  (dimH_liouville_le_wellApprox τ).trans (dimH_wellApprox τ hτ).le
+
+/-- **The Liouville numbers have Hausdorff dimension zero.**
+
+Although the Liouville set is uncountable (indeed comeagre), it is dimensionally
+negligible: it sits inside `W τ` for every `τ`, so its dimension is at most
+`2/τ → 0`. This is the classical corollary of Jarník–Besicovitch, here derived by
+an explicit squeeze of the bound `dimH ≤ 2/n` along `n → ∞`. -/
+theorem dimH_liouville_eq_zero : dimH {x : ℝ | Liouville x} = 0 := by
+  -- Bound along natural exponents `n ≥ 2`.
+  have hbound : ∀ n : ℕ, 2 ≤ n →
+      dimH {x : ℝ | Liouville x} ≤ ENNReal.ofReal (2 / (n : ℝ)) := by
+    intro n hn
+    have : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    exact dimH_liouville_le this
+  -- The bounds tend to `0`.
+  have htend : Tendsto (fun n : ℕ => ENNReal.ofReal (2 / (n : ℝ))) atTop (𝓝 0) := by
+    have h0 : Tendsto (fun n : ℕ => (2 : ℝ) / (n : ℝ)) atTop (𝓝 0) :=
+      tendsto_const_div_atTop_nhds_zero_nat 2
+    have := (ENNReal.continuous_ofReal.tendsto 0).comp h0
+    simpa using this
+  -- Squeeze: a constant below sequences converging to `0` is `≤ 0`.
+  have hle : dimH {x : ℝ | Liouville x} ≤ 0 :=
+    ge_of_tendsto htend (eventually_atTop.2 ⟨2, fun n hn => hbound n hn⟩)
+  exact le_antisymm hle (zero_le _)
+
+/-! ## Part VI: Summary -/
+
+/-- **Summary.** The Jarník–Besicovitch picture for `liouville-theorem-oq-03`:
+the well-approximable sets are antitone with antitone dimension, the dimension at
+the threshold is `1`, and the Liouville numbers — contained in every `W τ` — have
+dimension `0`. -/
+theorem jarnik_besicovitch_summary :
+    (∀ σ τ : ℝ, σ ≤ τ → wellApprox τ ⊆ wellApprox σ) ∧
+    (∀ τ : ℝ, {x : ℝ | Liouville x} ⊆ wellApprox τ) ∧
+    dimH (wellApprox 2) = 1 ∧
+    dimH {x : ℝ | Liouville x} = 0 :=
+  ⟨fun _ _ h => wellApprox_antitone h,
+   liouville_subset_wellApprox,
+   dimH_wellApprox_two,
+   dimH_liouville_eq_zero⟩
+
+end LiouvilleTheoremOQ03

--- a/src/data/proofs/liouville-theorem-oq-03/meta.json
+++ b/src/data/proofs/liouville-theorem-oq-03/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "liouville-theorem-oq-03",
+  "title": "Hausdorff Dimension of Well-Approximable Sets (Jarník–Besicovitch)",
+  "slug": "liouville-theorem-oq-03",
+  "description": "Formalizes the Jarník–Besicovitch theorem dimH(W τ) = 2/τ (τ ≥ 2) for the τ-well-approximable sets W τ = {x | LiouvilleWith τ x}, and derives the classical corollary that the Liouville numbers have Hausdorff dimension zero despite being uncountable. The deep dimension formula — not yet in Mathlib (its upper bound needs a Borel–Cantelli covering, its lower bound a mass-distribution/Frostman construction) — is recorded as the single axiom dimH_wellApprox; everything else is machine-checked. The structural facts are genuine Mathlib derivations: the sets are antitone in the exponent (from LiouvilleWith.mono), every Liouville number lies in every W τ (from Liouville.liouvilleWith), so dimH{Liouville} ≤ dimH(W τ) for all τ, and the dimension-zero result is squeezed from dimH ≤ 2/n as n → ∞.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/LiouvilleTheoremOQ03.lean",
+    "tags": [
+      "diophantine-approximation",
+      "hausdorff-dimension",
+      "liouville-numbers",
+      "irrationality-measure",
+      "jarnik-besicovitch",
+      "metric-number-theory",
+      "fractal-geometry",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 1,
+    "assumptions": "One axiom: `dimH_wellApprox` — the Jarník–Besicovitch dimension formula dimH(W τ) = ENNReal.ofReal(2/τ) for τ ≥ 2. This is the deep theorem of metric Diophantine approximation (Jarník 1931, Besicovitch 1934) and is not yet available in Mathlib (the upper bound requires a covering/Borel–Cantelli Hausdorff-measure estimate; the lower bound a mass-distribution principle / Frostman construction on a Cantor subset). `#print axioms` confirms: the structural lemmas (wellApprox_antitone, liouville_subset_wellApprox, dimH_liouville_le_wellApprox, and the jbDim exponent facts) depend on no axioms beyond the standard foundational trio; only the formula-dependent results (dimH_wellApprox_two, dimH_liouville_le, dimH_liouville_eq_zero, the summary) carry dimH_wellApprox.",
+    "lineCount": 210,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "originalContributions": [
+      "wellApprox τ := {x | LiouvilleWith τ x}: the τ-well-approximable sets, packaged on top of Mathlib's LiouvilleWith with the JB exponent in mind",
+      "wellApprox_antitone: σ ≤ τ → W τ ⊆ W σ, proved from LiouvilleWith.mono (genuine, 0-axiom)",
+      "liouville_subset_wellApprox: {x | Liouville x} ⊆ W τ for every τ, proved from Liouville.liouvilleWith (genuine, 0-axiom)",
+      "dimH_liouville_le_wellApprox and dimH_wellApprox_antitone: monotonicity of Hausdorff dimension transported through dimH_mono",
+      "dimH_liouville_eq_zero: the Liouville numbers have Hausdorff dimension 0, derived from the JB axiom by an explicit squeeze of dimH ≤ 2/n along n → ∞ (ge_of_tendsto with ENNReal.continuous_ofReal and tendsto_const_div_atTop_nhds_zero_nat)",
+      "jbDim τ := 2/τ with verified analytic properties (d(2)=1, positivity, ≤ 1 and < 1 above the threshold, antitone)"
+    ],
+    "openQuestions": [
+      "Discharge the dimH_wellApprox axiom: formalize the Jarník–Besicovitch upper bound via a Borel–Cantelli covering estimate on the approximating intervals using Mathlib's Hausdorff-measure API",
+      "Formalize the lower bound via the mass distribution principle (Frostman's lemma) on an explicit Cantor subset of W τ",
+      "Define the irrationality measure μ(x) = sSup {τ | LiouvilleWith τ x} and prove the level-set dimension dimH {x | μ(x) = τ} = 2/τ (the exact-measure refinement of JB)"
+    ],
+    "mathContext": "Sibling of the Liouville development: LiouvilleTheorem.lean (Liouville numbers are transcendental/uncountable), LiouvilleTheoremOQ05 (Liouville numbers have Lebesgue measure zero). This entry is the Hausdorff-dimension refinement: measure zero is sharpened to dimension zero. Self-contained on Mathlib; uses Mathlib's LiouvilleWith and dimH APIs directly.",
+    "proofStrategy": "Isolate the one deep input (the dimension formula) as an axiom and prove everything reachable from Mathlib unconditionally. Subset relations come from LiouvilleWith.mono and Liouville.liouvilleWith; dimension monotonicity from dimH_mono; the dimension-zero corollary from a tendsto squeeze of the per-exponent bound. The exponent function 2/τ is analyzed separately by elementary real inequalities.",
+    "historicalContext": "Jarník (1931) and independently Besicovitch (1934) proved that the set of reals approximable to order τ by rationals has Hausdorff dimension 2/τ for τ ≥ 2 — among the first computations of a non-trivial fractional dimension in number theory. The corollary that Liouville numbers form a dimension-zero (yet uncountable, comeagre) set is a standard illustration that Hausdorff dimension is a finer gauge of size than both cardinality and Lebesgue measure.",
+    "problemStatement": "Determine the Hausdorff dimension of the sets of real numbers with a prescribed irrationality measure / approximation exponent, and deduce the dimension of the Liouville set."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Scope",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Imports `Mathlib`, opens Filter/Set/Topology and ENNReal scope, declares namespace `LiouvilleTheoremOQ03`. The docstring states the Jarník–Besicovitch theorem, identifies the well-approximable set with Mathlib's `LiouvilleWith`, and explains which parts are machine-checked versus the single axiomatized dimension formula."
+    },
+    {
+      "id": "sec-sets",
+      "title": "The Well-Approximable Sets W τ",
+      "startLine": 64,
+      "endLine": 92,
+      "summary": "Defines `wellApprox τ := {x | LiouvilleWith τ x}` and proves the genuine (0-axiom) structural facts: `wellApprox_antitone` (σ ≤ τ → W τ ⊆ W σ via LiouvilleWith.mono), `wellApprox_le_one`/`wellApprox_one` (W τ = univ for τ ≤ 1), and `liouville_subset_wellApprox` ({Liouville} ⊆ W τ via Liouville.liouvilleWith)."
+    },
+    {
+      "id": "sec-dim-mono",
+      "title": "Monotonicity of the Hausdorff Dimension",
+      "startLine": 93,
+      "endLine": 106,
+      "summary": "`dimH_wellApprox_antitone` (σ ≤ τ → dimH(W τ) ≤ dimH(W σ)) and `dimH_liouville_le_wellApprox` (dimH{Liouville} ≤ dimH(W τ)), both transported through Mathlib's `dimH_mono`. Zero-axiom."
+    },
+    {
+      "id": "sec-exponent",
+      "title": "The Dimension Exponent 2/τ",
+      "startLine": 107,
+      "endLine": 136,
+      "summary": "`jbDim τ := 2/τ` with verified analytic properties: `jbDim_two` (d(2)=1), `jbDim_pos`, `jbDim_le_one` (τ ≥ 2), `jbDim_lt_one` (τ > 2), and `jbDim_antitone`. Elementary real inequalities, zero-axiom."
+    },
+    {
+      "id": "sec-jb-axiom",
+      "title": "The Jarník–Besicovitch Theorem (axiomatized)",
+      "startLine": 137,
+      "endLine": 160,
+      "summary": "The single axiom `dimH_wellApprox τ (hτ : 2 ≤ τ) : dimH(W τ) = ENNReal.ofReal(2/τ)`, with `dimH_wellApprox_two` (dimH(W 2) = 1) and `dimH_wellApprox_eq_jbDim` derived from it."
+    },
+    {
+      "id": "sec-liouville-zero",
+      "title": "Liouville Numbers Have Hausdorff Dimension Zero",
+      "startLine": 161,
+      "endLine": 196,
+      "summary": "`dimH_liouville_le` (dimH{Liouville} ≤ 2/τ for τ ≥ 2) and the capstone `dimH_liouville_eq_zero`, squeezed from the bound dimH ≤ 2/n along n → ∞ via `ge_of_tendsto`, `ENNReal.continuous_ofReal`, and `tendsto_const_div_atTop_nhds_zero_nat`."
+    },
+    {
+      "id": "sec-summary",
+      "title": "jarnik_besicovitch_summary",
+      "startLine": 197,
+      "endLine": 210,
+      "summary": "Bundles the set antitonicity, the Liouville-subset relation, the threshold dimension dimH(W 2)=1, and the dimension-zero result for the Liouville set."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Metric Diophantine approximation studies how well 'typical' or 'special' reals can be approximated by rationals. The well-approximable set W(τ) = {x : |x - p/q| < q^(-τ) for infinitely many p/q} captures reals of approximation exponent ≥ τ. Jarník (1931) and Besicovitch (1934) computed its Hausdorff dimension to be exactly 2/τ for τ ≥ 2 — one of the earliest fractional-dimension results in number theory and a template for the modern theory (Khinchin–Jarník, the Mass Transference Principle of Beresnevich–Velani). The Liouville numbers, approximable to every order, lie in the intersection of all W(τ); they are uncountable and topologically large (comeagre) yet, by Jarník–Besicovitch, have Hausdorff dimension 0 — a vivid demonstration that dimension is a strictly finer notion of size than cardinality or measure.",
+    "problemStatement": "Determine the Hausdorff dimension dimH(W τ) of the τ-well-approximable reals as a function of the approximation exponent τ, and deduce the Hausdorff dimension of the Liouville set.",
+    "proofStrategy": "Build on Mathlib's `LiouvilleWith` predicate and `dimH` Hausdorff-dimension API. The order structure of the sets (antitone in τ; Liouville ⊆ every W τ) and the resulting dimension monotonicity are proved outright from `LiouvilleWith.mono`, `Liouville.liouvilleWith`, and `dimH_mono`. The Jarník–Besicovitch dimension formula itself — whose proof needs Hausdorff-measure estimates absent from Mathlib — is taken as a single axiom, from which the dimension-zero corollary for Liouville numbers is genuinely derived by a tendsto squeeze.",
+    "keyInsights": [
+      "Mathlib's `LiouvilleWith τ x` is exactly membership in the τ-well-approximable set, and its `mono` lemma immediately gives antitonicity of the sets in the exponent — so the dimension is monotone before any measure theory is invoked.",
+      "`Liouville.liouvilleWith` places every Liouville number in every W τ, turning the dimension-zero claim into a one-parameter squeeze: dimH{Liouville} ≤ 2/τ for all τ, hence 0.",
+      "Only one genuinely deep fact — the value of dimH(W τ) — resists formalization today; isolating it as a single named axiom keeps the rest of the development fully machine-checked and makes precise exactly what Mathlib is still missing.",
+      "The dimension-zero corollary is a clean illustration that Hausdorff dimension refines Lebesgue measure: the sibling entry shows the Liouville set has measure zero; here that is sharpened to dimension zero, the strongest 'smallness' statement of metric type.",
+      "The squeeze uses natural-number exponents (tendsto_const_div_atTop_nhds_zero_nat) to avoid a real-parameter limit lemma, and ENNReal.continuous_ofReal to transport the real limit 2/n → 0 into ℝ≥0∞ where dimH lives."
+    ]
+  },
+  "conclusion": {
+    "summary": "This entry formalizes the Jarník–Besicovitch picture for `liouville-theorem-oq-03`: the well-approximable sets W τ = {x | LiouvilleWith τ x} are antitone in the exponent with antitone Hausdorff dimension, the dimension at the threshold τ = 2 is 1, and the Jarník–Besicovitch formula dimH(W τ) = 2/τ (the one axiom) yields the classical corollary that the uncountable Liouville set has Hausdorff dimension 0. Structural lemmas are genuine 0-axiom Mathlib derivations; the dimension-zero result is squeezed from the formula.",
+    "implications": "The framework reduces the open problem to formalizing a single Hausdorff-measure estimate. Discharging the dimH_wellApprox axiom — via a Borel–Cantelli covering for the upper bound and a Frostman mass distribution for the lower bound — would turn dimH_liouville_eq_zero and the dimension formula into fully unconditional theorems and seed a Mathlib library for metric Diophantine approximation (Khinchin–Jarník, mass transference).",
+    "openQuestions": [
+      "Prove the Jarník–Besicovitch upper bound dimH(W τ) ≤ 2/τ via an explicit Borel–Cantelli covering of the approximating intervals in Mathlib's Hausdorff-measure framework.",
+      "Prove the lower bound dimH(W τ) ≥ 2/τ via the mass distribution principle (Frostman) on a Cantor subset of W τ.",
+      "Introduce the irrationality measure μ(x) and prove the exact-level dimension dimH{x | μ(x) = τ} = 2/τ, refining the inequality form proved here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "liouville-theorem",
+      "relationship": "Parent development: Liouville numbers are transcendental and uncountable. This entry adds the metric/fractal refinement — those same numbers have Hausdorff dimension 0."
+    },
+    {
+      "targetId": "liouville-theorem-oq-05",
+      "relationship": "Sibling proving the Liouville set has Lebesgue measure zero; the present entry sharpens 'measure zero' to 'dimension zero', a strictly stronger smallness statement."
+    },
+    {
+      "targetId": "liouville-theorem-oq-04",
+      "relationship": "Sibling extending Liouville's theorem to p-adic and function-field settings; together the OQ leaves explore the qualitative (transcendence), metric (dimension/measure), and arithmetic (other fields) facets of Liouville approximation."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/LiouvilleTheoremOQ03.lean",
+    "sorries": 0,
+    "axiomCount": 1,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "lineCount": 210
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/liouville-theorem-oq-03.json
+++ b/src/data/research/problems/liouville-theorem-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "liouville-theorem-oq-03",
   "title": "Hausdorff Dimension of Sets with Given Irrationality Measure",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -13,15 +13,15 @@
   "knownResults": {
     "proven": [],
     "open": [],
-    "goal": ""
+    "goal": "Compute dimH of sets with given irrationality measure (Jarník–Besicovitch 2/τ) and deduce dimH{Liouville}=0."
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-22T12:51:58.295Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Shipped Jarník–Besicovitch dimension formalization (axiomatized JB formula, derived Liouville dim 0).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Discharge dimH_wellApprox axiom via Borel–Cantelli (upper) + Frostman mass distribution (lower).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Formalized Jarník–Besicovitch dimH(W τ)=2/τ (τ≥2) over Mathlib LiouvilleWith + dimH; JB formula = single axiom; derived dimH{Liouville}=0 by tendsto squeeze. Structural lemmas 0-axiom (LiouvilleWith.mono, Liouville.liouvilleWith, dimH_mono). 210L, 17 thm, 2 def, 1 axiom.",
+    "builtItems": [
+      "wellApprox τ := {x | LiouvilleWith τ x} + antitonicity (LiouvilleWith.mono) and {Liouville}⊆W τ (Liouville.liouvilleWith), 0-axiom",
+      "dimH_mono transport: dimH(W τ) antitone, dimH{Liouville} ≤ dimH(W τ)",
+      "dimH_wellApprox axiom (Jarník–Besicovitch formula) + derived dimH_liouville_eq_zero via ge_of_tendsto squeeze (n→∞)"
+    ],
+    "insights": [
+      "Mathlib's LiouvilleWith τ x IS membership in the τ-well-approximable set; .mono gives set antitonicity in the exponent for free.",
+      "Liouville.liouvilleWith puts every Liouville number in every W τ, so dimension-zero is a one-parameter squeeze dimH ≤ 2/τ → 0.",
+      "Only the dimension VALUE dimH(W τ)=2/τ is missing from Mathlib (needs Borel–Cantelli covering + Frostman mass distribution); isolate as one axiom, prove the rest unconditionally.",
+      "Dimension zero sharpens the sibling's Lebesgue-measure-zero result; dimH is a finer gauge than cardinality or measure."
+    ],
+    "mathlibGaps": [
+      "No Jarník–Besicovitch / Hausdorff-measure estimates for well-approximable sets; no irrationality-measure def; no mass transference principle."
+    ],
+    "nextSteps": [
+      "Discharge dimH_wellApprox: Borel–Cantelli covering for ≤, Frostman/mass-distribution Cantor construction for ≥."
+    ]
   },
   "tags": [
     "number-theory",


### PR DESCRIPTION
## Summary

Formalizes the **Jarník–Besicovitch theorem** for open question
`liouville-theorem-oq-03` ("Hausdorff dimension of sets with given irrationality
measure"): for the τ-well-approximable sets `W τ = {x | LiouvilleWith τ x}`,

  `dimH (W τ) = 2 / τ`   (τ ≥ 2),

and derives the classical corollary that the **Liouville numbers have Hausdorff
dimension 0** (uncountable, comeagre — yet dimensionally negligible).

## Honesty / axiom

Mathlib has the `LiouvilleWith` predicate and the full `dimH` API, but **not** the
Jarník–Besicovitch dimension formula (its upper bound needs a Borel–Cantelli
covering estimate, its lower bound a mass-distribution / Frostman construction).
That single formula is recorded as the lone `axiom dimH_wellApprox`. Everything
else is machine-checked, and `#print axioms` shows the structural lemmas depend on
no axioms beyond the standard foundational trio.

Status: **axiomatized**, badge `axiom`, axiomCount **1**.

## Contents (`Proofs/LiouvilleTheoremOQ03.lean`, 210 L, 17 thm, 2 def, 1 axiom)

**Verified 0-axiom core** (genuine Mathlib derivations):
- `wellApprox_antitone` — `σ ≤ τ → W τ ⊆ W σ` (from `LiouvilleWith.mono`)
- `liouville_subset_wellApprox` — `{Liouville} ⊆ W τ` for all τ (from `Liouville.liouvilleWith`)
- `dimH_wellApprox_antitone`, `dimH_liouville_le_wellApprox` (from `dimH_mono`)
- `jbDim τ = 2/τ` properties: `jbDim_two` (=1), `jbDim_le_one`/`jbDim_lt_one`, antitone

**Axiom + derived results**:
- `axiom dimH_wellApprox` — the Jarník–Besicovitch formula
- `dimH_wellApprox_two` — `dimH (W 2) = 1`
- `dimH_liouville_le` — `dimH {Liouville} ≤ 2/τ`
- **`dimH_liouville_eq_zero`** — squeezed from `dimH ≤ 2/n` as `n → ∞`

## Verification

- Self-contained on `Mathlib` (uses `LiouvilleWith`, `dimH`); built host-side with
  `lake env lean` (docker down): exit 0, no errors/sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)