### PR TITLE
research(cantors-theorem-oq-03-oq-02): higher-order diagonal needs domain-inhabitation [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -572,6 +572,7 @@ import Proofs.CantorsTheoremOQ01OQ03
 import Proofs.CantorsTheoremOQ01OQ03OQ04
 import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
+import Proofs.CantorsTheoremOQ03OQ02
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CarnotTheoremOQ01OQ01

--- a/proofs/Proofs/CantorsTheoremOQ03OQ02.lean
+++ b/proofs/Proofs/CantorsTheoremOQ03OQ02.lean
@@ -1,0 +1,195 @@
+import Mathlib
+
+/-
+# OQ-03 → OQ-02: The Diagonal Argument for Higher-Order Types
+
+Source: Lawvere (1969); follow-up to `CantorsTheoremOQ03` (verified, 0 axioms).
+
+## The Open Question
+
+The parent entry (OQ-03) organizes the diagonal argument into a hierarchy and
+proves the **Level-1 Lawvere theorem**:
+
+  > If `g : β → β` has no fixed point, then no `f : α → (α → β)` is surjective.
+
+Its open question OQ-02 asks:
+
+  > *Can the fixed-point-free characterization be extended to higher-order types
+  >  — does the diagonal argument for `(α → β) → γ` require a different structural
+  >  condition than `g : β → β` with no fixed point?*
+
+## The Answer
+
+**YES — it requires a strictly augmented condition.** When the codomain is the
+*function* type `T = (α → β) → γ`, the relevant fixed-point-free endomorphism of
+`T` is obtained by **post-composition** with a map on the *output* type `γ`:
+
+  `postcomp g : T → T,   postcomp g h = g ∘ h`.
+
+The exact characterization (Part II) is:
+
+  `postcomp g` is fixed-point-free  ⟺  `Nonempty (α → β)`  ∧  `g` is fixed-point-free.
+
+So compared with the base-type Level-1 condition "`g : γ → γ` has no fixed point",
+the higher-order diagonal needs **one extra hypothesis**: the function *domain*
+`α → β` must be inhabited. This inhabitation requirement is genuinely necessary —
+Part IV exhibits the failure: when `α → β` is empty, `T` is a singleton, every
+endomorphism of `T` has a fixed point, and the diagonal collapses.
+
+Feeding this characterization into the Level-1 engine yields a **higher-order
+Cantor / Lawvere theorem** (Part III): for an inhabited function domain and a
+fixed-point-free `g : γ → γ`, no `f : ι → (ι → ((α → β) → γ))` is surjective.
+
+## Results
+
+Part I:   The Lawvere diagonal engine (self-contained, 1 theorem)
+Part II:  Post-composition fixed-point-free characterization (core, 3 theorems)
+Part III: Higher-order Cantor and Lawvere theorems (2 theorems)
+Part IV:  Necessity of the inhabitation hypothesis (2 theorems)
+Part V:   Concrete higher-order non-surjectivity instances (2 theorems)
+
+Axioms: 0
+Sorries: 0
+-/
+
+set_option linter.unusedVariables false
+
+namespace CantorsTheoremOQ03OQ02
+
+open Function
+
+-- ============================================================
+-- PART I: The Lawvere Diagonal Engine
+-- ============================================================
+
+/-- **Lawvere's fixed-point theorem (contrapositive form).** A fixed-point-free
+endomorphism `g : β → β` obstructs surjectivity of any `f : α → (α → β)`.
+
+This is the Level-1 engine; the higher-order results below feed specially
+constructed fixed-point-free maps into it. -/
+theorem lawvere {α β : Type*} (g : β → β) (hg : ∀ b, g b ≠ b)
+    (f : α → α → β) : ¬ Surjective f := by
+  intro hf
+  obtain ⟨a, ha⟩ := hf (fun x => g (f x x))
+  -- `ha : f a = fun x => g (f x x)`, so `f a a = g (f a a)`: a fixed point of `g`.
+  exact hg (f a a) (congrFun ha a).symm
+
+-- ============================================================
+-- PART II: Post-Composition Fixed-Point-Free Characterization
+-- ============================================================
+
+/-- Post-composition with `g : γ → γ` as an endomorphism of the function type
+`X → γ`. This is the canonical lift of a map on the output type to a map on the
+higher-order type. -/
+def postcomp {X γ : Type*} (g : γ → γ) : (X → γ) → (X → γ) := fun h => g ∘ h
+
+/-- **Core characterization.** Post-composition `postcomp g` on `X → γ` is
+fixed-point-free **iff** the domain `X` is inhabited *and* `g` is fixed-point-free
+on the output type `γ`.
+
+The forward direction splits the single Level-1 condition into two: the
+inhabitation of `X` is the genuinely new ingredient absent at the base level. -/
+theorem postcomp_fixedPointFree_iff {X γ : Type*} (g : γ → γ) :
+    (∀ h : X → γ, postcomp g h ≠ h) ↔ (Nonempty X ∧ ∀ c : γ, g c ≠ c) := by
+  constructor
+  · intro H
+    refine ⟨?_, ?_⟩
+    · -- If `X` were empty, the unique empty function would be a fixed point.
+      by_contra hX
+      have : IsEmpty X := not_nonempty_iff.mp hX
+      exact H (fun x => isEmptyElim x) (funext fun x => isEmptyElim x)
+    · -- A fixed point `c` of `g` makes the constant function `fun _ => c` fixed.
+      intro c hc
+      exact H (fun _ => c) (funext fun _ => hc)
+  · rintro ⟨⟨x₀⟩, hg⟩ h hcon
+    -- `hcon : g ∘ h = h`, evaluate at `x₀` to get a fixed point of `g`.
+    exact hg (h x₀) (congrFun hcon x₀)
+
+/-- The constructive payload of the backward direction, stated directly: from a
+fixed-point-free `g` and an inhabited domain, `postcomp g` is fixed-point-free. -/
+theorem postcomp_fixedPointFree {X γ : Type*} [Nonempty X] (g : γ → γ)
+    (hg : ∀ c, g c ≠ c) : ∀ h : X → γ, postcomp g h ≠ h :=
+  (postcomp_fixedPointFree_iff g).mpr ⟨‹Nonempty X›, hg⟩
+
+/-- On an **empty** domain, post-composition can never be fixed-point-free: the
+unique empty function is always a fixed point, regardless of `g`. This is the
+structural obstruction that distinguishes higher-order from base-level diagonals. -/
+theorem postcomp_has_fixedPoint_of_isEmpty {X γ : Type*} [IsEmpty X] (g : γ → γ) :
+    ∃ h : X → γ, postcomp g h = h :=
+  ⟨fun x => isEmptyElim x, funext fun x => isEmptyElim x⟩
+
+-- ============================================================
+-- PART III: Higher-Order Cantor / Lawvere
+-- ============================================================
+
+/-- **Higher-order Cantor theorem.** With an inhabited function domain `α → β`
+and a fixed-point-free `g : γ → γ`, no `f : ι → (ι → ((α → β) → γ))` is
+surjective. The diagonal now dodges in the *output* type `γ`, lifted to the
+function type by `postcomp`. -/
+theorem higher_order_cantor {ι α β γ : Type*}
+    (hα : Nonempty (α → β)) (g : γ → γ) (hg : ∀ c, g c ≠ c)
+    (f : ι → ι → ((α → β) → γ)) : ¬ Surjective f :=
+  lawvere (postcomp g) ((postcomp_fixedPointFree_iff g).mpr ⟨hα, hg⟩) f
+
+/-- **Higher-order Lawvere theorem (positive form).** Dually, a surjection
+`f : ι → (ι → ((α → β) → γ))` forces **every** `g : γ → γ` to have a fixed point
+(given the function domain is inhabited). -/
+theorem higher_order_lawvere {ι α β γ : Type*}
+    (hα : Nonempty (α → β)) (f : ι → ι → ((α → β) → γ))
+    (hf : Surjective f) (g : γ → γ) : ∃ c, g c = c := by
+  by_contra hcon
+  push_neg at hcon
+  exact higher_order_cantor hα g hcon f hf
+
+-- ============================================================
+-- PART IV: Necessity of the Inhabitation Hypothesis
+-- ============================================================
+
+/-- When the function domain `α → β` is **empty**, the higher-order codomain
+`(α → β) → γ` is a subsingleton (all elements are equal). -/
+theorem subsingleton_codomain_of_isEmpty {α β γ : Type*} [IsEmpty (α → β)] :
+    Subsingleton ((α → β) → γ) :=
+  ⟨fun h₁ h₂ => funext fun x => isEmptyElim x⟩
+
+/-- **Necessity.** If the function domain `α → β` is empty (and the index type
+`ι` is inhabited), a surjection `f : ι → (ι → ((α → β) → γ))` *does* exist — so
+the higher-order diagonal genuinely fails without the inhabitation hypothesis.
+This is the precise sense in which the structural condition must be augmented. -/
+theorem surjection_exists_of_isEmpty_domain {ι α β γ : Type*}
+    [IsEmpty (α → β)] [Nonempty ι] :
+    ∃ f : ι → ι → ((α → β) → γ), Surjective f := by
+  haveI : Subsingleton ((α → β) → γ) := subsingleton_codomain_of_isEmpty
+  -- `ι → ((α→β)→γ)` is a subsingleton; pick any point as a constant surjection.
+  obtain ⟨i₀⟩ := ‹Nonempty ι›
+  refine ⟨fun _ => fun _ => isEmptyElim, fun y => ⟨i₀, ?_⟩⟩
+  exact Subsingleton.elim _ _
+
+-- ============================================================
+-- PART V: Concrete Higher-Order Instances
+-- ============================================================
+
+/-- Higher-order Cantor over `(ℕ → Bool) → Bool`: Boolean negation is the
+fixed-point-free output map, and `ℕ → Bool` is inhabited (constants), so no
+`f : ι → (ι → ((ℕ → Bool) → Bool))` is surjective. -/
+theorem cantor_higherOrder_bool {ι : Type*}
+    (f : ι → ι → ((ℕ → Bool) → Bool)) : ¬ Surjective f :=
+  higher_order_cantor ⟨fun _ => true⟩ (fun b => !b) (fun b => by cases b <;> decide) f
+
+/-- Higher-order Cantor over `(ℕ → Prop) → Prop`: propositional negation is the
+fixed-point-free output map. This is a "second-order Cantor" — the powerset of a
+powerset-valued function space resists enumeration. -/
+theorem cantor_higherOrder_prop {ι : Type*}
+    (f : ι → ι → ((ℕ → Prop) → Prop)) : ¬ Surjective f :=
+  higher_order_cantor ⟨fun _ => True⟩ Not
+    (fun p hp => by
+      have h1 : ¬p → p := Eq.mp hp
+      have h2 : p → ¬p := Eq.mp hp.symm
+      have hnp : ¬p := fun h => h2 h h
+      exact hnp (h1 hnp)) f
+
+-- Axiom audit: confirm the headline higher-order theorems use no extra axioms.
+#print axioms higher_order_cantor
+#print axioms higher_order_lawvere
+#print axioms postcomp_fixedPointFree_iff
+
+end CantorsTheoremOQ03OQ02

--- a/src/data/proofs/cantors-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-03-oq-02/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-lawvere-engine",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 70,
+      "endLine": 81
+    },
+    "type": "technique",
+    "title": "The Lawvere Diagonal Engine",
+    "content": "The self-contained Level-1 engine: a fixed-point-free `g : β → β` obstructs surjectivity of any `f : α → (α → β)`. If `f` were surjective it would hit the diagonal `fun x => g (f x x)`; evaluating the witnessing equality at its own index gives `f a a = g (f a a)`, a fixed point of `g`, contradiction. Every higher-order result in the file ultimately discharges through this one theorem by supplying a specially constructed fixed-point-free map.",
+    "mathContext": "Surjectivity of $f$ applied to the diagonal $d(x) = g(f(x)(x))$ yields $a$ with $f(a)(a) = g(f(a)(a))$, contradicting $\\forall b,\\ g(b) \\neq b$.",
+    "significance": "key",
+    "prerequisites": [
+      "Function.Surjective",
+      "congrFun"
+    ],
+    "relatedConcepts": [
+      "Lawvere fixed-point theorem",
+      "diagonal argument",
+      "self-application"
+    ]
+  },
+  {
+    "id": "ann-postcomp-def",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 84,
+      "endLine": 85
+    },
+    "type": "definition",
+    "title": "Post-Composition as a Higher-Order Lift",
+    "content": "`postcomp g h = g ∘ h` is the canonical way to turn an endomorphism of the output type `γ` into an endomorphism of the function type `X → γ`. This is the categorical mechanism by which Lawvere's fixed-point property propagates through exponential objects: rather than seeking a fixed-point-free map on the whole higher-order codomain, one dodges in the output and lifts.",
+    "mathContext": "$\\text{postcomp}\\,g : (X \\to \\gamma) \\to (X \\to \\gamma)$, $\\ h \\mapsto g \\circ h$.",
+    "significance": "key",
+    "prerequisites": [
+      "function composition"
+    ],
+    "relatedConcepts": [
+      "cartesian closed categories",
+      "exponential objects",
+      "post-composition"
+    ]
+  },
+  {
+    "id": "ann-postcomp-iff",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 127
+    },
+    "type": "theorem",
+    "title": "Core Characterization: When Post-Composition is Fixed-Point-Free",
+    "content": "The central result and the precise answer to the open question. `postcomp g` is fixed-point-free **iff** `Nonempty X ∧ (∀ c, g c ≠ c)`. The forward direction splits the single base-level condition into two parts: if `X` were empty the unique empty function would be a fixed point (forcing `Nonempty X`), and any fixed point `c` of `g` yields the constant fixed point `fun _ => c` (forcing `g` fixed-point-free). The backward direction evaluates `g ∘ h = h` at a witness point of `X`. The inhabitation clause is the genuinely new structural condition absent at the base level.",
+    "mathContext": "$(\\forall h : X \\to \\gamma,\\ g \\circ h \\neq h) \\iff \\text{Nonempty}\\,X \\wedge (\\forall c,\\ g(c) \\neq c)$.",
+    "significance": "critical",
+    "prerequisites": [
+      "not_nonempty_iff",
+      "isEmptyElim",
+      "funext",
+      "congrFun"
+    ],
+    "relatedConcepts": [
+      "fixed-point-free endomorphisms",
+      "inhabited types",
+      "empty function"
+    ]
+  },
+  {
+    "id": "ann-higher-order-cantor",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 129,
+      "endLine": 148
+    },
+    "type": "theorem",
+    "title": "Higher-Order Cantor and Lawvere",
+    "content": "Specializing the domain to `X := (α → β)` and feeding the lifted fixed-point-free map into the engine gives the higher-order Cantor theorem: no `f : ι → (ι → ((α → β) → γ))` is surjective when `(α → β)` is inhabited and `g : γ → γ` is fixed-point-free. The positive dual `higher_order_lawvere` reads the same iff in the other direction: a surjection forces every `g : γ → γ` to have a fixed point.",
+    "mathContext": "Inhabited $(\\alpha \\to \\beta)$ and fixed-point-free $g$ ⟹ no surjection $\\iota \\to (\\iota \\to ((\\alpha \\to \\beta) \\to \\gamma))$.",
+    "significance": "key",
+    "prerequisites": [
+      "lawvere",
+      "postcomp_fixedPointFree_iff"
+    ],
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "non-enumerability",
+      "higher-order types"
+    ]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 150,
+      "endLine": 167
+    },
+    "type": "insight",
+    "title": "Necessity of the Inhabitation Hypothesis",
+    "content": "The new hypothesis is not a technicality. When `(α → β)` is empty, every two elements of `(α → β) → γ` agree (the codomain is a subsingleton), so an explicit constant `f` is surjective onto `ι → ((α → β) → γ)` whenever `ι` is inhabited. Thus the higher-order diagonal provably fails without inhabitation — pinning down exactly why the structural condition must be augmented.",
+    "mathContext": "$\\text{IsEmpty}(\\alpha \\to \\beta) \\Rightarrow (\\alpha \\to \\beta) \\to \\gamma$ is a subsingleton, and a constant map is surjective onto $\\iota \\to (\\text{singleton})$.",
+    "significance": "key",
+    "prerequisites": [
+      "Subsingleton",
+      "isEmptyElim",
+      "Subsingleton.elim"
+    ],
+    "relatedConcepts": [
+      "empty types",
+      "subsingletons",
+      "degenerate cases"
+    ]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "cantors-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 174,
+      "endLine": 195
+    },
+    "type": "example",
+    "title": "Second-Order Cantor Instances",
+    "content": "Concrete witnesses that the theorem is non-vacuous: over `(ℕ → Bool) → Bool` Boolean negation `!` is the fixed-point-free output map, and over `(ℕ → Prop) → Prop` logical negation `¬` is. In both cases the function domain is inhabited by constant functions, so no `f : ι → (ι → (codomain))` is surjective — a genuine 'second-order' non-enumerability statement about a function space of function spaces.",
+    "mathContext": "$g = (\\lnot\\cdot)$ on Bool and $g = \\lnot$ on Prop are fixed-point-free; $\\mathbb{N} \\to \\text{Bool}$ and $\\mathbb{N} \\to \\text{Prop}$ are inhabited by constants.",
+    "significance": "supporting",
+    "prerequisites": [
+      "higher_order_cantor",
+      "Bool negation",
+      "propositional negation"
+    ],
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "powerset",
+      "self-reference"
+    ]
+  }
+]

--- a/src/data/proofs/cantors-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03-oq-02/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "cantors-theorem-oq-03-oq-02",
+  "title": "The Diagonal Argument for Higher-Order Types",
+  "slug": "cantors-theorem-oq-03-oq-02",
+  "description": "Answers OQ-03's open question OQ-02: extending the fixed-point-free diagonal to a higher-order codomain (α → β) → γ requires a strictly augmented structural condition. The relevant fixed-point-free endomorphism is post-composition postcomp g = (g ∘ ·), and the core theorem characterizes exactly when it is fixed-point-free: iff the function domain (α → β) is inhabited AND g is fixed-point-free on the output type γ. The inhabitation hypothesis is genuinely new (absent at the base level) and necessary — when (α → β) is empty the codomain collapses to a singleton and the diagonal fails. Feeding the characterization into Lawvere's engine yields a higher-order Cantor/Lawvere theorem.",
+  "meta": {
+    "author": "Lawvere (1969); formalized here as a follow-up to cantors-theorem-oq-03",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lawvere%27s_fixed-point_theorem",
+    "date": "1969",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorsTheoremOQ03OQ02.lean",
+    "tags": [
+      "set-theory",
+      "diagonal-argument",
+      "fixed-point",
+      "lawvere-theorem",
+      "higher-order",
+      "non-enumerability",
+      "cartesian-closed",
+      "generalization",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Function.Surjective",
+        "description": "Surjective functions: ∀ b, ∃ a, f a = b",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "congrFun",
+        "description": "Function extensionality: h : f = g → f a = g a",
+        "module": "Lean core"
+      },
+      {
+        "theorem": "isEmptyElim",
+        "description": "Elimination from an empty type: produces any goal from a term of an IsEmpty type",
+        "module": "Mathlib.Logic.IsEmpty"
+      },
+      {
+        "theorem": "not_nonempty_iff",
+        "description": "¬Nonempty α ↔ IsEmpty α, bridging non-inhabitation and emptiness",
+        "module": "Mathlib.Logic.IsEmpty"
+      }
+    ],
+    "originalContributions": [
+      "postcomp: post-composition endomorphism (g ∘ ·) on a function type X → γ as the canonical lift of an output-type map to a higher-order type",
+      "postcomp_fixedPointFree_iff: CORE characterization — postcomp g is fixed-point-free iff Nonempty X ∧ (g fixed-point-free); splits the single base-level condition into output-freeness plus domain inhabitation",
+      "postcomp_has_fixedPoint_of_isEmpty: on an empty domain post-composition always has a fixed point (the empty function), the obstruction distinguishing higher-order from base-level diagonals",
+      "higher_order_cantor: no f : ι → (ι → ((α → β) → γ)) is surjective when (α → β) is inhabited and g : γ → γ is fixed-point-free",
+      "higher_order_lawvere: positive form — a surjection forces every g : γ → γ to have a fixed point",
+      "subsingleton_codomain_of_isEmpty / surjection_exists_of_isEmpty_domain: necessity of the inhabitation hypothesis — an empty domain makes the codomain a singleton and a surjection exists, so the diagonal genuinely fails",
+      "cantor_higherOrder_bool / cantor_higherOrder_prop: concrete second-order instances over (ℕ → Bool) → Bool and (ℕ → Prop) → Prop"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 195,
+    "prerequisites": [
+      "Lawvere's fixed-point theorem (cantors-theorem-oq-03, Level 1)",
+      "Function types as exponential objects; post-composition",
+      "Empty / inhabited types (IsEmpty, Nonempty, Subsingleton)"
+    ],
+    "relatedProblems": [
+      {
+        "id": "cantors-theorem-oq-03",
+        "relationship": "Parent — proves the Level-1/Level-3 diagonal hierarchy and poses this open question"
+      },
+      {
+        "id": "cantors-theorem-oq-02",
+        "relationship": "Grandparent — formalizes Lawvere's FPT (the base-level condition being generalized)"
+      }
+    ],
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Lawvere's 1969 fixed-point theorem unifies the diagonal arguments of Cantor, Russell, and Gödel: in a cartesian closed category, a point-surjective morphism A → Y^A forces every endomorphism of Y to have a fixed point. The base-level condition for non-surjectivity is therefore 'Y admits a fixed-point-free endomorphism'. The parent entry (OQ-03) formalizes this Level-1 statement together with the König/coordinate hierarchy, and asks what happens when the codomain Y is itself a function type (α → β) → γ.",
+    "problemStatement": "**Open Question (cantors-theorem-oq-03, OQ-02)**: Can the fixed-point-free characterization be extended to higher-order types — does the diagonal argument for (α → β) → γ require a different structural condition than g : β → β with no fixed point?\n\n**Answer**: YES, a strictly augmented condition. For the higher-order codomain T = (α → β) → γ, the natural fixed-point-free endomorphism is post-composition postcomp g = (g ∘ ·). It is fixed-point-free precisely when the *function domain* (α → β) is inhabited AND g is fixed-point-free on the *output* type γ. The inhabitation requirement is the genuinely new ingredient — at the base level (codomain a plain type) it is vacuous, but here it is necessary: an empty domain collapses T to a singleton and the diagonal fails.",
+    "proofStrategy": "**Part I**: A self-contained statement of Lawvere's Level-1 engine: a fixed-point-free g : β → β obstructs surjectivity of f : α → (α → β).\n\n**Part II (core)**: Define postcomp g on X → γ and prove postcomp_fixedPointFree_iff — fixed-point-freeness ⟺ Nonempty X ∧ (g fixed-point-free). Forward: an empty domain yields the empty function as a fixed point, and a fixed point of g yields a constant fixed point; backward: evaluate g ∘ h = h at any point of X.\n\n**Part III**: Specialize X := (α → β) and feed the lifted fixed-point-free map into the Level-1 engine to obtain higher_order_cantor and its positive dual higher_order_lawvere.\n\n**Part IV**: Show the inhabitation hypothesis is necessary — when (α → β) is empty the codomain is a subsingleton and an explicit constant surjection exists.\n\n**Part V**: Instantiate over (ℕ → Bool) → Bool (negation) and (ℕ → Prop) → Prop (logical negation).",
+    "keyInsights": [
+      "The higher-order diagonal does NOT need a fixed-point-free map on the whole codomain (α → β) → γ; it suffices to dodge in the OUTPUT type γ and lift by post-composition",
+      "The base-level condition splits into TWO at higher order: (i) g fixed-point-free on γ, plus (ii) the function domain (α → β) inhabited — and (ii) is the genuinely new requirement",
+      "The inhabitation hypothesis is not a technicality: when (α → β) is empty, (α → β) → γ is a singleton, every endomorphism has a fixed point, and a surjection ι → (ι → singleton) exists, so the diagonal provably fails",
+      "postcomp_fixedPointFree_iff is an exact iff, so it simultaneously gives the positive Lawvere direction (surjection ⟹ fixed point) and pins down precisely when the diagonal succeeds"
+    ],
+    "prerequisites": [
+      "Lawvere's fixed-point theorem and the diagonal hierarchy (cantors-theorem-oq-03)",
+      "Cartesian closed structure: function types, post-composition",
+      "Inhabited vs. empty types (Nonempty, IsEmpty, Subsingleton)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction: The Higher-Order Question",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "States OQ-02 and the answer: the higher-order codomain (α → β) → γ requires the augmented condition 'g fixed-point-free on output + domain inhabited', realized via post-composition.",
+      "mathContext": "For T = (α → β) → γ, the relevant endomorphism is $\\text{postcomp}\\,g = (g \\circ -)$, fixed-point-free iff the domain is inhabited and $g$ is fixed-point-free."
+    },
+    {
+      "id": "lawvere-engine",
+      "title": "Part I: The Lawvere Diagonal Engine",
+      "startLine": 64,
+      "endLine": 85,
+      "summary": "Self-contained Level-1 Lawvere theorem: a fixed-point-free g : β → β obstructs surjectivity of f : α → (α → β).",
+      "mathContext": "If $g(b) \\neq b$ for all $b$ and $f$ were surjective, the diagonal $d(x) = g(f(x)(x))$ would force $f(a)(a) = g(f(a)(a))$, a fixed point of $g$."
+    },
+    {
+      "id": "postcomp-characterization",
+      "title": "Part II: Post-Composition Fixed-Point-Free Characterization",
+      "startLine": 86,
+      "endLine": 134,
+      "summary": "Core result: postcomp g on X → γ is fixed-point-free iff Nonempty X ∧ (g fixed-point-free). Plus the empty-domain obstruction.",
+      "mathContext": "$\\forall h,\\ g \\circ h \\neq h \\iff \\text{Nonempty}\\,X \\wedge \\forall c,\\ g(c) \\neq c$. Empty $X$ ⟹ the empty function is a fixed point."
+    },
+    {
+      "id": "higher-order-cantor",
+      "title": "Part III: Higher-Order Cantor / Lawvere",
+      "startLine": 135,
+      "endLine": 159,
+      "summary": "Feeding the characterization into the engine: no surjection ι → (ι → ((α → β) → γ)) when the domain is inhabited and g is fixed-point-free; dual positive form.",
+      "mathContext": "Inhabited $(\\alpha \\to \\beta)$ and fixed-point-free $g : \\gamma \\to \\gamma$ ⟹ no $f : \\iota \\to (\\iota \\to ((\\alpha \\to \\beta) \\to \\gamma))$ is surjective."
+    },
+    {
+      "id": "necessity",
+      "title": "Part IV: Necessity of the Inhabitation Hypothesis",
+      "startLine": 160,
+      "endLine": 180,
+      "summary": "When (α → β) is empty the codomain is a subsingleton and an explicit surjection exists — the diagonal fails, so inhabitation is essential.",
+      "mathContext": "$\\text{IsEmpty}(\\alpha \\to \\beta) \\Rightarrow (\\alpha \\to \\beta) \\to \\gamma$ is a subsingleton, and a constant $f$ is surjective onto $\\iota \\to (\\text{singleton})$."
+    },
+    {
+      "id": "instances",
+      "title": "Part V: Concrete Higher-Order Instances",
+      "startLine": 181,
+      "endLine": 195,
+      "summary": "Second-order Cantor over (ℕ → Bool) → Bool (negation) and (ℕ → Prop) → Prop (logical negation).",
+      "mathContext": "Boolean and propositional negation are the fixed-point-free output maps; $\\mathbb{N} \\to \\text{Bool}$ and $\\mathbb{N} \\to \\text{Prop}$ are inhabited by constants."
+    }
+  ],
+  "conclusion": {
+    "summary": "Extending Lawvere's diagonal from a base-type codomain to a higher-order codomain (α → β) → γ requires an augmented structural condition. The fixed-point-free endomorphism is post-composition postcomp g = (g ∘ ·), and it is fixed-point-free exactly when the function domain is inhabited AND g is fixed-point-free on the output type. This yields a higher-order Cantor/Lawvere theorem, and the new inhabitation hypothesis is proved necessary.",
+    "significance": "Gives a precise, fully verified (0 axioms, 0 sorries) answer to the parent's open question: the higher-order diagonal does need a different condition, and the difference is exactly one extra clause — inhabitation of the function domain — which is vacuous at the base level but essential here.",
+    "implications": "The post-composition lift identifies the categorical mechanism by which Lawvere's theorem propagates through exponential objects: dodging in the output object and lifting by (g ∘ -). The exact iff characterization isolates inhabitation of the function domain as the sole new obstruction, suggesting that in a cartesian closed category the fixed-point property transports along Y ↦ X ⇒ Y precisely when X has a global point.",
+    "openQuestions": [
+      "Does the post-composition lift compose across towers ((α → β) → γ) → δ, and does each additional arrow add exactly one inhabitation clause?",
+      "Is there a fixed-point-free endomorphism of (α → β) → γ that is NOT of post-composition form, and if so does it require a strictly weaker condition than 'g fixed-point-free on γ'?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantors-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Answers OQ-03's open question OQ-02 on extending the fixed-point-free characterization to higher-order types"
+    },
+    {
+      "targetId": "cantors-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Lifts Lawvere's Level-1 fixed-point theorem (the base-level condition) to a function-type codomain"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "generalizes",
+      "description": "Cantor's |A| < |P(A)| is the base case; here the codomain is itself a function space"
+    }
+  ],
+  "references": [
+    {
+      "text": "Lawvere, F.W. (1969). Diagonal Arguments and Cartesian Closed Categories. Lecture Notes in Mathematics 92, 134-145.",
+      "url": "https://en.wikipedia.org/wiki/Lawvere%27s_fixed-point_theorem"
+    },
+    {
+      "text": "Yanofsky, N.S. (2003). A Universal Approach to Self-Referential Paradoxes, Incompleteness and Fixed Points.",
+      "url": "https://arxiv.org/abs/math/0305282"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 195,
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "lemmaCount": 0,
+    "definitionCount": 1,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Function"
+    ],
+    "path": "Proofs/CantorsTheoremOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question **OQ-02** posed by the verified/0-axiom parent `cantors-theorem-oq-03` ("The Diagonal Argument in Cardinal Arithmetic and Beyond"):

> *Can the fixed-point-free characterization be extended to higher-order types — does the diagonal argument for `(α → β) → γ` require a different structural condition than `g : β → β` with no fixed point?*

**Answer: YES — a strictly augmented condition.** For the higher-order codomain `T = (α → β) → γ`, the natural fixed-point-free endomorphism is **post-composition** `postcomp g = (g ∘ ·)`, lifting a dodge on the *output* type `γ`. The core theorem characterizes exactly when it works:

```
postcomp_fixedPointFree_iff :
  (∀ h : X → γ, postcomp g h ≠ h) ↔ (Nonempty X ∧ ∀ c, g c ≠ c)
```

So compared with the base-level condition "`g : γ → γ` has no fixed point", the higher-order diagonal needs **one extra clause**: the function *domain* `α → β` must be inhabited. That clause is vacuous at the base level but here it is **necessary** — when `α → β` is empty, `T` collapses to a singleton, every endomorphism has a fixed point, and an explicit surjection exists (`surjection_exists_of_isEmpty_domain`).

Feeding the characterization into Lawvere's Level-1 engine yields `higher_order_cantor` (no surjection `ι → (ι → ((α → β) → γ))`) and its positive dual `higher_order_lawvere`, with concrete second-order instances over `(ℕ → Bool) → Bool` and `(ℕ → Prop) → Prop`.

## Verification

- **10 theorems, 1 definition, 195 lines**
- **0 sorries, 0 axioms** (`#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`)
- Builds against Mathlib v4.26.0 (`lake env lean Proofs/CantorsTheoremOQ03OQ02.lean`, exit 0)
- Self-contained: imports only `Mathlib`

## Files

- `proofs/Proofs/CantorsTheoremOQ03OQ02.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/cantors-theorem-oq-03-oq-02/{meta,annotations}.json` (gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)