### PR TITLE
audit(derangements-oq-03-oq-03-oq-01): add nested meta.sorries to clear phantom mismatch

### DIFF
--- a/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-03-oq-01/meta.json
@@ -83,6 +83,8 @@
     "author": "Burnside / Cauchy–Frobenius count, formalized in Lean 4",
     "badge": "mathlib",
     "status": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
     "originalContributions": [
       "Identification of the parent's fixed-point set (Function.fixedPoints σ, counted by Set.ncard in the trace formula) with the group-action fixed set MulAction.fixedBy (Fin n) σ counted by Fintype.card",
       "Orbit count = 1: the symmetric-group action on Fin n is transitive for n ≥ 1, so its orbit quotient is a singleton (card_orbits_eq_one)",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `derangements-oq-03-oq-03-oq-01` (Expected Number of Fixed Points of a Random Permutation is 1)
**Result**: Entry is **honest**; fixing a data-shape false positive.

## Finding

`find-targets.ts` flagged this entry as `sorry mismatch: claims -1, actual 0` on every run. Root cause is a data-shape inconsistency, **not** a content problem:

- The script reads the claimed sorry count from the nested `meta` object (`meta.meta.sorries`, see `find-targets.ts:288,340`).
- This entry stored `sorries: 0` only at the **top level** and in `leanFile`, leaving `meta.meta.sorries` absent → defaulted to `-1` → phantom mismatch.
- All sibling entries (e.g. `amgm-inequality-oq-02-oq-01-oq-01-oq-02`, `divisibility-by-3-oq-03-oq-02-oq-01`) carry `sorries`/`axiomCount` inside the nested `meta` object.

## Verification of the entry itself (all clean)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiom decls | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| native_decide | "no native_decide" | only in docstring text (no tactic) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| lineCount | 157 | 157 | ✓ |

- Badge `mathlib` is correct: the core routes through Mathlib's Burnside lemma (`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`) and `Matrix.trace_permutation`. `originalContributions` honestly scope to the fixed-set bridge and specialization, not "we proved Burnside".
- Status `verified` is appropriate for this Tier-B entry (0 sorries, 0 axioms).
- Headline `expected_trace_eq_one` is a genuine, fully-proved statement matching the title.

## Fix

Add `"sorries": 0` and `"axiomCount": 0` to the nested `meta` object. After the change, `find-targets.ts --issues` reports 0 issues. No mathematical or narrative content changed.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)