### PR TITLE
research(bernoulli-inequality-oq-01-oq-01-oq-01-oq-01): the quintic Bernoulli endpoint a₅* ∈ (−3,−2) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -315,6 +315,8 @@ import Proofs.BaselProblemOQ15
 import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01
 import Proofs.BernoulliInequalityOQ01OQ01
+import Proofs.BernoulliInequalityOQ01OQ01OQ01
+import Proofs.BernoulliInequalityOQ01OQ01OQ01OQ01
 import Proofs.BernoulliInequalityOQ01OQ01OQ02
 import Proofs.BernoulliInequalityOQ01OQ02
 import Proofs.BernoulliInequalityOQ01OQ02OQ01

--- a/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,161 @@
+/-
+# The quintic Bernoulli endpoint: `a₅* ∈ (−3, −2)` and the monotone creep toward `−2`
+
+**Open question (bernoulli-inequality-oq-01-oq-01-oq-01).** The parent entry
+`bernoulli-inequality-oq-01-oq-01-oq-01` (`BernoulliInequalityOQ01OQ01OQ01.lean`)
+proved that `−2` is the sharp *uniform* (`n`-independent) left endpoint of the
+strict Bernoulli inequality `1 + n·a < (1 + a)ⁿ`, while for each *individual* odd
+exponent the true endpoint `aₙ*` lies strictly **below** `−2`.  It pinned the cubic
+case exactly — `cubic_iff` shows the `n = 3` endpoint is `a₃* = −3` — and left open
+the behaviour of the higher odd endpoints, observing only that the sequence
+`a₃* < a₅* < a₇* < ⋯` is expected to *creep up toward `−2`*.
+
+This file resolves the **next odd case `n = 5`** and thereby exhibits the first
+step of that creep.  The mechanism mirrors the parent's cubic factorisation: where
+`(1+a)³ − (1+3a) = a²(a + 3)` had the rational root `−3`, here
+
+  `(1+a)⁵ − (1+5a) = a² · (a³ + 5a² + 10a + 10)`
+
+and the residual cubic `g(a) = a³ + 5a² + 10a + 10` has **no rational root**.  We
+show `g` is strictly increasing (its derivative `3a² + 10a + 12` — equivalently the
+divided-difference bracket — is a positive-definite quadratic), so it has a *unique*
+real root `a₅*`, and locate it by the sign change `g(−3) = −2 < 0 < 2 = g(−2)`.
+
+## Main results
+
+* `quintic_factor` — the residual factorisation `(1+a)⁵ − (1+5a) = a²·g(a)`.
+* `residualCubic_strictMono` — `g` is strictly monotone, hence injective: the
+  endpoint is unique.
+* `quintic_iff_residual_pos` — `1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ 0 < g(a)`.
+* `quintic_endpoint` — **the headline.** There is an endpoint `a₅* ∈ (−3, −2)` with
+  `1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a`, the exact analogue of the parent's
+  `cubic_iff` with the irrational endpoint in place of `−3`.  Since `−3 < a₅* < −2`,
+  this is the first instalment of the creep `a₃* = −3 < a₅* < −2`.
+* `strict_at_neg_five_halves` / `quintic_fails_at_neg_29` / `cubic_holds_at_neg_29`
+  — concrete witnesses bracketing `a₅*`: the `n = 5` inequality holds at `−5/2` but
+  fails at `−29/10`, while the `n = 3` inequality still holds at `−29/10`.  The
+  failure of `n = 5` where `n = 3` succeeds is the creep made concrete.
+* `strict_at_neg_two_odd` — the structural reason every odd endpoint is below `−2`:
+  for *every* odd `n ≥ 2` the strict inequality already holds at `a = −2` (there
+  `(1+a)ⁿ = (−1)ⁿ = −1` beats the line `1 − 2n`), so `−2` is interior and `aₙ* < −2`
+  universally, with `−2 = sup_n aₙ*` approached from below.
+
+All results are `0`-axiom and machine-checked.
+-/
+import Mathlib
+
+namespace BernoulliInequalityOQ01OQ01OQ01OQ01
+
+open Real
+
+/-- The residual cubic `g(a) = a³ + 5a² + 10a + 10` left after dividing the
+quintic Bernoulli gap `(1+a)⁵ − (1+5a)` by the trivial double factor `a²`. -/
+def residualCubic (a : ℝ) : ℝ := a ^ 3 + 5 * a ^ 2 + 10 * a + 10
+
+/-- **Residual factorisation.** `(1 + a)⁵ − (1 + 5a) = a²·g(a)`, the quintic
+analogue of the parent's `(1 + a)³ − (1 + 3a) = a²(a + 3)`.  The double factor `a²`
+is why `a = 0` is always an equality point; the strict inequality is governed
+entirely by the sign of `g`. -/
+theorem quintic_factor (a : ℝ) :
+    (1 + a) ^ 5 - (1 + 5 * a) = a ^ 2 * residualCubic a := by
+  simp only [residualCubic]; ring
+
+/-- **The residual cubic is strictly increasing.** The divided difference
+`g(b) − g(a) = (b − a)·(a² + ab + b² + 5a + 5b + 10)` has a positive-definite
+bracket — `12·bracket = (3a + 3b + 10)² + 3(a − b)² + 20 > 0` — so `g` is strictly
+monotone.  Consequently `g` is injective and has at most one real root: the quintic
+endpoint, once located, is unique. -/
+theorem residualCubic_strictMono : StrictMono residualCubic := by
+  intro a b hab
+  have hbr : 0 < a ^ 2 + a * b + b ^ 2 + 5 * a + 5 * b + 10 := by
+    nlinarith [sq_nonneg (3 * a + 3 * b + 10), sq_nonneg (a - b)]
+  have hid : residualCubic b - residualCubic a
+      = (b - a) * (a ^ 2 + a * b + b ^ 2 + 5 * a + 5 * b + 10) := by
+    simp only [residualCubic]; ring
+  have hp := mul_pos (sub_pos.mpr hab) hbr
+  linarith [hid, hp]
+
+/-- `g` is continuous (a polynomial), needed for the intermediate value argument. -/
+theorem continuous_residualCubic : Continuous residualCubic := by
+  unfold residualCubic; fun_prop
+
+/-- **Sign-governed form of the strict inequality.** Dividing out the double factor
+`a²`, the strict quintic Bernoulli inequality reduces to the sign of the residual
+cubic: `1 + 5a < (1 + a)⁵ ↔ a ≠ 0 ∧ 0 < g(a)`. -/
+theorem quintic_iff_residual_pos (a : ℝ) :
+    1 + 5 * a < (1 + a) ^ 5 ↔ a ≠ 0 ∧ 0 < residualCubic a := by
+  have hfac : (1 + a) ^ 5 - (1 + 5 * a) = a ^ 2 * residualCubic a := quintic_factor a
+  constructor
+  · intro h
+    have hpos : 0 < a ^ 2 * residualCubic a := by linarith [hfac]
+    refine ⟨?_, ?_⟩
+    · rintro rfl; norm_num [residualCubic] at hpos
+    · by_contra hg
+      push_neg at hg
+      nlinarith [hpos, mul_nonneg (sq_nonneg a) (neg_nonneg.mpr hg)]
+  · rintro ⟨ha0, hg⟩
+    have ha2 : 0 < a ^ 2 := by positivity
+    have : 0 < a ^ 2 * residualCubic a := mul_pos ha2 hg
+    linarith [hfac]
+
+/-- **The quintic endpoint (headline).** There is a left endpoint `a₅* ∈ (−3, −2)`
+such that the strict quintic Bernoulli inequality holds **iff** `a ≠ 0` and
+`a₅* < a`:
+
+  `1 + 5a < (1 + a)⁵ ↔ a ≠ 0 ∧ a₅* < a`.
+
+This is the exact analogue of the parent's `cubic_iff` (`a₃* = −3`), now with an
+irrational endpoint.  Because `−3 < a₅* < −2`, it realises the first step of the
+predicted creep `a₃* = −3 < a₅* < −2` of the odd endpoints up toward the sharp
+uniform bound `−2`. -/
+theorem quintic_endpoint :
+    ∃ a₅ : ℝ, (-3 < a₅ ∧ a₅ < -2) ∧
+      ∀ a : ℝ, (1 + 5 * a < (1 + a) ^ 5 ↔ a ≠ 0 ∧ a₅ < a) := by
+  -- Locate the unique root of `g` in `(−3, −2)` via the intermediate value theorem.
+  have hg3 : residualCubic (-3) < 0 := by norm_num [residualCubic]
+  have hg2 : 0 < residualCubic (-2) := by norm_num [residualCubic]
+  have hmem : (0 : ℝ) ∈ Set.Ioo (residualCubic (-3)) (residualCubic (-2)) := ⟨hg3, hg2⟩
+  obtain ⟨a₅, ha₅mem, ha₅⟩ :=
+    intermediate_value_Ioo (by norm_num : (-3 : ℝ) ≤ -2)
+      continuous_residualCubic.continuousOn hmem
+  refine ⟨a₅, ⟨ha₅mem.1, ha₅mem.2⟩, ?_⟩
+  intro a
+  rw [quintic_iff_residual_pos a]
+  -- `0 < g(a) ↔ a₅* < a` because `g` is strictly monotone and `g(a₅*) = 0`.
+  have key : (0 < residualCubic a ↔ a₅ < a) := by
+    rw [← ha₅]; exact residualCubic_strictMono.lt_iff_lt
+  exact and_congr_right (fun _ => key)
+
+/-- **Concrete witness below `−2`.** The `n = 5` strict inequality holds at
+`a = −5/2 ∈ (a₅*, −2)`, since `g(−5/2) = 5/8 > 0`.  In particular `a₅* < −5/2`,
+tightening the bracket on the endpoint. -/
+theorem strict_at_neg_five_halves :
+    1 + 5 * (-5 / 2 : ℝ) < (1 + (-5 / 2)) ^ 5 := by norm_num
+
+/-- **The creep, made concrete (`n = 5` fails).** At `a = −29/10` the residual cubic
+is negative (`g(−29/10) < 0`), so the `n = 5` strict inequality **fails**:
+`a₅* > −29/10`. -/
+theorem quintic_fails_at_neg_29 :
+    ¬ (1 + 5 * (-29 / 10 : ℝ) < (1 + (-29 / 10)) ^ 5) := by norm_num
+
+/-- **The creep, made concrete (`n = 3` still holds).** At the very same point
+`a = −29/10` the *cubic* inequality holds, because `−29/10 > a₃* = −3`.  Contrasting
+with `quintic_fails_at_neg_29`, this exhibits a point where `n = 3` succeeds yet
+`n = 5` fails — the endpoint has strictly moved up from `−3`, the creep in action. -/
+theorem cubic_holds_at_neg_29 :
+    1 + 3 * (-29 / 10 : ℝ) < (1 + (-29 / 10)) ^ 3 := by norm_num
+
+/-- **Why every odd endpoint sits below `−2`.** For *every* odd `n ≥ 2` the strict
+Bernoulli inequality already holds at `a = −2`: there `(1 + a)ⁿ = (−1)ⁿ = −1`, which
+beats the line value `1 + n·(−2) = 1 − 2n ≤ −3`.  Hence `−2` is interior to the
+strict domain for each odd `n`, forcing `aₙ* < −2` universally; the endpoints
+approach the sharp uniform bound `−2` from below, never reaching it. -/
+theorem strict_at_neg_two_odd {n : ℕ} (hn : Odd n) (hn2 : 2 ≤ n) :
+    1 + (n : ℝ) * (-2) < (1 + (-2 : ℝ)) ^ n := by
+  have hpow : (1 + (-2 : ℝ)) ^ n = -1 := by
+    rw [show (1 + (-2 : ℝ)) = -1 by norm_num, hn.neg_one_pow]
+  rw [hpow]
+  have hnr : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn2
+  nlinarith [hnr]
+
+end BernoulliInequalityOQ01OQ01OQ01OQ01

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-bernOQ01010101-overview",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 49
+    },
+    "type": "context",
+    "title": "Locating the Quintic Bernoulli Endpoint",
+    "content": "The parent pinned the cubic endpoint a₃* = −3 from (1+a)³ − (1+3a) = a²(a+3) and conjectured that the per-exponent odd endpoints creep up toward the sharp uniform bound −2. This file resolves the next odd case n = 5. The same algebra gives (1+a)⁵ − (1+5a) = a²·g(a) with g(a) = a³ + 5a² + 10a + 10, but g has no rational root, so the endpoint a₅* must be located rather than computed. Showing g strictly increasing makes the endpoint unique, and a sign change pins it inside (−3, −2), confirming a₃* = −3 < a₅* < −2."
+  },
+  {
+    "id": "ann-bernOQ01010101-factor",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 66
+    },
+    "type": "insight",
+    "title": "The Residual Cubic",
+    "content": "The double factor a² (the source of the always-equality at a = 0) splits off, leaving the residual cubic g(a) = a³ + 5a² + 10a + 10 to govern the sign of the strict inequality. This mirrors the parent's a²(a+3) — but where a+3 was linear with root −3, here the residual is a genuine cubic."
+  },
+  {
+    "id": "ann-bernOQ01010101-mono",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 83
+    },
+    "type": "insight",
+    "title": "Sum-of-Squares Monotonicity",
+    "content": "The divided difference g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10) has a positive-definite bracket: 12 times it equals (3a+3b+10)² + 3(a−b)² + 20, a sum of squares plus a positive constant. So g is strictly increasing — without differentiating — which both makes the endpoint unique and yields the clean equivalence 0 < g(a) ↔ a₅* < a."
+  },
+  {
+    "id": "ann-bernOQ01010101-endpoint",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 130
+    },
+    "type": "insight",
+    "title": "IVT Pins the Irrational Endpoint",
+    "content": "Because g(−3) = −2 < 0 < 2 = g(−2), the intermediate value theorem places a root a₅* in (−3, −2); strict monotonicity makes it the only one. The result 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a is the exact analogue of the parent's cubic_iff, now with an irrational endpoint, and −3 < a₅* < −2 is the first step of the creep."
+  },
+  {
+    "id": "ann-bernOQ01010101-witness",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 132,
+      "endLine": 151
+    },
+    "type": "insight",
+    "title": "The Creep Made Concrete",
+    "content": "At a = −29/10 the cubic inequality (n = 3) still holds — since −29/10 > a₃* = −3 — but the quintic inequality (n = 5) fails, because a₅* > −29/10. A single rational point thus witnesses that the endpoint has strictly risen from −3 to a₅*. The point −5/2 lies on the other side (n = 5 holds there), bracketing a₅* ∈ (−29/10, −5/2)."
+  },
+  {
+    "id": "ann-bernOQ01010101-belowneg2",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 153,
+      "endLine": 160
+    },
+    "type": "insight",
+    "title": "Why the Creep Stays Below −2",
+    "content": "For every odd n the power (1 + (−2))ⁿ = (−1)ⁿ = −1 already beats the line value 1 − 2n once n ≥ 2, so the strict inequality holds at a = −2 for all odd n. Hence −2 is interior to the strict domain of each odd exponent and aₙ* < −2 universally: the endpoints rise toward −2 = supₙ aₙ* but never reach it."
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Quintic Bernoulli Endpoint a₅* ∈ (−3, −2)",
+  "slug": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+  "description": "The parent entry proved that −2 is the sharp uniform left endpoint of the strict Bernoulli inequality 1 + n·a < (1 + a)ⁿ while each individual odd exponent has a true endpoint aₙ* strictly below −2, pinning the cubic case exactly (a₃* = −3 via (1+a)³ − (1+3a) = a²(a+3)) and leaving the higher odd endpoints open, conjecturing the creep a₃* < a₅* < ⋯ ↑ −2. This entry resolves the next odd case n = 5. The same mechanism gives (1+a)⁵ − (1+5a) = a²·g(a) with residual cubic g(a) = a³ + 5a² + 10a + 10, but now g has no rational root. We show g is strictly increasing (its divided-difference bracket is positive-definite: 12·bracket = (3a+3b+10)² + 3(a−b)² + 20), so it has a unique real root a₅*, located in (−3, −2) by the sign change g(−3) = −2 < 0 < 2 = g(−2). The headline quintic_endpoint gives 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a — the exact analogue of the parent's cubic_iff with an irrational endpoint — establishing the first step of the creep −3 = a₃* < a₅* < −2. Concrete witnesses bracket a₅*: the n = 5 inequality holds at −5/2 but fails at −29/10, where n = 3 still holds. A structural companion (strict_at_neg_two_odd) shows every odd endpoint lies below −2 because (1+a)ⁿ = (−1)ⁿ = −1 already beats the line 1 − 2n at a = −2 for all odd n.",
+  "meta": {
+    "author": "Jacob Bernoulli (1689); per-exponent endpoint analysis, quintic case",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "1689",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "strict-inequality",
+      "sharp-constant",
+      "polynomial",
+      "intermediate-value-theorem",
+      "strict-monotonicity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "intermediate_value_Ioo",
+        "description": "IVT on an open interval: a continuous function on [a,b] attains every value strictly between f a and f b on (a,b). Used to locate the unique real root a₅* of the residual cubic g in (−3, −2) from the sign change g(−3) < 0 < g(−2).",
+        "module": "Mathlib.Topology.Algebra.Order.IntermediateValue"
+      },
+      {
+        "theorem": "StrictMono.lt_iff_lt",
+        "description": "For a strictly monotone f, f x < f y ↔ x < y. Converts the sign condition 0 < g(a) = g(a) into the endpoint condition a₅* < a (using g(a₅*) = 0), and gives uniqueness of the endpoint.",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow",
+        "description": "For odd n, (−1)ⁿ = −1. Evaluates (1 + (−2))ⁿ = (−1)ⁿ = −1 in strict_at_neg_two_odd, showing −2 is interior to the strict domain for every odd exponent.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "quintic_factor: the residual factorization (1+a)⁵ − (1+5a) = a²·(a³ + 5a² + 10a + 10), the quintic analogue of the parent's cubic factorization, isolating the sign-governing residual cubic g",
+      "residualCubic_strictMono: g(a) = a³ + 5a² + 10a + 10 is strictly increasing, proved from the positive-definite divided-difference identity 12·(a²+ab+b²+5a+5b+10) = (3a+3b+10)² + 3(a−b)² + 20; hence g is injective and the quintic endpoint is unique",
+      "quintic_iff_residual_pos: 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ 0 < g(a), reducing the strict inequality to the sign of the residual cubic",
+      "quintic_endpoint: there is an endpoint a₅* ∈ (−3, −2) with 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a — the exact analogue of the parent's cubic_iff with an irrational endpoint, realizing the first step of the predicted creep a₃* = −3 < a₅* < −2 toward the sharp uniform bound −2",
+      "strict_at_neg_five_halves / quintic_fails_at_neg_29 / cubic_holds_at_neg_29: concrete witnesses bracketing a₅* — n = 5 holds at −5/2 but fails at −29/10, while n = 3 holds at −29/10, exhibiting a point where the cubic succeeds yet the quintic fails (the creep made concrete)",
+      "strict_at_neg_two_odd: for every odd n ≥ 2 the strict inequality holds at a = −2 (there (1+a)ⁿ = (−1)ⁿ = −1 beats the line 1 − 2n), so −2 is interior for each odd n and aₙ* < −2 universally, with −2 = supₙ aₙ* approached from below"
+    ],
+    "dateAdded": "2026-06-24",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 161,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (every theorem depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parent entry sharpened Mathlib's weak Bernoulli inequality one_add_mul_le_pow (valid on −2 ≤ a) to the strict form and showed −2 is the sharp uniform endpoint while each individual odd exponent has a finite endpoint aₙ* strictly below −2. It pinned the cubic case exactly — a₃* = −3 — and conjectured the per-exponent endpoints creep up toward −2 as n grows. The natural next question is the n = 5 case, the first one whose endpoint is not rational.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01-OQ-01-OQ-01):** Determine the left endpoint a₅* of the strict quintic Bernoulli inequality 1 + 5a < (1 + a)⁵, the next odd case after the cubic endpoint a₃* = −3, and confirm the predicted creep a₃* < a₅* < −2.\n\n**Answer:** (1+a)⁵ − (1+5a) = a²·g(a) with residual cubic g(a) = a³ + 5a² + 10a + 10. The cubic g is strictly increasing, so it has a unique real root a₅*, and the sign change g(−3) = −2 < 0 < 2 = g(−2) locates it in (−3, −2). Hence 1 + 5a < (1 + a)⁵ ↔ a ≠ 0 ∧ a₅* < a, the exact analogue of the parent's cubic_iff, and −3 = a₃* < a₅* < −2 confirms the first step of the creep.",
+    "text": "Where the parent's cubic factor a + 3 had the rational root −3, the quintic's residual cubic a³ + 5a² + 10a + 10 has an irrational root. The key structural fact is that this cubic is strictly monotone — its divided-difference bracket a² + ab + b² + 5a + 5b + 10 is a positive-definite quadratic form (12 times it is a sum of two squares plus 20) — so the endpoint is unique, and the intermediate value theorem pins it inside (−3, −2). Concrete rational witnesses tighten the bracket and, more pointedly, exhibit a value (−29/10) at which the cubic inequality still holds but the quintic one fails: the endpoint has strictly risen from −3, the creep in action. The structural companion explains why the rise stays below −2 for every odd exponent: at a = −2 the power (1+a)ⁿ equals (−1)ⁿ = −1, which already beats the line value 1 − 2n, so −2 is interior for all odd n and is only the supremum of the endpoints.",
+    "proofStrategy": "1. **Factorization** (`quintic_factor`): (1+a)⁵ − (1+5a) = a²·g(a) with g(a) = a³ + 5a² + 10a + 10, by ring.\n2. **Strict monotonicity** (`residualCubic_strictMono`): g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10), and the bracket is positive because 12·bracket = (3a+3b+10)² + 3(a−b)² + 20 > 0; so b > a ⟹ g(b) > g(a).\n3. **Sign form** (`quintic_iff_residual_pos`): since a² ≥ 0, the gap a²·g(a) is positive iff a ≠ 0 and g(a) > 0.\n4. **Endpoint** (`quintic_endpoint`): the IVT on [−3, −2] with g(−3) = −2 < 0 < 2 = g(−2) yields a root a₅* ∈ (−3, −2); strict monotonicity turns 0 < g(a) into a₅* < a (via g(a₅*) = 0), giving the iff and the uniqueness of a₅*.\n5. **Witnesses** (`strict_at_neg_five_halves`, `quintic_fails_at_neg_29`, `cubic_holds_at_neg_29`): direct norm_num evaluations bracket a₅* ∈ (−29/10, −5/2) and contrast n = 3 with n = 5 at −29/10.\n6. **Universal sub-(−2) endpoint** (`strict_at_neg_two_odd`): for odd n, (1 + (−2))ⁿ = (−1)ⁿ = −1 > 1 − 2n for n ≥ 2.",
+    "keyInsights": [
+      "**The quintic endpoint is irrational, so it must be located rather than computed.** Unlike the parent's rational a₃* = −3, the n = 5 endpoint is the unique real root of an irreducible-over-ℚ cubic; the proof characterizes it by monotonicity + IVT instead of a closed form.",
+      "**Strict monotonicity of the residual cubic is the whole game.** It simultaneously gives uniqueness of the endpoint and the clean iff 0 < g(a) ↔ a₅* < a. Monotonicity follows from a sum-of-squares certificate for the divided-difference bracket, avoiding any appeal to derivatives.",
+      "**The creep is concrete, not just asymptotic.** At a = −29/10 the cubic inequality holds while the quintic one fails — a single rational point that witnesses a₃* = −3 < a₅*, the endpoint strictly rising.",
+      "**Parity caps the creep at −2.** For every odd n the strict inequality already holds at a = −2, so no odd endpoint reaches −2; the endpoints rise toward but never attain the sharp uniform bound, exactly the parent's supₙ aₙ* = −2 picture."
+    ],
+    "prerequisites": [
+      "The parent's per-exponent endpoint analysis and cubic_iff (a₃* = −3)",
+      "Strict monotonicity from a positive divided difference (sum-of-squares certificate)",
+      "The intermediate value theorem on an open interval (intermediate_value_Ioo)",
+      "Sign of odd integer powers of −1 (Odd.neg_one_pow)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "factorization",
+      "title": "The Residual Cubic Factorization",
+      "startLine": 53,
+      "endLine": 66,
+      "summary": "Defines g(a) = a³ + 5a² + 10a + 10 and proves (1+a)⁵ − (1+5a) = a²·g(a), the quintic analogue of the parent's a²(a+3).",
+      "mathContext": "(1+a)⁵ − (1+5a) = a²·(a³ + 5a² + 10a + 10)."
+    },
+    {
+      "id": "strict-mono",
+      "title": "The Residual Cubic Is Strictly Increasing",
+      "startLine": 68,
+      "endLine": 83,
+      "summary": "g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10); the bracket is positive-definite since 12·bracket = (3a+3b+10)² + 3(a−b)² + 20, so g is strictly monotone (hence injective, giving a unique endpoint).",
+      "mathContext": "StrictMono (a ↦ a³ + 5a² + 10a + 10)."
+    },
+    {
+      "id": "sign-form",
+      "title": "Strict Inequality as the Sign of g",
+      "startLine": 85,
+      "endLine": 109,
+      "summary": "Dividing the gap by the double factor a², 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ 0 < g(a).",
+      "mathContext": "1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ 0 < g(a)."
+    },
+    {
+      "id": "endpoint",
+      "title": "The Quintic Endpoint a₅* ∈ (−3, −2)",
+      "startLine": 111,
+      "endLine": 130,
+      "summary": "The IVT on [−3, −2] with g(−3) < 0 < g(−2) produces a root a₅* ∈ (−3, −2); strict monotonicity yields 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a, realizing the creep a₃* = −3 < a₅* < −2.",
+      "mathContext": "∃ a₅* ∈ (−3, −2), 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete Witnesses Bracketing the Endpoint",
+      "startLine": 132,
+      "endLine": 151,
+      "summary": "n = 5 holds at −5/2 but fails at −29/10, while n = 3 holds at −29/10 — a point where the cubic succeeds yet the quintic fails, the creep made concrete.",
+      "mathContext": "1 + 5·(−5/2) < (1 − 5/2)⁵; ¬(1 + 5·(−29/10) < (1 − 29/10)⁵); 1 + 3·(−29/10) < (1 − 29/10)³."
+    },
+    {
+      "id": "below-neg-two",
+      "title": "Every Odd Endpoint Sits Below −2",
+      "startLine": 153,
+      "endLine": 160,
+      "summary": "For every odd n ≥ 2 the strict inequality holds at a = −2, since (1 + (−2))ⁿ = (−1)ⁿ = −1 beats 1 − 2n; so −2 is interior for each odd n and aₙ* < −2 universally.",
+      "mathContext": "Odd n, n ≥ 2 ⟹ 1 + n·(−2) < (1 + (−2))ⁿ."
+    }
+  ],
+  "conclusion": {
+    "summary": "The quintic Bernoulli endpoint a₅* is the unique real root of the residual cubic a³ + 5a² + 10a + 10, located in (−3, −2): 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a. This confirms the first step of the parent's predicted creep, a₃* = −3 < a₅* < −2, with the strict rise witnessed concretely at a = −29/10 (cubic holds, quintic fails). Every odd endpoint stays below −2 because (1+a)ⁿ = −1 beats the line at a = −2 for all odd n. Verified: 0 sorries, 0 axioms.",
+    "implications": "Together with the parent's a₃* = −3 and the universal bound aₙ* < −2, this gives the first two terms of the monotone endpoint sequence and concrete evidence for the conjectured creep aₙ* ↑ −2. The strict-monotonicity-plus-IVT method (a sum-of-squares certificate for the divided difference, then the intermediate value theorem) is reusable for the higher odd cases, where the residual polynomial is likewise irreducible and the endpoint irrational.",
+    "openQuestions": [
+      "Does the sequence of odd endpoints aₙ* admit the sharp asymptotic aₙ* = −2 − Θ(1/n), and can the residual polynomials' monotonicity be established uniformly in n rather than case by case?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent pins the cubic endpoint a₃* = −3 and conjectures the odd endpoints creep up toward −2; this entry resolves the next odd case, locating a₅* ∈ (−3, −2) and confirming a₃* < a₅* < −2"
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent proves strict Bernoulli on the full weak domain −2 ≤ a; this entry continues the per-exponent endpoint analysis into the quintic case"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BernoulliInequalityOQ01OQ01OQ01OQ01",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/BernoulliInequalityOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Positiones Arithmeticae de Seriebus Infinitis",
+      "year": "1689",
+      "venue": "Basel",
+      "note": "Early use of the inequality 1 + nx ≤ (1+x)ⁿ in the study of infinite series"
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Standard reference on Bernoulli's inequality, its strict forms, and admissible domains"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the next odd case of the **per-exponent Bernoulli endpoint** analysis. The parent (`bernoulli-inequality-oq-01-oq-01-oq-01`) pinned the **cubic** endpoint `a₃* = −3` from `(1+a)³ − (1+3a) = a²(a+3)` and conjectured the odd endpoints **creep up toward** the sharp uniform bound `−2`. This entry does the **quintic** case `n = 5`, the first whose endpoint is irrational.

## Result

`(1+a)⁵ − (1+5a) = a²·g(a)` with residual cubic `g(a) = a³ + 5a² + 10a + 10`.

- `residualCubic_strictMono` — `g` is strictly increasing, proved from the SOS certificate `12·(a²+ab+b²+5a+5b+10) = (3a+3b+10)² + 3(a−b)² + 20 > 0` (no derivatives). Hence the endpoint is **unique**.
- `quintic_endpoint` (headline) — there is `a₅* ∈ (−3, −2)` with
  `1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a`,
  the exact analogue of the parent's `cubic_iff` with an irrational endpoint, located via `intermediate_value_Ioo` from `g(−3) = −2 < 0 < 2 = g(−2)`. This confirms the first step of the creep **`a₃* = −3 < a₅* < −2`**.
- `strict_at_neg_five_halves` / `quintic_fails_at_neg_29` / `cubic_holds_at_neg_29` — concrete witnesses: `n = 5` holds at `−5/2` but **fails** at `−29/10`, where `n = 3` still **holds** — a single rational point witnessing the endpoint's strict rise.
- `strict_at_neg_two_odd` — every odd endpoint stays below `−2`: for odd `n ≥ 2`, `(1+(−2))ⁿ = (−1)ⁿ = −1` beats the line `1 − 2n`, so `−2` is interior and `aₙ* < −2` universally (`−2 = supₙ aₙ*`, approached from below).

## Verification

- **0 axioms**, **0 sorries** — every theorem depends only on `propext`, `Classical.choice`, `Quot.sound` (confirmed via `#print axioms`).
- Builds clean with `lake env lean` (Mathlib 4.26.0). 9 theorems / 1 definition / 161 lines.
- Imports only `Mathlib`; registered in `Proofs.lean` (also restored the parent's missing import).

## Files
- `proofs/Proofs/BernoulliInequalityOQ01OQ01OQ01OQ01.lean`
- `src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/{meta,annotations}.json`
- `proofs/Proofs.lean` (import registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)