### PR TITLE
Enrich: The δ-Function Engine of the Stepping-Up Lemma (ramseys-theorem-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/ramseys-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ramseys-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-ramsey0401-bit-helpers",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 47, "endLine": 75 },
+    "type": "definition",
+    "title": "Most Significant Bit via testBit",
+    "content": "The combinatorial foundation: bool_xor_true/false translate a Bool-xor into bit (in)equality (decide over the 4 Bool cases), and IsMSB n i defines the most significant set bit purely via Nat.testBit (bit i set, all higher bits clear). Existence reuses Mathlib's Nat.exists_most_significant_bit; uniqueness is a trichotomy where a higher set bit contradicts the 'all higher bits clear' clause. Everything stays constructive — no Classical.choice, no noncomputable.",
+    "mathContext": "$\\mathrm{IsMSB}(n,i) \\iff \\mathrm{testBit}(n,i) = \\mathtt{true} \\wedge \\forall j > i,\\ \\mathrm{testBit}(n,j) = \\mathtt{false}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.testBit", "binary expansion", "Bool.xor", "most significant bit"],
+    "prerequisites": ["binary representation of naturals"]
+  },
+  {
+    "id": "ann-ramsey0401-delta",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 76, "endLine": 91 },
+    "type": "definition",
+    "title": "The Top Differing Bit δ, Relationally",
+    "content": "δ(a,b) — the highest bit position where a and b differ — is the engine of the Erdős–Hajnal stepping-up lemma. It is defined relationally as TopDiff a b i := IsMSB (a XOR b) i, keeping the construction fully constructive (no choice function). topDiff_exists (a ≠ b ⟹ a XOR b ≠ 0 ⟹ has an MSB), topDiff_unique (well-defined) and topDiff_comm (symmetric, from xor_comm) establish δ as a genuine well-defined symmetric function captured without a noncomputable definition.",
+    "mathContext": "$\\delta(a,b) = \\mathrm{MSB}(a \\oplus b)$, the top bit where $a$ and $b$ differ; symmetric and unique.",
+    "significance": "key",
+    "relatedConcepts": ["XOR", "stepping-up lemma", "relational definition", "constructive mathematics"],
+    "prerequisites": ["Nat.xor", "the IsMSB predicate"]
+  },
+  {
+    "id": "ann-ramsey0401-winner",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 93, "endLine": 116 },
+    "type": "theorem",
+    "title": "Property (A): The Winner Bit",
+    "content": "topDiff_winner: if a < b and i = δ(a,b), then b has a 1 at bit i and a has a 0. Above i the two agree (bool_xor_false), and at i they differ (bool_xor_true); if b had 0 there, then Nat.lt_of_testBit would make b < a, contradicting a < b. This is what lets the stepping-up colouring RECOVER the order of two elements from their top differing bit — the larger number is the one with the 1 at δ.",
+    "mathContext": "$a < b,\\ i = \\delta(a,b) \\implies \\mathrm{testBit}(a,i) = \\mathtt{false} \\wedge \\mathrm{testBit}(b,i) = \\mathtt{true}$.",
+    "significance": "key",
+    "relatedConcepts": ["order recovery", "Nat.lt_of_testBit", "lexicographic comparison"],
+    "prerequisites": ["the δ definition", "bit comparison of naturals"]
+  },
+  {
+    "id": "ann-ramsey0401-distinct",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 117, "endLine": 129 },
+    "type": "theorem",
+    "title": "Property (B): Adjacent δ-Values Are Distinct",
+    "content": "topDiff_ne: for a < b < c, δ(a,b) ≠ δ(b,c). If they coincided at bit i, the winner-bit property would force b to be BOTH the larger of (a,b) — so testBit b i = true — and the smaller of (b,c) — so testBit b i = false, a contradiction. This 'no repeated adjacent value' is half of why the sequence of δ-values along an increasing chain forces the monochromatic structure to collapse.",
+    "mathContext": "$a < b < c \\implies \\delta(a,b) \\ne \\delta(b,c)$, since $b$ cannot carry both $1$ and $0$ at a shared top bit.",
+    "significance": "key",
+    "relatedConcepts": ["stepping-up colouring", "chain of δ-values", "winner bit"],
+    "prerequisites": ["Property (A)"]
+  },
+  {
+    "id": "ann-ramsey0401-max-xor",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 130, "endLine": 146 },
+    "type": "technique",
+    "title": "MSB of a XOR with Distinct Top Bits",
+    "content": "isMSB_xor_of_ne is the technical heart of the max law: if N₁ has MSB i and N₂ has MSB i' with i ≠ i', then N₁ XOR N₂ has MSB max(i,i'). At max(i,i') exactly one operand is set (the other is clear there, being below its own MSB), so the xor bit is 1; above max(i,i') both are clear, so the xor is 0. The case split on i < i' vs i > i' is handled by max_eq_right/left and decide on the Bool xor.",
+    "mathContext": "$\\mathrm{MSB}(N_1)=i \\ne i'=\\mathrm{MSB}(N_2) \\implies \\mathrm{MSB}(N_1 \\oplus N_2) = \\max(i,i')$.",
+    "significance": "supporting",
+    "relatedConcepts": ["XOR of bit patterns", "max", "Nat.testBit_xor"],
+    "prerequisites": ["the IsMSB predicate", "bitwise xor"]
+  },
+  {
+    "id": "ann-ramsey0401-max-law",
+    "proofId": "ramseys-theorem-oq-04-oq-01",
+    "range": { "startLine": 147, "endLine": 160 },
+    "type": "insight",
+    "title": "Property (C): The Max Law δ(a,c) = max(δ(a,b), δ(b,c))",
+    "content": "topDiff_max: for a < b < c, the top differing bit of the endpoints is the max of the two adjacent ones. The key algebra is (a⊕b)⊕(b⊕c) = a⊕c (xor telescopes, b cancels); since δ(a,b) ≠ δ(b,c) by Property (B), isMSB_xor_of_ne gives MSB(a⊕c) = max, and uniqueness of the MSB pins δ(a,c) = max(δ(a,b), δ(b,c)). Together (B) and (C) say the δ-sequence along a chain has no repeats and behaves like a max — exactly the structure the stepping-up lemma exploits.",
+    "mathContext": "$a < b < c \\implies \\delta(a,c) = \\max(\\delta(a,b),\\,\\delta(b,c))$, via $(a\\oplus b)\\oplus(b\\oplus c) = a\\oplus c$.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős–Hajnal stepping-up lemma", "telescoping XOR", "max law", "hypergraph Ramsey lower bounds"],
+    "prerequisites": ["Properties (A), (B)", "MSB of xor lemma"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `ramseys-theorem-oq-04-oq-01`.

## Quality improvements
- **Added `annotations.json`** (was missing): 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — covering the `testBit`/`IsMSB` constructive foundation, the relational top-differing-bit δ = MSB(a⊕b) (existence/uniqueness/symmetry), property (A) the winner bit (order recovery), property (B) adjacent distinctness, the MSB-of-XOR technical lemma, and property (C) the max law δ(a,c) = max(δ(a,b), δ(b,c)).

## Verification
- `pnpm annotations:build` runs clean for this entry (no "No Lean construct" warnings; `listings.json` regenerates).
- Axiom integrity confirmed accurate: `status: verified`, `badge: verified`, `axiomCount: 0`, 0 sorries — the `decide` calls are over `Bool` (no `native_decide`, no `Lean.ofReduceBool`); δ is captured relationally so the construction stays choice-free.
- The entry's existing `overview` (5 sections, conclusion, top-level description) was already present and is untouched; this pass only adds the missing annotations.