### PR TITLE
Enrich Generalized Ballot Count (Catalan reflection): add annotations.json

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,177 @@
+[
+  {
+    "id": "ann-cgb-overview",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 35 },
+    "type": "concept",
+    "title": "Statement and Strategy — Reflection at Arbitrary Depth −k",
+    "content": "The module docstring fixes the goal and the route. The parent file realizes the Catalan reflection form catalan n = C(2n,n) − C(2n,n+1) as an explicit bijection between n-up lattice paths that dip to height −1 (the 'bad' paths) and all (n−1)-up paths. This entry raises the barrier from −1 to an arbitrary depth −k. Encoding a 2n-step path by its set S : Finset (Fin (2n)) of up-step positions, the height after j steps is 2·preUps S j − j, and the path reaches −k exactly when some prefix satisfies j = 2·preUps S j + k. The same André reflection — complement every step from the first descent onward — is a bijection {n-up paths reaching −k} ≃ {(n−k)-up paths}, yielding the generalized ballot number C(2n,n) − C(2n,n+k). At k = 1 it recovers the parent.",
+    "mathContext": "$\\#\\{n\\text{-up paths staying above }-k\\} = \\binom{2n}{n} - \\binom{2n}{n+k}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "ballot problem",
+      "reflection principle",
+      "cycle lemma",
+      "lattice paths"
+    ],
+    "prerequisites": [
+      "Catalan numbers",
+      "binomial coefficients",
+      "monotone lattice paths"
+    ]
+  },
+  {
+    "id": "ann-cgb-predicates",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 60 },
+    "type": "definition",
+    "title": "hitsAtK / ReachesK — Depth-k Descent Predicates",
+    "content": "The single parametrized device that carries the barrier depth k. hitsAtK S k j holds when the prefix of length j has exactly k more down-steps than up-steps, i.e. j = 2·preUps S j + k (height 2·preUps − j equals −k). ReachesK S k asserts the path hits depth −k at some prefix among its 2n+1 prefixes. The parent's barrier-−1 predicate hitsAt is exactly the k = 1 slice, hitsAtK S 1, which is why the recovery at the end is definitional. Decidability instances are derived mechanically from the parent's, so BadPathsK / GoodPathsK can be defined as Finset filters.",
+    "mathContext": "$\\mathrm{hitsAtK}\\,S\\,k\\,j \\iff j = 2\\,\\mathrm{preUps}(S,j) + k$; the parent's $\\mathrm{hitsAt} = \\mathrm{hitsAtK}\\,\\cdot\\,1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "prefix up-count",
+      "first-passage predicate",
+      "parametrized barrier height"
+    ],
+    "prerequisites": [
+      "Finset.filter and decidability",
+      "the parent's preUps encoding"
+    ]
+  },
+  {
+    "id": "ann-cgb-ivt",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 91 },
+    "type": "technique",
+    "title": "reachesK_of_card_add_le — Discrete Intermediate-Value Theorem at Depth k",
+    "content": "Establishes that EVERY (n−k)-up path is a depth-k bad path, so the bijection needs no side condition beyond 1 ≤ k ≤ n. A path with S.card + k ≤ n up-steps ends at height 2·S.card − 2n ≤ −2k. Because every step is ±1, the height cannot jump past −k: taking j₀ = Nat.find of the first prefix where 2·preUps + k ≤ j, minimality of j₀ (Nat.find_min on j₀−1) plus the single-step increment hstep (preUps grows by at most one, card_filter_val_eq_le_one) forces the first crossing to land EXACTLY on −k, i.e. j₀ = 2·preUps S j₀ + k. The arithmetic is discharged by omega.",
+    "mathContext": "$\\#S + k \\le n \\Rightarrow \\text{path ends at height} \\le -2k \\Rightarrow \\text{first prefix hitting } \\le -k \\text{ lands on } -k$",
+    "significance": "key",
+    "relatedConcepts": [
+      "discrete intermediate value theorem",
+      "first-passage / least witness",
+      "unit-step monotonicity"
+    ],
+    "prerequisites": [
+      "Nat.find / Nat.find_spec / Nat.find_min",
+      "preUps_succ, preUps_zero, preUps_eq_card (parent)",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-cgb-cut",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 148 },
+    "type": "technique",
+    "title": "The Cut Point cutK and the Collapsed Cardinality Identity",
+    "content": "Sets up the first-descent involution by reusing the parent's barrier-independent core verbatim. hitsAtK_reflect_iff shows reflection does not alter the up-count below the cut (via preUps_reflect_eq), so the depth-k hit equation is preserved there. cutK S k := sInf {j | hitsAtK S k j} is the first prefix hitting −k; cutK_hits, cutK_min, cutK_le give its defining properties. reachesK_reflect and cutK_reflect prove that reflecting at the cut keeps the path a depth-k path AND preserves the cut point — so the reflection is an involution on bad paths. The quantitative payoff is card_reflect_cutK: substituting the hit equation cutK = 2·preUps + k into the parent's identity #(reflect S t) + #S + t = 2·preUps S t + 2n collapses it to #(reflect S) + #S + k = 2n. This one equation is the entire bijection: with #S = n the reflected path has exactly n − k up-steps.",
+    "mathContext": "$\\#(\\mathrm{reflect}\\,S\\,(\\mathrm{cutK}\\,S\\,k)) + \\#S + k = 2n,\\quad \\#S = n \\Rightarrow \\#(\\mathrm{reflect}) = n-k$",
+    "significance": "key",
+    "relatedConcepts": [
+      "André reflection",
+      "first-passage decomposition",
+      "involution",
+      "barrier-independent reuse"
+    ],
+    "prerequisites": [
+      "Nat.sInf_mem / Nat.sInf_le",
+      "card_reflect_add, preUps_reflect_eq, reflect_involutive (parent)",
+      "le_antisymm"
+    ]
+  },
+  {
+    "id": "ann-cgb-defs",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 150, "endLine": 166 },
+    "type": "definition",
+    "title": "BadPathsK / LowPathsK / GoodPathsK — The Three Finsets to Count",
+    "content": "The objects of the enumeration, all defined as filters over Finset.univ : Finset (Finset (Fin (2n))). BadPathsK n k = the n-up paths that DO reach depth −k. LowPathsK n k = ALL (n−k)-up paths (the reflection target). GoodPathsK n k = the n-up paths that NEVER reach −k — the generalized Dyck / ballot paths whose count is the headline result. Bad and Good partition the n-up paths by the decidable predicate ReachesK, which is what makes the additive count below a clean filter split.",
+    "mathContext": "$\\mathrm{BadPathsK} \\sqcup \\mathrm{GoodPathsK} = \\{S : \\#S = n\\};\\quad \\mathrm{LowPathsK} = \\{S : \\#S = n-k\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.filter",
+      "partition by a decidable predicate",
+      "generalized Dyck paths"
+    ],
+    "prerequisites": [
+      "Finset.univ over a power set",
+      "decidability of ReachesK"
+    ]
+  },
+  {
+    "id": "ann-cgb-bijection",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 168, "endLine": 197 },
+    "type": "theorem",
+    "title": "card_badPathsK — The Generalized Reflection Bijection",
+    "content": "The combinatorial heart: for 1 ≤ k ≤ n, reflecting at the first descent to −k is an explicit bijection BadPathsK ≃ LowPathsK. Built with Finset.card_bij' using reflect S (cutK S k) in BOTH directions (it is its own inverse). The four obligations are discharged uniformly: bad ↦ low and low ↦ bad both reduce to card_reflect_cutK + omega for the card change n ↔ n−k (with reachesK_of_card_add_le supplying that every low path reaches −k); the two inverse laws are cutK_reflect (cut point preserved) followed by reflect_involutive. The map carries no arithmetic beyond the collapsed identity #(reflect) + #S + k = 2n.",
+    "mathContext": "$\\mathrm{reflect}\\,S\\,(\\mathrm{cutK}\\,S\\,k) : \\mathrm{BadPathsK}\\,n\\,k \\xrightarrow{\\;\\sim\\;} \\mathrm{LowPathsK}\\,n\\,k$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "explicit bijection",
+      "self-inverse involution",
+      "reflection principle"
+    ],
+    "prerequisites": [
+      "Finset.card_bij'",
+      "card_reflect_cutK, cutK_reflect, reachesK_reflect (above)",
+      "reachesK_of_card_add_le (above)"
+    ]
+  },
+  {
+    "id": "ann-cgb-count",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 199, "endLine": 227 },
+    "type": "theorem",
+    "title": "The Ballot Count C(2n,n) − C(2n,n+k)",
+    "content": "Turns the bijection into the closed count. card_badPathsK_eq evaluates #LowPathsK via card_filter_card_eq (#{S : #S = m} = C(2n,m)) and Nat.choose_symm to write C(2n, n−k) = C(2n, n+k), so #BadPathsK = C(2n, n+k). Splitting the n-up paths into bad and good with Finset.filter_card_add_filter_neg_card_eq_card then gives the additive headline #GoodPathsK + C(2n, n+k) = C(2n, n) (card_goodPathsK_add); the ℕ subtraction is avoided to keep everything subtraction-free. card_goodPathsK_sub casts to ℤ to present the familiar difference form #GoodPathsK = C(2n,n) − C(2n,n+k).",
+    "mathContext": "$\\#\\mathrm{GoodPathsK}\\,n\\,k = \\binom{2n}{n} - \\binom{2n}{n+k}\\quad(1 \\le k \\le n)$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "binomial symmetry Nat.choose_symm",
+      "complementary counting",
+      "André–Bertrand ballot number"
+    ],
+    "prerequisites": [
+      "card_filter_card_eq (parent), Finset.card_powersetCard",
+      "Finset.filter_card_add_filter_neg_card_eq_card",
+      "Nat.choose_symm"
+    ]
+  },
+  {
+    "id": "ann-cgb-recovery",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 229, "endLine": 246 },
+    "type": "insight",
+    "title": "k = 1 is Definitionally the Parent's Catalan Form",
+    "content": "The recovery is not a re-derivation but an identity. reachesK_one_iff proves ReachesK S 1 ↔ Reaches S by Iff.rfl — the depth-1 predicate unfolds to the parent's. goodPathsK_one then shows GoodPathsK n 1 = GoodPaths n as Finsets, and card_goodPathsK_one reuses the parent's headline card_goodPaths_eq_catalan to conclude #GoodPathsK n 1 = catalan n. So catalan n = C(2n,n) − C(2n,n+1) is literally the k = 1 slice of the generalized count, confirming the generalization is faithful.",
+    "mathContext": "$\\mathrm{GoodPathsK}\\,n\\,1 = \\mathrm{GoodPaths}\\,n,\\quad \\#\\mathrm{GoodPathsK}\\,n\\,1 = \\mathrm{catalan}\\,n$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "definitional equality (Iff.rfl)",
+      "specialization to a known result",
+      "Catalan numbers"
+    ],
+    "prerequisites": [
+      "CatalanAndreReflection.Reaches / GoodPaths / card_goodPaths_eq_catalan (parent)"
+    ]
+  },
+  {
+    "id": "ann-cgb-instance",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 248, "endLine": 257 },
+    "type": "context",
+    "title": "Concrete Instance — n = 3, k = 2 Gives 14",
+    "content": "A numerical sanity check derived from the general theorem (not a separate computation): the number of 3-up paths staying strictly above depth −2 is C(6,3) − C(6,5) = 20 − 6 = 14. It is obtained by specializing card_goodPathsK_add at n = 3, k = 2 and evaluating the two binomial numerals by kernel `decide`. Because the binomials are closed Nat.choose numerals, this stays 0-axiom (plain kernel reduction, not native_decide / Lean.ofReduceBool).",
+    "mathContext": "$\\#\\mathrm{GoodPathsK}\\,3\\,2 = \\binom{6}{3} - \\binom{6}{5} = 20 - 6 = 14$",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked example",
+      "kernel decide on closed numerals"
+    ],
+    "prerequisites": [
+      "card_goodPathsK_add (above)"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `catalan-numbers-oq-01-oq-01-oq-01-oq-01`

Adds `annotations.json` (9 annotations) — this entry had a rich meta.json but no inline annotations. Covers the module docstring, depth-k descent predicates, discrete IVT, the cut-point involution + collapsed cardinality identity, the three counted Finsets, the reflection bijection, the C(2n,n)−C(2n,n+k) count, the k=1 recovery, and the n=3,k=2 worked instance. Each carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.

Verified: `annotations:build` clean (all 9 ranges anchor to Lean constructs); JSON validated. Data-only change. (Re-issued from closed #29290 onto a dedicated branch.)