### PR TITLE
research(cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03): exact count of xⁿ = g — gcd(n,|G|) when g is an n-th power, else 0 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -583,6 +583,7 @@ import Proofs.CatalanNumbersOQ01
 import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03
 import Proofs.CauchyGroupTheoremOQ01OQ02
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchyInterlacingOQ01OQ01

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,188 @@
+import Mathlib.Tactic
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01
+
+/-
+# Counting solutions of `xⁿ = g` for an arbitrary target `g`
+
+## What this proves
+
+The parent file `CauchyGroupTheoremOQ01OQ01OQ01OQ01` pins down the number of
+solutions of `xⁿ = 1` in a finite **cyclic** group: it is exactly
+`gcd(n, |G|)`. This file answers the natural follow-up question:
+
+> For a *fixed* element `g` (not necessarily the identity), how many `x`
+> satisfy `xⁿ = g`?
+
+The answer splits cleanly into a **structural** part valid in every finite
+**abelian** group, and an **explicit count** in the cyclic case.
+
+* **Structural dichotomy (abelian).** In any finite abelian group the power map
+  `x ↦ xⁿ` is a homomorphism, so the solution set of `xⁿ = g` is either empty
+  (when `g` is not an `n`-th power) or a *coset* of the solution set of
+  `xⁿ = 1`. Cosets have equal size, hence
+
+  ```
+  #{x | xⁿ = g} = #{x | xⁿ = 1}     if g is an n-th power
+  #{x | xⁿ = g} = 0                 otherwise.
+  ```
+
+  (`card_pow_eq_eq_card_pow_one`, `card_pow_eq`.)
+
+* **Explicit value (cyclic).** Feeding the parent's count `#{xⁿ = 1} =
+  gcd(n, |G|)` into the dichotomy gives, in a finite cyclic group,
+
+  ```
+  #{x | xⁿ = g} = gcd(n, |G|)   if g is an n-th power, else 0.
+  ```
+
+  (`card_pow_eq_cyclic`.)
+
+This is the sharp generalisation of the parent's `g = 1` count. It also makes
+precise the abelian shadow of **Frobenius' theorem**: the number of solutions
+of `xⁿ = g` is either `0` or a fixed value `gcd(n, |G|)` that does **not**
+depend on which `n`-th power `g` is.
+
+## Proof strategy
+
+The whole content is one bijection. Fix a witness `a₀` with `a₀ⁿ = g`. In an
+abelian group
+
+```
+x ↦ a₀⁻¹ · x
+```
+
+is a bijection from `{x | xⁿ = g}` to `{x | xⁿ = 1}` (with inverse
+`y ↦ a₀ · y`), because `(a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·g = 1` exactly when
+`xⁿ = g`. Equal-size sets, so equal cardinalities. When `g` is not an `n`-th
+power the solution set is empty by definition.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03
+
+open Finset
+
+variable {α : Type*} [CommGroup α]
+
+/-- **Coset count.** In a finite abelian group, if `g` is an `n`-th power then
+the equation `xⁿ = g` has exactly as many solutions as `xⁿ = 1`. The bijection
+is left-translation by a fixed `n`-th root `a₀` of `g`. -/
+theorem card_pow_eq_eq_card_pow_one [DecidableEq α] [Fintype α] {n : ℕ} {g : α}
+    (hg : ∃ a, a ^ n = g) :
+    (univ.filter (fun x => x ^ n = g)).card
+      = (univ.filter (fun x : α => x ^ n = 1)).card := by
+  obtain ⟨a₀, ha₀⟩ := hg
+  -- The solution set of `xⁿ = g` is the left-translate by `a₀` of the solution
+  -- set of `yⁿ = 1`; left translation is injective, so the cardinalities agree.
+  have hset : (univ.filter (fun x => x ^ n = g))
+      = (univ.filter (fun y : α => y ^ n = 1)).image (fun y => a₀ * y) := by
+    ext x
+    simp only [mem_filter, mem_univ, true_and, mem_image]
+    constructor
+    · intro hx
+      refine ⟨a₀⁻¹ * x, ?_, by rw [mul_inv_cancel_left]⟩
+      rw [mul_pow, inv_pow, ha₀, hx, inv_mul_cancel]
+    · rintro ⟨y, hy, rfl⟩
+      rw [mul_pow, ha₀, hy, mul_one]
+  rw [hset]
+  exact Finset.card_image_of_injective _ (Equiv.mulLeft a₀).injective
+
+/-- **Dichotomy.** In a finite abelian group the number of solutions of
+`xⁿ = g` equals the number of solutions of `xⁿ = 1` when `g` is an `n`-th
+power, and `0` otherwise. -/
+theorem card_pow_eq [DecidableEq α] [Fintype α] (n : ℕ) (g : α) :
+    (univ.filter (fun x => x ^ n = g)).card
+      = if (∃ a, a ^ n = g) then (univ.filter (fun x : α => x ^ n = 1)).card else 0 := by
+  by_cases h : ∃ a, a ^ n = g
+  · rw [if_pos h, card_pow_eq_eq_card_pow_one h]
+  · rw [if_neg h]
+    apply Finset.card_eq_zero.mpr
+    apply Finset.filter_false_of_mem
+    intro x _ hx
+    exact h ⟨x, hx⟩
+
+/-- **Explicit count in a cyclic group.** Combining the dichotomy with the
+parent's exact count `#{xⁿ = 1} = gcd(n, |G|)`, the number of solutions of
+`xⁿ = g` in a finite cyclic group is `gcd(n, |G|)` when `g` is an `n`-th power
+and `0` otherwise. In particular this value is independent of *which* `n`-th
+power `g` is. -/
+theorem card_pow_eq_cyclic [DecidableEq α] [Fintype α] [IsCyclic α] (n : ℕ) (g : α) :
+    (univ.filter (fun x => x ^ n = g)).card
+      = if (∃ a, a ^ n = g) then Nat.gcd n (Fintype.card α) else 0 := by
+  rw [card_pow_eq]
+  by_cases h : ∃ a, a ^ n = g
+  · rw [if_pos h, if_pos h,
+      CauchyGroupTheoremOQ01OQ01OQ01OQ01.card_pow_eq_one_eq_gcd]
+  · rw [if_neg h, if_neg h]
+
+/-- The identity `g = 1` is always an `n`-th power (`x = 1` works), so the
+cyclic count specialises back to the parent's `gcd(n, |G|)`. This confirms the
+new formula refines the old one. -/
+theorem card_pow_eq_cyclic_one [DecidableEq α] [Fintype α] [IsCyclic α] (n : ℕ) :
+    (univ.filter (fun x => x ^ n = (1 : α))).card = Nat.gcd n (Fintype.card α) := by
+  rw [card_pow_eq_cyclic, if_pos ⟨1, one_pow n⟩]
+
+/-- **Effective `n`-th power test (cyclic).** In a finite cyclic group of order
+`m`, an element `g` is an `n`-th power **iff** `g ^ (m / gcd(n, m)) = 1`. The
+`n`-th powers form the unique subgroup of order `m / gcd(n,m)`, namely the
+`(m/gcd(n,m))`-torsion subgroup; membership in it is exactly this power test.
+This turns the existential side condition of `card_pow_eq_cyclic` into a
+decidable computation. -/
+theorem isNthPower_iff [Fintype α] [IsCyclic α] {n : ℕ} {g : α} :
+    (∃ a, a ^ n = g) ↔ g ^ (Fintype.card α / Nat.gcd n (Fintype.card α)) = 1 := by
+  classical
+  set m := Fintype.card α with hm
+  set d := Nat.gcd n m with hd
+  have hcardα : Nat.card α = m := by rw [hm, Nat.card_eq_fintype_card]
+  have hmpos : 0 < m := Fintype.card_pos
+  have hdm : d ∣ m := Nat.gcd_dvd_right n m
+  have hdn : d ∣ n := Nat.gcd_dvd_left n m
+  set k := m / d with hk
+  have hkm : k ∣ m := Nat.div_dvd_of_dvd hdm
+  -- The image of `x ↦ xⁿ` is contained in the `k`-torsion: every `n`-th power
+  -- `aⁿ` satisfies `(aⁿ)ᵏ = a^(m·n') = 1`.
+  have hle : (powMonoidHom n : α →* α).range ≤ (powMonoidHom k : α →* α).ker := by
+    intro x hx
+    obtain ⟨a, rfl⟩ := MonoidHom.mem_range.mp hx
+    rw [MonoidHom.mem_ker]
+    simp only [powMonoidHom_apply]
+    rw [← pow_mul]
+    obtain ⟨n', hn'⟩ := hdn
+    have hnk : n * k = m * n' := by
+      rw [hn', hk, mul_comm d n', mul_assoc, Nat.mul_div_cancel' hdm, mul_comm]
+    exact orderOf_dvd_iff_pow_eq_one.mp (orderOf_dvd_card.trans ⟨n', hnk⟩)
+  -- Both subgroups have cardinality `k`, so the inclusion is an equality.
+  have hcr : Nat.card (powMonoidHom n : α →* α).range = k := by
+    rw [IsCyclic.card_powMonoidHom_range, hcardα, Nat.gcd_comm, ← hd, ← hk]
+  have hck : Nat.card (powMonoidHom k : α →* α).ker = k := by
+    rw [IsCyclic.card_powMonoidHom_ker, hcardα, Nat.gcd_eq_right hkm]
+  have hrange_eq : (powMonoidHom n : α →* α).range = (powMonoidHom k : α →* α).ker :=
+    Subgroup.eq_of_le_of_card_ge hle (le_of_eq (by rw [hck, hcr]))
+  -- Translate membership on both sides of the equality.
+  constructor
+  · rintro ⟨a, rfl⟩
+    have hmem : a ^ n ∈ (powMonoidHom n : α →* α).range :=
+      MonoidHom.mem_range.mpr ⟨a, powMonoidHom_apply n a⟩
+    have := hle hmem
+    rwa [MonoidHom.mem_ker, powMonoidHom_apply] at this
+  · intro hgk
+    have hmem : g ∈ (powMonoidHom k : α →* α).ker := by
+      rw [MonoidHom.mem_ker, powMonoidHom_apply]; exact hgk
+    rw [← hrange_eq] at hmem
+    obtain ⟨a, ha⟩ := MonoidHom.mem_range.mp hmem
+    exact ⟨a, by rw [← powMonoidHom_apply n a]; exact ha⟩
+
+/-- **Fully effective count (cyclic).** Combining the explicit value with the
+`n`-th power test: in a finite cyclic group of order `m`, the number of
+solutions of `xⁿ = g` is `gcd(n, m)` when `g ^ (m / gcd(n,m)) = 1`, and `0`
+otherwise — a condition that is directly checkable. -/
+theorem card_pow_eq_cyclic_effective [DecidableEq α] [Fintype α] [IsCyclic α]
+    (n : ℕ) (g : α) :
+    (univ.filter (fun x => x ^ n = g)).card
+      = if g ^ (Fintype.card α / Nat.gcd n (Fintype.card α)) = 1
+        then Nat.gcd n (Fintype.card α) else 0 := by
+  rw [card_pow_eq_cyclic]
+  by_cases h : g ^ (Fintype.card α / Nat.gcd n (Fintype.card α)) = 1
+  · rw [if_pos h, if_pos (isNthPower_iff.mpr h)]
+  · rw [if_neg h, if_neg (fun hex => h (isNthPower_iff.mp hex))]
+
+end CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 58 },
+    "type": "context",
+    "title": "From xⁿ = 1 to xⁿ = g: the Inhomogeneous Count",
+    "content": "The parent pins the homogeneous count #{xⁿ = 1} = gcd(n, |G|) on a cyclic group. This file answers the parent's own third open question: for a fixed g (not necessarily the identity), how many x satisfy xⁿ = g? The answer is a Boolean dichotomy — the count is either the homogeneous count or 0 — and in the cyclic case becomes gcd(n, |G|) or 0, with solvability decided by a single power test. The structural half is valid in every finite abelian group; only the explicit value uses cyclicity.",
+    "mathContext": "$$\\#\\{x : x^n = g\\} = \\begin{cases} \\gcd(n, |G|) & g \\text{ an } n\\text{-th power} \\\\ 0 & \\text{otherwise.}\\end{cases}$$",
+    "significance": "context",
+    "relatedConcepts": ["Frobenius divisibility theorem", "n-th power residues", "cosets of the power map kernel", "cyclic groups"],
+    "prerequisites": ["finite abelian groups", "order of an element", "homomorphisms and kernels"]
+  },
+  {
+    "id": "ann-coset-count",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 66, "endLine": 87 },
+    "type": "insight",
+    "title": "The Whole Generalisation Is One Coset Bijection",
+    "content": "In a finite abelian group the power map x ↦ xⁿ is a homomorphism, so the solutions of xⁿ = g form a coset of the kernel {x | xⁿ = 1} whenever they exist. Concretely, fixing one root a₀ (a₀ⁿ = g), left-translation x ↦ a₀⁻¹·x is a bijection onto {x | xⁿ = 1}: (a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ, which is 1 exactly when xⁿ = g. The formalization presents {x | xⁿ = g} as the image of {x | xⁿ = 1} under multiplication by a₀ and applies card_image_of_injective. The payoff: the number of n-th roots of g is the same for EVERY solvable g — it never depends on which g.",
+    "mathContext": "$x \\mapsto a_0^{-1}x$ bijects $\\{x : x^n = g\\}$ with $\\{x : x^n = 1\\}$ since $(a_0^{-1}x)^n = (a_0^n)^{-1}x^n = g^{-1}x^n$.",
+    "significance": "key",
+    "relatedConcepts": ["cosets", "fibres of a homomorphism", "orbit–stabiliser", "left translation"],
+    "prerequisites": ["mul_pow in commutative groups", "Finset.card_image_of_injective", "mul_left_cancel"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 89, "endLine": 101 },
+    "type": "technique",
+    "title": "A Boolean Dichotomy: 0 or the Full Count",
+    "content": "There is no intermediate possibility. If g is an n-th power, the count is #{x | xⁿ = 1}; if not, the solution Finset is empty by definition (no x even satisfies xⁿ = g), handled by filter_false_of_mem. The if-then-else packaging makes the dichotomy explicit and is what specialises cleanly to the cyclic value.",
+    "mathContext": "$\\#\\{x : x^n = g\\} = \\mathbf{1}[\\exists a, a^n = g]\\cdot \\#\\{x : x^n = 1\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["solvability", "empty fibres", "indicator of membership in the image"],
+    "prerequisites": ["Finset.filter_false_of_mem", "Finset.card_eq_zero"]
+  },
+  {
+    "id": "ann-effective-test",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 124, "endLine": 188 },
+    "type": "insight",
+    "title": "Deciding Solvability: the (m/gcd)-Torsion Test",
+    "content": "In a cyclic group of order m the n-th powers form the unique subgroup of order m/gcd(n,m), namely the (m/gcd(n,m))-torsion {x | x^(m/gcd(n,m)) = 1}. The proof identifies the image subgroup (powMonoidHom n).range with the kernel (powMonoidHom (m/d)).ker: the inclusion range ≤ ker holds because (aⁿ)^(m/d) = a^(m·n') = 1 when d ∣ n, and both subgroups have cardinality m/d by Mathlib's IsCyclic.card_powMonoidHom_range and card_powMonoidHom_ker, so Subgroup.eq_of_le_of_card_ge forces equality. Hence g is an n-th power iff g^(m/gcd(n,m)) = 1 — a decidable test that makes the entire count computable (card_pow_eq_cyclic_effective). Over a finite field's multiplicative group this is the classical n-th power residue criterion g^((q-1)/gcd(n,q-1)) = 1.",
+    "mathContext": "$g \\text{ is an } n\\text{-th power} \\iff g^{\\,m/\\gcd(n,m)} = 1,\\quad m = |G|.$",
+    "significance": "key",
+    "relatedConcepts": ["torsion subgroups", "unique subgroup of given order", "n-th power residues", "image of the power map"],
+    "prerequisites": ["IsCyclic.card_powMonoidHom_range", "IsCyclic.card_powMonoidHom_ker", "Subgroup.eq_of_le_of_card_ge"]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyGroupTheoremOq01Oq01Oq01Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyGroupTheoremOq01Oq01Oq01Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyGroupTheoremOq01Oq01Oq01Oq01Oq03Data: ProofData = {
+  proof: cauchyGroupTheoremOq01Oq01Oq01Oq01Oq03Proof,
+  annotations: cauchyGroupTheoremOq01Oq01Oq01Oq01Oq03Annotations,
+}

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+  "title": "Counting solutions of xⁿ = g: gcd(n, |G|) when g is an n-th power, else 0",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01"
+    ],
+    "opens": ["Finset"],
+    "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "description": "The inhomogeneous companion to the parent's count #{xⁿ = 1} = gcd(n, |G|): for a fixed, not-necessarily-identity target g, how many x satisfy xⁿ = g? The answer splits into a structural part valid in every finite abelian group and an explicit value in the cyclic case. Structural dichotomy: in a finite abelian group the power map x ↦ xⁿ is a homomorphism, so the solution set of xⁿ = g is either empty (g not an n-th power) or a single coset of the solution set of xⁿ = 1; cosets are equinumerous, so #{x | xⁿ = g} = #{x | xⁿ = 1} when g is an n-th power and 0 otherwise (card_pow_eq_eq_card_pow_one, card_pow_eq). The whole content is one bijection: left-translation x ↦ a₀⁻¹·x by a fixed n-th root a₀ of g carries {x | xⁿ = g} bijectively onto {x | xⁿ = 1}, since (a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ. Explicit value (cyclic): feeding the parent's count gives #{x | xⁿ = g} = gcd(n, |G|) if g is an n-th power, else 0 (card_pow_eq_cyclic), and this value does not depend on which n-th power g is. Effective test: in a cyclic group of order m the n-th powers form the unique subgroup of order m/gcd(n,m) — the (m/gcd(n,m))-torsion — so g is an n-th power iff g^(m/gcd(n,m)) = 1 (isNthPower_iff), turning the side condition into a decidable computation (card_pow_eq_cyclic_effective). Specialising g = 1 recovers the parent's gcd(n, |G|).",
+  "overview": {
+    "historicalContext": "Frobenius' 1895 theorem counts solutions of the homogeneous equation xⁿ = 1: in any finite group their number is divisible by gcd(n, |G|), with equality on the cyclic fibre (the parent entry). The natural next question — and the one the parent explicitly poses as its third open question — is the inhomogeneous equation xⁿ = g for a fixed g ≠ 1. Classically this is governed by whether g lies in the image of the n-th power map: the map x ↦ xⁿ on a finite abelian group is an endomorphism whose fibres are the cosets of its kernel {x | xⁿ = 1}, so every non-empty fibre has the same size. The count of n-th roots of a given element is thus either 0 or the number of n-th roots of unity — a clean instance of the orbit–stabiliser / first-isomorphism bookkeeping that pervades elementary abelian group theory and the theory of n-th power residues (the multiplicative group of a finite field being the prototypical cyclic case, where xⁿ = g asks whether g is an n-th power residue).",
+    "problemStatement": "For a fixed element g of a finite abelian (resp. cyclic) group G and a natural number n, determine exactly how many x satisfy xⁿ = g. Identify when the equation is solvable, show the count is independent of which solvable g is chosen, give the explicit value in the cyclic case, and reduce the solvability condition to an effective power test.",
+    "proofStrategy": "Work first in a finite abelian group. Fix a witness a₀ with a₀ⁿ = g (assuming g is an n-th power). The map x ↦ a₀⁻¹·x is a bijection from {x | xⁿ = g} to {x | xⁿ = 1}: in a commutative group (a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ, which is 1 exactly when xⁿ = g; its inverse is y ↦ a₀·y. Concretely the proof exhibits {x | xⁿ = g} as the Finset image of {x | xⁿ = 1} under left-multiplication by a₀ and applies card_image_of_injective (injectivity is mul_left_cancel). When g is not an n-th power the solution Finset is empty by definition (filter_false_of_mem). Combining gives the dichotomy card_pow_eq. Specialising to a cyclic group and substituting the parent's exact count card_pow_eq_one_eq_gcd yields card_pow_eq_cyclic. For the effective test isNthPower_iff, the image subgroup (powMonoidHom n).range is shown equal to the kernel (powMonoidHom (m/d)).ker, where m = |G|, d = gcd(n, m): the inclusion range ≤ ker holds because (aⁿ)^(m/d) = a^(m·n') = 1 (as d ∣ n), and both subgroups have cardinality m/d (Mathlib's IsCyclic.card_powMonoidHom_range and card_powMonoidHom_ker), so Subgroup.eq_of_le_of_card_ge forces equality; membership then reads g is an n-th power ⟺ g^(m/d) = 1.",
+    "keyInsights": [
+      "The entire generalisation from g = 1 to arbitrary g is one coset bijection. In a finite abelian group the n-th roots of g, when they exist, are a translate of the n-th roots of unity, so their number is the SAME for every solvable g — it never depends on which g.",
+      "Solvability is the only obstruction: #{x | xⁿ = g} ∈ {0, #{x | xⁿ = 1}}, a Boolean dichotomy. There is no intermediate count.",
+      "Commutativity is exactly what makes x ↦ xⁿ a homomorphism, hence what makes the solution set a coset; the bijection (a₀⁻¹·x)ⁿ = g⁻¹·xⁿ uses mul_pow, which requires the abelian hypothesis.",
+      "In the cyclic case the abstract condition 'g is an n-th power' becomes the decidable power test g^(|G|/gcd(n,|G|)) = 1: the n-th powers are precisely the (|G|/gcd(n,|G|))-torsion subgroup, the unique subgroup of that order.",
+      "This is the abelian shadow of Frobenius: the count of solutions of xⁿ = g is either 0 or a fixed constant gcd(n, |G|) determined by n and |G| alone, mirroring how the homogeneous count is pinned by the same gcd."
+    ]
+  },
+  "sections": [
+    {
+      "id": "coset-count",
+      "title": "The Coset Bijection",
+      "startLine": 66,
+      "endLine": 87,
+      "summary": "card_pow_eq_eq_card_pow_one: in a finite abelian group, if g is an n-th power then #{x | xⁿ = g} = #{x | xⁿ = 1}. The solution set is exhibited as the image of {x | xⁿ = 1} under left-multiplication by a fixed n-th root a₀ of g (forward: x = a₀·(a₀⁻¹x) with (a₀⁻¹x)ⁿ = 1; backward: (a₀y)ⁿ = a₀ⁿ·yⁿ = g). Left-multiplication is injective (mul_left_cancel), so card_image_of_injective gives equal cardinalities.",
+      "mathContext": "x ↦ a₀⁻¹·x is a bijection {x | xⁿ = g} → {x | xⁿ = 1}, because (a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Solvable/Unsolvable Dichotomy",
+      "startLine": 89,
+      "endLine": 101,
+      "summary": "card_pow_eq: the count of solutions of xⁿ = g equals #{x | xⁿ = 1} when g is an n-th power and 0 otherwise. The unsolvable branch is immediate — if no x has xⁿ = g the solution Finset is empty (filter_false_of_mem) — and the solvable branch is the coset bijection.",
+      "mathContext": "#{x | xⁿ = g} = if (∃ a, aⁿ = g) then #{x | xⁿ = 1} else 0."
+    },
+    {
+      "id": "cyclic-value",
+      "title": "The Explicit Cyclic Count",
+      "startLine": 103,
+      "endLine": 122,
+      "summary": "card_pow_eq_cyclic substitutes the parent's exact count #{xⁿ = 1} = gcd(n, |G|) into the dichotomy, giving #{x | xⁿ = g} = gcd(n, |G|) when g is an n-th power and 0 otherwise — a value independent of which n-th power g is. card_pow_eq_cyclic_one checks the g = 1 specialisation reproduces the parent's gcd(n, |G|).",
+      "mathContext": "On a finite cyclic group, #{x | xⁿ = g} = if (∃ a, aⁿ = g) then gcd(n, |G|) else 0."
+    },
+    {
+      "id": "effective-test",
+      "title": "The Effective n-th Power Test",
+      "startLine": 124,
+      "endLine": 188,
+      "summary": "isNthPower_iff: in a cyclic group of order m, g is an n-th power iff g^(m/gcd(n,m)) = 1. The image (powMonoidHom n).range is identified with the (m/gcd(n,m))-torsion (powMonoidHom (m/gcd(n,m))).ker — the inclusion holds since (aⁿ)^(m/d) = a^(m·n') = 1 (d ∣ n), and both subgroups have cardinality m/gcd(n,m) (IsCyclic.card_powMonoidHom_range/ker), so Subgroup.eq_of_le_of_card_ge yields equality. card_pow_eq_cyclic_effective then rephrases the cyclic count with the decidable condition g^(m/gcd(n,m)) = 1.",
+      "mathContext": "g is an n-th power ⟺ g^(m / gcd(n,m)) = 1, where m = |G|; the n-th powers are the unique subgroup of order m/gcd(n,m)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The inhomogeneous equation xⁿ = g has a clean count: in any finite abelian group its solution set is empty or a coset of the n-th roots of unity, so the number of solutions is 0 or #{x | xⁿ = 1}, never anything in between. On a cyclic group of order m this is gcd(n, m) when g is an n-th power and 0 otherwise, with solvability decided by the effective test g^(m/gcd(n,m)) = 1 (the n-th powers being exactly the (m/gcd(n,m))-torsion subgroup). Specialising g = 1 recovers the parent's homogeneous count, so this entry is its strict generalisation and directly answers the parent's stated open question on the inhomogeneous equation.",
+    "implications": [
+      "Generalises the parent's #{xⁿ = 1} = gcd(n, |G|) to arbitrary targets g, with the count for any solvable g equal to that of the homogeneous case — independent of which g.",
+      "Reduces solvability of xⁿ = g in a cyclic group to a single power test g^(|G|/gcd(n,|G|)) = 1, making the full count decidable.",
+      "Exhibits the abelian shadow of Frobenius' theorem for the inhomogeneous equation: a Boolean dichotomy 0 / gcd(n, |G|) governed only by whether g lies in the n-th power subgroup."
+    ],
+    "openQuestions": [
+      "What is the count of solutions of xⁿ = g in a general (non-abelian) finite group, where x ↦ xⁿ is no longer a homomorphism and the fibres need not be cosets — is there still a uniform bound or divisibility in terms of gcd(n, |G|) and the conjugacy class of g?",
+      "For the cyclic case, count the pairs (n, g) with a prescribed number of solutions, or invert the relation: given the multiset of fibre sizes of x ↦ xⁿ, recover n mod the relevant divisors of |G|."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Directly answers the parent's third open question (the inhomogeneous equation xⁿ = g). The parent counts the homogeneous case #{xⁿ = 1} = gcd(n, |G|); this entry shows every solvable inhomogeneous fibre is a coset of that solution set, hence has the same count, and specialising g = 1 (card_pow_eq_cyclic_one) reproduces the parent's value exactly."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The parent-of-parent's power-map dichotomy (x ↦ xⁿ bijective iff gcd(n, |G|) = 1) is the surjectivity/injectivity skeleton behind this count: here the fibres of x ↦ xⁿ are measured, and the map is a bijection exactly when every fibre has size 1, i.e. gcd(n, |G|) = 1."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (inhomogeneous root count xⁿ = g, abelian and cyclic)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "abelian-groups",
+      "cyclic-groups",
+      "solution-counting",
+      "cosets",
+      "power-map",
+      "frobenius-theorem",
+      "n-th-power-residues"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "(s.image f).card = s.card for injective f; turns the coset bijection (left-multiplication by a₀) into the cardinality equality #{xⁿ = g} = #{xⁿ = 1}.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "mul_pow",
+        "description": "(a·b)ⁿ = aⁿ·bⁿ in a commutative monoid; the abelian hypothesis that makes x ↦ xⁿ a homomorphism and the solution set a coset.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Finset.filter_false_of_mem",
+        "description": "If no element of s satisfies p then s.filter p = ∅; gives the empty solution set (count 0) when g is not an n-th power.",
+        "module": "Mathlib.Data.Finset.Filter"
+      },
+      {
+        "theorem": "CauchyGroupTheoremOQ01OQ01OQ01OQ01.card_pow_eq_one_eq_gcd",
+        "description": "The parent's exact homogeneous count #{a | aⁿ = 1} = gcd(n, |G|) on a cyclic group; substituted into the dichotomy to give the explicit cyclic value.",
+        "module": "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "IsCyclic.card_powMonoidHom_range",
+        "description": "Nat.card (powMonoidHom d).range = |G| / gcd(|G|, d) on a cyclic group; gives the order m/gcd(n,m) of the n-th power subgroup.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "IsCyclic.card_powMonoidHom_ker",
+        "description": "Nat.card (powMonoidHom d).ker = gcd(|G|, d) on a cyclic group; gives the order of the d-torsion subgroup, equal to m/gcd(n,m) when d = m/gcd(n,m).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "Subgroup.eq_of_le_of_card_ge",
+        "description": "H ≤ K and Nat.card K ≤ Nat.card H force H = K for finite subgroups; upgrades the inclusion range ≤ ker to the equality identifying the n-th powers with the torsion subgroup.",
+        "module": "Mathlib.Algebra.Group.Subgroup.Finite"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf a ∣ k ↔ aᵏ = 1; used to show (aⁿ)^(m/d) = 1, the inclusion of the n-th powers into the (m/d)-torsion.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Frobenius, Ferdinand Georg",
+        "title": "Verallgemeinerung des Sylow'schen Satzes",
+        "year": "1895",
+        "note": "Sitzungsberichte der Königlich Preußischen Akademie der Wissenschaften zu Berlin — the divisibility theorem for #{xⁿ = 1}; the inhomogeneous count here is its coset translate in the abelian case."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — fibres of the power map and coset structure of solution sets in abelian groups."
+      },
+      {
+        "authors": "Ireland, Kenneth; Rosen, Michael",
+        "title": "A Classical Introduction to Modern Number Theory",
+        "year": "1990",
+        "note": "Springer GTM 84 — n-th power residues: in the cyclic multiplicative group of a finite field, xⁿ = g is solvable iff g^((q-1)/gcd(n,q-1)) = 1, the field instance of isNthPower_iff."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **parent's own stated third open question**: the *inhomogeneous*
equation `xⁿ = g` for a fixed, not-necessarily-identity `g`. The parent
(`cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01`) counts the homogeneous case
`#{x | xⁿ = 1} = gcd(n, |G|)`; this entry extends it to arbitrary targets.

## Results (6 theorems, 188 lines, 0 sorries, 0 axioms)

**Structural — any finite abelian group:**
- `card_pow_eq_eq_card_pow_one` — if `g` is an `n`-th power then
  `#{x | xⁿ = g} = #{x | xⁿ = 1}`. The whole content is one bijection:
  left-translation `x ↦ a₀⁻¹·x` by a fixed root `a₀` carries the solution set
  onto the `n`-th roots of unity, since `(a₀⁻¹·x)ⁿ = (a₀ⁿ)⁻¹·xⁿ = g⁻¹·xⁿ`.
- `card_pow_eq` — the Boolean dichotomy: count is `#{xⁿ = 1}` if `g` is an
  `n`-th power, else `0`. No intermediate value.

**Explicit — cyclic groups:**
- `card_pow_eq_cyclic` — `#{x | xⁿ = g} = gcd(n, |G|)` if `g` is an `n`-th
  power, else `0` (substitutes the parent's count). Independent of *which*
  `n`-th power `g` is.
- `card_pow_eq_cyclic_one` — `g = 1` recovers the parent's `gcd(n, |G|)`.
- `isNthPower_iff` — **effective test**: `g` is an `n`-th power iff
  `g^(|G|/gcd(n,|G|)) = 1` (the `n`-th powers are the unique subgroup of that
  order — the `(|G|/gcd(n,|G|))`-torsion). Over a finite field this is the
  classical `n`-th power residue criterion.
- `card_pow_eq_cyclic_effective` — the full count with the *decidable*
  condition `g^(|G|/gcd(n,|G|)) = 1`.

## Verification

- `#print axioms` on all results: only `propext`, `Classical.choice`,
  `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **0-axiom, verified**.
- Reuses parent `card_pow_eq_one_eq_gcd`; Mathlib infra
  `Finset.card_image_of_injective`, `IsCyclic.card_powMonoidHom_range/ker`,
  `Subgroup.eq_of_le_of_card_ge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)