### PR TITLE
Enrich Base-b Divisibility Osculators: add annotations.json

### DIFF
--- a/src/data/proofs/divisibility-truncation-general-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-03-oq-01/annotations.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "ann-dtg-overview",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "Statement and Strategy — Osculators in an Arbitrary Radix",
+    "content": "The module docstring fixes the goal and answers OQ-01 of the parent. A truncation divisibility test replaces n by ⌊n/b⌋ + c·(n mod b), where the 'osculator' c is a modular inverse of the radix b modulo d (d | b·c − 1). The parent established this for base 10 with c = gcdA(10,d); here the radix b becomes a free parameter. Nothing in the construction is special to ten: the digit split n = b·⌊n/b⌋ + (n mod b) holds in every radix, and the divisibility transfer needs only gcd(b,d)=1. The seven results below build the radix-free test, show Bézout supplies an osculator, prove uniqueness mod d and existence of a canonical representative in [0,d), produce concrete base-100 and base-16 tests, and confirm b=10 recovers the parent.",
+    "mathContext": "$d \\mid n \\iff d \\mid \\left(\\lfloor n/b\\rfloor + c\\,(n \\bmod b)\\right),\\quad d \\mid b c - 1,\\ \\gcd(b,d)=1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular inverse",
+      "divisibility rules",
+      "radix / positional notation",
+      "Bézout's identity"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "the Euclidean algorithm",
+      "positional number systems"
+    ]
+  },
+  {
+    "id": "ann-dtg-unified",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "unified_osculator_base — The Radix-Free Divisibility Test",
+    "content": "The core theorem. IsOsculatorBase b d c is defined as d | b·c − 1. The digit split div_mod_cast_base casts the ℕ identity Nat.div_add_mod directly to ℤ (avoiding the pitfall that push_cast would turn ↑(n/b) into the unrelated ↑n/↑b). The proof then hinges on the single algebraic identity b·(⌊n/b⌋ + c·(n mod b)) = n + (b·c − 1)·(n mod b), obtained by linear_combination from the digit split. Since d | (b·c − 1), the right side is ≡ n (mod d); coprimality of d and b lets divisibility pass across the factor b in both directions via IsCoprime.dvd_of_dvd_mul_left, giving the iff d | n ↔ d | (⌊n/b⌋ + c·(n mod b)).",
+    "mathContext": "$b\\!\\left(\\lfloor n/b\\rfloor + c(n\\bmod b)\\right) = n + (bc-1)(n\\bmod b)$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "coprimality transfer of divisibility",
+      "linear_combination identity",
+      "base-b digit split"
+    ],
+    "prerequisites": [
+      "Nat.div_add_mod",
+      "IsCoprime.dvd_of_dvd_mul_left",
+      "dvd_add / dvd_mul_of_dvd_left"
+    ]
+  },
+  {
+    "id": "ann-dtg-bezout",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 108
+    },
+    "type": "technique",
+    "title": "Bézout Coefficients Give Osculators",
+    "content": "Identifies the canonical osculator. bezout_base restates Mathlib's Nat.gcd_eq_gcd_ab: gcd(b,d) = b·gcdA(b,d) + d·gcdB(b,d). When gcd(b,d)=1 this rearranges (linear_combination) to d | b·gcdA(b,d) − 1, so gcdA(b,d) is a valid osculator (bezout_gives_osculator_base). canonical_divisibility_test_base then chains this into unified_osculator_base to give the end-to-end test using the explicitly computable Bézout coefficient — the modular-inverse-as-Bézout-coefficient correspondence, now radix-independent.",
+    "mathContext": "$1 = b\\,\\mathrm{gcdA}(b,d) + d\\,\\mathrm{gcdB}(b,d) \\Rightarrow d \\mid b\\,\\mathrm{gcdA}(b,d) - 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "modular inverse via extended Euclid",
+      "Nat.gcdA / Nat.gcdB"
+    ],
+    "prerequisites": [
+      "Nat.gcd_eq_gcd_ab",
+      "Nat.Coprime",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-dtg-unique",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 130
+    },
+    "type": "theorem",
+    "title": "Osculators Form a Single Class mod d",
+    "content": "Pins down the structure of the osculator set. osculator_base_congr shows the osculator property is invariant under c ↦ c' whenever c' ≡ c (mod d), via the identity b·c' − 1 = (b·c − 1) + b·(c' − c). osculator_base_unique_mod is the converse direction: for any two osculators c, c', the difference satisfies d | b·(c − c') (subtracting the two defining relations), and coprimality of b and d strips the factor b to give d | c − c'. Together: the osculators of d in base b are exactly one residue class mod d.",
+    "mathContext": "$c,c' \\text{ osculators} \\Rightarrow d \\mid c - c';\\quad c' \\equiv c \\pmod d \\Rightarrow c' \\text{ osculator}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "residue classes",
+      "uniqueness of modular inverse",
+      "coprimality cancellation"
+    ],
+    "prerequisites": [
+      "dvd_sub / dvd_add",
+      "IsCoprime.dvd_of_dvd_mul_left"
+    ]
+  },
+  {
+    "id": "ann-dtg-canonical",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 136,
+      "endLine": 159
+    },
+    "type": "technique",
+    "title": "The Canonical Osculator in [0, d)",
+    "content": "Produces a canonical natural-number representative. osculator_base_mod shows gcdA(b,d) % d is still an osculator (reducing mod d changes c by a multiple of d, harmless by osculator_base_congr). osculator_base_exists then reduces c₀ = gcdA(b,d) % d, uses Int.emod_nonneg and Int.emod_lt_of_pos to place it in [0,d), and converts to ℕ with Int.toNat_of_nonneg — yielding a unique canonical osculator c with c < d for every d > 1 coprime to b.",
+    "mathContext": "$\\exists!\\, c \\in [0,d) \\cap \\mathbb{N},\\ d \\mid bc - 1,\\quad c = \\mathrm{gcdA}(b,d) \\bmod d$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "canonical residue representative",
+      "Int.toNat conversion",
+      "reduction modulo d"
+    ],
+    "prerequisites": [
+      "Int.emod_nonneg, Int.emod_lt_of_pos",
+      "Int.toNat_of_nonneg",
+      "osculator_base_congr (above)"
+    ]
+  },
+  {
+    "id": "ann-dtg-base100",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 165,
+      "endLine": 204
+    },
+    "type": "context",
+    "title": "Base-100 Tests — Decimal Digit-Pairs for 7, 11, 13, 101",
+    "content": "Specializes the general theorem to base 100, recovering the classical 'group decimal digits in pairs' divisibility tests. Each osculator is checked by norm_num: 7 has c = 4 (100·4 − 1 = 399 = 7·57); 11 has c = 1 (99 = 11·9), so the test sums digit-pairs; 13 has c = 3 (299 = 13·23); 101 has c = −1 (since 101 = 10²+1), giving the alternating digit-pair rule. Each divisibility corollary is a one-line application of unified_osculator_base, with coprimality discharged by norm_num [Int.isCoprime_iff_gcd_eq_one].",
+    "mathContext": "$7\\mid n \\iff 7 \\mid (\\lfloor n/100\\rfloor + 4(n\\bmod 100));\\ \\ 101\\mid n \\iff 101\\mid(\\lfloor n/100\\rfloor - (n\\bmod 100))$",
+    "significance": "context",
+    "relatedConcepts": [
+      "digit-pair divisibility rules",
+      "alternating-sum tests",
+      "classical base-10 mnemonics"
+    ],
+    "prerequisites": [
+      "unified_osculator_base (above)",
+      "Int.isCoprime_iff_gcd_eq_one"
+    ]
+  },
+  {
+    "id": "ann-dtg-base16",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 210,
+      "endLine": 239
+    },
+    "type": "context",
+    "title": "Base-16 Tests — Hexadecimal Digit-Sum and Alternating Rules",
+    "content": "Specializes to hexadecimal. Because 16 ≡ 1 (mod 3) and 16 ≡ 1 (mod 5), the osculator is c = 1 for both 3 and 5 (16·1 − 1 = 15 = 3·5), so divisibility by 3 or 5 is a hexadecimal digit-sum test. Since 17 = 16 + 1, the osculator is c = −1, giving the alternating hex-digit rule for 17. These illustrate the meta-pattern that b ≡ ±1 (mod d) yields the simplest (digit-sum / alternating) osculators — the same reason base 100 is natural for 7, 11, 13, 101.",
+    "mathContext": "$3\\mid n \\iff 3\\mid(\\lfloor n/16\\rfloor + (n\\bmod 16));\\ \\ 17\\mid n \\iff 17\\mid(\\lfloor n/16\\rfloor - (n\\bmod 16))$",
+    "significance": "context",
+    "relatedConcepts": [
+      "hexadecimal divisibility",
+      "digit-sum tests",
+      "b ≡ ±1 mod d simplest osculators"
+    ],
+    "prerequisites": [
+      "unified_osculator_base (above)",
+      "Int.isCoprime_iff_gcd_eq_one"
+    ]
+  },
+  {
+    "id": "ann-dtg-recovers",
+    "proofId": "divisibility-truncation-general-oq-03-oq-01",
+    "range": {
+      "startLine": 245,
+      "endLine": 257
+    },
+    "type": "insight",
+    "title": "recovers_base_ten — The Parent is the b = 10 Slice",
+    "content": "Makes the generalization auditable. recovers_base_ten is simply canonical_divisibility_test_base instantiated at b = 10, reproducing the parent's canonical base-10 divisibility test verbatim. This exhibits the entire base-10 osculator theory as the single specialization b = 10 of the radix-free statement, so the new theorem strictly subsumes the old one rather than merely resembling it. The closing #check commands confirm the four headline results typecheck with the stated signatures.",
+    "mathContext": "$\\mathrm{recovers\\_base\\_ten} = \\mathrm{canonical\\_divisibility\\_test\\_base}\\big|_{b=10}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization recovers parent",
+      "subsumption of a known result",
+      "auditability of a generalization"
+    ],
+    "prerequisites": [
+      "canonical_divisibility_test_base (above)"
+    ]
+  }
+]


### PR DESCRIPTION
## Enrichment pass for `divisibility-truncation-general-oq-03-oq-01`

Adds `annotations.json` (8 annotations) — this entry had a rich meta.json but no inline annotations. Covers the module docstring, `unified_osculator_base` (radix-free test), Bézout-gives-osculator, uniqueness mod d, the canonical osculator in [0,d), the base-100 decimal digit-pair tests (7, 11, 13, 101), the base-16 hexadecimal tests (3, 5, 17), and the b=10 recovery of the parent. Each carries mathContext (LaTeX), significance, relatedConcepts, prerequisites.

Verified: `annotations:build` clean (all 8 ranges anchor to Lean constructs); JSON validated. Data-only change.

No changes to status/badge/axiomCount: meta already accurately reports verified/original/0-axiom, consistent with the Lean source.