### PR TITLE
research(arsinh improper integral): ∫_1^b 1/√(t²−1) dt = arcosh b [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -242,6 +242,7 @@ import Proofs.ArsinhLogFormulaOQ01
 import Proofs.ArsinhLogFormulaOQ01OQ01
 import Proofs.ArsinhLogFormulaOQ01OQ01OQ01
 import Proofs.ArsinhLogFormulaOQ01OQ02OQ01
+import Proofs.ArsinhLogFormulaOQ01OQ02OQ01OQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02

--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,238 @@
+/-
+# The improper integral `∫_1^b 1/√(t² − 1) dt = arcosh b`
+
+Research: arsinh-log-formula-oq-01-oq-02-oq-01-oq-01
+Parent:   arsinh-log-formula-oq-01-oq-02-oq-01 (the `arcosh` antiderivative / FTC capstone)
+
+The parent entry proved the *proper* Fundamental Theorem of Calculus evaluation
+
+    ∫_a^b 1/√(t² − 1) dt = arcosh b − arcosh a      (1 < a, 1 < b),
+
+valid on any closed interval `[a, b] ⊂ (1, ∞)` where the integrand is continuous.
+It left open the natural endpoint question: the integrand has a singularity at
+`t = 1` (the radicand `t² − 1` vanishes), yet the area underneath remains finite.
+Can the FTC evaluation be pushed *down to the singularity* to obtain the improper
+integral `∫_1^b 1/√(t² − 1) dt = arcosh b`?
+
+This file answers that question two complementary ways.
+
+* **Genuine (Lebesgue) improper integral.**  The singularity at `t = 1` is
+  *integrable*: near `t = 1` we have `1/√(t² − 1) ≤ 1/√(t − 1)`, an inverse
+  square-root singularity, which is integrable.  We prove
+  `intervalIntegrable_one` — interval-integrability of `t ↦ 1/√(t² − 1)` on the
+  *closed* interval `[1, b]` across the singular endpoint — by domination against
+  the integrable model `t ↦ (t − 1)^(−1/2)`.  The FTC variant
+  `intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le`, which only requires
+  continuity at the endpoints plus differentiability on the open interior, then
+  yields `improper_integral_eq_arcosh`:
+
+      ∫_1^b 1/√(t² − 1) dt = arcosh b      (1 < b),
+
+  using `arcosh 1 = 0`.
+
+* **Improper integral as a limit.**  We also record the classical
+  limit form `integral_tendsto_arcosh`:
+
+      ∫_a^b 1/√(t² − 1) dt → arcosh b   as   a → 1⁺,
+
+  obtained directly from the parent closed form `arcosh b − arcosh a` and the
+  right-continuity of `arcosh` at `1`.  This is the precise sense in which the
+  lower limit is "taken to the singularity".
+
+Supporting infrastructure (`hasDerivAt_arcosh`, the proper FTC, …) is reproved
+here so the file is self-contained.  The new content over the parent is:
+right-continuity of `arcosh` at `1`, the integrability of the singular integrand
+across the endpoint, and the two improper-integral statements.  All results are
+`0`-axiom and machine-checked.
+-/
+import Mathlib
+
+namespace ArsinhLogFormulaOQ01OQ02OQ01OQ01
+
+open Real intervalIntegral MeasureTheory Filter Set
+
+/-! ### Reproved parent infrastructure -/
+
+/-- For `t > 1` the radicand `t² − 1` is strictly positive, hence `√(t² − 1) > 0`. -/
+theorem sqrt_sq_sub_one_pos {x : ℝ} (hx : 1 < x) : 0 < Real.sqrt (x ^ 2 - 1) :=
+  Real.sqrt_pos.mpr (by nlinarith)
+
+/-- **Antiderivative fact.** `arcosh` is an antiderivative of `1/√(t² − 1)` on
+`(1, ∞)`: `HasDerivAt Real.arcosh (1/√(t² − 1)) t` for `t > 1`.  Built from the
+logarithmic form `arcosh t = log(t + √(t² − 1))` by the chain rule. -/
+theorem hasDerivAt_arcosh {x : ℝ} (hx : 1 < x) :
+    HasDerivAt Real.arcosh (1 / Real.sqrt (x ^ 2 - 1)) x := by
+  have hpos : (0 : ℝ) < x ^ 2 - 1 := by nlinarith
+  have hs : (0 : ℝ) < Real.sqrt (x ^ 2 - 1) := Real.sqrt_pos.mpr hpos
+  have hg : (0 : ℝ) < x + Real.sqrt (x ^ 2 - 1) := by linarith [hs]
+  have h1 : HasDerivAt (fun y : ℝ => y ^ 2 - 1) (2 * x) x := by
+    simpa using (hasDerivAt_pow 2 x).sub_const 1
+  have h2 : HasDerivAt (fun y : ℝ => Real.sqrt (y ^ 2 - 1))
+      (2 * x / (2 * Real.sqrt (x ^ 2 - 1))) x := h1.sqrt hpos.ne'
+  have h3 : HasDerivAt (fun y : ℝ => y + Real.sqrt (y ^ 2 - 1))
+      (1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) x := (hasDerivAt_id x).add h2
+  have h4 : HasDerivAt (fun y : ℝ => Real.log (y + Real.sqrt (y ^ 2 - 1)))
+      ((1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) / (x + Real.sqrt (x ^ 2 - 1))) x :=
+    h3.log hg.ne'
+  have hval : (1 + 2 * x / (2 * Real.sqrt (x ^ 2 - 1))) / (x + Real.sqrt (x ^ 2 - 1))
+      = 1 / Real.sqrt (x ^ 2 - 1) := by
+    field_simp
+    ring
+  rw [hval] at h4
+  exact h4
+
+/-- On any interval `[a, b] ⊂ (1, ∞)` the integrand `t ↦ 1/√(t² − 1)` is
+continuous (the denominator stays strictly positive). -/
+theorem continuousOn_integrand {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    ContinuousOn (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1)) (Set.uIcc a b) := by
+  apply ContinuousOn.div continuousOn_const
+  · exact (Real.continuous_sqrt.comp (by continuity)).continuousOn
+  · intro t ht
+    have h1t : 1 < t := by
+      rcases Set.mem_uIcc.mp ht with ⟨h, _⟩ | ⟨h, _⟩ <;> linarith
+    exact (sqrt_sq_sub_one_pos h1t).ne'
+
+/-- Consequently the integrand is interval-integrable on `[a, b] ⊂ (1, ∞)`. -/
+theorem intervalIntegrable_integrand {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    IntervalIntegrable (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1)) volume a b :=
+  (continuousOn_integrand ha hb).intervalIntegrable
+
+/-- **Proper FTC (parent result).** `∫_a^b 1/√(t² − 1) dt = arcosh b − arcosh a`
+for `1 < a, b`. -/
+theorem integral_one_div_sqrt_sq_sub_one {a b : ℝ} (ha : 1 < a) (hb : 1 < b) :
+    ∫ t in a..b, 1 / Real.sqrt (t ^ 2 - 1) = Real.arcosh b - Real.arcosh a := by
+  apply intervalIntegral.integral_eq_sub_of_hasDerivAt
+  · intro x hx
+    have h1x : 1 < x := by
+      rcases Set.mem_uIcc.mp hx with ⟨h, _⟩ | ⟨h, _⟩ <;> linarith
+    exact hasDerivAt_arcosh h1x
+  · exact intervalIntegrable_integrand ha hb
+
+/-! ### New content: continuity of `arcosh` at the singular endpoint -/
+
+/-- `arcosh` is continuous on the closed ray `[1, ∞)`, including the endpoint `1`
+where the derivative blows up.  Since `arcosh x = log(x + √(x² − 1))` and the
+argument `x + √(x² − 1) ≥ 1 > 0` on `[1, ∞)`, the logarithm composes
+continuously. -/
+theorem continuousOn_arcosh : ContinuousOn Real.arcosh (Set.Ici 1) := by
+  have hcont : ContinuousOn (fun x : ℝ => Real.log (x + Real.sqrt (x ^ 2 - 1)))
+      (Set.Ici 1) := by
+    apply ContinuousOn.log
+    · exact (continuous_id.add (Real.continuous_sqrt.comp (by continuity))).continuousOn
+    · intro x hx
+      have hx1 : (1 : ℝ) ≤ x := hx
+      have hs : 0 ≤ Real.sqrt (x ^ 2 - 1) := Real.sqrt_nonneg _
+      have : (0 : ℝ) < x + Real.sqrt (x ^ 2 - 1) := by linarith
+      exact this.ne'
+  exact hcont
+
+/-! ### New content: integrability across the singularity -/
+
+/-- The model singular function `t ↦ (t − 1)^(−1/2)` is interval-integrable on
+`[1, b]`: it is the shift by `1` of `x ↦ x^(−1/2)`, integrable across `0` because
+the exponent `−1/2 > −1`. -/
+theorem intervalIntegrable_model (b : ℝ) :
+    IntervalIntegrable (fun t : ℝ => (t - 1) ^ (-(1 / (2 : ℝ)))) volume 1 b := by
+  have h : IntervalIntegrable (fun x : ℝ => x ^ (-(1 / (2 : ℝ)))) volume 0 (b - 1) :=
+    intervalIntegral.intervalIntegrable_rpow' (by norm_num)
+  have hshift := h.comp_sub_right 1
+  simpa using hshift
+
+/-- **Integrability across the singular endpoint.**  The integrand `t ↦ 1/√(t² − 1)`
+is interval-integrable on the *closed* interval `[1, b]` (for `1 < b`), even though
+it is unbounded near `t = 1`.  Proof: dominate by the integrable model
+`t ↦ (t − 1)^(−1/2)`, using `1/√(t² − 1) ≤ 1/√(t − 1) = (t − 1)^(−1/2)` on `(1, b]`. -/
+theorem intervalIntegrable_one {b : ℝ} (hb : 1 < b) :
+    IntervalIntegrable (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1)) volume 1 b := by
+  -- the dominating model function is integrable
+  have hmodel := intervalIntegrable_model b
+  -- the integrand is a.e.-strongly-measurable on the restricted measure
+  have hmeas : AEStronglyMeasurable (fun t : ℝ => 1 / Real.sqrt (t ^ 2 - 1))
+      (volume.restrict (Set.uIoc 1 b)) := by
+    apply ContinuousOn.aestronglyMeasurable _ measurableSet_uIoc
+    apply ContinuousOn.div continuousOn_const
+    · exact (Real.continuous_sqrt.comp (by continuity)).continuousOn
+    · intro t ht
+      have h1t : 1 < t := (Set.mem_uIoc.mp ht).elim (fun h => h.1) (fun h => by
+        rw [uIoc_of_le hb.le] at ht; exact (Set.mem_Ioc.mp ht).1)
+      exact (sqrt_sq_sub_one_pos h1t).ne'
+  -- the pointwise domination, holding on all of `Ι 1 b = Ioc 1 b`
+  refine hmodel.mono_fun' hmeas ?_
+  rw [uIoc_of_le hb.le]
+  refine (ae_restrict_iff' measurableSet_Ioc).2 (Filter.Eventually.of_forall ?_)
+  intro t ht
+  have h1t : 1 < t := (Set.mem_Ioc.mp ht).1
+  have hu : (0 : ℝ) < t - 1 := by linarith
+  -- rewrite the model value as `1/√(t − 1)`
+  have hmodel_eq : (t - 1) ^ (-(1 / (2 : ℝ))) = 1 / Real.sqrt (t - 1) := by
+    rw [Real.rpow_neg hu.le, ← Real.sqrt_eq_rpow, one_div]
+  show ‖1 / Real.sqrt (t ^ 2 - 1)‖ ≤ (t - 1) ^ (-(1 / (2 : ℝ)))
+  rw [hmodel_eq]
+  -- `‖1/√(t²−1)‖ = 1/√(t²−1)` (it is nonnegative)
+  have hpos2 : 0 < Real.sqrt (t ^ 2 - 1) := sqrt_sq_sub_one_pos h1t
+  have hnn : (0 : ℝ) ≤ 1 / Real.sqrt (t ^ 2 - 1) := by positivity
+  rw [Real.norm_eq_abs, abs_of_nonneg hnn]
+  -- `√(t−1) ≤ √(t²−1)`, hence `1/√(t²−1) ≤ 1/√(t−1)`
+  have hposu : 0 < Real.sqrt (t - 1) := Real.sqrt_pos.mpr hu
+  have hle : Real.sqrt (t - 1) ≤ Real.sqrt (t ^ 2 - 1) :=
+    Real.sqrt_le_sqrt (by nlinarith)
+  exact one_div_le_one_div_of_le hposu hle
+
+/-! ### Main results: the improper integral -/
+
+/-- **The improper integral.**  `∫_1^b 1/√(t² − 1) dt = arcosh b` for `1 < b`.
+
+The integrand is integrable across the singularity at the lower endpoint `t = 1`
+(`intervalIntegrable_one`); `arcosh` is continuous on `[1, b]`
+(`continuousOn_arcosh`) and differentiable on `(1, b)` with derivative the
+integrand (`hasDerivAt_arcosh`).  The endpoint-aware FTC
+`integral_eq_sub_of_hasDeriv_right_of_le` then evaluates the integral to
+`arcosh b − arcosh 1 = arcosh b`, using `arcosh 1 = 0`. -/
+theorem improper_integral_eq_arcosh {b : ℝ} (hb : 1 < b) :
+    ∫ t in (1 : ℝ)..b, 1 / Real.sqrt (t ^ 2 - 1) = Real.arcosh b := by
+  have key : ∫ t in (1 : ℝ)..b, 1 / Real.sqrt (t ^ 2 - 1)
+      = Real.arcosh b - Real.arcosh 1 := by
+    apply integral_eq_sub_of_hasDeriv_right_of_le hb.le
+    · exact continuousOn_arcosh.mono (by
+        intro x hx; exact (Set.mem_Icc.mp hx).1)
+    · intro x hx
+      have h1x : 1 < x := (Set.mem_Ioo.mp hx).1
+      exact (hasDerivAt_arcosh h1x).hasDerivWithinAt
+    · exact intervalIntegrable_one hb
+  rw [key, Real.arcosh_zero, sub_zero]
+
+/-- **The improper integral as a limit.**  `∫_a^b 1/√(t² − 1) dt → arcosh b` as
+`a → 1⁺`.  This is the classical "improper integral" reading: the lower limit is
+driven to the singularity.  It follows from the proper FTC closed form
+`arcosh b − arcosh a` and the right-continuity of `arcosh` at `1`. -/
+theorem integral_tendsto_arcosh {b : ℝ} (hb : 1 < b) :
+    Tendsto (fun a => ∫ t in a..b, 1 / Real.sqrt (t ^ 2 - 1))
+      (nhdsWithin 1 (Set.Ioi 1)) (nhds (Real.arcosh b)) := by
+  -- eventually (for `a > 1`) the integral equals `arcosh b − arcosh a`
+  have hev : (fun a => ∫ t in a..b, 1 / Real.sqrt (t ^ 2 - 1))
+      =ᶠ[nhdsWithin 1 (Set.Ioi 1)] (fun a => Real.arcosh b - Real.arcosh a) := by
+    filter_upwards [self_mem_nhdsWithin] with a ha
+    exact integral_one_div_sqrt_sq_sub_one (Set.mem_Ioi.mp ha) hb
+  rw [tendsto_congr' hev]
+  -- `arcosh a → arcosh 1 = 0` as `a → 1⁺`
+  have harc : Tendsto Real.arcosh (nhdsWithin 1 (Set.Ioi 1)) (nhds (Real.arcosh 1)) :=
+    (continuousOn_arcosh.continuousWithinAt Set.left_mem_Ici).mono_left
+      (nhdsWithin_mono 1 Set.Ioi_subset_Ici_self)
+  have hlim := harc.const_sub (Real.arcosh b)
+  rw [Real.arcosh_zero] at hlim
+  simpa using hlim
+
+/-! ### Concrete corollary -/
+
+/-- **Concrete improper evaluation.**  `∫_1^{5/3} 1/√(t² − 1) dt = log 3`, since
+`arcosh (5/3) = log 3` (the radicand at `5/3` is `(4/3)²`). -/
+theorem improper_integral_one_to_five_thirds :
+    ∫ t in (1 : ℝ)..(5 / 3), 1 / Real.sqrt (t ^ 2 - 1) = Real.log 3 := by
+  rw [improper_integral_eq_arcosh (by norm_num)]
+  have h : Real.sqrt ((5 / 3 : ℝ) ^ 2 - 1) = 4 / 3 := by
+    rw [show ((5 / 3 : ℝ) ^ 2 - 1) = (4 / 3) ^ 2 by norm_num]
+    exact Real.sqrt_sq (by norm_num)
+  show Real.log ((5 / 3 : ℝ) + Real.sqrt ((5 / 3) ^ 2 - 1)) = Real.log 3
+  rw [h, show (5 / 3 + 4 / 3 : ℝ) = 3 by norm_num]
+
+end ArsinhLogFormulaOQ01OQ02OQ01OQ01

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,212 @@
+{
+  "id": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+  "slug": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+  "description": "The improper integral ∫_1^b 1/√(t²−1) dt = arcosh b for 1 < b, pushing the parent's proper FTC evaluation (∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a) down to the singular endpoint t = 1. Answered two complementary ways. (1) Genuine Lebesgue improper integral: the singularity is integrable because 1/√(t²−1) ≤ 1/√(t−1) = (t−1)^(−1/2) on (1,b], an inverse square-root singularity dominated by the integrable rpow model; interval-integrability across the CLOSED interval [1,b] is then established (intervalIntegrable_one) and the endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le — which needs only continuity at the endpoints plus differentiability on the open interior — evaluates the integral to arcosh b − arcosh 1 = arcosh b, using arcosh 1 = 0. (2) Improper integral as a limit: ∫_a^b 1/√(t²−1) dt → arcosh b as a → 1⁺, from the parent closed form and the right-continuity of arcosh at 1 (continuousOn_arcosh, proved here since Mathlib's Arcosh file has no continuity lemma). Concrete corollary ∫_1^{5/3} 1/√(t²−1) dt = log 3. Verified, 0 axioms, 0 sorries, 11 theorems.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory",
+      "Filter",
+      "Set"
+    ],
+    "namespace": "ArsinhLogFormulaOQ01OQ02OQ01OQ01",
+    "lineCount": 238,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Improper Integral ∫_1^b 1/√(t²−1) dt = arcosh b",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "improper-integral",
+      "special-functions",
+      "hyperbolic-functions",
+      "inverse-hyperbolic",
+      "arcosh",
+      "fundamental-theorem-of-calculus",
+      "integrable-singularity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 238,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "improper_integral_eq_arcosh: the headline improper-integral evaluation ∫_1^b 1/√(t²−1) dt = arcosh b for 1 < b, proved as a genuine (Lebesgue) interval integral over the CLOSED interval [1,b] across the singular endpoint t = 1 — strictly stronger than the parent's proper FTC, which is confined to [a,b] ⊂ (1,∞). It is obtained from the endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le together with arcosh 1 = 0.",
+      "intervalIntegrable_one: interval-integrability of the unbounded integrand t ↦ 1/√(t²−1) on the closed interval [1,b], the technical crux. Proved by dominated comparison (IntervalIntegrable.mono_fun') against the integrable model t ↦ (t−1)^(−1/2), using the pointwise bound 1/√(t²−1) ≤ 1/√(t−1) = (t−1)^(−1/2) valid on (1,b] (since √(t²−1) ≥ √(t−1)).",
+      "intervalIntegrable_model: the model inverse-square-root singularity t ↦ (t−1)^(−1/2) is interval-integrable on [1,b], obtained as the unit shift of x ↦ x^(−1/2) (interval-integrable across 0 because the exponent −1/2 > −1) via IntervalIntegrable.comp_sub_right and intervalIntegrable_rpow'.",
+      "continuousOn_arcosh: Real.arcosh is continuous on the closed ray [1,∞), INCLUDING the endpoint 1 where its derivative blows up. Mathlib's Arcosh file records monotonicity and the inverse facts but no continuity lemma; this is built from the logarithmic form log(x + √(x²−1)), whose argument stays ≥ 1 > 0 on [1,∞).",
+      "integral_tendsto_arcosh: the classical improper-integral-as-a-limit statement ∫_a^b 1/√(t²−1) dt → arcosh b as a → 1⁺, from the parent closed form arcosh b − arcosh a and the right-continuity of arcosh at 1. This makes precise the sense in which the lower limit is driven to the singularity.",
+      "improper_integral_one_to_five_thirds: the concrete improper evaluation ∫_1^{5/3} 1/√(t²−1) dt = log 3, since arcosh(5/3) = log 3 (the radicand at 5/3 is (4/3)²)."
+    ],
+    "prerequisites": [
+      "Mathlib's definition Real.arcosh x = log(x + √(x² − 1)) and the value arcosh 1 = 0 (Real.arcosh_zero)",
+      "The endpoint-aware Fundamental Theorem of Calculus intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le (continuity on [a,b], derivative on (a,b), integrability of the derivative)",
+      "Interval-integrability of power singularities: intervalIntegral.intervalIntegrable_rpow' (x^r integrable for r > −1) and the translation IntervalIntegrable.comp_sub_right",
+      "Dominated comparison for interval integrals IntervalIntegrable.mono_fun', and ContinuousOn.aestronglyMeasurable for the measurability side condition"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le",
+        "description": "The endpoint-aware FTC: if F is continuous on [a,b], differentiable on the open interval (a,b) with derivative f', and f' is interval-integrable, then ∫_a^b f' = F b − F a. The key tool that allows evaluating the integral down to the singular endpoint, where the ordinary FTC (which needs differentiability on the closed interval) fails.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus"
+      },
+      {
+        "theorem": "intervalIntegral.intervalIntegrable_rpow'",
+        "description": "For r > −1, x ↦ x^r is interval-integrable on any [a,b], including across the singularity at 0. Supplies integrability of the model inverse-square-root singularity (r = −1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrability.Basic"
+      },
+      {
+        "theorem": "IntervalIntegrable.mono_fun'",
+        "description": "Dominated comparison: an a.e.-strongly-measurable function bounded in norm by an interval-integrable function is itself interval-integrable. Used to transfer integrability from the model (t−1)^(−1/2) to the actual integrand 1/√(t²−1).",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "IntervalIntegrable.comp_sub_right",
+        "description": "Translation invariance of interval-integrability: if f is integrable on [a,b], then x ↦ f(x − c) is integrable on [a+c, b+c]. Shifts the rpow singularity from 0 to 1.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "Real.arcosh_zero",
+        "description": "arcosh 1 = 0, the value at the singular endpoint that makes the improper integral equal arcosh b rather than arcosh b − arcosh a.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arcosh"
+      },
+      {
+        "theorem": "ContinuousOn.log",
+        "description": "log composes continuously with a continuous, nowhere-vanishing function; used to prove continuity of arcosh = log(x + √(x²−1)) on [1,∞), where Mathlib supplies no direct continuity lemma.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral ∫ dt/√(t²−1) = arcosh t + C is a calculus-table staple, but the definite integral from the lower bound t = 1 is improper: the integrand blows up there. Classically one writes ∫_1^b = lim_{a→1⁺} ∫_a^b and observes that the limit is finite — an 'integrable singularity' of inverse-square-root type. The parent entry proved the proper FTC ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a on [a,b] ⊂ (1,∞) and explicitly posed the improper extension as an open question. This entry settles it, both as a genuine Lebesgue integral over the closed interval [1,b] and as the classical limit.",
+    "problemStatement": "Extend the parent's proper FTC evaluation to the improper integral ∫_1^b 1/√(t²−1) dt = arcosh b for 1 < b, taking the lower limit down to the singularity at t = 1. Establish that the singular integrand is genuinely interval-integrable across the closed interval [1,b], evaluate the integral to arcosh b using the endpoint-aware FTC and arcosh 1 = 0, and record the equivalent limit statement ∫_a^b → arcosh b as a → 1⁺.",
+    "proofStrategy": "Two routes are developed. For the genuine integral: (i) prove t ↦ 1/√(t²−1) is interval-integrable on the closed [1,b] by dominating it with the integrable model (t−1)^(−1/2) — the bound 1/√(t²−1) ≤ 1/√(t−1) follows from √(t²−1) ≥ √(t−1) (monotonicity of √ on t²−1 ≥ t−1 ⇔ t ≥ 1), and (t−1)^(−1/2) is integrable as the unit shift of the rpow x^(−1/2) (integrable since −1/2 > −1); IntervalIntegrable.mono_fun' assembles this with the a.e.-measurability of the continuous-on-(1,b] integrand. (ii) Apply the endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le with F = arcosh: continuity on [1,b] from continuousOn_arcosh (built from the logarithmic form), differentiability on (1,b) from the parent's hasDerivAt_arcosh, integrability from (i); this gives arcosh b − arcosh 1 = arcosh b. For the limit route: the parent closed form gives ∫_a^b = arcosh b − arcosh a for a > 1, and arcosh a → arcosh 1 = 0 by right-continuity of arcosh at 1, so the integral tends to arcosh b.",
+    "keyInsights": [
+      "The endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le is exactly the tool for an integrable endpoint singularity: it only demands continuity of the antiderivative at the endpoints (arcosh is continuous at 1) and differentiability on the open interior (where arcosh' = 1/√(t²−1) holds), never differentiability AT the singular point — so the blow-up of the derivative at t = 1 is harmless.",
+      "Integrability across the singularity reduces to a single inequality 1/√(t²−1) ≤ 1/√(t−1): the extra factor √(t+1) ≥ 1 only helps, so the inverse-square-root model (t−1)^(−1/2) dominates and the rpow integrability lemma (exponent −1/2 > −1) does the rest.",
+      "arcosh is continuous at the very point where it is not differentiable; the proof goes through the logarithmic form log(x + √(x²−1)), whose argument is ≥ 1 > 0 on [1,∞), so the only Mathlib gap (no arcosh continuity lemma) is filled by a short ContinuousOn.log argument.",
+      "The genuine Lebesgue integral over [1,b] and the classical limit lim_{a→1⁺} ∫_a^b agree precisely because the singularity is integrable — the entry proves both, exhibiting the two standard meanings of an improper integral and that they coincide here.",
+      "arcosh 1 = 0 is what upgrades the proper two-endpoint formula arcosh b − arcosh a into the clean one-sided improper value arcosh b."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: the Improper Integral",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "States the open question (the improper integral ∫_1^b 1/√(t²−1) dt = arcosh b across the singularity at t = 1) and the two answers supplied: the genuine Lebesgue integral via integrability + endpoint-aware FTC, and the classical limit a → 1⁺.",
+      "mathContext": "$\\int_1^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b$, $b > 1$."
+    },
+    {
+      "id": "parent-infra",
+      "title": "Reproved Parent Infrastructure",
+      "startLine": 55,
+      "endLine": 130,
+      "summary": "Self-contained restatements of the parent results: sqrt_sq_sub_one_pos, hasDerivAt_arcosh (the arcosh derivative via the chain rule on the logarithmic form), continuousOn_integrand, intervalIntegrable_integrand, and the proper FTC integral_one_div_sqrt_sq_sub_one.",
+      "mathContext": "$\\operatorname{arcosh}'(t) = 1/\\sqrt{t^2-1}$ and $\\int_a^b = \\operatorname{arcosh} b - \\operatorname{arcosh} a$ on $(1,\\infty)$."
+    },
+    {
+      "id": "continuity",
+      "title": "Continuity of arcosh at the Singular Endpoint",
+      "startLine": 132,
+      "endLine": 153,
+      "summary": "continuousOn_arcosh: Real.arcosh is continuous on [1,∞), including the endpoint 1, via the logarithmic form whose argument stays positive. Mathlib has no such lemma.",
+      "mathContext": "$\\operatorname{arcosh}$ continuous on $[1,\\infty)$."
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability Across the Singularity",
+      "startLine": 155,
+      "endLine": 187,
+      "summary": "intervalIntegrable_model (the rpow model (t−1)^(−1/2) is integrable on [1,b]) and intervalIntegrable_one (the actual integrand 1/√(t²−1) is integrable on the closed [1,b], by dominated comparison).",
+      "mathContext": "$t \\mapsto 1/\\sqrt{t^2-1}$ integrable on $[1,b]$ despite the blow-up at $t=1$."
+    },
+    {
+      "id": "improper",
+      "title": "The Improper Integral",
+      "startLine": 189,
+      "endLine": 226,
+      "summary": "improper_integral_eq_arcosh (∫_1^b 1/√(t²−1) dt = arcosh b via the endpoint-aware FTC and arcosh 1 = 0) and integral_tendsto_arcosh (the limit form ∫_a^b → arcosh b as a → 1⁺).",
+      "mathContext": "$\\int_1^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b = \\lim_{a\\to 1^+}\\int_a^b$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Corollary",
+      "startLine": 228,
+      "endLine": 238,
+      "summary": "improper_integral_one_to_five_thirds: ∫_1^{5/3} 1/√(t²−1) dt = log 3, since arcosh(5/3) = log 3.",
+      "mathContext": "$\\int_1^{5/3} \\frac{dt}{\\sqrt{t^2-1}} = \\log 3$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01-oq-01",
+      "question": "Does the same integrable-singularity argument evaluate the doubly-improper integral ∫_1^∞ over the unbounded domain — i.e. characterize when ∫_1^b 1/√(t²−1) dt diverges as b → ∞ (it does, like log b), versus a convergent tail integral such as ∫_b^∞ 1/(t√(t²−1)) dt = arcsec-type?",
+      "significance": "low"
+    },
+    {
+      "id": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01-oq-02",
+      "question": "Can the genuine-Lebesgue and limit forms be unified into a single statement that the improper Riemann/Lebesgue integral of any antiderivative with a one-sided integrable singularity equals the boundary value of the antiderivative, abstracting away the specific integrand?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "The parent proves the proper FTC ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a on [a,b] ⊂ (1,∞) and explicitly poses, as its open question, the improper extension ∫_1^b 1/√(t²−1) dt = arcosh b across the singularity at t = 1. This entry answers it, both as a genuine Lebesgue integral over the closed interval [1,b] and as the limit a → 1⁺."
+    },
+    {
+      "targetId": "arsinh-log-formula-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "The grandparent develops the algebraic theory of arcosh (logarithmic form, addition laws, concrete values arcosh(5/3) = log 3, arcosh(5/4) = log 2), reused here for the concrete improper evaluation."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.IntervalIntegral.FundThmCalculus",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_eq_sub_of_hasDeriv_right_of_le, the endpoint-aware FTC that evaluates the integral down to the singular endpoint using only continuity there."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Integrability.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of intervalIntegrable_rpow' (x^r integrable across 0 for r > −1), the model integrability used to dominate the inverse-square-root singularity."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Arcosh",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.arcosh and arcosh_zero (arcosh 1 = 0); notably it records no continuity lemma for arcosh, a gap filled here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Answers the parent's open question by extending the proper FTC ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a to the improper integral ∫_1^b 1/√(t²−1) dt = arcosh b across the singularity at t = 1. The singularity is shown to be integrable (1/√(t²−1) ≤ 1/√(t−1) = (t−1)^(−1/2), dominated by the rpow model), so the integrand is interval-integrable on the CLOSED interval [1,b]; the endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le then evaluates the integral to arcosh b − arcosh 1 = arcosh b, using arcosh 1 = 0 and the continuity of arcosh on [1,∞) (proved here, as Mathlib has no arcosh continuity lemma). The equivalent limit form ∫_a^b → arcosh b as a → 1⁺ is also recorded, together with the concrete value ∫_1^{5/3} 1/√(t²−1) dt = log 3. 238 lines, 11 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The entry completes the calculus of the arcosh antiderivative by handling its single integrable endpoint singularity, and packages a reusable template: continuity of the antiderivative at a singular endpoint + an inverse-power domination bound + the endpoint-aware FTC yields the improper integral. The continuity lemma continuousOn_arcosh is itself a missing piece of Mathlib's arcosh development.",
+    "openQuestions": [
+      "Treat the doubly-improper / unbounded-domain integrals in the same family (divergence of ∫_1^∞ 1/√(t²−1) versus convergent arcsec-type tails).",
+      "Abstract the genuine-integral-equals-boundary-value pattern for one-sided integrable singularities away from the specific integrand."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of `arsinh-log-formula-oq-01-oq-02-oq-01`: extend the parent's *proper* FTC evaluation `∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a` (valid on `[a,b] ⊂ (1,∞)`) **down to the singular endpoint** `t = 1`, obtaining the improper integral `∫_1^b 1/√(t²−1) dt = arcosh b`.

Proved two complementary ways:

1. **Genuine Lebesgue improper integral.** The singularity at `t = 1` is *integrable*: `1/√(t²−1) ≤ 1/√(t−1) = (t−1)^(−1/2)` on `(1,b]`, an inverse-square-root singularity dominated by the rpow model (exponent `−1/2 > −1`). `intervalIntegrable_one` establishes interval-integrability across the **closed** interval `[1,b]` by `IntervalIntegrable.mono_fun'`; the endpoint-aware FTC `integral_eq_sub_of_hasDeriv_right_of_le` (which needs only continuity at the endpoints + differentiability on the open interior) evaluates it to `arcosh b − arcosh 1 = arcosh b` via `arcosh 1 = 0`.
2. **Improper integral as a limit.** `integral_tendsto_arcosh`: `∫_a^b 1/√(t²−1) dt → arcosh b` as `a → 1⁺`, from the parent closed form and the right-continuity of `arcosh` at `1` (`continuousOn_arcosh` — a lemma Mathlib's `Arcosh` file lacks, proved here from the logarithmic form).

Concrete corollary: `∫_1^{5/3} 1/√(t²−1) dt = log 3`.

## Verification
- **Status:** verified · **Badge:** original · **Axioms:** 0 (only `propext`/`Classical.choice`/`Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool`)
- 11 theorems, 0 definitions, 0 sorries, 238 lines
- Compiles against Mathlib via single-file `lake env lean`; registered in `Proofs.lean`; gallery `meta.json` generates cleanly (verified/original, no warnings)

## Files
- `proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)