### PR TITLE
research(bernoulli-inequality-oq-01-oq-01-oq-02-oq-01): magnitude-bounded power band & escape/capture dichotomy at B=1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -316,6 +316,7 @@ import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01
 import Proofs.BernoulliInequalityOQ01OQ01
 import Proofs.BernoulliInequalityOQ01OQ01OQ02
+import Proofs.BernoulliInequalityOQ01OQ01OQ02OQ01
 import Proofs.BernoulliInequalityOQ01OQ02
 import Proofs.BernoulliInequalityOQ01OQ02OQ01
 import Proofs.BertrandsPostulate

--- a/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,215 @@
+import Mathlib
+
+/-
+# The magnitude-bounded power band and the escape/capture dichotomy
+
+**Open question (bernoulli-inequality-oq-01-oq-01-oq-02-oq-01).** The parent entry
+`bernoulli-inequality-oq-01-oq-01-oq-02` (*the line-escapes-a-bounded-power lemma*)
+trapped every power of a magnitude-`≤ 1` base inside the **fixed** band `[-1, 1]`,
+and concluded that any line of nonzero slope eventually escapes it.
+
+This file generalizes the bound to a magnitude-`≤ B` base, whose powers live in the
+**`n`-dependent** band `[-Bⁿ, Bⁿ]`, and asks the natural follow-up:
+
+> *Which lines escape the `n`-dependent band?*
+
+The answer is a sharp dichotomy governed by the critical value `B = 1`.
+
+## The generalized trap
+
+* `abs_pow_le`     : `|x| ≤ B → |xⁿ| ≤ Bⁿ`.
+* `neg_pow_le_pow` : `|x| ≤ B → -Bⁿ ≤ xⁿ`.
+* `pow_le_pow_band`: `|x| ≤ B → xⁿ ≤ Bⁿ`.
+
+## The escape engine (any `B`)
+
+* `lt_pow_of_lt_neg_pow` : `|x| ≤ B → c < -Bⁿ → c < xⁿ`.
+* `pow_lt_of_pow_lt`     : `|x| ≤ B → Bⁿ < c → xⁿ < c`.
+
+## The dichotomy
+
+* **Shrinking / critical band `0 ≤ B ≤ 1`** (`Bⁿ ≤ 1`): the band is contained in
+  `[-1, 1]`, so the parent's mechanism survives verbatim — a negative-slope line
+  eventually drops below *every* power (`eventually_line_lt_pow_band`) and a
+  positive-slope line eventually rises above every power (`eventually_pow_lt_line_band`).
+  The parent (`B = 1`) is the boundary case.
+
+* **Growing band `B > 1`** (`Bⁿ → ∞`): the band swallows every line.  *No* line of
+  *any* slope can escape: beyond an explicit threshold the line lies strictly inside
+  `(-Bⁿ, Bⁿ)` (`eventually_line_mem_band`).  The driver is that the exponential `Bⁿ`
+  dominates the linear `|b| + n·|s|` — `Mathlib`'s
+  `tendsto_pow_const_div_const_pow_of_one_lt`.
+
+The contrast `eventually_line_lt_pow_band` (escape, `B ≤ 1`) versus
+`eventually_line_mem_band` (capture, `B > 1`) is the crystallized boundary
+phenomenon: the parent sits exactly on the knife-edge `B = 1`.
+
+Fully machine-checked: `0` sorries, `0` axioms.
+-/
+
+namespace BernoulliInequalityOQ01OQ01OQ02OQ01
+
+open Filter Topology
+
+variable {x c b s B : ℝ} {n : ℕ}
+
+/-! ## The generalized trap: powers of a magnitude-`≤ B` base stay in `[-Bⁿ, Bⁿ]`. -/
+
+/-- A magnitude bound is preserved by powers: `|x| ≤ B → |xⁿ| ≤ Bⁿ`.  (Note `0 ≤ B`
+is automatic from `|x| ≤ B`.) -/
+theorem abs_pow_le (hx : |x| ≤ B) (n : ℕ) : |x ^ n| ≤ B ^ n := by
+  rw [abs_pow]
+  exact pow_le_pow_left₀ (abs_nonneg x) hx n
+
+/-- Lower wall of the band: `|x| ≤ B → -Bⁿ ≤ xⁿ`. -/
+theorem neg_pow_le_pow (hx : |x| ≤ B) (n : ℕ) : -B ^ n ≤ x ^ n :=
+  (abs_le.mp (abs_pow_le hx n)).1
+
+/-- Upper wall of the band: `|x| ≤ B → xⁿ ≤ Bⁿ`. -/
+theorem pow_le_pow_band (hx : |x| ≤ B) (n : ℕ) : x ^ n ≤ B ^ n :=
+  (abs_le.mp (abs_pow_le hx n)).2
+
+/-! ## The escape engine (works for every `B`). -/
+
+/-- **Escape from below.**  Anything strictly under the lower wall `-Bⁿ` is beaten
+by the power `xⁿ`. -/
+theorem lt_pow_of_lt_neg_pow (hx : |x| ≤ B) (hc : c < -B ^ n) : c < x ^ n :=
+  lt_of_lt_of_le hc (neg_pow_le_pow hx n)
+
+/-- **Escape from above.**  Anything strictly over the upper wall `Bⁿ` exceeds the
+power `xⁿ`. -/
+theorem pow_lt_of_pow_lt (hx : |x| ≤ B) (hc : B ^ n < c) : x ^ n < c :=
+  lt_of_le_of_lt (pow_le_pow_band hx n) hc
+
+/-! ## Shrinking / critical band `0 ≤ B ≤ 1`: lines still escape.
+
+When `B ≤ 1` the band `[-Bⁿ, Bⁿ] ⊆ [-1, 1]`, so the parent's threshold argument
+generalizes unchanged: any line of nonzero slope eventually leaves `[-1, 1]`, and
+a fortiori the smaller band. -/
+
+/-- For `0 ≤ B ≤ 1` the upper wall never exceeds `1`. -/
+theorem pow_le_one_of_le_one (hB0 : 0 ≤ B) (hB1 : B ≤ 1) (n : ℕ) : B ^ n ≤ 1 :=
+  pow_le_one₀ hB0 hB1
+
+/-- **A negative-slope line eventually drops below the whole band (`B ≤ 1`).**  If
+`|x| ≤ B ≤ 1` and `s < 0`, then beyond an explicit threshold the line `b + n·s` is
+strictly below *every* power `xⁿ`.  Generalizes the parent's `eventually_line_lt_pow`
+from the fixed band `B = 1` to every `B ≤ 1`. -/
+theorem eventually_line_lt_pow_band (hx : |x| ≤ B) (hB1 : B ≤ 1) (hs : s < 0) :
+    ∃ N : ℕ, ∀ n ≥ N, b + n * s < x ^ n := by
+  have hB0 : 0 ≤ B := le_trans (abs_nonneg x) hx
+  have hns : (0 : ℝ) < -s := by linarith
+  obtain ⟨N, hN⟩ := exists_nat_gt ((b + 1) / (-s))
+  refine ⟨N, fun n hn => ?_⟩
+  have hnN : ((N : ℝ)) ≤ (n : ℝ) := by exact_mod_cast hn
+  have h1 : (b + 1) / (-s) < (n : ℝ) := lt_of_lt_of_le hN hnN
+  rw [div_lt_iff₀ hns] at h1
+  have hline : b + (n : ℝ) * s < -1 := by nlinarith [h1]
+  -- the line is below `-1 ≤ -Bⁿ`, hence below the band, hence below `xⁿ`.
+  have hwall : -(1 : ℝ) ≤ -B ^ n := by
+    have := pow_le_one_of_le_one hB0 hB1 n; linarith
+  exact lt_pow_of_lt_neg_pow hx (lt_of_lt_of_le hline hwall)
+
+/-- **A positive-slope line eventually rises above the whole band (`B ≤ 1`).**  The
+mirror image: if `|x| ≤ B ≤ 1` and `s > 0`, the line `b + n·s` eventually exceeds
+every power `xⁿ`. -/
+theorem eventually_pow_lt_line_band (hx : |x| ≤ B) (hB1 : B ≤ 1) (hs : 0 < s) :
+    ∃ N : ℕ, ∀ n ≥ N, x ^ n < b + n * s := by
+  have hB0 : 0 ≤ B := le_trans (abs_nonneg x) hx
+  obtain ⟨N, hN⟩ := exists_nat_gt ((1 - b) / s)
+  refine ⟨N, fun n hn => ?_⟩
+  have hnN : ((N : ℝ)) ≤ (n : ℝ) := by exact_mod_cast hn
+  have h1 : (1 - b) / s < (n : ℝ) := lt_of_lt_of_le hN hnN
+  rw [div_lt_iff₀ hs] at h1
+  have hline : (1 : ℝ) < b + (n : ℝ) * s := by nlinarith [h1]
+  have hwall : B ^ n ≤ (1 : ℝ) := pow_le_one_of_le_one hB0 hB1 n
+  exact pow_lt_of_pow_lt hx (lt_of_le_of_lt hwall hline)
+
+/-! ## Growing band `B > 1`: the band captures every line.
+
+The new phenomenon.  When `B > 1` the walls `±Bⁿ` grow exponentially and dominate
+any line `b + n·s`.  Hence *no* line escapes: it is eventually trapped strictly
+inside the open band `(-Bⁿ, Bⁿ)`.  This is the exact opposite of the `B ≤ 1` case. -/
+
+/-- The exponential wall dominates the linear envelope `|b| + n·|s|`: for `B > 1` the
+quotient `(|b| + |s|·n) / Bⁿ` tends to `0`. -/
+theorem tendsto_linear_div_pow (hB : 1 < B) (b s : ℝ) :
+    Tendsto (fun n : ℕ => (|b| + |s| * (n : ℝ)) / B ^ n) atTop (𝓝 0) := by
+  have h0 : Tendsto (fun n : ℕ => (1 : ℝ) / B ^ n) atTop (𝓝 0) := by
+    have := tendsto_pow_const_div_const_pow_of_one_lt 0 hB
+    simpa using this
+  have h1 : Tendsto (fun n : ℕ => (n : ℝ) / B ^ n) atTop (𝓝 0) := by
+    have := tendsto_pow_const_div_const_pow_of_one_lt 1 hB
+    simpa using this
+  have hcomb :
+      Tendsto (fun n : ℕ => |b| * ((1 : ℝ) / B ^ n) + |s| * ((n : ℝ) / B ^ n))
+        atTop (𝓝 (|b| * 0 + |s| * 0)) :=
+    (h0.const_mul |b|).add (h1.const_mul |s|)
+  have hcong :
+      (fun n : ℕ => (|b| + |s| * (n : ℝ)) / B ^ n)
+        = fun n : ℕ => |b| * ((1 : ℝ) / B ^ n) + |s| * ((n : ℝ) / B ^ n) := by
+    funext n; ring
+  rw [hcong]
+  simpa using hcomb
+
+/-- **Capture (`B > 1`): every line is eventually trapped strictly inside the band.**
+For `B > 1` and *any* intercept `b` and slope `s`, there is an explicit threshold
+beyond which `-Bⁿ < b + n·s < Bⁿ`.  No line of any slope escapes the growing band —
+the sharp contrast with `eventually_line_lt_pow_band`. -/
+theorem eventually_line_mem_band (hB : 1 < B) (b s : ℝ) :
+    ∃ N : ℕ, ∀ n ≥ N, b + n * s ∈ Set.Ioo (-B ^ n) (B ^ n) := by
+  have hBpos : (0 : ℝ) < B := lt_trans one_pos hB
+  have hev : ∀ᶠ n : ℕ in atTop, (|b| + |s| * (n : ℝ)) / B ^ n < 1 :=
+    (tendsto_linear_div_pow hB b s).eventually_lt_const (by norm_num)
+  obtain ⟨N, hN⟩ := eventually_atTop.mp hev
+  refine ⟨N, fun n hn => ?_⟩
+  have hBn : (0 : ℝ) < B ^ n := pow_pos hBpos n
+  have hlt : |b| + |s| * (n : ℝ) < B ^ n := (div_lt_one hBn).mp (hN n hn)
+  -- bound the line by its linear envelope
+  have henv : |b + (n : ℝ) * s| ≤ |b| + |s| * (n : ℝ) := by
+    have hns : |(n : ℝ) * s| = |s| * (n : ℝ) := by
+      rw [abs_mul, abs_of_nonneg (Nat.cast_nonneg n), mul_comm]
+    calc |b + (n : ℝ) * s| ≤ |b| + |(n : ℝ) * s| := abs_add_le b _
+      _ = |b| + |s| * (n : ℝ) := by rw [hns]
+  have : |b + (n : ℝ) * s| < B ^ n := lt_of_le_of_lt henv hlt
+  rw [abs_lt] at this
+  exact ⟨this.1, this.2⟩
+
+/-- The capture statement unpacked: for `B > 1` the line eventually lies strictly
+between the walls. -/
+theorem eventually_neg_pow_lt_line_lt_pow (hB : 1 < B) (b s : ℝ) :
+    ∃ N : ℕ, ∀ n ≥ N, -B ^ n < b + n * s ∧ b + n * s < B ^ n := by
+  obtain ⟨N, hN⟩ := eventually_line_mem_band hB b s
+  exact ⟨N, fun n hn => hN n hn⟩
+
+/-! ## The dichotomy, side by side. -/
+
+/-- **Boundary dichotomy.**  Fix any line `b + n·s` with negative slope `s < 0`.
+* If `B > 1` the line is eventually captured inside the band `(-Bⁿ, Bⁿ)`.
+* If `0 ≤ B ≤ 1` (and `|x| ≤ B`) the same line eventually escapes below the band,
+  beaten by every power `xⁿ`.
+The single hypothesis `B ≷ 1` flips capture into escape — the parent's fixed band
+`B = 1` is exactly the knife-edge. -/
+theorem escape_or_capture (hx : |x| ≤ B) (hs : s < 0) :
+    (1 < B → ∃ N : ℕ, ∀ n ≥ N, b + n * s ∈ Set.Ioo (-B ^ n) (B ^ n)) ∧
+    (B ≤ 1 → ∃ N : ℕ, ∀ n ≥ N, b + n * s < x ^ n) :=
+  ⟨fun hB => eventually_line_mem_band hB b s,
+   fun hB1 => eventually_line_lt_pow_band hx hB1 hs⟩
+
+/-! ## Sanity checks. -/
+
+/-- Shrinking band `B = 1/2`: the descending line `10 - n` escapes below the powers
+of `x = -1/2` (whose band is `[-(1/2)ⁿ, (1/2)ⁿ]`). -/
+example : ∃ N : ℕ, ∀ n ≥ N, (10 : ℝ) - n < (-1 / 2) ^ n := by
+  have hx : |(-1 / 2 : ℝ)| ≤ (1 / 2 : ℝ) := by rw [abs_le]; constructor <;> norm_num
+  obtain ⟨N, hN⟩ :=
+    eventually_line_lt_pow_band (x := (-1 / 2 : ℝ)) (B := (1 / 2 : ℝ))
+      (b := 10) (s := -1) hx (by norm_num) (by norm_num)
+  exact ⟨N, fun n hn => by have h := hN n hn; linarith⟩
+
+/-- Growing band `B = 2`: the steep line `5 + 100·n` cannot escape — it is eventually
+trapped inside `(-2ⁿ, 2ⁿ)`. -/
+example : ∃ N : ℕ, ∀ n ≥ N, (5 : ℝ) + n * 100 ∈ Set.Ioo (-(2 : ℝ) ^ n) ((2 : ℝ) ^ n) :=
+  eventually_line_mem_band (B := (2 : ℝ)) (by norm_num) 5 100
+
+end BernoulliInequalityOQ01OQ01OQ02OQ01

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "ann-bern-oq01010201-header",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "From a fixed band to an n-dependent band",
+    "content": "The docstring states the parent's first open question: generalize the bounded-power trap from the fixed band [−1, 1] to a magnitude-≤ B base, whose powers live in the n-dependent band [−Bⁿ, Bⁿ], and characterize which lines escape it. The answer is a sharp dichotomy at the critical value B = 1 — shrinking/critical band (B ≤ 1) lines escape, growing band (B > 1) every line is captured."
+  },
+  {
+    "id": "ann-bern-oq01010201-trap",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "The generalized trap",
+    "content": "abs_pow_le proves |xⁿ| ≤ Bⁿ from |x| ≤ B using abs_pow (|xⁿ| = |x|ⁿ) and pow_le_pow_left₀ (monotonicity of powers). abs_le then splits this into the two walls −Bⁿ ≤ xⁿ (neg_pow_le_pow) and xⁿ ≤ Bⁿ (pow_le_pow_band). This is the verbatim generalization of the parent's [−1, 1] band."
+  },
+  {
+    "id": "ann-bern-oq01010201-engine",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 87
+    },
+    "type": "technique",
+    "title": "The escape engine (any B)",
+    "content": "Two transitivity one-liners: lt_pow_of_lt_neg_pow says anything below the lower wall (c < −Bⁿ) is beaten by every power (c < xⁿ); pow_lt_of_pow_lt is the mirror above the upper wall. Both are B-agnostic — they need nothing about the sign or size of B."
+  },
+  {
+    "id": "ann-bern-oq01010201-shrinking",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 89,
+      "endLine": 134
+    },
+    "type": "insight",
+    "title": "Shrinking/critical band B ≤ 1: lines still escape",
+    "content": "When B ≤ 1 the wall Bⁿ ≤ 1 (pow_le_one₀), so the band sits inside [−1, 1]. eventually_line_lt_pow_band: a negative-slope line drops below −1 ≤ −Bⁿ past the Archimedean threshold N > (b+1)/(−s), hence below every power. eventually_pow_lt_line_band is the positive-slope mirror. These generalize the parent's lemmas from B = 1 to every B ≤ 1."
+  },
+  {
+    "id": "ann-bern-oq01010201-tendsto",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 136,
+      "endLine": 157
+    },
+    "type": "technique",
+    "title": "Exponential dominates linear",
+    "content": "tendsto_linear_div_pow proves (|b| + |s|·n)/Bⁿ → 0 for B > 1 by writing it as |b|·(1/Bⁿ) + |s|·(n/Bⁿ) and sending both terms to 0 with tendsto_pow_const_div_const_pow_of_one_lt (k = 0 and k = 1). This is the quantitative engine that lets the exponential wall absorb any line."
+  },
+  {
+    "id": "ann-bern-oq01010201-capture",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 191
+    },
+    "type": "insight",
+    "title": "Growing band B > 1: every line is captured",
+    "content": "eventually_line_mem_band turns the limit into an eventual bound (Tendsto.eventually_lt_const, div_lt_one): eventually |b| + |s|·n < Bⁿ, and bounding the line by its envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line lies strictly inside (−Bⁿ, Bⁿ). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
+  },
+  {
+    "id": "ann-bern-oq01010201-dichotomy",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 193,
+      "endLine": 201
+    },
+    "type": "insight",
+    "title": "The boundary dichotomy at B = 1",
+    "content": "escape_or_capture states both halves for a fixed negative-slope line: B > 1 forces capture inside the band, B ≤ 1 forces escape below every power. The single comparison B ≷ 1 flips one into the other, pinning the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BernoulliInequalityOQ01OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bernoulliInequalityOQ01OQ01OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bernoulliInequalityOQ01OQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const bernoulliInequalityOQ01OQ01OQ02OQ01Data: ProofData = {
+  proof: bernoulliInequalityOQ01OQ01OQ02OQ01Proof,
+  annotations: bernoulliInequalityOQ01OQ01OQ02OQ01Annotations,
+}

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+  "slug": "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01",
+  "title": "The Magnitude-Bounded Power Band and the Escape/Capture Dichotomy",
+  "description": "The parent entry (the line-escapes-a-bounded-power lemma) trapped every power of a magnitude-≤ 1 base inside the fixed band [−1, 1] and concluded that any line of nonzero slope eventually escapes it. This entry answers the parent's own first open question: generalize the trap to a magnitude-≤ B base, whose powers live in the n-dependent band [−Bⁿ, Bⁿ], and characterize exactly which lines escape it. The trap generalizes verbatim (abs_pow_le, neg_pow_le_pow, pow_le_pow_band), as does the escape engine (lt_pow_of_lt_neg_pow, pow_lt_of_pow_lt). The new content is a sharp dichotomy governed by the critical value B = 1: for a shrinking or critical band 0 ≤ B ≤ 1 the band sits inside [−1, 1], so the parent's mechanism survives — a negative-slope line eventually drops below every power (eventually_line_lt_pow_band) and a positive-slope line eventually rises above every power (eventually_pow_lt_line_band), with the parent B = 1 as the boundary case. For a growing band B > 1 the walls ±Bⁿ grow exponentially and dominate any line: beyond an explicit threshold the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band), so NO line of any slope escapes. The driver is that the exponential Bⁿ dominates the linear |b| + n·|s|, via Mathlib's tendsto_pow_const_div_const_pow_of_one_lt. The escape (B ≤ 1) versus capture (B > 1) contrast is packaged in escape_or_capture, with the parent's fixed band B = 1 sitting exactly on the knife-edge. Verified: 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Filter", "Topology"],
+    "namespace": "BernoulliInequalityOQ01OQ01OQ02OQ01",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/BernoulliInequalityOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Researcher (Lean Genius); generalization of the bounded-power escape lemma to an n-dependent band",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "bounded-power",
+      "sharp-boundary",
+      "exponential-vs-linear",
+      "archimedean",
+      "asymptotics",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "pow_le_pow_left₀",
+        "description": "For 0 ≤ a ≤ b, aⁿ ≤ bⁿ. Applied to |x| ≤ B to bound |x|ⁿ = |xⁿ| by Bⁿ in abs_pow_le, the generalized trap.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      },
+      {
+        "theorem": "abs_pow",
+        "description": "|xⁿ| = |x|ⁿ. Reduces the magnitude of a power to a power of the magnitude in abs_pow_le.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      },
+      {
+        "theorem": "abs_le",
+        "description": "|y| ≤ c ↔ −c ≤ y ∧ y ≤ c. Splits the trap |xⁿ| ≤ Bⁿ into the two walls −Bⁿ ≤ xⁿ and xⁿ ≤ Bⁿ.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      },
+      {
+        "theorem": "pow_le_one₀",
+        "description": "For 0 ≤ a ≤ 1, aⁿ ≤ 1. Gives Bⁿ ≤ 1 when B ≤ 1, placing the band inside [−1, 1] for the shrinking/critical-band escape lemmas.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "tendsto_pow_const_div_const_pow_of_one_lt",
+        "description": "For 1 < r, (nᵏ)/rⁿ → 0. With k = 0 and k = 1 this is exactly the exponential-dominates-linear engine that forces |b| + |s|·n < Bⁿ eventually, driving the B > 1 capture theorem eventually_line_mem_band.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Filter.Tendsto.eventually_lt_const",
+        "description": "If f → v and v < u then eventually f < u. Turns the limit (|b| + |s|·n)/Bⁿ → 0 into the eventual bound < 1 used to capture the line inside the growing band.",
+        "module": "Mathlib.Topology.Order.OrderClosed"
+      },
+      {
+        "theorem": "div_lt_one",
+        "description": "For 0 < c, a/c < 1 ↔ a < c. Converts the eventual quotient bound (|b| + |s|·n)/Bⁿ < 1 into the linear-vs-exponential inequality |b| + |s|·n < Bⁿ.",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "exists_nat_gt",
+        "description": "Archimedean property: every real is below some natural number. Produces the explicit escape thresholds N in the B ≤ 1 lemmas eventually_line_lt_pow_band and eventually_pow_lt_line_band.",
+        "module": "Mathlib.Algebra.Order.Archimedean.Basic"
+      },
+      {
+        "theorem": "abs_add_le",
+        "description": "|a + b| ≤ |a| + |b|. Bounds the line b + n·s by its linear envelope |b| + |s|·n in the B > 1 capture proof.",
+        "module": "Mathlib.Algebra.Order.AbsoluteValue"
+      }
+    ],
+    "originalContributions": [
+      "abs_pow_le / neg_pow_le_pow / pow_le_pow_band: the generalized trap — every power of a magnitude-≤ B base is confined to the n-dependent band [−Bⁿ, Bⁿ], directly extending the parent's fixed band [−1, 1].",
+      "lt_pow_of_lt_neg_pow / pow_lt_of_pow_lt: the generalized escape engine — anything below the lower wall −Bⁿ is beaten by every power, anything above the upper wall Bⁿ beats every power.",
+      "eventually_line_lt_pow_band / eventually_pow_lt_line_band: for a shrinking or critical band 0 ≤ B ≤ 1, a nonzero-slope line still escapes — generalizing the parent's eventually_line_lt_pow / eventually_pow_lt_line from B = 1 to every B ≤ 1, with explicit Archimedean thresholds.",
+      "tendsto_linear_div_pow: the quantitative heart — for B > 1 the quotient (|b| + |s|·n)/Bⁿ → 0, i.e. the exponential wall dominates the linear envelope of any line.",
+      "eventually_line_mem_band: the genuinely new phenomenon — for B > 1 EVERY line, of any slope, is eventually captured strictly inside the growing band (−Bⁿ, Bⁿ); no line escapes. This is the exact opposite of the B ≤ 1 case and has no analogue in the parent's fixed band.",
+      "eventually_neg_pow_lt_line_lt_pow: the capture statement unpacked into the two strict wall inequalities.",
+      "escape_or_capture: the sharp boundary, side by side — for a negative-slope line, B > 1 forces capture inside the band while B ≤ 1 forces escape below every power; the single comparison B ≷ 1 flips one into the other, and the parent's fixed band B = 1 is exactly the knife-edge."
+    ],
+    "dateAdded": "2026-06-24",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 215,
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "trap",
+      "title": "The generalized trap",
+      "content": "From |x| ≤ B (which forces 0 ≤ B), the identity |xⁿ| = |x|ⁿ (abs_pow) together with pow_le_pow_left₀ gives |xⁿ| ≤ Bⁿ. Splitting this with abs_le yields the two walls −Bⁿ ≤ xⁿ ≤ Bⁿ: every power of a magnitude-≤ B base lives in the n-dependent band [−Bⁿ, Bⁿ]. This is the verbatim generalization of the parent's band [−1, 1]."
+    },
+    {
+      "id": "engine",
+      "title": "The escape engine",
+      "content": "Two one-step comparisons hold for any B: anything strictly below the lower wall, c < −Bⁿ, is beaten by every power (lt_pow_of_lt_neg_pow: c < xⁿ); anything strictly above the upper wall, Bⁿ < c, beats every power (pow_lt_of_pow_lt: xⁿ < c). These are the building blocks for both sides of the dichotomy."
+    },
+    {
+      "id": "shrinking",
+      "title": "Shrinking / critical band (0 ≤ B ≤ 1): lines escape",
+      "content": "When B ≤ 1 the wall Bⁿ never exceeds 1 (pow_le_one₀), so the band sits inside [−1, 1] and the parent's argument survives unchanged. A negative-slope line b + n·s eventually drops below −1 ≤ −Bⁿ (threshold N > (b+1)/(−s) from exists_nat_gt), hence below every power (eventually_line_lt_pow_band); the positive-slope mirror is eventually_pow_lt_line_band. The parent (B = 1) is the boundary case."
+    },
+    {
+      "id": "growing",
+      "title": "Growing band (B > 1): the band captures every line",
+      "content": "When B > 1 the walls ±Bⁿ grow exponentially. The quotient (|b| + |s|·n)/Bⁿ → 0 (tendsto_linear_div_pow, built from tendsto_pow_const_div_const_pow_of_one_lt with k = 0, 1), so eventually |b| + |s|·n < Bⁿ (div_lt_one). Bounding the line by its linear envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line is trapped strictly inside (−Bⁿ, Bⁿ) (eventually_line_mem_band). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The boundary dichotomy",
+      "content": "escape_or_capture packages the contrast for a fixed negative-slope line: if B > 1 the line is eventually captured inside the band, while if B ≤ 1 it eventually escapes below every power. The single comparison B ≷ 1 flips capture into escape, identifying the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Bernoulli's inequality (Jacob Bernoulli, 1689) and its sharp extensions live on the interplay between an exponential power $(1+a)^n$ and the linear comparison $1 + na$. The parent gallery entry distilled the hard negative range into a Bernoulli-independent 'trap and escape' lemma over the fixed band $[-1,1]$, and explicitly asked: what happens when the base magnitude bound $B$ is no longer $1$, so the band $[-B^n, B^n]$ itself moves with $n$? This entry answers that question, locating $B = 1$ as the sharp boundary between escape and capture.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01-OQ-02-OQ-01, the parent's first open question):** Generalize the trap to magnitude-$\\le B$ bases: $|x| \\le B \\Rightarrow -B^n \\le x^n \\le B^n$, and characterize exactly which lines escape the now $n$-dependent band $B^n$ — the escape survives only when the line outgrows $B^n$, tying the threshold to whether $B < 1$, $B = 1$, or $B > 1$.\n\n**Answer:** The trap and escape engine generalize verbatim. A sharp dichotomy at $B = 1$ then governs the lines: for $0 \\le B \\le 1$ the band lies inside $[-1,1]$ and every nonzero-slope line still escapes (below for negative slope, above for positive); for $B > 1$ the exponential walls $\\pm B^n$ dominate every line, so no line escapes — each is eventually captured strictly inside $(-B^n, B^n)$. The parent's fixed band $B = 1$ is exactly the knife-edge.",
+    "text": "The generalized trap is immediate: $|x^n| = |x|^n \\le B^n$ from $|x| \\le B$. The dichotomy turns on comparing the exponential wall $B^n$ with the linear line $b + ns$. When $B \\le 1$ the wall is bounded by $1$, the band is contained in the parent's $[-1,1]$, and an unbounded sloped line must leave it — the parent's Archimedean threshold argument carries over unchanged. When $B > 1$ the wall grows exponentially and outpaces any line: $(|b| + |s|n)/B^n \\to 0$, so eventually the entire line lies strictly inside $(-B^n, B^n)$. Thus the very same 'a line escapes a bounded power' phenomenon reverses sign as $B$ crosses $1$.",
+    "proofStrategy": "1. **Trap** (`abs_pow_le`, `neg_pow_le_pow`, `pow_le_pow_band`): `abs_pow` + `pow_le_pow_left₀` give $|x^n| \\le B^n$; `abs_le` splits into the two walls.\n2. **Engine** (`lt_pow_of_lt_neg_pow`, `pow_lt_of_pow_lt`): chain $c < -B^n \\le x^n$ (resp. $x^n \\le B^n < c$) by transitivity.\n3. **Shrinking/critical band** (`eventually_line_lt_pow_band`): for $B \\le 1$, `pow_le_one₀` gives $-1 \\le -B^n$; pick $N > (b+1)/(-s)$ via `exists_nat_gt`, so $b + ns < -1 \\le -B^n$ and the engine finishes. `eventually_pow_lt_line_band` is the positive-slope mirror.\n4. **Growing band** (`tendsto_linear_div_pow`, `eventually_line_mem_band`): write $(|b| + |s|n)/B^n = |b|\\cdot(1/B^n) + |s|\\cdot(n/B^n)$ and send both terms to $0$ using `tendsto_pow_const_div_const_pow_of_one_lt` ($k = 0, 1$); `Filter.Tendsto.eventually_lt_const` then gives the quotient $< 1$, `div_lt_one` gives $|b| + |s|n < B^n$, and `abs_add_le` bounds the line by its envelope, yielding $|b + ns| < B^n$.\n5. **Dichotomy** (`escape_or_capture`): combine the $B > 1$ capture and the $B \\le 1$ escape for a fixed negative-slope line.",
+    "keyInsights": [
+      "**The escape/capture boundary is exactly $B = 1$.** Below it the band shrinks into $[-1,1]$ and every sloped line escapes; above it the band grows exponentially and swallows every line. The parent's fixed band sits precisely on the knife-edge.",
+      "**Exponential beats linear is the whole mechanism for $B > 1$.** The capture is not about any structure of the base $x$ — only that $B^n$ outgrows $|b| + |s|n$, which Mathlib's $n^k/r^n \\to 0$ delivers directly.",
+      "**The trap and engine are genuinely $B$-agnostic.** $-B^n \\le x^n \\le B^n$ and the two comparison lemmas need nothing about the sign or size of $B$; only the asymptotic conclusions split on $B \\lessgtr 1$.",
+      "**The $B \\le 1$ escape is sharper than the parent's.** It holds for the whole family of bands $[-B^n, B^n]$ with $B \\le 1$, not just $B = 1$, because each such band is contained in $[-1,1]$."
+    ],
+    "prerequisites": [
+      "The identity |xⁿ| = |x|ⁿ and monotonicity of powers (pow_le_pow_left₀)",
+      "Splitting an absolute-value bound into two one-sided walls (abs_le)",
+      "The limit nᵏ/rⁿ → 0 for r > 1 (exponential dominates polynomial)",
+      "Turning a limit into an eventual strict inequality (Tendsto.eventually_lt_const) and the Archimedean property (exists_nat_gt)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Generalizing the parent's bounded-power trap from the fixed band [−1, 1] to the n-dependent band [−Bⁿ, Bⁿ] reveals a sharp dichotomy at B = 1. The trap (−Bⁿ ≤ xⁿ ≤ Bⁿ) and the escape engine hold for every B. For a shrinking or critical band 0 ≤ B ≤ 1 the band sits inside [−1, 1] and every nonzero-slope line escapes it, exactly as in the parent. For a growing band B > 1 the exponential walls dominate every line, so no line escapes — each is eventually captured strictly inside (−Bⁿ, Bⁿ). The parent's fixed band B = 1 is the precise critical threshold. Verified: 0 sorries, 0 axioms.",
+    "implications": "The result answers the parent's first open question and sharpens the 'a line escapes a bounded power' principle into a complete escape/capture classification. The capture half (eventually_line_mem_band) is a clean packaging of 'exponential dominates linear' as an explicit eventual band-membership statement, reusable wherever an exponentially growing envelope must be shown to absorb a linear (or, with the same engine, polynomial) comparison. The escape half generalizes the parent's asymptotic lemmas across the entire sub-critical family B ≤ 1.",
+    "openQuestions": [
+      "Replace the line b + n·s by a polynomial p(n) of degree d: for B > 1 the band still captures it (nᵈ/Bⁿ → 0), but for B ≤ 1 the escape now requires the polynomial's leading behavior to outgrow Bⁿ — does a degree-vs-base dichotomy emerge, and is there a clean threshold statement?",
+      "Quantify the capture threshold for B > 1: extract an explicit N(B, b, s) (e.g. via the second-order binomial bound Bⁿ ≥ 1 + n(B−1) + C(n,2)(B−1)²) rather than the existential from the limit, matching the explicit Archimedean thresholds available on the escape side."
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent isolates the bounded-power 'trap and escape' lemma over the fixed band [−1, 1] and asks, as its first open question, to generalize to magnitude-≤ B bases and classify which lines escape the n-dependent band. This entry answers that question, exhibiting the sharp escape/capture dichotomy at B = 1."
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The grandparent proves strict Bernoulli on the full weak domain −2 ≤ a, whose hard negative range is the original instance of the bounded-power mechanism generalized here."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **parent's own first open question** (`bernoulli-inequality-oq-01-oq-01-oq-02`, *the line-escapes-a-bounded-power lemma*): generalize the bounded-power trap from the fixed band `[-1, 1]` to a magnitude-≤ `B` base, whose powers live in the **n-dependent** band `[-Bⁿ, Bⁿ]`, and **characterize exactly which lines escape it**.

The answer is a **sharp dichotomy at the critical value `B = 1`** — the parent's fixed band sits exactly on the knife-edge.

## Results (12 theorems, 0 defs, 215 lines, 0 sorries, 0 axioms)

**Generalized trap & engine (any `B`)**
- `abs_pow_le` / `neg_pow_le_pow` / `pow_le_pow_band`: `|x| ≤ B ⟹ -Bⁿ ≤ xⁿ ≤ Bⁿ`.
- `lt_pow_of_lt_neg_pow` / `pow_lt_of_pow_lt`: anything below `-Bⁿ` is beaten by every power; anything above `Bⁿ` beats every power.

**Shrinking / critical band `0 ≤ B ≤ 1` — lines escape**
- `eventually_line_lt_pow_band` / `eventually_pow_lt_line_band`: the band is contained in `[-1, 1]`, so any nonzero-slope line eventually escapes (below for negative slope, above for positive), with an explicit Archimedean threshold. Generalizes the parent (`B = 1`) to the whole sub-critical family.

**Growing band `B > 1` — every line is captured (the new phenomenon)**
- `tendsto_linear_div_pow`: `(|b| + |s|·n)/Bⁿ → 0` — the exponential wall dominates the linear envelope, via Mathlib's `tendsto_pow_const_div_const_pow_of_one_lt`.
- `eventually_line_mem_band`: **no** line of any slope escapes — each is eventually trapped strictly inside `(-Bⁿ, Bⁿ)`. The exact opposite of the `B ≤ 1` case.

**The dichotomy**
- `escape_or_capture`: for a fixed negative-slope line, `B > 1` forces capture inside the band while `B ≤ 1` forces escape below every power — the single comparison `B ≷ 1` flips one into the other.

## Verification

Compiles against Mathlib (`leanprover/lean4:v4.26.0`). `#print axioms` on the headline theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)