### PR TITLE
research(researcher-9): hilbert-23-oq-01 + abundant-number-oq-04 + divisibility-truncation-oq-03-oq-01 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3104,6 +3104,7 @@ import Proofs.Hilbert21RiemannHilbert
 import Proofs.Hilbert22OQ01
 import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
+import Proofs.Hilbert23CalculusVariationsOQ01
 import Proofs.Hilbert3ScissorsCongruence
 import Proofs.Hilbert4Geodesics
 import Proofs.Hilbert5LieGroups

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -43,6 +43,7 @@ import Proofs.AbelRuffiniOQ07NotSolvable
 import Proofs.AbelRuffiniOQ07Order6
 import Proofs.AbelRuffiniOQ09
 import Proofs.AbelRuffiniOQ10
+import Proofs.AbundantDeficientDvdOQ04
 import Proofs.AbundantMultiplesOQ01
 import Proofs.AbundantNumberOQ01
 import Proofs.AbundantNumberOQ02

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1011,6 +1011,7 @@ import Proofs.DivisibilityTruncationGeneral
 import Proofs.DivisibilityTruncationGeneralOQ01
 import Proofs.DivisibilityTruncationGeneralOQ01OQ01
 import Proofs.DivisibilityTruncationGeneralOQ03
+import Proofs.DivisibilityTruncationGeneralOQ03OQ01
 import Proofs.DyckCatalanCountOQ01
 import Proofs.ETranscendentalOQ01
 import Proofs.ETranscendentalOQ01OQ01

--- a/proofs/Proofs/AbundantDeficientDvdOQ04.lean
+++ b/proofs/Proofs/AbundantDeficientDvdOQ04.lean
@@ -1,0 +1,174 @@
+/-
+  The deficient side of divisibility: divisors of deficient numbers are deficient,
+  and proper divisors of perfect numbers are deficient.
+
+  A positive integer `n` is *abundant* (`Nat.Abundant`) when `σ(n) > 2n`,
+  *perfect* (`Nat.Perfect`) when `σ(n) = 2n`, and *deficient* (`Nat.Deficient`)
+  when `σ(n) < 2n` (equivalently the sum of its *proper* divisors is `< n`).
+
+  The companion files in this cluster develop the *abundant* side of divisibility:
+  `AbundantMultiplesOQ01.lean` proves that every positive multiple of an abundant
+  number is abundant (`abundant_mul_right`) and that every proper multiple of a
+  perfect number is abundant (`abundant_of_perfect_mul`). This file proves the
+  mirror-image *deficient* facts, which Mathlib does not record:
+
+  * `sigma_dvd_mono` — the **abundancy index is monotone along divisibility**:
+    if `d ∣ n` (and `n > 0`) then `n · σ(d) ≤ d · σ(n)`, i.e. `σ(d)/d ≤ σ(n)/n`.
+    This is the single inequality underlying both the abundant and deficient
+    propagation results. It is proved by the scaled-divisor injection
+    `e ↦ (n/d)·e`, which embeds `divisors d` into `divisors n`, giving
+    `(n/d)·σ(d) ≤ σ(n)`; multiplying by `d` clears the division.
+
+  * `deficient_of_dvd` — **deficiency propagates to divisors**: if `d ∣ n` and
+    `n` is deficient, then `d` is deficient. (Contrapositive flavour of
+    `abundant_mul_right`: if a divisor were abundant or perfect, the whole number
+    would be abundant, contradicting deficiency.) Proved from `sigma_dvd_mono`.
+
+  * `deficient_of_proper_dvd_perfect` — **every proper divisor of a perfect
+    number is deficient**: if `n` is perfect, `d ∣ n`, and `d < n`, then `d` is
+    deficient. (A proper divisor that were perfect or abundant would force `n`,
+    a proper multiple, to be abundant — impossible for a perfect `n`.) This is
+    the classical fact that perfect numbers sit exactly on the boundary: they are
+    not deficient themselves, yet all of their proper divisors are.
+
+  Concrete instances are recorded for the perfect numbers `6` and `28`
+  (`deficient_14`, etc.); note `14 = 2·7` is *not* a prime power, so its
+  deficiency is not covered by Mathlib's `Nat.IsPrimePow.deficient`.
+
+  The proof is axiom-free (no `sorry`, no `axiom`, no `native_decide`): the
+  monotonicity lemma is purely arithmetic over `ℕ`, and the propagation results
+  reuse the kernel-checked companion lemmas.
+-/
+import Mathlib
+import Proofs.AbundantMultiplesOQ01
+
+namespace AbundantDeficientDvdOQ04
+
+open Finset
+open AbundantMultiplesOQ01
+
+/-- The scaled-divisor injection bound. For `t > 0`, the map `e ↦ t·e` injects
+`divisors d` into `divisors (d*t)`, so `t·σ(d) ≤ σ(d*t)`. (The `d = 0` case is
+trivial: both sides are `0`.) -/
+theorem scaled_sigma_le (d t : ℕ) (ht : 0 < t) :
+    t * (∑ e ∈ d.divisors, e) ≤ ∑ e ∈ (d * t).divisors, e := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · simp
+  have hm : 0 < d * t := Nat.mul_pos hd ht
+  -- scaled divisors of `d` sit inside the divisors of `d * t`
+  have hsub : d.divisors.image (fun e => t * e) ⊆ (d * t).divisors := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨e, he, rfl⟩ := hx
+    rw [Nat.mem_divisors] at he ⊢
+    refine ⟨?_, hm.ne'⟩
+    rw [mul_comm d t]
+    exact mul_dvd_mul_left t he.1
+  -- scaling is injective on `divisors d` since `t > 0`
+  have hinj : Set.InjOn (fun e => t * e) (d.divisors : Set ℕ) :=
+    fun x _ y _ h => Nat.eq_of_mul_eq_mul_left ht h
+  have himg : ∑ x ∈ d.divisors.image (fun e => t * e), x = t * (∑ e ∈ d.divisors, e) := by
+    rw [Finset.sum_image hinj, Finset.mul_sum]
+  calc t * (∑ e ∈ d.divisors, e)
+      = ∑ x ∈ d.divisors.image (fun e => t * e), x := himg.symm
+    _ ≤ ∑ e ∈ (d * t).divisors, e := Finset.sum_le_sum_of_subset hsub
+
+/-- **Abundancy index is monotone along divisibility.** If `d ∣ n` and `n > 0`
+then `n · σ(d) ≤ d · σ(n)`, where `σ(m) = ∑_{e ∣ m} e`. Equivalently
+`σ(d)/d ≤ σ(n)/n`: passing to a multiple never decreases the abundancy index.
+This is the structural engine behind both the abundant and the deficient
+divisibility-propagation results. -/
+theorem sigma_dvd_mono {d n : ℕ} (hdvd : d ∣ n) (hn : 0 < n) :
+    n * (∑ e ∈ d.divisors, e) ≤ d * (∑ e ∈ n.divisors, e) := by
+  obtain ⟨t, rfl⟩ := hdvd
+  have hd : 0 < d := by
+    rcases Nat.eq_zero_or_pos d with rfl | h
+    · simp at hn
+    · exact h
+  have ht : 0 < t := by
+    rcases Nat.eq_zero_or_pos t with rfl | h
+    · simp at hn
+    · exact h
+  have key : t * (∑ e ∈ d.divisors, e) ≤ ∑ e ∈ (d * t).divisors, e := scaled_sigma_le d t ht
+  calc (d * t) * (∑ e ∈ d.divisors, e)
+      = d * (t * (∑ e ∈ d.divisors, e)) := by ring
+    _ ≤ d * (∑ e ∈ (d * t).divisors, e) := Nat.mul_le_mul (le_refl d) key
+
+/-- Divisor-sum form of deficiency: `n` is deficient iff `σ(n) < 2n`.
+(Bridge from Mathlib's proper-divisor definition; holds for every `n`, using
+`σ(n) = ∑ properDivisors n + n`.) -/
+theorem deficient_iff_sigma_lt_two_mul {n : ℕ} :
+    n.Deficient ↔ ∑ e ∈ n.divisors, e < 2 * n := by
+  unfold Nat.Deficient
+  rw [Nat.sum_divisors_eq_sum_properDivisors_add_self]
+  omega
+
+/-- A deficient number is positive. -/
+theorem pos_of_deficient {n : ℕ} (hn : n.Deficient) : 0 < n := by
+  rcases Nat.eq_zero_or_pos n with rfl | h
+  · simp [Nat.Deficient] at hn
+  · exact h
+
+/-- **Deficiency propagates to divisors.** If `d ∣ n` and `n` is deficient, then
+`d` is deficient. The mirror of `abundant_mul_right` (multiples of an abundant
+number are abundant): along divisibility the abundancy index only grows, so if
+the larger number `n` stays below the perfect threshold, so must every divisor. -/
+theorem deficient_of_dvd {d n : ℕ} (hdvd : d ∣ n) (hn : n.Deficient) : d.Deficient := by
+  have hnpos : 0 < n := pos_of_deficient hn
+  have hdpos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hnpos
+  have hn2 : ∑ e ∈ n.divisors, e < 2 * n := (deficient_iff_sigma_lt_two_mul).mp hn
+  have hmono : n * (∑ e ∈ d.divisors, e) ≤ d * (∑ e ∈ n.divisors, e) := sigma_dvd_mono hdvd hnpos
+  have hchain : n * (∑ e ∈ d.divisors, e) < n * (2 * d) :=
+    calc n * (∑ e ∈ d.divisors, e)
+        ≤ d * (∑ e ∈ n.divisors, e) := hmono
+      _ < d * (2 * n) := mul_lt_mul_of_pos_left hn2 hdpos
+      _ = n * (2 * d) := by ring
+  have hσd : ∑ e ∈ d.divisors, e < 2 * d := Nat.lt_of_mul_lt_mul_left hchain
+  exact (deficient_iff_sigma_lt_two_mul).mpr hσd
+
+/-- **Every proper divisor of a perfect number is deficient.** If `n` is perfect,
+`d ∣ n`, and `d < n`, then `d` is deficient. A proper divisor that were itself
+perfect or abundant would make `n` (a proper multiple, `t ≥ 2`) abundant via
+`abundant_of_perfect_mul` / `abundant_mul_right`, contradicting the perfection of
+`n`. Thus perfect numbers sit on the exact deficient/abundant boundary: not
+deficient themselves, but all of their proper divisors are. -/
+theorem deficient_of_proper_dvd_perfect {d n : ℕ}
+    (hp : n.Perfect) (hdvd : d ∣ n) (hlt : d < n) : d.Deficient := by
+  have hnpos : 0 < n := hp.2
+  have hdpos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hnpos
+  obtain ⟨t, rfl⟩ := hdvd
+  have ht2 : 2 ≤ t := by
+    have h1 : d * 1 < d * t := by simpa [Nat.mul_one] using hlt
+    have := Nat.lt_of_mul_lt_mul_left h1
+    omega
+  -- `n = d * t` is perfect, hence not abundant
+  have hnab : ¬ (d * t).Abundant := ((Nat.perfect_iff_not_abundant_and_not_deficient hnpos.ne).mp hp).1
+  rw [Nat.deficient_iff_not_abundant_and_not_perfect hdpos.ne']
+  refine ⟨?_, ?_⟩
+  · -- if `d` abundant then `d * t` abundant: contradiction
+    intro hab
+    exact hnab (abundant_mul_right hab (by omega))
+  · -- if `d` perfect then `d * t` abundant (proper multiple): contradiction
+    intro hper
+    exact hnab (abundant_of_perfect_mul hper ht2)
+
+/-! ### Concrete instances
+
+`6` and `28` are perfect, so all of their proper divisors are deficient. -/
+
+/-- `28 = 2²·7` is perfect: `1 + 2 + 4 + 7 + 14 = 28`. -/
+theorem perfect_28 : Nat.Perfect 28 := by
+  unfold Nat.Perfect
+  decide
+
+/-- `14 = 2·7` is deficient — and, not being a prime power, this is outside the
+scope of Mathlib's `Nat.IsPrimePow.deficient`. Obtained as a proper divisor of the
+perfect number `28`. -/
+theorem deficient_14 : Nat.Deficient 14 :=
+  deficient_of_proper_dvd_perfect perfect_28 (by norm_num) (by norm_num)
+
+/-- `3` is deficient, as a proper divisor of the perfect number `6`. -/
+theorem deficient_three_via_six : Nat.Deficient 3 :=
+  deficient_of_proper_dvd_perfect perfect_six (by norm_num) (by norm_num)
+
+end AbundantDeficientDvdOQ04

--- a/proofs/Proofs/DivisibilityTruncationGeneralOQ03OQ01.lean
+++ b/proofs/Proofs/DivisibilityTruncationGeneralOQ03OQ01.lean
@@ -1,0 +1,257 @@
+/-
+  Divisibility Truncation — Base-b Osculators (OQ-03 → OQ-01)
+
+  Generalizes the base-10 osculator theory of `DivisibilityTruncationGeneralOQ03`
+  ("Divisibility Osculators: Bézout Coefficients Are Canonical Osculators") to an
+  arbitrary radix b. For any modulus d coprime to b, the Bézout coefficient
+  gcdA(b, d) is a canonical osculator — d | b·gcdA(b,d) - 1 — and the truncation
+  divisibility test
+
+      d | n  ↔  d | (n / b + c · (n % b))
+
+  holds for any osculator c. This answers OQ-01 of the parent:
+
+    "Generalize to base b: is there an analogous osculator c with d | b·c - 1 for
+     any base b coprime to d? The Bézout argument generalizes directly."
+
+  ## Main Results (0 sorries, 0 axioms)
+
+  1. `unified_osculator_base`        — the base-b truncation divisibility test
+  2. `bezout_gives_osculator_base`   — gcdA(b,d) is an osculator when gcd(b,d)=1
+  3. `osculator_base_exists`         — a canonical osculator in [0,d) always exists
+  4. `osculator_base_unique_mod`     — osculators are unique mod d
+  5. `canonical_divisibility_test_base` — Bézout → base-b divisibility test pipeline
+  6. `recovers_base_ten`             — specializing b=10 recovers the parent's rule
+  7. Concrete examples: base-100 (digit-pair) rules for 7, 11, 13, 101;
+     hexadecimal (base-16) rules for 3, 5, 17.
+
+  The base-10 development is hard-coded to radix 10 (the digit split n = 10·(n/10)
+  + n%10 is baked into its `unified_osculator`); here the radix is a free parameter,
+  so the same osculator concept produces divisibility tests in every base at once —
+  e.g. hexadecimal digit-sum tests 3 and 5, hexadecimal alternating-digit tests 17,
+  and the classical "pairs of decimal digits" tests for 7, 11, 13, 101 in base 100.
+-/
+
+import Mathlib.Tactic
+
+namespace DivisibilityTruncationGeneralOQ03OQ01
+
+-- ============================================================
+-- PART I: The Base-b Osculator and Divisibility Test
+-- ============================================================
+
+/-- `c` is a base-`b` osculator for `d` if `d | b·c - 1` (c is the modular
+    inverse of the radix b modulo d). -/
+def IsOsculatorBase (b d : ℕ) (c : ℤ) : Prop := (d : ℤ) ∣ (b : ℤ) * c - 1
+
+/-- Digit split in base b: every n decomposes as n = b·(n/b) + (n%b). -/
+private lemma div_mod_cast_base (b n : ℕ) :
+    (n : ℤ) = (b : ℤ) * ↑(n / b) + ↑(n % b) := by
+  have h : b * (n / b) + n % b = n := Nat.div_add_mod n b
+  exact_mod_cast h.symm
+
+/-- **The Base-b Unified Osculator Theorem.**
+
+    For any modulus d coprime to the radix b and any osculator c (d | b·c - 1):
+
+      d | n  ↔  d | (n / b + c · (n % b)).
+
+    This is the radix-independent core of the truncation divisibility test: the
+    base-10 statement of the parent is the special case b = 10. The proof rests on
+
+      b · (n/b + c·(n%b)) = n + (b·c - 1)·(n%b),
+
+    so when d | (b·c - 1), divisibility transfers across the coprime factor b. -/
+theorem unified_osculator_base (b d : ℕ) (c : ℤ) (n : ℕ)
+    (hcop : IsCoprime (d : ℤ) (b : ℤ))
+    (hc : (d : ℤ) ∣ (b : ℤ) * c - 1) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / b) + c * ↑(n % b)) := by
+  have hdiv := div_mod_cast_base b n
+  have hkey : (b : ℤ) * (↑(n / b) + c * ↑(n % b))
+      = ↑n + ((b : ℤ) * c - 1) * ↑(n % b) := by
+    linear_combination -hdiv
+  constructor
+  · intro hn
+    have h1 : (d : ℤ) ∣ ↑n + ((b : ℤ) * c - 1) * ↑(n % b) :=
+      dvd_add hn (dvd_mul_of_dvd_left hc _)
+    rw [← hkey] at h1
+    exact hcop.dvd_of_dvd_mul_left h1
+  · intro hq
+    have hb : (d : ℤ) ∣ (b : ℤ) * (↑(n / b) + c * ↑(n % b)) :=
+      dvd_mul_of_dvd_right hq _
+    rw [hkey] at hb
+    have hterm : (d : ℤ) ∣ ((b : ℤ) * c - 1) * ↑(n % b) := dvd_mul_of_dvd_left hc _
+    have hsub := Int.dvd_sub hb hterm
+    simp only [add_sub_cancel_right] at hsub
+    exact_mod_cast hsub
+
+-- ============================================================
+-- PART II: Bézout Coefficients Give Osculators
+-- ============================================================
+
+/-- Bézout identity for the radix: gcd(b,d) = b·gcdA(b,d) + d·gcdB(b,d). -/
+theorem bezout_base (b d : ℕ) :
+    (Nat.gcd b d : ℤ) = b * Nat.gcdA b d + d * Nat.gcdB b d :=
+  Nat.gcd_eq_gcd_ab b d
+
+/-- When gcd(b,d) = 1, gcdA(b,d) is a valid base-b osculator: d | b·gcdA(b,d) - 1. -/
+theorem bezout_gives_osculator_base (b d : ℕ) (hcop : Nat.Coprime b d) :
+    IsOsculatorBase b d (Nat.gcdA b d) := by
+  have hbez := bezout_base b d
+  rw [show (Nat.gcd b d : ℤ) = 1 from by exact_mod_cast hcop] at hbez
+  exact ⟨-Nat.gcdB b d, by linear_combination -hbez⟩
+
+/-- Bézout → base-b divisibility test, end to end. -/
+theorem canonical_divisibility_test_base (b d : ℕ) (n : ℕ) (hcop : Nat.Coprime b d) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / b) + Nat.gcdA b d * ↑(n % b)) :=
+  unified_osculator_base b d (Nat.gcdA b d) n hcop.isCoprime.symm
+    (bezout_gives_osculator_base b d hcop)
+
+-- ============================================================
+-- PART III: Osculator Equivalence Classes
+-- ============================================================
+
+/-- If c' ≡ c (mod d) and c is a base-b osculator, so is c'. -/
+theorem osculator_base_congr (b d : ℕ) (c c' : ℤ)
+    (hc : IsOsculatorBase b d c) (heq : (d : ℤ) ∣ c' - c) :
+    IsOsculatorBase b d c' := by
+  unfold IsOsculatorBase at *
+  have : (b : ℤ) * c' - 1 = ((b : ℤ) * c - 1) + (b : ℤ) * (c' - c) := by ring
+  rw [this]; exact dvd_add hc (dvd_mul_of_dvd_right heq (b : ℤ))
+
+/-- Base-b osculators are unique mod d: d | c - c' for any two osculators. -/
+theorem osculator_base_unique_mod (b d : ℕ) (hcop : Nat.Coprime b d) (c c' : ℤ)
+    (hc : IsOsculatorBase b d c) (hc' : IsOsculatorBase b d c') :
+    (d : ℤ) ∣ c - c' := by
+  unfold IsOsculatorBase at *
+  have hdiff : (d : ℤ) ∣ (b : ℤ) * (c - c') := by
+    have : (b : ℤ) * (c - c') = ((b : ℤ) * c - 1) - ((b : ℤ) * c' - 1) := by ring
+    rw [this]; exact dvd_sub hc hc'
+  exact IsCoprime.dvd_of_dvd_mul_left hcop.isCoprime.symm hdiff
+
+-- ============================================================
+-- PART IV: The Canonical Reduced Osculator Exists in [0, d)
+-- ============================================================
+
+/-- gcdA(b,d) reduced mod d is still a base-b osculator. -/
+theorem osculator_base_mod (b d : ℕ) (_hd : 0 < d) (hcop : Nat.Coprime b d) :
+    IsOsculatorBase b d (Nat.gcdA b d % d) := by
+  apply osculator_base_congr b d (Nat.gcdA b d) _ (bezout_gives_osculator_base b d hcop)
+  refine ⟨-(Nat.gcdA b d / ↑d), ?_⟩
+  have h := Int.emod_add_mul_ediv (Nat.gcdA b d) (d : ℤ)
+  linarith
+
+/-- A canonical base-b osculator always exists as a natural number in [0, d). -/
+theorem osculator_base_exists (b d : ℕ) (hd : 1 < d) (hcop : Nat.Coprime b d) :
+    ∃ c : ℕ, c < d ∧ IsOsculatorBase b d c := by
+  have hd_pos : 0 < d := Nat.lt_trans Nat.zero_lt_one hd
+  have hd_pos_z : (0 : ℤ) < d := by exact_mod_cast hd_pos
+  have hd_ne_z : (d : ℤ) ≠ 0 := ne_of_gt hd_pos_z
+  set c₀ := Nat.gcdA b d % (d : ℤ) with hc0
+  have hnn : 0 ≤ c₀ := Int.emod_nonneg _ hd_ne_z
+  have hlt : c₀ < (d : ℤ) := Int.emod_lt_of_pos _ hd_pos_z
+  have hosc : IsOsculatorBase b d c₀ := osculator_base_mod b d hd_pos hcop
+  refine ⟨c₀.toNat, ?_, ?_⟩
+  · have hconv : (c₀.toNat : ℤ) = c₀ := Int.toNat_of_nonneg hnn
+    have : (c₀.toNat : ℤ) < (d : ℤ) := by rw [hconv]; exact hlt
+    exact_mod_cast this
+  · unfold IsOsculatorBase at hosc ⊢
+    rw [Int.toNat_of_nonneg hnn]; exact hosc
+
+-- ============================================================
+-- PART V: Concrete Examples — Base 100 (pairs of decimal digits)
+-- ============================================================
+
+/-- Base 100, d = 7: osculator 4 (100·4 - 1 = 399 = 7·57). -/
+theorem osculator_base100_seven : IsOsculatorBase 100 7 4 := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 7 | n ↔ 7 | (n/100 + 4·(n%100)) — group the decimal digits in pairs. -/
+theorem div_by_seven_base100 (n : ℕ) :
+    (7 : ℤ) ∣ n ↔ (7 : ℤ) ∣ (↑(n / 100) + (4 : ℤ) * ↑(n % 100)) :=
+  unified_osculator_base 100 7 4 n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base100_seven
+
+/-- Base 100, d = 11: osculator 1 (100·1 - 1 = 99 = 11·9). -/
+theorem osculator_base100_eleven : IsOsculatorBase 100 11 1 := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 11 | n ↔ 11 | (n/100 + (n%100)) — sum the decimal digit-pairs. -/
+theorem div_by_eleven_base100 (n : ℕ) :
+    (11 : ℤ) ∣ n ↔ (11 : ℤ) ∣ (↑(n / 100) + (1 : ℤ) * ↑(n % 100)) :=
+  unified_osculator_base 100 11 1 n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base100_eleven
+
+/-- Base 100, d = 13: osculator 3 (100·3 - 1 = 299 = 13·23). -/
+theorem osculator_base100_thirteen : IsOsculatorBase 100 13 3 := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 13 | n ↔ 13 | (n/100 + 3·(n%100)). -/
+theorem div_by_thirteen_base100 (n : ℕ) :
+    (13 : ℤ) ∣ n ↔ (13 : ℤ) ∣ (↑(n / 100) + (3 : ℤ) * ↑(n % 100)) :=
+  unified_osculator_base 100 13 3 n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base100_thirteen
+
+/-- Base 100, d = 101: osculator -1 (100·(-1) - 1 = -101 = 101·(-1)) — the
+    base-100 alternating digit-pair rule (101 = 10² + 1). -/
+theorem osculator_base100_hundredone : IsOsculatorBase 100 101 (-1) := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 101 | n ↔ 101 | (n/100 - (n%100)) — alternate the decimal digit-pairs. -/
+theorem div_by_hundredone_base100 (n : ℕ) :
+    (101 : ℤ) ∣ n ↔ (101 : ℤ) ∣ (↑(n / 100) + (-1 : ℤ) * ↑(n % 100)) :=
+  unified_osculator_base 100 101 (-1) n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base100_hundredone
+
+-- ============================================================
+-- PART VI: Concrete Examples — Base 16 (hexadecimal)
+-- ============================================================
+
+/-- Hexadecimal, d = 3: osculator 1 (16·1 - 1 = 15 = 3·5) — hex digit-sum tests 3. -/
+theorem osculator_base16_three : IsOsculatorBase 16 3 1 := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 3 | n ↔ 3 | (n/16 + (n%16)) — sum the hexadecimal digits. -/
+theorem div_by_three_base16 (n : ℕ) :
+    (3 : ℤ) ∣ n ↔ (3 : ℤ) ∣ (↑(n / 16) + (1 : ℤ) * ↑(n % 16)) :=
+  unified_osculator_base 16 3 1 n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base16_three
+
+/-- Hexadecimal, d = 5: osculator 1 (16·1 - 1 = 15 = 5·3) — hex digit-sum tests 5. -/
+theorem osculator_base16_five : IsOsculatorBase 16 5 1 := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 5 | n ↔ 5 | (n/16 + (n%16)) — sum the hexadecimal digits. -/
+theorem div_by_five_base16 (n : ℕ) :
+    (5 : ℤ) ∣ n ↔ (5 : ℤ) ∣ (↑(n / 16) + (1 : ℤ) * ↑(n % 16)) :=
+  unified_osculator_base 16 5 1 n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base16_five
+
+/-- Hexadecimal, d = 17: osculator -1 (16·(-1) - 1 = -17 = 17·(-1)) — hex
+    alternating-digit rule (17 = 16 + 1). -/
+theorem osculator_base16_seventeen : IsOsculatorBase 16 17 (-1) := by
+  unfold IsOsculatorBase; norm_num
+
+/-- 17 | n ↔ 17 | (n/16 - (n%16)) — alternate the hexadecimal digits. -/
+theorem div_by_seventeen_base16 (n : ℕ) :
+    (17 : ℤ) ∣ n ↔ (17 : ℤ) ∣ (↑(n / 16) + (-1 : ℤ) * ↑(n % 16)) :=
+  unified_osculator_base 16 17 (-1) n
+    (by norm_num [Int.isCoprime_iff_gcd_eq_one]) osculator_base16_seventeen
+
+-- ============================================================
+-- PART VII: Specialization Recovers the Base-10 Parent
+-- ============================================================
+
+/-- Specializing the radix to b = 10 recovers the parent's canonical base-10
+    divisibility test, exhibiting the base-10 theory as one instance of the
+    radix-free statement. -/
+theorem recovers_base_ten (d : ℕ) (n : ℕ) (hcop : Nat.Coprime 10 d) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / 10) + Nat.gcdA 10 d * ↑(n % 10)) :=
+  canonical_divisibility_test_base 10 d n hcop
+
+#check @unified_osculator_base
+#check @bezout_gives_osculator_base
+#check @osculator_base_exists
+#check @recovers_base_ten
+
+end DivisibilityTruncationGeneralOQ03OQ01

--- a/proofs/Proofs/Hilbert23CalculusVariationsOQ01.lean
+++ b/proofs/Proofs/Hilbert23CalculusVariationsOQ01.lean
@@ -1,0 +1,166 @@
+/-
+# Hilbert's 23rd Problem (Calculus of Variations) — OQ-01: Regularity / sufficiency theory
+
+The parent entry `hilbert-23` sketches the calculus of variations as a research
+program and lists, as its first open question, *"What is the regularity theory for
+general variational problems?"*. The classical first‑order theory answers a clean,
+self‑contained slice of this: for a **convex** functional `J` the Euler–Lagrange /
+first‑variation condition is not merely *necessary* for a minimizer (the usual
+necessary condition) but also *sufficient*, and strict convexity upgrades this to a
+**uniqueness** statement.
+
+This file proves that package with **zero axioms**, working over an arbitrary real
+vector space `E` (no norm, no measure theory required):
+
+* `firstVariation_le_sub` — the convexity engine: the one‑sided directional
+  derivative of `J` at `y₀` toward `y` is at most `J y - J y₀`.
+* `firstVariation_nonneg_of_isMinOn` — **necessity**: at a minimizer every first
+  variation is `≥ 0`.
+* `isMinOn_of_firstVariation_nonneg` — **sufficiency**: if `J` is convex and every
+  first variation at `y₀` is `≥ 0`, then `y₀` is a global minimizer.
+* `isMinOn_iff_firstVariation_nonneg` — the resulting necessary‑and‑sufficient
+  first‑order characterization for convex variational problems.
+* `subsingleton_minimizers_of_strictConvex` — strict convexity ⇒ the minimizer is
+  unique.
+* A concrete instance (`example_*`) on `J y = y^2`.
+
+The "first variation" of `J` at `y₀` in the direction of `y` is the right‑hand
+derivative at `t = 0` of the path `t ↦ J(y₀ + t·(y - y₀))`; for a convex `J` this is
+the Gateaux derivative restricted to admissible directions.  All proofs go through
+Mathlib's convexity slope monotonicity, so the entry is fully machine‑checked.
+-/
+import Mathlib
+
+open Set Filter Topology
+
+namespace Hilbert23OQ01
+
+variable {E : Type*} [AddCommGroup E] [Module ℝ E]
+
+/-- The variational path from `y₀` toward `y`: `φ(t) = J(y₀ + t·(y - y₀))`.
+Its right derivative at `0` is the first variation of `J` at `y₀` in direction
+`y - y₀`. -/
+noncomputable def segPath (J : E → ℝ) (y₀ y : E) : ℝ → ℝ :=
+  fun t => J (y₀ + t • (y - y₀))
+
+@[simp] lemma segPath_zero (J : E → ℝ) (y₀ y : E) : segPath J y₀ y 0 = J y₀ := by
+  simp [segPath]
+
+/-- The path point is the convex combination `(1 - t)·y₀ + t·y`. -/
+lemma segPath_eq_combo (J : E → ℝ) (y₀ y : E) (t : ℝ) :
+    segPath J y₀ y t = J ((1 - t) • y₀ + t • y) := by
+  unfold segPath
+  congr 1
+  module
+
+/-- **Convexity engine.** For a convex functional `J`, the first variation `d` of `J`
+at `y₀` toward `y` (the right derivative of `segPath J y₀ y` at `0`) is bounded above
+by the actual change in value `J y - J y₀`.  This is the quantitative form of "the
+tangent line of a convex function lies below it." -/
+lemma firstVariation_le_sub {J : E → ℝ} (hJ : ConvexOn ℝ univ J)
+    {y₀ y : E} {d : ℝ}
+    (hd : HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0) :
+    d ≤ J y - J y₀ := by
+  -- Convexity gives, for every `t ∈ (0,1]`, a slope bound.
+  have key : ∀ t : ℝ, 0 < t → t ≤ 1 →
+      segPath J y₀ y t - J y₀ ≤ t * (J y - J y₀) := by
+    intro t ht ht1
+    rw [segPath_eq_combo]
+    have hc := hJ.2 (mem_univ y₀) (mem_univ y)
+      (show (0:ℝ) ≤ 1 - t by linarith) (show (0:ℝ) ≤ t from le_of_lt ht)
+      (show (1 - t) + t = 1 by ring)
+    simp only [smul_eq_mul] at hc
+    nlinarith [hc]
+  -- Pass to the limit `t → 0⁺`: the right derivative is `≤` every such slope bound.
+  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_diff_left] at hd
+  refine le_of_tendsto hd ?_
+  have hlt1 : ∀ᶠ t in 𝓝[Ioi (0:ℝ)] 0, t < 1 := by
+    have hmem : Iio (1 : ℝ) ∈ 𝓝 (0 : ℝ) := isOpen_Iio.mem_nhds (by norm_num)
+    filter_upwards [nhdsWithin_le_nhds hmem] with t ht using ht
+  filter_upwards [hlt1, self_mem_nhdsWithin] with t ht1 ht0
+  have ht0' : 0 < t := ht0
+  rw [slope_def_field, segPath_zero, sub_zero]
+  rw [div_le_iff₀ ht0', mul_comm]
+  exact key t ht0' (le_of_lt ht1)
+
+/-- **Necessity (Euler–Lagrange necessary condition).** If `y₀` is a global minimizer
+of `J`, then every first variation of `J` at `y₀` is nonnegative. -/
+lemma firstVariation_nonneg_of_isMinOn {J : E → ℝ} {y₀ y : E} {d : ℝ}
+    (hmin : ∀ z, J y₀ ≤ J z)
+    (hd : HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0) :
+    0 ≤ d := by
+  rw [hasDerivWithinAt_iff_tendsto_slope, Ici_diff_left] at hd
+  refine ge_of_tendsto hd ?_
+  filter_upwards [self_mem_nhdsWithin] with t ht0
+  have ht0' : 0 < t := ht0
+  rw [slope_def_field, segPath_zero, sub_zero]
+  apply div_nonneg _ (le_of_lt ht0')
+  have h := hmin (y₀ + t • (y - y₀))
+  simpa [segPath] using sub_nonneg.mpr h
+
+/-- **Sufficiency.** For a convex functional `J`, if at `y₀` every first variation
+exists and is nonnegative, then `y₀` is a global minimizer.  This is the variational
+sufficiency theorem: for convex problems the first‑order condition is enough. -/
+theorem isMinOn_of_firstVariation_nonneg {J : E → ℝ} (hJ : ConvexOn ℝ univ J) {y₀ : E}
+    (hcrit : ∀ y, ∃ d, HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0 ∧ 0 ≤ d) :
+    ∀ y, J y₀ ≤ J y := by
+  intro y
+  obtain ⟨d, hd, hd0⟩ := hcrit y
+  have := firstVariation_le_sub hJ hd
+  linarith
+
+/-- **First‑order characterization of minimizers for convex variational problems.**
+Assume `J` is convex and Gateaux‑differentiable at `y₀` along every admissible
+direction.  Then `y₀` is a global minimizer **iff** every first variation of `J` at
+`y₀` is nonnegative — the necessary‑and‑sufficient Euler–Lagrange condition. -/
+theorem isMinOn_iff_firstVariation_nonneg {J : E → ℝ} (hJ : ConvexOn ℝ univ J) {y₀ : E}
+    (hdiff : ∀ y, ∃ d, HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0) :
+    (∀ y, J y₀ ≤ J y) ↔
+      (∀ y d, HasDerivWithinAt (segPath J y₀ y) d (Ici 0) 0 → 0 ≤ d) := by
+  constructor
+  · intro hmin y d hd
+    exact firstVariation_nonneg_of_isMinOn hmin hd
+  · intro hcrit y
+    obtain ⟨d, hd⟩ := hdiff y
+    have hle := firstVariation_le_sub hJ hd
+    have hge := hcrit y d hd
+    linarith
+
+/-- **Uniqueness (regularity from strict convexity).** A strictly convex functional has
+at most one global minimizer.  Combined with the sufficiency theorem above, this is the
+classical statement that strictly convex variational problems are well‑posed: any
+solution of the Euler–Lagrange equation is *the* minimizer. -/
+theorem subsingleton_minimizers_of_strictConvex {J : E → ℝ}
+    (hJ : StrictConvexOn ℝ univ J) {a b : E}
+    (ha : ∀ z, J a ≤ J z) (hb : ∀ z, J b ≤ J z) : a = b := by
+  by_contra hne
+  have hlt := hJ.2 (mem_univ a) (mem_univ b) hne
+    (by norm_num : (0:ℝ) < 1/2) (by norm_num : (0:ℝ) < 1/2) (by norm_num)
+  simp only [smul_eq_mul] at hlt
+  have hmid : J a ≤ J ((1/2 : ℝ) • a + (1/2 : ℝ) • b) := ha _
+  have hab : J a = J b := le_antisymm (ha b) (hb a)
+  linarith
+
+/-! ## A concrete instance: the energy `J y = y²`
+
+The simplest variational problem: minimize `J y = y²` over `ℝ`.  It is strictly
+convex, its unique minimizer is `0`, and the first‑order characterization applies. -/
+
+/-- `J y = y²` is convex on all of `ℝ`. -/
+theorem example_convex : ConvexOn ℝ univ (fun y : ℝ => y ^ 2) :=
+  (Even.strictConvexOn_pow (n := 2) ⟨1, by ring⟩ (by norm_num)).convexOn
+
+/-- `J y = y²` is strictly convex on all of `ℝ`. -/
+theorem example_strictConvex : StrictConvexOn ℝ univ (fun y : ℝ => y ^ 2) :=
+  Even.strictConvexOn_pow (n := 2) ⟨1, by ring⟩ (by norm_num)
+
+/-- `0` is a global minimizer of `J y = y²`. -/
+theorem example_zero_isMin : ∀ z : ℝ, (fun y : ℝ => y ^ 2) 0 ≤ (fun y : ℝ => y ^ 2) z := by
+  intro z; dsimp only; nlinarith [sq_nonneg z]
+
+/-- The minimizer of `J y = y²` is unique: it is exactly `0`. -/
+theorem example_unique_minimizer {a : ℝ}
+    (ha : ∀ z : ℝ, (fun y : ℝ => y ^ 2) a ≤ (fun y : ℝ => y ^ 2) z) : a = 0 :=
+  subsingleton_minimizers_of_strictConvex example_strictConvex ha example_zero_isMin
+
+end Hilbert23OQ01

--- a/src/data/proofs/abundant-number-oq-04/meta.json
+++ b/src/data/proofs/abundant-number-oq-04/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "abundant-number-oq-04",
+  "title": "The Deficient Side: Divisors of Deficient Numbers Are Deficient, and Abundancy Is Monotone Along Divisibility",
+  "slug": "abundant-number-oq-04",
+  "description": "A positive integer n is abundant when σ(n) > 2n, perfect when σ(n) = 2n, and deficient when σ(n) < 2n (Mathlib's Nat.Abundant / Nat.Perfect / Nat.Deficient). The companion entries in this family develop the ABUNDANT side of divisibility: every positive multiple of an abundant number is abundant (abundant_mul_right), and every proper multiple of a perfect number is abundant (abundant_of_perfect_mul). This entry proves the mirror-image DEFICIENT facts, which Mathlib does not record. The structural engine is abundancy-index monotonicity along divisibility: if d ∣ n (n > 0) then n·σ(d) ≤ d·σ(n), i.e. σ(d)/d ≤ σ(n)/n — passing to a multiple never decreases the abundancy index. From it, deficiency propagates to divisors (d ∣ n with n deficient ⟹ d deficient), and every proper divisor of a perfect number is deficient (n perfect, d ∣ n, d < n ⟹ d deficient), placing perfect numbers exactly on the deficient/abundant boundary. Concrete corollaries record that 14 = 2·7 is deficient as a proper divisor of the perfect number 28 — outside the scope of Mathlib's Nat.IsPrimePow.deficient since 14 is not a prime power. Fully machine-checked with 0 axioms and 0 sorries; the monotonicity lemma is purely arithmetic over ℕ and the propagation results reuse the kernel-checked companion lemmas.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A005100 (deficient numbers), A000396 (perfect numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantDeficientDvdOQ04.lean",
+    "badge": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "deficient-numbers",
+      "perfect-numbers",
+      "divisibility",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 174,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms` on deficient_of_dvd, deficient_of_proper_dvd_perfect, sigma_dvd_mono, and deficient_14 reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no native_decide, hence no Lean.ofReduceBool. The concrete instances (perfect_28, deficient_14) are discharged by kernel `decide` over a small divisor sum. The propagation results reuse abundant_mul_right and abundant_of_perfect_mul (purely arithmetic closure lemmas from abundant-number-oq-01).",
+    "originalContributions": [
+      "Proves `sigma_dvd_mono : d ∣ n → 0 < n → n · σ(d) ≤ d · σ(n)`, the monotonicity of the abundancy index σ(n)/n along divisibility — a single ℕ-arithmetic inequality Mathlib does not record, obtained via the scaled-divisor injection e ↦ (n/d)·e which embeds divisors d into divisors n.",
+      "Proves `deficient_of_dvd : d ∣ n → n.Deficient → d.Deficient` — deficiency propagates to divisors. This is the mirror of abundant_mul_right (multiples of an abundant number are abundant) and is derived directly from sigma_dvd_mono together with the divisor-sum form of deficiency (deficient_iff_sigma_lt_two_mul).",
+      "Proves `deficient_of_proper_dvd_perfect : n.Perfect → d ∣ n → d < n → d.Deficient` — every proper divisor of a perfect number is deficient. A proper divisor that were perfect or abundant would force n (a proper multiple, t ≥ 2) to be abundant via abundant_of_perfect_mul / abundant_mul_right, contradicting perfection; so perfect numbers sit on the exact deficient/abundant boundary.",
+      "Records concrete instances perfect_28 (28 = 2²·7 is perfect) and deficient_14 (14 = 2·7 is deficient as a proper divisor of 28), together with deficient_three_via_six. Because 14 is not a prime power, its deficiency lies outside Mathlib's Nat.IsPrimePow.deficient — the proper-divisor-of-perfect route supplies it for free.",
+      "Supplies the divisor-sum bridge deficient_iff_sigma_lt_two_mul : n.Deficient ↔ σ(n) < 2n (the deficient analogue of the abundant bridge abundant_iff_two_mul_lt_sigma), valid for every n via σ(n) = ∑ properDivisors n + n."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of integers as deficient (σ(n) < 2n), perfect (σ(n) = 2n), or abundant (σ(n) > 2n) dates to Nicomachus of Gerasa (~100 CE). A recurring structural theme is that the abundancy index h(n) = σ(n)/n is monotone non-decreasing along divisibility: if d ∣ n then h(d) ≤ h(n). This single fact organizes much of the elementary theory — it makes the abundant numbers closed upward under multiples and, dually, the deficient numbers closed downward under divisors, and it pins perfect numbers (h = 2) as the exact threshold separating the two. In particular every proper divisor of a perfect number is deficient, a classical observation already implicit in Euclid's study of perfect numbers. Mathlib records the Nat.Abundant / Nat.Perfect / Nat.Deficient predicates and that prime powers are deficient (Nat.IsPrimePow.deficient), but not the divisibility-monotonicity of the abundancy index nor the deficient-side closure results.",
+    "problemStatement": "Working with Mathlib's σ(n) = ∑_{d ∣ n} d and the predicates Nat.Abundant / Nat.Perfect / Nat.Deficient, prove (i) abundancy-index monotonicity along divisibility n·σ(d) ≤ d·σ(n) for d ∣ n, (ii) that deficiency propagates to divisors, and (iii) that every proper divisor of a perfect number is deficient. Keep everything axiom-free, reusing the abundant-side closure lemmas (abundant_mul_right, abundant_of_perfect_mul) rather than recomputing divisor sums.",
+    "text": "A self-contained Lean 4 / Mathlib formalization (174 lines, 0 sorries, 0 axioms) that develops the deficient counterpart to the abundant-side closure results of abundant-number-oq-01. The conceptual core is sigma_dvd_mono, the inequality n·σ(d) ≤ d·σ(n) for d ∣ n, proved by the same scaled-divisor injection that powers abundant_mul_right: the map e ↦ (n/d)·e injects divisors d into divisors n, giving (n/d)·σ(d) ≤ σ(n), and multiplying by d clears the division. Monotonicity immediately yields deficient_of_dvd (divisors of deficient numbers are deficient). The boundary result deficient_of_proper_dvd_perfect — proper divisors of perfect numbers are deficient — needs strictness that monotonicity alone does not give, so it argues by trichotomy: a non-deficient proper divisor would be perfect or abundant, and either way makes the perfect number a proper multiple that is abundant, a contradiction. Concrete instances (14 deficient as a divisor of the perfect 28, outside Mathlib's prime-power lemma) close the file.",
+    "proofStrategy": "1. **Scaled-divisor injection (scaled_sigma_le).** For t > 0, e ↦ t·e injects divisors d into divisors (d·t) (mul_dvd_mul_left, injectivity by left-cancellation), so summing gives t·σ(d) ≤ σ(d·t) via Finset.sum_le_sum_of_subset.\n\n2. **Abundancy monotonicity (sigma_dvd_mono).** Write n = d·t. Then (d·t)·σ(d) = d·(t·σ(d)) ≤ d·σ(d·t), i.e. n·σ(d) ≤ d·σ(n), by Nat.mul_le_mul on step 1.\n\n3. **Deficiency bridge (deficient_iff_sigma_lt_two_mul).** n.Deficient ↔ σ(n) < 2n, from σ(n) = ∑ properDivisors n + n (Nat.sum_divisors_eq_sum_properDivisors_add_self) and omega — valid for all n.\n\n4. **Deficiency propagates to divisors (deficient_of_dvd).** From n·σ(d) ≤ d·σ(n) < d·(2n) = n·(2d), cancel the positive factor n (Nat.lt_of_mul_lt_mul_left) to get σ(d) < 2d, i.e. d deficient.\n\n5. **Proper divisors of perfect numbers (deficient_of_proper_dvd_perfect).** Write n = d·t with t ≥ 2 (from d < n, d > 0). A perfect n is not abundant; if d were abundant (abundant_mul_right) or perfect (abundant_of_perfect_mul, t ≥ 2) then n = d·t would be abundant — contradiction. By Nat.deficient_iff_not_abundant_and_not_perfect, d is deficient.\n\n6. **Concrete instances.** perfect_28 by kernel decide; deficient_14 / deficient_three_via_six as proper divisors of 28 / 6.",
+    "keyInsights": [
+      "**One inequality, two closure laws.** Abundancy-index monotonicity σ(d)/d ≤ σ(n)/n for d ∣ n is the single structural fact behind both directions: it makes the abundant numbers closed upward under multiples and the deficient numbers closed downward under divisors. The deficient closure is literally the abundant closure read in the contrapositive direction along the same scaled-divisor injection.",
+      "**Monotonicity gives ≤, the boundary needs <.** Deficiency propagation works directly from the non-strict inequality n·σ(d) ≤ d·σ(n) because n is strictly below the threshold. But a proper divisor of a perfect number only gives σ(d) ≤ 2d from monotonicity; the strict deficiency (ruling out d itself being perfect) requires the trichotomy argument that a perfect-or-abundant proper divisor would make the whole perfect number abundant.",
+      "**Perfect numbers are the exact deficient/abundant boundary.** A perfect number is neither deficient nor abundant, yet every one of its proper divisors is strictly deficient and every proper multiple is strictly abundant. The two companion results (abundant_of_perfect_mul on the multiple side, deficient_of_proper_dvd_perfect here on the divisor side) together pin this boundary precisely.",
+      "**Reuse beats recomputation.** No new divisor-sum computation is performed beyond the small kernel `decide` for perfect_28. The proofs compose the abundant-side closure lemmas (abundant_mul_right, abundant_of_perfect_mul) with a single new arithmetic inequality, mirroring how the odd-infinitude entry composed abundant_945 with abundant_mul_right.",
+      "**Beyond prime powers.** Mathlib already proves prime powers are deficient (Nat.IsPrimePow.deficient). The proper-divisor-of-perfect route certifies deficiency for non-prime-power numbers such as 14 = 2·7 (a proper divisor of the perfect 28) for free — a strictly larger supply of certified deficient numbers."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ and the abundant / deficient / perfect classification (Nat.Abundant, Nat.Perfect, Nat.Deficient)",
+      "Closure of abundant numbers under positive multiples (abundant_mul_right) and of perfect numbers' proper multiples (abundant_of_perfect_mul), from abundant-number-oq-01",
+      "Finset image/subset reasoning for divisor sums (Finset.sum_le_sum_of_subset, Finset.sum_image)",
+      "The trichotomy deficient ∨ perfect ∨ abundant and the iff characterizations (Nat.deficient_iff_not_abundant_and_not_perfect, Nat.perfect_iff_not_abundant_and_not_deficient)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring: the deficient side of divisibility. States abundancy-index monotonicity along divisibility, deficiency propagation to divisors, and that proper divisors of perfect numbers are deficient, framed as the mirror of the abundant-side closure results in AbundantMultiplesOQ01.",
+      "mathContext": "The abundancy index σ(n)/n is non-decreasing along divisibility; this organizes the deficient/perfect/abundant structure."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Abundancy-Index Monotonicity",
+      "startLine": 50,
+      "endLine": 95,
+      "summary": "`scaled_sigma_le` injects divisors d into divisors (d·t) via e ↦ t·e, giving t·σ(d) ≤ σ(d·t); `sigma_dvd_mono` then multiplies by d to obtain n·σ(d) ≤ d·σ(n) for d ∣ n.",
+      "mathContext": "σ(d)/d ≤ σ(n)/n: passing to a multiple never decreases the abundancy index."
+    },
+    {
+      "id": "deficient-closure",
+      "title": "Deficiency Propagates to Divisors",
+      "startLine": 96,
+      "endLine": 127,
+      "summary": "`deficient_iff_sigma_lt_two_mul` bridges Nat.Deficient to σ(n) < 2n; `pos_of_deficient` records positivity; `deficient_of_dvd` chains n·σ(d) ≤ d·σ(n) < n·2d and cancels n to conclude σ(d) < 2d.",
+      "mathContext": "A divisor of a number below the perfect threshold is itself below the threshold."
+    },
+    {
+      "id": "perfect-boundary",
+      "title": "Proper Divisors of Perfect Numbers",
+      "startLine": 129,
+      "endLine": 153,
+      "summary": "`deficient_of_proper_dvd_perfect` writes n = d·t (t ≥ 2) and argues by trichotomy: a perfect/abundant proper divisor d would make n abundant via abundant_of_perfect_mul / abundant_mul_right, contradicting perfection of n.",
+      "mathContext": "Perfect numbers are the exact boundary: every proper divisor is strictly deficient."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "startLine": 155,
+      "endLine": 174,
+      "summary": "`perfect_28` (by kernel decide), `deficient_14` (14 = 2·7 as a proper divisor of 28, outside Mathlib's prime-power lemma), and `deficient_three_via_six`.",
+      "mathContext": "Non-prime-power deficiency certified for free from the perfect-boundary result."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sigma_dvd_mono",
+      "type": "core",
+      "description": "d ∣ n → 0 < n → n·σ(d) ≤ d·σ(n): the abundancy index σ(n)/n is monotone along divisibility. Proved by the scaled-divisor injection e ↦ (n/d)·e embedding divisors d into divisors n. The structural engine of the file.",
+      "leanType": "n * (∑ e ∈ d.divisors, e) ≤ d * (∑ e ∈ n.divisors, e)"
+    },
+    {
+      "name": "deficient_of_dvd",
+      "type": "core",
+      "description": "d ∣ n → n.Deficient → d.Deficient: deficiency propagates to divisors. The mirror of abundant_mul_right, derived from sigma_dvd_mono and the divisor-sum form of deficiency.",
+      "leanType": "d ∣ n → n.Deficient → d.Deficient"
+    },
+    {
+      "name": "deficient_of_proper_dvd_perfect",
+      "type": "core",
+      "description": "n.Perfect → d ∣ n → d < n → d.Deficient: every proper divisor of a perfect number is deficient. A non-deficient proper divisor would make n a proper multiple that is abundant, contradicting perfection.",
+      "leanType": "n.Perfect → d ∣ n → d < n → d.Deficient"
+    },
+    {
+      "name": "deficient_14",
+      "type": "supporting",
+      "description": "Nat.Deficient 14 — 14 = 2·7 is deficient as a proper divisor of the perfect number 28. Not a prime power, so outside the scope of Mathlib's Nat.IsPrimePow.deficient.",
+      "leanType": "Nat.Deficient 14"
+    }
+  ],
+  "conclusion": {
+    "summary": "Using Mathlib's Nat.Abundant / Nat.Perfect / Nat.Deficient predicates, the entry proves the deficient-side companions to the abundant closure results: abundancy-index monotonicity along divisibility (n·σ(d) ≤ d·σ(n) for d ∣ n), that divisors of deficient numbers are deficient, and that every proper divisor of a perfect number is deficient. Concrete instances certify 14 = 2·7 deficient as a proper divisor of the perfect number 28 — outside Mathlib's prime-power deficiency lemma. Fully machine-checked, 0 axioms and 0 sorries, reusing the abundant-side closure lemmas without new divisor-sum computation.",
+    "implications": "Together with abundant_mul_right and abundant_of_perfect_mul (abundant-number-oq-01) the results pin perfect numbers as the exact deficient/abundant boundary: not deficient, not abundant, yet every proper divisor strictly deficient and every proper multiple strictly abundant. The monotonicity lemma sigma_dvd_mono is a reusable arithmetic inequality (σ(n)/n non-decreasing along divisibility) that Mathlib lacks; it would underwrite further abundancy-index results such as multiplicativity bounds and the structure of primitive abundant/deficient numbers.",
+    "openQuestions": [
+      "Prove that the abundancy index is *strictly* increasing at a proper multiple by a factor sharing no common refinement — i.e. quantify the gap σ(n)/n − σ(d)/d for d ∣ n, d < n, sharpening sigma_dvd_mono to a strict, lower-bounded inequality.",
+      "Formalize that the deficient numbers have natural density 1 − (density of abundant) − 0 (perfect numbers are density 0): combine deficient_of_dvd with the known density ≈ 0.2476 of abundant numbers to get the complementary deficient density ≈ 0.7524.",
+      "Characterize the *primitive* deficient numbers (deficient numbers all of whose multiples up to the next threshold remain deficient is vacuous; instead study primitive abundant numbers — abundant with all proper divisors deficient — for which deficient_of_proper_dvd_perfect is the perfect-number boundary case)."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005100: Deficient numbers (n with σ(n) < 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The deficient numbers; this entry proves they are closed under taking divisors."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "extends",
+      "description": "The oq-01 entry establishes abundant_mul_right (multiples of an abundant number are abundant) and abundant_of_perfect_mul (proper multiples of a perfect number are abundant) via the scaled-divisor injection. This entry develops the mirror-image deficient side from the same injection, proving abundancy-index monotonicity, that divisors of deficient numbers are deficient, and that proper divisors of perfect numbers are deficient."
+    },
+    {
+      "targetId": "abundant-number-oq-02",
+      "relationship": "related",
+      "description": "The oq-02 entry proves 945 is the smallest odd abundant number via a kernel-reducible σ. This entry uses the perfect numbers 6 and 28 and the same Nat.Abundant/Perfect/Deficient framework to certify deficiency of non-prime-power numbers such as 14 as proper divisors of perfect numbers."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantDeficientDvdOQ04.lean",
+    "namespace": "AbundantDeficientDvdOQ04",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantMultiplesOQ01"
+    ],
+    "lineCount": 174,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 9,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/divisibility-truncation-general-oq-03-oq-01/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-03-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "divisibility-truncation-general-oq-03-oq-01",
+  "title": "Base-b Divisibility Osculators: Bézout Coefficients in Every Radix",
+  "slug": "divisibility-truncation-general-oq-03-oq-01",
+  "description": "A complete Lean 4 proof generalizing the base-10 divisibility osculator theory to an arbitrary radix b. For any modulus d coprime to b, the Bézout coefficient gcdA(b,d) is a canonical osculator (d | b·gcdA(b,d) − 1), and the truncation divisibility test d | n ↔ d | (n/b + c·(n%b)) holds for every osculator c. Proves: the radix-free unified osculator theorem; Bézout gives an osculator; osculators are unique mod d; a canonical osculator exists in [0,d); and that specializing b=10 recovers the parent's base-10 rule. Includes concrete digit-pair (base-100) tests for 7, 11, 13, 101 and hexadecimal (base-16) tests for 3, 5, 17. All results: 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DivisibilityTruncationGeneralOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "euclidean-algorithm",
+      "modular-arithmetic",
+      "radix",
+      "elementary-number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using only Mathlib.",
+    "lineCount": 257,
+    "theoremCount": 24,
+    "definitionCount": 1,
+    "originalContributions": [
+      "unified_osculator_base: the radix-free truncation divisibility test — for d coprime to b and any osculator c (d | b·c−1), d | n ↔ d | (n/b + c·(n%b)). The parent's unified_osculator hard-codes radix 10 in its digit split; here the base is a free parameter.",
+      "bezout_gives_osculator_base: gcdA(b,d) is a valid osculator in base b whenever gcd(b,d)=1, via the Bézout identity 1 = b·gcdA(b,d) + d·gcdB(b,d).",
+      "osculator_base_exists: a canonical osculator always exists as a natural number c < d (gcdA(b,d) reduced mod d, converted via Int.toNat).",
+      "osculator_base_unique_mod: all base-b osculators are congruent mod d, via coprimality of b and d.",
+      "recovers_base_ten: specializing the radix to b=10 recovers the parent's canonical base-10 divisibility test, exhibiting the base-10 theory as one instance of the radix-free statement.",
+      "Concrete new tests obtained uniformly: base-100 digit-pair rules for 7 (c=4), 11 (c=1), 13 (c=3), 101 (c=−1, alternating pairs); hexadecimal digit-sum tests for 3 and 5 (c=1) and the hex alternating-digit test for 17 (c=−1)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Truncation divisibility tests — replacing n by ⌊n/b⌋ + c·(n mod b) — are classical for base 10, where c is the 'osculator' for d (a modular inverse of the radix, c ≡ b⁻¹ mod d). The parent entry (OQ-03) established that for base 10 the osculator is exactly the Bézout coefficient gcdA(10,d). But nothing about the construction is special to ten: the Euclidean algorithm produces Bézout coefficients for any pair (b,d), and the digit split n = b·⌊n/b⌋ + (n mod b) holds in every radix. This entry makes the radix a free parameter, so the same osculator concept yields divisibility tests simultaneously in every base — recovering, for example, the classical 'pairs of decimal digits' tests modulo 7, 11, 13, 101 (base 100) and the hexadecimal digit-sum tests for 3, 5, 15 and alternating-digit test for 17. Hardy and Wright's 'An Introduction to the Theory of Numbers' (Chapter X) covers modular inverses and the Euclidean algorithm that underpin the construction in any base.",
+    "problemStatement": "OQ-01 of the parent asks: **Generalize to base b** — is there an analogous osculator c with d | b·c − 1 for any base b coprime to d, and does the Bézout argument generalize directly? Formalize the radix-free divisibility test d | n ↔ d | (⌊n/b⌋ + c·(n mod b)), the existence of a canonical osculator gcdA(b,d) mod d in [0,d), and confirm that b=10 recovers the parent.",
+    "proofStrategy": "**Step 1 (Radix-free test).** The single algebraic identity b·(⌊n/b⌋ + c·(n mod b)) = n + (b·c − 1)·(n mod b), together with d | (b·c − 1) and gcd(b,d) = 1, gives d | n ↔ d | (⌊n/b⌋ + c·(n mod b)) by transferring divisibility across the coprime factor b (IsCoprime.dvd_of_dvd_mul_left). This is unified_osculator_base, the radix-parametrized analogue of the parent's base-10 unified_osculator.\n\n**Step 2 (Bézout gives osculator).** The Bézout identity 1 = b·gcdA(b,d) + d·gcdB(b,d) rearranges to d | b·gcdA(b,d) − 1, so gcdA(b,d) is an osculator (bezout_gives_osculator_base).\n\n**Step 3 (Uniqueness mod d).** Two osculators c, c' satisfy d | b(c − c'); coprimality of b and d gives d | c − c' (osculator_base_unique_mod).\n\n**Step 4 (Canonical representative).** gcdA(b,d) mod d is still an osculator (osculator_base_congr), lies in [0,d), and via Int.toNat yields a natural-number witness c < d (osculator_base_exists).\n\n**Step 5 (Recovers parent).** canonical_divisibility_test_base instantiated at b=10 is recovers_base_ten, matching the parent's canonical_divisibility_test verbatim.",
+    "keyInsights": [
+      "Nothing in the osculator construction depends on the radix being 10: the digit split n = b·⌊n/b⌋ + (n mod b) is Nat.div_add_mod for any b, and the divisibility transfer needs only gcd(b,d)=1. Making b a parameter costs no extra mathematics.",
+      "The proof of the digit-split cast is cleanest by casting the ℕ identity Nat.div_add_mod directly (exact_mod_cast) rather than push_cast-ing the goal, which would replace ↑(n/b) by the unrelated integer quotient ↑n / ↑b.",
+      "The same theorem instantiates to genuinely different classical rules: base 100 gives the 'group decimal digits in pairs' tests (7, 11, 13, 101), while base 16 gives hexadecimal digit-sum (3, 5) and alternating-digit (17) tests — all as one-line corollaries.",
+      "recovers_base_ten makes the generalization auditable: the base-10 parent is literally the b=10 specialization, so the new statement strictly subsumes the old one."
+    ],
+    "prerequisites": [
+      "Bézout's identity (Nat.gcd_eq_gcd_ab in Mathlib)",
+      "IsCoprime.dvd_of_dvd_mul_left for the coprimality transfer",
+      "Nat.div_add_mod for the base-b digit split",
+      "Int.emod_nonneg, Int.emod_lt_of_pos, Int.toNat_of_nonneg for the canonical representative",
+      "Parent base-10 osculator proof (DivisibilityTruncationGeneralOQ03) and its OQ-01"
+    ]
+  },
+  "sections": [
+    {
+      "id": "radix-free-test",
+      "title": "Part I: The Base-b Osculator and Divisibility Test",
+      "startLine": 40,
+      "endLine": 88,
+      "summary": "IsOsculatorBase b d c := d | b·c − 1. div_mod_cast_base: the base-b digit split n = b·(n/b) + (n%b) over ℤ. unified_osculator_base: the radix-free divisibility test d | n ↔ d | (n/b + c·(n%b)) for any osculator c."
+    },
+    {
+      "id": "bezout-osculator",
+      "title": "Part II: Bézout Coefficients Give Osculators",
+      "startLine": 89,
+      "endLine": 110,
+      "summary": "bezout_base: gcd(b,d) = b·gcdA(b,d) + d·gcdB(b,d). bezout_gives_osculator_base: gcdA(b,d) is an osculator when gcd(b,d)=1. canonical_divisibility_test_base: Bézout → base-b test, end to end."
+    },
+    {
+      "id": "equivalence-classes",
+      "title": "Part III: Osculator Equivalence Classes",
+      "startLine": 111,
+      "endLine": 132,
+      "summary": "osculator_base_congr: c' ≡ c (mod d) and c osculator ⟹ c' osculator. osculator_base_unique_mod: all base-b osculators are congruent mod d (via coprimality of b and d)."
+    },
+    {
+      "id": "canonical-existence",
+      "title": "Part IV: The Canonical Reduced Osculator Exists in [0, d)",
+      "startLine": 133,
+      "endLine": 161,
+      "summary": "osculator_base_mod: gcdA(b,d) % d is still an osculator. osculator_base_exists: a canonical osculator exists as a natural number c < d, via Int.toNat of the reduced Bézout coefficient."
+    },
+    {
+      "id": "base100-examples",
+      "title": "Part V: Concrete Examples — Base 100 (decimal digit-pairs)",
+      "startLine": 162,
+      "endLine": 206,
+      "summary": "Digit-pair tests grouping decimal digits two at a time: 7 (c=4), 11 (c=1), 13 (c=3), 101 (c=−1, alternating pairs since 101 = 10²+1)."
+    },
+    {
+      "id": "base16-examples",
+      "title": "Part VI: Concrete Examples — Base 16 (hexadecimal)",
+      "startLine": 207,
+      "endLine": 241,
+      "summary": "Hexadecimal tests: digit-sum tests for 3 and 5 (c=1, since 16 ≡ 1 mod 3 and mod 5), and the alternating-digit test for 17 (c=−1, since 17 = 16+1)."
+    },
+    {
+      "id": "recovers-parent",
+      "title": "Part VII: Specialization Recovers the Base-10 Parent",
+      "startLine": 242,
+      "endLine": 257,
+      "summary": "recovers_base_ten: instantiating the radix-free pipeline at b=10 reproduces the parent's canonical base-10 divisibility test, so the new statement strictly subsumes the old one."
+    }
+  ],
+  "conclusion": {
+    "summary": "The base-10 divisibility osculator theory generalizes verbatim to an arbitrary radix b: for d coprime to b, the Bézout coefficient gcdA(b,d) is a canonical osculator, the truncation test d | n ↔ d | (⌊n/b⌋ + c·(n mod b)) holds for every osculator c, a canonical representative exists in [0,d), and b=10 recovers the parent. The proof is 0 sorries, 0 axioms, using only Bézout's identity and the coprimality of the radix with the modulus.",
+    "implications": "Truncation divisibility rules are radix-independent: one theorem produces the classical decimal tests (base 10), the digit-pair tests (base 100), hexadecimal digit-sum and alternating tests (base 16), and a test in every other base at once. Given any (b, d) with gcd(b,d)=1, compute gcdA(b,d), reduce mod d, and the result is the canonical osculator.",
+    "openQuestions": [
+      "Iterate the base-b test: applying the truncation step repeatedly reduces n to a bounded residue; formalize the resulting finite digit-folding algorithm and bound its number of steps in terms of the number of base-b digits.",
+      "Characterize the simplest bases for a fixed d: among radices b coprime to d, which minimize |c| for the canonical osculator (e.g. b ≡ ±1 mod d giving the digit-sum / alternating rules), explaining why base 100 is natural for 7, 11, 13, 101 and base 16 for 3, 5, 17?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-truncation-general-oq-03",
+      "relationship": "extends",
+      "description": "Answers OQ-01 of the parent ('Generalize to base b'). The parent identifies the canonical osculator gcdA(10,d) for base 10; this entry makes the radix a free parameter and proves recovers_base_ten, exhibiting the parent's base-10 rule as the b=10 specialization."
+    },
+    {
+      "targetId": "divisibility-truncation-general-oq-01",
+      "relationship": "generalizes",
+      "description": "Generalizes OQ-01's unified_osculator, whose digit split is hard-coded to radix 10, to unified_osculator_base over an arbitrary radix b, while reusing the same coprimality-transfer argument (IsCoprime.dvd_of_dvd_mul_left)."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "foundational",
+      "description": "Bézout's identity (Nat.gcd_eq_gcd_ab) is the engine: for gcd(b,d)=1 it gives integers with b·a + d·e = 1, hence d | b·a − 1, making a = gcdA(b,d) the osculator in base b. This entry shows the modular-inverse-as-Bézout-coefficient correspondence is radix-independent."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 257,
+    "path": "Proofs/DivisibilityTruncationGeneralOQ03OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 24
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/hilbert-23-oq-01/meta.json
+++ b/src/data/proofs/hilbert-23-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "hilbert-23-oq-01",
+  "title": "First-Order Characterization of Minimizers for Convex Variational Problems",
+  "slug": "hilbert-23-oq-01",
+  "description": "A fully machine-checked slice of regularity/sufficiency theory for the calculus of variations: for a convex functional the Euler-Lagrange / first-variation condition is necessary AND sufficient for a global minimizer, and strict convexity forces the minimizer to be unique.",
+  "parentId": "hilbert-23",
+  "meta": {
+    "proofRepoPath": "Proofs/Hilbert23CalculusVariationsOQ01.lean",
+    "author": "Lean Genius Researcher",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "optimization",
+      "calculus-of-variations",
+      "convex-analysis",
+      "hilbert-problems",
+      "intermediate"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ConvexOn",
+        "description": "Convex functions on a real vector space; the defining slope inequality is the engine of the sufficiency direction",
+        "module": "Analysis.Convex.Function"
+      },
+      {
+        "theorem": "ConvexOn.slope_mono",
+        "description": "Monotonicity of difference quotients of a convex function, which makes the one-sided directional derivative well-behaved",
+        "module": "Analysis.Convex.Deriv"
+      },
+      {
+        "theorem": "hasDerivWithinAt_iff_tendsto_slope",
+        "description": "Characterizes the one-sided derivative as the limit of slopes, used to pass the convexity bound to the first variation",
+        "module": "Analysis.Calculus.Deriv.Slope"
+      },
+      {
+        "theorem": "Even.strictConvexOn_pow",
+        "description": "Strict convexity of even powers, used for the concrete energy example J(y) = y^2",
+        "module": "Analysis.Convex.SpecificFunctions.Deriv"
+      }
+    ],
+    "originalContributions": [
+      "Abstract first-variation (Gateaux directional derivative) of a functional along admissible directions, over an arbitrary real vector space with no norm or measure theory",
+      "Necessity: at a global minimizer every first variation is nonnegative (Euler-Lagrange necessary condition)",
+      "Sufficiency: for convex functionals a nonnegative first variation already forces a global minimizer (the converse that fails without convexity)",
+      "The resulting necessary-and-sufficient first-order characterization isMinOn_iff_firstVariation_nonneg",
+      "Uniqueness of the minimizer for strictly convex functionals (well-posedness), with a concrete worked instance on J(y) = y^2"
+    ],
+    "dateAdded": "2026-06-24",
+    "hilbertNumber": 23,
+    "axiomCount": 0,
+    "lineCount": 166,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms. #print axioms reports only propext, Classical.choice, Quot.sound for the main theorems (no sorryAx, no Lean.ofReduceBool).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Hilbert's twenty-third problem is a research program: 'further development of the methods of the calculus of variations.' Its first open question in our gallery — 'What is the regularity theory for general variational problems?' — is too broad to settle in one stroke, but the classical first-order theory answers a clean, self-contained slice of it.\n\nThe Euler-Lagrange equation provides a *necessary* condition for a function to extremize an action functional: the first variation must vanish. The deep companion fact is that under **convexity** this condition becomes *sufficient* — a critical point is automatically a global minimizer — and under **strict convexity** the minimizer is *unique*. This convex first-order theory is the backbone of the direct method and of modern variational regularity and well-posedness results.",
+    "problemStatement": "Let J be a real-valued functional on a real vector space E. The first variation of J at a point y0 in the direction toward y is the right-hand derivative at t = 0 of the path t |-> J(y0 + t*(y - y0)). We ask: when does a vanishing (or nonnegative) first variation in every admissible direction certify that y0 globally minimizes J?",
+    "text": "For a convex functional the Euler-Lagrange / first-variation condition is necessary and sufficient for a global minimizer; strict convexity makes the minimizer unique. The whole package is formalized with zero axioms over an arbitrary real vector space.",
+    "proofStrategy": "1. **Path and first variation.** Define segPath J y0 y t = J(y0 + t*(y - y0)) and identify the path point with the convex combination (1-t)*y0 + t*y. The first variation is the right derivative of segPath at 0.\n\n2. **Convexity engine (firstVariation_le_sub).** Convexity gives, for every t in (0,1], the slope bound (segPath t - J y0)/t <= J y - J y0. Passing to the limit t -> 0+ via hasDerivWithinAt_iff_tendsto_slope, the first variation d satisfies d <= J y - J y0.\n\n3. **Necessity (firstVariation_nonneg_of_isMinOn).** If y0 is a minimizer, each slope is >= 0, so the limiting first variation is >= 0.\n\n4. **Sufficiency (isMinOn_of_firstVariation_nonneg).** Combining the engine with d >= 0 yields 0 <= d <= J y - J y0, i.e. J y0 <= J y for all y.\n\n5. **Characterization and uniqueness.** Packaging 3 and 4 gives the iff; strict convexity plus the midpoint inequality yields subsingleton_minimizers_of_strictConvex. A concrete instance closes the entry on J(y) = y^2.",
+    "keyInsights": [
+      "The one-sided directional (Gateaux) derivative needs no norm: it lives on any real vector space.",
+      "Convexity is exactly what turns the necessary first-order condition into a sufficient one — the tangent line of a convex function lies below the graph.",
+      "Strict convexity upgrades existence of a minimizer to uniqueness, the well-posedness half of regularity theory.",
+      "Mathlib's slope-monotonicity machinery (ConvexOn.slope_mono, hasDerivWithinAt_iff_tendsto_slope) is enough to make the limit argument fully rigorous and axiom-free."
+    ],
+    "prerequisites": [
+      "Convex analysis (convex and strictly convex functions, slope monotonicity)",
+      "One-variable differentiation (one-sided derivatives as limits of slopes)",
+      "Basic calculus of variations (first variation, Euler-Lagrange condition)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "path",
+      "title": "The Variational Path and First Variation",
+      "startLine": 41,
+      "endLine": 58,
+      "summary": "segPath J y0 y t = J(y0 + t*(y - y0)) and its identification with the convex combination (1-t)*y0 + t*y.",
+      "mathContext": "The first variation of $J$ at $y_0$ toward $y$ is the right derivative at $t=0$ of $\\varphi(t) = J(y_0 + t(y-y_0))$, where $y_0 + t(y-y_0) = (1-t)y_0 + ty$ lies on the segment from $y_0$ to $y$."
+    },
+    {
+      "id": "engine",
+      "title": "Convexity Engine: First Variation Bounds the Value Change",
+      "startLine": 59,
+      "endLine": 86,
+      "summary": "For convex J, the first variation d toward y satisfies d <= J y - J y0.",
+      "mathContext": "Convexity gives $\\varphi(t) - \\varphi(0) \\le t\\,(J y - J y_0)$ for $t \\in (0,1]$, hence the right derivative $d = \\lim_{t\\to 0^+} \\frac{\\varphi(t)-\\varphi(0)}{t} \\le J y - J y_0$. This is the quantitative 'tangent below graph' inequality."
+    },
+    {
+      "id": "necessary",
+      "title": "Necessity: Minimizers Have Nonnegative First Variation",
+      "startLine": 87,
+      "endLine": 102,
+      "summary": "If y0 minimizes J then every first variation at y0 is >= 0 (Euler-Lagrange necessary condition).",
+      "mathContext": "If $J y_0 \\le J z$ for all $z$, the slopes $\\frac{\\varphi(t)-\\varphi(0)}{t}$ are nonnegative for $t>0$, so their limit, the first variation, is nonnegative."
+    },
+    {
+      "id": "sufficient",
+      "title": "Sufficiency and the First-Order Characterization",
+      "startLine": 103,
+      "endLine": 131,
+      "summary": "For convex J a nonnegative first variation forces a global minimizer; combined with necessity this is the iff.",
+      "mathContext": "For convex $J$, $0 \\le d \\le J y - J y_0$ gives $J y_0 \\le J y$. Hence $y_0$ minimizes $J$ iff every first variation at $y_0$ is nonnegative — the necessary-and-sufficient Euler-Lagrange condition for convex problems."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness from Strict Convexity",
+      "startLine": 132,
+      "endLine": 147,
+      "summary": "A strictly convex functional has at most one global minimizer (well-posedness).",
+      "mathContext": "If $a \\ne b$ both minimize a strictly convex $J$, the midpoint satisfies $J(\\tfrac{a+b}{2}) < \\tfrac{1}{2}J a + \\tfrac{1}{2}J b = J a$, contradicting minimality. So the minimizer is unique."
+    },
+    {
+      "id": "example",
+      "title": "Concrete Instance: the Energy J(y) = y^2",
+      "startLine": 148,
+      "endLine": 164,
+      "summary": "y^2 is strictly convex with unique minimizer 0, illustrating the abstract theorems.",
+      "mathContext": "The Dirichlet-type energy $J(y) = y^2$ on $\\mathbb{R}$ is strictly convex; its unique global minimizer is $0$, recovered from subsingleton_minimizers_of_strictConvex."
+    }
+  ],
+  "conclusion": {
+    "summary": "We isolate and fully verify the convex first-order theory at the heart of variational regularity: the Euler-Lagrange / first-variation condition is necessary for any minimizer and, under convexity, also sufficient; strict convexity makes the minimizer unique. The development works over an arbitrary real vector space, uses no axioms beyond Lean's foundations, and is grounded in a concrete energy example.",
+    "implications": "This is the well-posedness core of regularity theory for variational problems (Hilbert's 23rd): convex problems are solved exactly by their Euler-Lagrange equations, and strictly convex problems have a single solution. It underlies the direct method, optimal control sufficiency conditions, and the variational formulation of elliptic PDEs.",
+    "openQuestions": [
+      "Can the first-variation framework be extended to constrained admissible sets (variational inequalities / KKT conditions)?",
+      "How does the sufficiency theorem combine with coercivity to give existence (the full direct method) in infinite-dimensional spaces?",
+      "What quantitative (strong-convexity) version yields rates of convergence toward the unique minimizer?"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/Hilbert23CalculusVariationsOQ01.lean",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-23",
+      "relationship": "parent",
+      "description": "Answers a self-contained slice of the parent's first open question, 'What is the regularity theory for general variational problems?', by formalizing the convex first-order (Euler-Lagrange) sufficiency and uniqueness theory."
+    },
+    {
+      "targetId": "hilbert-19",
+      "relationship": "related",
+      "description": "Hilbert's 19th problem concerns regularity (analyticity) of minimizers of regular variational integrals; convexity of the integrand is the standing hypothesis there, and the sufficiency/uniqueness results here are the elementary first-order counterpart."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Giaquinta, Mariano; Hildebrandt, Stefan",
+      "title": "Calculus of Variations I & II",
+      "year": "1996",
+      "venue": "Springer, Grundlehren der mathematischen Wissenschaften 310-311",
+      "note": "Convexity, the direct method, and first-order sufficiency conditions for variational problems"
+    },
+    {
+      "authors": "Ekeland, Ivar; Temam, Roger",
+      "title": "Convex Analysis and Variational Problems",
+      "year": "1976",
+      "venue": "North-Holland",
+      "note": "Standard reference for the convex first-order theory: first variation, sufficiency, and uniqueness of minimizers"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isMinOn_iff_firstVariation_nonneg",
+      "type": "core",
+      "description": "For a convex Gateaux-differentiable functional, y0 is a global minimizer iff every first variation at y0 is nonnegative.",
+      "leanType": "ConvexOn ℝ univ J → (∀ y, ∃ d, HasDerivWithinAt (segPath J y0 y) d (Ici 0) 0) → ((∀ y, J y0 ≤ J y) ↔ ∀ y d, HasDerivWithinAt (segPath J y0 y) d (Ici 0) 0 → 0 ≤ d)"
+    },
+    {
+      "name": "subsingleton_minimizers_of_strictConvex",
+      "type": "core",
+      "description": "A strictly convex functional has at most one global minimizer.",
+      "leanType": "StrictConvexOn ℝ univ J → (∀ z, J a ≤ J z) → (∀ z, J b ≤ J z) → a = b"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open-question leaf **abundant-number-oq-01-oq-04** (verified 0-axiom parent `abundant-number-oq-01`), developing the **deficient side** of divisibility as the mirror of the abundant-side closure results.

Mathlib records `Nat.Abundant`/`Nat.Perfect`/`Nat.Deficient` and `Nat.IsPrimePow.deficient`, but **not** the abundancy-index monotonicity along divisibility nor the deficient-side closure facts. This entry supplies them.

### New results (all axiom-free)
- **`sigma_dvd_mono`** — abundancy index is monotone along divisibility: `d ∣ n → 0 < n → n·σ(d) ≤ d·σ(n)`, i.e. `σ(d)/d ≤ σ(n)/n`. Proved by the scaled-divisor injection `e ↦ (n/d)·e` embedding `divisors d` into `divisors n`. *The structural engine.*
- **`deficient_of_dvd`** — divisors of deficient numbers are deficient (mirror of `abundant_mul_right`), from `sigma_dvd_mono` + the divisor-sum bridge `deficient_iff_sigma_lt_two_mul`.
- **`deficient_of_proper_dvd_perfect`** — every proper divisor of a perfect number is deficient. Needs strictness beyond monotonicity, so argues by trichotomy: a perfect/abundant proper divisor would make `n` a proper multiple that is abundant (`abundant_of_perfect_mul`/`abundant_mul_right`), contradicting perfection.
- **Concrete:** `perfect_28`, `deficient_14` (14 = 2·7 — not a prime power, so outside `Nat.IsPrimePow.deficient`), `deficient_three_via_six`.

Together with `abundant_of_perfect_mul` (oq-01) this pins perfect numbers as the **exact deficient/abundant boundary**: not deficient, not abundant, yet every proper divisor strictly deficient and every proper multiple strictly abundant.

## Verification
- Builds against Mathlib (lean v4.26.0), **0 sorries, 0 `axiom` declarations**.
- `#print axioms` on `sigma_dvd_mono`, `deficient_of_dvd`, `deficient_of_proper_dvd_perfect`, `deficient_14` → only `propext, Classical.choice, Quot.sound` (kernel `decide`, **no** `native_decide`/`Lean.ofReduceBool`).
- 9 theorems / 0 defs / 174 lines. Reuses kernel-checked `abundant_mul_right`/`abundant_of_perfect_mul` from `AbundantMultiplesOQ01`.

## Files
- `proofs/Proofs/AbundantDeficientDvdOQ04.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/abundant-number-oq-04/meta.json` (new gallery entry, badge `verified`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)