### PR TITLE
research(amgm-inequality-oq-02-oq-01-oq-01-oq-01): power sums are a complete invariant — moments determine the multiset [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -68,6 +68,7 @@ import Proofs.AlternatingSeriesTestOQ01OQ01
 import Proofs.AlternatingSeriesTestOQ01OQ02OQ01
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02OQ01OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ01OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ01OQ02
 import Proofs.AmgmInequalityOQ02Aristotle
 import Proofs.AmgmInequalityOQ02Defs

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,142 @@
+import Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities
+import Mathlib.Tactic
+
+/-!
+# AM-GM OQ-02 → OQ-01 → OQ-01 → OQ-01: power sums are a complete invariant
+
+The parent (`amgm-inequality-oq-02-oq-01-oq-01`) packages Mathlib's Newton–Girard recurrence
+`k·eₖ = (−1)^{k+1} Σ_{i+j=k, i<k} (−1)ⁱ eᵢ pⱼ` (`MvPolynomial.mul_esymm_eq_sum`).  A sibling
+(`…-oq-02`) used the *inverted* recurrence over a ℚ-algebra to show that the power sums and the
+elementary symmetric polynomials generate the same subalgebra.
+
+This entry answers a different open question of the parent: **to what extent do the power sums
+determine the rest of the symmetric data?**  We prove the moment-determinacy (complete-invariant)
+theorem:
+
+> over any characteristic-zero commutative ring `K`, if two families `v, w : σ → K` have equal
+> power sums `Σᵢ vᵢʲ = Σᵢ wᵢʲ` for every `1 ≤ j ≤ n`, then they have equal elementary symmetric
+> functions `eₖ(v) = eₖ(w)` for every `k ≤ n`.
+
+The proof is a single strong induction running the *forward* Newton recurrence: at stage `k` the
+right-hand side involves only lower elementary symmetric functions (equal by the inductive
+hypothesis) and power sums `pⱼ`, `1 ≤ j ≤ k` (equal by hypothesis), so `k·eₖ(v) = k·eₖ(w)`, and
+`k ≠ 0` in characteristic zero cancels.  Specialising at `n = |σ|`, where the elementary
+symmetric functions of degree `> |σ|` both vanish, shows that the first `|σ|` power sums determine
+**all** elementary symmetric functions — equivalently the monic polynomial `∏ᵢ (X − vᵢ)` — so the
+power sums `p₁, …, p_{|σ|}` are a complete invariant of an unordered `|σ|`-tuple.
+
+The symmetric polynomials are taken over `ℤ`; evaluation lands in any characteristic-zero `K`
+(`ℚ`, `ℝ`, `ℂ`, `ℤ`, …), where the necessary division by `k` happens in `K`.  `0` axioms.
+
+## Main results
+
+* `aeval_mul_esymm_eq_sum`         — the forward Newton identity evaluated at a point.
+* `esymm_eval_eq_of_psum_eval_eq`  — equal power sums (`1 ≤ j ≤ n`) ⟹ equal `eₖ` (`k ≤ n`).
+* `esymm_eval_eq_of_psum_eval_eq_card` — at `n = |σ|`, *all* `eₖ` agree.
+* `prod_X_sub_C_eq_of_psum_eval_eq` — the monic polynomials `∏ᵢ (X − vᵢ)` agree: power sums
+  `p₁, …, p_{|σ|}` are a complete invariant.
+-/
+
+namespace AmgmInequalityOQ02OQ01OQ01OQ01
+
+open MvPolynomial Finset
+
+variable {σ : Type*} [Fintype σ] {K : Type*} [CommRing K]
+
+/-- Elementary symmetric functions of degree exceeding the number of variables vanish: there are
+no squarefree monomials of degree `> |σ|`. -/
+theorem esymm_eval_eq_zero (v : σ → K) {k : ℕ} (hk : Fintype.card σ < k) :
+    aeval v (esymm σ ℤ k) = 0 := by
+  rw [esymm, Finset.powersetCard_eq_empty.mpr (by rwa [Finset.card_univ]), Finset.sum_empty,
+    map_zero]
+
+/-- **The forward Newton identity, evaluated at a point.** Applying the evaluation algebra
+homomorphism `aeval v` to Mathlib's `mul_esymm_eq_sum` turns the `MvPolynomial` identity into the
+numerical Newton–Girard recurrence for the symmetric functions of the family `v : σ → K`:
+
+`k · eₖ(v) = (−1)^{k+1} Σ_{i+j=k, i<k} (−1)ⁱ eᵢ(v) pⱼ(v)`. -/
+theorem aeval_mul_esymm_eq_sum (v : σ → K) (k : ℕ) :
+    (k : K) * aeval v (esymm σ ℤ k)
+      = (-1) ^ (k + 1) *
+        ∑ a ∈ antidiagonal k with a.1 < k,
+          (-1) ^ a.1 * aeval v (esymm σ ℤ a.1) * aeval v (psum σ ℤ a.2) := by
+  have h := congrArg (aeval (R := ℤ) v) (mul_esymm_eq_sum σ ℤ k)
+  simpa [map_mul, map_sum, map_pow, map_neg, map_one, map_natCast] using h
+
+variable [IsDomain K] [CharZero K]
+
+/-- **Power sums determine elementary symmetric functions (moment determinacy).** If two families
+`v, w : σ → K` over a characteristic-zero ring have equal power sums `pⱼ(v) = pⱼ(w)` for every
+`1 ≤ j ≤ n`, then their elementary symmetric functions agree, `eₖ(v) = eₖ(w)`, for every `k ≤ n`.
+
+The proof is a strong induction on `k`: the forward Newton recurrence expresses `k·eₖ` through
+elementary symmetric functions of degree `< k` (equal by the inductive hypothesis) and power sums
+`pⱼ` with `1 ≤ j ≤ k ≤ n` (equal by hypothesis); cancelling the nonzero scalar `k` (a nonzero
+element of the domain `K`, by characteristic zero) gives the claim. -/
+theorem esymm_eval_eq_of_psum_eval_eq (v w : σ → K) (n : ℕ)
+    (hp : ∀ j, 1 ≤ j → j ≤ n → aeval v (psum σ ℤ j) = aeval w (psum σ ℤ j)) :
+    ∀ k, k ≤ n → aeval v (esymm σ ℤ k) = aeval w (esymm σ ℤ k) := by
+  intro k
+  induction k using Nat.strongRecOn with
+  | ind k ih =>
+    intro hkn
+    rcases Nat.eq_zero_or_pos k with hk | hk
+    · subst hk; simp [esymm_zero]
+    · have hkne : (k : K) ≠ 0 := Nat.cast_ne_zero.mpr hk.ne'
+      have hsum :
+          (∑ a ∈ antidiagonal k with a.1 < k,
+              (-1) ^ a.1 * aeval v (esymm σ ℤ a.1) * aeval v (psum σ ℤ a.2))
+            = ∑ a ∈ antidiagonal k with a.1 < k,
+              (-1) ^ a.1 * aeval w (esymm σ ℤ a.1) * aeval w (psum σ ℤ a.2) := by
+        refine Finset.sum_congr rfl fun a ha => ?_
+        rw [mem_filter, mem_antidiagonal] at ha
+        obtain ⟨hsum, hlt⟩ := ha
+        have he : aeval v (esymm σ ℤ a.1) = aeval w (esymm σ ℤ a.1) :=
+          ih a.1 hlt (le_trans hlt.le hkn)
+        have hpe : aeval v (psum σ ℤ a.2) = aeval w (psum σ ℤ a.2) :=
+          hp a.2 (by omega) (by omega)
+        rw [he, hpe]
+      have hk_eq : (k : K) * aeval v (esymm σ ℤ k) = (k : K) * aeval w (esymm σ ℤ k) := by
+        rw [aeval_mul_esymm_eq_sum v k, aeval_mul_esymm_eq_sum w k, hsum]
+      exact mul_left_cancel₀ hkne hk_eq
+
+/-- **The first `|σ|` power sums determine every elementary symmetric function.** Beyond degree
+`|σ|` the elementary symmetric polynomials vanish, so agreement of the power sums `p₁, …, p_{|σ|}`
+forces agreement of `eₖ(v)` and `eₖ(w)` for *all* `k`, not merely `k ≤ |σ|`. -/
+theorem esymm_eval_eq_of_psum_eval_eq_card (v w : σ → K)
+    (hp : ∀ j, 1 ≤ j → j ≤ Fintype.card σ → aeval v (psum σ ℤ j) = aeval w (psum σ ℤ j)) :
+    ∀ k, aeval v (esymm σ ℤ k) = aeval w (esymm σ ℤ k) := by
+  intro k
+  rcases le_or_gt k (Fintype.card σ) with hk | hk
+  · exact esymm_eval_eq_of_psum_eval_eq v w (Fintype.card σ) hp k hk
+  · rw [esymm_eval_eq_zero v hk, esymm_eval_eq_zero w hk]
+
+/-- **Power sums are a complete invariant of an unordered tuple.** If two families
+`v, w : σ → K` over a characteristic-zero domain have equal power sums `pⱼ(v) = pⱼ(w)` for every
+`1 ≤ j ≤ |σ|`, then they define the *same monic polynomial* `∏ᵢ (X + vᵢ) = ∏ᵢ (X + wᵢ)`.
+
+By Vieta's formulas the coefficients of `∏ᵢ (X + vᵢ)` are precisely the elementary symmetric
+functions `eⱼ(v)`, which agree with `eⱼ(w)` by `esymm_eval_eq_of_psum_eval_eq_card`. Hence
+`p₁, …, p_{|σ|}` determine the multiset `{vᵢ}` up to reordering — equivalently the roots of the
+polynomial — which is the sharp form of Newton's identities as a moment problem for finite
+multisets. -/
+theorem prod_X_add_C_eq_of_psum_eval_eq (v w : σ → K)
+    (hp : ∀ j, 1 ≤ j → j ≤ Fintype.card σ → aeval v (psum σ ℤ j) = aeval w (psum σ ℤ j)) :
+    ∏ i, (Polynomial.X + Polynomial.C (v i)) = ∏ i, (Polynomial.X + Polynomial.C (w i)) := by
+  have key : ∀ u : σ → K, (∏ i, (Polynomial.X + Polynomial.C (u i)))
+      = ∑ j ∈ Finset.range (Fintype.card σ + 1),
+          Polynomial.C (aeval u (esymm σ ℤ j)) * Polynomial.X ^ (Fintype.card σ - j) := by
+    intro u
+    rw [Finset.prod,
+      show (fun i => Polynomial.X + Polynomial.C (u i))
+          = (fun r => Polynomial.X + Polynomial.C r) ∘ u from rfl,
+      ← Multiset.map_map, Multiset.prod_X_add_C_eq_sum_esymm]
+    have hcard : Multiset.card (Finset.univ.val.map u) = Fintype.card σ := by
+      rw [Multiset.card_map, ← Finset.card_def, Finset.card_univ]
+    rw [hcard]
+    exact Finset.sum_congr rfl fun j _ => by rw [aeval_esymm_eq_multiset_esymm]
+  rw [key v, key w]
+  exact Finset.sum_congr rfl fun j _ => by
+    rw [esymm_eval_eq_of_psum_eval_eq_card v w hp j]
+
+end AmgmInequalityOQ02OQ01OQ01OQ01

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-01-oq-01",
+  "title": "Power Sums Are a Complete Invariant: Moments Determine the Multiset",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-01-oq-01",
+  "description": "Over any characteristic-zero commutative domain K, the first |σ| power sums of a finite family v : σ → K determine all of its elementary symmetric functions — equivalently the monic polynomial ∏ᵢ (X + vᵢ), hence the multiset {vᵢ} up to order. This is the determinacy (injectivity) half of Newton's identities: the parent packages the forward recurrence k·eₖ = (−1)^{k+1} Σ (−1)ⁱ eᵢ pⱼ, and a single strong induction running that recurrence — cancelling the nonzero scalar k in characteristic zero — shows equal power sums force equal elementary symmetric functions. A Vieta capstone upgrades this to equality of the monic polynomials. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "vieta",
+      "moment-problem",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using only Mathlib. The ambient ring K is an arbitrary characteristic-zero commutative integral domain (ℚ, ℝ, ℂ, ℤ, …); the symmetric polynomials live over ℤ and are evaluated into K.",
+    "lineCount": 142,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "esymm_eval_eq_of_psum_eval_eq: equal power sums pⱼ(v)=pⱼ(w) for 1 ≤ j ≤ n force equal elementary symmetric functions eₖ(v)=eₖ(w) for k ≤ n — the moment-determinacy direction of Newton's identities, proved by a single strong induction on the forward recurrence with scalar cancellation in characteristic zero",
+      "esymm_eval_eq_of_psum_eval_eq_card: at n = |σ| the agreement extends to ALL eₖ (those of degree > |σ| vanish on both sides), so the first |σ| power sums pin down every symmetric function",
+      "prod_X_add_C_eq_of_psum_eval_eq: Vieta capstone — equal first-|σ| power sums imply equal monic polynomials ∏ᵢ (X + vᵢ) = ∏ᵢ (X + wᵢ), i.e. power sums are a complete invariant of an unordered tuple / finite multiset",
+      "aeval_mul_esymm_eq_sum: Mathlib's MvPolynomial Newton identity mul_esymm_eq_sum pushed through the evaluation algebra homomorphism aeval v into the numerical Newton–Girard recurrence for an explicit family of scalars",
+      "esymm_eval_eq_zero: elementary symmetric functions of degree exceeding the number of variables evaluate to zero (powersetCard is empty)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (the Newton–Girard formulae, 17th century) relate the power sums pₖ = Σᵢ xᵢᵏ of a collection of quantities to their elementary symmetric functions eₖ. Read one way they compute the pₖ from the eₖ; read the other way — solving for eₖ and dividing by k, which is legitimate only in characteristic zero — they recover the eₖ, and hence the whole symmetric profile, from the first n power sums. This second reading is a finite, exact analogue of the classical moment problem: just as the moments of a measure can determine it, the 'moments' p₁,…,pₙ of an n-element multiset determine the multiset. The fact that exactly n power sums suffice (no more are needed, because eₖ = 0 for k > n) is the sharp form. Equivalently, two monic degree-n polynomials with the same first n Newton power sums of their roots are identical — a standard tool in Galois theory, the theory of the resultant/discriminant, and symmetric-function combinatorics.",
+    "problemStatement": "The parent (amgm-inequality-oq-02-oq-01-oq-01) packages the forward Newton–Girard recurrence over MvPolynomial σ R, and a sibling (…-oq-02) shows the power sums and elementary symmetric polynomials generate the same ℚ-subalgebra. **This entry asks the determinacy question**: to what extent, and using how many of them, do the power sums determine the remaining symmetric data of a concrete family of scalars? Prove that the first |σ| power sums are a complete invariant — equal power sums ⟹ equal elementary symmetric functions ⟹ equal monic polynomial ∏ᵢ(X + vᵢ).",
+    "proofStrategy": "**Step 1 (evaluate the recurrence)**: apply the evaluation algebra homomorphism aeval v : MvPolynomial σ ℤ → K to Mathlib's `mul_esymm_eq_sum`; since aeval is a ring hom it distributes over the sum/product/power/natCast, yielding `k·eₖ(v) = (−1)^{k+1} Σ_{i+j=k, i<k} (−1)ⁱ eᵢ(v) pⱼ(v)`.\n\n**Step 2 (strong induction)**: to show eₖ(v) = eₖ(w) for k ≤ n, induct strongly on k. The base case e₀ = 1 is immediate. For k > 0 the right-hand side of the evaluated recurrence involves only eᵢ with i < k (equal by the inductive hypothesis) and pⱼ with 1 ≤ j ≤ k ≤ n (equal by hypothesis), so the two right-hand sides coincide and `k·eₖ(v) = k·eₖ(w)`. Because K is a characteristic-zero domain, (k : K) ≠ 0 is a non-zero-divisor, and `mul_left_cancel₀` gives eₖ(v) = eₖ(w).\n\n**Step 3 (extend past the degree)**: for k > |σ| the elementary symmetric polynomial esymm σ ℤ k is a sum over the empty family of k-subsets, so it evaluates to 0 on both sides; combined with Step 2 at n = |σ| this proves agreement for all k.\n\n**Step 4 (Vieta capstone)**: `Multiset.prod_X_add_C_eq_sum_esymm` writes ∏ᵢ(X + vᵢ) = Σⱼ C(eⱼ(v))·X^{|σ|−j}; the coefficients are exactly the evaluated elementary symmetric functions, which agree for v and w, so the polynomials are equal.",
+    "keyInsights": [
+      "Determinacy is the *injectivity* counterpart of the sibling's generation result: -oq-02 shows the p's and e's generate the same algebra; this entry shows the p's already separate distinct tuples. Generation says 'each e is a polynomial in the p's'; determinacy says 'fixing the p's fixes the e's'.",
+      "Only the FORWARD recurrence is needed. One does not have to invert Newton's identities symbolically; cancelling the scalar k at each induction step in the characteristic-zero target K suffices, keeping the proof to a single strong induction.",
+      "Characteristic zero enters solely as 'k ≠ 0 is cancellable'. The hypothesis is packaged as [CommRing K] [IsDomain K] [CharZero K]; a domain is used so that the nonzero k is a non-zero-divisor for mul_left_cancel₀.",
+      "Exactly |σ| power sums are required and sufficient: esymm of degree > |σ| vanishes (esymm_eval_eq_zero), so no further power sums add information — the sharp cutoff matching the degree of the monic polynomial.",
+      "Pushing a symbolic MvPolynomial identity through aeval is a reusable bridge from Mathlib's abstract symmetric-function theory to concrete numerical statements about explicit tuples of ring elements."
+    ],
+    "prerequisites": [
+      "MvPolynomial.mul_esymm_eq_sum (Mathlib's forward Newton identity)",
+      "MvPolynomial.aeval as an algebra homomorphism (map_sum, map_mul, map_pow, map_natCast)",
+      "Multiset.prod_X_add_C_eq_sum_esymm and MvPolynomial.aeval_esymm_eq_multiset_esymm (Vieta)",
+      "Nat.strongRecOn for strong induction; mul_left_cancel₀ in an integral domain",
+      "Finset.powersetCard_eq_empty for the degree cutoff"
+    ]
+  },
+  "sections": [
+    {
+      "id": "evaluated-newton",
+      "title": "Part I: The Forward Newton Identity, Evaluated",
+      "startLine": 36,
+      "endLine": 60,
+      "summary": "esymm_eval_eq_zero: elementary symmetric functions vanish above degree |σ|. aeval_mul_esymm_eq_sum: Mathlib's mul_esymm_eq_sum pushed through aeval v into the numerical recurrence k·eₖ(v) = (−1)^{k+1} Σ (−1)ⁱ eᵢ(v) pⱼ(v)."
+    },
+    {
+      "id": "determinacy",
+      "title": "Part II: Power Sums Determine Elementary Symmetric Functions",
+      "startLine": 62,
+      "endLine": 110,
+      "summary": "esymm_eval_eq_of_psum_eval_eq: strong induction on k — equal pⱼ (1 ≤ j ≤ n) force equal eₖ (k ≤ n), cancelling the nonzero k in the characteristic-zero domain. esymm_eval_eq_of_psum_eval_eq_card: at n = |σ| this extends to all k since higher eₖ vanish."
+    },
+    {
+      "id": "vieta-capstone",
+      "title": "Part III: Complete Invariant — the Monic Polynomial",
+      "startLine": 112,
+      "endLine": 142,
+      "summary": "prod_X_add_C_eq_of_psum_eval_eq: via Multiset.prod_X_add_C_eq_sum_esymm the coefficients of ∏ᵢ(X + vᵢ) are the evaluated elementary symmetric functions, so equal first-|σ| power sums yield equal monic polynomials — power sums are a complete invariant of the multiset {vᵢ}."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over a characteristic-zero integral domain, the first |σ| power sums of a finite family determine all of its elementary symmetric functions and hence the monic polynomial ∏ᵢ(X + vᵢ) — power sums are a complete invariant of an unordered tuple. The proof needs only the forward Newton–Girard recurrence (evaluated through aeval) and one strong induction with scalar cancellation, plus a Vieta coefficient identity for the capstone. 0 sorries, 0 axioms.",
+    "implications": "This is the determinacy (injectivity) face of Newton's identities, complementing the parent's recurrence and the sibling's same-subalgebra generation theorem. It is the exact-arithmetic analogue of a finite moment problem and underlies the use of power sums as canonical coordinates on the space of monic polynomials (Galois theory, resultants/discriminants, symmetric-function combinatorics).",
+    "openQuestions": [
+      "Quantitative/stable version: over ℝ or ℂ, bound how far two tuples can differ in terms of the differences of their first n power sums (a perturbation/conditioning statement for the power-sum-to-coefficient map).",
+      "Positive-characteristic obstruction: in characteristic p the scalar k = p is not cancellable; characterise exactly which elementary symmetric functions remain determined by the power sums, and exhibit minimal tuples with equal power sums but distinct multisets."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent packages Mathlib's forward Newton–Girard recurrence over MvPolynomial σ R. This entry evaluates that recurrence at a concrete family and runs a strong induction to obtain the determinacy theorem: the first |σ| power sums fix all elementary symmetric functions."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "complements",
+      "description": "The sibling (-oq-02) proves the power sums and elementary symmetric polynomials generate the same ℚ-subalgebra (a generation statement). This entry proves the dual determinacy/injectivity statement: equal power sums force equal elementary symmetric functions, hence equal monic polynomial."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "uses",
+      "description": "The capstone uses Vieta's formulas (Multiset.prod_X_add_C_eq_sum_esymm) to identify the coefficients of ∏ᵢ(X + vᵢ) with the elementary symmetric functions, turning equality of symmetric functions into equality of monic polynomials."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 142,
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the determinacy open question of the parent `amgm-inequality-oq-02-oq-01-oq-01` (the Newton–Girard recurrence packaging).

**Theorem.** Over any characteristic-zero integral domain `K`, if two finite families `v, w : σ → K` have equal power sums `pⱼ(v) = pⱼ(w)` for every `1 ≤ j ≤ |σ|`, then they have the same elementary symmetric functions and define the **same monic polynomial** `∏ᵢ (X + vᵢ) = ∏ᵢ (X + wᵢ)` — so the first `|σ|` power sums are a complete invariant of an unordered tuple / finite multiset.

This is the **determinacy (injectivity)** face of Newton's identities:
- the parent packages the forward recurrence `k·eₖ = (−1)^{k+1} Σ (−1)ⁱ eᵢ pⱼ`;
- the sibling `-oq-02` shows `p`'s and `e`'s generate the same ℚ-subalgebra (*generation*);
- this entry shows fixing the `p`'s fixes the `e`'s (*determinacy*), an exact-arithmetic finite moment problem.

## Proof

1. `aeval_mul_esymm_eq_sum` — push Mathlib's `mul_esymm_eq_sum` through the evaluation algebra hom `aeval v` to get the numerical recurrence.
2. `esymm_eval_eq_of_psum_eval_eq` — strong induction on `k`: the RHS uses only lower `eᵢ` (IH) and `pⱼ`, `1 ≤ j ≤ k` (hypothesis), so `k·eₖ(v) = k·eₖ(w)`; cancel the nonzero `k` in the char-0 domain.
3. `esymm_eval_eq_of_psum_eval_eq_card` — at `n = |σ|`, higher `eₖ` vanish, so all `eₖ` agree.
4. `prod_X_add_C_eq_of_psum_eval_eq` — Vieta (`Multiset.prod_X_add_C_eq_sum_esymm`) turns equal symmetric functions into equal monic polynomials.

## Verification

- 5 theorems, 142 lines, **0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`).
- Builds against Mathlib (Lean v4.26.0); self-contained, imports only `Mathlib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)