### PR TITLE
research(combinations-formula-oq-01-oq-01-oq-02): p-step shallow diagonals give the p-bonacci sequences [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -805,6 +805,7 @@ import Proofs.CombinationsFormulaOQ01
 import Proofs.CombinationsFormulaOQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
+import Proofs.CombinationsFormulaOQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle

--- a/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ01OQ01OQ02.lean
@@ -1,0 +1,195 @@
+/-
+p-step shallow diagonals of Pascal's triangle and the p-bonacci sequences
+(combinations-formula-oq-01-oq-01-oq-02)
+
+The parent entry `combinations-formula-oq-01-oq-01` proved the classical Fibonacci
+shallow-diagonal identity
+
+  `∑_{j} C(n − j, j) = F(n+1)`,
+
+summing binomial coefficients along the shallow (rising) diagonals of Pascal's
+triangle.  Its second open question asks to generalize this to the *p-step* shallow
+diagonals, which produce the **p-bonacci** (generalized Fibonacci) sequences.
+
+This file answers that question, axiom-free.  Fix a step parameter `q : ℕ`
+(so `p = q + 1`) and define the p-step shallow-diagonal sum
+
+  `S q n = ∑_{j} C(n − q·j, j)`.
+
+The main result is that `S q` satisfies the **p-bonacci recurrence**
+
+  `S q (n + q + 1) = S q (n + q) + S q n`          (`pbonacci_rec`)
+
+together with the constant base segment
+
+  `S q n = 1`   for `n ≤ q`                          (`pbonacci_base`).
+
+These two facts characterize `S q` as the generalized Fibonacci sequence of step
+`p = q + 1`:
+
+  * `q = 0` (p = 1): the recurrence `S 0 (n+1) = 2·S 0 n` gives the powers of two
+    `S 0 n = ∑_j C(n, j) = 2^n`;
+  * `q = 1` (p = 2): `S 1 n = F(n+1)`, the Fibonacci numbers — recovering the parent
+    result (`pbonacci_one_eq_fib`);
+  * `q = 2` (p = 3): `S 2` is Narayana's-cows sequence `a(n) = a(n−1) + a(n−3)`;
+  * general `q`: the p-bonacci recurrence `a(n) = a(n−1) + a(n−p)`.
+
+The proof of the recurrence is a single application of Pascal's rule
+`C(m+1, k+1) = C(m, k+1) + C(m, k)` to each diagonal term, after peeling the leading
+`j = 0` term and reindexing.  The only subtlety is natural-number subtraction
+bookkeeping, discharged with `omega` and the vanishing of binomial coefficients past
+their support.
+
+Main results:
+* `pbonacci`               — the p-step shallow-diagonal sum `∑_j C(n − q·j, j)`.
+* `pbonacci_base`          — `S q n = 1` for `n ≤ q` (the constant base segment).
+* `pbonacci_rec`           — `S q (n+q+1) = S q (n+q) + S q n` (the p-bonacci recurrence).
+* `pbonacci_one_eq_fib`    — `S 1 n = F(n+1)`, recovering the parent Fibonacci identity.
+-/
+
+import Mathlib
+
+namespace CombinationsFormulaOQ01OQ01OQ02
+
+open Finset
+
+/-- **The p-step shallow-diagonal sum.** With step parameter `q` (so `p = q + 1`),
+sum `C(n − q·j, j)` along the p-step shallow diagonal of Pascal's triangle.  For
+`q = 1` this is the Fibonacci diagonal sum `∑_j C(n − j, j)` of the parent entry. -/
+def pbonacci (q n : ℕ) : ℕ :=
+  ∑ j ∈ Finset.range (n + 1), Nat.choose (n - q * j) j
+
+/-- Terms of the diagonal sum vanish once the lower index outruns the upper index,
+so the summation range may be enlarged freely above `n`. -/
+theorem pbonacci_extend (q n N : ℕ) (h : n ≤ N) :
+    ∑ j ∈ Finset.range (N + 1), Nat.choose (n - q * j) j = pbonacci q n := by
+  unfold pbonacci
+  refine (Finset.sum_subset ?_ ?_).symm
+  · intro x hx
+    rw [Finset.mem_range] at hx ⊢
+    omega
+  · intro j _ hjn
+    simp only [Finset.mem_range, not_lt] at hjn
+    -- `j ≥ n + 1` forces `n - q*j ≤ n < j`, hence the binomial is zero.
+    apply Nat.choose_eq_zero_of_lt
+    exact lt_of_le_of_lt (Nat.sub_le n (q * j)) (Nat.lt_of_succ_le hjn)
+
+/-- **Pascal's rule on a diagonal term** (for `j ≥ 1`):
+`C(n+q+1 − q(j+1), j+1) = C(n − q·j, j+1) + C(n − q·j, j)`.
+This is the engine of the recurrence: the first summand feeds `S q (n+q)`, the second
+feeds `S q n`. -/
+private theorem diag_pascal (q n j : ℕ) :
+    Nat.choose (n + q + 1 - q * (j + 1)) (j + 1)
+      = Nat.choose (n - q * j) (j + 1) + Nat.choose (n - q * j) j := by
+  rcases le_or_gt (q * (j + 1)) (n + q) with hle | hlt
+  · -- No truncation: `n + q + 1 - q(j+1) = (n - q·j) + 1`, plain Pascal.
+    have e1 : n + q + 1 - q * (j + 1) = (n - q * j) + 1 := by
+      have : q * (j + 1) = q * j + q := by ring
+      omega
+    rw [e1, Nat.choose_succ_succ, Nat.succ_eq_add_one]
+    exact Nat.add_comm _ _
+  · -- Truncated case: both upper indices collapse to `0`; here `j ≥ 1`.
+    have hj : 1 ≤ j := by
+      rcases Nat.eq_zero_or_pos j with rfl | hpos
+      · exfalso
+        simp only [Nat.zero_add, mul_one] at hlt
+        omega
+      · exact hpos
+    have e1 : n + q + 1 - q * (j + 1) = 0 := by
+      have : q * (j + 1) = q * j + q := by ring
+      omega
+    have e2 : n - q * j = 0 := by
+      have h : q * (j + 1) = q * j + q := by ring
+      omega
+    rw [e1, e2]
+    rw [Nat.choose_eq_zero_of_lt (Nat.succ_pos j)]
+    rw [Nat.choose_eq_zero_of_lt (show 0 < j by omega)]
+
+/-- **The p-bonacci recurrence.** The p-step shallow-diagonal sums satisfy
+`S q (n + q + 1) = S q (n + q) + S q n`, i.e. `a(m) = a(m−1) + a(m−p)` with `p = q+1`. -/
+theorem pbonacci_rec (q n : ℕ) :
+    pbonacci q (n + q + 1) = pbonacci q (n + q) + pbonacci q n := by
+  -- Expand the left side over its natural range and peel the `j = 0` term.
+  have hL : pbonacci q (n + q + 1)
+      = (∑ j ∈ Finset.range (n + q + 1),
+            (Nat.choose (n - q * j) (j + 1) + Nat.choose (n - q * j) j)) + 1 := by
+    have hsum : (∑ j ∈ Finset.range (n + q + 1),
+          Nat.choose (n + q + 1 - q * (j + 1)) (j + 1))
+        = ∑ j ∈ Finset.range (n + q + 1),
+            (Nat.choose (n - q * j) (j + 1) + Nat.choose (n - q * j) j) :=
+      Finset.sum_congr rfl (fun j _ => diag_pascal q n j)
+    unfold pbonacci
+    rw [Finset.sum_range_succ', hsum]
+    simp
+  rw [hL, Finset.sum_add_distrib]
+  -- The `C(n - q·j, j)` block over `range (n+q+1)` is `S q n` (extended range).
+  have hB : ∑ j ∈ Finset.range (n + q + 1), Nat.choose (n - q * j) j = pbonacci q n :=
+    pbonacci_extend q n (n + q) (by omega)
+  -- The `C(n - q·j, j+1)` block plus `1` is `S q (n+q)`.
+  have hA : (∑ j ∈ Finset.range (n + q + 1), Nat.choose (n - q * j) (j + 1)) + 1
+      = pbonacci q (n + q) := by
+    -- Expand `S q (n+q)` over its range and peel its `j = 0` term.
+    have hexp : pbonacci q (n + q)
+        = (∑ j ∈ Finset.range (n + q), Nat.choose (n - q * j) (j + 1)) + 1 := by
+      have hsum : (∑ j ∈ Finset.range (n + q), Nat.choose (n + q - q * (j + 1)) (j + 1))
+          = ∑ j ∈ Finset.range (n + q), Nat.choose (n - q * j) (j + 1) := by
+        refine Finset.sum_congr rfl (fun j _ => ?_)
+        congr 1
+        have : q * (j + 1) = q * j + q := by ring
+        omega
+      unfold pbonacci
+      rw [Finset.sum_range_succ', hsum]
+      simp
+    rw [hexp]
+    -- The two `C(n - q·j, j+1)` sums differ only by the `j = n+q` term, which vanishes.
+    have htop : ∑ j ∈ Finset.range (n + q + 1), Nat.choose (n - q * j) (j + 1)
+        = ∑ j ∈ Finset.range (n + q), Nat.choose (n - q * j) (j + 1) := by
+      rw [Finset.sum_range_succ]
+      have : Nat.choose (n - q * (n + q)) (n + q + 1) = 0 := by
+        apply Nat.choose_eq_zero_of_lt
+        have h1 : n - q * (n + q) ≤ n := Nat.sub_le _ _
+        omega
+      rw [this, Nat.add_zero]
+    rw [htop]
+  -- `(∑A + ∑B) + 1 = (∑A + 1) + ∑B = S q (n+q) + S q n`.
+  omega
+
+/-- **Constant base segment.** For `n ≤ q` the p-step diagonal collapses to its single
+leading term: `S q n = 1`.  These are the `p = q+1` initial values of the p-bonacci
+sequence. -/
+theorem pbonacci_base (q n : ℕ) (h : n ≤ q) : pbonacci q n = 1 := by
+  unfold pbonacci
+  rw [Finset.sum_range_succ']
+  have hzero : ∑ j ∈ Finset.range n, Nat.choose (n - q * (j + 1)) (j + 1) = 0 := by
+    apply Finset.sum_eq_zero
+    intro j _
+    have e : n - q * (j + 1) = 0 := by
+      have : q ≤ q * (j + 1) := by
+        calc q = q * 1 := (Nat.mul_one q).symm
+          _ ≤ q * (j + 1) := by apply Nat.mul_le_mul_left; omega
+      omega
+    rw [e]
+    exact Nat.choose_eq_zero_of_lt (by omega)
+  rw [hzero, Nat.zero_add]
+  simp
+
+/-- **Recovering the parent Fibonacci identity.** For step `q = 1` (`p = 2`) the
+p-step diagonal sum is the Fibonacci sequence: `S 1 n = F(n+1)`.  Since
+`S 1 n = ∑_j C(n − j, j)`, this is exactly the parent's shallow-diagonal identity,
+here obtained as a corollary of the general recurrence. -/
+theorem pbonacci_one_eq_fib (n : ℕ) : pbonacci 1 n = Nat.fib (n + 1) := by
+  induction n using Nat.twoStepInduction with
+  | zero => decide
+  | one => decide
+  | more n ih1 ih2 =>
+    -- `pbonacci_rec` at `q = 1` gives `S 1 (n+2) = S 1 (n+1) + S 1 n`.
+    have hrec : pbonacci 1 (n + 1 + 1) = pbonacci 1 (n + 1) + pbonacci 1 n :=
+      pbonacci_rec 1 n
+    have hfib : Nat.fib (n + 1 + 1 + 1) = Nat.fib (n + 1 + 1) + Nat.fib (n + 1) := by
+      have h := Nat.fib_add_two (n := n + 1)
+      rw [Nat.add_comm (Nat.fib (n + 1)) (Nat.fib (n + 1 + 1))] at h
+      exact h
+    show pbonacci 1 (n + 1 + 1) = Nat.fib (n + 1 + 1 + 1)
+    rw [hrec, ih1, ih2, hfib]
+
+end CombinationsFormulaOQ01OQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "combinations-formula-oq-01-oq-01-oq-02",
+  "title": "p-Step Shallow Diagonals of Pascal's Triangle and the p-Bonacci Sequences",
+  "slug": "combinations-formula-oq-01-oq-01-oq-02",
+  "description": "Generalizes the Fibonacci shallow-diagonal identity ∑_j C(n−j, j) = F(n+1) to the p-step shallow diagonals of Pascal's triangle, which produce the p-bonacci (generalized Fibonacci) sequences. For step parameter q (so p = q+1), the diagonal sum S q n = ∑_j C(n − q·j, j) is proved, axiom-free, to satisfy the p-bonacci recurrence S q (n+q+1) = S q (n+q) + S q n together with the constant base segment S q n = 1 for n ≤ q. Specializations recover the powers of two (q=0), the Fibonacci numbers (q=1, the parent result), and Narayana's-cows sequence (q=2).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ01OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "fibonacci",
+      "p-bonacci",
+      "generalized-fibonacci",
+      "pascal-triangle",
+      "linear-recurrence",
+      "finite-sums"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound for every theorem (pbonacci_rec, pbonacci_base, pbonacci_one_eq_fib, pbonacci_extend). No native_decide is used; numeric sanity checks use kernel decide only.",
+    "lineCount": 195,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "pbonacci q n := ∑_j C(n − q·j, j): the p-step shallow-diagonal sum of Pascal's triangle, indexed by a single step parameter q so that p = q+1 covers all cases at once.",
+      "pbonacci_rec: S q (n+q+1) = S q (n+q) + S q n — the p-bonacci linear recurrence a(m) = a(m−1) + a(m−p), proved uniformly for all q ≥ 0 by a single application of Pascal's rule to each diagonal term.",
+      "pbonacci_base: S q n = 1 for n ≤ q — the constant initial segment fixing the p initial values of the generalized Fibonacci sequence.",
+      "pbonacci_one_eq_fib: S 1 n = F(n+1) — the q=1 specialization recovers the parent's Fibonacci shallow-diagonal identity as a corollary of the general recurrence."
+    ]
+  },
+  "overview": {
+    "historicalContext": "That the shallow (rising) diagonals of Pascal's triangle sum to the Fibonacci numbers is a classical observation (Lucas). Replacing the diagonal slope by a steeper one produces the 'generalized Fibonacci' or p-bonacci sequences obeying a(m) = a(m−1) + a(m−p): p=2 is Fibonacci, p=3 is Narayana's cows (a(m)=a(m−1)+a(m−3), OEIS A000930), and so on. The parent gallery entry combinations-formula-oq-01-oq-01 proved the Fibonacci case ∑_j C(n−j, j) = F(n+1) axiom-free and posed the p-step generalization as its second open question. This entry answers it.",
+    "problemStatement": "For a step parameter q (with p = q+1), show that the p-step shallow-diagonal sum S q n = ∑_j C(n − q·j, j) satisfies the p-bonacci recurrence S q (n+q+1) = S q (n+q) + S q n with constant base segment S q n = 1 for n ≤ q, and that q=1 recovers the Fibonacci numbers.",
+    "text": "The single parameter q unifies the family: q=0 gives ∑_j C(n,j) = 2^n (the degenerate p=1 case), q=1 gives the Fibonacci diagonal, q=2 gives Narayana's cows, and general q gives the p-bonacci recurrence with p=q+1. The engine is Pascal's rule C(m+1, k+1) = C(m, k+1) + C(m, k) applied to each diagonal term: writing the index of the leading term as n+q+1−q(j+1), Pascal splits C(n+q+1−q(j+1), j+1) into C(n−q·j, j+1) (which feeds S q (n+q)) and C(n−q·j, j) (which feeds S q n after reindexing j ↦ j−1). The only subtlety is natural-number subtraction at the boundary of the binomial support, handled by the helper diag_pascal (which checks the truncated case where both upper indices collapse to 0) and by pbonacci_extend (which enlarges summation ranges freely, since C(n−q·j, j) = 0 once j > n). The Fibonacci corollary follows by two-step induction from the recurrence at q=1 and Nat.fib_add_two.",
+    "proofStrategy": "Peel the j=0 term with Finset.sum_range_succ', apply Pascal's rule termwise via the helper diag_pascal, recognize the two resulting sums as S q (n+q) and S q n (extending ranges with pbonacci_extend so the bookkeeping is linear), and finish with omega. Specialize to q=1 and induct with Nat.fib_add_two for the Fibonacci corollary.",
+    "keyInsights": [
+      "A single step parameter q (p = q+1) captures the whole p-bonacci family — powers of two, Fibonacci, Narayana's cows, and beyond — in one definition and one recurrence proof.",
+      "Pascal's rule on the leading diagonal index n+q+1−q(j+1) splits each term into exactly the contributions of S q (n+q) (slope-preserving) and S q n (one full step down), which is precisely the recurrence a(m) = a(m−1) + a(m−p).",
+      "The boundary case of natural-number subtraction is the only obstruction; isolating it in a termwise Pascal lemma (diag_pascal) and a range-extension lemma (pbonacci_extend) keeps the main argument purely linear (omega-dischargeable).",
+      "The recurrence plus the constant base segment S q n = 1 for n ≤ q together characterize the sequence, so no separate Lean definition of the p-bonacci numbers is needed — the diagonal sum is its own generating recurrence."
+    ],
+    "prerequisites": [
+      "Binomial coefficients Nat.choose and Pascal's rule Nat.choose_succ_succ",
+      "The Fibonacci sequence Nat.fib and Nat.fib_add_two",
+      "Finset range sums, Finset.sum_range_succ', and Finset.sum_subset",
+      "Two-step induction Nat.twoStepInduction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The p-step shallow-diagonal sums S q n = ∑_j C(n − q·j, j) of Pascal's triangle are proved, axiom-free, to satisfy the p-bonacci recurrence S q (n+q+1) = S q (n+q) + S q n with constant base segment S q n = 1 for n ≤ q, and the q=1 case is shown to equal F(n+1). 5 theorems, 1 definition, 195 lines, 0 axioms.",
+    "implications": "Upgrades the parent's single Fibonacci diagonal identity to the full p-bonacci family in one uniform statement, recovering the Fibonacci result as a corollary and exhibiting the powers of two and Narayana's cows as the q=0 and q=2 instances.",
+    "openQuestions": [
+      "Express the p-bonacci closed form (Binet-type / dominant-root asymptotics) and prove S q n ∼ C·ρ^n where ρ is the real root of x^p = x^{p−1} + 1.",
+      "Give a bijective (lattice-path) proof in Lean matching the combinatorial interpretation of the p-step diagonal.",
+      "Prove the companion identity for the row sums of the p-step diagonals (partial sums ∑_{m≤N} S q m) and the associated generating function ∑_n S q n · x^n = 1/(1 − x − x^p)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the Fibonacci shallow-diagonal identity ∑_j C(n−j, j) = F(n+1). This entry answers its second open question, generalizing to the p-step diagonals and recovering the Fibonacci case as pbonacci_one_eq_fib."
+    },
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: extended binomial coefficient identities, which first recorded the shallow-diagonal Fibonacci connection via native_decide examples."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "related",
+      "description": "Fibonacci summation identities; this entry places the Fibonacci diagonal sum inside the broader p-bonacci family of linear recurrences."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States the p-step shallow-diagonal generalization (the parent's second open question), the step parametrization q = p−1, the main results (recurrence, base segment, Fibonacci corollary), and the worked specializations q=0 (powers of two), q=1 (Fibonacci), q=2 (Narayana's cows). Imports Mathlib."
+    },
+    {
+      "title": "The p-step shallow-diagonal sum",
+      "startLine": 56,
+      "endLine": 60,
+      "summary": "pbonacci q n := ∑_{j ∈ range (n+1)} C(n − q·j, j), the p-step diagonal sum; q=1 is the parent's Fibonacci diagonal."
+    },
+    {
+      "title": "Range extension",
+      "startLine": 62,
+      "endLine": 73,
+      "summary": "pbonacci_extend: terms vanish once j outruns n − q·j, so the summation range may be enlarged above n without changing the value. Used to make the recurrence bookkeeping linear."
+    },
+    {
+      "title": "Pascal's rule on a diagonal term",
+      "startLine": 77,
+      "endLine": 106,
+      "summary": "diag_pascal (private helper): C(n+q+1 − q(j+1), j+1) = C(n − q·j, j+1) + C(n − q·j, j) for j ≥ 1, splitting by whether the subtraction truncates. This is the engine of the recurrence."
+    },
+    {
+      "title": "The p-bonacci recurrence",
+      "startLine": 108,
+      "endLine": 155,
+      "summary": "pbonacci_rec: S q (n+q+1) = S q (n+q) + S q n. Peels the j=0 term, applies diag_pascal termwise, identifies the two resulting sums as S q (n+q) and S q n via pbonacci_extend, and closes with omega."
+    },
+    {
+      "title": "Constant base segment",
+      "startLine": 157,
+      "endLine": 174,
+      "summary": "pbonacci_base: S q n = 1 for n ≤ q. Every term beyond j=0 vanishes because n − q(j+1) = 0, leaving the single leading C(n,0) = 1."
+    },
+    {
+      "title": "Recovering the parent Fibonacci identity",
+      "startLine": 176,
+      "endLine": 195,
+      "summary": "pbonacci_one_eq_fib: S 1 n = F(n+1), proved by two-step induction from pbonacci_rec at q=1 and Nat.fib_add_two — the parent result as a corollary of the general recurrence."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `combinations-formula-oq-01-oq-01` (verified, 0-axiom parent): generalize the Fibonacci shallow-diagonal identity `∑_j C(n−j, j) = F(n+1)` to the **p-step shallow diagonals** of Pascal's triangle, which produce the **p-bonacci / generalized Fibonacci** sequences.

For a step parameter `q` (so `p = q+1`), define `S q n = ∑_j C(n − q·j, j)`. The file proves, axiom-free:

- **`pbonacci_rec`** — the p-bonacci recurrence `S q (n+q+1) = S q (n+q) + S q n`, i.e. `a(m) = a(m−1) + a(m−p)`, uniformly for all `q ≥ 0`.
- **`pbonacci_base`** — the constant base segment `S q n = 1` for `n ≤ q` (the `p` initial values).
- **`pbonacci_one_eq_fib`** — `S 1 n = F(n+1)`, recovering the parent's Fibonacci identity as a corollary.
- **`pbonacci_extend`** — range-extension helper (terms vanish once `j > n − q·j`).

Specializations: `q=0` ⇒ `∑_j C(n,j) = 2^n`; `q=1` ⇒ Fibonacci; `q=2` ⇒ Narayana's cows `a(m)=a(m−1)+a(m−3)`.

## Proof idea

Pascal's rule `C(m+1, k+1) = C(m, k+1) + C(m, k)` applied to the leading diagonal index `n+q+1−q(j+1)` splits each term into a `C(n−q·j, j+1)` part (feeding `S q (n+q)`) and a `C(n−q·j, j)` part (feeding `S q n` after reindexing). Boundary natural-number subtraction is isolated in the helper `diag_pascal`; the main argument is then linear and closed by `omega`. The Fibonacci corollary is two-step induction via `Nat.fib_add_two`.

## Verification

- Builds against Mathlib (`lean-toolchain` v4.26.0).
- `#print axioms` for every theorem reports only `propext, Classical.choice, Quot.sound` — **no `native_decide`, no `sorryAx`**.
- 5 theorems, 1 definition, 195 lines, 0 sorries.
- Numeric sanity checks (`pbonacci 1 6 = 13`, `pbonacci 2 5 = 4`, `pbonacci 0 4 = 16`) pass via kernel `decide`.

## Files
- `proofs/Proofs/CombinationsFormulaOQ01OQ01OQ02.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/combinations-formula-oq-01-oq-01-oq-02/meta.json` (new gallery entry, badge `original`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)