### PR TITLE
audit: 9 research leaves clean (bernoulli/cantors/cauchy-group/cayley-minpoly/derangements/digital-root/lhopital/liouville/niven)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22001,6 +22001,60 @@
       "lastAudited": "2026-06-24T19:08:44Z",
       "result": "clean",
       "issues": []
+    },
+    "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:48Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-minpoly-oq-07-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-oq-03-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-3-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lhopital-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "liouville-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "niven-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T19:24:49Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — batch18

Verified 9 on-main, never-audited research leaves against their Lean sources. All **CLEAN** — public claims match the kernel.

| Slug | status/badge | sorry/axiom | Notes |
|------|-------------|-------------|-------|
| bernoulli-inequality-oq-01-oq-01-oq-01-oq-01 | verified/original | 0/0 | matches |
| cantors-theorem-oq-03-oq-02 | verified/original | 0/0 | plain kernel `decide` on closed Bool = 0-ax |
| cauchy-group-theorem-oq-01-…-oq-03 | verified/original | 0/0 | 6 substantive thms, genuine assembly not wrapper |
| cayley-hamilton-minpoly-oq-07-oq-01 | verified/original | 0/0 | matches |
| derangements-oq-03-oq-03-oq-01 | verified/mathlib | 0/0 | Burnside via Mathlib → badge `mathlib` correct |
| divisibility-by-3-oq-03-oq-02-oq-01 | verified/original | 0/0 | matches |
| lhopital-oq-05-oq-01 | verified/verified | 0/0 | matches |
| liouville-theorem-oq-03 | axiomatized/axiom | 0 sorry/1 axiom | JB `dimH_wellApprox` axiom disclosed; matches axiomCount=1 |
| niven-theorem-oq-01-oq-03 | verified/original | 0/0 | matches |

### False-positive grep flags resolved
- `divisibility`: `sorry` hit = docstring "`sorry`-free"; real sorries = 0.
- `derangements`: `native_decide` hit = docstring "no `native_decide`"; real usage = 0.
- `liouville`: 2nd `^axiom ` hit = docstring line "axiom of this entry"; only `dimH_wellApprox` is a real axiom decl → matches meta.axiomCount=1.

### Excluded from this batch
- 7 leaves (amgm/binomial/BSD/cevas/FTA/leibniz/stern-brocot) already covered by open tracker PR #29299 — resurface only because that tracker update is unmerged. Not duplicated.
- `hilbert-17-oq-03-oq-06`: ABSENT on origin/main (pollution from open research PR #22850). Skipped.

Tracker-only change; no proof content modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)