### PR TITLE
research(erdos-175): prove 4 | C(2n,n) ⟺ n not a power of 2 — eliminate sole sorry [axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos175Problem.lean
+++ b/proofs/Proofs/Erdos175Problem.lean
@@ -51,10 +51,76 @@ noncomputable def maxPrimePowerExp (n : ℕ) : ℕ :=
 4 | C(2n, n) unless n is a power of 2.
 -/
 
+/-- The base-2 digit sum of a positive number is positive (the leading digit is nonzero). -/
+theorem digitSum_two_pos {n : ℕ} (hn : n ≠ 0) : 0 < (Nat.digits 2 n).sum := by
+  have hnil : Nat.digits 2 n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hn
+  have hlast : (Nat.digits 2 n).getLast hnil ≠ 0 := Nat.getLast_digit_ne_zero 2 hn
+  have hmem : (Nat.digits 2 n).getLast hnil ∈ Nat.digits 2 n := List.getLast_mem hnil
+  have hle := List.single_le_sum (fun x _ => Nat.zero_le x) _ hmem
+  omega
+
+/-- **Kummer/Legendre for `p = 2`.** The 2-adic valuation of the central binomial coefficient
+`C(2n, n)` equals the number of one-bits of `n`, i.e. its base-2 digit sum.
+
+Indeed `v₂(C(2n,n)) = s₂(n) + s₂(n) − s₂(2n)` by Kummer's theorem, and `s₂(2n) = s₂(n)` since
+doubling only prepends a zero bit. -/
+theorem padicValNat_two_centralBinom (n : ℕ) :
+    padicValNat 2 (centralBinom n) = (Nat.digits 2 n).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hcb : centralBinom n = Nat.choose (n + n) n := by rw [centralBinom, two_mul]
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp [centralBinom]
+  -- doubling preserves the base-2 digit sum: `digits 2 (n+n) = 0 :: digits 2 n`
+  have hdd : (Nat.digits 2 (n + n)).sum = (Nat.digits 2 n).sum := by
+    have h2 : n + n = 2 ^ 1 * n := by ring
+    rw [h2, Nat.digits_base_pow_mul (by norm_num) hn]
+    simp
+  have key := sub_one_mul_padicValNat_choose_eq_sub_sum_digits' (p := 2) (k := n) (n := n)
+  rw [hcb]
+  rw [hdd] at key
+  simp only [show (2 : ℕ) - 1 = 1 from rfl, one_mul] at key
+  omega
+
+/-- For a positive `n`, the base-2 digit sum is `1` exactly when `n` is a power of two. -/
+theorem digitSum_two_eq_one_iff {n : ℕ} (hn : 0 < n) :
+    (Nat.digits 2 n).sum = 1 ↔ ∃ k, n = 2 ^ k := by
+  constructor
+  · intro hs
+    obtain ⟨k, m, hm, rfl⟩ := Nat.exists_eq_two_pow_mul_odd hn.ne'
+    have hmpos : 0 < m := Nat.pos_of_ne_zero (by rintro rfl; simp at hn)
+    rw [Nat.digits_base_pow_mul (by norm_num) hmpos] at hs
+    simp only [List.sum_append, List.sum_replicate, smul_eq_mul, Nat.mul_zero, zero_add] at hs
+    have hmod : m % 2 = 1 := Nat.odd_iff.mp hm
+    rw [Nat.digits_of_two_le_of_pos (by norm_num) hmpos, hmod, List.sum_cons] at hs
+    have hzero : (Nat.digits 2 (m / 2)).sum = 0 := by omega
+    have hm2 : m / 2 = 0 := by
+      by_contra h
+      exact absurd hzero (digitSum_two_pos h).ne'
+    have hm1 : m = 1 := by omega
+    exact ⟨k, by rw [hm1, mul_one]⟩
+  · rintro ⟨k, rfl⟩
+    rw [show (2 : ℕ) ^ k = 2 ^ k * 1 from (mul_one _).symm,
+        Nat.digits_base_pow_mul (by norm_num) one_pos,
+        Nat.digits_of_two_le_of_pos (by norm_num) one_pos]
+    simp
+
 /-- 4 | C(2n, n) iff n is not a power of 2 -/
 theorem four_divides_iff (n : ℕ) (hn : n ≥ 2) :
     4 ∣ centralBinom n ↔ ¬∃ k : ℕ, n = 2 ^ k := by
-  sorry
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hpos : 0 < n := by omega
+  have hcb0 : centralBinom n ≠ 0 := by
+    rw [centralBinom]; exact (Nat.choose_pos (by omega)).ne'
+  -- `4 ∣ C(2n,n)` ↔ `v₂(C(2n,n)) ≥ 2`, and `v₂ = s₂(n)`
+  have hdvd : 4 ∣ centralBinom n ↔ 2 ≤ padicValNat 2 (centralBinom n) := by
+    rw [show (4 : ℕ) = 2 ^ 2 by norm_num]
+    exact padicValNat_dvd_iff_le hcb0
+  rw [hdvd, padicValNat_two_centralBinom]
+  -- `s₂(n) ≥ 2` ↔ `n` is not a power of two (since `s₂(n) ≥ 1` for `n ≥ 1`)
+  have hs1 : 0 < (Nat.digits 2 n).sum := digitSum_two_pos hpos.ne'
+  rw [show (¬∃ k, n = 2 ^ k) ↔ (Nat.digits 2 n).sum ≠ 1 from
+        (digitSum_two_eq_one_iff hpos).not.symm]
+  omega
 
 /-
 ## Part 3: The Main Theorem

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -17,7 +17,7 @@
       "prime-powers"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 175,
     "erdosUrl": "https://erdosproblems.com/175",
     "erdosProblemStatus": "solved",
@@ -36,16 +36,27 @@
         "theorem": "Squarefree",
         "description": "Squarefreeness predicate",
         "module": "Mathlib.Data.Nat.Squarefree"
+      },
+      {
+        "theorem": "sub_one_mul_padicValNat_choose_eq_sub_sum_digits'",
+        "description": "Kummer/Legendre: (p-1)*v_p(C(n+k,k)) = s_p(k)+s_p(n)-s_p(n+k)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.digits_base_pow_mul",
+        "description": "digits b (b^k * m) = replicate k 0 ++ digits b m",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
       }
     ],
     "originalContributions": [
-      "Formalized central binomial squarefreeness for n ≥ 5",
-      "Axiomatized bounds on maximum prime power exponent f(n)",
-      "Connected Kummer's theorem to divisibility analysis",
-      "Included explicit computations for small cases"
+      "Fully proved (axiom-free) that 4 divides C(2n,n) iff n is not a power of 2, for n >= 2",
+      "Proved v2(C(2n,n)) = s2(n) (base-2 digit sum) specializing Kummer/Legendre via sub_one_mul_padicValNat_choose_eq_sub_sum_digits'",
+      "Proved s2(n) = 1 iff n is a power of two, and that doubling preserves the base-2 digit sum",
+      "Axiomatized the deep bounds (Granville-Ramare squarefreeness; Sander/Erdos-Kolesnik bounds on f(n))",
+      "Included explicit machine-checked computations for small cases"
     ],
     "axiomCount": 4,
-    "lineCount": 182,
+    "lineCount": 248,
     "references": [
       {
         "title": "The largest prime factor of (2n choose n)",
@@ -72,9 +83,9 @@
         "description": "Kummer's classical theorem relating p-adic valuations of binomial coefficients to carries in base-p arithmetic"
       }
     ],
-    "assumptions": "4 axioms: granville_ramare_1996 (Granville-Ramaré 1996: C(2n,n) not squarefree for n≥5), sander_1992_f_unbounded (Sander 1992: f(n) → ∞), sander_1995_upper_bound (Sander 1995: f(n) ≪ log n), erdos_kolesnik_1999 (Erdős-Kolesnik: f(n) ≫ (log n)^{1/4}). 1 sorry.",
+    "assumptions": "4 axioms (deep analytic results, not yet formalizable): granville_ramare_1996 (Granville-Ramaré 1996: C(2n,n) not squarefree for n≥5), sander_1992_f_unbounded (Sander 1992: f(n) → ∞), sander_1995_upper_bound (Sander 1995: f(n) ≪ log n), erdos_kolesnik_1999 (Erdős-Kolesnik: f(n) ≫ (log n)^{1/4}). 0 sorries: the divisibility characterization four_divides_iff is now fully proven (axiom-free) via Kummer theorem.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 5
   },
   "overview": {
@@ -180,19 +191,24 @@
   },
   "mainTheorems": [
     {
+      "name": "four_divides_iff",
+      "type": "core",
+      "description": "Fully proven (axiom-free): for n >= 2, 4 divides C(2n,n) iff n is not a power of 2. Proved via the 2-adic valuation v2(C(2n,n)) = base-2 digit sum of n."
+    },
+    {
+      "name": "padicValNat_two_centralBinom",
+      "type": "supporting",
+      "description": "Kummer/Legendre specialization: v2(C(2n,n)) equals the base-2 digit sum s2(n) (the number of one-bits of n), using that doubling preserves the base-2 digit sum."
+    },
+    {
       "name": "granville_ramare_1996",
       "type": "core",
-      "description": "The main theorem axiomatizing Granville-Ramaré's 1996 result: C(2n,n) is not squarefree for all n ≥ 5, completing the solution to Erdős's problem."
+      "description": "Axiomatized Granville-Ramare 1996 result: C(2n,n) is not squarefree for all n >= 5, completing the solution to Erdos problem #175."
     },
     {
       "name": "c_10_5_not_squarefree",
       "type": "supporting",
-      "description": "Concrete verified instance: C(10,5) = 252 = 2²·3²·7 is not squarefree, proved by norm_num as a machine-checked small case."
-    },
-    {
-      "name": "sander_1992_f_unbounded",
-      "type": "supporting",
-      "description": "Sander's 1992 result that f(n) = max_p v_p(C(2n,n)) tends to infinity, establishing that the prime power exponents of central binomial coefficients grow without bound."
+      "description": "Concrete verified instance: C(10,5) = 252 = 2^2*3^2*7 is not squarefree."
     }
   ],
   "leanFile": {
@@ -203,12 +219,12 @@
       "Nat"
     ],
     "namespace": "Erdos175",
-    "lineCount": 182,
+    "lineCount": 248,
     "axiomCount": 4,
-    "theoremCount": 5,
+    "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/Erdos175Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -253,5 +269,5 @@
       "note": "Modern survey of prime factors and divisibility of binomial coefficients"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Eliminates the only `sorry` in `proofs/Proofs/Erdos175Problem.lean` (Erdős Problem #175) by giving a complete, **axiom-free** proof of the divisibility characterization:

> For `n ≥ 2`,  `4 ∣ C(2n, n)  ⟺  n` is **not** a power of 2.

`#print axioms four_divides_iff` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).

## Mathematical content

The proof routes through the 2-adic valuation:

- **`padicValNat_two_centralBinom`** — `v₂(C(2n,n)) = s₂(n)`, the base-2 digit sum of `n`. This specializes Kummer/Legendre (`sub_one_mul_padicValNat_choose_eq_sub_sum_digits'`) and uses that doubling prepends a zero bit, so `s₂(2n) = s₂(n)` (`Nat.digits_base_pow_mul`).
- **`digitSum_two_eq_one_iff`** — `s₂(n) = 1 ⟺ n` is a power of two (via `Nat.exists_eq_two_pow_mul_odd`).
- **`digitSum_two_pos`** — `s₂(n) > 0` for `n ≥ 1` (leading digit nonzero).

Then `4 ∣ C(2n,n) ⟺ v₂ ≥ 2 ⟺ s₂(n) ≥ 2 ⟺ s₂(n) ≠ 1 ⟺ n` not a power of 2.

## Scope / honesty

The 4 deep analytic results in the file remain **axioms** (Granville-Ramaré squarefreeness for `n ≥ 5`; Sander and Erdős-Kolesnik bounds on `f(n)`). The entry therefore stays `status: axiomatized`, `badge: axiom`, `axiomCount: 4`. This PR's contribution is removing the elementary divisibility `sorry`, not the deep theorems.

## Verification

`lake env lean Proofs/Erdos175Problem.lean` → exit 0, no errors (only pre-existing unused-variable warnings in the `maxPrimePowerExp`/`f` stub defs).

## meta.json

- `sorries`: 1 → 0 (top-level, `.meta`, `.leanFile`)
- `theoremCount`: 5 → 8
- updated `originalContributions`, `mainTheorems`, `mathlibDependencies`, `assumptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)