### PR TITLE
research(baire-category-theorem-oq-01-oq-03): perfect complete metric spaces have cardinality ≥ continuum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -249,6 +249,7 @@ import Proofs.AutomorphicNumberOQ01OQ03
 import Proofs.AutomorphicNumberOQ01OQ03OQ01
 import Proofs.BaireCategoryTheoremOQ01
 import Proofs.BaireCategoryTheoremOQ01OQ01
+import Proofs.BaireCategoryTheoremOQ01OQ03
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
 import Proofs.BallotProblemOQ01OQ01

--- a/proofs/Proofs/BaireCategoryTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/BaireCategoryTheoremOQ01OQ03.lean
@@ -1,0 +1,95 @@
+import Mathlib
+
+/-!
+# Perfect complete metric spaces have at least the cardinality of the continuum
+
+The parent entry (`BaireCategoryTheoremOQ01.lean`) derives the **uncountability of `ℝ`**
+from the Baire category theorem: a nonempty complete metric space is non-meagre, so it
+cannot be a countable union of singletons, hence it is uncountable.
+
+This file *sharpens* that conclusion from "uncountable" to "has cardinality at least the
+continuum `𝔠 = 2^{ℵ₀}`".  The mechanism is the classical **Cantor scheme**: inside any
+nonempty perfect set of a complete metric space one can build a binary tree of nested
+closed balls with vanishing diameter, producing a continuous injection of the Cantor
+space `ℕ → Bool` into the set.  Mathlib packages exactly this construction as
+`Perfect.exists_nat_bool_injection`, and we turn the resulting injection into a cardinal
+inequality.
+
+## Main results
+
+* `Cardinal.mk_nat_arrow_bool` — the Cantor space has cardinality the continuum,
+  `#(ℕ → Bool) = 𝔠`.
+* `continuum_le_mk_of_perfect` — **the core statement**: a nonempty perfect subset `C`
+  of a complete metric space satisfies `𝔠 ≤ #C`.
+* `not_countable_of_perfect` — consequently such a `C` is uncountable (a quantitative
+  strengthening of the Cantor–Bendixson "perfect sets are uncountable" fact).
+* `continuum_le_mk_of_perfectSpace` — for a nonempty complete metric space **with no
+  isolated points** (`PerfectSpace`), the whole space has `𝔠 ≤ #α`.
+* `uncountable_of_perfectSpace` — hence such a space is `Uncountable`.
+* `continuum_le_mk_real` — the concrete witness `𝔠 ≤ #ℝ`, recovering and sharpening the
+  parent's `real_uncountable` (`ℝ` is connected, `T1`, and nontrivial, so it is a
+  `PerfectSpace`).
+
+This is the cardinal-arithmetic refinement of the Baire-category uncountability theorem
+absent from the gallery; `Mathlib` supplies the Cantor-scheme injection but not the
+cardinality corollary.
+-/
+
+open Set Cardinal
+
+namespace BaireCategoryTheoremOQ01OQ03
+
+/-- The Cantor space `ℕ → Bool` has cardinality the continuum, `#(ℕ → Bool) = 𝔠`.
+
+`#(ℕ → Bool) = #Bool ^ #ℕ = 2 ^ ℵ₀ = 𝔠`. -/
+theorem mk_nat_arrow_bool : #(ℕ → Bool) = 𝔠 := by
+  rw [← Cardinal.power_def, Cardinal.mk_bool, Cardinal.mk_nat, Cardinal.two_power_aleph0]
+
+variable {α : Type} [MetricSpace α] [CompleteSpace α]
+
+/-- **Core statement.** A nonempty perfect subset `C` of a complete metric space has
+cardinality at least the continuum.
+
+The Cantor scheme inside `C` (Mathlib's `Perfect.exists_nat_bool_injection`) yields a
+*continuous injection* `f : (ℕ → Bool) → α` with range contained in `C`; restricting its
+codomain to `C` gives an injection of the continuum-sized Cantor space into `C`. -/
+theorem continuum_le_mk_of_perfect {C : Set α} (hC : Perfect C) (hne : C.Nonempty) :
+    𝔠 ≤ #C := by
+  obtain ⟨f, hrange, _, hinj⟩ := hC.exists_nat_bool_injection hne
+  -- Restrict the codomain of `f` to the subtype `C`.
+  have hmem : ∀ x : ℕ → Bool, f x ∈ C := fun x => hrange (mem_range_self x)
+  let g : (ℕ → Bool) → C := fun x => ⟨f x, hmem x⟩
+  have hginj : Function.Injective g := fun a b hab => hinj (congrArg Subtype.val hab)
+  have hle : #(ℕ → Bool) ≤ #C := Cardinal.mk_le_of_injective hginj
+  rwa [mk_nat_arrow_bool] at hle
+
+/-- A nonempty perfect subset of a complete metric space is uncountable — the
+quantitative Cantor–Bendixson statement that perfect sets carry continuum-many points. -/
+theorem not_countable_of_perfect {C : Set α} (hC : Perfect C) (hne : C.Nonempty) :
+    ¬ C.Countable := by
+  intro hcount
+  have hco : Countable C := Set.countable_coe_iff.mpr hcount
+  have hle : #C ≤ ℵ₀ := Cardinal.mk_le_aleph0_iff.mpr hco
+  have hge : 𝔠 ≤ #C := continuum_le_mk_of_perfect hC hne
+  exact absurd (hge.trans hle) (not_le.mpr aleph0_lt_continuum)
+
+/-- **Whole-space form.** A nonempty complete metric space with no isolated points
+(a `PerfectSpace`) has cardinality at least the continuum. -/
+theorem continuum_le_mk_of_perfectSpace [Nonempty α] [PerfectSpace α] : 𝔠 ≤ #α := by
+  have h := continuum_le_mk_of_perfect (C := (univ : Set α))
+    (PerfectSpace.univ_perfect (α := α)) univ_nonempty
+  rwa [Cardinal.mk_univ] at h
+
+/-- A nonempty complete metric space with no isolated points is uncountable. -/
+theorem uncountable_of_perfectSpace [Nonempty α] [PerfectSpace α] : Uncountable α := by
+  rw [← Cardinal.aleph0_lt_mk_iff]
+  exact aleph0_lt_continuum.trans_le continuum_le_mk_of_perfectSpace
+
+/-- **Concrete witness.** The real line has cardinality at least the continuum,
+recovering (and quantitatively sharpening) the parent file's `real_uncountable`.
+
+`ℝ` is connected, `T1`, and nontrivial, hence a `PerfectSpace`; it is also a complete
+metric space, so the whole-space form applies. -/
+theorem continuum_le_mk_real : 𝔠 ≤ #ℝ := continuum_le_mk_of_perfectSpace
+
+end BaireCategoryTheoremOQ01OQ03

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-cantor-cardinality",
+    "proofId": "baire-category-theorem-oq-01-oq-03",
+    "range": { "startLine": 42, "endLine": 47 },
+    "type": "insight",
+    "title": "The Cantor Space Has Cardinality the Continuum",
+    "content": "mk_nat_arrow_bool reads off #(ℕ → Bool) = 𝔠 in one chain. Cardinal.power_def rewrites the function space as a power #Bool ^ #ℕ; mk_bool gives #Bool = 2 and mk_nat gives #ℕ = ℵ₀; and two_power_aleph0 closes with 2 ^ ℵ₀ = 𝔠. This is the cardinal that the Cantor-scheme embedding will transfer into any nonempty perfect set — the whole point is that a perfect set contains a topological copy of Cantor space, and Cantor space already has continuum cardinality."
+  },
+  {
+    "id": "ann-core-perfect-bound",
+    "proofId": "baire-category-theorem-oq-01-oq-03",
+    "range": { "startLine": 50, "endLine": 64 },
+    "type": "insight",
+    "title": "Corestrict the Cantor-Scheme Injection to the Perfect Set",
+    "content": "continuum_le_mk_of_perfect is the core. Mathlib's Perfect.exists_nat_bool_injection supplies a continuous injection f : (ℕ → Bool) → X whose range lies inside C (the Cantor scheme: nested closed balls of vanishing diameter, whose limit points are indexed by binary sequences). Since range f ⊆ C, every f x lands in C, so g x := ⟨f x, hmem x⟩ corestricts f to the subtype ↥C; corestriction preserves injectivity (congrArg Subtype.val). Then mk_le_of_injective gives #(ℕ → Bool) ≤ #C, and mk_nat_arrow_bool rewrites the left side to 𝔠. The bound is a property of perfect SETS, not just perfect spaces."
+  },
+  {
+    "id": "ann-not-countable",
+    "proofId": "baire-category-theorem-oq-01-oq-03",
+    "range": { "startLine": 66, "endLine": 74 },
+    "type": "insight",
+    "title": "Uncountability as a Corollary of the Cardinal Bound",
+    "content": "not_countable_of_perfect recovers the qualitative Cantor–Bendixson fact (perfect sets are uncountable) from the quantitative one. If C were countable then Countable ↥C (countable_coe_iff), giving #C ≤ ℵ₀ (mk_le_aleph0_iff). But the core bound gives 𝔠 ≤ #C, so 𝔠 ≤ ℵ₀ — contradicting aleph0_lt_continuum (ℵ₀ < 𝔠). The strict gap between ℵ₀ and 𝔠 is exactly what upgrades 'at least continuum' to 'uncountable'."
+  },
+  {
+    "id": "ann-whole-space",
+    "proofId": "baire-category-theorem-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 86 },
+    "type": "insight",
+    "title": "Whole-Space Form: No Isolated Points",
+    "content": "continuum_le_mk_of_perfectSpace specializes the core to C = univ. The hypothesis is PerfectSpace α — a space with no isolated points (perfectSpace_iff_forall_not_isolated equates this with NeBot (𝓝[≠] x) at every point). PerfectSpace.univ_perfect makes univ a perfect set and univ_nonempty supplies nonemptiness; mk_univ rewrites #↥univ = #α. uncountable_of_perfectSpace then chains ℵ₀ < 𝔠 ≤ #α through aleph0_lt_mk_iff to conclude Uncountable α. Completeness powers the convergence of the nested balls; no-isolated-points powers the room to keep splitting — both Baire-flavored hypotheses are load-bearing."
+  },
+  {
+    "id": "ann-real-witness",
+    "proofId": "baire-category-theorem-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 93 },
+    "type": "insight",
+    "title": "The Real Line Falls Out for Free",
+    "content": "continuum_le_mk_real : 𝔠 ≤ #ℝ is just the whole-space form at α = ℝ — no real-analysis input. ℝ is a complete metric space, and it is a PerfectSpace purely formally: the instance [T1Space α] [ConnectedSpace α] [Nontrivial α] → PerfectSpace α fires because ℝ is connected, T1, and nontrivial, so it has no isolated points. This recovers and quantitatively sharpens the parent entry's real_uncountable: not merely uncountable, but of cardinality at least the continuum."
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "baire-category-theorem-oq-01-oq-03",
+  "slug": "baire-category-theorem-oq-01-oq-03",
+  "title": "Perfect Complete Metric Spaces Have at Least the Cardinality of the Continuum",
+  "description": "The parent entry derives the uncountability of ℝ from the Baire category theorem. This entry sharpens 'uncountable' to the quantitative cardinal bound 𝔠 ≤ #X: a nonempty perfect subset of a complete metric space — and in particular a nonempty complete metric space with no isolated points (a PerfectSpace) — has cardinality at least the continuum. The mechanism is the classical Cantor scheme, a binary tree of nested closed balls of vanishing diameter, which embeds the Cantor space ℕ → Bool; Mathlib packages the embedding as Perfect.exists_nat_bool_injection, and this entry converts it into the cardinal inequality 𝔠 = #(ℕ → Bool) ≤ #X, recovering 𝔠 ≤ #ℝ as the concrete witness. Verified, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "That a nonempty perfect set in a complete metric space is uncountable is the cardinality half of the Cantor–Bendixson theory (Cantor 1883), and the sharper statement — such a set has at least continuum-many points — is the standard strengthening: a perfect set is 'large' not merely in being uncountable but in carrying a topological copy of Cantor space 2^ℕ, hence cardinality 2^{ℵ₀} = 𝔠. The Baire category theorem (Baire 1899) gives the qualitative version for the whole space (a complete metric space is non-meagre, so a fortiori uncountable), and the parent gallery entry extracts the uncountability of ℝ this way. Mathlib formalizes the Cantor-scheme construction abstractly as Perfect.exists_nat_bool_injection (a continuous injection of ℕ → Bool into any nonempty perfect set of a complete metric space) and the PerfectSpace typeclass for spaces with no isolated points, but records no cardinality corollary. This entry supplies it, turning the embedding into the cardinal lower bound and recovering 𝔠 ≤ #ℝ.",
+    "problemStatement": "Sharpen the Baire-category uncountability theorem from 'uncountable' to a continuum-cardinality lower bound. Concretely: (1) show the Cantor space has cardinality the continuum, #(ℕ → Bool) = 𝔠; (2) show that for a nonempty perfect subset C of a complete metric space, 𝔠 ≤ #C; (3) deduce that such a C is uncountable; (4) specialize to a nonempty complete metric space with no isolated points (PerfectSpace) to get 𝔠 ≤ #X for the whole space, hence X is uncountable; (5) instantiate at ℝ (connected, T1, nontrivial ⇒ PerfectSpace; complete metric) to obtain 𝔠 ≤ #ℝ, sharpening the parent's real_uncountable.",
+    "proofStrategy": "The cardinal identity mk_nat_arrow_bool reads off #(ℕ → Bool) = #Bool ^ #ℕ = 2 ^ ℵ₀ = 𝔠 from Cardinal.power_def, mk_bool, mk_nat, and two_power_aleph0. The core continuum_le_mk_of_perfect invokes Perfect.exists_nat_bool_injection to obtain a continuous injection f : (ℕ → Bool) → X whose range lies in C, restricts its codomain to the subtype ↥C (the corestriction stays injective), and applies mk_le_of_injective to get #(ℕ → Bool) ≤ #C, which mk_nat_arrow_bool rewrites to 𝔠 ≤ #C. not_countable_of_perfect contradicts countability (#C ≤ ℵ₀ via mk_le_aleph0_iff and countable_coe_iff) against 𝔠 ≤ #C and ℵ₀ < 𝔠 (aleph0_lt_continuum). continuum_le_mk_of_perfectSpace applies the core to C = univ, using PerfectSpace.univ_perfect and univ_nonempty and rewriting #↥univ = #X (mk_univ); uncountable_of_perfectSpace then chains ℵ₀ < 𝔠 ≤ #X through aleph0_lt_mk_iff. continuum_le_mk_real is the whole-space form at X = ℝ, whose PerfectSpace instance is inferred from connectedness + T1 + nontriviality. Restricting the ambient type to universe 0 (Type) keeps #(ℕ → Bool) : Cardinal.{0} commensurable with #C and covers ℝ and every concrete metric space.",
+    "keyInsights": [
+      "The leap from 'uncountable' to '≥ continuum' is exactly the leap from the qualitative Baire/Cantor–Bendixson statement to the embedding 2^ℕ ↪ C: a perfect set does not merely fail to be a countable union of points, it topologically contains the whole Cantor space, and Cantor space already has continuum cardinality. mk_nat_arrow_bool isolates that last fact.",
+      "The continuum bound is a property of perfect SETS, not just perfect SPACES. continuum_le_mk_of_perfect takes an arbitrary nonempty perfect subset C, so it applies to closed-without-isolated-points subsets of any complete metric space; the whole-space PerfectSpace form is the special case C = univ. This is the genuinely reusable statement.",
+      "PerfectSpace = 'no isolated points' is the precise hypothesis. perfectSpace_iff_forall_not_isolated equates it with NeBot (𝓝[≠] x) at every point. Completeness supplies the convergence of the nested balls (the Cantor scheme needs a limit), and no-isolated-points supplies the room to keep splitting — both hypotheses are load-bearing, exactly mirroring the original Baire setup.",
+      "ℝ needs no bespoke argument: it is a PerfectSpace purely formally (connected + T1 + nontrivial ⇒ no isolated points), so 𝔠 ≤ #ℝ falls out of the general theorem with zero real-analysis input — a sharper conclusion than the parent's real_uncountable obtained with strictly less hand-tailoring.",
+      "The proof is universe-pinned to Type 0 by design: comparing #(ℕ → Bool) (a Type 0 cardinal) with #C requires them to live in the same universe. Since the target spaces (ℝ and concrete metric spaces) are all Type 0, restricting the ambient type avoids the lift bookkeeping with no loss of applicability."
+    ]
+  },
+  "conclusion": {
+    "summary": "A nonempty perfect subset C of a complete metric space has cardinality at least the continuum, 𝔠 ≤ #C (continuum_le_mk_of_perfect), and is therefore uncountable (not_countable_of_perfect). The engine is mk_nat_arrow_bool (#(ℕ → Bool) = 𝔠) combined with Mathlib's Cantor-scheme embedding Perfect.exists_nat_bool_injection, whose continuous injection of the Cantor space is corestricted to C and fed to mk_le_of_injective. Specializing to C = univ gives the whole-space form continuum_le_mk_of_perfectSpace: a nonempty complete metric space with no isolated points (PerfectSpace) satisfies 𝔠 ≤ #X, hence is Uncountable (uncountable_of_perfectSpace). The concrete witness continuum_le_mk_real : 𝔠 ≤ #ℝ recovers and quantitatively sharpens the parent file's real_uncountable, ℝ being a PerfectSpace by connectedness + T1 + nontriviality. 95 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "This is the cardinal-arithmetic refinement of the Baire-category uncountability theorem absent from both Mathlib and the gallery: Mathlib supplies the Cantor-scheme injection and the PerfectSpace typeclass but no cardinality corollary. The perfect-SET version (continuum_le_mk_of_perfect) is reusable wherever a closed set without isolated points appears — Cantor sets, perfect kernels in the Cantor–Bendixson decomposition, supports of atomless measures — giving '≥ continuum' immediately. It answers the parent's open question 'Sharpen uncountability to a continuum-cardinality lower bound for perfect complete metric spaces' verbatim.",
+    "openQuestions": [
+      "Upgrade the lower bound to an exact cardinality for separable spaces: a perfect Polish space (nonempty, complete, separable, no isolated points) has cardinality EXACTLY 𝔠, combining 𝔠 ≤ #X with the upper bound #X ≤ 𝔠 that holds for every second-countable T0 (hence separable metric) space.",
+      "Lift the result to arbitrary universes by inserting Cardinal.lift, replacing 𝔠 ≤ #X with the lift-correct statement lift 𝔠 ≤ lift #X, so the bound applies to complete metric spaces in any Type universe rather than only Type 0."
+    ]
+  },
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Cardinal"
+    ],
+    "namespace": "BaireCategoryTheoremOQ01OQ03",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BaireCategoryTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaireCategoryTheoremOQ01OQ03.lean",
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 95,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "tags": [
+      "topology",
+      "descriptive-set-theory",
+      "cardinality",
+      "continuum",
+      "perfect-set",
+      "cantor-scheme",
+      "baire-category",
+      "metric-space",
+      "research"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Perfect.exists_nat_bool_injection",
+        "description": "For a nonempty perfect set C in a complete metric space, there is a continuous injection f : (ℕ → Bool) → X with range f ⊆ C. This is Mathlib's formalization of the Cantor scheme (nested closed balls of vanishing diameter) and the engine of the whole entry: it transfers the continuum cardinality of Cantor space into C.",
+        "module": "Mathlib.Topology.MetricSpace.Perfect"
+      },
+      {
+        "theorem": "Cardinal.two_power_aleph0",
+        "description": "2 ^ ℵ₀ = 𝔠. Combined with power_def, mk_bool, and mk_nat it gives #(ℕ → Bool) = 𝔠, the cardinal that the Cantor-scheme injection lower-bounds #C by.",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      },
+      {
+        "theorem": "Cardinal.mk_le_of_injective",
+        "description": "An injection α → β yields #α ≤ #β. Applied to the corestriction of the Cantor-scheme injection to the subtype ↥C to produce #(ℕ → Bool) ≤ #C.",
+        "module": "Mathlib.SetTheory.Cardinal.Order"
+      },
+      {
+        "theorem": "PerfectSpace.univ_perfect",
+        "description": "In a PerfectSpace (a space with no isolated points) the whole space univ is a perfect set. Specializes the perfect-set bound to the whole space. The instance PerfectSpace ℝ is inferred from connectedness + T1 + nontriviality, giving 𝔠 ≤ #ℝ for free.",
+        "module": "Mathlib.Topology.Perfect"
+      },
+      {
+        "theorem": "Cardinal.aleph0_lt_continuum",
+        "description": "ℵ₀ < 𝔠. Turns the cardinal lower bound 𝔠 ≤ #X into uncountability (ℵ₀ < #X) for both the perfect-set and whole-space forms.",
+        "module": "Mathlib.SetTheory.Cardinal.Continuum"
+      }
+    ],
+    "originalContributions": [
+      "continuum_le_mk_of_perfect: the core result — a nonempty perfect subset C of a complete metric space satisfies 𝔠 ≤ #C. Obtained by corestricting Mathlib's Cantor-scheme injection (ℕ → Bool) → X to the subtype ↥C and applying mk_le_of_injective, then rewriting #(ℕ → Bool) = 𝔠. Mathlib has the embedding but not this cardinality corollary.",
+      "mk_nat_arrow_bool: #(ℕ → Bool) = 𝔠, the cardinality of the Cantor space, assembled from power_def, mk_bool, mk_nat, and two_power_aleph0.",
+      "continuum_le_mk_of_perfectSpace: the whole-space form — a nonempty complete metric space with no isolated points (PerfectSpace) has 𝔠 ≤ #X, via the core bound at C = univ (PerfectSpace.univ_perfect, mk_univ).",
+      "not_countable_of_perfect / uncountable_of_perfectSpace: the qualitative corollaries (perfect sets and perfect spaces are uncountable) recovered from the quantitative bound against ℵ₀ < 𝔠.",
+      "continuum_le_mk_real: the concrete witness 𝔠 ≤ #ℝ, sharpening the parent entry's real_uncountable; ℝ's PerfectSpace instance is purely formal (connected + T1 + nontrivial)."
+    ],
+    "prerequisites": [
+      "baire-category-theorem-oq-01"
+    ]
+  },
+  "references": [
+    {
+      "title": "Perfect set (Cantor–Bendixson; perfect sets have continuum cardinality)",
+      "url": "https://en.wikipedia.org/wiki/Perfect_set"
+    },
+    {
+      "title": "Cardinality of the continuum",
+      "url": "https://en.wikipedia.org/wiki/Cardinality_of_the_continuum"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "parent",
+      "description": "The parent derives the uncountability of ℝ from the Baire category theorem (real_uncountable) and lists as an open question 'Sharpen uncountability to a continuum-cardinality lower bound for perfect complete metric spaces.' This entry answers exactly that, replacing 'uncountable' with the cardinal bound 𝔠 ≤ #X for perfect complete metric spaces and recovering 𝔠 ≤ #ℝ as continuum_le_mk_real."
+    }
+  ],
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: From Uncountable to ≥ Continuum",
+      "startLine": 3,
+      "endLine": 49,
+      "summary": "States the goal — sharpen the Baire-category uncountability of ℝ to a continuum-cardinality lower bound — and the mechanism: the Cantor scheme embeds ℕ → Bool into any nonempty perfect set of a complete metric space (Mathlib's Perfect.exists_nat_bool_injection), and the Cantor space has cardinality 𝔠. Lists the six results and notes Mathlib has the embedding but not the cardinality corollary.",
+      "mathContext": "A nonempty perfect set $C$ in a complete metric space satisfies $\\mathfrak{c} = \\#(\\mathbb{N}\\to\\mathrm{Bool}) \\le \\#C$."
+    },
+    {
+      "id": "cantor-cardinality",
+      "title": "The Cantor Space Has Cardinality the Continuum",
+      "startLine": 53,
+      "endLine": 58,
+      "summary": "mk_nat_arrow_bool: #(ℕ → Bool) = 𝔠, read off as #Bool ^ #ℕ = 2 ^ ℵ₀ = 𝔠 via Cardinal.power_def, mk_bool, mk_nat, and two_power_aleph0. This is the cardinal that the Cantor-scheme embedding transfers into the perfect set.",
+      "mathContext": "$\\#(\\mathbb{N}\\to\\mathrm{Bool}) = \\#\\mathrm{Bool}^{\\#\\mathbb{N}} = 2^{\\aleph_0} = \\mathfrak{c}$."
+    },
+    {
+      "id": "perfect-set-bound",
+      "title": "The Core Bound on Perfect Sets",
+      "startLine": 60,
+      "endLine": 84,
+      "summary": "continuum_le_mk_of_perfect: a nonempty perfect subset C of a complete metric space has 𝔠 ≤ #C, via corestricting the Cantor-scheme injection to ↥C and applying mk_le_of_injective. not_countable_of_perfect deduces C is uncountable by contradicting #C ≤ ℵ₀ with 𝔠 ≤ #C and ℵ₀ < 𝔠.",
+      "mathContext": "$\\mathrm{Perfect}\\,C$, $C \\ne \\varnothing \\Rightarrow \\mathfrak{c} \\le \\#C$, hence $C$ uncountable."
+    },
+    {
+      "id": "whole-space-and-real",
+      "title": "Whole-Space Form and the Real Line",
+      "startLine": 86,
+      "endLine": 95,
+      "summary": "continuum_le_mk_of_perfectSpace applies the core at C = univ (PerfectSpace.univ_perfect, mk_univ) to get 𝔠 ≤ #X for a nonempty complete metric space with no isolated points; uncountable_of_perfectSpace chains ℵ₀ < 𝔠 ≤ #X through aleph0_lt_mk_iff; continuum_le_mk_real instantiates at ℝ, whose PerfectSpace instance is inferred from connectedness, T1, and nontriviality.",
+      "mathContext": "$\\mathrm{PerfectSpace}\\,X$ complete metric $\\Rightarrow \\mathfrak{c} \\le \\#X$; at $X=\\mathbb{R}$, $\\mathfrak{c} \\le \\#\\mathbb{R}$."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry's Baire-category **uncountability of ℝ** to the quantitative cardinal bound **𝔠 ≤ #X**. This answers the parent (`baire-category-theorem-oq-01`) open question verbatim: *"Sharpen uncountability to a continuum-cardinality lower bound for perfect complete metric spaces."*

A nonempty **perfect subset** of a complete metric space — and in particular a nonempty complete metric space **with no isolated points** (a `PerfectSpace`) — has at least continuum-many points. The mechanism is the classical **Cantor scheme** (nested closed balls of vanishing diameter), packaged in Mathlib as `Perfect.exists_nat_bool_injection`, which embeds the Cantor space `ℕ → Bool` (of cardinality `𝔠 = 2^{ℵ₀}`) into the set.

## Results (`Proofs/BaireCategoryTheoremOQ01OQ03.lean`)

| Theorem | Statement |
|---|---|
| `mk_nat_arrow_bool` | `#(ℕ → Bool) = 𝔠` |
| `continuum_le_mk_of_perfect` | nonempty perfect `C ⊆ X` complete metric ⟹ `𝔠 ≤ #C` *(core)* |
| `not_countable_of_perfect` | such `C` is uncountable |
| `continuum_le_mk_of_perfectSpace` | nonempty complete metric `PerfectSpace X` ⟹ `𝔠 ≤ #X` |
| `uncountable_of_perfectSpace` | such `X` is `Uncountable` |
| `continuum_le_mk_real` | `𝔠 ≤ #ℝ` — recovers/sharpens parent's `real_uncountable` |

Mathlib supplies the Cantor-scheme injection and the `PerfectSpace` typeclass but **no cardinality corollary**; this entry adds it. The perfect-**set** form is reusable wherever a closed set without isolated points appears (Cantor sets, perfect kernels, supports of atomless measures). ℝ's `PerfectSpace` instance is purely formal (connected + T1 + nontrivial).

## Verification

- **6 theorems, 0 definitions, 95 lines, 0 sorries, no `native_decide`**
- `#print axioms` on all main theorems: only `[propext, Classical.choice, Quot.sound]` — **0 axioms** in the policy sense (no `sorryAx`, no `Lean.ofReduceBool`)
- Builds clean against Mathlib (v4.26.0)
- `status: verified`, `badge: original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)