### PR TITLE
research(carnot-theorem-oq-01-oq-01-oq-02): sharp cosine-product bound cos A cos B cos C ≤ 1/8 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -581,6 +581,7 @@ import Proofs.CantorsTheoremOQ03OQ02
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CarnotTheoremOQ01OQ01
+import Proofs.CarnotTheoremOQ01OQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ03
 import Proofs.CarnotTheoremOQ01OQ03OQ01

--- a/proofs/Proofs/CarnotTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CarnotTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,166 @@
+import Mathlib
+import Proofs.CarnotTheorem
+import Proofs.CarnotTheoremOQ01OQ02
+
+/-
+# Carnot's Theorem — the sharp cosine-product bound and the lower range of the squared cosine sum
+
+The sibling files pin down several extremal triangle trigonometric quantities:
+
+* `CarnotTheoremOQ01OQ01` — the cosine **sum** range `(1, 3/2]` and Euler's
+  inequality `r ≤ R/2`;
+* `CarnotTheoremOQ01OQ02` — the **squared** cosine sum identity
+  `cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C` and the acute/right/obtuse
+  trichotomy against the value `1`.
+
+What is missing there is the **sharp lower bound** of the squared cosine sum.
+The trichotomy compares it to `1`, but the genuine extremum — the smallest
+value `cos²A + cos²B + cos²C` can take over all triangles — is `3/4`, attained
+at the equilateral triangle. Equivalently, through the sibling identity, the
+**product** of the cosines is bounded sharply from above by `1/8`.
+
+This file proves:
+
+* `eight_cos_prod_identity` — for any reals with `A + B + C = π`,
+  `1 - 8 cos A cos B cos C = (2 cos C - cos (A - B))² + sin (A - B)²`;
+* `cos_prod_le_eighth`     — hence `cos A cos B cos C ≤ 1/8`;
+* `cos_sq_sum_ge_three_quarters` — hence `cos²A + cos²B + cos²C ≥ 3/4`;
+* `cos_prod_eq_eighth_iff` — equality `= 1/8` ⟺ the triangle is equilateral;
+* `cos_sq_sum_eq_three_quarters_iff` — equality `= 3/4` ⟺ equilateral.
+
+The whole argument rests on one sum-of-squares identity. Writing
+`cos A cos B = ½(cos (A - B) - cos C)` (from `cos A cos B = ½(cos(A-B)+cos(A+B))`
+and `cos(A+B) = -cos C` because `A + B = π - C`) turns
+
+  `1 - 8 cos A cos B cos C = 1 - 4 cos (A - B) cos C + 4 cos²C`,
+
+and completing the square against `cos²(A-B) + sin²(A-B) = 1` gives
+
+  `= (2 cos C - cos (A - B))² + sin²(A - B) ≥ 0`.
+
+The bound is therefore **sign-agnostic** — it holds for every real triple
+summing to `π`, never splitting on acute/obtuse. Positivity of the angles is
+needed only to identify the equality case as the equilateral triangle:
+`sin(A-B) = 0` forces `A = B`, and `2 cos C = cos (A - B) = 1` forces
+`C = π/3`.
+
+**No axioms, no sorries.**
+-/
+
+open Real
+
+namespace CarnotTheoremOQ01OQ01OQ02
+
+/-- **Core sum-of-squares identity.**  For any reals with `A + B + C = π`,
+`1 - 8 cos A cos B cos C = (2 cos C - cos (A - B))² + sin (A - B)²`.
+
+This single identity drives every bound in this file. It is purely algebraic in
+the three cosines once `A + B = π - C` is used to rewrite `cos (A + B)`; no
+positivity of the angles is assumed. -/
+theorem eight_cos_prod_identity (A B C : ℝ) (h : A + B + C = π) :
+    1 - 8 * Real.cos A * Real.cos B * Real.cos C
+      = (2 * Real.cos C - Real.cos (A - B)) ^ 2 + Real.sin (A - B) ^ 2 := by
+  -- `cos (A + B) = -cos C` from the angle-sum constraint.
+  have hAB : Real.cos (A + B) = - Real.cos C := by
+    rw [show A + B = π - C by linarith, Real.cos_pi_sub]
+  -- product-to-sum: `cos A cos B = ½ (cos (A - B) - cos C)`.
+  have e1 := Real.cos_sub A B
+  have e2 := Real.cos_add A B
+  have hprod : Real.cos A * Real.cos B = (Real.cos (A - B) - Real.cos C) / 2 := by
+    linarith [e1, e2, hAB]
+  -- pythagorean identity for the `(A - B)` argument.
+  have hpyth : Real.sin (A - B) ^ 2 = 1 - Real.cos (A - B) ^ 2 := by
+    have := Real.sin_sq_add_cos_sq (A - B); linarith
+  rw [hpyth]
+  linear_combination (-8 * Real.cos C) * hprod
+
+/-- **Sharp cosine-product bound.**  For any reals with `A + B + C = π` (in
+particular for every triangle), `cos A cos B cos C ≤ 1/8`.
+
+Immediate from `eight_cos_prod_identity`: the right-hand side is a sum of two
+squares, hence nonnegative, so `8 cos A cos B cos C ≤ 1`. The bound is sharp,
+attained by the equilateral triangle (`cos_prod_eq_eighth_iff`). -/
+theorem cos_prod_le_eighth (A B C : ℝ) (h : A + B + C = π) :
+    Real.cos A * Real.cos B * Real.cos C ≤ 1 / 8 := by
+  have hid := eight_cos_prod_identity A B C h
+  nlinarith [hid, sq_nonneg (2 * Real.cos C - Real.cos (A - B)),
+    sq_nonneg (Real.sin (A - B))]
+
+/-- **Sharp lower bound on the squared cosine sum.**  For any reals with
+`A + B + C = π`, `cos²A + cos²B + cos²C ≥ 3/4`.
+
+The sibling identity `cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C` combined
+with `cos A cos B cos C ≤ 1/8` gives the bound. It complements the sibling's
+trichotomy against `1`: the *smallest* the squared sum can be is `3/4` (at the
+equilateral triangle), while it ranges up towards `3` for degenerate triangles. -/
+theorem cos_sq_sum_ge_three_quarters (A B C : ℝ) (h : A + B + C = π) :
+    Real.cos A ^ 2 + Real.cos B ^ 2 + Real.cos C ^ 2 ≥ 3 / 4 := by
+  have hsq := CarnotTheoremOQ01OQ02.cos_sq_sum A B C h
+  have hp := cos_prod_le_eighth A B C h
+  linarith [hsq, hp]
+
+/-- **Equality case for the product bound.**  For a triangle
+(`A, B, C > 0`, `A + B + C = π`), `cos A cos B cos C = 1/8` if and only if the
+triangle is equilateral (`A = B = C = π/3`).
+
+Forward: equality forces the two squares in `eight_cos_prod_identity` to vanish,
+i.e. `sin (A - B) = 0` and `2 cos C = cos (A - B)`. With `|A - B| < π` the first
+gives `A = B`, so `cos (A - B) = 1` and `cos C = 1/2`; injectivity of cosine on
+`[0, π]` gives `C = π/3`, and `A + B + C = π` then forces `A = B = π/3`.
+Backward: `cos (π/3) = 1/2`. -/
+theorem cos_prod_eq_eighth_iff (A B C : ℝ) (hA : 0 < A) (hB : 0 < B) (hC : 0 < C)
+    (h : A + B + C = π) :
+    Real.cos A * Real.cos B * Real.cos C = 1 / 8 ↔
+      A = π / 3 ∧ B = π / 3 ∧ C = π / 3 := by
+  constructor
+  · intro heq
+    have hid := eight_cos_prod_identity A B C h
+    -- the two squares sum to zero, hence each is zero
+    have hsin0 : Real.sin (A - B) = 0 := by
+      have hsq : Real.sin (A - B) ^ 2 = 0 := by
+        nlinarith [hid, heq, sq_nonneg (2 * Real.cos C - Real.cos (A - B)),
+          sq_nonneg (Real.sin (A - B))]
+      exact pow_eq_zero_iff (by norm_num) |>.mp hsq
+    have hcos0 : 2 * Real.cos C - Real.cos (A - B) = 0 := by
+      have hsq : (2 * Real.cos C - Real.cos (A - B)) ^ 2 = 0 := by
+        nlinarith [hid, heq, sq_nonneg (2 * Real.cos C - Real.cos (A - B)),
+          sq_nonneg (Real.sin (A - B))]
+      exact pow_eq_zero_iff (by norm_num) |>.mp hsq
+    -- `sin (A - B) = 0` with `|A - B| < π` gives `A = B`
+    have hABeq : A = B := by
+      have hlt : -π < A - B := by linarith
+      have hgt : A - B < π := by linarith
+      have := (Real.sin_eq_zero_iff_of_lt_of_lt hlt hgt).mp hsin0
+      linarith
+    -- hence `cos (A - B) = 1` and `cos C = 1/2`
+    have hcosC : Real.cos C = 1 / 2 := by
+      have : Real.cos (A - B) = 1 := by
+        rw [show A - B = 0 by linarith, Real.cos_zero]
+      rw [this] at hcos0; linarith
+    -- injectivity of cosine on `[0, π]` gives `C = π/3`
+    have hCval : C = π / 3 := by
+      have hmem1 : C ∈ Set.Icc 0 π := ⟨by linarith, by linarith⟩
+      have hmem2 : π / 3 ∈ Set.Icc 0 π := ⟨by linarith [Real.pi_pos], by linarith [Real.pi_pos]⟩
+      have heqcos : Real.cos C = Real.cos (π / 3) := by rw [hcosC, Real.cos_pi_div_three]
+      exact Real.injOn_cos hmem1 hmem2 heqcos
+    refine ⟨?_, ?_, hCval⟩ <;> linarith
+  · rintro ⟨rfl, rfl, rfl⟩
+    rw [Real.cos_pi_div_three]; norm_num
+
+/-- **Equality case for the squared-sum lower bound.**  For a triangle,
+`cos²A + cos²B + cos²C = 3/4` if and only if the triangle is equilateral.
+
+Transported from `cos_prod_eq_eighth_iff` through the sibling identity
+`cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C`: the squared sum equals `3/4`
+exactly when the product equals `1/8`. -/
+theorem cos_sq_sum_eq_three_quarters_iff (A B C : ℝ) (hA : 0 < A) (hB : 0 < B)
+    (hC : 0 < C) (h : A + B + C = π) :
+    Real.cos A ^ 2 + Real.cos B ^ 2 + Real.cos C ^ 2 = 3 / 4 ↔
+      A = π / 3 ∧ B = π / 3 ∧ C = π / 3 := by
+  have hsq := CarnotTheoremOQ01OQ02.cos_sq_sum A B C h
+  rw [hsq]
+  rw [show (1 : ℝ) - 2 * (Real.cos A * Real.cos B * Real.cos C) = 3 / 4
+      ↔ Real.cos A * Real.cos B * Real.cos C = 1 / 8 by constructor <;> intro <;> linarith]
+  exact cos_prod_eq_eighth_iff A B C hA hB hC h
+
+end CarnotTheoremOQ01OQ01OQ02

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "carnot-theorem-oq-01-oq-01-oq-02",
+  "title": "Carnot's Theorem — the sharp cosine-product bound cos A cos B cos C ≤ 1/8",
+  "slug": "carnot-theorem-oq-01-oq-01-oq-02",
+  "description": "The sibling entries pin the linear cosine-sum range (1, 3/2] and classify the squared cosine sum against the threshold 1, but neither gives the sharp lower extremum of cos²A + cos²B + cos²C. That extremum is 3/4, attained at the equilateral triangle, equivalent through the squared identity to the sharp upper bound cos A cos B cos C ≤ 1/8. Everything follows from one sum-of-squares identity, 1 - 8 cos A cos B cos C = (2 cos C - cos(A - B))² + sin²(A - B), valid for any reals with A + B + C = π. The bound is sign-agnostic; positivity of the angles is used only to identify the equality case as the equilateral triangle. All results are axiom- and sorry-free.",
+  "meta": {
+    "author": "Classical triangle inequality (cos A cos B cos C ≤ 1/8); SOS formalization original to this entry",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carnot%27s_theorem_(inradius,_circumradius)",
+    "date": "1803",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CarnotTheoremOQ01OQ01OQ02.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "trigonometry",
+      "inequality",
+      "sum-of-squares",
+      "carnot-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "CarnotTheoremOQ01OQ02.cos_sq_sum",
+        "description": "Sibling rearranged identity cos²A + cos²B + cos²C = 1 - 2(cos A cos B cos C), converting the product bound into the sharp lower bound on the squared cosine sum",
+        "module": "Proofs.CarnotTheoremOQ01OQ02"
+      },
+      {
+        "theorem": "Real.cos_pi_sub",
+        "description": "cos(π - x) = -cos x, used via A + B = π - C to turn cos(A + B) into -cos C in the product-to-sum step",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_add",
+        "description": "cos(A + B) = cos A cos B - sin A sin B, half of the product-to-sum derivation of cos A cos B = ½(cos(A-B) - cos C)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_sub",
+        "description": "cos(A - B) = cos A cos B + sin A sin B, the other half of the product-to-sum derivation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "sin²x + cos²x = 1, used to complete the square against cos²(A-B) + sin²(A-B)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_eq_zero_iff_of_lt_of_lt",
+        "description": "For -π < x < π, sin x = 0 ↔ x = 0; applied to x = A - B to force A = B in the equality case",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.injOn_cos",
+        "description": "cos is injective on [0, π]; from cos C = 1/2 = cos(π/3) it gives C = π/3 in the equality case",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_pi_div_three",
+        "description": "cos(π/3) = 1/2, the equilateral cosine value closing both directions of the equality cases",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The sum-of-squares identity 1 - 8 cos A cos B cos C = (2 cos C - cos(A - B))² + sin²(A - B) for any reals with A + B + C = π, giving a one-line sign-agnostic proof of the product bound",
+      "The sharp upper bound cos A cos B cos C ≤ 1/8, valid for every real triple summing to π (no acute/obtuse split)",
+      "The sharp lower bound cos²A + cos²B + cos²C ≥ 3/4, the genuine extremum complementing the sibling trichotomy against 1",
+      "Both equality cases proved equivalent to the equilateral triangle: sin(A - B) = 0 forces A = B and 2 cos C = cos(A - B) = 1 forces C = π/3"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 166,
+    "assumptions": "0 axioms. 0 sorries. The bounds cos A cos B cos C ≤ 1/8 and cos²A + cos²B + cos²C ≥ 3/4 require only A + B + C = π (no positivity); the triangle conditions A, B, C > 0 are used only for the equality characterizations. Builds on the sibling file Proofs/CarnotTheoremOQ01OQ02.lean and the parent Proofs/CarnotTheorem.lean (both axiom-free). Verified locally with lake env lean against Mathlib v4.26.0 (Docker build host unresponsive this session); gated by the deployer build before merge.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "title": "Module header",
+      "startLine": 4,
+      "endLine": 63,
+      "description": "Docstring framing the missing sharp lower bound of the squared cosine sum and its equivalent product bound, the single sum-of-squares identity that drives the file, and why the bound is sign-agnostic while positivity is needed only for the equality cases.",
+      "summary": "Module header",
+      "id": "module-header"
+    },
+    {
+      "title": "Core sum-of-squares identity",
+      "startLine": 65,
+      "endLine": 90,
+      "description": "eight_cos_prod_identity: for A + B + C = π, 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B). Derived from cos(A+B) = -cos C (via A + B = π - C), the product-to-sum form cos A cos B = ½(cos(A-B) - cos C) by linarith on cos_add/cos_sub, and completing the square against the pythagorean identity by linear_combination.",
+      "summary": "The driving SOS identity",
+      "id": "sos-identity"
+    },
+    {
+      "title": "Sharp product bound",
+      "startLine": 92,
+      "endLine": 101,
+      "description": "cos_prod_le_eighth: cos A cos B cos C ≤ 1/8 for any reals with A + B + C = π. Immediate from the identity since the right-hand side is a sum of two squares; a single nlinarith with the two sq_nonneg hints.",
+      "summary": "cos A cos B cos C ≤ 1/8",
+      "id": "product-bound"
+    },
+    {
+      "title": "Sharp squared-sum lower bound",
+      "startLine": 103,
+      "endLine": 116,
+      "description": "cos_sq_sum_ge_three_quarters: cos²A + cos²B + cos²C ≥ 3/4. The sibling identity cos²A + cos²B + cos²C = 1 - 2(cos A cos B cos C) together with the product bound gives 1 - 2(1/8) = 3/4 as the sharp lower extremum.",
+      "summary": "cos²A + cos²B + cos²C ≥ 3/4",
+      "id": "sqsum-bound"
+    },
+    {
+      "title": "Equality case for the product bound",
+      "startLine": 118,
+      "endLine": 160,
+      "description": "cos_prod_eq_eighth_iff: for a triangle, cos A cos B cos C = 1/8 ⟺ equilateral. Equality forces both squares to vanish; sin(A-B) = 0 with |A-B| < π gives A = B (Real.sin_eq_zero_iff_of_lt_of_lt), then 2 cos C = cos(A-B) = 1 gives cos C = 1/2 and C = π/3 (Real.injOn_cos), and the angle sum forces A = B = π/3.",
+      "summary": "Product = 1/8 ⟺ equilateral",
+      "id": "product-equality"
+    },
+    {
+      "title": "Equality case for the squared-sum bound",
+      "startLine": 162,
+      "endLine": 166,
+      "description": "cos_sq_sum_eq_three_quarters_iff: for a triangle, cos²A + cos²B + cos²C = 3/4 ⟺ equilateral, transported from the product equality through the sibling identity by an arithmetic rewrite.",
+      "summary": "Squared sum = 3/4 ⟺ equilateral",
+      "id": "sqsum-equality"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Carnot's theorem on the inradius and circumradius has as its analytic core the angle identity cos A + cos B + cos C = 1 + r/R and the fundamental polynomial identity cos²A + cos²B + cos²C + 2 cos A cos B cos C = 1. The sibling entries extract the linear cosine-sum range (1, 3/2] and the acute/right/obtuse trichotomy of the squared sum against 1. What those leave open is the sharp lower extremum of the squared cosine sum — the smallest value it can take over all triangles. This entry supplies it: cos²A + cos²B + cos²C ≥ 3/4, with equality exactly at the equilateral triangle, equivalent to the classical inequality cos A cos B cos C ≤ 1/8.",
+    "problemStatement": "For a triangle with angles A, B, C > 0 and A + B + C = π, prove the sharp bound cos A cos B cos C ≤ 1/8 (equivalently cos²A + cos²B + cos²C ≥ 3/4) with equality if and only if the triangle is equilateral.",
+    "text": "The product of a triangle's angle cosines never exceeds 1/8, and its squared cosine sum never drops below 3/4 — both extremes hit only by the equilateral triangle.",
+    "proofStrategy": "Write the product-to-sum form cos A cos B = ½(cos(A-B) + cos(A+B)) and use A + B = π - C, so cos(A+B) = -cos C and cos A cos B = ½(cos(A-B) - cos C). Substituting and completing the square against cos²(A-B) + sin²(A-B) = 1 yields the single identity\n\n  1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B).\n\n1. **Product bound**: the right-hand side is a sum of two squares, hence ≥ 0, so cos A cos B cos C ≤ 1/8. This uses only A + B + C = π — no acute/obtuse case split.\n2. **Squared-sum bound**: the sibling identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C turns the product bound into cos²A + cos²B + cos²C ≥ 1 - 2(1/8) = 3/4.\n3. **Equality**: cos A cos B cos C = 1/8 makes the right-hand side zero, forcing both squares to vanish. sin(A-B) = 0 with |A-B| < π gives A = B; then cos(A-B) = 1 and 2 cos C = 1, so cos C = 1/2 and C = π/3 by injectivity of cosine on [0, π]; the angle sum then forces A = B = π/3.",
+    "keyInsights": [
+      "**One sum-of-squares identity does everything**: 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), so the bound cos A cos B cos C ≤ 1/8 is a single nonnegativity statement",
+      "**The bound is sign-agnostic**: it holds for every real triple summing to π, never splitting on whether the triangle is acute or obtuse — positivity of the angles enters only to pin the equality case",
+      "**The genuine lower extremum of the squared cosine sum is 3/4**: where the sibling entry compares cos²A + cos²B + cos²C only to the threshold 1, this entry gives its sharp minimum, attained at the equilateral triangle",
+      "**Equality is rigid**: vanishing of the two squares forces A = B (from sin(A-B) = 0) and C = π/3 (from 2 cos C = cos(A-B) = 1), i.e. the equilateral triangle"
+    ],
+    "prerequisites": [
+      "Real trigonometric functions cos, sin, the addition formulas, and the pythagorean identity",
+      "The sibling rearranged identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C",
+      "Injectivity of cosine on [0, π] and the zero set of sine on (-π, π)"
+    ],
+    "openQuestions": [
+      "Does the companion sharp bound sin A sin B sin C ≤ 3√3/8 (equivalently a sharp upper bound on the squared sine sum) admit the same one-identity sum-of-squares treatment?",
+      "Can the product bound be promoted to the full equilateral extremality statement for the elementary symmetric functions of the angle cosines, unifying the linear, quadratic, and cubic cases proved across these sibling entries?"
+    ]
+  },
+  "conclusion": {
+    "summary": "For a triangle the product of the angle cosines satisfies cos A cos B cos C ≤ 1/8 and the squared cosine sum satisfies cos²A + cos²B + cos²C ≥ 3/4, each with equality exactly at the equilateral triangle. The proof rests on one sum-of-squares identity, 1 - 8 cos A cos B cos C = (2 cos C - cos(A-B))² + sin²(A-B), which is sign-agnostic; the equality case is identified using only the positivity of the angles. All results are axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry supplies the sharp lower extremum of the squared cosine sum that the sibling trichotomy leaves open, exhibiting the cubic symmetric form cos A cos B cos C as the analytic partner of the linear and quadratic forms already formalized. Together the three follow-ups bound the elementary symmetric functions of a triangle's angle cosines, each extremized by the equilateral triangle.",
+    "openQuestions": [
+      "A one-identity sum-of-squares proof of the companion product-of-sines bound sin A sin B sin C ≤ 3√3/8?",
+      "A unified equilateral-extremality statement for all elementary symmetric functions of the angle cosines?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "carnot-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent entry pins the cosine-sum range (1, 3/2] and Euler's inequality; this follow-up adds the sharp product bound and the sharp lower bound of the squared cosine sum."
+    },
+    {
+      "targetId": "carnot-theorem-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "The squared-sum sibling supplies the identity cos²A + cos²B + cos²C = 1 - 2 cos A cos B cos C used here to convert the product bound into the sharp lower bound 3/4, and classifies the squared sum against 1 where this entry gives its minimum."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CarnotTheorem",
+      "Proofs.CarnotTheoremOQ01OQ02"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CarnotTheoremOQ01OQ01OQ02",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CarnotTheoremOQ01OQ01OQ02.lean"
+  }
+}


### PR DESCRIPTION
## Summary

A follow-up to **carnot-theorem-oq-01-oq-01** (cosine-sum range `(1, 3/2]` + Euler's inequality). The Carnot sibling family covers the linear cosine sum, the squared cosine sum's acute/right/obtuse trichotomy against `1`, the sine sum, and the perimeter — but **not** the sharp *lower extremum* of the squared cosine sum. This entry supplies it:

- **`cos A · cos B · cos C ≤ 1/8`** (sharp upper bound), and equivalently
- **`cos²A + cos²B + cos²C ≥ 3/4`** (sharp lower bound),

each attained **iff** the triangle is equilateral.

## Method

Everything rests on a single **sign-agnostic sum-of-squares identity**, valid for *any* reals with `A + B + C = π`:

```
1 - 8 cos A cos B cos C = (2 cos C - cos(A - B))² + sin²(A - B)
```

obtained from `cos A cos B = ½(cos(A-B) - cos C)` (using `cos(A+B) = -cos C`) and completing the square against `cos²(A-B) + sin²(A-B) = 1`. Nonnegativity of the RHS gives the product bound with **no acute/obtuse case split**; positivity of the angles is used only to pin the equality case (`sin(A-B)=0 ⟹ A=B`, `2cos C = 1 ⟹ C = π/3`).

## Theorems (5, 0 def, 166 lines)

| Theorem | Statement |
|---|---|
| `eight_cos_prod_identity` | the driving SOS identity (A+B+C=π) |
| `cos_prod_le_eighth` | `cos A cos B cos C ≤ 1/8` |
| `cos_sq_sum_ge_three_quarters` | `cos²A + cos²B + cos²C ≥ 3/4` |
| `cos_prod_eq_eighth_iff` | product `= 1/8` ⟺ equilateral |
| `cos_sq_sum_eq_three_quarters_iff` | squared sum `= 3/4` ⟺ equilateral |

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on all 5 theorems reports only `[propext, Classical.choice, Quot.sound]`.
- Type-checked with `lake env lean` against the pinned **Mathlib v4.26.0** (Docker build host unresponsive this session; gated by the deployer build before merge).
- Reuses the sibling identity `CarnotTheoremOQ01OQ02.cos_sq_sum` and standard Mathlib trig lemmas only.

Status: `verified` · badge `original` · axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)