### PR TITLE
research(gram-linear-independence-iff-oq-01-oq-03): k-dimensional content √(det gram) = ∏ Gram–Schmidt heights

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3011,6 +3011,7 @@ import Proofs.GramLinearIndependenceOQ01
 import Proofs.GramLinearIndependenceOQ01OQ01
 import Proofs.GramLinearIndependenceOQ01OQ01OQ02OQ01
 import Proofs.GramLinearIndependenceOQ01OQ02
+import Proofs.GramLinearIndependenceOQ01OQ03
 import Proofs.GraphCore
 import Proofs.GreensTheorem
 import Proofs.GreensTheoremOQ01

--- a/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,228 @@
+/-
+# Erdős Problem #396 — OQ-04 → OQ-01 → OQ-01 → OQ-01 → OQ-02: the sharp central-binomial growth law `C(2n,n) ∼ 4ⁿ/√(πn)`
+
+The parent `Erdos396OQ04OQ01OQ01OQ01` telescopes the Catalan recurrence into a closed
+product and asks, as its second open question, whether the same recurrence yields the
+**central-binomial telescoping product** `C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1)` *and hence the
+matching growth law* `C(2n,n) ∼ 4ⁿ/√(πn)`.
+
+The telescoping product itself is already established (sibling entry
+`Erdos396OQ04OQ01OQ01OQ02OQ02OQ01`, "central binomial coefficient as a telescoping Wallis
+product"), which deliberately stops at the *elementary* bound `C(2n,n) < 4ⁿ` and uses **no
+Stirling estimate**. This entry supplies the remaining, genuinely analytic half — the
+**sharp asymptotic constant** — which is exactly the ingredient that needs Stirling's
+formula:
+
+* **`centralBinom_isEquivalent`** : `(C(2n,n) : ℝ) ~[atTop] 4ⁿ/√(πn)`,
+* **`centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one`** : `C(2n,n)·√(πn)/4ⁿ → 1`.
+
+The derivation is pure `Asymptotics.IsEquivalent` algebra on Mathlib's Stirling equivalence
+`Stirling.factorial_isEquivalent_stirling` (`n! ~ √(2nπ)·(n/e)ⁿ`): writing
+`C(2n,n) = (2n)!/(n!)²`, substituting Stirling into numerator and denominator, the `(n/e)`
+powers contribute `4ⁿ`, `√(4nπ)/(2nπ)` collapses to `1/√(πn)`, and the Stirling constants
+cancel to `1`.
+
+Two consequences:
+
+* **`succ_mul_catalan_eq_centralBinom`** : `C(2n,n) = (n+1)·catalan n` — the bridge to the
+  parent's Catalan product; together with the asymptotic it yields the **Catalan growth law**
+  the parent's docstring states but never proves,
+* **`catalan_isEquivalent`** : `(catalan n : ℝ) ~[atTop] 4ⁿ/(n·√(πn))` (i.e.
+  `catalan n ∼ 4ⁿ/(√π · n^{3/2})`), with limit form
+  **`catalan_mul_div_four_pow_tendsto_one`**.
+
+Finally the asymptotic upper rate is complemented by the elementary *effective* lower bound
+
+* **`four_pow_div_two_mul_le_centralBinom`** : `4ⁿ/(2n) ≤ C(2n,n)` (`n ≥ 1`),
+
+from Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom`, valid for every `n` (not just
+asymptotically), so `4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ`.
+
+Reference: https://erdosproblems.com/396
+-/
+
+import Mathlib
+
+open Filter Topology Real Nat Asymptotics
+
+namespace Erdos396OQ04OQ01OQ01OQ01OQ02
+
+/-- The Stirling approximation function for `n!`: `√(2nπ)·(n/e)ⁿ`. By Mathlib's
+    `Stirling.factorial_isEquivalent_stirling`, `n! ~[atTop] stirlingFn n`. -/
+noncomputable def stirlingFn (n : ℕ) : ℝ := Real.sqrt (2 * n * π) * (n / Real.exp 1) ^ n
+
+/- ## The central binomial coefficient as a quotient of factorials -/
+
+/-- `(C(2n,n) : ℝ) = (2n)! / (n! · n!)`. From `Nat.choose_mul_factorial_mul_factorial`
+    with `2n - n = n`. -/
+theorem centralBinom_eq_factorial_div (n : ℕ) :
+    (centralBinom n : ℝ) = (2 * n)! / (n ! * n !) := by
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  have h2 : 2 * n - n = n := by omega
+  rw [eq_div_iff (by positivity)]
+  have := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+  rw [h2] at this
+  push_cast [← this]; ring
+
+/- ## The key pointwise simplification of the Stirling quotient -/
+
+/-- For `n ≥ 1`, the Stirling quotient that governs `C(2n,n) = (2n)!/(n!)²` simplifies in
+    closed form: `stirlingFn (2n) / (stirlingFn n)² = 4ⁿ / √(πn)`. The `(n/e)` powers give
+    `4ⁿ`, `√(4nπ)/(2nπ)` collapses to `1/√(πn)`. -/
+theorem stirlingFn_quotient (n : ℕ) (hn : 1 ≤ n) :
+    stirlingFn (2 * n) / (stirlingFn n * stirlingFn n) = 4 ^ n / Real.sqrt (π * n) := by
+  have hnpos : (0 : ℝ) < n := by positivity
+  have he : Real.exp 1 ≠ 0 := Real.exp_ne_zero 1
+  have hsq : (Real.sqrt (2 * n * π)) ^ 2 = 2 * n * π := by rw [Real.sq_sqrt]; positivity
+  unfold stirlingFn
+  have hcast : ((2 * n : ℕ) : ℝ) = 2 * (n : ℝ) := by push_cast; ring
+  rw [hcast]
+  have h4 : Real.sqrt (2 * (2 * (n:ℝ)) * π) = 2 * Real.sqrt (n * π) := by
+    rw [show 2 * (2 * (n:ℝ)) * π = 4 * (n * π) by ring, show (4:ℝ) = 2 ^ 2 by norm_num,
+        Real.sqrt_mul (by positivity), Real.sqrt_sq (by norm_num)]
+  rw [h4]
+  have hpow : ((2 * (n:ℝ)) / Real.exp 1) ^ (2 * n)
+      = 4 ^ n * ((n:ℝ) / Real.exp 1) ^ (2 * n) := by
+    rw [show (2 * (n:ℝ)) / Real.exp 1 = 2 * ((n:ℝ) / Real.exp 1) by ring, mul_pow,
+        pow_mul, show ((2:ℝ)) ^ 2 = 4 by norm_num]
+  rw [hpow,
+      show (Real.sqrt (2 * (n:ℝ) * π) * ((n:ℝ) / Real.exp 1) ^ n)
+          * (Real.sqrt (2 * (n:ℝ) * π) * ((n:ℝ) / Real.exp 1) ^ n)
+        = (Real.sqrt (2 * (n:ℝ) * π)) ^ 2 * ((n:ℝ) / Real.exp 1) ^ (2 * n) by ring, hsq,
+      show Real.sqrt (π * n) = Real.sqrt (n * π) by rw [mul_comm]]
+  have hgne : ((n:ℝ) / Real.exp 1) ^ (2 * n) ≠ 0 := by positivity
+  have hnpisq : Real.sqrt (n * π) ^ 2 = n * π := by rw [Real.sq_sqrt]; positivity
+  field_simp
+  nlinarith [hnpisq, Real.sqrt_nonneg ((n:ℝ) * π)]
+
+/- ## The sharp central-binomial asymptotic -/
+
+/-- **The sharp growth law.** `(C(2n,n) : ℝ) ~[atTop] 4ⁿ/√(πn)`.
+
+    Writing `C(2n,n) = (2n)!/(n!)²` and substituting Mathlib's Stirling equivalence
+    `Stirling.factorial_isEquivalent_stirling` into numerator and denominator via
+    `IsEquivalent.comp_tendsto`, `IsEquivalent.mul` and `IsEquivalent.div`, then collapsing
+    the Stirling quotient by `stirlingFn_quotient`. This is the analytic half of the open
+    question that the elementary telescoping-product sibling left open. -/
+theorem centralBinom_isEquivalent :
+    (fun n : ℕ => (centralBinom n : ℝ)) ~[atTop] (fun n : ℕ => 4 ^ n / Real.sqrt (π * n)) := by
+  have hstir := Stirling.factorial_isEquivalent_stirling
+  have hφ : Tendsto (fun n : ℕ => 2 * n) atTop atTop :=
+    tendsto_atTop_mono (fun n => by simp only [id_eq]; omega) tendsto_id
+  have h1 : (fun n : ℕ => ((2 * n)! : ℝ)) ~[atTop] (fun n : ℕ => stirlingFn (2 * n)) :=
+    hstir.comp_tendsto hφ
+  have h2 : (fun n : ℕ => (n ! : ℝ) * (n ! : ℝ)) ~[atTop]
+      (fun n : ℕ => stirlingFn n * stirlingFn n) := hstir.mul hstir
+  have hdiv : (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ)))
+      ~[atTop] (fun n : ℕ => stirlingFn (2 * n) / (stirlingFn n * stirlingFn n)) := h1.div h2
+  have hcbL : (fun n : ℕ => (centralBinom n : ℝ))
+      = (fun n : ℕ => ((2 * n)! : ℝ) / ((n ! : ℝ) * (n ! : ℝ))) := by
+    ext n; exact centralBinom_eq_factorial_div n
+  have hRHS : (fun n : ℕ => stirlingFn (2 * n) / (stirlingFn n * stirlingFn n))
+      =ᶠ[atTop] (fun n : ℕ => 4 ^ n / Real.sqrt (π * n)) := by
+    filter_upwards [eventually_ge_atTop 1] with n hn using stirlingFn_quotient n hn
+  rw [hcbL]
+  exact hdiv.trans hRHS.isEquivalent
+
+/-- **Limit form of the growth law.** `C(2n,n)·√(πn)/4ⁿ → 1`. -/
+theorem centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one :
+    Tendsto (fun n : ℕ => (centralBinom n : ℝ) * Real.sqrt (π * n) / 4 ^ n) atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, (4:ℝ) ^ n / Real.sqrt (π * n) ≠ 0 := by
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    have : (0:ℝ) < n := by positivity
+    positivity
+  have key := (Asymptotics.isEquivalent_iff_tendsto_one hz).mp centralBinom_isEquivalent
+  refine key.congr' ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div_eq_mul_div]
+
+/- ## Bridge to the parent's Catalan product, and the Catalan growth law -/
+
+/-- **Catalan bridge.** `C(2n,n) = (n+1)·catalan n`, from `catalan_eq_centralBinom_div` and
+    `Nat.succ_dvd_centralBinom`. This identifies the central-binomial product of the sibling
+    entry with the parent's Catalan product. -/
+theorem succ_mul_catalan_eq_centralBinom (n : ℕ) :
+    (n + 1) * catalan n = centralBinom n := by
+  rw [catalan_eq_centralBinom_div, Nat.mul_div_cancel' (Nat.succ_dvd_centralBinom n)]
+
+/-- `(n+1) ~[atTop] n`: the prefactor relating the Catalan and central-binomial products is
+    asymptotically negligible. -/
+theorem nat_succ_isEquivalent :
+    (fun n : ℕ => ((n : ℝ) + 1)) ~[atTop] (fun n : ℕ => (n : ℝ)) := by
+  refine (Asymptotics.isEquivalent_iff_tendsto_one ?_).2 ?_
+  · filter_upwards [eventually_ge_atTop 1] with n hn; positivity
+  · have h0 : Tendsto (fun n : ℕ => (1:ℝ) / (n:ℝ)) atTop (𝓝 0) :=
+      tendsto_one_div_atTop_nhds_zero_nat
+    have hsum : Tendsto (fun n : ℕ => 1 + (1:ℝ) / (n:ℝ)) atTop (𝓝 (1 + 0)) :=
+      tendsto_const_nhds.add h0
+    rw [add_zero] at hsum
+    refine hsum.congr' ?_
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    simp only [Pi.div_apply]
+    have : (n:ℝ) ≠ 0 := by positivity
+    field_simp
+
+/-- **The Catalan growth law** the parent's docstring states but never proves:
+    `(catalan n : ℝ) ~[atTop] 4ⁿ/(n·√(πn))`, i.e. `catalan n ∼ 4ⁿ/(√π · n^{3/2})`.
+    Immediate from `catalan n = C(2n,n)/(n+1)`, the central-binomial asymptotic, and
+    `(n+1) ~ n`. -/
+theorem catalan_isEquivalent :
+    (fun n : ℕ => (catalan n : ℝ)) ~[atTop]
+      (fun n : ℕ => 4 ^ n / ((n : ℝ) * Real.sqrt (π * n))) := by
+  have hcat : (fun n : ℕ => (catalan n : ℝ))
+      = (fun n : ℕ => (centralBinom n : ℝ) / ((n : ℝ) + 1)) := by
+    ext n
+    have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+    rw [eq_div_iff hne]
+    have : ((n : ℝ) + 1) * (catalan n : ℝ) = (centralBinom n : ℝ) := by
+      exact_mod_cast succ_mul_catalan_eq_centralBinom n
+    linarith [this]
+  rw [hcat]
+  have hdiv := centralBinom_isEquivalent.div nat_succ_isEquivalent
+  refine hdiv.trans ?_
+  refine Filter.EventuallyEq.isEquivalent ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div, mul_comm]
+
+/-- **Limit form of the Catalan growth law.** `catalan n · (n·√(πn)) / 4ⁿ → 1`. -/
+theorem catalan_mul_div_four_pow_tendsto_one :
+    Tendsto (fun n : ℕ => (catalan n : ℝ) * ((n : ℝ) * Real.sqrt (π * n)) / 4 ^ n)
+      atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, (4:ℝ) ^ n / ((n : ℝ) * Real.sqrt (π * n)) ≠ 0 := by
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    have : (0:ℝ) < n := by positivity
+    positivity
+  have key := (Asymptotics.isEquivalent_iff_tendsto_one hz).mp catalan_isEquivalent
+  refine key.congr' ?_
+  filter_upwards with n
+  simp only [Pi.div_apply]
+  rw [div_div_eq_mul_div]
+
+/- ## Effective elementary lower bound (valid for every `n`, not just asymptotically) -/
+
+/-- **Effective lower bound.** `4ⁿ/(2n) ≤ C(2n,n)` for `n ≥ 1`, from Mathlib's
+    `Nat.four_pow_le_two_mul_self_mul_centralBinom`. Together with the asymptotic and the
+    sibling's `C(2n,n) < 4ⁿ`, this brackets `4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ`. -/
+theorem four_pow_div_two_mul_le_centralBinom (n : ℕ) (hn : 1 ≤ n) :
+    (4 : ℝ) ^ n / (2 * n) ≤ (centralBinom n : ℝ) := by
+  have h := Nat.four_pow_le_two_mul_self_mul_centralBinom n hn
+  have hcast : (4 : ℝ) ^ n ≤ 2 * n * centralBinom n := by exact_mod_cast h
+  rw [div_le_iff₀ (by positivity : (0:ℝ) < 2 * n)]
+  calc (4 : ℝ) ^ n ≤ 2 * n * centralBinom n := hcast
+    _ = (centralBinom n : ℝ) * (2 * n) := by ring
+
+/- ## Sanity checks -/
+
+/-- `C(6,3) = 20`. -/
+example : centralBinom 3 = 20 := by decide
+
+/-- The Catalan bridge at `n = 3`: `C(6,3) = 4 · catalan 3 = 4 · 5 = 20`. -/
+example : centralBinom 3 = 4 * catalan 3 := by
+  have h := succ_mul_catalan_eq_centralBinom 3; omega
+
+/-- The factorial quotient at `n = 3`: `C(6,3) = 6!/(3!·3!) = 720/36 = 20`. -/
+example : (centralBinom 3 : ℝ) = (2 * 3)! / (3 ! * 3 !) := centralBinom_eq_factorial_div 3
+
+end Erdos396OQ04OQ01OQ01OQ01OQ02

--- a/proofs/Proofs/GramLinearIndependenceOQ01OQ03.lean
+++ b/proofs/Proofs/GramLinearIndependenceOQ01OQ03.lean
@@ -1,0 +1,209 @@
+import Mathlib
+
+/-!
+# The `k`-dimensional content: `√(det gram v)` as a product of Gram–Schmidt heights
+
+For a finite family of vectors `v : Fin n → F` in a real inner product space `F`, the
+grandparent entry `gram-linear-independence-iff-oq-01` proved the **Gramian criterion**
+(`det (gram ℝ v) ≥ 0`, with equality iff `v` is dependent), and the sibling entry
+`…-oq-01-oq-02` identified `√(det gram v)` with the parallelepiped volume in the **square**
+case, where the vectors *fill* the ambient space (`finrank ℝ F = n`).
+
+This entry removes the `finrank = n` hypothesis, supplying the genuinely
+`k`-**dimensional** content of `n` vectors sitting inside a possibly larger space.  The key
+identity is the Gram–Schmidt factorization of the Gramian:
+
+> **`det_gram_eq_prod_gramSchmidt_norm_sq`** :
+> `det (gram ℝ v) = ∏ i, ‖gramSchmidt ℝ v i‖²`.
+
+Writing `gᵢ = gramSchmidt ℝ v i` for the orthogonalized family, the number `‖gᵢ‖` is the
+*height* of `vᵢ` above the span of the earlier vectors (the perpendicular distance), so the
+content
+
+> **`content_eq_prod_gramSchmidt_norm`** :
+> `√(det gram v) = ∏ i, ‖gramSchmidt ℝ v i‖`
+
+is exactly the iterated *base × height* volume of the parallelepiped — valid in any
+dimension, no spanning hypothesis required.  This is the orthogonalization / exterior-power
+picture of the Gramian that the parent's third open question asks for.
+
+## Proof
+
+Let `C` be the lower-unitriangular *change-of-basis* matrix expressing each `vᵢ` in the
+orthogonal family `g` (`vᵢ = ∑ⱼ Cᵢⱼ gⱼ`, read off from `gramSchmidt_def''`), and let
+`D = diagonal (‖gⱼ‖²)`.  Orthogonality of `g` gives the matrix factorization
+`gram ℝ v = C · D · Cᵀ`, whence
+`det (gram ℝ v) = (det C)² · det D = 1² · ∏ ‖gⱼ‖²`, since `det C = 1` (unitriangular).
+
+## Main results
+
+* `det_gram_eq_prod_gramSchmidt_norm_sq` — the Gram–Schmidt factorization of the Gramian.
+* `content_eq_prod_gramSchmidt_norm` — content `= ∏ heights`.
+* `content_nonneg`, `content_sq` — basic shape of the content.
+* `content_pos_iff_linearIndependent`, `content_eq_zero_iff` — geometric independence test.
+
+All results hold with **no** assumption relating `n` to `finrank ℝ F`, and are fully
+machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace GramLinearIndependenceOQ01OQ03
+
+open InnerProductSpace Matrix Finset
+open scoped RealInnerProductSpace
+
+noncomputable section
+
+variable {n : ℕ} {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+/-- The coefficient of `gⱼ = gramSchmidt ℝ v j` in the expansion of `vᵢ`.  On the diagonal
+it is `1`, strictly below the diagonal (`j < i`) it is the Gram–Schmidt projection
+coefficient, and strictly above the diagonal it vanishes. -/
+def coeff (v : Fin n → F) (i j : Fin n) : ℝ :=
+  if j < i then ⟪gramSchmidt ℝ v j, v i⟫_ℝ / ‖gramSchmidt ℝ v j‖ ^ 2
+  else if j = i then 1 else 0
+
+/-- The lower-unitriangular change-of-basis matrix `C` with `vᵢ = ∑ⱼ Cᵢⱼ gⱼ`. -/
+def Cmat (v : Fin n → F) : Matrix (Fin n) (Fin n) ℝ := Matrix.of (coeff v)
+
+/-- The diagonal matrix `D = diagonal (‖gⱼ‖²)` of squared Gram–Schmidt norms. -/
+def Dmat (v : Fin n → F) : Matrix (Fin n) (Fin n) ℝ :=
+  Matrix.diagonal (fun j => ‖gramSchmidt ℝ v j‖ ^ 2)
+
+@[simp] theorem coeff_self (v : Fin n → F) (i : Fin n) : coeff v i i = 1 := by
+  simp [coeff]
+
+theorem coeff_eq_zero_of_lt (v : Fin n → F) {i j : Fin n} (hij : i < j) :
+    coeff v i j = 0 := by
+  unfold coeff
+  rw [if_neg (not_lt.2 hij.le), if_neg hij.ne']
+
+/-- Each input vector is the prescribed combination of the orthogonalized family. -/
+theorem v_eq_sum_coeff (v : Fin n → F) (i : Fin n) :
+    v i = ∑ j, coeff v i j • gramSchmidt ℝ v j := by
+  -- expand the left-hand `v i` via the Gram–Schmidt projection formula
+  conv_lhs => rw [gramSchmidt_def'' ℝ v i]
+  -- restrict the universal sum to `Iic i`, the support of `coeff v i ·`
+  rw [← Finset.sum_subset (Finset.subset_univ (Iic i))]
+  · rw [← Iio_insert, Finset.sum_insert (by simp), coeff_self, one_smul]
+    congr 1
+    refine Finset.sum_congr rfl fun j hj => ?_
+    have hji : j < i := Finset.mem_Iio.1 hj
+    simp only [coeff, if_pos hji, RCLike.ofReal_real_eq_id, id_eq]
+  · intro j _ hj
+    have hlt : i < j := by
+      by_contra hle
+      exact hj (Finset.mem_Iic.2 (not_lt.1 hle))
+    rw [coeff_eq_zero_of_lt v hlt, zero_smul]
+
+/-- The Gram-matrix factorization `gram ℝ v = C · D · Cᵀ`. -/
+theorem gram_eq_cmat_dmat (v : Fin n → F) :
+    gram ℝ v = Cmat v * Dmat v * (Cmat v)ᵀ := by
+  ext i k
+  -- the matrix product `(C · D · Cᵀ) i k` as an explicit sum
+  have hrhs : (Cmat v * Dmat v * (Cmat v)ᵀ) i k
+      = ∑ j, coeff v i j * coeff v k j * ‖gramSchmidt ℝ v j‖ ^ 2 := by
+    rw [Matrix.mul_apply]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    simp only [Cmat, Dmat, Matrix.mul_diagonal, Matrix.transpose_apply, Matrix.of_apply]
+    ring
+  rw [gram_apply, hrhs]
+  conv_lhs => rw [v_eq_sum_coeff v i, v_eq_sum_coeff v k]
+  rw [sum_inner]
+  -- expand each outer term and collapse the inner sum by orthogonality
+  refine Finset.sum_congr rfl fun j _ => ?_
+  rw [real_inner_smul_left, inner_sum, Finset.mul_sum, Finset.sum_eq_single j]
+  · rw [real_inner_smul_right, real_inner_self_eq_norm_sq]; ring
+  · intro l _ hl
+    rw [real_inner_smul_right, gramSchmidt_orthogonal ℝ v (Ne.symm hl), mul_zero, mul_zero]
+  · intro h; exact absurd (Finset.mem_univ j) h
+
+theorem det_Cmat (v : Fin n → F) : (Cmat v).det = 1 := by
+  have htri : (Cmat v).BlockTriangular OrderDual.toDual := by
+    intro i j hij
+    rw [OrderDual.toDual_lt_toDual] at hij
+    simp only [Cmat, Matrix.of_apply]
+    exact coeff_eq_zero_of_lt v hij
+  rw [Matrix.det_of_lowerTriangular (Cmat v) htri]
+  refine Finset.prod_eq_one fun i _ => ?_
+  simp [Cmat]
+
+theorem det_Dmat (v : Fin n → F) :
+    (Dmat v).det = ∏ i, ‖gramSchmidt ℝ v i‖ ^ 2 := by
+  rw [Dmat, Matrix.det_diagonal]
+
+/-- **Gram–Schmidt factorization of the Gramian.**  The Gram determinant of any finite
+family of vectors equals the product of the squared norms of its Gram–Schmidt
+orthogonalization — the squared `k`-dimensional content, with no spanning hypothesis. -/
+theorem det_gram_eq_prod_gramSchmidt_norm_sq (v : Fin n → F) :
+    (gram ℝ v).det = ∏ i, ‖gramSchmidt ℝ v i‖ ^ 2 := by
+  rw [gram_eq_cmat_dmat, Matrix.det_mul, Matrix.det_mul, Matrix.det_transpose,
+    det_Cmat, det_Dmat, one_mul, mul_one]
+
+/-! ## The Gramian criterion (re-derived locally from Mathlib)
+
+These two facts are the grandparent entry `gram-linear-independence-iff-oq-01`, reproved
+inline here so the file depends only on Mathlib. -/
+
+/-- The Gramian is always nonnegative (determinant of a positive semidefinite matrix). -/
+theorem gram_det_nonneg (v : Fin n → F) : 0 ≤ (gram ℝ v).det :=
+  (Matrix.posSemidef_gram ℝ v).det_nonneg
+
+/-- A family is linearly independent iff its Gramian is strictly positive. -/
+theorem linearIndependent_iff_gram_det_pos (v : Fin n → F) :
+    LinearIndependent ℝ v ↔ 0 < (gram ℝ v).det := by
+  constructor
+  · intro h
+    exact ((Matrix.posDef_gram_iff_linearIndependent (v := v)).mpr h).det_pos
+  · intro h
+    by_contra hni
+    obtain ⟨g, hg, i, hi⟩ := Fintype.not_linearIndependent_iff.mp hni
+    have hker : gram ℝ v *ᵥ g = 0 := by
+      funext j
+      have key : (gram ℝ v *ᵥ g) j = ⟪v j, ∑ l, g l • v l⟫_ℝ := by
+        simp only [mulVec, dotProduct, Matrix.gram_apply, inner_sum, inner_smul_right]
+        exact Finset.sum_congr rfl fun l _ => mul_comm _ _
+      rw [Pi.zero_apply, key, hg, inner_zero_right]
+    have hdet0 : (gram ℝ v).det = 0 := by
+      rw [← Matrix.exists_mulVec_eq_zero_iff]
+      exact ⟨g, fun hgz => hi (by rw [hgz]; rfl), hker⟩
+    rw [hdet0] at h
+    exact lt_irrefl 0 h
+
+/-! ## The content as a product of heights -/
+
+/-- The `k`-dimensional **content** (volume) of the parallelepiped spanned by `v`, defined
+as `√(det gram v)`. -/
+def content (v : Fin n → F) : ℝ := Real.sqrt (gram ℝ v).det
+
+theorem content_nonneg (v : Fin n → F) : 0 ≤ content v := Real.sqrt_nonneg _
+
+theorem content_sq (v : Fin n → F) : content v ^ 2 = (gram ℝ v).det := by
+  rw [content, Real.sq_sqrt (gram_det_nonneg v)]
+
+/-- **Content as a product of Gram–Schmidt heights.**  `√(det gram v) = ∏ ‖gᵢ‖`, the
+iterated base × height volume. -/
+theorem content_eq_prod_gramSchmidt_norm (v : Fin n → F) :
+    content v = ∏ i, ‖gramSchmidt ℝ v i‖ := by
+  rw [content, det_gram_eq_prod_gramSchmidt_norm_sq, Finset.prod_pow]
+  exact Real.sqrt_sq (Finset.prod_nonneg fun i _ => norm_nonneg _)
+
+/-- The content is strictly positive exactly when the family is linearly independent. -/
+theorem content_pos_iff_linearIndependent (v : Fin n → F) :
+    0 < content v ↔ LinearIndependent ℝ v := by
+  rw [content, Real.sqrt_pos]
+  exact (linearIndependent_iff_gram_det_pos v).symm
+
+/-- The content vanishes exactly when the family is linearly dependent. -/
+theorem content_eq_zero_iff (v : Fin n → F) :
+    content v = 0 ↔ ¬ LinearIndependent ℝ v := by
+  rw [← content_pos_iff_linearIndependent]
+  constructor
+  · intro h; rw [h]; exact lt_irrefl 0
+  · intro h
+    rcases (content_nonneg v).lt_or_eq with hlt | heq
+    · exact absurd hlt h
+    · exact heq.symm
+
+end
+
+end GramLinearIndependenceOQ01OQ03

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-factquot",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "The central binomial coefficient as a quotient of factorials",
+    "content": "`centralBinom_eq_factorial_div` proves $(C(2n,n):\\mathbb{R}) = (2n)!/(n!\\cdot n!)$ from `Nat.choose_mul_factorial_mul_factorial` with $2n-n=n$. This puts $C(2n,n)$ in the quotient-of-factorials form that lets Stirling's equivalence act on numerator and denominator independently.",
+    "mathContext": "$\\displaystyle C(2n,n) = \\frac{(2n)!}{(n!)^2}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-stirlingquot",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 100
+    },
+    "type": "key-step",
+    "title": "Closed-form simplification of the Stirling quotient",
+    "content": "`stirlingFn_quotient` proves the pointwise identity $\\mathrm{stirlingFn}(2n)/(\\mathrm{stirlingFn}\\,n)^2 = 4^n/\\sqrt{\\pi n}$ for $n \\ge 1$, where $\\mathrm{stirlingFn}\\,n = \\sqrt{2n\\pi}(n/e)^n$. The $(n/e)$ powers contribute $4^n$ (since $(2n/e)^{2n} = 4^n(n/e)^{2n}$), $\\sqrt{2\\cdot 2n\\cdot\\pi} = 2\\sqrt{n\\pi}$ and $(\\sqrt{2n\\pi})^2 = 2n\\pi$ collapse $\\sqrt{4n\\pi}/(2n\\pi)$ to $1/\\sqrt{\\pi n}$. This is the only hand computation in the entry; everything else is `IsEquivalent` algebra.",
+    "mathContext": "$\\dfrac{\\mathrm{stirlingFn}(2n)}{(\\mathrm{stirlingFn}\\,n)^2} = \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-asymp",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 126
+    },
+    "type": "key-step",
+    "title": "The sharp central-binomial growth law",
+    "content": "`centralBinom_isEquivalent` proves $(C(2n,n):\\mathbb{R}) \\sim_{atTop} 4^n/\\sqrt{\\pi n}$. Mathlib's Stirling equivalence $n! \\sim \\mathrm{stirlingFn}\\,n$ is composed with $n \\mapsto 2n$ (`IsEquivalent.comp_tendsto`) for the numerator $(2n)!$ and squared (`IsEquivalent.mul`) for $(n!)^2$, then divided (`IsEquivalent.div`); the resulting Stirling quotient is replaced by $4^n/\\sqrt{\\pi n}$ via `stirlingFn_quotient` (`EventuallyEq.isEquivalent`, `trans`). This is the analytic half of the parent's open question that the elementary telescoping-product sibling left open.",
+    "mathContext": "$C(2n,n) \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-bridge",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 147
+    },
+    "type": "insight",
+    "title": "Bridge to the parent's Catalan product",
+    "content": "`succ_mul_catalan_eq_centralBinom` proves $C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$ from `catalan_eq_centralBinom_div` and `Nat.mul_div_cancel'` on `Nat.succ_dvd_centralBinom`. This identifies the central-binomial coefficient with the parent's Catalan number up to the $n+1$ prefactor, and is the conduit that carries the central-binomial asymptotic to the Catalan growth law.",
+    "mathContext": "$C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-catalan",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 170,
+      "endLine": 188
+    },
+    "type": "key-step",
+    "title": "The Catalan growth law the parent only asserted",
+    "content": "`catalan_isEquivalent` proves $(\\mathrm{catalan}\\,n:\\mathbb{R}) \\sim_{atTop} 4^n/(n\\sqrt{\\pi n}) = 4^n/(\\sqrt{\\pi}\\,n^{3/2})$. Using $\\mathrm{catalan}\\,n = C(2n,n)/(n+1)$, the central-binomial asymptotic, and $(n+1)\\sim n$ (`nat_succ_isEquivalent`, from $1+1/n \\to 1$), divided through `IsEquivalent.div`. This is the $n^{3/2}$ polynomial correction the parent's docstring asserts ($\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$) but never proves.",
+    "mathContext": "$\\mathrm{catalan}\\,n \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi}\\,n^{3/2}}$"
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01oq02-lower",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 208,
+      "endLine": 215
+    },
+    "type": "insight",
+    "title": "Effective lower bound for every n",
+    "content": "`four_pow_div_two_mul_le_centralBinom` proves $4^n/(2n) \\le C(2n,n)$ for $n \\ge 1$ by casting Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom` and dividing by $2n$. Unlike the asymptotic, this holds for every $n$, so together with the sibling's $C(2n,n) < 4^n$ it brackets $4^n/(2n) \\le C(2n,n) \\sim 4^n/\\sqrt{\\pi n} < 4^n$.",
+    "mathContext": "$\\dfrac{4^n}{2n} \\le C(2n,n) \\quad (n \\ge 1)$"
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "title": "Erdős #396 OQ-04 → OQ-01 → OQ-01 → OQ-01 → OQ-02: The Sharp Central-Binomial Growth Law C(2n,n) ∼ 4ⁿ/√(πn)",
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "description": "The parent's second open question asks whether the central-binomial recurrence telescopes to C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) AND yields the matching growth law C(2n,n) ∼ 4ⁿ/√(πn). The telescoping product is already established by a sibling entry that deliberately stops at the elementary bound C(2n,n) < 4ⁿ with no Stirling input. This entry supplies the remaining analytic half — the sharp asymptotic constant: C(2n,n) ~[atTop] 4ⁿ/√(πn) and the limit form C(2n,n)·√(πn)/4ⁿ → 1, derived by pure Asymptotics.IsEquivalent algebra on Mathlib's Stirling equivalence (n! ~ √(2nπ)·(n/e)ⁿ) via C(2n,n) = (2n)!/(n!)². The Catalan bridge C(2n,n) = (n+1)·catalan n then yields the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) the parent's docstring states but never proves. An effective lower bound 4ⁿ/(2n) ≤ C(2n,n) (valid for all n) brackets the rate.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/396",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "asymptotics",
+      "central-binomial-coefficient",
+      "catalan",
+      "stirling-formula",
+      "growth-bounds"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 396,
+    "erdosUrl": "https://erdosproblems.com/396",
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "0 axioms, 0 sorries. All results depend only on the foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool / native_decide). Built against Mathlib 4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #396 concerns descending-factorial divisibility of central binomial coefficients, whose base case rests on the Catalan numbers catalan n = C(2n,n)/(n+1). The chain OQ-04 → OQ-01 → OQ-01 → OQ-01 reads the two-term Catalan recurrence multiplicatively, telescoping catalan n = ∏_{k<n} r k, and its second open question asks whether the same technique applied to the central-binomial recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) gives both the product form C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) AND the matching growth law C(2n,n) ∼ 4ⁿ/√(πn). The telescoping product (and the elementary bound C(2n,n) < 4ⁿ) was established by the sibling entry erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01, which uses no Stirling input by design. This entry completes the remaining, genuinely analytic half: the sharp asymptotic constant 1/√(πn).",
+    "problemStatement": "Establish the matching growth law C(2n,n) ∼ 4ⁿ/√(πn) for the central binomial coefficient (the analytic half of the parent's open question that the telescoping-product sibling left open), and deduce the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}).",
+    "text": "Writing C(2n,n) = (2n)!/(n!)² and substituting Mathlib's Stirling equivalence n! ~[atTop] √(2nπ)·(n/e)ⁿ into numerator and denominator, the (n/e) powers contribute 4ⁿ, √(4nπ)/(2nπ) collapses to 1/√(πn), and the Stirling constants cancel, giving C(2n,n) ~[atTop] 4ⁿ/√(πn), equivalently C(2n,n)·√(πn)/4ⁿ → 1. The bridge C(2n,n) = (n+1)·catalan n, together with (n+1) ~ n, transports this to catalan n ~[atTop] 4ⁿ/(n·√(πn)) = 4ⁿ/(√π·n^{3/2}). The asymptotic rate is complemented by the effective bound 4ⁿ/(2n) ≤ C(2n,n), valid for every n.",
+    "proofStrategy": "The core is pure Asymptotics.IsEquivalent algebra. centralBinom_eq_factorial_div gives (C(2n,n):ℝ) = (2n)!/(n!·n!) via Nat.choose_mul_factorial_mul_factorial. Mathlib's Stirling.factorial_isEquivalent_stirling (n! ~ stirlingFn n with stirlingFn n = √(2nπ)·(n/e)ⁿ) is composed with the index map n ↦ 2n (IsEquivalent.comp_tendsto along Tendsto (2·) atTop atTop) for the numerator and squared (IsEquivalent.mul) for the denominator, then divided (IsEquivalent.div). The resulting Stirling quotient is simplified pointwise for n ≥ 1 by stirlingFn_quotient: √(2·2n·π) = 2√(nπ) (Real.sqrt_mul, sqrt_sq), (2n/e)^{2n} = 4ⁿ·(n/e)^{2n} (mul_pow, pow_mul), (√(2nπ))² = 2nπ (Real.sq_sqrt), and field_simp/nlinarith collapse the ratio to 4ⁿ/√(πn); transferring through the eventual equality (IsEquivalent.trans, EventuallyEq.isEquivalent) gives centralBinom_isEquivalent. The limit form is isEquivalent_iff_tendsto_one with div_div_eq_mul_div. The Catalan bridge is catalan_eq_centralBinom_div with Nat.mul_div_cancel' on Nat.succ_dvd_centralBinom; combined with nat_succ_isEquivalent ((n+1)~n via 1+1/n → 1) and IsEquivalent.div it gives the Catalan asymptotic. The effective lower bound casts Nat.four_pow_le_two_mul_self_mul_centralBinom and divides by 2n (div_le_iff₀).",
+    "keyInsights": [
+      "**The sharp constant is exactly the Stirling-dependent ingredient.** The telescoping product and the elementary bound C(2n,n) < 4ⁿ need no analysis (the sibling entry proves them with no Stirling input); the asymptotic constant 1/√(πn) is the one piece that genuinely requires Stirling's formula, supplied here via Mathlib's Stirling.factorial_isEquivalent_stirling.",
+      "**IsEquivalent algebra makes the derivation structural, not computational.** Treating C(2n,n) = (2n)!/(n!)² as a quotient of equivalent sequences, the asymptotic follows from composing/​multiplying/​dividing Stirling equivalences; the only hand computation is the closed-form pointwise simplification stirlingFn(2n)/(stirlingFn n)² = 4ⁿ/√(πn), where √(4nπ)/(2nπ) = 1/√(πn) and the (n/e) powers contribute 4ⁿ.",
+      "**One asymptotic, two growth laws.** The bridge C(2n,n) = (n+1)·catalan n with (n+1) ~ n transports the central-binomial asymptotic to the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) — the n^{3/2} correction the parent's docstring asserts but never proves, now derived from the same Stirling input.",
+      "**Asymptotic rate plus an effective for-all-n bound.** Mathlib's 4ⁿ ≤ 2n·C(2n,n) gives the effective lower bound 4ⁿ/(2n) ≤ C(2n,n) holding for every n ≥ 1 (not merely asymptotically), bracketing 4ⁿ/(2n) ≤ C(2n,n) ∼ 4ⁿ/√(πn) < 4ⁿ."
+    ],
+    "prerequisites": [
+      "Central binomial coefficient C(2n,n) = Nat.centralBinom n and C(2n,n) = (2n)!/(n!)²",
+      "Stirling's formula as an asymptotic equivalence (Stirling.factorial_isEquivalent_stirling)",
+      "Asymptotics.IsEquivalent algebra (comp_tendsto, mul, div, isEquivalent_iff_tendsto_one)",
+      "Catalan numbers and catalan_eq_centralBinom_div"
+    ]
+  },
+  "conclusion": {
+    "summary": "The central binomial coefficient satisfies the sharp asymptotic C(2n,n) ~[atTop] 4ⁿ/√(πn) (limit form C(2n,n)·√(πn)/4ⁿ → 1), proved by pure Asymptotics.IsEquivalent algebra on Mathlib's Stirling equivalence applied to C(2n,n) = (2n)!/(n!)². The bridge C(2n,n) = (n+1)·catalan n transports this to the Catalan growth law catalan n ~[atTop] 4ⁿ/(n·√(πn)) = 4ⁿ/(√π·n^{3/2}). An effective lower bound 4ⁿ/(2n) ≤ C(2n,n) holds for every n ≥ 1. All nine theorems are machine-checked with no axioms or sorries.",
+    "implications": "This completes the analytic half of the parent's second open question: the telescoping-product sibling supplies the recurrence-level product and the elementary 4ⁿ bound with no Stirling input, and this entry supplies the sharp asymptotic constant 1/√(πn) that genuinely needs Stirling. The derivation also delivers the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) — long asserted in the parent's documentation but previously unproved in the gallery — from the same Stirling equivalence, isolating the n^{3/2} polynomial correction the multiplicative recurrence files only shadowed.",
+    "openQuestions": [
+      "Mathlib's Stirling equivalence yields the asymptotic but not an effective two-sided error bound; can the entry's effective lower bound 4ⁿ/(2n) ≤ C(2n,n) and the sibling's C(2n,n) < 4ⁿ be sharpened to explicit constants c₁,c₂ with c₁·4ⁿ/√n ≤ C(2n,n) ≤ c₂·4ⁿ/√n for all n, using sqrt_pi_le_stirlingSeq-style effective Stirling bounds?",
+      "Does the Catalan asymptotic catalan n ∼ 4ⁿ/(√π·n^{3/2}) combine with the parent's strictly decreasing normalized sequence catalan n/4ⁿ to give a monotone (not merely asymptotic) envelope c/n^{3/2} ≤ catalan n/4ⁿ at the recurrence level?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Real",
+      "Nat",
+      "Asymptotics"
+    ],
+    "namespace": "Erdos396OQ04OQ01OQ01OQ01OQ02",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ: telescopes the Catalan recurrence into catalan n = ∏_{k<n} r k and tracks the strictly decreasing normalized sequence catalan n/4ⁿ. Its second open question asks for the central-binomial product and the matching growth law C(2n,n) ∼ 4ⁿ/√(πn); this entry supplies the sharp asymptotic (and the Catalan growth law catalan n ∼ 4ⁿ/(√π·n^{3/2}) the parent only asserts)."
+    },
+    {
+      "targetId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry that proves the central-binomial telescoping product C(2n,n) = ∏_{k<n} 2(2k+1)/(k+1) and its Wallis form, deliberately stopping at the elementary bound C(2n,n) < 4ⁿ with no Stirling input. This entry supplies the analytic half that sibling leaves open: the sharp asymptotic constant 1/√(πn)."
+    },
+    {
+      "targetId": "erdos-396",
+      "relationship": "ancestor",
+      "description": "Root problem: descending factorials dividing central binomial coefficients, whose growth law C(2n,n) ∼ 4ⁿ/√(πn) is established here."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-03/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "gram-linear-independence-iff-oq-01-oq-03",
+  "slug": "gram-linear-independence-iff-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "Matrix",
+      "Finset",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "GramLinearIndependenceOQ01OQ03",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/GramLinearIndependenceOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The k-Dimensional Content: √(det Gram) as a Product of Gram–Schmidt Heights",
+  "description": "Removes the top-dimensional hypothesis from the Gramian volume identity: for any finite family of n vectors in a (possibly larger) real inner product space, det(gram v) = ∏ ‖gramSchmidt v i‖², so the k-dimensional content √(det gram v) = ∏ ‖gramSchmidt v i‖ is the iterated base × height volume — the orthogonalization / exterior-power picture of the Gramian.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GramLinearIndependenceOQ01OQ03.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-space",
+      "gram-matrix",
+      "gram-schmidt",
+      "determinant",
+      "volume",
+      "content",
+      "orthogonalization",
+      "exterior-algebra",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 209,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "badge": "original",
+    "originalContributions": [
+      "det_gram_eq_prod_gramSchmidt_norm_sq: the Gram–Schmidt factorization of the Gramian — det(gram ℝ v) = ∏ i, ‖gramSchmidt ℝ v i‖² for ANY finite family v : Fin n → F in a real inner product space, with NO hypothesis relating n to finrank ℝ F. This is the genuinely k-dimensional content identity that the parent's top-dimensional (square) volume identity does not cover; Mathlib has Gram–Schmidt and the Gram matrix but not this determinant identity",
+      "gram_eq_cmat_dmat: the driving factorization gram ℝ v = C · D · Cᵀ, where C i j = coeff v i j is the lower-unitriangular change-of-basis matrix expressing each vᵢ in the orthogonal Gram–Schmidt family (read off from gramSchmidt_def''), and D = diagonal(‖gramSchmidt v j‖²). Orthogonality of the Gram–Schmidt vectors collapses the bilinear expansion of ⟪vᵢ, vₖ⟫ onto the diagonal",
+      "v_eq_sum_coeff: each input vector is the prescribed combination vᵢ = ∑ⱼ Cᵢⱼ · gramSchmidt ℝ v j of the orthogonalized family, with the universal sum restricted to its Iic-support via Finset.sum_subset and the diagonal coefficient normalized to 1",
+      "det_Cmat: the change-of-basis matrix is unitriangular (det C = 1), proved via Matrix.det_of_lowerTriangular on the BlockTriangular OrderDual.toDual structure of coeff",
+      "content_eq_prod_gramSchmidt_norm: the geometric reading √(det gram v) = ∏ i, ‖gramSchmidt ℝ v i‖ — the content is the iterated base × height volume, each height ‖gramSchmidt v i‖ being the perpendicular distance of vᵢ to the span of the earlier vectors",
+      "content_pos_iff_linearIndependent and content_eq_zero_iff: the geometric independence criterion in the k-dimensional setting — the content is positive iff the family is linearly independent, zero iff dependent"
+    ],
+    "prerequisites": [
+      "Gram matrix Matrix.gram 𝕜 v with entries ⟪v i, v j⟫ and its positive semidefiniteness / linear-independence criterion (grandparent entry gram-linear-independence-iff-oq-01)",
+      "Mathlib's Gram–Schmidt machinery: InnerProductSpace.gramSchmidt, gramSchmidt_def'' (the explicit projection expansion vₙ = gₙ + ∑_{i<n} (⟪gᵢ,vₙ⟫/‖gᵢ‖²)•gᵢ) and gramSchmidt_orthogonal (pairwise orthogonality of the output)",
+      "Triangular-matrix determinants Matrix.det_of_lowerTriangular via Matrix.BlockTriangular OrderDual.toDual, the diagonal determinant Matrix.det_diagonal, and Matrix.det_mul / Matrix.det_transpose",
+      "Real inner-product bilinearity real_inner_smul_left / real_inner_smul_right, sum_inner / inner_sum, and real_inner_self_eq_norm_sq",
+      "Real.sqrt algebra: Real.sqrt_sq, Real.sq_sqrt, Real.sqrt_pos and Finset.prod_pow"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "InnerProductSpace.gramSchmidt_def''",
+        "description": "The explicit Gram–Schmidt projection expansion vₙ = gramSchmidt v n + ∑_{i < n} (⟪gramSchmidt v i, vₙ⟫ / ‖gramSchmidt v i‖²) • gramSchmidt v i, the source of the lower-unitriangular change-of-basis coefficients.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho"
+      },
+      {
+        "theorem": "InnerProductSpace.gramSchmidt_orthogonal",
+        "description": "The Gram–Schmidt process produces a pairwise-orthogonal family (⟪gramSchmidt v a, gramSchmidt v b⟫ = 0 for a ≠ b), which collapses the bilinear expansion of the Gram entries onto the diagonal.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho"
+      },
+      {
+        "theorem": "Matrix.det_of_lowerTriangular",
+        "description": "The determinant of a matrix that is BlockTriangular for OrderDual.toDual (zero strictly above the diagonal) is the product of its diagonal entries — giving det C = ∏ coeff v i i = 1 for the unitriangular change-of-basis matrix.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Block"
+      },
+      {
+        "theorem": "Matrix.det_diagonal / Matrix.det_mul / Matrix.det_transpose",
+        "description": "det(diagonal d) = ∏ d i, det(MN) = det M · det N and det(Mᵀ) = det M, which turn the factorization gram v = C D Cᵀ into det(gram v) = (det C)² · ∏ ‖gramSchmidt v i‖² = ∏ ‖gramSchmidt v i‖².",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.posSemidef_gram / Matrix.posDef_gram_iff_linearIndependent",
+        "description": "The Gram matrix is positive semidefinite, and positive definite iff the family is linearly independent — combined with PosSemidef.det_nonneg and PosDef.det_pos to re-derive locally the Gramian criterion (det ≥ 0, det > 0 iff independent) used for the content's sign and the independence test.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramMatrix"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Gram determinant of a family of vectors is the square of the volume of the parallelepiped they span — but `volume' in any ambient dimension means the k-dimensional content of a k-vector box living inside a possibly much larger space. The classical recipe for that content is iterated base × height: orthogonalize the vectors (Gram–Schmidt), and the content is the product of the resulting perpendicular heights. This is the orthogonalization picture of the Gramian, dual to the exterior-power picture (where the content is the norm of the wedge v₁ ∧ ⋯ ∧ vₖ) and to the Cauchy–Binet picture (where det(gram v) is a sum of squared k×k minors). The grandparent entry established the algebraic Gramian criterion, and the sibling entry oq-01-oq-02 realized √(det gram v) as a Haar/Lebesgue volume — but only in the top-dimensional (square) case, where the n vectors fill the ambient space (finrank ℝ F = n). Mathlib formalizes the Gram matrix, its positive-definiteness criterion, and the full Gram–Schmidt API, but it does not connect the Gram determinant to the orthogonalized norms. This entry supplies that bridge in arbitrary dimension.",
+    "problemStatement": "For an arbitrary finite family v : Fin n → F in a real inner product space F — with no hypothesis relating n to finrank ℝ F — express the Gram determinant through the Gram–Schmidt orthogonalization: det(gram ℝ v) = ∏ i, ‖gramSchmidt ℝ v i‖². Deduce the k-dimensional content √(det gram v) = ∏ i, ‖gramSchmidt ℝ v i‖ as an iterated base × height volume, and the geometric independence criterion (content positive iff independent, zero iff dependent).",
+    "proofStrategy": "Write g i = gramSchmidt ℝ v i for the orthogonalized family. Define the change-of-basis matrix C with C i j = coeff v i j: on the diagonal it is 1, strictly below it is the Gram–Schmidt projection coefficient ⟪g j, v i⟫/‖g j‖², strictly above it vanishes. Reading gramSchmidt_def'' and restricting the universal sum to its Iic-support gives v_eq_sum_coeff: vᵢ = ∑ⱼ Cᵢⱼ • gⱼ. Substituting both arguments into ⟪vᵢ, vₖ⟫ and expanding by bilinearity (sum_inner, real_inner_smul_left/right, inner_sum), orthogonality of g (gramSchmidt_orthogonal) collapses the inner sum over l onto l = j, so ⟪vᵢ, vₖ⟫ = ∑ⱼ Cᵢⱼ Cₖⱼ ‖gⱼ‖², i.e. gram ℝ v = C · D · Cᵀ with D = diagonal(‖gⱼ‖²) (gram_eq_cmat_dmat, matched against the matrix product via Matrix.mul_diagonal). Taking determinants: C is lower-unitriangular so det C = 1 (det_Cmat, via Matrix.det_of_lowerTriangular on the BlockTriangular OrderDual.toDual structure), det D = ∏ ‖gⱼ‖² (det_Dmat), and det_mul/det_transpose give det(gram v) = (det C)² · det D = ∏ ‖gⱼ‖² (det_gram_eq_prod_gramSchmidt_norm_sq). The content √(det gram v) = ∏ ‖gⱼ‖ follows by Finset.prod_pow and Real.sqrt_sq (all norms nonneg); the independence criterion combines the content with the locally re-derived Gramian criterion (PosSemidef.det_nonneg, posDef_gram_iff_linearIndependent, PosDef.det_pos).",
+    "keyInsights": [
+      "Removing the spanning hypothesis is exactly what makes the identity k-dimensional: gramSchmidt is defined for any finite family, not only a basis, so the factorization gram v = C D Cᵀ needs no relation between n and finrank F — the content of n vectors inside a larger space is captured purely by their orthogonalized norms.",
+      "The Gram determinant linearizes through one unitriangular change of basis: C expresses v in the orthogonal family g, and because C is unitriangular (det = 1) the determinant of gram v = C D Cᵀ is just det D = ∏ ‖gᵢ‖² — the Gram–Schmidt analogue of LU/Cholesky, with the heights ‖gᵢ‖ on the diagonal.",
+      "Each Gram–Schmidt norm is a perpendicular height: ‖gramSchmidt v i‖ is the distance from vᵢ to the span of v₀,…,v_{i-1}, so ∏ ‖gᵢ‖ is the textbook base × height × ⋯ recursion for the volume of a parallelepiped — the orthogonalization picture, complementary to the Cauchy–Binet (sum-of-squared-minors) and exterior-power (wedge-norm) pictures.",
+      "Squaring then square-rooting handles the sign with no orientation hypothesis: det(gram v) = ∏ ‖gᵢ‖² is manifestly nonnegative and its square root recovers ∏ ‖gᵢ‖ = the unsigned content, valid even when the vectors do not span and no signed determinant is available.",
+      "Orthogonality is the only analytic input: the whole collapse of the bilinear double sum onto the diagonal is gramSchmidt_orthogonal; everything else is matrix-determinant algebra, so the proof is elementary (no measure theory) and works over any real inner product space."
+    ]
+  },
+  "sections": [
+    {
+      "id": "change-of-basis",
+      "title": "The Unitriangular Change of Basis",
+      "startLine": 58,
+      "endLine": 96,
+      "summary": "Defines coeff (the change-of-basis coefficients, 1 on the diagonal, projection coefficients below, 0 above), the matrices Cmat and Dmat, and proves v_eq_sum_coeff: each input vector vᵢ = ∑ⱼ Cᵢⱼ • gramSchmidt v j, obtained from gramSchmidt_def'' by restricting the universal sum to the Iic-support of coeff.",
+      "mathContext": "$v_i = \\sum_j C_{ij}\\, g_j$, with $C_{ii} = 1$, $C_{ij} = \\langle g_j, v_i\\rangle/\\lVert g_j\\rVert^2$ for $j<i$, $0$ for $j>i$."
+    },
+    {
+      "id": "factorisation",
+      "title": "The Factorization gram v = C · D · Cᵀ",
+      "startLine": 98,
+      "endLine": 118,
+      "summary": "gram_eq_cmat_dmat expands ⟪vᵢ, vₖ⟫ = ⟪∑ⱼ Cᵢⱼ gⱼ, ∑ₗ Cₖₗ gₗ⟫ by bilinearity and collapses the inner sum by orthogonality of the Gram–Schmidt vectors (gramSchmidt_orthogonal), yielding gram ℝ v = C · D · Cᵀ with D = diagonal(‖gⱼ‖²).",
+      "mathContext": "$\\mathrm{Gram}(v) = C\\,D\\,C^{\\mathsf T}$, $D = \\operatorname{diag}(\\lVert g_j\\rVert^2)$."
+    },
+    {
+      "id": "determinant",
+      "title": "The Gram–Schmidt Factorization of the Gramian",
+      "startLine": 120,
+      "endLine": 146,
+      "summary": "det_Cmat shows C is unitriangular (det C = 1) via Matrix.det_of_lowerTriangular on its BlockTriangular OrderDual.toDual structure; det_Dmat gives det D = ∏ ‖gⱼ‖². Combined through det_mul and det_transpose, det_gram_eq_prod_gramSchmidt_norm_sq gives det(gram v) = ∏ ‖gᵢ‖².",
+      "mathContext": "$\\det\\mathrm{Gram}(v) = (\\det C)^2\\,\\det D = \\prod_i \\lVert g_i\\rVert^2$."
+    },
+    {
+      "id": "content",
+      "title": "The Content as a Product of Heights",
+      "startLine": 148,
+      "endLine": 205,
+      "summary": "After re-deriving the Gramian criterion locally from Mathlib (gram_det_nonneg, linearIndependent_iff_gram_det_pos), defines the content √(det gram v) and proves content_eq_prod_gramSchmidt_norm (content = ∏ ‖gᵢ‖), content_sq, and the geometric independence tests content_pos_iff_linearIndependent and content_eq_zero_iff.",
+      "mathContext": "$\\sqrt{\\det\\mathrm{Gram}(v)} = \\prod_i \\lVert g_i\\rVert$; positive iff $v$ independent."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-03-oq-01",
+      "question": "Identify each Gram–Schmidt height ‖gramSchmidt v i‖ with the metric distance dist(v i, span {v 0, …, v (i-1)}) (the perpendicular height), turning content = ∏ heights into the literal recursive base × height formula and connecting to Mathlib's orthogonalProjection distance API.",
+      "significance": "medium"
+    },
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-03-oq-02",
+      "question": "Prove the Cauchy–Binet form det(gram v) = ∑ over k-subsets S of det(B_S)² (B the coordinate matrix in an orthonormal basis of the span), reconciling the orthogonalization picture proved here with the minor-sum / exterior-power picture, and identify ∏ ‖gramSchmidt v i‖ with the norm of the wedge v₀ ∧ ⋯ ∧ v_{n-1}.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gram-linear-independence-iff-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The sibling entry realized √(det gram v) as the Haar/Lebesgue parallelepiped volume in the top-dimensional (square) case finrank ℝ F = n. This entry removes the spanning hypothesis: for n vectors in any larger space, √(det gram v) = ∏ ‖gramSchmidt v i‖ is the k-dimensional content via Gram–Schmidt heights — the explicit follow-up the sibling lists as an open question."
+    },
+    {
+      "targetId": "gram-linear-independence-iff-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent established the Gramian criterion (det(gram v) > 0 iff independent), re-derived locally here, and read geometrically as content_pos_iff_linearIndependent in the k-dimensional setting."
+    },
+    {
+      "targetId": "gram-linear-independence-iff-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "The Hadamard sibling bounds det(gram v) ≤ ∏ ‖v i‖²; combined with the factorization here it reads as ∏ ‖gramSchmidt v i‖ ≤ ∏ ‖v i‖, i.e. orthogonalization never increases the per-vector lengths — the box of fixed edge lengths is largest when already orthogonal."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.InnerProductSpace.GramSchmidtOrtho",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of gramSchmidt, gramSchmidt_def'' (the projection expansion) and gramSchmidt_orthogonal (pairwise orthogonality of the output) used to build the unitriangular change of basis."
+    },
+    {
+      "title": "Mathlib4: Analysis.InnerProductSpace.GramMatrix",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Matrix.gram, posSemidef_gram and posDef_gram_iff_linearIndependent, used to re-derive the Gramian criterion locally."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For any finite family v : Fin n → F in a real inner product space — with no hypothesis relating n to finrank ℝ F — the Gram determinant equals the product of the squared Gram–Schmidt norms: det(gram ℝ v) = ∏ i, ‖gramSchmidt ℝ v i‖² (det_gram_eq_prod_gramSchmidt_norm_sq). The proof factors gram ℝ v = C · D · Cᵀ through the lower-unitriangular change-of-basis matrix C expressing v in its Gram–Schmidt orthogonalization (gram_eq_cmat_dmat), where det C = 1 (det_Cmat) and det D = ∏ ‖gᵢ‖² (det_Dmat). The k-dimensional content √(det gram v) = ∏ i, ‖gramSchmidt ℝ v i‖ (content_eq_prod_gramSchmidt_norm) is therefore the iterated base × height volume, and is positive iff the family is linearly independent (content_pos_iff_linearIndependent), zero iff dependent (content_eq_zero_iff). 209 lines, 14 theorems, 4 definitions, 0 axioms, 0 sorries.",
+    "implications": "This answers the parent entry's third open question (k-dimensional content) along the orthogonalization route, complementing the sibling's top-dimensional Haar-volume identity. Because gramSchmidt requires no spanning hypothesis, the content of n vectors inside an arbitrarily large space is reduced to their orthogonalized norms — an elementary, measure-theory-free identity reusable for the perpendicular-distance reading of the heights and for reconciling the orthogonalization picture with the Cauchy–Binet / exterior-power pictures recorded as open questions.",
+    "openQuestions": [
+      "Identify each Gram–Schmidt height with the distance dist(v i, span of the earlier vectors), giving the literal base × height recursion.",
+      "Cauchy–Binet form det(gram v) = ∑ squared k×k minors, reconciling the orthogonalization picture with the exterior-power picture and the wedge norm ‖v₀ ∧ ⋯ ∧ v_{n-1}‖."
+    ]
+  }
+}

--- a/src/data/research/problems/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,244 @@
+{
+  "slug": "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "title": "Does the telescoping-product technique applied to the central-binomial recurr...",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "",
+    "plain": "This is an open question (technique) arising from the verified gallery proof",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T10:22:55-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved the sharp asymptotic C(2n,n) ~ 4^n/sqrt(pi n) (the Stirling-dependent analytic half the telescoping-product sibling left open) and the Catalan growth law catalan n ~ 4^n/(sqrt(pi) n^{3/2}); verified 0-axiom, 9 thm/1 def/228L.",
+    "builtItems": [
+      "centralBinom_isEquivalent : (C(2n,n):R) ~[atTop] 4^n/sqrt(pi n) (Erdos396OQ04OQ01OQ01OQ01OQ02.lean:107)",
+      "centralBinom_mul_sqrt_pi_div_four_pow_tendsto_one : limit form -> 1 (line 128)",
+      "stirlingFn_quotient : closed-form Stirling-quotient simplification (line 72)",
+      "succ_mul_catalan_eq_centralBinom : C(2n,n)=(n+1) catalan n (line 145)",
+      "catalan_isEquivalent : (catalan n:R) ~[atTop] 4^n/(n sqrt(pi n)) (line 170)",
+      "four_pow_div_two_mul_le_centralBinom : effective 4^n/(2n) <= C(2n,n) (line 208)"
+    ],
+    "insights": [
+      "The telescoping product half of this open question was already established by sibling oq-04-oq-01-oq-01-oq-02-oq-02-oq-01 (PR #27516), which deliberately uses no Stirling input and stops at C(2n,n)<4^n; the genuinely-new contribution is the SHARP asymptotic constant 1/sqrt(pi n).",
+      "C(2n,n) ~ 4^n/sqrt(pi n) derives cleanly from Mathlib Stirling.factorial_isEquivalent_stirling (n! ~ sqrt(2 n pi)(n/e)^n) by pure Asymptotics.IsEquivalent algebra on C(2n,n)=(2n)!/(n!)^2: comp_tendsto (n->2n) for numerator, mul for denominator, div, then a single pointwise simplification.",
+      "The only hand computation is stirlingFn(2n)/(stirlingFn n)^2 = 4^n/sqrt(pi n): (2n/e)^{2n}=4^n(n/e)^{2n}, sqrt(4 n pi)/(2 n pi)=1/sqrt(pi n).",
+      "Catalan asymptotic catalan n ~ 4^n/(sqrt(pi) n^{3/2}) follows from the bridge C(2n,n)=(n+1) catalan n plus (n+1)~n; this is the n^{3/2} correction the parent docstring asserts but never proves."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no centralBinom asymptotic (only Stirling for n! and Bertrand bounds); derived here from factorial_isEquivalent_stirling.",
+      "Mathlib Stirling gives an asymptotic equivalence but no effective two-sided c1 4^n/sqrt n <= C <= c2 4^n/sqrt n for all n (would need sqrt_pi_le_stirlingSeq-style effective bounds)."
+    ],
+    "nextSteps": [
+      "Upgrade to effective two-sided constants using sqrt_pi_le_stirlingSeq effective Stirling lower bound.",
+      "Combine catalan asymptotic with parent strictly-decreasing catalan n/4^n for a monotone n^{-3/2} envelope."
+    ],
+    "markdown": "# Knowledge Base: erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "binomial-coefficients",
+    "telescoping"
+  ],
+  "relatedProofs": [
+    "erdos-3",
+    "erdos-39",
+    "erdos-396",
+    "erdos-396-oq-04",
+    "erdos-396-oq-04-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01",
+    "erdos-396-oq-04-oq-01-oq-01-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T18:10:26.102Z",
+  "lastUpdate": "2026-06-24T18:10:26.141Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos396OQ04.lean",
+      "filename": "Erdos396OQ04.lean",
+      "lineCount": 132,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01.lean",
+      "filename": "Erdos396OQ04OQ01.lean",
+      "lineCount": 188,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01.lean",
+      "lineCount": 134,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ01.lean",
+      "lineCount": 163,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02.lean",
+      "lineCount": 214,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ01.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02.lean",
+      "lineCount": 249,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean",
+      "lineCount": 207,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean",
+      "lineCount": 251,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean",
+      "lineCount": 168,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos396OQ04OQ01OQ01OQ03.lean",
+      "filename": "Erdos396OQ04OQ01OQ01OQ03.lean",
+      "lineCount": 129,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396OQ04OQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos396Problem.lean",
+      "filename": "Erdos396Problem.lean",
+      "lineCount": 103,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Removes the top-dimensional hypothesis (`finrank ℝ F = n`) from the Gramian volume identity. For **any** finite family `v : Fin n → F` in a real inner product space — n vectors possibly sitting inside a larger space — the Gram determinant factors through the Gram–Schmidt orthogonalization:

- **`det_gram_eq_prod_gramSchmidt_norm_sq`**: `det (gram ℝ v) = ∏ i, ‖gramSchmidt ℝ v i‖²`
- **`content_eq_prod_gramSchmidt_norm`**: `√(det gram v) = ∏ i, ‖gramSchmidt ℝ v i‖`

So the **k-dimensional content** is the iterated *base × height* volume — the orthogonalization picture of the Gramian — valid with no spanning hypothesis. The geometric independence test (`content_pos_iff_linearIndependent`, `content_eq_zero_iff`) follows.

## Proof

Factor `gram ℝ v = C · D · Cᵀ`, where `C` is the lower-unitriangular change-of-basis matrix expressing each `vᵢ` in the orthogonal Gram–Schmidt family (read off from `gramSchmidt_def''`) and `D = diagonal(‖gⱼ‖²)`. Orthogonality (`gramSchmidt_orthogonal`) collapses the bilinear double sum onto the diagonal. Taking determinants: `det C = 1` (unitriangular, via `Matrix.det_of_lowerTriangular`), `det D = ∏ ‖gⱼ‖²`, giving the result through `det_mul`/`det_transpose`.

## Context

Answers the sibling entry `gram-linear-independence-iff-oq-01-oq-02`'s open question — extend the parallelepiped-volume identity from the top-dimensional (square) case to a lower-dimensional family `k < n`, here along the Gram–Schmidt route (complementary to the Cauchy–Binet / wedge-norm picture).

## Verification

- 14 theorems, 4 definitions, 209 lines
- **0 sorries, 0 axioms** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`
- Status: `verified`, badge: `original`
- Compiled against Mathlib (docker down → `lake env lean` against prebuilt main Mathlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)