### PR TITLE
Enrich Jarník–Besicovitch Dimension (liouville-theorem-oq-03): add index.ts + annotations

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-03/annotations.json
+++ b/src/data/proofs/liouville-theorem-oq-03/annotations.json
@@ -1,0 +1,209 @@
+[
+  {
+    "id": "ann-liouoq03-1",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 1, "endLine": 63 },
+    "type": "context",
+    "title": "Jarník–Besicovitch: Dimension of the Well-Approximable Reals",
+    "content": "**Module framing.** Metric Diophantine approximation asks *how large* the set of reals approximable to a given order really is. For an exponent $\\tau$, the $\\tau$-well-approximable set $W(\\tau)$ collects the reals $x$ with $|x - p/q| < C/q^{\\tau}$ for infinitely many $p/q$ — exactly Mathlib's `LiouvilleWith τ x`. The **Jarník–Besicovitch theorem** (Jarník 1931, Besicovitch 1934) evaluates its Hausdorff dimension as $\\dim_H W(\\tau) = 2/\\tau$ for $\\tau \\ge 2$, one of the first non-trivial fractional dimensions computed in number theory. This entry isolates that single deep formula as an axiom and machine-checks everything reachable from it, so the page makes precise exactly what Mathlib is still missing. The capstone corollary: the Liouville numbers — uncountable and comeagre — nonetheless have Hausdorff dimension $0$.",
+    "mathContext": "$W(\\tau) = \\{x : \\mathbb{R} \\mid \\exists\\,\\text{infinitely many } p/q,\\ |x - p/q| < C q^{-\\tau}\\} = \\{x \\mid \\mathrm{LiouvilleWith}\\,\\tau\\,x\\}$, and $\\dim_H W(\\tau) = 2/\\tau$ for $\\tau \\ge 2$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Metric Diophantine approximation",
+      "Hausdorff dimension",
+      "Irrationality measure / approximation exponent",
+      "Liouville numbers"
+    ],
+    "prerequisites": [
+      "Hausdorff measure and dimension",
+      "Diophantine approximation by rationals"
+    ],
+    "tags": ["module-header", "framing", "jarnik-besicovitch"]
+  },
+  {
+    "id": "ann-liouoq03-2",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 66, "endLine": 73 },
+    "type": "definition",
+    "title": "The Well-Approximable Set W τ",
+    "content": "**`wellApprox τ := {x | LiouvilleWith τ x}`** packages the central object directly on top of Mathlib's `LiouvilleWith` predicate. The `@[simp]` lemma `mem_wellApprox` unfolds membership definitionally to `LiouvilleWith τ x` (`Iff.rfl`), so every later proof can move freely between the set-builder view (good for `dimH_mono`, subset reasoning) and the predicate view (good for invoking Mathlib's `LiouvilleWith.mono`). Choosing a named set rather than working through the bare predicate is what makes the Hausdorff-dimension API — which acts on `Set ℝ` — directly applicable.",
+    "mathContext": "$W(\\tau) := \\{x \\in \\mathbb{R} \\mid \\mathrm{LiouvilleWith}\\,\\tau\\,x\\}$; $x \\in W(\\tau) \\iff \\mathrm{LiouvilleWith}\\,\\tau\\,x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "LiouvilleWith predicate",
+      "Set-builder notation",
+      "Definitional unfolding (Iff.rfl)"
+    ],
+    "prerequisites": [
+      "Mathlib's LiouvilleWith",
+      "Set membership in Lean"
+    ],
+    "tags": ["definition", "wellApprox"]
+  },
+  {
+    "id": "ann-liouoq03-3",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 75, "endLine": 91 },
+    "type": "technique",
+    "title": "Order Structure: Antitone Sets and the Liouville Subset",
+    "content": "Three genuine (0-axiom) structural facts establish the order skeleton. **`wellApprox_antitone`**: a larger exponent is a stronger demand, so $\\sigma \\le \\tau \\Rightarrow W(\\tau) \\subseteq W(\\sigma)$ — one line from `LiouvilleWith.mono`. **`wellApprox_le_one`** / **`wellApprox_one`**: for $\\tau \\le 1$ approximation to that order is automatic for *every* real (via `liouvilleWith_one`), so $W(\\tau) = \\mathbb{R}$; the interesting regime is therefore $\\tau > 1$, and the dimension formula activates at the threshold $\\tau = 2$. **`liouville_subset_wellApprox`**: a Liouville number is approximable to *every* order, so $\\{x \\mid \\mathrm{Liouville}\\,x\\} \\subseteq W(\\tau)$ for all $\\tau$ — from `Liouville.liouvilleWith`. This last inclusion is the hinge that later forces the Liouville dimension to $0$.",
+    "mathContext": "$\\sigma \\le \\tau \\Rightarrow W(\\tau) \\subseteq W(\\sigma)$; $\\tau \\le 1 \\Rightarrow W(\\tau) = \\mathbb{R}$; $\\{x \\mid \\mathrm{Liouville}\\,x\\} \\subseteq \\bigcap_{\\tau} W(\\tau)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "LiouvilleWith.mono",
+      "Liouville.liouvilleWith",
+      "Antitone family of sets",
+      "Nested intersection"
+    ],
+    "prerequisites": [
+      "Monotonicity of predicates in a parameter",
+      "Subset relations"
+    ],
+    "tags": ["structural", "antitone", "subset", "zero-axiom"]
+  },
+  {
+    "id": "ann-liouoq03-4",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 93, "endLine": 105 },
+    "type": "technique",
+    "title": "Transporting the Order to Hausdorff Dimension",
+    "content": "The set-level inclusions are pushed through Mathlib's **`dimH_mono`** (monotonicity of Hausdorff dimension under $\\subseteq$). **`dimH_wellApprox_antitone`**: $\\sigma \\le \\tau \\Rightarrow \\dim_H W(\\tau) \\le \\dim_H W(\\sigma)$. **`dimH_liouville_le_wellApprox`**: $\\dim_H\\{x \\mid \\mathrm{Liouville}\\,x\\} \\le \\dim_H W(\\tau)$ for every $\\tau$. Notably this monotonicity is established *before* any actual value of the dimension is known — it is purely structural and entirely axiom-free. That separation is the design point: the qualitative shape of the dimension function is verified outright, and only its quantitative value $2/\\tau$ awaits the one deep input.",
+    "mathContext": "$\\dim_H$ is monotone: $A \\subseteq B \\Rightarrow \\dim_H A \\le \\dim_H B$. Hence $\\dim_H\\{\\mathrm{Liouville}\\} \\le \\dim_H W(\\tau)$ for all $\\tau$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dimH_mono",
+      "Monotonicity of Hausdorff dimension",
+      "Order-preserving maps"
+    ],
+    "prerequisites": [
+      "Hausdorff dimension as a set function",
+      "Monotone functions"
+    ],
+    "tags": ["dimension", "monotonicity", "zero-axiom"]
+  },
+  {
+    "id": "ann-liouoq03-5",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 106, "endLine": 135 },
+    "type": "concept",
+    "title": "The Dimension Exponent d(τ) = 2/τ",
+    "content": "Before invoking the theorem, the exponent function $d(\\tau) = 2/\\tau$ is analyzed by elementary real inequalities, all 0-axiom: **`jbDim_two`** gives $d(2) = 1$ (the threshold is full-dimensional on the line), **`jbDim_pos`** positivity, **`jbDim_le_one`** ($d(\\tau) \\le 1$ for $\\tau \\ge 2$) and **`jbDim_lt_one`** ($d(\\tau) < 1$ strictly for $\\tau > 2$) show dimension strictly drops above threshold, and **`jbDim_antitone`** ($0 < \\sigma \\le \\tau \\Rightarrow d(\\tau) \\le d(\\sigma)$, via `gcongr`) mirrors at the level of numbers the set-antitonicity proved earlier. Verifying these independently means the eventual dimension equality $\\dim_H W(\\tau) = \\mathrm{ofReal}\\,(2/\\tau)$ inherits a fully checked right-hand side.",
+    "mathContext": "$d(\\tau) = 2/\\tau$: $d(2) = 1$; $\\tau \\ge 2 \\Rightarrow 0 < d(\\tau) \\le 1$; $\\tau > 2 \\Rightarrow d(\\tau) < 1$; antitone on $(0,\\infty)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Reciprocal function",
+      "gcongr tactic",
+      "Threshold τ = 2",
+      "Monotone real functions"
+    ],
+    "prerequisites": [
+      "Real inequalities (div_le_one, div_lt_one)",
+      "Positivity reasoning"
+    ],
+    "tags": ["exponent", "elementary", "zero-axiom"]
+  },
+  {
+    "id": "ann-liouoq03-6",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 137, "endLine": 152 },
+    "type": "context",
+    "title": "The Jarník–Besicovitch Axiom — the Single Deep Input",
+    "content": "**`axiom dimH_wellApprox (τ) (hτ : 2 ≤ τ) : dimH (wellApprox τ) = ENNReal.ofReal (2 / τ)`** records the one fact that Mathlib cannot yet supply. Its proof has two genuinely different halves: an **upper bound** $\\dim_H W(\\tau) \\le 2/\\tau$ from an efficient covering of the approximating intervals (a convergence / Borel–Cantelli Hausdorff-measure estimate), and a **lower bound** $\\dim_H W(\\tau) \\ge 2/\\tau$ from a **mass distribution principle** (Frostman's lemma) on a Cantor-like subset carrying a measure of the right Hölder regularity. Stating it as a named axiom — rather than hiding it in a `sorry` — keeps the assumption auditable: `#print axioms` cleanly separates the formula-dependent results from the structural ones. The remark that the constant $C$ does not affect the dimension reflects countable stability of $\\dim_H$ over $C \\in \\mathbb{N}$.",
+    "mathContext": "Axiom: $\\dim_H W(\\tau) = \\mathrm{ENNReal.ofReal}(2/\\tau)$ for $\\tau \\ge 2$. Upper bound: covering/Borel–Cantelli; lower bound: mass distribution principle (Frostman).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Borel–Cantelli lemma",
+      "Mass distribution principle / Frostman's lemma",
+      "Hausdorff measure covering estimates",
+      "Axiom isolation"
+    ],
+    "prerequisites": [
+      "Hausdorff measure Hˢ and dimension",
+      "Covering arguments",
+      "Frostman's lemma"
+    ],
+    "tags": ["axiom", "deep-input", "frostman", "borel-cantelli"]
+  },
+  {
+    "id": "ann-liouoq03-7",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 153, "endLine": 160 },
+    "type": "insight",
+    "title": "Threshold Value: dimH(W 2) = 1",
+    "content": "**`dimH_wellApprox_two`** instantiates the axiom at $\\tau = 2$: since $2/2 = 1$ and $\\mathrm{ENNReal.ofReal}\\,1 = 1$, the well-approximable set at the natural threshold has **full dimension** $1$ in $\\mathbb{R}$. This is the boundary case of Dirichlet's theorem: *every* irrational is approximable to order $2$ (with infinitely many convergents from its continued fraction), so $W(2)$ is essentially all of $\\mathbb{R}$ up to a null set and is dimensionally full. **`dimH_wellApprox_eq_jbDim`** simply re-expresses the axiom through the verified exponent function $d(\\tau)$, tying the proven analytic facts about $2/\\tau$ to the dimension value.",
+    "mathContext": "$\\dim_H W(2) = \\mathrm{ofReal}(2/2) = \\mathrm{ofReal}\\,1 = 1$. Dirichlet: every irrational satisfies $|x - p/q| < q^{-2}$ infinitely often.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dirichlet's approximation theorem",
+      "Continued fraction convergents",
+      "Full-dimensional sets",
+      "ENNReal.ofReal"
+    ],
+    "prerequisites": [
+      "Dirichlet approximation",
+      "ENNReal coercions"
+    ],
+    "tags": ["threshold", "dirichlet", "full-dimension"]
+  },
+  {
+    "id": "ann-liouoq03-8",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 162, "endLine": 174 },
+    "type": "technique",
+    "title": "Per-Exponent Bound on the Liouville Dimension",
+    "content": "**`dimH_liouville_le`** chains the two ingredients: the structural inclusion $\\{x \\mid \\mathrm{Liouville}\\,x\\} \\subseteq W(\\tau)$ (giving $\\dim_H\\{\\mathrm{Liouville}\\} \\le \\dim_H W(\\tau)$ via `dimH_liouville_le_wellApprox`) composed with the axiom's value $\\dim_H W(\\tau) = \\mathrm{ofReal}(2/\\tau)$. The result, $\\dim_H\\{\\mathrm{Liouville}\\} \\le \\mathrm{ofReal}(2/\\tau)$ for every $\\tau \\ge 2$, is a *one-parameter family* of upper bounds — exactly the form needed to let $\\tau \\to \\infty$ and squeeze the dimension to zero. The `.trans` composition makes the logical dependency transparent: only this lemma and below carry the axiom.",
+    "mathContext": "$\\dim_H\\{\\mathrm{Liouville}\\} \\le \\dim_H W(\\tau) = \\mathrm{ofReal}(2/\\tau)$ for all $\\tau \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Transitivity of ≤",
+      "Family of upper bounds",
+      "Subset → dimension bound"
+    ],
+    "prerequisites": [
+      "Composing inequalities",
+      "Hausdorff dimension monotonicity"
+    ],
+    "tags": ["liouville", "upper-bound", "axiom-dependent"]
+  },
+  {
+    "id": "ann-liouoq03-9",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 175, "endLine": 193 },
+    "type": "insight",
+    "title": "The Capstone: Liouville Numbers Have Dimension Zero",
+    "content": "**`dimH_liouville_eq_zero`** is the classical corollary, here *derived* (not axiomatized). The argument is an explicit squeeze: restrict the per-exponent bound to natural numbers $n \\ge 2$, giving $\\dim_H\\{\\mathrm{Liouville}\\} \\le \\mathrm{ofReal}(2/n)$; observe $2/n \\to 0$ via `tendsto_const_div_atTop_nhds_zero_nat`, transported into $\\mathbb{R}_{\\ge 0}^{\\infty}$ by `ENNReal.continuous_ofReal`; then `ge_of_tendsto` forces the constant left side below every tail, i.e. $\\le 0$; finally `le_antisymm` with `zero_le` pins it to $0$. The mathematical content is striking: the Liouville set is **uncountable** (a perfect, dense set) and **comeagre** (topologically generic), yet **dimensionally negligible** — Hausdorff dimension separates 'size' more finely than cardinality, category, or Lebesgue measure all do.",
+    "mathContext": "$\\dim_H\\{\\mathrm{Liouville}\\} \\le \\mathrm{ofReal}(2/n) \\to 0$ as $n \\to \\infty$, hence $= 0$. Using natural $n$ sidesteps a real-parameter limit lemma.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Squeeze / ge_of_tendsto",
+      "tendsto_const_div_atTop_nhds_zero_nat",
+      "ENNReal.continuous_ofReal",
+      "Dimension zero vs. measure zero"
+    ],
+    "prerequisites": [
+      "Limits of sequences in ℝ≥0∞",
+      "Order limit theorems (ge_of_tendsto)"
+    ],
+    "tags": ["capstone", "dimension-zero", "squeeze", "axiom-dependent"]
+  },
+  {
+    "id": "ann-liouoq03-10",
+    "proofId": "liouville-theorem-oq-03",
+    "range": { "startLine": 194, "endLine": 210 },
+    "type": "insight",
+    "title": "Summary Bundle and the Measure-Refinement Picture",
+    "content": "**`jarnik_besicovitch_summary`** packages the four headline facts into one conjunction: set antitonicity, the Liouville subset relation, the threshold value $\\dim_H W(2) = 1$, and the dimension-zero result for the Liouville set. Read top-to-bottom it tells the whole story — the dimension function $\\tau \\mapsto \\dim_H W(\\tau)$ starts at $1$ for $\\tau = 2$ and decreases along $2/\\tau$ toward $0$, with the Liouville numbers sitting at the limiting bottom. This sharpens the sibling result that the Liouville set is Lebesgue-null: **dimension zero is strictly stronger than measure zero** (e.g. a measure-zero set can have full dimension $1$), so this is the strongest 'smallness' statement of metric type available for the Liouville set.",
+    "mathContext": "Summary: $\\sigma \\le \\tau \\Rightarrow W(\\tau) \\subseteq W(\\sigma)$; $\\{\\mathrm{Liouville}\\} \\subseteq W(\\tau)$; $\\dim_H W(2) = 1$; $\\dim_H\\{\\mathrm{Liouville}\\} = 0$. Dimension $0$ $\\Rightarrow$ measure $0$, but not conversely.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Hausdorff dimension vs. Lebesgue measure",
+      "Smallness hierarchies",
+      "Conjunctive theorem bundling"
+    ],
+    "prerequisites": [
+      "Relation between dimension and measure",
+      "Logical conjunction in Lean"
+    ],
+    "tags": ["summary", "measure-refinement"]
+  }
+]

--- a/src/data/proofs/liouville-theorem-oq-03/index.ts
+++ b/src/data/proofs/liouville-theorem-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LiouvilleTheoremOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const liouvilleTheoremOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const liouvilleTheoremOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const liouvilleTheoremOQ03Data: ProofData = {
+  proof: liouvilleTheoremOQ03Proof,
+  annotations: liouvilleTheoremOQ03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for liouville-theorem-oq-03. Adds missing index.ts (page would otherwise 404) and deepens annotations. (Recovered from feature/enricher-1, which was reset for the next enrichment target.)