### PR TITLE
Enrich Hyperbolic Dual Law of Cosines (spherical-law-of-cosines-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "slc-oq0301-ann-question",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 93
+    },
+    "type": "concept",
+    "title": "The open question and its correction",
+    "content": "OQ-01 of the spherical dual entry asked whether the clear-radicals-then-ring strategy yields the hyperbolic dual law over a Lorentzian structure, tentatively proposing the *all-hyperbolic* formula $\\cosh C = -\\cosh A\\cosh B + \\sinh A\\sinh B\\cosh c$. The answer is *yes, the strategy ports* — but the geometrically correct identity keeps the interior angles **circular**: $\\cos C = -\\cos A\\cos B + \\sin A\\sin B\\cosh c$, with only the included side becoming hyperbolic. A hyperbolic triangle's angles are ordinary Euclidean angles in $[0,\\pi]$, realised as the angle between the two *spacelike* edge normals $u\\boxtimes v,\\ u\\boxtimes w$ at a vertex; their Lorentzian inner product $\\sinh b\\,\\sinh c\\,\\cos A$ and norms $\\sinh b,\\sinh c$ give a genuine $\\cos A$ with $|\\cos A|\\le 1$. Replacing it by $\\cosh A$ would demand an unbounded angle and does not match the algebra the Minkowski structure produces.",
+    "mathContext": "$\\cos C = -\\cos A\\,\\cos B + \\sin A\\,\\sin B\\,\\cosh c \\quad(\\text{not } \\cosh C = -\\cosh A\\cosh B + \\sinh A\\sinh B\\cosh c).$",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic geometry", "dual law of cosines", "interior angles as Euclidean angles", "spherical–hyperbolic duality", "a ↦ ia metric substitution"],
+    "prerequisites": ["spherical dual law of cosines", "hyperboloid model of H²", "non-Euclidean trigonometry"]
+  },
+  {
+    "id": "slc-oq0301-ann-toolkit",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 127
+    },
+    "type": "definition",
+    "title": "Part I — the Lorentzian inner/cross/triple products",
+    "content": "The three-field structure `V` carries the Minkowski form of signature $(+,+,-)$, with the $z$-axis timelike. `mdot u v = u_x v_x + u_y v_y - u_z v_z` is the Lorentzian inner product; `mcross u v` is the Lorentzian cross product, the unique vector with $\\langle u\\boxtimes v, w\\rangle = \\det(u,v,w)$ (its timelike component is negated relative to the Euclidean cross product); and `mtriple u v w = mdot u (mcross v w) = det(u,v,w)` is the scalar triple product. Working over an explicit struct (rather than `EuclideanSpace`) is what keeps every later proof radical-free and `ring`-closable.",
+    "mathContext": "$\\langle u,v\\rangle = u_x v_x + u_y v_y - u_z v_z, \\qquad \\langle u\\boxtimes v, w\\rangle = \\det(u,v,w).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Minkowski space ℝ^{2,1}", "signature (+,+,−)", "Lorentzian cross product", "scalar triple product", "determinant as triple product"],
+    "prerequisites": ["bilinear forms", "cross product", "3×3 determinants"]
+  },
+  {
+    "id": "slc-oq0301-ann-gram",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 129,
+      "endLine": 174
+    },
+    "type": "technique",
+    "title": "Part II — sign-flipped Binet–Cauchy, Lagrange, and Gram algebra",
+    "content": "The pseudo-Euclidean analogues of the classical identities, each closed by pure `ring` after destructuring the vectors. The Lorentzian **Binet–Cauchy** identity reads $\\langle a\\boxtimes b, c\\boxtimes d\\rangle = \\langle a,d\\rangle\\langle b,c\\rangle - \\langle a,c\\rangle\\langle b,d\\rangle$ (pairing swapped vs. Euclidean). The **Lagrange** identity $\\langle a\\boxtimes b, a\\boxtimes b\\rangle = \\langle a,b\\rangle^2 - \\langle a,a\\rangle\\langle b,b\\rangle$ has the sign *flipped* from the Euclidean $\\|a\\|^2\\|b\\|^2-\\langle a,b\\rangle^2$ — which is exactly what makes the edge normal $u\\boxtimes v$ **spacelike**. `triple_sq` records $[uvw]^2 = -\\mathrm{Gram}(u,v,w)$: the leading minus sign is $\\det\\eta = -1$, while the Gram polynomial itself is identical to the Euclidean one.",
+    "mathContext": "$\\langle a\\boxtimes b, a\\boxtimes b\\rangle = \\langle a,b\\rangle^2 - \\langle a,a\\rangle\\langle b,b\\rangle, \\qquad [uvw]^2 = -\\mathrm{Gram}(u,v,w).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Binet–Cauchy identity", "Lagrange identity", "Gram determinant", "spacelike vectors", "ring tactic"],
+    "prerequisites": ["Gram matrices", "vector identities", "Lean ring tactic"]
+  },
+  {
+    "id": "slc-oq0301-ann-rcs",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 176,
+      "endLine": 203
+    },
+    "type": "insight",
+    "title": "Part III — reverse Cauchy–Schwarz makes the sides well-defined",
+    "content": "On the upper hyperboloid $\\{\\langle x,x\\rangle = -1,\\ x_z>0\\}$ — the model of $H^2$ — two future-directed unit timelike vectors satisfy the *reverse* Cauchy–Schwarz inequality $\\langle u,v\\rangle \\le -1$, so $\\cosh c := -\\langle u,v\\rangle \\ge 1$ is a genuine hyperbolic distance. The proof hands `nlinarith` an explicit sum-of-squares certificate $(u_x-v_x)^2 + (u_y-v_y)^2 + (u_x v_y - u_y v_x)^2 \\ge 0$, the exact dual of the spherical Cauchy–Schwarz bound $\\cos^2 c \\le 1$. Consequently `sinhc_sq_nonneg` gives $\\sinh^2 c = \\langle u,v\\rangle^2 - 1 \\ge 0$: the edge normals really are spacelike, so the side-sine denominators in the trig form are real.",
+    "mathContext": "$\\langle u,u\\rangle=\\langle v,v\\rangle=-1,\\ u_z,v_z>0 \\;\\Longrightarrow\\; \\langle u,v\\rangle\\le -1,\\quad \\cosh c=-\\langle u,v\\rangle\\ge 1.$",
+    "significance": "key",
+    "relatedConcepts": ["reverse Cauchy–Schwarz", "future-directed timelike vectors", "hyperboloid model", "sum-of-squares certificate", "well-definedness of distance"],
+    "prerequisites": ["Cauchy–Schwarz inequality", "timelike/spacelike causal structure", "nlinarith / SOS certificates"]
+  },
+  {
+    "id": "slc-oq0301-ann-poly",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 205,
+      "endLine": 264
+    },
+    "type": "theorem",
+    "title": "Parts IV–V — the polynomial heart and the cleared hyperboloid law",
+    "content": "`hyp_dual_poly` is the algebraic core, a bare polynomial identity in the side inner products $ca,cb,cc$ closed by a single `ring`: $(cc+ca\\,cb)(cc^2-1) = -(ca+cb\\,cc)(cb+ca\\,cc) - (1-ca^2-cb^2-cc^2-2\\,ca\\,cb\\,cc)\\,cc$. The factor $cc^2-1$ is $\\sinh^2 c$ and the last bracket is $[uvw]^2 = -\\mathrm{Gram}$. Compared with the spherical `dual_poly`, the Gram cross term is $-2\\,ca\\,cb\\,cc$ (vs. $+2$) and the included-side term carries an extra minus — the Lorentzian signature made explicit. `hyp_dual_law_minkowski_cleared` then instantiates this for three hyperboloid points by rewriting `triple_sq` with the $-1$ self-inner-products substituted, giving the cleared dual law with no non-degeneracy side conditions.",
+    "mathContext": "$(cc+ca\\,cb)(cc^2-1) = -(ca+cb\\,cc)(cb+ca\\,cc) - (1-ca^2-cb^2-cc^2-2\\,ca\\,cb\\,cc)\\,cc.$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial identity", "clear-radicals-then-ring", "Gram determinant", "signature sign flip", "hyperboloid triangle"],
+    "prerequisites": ["polynomial algebra", "Lean ring tactic", "Gram identities"]
+  },
+  {
+    "id": "slc-oq0301-ann-trig-cross",
+    "proofId": "spherical-law-of-cosines-oq-03-oq-01",
+    "range": {
+      "startLine": 266,
+      "endLine": 382
+    },
+    "type": "theorem",
+    "title": "Parts VI–VII — the trigonometric law and its pure cross-product form",
+    "content": "`hyp_dual_law_trig` recovers the literal $\\cos C = -\\cos A\\cos B + \\sin A\\sin B\\cosh c$ from the cleared normal-form hypotheses, division-free: the common denominator $\\sinh a\\,\\sinh b\\,\\sinh^2 c$ is removed once via `mul_right_cancel₀` and the goal closes by a single `linear_combination` against the polynomial heart. Part VII grounds the posited normal forms in actual Minkowski geometry: each angle-cosine numerator (`cosA_num`/`cosB_num`/`cosC_num`) is a Binet–Cauchy inner product of two edge normals, and each side-sine square (`sinha_sq`/`sinhb_sq`/`sinhc_sq`) is a Lagrange self-inner-product. `hyp_dual_law_cross_product_form` assembles them, re-expressing the entire dual law through Lorentzian scalar triple products and spacelike cross-product norms — all `ring`/`rw`-only.",
+    "mathContext": "$\\langle u\\boxtimes v, u\\boxtimes w\\rangle = \\sinh b\\,\\sinh c\\,\\cos A, \\qquad \\langle u\\boxtimes v, u\\boxtimes v\\rangle = \\sinh^2 c.$",
+    "significance": "key",
+    "relatedConcepts": ["trigonometric form", "linear_combination tactic", "mul_right_cancel₀", "edge normals", "scalar triple product form"],
+    "prerequisites": ["hyperbolic trigonometry", "Lean linear_combination", "Binet–Cauchy / Lagrange identities"]
+  }
+]

--- a/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/index.ts
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SphericalLawOfCosinesOQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sphericalLawOfCosinesOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sphericalLawOfCosinesOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sphericalLawOfCosinesOq03Oq01Data: ProofData = {
+  proof: sphericalLawOfCosinesOq03Oq01Proof,
+  annotations: sphericalLawOfCosinesOq03Oq01Annotations,
+}

--- a/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/meta.json
@@ -73,10 +73,17 @@
   },
   "sections": [
     {
+      "id": "module-docstring",
+      "title": "Overview: the open question and its correction",
+      "startLine": 1,
+      "endLine": 93,
+      "summary": "Module docstring stating OQ-01 of the spherical dual entry and answering it: the clear-radicals-then-ring strategy ports to a Lorentzian structure, but the geometrically correct identity is cos C = −cos A·cos B + sin A·sin B·cosh c — the interior angles stay circular, only the included side becomes hyperbolic. Corrects the open question's tentative all-hyperbolic formula."
+    },
+    {
       "id": "part1-lorentzian-toolkit",
       "title": "Part I: Minkowski Vector Toolkit",
-      "startLine": 95,
-      "endLine": 135,
+      "startLine": 104,
+      "endLine": 127,
       "summary": "The 3-field structure V with the Lorentzian inner product mdot (signature +,+,−), the Lorentzian cross product mcross, and mtriple = mdot u (mcross v w) = det(u,v,w)."
     },
     {


### PR DESCRIPTION
Enrichment pass for `spherical-law-of-cosines-oq-03-oq-01` (Hyperbolic Dual Law of Cosines, Lorentzian).

## Changes
- **Created missing `index.ts`** — without it the proof page 404s on the live site despite appearing in the gallery listing.
- **Created `annotations.json` from scratch** — none existed. 6 annotations covering all seven parts of the Lean file (the open question & its correction; Minkowski toolkit; sign-flipped Binet–Cauchy/Lagrange/Gram algebra; reverse Cauchy–Schwarz well-definedness; the polynomial heart `hyp_dual_poly`; trig + cross-product forms), each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.
- **Improved `meta.sections`** — added a module-docstring section (lines 1–93 were uncovered) and corrected Part I's line range; sections now span the full file.

Verified with `pnpm build` (gallery data + tsc typecheck pass). 0 sorries, 0 axioms; status/badge unchanged (verified/original), accurate to the Lean file.