### PR TITLE
research(angle-trisection-oq-02-oq-03-ext-oq-01): the prime 2 in Gauss–Wantzel — doubling invariance [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -137,6 +137,7 @@ import Proofs.AngleTrisectionOQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ03
 import Proofs.AngleTrisectionOQ02OQ03Ext
+import Proofs.AngleTrisectionOQ02OQ03ExtOQ01
 import Proofs.AngleTrisectionOQ02OQ03OQ01
 import Proofs.AngleTrisectionOQ02OQ04
 import Proofs.AngleTrisectionOQ02OQ04OQ01

--- a/proofs/Proofs/AngleTrisectionOQ02OQ03ExtOQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ03ExtOQ01.lean
@@ -1,0 +1,159 @@
+/-
+# Angle Trisection OQ02-OQ03 Extension — OQ01
+# The Role of the Prime 2 in the Gauss–Wantzel Arithmetic Bridge
+
+The parent file `AngleTrisectionOQ02OQ03Ext` established the arithmetic bridge
+behind Gauss–Wantzel: a regular `n`-gon is constructible iff `φ(n)` is a power
+of two, together with the *coprime* multiplicativity
+`TotientIsPow2 m → TotientIsPow2 n → Coprime m n → TotientIsPow2 (m*n)`.
+
+That multiplicativity says nothing about the prime `2` itself, because `2` is
+never coprime to an even number. This file fills exactly that gap: it isolates
+the role of the prime `2`, which classically corresponds to **angle bisection**.
+
+## Main result (the doubling invariance)
+
+  `totient_pow2_double_iff : TotientIsPow2 (2 * n) ↔ TotientIsPow2 n`
+
+Geometrically: **the regular `2n`-gon is constructible iff the regular
+`n`-gon is.** The forward direction (`2n` constructible ⇒ `n` constructible) is
+the non-obvious one — bisecting backwards is not a ruler-and-compass move, yet
+the arithmetic forces it. The reverse is the familiar bisection step.
+
+Iterating gives the **2-power invariance**
+
+  `totient_pow2_two_pow_mul_iff : TotientIsPow2 (2^a * n) ↔ TotientIsPow2 n`,
+
+so constructibility of a regular polygon depends only on the **odd part** of `n`.
+Thus the 7-gon, 14-gon, 28-gon, … are all non-constructible (no amount of
+bisection helps), while the 15-gon, 30-gon, 60-gon, … are all constructible.
+
+## Engine
+
+The two single-step totient identities for the prime `2`:
+  * `2 ∣ n  → φ(2n) = 2·φ(n)`  (`Nat.totient_mul_of_prime_of_dvd`)
+  * `2 ∤ n  → φ(2n) =   φ(n)`  (`Nat.totient_mul_of_prime_of_not_dvd`, since `2-1=1`)
+
+Results: 0 sorries, 0 axioms — fully proved.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+
+namespace AngleTrisectionOQ02OQ03ExtOQ01
+
+/-- `φ(n)` is a power of two — the Gauss–Wantzel constructibility predicate
+    (matching the parent file's `TotientIsPow2`). -/
+def TotientIsPow2 (n : ℕ) : Prop := ∃ k : ℕ, Nat.totient n = 2 ^ k
+
+-- ============================================================
+-- SECTION I: The two single-step totient identities for p = 2
+-- ============================================================
+
+/-- If `n` is even then `φ(2n) = 2·φ(n)`. -/
+theorem totient_two_mul_of_even {n : ℕ} (h : 2 ∣ n) :
+    Nat.totient (2 * n) = 2 * Nat.totient n :=
+  Nat.totient_mul_of_prime_of_dvd (by norm_num) h
+
+/-- If `n` is odd then `φ(2n) = φ(n)`. -/
+theorem totient_two_mul_of_odd {n : ℕ} (h : ¬ 2 ∣ n) :
+    Nat.totient (2 * n) = Nat.totient n := by
+  have := Nat.totient_mul_of_prime_of_not_dvd (p := 2) (n := n) (by norm_num) h
+  simpa using this
+
+-- ============================================================
+-- SECTION II: The doubling invariance
+-- ============================================================
+
+/-- **Doubling invariance.** `φ(2n)` is a power of two iff `φ(n)` is.
+
+    Geometrically: the regular `2n`-gon is constructible iff the regular
+    `n`-gon is. The reverse direction is angle bisection; the forward direction
+    is the non-trivial arithmetic converse. -/
+theorem totient_pow2_double_iff (n : ℕ) :
+    TotientIsPow2 (2 * n) ↔ TotientIsPow2 n := by
+  by_cases hd : 2 ∣ n
+  · -- even case: φ(2n) = 2·φ(n)
+    have hphi : Nat.totient (2 * n) = 2 * Nat.totient n := totient_two_mul_of_even hd
+    constructor
+    · rintro ⟨k, hk⟩
+      rw [hphi] at hk
+      -- 2·φ(n) = 2^k forces k ≥ 1 and φ(n) = 2^(k-1)
+      have hdvd2 : 2 ∣ 2 ^ k := ⟨Nat.totient n, hk.symm⟩
+      have hk1 : 1 ≤ k := by
+        rcases Nat.eq_zero_or_pos k with rfl | h
+        · simp at hdvd2
+        · exact h
+      refine ⟨k - 1, ?_⟩
+      have e : (2 : ℕ) ^ k = 2 * 2 ^ (k - 1) := by
+        conv_lhs => rw [show k = (k - 1) + 1 by omega]
+        rw [pow_succ']
+      have : 2 * Nat.totient n = 2 * 2 ^ (k - 1) := by rw [hk, e]
+      exact Nat.eq_of_mul_eq_mul_left (by norm_num) this
+    · rintro ⟨k, hk⟩
+      exact ⟨k + 1, by rw [hphi, pow_succ', hk]⟩
+  · -- odd case: φ(2n) = φ(n), so the predicate is literally unchanged
+    have hphi : Nat.totient (2 * n) = Nat.totient n := totient_two_mul_of_odd hd
+    simp only [TotientIsPow2, hphi]
+
+/-- Bisection (the easy direction): if the regular `n`-gon is constructible,
+    so is the regular `2n`-gon. -/
+theorem constructible_double {n : ℕ} (h : TotientIsPow2 n) : TotientIsPow2 (2 * n) :=
+  (totient_pow2_double_iff n).mpr h
+
+/-- Sharp converse: if the regular `2n`-gon is constructible, so is the
+    regular `n`-gon. -/
+theorem constructible_of_double {n : ℕ} (h : TotientIsPow2 (2 * n)) : TotientIsPow2 n :=
+  (totient_pow2_double_iff n).mp h
+
+-- ============================================================
+-- SECTION III: 2-power invariance and reduction to the odd part
+-- ============================================================
+
+/-- **2-power invariance.** Multiplying by any power of `2` does not change
+    constructibility: `φ(2^a · n)` is a power of two iff `φ(n)` is. -/
+theorem totient_pow2_two_pow_mul_iff (a n : ℕ) :
+    TotientIsPow2 (2 ^ a * n) ↔ TotientIsPow2 n := by
+  induction a with
+  | zero => simp only [pow_zero, one_mul]
+  | succ a ih =>
+    have hrw : 2 ^ (a + 1) * n = 2 * (2 ^ a * n) := by rw [pow_succ']; ring
+    rw [hrw, totient_pow2_double_iff, ih]
+
+/-- **Reduction to the odd part.** If `n = 2^a · m`, then the regular `n`-gon
+    is constructible iff the regular `m`-gon is. In particular constructibility
+    of a regular polygon depends only on the odd part of `n`. -/
+theorem totient_pow2_iff_odd_part {n a m : ℕ} (h : n = 2 ^ a * m) :
+    TotientIsPow2 n ↔ TotientIsPow2 m := by
+  rw [h, totient_pow2_two_pow_mul_iff]
+
+-- ============================================================
+-- SECTION IV: Consequences — whole 2-power towers, at once
+-- ============================================================
+
+/-- The regular 15-gon is constructible (`φ(15) = 8 = 2^3`). -/
+theorem totient_pow2_fifteen : TotientIsPow2 15 := ⟨3, by decide⟩
+
+/-- Every regular `2^a · 15`-gon is constructible: 15, 30, 60, 120, 240, …
+    The single arithmetic input is the 15-gon; bisection supplies the rest. -/
+theorem constructible_two_pow_mul_fifteen (a : ℕ) : TotientIsPow2 (2 ^ a * 15) :=
+  (totient_pow2_two_pow_mul_iff a 15).mpr totient_pow2_fifteen
+
+/-- The regular 7-gon is **not** constructible (`φ(7) = 6 = 2·3`, odd prime 3). -/
+theorem not_totient_pow2_seven : ¬ TotientIsPow2 7 := by
+  rintro ⟨k, hk⟩
+  have h6 : Nat.totient 7 = 6 := by decide
+  rw [h6] at hk
+  have h3 : (3 : ℕ) ∣ 2 ^ k := hk ▸ (by norm_num : (3 : ℕ) ∣ 6)
+  have : (3 : ℕ) ∣ 2 := (by norm_num : Nat.Prime 3).dvd_of_dvd_pow h3
+  norm_num at this
+
+/-- No regular `2^a · 7`-gon is constructible: 7, 14, 28, 56, … remain out of
+    reach no matter how many bisections are applied. This is the sharp content
+    of the doubling invariance — bisection can never *create* constructibility. -/
+theorem not_constructible_two_pow_mul_seven (a : ℕ) : ¬ TotientIsPow2 (2 ^ a * 7) := by
+  rw [totient_pow2_two_pow_mul_iff]
+  exact not_totient_pow2_seven
+
+end AngleTrisectionOQ02OQ03ExtOQ01

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-ext-oq-01/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "angle-trisection-oq-02-oq-03-ext-oq-01",
+  "title": "Angle Trisection OQ02-OQ03 Ext OQ01: The Prime 2 in Gauss–Wantzel — Doubling Invariance",
+  "slug": "angle-trisection-oq-02-oq-03-ext-oq-01",
+  "description": "Isolates the role of the prime 2 in the Gauss–Wantzel arithmetic bridge. Proves the doubling invariance TotientIsPow2 (2n) ↔ TotientIsPow2 n (the regular 2n-gon is constructible iff the n-gon is), its 2-power generalization TotientIsPow2 (2^a·n) ↔ TotientIsPow2 n, and reduction to the odd part. Consequences: every 2^a·15-gon is constructible; no 2^a·7-gon ever is. 11 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-1",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ03ExtOQ01.lean",
+    "tags": [
+      "constructibility",
+      "angle-trisection",
+      "gauss-wantzel",
+      "totient",
+      "number-theory",
+      "regular-polygon",
+      "bisection"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 11,
+    "assumptions": "None. All 11 theorems proved, 0 axioms. Verified axiom-free: #print axioms reports only propext, Classical.choice, Quot.sound (decide uses kernel reduction, not native_decide, so no Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_mul_of_prime_of_dvd",
+        "description": "φ(p·n) = p·φ(n) when p prime and p ∣ n (with p = 2: φ(2n) = 2φ(n) for even n)",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_mul_of_prime_of_not_dvd",
+        "description": "φ(p·n) = (p-1)·φ(n) when p prime and p ∤ n (with p = 2: φ(2n) = φ(n) for odd n)",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_of_dvd_pow",
+        "description": "A prime dividing a power divides the base (used for the 7-gon non-constructibility)",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "By Gauss–Wantzel, a regular n-gon is constructible with ruler and compass iff φ(n) is a power of 2, equivalently iff n = 2^a × (product of distinct Fermat primes). The factor 2^a in this characterization reflects that angle bisection — halving an arc, the most elementary ruler-and-compass operation — turns a constructible n-gon into a constructible 2n-gon. The parent extension file established the arithmetic bridge φ(n)=2^k ↔ constructibility together with multiplicativity of TotientIsPow2 across COPRIME factors. That coprime statement is silent about the prime 2 itself, since 2 is never coprime to an even number. This file supplies exactly the missing prime-2 case.",
+    "problemStatement": "Determine how the prime 2 acts on the Gauss–Wantzel predicate TotientIsPow2 n := (∃ k, φ(n) = 2^k). Prove: (1) TotientIsPow2 (2n) ↔ TotientIsPow2 n (doubling invariance); (2) TotientIsPow2 (2^a·n) ↔ TotientIsPow2 n (2-power invariance); (3) constructibility depends only on the odd part of n; (4) explicit infinite families that are always / never constructible.",
+    "proofStrategy": "Two single-step totient identities for p=2 drive everything: for even n, φ(2n)=2φ(n) (Nat.totient_mul_of_prime_of_dvd); for odd n, φ(2n)=φ(n) (Nat.totient_mul_of_prime_of_not_dvd, since 2-1=1). The doubling iff splits on parity: odd n makes the predicate literally unchanged; even n requires the arithmetic step 2·φ(n)=2^k ⟹ k≥1 ∧ φ(n)=2^(k-1) (the non-obvious forward direction). The 2-power invariance is induction on a using 2^(a+1)·n = 2·(2^a·n). Reduction to the odd part is a direct corollary. Families: a single base computation (φ(15)=2^3, φ(7)=2·3) is propagated across all 2-power multiples by the invariance.",
+    "keyInsights": [
+      "**Doubling invariance**: TotientIsPow2 (2n) ↔ TotientIsPow2 n. The reverse direction is angle bisection (n-gon ⇒ 2n-gon); the forward direction (2n-gon ⇒ n-gon) is the arithmetically forced converse — bisection can never *create* constructibility where there was none.",
+      "**The prime 2 splits by parity**: φ(2n) equals 2φ(n) for even n but only φ(n) for odd n. Both cases nonetheless preserve the power-of-2 property, which is why the prime 2 is 'free' in the Gauss–Wantzel criterion and only the odd part of n matters.",
+      "**Reduction to the odd part**: writing n = 2^a·m collapses constructibility of the n-gon to that of the m-gon. This complements the parent's coprime multiplicativity — together they reduce the whole criterion to odd prime powers.",
+      "**Infinite families from one computation**: φ(15)=8 gives that every 2^a·15-gon (15,30,60,120,…) is constructible; φ(7)=6 has the odd prime factor 3, so no 2^a·7-gon (7,14,28,56,…) is ever constructible, regardless of how many bisections are applied."
+    ]
+  },
+  "sections": [
+    {
+      "id": "single-step",
+      "title": "Section I: The two single-step totient identities for p = 2",
+      "startLine": 47,
+      "endLine": 64,
+      "summary": "totient_two_mul_of_even: 2∣n ⟹ φ(2n)=2φ(n). totient_two_mul_of_odd: 2∤n ⟹ φ(2n)=φ(n). Thin wrappers over Mathlib's prime-multiplicativity lemmas specialized to p=2.",
+      "mathContext": "For even $n$: $\\varphi(2n)=2\\varphi(n)$. For odd $n$: $\\varphi(2n)=\\varphi(n)$ since $2-1=1$."
+    },
+    {
+      "id": "doubling",
+      "title": "Section II: The doubling invariance",
+      "startLine": 65,
+      "endLine": 108,
+      "summary": "totient_pow2_double_iff: TotientIsPow2 (2n) ↔ TotientIsPow2 n, by parity case split. constructible_double (bisection, mpr) and constructible_of_double (sharp converse, mp).",
+      "mathContext": "Even case forward: $2\\varphi(n)=2^k \\Rightarrow k\\geq 1 \\wedge \\varphi(n)=2^{k-1}$. Odd case: predicate is literally unchanged."
+    },
+    {
+      "id": "two-power",
+      "title": "Section III: 2-power invariance and reduction to the odd part",
+      "startLine": 109,
+      "endLine": 132,
+      "summary": "totient_pow2_two_pow_mul_iff: TotientIsPow2 (2^a·n) ↔ TotientIsPow2 n by induction on a. totient_pow2_iff_odd_part: if n=2^a·m then TotientIsPow2 n ↔ TotientIsPow2 m.",
+      "mathContext": "Induction step uses $2^{a+1}\\cdot n = 2\\cdot(2^a\\cdot n)$ and the doubling iff."
+    },
+    {
+      "id": "families",
+      "title": "Section IV: Consequences — whole 2-power towers at once",
+      "startLine": 133,
+      "endLine": 159,
+      "summary": "totient_pow2_fifteen (φ(15)=2^3) ⟹ constructible_two_pow_mul_fifteen: every 2^a·15-gon constructible. not_totient_pow2_seven (φ(7)=6, odd prime 3) ⟹ not_constructible_two_pow_mul_seven: no 2^a·7-gon constructible.",
+      "mathContext": "$15,30,60,120,\\dots$ all constructible; $7,14,28,56,\\dots$ none constructible."
+    }
+  ],
+  "conclusion": {
+    "summary": "The role of the prime 2 in the Gauss–Wantzel arithmetic bridge is isolated and fully formalized: 11 theorems, 1 definition, 0 sorries, 0 axioms. The central result is the doubling invariance TotientIsPow2 (2n) ↔ TotientIsPow2 n, generalized to all 2-power multiples and reduced to the odd part of n.",
+    "implications": "Together with the parent file's coprime multiplicativity, this reduces Gauss–Wantzel constructibility entirely to odd prime powers: the prime 2 is 'free'. The invariance also explains the infinite-family structure of the constructible/non-constructible lists — each is generated by an odd base computation propagated through bisection.",
+    "openQuestions": [
+      "Combine the doubling invariance with the parent's odd-prime-factor analysis to derive the full TotientIsPow2 n ↔ (n = 2^a × distinct Fermat primes) characterization as a single biconditional.",
+      "Is TotientIsPow2 decidable with an explicit Bool decision procedure that operates only on the odd part (avoiding factoring out 2^a by repeated halving)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "AngleTrisectionOQ02OQ03ExtOQ01",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/AngleTrisectionOQ02OQ03ExtOQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-03-ext",
+      "relationship": "extends",
+      "description": "Parent extension established the φ(n)=2^k arithmetic bridge and COPRIME multiplicativity of TotientIsPow2; this file fills the missing prime-2 case via the doubling invariance"
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-03",
+      "relationship": "ancestor",
+      "description": "OQ02-OQ03 introduced the TotientIsPow2 predicate this file analyzes under multiplication by 2"
+    },
+    {
+      "targetId": "angle-trisection-oq-02",
+      "relationship": "related",
+      "description": "OQ02 characterizes constructibility via [ℚ(cos 2π/n):ℚ] being a power of 2; the doubling invariance is the arithmetic shadow of the angle-bisection construction"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "totient_pow2_double_iff",
+      "type": "core",
+      "statement": "∀ n, TotientIsPow2 (2 * n) ↔ TotientIsPow2 n",
+      "description": "Doubling invariance: the regular 2n-gon is constructible iff the regular n-gon is.",
+      "significance": "Isolates the prime 2 in the Gauss–Wantzel criterion; the forward direction is the non-obvious arithmetic converse of angle bisection"
+    },
+    {
+      "name": "totient_pow2_two_pow_mul_iff",
+      "type": "core",
+      "statement": "∀ a n, TotientIsPow2 (2^a * n) ↔ TotientIsPow2 n",
+      "description": "Constructibility of a regular polygon depends only on the odd part of n.",
+      "significance": "Reduces Gauss–Wantzel to odd prime powers when combined with coprime multiplicativity"
+    },
+    {
+      "name": "not_constructible_two_pow_mul_seven",
+      "type": "corollary",
+      "statement": "∀ a, ¬ TotientIsPow2 (2^a * 7)",
+      "description": "No 2^a·7-gon (7, 14, 28, 56, …) is constructible — bisection never helps.",
+      "significance": "Sharp illustration: bisection cannot create constructibility"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-ext-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-ext-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "angle-trisection-oq-02-oq-03-ext-oq-01",
-  "title": "Angle Trisection OQ02-OQ03 Extension: Gauss-Wantzel Arithmetic Bridge — OQ extension (01)",
-  "phase": "NEW",
-  "status": "active",
+  "title": "Angle Trisection OQ02-OQ03 Extension: Gauss-Wantzel Arithmetic Bridge \u2014 OQ extension (01)",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: Angle Trisection OQ02-OQ03 Extension: Gauss-Wantzel Arithmetic Bridge — OQ extension (01).",
+    "plain": "Formal mathematical investigation: Angle Trisection OQ02-OQ03 Extension: Gauss-Wantzel Arithmetic Bridge \u2014 OQ extension (01).",
     "whyMatters": [
       "Research value"
     ]
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-05-29T19:14:09.202Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Doubling invariance of TotientIsPow2 \u2014 shipped PR #29331.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None \u2014 solved, 0 sorries / 0 axioms.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -31,11 +31,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Isolated the role of the prime 2 in the Gauss\u2013Wantzel arithmetic bridge: proved TotientIsPow2 (2n) \u2194 TotientIsPow2 n and its 2-power generalization, reducing constructibility to the odd part of n. 11 thm / 1 def / 159L, verified 0-axiom. PR #29331.",
+    "builtItems": [
+      "AngleTrisectionOQ02OQ03ExtOQ01.lean: 11 theorems, 1 definition, 0 sorries, 0 axioms (verified)",
+      "totient_pow2_double_iff: TotientIsPow2 (2n) \u2194 TotientIsPow2 n (doubling invariance)",
+      "totient_pow2_two_pow_mul_iff: TotientIsPow2 (2^a\u00b7n) \u2194 TotientIsPow2 n (reduction to odd part)",
+      "not_constructible_two_pow_mul_seven / constructible_two_pow_mul_fifteen: infinite families"
+    ],
+    "insights": [
+      "The prime 2 splits \u03c6(2n) by parity: 2\u03c6(n) for even n, \u03c6(n) for odd n (Nat.totient_mul_of_prime_of_{dvd,not_dvd}); both preserve the power-of-2 property, so 2 is 'free' in Gauss\u2013Wantzel.",
+      "Doubling iff forward direction is the non-trivial one: from 2\u03c6(n)=2^k deduce k\u22651 and \u03c6(n)=2^(k-1); reverse is angle bisection.",
+      "Constructibility of a regular n-gon depends only on the odd part of n; combined with the parent's coprime multiplicativity this reduces the whole criterion to odd prime powers.",
+      "Bisection can never create constructibility: a single odd-base computation (\u03c6(7)=2\u00b73, \u03c6(15)=2^3) propagates to all 2^a multiples via the invariance."
+    ],
+    "mathlibGaps": [
+      "No direct doubling/2-power-invariance lemma for the power-of-2-totient predicate in Mathlib; built from the prime-multiplicativity totient lemmas."
+    ],
+    "nextSteps": [
+      "Assemble TotientIsPow2 n \u2194 (n = 2^a \u00d7 distinct Fermat primes) as a single biconditional using this invariance + the parent's odd-prime-factor / Fermat analysis.",
+      "Explicit Bool decision procedure operating only on the odd part."
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Isolates the role of the **prime 2** in the Gauss–Wantzel arithmetic bridge — the case the parent extension (`angle-trisection-oq-02-oq-03-ext`) left open. The parent proved multiplicativity of `TotientIsPow2` across **coprime** factors, which is silent about the prime 2 since 2 is never coprime to an even number. This file fills exactly that gap.

`TotientIsPow2 n := ∃ k, φ(n) = 2^k` is the Gauss–Wantzel constructibility predicate (the regular n-gon is ruler-and-compass constructible iff `φ(n)` is a power of 2).

## Main results (11 theorems, 1 def, 159 lines, 0 sorries, 0 axioms)

- **`totient_pow2_double_iff`** — `TotientIsPow2 (2n) ↔ TotientIsPow2 n`. Geometrically: the regular **2n-gon is constructible iff the n-gon is**. The reverse direction is angle bisection; the forward direction (`2n` constructible ⇒ `n` constructible) is the non-obvious arithmetically-forced converse.
- **`totient_pow2_two_pow_mul_iff`** — `TotientIsPow2 (2^a·n) ↔ TotientIsPow2 n`: constructibility depends only on the **odd part** of n.
- **`totient_pow2_iff_odd_part`** — reduction to the odd part (`n = 2^a·m`).
- **Families from one computation**: every `2^a·15`-gon (15, 30, 60, 120, …) is constructible; **no** `2^a·7`-gon (7, 14, 28, 56, …) is ever constructible — bisection can never *create* constructibility.

## Engine

The two single-step totient identities for `p = 2`:
- even `n`: `φ(2n) = 2φ(n)` (`Nat.totient_mul_of_prime_of_dvd`)
- odd `n`: `φ(2n) = φ(n)` (`Nat.totient_mul_of_prime_of_not_dvd`, since `2-1=1`)

The doubling iff is a parity case split (odd ⇒ predicate literally unchanged; even ⇒ the step `2φ(n)=2^k ⇒ k≥1 ∧ φ(n)=2^{k-1}`); the 2-power invariance is induction on `a` via `2^{a+1}·n = 2·(2^a·n)`.

## Verification

Compiled with `lake env lean` against Mathlib. `#print axioms` on the main theorems reports only `propext, Classical.choice, Quot.sound` — **axiom-free** (`decide` uses kernel reduction, no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)