### PR TITLE
research(dini-theorem-oq-01-oq-01): monotonicity in n is necessary — moving-bump witness [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -970,6 +970,7 @@ import Proofs.DiamondImpliesCH
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
 import Proofs.DiniTheorem
+import Proofs.DiniTheoremOQ01OQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ01OQ01

--- a/proofs/Proofs/DiniTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/DiniTheoremOQ01OQ01.lean
@@ -1,0 +1,182 @@
+import Mathlib
+
+/-!
+# Dini's Theorem: monotonicity in `n` is necessary (a moving-bump witness)
+
+**Dini's theorem.** If `Fₙ` is a *monotone* sequence of continuous real-valued functions on a
+compact space, converging pointwise to a continuous limit `f`, then the convergence is in fact
+*uniform*.
+
+The parent entry (`DiniTheorem.lean`) re-exports Dini's theorem from Mathlib and supplies two
+sharpness witnesses built from `xⁿ`:
+
+* **continuity of the limit is necessary** — `xⁿ` on `[0,1]`, whose pointwise limit jumps at
+  `x = 1`;
+* **compactness of the domain is necessary** — `xⁿ` on `[0,1)`.
+
+This entry completes the trilogy by addressing the *third* hypothesis, which the parent's open
+question singles out: **monotonicity in `n` is necessary**. We exhibit a smooth **moving bump**
+
+```
+  Fₙ(x) = n · x · exp(−n · x)
+```
+
+on the compact interval `[0,1]`. Each `Fₙ` is continuous; the sequence converges pointwise to the
+continuous function `0`; the domain is compact — yet the convergence is **not** uniform. The bump
+peaks at `x = 1/n` with height `Fₙ(1/n) = e⁻¹`, which travels left toward `0` as `n → ∞` without
+shrinking in height, so `sup_x |Fₙ(x)|` stays `≥ e⁻¹`. Since the only Dini hypothesis that fails is
+monotonicity (we verify the family is, concretely, neither monotone nor antitone in `n` at
+`x = 1/2`), monotonicity cannot be dropped.
+
+This is the smooth analogue of the classical "moving triangular bump"; using `n x e^{−n x}` instead
+of a piecewise-linear tent keeps continuity a one-liner (`fun_prop`) and reduces the pointwise limit
+to the standard fact `t · e^{−t} → 0`.
+-/
+
+open Filter Topology Set
+
+namespace DiniTheoremOQ01OQ01
+
+/-- The moving bump `Fₙ(x) = n · x · exp(−n · x)`. It peaks at `x = 1/n` with height `e⁻¹`. -/
+noncomputable def bump (n : ℕ) (x : ℝ) : ℝ := (n : ℝ) * x * Real.exp (-((n : ℝ) * x))
+
+/-! ## The bump satisfies all of Dini's hypotheses except monotonicity -/
+
+/-- Each `Fₙ` is continuous. -/
+theorem bump_continuous (n : ℕ) : Continuous (bump n) := by
+  unfold bump; fun_prop
+
+/-- **Pointwise convergence.** For every `x ≥ 0`, `Fₙ(x) → 0`. For `x = 0` the sequence is constantly
+`0`; for `x > 0` we substitute `t = n·x → ∞` into the standard limit `t·e^{−t} → 0`. -/
+theorem bump_tendsto_zero {x : ℝ} (hx : 0 ≤ x) :
+    Tendsto (fun n : ℕ => bump n x) atTop (𝓝 0) := by
+  rcases hx.eq_or_lt with h0 | hpos
+  · subst h0
+    simp only [bump, mul_zero, zero_mul]
+    exact tendsto_const_nhds
+  · have hto : Tendsto (fun n : ℕ => (n : ℝ) * x) atTop atTop :=
+      tendsto_natCast_atTop_atTop.atTop_mul_const hpos
+    simpa only [bump, Function.comp, pow_one] using
+      (Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero 1).comp hto
+
+/-- The pointwise limit `0` is continuous (the limit-continuity hypothesis of Dini holds). -/
+theorem zero_continuous : Continuous (fun _ : ℝ => (0 : ℝ)) := continuous_const
+
+/-- The domain `[0,1]` is compact (the compactness hypothesis of Dini holds). -/
+theorem domain_isCompact : IsCompact (Icc (0 : ℝ) 1) := isCompact_Icc
+
+/-! ## Two numeric facts about `exp(1/2)` -/
+
+/-- `exp(1/2) < 2`, since `exp(1/2)² = exp 1 < 2.72 < 4`. -/
+theorem exp_half_lt_two : Real.exp (1 / 2) < 2 := by
+  have h := Real.exp_one_lt_d9
+  have hsq : Real.exp (1 / 2) * Real.exp (1 / 2) = Real.exp 1 := by
+    rw [← Real.exp_add]; norm_num
+  have hpos : 0 < Real.exp (1 / 2) := Real.exp_pos _
+  nlinarith [h, hsq, hpos]
+
+/-- `3/2 < exp(1/2)`, directly from `1 + x < exp x`. -/
+theorem three_half_lt_exp_half : (3 : ℝ) / 2 < Real.exp (1 / 2) := by
+  have h := Real.add_one_lt_exp (x := (1 / 2 : ℝ)) (by norm_num)
+  linarith
+
+/-! ## The bump is non-monotone in `n` at `x = 1/2` -/
+
+/-- `F₁(1/2) = (1/2)·e^{−1/2}`. -/
+theorem bump_one_eval : bump 1 (1 / 2 : ℝ) = (1 / 2) * Real.exp (-(1 / 2)) := by
+  unfold bump; norm_num
+
+/-- `F₂(1/2) = e^{−1}` (the bump peaks here: `1/2 = 1/n` with `n = 2`). -/
+theorem bump_two_eval : bump 2 (1 / 2 : ℝ) = Real.exp (-1) := by
+  unfold bump; norm_num
+
+/-- `F₃(1/2) = (3/2)·e^{−3/2}`. -/
+theorem bump_three_eval : bump 3 (1 / 2 : ℝ) = (3 / 2) * Real.exp (-(3 / 2)) := by
+  unfold bump; norm_num
+
+/-- The sequence *rises* from `n = 1` to `n = 2` at `x = 1/2`: `F₁(1/2) < F₂(1/2)`. -/
+theorem bump_one_lt_two : bump 1 (1 / 2 : ℝ) < bump 2 (1 / 2 : ℝ) := by
+  rw [bump_one_eval, bump_two_eval]
+  have f1 : Real.exp (-(1 / 2)) * Real.exp 1 = Real.exp (1 / 2) := by
+    rw [← Real.exp_add]; norm_num
+  have f2 : Real.exp (-1 : ℝ) * Real.exp 1 = 1 := by
+    rw [← Real.exp_add]; norm_num
+  nlinarith [f1, f2, exp_half_lt_two, Real.exp_pos (1 : ℝ),
+    Real.exp_pos (-(1 / 2) : ℝ), Real.exp_pos (-1 : ℝ)]
+
+/-- The sequence *falls* from `n = 2` to `n = 3` at `x = 1/2`: `F₃(1/2) < F₂(1/2)`. -/
+theorem bump_three_lt_two : bump 3 (1 / 2 : ℝ) < bump 2 (1 / 2 : ℝ) := by
+  rw [bump_three_eval, bump_two_eval]
+  have g1 : Real.exp (-(3 / 2)) * Real.exp (3 / 2) = 1 := by
+    rw [← Real.exp_add]; norm_num
+  have g2 : Real.exp (-1 : ℝ) * Real.exp (3 / 2) = Real.exp (1 / 2) := by
+    rw [← Real.exp_add]; norm_num
+  nlinarith [g1, g2, three_half_lt_exp_half, Real.exp_pos (3 / 2 : ℝ),
+    Real.exp_pos (-(3 / 2) : ℝ), Real.exp_pos (-1 : ℝ)]
+
+/-- **Non-monotonicity.** At `x = 1/2` the sequence `n ↦ Fₙ(1/2)` is neither monotone (it falls
+`2 → 3`) nor antitone (it rises `1 → 2`). This is exactly the Dini hypothesis that fails. -/
+theorem bump_not_monotone :
+    ¬ Monotone (fun n : ℕ => bump n (1 / 2)) ∧ ¬ Antitone (fun n : ℕ => bump n (1 / 2)) := by
+  constructor
+  · intro hmono
+    have h := hmono (show (2 : ℕ) ≤ 3 by norm_num)
+    have := bump_three_lt_two
+    simp only at h
+    linarith
+  · intro hanti
+    have h := hanti (show (1 : ℕ) ≤ 2 by norm_num)
+    have := bump_one_lt_two
+    simp only at h
+    linarith
+
+/-! ## Yet the convergence is not uniform -/
+
+/-- **Sharpness witness (monotonicity in `n` is necessary).** On the compact interval `[0,1]` the
+moving bump `Fₙ(x) = n·x·e^{−n·x}` is continuous, converges pointwise to the continuous function `0`,
+and the domain is compact — all of Dini's hypotheses except monotonicity. Yet it does **not**
+converge uniformly: for every `n ≥ 1` the point `x = 1/n` lies in `[0,1]` and `Fₙ(1/n) = e⁻¹ > 1/3`,
+so the uniform error never drops below `1/3`. -/
+theorem bump_not_tendstoUniformlyOn :
+    ¬ TendstoUniformlyOn bump (fun _ => (0 : ℝ)) atTop (Icc (0 : ℝ) 1) := by
+  rw [Metric.tendstoUniformlyOn_iff]
+  push_neg
+  refine ⟨1 / 3, by norm_num, ?_⟩
+  rw [Filter.frequently_atTop]
+  intro N
+  refine ⟨N + 1, le_self_add, ?_⟩
+  have hmpos : (0 : ℝ) < ((N + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos N
+  have hmge : (1 : ℝ) ≤ ((N + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_le_succ (Nat.zero_le N)
+  -- the travelling peak `x = 1/(N+1)` lies in `[0,1]` and has height `e⁻¹`
+  refine ⟨1 / ((N + 1 : ℕ) : ℝ), ⟨by positivity, ?_⟩, ?_⟩
+  · rw [div_le_one hmpos]; exact hmge
+  · have hval : bump (N + 1) (1 / ((N + 1 : ℕ) : ℝ)) = Real.exp (-1) := by
+      have hcancel : ((N + 1 : ℕ) : ℝ) * (1 / ((N + 1 : ℕ) : ℝ)) = 1 := by
+        field_simp
+      unfold bump
+      rw [hcancel, one_mul]
+    rw [hval, Real.dist_eq, zero_sub, abs_neg, abs_of_pos (Real.exp_pos _)]
+    -- remaining goal: `1/3 ≤ exp(-1)`, equivalently `exp 1 < 3`
+    have hpos := Real.exp_pos (1 : ℝ)
+    have hpos' := Real.exp_pos (-1 : ℝ)
+    have h3 : Real.exp 1 < 3 := by nlinarith [Real.exp_one_lt_d9]
+    have hmul : Real.exp (-1 : ℝ) * Real.exp 1 = 1 := by
+      rw [← Real.exp_add]; norm_num
+    nlinarith [hmul, h3, hpos, hpos', mul_pos hpos' (by linarith : (0 : ℝ) < 3 - Real.exp 1)]
+
+/-! ## Capstone: all Dini hypotheses but monotonicity, no uniform convergence -/
+
+/-- **The moving bump is a complete sharpness witness for the monotonicity hypothesis of Dini's
+theorem.** Every hypothesis holds except monotonicity in `n`, and uniform convergence fails. -/
+theorem bump_witness :
+    (∀ n, Continuous (bump n)) ∧
+      (∀ x ∈ Icc (0 : ℝ) 1, Tendsto (fun n => bump n x) atTop (𝓝 0)) ∧
+      Continuous (fun _ : ℝ => (0 : ℝ)) ∧
+      IsCompact (Icc (0 : ℝ) 1) ∧
+      ¬ Monotone (fun n : ℕ => bump n (1 / 2)) ∧
+      ¬ Antitone (fun n : ℕ => bump n (1 / 2)) ∧
+      ¬ TendstoUniformlyOn bump (fun _ => (0 : ℝ)) atTop (Icc (0 : ℝ) 1) :=
+  ⟨bump_continuous, fun _ hx => bump_tendsto_zero hx.1, zero_continuous, domain_isCompact,
+    bump_not_monotone.1, bump_not_monotone.2, bump_not_tendstoUniformlyOn⟩
+
+end DiniTheoremOQ01OQ01

--- a/src/data/proofs/dini-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "dini-theorem-oq-01-oq-01",
+  "title": "Dini's Theorem: Monotonicity in n Is Necessary (a Moving-Bump Witness)",
+  "slug": "dini-theorem-oq-01-oq-01",
+  "description": "Dini's theorem upgrades pointwise convergence of a monotone sequence of continuous functions on a compact space to uniform convergence. The parent entry re-exports Dini's theorem from Mathlib and supplies two sharpness witnesses built from xⁿ — one showing continuity of the limit is necessary, one showing compactness of the domain is necessary. This entry completes the trilogy by addressing the third hypothesis singled out in the parent's open question: monotonicity in n is necessary. The witness is a smooth moving bump Fₙ(x) = n·x·exp(−n·x) on the compact interval [0,1]. Each Fₙ is continuous, the sequence converges pointwise to the continuous function 0, and the domain is compact — every Dini hypothesis holds except monotonicity. Yet the convergence is not uniform: the bump peaks at x = 1/n with height Fₙ(1/n) = e⁻¹, a peak that travels toward 0 without shrinking, so the supremum error stays ≥ e⁻¹ > 1/3. We confirm the family is genuinely non-monotone (at x = 1/2 it rises 1→2 and falls 2→3, hence neither monotone nor antitone in n), so the only failing hypothesis is monotonicity. Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Ulisse Dini (1878); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DiniTheoremOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "real-analysis",
+      "uniform-convergence",
+      "compactness",
+      "monotonicity",
+      "counterexample",
+      "exponential",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero",
+        "description": "tᵏ·exp(−t) → 0 as t → ∞; with k = 1 it gives the pointwise limit Fₙ(x) = (n·x)·exp(−n·x) → 0 after substituting t = n·x → ∞",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      },
+      {
+        "theorem": "Tendsto.atTop_mul_const",
+        "description": "n·x → ∞ for fixed x > 0, the inner substitution feeding the t·e^{−t} limit",
+        "module": "Mathlib.Order.Filter.AtTopBot.Field"
+      },
+      {
+        "theorem": "Real.add_one_lt_exp",
+        "description": "1 + x < exp x for x ≠ 0; gives the lower bound 3/2 < exp(1/2) used in the non-monotonicity computation",
+        "module": "Mathlib.Analysis.Complex.Exponential"
+      },
+      {
+        "theorem": "Real.exp_one_lt_d9",
+        "description": "exp 1 < 2.7182818286; gives exp(1/2) < 2 (since exp(1/2)² = exp 1 < 4) and e⁻¹ > 1/3, the numeric facts behind non-monotonicity and the e⁻¹ peak height",
+        "module": "Mathlib.Analysis.Complex.ExponentialBounds"
+      },
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "The ε–N characterization of uniform convergence; negated to exhibit the travelling peak x = 1/n where the error stays ≥ 1/3",
+        "module": "Mathlib.Topology.UniformSpace.UniformConvergence"
+      }
+    ],
+    "originalContributions": [
+      "bump: the smooth moving bump Fₙ(x) = n·x·exp(−n·x) on [0,1], peaking at x = 1/n with height e⁻¹ — a smooth analogue of the classical moving triangular tent that keeps continuity a one-line fun_prop",
+      "bump_tendsto_zero: Fₙ(x) → 0 pointwise for every x ≥ 0, via substituting t = n·x → ∞ into the standard limit t·e^{−t} → 0 (the x = 0 case is the constant 0 sequence)",
+      "exp_half_lt_two / three_half_lt_exp_half: the two numeric facts 3/2 < exp(1/2) < 2 isolating where the bump rises then falls",
+      "bump_one_lt_two / bump_three_lt_two: at x = 1/2 the sequence rises F₁ < F₂ and then falls F₃ < F₂, computed from the exp bounds",
+      "bump_not_monotone: the family n ↦ Fₙ(1/2) is neither monotone nor antitone — the Dini hypothesis that fails, verified concretely rather than asserted",
+      "bump_not_tendstoUniformlyOn: SHARPNESS WITNESS #3 — Fₙ on the compact [0,1] is continuous, converges pointwise to the continuous limit 0, and lives on a compact domain, yet is NOT uniformly convergent because for every n ≥ 1 the travelling peak x = 1/n gives Fₙ(1/n) = e⁻¹ > 1/3, so the supremum error never drops below 1/3. Shows monotonicity in n cannot be dropped. Not in Mathlib",
+      "bump_witness: the capstone bundling all Dini hypotheses except monotonicity together with the failure of uniform convergence, certifying the bump is an honest counterexample"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 182,
+    "theoremCount": 14,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Dini's theorem (1878) is the canonical instance of a pointwise hypothesis being promoted to a uniform conclusion under monotonicity and compactness. Every first analysis course pairs it with the counterexamples that show each hypothesis is load-bearing: xⁿ on [0,1] (discontinuous limit) and on [0,1) (non-compact domain). The third hypothesis — monotonicity in the index n — is the subtlest, and the textbook witness is a 'moving bump' that travels across the interval without shrinking. The parent gallery entry formalized the first two witnesses and explicitly asked for the third.",
+    "problemStatement": "Can monotonicity's necessity in Dini's theorem be formalized with a single honest witness: a sequence of continuous functions on a compact interval, converging pointwise to a continuous limit, that fails to converge uniformly purely because it is non-monotone in n?\n\n**Answer:** Yes. The smooth moving bump Fₙ(x) = n·x·exp(−n·x) on [0,1] is continuous in x, converges pointwise to 0 (a continuous limit) on the compact [0,1], and is verifiably non-monotone in n — yet its travelling peak Fₙ(1/n) = e⁻¹ keeps the uniform error ≥ e⁻¹ > 1/3 forever, so convergence is not uniform.",
+    "text": "A formalized sharpness witness for the monotonicity hypothesis of Dini's theorem: the moving bump n·x·e^{−n·x} on [0,1] satisfies every Dini hypothesis except monotonicity in n and fails to converge uniformly. Verified in Lean with no axioms.",
+    "proofStrategy": "1. bump_continuous: n·x·exp(−n·x) is continuous by fun_prop.\n2. bump_tendsto_zero: for x = 0 the sequence is constantly 0; for x > 0, n·x → ∞ (Tendsto.atTop_mul_const) and t·e^{−t} → 0 (Real.tendsto_pow_mul_exp_neg_atTop_nhds_zero with k = 1) compose to give Fₙ(x) → 0.\n3. exp_half_lt_two: exp(1/2)² = exp 1 < 2.72 < 4 with exp(1/2) > 0 gives exp(1/2) < 2 (nlinarith). three_half_lt_exp_half: 1 + 1/2 < exp(1/2) directly from add_one_lt_exp.\n4. bump_one_lt_two / bump_three_lt_two: evaluate F₁(1/2) = (1/2)e^{−1/2}, F₂(1/2) = e^{−1}, F₃(1/2) = (3/2)e^{−3/2}; clearing the exponentials with exp_add reduces the two inequalities to exp(1/2) < 2 and 3/2 < exp(1/2) (nlinarith).\n5. bump_not_monotone: F₁ < F₂ refutes antitonicity, F₃ < F₂ refutes monotonicity.\n6. bump_not_tendstoUniformlyOn: unfold uniform convergence metrically and push the negation; for ε = 1/3 and every n, the point x = 1/n ∈ [0,1] gives Fₙ(1/n) = e⁻¹, and e⁻¹ > 1/3 because exp 1 < 3.\n7. bump_witness: bundle (1)–(6).",
+    "keyInsights": [
+      "**The third hypothesis is the subtle one.** Continuity-of-limit and compactness each fail via a *static* obstruction (a fixed jump, a fixed escaping point). Monotonicity fails via a *moving* one: the bump's peak slides toward 0 while keeping constant height e⁻¹, so no single point witnesses non-uniformity — the witness is the travelling family x = 1/n.",
+      "**A smooth bump beats a triangular tent in Lean.** Replacing the piecewise-linear tent of the textbook with n·x·e^{−n·x} makes continuity a one-line fun_prop and reduces pointwise convergence to the off-the-shelf limit t·e^{−t} → 0, avoiding all piecewise/absolute-value case analysis.",
+      "**Non-monotonicity is verified, not assumed.** The entry proves the family is concretely neither monotone nor antitone at x = 1/2 (it rises 1→2 then falls 2→3), so the witness genuinely satisfies every Dini hypothesis except the one it is built to remove — an honest counterexample, not a strawman.",
+      "**The whole obstruction is a constant peak height.** Because Fₙ(1/n) = e⁻¹ exactly for all n, the supremum error is bounded below by a fixed positive constant; the proof needs only the crude bound e⁻¹ > 1/3, i.e. exp 1 < 3."
+    ],
+    "prerequisites": [
+      "Pointwise versus uniform convergence of sequences of functions",
+      "Dini's theorem and the role of its three hypotheses",
+      "The limit t·e^{−t} → 0 and elementary bounds on the exponential",
+      "Filters and Tendsto / TendstoUniformlyOn in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "File-level docstring recalling Dini's theorem and the parent's two witnesses, then framing the new content: the moving bump n·x·e^{−n·x} addressing the necessity of monotonicity in n.",
+      "mathContext": "Dini's theorem: pointwise + monotone + continuous limit + compact ⟹ uniform convergence; this entry removes monotonicity."
+    },
+    {
+      "id": "bump-hypotheses",
+      "title": "The bump satisfies all Dini hypotheses except monotonicity",
+      "startLine": 49,
+      "endLine": 74,
+      "summary": "bump defines Fₙ(x) = n·x·exp(−n·x); bump_continuous (fun_prop), bump_tendsto_zero (pointwise limit 0 via t·e^{−t} → 0), zero_continuous and domain_isCompact record the continuity-of-limit and compactness hypotheses.",
+      "mathContext": "Each Fₙ is continuous, the pointwise limit 0 is continuous, and the domain [0,1] is compact."
+    },
+    {
+      "id": "exp-bounds",
+      "title": "Two numeric facts about exp(1/2)",
+      "startLine": 76,
+      "endLine": 92,
+      "summary": "exp_half_lt_two (exp(1/2) < 2, from exp(1/2)² = exp 1 < 4) and three_half_lt_exp_half (3/2 < exp(1/2), from 1 + x < exp x) pin exp(1/2) into (3/2, 2).",
+      "mathContext": "3/2 < exp(1/2) < 2 — the window in which the bump rises and then falls."
+    },
+    {
+      "id": "non-monotone",
+      "title": "The bump is non-monotone in n at x = 1/2",
+      "startLine": 94,
+      "endLine": 152,
+      "summary": "bump_one_eval / bump_two_eval / bump_three_eval evaluate the three samples; bump_one_lt_two and bump_three_lt_two reduce the rise F₁ < F₂ and fall F₃ < F₂ to the exp(1/2) bounds; bump_not_monotone concludes the family is neither monotone nor antitone.",
+      "mathContext": "At x = 1/2 the sequence rises 1→2 and falls 2→3, so monotonicity in n genuinely fails."
+    },
+    {
+      "id": "not-uniform",
+      "title": "Yet the convergence is not uniform",
+      "startLine": 154,
+      "endLine": 182,
+      "summary": "bump_not_tendstoUniformlyOn unfolds uniform convergence metrically and, for ε = 1/3 and every n, exhibits the travelling peak x = 1/n with Fₙ(1/n) = e⁻¹ > 1/3; bump_witness bundles all hypotheses and the failure of uniformity.",
+      "mathContext": "The moving peak x = 1/n keeps the supremum error ≥ e⁻¹ > 1/3, so convergence is not uniform — monotonicity cannot be dropped."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dini, Ulisse",
+      "title": "Fondamenti per la teorica delle funzioni di variabili reali",
+      "year": "1878",
+      "note": "The lectures where Dini's theorem on uniform convergence first appears"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "Theorem 7.13 (Dini's theorem); Chapter 7 discusses why each hypothesis is necessary, including non-monotone moving-bump behaviour"
+    },
+    {
+      "authors": "Bartle, Robert; Sherbert, Donald",
+      "title": "Introduction to Real Analysis",
+      "year": "2011",
+      "note": "Dini's theorem and the role of monotonicity in the index"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "dini-theorem-oq-01",
+      "relationship": "Parent entry: re-exports Dini's theorem and proves the necessity of continuity-of-limit and compactness; this entry answers its open question on the necessity of monotonicity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The moving bump Fₙ(x) = n·x·exp(−n·x) on the compact interval [0,1] is continuous in x, converges pointwise to the continuous function 0, and is verifiably non-monotone in n, yet does not converge uniformly because its travelling peak Fₙ(1/n) = e⁻¹ keeps the supremum error ≥ e⁻¹ > 1/3. This completes the Dini sharpness trilogy: with the parent's two witnesses it shows all three hypotheses of Dini's theorem — continuity of the limit, compactness of the domain, and monotonicity in n — are each necessary. Verified with 0 axioms and 0 sorries.",
+    "implications": "Gives the gallery a formal demonstration that the monotonicity hypothesis of Dini's theorem is load-bearing, using a smooth moving bump whose only failing hypothesis is monotonicity, and whose non-uniformity is witnessed by a single explicit travelling family of points.",
+    "openQuestions": [
+      "Can the moving-bump escape be quantified into an exact modulus: is sup_{x ∈ [0,1]} Fₙ(x) = e⁻¹ for every n ≥ 1, giving the precise supremum error rather than the crude lower bound 1/3?",
+      "Does the same bump, rescaled to height 1 (e·n·x·exp(−n·x) near its peak), give a uniformly bounded non-monotone witness, and can Dini fail simultaneously with all three hypotheses isolated in one family?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "DiniTheoremOQ01OQ01",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "path": "Proofs/DiniTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the **Dini sharpness trilogy**. The parent entry [`dini-theorem-oq-01`](../tree/main/src/data/proofs/dini-theorem-oq-01) re-exports Dini's theorem from Mathlib and proves two hypotheses are necessary via `xⁿ` (continuity of the limit; compactness of the domain). This PR answers its first listed open question — **monotonicity in `n` is necessary** — with a smooth *moving bump*.

## The witness

```
Fₙ(x) = n · x · exp(−n · x)   on the compact interval [0,1]
```

The bump peaks at `x = 1/n` with height `Fₙ(1/n) = e⁻¹`. As `n → ∞` the peak travels toward `0` **without shrinking**, so the supremum error never drops below `e⁻¹`.

| Dini hypothesis | Holds for the bump? |
|---|---|
| each `Fₙ` continuous | ✅ `fun_prop` |
| pointwise limit exists & is continuous (`= 0`) | ✅ via `t·e^{−t} → 0` |
| domain compact (`[0,1]`) | ✅ |
| **monotone in `n`** | ❌ rises 1→2, falls 2→3 at `x = 1/2` |
| ⟹ uniform convergence | ❌ `sup` error `≥ e⁻¹ > 1/3` |

Only monotonicity fails — an honest counterexample, verified non-monotone rather than asserted.

## Verification

- **14 theorems, 1 definition, 182 lines**
- **0 sorries, 0 `axiom` declarations, no `native_decide`**
- `#print axioms bump_witness` → `[propext, Classical.choice, Quot.sound]` (standard foundational axioms only)
- Type-checked against Mathlib 4.26.0

## Files

- `proofs/Proofs/DiniTheoremOQ01OQ01.lean` — the proof
- `proofs/Proofs.lean` — import registration
- `src/data/proofs/dini-theorem-oq-01-oq-01/meta.json` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)