### PR TITLE
Enrich Graph Dimension Foundations (erdos-1007-oq-05-oq-01): expand annotations

### DIFF
--- a/src/data/proofs/erdos-1007-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1007-oq-05-oq-01/annotations.json
@@ -1,24 +1,92 @@
 [
   {
+    "id": "ann-context",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 29
+    },
+    "type": "context",
+    "title": "Foundations for a Computational Graph-Dimension Check",
+    "content": "The Euclidean dimension of a graph is the least n admitting a unit-distance embedding in ℝⁿ — vertices placed so adjacent ones are at distance exactly 1 (Erdős–Harary–Tutte, 1965). The parent's first open question asks whether House's bound 'a 4-dimensional graph has ≥ 9 edges' can be reached computationally, by enumerating small graphs and checking each one's dimension. This file supplies two structural facts any such procedure silently needs but the parent never proved: monotonicity of embeddability and the dimension-0 base case. The UnitDistanceEmbedding structure and hasUnitEmbedding predicate are reproduced locally because Erdos1007Problem.lean is bit-rotted under toolchain 4.26.0 (Nat.find DecidablePred / LT V synthesis failures) and cannot be imported.",
+    "mathContext": "Graph dimension $\\dim(G) = \\min\\{n : G \\hookrightarrow \\mathbb{R}^n \\text{ as unit distances}\\}$. House (2013): $\\dim(G)=4 \\Rightarrow |E(G)| \\ge 9$, with $K_{3,3}$ the unique minimizer.",
+    "significance": "context",
+    "relatedConcepts": ["graph dimension", "unit-distance graph", "extremal graph theory", "Erdős problem #1007", "K₃,₃"],
+    "prerequisites": ["Euclidean embeddings of graphs", "metric geometry"]
+  },
+  {
+    "id": "ann-structure",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 43
+    },
+    "type": "definition",
+    "title": "Unit-Distance Embedding and the Embeddability Predicate",
+    "content": "UnitDistanceEmbedding V adj n bundles a coordinate map embed : V → Fin n → ℝ with the proof unit_edges that every adjacent pair lands at Euclidean distance exactly 1, i.e. √(∑ᵢ (embed u i − embed v i)²) = 1. The predicate hasUnitEmbedding V adj n is the propositional truncation Nonempty (UnitDistanceEmbedding V adj n) — it forgets the witness, recording only that some embedding exists, which is what the dimension (a minimum over n) quantifies over. Note the constraint is imposed only on edges; non-adjacent vertices are unconstrained, so this is a unit-distance representation, not a faithful metric embedding.",
+    "mathContext": "$\\mathrm{embed}:V\\to\\mathbb{R}^n$ with $\\|\\mathrm{embed}(u)-\\mathrm{embed}(v)\\|=1$ whenever $u\\sim v$; $\\;\\mathrm{hasUnitEmbedding} := \\mathrm{Nonempty}(\\dots)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit-distance embedding", "propositional truncation (Nonempty)", "Euclidean norm", "adjacency relation"],
+    "prerequisites": ["Finset.sum", "Real.sqrt", "structures in Lean 4"]
+  },
+  {
     "id": "ann-mono",
     "proofId": "erdos-1007-oq-05-oq-01",
     "range": {
       "startLine": 44,
-      "endLine": 70
+      "endLine": 69
     },
     "type": "insight",
     "title": "Padding With Zeros Preserves Distances",
-    "content": "`embedding_mono` extends a unit-distance embedding from ℝⁿ to ℝᵐ (m ≥ n) by sending each new coordinate to 0. The squared distance is unchanged because the appended coordinates contribute (0−0)² = 0. Formally, both coordinate sums are rewritten to Finset.range sums (Fin.sum_univ_eq_sum_range) and the range-m sum collapses to the range-n sum via Finset.sum_subset, the dropped terms vanishing. Consequently `hasUnitEmbedding_mono`: embeddability is monotone in the ambient dimension, so the admissible dimensions form an up-set and the graph dimension is its minimum."
+    "content": "embedding_mono extends a unit-distance embedding from ℝⁿ to ℝᵐ (m ≥ n) by sending each new coordinate to 0 (the dependent-if `if h : (i:ℕ) < n then e.embed v ⟨i,h⟩ else 0`). The squared distance is unchanged because the appended coordinates contribute (0−0)² = 0. Formally, both coordinate sums are rewritten to Finset.range sums (Fin.sum_univ_eq_sum_range) and the range-m sum collapses to the range-n sum via Finset.sum_subset, the dropped terms (j ∉ range n) vanishing by hGzero. A final sum_congr identifies the surviving terms (dif_pos + Fin.eta). The geometry needed is nil — 'extra zero coordinates cost nothing'.",
+    "mathContext": "$\\sum_{i<m}(\\bar e_u(i)-\\bar e_v(i))^2 = \\sum_{i<n}(e_u(i)-e_v(i))^2$ since the padded coordinates add $(0-0)^2=0$.",
+    "significance": "key",
+    "relatedConcepts": ["coordinate padding", "Fin.sum_univ_eq_sum_range", "Finset.sum_subset", "dependent if (dite)", "isometric embedding"],
+    "prerequisites": ["Finset sums and reindexing", "Euclidean distance"]
   },
   {
-    "id": "ann-base",
+    "id": "ann-mono-haspred",
     "proofId": "erdos-1007-oq-05-oq-01",
     "range": {
-      "startLine": 82,
-      "endLine": 100
+      "startLine": 71,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "Monotonicity: the Admissible Dimensions Form an Up-Set",
+    "content": "hasUnitEmbedding_mono lifts embedding_mono through the Nonempty truncation (h.elim … ⟨embedding_mono hnm e⟩): if a graph embeds in ℝⁿ it embeds in ℝᵐ for every m ≥ n. Therefore {n : hasUnitEmbedding V adj n} is upward closed, so it is the up-set [dim G, ∞) and the dimension is well defined as its minimum. This is the well-definedness that any dimension computation tacitly relies on — it lets an enumeration check only the least admissible dimension rather than all of them.",
+    "mathContext": "$n\\le m \\wedge \\mathrm{hasUnitEmbedding}(n) \\Rightarrow \\mathrm{hasUnitEmbedding}(m)$; the admissible set is $[\\dim G,\\infty)\\cap\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["up-set (upward-closed set)", "monotone predicate", "minimum of a set", "well-definedness of dimension"],
+    "prerequisites": ["Nonempty.elim", "order theory (up-sets)"]
+  },
+  {
+    "id": "ann-base-forward",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 89
+    },
+    "type": "technique",
+    "title": "Both Directions of the Edgeless Base Case",
+    "content": "hasUnitEmbedding_zero_of_edgeless: an edgeless graph embeds in ℝ⁰ via the trivial map (fun _ _ => 0); the unit_edges obligation is discharged vacuously since adj u v is impossible (absurd huv (h u v)). Conversely no_edge_of_hasUnitEmbedding_zero: from an embedding in ℝ⁰, an edge would give √(∑ over Fin 0) = √0 = 0; simp reduces univ over Fin 0 to ∅ (univ_eq_empty), the empty sum to 0, and Real.sqrt_zero to 0, so the unit constraint becomes 0 = 1, refuted by norm_num. These are the two halves combined in the iff below.",
+    "mathContext": "Edgeless $\\Rightarrow$ embeds in $\\mathbb{R}^0$ (vacuous); embeds in $\\mathbb{R}^0 \\Rightarrow$ an edge forces $\\sqrt{0}=1$, contradiction.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous truth", "empty sum (Finset.univ over Fin 0)", "Real.sqrt_zero", "proof by contradiction"],
+    "prerequisites": ["Fin 0 is empty", "norm_num"]
+  },
+  {
+    "id": "ann-base-iff",
+    "proofId": "erdos-1007-oq-05-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 96
     },
     "type": "concept",
-    "title": "Dimension 0 Means Edgeless",
-    "content": "`hasUnitEmbedding_zero_iff_edgeless` characterizes the base of the dimension hierarchy. An edgeless graph embeds in ℝ⁰ trivially (the unit-distance condition is vacuous). Conversely, if a graph embeds in ℝ⁰ then any edge would force √(∑ over Fin 0 of squared differences) = √0 = 0 to equal 1 — impossible. So a graph has dimension 0 exactly when it has no edges, the starting point for any inductive or computational analysis of higher dimensions."
+    "title": "Dimension 0 ⟺ Edgeless",
+    "content": "hasUnitEmbedding_zero_iff_edgeless packages the two directions into the characterization hasUnitEmbedding V adj 0 ↔ ∀ u v, ¬ adj u v. It fixes the base of the dimension hierarchy: dimension 0 is exactly the edgeless graphs, the starting point for any inductive or computational analysis of higher dimensions. Combined with monotonicity, it gives the two anchors — a well-defined minimum and a known bottom — that a verified dimension-checking enumeration needs before it can attack House's degree-4 bound.",
+    "mathContext": "$\\mathrm{hasUnitEmbedding}\\,V\\,\\mathrm{adj}\\,0 \\iff \\forall u\\,v,\\ \\neg\\,\\mathrm{adj}\\,u\\,v$, i.e. $\\dim G = 0 \\iff E(G)=\\varnothing$.",
+    "significance": "key",
+    "relatedConcepts": ["iff characterization", "base case of an induction", "edgeless graph", "graph dimension hierarchy"],
+    "prerequisites": ["logical equivalence", "the two base-case lemmas"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1007-oq-05-oq-01` (Foundations of the Graph Dimension).

The entry had a rich meta.json but only **2 annotations**, neither carrying any structured fields (below the quality target of ≥5 with `mathContext`/`significance`/`relatedConcepts`).

Changes (annotations.json only):
- **Expanded coverage 2 → 6 annotations**, now covering: the context/header, the `UnitDistanceEmbedding` structure + `hasUnitEmbedding` predicate, `embedding_mono` (zero-padding), `hasUnitEmbedding_mono` (up-set well-definedness of the dimension), both directions of the edgeless base case, and the `hasUnitEmbedding_zero_iff_edgeless` characterization.
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to **every** annotation. Line ranges aligned to the on-main Lean source `Proofs/Erdos1007OQ05OQ01.lean`.

Existing content preserved/folded in. Axiom/status fields unchanged (verified/0-axiom). `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)