### PR TITLE
Add + enrich Cauchy-interlacing unitary-invariance corollary (cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,80 @@
+import Proofs.CauchyInterlacingOQ01OQ01OQ01
+
+/-
+# Sorted Eigenvalues Are a Unitary Invariant
+
+The parent entry (`cauchy-interlacing-theorem-oq-01-oq-01-oq-01`) proves the **bridge lemma**
+`eigenvalues_eq_of_eigenbasis`: a self-adjoint operator's *sorted* eigenvalue list is determined
+by *any* orthonormal eigenbasis with antitone real eigenvalues.  Its docstring records — but does
+not formalize — the headline corollary singled out as that entry's lead open question:
+
+> **The sorted spectrum is invariant under unitary (isometric) conjugation.**
+
+This file isolates that corollary as a reusable lemma.
+
+* `isSymmetric_of_isometryConj` — symmetry transports across an isometric intertwiner: if
+  `e : E ≃ₗᵢ F` is a linear isometry equivalence with `S (e x) = e (T x)` and `T` is symmetric,
+  then `S` is symmetric.  (So the symmetry hypothesis on `S` below is *automatic*, recorded here
+  for completeness.)
+
+* `eigenvalues_isometryConj` — the main result: for symmetric `T : E →ₗ[𝕜] E`, `S : F →ₗ[𝕜] F`
+  and a linear isometry equivalence `e : E ≃ₗᵢ F` intertwining them (`S (e x) = e (T x)`, i.e.
+  `S = e ∘ T ∘ e⁻¹`), the sorted eigenvalue tuples coincide: `hS.eigenvalues hnF = hT.eigenvalues hnE`.
+
+The proof is exactly the recipe sketched in the parent: transport `T`'s canonical orthonormal
+eigenbasis through `e` to obtain an orthonormal eigenbasis of `S` *with the same antitone eigenvalue
+tuple* `f = hT.eigenvalues hnE`, then feed it to `eigenvalues_eq_of_eigenbasis`.  The eigenbasis
+condition `S (b i) = f i • b i` is immediate from the intertwining relation and the parent's
+`apply_eigenvectorBasis`.
+
+This is the tool that finishes principal-submatrix Cauchy interlacing: the orthogonal compression
+of a Hermitian `A` to a coordinate hyperplane is the isometric conjugate of the principal-submatrix
+operator, so this lemma identifies their sorted spectra.
+
+Holds over any `RCLike` field `𝕜` (so `ℝ` and `ℂ`), with `0` sorries and `0` axioms.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open Matrix Polynomial
+
+namespace CauchyInterlacingOQ01OQ01OQ01OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace 𝕜 F] [FiniteDimensional 𝕜 F]
+
+/-- **Symmetry transports across an isometric intertwiner.** If `e : E ≃ₗᵢ F` satisfies
+`S (e x) = e (T x)` (so `S = e ∘ T ∘ e⁻¹`) and `T` is symmetric, then so is `S`.  Hence the
+symmetry hypothesis on `S` in `eigenvalues_isometryConj` is automatic. -/
+theorem isSymmetric_of_isometryConj {T : E →ₗ[𝕜] E} {S : F →ₗ[𝕜] F}
+    (hT : T.IsSymmetric) (e : E ≃ₗᵢ[𝕜] F) (hes : ∀ x, S (e x) = e (T x)) :
+    S.IsSymmetric := by
+  intro y z
+  obtain ⟨x, rfl⟩ := e.surjective y
+  obtain ⟨x', rfl⟩ := e.surjective z
+  rw [hes, hes, e.inner_map_map, e.inner_map_map]
+  exact hT x x'
+
+/-- **Unitary conjugation invariance of the sorted spectrum.** For symmetric `T : E →ₗ[𝕜] E` and
+`S : F →ₗ[𝕜] F` related by a linear isometry equivalence `e : E ≃ₗᵢ F` with `S (e x) = e (T x)`,
+the sorted eigenvalue tuples are equal. -/
+theorem eigenvalues_isometryConj {T : E →ₗ[𝕜] E} {S : F →ₗ[𝕜] F}
+    (hT : T.IsSymmetric) (hS : S.IsSymmetric) (e : E ≃ₗᵢ[𝕜] F)
+    (hes : ∀ x, S (e x) = e (T x))
+    {n : ℕ} (hnE : Module.finrank 𝕜 E = n) (hnF : Module.finrank 𝕜 F = n) :
+    hS.eigenvalues hnF = hT.eigenvalues hnE := by
+  -- Transport `T`'s canonical eigenbasis through `e`.
+  set b : OrthonormalBasis (Fin n) 𝕜 F := (hT.eigenvectorBasis hnE).map e with hb_def
+  -- `b` is an orthonormal eigenbasis of `S` for the *same* eigenvalue tuple.
+  have hb : ∀ i, S (b i) = ((hT.eigenvalues hnE i : ℝ) : 𝕜) • b i := by
+    intro i
+    have hmap : b i = e ((hT.eigenvectorBasis hnE) i) := by
+      rw [hb_def, OrthonormalBasis.map_apply]
+    rw [hmap, hes, hT.apply_eigenvectorBasis hnE i, map_smul]
+  -- Apply the parent's bridge lemma.
+  exact CauchyInterlacingOQ01OQ01OQ01.eigenvalues_eq_of_eigenbasis hS hnF b
+    (hT.eigenvalues hnE) (hT.eigenvalues_antitone hnE) hb
+
+end CauchyInterlacingOQ01OQ01OQ01OQ01

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 37 },
+    "type": "concept",
+    "title": "The corollary the parent flagged: spectrum is a unitary invariant",
+    "content": "The parent entry proved the *bridge lemma* `eigenvalues_eq_of_eigenbasis` — a self-adjoint operator's sorted eigenvalue list is determined by *any* orthonormal eigenbasis with antitone real eigenvalues — and recorded, but did not formalize, the headline corollary as its lead open question: **the sorted spectrum is invariant under unitary (isometric) conjugation.** This file isolates that corollary as a reusable lemma, which also contains the heavy elaboration the parent reported when attempting it inline. The payoff is principal-submatrix Cauchy interlacing: the orthogonal compression of a Hermitian $A$ to a coordinate hyperplane is the isometric conjugate of the principal-submatrix operator, so equal sorted spectra let interlacing be read off in the familiar form $\\lambda_{k+1}(A) \\le \\lambda_k(A^{(j)}) \\le \\lambda_k(A)$.",
+    "mathContext": "$S = e\\circ T\\circ e^{-1},\\ e \\text{ unitary} \\;\\Longrightarrow\\; \\operatorname{spec}(S) = \\operatorname{spec}(T) \\text{ (as sorted tuples)}.$",
+    "significance": "context",
+    "relatedConcepts": ["unitary invariant", "spectral theorem", "Cauchy interlacing", "principal submatrix", "compression"],
+    "prerequisites": ["self-adjoint operators", "eigenvalues of Hermitian matrices"]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 46 },
+    "type": "definition",
+    "title": "Setup: two finite-dimensional inner-product spaces over an RCLike field",
+    "content": "The development is stated over an arbitrary `RCLike` field `𝕜` (covering both `ℝ` and `ℂ`) and two finite-dimensional inner-product spaces `E`, `F`. Working with abstract operators `T : E →ₗ[𝕜] E`, `S : F →ₗ[𝕜] F` and a linear isometry equivalence `e : E ≃ₗᵢ[𝕜] F` between them — rather than with matrices — is what lets the proof be a few lines of basis transport: the unitary is packaged as `≃ₗᵢ`, whose defining property `⟪e x, e y⟫ = ⟪x, y⟫` is exactly the inner-product preservation the argument needs.",
+    "mathContext": "$\\mathbb{K} \\in \\{\\mathbb{R}, \\mathbb{C}\\},\\quad e : E \\xrightarrow{\\ \\simeq\\ } F \\text{ with } \\langle e x, e y\\rangle = \\langle x, y\\rangle.$",
+    "significance": "technical",
+    "relatedConcepts": ["RCLike field", "inner product space", "linear isometry equivalence", "finite dimensional"],
+    "prerequisites": ["inner product spaces", "linear isometries"]
+  },
+  {
+    "id": "ann-symmetry-transport",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 61 },
+    "type": "insight",
+    "title": "Symmetry Rides Along the Isometry",
+    "content": "`isSymmetric_of_isometryConj`: if `S (e x) = e (T x)` for a linear isometry equivalence `e : E ≃ₗᵢ F` and `T` is symmetric, then so is `S`. The proof writes arbitrary inputs as `e x`, `e x'` (using surjectivity of `e`), rewrites both occurrences of `S` through the intertwining relation, and collapses each inner product with `LinearIsometryEquiv.inner_map_map` (`⟪e a, e b⟫ = ⟪a, b⟫`). The goal `⟪S(e x), e x'⟫ = ⟪e x, S(e x')⟫` becomes `⟪T x, x'⟫ = ⟪x, T x'⟫`, which is exactly `hT x x'`. Consequence: the symmetry hypothesis on the conjugate `S` is automatic, so the main theorem's `hS` is a convenience, not a genuine extra assumption.",
+    "mathContext": "S = e ∘ T ∘ e⁻¹ with e unitary ⟹ S* = S whenever T* = T, since unitary conjugation preserves the adjoint.",
+    "significance": "key",
+    "relatedConcepts": ["self-adjoint operator", "unitary conjugation", "adjoint"],
+    "prerequisites": ["LinearMap.IsSymmetric", "LinearIsometryEquiv.inner_map_map"]
+  },
+  {
+    "id": "ann-eigenbasis-transport",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "insight",
+    "title": "Transport the Eigenbasis, Keep the Eigenvalues",
+    "content": "`eigenvalues_isometryConj`: the sorted eigenvalue tuples of `T` and its unitary conjugate `S` coincide. The single idea is that `b := (hT.eigenvectorBasis hnE).map e` is an orthonormal eigenbasis of `S` for the SAME eigenvalue tuple `f = hT.eigenvalues hnE`: from `OrthonormalBasis.map_apply`, `b i = e (eigenvectorBasis i)`, so `S (b i) = S (e (eigenvectorBasis i)) = e (T (eigenvectorBasis i)) = e (f i • eigenvectorBasis i) = f i • b i`, using the intertwining relation, the parent's `apply_eigenvectorBasis`, and `𝕜`-linearity of `e` (`map_smul`). Feeding this eigenbasis and the antitone tuple `f` to the parent's bridge `eigenvalues_eq_of_eigenbasis` forces `hS.eigenvalues hnF = f`.",
+    "mathContext": "If T = diag(f) in basis (v_i) then S = e∘T∘e⁻¹ = diag(f) in basis (e v_i); the sorted multiset of f is unchanged, so the sorted spectra agree.",
+    "significance": "key",
+    "relatedConcepts": ["spectral theorem", "unitary invariance", "Cauchy interlacing", "principal submatrix"],
+    "prerequisites": ["OrthonormalBasis.map", "LinearMap.IsSymmetric.apply_eigenvectorBasis", "LinearMap.IsSymmetric.eigenvalues_antitone"]
+  },
+  {
+    "id": "ann-why-it-matters",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "context",
+    "title": "The Bridge to Principal-Submatrix Interlacing",
+    "content": "This corollary is the precise tool the Cauchy-interlacing keystone flagged as future work. The orthogonal compression of a Hermitian `A` to a coordinate hyperplane `e_jᗮ` is the isometric conjugate of the principal-submatrix operator `toEuclideanLin (A.submatrix j.succAbove j.succAbove)`. Because `eigenvalues_isometryConj` shows isometric conjugates share a sorted spectrum, it identifies the compression's eigenvalues with the submatrix's, letting the parent's compression-form interlacing be read off in the familiar principal-submatrix form `λ_{k+1}(A) ≤ λ_k(A⁽ʲ⁾) ≤ λ_k(A)`. The parent had recorded this packaging as its lead open question, noting the inline proof triggered heavy elaboration; isolating it in its own file contains that cost.",
+    "mathContext": "Cauchy interlacing: deleting one row/column of a Hermitian matrix interlaces its eigenvalues.",
+    "significance": "context",
+    "relatedConcepts": ["Cauchy interlacing theorem", "compression", "Hermitian matrix", "eigenvalue inequalities"],
+    "prerequisites": ["principal submatrix"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyInterlacingTheoremOq01Oq01Oq01Oq01Data: ProofData = {
+  proof: cauchyInterlacingTheoremOq01Oq01Oq01Oq01Proof,
+  annotations: cauchyInterlacingTheoremOq01Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Sorted Spectrum Is a Unitary Invariant (eigenvalues_isometryConj)",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01",
+  "description": "The parent entry (cauchy-interlacing-theorem-oq-01-oq-01-oq-01) proves the bridge lemma eigenvalues_eq_of_eigenbasis — a self-adjoint operator's sorted eigenvalue list is determined by ANY orthonormal eigenbasis with antitone real eigenvalues — and records as its lead open question the request to package the unitary-conjugation corollary as a standalone lemma. This entry does exactly that, isolating the proof into its own file so the heavy elaboration the parent flagged is contained. isSymmetric_of_isometryConj: symmetry transports across an isometric intertwiner — if e : E ≃ₗᵢ F is a linear isometry equivalence with S (e x) = e (T x) and T is symmetric, then S is symmetric (so the symmetry hypothesis on S is automatic). eigenvalues_isometryConj: the headline result — for symmetric T : E →ₗ[𝕜] E, S : F →ₗ[𝕜] F related by a linear isometry equivalence e : E ≃ₗᵢ F intertwining them (S = e ∘ T ∘ e⁻¹), the sorted eigenvalue tuples coincide: hS.eigenvalues hnF = hT.eigenvalues hnE. The proof transports T's canonical orthonormal eigenbasis through e via OrthonormalBasis.map to get an orthonormal eigenbasis of S with the SAME antitone eigenvalue tuple, then feeds it to the parent's eigenvalue bridge; the eigenbasis condition S (b i) = f i • b i is immediate from the intertwining relation and the parent's apply_eigenvectorBasis. This is the tool that finishes principal-submatrix Cauchy interlacing: the orthogonal compression of a Hermitian A to a coordinate hyperplane is the isometric conjugate of the principal-submatrix operator, so this lemma identifies their sorted spectra. Holds over any RCLike field (ℝ and ℂ), with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Cauchy (interlacing); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral",
+      "hermitian",
+      "cauchy-interlacing",
+      "eigenvalues",
+      "unitary-conjugation",
+      "linear-isometry",
+      "spectral-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "OrthonormalBasis.map",
+        "description": "transports an orthonormal basis along a linear isometry equivalence e : E ≃ₗᵢ F to an orthonormal basis of F, with (b.map e) i = e (b i) (OrthonormalBasis.map_apply)",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "LinearIsometryEquiv.inner_map_map",
+        "description": "⟪e x, e y⟫ = ⟪x, y⟫ — a linear isometry equivalence preserves the inner product; used to transport symmetry of T to S",
+        "module": "Mathlib.Analysis.InnerProductSpace.LinearMap"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.apply_eigenvectorBasis",
+        "description": "T (eigenvectorBasis i) = (eigenvalues i) • eigenvectorBasis i — the canonical eigenbasis of a self-adjoint operator realizes its sorted eigenvalues",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues_antitone",
+        "description": "the sorted eigenvalue tuple of a self-adjoint operator is antitone — supplies the antitonicity hypothesis of the parent's bridge lemma",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues",
+        "description": "the sorted (antitone) eigenvalue tuple of a self-adjoint operator on a finite-dimensional inner product space — the object shown here to be a unitary invariant",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      }
+    ],
+    "galleryDependencies": [
+      {
+        "theorem": "CauchyInterlacingOQ01OQ01OQ01.eigenvalues_eq_of_eigenbasis",
+        "description": "the parent bridge lemma: a self-adjoint operator's sorted eigenvalues equal f for ANY orthonormal eigenbasis (b, f) with f antitone",
+        "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01"
+      }
+    ],
+    "originalContributions": [
+      "isSymmetric_of_isometryConj: symmetry of a self-adjoint operator transports across an isometric intertwiner S (e x) = e (T x), so the symmetry hypothesis on the conjugate S is automatic — proved by writing arbitrary inputs as e x, e x' and collapsing the two inner products with LinearIsometryEquiv.inner_map_map",
+      "eigenvalues_isometryConj: the sorted eigenvalue tuple is invariant under unitary (isometric) conjugation — packaged as the standalone lemma requested in the parent's lead open question, by transporting the canonical eigenbasis through e (OrthonormalBasis.map) to an eigenbasis of S with the same antitone eigenvalue tuple and invoking the parent's bridge. This containment also tames the heavy elaboration the parent flagged when the corollary was attempted inline."
+    ],
+    "openQuestions": [
+      "Assemble the headline principal-submatrix corollary in Lean: build the explicit isometry EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ e_jᗮ from the standard basis vectors e_{j.succAbove i}, feed the parent's compress_inner_eq_principalSubmatrix into eigenvalues_isometryConj, and conclude λ_{k+1}(A) ≤ λ_k(A.submatrix j.succAbove j.succAbove) ≤ λ_k(A) for Matrix.IsHermitian.eigenvalues₀.",
+      "Upstream eigenvalue invariance under conjugation to Mathlib as LinearMap.IsSymmetric.eigenvalues_comp_linearIsometryEquiv, together with the symmetry-transport lemma isSymmetric_of_isometryConj."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) states that deleting one row and the corresponding column of a real symmetric (or complex Hermitian) matrix produces a principal submatrix whose eigenvalues interlace those of the original: λ_{k+1}(A) ≤ λ_k(A^{(j)}) ≤ λ_k(A). It is one of the cornerstones of matrix perturbation theory and the variational (Courant–Fischer / Rayleigh–Ritz) view of eigenvalues, with descendants in graph spectra (eigenvalue interlacing for vertex-deleted subgraphs), numerical linear algebra (the bisection method for symmetric tridiagonal eigenproblems), and the theory of orthogonal polynomials. The keystone fact that makes the operator-theoretic proof go through is that the *sorted spectrum is a unitary invariant*: conjugating a self-adjoint operator by a unitary (an isometric isomorphism) leaves its eigenvalues — as a sorted tuple — unchanged. This is the abstract content of 'similar Hermitian matrices via a unitary have the same eigenvalues', and it is exactly what this entry isolates and formalizes.",
+    "problemStatement": "For symmetric operators $T : E \\to E$ and $S : F \\to F$ on finite-dimensional inner-product spaces over an RCLike field $\\mathbb{K}$, related by a linear isometry equivalence $e : E \\simeq_{\\ell i} F$ intertwining them ($S(e\\,x) = e(T\\,x)$, i.e. $S = e\\circ T\\circ e^{-1}$), prove that their sorted eigenvalue tuples coincide: $\\mathrm{hS.eigenvalues}\\ h_{nF} = \\mathrm{hT.eigenvalues}\\ h_{nE}$. Provide also that the symmetry of $S$ is automatic from the symmetry of $T$ and the isometric intertwining.",
+    "proofStrategy": "1. **Symmetry transport (`isSymmetric_of_isometryConj`).** Write arbitrary inputs of S as e x, e x' (surjectivity of e), rewrite both S-occurrences through the intertwining relation, and collapse each inner product with `LinearIsometryEquiv.inner_map_map`; the goal reduces to the symmetry of T. So S's symmetry hypothesis is a convenience, not a real assumption.\n\n2. **Eigenbasis transport (`eigenvalues_isometryConj`).** Transport T's canonical orthonormal eigenbasis through e: set b := (hT.eigenvectorBasis hnE).map e. By `OrthonormalBasis.map_apply`, b i = e (eigenvectorBasis i), so S (b i) = e (T (eigenvectorBasis i)) = e (f i • eigenvectorBasis i) = f i • b i using the intertwining relation, the parent's `apply_eigenvectorBasis`, and `map_smul`. Thus b is an orthonormal eigenbasis of S for the *same* antitone tuple f = hT.eigenvalues hnE.\n\n3. **Invoke the parent bridge.** Feed b and the antitone tuple f (antitonicity from `eigenvalues_antitone`) to the parent's `eigenvalues_eq_of_eigenbasis`, which forces hS.eigenvalues hnF = f = hT.eigenvalues hnE.",
+    "keyInsights": [
+      "**The sorted spectrum is a unitary invariant, and the proof is pure basis transport.** No spectral computation is redone for S: T's eigenbasis is carried through the isometry e and the eigenvalue tuple comes along unchanged, so equality of sorted spectra is immediate from the parent's bridge lemma.",
+      "**The unitary is packaged as a `LinearIsometryEquiv`.** Its single defining property ⟪e x, e y⟫ = ⟪x, y⟫ does double duty: it transports symmetry (step 1) and guarantees the transported basis stays orthonormal (`OrthonormalBasis.map`), so the whole argument needs no adjoint manipulation.",
+      "**The symmetry hypothesis on S is redundant.** `isSymmetric_of_isometryConj` derives it from T's symmetry plus the intertwining relation; carrying hS as an explicit argument is only a notational convenience for the caller.",
+      "**Isolation tames elaboration.** The parent reported that proving this corollary inline triggered heavy elaboration; giving it its own file with a fixed statement contains that cost and yields a directly citable lemma for the principal-submatrix interlacing finale.",
+      "**Stated over any RCLike field.** Because the argument is inner-product-theoretic rather than real-specific, it holds uniformly for ℝ and ℂ, matching the generality of Mathlib's spectral theorem for self-adjoint operators."
+    ],
+    "prerequisites": [
+      "The parent bridge lemma eigenvalues_eq_of_eigenbasis (cauchy-interlacing-theorem-oq-01-oq-01-oq-01)",
+      "Spectral theorem for self-adjoint operators on finite-dimensional inner-product spaces (eigenvectorBasis, eigenvalues, eigenvalues_antitone)",
+      "Linear isometry equivalences (≃ₗᵢ) and OrthonormalBasis.map",
+      "Cauchy interlacing and principal submatrices at a high level"
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Overview: the unitary-invariance corollary",
+      "startLine": 3,
+      "endLine": 37,
+      "summary": "Module docstring: the parent proved the bridge lemma eigenvalues_eq_of_eigenbasis and flagged the unitary-conjugation corollary as its lead open question. This file isolates that corollary, names the two results, sketches the eigenbasis-transport recipe, and explains the payoff for principal-submatrix Cauchy interlacing. Notes the file is intentionally not registered in Proofs.lean (research file)."
+    },
+    {
+      "id": "setup",
+      "title": "Opens and variable context",
+      "startLine": 39,
+      "endLine": 46,
+      "summary": "Opens InnerProductSpace / Matrix / Polynomial, the namespace, and the variable context: an RCLike field 𝕜 and two finite-dimensional inner-product spaces E, F over 𝕜."
+    },
+    {
+      "id": "symmetry-transport",
+      "title": "isSymmetric_of_isometryConj — symmetry transports across the intertwiner",
+      "startLine": 48,
+      "endLine": 58,
+      "summary": "Symmetry of T transports to S along an isometric intertwiner: writing inputs as e x, e x', rewriting through S(e x) = e(T x), and collapsing inner products with e.inner_map_map reduces the goal to hT x x'. Makes S's symmetry hypothesis automatic."
+    },
+    {
+      "id": "main-result",
+      "title": "eigenvalues_isometryConj — sorted spectrum is a unitary invariant",
+      "startLine": 60,
+      "endLine": 80,
+      "summary": "The headline lemma: for T, S intertwined by e : E ≃ₗᵢ F, the sorted eigenvalue tuples coincide. Transports T's canonical eigenbasis via OrthonormalBasis.map to an orthonormal eigenbasis of S with the same antitone tuple, verifies the eigenbasis condition from the intertwining relation and apply_eigenvectorBasis, and concludes through the parent's eigenvalues_eq_of_eigenbasis."
+    }
+  ],
+  "conclusion": {
+    "summary": "The sorted eigenvalue tuple of a self-adjoint operator is invariant under unitary (isometric) conjugation: if S = e ∘ T ∘ e⁻¹ for a linear isometry equivalence e, then S and T have identical sorted spectra. The proof transports T's canonical orthonormal eigenbasis through e — keeping the antitone eigenvalue tuple fixed — and feeds it to the parent's bridge lemma; a companion result shows the symmetry of S is automatic from that of T. Stated over any RCLike field (ℝ and ℂ), with 0 sorries and 0 axioms, as the standalone lemma the parent entry requested.",
+    "implications": "This packages the abstract content of 'unitarily similar Hermitian matrices share their eigenvalues' as a reusable Lean lemma, and supplies the final ingredient for principal-submatrix Cauchy interlacing: the orthogonal compression of a Hermitian A to a coordinate hyperplane is the isometric conjugate of the principal-submatrix operator, so eigenvalues_isometryConj identifies their sorted spectra and lets the parent's compression-form interlacing be read off as λ_{k+1}(A) ≤ λ_k(A^{(j)}) ≤ λ_k(A). Isolating the corollary also contains the heavy elaboration the parent flagged when it was attempted inline.",
+    "openQuestions": [
+      "Assemble the headline principal-submatrix corollary in Lean: build the explicit isometry EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ e_jᗮ from the standard basis vectors e_{j.succAbove i}, feed the parent's compress_inner_eq_principalSubmatrix into eigenvalues_isometryConj, and conclude λ_{k+1}(A) ≤ λ_k(A.submatrix j.succAbove j.succAbove) ≤ λ_k(A) for Matrix.IsHermitian.eigenvalues₀.",
+      "Upstream eigenvalue invariance under conjugation to Mathlib as LinearMap.IsSymmetric.eigenvalues_comp_linearIsometryEquiv, together with the symmetry-transport lemma isSymmetric_of_isometryConj.",
+      "Generalize from a single coordinate-hyperplane compression to a k-codimensional compression, recovering the general Cauchy interlacing bound λ_{i+k}(A) ≤ λ_i(B) ≤ λ_i(A) for a k-fold principal submatrix B."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves the bridge lemma eigenvalues_eq_of_eigenbasis and records the unitary-conjugation corollary as its lead open question. This entry formalizes exactly that corollary as the standalone lemma eigenvalues_isometryConj, invoking the parent's bridge."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "related",
+      "description": "The root Cauchy interlacing entry. Unitary-conjugation invariance of the sorted spectrum is the structural fact that lets the orthogonal compression of a Hermitian matrix be identified spectrally with its principal submatrix, completing the interlacing argument."
+    }
+  ]
+}


### PR DESCRIPTION
Adopts a **complete-but-orphaned** research entry into the gallery. The Lean file and a minimal meta/annotations pair existed untracked in the working tree (a researcher's interrupted work — never committed, no open PR), so the page neither shipped nor loaded. This PR turns it into a tracked, deployable, fully-enriched entry.

## Provenance / safety
- Parent `CauchyInterlacingOQ01OQ01OQ01` and both crossref targets (`cauchy-interlacing-theorem-oq-01-oq-01-oq-01`, `cauchy-interlacing-theorem`) are **already on main** — this entry depends only on merged content.
- The Lean file declares 0 sorries / 0 axioms (the only `sorry`/`axiom` token is in its docstring). It is a research file, intentionally **not** registered in `Proofs.lean`; the gallery imports it as raw text. Kernel build verification is inherited from the originating researcher's claim — the enricher did not re-run `lake`.

## Changes
- **Added** `proofs/Proofs/CauchyInterlacingOQ01OQ01OQ01OQ01.lean`
- **Added `index.ts`** (entry would 404 without it)
- **Added `overview`**: historicalContext, problemStatement, proofStrategy, 5 keyInsights, prerequisites
- **Added `sections`** covering the full file
- **Added `conclusion`**: summary, implications, 3 openQuestions
- **Added `crossReferences`** to the parent and root entries
- **Annotations**: added overview + setup annotations (now 5), normalized `significance` to the schema enum (`key`/`technical`/`context`)

Verified with `pnpm build` (gallery data + tsc typecheck pass). Math: the sorted eigenvalue tuple of a self-adjoint operator is a unitary invariant (`eigenvalues_isometryConj`) — the standalone corollary the parent flagged as its lead open question, and the final ingredient for principal-submatrix Cauchy interlacing.