### PR TITLE
research(dilworth-theorem-oq-01-oq-01-oq-02): maxChainLen = Set.chainHeight bridge [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -969,6 +969,7 @@ import Proofs.DetConjugateTransposeOQ01
 import Proofs.DiamondImpliesCH
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
+import Proofs.DilworthTheoremOQ01OQ01OQ02
 import Proofs.DiniTheorem
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01

--- a/proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,122 @@
+/-
+  Dilworth / Mirsky — bridging the gallery's combinatorial `maxChainLen` to
+  Mathlib's order-theoretic `Set.chainHeight`.
+  (dilworth-theorem-oq-01-oq-01-oq-02)
+
+  ## Background
+
+  The companion file `Proofs.DilworthMirskyHardOQ01` develops the hard
+  (attainment) direction of Mirsky's theorem on a finite poset.  Its central
+  combinatorial invariant is
+
+      `maxChainLen = (allChains).sup Finset.card : ℕ`,
+
+  the largest cardinality of a chain (a pairwise-`≤`-comparable `Finset`).
+
+  Mathlib has its own order-theoretic notion of the same quantity,
+
+      `Set.chainHeight r s = ⨆ {t // t ⊆ s ∧ IsChain r t}, t.encard : ℕ∞`,
+
+  the supremum (in `ℕ∞`) of the extended cardinalities of `r`-chains contained
+  in a set `s`.
+
+  ## What this file proves
+
+  The single **definitional bridge lemma** that the two notions coincide on the
+  whole finite poset, taken with respect to `≤`:
+
+      `maxChainLen_eq_univ_chainHeight` :
+          (maxChainLen : ℕ∞) = (Set.univ).chainHeight (· ≤ ·)`.
+
+  The proof is two opposite inequalities, each one line of real content thanks
+  to Mathlib's chain-height API:
+
+  * `≤` : the chain attaining `maxChainLen` (from the parent's
+    `exists_chain_card_eq_maxChainLen`) is, as a set, an `IsChain (· ≤ ·)`, so
+    `encard_le_chainHeight_of_isChain` bounds `chainHeight` from below.
+  * `≥` : `exists_eq_chainHeight_of_finite` produces a chain *set* attaining
+    `chainHeight`; pushing it to a `Finset` lands it in `allChains`, whose
+    cardinalities are bounded by `maxChainLen` via `Finset.le_sup`.
+
+  The bridge is purely a translation between two encodings of the same maximum,
+  so it carries `0 sorries, 0 axioms`.  As an immediate consequence we restate
+  the parent's Mirsky theorem (`mirsky_min_antichain_cover`) in Mathlib's
+  vocabulary: the chain height of the poset equals the minimum size of an
+  antichain cover (`mirsky_chainHeight`).
+
+  ## Status: BUILD-TARGET.  0 axioms, 0 sorries.
+-/
+import Mathlib
+import Proofs.DilworthMirskyHardOQ01
+
+open Classical Set
+
+attribute [local instance] Classical.propDecidable
+
+namespace DilworthTheoremOQ01
+
+variable {α : Type*} [PartialOrder α] [Fintype α]
+
+omit [Fintype α] in
+/-- The parent's `IsChainOn` (a pairwise-`≤`-comparable `Finset`) is exactly
+Mathlib's `IsChain (· ≤ ·)` on the underlying set of points. -/
+theorem isChainOn_iff_isChain (C : Finset α) :
+    IsChainOn C ↔ IsChain (· ≤ ·) (↑C : Set α) := by
+  constructor
+  · intro h x hx y hy _hne
+    exact h (Finset.mem_coe.mp hx) (Finset.mem_coe.mp hy)
+  · intro h x hx y hy
+    rcases eq_or_ne x y with rfl | hne
+    · exact Or.inl le_rfl
+    · exact h (Finset.mem_coe.mpr hx) (Finset.mem_coe.mpr hy) hne
+
+/-- **Bridge to `Set.chainHeight`.** The gallery's combinatorial maximum chain
+length `maxChainLen` agrees with Mathlib's order-theoretic `Set.chainHeight` of
+the whole (finite) poset, taken with respect to `≤`. -/
+theorem maxChainLen_eq_univ_chainHeight :
+    (maxChainLen (α := α) : ℕ∞) = (Set.univ : Set α).chainHeight (· ≤ ·) := by
+  apply le_antisymm
+  · -- `maxChainLen ≤ chainHeight`: the attaining chain witnesses the supremum.
+    obtain ⟨C, hC, hCard⟩ := exists_chain_card_eq_maxChainLen (α := α)
+    have hchain : IsChain (· ≤ ·) (↑C : Set α) := (isChainOn_iff_isChain C).mp hC
+    have hle :=
+      encard_le_chainHeight_of_isChain (Set.univ) (↑C : Set α) (Set.subset_univ _) hchain
+    rwa [Set.encard_coe_eq_coe_finsetCard, hCard] at hle
+  · -- `chainHeight ≤ maxChainLen`: a chain set attaining `chainHeight` becomes a
+    -- `Finset` in `allChains`, hence bounded by the `sup`.
+    obtain ⟨t, hsub, ht_enc, ht_chain⟩ :=
+      exists_eq_chainHeight_of_finite (Set.univ : Set α) (· ≤ ·) Set.finite_univ
+    have ht_fin : t.Finite := Set.finite_univ.subset hsub
+    rw [← ht_enc, ht_fin.encard_eq_coe_toFinset_card]
+    have hCo : IsChainOn ht_fin.toFinset := by
+      rw [isChainOn_iff_isChain, ht_fin.coe_toFinset]; exact ht_chain
+    have hmem : ht_fin.toFinset ∈ allChains (α := α) := by
+      unfold allChains
+      rw [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.subset_univ _, hCo⟩
+    have hle : ht_fin.toFinset.card ≤ maxChainLen (α := α) :=
+      Finset.le_sup (f := Finset.card) hmem
+    exact_mod_cast hle
+
+/-- The chain height of a finite poset is finite (never `⊤`). -/
+theorem univ_chainHeight_ne_top :
+    (Set.univ : Set α).chainHeight (· ≤ ·) ≠ ⊤ := by
+  rw [← maxChainLen_eq_univ_chainHeight]; exact ENat.coe_ne_top _
+
+/-- **Mirsky's theorem, in Mathlib's vocabulary.** The order-theoretic chain
+height of a finite poset equals the minimum size of an antichain cover:
+there is an antichain cover whose cardinality equals `Set.chainHeight`, and no
+antichain cover is smaller. -/
+theorem mirsky_chainHeight :
+    ∃ 𝒜 : Finset (Finset α),
+      (∀ A ∈ 𝒜, IsAntichainOn A) ∧
+      (∀ x : α, ∃ A ∈ 𝒜, x ∈ A) ∧
+      (𝒜.card : ℕ∞) = (Set.univ : Set α).chainHeight (· ≤ ·) ∧
+      (∀ ℬ : Finset (Finset α),
+        (∀ A ∈ ℬ, IsAntichainOn A) → (∀ x : α, ∃ A ∈ ℬ, x ∈ A) →
+        𝒜.card ≤ ℬ.card) := by
+  obtain ⟨𝒜, hanti, hcover, hcard, hmin⟩ := mirsky_min_antichain_cover (α := α)
+  refine ⟨𝒜, hanti, hcover, ?_, hmin⟩
+  rw [hcard]; exact maxChainLen_eq_univ_chainHeight
+
+end DilworthTheoremOQ01

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "dilworth-theorem-oq-01-oq-01-oq-02",
+  "title": "Mirsky's maxChainLen equals Mathlib's Set.chainHeight on a finite poset",
+  "slug": "dilworth-theorem-oq-01-oq-01-oq-02",
+  "description": "A definitional bridge lemma: the gallery's combinatorial maximum-chain-length invariant maxChainLen (a Finset.sup of chain cardinalities, used in the Mirsky hard-direction file) coincides with Mathlib's order-theoretic Set.chainHeight of the whole finite poset with respect to ≤. The proof is two one-line inequalities via Mathlib's chain-height API (encard_le_chainHeight_of_isChain and exists_eq_chainHeight_of_finite), bridged by the identity of Finset chains (IsChainOn) with set chains (IsChain (· ≤ ·)). As a corollary, Mirsky's min–max theorem is restated in Mathlib's vocabulary: the chain height of a finite poset equals the minimum size of an antichain cover. Answers the parent's listed open question.",
+  "meta": {
+    "author": "Robb Walters (researcher-3); building on Mirsky (1971) and Mathlib's Set.chainHeight",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mirsky%27s_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "order-theory",
+      "poset",
+      "mirsky",
+      "dilworth",
+      "chain-height",
+      "mathlib-bridge"
+    ],
+    "proofRepoPath": "Proofs/DilworthTheoremOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.encard_le_chainHeight_of_isChain",
+        "description": "Every chain contained in a set has extended cardinality at most the set's chainHeight — the lower-bound half, applied to the chain attaining maxChainLen",
+        "module": "Mathlib.Order.Height"
+      },
+      {
+        "theorem": "Set.exists_eq_chainHeight_of_finite",
+        "description": "On a finite set the chainHeight supremum is attained by an actual chain set — supplies the chain pushed to a Finset for the upper-bound half",
+        "module": "Mathlib.Order.Height"
+      },
+      {
+        "theorem": "Set.encard_coe_eq_coe_finsetCard",
+        "description": "The extended cardinality of a Finset coerced to a set equals its (cast) card — converts between encard and Finset.card across the two encodings",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Set.Finite.encard_eq_coe_toFinset_card",
+        "description": "A finite set's encard equals the card of its toFinset — turns the attaining chain set into a Finset bounded by maxChainLen",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Finset.le_sup",
+        "description": "Each member's value lies below the Finset supremum — bounds the attaining chain's card by maxChainLen = allChains.sup card",
+        "module": "Mathlib.Data.Finset.Lattice.Fold"
+      }
+    ],
+    "originalContributions": [
+      "isChainOn_iff_isChain: the parent's Finset-level chain predicate IsChainOn C is exactly Mathlib's set-level IsChain (· ≤ ·) on ↑C, the dictionary that makes the bridge possible",
+      "maxChainLen_eq_univ_chainHeight: (maxChainLen : ℕ∞) = (Set.univ).chainHeight (· ≤ ·), proved by antisymmetry — lower bound from the attaining chain via encard_le_chainHeight_of_isChain, upper bound from exists_eq_chainHeight_of_finite pushed through a Finset and Finset.le_sup",
+      "univ_chainHeight_ne_top: the chain height of a finite poset is finite, read off from the bridge",
+      "mirsky_chainHeight: Mirsky's min–max theorem restated in Mathlib's vocabulary — there is an antichain cover whose cardinality equals Set.chainHeight, minimal among all antichain covers"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries over an arbitrary finite PartialOrder ([PartialOrder α] [Fintype α]). Classical decidability is registered as a local instance for Finset operations; all definitions are noncomputable. The parent invariants (IsChainOn, IsAntichainOn, maxChainLen, exists_chain_card_eq_maxChainLen, mirsky_min_antichain_cover) are imported from Proofs.DilworthMirskyHardOQ01.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**Mirsky's theorem (1971)** gives a min–max identity for a finite poset: the minimum number of antichains needed to cover it equals the maximum length of a chain. The gallery's companion files formalize this via a hand-rolled invariant maxChainLen, defined combinatorially as a Finset.sup of chain cardinalities. Mathlib, independently, carries a general order-theoretic notion Set.chainHeight r s — the supremum (in ℕ∞) of the extended cardinalities of r-chains contained in s. This file proves the two are the same quantity on a finite poset, so the gallery's Mirsky development can be read directly in terms of Mathlib's standard invariant.",
+    "problemStatement": "**Bridge maxChainLen to Set.chainHeight (parent OQ-01 follow-up).** The parent file's open question asks to connect the combinatorial maxChainLen / height function to Mathlib's Set.chainHeight and prove their equivalence for finite posets. Concretely: show (maxChainLen : ℕ∞) = (Set.univ).chainHeight (· ≤ ·).",
+    "text": "A definitional bridge: the gallery's maxChainLen equals Mathlib's Set.chainHeight of the whole finite poset under ≤, established by identifying Finset chains with set chains and applying Mathlib's chain-height supremum API in both directions.",
+    "proofStrategy": "**Strategy (antisymmetry through the chain-height API).**\n\n1. **Dictionary.** Prove isChainOn_iff_isChain: a Finset C is a chain in the parent's sense (IsChainOn C, pairwise ≤-comparable) iff its coercion ↑C is a Mathlib chain IsChain (· ≤ ·). The forward direction drops the redundant x ≠ y hypothesis; the reverse handles x = y by reflexivity.\n2. **Lower bound (maxChainLen ≤ chainHeight).** Take the chain C attaining maxChainLen from the parent's exists_chain_card_eq_maxChainLen. As a set ↑C is a chain contained in univ, so encard_le_chainHeight_of_isChain gives (↑C).encard ≤ chainHeight; rewriting encard ↑C = C.card = maxChainLen finishes.\n3. **Upper bound (chainHeight ≤ maxChainLen).** exists_eq_chainHeight_of_finite (univ is finite) yields a chain set t with t.encard = chainHeight. Its toFinset is a chain Finset, hence a member of allChains, so Finset.le_sup bounds its card by maxChainLen; rewriting t.encard = card t.toFinset and casting finishes.\n4. **Corollaries.** univ_chainHeight_ne_top follows since the value equals a cast natural; mirsky_chainHeight rewrites the parent's mirsky_min_antichain_cover (cover of size maxChainLen, minimal) through the bridge to express the minimum antichain-cover size as Set.chainHeight.",
+    "keyInsights": [
+      "Mathlib's modern Set.chainHeight is set/encard-based (⨆ over chains t of t.encard), not list-based, so the bridge needs no sorting of chains into increasing lists — Finset ↔ set chain translation plus two supremum lemmas suffice.",
+      "The only genuine content is the predicate dictionary isChainOn_iff_isChain; once Finset chains are recognized as set chains, both inequalities are direct applications of off-the-shelf chain-height lemmas.",
+      "Finiteness is what makes the supremum attained on both sides: exists_chain_card_eq_maxChainLen on the Finset side and exists_eq_chainHeight_of_finite on the set side.",
+      "Carrying the equality in ℕ∞ (rather than ℕ) is essential because Set.chainHeight is valued in ℕ∞; the finiteness corollary recovers that the value is a genuine natural number.",
+      "The bridge upgrades the gallery's bespoke Mirsky statement into a statement about Mathlib's standard invariant, making mirsky_chainHeight reusable by any development phrased in Set.chainHeight."
+    ],
+    "prerequisites": [
+      "Partial orders: chains, antichains, comparability",
+      "Mathlib's Set.chainHeight and its supremum/attainment API",
+      "Extended natural numbers ℕ∞ and the encard cardinality of sets",
+      "The parent Mirsky hard-direction development (maxChainLen, mirsky_min_antichain_cover)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Docstring, imports, and classical setup",
+      "summary": "The module docstring states the bridge, contrasts the combinatorial maxChainLen with Mathlib's Set.chainHeight, and outlines the two-inequality proof. It imports Mathlib and the parent Proofs.DilworthMirskyHardOQ01, opens Classical and Set, and registers Classical.propDecidable. Context is a finite poset [PartialOrder α] [Fintype α].",
+      "startLine": 1,
+      "endLine": 64,
+      "mathContext": "Goal: $(\\mathrm{maxChainLen} : \\mathbb{N}_\\infty) = (\\mathrm{Set.univ}).\\mathrm{chainHeight}\\,(\\le)$."
+    },
+    {
+      "id": "dictionary",
+      "title": "Finset chains are set chains",
+      "summary": "isChainOn_iff_isChain: the parent's IsChainOn C holds iff IsChain (· ≤ ·) (↑C). Forward direction supplies comparability for distinct members; reverse covers equal members by reflexivity.",
+      "startLine": 66,
+      "endLine": 79,
+      "mathContext": "$\\mathrm{IsChainOn}\\,C \\iff \\mathrm{IsChain}\\,(\\le)\\,\\uparrow\\! C$."
+    },
+    {
+      "id": "bridge",
+      "title": "The bridge: maxChainLen = chainHeight",
+      "summary": "maxChainLen_eq_univ_chainHeight by le_antisymm. Lower bound: the attaining chain witnesses the chainHeight supremum via encard_le_chainHeight_of_isChain. Upper bound: a chainHeight-attaining set (exists_eq_chainHeight_of_finite) becomes a Finset in allChains, bounded by Finset.le_sup.",
+      "startLine": 81,
+      "endLine": 108,
+      "mathContext": "$\\mathrm{maxChainLen} \\le \\mathrm{chainHeight}$ from the attaining chain; $\\mathrm{chainHeight} \\le \\mathrm{maxChainLen}$ from the attaining chain set pushed to a Finset."
+    },
+    {
+      "id": "corollaries",
+      "title": "Finiteness and Mirsky in Mathlib's vocabulary",
+      "summary": "univ_chainHeight_ne_top (the chain height is a genuine natural number) and mirsky_chainHeight (the minimum antichain-cover size equals Set.chainHeight), obtained by rewriting the parent's mirsky_min_antichain_cover through the bridge.",
+      "startLine": 110,
+      "endLine": 121,
+      "mathContext": "$\\mathrm{chainHeight} \\ne \\top$; and $\\min(\\text{antichain cover}) = \\mathrm{chainHeight}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The gallery's combinatorial maxChainLen is identified with Mathlib's order-theoretic Set.chainHeight on any finite poset, answering the parent file's open question. The proof reduces to one predicate dictionary (Finset chains = set chains) plus two applications of Mathlib's chain-height supremum API. As a corollary, the gallery's Mirsky min–max theorem is restated in Mathlib's standard vocabulary. Verified with 0 sorries and 0 axioms.",
+    "implications": "The bridge lets any development that speaks Mathlib's Set.chainHeight invoke the gallery's Mirsky results directly, and vice versa. It also pins down the gallery invariant as a special case of a general library notion, reducing duplication. Natural next steps connect Set.chainHeight to Mathlib's Order.height of a single element and to poset dimension.",
+    "openQuestions": [
+      "Bridge the parent's per-element height function to Mathlib's Order.height (the supremum of lengths of chains below an element) and relate the level decomposition to Order.height fibers.",
+      "Establish the dual bridge for Dilworth: relate the minimum chain-cover number to a Mathlib width/antichain invariant once the hard direction is formalized."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "dilworth-theorem-oq-01-oq-01",
+      "relationship": "Parent / source of maxChainLen",
+      "description": "The parent file defines maxChainLen and proves Mirsky's hard direction (mirsky_min_antichain_cover). Its open question — connect maxChainLen to Set.chainHeight — is exactly what this file answers, and it supplies the imported invariants used here."
+    },
+    {
+      "proofId": "dilworth-theorem-oq-01",
+      "relationship": "Grandparent / easy direction",
+      "description": "Supplies IsChainOn and IsAntichainOn, the Finset chain/antichain predicates whose translation to Mathlib's set-level IsChain underlies the bridge."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.DilworthMirskyHardOQ01"
+    ],
+    "opens": [
+      "Classical",
+      "Set"
+    ],
+    "namespace": "DilworthTheoremOQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/DilworthTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "L. Mirsky",
+      "title": "A Dual of Dilworth's Decomposition Theorem",
+      "year": "1971",
+      "venue": "American Mathematical Monthly 78 (8): 876–877",
+      "note": "Original min–max statement bridged here to Set.chainHeight"
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "The Lean Mathematical Library — Mathlib.Order.Height",
+      "year": "2020",
+      "venue": "Mathlib4",
+      "note": "Definition of Set.chainHeight and the supremum/attainment API used in the bridge"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Definitional bridge lemma answering the parent file's (`dilworth-theorem-oq-01-oq-01`) listed open question:

> *"Connect maxChainLen and the height function to Mathlib's Set.chainHeight and prove the equivalence for finite posets."*

The gallery's Mirsky hard-direction file defines a combinatorial invariant `maxChainLen : ℕ` (a `Finset.sup` of chain cardinalities). Mathlib carries its own order-theoretic `Set.chainHeight r s : ℕ∞` (supremum of `encard`s of `r`-chains in `s`). This file proves they are the **same quantity** on a finite poset under `≤`.

## Results (4 theorems, 121 lines, 0 sorries, 0 axioms)

- `isChainOn_iff_isChain` — the parent's Finset chain predicate `IsChainOn C` equals Mathlib's set predicate `IsChain (· ≤ ·) ↑C` (the dictionary enabling the bridge).
- `maxChainLen_eq_univ_chainHeight` — `(maxChainLen : ℕ∞) = (Set.univ).chainHeight (· ≤ ·)`, by antisymmetry:
  - **≤** from the attaining chain via `Set.encard_le_chainHeight_of_isChain`;
  - **≥** from `Set.exists_eq_chainHeight_of_finite` pushed through a `Finset` and `Finset.le_sup`.
- `univ_chainHeight_ne_top` — the chain height of a finite poset is a genuine natural number.
- `mirsky_chainHeight` — Mirsky's min–max theorem restated in Mathlib's vocabulary: the minimum antichain-cover size equals `Set.chainHeight`.

## Why it's clean

Mathlib's modern `Set.chainHeight` is set/`encard`-based, so no sorting of chains into increasing lists is needed — only the predicate dictionary plus two off-the-shelf supremum lemmas.

## Verification

Docker daemon was down; verified with `lake env lean` against main's prebuilt Mathlib oleans (toolchain `leanprover/lean4:v4.26.0`) by compiling the parent chain (`DilworthTheoremOQ01` → `DilworthMirskyHardOQ01` → this file). Clean compile, no warnings. `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — **0 axioms** in the policy sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)