### PR TITLE
Enrich Burnside rotation fixed-point closed form (burnside-counting-oq-04-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "burnside-oq04010101-ann-overview",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "concept",
+    "title": "From per-n decide to a uniform closed form",
+    "content": "The parent entry computed binary bracelet counts $b(5)=8$, $b(6)=13$ by evaluating the Burnside fixed-point sum $\\sum_{g\\in D_n}|\\mathrm{Fix}(g)|$ with kernel `decide` — one length at a time. Its open question asked for a **closed form** for the individual fixed-point counts. This file proves the generic rotation term with no computation and uniformly in $n$: the binary colourings of the $n$-cycle fixed by the rotation $x\\mapsto x+i$ number exactly $2^{\\gcd(n,\\,i.\\mathrm{val})}$. The principle is Burnside-flavoured: a colouring is fixed by the rotation iff it is constant on the rotation's orbits, and the rotation $x\\mapsto x+i$ has exactly $\\gcd(n,i)$ orbits (the index of the cyclic subgroup $\\langle i\\rangle\\le\\mathbb{Z}/n$), so the count is $2$ to the number of orbits. Honest scope: only the rotation half is closed-form here; the reflection contribution is left to future work.",
+    "mathContext": "$\\#\\{c:\\mathbb{Z}/n\\to\\mathbb{F}_2 \\mid c(p+i)=c(p)\\ \\forall p\\} = 2^{\\gcd(n,\\,i)}.$",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "necklace/bracelet counting", "cyclic group action", "orbit counting", "fixed points"],
+    "prerequisites": ["group actions", "ZMod n", "greatest common divisor"]
+  },
+  {
+    "id": "burnside-oq04010101-ann-defs",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 71 },
+    "type": "definition",
+    "title": "Colourings, rotation-invariance, and the fixed subtype",
+    "content": "`Coloring n := ZMod n → Fin 2` is a binary colouring of the $n$ vertices (there are $2^n$). `IsRotInvariant i c` is the predicate $\\forall p,\\ c(p+i)=c(p)$ — the colouring is unchanged by the rotation $x\\mapsto x+i$. `RotFixed n i` packages the fixed colourings as a subtype $\\{c\\mid \\texttt{IsRotInvariant } i\\ c\\}$. The `DecidablePred` and `Fintype` instances (needing `[NeZero n]`) make `Fintype.card (RotFixed n i)` and the finite cross-checks meaningful.",
+    "mathContext": "$\\mathrm{Coloring}(n)=\\mathbb{F}_2^{\\,\\mathbb{Z}/n},\\qquad \\mathrm{RotFixed}(n,i)=\\{c \\mid c(p+i)=c(p)\\ \\forall p\\}.$",
+    "significance": "technical",
+    "relatedConcepts": ["binary colouring", "fixed-point subtype", "DecidablePred", "Fintype.card"],
+    "prerequisites": ["ZMod n", "Fin 2", "subtypes in Lean"]
+  },
+  {
+    "id": "burnside-oq04010101-ann-zsmul",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 73, "endLine": 93 },
+    "type": "technique",
+    "title": "invariant_zsmul — single shift extends to the whole cyclic subgroup",
+    "content": "`invariant_zsmul` upgrades invariance under one shift $+i$ to invariance under $+k\\cdot i$ for every *integer* $k$, by `Int.induction_on`. The successor branch rewrites $p+(k{+}1)i = (p+ki)+i$ and applies `h` then the inductive hypothesis; the predecessor branch uses the 'subtract $i$' form $c(p-i)=c(p)$ (obtained by substituting $p\\mapsto p-i$ in `h`). The content is geometric: an invariant colouring is **constant on each coset** of the additive cyclic subgroup $\\langle i\\rangle = \\texttt{zmultiples } i$ — the orbits of the rotation. This is the bridge from a one-step symmetry to a subgroup-wide one.",
+    "mathContext": "$c(p+i)=c(p)\\ \\forall p \\;\\Longrightarrow\\; c(p+k\\cdot i)=c(p)\\ \\forall k\\in\\mathbb{Z},\\ p\\in\\mathbb{Z}/n.$",
+    "significance": "key",
+    "relatedConcepts": ["cyclic subgroup ⟨i⟩", "cosets / orbits", "integer induction", "zmultiples"],
+    "prerequisites": ["Int.induction_on", "additive subgroups", "zsmul"]
+  },
+  {
+    "id": "burnside-oq04010101-ann-equiv",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 121 },
+    "type": "theorem",
+    "title": "rotFixedEquiv — fixed colourings ≃ functions on the coset space",
+    "content": "The bijection `RotFixed n i ≃ (ZMod n ⧸ zmultiples i → Fin 2)`. Forward: an invariant colouring factors through the quotient via `Quotient.liftOn'`, well-defined because $b\\sim a \\Rightarrow b=a+k\\cdot i \\Rightarrow c(b)=c(a)$ (exactly `invariant_zsmul`). Backward: any function on the quotient pulls back along `QuotientAddGroup.mk`, and the pullback is invariant because $(p+i)-p=i\\in\\langle i\\rangle$. Both round-trips are definitional (`rfl` after `Quotient.inductionOn'`). This recasts 'count fixed colourings' as 'count arbitrary functions on the orbit space'.",
+    "mathContext": "$\\{c \\mid \\texttt{IsRotInvariant } i\\ c\\} \\;\\simeq\\; \\big(\\mathbb{Z}/n \\,/\\, \\langle i\\rangle \\to \\mathbb{F}_2\\big).$",
+    "significance": "key",
+    "relatedConcepts": ["quotient group", "Quotient.liftOn'", "QuotientAddGroup.mk", "coset space", "equivalence of types"],
+    "prerequisites": ["quotient additive groups", "Quotient.liftOn'", "type equivalences"]
+  },
+  {
+    "id": "burnside-oq04010101-ann-gcd",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 149 },
+    "type": "theorem",
+    "title": "card_quotient_zmultiples — the orbit count is gcd(n, i)",
+    "content": "The coset space $\\mathbb{Z}/n \\,/\\, \\langle i\\rangle$ has exactly $\\gcd(n,\\,i.\\mathrm{val})$ points — the number of orbits of the rotation. The proof combines three facts: `Nat.card_zmultiples` with `ZMod.addOrderOf_coe` gives $|\\langle i\\rangle| = \\mathrm{addOrderOf}\\ i = n/\\gcd(n,i)$; Lagrange's `index_mul_card` gives $\\mathrm{index}\\cdot|\\langle i\\rangle| = |\\mathbb{Z}/n| = n$; identifying the index with the quotient's cardinality and cancelling the positive factor $n/\\gcd(n,i)$ leaves $\\mathrm{index}=\\gcd(n,i)$.",
+    "mathContext": "$|\\,\\mathbb{Z}/n \\,/\\, \\langle i\\rangle\\,| = \\frac{n}{|\\langle i\\rangle|} = \\frac{n}{n/\\gcd(n,i)} = \\gcd(n,\\,i).$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's theorem", "subgroup index", "additive order", "addOrderOf", "gcd"],
+    "prerequisites": ["Lagrange's theorem (index_mul_card)", "order of a cyclic subgroup", "Nat division identities"]
+  },
+  {
+    "id": "burnside-oq04010101-ann-closedform",
+    "proofId": "burnside-counting-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 150, "endLine": 183 },
+    "type": "theorem",
+    "title": "card_rotFixed and corollaries — the 2^gcd(n,i) closed form",
+    "content": "Chaining the bijection (`Fintype.card_congr (rotFixedEquiv i)`), the function-space count (`Fintype.card_fun`, `Fintype.card_fin`), and the orbit count (`card_quotient_zmultiples`) reads off the headline $\\#\\mathrm{RotFixed}(n,i) = 2^{\\gcd(n,\\,i.\\mathrm{val})}$. Corollaries: $i=0$ fixes all $2^n$ colourings; a generator ($\\gcd(n,i)=1$, e.g. any nonzero rotation for $n$ prime) fixes exactly the $2$ constant colourings. The cross-checks `rotation_sum_five` ($\\sum_{i:\\mathbb{Z}/5}=40$) and `rotation_sum_six` ($\\sum_{i:\\mathbb{Z}/6}=84$) recover the rotation sub-sums of the parent's computed Burnside totals — now from the formula via ordinary kernel `decide` on closed ℕ arithmetic (no `native_decide`, so still axiom-free).",
+    "mathContext": "$\\#\\mathrm{RotFixed}(n,i)=2^{\\gcd(n,i)};\\quad i=0\\mapsto 2^n;\\quad \\gcd(n,i)=1\\mapsto 2.$",
+    "significance": "key",
+    "relatedConcepts": ["Fintype.card_fun", "closed-form count", "Burnside sum", "kernel decide", "necklace counting"],
+    "prerequisites": ["Fintype cardinality lemmas", "exponentiation", "gcd"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -83,6 +83,14 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview and Scope: the rotation half of the closed form",
+      "startLine": 3,
+      "endLine": 52,
+      "summary": "Module docstring: the parent computed bracelet counts via per-n kernel decide and asked for a closed form. This file proves the generic rotation term 2^gcd(n, i.val) uniformly in n (no computation), plus the namespace, the Coloring/IsRotInvariant/RotFixed definitions and their Fintype instances. Honest scope: only the rotation half; the reflection contribution is left to future work; everything is axiom-free (kernel decide, no native_decide).",
+      "mathContext": "$\\#\\{c:\\mathbb{Z}/n\\to\\mathbb{F}_2 \\mid c(p+i)=c(p)\\} = 2^{\\gcd(n,\\,i)}.$"
+    },
+    {
       "id": "invariance",
       "title": "Rotation Invariance Extends to the Whole Cyclic Subgroup",
       "startLine": 54,


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04-oq-01-oq-01-oq-01` (Closed form for the rotation fixed-point count: |Fix(r_i)| = 2^gcd(n,i)).

## Changes
- **Created `annotations.json` from scratch** — the entry had **0 annotations**. 6 annotations now cover every part of the proof: overview/scope, the Coloring/IsRotInvariant/RotFixed definitions, `invariant_zsmul` (single shift → whole cyclic subgroup), `rotFixedEquiv` (fixed colourings ≃ functions on the coset space), `card_quotient_zmultiples` (orbit count = gcd via Lagrange), and `card_rotFixed` + corollaries (the 2^gcd(n,i) closed form). Each has `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **Added a module-overview section** to `meta.sections` (lines 3–52 were uncovered); sections now span the full file.

The existing meta was already rich (overview, conclusion, crossReferences) and accurate; this pass fills the annotation gap. 0 sorries, 0 axioms (kernel `decide` on closed ℕ, **not** native_decide — verified/original badge is honest). Verified with `pnpm build`.