### PR TITLE
audit(baire-oq-01-oq-03): badge original → mathlib (Tier B Mathlib bridge)

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-03/meta.json
@@ -44,7 +44,7 @@
     "author": "Lean Genius",
     "status": "verified",
     "proofRepoPath": "Proofs/BaireCategoryTheoremOQ01OQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 95,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: \`baire-category-theorem-oq-01-oq-03\` — "Perfect Complete Metric Spaces Have at Least the Cardinality of the Continuum"
**Severity**: MEDIUM — Mathlib wrapper claimed as \`original\`

## Problem

The core result \`continuum_le_mk_of_perfect\` (𝔠 ≤ #C for a nonempty perfect set C in a complete metric space) is a ~7-line bridge: it corestricts **Mathlib's Cantor-scheme injection** \`Perfect.exists_nat_bool_injection\` to the subtype and combines with cardinal arithmetic. Mathlib does all the hard work (the nested-balls construction); the file supplies the cardinality corollary.

Per the auditor Tier classification this is **Tier B** (core argument relies on a Mathlib theorem; file provides the bridge), whose badge must be \`mathlib\`, not \`original\`.

## Evidence

The **direct sibling** \`baire-category-theorem-oq-01-oq-02\` has the *identical* headline result (\`continuum_le_mk_of_perfect\`, same Mathlib engine) and is correctly badged \`mathlib\`:

| entry | status | badge |
|-------|--------|-------|
| baire-...-oq-01-oq-02 | verified | **mathlib** |
| baire-...-oq-01-oq-03 (this) | verified | original ← inconsistent |

The entry's own \`mathlibDependencies\` already lists \`Perfect.exists_nat_bool_injection\` as "the engine of the whole entry," and the overview states "Mathlib supplies the Cantor-scheme injection but not the cardinality corollary." The prose is honest and transparent — only the badge field overclaimed independence.

## Fix

\`badge\`: \`original\` → \`mathlib\` (one field). Status stays \`verified\` (0 sorries, 0 axioms — machine-checked). No prose changes needed; the description already credits Mathlib.

---
Discovered during gallery integrity audit.