### PR TITLE
research(wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01): Kempner value of a squarefree semiprime S(p·q)=max(p,q) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4029,6 +4029,7 @@ import Proofs.WilsonsTheoremOQ03
 import Proofs.WilsonsTheoremOQ04
 import Proofs.WilsonsTheoremOQ04OQ02
 import Proofs.WilsonsTheoremOQ05
+import Proofs.WilsonsTheoremOQ05OQ01OQ01OQ01OQ01
 import Proofs.WilsonsTheoremOQ06
 import Proofs.WolstenholmePrimeMod4
 import Proofs.WolstenholmeTheorem

--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,126 @@
+import Mathlib
+
+/-
+# The Kempner–Smarandache value of a squarefree semiprime: `S(p·q) = max p q`
+
+**Open Question (`wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01`)**: the parent
+entry `wilsons-theorem-oq-05-oq-01-oq-01-oq-01` computed the Kempner–Smarandache
+function on prime powers, proving `S(p^k) = p·k ↔ k ≤ p` and isolating the role
+of the largest prime power dividing `n`.  For a general `n` the Kempner function
+is the *maximum* of its values on the prime-power factors,
+
+  `S(n) = max_{p^k ‖ n} S(p^k)`,
+
+so the very first nontrivial multi-prime case is the squarefree semiprime
+`n = p·q` with `p ≠ q` prime, where each prime appears to the first power and
+`S(p) = p`, `S(q) = q`.  This entry proves the expected closed form
+
+  `S(p·q) = max p q`     (for distinct primes `p`, `q`).
+
+## The mathematics
+
+The Kempner–Smarandache function is `S m = sInf {n | m ∣ n !}`, the least `n`
+whose factorial is divisible by `m`.  For distinct primes `p`, `q`:
+
+* **Upper bound `S(p·q) ≤ max p q`.**  Both `p` and `q` are `≤ max p q`, so each
+  divides `(max p q)!` (a prime divides `n!` iff it is `≤ n`).  Being *distinct*
+  primes they are coprime, hence their product divides `(max p q)!`.  Thus
+  `max p q` is a witness and `S(p·q)` cannot exceed it.
+
+* **Lower bound `max p q ≤ S(p·q)`.**  By definition `p·q ∣ (S(p·q))!`, so in
+  particular `p ∣ (S(p·q))!` and `q ∣ (S(p·q))!`.  Since a prime divides a
+  factorial only once the index reaches it, both `p ≤ S(p·q)` and `q ≤ S(p·q)`,
+  i.e. `max p q ≤ S(p·q)`.
+
+Antisymmetry gives the exact value.  As a corollary `S(p·q) = max p q < p·q`,
+the **Kempner drop** for composite arguments that the grandparent threshold
+theorem `(∃ m < n, n ∣ m!) ↔ (¬ n.Prime ∧ n ≠ 4)` predicts qualitatively — here
+made fully explicit, with the precise value of the drop.
+
+The engine is purely the prime-divides-factorial criterion
+`Nat.Prime.dvd_factorial : p ∣ n! ↔ p ≤ n` and coprimality of distinct primes
+`Nat.coprime_primes`; no Legendre valuation machinery is needed because each
+prime occurs to the first power.
+-/
+
+open Nat
+
+namespace WilsonsTheoremOQ05OQ01OQ01OQ01OQ01
+
+/-! ## The Kempner–Smarandache function
+
+We re-establish the minimal interface from the parent entry so this file is
+self-contained: the function `S` together with its membership and minimality
+witnesses. -/
+
+/-- The **Kempner–Smarandache function**: the least `n` with `m ∣ n!`.
+For `m ≥ 1` this is well defined, since `m ∣ m!`. -/
+noncomputable def S (m : ℕ) : ℕ := sInf {n | m ∣ n !}
+
+/-- For `m ≥ 1`, `S m` is an actual witness: `m ∣ (S m)!`. -/
+theorem dvd_factorial_S {m : ℕ} (hm : 0 < m) : m ∣ (S m)! := by
+  have hne : Set.Nonempty {n | m ∣ n !} := ⟨m, Nat.dvd_factorial hm le_rfl⟩
+  exact Nat.sInf_mem hne
+
+/-- `S m` is the *least* witness: every `n` with `m ∣ n!` satisfies `S m ≤ n`. -/
+theorem S_le {m n : ℕ} (h : m ∣ n !) : S m ≤ n := Nat.sInf_le h
+
+/-! ## The squarefree semiprime value -/
+
+variable {p q : ℕ}
+
+/-- **Upper bound.**  For distinct primes `p`, `q` the product `p·q` divides
+`(max p q)!`: each prime is `≤ max p q` hence divides the factorial, and being
+distinct primes they are coprime, so their product divides it too.  Therefore
+`max p q` is a Kempner witness for `p·q`. -/
+theorem semiprime_dvd_factorial_max (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    p * q ∣ (max p q)! := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr hpq
+  have hpd : p ∣ (max p q)! := (hp.dvd_factorial).mpr (le_max_left p q)
+  have hqd : q ∣ (max p q)! := (hq.dvd_factorial).mpr (le_max_right p q)
+  exact hcop.mul_dvd_of_dvd_of_dvd hpd hqd
+
+/-- **The Kempner–Smarandache value of a squarefree semiprime.**
+For distinct primes `p`, `q`, `S(p·q) = max p q`. -/
+theorem S_semiprime (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    S (p * q) = max p q := by
+  -- Upper bound: `max p q` is a witness.
+  have hupper : S (p * q) ≤ max p q := S_le (semiprime_dvd_factorial_max hp hq hpq)
+  -- Lower bound: `p·q ∣ (S(p·q))!` forces both primes to lie below `S(p·q)`.
+  have hpos : 0 < p * q := Nat.mul_pos hp.pos hq.pos
+  have hdvd : p * q ∣ (S (p * q))! := dvd_factorial_S hpos
+  have hpS : p ≤ S (p * q) := (hp.dvd_factorial).mp ((dvd_mul_right p q).trans hdvd)
+  have hqS : q ≤ S (p * q) := (hq.dvd_factorial).mp ((dvd_mul_left q p).trans hdvd)
+  have hlower : max p q ≤ S (p * q) := max_le hpS hqS
+  exact le_antisymm hupper hlower
+
+/-- **The Kempner drop, explicitly.**  For distinct primes `p`, `q` the value
+`S(p·q) = max p q` is *strictly below* `p·q`; the grandparent threshold theorem
+guarantees such a drop for every composite, and here it is computed exactly. -/
+theorem S_semiprime_lt_self (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    S (p * q) < p * q := by
+  rw [S_semiprime hp hq hpq]
+  exact max_lt (lt_mul_of_one_lt_right hp.pos hq.one_lt)
+    (lt_mul_of_one_lt_left hq.pos hp.one_lt)
+
+/-- **Symmetry.**  `S` only sees the product, so the value is symmetric in the
+two primes. -/
+theorem S_semiprime_comm (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q) :
+    S (p * q) = S (q * p) := by
+  rw [S_semiprime hp hq hpq, S_semiprime hq hp hpq.symm, max_comm]
+
+/-! ## Sanity checks -/
+
+/-- `S(6) = 3 = max 2 3`. -/
+example : S (2 * 3) = 3 := by
+  rw [S_semiprime Nat.prime_two Nat.prime_three (by norm_num)]; decide
+
+/-- `S(15) = 5 = max 3 5`. -/
+example : S (3 * 5) = 5 := by
+  rw [S_semiprime Nat.prime_three (by norm_num) (by norm_num)]; decide
+
+/-- `S(35) = 7 = max 5 7`. -/
+example : S (5 * 7) = 7 := by
+  rw [S_semiprime (by norm_num) (by norm_num) (by norm_num)]; decide
+
+end WilsonsTheoremOQ05OQ01OQ01OQ01OQ01

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Kempner–Smarandache Value of a Squarefree Semiprime: $S(p\\cdot q) = \\max(p,q)$",
+  "slug": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "description": "Answers the open question of the parent entry `wilsons-theorem-oq-05-oq-01-oq-01-oq-01`, which computed the Kempner–Smarandache function S(n) = min{m : n ∣ m!} on prime powers (S(p^k) = p·k ⟺ k ≤ p) and asked to assemble the value of S on a general n from its prime-power factors. This entry settles the first nontrivial multi-prime case: the squarefree semiprime n = p·q with p ≠ q prime, proving the closed form S(p·q) = max(p,q). The function is re-established self-contained as `S m = sInf {n | m ∣ n!}` with `dvd_factorial_S` (m ∣ (S m)! for m ≥ 1) and `S_le` (least-witness property). The upper bound `semiprime_dvd_factorial_max` shows p·q ∣ (max p q)!: both primes are ≤ max p q so each divides the factorial (`Nat.Prime.dvd_factorial`: p ∣ n! ↔ p ≤ n), and being distinct primes they are coprime (`Nat.coprime_primes`), so their product divides it (`Nat.Coprime.mul_dvd_of_dvd_of_dvd`); hence S(p·q) ≤ max p q. The lower bound runs the divisibility backwards: p·q ∣ (S(p·q))! gives p ∣ (S(p·q))! and q ∣ (S(p·q))!, so p ≤ S(p·q) and q ≤ S(p·q), i.e. max p q ≤ S(p·q). Antisymmetry yields S(p·q) = max(p,q) (`S_semiprime`). The corollary `S_semiprime_lt_self` makes the grandparent's qualitative Kempner drop fully explicit: S(p·q) = max(p,q) < p·q for distinct primes — the exact value of the drop. Unlike the prime-power case no Legendre valuation machinery is needed, because each prime occurs to the first power; the entire argument is the prime-divides-factorial criterion plus coprimality of distinct primes. Fully machine-checked: 0 sorries, 0 axioms beyond the foundational propext, Classical.choice, Quot.sound; the numeric sanity checks use `decide` (plain kernel reduction, not native_decide).",
+  "meta": {
+    "author": "Kempner (1918) / Smarandache function S(n) = min{m : n ∣ m!}; squarefree-semiprime value S(pq) = max(p,q) formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kempner_function",
+    "date": "1918",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "kempner-function",
+      "smarandache-function",
+      "factorial",
+      "squarefree-semiprime",
+      "coprimality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The development rests on elementary Mathlib divisibility infrastructure: `Nat.Prime.dvd_factorial` (p ∣ n! ↔ p ≤ n, for prime p), `Nat.coprime_primes` (Coprime p q ↔ p ≠ q for primes p, q), `Nat.Coprime.mul_dvd_of_dvd_of_dvd` (coprime a, b each dividing c ⟹ a·b ∣ c), `Nat.dvd_factorial`, and the order lemmas `lt_mul_of_one_lt_right` / `lt_mul_of_one_lt_left` for the strict drop. The Kempner function is built on `Nat.sInf` (`Nat.sInf_mem`, `Nat.sInf_le`). The three numeric sanity checks (S(6)=3, S(15)=5, S(35)=7) use `decide` on concrete `max` values — plain kernel decidability, NOT native_decide — so the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.dvd_factorial",
+        "description": "`p.Prime → (p ∣ n! ↔ p ≤ n)`. The single engine of both bounds: forward it gives the upper bound (p, q ≤ max p q ⟹ each divides (max p q)!), and backward it gives the lower bound (p ∣ (S(pq))! ⟹ p ≤ S(pq)).",
+        "module": "Mathlib.Data.Nat.Prime.Factorial"
+      },
+      {
+        "theorem": "Nat.coprime_primes",
+        "description": "`p.Prime → q.Prime → (Nat.Coprime p q ↔ p ≠ q)`. Distinct primes are coprime — the fact that lets the two single-prime divisibilities combine into p·q ∣ (max p q)!.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+        "description": "`Nat.Coprime a b → a ∣ c → b ∣ c → a·b ∣ c`. Assembles p ∣ (max p q)! and q ∣ (max p q)! into p·q ∣ (max p q)!, giving the witness for the upper bound S(pq) ≤ max p q.",
+        "module": "Mathlib.RingTheory.Coprime.Lemmas"
+      },
+      {
+        "theorem": "Nat.dvd_factorial / Nat.sInf_mem / Nat.sInf_le",
+        "description": "`0 < m → m ≤ n → m ∣ n!` makes m ∣ m! so {n | m ∣ n!} is nonempty; `Nat.sInf_mem` and `Nat.sInf_le` then make S m = sInf{n | m ∣ n!} a genuine least witness (`dvd_factorial_S`, `S_le`).",
+        "module": "Mathlib.Data.Nat.Factorial.Basic / Mathlib.Data.Nat.Lattice"
+      },
+      {
+        "theorem": "lt_mul_of_one_lt_right / lt_mul_of_one_lt_left",
+        "description": "`0 < a → 1 < b → a < a·b` and `0 < b → 1 < a → b < a·b`. With both primes > 1 these give p < p·q and q < p·q, hence max p q < p·q — the strict Kempner drop.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "`S`, `dvd_factorial_S`, `S_le`: the Kempner–Smarandache function S m = sInf {n | m ∣ n!} with its membership and least-witness specification, re-established self-contained from the parent so the file stands alone.",
+      "`semiprime_dvd_factorial_max`: for distinct primes p, q the product p·q divides (max p q)! — each prime divides the factorial (being ≤ max p q) and distinct primes are coprime, so the product divides it. This is the witness behind the upper bound.",
+      "`S_semiprime`: the headline closed form S(p·q) = max(p,q) for distinct primes, by antisymmetry of the witness upper bound and the prime-forced lower bound.",
+      "`S_semiprime_lt_self`: the explicit Kempner drop S(p·q) = max(p,q) < p·q — the grandparent threshold theorem's qualitative 'S(n) < n for composite n' made quantitative for squarefree semiprimes.",
+      "`S_semiprime_comm`: symmetry S(p·q) = S(q·p), reflecting that S sees only the product.",
+      "Three numeric sanity checks S(6) = 3, S(15) = 5, S(35) = 7 confirming max p q against the smaller prime, discharged by plain `decide`."
+    ],
+    "prerequisites": [
+      "The Kempner–Smarandache function S(n) = min {m : n ∣ m!}",
+      "A prime divides a factorial iff the index reaches it (`Nat.Prime.dvd_factorial`)",
+      "Distinct primes are coprime (`Nat.coprime_primes`) and coprime divisors multiply into the dividend",
+      "The least-element operator `Nat.sInf` and its membership/minimality lemmas"
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+        "relationship": "Parent: computed S(p^k) for prime powers (S(p^k) = p·k ⟺ k ≤ p) and asked to assemble S(n) for general n from its prime-power factors as a maximum. This entry settles the first multi-prime case — the squarefree semiprime p·q — giving S(p·q) = max(p,q), exactly the max of the two single-prime values S(p) = p, S(q) = q."
+      },
+      {
+        "id": "wilsons-theorem-oq-05-oq-01-oq-01",
+        "relationship": "Grandparent: proved the Kempner threshold (∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4), locating when S(n) < n. `S_semiprime_lt_self` makes that drop explicit for p·q: S(p·q) = max(p,q) < p·q."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 126,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 7
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The Kempner–Smarandache function S(n) = min{m : n ∣ m!} (Kempner 1918, later rediscovered as the Smarandache function) inverts the factorial: it asks for the smallest factorial divisible by n. On primes the answer is immediate (S(p) = p), and on prime powers it is governed by Legendre's formula (the parent entry). A classical structural fact is that S is determined by its values on the prime-power factors of n via a maximum: S(n) = max over p^k ∥ n of S(p^k). The simplest case combining two distinct primes is the squarefree semiprime n = p·q, where each prime appears to the first power and the formula predicts S(p·q) = max(S(p), S(q)) = max(p, q).",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-05-oq-01-oq-01-oq-01):** assemble the Kempner–Smarandache value S(n) for general n from its prime-power factors. This entry resolves the first multi-prime instance: for distinct primes p, q, S(p·q) = max(p, q), with the explicit drop S(p·q) < p·q.",
+    "text": "For distinct primes p and q, the least m with p·q ∣ m! is max(p, q); in particular S(p·q) < p·q.",
+    "proofStrategy": "Define S m = sInf {n | m ∣ n!}; m ∣ m! gives nonemptiness, so Nat.sInf_mem/Nat.sInf_le give m ∣ (S m)! and the least-witness property S m ≤ n. Upper bound: by Nat.Prime.dvd_factorial both p, q ≤ max p q divide (max p q)!; distinct primes are coprime (Nat.coprime_primes), so Nat.Coprime.mul_dvd_of_dvd_of_dvd gives p·q ∣ (max p q)!, hence S(p·q) ≤ max p q. Lower bound: from p·q ∣ (S(p·q))! we get p ∣ (S(p·q))! and q ∣ (S(p·q))! (dvd_mul_right/dvd_mul_left then transitivity), so Nat.Prime.dvd_factorial gives p ≤ S(p·q) and q ≤ S(p·q), i.e. max p q ≤ S(p·q). Antisymmetry yields equality. The strict drop S(p·q) < p·q follows from max_lt with p < p·q and q < p·q (both primes exceed 1).",
+    "keyInsights": [
+      "**No Legendre machinery needed for squarefree arguments.** Because each prime occurs to the first power, the whole computation is the single criterion 'a prime divides n! iff it is ≤ n' (Nat.Prime.dvd_factorial), used forward for the upper bound and backward for the lower bound — a marked simplification over the prime-power case, which required the full p-adic valuation of factorials.",
+      "**Coprimality is the only assembly tool.** The two single-prime divisibilities p ∣ (max p q)! and q ∣ (max p q)! combine into p·q ∣ (max p q)! solely because distinct primes are coprime; this is the squarefree shadow of the CRT-style combination that assembles S on a general n.",
+      "**S(p·q) = max(p, q) = max(S(p), S(q)).** The semiprime value is exactly the maximum of the per-prime Kempner values, confirming the 'maximum over prime powers' law in its first genuinely multi-prime instance.",
+      "**The drop is exact, not just qualitative.** The grandparent threshold theorem guarantees only S(n) < n for composite n ≠ 4; here for n = p·q the value of the drop is pinned precisely: S(p·q) = max(p, q), with deficit p·q − max(p, q) = max(p,q)·(min(p,q) − 1)."
+    ],
+    "prerequisites": [
+      "The Kempner–Smarandache function S(n) = min{m : n ∣ m!}",
+      "Nat.Prime.dvd_factorial: a prime divides n! iff it is ≤ n",
+      "Distinct primes are coprime; coprime divisors multiply into the dividend",
+      "The least-element operator Nat.sInf and its lemmas"
+    ]
+  },
+  "conclusion": {
+    "summary": "The parent's prime-power value is extended to the first multi-prime case: defining S m = sInf{n | m ∣ n!}, for distinct primes p, q we prove S(p·q) = max(p, q) by antisymmetry — an upper bound from p·q ∣ (max p q)! (each prime divides the factorial, coprimality multiplies them) and a lower bound from p·q ∣ (S(p·q))! forcing both primes below S(p·q). The corollary S(p·q) < p·q makes the grandparent's Kempner drop explicit. 7 theorems, 1 definition, 126 lines, 0 sorries, 0 axioms; numeric checks use plain decide, no native_decide.",
+    "implications": "Confirms the 'S(n) = max over prime powers p^k ∥ n of S(p^k)' law in its first multi-prime case and isolates coprimality as the assembly mechanism. The natural next step is the general squarefree value S(p₁···p_r) = max p_i, and beyond it the full S(n) = max over prime powers, combining this coprime-product argument with the per-prime-power values of the parent.",
+    "openQuestions": [
+      "Generalize to an arbitrary squarefree number: prove S(p₁·p₂···p_r) = max_i p_i for distinct primes, by induction on the number of prime factors using the same coprime-product upper bound and prime-forced lower bound.",
+      "Combine with the parent's prime-power values to prove the full law S(n) = max over prime powers p^k ∥ n of S(p^k) for every n ≥ 1."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring stating the closed form S(p·q) = max(p,q) for distinct primes, the upper/lower bound strategy, and the explicit Kempner drop; imports Mathlib, opens Nat."
+    },
+    {
+      "id": "kempner-function",
+      "title": "The Kempner–Smarandache Function",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "Re-establishes S m = sInf {n | m ∣ n!} self-contained: dvd_factorial_S (m ∣ (S m)! for m ≥ 1, via Nat.sInf_mem and m ∣ m!) and S_le (least-witness property, via Nat.sInf_le)."
+    },
+    {
+      "id": "semiprime-value",
+      "title": "The Squarefree Semiprime Value",
+      "startLine": 69,
+      "endLine": 110,
+      "summary": "semiprime_dvd_factorial_max (p·q ∣ (max p q)! via coprimality), S_semiprime (S(p·q) = max p q by antisymmetry), S_semiprime_lt_self (the explicit drop S(p·q) < p·q), and S_semiprime_comm (symmetry in the two primes)."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Numeric Sanity Checks",
+      "startLine": 111,
+      "endLine": 126,
+      "summary": "Concrete evaluations S(6) = 3, S(15) = 5, S(35) = 7, each rewriting via S_semiprime and discharging max by plain decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent computed S(p^k) for prime powers and asked to assemble S(n) for general n from its prime-power factors. This entry settles the first multi-prime case: S(p·q) = max(p,q) for distinct primes, the maximum of the per-prime values S(p) = p and S(q) = q."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "The grandparent proved the Kempner threshold (∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4). S_semiprime_lt_self makes that qualitative drop explicit for p·q: S(p·q) = max(p,q) < p·q."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question of the parent entry **`wilsons-theorem-oq-05-oq-01-oq-01-oq-01`** (which computed the Kempner–Smarandache function on prime powers, `S(p^k) = p·k ⟺ k ≤ p`, and asked to assemble `S(n)` for general `n` from its prime-power factors as a maximum).

This entry settles the **first multi-prime case** — the squarefree semiprime `n = p·q` with `p ≠ q` prime:

$$S(p\cdot q) = \max(p, q).$$

## Mathematics

With `S m = sInf {n | m ∣ n!}` (least `n` whose factorial is divisible by `m`):

- **Upper bound** (`semiprime_dvd_factorial_max`): both primes are `≤ max p q`, so each divides `(max p q)!` (`Nat.Prime.dvd_factorial`: `p ∣ n! ↔ p ≤ n`); distinct primes are coprime (`Nat.coprime_primes`), so their product divides it (`Nat.Coprime.mul_dvd_of_dvd_of_dvd`). Hence `S(p·q) ≤ max p q`.
- **Lower bound**: `p·q ∣ (S(p·q))!` gives `p ∣ (S(p·q))!` and `q ∣ (S(p·q))!`, so `p, q ≤ S(p·q)`, i.e. `max p q ≤ S(p·q)`.
- Antisymmetry ⟹ `S(p·q) = max(p,q)` (`S_semiprime`).
- **Explicit Kempner drop** (`S_semiprime_lt_self`): `S(p·q) = max(p,q) < p·q`, making the grandparent threshold theorem `(∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4)` quantitative.

No Legendre valuation machinery is needed — each prime occurs to the first power, so the whole argument is the prime-divides-factorial criterion plus coprimality of distinct primes. This is the squarefree shadow of the maximum-over-prime-powers law `S(p·q) = max(S(p), S(q))`.

## Verification

- **7 theorems, 1 definition, 126 lines, 0 sorries, 0 axioms.**
- `#print axioms` for `S_semiprime` / `S_semiprime_lt_self` = `propext, Classical.choice, Quot.sound` only.
- Numeric sanity checks `S(6)=3, S(15)=5, S(35)=7` use plain `decide` (kernel reduction, **not** `native_decide`).
- Compiled via `lake env lean` against the repo's Mathlib (Docker daemon unavailable this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)