### PR TITLE
research(kummer-theorem-oq-02-oq-03): mixed-radix Kummer carry law [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3220,6 +3220,7 @@ import Proofs.KummerTheoremOQ01
 import Proofs.KummerTheoremOQ01Aristotle
 import Proofs.KummerTheoremOQ01OQ01
 import Proofs.KummerTheoremOQ02
+import Proofs.KummerTheoremOQ02OQ03
 import Proofs.KummerTheoremOQ03
 import Proofs.KummerTheoremOQ04
 import Proofs.KummerTheoremOQ04OQ02

--- a/proofs/Proofs/KummerTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/KummerTheoremOQ02OQ03.lean
@@ -1,0 +1,263 @@
+/-
+Kummer's Theorem OQ-02-OQ-03: Mixed-Radix Carry Law
+
+Parent (q-Kummer, KummerTheoremOQ02) established that for a *single* base d ≥ 2,
+the cyclotomic multiplicity of Φ_d in the q-binomial [n choose k]_q equals the
+floor deficiency
+
+    e_d = ⌊n/d⌋ − ⌊k/d⌋ − ⌊(n−k)/d⌋ ∈ {0, 1},
+
+which is exactly the carry crossing the d-boundary when adding k and (n−k) in
+base d.  Parent open question #3 asks:
+
+    "Can the floor deficiency be related to carries in MIXED-RADIX numeral systems?"
+
+This file answers it.  We fix an arbitrary sequence of bases  b : ℕ → ℕ  (each
+b i ≥ 1) with positional weights
+
+    W₀ = 1,   W_{i+1} = W_i · b_i,
+
+so a number is written in the mixed-radix system  (b₀, b₁, b₂, …)  with digit
+    digᵢ(x) = ⌊x / Wᵢ⌋ mod bᵢ.
+
+For two summands a, c the per-weight floor deficiency is
+
+    δ(j) = ⌊(a+c)/W_j⌋ − ⌊a/W_j⌋ − ⌊c/W_j⌋ ∈ {0, 1},
+
+and δ(i+1) is precisely the carry out of digit position i (it is 1 iff the low
+parts overflow:  W_{i+1} ≤ a mod W_{i+1} + c mod W_{i+1}).  The headline result
+is the mixed-radix generalization of Kummer's carry/digit-sum identity:
+
+    S(a) + S(c) = S(a+c) + Σ_i δ(i+1) · (b_i − 1),                    (★)
+
+where S is the mixed-radix digit sum.  When every b_i equals a fixed d this
+collapses to the classical law  s_d(a) + s_d(c) − s_d(a+c) = (d−1)·#carries,
+the number of carries being Σ_i δ(i+1) (a sum of {0,1} indicators).
+
+Main results:
+1. `mixedWeight_pos`        — the positional weights are positive
+2. `defc_eq_indicator`      — δ(i+1) is the carry indicator (∈ {0,1})  [Engine: Nat.add_div]
+3. `mixedDigit_eq`          — digit recurrence  digᵢ(x) = ⌊x/Wᵢ⌋ − bᵢ·⌊x/W_{i+1}⌋
+4. `mixedRadix_kummer`      — the carry law (★)
+5. `const_base_carry_law`   — specialization recovering the classical single-base law
+
+Everything is elementary (ℕ/ℤ arithmetic + Finset telescoping); no axioms beyond
+Mathlib's foundations.
+
+References:
+- Kummer (1852): carries and binomial valuations
+- Cantor (1869): mixed-radix numeral systems
+- Parent: KummerTheoremOQ02 (q-Kummer, floorDeficiency)
+-/
+
+import Mathlib
+
+namespace KummerTheoremOQ02OQ03
+
+open Finset
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part I: Mixed-radix weights, digits, and digit sums
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Positional weights of the mixed-radix system with base sequence `b`:
+    `W₀ = 1` and `W_{i+1} = W_i · b_i`.  So `W_i = b₀·b₁·⋯·b_{i-1}`. -/
+def mixedWeight (b : ℕ → ℕ) : ℕ → ℕ
+  | 0 => 1
+  | (i + 1) => mixedWeight b i * b i
+
+@[simp] theorem mixedWeight_zero (b : ℕ → ℕ) : mixedWeight b 0 = 1 := rfl
+
+theorem mixedWeight_succ (b : ℕ → ℕ) (i : ℕ) :
+    mixedWeight b (i + 1) = mixedWeight b i * b i := rfl
+
+/-- All weights are positive when every base is. -/
+theorem mixedWeight_pos (b : ℕ → ℕ) (hb : ∀ i, 0 < b i) :
+    ∀ i, 0 < mixedWeight b i
+  | 0 => by simp
+  | (i + 1) => by
+    rw [mixedWeight_succ]
+    exact Nat.mul_pos (mixedWeight_pos b hb i) (hb i)
+
+/-- The `i`-th mixed-radix digit of `x`. -/
+def mixedDigit (b : ℕ → ℕ) (i x : ℕ) : ℕ := (x / mixedWeight b i) % b i
+
+/-- The mixed-radix digit sum of `x` over the first `N` positions. -/
+def mixedDigitSum (b : ℕ → ℕ) (N x : ℕ) : ℕ :=
+  ∑ i ∈ range N, mixedDigit b i x
+
+/-- The floor deficiency of `a + c` at weight `W_j`:
+    `δ(j) = ⌊(a+c)/W_j⌋ − ⌊a/W_j⌋ − ⌊c/W_j⌋`, an integer (always ≥ 0). -/
+def defc (b : ℕ → ℕ) (a c j : ℕ) : ℤ :=
+  (((a + c) / mixedWeight b j : ℕ) : ℤ) - ((a / mixedWeight b j : ℕ) : ℤ)
+    - ((c / mixedWeight b j : ℕ) : ℤ)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part II: The carry indicator (Engine — Nat.add_div)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- `δ(0) = 0`: the weight `W₀ = 1` divides everything. -/
+@[simp] theorem defc_zero (b : ℕ → ℕ) (a c : ℕ) : defc b a c 0 = 0 := by
+  simp [defc]
+
+/-- Above the top weight the deficiency vanishes: if `a + c < W_N` then `δ(N) = 0`. -/
+theorem defc_high (b : ℕ → ℕ) (a c N : ℕ) (hN : a + c < mixedWeight b N) :
+    defc b a c N = 0 := by
+  have ha : a < mixedWeight b N := lt_of_le_of_lt (Nat.le_add_right a c) hN
+  have hc : c < mixedWeight b N := lt_of_le_of_lt (Nat.le_add_left c a) hN
+  simp only [defc, Nat.div_eq_of_lt ha, Nat.div_eq_of_lt hc, Nat.div_eq_of_lt hN]
+  norm_num
+
+/-- **Carry indicator.** The deficiency at weight `W_{j+1}` is exactly the carry
+    crossing that boundary: it is `1` when the low parts overflow and `0`
+    otherwise.  This is Kummer's "carry" reading, now at a mixed-radix weight. -/
+theorem defc_eq_indicator (b : ℕ → ℕ) (hb : ∀ i, 0 < b i) (a c j : ℕ) :
+    defc b a c (j + 1) =
+      (if mixedWeight b (j + 1) ≤ a % mixedWeight b (j + 1) + c % mixedWeight b (j + 1)
+        then 1 else 0) := by
+  have hW : 0 < mixedWeight b (j + 1) := mixedWeight_pos b hb (j + 1)
+  have h : (a + c) / mixedWeight b (j + 1)
+      = a / mixedWeight b (j + 1) + c / mixedWeight b (j + 1)
+        + (if mixedWeight b (j + 1) ≤ a % mixedWeight b (j + 1) + c % mixedWeight b (j + 1)
+            then 1 else 0) := Nat.add_div hW
+  simp only [defc]
+  rw [h]
+  split <;> push_cast <;> ring
+
+/-- The carry indicator is `0` or `1`. -/
+theorem defc_mem_zero_one (b : ℕ → ℕ) (hb : ∀ i, 0 < b i) (a c j : ℕ) :
+    defc b a c (j + 1) = 0 ∨ defc b a c (j + 1) = 1 := by
+  rw [defc_eq_indicator b hb]
+  split
+  · right; rfl
+  · left; rfl
+
+/-- A carry happens at position `j` exactly when the low parts overflow `W_{j+1}`. -/
+theorem defc_eq_one_iff (b : ℕ → ℕ) (hb : ∀ i, 0 < b i) (a c j : ℕ) :
+    defc b a c (j + 1) = 1 ↔
+      mixedWeight b (j + 1) ≤ a % mixedWeight b (j + 1) + c % mixedWeight b (j + 1) := by
+  rw [defc_eq_indicator b hb]
+  split <;> simp_all
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part III: The digit recurrence and digit-sum expansion
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The mixed-radix digit recurrence (over ℤ):
+    `digᵢ(x) = ⌊x/Wᵢ⌋ − bᵢ · ⌊x/W_{i+1}⌋`.
+    This is just `(x/Wᵢ) mod bᵢ` rewritten via `Nat.mod_add_div` together with
+    `⌊⌊x/Wᵢ⌋ / bᵢ⌋ = ⌊x/W_{i+1}⌋`. -/
+theorem mixedDigit_eq (b : ℕ → ℕ) (i x : ℕ) :
+    (mixedDigit b i x : ℤ) =
+      ((x / mixedWeight b i : ℕ) : ℤ)
+        - (b i : ℤ) * ((x / mixedWeight b (i + 1) : ℕ) : ℤ) := by
+  have hdd : x / mixedWeight b i / b i = x / mixedWeight b (i + 1) := by
+    rw [Nat.div_div_eq_div_mul]; rfl
+  have h1 : (x / mixedWeight b i) % b i + b i * (x / mixedWeight b i / b i)
+      = x / mixedWeight b i := Nat.mod_add_div _ _
+  rw [hdd] at h1
+  have h1' : ((x / mixedWeight b i % b i : ℕ) : ℤ)
+      + (b i : ℤ) * ((x / mixedWeight b (i + 1) : ℕ) : ℤ)
+        = ((x / mixedWeight b i : ℕ) : ℤ) := by
+    exact_mod_cast h1
+  simp only [mixedDigit]
+  linarith
+
+/-- The digit sum expanded as a telescoping-ready ℤ sum. -/
+theorem mixedDigitSum_expand (b : ℕ → ℕ) (N x : ℕ) :
+    (mixedDigitSum b N x : ℤ) =
+      ∑ i ∈ range N,
+        (((x / mixedWeight b i : ℕ) : ℤ)
+          - (b i : ℤ) * ((x / mixedWeight b (i + 1) : ℕ) : ℤ)) := by
+  simp only [mixedDigitSum, Nat.cast_sum]
+  exact Finset.sum_congr rfl (fun i _ => mixedDigit_eq b i x)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part IV: The mixed-radix Kummer carry law
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Combined digit-sum difference as a single sum of per-position terms
+    `bᵢ·δ(i+1) − δ(i)`. -/
+theorem mixedDigitSum_diff (b : ℕ → ℕ) (a c N : ℕ) :
+    (mixedDigitSum b N a : ℤ) + mixedDigitSum b N c - mixedDigitSum b N (a + c)
+      = ∑ i ∈ range N, ((b i : ℤ) * defc b a c (i + 1) - defc b a c i) := by
+  rw [mixedDigitSum_expand b N a, mixedDigitSum_expand b N c,
+      mixedDigitSum_expand b N (a + c), ← Finset.sum_add_distrib,
+      ← Finset.sum_sub_distrib]
+  apply Finset.sum_congr rfl
+  intro i _
+  simp only [defc]
+  push_cast
+  ring
+
+/-- **Mixed-radix Kummer carry law.**
+    For any base sequence `b` (each `bᵢ ≥ 1`) and any `N` with `a + c < W_N`,
+
+        S(a) + S(c) = S(a+c) + Σ_{i<N} δ(i+1) · (bᵢ − 1),
+
+    where `S = mixedDigitSum` and `δ(i+1)` is the carry out of position `i`.
+    The right-hand sum is the carry contribution weighted by `bᵢ − 1`; with each
+    `δ(i+1) ∈ {0,1}` (see `defc_mem_zero_one`, which needs `bᵢ ≥ 1`) it literally
+    counts carries.  The identity itself is purely algebraic and needs no
+    hypothesis on the bases. -/
+theorem mixedRadix_kummer (b : ℕ → ℕ) (a c N : ℕ)
+    (hN : a + c < mixedWeight b N) :
+    (mixedDigitSum b N a : ℤ) + mixedDigitSum b N c
+      = (mixedDigitSum b N (a + c) : ℤ)
+        + ∑ i ∈ range N, defc b a c (i + 1) * ((b i : ℤ) - 1) := by
+  have hdiff := mixedDigitSum_diff b a c N
+  -- rewrite each per-position term:  bᵢ·δ(i+1) − δ(i)
+  --   = δ(i+1)·(bᵢ−1) + (δ(i+1) − δ(i))
+  have hsplit :
+      ∑ i ∈ range N, ((b i : ℤ) * defc b a c (i + 1) - defc b a c i)
+        = (∑ i ∈ range N, defc b a c (i + 1) * ((b i : ℤ) - 1))
+          + ∑ i ∈ range N, (defc b a c (i + 1) - defc b a c i) := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  -- telescoping
+  have htel : ∑ i ∈ range N, (defc b a c (i + 1) - defc b a c i)
+      = defc b a c N - defc b a c 0 :=
+    Finset.sum_range_sub (fun i => defc b a c i) N
+  have key : (mixedDigitSum b N a : ℤ) + mixedDigitSum b N c - mixedDigitSum b N (a + c)
+      = ∑ i ∈ range N, defc b a c (i + 1) * ((b i : ℤ) - 1) := by
+    rw [hdiff, hsplit, htel, defc_zero, defc_high b a c N hN]
+    ring
+  linarith [key]
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part V: Recovering the classical single-base law
+-- ══════════════════════════════════════════════════════════════════
+
+/-- For a constant base `d`, the mixed-radix weights are the powers `d^i`. -/
+theorem mixedWeight_const (d : ℕ) : ∀ i, mixedWeight (fun _ => d) i = d ^ i
+  | 0 => by simp
+  | (i + 1) => by rw [mixedWeight_succ, mixedWeight_const d i, pow_succ]
+
+/-- **Classical Kummer/Legendre digit-sum law, recovered.**
+    Taking every base equal to a fixed `d ≥ 1` collapses (★) to
+
+        s_d(a) + s_d(c) = s_d(a+c) + (d − 1) · Σ_{i<N} δ(i+1),
+
+    i.e. `s_d(a) + s_d(c) − s_d(a+c) = (d−1) · (number of carries)`, the standard
+    statement for ordinary base-`d` addition. -/
+theorem const_base_carry_law (d a c N : ℕ) (hN : a + c < d ^ N) :
+    (mixedDigitSum (fun _ => d) N a : ℤ) + mixedDigitSum (fun _ => d) N c
+      = (mixedDigitSum (fun _ => d) N (a + c) : ℤ)
+        + ((d : ℤ) - 1) * ∑ i ∈ range N, defc (fun _ => d) a c (i + 1) := by
+  have hN' : a + c < mixedWeight (fun _ => d) N := by
+    rwa [mixedWeight_const]
+  have h := mixedRadix_kummer (fun _ => d) a c N hN'
+  -- factor the constant `(d − 1)` out of the carry sum (matching `h`'s RHS exactly)
+  have e : ∑ i ∈ range N, defc (fun _ => d) a c (i + 1) * (((fun _ => d) i : ℤ) - 1)
+      = ((d : ℤ) - 1) * ∑ i ∈ range N, defc (fun _ => d) a c (i + 1) := by
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    show defc (fun _ => d) a c (i + 1) * ((d : ℤ) - 1)
+        = ((d : ℤ) - 1) * defc (fun _ => d) a c (i + 1)
+    ring
+  rw [e] at h
+  exact h
+
+end KummerTheoremOQ02OQ03

--- a/src/data/proofs/kummer-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02-oq-03/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "kummer-theorem-oq-02-oq-03",
+  "title": "Mixed-Radix Kummer Carry Law",
+  "slug": "kummer-theorem-oq-02-oq-03",
+  "description": "Generalizes Kummer's carry/floor-deficiency interpretation from a single base to an arbitrary mixed-radix numeral system. For weights W_0 = 1, W_{i+1} = W_i*b_i, the per-weight deficiency delta(j) = floor((a+c)/W_j) - floor(a/W_j) - floor(c/W_j) at W_{i+1} is exactly the carry out of digit position i, and the mixed-radix digit sums satisfy S(a) + S(c) = S(a+c) + sum_i delta(i+1)*(b_i - 1). Specializing to a constant base recovers the classical law s_d(a) + s_d(c) - s_d(a+c) = (d-1)*(number of carries).",
+  "meta": {
+    "author": "Kummer (carries, 1852), Cantor (mixed-radix systems, 1869)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mixed_radix",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KummerTheoremOQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "mixed-radix",
+      "carries",
+      "digit-sums",
+      "kummer-theorem",
+      "elementary",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_div",
+        "description": "(a+b)/c = a/c + b/c + (if c <= a%c + b%c then 1 else 0); the engine identifying the floor deficiency with the carry indicator",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.mod_add_div",
+        "description": "a%b + b*(a/b) = a; gives the digit recurrence dig_i(x) = floor(x/W_i) - b_i*floor(x/W_{i+1})",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.div_div_eq_div_mul",
+        "description": "x/m/n = x/(m*n); collapses iterated weight division to the next mixed-radix weight",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Finset.sum_range_sub",
+        "description": "Telescoping sum: sum_{i<N} (f(i+1) - f(i)) = f(N) - f(0); cancels the deficiency boundary terms",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "mixedWeight / mixedDigit / mixedDigitSum: definitions of an arbitrary mixed-radix numeral system and its digit sum",
+      "defc_eq_indicator: the floor deficiency at weight W_{i+1} equals the carry crossing that boundary (in {0,1}), via Nat.add_div",
+      "mixedDigit_eq: the digit recurrence dig_i(x) = floor(x/W_i) - b_i*floor(x/W_{i+1}) over the integers",
+      "mixedRadix_kummer: the carry law S(a)+S(c) = S(a+c) + sum_i delta(i+1)*(b_i-1), proved by a purely algebraic telescoping requiring NO hypothesis on the bases",
+      "const_base_carry_law: specialization to a constant base recovering the classical (d-1)*(carry count) digit-sum law"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 263,
+    "prerequisites": [
+      "Natural-number floor division and the identity Nat.add_div",
+      "Mixed-radix (factorial / general positional) numeral systems",
+      "Classical Kummer's theorem and carry counting in base-d addition",
+      "Finset telescoping sums over the integers"
+    ],
+    "assumptions": "0 axioms, 0 sorries. Only the standard foundational axioms (propext, Classical.choice, Quot.sound) appear via #print axioms; none counts under the project's axiom policy. All mixed-radix infrastructure is built from scratch.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 14,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) reads the p-adic valuation of a binomial coefficient as the number of carries when adding in base p; equivalently it is the floor deficiency floor(n/p^j) - floor(k/p^j) - floor((n-k)/p^j) summed over j. The parent entry (q-Kummer) lifted the single-prime base to all integer bases d >= 2 through cyclotomic factorization. A natural further question, recorded as the parent's third open question, is whether the carry interpretation survives in a MIXED-radix system, where each digit position has its own base b_i (as in factorial-base numerals or general Cantor systems).",
+    "problemStatement": "**Open Question (parent OQ-03)**: Can the floor deficiency be related to carries in mixed-radix numeral systems?\n\n**Answer**: Yes. With weights W_0 = 1, W_{i+1} = W_i * b_i, the deficiency delta(i+1) = floor((a+c)/W_{i+1}) - floor(a/W_{i+1}) - floor(c/W_{i+1}) is exactly the carry out of position i, and the mixed-radix digit sum S obeys S(a) + S(c) = S(a+c) + sum_{i<N} delta(i+1) * (b_i - 1).",
+    "text": "In any mixed-radix numeral system the per-position floor deficiency is the carry indicator, and the digit sums of two summands and their sum differ by the carries weighted by (base - 1) at each position.",
+    "proofStrategy": "**Step 1 (Carry indicator)**: Nat.add_div gives (a+c)/W = a/W + c/W + [W <= a%W + c%W], so the deficiency delta at any weight lies in {0,1} and is 1 exactly when the low parts overflow that boundary (defc_eq_indicator).\n\n**Step 2 (Digit recurrence)**: Rewriting dig_i(x) = (x/W_i) mod b_i via Nat.mod_add_div together with x/W_i/b_i = x/W_{i+1} yields, over the integers, dig_i(x) = floor(x/W_i) - b_i*floor(x/W_{i+1}) (mixedDigit_eq).\n\n**Step 3 (Telescoping)**: Summing the digit recurrence for a, c and a+c, each position contributes b_i*delta(i+1) - delta(i). Splitting b_i*delta(i+1) - delta(i) = delta(i+1)*(b_i-1) + (delta(i+1) - delta(i)) and telescoping the second part (Finset.sum_range_sub) collapses to delta(N) - delta(0); both vanish (delta(0)=0 since W_0=1; delta(N)=0 once a+c < W_N), giving the carry law.\n\n**Step 4 (Specialization)**: Setting every b_i = d turns the weights into d^i and factors (d-1) out of the carry sum, recovering the classical single-base digit-sum law.",
+    "keyInsights": [
+      "The floor deficiency at a positional weight already accounts for carry propagation: a%W + c%W >= W captures the full lower-order sum, so no separate propagation argument is needed.",
+      "The carry law is a purely ALGEBRAIC telescoping identity; it needs no positivity or size hypothesis on the bases b_i (positivity is only required to read delta as a {0,1} carry indicator).",
+      "The mixed-radix generalization replaces the classical scalar factor (d-1) by a per-position weight (b_i - 1), exactly matching the digit-by-digit carry recurrence digit_i(a) + digit_i(c) + carry_in = digit_i(a+c) + b_i * carry_out.",
+      "Constant base recovers Kummer/Legendre: s_d(a) + s_d(c) - s_d(a+c) = (d-1) * (number of carries)."
+    ],
+    "prerequisites": [
+      "Floor division identities for natural numbers",
+      "Mixed-radix numeral systems",
+      "Classical Kummer carry counting",
+      "Telescoping Finset sums"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Mixed-Radix Weights, Digits, and Digit Sums",
+      "startLine": 56,
+      "endLine": 99,
+      "summary": "mixedWeight (W_0 = 1, W_{i+1} = W_i*b_i), mixedDigit dig_i(x) = (x/W_i) mod b_i, mixedDigitSum over range N, and the floor deficiency defc; mixedWeight_pos shows weights are positive when bases are.",
+      "mathContext": "$W_0 = 1,\\ W_{i+1} = W_i b_i,\\ \\mathrm{dig}_i(x) = \\lfloor x/W_i\\rfloor \\bmod b_i,\\ \\delta(j) = \\lfloor (a+c)/W_j\\rfloor - \\lfloor a/W_j\\rfloor - \\lfloor c/W_j\\rfloor.$"
+    },
+    {
+      "id": "carry-indicator",
+      "title": "The Carry Indicator (Engine: Nat.add_div)",
+      "startLine": 100,
+      "endLine": 148,
+      "summary": "defc_zero (delta(0)=0), defc_high (delta(N)=0 above the top weight), defc_eq_indicator (delta(i+1) is the carry boundary indicator), defc_mem_zero_one, defc_eq_one_iff.",
+      "mathContext": "$\\delta(i+1) = [\\,W_{i+1} \\le a \\bmod W_{i+1} + c \\bmod W_{i+1}\\,] \\in \\{0,1\\}.$"
+    },
+    {
+      "id": "digit-recurrence",
+      "title": "Digit Recurrence and Digit-Sum Expansion",
+      "startLine": 149,
+      "endLine": 179,
+      "summary": "mixedDigit_eq: dig_i(x) = floor(x/W_i) - b_i*floor(x/W_{i+1}) over Z; mixedDigitSum_expand writes the digit sum as a telescoping-ready integer sum.",
+      "mathContext": "$\\mathrm{dig}_i(x) = \\lfloor x/W_i\\rfloor - b_i \\lfloor x/W_{i+1}\\rfloor.$"
+    },
+    {
+      "id": "carry-law",
+      "title": "The Mixed-Radix Kummer Carry Law",
+      "startLine": 180,
+      "endLine": 232,
+      "summary": "mixedDigitSum_diff collects the per-position terms b_i*delta(i+1) - delta(i); mixedRadix_kummer telescopes them into the carry law S(a)+S(c) = S(a+c) + sum delta(i+1)*(b_i-1).",
+      "mathContext": "$S(a) + S(c) = S(a+c) + \\sum_{i<N} \\delta(i+1)\\,(b_i - 1).$"
+    },
+    {
+      "id": "classical-recovery",
+      "title": "Recovering the Classical Single-Base Law",
+      "startLine": 233,
+      "endLine": 261,
+      "summary": "mixedWeight_const (constant base gives weights d^i) and const_base_carry_law: s_d(a)+s_d(c) = s_d(a+c) + (d-1)*(number of carries).",
+      "mathContext": "$s_d(a) + s_d(c) - s_d(a+c) = (d-1)\\,\\#\\text{carries}.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The mixed-radix Kummer carry law answers the parent's third open question: in an arbitrary positional system with per-digit bases b_i, the floor deficiency at each weight is the carry crossing that boundary, and the mixed-radix digit sums satisfy S(a)+S(c) = S(a+c) + sum_i delta(i+1)*(b_i - 1). The proof is an elementary telescoping over the integers and, notably, requires no hypothesis on the bases for the identity itself.",
+    "implications": "1. **Strict generalization**: the classical Kummer/Legendre law (d-1)*(carry count) = s_d(a)+s_d(c)-s_d(a+c) is the constant-base specialization.\n2. **Carry interpretation**: each delta(i+1) is a genuine {0,1} carry indicator (defc_eq_indicator), so the right-hand sum literally counts carries weighted by (b_i - 1).\n3. **Hypothesis-free identity**: the digit-sum law is purely algebraic; positivity of the bases is needed only to read delta as a carry, not to prove the identity.\n4. **Applies to factorial base and Cantor systems**: any weight sequence W_{i+1} = W_i*b_i is covered.",
+    "openQuestions": [
+      "Does an analogous law hold for the mixed-radix multinomial deficiency of more than two summands, with carries weighted by (b_i - 1)?",
+      "Can the carry count sum_i delta(i+1) be identified with a generalized p-adic-style valuation of a mixed-radix multinomial coefficient?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "KummerTheoremOQ02OQ03",
+    "lineCount": 263,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/KummerTheoremOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the q-Kummer theorem, whose third open question asks whether the floor deficiency relates to carries in mixed-radix numeral systems. This entry answers it."
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "related",
+      "description": "Classical Kummer's theorem on carries in base-p addition; recovered here as the constant-base specialization const_base_carry_law."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kummer, Ernst Eduard",
+      "title": "Uber die Erganzungssatze zu den allgemeinen Reciprocitatsgesetzen",
+      "year": "1852",
+      "venue": "Journal fur die reine und angewandte Mathematik 44, 93-146",
+      "note": "Classical Kummer's theorem: v_p(C(n,k)) = number of carries in base-p addition"
+    },
+    {
+      "authors": "Cantor, Georg",
+      "title": "Uber die einfachen Zahlensysteme",
+      "year": "1869",
+      "venue": "Zeitschrift fur Mathematik und Physik 14, 121-128",
+      "note": "Mixed-radix (general positional) numeral systems"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "mixedRadix_kummer",
+      "type": "core",
+      "description": "Mixed-radix Kummer carry law: digit sums differ by the carries weighted by (b_i - 1)",
+      "leanType": "(mixedDigitSum b N a : Z) + mixedDigitSum b N c = (mixedDigitSum b N (a+c) : Z) + sum i in range N, defc b a c (i+1) * ((b i : Z) - 1)"
+    },
+    {
+      "name": "defc_eq_indicator",
+      "type": "supporting",
+      "description": "The floor deficiency at weight W_{i+1} is the carry boundary indicator (in {0,1})",
+      "leanType": "defc b a c (j+1) = (if mixedWeight b (j+1) <= a % mixedWeight b (j+1) + c % mixedWeight b (j+1) then 1 else 0)"
+    },
+    {
+      "name": "mixedDigit_eq",
+      "type": "supporting",
+      "description": "Mixed-radix digit recurrence over the integers",
+      "leanType": "(mixedDigit b i x : Z) = (x / mixedWeight b i : Z) - (b i : Z) * (x / mixedWeight b (i+1) : Z)"
+    },
+    {
+      "name": "const_base_carry_law",
+      "type": "supporting",
+      "description": "Constant base recovers the classical (d-1)*(carry count) digit-sum law",
+      "leanType": "(mixedDigitSum (fun _ => d) N a : Z) + mixedDigitSum (fun _ => d) N c = (mixedDigitSum (fun _ => d) N (a+c) : Z) + ((d : Z) - 1) * sum i in range N, defc (fun _ => d) a c (i+1)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Mixed-Radix Kummer Carry Law

Answers the **third open question** of the parent q-Kummer entry (`kummer-theorem-oq-02`):

> *Can the floor deficiency be related to carries in mixed-radix numeral systems?*

**Yes.** For an arbitrary base sequence `b : ℕ → ℕ` with positional weights `W₀ = 1`, `W_{i+1} = W_i · b_i`:

- **`defc_eq_indicator`** — the per-weight floor deficiency
  `δ(i+1) = ⌊(a+c)/W_{i+1}⌋ − ⌊a/W_{i+1}⌋ − ⌊c/W_{i+1}⌋ ∈ {0,1}`
  is exactly the carry out of digit position `i` (engine: `Nat.add_div`).
- **`mixedDigit_eq`** — the digit recurrence `digᵢ(x) = ⌊x/Wᵢ⌋ − bᵢ·⌊x/W_{i+1}⌋` over ℤ.
- **`mixedRadix_kummer`** — the carry law
  `S(a) + S(c) = S(a+c) + Σᵢ δ(i+1)·(bᵢ − 1)`,
  where `S` is the mixed-radix digit sum. The identity is a **purely algebraic telescoping** and needs *no* hypothesis on the bases (positivity is only needed to read `δ` as a `{0,1}` carry indicator).
- **`const_base_carry_law`** — setting every `bᵢ = d` recovers the classical Kummer/Legendre law
  `s_d(a) + s_d(c) − s_d(a+c) = (d − 1)·(number of carries)`.

### Verification
- 14 theorems, 4 definitions, 263 lines.
- Host-verified with `lake env lean` (Docker unavailable).
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom / verified**.
- Registered in `Proofs.lean`; gallery `meta.json` added (`status: verified`, `badge: original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)