### PR TITLE
Enrich Power Sums Are a Complete Invariant (amgm-inequality-oq-02-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ02OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const amgmInequalityOq02Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq02Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq02Oq01Oq01Oq01Data: ProofData = {
+  proof: amgmInequalityOq02Oq01Oq01Oq01Proof,
+  annotations: amgmInequalityOq02Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -54,6 +54,13 @@
   },
   "sections": [
     {
+      "id": "overview",
+      "title": "Overview: power sums as a complete invariant",
+      "startLine": 4,
+      "endLine": 38,
+      "summary": "Module docstring. Situates the entry against the parent (forward Newton recurrence) and the sibling (subalgebra equality), states the moment-determinacy theorem — equal power sums p_j (1 ≤ j ≤ |σ|) force equal elementary symmetric functions and hence the same monic polynomial ∏ᵢ(X+vᵢ) — and lists the four main results. Symmetric polynomials over ℤ, evaluation into any characteristic-zero K; 0 axioms."
+    },
+    {
       "id": "evaluated-newton",
       "title": "Part I: The Forward Newton Identity, Evaluated",
       "startLine": 36,


### PR DESCRIPTION
Enrichment for `amgm-inequality-oq-02-oq-01-oq-01-oq-01` (Power Sums Are a Complete Invariant).

A richer 6-annotation version of this entry merged to main while this PR was open, so this PR was rebased to **keep that annotations.json untouched** and add only what main still lacks:
- **`index.ts`** — without it the proof page 404s on the live site.
- **A module-overview section** in `meta.sections` (docstring lines 4–38 were uncovered; sections now span the full file).

Verified with `pnpm build`. No change to the Lean file, status, or badge (verified/original).