### PR TITLE
research(wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01): Kempner function determined by prime powers — S(n) = max S(p^k) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4029,6 +4029,7 @@ import Proofs.WilsonsTheoremOQ03
 import Proofs.WilsonsTheoremOQ04
 import Proofs.WilsonsTheoremOQ04OQ02
 import Proofs.WilsonsTheoremOQ05
+import Proofs.WilsonsTheoremOQ05OQ01OQ01OQ01OQ01
 import Proofs.WilsonsTheoremOQ06
 import Proofs.WolstenholmePrimeMod4
 import Proofs.WolstenholmeTheorem

--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,115 @@
+import Mathlib
+
+/-
+# The Kempner–Smarandache function is determined by its prime powers:
+# `S(n) = max over p^k ∥ n of S(p^k)`
+
+**Open Question (`wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01`)**: the parent
+entry `wilsons-theorem-oq-05-oq-01-oq-01-oq-01` computed the Kempner–Smarandache
+value `S(p^k) = sInf {n | p^k ∣ n!}` for prime powers (e.g. `S(p^k) = p·k` iff
+`k ≤ p`). Its **first** registered open question asks to *assemble the general
+value*:
+
+  > prove `S(n) = max over prime powers p^k ∥ n of S(p^k)`, i.e. that the
+  > Kempner function is determined by its values on the prime powers in the
+  > factorization of `n`.
+
+This file proves exactly that. The Kempner–Smarandache function is
+
+  `S m = sInf {n | m ∣ n !}`,
+
+the least `n` whose factorial is divisible by `m` (identical to the parent's
+definition; re-stated here so the file is self-contained — the assembly result
+is independent of the *exact* prime-power values).
+
+## Main results
+
+* `S_mono_dvd`        : `a ∣ b → 0 < b → S a ≤ S b`  (divisibility-monotonicity).
+* `S_eq_sup_prime_pow`: **`S n = ⨆_{p ∈ primeFactors n} S(p^{v_p(n)})`** for
+  `n ≥ 1` — the Kempner function is the maximum of its prime-power values.
+* `S_eq_S_some_prime_pow`: for `n > 1`, that maximum is *attained* by a single
+  prime power: `∃ p ∣ n, S n = S(p^{v_p(n)})`.
+
+## Engine
+
+Two halves, by `le_antisymm`:
+
+* `M ≤ S n`: each prime power `p^{v_p(n)} ∣ n`, so `S(p^{v_p(n)}) ≤ S n` by
+  divisibility-monotonicity; take the sup.
+* `S n ≤ M`: it suffices that `n ∣ M!`. By `Nat.factorization_le_iff_dvd` this is
+  a pointwise valuation inequality `v_p(n) ≤ v_p(M!)` at each prime `p ∣ n`. For
+  such `p`, `S(p^{v_p(n)}) ≤ M`, hence `p^{v_p(n)} ∣ (S(p^{v_p(n)}))! ∣ M!`
+  (factorial-monotonicity), and Legendre (`pow_dvd_iff_le_factorization`) turns
+  this divisibility into the valuation bound.
+-/
+
+open Nat
+
+namespace WilsonsTheoremOQ05OQ01OQ01OQ01OQ01
+
+/-! ## The Kempner–Smarandache function (matching the parent definition) -/
+
+/-- The **Kempner–Smarandache function**: the least `n` with `m ∣ n!`. -/
+noncomputable def S (m : ℕ) : ℕ := sInf {n | m ∣ n !}
+
+/-- For `m ≥ 1`, `S m` is an actual witness: `m ∣ (S m)!`. -/
+theorem dvd_factorial_S {m : ℕ} (hm : 0 < m) : m ∣ (S m)! := by
+  have hne : Set.Nonempty {n | m ∣ n !} := ⟨m, Nat.dvd_factorial hm le_rfl⟩
+  exact Nat.sInf_mem hne
+
+/-- `S m` is the *least* witness: every `n` with `m ∣ n!` satisfies `S m ≤ n`. -/
+theorem S_le {m n : ℕ} (h : m ∣ n !) : S m ≤ n := Nat.sInf_le h
+
+/-! ## Divisibility-monotonicity -/
+
+/-- **Monotonicity under divisibility.** If `a ∣ b` and `b ≥ 1`, then
+`S a ≤ S b`: since `b ∣ (S b)!` and `a ∣ b`, also `a ∣ (S b)!`, so `S a ≤ S b`. -/
+theorem S_mono_dvd {a b : ℕ} (hab : a ∣ b) (hb : 0 < b) : S a ≤ S b :=
+  S_le (dvd_trans hab (dvd_factorial_S hb))
+
+/-! ## Assembly: `S` is the maximum of its prime-power values -/
+
+/-- **The Kempner function is determined by its prime powers.** For `n ≥ 1`,
+
+  `S n = ⨆_{p ∈ primeFactors n} S(p^{v_p(n)})`,
+
+the maximum of the Kempner values of the prime powers `p^{v_p(n)}` exactly
+dividing `n`. -/
+theorem S_eq_sup_prime_pow {n : ℕ} (hn : 0 < n) :
+    S n = n.primeFactors.sup (fun p => S (p ^ n.factorization p)) := by
+  set M := n.primeFactors.sup (fun p => S (p ^ n.factorization p)) with hM
+  refine le_antisymm ?_ ?_
+  · -- `S n ≤ M`, via `n ∣ M!`.
+    apply S_le
+    rw [← Nat.factorization_le_iff_dvd hn.ne' (Nat.factorial_ne_zero M), Finsupp.le_iff]
+    intro p hp
+    have hk0 : n.factorization p ≠ 0 := Finsupp.mem_support_iff.mp hp
+    have hpp : p.Prime := by
+      by_contra h
+      exact hk0 (Nat.factorization_eq_zero_of_not_prime n h)
+    have hmem : p ∈ n.primeFactors :=
+      hpp.mem_primeFactors (Nat.dvd_of_factorization_pos hk0) hn.ne'
+    -- `p^{v_p(n)} ∣ M!`
+    have hSle : S (p ^ n.factorization p) ≤ M :=
+      Finset.le_sup (f := fun q => S (q ^ n.factorization q)) hmem
+    have hdvd : p ^ n.factorization p ∣ M ! :=
+      dvd_trans (dvd_factorial_S (pow_pos hpp.pos _))
+        (Nat.factorial_dvd_factorial hSle)
+    -- Legendre converts divisibility to the valuation bound.
+    exact (Nat.Prime.pow_dvd_iff_le_factorization hpp (Nat.factorial_ne_zero M)).mp hdvd
+  · -- `M ≤ S n`: each prime-power factor's value is `≤ S n`.
+    apply Finset.sup_le
+    intro p hp
+    exact S_mono_dvd (Nat.ordProj_dvd n p) hn
+
+/-- **The maximum is attained by a single prime power.** For `n > 1` there is a
+prime `p ∣ n` with `S n = S(p^{v_p(n)})`: the Kempner value of `n` is realized by
+one of its prime-power factors (the "dominant" prime power). -/
+theorem S_eq_S_some_prime_pow {n : ℕ} (hn : 1 < n) :
+    ∃ p ∈ n.primeFactors, S n = S (p ^ n.factorization p) := by
+  obtain ⟨p, hp, hpe⟩ :=
+    Finset.exists_mem_eq_sup n.primeFactors (Nat.nonempty_primeFactors.mpr hn)
+      (fun p => S (p ^ n.factorization p))
+  exact ⟨p, hp, (S_eq_sup_prime_pow (by omega)).trans hpe⟩
+
+end WilsonsTheoremOQ05OQ01OQ01OQ01OQ01

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "title": "Kempner Function is Determined by its Prime Powers: S(n) = max over p^k ∥ n of S(p^k)",
+  "slug": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "description": "Assembles the general value of the Kempner–Smarandache function S(m) = sInf {n | m ∣ n!} from its prime-power values, answering the parent prime-power file's first open question. Proves divisibility-monotonicity of S, the maximum identity S(n) = sup over p ∈ primeFactors n of S(p^{v_p(n)}), and that this maximum is attained by a single dominant prime power. 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-1",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "wilsons-theorem",
+      "kempner-smarandache",
+      "number-theory",
+      "factorial",
+      "prime-factorization",
+      "legendre-formula",
+      "multiplicative-structure"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 115,
+    "theoremCount": 5,
+    "assumptions": "None. All 5 theorems proved, 0 axioms. Verified axiom-free: #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_le_iff_dvd",
+        "description": "d ∣ n ↔ d.factorization ≤ n.factorization (reduces n ∣ M! to pointwise valuation bounds)",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "p^k ∣ m ↔ k ≤ m.factorization p (Legendre divisibility criterion)",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.ordProj_dvd",
+        "description": "p ^ n.factorization p ∣ n (each prime-power factor divides n)",
+        "module": "Mathlib.Data.Nat.Factorization.Defs"
+      },
+      {
+        "theorem": "Nat.factorial_dvd_factorial",
+        "description": "m ≤ n → m! ∣ n! (factorial monotonicity)",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Finset.exists_mem_eq_sup",
+        "description": "a nonempty Finset sup over ℕ is attained at some element",
+        "module": "Mathlib.Data.Finset.Lattice.Fold"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Kempner–Smarandache function S(m) = min {n : m ∣ n!} (the smallest factorial divisible by m) was studied by Lucas (1883), Kempner (1918, who gave the first algorithm), and later named after Smarandache. A foundational structural fact is that S is determined by the prime-power factorization of its argument: S(n) = max over the prime powers p^k exactly dividing n of S(p^k). This reduces the computation of S to prime powers, where Legendre's formula applies. The grandparent file located the Kempner threshold (when S(n) < n), the parent prime-power file computed S(p^k) for prime powers, and explicitly asked, as its first open question, to 'assemble the general value' via this maximum identity. This file proves it.",
+    "problemStatement": "Prove that the Kempner–Smarandache function is the maximum of its prime-power values: for n ≥ 1, S(n) = sup over p ∈ primeFactors n of S(p^{v_p(n)}); and that for n > 1 the maximum is attained by a single prime power.",
+    "proofStrategy": "Antisymmetry. (≥) Each prime-power factor p^{v_p(n)} divides n, so by divisibility-monotonicity of S (S a ≤ S b when a ∣ b, b ≥ 1) we get S(p^{v_p(n)}) ≤ S(n); take the Finset sup. (≤) It suffices that n ∣ M! where M is the sup. By Nat.factorization_le_iff_dvd this is equivalent to the pointwise valuation inequality v_p(n) ≤ v_p(M!) at every prime p in the support of n.factorization. For such p, S(p^{v_p(n)}) ≤ M, hence p^{v_p(n)} ∣ (S(p^{v_p(n)}))! ∣ M! by factorial monotonicity, and Legendre's criterion (pow_dvd_iff_le_factorization) converts the divisibility to the valuation bound. Attainment follows from Finset.exists_mem_eq_sup on the nonempty primeFactors set.",
+    "keyInsights": [
+      "**Divisibility-monotonicity is the engine**: if a ∣ b and b ≥ 1, then S a ≤ S b, because b ∣ (S b)! already forces a ∣ (S b)!. This three-line lemma drives both halves of the maximum identity.",
+      "**The hard direction is a valuation inequality.** Reducing S(n) ≤ M to n ∣ M! and then, via Nat.factorization_le_iff_dvd, to v_p(n) ≤ v_p(M!) at each prime, converts a global divisibility into independent local checks — each settled by Legendre's formula applied to the dominating prime power.",
+      "**The maximum is realized, not just bounded.** For n > 1 there is a single 'dominant' prime power p^{v_p(n)} with S(n) = S(p^{v_p(n)}); the Kempner value of any n is literally the Kempner value of one of its prime-power factors.",
+      "**The assembly is independent of the exact prime-power values.** It needs only that S exists (sInf of a nonempty set) and is divisibility-monotone, so it composes with any computation of S(p^k) — including the parent's closed form S(p^k) = p·k for k ≤ p."
+    ]
+  },
+  "sections": [
+    {
+      "id": "kempner-def",
+      "title": "The Kempner–Smarandache function",
+      "startLine": 50,
+      "endLine": 62,
+      "summary": "S m := sInf {n | m ∣ n!}. dvd_factorial_S: m ∣ (S m)! for m ≥ 1 (sInf is a member). S_le: S m ≤ n whenever m ∣ n! (sInf is a lower bound). Matches the parent definition; restated for a self-contained file.",
+      "mathContext": "$S(m) = \\min\\{n : m \\mid n!\\}$, well defined since $m \\mid m!$."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Divisibility-monotonicity",
+      "startLine": 63,
+      "endLine": 69,
+      "summary": "S_mono_dvd: a ∣ b → 0 < b → S a ≤ S b. Proof: b ∣ (S b)! and a ∣ b give a ∣ (S b)!, so S a ≤ S b.",
+      "mathContext": "$a \\mid b \\Rightarrow S(a) \\leq S(b)$ — the core monotonicity of the Kempner function."
+    },
+    {
+      "id": "assembly",
+      "title": "Assembly: S is the maximum of its prime-power values",
+      "startLine": 70,
+      "endLine": 115,
+      "summary": "S_eq_sup_prime_pow: S n = primeFactors n .sup (fun p => S (p^{v_p(n)})). Hard direction n ∣ M! via factorization_le_iff_dvd + Finsupp.le_iff + Legendre; easy direction via ordProj_dvd + S_mono_dvd. S_eq_S_some_prime_pow: for n > 1 the sup is attained (Finset.exists_mem_eq_sup).",
+      "mathContext": "$S(n) = \\max_{p \\mid n} S(p^{v_p(n)})$, attained by a single prime power for $n > 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Kempner–Smarandache function is determined by its prime powers: S(n) = max over p ∈ primeFactors n of S(p^{v_p(n)}), with the maximum attained by a single dominant prime power for n > 1. 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+    "implications": "Combined with the parent file's prime-power computation (S(p^k) = p·k iff k ≤ p, and the structural facts p ∣ S(p^k)), this reduces the Kempner function on all of ℕ to prime powers — closing the parent's first open question. The divisibility-monotonicity lemma is reusable for any further Kempner-function work.",
+    "openQuestions": [
+      "Combine with the parent's prime-power closed form to give a fully explicit S(n) for n whose prime powers all satisfy k ≤ p (then S(n) = max p·v_p(n)), and handle the k > p tail via the greedy base-p Kempner algorithm.",
+      "Formalize the classical bound S(n) ≤ (largest prime factor of n) · (its exponent) and the cases of equality."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "WilsonsTheoremOQ05OQ01OQ01OQ01OQ01",
+    "lineCount": 115,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent computed S(p^k) for prime powers and asked, as its first open question, to assemble the general value S(n) = max over prime powers; this file proves that assembly"
+    },
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent located the Kempner threshold (when S(n) < n); this file determines the actual value structure"
+    },
+    {
+      "targetId": "wilsons-theorem-oq-05",
+      "relationship": "ancestor",
+      "description": "Root of the OQ05 chain connecting Wilson's theorem to the Kempner–Smarandache function"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "S_eq_sup_prime_pow",
+      "type": "core",
+      "statement": "0 < n → S n = n.primeFactors.sup (fun p => S (p ^ n.factorization p))",
+      "description": "The Kempner function equals the maximum of its prime-power values.",
+      "significance": "Closes the parent's first open question: S is determined by the prime powers in n's factorization"
+    },
+    {
+      "name": "S_eq_S_some_prime_pow",
+      "type": "corollary",
+      "statement": "1 < n → ∃ p ∈ n.primeFactors, S n = S (p ^ n.factorization p)",
+      "description": "The maximum is attained by a single dominant prime power.",
+      "significance": "S(n) is literally the Kempner value of one of n's prime-power factors"
+    },
+    {
+      "name": "S_mono_dvd",
+      "type": "lemma",
+      "statement": "a ∣ b → 0 < b → S a ≤ S b",
+      "description": "Divisibility-monotonicity of the Kempner function.",
+      "significance": "The reusable engine behind both directions of the maximum identity"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent prime-power file's (`wilsons-theorem-oq-05-oq-01-oq-01-oq-01`) **first open question** — *assemble the general Kempner value from its prime-power values*.

The Kempner–Smarandache function is `S(m) = sInf {n | m ∣ n!}` (least `n` whose factorial is divisible by `m`). This file proves it is **determined by its prime powers**:

$$ S(n) = \max_{p \mid n} S\!\left(p^{v_p(n)}\right). $$

## Results (5 theorems, 1 def, 115 lines, 0 sorries, 0 axioms)

- **`S_mono_dvd`** — `a ∣ b → 0 < b → S a ≤ S b` (divisibility-monotonicity; the reusable engine).
- **`S_eq_sup_prime_pow`** — `S n = n.primeFactors.sup (fun p => S (p ^ n.factorization p))`.
- **`S_eq_S_some_prime_pow`** — for `n > 1` the maximum is **attained** by a single dominant prime power: `∃ p ∣ n, S n = S(p^{v_p(n)})`.

## Engine

`le_antisymm`:
- **(≥)** each prime power `p^{v_p(n)} ∣ n`, so `S(p^{v_p(n)}) ≤ S n` by `S_mono_dvd`; take the `Finset.sup`.
- **(≤)** it suffices that `n ∣ M!`. Via `Nat.factorization_le_iff_dvd` + `Finsupp.le_iff` this is the pointwise valuation bound `v_p(n) ≤ v_p(M!)` at each prime `p ∣ n`; since `S(p^{v_p(n)}) ≤ M`, we get `p^{v_p(n)} ∣ (S(p^{v_p(n)}))! ∣ M!` (factorial monotonicity), and Legendre (`pow_dvd_iff_le_factorization`) converts divisibility to the valuation bound.

Attainment uses `Finset.exists_mem_eq_sup`. The file is self-contained (re-declares `S`; the assembly is independent of the *exact* prime-power values, so it composes with the parent's `S(p^k) = p·k ↔ k ≤ p`).

## Verification

Compiled with `lake env lean` against Mathlib; `#print axioms` on the main theorems reports only `propext, Classical.choice, Quot.sound` — **axiom-free**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)