### PR TITLE
audit(batch31): 9 research leaves clean + baire-oq03 badge fix

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22097,8 +22097,68 @@
       "lastAudited": "2026-06-24T19:24:49Z",
       "result": "clean",
       "issues": []
+    },
+    "abundant-number-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:45Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:46Z",
+      "result": "clean"
+    },
+    "angle-trisection-oq-02-oq-03-ext-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:46Z",
+      "result": "clean"
+    },
+    "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:46Z",
+      "result": "clean"
+    },
+    "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:46Z",
+      "result": "clean"
+    },
+    "bernoulli-inequality-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:47Z",
+      "result": "clean"
+    },
+    "birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:47Z",
+      "result": "clean"
+    },
+    "bounded-prime-gaps-oq-05": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:48Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:48Z",
+      "result": "clean"
+    },
+    "baire-category-theorem-oq-01-oq-03": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-06-24T20:41:48Z",
+      "result": "issues-fixed"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T18:02:41Z"
+  "lastUpdated": "2026-06-24T20:41:27Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — Batch 31

Audited 10 newly-merged on-main research leaves (the `a*`/`b*` alphabetical front of the never-audited queue). Tracker-only update plus one badge correction shipped separately.

### Clean (9) — verified/original, 0-sorry/0-axiom, public claims match Lean source
| slug | result |
|------|--------|
| abundant-number-oq-04 | deficient-side divisibility; kernel `decide` correctly disclosed, no native_decide |
| amgm-inequality-oq-02-oq-01-oq-01-oq-01 | power-sum complete invariant (strong induction; Newton+Vieta are building blocks) |
| angle-trisection-oq-02-oq-03-ext-oq-01 | Gauss–Wantzel doubling invariance; geometric framing interpretive, not overclaimed |
| arsinh-log-formula-oq-01-oq-01-oq-01-oq-01 | catenoid surface area; new `cosh²` antiderivative |
| arsinh-log-formula-oq-01-oq-02-oq-01-oq-01 | improper integral across `t=1` singularity |
| bernoulli-inequality-oq-01-oq-01-oq-02-oq-01 | escape/capture dichotomy; 12 substantive theorems |
| birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01 | Schur-convexity of collision probability (in-file Jensen) |
| bounded-prime-gaps-oq-05 | Firoozbakht three-forms equivalence; **conjecture honestly disclaimed as open** |
| burnside-counting-oq-04-oq-01-oq-01-oq-01 | rotation fixed-point gcd closed form; native_decide grep = docstring only |

### Issues-fixed (1)
- **baire-category-theorem-oq-01-oq-03** — badge `original` → `mathlib` (Tier B Mathlib bridge over `Perfect.exists_nat_bool_injection`; matches sibling oq-02 which has the identical headline result correctly badged `mathlib`). Meta fix in **PR #29343**.

All other never-audited queue entries are either absent-on-main pollution or remain for the next cycle.

---
Gallery integrity audit. Tracker-only change; safe to merge.