### PR TITLE
research(vandermonde-interpolation-oq-01-oq-02-oq-01): Lagrange basis polynomials as a basis of degree-< n polynomials

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4006,6 +4006,7 @@ import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VandermondeInterpolationOQ01OQ02
+import Proofs.VandermondeInterpolationOQ01OQ02OQ01
 import Proofs.VarignonTheorem
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02

--- a/proofs/Proofs/VandermondeInterpolationOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/VandermondeInterpolationOQ01OQ02OQ01.lean
@@ -1,0 +1,150 @@
+/-
+  The Lagrange basis polynomials as a *basis* of the degree-`< n` polynomials.
+
+  Fix `n` DISTINCT nodes `v : Fin n → F` over a field `F`.  The companion entry
+  `VandermondeInterpolationOQ01OQ02` packages the two halves of the interpolation
+  problem (existence + uniqueness) into a single linear isomorphism
+
+      `evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F)`,   `p ↦ (j ↦ p.eval (v j))`,
+
+  whose inverse is the explicit Lagrange interpolant.  This entry transports the
+  *standard basis* of `Fin n → F` across that isomorphism to obtain a concrete
+  basis of the polynomial space `degreeLT F n`:
+
+      `lagrangeBasis : Basis (Fin n) F (degreeLT F n)`,
+
+  whose `j`-th vector is exactly Mathlib's Lagrange basis polynomial
+  `Lagrange.basis univ v j` (`lagrangeBasis_coe`).
+
+  The structural payoff is the **interpolation reading of the coordinates**:
+
+      `(lagrangeBasis).repr p j = (p : F[X]).eval (v j)`   (`lagrangeBasis_repr`),
+
+  i.e. the coordinate of a degree-`< n` polynomial in the Lagrange basis is
+  simply its value at the corresponding node.  Equivalently every such `p` is the
+  interpolation sum of its node values (`degreeLT_eq_node_sum`).  The defining
+  Kronecker-delta property `(lagrangeBasis j).eval (v k) = [j = k]`
+  (`eval_lagrangeBasis`) exhibits this basis as the dual of the evaluation
+  functionals.
+
+  The file is self-contained: the small interpolation isomorphism is rebuilt here
+  (mirroring the companion entry) so the basis result can be checked in isolation.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Polynomial Finset
+
+namespace VandermondeInterpolationOQ01OQ02OQ01
+
+variable {F : Type*} [Field F] {n : ℕ} {v : Fin n → F}
+
+/-! ### The interpolation isomorphism (self-contained companion of OQ01OQ02) -/
+
+/-- The number of nodes is `n`. -/
+private theorem card_univ_fin : #(univ : Finset (Fin n)) = n := by simp
+
+/-- The Lagrange interpolant lands in `degreeLT F n` (degree `< n`). -/
+theorem interp_mem_degreeLT (hv : Function.Injective v) (r : Fin n → F) :
+    Lagrange.interpolate univ v r ∈ degreeLT F n := by
+  rw [mem_degreeLT]
+  have h := Lagrange.degree_interpolate_lt (s := univ) (v := v) (r := r) hv.injOn
+  rwa [card_univ_fin] at h
+
+/-- The **evaluation map** `p ↦ (j ↦ p.eval (v j))` as an `F`-linear map. -/
+def evalNodes (v : Fin n → F) : degreeLT F n →ₗ[F] (Fin n → F) :=
+  LinearMap.pi fun j => (Polynomial.leval (v j)).comp (degreeLT F n).subtype
+
+@[simp] theorem evalNodes_apply (v : Fin n → F) (p : degreeLT F n) (j : Fin n) :
+    evalNodes v p j = (p : F[X]).eval (v j) := rfl
+
+/-- The Lagrange interpolant as an `F`-linear map into `degreeLT F n`. -/
+noncomputable def interpLT (hv : Function.Injective v) :
+    (Fin n → F) →ₗ[F] degreeLT F n :=
+  LinearMap.codRestrict _ (Lagrange.interpolate univ v) (interp_mem_degreeLT hv)
+
+/-- The evaluation map is a linear isomorphism `degreeLT F n ≃ₗ[F] (Fin n → F)`,
+with inverse the Lagrange interpolant. -/
+noncomputable def evalEquiv (hv : Function.Injective v) :
+    degreeLT F n ≃ₗ[F] (Fin n → F) :=
+  LinearEquiv.ofLinear (evalNodes v) (interpLT hv)
+    (by
+      refine LinearMap.ext fun r => funext fun j => ?_
+      show (Lagrange.interpolate univ v r).eval (v j) = r j
+      exact Lagrange.eval_interpolate_at_node r hv.injOn (mem_univ j))
+    (by
+      refine LinearMap.ext fun p => Subtype.ext ?_
+      have hdeg : (p : F[X]).degree < #(univ : Finset (Fin n)) := by
+        rw [card_univ_fin]; exact mem_degreeLT.1 p.2
+      exact (Lagrange.eq_interpolate hv.injOn hdeg).symm)
+
+@[simp] theorem evalEquiv_apply (hv : Function.Injective v) (p : degreeLT F n) :
+    evalEquiv hv p = evalNodes v p := rfl
+
+@[simp] theorem evalEquiv_symm_apply (hv : Function.Injective v) (r : Fin n → F) :
+    ((evalEquiv hv).symm r : F[X]) = Lagrange.interpolate univ v r := rfl
+
+/-! ### The Lagrange basis -/
+
+/-- The **Lagrange basis** of `degreeLT F n`: the image of the standard basis of
+`Fin n → F` under the inverse evaluation isomorphism.  Its vectors are the
+Lagrange basis polynomials. -/
+noncomputable def lagrangeBasis (hv : Function.Injective v) :
+    Module.Basis (Fin n) F (degreeLT F n) :=
+  (Pi.basisFun F (Fin n)).map (evalEquiv hv).symm
+
+@[simp] theorem lagrangeBasis_apply (hv : Function.Injective v) (j : Fin n) :
+    lagrangeBasis hv j = (evalEquiv hv).symm (Pi.single j 1) := by
+  simp only [lagrangeBasis, Module.Basis.map_apply, Pi.basisFun_apply]
+
+/-- The `j`-th vector of `lagrangeBasis` is Mathlib's Lagrange basis polynomial
+`Lagrange.basis univ v j`. -/
+theorem lagrangeBasis_coe (hv : Function.Injective v) (j : Fin n) :
+    ((lagrangeBasis hv j : degreeLT F n) : F[X]) = Lagrange.basis univ v j := by
+  rw [lagrangeBasis_apply, evalEquiv_symm_apply, Lagrange.interpolate_apply,
+    Finset.sum_eq_single j]
+  · simp
+  · intro i _ hij
+    simp [hij]
+  · intro h; exact absurd (mem_univ j) h
+
+/-- **Kronecker-delta property.** The `j`-th Lagrange basis polynomial takes the
+value `1` at node `v j` and `0` at the other nodes — it is dual to the evaluation
+functionals. -/
+theorem eval_lagrangeBasis (hv : Function.Injective v) (j k : Fin n) :
+    ((lagrangeBasis hv j : degreeLT F n) : F[X]).eval (v k) = if j = k then 1 else 0 := by
+  rw [lagrangeBasis_coe]
+  by_cases h : j = k
+  · subst h; rw [if_pos rfl, Lagrange.eval_basis_self hv.injOn (mem_univ j)]
+  · rw [if_neg h, Lagrange.eval_basis_of_ne h (mem_univ k)]
+
+/-- **Interpolation reading of the coordinates.** The coordinate of a degree-`< n`
+polynomial in the Lagrange basis is its value at the corresponding node. -/
+@[simp] theorem lagrangeBasis_repr (hv : Function.Injective v) (p : degreeLT F n)
+    (j : Fin n) : (lagrangeBasis hv).repr p j = (p : F[X]).eval (v j) := by
+  simp only [lagrangeBasis, Module.Basis.map_repr, LinearEquiv.trans_apply,
+    LinearEquiv.symm_symm, Pi.basisFun_repr, evalEquiv_apply, evalNodes_apply]
+
+/-- Every degree-`< n` polynomial is the interpolation sum of its node values
+against the Lagrange basis. -/
+theorem degreeLT_eq_node_sum (hv : Function.Injective v) (p : degreeLT F n) :
+    ∑ j, (p : F[X]).eval (v j) • lagrangeBasis hv j = p := by
+  conv_rhs => rw [← (lagrangeBasis hv).sum_repr p]
+  exact Finset.sum_congr rfl fun j _ => by rw [lagrangeBasis_repr]
+
+/-- The Lagrange basis polynomials are linearly independent. -/
+theorem lagrangeBasis_linearIndependent (hv : Function.Injective v) :
+    LinearIndependent F (lagrangeBasis hv) := (lagrangeBasis hv).linearIndependent
+
+/-- The Lagrange basis polynomials span `degreeLT F n`. -/
+theorem lagrangeBasis_span (hv : Function.Injective v) :
+    Submodule.span F (Set.range (lagrangeBasis hv)) = ⊤ := (lagrangeBasis hv).span_eq
+
+/-- **Structural consequence.** The space of degree-`< n` polynomials has dimension
+`n`, witnessed concretely by the `n` Lagrange basis polynomials. -/
+theorem finrank_degreeLT (hv : Function.Injective v) :
+    Module.finrank F (degreeLT F n) = n := by
+  rw [Module.finrank_eq_card_basis (lagrangeBasis hv), Fintype.card_fin]
+
+end VandermondeInterpolationOQ01OQ02OQ01

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,197 @@
+{
+  "id": "vandermonde-interpolation-oq-01-oq-02-oq-01",
+  "title": "The Lagrange Basis Polynomials as a Basis of the Degree-< n Polynomials",
+  "slug": "vandermonde-interpolation-oq-01-oq-02-oq-01",
+  "description": "Over a field F with n distinct nodes v : Fin n → F, the companion entry vandermonde-interpolation-oq-01-oq-02 builds the interpolation isomorphism evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F), p ↦ (j ↦ p(v_j)). This entry transports the standard basis of Fin n → F across that isomorphism to obtain a concrete Module.Basis of the polynomial space: lagrangeBasis : Module.Basis (Fin n) F (degreeLT F n), whose j-th vector is exactly Mathlib's Lagrange basis polynomial Lagrange.basis univ v j (lagrangeBasis_coe). The structural payoff is the interpolation reading of the coordinates: (lagrangeBasis).repr p j = p(v_j) — the coordinate of a degree-< n polynomial in the Lagrange basis is simply its value at the corresponding node (lagrangeBasis_repr). Equivalently every such p is the interpolation sum of its node values (degreeLT_eq_node_sum), and the Lagrange basis is dual to the evaluation functionals via the Kronecker-delta property (lagrangeBasis j)(v_k) = [j = k] (eval_lagrangeBasis). Linear independence (lagrangeBasis_linearIndependent), spanning (lagrangeBasis_span), and the dimension count finrank = n (finrank_degreeLT) all follow for free from the Module.Basis structure. The interpolation isomorphism is rebuilt self-contained so the basis result is checkable in isolation. 12 theorems (incl. 5 simp lemmas), 4 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange_polynomial",
+    "date": "Joseph-Louis Lagrange (1795); Edward Waring (1779)",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "polynomials",
+      "interpolation",
+      "lagrange",
+      "vandermonde",
+      "basis",
+      "dual-basis",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/VandermondeInterpolationOQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere. The single hypothesis is that the node map v : Fin n → F is injective (the n nodes are distinct), exactly the well-posedness condition for interpolation.",
+    "originalContributions": [
+      "lagrangeBasis: a Module.Basis (Fin n) F (degreeLT F n) obtained as the image of the standard basis Pi.basisFun under the inverse interpolation isomorphism (evalEquiv hv).symm — a basis of the degree-< n polynomials whose vectors are the Lagrange basis polynomials",
+      "lagrangeBasis_coe: the j-th basis vector coerces to Mathlib's Lagrange basis polynomial Lagrange.basis univ v j, identifying the transported standard basis with the classical Lagrange polynomials",
+      "lagrangeBasis_repr: the interpolation reading of the coordinates — the coordinate of a degree-< n polynomial in the Lagrange basis is its value at the corresponding node, repr p j = p(v_j)",
+      "eval_lagrangeBasis: the Kronecker-delta property (lagrangeBasis j)(v_k) = if j = k then 1 else 0, exhibiting the basis as dual to the evaluation functionals",
+      "degreeLT_eq_node_sum: every degree-< n polynomial is the interpolation sum ∑_j p(v_j) • lagrangeBasis_j of its node values against the Lagrange basis",
+      "lagrangeBasis_linearIndependent / lagrangeBasis_span: linear independence and spanning of the Lagrange basis polynomials, free consequences of the Module.Basis",
+      "finrank_degreeLT: dim_F(degreeLT F n) = n re-derived concretely from the explicit n-element basis (Module.finrank_eq_card_basis), complementing the companion's transport-of-isomorphism proof"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 150,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Lagrange basis polynomials ℓ_j(x) = ∏_{i≠j}(x − v_i)/(v_j − v_i) are the oldest explicit basis of the space of polynomials of degree < n: each ℓ_j takes the value 1 at its own node v_j and 0 at all other nodes, so the interpolant through data (y_0, …, y_{n−1}) is simply ∑_j y_j ℓ_j. That they form a basis — and that the coordinates of any polynomial in this basis are exactly its sampled values — is the dual-basis statement underlying the change of representation between coefficients and point-values. It is the linear-algebra heart of nodal finite-element shape functions, Reed–Solomon encoding, and the barycentric interpolation formula.",
+    "problemStatement": "**Open Question (OQ-01 of vandermonde-interpolation-oq-01-oq-02)**: Promote the interpolation isomorphism to an explicit basis — show the Lagrange basis polynomials form a basis of degreeLT F n, and identify the coordinates of a polynomial in this basis with its values at the nodes.\n\n**Formalized**: lagrangeBasis (the Module.Basis), lagrangeBasis_coe (vectors are Lagrange.basis univ v j), lagrangeBasis_repr (coordinates = node values), eval_lagrangeBasis (Kronecker-delta / dual basis), degreeLT_eq_node_sum (interpolation expansion), lagrangeBasis_linearIndependent / lagrangeBasis_span, finrank_degreeLT.",
+    "text": "A 150-line formalization that upgrades the companion entry's interpolation isomorphism evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F) into an explicit basis of the polynomial space. The construction is one line — lagrangeBasis = (Pi.basisFun F (Fin n)).map (evalEquiv hv).symm — transporting the standard coordinate basis of Fin n → F backwards across the isomorphism. The content is in identifying this abstract transported basis with the classical objects. lagrangeBasis_apply rewrites the j-th vector as (evalEquiv hv).symm (Pi.single j 1); since the inverse isomorphism is the Lagrange interpolant, that is interpolate univ v (Pi.single j 1), which collapses to Lagrange.basis univ v j (lagrangeBasis_coe). The structural payoff comes from Module.Basis.map_repr: the j-th coordinate of p in lagrangeBasis is the j-th coordinate of (evalEquiv hv p) in the standard basis, which is evalNodes v p j = p(v_j) (lagrangeBasis_repr). Thus the coordinate functionals of this basis are precisely the point-evaluations. eval_lagrangeBasis records the dual Kronecker-delta property via Lagrange.eval_basis_self / eval_basis_of_ne, degreeLT_eq_node_sum is the resulting interpolation expansion (Module.Basis.sum_repr specialized), and linear independence, spanning, and finrank = n drop out of the Module.Basis API. The interpolation isomorphism is rebuilt inline (mirroring the companion) so the file is self-contained: 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "**Isomorphism (self-contained companion)**: evalNodes = LinearMap.pi (Polynomial.leval (v j) ∘ subtype); interpLT = codRestrict of Lagrange.interpolate univ v using interp_mem_degreeLT (degree < #univ = n); evalEquiv = LinearEquiv.ofLinear with right inverse Lagrange.eval_interpolate_at_node and left inverse Lagrange.eq_interpolate.\n\n**lagrangeBasis**: (Pi.basisFun F (Fin n)).map (evalEquiv hv).symm.\n\n**lagrangeBasis_apply**: simp [lagrangeBasis, Module.Basis.map_apply, Pi.basisFun_apply] gives (evalEquiv hv).symm (Pi.single j 1).\n\n**lagrangeBasis_coe**: rewrite by lagrangeBasis_apply and evalEquiv_symm_apply to interpolate univ v (Pi.single j 1), then Lagrange.interpolate_apply and Finset.sum_eq_single j (off-diagonal terms vanish since Pi.single j 1 i = 0 for i ≠ j) leave Lagrange.basis univ v j.\n\n**eval_lagrangeBasis**: rewrite by lagrangeBasis_coe then case split: Lagrange.eval_basis_self (diagonal = 1) and Lagrange.eval_basis_of_ne (off-diagonal = 0).\n\n**lagrangeBasis_repr**: simp [lagrangeBasis, Module.Basis.map_repr, LinearEquiv.symm_symm, Pi.basisFun_repr, evalEquiv_apply, evalNodes_apply] reduces the coordinate to p(v_j).\n\n**degreeLT_eq_node_sum**: rewrite the RHS by (lagrangeBasis hv).sum_repr p, then sum_congr with lagrangeBasis_repr.\n\n**lagrangeBasis_linearIndependent / span / finrank_degreeLT**: (lagrangeBasis hv).linearIndependent, .span_eq, and Module.finrank_eq_card_basis with Fintype.card_fin.",
+    "keyInsights": [
+      "**A basis by transport, not by hand**: rather than verifying linear independence and spanning of the Lagrange polynomials directly, the basis is the image of the standard coordinate basis under the interpolation isomorphism — Module.Basis.map turns one line of structure into a full basis with all its API.",
+      "**Coordinates are sampled values**: the decisive fact (lagrangeBasis_repr) is that the coordinate functionals of the Lagrange basis are exactly the point-evaluations p ↦ p(v_j). This is the dual-basis statement and the reason the interpolation formula ∑_j p(v_j) ℓ_j is literally the basis expansion of p.",
+      "**The transported standard basis IS the classical Lagrange basis**: lagrangeBasis_coe pins the abstract construction to Mathlib's Lagrange.basis univ v j, because the inverse isomorphism is the Lagrange interpolant and interpolating the j-th unit vector returns the j-th Lagrange polynomial.",
+      "**Kronecker delta = dual basis**: eval_lagrangeBasis ((ℓ_j)(v_k) = [j = k]) is precisely the biorthogonality of the Lagrange basis and the evaluation functionals — the defining property from which everything else (coordinates, expansion) follows.",
+      "**Dimension two ways**: finrank = n is re-proved here from an explicit n-element basis (Module.finrank_eq_card_basis), complementing the companion entry's proof by transport of the isomorphism to F^n; the basis route exhibits the actual coordinate system.",
+      "**0-axiom, no native_decide**: every step is kernel-checked, depending only on propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "The companion entry vandermonde-interpolation-oq-01-oq-02 (the interpolation isomorphism evalEquiv; rebuilt self-contained here)",
+      "Mathlib's Lagrange API: Lagrange.interpolate, interpolate_apply, basis, eval_basis_self, eval_basis_of_ne, eval_interpolate_at_node, degree_interpolate_lt, eq_interpolate (LinearAlgebra/Lagrange.lean)",
+      "Module.Basis and its API: Pi.basisFun, Basis.map, Module.Basis.map_apply, Module.Basis.map_repr, Pi.basisFun_apply, Pi.basisFun_repr, Basis.sum_repr, Module.finrank_eq_card_basis",
+      "Polynomial.degreeLT, mem_degreeLT, Polynomial.leval; LinearMap.pi, LinearMap.codRestrict, LinearEquiv.ofLinear",
+      "Pi.single and Pi.single_apply; Function.Injective.injOn and Finset.card_fin"
+    ]
+  },
+  "sections": [
+    {
+      "id": "isomorphism",
+      "title": "The Interpolation Isomorphism (self-contained)",
+      "startLine": 43,
+      "endLine": 86,
+      "summary": "Rebuilds the companion entry's evalNodes (evaluation as a linear map), interpLT (the codomain-restricted Lagrange interpolant), and evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F) with the interpolant as its two-sided inverse, so the basis result below is checkable in isolation."
+    },
+    {
+      "id": "basis-def",
+      "title": "The Lagrange Basis by Transport",
+      "startLine": 88,
+      "endLine": 101,
+      "summary": "lagrangeBasis = (Pi.basisFun F (Fin n)).map (evalEquiv hv).symm transports the standard basis of Fin n → F across the inverse isomorphism; lagrangeBasis_apply rewrites the j-th vector as (evalEquiv hv).symm (Pi.single j 1)."
+    },
+    {
+      "id": "basis-coe",
+      "title": "The Vectors Are the Lagrange Polynomials",
+      "startLine": 103,
+      "endLine": 113,
+      "summary": "lagrangeBasis_coe identifies the j-th basis vector with Mathlib's Lagrange.basis univ v j, via interpolate_apply and Finset.sum_eq_single (off-diagonal unit-vector terms vanish)."
+    },
+    {
+      "id": "dual",
+      "title": "Kronecker Delta: Duality with Evaluation",
+      "startLine": 115,
+      "endLine": 122,
+      "summary": "eval_lagrangeBasis proves (lagrangeBasis j)(v_k) = if j = k then 1 else 0 from Lagrange.eval_basis_self and eval_basis_of_ne — the biorthogonality of the basis and the point-evaluation functionals."
+    },
+    {
+      "id": "coordinates",
+      "title": "Coordinates Are Node Values",
+      "startLine": 124,
+      "endLine": 135,
+      "summary": "lagrangeBasis_repr: the j-th coordinate of p in the Lagrange basis equals p(v_j) (Module.Basis.map_repr + Pi.basisFun_repr + evalNodes_apply). degreeLT_eq_node_sum is the resulting interpolation expansion p = ∑_j p(v_j) • lagrangeBasis_j."
+    },
+    {
+      "id": "consequences",
+      "title": "Independence, Spanning, Dimension",
+      "startLine": 137,
+      "endLine": 147,
+      "summary": "lagrangeBasis_linearIndependent, lagrangeBasis_span, and finrank_degreeLT (dim = n from the explicit n-element basis) follow directly from the Module.Basis structure."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "vandermonde-interpolation-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The companion entry builds the interpolation isomorphism evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F). This entry transports the standard basis backwards across that isomorphism to obtain the explicit Lagrange basis, and identifies its coordinate functionals with the point-evaluations the isomorphism is built from."
+    },
+    {
+      "proofId": "vandermonde-interpolation-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent entry constructs the explicit Lagrange interpolant realizing prescribed values. Here that interpolant reappears as the inverse isomorphism, and interpolating the unit vectors recovers exactly the Lagrange basis polynomials that form the basis."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "VandermondeInterpolationOQ01OQ02OQ01",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "path": "Proofs/VandermondeInterpolationOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "lagrangeBasis",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $\\mathrm{Module.Basis}\\,(\\mathrm{Fin}\\,n)\\,F\\,(\\mathrm{degreeLT}\\,F\\,n)$",
+      "significance": "A concrete basis of the degree-< n polynomials obtained by transporting the standard basis of F^n across the inverse interpolation isomorphism; its vectors are the Lagrange basis polynomials.",
+      "description": "The Lagrange basis of the degree-< n polynomial space."
+    },
+    {
+      "name": "lagrangeBasis_repr",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $(\\mathrm{lagrangeBasis})\\,.\\mathrm{repr}\\,p\\,j = p(v_j)$",
+      "significance": "The interpolation reading of the coordinates: the coordinate of a degree-< n polynomial in the Lagrange basis is exactly its value at the corresponding node — the basis is dual to the evaluation functionals.",
+      "description": "Coordinates in the Lagrange basis are the node values."
+    },
+    {
+      "name": "lagrangeBasis_coe",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $(\\mathrm{lagrangeBasis}\\,j : F[X]) = \\mathrm{Lagrange.basis}\\,\\mathrm{univ}\\,v\\,j$",
+      "significance": "Identifies the abstract transported basis vector with Mathlib's classical Lagrange basis polynomial, grounding the construction in the explicit formula.",
+      "description": "The j-th basis vector is the Lagrange basis polynomial."
+    },
+    {
+      "name": "eval_lagrangeBasis",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $(\\mathrm{lagrangeBasis}\\,j)(v_k) = [\\,j = k\\,]$",
+      "significance": "The Kronecker-delta / dual-basis property: each Lagrange polynomial is 1 at its own node and 0 at the others, the biorthogonality from which the coordinate identity follows.",
+      "description": "Kronecker-delta property of the Lagrange basis."
+    },
+    {
+      "name": "degreeLT_eq_node_sum",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $\\sum_j p(v_j) \\cdot \\mathrm{lagrangeBasis}_j = p$",
+      "significance": "Every degree-< n polynomial is the interpolation sum of its node values against the Lagrange basis — the classical Lagrange interpolation formula as a basis expansion.",
+      "description": "Interpolation expansion in the Lagrange basis."
+    },
+    {
+      "name": "finrank_degreeLT",
+      "type": "supporting",
+      "statement": "$v$ injective $\\Rightarrow$ $\\dim_F(\\mathrm{degreeLT}\\,F\\,n) = n$",
+      "significance": "The degree-< n polynomial space has dimension n, re-derived from the explicit n-element Lagrange basis (complementing the companion's transport-of-isomorphism proof).",
+      "description": "Dimension n from the explicit basis."
+    }
+  ],
+  "references": [
+    {
+      "text": "Lagrange polynomial: the basis ℓ_j(x) = ∏_{i≠j}(x − x_i)/(x_j − x_i) with ℓ_j(x_k) = δ_{jk}.",
+      "url": "https://en.wikipedia.org/wiki/Lagrange_polynomial"
+    },
+    {
+      "text": "Polynomial interpolation — the Lagrange basis and the change of representation between coefficients and point-values.",
+      "url": "https://en.wikipedia.org/wiki/Polynomial_interpolation"
+    },
+    {
+      "text": "Mathlib4: Lagrange.basis, Lagrange.eval_basis_self, Lagrange.eval_basis_of_ne, Lagrange.interpolate_apply; Module.Basis.map, Pi.basisFun (LinearAlgebra/Lagrange.lean, LinearAlgebra/Basis).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Lagrange.html"
+    }
+  ],
+  "conclusion": {
+    "summary": "Upgrades the companion entry's interpolation isomorphism into an explicit basis of the degree-< n polynomials. lagrangeBasis is the image of the standard basis of F^n under the inverse isomorphism; its vectors are Mathlib's Lagrange basis polynomials (lagrangeBasis_coe), it is biorthogonal to the point-evaluations (eval_lagrangeBasis), and crucially its coordinate functionals are exactly those evaluations: (lagrangeBasis).repr p j = p(v_j) (lagrangeBasis_repr). The interpolation formula p = ∑_j p(v_j) • lagrangeBasis_j (degreeLT_eq_node_sum), linear independence, spanning, and dim = n all follow from the Module.Basis structure. All 12 theorems (5 simp lemmas) and 4 definitions verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Exhibits the Lagrange basis as the canonical dual of the point-evaluation functionals: the change of representation between a polynomial and its sampled values is now a literal change of basis with the interpolation formula as the expansion. This is the linear-algebra core of nodal finite-element shape functions, barycentric interpolation, and Reed–Solomon coordinates.",
+    "openQuestions": [
+      "Build the barycentric form: express lagrangeBasis_repr / the interpolation expansion through the barycentric weights w_j = ∏_{i≠j}(v_j − v_i)^{-1}, and prove the second barycentric formula as an identity of the basis expansion.",
+      "Change of basis to the monomials: compute the transition matrix between lagrangeBasis and the monomial basis of degreeLT F n (the inverse Vandermonde matrix), making the coefficient↔value duality fully explicit."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `vandermonde-interpolation-oq-01-oq-02`: promote the interpolation isomorphism to an explicit **basis** and identify its coordinates with sampled values.

Over a field `F` with `n` distinct nodes `v : Fin n → F`, transports the standard basis of `Fin n → F` backwards across the companion entry's interpolation isomorphism `evalEquiv : degreeLT F n ≃ₗ[F] (Fin n → F)`:

```
lagrangeBasis = (Pi.basisFun F (Fin n)).map (evalEquiv hv).symm
```

## Results

- **`lagrangeBasis`** — a `Module.Basis (Fin n) F (degreeLT F n)`.
- **`lagrangeBasis_coe`** — its `j`-th vector is Mathlib's Lagrange basis polynomial `Lagrange.basis univ v j`.
- **`lagrangeBasis_repr`** (the payoff) — the coordinate of a degree-< n polynomial in this basis is its value at the node: `repr p j = p(v_j)`. The basis is dual to the point-evaluation functionals.
- **`eval_lagrangeBasis`** — Kronecker delta `(ℓ_j)(v_k) = [j = k]` (biorthogonality).
- **`degreeLT_eq_node_sum`** — the interpolation expansion `p = ∑_j p(v_j) • ℓ_j`.
- **`lagrangeBasis_linearIndependent` / `lagrangeBasis_span` / `finrank_degreeLT`** — free from the `Module.Basis` structure (dim = n from the explicit n-element basis).

## Verification

- 12 theorems (5 simp lemmas), 4 definitions, 150 lines.
- **0 sorries, 0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), no `native_decide`.
- Self-contained: the interpolation isomorphism is rebuilt inline so the file checks in isolation.
- Registered in `Proofs.lean`; gallery `meta.json` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)