### PR TITLE
research(factor-remainder-theorem-oq-01-oq-01-oq-01): sharp positive-characteristic discrepancy over 𝔽ₚ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2809,6 +2809,7 @@ import Proofs.FactorRemainderNullstellensatzOQ01OQ02
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem
 import Proofs.FactorRemainderTheoremOQ01
+import Proofs.FactorRemainderTheoremOQ01OQ01OQ01
 import Proofs.FactorRemainderTheoremOQ01OQ02
 import Proofs.FactorRemainderTheoremOQ01OQ02OQ01
 import Proofs.FactorRemainderTheoremOQ02

--- a/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,126 @@
+import Mathlib
+
+/-!
+# Factor–remainder theorem OQ-01-OQ-01-OQ-01:
+# the sharp positive-characteristic discrepancy
+
+The parent entry `factor-remainder-theorem-oq-01-oq-01` formalized the
+**Taylor-coefficient** multiplicity test
+
+  `(X − a)^k ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0`,
+
+valid over *any* commutative ring, and noted that over a characteristic-zero
+field it is equivalent to the parent's **ordinary-derivative** test
+`(X − a)^k ∣ p ↔ p(a) = p′(a) = ⋯ = p^{(k−1)}(a) = 0`, because
+`(derivative^[m] p).eval a = m! · (taylor a p).coeff m` and `m! ≠ 0`.
+
+Its **first open question** asks to *make the discrepancy explicit*: exhibit a
+polynomial over `𝔽ₚ` for which the ordinary-derivative criterion fails but the
+Hasse/Taylor criterion succeeds, "quantifying exactly where the parent's
+characteristic-zero hypothesis is needed."
+
+This entry does so with the canonical witness `f = Xᵖ` over `𝔽ₚ = ZMod p`:
+
+* **The ordinary-derivative test collapses.** `derivative (Xᵖ) = 0` identically
+  (`derivative_X_pow_eq_zero`), so *every* iterated derivative vanishes and
+  *every* derivative condition `(derivative^[j] f).eval 0 = 0` holds
+  (`ordinary_criterion_vacuous`). The criterion therefore certifies *no* finite
+  multiplicity — it would assert `Xᵏ ∣ Xᵖ` for all `k`, which is false.
+
+* **The coefficient / Taylor test stays sharp.** It is characteristic-free
+  (`X_pow_dvd_iff`), so `Xᵏ ∣ Xᵖ ↔ k ≤ p` (`coeff_criterion_correct`): the true
+  multiplicity `p` is detected exactly.
+
+* **The Hasse derivative survives where the ordinary one dies.**
+  `hasseDeriv p (Xᵖ) ≠ 0` (`hasseDeriv_ne_zero`), yet `derivative^[p] (Xᵖ) = 0`.
+  The bridge `derivative^[p] f = p! · hasseDeriv p f` shows the obstruction is
+  *exactly* the factorial: `p! • hasseDeriv p (Xᵖ) = 0` because `p! ≡ 0 (mod p)`
+  (`factorial_annihilates_hasseDeriv`). This pinpoints `k! ≠ 0` — i.e. the
+  characteristic-zero hypothesis — as the precise input the ordinary-derivative
+  test needs and the Hasse/Taylor test does not.
+
+`0` axioms.
+-/
+
+namespace FactorRemainderTheoremOQ01OQ01OQ01
+
+open Polynomial
+
+variable (p : ℕ) [hp : Fact p.Prime]
+
+/-! ## The ordinary-derivative test collapses over `𝔽ₚ` -/
+
+/-- **The ordinary derivative of `Xᵖ` vanishes identically over `𝔽ₚ`.**
+`derivative (Xᵖ) = C(p)·X^{p−1} = 0` since `p ≡ 0 (mod p)`. -/
+theorem derivative_X_pow_eq_zero : derivative ((X : (ZMod p)[X]) ^ p) = 0 := by
+  rw [derivative_X_pow, ZMod.natCast_self, map_zero, zero_mul]
+
+/-- Consequently *every* iterated derivative of `Xᵖ` (of positive order) is `0`. -/
+theorem iterate_derivative_X_pow_eq_zero {j : ℕ} (hj : 1 ≤ j) :
+    (derivative^[j]) ((X : (ZMod p)[X]) ^ p) = 0 := by
+  obtain ⟨j, rfl⟩ : ∃ j', j = j' + 1 := ⟨j - 1, by omega⟩
+  rw [Function.iterate_succ_apply, derivative_X_pow_eq_zero p, iterate_derivative_zero]
+
+/-- **The ordinary-derivative criterion is vacuous.** *Every* derivative
+condition `(derivative^[j] (Xᵖ)).eval 0 = 0` holds — for `j = 0` because
+`Xᵖ` evaluates to `0` at `0`, and for `j ≥ 1` because the derivative is `0`.
+The criterion thus cannot bound the multiplicity: it would (falsely) certify
+`Xᵏ ∣ Xᵖ` for every `k`. -/
+theorem ordinary_criterion_vacuous (j : ℕ) :
+    ((derivative^[j]) ((X : (ZMod p)[X]) ^ p)).eval 0 = 0 := by
+  rcases Nat.eq_zero_or_pos j with rfl | hj
+  · simp only [Function.iterate_zero, id_eq, eval_pow, eval_X]
+    exact zero_pow hp.out.pos.ne'
+  · rw [iterate_derivative_X_pow_eq_zero p hj, eval_zero]
+
+/-! ## The coefficient / Taylor test stays sharp -/
+
+/-- **The characteristic-free coefficient criterion gives the right multiplicity.**
+`Xᵏ ∣ Xᵖ ↔ k ≤ p`, via `X_pow_dvd_iff` (the `a = 0` Taylor-coefficient test):
+the true multiplicity `p` of the root `0` is detected exactly, in every
+characteristic. -/
+theorem coeff_criterion_correct (k : ℕ) :
+    (X : (ZMod p)[X]) ^ k ∣ (X : (ZMod p)[X]) ^ p ↔ k ≤ p := by
+  rw [X_pow_dvd_iff]
+  constructor
+  · intro h
+    by_contra hk
+    push_neg at hk
+    have hpc := h p (by omega)
+    rw [coeff_X_pow] at hpc
+    simp at hpc
+  · intro hk d hd
+    rw [coeff_X_pow, if_neg (by omega)]
+
+/-- The true multiplicity is exactly `p`: `Xᵖ ∣ Xᵖ` but `X^{p+1} ∤ Xᵖ` — in
+flat contradiction with the vacuous ordinary-derivative certificate. -/
+theorem multiplicity_eq_p :
+    (X : (ZMod p)[X]) ^ p ∣ (X : (ZMod p)[X]) ^ p ∧
+      ¬ (X : (ZMod p)[X]) ^ (p + 1) ∣ (X : (ZMod p)[X]) ^ p :=
+  ⟨dvd_refl _, by rw [coeff_criterion_correct]; omega⟩
+
+/-! ## The Hasse derivative survives — and the factorial is the obstruction -/
+
+/-- **The `p`-th Hasse derivative of `Xᵖ` is nonzero**, even though the `p`-th
+*ordinary* derivative is `0`. (Its constant coefficient is `C(p,p) = 1 ≠ 0`.) -/
+theorem hasseDeriv_ne_zero : hasseDeriv p ((X : (ZMod p)[X]) ^ p) ≠ 0 := by
+  intro h
+  have hc : (hasseDeriv p ((X : (ZMod p)[X]) ^ p)).coeff 0 = 0 := by rw [h, coeff_zero]
+  rw [hasseDeriv_coeff, coeff_X_pow] at hc
+  simp [Nat.choose_self] at hc
+
+/-- **The factorial is exactly the obstruction.** The bridge
+`derivative^[p] f = p! · hasseDeriv p f` makes the discrepancy quantitative: the
+`p`-th Hasse derivative is nonzero (`hasseDeriv_ne_zero`), yet scaling it by the
+factorial annihilates it, `p! • hasseDeriv p (Xᵖ) = derivative^[p] (Xᵖ) = 0`,
+precisely because `p! ≡ 0 (mod p)`. This is *where* the characteristic-zero
+hypothesis `k! ≠ 0` of the ordinary-derivative test is needed. -/
+theorem factorial_annihilates_hasseDeriv :
+    Nat.factorial p • hasseDeriv p ((X : (ZMod p)[X]) ^ p) = 0 := by
+  have h := congrFun (factorial_smul_hasseDeriv (R := ZMod p) (k := p))
+    ((X : (ZMod p)[X]) ^ p)
+  rw [LinearMap.smul_apply] at h
+  rw [h]
+  exact iterate_derivative_X_pow_eq_zero p hp.out.one_lt.le
+
+end FactorRemainderTheoremOQ01OQ01OQ01

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+  "title": "The Sharp Positive-Characteristic Discrepancy: Ordinary vs Hasse/Taylor Multiplicity over 𝔽ₚ",
+  "slug": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+  "description": "Answers the parent Taylor-coefficient file's first open question by making the characteristic-p discrepancy explicit. For the witness Xᵖ over 𝔽ₚ = ZMod p: the ordinary-derivative multiplicity test collapses (derivative(Xᵖ)=0 identically, so every derivative condition holds vacuously and would falsely certify Xᵏ ∣ Xᵖ for all k), while the characteristic-free coefficient/Taylor test stays sharp (Xᵏ ∣ Xᵖ ↔ k ≤ p). The Hasse derivative survives where the ordinary one dies (hasseDeriv p Xᵖ ≠ 0), and the bridge derivative^[p] f = p!·hasseDeriv p f shows the obstruction is exactly the factorial p! ≡ 0 (mod p) — pinpointing where the parent's characteristic-zero hypothesis k! ≠ 0 is needed. 7 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-1",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "factor-remainder-theorem",
+      "polynomial",
+      "multiplicity",
+      "hasse-derivative",
+      "taylor-coefficient",
+      "positive-characteristic",
+      "finite-field",
+      "counterexample"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. All 7 theorems proved, 0 axioms. Verified axiom-free: #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.derivative_X_pow",
+        "description": "derivative (X^n) = C(n)·X^(n-1); with n = p over ZMod p the coefficient C(p) = 0",
+        "module": "Mathlib.Algebra.Polynomial.Derivative"
+      },
+      {
+        "theorem": "ZMod.natCast_self",
+        "description": "(p : ZMod p) = 0 — the source of the ordinary-derivative collapse",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Polynomial.X_pow_dvd_iff",
+        "description": "X^n ∣ f ↔ ∀ d < n, f.coeff d = 0 — the characteristic-free (Taylor-at-0) coefficient criterion",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "Polynomial.hasseDeriv_coeff",
+        "description": "(hasseDeriv k f).coeff n = (n+k).choose k · f.coeff (n+k); gives (hasseDeriv p Xᵖ).coeff 0 = C(p,p) = 1 ≠ 0",
+        "module": "Mathlib.Algebra.Polynomial.HasseDeriv"
+      },
+      {
+        "theorem": "Polynomial.factorial_smul_hasseDeriv",
+        "description": "k! • hasseDeriv k = derivative^[k]; the quantitative bridge whose factorial factor is the obstruction in characteristic p",
+        "module": "Mathlib.Algebra.Polynomial.HasseDeriv"
+      }
+    ],
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "Over a characteristic-zero field, the multiplicity of a root a of a polynomial p is detected by ordinary derivatives: (X−a)^k ∣ p iff p(a)=p′(a)=⋯=p^{(k−1)}(a)=0. In positive characteristic this fails dramatically: ordinary derivatives of order ≥ p vanish identically on pure p-th powers, losing all information. Hasse derivatives — the divided-derivative operators hasseDeriv k whose coefficients are the binomial coefficients rather than the factorial-laden ones — repair this, and equal the Taylor coefficients, which is why the Taylor-coefficient multiplicity test is characteristic-free. The parent entry formalized that characteristic-free test and asked, as its first open question, to make the discrepancy explicit over 𝔽ₚ.",
+    "problemStatement": "Exhibit a polynomial over 𝔽ₚ for which the ordinary-derivative multiplicity criterion fails but the Hasse/Taylor criterion succeeds, and quantify exactly where the characteristic-zero hypothesis is needed.",
+    "proofStrategy": "Take f = Xᵖ over 𝔽ₚ = ZMod p (p prime). (1) Collapse: derivative(Xᵖ) = C(p)·X^(p−1) = 0 since (p : ZMod p) = 0 (derivative_X_pow + ZMod.natCast_self); hence every iterated derivative of positive order is 0, and every derivative condition (derivative^[j] f).eval 0 = 0 holds (j = 0 because Xᵖ vanishes at 0, j ≥ 1 because the derivative is 0). (2) Sharpness: the coefficient criterion X_pow_dvd_iff is characteristic-free, so Xᵏ ∣ Xᵖ ↔ k ≤ p via coeff_X_pow; the true multiplicity p is detected and X^(p+1) ∤ Xᵖ. (3) Quantify: hasseDeriv p (Xᵖ) ≠ 0 (its constant coefficient is C(p,p)=1), yet derivative^[p](Xᵖ)=0; the identity factorial_smul_hasseDeriv (p!·hasseDeriv p = derivative^[p]) shows p! • hasseDeriv p (Xᵖ) = 0, so the factorial p! ≡ 0 (mod p) is precisely the obstruction.",
+    "keyInsights": [
+      "**The ordinary-derivative test is not merely weaker — it is vacuous.** Over 𝔽ₚ, derivative(Xᵖ) = 0 identically, so every derivative condition holds and the test certifies no finite multiplicity at all; it would assert Xᵏ ∣ Xᵖ for every k, which is false.",
+      "**The coefficient/Taylor test is characteristic-free.** X_pow_dvd_iff (X^k ∣ f ↔ first k coefficients vanish) is exactly the a = 0 Taylor-coefficient criterion and needs no division, so it detects the true multiplicity p in every characteristic.",
+      "**The factorial is the precise obstruction.** The bridge derivative^[p] f = p!·hasseDeriv p f makes the discrepancy quantitative: the Hasse derivative is nonzero but the factorial scaling annihilates it because p! ≡ 0 (mod p). This is exactly the input (k! ≠ 0) that the characteristic-zero ordinary-derivative test relies on and the Hasse/Taylor test does not.",
+      "**Xᵖ is the minimal witness.** A pure p-th power is where ordinary and Hasse derivatives first diverge maximally — every ordinary derivative dies while the p-th Hasse derivative is a nonzero unit."
+    ]
+  },
+  "sections": [
+    {
+      "id": "collapse",
+      "title": "The ordinary-derivative test collapses over 𝔽ₚ",
+      "startLine": 51,
+      "endLine": 75,
+      "summary": "derivative_X_pow_eq_zero: derivative(Xᵖ)=0 (C(p)=0 in ZMod p). iterate_derivative_X_pow_eq_zero: every positive-order iterated derivative is 0. ordinary_criterion_vacuous: every condition (derivative^[j] Xᵖ).eval 0 = 0 holds.",
+      "mathContext": "$\\mathrm{d}/\\mathrm{d}X(X^p) = pX^{p-1} = 0$ in $\\mathbb{F}_p$; all higher derivatives vanish, so the criterion is uninformative."
+    },
+    {
+      "id": "sharp",
+      "title": "The coefficient / Taylor test stays sharp",
+      "startLine": 76,
+      "endLine": 101,
+      "summary": "coeff_criterion_correct: Xᵏ ∣ Xᵖ ↔ k ≤ p (X_pow_dvd_iff + coeff_X_pow). multiplicity_eq_p: Xᵖ ∣ Xᵖ but X^(p+1) ∤ Xᵖ — the true multiplicity is exactly p.",
+      "mathContext": "$X^k \\mid X^p \\iff k \\leq p$, characteristic-free; the multiplicity $p$ is detected exactly."
+    },
+    {
+      "id": "obstruction",
+      "title": "The Hasse derivative survives — and the factorial is the obstruction",
+      "startLine": 102,
+      "endLine": 126,
+      "summary": "hasseDeriv_ne_zero: hasseDeriv p (Xᵖ) ≠ 0 (constant coeff C(p,p)=1). factorial_annihilates_hasseDeriv: p! • hasseDeriv p (Xᵖ) = derivative^[p](Xᵖ) = 0, so the factorial p! ≡ 0 (mod p) is exactly where char 0 is needed.",
+      "mathContext": "$\\partial^{[p]} = p!\\cdot \\mathrm{hasse}_p$; $\\mathrm{hasse}_p(X^p)\\neq 0$ but $p!\\equiv 0$, so $\\partial^{[p]}(X^p)=0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The positive-characteristic discrepancy of the multiplicity test is made explicit and quantitative over 𝔽ₚ via the witness Xᵖ: the ordinary-derivative criterion is vacuous, the coefficient/Taylor criterion is sharp, and the factorial p! ≡ 0 is exactly the obstruction relating the two. 7 theorems, 0 sorries, 0 axioms.",
+    "implications": "Confirms the parent's claim that the Taylor-coefficient test is strictly more general than the ordinary-derivative test, by an explicit characteristic-p example, and identifies the single arithmetic fact (k! invertible) on which the characteristic-zero equivalence rests.",
+    "openQuestions": [
+      "Generalize the witness to f = X^(p^e) and to arbitrary 𝔽_q, giving the full failure profile of the ordinary-derivative test as a function of multiplicity vs characteristic.",
+      "Formalize the divided-difference / Newton-form route to the same multiplicity test (the parent's second open question) and compare with the Hasse-derivative form in characteristic p."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "FactorRemainderTheoremOQ01OQ01OQ01",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent formalized the characteristic-free Taylor-coefficient multiplicity test and asked, as its first open question, to make the characteristic-p discrepancy with the ordinary-derivative test explicit; this file does so with Xᵖ over 𝔽ₚ"
+    },
+    {
+      "targetId": "factor-remainder-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "OQ-01 gave the ordinary-derivative multiplicity test over a characteristic-zero field, the criterion shown here to fail in characteristic p"
+    },
+    {
+      "targetId": "factor-remainder-theorem",
+      "relationship": "ancestor",
+      "description": "Root Factor Theorem (X − a) ∣ p ↔ p(a) = 0"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "coeff_criterion_correct",
+      "type": "core",
+      "statement": "Xᵏ ∣ Xᵖ ↔ k ≤ p  (over ZMod p)",
+      "description": "The characteristic-free coefficient/Taylor criterion detects the true multiplicity p.",
+      "significance": "Shows the Hasse/Taylor test succeeds where the ordinary-derivative test fails"
+    },
+    {
+      "name": "ordinary_criterion_vacuous",
+      "type": "core",
+      "statement": "∀ j, (derivative^[j] (Xᵖ)).eval 0 = 0",
+      "description": "Every ordinary-derivative condition holds, so the criterion certifies no finite multiplicity.",
+      "significance": "The explicit failure of the ordinary-derivative multiplicity test in characteristic p"
+    },
+    {
+      "name": "factorial_annihilates_hasseDeriv",
+      "type": "core",
+      "statement": "p! • hasseDeriv p (Xᵖ) = 0, with hasseDeriv p (Xᵖ) ≠ 0",
+      "description": "The factorial p! ≡ 0 (mod p) annihilates the nonzero Hasse derivative — the exact obstruction.",
+      "significance": "Quantifies where the characteristic-zero hypothesis k! ≠ 0 is needed"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent Taylor-coefficient file's (`factor-remainder-theorem-oq-01-oq-01`) **first open question** — *make the positive-characteristic discrepancy explicit*: exhibit a polynomial over 𝔽ₚ where the ordinary-derivative multiplicity test fails but the Hasse/Taylor test succeeds, and quantify where the characteristic-zero hypothesis is needed.

Witness: **`f = Xᵖ` over `𝔽ₚ = ZMod p`.**

## Results (7 theorems, 126 lines, 0 sorries, 0 axioms)

**The ordinary-derivative test collapses:**
- `derivative_X_pow_eq_zero` — `derivative(Xᵖ) = C(p)·X^(p−1) = 0` since `(p : ZMod p) = 0`.
- `ordinary_criterion_vacuous` — `∀ j, (derivative^[j] Xᵖ).eval 0 = 0`. Every derivative condition holds, so the criterion certifies **no** finite multiplicity — it would assert `Xᵏ ∣ Xᵖ` for all `k`, which is false.

**The coefficient / Taylor test stays sharp (characteristic-free):**
- `coeff_criterion_correct` — `Xᵏ ∣ Xᵖ ↔ k ≤ p` (via `X_pow_dvd_iff`, the `a = 0` Taylor-coefficient criterion).
- `multiplicity_eq_p` — `Xᵖ ∣ Xᵖ` but `X^(p+1) ∤ Xᵖ`: the true multiplicity is exactly `p`.

**The factorial is the precise obstruction:**
- `hasseDeriv_ne_zero` — `hasseDeriv p (Xᵖ) ≠ 0` (its constant coefficient is `C(p,p) = 1`).
- `factorial_annihilates_hasseDeriv` — `p! • hasseDeriv p (Xᵖ) = derivative^[p](Xᵖ) = 0`. The bridge `derivative^[p] f = p!·hasseDeriv p f` shows the obstruction is exactly `p! ≡ 0 (mod p)` — pinpointing the `k! ≠ 0` input that the characteristic-zero ordinary-derivative test relies on and the Hasse/Taylor test does not.

## Verification

Compiled with `lake env lean` against Mathlib; `#print axioms` on the main theorems reports only `propext, Classical.choice, Quot.sound` — **axiom-free** (`decide`-free; `ZMod p` is a field via `Fact p.Prime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)