### PR TITLE
audit(batch32+33): 20 never-audited gallery leaves CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -268,7 +268,7 @@
       "auditCount": 2,
       "issues": [],
       "lastAudited": "2026-05-03T20:24:34Z",
-      "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open — marked clean",
+      "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open \u2014 marked clean",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {
@@ -520,7 +520,7 @@
     "area-of-circle-oq-05": {
       "auditCount": 4,
       "issues": [
-        "sorries 1→0, status formalized→verified, badge wip→mathlib (sorry was completed)"
+        "sorries 1\u21920, status formalized\u2192verified, badge wip\u2192mathlib (sorry was completed)"
       ],
       "lastAudited": "2026-05-09T03:53:48Z",
       "result": "clean"
@@ -1455,7 +1455,7 @@
     "cantor-diagonalization-oq-01-oq-01-oq-02-oq-01": {
       "auditCount": 1,
       "issues": [
-        "PR #16819: theoremCount drift 9→7 (def IsPermittedValue + structure IsEastonFunction were counted as theorems); narrative + section summaries realigned"
+        "PR #16819: theoremCount drift 9\u21927 (def IsPermittedValue + structure IsEastonFunction were counted as theorems); narrative + section summaries realigned"
       ],
       "lastAudited": "2026-05-08T00:07:19Z",
       "result": "issues-fixed"
@@ -1948,7 +1948,7 @@
     "central-limit-theorem-oq-01-oq-02-oq-01": {
       "auditCount": 2,
       "issues": [
-        "lineCount 98→112, theoremCount 7→8 (enricher used stale counts)"
+        "lineCount 98\u2192112, theoremCount 7\u21928 (enricher used stale counts)"
       ],
       "lastAudited": "2026-05-04T04:08:08Z",
       "result": "clean"
@@ -1976,7 +1976,7 @@
     "central-limit-theorem-oq-03": {
       "auditCount": 4,
       "issues": [
-        "Phantom claims: meta.json asserted Cramér's indecomposability theorem and Gaussian stability were formalized/axiomatized, but neither is declared as an axiom or theorem in any of the 4 Lean files — they exist only as orphan docstring comments (lines 176-182, 224). Reworded originalContributions, conclusion.summary, gaussian-fixed-point section summary, and description to remove the overclaim and surface the genuine (unlisted) OQ02 infinite-divisibility / Lévy-Khintchine work. Axiom/sorry/def/theorem counts (25/0/5/8) all verified accurate."
+        "Phantom claims: meta.json asserted Cram\u00e9r's indecomposability theorem and Gaussian stability were formalized/axiomatized, but neither is declared as an axiom or theorem in any of the 4 Lean files \u2014 they exist only as orphan docstring comments (lines 176-182, 224). Reworded originalContributions, conclusion.summary, gaussian-fixed-point section summary, and description to remove the overclaim and surface the genuine (unlisted) OQ02 infinite-divisibility / L\u00e9vy-Khintchine work. Axiom/sorry/def/theorem counts (25/0/5/8) all verified accurate."
       ],
       "lastAudited": "2026-06-18T09:05:01Z",
       "result": "issues-fixed"
@@ -2237,7 +2237,7 @@
     "cramers-rule-oq-01-oq-03": {
       "auditCount": 6,
       "issues": [
-        "cramer_ops_{1,2,3,4} prove arithmetically false equalities (1=2, 11=5, 71=53, 479=475); status verified/original suspect — file likely fails to compile but build-safe-subset masks failures. Issue #15032."
+        "cramer_ops_{1,2,3,4} prove arithmetically false equalities (1=2, 11=5, 71=53, 479=475); status verified/original suspect \u2014 file likely fails to compile but build-safe-subset masks failures. Issue #15032."
       ],
       "lastAudited": "2026-06-05T14:43:13Z",
       "result": "clean"
@@ -2382,7 +2382,7 @@
     "derangements-oq-02": {
       "auditCount": 7,
       "issues": [
-        "Re-audit 2026-06-04 vs origin/main c7314d69: 0 sorries (code-level confirmed via comment-stripped grep; line 340 hit was inside a /-! ... -/ summary block), 0 axioms, 10 theorems, 1 def, 357 lines — all match meta.json. Badge `original` justified by permSupportEqEquiv bijection + Finset.card_biUnion decomposition; Mathlib lemma card_derangements_eq_numDerangements used only for derangement-set size lookup, not as core argument. Minor doc-drift: meta + Lean docstring summary both say \"11 native_decide verifications\" but actual count is 10 (S(3,k) k=0..3 + S(4,k) k=0..4 + S(5,2) = 4+5+1); below issue threshold. Clean."
+        "Re-audit 2026-06-04 vs origin/main c7314d69: 0 sorries (code-level confirmed via comment-stripped grep; line 340 hit was inside a /-! ... -/ summary block), 0 axioms, 10 theorems, 1 def, 357 lines \u2014 all match meta.json. Badge `original` justified by permSupportEqEquiv bijection + Finset.card_biUnion decomposition; Mathlib lemma card_derangements_eq_numDerangements used only for derangement-set size lookup, not as core argument. Minor doc-drift: meta + Lean docstring summary both say \"11 native_decide verifications\" but actual count is 10 (S(3,k) k=0..3 + S(4,k) k=0..4 + S(5,2) = 4+5+1); below issue threshold. Clean."
       ],
       "lastAudited": "2026-06-04T17:30:00Z",
       "result": "clean"
@@ -2480,7 +2480,7 @@
     "descartes-rule-of-signs-oq-02": {
       "auditCount": 5,
       "issues": [
-        "PR #6448: sorries 2→0, lineCount 552→698"
+        "PR #6448: sorries 2\u21920, lineCount 552\u2192698"
       ],
       "lastAudited": "2026-05-04T04:04:48Z",
       "result": "clean"
@@ -3115,7 +3115,7 @@
       "issues": [],
       "lastAudited": "2026-06-05T13:32:43Z",
       "result": "clean",
-      "notes": "PR #15021: stale sorry/lineCount after #14937 (top.sorries 4→3, leanFile.sorries 4→3, lineCount 279→287, narrative 5→3)"
+      "notes": "PR #15021: stale sorry/lineCount after #14937 (top.sorries 4\u21923, leanFile.sorries 4\u21923, lineCount 279\u2192287, narrative 5\u21923)"
     },
     "erdos-1019": {
       "agentId": "auditor-cycle-20-batch",
@@ -3861,7 +3861,7 @@
       "lastAudited": "2026-06-01T09:53:52Z",
       "result": "clean",
       "issues": [
-        "Phantom-axiom narrative: 5 \"Axiom (van Doorn-Tao 2025)\" docstrings but only 1 axiom declared (propertyQ_achievable). Section line ranges drifted (main-axioms 93–130 → actual 93–115; special-sequences 154–154 → actual 140–153). originalContributions/proofStrategy overclaim plural axiomatization. Issue #14809."
+        "Phantom-axiom narrative: 5 \"Axiom (van Doorn-Tao 2025)\" docstrings but only 1 axiom declared (propertyQ_achievable). Section line ranges drifted (main-axioms 93\u2013130 \u2192 actual 93\u2013115; special-sequences 154\u2013154 \u2192 actual 140\u2013153). originalContributions/proofStrategy overclaim plural axiomatization. Issue #14809."
       ]
     },
     "erdos-1103": {
@@ -3870,7 +3870,7 @@
       "lastAudited": "2026-06-01T12:06:02Z",
       "result": "clean",
       "issues": [
-        "Phantom-axiom narrative: proofStrategy/sections claim 3 axioms (van Doorn–Tao upper/lower + Konyagin) but only vanDoorn_tao_upper exists; basic-properties says \"Axiomatizes the singleton characterization\" but it is a proved theorem; orphaned docstrings at lines 70-71 and 72-73; section line drift — basic-properties ends at 92 but file has 162 lines (squarefreeSumset_pair, subexp_eventually_lt_exp, erdos_1103_false uncovered). Issue #14812."
+        "Phantom-axiom narrative: proofStrategy/sections claim 3 axioms (van Doorn\u2013Tao upper/lower + Konyagin) but only vanDoorn_tao_upper exists; basic-properties says \"Axiomatizes the singleton characterization\" but it is a proved theorem; orphaned docstrings at lines 70-71 and 72-73; section line drift \u2014 basic-properties ends at 92 but file has 162 lines (squarefreeSumset_pair, subexp_eventually_lt_exp, erdos_1103_false uncovered). Issue #14812."
       ]
     },
     "erdos-1104": {
@@ -3937,7 +3937,7 @@
       "auditCount": 4,
       "lastAudited": "2026-06-01T07:32:12Z",
       "result": "clean",
-      "notes": "Issue #14804 — phantom-axiom narrative: proofStrategy/sections claim axioms for Reduction-to-t<=c, general c=3 bound, Ramsey/chi-boundedness; only orphan docstrings exist (numerical counts correct)",
+      "notes": "Issue #14804 \u2014 phantom-axiom narrative: proofStrategy/sections claim axioms for Reduction-to-t<=c, general c=3 bound, Ramsey/chi-boundedness; only orphan docstrings exist (numerical counts correct)",
       "issues": []
     },
     "erdos-1112": {
@@ -3946,9 +3946,9 @@
       "lastAudited": "2026-06-01T07:09:37Z",
       "result": "clean",
       "issues": [
-        "sections[6] (tang-yang-2021) claims a tang_yang_2021 axiom that is not declared in the Lean file (only a docstring); mathContext also writes 'k ≠ 3' instead of 'k ≥ 3'"
+        "sections[6] (tang-yang-2021) claims a tang_yang_2021 axiom that is not declared in the Lean file (only a docstring); mathContext also writes 'k \u2260 3' instead of 'k \u2265 3'"
       ],
-      "notes": "Issue #14800 — phantom tang_yang_2021 axiom in sections; meta.axiomCount=5 is correct (5 actual axioms: erdos_graham_1980, twofold_eq_kfold, threefold_eq_kfold, bhj_r_lacunary, chen_r2_bound)"
+      "notes": "Issue #14800 \u2014 phantom tang_yang_2021 axiom in sections; meta.axiomCount=5 is correct (5 actual axioms: erdos_graham_1980, twofold_eq_kfold, threefold_eq_kfold, bhj_r_lacunary, chen_r2_bound)"
     },
     "erdos-1113": {
       "auditCount": 4,
@@ -4004,7 +4004,7 @@
       ],
       "lastAudited": "2026-06-01T05:31:54Z",
       "result": "clean",
-      "notes": "Issue #14777 — phantom axioms in narrative + section line drift; meta.axiomCount=3 (correct)"
+      "notes": "Issue #14777 \u2014 phantom axioms in narrative + section line drift; meta.axiomCount=3 (correct)"
     },
     "erdos-112": {
       "auditCount": 4,
@@ -4038,17 +4038,17 @@
       ],
       "lastAudited": "2026-06-01T06:03:09Z",
       "result": "clean",
-      "notes": "Issue #14781 — phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
+      "notes": "Issue #14781 \u2014 phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
     },
     "erdos-1123": {
       "auditCount": 4,
       "issues": [
-        "proofStrategy claims 'axiomatizes the Just-Krawczyk conditional isomorphism and ZFC independence' — neither is axiomatized (only docstring placeholders)",
+        "proofStrategy claims 'axiomatizes the Just-Krawczyk conditional isomorphism and ZFC independence' \u2014 neither is axiomatized (only docstring placeholders)",
         "section line drift: just-krawczyk (80-97 vs actual 80-88), ideal-properties (98-110 vs actual 89-94); Part V Summary missing from sections array"
       ],
       "lastAudited": "2026-06-01T06:05:03Z",
       "result": "clean",
-      "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
+      "notes": "Issue #14783 \u2014 proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {
       "auditCount": 5,
@@ -4085,7 +4085,7 @@
     "erdos-1127": {
       "auditCount": 4,
       "issues": [
-        "#14765: phantom 'Statement of Erdős-Hajnal necessity result' contribution + false 'former axioms now proved as theorems or definitions' claim (none of the named identifiers exist) + section line drift starting at davies-theorem (Parts VIII/IX missing entirely)"
+        "#14765: phantom 'Statement of Erd\u0151s-Hajnal necessity result' contribution + false 'former axioms now proved as theorems or definitions' claim (none of the named identifiers exist) + section line drift starting at davies-theorem (Parts VIII/IX missing entirely)"
       ],
       "lastAudited": "2026-06-01T06:45:05Z",
       "result": "clean"
@@ -4469,7 +4469,7 @@
       "lastAudited": "2026-06-01T01:06:05Z",
       "result": "clean",
       "issues": [
-        "#14741: phantom axiom claims for Mycielski / finite case / Erdős 1959 in proofStrategy + sections (only docstrings; no declarations)"
+        "#14741: phantom axiom claims for Mycielski / finite case / Erd\u0151s 1959 in proofStrategy + sections (only docstrings; no declarations)"
       ]
     },
     "erdos-1176": {
@@ -4495,7 +4495,7 @@
       "auditCount": 5,
       "lastAudited": "2026-05-31T23:48:01Z",
       "result": "clean",
-      "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound→basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
+      "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound\u2192basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
     },
     "erdos-1179-oq-01": {
       "auditCount": 3,
@@ -4701,7 +4701,7 @@
       "auditCount": 7,
       "issues": [
         "Phantom sorry/partial-verification claims for nondividing_implies_nonaveraging + section line drift across all 8 sections; counts correct; issue #14716",
-        "#14734: residual phantom claims after PR #14724 — sections[0].summary still references nonexistent nondividing_equiv; originalContributions[0] claims false equivalence (nondividing_not_iff_alt proves they are NOT equivalent); sections[1].mathContext + sections[6].mathContext stale (summaries fixed, mathContext not); sections[4].mathContext LaTeX bug"
+        "#14734: residual phantom claims after PR #14724 \u2014 sections[0].summary still references nonexistent nondividing_equiv; originalContributions[0] claims false equivalence (nondividing_not_iff_alt proves they are NOT equivalent); sections[1].mathContext + sections[6].mathContext stale (summaries fixed, mathContext not); sections[4].mathContext LaTeX bug"
       ],
       "lastAudited": "2026-05-31T22:43:48Z",
       "result": "clean"
@@ -4718,7 +4718,7 @@
       "lastAudited": "2026-05-31T20:12:53Z",
       "result": "clean",
       "issues": [
-        "#14714: phantom axiom claims for CDL 2025, Spencer-Szemerédi-Trotter, Guth-Katz in proofStrategy/sections"
+        "#14714: phantom axiom claims for CDL 2025, Spencer-Szemer\u00e9di-Trotter, Guth-Katz in proofStrategy/sections"
       ]
     },
     "erdos-133": {
@@ -4973,7 +4973,7 @@
     "erdos-167": {
       "auditCount": 4,
       "issues": [
-        "#14679: phantom axioms in proofStrategy/sections (5 axioms claimed; only IsPlanar declared); lineCount 275→274; section line drift in known-results/fractional-version/summary"
+        "#14679: phantom axioms in proofStrategy/sections (5 axioms claimed; only IsPlanar declared); lineCount 275\u2192274; section line drift in known-results/fractional-version/summary"
       ],
       "lastAudited": "2026-05-31T10:00:24Z",
       "result": "clean"
@@ -5028,7 +5028,7 @@
     "erdos-174": {
       "auditCount": 4,
       "issues": [
-        "section line drift in 5/9 sections (Parts V-IX); known-ramsey endLine 160→158, examples 161-187→159-178, non-ramsey 188-206→179-197, characterization 207-221→198-212, summary 222-247→213-247; not_spherical_not_ramsey at L182 falls outside its claimed section by line; counts/axioms/narrative all accurate (#14671)"
+        "section line drift in 5/9 sections (Parts V-IX); known-ramsey endLine 160\u2192158, examples 161-187\u2192159-178, non-ramsey 188-206\u2192179-197, characterization 207-221\u2192198-212, summary 222-247\u2192213-247; not_spherical_not_ramsey at L182 falls outside its claimed section by line; counts/axioms/narrative all accurate (#14671)"
       ],
       "lastAudited": "2026-05-31T07:58:44Z",
       "result": "clean"
@@ -5120,7 +5120,7 @@
       "issues": [
         "originalContributions called f3_1, f3_2, f3_3, f3_4 'Small value axioms' but they are theorems (proved). Numerical axiomCount: 2 was correct."
       ],
-      "notes": "Fixed via PR #14654 — phantom small-value axiom narrative in originalContributions."
+      "notes": "Fixed via PR #14654 \u2014 phantom small-value axiom narrative in originalContributions."
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",
@@ -5169,7 +5169,7 @@
       "lastAudited": "2026-05-31T01:15:39Z",
       "result": "issues-fixed",
       "issues": [
-        "proofStrategy/keyInsight reverse H(k)≤W(k) (Lean proves W(k)≤H(k) at line 177); section line drift in 6/10 sections; filed #14641"
+        "proofStrategy/keyInsight reverse H(k)\u2264W(k) (Lean proves W(k)\u2264H(k) at line 177); section line drift in 6/10 sections; filed #14641"
       ]
     },
     "erdos-191": {
@@ -5254,7 +5254,7 @@
       "agentId": "auditor-agent-2026-05-02",
       "auditCount": 4,
       "issues": [
-        "meta.json: phantom axioms in proofStrategy (claims PNT/conjecture axiomatized — only green_tao is); 3 dangling /-- -/ docstrings (lines 48-55, 77-81, 100-102); section line drift in all sections after core-definitions (structural claims 112-125 but ap_difference_primorial is at 136-146). Issue #14625."
+        "meta.json: phantom axioms in proofStrategy (claims PNT/conjecture axiomatized \u2014 only green_tao is); 3 dangling /-- -/ docstrings (lines 48-55, 77-81, 100-102); section line drift in all sections after core-definitions (structural claims 112-125 but ap_difference_primorial is at 136-146). Issue #14625."
       ],
       "lastAudited": "2026-05-30T22:35:16Z",
       "result": "clean"
@@ -5379,7 +5379,7 @@
       "lastAudited": "2026-05-30T19:59:20Z",
       "result": "clean",
       "issues": [
-        "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)",
+        "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Pal\u00e1sti axiomatization (#14603)",
         "originalContributions listed phantom identifiers: NoFourConcyclic, allDistances, distinctDistances, HasStaircaseMultiplicity, HasErdos217Property, Erdos217Exists. Also misnamed PointConfig as 'PointConfiguration structure' and omitted sqDist. Replaced with accurate list of actual Lean declarations."
       ]
     },
@@ -5395,7 +5395,7 @@
       "lastAudited": "2026-05-30T15:32:28Z",
       "result": "clean",
       "issues": [
-        "section line drift across all 6 sections; missing summary section; 2 dangling docstrings (lines 95-96, 102-109) — issue #14601"
+        "section line drift across all 6 sections; missing summary section; 2 dangling docstrings (lines 95-96, 102-109) \u2014 issue #14601"
       ]
     },
     "erdos-22": {
@@ -5424,7 +5424,7 @@
       "agentId": "auditor-1777701908",
       "auditCount": 4,
       "issues": [
-        "phantom axioms in sections (Fermat criterion, Landau, Richards 1982, DEKKM 2022, monotonicity) + section line drift Parts II–VII (#14599)"
+        "phantom axioms in sections (Fermat criterion, Landau, Richards 1982, DEKKM 2022, monotonicity) + section line drift Parts II\u2013VII (#14599)"
       ],
       "lastAudited": "2026-05-30T15:30:00Z",
       "result": "clean"
@@ -5686,7 +5686,7 @@
       "lastAudited": "2026-05-30T04:33:13Z",
       "result": "clean",
       "issues": [
-        "section line drift: sections[].startLine/endLine off by ~20–90 lines; missing 'Squarefree Numbers' section (issue #14564)"
+        "section line drift: sections[].startLine/endLine off by ~20\u201390 lines; missing 'Squarefree Numbers' section (issue #14564)"
       ]
     },
     "erdos-26": {
@@ -5728,7 +5728,7 @@
       "lastAudited": "2026-05-30T04:24:12Z",
       "result": "clean",
       "issues": [
-        "phantom-axiom narrative: originalContributions/proofStrategy/sections claim formal statements for Kovač-Tao negative/positive criteria and 2^(2ⁿ) example that exist only as docstrings (issue #14549)"
+        "phantom-axiom narrative: originalContributions/proofStrategy/sections claim formal statements for Kova\u010d-Tao negative/positive criteria and 2^(2\u207f) example that exist only as docstrings (issue #14549)"
       ]
     },
     "erdos-265": {
@@ -5846,8 +5846,8 @@
       "lastAudited": "2026-05-29T00:00:00Z",
       "result": "clean",
       "issues": [
-        "phantom axiom 'cambie_only_one_avoider' in originalContributions; section summaries reference cambie_satisfies_growth/cambie_only_one_avoider/cambie_count_is_one/prime_number_theorem_approx that exist only as docstrings; section line ranges drifted — issue #14535",
-        "phantom-axiom narrative in proofStrategy: claims 'growth bound, covering property, exact count, and conjecture refutation are axiomatized' but only original_conjecture_false exists; growth/covering/count are dangling docstrings (lines 78-83) — issue #14552"
+        "phantom axiom 'cambie_only_one_avoider' in originalContributions; section summaries reference cambie_satisfies_growth/cambie_only_one_avoider/cambie_count_is_one/prime_number_theorem_approx that exist only as docstrings; section line ranges drifted \u2014 issue #14535",
+        "phantom-axiom narrative in proofStrategy: claims 'growth bound, covering property, exact count, and conjecture refutation are axiomatized' but only original_conjecture_false exists; growth/covering/count are dangling docstrings (lines 78-83) \u2014 issue #14552"
       ]
     },
     "erdos-281": {
@@ -5856,7 +5856,7 @@
       "lastAudited": "2026-05-30T02:31:00Z",
       "result": "clean",
       "issues": [
-        "phantom-axiom narrative: claims axiomatization of divergence/coprime/Davenport-Erdős/Rogers but only erdos_281_proved exists; sections.divergence-coprime summary describes content that is only dangling docstrings (lines 217-219) — issue #14532"
+        "phantom-axiom narrative: claims axiomatization of divergence/coprime/Davenport-Erd\u0151s/Rogers but only erdos_281_proved exists; sections.divergence-coprime summary describes content that is only dangling docstrings (lines 217-219) \u2014 issue #14532"
       ]
     },
     "erdos-282": {
@@ -5875,7 +5875,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "issues": [
-        "phantom theorems harmonic_interval/croot_2001/f_asymptotic claimed in originalContributions/mainTheorems but only docstrings, never declared; section line drift (examples L147–157 actually contains Part VI Summary header) — issue #14526"
+        "phantom theorems harmonic_interval/croot_2001/f_asymptotic claimed in originalContributions/mainTheorems but only docstrings, never declared; section line drift (examples L147\u2013157 actually contains Part VI Summary header) \u2014 issue #14526"
       ],
       "lastAudited": "2026-05-30T01:44:22Z",
       "result": "issues-fixed"
@@ -6172,7 +6172,7 @@
       "lastAudited": "2026-05-29T19:23:16Z",
       "result": "clean",
       "issues": [
-        "phantom originalContributions (mahler_theorem, erdos_positive_density_claim — neither axiom exists); proofStrategy + sections.positive-density falsely claim Part VII axiomatizes positive density (orphan docstring only); overview.text says '5 axioms' (actual 3) and '191-line' (actual 182); section line drift +4 from Part III onward (#14493)"
+        "phantom originalContributions (mahler_theorem, erdos_positive_density_claim \u2014 neither axiom exists); proofStrategy + sections.positive-density falsely claim Part VII axiomatizes positive density (orphan docstring only); overview.text says '5 axioms' (actual 3) and '191-line' (actual 182); section line drift +4 from Part III onward (#14493)"
       ]
     },
     "erdos-323": {
@@ -6229,7 +6229,7 @@
       "lastAudited": "2026-05-29T19:31:25Z",
       "result": "clean",
       "issues": [
-        "phantom Erdős 1/2 axiom + conditional embedding (orphan docstrings, no declarations); section line drift lower-bounds onward (#14484)"
+        "phantom Erd\u0151s 1/2 axiom + conditional embedding (orphan docstrings, no declarations); section line drift lower-bounds onward (#14484)"
       ]
     },
     "erdos-33": {
@@ -6349,7 +6349,7 @@
       "lastAudited": "2026-05-29T12:49:36Z",
       "result": "clean",
       "issues": [
-        "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20→19; imports drift (#14463)"
+        "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20\u219219; imports drift (#14463)"
       ]
     },
     "erdos-343": {
@@ -6636,7 +6636,7 @@
       "lastAudited": "2026-05-29T19:45:00Z",
       "result": "clean",
       "issues": [
-        "phantom HC_exponent_decreasing/ramanujan_characterization/HC_sparser_than_primes theorems in originalContributions; 4 dangling doc-comments; section line drift Parts VI–IX (#14438)"
+        "phantom HC_exponent_decreasing/ramanujan_characterization/HC_sparser_than_primes theorems in originalContributions; 4 dangling doc-comments; section line drift Parts VI\u2013IX (#14438)"
       ]
     },
     "erdos-382": {
@@ -6838,7 +6838,7 @@
       "lastAudited": "2026-05-29T06:50:27Z",
       "result": "clean",
       "issues": [
-        "phantom Bajpai-Bennett 131082 axiom (only ≤ 9 declared, 131082 only in docstring); phantom FourRepFamily theorems (def + 2 docstring headers, no proofs); section line drift in main-results/infinite-family/summary (#14418)"
+        "phantom Bajpai-Bennett 131082 axiom (only \u2264 9 declared, 131082 only in docstring); phantom FourRepFamily theorems (def + 2 docstring headers, no proofs); section line drift in main-results/infinite-family/summary (#14418)"
       ]
     },
     "erdos-408": {
@@ -7040,7 +7040,7 @@
       "lastAudited": "2026-05-29T04:47:55Z",
       "result": "issues-fixed",
       "issues": [
-        "PR #14407 / issue #14397 + follow-up comment: phantom non_representable_exist axiom in section main-theorem; conclusion summary claims 6 axioms (only 2 declared); Sylvester–Frobenius docstring labelled axiomatized in section related-results",
+        "PR #14407 / issue #14397 + follow-up comment: phantom non_representable_exist axiom in section main-theorem; conclusion summary claims 6 axioms (only 2 declared); Sylvester\u2013Frobenius docstring labelled axiomatized in section related-results",
         "mechanic fix: removed phantom-axiom narrative from proofStrategy and sections main-theorem/special-cases/related-results to match the 2 declared axioms (hwang_song_theorem, large_numbers_representable); conclusion.summary already corrected by #20886"
       ]
     },
@@ -7082,7 +7082,7 @@
       "lastAudited": "2026-05-27T14:21:26Z",
       "result": "clean",
       "issues": [
-        "PR #14387: phantom axiom erdos_szemeredi_liminf_bound in originalContributions/proofStrategy/section-3 — only tao_elementary_proof and van_doorn_sharp_bound declared in Lean"
+        "PR #14387: phantom axiom erdos_szemeredi_liminf_bound in originalContributions/proofStrategy/section-3 \u2014 only tao_elementary_proof and van_doorn_sharp_bound declared in Lean"
       ]
     },
     "erdos-441": {
@@ -7125,7 +7125,7 @@
       "lastAudited": "2026-06-05T15:21:03Z",
       "result": "clean",
       "issues": [
-        "Phantom axiom narrative: \"Historical axioms: Besicovitch/Erdős\" entry claimed axioms for docstring-only sections; ford section claimed phantom ford_2008_general axiom; delta originalContributions overstated constraints; section line ranges were stale by 10-25 lines."
+        "Phantom axiom narrative: \"Historical axioms: Besicovitch/Erd\u0151s\" entry claimed axioms for docstring-only sections; ford section claimed phantom ford_2008_general axiom; delta originalContributions overstated constraints; section line ranges were stale by 10-25 lines."
       ]
     },
     "erdos-447": {
@@ -7365,7 +7365,7 @@
       "lastAudited": "2026-05-27T09:49:20Z",
       "result": "clean",
       "issues": [
-        "Issue #14351: phantom k=-1 axiom narrative — originalContributions, proofStrategy, sections[partial-results], and erdos_479_summary docstring all claim a Graham-Lehmer-Lehmer k=-1 axiom that does not exist in the Lean source; only solution_set_one_finite and powers_of_two_infinite are declared. Numerical fields (axiomCount=2, sorries=0, lineCount=230) are correct."
+        "Issue #14351: phantom k=-1 axiom narrative \u2014 originalContributions, proofStrategy, sections[partial-results], and erdos_479_summary docstring all claim a Graham-Lehmer-Lehmer k=-1 axiom that does not exist in the Lean source; only solution_set_one_finite and powers_of_two_infinite are declared. Numerical fields (axiomCount=2, sorries=0, lineCount=230) are correct."
       ]
     },
     "erdos-48": {
@@ -7395,7 +7395,7 @@
       "lastAudited": "2026-05-27T08:49:08Z",
       "result": "issues-fixed",
       "issues": [
-        "Phantom non-periodicity axiom in originalContributions; sections part-1/3/5 describe docstring-only content as axiomatized — issue #14343"
+        "Phantom non-periodicity axiom in originalContributions; sections part-1/3/5 describe docstring-only content as axiomatized \u2014 issue #14343"
       ]
     },
     "erdos-483": {
@@ -7637,8 +7637,8 @@
       "auditCount": 4,
       "issuesFixed": [
         "stale originalContributions items (#12149)",
-        "annotation L1norm_upper_bound incorrectly labelled (sorry) — proved",
-        "annotation L2_norm incorrectly labelled (sorry) — proved pending expSumNorm_sq_double; range updated to 257-295"
+        "annotation L1norm_upper_bound incorrectly labelled (sorry) \u2014 proved",
+        "annotation L2_norm incorrectly labelled (sorry) \u2014 proved pending expSumNorm_sq_double; range updated to 257-295"
       ],
       "lastAudited": "2026-05-08T12:06:34Z",
       "result": "clean"
@@ -7667,7 +7667,7 @@
       "lastAudited": "2026-05-27T06:06:21Z",
       "result": "clean",
       "issues": [
-        "Issue #14314: originalContributions claims 3 phantom Statement-of-theorem items (Wiman 1914, Erdős-Macintyre 1954, Kovári 1965) that exist only as doc-comments; numerical fields (axiomCount=1, sorries=1, lineCount=196) are correct"
+        "Issue #14314: originalContributions claims 3 phantom Statement-of-theorem items (Wiman 1914, Erd\u0151s-Macintyre 1954, Kov\u00e1ri 1965) that exist only as doc-comments; numerical fields (axiomCount=1, sorries=1, lineCount=196) are correct"
       ]
     },
     "erdos-517": {
@@ -7716,7 +7716,7 @@
       "lastAudited": "2026-05-27T05:50:48Z",
       "result": "clean",
       "issues": [
-        "Issue #14311: proofStrategy claims phantom Erdős-Offord/Yakir/almost-sure-convergence axioms; root-counting section misclaimed as axiomatized; assumptions misnames axiom (KacPolynomialData → KacPolynomialData.isRademacher)"
+        "Issue #14311: proofStrategy claims phantom Erd\u0151s-Offord/Yakir/almost-sure-convergence axioms; root-counting section misclaimed as axiomatized; assumptions misnames axiom (KacPolynomialData \u2192 KacPolynomialData.isRademacher)"
       ]
     },
     "erdos-523": {
@@ -7869,7 +7869,7 @@
       "lastAudited": "2026-05-27T06:27:23Z",
       "result": "clean",
       "issues": [
-        "Issue #14282: phantom-axiom narrative (axiomCount=1 correct, but assumptions list 3, sections claim EGZ/Erdős-Szemerédi axiomatized, proofStrategy says graham_conjecture is sorry — it is proved)"
+        "Issue #14282: phantom-axiom narrative (axiomCount=1 correct, but assumptions list 3, sections claim EGZ/Erd\u0151s-Szemer\u00e9di axiomatized, proofStrategy says graham_conjecture is sorry \u2014 it is proved)"
       ]
     },
     "erdos-542": {
@@ -7908,7 +7908,7 @@
       "lastAudited": "2026-05-27T02:38:37Z",
       "result": "clean",
       "issues": [
-        "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chvátal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"
+        "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chv\u00e1tal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"
       ]
     },
     "erdos-548": {
@@ -8019,7 +8019,7 @@
       "lastAudited": "2026-05-25T22:22:40Z",
       "result": "clean",
       "issues": [
-        "phantom-axiom narrative: proofStrategy/sections claim Erdős–Rado, Erdős–Hajnal, general lower, and main conjecture as axioms but they are docstring-only (issue #14247)"
+        "phantom-axiom narrative: proofStrategy/sections claim Erd\u0151s\u2013Rado, Erd\u0151s\u2013Hajnal, general lower, and main conjecture as axioms but they are docstring-only (issue #14247)"
       ]
     },
     "erdos-563": {
@@ -8034,7 +8034,7 @@
       "lastAudited": "2026-05-25T22:33:21Z",
       "result": "clean",
       "issues": [
-        "Phantom-axiom narrative — originalContributions 6/7/8, proofStrategy steps 7/8, sections small-values/comparison/four-colour describe docstring placeholders, not Lean declarations (axiomCount 3, sorries 1 are correct) — issue #14254"
+        "Phantom-axiom narrative \u2014 originalContributions 6/7/8, proofStrategy steps 7/8, sections small-values/comparison/four-colour describe docstring placeholders, not Lean declarations (axiomCount 3, sorries 1 are correct) \u2014 issue #14254"
       ]
     },
     "erdos-565": {
@@ -8070,7 +8070,7 @@
       "lastAudited": "2026-05-25T19:55:24Z",
       "result": "clean",
       "issues": [
-        "Phantom axioms in narrative: pentagon case + lower bounds in proofStrategy; vertex-bound axiom in section summary; pentagon axiom claimed in known-results section — issue #14242"
+        "Phantom axioms in narrative: pentagon case + lower bounds in proofStrategy; vertex-bound axiom in section summary; pentagon axiom claimed in known-results section \u2014 issue #14242"
       ]
     },
     "erdos-57": {
@@ -8085,14 +8085,14 @@
       "lastAudited": "2026-05-25T19:51:49Z",
       "result": "clean",
       "issues": [
-        "sections.cases.summary claims four phantom axioms (EFRS/Sidorenko/Jayawardene/CFMPP) — only erdos_570_resolved exists in Lean; numerical fields correct — issue #14234"
+        "sections.cases.summary claims four phantom axioms (EFRS/Sidorenko/Jayawardene/CFMPP) \u2014 only erdos_570_resolved exists in Lean; numerical fields correct \u2014 issue #14234"
       ]
     },
     "erdos-571": {
       "agentId": "auditor-session-1777631912",
       "auditCount": 4,
       "issues": [
-        "phantom axioms in originalContributions / proofStrategy / sections (jiang_qiu_exponents_4_3, jiang_qiu_exponents_5_4, jiang_ma_yepremyan_exponents, conlon_janzer_near_two, bukh_conlon_families, kovari_sos_turan, bondy_simonovits_upper) — issue #14232"
+        "phantom axioms in originalContributions / proofStrategy / sections (jiang_qiu_exponents_4_3, jiang_qiu_exponents_5_4, jiang_ma_yepremyan_exponents, conlon_janzer_near_two, bukh_conlon_families, kovari_sos_turan, bondy_simonovits_upper) \u2014 issue #14232"
       ],
       "lastAudited": "2026-05-25T19:41:47Z",
       "result": "clean"
@@ -8109,7 +8109,7 @@
       "lastAudited": "2026-05-25T19:18:23Z",
       "result": "clean",
       "issues": [
-        "Phantom KST/Erdős-Simonovits bound axioms in narrative (counts correct); lineCount 152→177; section line drift — issue #14227"
+        "Phantom KST/Erd\u0151s-Simonovits bound axioms in narrative (counts correct); lineCount 152\u2192177; section line drift \u2014 issue #14227"
       ]
     },
     "erdos-574": {
@@ -8187,7 +8187,7 @@
       "lastAudited": "2026-05-25T18:15:02Z",
       "result": "clean",
       "issues": [
-        "Inconsistent axioms: folkmanNumber_2_3_4 := 0 (def) with axiom folkman_lower_bound : ≥ 19 — issue #14212"
+        "Inconsistent axioms: folkmanNumber_2_3_4 := 0 (def) with axiom folkman_lower_bound : \u2265 19 \u2014 issue #14212"
       ]
     },
     "erdos-583": {
@@ -8298,7 +8298,7 @@
       "lastAudited": "2026-05-25T12:23:14Z",
       "result": "clean",
       "issues": [
-        "phantom axioms in narrative: section summaries claim Axiom erdos_596 (Part IV) and Axiom erdos_595_k4_k3 (Part V) — neither declared in Lean file; only nesetril_rodl_c4_c6 and erdos_hajnal_c4_trees exist — issue #14179"
+        "phantom axioms in narrative: section summaries claim Axiom erdos_596 (Part IV) and Axiom erdos_595_k4_k3 (Part V) \u2014 neither declared in Lean file; only nesetril_rodl_c4_c6 and erdos_hajnal_c4_trees exist \u2014 issue #14179"
       ]
     },
     "erdos-597": {
@@ -8324,7 +8324,7 @@
       "auditCount": 4,
       "lastAudited": "2026-05-25T10:36:18Z",
       "result": "clean",
-      "notes": "Section line ranges drifted from actual Lean section markers — corrected."
+      "notes": "Section line ranges drifted from actual Lean section markers \u2014 corrected."
     },
     "erdos-60": {
       "auditCount": 5,
@@ -8584,7 +8584,7 @@
       "lastAudited": "2026-06-04T17:10:20Z",
       "result": "clean",
       "issues": [
-        "sorries claim 7 actual 1 (PR #14856 reduced 7→1 but meta.json not refreshed); lineCount 298→332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness — issue #14859",
+        "sorries claim 7 actual 1 (PR #14856 reduced 7\u21921 but meta.json not refreshed); lineCount 298\u2192332; assumptions string still says \"7 sorries\"; deeper concern: Dissection structure has placeholder area condition (line 93), so *_dissectable theorems use trivial constant-function witness \u2014 issue #14859",
         "Re-audit 2026-05-02 vs origin/main a0a5957: PR #14866 fixed only meta.json text; deeper Dissection placeholder + axiom inconsistency unresolved -> issue #14888"
       ]
     },
@@ -8600,8 +8600,8 @@
       "lastAudited": "2026-05-25T12:05:00Z",
       "result": "issues-fixed",
       "issues": [
-        "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136",
-        "section line ranges drift: kwan-sudakov 135-152 cuts kwan_sudakov axiom (133-137); optimality 153-177 cuts signature_upper_bound axiom (151-155); related 234-256 covers Part XI content; main-result 257-261 contains only #check directives while erdos_636 theorem is at 244-248 — issue #14169"
+        "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist \u2014 issue #14136",
+        "section line ranges drift: kwan-sudakov 135-152 cuts kwan_sudakov axiom (133-137); optimality 153-177 cuts signature_upper_bound axiom (151-155); related 234-256 covers Part XI content; main-result 257-261 contains only #check directives while erdos_636 theorem is at 244-248 \u2014 issue #14169"
       ]
     },
     "erdos-637": {
@@ -8689,7 +8689,7 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "issues": [
-        "originalContributions claims Tong's theorem and Mahler's growth theorem as contributions when both are axiom declarations (axiom tong_theorem, axiom mahler_growth) — issue #14123 also covers this proof"
+        "originalContributions claims Tong's theorem and Mahler's growth theorem as contributions when both are axiom declarations (axiom tong_theorem, axiom mahler_growth) \u2014 issue #14123 also covers this proof"
       ],
       "lastAudited": "2026-05-25T09:34:53Z",
       "result": "clean"
@@ -8767,7 +8767,7 @@
       "lastAudited": "2026-05-25T08:29:08Z",
       "result": "clean",
       "issues": [
-        "Section range drift (axiom/theorem swapped); 3 of 6 isConfiguration cases reduce to True (isoTrap1, isoTrap2, kite) — issue #14110"
+        "Section range drift (axiom/theorem swapped); 3 of 6 isConfiguration cases reduce to True (isoTrap1, isoTrap2, kite) \u2014 issue #14110"
       ]
     },
     "erdos-659-oq-01": {
@@ -8794,7 +8794,7 @@
       "lastAudited": "2026-06-18T20:40:00Z",
       "result": "issues-fixed",
       "issues": [
-        "axiomCount 2→0 (no axiom decls; F/f are opaque stubs := fun _=>0 asserting nothing); status axiomatized→formalized; rewrote proofStrategy/section/conclusion prose that falsely claimed F/f, the conjecture, Guth–Katz, and lattice bounds were axiomatized — they are opaque placeholders or prose comments. Only Lenz ℝ⁴ + infra proved."
+        "axiomCount 2\u21920 (no axiom decls; F/f are opaque stubs := fun _=>0 asserting nothing); status axiomatized\u2192formalized; rewrote proofStrategy/section/conclusion prose that falsely claimed F/f, the conjecture, Guth\u2013Katz, and lattice bounds were axiomatized \u2014 they are opaque placeholders or prose comments. Only Lenz \u211d\u2074 + infra proved."
       ]
     },
     "erdos-662": {
@@ -8822,7 +8822,7 @@
       "result": "clean",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14171",
       "issues": [
-        "Section line ranges drift 1-5 lines in middle sections (II/III/IV/V) — endpoints cross axiom/def boundaries; proofStrategy credits Shrikhande-Singhi embedding theorem and Cramér conjecture as axiomatized but they are docstring-only — issue #14171"
+        "Section line ranges drift 1-5 lines in middle sections (II/III/IV/V) \u2014 endpoints cross axiom/def boundaries; proofStrategy credits Shrikhande-Singhi embedding theorem and Cram\u00e9r conjecture as axiomatized but they are docstring-only \u2014 issue #14171"
       ]
     },
     "erdos-666": {
@@ -8851,14 +8851,14 @@
       "lastAudited": "2026-05-25T04:53:54Z",
       "result": "clean",
       "issues": [
-        "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section — issue #14091"
+        "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section \u2014 issue #14091"
       ]
     },
     "erdos-67": {
       "agentId": "auditor-agent",
       "auditCount": 5,
       "issues": [
-        "section line ranges drift across 3 sections (complex-variant, stronger-conjecture, multiplicative) — issue #14099"
+        "section line ranges drift across 3 sections (complex-variant, stronger-conjecture, multiplicative) \u2014 issue #14099"
       ],
       "lastAudited": "2026-05-25T09:17:50Z",
       "result": "clean"
@@ -9204,7 +9204,7 @@
     "erdos-719": {
       "auditCount": 5,
       "issues": [
-        "PR #6447: sorries 2→1, lineCount 175→196"
+        "PR #6447: sorries 2\u21921, lineCount 175\u2192196"
       ],
       "lastAudited": "2026-05-04T04:02:32Z",
       "result": "clean"
@@ -9392,7 +9392,7 @@
     "erdos-746": {
       "auditCount": 7,
       "issues": [
-        "PR #6440: sorry count 3→4",
+        "PR #6440: sorry count 3\u21924",
         "Issue #6441: 9 vacuous True stubs",
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
@@ -9561,7 +9561,7 @@
       "lastAudited": "2026-06-05T23:28:23Z",
       "result": "issues-fixed",
       "issues": [
-        "theoremCount 80→74: meta.meta.theoremCount and leanFile.theoremCount overcounted by 6 — FIXED in this audit cycle"
+        "theoremCount 80\u219274: meta.meta.theoremCount and leanFile.theoremCount overcounted by 6 \u2014 FIXED in this audit cycle"
       ]
     },
     "erdos-771": {
@@ -9953,8 +9953,8 @@
       "agentId": "mechanic-tracker-sync",
       "auditCount": 4,
       "issues": [
-        "phantom mahler_1935/density_of_sums in originalContributions — fixed via PR #13710",
-        "section line drift — fixed via PR #13710"
+        "phantom mahler_1935/density_of_sums in originalContributions \u2014 fixed via PR #13710",
+        "section line drift \u2014 fixed via PR #13710"
       ],
       "lastAudited": "2026-05-16T19:01:01Z",
       "result": "clean"
@@ -10029,8 +10029,8 @@
       "agentId": "mechanic-tracker-sync",
       "auditCount": 5,
       "issues": [
-        "phantom axiom narrative in overview/conclusion — fixed via PR #13693",
-        "section structure drift — fixed via PR #13690"
+        "phantom axiom narrative in overview/conclusion \u2014 fixed via PR #13693",
+        "section structure drift \u2014 fixed via PR #13690"
       ],
       "lastAudited": "2026-05-16T19:00:32Z",
       "result": "clean"
@@ -10064,8 +10064,8 @@
       "agentId": "mechanic-tracker-sync",
       "auditCount": 4,
       "issues": [
-        "phantom axioms burr_unpublished/cfp_density_bounds/burr_erdos_upper_bound in section summaries — fixed via PR #13679",
-        "section line drift — fixed via PR #13689"
+        "phantom axioms burr_unpublished/cfp_density_bounds/burr_erdos_upper_bound in section summaries \u2014 fixed via PR #13679",
+        "section line drift \u2014 fixed via PR #13689"
       ],
       "lastAudited": "2026-05-04T03:12:35Z",
       "result": "clean"
@@ -10429,7 +10429,7 @@
       "auditCount": 6,
       "lastAudited": "2026-05-06T15:10:28Z",
       "result": "clean",
-      "notes": "Verified vs origin/main: 462 lines, 3 sorries — matches meta.json (sorries=3, status=formalized, badge=wip). Earlier \"7 sorries\" notes were stale.",
+      "notes": "Verified vs origin/main: 462 lines, 3 sorries \u2014 matches meta.json (sorries=3, status=formalized, badge=wip). Earlier \"7 sorries\" notes were stale.",
       "issues": []
     },
     "erdos-896": {
@@ -10846,7 +10846,7 @@
       "lastAudited": "2026-05-04T01:00:00Z",
       "result": "issues-fixed",
       "issues": [
-        "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections — fixed via PR #15406"
+        "IsUntouchable def had empty body (parse error); stale Axiomatizes narratives in 4 sections \u2014 fixed via PR #15406"
       ]
     },
     "erdos-956": {
@@ -12146,7 +12146,7 @@
       "lastAudited": "2026-06-02T10:49:17Z",
       "result": "clean",
       "issues": [
-        "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410→392, theoremCount 17→15"
+        "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410\u2192392, theoremCount 17\u219215"
       ]
     },
     "lagrange-four-squares-oq-01": {
@@ -12581,7 +12581,7 @@
       "issues": [],
       "lastAudited": "2026-05-08T00:00:00Z",
       "result": "clean",
-      "notes": "Re-audit: structural counts (lineCount 71, theoremCount 19, sorries 0, axioms 0) all match Lean source; no True stubs; description accurately scoped to native_decide for n≤8 (no overclaiming general identity)."
+      "notes": "Re-audit: structural counts (lineCount 71, theoremCount 19, sorries 0, axioms 0) all match Lean source; no True stubs; description accurately scoped to native_decide for n\u22648 (no overclaiming general identity)."
     },
     "partition-theorem-oq-03": {
       "auditCount": 4,
@@ -12919,7 +12919,7 @@
     "riemann-hypothesis": {
       "auditCount": 5,
       "issues": [
-        "leanFile.axiomCount 44→32 to match literal axiom declarations (32); meta.axiomCount kept at 44 as literal+structure-assumption aggregate per convention."
+        "leanFile.axiomCount 44\u219232 to match literal axiom declarations (32); meta.axiomCount kept at 44 as literal+structure-assumption aggregate per convention."
       ],
       "lastAudited": "2026-06-18T20:40:00Z",
       "result": "issues-fixed"
@@ -12975,8 +12975,8 @@
     "schauder-fixed-point-oq-03-oq-01": {
       "auditCount": 4,
       "issues": [
-        "sorries 2→0, axiomCount 3→2, theoremCount 2→3, lineCount 280→349; prose drift in description/assumptions/originalContributions/sections (PR #16834)",
-        "sorries 2→1, lineCount 517→668; brouwer_fpt body landed S13 (#17575); fix in PR #17620"
+        "sorries 2\u21920, axiomCount 3\u21922, theoremCount 2\u21923, lineCount 280\u2192349; prose drift in description/assumptions/originalContributions/sections (PR #16834)",
+        "sorries 2\u21921, lineCount 517\u2192668; brouwer_fpt body landed S13 (#17575); fix in PR #17620"
       ],
       "lastAudited": "2026-05-09T02:45:00Z",
       "result": "issues-fixed"
@@ -13759,7 +13759,7 @@
     "yang-mills-transfer-matrix": {
       "auditCount": 8,
       "issues": [
-        "axiomCount inconsistency with same-file precedent: yang-mills-lattice fixed to 12 (PR #14832), yang-mills-transfer-matrix still 1 — same Exploration.lean, same 11 :True structure-encoded fields. Issue #14840."
+        "axiomCount inconsistency with same-file precedent: yang-mills-lattice fixed to 12 (PR #14832), yang-mills-transfer-matrix still 1 \u2014 same Exploration.lean, same 11 :True structure-encoded fields. Issue #14840."
       ],
       "lastAudited": "2026-06-03T18:32:15Z",
       "result": "clean"
@@ -13826,7 +13826,7 @@
     "angle-trisection-oq-03-oq-01": {
       "auditCount": 2,
       "issues": [
-        "lineCount 123→150, theoremCount 13→12, all 5 section line ranges off by ~10 (file has been edited since enrichment); core integrity claims (verified/0 sorries/0 axioms) hold — fixed in PR"
+        "lineCount 123\u2192150, theoremCount 13\u219212, all 5 section line ranges off by ~10 (file has been edited since enrichment); core integrity claims (verified/0 sorries/0 axioms) hold \u2014 fixed in PR"
       ],
       "result": "clean",
       "lastAudited": "2026-06-05T15:48:19Z"
@@ -13982,7 +13982,7 @@
       "auditCount": 3,
       "issues": [
         "missing top-level sorries field; lineCount stale 155->152",
-        "leanFile.theoremCount stale 12→11; PR #15106"
+        "leanFile.theoremCount stale 12\u219211; PR #15106"
       ],
       "lastAudited": "2026-06-05T21:25:44Z",
       "result": "clean"
@@ -14026,7 +14026,7 @@
       "lastAudited": "2026-06-05T21:31:16Z",
       "result": "clean",
       "issues": [
-        "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140→156, theoremCount 12→13"
+        "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140\u2192156, theoremCount 12\u219213"
       ],
       "notes": "Fix PR #15099 in-flight; tracker PR #15105 in-flight"
     },
@@ -14143,7 +14143,7 @@
       "lastAudited": "2026-06-06T14:22:00Z",
       "result": "clean",
       "issues": [
-        "lineCount was 248 (actual 313); leanFile section was missing — both corrected"
+        "lineCount was 248 (actual 313); leanFile section was missing \u2014 both corrected"
       ]
     },
     "bounded-prime-gaps-oq-04-oq-02": {
@@ -14210,7 +14210,7 @@
       "lastAudited": "2026-05-04T00:55:01Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount 463→562, theoremCount 24→27 (stale after PRs #15357/#15414); fix in PR #15414"
+        "lineCount 463\u2192562, theoremCount 24\u219227 (stale after PRs #15357/#15414); fix in PR #15414"
       ]
     },
     "intermediate-value-theorem-oq-02-oq-03": {
@@ -14753,7 +14753,7 @@
       "lastAudited": "2026-05-05T02:55:34Z",
       "result": "issues-fixed",
       "issues": [
-        "sorries mismatch: claims 1, actual 0 (uses axiom declarations not sorry); lineCount mismatch: claims 224, actual 211 — fixed in PR #15942"
+        "sorries mismatch: claims 1, actual 0 (uses axiom declarations not sorry); lineCount mismatch: claims 224, actual 211 \u2014 fixed in PR #15942"
       ]
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03": {
@@ -14761,7 +14761,7 @@
       "lastAudited": "2026-05-05T02:55:34Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount mismatch: claims 221, actual 226; theoremCount mismatch: claims 10, actual 12 — fixed in this PR"
+        "lineCount mismatch: claims 221, actual 226; theoremCount mismatch: claims 10, actual 12 \u2014 fixed in this PR"
       ]
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02": {
@@ -14781,7 +14781,7 @@
       "lastAudited": "2026-05-05T03:05:00Z",
       "result": "issues-fixed",
       "issues": [
-        "lineCount mismatch: claims 253, actual 311; theoremCount mismatch: claims 7, actual 8 (real_ac_implies_normed_ac undercounted) — fixed in PR #15948"
+        "lineCount mismatch: claims 253, actual 311; theoremCount mismatch: claims 7, actual 8 (real_ac_implies_normed_ac undercounted) \u2014 fixed in PR #15948"
       ]
     },
     "greens-theorem-oq-03-oq-04": {
@@ -14801,7 +14801,7 @@
       "issues": [],
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
-      "notes": "Drift resolved on origin/main: meta-sync PRs #16094/#16101 (and follow-up #16192) merged. File now sorries=0, lineCount=338, theoremCount=12, axiomCount=0; meta status=verified, badge=verified — all consistent. find-targets.ts --issues no longer flags this entry."
+      "notes": "Drift resolved on origin/main: meta-sync PRs #16094/#16101 (and follow-up #16192) merged. File now sorries=0, lineCount=338, theoremCount=12, axiomCount=0; meta status=verified, badge=verified \u2014 all consistent. find-targets.ts --issues no longer flags this entry."
     },
     "lagrange-theorem-oq-01-oq-01": {
       "auditCount": 2,
@@ -14856,7 +14856,7 @@
       "issues": [],
       "lastAudited": "2026-05-06T08:18:00Z",
       "result": "clean",
-      "notes": "Not yet on origin/main; in PR #16077 (feature/researcher-7). Verified PR content: 0 sorries, 0 axioms, status verified, badge original — all consistent."
+      "notes": "Not yet on origin/main; in PR #16077 (feature/researcher-7). Verified PR content: 0 sorries, 0 axioms, status verified, badge original \u2014 all consistent."
     },
     "laws-of-large-numbers-oq-01-oq-03": {
       "auditCount": 1,
@@ -14893,7 +14893,7 @@
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
       "issues": [],
-      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found → issues-fixed."
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "erdos-895-oq-01": {
       "auditCount": 2,
@@ -14924,7 +14924,7 @@
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
       "issues": [],
-      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found → issues-fixed."
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "laws-of-large-numbers-oq-01-oq-02": {
       "auditCount": 1,
@@ -14979,14 +14979,14 @@
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
       "issues": [],
-      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found → issues-fixed."
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "cauchy-schwarz-oq-02-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
       "issues": [],
-      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found → issues-fixed."
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "ehrhart-cube-proven-oq-02": {
       "auditCount": 2,
@@ -14999,7 +14999,7 @@
       "lastAudited": "2026-05-07T20:00:00Z",
       "result": "issues-fixed",
       "issues": [],
-      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found → issues-fixed."
+      "notes": "Re-audit confirms drift resolved on origin/main: sorries/axioms/true_stubs all match meta. Bumping issues-found \u2192 issues-fixed."
     },
     "chinese-remainder-constructive-oq-04-oq-02": {
       "auditCount": 1,
@@ -17617,7 +17617,7 @@
       "result": "clean",
       "auditCount": 2,
       "lastAudited": "2026-06-21T11:18:12Z",
-      "notes": "Build-verified (docker, 3093 jobs OK). 0 axioms / 0 sorries / 0 native_decide / 0 True-stubs. 347L, 20 theorems + 5 lemmas (4 private + sq_dist2), 0 defs — matches meta. Vector identity A−H=2(O−M_a) circle-free (Prod.ext;ring); AH²=4·OM_a² ring; 4·OM_a²=4R²−a² one linear_combination over equidist defects; true-dist via eq_of_sq_eq_of_nonneg. Triangle.nondegenerate is well-formedness, not a smuggled assumption. Dep FeuerbachsTheoremDefs.lean is itself 0-axiom/0-sorry. #print-axioms claim (propext/Classical/Quot only) consistent with clean build."
+      "notes": "Build-verified (docker, 3093 jobs OK). 0 axioms / 0 sorries / 0 native_decide / 0 True-stubs. 347L, 20 theorems + 5 lemmas (4 private + sq_dist2), 0 defs \u2014 matches meta. Vector identity A\u2212H=2(O\u2212M_a) circle-free (Prod.ext;ring); AH\u00b2=4\u00b7OM_a\u00b2 ring; 4\u00b7OM_a\u00b2=4R\u00b2\u2212a\u00b2 one linear_combination over equidist defects; true-dist via eq_of_sq_eq_of_nonneg. Triangle.nondegenerate is well-formedness, not a smuggled assumption. Dep FeuerbachsTheoremDefs.lean is itself 0-axiom/0-sorry. #print-axioms claim (propext/Classical/Quot only) consistent with clean build."
     },
     "intermediate-value-theorem-oq-02-oq-01": {
       "slug": "intermediate-value-theorem-oq-02-oq-01",
@@ -17625,7 +17625,7 @@
       "result": "clean",
       "auditCount": 2,
       "lastAudited": "2026-06-21",
-      "notes": "Build-verified (docker, 7744 jobs). 0 axioms / 0 sorries / 0 native_decide / 0 True-stubs. 137L, 5 theorems, 0 defs — matches meta. Bisection midpoints converge to exact zero (tendsto_atTop_ciSup) recovering classical IVT from parent oq-02 approximate version. Reuses parent IntermediateValueTheoremOQ02 defs (bisectStep etc); parent dep is itself 0-axiom/0-sorry/0-structure. No smuggled assumptions."
+      "notes": "Build-verified (docker, 7744 jobs). 0 axioms / 0 sorries / 0 native_decide / 0 True-stubs. 137L, 5 theorems, 0 defs \u2014 matches meta. Bisection midpoints converge to exact zero (tendsto_atTop_ciSup) recovering classical IVT from parent oq-02 approximate version. Reuses parent IntermediateValueTheoremOQ02 defs (bisectStep etc); parent dep is itself 0-axiom/0-sorry/0-structure. No smuggled assumptions."
     },
     "lagrange-four-squares-waring-g2-oq-03-oq-08": {
       "slug": "lagrange-four-squares-waring-g2-oq-03-oq-08",
@@ -17633,44 +17633,44 @@
       "result": "clean",
       "auditCount": 2,
       "lastAudited": "2026-06-21",
-      "notes": "Build-verified (docker, 7743 jobs). 0 axioms / 0 sorries / 0 True-stubs. 98L, 8 theorems, 2 defs — matches meta. Two 'native_decide' grep hits are BOTH docstring PROSE (lines 8,21) describing/disclaiming it — no native_decide tactic. mod-8 lower bound uses plain kernel `decide` over ZMod 8 (axiom-free, no Lean.ofReduceBool). Sharpens parent umbrella's waring_g2 into 0-axiom IsLeast/sInf form, REMOVING the parent's native_decide taint as claimed."
+      "notes": "Build-verified (docker, 7743 jobs). 0 axioms / 0 sorries / 0 True-stubs. 98L, 8 theorems, 2 defs \u2014 matches meta. Two 'native_decide' grep hits are BOTH docstring PROSE (lines 8,21) describing/disclaiming it \u2014 no native_decide tactic. mod-8 lower bound uses plain kernel `decide` over ZMod 8 (axiom-free, no Lean.ofReduceBool). Sharpens parent umbrella's waring_g2 into 0-axiom IsLeast/sInf form, REMOVING the parent's native_decide taint as claimed."
     },
     "erdos-816-oq-01": {
       "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-06-21T11:58:59Z",
       "result": "clean",
-      "notes": "Build-verified (docker, 7743 jobs). #print axioms on no_equalDegreePath3_of_partDegrees + exists_sameDegree_pair = [propext, Classical.choice, Quot.sound] only → 0-axiom. 0 sorries / 0 native_decide / 0 True-stubs. 161L, 5 theorems, 4 defs — matches meta. Self-contained (import Mathlib only); bit-rotted parent Erdos816Problem.lean NOT imported, 4 defs inlined as disclosed in assumptions. status verified justified."
+      "notes": "Build-verified (docker, 7743 jobs). #print axioms on no_equalDegreePath3_of_partDegrees + exists_sameDegree_pair = [propext, Classical.choice, Quot.sound] only \u2192 0-axiom. 0 sorries / 0 native_decide / 0 True-stubs. 161L, 5 theorems, 4 defs \u2014 matches meta. Self-contained (import Mathlib only); bit-rotted parent Erdos816Problem.lean NOT imported, 4 defs inlined as disclosed in assumptions. status verified justified."
     },
     "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01-oq-02": {
       "auditCount": 1,
       "issues": [
-        "meta theoremCount 8→7 (file has 7 theorem decls)"
+        "meta theoremCount 8\u21927 (file has 7 theorem decls)"
       ],
       "lastAudited": "2026-06-21T11:58:59Z",
       "result": "issues-fixed",
-      "notes": "Build-verified (docker, 7743 jobs). #print axioms on jacobiSym_neg_eq_neg_one_of_three_mod_four + multiplier_route_obstructed_of_three_mod_four = [propext, Classical.choice, Quot.sound] only → 0-axiom. 0 sorries / 0 native_decide / 0 admit (grep hits on lines 53,63 are docstring PROSE). 178L, 7 theorems, 0 defs. Self-contained (import Mathlib only). Fixed meta theoremCount 8→7. status verified justified."
+      "notes": "Build-verified (docker, 7743 jobs). #print axioms on jacobiSym_neg_eq_neg_one_of_three_mod_four + multiplier_route_obstructed_of_three_mod_four = [propext, Classical.choice, Quot.sound] only \u2192 0-axiom. 0 sorries / 0 native_decide / 0 admit (grep hits on lines 53,63 are docstring PROSE). 178L, 7 theorems, 0 defs. Self-contained (import Mathlib only). Fixed meta theoremCount 8\u21927. status verified justified."
     },
     "birthday-problem-oq-03-oq-01-oq-01-oq-05": {
       "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-06-21T12:27:37Z",
       "result": "issues-fixed",
-      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide (base cases d=0,1,2 use kernel decide → no Lean.ofReduceBool) / no structures. 0-axiom verified claim holds. Fixed stale metadata: leanFile.namespace BirthdayOptimized→BirthdayN4Closed, theoremCount 3→6, definitionCount 0→2, lineCount 60→77 (file has defs R, birthdayCount3 + theorems R_zero/R_succ/R_one/four/four_factored/four_eq_nat), plus section line ranges and summary."
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide (base cases d=0,1,2 use kernel decide \u2192 no Lean.ofReduceBool) / no structures. 0-axiom verified claim holds. Fixed stale metadata: leanFile.namespace BirthdayOptimized\u2192BirthdayN4Closed, theoremCount 3\u21926, definitionCount 0\u21922, lineCount 60\u219277 (file has defs R, birthdayCount3 + theorems R_zero/R_succ/R_one/four/four_factored/four_eq_nat), plus section line ranges and summary."
     },
     "cantor-diagonalization-oq-01-oq-01-oq-03": {
       "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-06-21T12:27:37Z",
       "result": "clean",
-      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide / no structures. 7 theorems, 1 noncomputable def (contFn), 79 lines — matches meta. 0-axiom verified claim holds (König constraint proved via Mathlib cofinality, not assumed)."
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide / no structures. 7 theorems, 1 noncomputable def (contFn), 79 lines \u2014 matches meta. 0-axiom verified claim holds (K\u00f6nig constraint proved via Mathlib cofinality, not assumed)."
     },
     "platonic-solids-oq-02-oq-01": {
       "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-06-21T12:27:37Z",
       "result": "clean",
-      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide tactic (grep hits lines 18/29/114 are docstring prose; line 18 \"admits\" matched admit-grep) / no structures (6 plain defs/Props: angleFrac, vertexAngleSum, PositiveDefect, archimedeanTypes, family, IsUniform). 12 theorems, 6 defs, 206 lines — matches meta. 0-axiom original claim holds."
+      "notes": "Static audit: 0 sorries / 0 axiom decls / no native_decide tactic (grep hits lines 18/29/114 are docstring prose; line 18 \"admits\" matched admit-grep) / no structures (6 plain defs/Props: angleFrac, vertexAngleSum, PositiveDefect, archimedeanTypes, family, IsUniform). 12 theorems, 6 defs, 206 lines \u2014 matches meta. 0-axiom original claim holds."
     },
     "combinations-formula-oq-01-oq-01": {
       "auditCount": 1,
@@ -22157,8 +22157,68 @@
       "issues": [],
       "lastAudited": "2026-06-24T20:41:48Z",
       "result": "issues-fixed"
+    },
+    "carnot-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dilworth-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dini-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-nullstellensatz-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gram-linear-independence-iff-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-23-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "tangent-addition-formula-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:18:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T20:41:27Z"
+  "lastUpdated": "2026-06-24T21:18:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — Batches 32 & 33

Audited **20 on-main, never-audited gallery leaves** across two passes. **All 20 integrity-clean** — public claims (status/badge/sorries/axioms) match what the Lean kernel actually guarantees. Updates `audit-tracker.json` only; no proof/meta fixes needed.

### Checks performed (every entry, comment-stripped source)
- **Sorry count = 0** real sorries. Note: `sorry`/`native_decide` grep hits in `AbundantDeficientDvdOQ04.lean` and `BurnsideCountingOQ04OQ01OQ01OQ01.lean` are **docstring prose** ("no `sorry`, no `axiom`, no `native_decide`"), not code.
- **Axiom declarations = 0**, **True stubs = 0** in every file.
- **native_decide = 0** → no `Lean.ofReduceBool`; all `decide` is kernel reduction, consistent with each meta's `assumptions` disclosure.
- **Badge tier matches source**: `baire-category-theorem-oq-01-oq-03` correctly `mathlib` (bridge); the rest carry substantive multi-theorem content (no delegation opacity / Mathlib-wrapper-as-original).

### Batch 32
abundant-number-oq-04 · amgm-inequality-oq-02-oq-01-oq-01-oq-01 · angle-trisection-oq-02-oq-03-ext-oq-01 · arsinh-log-formula-oq-01-oq-01-oq-01-oq-01 · arsinh-log-formula-oq-01-oq-02-oq-01-oq-01 · baire-category-theorem-oq-01-oq-03 · bernoulli-inequality-oq-01-oq-01-oq-02-oq-01 · birthday-problem-oq-02-oq-01-oq-02-oq-01-oq-01 · bounded-prime-gaps-oq-05 · burnside-counting-oq-04-oq-01-oq-01-oq-01

### Batch 33
carnot-theorem-oq-01-oq-01-oq-02 · cauchy-interlacing-theorem-oq-01-oq-01-oq-01-oq-01 · combinations-formula-oq-01-oq-01-oq-02 · dilworth-theorem-oq-01-oq-01-oq-02 · dini-theorem-oq-01-oq-01 · factor-remainder-nullstellensatz-oq-01-oq-02 · gram-linear-independence-iff-oq-01-oq-03 · hilbert-23-oq-01 · tangent-addition-formula-oq-01-oq-01-oq-01 · wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)