### PR TITLE
research(erdos-divisibility-pigeonhole-oq-02): coprime dual — any n+1 of {1,…,2n} contain a coprime pair [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2756,6 +2756,7 @@ import Proofs.Erdos9Problem
 import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
 import Proofs.ErdosDivisibilityPigeonholeOQ01OQ01
+import Proofs.ErdosDivisibilityPigeonholeOQ02
 import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosKoRadoOQ02

--- a/proofs/Proofs/ErdosDivisibilityPigeonholeOQ02.lean
+++ b/proofs/Proofs/ErdosDivisibilityPigeonholeOQ02.lean
@@ -1,0 +1,126 @@
+/-
+# Erdős Coprime Pigeonhole: among any `n+1` integers from `{1, …, 2n}`, two are coprime
+
+The **coprimality dual** of the Erdős divisibility pigeonhole
+(`Proofs.ErdosDivisibilityPigeonhole`). Where the divisibility version pigeonholes
+on the *odd part* `ordCompl[2] m` to force a `∣`-comparable pair, here we pigeonhole
+on the *consecutive-pair index* to force two **consecutive** integers — which are
+automatically coprime.
+
+> If `S ⊆ {1, 2, …, 2n}` has `|S| ≥ n + 1`, then there are two **distinct**
+> elements `a, b ∈ S` with `Nat.Coprime a b`.
+
+## Proof
+
+Partition `{1, …, 2n}` into the `n` consecutive blocks
+`{1,2}, {3,4}, …, {2n−1, 2n}`. The block of `m` is indexed by `(m−1)/2`, a map
+sending `S` (of size `n+1`) into `range n`. By pigeonhole two distinct
+`a, b ∈ S` land in the same block. Two distinct members of a block `{2k+1, 2k+2}`
+differ by exactly `1`, so `{a, b}` are consecutive integers, hence coprime
+(`gcd(m, m+1) = 1`).
+
+## Sharpness
+
+The bound `n+1` is best possible: the `n`-element set of **even** numbers
+`{2, 4, …, 2n}` contains no coprime pair — any two share the factor `2`. This is
+recorded as `erdos_coprime_pigeonhole_sharp`.
+
+## Unification
+
+`erdos_pigeonhole_div_and_coprime` runs both pigeonholes on the *same* hypothesis:
+any `n+1`-element subset of `{1, …, 2n}` simultaneously contains a `∣`-comparable
+pair **and** a coprime pair. The two extremal sets that defeat each conclusion are
+dual — the top block `{n+1, …, 2n}` (no divisible pair) versus the evens
+`{2, …, 2n}` (no coprime pair).
+
+## References
+
+* P. Erdős, problem folklore; the consecutive-pair pigeonhole is a companion to
+  the divisor-chain pigeonhole. See e.g. Bóna, *A Walk Through Combinatorics*.
+-/
+import Mathlib
+import Proofs.ErdosDivisibilityPigeonhole
+
+namespace ErdosDivisibilityPigeonholeOQ02
+
+open Finset
+
+/-- An integer is coprime to its successor: `gcd(b, b+1) = 1`. -/
+private lemma coprime_succ (b : ℕ) : Nat.Coprime b (b + 1) :=
+  Nat.coprime_self_add_right.mpr (Nat.coprime_one_right b)
+
+/-- Two **consecutive** integers are coprime: `gcd(m, m+1) = 1`, in either order. -/
+private lemma coprime_of_consecutive {a b : ℕ} (h : a = b + 1 ∨ b = a + 1) :
+    Nat.Coprime a b := by
+  rcases h with h | h
+  · subst h; exact (coprime_succ b).symm
+  · subst h; exact coprime_succ a
+
+/-- **Erdős Coprime Pigeonhole.** Among any `n + 1` integers chosen from
+    `{1, 2, …, 2n}`, two are coprime: if `S ⊆ Icc 1 (2n)` and `n + 1 ≤ |S|`, then
+    there exist distinct `a, b ∈ S` with `Nat.Coprime a b`. -/
+theorem erdos_coprime_pigeonhole {n : ℕ} {S : Finset ℕ}
+    (hsub : S ⊆ Finset.Icc 1 (2 * n)) (hcard : n + 1 ≤ S.card) :
+    ∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧ Nat.Coprime a b := by
+  -- The consecutive-block index `(m−1)/2` lands in `range n`.
+  set g : ℕ → ℕ := fun m => (m - 1) / 2 with hg
+  have hmaps : ∀ m ∈ S, g m ∈ Finset.range n := by
+    intro m hm
+    obtain ⟨hm1, hm2⟩ := Finset.mem_Icc.mp (hsub hm)
+    rw [Finset.mem_range, hg]
+    -- (m − 1)/2 < n ↔ m − 1 < 2n, and m ≤ 2n.
+    rw [Nat.div_lt_iff_lt_mul (by norm_num)]
+    omega
+  -- Pigeonhole: `range n` is strictly smaller than `S`.
+  have hlt : (Finset.range n).card < S.card := by
+    rw [Finset.card_range]; omega
+  obtain ⟨a, ha, b, hb, hab, hgab⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmaps
+  -- Positivity from `S ⊆ Icc 1 (2n)`.
+  have hane : 1 ≤ a := (Finset.mem_Icc.mp (hsub ha)).1
+  have hbne : 1 ≤ b := (Finset.mem_Icc.mp (hsub hb)).1
+  -- Same block index + distinct ⇒ consecutive.
+  have hconsec : a = b + 1 ∨ b = a + 1 := by
+    have hidx : (a - 1) / 2 = (b - 1) / 2 := by
+      have := hgab; simp only [hg] at this; exact this
+    omega
+  exact ⟨a, ha, b, hb, hab, coprime_of_consecutive hconsec⟩
+
+/-- **Sharpness.** The threshold `n + 1` is optimal: the `n`-element set of even
+    numbers `{2, 4, …, 2n}` has no coprime pair, since every two of its members
+    share the factor `2`. Hence no `n`-element bound suffices. -/
+theorem erdos_coprime_pigeonhole_sharp (n : ℕ) :
+    ∃ S : Finset ℕ, S ⊆ Finset.Icc 1 (2 * n) ∧ S.card = n ∧
+      ∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬ Nat.Coprime a b := by
+  refine ⟨(Finset.Icc 1 n).image (fun k => 2 * k), ?_, ?_, ?_⟩
+  · -- evens `2k` with `1 ≤ k ≤ n` lie in `Icc 1 (2n)`
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨k, hk, rfl⟩ := hx
+    rw [Finset.mem_Icc] at hk ⊢; omega
+  · -- `k ↦ 2k` is injective, so the image has `n` elements
+    rw [Finset.card_image_of_injective _
+        (by intro x y h; have h2 : 2 * x = 2 * y := h; omega), Nat.card_Icc]
+    omega
+  · -- any two members are even, hence `2 ∣ gcd`, so not coprime
+    intro a ha b hb _ hcop
+    rw [Finset.mem_image] at ha hb
+    obtain ⟨ka, _, rfl⟩ := ha
+    obtain ⟨kb, _, rfl⟩ := hb
+    have h2 : (2 : ℕ) ∣ Nat.gcd (2 * ka) (2 * kb) :=
+      Nat.dvd_gcd ⟨ka, rfl⟩ ⟨kb, rfl⟩
+    rw [Nat.Coprime] at hcop
+    rw [hcop] at h2
+    omega
+
+/-- **Unification.** Both pigeonholes on the same hypothesis: any `n + 1`-element
+    subset of `{1, …, 2n}` simultaneously contains a `∣`-comparable pair (parent
+    `erdos_divisibility_pigeonhole`) **and** a coprime pair. -/
+theorem erdos_pigeonhole_div_and_coprime {n : ℕ} {S : Finset ℕ}
+    (hsub : S ⊆ Finset.Icc 1 (2 * n)) (hcard : n + 1 ≤ S.card) :
+    (∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧ a ∣ b) ∧
+      (∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧ Nat.Coprime a b) :=
+  ⟨ErdosDivisibilityPigeonhole.erdos_divisibility_pigeonhole hsub hcard,
+   erdos_coprime_pigeonhole hsub hcard⟩
+
+end ErdosDivisibilityPigeonholeOQ02

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-02/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-02/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "erdos-divisibility-pigeonhole-oq-02",
+  "title": "Erdős Coprime Pigeonhole — any n+1 elements of {1,…,2n} contain a coprime pair (the dual gem)",
+  "slug": "erdos-divisibility-pigeonhole-oq-02",
+  "description": "The coprimality dual of the Erdős divisibility pigeonhole. Where the parent forces a divisor-comparable pair (a ∣ b) by pigeonholing on the odd part ordCompl[2] m, this entry forces a coprime pair by pigeonholing on the consecutive-pair index ⌊(m−1)/2⌋: any n+1 elements of {1,…,2n} land two in a common block {2k−1,2k}, which are consecutive integers, hence coprime (gcd(m,m+1)=1). The threshold n+1 is sharp — the n even numbers {2,4,…,2n} have no coprime pair — and a unifying theorem runs both pigeonholes on the same hypothesis, producing simultaneously a divisible pair and a coprime pair, with dual extremal obstructions ({n+1,…,2n} versus {2,…,2n}). Formalized over Mathlib with zero sorries and zero axioms.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pigeonhole_principle",
+    "date": "folklore",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosDivisibilityPigeonholeOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "number-theory",
+      "pigeonhole-principle",
+      "coprime",
+      "consecutive-integers",
+      "extremal",
+      "erdos"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+        "description": "The finite pigeonhole principle: if |s| > |t| and f maps s into t, then two distinct elements of s have equal image. Applied with f m = ⌊(m−1)/2⌋ mapping the (n+1)-element set into Finset.range n to force two elements into a common consecutive block.",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "Nat.coprime_self_add_right",
+        "description": "Coprime m (m + n) ↔ Coprime m n. Instantiated at n = 1 (with Nat.coprime_one_right) to prove gcd(b, b+1) = 1, the coprimality of consecutive integers that the block collision delivers.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_gcd",
+        "description": "k ∣ m → k ∣ n → k ∣ gcd m n. Used in the sharpness witness: 2 ∣ 2ka and 2 ∣ 2kb force 2 ∣ gcd, so two even numbers are never coprime.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      }
+    ],
+    "originalContributions": [
+      "erdos_coprime_pigeonhole: the coprimality dual of the gem — any n+1 elements of {1,…,2n} contain two distinct a, b with Nat.Coprime a b — proved by pigeonholing on the consecutive-block index ⌊(m−1)/2⌋ ∈ range n and observing that two members of a common block {2k+1, 2k+2} are consecutive, hence coprime.",
+      "erdos_coprime_pigeonhole_sharp: the threshold n+1 is optimal — the n-element set of evens {2,4,…,2n} has no coprime pair, since any two members share the factor 2 (2 ∣ gcd).",
+      "erdos_pigeonhole_div_and_coprime: a unifying theorem running both pigeonholes on the same hypothesis, yielding simultaneously a ∣-comparable pair (from the parent erdos_divisibility_pigeonhole) and a coprime pair — exhibiting the two phenomena as duals with dual extremal obstructions.",
+      "coprime_of_consecutive: a reusable lemma that two consecutive integers (in either order) are coprime, built from Nat.coprime_self_add_right."
+    ],
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "erdos-divisibility-pigeonhole",
+        "relationship": "Parent. The divisibility version forces a ∣ b by pigeonholing on the odd part; this entry is its coprimality dual, forcing a coprime pair by pigeonholing on the consecutive-pair index. The unification theorem invokes the parent's erdos_divisibility_pigeonhole directly."
+      },
+      {
+        "id": "erdos-divisibility-pigeonhole-oq-01",
+        "relationship": "Sibling. The extremal form of the divisibility version (largest divisibility-antichain has size n); the coprime dual here has its own extremal obstruction, the n evens."
+      }
+    ],
+    "lineCount": 126,
+    "assumptions": "0 axioms, 0 sorries (#print axioms reports only propext, Classical.choice, Quot.sound — no Lean.ofReduceBool, no native_decide, no sorryAx). The only hypotheses are structural: membership in {1,…,2n} and the cardinality bound n+1, both part of each statement. Badge is 'original' because the coprimality dual, its sharpness witness, and the unifying both-pigeonholes statement are formalized from first principles; Mathlib does not contain this application.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Among the folklore pigeonhole gems associated with Erdős (famously posed to the young Lajos Pósa) are two dual statements about {1,…,2n}. The first: any n+1 elements contain a pair with a ∣ b — proved by classifying by odd part, of which there are exactly n. The second, dual statement: any n+1 elements contain two that are coprime — proved by noticing that n+1 elements among the n consecutive blocks {1,2},{3,4},…,{2n−1,2n} must place two in the same block, and two consecutive integers are always coprime. The two results have dual extremal sets: the top half {n+1,…,2n} is divisibility-free, while the evens {2,…,2n} are pairwise non-coprime — each of size n, certifying that n+1 is the exact threshold for the respective conclusion.",
+    "problemStatement": "Let $n \\ge 0$ and $S \\subseteq \\{1,\\dots,2n\\}$ with $|S| \\ge n+1$. Then there exist distinct $a, b \\in S$ with $\\gcd(a,b) = 1$. The bound $n+1$ is best possible: the $n$ even numbers $\\{2,4,\\dots,2n\\}$ contain no coprime pair.",
+    "text": "Any $n+1$ integers chosen from $\\{1,\\dots,2n\\}$ contain two that are coprime. Partition $\\{1,\\dots,2n\\}$ into the $n$ consecutive blocks $\\{1,2\\},\\{3,4\\},\\dots,\\{2n-1,2n\\}$; by pigeonhole two of the $n+1$ chosen numbers share a block, so they are consecutive integers, hence coprime. The threshold is sharp because the $n$ even numbers form a coprime-free set.",
+    "proofStrategy": "Map each m ∈ S to its consecutive-block index g(m) = ⌊(m−1)/2⌋. For m ∈ {1,…,2n} one has g(m) < n (since m−1 < 2n), so g sends S into Finset.range n. As |S| ≥ n+1 > n = |range n|, Finset.exists_ne_map_eq_of_card_lt_of_maps_to yields distinct a, b ∈ S with g(a) = g(b). Equal block index together with a ≠ b forces a = b+1 or b = a+1 (an omega arithmetic on ⌊·/2⌋), so a, b are consecutive; coprime_of_consecutive then gives Nat.Coprime a b via gcd(b, b+1) = 1. Sharpness: the image of Icc 1 n under k ↦ 2k is an n-element subset of {1,…,2n} (the map is injective), and any two members 2ka, 2kb satisfy 2 ∣ gcd, so are not coprime. The unification theorem pairs this with the parent's odd-part pigeonhole on the identical hypothesis.",
+    "keyInsights": [
+      "**Dual pigeonholes on dual partitions**: the divisibility gem pigeonholes {1,…,2n} by *odd part* (n classes, each a divisibility chain o, 2o, 4o, …); the coprime gem pigeonholes by *consecutive block* (n classes {2k−1,2k}). A collision in the first gives a ∣-comparable pair; a collision in the second gives a consecutive — hence coprime — pair.",
+      "**Consecutive ⇒ coprime is the whole point**: the only number theory needed downstream is gcd(m, m+1) = 1, packaged as coprime_of_consecutive. Everything else is the pigeonhole counting argument that two of n+1 elements must be consecutive.",
+      "**The index map is a clean ⌊·/2⌋**: g(m) = ⌊(m−1)/2⌋ collapses {2k+1, 2k+2} to k and lands in range n exactly when m ≤ 2n, so the maps-to and cardinality hypotheses of Mathlib's pigeonhole lemma are both immediate by omega.",
+      "**Sharpness is the evens, dual to the top block**: divisibility-freeness is achieved by the top half {n+1,…,2n}; coprime-freeness by the evens {2,…,2n}. Both have size n, so n+1 is the exact threshold for each conclusion — the two extremal sets are genuinely different witnesses to the same optimal bound.",
+      "**One hypothesis, two conclusions**: erdos_pigeonhole_div_and_coprime shows the same (n+1)-element set simultaneously contains a divisible pair and a coprime pair — the divisibility and coprimality phenomena are not in tension but co-occur, each forced by its own pigeonhole."
+    ],
+    "prerequisites": [
+      "The finite pigeonhole principle (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "Coprimality of consecutive integers (gcd(m, m+1) = 1)",
+      "Elementary natural-number arithmetic and floor division",
+      "The parent Erdős divisibility pigeonhole (for the unification theorem)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Problem Statement & Setup",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring presenting the coprimality dual of the Erdős divisibility pigeonhole: pigeonhole on the consecutive-block index to force two consecutive (hence coprime) integers, with sharpness via the evens and a unifying both-pigeonholes theorem. Imports Mathlib and the parent ErdosDivisibilityPigeonhole, opens Finset."
+    },
+    {
+      "id": "consecutive-coprime",
+      "title": "Consecutive Integers Are Coprime",
+      "startLine": 48,
+      "endLine": 58,
+      "summary": "coprime_succ proves gcd(b, b+1) = 1 from Nat.coprime_self_add_right and Nat.coprime_one_right; coprime_of_consecutive lifts this to either order (a = b+1 ∨ b = a+1), the number-theoretic core the block collision feeds."
+    },
+    {
+      "id": "main-pigeonhole",
+      "title": "The Coprime Pigeonhole",
+      "startLine": 59,
+      "endLine": 88,
+      "summary": "erdos_coprime_pigeonhole: the consecutive-block index g(m) = ⌊(m−1)/2⌋ maps S into range n; Finset's pigeonhole lemma produces distinct a, b with equal index; omega turns equal index + distinctness into 'a, b consecutive', and coprime_of_consecutive concludes Nat.Coprime a b."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: the n Evens Have No Coprime Pair",
+      "startLine": 89,
+      "endLine": 115,
+      "summary": "erdos_coprime_pigeonhole_sharp exhibits {2,4,…,2n} (the image of Icc 1 n under k ↦ 2k) as an n-element coprime-free subset of {1,…,2n}: the doubling map is injective (card n), and any two members 2ka, 2kb have 2 ∣ gcd, so are not coprime — certifying n+1 is the optimal threshold."
+    },
+    {
+      "id": "unification",
+      "title": "Unification: Both Pigeonholes at Once",
+      "startLine": 116,
+      "endLine": 126,
+      "summary": "erdos_pigeonhole_div_and_coprime runs the parent's divisibility pigeonhole and this entry's coprime pigeonhole on the same hypothesis, yielding simultaneously a ∣-comparable pair and a coprime pair — the dual gems combined into one statement."
+    }
+  ],
+  "conclusion": {
+    "summary": "The coprimality dual of the Erdős divisibility pigeonhole is formalized with zero sorries and zero axioms: any n+1 elements of {1,…,2n} contain a coprime pair (erdos_coprime_pigeonhole), proved by pigeonholing on the consecutive-block index and using that consecutive integers are coprime. The bound n+1 is shown sharp by the n even numbers (erdos_coprime_pigeonhole_sharp), and erdos_pigeonhole_div_and_coprime unifies the divisibility and coprimality gems by forcing both a divisible pair and a coprime pair from the same hypothesis.",
+    "implications": "The entry completes the dual pair of {1,…,2n} pigeonhole gems: divisibility (collision in odd-part classes) and coprimality (collision in consecutive blocks). Phrasing both as pigeonholes on dual partitions, with dual extremal obstructions (top half vs. evens), makes the symmetry explicit and reusable. The unifying theorem records that the two conclusions co-occur rather than compete — a single (n+1)-element subset is simultaneously rich in divisor structure and in coprimality. The consecutive-coprime lemma and the index-map technique are standalone building blocks for further interval-combinatorics results.",
+    "openQuestions": [
+      "Generalize to {1,…,N}: any ⌈N/2⌉+1 elements contain a coprime pair (same consecutive-block pigeonhole on ⌈N/2⌉ blocks), with the evens {2,…,2⌊N/2⌋} as the sharp coprime-free witness — paralleling the general-N divisibility statement already in the sibling oq-01-oq-01.",
+      "Strengthen 'coprime pair' to a quantitative count: how many pairwise-coprime elements must any n+1-subset of {1,…,2n} contain, and what is the largest subset with no three pairwise coprime (an Erdős-style question on coprime hypergraphs)?",
+      "Formalize the dual extremal characterization: classify all n-element coprime-free subsets of {1,…,2n} (must they all be contained in a single prime's multiples?), mirroring the primitive-set classification on the divisibility side."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-divisibility-pigeonhole",
+      "relationship": "extends",
+      "description": "Coprimality dual of the parent divisibility gem; the unification theorem erdos_pigeonhole_div_and_coprime invokes the parent's erdos_divisibility_pigeonhole to force a divisible pair alongside the coprime pair on the same hypothesis."
+    },
+    {
+      "targetId": "erdos-divisibility-pigeonhole-oq-01",
+      "relationship": "uses-similar-technique",
+      "description": "Sibling extremal-form entry on the divisibility side; both pin the optimal threshold via an explicit n-element witness (top block there, evens here)."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ErdosDivisibilityPigeonholeOQ02.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.ErdosDivisibilityPigeonhole"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosDivisibilityPigeonholeOQ02",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

The **coprimality dual** of the Erdős divisibility pigeonhole (parent: `erdos-divisibility-pigeonhole`). Where the parent forces a divisor-comparable pair `a ∣ b` by pigeonholing on the *odd part* `ordCompl[2] m`, this entry forces a **coprime** pair by pigeonholing on the *consecutive-block index* `⌊(m−1)/2⌋`.

### Results (`Proofs/ErdosDivisibilityPigeonholeOQ02.lean`, 126 lines, 3 theorems, 0 defs)

- **`erdos_coprime_pigeonhole`** — any `n+1` elements of `{1,…,2n}` contain two distinct `a, b` with `Nat.Coprime a b`. Proof: `g(m) = ⌊(m−1)/2⌋` maps `S` into `range n`; `Finset.exists_ne_map_eq_of_card_lt_of_maps_to` collides two into a block `{2k+1, 2k+2}`; equal index + distinctness ⟹ consecutive (omega); consecutive ⟹ coprime via `gcd(b,b+1)=1`.
- **`erdos_coprime_pigeonhole_sharp`** — the threshold `n+1` is optimal: the `n` evens `{2,4,…,2n}` are coprime-free (`2 ∣ gcd`).
- **`erdos_pigeonhole_div_and_coprime`** — unification: the same `(n+1)`-element hypothesis yields **simultaneously** a divisible pair (parent's `erdos_divisibility_pigeonhole`) and a coprime pair. Dual extremal obstructions: top block `{n+1,…,2n}` vs. evens `{2,…,2n}`.

### Verification

`#print axioms` on all three theorems reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Compiled via `lake env lean` against Mathlib (docker down this session). 0 sorries, 0 axioms → `verified` / `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)