### PR TITLE
research(banach-fixed-point-oq-01-oq-02-oq-01): Picard iteration & geometric error bounds for the inverse of id + g [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -287,6 +287,7 @@ import Proofs.BallotProblemOQ03OQ02
 import Proofs.BallotProblemOQ03OQ03
 import Proofs.BanachFixedPointOQ01
 import Proofs.BanachPerturbationIdentityOQ01OQ02
+import Proofs.BanachPicardInverseOQ01OQ02OQ01
 import Proofs.BanachSteinhausTheoremOQ01
 import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01

--- a/proofs/Proofs/BanachPicardInverseOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BanachPicardInverseOQ01OQ02OQ01.lean
@@ -1,0 +1,157 @@
+import Mathlib
+
+/-
+# Explicit Picard Iteration and Geometric Error Bounds for the Inverse of `id + g`
+
+Open-question extension `oq-01-oq-02-oq-01` of the Banach Fixed Point chain.
+
+The parent result (`oq-01-oq-02`) proves that a `k`-Lipschitz perturbation of the
+identity `f x = x + g x` (with `k < 1`, on a complete normed group `E`) is a
+homeomorphism whose inverse is `(1-k)⁻¹`-Lipschitz.  That argument is *existential*:
+it produces `f⁻¹` from the contraction-mapping theorem but says nothing about how to
+**compute** it or how fast an iteration converges.
+
+This file supplies the missing *constructive / quantitative* layer.  To solve
+`f x = y`, i.e. `x + g x = y`, rewrite it as the fixed-point equation
+
+  `x = y - g x`,   the **Picard operator**  `T_y x = y - g x`.
+
+`T_y` is a `k`-contraction (same constant as `g`), so its unique fixed point is the
+preimage `f⁻¹ y`, reached by the iteration `xₙ₊₁ = y - g xₙ` from *any* starting
+point `x₀`.  We package:
+
+* `inverse`            — the inverse `f⁻¹ y`, defined as the fixed point of `T_y`;
+* `inverse_solves`     — it really solves `x + g x = y`;
+* `inverse_unique`     — it is the *only* solution;
+* `tendsto_picard`     — Picard iterates converge to `f⁻¹ y` from any seed `x₀`;
+* `apriori_error`      — a priori geometric bound `‖xₙ - f⁻¹ y‖ ≤ ‖x₀ - x₁‖·kⁿ/(1-k)`;
+* `aposteriori_error`  — a posteriori bound `‖xₙ - f⁻¹ y‖ ≤ ‖xₙ - xₙ₊₁‖/(1-k)`;
+* `linear_rate`        — one-step linear (geometric) contraction of the error;
+* `apriori_error_seed_target` — the clean specialisation with seed `x₀ = y`:
+                          `‖(T_y)ⁿ y - f⁻¹ y‖ ≤ ‖g y‖·kⁿ/(1-k)`.
+
+The contraction machinery (`ContractingWith.fixedPoint`, its error estimates, and the
+convergence theorem) is the Mathlib input; the new content is identifying the fixed
+point with the inverse of `id + g` and turning the generic estimates into explicit,
+computable error bounds for inverting a Lipschitz perturbation of the identity.
+
+Everything is fully machine-checked: `0` `sorry`s and `0` `axiom`s.  The file is
+self-contained — it re-introduces the perturbed map `f = id + g` locally rather than
+importing the parent module.
+-/
+
+namespace BanachPicardInverseOQ01OQ02OQ01
+
+set_option linter.unusedSectionVars false
+
+open Metric Function Filter Topology
+open scoped NNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E]
+variable {k : ℝ≥0} {g : E → E}
+
+/-- The perturbed map `f = id + g` whose inverse we compute. -/
+def pmap (g : E → E) : E → E := fun x => x + g x
+
+@[simp] theorem pmap_apply (g : E → E) (x : E) : pmap g x = x + g x := rfl
+
+/-- The **Picard operator** for the target `y`: `T_y x = y - g x`.  A point `x`
+solves `f x = y` iff it is a fixed point of `T_y`. -/
+def picard (g : E → E) (y : E) : E → E := fun x => y - g x
+
+@[simp] theorem picard_apply (g : E → E) (y x : E) : picard g y x = y - g x := rfl
+
+/-- `T_y` is `k`-Lipschitz: it inherits `g`'s Lipschitz constant. -/
+theorem picard_lipschitz (hg : LipschitzWith k g) (y : E) :
+    LipschitzWith k (picard g y) := by
+  apply LipschitzWith.of_dist_le_mul
+  intro a b
+  have hd := hg.dist_le_mul a b
+  simp only [dist_eq_norm, picard_apply]
+  calc ‖(y - g a) - (y - g b)‖ = ‖g a - g b‖ := by
+          rw [show (y - g a) - (y - g b) = -(g a - g b) by abel, norm_neg]
+    _ ≤ (k : ℝ) * ‖a - b‖ := by simpa [dist_eq_norm] using hd
+
+/-- `T_y` is a `k`-contraction (`k < 1`). -/
+theorem picard_contracting (hg : LipschitzWith k g) (hk : k < 1) (y : E) :
+    ContractingWith k (picard g y) :=
+  ⟨hk, picard_lipschitz hg y⟩
+
+/-- The **inverse** `f⁻¹ y`, defined constructively as the unique fixed point of the
+Picard operator `T_y`. -/
+noncomputable def inverse (hg : LipschitzWith k g) (hk : k < 1) (y : E) : E :=
+  haveI : Nonempty E := ⟨0⟩
+  ContractingWith.fixedPoint (picard g y) (picard_contracting hg hk y)
+
+/-- `inverse` is genuinely the fixed point of the Picard operator. -/
+theorem isFixedPt_inverse (hg : LipschitzWith k g) (hk : k < 1) (y : E) :
+    IsFixedPt (picard g y) (inverse hg hk y) := by
+  haveI : Nonempty E := ⟨0⟩
+  exact (picard_contracting hg hk y).fixedPoint_isFixedPt
+
+/-- **The inverse solves the equation.**  `f (f⁻¹ y) = y`, i.e.
+`inverse y + g (inverse y) = y`. -/
+theorem inverse_solves (hg : LipschitzWith k g) (hk : k < 1) (y : E) :
+    pmap g (inverse hg hk y) = y := by
+  have h := isFixedPt_inverse hg hk y
+  rw [IsFixedPt, picard_apply, sub_eq_iff_eq_add] at h
+  rw [pmap_apply]
+  -- `h : y = inverse + g inverse`
+  exact h.symm
+
+/-- **Uniqueness.**  Any solution of `x + g x = y` equals the constructed inverse;
+in particular `id + g` is injective and `inverse` is its honest two-sided inverse. -/
+theorem inverse_unique (hg : LipschitzWith k g) (hk : k < 1) {y x : E}
+    (hx : pmap g x = y) : x = inverse hg hk y := by
+  haveI : Nonempty E := ⟨0⟩
+  have hfix : IsFixedPt (picard g y) x := by
+    rw [IsFixedPt, picard_apply, pmap_apply] at *
+    -- from `x + g x = y` deduce `y - g x = x`
+    rw [← hx]; abel
+  exact (picard_contracting hg hk y).fixedPoint_unique hfix
+
+/-- **Convergence of Picard iteration.**  From *any* seed `x₀`, the iterates
+`xₙ₊₁ = y - g xₙ` converge to the inverse `f⁻¹ y`. -/
+theorem tendsto_picard (hg : LipschitzWith k g) (hk : k < 1) (y x₀ : E) :
+    Tendsto (fun n => (picard g y)^[n] x₀) atTop (𝓝 (inverse hg hk y)) := by
+  haveI : Nonempty E := ⟨0⟩
+  exact (picard_contracting hg hk y).tendsto_iterate_fixedPoint x₀
+
+/-- **A priori geometric error bound.**  After `n` Picard steps from seed `x₀`,
+`‖xₙ - f⁻¹ y‖ ≤ ‖x₀ - x₁‖ · kⁿ / (1 - k)`. -/
+theorem apriori_error (hg : LipschitzWith k g) (hk : k < 1) (y x₀ : E) (n : ℕ) :
+    dist ((picard g y)^[n] x₀) (inverse hg hk y)
+      ≤ dist x₀ (picard g y x₀) * (k : ℝ) ^ n / (1 - k) := by
+  haveI : Nonempty E := ⟨0⟩
+  exact (picard_contracting hg hk y).apriori_dist_iterate_fixedPoint_le x₀ n
+
+/-- **A posteriori error bound.**  The error is controlled by the last increment:
+`‖xₙ - f⁻¹ y‖ ≤ ‖xₙ - xₙ₊₁‖ / (1 - k)`. -/
+theorem aposteriori_error (hg : LipschitzWith k g) (hk : k < 1) (y x₀ : E) (n : ℕ) :
+    dist ((picard g y)^[n] x₀) (inverse hg hk y)
+      ≤ dist ((picard g y)^[n] x₀) ((picard g y)^[n + 1] x₀) / (1 - k) := by
+  haveI : Nonempty E := ⟨0⟩
+  exact (picard_contracting hg hk y).aposteriori_dist_iterate_fixedPoint_le x₀ n
+
+/-- **Linear (geometric) convergence rate.**  One Picard step shrinks the error by
+the factor `k`: `‖T_y x - f⁻¹ y‖ ≤ k · ‖x - f⁻¹ y‖`. -/
+theorem linear_rate (hg : LipschitzWith k g) (hk : k < 1) (y x : E) :
+    dist (picard g y x) (inverse hg hk y) ≤ (k : ℝ) * dist x (inverse hg hk y) := by
+  have hfix := isFixedPt_inverse hg hk y
+  calc dist (picard g y x) (inverse hg hk y)
+      = dist (picard g y x) (picard g y (inverse hg hk y)) := by rw [hfix.eq]
+    _ ≤ (k : ℝ) * dist x (inverse hg hk y) :=
+        (picard_lipschitz hg y).dist_le_mul x (inverse hg hk y)
+
+/-- **Clean specialisation with the natural seed `x₀ = y`.**  Since the first
+increment is `‖y - T_y y‖ = ‖g y‖`, the a priori bound reads
+`‖(T_y)ⁿ y - f⁻¹ y‖ ≤ ‖g y‖ · kⁿ / (1 - k)`. -/
+theorem apriori_error_seed_target (hg : LipschitzWith k g) (hk : k < 1) (y : E) (n : ℕ) :
+    dist ((picard g y)^[n] y) (inverse hg hk y)
+      ≤ ‖g y‖ * (k : ℝ) ^ n / (1 - k) := by
+  have h := apriori_error hg hk y y n
+  have hseed : dist y (picard g y y) = ‖g y‖ := by
+    rw [dist_eq_norm, picard_apply, show y - (y - g y) = g y by abel]
+  rwa [hseed] at h
+
+end BanachPicardInverseOQ01OQ02OQ01

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "banach-fixed-point-oq-01-oq-02-oq-01",
+  "title": "Explicit Picard iteration and geometric error bounds for the inverse of id + g",
+  "slug": "banach-fixed-point-oq-01-oq-02-oq-01",
+  "description": "The parent entry proves that a k-Lipschitz perturbation of the identity f x = x + g x (k < 1, on a complete normed group E) is a homeomorphism whose inverse is (1−k)⁻¹-Lipschitz — but only existentially: it produces f⁻¹ from the contraction-mapping theorem without saying how to compute it. This entry supplies the missing constructive and quantitative layer. Solving f x = y, i.e. x + g x = y, is the fixed-point equation x = y − g x for the Picard operator T_y x = y − g x, which is a k-contraction (same constant as g). The entry defines the inverse f⁻¹ y as the fixed point of T_y (inverse), proves it actually solves x + g x = y (inverse_solves) and is the unique solution (inverse_unique), shows Picard iteration xₙ₊₁ = y − g xₙ converges to f⁻¹ y from any seed (tendsto_picard), and exposes the explicit error estimates: the a priori geometric bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k) (apriori_error), the a posteriori bound ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k) (aposteriori_error), the one-step linear contraction of the error (linear_rate), and the clean seed-at-target specialisation ‖(T_y)ⁿ y − f⁻¹ y‖ ≤ ‖g y‖·kⁿ/(1−k) (apriori_error_seed_target). Directly answers the parent's listed open question on recovering f⁻¹ as the explicit limit of Picard iteration. Verified with 0 axioms and 0 sorries; the Mathlib input is the ContractingWith fixed-point API and its convergence/error estimates.",
+  "meta": {
+    "author": "Classical (Banach iteration / successive approximations for the inverse function theorem); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachPicardInverseOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "banach-fixed-point",
+      "contraction-mapping",
+      "fixed-point-iteration",
+      "picard-iteration",
+      "error-bounds",
+      "inverse-function-theorem",
+      "perturbation-of-identity",
+      "normed-space",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ContractingWith.fixedPoint",
+        "description": "The unique fixed point of a contraction on a nonempty complete metric space. Used to define the inverse f⁻¹ y as the fixed point of the Picard operator T_y x = y − g x.",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "ContractingWith.apriori_dist_iterate_fixedPoint_le",
+        "description": "A priori error estimate dist (f^[n] x) (fixedPoint) ≤ dist x (f x) · Kⁿ / (1 − K). Specialised to T_y it gives the geometric a priori bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k).",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "ContractingWith.aposteriori_dist_iterate_fixedPoint_le",
+        "description": "A posteriori error estimate dist (f^[n] x) (fixedPoint) ≤ dist (f^[n] x) (f^[n+1] x) / (1 − K). Gives the computable stopping criterion ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k).",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "ContractingWith.tendsto_iterate_fixedPoint",
+        "description": "The iterates of a contraction converge to its fixed point. Gives convergence of Picard iteration xₙ₊₁ = y − g xₙ to f⁻¹ y from any seed.",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "ContractingWith.fixedPoint_unique",
+        "description": "Any fixed point of a contraction equals the canonical fixed point. Used to prove inverse_unique: any solution of x + g x = y equals the constructed inverse.",
+        "module": "Mathlib.Topology.MetricSpace.Contracting"
+      },
+      {
+        "theorem": "LipschitzWith.of_dist_le_mul",
+        "description": "Characterises a Lipschitz bound by dist (f x) (f y) ≤ K · dist x y; used to show the Picard operator T_y x = y − g x is k-Lipschitz, hence a contraction.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "picard / picard_contracting: the Picard operator T_y x = y − g x for solving f x = y, proved to be a k-contraction (inheriting g's Lipschitz constant), the constructive engine for inverting id + g.",
+      "inverse / inverse_solves / inverse_unique: defines f⁻¹ y as the fixed point of T_y, proves it solves x + g x = y, and proves it is the unique solution — an honest constructive two-sided inverse, not merely an abstract existence statement.",
+      "tendsto_picard: from any seed x₀, the Picard iterates xₙ₊₁ = y − g xₙ converge to f⁻¹ y — the inverse exhibited as an explicit limit of successive approximations.",
+      "apriori_error: the a priori geometric error bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k), giving an effective number of iterations for any target accuracy.",
+      "aposteriori_error: the a posteriori bound ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k), a computable stopping criterion using only the last increment.",
+      "linear_rate: one Picard step contracts the error by the factor k, ‖T_y x − f⁻¹ y‖ ≤ k·‖x − f⁻¹ y‖ — the linear (geometric) convergence rate.",
+      "apriori_error_seed_target: the clean specialisation at seed x₀ = y, ‖(T_y)ⁿ y − f⁻¹ y‖ ≤ ‖g y‖·kⁿ/(1−k), since the first increment is exactly ‖g y‖."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas (#print axioms confirms exactly these three on inverse_solves, inverse_unique, apriori_error, apriori_error_seed_target). The hypotheses (complete normed group, g k-Lipschitz with k < 1) are ordinary mathematical hypotheses, not unproved assumptions.",
+    "lineCount": 157,
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Banach's 1922 contraction principle is constructive at heart: the fixed point is the limit of the iteration xₙ₊₁ = T xₙ, and the proof yields the geometric error estimate kⁿ/(1−k) for free. This is the basis of successive approximations (Picard) for ODEs and of the iterative solution of the equation x + g x = y at the core of the inverse function theorem and Newton's method. The parent entry obtained the inverse of id + g abstractly as a fixed point; the present entry restores the algorithm and its quantitative guarantees, making f⁻¹ y computable to any prescribed accuracy with an explicit, certifiable iteration count.",
+    "problemStatement": "The parent entry proves f x = x + g x (g k-Lipschitz, k < 1) is a homeomorphism with a (1−k)⁻¹-Lipschitz inverse, but only existentially. Can f⁻¹ y be computed, and how fast?\n\n**Answer:** Yes. Solving f x = y is the fixed-point equation x = y − g x for the k-contraction T_y, so f⁻¹ y is the limit of the Picard iteration xₙ₊₁ = y − g xₙ from any seed, with the a priori geometric bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k), the a posteriori bound ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k), and one-step error contraction by the factor k.",
+    "text": "The inverse of a Lipschitz perturbation of the identity is the explicit limit of Picard iteration xₙ₊₁ = y − g xₙ, with geometric a priori error kⁿ/(1−k) and an a posteriori stopping bound — the constructive, quantitative refinement of the parent homeomorphism, verified with 0 axioms.",
+    "proofStrategy": "1. picard_lipschitz / picard_contracting: T_y x = y − g x satisfies ‖T_y a − T_y b‖ = ‖g a − g b‖ ≤ k‖a − b‖, so it is k-Lipschitz and (k < 1) a contraction.\n2. inverse: define f⁻¹ y := ContractingWith.fixedPoint T_y. isFixedPt_inverse gives T_y (f⁻¹ y) = f⁻¹ y.\n3. inverse_solves: the fixed-point equation y − g x = x rearranges to x + g x = y, i.e. pmap g (f⁻¹ y) = y.\n4. inverse_unique: any solution x of x + g x = y gives y − g x = x, a fixed point of T_y, so x = f⁻¹ y by ContractingWith.fixedPoint_unique.\n5. tendsto_picard / apriori_error / aposteriori_error: direct specialisations of ContractingWith.tendsto_iterate_fixedPoint and the (a)priori distance estimates to T_y.\n6. linear_rate: dist (T_y x) (f⁻¹ y) = dist (T_y x) (T_y (f⁻¹ y)) ≤ k·dist x (f⁻¹ y) using the fixed point and the Lipschitz bound.\n7. apriori_error_seed_target: with seed y, the first increment dist y (T_y y) = ‖y − (y − g y)‖ = ‖g y‖, so the a priori bound becomes ‖g y‖·kⁿ/(1−k).",
+    "keyInsights": [
+      "**The inverse is an algorithm, not just an existence theorem.** Inverting id + g is the contraction T_y x = y − g x; its iterates are the successive approximations and their limit is f⁻¹ y, so the abstract fixed point of the parent becomes a runnable iteration with certified accuracy.",
+      "**A priori and a posteriori bounds answer different questions.** The a priori bound kⁿ/(1−k) fixes the iteration count in advance from the first step; the a posteriori bound ‖xₙ − xₙ₊₁‖/(1−k) is a computable stopping criterion measured during the run. Both are exposed.",
+      "**Uniqueness comes free from the contraction.** Because T_y has a unique fixed point, the inverse is the only solution of x + g x = y — recovering injectivity of id + g from the iterative side, complementing the parent's antilipschitz argument.",
+      "**Seed at the target for the cleanest constant.** Starting the iteration at x₀ = y makes the first increment exactly ‖g y‖, so the error after n steps is ‖g y‖·kⁿ/(1−k) — a bound depending only on the data g, y and the contraction constant."
+    ],
+    "exampleSections": [
+      {
+        "title": "Neumann series as Picard iteration",
+        "mathContext": "For a bounded linear T with ‖T‖ = k < 1, inverting I + T at target y by Picard iteration xₙ₊₁ = y − T xₙ from x₀ = 0 produces the partial sums xₙ = Σ_{j<n} (−T)ʲ y of the Neumann series, and the a priori bound ‖xₙ − (I+T)⁻¹ y‖ ≤ ‖y‖·kⁿ/(1−k) is exactly the geometric tail estimate of that series."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Banach, Stefan",
+      "title": "Sur les opérations dans les ensembles abstraits et leur application aux équations intégrales",
+      "year": "1922",
+      "note": "Fund. Math. 3, 133–181 — the contraction principle, constructive with the geometric error estimate."
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "McGraw–Hill — the inverse function theorem solves f x = y by iterating x ↦ y − g x, the scheme made quantitative here."
+    },
+    {
+      "authors": "Atkinson, Kendall; Han, Weimin",
+      "title": "Theoretical Numerical Analysis",
+      "year": "2009",
+      "note": "Springer — a priori and a posteriori error bounds for fixed-point iteration of contractions."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "banach-fixed-point-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent entry proves id + g is a homeomorphism with a (1−k)⁻¹-Lipschitz inverse existentially. This entry recovers that inverse constructively as the limit of Picard iteration with explicit geometric error bounds, answering the parent's listed open question on successive approximations."
+    },
+    {
+      "targetId": "banach-fixed-point-oq-01",
+      "relationship": "related",
+      "description": "The root Banach contraction mapping theorem, whose constructive content (iterate-to-the-fixed-point with geometric error) is exactly what is specialised here to the inverse-of-identity-perturbation setting."
+    }
+  ],
+  "conclusion": {
+    "summary": "The inverse of a k-Lipschitz perturbation of the identity f x = x + g x (k < 1) is realised constructively as the fixed point of the Picard operator T_y x = y − g x (inverse), proved to solve x + g x = y (inverse_solves) and be its unique solution (inverse_unique). Picard iteration converges to it from any seed (tendsto_picard) with the a priori geometric bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k) (apriori_error), the a posteriori bound ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k) (aposteriori_error), one-step linear error contraction (linear_rate), and the seed-at-target specialisation ‖g y‖·kⁿ/(1−k) (apriori_error_seed_target). Verified with 0 axioms and 0 sorries.",
+    "implications": "Turns the parent's abstract inverse into a runnable, certifiable algorithm: f⁻¹ y is computable to any accuracy with an explicit iteration count and a computable stopping criterion, the constructive counterpart of the inverse function theorem core and the model case of Newton/Neumann iteration.",
+    "openQuestions": [
+      "Perturbation of a linear isomorphism A: iterate x ↦ A⁻¹(y − g x) to invert A + g, carrying the geometric error bound with constant (k‖A⁻¹‖)ⁿ/(1 − k‖A⁻¹‖) — the full local inverse function theorem with quantitative convergence.",
+      "Quadratic (Newton) acceleration: replace the linear Picard step by a Newton step when g is differentiable and compare the kⁿ geometric rate proved here with the locally quadratic rate."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and statement",
+      "startLine": 3,
+      "endLine": 48,
+      "summary": "Frames the constructive/quantitative goal: compute the inverse of f = id + g via the Picard operator T_y x = y − g x, with convergence and explicit a priori/a posteriori error bounds, complementing the parent's existential homeomorphism.",
+      "mathContext": "$x_{n+1} = y - g(x_n) \\to f^{-1}y$, $\\|x_n - f^{-1}y\\| \\le \\|x_0-x_1\\|\\,k^n/(1-k)$."
+    },
+    {
+      "id": "picard-operator",
+      "title": "The Picard operator and its contraction property",
+      "startLine": 50,
+      "endLine": 73,
+      "summary": "Defines pmap g x = x + g x and the Picard operator picard g y x = y − g x, and proves picard_lipschitz / picard_contracting: T_y is k-Lipschitz (inheriting g's constant), hence a contraction for k < 1.",
+      "mathContext": "$\\|T_y a - T_y b\\| = \\|g a - g b\\| \\le k\\|a-b\\|$."
+    },
+    {
+      "id": "inverse",
+      "title": "The constructive inverse",
+      "startLine": 75,
+      "endLine": 117,
+      "summary": "Defines inverse as the fixed point of T_y (inverse, isFixedPt_inverse), proves it solves x + g x = y (inverse_solves) and is the unique solution (inverse_unique).",
+      "mathContext": "$y - g(f^{-1}y) = f^{-1}y \\iff f^{-1}y + g(f^{-1}y) = y$."
+    },
+    {
+      "id": "convergence-bounds",
+      "title": "Convergence and error bounds",
+      "startLine": 119,
+      "endLine": 145,
+      "summary": "tendsto_picard (convergence from any seed), apriori_error (geometric a priori bound), aposteriori_error (computable stopping bound), specialising the ContractingWith convergence and distance estimates to T_y.",
+      "mathContext": "$\\|x_n - f^{-1}y\\| \\le \\|x_n - x_{n+1}\\|/(1-k)$."
+    },
+    {
+      "id": "rate-and-seed",
+      "title": "Linear rate and seed-at-target specialisation",
+      "startLine": 147,
+      "endLine": 157,
+      "summary": "linear_rate (one step contracts the error by k) and apriori_error_seed_target (seed x₀ = y gives first increment ‖g y‖, hence ‖(T_y)ⁿ y − f⁻¹ y‖ ≤ ‖g y‖·kⁿ/(1−k)).",
+      "mathContext": "$\\|T_y x - f^{-1}y\\| \\le k\\|x - f^{-1}y\\|$; seed $y$: $\\|g y\\|\\,k^n/(1-k)$."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Metric",
+      "Function",
+      "Filter",
+      "Topology",
+      "NNReal"
+    ],
+    "namespace": "BanachPicardInverseOQ01OQ02OQ01",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "path": "Proofs/BanachPicardInverseOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Constructive and quantitative refinement of the parent entry **banach-fixed-point-oq-01-oq-02** ("Lipschitz perturbation of the identity is a homeomorphism").

The parent proves `f x = x + g x` (g `k`-Lipschitz, `k < 1`, complete normed group) is a homeomorphism with a `(1-k)⁻¹`-Lipschitz inverse — but only **existentially**. This entry restores the algorithm: solving `f x = y` is the fixed-point equation `x = y - g x` for the Picard operator `T_y x = y - g x`, a `k`-contraction, so `f⁻¹ y` is the limit of `x_{n+1} = y - g x_n` from any seed, with explicit error bounds.

This **directly answers the parent's listed open question #3**: *"Recover f⁻¹ as the explicit limit of the Picard iteration x_{n+1} = y − g x_n with the geometric a priori error estimate kⁿ/(1 − k)."*

## Results (12 theorems, 3 defs, 157 lines)

| Theorem | Statement |
|---|---|
| `inverse` / `inverse_solves` / `inverse_unique` | `f⁻¹ y` as the unique solution of `x + g x = y` |
| `tendsto_picard` | Picard iterates converge to `f⁻¹ y` from any seed |
| `apriori_error` | `‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k)` |
| `aposteriori_error` | `‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k)` (stopping criterion) |
| `linear_rate` | one step contracts the error by `k` |
| `apriori_error_seed_target` | seed `x₀ = y` ⟹ `‖gy‖·kⁿ/(1−k)` |

## Verification

- `#print axioms` on all main theorems: `propext, Classical.choice, Quot.sound` only.
- **0 axioms, 0 sorries, no `native_decide`** (no `Lean.ofReduceBool`), no `sorryAx`.
- Compiled with `lake env lean` against Mathlib 4.26 (docker harness down this cycle).
- Self-contained: re-introduces `f = id + g` locally; the only Mathlib input is the `ContractingWith` fixed-point API and its convergence/error estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)