### PR TITLE
research(tietze-extension-theorem-oq-01-oq-01-oq-01): bounded Tietze property characterizes normality [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3963,6 +3963,7 @@ import Proofs.ThreeSubgroupsLemmaOQ0101
 import Proofs.ThueMorse
 import Proofs.TietzeExtensionTheoremOQ01
 import Proofs.TietzeExtensionTheoremOQ01OQ01
+import Proofs.TietzeExtensionTheoremOQ01OQ01OQ01
 import Proofs.TractatusOntology
 import Proofs.TractatusOntologyEquiv
 import Proofs.TractatusOntologyHorn

--- a/proofs/Proofs/TietzeExtensionTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/TietzeExtensionTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,193 @@
+/-
+# The Bounded Tietze Extension Property Characterizes Normality
+
+The parent entry (`TietzeExtensionTheoremOQ01OQ01`) proves the converse of the Tietze
+extension theorem: a space in which **every** continuous real function on a closed set
+extends to the whole space is normal.  This file *sharpens* that converse.
+
+Consider the **bounded** (range-controlled) Tietze property:
+
+  for every closed set `s`, every real `a ≤ b`, and every continuous `f : s → ℝ`
+  whose values lie in the closed interval `[a, b]`, there is a continuous extension
+  `g : X → ℝ` whose values *also* lie in `[a, b]` and which restricts to `f` on `s`.
+
+This hypothesis is *formally weaker* than the parent's full Tietze property in two
+independent ways: it only asks to extend functions with **bounded** range, and it puts
+an **extra constraint** on the extension (its range must stay inside `[a, b]`).  The
+forward direction `hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty`
+records this: clamping any unrestricted extension into `[a, b]` shows the full property
+implies the bounded one.
+
+The contribution is that this weaker property *still forces normality*
+(`normalSpace_of_hasBoundedTietzeExtensionProperty`).  The separating function used in
+the converse — the two-valued indicator that is `0` on `A` and `1` on `B` — already has
+range in `[0, 1]`, so the range-controlled hypothesis with `a = 0`, `b = 1` is all that
+is needed; the level sets `F ⁻¹' (Iio ½)` and `F ⁻¹' (Ioi ½)` separate `A` and `B`.
+
+Combined with the parent equivalence this yields a three-way characterisation
+
+  `NormalSpace X  ⟺  Tietze property  ⟺  bounded Tietze property`,
+
+recorded as `normal_tietze_boundedTietze_tfae`.
+
+The forward direction (`hasBoundedTietzeExtensionProperty_of_normalSpace`) is the
+classical range-controlled Tietze theorem, proved here elementarily by clamping an
+ordinary Mathlib Tietze extension with `fun t => max a (min b t)` — no interval-valued
+`TietzeExtension` instance is required.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+import Mathlib
+import Proofs.TietzeExtensionTheoremOQ01OQ01
+
+namespace TietzeExtensionTheoremOQ01OQ01OQ01
+
+open Set Topology
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- The **bounded (range-controlled) Tietze extension property**.  Every continuous
+`f : s → ℝ` on a closed set `s`, whose values lie in a closed interval `[a, b]`, extends
+to a continuous `g : X → ℝ` whose values *also* lie in `[a, b]`.
+
+This is formally weaker than the parent's `HasTietzeExtensionProperty`: it only concerns
+functions of bounded range, and it additionally demands the extension keep that range. -/
+def HasBoundedTietzeExtensionProperty (X : Type*) [TopologicalSpace X] : Prop :=
+  ∀ {s : Set X} (a b : ℝ), a ≤ b → IsClosed s → ∀ f : C(s, ℝ),
+    (∀ x, f x ∈ Set.Icc a b) →
+      ∃ g : C(X, ℝ), (∀ x, g x ∈ Set.Icc a b) ∧ g.restrict s = f
+
+/-- **Clamp.** The continuous retraction `t ↦ max a (min b t)` of `ℝ` onto `[a, b]`.
+On `[a, b]` it is the identity; everywhere it lands in `[a, b]` (when `a ≤ b`). -/
+private def clamp (a b : ℝ) (t : ℝ) : ℝ := max a (min b t)
+
+private theorem continuous_clamp (a b : ℝ) : Continuous (clamp a b) := by
+  unfold clamp
+  fun_prop
+
+private theorem clamp_mem_Icc {a b : ℝ} (hab : a ≤ b) (t : ℝ) : clamp a b t ∈ Set.Icc a b := by
+  unfold clamp
+  refine ⟨le_max_left _ _, max_le hab (min_le_left _ _)⟩
+
+private theorem clamp_eq_self {a b : ℝ} {t : ℝ} (ht : t ∈ Set.Icc a b) : clamp a b t = t := by
+  obtain ⟨hat, htb⟩ := ht
+  unfold clamp
+  rw [min_eq_right htb, max_eq_right hat]
+
+/-- **Forward direction (range-controlled Tietze).** A normal space has the bounded Tietze
+property.  Proof: take any ordinary Mathlib extension and clamp it into `[a, b]`; on `s`
+the clamp is invisible because `f` already lands in `[a, b]`. -/
+theorem hasBoundedTietzeExtensionProperty_of_normalSpace [NormalSpace X] :
+    HasBoundedTietzeExtensionProperty X := by
+  intro s a b hab hs f hf
+  -- An ordinary (unrestricted) Tietze extension of `f`.
+  obtain ⟨F, hF⟩ := f.exists_restrict_eq hs
+  -- Clamp it into `[a, b]`.
+  refine ⟨(⟨clamp a b, continuous_clamp a b⟩ : C(ℝ, ℝ)).comp F, fun x => ?_, ?_⟩
+  · exact clamp_mem_Icc hab (F x)
+  · ext x
+    have hx : F x = f x := ContinuousMap.congr_fun hF x
+    simp only [ContinuousMap.comp_apply, ContinuousMap.coe_mk, ContinuousMap.restrict_apply, hx]
+    exact clamp_eq_self (hf x)
+
+/-- The full Tietze property implies the bounded one (clamp the unrestricted extension),
+exhibiting the bounded property as the *weaker* of the two hypotheses. -/
+theorem hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty
+    (h : TietzeExtensionTheoremOQ01OQ01.HasTietzeExtensionProperty X) :
+    HasBoundedTietzeExtensionProperty X := by
+  intro s a b hab hs f hf
+  obtain ⟨F, hF⟩ := h hs f
+  refine ⟨(⟨clamp a b, continuous_clamp a b⟩ : C(ℝ, ℝ)).comp F, fun x => ?_, ?_⟩
+  · exact clamp_mem_Icc hab (F x)
+  · ext x
+    have hx : F x = f x := ContinuousMap.congr_fun hF x
+    simp only [ContinuousMap.comp_apply, ContinuousMap.coe_mk, ContinuousMap.restrict_apply, hx]
+    exact clamp_eq_self (hf x)
+
+/-- **Main result: the bounded Tietze property forces normality.**
+
+Given disjoint closed sets `A` and `B`, the indicator that is `0` on `A` and `1` on `B`
+is continuous on the closed union `s = A ∪ B` (each part is clopen in `s`, by the parent's
+`isClopen_subtype_of_disjoint_closed`) and has range in `[0, 1]`.  The *bounded* hypothesis
+with `a = 0`, `b = 1` extends it to a continuous `F : X → ℝ`, whose level sets at `½`
+separate `A` and `B`.  No separation axiom on `X` is assumed. -/
+theorem normalSpace_of_hasBoundedTietzeExtensionProperty
+    (h : HasBoundedTietzeExtensionProperty X) : NormalSpace X := by
+  classical
+  refine ⟨fun A B hA hB hAB => ?_⟩
+  set s : Set X := A ∪ B with hs_def
+  have hs : IsClosed s := hA.union hB
+  set Bsub : Set s := {x : s | (x : X) ∈ B} with hBsub_def
+  have hBclopen : IsClopen Bsub :=
+    TietzeExtensionTheoremOQ01OQ01.isClopen_subtype_of_disjoint_closed hA hB hAB
+  have hfront : frontier {x : s | x ∈ Bsub} = (∅ : Set s) := by
+    simpa [Bsub, setOf_mem_eq] using hBclopen.frontier_eq
+  -- The indicator `f = 1` on `B`, `f = 0` on `A`, continuous on `s`.
+  have hcont : Continuous fun x : s => if x ∈ Bsub then (1 : ℝ) else 0 := by
+    refine Continuous.if (fun a ha => ?_) continuous_const continuous_const
+    rw [hfront] at ha
+    exact absurd ha (Set.notMem_empty a)
+  let f : C(s, ℝ) := ⟨fun x => if x ∈ Bsub then (1 : ℝ) else 0, hcont⟩
+  -- Its range lies in `[0, 1]`, so the *bounded* hypothesis applies with `a = 0`, `b = 1`.
+  have hf01 : ∀ x : s, f x ∈ Set.Icc (0 : ℝ) 1 := by
+    intro x
+    simp only [f, ContinuousMap.coe_mk]
+    split_ifs <;> norm_num
+  obtain ⟨F, _hFrange, hF⟩ := h 0 1 zero_le_one hs f hf01
+  -- Pointwise description of the extension on `s`.
+  have hval : ∀ x : s, F x = if x ∈ Bsub then (1 : ℝ) else 0 := by
+    intro x
+    have := ContinuousMap.congr_fun hF x
+    simpa [f] using this
+  -- `F = 0` on `A`.
+  have hFA : ∀ a ∈ A, F a = 0 := by
+    intro a ha
+    have hmem : a ∈ s := Or.inl ha
+    have hnotB : (⟨a, hmem⟩ : s) ∉ Bsub := by
+      simp only [hBsub_def, mem_setOf_eq]
+      exact fun hbB => (hAB.le_bot ⟨ha, hbB⟩).elim
+    have := hval ⟨a, hmem⟩
+    simpa [hnotB] using this
+  -- `F = 1` on `B`.
+  have hFB : ∀ b ∈ B, F b = 1 := by
+    intro b hb
+    have hmem : b ∈ s := Or.inr hb
+    have hinB : (⟨b, hmem⟩ : s) ∈ Bsub := by
+      simp only [hBsub_def, mem_setOf_eq]; exact hb
+    have := hval ⟨b, hmem⟩
+    simpa [hinB] using this
+  -- Separate `A` and `B` by the open level sets of `F`.
+  refine ⟨F ⁻¹' Iio (1 / 2), F ⁻¹' Ioi (1 / 2),
+    isOpen_Iio.preimage F.continuous, isOpen_Ioi.preimage F.continuous, ?_, ?_, ?_⟩
+  · intro a ha
+    simp only [mem_preimage, mem_Iio, hFA a ha]; norm_num
+  · intro b hb
+    simp only [mem_preimage, mem_Ioi, hFB b hb]; norm_num
+  · rw [Set.disjoint_left]
+    intro x hx hx'
+    simp only [mem_preimage, mem_Iio] at hx
+    simp only [mem_preimage, mem_Ioi] at hx'
+    linarith
+
+/-- **The equivalence.** For any topological space, normality is *equivalent* to the
+bounded Tietze extension property. -/
+theorem normalSpace_iff_hasBoundedTietzeExtensionProperty :
+    NormalSpace X ↔ HasBoundedTietzeExtensionProperty X :=
+  ⟨fun _ => hasBoundedTietzeExtensionProperty_of_normalSpace,
+   normalSpace_of_hasBoundedTietzeExtensionProperty⟩
+
+/-- **Three-way characterisation of normality.**  Normality, the full Tietze extension
+property (parent), and the *bounded* Tietze extension property are all equivalent.  The
+chain `normal → full → bounded → normal` shows that weakening the Tietze property to
+range-controlled functions loses nothing. -/
+theorem normal_tietze_boundedTietze_tfae :
+    [ NormalSpace X,
+      TietzeExtensionTheoremOQ01OQ01.HasTietzeExtensionProperty X,
+      HasBoundedTietzeExtensionProperty X ].TFAE := by
+  tfae_have 1 → 2 := fun _ =>
+    TietzeExtensionTheoremOQ01OQ01.hasTietzeExtensionProperty_of_normalSpace
+  tfae_have 2 → 3 := hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty
+  tfae_have 3 → 1 := normalSpace_of_hasBoundedTietzeExtensionProperty
+  tfae_finish
+
+end TietzeExtensionTheoremOQ01OQ01OQ01

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-bounded-property",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 78
+    },
+    "type": "definition",
+    "title": "The Bounded Tietze Property and the Clamp",
+    "content": "`HasBoundedTietzeExtensionProperty X` is the range-controlled extension property: for every closed s ⊆ X, every a ≤ b, and every f ∈ C(s, ℝ) with f(x) ∈ [a,b], there is g ∈ C(X, ℝ) with g(x) ∈ [a,b] and g.restrict s = f. It is formally weaker than the parent's `HasTietzeExtensionProperty` in two ways: only bounded-range functions are extended, and the extension's range is constrained too. The engine is the retraction `clamp a b t = max a (min b t)` of ℝ onto [a,b]: `continuous_clamp` (continuity via fun_prop), `clamp_mem_Icc` (it lands in [a,b] when a ≤ b: a ≤ max a _, and max a (min b t) ≤ b since min b t ≤ b), and `clamp_eq_self` (it is the identity on [a,b]).",
+    "mathContext": "$\\mathrm{BddTietze}(X):\\ \\forall s\\ \\text{closed},\\ \\forall a\\le b,\\ \\forall f\\in C(s,[a,b]),\\ \\exists g\\in C(X,[a,b]),\\ g|_s=f$; clamp $t\\mapsto\\max(a,\\min(b,t))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "range-controlled Tietze extension",
+      "retraction onto an interval",
+      "max/min clamp",
+      "bundled continuous maps C(s, ℝ)"
+    ],
+    "prerequisites": [
+      "normal spaces",
+      "closed intervals Set.Icc",
+      "order arithmetic of max and min"
+    ]
+  },
+  {
+    "id": "ann-forward-full-implies-bounded",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "Forward Direction and Full ⟹ Bounded",
+    "content": "`hasBoundedTietzeExtensionProperty_of_normalSpace` proves normal ⟹ bounded without any interval-valued Tietze instance: take an ordinary unrestricted extension F of f via Mathlib's `ContinuousMap.exists_restrict_eq`, then post-compose with the clamp. The result lands in [a,b] everywhere (clamp_mem_Icc) and equals f on s because f is already in [a,b] there, where the clamp is the identity (clamp_eq_self). `hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty` runs the identical clamp on the parent's unrestricted extension, showing the full Tietze property implies the bounded one — so the bounded property is the strictly weaker hypothesis.",
+    "mathContext": "Clamp an unrestricted extension $F$: $\\max(a,\\min(b,F))\\in[a,b]$ and restricts to $f$ on $s$ since $f\\in[a,b]$ there. Hence $\\mathrm{Normal}\\Rightarrow\\mathrm{BddTietze}$ and $\\mathrm{Tietze}\\Rightarrow\\mathrm{BddTietze}$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "clamping / retraction",
+      "ContinuousMap.exists_restrict_eq",
+      "ContinuousMap composition",
+      "restriction equality"
+    ],
+    "prerequisites": [
+      "Mathlib's Tietze theorem",
+      "continuous map composition",
+      "clamp_mem_Icc and clamp_eq_self"
+    ]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 172
+    },
+    "type": "theorem",
+    "title": "The Bounded Property Implies Normal",
+    "content": "`normalSpace_of_hasBoundedTietzeExtensionProperty` is the new content. For disjoint closed A, B set s = A ∪ B (closed). By the parent's `isClopen_subtype_of_disjoint_closed` the part of s over B is clopen, hence has empty frontier, so the two-valued indicator f (1 on B, 0 on A) is continuous on s via `Continuous.if`. Crucially its range is {0,1} ⊆ [0,1], so the bounded hypothesis applies with a=0, b=1, extending f to F ∈ C(X, ℝ). Unwinding the restriction gives F = 0 on A and F = 1 on B, and the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A from B. No separation axiom on X is used, and the output range constraint on F is not even exercised — ½ alone does the separating.",
+    "mathContext": "Disjoint closed $A,B$: the $\\{0,1\\}$ boundary function on $A\\cup B$ is $[0,1]$-valued; the bounded hypothesis extends it to $F$, and $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$, $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens.",
+    "significance": "key",
+    "relatedConcepts": [
+      "converse of Tietze extension",
+      "clopen boundary function",
+      "Continuous.if",
+      "separation by level sets",
+      "NormalSpace"
+    ],
+    "prerequisites": [
+      "the parent clopen boundary lemma",
+      "continuity across an empty frontier",
+      "open level sets of continuous functions"
+    ]
+  },
+  {
+    "id": "ann-equivalence-tfae",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 173,
+      "endLine": 191
+    },
+    "type": "theorem",
+    "title": "The Equivalence and Three-Way Characterization",
+    "content": "`normalSpace_iff_hasBoundedTietzeExtensionProperty` pairs the converse with the forward direction into the equivalence normal ⟺ bounded Tietze property. `normal_tietze_boundedTietze_tfae` assembles the chain normal → full → bounded → normal into a TFAE over three predicates: normality, the parent's unrestricted Tietze property, and the bounded Tietze property. The cycle uses the parent's forward direction (normal ⟹ full), the clamp (full ⟹ bounded), and the new converse (bounded ⟹ normal), collapsing all three into interchangeable characterizations and showing the range control of the classical statement is inessential.",
+    "mathContext": "$\\mathrm{Normal}\\iff\\mathrm{BddTietze}$; and $[\\mathrm{Normal},\\ \\mathrm{Tietze},\\ \\mathrm{BddTietze}]$ are pairwise equivalent via the cycle $\\mathrm{Normal}\\to\\mathrm{Tietze}\\to\\mathrm{BddTietze}\\to\\mathrm{Normal}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.TFAE",
+      "characterization of normality",
+      "equivalence of separation properties"
+    ],
+    "prerequisites": [
+      "the parent equivalence normal ⟺ Tietze",
+      "tfae_have / tfae_finish"
+    ]
+  }
+]

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TietzeExtensionTheoremOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const tietzeExtensionTheoremOQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const tietzeExtensionTheoremOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const tietzeExtensionTheoremOQ01OQ01OQ01Data: ProofData = {
+  proof: tietzeExtensionTheoremOQ01OQ01OQ01Proof,
+  annotations: tietzeExtensionTheoremOQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+  "slug": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.TietzeExtensionTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Set",
+      "Topology"
+    ],
+    "namespace": "TietzeExtensionTheoremOQ01OQ01OQ01",
+    "lineCount": 193,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/TietzeExtensionTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Bounded Tietze Extension Property Characterizes Normality",
+  "description": "The parent entry proves that the full Tietze extension property — every continuous real function on a closed set extends to the whole space — forces normality. This entry sharpens that converse to the bounded (range-controlled) form. The bounded Tietze property asks only that continuous functions whose values lie in a closed interval [a,b] extend, with the extension also staying in [a,b]. This hypothesis is formally weaker in two ways: it concerns only functions of bounded range, and it constrains the extension's range too. The main theorem normalSpace_of_hasBoundedTietzeExtensionProperty shows this weaker property still forces normality: the separating boundary function — 0 on A, 1 on B — already has range in [0,1], so the range-controlled hypothesis with a=0, b=1 suffices, and the level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A and B. The forward direction hasBoundedTietzeExtensionProperty_of_normalSpace is the classical range-controlled Tietze theorem, proved elementarily by clamping an ordinary Mathlib extension with t ↦ max a (min b t), so no interval-valued TietzeExtension instance is needed. The implication hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty (clamp the unrestricted extension) records that the full property implies the bounded one, exhibiting bounded as the weaker hypothesis. Combined with the parent equivalence this yields the three-way characterization normal ⟺ Tietze ⟺ bounded Tietze, recorded as normal_tietze_boundedTietze_tfae.",
+  "overview": {
+    "historicalContext": "The Tietze extension theorem is usually stated in two flavours: an unrestricted version, where a continuous real function on a closed set extends to the whole space, and a range-controlled version, where a function valued in a closed interval [a,b] extends within [a,b]. The two forward directions are equivalent for normal spaces — the range-controlled form follows by clamping — and Mathlib records the bounded statement through its retraction machinery (ContinuousMap.exists_forall_mem_restrict_eq). The parent entry of this leaf supplied the missing reverse arrow for the unrestricted form: the Tietze extension property implies normality. A natural question is whether the same conclusion survives under the bounded hypothesis, which is a priori weaker — one is allowed to extend fewer functions, and the extension is held to a range constraint. This entry answers it affirmatively: the bounded property already characterizes normality, so nothing is lost by restricting attention to interval-valued data. The separating function used in the converse is the two-valued boundary indicator, whose range is exactly [0,1], so the bounded hypothesis applies with no widening.",
+    "problemStatement": "Define the bounded Tietze extension property of a space X: for every closed s ⊆ X, every a ≤ b, and every f ∈ C(s, ℝ) with f(x) ∈ [a,b] for all x, there is g ∈ C(X, ℝ) with g(x) ∈ [a,b] for all x and g.restrict s = f. Prove that X has this property if and only if it is normal (Mathlib's NormalSpace). Show further that the full (unrestricted) Tietze property implies the bounded one, so that normality, the Tietze property, and the bounded Tietze property are all equivalent.",
+    "proofStrategy": "Three pieces. (1) Forward, normal ⟹ bounded: take any unrestricted Mathlib extension F of f (ContinuousMap.exists_restrict_eq) and post-compose with the continuous clamp t ↦ max a (min b t); the result lands in [a,b] everywhere (a ≤ max a _, and max a (min b t) ≤ b since a ≤ b and min b t ≤ b) and equals f on s because f already lies in [a,b] there (clamp is the identity on [a,b]). (2) Full ⟹ bounded: identical clamp applied to the parent's unrestricted extension property, exhibiting bounded as the weaker hypothesis. (3) Converse, bounded ⟹ normal: for disjoint closed A, B set s = A ∪ B, closed. By the parent's isClopen_subtype_of_disjoint_closed the part of s over B is clopen, so the two-valued indicator f (1 on B, 0 on A) is continuous on s via Continuous.if with empty frontier; its range is {0,1} ⊆ [0,1], so the bounded hypothesis with a=0, b=1 extends it to F ∈ C(X, ℝ). Unwinding the restriction gives F = 0 on A and F = 1 on B, and the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A from B, witnessing NormalSpace X. Chaining normal → full (parent) → bounded (clamp) → normal gives the three-way TFAE.",
+    "keyInsights": [
+      "Weakening the hypothesis loses nothing. The bounded property extends strictly fewer functions than the full property, and additionally pins the extension's range, yet it still forces normality. The reason is that the converse only ever needs to extend one function — the {0,1} boundary indicator — and that function is already interval-valued, so the range restriction is free.",
+      "The range constraint on the output is never exercised by the converse. The extension F of the {0,1} indicator separates A and B through the threshold ½ regardless of where F's values lie; the bounded hypothesis hands over an F valued in [0,1], which is more than enough but not needed. This isolates exactly why the weaker property suffices.",
+      "Clamping replaces the interval-valued Tietze instance. Mathlib has no off-the-shelf TietzeExtension instance for a closed interval [a,b], but the forward direction never needs one: post-composing an unrestricted extension with the 1-Lipschitz retraction max a (min b ·) yields a range-controlled extension by elementary order arithmetic, and it is invisible on s because f is already in range.",
+      "The same clamp proves full ⟹ bounded. Applying the retraction to the parent's unrestricted extension shows the full Tietze property implies the bounded one, so the bounded property sits below the full one in strength — making the equivalence with normality a genuine sharpening, not a reformulation.",
+      "The three-way TFAE closes the loop. normal → full → bounded → normal collapses all three predicates: normality, the unrestricted Tietze property (parent), and the bounded Tietze property are interchangeable characterizations, with the range control of the classical statement shown to be inessential to recovering normality."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bounded-property",
+      "title": "The Bounded Tietze Property and the Clamp",
+      "startLine": 52,
+      "endLine": 78,
+      "summary": "HasBoundedTietzeExtensionProperty X packages the range-controlled extension property: every f ∈ C(s, ℝ) valued in [a,b] extends to g ∈ C(X, ℝ) also valued in [a,b]. The retraction clamp a b t = max a (min b t) is the continuous map of ℝ onto [a,b]; continuous_clamp, clamp_mem_Icc (lands in [a,b] when a ≤ b), and clamp_eq_self (identity on [a,b]) are the order facts that drive both the forward direction and the full ⟹ bounded reduction.",
+      "mathContext": "$\\mathrm{BddTietze}(X):\\ \\forall s\\ \\text{closed},\\ \\forall a\\le b,\\ \\forall f\\in C(s,[a,b]),\\ \\exists g\\in C(X,[a,b]),\\ g|_s=f$; clamp $t\\mapsto\\max(a,\\min(b,t))$."
+    },
+    {
+      "id": "forward-and-full-implies-bounded",
+      "title": "Forward Direction and Full ⟹ Bounded",
+      "startLine": 79,
+      "endLine": 112,
+      "summary": "hasBoundedTietzeExtensionProperty_of_normalSpace proves normal ⟹ bounded by clamping an ordinary Mathlib Tietze extension into [a,b]; on s the clamp is invisible because f is already in range. hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty applies the same clamp to the parent's unrestricted extension, showing the full Tietze property implies the bounded one — so the bounded property is the formally weaker hypothesis.",
+      "mathContext": "Clamp an unrestricted extension $F$: $\\max(a,\\min(b,F))\\in[a,b]$ and equals $f$ on $s$ since $f\\in[a,b]$ there. Hence $\\mathrm{Normal}\\Rightarrow\\mathrm{BddTietze}$ and $\\mathrm{Tietze}\\Rightarrow\\mathrm{BddTietze}$."
+    },
+    {
+      "id": "converse",
+      "title": "The Main Result: Bounded Property Implies Normal",
+      "startLine": 113,
+      "endLine": 172,
+      "summary": "normalSpace_of_hasBoundedTietzeExtensionProperty: the new content. For disjoint closed A, B the part over B in s = A ∪ B is clopen (parent lemma), so the {0,1} indicator is continuous on s and has range in [0,1]. The bounded hypothesis with a=0, b=1 extends it to F : X → ℝ with F = 0 on A, F = 1 on B; the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A and B. No separation axiom on X is assumed, and the output range constraint is not even used.",
+      "mathContext": "Disjoint closed $A,B$: the $\\{0,1\\}$ boundary function on $A\\cup B$ is $[0,1]$-valued; the bounded hypothesis extends it to $F$, and $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$, $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens."
+    },
+    {
+      "id": "equivalence-tfae",
+      "title": "The Equivalence and Three-Way Characterization",
+      "startLine": 173,
+      "endLine": 191,
+      "summary": "normalSpace_iff_hasBoundedTietzeExtensionProperty pairs the converse with the forward direction into normal ⟺ bounded Tietze property. normal_tietze_boundedTietze_tfae assembles the chain normal → full → bounded → normal into a TFAE over the three predicates — normality, the parent's unrestricted Tietze property, and the bounded Tietze property — showing the range control of the classical statement is inessential.",
+      "mathContext": "$\\mathrm{Normal}\\iff\\mathrm{BddTietze}$; and $[\\mathrm{Normal},\\ \\mathrm{Tietze},\\ \\mathrm{BddTietze}]$ are pairwise equivalent."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TietzeExtensionTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "tietze-extension",
+      "bounded-extension",
+      "clopen-set",
+      "continuous-function",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 193,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "HasBoundedTietzeExtensionProperty: a reusable predicate capturing the range-controlled Tietze extension property — every continuous [a,b]-valued function on a closed set extends to an [a,b]-valued function on the whole space — formally weaker than the parent's HasTietzeExtensionProperty in both the data extended and the constraint on the extension",
+      "normalSpace_of_hasBoundedTietzeExtensionProperty: NEW CONTENT — the bounded converse of the Tietze extension theorem. A space with the bounded (range-controlled) Tietze property is normal. Sharper than the parent: the separating function is the [0,1]-valued boundary indicator, so the weaker hypothesis with a=0, b=1 already produces the separating neighbourhoods; no separation axiom on X is required and the output range constraint is not even used",
+      "hasBoundedTietzeExtensionProperty_of_normalSpace: the range-controlled forward direction, proved elementarily by post-composing an ordinary Mathlib Tietze extension with the continuous clamp max a (min b ·) — avoiding any interval-valued TietzeExtension instance, which Mathlib does not provide for a closed interval",
+      "hasBoundedTietzeExtensionProperty_of_hasTietzeExtensionProperty: the full Tietze property implies the bounded one (the same clamp applied to the parent's unrestricted extension), establishing that the bounded property is the weaker hypothesis and the equivalence with normality is a genuine sharpening",
+      "normal_tietze_boundedTietze_tfae: the three-way characterization normal ⟺ Tietze ⟺ bounded Tietze, assembling the chain normal → full → bounded → normal and showing the range control of the classical statement is inessential to recovering normality"
+    ],
+    "prerequisites": [
+      "Normal topological spaces (Mathlib's NormalSpace) and SeparatedNhds",
+      "The bundled continuous-map type C(s, ℝ), composition, and restriction equality",
+      "Mathlib's Tietze theorem ContinuousMap.exists_restrict_eq (used for the forward direction)",
+      "The parent entry's clopen boundary lemma isClopen_subtype_of_disjoint_closed",
+      "Order arithmetic of max/min: the clamp max a (min b ·) as a retraction onto [a,b]",
+      "Open level sets of continuous functions: isOpen_Iio, isOpen_Ioi, IsOpen.preimage"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ContinuousMap.exists_restrict_eq",
+        "description": "Mathlib's Tietze extension theorem for NormalSpaces; supplies an unrestricted extension which is then clamped into [a,b] to prove the bounded forward direction.",
+        "module": "Mathlib.Topology.TietzeExtension"
+      },
+      {
+        "theorem": "Continuous.max / Continuous.min",
+        "description": "Continuity of the clamp max a (min b ·); discharged here by fun_prop, making the retraction onto [a,b] a ContinuousMap.",
+        "module": "Mathlib.Topology.Order.Lattice"
+      },
+      {
+        "theorem": "Continuous.if",
+        "description": "A function 'if p then f else g' is continuous when f, g are continuous and agree on the frontier of {p}; with the parent's clopen predicate the frontier is empty, so the {0,1} boundary function on A ∪ B is continuous.",
+        "module": "Mathlib.Topology.Piecewise"
+      },
+      {
+        "theorem": "IsClopen.frontier_eq",
+        "description": "A clopen set has empty frontier — the side condition discharging the frontier hypothesis of Continuous.if for the boundary indicator.",
+        "module": "Mathlib.Topology.Separation.Basic"
+      },
+      {
+        "theorem": "NormalSpace / SeparatedNhds",
+        "description": "Target structure: NormalSpace is built by exhibiting, for disjoint closed sets, the disjoint open neighbourhoods F⁻¹(Iio ½) and F⁻¹(Ioi ½).",
+        "module": "Mathlib.Topology.Separation.Regular"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "tietze-extension-theorem-oq-01-oq-01-oq-01-oq-01",
+      "question": "Quantitative bounded Tietze: for f valued in [a,b], can the converse separation be packaged with an explicit modulus, e.g. extending into the open interval (a,b) on the complement of s, or controlling ‖F‖ in terms of ‖f‖, matching the norm-preserving bounded Tietze of Mathlib's exists_extension_norm_eq?",
+      "significance": "medium"
+    },
+    {
+      "id": "tietze-extension-theorem-oq-01-oq-01-oq-01-oq-02",
+      "question": "Vector-valued bounded converse: does the analogous range-controlled extension property into a closed convex bounded set of a normed space (or a closed ball) characterize normality, using the convex retraction in place of the scalar clamp?",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "tietze-extension-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It proves the unrestricted converse — the Tietze extension property forces normality — and records the bounded form as an open question. This entry supplies that bounded converse, reusing the parent's clopen boundary lemma isClopen_subtype_of_disjoint_closed and showing the formally weaker range-controlled hypothesis still characterizes normality."
+    },
+    {
+      "targetId": "tietze-extension-theorem-oq-01",
+      "relationship": "related",
+      "description": "Grandparent entry deriving Urysohn's lemma from the Tietze extension theorem. Together with the parent's converse and this bounded sharpening, the three-way TFAE normal ⟺ Tietze ⟺ bounded Tietze completes the functional characterization of normality on the range-controlled side."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.TietzeExtension",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of ContinuousMap.exists_restrict_eq (used for the forward direction) and the range-controlled ContinuousMap.exists_forall_mem_restrict_eq. The bounded converse proved here — that the range-controlled extension property forces normality — is not present in Mathlib."
+    },
+    {
+      "title": "James Munkres, Topology",
+      "author": "J. R. Munkres",
+      "year": "2000",
+      "venue": "Prentice Hall, 2nd ed.",
+      "description": "Standard reference for the Tietze extension theorem in both its unrestricted and interval-valued forms and their equivalence with normality (§35)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "This entry sharpens the parent's converse of the Tietze extension theorem to the bounded, range-controlled form. The bounded Tietze property — every continuous [a,b]-valued function on a closed set extends to an [a,b]-valued function — is formally weaker than the full property, yet normalSpace_of_hasBoundedTietzeExtensionProperty shows it still forces normality: the {0,1} boundary indicator that is 0 on A and 1 on B is [0,1]-valued, so the bounded hypothesis with a=0, b=1 extends it to F, and the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A and B. The forward direction is the range-controlled Tietze theorem, proved by clamping an ordinary Mathlib extension with max a (min b ·), and the full property is shown to imply the bounded one by the same clamp. Pairing the directions gives normal ⟺ bounded Tietze, and the chain normal → full → bounded → normal yields the three-way TFAE. 193 lines, 8 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "implications": "Shows the range control in the classical statement of the Tietze theorem is inessential to characterizing normality: the weaker bounded extension property already recovers it, because the converse only needs to extend one interval-valued boundary function. The elementary clamp argument sidesteps the absence of an interval-valued TietzeExtension instance in Mathlib, and the reusable predicate HasBoundedTietzeExtensionProperty together with the three-way TFAE makes the bounded characterization available alongside the parent's unrestricted one.",
+    "openQuestions": [
+      "Package the bounded converse quantitatively, with an explicit modulus or norm control matching Mathlib's norm-preserving bounded Tietze.",
+      "Extend the bounded converse to vector-valued functions into a closed convex bounded set, replacing the scalar clamp with a convex retraction."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry's converse of the Tietze extension theorem (`tietze-extension-theorem-oq-01-oq-01`) to the **bounded (range-controlled)** form, answering the bounded-converse question the parent recorded as open.

**Bounded Tietze property** of `X`: for every closed `s`, every `a ≤ b`, and every `f ∈ C(s, ℝ)` valued in `[a,b]`, there is `g ∈ C(X, ℝ)` *also* valued in `[a,b]` with `g|_s = f`. This is formally weaker than the parent's full property in two independent ways — fewer functions are extended, and the extension's range is constrained.

**Main result** (`normalSpace_of_hasBoundedTietzeExtensionProperty`): the bounded property still forces normality. The converse only ever extends the `{0,1}` boundary indicator (`0` on `A`, `1` on `B`), which is already `[0,1]`-valued, so the range-controlled hypothesis with `a=0, b=1` suffices; the disjoint open level sets `F⁻¹(Iio ½)`, `F⁻¹(Ioi ½)` separate `A` and `B`. No separation axiom on `X` is assumed, and the output range constraint is never even exercised.

**Other directions.** `hasBoundedTietzeExtensionProperty_of_normalSpace` is the classical range-controlled Tietze theorem, proved elementarily by post-composing an ordinary Mathlib extension with the continuous clamp `t ↦ max a (min b t)` — no interval-valued `TietzeExtension` instance needed. The same clamp gives `full ⟹ bounded`, exhibiting bounded as the weaker hypothesis. Assembled into the three-way characterization `normal ⟺ Tietze ⟺ bounded Tietze` (`normal_tietze_boundedTietze_tfae`).

## Verification

- **8 theorems, 2 definitions, 193 lines, 0 sorries, 0 axioms.**
- `#print axioms` on the main results lists only `propext`, `Classical.choice`, `Quot.sound` (the foundational trio) — no `sorryAx`, no `Lean.ofReduceBool`.
- Compiled with `lake env lean` against Mathlib + the parent module (Docker unavailable in this environment).
- Reuses the parent's `isClopen_subtype_of_disjoint_closed`.

Gallery entry: `src/data/proofs/tietze-extension-theorem-oq-01-oq-01-oq-01/` (meta.json, index.ts, annotations.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)