### PR TITLE
Enrich Kempner value of a squarefree semiprime S(p·q)=max(p,q): add index.ts + annotations

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "wilson-oq0501010101-ann-header",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 46 },
+    "type": "context",
+    "title": "From prime powers to squarefree semiprimes",
+    "content": "The parent entry computed the Kempner–Smarandache function S(n) = min{m : n ∣ m!} on prime powers (S(p^k) = p·k ⟺ k ≤ p) and posed the assembly question: S of a general n is the maximum of its values on the prime-power factors, S(n) = max over p^k ‖ n of S(p^k). This file settles the first genuinely multi-prime instance — the squarefree semiprime n = p·q with p ≠ q prime — where each prime appears to the first power, S(p) = p and S(q) = q, so the law predicts S(p·q) = max(p, q). Crucially, no Legendre p-adic valuation machinery is required here: with each prime to the first power the entire argument is the single criterion 'a prime divides n! iff it is ≤ n' plus coprimality of distinct primes.",
+    "mathContext": "$S(m) = \\min\\{n : m \\mid n!\\}$; for distinct primes $p,q$: $S(p\\cdot q) = \\max(p,q) = \\max(S(p), S(q))$.",
+    "significance": "context",
+    "relatedConcepts": ["Kempner function", "Smarandache function", "squarefree semiprime", "maximum over prime powers"],
+    "prerequisites": ["factorials and divisibility", "the parent prime-power value S(p^k)"]
+  },
+  {
+    "id": "wilson-oq0501010101-ann-def",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "definition",
+    "title": "The Kempner–Smarandache function, self-contained",
+    "content": "S m := sInf {n | m ∣ n!}, the least n whose factorial is divisible by m, re-established so the file stands alone. Two lemmas pin its specification. dvd_factorial_S (m ∣ (S m)! for m ≥ 1) shows S m is a genuine witness: the defining set is nonempty because m ∣ m! (Nat.dvd_factorial with le_rfl), so Nat.sInf_mem applies. S_le (any n with m ∣ n! satisfies S m ≤ n) is the minimality, directly from Nat.sInf_le. Together they characterize S m as the least element of {n | m ∣ n!}, the only interface the semiprime computation needs.",
+    "mathContext": "$S(m) = \\inf\\{n \\in \\mathbb{N} \\mid m \\mid n!\\}$; well defined for $m\\ge1$ since $m \\mid m!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sInf", "least-element operator", "Nat.dvd_factorial", "Nat.sInf_mem"],
+    "prerequisites": ["the infimum on ℕ and its membership/minimality lemmas"]
+  },
+  {
+    "id": "wilson-oq0501010101-ann-upper",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 83 },
+    "type": "technique",
+    "title": "Upper bound: coprimality assembles the witness",
+    "content": "semiprime_dvd_factorial_max proves p·q ∣ (max p q)!, exhibiting max p q as a Kempner witness for p·q. Each prime is ≤ max p q, so by Nat.Prime.dvd_factorial each divides (max p q)! individually. Being distinct primes they are coprime (Nat.coprime_primes), so Nat.Coprime.mul_dvd_of_dvd_of_dvd combines the two single-prime divisibilities into the product p·q ∣ (max p q)!. Coprimality is the sole assembly tool — the squarefree shadow of the CRT-style combination that would assemble S on a general n. With this witness, S_le immediately gives S(p·q) ≤ max p q.",
+    "mathContext": "$p,q \\le \\max(p,q) \\Rightarrow p \\mid (\\max p\\,q)! \\wedge q \\mid (\\max p\\,q)!$; $\\gcd(p,q)=1 \\Rightarrow p\\cdot q \\mid (\\max p\\,q)!$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.Prime.dvd_factorial", "Nat.coprime_primes", "Nat.Coprime.mul_dvd_of_dvd_of_dvd", "coprime divisors"],
+    "prerequisites": ["a prime divides n! iff it is ≤ n", "coprime divisors multiply into the dividend"]
+  },
+  {
+    "id": "wilson-oq0501010101-ann-value",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 98 },
+    "type": "insight",
+    "title": "The closed form S(p·q) = max(p, q) by antisymmetry",
+    "content": "S_semiprime is the headline result, proved by le_antisymm of two bounds. The upper bound S(p·q) ≤ max p q is the witness from semiprime_dvd_factorial_max. The lower bound runs divisibility backwards: by dvd_factorial_S, p·q ∣ (S(p·q))!, so p ∣ (S(p·q))! and q ∣ (S(p·q))! (via dvd_mul_right / dvd_mul_left and transitivity); Nat.Prime.dvd_factorial then forces p ≤ S(p·q) and q ≤ S(p·q), i.e. max p q ≤ S(p·q). The single criterion 'prime divides factorial iff index reaches it' thus drives both directions — forward for the upper bound, backward for the lower. The value equals max(S(p), S(q)), confirming the maximum-over-prime-powers law in its first multi-prime case.",
+    "mathContext": "$S(p\\cdot q) \\le \\max(p,q)$ (witness) and $p\\cdot q \\mid (S(p\\cdot q))! \\Rightarrow p,q \\le S(p\\cdot q)$, so $\\max(p,q) = S(p\\cdot q)$.",
+    "significance": "key",
+    "relatedConcepts": ["antisymmetry", "Nat.Prime.dvd_factorial", "least-witness property", "maximum over prime powers"],
+    "prerequisites": ["the upper-bound witness", "minimality of S", "le_antisymm"]
+  },
+  {
+    "id": "wilson-oq0501010101-ann-drop",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 112 },
+    "type": "insight",
+    "title": "The Kempner drop, made exact",
+    "content": "S_semiprime_lt_self computes the strict drop S(p·q) = max(p,q) < p·q. After rewriting by S_semiprime, max_lt reduces it to p < p·q and q < p·q, each delivered by lt_mul_of_one_lt_right / lt_mul_of_one_lt_left since both primes exceed 1. The grandparent threshold theorem (∃ m < n, n ∣ m!) ↔ (¬ n.Prime ∧ n ≠ 4) only guarantees that some drop occurs for composite n ≠ 4; here the value of the drop is pinned precisely, with deficit p·q − max(p,q) = max(p,q)·(min(p,q) − 1). S_semiprime_comm records that S sees only the product (max_comm), so the value is symmetric in the two primes.",
+    "mathContext": "$S(p\\cdot q) = \\max(p,q) < p\\cdot q$; deficit $p\\cdot q - \\max(p,q) = \\max(p,q)\\,(\\min(p,q)-1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Kempner drop", "lt_mul_of_one_lt_right", "max_lt", "threshold theorem"],
+    "prerequisites": ["the closed form S(p·q) = max(p,q)", "order lemmas for products of naturals"]
+  },
+  {
+    "id": "wilson-oq0501010101-ann-sanity",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 126 },
+    "type": "context",
+    "title": "Numeric sanity checks by plain decide",
+    "content": "Three concrete evaluations confirm the closed form against the smaller prime: S(6) = 3, S(15) = 5, S(35) = 7. Each rewrites by S_semiprime (supplying primality of the two factors and their distinctness) and discharges the residual max computation with plain decide — kernel reduction, NOT native_decide — so the file introduces no Lean.ofReduceBool axiom and remains genuinely 0-axiom beyond the foundational propext, Classical.choice, Quot.sound. The examples double as a guard against an off-by-one in which prime is selected: each result is max(p,q), the larger prime.",
+    "mathContext": "$S(2\\cdot3)=3,\\ S(3\\cdot5)=5,\\ S(5\\cdot7)=7$ — each $=\\max(p,q)$, the larger factor.",
+    "significance": "technical",
+    "relatedConcepts": ["decide vs native_decide", "kernel reduction", "axiom integrity", "regression checks"],
+    "prerequisites": ["decidable equality on ℕ", "the closed-form theorem S_semiprime"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01OQ01Data: ProofData = {
+  proof: wilsonsTheoremOQ05OQ01OQ01OQ01OQ01Proof,
+  annotations: wilsonsTheoremOQ05OQ01OQ01OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01-oq-01-oq-01-oq-01` (The Kempner–Smarandache value of a squarefree semiprime).

## Gap addressed
This entry had a rich `meta.json` but was **missing both `index.ts` and `annotations.json`**. Without `index.ts`, Vite's `import.meta.glob` cannot discover the proof, so the page renders **"proof not found"** on the live site even though the entry appears in the gallery listing.

## Changes
- **`index.ts`** — created from the standard template (matches the parent entry verbatim), wiring `meta.json`, `annotations.json`, and the raw Lean source for `Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01OQ01.lean`.
- **`annotations.json`** — 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
  1. Header context — prime-power → squarefree-semiprime assembly, why no Legendre machinery is needed
  2. The self-contained Kempner function `S m = sInf {n | m ∣ n!}` with `dvd_factorial_S` / `S_le`
  3. Upper bound `semiprime_dvd_factorial_max` — coprimality assembles `p·q ∣ (max p q)!`
  4. The closed form `S_semiprime` — `S(p·q) = max(p,q)` by antisymmetry
  5. The explicit Kempner drop `S_semiprime_lt_self` with exact deficit
  6. The `decide`-based numeric sanity checks (and why they stay 0-axiom, not `native_decide`)

## Verification
- `tsc --noEmit` passes cleanly (0 errors).
- The build's data-generation step parses all `meta.json`/`annotations.json` without error.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` — consistent with the Lean file (0 sorries, plain `decide` not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)