### PR TITLE
research(menelaus-theorem-oq-01-oq-01-oq-01): realisable sign patterns biconditional [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3393,6 +3393,7 @@ import Proofs.MeanValueTheoremOQ04
 import Proofs.MeanValueTheoremOQ05
 import Proofs.MenelausTheorem
 import Proofs.MenelausTheoremOQ01
+import Proofs.MenelausTheoremOQ01OQ01OQ01
 import Proofs.MidyTheorem
 import Proofs.MinkowskiFundamentalTheorem
 import Proofs.MinkowskiFundamentalTheoremOQ01

--- a/proofs/Proofs/MenelausTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/MenelausTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,257 @@
+import Proofs.MenelausTheoremOQ01
+import Mathlib.Tactic
+
+/-
+# Menelaus follow-up: realisable sign patterns (biconditional characterisation)
+
+Open question: `menelaus-theorem-oq-01-oq-01-oq-01`
+Parent: `Proofs/MenelausTheoremOQ01.lean` (`menelaus-theorem-oq-01-oq-01`).
+
+## What this adds
+
+The parent proves the *forward* parity dichotomy: a collinear transversal
+(`menelausProduct cfg = -1`) forces an **odd** number of the three division points to be
+external (`external_parity_odd`), and the Ceva value `+1` forces an **even** number
+(`external_parity_even`). Those are one-directional: they say "if a configuration exists,
+its sign pattern has the stated parity".
+
+This file proves the **converse / realisability** direction and packages both into sharp
+biconditionals. A sign pattern `(sX, sY, sZ) ∈ Bool³` (where `sᵢ = true` means "point `i`
+is external", i.e. its signed ratio is negative) is **realisable by a genuine
+non-degenerate transversal with product `-1`** *if and only if* it has an odd number of
+`true`s. Symmetrically, it is realisable with product `+1` iff it has an even number.
+
+The forward implication reuses the parent's parity theorems; the backward (existence)
+implication is the new content — four explicit witness configurations on the fixed
+triangle `(0,0),(1,0),(0,1)`, one realising each admissible pattern.
+
+`odd #true` is encoded as `sX ^^ sY ^^ sZ = true` (`xor` of the three bits), `even` as
+`= false`.
+
+## Status
+- [x] Four explicit witnesses for the odd (Menelaus) patterns
+- [x] Four explicit witnesses for the even (Ceva) patterns
+- [x] `realisable_iff_odd`: product `-1` realisability ⟺ odd parity
+- [x] `realisable_iff_even`: product `+1` realisability ⟺ even parity
+- [x] 0 sorries, 0 axioms
+-/
+
+namespace MenelausTheoremOQ01OQ01OQ01
+
+open MenelausTheorem MenelausTheoremOQ01
+
+set_option linter.unusedVariables false
+
+/-! ### Sign ↔ boolean bookkeeping helpers -/
+
+/-- Package "`p` holds" as the boolean iff `p ↔ (true = true)`. -/
+private theorem iff_true_of {p : Prop} (hp : p) : p ↔ (true = true) :=
+  ⟨fun _ => rfl, fun _ => hp⟩
+
+/-- Package "`p` fails" as the boolean iff `p ↔ (false = true)`. -/
+private theorem iff_false_of {p : Prop} (hp : ¬ p) : p ↔ (false = true) :=
+  ⟨fun h => absurd h hp, fun h => absurd h (by decide)⟩
+
+/-- A negative ratio pins the corresponding sign bit to `true`. -/
+private theorem bit_of_neg {r : ℝ} {s : Bool} (hneg : r < 0) (h : r < 0 ↔ s = true) :
+    s = true := h.mp hneg
+
+/-- A positive ratio pins the corresponding sign bit to `false`. -/
+private theorem bit_of_pos {r : ℝ} {s : Bool} (hpos : 0 < r) (h : r < 0 ↔ s = true) :
+    s = false := by
+  rcases s with _ | _
+  · rfl
+  · exact absurd (h.mpr rfl) (not_lt.mpr hpos.le)
+
+/-! ### Witnesses for the odd (Menelaus, product `-1`) patterns
+
+All four use the fixed non-degenerate triangle `(0,0),(1,0),(0,1)`; only the division
+parameters `t,u,v` change. In each case `menelausProduct = (t/(1-t))·(u/(1-u))·(v/(1-v))`
+equals `-1`, and the three signed ratios realise the advertised sign pattern. -/
+
+/-- **All three external.** `t = 2, u = 2, v = -1/3` gives `rX = rY = -2`, `rZ = -1/4`. -/
+theorem witness_odd_XYZ :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧ rX cfg < 0 ∧ rY cfg < 0 ∧ rZ cfg < 0 := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 2, u := 2, v := -1/3,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **Only `X` external.** `t = -1, u = 2/3, v = 1/2` gives `rX = -1/2`, `rY = 2`, `rZ = 1`. -/
+theorem witness_odd_X :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧ rX cfg < 0 ∧ 0 < rY cfg ∧ 0 < rZ cfg := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := -1, u := 2/3, v := 1/2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **Only `Y` external.** `t = 2/3, u = -1, v = 1/2` gives `rX = 2`, `rY = -1/2`, `rZ = 1`. -/
+theorem witness_odd_Y :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧ 0 < rX cfg ∧ rY cfg < 0 ∧ 0 < rZ cfg := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 2/3, u := -1, v := 1/2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **Only `Z` external.** `t = 2/3, u = 1/2, v = -1` gives `rX = 2`, `rY = 1`, `rZ = -1/2`. -/
+theorem witness_odd_Z :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = -1 ∧ 0 < rX cfg ∧ 0 < rY cfg ∧ rZ cfg < 0 := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 2/3, u := 1/2, v := -1,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-! ### Witnesses for the even (Ceva, product `+1`) patterns -/
+
+/-- **None external.** `t = u = v = 1/2` gives `rX = rY = rZ = 1`. -/
+theorem witness_even_none :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = 1 ∧ 0 < rX cfg ∧ 0 < rY cfg ∧ 0 < rZ cfg := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 1/2, u := 1/2, v := 1/2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **`Y,Z` external.** `t = 1/2, u = -1, v = 2` gives `rX = 1`, `rY = -1/2`, `rZ = -2`. -/
+theorem witness_even_YZ :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = 1 ∧ 0 < rX cfg ∧ rY cfg < 0 ∧ rZ cfg < 0 := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := 1/2, u := -1, v := 2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **`X,Z` external.** `t = -1, u = 1/2, v = 2` gives `rX = -1/2`, `rY = 1`, `rZ = -2`. -/
+theorem witness_even_XZ :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = 1 ∧ rX cfg < 0 ∧ 0 < rY cfg ∧ rZ cfg < 0 := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := -1, u := 1/2, v := 2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-- **`X,Y` external.** `t = -1, u = 2, v = 1/2` gives `rX = -1/2`, `rY = -2`, `rZ = 1`. -/
+theorem witness_even_XY :
+    ∃ cfg : MenelausConfig,
+      menelausProduct cfg = 1 ∧ rX cfg < 0 ∧ rY cfg < 0 ∧ 0 < rZ cfg := by
+  refine ⟨{ A := (0, 0), B := (1, 0), C := (0, 1), t := -1, u := 2, v := 1/2,
+            t_ne_1 := by norm_num, u_ne_1 := by norm_num, v_ne_1 := by norm_num,
+            nondegen := by norm_num [collinearDet] }, ?_, ?_, ?_, ?_⟩
+  · unfold menelausProduct; norm_num
+  · unfold rX; norm_num
+  · unfold rY; norm_num
+  · unfold rZ; norm_num
+
+/-! ### Master biconditionals -/
+
+/-- **Realisable sign patterns of a Menelaus transversal.** Encoding `sᵢ = true` as
+    "division point `i` is external" (signed ratio `< 0`), a pattern `(sX, sY, sZ)` is
+    realisable by some genuine non-degenerate configuration whose signed Menelaus product
+    is `-1` **iff** it has an odd number of external points (`sX ^^ sY ^^ sZ = true`).
+
+    Forward: the parent's `external_parity_odd`. Backward: the four explicit witnesses. -/
+theorem realisable_iff_odd (sX sY sZ : Bool) :
+    (∃ cfg : MenelausConfig, menelausProduct cfg = -1 ∧
+       (rX cfg < 0 ↔ sX = true) ∧ (rY cfg < 0 ↔ sY = true) ∧ (rZ cfg < 0 ↔ sZ = true))
+    ↔ (sX ^^ sY ^^ sZ) = true := by
+  constructor
+  · rintro ⟨cfg, hp, hX, hY, hZ⟩
+    rcases external_parity_odd cfg hp with
+      ⟨a, b, c⟩ | ⟨a, b, c⟩ | ⟨a, b, c⟩ | ⟨a, b, c⟩
+    · rw [bit_of_neg a hX, bit_of_neg b hY, bit_of_neg c hZ]; decide
+    · rw [bit_of_neg a hX, bit_of_pos b hY, bit_of_pos c hZ]; decide
+    · rw [bit_of_pos a hX, bit_of_neg b hY, bit_of_pos c hZ]; decide
+    · rw [bit_of_pos a hX, bit_of_pos b hY, bit_of_neg c hZ]; decide
+  · intro hodd
+    rcases sX with _ | _ <;> rcases sY with _ | _ <;> rcases sZ with _ | _
+    · exact absurd hodd (by decide)
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_odd_Z
+      exact ⟨cfg, hp, iff_false_of (not_lt.mpr hx.le),
+        iff_false_of (not_lt.mpr hy.le), iff_true_of hz⟩
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_odd_Y
+      exact ⟨cfg, hp, iff_false_of (not_lt.mpr hx.le),
+        iff_true_of hy, iff_false_of (not_lt.mpr hz.le)⟩
+    · exact absurd hodd (by decide)
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_odd_X
+      exact ⟨cfg, hp, iff_true_of hx,
+        iff_false_of (not_lt.mpr hy.le), iff_false_of (not_lt.mpr hz.le)⟩
+    · exact absurd hodd (by decide)
+    · exact absurd hodd (by decide)
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_odd_XYZ
+      exact ⟨cfg, hp, iff_true_of hx, iff_true_of hy, iff_true_of hz⟩
+
+/-- **Realisable sign patterns of a Ceva (concurrent) configuration.** A pattern is
+    realisable by a genuine non-degenerate configuration with signed product `+1` **iff**
+    it has an even number of external points (`sX ^^ sY ^^ sZ = false`).
+
+    Forward: the parent's `external_parity_even`. Backward: the four even witnesses. -/
+theorem realisable_iff_even (sX sY sZ : Bool) :
+    (∃ cfg : MenelausConfig, menelausProduct cfg = 1 ∧
+       (rX cfg < 0 ↔ sX = true) ∧ (rY cfg < 0 ↔ sY = true) ∧ (rZ cfg < 0 ↔ sZ = true))
+    ↔ (sX ^^ sY ^^ sZ) = false := by
+  constructor
+  · rintro ⟨cfg, hp, hX, hY, hZ⟩
+    rcases external_parity_even cfg hp with
+      ⟨a, b, c⟩ | ⟨a, b, c⟩ | ⟨a, b, c⟩ | ⟨a, b, c⟩
+    · rw [bit_of_pos a hX, bit_of_pos b hY, bit_of_pos c hZ]; decide
+    · rw [bit_of_pos a hX, bit_of_neg b hY, bit_of_neg c hZ]; decide
+    · rw [bit_of_neg a hX, bit_of_pos b hY, bit_of_neg c hZ]; decide
+    · rw [bit_of_neg a hX, bit_of_neg b hY, bit_of_pos c hZ]; decide
+  · intro heven
+    rcases sX with _ | _ <;> rcases sY with _ | _ <;> rcases sZ with _ | _
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_even_none
+      exact ⟨cfg, hp, iff_false_of (not_lt.mpr hx.le),
+        iff_false_of (not_lt.mpr hy.le), iff_false_of (not_lt.mpr hz.le)⟩
+    · exact absurd heven (by decide)
+    · exact absurd heven (by decide)
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_even_YZ
+      exact ⟨cfg, hp, iff_false_of (not_lt.mpr hx.le),
+        iff_true_of hy, iff_true_of hz⟩
+    · exact absurd heven (by decide)
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_even_XZ
+      exact ⟨cfg, hp, iff_true_of hx,
+        iff_false_of (not_lt.mpr hy.le), iff_true_of hz⟩
+    · obtain ⟨cfg, hp, hx, hy, hz⟩ := witness_even_XY
+      exact ⟨cfg, hp, iff_true_of hx, iff_true_of hy,
+        iff_false_of (not_lt.mpr hz.le)⟩
+    · exact absurd heven (by decide)
+
+/-- **Corollary: exactly four sign patterns are Menelaus-realisable.** Listing the four
+    odd patterns explicitly confirms the count `2³ / 2 = 4`. -/
+theorem four_odd_patterns_realisable :
+    (∃ cfg : MenelausConfig, menelausProduct cfg = -1 ∧
+       rX cfg < 0 ∧ rY cfg < 0 ∧ rZ cfg < 0) ∧
+    (∃ cfg : MenelausConfig, menelausProduct cfg = -1 ∧
+       rX cfg < 0 ∧ 0 < rY cfg ∧ 0 < rZ cfg) ∧
+    (∃ cfg : MenelausConfig, menelausProduct cfg = -1 ∧
+       0 < rX cfg ∧ rY cfg < 0 ∧ 0 < rZ cfg) ∧
+    (∃ cfg : MenelausConfig, menelausProduct cfg = -1 ∧
+       0 < rX cfg ∧ 0 < rY cfg ∧ rZ cfg < 0) :=
+  ⟨witness_odd_XYZ, witness_odd_X, witness_odd_Y, witness_odd_Z⟩
+
+end MenelausTheoremOQ01OQ01OQ01

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,61 @@
+{
+  "id": "menelaus-theorem-oq-01-oq-01-oq-01",
+  "title": "Menelaus: Realisable Sign Patterns (Biconditional Characterisation)",
+  "slug": "menelaus-theorem-oq-01-oq-01-oq-01",
+  "description": "Strengthens the parent's one-directional parity dichotomy into a sharp biconditional characterisation of which sign patterns of the three signed segment ratios are REALISABLE by a genuine non-degenerate transversal configuration. Encoding a pattern as a triple of bits (sX, sY, sZ) where sᵢ = true means division point i is external (signed ratio < 0), the result is: a pattern is realisable with signed Menelaus product -1 IFF it has an odd number of external points (sX ^^ sY ^^ sZ = true), and realisable with the Ceva product +1 IFF it has an even number. The forward implications reuse the parent's external_parity_odd / external_parity_even; the converse (existence) direction is the new content — eight explicit witness configurations on the fixed triangle (0,0),(1,0),(0,1), one realising each admissible pattern. 11 theorems, 0 sorries, 0 axioms. Builds on Proofs/MenelausTheoremOQ01.lean.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Menelaus%27s_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MenelausTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "menelaus",
+      "ceva",
+      "signed-ratios",
+      "parity",
+      "collinearity",
+      "realisability",
+      "biconditional"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the standard foundational axioms propext, Classical.choice, Quot.sound).",
+    "lineCount": 257,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "originalContributions": [
+      "realisable_iff_odd: a sign pattern (sX, sY, sZ) is realisable by a non-degenerate configuration with signed product -1 if and only if sX ^^ sY ^^ sZ = true (odd number of external points) — the sharp converse to the parent's external_parity_odd",
+      "realisable_iff_even: realisable with the Ceva product +1 if and only if sX ^^ sY ^^ sZ = false (even number of external points)",
+      "witness_odd_XYZ / witness_odd_X / witness_odd_Y / witness_odd_Z: four explicit configurations on the triangle (0,0),(1,0),(0,1) realising each of the four odd sign patterns with product -1 (all-external, and each of the three exactly-one-external cases)",
+      "witness_even_none / witness_even_YZ / witness_even_XZ / witness_even_XY: four explicit configurations realising each of the four even sign patterns with product +1 (none-external, and each of the three exactly-two-external cases)",
+      "four_odd_patterns_realisable: packaged corollary confirming exactly 2³/2 = 4 sign patterns are Menelaus-realisable",
+      "bit_of_neg / bit_of_pos: sign-to-boolean bookkeeping translating a negative/positive signed ratio into the corresponding sign bit"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classical Menelaus/Ceva parity dichotomy says a straight transversal cuts an odd number of a triangle's three sides externally while three concurrent cevians cut an even number. The parent entry formalised one direction: every realised configuration has the stated parity. The natural completion is the converse — every parity-admissible sign pattern is actually achieved by some genuine configuration — so that the realisable patterns are characterised exactly. That converse is a constructive existence question, answered here by exhibiting explicit witnesses.",
+    "problemStatement": "The parent proves: collinear transversal (product -1) ⟹ odd number of external points; Ceva value (product +1) ⟹ even number. Strengthen each to a biconditional characterising precisely which of the eight sign patterns of (rX, rY, rZ) are realisable: show every odd pattern is realised by some non-degenerate configuration with product -1, and every even pattern by some configuration with product +1, while the parity-violating patterns are realised by neither.",
+    "text": "Encode a sign pattern as a triple of booleans (sX, sY, sZ), with sᵢ = true meaning point i is external (its signed ratio is negative). The number of external points is odd exactly when sX ^^ sY ^^ sZ = true. The forward direction of each biconditional is the parent's complete sign-case enumeration (external_parity_odd, external_parity_even). The backward (realisability) direction supplies, for each admissible pattern, a concrete configuration on the fixed non-degenerate triangle (0,0),(1,0),(0,1): only the division parameters t,u,v vary, chosen so that menelausProduct = (t/(1-t))·(u/(1-u))·(v/(1-v)) hits the target sign ±1 with the prescribed sign of each factor. For instance t=-1, u=2/3, v=1/2 gives rX=-1/2, rY=2, rZ=1 (product -1, only X external). Each witness is discharged by norm_num.",
+    "proofStrategy": "State the characterisation over Bool³ using xor for the parity. For the forward direction, destructure the parent's four-way parity disjunction and pin each sign bit from the corresponding ratio sign via bit_of_neg / bit_of_pos, then evaluate the boolean xor by decide. For the backward direction, case-split the three sign bits into the eight patterns; the four parity-violating cases are closed by `absurd hodd (by decide)`, and the four admissible cases are supplied by the matching explicit witness, with its ratio signs repackaged into the boolean iff form via iff_true_of / iff_false_of. The eight witnesses are pure norm_num evaluations on the fixed triangle.",
+    "keyInsights": [
+      "Realisability of a sign pattern is governed solely by the parity of its negative-ratio count — exactly the patterns the parent's one-directional theorem permits are in fact all achieved",
+      "The xor of the three external-point bits is a clean algebraic encoding of the odd/even parity, turning the characterisation into a single boolean identity",
+      "A single fixed non-degenerate triangle suffices for all eight witnesses; only the division parameters move, since the parity content is independent of the triangle's shape",
+      "The product of signed ratios realises any prescribed sign of each factor subject only to the total sign ±1, which is why exactly the four odd (resp. even) patterns are constructible at product -1 (resp. +1)"
+    ],
+    "prerequisites": [
+      "Parent formalization: MenelausConfig, menelausProduct, rX/rY/rZ and the parity theorems external_parity_odd / external_parity_even (Proofs/MenelausTheoremOQ01.lean)",
+      "Boolean xor and decidable evaluation (decide)",
+      "Elementary real sign arithmetic and norm_num for the explicit witnesses"
+    ]
+  },
+  "conclusion": {
+    "summary": "The realisable sign patterns of a Menelaus configuration are characterised exactly: a pattern (sX, sY, sZ) is realisable with signed product -1 iff it has an odd number of external points, and with the Ceva product +1 iff it has an even number. The converse to the parent's parity dichotomy is established constructively via eight explicit witness configurations, four for each product sign. 11 theorems, 0 definitions, 257 lines, 0 sorries, 0 axioms.",
+    "implications": "Upgrades the parent's necessary parity condition into a necessary-and-sufficient characterisation, completing the realisability picture for the gallery's Menelaus formalization. The witness-construction template (fix a non-degenerate triangle, solve for division parameters realising a prescribed product and per-factor sign) transfers directly to Ceva, Routh, and other affine division-ratio configurations.",
+    "openQuestions": null
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **menelaus-theorem-oq-01-oq-01-oq-01** (seeker-selected): strengthen the parent's Menelaus parity statements to a **biconditional**, characterising exactly which sign patterns of the three signed segment ratios are *realisable* by a genuine non-degenerate transversal configuration.

The parent (`MenelausTheoremOQ01.lean`) proves only the forward direction — a realised configuration with signed product `-1` has an **odd** number of external division points (`external_parity_odd`), and the Ceva value `+1` forces an **even** number (`external_parity_even`). This PR adds the **converse / realisability** direction and packages both into sharp biconditionals.

## Result

Encoding a pattern as bits `(sX, sY, sZ)` where `sᵢ = true` means point `i` is external (signed ratio `< 0`):

- `realisable_iff_odd`: realisable with signed product `-1` **⟺** `sX ^^ sY ^^ sZ = true` (odd # external)
- `realisable_iff_even`: realisable with the Ceva product `+1` **⟺** `sX ^^ sY ^^ sZ = false` (even # external)

The forward implications reuse the parent's complete sign-case enumeration. The backward (existence) direction is the new content: **eight explicit witness configurations** on the fixed triangle `(0,0),(1,0),(0,1)` — only the division parameters `t,u,v` vary — one realising each admissible pattern, each discharged by `norm_num`. A corollary `four_odd_patterns_realisable` confirms exactly `2³/2 = 4` patterns are Menelaus-realisable.

## Verification

- **11 theorems**, 0 definitions, 257 lines, **0 sorries, 0 axioms**
- `#print axioms` on all three master results lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`
- Status: **verified**, badge **original**
- Compiled with `lake env lean` against the parent dependency chain (Docker unavailable this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)