### PR TITLE
research(mathematical-induction-oq-01-oq-04): Ordinal induction and the von Neumann cumulative hierarchy [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3378,6 +3378,7 @@ import Proofs.MantelTheoremOQ04OQ02
 import Proofs.MaschkeAugmentationNoSplitOQ010101
 import Proofs.MathematicalInduction
 import Proofs.MathematicalInductionOQ01
+import Proofs.MathematicalInductionOQ01OQ04
 import Proofs.MathematicalInductionOQ03
 import Proofs.MatrixPosDefSqrtOQ01
 import Proofs.MatrixSimilarityInvariantsOQ01

--- a/proofs/Proofs/MathematicalInductionOQ01OQ04.lean
+++ b/proofs/Proofs/MathematicalInductionOQ01OQ04.lean
@@ -1,0 +1,169 @@
+import Mathlib
+
+/-
+# Ordinal Induction and the Von Neumann Cumulative Hierarchy
+
+## The Question (OQ-01-OQ-04)
+The parent entry (`mathematical-induction-oq-01`) shows that Lean's
+well-founded recursion *is* transfinite induction over ordinals, packaged by
+Mathlib as `Ordinal.induction`.  This child asks the natural follow-up:
+
+> How does `Ordinal.induction` (well-founded recursion on the ordinals)
+> relate to the von Neumann cumulative hierarchy `V_ α = ⋃_{β<α} 𝒫(V_ β)`,
+> and to the foundational fact that set membership `(· ∈ ·)` is well-founded
+> (the Axiom of Foundation / Regularity)?
+
+The cumulative hierarchy stratifies the set-theoretic universe: every set sits
+at some level `V_ α`.  Mathlib (in `Mathlib/SetTheory/ZFC/VonNeumann.lean`)
+defines `vonNeumann` and proves the structural facts — the level equations
+`V_ 0 = ∅`, `V_ (succ o) = 𝒫(V_ o)`, exhaustion `⋃ o, V_ o = univ`, and the
+rank characterisation `x ∈ V_ o ↔ rank x < o`.  What it does **not** package is
+the *bridge* between `Ordinal.induction` and the hierarchy:
+
+  * that the von Neumann rank turns `(· ∈ ·)` into the pullback of `(· < ·)` on
+    ordinals, so **Foundation is a consequence of ordinal well-foundedness**;
+  * the resulting **rank-stratified strong induction** and **∈-induction**
+    principles, exhibited as instances of `Ordinal.induction` (Mathlib derives
+    `ZFSet.inductionOn` independently from `PSet.mem_wf`, not via rank);
+  * a **uniqueness / fixed-point characterisation** of the hierarchy: `V_` is
+    the *unique* ordinal-indexed family satisfying the cumulative recursion
+    `F o = ⋃_{a<o} 𝒫(F a)`, proved by `Ordinal.induction`.  This is exactly the
+    statement that `vonNeumann` is the `WellFounded.fix` solution of the
+    cumulative functional.
+
+## What We Prove
+- `mem_imp_rank_lt`        : `y ∈ x → rank y < rank x` (the rank drop).
+- `mem_subrelation_rank`   : `(· ∈ ·)` is a subrelation of `rank`-pullback of `<`.
+- `mem_wf_via_rank`        : `WellFounded (· ∈ ·)` **from** ordinal well-foundedness.
+- `rank_strong_induction`  : strong induction on rank, **via `Ordinal.induction`**.
+- `mem_induction`          : ∈-induction (Foundation), **via `Ordinal.induction`**.
+- `vonNeumann_level_induction` : prove `P` everywhere by climbing the levels `V_ o`.
+- `vonNeumann_unique`      : `V_` is the unique solution of the cumulative
+                             recursion (the `WellFounded.fix` fixed point).
+- `vonNeumann_mem_iff_unique` : the membership-characterisation uniqueness.
+
+Everything is fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+open Ordinal
+open scoped ZFSet
+
+namespace MathematicalInductionOQ01OQ04
+
+variable {x y : ZFSet.{u}} {o a : Ordinal.{u}}
+
+/-! ### Part I — The rank drop and Foundation from ordinal well-foundedness
+
+The von Neumann `rank : ZFSet → Ordinal` strictly decreases along membership.
+This single fact is the entire content of the Axiom of Foundation: it embeds
+the membership relation into the (well-founded) order on ordinals. -/
+
+/-- **Rank drop.**  A member has strictly smaller rank than the containing set.
+This is `ZFSet.rank_lt_of_mem`, re-exported as the bridge lemma. -/
+theorem mem_imp_rank_lt (h : y ∈ x) : ZFSet.rank y < ZFSet.rank x :=
+  ZFSet.rank_lt_of_mem h
+
+/-- **Membership is a subrelation of the rank-pullback of `<`.**  Equivalently,
+`rank : ZFSet → Ordinal` is an order-embedding of the membership relation into
+the well-founded order on ordinals. -/
+theorem mem_subrelation_rank :
+    Subrelation (α := ZFSet.{u}) (· ∈ ·) (InvImage (· < ·) ZFSet.rank) :=
+  fun h => mem_imp_rank_lt h
+
+/-- **Foundation from ordinal well-foundedness.**  Because the ordinals are
+well-founded under `<` and `rank` strictly drops along `∈`, the membership
+relation on `ZFSet` is well-founded.  This re-proves the Axiom of Foundation
+(Mathlib's `ZFSet.mem_wf`) through the cumulative hierarchy rank rather than
+through `PSet`. -/
+theorem mem_wf_via_rank : WellFounded ((· ∈ ·) : ZFSet.{u} → ZFSet.{u} → Prop) :=
+  mem_subrelation_rank.wf (InvImage.wf ZFSet.rank wellFounded_lt)
+
+/-! ### Part II — Induction principles as instances of `Ordinal.induction`
+
+`Ordinal.induction` is well-founded recursion on the ordinals.  Transporting it
+along `rank` yields strong induction on sets ordered by rank, and specialising
+the rank drop recovers ∈-induction. -/
+
+/-- **Rank-stratified strong induction.**  To prove `P` for every set it suffices
+to prove `P x` assuming `P y` for every set `y` of strictly smaller rank.  The
+proof is a direct application of `Ordinal.induction` to the rank. -/
+theorem rank_strong_induction {P : ZFSet.{u} → Prop}
+    (H : ∀ x, (∀ y, ZFSet.rank y < ZFSet.rank x → P y) → P x) : ∀ x, P x := by
+  -- Prove `P` level by level: by ordinal induction, `P` holds on every set of
+  -- rank `o`, assuming it holds on all sets of smaller rank.
+  have key : ∀ o : Ordinal.{u}, ∀ x : ZFSet.{u}, ZFSet.rank x = o → P x := by
+    intro o
+    induction o using Ordinal.induction with
+    | h o IH =>
+      intro x hx
+      refine H x (fun y hy => ?_)
+      exact IH (ZFSet.rank y) (hx ▸ hy) y rfl
+  exact fun x => key (ZFSet.rank x) x rfl
+
+/-- **∈-induction (Foundation), via `Ordinal.induction`.**  The usual
+membership-induction principle on sets, here obtained as a specialisation of
+rank-stratified strong induction through the rank drop `mem_imp_rank_lt`.
+(Mathlib's `ZFSet.inductionOn` proves the same statement, but from
+`PSet.mem_wf`; this derivation routes through the cumulative hierarchy.) -/
+theorem mem_induction {P : ZFSet.{u} → Prop}
+    (H : ∀ x, (∀ y ∈ x, P y) → P x) : ∀ x, P x :=
+  rank_strong_induction fun x IH => H x fun _ hy => IH _ (mem_imp_rank_lt hy)
+
+/-! ### Part III — Climbing the cumulative hierarchy
+
+The membership characterisation `x ∈ V_ o ↔ rank x < o` lets us recast strong
+induction as "climbing the levels": to prove `P` everywhere it suffices, at each
+level `o`, to extend `P` from the whole of `V_ o` to the sets of rank exactly
+`o`. -/
+
+/-- **Level induction up the cumulative hierarchy.**  Reading `∀ x ∈ V_ o, P x`
+as "`P` holds below level `o`" (since `x ∈ V_ o ↔ rank x < o`), this is the
+hierarchy form of strong induction, again powered by `Ordinal.induction`. -/
+theorem vonNeumann_level_induction {P : ZFSet.{u} → Prop}
+    (H : ∀ o : Ordinal.{u}, (∀ x ∈ ZFSet.vonNeumann o, P x) →
+      ∀ x, ZFSet.rank x = o → P x) : ∀ x, P x := by
+  apply rank_strong_induction
+  intro x IH
+  refine H (ZFSet.rank x) (fun y hy => ?_) x rfl
+  -- `y ∈ V_ (rank x)` unfolds to `rank y < rank x`, which is exactly `IH`.
+  exact IH y (ZFSet.mem_vonNeumann.mp hy)
+
+/-! ### Part IV — Uniqueness of the hierarchy (the `WellFounded.fix` fixed point)
+
+`vonNeumann` is defined by the cumulative recursion `V_ o = ⋃_{a<o} 𝒫(V_ a)`
+(Mathlib uses `termination_by`, i.e. `WellFounded.fix`).  We show this recursion
+has a *unique* solution: any `F` satisfying the same equation equals `vonNeumann`.
+The proof is `Ordinal.induction` — the very principle that justifies the
+recursive definition. -/
+
+/-- **Uniqueness of the cumulative recursion.**  If `F : Ordinal → ZFSet`
+satisfies the von Neumann recurrence `F o = ⋃_{a < o} 𝒫(F a)`, then `F = V_`.
+Equivalently: `vonNeumann` is the unique fixed point of the cumulative
+functional, i.e. its `WellFounded.fix` solution is determined. -/
+theorem vonNeumann_unique (F : Ordinal.{u} → ZFSet.{u})
+    (hF : ∀ o, F o = ⋃ a : Set.Iio o, ZFSet.powerset (F a)) :
+    F = ZFSet.vonNeumann := by
+  funext o
+  induction o using Ordinal.induction with
+  | h o IH =>
+    apply ZFSet.ext
+    intro x
+    rw [hF o, ZFSet.mem_iUnion, ZFSet.mem_vonNeumann']
+    constructor
+    · rintro ⟨⟨a, ha⟩, hx⟩
+      rw [ZFSet.mem_powerset] at hx
+      exact ⟨a, ha, by rwa [IH a ha] at hx⟩
+    · rintro ⟨a, ha, hx⟩
+      exact ⟨⟨a, ha⟩, by rw [ZFSet.mem_powerset, IH a ha]; exact hx⟩
+
+/-- **Membership-characterisation uniqueness.**  The hierarchy is also pinned
+down level-by-level by its members: `V_ o` is the set of all sets of rank `< o`.
+Any family with that membership property is `vonNeumann`. -/
+theorem vonNeumann_mem_iff_unique (F : Ordinal.{u} → ZFSet.{u})
+    (hF : ∀ o x, x ∈ F o ↔ ZFSet.rank x < o) : F = ZFSet.vonNeumann := by
+  funext o
+  apply ZFSet.ext
+  intro x
+  rw [hF o x, ZFSet.mem_vonNeumann]
+
+end MathematicalInductionOQ01OQ04

--- a/src/data/proofs/mathematical-induction-oq-01-oq-04/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-04/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "mathematical-induction-oq-01-oq-04",
+  "title": "Ordinal Induction and the Von Neumann Cumulative Hierarchy",
+  "slug": "mathematical-induction-oq-01-oq-04",
+  "description": "Bridges Ordinal.induction (well-founded recursion on the ordinals) to the von Neumann cumulative hierarchy V_alpha and to the well-foundedness of set membership. The von Neumann rank embeds the membership relation into the order on ordinals (rank y < rank x whenever y in x), so the Axiom of Foundation (well-founded membership) becomes a consequence of ordinal well-foundedness; transporting Ordinal.induction along rank yields rank-stratified strong induction and epsilon-induction; and the hierarchy is shown to be the UNIQUE solution of the cumulative recursion F o = union_{a<o} powerset(F a), i.e. the WellFounded.fix fixed point of the cumulative functional.",
+  "meta": {
+    "author": "John von Neumann (cumulative hierarchy, 1928); Mostowski/Zermelo (rank and Foundation)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Von_Neumann_universe",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MathematicalInductionOQ01OQ04.lean",
+    "tags": [
+      "foundations",
+      "set-theory",
+      "ordinals",
+      "cumulative-hierarchy",
+      "von-neumann",
+      "well-founded-recursion",
+      "transfinite-induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Ordinal.induction",
+        "description": "Well-founded recursion on the ordinals: if p holds at j whenever it holds at every k < j, then p holds everywhere. The engine behind every induction principle in this file.",
+        "module": "Mathlib.SetTheory.Ordinal.Basic"
+      },
+      {
+        "theorem": "ZFSet.rank_lt_of_mem",
+        "description": "y in x implies rank y < rank x; the rank drop that embeds membership into the order on ordinals.",
+        "module": "Mathlib.SetTheory.ZFC.Rank"
+      },
+      {
+        "theorem": "ZFSet.mem_vonNeumann",
+        "description": "x in V_ o iff rank x < o; identifies the levels of the cumulative hierarchy with rank thresholds.",
+        "module": "Mathlib.SetTheory.ZFC.VonNeumann"
+      },
+      {
+        "theorem": "ZFSet.mem_vonNeumann'",
+        "description": "x in V_ o iff exists a < o, x subset V_ a; the cumulative recurrence in membership form, used for the uniqueness proof.",
+        "module": "Mathlib.SetTheory.ZFC.VonNeumann"
+      },
+      {
+        "theorem": "InvImage.wf / Subrelation.wf",
+        "description": "Well-foundedness transfers along a function (pullback) and to subrelations; turns ordinal well-foundedness into well-founded membership via rank.",
+        "module": "Mathlib.Order.RelClasses"
+      }
+    ],
+    "originalContributions": [
+      "mem_subrelation_rank: membership is a subrelation of the rank-pullback of < on ordinals (rank is an order-embedding of the membership relation)",
+      "mem_wf_via_rank: WellFounded (membership) re-proved through the cumulative-hierarchy rank rather than Mathlib's PSet-level argument; exhibits the Axiom of Foundation as a consequence of ordinal well-foundedness",
+      "rank_strong_induction: rank-stratified strong induction on sets, obtained as a direct instance of Ordinal.induction applied to the rank",
+      "mem_induction: epsilon-induction (Foundation) routed through the cumulative hierarchy rank, in contrast to Mathlib's PSet.mem_wf derivation",
+      "vonNeumann_level_induction: prove P for all sets by climbing the levels V_ o, using x in V_ o iff rank x < o",
+      "vonNeumann_unique: V_ is the UNIQUE ordinal-indexed family satisfying the cumulative recursion F o = union_{a<o} powerset(F a), proved by Ordinal.induction -- the statement that vonNeumann is the WellFounded.fix solution of the cumulative functional",
+      "vonNeumann_mem_iff_unique: level-by-level membership uniqueness of the hierarchy"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 169,
+    "prerequisites": [
+      "Well-founded recursion and Ordinal.induction",
+      "The von Neumann cumulative hierarchy V_alpha and its rank function",
+      "The Axiom of Foundation / well-foundedness of set membership",
+      "Subrelation and inverse-image transfer of well-foundedness"
+    ],
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) for all six theorems; none counts under the project's axiom policy, and no sorryAx or Lean.ofReduceBool appears. All results are built on top of Mathlib's von Neumann hierarchy without introducing new assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry (mathematical-induction-oq-01, 'Transfinite Induction over Ordinals') shows that Lean's well-founded recursion is exactly transfinite induction, packaged by Mathlib as Ordinal.induction. Von Neumann's cumulative hierarchy (1928) stratifies the universe of sets into levels V_alpha = union_{beta<alpha} powerset(V_beta), and the rank function assigns to each set the least level above it. The hierarchy and the Axiom of Foundation are the classical bridge between ordinals and arbitrary sets.",
+    "problemStatement": "**Open Question (parent OQ-04)**: How does Ordinal.induction relate to the cumulative hierarchy V_alpha and to WellFounded.fix?\n\n**Answer**: The von Neumann rank embeds set membership into the order on ordinals, so ordinal well-foundedness (the basis of Ordinal.induction) yields well-founded membership (Foundation); transporting Ordinal.induction along rank gives rank-stratified strong induction and epsilon-induction; and Ordinal.induction shows the hierarchy is the unique solution of its cumulative recursion, i.e. the WellFounded.fix fixed point of the cumulative functional.",
+    "text": "Ordinal induction, transported along the von Neumann rank, is the engine behind both the well-foundedness of set membership and the recursion that defines the cumulative hierarchy.",
+    "proofStrategy": "**Foundation from ordinals**: rank_lt_of_mem makes (membership) a Subrelation of the rank-pullback of < on ordinals; Subrelation.wf composed with InvImage.wf (rank) wellFounded_lt yields WellFounded membership (mem_wf_via_rank).\n\n**Induction principles**: rank_strong_induction runs Ordinal.induction on the rank, proving P at every set of rank o from P on all sets of smaller rank; mem_induction specialises it through the rank drop to recover epsilon-induction; vonNeumann_level_induction rephrases the strong-induction hypothesis using x in V_ o iff rank x < o, so the induction climbs the hierarchy levels.\n\n**Uniqueness (fixed point)**: vonNeumann_unique runs Ordinal.induction on o; assuming F a = V_ a for all a < o, the membership form of the recurrence (mem_iUnion, mem_powerset, mem_vonNeumann') forces F o = V_ o. Hence the cumulative functional has a unique solution, namely vonNeumann (the WellFounded.fix solution). vonNeumann_mem_iff_unique gives the parallel membership-characterisation uniqueness.",
+    "keyInsights": [
+      "The single fact rank y < rank x for y in x is the entire content of the Axiom of Foundation: it embeds the membership relation into the well-founded order on ordinals.",
+      "Every set-theoretic induction principle here is a transported copy of one ordinal induction: strong induction on rank, epsilon-induction, and level induction are all Ordinal.induction in disguise.",
+      "Mathlib proves epsilon-induction (ZFSet.inductionOn) from PSet.mem_wf; routing it through the cumulative rank makes explicit that Foundation is downstream of ordinal well-foundedness.",
+      "The cumulative recursion F o = union_{a<o} powerset(F a) has a unique solution; proving this by Ordinal.induction is precisely the assertion that vonNeumann is the WellFounded.fix fixed point of the functional."
+    ],
+    "prerequisites": [
+      "Well-founded recursion and Ordinal.induction",
+      "The von Neumann cumulative hierarchy and rank",
+      "The Axiom of Foundation",
+      "Transfer of well-foundedness along functions and subrelations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "foundation-from-ordinals",
+      "title": "The Rank Drop and Foundation from Ordinal Well-Foundedness",
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "mem_imp_rank_lt (the rank drop along membership), mem_subrelation_rank (membership is a subrelation of the rank-pullback of <), and mem_wf_via_rank (well-founded membership obtained from ordinal well-foundedness through rank).",
+      "mathContext": "$y \\in x \\Rightarrow \\operatorname{rank} y < \\operatorname{rank} x;\\quad (\\in) \\subseteq \\operatorname{InvImage}(<)\\,\\operatorname{rank};\\quad \\text{WellFounded}(\\in).$"
+    },
+    {
+      "id": "induction-principles",
+      "title": "Induction Principles as Instances of Ordinal.induction",
+      "startLine": 81,
+      "endLine": 110,
+      "summary": "rank_strong_induction (strong induction on rank via Ordinal.induction) and mem_induction (epsilon-induction recovered through the rank drop).",
+      "mathContext": "$\\big(\\forall x,\\ (\\forall y,\\ \\operatorname{rank} y < \\operatorname{rank} x \\to P y) \\to P x\\big) \\to \\forall x,\\ P x.$"
+    },
+    {
+      "id": "climbing-the-hierarchy",
+      "title": "Climbing the Cumulative Hierarchy",
+      "startLine": 112,
+      "endLine": 129,
+      "summary": "vonNeumann_level_induction: prove P for all sets by extending it from V_ o (all sets of rank < o) to the sets of rank exactly o, using x in V_ o iff rank x < o.",
+      "mathContext": "$x \\in V_o \\iff \\operatorname{rank} x < o.$"
+    },
+    {
+      "id": "uniqueness-fixed-point",
+      "title": "Uniqueness of the Hierarchy (the WellFounded.fix Fixed Point)",
+      "startLine": 131,
+      "endLine": 169,
+      "summary": "vonNeumann_unique (V_ is the unique solution of the cumulative recursion F o = union_{a<o} powerset(F a), by Ordinal.induction) and vonNeumann_mem_iff_unique (the membership-characterisation uniqueness).",
+      "mathContext": "$F o = \\bigcup_{a<o} \\mathcal{P}(F a)\\ \\ \\forall o \\ \\Longrightarrow\\ F = V_{\\bullet}.$"
+    }
+  ],
+  "conclusion": "Ordinal.induction, transported along the von Neumann rank, simultaneously yields the well-foundedness of set membership (the Axiom of Foundation), the rank-stratified and epsilon-induction principles on sets, and the uniqueness of the cumulative hierarchy as the WellFounded.fix solution of its defining recursion. This makes precise how the parent's transfinite-induction principle drives the cumulative-hierarchy construction.",
+  "leanFile": {
+    "namespace": "MathematicalInductionOQ01OQ04",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "path": "Proofs/MathematicalInductionOQ01OQ04.lean",
+    "sorries": 0,
+    "definitionCount": 0
+  },
+  "sorries": [],
+  "crossReferences": []
+}


### PR DESCRIPTION
## Summary

Answers the **4th open question** of `mathematical-induction-oq-01` (Transfinite Induction over Ordinals): *how does `Ordinal.induction` relate to the von Neumann cumulative hierarchy `V_α` and to `WellFounded.fix`?*

Mathlib's `SetTheory/ZFC/VonNeumann.lean` already builds the hierarchy (`vonNeumann`, `rank`, the recurrence, exhaustion). This entry supplies the **bridge** to `Ordinal.induction` that Mathlib does not package.

## Results (`Proofs/MathematicalInductionOQ01OQ04.lean`, 6 theorems, 169 lines)

- **`mem_subrelation_rank` / `mem_wf_via_rank`** — the von Neumann rank embeds membership into the order on ordinals (`rank y < rank x` for `y ∈ x`), so the **Axiom of Foundation** (well-founded membership) is obtained *from ordinal well-foundedness via rank*, rather than from Mathlib's `PSet.mem_wf`.
- **`rank_strong_induction`, `mem_induction`** — rank-stratified strong induction and ∈-induction, exhibited as direct instances of `Ordinal.induction`.
- **`vonNeumann_level_induction`** — prove `P` for all sets by climbing the levels `V_ o`, using `x ∈ V_ o ↔ rank x < o`.
- **`vonNeumann_unique`** — `V_` is the **unique** solution of the cumulative recursion `F o = ⋃_{a<o} 𝒫(F a)`, proved by `Ordinal.induction`; i.e. `vonNeumann` is the `WellFounded.fix` fixed point of the cumulative functional.
- **`vonNeumann_mem_iff_unique`** — membership-characterisation uniqueness.

## Verification

`#print axioms` on all six theorems reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **0 sorries, 0 axioms.** Compiled against Mathlib 4.26.0 via `lake env lean` (Docker host unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)