### PR TITLE
research(erdos-1012-oq-04): Woodall threshold as a deficiency from the complete graph [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1145,6 +1145,7 @@ import Proofs.Erdos1012OQ01
 import Proofs.Erdos1012OQ02
 import Proofs.Erdos1012OQ03
 import Proofs.Erdos1012OQ03OQ02
+import Proofs.Erdos1012OQ04
 import Proofs.Erdos1012OQ03Aristotle
 import Proofs.Erdos1012Problem
 import Proofs.Erdos1013Problem

--- a/proofs/Proofs/Erdos1012OQ04.lean
+++ b/proofs/Proofs/Erdos1012OQ04.lean
@@ -1,0 +1,171 @@
+/-
+# Erdős Problem #1012 — OQ-04: the Woodall threshold as a deficiency from the complete graph
+
+## Background
+
+Erdős Problem #1012 (Woodall, 1972) concerns long cycles in dense graphs: every
+graph on `n` vertices with at least
+
+      edgeThreshold n k = C(n-k-1, 2) + C(k+2, 2) + 1
+
+edges contains a cycle on `n - k` vertices.  The parent entry `Erdos1012OQ01`
+formalizes this threshold and evaluates it at the extremal points `n = 2k+2`,
+`n = 2k+3`; the sibling `Erdos1012OQ01OQ02` records its monotonicity / recurrence
+*in `n`*.  What none of them records is how the threshold sits inside the
+**complete graph** `K_n`, which has `C(n, 2)` edges.
+
+This file supplies that structural decomposition.  The clean closed identity is
+
+      C(n, 2) = C(n-k-1, 2) + C(k+2, 2) + (k+1)(n-k-2)              (n ≥ k+2),
+
+so the maximal edge count that *avoids* the long cycle, `edgeThreshold n k − 1
+= C(n-k-1, 2) + C(k+2, 2)`, is exactly the complete graph minus a **deficiency**
+of `(k+1)(n-k-2)` edges:
+
+      edgeThreshold n k = C(n, 2) − (k+1)(n-k-2) + 1.
+
+The deficiency `(k+1)(n-k-2)` is itself the edge count of the complete bipartite
+graph `K_{k+1, n-k-2}` — the bipartite "gap" between the `(k+1)`-part governing the
+defect and the remaining `n-k-2` vertices.  This is precisely the structure of the
+Woodall extremal construction, now pinned down arithmetically.
+
+Everything is elementary `Nat.choose` arithmetic.  To keep the file self-contained
+and machine-checked end to end (matching the style of `Erdos1012OQ03OQ02`), the
+parent's one-line `edgeThreshold` definition is re-declared verbatim.
+
+All results: 0 sorries, 0 axioms, no `native_decide`.
+
+Reference: Woodall, D.R. (1972), *Sufficient conditions for circuits in graphs*;
+https://erdosproblems.com/1012
+-/
+
+import Mathlib
+
+open Nat
+
+namespace Erdos1012OQ04
+
+/-- The Erdős/Woodall edge threshold for the `(n-k)`-cycle problem, re-declared
+verbatim from the parent `Erdos1012` namespace so this file stands alone. -/
+def edgeThreshold (n k : ℕ) : ℕ :=
+  Nat.choose (n - k - 1) 2 + Nat.choose (k + 2) 2 + 1
+
+/-- The complete-bipartite **deficiency** `(k+1)(n-k-2)` separating the Woodall
+threshold from the complete graph `K_n`. -/
+def deficiency (n k : ℕ) : ℕ := (k + 1) * (n - k - 2)
+
+/-! ## Core arithmetic: doubling `C(·, 2)` -/
+
+/-- `2 · C(x+1, 2) = (x+1) · x`.  The successor form avoids truncated `ℕ`
+subtraction, since `(x+1) - 1 = x` reduces definitionally. -/
+theorem two_mul_choose_two_succ (x : ℕ) :
+    2 * Nat.choose (x + 1) 2 = (x + 1) * x := by
+  rw [Nat.choose_two_right]
+  -- goal: `2 * ((x+1) * ((x+1) - 1) / 2) = (x+1) * x`
+  rw [Nat.add_sub_cancel]
+  -- `(x+1) * x` is even, so `2 * (· / 2)` recovers it
+  rcases Nat.even_or_odd x with hx | hx
+  · obtain ⟨t, ht⟩ := hx
+    subst ht
+    ring_nf
+    omega
+  · obtain ⟨t, ht⟩ := hx
+    subst ht
+    ring_nf
+    omega
+
+/-! ## The complete-graph decomposition -/
+
+/-- **Core split identity (successor form).**  Writing `n = m + k + 2`
+(so `m = n - k - 2 ≥ 0`), the complete-graph edge count `C(n, 2)` splits as
+
+    C(m+k+2, 2) = C(m+1, 2) + C(k+2, 2) + (k+1)·m.
+
+This is the parameter-clean heart of the file; the `n`-indexed form follows. -/
+theorem choose_two_split (m k : ℕ) :
+    Nat.choose (m + k + 2) 2
+      = Nat.choose (m + 1) 2 + Nat.choose (k + 2) 2 + (k + 1) * m := by
+  have key :
+      2 * Nat.choose (m + k + 2) 2
+        = 2 * (Nat.choose (m + 1) 2 + Nat.choose (k + 2) 2 + (k + 1) * m) := by
+    have h1 : 2 * Nat.choose (m + k + 2) 2 = (m + k + 2) * (m + k + 1) := by
+      have := two_mul_choose_two_succ (m + k + 1)
+      simpa [Nat.add_assoc] using this
+    have h2 : 2 * Nat.choose (m + 1) 2 = (m + 1) * m := two_mul_choose_two_succ m
+    have h3 : 2 * Nat.choose (k + 2) 2 = (k + 2) * (k + 1) := two_mul_choose_two_succ (k + 1)
+    -- expand the RHS doubling and finish by polynomial arithmetic
+    rw [Nat.mul_add, Nat.mul_add, h1, h2, h3]
+    ring
+  exact Nat.eq_of_mul_eq_mul_left (by norm_num) key
+
+/-- **Core split identity (`n`-indexed form).**  For `n ≥ k + 2`,
+
+    C(n, 2) = C(n-k-1, 2) + C(k+2, 2) + (k+1)(n-k-2).
+
+The complete graph on `n` vertices decomposes into the Woodall extremal blocks
+plus the bipartite deficiency. -/
+theorem choose_two_split_n {n k : ℕ} (h : k + 2 ≤ n) :
+    Nat.choose n 2
+      = Nat.choose (n - k - 1) 2 + Nat.choose (k + 2) 2 + (k + 1) * (n - k - 2) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + k + 2 := ⟨n - k - 2, by omega⟩
+  have e1 : m + k + 2 - k - 1 = m + 1 := by omega
+  have e2 : m + k + 2 - k - 2 = m := by omega
+  rw [e1, e2]
+  exact choose_two_split m k
+
+/-! ## Threshold ↔ complete graph -/
+
+/-- **Threshold as complete minus deficiency (additive, successor form).**
+`edgeThreshold (m+k+2) k + (k+1)·m = C(m+k+2, 2) + 1`. -/
+theorem edgeThreshold_add_deficiency (m k : ℕ) :
+    edgeThreshold (m + k + 2) k + (k + 1) * m = Nat.choose (m + k + 2) 2 + 1 := by
+  have e1 : m + k + 2 - k - 1 = m + 1 := by omega
+  rw [edgeThreshold, e1, choose_two_split m k]
+  ring
+
+/-- **Threshold as complete minus deficiency (`n`-indexed).**  For `n ≥ k + 2`,
+`edgeThreshold n k + deficiency n k = C(n, 2) + 1`.  Equivalently, the threshold
+is the complete-graph edge count reduced by the deficiency, plus one. -/
+theorem edgeThreshold_add_deficiency_n {n k : ℕ} (h : k + 2 ≤ n) :
+    edgeThreshold n k + deficiency n k = Nat.choose n 2 + 1 := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + k + 2 := ⟨n - k - 2, by omega⟩
+  have e2 : m + k + 2 - k - 2 = m := by omega
+  rw [deficiency, e2]
+  exact edgeThreshold_add_deficiency m k
+
+/-- **Maximal long-cycle-free edge count.**  The largest edge count that may avoid
+the `(n-k)`-cycle is `edgeThreshold n k − 1`, and it equals the complete graph
+minus the deficiency:  `(edgeThreshold n k − 1) + deficiency n k = C(n, 2)`. -/
+theorem maxEdges_add_deficiency_n {n k : ℕ} (h : k + 2 ≤ n) :
+    (edgeThreshold n k - 1) + deficiency n k = Nat.choose n 2 := by
+  have hpos : 1 ≤ edgeThreshold n k := by
+    rw [edgeThreshold]; omega
+  have := edgeThreshold_add_deficiency_n h
+  omega
+
+/-! ## The deficiency is a complete-bipartite edge count -/
+
+/-- The deficiency `(k+1)(n-k-2)` is the number of edges of the complete bipartite
+graph `K_{k+1,\,n-k-2}` — the product of the two part sizes.  This is the precise
+sense in which the Woodall threshold is "the complete graph minus a bipartite gap". -/
+theorem deficiency_eq_bipartite_edges (n k : ℕ) :
+    deficiency n k = (k + 1) * (n - k - 2) := rfl
+
+/-! ## Sanity specializations -/
+
+/-- **Hamiltonian (Ore) case `k = 0`.**  Avoiding an `n`-cycle, the maximal edge
+count is `C(n,2) − (n-2) = C(n-1, 2) + 1`, i.e. one more than the complete graph on
+`n − 1` vertices: removing a single vertex's worth of "long-cycle" connectivity. -/
+theorem maxEdges_hamiltonian {n : ℕ} (h : 2 ≤ n) :
+    (edgeThreshold n 0 - 1) + (n - 2) = Nat.choose n 2 := by
+  have := maxEdges_add_deficiency_n (k := 0) (n := n) (by omega)
+  simpa [deficiency] using this
+
+/-- **Extremal point `n = 2k+2`.**  At the lower Woodall extremal size the
+deficiency is `(k+1)·k = 2·C(k+1, 2)`. -/
+theorem deficiency_at_extremal (k : ℕ) :
+    deficiency (2 * k + 2) k = (k + 1) * k := by
+  have e : 2 * k + 2 - k - 2 = k := by omega
+  rw [deficiency, e]
+
+end Erdos1012OQ04

--- a/src/data/proofs/erdos-1012-oq-04/meta.json
+++ b/src/data/proofs/erdos-1012-oq-04/meta.json
@@ -1,0 +1,227 @@
+{
+  "id": "erdos-1012-oq-04",
+  "title": "The Woodall Threshold as a Deficiency from the Complete Graph",
+  "slug": "erdos-1012-oq-04",
+  "description": "Locates the Erdős/Woodall edge threshold of Erdős #1012 inside the complete graph K_n. The parent (oq-01) defines edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1 and evaluates it at the extremal sizes; the sibling oq-01-oq-02 records its monotonicity in n. Neither relates it to the C(n,2) edges of K_n. This entry proves the clean closed decomposition C(n,2) = C(n-k-1,2) + C(k+2,2) + (k+1)(n-k-2) for n ≥ k+2, so the maximal long-cycle-free edge count edgeThreshold n k − 1 equals the complete graph minus a deficiency of exactly (k+1)(n-k-2) edges — the edge count of the complete bipartite graph K_{k+1,n-k-2}, which is precisely the structure of the Woodall extremal construction. Includes the parameter-clean successor form, the n-indexed form, the threshold/complete reformulation, the maximal-edge corollary, the k=0 Hamiltonian (Ore) specialisation, and the deficiency at the extremal point n=2k+2. Self-contained (re-declares the parent's one-line edgeThreshold) and fully machine-checked.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://erdosproblems.com/1012",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1012OQ04.lean",
+    "tags": [
+      "graph-theory",
+      "extremal-graph-theory",
+      "long-cycles",
+      "binomial-coefficients",
+      "complete-graph",
+      "woodall",
+      "erdos-problem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-24",
+    "originalContributions": [
+      "choose_two_split: the successor-form identity C(m+k+2,2) = C(m+1,2) + C(k+2,2) + (k+1)·m — the parameter-clean heart, avoiding truncated ℕ subtraction",
+      "choose_two_split_n: the n-indexed complete-graph decomposition C(n,2) = C(n-k-1,2) + C(k+2,2) + (k+1)(n-k-2) for n ≥ k+2",
+      "two_mul_choose_two_succ: the doubling lemma 2·C(x+1,2) = (x+1)·x that linearises the binomial arithmetic so a single ring step closes the split",
+      "edgeThreshold_add_deficiency_n: edgeThreshold n k + (k+1)(n-k-2) = C(n,2) + 1 — the threshold is the complete graph minus the deficiency, plus one",
+      "maxEdges_add_deficiency_n: (edgeThreshold n k − 1) + (k+1)(n-k-2) = C(n,2) — the maximal long-cycle-free edge count is exactly K_n minus the deficiency",
+      "deficiency_eq_bipartite_edges: the deficiency (k+1)(n-k-2) is the edge count of the complete bipartite graph K_{k+1,n-k-2}",
+      "maxEdges_hamiltonian: the k=0 (Hamiltonian/Ore) specialisation, deficiency n − 2",
+      "deficiency_at_extremal: at the lower Woodall extremal size n=2k+2 the deficiency is (k+1)·k = 2·C(k+1,2)"
+    ],
+    "prerequisites": [
+      "Erdos1012OQ01 (parent): defines the Woodall edge threshold edgeThreshold n k and evaluates it at the extremal points",
+      "Erdos1012OQ01OQ02 (sibling): the threshold's recurrence and monotonicity in n"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "n.choose 2 = n * (n - 1) / 2 — the closed form for the second binomial column, the starting point for the doubling lemma",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "cancels the common factor 2 after proving the doubled identity, recovering the original split",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.add_sub_cancel",
+        "description": "(x + 1) - 1 = x — clears the truncated subtraction in the choose-two closed form for the successor argument",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "theoremCount": 9,
+    "relatedProblems": [
+      {
+        "id": "erdos-1012-oq-01",
+        "relationship": "Parent: defines the Woodall edge threshold f(k) and edgeThreshold n k and evaluates it at the extremal sizes n = 2k+2, 2k+3. This entry places that threshold inside the complete graph."
+      },
+      {
+        "id": "erdos-1012-oq-01-oq-02",
+        "relationship": "Sibling: records the threshold's recurrence and monotonicity in n. This entry gives the complementary structural fact — its position relative to C(n,2)."
+      },
+      {
+        "id": "erdos-1012",
+        "relationship": "Root: Erdős Problem #1012 (Long Cycles in Dense Graphs)."
+      }
+    ],
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1012 asks for the function f(k) such that every graph on n ≥ f(k) vertices with at least C(n-k-1,2) + C(k+2,2) + 1 edges contains a cycle on n − k vertices; Woodall (1972) proved f(k) ≤ 2k+3 with the extremal graphs being pancyclic from 3 to n − k. The threshold's form is dictated by an extremal construction — a clique on n-k-1 vertices together with a (k+2)-clique sharing structure — and the natural way to read such a construction is as the complete graph K_n with a controlled set of edges deleted. This entry makes that reading exact.",
+    "problemStatement": "Relate the Woodall edge threshold edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1 to the complete graph K_n, which has C(n,2) edges. Prove the closed decomposition of C(n,2) into the threshold blocks plus a single deficiency term, identify that deficiency as a complete-bipartite edge count, and derive the maximal long-cycle-free edge count as 'complete minus deficiency'.",
+    "proofStrategy": "The whole development reduces to one binomial identity. Substituting n = m + k + 2 (m = n-k-2 ≥ 0) removes all truncated ℕ subtraction, turning the goal into C(m+k+2,2) = C(m+1,2) + C(k+2,2) + (k+1)·m. Each C(x+1,2) is doubled via the lemma 2·C(x+1,2) = (x+1)·x (from Nat.choose_two_right, using that (x+1)·x is even), after which the doubled identity (m+k+2)(m+k+1) = (m+1)m + (k+2)(k+1) + 2(k+1)m is a pure polynomial identity closed by ring; cancelling the factor 2 gives the split. The n-indexed form, the threshold/complete reformulation, and the maximal-edge corollary all follow by rewriting with this split and omega bookkeeping.",
+    "keyInsights": [
+      "The Woodall threshold is the complete graph minus a deficiency: C(n,2) = C(n-k-1,2) + C(k+2,2) + (k+1)(n-k-2), so the maximal long-cycle-free edge count edgeThreshold n k − 1 = C(n,2) − (k+1)(n-k-2).",
+      "The deficiency (k+1)(n-k-2) is exactly |E(K_{k+1,n-k-2})|, the complete bipartite edge count — the bipartite gap between the (k+1)-part controlling the cycle defect and the remaining n-k-2 vertices, matching the Woodall extremal construction.",
+      "Reparametrising n = m+k+2 eliminates every truncated ℕ subtraction up front, so the combinatorial identity becomes a clean polynomial identity provable by ring after a uniform doubling step.",
+      "Doubling each C(x+1,2) to (x+1)·x via Nat.choose_two_right (and evenness of (x+1)·x) is what linearises the binomial coefficients into a single ring-closable equation, sidestepping ℕ division entirely.",
+      "Specialising to k = 0 recovers the Hamiltonian (Ore) regime with deficiency n − 2, and the lower extremal size n = 2k+2 gives deficiency (k+1)·k = 2·C(k+1,2)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "§0: Definitions",
+      "startLine": 47,
+      "endLine": 55,
+      "summary": "Re-declares the parent's one-line edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1 verbatim, and introduces deficiency n k = (k+1)(n-k-2), keeping the file self-contained and end-to-end checkable.",
+      "mathContext": "edgeThreshold is the Erdős/Woodall edge bound for the (n-k)-cycle; deficiency is the gap separating it from the complete graph."
+    },
+    {
+      "id": "doubling",
+      "title": "§1: Doubling C(·,2)",
+      "startLine": 57,
+      "endLine": 83,
+      "summary": "two_mul_choose_two_succ: 2·C(x+1,2) = (x+1)·x, the lemma that linearises binomial arithmetic. Proved from Nat.choose_two_right and evenness of (x+1)·x.",
+      "mathContext": "The successor argument x+1 makes (x+1)-1 = x reduce, avoiding truncated subtraction; doubling clears the division by 2 in the choose-two closed form."
+    },
+    {
+      "id": "split",
+      "title": "§2: The complete-graph decomposition",
+      "startLine": 84,
+      "endLine": 117,
+      "summary": "choose_two_split (successor form) and choose_two_split_n (n-indexed, n ≥ k+2): C(n,2) = C(n-k-1,2) + C(k+2,2) + (k+1)(n-k-2). The core identity proved by doubling all binomials and closing with ring, then cancelling 2.",
+      "mathContext": "Decomposes the complete graph's edge count into the two Woodall extremal blocks plus the bipartite deficiency."
+    },
+    {
+      "id": "threshold",
+      "title": "§3: Threshold ↔ complete graph",
+      "startLine": 118,
+      "endLine": 149,
+      "summary": "edgeThreshold_add_deficiency(_n): edgeThreshold n k + deficiency n k = C(n,2) + 1; and maxEdges_add_deficiency_n: (edgeThreshold n k − 1) + deficiency n k = C(n,2), the maximal long-cycle-free edge count as complete minus deficiency.",
+      "mathContext": "Rewrites the split in terms of the threshold; the maximal-edge form is the threshold minus one, valid since the threshold is always ≥ 1."
+    },
+    {
+      "id": "interpretation",
+      "title": "§4: Deficiency as bipartite edges, and specialisations",
+      "startLine": 150,
+      "endLine": 170,
+      "summary": "deficiency_eq_bipartite_edges identifies the deficiency with |E(K_{k+1,n-k-2})|; maxEdges_hamiltonian is the k=0 Ore case (deficiency n−2); deficiency_at_extremal gives (k+1)·k at n=2k+2.",
+      "mathContext": "Connects the arithmetic deficiency to the complete-bipartite structure of the extremal construction and checks the boundary regimes."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Woodall edge threshold of Erdős #1012 is the complete graph minus a deficiency: C(n,2) = C(n-k-1,2) + C(k+2,2) + (k+1)(n-k-2), so the maximal long-cycle-free edge count is K_n minus exactly (k+1)(n-k-2) = |E(K_{k+1,n-k-2})| edges. This places the threshold inside the complete graph, complementing the parent's extremal-point evaluation and the sibling's monotonicity in n. Everything is elementary Nat.choose arithmetic, sorry-free and 0-axiom.",
+    "futureWork": "Formalise the Woodall extremal graph itself (a clique join realising exactly edgeThreshold n k − 1 edges with no (n-k)-cycle) and verify its edge count against this decomposition, turning the arithmetic deficiency into a witnessed extremal construction."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1012-oq-01",
+      "relationship": "parent",
+      "description": "Defines the Woodall edge threshold and evaluates it at the extremal sizes; this entry places it inside the complete graph K_n."
+    },
+    {
+      "targetId": "erdos-1012-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Records the threshold's recurrence/monotonicity in n; this entry gives the complementary structural fact relative to C(n,2)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "choose_two_split_n",
+      "type": "core",
+      "description": "Complete-graph decomposition: C(n,2) splits into the two Woodall extremal blocks plus the deficiency, for n ≥ k+2.",
+      "leanType": "k + 2 ≤ n → n.choose 2 = (n-k-1).choose 2 + (k+2).choose 2 + (k+1)*(n-k-2)"
+    },
+    {
+      "name": "choose_two_split",
+      "type": "core",
+      "description": "Successor (subtraction-free) form of the decomposition with n = m+k+2.",
+      "leanType": "(m+k+2).choose 2 = (m+1).choose 2 + (k+2).choose 2 + (k+1)*m"
+    },
+    {
+      "name": "edgeThreshold_add_deficiency_n",
+      "type": "core",
+      "description": "The threshold is the complete graph minus the deficiency, plus one.",
+      "leanType": "k + 2 ≤ n → edgeThreshold n k + deficiency n k = n.choose 2 + 1"
+    },
+    {
+      "name": "maxEdges_add_deficiency_n",
+      "type": "core",
+      "description": "Maximal long-cycle-free edge count equals the complete graph minus the deficiency.",
+      "leanType": "k + 2 ≤ n → (edgeThreshold n k - 1) + deficiency n k = n.choose 2"
+    },
+    {
+      "name": "two_mul_choose_two_succ",
+      "type": "supporting",
+      "description": "Doubling lemma linearising the binomial arithmetic.",
+      "leanType": "2 * (x+1).choose 2 = (x+1) * x"
+    },
+    {
+      "name": "deficiency_eq_bipartite_edges",
+      "type": "supporting",
+      "description": "The deficiency is the edge count of the complete bipartite graph K_{k+1,n-k-2}.",
+      "leanType": "deficiency n k = (k+1) * (n-k-2)"
+    },
+    {
+      "name": "maxEdges_hamiltonian",
+      "type": "supporting",
+      "description": "k=0 Hamiltonian (Ore) specialisation, deficiency n − 2.",
+      "leanType": "2 ≤ n → (edgeThreshold n 0 - 1) + (n - 2) = n.choose 2"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "D. R. Woodall"
+      ],
+      "title": "Sufficient conditions for circuits in graphs",
+      "year": "1972",
+      "venue": "Proceedings of the London Mathematical Society, vol. s3-24, no. 4, pp. 739–755",
+      "note": "Proves f(k) ≤ 2k+3 and the pancyclicity of dense graphs above the edge threshold whose structure this entry decomposes."
+    },
+    {
+      "authors": [
+        "Oystein Ore"
+      ],
+      "title": "Note on Hamilton circuits",
+      "year": "1961",
+      "venue": "American Mathematical Monthly, vol. 67, p. 55",
+      "note": "The k=0 Hamiltonian regime recovered by the maxEdges_hamiltonian specialisation."
+    }
+  ],
+  "sorries": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "Erdos1012OQ04",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/Erdos1012OQ04.lean"
+  }
+}


### PR DESCRIPTION
## Summary

New 0-axiom research leaf for **Erdős Problem #1012** (Long Cycles in Dense Graphs), answering the open question `erdos-1012-oq-04`: where does the Woodall edge threshold sit inside the **complete graph** `K_n`?

The parent `Erdos1012OQ01` defines the threshold
`edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1` and evaluates it at the extremal sizes; the sibling `Erdos1012OQ01OQ02` records its monotonicity in `n`. Neither relates it to the `C(n,2)` edges of `K_n`. This entry supplies that decomposition.

## Main result

$$\binom{n}{2} = \binom{n-k-1}{2} + \binom{k+2}{2} + (k+1)(n-k-2)\qquad (n \ge k+2)$$

so the maximal long-cycle-free edge count `edgeThreshold n k − 1` is exactly the complete graph minus a **deficiency** of `(k+1)(n-k-2)` edges — the edge count of the complete bipartite graph `K_{k+1, n-k-2}`, precisely the bipartite gap of the Woodall extremal construction:

$$\texttt{edgeThreshold } n\,k \;=\; \binom{n}{2} - (k+1)(n-k-2) + 1.$$

## Contents (9 theorems, 2 defs, 171 lines)

- `two_mul_choose_two_succ` — doubling lemma `2·C(x+1,2) = (x+1)·x` (linearises the binomial arithmetic).
- `choose_two_split` / `choose_two_split_n` — the decomposition (subtraction-free successor form and the `n`-indexed form).
- `edgeThreshold_add_deficiency(_n)` — threshold + deficiency = `C(n,2) + 1`.
- `maxEdges_add_deficiency_n` — maximal long-cycle-free edge count = `K_n` minus deficiency.
- `deficiency_eq_bipartite_edges` — the deficiency is `|E(K_{k+1,n-k-2})|`.
- `maxEdges_hamiltonian` — `k=0` Hamiltonian (Ore) specialisation.
- `deficiency_at_extremal` — `(k+1)·k` at `n = 2k+2`.

## Proof technique

Reparametrise `n = m+k+2` to eliminate truncated `ℕ` subtraction, double every `C(x+1,2)` to `(x+1)·x`, close the resulting polynomial identity with `ring`, and cancel the factor 2. Numerically checked at `(n,k) = (6,2), (7,2), (5,0)`.

## Verification

Self-contained (`import Mathlib`; re-declares the parent's one-line `edgeThreshold`). Compiled with `lake env lean` (docker build host down). `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries, no native_decide**. `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)