### PR TITLE
Enrich Mirsky maxChainLen = Set.chainHeight bridge: add index.ts + annotations

### DIFF
--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dilworth-oq010102-ann-header",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 60 },
+    "type": "context",
+    "title": "Bridging a bespoke invariant to a library standard",
+    "content": "Mirsky's theorem (1971), the order-dual of Dilworth's, says a finite poset's minimum antichain-cover size equals its maximum chain length. The gallery's companion files prove this with a hand-rolled invariant maxChainLen — a Finset.sup of chain cardinalities. Mathlib independently carries a general order-theoretic Set.chainHeight r s: the supremum in ℕ∞ of the extended cardinalities of r-chains inside s. This file proves the two coincide on a finite poset, (maxChainLen : ℕ∞) = (Set.univ).chainHeight (· ≤ ·), so the gallery's Mirsky development can be read in Mathlib's vocabulary. Context is an arbitrary finite poset [PartialOrder α] [Fintype α], with Classical.propDecidable registered for the Finset operations.",
+    "mathContext": "$(\\mathrm{maxChainLen} : \\mathbb{N}_\\infty) = (\\mathrm{Set.univ}).\\mathrm{chainHeight}(\\le)$, bridging a Finset.sup invariant to Mathlib's $\\mathrm{Set.chainHeight}$.",
+    "significance": "context",
+    "relatedConcepts": ["Mirsky's theorem", "Dilworth duality", "Set.chainHeight", "chain", "antichain cover"],
+    "prerequisites": ["partial orders and chains", "the parent Mirsky hard-direction file"]
+  },
+  {
+    "id": "dilworth-oq010102-ann-dictionary",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 73 },
+    "type": "definition",
+    "title": "The predicate dictionary: Finset chains are set chains",
+    "content": "isChainOn_iff_isChain is the only genuine content of the file: the parent's Finset-level predicate IsChainOn C (pairwise ≤-comparable) holds iff its coercion ↑C is a Mathlib chain IsChain (· ≤ ·). The forward direction drops the redundant x ≠ y hypothesis (comparability is supplied unconditionally on Finset members); the reverse handles the x = y case by reflexivity (le_rfl), since IsChain only constrains distinct elements. The lemma omits [Fintype α] — it is a pure translation needing no finiteness. Once this dictionary is in place, the two height inequalities become direct applications of off-the-shelf chain-height lemmas.",
+    "mathContext": "$\\mathrm{IsChainOn}\\,C \\iff \\mathrm{IsChain}\\,(\\le)\\,(\\uparrow\\! C)$; reverse fills $x=y$ by $\\le$-reflexivity.",
+    "significance": "key",
+    "relatedConcepts": ["IsChain", "Finset coercion", "reflexivity", "comparability"],
+    "prerequisites": ["chains in a partial order", "Finset-to-set coercion ↑C"]
+  },
+  {
+    "id": "dilworth-oq010102-ann-lower",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 90 },
+    "type": "technique",
+    "title": "Lower bound: the attaining chain witnesses the supremum",
+    "content": "The lower half of maxChainLen_eq_univ_chainHeight (maxChainLen ≤ chainHeight). The parent's exists_chain_card_eq_maxChainLen supplies a Finset chain C with C.card = maxChainLen. Via the dictionary, ↑C is a Mathlib chain contained in univ, so Set.encard_le_chainHeight_of_isChain gives (↑C).encard ≤ chainHeight. Rewriting encard ↑C = C.card (Set.encard_coe_eq_coe_finsetCard) and C.card = maxChainLen closes the inequality. The witness chain on the gallery side maps directly onto the supremum defining chainHeight.",
+    "mathContext": "$\\mathrm{maxChainLen} = |C| = (\\uparrow C).\\mathrm{encard} \\le \\mathrm{chainHeight}$, $C$ the attaining chain.",
+    "significance": "supporting",
+    "relatedConcepts": ["encard_le_chainHeight_of_isChain", "exists_chain_card_eq_maxChainLen", "encard", "extended naturals ℕ∞"],
+    "prerequisites": ["the chain dictionary", "encard of a coerced Finset"]
+  },
+  {
+    "id": "dilworth-oq010102-ann-upper",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 100 },
+    "type": "technique",
+    "title": "Upper bound: a chainHeight-attaining set becomes a Finset",
+    "content": "The upper half (chainHeight ≤ maxChainLen). Because univ is finite, Set.exists_eq_chainHeight_of_finite yields a chain set t with t.encard = chainHeight. Its toFinset is, via the dictionary, a chain Finset and therefore a member of allChains (the filtered powerset), so Finset.le_sup bounds t.toFinset.card by maxChainLen = allChains.sup card. Rewriting t.encard = t.toFinset.card (Set.Finite.encard_eq_coe_toFinset_card) and casting through ℕ∞ finishes. Finiteness is what makes the supremum attained on BOTH sides — exists_chain_card_eq_maxChainLen below and exists_eq_chainHeight_of_finite above.",
+    "mathContext": "$\\mathrm{chainHeight} = t.\\mathrm{encard} = |t.\\mathrm{toFinset}| \\le \\mathrm{maxChainLen}$ via $\\mathrm{Finset.le\\_sup}$.",
+    "significance": "key",
+    "relatedConcepts": ["exists_eq_chainHeight_of_finite", "Finset.le_sup", "Set.Finite.toFinset", "le_antisymm"],
+    "prerequisites": ["attainment of chainHeight on finite sets", "the allChains filtered powerset"]
+  },
+  {
+    "id": "dilworth-oq010102-ann-finite",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 108 },
+    "type": "insight",
+    "title": "Finiteness corollary: the height is a genuine natural",
+    "content": "univ_chainHeight_ne_top reads off from the bridge that the chain height of a finite poset is never ⊤. Carrying the main equality in ℕ∞ (rather than ℕ) is essential — Set.chainHeight is valued in the extended naturals — but since the value equals the cast of a natural number maxChainLen, ENat.coe_ne_top recovers that it is finite. This is the small but necessary reconciliation between Mathlib's ℕ∞-valued invariant and the gallery's ℕ-valued one.",
+    "mathContext": "$\\mathrm{chainHeight}(\\le) = \\uparrow\\mathrm{maxChainLen} \\ne \\top$ since a cast natural is never $\\top$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ENat.coe_ne_top", "ℕ∞ vs ℕ", "finiteness", "extended naturals"],
+    "prerequisites": ["the bridge equality", "the top element of ℕ∞"]
+  },
+  {
+    "id": "dilworth-oq010102-ann-mirsky",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 104, "endLine": 122 },
+    "type": "insight",
+    "title": "Mirsky's min–max theorem in Mathlib's vocabulary",
+    "content": "mirsky_chainHeight restates the gallery's Mirsky result in library terms: there exists an antichain cover 𝒜 (every block an antichain, every point covered) whose cardinality equals Set.chainHeight, and no antichain cover is smaller. The proof takes the parent's mirsky_min_antichain_cover (a minimal cover of size maxChainLen) and rewrites its cardinality through the bridge. This upgrades the bespoke statement into one about Mathlib's standard invariant, making the result reusable by any development phrased in Set.chainHeight — the payoff of building the bridge.",
+    "mathContext": "$\\min\\{|\\mathcal{A}| : \\mathcal{A}\\text{ an antichain cover}\\} = (\\mathrm{Set.univ}).\\mathrm{chainHeight}(\\le)$.",
+    "significance": "key",
+    "relatedConcepts": ["mirsky_min_antichain_cover", "min–max theorem", "antichain cover", "reusability"],
+    "prerequisites": ["the parent Mirsky hard direction", "the bridge equality"]
+  }
+]

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const dilworthTheoremOQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const dilworthTheoremOQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const dilworthTheoremOQ01OQ01OQ02Data: ProofData = {
+  proof: dilworthTheoremOQ01OQ01OQ02Proof,
+  annotations: dilworthTheoremOQ01OQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `dilworth-theorem-oq-01-oq-01-oq-02` (Mirsky's maxChainLen equals Mathlib's Set.chainHeight on a finite poset).

## Gap addressed
Rich `meta.json` but **missing both `index.ts` and `annotations.json`** — without `index.ts`, Vite's `import.meta.glob` cannot discover the proof and the page renders **"proof not found"** on the live site.

## Changes
- **`index.ts`** — standard Vite entry point wiring `meta.json`, `annotations.json`, and the raw Lean source `Proofs/DilworthTheoremOQ01OQ01OQ02.lean`.
- **`annotations.json`** — 6 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering: the bridge context (bespoke invariant → library standard), the chain predicate dictionary `isChainOn_iff_isChain`, the lower bound (attaining chain witnesses the supremum), the upper bound (chainHeight-attaining set → Finset via `Finset.le_sup`), the finiteness corollary, and Mirsky's min–max theorem restated in `Set.chainHeight` vocabulary.

## Verification
- `tsc --noEmit` passes (0 errors); `annotations.json` parses cleanly.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0 sorries; imports parent invariants from `Proofs.DilworthMirskyHardOQ01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)