### PR TITLE
Enrich Ordinal Induction & Von Neumann Cumulative Hierarchy: add index.ts + annotations

### DIFF
--- a/src/data/proofs/mathematical-induction-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "mathind-oq0104-ann-header",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Ordinal induction meets the cumulative hierarchy",
+    "content": "The parent entry showed that Lean's well-founded recursion is exactly transfinite induction, packaged as Ordinal.induction. This file answers the parent's fourth open question: how does Ordinal.induction relate to von Neumann's cumulative hierarchy V_α and to WellFounded.fix? The unifying device is the rank function, which assigns each set the least ordinal level strictly above it. Rank embeds set membership into the order on ordinals, so a single ordinal-induction principle, transported along rank, simultaneously yields the well-foundedness of membership (the Axiom of Foundation), the rank-stratified and ε-induction principles, and the uniqueness of the hierarchy as the fixed point of its cumulative recursion.",
+    "mathContext": "$V_\\alpha = \\bigcup_{\\beta<\\alpha}\\mathcal P(V_\\beta)$; $\\operatorname{rank}$ embeds $(\\in)$ into $(<)$ on $\\mathrm{Ordinal}$.",
+    "significance": "context",
+    "relatedConcepts": ["Ordinal.induction", "von Neumann hierarchy", "rank function", "Axiom of Foundation", "transfinite induction"],
+    "prerequisites": ["well-founded recursion", "ordinals and the cumulative hierarchy"]
+  },
+  {
+    "id": "mathind-oq0104-ann-foundation",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 55, "endLine": 88 },
+    "type": "insight",
+    "title": "Foundation from ordinal well-foundedness via rank",
+    "content": "The structural heart: mem_imp_rank_lt records the rank drop y ∈ x ⟹ rank y < rank x (Mathlib's ZFSet.rank_lt_of_mem), the single fact carrying the whole Axiom of Foundation. mem_subrelation_rank then expresses membership as a Subrelation of the rank-pullback InvImage(<) rank — i.e. rank is an order-embedding of the membership relation into the well-founded order on ordinals. Composing InvImage.wf (well-foundedness pulls back along rank from wellFounded_lt on Ordinal) with Subrelation.wf yields mem_wf_via_rank: WellFounded (· ∈ ·). This re-derives Foundation through the cumulative-hierarchy rank rather than Mathlib's PSet-level argument, making explicit that Foundation is downstream of ordinal well-foundedness.",
+    "mathContext": "$y\\in x \\Rightarrow \\operatorname{rank}y < \\operatorname{rank}x$; $(\\in)\\subseteq\\operatorname{InvImage}(<)\\,\\operatorname{rank}$; hence $\\mathrm{WellFounded}(\\in)$.",
+    "significance": "key",
+    "relatedConcepts": ["ZFSet.rank_lt_of_mem", "Subrelation.wf", "InvImage.wf", "Axiom of Foundation"],
+    "prerequisites": ["the rank function on sets", "transfer of well-foundedness along functions and to subrelations"]
+  },
+  {
+    "id": "mathind-oq0104-ann-strong",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 89, "endLine": 107 },
+    "type": "technique",
+    "title": "Rank-stratified strong induction",
+    "content": "rank_strong_induction is Ordinal.induction run directly on the rank: to prove P at every set x, it suffices to prove P x from P holding on all sets of strictly smaller rank. The proof applies Ordinal.induction to the predicate 'P holds for every set of rank o', then unfolds at o = rank x. This is the template instance — every set-theoretic induction principle in the file is a transported copy of this one ordinal induction, with the rank function as the transport map.",
+    "mathContext": "$\\big(\\forall x,\\ (\\forall y,\\ \\operatorname{rank}y<\\operatorname{rank}x\\to P\\,y)\\to P\\,x\\big)\\to\\forall x,\\ P\\,x.$",
+    "significance": "key",
+    "relatedConcepts": ["Ordinal.induction", "strong induction", "rank stratification", "transport along a map"],
+    "prerequisites": ["ordinal well-founded recursion", "the rank drop"]
+  },
+  {
+    "id": "mathind-oq0104-ann-epsilon",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 108, "endLine": 121 },
+    "type": "insight",
+    "title": "ε-induction recovered through the rank",
+    "content": "mem_induction is ε-induction (Foundation's induction principle): prove P x from P holding on all members y ∈ x. It is recovered by specializing rank_strong_induction through the rank drop — every member y ∈ x has rank y < rank x, so the membership-induction hypothesis is implied by the rank-induction hypothesis. Mathlib derives ε-induction (ZFSet.inductionOn) from PSet.mem_wf at the pre-set level; routing it through the cumulative rank instead makes the dependence on ordinal well-foundedness explicit.",
+    "mathContext": "$\\big(\\forall x,\\ (\\forall y\\in x,\\ P\\,y)\\to P\\,x\\big)\\to\\forall x,\\ P\\,x$ — the $\\in$-induction of Foundation.",
+    "significance": "supporting",
+    "relatedConcepts": ["ε-induction", "ZFSet.inductionOn", "membership induction", "specialization"],
+    "prerequisites": ["rank-stratified strong induction", "the rank drop along membership"]
+  },
+  {
+    "id": "mathind-oq0104-ann-levels",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 122, "endLine": 142 },
+    "type": "technique",
+    "title": "Climbing the cumulative hierarchy",
+    "content": "vonNeumann_level_induction rephrases strong induction in hierarchy terms: prove P for all sets by extending it from V_o (all sets of rank < o) to the sets of rank exactly o. The translation uses ZFSet.mem_vonNeumann (x ∈ V_o ↔ rank x < o), which identifies the levels of the cumulative hierarchy with rank thresholds. The induction thus literally climbs the levels of the von Neumann universe, the concrete picture behind the abstract rank induction.",
+    "mathContext": "$x \\in V_o \\iff \\operatorname{rank}x < o$; induction over $o$ proves $P$ on all of $V_o$, hence on every set.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZFSet.mem_vonNeumann", "level induction", "rank thresholds", "cumulative levels"],
+    "prerequisites": ["the von Neumann levels V_o", "the rank/level identification"]
+  },
+  {
+    "id": "mathind-oq0104-ann-unique",
+    "proofId": "mathematical-induction-oq-01-oq-04",
+    "range": { "startLine": 143, "endLine": 169 },
+    "type": "insight",
+    "title": "Uniqueness of the hierarchy as a fixed point",
+    "content": "vonNeumann_unique closes the loop with WellFounded.fix: the cumulative functional F o = ⋃_{a<o} 𝒫(F a) has a UNIQUE solution, namely the von Neumann hierarchy. The proof runs Ordinal.induction on o; assuming F a = V_a for all a < o, the membership form of the recurrence (mem_iUnion, mem_powerset, and ZFSet.mem_vonNeumann') forces F o = V_o by set extensionality. This is precisely the statement that vonNeumann is the WellFounded.fix fixed point of its defining functional. vonNeumann_mem_iff_unique gives the parallel membership-characterisation uniqueness — the same conclusion stated level-by-level via membership.",
+    "mathContext": "$\\big(\\forall o,\\ F o = \\bigcup_{a<o}\\mathcal P(F a)\\big) \\Rightarrow F = V_\\bullet$ — the unique fixed point of the cumulative functional.",
+    "significance": "key",
+    "relatedConcepts": ["WellFounded.fix", "ZFSet.mem_vonNeumann'", "fixed point uniqueness", "set extensionality"],
+    "prerequisites": ["Ordinal.induction", "the membership form of the cumulative recurrence"]
+  }
+]

--- a/src/data/proofs/mathematical-induction-oq-01-oq-04/index.ts
+++ b/src/data/proofs/mathematical-induction-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MathematicalInductionOQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const mathematicalInductionOQ01OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const mathematicalInductionOQ01OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const mathematicalInductionOQ01OQ04Data: ProofData = {
+  proof: mathematicalInductionOQ01OQ04Proof,
+  annotations: mathematicalInductionOQ01OQ04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `mathematical-induction-oq-01-oq-04` (Ordinal Induction and the Von Neumann Cumulative Hierarchy).

## Gap addressed
Rich `meta.json` but **missing both `index.ts` and `annotations.json`** — without `index.ts`, Vite's `import.meta.glob` cannot discover the proof and the page renders **"proof not found"** on the live site.

## Changes
- **`index.ts`** — standard Vite entry point wiring `meta.json`, `annotations.json`, and the raw Lean source `Proofs/MathematicalInductionOQ01OQ04.lean`.
- **`annotations.json`** — 6 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering: the rank bridge context, Foundation from ordinal well-foundedness via rank, rank-stratified strong induction as `Ordinal.induction`, ε-induction recovered through the rank drop, climbing the cumulative hierarchy levels, and uniqueness of the hierarchy as the `WellFounded.fix` fixed point.

## Verification
- `tsc --noEmit` passes (0 errors); `annotations.json` parses cleanly.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0 sorries; built on Mathlib's von Neumann hierarchy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)