### PR TITLE
research(erdos-ginzburg-ziv-oq-01-oq-01): Davenport constant D(ℤ/nℤ)=n [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2757,6 +2757,7 @@ import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
 import Proofs.ErdosDivisibilityPigeonholeOQ01OQ01
 import Proofs.ErdosGinzburgZivOQ01
+import Proofs.ErdosGinzburgZivOQ01OQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosKoRadoOQ02
 import Proofs.ErdosMordellChordIdentity

--- a/proofs/Proofs/ErdosGinzburgZivOQ01OQ01.lean
+++ b/proofs/Proofs/ErdosGinzburgZivOQ01OQ01.lean
@@ -1,0 +1,154 @@
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-
+# The Davenport constant of a cyclic group: D(ℤ/nℤ) = n
+
+## What This Proves
+
+For a finite abelian group `G`, the **Davenport constant** `D(G)` is the smallest
+integer `d` such that *every* sequence of `d` elements of `G` (repetitions allowed)
+admits a **nonempty zero-sum subsequence**. It is a second fundamental zero-sum
+invariant of `G`, sitting alongside the Erdős–Ginzburg–Ziv constant
+`s(G)` (the smallest `d` forcing a zero-sum subsequence of length exactly `|G|`).
+For the cyclic group the two are different numbers: this file proves the cyclic
+Davenport value
+
+  `D(ℤ/nℤ) = n`,
+
+complementing the gallery's `s(ℤ/nℤ) = 2n − 1` (Erdős–Ginzburg–Ziv, sharp form).
+
+The result is packaged as an `IsLeast` statement about the set of admissible
+lengths, which is exactly the textbook definition of the Davenport constant as a
+minimum. Two ingredients meet at `n`:
+
+* **Upper bound `n ∈ DavenportSet`** (`exists_nonempty_zerosum`): any `n` elements
+  `a₀, …, a_{n-1}` of `ℤ/nℤ` contain a nonempty (in fact *consecutive*) zero-sum
+  block. The crux is the classical prefix-sum pigeonhole: the `n + 1` partial sums
+  `P(0), …, P(n)` cannot be distinct in the `n`-element group `ℤ/nℤ`, so two of them
+  coincide, `P(u) = P(v)` with `u < v`, and the intervening block
+  `{k : u ≤ k < v}` is a nonempty subset summing to `P(v) − P(u) = 0`.
+
+* **Lower bound (sharpness)** (`davenport_lower_bound`, `davenport_sharp`): no
+  shorter length works. The all-ones sequence of length `n − 1` (i.e. `n − 1`
+  copies of a generator) has every nonempty subsequence summing to its cardinality
+  `c` with `1 ≤ c ≤ n − 1`, never `0 mod n`. Hence every admissible length is `≥ n`.
+
+Combining the two, `n` is the least admissible length, i.e. `D(ℤ/nℤ) = n`
+(`davenport_zmod`). All results are verified with `0` axioms and `0` sorries.
+
+## Why This Is Not Already in the Gallery / Mathlib
+
+Mathlib has neither the Davenport constant nor this prefix-sum zero-sum lemma; its
+only zero-sum content is Erdős–Ginzburg–Ziv. The gallery's
+`erdos-ginzburg-ziv-oq-01` computes the *EGZ* constant `s(ℤ/nℤ) = 2n − 1`; the
+Davenport constant is the genuinely distinct companion invariant, with an
+independent (prefix-sum, not Chevalley–Warning) proof and a different value `n`.
+The neighbouring `erdos-divisibility-pigeonhole` family concerns the divisibility
+relation, not zero sums, so there is no overlap.
+-/
+
+namespace Proofs.DavenportZMod
+
+open Finset
+
+variable (n : ℕ) [NeZero n]
+
+/-- The prefix sum: the sum of the first `k` entries of the sequence `a`. -/
+def prefixSum (a : Fin n → ZMod n) (k : ℕ) : ZMod n :=
+  ∑ i ∈ univ.filter (fun i : Fin n => i.val < k), a i
+
+/-- The set of *admissible lengths*: those `d` for which every length-`d`
+sequence over `ℤ/nℤ` has a nonempty zero-sum subsequence. The Davenport constant
+is by definition the least element of this set. -/
+def DavenportSet (n : ℕ) : Set ℕ :=
+  {d | ∀ a : Fin d → ZMod n, ∃ S : Finset (Fin d), S.Nonempty ∧ ∑ i ∈ S, a i = 0}
+
+omit [NeZero n] in
+/-- **Prefix-sum split.** For `u ≤ v`, the first `v` entries split as the first
+`u` entries together with the block `[u, v)`. -/
+theorem prefixSum_split (a : Fin n → ZMod n) {u v : ℕ} (huv : u ≤ v) :
+    prefixSum n a v
+      = prefixSum n a u + ∑ k ∈ univ.filter (fun k : Fin n => u ≤ k.val ∧ k.val < v), a k := by
+  unfold prefixSum
+  rw [← Finset.sum_union]
+  · congr 1
+    ext k
+    simp only [mem_filter, mem_union, mem_univ, true_and]
+    omega
+  · rw [Finset.disjoint_filter]
+    intro k _ h
+    omega
+
+/-- **Davenport upper bound (the crux).** Any `n` elements of `ℤ/nℤ` contain a
+nonempty zero-sum subsequence — in fact a nonempty consecutive block. -/
+theorem exists_nonempty_zerosum (a : Fin n → ZMod n) :
+    ∃ S : Finset (Fin n), S.Nonempty ∧ ∑ i ∈ S, a i = 0 := by
+  -- Pigeonhole on the `n + 1` prefix sums `P 0, …, P n` valued in the `n`-element `ZMod n`.
+  have hcard : (univ : Finset (ZMod n)).card < (range (n + 1)).card := by
+    rw [Finset.card_univ, ZMod.card, Finset.card_range]; omega
+  obtain ⟨u, hu, v, hv, huv, hPeq⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hcard
+      (f := fun k => prefixSum n a k) (fun k _ => mem_univ _)
+  rw [Finset.mem_range] at hu hv
+  -- Order the two colliding indices.
+  wlog hlt : u < v generalizing u v
+  · exact this v hv u hu (Ne.symm huv) hPeq.symm (by omega)
+  -- The block `[u, v)` is a nonempty zero-sum subset.
+  refine ⟨univ.filter (fun k : Fin n => u ≤ k.val ∧ k.val < v), ?_, ?_⟩
+  · -- nonempty: the index with value `u` lies in `Fin n` (since `u < v ≤ n`) and in the block
+    refine ⟨⟨u, by omega⟩, ?_⟩
+    simp only [mem_filter, mem_univ, true_and]
+    omega
+  · -- zero-sum: the block sum is `P v - P u = 0`
+    have hsplit := prefixSum_split n a (le_of_lt hlt)
+    have : prefixSum n a u
+        + ∑ k ∈ univ.filter (fun k : Fin n => u ≤ k.val ∧ k.val < v), a k
+        = prefixSum n a u := by rw [← hsplit, hPeq]
+    linear_combination this
+
+/-- `n` is an admissible length: it lies in `DavenportSet n`. -/
+theorem n_mem_DavenportSet : n ∈ DavenportSet n :=
+  exists_nonempty_zerosum n
+
+/-- **Sharpness witness.** The all-ones sequence of length `n - 1` (i.e. `n - 1`
+copies of the generator `1`) has *no* nonempty zero-sum subsequence: every nonempty
+sub-block sums to its cardinality `c` with `1 ≤ c ≤ n - 1`, never `0` in `ℤ/nℤ`. -/
+theorem davenport_sharp :
+    ∃ a : Fin (n - 1) → ZMod n,
+      ∀ S : Finset (Fin (n - 1)), S.Nonempty → ∑ i ∈ S, a i ≠ 0 := by
+  refine ⟨fun _ => 1, fun S hS hzero => ?_⟩
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one] at hzero
+  -- `(S.card : ZMod n) = 0` forces `n ∣ S.card`, impossible for `0 < S.card < n`.
+  rw [ZMod.natCast_eq_zero_iff] at hzero
+  have h1 : 0 < S.card := Finset.card_pos.mpr hS
+  have h2 : S.card ≤ n - 1 := by
+    calc S.card ≤ (univ : Finset (Fin (n - 1))).card := Finset.card_le_card (subset_univ S)
+      _ = n - 1 := by rw [Finset.card_univ, Fintype.card_fin]
+  have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr (NeZero.ne n)
+  have := Nat.le_of_dvd h1 hzero
+  omega
+
+omit [NeZero n] in
+/-- **Davenport lower bound.** Every admissible length is at least `n`: no sequence
+shorter than `n` is guaranteed a nonempty zero-sum subsequence. -/
+theorem davenport_lower_bound : ∀ d ∈ DavenportSet n, n ≤ d := by
+  intro d hd
+  by_contra hlt
+  push_neg at hlt
+  -- The all-ones sequence of length `d < n` is a counterexample to `d ∈ DavenportSet n`.
+  obtain ⟨S, hS, hzero⟩ := hd (fun _ => 1)
+  rw [Finset.sum_const, nsmul_eq_mul, mul_one, ZMod.natCast_eq_zero_iff] at hzero
+  have h1 : 0 < S.card := Finset.card_pos.mpr hS
+  have h2 : S.card ≤ d := by
+    calc S.card ≤ (univ : Finset (Fin d)).card := Finset.card_le_card (subset_univ S)
+      _ = d := by rw [Finset.card_univ, Fintype.card_fin]
+  have := Nat.le_of_dvd h1 hzero
+  omega
+
+/-- **The Davenport constant of the cyclic group: `D(ℤ/nℤ) = n`.** It is the least
+length forcing a nonempty zero-sum subsequence. -/
+theorem davenport_zmod : IsLeast (DavenportSet n) n :=
+  ⟨n_mem_DavenportSet n, davenport_lower_bound n⟩
+
+end Proofs.DavenportZMod

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-davenport-overview",
+    "proofId": "erdos-ginzburg-ziv-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 49 },
+    "type": "context",
+    "title": "The Davenport Constant D(ℤ/nℤ) = n",
+    "content": "The docstring frames the second fundamental zero-sum invariant. The Davenport constant D(G) of a finite abelian group is the least length d such that EVERY length-d sequence over G admits a nonempty zero-sum subsequence. It sits beside the Erdős–Ginzburg–Ziv constant s(G) — which forces a zero-sum subsequence of length exactly |G| — and for the cyclic group the two are different numbers: D(ℤ/nℤ) = n versus s(ℤ/nℤ) = 2n−1. This file answers the open question recorded in the EGZ entry by computing D(ℤ/nℤ) = n with a fully independent proof (prefix-sum pigeonhole, not Chevalley–Warning).",
+    "mathContext": "$D(\\mathbb{Z}/n\\mathbb{Z}) = n$: the least $d$ such that every length-$d$ sequence over $\\mathbb{Z}/n\\mathbb{Z}$ has a nonempty zero-sum subsequence.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Davenport constant",
+      "zero-sum sequences",
+      "additive combinatorics",
+      "pigeonhole principle"
+    ]
+  },
+  {
+    "id": "ann-davenport-set",
+    "proofId": "erdos-ginzburg-ziv-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 66 },
+    "type": "definition",
+    "title": "Admissible Lengths: the Minimum-Definition of D(G)",
+    "content": "DavenportSet n is the set of lengths d for which every sequence a : Fin d → ℤ/nℤ has a nonempty subset summing to 0. The Davenport constant is by definition the LEAST element of this set, so proving D(ℤ/nℤ) = n becomes the IsLeast statement IsLeast (DavenportSet n) n — packaging the invariant exactly as in the textbook definition rather than as two separate inequalities.",
+    "mathContext": "$\\mathrm{DavenportSet}(n) = \\{ d : \\forall a \\in (\\mathbb{Z}/n\\mathbb{Z})^d,\\ \\exists \\emptyset \\neq S,\\ \\sum_{i\\in S} a_i = 0 \\}$.",
+    "significance": "core",
+    "relatedConcepts": ["IsLeast", "minimum", "zero-sum subsequence"]
+  },
+  {
+    "id": "ann-davenport-prefixsum",
+    "proofId": "erdos-ginzburg-ziv-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 81 },
+    "type": "technique",
+    "title": "Prefix Sums and their Additive Split",
+    "content": "prefixSum a k is the sum of the entries with index < k. The key algebraic fact prefixSum_split says that for u ≤ v, the first v entries split as the first u entries plus the block [u, v): P(v) = P(u) + (∑ over the block). This is proved by Finset.sum_union after exhibiting the index filter for [0,v) as the disjoint union of the filters for [0,u) and [u,v) — pure index bookkeeping discharged by omega. The split is the engine that turns a coincidence of two prefix sums into a zero-sum block.",
+    "mathContext": "$P(v) = P(u) + \\sum_{u \\le k < v} a_k$ for $u \\le v$.",
+    "significance": "core",
+    "relatedConcepts": ["telescoping", "partial sums", "Finset.sum_union"]
+  },
+  {
+    "id": "ann-davenport-upper",
+    "proofId": "erdos-ginzburg-ziv-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 108 },
+    "type": "key-step",
+    "title": "The Crux: Prefix-Sum Pigeonhole (Upper Bound)",
+    "content": "exists_nonempty_zerosum proves that any n elements of ℤ/nℤ contain a nonempty — in fact CONSECUTIVE — zero-sum block. There are n+1 prefix sums P(0), …, P(n) but only n residues in ℤ/nℤ, so by the pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to) two of them coincide: P(u) = P(v) with u < v. The intervening block {k : u ≤ k < v} is nonempty (the index valued u lies in Fin n since u < v ≤ n) and sums to P(v) − P(u) = 0 by prefixSum_split. A wlog reduces the symmetric u, v case. This is the classical n-consecutive-integers argument.",
+    "mathContext": "$n+1$ prefix sums in an $n$-element group must collide: $P(u)=P(v)$, $u<v$, giving $\\sum_{u\\le k<v} a_k = 0$.",
+    "significance": "core",
+    "relatedConcepts": ["pigeonhole principle", "consecutive subsequence", "ZMod.card"]
+  },
+  {
+    "id": "ann-davenport-sharp",
+    "proofId": "erdos-ginzburg-ziv-oq-01-oq-01",
+    "range": { "startLine": 114, "endLine": 147 },
+    "type": "key-step",
+    "title": "Sharpness: the All-Ones Extremal Sequence (Lower Bound)",
+    "content": "davenport_sharp exhibits the extremal zero-sum-free sequence: n−1 copies of the generator 1. Any nonempty sub-block S sums to ∑_{i∈S} 1 = (S.card : ℤ/nℤ); since 1 ≤ S.card ≤ n−1 < n, the cardinality is not divisible by n (ZMod.natCast_eq_zero_iff), so the sum is nonzero. davenport_lower_bound upgrades this to: every admissible length is ≥ n, because the all-ones sequence of any length d < n is a counterexample. Together with the upper bound, n is the LEAST admissible length, giving davenport_zmod : IsLeast (DavenportSet n) n.",
+    "mathContext": "The sequence $1^{n-1}$ has every nonempty sub-block summing to $c \\in \\{1,\\dots,n-1\\}$, never $0 \\bmod n$; hence $D(\\mathbb{Z}/n\\mathbb{Z}) \\ge n$.",
+    "significance": "core",
+    "relatedConcepts": ["sharpness", "extremal configuration", "zero-sum-free sequence"]
+  }
+]

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "erdos-ginzburg-ziv-oq-01-oq-01",
+  "slug": "erdos-ginzburg-ziv-oq-01-oq-01",
+  "title": "The Davenport constant of a cyclic group: D(ℤ/nℤ) = n",
+  "description": "The Davenport constant D(G) of a finite abelian group is the least length d such that every length-d sequence over G has a nonempty zero-sum subsequence. For the cyclic group this entry proves D(ℤ/nℤ) = n, packaged as an IsLeast statement — the second fundamental zero-sum invariant alongside the Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n−1. The upper bound is the classical prefix-sum pigeonhole; the lower bound is the all-ones extremal sequence of length n−1. Fully verified, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Proofs.DavenportZMod",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/ErdosGinzburgZivOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Harold Davenport (constant named, ~1960s); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosGinzburgZivOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "additive-combinatorics",
+      "number-theory",
+      "zero-sum",
+      "davenport-constant",
+      "pigeonhole",
+      "ZMod",
+      "extremal",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+        "description": "Pigeonhole: a map from a larger finset into a smaller one identifies two distinct points; applied to the n+1 prefix sums valued in the n-element ZMod n",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "Fintype.card (ZMod n) = n for NeZero n; supplies the n in the pigeonhole count n < n+1",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod n) = 0 ↔ n ∣ a; turns a block-cardinality residue into a divisibility condition for the sharpness argument",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_union",
+        "description": "Sum over a disjoint union splits additively; used to peel the prefix sum P(v) into P(u) plus the block sum [u,v)",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "∑_{i∈S} c = S.card • c; evaluates the all-ones extremal sequence's subsequence sums to their cardinality",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "DavenportSet: the set of admissible lengths d such that every length-d sequence over ℤ/nℤ has a nonempty zero-sum subsequence — the textbook minimum-definition of the Davenport constant, packaged for an IsLeast statement",
+      "prefixSum / prefixSum_split: the prefix sums of a sequence and their additive split P(v) = P(u) + (block sum over [u,v)) for u ≤ v, the engine of the pigeonhole argument",
+      "exists_nonempty_zerosum: the Davenport upper bound (the crux) — any n elements of ℤ/nℤ contain a nonempty, in fact consecutive, zero-sum block, proved by pigeonholing the n+1 prefix sums into the n-element group ℤ/nℤ",
+      "davenport_sharp: the sharpness witness — the all-ones sequence of length n−1 (n−1 copies of a generator) has no nonempty zero-sum subsequence, since every nonempty sub-block sums to its cardinality 1 ≤ c ≤ n−1, never 0 mod n",
+      "davenport_lower_bound: every admissible length is ≥ n, the lower-bound half of the IsLeast statement",
+      "davenport_zmod: the headline IsLeast (DavenportSet n) n, i.e. D(ℤ/nℤ) = n — the second fundamental zero-sum invariant of the cyclic group, answering the open question posed by the EGZ entry (erdos-ginzburg-ziv-oq-01)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 154,
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "conclusion": {
+    "summary": "The Davenport constant of the cyclic group is computed and verified: D(ℤ/nℤ) = n, stated as IsLeast (DavenportSet n) n (davenport_zmod). The upper bound (exists_nonempty_zerosum) is the prefix-sum pigeonhole — the n+1 partial sums P(0),…,P(n) cannot be distinct in the n-element group ℤ/nℤ, so a coincidence P(u) = P(v) with u < v exhibits the intervening block as a nonempty zero-sum subsequence. The lower bound (davenport_lower_bound, davenport_sharp) uses the all-ones extremal sequence of length n−1, whose nonempty sub-block sums equal their cardinalities 1,…,n−1, none divisible by n. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Computes the second fundamental zero-sum invariant of ℤ/nℤ, complementing the gallery's Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n−1 and exhibiting the two as distinct numbers (n vs 2n−1). Directly answers the open question recorded in the EGZ entry (erdos-ginzburg-ziv-oq-01) on whether the Davenport constant admits a packaged formalization. Mathlib has neither the Davenport constant nor the prefix-sum zero-sum lemma; the proof is independent of EGZ (prefix-sum pigeonhole, not Chevalley–Warning).",
+    "openQuestions": [
+      "Does the Davenport constant of the non-cyclic group ℤ/nℤ × ℤ/mℤ (m ∣ n) equal n + m − 1, and can the prefix-sum method be adapted to the rank-2 case?",
+      "Can the exact structure of the extremal (zero-sum-free) sequences of length n−1 be characterized — namely all sequences a·g for a generator g — and formalized as a uniqueness statement?"
+    ]
+  },
+  "crossReferences": [
+    "erdos-ginzburg-ziv-oq-01"
+  ],
+  "references": [
+    {
+      "authors": "Davenport, Harold",
+      "title": "Proceedings of the Midwestern Conference on Group Theory and Number Theory (Ohio State University, 1966)",
+      "year": "1966",
+      "note": "Origin of the Davenport constant as the least d forcing a nonempty zero-sum subsequence"
+    },
+    {
+      "authors": "Gao, Weidong; Geroldinger, Alfred",
+      "title": "Zero-sum problems in finite abelian groups: a survey",
+      "year": "2006",
+      "note": "Expositio Mathematica 24, 337–369 — the Davenport constant D(G), the value D(ℤ/nℤ) = n, and the EGZ constant s(G)"
+    },
+    {
+      "authors": "Geroldinger, Alfred; Halter-Koch, Franz",
+      "title": "Non-Unique Factorizations: Algebraic, Combinatorial and Analytic Theory",
+      "year": "2006",
+      "note": "Pure and Applied Mathematics 278, Chapman & Hall/CRC — the Davenport constant and its role in factorization theory; the cyclic value D(C_n) = n"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Computes the **Davenport constant of the cyclic group**, `D(ℤ/nℤ) = n`, packaged as `IsLeast (DavenportSet n) n` (`davenport_zmod`). This is the second fundamental zero-sum invariant of `ℤ/nℤ`, distinct from the gallery's Erdős–Ginzburg–Ziv constant `s(ℤ/nℤ) = 2n−1` (entry `erdos-ginzburg-ziv-oq-01`). The two are different numbers (`n` vs `2n−1`).

It **directly answers an open question** posed by the EGZ entry: *"Does the Davenport constant D(ℤ/nℤ) = n admit a similar packaged formalization?"*

## Proof

- **Upper bound** (`exists_nonempty_zerosum`, the crux): any `n` elements of `ℤ/nℤ` contain a nonempty — in fact *consecutive* — zero-sum block. The `n+1` prefix sums `P(0),…,P(n)` cannot be distinct in the `n`-element group, so a collision `P(u)=P(v)`, `u<v`, makes the block `[u,v)` a nonempty zero-sum subset (`P(v)−P(u)=0`). This is the classical prefix-sum pigeonhole, **independent of Chevalley–Warning** (Mathlib's EGZ route).
- **Lower bound** (`davenport_sharp`, `davenport_lower_bound`): the all-ones sequence of length `n−1` has every nonempty sub-block summing to its cardinality `c ∈ {1,…,n−1}`, never `0 mod n`. Hence every admissible length is `≥ n`.

## Originality

Mathlib has **neither** the Davenport constant **nor** the prefix-sum zero-sum lemma (its only zero-sum content is EGZ). The neighbouring `erdos-divisibility-pigeonhole` family concerns divisibility, not zero sums — no overlap.

## Verification

- 6 theorems, 2 definitions, 154 lines
- **0 axioms, 0 sorries**, no `native_decide`
- `#print axioms davenport_zmod` → `[propext, Classical.choice, Quot.sound]` (foundational only)
- Compiled standalone against Mathlib v4.26.0 (Docker daemon down this cycle; `lake env lean` single-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)