### PR TITLE
research(lucas-theorem-oq-01-oq-01-oq-02): Kummer carry count + zero-carry stratum fusing Lucas/Kummer/Fine [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3376,6 +3376,7 @@ import Proofs.LucasLehmerTestOQ01
 import Proofs.LucasTheoremOQ01
 import Proofs.LucasTheoremOQ01OQ01
 import Proofs.LucasTheoremOQ01OQ01OQ01
+import Proofs.LucasTheoremOQ01OQ01OQ02
 import Proofs.LucasTheoremOQ01OQ02
 import Proofs.LucasTheoremOQ01OQ02OQ01
 import Proofs.MachinFromAddition

--- a/proofs/Proofs/LucasTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LucasTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,219 @@
+import Mathlib
+import Proofs.LucasTheoremOQ01OQ01
+
+/-!
+# Kummer's carry count and the zero-carry stratum of Fine's theorem
+
+For a prime `p` and `k ≤ n`, **Kummer's theorem** (1852) identifies the exact power of `p`
+dividing the binomial coefficient `C(n, k)` with the number of carries that occur when adding
+`k` and `n - k` in base `p`.  Mathlib packages this as `Nat.factorization_choose`:
+
+> `(C(n,k)).factorization p = #{ i ∈ [1, b) : pⁱ ≤ k % pⁱ + (n-k) % pⁱ }`,
+
+the right-hand side counting exactly the carry positions.  This file builds the bridge between
+that *valuation* statement and the *divisibility* statement of **Lucas' theorem**, and uses it
+to recover **Fine's theorem** (`LucasTheoremOQ01OQ01`) as the **zero-carry stratum**.
+
+## What this file adds
+
+The parent `FineTheorem` (Fine's theorem) counts the entries of row `n` of Pascal's triangle
+that survive mod `p` — i.e. `fineRow p n = { k ≤ n : ¬ p ∣ C(n,k) }` — and proves the count is
+the digit product `∏ᵢ (nᵢ + 1)`.  But it never characterises *which* columns `k` survive.  That
+characterisation is the content of **Lucas' divisibility criterion**, which is *not* a named
+Mathlib lemma (Mathlib only has the single-digit step `Nat.dvd_choose` and the Lucas
+*congruence* `Choose.choose_modEq_prod_range_choose_nat`).  We prove it here:
+
+> **Lucas' criterion (`not_dvd_choose_iff_forall_digit_le`).**
+> `¬ p ∣ C(n,k) ↔ ∀ i, (k base-p digit i) ≤ (n base-p digit i)`.
+
+i.e. `p ∤ C(n,k)` exactly when `k` is **digit-dominated** by `n` in base `p` ("no borrow when
+subtracting `k` from `n`"), with the dual divisibility statement `p ∣ C(n,k) ↔ ∃ i, nᵢ < kᵢ`.
+
+Combining this with the Kummer valuation produces the **zero-carry stratum** linking all three
+classical theorems:
+
+> **Zero-carry stratum (`carries_eq_zero_iff_forall_digit_le`).**
+> For `k ≤ n`,   `kummerCarries p n k = 0  ↔  ∀ i, kᵢ ≤ nᵢ  ↔  ¬ p ∣ C(n,k)`.
+
+Reading the three sides: *no carries* (Kummer) `⟺` *digit dominance* (Lucas) `⟺` *survives mod
+`p`* (Fine).  Finally `fineRow_eq_digitDominated` rewrites Fine's surviving set as exactly the
+digit-dominated columns, so Fine's count `∏ᵢ (nᵢ + 1)` is literally the size of the zero-carry
+stratum.
+
+## Proof of Lucas' criterion
+
+The engine is the base-`p` factorisation of Pascal's triangle.  Choose `a` with `n, k < pᵃ`.
+The Lucas congruence gives `C(n,k) ≡ ∏_{i<a} C(nᵢ, kᵢ) (mod p)`, so `p ∣ C(n,k)` iff `p` divides
+the product, iff `p ∣ C(nᵢ, kᵢ)` for some single digit.  For digits `nᵢ < p`, the helper
+`not_dvd_choose_lt_iff` shows `p ∤ C(nᵢ, kᵢ) ↔ kᵢ ≤ nᵢ`: if `kᵢ ≤ nᵢ` then `C(nᵢ,kᵢ) ∣ nᵢ!`
+and `p ∤ nᵢ!` (because `nᵢ < p`); if `kᵢ > nᵢ` then `C(nᵢ,kᵢ) = 0`.  Digit positions `i ≥ a`
+contribute nothing because both digits vanish there.
+
+## Status
+
+All results fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+
+## References
+- Kummer, E. (1852). "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen."
+- Lucas, É. (1878). "Théorie des fonctions numériques simplement périodiques."
+- Fine, N. J. (1947). "Binomial coefficients modulo a prime." *Amer. Math. Monthly* 54.
+- Granville, A. (1997). "Arithmetic properties of binomial coefficients."
+-/
+
+open Nat Finset
+
+namespace LucasKummerCarries
+
+/-! ## A single base-`p` digit: divisibility of `C(a, b)` for `a < p`
+
+Within the first `p` rows of Pascal's triangle there are no multiples of `p`: every nonzero
+entry `C(a, b)` with `a < p` is coprime to `p`.  Hence for such a row, `p ∣ C(a, b)` happens
+*only* through the trivial vanishing `b > a`. -/
+
+/-- For a prime `p` and a row index `a < p`, a binomial with `b ≤ a` is coprime to `p`.
+`C(a,b)` divides `a!`, and `a < p` forces `p ∤ a!`. -/
+theorem not_dvd_choose_of_lt {p a b : ℕ} (hp : p.Prime) (ha : a < p) (hb : b ≤ a) :
+    ¬ p ∣ a.choose b := by
+  intro hdvd
+  have hdiv : a.choose b ∣ a ! :=
+    ⟨b ! * (a - b)!, by rw [← mul_assoc]; exact (choose_mul_factorial_mul_factorial hb).symm⟩
+  have hpa : p ∣ a ! := hdvd.trans hdiv
+  rw [hp.dvd_factorial] at hpa
+  exact absurd hpa (not_le.mpr ha)
+
+/-- **Single-digit Lucas step.** For a prime `p` and `a < p`, the binomial `C(a, b)` is coprime
+to `p` exactly when the column fits the row: `b ≤ a`.  (If `b > a` then `C(a, b) = 0`.) -/
+theorem not_dvd_choose_lt_iff {p a b : ℕ} (hp : p.Prime) (ha : a < p) :
+    ¬ p ∣ a.choose b ↔ b ≤ a := by
+  constructor
+  · intro h
+    by_contra hba
+    push_neg at hba
+    exact h (by rw [choose_eq_zero_of_lt hba]; exact dvd_zero p)
+  · exact not_dvd_choose_of_lt hp ha
+
+/-! ## Lucas' divisibility criterion via the Lucas congruence
+
+`p ∣ C(n,k)` is governed digit-by-digit: it occurs iff some base-`p` digit of `k` strictly
+exceeds the corresponding digit of `n`.  Equivalently, `p ∤ C(n,k)` iff `k` is digit-dominated
+by `n`. -/
+
+/-- **Lucas' theorem, divisibility form.** For a prime `p`, the prime `p` divides `C(n,k)`
+exactly when some base-`p` digit of `k` exceeds the corresponding digit of `n`. -/
+theorem dvd_choose_iff_exists_digit_lt {p n k : ℕ} (hp : p.Prime) :
+    p ∣ n.choose k ↔ ∃ i, n / p ^ i % p < k / p ^ i % p := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- A common bound `a` past which all base-`p` digits of `n` and `k` vanish.
+  obtain ⟨a, hna, hka⟩ : ∃ a, n < p ^ a ∧ k < p ^ a :=
+    ⟨n + k,
+      lt_of_lt_of_le (Nat.lt_pow_self hp.one_lt) (Nat.pow_le_pow_right hp.pos (Nat.le_add_right n k)),
+      lt_of_lt_of_le (Nat.lt_pow_self hp.one_lt) (Nat.pow_le_pow_right hp.pos (Nat.le_add_left k n))⟩
+  -- Lucas congruence: `C(n,k) ≡ ∏ᵢ C(nᵢ, kᵢ) (mod p)`, so `p` divides one iff the other.
+  have hcong := Choose.choose_modEq_prod_range_choose_nat (p := p) hna hka
+  have hdvd_iff : p ∣ n.choose k ↔
+      p ∣ ∏ i ∈ Finset.range a, (n / p ^ i % p).choose (k / p ^ i % p) := by
+    rw [← Nat.modEq_zero_iff_dvd, ← Nat.modEq_zero_iff_dvd]
+    exact ⟨hcong.symm.trans, hcong.trans⟩
+  rw [hdvd_iff, (hp.prime).dvd_finset_prod_iff]
+  constructor
+  · rintro ⟨i, _, hi⟩
+    refine ⟨i, ?_⟩
+    have hlt : n / p ^ i % p < p := Nat.mod_lt _ hp.pos
+    by_contra hle
+    push_neg at hle
+    exact not_dvd_choose_of_lt hp hlt hle hi
+  · rintro ⟨i, hi⟩
+    refine ⟨i, Finset.mem_range.mpr ?_, ?_⟩
+    · -- Digits beyond `a` vanish, so the strict inequality forces `i < a`.
+      by_contra hia
+      push_neg at hia
+      have hn0 : n / p ^ i % p = 0 := by
+        rw [Nat.div_eq_of_lt (lt_of_lt_of_le hna (Nat.pow_le_pow_right hp.pos hia)), Nat.zero_mod]
+      have hk0 : k / p ^ i % p = 0 := by
+        rw [Nat.div_eq_of_lt (lt_of_lt_of_le hka (Nat.pow_le_pow_right hp.pos hia)), Nat.zero_mod]
+      rw [hn0, hk0] at hi
+      exact absurd hi (lt_irrefl 0)
+    · rw [choose_eq_zero_of_lt hi]; exact dvd_zero p
+
+/-- **Lucas' criterion (digit-dominance form).** For a prime `p`, the prime `p` does *not*
+divide `C(n,k)` exactly when every base-`p` digit of `k` is at most the corresponding digit
+of `n`.  This is the precise description of which entries of row `n` survive mod `p`. -/
+theorem not_dvd_choose_iff_forall_digit_le {p n k : ℕ} (hp : p.Prime) :
+    ¬ p ∣ n.choose k ↔ ∀ i, k / p ^ i % p ≤ n / p ^ i % p := by
+  rw [dvd_choose_iff_exists_digit_lt hp, not_exists]
+  exact forall_congr' fun i => not_lt
+
+/-! ## Kummer's carry count and the zero-carry stratum
+
+Kummer's theorem (`Nat.factorization_choose`) reads the `p`-adic valuation of `C(n,k)` off the
+base-`p` addition of `k` and `n - k`.  We package the carry count and connect it to the
+divisibility criterion above. -/
+
+/-- The number of carries when adding `k` and `n - k` in base `p`: the positions `i ≥ 1` at
+which the partial sums overflow `pⁱ`.  By Kummer's theorem this equals `ν_p(C(n,k))`. -/
+def kummerCarries (p n k : ℕ) : ℕ :=
+  #{i ∈ Finset.Ico 1 (n + 1) | p ^ i ≤ k % p ^ i + (n - k) % p ^ i}
+
+/-- **Kummer's theorem.** The exact power of `p` dividing `C(n,k)` is the number of carries
+when adding `k` and `n - k` in base `p`. -/
+theorem factorization_choose_eq_carries {p n k : ℕ} (hp : p.Prime) (hkn : k ≤ n) :
+    (n.choose k).factorization p = kummerCarries p n k :=
+  Nat.factorization_choose hp hkn (Nat.lt_succ_of_le (Nat.log_le_self p n))
+
+/-- **Zero-carry stratum (valuation form).** For `k ≤ n`, the entry `C(n,k)` survives mod `p`
+exactly when adding `k` and `n - k` in base `p` produces *no carries*. -/
+theorem not_dvd_choose_iff_carries_eq_zero {p n k : ℕ} (hp : p.Prime) (hkn : k ≤ n) :
+    ¬ p ∣ n.choose k ↔ kummerCarries p n k = 0 := by
+  have hpos : n.choose k ≠ 0 := (Nat.choose_pos hkn).ne'
+  rw [hp.dvd_iff_one_le_factorization hpos, factorization_choose_eq_carries hp hkn]
+  omega
+
+/-- **The bridge: no carries `⟺` digit dominance.** Combining Kummer's theorem with Lucas'
+criterion, the base-`p` addition `k + (n - k)` is carry-free exactly when `k` is digit-dominated
+by `n`.  Equivalently: a subtraction `n - k` in base `p` needs no borrow iff every digit of `k`
+fits under the corresponding digit of `n`. -/
+theorem carries_eq_zero_iff_forall_digit_le {p n k : ℕ} (hp : p.Prime) (hkn : k ≤ n) :
+    kummerCarries p n k = 0 ↔ ∀ i, k / p ^ i % p ≤ n / p ^ i % p := by
+  rw [← not_dvd_choose_iff_carries_eq_zero hp hkn, not_dvd_choose_iff_forall_digit_le hp]
+
+/-! ## Recovering Fine's theorem as the zero-carry stratum
+
+Fine's surviving set `fineRow p n` (from `LucasTheoremOQ01OQ01`) is, column by column, exactly
+the set of `k ≤ n` that are digit-dominated by `n` — the zero-carry stratum.  Thus Fine's count
+`∏ᵢ (nᵢ + 1)` is precisely the number of carry-free columns. -/
+
+open scoped Classical in
+/-- **Fine's surviving entries are the digit-dominated columns.** The columns `k` of row `n`
+that are not divisible by `p` are exactly those whose base-`p` digits are dominated by `n`. -/
+theorem fineRow_eq_digitDominated {p : ℕ} (n : ℕ) (hp : p.Prime) :
+    FineTheorem.fineRow p n
+      = {k ∈ Finset.range (n + 1) | ∀ i, k / p ^ i % p ≤ n / p ^ i % p} := by
+  ext k
+  simp only [FineTheorem.fineRow, Finset.mem_filter, Finset.mem_range]
+  exact and_congr_right fun _ => not_dvd_choose_iff_forall_digit_le hp
+
+/-! ## Worked examples (kernel-checked, no `native_decide`) -/
+
+/-- Row `4` over `p = 2`: `4 = 100₂`.  Column `1 = 001₂` has digit `1 > 0` at position `0`,
+so `2 ∣ C(4,1) = 4`. -/
+example : (2 : ℕ) ∣ Nat.choose 4 1 := by decide
+
+/-- Column `0` is always digit-dominated, so it always survives: `2 ∤ C(4,0) = 1`. -/
+example : ¬ (2 : ℕ) ∣ Nat.choose 4 0 := by decide
+
+/-- `C(6,3) = 20 = 2² · 5`: adding `3 = 11₂` to `3 = 11₂` produces two carries,
+so `ν₂(C(6,3)) = 2`. -/
+example : (Nat.choose 6 3).factorization 2 = 2 := by
+  rw [factorization_choose_eq_carries (by norm_num) (by norm_num)]; decide
+
+/-- Fine's surviving columns of row `5` over `p = 2` (`5 = 101₂`) are the digit-dominated
+columns `{0, 1, 4, 5}`, of which there are `(1+1)(0+1)(1+1) = 4` — Fine's digit product. -/
+example : (FineTheorem.fineRow 2 5).card = 4 := by decide
+
+#check @not_dvd_choose_iff_forall_digit_le
+#check @dvd_choose_iff_exists_digit_lt
+#check @factorization_choose_eq_carries
+#check @carries_eq_zero_iff_forall_digit_le
+#check @fineRow_eq_digitDominated
+
+end LucasKummerCarries

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "lucas-theorem-oq-01-oq-01-oq-02",
+  "slug": "lucas-theorem-oq-01-oq-01-oq-02",
+  "title": "Kummer's carry count and the zero-carry stratum of Lucas/Fine",
+  "description": "Strengthens the divisibility statement of Lucas' theorem (whether a prime p divides a binomial coefficient C(n,k)) to the full p-adic valuation. Kummer's theorem (1852) identifies ν_p(C(n,k)) — the exact power of p dividing C(n,k) — with the number of carries that occur when adding k and n−k in base p; Mathlib packages this as Nat.factorization_choose. This entry first proves Lucas' divisibility criterion, which is NOT a named Mathlib lemma: ¬ p ∣ C(n,k) ↔ every base-p digit of k is ≤ the corresponding digit of n (digit-dominance), with the dual p ∣ C(n,k) ↔ ∃ i, nᵢ < kᵢ. The criterion is derived from Mathlib's Lucas congruence Choose.choose_modEq_prod_range_choose_nat (C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) mod p): the prime divides the product iff it divides a single-digit factor C(nᵢ,kᵢ), and for a digit row nᵢ < p the only way p ∣ C(nᵢ,kᵢ) is the trivial vanishing kᵢ > nᵢ (since C(nᵢ,kᵢ) ∣ nᵢ! and p ∤ nᵢ!). Combining the Kummer valuation with this criterion yields the zero-carry stratum that unifies all three classical theorems: for k ≤ n, kummerCarries p n k = 0 ↔ (∀ i, kᵢ ≤ nᵢ) ↔ ¬ p ∣ C(n,k). Reading the three sides: no carries (Kummer) ⟺ digit dominance (Lucas) ⟺ survives mod p (Fine). Finally fineRow_eq_digitDominated rewrites Fine's surviving column set fineRow p n as exactly the digit-dominated columns, so the parent's Fine count ∏ᵢ(nᵢ+1) is literally the size of the zero-carry stratum. Verified with 0 axioms, 0 sorries, no native_decide (concrete row checks use kernel decide).",
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.LucasTheoremOQ01OQ01"],
+    "opens": ["Nat", "Finset"],
+    "namespace": "LucasKummerCarries",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/LucasTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "text": "The parent Fine's-theorem entry counts how many entries of row n of Pascal's triangle survive mod p, but never says WHICH columns survive. That characterisation is Lucas' divisibility criterion: column k survives iff k is digit-dominated by n in base p. This entry proves the criterion from Mathlib's Lucas congruence, then upgrades the binary survives/dies dichotomy to the full p-adic valuation via Kummer's theorem, which reads ν_p(C(n,k)) off the carries of the base-p addition k + (n−k). The keystone is the zero-carry stratum: no carries ⟺ digit dominance ⟺ not divisible by p — a single biconditional fusing Kummer (1852), Lucas (1878), and Fine (1947). The parent's surviving set is then identified as exactly the carry-free columns."
+  },
+  "meta": {
+    "author": "Classical (Kummer 1852; Lucas 1878; Fine 1947; Granville 1997 survey). Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasTheoremOQ01OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "prime",
+      "binomial-coefficients",
+      "p-adic-valuation",
+      "kummer-theorem",
+      "lucas-theorem",
+      "fines-theorem",
+      "pascals-triangle",
+      "base-p-digits",
+      "carries",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_choose",
+        "description": "(choose n k).factorization p = #{i ∈ Ico 1 b | p^i ≤ k % p^i + (n−k) % p^i} for log p n < b. Mathlib's form of Kummer's theorem: the p-adic valuation of C(n,k) is the carry count of the base-p addition k + (n−k). Instantiated at b = n+1 (valid since log p n ≤ n) to match the kummerCarries definition.",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.Choose.choose_modEq_prod_range_choose_nat",
+        "description": "Lucas' congruence: for n, k < pᵃ, C(n,k) ≡ ∏_{i<a} C(n/pⁱ%p, k/pⁱ%p) (mod p). The engine of the divisibility criterion — p divides C(n,k) iff p divides the digit product.",
+        "module": "Mathlib.Data.Nat.Choose.Lucas"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_finset_prod_iff",
+        "description": "A prime divides a finite product iff it divides one of the factors. Reduces p ∣ ∏ᵢ C(nᵢ,kᵢ) to the existence of a single digit position with p ∣ C(nᵢ,kᵢ).",
+        "module": "Mathlib.Algebra.BigOperators.Associated"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_factorial",
+        "description": "For a prime p, p ∣ a! ↔ p ≤ a. With a = nᵢ < p this gives p ∤ nᵢ!, so the single-digit binomial C(nᵢ,kᵢ) ∣ nᵢ! is coprime to p whenever kᵢ ≤ nᵢ.",
+        "module": "Mathlib.Data.Nat.Factorial.Prime"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_iff_one_le_factorization",
+        "description": "For a prime p and m ≠ 0, p ∣ m ↔ 1 ≤ m.factorization p. Bridges the divisibility criterion to the valuation form of the zero-carry stratum: ¬ p ∣ C(n,k) ↔ ν_p(C(n,k)) = 0.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "FineTheorem.fineRow",
+        "description": "The parent's surviving-column set fineRow p n = {k ≤ n : ¬ p ∣ C(n,k)}, whose Fine count is ∏ᵢ(nᵢ+1). Identified here with the digit-dominated columns (the zero-carry stratum).",
+        "module": "Proofs.LucasTheoremOQ01OQ01"
+      }
+    ],
+    "originalContributions": [
+      "not_dvd_choose_iff_forall_digit_le / dvd_choose_iff_exists_digit_lt: Lucas' divisibility criterion in digit-dominance form, ¬ p ∣ C(n,k) ↔ ∀ i, k/pⁱ%p ≤ n/pⁱ%p (dually p ∣ C(n,k) ↔ ∃ i, nᵢ < kᵢ). This precise WHICH-columns-survive statement is not a named Mathlib lemma — Mathlib has only the Lucas congruence and the single-digit step Nat.dvd_choose. Derived by pushing the congruence through Nat.Prime.dvd_finset_prod_iff and the single-digit lemma below.",
+      "not_dvd_choose_lt_iff (single-digit Lucas step): for a prime p and a row a < p, ¬ p ∣ C(a,b) ↔ b ≤ a. Within the first p rows the only multiples of p are the trivial zeros C(a,b) = 0 for b > a, since C(a,b) ∣ a! and p ∤ a!.",
+      "kummerCarries and factorization_choose_eq_carries: packages the base-p carry count of k + (n−k) and states Kummer's theorem ν_p(C(n,k)) = kummerCarries p n k for k ≤ n by instantiating Mathlib's Nat.factorization_choose at the bound b = n+1.",
+      "carries_eq_zero_iff_forall_digit_le / not_dvd_choose_iff_carries_eq_zero (the zero-carry stratum): for k ≤ n, kummerCarries p n k = 0 ↔ (∀ i, kᵢ ≤ nᵢ) ↔ ¬ p ∣ C(n,k). A single biconditional fusing Kummer's carry count, Lucas' digit dominance, and Fine's survival — the carry-free / borrow-free / non-divisible columns coincide.",
+      "fineRow_eq_digitDominated: rewrites the parent's Fine surviving set fineRow p n as exactly the digit-dominated columns {k ∈ range (n+1) | ∀ i, kᵢ ≤ nᵢ}, exhibiting Fine's count ∏ᵢ(nᵢ+1) as the cardinality of the zero-carry stratum."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Lucas' divisibility criterion is assembled in-file from Mathlib's Lucas congruence Choose.choose_modEq_prod_range_choose_nat and the prime-product / prime-factorial lemmas; Kummer's valuation is Mathlib's Nat.factorization_choose instantiated at b = n+1. All dependencies are credited in mathlibDependencies. No native_decide — the four worked examples (2 ∣ C(4,1), 2 ∤ C(4,0), ν₂(C(6,3)) = 2, |fineRow 2 5| = 4) use kernel `decide`, so no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 219,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "title": "The single-digit Lucas step (not_dvd_choose_lt_iff)",
+      "text": "Within the first p rows of Pascal's triangle there are no nontrivial multiples of p: for a < p, every nonzero entry C(a,b) is coprime to p. The proof observes C(a,b) ∣ a! (from choose_mul_factorial_mul_factorial) and p ∤ a! (since a < p, via Nat.Prime.dvd_factorial). Hence p ∣ C(a,b) forces the trivial vanishing C(a,b) = 0, i.e. b > a, giving ¬ p ∣ C(a,b) ↔ b ≤ a."
+    },
+    {
+      "title": "Lucas' divisibility criterion (dvd_choose_iff_exists_digit_lt)",
+      "text": "Choose a with n, k < pᵃ so all higher base-p digits vanish. Mathlib's Lucas congruence gives C(n,k) ≡ ∏_{i<a} C(nᵢ,kᵢ) (mod p), so p ∣ C(n,k) iff p divides the digit product. By Nat.Prime.dvd_finset_prod_iff this happens iff p ∣ C(nᵢ,kᵢ) for some i, and the single-digit step turns that into nᵢ < kᵢ. Digit positions i ≥ a contribute nothing since both digits are 0 there. Negating gives the digit-dominance form ¬ p ∣ C(n,k) ↔ ∀ i, kᵢ ≤ nᵢ."
+    },
+    {
+      "title": "Kummer's carry count (factorization_choose_eq_carries)",
+      "text": "Define kummerCarries p n k as the number of positions i ≥ 1 at which the partial sums overflow pⁱ, i.e. p^i ≤ k % p^i + (n−k) % p^i. Kummer's theorem ν_p(C(n,k)) = kummerCarries p n k is Mathlib's Nat.factorization_choose instantiated at the bound b = n+1, which is admissible because log p n ≤ n."
+    },
+    {
+      "title": "The zero-carry stratum (carries_eq_zero_iff_forall_digit_le)",
+      "text": "For k ≤ n, C(n,k) ≠ 0, so p ∣ C(n,k) ↔ 1 ≤ ν_p(C(n,k)) = kummerCarries p n k. Therefore ¬ p ∣ C(n,k) ↔ kummerCarries p n k = 0. Composing with the divisibility criterion yields the central biconditional kummerCarries p n k = 0 ↔ ∀ i, kᵢ ≤ nᵢ: the base-p addition k + (n−k) is carry-free exactly when k is digit-dominated by n (equivalently, the subtraction n − k needs no borrow)."
+    },
+    {
+      "title": "Recovering Fine's count as the zero-carry stratum (fineRow_eq_digitDominated)",
+      "text": "The parent's Fine surviving set fineRow p n = (range (n+1)).filter (fun k => ¬ p ∣ C(n,k)) is rewritten column-by-column as the digit-dominated columns {k ∈ range (n+1) | ∀ i, kᵢ ≤ nᵢ}. Thus Fine's count ∏ᵢ(nᵢ+1) is exactly the number of carry-free columns of row n — the size of the zero-carry stratum. Four kernel-`decide` examples instantiate the chain at p = 2."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lucas-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves Fine's theorem (the per-row count fineCount p n = ∏ᵢ(nᵢ+1)) but does not characterise which columns survive mod p. This entry supplies that characterisation (Lucas' digit-dominance criterion), upgrades it to the full Kummer valuation, and identifies the parent's surviving set fineRow as the zero-carry stratum. Imports Proofs.LucasTheoremOQ01OQ01."
+    },
+    {
+      "targetId": "lucas-theorem-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question of the same parent: the row-sum entry sums Fine's count over a base-p block to get the fractal total (p(p+1)/2)ᵐ. This entry instead resolves the per-column structure underlying that count — exactly which columns are counted (the digit-dominated / zero-carry ones)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "author": "E. Kummer",
+      "year": 1852,
+      "note": "J. Reine Angew. Math. 44 (1852), 93–146. The p-adic valuation of C(m+n, m) equals the number of carries when adding m and n in base p."
+    },
+    {
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "author": "É. Lucas",
+      "year": 1878,
+      "note": "American Journal of Mathematics 1 (1878), 184–196, 197–240, 289–321. The congruence C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) (mod p) and the digit-dominance divisibility criterion."
+    },
+    {
+      "title": "Binomial coefficients modulo a prime",
+      "author": "N. J. Fine",
+      "year": 1947,
+      "note": "American Mathematical Monthly 54 (1947), 589–592. The per-row count of entries not divisible by p — here identified as the cardinality of the zero-carry stratum."
+    },
+    {
+      "title": "Arithmetic properties of binomial coefficients I: Binomial coefficients modulo prime powers",
+      "author": "A. Granville",
+      "year": 1997,
+      "note": "CMS Conf. Proc. 20 (1997), 253–276. Modern survey unifying the Kummer/Lucas/Fine circle of results."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "Lucas' theorem (whether p ∣ C(n,k)) is strengthened to the full Kummer valuation ν_p(C(n,k)) = number of carries when adding k and n−k in base p. The keystone is the zero-carry stratum: for k ≤ n, no carries ⟺ k is digit-dominated by n (Lucas' criterion, proved here from Mathlib's Lucas congruence) ⟺ ¬ p ∣ C(n,k). The parent's Fine surviving set fineRow p n is then identified as exactly the digit-dominated columns, so its count ∏ᵢ(nᵢ+1) is the size of the zero-carry stratum. Verified with 0 axioms and no native_decide.",
+    "implications": "A single biconditional fuses three classical theorems — Kummer's carry count (1852), Lucas' digit-dominance criterion (1878), and Fine's survival count (1947) — and exposes the per-column structure behind Fine's row count: the surviving columns are precisely the carry-free (equivalently borrow-free) ones. Lucas' divisibility criterion in digit-dominance form, absent from Mathlib, is now available as a reusable lemma.",
+    "openQuestions": [
+      "Prime-power valuations: Granville's theory extends Kummer to ν_p over prime powers p^a via carries with borrows in a base-p^a expansion. Formalise the analogous stratum for C(n,k) mod p^a.",
+      "Carry-count distribution: for fixed n, study the distribution of kummerCarries p n k as k ranges over [0,n] — its generating function and the connection to the p-adic digits of n via the q-analogue of the Kummer carry law."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question recorded for the parent **Fine's-theorem** entry (`lucas-theorem-oq-01-oq-01`): strengthen the *divisibility* statement of Lucas' theorem (does prime `p` divide `C(n,k)`?) to the full **p-adic valuation** `ν_p(C(n,k))`, and recover Fine's count as the zero-carry stratum.

**Kummer's theorem** (Mathlib `Nat.factorization_choose`) reads `ν_p(C(n,k))` off the number of carries when adding `k` and `n−k` in base `p`. This entry proves **Lucas' divisibility criterion** in digit-dominance form — *not* a named Mathlib lemma — from the Lucas congruence `Choose.choose_modEq_prod_range_choose_nat`, then fuses three classical theorems:

> **Zero-carry stratum.** For `k ≤ n`,  `kummerCarries p n k = 0  ↔  (∀ i, kᵢ ≤ nᵢ)  ↔  ¬ p ∣ C(n,k)`.

Reading the three sides: *no carries* (Kummer 1852) ⟺ *digit dominance* (Lucas 1878) ⟺ *survives mod p* (Fine 1947). Finally `fineRow_eq_digitDominated` rewrites the parent's Fine surviving set as exactly the digit-dominated columns, so Fine's count `∏ᵢ(nᵢ+1)` is literally the cardinality of the zero-carry stratum.

## Key results
- `not_dvd_choose_iff_forall_digit_le` / `dvd_choose_iff_exists_digit_lt` — Lucas' criterion (digit dominance), via the Lucas congruence + `Nat.Prime.dvd_finset_prod_iff` + single-digit step
- `not_dvd_choose_lt_iff` — single-digit step: for `a < p`, `¬ p ∣ C(a,b) ↔ b ≤ a`
- `factorization_choose_eq_carries` — Kummer: `ν_p(C(n,k)) = kummerCarries p n k`
- `carries_eq_zero_iff_forall_digit_le` / `not_dvd_choose_iff_carries_eq_zero` — the zero-carry stratum
- `fineRow_eq_digitDominated` — Fine's surviving columns = digit-dominated columns

## Verification
- **8 theorems, 1 definition, 219 lines**
- **0 sorries, 0 axioms, no `native_decide`** — every result depends only on `propext`, `Classical.choice`, `Quot.sound` (verified via `#print axioms`)
- Four worked examples use kernel `decide` (no `Lean.ofReduceBool`)
- Builds against Mathlib 4.26.0; imports the parent `Proofs.LucasTheoremOQ01OQ01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)