### PR TITLE
Enrich Integral Apollonian Curvatures (integrality ⟺ square discriminant): index.ts + annotations + meta depth

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DescartesCircleTheoremOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const descartesCircleTheoremOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const descartesCircleTheoremOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const descartesCircleTheoremOQ01OQ02Data: ProofData = {
+  proof: descartesCircleTheoremOQ01OQ02Proof,
+  annotations: descartesCircleTheoremOQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `descartes-circle-theorem-oq-01-oq-02` (Integral Apollonian Curvatures: Integrality ⟺ Square Discriminant).

## Gaps addressed
The entry had a partial `meta.json` and was **missing `index.ts`, `annotations.json`, `sections`, `conclusion`, and `crossReferences`** — without `index.ts` the page renders **"proof not found"** on the live site.

## Changes
- **`index.ts`** — standard Vite entry point for `Proofs/DescartesCircleTheoremOQ01OQ02.lean`.
- **`annotations.json`** — 5 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`): gasket context, the discriminant identity `descartesRelZ_iff_sq`, Soddy reflection as a ring identity (why integrality propagates), the headline biconditional `exists_integral_fourth_iff_sq`, and the real-relation bridge `apollonian_new_curvature_isInt`.
- **`meta.json` depth** — added `overview.proofStrategy` + 4 `keyInsights`, a full 5-entry `sections` array (with `mathContext`), a `conclusion` (summary, implications, 3 `openQuestions`), and `crossReferences` to the parent and ancestor.

## Verification
- `tsc --noEmit` passes (0 errors); both JSON files parse cleanly.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0 sorries; no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)