### PR TITLE
audit(batch35): 7 never-audited gallery leaves CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22277,8 +22277,50 @@
       "lastAudited": "2026-06-24T21:30:00Z",
       "result": "clean",
       "issues": []
+    },
+    "kummer-theorem-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "nesbitt-inequality-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "nesbitt-inequality-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pell-equation-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "tietze-extension-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "vandermonde-interpolation-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T21:43:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T21:30:00Z"
+  "lastUpdated": "2026-06-24T21:43:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — batch35

Audited 7 never-audited gallery leaves. All claims verified to match Lean source (comment-stripped grep for sorry/native_decide).

All status=verified/original, 0 sorry / 0 native_decide / 0 axiom decl / 0 True-stub:
kummer-theorem-oq-02-oq-03, nesbitt-inequality-oq-01-oq-01, nesbitt-inequality-oq-01-oq-02, pell-equation-oq-01-oq-04, sylow-theorem-oq-02-oq-01-oq-01, tietze-extension-theorem-oq-01-oq-01-oq-01, vandermonde-interpolation-oq-01-oq-02-oq-01.

**Note** — the two `nesbitt-inequality-oq-01-oq-0{1,2}` entries are the renumbered slug-collision pair (Shapiro n=4 vs weighted Nesbitt); distinct mathematics, both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)