### PR TITLE
research(descartes-rule-of-signs-oq-02-oq-04): verified VAS real-root isolation from Budan certificates [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -972,6 +972,7 @@ import Proofs.DescartesRuleOfSignsOQ01OQ01
 import Proofs.DescartesRuleOfSignsOQ01OQ02
 import Proofs.DescartesRuleOfSignsOQ02
 import Proofs.DescartesRuleOfSignsOQ02OQ03
+import Proofs.DescartesRuleOfSignsOQ02OQ04
 import Proofs.DescartesRuleOfSignsOQ02OQ01
 import Proofs.DescartesRuleOfSignsOQ02OQ01OQ02
 import Proofs.DescartesRuleOfSignsOQ02Parity

--- a/proofs/Proofs/DescartesRuleOfSignsOQ02OQ04.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02OQ04.lean
@@ -1,0 +1,285 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.List.Basic
+import Mathlib.Tactic
+
+/-
+# Verified VAS real-root isolation from Budan certificates
+
+This file answers open question #4 of *Budan's Theorem*
+(`descartes-rule-of-signs-oq-02`):
+
+> Can we formalize the VAS root isolation algorithm as a verified program that
+> uses the proved root isolation certificates to produce certified root
+> intervals?
+
+The Vincent–Akritas–Strzeboński (VAS) algorithm isolates the real roots of a
+polynomial by recursive bisection guided by Budan–Fourier sign-variation counts.
+At an interval `(a, b]` it computes the count `V` at both endpoints and uses two
+certificates proved in the parent entry:
+
+* **root-free certificate**: `V a = V b  ⟹  no roots in (a, b]`
+  (`no_roots_of_equal_budanCount`);
+* **unique-root certificate**: `V a = V b + 1  ⟹  exactly one root in (a, b]`
+  (`unique_root_of_budanCount_diff_one`).
+
+When `V a - V b ≥ 2` the interval is bisected and the algorithm recurses on the
+two halves.
+
+## What is proved here, and what it depends on
+
+The key mathematical observation is that **the correctness of the VAS procedure
+depends only on the certificate properties of the count function, not on the
+(axiomatized, analytic) proof of Budan's theorem itself.** We therefore develop
+the algorithm *abstractly* over an arbitrary count function `V : ℝ → ℕ` and root
+count `N : ℝ → ℝ → ℕ` satisfying:
+
+* `hEq`   : `a < b → V a = V b     → N a b = 0`   (root-free certificate)
+* `hOne`  : `a < b → V a = V b + 1 → N a b = 1`   (unique-root certificate)
+* `hSplit`: `a < c → c < b → N a b = N a c + N c b` (additivity over a split point)
+
+The parent entry supplies exactly such a triple: `V = budanCount p`,
+`N = rootsInInterval p`, with `hEq`/`hOne` being the proved certificates and
+`hSplit` being root counting over a partition (`rootsInInterval_split`).
+
+Because we abstract over the interface, **this development is fully axiom-free
+and machine-checked**: every `axiom` of Budan's theorem becomes an explicit
+hypothesis, so the algorithm's correctness is established unconditionally as a
+*reduction* (certificates ⟹ verified isolation).
+
+## Results
+
+Run with a fuel budget `fuel : ℕ` bounding the bisection depth, `vasIsolate`
+returns an `IsolationResult` splitting the work into `isolated` intervals (each
+certified to contain exactly one root) and `unresolved` intervals (where fuel
+ran out before the count gap shrank to `≤ 1`). We prove:
+
+* `vasIsolate_isolated_subset`   — every isolated interval lies inside `(a, b]`;
+* `vasIsolate_isolated_one_root` — every isolated interval `(l, r)` has `l < r`
+  and `N l r = 1` (exactly one root);
+* `vasIsolate_isolated_disjoint` — the isolated intervals are pairwise disjoint;
+* `vasIsolate_complete`          — once fully resolved (`unresolved = []`) the
+  number of isolated intervals equals `N a b`, i.e. *every* root is isolated;
+* `vasIsolate_correct`           — the packaged correctness statement.
+-/
+
+namespace VASIsolation
+
+/-- The output of one run of the isolation procedure: a list of intervals each
+certified to contain exactly one root, together with a list of intervals that
+were left unresolved when the fuel budget was exhausted. -/
+structure IsolationResult where
+  /-- Intervals each certified to contain exactly one root. -/
+  isolated : List (ℝ × ℝ)
+  /-- Intervals where the fuel budget ran out before isolation. -/
+  unresolved : List (ℝ × ℝ)
+
+section Algorithm
+
+variable (V : ℝ → ℕ) (N : ℝ → ℝ → ℕ)
+
+/-- **The VAS isolation procedure.**
+
+`vasIsolate V fuel a b` isolates the real roots inside the half-open interval
+`(a, b]`, using only the sign-variation count `V` at the endpoints to decide each
+step (the semantic root count `N` enters only in the correctness proofs):
+
+* `V a = V b`     → no roots, return nothing;
+* `V a = V b + 1` → one root, return the interval `(a, b)`;
+* otherwise       → bisect at the midpoint and recurse on each half (consuming
+  one unit of fuel). When `fuel = 0`, the still-undecided interval is recorded as
+  *unresolved* rather than bisected. -/
+noncomputable def vasIsolate : ℕ → ℝ → ℝ → IsolationResult
+  | 0, a, b =>
+      if V a = V b then ⟨[], []⟩
+      else if V a = V b + 1 then ⟨[(a, b)], []⟩
+      else ⟨[], [(a, b)]⟩
+  | fuel + 1, a, b =>
+      if V a = V b then ⟨[], []⟩
+      else if V a = V b + 1 then ⟨[(a, b)], []⟩
+      else
+        ⟨(vasIsolate fuel a ((a + b) / 2)).isolated ++
+            (vasIsolate fuel ((a + b) / 2) b).isolated,
+          (vasIsolate fuel a ((a + b) / 2)).unresolved ++
+            (vasIsolate fuel ((a + b) / 2) b).unresolved⟩
+
+end Algorithm
+
+section Correctness
+
+variable {V : ℝ → ℕ} {N : ℝ → ℝ → ℕ}
+
+/-- Midpoint lies strictly between the endpoints. -/
+private theorem lt_mid {a b : ℝ} (h : a < b) : a < (a + b) / 2 := by linarith
+
+private theorem mid_lt {a b : ℝ} (h : a < b) : (a + b) / 2 < b := by linarith
+
+/-- **Containment.** Every isolated interval is a subinterval of `(a, b]`:
+its endpoints satisfy `a ≤ l` and `r ≤ b`. -/
+theorem vasIsolate_isolated_subset :
+    ∀ (fuel : ℕ) (a b : ℝ), a < b →
+      ∀ q ∈ (vasIsolate V fuel a b).isolated, a ≤ q.1 ∧ q.2 ≤ b := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro a b hab q hq
+    simp only [vasIsolate] at hq
+    split_ifs at hq with h1 h2
+    · simp at hq
+    · simp only [List.mem_singleton] at hq
+      subst hq; exact ⟨le_refl _, le_refl _⟩
+    · simp at hq
+  | succ fuel ih =>
+    intro a b hab q hq
+    simp only [vasIsolate] at hq
+    split_ifs at hq with h1 h2
+    · simp at hq
+    · simp only [List.mem_singleton] at hq
+      subst hq; exact ⟨le_refl _, le_refl _⟩
+    · rw [List.mem_append] at hq
+      have hac : a < (a + b) / 2 := lt_mid hab
+      have hcb : (a + b) / 2 < b := mid_lt hab
+      rcases hq with hL | hR
+      · obtain ⟨h1', h2'⟩ := ih a ((a + b) / 2) hac q hL
+        exact ⟨h1', le_trans h2' (le_of_lt hcb)⟩
+      · obtain ⟨h1', h2'⟩ := ih ((a + b) / 2) b hcb q hR
+        exact ⟨le_trans (le_of_lt hac) h1', h2'⟩
+
+/-- **Soundness.** Every isolated interval `(l, r)` is nondegenerate (`l < r`)
+and contains *exactly one* root (`N l r = 1`). -/
+theorem vasIsolate_isolated_one_root
+    (hOne : ∀ a b : ℝ, a < b → V a = V b + 1 → N a b = 1) :
+    ∀ (fuel : ℕ) (a b : ℝ), a < b →
+      ∀ q ∈ (vasIsolate V fuel a b).isolated, q.1 < q.2 ∧ N q.1 q.2 = 1 := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro a b hab q hq
+    simp only [vasIsolate] at hq
+    split_ifs at hq with h1 h2
+    · simp at hq
+    · simp only [List.mem_singleton] at hq
+      subst hq; exact ⟨hab, hOne a b hab h2⟩
+    · simp at hq
+  | succ fuel ih =>
+    intro a b hab q hq
+    simp only [vasIsolate] at hq
+    split_ifs at hq with h1 h2
+    · simp at hq
+    · simp only [List.mem_singleton] at hq
+      subst hq; exact ⟨hab, hOne a b hab h2⟩
+    · rw [List.mem_append] at hq
+      have hac : a < (a + b) / 2 := lt_mid hab
+      have hcb : (a + b) / 2 < b := mid_lt hab
+      rcases hq with hL | hR
+      · exact ih a ((a + b) / 2) hac q hL
+      · exact ih ((a + b) / 2) b hcb q hR
+
+/-- Disjointness predicate for two half-open intervals `(l, r]`: one ends weakly
+before the other begins. -/
+def IntDisjoint (q r : ℝ × ℝ) : Prop := q.2 ≤ r.1 ∨ r.2 ≤ q.1
+
+/-- **Disjointness.** The isolated intervals produced by one run are pairwise
+disjoint. -/
+theorem vasIsolate_isolated_disjoint :
+    ∀ (fuel : ℕ) (a b : ℝ), a < b →
+      (vasIsolate V fuel a b).isolated.Pairwise IntDisjoint := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro a b hab
+    simp only [vasIsolate]
+    split_ifs with h1 h2
+    · exact List.Pairwise.nil
+    · exact List.pairwise_singleton _ _
+    · exact List.Pairwise.nil
+  | succ fuel ih =>
+    intro a b hab
+    simp only [vasIsolate]
+    split_ifs with h1 h2
+    · exact List.Pairwise.nil
+    · exact List.pairwise_singleton _ _
+    · have hac : a < (a + b) / 2 := lt_mid hab
+      have hcb : (a + b) / 2 < b := mid_lt hab
+      rw [List.pairwise_append]
+      refine ⟨ih a ((a + b) / 2) hac, ih ((a + b) / 2) b hcb, ?_⟩
+      intro x hx y hy
+      -- left intervals end ≤ midpoint, right intervals begin ≥ midpoint
+      have hxr : x.2 ≤ (a + b) / 2 :=
+        (vasIsolate_isolated_subset fuel a ((a + b) / 2) hac x hx).2
+      have hyl : (a + b) / 2 ≤ y.1 :=
+        (vasIsolate_isolated_subset fuel ((a + b) / 2) b hcb y hy).1
+      exact Or.inl (le_trans hxr hyl)
+
+/-- **Completeness.** Once the procedure has fully resolved the interval (no
+intervals are left unresolved), the number of isolated intervals equals the
+total root count `N a b`. Combined with soundness, this says *every* root has
+been isolated into its own certified interval. -/
+theorem vasIsolate_complete
+    (hEq : ∀ a b : ℝ, a < b → V a = V b → N a b = 0)
+    (hOne : ∀ a b : ℝ, a < b → V a = V b + 1 → N a b = 1)
+    (hSplit : ∀ a c b : ℝ, a < c → c < b → N a b = N a c + N c b) :
+    ∀ (fuel : ℕ) (a b : ℝ), a < b →
+      (vasIsolate V fuel a b).unresolved = [] →
+      (vasIsolate V fuel a b).isolated.length = N a b := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro a b hab hres
+    simp only [vasIsolate] at hres ⊢
+    split_ifs at hres ⊢ with h1 h2
+    · simp only [List.length_nil]; exact (hEq a b hab h1).symm
+    · simp only [List.length_singleton]; exact (hOne a b hab h2).symm
+  | succ fuel ih =>
+    intro a b hab hres
+    simp only [vasIsolate] at hres ⊢
+    split_ifs at hres ⊢ with h1 h2
+    · simp only [List.length_nil]; exact (hEq a b hab h1).symm
+    · simp only [List.length_singleton]; exact (hOne a b hab h2).symm
+    · have hac : a < (a + b) / 2 := lt_mid hab
+      have hcb : (a + b) / 2 < b := mid_lt hab
+      rw [List.append_eq_nil_iff] at hres
+      obtain ⟨hresL, hresR⟩ := hres
+      rw [List.length_append,
+        ih a ((a + b) / 2) hac hresL,
+        ih ((a + b) / 2) b hcb hresR]
+      exact (hSplit a ((a + b) / 2) b hac hcb).symm
+
+/-- **Packaged correctness of VAS isolation.**
+
+Given a sign-variation count `V` and root count `N` satisfying the Budan
+certificates (`hEq`, `hOne`) and root-count additivity (`hSplit`), if the
+procedure fully resolves `(a, b]` within its fuel budget, then it returns a list
+of pairwise-disjoint subintervals of `(a, b]`, each containing exactly one root,
+and there are exactly `N a b` of them — so every root of the interval is
+isolated. -/
+theorem vasIsolate_correct
+    (hEq : ∀ a b : ℝ, a < b → V a = V b → N a b = 0)
+    (hOne : ∀ a b : ℝ, a < b → V a = V b + 1 → N a b = 1)
+    (hSplit : ∀ a c b : ℝ, a < c → c < b → N a b = N a c + N c b)
+    (fuel : ℕ) (a b : ℝ) (hab : a < b)
+    (hres : (vasIsolate V fuel a b).unresolved = []) :
+    (∀ q ∈ (vasIsolate V fuel a b).isolated,
+        a ≤ q.1 ∧ q.2 ≤ b ∧ q.1 < q.2 ∧ N q.1 q.2 = 1) ∧
+      (vasIsolate V fuel a b).isolated.Pairwise IntDisjoint ∧
+      (vasIsolate V fuel a b).isolated.length = N a b := by
+  refine ⟨?_, vasIsolate_isolated_disjoint fuel a b hab,
+    vasIsolate_complete hEq hOne hSplit fuel a b hab hres⟩
+  intro q hq
+  obtain ⟨hsub1, hsub2⟩ := vasIsolate_isolated_subset fuel a b hab q hq
+  obtain ⟨hlt, hroot⟩ := vasIsolate_isolated_one_root hOne fuel a b hab q hq
+  exact ⟨hsub1, hsub2, hlt, hroot⟩
+
+end Correctness
+
+/-!
+## Worked sanity check
+
+A degenerate but illustrative instance: a count function with no sign variation
+anywhere (`V ≡ 0`) and the zero root count. The certificates hold vacuously, and
+the procedure isolates nothing. -/
+
+example :
+    (vasIsolate (fun _ => 0) 5 0 1).isolated = [] := by
+  simp [vasIsolate]
+
+end VASIsolation

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-04/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "descartes-rule-of-signs-oq-02-oq-04",
+  "title": "Verified VAS Real-Root Isolation from Budan Certificates",
+  "slug": "descartes-rule-of-signs-oq-02-oq-04",
+  "description": "Answers the parent Budan's-theorem OQ-04: formalize the Vincent–Akritas–Strzeboński (VAS) real-root isolation algorithm as a verified program that consumes the proved sign-variation root-isolation certificates and outputs certified disjoint root intervals. The key observation is that VAS's correctness depends ONLY on the certificate properties of the count function, not on the (axiomatized, analytic) proof of Budan's theorem. So the algorithm is developed abstractly over an arbitrary sign-variation count V : ℝ → ℕ and root count N : ℝ → ℝ → ℕ satisfying the root-free certificate (V a = V b ⟹ N a b = 0), the unique-root certificate (V a = V b + 1 ⟹ N a b = 1), and additivity over a split point. The recursive-bisection procedure vasIsolate is proved sound (every isolated interval contains exactly one root), containment-respecting (each interval ⊆ (a,b]), pairwise-disjoint, and complete (full resolution isolates exactly N a b roots). Because every Budan axiom becomes an explicit hypothesis, the whole development is axiom-free and machine-checked: VAS correctness is established as a reduction (certificates ⟹ verified isolation).",
+  "meta": {
+    "author": "Vincent (1836), Akritas, Strzeboński; abstract certificate-driven formalization in Lean 4",
+    "date": "1836",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ02OQ04.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "roots",
+      "real-analysis",
+      "sign-variations",
+      "root-isolation",
+      "algorithm-verification",
+      "descartes",
+      "budan"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 285,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "originalContributions": [
+      "vasIsolate: the VAS recursive-bisection isolation procedure, defined abstractly over any sign-variation count V using a fuel budget to bound bisection depth (no termination/root-separation argument needed for soundness).",
+      "vasIsolate_isolated_one_root (soundness): every interval the procedure marks as isolated is nondegenerate and contains exactly one root — proved from the unique-root certificate alone.",
+      "vasIsolate_isolated_subset (containment): every isolated interval is a subinterval of the input (a,b], by induction over the bisection tree.",
+      "vasIsolate_isolated_disjoint (disjointness): the isolated intervals are pairwise disjoint — left-half outputs end at or before the midpoint and right-half outputs begin at or after it, so the two recursive halves never overlap.",
+      "vasIsolate_complete (completeness): once the run is fully resolved (no unresolved intervals), the number of isolated intervals equals the total root count N a b, so every root is isolated — proved from the root-free and unique-root certificates plus additivity over the split point.",
+      "vasIsolate_correct: the packaged statement — a fully resolved run returns exactly N a b pairwise-disjoint subintervals of (a,b], each containing exactly one root.",
+      "Conceptual separation of concerns: VAS correctness is shown to be a logical consequence of the Budan certificates, independent of the (axiomatized) analytic Budan theorem — making the entire isolation layer axiom-free."
+    ],
+    "prerequisites": [
+      "Budan's theorem root-isolation certificates (parent entry): V a = V b ⟹ no roots; V a = V b + 1 ⟹ exactly one root",
+      "Additivity of interval root counts over a split point",
+      "Structural recursion with a fuel budget; List membership and List.Pairwise reasoning in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "List.mem_append",
+        "description": "membership in a concatenation splits as membership in either part — drives the induction over the two recursive halves",
+        "module": "Mathlib.Data.List.Basic"
+      },
+      {
+        "theorem": "List.pairwise_append",
+        "description": "Pairwise R (l₁ ++ l₂) ↔ Pairwise R l₁ ∧ Pairwise R l₂ ∧ (∀ a ∈ l₁, ∀ b ∈ l₂, R a b) — the disjointness proof",
+        "module": "Mathlib.Data.List.Pairwise"
+      },
+      {
+        "theorem": "List.append_eq_nil_iff",
+        "description": "l₁ ++ l₂ = [] ↔ l₁ = [] ∧ l₂ = [] — propagates full resolution to both halves",
+        "module": "Mathlib.Data.List.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Vincent's theorem (1836), refined by Akritas and Strzeboński, underlies the fastest practical real-root isolation algorithms (the VAS / continued-fraction method). The algorithm isolates the real roots of a polynomial by recursively bisecting an interval, using Budan–Fourier sign-variation counts at the endpoints to decide each step: equal counts certify no roots, a count gap of one certifies a single root, and a larger gap triggers a bisection. The Budan entry in this gallery proves exactly the two certificates this decision rule needs, and asks (OQ-04) whether the isolation algorithm itself can be turned into a verified program.",
+    "problemStatement": "**Open Question (parent descartes-rule-of-signs-oq-02, OQ-04)**: Can we formalize the VAS root isolation algorithm as a verified program that uses the proved root isolation certificates to produce certified root intervals?\n\n**Result**: yes — the bisection procedure is implemented and proved sound, containment-respecting, pairwise-disjoint, and complete. Crucially the proof is carried out abstractly over the certificate interface, so it is axiom-free even though Budan's theorem itself is (currently) axiomatized.",
+    "text": "A 285-line, fully verified (0 sorries, 0 axioms, no native_decide) file. vasIsolate V fuel a b runs the bisection to depth fuel, returning an IsolationResult with an `isolated` list (intervals certified to contain one root) and an `unresolved` list (where the fuel ran out). The four correctness theorems and their packaged form vasIsolate_correct establish that, on a fully resolved run, the isolated intervals are disjoint subintervals of (a,b] each holding exactly one root, and that there are exactly N a b of them.",
+    "proofStrategy": "The algorithm is structurally recursive on a fuel parameter, sidestepping the root-separation/termination argument that the unbounded VAS recursion would require — soundness and disjointness hold for ANY fuel budget. Each correctness property is proved by induction on fuel with the interval endpoints generalized. The base and unique-root branches discharge directly from the certificates (hEq, hOne); the bisection branch reduces to the two recursive halves on (a, (a+b)/2] and ((a+b)/2, b] via List.mem_append (soundness, containment), List.pairwise_append together with containment (disjointness: left outputs end ≤ midpoint, right outputs begin ≥ midpoint), and List.append_eq_nil_iff with the count additivity hSplit (completeness). The midpoint inequalities a < (a+b)/2 < b follow from a < b by linarith.",
+    "keyInsights": [
+      "VAS correctness factors through the certificate interface: the only facts the decision rule uses are 'equal count ⟹ no root' and 'count gap one ⟹ one root', so the algorithm can be verified without committing to the analytic proof of Budan's theorem.",
+      "Abstracting over V and N turns the parent's three Budan axioms into explicit hypotheses, making the isolation layer itself unconditionally axiom-free — a clean separation of the algorithmic content from the analytic content.",
+      "A fuel budget makes the recursion structural and the soundness/disjointness proofs unconditional; termination (which needs a root-separation bound) is only relevant to whether a run is *fully resolved*, and is captured cleanly by the unresolved-list being empty.",
+      "Disjointness is purely structural: the bisection guarantees left-half intervals end at or before the midpoint and right-half intervals begin at or after it, so the recursive outputs are automatically separated — no metric separation bound is needed.",
+      "Completeness ties the pieces together: with count additivity over the split, a fully resolved run produces exactly N a b unit-root intervals, certifying that no root is missed."
+    ]
+  },
+  "sections": [
+    {
+      "id": "algorithm",
+      "title": "The VAS Isolation Procedure",
+      "startLine": 76,
+      "endLine": 105,
+      "summary": "IsolationResult; vasIsolate, the fuel-bounded recursive-bisection procedure driven by the sign-variation count V at the interval endpoints.",
+      "mathContext": "Equal count ⟹ empty; gap one ⟹ isolate; larger gap ⟹ bisect at the midpoint and recurse."
+    },
+    {
+      "id": "soundness",
+      "title": "Containment and Soundness",
+      "startLine": 116,
+      "endLine": 175,
+      "summary": "vasIsolate_isolated_subset (each isolated interval ⊆ (a,b]); vasIsolate_isolated_one_root (each isolated interval is nondegenerate and holds exactly one root).",
+      "mathContext": "Induction over the bisection tree, discharging leaves with the unique-root certificate."
+    },
+    {
+      "id": "disjointness",
+      "title": "Pairwise Disjointness",
+      "startLine": 177,
+      "endLine": 211,
+      "summary": "IntDisjoint; vasIsolate_isolated_disjoint via List.pairwise_append, using containment to separate the two recursive halves at the midpoint.",
+      "mathContext": "Left outputs end ≤ midpoint, right outputs begin ≥ midpoint, hence disjoint."
+    },
+    {
+      "id": "completeness",
+      "title": "Completeness and Packaged Correctness",
+      "startLine": 213,
+      "endLine": 272,
+      "summary": "vasIsolate_complete (fully resolved ⟹ #isolated = N a b) and vasIsolate_correct, the combined correctness statement.",
+      "mathContext": "Root-count additivity over the split point gives that every root is isolated."
+    }
+  ],
+  "conclusion": {
+    "summary": "The VAS real-root isolation algorithm is formalized as a verified, fuel-bounded recursive-bisection procedure and proved sound (each isolated interval holds exactly one root), containment-respecting (each ⊆ (a,b]), pairwise-disjoint, and complete (a fully resolved run isolates exactly N a b roots). The proof is carried out abstractly over the Budan certificate interface, so the entire isolation layer is axiom-free even though Budan's theorem is presently axiomatized.",
+    "implications": "This answers the parent's OQ-04 and shows precisely what root isolation requires of the underlying root-counting theory: only the two certificates and additivity, nothing analytic. It cleanly separates the algorithmic content (verified here, unconditionally) from the analytic content (Budan's theorem, axiomatized in the parent). Instantiating V := budanCount p and N := rootsInInterval p, with the parent's proved certificates and rootsInInterval_split, yields a verified isolator for any concrete polynomial whose Budan run fully resolves.",
+    "openQuestions": [
+      "Prove termination of the unbounded VAS recursion by supplying a root-separation (e.g. Mahler-measure) bound, so that a sufficient fuel budget always fully resolves a squarefree polynomial.",
+      "Instantiate the abstract interface with the parent's budanCount / rootsInInterval and the proved certificates to obtain an executable certified isolator for concrete real polynomials.",
+      "Extend the certificate set to the two-or-zero case (V a − V b = 2) to refine the unresolved branch instead of bisecting blindly."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "descartes-rule-of-signs-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Budan's theorem, whose proved root-isolation certificates (no_roots_of_equal_budanCount, unique_root_of_budanCount_diff_one) are exactly the interface this verified VAS procedure consumes. Answers its open question OQ-04."
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "related",
+      "description": "Root: Descartes' Rule of Signs, the sign-variation root bound that Budan's theorem and the VAS algorithm generalize to arbitrary intervals."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Data.List.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "VASIsolation",
+    "lineCount": 285,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "mainTheorems": [
+      {
+        "name": "vasIsolate_correct",
+        "type": "core",
+        "description": "A fully resolved run returns exactly N a b pairwise-disjoint subintervals of (a,b], each containing exactly one root",
+        "leanType": "{V : ℝ → ℕ} → {N : ℝ → ℝ → ℕ} → (∀ a b, a < b → V a = V b → N a b = 0) → (∀ a b, a < b → V a = V b + 1 → N a b = 1) → (∀ a c b, a < c → c < b → N a b = N a c + N c b) → (fuel : ℕ) → (a b : ℝ) → a < b → (vasIsolate V fuel a b).unresolved = [] → (∀ q ∈ (vasIsolate V fuel a b).isolated, a ≤ q.1 ∧ q.2 ≤ b ∧ q.1 < q.2 ∧ N q.1 q.2 = 1) ∧ (vasIsolate V fuel a b).isolated.Pairwise IntDisjoint ∧ (vasIsolate V fuel a b).isolated.length = N a b"
+      },
+      {
+        "name": "vasIsolate_isolated_one_root",
+        "type": "key",
+        "description": "Soundness: every isolated interval is nondegenerate and contains exactly one root",
+        "leanType": "{V : ℝ → ℕ} → {N : ℝ → ℝ → ℕ} → (∀ a b, a < b → V a = V b + 1 → N a b = 1) → ∀ (fuel : ℕ) (a b : ℝ), a < b → ∀ q ∈ (vasIsolate V fuel a b).isolated, q.1 < q.2 ∧ N q.1 q.2 = 1"
+      },
+      {
+        "name": "vasIsolate_complete",
+        "type": "key",
+        "description": "Completeness: a fully resolved run isolates exactly N a b roots",
+        "leanType": "{V : ℝ → ℕ} → {N : ℝ → ℝ → ℕ} → (∀ a b, a < b → V a = V b → N a b = 0) → (∀ a b, a < b → V a = V b + 1 → N a b = 1) → (∀ a c b, a < c → c < b → N a b = N a c + N c b) → ∀ (fuel : ℕ) (a b : ℝ), a < b → (vasIsolate V fuel a b).unresolved = [] → (vasIsolate V fuel a b).isolated.length = N a b"
+      },
+      {
+        "name": "vasIsolate_isolated_disjoint",
+        "type": "key",
+        "description": "The isolated intervals produced by one run are pairwise disjoint",
+        "leanType": "{V : ℝ → ℕ} → ∀ (fuel : ℕ) (a b : ℝ), a < b → (vasIsolate V fuel a b).isolated.Pairwise IntDisjoint"
+      }
+    ],
+    "path": "Proofs/DescartesRuleOfSignsOQ02OQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "vasIsolate_correct",
+      "type": "core",
+      "description": "Packaged correctness: a fully resolved VAS run returns exactly N a b pairwise-disjoint unit-root subintervals of (a,b]",
+      "leanType": "{V : ℝ → ℕ} → {N : ℝ → ℝ → ℕ} → (Budan certificates hEq, hOne, hSplit) → (fuel : ℕ) → (a b : ℝ) → a < b → (vasIsolate V fuel a b).unresolved = [] → certified-disjoint-one-root-intervals ∧ count = N a b"
+    },
+    {
+      "name": "vasIsolate_isolated_one_root",
+      "type": "key",
+      "description": "Soundness: every isolated interval is nondegenerate and contains exactly one root",
+      "leanType": "(hOne) → ∀ fuel a b, a < b → ∀ q ∈ (vasIsolate V fuel a b).isolated, q.1 < q.2 ∧ N q.1 q.2 = 1"
+    },
+    {
+      "name": "vasIsolate_complete",
+      "type": "key",
+      "description": "Completeness: a fully resolved run isolates exactly N a b roots, so none is missed",
+      "leanType": "(hEq, hOne, hSplit) → ∀ fuel a b, a < b → (vasIsolate V fuel a b).unresolved = [] → (vasIsolate V fuel a b).isolated.length = N a b"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Vincent, Alexandre Joseph Hidulphe",
+      "title": "Sur la résolution des équations numériques",
+      "year": "1836",
+      "venue": "Journal de Mathématiques Pures et Appliquées",
+      "note": "The continued-fraction root-isolation theorem underlying the VAS method"
+    },
+    {
+      "authors": "Akritas, Alkiviadis G.; Strzeboński, Adam W.; Vigklas, Panagiotis S.",
+      "title": "Improving the performance of the continued fractions method using new bounds of positive roots",
+      "year": "2008",
+      "venue": "Nonlinear Analysis: Modelling and Control",
+      "note": "The modern VAS real-root isolation algorithm"
+    },
+    {
+      "authors": "Budan de Boislaurent, Ferdinand François Désiré",
+      "title": "Nouvelle méthode pour la résolution des équations numériques",
+      "year": "1822",
+      "venue": "Paris",
+      "note": "Budan's theorem; supplies the sign-variation certificates the isolation algorithm consumes"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question OQ-04** of the parent *Budan's Theorem* entry (`descartes-rule-of-signs-oq-02`):

> Can we formalize the VAS root isolation algorithm as a verified program that uses the proved root isolation certificates to produce certified root intervals?

**Yes.** This entry formalizes the Vincent–Akritas–Strzeboński (VAS) real-root isolation algorithm as a verified recursive-bisection procedure and proves it correct.

## Key idea: correctness factors through the certificate interface

The VAS decision rule only ever uses two facts about the sign-variation count: *equal count ⟹ no root* and *count gap one ⟹ exactly one root*. So the algorithm's correctness depends **only** on the Budan certificates, not on the (axiomatized, analytic) proof of Budan's theorem itself.

The development therefore abstracts over an arbitrary count `V : ℝ → ℕ` and root count `N : ℝ → ℝ → ℕ` satisfying:
- `hEq`   : `a < b → V a = V b → N a b = 0`   (root-free certificate)
- `hOne`  : `a < b → V a = V b + 1 → N a b = 1`   (unique-root certificate)
- `hSplit`: `a < c → c < b → N a b = N a c + N c b`   (additivity over a split)

Every Budan axiom becomes an explicit hypothesis, so **the entire isolation layer is axiom-free and machine-checked** — VAS correctness is established as a reduction (certificates ⟹ verified isolation). The parent supplies exactly such a triple: `V := budanCount p`, `N := rootsInInterval p`, with the proved certificates and `rootsInInterval_split`.

## What is proved

`vasIsolate V fuel a b` runs the bisection to depth `fuel`, returning isolated vs. unresolved intervals. A fuel budget makes the recursion structural, so soundness/disjointness hold for **any** budget (no root-separation/termination argument needed).

- **`vasIsolate_isolated_one_root`** (soundness) — every isolated interval is nondegenerate and contains exactly one root.
- **`vasIsolate_isolated_subset`** (containment) — every isolated interval ⊆ `(a,b]`.
- **`vasIsolate_isolated_disjoint`** (disjointness) — the isolated intervals are pairwise disjoint (left outputs end ≤ midpoint, right outputs begin ≥ midpoint).
- **`vasIsolate_complete`** (completeness) — a fully resolved run isolates exactly `N a b` roots, so none is missed.
- **`vasIsolate_correct`** — the packaged statement.

## Status

| | |
|---|---|
| Status | **verified** (badge: original) |
| Axioms | **0** (`propext`/`Classical.choice`/`Quot.sound` only; no `sorryAx`, no `native_decide`) |
| Sorries | 0 |
| Lines | 285 · 7 theorems · 3 defs |

Self-contained (imports Mathlib only); verified via `lake env lean` against the prebuilt Mathlib v4.26.0 oleans (`#print axioms` confirms axiom-freeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)