### PR TITLE
research(little-wedderburn-oq-01-oq-02): class-equation core — center is a field + dimension identity |D|=|Z(D)|^k [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3475,6 +3475,7 @@ import Proofs.LiouvilleTheoremOQ05
 import Proofs.LittleWedderburnOQ01
 import Proofs.LittleWedderburnOQ01OQ01
 import Proofs.LittleWedderburnOQ01OQ01OQ01
+import Proofs.LittleWedderburnOQ01OQ02
 import Proofs.LittleWedderburnOQ02
 import Proofs.LittleWedderburnOQ02OQ02
 import Proofs.LittleWedderburnSubfieldLatticeOQ020101

--- a/proofs/Proofs/LittleWedderburnOQ01OQ02.lean
+++ b/proofs/Proofs/LittleWedderburnOQ01OQ02.lean
@@ -1,0 +1,129 @@
+import Mathlib
+
+/-
+# The class-equation core of Wedderburn: the center and the dimension identity
+
+The parent entry (`LittleWedderburnOQ01`) records the arithmetic shadow of
+Wedderburn's little theorem — the order of a finite division ring is a prime
+power — by upgrading the ring to a field and then quoting the field-level
+`FiniteField.isPrimePow_card`. The sibling entry (`LittleWedderburnOQ01OQ01`)
+develops the *uniqueness* companion (exactly one finite field of each prime-power
+order).
+
+This entry develops the **other** structural companion the parent left open: the
+center-and-dimension refinement that sits at the heart of Wedderburn's *own*
+proof. For a finite division ring `D` one writes the multiplicative class
+equation against the **center** `Z = Z(D)`; the structural inputs that make that
+class equation arithmetic are exactly:
+
+* `Z(D)` is a **field** (a commutative division ring), and `D` is a vector space
+  over it;
+* therefore `|D| = |Z(D)| ^ k` where `k = dim_{Z(D)} D` (the **dimension
+  identity**, `Module.card_eq_pow_finrank`);
+* `Z(D)` is itself a finite field, so `|Z(D)| = p ^ m` is a prime power;
+* combining the two, `|D| = p ^ (m·k)` is a prime power — the prime-power-order
+  corollary recovered through the *center route* rather than by collapsing to a
+  field first.
+
+The arithmetic content lies in `Module.card_eq_pow_finrank` (which realises the
+class-equation bookkeeping), the Mathlib `Field` instance on the center of a
+division ring (`Subring.instField`), and `FiniteField.isPrimePow_card`; the
+contribution here is to assemble them into the named class-equation refinement
+and to record its **collapse**: Wedderburn's theorem (Mathlib's
+`littleWedderburn` instance) forces `Z(D) = D` and `k = 1`, i.e. the central
+degree that the class equation a priori allows is in fact always `1`. The badge
+is therefore `mathlib`: every step rests on a Mathlib lemma, with the value being
+the explicit packaging of the center refinement. Everything is fully
+machine-checked, with no axioms or sorries.
+-/
+
+namespace LittleWedderburnOQ01OQ02
+
+open scoped Classical
+
+variable (D : Type*) [DivisionRing D] [Finite D]
+
+/-! ## The center is a field -/
+
+omit [Finite D] in
+/-- **The center of a finite division ring is a field.** Mathlib equips the
+center of *any* division ring with a `Field` structure (`Subring.instField`); we
+expose it as the structural predicate `IsField`, which is the input the class
+equation needs. -/
+theorem center_isField : IsField (Subring.center D) :=
+  Field.toIsField _
+
+/-- The center is finite (a subset of the finite ring `D`). -/
+instance : Finite (Subring.center D) := Subtype.finite
+
+/-! ## The dimension identity: the class-equation core -/
+
+/-- **The dimension identity `|D| = |Z(D)| ^ k`.** Writing `Z = Z(D)`, the
+division ring `D` is a `Z`-vector space, so its cardinality is `|Z|` raised to the
+`Z`-dimension `k = dim_{Z} D`. This is the bookkeeping identity at the heart of the
+class-equation proof of Wedderburn's theorem (it is also the very first step of
+Mathlib's own proof). -/
+theorem card_eq_center_pow_finrank :
+    Nat.card D = Nat.card (Subring.center D) ^ Module.finrank (Subring.center D) D := by
+  have hD : Fintype D := Fintype.ofFinite D
+  have hZ : Fintype (Subring.center D) := Fintype.ofFinite _
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card]
+  exact Module.card_eq_pow_finrank
+
+/-- The dimension identity in existence form: `|D|` is a power of `|Z(D)|`. -/
+theorem exists_card_eq_center_pow :
+    ∃ k : ℕ, Nat.card D = Nat.card (Subring.center D) ^ k :=
+  ⟨_, card_eq_center_pow_finrank D⟩
+
+/-- The central degree `k = dim_{Z(D)} D` is positive (`D` is nontrivial). -/
+theorem finrank_center_pos : 0 < Module.finrank (Subring.center D) D := by
+  haveI : Module.Finite (Subring.center D) D := Module.Finite.of_finite
+  exact Module.finrank_pos
+
+/-! ## Prime-power orders -/
+
+/-- **The center is a finite field, so its order is a prime power** `p ^ m`. -/
+theorem center_card_isPrimePow : IsPrimePow (Nat.card (Subring.center D)) := by
+  have : Fintype (Subring.center D) := Fintype.ofFinite _
+  rw [Nat.card_eq_fintype_card]
+  exact FiniteField.isPrimePow_card (Subring.center D)
+
+/-- **Prime-power order recovered via the center route.** Since `|D| = |Z(D)| ^ k`
+with `k ≥ 1` and `|Z(D)|` a prime power, `|D|` is a prime power. This is the
+parent's prime-power-order corollary obtained through the class-equation
+decomposition rather than by upgrading `D` to a field first. -/
+theorem card_isPrimePow : IsPrimePow (Nat.card D) := by
+  rw [card_eq_center_pow_finrank D]
+  exact (center_card_isPrimePow D).pow (finrank_center_pos D).ne'
+
+/-! ## The collapse: Wedderburn forces the central degree to be `1` -/
+
+/-- **Wedderburn collapse, center form.** By Wedderburn's little theorem `D` is
+commutative (Mathlib's `littleWedderburn` instance), so its center is the whole
+ring. -/
+theorem center_eq_top : Subring.center D = ⊤ :=
+  Subring.center_eq_top D
+
+/-- With the center equal to the whole ring, `|Z(D)| = |D|`. -/
+theorem center_card_eq : Nat.card (Subring.center D) = Nat.card D := by
+  have e : Subring.center D ≃+* D :=
+    (RingEquiv.subringCongr (center_eq_top D)).trans Subring.topEquiv
+  exact Nat.card_congr e.toEquiv
+
+/-- **The central degree collapses to `1`.** Combining the dimension identity
+`|D| = |Z(D)| ^ k` with `|Z(D)| = |D|` (Wedderburn) and `|D| ≥ 2`, the exponent
+`k = dim_{Z(D)} D` must equal `1`: the class equation that a priori permits an
+arbitrary central degree in fact always has degree one. -/
+theorem finrank_center_eq_one : Module.finrank (Subring.center D) D = 1 := by
+  have hbase := card_eq_center_pow_finrank D
+  rw [center_card_eq D] at hbase
+  -- hbase : Nat.card D = Nat.card D ^ finrank
+  have h2 : 2 ≤ Nat.card D := by
+    have : Fintype D := Fintype.ofFinite D
+    rw [Nat.card_eq_fintype_card]
+    exact Fintype.one_lt_card
+  have hpow : Nat.card D ^ 1 = Nat.card D ^ Module.finrank (Subring.center D) D := by
+    rw [pow_one]; exact hbase
+  exact (Nat.pow_right_injective h2 hpow).symm
+
+end LittleWedderburnOQ01OQ02

--- a/src/data/proofs/little-wedderburn-oq-01-oq-02/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-01-oq-02/meta.json
@@ -1,0 +1,360 @@
+{
+  "id": "little-wedderburn-oq-01-oq-02",
+  "slug": "little-wedderburn-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped Classical"
+    ],
+    "namespace": "LittleWedderburnOQ01OQ02",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/LittleWedderburnOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Class-Equation Core of Wedderburn: Center and Dimension Identity",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LittleWedderburnOQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "ring-theory",
+      "division-ring",
+      "center",
+      "finite-field",
+      "class-equation",
+      "wedderburn",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 129,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "card_eq_center_pow_finrank: the dimension identity |D| = |Z(D)|^k with k = dim_{Z(D)} D, the bookkeeping identity at the heart of the class-equation proof of Wedderburn — D as a vector space over its center, packaged as a named statement",
+      "center_card_isPrimePow: the center of a finite division ring is a finite field, so its order |Z(D)| is a prime power p^m",
+      "card_isPrimePow: the prime-power-order corollary recovered through the CENTER route (|D| = |Z(D)|^k with k ≥ 1 and |Z(D)| a prime power), rather than by first collapsing D to a field — a structurally different derivation of the parent's result",
+      "finrank_center_eq_one: the collapse — combining the dimension identity with Wedderburn (Z(D) = D) and |D| ≥ 2 forces the central degree k to equal 1, so the class equation that a priori permits an arbitrary central degree in fact always has degree one",
+      "center_eq_top and center_card_eq: the Wedderburn collapse in center form — the center is the whole ring and |Z(D)| = |D|",
+      "finrank_center_pos: the central degree k = dim_{Z(D)} D is positive (D is nontrivial), the input that makes the prime-power-order recovery go through"
+    ],
+    "prerequisites": [
+      "Mathlib's Subring.instField: the center of any division ring carries a Field structure (a commutative division ring)",
+      "Module.card_eq_pow_finrank: a finite vector space over a finite field K has cardinality |K|^(dim) — the identity that turns the center decomposition into the class-equation arithmetic",
+      "FiniteField.isPrimePow_card: the order of a finite field is a prime power",
+      "littleWedderburn: a finite division ring is a field (Mathlib instance), the input that collapses the central degree to 1",
+      "IsPrimePow.pow: a positive power of a prime power is a prime power"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Subring.instField",
+        "description": "The center of a division ring is a field; supplies the Field structure on Z(D) that the dimension identity and prime-power count rely on.",
+        "module": "Mathlib.Algebra.Ring.Subring.Basic"
+      },
+      {
+        "theorem": "Module.card_eq_pow_finrank",
+        "description": "A finite module over a finite (division) ring has cardinality |scalars|^finrank; applied to D over its center Z(D) this is the class-equation identity |D| = |Z(D)|^k.",
+        "module": "Mathlib.FieldTheory.Finiteness"
+      },
+      {
+        "theorem": "FiniteField.isPrimePow_card",
+        "description": "The number of elements of a finite field is a prime power; applied to the center gives |Z(D)| = p^m.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "littleWedderburn",
+        "description": "Wedderburn's little theorem: a finite division ring is a field. The instance that forces Z(D) = D and the central degree to be 1.",
+        "module": "Mathlib.RingTheory.LittleWedderburn"
+      },
+      {
+        "theorem": "IsPrimePow.pow",
+        "description": "A nonzero power of a prime power is a prime power; turns |D| = |Z(D)|^k with |Z(D)| a prime power and k ≥ 1 into a prime power.",
+        "module": "Mathlib.Algebra.IsPrimePow"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Wedderburn's little theorem (1905) states that every finite division ring is commutative, hence a field. The standard modern proof — and Wedderburn's own argument, later streamlined by Witt using cyclotomic polynomials — runs through the multiplicative class equation written against the center Z(D). The structural backbone of that argument is purely linear-algebraic: Z(D) is a field, D is a vector space over it, and so |D| = |Z(D)|^k where k is the Z(D)-dimension of D; the same identity applies to the centralizer of each non-central element, and a cyclotomic divisibility argument then forces k = 1. This entry isolates that backbone — the center-and-dimension refinement — as the class-equation core that the parent entry left open. It is the companion to the sibling entry's uniqueness statement: where the sibling classifies finite fields up to isomorphism by order, this records the internal structural identity that drives Wedderburn itself, and notes that the identity ultimately collapses (k = 1) precisely because the theorem holds.",
+    "problemStatement": "Prove the Skolem–Noether-flavoured refinement at the heart of Wedderburn's own proof: for a finite division ring D the center Z(D) is a field, D is a Z(D)-vector space so that |D| = |Z(D)|^k for some k (the dimension identity), |Z(D)| is a prime power, and hence |D| is a prime power recovered through the center route. Record the collapse: by Wedderburn the center is the whole ring and the central degree k equals 1.",
+    "proofStrategy": "center_isField exposes the Mathlib Field instance on Subring.center D as IsField. card_eq_center_pow_finrank instantiates Module.card_eq_pow_finrank with scalar ring Z(D) and module D — after bridging Nat.card to Fintype.card on the finite types — giving |D| = |Z(D)|^(finrank). finrank_center_pos uses Module.finrank_pos (D is a nontrivial finite module over its center). center_card_isPrimePow applies FiniteField.isPrimePow_card to the finite field Z(D). card_isPrimePow combines these via IsPrimePow.pow: |D| = |Z(D)|^k with |Z(D)| a prime power and k ≥ 1. For the collapse, center_eq_top is Subring.center_eq_top applied to the field D supplied by the littleWedderburn instance; center_card_eq transports cardinality across the resulting Z(D) ≃+* D; and finrank_center_eq_one reads off k = 1 from |D| = |D|^k with |D| ≥ 2 via Nat.pow_right_injective.",
+    "keyInsights": [
+      "The class equation that proves Wedderburn is, at its core, a counting identity in linear algebra: |D| = |Z(D)|^k because D is a vector space over its center. Isolating this identity (card_eq_center_pow_finrank) separates the structural bookkeeping from the cyclotomic number theory that finishes the proof.",
+      "The center of a division ring is automatically a field — Mathlib records this as an instance (Subring.instField) — so |Z(D)| is itself a prime power, and the prime-power order of D follows from the center decomposition without first invoking commutativity of D.",
+      "This gives a genuinely different route to the parent's prime-power-order corollary: the parent upgrades D to a field and quotes FiniteField.isPrimePow_card; here |D| = |Z(D)|^k is a prime power because |Z(D)| is and k ≥ 1, mirroring the way Wedderburn's own proof reasons before commutativity is known.",
+      "The refinement collapses: Wedderburn's theorem forces Z(D) = D and the central degree k = 1. The 'a priori arbitrary central degree' that the class equation permits is, in hindsight, always 1 — which is exactly the content of the theorem the class equation proves.",
+      "The 'mathlib' badge is honest: every step rests on a Mathlib lemma (Subring.instField, Module.card_eq_pow_finrank, FiniteField.isPrimePow_card, littleWedderburn). The contribution is the explicit assembly of the center-and-dimension refinement and the named statement of its collapse, which Mathlib does not record outside the internals of its Wedderburn proof."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Class-Equation Core",
+      "startLine": 3,
+      "endLine": 38,
+      "summary": "Frames the entry as the center-and-dimension companion the parent left open: the structural backbone of Wedderburn's own proof. States the four ingredients — Z(D) a field, the dimension identity |D| = |Z(D)|^k, |Z(D)| a prime power, hence |D| a prime power via the center route — and the collapse forced by Wedderburn.",
+      "mathContext": "For a finite division ring $D$: $Z(D)$ is a field and $|D| = |Z(D)|^k$."
+    },
+    {
+      "id": "center-field",
+      "title": "The Center is a Field",
+      "startLine": 46,
+      "endLine": 58,
+      "summary": "center_isField: the center of a finite division ring is a field, exposing Mathlib's Field instance on Subring.center D as the predicate IsField. A Finite instance on the center records that it is a finite field.",
+      "mathContext": "$Z(D)$ is a (finite) field."
+    },
+    {
+      "id": "dimension-identity",
+      "title": "The Dimension Identity",
+      "startLine": 59,
+      "endLine": 82,
+      "summary": "card_eq_center_pow_finrank: |D| = |Z(D)|^k with k = dim_{Z(D)} D, via Module.card_eq_pow_finrank — the class-equation bookkeeping. exists_card_eq_center_pow is its existence form, and finrank_center_pos records k ≥ 1 (D is nontrivial).",
+      "mathContext": "$|D| = |Z(D)|^{\\,\\dim_{Z(D)} D}$, with $\\dim_{Z(D)} D \\ge 1$."
+    },
+    {
+      "id": "prime-power",
+      "title": "Prime-Power Orders",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "center_card_isPrimePow: |Z(D)| is a prime power (Z(D) is a finite field). card_isPrimePow: |D| is a prime power, obtained through the center decomposition |D| = |Z(D)|^k with k ≥ 1 — the parent's corollary recovered via the center route.",
+      "mathContext": "$|Z(D)| = p^m$ and $|D| = p^{mk}$ are prime powers."
+    },
+    {
+      "id": "collapse",
+      "title": "The Wedderburn Collapse",
+      "startLine": 99,
+      "endLine": 129,
+      "summary": "center_eq_top: by Wedderburn D is commutative, so Z(D) = D. center_card_eq: hence |Z(D)| = |D|. finrank_center_eq_one: combining with the dimension identity and |D| ≥ 2 forces the central degree k = 1 — the class equation always has central degree one.",
+      "mathContext": "$Z(D) = D$, $|Z(D)| = |D|$, and $\\dim_{Z(D)} D = 1$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "little-wedderburn-oq-01-oq-02-oq-01",
+      "question": "Formalize the cyclotomic finish that turns the dimension identity into a proof of k = 1 directly: write the class equation |Dˣ| = |Z(D)ˣ| + Σ [Dˣ : C(x)ˣ] over conjugacy classes of non-central units, and show that the cyclotomic polynomial Φ_n(q) dividing both q^n − 1 and each (q^n − 1)/(q^{d} − 1) forces n = 1 — recovering Witt's proof rather than quoting Mathlib's littleWedderburn instance.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the order of a finite division ring is a prime power by upgrading it to a field. This entry develops the center-and-dimension refinement that drives Wedderburn's own proof, recovering the prime-power order through the class-equation decomposition |D| = |Z(D)|^k."
+    },
+    {
+      "targetId": "little-wedderburn-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "The sibling classifies finite fields up to isomorphism by cardinality (the uniqueness companion); this entry records the internal structural identity (the class-equation core) of the same parent theorem."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: RingTheory.LittleWedderburn",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the littleWedderburn instance and the class-equation proof whose center-and-dimension backbone this entry isolates."
+    },
+    {
+      "title": "Über die kommutativität endlicher Schiefkörper",
+      "author": "Ernst Witt",
+      "year": "1931",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 8: 413",
+      "description": "Witt's one-page proof of Wedderburn's little theorem via the class equation and cyclotomic polynomials, the argument whose linear-algebraic backbone is formalized here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The class-equation core of Wedderburn is formalized: the center Z(D) of a finite division ring is a field (center_isField), D is a Z(D)-vector space so that |D| = |Z(D)|^k with k = dim_{Z(D)} D (card_eq_center_pow_finrank) and k ≥ 1 (finrank_center_pos), the center has prime-power order (center_card_isPrimePow), and hence |D| is a prime power obtained through the center route (card_isPrimePow). The refinement collapses under Wedderburn: the center is the whole ring (center_eq_top), |Z(D)| = |D| (center_card_eq), and the central degree is 1 (finrank_center_eq_one). 129 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Every step rests on a Mathlib lemma — Subring.instField, Module.card_eq_pow_finrank, FiniteField.isPrimePow_card, littleWedderburn — hence the mathlib badge; the contribution is the explicit assembly of the center-and-dimension refinement that drives Wedderburn's own proof and the named statement of its collapse to central degree 1. Together with the parent's prime-power-order corollary and the sibling's uniqueness-by-cardinality classification, this rounds out the structural picture of finite division rings.",
+    "openQuestions": [
+      "Recover Witt's cyclotomic finish directly: show the class equation forces the central degree to be 1 via Φ_n(q) divisibility, rather than quoting the littleWedderburn instance."
+    ]
+  }
+}
+{
+  "id": "little-wedderburn-oq-01-oq-02",
+  "slug": "little-wedderburn-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped Classical"
+    ],
+    "namespace": "LittleWedderburnOQ01OQ02",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/LittleWedderburnOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Class-Equation Core of Wedderburn: Center and Dimension Identity",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LittleWedderburnOQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "ring-theory",
+      "division-ring",
+      "center",
+      "finite-field",
+      "class-equation",
+      "wedderburn",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 129,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "card_eq_center_pow_finrank: the dimension identity |D| = |Z(D)|^k with k = dim_{Z(D)} D, the bookkeeping identity at the heart of the class-equation proof of Wedderburn — D as a vector space over its center, packaged as a named statement",
+      "center_card_isPrimePow: the center of a finite division ring is a finite field, so its order |Z(D)| is a prime power p^m",
+      "card_isPrimePow: the prime-power-order corollary recovered through the CENTER route (|D| = |Z(D)|^k with k ≥ 1 and |Z(D)| a prime power), rather than by first collapsing D to a field — a structurally different derivation of the parent's result",
+      "finrank_center_eq_one: the collapse — combining the dimension identity with Wedderburn (Z(D) = D) and |D| ≥ 2 forces the central degree k to equal 1, so the class equation that a priori permits an arbitrary central degree in fact always has degree one",
+      "center_eq_top and center_card_eq: the Wedderburn collapse in center form — the center is the whole ring and |Z(D)| = |D|",
+      "finrank_center_pos: the central degree k = dim_{Z(D)} D is positive (D is nontrivial), the input that makes the prime-power-order recovery go through"
+    ],
+    "prerequisites": [
+      "Mathlib's Subring.instField: the center of any division ring carries a Field structure (a commutative division ring)",
+      "Module.card_eq_pow_finrank: a finite vector space over a finite field K has cardinality |K|^(dim) — the identity that turns the center decomposition into the class-equation arithmetic",
+      "FiniteField.isPrimePow_card: the order of a finite field is a prime power",
+      "littleWedderburn: a finite division ring is a field (Mathlib instance), the input that collapses the central degree to 1",
+      "IsPrimePow.pow: a positive power of a prime power is a prime power"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Subring.instField",
+        "description": "The center of a division ring is a field; supplies the Field structure on Z(D) that the dimension identity and prime-power count rely on.",
+        "module": "Mathlib.Algebra.Ring.Subring.Basic"
+      },
+      {
+        "theorem": "Module.card_eq_pow_finrank",
+        "description": "A finite module over a finite (division) ring has cardinality |scalars|^finrank; applied to D over its center Z(D) this is the class-equation identity |D| = |Z(D)|^k.",
+        "module": "Mathlib.FieldTheory.Finiteness"
+      },
+      {
+        "theorem": "FiniteField.isPrimePow_card",
+        "description": "The number of elements of a finite field is a prime power; applied to the center gives |Z(D)| = p^m.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "littleWedderburn",
+        "description": "Wedderburn's little theorem: a finite division ring is a field. The instance that forces Z(D) = D and the central degree to be 1.",
+        "module": "Mathlib.RingTheory.LittleWedderburn"
+      },
+      {
+        "theorem": "IsPrimePow.pow",
+        "description": "A nonzero power of a prime power is a prime power; turns |D| = |Z(D)|^k with |Z(D)| a prime power and k ≥ 1 into a prime power.",
+        "module": "Mathlib.Algebra.IsPrimePow"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Wedderburn's little theorem (1905) states that every finite division ring is commutative, hence a field. The standard modern proof — and Wedderburn's own argument, later streamlined by Witt using cyclotomic polynomials — runs through the multiplicative class equation written against the center Z(D). The structural backbone of that argument is purely linear-algebraic: Z(D) is a field, D is a vector space over it, and so |D| = |Z(D)|^k where k is the Z(D)-dimension of D; the same identity applies to the centralizer of each non-central element, and a cyclotomic divisibility argument then forces k = 1. This entry isolates that backbone — the center-and-dimension refinement — as the class-equation core that the parent entry left open. It is the companion to the sibling entry's uniqueness statement: where the sibling classifies finite fields up to isomorphism by order, this records the internal structural identity that drives Wedderburn itself, and notes that the identity ultimately collapses (k = 1) precisely because the theorem holds.",
+    "problemStatement": "Prove the Skolem–Noether-flavoured refinement at the heart of Wedderburn's own proof: for a finite division ring D the center Z(D) is a field, D is a Z(D)-vector space so that |D| = |Z(D)|^k for some k (the dimension identity), |Z(D)| is a prime power, and hence |D| is a prime power recovered through the center route. Record the collapse: by Wedderburn the center is the whole ring and the central degree k equals 1.",
+    "proofStrategy": "center_isField exposes the Mathlib Field instance on Subring.center D as IsField. card_eq_center_pow_finrank instantiates Module.card_eq_pow_finrank with scalar ring Z(D) and module D — after bridging Nat.card to Fintype.card on the finite types — giving |D| = |Z(D)|^(finrank). finrank_center_pos uses Module.finrank_pos (D is a nontrivial finite module over its center). center_card_isPrimePow applies FiniteField.isPrimePow_card to the finite field Z(D). card_isPrimePow combines these via IsPrimePow.pow: |D| = |Z(D)|^k with |Z(D)| a prime power and k ≥ 1. For the collapse, center_eq_top is Subring.center_eq_top applied to the field D supplied by the littleWedderburn instance; center_card_eq transports cardinality across the resulting Z(D) ≃+* D; and finrank_center_eq_one reads off k = 1 from |D| = |D|^k with |D| ≥ 2 via Nat.pow_right_injective.",
+    "keyInsights": [
+      "The class equation that proves Wedderburn is, at its core, a counting identity in linear algebra: |D| = |Z(D)|^k because D is a vector space over its center. Isolating this identity (card_eq_center_pow_finrank) separates the structural bookkeeping from the cyclotomic number theory that finishes the proof.",
+      "The center of a division ring is automatically a field — Mathlib records this as an instance (Subring.instField) — so |Z(D)| is itself a prime power, and the prime-power order of D follows from the center decomposition without first invoking commutativity of D.",
+      "This gives a genuinely different route to the parent's prime-power-order corollary: the parent upgrades D to a field and quotes FiniteField.isPrimePow_card; here |D| = |Z(D)|^k is a prime power because |Z(D)| is and k ≥ 1, mirroring the way Wedderburn's own proof reasons before commutativity is known.",
+      "The refinement collapses: Wedderburn's theorem forces Z(D) = D and the central degree k = 1. The 'a priori arbitrary central degree' that the class equation permits is, in hindsight, always 1 — which is exactly the content of the theorem the class equation proves.",
+      "The 'mathlib' badge is honest: every step rests on a Mathlib lemma (Subring.instField, Module.card_eq_pow_finrank, FiniteField.isPrimePow_card, littleWedderburn). The contribution is the explicit assembly of the center-and-dimension refinement and the named statement of its collapse, which Mathlib does not record outside the internals of its Wedderburn proof."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Class-Equation Core",
+      "startLine": 3,
+      "endLine": 38,
+      "summary": "Frames the entry as the center-and-dimension companion the parent left open: the structural backbone of Wedderburn's own proof. States the four ingredients — Z(D) a field, the dimension identity |D| = |Z(D)|^k, |Z(D)| a prime power, hence |D| a prime power via the center route — and the collapse forced by Wedderburn.",
+      "mathContext": "For a finite division ring $D$: $Z(D)$ is a field and $|D| = |Z(D)|^k$."
+    },
+    {
+      "id": "center-field",
+      "title": "The Center is a Field",
+      "startLine": 46,
+      "endLine": 58,
+      "summary": "center_isField: the center of a finite division ring is a field, exposing Mathlib's Field instance on Subring.center D as the predicate IsField. A Finite instance on the center records that it is a finite field.",
+      "mathContext": "$Z(D)$ is a (finite) field."
+    },
+    {
+      "id": "dimension-identity",
+      "title": "The Dimension Identity",
+      "startLine": 59,
+      "endLine": 82,
+      "summary": "card_eq_center_pow_finrank: |D| = |Z(D)|^k with k = dim_{Z(D)} D, via Module.card_eq_pow_finrank — the class-equation bookkeeping. exists_card_eq_center_pow is its existence form, and finrank_center_pos records k ≥ 1 (D is nontrivial).",
+      "mathContext": "$|D| = |Z(D)|^{\\,\\dim_{Z(D)} D}$, with $\\dim_{Z(D)} D \\ge 1$."
+    },
+    {
+      "id": "prime-power",
+      "title": "Prime-Power Orders",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "center_card_isPrimePow: |Z(D)| is a prime power (Z(D) is a finite field). card_isPrimePow: |D| is a prime power, obtained through the center decomposition |D| = |Z(D)|^k with k ≥ 1 — the parent's corollary recovered via the center route.",
+      "mathContext": "$|Z(D)| = p^m$ and $|D| = p^{mk}$ are prime powers."
+    },
+    {
+      "id": "collapse",
+      "title": "The Wedderburn Collapse",
+      "startLine": 99,
+      "endLine": 129,
+      "summary": "center_eq_top: by Wedderburn D is commutative, so Z(D) = D. center_card_eq: hence |Z(D)| = |D|. finrank_center_eq_one: combining with the dimension identity and |D| ≥ 2 forces the central degree k = 1 — the class equation always has central degree one.",
+      "mathContext": "$Z(D) = D$, $|Z(D)| = |D|$, and $\\dim_{Z(D)} D = 1$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "little-wedderburn-oq-01-oq-02-oq-01",
+      "question": "Formalize the cyclotomic finish that turns the dimension identity into a proof of k = 1 directly: write the class equation |Dˣ| = |Z(D)ˣ| + Σ [Dˣ : C(x)ˣ] over conjugacy classes of non-central units, and show that the cyclotomic polynomial Φ_n(q) dividing both q^n − 1 and each (q^n − 1)/(q^{d} − 1) forces n = 1 — recovering Witt's proof rather than quoting Mathlib's littleWedderburn instance.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the order of a finite division ring is a prime power by upgrading it to a field. This entry develops the center-and-dimension refinement that drives Wedderburn's own proof, recovering the prime-power order through the class-equation decomposition |D| = |Z(D)|^k."
+    },
+    {
+      "targetId": "little-wedderburn-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "The sibling classifies finite fields up to isomorphism by cardinality (the uniqueness companion); this entry records the internal structural identity (the class-equation core) of the same parent theorem."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: RingTheory.LittleWedderburn",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the littleWedderburn instance and the class-equation proof whose center-and-dimension backbone this entry isolates."
+    },
+    {
+      "title": "Über die kommutativität endlicher Schiefkörper",
+      "author": "Ernst Witt",
+      "year": "1931",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 8: 413",
+      "description": "Witt's one-page proof of Wedderburn's little theorem via the class equation and cyclotomic polynomials, the argument whose linear-algebraic backbone is formalized here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The class-equation core of Wedderburn is formalized: the center Z(D) of a finite division ring is a field (center_isField), D is a Z(D)-vector space so that |D| = |Z(D)|^k with k = dim_{Z(D)} D (card_eq_center_pow_finrank) and k ≥ 1 (finrank_center_pos), the center has prime-power order (center_card_isPrimePow), and hence |D| is a prime power obtained through the center route (card_isPrimePow). The refinement collapses under Wedderburn: the center is the whole ring (center_eq_top), |Z(D)| = |D| (center_card_eq), and the central degree is 1 (finrank_center_eq_one). 129 lines, 9 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Every step rests on a Mathlib lemma — Subring.instField, Module.card_eq_pow_finrank, FiniteField.isPrimePow_card, littleWedderburn — hence the mathlib badge; the contribution is the explicit assembly of the center-and-dimension refinement that drives Wedderburn's own proof and the named statement of its collapse to central degree 1. Together with the parent's prime-power-order corollary and the sibling's uniqueness-by-cardinality classification, this rounds out the structural picture of finite division rings.",
+    "openQuestions": [
+      "Recover Witt's cyclotomic finish directly: show the class equation forces the central degree to be 1 via Φ_n(q) divisibility, rather than quoting the littleWedderburn instance."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `little-wedderburn-oq-01` (the parent's openQuestions[0]): the Skolem–Noether-flavoured refinement at the heart of Wedderburn's *own* proof. The sibling `little-wedderburn-oq-01-oq-01` already covers the **uniqueness** companion (exactly one finite field of each prime-power order); this entry develops the **center-and-dimension** companion.

For a finite division ring `D`:
- **center_isField** — the center `Z(D)` is a field;
- **card_eq_center_pow_finrank** — the class-equation dimension identity `|D| = |Z(D)|^k` with `k = dim_{Z(D)} D`;
- **finrank_center_pos** — `k ≥ 1`;
- **center_card_isPrimePow** — `|Z(D)|` is a prime power;
- **card_isPrimePow** — `|D|` is a prime power, recovered through the *center route* (a structurally different derivation than the parent's, which upgrades `D` to a field first);
- **center_eq_top / center_card_eq / finrank_center_eq_one** — the collapse: Wedderburn forces `Z(D) = D` and central degree `k = 1`.

## Verification
- **9 theorems, 0 definitions, 129 lines, 0 axioms, 0 sorries** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`.
- Badge **mathlib** (honest): every step rests on a Mathlib lemma — `Module.card_eq_pow_finrank`, `Subring.instField`, `FiniteField.isPrimePow_card`, `littleWedderburn`, `IsPrimePow.pow`. The contribution is the explicit assembly of the center refinement and the named statement of its collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)