### PR TITLE
research(euler-criterion-squares-oq-01-oq-02): two supplementary laws of quadratic reciprocity from Euler's criterion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2770,6 +2770,7 @@ import Proofs.ErdosMordellFeetAngleAristotle
 import Proofs.ErdosMordellInequalityOQ01
 import Proofs.ErdosSzekeres
 import Proofs.EulerCriterionSquaresOQ01
+import Proofs.EulerCriterionSquaresOQ01OQ02
 import Proofs.EulerIdentity
 import Proofs.EulerIdentityOQ01
 import Proofs.EulerIdentityOQ01OQ02

--- a/proofs/Proofs/EulerCriterionSquaresOQ01OQ02.lean
+++ b/proofs/Proofs/EulerCriterionSquaresOQ01OQ02.lean
@@ -1,0 +1,131 @@
+/-
+# Euler's Criterion OQ-01-OQ-02: the two supplementary laws of quadratic reciprocity
+
+The parent `euler-criterion-squares-oq-01` (`EulerCriterionSquaresOQ01.lean`) proved **Euler's
+criterion** in Legendre-symbol form,
+
+  `(a | p) ≡ a^((p−1)/2)  (mod p)`   (`legendreSym_eq_pow`),
+
+together with the fact that `a^((p−1)/2)` is always `±1` for `a ≠ 0`.
+
+This leaf derives the **two supplementary laws of quadratic reciprocity**:
+
+1. **First supplementary law** — the value of `(−1 | p)`:
+   `(−1 | p) = (−1)^((p−1)/2)`, and `−1` is a square mod `p` iff `p ≡ 1 (mod 4)`.
+   This is obtained *directly from the parent's Euler criterion*: the integer `(−1 | p)` and
+   the integer `(−1)^((p−1)/2)` are both `±1` and are congruent mod `p`, hence equal (two
+   distinct elements of `{−1, 1}` cannot coincide modulo an odd prime).
+
+2. **Second supplementary law** — the value of `(2 | p)` is governed by `p (mod 8)`:
+   `2` is a square mod `p` iff `p ≡ ±1 (mod 8)`, equivalently `(2 | p) = 1 ⟺ p ≡ 1, 7 (mod 8)`
+   and `(2 | p) = −1 ⟺ p ≡ 3, 5 (mod 8)`. The hard arithmetic content here (the Gauss-sum
+   evaluation `(2 | p) = χ₈ p`) is supplied by Mathlib's `ZMod.exists_sq_eq_two_iff`; this file
+   packages it into the explicit residue dictionary and reconciles it with the criterion.
+
+## What this proves
+
+* `legendreSym_neg_one`   — `(−1 | p) = (−1)^((p−1)/2)`   (derived from Euler's criterion).
+* `neg_one_isSquare_iff`  — `IsSquare (−1) ↔ p % 4 = 1`.
+* `legendreSym_neg_one_eq_one_iff` — `(−1 | p) = 1 ↔ p % 4 = 1`.
+* `two_isSquare_iff`      — `IsSquare (2) ↔ p % 8 = 1 ∨ p % 8 = 7`.
+* `legendreSym_two_eq_one_iff`     — `(2 | p) = 1 ↔ p % 8 = 1 ∨ p % 8 = 7`.
+* `legendreSym_two_eq_neg_one_iff` — `(2 | p) = −1 ↔ p % 8 = 3 ∨ p % 8 = 5`.
+
+All results are machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+import Mathlib
+import Proofs.EulerCriterionSquaresOQ01
+
+open ZMod
+
+namespace EulerCriterionSquaresOQ01OQ02
+
+variable (p : ℕ) [Fact p.Prime] [Fact (2 < p)]
+
+/-- `p` is odd: `p % 2 = 1`. -/
+private theorem p_odd : p % 2 = 1 :=
+  (Fact.out : p.Prime).eq_two_or_odd.resolve_left (by have := (Fact.out : 2 < p); omega)
+
+omit [Fact p.Prime] in
+/-- `p ≠ 2`, the hypothesis required by Mathlib's supplementary-law lemmas. -/
+private theorem p_ne_two : p ≠ 2 := by have := (Fact.out : 2 < p); omega
+
+/-- **Casting `{−1, 1}` is injective modulo an odd prime.** Two integers, each equal to `1`
+or `−1`, that have the same image in `ZMod p` are equal. This is the bridge that lets us lift
+the Euler-criterion *congruence* to an *equality* of Legendre-symbol values. -/
+theorem intCast_inj_of_pm_one {x y : ℤ} (hx : x = 1 ∨ x = -1) (hy : y = 1 ∨ y = -1)
+    (h : (x : ZMod p) = (y : ZMod p)) : x = y := by
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · rfl
+  · exact absurd (by push_cast at h; exact h) (EulerCriterionSquaresOQ01.one_ne_neg_one p)
+  · exact absurd (by push_cast at h; exact h.symm) (EulerCriterionSquaresOQ01.one_ne_neg_one p)
+  · rfl
+
+/-- `(−1)^n` is always `1` or `−1` in `ℤ`. -/
+private theorem neg_one_pow_pm (n : ℕ) : (-1 : ℤ) ^ n = 1 ∨ (-1 : ℤ) ^ n = -1 := by
+  rcases Nat.even_or_odd n with he | ho
+  · exact Or.inl he.neg_one_pow
+  · exact Or.inr ho.neg_one_pow
+
+/-- **First supplementary law (value form).** `(−1 | p) = (−1)^((p−1)/2)`.
+
+Proved straight from the parent's Euler criterion: both sides lie in `{−1, 1}` and are
+congruent mod `p` (the criterion `legendreSym_eq_pow`), so they are equal by
+`intCast_inj_of_pm_one`. -/
+theorem legendreSym_neg_one :
+    legendreSym p (-1) = (-1 : ℤ) ^ ((p - 1) / 2) := by
+  refine intCast_inj_of_pm_one p ?_ (neg_one_pow_pm ((p - 1) / 2)) ?_
+  · -- `(−1 | p) ∈ {1, −1}` since `(−1 : ZMod p) ≠ 0`
+    refine legendreSym.eq_one_or_neg_one p ?_
+    push_cast; exact neg_ne_zero.mpr one_ne_zero
+  · -- the congruence `(−1 | p) ≡ (−1)^((p−1)/2) (mod p)` is exactly Euler's criterion
+    rw [EulerCriterionSquaresOQ01.legendreSym_eq_pow]
+    push_cast
+    ring
+
+/-- **First supplementary law (residue form).** `−1` is a quadratic residue mod `p` iff
+`p ≡ 1 (mod 4)`. -/
+theorem neg_one_isSquare_iff : IsSquare (-1 : ZMod p) ↔ p % 4 = 1 := by
+  rw [ZMod.exists_sq_eq_neg_one_iff]
+  have := p_odd p
+  omega
+
+/-- `(−1 | p) = 1` iff `p ≡ 1 (mod 4)`. -/
+theorem legendreSym_neg_one_eq_one_iff : legendreSym p (-1) = 1 ↔ p % 4 = 1 := by
+  rw [legendreSym.eq_one_iff p (by push_cast; exact neg_ne_zero.mpr one_ne_zero)]
+  rw [show ((-1 : ℤ) : ZMod p) = (-1 : ZMod p) by push_cast; ring]
+  exact neg_one_isSquare_iff p
+
+/-- `((2 : ℤ) : ZMod p) ≠ 0`, since `p > 2` is prime and so does not divide `2`. -/
+private theorem two_ne_zero' : ((2 : ℤ) : ZMod p) ≠ 0 := by
+  have h2 : ((2 : ℕ) : ZMod p) ≠ 0 := by
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    intro hd
+    have := Nat.le_of_dvd (by norm_num) hd
+    have := (Fact.out : 2 < p)
+    omega
+  exact_mod_cast h2
+
+/-- **Second supplementary law (residue form).** `2` is a quadratic residue mod `p` iff
+`p ≡ ±1 (mod 8)`. The deep content (the Gauss-sum value `(2 | p) = χ₈ p`) is Mathlib's
+`ZMod.exists_sq_eq_two_iff`. -/
+theorem two_isSquare_iff : IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+  ZMod.exists_sq_eq_two_iff (p_ne_two p)
+
+/-- `(2 | p) = 1` iff `p ≡ 1 or 7 (mod 8)`. -/
+theorem legendreSym_two_eq_one_iff :
+    legendreSym p 2 = 1 ↔ p % 8 = 1 ∨ p % 8 = 7 := by
+  rw [legendreSym.eq_one_iff p (two_ne_zero' p)]
+  rw [show ((2 : ℤ) : ZMod p) = (2 : ZMod p) by push_cast; ring]
+  exact two_isSquare_iff p
+
+/-- `(2 | p) = −1` iff `p ≡ 3 or 5 (mod 8)`. -/
+theorem legendreSym_two_eq_neg_one_iff :
+    legendreSym p 2 = -1 ↔ p % 8 = 3 ∨ p % 8 = 5 := by
+  rw [legendreSym.eq_neg_one_iff p]
+  rw [show ((2 : ℤ) : ZMod p) = (2 : ZMod p) by push_cast; ring]
+  rw [two_isSquare_iff p]
+  have := p_odd p
+  omega
+
+end EulerCriterionSquaresOQ01OQ02

--- a/research/problems/euler-criterion-squares-oq-01-oq-02/knowledge.md
+++ b/research/problems/euler-criterion-squares-oq-01-oq-02/knowledge.md
@@ -1,0 +1,33 @@
+# Euler's Criterion OQ-01-OQ-02 — Supplementary Laws of Quadratic Reciprocity
+
+## Summary
+Leaf of `euler-criterion-squares-oq-01` (Euler's criterion in Legendre-symbol form). Derives
+the two supplementary laws of quadratic reciprocity for an odd prime `p`.
+
+## Session 2026-06-24 (Session 1) — FRESH
+**Mode**: FRESH | **Outcome**: completed (verified, 0-axiom)
+
+### What I Did
+- Built `Proofs/EulerCriterionSquaresOQ01OQ02.lean` (131 lines, 11 theorems, 0 defs).
+- First supplementary law `(−1 | p) = (−1)^((p−1)/2)` derived **from the parent's Euler
+  criterion** `legendreSym_eq_pow` (not from Mathlib's `at_neg_one`): both sides are ±1 and
+  congruent mod p, lifted to equality via a reusable `intCast_inj_of_pm_one` bridge that uses
+  the parent's `one_ne_neg_one`.
+- Residue forms: `neg_one_isSquare_iff` (p%4=1), `two_isSquare_iff` (p%8∈{1,7}).
+- Legendre-value dictionary: `legendreSym_neg_one_eq_one_iff`, `legendreSym_two_eq_one_iff`,
+  `legendreSym_two_eq_neg_one_iff` (p%8∈{3,5}), case splits via omega from oddness of p.
+
+### Key Findings
+- The (−1) law is a genuine derivation from Euler's criterion; the (2) law packages Mathlib's
+  Gauss-sum result `ZMod.exists_sq_eq_two_iff` (not re-derived).
+- `omit [inst] in` must precede the docstring, not follow it (syntax error otherwise).
+- `Nat.even_or_odd` (not `Int.even_or_odd`) for a ℕ exponent feeding `Even.neg_one_pow`.
+- `ZMod.natCast_zmod_eq_zero_iff_dvd` is deprecated → `ZMod.natCast_eq_zero_iff`.
+
+### Files
+- proofs/Proofs/EulerCriterionSquaresOQ01OQ02.lean
+- src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
+
+### Next Steps
+- Possible follow-up: full Gauss-lemma derivation of (2 | p) from Euler's criterion alone
+  (currently leans on Mathlib's Gauss-sum), or (−2 | p) / (3 | p) supplementary values.

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
@@ -1,0 +1,84 @@
+{
+  "id": "euler-criterion-squares-oq-01-oq-02",
+  "title": "The Two Supplementary Laws of Quadratic Reciprocity from Euler's Criterion",
+  "slug": "euler-criterion-squares-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.EulerCriterionSquaresOQ01"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "EulerCriterionSquaresOQ01OQ02",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/EulerCriterionSquaresOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "description": "The two supplementary laws of quadratic reciprocity, derived for an odd prime p. First supplementary law: (−1 | p) = (−1)^((p−1)/2), obtained directly from the parent's Euler criterion (legendreSym_eq_pow) — the integers (−1 | p) and (−1)^((p−1)/2) both lie in {−1, 1} and are congruent mod p, hence equal by an injectivity-of-{±1}-mod-p lemma — together with its residue form IsSquare(−1) ↔ p ≡ 1 (mod 4). Second supplementary law: 2 is a quadratic residue mod p iff p ≡ ±1 (mod 8), packaged into the explicit value dictionary (2 | p) = 1 ⟺ p ≡ 1,7 (mod 8) and (2 | p) = −1 ⟺ p ≡ 3,5 (mod 8); the deep Gauss-sum content is Mathlib's ZMod.exists_sq_eq_two_iff.",
+  "meta": {
+    "author": "Lean Genius Researcher (2026)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_criterion#Supplements_to_the_law_of_quadratic_reciprocity",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerCriterionSquaresOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "euler-criterion",
+      "legendre-symbol",
+      "quadratic-reciprocity",
+      "supplementary-laws"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.eq_one_or_neg_one",
+        "description": "the Legendre symbol of a unit is ±1; supplies membership of (−1 | p) in {−1, 1} for the criterion-to-equality lift",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "legendreSym.eq_one_iff / eq_neg_one_iff",
+        "description": "(a | p) = ±1 characterized by IsSquare (a : ZMod p); converts the residue dictionaries into Legendre-value form",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.exists_sq_eq_neg_one_iff",
+        "description": "IsSquare (−1 : ZMod p) ↔ p % 4 ≠ 3; the residue form of the first supplementary law",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.exists_sq_eq_two_iff",
+        "description": "IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 — the Gauss-sum content of the SECOND supplementary law; this entry packages it, it does not re-derive it",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      }
+    ],
+    "originalContributions": [
+      "legendreSym_neg_one: (−1 | p) = (−1)^((p−1)/2) derived straight from the PARENT's Euler criterion (legendreSym_eq_pow), not from Mathlib's legendreSym.at_neg_one — both sides are ±1 and congruent mod p, so equal",
+      "intCast_inj_of_pm_one: the reusable bridge lemma making the criterion's congruence into an equality — two integers in {−1, 1} with equal image in ZMod p are equal (uses the parent's one_ne_neg_one)",
+      "neg_one_isSquare_iff / legendreSym_neg_one_eq_one_iff: first supplementary law in residue (p % 4 = 1) and Legendre-value forms",
+      "two_isSquare_iff / legendreSym_two_eq_one_iff / legendreSym_two_eq_neg_one_iff: the SECOND supplementary law as a complete explicit p (mod 8) dictionary, with the residue/non-residue cases (p ≡ 1,7 vs 3,5) separated via omega from oddness of p"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 131,
+    "assumptions": "0 axioms (depends only on propext / Classical.choice / Quot.sound — the foundational Lean axioms; no sorry, no native_decide / Lean.ofReduceBool). 0 sorries. Fully verified. Honest scope: the FIRST supplementary law (−1 | p) is derived from the parent's Euler criterion (an original route); the SECOND supplementary law (2 | p) packages Mathlib's Gauss-sum result ZMod.exists_sq_eq_two_iff into an explicit p (mod 8) dictionary rather than re-deriving the Gauss-sum evaluation from scratch.",
+    "mathlib_version": "4.26.0",
+    "parentProof": "euler-criterion-squares-oq-01",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler's criterion (1748) states that for an odd prime p and a not divisible by p, a is a quadratic residue mod p iff a^((p−1)/2) ≡ 1 (mod p). Two famous consequences are the 'supplementary laws' that accompany Gauss's law of quadratic reciprocity: the value of the Legendre symbol at −1 (governed by p mod 4) and at 2 (governed by p mod 8). The first follows immediately by substituting a = −1 into Euler's criterion; the second is more delicate and classically requires Gauss's lemma or a Gauss-sum computation.",
+    "problemStatement": "Prove the two supplementary laws of quadratic reciprocity from Euler's criterion: (−1 | p) = (−1)^((p−1)/2), and the value of (2 | p) determined by p mod 8.",
+    "keyResults": [
+      "First supplementary law: (−1 | p) = (−1)^((p−1)/2), derived directly from the parent's Euler criterion; equivalently −1 is a square mod p iff p ≡ 1 (mod 4).",
+      "Second supplementary law: 2 is a square mod p iff p ≡ ±1 (mod 8); explicitly (2 | p) = 1 iff p ≡ 1, 7 (mod 8) and (2 | p) = −1 iff p ≡ 3, 5 (mod 8).",
+      "A reusable lemma lifting Euler's congruence to an equality of Legendre values: distinct elements of {−1, 1} stay distinct modulo an odd prime."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question oq-01-oq-02 of `euler-criterion-squares-oq-01` (Euler's criterion in Legendre-symbol form): **derive the two supplementary laws of quadratic reciprocity for an odd prime `p`.**

- **First supplementary law** `(−1 | p) = (−1)^((p−1)/2)` — derived **directly from the parent's Euler criterion** `legendreSym_eq_pow` (not from Mathlib's `legendreSym.at_neg_one`). Both `(−1 | p)` and `(−1)^((p−1)/2)` lie in `{−1, 1}` and are congruent mod `p`; they are lifted to an equality by the reusable bridge `intCast_inj_of_pm_one` (distinct elements of `{±1}` stay distinct mod an odd prime, via the parent's `one_ne_neg_one`). Residue form: `IsSquare (−1) ↔ p ≡ 1 (mod 4)`.
- **Second supplementary law** — `2` is a quadratic residue mod `p` iff `p ≡ ±1 (mod 8)`, packaged into the explicit value dictionary `(2 | p) = 1 ⟺ p ≡ 1,7 (mod 8)` and `(2 | p) = −1 ⟺ p ≡ 3,5 (mod 8)`. The deep Gauss-sum content is Mathlib's `ZMod.exists_sq_eq_two_iff`; this entry packages it, it does not re-derive it.

## Verification

- Compiles against Mathlib 4.26.0; **0 sorries, 0 `axiom` declarations, no `native_decide`**.
- `#print axioms` on every headline theorem reports only `[propext, Classical.choice, Quot.sound]` (the foundational Lean axioms) — genuinely 0-axiom.
- 131 lines, 11 theorems, 0 definitions.

## Honesty note

The first supplementary law is an original derivation from the parent's Euler criterion; the second supplementary law packages Mathlib's Gauss-sum result rather than re-deriving the Gauss-sum evaluation from scratch. Badge set to `verified` (machine-checked, 0-axiom) accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)