### PR TITLE
research(stirling-second-kind-oq-01-oq-01): third column S(n,3)=(3ⁿ⁻¹+1)/2−2ⁿ⁻¹ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3810,6 +3810,7 @@ import Proofs.StirlingFormulaOQ02
 import Proofs.StirlingFormulaOQ03
 import Proofs.StirlingFormulaOQ03OQ01
 import Proofs.StirlingSecondKindOQ01
+import Proofs.StirlingSecondKindOQ01OQ01
 import Proofs.StirlingSecondKindOQ01OQ02
 import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01

--- a/proofs/Proofs/StirlingSecondKindOQ01OQ01.lean
+++ b/proofs/Proofs/StirlingSecondKindOQ01OQ01.lean
@@ -1,0 +1,131 @@
+/-
+Stirling Numbers of the Second Kind: the three-block column  S(n,3) = (3^(n-1)+1)/2 − 2^(n-1)
+
+Source: Open question from the stirling-second-kind / stirling-second-kind-oq-01 gallery family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+`Nat.stirlingSecond n k` counts the partitions of an `n`-element set into exactly
+`k` nonempty, unlabeled blocks. The gallery entry `stirling-second-kind-oq-01`
+records the first nontrivial column
+
+      S(n, 2) = 2^(n-1) − 1     (n ≥ 2),
+
+obtained by solving the inhomogeneous geometric recurrence
+`S(n+1,2) = 2·S(n,2) + 1`. This entry climbs one more rung of the
+"column closed-forms" family and pins down the third column:
+
+      S(n, 3) = (3^(n-1) + 1)/2 − 2^(n-1)     (n ≥ 3).
+
+The Pascal recurrence specialised to the third column is the genuinely
+inhomogeneous first-order recursion
+
+      S(n+1, 3) = 3·S(n, 3) + S(n, 2) = 3·S(n, 3) + (2^(n-1) − 1),
+
+a recurrence with two competing exponential modes (`3^n` and `2^n`). Solving it
+gives the stated closed form. Unlike the `k = 2` column the answer carries a
+genuine division by `2`; we sidestep `ℕ` truncated-division pitfalls by first
+proving the *denominator-free* shifted identity
+
+      2·S(m+3, 3) + 2^(m+3) = 3^(m+2) + 1                         (`stirlingSecond_three_add`)
+
+purely by induction over the Pascal recurrence, and only then dividing to recover
+the textbook form. The denominator-free statement is also the cleaner object: it
+makes manifest that `3^(n-1) + 1` is always even (the right side is `2·(…)`),
+which is exactly why the division in the closed form is exact.
+
+We prove:
+1. `stirlingSecond_three_add` — denominator-free shifted form 2·S(m+3,3)+2^(m+3)=3^(m+2)+1
+2. `stirlingSecond_three`     — textbook form S(n,3) = (3^(n-1)+1)/2 − 2^(n-1) for n ≥ 3
+3. `stirlingSecond_three_pos` — there is always at least one three-block partition (n ≥ 3)
+
+The supporting two-block value `S(n,2) = 2^(n-1) − 1` is re-derived inline
+(`aux_two`) so the file is self-contained and depends only on Mathlib.
+-/
+
+import Mathlib
+
+open Nat
+
+namespace StirlingSecondKindOQ01OQ01
+
+/-- **Two-block column, shifted form** (re-derived inline from the Pascal
+recurrence, mirroring `stirling-second-kind-oq-01`). The number of partitions of
+an `(m+2)`-element set into two nonempty blocks is `2^(m+1) − 1`. Used as the
+inhomogeneous driving term for the three-block recurrence. -/
+private theorem aux_two (m : ℕ) :
+    Nat.stirlingSecond (m + 2) 2 = 2 ^ (m + 1) - 1 := by
+  induction m with
+  | zero => decide
+  | succ m ih =>
+    have key : Nat.stirlingSecond (m + 1 + 2) 2
+        = 2 * Nat.stirlingSecond (m + 2) 2 + Nat.stirlingSecond (m + 2) 1 :=
+      Nat.stirlingSecond_succ_succ (m + 2) 1
+    have hone : Nat.stirlingSecond (m + 2) 1 = 1 := Nat.stirlingSecond_one_right (m + 1)
+    have h1 : 1 ≤ 2 ^ (m + 1) := Nat.one_le_two_pow
+    have h2 : 2 ^ (m + 1 + 1) = 2 * 2 ^ (m + 1) := by ring
+    rw [key, ih, hone]
+    omega
+
+/-- **Three-block column, denominator-free shifted form.**
+
+For every `m ≥ 0`,
+$$2\cdot S(m+3,\,3) + 2^{\,m+3} = 3^{\,m+2} + 1.$$
+
+Equivalently `S(m+3,3) = (3^(m+2)+1)/2 − 2^(m+2)`, but stated without division so the
+induction stays inside `ℕ`. Proof by induction using the Pascal recurrence
+`S((m+3)+1, 3) = 3·S(m+3,3) + S(m+3,2)` together with the two-block value
+`S(m+3,2) = 2^(m+2) − 1`. The recursion `a(m+1) = 3·a(m) + 2^(m+2) − 1` is solved
+by `a(m) = (3^(m+2)+1)/2 − 2^(m+2)`; in the doubled, subtraction-free form the
+inductive step is linear and closed by `omega` once the powers are expanded. -/
+theorem stirlingSecond_three_add (m : ℕ) :
+    2 * Nat.stirlingSecond (m + 3) 3 + 2 ^ (m + 3) = 3 ^ (m + 2) + 1 := by
+  induction m with
+  | zero => decide
+  | succ m ih =>
+    -- Pascal recurrence specialised to the third column (k = 2):
+    --   S(m+4, 3) = 3·S(m+3, 3) + S(m+3, 2).
+    have key : Nat.stirlingSecond (m + 3 + 1) 3
+        = 3 * Nat.stirlingSecond (m + 3) 3 + Nat.stirlingSecond (m + 3) 2 :=
+      Nat.stirlingSecond_succ_succ (m + 3) 2
+    -- The inhomogeneous term: the two-block value S(m+3, 2) = 2^(m+2) − 1.
+    have hS2 : Nat.stirlingSecond (m + 3) 2 = 2 ^ (m + 2) - 1 := aux_two (m + 1)
+    have hPpos : 1 ≤ 2 ^ (m + 2) := Nat.one_le_two_pow
+    -- Expand the powers so `omega` can treat 2^(m+2) and 3^(m+2) as opaque atoms.
+    have e2a : 2 ^ (m + 3) = 2 * 2 ^ (m + 2) := by ring
+    have e2b : 2 ^ (m + 1 + 3) = 4 * 2 ^ (m + 2) := by ring
+    have e3 : 3 ^ (m + 1 + 2) = 3 * 3 ^ (m + 2) := by ring
+    rw [key, hS2]
+    omega
+
+/-- **Three-block column, textbook form.** For `n ≥ 3`, the number of partitions of
+an `n`-element set into exactly three nonempty blocks is
+$$S(n,3) = \frac{3^{\,n-1}+1}{2} - 2^{\,n-1}.$$
+The division by `2` is exact because `3^(n-1)` is odd. -/
+theorem stirlingSecond_three {n : ℕ} (hn : 3 ≤ n) :
+    Nat.stirlingSecond n 3 = (3 ^ (n - 1) + 1) / 2 - 2 ^ (n - 1) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 3 := ⟨n - 3, by omega⟩
+  have h := stirlingSecond_three_add m
+  have he : m + 3 - 1 = m + 2 := by omega
+  have e2 : 2 ^ (m + 3) = 2 * 2 ^ (m + 2) := by ring
+  rw [he]
+  omega
+
+/-- **Existence of a three-block partition.** Any set with at least three elements
+can be split into three nonempty blocks, i.e. `S(n,3) > 0` for `n ≥ 3`.
+
+Concretely `2·S(n,3) = 3^(n-1) + 1 − 2^n` and `3^(n-1) + 1 > 2^n` for `n ≥ 3`
+(the `3^(n-1)` mode dominates), so `S(n,3) ≥ 1`. -/
+theorem stirlingSecond_three_pos {n : ℕ} (hn : 3 ≤ n) :
+    0 < Nat.stirlingSecond n 3 := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 3 := ⟨n - 3, by omega⟩
+  have h := stirlingSecond_three_add m
+  -- `2^(m+3) = 8·2^m ≤ 9·3^m = 3^(m+2)`, so the doubled value `3^(m+2)+1 − 2^(m+3)`
+  -- is at least `1`, giving `S(m+3,3) ≥ 1`.
+  have hdom : 2 ^ (m + 3) ≤ 3 ^ (m + 2) := by
+    have hle : 2 ^ m ≤ 3 ^ m := Nat.pow_le_pow_left (by norm_num) m
+    have e2 : 2 ^ (m + 3) = 8 * 2 ^ m := by ring
+    have e3 : 3 ^ (m + 2) = 9 * 3 ^ m := by ring
+    omega
+  omega
+
+end StirlingSecondKindOQ01OQ01

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-01/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "stirling-second-kind-oq-01-oq-01",
+  "title": "Stirling Numbers of the Second Kind: the three-block column S(n,3) = (3ⁿ⁻¹+1)/2 − 2ⁿ⁻¹",
+  "slug": "stirling-second-kind-oq-01-oq-01",
+  "description": "The closed form for the third column of Stirling's triangle: the number of ways to partition an n-element set into exactly three nonempty blocks is (3^(n-1)+1)/2 − 2^(n-1) for n ≥ 3. This answers the first open question of the parent entry stirling-second-kind-oq-01 (the k=2 column), climbing one more rung of the column-closed-forms family. Unlike the geometric k=2 case, the k=3 recurrence is genuinely inhomogeneous with two competing exponential modes (3ⁿ and 2ⁿ); the answer carries a division by 2 handled via a denominator-free shifted identity.",
+  "meta": {
+    "author": "James Stirling (1730)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingSecondKindOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "set-partitions",
+      "enumerative",
+      "closed-form",
+      "recurrence",
+      "classic"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "Pascal recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k); specialised to k=2 it gives S(n+1,3) = 3·S(n,3) + S(n,2)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_one_right",
+        "description": "First-column value S(n+1,1) = 1, used in the re-derivation of the two-block driving term S(n,2)",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.one_le_two_pow",
+        "description": "1 ≤ 2^n, used to discharge the natural-subtraction arithmetic for the two-block term",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_left",
+        "description": "Monotonicity 2^m ≤ 3^m of the base, used to show 2^(m+3) ≤ 3^(m+2) for the positivity corollary",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "stirlingSecond_three_add: the denominator-free shifted identity 2·S(m+3,3) + 2^(m+3) = 3^(m+2) + 1, proved by induction on the Pascal recurrence — the workhorse that keeps the whole argument inside ℕ and makes manifest that 3^(n-1)+1 is even",
+      "stirlingSecond_three: the textbook closed form S(n,3) = (3^(n-1)+1)/2 − 2^(n-1) for n ≥ 3, obtained by dividing the shifted identity by 2",
+      "stirlingSecond_three_pos: every set with at least three elements admits a three-block partition, i.e. S(n,3) > 0 for n ≥ 3, via the domination 2^(n-1)·2 = 2^n < 3^(n-1)+1",
+      "aux_two: an inline self-contained re-derivation of the two-block column S(m+2,2) = 2^(m+1) − 1, supplying the inhomogeneous driving term without importing the parent entry"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The three results depend only on propext, Classical.choice, Quot.sound. Base cases use kernel `decide` (no `native_decide`, hence no `Lean.ofReduceBool`).",
+    "lineCount": 131,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Stirling numbers of the second kind S(n,k) count the partitions of an n-element set into k nonempty, unlabeled blocks, appearing in James Stirling's 1730 Methodus Differentialis. Their triangle obeys the Pascal-like recurrence S(n+1,k) = k·S(n,k) + S(n,k-1). The boundary columns S(n,1)=1, S(n,n)=1, S(n,n-1)=C(n,2) are elementary and in Mathlib; the parent gallery entry supplies the first nontrivial column S(n,2)=2^(n-1)−1. The third column S(n,3) is the next rung. Its values 1, 6, 25, 90, 301, … (n = 3, 4, 5, 6, 7) are OEIS A000392, and the closed form (3^(n-1)+1)/2 − 2^(n-1) is classical, but it is not recorded in Mathlib.",
+    "problemStatement": "Determine and verify the number of partitions of an n-element set into exactly three nonempty blocks.\n\n**Answer:** S(n,3) = (3^(n-1)+1)/2 − 2^(n-1) for every n ≥ 3.",
+    "text": "The third column of Stirling's triangle of the second kind has the closed form S(n,3) = (3^(n-1)+1)/2 − 2^(n-1), derived by solving the inhomogeneous Pascal recurrence and verified in Lean with no axioms.",
+    "proofStrategy": "1. aux_two: re-derive the two-block value S(m+2,2) = 2^(m+1) − 1 inline by induction (base by decide; step from the Pascal recurrence specialised to the second column), so the file is self-contained.\n2. stirlingSecond_three_add: induct on m to prove the denominator-free shifted identity 2·S(m+3,3) + 2^(m+3) = 3^(m+2) + 1. Base S(3,3)=1 by decide. Step specialises the Pascal recurrence to the third column, S(m+4,3) = 3·S(m+3,3) + S(m+3,2), substitutes S(m+3,2) = 2^(m+2) − 1, expands the three power terms (2^(m+3), 2^(m+4), 3^(m+3)) in terms of 2^(m+2) and 3^(m+2), and closes the linear arithmetic with omega.\n3. stirlingSecond_three: write n = m + 3, rewrite the exponent n − 1 = m + 2, and divide the shifted identity by 2 — omega derives both the exactness of the division (3^(n-1)+1 is even) and the closed form.\n4. stirlingSecond_three_pos: from 2^(m+3) = 8·2^m ≤ 9·3^m = 3^(m+2), the shifted identity forces 2·S(m+3,3) ≥ 1, so S(n,3) > 0.",
+    "keyInsights": [
+      "**Two competing exponential modes.** Specialising Pascal's rule to the third column gives the genuinely inhomogeneous first-order recurrence S(n+1,3) = 3·S(n,3) + (2^(n-1) − 1); its solution superimposes a 3^n mode (homogeneous) and a 2^n mode (driven by the two-block column), unlike the purely geometric k=2 case.",
+      "**Division-by-2 via a denominator-free identity.** The closed form has a /2, which over ℕ invites truncated-division pitfalls. Proving the doubled identity 2·S(m+3,3) + 2^(m+3) = 3^(m+2) + 1 keeps the induction in ℕ and simultaneously exhibits 3^(n-1)+1 as 2·(S + 2^(n-1)), i.e. proves the parity that makes the division exact.",
+      "**omega closes the step once powers are atomised.** The inductive step is linear in the atoms 2^(m+2) and 3^(m+2) after supplying the rewrites 2^(m+3)=2·2^(m+2), 2^(m+4)=4·2^(m+2), 3^(m+3)=3·3^(m+2); omega then handles the natural subtraction and the division.",
+      "**Reusing the predecessor column.** The k=2 value is the inhomogeneous driving term for k=3, exactly the recurrence-to-geometric-sum method the parent used — demonstrating that the technique scales past the trivially geometric column."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind and set partitions",
+      "Induction on the natural numbers",
+      "The Pascal recurrence for Stirling numbers",
+      "Solving inhomogeneous first-order linear recurrences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "File-level docstring stating S(n,3) = (3^(n-1)+1)/2 − 2^(n-1), the inhomogeneous recurrence S(n+1,3) = 3·S(n,3) + (2^(n-1)−1), and the denominator-free strategy. Imports Mathlib and opens Nat.",
+      "mathContext": "S(n,3) counts partitions of an n-set into three nonempty unlabeled blocks; Mathlib's Nat.stirlingSecond supplies the Pascal recurrence used to derive the column closed form."
+    },
+    {
+      "id": "two-block-aux",
+      "title": "Inline Two-Block Driving Term S(m+2,2) = 2^(m+1) − 1",
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "aux_two: induction re-deriving the two-block column (base by decide; step from the Pascal recurrence specialised to the second column with S(m+2,1)=1 and 1 ≤ 2^(m+1), closed by omega). Keeps the entry self-contained.",
+      "mathContext": "The k=2 column is the inhomogeneous term in the k=3 recurrence; S(m+3,2) = 2^(m+2) − 1 is obtained as aux_two (m+1)."
+    },
+    {
+      "id": "shifted-form",
+      "title": "The Denominator-Free Shifted Identity",
+      "startLine": 80,
+      "endLine": 102,
+      "summary": "stirlingSecond_three_add: induction proving 2·S(m+3,3) + 2^(m+3) = 3^(m+2) + 1. Base S(3,3)=1 by decide. Step uses Pascal (S(m+4,3) = 3·S(m+3,3) + S(m+3,2)), substitutes the two-block value, expands the powers, and closes with omega.",
+      "mathContext": "a(m+1) = 3·a(m) + 2^(m+2) − 1 solved by a(m) = (3^(m+2)+1)/2 − 2^(m+2); the doubled, subtraction-free form keeps the induction inside ℕ."
+    },
+    {
+      "id": "textbook-form",
+      "title": "The Textbook Form S(n,3) = (3^(n-1)+1)/2 − 2^(n-1)",
+      "startLine": 104,
+      "endLine": 116,
+      "summary": "stirlingSecond_three: for n ≥ 3, write n = m + 3, rewrite n − 1 = m + 2, and divide the shifted identity by 2. omega supplies both the exactness of the division and the closed form.",
+      "mathContext": "The standard statement: for n ≥ 3, S(n,3) = (3^(n-1)+1)/2 − 2^(n-1), with the division exact because 3^(n-1) is odd."
+    },
+    {
+      "id": "existence",
+      "title": "Existence of a Three-Block Partition",
+      "startLine": 118,
+      "endLine": 131,
+      "summary": "stirlingSecond_three_pos: S(n,3) > 0 for n ≥ 3. From 2^(m+3) = 8·2^m ≤ 9·3^m = 3^(m+2) and the shifted identity, 2·S(m+3,3) ≥ 1, so the count is positive.",
+      "mathContext": "Any set of size ≥ 3 can be split into three nonempty parts, so the count is strictly positive; the 3^n mode dominates the 2^n mode."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "Origin of the Stirling numbers; S(n,k) as connection coefficients between powers and falling factorials"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6 develops the Stirling triangle, including the column closed forms S(n,2) and S(n,3)"
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "Sequence A000392: Stirling numbers of the second kind S(n,3)",
+      "year": "2024",
+      "note": "Values 1, 6, 25, 90, 301, 966, … with the closed form (3^(n-1)+1)/2 − 2^(n-1)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "extends",
+      "description": "Answers the first open question of the parent two-block entry by establishing the third column with the same recurrence-to-geometric-sum method, reusing the k=2 value as the inhomogeneous driving term"
+    }
+  ],
+  "conclusion": {
+    "summary": "The third column of Stirling's triangle of the second kind has the closed form S(n,3) = (3^(n-1)+1)/2 − 2^(n-1) (stirlingSecond_three), obtained by solving the inhomogeneous first-order recurrence S(n+1,3) = 3·S(n,3) + (2^(n-1)−1) that Pascal's rule induces on the column. The denominator-free shifted identity (stirlingSecond_three_add) carries the induction and exhibits the parity making the division exact; the existence corollary (stirlingSecond_three_pos) records that the count is always positive. All four results are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the third nontrivial column value of the Stirling-second-kind triangle as a directly citable closed form and confirms that the recurrence-to-geometric-sum technique scales beyond the geometric k=2 case to a genuinely inhomogeneous recurrence with two exponential modes.",
+    "openQuestions": [
+      "Is there a closed form for the fourth column S(n,4) = (4^(n-1) − 2·3^(n-1) + 2^n − 2)/6, derivable by the same method with three competing exponential modes?",
+      "Can the general finite-difference formula S(n,k) = (1/k!)·∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n be formalized and shown to recover the k = 2 and k = 3 columns as instances?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "StirlingSecondKindOQ01OQ01",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/StirlingSecondKindOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent gallery entry `stirling-second-kind-oq-01` (the two-block column S(n,2)=2ⁿ⁻¹−1):

> *Is there a comparably clean closed form for the third column S(n,3) = (3ⁿ⁻¹+1)/2 − 2ⁿ⁻¹, and can it be derived by the same recurrence-to-geometric-sum method?*

Yes. This entry establishes, for n ≥ 3,
$$S(n,3) = \frac{3^{\,n-1}+1}{2} - 2^{\,n-1}.$$

Values 1, 6, 25, 90, 301, … (OEIS A000392). Mathlib records the Pascal recurrences and boundary columns but not this column.

## Mathematics

Specialising Pascal's rule `S(n+1,k+1)=(k+1)·S(n,k+1)+S(n,k)` to k=2 gives the **genuinely inhomogeneous** first-order recurrence
$$S(n+1,3) = 3\cdot S(n,3) + \bigl(2^{\,n-1}-1\bigr),$$
whose solution superimposes a 3ⁿ mode (homogeneous) and a 2ⁿ mode (driven by the predecessor column) — unlike the purely geometric k=2 case.

The closed form carries a division by 2. To stay inside ℕ and avoid truncated-division pitfalls, the workhorse lemma is the **denominator-free shifted identity**
$$2\cdot S(m+3,3) + 2^{\,m+3} = 3^{\,m+2}+1,$$
which simultaneously makes manifest that 3ⁿ⁻¹+1 is even (so the division is exact). Dividing by 2 recovers the textbook form.

## Contents (4 theorems, 0 definitions, 131 lines)

- `stirlingSecond_three_add` — denominator-free shifted identity (induction on the Pascal recurrence)
- `stirlingSecond_three` — textbook form S(n,3)=(3ⁿ⁻¹+1)/2−2ⁿ⁻¹ for n≥3
- `stirlingSecond_three_pos` — S(n,3)>0 for n≥3 (the 3ⁿ mode dominates)
- `aux_two` — inline re-derivation of the k=2 driving term S(m+2,2)=2^(m+1)−1, keeping the file self-contained (no dependency on the parent olean)

## Verification

Compiles against Mathlib 4.26.0. `#print axioms` on all three public theorems shows dependence only on `propext`, `Classical.choice`, `Quot.sound`. Base cases use kernel `decide` (**no** `native_decide`, hence no `Lean.ofReduceBool`). **Verified, 0 axioms, 0 sorries.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)