### PR TITLE
research(erdos-191-incomplete-01): eliminate tripleLog_unbounded axiom — log log log n → ∞ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1594,6 +1594,7 @@ import Proofs.Erdos189Problem
 import Proofs.Erdos18Problem
 import Proofs.Erdos190Problem
 import Proofs.Erdos191Problem
+import Proofs.Erdos191Incomplete01
 import Proofs.Erdos192Problem
 import Proofs.Erdos193Problem
 import Proofs.Erdos194Problem

--- a/proofs/Proofs/Erdos191Incomplete01.lean
+++ b/proofs/Proofs/Erdos191Incomplete01.lean
@@ -1,0 +1,62 @@
+import Mathlib
+
+/-
+  # Erdős #191 — eliminating the `tripleLog_unbounded` axiom
+
+  The gallery entry `erdos-191` (`Erdos191Problem.lean`) formalizes Erdős
+  Problem #191 (monochromatic sets with large `∑ 1/log x`) and its known
+  solution, carrying four axioms for the deep results. One of those axioms is
+  *not* deep — it is the elementary fact that
+
+      `tripleLog n = log(log(log n)) → ∞`   as `n → ∞`,
+
+  stated there as `tripleLog_unbounded : ∀ M, ∃ N, ∀ n ≥ N, tripleLog n > M`.
+
+  This file **proves** it (0 axioms, 0 sorries), so the axiom can be retired:
+  the natural cast `ℕ → ℝ` tends to `atTop`, `Real.log` tends to `atTop` along
+  `atTop`, and the threefold composition therefore tends to `atTop`; a `Tendsto …
+  atTop` statement immediately gives the `∀ M, ∃ N, ∀ n ≥ N, … > M` form.
+
+  (Proved standalone because `Erdos191Problem.lean` does not currently compile
+  against this Mathlib under its declared imports — several supporting imports,
+  e.g. `Real.log_two_gt_d9` and `rpow`, are missing there — so this entry
+  re-states `tripleLog` and supplies the elementary divergence axiom-free,
+  ready to drop in once those imports are repaired.)
+
+  ## Results
+  * `tripleLog_tendsto_atTop` : `log(log(log n)) → ∞`.
+  * `tripleLog_unbounded`     : the `ε`-`N` form matching the parent's axiom.
+
+  `0` axioms.
+-/
+
+namespace Erdos191Incomplete01
+
+open Filter Real
+
+/-- `log log log n`, the natural scale of Erdős #191 (matching the parent definition). -/
+noncomputable def tripleLog (n : ℕ) : ℝ :=
+  Real.log (Real.log (Real.log n))
+
+/-- **Triple log diverges.** As `n → ∞`, `log(log(log n)) → ∞`: the cast
+`ℕ → ℝ` tends to `atTop`, and `Real.log` preserves `atTop`, so the threefold
+composition does too. -/
+theorem tripleLog_tendsto_atTop :
+    Tendsto (fun n : ℕ => tripleLog n) atTop atTop := by
+  have hcast : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop := tendsto_natCast_atTop_atTop
+  have h :=
+    Real.tendsto_log_atTop.comp (Real.tendsto_log_atTop.comp (Real.tendsto_log_atTop.comp hcast))
+  simpa only [Function.comp_def, tripleLog] using h
+
+/-- **`tripleLog_unbounded`, axiom-free.** For every threshold `M` there is `N`
+beyond which `tripleLog n > M`. This is exactly the statement axiomatized as
+`tripleLog_unbounded` in `Erdos191Problem.lean`, here derived from
+`tripleLog_tendsto_atTop`. -/
+theorem tripleLog_unbounded : ∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, tripleLog n > M := by
+  intro M
+  have h := tripleLog_tendsto_atTop.eventually (eventually_gt_atTop M)
+  rw [eventually_atTop] at h
+  obtain ⟨N, hN⟩ := h
+  exact ⟨N, fun n hn => hN n hn⟩
+
+end Erdos191Incomplete01

--- a/src/data/proofs/erdos-191-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-191-incomplete-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "erdos-191-incomplete-01",
+  "title": "Erdős #191: Eliminating the tripleLog_unbounded Axiom (log log log n → ∞)",
+  "slug": "erdos-191-incomplete-01",
+  "description": "Discharges one of the four axioms carried by the erdos-191 entry: tripleLog_unbounded, the elementary statement that tripleLog n = log(log(log n)) → ∞. Proved axiom-free from Real.tendsto_log_atTop composed three times with the ℕ→ℝ cast. The other three erdos-191 axioms (Rödl/Conlon-Fox-Sudakov) are genuinely deep; this one was not. 2 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-1",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos191Incomplete01.lean",
+    "tags": [
+      "erdos-problems",
+      "axiom-elimination",
+      "asymptotics",
+      "logarithm",
+      "filter-limits",
+      "ramsey-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 62,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "assumptions": "None. Both theorems proved, 0 axioms. Verified axiom-free: #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tendsto_log_atTop",
+        "description": "Tendsto Real.log atTop atTop — log preserves divergence to +∞, applied three times",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "tendsto_natCast_atTop_atTop",
+        "description": "the natural cast ℕ → ℝ tends to atTop, the innermost composition",
+        "module": "Mathlib.Order.Filter.AtTopBot.Archimedean"
+      },
+      {
+        "theorem": "Filter.Tendsto.eventually / Filter.eventually_atTop",
+        "description": "convert Tendsto … atTop into the ∀ M, ∃ N, ∀ n ≥ N, … > M form",
+        "module": "Mathlib.Order.Filter.AtTopBot.Defs"
+      }
+    ],
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #191 asks whether, in any 2-colouring of the edges of the complete graph on {2,…,n}, one can find a monochromatic X with ∑_{x∈X} 1/log x ≥ C for arbitrary C. It was solved affirmatively by Rödl (2003), with tight Θ(log log log n) bounds (Conlon–Fox–Sudakov 2013). The gallery entry erdos-191 formalizes the problem and its solution, necessarily axiomatizing the deep theorems (Rödl's construction, the Conlon–Fox–Sudakov lower bound, the main conjecture). It also axiomatized tripleLog_unbounded — that log(log(log n)) → ∞ — but that is elementary, not deep, and should be a theorem.",
+    "problemStatement": "Prove, axiom-free, that tripleLog n = log(log(log n)) tends to +∞: for every M there is N with tripleLog n > M for all n ≥ N (the statement axiomatized as tripleLog_unbounded in Erdos191Problem.lean).",
+    "proofStrategy": "The natural cast ℕ → ℝ tends to atTop (tendsto_natCast_atTop_atTop), and Real.log tends to atTop along atTop (Real.tendsto_log_atTop); composing the latter three times over the former gives Tendsto (fun n => log(log(log n))) atTop atTop (tripleLog_tendsto_atTop). A Tendsto … atTop atTop statement, pulled back through eventually_gt_atTop and unpacked via eventually_atTop, yields exactly ∀ M, ∃ N, ∀ n ≥ N, tripleLog n > M.",
+    "keyInsights": [
+      "**Not every axiom in a solved-problem file is deep.** Three of erdos-191's axioms encode genuine research theorems (Rödl, Conlon–Fox–Sudakov); tripleLog_unbounded merely says a triple logarithm diverges — provable in a few lines.",
+      "**Divergence composes.** log preserves atTop, so any finite tower log(log(…log n…)) diverges; the proof is just `Real.tendsto_log_atTop.comp` applied threefold over the cast.",
+      "**Tendsto ⇒ ε–N.** The filter statement Tendsto f atTop atTop is strictly stronger than and immediately yields the quantifier form ∀ M ∃ N ∀ n ≥ N, f n > M, so the axiom is fully discharged.",
+      "**Axiom reduction is real progress.** Replacing tripleLog_unbounded by a theorem lowers the genuine assumption count of erdos-191 from 4 to 3, leaving only the deep results assumed."
+    ]
+  },
+  "sections": [
+    {
+      "id": "divergence",
+      "title": "Triple-log divergence and the ε–N form",
+      "startLine": 39,
+      "endLine": 62,
+      "summary": "tripleLog n := log(log(log n)). tripleLog_tendsto_atTop: Tendsto (fun n => tripleLog n) atTop atTop, via Real.tendsto_log_atTop composed three times over tendsto_natCast_atTop_atTop. tripleLog_unbounded: the ∀ M ∃ N ∀ n ≥ N form, matching the parent's axiom.",
+      "mathContext": "$\\log\\log\\log n \\to \\infty$, hence $\\forall M\\, \\exists N\\, \\forall n \\geq N,\\ \\log\\log\\log n > M$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The tripleLog_unbounded axiom of erdos-191 is discharged: log(log(log n)) → ∞ is proved axiom-free, reducing the genuine assumption count of the Erdős #191 formalization from 4 axioms to 3 (the remaining three being the deep Rödl / Conlon–Fox–Sudakov results). 2 theorems, 1 definition, 0 sorries, 0 axioms.",
+    "implications": "Demonstrates that the elementary divergence axiom in the Erdős #191 entry is unnecessary; the proof is ready to drop into Erdos191Problem.lean once that file's unrelated import breakage (missing ExponentialBounds / rpow imports under the current Mathlib) is repaired.",
+    "openQuestions": [
+      "Repair the import breakage in Erdos191Problem.lean (it does not currently compile standalone: Real.log_two_gt_d9 and rpow are out of scope) and inline this proof to retire the axiom in place.",
+      "Quantify the threshold: give an explicit N(M) (a tower of exponentials) for which tripleLog n > M, turning the existence statement into a constructive bound."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Real"
+    ],
+    "namespace": "Erdos191Incomplete01",
+    "lineCount": 62,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos191Incomplete01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-191",
+      "relationship": "extends",
+      "description": "Discharges the tripleLog_unbounded axiom of the erdos-191 entry, reducing its genuine assumption count from 4 to 3"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "tripleLog_unbounded",
+      "type": "core",
+      "statement": "∀ M : ℝ, ∃ N : ℕ, ∀ n ≥ N, tripleLog n > M",
+      "description": "log(log(log n)) → ∞, the elementary divergence axiomatized in the parent entry, now proved.",
+      "significance": "Eliminates a non-deep axiom from the Erdős #191 formalization"
+    },
+    {
+      "name": "tripleLog_tendsto_atTop",
+      "type": "lemma",
+      "statement": "Tendsto (fun n : ℕ => tripleLog n) atTop atTop",
+      "description": "The filter form of triple-log divergence, from which the ε–N statement follows.",
+      "significance": "log preserves atTop; threefold composition diverges"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

**Axiom elimination** for the `erdos-191` entry. `Erdos191Problem.lean` carries four axioms; three encode the genuinely deep results (Rödl's construction, the Conlon–Fox–Sudakov bound, the main conjecture), but the fourth — `tripleLog_unbounded` — merely states the elementary fact that

$$ \mathrm{tripleLog}(n) = \log(\log(\log n)) \to \infty. $$

This file proves it axiom-free, reducing the formalization's genuine assumption count from **4 to 3**.

## Results (2 theorems, 1 def, 62 lines, 0 sorries, 0 axioms)

- `tripleLog_tendsto_atTop` — `Tendsto (fun n => log(log(log n))) atTop atTop`, from `Real.tendsto_log_atTop` composed three times over `tendsto_natCast_atTop_atTop`.
- **`tripleLog_unbounded`** — `∀ M, ∃ N, ∀ n ≥ N, tripleLog n > M`, exactly the parent's axiom, derived from the `Tendsto` statement.

## Note on packaging

Shipped as a **standalone companion** rather than an in-place edit because `Erdos191Problem.lean` does **not currently compile** under its declared imports — a pre-existing Mathlib-drift breakage unrelated to this work (e.g. `Real.log_two_gt_d9` and `rpow` are used but their imports `Mathlib.Analysis.Complex.ExponentialBounds` / `…Pow.Real` are missing). The proof here is ready to drop in to retire the axiom once those imports are repaired (a mechanic-scope fix). Flagging that breakage for follow-up.

## Verification

Compiled with `lake env lean` against Mathlib; `#print axioms tripleLog_unbounded` reports only `propext, Classical.choice, Quot.sound` — **axiom-free**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)