### PR TITLE
research(frobenius-endomorphism-oq-01-oq-01): Frobenius generates the Galois group of 𝔽_{pⁿ} with order exactly n

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2933,6 +2933,7 @@ import Proofs.FriendshipTheoremOQ04
 import Proofs.FriendshipTheoremOQ04Amalgam
 import Proofs.FriendshipTheoremOQ04Universal
 import Proofs.FrobeniusEndomorphismOQ01
+import Proofs.FrobeniusEndomorphismOQ01OQ01
 import Proofs.FrobeniusEndomorphismOQ01OQ02
 import Proofs.FrobeniusEndomorphismOQ02
 import Proofs.FrobeniusNumber

--- a/proofs/Proofs/FrobeniusEndomorphismOQ01OQ01.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ01OQ01.lean
@@ -1,0 +1,128 @@
+/-
+  The Frobenius automorphism generates the Galois group of a finite field.
+
+  Parent (`frobenius-endomorphism-oq-01`) packaged the absolute Frobenius
+  `x ↦ x ^ p` as a ring homomorphism in prime characteristic, together with the
+  fixed-point characterisations: it is the identity on the prime field `𝔽_p`
+  (Fermat) and `x ^ q = x` on a finite field of order `q`.  Its first listed open
+  question asks to exhibit the Frobenius as a GENERATOR of the cyclic Galois
+  group `Gal(𝔽_{pⁿ} / 𝔽_p)` and to prove that its order is EXACTLY `n`.
+
+  This file answers that question for the canonical model `GaloisField p n = 𝔽_{pⁿ}`.
+  Working over the prime field `K = ZMod p` (so `q = |K| = p`), the Frobenius
+
+      frob : 𝔽_{pⁿ} ≃ₐ[𝔽_p] 𝔽_{pⁿ},   x ↦ x ^ p
+
+  is a field automorphism fixing `𝔽_p`.  We prove:
+
+    * `frob_apply`         : `frob x = x ^ p` (the absolute Frobenius);
+    * `frob_pow_apply`     : `(frobᵏ) x = x ^ (pᵏ)` (the iterated Frobenius);
+    * `orderOf_frob`       : `orderOf frob = n` (order EXACTLY the degree);
+    * `frob_pow_card`      : `frobⁿ = 1`;
+    * `frob_pow_ne_one`    : `frobᵏ ≠ 1` for `0 < k < n` (sharpness of the order);
+    * `frob_generates`     : every `σ ∈ Gal` is a power of `frob`;
+    * `zpowers_frob_eq_top`: `⟨frob⟩ = Gal` (the Frobenius GENERATES);
+    * `card_aut`           : `|Gal(𝔽_{pⁿ}/𝔽_p)| = n`;
+    * `galois_group_cyclic`: the Galois group is cyclic.
+
+  The heavy machinery (`frobeniusAlgEquivOfAlgebraic`, its order equals the
+  finite-field degree, and the cyclicity of the absolute Galois group of a finite
+  field) lives in Mathlib's `FieldTheory/Finite/Basic`.  The contribution here is
+  the explicit SPECIALISATION to `GaloisField p n / ZMod p`, where the degree is
+  literally `n`: this turns "order = finrank" into "order = exactly `n`", pins down
+  `frob` as the named generator `x ↦ x ^ p`, and records the iterated-Frobenius
+  formula `frobᵏ = (x ↦ x ^ pᵏ)` connecting to the parent's finite-field iterates.
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+namespace FrobeniusEndomorphismOQ01OQ01
+
+open FiniteField
+
+variable (p : ℕ) [Fact p.Prime] (n : ℕ) [NeZero n]
+
+/-- The **Frobenius automorphism** `x ↦ x ^ p` of the finite field `𝔽_{pⁿ}`,
+viewed as an element of the Galois group `Gal(𝔽_{pⁿ} / 𝔽_p)`.  It fixes the prime
+field `𝔽_p = ZMod p` pointwise (Fermat) and is the canonical generator. -/
+noncomputable def frob : GaloisField p n ≃ₐ[ZMod p] GaloisField p n :=
+  frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n)
+
+omit [NeZero n] in
+/-- The Frobenius acts as the absolute `p`-power map: `frob x = x ^ p`. -/
+theorem frob_apply (x : GaloisField p n) : frob p n x = x ^ p := by
+  rw [show frob p n x = x ^ Fintype.card (ZMod p) from
+        congrFun (coe_frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n)) x,
+      ZMod.card]
+
+omit [NeZero n] in
+/-- The `k`-th power of the Frobenius is the iterated Frobenius `x ↦ x ^ (pᵏ)`. -/
+theorem frob_pow_apply (k : ℕ) (x : GaloisField p n) :
+    (frob p n ^ k) x = x ^ p ^ k := by
+  rw [show (frob p n ^ k) x = (⇑(frob p n))^[k] x from
+        congrFun (AlgEquiv.coe_pow (frob p n) k) x,
+      show (⇑(frob p n))^[k] x = x ^ Fintype.card (ZMod p) ^ k from
+        congrFun (coe_frobeniusAlgEquivOfAlgebraic_iterate (ZMod p) (GaloisField p n) k) x,
+      ZMod.card]
+
+/-- **Order exactly `n`.** The Frobenius automorphism of `𝔽_{pⁿ}` has order
+exactly `n` — the degree `[𝔽_{pⁿ} : 𝔽_p]`. -/
+theorem orderOf_frob : orderOf (frob p n) = n := by
+  rw [show frob p n = frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n) from rfl,
+      orderOf_frobeniusAlgEquivOfAlgebraic, GaloisField.finrank p (NeZero.ne n)]
+
+/-- `frobⁿ = 1`: the `n`-fold Frobenius is the identity (every `x ∈ 𝔽_{pⁿ}`
+satisfies `x ^ (pⁿ) = x`). -/
+theorem frob_pow_card : frob p n ^ n = 1 := by
+  have h := pow_orderOf_eq_one (frob p n)
+  rwa [orderOf_frob p n] at h
+
+/-- **Sharpness of the order.** No smaller positive power of the Frobenius is the
+identity: `frobᵏ ≠ 1` whenever `0 < k < n`. -/
+theorem frob_pow_ne_one {k : ℕ} (hk : 0 < k) (hkn : k < n) : frob p n ^ k ≠ 1 := by
+  intro h
+  have hdvd : orderOf (frob p n) ∣ k := orderOf_dvd_of_pow_eq_one h
+  rw [orderOf_frob p n] at hdvd
+  exact absurd (Nat.le_of_dvd hk hdvd) (not_le.mpr hkn)
+
+omit [NeZero n] in
+/-- **The Frobenius generates.** Every automorphism `σ ∈ Gal(𝔽_{pⁿ} / 𝔽_p)` is a
+nonnegative power of the Frobenius. -/
+theorem frob_generates (σ : GaloisField p n ≃ₐ[ZMod p] GaloisField p n) :
+    ∃ k : ℕ, frob p n ^ k = σ := by
+  obtain ⟨m, hm⟩ :=
+    (bijective_frobeniusAlgEquivOfAlgebraic_pow (ZMod p) (GaloisField p n)).2 σ
+  exact ⟨m.1, hm⟩
+
+omit [NeZero n] in
+/-- **The Frobenius is a generator of the Galois group**: the cyclic subgroup it
+generates is the whole group, `⟨frob⟩ = Gal(𝔽_{pⁿ} / 𝔽_p)`. -/
+theorem zpowers_frob_eq_top : Subgroup.zpowers (frob p n) = ⊤ := by
+  rw [Subgroup.eq_top_iff']
+  intro σ
+  obtain ⟨k, hk⟩ := frob_generates p n σ
+  rw [Subgroup.mem_zpowers_iff]
+  exact ⟨(k : ℤ), by rw [zpow_natCast]; exact hk⟩
+
+/-- The Galois group `Gal(𝔽_{pⁿ} / 𝔽_p)` has order exactly `n`. -/
+theorem card_aut :
+    Nat.card (GaloisField p n ≃ₐ[ZMod p] GaloisField p n) = n := by
+  rw [IsGalois.card_aut_eq_finrank, GaloisField.finrank p (NeZero.ne n)]
+
+omit [NeZero n] in
+/-- The Galois group of a finite field over its prime field is cyclic — generated
+by the Frobenius (`zpowers_frob_eq_top`). -/
+theorem galois_group_cyclic :
+    IsCyclic (GaloisField p n ≃ₐ[ZMod p] GaloisField p n) :=
+  inferInstance
+
+omit [NeZero n] in
+/-- A fixed point of the Frobenius is exactly a Fermat fixed point `x ^ p = x`;
+these are the elements of the prime field `𝔽_p`. -/
+theorem frob_fixed_iff (x : GaloisField p n) : frob p n x = x ↔ x ^ p = x := by
+  rw [frob_apply]
+
+/-- Concrete instance `𝔽_{2³}`: the Frobenius `x ↦ x²` has order exactly `3`. -/
+theorem orderOf_frob_two_three : orderOf (frob 2 3) = 3 := orderOf_frob 2 3
+
+end FrobeniusEndomorphismOQ01OQ01

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-01-module-header",
+    "proofId": "frobenius-endomorphism-oq-01-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "title": "Module Header: Frobenius Generates the Galois Group",
+    "content": "For the canonical finite field $\\mathbb{F}_{p^n} = \\mathrm{GaloisField}\\,p\\,n$ over its prime field $\\mathbb{F}_p = \\mathbb{Z}/p$, the **Frobenius automorphism** $\\mathrm{frob} : x \\mapsto x^p$ is the canonical generator of the Galois group $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. This file answers the parent's first open question: $\\mathrm{frob}$ has order **exactly** $n$ ($\\mathrm{frob}^n = 1$ but $\\mathrm{frob}^k \\neq 1$ for $0 < k < n$), **generates** the whole group ($\\langle\\mathrm{frob}\\rangle = \\top$, every $\\sigma$ a power of $\\mathrm{frob}$), and the group is cyclic of order $n$. The core machinery is Mathlib's `frobeniusAlgEquivOfAlgebraic`; the contribution is the specialisation to $\\mathbb{F}_{p^n}/\\mathbb{F}_p$ where the degree is literally $n$."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-01-def",
+    "proofId": "frobenius-endomorphism-oq-01-oq-01",
+    "type": "definition",
+    "range": {
+      "startLine": 48,
+      "endLine": 65
+    },
+    "title": "The Frobenius Automorphism and its Powers",
+    "content": "`frob` is `frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n)`, the Frobenius as an element of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. Because $|\\mathbb{Z}/p| = p$, `frob_apply` gives $\\mathrm{frob}\\,x = x^p$ (the absolute Frobenius of the parent entry), and `frob_pow_apply` gives the iterated Frobenius $\\mathrm{frob}^k x = x^{p^k}$ — the $q$-power iterates of the parent, now realised as powers of a single group element."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-01-order",
+    "proofId": "frobenius-endomorphism-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 70,
+      "endLine": 88
+    },
+    "title": "Order Exactly n, with Sharpness",
+    "content": "`orderOf_frob`: $\\mathrm{ord}(\\mathrm{frob}) = n$, the heart of the open question. Mathlib's `orderOf_frobeniusAlgEquivOfAlgebraic` gives $\\mathrm{ord} = \\mathrm{finrank}$, and `GaloisField.finrank` $= n$ supplies the exact value. The bound `frob_pow_card` ($\\mathrm{frob}^n = 1$) is `pow_orderOf_eq_one`; sharpness `frob_pow_ne_one` ($\\mathrm{frob}^k \\neq 1$ for $0 < k < n$) follows since $\\mathrm{frob}^k = 1 \\Rightarrow n \\mid k$, impossible for $0 < k < n$. Mathematically this says $\\mathbb{F}_{p^n} \\not\\subseteq \\mathbb{F}_{p^k}$ for $k < n$."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-01-generates",
+    "proofId": "frobenius-endomorphism-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 90,
+      "endLine": 113
+    },
+    "title": "The Frobenius Generates the Galois Group",
+    "content": "`frob_generates`: every automorphism $\\sigma \\in \\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ is a power of $\\mathrm{frob}$ — the surjectivity of $k \\mapsto \\mathrm{frob}^k$ from Mathlib's `bijective_frobeniusAlgEquivOfAlgebraic_pow`. `zpowers_frob_eq_top`: the cyclic subgroup $\\langle\\mathrm{frob}\\rangle$ is the whole group. Together with order $n$, this exhibits $\\mathrm{frob}$ as a genuine generator."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-01-cyclic",
+    "proofId": "frobenius-endomorphism-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 114,
+      "endLine": 127
+    },
+    "title": "Cardinality, Cyclicity, and a Concrete Instance",
+    "content": "`card_aut`: $|\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)| = n$ via `IsGalois.card_aut_eq_finrank` and `GaloisField.finrank`. `galois_group_cyclic`: the group is cyclic (Mathlib's `IsCyclic Gal(L/K)` instance for finite fields). `frob_fixed_iff` records that a Frobenius fixed point is a Fermat fixed point $x^p = x$, and `orderOf_frob_two_three` is the concrete instance: the Frobenius $x \\mapsto x^2$ of $\\mathbb{F}_8 = \\mathbb{F}_{2^3}$ has order exactly $3$."
+  }
+]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "frobenius-endomorphism-oq-01-oq-01",
+  "title": "The Frobenius Generates the Galois Group of a Finite Field",
+  "slug": "frobenius-endomorphism-oq-01-oq-01",
+  "description": "Answers the first open question of frobenius-endomorphism-oq-01: exhibit the Frobenius x ↦ x^p as a generator of the cyclic Galois group Gal(𝔽_{pⁿ}/𝔽_p) with order EXACTLY n. For the canonical model GaloisField p n over its prime field ZMod p, the Frobenius automorphism frob satisfies frob x = x^p (and frobᵏ x = x^(pᵏ)), has orderOf frob = n with frobⁿ = 1 and frobᵏ ≠ 1 for 0 < k < n (sharpness), generates the whole group (zpowers frob = ⊤, every automorphism is a power of frob), and the group has order n and is cyclic. 11 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_endomorphism",
+    "date": "Ferdinand Georg Frobenius (late 19th century)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "finite-fields",
+      "galois-theory",
+      "characteristic-p",
+      "cyclic-group",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 11 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, confirmed via #print axioms, which do not count). No native_decide, so no Lean.ofReduceBool. Hypotheses are the natural ones: p prime (Fact p.Prime) and n ≠ 0 (NeZero n) so that 𝔽_{pⁿ} is a proper field of degree n.",
+    "originalContributions": [
+      "Specialisation and packaging — the core machinery (frobeniusAlgEquivOfAlgebraic, orderOf_frobeniusAlgEquivOfAlgebraic = finrank, bijective_frobeniusAlgEquivOfAlgebraic_pow, and the IsCyclic Gal(L/K) instance for finite fields) lives in Mathlib's FieldTheory/Finite/Basic. The contribution is the explicit specialisation to GaloisField p n / ZMod p, where the extension degree is literally n, turning 'order = finrank' into 'order = exactly n', pinning down frob as the named generator x ↦ x^p, and assembling the generation / order-sharpness / cardinality statements that directly answer the parent's open question.",
+      "frob (def): the Frobenius automorphism of 𝔽_{pⁿ} over its prime field 𝔽_p, as an element of Gal(𝔽_{pⁿ}/𝔽_p)",
+      "frob_apply / frob_pow_apply: frob x = x^p and frobᵏ x = x^(pᵏ) — the absolute Frobenius and its iterates (connecting to the parent's finite_field_iterate)",
+      "orderOf_frob: orderOf frob = n — the order is EXACTLY the degree n (via orderOf = finrank and GaloisField.finrank = n)",
+      "frob_pow_card / frob_pow_ne_one: frobⁿ = 1 and frobᵏ ≠ 1 for 0 < k < n — the order is exactly n, with sharpness made explicit",
+      "frob_generates / zpowers_frob_eq_top: every σ ∈ Gal is a power of frob, and ⟨frob⟩ = ⊤ — the Frobenius GENERATES the Galois group",
+      "card_aut / galois_group_cyclic: |Gal(𝔽_{pⁿ}/𝔽_p)| = n and the group is cyclic",
+      "orderOf_frob_two_three: concrete instance — the Frobenius x ↦ x² of 𝔽_8 = 𝔽_{2³} has order exactly 3"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "frobeniusAlgEquivOfAlgebraic",
+        "description": "For L/K an algebraic extension of a finite field K, the Frobenius K-algebra endomorphism x ↦ x^(|K|) of L is an automorphism. frob is this for K = ZMod p, L = GaloisField p n.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "orderOf_frobeniusAlgEquivOfAlgebraic",
+        "description": "orderOf (frobeniusAlgEquivOfAlgebraic K L) = Module.finrank K L. Combined with GaloisField.finrank gives orderOf frob = n.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "bijective_frobeniusAlgEquivOfAlgebraic_pow",
+        "description": "n ↦ (frobeniusAlgEquivOfAlgebraic K L)^n on Fin (finrank K L) is bijective onto the Galois group; gives frob_generates / zpowers_frob_eq_top.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "GaloisField.finrank",
+        "description": "Module.finrank (ZMod p) (GaloisField p n) = n for n ≠ 0. Supplies the EXACT order n.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "IsGalois.card_aut_eq_finrank",
+        "description": "Nat.card Gal(E/F) = finrank F E for a finite Galois extension; gives card_aut = n.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "coe_frobeniusAlgEquivOfAlgebraic / coe_frobeniusAlgEquivOfAlgebraic_iterate",
+        "description": "The coercions ⇑frob = (· ^ |K|) and its k-th iterate = (· ^ |K|^k); with ZMod.card give frob_apply / frob_pow_apply.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 128,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Galois theory of finite fields is the cleanest in all of algebra: for every prime p and every n ≥ 1 there is a unique field 𝔽_{pⁿ} of order pⁿ, it is a Galois extension of its prime field 𝔽_p, and its Galois group is cyclic of order n, generated by the Frobenius automorphism x ↦ x^p. This single fact — proven here for the canonical model GaloisField p n — is the foundation of cyclotomy, the structure of finite field extensions, and the local theory of arithmetic geometry, where the Frobenius is the canonical generator of the absolute Galois group of every finite field.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01, from frobenius-endomorphism-oq-01)**: Exhibit the Frobenius x ↦ x^p as a generator of the cyclic Galois group Gal(𝔽_{pⁿ}/𝔽_p), and prove that its order is exactly n.\n\n**Formalized**: frob (the automorphism), frob_apply / frob_pow_apply (x ↦ x^p and its iterates x ↦ x^(pᵏ)), orderOf_frob (order exactly n), frob_pow_card / frob_pow_ne_one (frobⁿ = 1, sharpness), frob_generates / zpowers_frob_eq_top (it generates), card_aut / galois_group_cyclic (group of order n, cyclic).",
+    "text": "A 128-line formalization specialising Mathlib's finite-field Frobenius machinery to the canonical Galois field 𝔽_{pⁿ} = GaloisField p n over its prime field 𝔽_p = ZMod p. The Frobenius automorphism frob (an element of Gal(𝔽_{pⁿ}/𝔽_p)) acts as x ↦ x^p, with its k-th power the iterated Frobenius x ↦ x^(pᵏ). The central result is orderOf_frob: the order of frob is exactly n, the extension degree [𝔽_{pⁿ}:𝔽_p] — obtained by combining Mathlib's orderOf = finrank with GaloisField.finrank = n. Sharpness is recorded explicitly: frobⁿ = 1 but frobᵏ ≠ 1 for 0 < k < n. The Frobenius generates: every automorphism is a power of frob (frob_generates) and ⟨frob⟩ is the whole group (zpowers_frob_eq_top), which has order n (card_aut) and is cyclic. All 11 theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**The automorphism**: frob := frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n). Since |ZMod p| = p (ZMod.card), the coercion lemma gives frob x = x^p, and the iterate lemma gives frobᵏ x = x^(pᵏ).\n\n**Order exactly n**: orderOf frob = finrank (ZMod p) (GaloisField p n) (Mathlib's orderOf_frobeniusAlgEquivOfAlgebraic) = n (GaloisField.finrank, n ≠ 0). Then frobⁿ = 1 is pow_orderOf_eq_one rewritten by orderOf = n, and frobᵏ ≠ 1 for 0 < k < n follows because frobᵏ = 1 ⟹ orderOf frob = n ∣ k, contradicting k < n.\n\n**Generation**: Mathlib's bijective_frobeniusAlgEquivOfAlgebraic_pow says n ↦ frobⁿ is surjective onto the Galois group, so every σ is a power of frob (frob_generates); membership in zpowers then gives ⟨frob⟩ = ⊤.\n\n**Cardinality**: Nat.card Gal = finrank = n via IsGalois.card_aut_eq_finrank (the IsGalois instance for finite extensions is automatic), and the group is cyclic by Mathlib's IsCyclic Gal(L/K) instance for finite fields.",
+    "keyInsights": [
+      "**Order exactly the degree**: the heart of the open question is the word 'exactly'. Mathlib gives orderOf frob = finrank K L for a general finite extension; specialising to GaloisField p n / ZMod p, where GaloisField.finrank = n, converts this to the concrete orderOf frob = n.",
+      "**Sharpness via divisibility**: that no smaller positive power is the identity (frobᵏ ≠ 1, 0 < k < n) is exactly orderOf frob = n unwound: frobᵏ = 1 forces n ∣ k, impossible for 0 < k < n. Mathematically, frobᵏ = id means x^(pᵏ) = x for all x ∈ 𝔽_{pⁿ}, i.e. 𝔽_{pⁿ} ⊆ 𝔽_{pᵏ}, impossible when k < n.",
+      "**An element of full order generates a finite cyclic group**: orderOf frob = n equals |Gal| = n, so ⟨frob⟩ = ⊤. The generation is also delivered directly by Mathlib's bijective_frobeniusAlgEquivOfAlgebraic_pow, the surjectivity of k ↦ frobᵏ.",
+      "**The absolute Frobenius**: over the prime field |K| = p, so the relative Frobenius x ↦ x^(|K|) is the absolute Frobenius x ↦ x^p — the same map studied in the parent, now seen as the canonical generator of the Galois group.",
+      "**0-axiom**: the whole development rests only on propext / Classical.choice / Quot.sound (confirmed by #print axioms); no decision procedure or native_decide is invoked, even for the concrete 𝔽_8 instance."
+    ],
+    "prerequisites": [
+      "Finite fields and the canonical model GaloisField p n = 𝔽_{pⁿ} (splitting field of X^(pⁿ) − X over ZMod p)",
+      "The Frobenius automorphism frobeniusAlgEquivOfAlgebraic of an algebraic extension of a finite field, and its order = degree (Mathlib)",
+      "Galois theory of finite extensions: IsGalois.card_aut_eq_finrank and the cyclicity of Gal of a finite field",
+      "orderOf in a finite group, pow_orderOf_eq_one, orderOf_dvd_of_pow_eq_one, and Subgroup.zpowers",
+      "GaloisField.finrank (ZMod p) (GaloisField p n) = n for n ≠ 0, and ZMod.card (|ZMod p| = p)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-01",
+      "relationship": "answers-open-question",
+      "description": "Answers the first open question of the parent ('Exhibit the iterated Frobenius x ↦ x^(p^k) as a generator of Gal(𝔽_{p^n}/𝔽_p), with order exactly n'). The parent gave the Frobenius ring-hom and its fixed-point characterisations (Fermat, x^q = x); this entry upgrades the q-power map to the named Galois-group generator with order exactly n."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ01OQ01",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/FrobeniusEndomorphismOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "orderOf_frob",
+      "type": "core",
+      "statement": "$\\mathrm{ord}(\\mathrm{frob}) = n$ in $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$",
+      "significance": "The Frobenius automorphism of 𝔽_{pⁿ} has order exactly n, the extension degree — the precise statement asked by the parent's open question. Obtained from Mathlib's orderOf = finrank specialised by GaloisField.finrank = n.",
+      "description": "orderOf frob = n."
+    },
+    {
+      "name": "zpowers_frob_eq_top",
+      "type": "core",
+      "statement": "$\\langle \\mathrm{frob} \\rangle = \\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$",
+      "significance": "The Frobenius GENERATES the Galois group: the cyclic subgroup it generates is the whole group. Together with order n this exhibits Gal as cyclic of order n with named generator.",
+      "description": "The subgroup generated by frob is everything."
+    },
+    {
+      "name": "frob_generates",
+      "type": "core",
+      "statement": "$\\forall \\sigma,\\ \\exists k,\\ \\mathrm{frob}^k = \\sigma$",
+      "significance": "Every automorphism in Gal(𝔽_{pⁿ}/𝔽_p) is a power of the Frobenius — the surjectivity form of generation, from Mathlib's bijective power map.",
+      "description": "Every Galois automorphism is a power of frob."
+    },
+    {
+      "name": "frob_pow_ne_one",
+      "type": "core",
+      "statement": "$0 < k < n \\Rightarrow \\mathrm{frob}^k \\neq 1$",
+      "significance": "Sharpness of the order: no smaller positive power of the Frobenius is the identity. Equivalent to 𝔽_{pⁿ} not being contained in any proper subfield 𝔽_{pᵏ}, k < n.",
+      "description": "No positive power below n is the identity."
+    },
+    {
+      "name": "frob_apply",
+      "type": "supporting",
+      "statement": "$\\mathrm{frob}\\,x = x^p$",
+      "significance": "The Galois-group generator is the absolute Frobenius x ↦ x^p of the parent entry, now over the prime field where |𝔽_p| = p.",
+      "description": "frob acts as the p-power map."
+    },
+    {
+      "name": "frob_pow_apply",
+      "type": "supporting",
+      "statement": "$\\mathrm{frob}^k x = x^{p^k}$",
+      "significance": "The k-th power of the Frobenius is the iterated Frobenius x ↦ x^(pᵏ), connecting to the parent's finite_field_iterate.",
+      "description": "frobᵏ acts as the pᵏ-power map."
+    },
+    {
+      "name": "frob_pow_card",
+      "type": "supporting",
+      "statement": "$\\mathrm{frob}^n = 1$",
+      "significance": "The n-fold Frobenius is the identity — every x ∈ 𝔽_{pⁿ} satisfies x^(pⁿ) = x. The upper bound on the order.",
+      "description": "frobⁿ = 1."
+    },
+    {
+      "name": "card_aut",
+      "type": "supporting",
+      "statement": "$|\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)| = n$",
+      "significance": "The Galois group has order exactly n, matching the order of the Frobenius — confirming ⟨frob⟩ exhausts the group.",
+      "description": "The Galois group has order n."
+    },
+    {
+      "name": "galois_group_cyclic",
+      "type": "supporting",
+      "statement": "$\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ is cyclic",
+      "significance": "The Galois group of a finite field over its prime field is cyclic — generated by the Frobenius (zpowers_frob_eq_top).",
+      "description": "The Galois group is cyclic."
+    },
+    {
+      "name": "orderOf_frob_two_three",
+      "type": "supporting",
+      "statement": "$\\mathrm{ord}(\\mathrm{frob}) = 3$ in $\\mathrm{Gal}(\\mathbb{F}_8/\\mathbb{F}_2)$",
+      "significance": "Concrete instance: the Frobenius x ↦ x² of 𝔽_8 = 𝔽_{2³} has order exactly 3.",
+      "description": "Frobenius of 𝔽_8 has order 3."
+    }
+  ],
+  "references": [
+    {
+      "text": "Frobenius endomorphism — the p-power map generating the cyclic Galois group of every finite field over its prime subfield.",
+      "url": "https://en.wikipedia.org/wiki/Frobenius_endomorphism"
+    },
+    {
+      "text": "Finite field — Gal(𝔽_{pⁿ}/𝔽_p) is cyclic of order n, generated by the Frobenius automorphism x ↦ x^p.",
+      "url": "https://en.wikipedia.org/wiki/Finite_field"
+    },
+    {
+      "text": "Mathlib4: frobeniusAlgEquivOfAlgebraic, orderOf_frobeniusAlgEquivOfAlgebraic, bijective_frobeniusAlgEquivOfAlgebraic_pow (FieldTheory/Finite/Basic.lean); GaloisField.finrank (FieldTheory/Finite/GaloisField.lean); IsGalois.card_aut_eq_finrank (FieldTheory/Galois/Basic.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Specialises Mathlib's finite-field Frobenius machinery to the canonical Galois field 𝔽_{pⁿ} = GaloisField p n over its prime field 𝔽_p = ZMod p, answering the parent's first open question. The Frobenius automorphism frob acts as x ↦ x^p (frobᵏ as x ↦ x^(pᵏ)), has order EXACTLY n (orderOf_frob), with frobⁿ = 1 and frobᵏ ≠ 1 for 0 < k < n (sharpness), generates the whole Galois group (zpowers_frob_eq_top, frob_generates), which has order n (card_aut) and is cyclic (galois_group_cyclic). All 11 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "This packages the cleanest piece of Galois theory — Gal(𝔽_{pⁿ}/𝔽_p) is cyclic of order n with canonical generator the Frobenius — into the gallery in fully explicit form. It is the structural backbone of finite-field extension theory (subfields ↔ divisors of n via subgroups of a cyclic group) and the local model for the Frobenius elements that organise the absolute Galois groups of number fields and the Weil conjectures.",
+    "openQuestions": [
+      "Establish the subfield correspondence: subfields of 𝔽_{pⁿ} ↔ divisors d ∣ n via fixed fields of frob^d, making the cyclic Galois correspondence fully explicit",
+      "Characterise the fixed field of frob as the prime field 𝔽_p (parent OQ-01-OQ-02) and count its elements (the p roots of X^p − X)"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `frobenius-endomorphism-oq-01`:

> *Exhibit the iterated Frobenius x ↦ x^(p^k) as a generator of Gal(𝔽_{pⁿ}/𝔽_p), with order exactly n.*

For the canonical model `GaloisField p n` = 𝔽_{pⁿ} over its prime field `ZMod p` = 𝔽_p, the Frobenius automorphism `frob` (an element of `Gal(𝔽_{pⁿ}/𝔽_p)`):

- **acts as the absolute Frobenius** `frob x = x^p`, with `frobᵏ x = x^(pᵏ)` (the parent's iterated q-power map);
- has **order exactly n**: `orderOf_frob : orderOf frob = n`, with `frobⁿ = 1` and the sharpness `frobᵏ ≠ 1` for `0 < k < n`;
- **generates** the Galois group: `frob_generates` (every σ is a power of frob) and `zpowers_frob_eq_top` (⟨frob⟩ = ⊤);
- the group has **order n** (`card_aut`) and is **cyclic** (`galois_group_cyclic`);
- concrete instance: the Frobenius x ↦ x² of 𝔽₈ = 𝔽_{2³} has order exactly 3.

## Approach (honest framing)

The heavy machinery lives in Mathlib's `FieldTheory/Finite/Basic` (`frobeniusAlgEquivOfAlgebraic`, `orderOf_frobeniusAlgEquivOfAlgebraic = finrank`, `bijective_frobeniusAlgEquivOfAlgebraic_pow`, the `IsCyclic Gal(L/K)` instance). The contribution is the explicit **specialisation** to `GaloisField p n / ZMod p`, where `GaloisField.finrank = n` turns "order = finrank" into "order = **exactly n**", pins down `frob` as the named generator x ↦ x^p, and assembles the generation / sharpness / cardinality statements that directly answer the open question. Badge: `mathlib`.

## Verification

- 11 theorems, 1 definition, 128 lines, 0 sorries, **0 axioms**
- `#print axioms` confirms only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`); no `native_decide`
- Compiles against Mathlib 4.26.0; annotations validator clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)