### PR TITLE
research(second-isomorphism-theorem-modules-oq-01-oq-01): iterated three-submodule modular dimension law + ℝ² counterexample [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3673,6 +3673,7 @@ import Proofs.SchursLemma
 import Proofs.SchursTheorem
 import Proofs.SearchMathlib
 import Proofs.SecondIsomorphismTheoremModulesOQ01
+import Proofs.SecondIsomorphismTheoremModulesOQ01OQ01
 import Proofs.ShannonChannelCoding
 import Proofs.ShannonChannelCodingAWGN
 import Proofs.ShannonChannelCodingBEC

--- a/proofs/Proofs/SecondIsomorphismTheoremModulesOQ01OQ01.lean
+++ b/proofs/Proofs/SecondIsomorphismTheoremModulesOQ01OQ01.lean
@@ -1,0 +1,237 @@
+import Mathlib.Tactic
+import Mathlib.LinearAlgebra.Isomorphisms
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+
+/-
+# Three submodules: the iterated modular dimension law and the failure of
+  naive inclusion–exclusion — OQ01·OQ01
+
+## Question
+
+The parent entry (`second-isomorphism-theorem-modules-oq-01`) derives the **two-submodule
+modular dimension law**
+
+  `finrank (p ⊔ q) + finrank (p ⊓ q) = finrank p + finrank q`
+
+*structurally*, as a corollary of the second (diamond) isomorphism theorem
+`LinearMap.quotientInfEquivSupQuotient`. Its first open question asks whether the analogous
+count for **three** submodules `p, q, r` can be obtained in the same structural way, given the
+warning that the symmetric set-theoretic inclusion–exclusion formula
+
+  `finrank (p ⊔ q ⊔ r) =? finrank p + finrank q + finrank r`
+  `                      - finrank (p ⊓ q) - finrank (p ⊓ r) - finrank (q ⊓ r)`
+  `                      + finrank (p ⊓ q ⊓ r)`
+
+**fails**, because the lattice of submodules is *modular* but not *distributive*.
+
+## Answer
+
+* The correct three-submodule identity is **asymmetric** and is obtained by iterating the
+  two-submodule modular law twice (once on `p, q`, once on `p ⊔ q, r`). In the
+  subtraction-free `ℕ` form it reads
+
+    `finrank (p ⊔ q ⊔ r) + finrank (p ⊓ q) + finrank ((p ⊔ q) ⊓ r)`
+    `      = finrank p + finrank q + finrank r`.                       (`finrank_sup_three`)
+
+  The whole chain rests on the second isomorphism theorem: we re-derive the two-term law
+  (`finrank_modular_law`) from `secondIso` and then apply it twice. The "correction" term
+  `finrank ((p ⊔ q) ⊓ r)` *replaces* the symmetric combination
+  `finrank (p ⊓ r) + finrank (q ⊓ r) - finrank (p ⊓ q ⊓ r)` of the naive formula.
+
+* The naive symmetric formula is genuinely **false**: three distinct lines in `ℝ²`
+  (`counterexample_naive_inclusion_exclusion`) give
+
+    `finrank (p ⊔ q ⊔ r) + finrank (p ⊓ q) + finrank (p ⊓ r) + finrank (q ⊓ r)`
+    `   = 2 ≠ 3 = finrank p + finrank q + finrank r + finrank (p ⊓ q ⊓ r)`,
+
+  the gap `3 - 2 = 1` being exactly the failure of distributivity, i.e. of
+  `(p ⊔ q) ⊓ r = (p ⊓ r) ⊔ (q ⊓ r)`.
+
+## What this establishes
+
+* `secondIso` — the second isomorphism theorem as a named `LinearEquiv` (any ring/module).
+* `finrank_modular_law` — the two-submodule modular law, re-derived from `secondIso`.
+* `finrank_sup_three` — the exact iterated three-submodule identity (`ℕ`, subtraction-free).
+* `finrank_sup_three_sub` — the same identity in `ℤ` subtraction form.
+* `finrank_sup_three_of_pairwise_bot` — the clean special case when `p ⊓ q = ⊥` and
+  `(p ⊔ q) ⊓ r = ⊥`: dimensions simply add.
+* `counterexample_naive_inclusion_exclusion` — an explicit `ℝ²` witness showing the symmetric
+  inclusion–exclusion formula fails.
+-/
+
+open Submodule FiniteDimensional Module
+
+namespace SecondIsomorphismTheoremModulesOQ01OQ01
+
+section AnyRing
+
+variable {R : Type*} [Ring R] {M : Type*} [AddCommGroup M] [Module R M]
+
+/-- **Second (diamond) isomorphism theorem** as a named linear equivalence:
+`p ⧸ (p ⊓ p') ≃ₗ (p ⊔ p') ⧸ p'`, read inside the appropriate ambient submodules. -/
+noncomputable def secondIso (p p' : Submodule R M) :
+    (↥p ⧸ Submodule.comap p.subtype (p ⊓ p')) ≃ₗ[R]
+      (↥(p ⊔ p') ⧸ Submodule.comap (p ⊔ p').subtype p') :=
+  LinearMap.quotientInfEquivSupQuotient p p'
+
+end AnyRing
+
+section FiniteDimensional
+
+variable {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V]
+variable [FiniteDimensional K V]
+
+/-- **Two-submodule modular dimension law**, re-derived *from the second isomorphism theorem*
+(`secondIso`), so that the three-submodule identity below rests entirely on the structural
+diamond equivalence. This reproduces the parent entry's result self-containedly. -/
+theorem finrank_modular_law (p q : Submodule K V) :
+    Module.finrank K ↥(p ⊔ q) + Module.finrank K ↥(p ⊓ q)
+      = Module.finrank K ↥p + Module.finrank K ↥q := by
+  -- The two diamond quotients have equal dimension because `secondIso` is an equivalence.
+  have hiso :
+      Module.finrank K (↥p ⧸ Submodule.comap p.subtype (p ⊓ q))
+        = Module.finrank K (↥(p ⊔ q) ⧸ Submodule.comap (p ⊔ q).subtype q) :=
+    (secondIso p q).finrank_eq
+  -- Rank–nullity on the left quotient (ambient `↥p`); comap preserves dimension.
+  have hL :
+      Module.finrank K (↥p ⧸ Submodule.comap p.subtype (p ⊓ q))
+        + Module.finrank K ↥(p ⊓ q) = Module.finrank K ↥p := by
+    have h := Submodule.finrank_quotient_add_finrank (Submodule.comap p.subtype (p ⊓ q))
+    rwa [(Submodule.comapSubtypeEquivOfLe (inf_le_left)).finrank_eq] at h
+  -- Rank–nullity on the right quotient (ambient `↥(p ⊔ q)`).
+  have hR :
+      Module.finrank K (↥(p ⊔ q) ⧸ Submodule.comap (p ⊔ q).subtype q)
+        + Module.finrank K ↥q = Module.finrank K ↥(p ⊔ q) := by
+    have h := Submodule.finrank_quotient_add_finrank (Submodule.comap (p ⊔ q).subtype q)
+    rwa [(Submodule.comapSubtypeEquivOfLe (le_sup_right)).finrank_eq] at h
+  omega
+
+/-- **Iterated three-submodule dimension identity** (subtraction-free `ℕ` form):
+
+`finrank (p ⊔ q ⊔ r) + finrank (p ⊓ q) + finrank ((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r`.
+
+Obtained by applying the modular law to `p, q` and then to `p ⊔ q, r`. Note `p ⊔ q ⊔ r`
+parses as `(p ⊔ q) ⊔ r`, so the second application closes the goal directly. -/
+theorem finrank_sup_three (p q r : Submodule K V) :
+    Module.finrank K ↥(p ⊔ q ⊔ r) + Module.finrank K ↥(p ⊓ q)
+        + Module.finrank K ↥((p ⊔ q) ⊓ r)
+      = Module.finrank K ↥p + Module.finrank K ↥q + Module.finrank K ↥r := by
+  have h1 := finrank_modular_law p q
+  have h2 := finrank_modular_law (p ⊔ q) r
+  omega
+
+/-- The same identity in `ℤ`, written with genuine subtraction to match the textbook form
+`finrank (p ⊔ q ⊔ r) = finrank p + finrank q + finrank r - finrank (p ⊓ q) - finrank ((p ⊔ q) ⊓ r)`. -/
+theorem finrank_sup_three_sub (p q r : Submodule K V) :
+    (Module.finrank K ↥(p ⊔ q ⊔ r) : ℤ)
+      = Module.finrank K ↥p + Module.finrank K ↥q + Module.finrank K ↥r
+        - Module.finrank K ↥(p ⊓ q) - Module.finrank K ↥((p ⊔ q) ⊓ r) := by
+  have h := finrank_sup_three p q r
+  omega
+
+/-- **Direct-sum special case**: if `p ⊓ q = ⊥` and `(p ⊔ q) ⊓ r = ⊥`, the three dimensions
+simply add. This is the genuinely "additive" situation; the general law differs from it by the
+two correction terms. -/
+theorem finrank_sup_three_of_pairwise_bot (p q r : Submodule K V)
+    (hpq : p ⊓ q = ⊥) (hr : (p ⊔ q) ⊓ r = ⊥) :
+    Module.finrank K ↥(p ⊔ q ⊔ r)
+      = Module.finrank K ↥p + Module.finrank K ↥q + Module.finrank K ↥r := by
+  have h := finrank_sup_three p q r
+  rw [hpq, hr, finrank_bot] at h
+  omega
+
+end FiniteDimensional
+
+/-! ## Counterexample: the symmetric inclusion–exclusion formula fails
+
+We exhibit three distinct lines in `ℝ²`:
+`p = span {(1,0)}`, `q = span {(0,1)}`, `r = span {(1,1)}`.
+Each is `1`-dimensional, every pairwise (hence triple) intersection is `⊥`, yet
+`p ⊔ q ⊔ r = ⊤` is `2`-dimensional. The naive symmetric count predicts `3`, not `2`. -/
+
+section Counterexample
+
+/-- The three lines as submodules of `ℝ²`. -/
+private def p₀ : Submodule ℝ (ℝ × ℝ) := Submodule.span ℝ {((1 : ℝ), (0 : ℝ))}
+private def q₀ : Submodule ℝ (ℝ × ℝ) := Submodule.span ℝ {((0 : ℝ), (1 : ℝ))}
+private def r₀ : Submodule ℝ (ℝ × ℝ) := Submodule.span ℝ {((1 : ℝ), (1 : ℝ))}
+
+private theorem finrank_p₀ : Module.finrank ℝ ↥p₀ = 1 :=
+  finrank_span_singleton (by simp [Prod.ext_iff])
+
+private theorem finrank_q₀ : Module.finrank ℝ ↥q₀ = 1 :=
+  finrank_span_singleton (by simp [Prod.ext_iff])
+
+private theorem finrank_r₀ : Module.finrank ℝ ↥r₀ = 1 :=
+  finrank_span_singleton (by simp [Prod.ext_iff])
+
+/-- A vector lying in two distinct lines through the origin is `0`: helper that turns a
+membership pair into the two scalar witnesses and a coordinate identity. -/
+private theorem inf_span_eq_bot {u v : ℝ × ℝ}
+    (hindep : ∀ a b : ℝ, a • u = b • v → a • u = 0) :
+    Submodule.span ℝ {u} ⊓ Submodule.span ℝ {v} = ⊥ := by
+  rw [eq_bot_iff]
+  intro x hx
+  obtain ⟨hxu, hxv⟩ := hx
+  obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp hxu
+  obtain ⟨b, hb⟩ := Submodule.mem_span_singleton.mp hxv
+  have : a • u = b • v := by rw [ha, hb]
+  rw [Submodule.mem_bot, ← ha]
+  exact hindep a b this
+
+private theorem inf_pq : p₀ ⊓ q₀ = ⊥ :=
+  inf_span_eq_bot fun a b h => by
+    rw [Prod.ext_iff] at h
+    simp only [Prod.smul_mk, smul_eq_mul, mul_one, mul_zero] at h ⊢
+    rw [Prod.ext_iff]; constructor <;> simp_all
+
+private theorem inf_pr : p₀ ⊓ r₀ = ⊥ :=
+  inf_span_eq_bot fun a b h => by
+    rw [Prod.ext_iff] at h
+    simp only [Prod.smul_mk, smul_eq_mul, mul_one, mul_zero] at h ⊢
+    obtain ⟨h1, h2⟩ := h
+    rw [Prod.ext_iff]; constructor <;> simp_all
+
+private theorem inf_qr : q₀ ⊓ r₀ = ⊥ :=
+  inf_span_eq_bot fun a b h => by
+    rw [Prod.ext_iff] at h
+    simp only [Prod.smul_mk, smul_eq_mul, mul_one, mul_zero] at h ⊢
+    obtain ⟨h1, h2⟩ := h
+    rw [Prod.ext_iff]; constructor <;> simp_all
+
+/-- The first two lines already span the whole plane. -/
+private theorem sup_pq_top : p₀ ⊔ q₀ = ⊤ := by
+  rw [eq_top_iff]
+  rintro ⟨a, b⟩ -
+  have hrw : ((a, b) : ℝ × ℝ) = a • ((1 : ℝ), (0 : ℝ)) + b • ((0 : ℝ), (1 : ℝ)) := by
+    simp
+  rw [hrw]
+  refine add_mem (Submodule.mem_sup_left ?_) (Submodule.mem_sup_right ?_)
+  · exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+  · exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+
+private theorem sup_pqr_top : p₀ ⊔ q₀ ⊔ r₀ = ⊤ := by
+  rw [sup_pq_top]; simp
+
+/-- **The naive symmetric inclusion–exclusion formula fails.** With the three lines above,
+
+`finrank (p ⊔ q ⊔ r) + finrank (p ⊓ q) + finrank (p ⊓ r) + finrank (q ⊓ r)`
+`  = 2`,  while
+`finrank p + finrank q + finrank r + finrank (p ⊓ q ⊓ r) = 3`,
+
+so the two sides differ: there is **no** symmetric inclusion–exclusion law for subspace
+dimensions. (Both sides are written subtraction-free over `ℕ`.) -/
+theorem counterexample_naive_inclusion_exclusion :
+    Module.finrank ℝ ↥(p₀ ⊔ q₀ ⊔ r₀) + Module.finrank ℝ ↥(p₀ ⊓ q₀)
+        + Module.finrank ℝ ↥(p₀ ⊓ r₀) + Module.finrank ℝ ↥(q₀ ⊓ r₀)
+      ≠ Module.finrank ℝ ↥p₀ + Module.finrank ℝ ↥q₀ + Module.finrank ℝ ↥r₀
+        + Module.finrank ℝ ↥(p₀ ⊓ q₀ ⊓ r₀) := by
+  have htriple : p₀ ⊓ q₀ ⊓ r₀ = ⊥ := by rw [inf_pq]; simp
+  rw [sup_pqr_top, htriple, inf_pq, inf_pr, inf_qr]
+  -- finrank ℝ (ℝ × ℝ) = 2; left side = 2, right side = 3
+  simp [finrank_p₀, finrank_q₀, finrank_r₀, finrank_top, finrank_bot,
+    Module.finrank_prod, Module.finrank_self]
+
+end Counterexample
+
+end SecondIsomorphismTheoremModulesOQ01OQ01

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "second-isomorphism-theorem-modules-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "concept",
+    "title": "Why Inclusion–Exclusion Fails for Dimensions",
+    "content": "The two-submodule modular law finrank(p ⊔ q) + finrank(p ⊓ q) = finrank p + finrank q looks exactly like |A ∪ B| + |A ∩ B| = |A| + |B|, tempting the reader to extend the full three-set inclusion–exclusion formula to dimensions. That extension is false: the lattice of submodules is modular (Dedekind) but not distributive, and the symmetric three-term formula silently assumes distributivity. The correct count is asymmetric — built by iterating the two-term law along a chain — and this entry answers the parent's first open question by deriving it structurally from the second isomorphism theorem, then refuting the naive formula with an explicit ℝ² witness.",
+    "mathContext": "$\\operatorname{finrank}(p \\sqcup q \\sqcup r) + \\operatorname{finrank}(p \\sqcap q) + \\operatorname{finrank}((p \\sqcup q) \\sqcap r) = \\operatorname{finrank} p + \\operatorname{finrank} q + \\operatorname{finrank} r$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular lattice",
+      "distributive lattice",
+      "inclusion–exclusion",
+      "dimension formula"
+    ],
+    "prerequisites": [
+      "submodule lattice (⊓, ⊔, ⊥, ⊤)",
+      "the two-submodule modular dimension law"
+    ]
+  },
+  {
+    "id": "ann-second-iso",
+    "proofId": "second-isomorphism-theorem-modules-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 77
+    },
+    "type": "definition",
+    "title": "The Diamond Isomorphism as the Structural Foundation",
+    "content": "secondIso names Mathlib's LinearMap.quotientInfEquivSupQuotient as a LinearEquiv over an arbitrary ring R and module M, with the ambient comaps written explicitly in the type. The point of keeping it is provenance: by re-deriving the two-submodule modular law from this equivalence (next section), the three-submodule identity is exhibited as a consequence of the second isomorphism theorem rather than of Mathlib's independent dimension lemma — directly matching the parent's 'derived structurally' phrasing.",
+    "mathContext": "$\\uparrow\\!p \\,\\big/\\, \\operatorname{comap} p.\\mathrm{subtype}\\,(p \\sqcap q) \\;\\simeq_{\\ell}[R]\\; \\uparrow\\!(p \\sqcup q) \\,\\big/\\, \\operatorname{comap}(p \\sqcup q).\\mathrm{subtype}\\,q$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LinearEquiv",
+      "second isomorphism theorem",
+      "quotient module"
+    ],
+    "prerequisites": [
+      "modules and quotient modules",
+      "linear equivalences"
+    ]
+  },
+  {
+    "id": "ann-modular-law",
+    "proofId": "second-isomorphism-theorem-modules-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 113
+    },
+    "type": "proof_step",
+    "title": "Re-deriving the Two-Submodule Modular Law",
+    "content": "finrank_modular_law re-proves finrank(p ⊔ q) + finrank(p ⊓ q) = finrank p + finrank q self-containedly. A linear equivalence preserves finrank, so the two diamond quotients have equal dimension; rank–nullity (Submodule.finrank_quotient_add_finrank) on each side turns those quotient dimensions into honest submodule dimensions, with the comap denominators identified by Submodule.comapSubtypeEquivOfLe. omega combines the isomorphism equality with the two additive rank–nullity identities to produce the modular law — never forming a subtraction, staying entirely in ℕ.",
+    "mathContext": "$\\dim(p+q) + \\dim(p \\cap q) = \\dim p + \\dim q$, as a corollary of the diamond isomorphism.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rank–nullity",
+      "LinearEquiv.finrank_eq",
+      "comapSubtypeEquivOfLe"
+    ],
+    "prerequisites": [
+      "rank–nullity for quotients",
+      "dimension invariance under linear equivalence"
+    ]
+  },
+  {
+    "id": "ann-three-submodule",
+    "proofId": "second-isomorphism-theorem-modules-oq-01-oq-01",
+    "range": {
+      "startLine": 115,
+      "endLine": 143
+    },
+    "type": "key_insight",
+    "title": "Iteration, Not Symmetry: the Exact Three-Submodule Identity",
+    "content": "finrank_sup_three applies the modular law twice — to (p, q), then to (p ⊔ q, r). Because p ⊔ q ⊔ r parses as (p ⊔ q) ⊔ r, the second application's left-hand sup is literally the target, so omega closes the goal: finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r. The correction term finrank((p ⊔ q) ⊓ r) is *asymmetric* and replaces the naive symmetric combination finrank(p ⊓ r) + finrank(q ⊓ r) − finrank(p ⊓ q ⊓ r); the two agree exactly under distributivity. finrank_sup_three_sub records the ℤ subtraction form, and finrank_sup_three_of_pairwise_bot isolates the additive case where both corrections vanish.",
+    "mathContext": "Correction term $\\operatorname{finrank}((p \\sqcup q) \\sqcap r)$ replaces $\\operatorname{finrank}(p \\sqcap r) + \\operatorname{finrank}(q \\sqcap r) - \\operatorname{finrank}(p \\sqcap q \\sqcap r)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "modular law iteration",
+      "asymmetric correction term",
+      "distributivity"
+    ],
+    "prerequisites": [
+      "the two-submodule modular law",
+      "left-associativity of ⊔"
+    ]
+  },
+  {
+    "id": "ann-counterexample",
+    "proofId": "second-isomorphism-theorem-modules-oq-01-oq-01",
+    "range": {
+      "startLine": 145,
+      "endLine": 235
+    },
+    "type": "key_insight",
+    "title": "Three Lines in the Plane Kill the Symmetric Formula",
+    "content": "The witness is the simplest possible: p = span{(1,0)}, q = span{(0,1)}, r = span{(1,1)} in ℝ². Each line is 1-dimensional (finrank_span_singleton on a nonzero vector); the helper inf_span_eq_bot packages the scalar-witness chase (a • u = b • v forces both scalars to 0 for independent u, v), giving inf_pq, inf_pr, inf_qr = ⊥, and the triple intersection ⊆ p ⊓ q is ⊥ too; sup_pq_top shows the first two lines already span the plane. Hence the symmetric sum finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank(p ⊓ r) + finrank(q ⊓ r) = 2 + 0 + 0 + 0, while finrank p + finrank q + finrank r + finrank(p ⊓ q ⊓ r) = 1 + 1 + 1 + 0 = 3. Since 2 ≠ 3, the naive inclusion–exclusion formula is false. The gap 3 − 2 = 1 is exactly the failure of (p ⊔ q) ⊓ r = (p ⊓ r) ⊔ (q ⊓ r).",
+    "mathContext": "$\\underbrace{2}_{\\dim(p+q+r)} + 0 + 0 + 0 \\;\\neq\\; \\underbrace{1+1+1}_{\\dim p+\\dim q+\\dim r} + 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "explicit counterexample",
+      "span of a vector",
+      "finrank of a product",
+      "non-distributivity"
+    ],
+    "prerequisites": [
+      "spans of single vectors",
+      "finrank of ℝ × ℝ"
+    ]
+  }
+]

--- a/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "second-isomorphism-theorem-modules-oq-01-oq-01",
+  "title": "Three Submodules: the Iterated Modular Dimension Law and the Failure of Naive Inclusion–Exclusion",
+  "slug": "second-isomorphism-theorem-modules-oq-01-oq-01",
+  "description": "The parent entry derives the two-submodule modular dimension law finrank(p+q)+finrank(p∩q)=finrank p+finrank q structurally from the second (diamond) isomorphism theorem. Its first open question asks for the three-submodule analogue, warning that the symmetric set-theoretic inclusion–exclusion formula fails because the submodule lattice is modular but not distributive. This entry answers it: the correct identity is the asymmetric finrank(p+q+r)+finrank(p∩q)+finrank((p+q)∩r)=finrank p+finrank q+finrank r, obtained by iterating the modular law (re-derived from the isomorphism theorem) twice — and the naive symmetric formula is refuted by an explicit witness of three distinct lines in ℝ².",
+  "meta": {
+    "author": "Lean formalization original (modular law: Emmy Noether 1927; Dedekind modular lattice)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SecondIsomorphismTheoremModulesOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "module-theory",
+      "linear-algebra",
+      "isomorphism-theorems",
+      "dimension",
+      "modular-lattice",
+      "inclusion-exclusion",
+      "counterexample"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "LinearMap.quotientInfEquivSupQuotient",
+        "description": "The second (diamond) isomorphism theorem p ⧸ (p ⊓ q) ≃ₗ (p ⊔ q) ⧸ q; the two-submodule modular law is re-derived from it self-containedly so the three-submodule identity rests on the structural equivalence",
+        "module": "Mathlib.LinearAlgebra.Isomorphisms"
+      },
+      {
+        "theorem": "Submodule.finrank_quotient_add_finrank",
+        "description": "Rank–nullity for quotients: finrank (M ⧸ N) + finrank N = finrank M; used twice to turn the diamond equivalence into the two-submodule modular law",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+      },
+      {
+        "theorem": "Submodule.comapSubtypeEquivOfLe",
+        "description": "For submodules p ≤ q, the comap of p under q's inclusion is linearly equivalent to p; identifies the quotient denominators with honest submodule dimensions",
+        "module": "Mathlib.Algebra.Module.Submodule.Map"
+      },
+      {
+        "theorem": "finrank_span_singleton",
+        "description": "A nonzero vector spans a one-dimensional submodule; gives finrank = 1 for each of the three lines in the ℝ² counterexample",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      },
+      {
+        "theorem": "Submodule.mem_span_singleton",
+        "description": "Membership in the span of a single vector as scalar multiplicity; used to prove each pairwise intersection of distinct lines is ⊥",
+        "module": "Mathlib.LinearAlgebra.Span.Basic"
+      },
+      {
+        "theorem": "Module.finrank_prod",
+        "description": "finrank K (M × N) = finrank K M + finrank K N; gives finrank ℝ (ℝ × ℝ) = 2 for the spanned plane in the counterexample",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "finrank_sup_three: the exact iterated three-submodule dimension identity finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r, in subtraction-free ℕ form, obtained by applying the modular law to (p,q) and then to (p ⊔ q, r) — not present in Mathlib",
+      "finrank_sup_three_sub: the same identity in ℤ subtraction form, matching the textbook finrank(p ⊔ q ⊔ r) = finrank p + finrank q + finrank r − finrank(p ⊓ q) − finrank((p ⊔ q) ⊓ r)",
+      "finrank_sup_three_of_pairwise_bot: the genuinely additive special case (p ⊓ q = ⊥ and (p ⊔ q) ⊓ r = ⊥) where the three dimensions simply add, isolating exactly when the correction terms vanish",
+      "finrank_modular_law: the two-submodule modular law re-derived self-containedly from the diamond isomorphism (secondIso) so the whole chain is structural",
+      "counterexample_naive_inclusion_exclusion: an explicit ℝ² witness (three distinct lines span{(1,0)}, span{(0,1)}, span{(1,1)}) proving the symmetric inclusion–exclusion formula fails — left side 2, right side 3 — the gap being precisely the failure of distributivity (p ⊔ q) ⊓ r = (p ⊓ r) ⊔ (q ⊓ r)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 237,
+    "theoremCount": 14,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "The two-submodule modular dimension law dim(p+q)+dim(p∩q)=dim p+dim q is the linear-algebraic shadow of set inclusion–exclusion |A∪B|+|A∩B|=|A|+|B|, and the resemblance invites the false hope that the three-set formula |A∪B∪C|=Σ|·|−Σ|·∩·|+|·∩·∩·| also transfers to dimensions. It does not. The lattice of submodules is *modular* (Dedekind, 1900) — it satisfies a ≤ c ⟹ a ⊔ (b ⊓ c) = (a ⊔ b) ⊓ c — but not *distributive*, and the symmetric three-term inclusion–exclusion identity silently assumes distributivity. The correct count is asymmetric and is built by iterating the two-term modular law, exactly as one iterates the second isomorphism theorem.",
+    "problemStatement": "The parent entry's first open question: can the three-submodule dimension count be derived structurally, given that the naive symmetric inclusion–exclusion formula for finrank(p ⊔ q ⊔ r) fails on the non-distributive submodule lattice?\n\n**Answer:** Yes. Iterating the modular law twice gives the exact asymmetric identity finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r, and an explicit triple of lines in ℝ² shows the symmetric formula is genuinely false.",
+    "text": "Iterating the second-isomorphism-derived modular law yields the exact three-submodule dimension identity (asymmetric, with correction term finrank((p+q)∩r)), and three concrete lines in ℝ² refute the naive symmetric inclusion–exclusion formula — all verified in Lean with 0 axioms.",
+    "proofStrategy": "1. secondIso / finrank_modular_law: re-derive the two-submodule modular law from the diamond isomorphism (equal quotient dimensions via LinearEquiv.finrank_eq, rank–nullity on each side, comap denominators identified by comapSubtypeEquivOfLe, combined by omega), so the three-submodule result is structural.\n2. finrank_sup_three: apply finrank_modular_law to (p, q) and to (p ⊔ q, r). Since p ⊔ q ⊔ r parses as (p ⊔ q) ⊔ r, the second application's left-hand sup is literally the target; omega combines the two additive identities into finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r.\n3. finrank_sup_three_sub / finrank_sup_three_of_pairwise_bot: cast to ℤ for the textbook subtraction form, and specialize to the vanishing-correction case.\n4. counterexample_naive_inclusion_exclusion: with p = span{(1,0)}, q = span{(0,1)}, r = span{(1,1)} in ℝ², each line has finrank 1 (finrank_span_singleton), every pairwise intersection is ⊥ (mem_span_singleton scalar-witness chase, packaged by the helper inf_span_eq_bot), the triple intersection is ⊥ (⊆ p ⊓ q), and p ⊔ q = ⊤ already (every (a,b) = a•(1,0)+b•(0,1)). So the symmetric sum finrank(p ⊔ q ⊔ r)+finrank(p ⊓ q)+finrank(p ⊓ r)+finrank(q ⊓ r) = 2 while finrank p+finrank q+finrank r+finrank(p ⊓ q ⊓ r) = 3; finrank_prod gives finrank ℝ (ℝ × ℝ) = 2 and the two sides differ.",
+    "keyInsights": [
+      "**Iteration, not symmetry**: the right three-submodule law is obtained by applying the two-term modular law along a *chain* (p, then p ⊔ q against r), producing the asymmetric correction term finrank((p ⊔ q) ⊓ r). There is no order-independent symmetric formula because the lattice is not distributive.",
+      "**The correction term replaces a symmetric combination**: finrank((p ⊔ q) ⊓ r) stands in for the naive finrank(p ⊓ r) + finrank(q ⊓ r) − finrank(p ⊓ q ⊓ r), and the two agree exactly when (p ⊔ q) ⊓ r = (p ⊓ r) ⊔ (q ⊓ r) — i.e. precisely under distributivity.",
+      "**One concrete witness kills the symmetric formula**: three distinct lines in the plane already break it. Each is 1-dimensional with all pairwise and triple intersections trivial, yet they span the whole 2-dimensional plane — the naive count predicts 3, reality is 2.",
+      "**Subtraction-free discipline**: the exact identity is proved over ℕ with no explicit differences (omega combines two additive modular identities), and the counterexample is stated as an inequality of two ℕ sums, so neither result depends on truncated subtraction.",
+      "**Structural provenance**: by re-deriving the two-term law from secondIso inside the file, the entire three-submodule identity is exhibited as a consequence of the second isomorphism theorem, directly answering the parent's 'derived structurally' phrasing."
+    ],
+    "prerequisites": [
+      "Modules and submodules over a ring; quotient modules and the second isomorphism theorem",
+      "The two-submodule modular dimension law and rank–nullity",
+      "The lattice of submodules: ⊓, ⊔, ⊥, ⊤, and the modular vs. distributive distinction",
+      "Spans of single vectors and finrank of a product space"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "File-level docstring framing the parent's first open question — the three-submodule analogue of the modular dimension law, and the warning that the symmetric inclusion–exclusion formula fails on the non-distributive submodule lattice. States the asymmetric correct identity and the ℝ² counterexample plan.",
+      "mathContext": "finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r; symmetric inclusion–exclusion fails."
+    },
+    {
+      "id": "second-iso",
+      "title": "The Second Isomorphism Theorem as a Named Equivalence",
+      "startLine": 66,
+      "endLine": 77,
+      "summary": "secondIso names Mathlib's LinearMap.quotientInfEquivSupQuotient as a LinearEquiv over an arbitrary ring and module, with the ambient comaps written explicitly — the structural foundation the dimension count is built on.",
+      "mathContext": "↥p ⧸ comap p.subtype (p ⊓ q) ≃ₗ[R] ↥(p ⊔ q) ⧸ comap (p ⊔ q).subtype q."
+    },
+    {
+      "id": "modular-law",
+      "title": "The Two-Submodule Modular Law, Re-derived from the Isomorphism",
+      "startLine": 79,
+      "endLine": 113,
+      "summary": "finrank_modular_law re-proves finrank(p ⊔ q) + finrank(p ⊓ q) = finrank p + finrank q self-containedly: the diamond equivalence forces equal quotient dimensions, rank–nullity turns each into a submodule-dimension identity (comap denominators identified via comapSubtypeEquivOfLe), and omega combines them. This keeps the three-submodule result structural.",
+      "mathContext": "dim(p+q) + dim(p∩q) = dim p + dim q, as a corollary of the diamond isomorphism."
+    },
+    {
+      "id": "three-submodule",
+      "title": "The Iterated Three-Submodule Identity",
+      "startLine": 115,
+      "endLine": 143,
+      "summary": "finrank_sup_three applies the modular law to (p, q) and to (p ⊔ q, r); since p ⊔ q ⊔ r is (p ⊔ q) ⊔ r, omega yields finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r. finrank_sup_three_sub gives the ℤ subtraction form; finrank_sup_three_of_pairwise_bot isolates the additive special case where both correction terms vanish.",
+      "mathContext": "Asymmetric exact identity with correction term finrank((p ⊔ q) ⊓ r); additive when p ⊓ q = ⊥ and (p ⊔ q) ⊓ r = ⊥."
+    },
+    {
+      "id": "counterexample",
+      "title": "Counterexample: the Symmetric Formula Fails",
+      "startLine": 145,
+      "endLine": 235,
+      "summary": "Three distinct lines p = span{(1,0)}, q = span{(0,1)}, r = span{(1,1)} in ℝ². finrank_p₀/q₀/r₀ give dimension 1; inf_span_eq_bot packages the scalar-witness chase showing distinct lines meet only at 0, yielding inf_pq/inf_pr/inf_qr = ⊥; sup_pq_top shows the first two already span the plane. counterexample_naive_inclusion_exclusion concludes the symmetric sum is 2, not the predicted 3, refuting naive inclusion–exclusion.",
+      "mathContext": "finrank(p ⊔ q ⊔ r)+finrank(p ⊓ q)+finrank(p ⊓ r)+finrank(q ⊓ r) = 2 ≠ 3 = finrank p+finrank q+finrank r+finrank(p ⊓ q ⊓ r)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dedekind, Richard",
+      "title": "Über die von drei Moduln erzeugte Dualgruppe",
+      "year": "1900",
+      "note": "Origin of the modular law for lattices of modules; the three-module identity studied here"
+    },
+    {
+      "authors": "Noether, Emmy",
+      "title": "Abstrakter Aufbau der Idealtheorie in algebraischen Zahl- und Funktionenkörpern",
+      "year": "1927",
+      "note": "General formulation of the isomorphism theorems for modules"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "note": "Section 10.2 and the modular/dimension law; non-distributivity of the subspace lattice"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "second-isomorphism-theorem-modules-oq-01",
+      "relation": "parent",
+      "note": "Derives the two-submodule modular law from the diamond isomorphism; this entry answers its first open question on three submodules"
+    }
+  ],
+  "conclusion": {
+    "summary": "The three-submodule dimension count is the asymmetric finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r) = finrank p + finrank q + finrank r, obtained by iterating the second-isomorphism-derived modular law twice. The symmetric set-style inclusion–exclusion formula is refuted by three distinct lines in ℝ², whose symmetric sum is 2 against the predicted 3 — the discrepancy being exactly the failure of distributivity. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Pins down, as a machine-checked theorem plus an explicit witness, the precise sense in which subspace dimensions do *not* obey set-theoretic inclusion–exclusion: the correct law is order-dependent and built from the modular law along a chain, with the gap to the naive formula measuring non-distributivity.",
+    "openQuestions": [
+      "Does the asymmetric n-submodule telescoping identity finrank(⊔ᵢ pᵢ) + Σ finrank((⊔_{j<i} pⱼ) ⊓ pᵢ) = Σ finrank pᵢ hold for all n, and what is the cleanest inductive statement?",
+      "Can the exact gap between the symmetric naive formula and the true count be expressed intrinsically as a single 'distributivity defect' dimension finrank((p ⊓ r) ⊔ (q ⊓ r)) − ... for general modular lattices?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.LinearAlgebra.Isomorphisms",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas"
+    ],
+    "opens": [
+      "Submodule",
+      "FiniteDimensional",
+      "Module"
+    ],
+    "namespace": "SecondIsomorphismTheoremModulesOQ01OQ01",
+    "lineCount": 237,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/SecondIsomorphismTheoremModulesOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `second-isomorphism-theorem-modules-oq-01` (the diamond-isomorphism modular dimension law): *can the three-submodule dimension count be derived structurally, given that the naive symmetric inclusion–exclusion formula fails on the non-distributive submodule lattice?*

**Yes.** Two results:

1. **The exact iterated identity** (`finrank_sup_three`), subtraction-free over ℕ:
   ```
   finrank(p ⊔ q ⊔ r) + finrank(p ⊓ q) + finrank((p ⊔ q) ⊓ r)
     = finrank p + finrank q + finrank r
   ```
   obtained by applying the modular law to `(p, q)` and then to `(p ⊔ q, r)`. Since `p ⊔ q ⊔ r` parses as `(p ⊔ q) ⊔ r`, the two applications close the goal via `omega`. The two-submodule modular law is **re-derived from the second isomorphism theorem** (`secondIso`) inside the file, so the whole chain is structural. Also provided: the ℤ subtraction form (`finrank_sup_three_sub`) and the additive special case (`finrank_sup_three_of_pairwise_bot`).

2. **An explicit counterexample** (`counterexample_naive_inclusion_exclusion`) — three distinct lines `span{(1,0)}`, `span{(0,1)}`, `span{(1,1)}` in ℝ². Each is 1-dimensional, all pairwise/triple intersections are `⊥`, yet they span the plane, so the symmetric sum is `2`, not the predicted `3`. The gap is exactly the failure of distributivity `(p ⊔ q) ⊓ r = (p ⊓ r) ⊔ (q ⊓ r)`.

The asymmetric correction term `finrank((p ⊔ q) ⊓ r)` replaces the naive symmetric combination `finrank(p ⊓ r) + finrank(q ⊓ r) − finrank(p ⊓ q ⊓ r)`; the two agree exactly under distributivity.

## Verification

- **14 theorems, 4 definitions, 237 lines**
- **0 axioms, 0 sorries, no `native_decide`** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- Compiles against Mathlib 4.26.0 (`lake env lean`)
- `status: verified`, `badge: original` (the three-submodule identity and the counterexample are not in Mathlib)

## Files
- `proofs/Proofs/SecondIsomorphismTheoremModulesOQ01OQ01.lean`
- `proofs/Proofs.lean` (registration)
- `src/data/proofs/second-isomorphism-theorem-modules-oq-01-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)