### PR TITLE
research(mason-stothers-theorem-oq-01-oq-01): deg(rad p) = #{distinct roots of p} over an algebraically closed field [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/MasonStothersOQ01OQ01.lean
+++ b/proofs/Proofs/MasonStothersOQ01OQ01.lean
@@ -1,0 +1,118 @@
+import Mathlib
+import Proofs.MasonStothersOQ01
+
+/-
+# Mason–Stothers via distinct roots: `deg(rad p) = #{distinct roots of p}`
+
+The parent entry (`MasonStothersOQ01`) proves the polynomial ABC inequality in the
+form `deg c < deg(rad(a·b·c))`, leaving the radical `rad(p)` as an algebraic black
+box — the product of the *distinct* monic irreducible factors of `p`.  Over an
+**algebraically closed field** every monic irreducible is linear (`X - α`), so the
+degree of the radical is simply the number of distinct roots of `p`.
+
+This file makes that translation precise:
+
+  `(radical p).natDegree = p.roots.toFinset.card`,
+
+the cardinality of the zero set of `p` in `k`.  Feeding it into the parent bound
+turns the abstract inequality `deg c < deg(rad(a·b·c))` into the tangible
+*distinct-roots* form
+
+  `deg c < #{distinct roots of a·b·c}`,
+
+which is the shape in which Mason–Stothers is actually applied (Fermat for
+polynomials, Davenport's inequality): one counts roots, not factorisations.
+
+## Proof outline
+
+The argument splits into three independent facts, each valid over any field
+(only the degree↔root-count step needs algebraic closure):
+
+* `roots_toFinset_radical` — `radical p` and `p` have **the same set of roots**.
+  For a fixed `a`, `α = a` is a root of `radical p` iff `X - C a ∣ radical p`,
+  and `dvd_radical_iff_of_irreducible` (with `X - C a` irreducible) says this is
+  equivalent to `X - C a ∣ p`, i.e. `a` is a root of `p`.  No closure needed.
+
+* `nodup_roots_radical` — the roots of `radical p` are **distinct** (no
+  multiplicity).  `radical p` is squarefree (`squarefree_radical`), so
+  `(X - C a)² ∤ radical p`, hence `rootMultiplicity a (radical p) ≤ 1`, hence the
+  root multiset has no repeats.  No closure needed.
+
+* over an algebraically closed field `radical p` **splits**
+  (`IsAlgClosed.splits`), so `natDegree = roots.card`
+  (`Splits.natDegree_eq_card_roots`).
+
+Combining: `deg(rad p) = #(rad p).roots = #(rad p).roots.toFinset =
+#p.roots.toFinset`.  A `0`-axiom derivation from Mathlib's radical and root API.
+-/
+
+open Polynomial UniqueFactorizationMonoid
+
+namespace MasonStothersOQ01OQ01
+
+variable {k : Type*} [Field k] [DecidableEq k] {p : k[X]}
+
+/-- **Same roots.** A field element `a` is a root of `radical p` exactly when it is
+a root of `p`.  The radical strips multiplicities but keeps every distinct root:
+`a` is a root iff `X - C a` divides, and `X - C a` (being irreducible) divides
+`radical p` iff it divides `p` (`dvd_radical_iff_of_irreducible`). -/
+theorem mem_roots_radical (hp : p ≠ 0) (a : k) :
+    a ∈ (radical p).roots ↔ a ∈ p.roots := by
+  rw [mem_roots', mem_roots', and_iff_right (radical_ne_zero), and_iff_right hp,
+    ← dvd_iff_isRoot, ← dvd_iff_isRoot]
+  exact dvd_radical_iff_of_irreducible (irreducible_X_sub_C a) hp
+
+/-- **Same root set.** `radical p` and `p` have identical sets (finsets) of roots. -/
+theorem roots_toFinset_radical (p : k[X]) :
+    (radical p).roots.toFinset = p.roots.toFinset := by
+  ext a
+  by_cases hp : p = 0
+  · subst hp; simp
+  · simpa only [Multiset.mem_toFinset] using mem_roots_radical hp a
+
+/-- **Distinct roots.** The roots of `radical p` carry no multiplicity: the root
+multiset is `Nodup`.  Squarefreeness of `radical p` rules out `(X - C a)²` as a
+factor, so every root multiplicity is at most one. -/
+theorem nodup_roots_radical (p : k[X]) : (radical p).roots.Nodup := by
+  rw [Multiset.nodup_iff_count_le_one]
+  intro a
+  rw [count_roots, rootMultiplicity_le_iff radical_ne_zero a 1]
+  intro hdvd
+  rw [pow_succ, pow_one] at hdvd
+  exact not_isUnit_X_sub_C a (squarefree_radical _ hdvd)
+
+/-- **Radical degree = number of distinct roots (algebraically closed field).**
+
+For a polynomial `p` over an algebraically closed field `k`,
+
+  `deg(rad p) = #{distinct roots of p}  =  |p.roots.toFinset|`.
+
+The radical degree is exactly the cardinality of the zero set of `p` in `k`.
+Proof: `radical p` splits, so its degree equals the size of its root multiset;
+that multiset is `Nodup` (radical is squarefree) and has the same underlying set
+as `p`'s roots. -/
+theorem natDegree_radical_eq_card_roots [IsAlgClosed k] (p : k[X]) :
+    (radical p).natDegree = p.roots.toFinset.card := by
+  rw [(IsAlgClosed.splits (radical p)).natDegree_eq_card_roots,
+    ← roots_toFinset_radical p, Multiset.toFinset_card_of_nodup (nodup_roots_radical p)]
+
+/-- **Mason–Stothers, distinct-roots form (characteristic-zero, algebraically
+closed).**
+
+For a coprime additive triple `a + b = c` of nonzero polynomials over an
+algebraically closed field of characteristic zero, with `c` non-constant,
+
+  `deg c < #{distinct roots of a·b·c}`.
+
+This is the `abc`-inequality for polynomials stated as an explicit count of the
+distinct roots of the product — the form used in the one-line proof of Fermat's
+Last Theorem for polynomials.  It is `natDegree_lt_radical_charZero` from the
+parent with the radical degree rewritten as the size of the zero set. -/
+theorem natDegree_lt_card_roots_charZero [IsAlgClosed k] [CharZero k]
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (hsum : a + b = c) (hcdeg : c.natDegree ≠ 0) :
+    c.natDegree < (a * b * c).roots.toFinset.card := by
+  have h := MasonStothersOQ01.natDegree_lt_radical_charZero ha hb hc hab hsum hcdeg
+  rwa [natDegree_radical_eq_card_roots] at h
+
+end MasonStothersOQ01OQ01

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "mason-oq0101-ann-header",
+    "proofId": "mason-stothers-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "The Radical Degree as a Distinct-Root Count",
+    "content": "The Mason–Stothers theorem bounds a coprime polynomial relation a + b = c by the degree of the radical of abc — the product of its distinct irreducible factors. Over an algebraically closed field every irreducible is a linear factor X − α, so deg(rad p) is simply the number of distinct roots of p. This file proves (radical p).natDegree = p.roots.toFinset.card and uses it to recast the parent's bound as deg c < #{distinct roots of a·b·c}, the form behind the polynomial Fermat theorem. The proof separates two field-agnostic facts (same root set, distinct roots) from the single step that needs algebraic closure (degree = root count).",
+    "mathContext": "$\\deg(\\mathrm{rad}\\,p) = |\\{\\alpha \\in k : p(\\alpha) = 0\\}| = |p.\\mathrm{roots}.\\mathrm{toFinset}|$",
+    "significance": "key",
+    "relatedConcepts": ["Mason–Stothers theorem", "abc conjecture", "radical (squarefree part)", "distinct roots", "algebraically closed field"],
+    "prerequisites": ["polynomial degree", "roots of a polynomial", "radical of a polynomial"]
+  },
+  {
+    "id": "mason-oq0101-ann-same-roots",
+    "proofId": "mason-stothers-theorem-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 71 },
+    "type": "theorem",
+    "title": "Same Root Set: rad p and p Have Identical Roots",
+    "content": "mem_roots_radical and roots_toFinset_radical establish that radical p and p have the same set of roots — over ANY field, no closure needed. The key is dvd_radical_iff_of_irreducible: an irreducible element divides the radical exactly when it divides the original. With the irreducible X − C a and dvd_iff_isRoot, root membership a ∈ (radical p).roots becomes X − C a ∣ radical p ↔ X − C a ∣ p ↔ a ∈ p.roots. The radical strips multiplicities but keeps every distinct root.",
+    "mathContext": "$(\\mathrm{rad}\\,p).\\mathrm{roots}.\\mathrm{toFinset} = p.\\mathrm{roots}.\\mathrm{toFinset}$ via $X - C\\,a \\mid \\mathrm{rad}\\,p \\iff X - C\\,a \\mid p$",
+    "significance": "key",
+    "relatedConcepts": ["dvd_radical_iff_of_irreducible", "dvd_iff_isRoot", "irreducible_X_sub_C", "root set"],
+    "prerequisites": ["unique factorization", "divisibility by linear factors"]
+  },
+  {
+    "id": "mason-oq0101-ann-distinct-roots",
+    "proofId": "mason-stothers-theorem-oq-01-oq-01",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "theorem",
+    "title": "Distinct Roots from Squarefreeness",
+    "content": "nodup_roots_radical shows the roots of radical p carry no multiplicity — again over any field. Since radical p is squarefree (squarefree_radical), the square (X − C a)² cannot divide it (X − C a is not a unit, not_isUnit_X_sub_C), so by rootMultiplicity_le_iff the multiplicity of every root is at most one. Via count_roots and nodup_iff_count_le_one this makes the root multiset Nodup, so its cardinality equals the size of the underlying finset.",
+    "mathContext": "$(\\mathrm{rad}\\,p).\\mathrm{roots}$ is $\\mathrm{Nodup}$: $(X - C\\,a)^2 \\nmid \\mathrm{rad}\\,p \\Rightarrow \\mathrm{rootMultiplicity}\\,a\\,(\\mathrm{rad}\\,p) \\le 1$",
+    "significance": "key",
+    "relatedConcepts": ["squarefree_radical", "rootMultiplicity_le_iff", "count_roots", "Multiset.Nodup"],
+    "prerequisites": ["squarefree elements", "root multiplicity"]
+  },
+  {
+    "id": "mason-oq0101-ann-degree-count",
+    "proofId": "mason-stothers-theorem-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 97 },
+    "type": "insight",
+    "title": "Where Algebraic Closure Enters: Degree = Root Count",
+    "content": "natDegree_radical_eq_card_roots is the headline identity, and the ONLY step needing an algebraically closed field. IsAlgClosed.splits gives (radical p).Splits, so by Splits.natDegree_eq_card_roots the degree equals the size of the root multiset. Combined with the same-root-set lemma (← roots_toFinset_radical) and Nodup (Multiset.toFinset_card_of_nodup) this yields deg(rad p) = |p.roots.toFinset|. Over a non-closed field the radical can keep irreducible factors of degree > 1 (e.g. X² + 1 over ℝ), so the identity genuinely fails there.",
+    "mathContext": "$\\deg(\\mathrm{rad}\\,p) = \\#(\\mathrm{rad}\\,p).\\mathrm{roots} = |p.\\mathrm{roots}.\\mathrm{toFinset}|$ over an algebraically closed field",
+    "significance": "key",
+    "relatedConcepts": ["IsAlgClosed.splits", "Splits.natDegree_eq_card_roots", "Multiset.toFinset_card_of_nodup", "splitting field"],
+    "prerequisites": ["algebraically closed field", "splitting of polynomials"]
+  },
+  {
+    "id": "mason-oq0101-ann-distinct-roots-form",
+    "proofId": "mason-stothers-theorem-oq-01-oq-01",
+    "range": { "startLine": 99, "endLine": 118 },
+    "type": "theorem",
+    "title": "Mason–Stothers as a Distinct-Root Inequality",
+    "content": "natDegree_lt_card_roots_charZero feeds the degree identity back into the parent bound: over an algebraically closed field of characteristic zero, a coprime triple a + b = c with c non-constant satisfies deg c < #{distinct roots of a·b·c}. This is the workable form of the polynomial abc inequality — the right-hand side is a finite, visibly countable quantity — and is exactly what makes the one-line proof of Fermat's Last Theorem for polynomials and Davenport's inequality go through.",
+    "mathContext": "$\\deg c < |\\{\\alpha : (a b c)(\\alpha) = 0\\}|$",
+    "significance": "key",
+    "relatedConcepts": ["natDegree_lt_radical_charZero", "polynomial Fermat", "abc inequality", "characteristic zero"],
+    "prerequisites": ["Mason–Stothers degree bound", "coprime polynomials"]
+  }
+]

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MasonStothersOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const masonStothersTheoremOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const masonStothersTheoremOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const masonStothersTheoremOq01Oq01Data: ProofData = {
+  proof: masonStothersTheoremOq01Oq01Proof,
+  annotations: masonStothersTheoremOq01Oq01Annotations,
+}

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "mason-stothers-theorem-oq-01-oq-01",
+  "title": "Mason–Stothers via distinct roots: deg(rad p) = #{distinct roots of p} over an algebraically closed field",
+  "slug": "mason-stothers-theorem-oq-01-oq-01",
+  "description": "The parent entry (mason-stothers-theorem-oq-01) proves the polynomial ABC inequality deg c < deg(rad(a·b·c)), leaving the radical rad(p) — the product of the distinct monic irreducible factors of p — as an algebraic black box. Over an algebraically closed field every monic irreducible is linear (X − α), so the radical degree is just the number of distinct roots. This entry answers the first open question of the parent by proving exactly that: (radical p).natDegree = p.roots.toFinset.card, the cardinality of the zero set of p in k. The argument is three independent facts. roots_toFinset_radical: radical p and p have the same set of roots — a is a root of radical p iff X − C a ∣ radical p, which by dvd_radical_iff_of_irreducible (X − C a irreducible) holds iff X − C a ∣ p; valid over any field. nodup_roots_radical: the roots of radical p are distinct — radical p is squarefree (squarefree_radical), so (X − C a)² ∤ radical p, hence rootMultiplicity a (radical p) ≤ 1; valid over any field. Then over an algebraically closed field radical p splits (IsAlgClosed.splits), so natDegree = roots.card (Splits.natDegree_eq_card_roots). Combining gives deg(rad p) = #(rad p).roots = #(rad p).roots.toFinset = #p.roots.toFinset. Feeding this into the parent's natDegree_lt_radical_charZero yields the distinct-roots form of Mason–Stothers: deg c < #{distinct roots of a·b·c}. A 0-axiom derivation from Mathlib's radical and root API.",
+  "meta": {
+    "author": "R. C. Mason, W. W. Stothers (1981/1983, classical); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MasonStothersOQ01OQ01.lean",
+    "tags": [
+      "polynomials",
+      "mason-stothers",
+      "abc-conjecture",
+      "radical",
+      "distinct-roots",
+      "algebraically-closed-field",
+      "degree-bound",
+      "unique-factorization",
+      "number-theory",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "UniqueFactorizationMonoid.dvd_radical_iff_of_irreducible",
+        "description": "For irreducible a and b ≠ 0, a ∣ radical b ↔ a ∣ b. With a = X − C α this is the heart of roots_toFinset_radical: a linear factor divides the radical exactly when it divides p, so radical and p share their root sets.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "UniqueFactorizationMonoid.squarefree_radical",
+        "description": "Squarefree (radical a). Rules out (X − C α)² as a factor of radical p, forcing every root multiplicity to be at most one — the distinct-roots (Nodup) input.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "Polynomial.irreducible_X_sub_C",
+        "description": "X − C r is irreducible over a field. Supplies the irreducibility hypothesis of dvd_radical_iff_of_irreducible and the non-unit fact behind the squarefree argument.",
+        "module": "Mathlib.Algebra.Polynomial.RingDivision"
+      },
+      {
+        "theorem": "Polynomial.dvd_iff_isRoot",
+        "description": "X − C a ∣ p ↔ p.IsRoot a. Translates membership in the root multiset into divisibility by a linear factor, the bridge between roots and the radical's prime factors.",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "Polynomial.rootMultiplicity_le_iff",
+        "description": "For p ≠ 0, rootMultiplicity a p ≤ n ↔ ¬ (X − C a)^(n+1) ∣ p. With n = 1, reduces 'roots of radical p are distinct' to '(X − C a)² ∤ radical p', discharged by squarefreeness.",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "Polynomial.Splits.natDegree_eq_card_roots",
+        "description": "A split polynomial has natDegree equal to the cardinality of its root multiset. Combined with IsAlgClosed.splits this is the only step needing algebraic closure: deg(rad p) = #(rad p).roots.",
+        "module": "Mathlib.Algebra.Polynomial.Factors"
+      },
+      {
+        "theorem": "IsAlgClosed.splits",
+        "description": "Every polynomial over an algebraically closed field splits. Provides (radical p).Splits, turning the radical's degree into a root count.",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Multiset.toFinset_card_of_nodup",
+        "description": "A Nodup multiset has toFinset.card equal to its card. Converts #(rad p).roots into #(rad p).roots.toFinset once the roots are known to be distinct.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "roots_toFinset_radical: (radical p).roots.toFinset = p.roots.toFinset over any field — radical p and p have the same set of roots. Proved by reducing root membership to divisibility by X − C a and applying dvd_radical_iff_of_irreducible. Not a Mathlib export.",
+      "nodup_roots_radical: (radical p).roots.Nodup over any field — the roots of a radical carry no multiplicity, from squarefree_radical via rootMultiplicity_le_iff. A reusable distinct-roots fact for radicals.",
+      "natDegree_radical_eq_card_roots: (radical p).natDegree = p.roots.toFinset.card over an algebraically closed field — the radical degree equals the number of distinct roots (the size of the zero set). Answers the first open question of the parent entry.",
+      "natDegree_lt_card_roots_charZero: the distinct-roots form of Mason–Stothers, deg c < #{distinct roots of a·b·c}, for a coprime additive triple over an algebraically closed field of characteristic zero, obtained by rewriting the parent's radical-degree bound natDegree_lt_radical_charZero through natDegree_radical_eq_card_roots."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas and the parent entry's natDegree_lt_radical_charZero (itself 0-axiom). The [IsAlgClosed k] and [CharZero k] field instances and the coprimality / non-constancy hypotheses are mathematical hypotheses of the statements, not assumptions about unproved facts. Algebraic closure is genuinely required for the degree↔root-count identity (over a non-closed field the radical can have irreducible factors of degree > 1, so deg(rad p) exceeds the number of k-rational roots); the same-root-set and distinct-root lemmas hold over any field.",
+    "lineCount": 118,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Mason–Stothers theorem (R. C. Mason 1983, W. W. Stothers 1981) is the function-field analogue of the abc conjecture: for a coprime polynomial relation a + b = c, the maximal degree is bounded by the number of distinct roots of the product abc (the degree of its radical) minus one. The radical of a polynomial — its squarefree part — strips each factor to multiplicity one, and over an algebraically closed field its degree is exactly the number of distinct roots. This distinct-roots reading is the form in which Mason–Stothers is actually used: it powers the one-line proof of Fermat's Last Theorem for polynomials and Davenport's inequality, because one counts roots, not factorizations.",
+    "problemStatement": "The parent entry proves the characteristic-zero Mason–Stothers degree bound and leaves rad(a·b·c) abstract. Its first open question asks: over an algebraically closed field, is deg(rad p) literally the number of distinct roots |p.roots.toFinset|, making the bound a concrete root count?\n\n**Answer:** Yes. radical p and p share their root set (any field), the roots of radical p are distinct because radical p is squarefree (any field), and over an algebraically closed field radical p splits so its degree equals its root count. Hence deg(rad p) = |p.roots.toFinset|, and the parent bound becomes deg c < #{distinct roots of a·b·c}.",
+    "text": "Over an algebraically closed field the degree of the radical equals the number of distinct roots: (radical p).natDegree = p.roots.toFinset.card. This turns the parent's abstract Mason–Stothers bound deg c < deg(rad(a·b·c)) into the tangible distinct-roots inequality deg c < #{distinct roots of a·b·c}.",
+    "proofStrategy": "1. mem_roots_radical / roots_toFinset_radical: a ∈ (radical p).roots ↔ a ∈ p.roots. Rewrite both sides through mem_roots' and ← dvd_iff_isRoot to reduce to X − C a ∣ radical p ↔ X − C a ∣ p, which is dvd_radical_iff_of_irreducible applied to the irreducible X − C a. Take toFinset (p = 0 handled by simp).\n2. nodup_roots_radical: via Multiset.nodup_iff_count_le_one and count_roots it suffices that rootMultiplicity a (radical p) ≤ 1; rootMultiplicity_le_iff turns this into (X − C a)² ∤ radical p, which squarefree_radical gives since X − C a is not a unit (not_isUnit_X_sub_C).\n3. natDegree_radical_eq_card_roots: IsAlgClosed.splits (radical p) gives (radical p).Splits, so Splits.natDegree_eq_card_roots rewrites natDegree to (radical p).roots.card; then ← roots_toFinset_radical and Multiset.toFinset_card_of_nodup (using step 2) finish.\n4. natDegree_lt_card_roots_charZero: rewrite the parent's natDegree_lt_radical_charZero through natDegree_radical_eq_card_roots.",
+    "keyInsights": [
+      "**Radical and polynomial have the same root set — over any field.** A field element a is a root iff X − C a divides, and dvd_radical_iff_of_irreducible says an irreducible divides the radical exactly when it divides the original. Closure is not needed for the root set to be preserved, only for counting it by degree.",
+      "**Distinctness is squarefreeness in disguise.** radical p is squarefree, so no (X − C a)² divides it; equivalently every root multiplicity is at most one and the root multiset is Nodup. This step, too, is field-agnostic.",
+      "**Algebraic closure enters exactly once.** Only the identity natDegree = roots.card requires that radical p splits. Over a non-closed field a radical can carry irreducible factors of degree > 1 (e.g. X² + 1 over ℝ), so deg(rad p) counts factor degrees, not k-rational roots; closure makes every factor linear and the two coincide.",
+      "**Concretising the abc bound.** Substituting deg(rad(a·b·c)) = #{distinct roots of a·b·c} into the parent inequality gives deg c < #distinct roots — the visibly finite, computable quantity on which the polynomial Fermat and Davenport arguments rest."
+    ],
+    "exampleSections": [
+      {
+        "title": "Why closure is essential: ℝ versus ℂ",
+        "mathContext": "Take p = (X² + 1)² over ℝ. Its radical is X² + 1 (degree 2), but p has no real roots, so |p.roots.toFinset| = 0 ≠ 2: the identity fails over ℝ. Over ℂ the radical X² + 1 = (X − i)(X + i) has degree 2 and p has exactly the two distinct roots ±i, so deg(rad p) = 2 = |p.roots.toFinset|. The same-root-set and Nodup lemmas hold over ℝ; only the degree-counts-roots step needs ℂ."
+      },
+      {
+        "title": "Reading the parent bound as a root count",
+        "mathContext": "For a coprime triple a + b = c over ℂ with c non-constant, natDegree_lt_card_roots_charZero gives deg c < #{distinct roots of a·b·c}. For the polynomial Fermat equation xⁿ + yⁿ = zⁿ with x, y, z pairwise coprime non-constant, the product has at most deg x + deg y + deg z distinct roots, and the three instances of this inequality force n ≤ 2 — the textbook one-line proof, now expressed purely through counts of distinct roots."
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header: Mason–Stothers via Distinct Roots",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Docstring stating the target identity (radical p).natDegree = p.roots.toFinset.card and its three-step outline: same root set (any field), distinct roots from squarefreeness (any field), and degree = root count over an algebraically closed field. Imports Mathlib and the parent MasonStothersOQ01.",
+      "mathContext": "$\\deg(\\mathrm{rad}\\,p) = |\\{\\alpha : p(\\alpha) = 0\\}|$ over an algebraically closed field."
+    },
+    {
+      "id": "sec-same-roots",
+      "title": "§1 Same Root Set",
+      "startLine": 55,
+      "endLine": 71,
+      "summary": "mem_roots_radical and roots_toFinset_radical: radical p and p have the same roots. Reduce root membership to X − C a ∣ · via dvd_iff_isRoot, then apply dvd_radical_iff_of_irreducible to the irreducible X − C a. Valid over any field.",
+      "mathContext": "$(\\mathrm{rad}\\,p).\\mathrm{roots}.\\mathrm{toFinset} = p.\\mathrm{roots}.\\mathrm{toFinset}$."
+    },
+    {
+      "id": "sec-distinct-roots",
+      "title": "§2 Distinct Roots from Squarefreeness",
+      "startLine": 73,
+      "endLine": 82,
+      "summary": "nodup_roots_radical: the roots of radical p carry no multiplicity. Via nodup_iff_count_le_one and count_roots reduce to rootMultiplicity ≤ 1, i.e. (X − C a)² ∤ radical p (rootMultiplicity_le_iff), discharged by squarefree_radical and not_isUnit_X_sub_C. Valid over any field.",
+      "mathContext": "$(\\mathrm{rad}\\,p).\\mathrm{roots}$ is $\\mathrm{Nodup}$ because $\\mathrm{rad}\\,p$ is squarefree."
+    },
+    {
+      "id": "sec-degree-eq-count",
+      "title": "§3 Radical Degree = Distinct-Root Count",
+      "startLine": 84,
+      "endLine": 97,
+      "summary": "natDegree_radical_eq_card_roots: over an algebraically closed field, IsAlgClosed.splits gives (radical p).Splits, so Splits.natDegree_eq_card_roots rewrites natDegree to the root-multiset cardinality; ← roots_toFinset_radical and Multiset.toFinset_card_of_nodup finish. The only step using closure.",
+      "mathContext": "$\\deg(\\mathrm{rad}\\,p) = \\#(\\mathrm{rad}\\,p).\\mathrm{roots} = |p.\\mathrm{roots}.\\mathrm{toFinset}|$."
+    },
+    {
+      "id": "sec-distinct-roots-form",
+      "title": "§4 Mason–Stothers in Distinct-Roots Form",
+      "startLine": 99,
+      "endLine": 118,
+      "summary": "natDegree_lt_card_roots_charZero: rewriting the parent's natDegree_lt_radical_charZero through natDegree_radical_eq_card_roots yields deg c < #{distinct roots of a·b·c} for a coprime additive triple over an algebraically closed field of characteristic zero.",
+      "mathContext": "$\\deg c < |\\{\\alpha : (abc)(\\alpha) = 0\\}|$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stothers, W. W.",
+      "title": "Polynomial identities and Hauptmoduln",
+      "year": "1981",
+      "note": "Quart. J. Math. Oxford 32, 349–370 — the original Mason–Stothers degree bound in terms of the number of distinct roots of abc."
+    },
+    {
+      "authors": "Mason, R. C.",
+      "title": "Diophantine Equations over Function Fields",
+      "year": "1984",
+      "note": "London Math. Soc. Lecture Note Series 96, Cambridge — the independent statement and proof, in the distinct-roots form used here."
+    },
+    {
+      "authors": "Lang, Serge",
+      "title": "Algebra (3rd ed.)",
+      "year": "2002",
+      "note": "Springer GTM 211 — radical of a polynomial, splitting over algebraically closed fields, and the equivalence deg(rad p) = #distinct roots."
+    },
+    {
+      "authors": "Snyder, Noah",
+      "title": "An alternate proof of Mason's theorem",
+      "year": "2000",
+      "note": "Elem. Math. 55, 93–94 — the elementary distinct-roots proof and the one-line polynomial Fermat application."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "mason-stothers-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry. Supplies natDegree_lt_radical_charZero, the characteristic-zero Mason–Stothers degree bound stated with deg(rad(a·b·c)); this entry answers its first open question by identifying that radical degree with the number of distinct roots."
+    },
+    {
+      "targetId": "mason-stothers-theorem-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling entry deriving Davenport's inequality from the same parent bound. Both make the radical-degree term concrete: this entry as a distinct-root count, that one via a hypothesis-free radical-degree upper bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over an algebraically closed field, (radical p).natDegree = p.roots.toFinset.card: the degree of the radical equals the number of distinct roots, the cardinality of the zero set of p. The proof combines two field-agnostic facts — radical p and p share their root set (dvd_radical_iff_of_irreducible) and the roots of radical p are distinct (squarefree_radical) — with the single closure-dependent step that radical p splits (IsAlgClosed.splits, Splits.natDegree_eq_card_roots). Substituting into the parent's natDegree_lt_radical_charZero gives the distinct-roots form of Mason–Stothers, deg c < #{distinct roots of a·b·c}. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Closes the first open question of mason-stothers-theorem-oq-01 and turns the gallery's abstract Mason–Stothers bound into the computable, visibly finite distinct-roots inequality that underlies the polynomial Fermat theorem and Davenport's inequality. The reusable lemmas roots_toFinset_radical and nodup_roots_radical record that a radical preserves the root set and removes multiplicity over any field.",
+    "openQuestions": [
+      "State the explicit factorisation radical p = leadingCoeff⁻¹-normalised ∏_{α ∈ p.roots.toFinset} (X − C α) over an algebraically closed field, upgrading the degree identity to an equality of polynomials.",
+      "Give the distinct-roots form of the polynomial Fermat theorem xⁿ + yⁿ = zⁿ ⟹ n ≤ 2 directly from natDegree_lt_card_roots_charZero, counting distinct roots of xyz rather than radical degrees."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MasonStothersOQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "UniqueFactorizationMonoid"
+    ],
+    "namespace": "MasonStothersOQ01OQ01",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/MasonStothersOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `mason-stothers-theorem-oq-01`: over an algebraically closed field, the degree of the radical equals the number of distinct roots,

```
(radical p).natDegree = p.roots.toFinset.card
```

i.e. the cardinality of the zero set of `p` in `k`. The parent proves the polynomial ABC bound `deg c < deg(rad(a·b·c))` but leaves `rad(p)` as an algebraic black box; this entry makes it the tangible *distinct-roots* count in which Mason–Stothers is actually used (polynomial Fermat, Davenport).

## Structure

The proof cleanly separates **two field-agnostic facts** from the **one step needing closure**:

- `roots_toFinset_radical` — `radical p` and `p` have the **same root set** (any field). `a` is a root of `radical p` iff `X - C a ∣ radical p`, which by `dvd_radical_iff_of_irreducible` (with `X - C a` irreducible) holds iff `X - C a ∣ p`.
- `nodup_roots_radical` — the roots of `radical p` are **distinct** (any field). `radical p` is squarefree, so `(X - C a)² ∤ radical p`, hence `rootMultiplicity a (radical p) ≤ 1` (`rootMultiplicity_le_iff`).
- `natDegree_radical_eq_card_roots` — over an **algebraically closed** field `radical p` splits (`IsAlgClosed.splits`), so `natDegree = roots.card` (`Splits.natDegree_eq_card_roots`); combined with the two facts above this gives the identity. Closure is genuinely required: over ℝ, `rad((X²+1)²) = X²+1` has degree 2 but no real roots.
- `natDegree_lt_card_roots_charZero` — rewriting the parent's `natDegree_lt_radical_charZero` through the identity yields `deg c < #{distinct roots of a·b·c}` for a coprime triple over an algebraically closed field of characteristic zero.

## Verification

- **5 theorems, 0 definitions, 118 lines**
- **0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`; no `native_decide`, no `sorry`
- Compiles against Mathlib 4.26.0 + parent `Proofs.MasonStothersOQ01`
- Status `verified`, badge `mathlib`

## Gallery

Adds `src/data/proofs/mason-stothers-theorem-oq-01-oq-01/` (meta.json, annotations.json, index.ts) with parent + sibling cross-references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)