### PR TITLE
research(dyck-catalan-count-oq-01-oq-01): rooted plane trees counted by Catalan via explicit Dyck-word bijection [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1043,6 +1043,7 @@ import Proofs.DivisibilityTruncationGeneralOQ01OQ01
 import Proofs.DivisibilityTruncationGeneralOQ03
 import Proofs.DivisibilityTruncationGeneralOQ03OQ01
 import Proofs.DyckCatalanCountOQ01
+import Proofs.DyckCatalanCountOQ01OQ01
 import Proofs.ETranscendentalOQ01
 import Proofs.ETranscendentalOQ01OQ01
 import Proofs.ETranscendentalOQ02

--- a/proofs/Proofs/DyckCatalanCountOQ01OQ01.lean
+++ b/proofs/Proofs/DyckCatalanCountOQ01OQ01.lean
@@ -1,0 +1,241 @@
+import Mathlib
+
+/-
+# Rooted plane trees are counted by the Catalan numbers, via an explicit
+# bijection to Dyck words
+
+The parent gallery entry `dyck-catalan-count-oq-01`
+(`Proofs/DyckCatalanCountOQ01.lean`) packages Mathlib's headline count
+
+  `DyckWord.card_dyckWord_semilength_eq_catalan :`
+  `  Fintype.card { p : DyckWord // p.semilength = n } = catalan n`
+
+with closed forms and the Segner recurrence.  The follow-up question asks us to
+count *another* Catalan family by an **explicit bijection to Dyck words**, rather
+than re-deriving an arithmetic recurrence.
+
+The originally suggested family was triangulations of a convex polygon.  A
+*faithful* geometric encoding (non-crossing maximal diagonal sets, with the
+apex-uniqueness lemma underpinning the recursion) is a genuinely multi-session
+undertaking in Lean.  The problem statement explicitly sanctions an alternative:
+
+  > Counting an alternative family (rooted plane trees) is an acceptable fallback
+  > if the triangulation encoding proves intractable.
+
+So this file counts **rooted plane trees** (a.k.a. ordered rooted trees), the
+second-most-classical Catalan family after triangulations and one that Mathlib
+does *not* count.  A rooted plane tree is a root carrying an ordered list of
+subtrees, each itself a plane tree; a *forest* is an ordered list of plane trees.
+Plane trees are a genuinely different combinatorial object from the rooted binary
+trees Mathlib already counts (`treesOfNumNodesEq`), even though both are counted
+by the same Catalan numbers.
+
+## What is proved
+
+* `PlaneForest ≃ Tree Unit` (`forestEquivTree`) — **Knuth's natural
+  correspondence** ("left-child / right-sibling" rotation): a forest
+  `t₁ t₂ … tₖ` whose first tree `t₁` has children-forest `c` maps to the binary
+  tree whose left subtree encodes `c` and whose right subtree encodes
+  `t₂ … tₖ`.  This is the canonical bijection between forests of plane trees and
+  rooted binary trees, given here with a fully verified two-sided inverse.
+* `numNodes_toTree` — the bijection is **node-preserving**: a forest with `n`
+  plane-tree nodes maps to a binary tree with `n` internal nodes.
+* `forestEquivDyck` — composing with Mathlib's `DyckWord.equivTree` gives the
+  requested **explicit bijection `PlaneForest ≃ DyckWord`** carrying node count to
+  semilength.
+* `card_planeForest_size_eq_catalan` — there are `catalan n` plane forests with
+  `n` nodes, the count *transported* from the parent Dyck-word count.
+* `card_planeTree_size_eq_catalan` — there are `catalan n` rooted plane trees with
+  `n + 1` nodes (equivalently `n` edges): the headline Catalan interpretation
+  `#{plane trees with n edges} = Cₙ`.
+* Positivity and a small-case sanity ladder `1, 1, 2, 5`.
+
+Everything is over `ℕ`, fully machine-checked, 0 axioms, 0 sorries, no
+`decide` / `native_decide`.
+-/
+
+namespace PlaneTreeCatalan
+
+/- A **rooted plane tree** is a root carrying an *ordered* forest of children;
+a **plane forest** is an ordered (possibly empty) list of plane trees.  The two
+types are mutually recursive.  Unlike rooted binary trees, the children of a node
+form a sequence of arbitrary length, so this is a genuinely distinct Catalan
+family. -/
+mutual
+/-- A rooted plane tree: a root carrying an ordered forest of children. -/
+inductive PlaneTree : Type
+  | node : PlaneForest → PlaneTree
+/-- A plane forest: an ordered (possibly empty) list of plane trees. -/
+inductive PlaneForest : Type
+  | nil : PlaneForest
+  | cons : PlaneTree → PlaneForest → PlaneForest
+end
+
+namespace PlaneTree
+
+/- The number of nodes of a plane tree (resp. forest): one for the root plus the
+nodes of its children forest. -/
+mutual
+/-- The number of nodes of a plane tree. -/
+def size : PlaneTree → ℕ
+  | .node c => c.size + 1
+/-- The number of plane-tree nodes in a forest. -/
+def _root_.PlaneTreeCatalan.PlaneForest.size : PlaneForest → ℕ
+  | .nil => 0
+  | .cons t f => t.size + f.size
+end
+
+end PlaneTree
+
+/- **Knuth's natural correspondence (forest → binary tree).**  The empty forest
+maps to the empty binary tree.  A forest `t :: f` whose head `t = node c` has
+children-forest `c` maps to a binary node whose *left* subtree encodes `c` (the
+children of the first tree) and whose *right* subtree encodes `f` (the remaining
+trees).  This is the left-child/right-sibling rotation. -/
+mutual
+/-- Encode a single plane tree as the binary tree of its children forest. -/
+def PlaneTree.toTree : PlaneTree → Tree Unit
+  | .node c => c.toTree
+/-- Encode a plane forest as a rooted binary tree (Knuth's correspondence). -/
+def PlaneForest.toTree : PlaneForest → Tree Unit
+  | .nil => Tree.nil
+  | .cons t f => Tree.node () t.toTree f.toTree
+end
+
+/-- The inverse rotation (binary tree → forest).  A binary node `node () l r`
+becomes the forest whose first tree has children-forest `fromTree l`, followed by
+the forest `fromTree r`. -/
+def fromTree : Tree Unit → PlaneForest
+  | .nil => .nil
+  | .node _ l r => .cons (.node (fromTree l)) (fromTree r)
+
+/-- `fromTree` is a left inverse of `PlaneForest.toTree`: decoding the encoding of
+any forest returns the forest. -/
+theorem fromTree_toTree : ∀ f : PlaneForest, fromTree f.toTree = f
+  | .nil => rfl
+  | .cons (.node c) f => by
+      simp only [PlaneForest.toTree, PlaneTree.toTree, fromTree]
+      rw [fromTree_toTree c, fromTree_toTree f]
+termination_by f => f.size
+decreasing_by
+  · simp only [PlaneForest.size, PlaneTree.size]; omega
+  · simp only [PlaneForest.size, PlaneTree.size]; omega
+
+/-- `fromTree` is a right inverse of `PlaneForest.toTree`: encoding the decoding of
+any binary tree returns the binary tree. -/
+theorem toTree_fromTree : ∀ t : Tree Unit, (fromTree t).toTree = t
+  | .nil => rfl
+  | .node _ l r => by
+      simp only [fromTree, PlaneForest.toTree, PlaneTree.toTree]
+      rw [toTree_fromTree l, toTree_fromTree r]
+
+/-- **The explicit bijection** between plane forests and rooted binary trees:
+Knuth's natural correspondence, with its verified two-sided inverse. -/
+def forestEquivTree : PlaneForest ≃ Tree Unit where
+  toFun := PlaneForest.toTree
+  invFun := fromTree
+  left_inv := fromTree_toTree
+  right_inv := toTree_fromTree
+
+/-- The bijection is **node-preserving**: a forest with `n` plane-tree nodes maps
+to a binary tree with `n` internal nodes. -/
+theorem numNodes_toTree : ∀ f : PlaneForest, f.toTree.numNodes = f.size
+  | .nil => rfl
+  | .cons (.node c) f => by
+      simp only [PlaneForest.toTree, PlaneTree.toTree, Tree.numNodes,
+        PlaneForest.size, PlaneTree.size]
+      rw [numNodes_toTree c, numNodes_toTree f]; ring
+termination_by f => f.size
+decreasing_by
+  · simp only [PlaneForest.size, PlaneTree.size]; omega
+  · simp only [PlaneForest.size, PlaneTree.size]; omega
+
+/-- The node-preserving bijection, restricted to a fixed size `n`:
+plane forests with `n` nodes correspond to binary trees with `n` internal nodes. -/
+def forestEquivTreeSize (n : ℕ) :
+    { f : PlaneForest // f.size = n } ≃ { b : Tree Unit // b.numNodes = n } :=
+  forestEquivTree.subtypeEquiv fun f => by
+    simp only [forestEquivTree, Equiv.coe_fn_mk, numNodes_toTree]
+
+/-- Binary trees with `n` internal nodes correspond to Dyck words of semilength
+`n`, via Mathlib's `DyckWord.equivTree`. -/
+def treeEquivDyckSize (n : ℕ) :
+    { b : Tree Unit // b.numNodes = n } ≃ { p : DyckWord // p.semilength = n } :=
+  (DyckWord.equivTree.subtypeEquiv fun p => by
+    rw [DyckWord.semilength_eq_numNodes_equivTree]).symm
+
+/-- **The requested explicit bijection to Dyck words.**  Composing Knuth's
+correspondence with Mathlib's Dyck-word ↔ binary-tree bijection yields an
+explicit bijection between plane forests with `n` nodes and Dyck words of
+semilength `n`. -/
+def forestEquivDyckSize (n : ℕ) :
+    { f : PlaneForest // f.size = n } ≃ { p : DyckWord // p.semilength = n } :=
+  (forestEquivTreeSize n).trans (treeEquivDyckSize n)
+
+/-- **Headline (forests).**  The number of plane forests with `n` nodes is the
+`n`-th Catalan number — the count *transported* along the explicit bijection to
+Dyck words, not re-derived. -/
+theorem card_planeForest_size_eq_catalan (n : ℕ) :
+    Nat.card { f : PlaneForest // f.size = n } = catalan n := by
+  rw [Nat.card_congr (forestEquivDyckSize n), Nat.card_eq_fintype_card,
+    DyckWord.card_dyckWord_semilength_eq_catalan]
+
+/-- A plane tree `node c` has exactly one more node than its children forest `c`,
+so plane trees with `n + 1` nodes correspond to forests with `n` nodes. -/
+def treeEquivForestSize (n : ℕ) :
+    { t : PlaneTree // t.size = n + 1 } ≃ { f : PlaneForest // f.size = n } where
+  toFun := fun ⟨t, ht⟩ => match t, ht with
+    | .node c, ht => ⟨c, by simpa [PlaneTree.size] using ht⟩
+  invFun := fun ⟨c, hc⟩ => ⟨.node c, by simp [PlaneTree.size, hc]⟩
+  left_inv := fun ⟨t, ht⟩ => by cases t; rfl
+  right_inv := fun ⟨c, hc⟩ => rfl
+
+/-- **Headline (plane trees).**  The number of rooted plane trees with `n + 1`
+nodes — equivalently `n` edges — is the `n`-th Catalan number `Cₙ`.  This is the
+classical Catalan interpretation `#{ordered trees with n edges} = Cₙ`, here
+obtained by transporting the parent Dyck-word count along an explicit bijection. -/
+theorem card_planeTree_size_eq_catalan (n : ℕ) :
+    Nat.card { t : PlaneTree // t.size = n + 1 } = catalan n := by
+  rw [Nat.card_congr (treeEquivForestSize n), card_planeForest_size_eq_catalan]
+
+/-! ### Positivity -/
+
+/-- An explicit "caterpillar" forest of each size `n`: `n` single-node trees in a
+row.  It witnesses that the counted set is nonempty. -/
+def caterpillar : ℕ → PlaneForest
+  | 0 => .nil
+  | n + 1 => .cons (.node .nil) (caterpillar n)
+
+@[simp] theorem caterpillar_size : ∀ n, (caterpillar n).size = n
+  | 0 => rfl
+  | n + 1 => by
+      simp only [caterpillar, PlaneForest.size, PlaneTree.size, caterpillar_size n]
+      omega
+
+/-- There is always at least one plane forest of each size `n`, so the count is
+positive (giving, via the headline, a combinatorial proof that `0 < catalan n`). -/
+theorem card_planeForest_size_pos (n : ℕ) :
+    0 < Nat.card { f : PlaneForest // f.size = n } := by
+  have hfin : Finite { f : PlaneForest // f.size = n } :=
+    Finite.of_equiv _ (forestEquivDyckSize n).symm
+  have hne : Nonempty { f : PlaneForest // f.size = n } :=
+    ⟨⟨caterpillar n, caterpillar_size n⟩⟩
+  exact Nat.card_pos_iff.mpr ⟨hne, hfin⟩
+
+/-! ### Small-case sanity ladder: `C₀, C₁, C₂, C₃ = 1, 1, 2, 5`.
+
+Plane trees with `1, 2, 3, 4` nodes (i.e. `0, 1, 2, 3` edges) number `1, 1, 2, 5`. -/
+
+example : Nat.card { t : PlaneTree // t.size = 1 } = 1 := by
+  rw [card_planeTree_size_eq_catalan, catalan_zero]
+
+example : Nat.card { t : PlaneTree // t.size = 2 } = 1 := by
+  rw [card_planeTree_size_eq_catalan, catalan_one]
+
+example : Nat.card { t : PlaneTree // t.size = 3 } = 2 := by
+  rw [card_planeTree_size_eq_catalan, catalan_two]
+
+example : Nat.card { t : PlaneTree // t.size = 4 } = 5 := by
+  rw [card_planeTree_size_eq_catalan, catalan_three]
+
+end PlaneTreeCatalan

--- a/src/data/proofs/dyck-catalan-count-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dyck-oq0101-ann-header",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 2, "endLine": 55 },
+    "type": "context",
+    "title": "Choosing rooted plane trees as the new Catalan family",
+    "content": "The parent entry asked to count another Catalan family and exhibit an explicit bijection to Dyck words. The originally suggested family was triangulations of a convex polygon, but a faithful geometric encoding (non-crossing maximal diagonal sets with the apex-uniqueness lemma) is a multi-session undertaking in Lean. The problem statement explicitly sanctions an alternative, so this entry counts rooted plane (ordered) trees — the second-most-classical Catalan family and one Mathlib does not encode. Plane trees are a genuinely distinct combinatorial object from the rooted binary trees Mathlib already counts, even though both are counted by the same Catalan numbers.",
+    "mathContext": "$\\#\\{\\text{rooted plane trees with } n \\text{ edges}\\} = C_n$.",
+    "significance": "context",
+    "relatedConcepts": ["plane trees", "ordered trees", "Catalan numbers", "bijective combinatorics", "polygon triangulations"],
+    "prerequisites": ["rooted ordered trees", "the Catalan numbers"]
+  },
+  {
+    "id": "dyck-oq0101-ann-encoding",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 86 },
+    "type": "concept",
+    "title": "A mutually-recursive encoding of plane trees and forests",
+    "content": "PlaneTree and PlaneForest are defined as a mutually-recursive inductive pair: a PlaneTree is node carrying a PlaneForest (its ordered children), and a PlaneForest is nil or cons of a PlaneTree onto a PlaneForest. The node-count function size is defined by mutual recursion. Because the children of a node form a sequence of arbitrary length (not a fixed left/right pair), this is honestly a different family from rooted binary trees.",
+    "mathContext": "A plane tree is a root with an ordered forest of children; $\\mathrm{size}$ counts nodes.",
+    "significance": "key",
+    "relatedConcepts": ["mutually-recursive inductive types", "ordered trees", "forests", "node count"],
+    "prerequisites": ["inductive types in Lean", "mutual recursion"]
+  },
+  {
+    "id": "dyck-oq0101-ann-bijection",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 140 },
+    "type": "concept",
+    "title": "Knuth's natural correspondence as an explicit bijection",
+    "content": "PlaneForest.toTree encodes a forest as a binary tree by the left-child/right-sibling rotation: the empty forest becomes Tree.nil; a forest cons (node c) f becomes Tree.node () (encode c) (encode f), so the left subtree holds the children of the first tree and the right subtree holds the remaining forest. The inverse fromTree is plain recursion on Tree Unit. The two round-trips fromTree_toTree and toTree_fromTree are proved by structural induction and packaged as forestEquivTree : PlaneForest ≃ Tree Unit — an explicit, verified two-sided bijection.",
+    "mathContext": "$\\mathrm{PlaneForest} \\simeq \\mathrm{Tree}\\,\\mathrm{Unit}$ via the rotation correspondence.",
+    "significance": "key",
+    "relatedConcepts": ["left-child/right-sibling rotation", "Knuth correspondence", "Equiv", "structural induction"],
+    "prerequisites": ["binary trees", "two-sided inverses / equivalences"]
+  },
+  {
+    "id": "dyck-oq0101-ann-sizegraded",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 141, "endLine": 176 },
+    "type": "concept",
+    "title": "Node preservation and the bijection to Dyck words",
+    "content": "numNodes_toTree shows the bijection is node-preserving: a forest with n plane-tree nodes maps to a binary tree with n internal nodes. forestEquivTreeSize restricts the bijection to fixed size n via Equiv.subtypeEquiv. treeEquivDyckSize turns Mathlib's DyckWord.equivTree (with semilength_eq_numNodes_equivTree) into an equivalence between binary trees of n nodes and Dyck words of semilength n; forestEquivDyckSize composes the two into the requested explicit bijection between plane forests of n nodes and Dyck words of semilength n.",
+    "mathContext": "$\\{f \\mid \\mathrm{size}\\,f = n\\} \\simeq \\{p:\\mathrm{DyckWord} \\mid \\mathrm{semilength}\\,p = n\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["size-graded bijection", "Equiv.subtypeEquiv", "DyckWord.equivTree", "Dyck words"],
+    "prerequisites": ["subtype equivalences", "the Dyck-word/binary-tree bijection"]
+  },
+  {
+    "id": "dyck-oq0101-ann-counts",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 177, "endLine": 201 },
+    "type": "concept",
+    "title": "The Catalan counts, transported not re-derived",
+    "content": "card_planeForest_size_eq_catalan transports the parent's Dyck-word count across forestEquivDyckSize by Nat.card_congr: plane forests with n nodes number catalan n. Since a plane tree is exactly a forest with a root placed on top (adding one node), treeEquivForestSize gives { t : PlaneTree // size = n+1 } ≃ { f // size = n }, hence card_planeTree_size_eq_catalan: rooted plane trees with n+1 nodes — equivalently n edges — number catalan n, the classical interpretation #{ordered trees with n edges} = Cₙ.",
+    "mathContext": "$\\#\\{\\text{plane trees with } n \\text{ edges}\\} = C_n$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_congr", "count transport", "Catalan numbers", "edges vs nodes"],
+    "prerequisites": ["transporting cardinalities along equivalences"]
+  },
+  {
+    "id": "dyck-oq0101-ann-positivity",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 202, "endLine": 241 },
+    "type": "concept",
+    "title": "Positivity from an explicit witness, and the small-case ladder",
+    "content": "caterpillar n is an explicit forest of n single-node trees in a row, with caterpillar_size verifying its size; card_planeForest_size_pos concludes positivity of the count via Nat.card_pos_iff, drawing finiteness from the bijection. The closing ladder checks the plane-tree counts 1, 1, 2, 5 for 1, 2, 3, 4 nodes (0, 1, 2, 3 edges) through the counting theorem and Mathlib's catalan_zero/one/two/three — no decide/native_decide.",
+    "mathContext": "$C_0,\\dots,C_3 = 1,1,2,5$ realized as plane-tree counts.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "explicit witness", "Nat.card_pos_iff", "sanity checks"],
+    "prerequisites": ["nonempty finite types", "the Catalan small cases"]
+  }
+]

--- a/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "dyck-catalan-count-oq-01-oq-01",
+  "title": "Rooted Plane Trees Are Counted by the Catalan Numbers, via an Explicit Bijection to Dyck Words",
+  "slug": "dyck-catalan-count-oq-01-oq-01",
+  "description": "A new Catalan family, counted by an explicit bijection to Dyck words. The parent entry asked to enumerate another Catalan family (the suggestion was triangulations of a convex polygon) and exhibit an explicit bijection to Dyck words rather than re-deriving an arithmetic recurrence. A faithful geometric encoding of triangulations is a genuinely multi-session undertaking in Lean, so — exactly as the problem sanctions as an acceptable alternative — this entry counts rooted plane trees (ordered rooted trees), the second-most-classical Catalan family and one Mathlib does not count. A plane tree is a root carrying an ordered list of plane subtrees; a forest is an ordered list of plane trees. The headline is forestEquivTree: an explicit bijection PlaneForest ≃ Tree Unit given by Knuth's natural correspondence (the left-child / right-sibling rotation), with a fully verified two-sided inverse, shown node-preserving (numNodes_toTree). Composing with Mathlib's DyckWord.equivTree gives the requested explicit bijection forestEquivDyckSize: PlaneForest with n nodes ≃ Dyck words of semilength n. Transporting the parent's Dyck-word count along it yields card_planeForest_size_eq_catalan (plane forests with n nodes number catalan n) and card_planeTree_size_eq_catalan (rooted plane trees with n+1 nodes, i.e. n edges, number catalan n) — the classical interpretation #{ordered trees with n edges} = Cₙ. Plane trees are a genuinely distinct combinatorial object from the rooted binary trees Mathlib already counts. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Euler / Segner; Catalan; the forest↔binary-tree correspondence due to Knuth); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "dyck-words",
+      "plane-trees",
+      "ordered-trees",
+      "bijective-combinatorics",
+      "enumerative-combinatorics",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DyckCatalanCountOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "DyckWord.card_dyckWord_semilength_eq_catalan",
+        "description": "The parent count Fintype.card { p : DyckWord // p.semilength = n } = catalan n. The plane-tree count is transported from this along the explicit bijection, not re-derived.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "DyckWord.equivTree",
+        "description": "The Mathlib bijection DyckWord ≃ Tree Unit. Composed with Knuth's forest↔binary-tree correspondence to obtain the explicit bijection from plane forests to Dyck words.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "DyckWord.semilength_eq_numNodes_equivTree",
+        "description": "p.semilength = (equivTree p).numNodes. Makes the Dyck-word/binary-tree bijection size-graded, so the composed bijection sends forest node count to Dyck semilength.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "Tree.numNodes",
+        "description": "The number of internal nodes of a rooted binary tree. The plane-tree node count is matched to it through numNodes_toTree.",
+        "module": "Mathlib.Data.Tree.Basic"
+      },
+      {
+        "theorem": "Equiv.subtypeEquiv",
+        "description": "Restricts a bijection to fixed-size subtypes given a pointwise iff of the size predicates; used to pass from the global bijections to the size-n equivalences forestEquivTreeSize / treeEquivDyckSize.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "Transports a cardinality along an equivalence. Used to push the Dyck-word count back through the bijection onto plane forests and plane trees.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.card_pos_iff",
+        "description": "0 < Nat.card α ↔ Nonempty α ∧ Finite α. Combined with the explicit caterpillar witness and finiteness from the bijection to give positivity of the plane-forest count.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "originalContributions": [
+      "PlaneTree / PlaneForest: a mutually-recursive Lean encoding of rooted plane (ordered) trees and forests — a Catalan family absent from Mathlib, genuinely distinct from the rooted binary trees Mathlib counts",
+      "forestEquivTree: an explicit bijection PlaneForest ≃ Tree Unit realizing Knuth's natural correspondence (left-child / right-sibling rotation), with both inverse directions proved (fromTree_toTree, toTree_fromTree)",
+      "numNodes_toTree: the correspondence is node-preserving — a forest with n plane-tree nodes maps to a binary tree with n internal nodes — making it size-graded",
+      "forestEquivDyckSize: the requested explicit bijection between plane forests with n nodes and Dyck words of semilength n, obtained by composing Knuth's correspondence with Mathlib's DyckWord.equivTree",
+      "card_planeForest_size_eq_catalan and card_planeTree_size_eq_catalan: the counts #{plane forests with n nodes} = catalan n and #{rooted plane trees with n+1 nodes (n edges)} = catalan n, transported from the parent Dyck-word count along the explicit bijection",
+      "card_planeForest_size_pos: positivity of the count from the explicit caterpillar forest witness, with finiteness supplied by the bijection"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 241,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; the small-case ladder (counts 1,1,2,5) is derived through the counting theorem and Mathlib's catalan_zero/one/two/three, not by kernel computation.",
+    "mathlib_version": "4.31.0",
+    "theoremCount": 7,
+    "definitionCount": 13
+  },
+  "overview": {
+    "historicalContext": "The enumeration of convex-polygon triangulations by what are now the Catalan numbers is due to Euler (1751) and Segner (1758) — the original Catalan family. Rooted plane (ordered) trees are the next most classical family: a plane tree with n edges is counted by Cₙ, and forests of plane trees with n total nodes likewise by Cₙ. The bridge used here, the bijection between forests of plane trees and rooted binary trees — the 'left-child / right-sibling' or 'rotation' correspondence — is the natural correspondence popularized by Knuth (TAOCP Vol. 1). Mathlib counts the Catalan numbers through Dyck words and rooted binary trees (treesOfNumNodesEq) but contains no encoding of plane trees, so this fills a genuine library gap while honouring the parent's request for a bijective transport to Dyck words.",
+    "problemStatement": "**Open Question (dyck-catalan-count-oq-01, question 1)**: Prove the corresponding enumeration for another Catalan family not yet counted in Mathlib and exhibit an explicit bijection to Dyck words.\n\n**Result**: rooted plane trees (and forests) are encoded as a mutually-recursive Lean type; Knuth's natural correspondence is formalized as an explicit, verified bijection PlaneForest ≃ Tree Unit, made size-graded and composed with Mathlib's DyckWord.equivTree to obtain PlaneForest with n nodes ≃ Dyck words of semilength n; the parent's Dyck-word count is transported along it to give #{plane trees with n edges} = catalan n. A faithful geometric encoding of triangulations was the original suggestion but is multi-session work; rooted plane trees are the explicitly sanctioned alternative family.",
+    "text": "A rooted plane tree is a root with an ordered list of plane subtrees; a plane forest is an ordered list of plane trees. For every n, the number of plane forests with n nodes is catalan n, and the number of rooted plane trees with n+1 nodes (equivalently n edges) is catalan n. The count is established bijectively: Knuth's left-child/right-sibling rotation is an explicit node-preserving bijection between plane forests and rooted binary trees, which composed with Mathlib's Dyck-word ↔ binary-tree bijection gives an explicit bijection between plane forests of n nodes and Dyck words of semilength n; the parent's Dyck-word count is then transported across.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Encode plane trees and forests as a mutually-recursive inductive pair (PlaneTree.node carrying a PlaneForest; PlaneForest = nil | cons), with a node-count function size defined by mutual recursion.\n\n2. Define the forest→binary-tree encoding by mutual recursion (PlaneForest.toTree): the empty forest ↦ Tree.nil; a forest cons (node c) f ↦ Tree.node () (encode c) (encode f), i.e. left subtree = children of the head, right subtree = the rest of the forest (the left-child/right-sibling rotation). Define the inverse fromTree by plain recursion on Tree Unit.\n\n3. Prove the two round-trips fromTree_toTree and toTree_fromTree by structural induction (the forest direction matching the nested head cons (node c) f and recursing on c and f, with termination by size), packaging them as forestEquivTree : PlaneForest ≃ Tree Unit.\n\n4. Prove numNodes_toTree: (toTree f).numNodes = f.size, so the bijection is size-graded; restrict to forestEquivTreeSize n : { f // f.size = n } ≃ { b : Tree Unit // b.numNodes = n } via Equiv.subtypeEquiv.\n\n5. Use Mathlib's DyckWord.equivTree and semilength_eq_numNodes_equivTree to build treeEquivDyckSize n : { b // b.numNodes = n } ≃ { p : DyckWord // p.semilength = n }; compose to forestEquivDyckSize n.\n\n6. Transport the parent count: card_planeForest_size_eq_catalan via Nat.card_congr and DyckWord.card_dyckWord_semilength_eq_catalan; deduce card_planeTree_size_eq_catalan through treeEquivForestSize n : { t : PlaneTree // t.size = n+1 } ≃ { f // f.size = n }. Positivity from the explicit caterpillar witness and Nat.card_pos_iff.",
+    "keyInsights": [
+      "**Plane trees are a different family from binary trees, with the same count.** Mathlib counts Cₙ via Dyck words and rooted binary trees; rooted plane (ordered) trees are a distinct combinatorial object. Counting them is not a relabelling of the binary-tree count but a transport across a genuine bijection.",
+      "**Knuth's natural correspondence is the right bridge.** The left-child / right-sibling rotation makes a forest of plane trees correspond to one binary tree: the first tree's children become the left subtree, the remaining forest becomes the right subtree. This single recursive idea is both the bijection and the explanation of why forests and binary trees share the Catalan count.",
+      "**Forests, not single trees, are what biject with binary trees.** A single plane tree node c and its children-forest c encode to the same binary tree, so the bijection lives at the forest level; the single-tree count is recovered by the trivial shift { t // size = n+1 } ≃ { f // size = n } (a plane tree is exactly a forest with a root placed on top, adding one node).",
+      "**Transport, don't re-derive.** Following the parent's mandate, no arithmetic recurrence is re-run: the count is carried from Mathlib's Dyck-word count straight across the composed bijection by Nat.card_congr. The node-preservation lemma is what lets the global bijection descend to each fixed size.",
+      "**Faithfulness drove the family choice.** An abstract inductive 'triangulation' that is secretly a binary tree would weaken the originality claim; rooted plane trees are an honestly distinct object, and the problem statement explicitly lists them as an acceptable alternative to the heavier geometric triangulation encoding."
+    ],
+    "prerequisites": [
+      "Rooted plane (ordered) trees and forests, and their enumeration by the Catalan numbers",
+      "The forest ↔ binary-tree (left-child/right-sibling) correspondence and Mathlib's Dyck-word ↔ binary-tree bijection",
+      "Defining functions and proving equalities by mutual structural recursion on mutually-recursive inductive types",
+      "Transporting cardinalities along equivalences with Equiv.subtypeEquiv and Nat.card_congr"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Plane-Tree Encoding",
+      "startLine": 1,
+      "endLine": 86,
+      "summary": "Module docstring explaining the choice of rooted plane trees as the new Catalan family (with triangulations deferred as multi-session geometry), the mutually-recursive inductive types PlaneTree and PlaneForest, and the node-count function size.",
+      "mathContext": "A plane tree is a root with an ordered forest of children; size counts nodes."
+    },
+    {
+      "id": "bijection",
+      "title": "Knuth's Forest ↔ Binary-Tree Bijection",
+      "startLine": 87,
+      "endLine": 140,
+      "summary": "The encoding PlaneForest.toTree (left-child/right-sibling rotation) and its inverse fromTree, the two round-trip proofs fromTree_toTree and toTree_fromTree, and their packaging as the explicit equivalence forestEquivTree : PlaneForest ≃ Tree Unit.",
+      "mathContext": "$\\mathrm{PlaneForest} \\simeq \\mathrm{Tree}\\,\\mathrm{Unit}$ via the rotation correspondence."
+    },
+    {
+      "id": "size-graded",
+      "title": "Node Preservation and the Bijection to Dyck Words",
+      "startLine": 141,
+      "endLine": 176,
+      "summary": "numNodes_toTree shows the bijection is node-preserving; forestEquivTreeSize restricts it to fixed size n; treeEquivDyckSize uses Mathlib's DyckWord.equivTree; forestEquivDyckSize composes them into the requested explicit bijection between plane forests of n nodes and Dyck words of semilength n.",
+      "mathContext": "$\\{f : \\mathrm{PlaneForest} \\mid \\mathrm{size}\\,f = n\\} \\simeq \\{p : \\mathrm{DyckWord} \\mid \\mathrm{semilength}\\,p = n\\}$."
+    },
+    {
+      "id": "counts",
+      "title": "The Catalan Counts",
+      "startLine": 177,
+      "endLine": 201,
+      "summary": "card_planeForest_size_eq_catalan (plane forests with n nodes number catalan n, transported from the parent Dyck count) and, via treeEquivForestSize, card_planeTree_size_eq_catalan (rooted plane trees with n+1 nodes, i.e. n edges, number catalan n).",
+      "mathContext": "$\\#\\{\\text{plane trees with } n \\text{ edges}\\} = C_n$."
+    },
+    {
+      "id": "positivity-ladder",
+      "title": "Positivity and Small-Case Ladder",
+      "startLine": 202,
+      "endLine": 241,
+      "summary": "The explicit caterpillar forest of each size, caterpillar_size, and card_planeForest_size_pos (positivity from the witness plus finiteness from the bijection); followed by the small-case ladder verifying plane-tree counts 1, 1, 2, 5 for 1, 2, 3, 4 nodes.",
+      "mathContext": "$C_0,\\dots,C_3 = 1,1,2,5$ realized as plane-tree counts."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "dyck-catalan-count-oq-01",
+      "relationship": "Direct parent: supplies the Dyck-word count card_dyckWord_semilength_eq_catalan and the Dyck-word ↔ binary-tree bijection that this entry's count is transported across; this entry answers the parent's first open question (enumerate another Catalan family with an explicit bijection to Dyck words)."
+    },
+    {
+      "id": "dyck-catalan-count",
+      "relationship": "Foundational Dyck-word/Catalan count; the reference family the bijection targets."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms) formalization that rooted plane trees and forests are counted by the Catalan numbers, established bijectively: Knuth's left-child/right-sibling correspondence is given as an explicit node-preserving bijection PlaneForest ≃ Tree Unit, composed with Mathlib's Dyck-word ↔ binary-tree bijection to obtain an explicit bijection from plane forests of n nodes to Dyck words of semilength n, along which the parent's Dyck-word count is transported to give #{plane trees with n edges} = catalan n.",
+    "implications": "Adds a Catalan family absent from Mathlib (rooted plane trees) together with the canonical forest↔binary-tree bijection, both reusable for further enumerative work (plane-tree statistics, associahedra, the tree-rotation lattice). Demonstrates the bijective method end-to-end in Lean: encode a new family, build a verified two-sided bijection, make it size-graded, and transport an existing count rather than re-deriving it.",
+    "openQuestions": [
+      "Carry out the originally suggested faithful geometric encoding of convex-polygon triangulations (non-crossing maximal diagonal sets) and prove its count by an explicit bijection to plane trees or Dyck words, including the unique-apex/ear lemma underpinning the recursion.",
+      "Recover the Segner convolution recurrence directly on the plane-forest counts via the head-tree / remaining-forest decomposition, mirroring the parent's card_semilength_succ, and identify the decomposition with the binary-tree split under forestEquivTree."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PlaneTreeCatalan",
+    "lineCount": 241,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 13,
+    "path": "Proofs/DyckCatalanCountOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Donald E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "Addison-Wesley",
+      "note": "Section 2.3.2: the natural correspondence between forests of ordered trees and binary trees (left-child / right-sibling), the bijection formalized here."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press",
+      "note": "Definitive catalogue of Catalan objects; ordered (plane) trees with n edges and Dyck paths appear as foundational families with the standard bijection between them."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.DyckWord and Mathlib.Combinatorics.Enumerative.Catalan",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the Dyck-word ↔ binary-tree bijection (DyckWord.equivTree), the Dyck-word count, and the binary-tree count treesOfNumNodesEq used as the transport target."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `dyck-catalan-count-oq-01`: *enumerate another Catalan family not yet counted in Mathlib and exhibit an explicit bijection to Dyck words.*

The originally suggested family was triangulations of a convex polygon. A **faithful** geometric encoding (non-crossing maximal diagonal sets + the apex-uniqueness lemma) is a genuinely multi-session undertaking in Lean. The problem statement explicitly sanctions an alternative — *"Counting an alternative family (rooted plane trees) is an acceptable fallback"* — so this entry counts **rooted plane (ordered) trees**: the second-most-classical Catalan family, absent from Mathlib, and genuinely distinct from the rooted binary trees Mathlib already counts.

## What is proved

| Result | Statement |
|--------|-----------|
| `forestEquivTree` | Explicit bijection `PlaneForest ≃ Tree Unit` — **Knuth's natural correspondence** (left-child / right-sibling rotation), with both inverse directions proved (`fromTree_toTree`, `toTree_fromTree`) |
| `numNodes_toTree` | The bijection is **node-preserving** (forest with n nodes ↦ binary tree with n internal nodes) |
| `forestEquivDyckSize` | The requested **explicit bijection to Dyck words**: `{f : PlaneForest // size = n} ≃ {p : DyckWord // semilength = n}`, via Mathlib's `DyckWord.equivTree` |
| `card_planeForest_size_eq_catalan` | #{plane forests with n nodes} = `catalan n`, transported (not re-derived) from the parent Dyck-word count |
| `card_planeTree_size_eq_catalan` | #{rooted plane trees with n+1 nodes, i.e. n edges} = `catalan n` — the classical interpretation #{ordered trees with n edges} = Cₙ |
| `card_planeForest_size_pos` | Positivity from an explicit caterpillar witness |

Plus the small-case ladder 1, 1, 2, 5.

## Verification

- Compiles against Mathlib 4.31.0 (`lake env lean`), **0 errors**.
- `#print axioms` on the headline results: only `propext`, `Classical.choice`, `Quot.sound` (the foundational three, which do not count). **0 `axiom` declarations, 0 sorries, no `decide`/`native_decide`.**
- 7 theorems, 13 defs/inductives, 241 lines.

## Honesty notes

- This is **not** the triangulation result; it is the sanctioned plane-tree alternative. Plane trees are an honestly distinct combinatorial object (arbitrary-arity ordered children), not a relabelling of binary trees.
- The count is **transported** from Mathlib's `card_dyckWord_semilength_eq_catalan` along the explicit bijection — no arithmetic recurrence is re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)