### PR TITLE
research(taylor-theorem-oq-01): multivariate Taylor with Lagrange remainder via line restriction [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3887,6 +3887,7 @@ import Proofs.TaylorSinCosConvergenceOQ03Incomplete01
 import Proofs.TaylorSinCosConvergenceOQ03Aristotle
 import Proofs.TaylorSinCosConvergenceOQ04
 import Proofs.TaylorTheorem
+import Proofs.TaylorTheoremOQ01
 import Proofs.TaylorTheoremOQ02
 import Proofs.TaylorTheoremOQ03
 import Proofs.TaylorTheoremOQ03OQ01

--- a/proofs/Proofs/TaylorTheoremOQ01.lean
+++ b/proofs/Proofs/TaylorTheoremOQ01.lean
@@ -1,0 +1,135 @@
+import Mathlib.Analysis.Calculus.Taylor
+import Mathlib.Tactic
+
+/-!
+# Multivariate Taylor's Theorem via Restriction to a Line (Taylor #35, OQ-01)
+
+## The Open Question
+The parent entry (Taylor's theorem, Wiedijk #35) asks:
+
+> *Can Lean formalize the multivariate Taylor theorem with remainder?*
+
+The fully general statement expresses the `k`-th term of the expansion as a symmetric
+`k`-linear map applied to `k` copies of the displacement vector (multi-index notation).
+That packaging is genuinely heavy. This entry establishes the **standard reduction** that
+underlies every proof of multivariate Taylor: restrict `f : E → ℝ` to the line segment
+`t ↦ f(a + t • v)` and apply the one-dimensional Taylor theorem already in Mathlib.
+
+## What This Proves
+For a normed real vector space `E` and `f : E → ℝ`, define the *line restriction*
+`g(t) = f(a + t • v)`. Then:
+
+* `restriction_contDiff` — `g` inherits the smoothness of `f` (composition with the affine
+  map `t ↦ a + t • v`);
+* `restriction_hasDerivAt` / `restriction_deriv` — the first derivative of `g` is the
+  directional (Fréchet) derivative: `g'(t) = Df(a + t•v)(v)`;
+* `multivariate_taylor_lagrange` — the multivariate Taylor expansion with Lagrange
+  remainder, with each term carried by the iterated derivative of the restriction
+  (the directional-derivative form):
+  `f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)!` for some `θ ∈ (0,1)`;
+* `multivariate_taylor_first_order` — the headline `n = 0` case, the multivariate mean
+  value theorem in Lagrange form with the gradient made explicit:
+  `f(a+v) = f(a) + Df(a + θ•v)(v)` for some `θ ∈ (0,1)`.
+
+## Honest Scope
+The remainder here is expressed through the iterated derivative of the one-dimensional
+restriction `g`, i.e. the iterated **directional** derivative along `v`. The fully
+symmetric-multilinear / multi-index packaging asked for in the open question (writing
+`g^{(k)}(0)` as `D^k f(a)(v,…,v)` via `iteratedFDeriv`) is left as future work: it requires
+the bridge `iteratedDeriv k g t = iteratedFDeriv ℝ k f (a+t•v) (fun _ => v)`, an induction
+over the chain rule that we do not carry out here. The first-order term *is* given the
+explicit Fréchet-derivative form, so the headline result is fully multivariate.
+
+## Approach
+- **Foundation (Mathlib):** `taylor_mean_remainder_lagrange_iteratedDeriv` (1-D Taylor with
+  Lagrange remainder), the chain rule `HasFDerivAt.comp_hasDerivAt`, and `ContDiff.comp`.
+- **Key Insight:** multivariate Taylor is one-dimensional Taylor applied to the restriction
+  of `f` to a line; smoothness and the first derivative transfer through composition with
+  the affine parametrisation `t ↦ a + t • v`.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Builds on Mathlib's 1-D Taylor theorem
+- [x] Multivariate first-order Lagrange form with explicit Fréchet derivative
+-/
+
+namespace MultivariateTaylor
+
+open Set Nat
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The restriction of `f : E → ℝ` to the line through `a` in direction `v`,
+viewed as a one-variable function `g(t) = f(a + t • v)`. -/
+noncomputable def restriction (f : E → ℝ) (a v : E) : ℝ → ℝ := fun t => f (a + t • v)
+
+@[simp] theorem restriction_apply (f : E → ℝ) (a v : E) (t : ℝ) :
+    restriction f a v t = f (a + t • v) := rfl
+
+@[simp] theorem restriction_zero (f : E → ℝ) (a v : E) :
+    restriction f a v 0 = f a := by simp [restriction]
+
+@[simp] theorem restriction_one (f : E → ℝ) (a v : E) :
+    restriction f a v 1 = f (a + v) := by simp [restriction]
+
+/-- The affine parametrisation `t ↦ a + t • v` is `HasDerivAt` with derivative `v`. -/
+theorem line_hasDerivAt (a v : E) (t : ℝ) :
+    HasDerivAt (fun s : ℝ => a + s • v) v t := by
+  simpa using (((hasDerivAt_id t).smul_const v).const_add a)
+
+/-- The line restriction inherits the smoothness of `f`. -/
+theorem restriction_contDiff {N : WithTop ℕ∞} (f : E → ℝ) (a v : E)
+    (hf : ContDiff ℝ N f) : ContDiff ℝ N (restriction f a v) := by
+  have hline : ContDiff ℝ N (fun s : ℝ => a + s • v) :=
+    contDiff_const.add (contDiff_id.smul contDiff_const)
+  exact hf.comp hline
+
+/-- **First directional derivative.** The derivative of the line restriction `g(t)` is the
+Fréchet derivative of `f` applied to the direction `v`. -/
+theorem restriction_hasDerivAt (f : E → ℝ) (a v : E) (t : ℝ)
+    (hf : DifferentiableAt ℝ f (a + t • v)) :
+    HasDerivAt (restriction f a v) (fderiv ℝ f (a + t • v) v) t := by
+  have := hf.hasFDerivAt.comp_hasDerivAt t (line_hasDerivAt a v t)
+  simpa [restriction, Function.comp] using this
+
+/-- The derivative of the line restriction, in `deriv` form. -/
+theorem restriction_deriv (f : E → ℝ) (a v : E) (t : ℝ)
+    (hf : DifferentiableAt ℝ f (a + t • v)) :
+    deriv (restriction f a v) t = fderiv ℝ f (a + t • v) v :=
+  (restriction_hasDerivAt f a v t hf).deriv
+
+/-- **Multivariate Taylor's theorem with Lagrange remainder.**
+
+For `f : E → ℝ` that is `(n+1)`-times continuously differentiable, the value `f(a + v)`
+equals the degree-`n` Taylor polynomial of the line restriction `g(t) = f(a + t • v)`,
+plus a Lagrange remainder `g^{(n+1)}(θ)/(n+1)!` for some `θ ∈ (0,1)`. The remainder is
+carried by the iterated derivative of the restriction, i.e. the iterated directional
+derivative along `v`. -/
+theorem multivariate_taylor_lagrange {n : ℕ} (f : E → ℝ) (a v : E)
+    (hf : ContDiff ℝ (n + 1) f) :
+    ∃ θ ∈ Ioo (0 : ℝ) 1,
+      f (a + v) - taylorWithinEval (restriction f a v) n (Icc 0 1) 0 1 =
+        iteratedDeriv (n + 1) (restriction f a v) θ / (n + 1)! := by
+  have hg : ContDiff ℝ (n + 1) (restriction f a v) := restriction_contDiff f a v hf
+  obtain ⟨θ, hθ, hEq⟩ :=
+    taylor_mean_remainder_lagrange_iteratedDeriv (f := restriction f a v)
+      (x := 1) (x₀ := 0) (n := n) (by norm_num) hg.contDiffOn
+  exact ⟨θ, hθ, by simpa using hEq⟩
+
+/-- **Multivariate mean value / first-order Taylor theorem with Lagrange remainder.**
+
+For `f : E → ℝ` continuously differentiable, there is an interior point `a + θ • v`
+(`θ ∈ (0,1)`) at which the Fréchet derivative recovers the increment exactly:
+`f(a + v) = f(a) + Df(a + θ•v)(v)`. This is the multivariate analogue of the
+one-dimensional `f(b) - f(a) = f'(ξ)(b - a)`. -/
+theorem multivariate_taylor_first_order (f : E → ℝ) (a v : E) (hf : ContDiff ℝ 1 f) :
+    ∃ θ ∈ Ioo (0 : ℝ) 1, f (a + v) = f a + fderiv ℝ f (a + θ • v) v := by
+  obtain ⟨θ, hθ, hEq⟩ := multivariate_taylor_lagrange (n := 0) f a v (by simpa using hf)
+  refine ⟨θ, hθ, ?_⟩
+  have hdiff : DifferentiableAt ℝ f (a + θ • v) := (hf.differentiable le_rfl).differentiableAt
+  rw [taylor_within_zero_eval, iteratedDeriv_one,
+    restriction_deriv f a v θ hdiff, restriction_zero] at hEq
+  simp only [zero_add, Nat.factorial_one, Nat.cast_one, div_one] at hEq
+  linarith [hEq]
+
+end MultivariateTaylor

--- a/src/data/proofs/taylor-theorem-oq-01/annotations.json
+++ b/src/data/proofs/taylor-theorem-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-taylor-oq01-restriction",
+    "proofId": "taylor-theorem-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "The Line Restriction g(t) = f(a + t·v)",
+    "content": "restriction f a v is the one-variable function obtained by restricting f : E → ℝ to the line through a in direction v. Its endpoints are the only values that matter for Taylor's theorem on [0,1]: restriction_zero gives g(0) = f(a) and restriction_one gives g(1) = f(a+v). This single definition is the bridge that turns a multivariate question into a one-dimensional one — every later result is about g.",
+    "mathContext": "$g(t) = f(a + t\\,v)$, with $g(0) = f(a)$ and $g(1) = f(a+v)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "line restriction",
+      "directional derivative",
+      "reduction to one variable"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-taylor-oq01-derivative",
+    "proofId": "taylor-theorem-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "Smoothness and the Directional Derivative Transfer",
+    "content": "restriction_contDiff shows g inherits the ContDiff smoothness of f, because g = f ∘ φ with φ(t) = a + t·v an affine (hence smooth) parametrisation, via ContDiff.comp. restriction_hasDerivAt then computes the first derivative by the chain rule HasFDerivAt.comp_hasDerivAt: since φ'(t) = v (line_hasDerivAt), the derivative of g is the Fréchet derivative of f in the direction v, deriv g t = fderiv ℝ f (a + t·v) v. This directional-derivative identity is the reusable core of the entry.",
+    "mathContext": "$g'(t) = Df(a + t\\,v)(v)$, obtained from the chain rule along the curve $\\varphi(t) = a + t\\,v$ with $\\varphi'(t) = v$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "chain rule",
+      "Fréchet derivative",
+      "ContDiff.comp",
+      "affine parametrisation"
+    ],
+    "prerequisites": [
+      "HasFDerivAt.comp_hasDerivAt",
+      "ContDiff.comp"
+    ]
+  },
+  {
+    "id": "ann-taylor-oq01-lagrange",
+    "proofId": "taylor-theorem-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 123
+    },
+    "type": "insight",
+    "title": "Multivariate Taylor with Lagrange Remainder",
+    "content": "multivariate_taylor_lagrange applies Mathlib's one-dimensional taylor_mean_remainder_lagrange_iteratedDeriv to the restriction g on the interval [0,1]. After rewriting g(1) = f(a+v) and g(0) = f(a), this yields f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)! for some θ ∈ (0,1). The remainder is carried by the iterated derivative of the restriction — the iterated directional derivative of f along v — which is the honest form proved here in place of the heavier symmetric-multilinear / multi-index packaging.",
+    "mathContext": "$f(a+v) = T_n g(0) + \\dfrac{g^{(n+1)}(\\theta)}{(n+1)!}$ for some $\\theta \\in (0,1)$, where $g(t) = f(a+t\\,v)$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "Taylor's theorem",
+      "Lagrange remainder",
+      "iterated directional derivative"
+    ],
+    "prerequisites": [
+      "taylor_mean_remainder_lagrange_iteratedDeriv"
+    ]
+  },
+  {
+    "id": "ann-taylor-oq01-first-order",
+    "proofId": "taylor-theorem-oq-01",
+    "range": {
+      "startLine": 125,
+      "endLine": 134
+    },
+    "type": "insight",
+    "title": "First-Order Case: the Multivariate Mean Value Theorem",
+    "content": "multivariate_taylor_first_order specialises the Lagrange expansion to n = 0. The degree-0 Taylor polynomial of g is f(a) (taylor_within_zero_eval), the single remainder term is deriv g θ = Df(a+θ·v)(v) (restriction_deriv), and 1! = 1, giving f(a+v) = f(a) + Df(a+θ·v)(v) for some θ ∈ (0,1). This is the exact multivariate analogue of the mean value theorem f(b) - f(a) = f'(ξ)(b-a), with the interior point a+θ·v lying strictly on the open segment between a and a+v.",
+    "mathContext": "$f(a+v) = f(a) + Df(a+\\theta\\,v)(v)$ for some $\\theta \\in (0,1)$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "mean value theorem",
+      "Fréchet derivative",
+      "first-order Taylor expansion"
+    ],
+    "prerequisites": [
+      "taylor_within_zero_eval"
+    ]
+  }
+]

--- a/src/data/proofs/taylor-theorem-oq-01/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "taylor-theorem-oq-01",
+  "title": "Multivariate Taylor's Theorem via Restriction to a Line",
+  "slug": "taylor-theorem-oq-01",
+  "description": "Formalizes the multivariate Taylor theorem with Lagrange remainder for f : E → ℝ on a real normed space, via the standard reduction to one-dimensional Taylor applied to the line restriction g(t) = f(a + t·v). Establishes smoothness transfer, the first directional derivative g'(t) = Df(a+t·v)(v), the degree-n Lagrange expansion, and the headline first-order multivariate mean value theorem f(a+v) = f(a) + Df(a+θ·v)(v) for some θ ∈ (0,1).",
+  "meta": {
+    "author": "Taylor (1715), Lagrange (1797) (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Taylor%27s_theorem#Taylor's_theorem_for_multivariate_functions",
+    "date": "1715",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TaylorTheoremOQ01.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "taylor-series",
+      "multivariate",
+      "frechet-derivative",
+      "mean-value-theorem",
+      "lagrange-remainder",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "taylor_mean_remainder_lagrange_iteratedDeriv",
+        "description": "One-dimensional Taylor theorem with Lagrange remainder in iteratedDeriv form",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      },
+      {
+        "theorem": "HasFDerivAt.comp_hasDerivAt",
+        "description": "Chain rule: Fréchet derivative of f composed with a one-variable curve",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Comp"
+      },
+      {
+        "theorem": "ContDiff.comp",
+        "description": "Smoothness is preserved under composition, used to transfer ContDiff of f to the line restriction",
+        "module": "Mathlib.Analysis.Calculus.ContDiff.Basic"
+      },
+      {
+        "theorem": "HasDerivAt.smul_const",
+        "description": "Derivative of t ↦ t • v is v, the affine line parametrisation",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Mul"
+      },
+      {
+        "theorem": "taylor_within_zero_eval",
+        "description": "The degree-0 Taylor polynomial of g at x₀ equals g(x₀)",
+        "module": "Mathlib.Analysis.Calculus.Taylor"
+      }
+    ],
+    "originalContributions": [
+      "Defined the line restriction g(t) = f(a + t·v) of a function on a real normed space and proved it inherits the smoothness (ContDiff) of f via composition with the affine parametrisation t ↦ a + t·v",
+      "Proved the first derivative of the restriction is the directional Fréchet derivative: deriv g t = fderiv ℝ f (a + t·v) v (both HasDerivAt and deriv forms)",
+      "Proved the multivariate Taylor theorem with Lagrange remainder (general degree n): f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)! for some θ ∈ (0,1), with the remainder carried by the iterated directional derivative of the restriction",
+      "Proved the headline first-order multivariate mean value theorem in Lagrange form with the gradient made explicit: f(a+v) = f(a) + Df(a+θ·v)(v) for some θ ∈ (0,1)",
+      "Carried out the standard reduction (multivariate Taylor = 1-D Taylor on the line restriction) entirely with Mathlib's one-dimensional Taylor theorem and the chain rule, with 0 axioms and 0 sorries"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "assumptions": "0 axioms, 0 sorries. The one-dimensional Taylor theorem with Lagrange remainder (taylor_mean_remainder_lagrange_iteratedDeriv), the chain rule, and ContDiff.comp come from Mathlib; the original work is the line-restriction reduction, the directional-derivative identity, and the multivariate Lagrange/first-order statements. Only the foundational axioms propext, Classical.choice, Quot.sound are used (none counted).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Taylor's theorem (1715) is classically stated for functions of one real variable, but its multivariate generalisation — expressing f(a+v) as a sum of symmetric-multilinear terms D^k f(a)(v,…,v)/k! plus a remainder — is the form that powers optimisation (second-order conditions), numerical analysis, and differential geometry. Every textbook proof of the multivariate theorem proceeds by the same reduction: restrict f to the line segment t ↦ a + t·v and apply the one-dimensional theorem to the resulting function g(t) = f(a + t·v). This entry, the first open question under the parent Taylor's theorem (Wiedijk #35), formalises exactly that reduction in Lean 4. The smoothness of f transfers to g through the chain rule, the first derivative of g is the directional (Fréchet) derivative Df(a+t·v)(v), and Mathlib's one-dimensional Lagrange remainder then yields a genuine multivariate Taylor statement. The headline first-order case is the multivariate mean value theorem f(a+v) = f(a) + Df(a+θ·v)(v), the exact analogue of f(b) - f(a) = f'(ξ)(b-a).",
+    "problemStatement": "**Main Results** (for f : E → ℝ on a real normed space E, displacement v, base point a):\n\n1. The line restriction g(t) = f(a + t·v) inherits ContDiff smoothness from f.\n2. g'(t) = Df(a + t·v)(v) — the derivative of the restriction is the directional Fréchet derivative.\n3. **Lagrange form (degree n):** if f is C^{n+1}, then ∃ θ ∈ (0,1), f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)!, where the remainder is the (n+1)-th iterated directional derivative.\n4. **First-order multivariate MVT:** if f is C^1, then ∃ θ ∈ (0,1), f(a+v) = f(a) + Df(a+θ·v)(v).",
+    "text": "Formalizes the multivariate Taylor theorem with Lagrange remainder for real-valued functions on a normed space, via the standard reduction to one-dimensional Taylor applied to the line restriction g(t) = f(a + t·v).",
+    "proofStrategy": "The line restriction g(t) = f(a + t·v) is written as f ∘ φ with φ(t) = a + t·v an affine parametrisation. φ is ContDiff (constant plus a scalar multiple of v) and HasDerivAt with derivative v, so g inherits the smoothness of f via ContDiff.comp and, by the chain rule HasFDerivAt.comp_hasDerivAt, has derivative deriv g t = fderiv ℝ f (a+t·v) v. Applying Mathlib's taylor_mean_remainder_lagrange_iteratedDeriv to g on the interval [0,1] gives the degree-n Lagrange expansion with remainder g^{(n+1)}(θ)/(n+1)! for some θ ∈ (0,1); simplifying g(1) = f(a+v) and g(0) = f(a) yields the multivariate statement. The first-order case specialises n = 0: the degree-0 Taylor polynomial is f(a), the single remainder term is deriv g θ = Df(a+θ·v)(v), and 1! = 1, giving f(a+v) = f(a) + Df(a+θ·v)(v).",
+    "keyInsights": [
+      "Multivariate Taylor is one-dimensional Taylor applied to the restriction of f to a line — the reduction is the whole content of the theorem, and Mathlib already has the one-dimensional half",
+      "Smoothness and the first derivative transfer through the affine parametrisation t ↦ a + t·v: ContDiff.comp gives smoothness, the chain rule gives deriv g t = Df(a+t·v)(v)",
+      "The first-order Lagrange case is the multivariate mean value theorem f(a+v) = f(a) + Df(a+θ·v)(v), with the interior point a+θ·v lying strictly between a and a+v",
+      "Expressing the higher-order remainder as the iterated derivative of the restriction (the iterated directional derivative) avoids the heavy symmetric-multilinear / multi-index machinery while still giving a fully rigorous multivariate statement"
+    ],
+    "prerequisites": [
+      "Multivariable calculus and the Fréchet derivative",
+      "Taylor's theorem (Wiedijk #35)",
+      "The chain rule for derivatives along curves"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-and-docstring",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Imports Mathlib's Taylor module and tactics. The module docstring states the open question, the line-restriction reduction strategy, and an explicit honest-scope note distinguishing the directional-derivative remainder proved here from the fully symmetric-multilinear / multi-index packaging left as future work.",
+      "mathContext": "Setup for reducing multivariate Taylor to one-dimensional Taylor on the line restriction g(t) = f(a + t·v)."
+    },
+    {
+      "id": "restriction-def",
+      "title": "Section I: The Line Restriction",
+      "startLine": 60,
+      "endLine": 73,
+      "summary": "Defines restriction f a v = (fun t => f (a + t·v)) and its evaluation simp lemmas: restriction_apply, restriction_zero (value f a at t=0) and restriction_one (value f (a+v) at t=1).",
+      "mathContext": "The one-variable function g(t) = f(a + t·v) obtained by restricting f to the line through a in direction v, with endpoints g(0) = f(a) and g(1) = f(a+v)."
+    },
+    {
+      "id": "smoothness-and-derivative",
+      "title": "Section II: Smoothness and the Directional Derivative",
+      "startLine": 75,
+      "endLine": 99,
+      "summary": "Proves line_hasDerivAt (the affine parametrisation t ↦ a + t·v has derivative v), restriction_contDiff (g inherits ContDiff smoothness of f via ContDiff.comp), and restriction_hasDerivAt / restriction_deriv (the first derivative of g is the directional Fréchet derivative Df(a+t·v)(v), via the chain rule).",
+      "mathContext": "The restriction g = f ∘ φ inherits smoothness from f, and g'(t) = Df(a+t·v)(v) by the chain rule along the affine curve φ(t) = a + t·v."
+    },
+    {
+      "id": "multivariate-taylor",
+      "title": "Section III: Multivariate Taylor with Lagrange Remainder",
+      "startLine": 101,
+      "endLine": 134,
+      "summary": "Proves multivariate_taylor_lagrange (degree-n expansion f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)! for some θ ∈ (0,1), by applying Mathlib's taylor_mean_remainder_lagrange_iteratedDeriv to g on [0,1]) and multivariate_taylor_first_order (the n=0 case: f(a+v) = f(a) + Df(a+θ·v)(v), the multivariate mean value theorem in Lagrange form with explicit gradient).",
+      "mathContext": "Multivariate Taylor with Lagrange remainder, and its first-order specialisation, the multivariate mean value theorem f(a+v) = f(a) + Df(a+θ·v)(v) with a + θ·v an interior point of the segment."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization establishes the multivariate Taylor theorem with Lagrange remainder for real-valued functions on a normed space, via the textbook reduction to one-dimensional Taylor on the line restriction g(t) = f(a + t·v). It proves smoothness transfer, the directional-derivative identity g'(t) = Df(a+t·v)(v), the degree-n Lagrange expansion, and the headline first-order multivariate mean value theorem f(a+v) = f(a) + Df(a+θ·v)(v). It answers the first open question under the parent Taylor's theorem (Wiedijk #35); the fully symmetric-multilinear / multi-index packaging of higher-order terms is identified as the remaining future work.",
+    "implications": "**Theoretical Significance**: The line-restriction reduction is the backbone of every proof of multivariate Taylor and of second-order optimality conditions (Hessian tests), so a verified version supplies reusable infrastructure: the directional-derivative identity deriv (restriction f a v) t = Df(a+t·v)(v) is exactly the ingredient needed to iterate toward the full multi-index form. The first-order result is the multivariate mean value theorem, which underlies Lipschitz estimates, the inverse and implicit function theorems, and gradient-based optimisation.",
+    "openQuestions": [
+      "Can the higher-order remainder be rewritten in the fully symmetric-multilinear form D^{n+1} f(a+θ·v)(v,…,v) by proving the bridge iteratedDeriv k (restriction f a v) t = iteratedFDeriv ℝ k f (a+t·v) (fun _ => v) by induction over the chain rule?",
+      "Can the directional second derivative deriv^[2] (restriction f a v) t be expressed via the second Fréchet derivative fderiv (fderiv f) to give an explicit Hessian / second-order Taylor statement f(a+v) = f(a) + Df(a)(v) + ½ D²f(a+θ·v)(v,v)?",
+      "Does the result extend from f : E → ℝ to Banach-space-valued f : E → F using the vector-valued one-dimensional Taylor bound (exists_taylor_mean_remainder_bound) in place of the Lagrange equality?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "taylor-theorem",
+      "relationship": "extends",
+      "description": "Parent entry formalizing the one-dimensional Taylor's theorem (Wiedijk #35) with Lagrange and Cauchy remainder forms. This entry answers its first open question by formalizing the multivariate Taylor theorem via restriction to a line, reusing the one-dimensional Lagrange remainder."
+    },
+    {
+      "targetId": "taylor-theorem-oq-03",
+      "relationship": "related",
+      "description": "Sibling open question specialising the Lagrange remainder to the exponential function to prove convergence of its Taylor series; this entry instead generalises the base point to multiple variables."
+    },
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "related",
+      "description": "The first-order result f(a+v) = f(a) + Df(a+θ·v)(v) is the multivariate analogue of the mean value theorem f(b) - f(a) = f'(ξ)(b-a), obtained here as the n=0 case of multivariate Taylor."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Calculus.Taylor",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Set",
+      "Nat"
+    ],
+    "namespace": "MultivariateTaylor",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/TaylorTheoremOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent *Taylor's theorem* (Wiedijk #35):
> *Can Lean formalize the multivariate Taylor theorem with remainder?*

Formalizes multivariate Taylor with Lagrange remainder for `f : E → ℝ` on a real normed space, via the textbook reduction to one-dimensional Taylor applied to the **line restriction** `g(t) = f(a + t·v)`.

## Results (`proofs/Proofs/TaylorTheoremOQ01.lean`, 9 thm / 1 def / 135 L)

- `restriction_contDiff` — `g` inherits `ContDiff` smoothness of `f` (`ContDiff.comp` with the affine map `t ↦ a + t·v`).
- `restriction_deriv` — first directional derivative: `deriv g t = fderiv ℝ f (a + t·v) v` (chain rule `HasFDerivAt.comp_hasDerivAt`).
- `multivariate_taylor_lagrange` — degree-`n` Lagrange expansion `f(a+v) = T_n g(0) + g^{(n+1)}(θ)/(n+1)!`, `θ ∈ (0,1)`, via Mathlib's `taylor_mean_remainder_lagrange_iteratedDeriv` on `[0,1]`.
- `multivariate_taylor_first_order` — **headline**: `f(a+v) = f(a) + Df(a+θ·v)(v)`, `θ ∈ (0,1)` — the multivariate mean value theorem in Lagrange form with the gradient made explicit.

## Honesty / scope

The higher-order remainder is carried by the **iterated directional derivative** of the restriction (`iteratedDeriv k g`). The fully symmetric-multilinear / multi-index packaging `D^k f(a)(v,…,v)` asked for in the open question is documented as future work (requires the bridge `iteratedDeriv k g t = iteratedFDeriv ℝ k f (a+t·v) (fun _ => v)` by induction). The **first-order** term is given the explicit Fréchet-derivative form, so the headline result is fully multivariate.

## Verification

- Built on host (`lake env lean`); Mathlib 4.26.0.
- 0 sorries. `#print axioms` on both Taylor theorems: only `propext`, `Classical.choice`, `Quot.sound` (none counted) → `status: verified`, `badge: original`, `axiomCount: 0`.
- Gallery: `src/data/proofs/taylor-theorem-oq-01/{meta.json,annotations.json}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)