### PR TITLE
research(dyck-catalan-count-oq-01-oq-01): plane trees are a Catalan family via first-child/next-sibling bijection [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1043,6 +1043,7 @@ import Proofs.DivisibilityTruncationGeneralOQ01OQ01
 import Proofs.DivisibilityTruncationGeneralOQ03
 import Proofs.DivisibilityTruncationGeneralOQ03OQ01
 import Proofs.DyckCatalanCountOQ01
+import Proofs.DyckCatalanCountOQ01OQ01
 import Proofs.ETranscendentalOQ01
 import Proofs.ETranscendentalOQ01OQ01
 import Proofs.ETranscendentalOQ02

--- a/proofs/Proofs/DyckCatalanCountOQ01OQ01.lean
+++ b/proofs/Proofs/DyckCatalanCountOQ01OQ01.lean
@@ -1,0 +1,248 @@
+import Mathlib
+
+/-!
+# Plane trees are a Catalan family: the first-child/next-sibling bijection — OQ01·OQ01
+
+The parent entry (`dyck-catalan-count-oq-01`) records the Mathlib theorem that **Dyck
+words** of semilength `n` are counted by the Catalan number `catalan n`, via Mathlib's
+explicit bijection `DyckWord.equivTree : DyckWord ≃ Tree Unit` with rooted *binary* trees.
+Its first open question asks:
+
+> Enumerate **another** Catalan family not yet counted in Mathlib, and exhibit an
+> *explicit bijection* to Dyck words.
+
+This file answers it with the classic and genuinely distinct family of **plane trees**
+(a.k.a. *ordered rooted trees*): a root together with an **ordered list** of subtrees of
+arbitrary arity.  Mathlib counts *binary* trees (`Tree Unit`), where every node has exactly
+two — possibly empty — children; plane trees are different objects (a node may have any
+number of children, in order), and Mathlib does not count them.
+
+The bridge is the textbook **natural correspondence** between forests of plane trees and
+binary trees (the *first-child / next-sibling*, or *left-child right-sibling*, encoding):
+
+* the **left** child of a binary node holds the encoding of the **children** of the first
+  plane tree of a forest;
+* the **right** child holds the encoding of the **remaining** trees of the forest.
+
+This is not a relabeling of the symbols of a Dyck word — it is a recursive,
+arity-changing bijection.  Composing it with Mathlib's `equivTree` gives an explicit
+bijection from plane forests (and plane trees) to Dyck words, and hence the count.
+
+## Main results
+
+* `PlaneTree` / `PlaneForest` : ordered rooted trees and forests.
+* `PlaneForest.encode` / `Tree.decode` : the natural correspondence, with both round-trips
+  proved (`encode_decode`, `decode_encode`), packaged as `forestEquivTree : PlaneForest ≃
+  Tree Unit`.
+* `forestEquivDyck` / `forestEquivDyckSubtype` : the resulting explicit bijection of plane
+  forests with Dyck words, refined to fixed size / semilength.
+* `card_planeForest_numNodes_eq_catalan` : **plane forests with `n` nodes are counted by
+  `catalan n`.**
+* `card_planeTree_numNodes_eq_catalan` : **plane trees with `n + 1` nodes are counted by
+  `catalan n`** (a plane tree is a root over a forest of `n` nodes).
+* `card_planeForest_eq_card_dyckWord` : the two families literally have the same cardinality
+  at every size.
+
+Everything is over `ℕ`, fully machine-checked, 0 axioms, 0 sorries, no `decide`/
+`native_decide`.
+-/
+
+namespace PlaneTreeCatalan
+
+open scoped Classical
+
+/-- A **plane tree** (ordered rooted tree): a root carrying an *ordered list* of child
+subtrees of arbitrary arity.  This is a nested inductive type; `PlaneForest` below is the
+list of subtrees. -/
+inductive PlaneTree : Type
+  | node : List PlaneTree → PlaneTree
+
+/-- A **plane forest** is an ordered list of plane trees. -/
+abbrev PlaneForest := List PlaneTree
+
+namespace PlaneForest
+
+/-- Number of nodes in a plane forest (the sum of the node counts of its trees; a tree
+`node cs` contributes `1` for its root plus the nodes of its child forest `cs`). -/
+def numNodes : PlaneForest → ℕ
+  | [] => 0
+  | (PlaneTree.node cs) :: rest => 1 + numNodes cs + numNodes rest
+
+/-- The **first-child / next-sibling** encoding of a plane forest as a binary tree.
+The left child of the root holds the encoding of the children of the first plane tree;
+the right child holds the encoding of the remaining trees. -/
+def encode : PlaneForest → Tree Unit
+  | [] => Tree.nil
+  | (PlaneTree.node cs) :: rest => Tree.node () (encode cs) (encode rest)
+
+end PlaneForest
+
+/-- Inverse of `PlaneForest.encode`: decode a binary tree back into a plane forest.
+A `nil` becomes the empty forest; a `node` becomes a forest whose first tree has the
+decoding of the left child as its own children, followed by the decoding of the right
+child. -/
+def Tree.decodeForest : Tree Unit → PlaneForest
+  | Tree.nil => []
+  | Tree.node _ l r => PlaneTree.node (Tree.decodeForest l) :: Tree.decodeForest r
+
+namespace PlaneForest
+
+@[simp] theorem encode_nil : encode [] = Tree.nil := by simp [encode]
+
+@[simp] theorem encode_cons (cs rest : PlaneForest) :
+    encode (PlaneTree.node cs :: rest) = Tree.node () (encode cs) (encode rest) := by
+  simp [encode]
+
+@[simp] theorem decodeForest_nil : Tree.decodeForest Tree.nil = ([] : PlaneForest) := rfl
+
+@[simp] theorem decodeForest_node (a : Unit) (l r : Tree Unit) :
+    Tree.decodeForest (Tree.node a l r) =
+      PlaneTree.node (Tree.decodeForest l) :: Tree.decodeForest r := rfl
+
+/-- `encode` followed by `decodeForest` is the identity on plane forests.  This is the
+left inverse; the recursion descends into both the children of the head tree and the rest
+of the forest, each strictly smaller than the input. -/
+theorem decode_encode : ∀ f : PlaneForest, Tree.decodeForest (encode f) = f
+  | [] => by simp
+  | (PlaneTree.node cs) :: rest => by
+      rw [encode_cons, decodeForest_node, decode_encode cs, decode_encode rest]
+
+/-- `decodeForest` followed by `encode` is the identity on binary trees.  This is the
+right inverse, by structural induction on the tree. -/
+theorem encode_decode : ∀ t : Tree Unit, encode (Tree.decodeForest t) = t
+  | Tree.nil => by simp
+  | Tree.node a l r => by
+      rw [decodeForest_node, encode_cons, encode_decode l, encode_decode r]
+
+/-- The **natural correspondence** as an equivalence: plane forests are in explicit
+bijection with rooted binary trees. -/
+def forestEquivTree : PlaneForest ≃ Tree Unit where
+  toFun := encode
+  invFun := Tree.decodeForest
+  left_inv := decode_encode
+  right_inv := encode_decode
+
+@[simp] theorem forestEquivTree_apply (f : PlaneForest) : forestEquivTree f = encode f := rfl
+
+@[simp] theorem forestEquivTree_symm_apply (t : Tree Unit) :
+    forestEquivTree.symm t = Tree.decodeForest t := rfl
+
+/-- The encoding preserves size: the number of internal nodes of the encoded binary tree
+equals the number of nodes of the plane forest.  (Each plane-tree root becomes one binary
+internal node.) -/
+theorem numNodes_encode : ∀ f : PlaneForest, (encode f).numNodes = numNodes f
+  | [] => by simp [numNodes]
+  | (PlaneTree.node cs) :: rest => by
+      rw [encode_cons, Tree.numNodes, numNodes_encode cs, numNodes_encode rest]
+      simp only [numNodes]
+      ring
+
+end PlaneForest
+
+/-! ## From plane forests to Dyck words
+
+We now chain `forestEquivTree` with Mathlib's `DyckWord.equivTree` to land on Dyck words,
+and refine everything to fixed size. -/
+
+namespace PlaneForest
+
+/-- An explicit bijection between **plane forests** and **Dyck words**, obtained by
+composing the first-child/next-sibling encoding with Mathlib's `DyckWord.equivTree`. -/
+noncomputable def forestEquivDyck : PlaneForest ≃ DyckWord :=
+  forestEquivTree.trans DyckWord.equivTree.symm
+
+/-- Size-refined bijection: plane forests with `n` nodes correspond to binary trees with
+`n` internal nodes. -/
+def forestEquivTreeSubtype (n : ℕ) :
+    { f : PlaneForest // numNodes f = n } ≃ { t : Tree Unit // t.numNodes = n } :=
+  forestEquivTree.subtypeEquiv fun f => by
+    simp [forestEquivTree_apply, numNodes_encode]
+
+/-- Size-refined bijection: plane forests with `n` nodes correspond to Dyck words of
+semilength `n`.  This is the explicit bijection the open question asks for. -/
+noncomputable def forestEquivDyckSubtype (n : ℕ) :
+    { f : PlaneForest // numNodes f = n } ≃ { p : DyckWord // p.semilength = n } :=
+  (forestEquivTreeSubtype n).trans
+    { toFun := fun ⟨t, ht⟩ => ⟨DyckWord.equivTree.symm t, by
+        rw [DyckWord.semilength_eq_numNodes_equivTree, Equiv.apply_symm_apply, ht]⟩
+      invFun := fun ⟨p, hp⟩ => ⟨DyckWord.equivTree p, by
+        rw [← DyckWord.semilength_eq_numNodes_equivTree, hp]⟩
+      left_inv := fun ⟨t, _⟩ => by simp
+      right_inv := fun ⟨p, _⟩ => by simp }
+
+noncomputable instance fintypeNumNodes (n : ℕ) :
+    Fintype { f : PlaneForest // numNodes f = n } :=
+  Fintype.ofEquiv _ (forestEquivDyckSubtype n).symm
+
+/-- **Main count.** Plane forests with `n` nodes are counted by the Catalan number
+`catalan n`. -/
+theorem card_planeForest_numNodes_eq_catalan (n : ℕ) :
+    Fintype.card { f : PlaneForest // numNodes f = n } = catalan n := by
+  rw [Fintype.card_congr (forestEquivDyckSubtype n),
+    DyckWord.card_dyckWord_semilength_eq_catalan]
+
+/-- The plane-forest and Dyck-word families have the same cardinality at every size. -/
+theorem card_planeForest_eq_card_dyckWord (n : ℕ) :
+    Fintype.card { f : PlaneForest // numNodes f = n }
+      = Fintype.card { p : DyckWord // p.semilength = n } :=
+  Fintype.card_congr (forestEquivDyckSubtype n)
+
+end PlaneForest
+
+/-! ## The single-tree version
+
+A plane tree is exactly a root placed over a forest of its children, so plane trees with
+`n + 1` nodes correspond to plane forests with `n` nodes — and hence to `catalan n`. -/
+
+namespace PlaneTree
+
+/-- Number of nodes of a plane tree (`1` for the root plus the nodes of its children). -/
+def numNodes : PlaneTree → ℕ
+  | PlaneTree.node cs => 1 + PlaneForest.numNodes cs
+
+@[simp] theorem numNodes_node (cs : PlaneForest) :
+    (PlaneTree.node cs).numNodes = 1 + PlaneForest.numNodes cs := rfl
+
+/-- The constructor `node : PlaneForest → PlaneTree` is an equivalence: every plane tree is
+the root over a unique forest of children. -/
+def equivForest : PlaneTree ≃ PlaneForest where
+  toFun := fun t => match t with | PlaneTree.node cs => cs
+  invFun := PlaneTree.node
+  left_inv := fun t => by cases t; rfl
+  right_inv := fun _ => rfl
+
+/-- Size-refined: plane trees with `n + 1` nodes correspond to plane forests with `n`
+nodes (delete the root). -/
+def equivForestSubtype (n : ℕ) :
+    { t : PlaneTree // t.numNodes = n + 1 } ≃ { f : PlaneForest // PlaneForest.numNodes f = n } :=
+  equivForest.subtypeEquiv fun t => by
+    cases t with
+    | node cs => simp only [equivForest, numNodes, Equiv.coe_fn_mk]; omega
+
+noncomputable instance fintypeNumNodes (n : ℕ) :
+    Fintype { t : PlaneTree // t.numNodes = n + 1 } :=
+  Fintype.ofEquiv _ (equivForestSubtype n).symm
+
+/-- **Plane-tree count.** Plane trees with `n + 1` nodes are counted by `catalan n`. -/
+theorem card_planeTree_numNodes_eq_catalan (n : ℕ) :
+    Fintype.card { t : PlaneTree // t.numNodes = n + 1 } = catalan n := by
+  rw [Fintype.card_congr (equivForestSubtype n),
+    PlaneForest.card_planeForest_numNodes_eq_catalan]
+
+end PlaneTree
+
+/-! ## Sanity checks (small cases) -/
+
+/-- There is a unique empty plane forest of size `0` (it is `catalan 0 = 1`). -/
+example : Fintype.card { f : PlaneForest // PlaneForest.numNodes f = 0 } = 1 := by
+  rw [PlaneForest.card_planeForest_numNodes_eq_catalan]; exact catalan_zero
+
+/-- Plane forests of size `3` number `catalan 3 = 5`. -/
+example : Fintype.card { f : PlaneForest // PlaneForest.numNodes f = 3 } = 5 := by
+  rw [PlaneForest.card_planeForest_numNodes_eq_catalan]; exact catalan_three
+
+/-- Plane trees with `4` nodes number `catalan 3 = 5`. -/
+example : Fintype.card { t : PlaneTree // t.numNodes = 3 + 1 } = 5 := by
+  rw [PlaneTree.card_planeTree_numNodes_eq_catalan]; exact catalan_three
+
+end PlaneTreeCatalan

--- a/src/data/proofs/dyck-catalan-count-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "dyck-oq0101-ann-header",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 48 },
+    "type": "context",
+    "title": "The open question and why plane trees are a genuinely new family",
+    "content": "The parent entry counts Dyck words and asks for another Catalan family not yet in Mathlib, with an explicit bijection to Dyck words. Plane trees (ordered rooted trees) answer it: a root carrying an ordered list of subtrees of arbitrary arity. This is different from Mathlib's Tree Unit, where every node has exactly two possibly-empty children. The bridge is the first-child/next-sibling correspondence, a recursive arity-changing bijection — not a relabeling of the U/D symbols of a Dyck word.",
+    "mathContext": "$\\mathrm{PlaneTree} = \\mathrm{node}\\,(\\mathrm{List}\\,\\mathrm{PlaneTree})$; plane trees with $n+1$ nodes are counted by $C_n$.",
+    "significance": "context",
+    "relatedConcepts": ["plane trees", "ordered rooted trees", "Catalan family", "binary trees", "Dyck words"],
+    "prerequisites": ["the Catalan numbers", "bijective enumeration"]
+  },
+  {
+    "id": "dyck-oq0101-ann-type",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 78 },
+    "type": "concept",
+    "title": "Plane trees and forests as a nested inductive type",
+    "content": "PlaneTree is defined by node : List PlaneTree → PlaneTree, with PlaneForest := List PlaneTree. numNodes counts nodes (a tree node contributes 1 plus the nodes of its child forest). encode is the first-child/next-sibling encoding into a binary tree: the empty forest becomes nil, and a forest (node cs :: rest) becomes a binary node whose left child encodes the children cs of the first tree and whose right child encodes the remaining forest rest. Because List PlaneTree is a nested inductive, encode and numNodes are well-founded recursions (their defining equations are recovered as the simp lemmas encode_nil/encode_cons rather than holding definitionally).",
+    "mathContext": "$\\mathrm{encode}(\\mathrm{node}\\,cs :: rest) = \\mathrm{node}\\,()\\,(\\mathrm{encode}\\,cs)\\,(\\mathrm{encode}\\,rest)$.",
+    "significance": "key",
+    "relatedConcepts": ["nested inductive types", "well-founded recursion", "left-child right-sibling representation", "node count"],
+    "prerequisites": ["inductive types over List", "recursion and termination in Lean"]
+  },
+  {
+    "id": "dyck-oq0101-ann-bijection",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 140 },
+    "type": "insight",
+    "title": "Both round-trips, and size preservation",
+    "content": "Tree.decodeForest inverts the encoding by structural recursion on the binary tree. decode_encode (left inverse) is proved by recursion that descends into both the children of the head tree and the rest of the forest — each strictly smaller than the input — exactly the two recursive calls that make the nested type behave. encode_decode (right inverse) is a structural induction on the binary tree. Together they give forestEquivTree : PlaneForest ≃ Tree Unit. numNodes_encode shows the encoding is size-preserving: each plane-tree root becomes one binary internal node, so a forest of n nodes maps to a binary tree with numNodes = n. This single statistic alignment is what lets the global bijection refine to every fixed size.",
+    "mathContext": "$\\mathrm{numNodes}(\\mathrm{encode}\\,f) = \\#\\text{nodes}(f)$; $\\mathrm{decode}\\circ\\mathrm{encode}=\\mathrm{id}$, $\\mathrm{encode}\\circ\\mathrm{decode}=\\mathrm{id}$.",
+    "significance": "key",
+    "relatedConcepts": ["bijection", "Equiv", "structural induction", "size-preserving map", "first-child/next-sibling"],
+    "prerequisites": ["building an Equiv from inverse functions", "induction on binary trees"]
+  },
+  {
+    "id": "dyck-oq0101-ann-todyck",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 142, "endLine": 190 },
+    "type": "technique",
+    "title": "Composing to Dyck words and reading off the count",
+    "content": "forestEquivDyck composes forestEquivTree with Mathlib's DyckWord.equivTree.symm to give the explicit plane-forest/Dyck-word bijection the open question asks for. forestEquivTreeSubtype uses Equiv.subtypeEquiv with numNodes_encode to match forests of n nodes with binary trees of n internal nodes; forestEquivDyckSubtype then matches them with Dyck words of semilength n, using semilength_eq_numNodes_equivTree to align the statistics. card_planeForest_numNodes_eq_catalan transports Fintype.card along this equivalence and rewrites with the parent's headline count to conclude catalan n. card_planeForest_eq_card_dyckWord records that the two families literally have equal cardinality at every size.",
+    "mathContext": "$\\#\\{f\\mid\\#\\text{nodes}(f)=n\\} = \\#\\{p\\mid\\mathrm{semilength}\\,p=n\\} = C_n$.",
+    "significance": "key",
+    "relatedConcepts": ["composition of equivalences", "Equiv.subtypeEquiv", "Fintype.card_congr", "transport of counts"],
+    "prerequisites": ["subtype equivalences", "Fintype.card along an Equiv"]
+  },
+  {
+    "id": "dyck-oq0101-ann-tree",
+    "proofId": "dyck-catalan-count-oq-01-oq-01",
+    "range": { "startLine": 192, "endLine": 248 },
+    "type": "concept",
+    "title": "From forests back to a single tree, and sanity checks",
+    "content": "A single plane tree is exactly a root over a forest of its children, so the constructor node gives an equivalence equivForest : PlaneTree ≃ PlaneForest. Since the root adds one node, plane trees with n+1 nodes correspond to plane forests with n nodes (equivForestSubtype), and card_planeTree_numNodes_eq_catalan reads off catalan n. The closing examples check the counts against catalan 0 = 1 (the unique empty forest) and catalan 3 = 5 (five plane forests of 3 nodes; five plane trees of 4 nodes), using catalan_zero/catalan_three rather than decide.",
+    "mathContext": "$\\#\\{t\\mid\\#\\text{nodes}(t)=n+1\\}=C_n$; $C_0=1$, $C_3=5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructor equivalence", "root deletion", "small-case verification", "Catalan numbers"],
+    "prerequisites": ["equivalences from constructors", "Fintype.card"]
+  }
+]

--- a/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dyck-catalan-count-oq-01-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "dyck-catalan-count-oq-01-oq-01",
+  "title": "Plane Trees Are a Catalan Family: the First-Child/Next-Sibling Bijection",
+  "slug": "dyck-catalan-count-oq-01-oq-01",
+  "description": "Answers the parent entry's first open question — 'enumerate another Catalan family not yet counted in Mathlib and exhibit an explicit bijection to Dyck words' — with plane trees (ordered rooted trees), the classic Catalan family distinct from the binary trees Mathlib already counts. A plane tree is a root carrying an ordered list of subtrees of arbitrary arity (PlaneTree := node : List PlaneTree → PlaneTree); Mathlib's Tree Unit instead has exactly two possibly-empty children per node, and does not count plane trees. The bridge is the textbook natural correspondence between forests of plane trees and binary trees (first-child / next-sibling, a.k.a. left-child right-sibling): the left child of a binary node holds the encoding of the first plane tree's children, the right child holds the encoding of the remaining forest. This is a genuine arity-changing recursive bijection, not a relabeling of the U/D symbols of a Dyck word. Both round-trips are proved (decode_encode, encode_decode), packaged as forestEquivTree : PlaneForest ≃ Tree Unit; composing with Mathlib's DyckWord.equivTree gives an explicit bijection of plane forests with Dyck words, refined to fixed size, yielding card_planeForest_numNodes_eq_catalan (plane forests with n nodes are counted by catalan n) and card_planeTree_numNodes_eq_catalan (plane trees with n+1 nodes are counted by catalan n). Fully verified, 0 axioms, 0 sorries, no decide/native_decide on the main results.",
+  "meta": {
+    "author": "Classical correspondence (Knuth, the natural bijection forests ↔ binary trees); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Catalan_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "plane-trees",
+      "ordered-trees",
+      "bijective-combinatorics",
+      "enumerative-combinatorics",
+      "dyck-words",
+      "binary-trees",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DyckCatalanCountOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "DyckWord.equivTree",
+        "description": "The explicit equivalence DyckWord ≃ Tree Unit between Dyck words and rooted binary trees. Composed with the new plane-forest/binary-tree bijection to land plane forests on Dyck words.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "DyckWord.semilength_eq_numNodes_equivTree",
+        "description": "p.semilength = (equivTree p).numNodes. Identifies the size statistic across the bijection, so that plane forests with n nodes match Dyck words of semilength n.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "DyckWord.card_dyckWord_semilength_eq_catalan",
+        "description": "Fintype.card { p : DyckWord // p.semilength = n } = catalan n, the parent entry's headline count, transported across the bijection to count plane forests and plane trees.",
+        "module": "Mathlib.Combinatorics.Enumerative.DyckWord"
+      },
+      {
+        "theorem": "Tree.numNodes",
+        "description": "Number of internal nodes of a binary tree. The encoding sends a plane forest of n nodes to a binary tree with numNodes = n (numNodes_encode), aligning the size gradings.",
+        "module": "Mathlib.Data.Tree.Basic"
+      },
+      {
+        "theorem": "Equiv.subtypeEquiv",
+        "description": "Refines a global equivalence to subtypes cut out by a pointwise-equivalent predicate; used to pass from the bijection of all forests/trees to the fixed-size bijections.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "Transports a finite cardinality along an equivalence; turns the explicit plane-forest/Dyck-word bijection into the count card = catalan n.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "catalan_three",
+        "description": "catalan 3 = 5, used (with catalan_zero) for the small-case sanity checks on the plane-forest and plane-tree counts.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      }
+    ],
+    "originalContributions": [
+      "PlaneTree / PlaneForest: ordered rooted trees and forests as a nested inductive type, a Catalan family Mathlib does not have (Mathlib counts only binary Tree Unit)",
+      "PlaneForest.encode and Tree.decodeForest: the first-child/next-sibling (left-child right-sibling) natural correspondence between plane forests and binary trees, with both inverse laws proved (decode_encode by recursion descending into both a head tree's children and the rest of the forest; encode_decode by structural induction on the binary tree), packaged as forestEquivTree : PlaneForest ≃ Tree Unit",
+      "numNodes_encode: the encoding is size-preserving — the binary tree has as many internal nodes as the forest has nodes — so the bijection refines to each fixed size",
+      "forestEquivDyck and forestEquivDyckSubtype: the explicit bijection of plane forests with Dyck words requested by the open question, obtained by composing forestEquivTree with Mathlib's DyckWord.equivTree, refined to plane forests of n nodes ↔ Dyck words of semilength n",
+      "card_planeForest_numNodes_eq_catalan: plane forests with n nodes are counted by catalan n; card_planeForest_eq_card_dyckWord records that the two families have equal cardinality at every size",
+      "card_planeTree_numNodes_eq_catalan: plane trees with n+1 nodes are counted by catalan n, via the constructor equivalence PlaneTree ≃ PlaneForest (a tree is a root over its forest of children)"
+    ],
+    "dateAdded": "2026-06-24",
+    "prerequisites": [
+      "Nested inductive types and recursion over List in Lean 4",
+      "Mathlib's binary trees Tree Unit, their numNodes, and the Dyck-word/binary-tree equivalence DyckWord.equivTree",
+      "Building equivalences (Equiv), refining them to subtypes, and transporting Fintype.card along them",
+      "The Catalan numbers and the notion of a Catalan family / bijective enumeration"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Plane-Tree Type",
+      "startLine": 1,
+      "endLine": 78,
+      "summary": "Module docstring stating the open question and the answer (plane trees as a distinct Catalan family, bridged by the first-child/next-sibling correspondence), followed by the nested inductive PlaneTree, the abbreviation PlaneForest := List PlaneTree, the node count PlaneForest.numNodes, and the encoding PlaneForest.encode into binary trees.",
+      "mathContext": "A plane tree is a root over an ordered list of subtrees; $\\mathrm{PlaneTree} = \\mathrm{node}\\,(\\mathrm{List}\\,\\mathrm{PlaneTree})$."
+    },
+    {
+      "id": "bijection",
+      "title": "The Natural Correspondence as an Equivalence",
+      "startLine": 84,
+      "endLine": 140,
+      "summary": "Tree.decodeForest (the inverse decoding), the simp equation lemmas, and the two round-trip proofs decode_encode and encode_decode, packaged as forestEquivTree : PlaneForest ≃ Tree Unit; numNodes_encode shows the encoding preserves the size statistic (forest nodes ↔ binary internal nodes).",
+      "mathContext": "$\\mathrm{decode}\\circ\\mathrm{encode}=\\mathrm{id}$ and $\\mathrm{encode}\\circ\\mathrm{decode}=\\mathrm{id}$; $\\#\\text{nodes}(f)=\\mathrm{numNodes}(\\mathrm{encode}\\,f)$."
+    },
+    {
+      "id": "to-dyck",
+      "title": "From Plane Forests to Dyck Words, and the Count",
+      "startLine": 142,
+      "endLine": 190,
+      "summary": "forestEquivDyck composes forestEquivTree with Mathlib's DyckWord.equivTree; forestEquivTreeSubtype and forestEquivDyckSubtype refine to fixed size; card_planeForest_numNodes_eq_catalan concludes the count, and card_planeForest_eq_card_dyckWord records equal cardinalities at every size.",
+      "mathContext": "$\\#\\{f\\mid \\#\\text{nodes}(f)=n\\}=\\#\\{p:\\mathrm{DyckWord}\\mid\\mathrm{semilength}\\,p=n\\}=C_n$."
+    },
+    {
+      "id": "single-tree",
+      "title": "The Single-Tree Version",
+      "startLine": 192,
+      "endLine": 232,
+      "summary": "PlaneTree.numNodes; the constructor equivalence equivForest : PlaneTree ≃ PlaneForest (delete the root); its size refinement equivForestSubtype; and card_planeTree_numNodes_eq_catalan: plane trees with n+1 nodes number catalan n.",
+      "mathContext": "$\\#\\{t:\\mathrm{PlaneTree}\\mid \\#\\text{nodes}(t)=n+1\\}=C_n$."
+    },
+    {
+      "id": "sanity",
+      "title": "Small-Case Sanity Checks",
+      "startLine": 234,
+      "endLine": 248,
+      "summary": "Cardinalities at sizes 0 and 3 verified against catalan 0 = 1 and catalan 3 = 5 (via catalan_zero / catalan_three, no decide on the headline results).",
+      "mathContext": "$C_0=1$, $C_3=5$: one empty forest; five plane forests of 3 nodes; five plane trees of 4 nodes."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "dyck-catalan-count-oq-01",
+      "relationship": "Parent entry: counts Dyck words of semilength n by catalan n and poses the open question this entry answers; supplies the Dyck-word side of the bijection."
+    },
+    {
+      "id": "catalan-numbers-oq-01",
+      "relationship": "Companion Catalan entry on the arithmetic linear recurrence of the abstract sequence; disjoint from this entry's bijective enumeration of a new Catalan family."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms) proof that plane trees (ordered rooted trees) are a Catalan family, via an explicit arity-changing bijection — the first-child/next-sibling correspondence between plane forests and binary trees — composed with Mathlib's Dyck-word/binary-tree equivalence. Plane forests with n nodes, and plane trees with n+1 nodes, are each counted by catalan n.",
+    "implications": "Adds a genuinely new Catalan object to the Lean gallery (Mathlib counts only binary trees and Dyck words) with a reusable forest↔binary-tree equivalence, and demonstrates the standard technique of counting a new combinatorial family by an explicit bijection to an already-counted one rather than re-deriving a closed form.",
+    "openQuestions": [
+      "Count a non-tree Catalan family with an explicit bijection — e.g. triangulations of a convex polygon or noncrossing partitions of [n] — chaining through this plane-tree equivalence or directly to Dyck words.",
+      "Refine the bijection to track a finer statistic (e.g. number of leaves / root degree of the plane tree against the corresponding Dyck-word statistic) to obtain a Narayana-number refinement of the count."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "PlaneTreeCatalan",
+    "lineCount": 248,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 6,
+    "path": "Proofs/DyckCatalanCountOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press",
+      "note": "Catalogue of Catalan objects; plane (ordered) trees and their bijection with binary trees and Dyck paths are standard entries."
+    },
+    {
+      "authors": "Donald E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 1: Fundamental Algorithms",
+      "year": "1997",
+      "venue": "Addison-Wesley",
+      "note": "The natural correspondence between forests and binary trees (left-child/right-sibling representation) formalized here."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.DyckWord and Mathlib.Data.Tree.Basic",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the binary trees Tree Unit, their numNodes, and the Dyck-word/binary-tree equivalence DyckWord.equivTree composed with here."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent gallery entry `dyck-catalan-count-oq-01` ("Dyck Words Are Counted by the Catalan Numbers"):

> Enumerate another Catalan family not yet counted in Mathlib, and exhibit an explicit bijection to Dyck words.

The new family is **plane trees** (ordered rooted trees): `inductive PlaneTree | node : List PlaneTree → PlaneTree`. These are genuinely distinct from Mathlib's binary `Tree Unit` (where every node has exactly two possibly-empty children); Mathlib does not count plane trees.

The bridge is the textbook **first-child / next-sibling** (left-child right-sibling) natural correspondence between *forests* of plane trees and binary trees — a recursive, arity-changing bijection, **not** a relabeling of the `U`/`D` symbols of a Dyck word:
- the left child of a binary node holds the encoding of the first plane tree's children;
- the right child holds the encoding of the remaining forest.

Composing it with Mathlib's `DyckWord.equivTree` gives the explicit bijection to Dyck words and hence the count.

## Main results

- `forestEquivTree : PlaneForest ≃ Tree Unit` — the correspondence, with **both** round-trips proved (`decode_encode`, `encode_decode`).
- `numNodes_encode` — the encoding is size-preserving, so the bijection refines to every fixed size.
- `forestEquivDyck` / `forestEquivDyckSubtype` — plane forests of `n` nodes ≃ Dyck words of semilength `n`.
- `card_planeForest_numNodes_eq_catalan` — **plane forests with `n` nodes are counted by `catalan n`.**
- `card_planeTree_numNodes_eq_catalan` — **plane trees with `n + 1` nodes are counted by `catalan n`** (a tree is a root over its forest of children).

## Verification

- Compiles against Mathlib (Lean 4, `v4.26.0`) via `lake env lean`.
- `#print axioms` on the main theorems and `forestEquivDyck`: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- **0 axioms, 0 sorries**, no `decide`/`native_decide` on the headline results.
- 7 theorems, 6 definitions, 248 lines.

Gallery entry: `src/data/proofs/dyck-catalan-count-oq-01-oq-01/` (`meta.json` + `annotations.json`), status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)