### PR TITLE
research(pythagorean-triples-oq-06-oq-01-oq-01): pin prime factor locations in primitive triples [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3718,6 +3718,7 @@ import Proofs.PythagoreanTriplesOQ05
 import Proofs.PythagoreanTriplesOQ06
 import Proofs.PythagoreanTriplesOQ06OQ01
 import Proofs.PythagoreanTriplesOQ06OQ01OQ01
+import Proofs.PythagoreanTriplesOQ06OQ01OQ01OQ01
 import Proofs.PythagoreanTriplesOQ06OQ01OQ01OQ02
 import Proofs.PythagoreanTriplesOQ07
 import Proofs.PythagoreanTriplesOQ08

--- a/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ06OQ01OQ01OQ01.lean
@@ -1,0 +1,181 @@
+import Mathlib
+
+/-!
+# Pinning the location of prime factors in primitive Pythagorean triples
+
+A **Pythagorean triple** is `(x, y, z)` with `x² + y² = z²`, and it is **primitive** when the
+two legs are coprime (`IsCoprime x y`).  The parent entry
+`pythagorean-triples-oq-06-oq-01-oq-01` (`PythagoreanTriples60`) proves the divisibility
+*package* `60 ∣ x·y·z`: each of the primes `3`, `5` and the factor `4` divides *some* side.  Its
+recorded open question `pythagorean-triples-oq-06-oq-01-oq-01-oq-01` asks to *pin the location*
+of these factors for primitive triples:
+
+> *Prove that `3` and `5` never divide the hypotenuse `z` (so the obstruction always falls on a
+> leg), and that the even leg is divisible by `4`.*
+
+## Honest correction to the open question
+
+The claim is **only half true**, and this file proves the correct sharp statement together with
+the counterexample to the false half:
+
+* **`3` never divides `z`** (`three_not_dvd_hyp`) — TRUE. Hence `3` always lands on a leg
+  (`three_dvd_leg`).
+* **The even leg is divisible by `4`** (`four_dvd_even_leg`) — TRUE.
+* **`5` *can* divide `z`** (`five_can_divide_hyp`) — the symmetric claim for `5` is FALSE:
+  `(3, 4, 5)` is a primitive triple with `5 ∣ z`. So `5` is **not** pinned to a leg.
+
+This `3`-versus-`5` asymmetry is not an accident: a prime `p` can be a hypotenuse exactly when
+`p` is a sum of two squares, i.e. `p ≡ 1 (mod 4)`.  Here `5 = 1² + 2²` is the hypotenuse of
+`(3,4,5)`, whereas `3 ≡ 3 (mod 4)` is not a sum of two squares and so can never be a hypotenuse.
+The naive expectation behind the open question — that "an odd prime divisor of `xyz` is forced
+onto a leg" — holds for `3` but fails for `5`.
+
+## Method
+
+`3 ∤ z`: if `3 ∣ z` then over `ZMod 3` the relation reads `x² + y² = 0`, and a finite check
+(`decide`) shows this forces `x ≡ y ≡ 0`, so `3 ∣ x` and `3 ∣ y`, contradicting coprimality
+(`IsCoprime.isUnit_of_dvd'`, since `3` is not a unit).
+
+`4 ∣ even leg`: if a leg `x` is even then the other leg `y` and the hypotenuse `z` are odd.
+Odd squares are `1 (mod 8)`, so `x² = z² − y² ≡ 0 (mod 8)`; a finite check over `ZMod 8`
+(carrying the two oddness conditions as residues mod `2`) certifies `x ≡ 0 (mod 4)`.
+
+Everything is `0`-axiom: `decide` over small `ZMod`s plus elementary divisibility.
+-/
+
+namespace PythagoreanPrimeLocation
+
+/-- Transport an integer Pythagorean relation `x²+y²=z²` to `ZMod n`. -/
+theorem zmod_rel (n : ℕ) {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) :
+    (x : ZMod n) ^ 2 + (y : ZMod n) ^ 2 = (z : ZMod n) ^ 2 := by
+  exact_mod_cast congrArg (fun t : ℤ => (t : ZMod n)) h
+
+/-! ### `3` is pinned to a leg -/
+
+/-- **`3` never divides the hypotenuse of a primitive triple.**  If `3 ∣ z` then `x²+y²≡0`
+modulo `3`, forcing `3 ∣ x` and `3 ∣ y`, contradicting `IsCoprime x y`. -/
+theorem three_not_dvd_hyp {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) (hcop : IsCoprime x y) :
+    ¬ (3 : ℤ) ∣ z := by
+  intro hz
+  -- Over `ZMod 3`, the relation collapses to `x² + y² = 0`, whence `x ≡ y ≡ 0`.
+  have hz0 : (z : ZMod 3) = 0 := by
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd]; exact_mod_cast hz
+  have hrel := zmod_rel 3 h
+  rw [hz0] at hrel
+  -- finite check: in `ZMod 3`, `a²+b²=0 → a=0 ∧ b=0`.
+  have key : ∀ a b : ZMod 3, a ^ 2 + b ^ 2 = 0 → a = 0 ∧ b = 0 := by decide
+  obtain ⟨hx0, hy0⟩ := key _ _ (by rw [hrel]; ring)
+  have hdx : (3 : ℤ) ∣ x := by
+    exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd x 3).1 hx0
+  have hdy : (3 : ℤ) ∣ y := by
+    exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd y 3).1 hy0
+  -- `3` divides both coprime legs, so `3` is a unit — false.
+  have : IsUnit (3 : ℤ) := hcop.isUnit_of_dvd' hdx hdy
+  rw [Int.isUnit_iff] at this
+  omega
+
+/-- **`3` divides one of the legs.**  Combining `3 ∣ xyz` (the parent obstruction) with
+`3 ∤ z`, primality of `3` forces `3` onto a leg. -/
+theorem three_dvd_leg {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) (hcop : IsCoprime x y) :
+    (3 : ℤ) ∣ x ∨ (3 : ℤ) ∣ y := by
+  -- `3 ∣ xyz` via the same `ZMod 3` obstruction as the parent entry.
+  have hprod : (3 : ℤ) ∣ x * y * z := by
+    have hzero : ((x * y * z : ℤ) : ZMod 3) = 0 := by
+      have key : ∀ a b c : ZMod 3, a ^ 2 + b ^ 2 = c ^ 2 → a * b * c = 0 := by decide
+      push_cast; exact key _ _ _ (zmod_rel 3 h)
+    exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ 3).1 hzero
+  have hp : Prime (3 : ℤ) := by norm_num
+  have hnz : ¬ (3 : ℤ) ∣ z := three_not_dvd_hyp h hcop
+  -- `3 ∣ x*y*z`, `3 ∤ z`, so `3 ∣ x*y`, so `3 ∣ x` or `3 ∣ y`.
+  rcases (hp.dvd_mul.mp hprod) with hxy | hz
+  · exact hp.dvd_mul.mp hxy
+  · exact absurd hz hnz
+
+/-! ### The even leg is divisible by `4` -/
+
+/-- Finite certificate over `ZMod 8`: for any solution of `a²+b²=c²` with `b` and `c` odd
+(non-zero modulo `2`), the leg `a` reduces to `0` modulo `4`. -/
+theorem four_dvd_even_leg_aux : ∀ a b c : ZMod 8, a ^ 2 + b ^ 2 = c ^ 2 →
+    (ZMod.castHom (show (2 : ℕ) ∣ 8 by norm_num) (ZMod 2)) b ≠ 0 →
+    (ZMod.castHom (show (2 : ℕ) ∣ 8 by norm_num) (ZMod 2)) c ≠ 0 →
+    (ZMod.castHom (show (4 : ℕ) ∣ 8 by norm_num) (ZMod 4)) a = 0 := by decide
+
+/-- **The even leg is divisible by `4`.**  In a primitive triple, if a leg `x` is even then the
+other leg and the hypotenuse are odd; odd squares are `1 (mod 8)`, forcing `x ≡ 0 (mod 4)`. -/
+theorem four_dvd_even_leg {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) (hcop : IsCoprime x y)
+    (hx : (2 : ℤ) ∣ x) : (4 : ℤ) ∣ x := by
+  -- The other leg `y` is odd: otherwise `2 ∣ x` and `2 ∣ y` make `2` a unit.
+  have hy : ¬ (2 : ℤ) ∣ y := by
+    intro hy
+    have : IsUnit (2 : ℤ) := hcop.isUnit_of_dvd' hx hy
+    rw [Int.isUnit_iff] at this; omega
+  -- The hypotenuse `z` is odd: `2 ∣ z → 2 ∣ z² = x²+y² → 2 ∣ y²` (as `2 ∣ x²`) → `2 ∣ y`.
+  have hz : ¬ (2 : ℤ) ∣ z := by
+    intro hz
+    apply hy
+    have h2z : (2 : ℤ) ∣ z ^ 2 := Dvd.dvd.pow hz (by norm_num)
+    have h2x : (2 : ℤ) ∣ x ^ 2 := Dvd.dvd.pow hx (by norm_num)
+    have h2y2 : (2 : ℤ) ∣ y ^ 2 := by
+      have : y ^ 2 = z ^ 2 - x ^ 2 := by linarith
+      rw [this]; exact dvd_sub h2z h2x
+    exact (Prime.dvd_of_dvd_pow Int.prime_two h2y2)
+  -- Push the two oddness facts into `ZMod 2` residues of the `ZMod 8` casts.
+  have cast2 : ∀ w : ℤ, (ZMod.castHom (show (2 : ℕ) ∣ 8 by norm_num) (ZMod 2)) (w : ZMod 8)
+      = (w : ZMod 2) := fun w => map_intCast _ w
+  have hb : (ZMod.castHom (show (2 : ℕ) ∣ 8 by norm_num) (ZMod 2)) (y : ZMod 8) ≠ 0 := by
+    rw [cast2]; rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact_mod_cast hy
+  have hc : (ZMod.castHom (show (2 : ℕ) ∣ 8 by norm_num) (ZMod 2)) (z : ZMod 8) ≠ 0 := by
+    rw [cast2]; rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact_mod_cast hz
+  -- The certificate gives `x ≡ 0 (mod 4)`.
+  have h8 := four_dvd_even_leg_aux _ _ _ (zmod_rel 8 h) hb hc
+  rw [map_intCast] at h8
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ 4).1 h8
+
+/-! ### The `5`-asymmetry: the false half of the open question, with counterexample -/
+
+/-- **`5` can divide the hypotenuse.**  The primitive triple `(3, 4, 5)` has `5 ∣ z`, so unlike
+`3`, the prime `5` is *not* pinned to a leg.  This refutes the symmetric form of the open
+question.  Structurally, `5 ≡ 1 (mod 4)` is a sum of two squares (`5 = 1²+2²`) and hence can be a
+hypotenuse, whereas `3 ≡ 3 (mod 4)` cannot. -/
+theorem five_can_divide_hyp :
+    ∃ x y z : ℤ, x ^ 2 + y ^ 2 = z ^ 2 ∧ IsCoprime x y ∧ (5 : ℤ) ∣ z :=
+  ⟨3, 4, 5, by norm_num, by rw [Int.isCoprime_iff_gcd_eq_one]; decide, by norm_num⟩
+
+/-- For contrast, `5` still divides *some* side of every triple (the parent obstruction),
+but as `five_can_divide_hyp` shows that side may be the hypotenuse. -/
+theorem five_dvd_prod {x y z : ℤ} (h : x ^ 2 + y ^ 2 = z ^ 2) : (5 : ℤ) ∣ x * y * z := by
+  have hzero : ((x * y * z : ℤ) : ZMod 5) = 0 := by
+    have key : ∀ a b c : ZMod 5, a ^ 2 + b ^ 2 = c ^ 2 → a * b * c = 0 := by decide
+    push_cast; exact key _ _ _ (zmod_rel 5 h)
+  exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ 5).1 hzero
+
+/-! ### Concrete instances -/
+
+/-- `(3,4,5)` is primitive, `3 ∤ 5`, the even leg `4` is divisible by `4`, and `5 ∣ 5`. -/
+theorem example_3_4_5 :
+    ¬ (3 : ℤ) ∣ 5 ∧ (4 : ℤ) ∣ 4 ∧ (5 : ℤ) ∣ 5 := by
+  refine ⟨?_, ?_, ?_⟩
+  · exact three_not_dvd_hyp (x := 3) (y := 4) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide)
+  · exact four_dvd_even_leg (x := 4) (y := 3) (z := 5) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide) (by norm_num)
+  · norm_num
+
+/-- `(5,12,13)`: here `5` lands on a *leg* and `3 ∤ 13`, with even leg `12` divisible by `4`. -/
+theorem example_5_12_13 : ¬ (3 : ℤ) ∣ 13 ∧ (4 : ℤ) ∣ 12 := by
+  refine ⟨?_, ?_⟩
+  · exact three_not_dvd_hyp (x := 5) (y := 12) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide)
+  · exact four_dvd_even_leg (x := 12) (y := 5) (z := 13) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide) (by norm_num)
+
+/-- `(7,24,25)`: another primitive triple with `5 ∣ z` (`25`), reinforcing that `5` is not
+pinned to a leg, while `3 ∤ 25` and `4 ∣ 24`. -/
+theorem example_7_24_25 : (5 : ℤ) ∣ 25 ∧ ¬ (3 : ℤ) ∣ 25 ∧ (4 : ℤ) ∣ 24 := by
+  refine ⟨by norm_num, ?_, ?_⟩
+  · exact three_not_dvd_hyp (x := 7) (y := 24) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide)
+  · exact four_dvd_even_leg (x := 24) (y := 7) (z := 25) (by norm_num)
+      (by rw [Int.isCoprime_iff_gcd_eq_one]; decide) (by norm_num)
+
+end PythagoreanPrimeLocation

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-pythloc-overview",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "context",
+    "title": "Pinning Prime Factors — and an Honest Correction",
+    "content": "The parent entry proves 60 ∣ xyz for every Pythagorean triple; its first open question asks to pin the LOCATION of the factors for primitive triples — claiming 3 and 5 never divide the hypotenuse z and the even leg is divisible by 4. This docstring states up front that the question is only half true. The claim for 3 is correct (three_not_dvd_hyp), and 4 ∣ even leg is correct (four_dvd_even_leg), but the claim for 5 is FALSE: (3,4,5) is a primitive triple with 5 ∣ z. The structural reason is recorded: a prime is a Pythagorean hypotenuse exactly when it is a sum of two squares, i.e. p ≡ 1 (mod 4). Here 5 = 1²+2² ≡ 1 (mod 4) can be a hypotenuse, while 3 ≡ 3 (mod 4) cannot. Reporting only the true half would misstate the mathematics; the honest deliverable is the 3-vs-5 dichotomy.",
+    "mathContext": "Primitive triple $x^2+y^2=z^2$, $\\gcd(x,y)=1$: $3\\nmid z$, $4\\mid$ even leg, but $5\\mid z$ is possible since $5\\equiv 1\\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["primitive Pythagorean triples", "sum of two squares", "Fermat p ≡ 1 mod 4", "location of prime factors"],
+    "prerequisites": ["coprime integer solutions of x²+y²=z²", "quadratic residues mod 4"]
+  },
+  {
+    "id": "ann-pythloc-zmod-rel",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 54 },
+    "type": "technique",
+    "title": "Transporting the Relation to ZMod n",
+    "content": "`zmod_rel` casts the integer relation x²+y²=z² into ZMod n via the canonical ring homomorphism, which commutes with addition and squaring (exact_mod_cast applied to congrArg). This single bridge feeds every subsequent finite check: the ZMod 3 collapse for the 3-obstruction and the ZMod 8 certificate for the even leg.",
+    "mathContext": "$x^2+y^2=z^2 \\text{ in } \\mathbb{Z} \\Rightarrow \\bar x^2+\\bar y^2=\\bar z^2 \\text{ in } \\mathbb{Z}/n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring homomorphism", "reduction mod n", "integer casts into ZMod"],
+    "prerequisites": ["ZMod ring structure"]
+  },
+  {
+    "id": "ann-pythloc-three",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 96 },
+    "type": "concept",
+    "title": "3 Is Pinned to a Leg (a Coprimality Obstruction)",
+    "content": "`three_not_dvd_hyp` is the heart of the true half. Suppose 3 ∣ z. Over ZMod 3 the relation becomes x²+y²=0, and a finite `decide` over the 9 pairs shows the only solution is x ≡ y ≡ 0 — because the nonzero squares mod 3 are just {1} and 1+1=2≠0, so a sum of two squares vanishes only when both vanish (this is exactly 3 ≡ 3 mod 4 not being a sum of two nonzero squares). Then 3 divides both legs, so IsCoprime.isUnit_of_dvd' makes 3 a unit in ℤ — refuted by Int.isUnit_iff (a unit is ±1). Note this genuinely uses primitivity, unlike the parent's product obstruction 3 ∣ xyz which holds for all triples. `three_dvd_leg` then combines 3 ∣ xyz (re-derived by the same ZMod 3 check as the parent), 3 ∤ z, and primality of 3 (Prime.dvd_mul) to place 3 on a leg.",
+    "mathContext": "$3\\mid z \\Rightarrow x^2+y^2\\equiv 0 \\Rightarrow 3\\mid x \\wedge 3\\mid y$, contradicting $\\gcd(x,y)=1$. Hence $3\\mid x$ or $3\\mid y$.",
+    "significance": "key",
+    "relatedConcepts": ["IsCoprime.isUnit_of_dvd'", "quadratic residues mod 3", "Prime.dvd_mul", "decide tactic"],
+    "prerequisites": ["coprimality and units in ℤ", "squares modulo 3"]
+  },
+  {
+    "id": "ann-pythloc-four",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 138 },
+    "type": "technique",
+    "title": "The Even Leg Is Divisible by 4 (a ZMod 8 Certificate Carrying Parity)",
+    "content": "Like the parent's 4-obstruction, this needs modulus 8 — '4 ∣ even leg' is invisible mod 4. `four_dvd_even_leg_aux` is the certificate: for every a²+b²=c² over ZMod 8 with b and c odd (nonzero images under the ring map ZMod 8 → ZMod 2), the leg a maps to 0 under ZMod 8 → ZMod 4; `decide` verifies all 8³ cases. The wrapper `four_dvd_even_leg` supplies the parity hypotheses from primitivity: if leg x is even then the other leg y is odd (else 2 divides both legs, a unit), and the hypotenuse z is odd (2 ∣ z would force 2 ∣ y² hence 2 ∣ y). These two oddness facts are pushed into ZMod 8 through map_intCast (a ring hom commutes with intCast), so the certificate applies and yields 4 ∣ x. The mathematical content: odd squares are 1 mod 8, so x² = z² − y² ≡ 0 mod 8, and an even x with x² ≡ 0 mod 8 must be ≡ 0 mod 4.",
+    "mathContext": "Odd $\\Rightarrow$ square $\\equiv 1\\pmod 8$; $x^2=z^2-y^2\\equiv 0\\pmod 8$ with $x$ even $\\Rightarrow 4\\mid x$. Carried through $\\mathbb{Z}/8\\to\\mathbb{Z}/2$ and $\\mathbb{Z}/8\\to\\mathbb{Z}/4$.",
+    "significance": "key",
+    "relatedConcepts": ["2-adic valuation", "ZMod.castHom", "map_intCast", "odd squares mod 8", "decide tactic"],
+    "prerequisites": ["squares modulo 8", "ring homomorphisms between ZMod rings"]
+  },
+  {
+    "id": "ann-pythloc-five",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 140, "endLine": 153 },
+    "type": "insight",
+    "title": "The 5-Asymmetry: Counterexample to the Open Question",
+    "content": "`five_can_divide_hyp` is the false-half correction: it exhibits the primitive triple (3,4,5) — with IsCoprime 3 4 proved via Int.isCoprime_iff_gcd_eq_one and decide — having 5 ∣ z. So unlike 3, the prime 5 is NOT pinned to a leg. `five_dvd_prod` keeps the inherited fact that 5 divides some side of every triple (a ZMod 5 obstruction identical to the parent's), but the counterexample shows that side may be the hypotenuse. The asymmetry is not accidental: 5 ≡ 1 (mod 4) is a sum of two squares (5 = 1²+2²) and thus a permissible Pythagorean hypotenuse, whereas 3 ≡ 3 (mod 4) is not — this is the Fermat two-squares phenomenon controlling factor location.",
+    "mathContext": "$(3,4,5)$ primitive with $5\\mid 5$; $5=1^2+2^2\\equiv 1\\pmod 4$ is a hypotenuse, $3\\equiv 3\\pmod 4$ is not.",
+    "significance": "key",
+    "relatedConcepts": ["sum of two squares theorem", "Fermat p ≡ 1 mod 4", "counterexample", "Int.isCoprime_iff_gcd_eq_one"],
+    "prerequisites": ["primitive triples", "primes as sums of two squares"]
+  },
+  {
+    "id": "ann-pythloc-instances",
+    "proofId": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+    "range": { "startLine": 155, "endLine": 181 },
+    "type": "concept",
+    "title": "Concrete Instances",
+    "content": "Three worked triples exercise both the rule and the asymmetry. (3,4,5): 3 ∤ 5, even leg 4 divisible by 4, and 5 ∣ 5 (5 on the hypotenuse). (5,12,13): here 5 sits on the leg, 3 ∤ 13, even leg 12 divisible by 4 — showing 5 can also land on a leg. (7,24,25): another case with 5 ∣ z (=25), reinforcing that the hypotenuse position for 5 is common, while 3 ∤ 25 and 4 ∣ 24. Each is discharged through the general theorems with explicitly supplied generators, so the instances are genuine applications rather than standalone computations.",
+    "mathContext": "$(3,4,5),(5,12,13),(7,24,25)$: $3\\nmid z$ and $4\\mid$ even leg always; $5\\mid z$ for the first and third, $5\\mid$ leg for the second.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "Euclid's parametrization"],
+    "prerequisites": ["the general theorems above"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-06-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+  "slug": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01",
+  "title": "Pinning prime factors in primitive Pythagorean triples: 3 avoids the hypotenuse, 5 need not",
+  "description": "For primitive Pythagorean triples x²+y²=z², the prime 3 never divides the hypotenuse z (so 3 always lands on a leg) and the even leg is divisible by 4. The symmetric claim for 5 is FALSE: (3,4,5) is primitive with 5∣z. This entry proves the true half of the parent's open question and supplies the counterexample to the false half, exposing a structural 3-vs-5 asymmetry (5≡1 mod 4 is a sum of two squares, hence a possible hypotenuse; 3≡3 mod 4 is not).",
+  "overview": {
+    "historicalContext": "The parent entry pythagorean-triples-oq-06-oq-01-oq-01 proves the divisibility package 60 ∣ x·y·z for every Pythagorean triple — each of 3, 4, 5 divides some side — and asks, in its first recorded open question, whether one can pin the LOCATION of these factors for primitive triples: do 3 and 5 always fall on a leg (never the hypotenuse), and is the even leg always divisible by 4? This 'where, not just whether' refinement is the natural sharpening of a divisibility package. It turns out the question is only half correct, and the correct answer reveals a clean number-theoretic phenomenon: a prime p can be the hypotenuse of a primitive triple exactly when p is a sum of two squares, i.e. p ≡ 1 (mod 4). Since 3 ≡ 3 (mod 4) it can never be a hypotenuse, while 5 = 1² + 2² ≡ 1 (mod 4) is the hypotenuse of (3,4,5). Mathlib carries Euclid's m²−n²/2mn/m²+n² classification but neither the divisibility package nor this location refinement.",
+    "problemStatement": "Let (x, y, z) be a primitive Pythagorean triple: x² + y² = z² with IsCoprime x y. Prove (i) 3 ∤ z, so 3 divides one of the legs; (ii) if a leg is even then it is divisible by 4. Determine whether the analogous statement '5 ∤ z' holds, and if not exhibit a counterexample.",
+    "proofStrategy": "Three independent congruence arguments. (1) 3 ∤ z: if 3 ∣ z then over ZMod 3 the relation reads x²+y²=0; an exhaustive check (`decide`) shows this forces x ≡ y ≡ 0 (mod 3), so 3 divides both legs, contradicting coprimality via IsCoprime.isUnit_of_dvd' (3 is not a unit in ℤ). Combined with the inherited 3 ∣ xyz and primality of 3, this pins 3 to a leg. (2) 4 ∣ even leg: if a leg x is even, the other leg y is odd (else 2 divides both, making 2 a unit) and the hypotenuse z is odd (2 ∣ z would force 2 ∣ y² hence 2 ∣ y). Odd squares are 1 (mod 8), so x² = z² − y² ≡ 0 (mod 8); a finite certificate over ZMod 8 — carrying the two oddness conditions as nonzero residues mod 2 through ZMod.castHom 8→2 — certifies x ≡ 0 (mod 4) through ZMod.castHom 8→4. (3) 5-asymmetry: the explicit primitive triple (3,4,5) has 5 ∣ z, refuting '5 ∤ z'; 5 still divides some side (the inherited five_dvd_prod), but that side may be the hypotenuse.",
+    "keyInsights": [
+      "**The open question is half false, and the correct answer is sharper.** '3 never divides z' is TRUE, but '5 never divides z' is FALSE — (3,4,5) and (7,24,25) are primitive triples with 5 ∣ z. Reporting only the true half would misstate the mathematics; the honest result is the 3-vs-5 dichotomy.",
+      "**The dichotomy is governed by p mod 4.** A prime p is the hypotenuse of a primitive triple iff p is a sum of two squares iff p ≡ 1 (mod 4). Here 3 ≡ 3 (mod 4) can never be a hypotenuse, while 5 = 1²+2² ≡ 1 (mod 4) can. The location of a prime factor is controlled by whether the prime itself is Pythagorean.",
+      "**3 ∤ z is a coprimality obstruction, not a product obstruction.** Unlike the parent's '3 ∣ xyz' (which holds for all triples), '3 ∤ z' genuinely uses primitivity: 3 ∣ z forces 3 ∣ x and 3 ∣ y, killed by IsCoprime.isUnit_of_dvd'. The single ZMod 3 check 'x²+y²=0 → x=0 ∧ y=0' encodes that 3 ≡ 3 (mod 4) is not a sum of two nonzero squares.",
+      "**The 2-adic argument needs modulus 8, and the oddness hypotheses must travel with the residue.** '4 ∣ even leg' is invisible mod 4; the certificate runs over ZMod 8 and feeds the two parity conditions (y, z odd) as nonzero images under ZMod.castHom 8→2, so the decidable check sees exactly the odd-square geometry that forces x ≡ 0 (mod 4).",
+      "**0-axiom via `decide`, not `native_decide`.** All finite checks are kernel-reduced; the theorems depend only on propext, Classical.choice, Quot.sound — no Lean.ofReduceBool, no sorry."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 0-axiom Lean 4 formalization sharpening the parent's divisibility package by location for primitive triples: 3 never divides the hypotenuse (three_not_dvd_hyp), hence lands on a leg (three_dvd_leg), and the even leg is divisible by 4 (four_dvd_even_leg). It also proves the parent's open question is half wrong — five_can_divide_hyp exhibits the primitive triple (3,4,5) with 5 ∣ z — and records the structural reason (5 ≡ 1 mod 4 is a sum of two squares, so a permissible hypotenuse). Three worked instances (3,4,5), (5,12,13), (7,24,25) illustrate both the rule for 3/4 and the asymmetry for 5.",
+    "implications": "Corrects and completes the first open question of the parent 60 ∣ xyz package. The takeaway is that 'an odd prime divisor of xyz is forced onto a leg' is a property of the prime 3 (and of any prime ≡ 3 mod 4), not a universal feature: primes ≡ 1 mod 4 such as 5 can sit on the hypotenuse. The proof technique — coprimality obstructions over ZMod for location, a ZMod 8 certificate carrying parity for the 2-adic factor — transfers to analogous 'which side' questions for other small primes.",
+    "openQuestions": [
+      "Generalize three_not_dvd_hyp to the full mod-4 dichotomy: prove that for a prime p, p divides the hypotenuse of some primitive triple iff p ≡ 1 (mod 4) (equivalently p is a sum of two squares), formalizing the Fermat two-squares characterization of Pythagorean hypotenuses.",
+      "Pin the 5-factor precisely: show that in a primitive triple exactly one of the three sides is divisible by 5, and characterize when that side is the hypotenuse versus a leg in terms of the generators (m, n) of Euclid's parametrization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Header & Honest Correction",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the refinement and explicitly flagging that the parent's open question is only half true: 3 never divides the hypotenuse (true) but 5 can (false), with the explicit (3,4,5) counterexample and the p mod 4 explanation. Outlines the three congruence methods. Imports Mathlib.",
+      "mathContext": "Primitive triple: $x^2+y^2=z^2$, $\\gcd(x,y)=1$. Claim: $3\\nmid z$, $4\\mid$ even leg, but $5\\mid z$ is possible."
+    },
+    {
+      "id": "zmod-rel",
+      "title": "Transporting the relation to ZMod n",
+      "startLine": 49,
+      "endLine": 54,
+      "summary": "`zmod_rel` casts x²+y²=z² into ZMod n via the canonical ring homomorphism (exact_mod_cast on congrArg), the bridge from the Diophantine relation to the decidable finite checks.",
+      "mathContext": "$x^2+y^2=z^2 \\text{ in } \\mathbb{Z} \\Rightarrow \\bar x^2+\\bar y^2=\\bar z^2 \\text{ in } \\mathbb{Z}/n$."
+    },
+    {
+      "id": "three-not-dvd-hyp",
+      "title": "3 is pinned to a leg",
+      "startLine": 56,
+      "endLine": 96,
+      "summary": "`three_not_dvd_hyp`: if 3 ∣ z then over ZMod 3 the relation collapses to x²+y²=0, which `decide` shows forces x ≡ y ≡ 0 (mod 3); then 3 divides both coprime legs, so IsCoprime.isUnit_of_dvd' makes 3 a unit in ℤ — impossible. `three_dvd_leg` combines the inherited 3 ∣ xyz with 3 ∤ z and primality of 3 (Prime.dvd_mul) to place 3 on a leg.",
+      "mathContext": "$3\\mid z \\Rightarrow 3\\mid x \\wedge 3\\mid y \\Rightarrow \\gcd(x,y)\\ge 3$, contradicting primitivity; so $3\\mid x$ or $3\\mid y$."
+    },
+    {
+      "id": "four-dvd-even-leg",
+      "title": "The even leg is divisible by 4",
+      "startLine": 98,
+      "endLine": 138,
+      "summary": "`four_dvd_even_leg_aux` is a ZMod 8 certificate: for a²+b²=c² with b, c odd (nonzero images under ZMod.castHom 8→2), the leg a vanishes under ZMod.castHom 8→4. `four_dvd_even_leg` then derives the parity facts (even leg ⇒ other leg odd, hypotenuse odd) from primitivity and the relation, transports them into ZMod 8 via map_intCast, and reads off 4 ∣ x.",
+      "mathContext": "Odd squares $\\equiv 1\\pmod 8$, so $x^2=z^2-y^2\\equiv 0\\pmod 8$ with $x$ even $\\Rightarrow 4\\mid x$."
+    },
+    {
+      "id": "five-asymmetry",
+      "title": "The 5-asymmetry: counterexample to the open question",
+      "startLine": 140,
+      "endLine": 153,
+      "summary": "`five_can_divide_hyp` exhibits the primitive triple (3,4,5) with 5 ∣ z, refuting the symmetric '5 ∤ z' claim. `five_dvd_prod` retains the inherited fact that 5 divides some side of every triple — but as the counterexample shows, that side may be the hypotenuse. The docstring records the structural reason: 5 ≡ 1 (mod 4) is a sum of two squares.",
+      "mathContext": "$(3,4,5)$ primitive, $5\\mid 5$; $5=1^2+2^2\\equiv 1\\pmod 4$ is a permissible hypotenuse, unlike $3\\equiv 3\\pmod 4$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete instances",
+      "startLine": 155,
+      "endLine": 181,
+      "summary": "Three worked instances: (3,4,5) with 3 ∤ 5, 4 ∣ 4, 5 ∣ 5; (5,12,13) where 5 lands on a leg, 3 ∤ 13, 4 ∣ 12; and (7,24,25) reinforcing 5 ∣ z (=25) while 3 ∤ 25 and 4 ∣ 24. Each discharged through the general theorems with explicit generators.",
+      "mathContext": "$(3,4,5),(5,12,13),(7,24,25)$ exercising the $3/4$ rule and the $5$-asymmetry."
+    }
+  ],
+  "references": [
+    {
+      "title": "Pythagorean triple — divisibility and the hypotenuse",
+      "url": "https://en.wikipedia.org/wiki/Pythagorean_triple"
+    },
+    {
+      "title": "Sum of two squares theorem (Fermat): p = a²+b² iff p ≡ 1 (mod 4)",
+      "url": "https://en.wikipedia.org/wiki/Sum_of_two_squares_theorem"
+    },
+    {
+      "title": "Mathlib: Mathlib.NumberTheory.PythagoreanTriples",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/PythagoreanTriples.html"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-triples-oq-06-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: proves 60 ∣ xyz for every triple. This entry answers its first open question by pinning the location of the factors for primitive triples — proving 3 ∤ z and 4 ∣ (even leg), and correcting the open question's false claim that 5 ∤ z via the counterexample (3,4,5)."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01-oq-01",
+      "question": "Generalize three_not_dvd_hyp to the full mod-4 dichotomy: a prime p divides the hypotenuse of some primitive triple iff p ≡ 1 (mod 4) (iff p is a sum of two squares), formalizing the Fermat two-squares characterization of Pythagorean hypotenuses.",
+      "significance": "medium"
+    },
+    {
+      "id": "pythagorean-triples-oq-06-oq-01-oq-01-oq-01-oq-02",
+      "question": "Show that in a primitive triple exactly one side is divisible by 5, and characterize whether that side is the hypotenuse or a leg in terms of Euclid's generators (m, n).",
+      "significance": "low"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "imports": ["Mathlib"],
+    "lineCount": 181,
+    "namespace": "PythagoreanPrimeLocation",
+    "opens": [],
+    "path": "Proofs/PythagoreanTriplesOQ06OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "theoremCount": 10
+  },
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ06OQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "pythagorean-triples",
+      "divisibility",
+      "modular-arithmetic",
+      "primitive-triples",
+      "sum-of-two-squares",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 181,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "An integer's cast to ZMod n vanishes iff n divides it — converts each finite ZMod check into an integer divisibility (and back, for 3 ∣ x / 3 ∣ y / 4 ∣ x)",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "IsCoprime.isUnit_of_dvd'",
+        "description": "A common divisor of two coprime elements is a unit — turns '3 divides both legs' (resp. 2) into 'IsUnit 3' (resp. IsUnit 2), refuted by Int.isUnit_iff",
+        "module": "Mathlib.RingTheory.Coprime.Basic"
+      },
+      {
+        "theorem": "ZMod.castHom",
+        "description": "Canonical ring maps ZMod 8 → ZMod 2 (carrying the parity hypotheses) and ZMod 8 → ZMod 4 (reading off 4 ∣ x) in the even-leg certificate",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Prime.dvd_mul",
+        "description": "A prime dividing a product divides a factor — places 3 on a leg given 3 ∣ xyz and 3 ∤ z",
+        "module": "Mathlib.Algebra.GroupWithZero.Divisibility"
+      },
+      {
+        "theorem": "map_intCast",
+        "description": "Ring homomorphisms commute with integer casts — bridges (w : ZMod 8) through castHom to (w : ZMod 2) / (w : ZMod 4)",
+        "module": "Mathlib.Data.Int.Cast.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "three_not_dvd_hyp: in a primitive triple 3 never divides the hypotenuse z — a coprimality obstruction (not a product obstruction), genuinely using primitivity",
+      "three_dvd_leg: 3 therefore divides one of the legs, pinning the location of the factor 3",
+      "four_dvd_even_leg: the even leg of a primitive triple is divisible by 4, via a ZMod 8 certificate carrying the two oddness hypotheses through ZMod.castHom",
+      "five_can_divide_hyp: the explicit primitive triple (3,4,5) with 5 ∣ z — a counterexample CORRECTING the parent's open question, which falsely claimed 5 never divides the hypotenuse",
+      "Identification of the structural cause: 5 ≡ 1 (mod 4) is a sum of two squares (5 = 1²+2²) hence a permissible Pythagorean hypotenuse, whereas 3 ≡ 3 (mod 4) is not — the 3-vs-5 dichotomy"
+    ],
+    "prerequisites": [
+      "Primitive Pythagorean triples (coprime integer solutions of x² + y² = z²)",
+      "Quadratic residues modulo 3 and 8, and sums of two squares mod 4",
+      "ZMod ring homomorphisms (ZMod.castHom, map_intCast) and the intCast-is-zero divisibility criterion",
+      "Coprimality obstructions (IsCoprime.isUnit_of_dvd') and prime divisibility of products"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `pythagorean-triples-oq-06-oq-01-oq-01` ("The full divisibility package: 60 ∣ xyz"), which asked to *pin the location* of the prime factors for primitive triples.

**The open question is half false, and this PR proves the correct sharper statement.** For a primitive Pythagorean triple `x²+y²=z²` (`IsCoprime x y`):

- ✅ **`three_not_dvd_hyp`** — `3` never divides the hypotenuse `z` (TRUE), so `3` always lands on a leg (`three_dvd_leg`).
- ✅ **`four_dvd_even_leg`** — the even leg is divisible by `4` (TRUE).
- ❌ **`five_can_divide_hyp`** — the parent's claim that `5` never divides `z` is **FALSE**: `(3,4,5)` is primitive with `5 ∣ z`. So `5` is *not* pinned to a leg.

### The structural reason (3-vs-5 dichotomy)
A prime is a Pythagorean hypotenuse iff it is a sum of two squares iff `p ≡ 1 (mod 4)`. Here `5 = 1²+2² ≡ 1 (mod 4)` can be a hypotenuse, whereas `3 ≡ 3 (mod 4)` cannot. Reporting only the true half would misstate the mathematics; the honest deliverable is the dichotomy plus its cause.

## Method
- `3 ∤ z`: a **coprimality** obstruction — `3∣z` forces `3∣x ∧ 3∣y` (ZMod 3 `decide`), refuted by `IsCoprime.isUnit_of_dvd'` (3 not a unit). Genuinely uses primitivity, unlike the parent's product obstruction.
- `4 ∣ even leg`: a **ZMod 8 certificate** carrying the two oddness conditions (other leg, hypotenuse) through `ZMod.castHom 8→2`, reading off `4∣x` via `ZMod.castHom 8→4`.
- `5`-asymmetry: explicit counterexample `(3,4,5)`; `5` still divides *some* side (`five_dvd_prod`) but it may be the hypotenuse.

## Verification
- **0-axiom / verified / original**: `#print axioms` shows every theorem depends only on `[propext, Classical.choice, Quot.sound]` — uses `decide` (kernel), **not** `native_decide`, so no `Lean.ofReduceBool`; no `sorry`.
- Compiled clean against Mathlib (Lean v4.26.0). 10 theorems, 181 lines.
- 3 worked instances: `(3,4,5)`, `(5,12,13)` (5 on a leg), `(7,24,25)` (5 on hypotenuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)