### PR TITLE
Enrich Menelaus: Realisable Sign Patterns (menelaus-theorem-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-imports-encoding",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "Sign patterns as Bool³ and the xor parity encoding",
+    "content": "The file imports the parent Menelaus formalization and encodes a sign pattern as a triple of booleans (sX, sY, sZ), where sᵢ = true means division point i is external (its signed ratio is negative). The number of external points is odd exactly when the xor of the three bits is true. This boolean encoding is what turns the geometric realisability question into a decidable identity that `decide` can finish.",
+    "mathContext": "$(s_X, s_Y, s_Z) \\in \\mathbb{B}^3$; $\\;\\#\\{\\text{external}\\}\\text{ odd} \\iff s_X \\oplus s_Y \\oplus s_Z = \\text{true}$.",
+    "significance": "key",
+    "relatedConcepts": ["Menelaus's theorem", "Ceva's theorem", "signed ratio", "parity", "boolean xor"],
+    "prerequisites": ["boolean algebra", "signed division ratios"]
+  },
+  {
+    "id": "ann-bookkeeping-helpers",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 64 },
+    "type": "lemma",
+    "title": "Sign ↔ boolean bookkeeping lemmas",
+    "content": "Four private helper lemmas bridge the geometric sign conditions and the boolean encoding. iff_true_of / iff_false_of repackage a true (resp. false) proposition into the boolean iff form p ↔ (b = true); bit_of_neg pins a sign bit to true from a negative ratio, and bit_of_pos pins it to false from a positive ratio (by case-splitting the Bool and deriving a contradiction in the true case). These are the glue letting the witnesses' raw sign facts feed the master biconditionals.",
+    "mathContext": "$r < 0 \\;\\wedge\\; (r<0 \\iff s=\\text{true}) \\;\\Rightarrow\\; s = \\text{true}$; dually $0<r \\Rightarrow s=\\text{false}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidable propositions", "iff packaging", "sign function"],
+    "prerequisites": ["propositional logic", "Lean Bool/Prop bridge"]
+  },
+  {
+    "id": "ann-witnesses-odd",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 118 },
+    "type": "theorem",
+    "title": "Witnesses for the odd (Menelaus, product −1) patterns",
+    "content": "Four explicit configurations realising each odd sign pattern with signed product −1, all on the single fixed non-degenerate triangle (0,0),(1,0),(0,1): all three external (t=2,u=2,v=−1/3), and each of the three exactly-one-external cases. Each is the constructive heart of the converse direction — existence is demonstrated by exhibiting a concrete configuration whose menelausProduct and per-point ratio signs are verified by norm_num.",
+    "mathContext": "$\\text{menelausProduct} = \\dfrac{t}{1-t}\\cdot\\dfrac{u}{1-u}\\cdot\\dfrac{v}{1-v} = -1$, with each factor's sign matching the target pattern.",
+    "significance": "critical",
+    "relatedConcepts": ["constructive existence", "transversal line", "collinearity", "witness configuration"],
+    "prerequisites": ["affine coordinates", "norm_num evaluation"]
+  },
+  {
+    "id": "ann-witnesses-even",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 168 },
+    "type": "theorem",
+    "title": "Witnesses for the even (Ceva, product +1) patterns",
+    "content": "Four configurations realising each even sign pattern with signed product +1: none external (t=u=v=1/2, all interior cevian feet) and the three exactly-two-external cases. Together with the odd witnesses these exhaust the four admissible patterns of each parity class, demonstrating that the parent's necessary parity condition is also sufficient.",
+    "mathContext": "$\\dfrac{t}{1-t}\\cdot\\dfrac{u}{1-u}\\cdot\\dfrac{v}{1-v} = +1$ — the Ceva (concurrent cevians) value.",
+    "significance": "critical",
+    "relatedConcepts": ["Ceva's theorem", "concurrent cevians", "constructive existence", "internal division"],
+    "prerequisites": ["affine coordinates", "norm_num evaluation"]
+  },
+  {
+    "id": "ann-realisable-iff-odd",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 170, "endLine": 206 },
+    "type": "theorem",
+    "title": "Master biconditional: realisable with product −1 ⟺ odd parity",
+    "content": "The headline result. A sign pattern is realisable by a genuine non-degenerate configuration with menelausProduct = −1 if and only if it has an odd number of external points. Forward: destructure the parent's external_parity_odd four-way disjunction and pin each bit, then close by decide. Backward: case-split the eight patterns; the four parity-violating cases are impossible (absurd hodd (by decide)) and the four admissible cases are supplied by the matching odd witness, its ratio signs repackaged via iff_true_of / iff_false_of.",
+    "mathContext": "$\\big(\\exists\\,\\text{cfg},\\ \\text{product}=-1 \\wedge \\text{sign pattern}=(s_X,s_Y,s_Z)\\big) \\iff s_X \\oplus s_Y \\oplus s_Z = \\text{true}$.",
+    "significance": "critical",
+    "relatedConcepts": ["biconditional characterisation", "necessary and sufficient condition", "case analysis", "decide tactic"],
+    "prerequisites": ["Menelaus parity dichotomy", "boolean xor", "existential introduction"]
+  },
+  {
+    "id": "ann-realisable-iff-even",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 208, "endLine": 242 },
+    "type": "theorem",
+    "title": "Master biconditional: realisable with product +1 ⟺ even parity",
+    "content": "The Ceva counterpart: a sign pattern is realisable with menelausProduct = +1 iff it has an even number of external points. Same proof architecture as realisable_iff_odd, using the parent's external_parity_even for the forward direction and the four even witnesses for the converse. Together the two theorems partition all eight sign patterns by parity into exactly the realisable ones at each product value.",
+    "mathContext": "$\\big(\\exists\\,\\text{cfg},\\ \\text{product}=+1 \\wedge \\text{pattern}=(s_X,s_Y,s_Z)\\big) \\iff s_X \\oplus s_Y \\oplus s_Z = \\text{false}$.",
+    "significance": "key",
+    "relatedConcepts": ["Ceva's theorem", "biconditional characterisation", "parity partition"],
+    "prerequisites": ["Menelaus parity dichotomy", "boolean xor"]
+  },
+  {
+    "id": "ann-corollary-count",
+    "proofId": "menelaus-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 244, "endLine": 257 },
+    "type": "theorem",
+    "title": "Corollary: exactly four patterns are realisable",
+    "content": "four_odd_patterns_realisable bundles the four odd witnesses into one conjunction, making explicit the count 2³ / 2 = 4: of the eight possible sign patterns, exactly four are realisable as a Menelaus transversal (product −1), and by symmetry exactly four as a Ceva configuration (product +1). This is the quantitative reading of the parity characterisation.",
+    "mathContext": "$\\#\\{\\text{realisable patterns at } -1\\} = 2^3/2 = 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["counting", "parity classes", "sign pattern enumeration"],
+    "prerequisites": ["basic combinatorics"]
+  }
+]

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MenelausTheoremOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const menelausTheoremOQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const menelausTheoremOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const menelausTheoremOQ01OQ01OQ01Data: ProofData = {
+  proof: menelausTheoremOQ01OQ01OQ01Proof,
+  annotations: menelausTheoremOQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-01-oq-01/meta.json
@@ -56,6 +56,71 @@
   "conclusion": {
     "summary": "The realisable sign patterns of a Menelaus configuration are characterised exactly: a pattern (sX, sY, sZ) is realisable with signed product -1 iff it has an odd number of external points, and with the Ceva product +1 iff it has an even number. The converse to the parent's parity dichotomy is established constructively via eight explicit witness configurations, four for each product sign. 11 theorems, 0 definitions, 257 lines, 0 sorries, 0 axioms.",
     "implications": "Upgrades the parent's necessary parity condition into a necessary-and-sufficient characterisation, completing the realisability picture for the gallery's Menelaus formalization. The witness-construction template (fix a non-degenerate triangle, solve for division parameters realising a prescribed product and per-factor sign) transfers directly to Ceva, Routh, and other affine division-ratio configurations.",
-    "openQuestions": null
-  }
+    "openQuestions": [
+      "Can the realisability characterisation be lifted from the boolean sign pattern to the full continuum of attainable signed-ratio triples? That is, for which triples (rX, rY, rZ) ∈ (ℝ \\ {0,1})³ does a non-degenerate configuration exist — is the only constraint the product rX·rY·rZ = ±1, or are there further inequalities from non-degeneracy?",
+      "Does an analogous sharp biconditional hold for Routh's theorem, where the three cevians bound a central triangle whose area ratio is a rational function of the division parameters — i.e. which sign patterns and area values are simultaneously realisable?",
+      "The eight witnesses live on a single fixed triangle. Is there a configuration-space statement making precise that the realisable-pattern set is a topological invariant, independent of the triangle's shape (an affine-invariance argument rather than a per-witness norm_num check)?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-docstring",
+      "title": "Overview: from parity dichotomy to biconditional",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Module docstring. The parent (MenelausTheoremOQ01) proved the forward parity dichotomy — a collinear transversal (menelausProduct = -1) forces an odd number of external division points, the Ceva value +1 an even number. This file adds the converse/realisability direction and packages both into sharp biconditionals over sign patterns (sX,sY,sZ) ∈ Bool³, encoding 'odd #external' as the xor sX ^^ sY ^^ sZ = true."
+    },
+    {
+      "id": "bookkeeping-helpers",
+      "title": "Sign ↔ boolean bookkeeping helpers",
+      "startLine": 39,
+      "endLine": 64,
+      "summary": "Opens the parent namespaces and four private lemmas: iff_true_of / iff_false_of repackage a Prop and its negation into the boolean iff form p ↔ (b = true); bit_of_neg / bit_of_pos pin a sign bit to true/false from the sign of the corresponding signed ratio. These translate between the geometric sign conditions and the boolean encoding used in the master theorems."
+    },
+    {
+      "id": "witnesses-odd",
+      "title": "Witnesses for the odd (Menelaus, product -1) patterns",
+      "startLine": 66,
+      "endLine": 118,
+      "summary": "Four explicit configurations on the fixed triangle (0,0),(1,0),(0,1) realising each odd sign pattern with menelausProduct = -1: witness_odd_XYZ (all three external), witness_odd_X / witness_odd_Y / witness_odd_Z (exactly one external). Only the division parameters t,u,v change; each goal is discharged by unfold + norm_num."
+    },
+    {
+      "id": "witnesses-even",
+      "title": "Witnesses for the even (Ceva, product +1) patterns",
+      "startLine": 120,
+      "endLine": 168,
+      "summary": "Four explicit configurations with menelausProduct = +1: witness_even_none (none external), witness_even_YZ / witness_even_XZ / witness_even_XY (exactly two external). Same fixed triangle and norm_num discharge pattern."
+    },
+    {
+      "id": "master-biconditionals",
+      "title": "Master biconditionals: realisable ⟺ parity",
+      "startLine": 170,
+      "endLine": 242,
+      "summary": "realisable_iff_odd: a sign pattern is realisable with product -1 iff sX ^^ sY ^^ sZ = true. Forward direction destructures the parent's external_parity_odd disjunction, pins each bit via bit_of_neg/bit_of_pos, and closes by decide; backward direction case-splits the 8 patterns, closing the 4 parity-violating ones by absurd ... (by decide) and supplying a matching witness for each of the 4 admissible ones. realisable_iff_even is the symmetric statement for product +1."
+    },
+    {
+      "id": "corollary-count",
+      "title": "Corollary: exactly four realisable patterns",
+      "startLine": 244,
+      "endLine": 257,
+      "summary": "four_odd_patterns_realisable packages the four odd witnesses into a single conjunction, confirming the count 2³ / 2 = 4 of Menelaus-realisable sign patterns."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "menelaus-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Provides the forward parity dichotomy reused here: external_parity_odd (product -1 ⟹ odd number of external points) and external_parity_even (product +1 ⟹ even). This leaf supplies the converse, upgrading both to biconditionals."
+    },
+    {
+      "proofId": "menelaus-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "The base formalization of Menelaus's theorem: the MenelausConfig structure, the signed ratios rX/rY/rZ, and menelausProduct, with collinearity characterised by the signed product equalling -1. All witnesses here are instances of MenelausConfig."
+    },
+    {
+      "proofId": "menelaus-theorem-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "A sibling leaf in the Menelaus family treating Desargues's theorem via the homogeneous-coordinate determinant bracket — another projective/affine incidence result building on the same parent's signed-ratio machinery."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `menelaus-theorem-oq-01-oq-01-oq-01` (Menelaus: Realisable Sign Patterns — Biconditional Characterisation). The entry had a rich `overview` and `conclusion` already, but was missing inline annotations, `index.ts`, sections, cross-references, and open questions.

## Changes
- **Created `index.ts`** — was missing, so the proof page would render "proof not found" on the live site despite appearing in the gallery listing.
- **Created `annotations.json`** — 7 annotations spanning the Bool³/xor encoding, the sign↔boolean bookkeeping lemmas, the odd (product −1) and even (product +1) witness families, both master biconditionals, and the counting corollary. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **`sections`** added — 6 sections covering all 257 lines.
- **`crossReferences`** added — parent `menelaus-theorem-oq-01-oq-01` (the parity dichotomy reused here), ancestor `menelaus-theorem-oq-01` (the base config/ratio machinery), and sibling `menelaus-theorem-oq-01-oq-02` (Desargues).
- **`conclusion.openQuestions`** filled — was `null`; now 3 genuine extensions (continuum of attainable ratio triples, a Routh analogue, an affine-invariance configuration-space statement).

## Axiom integrity
Verified `status: verified` / `badge: original` / `axiomCount: 0` is accurate: the Lean file has 0 `sorry`, 0 `axiom`, no `native_decide`, and no assumption-carrying structures.

## Verification
`tsc -b` and `vite build` both pass (exit 0). All proof JSON validates.