### PR TITLE
research(erdos-606-oq-03-wip-01): de Bruijn–Erdős line-count sandwich n ≤ #L ≤ C(n,2) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2187,6 +2187,7 @@ import Proofs.Erdos604Problem
 import Proofs.Erdos605Problem
 import Proofs.Erdos606OQ03
 import Proofs.Erdos606OQ03OQ03
+import Proofs.Erdos606OQ03WIP01
 import Proofs.Erdos606Problem
 import Proofs.Erdos607Problem
 import Proofs.Erdos608Aristotle

--- a/proofs/Proofs/Erdos606OQ03WIP01.lean
+++ b/proofs/Proofs/Erdos606OQ03WIP01.lean
@@ -1,0 +1,117 @@
+import Mathlib
+
+/-
+# Erdős 606 — OQ-03 / WIP-01: The de Bruijn–Erdős Lower Bound, Rigorously
+
+## Research Problem: erdos-606-oq-03-wip-01
+
+The parent entry `erdos-606-oq-03` (Hyperplane Determination in Higher Dimensions)
+records, in prose comments only, the central lower bound for Erdős's line-counting
+problem:
+
+> "Minimum lines (non-collinear): at least n"
+
+This work-in-progress turns that prose into a machine-checked theorem. The correct
+attribution for the bound "n points, not all collinear, determine at least n lines"
+is the **de Bruijn–Erdős theorem** (1948) — *not* Sylvester–Gallai, which instead
+asserts the existence of an *ordinary* line. Mathlib already proves the de Bruijn–Erdős
+bound in the abstract incidence-geometry setting as
+`Configuration.HasLines.card_le : Fintype.card P ≤ Fintype.card L`.
+
+We use that to establish the full **sandwich** for the number of lines determined by a
+finite point configuration in which any two distinct points lie on a unique common
+line and every line passes through at least two of the points:
+
+  `n ≤ (number of lines) ≤ C(n, 2)`,  where `n` is the number of points.
+
+* lower bound `n ≤ #L` — de Bruijn–Erdős (`HasLines.card_le`);
+* upper bound `#L ≤ C(n,2)` — a counting injection: a line determined by the points
+  carries a distinct unordered pair of points (uniqueness of the line through two
+  points makes the assignment injective).
+
+## Honest Scope
+This is the *combinatorial* incidence content of Erdős 606. The deeper open questions of
+the parent entry — Sylvester–Gallai (existence of an ordinary line), Green–Tao
+(`≥ n/2` ordinary lines), and the exact set of achievable line counts — require
+projective-geometry / polynomial-method machinery and remain open here. The abstract
+`Configuration.HasLines` hypothesis is exactly the "any two points determine a unique
+line" axiom satisfied by genuine planar point sets in general position; we do not build
+a concrete geometric instance in this file.
+
+Tags: combinatorial-geometry, de-bruijn-erdos, incidence-geometry, sylvester-gallai
+-/
+
+namespace Erdos606OQ03WIP01
+
+open Configuration Finset
+
+variable {P L : Type*} [Membership P L]
+
+/-- **The de Bruijn–Erdős theorem (abstract form).**
+
+In any nondegenerate configuration where every two distinct points lie on a (unique)
+common line, the number of points is at most the number of lines. Specialised to a
+finite set of points in the plane, not all collinear: `n` points determine at least
+`n` distinct lines. This is the rigorous version of the parent entry's prose lower
+bound, here delegated to Mathlib's `Configuration.HasLines.card_le`. -/
+theorem deBruijn_erdos [HasLines P L] [Fintype P] [Fintype L] :
+    Fintype.card P ≤ Fintype.card L :=
+  HasLines.card_le P L
+
+/-- **Upper bound on the number of determined lines.**
+
+If every line is determined by the points — i.e. passes through at least two of them —
+then distinct lines carry distinct unordered pairs of points (uniqueness of the line
+through two points), so the number of lines is at most `C(n, 2)`. -/
+theorem card_le_choose_two [HasLines P L] [Fintype P] [Fintype L]
+    (htwo : ∀ l : L, ∃ p q : P, p ≠ q ∧ p ∈ l ∧ q ∈ l) :
+    Fintype.card L ≤ (Fintype.card P).choose 2 := by
+  classical
+  choose p q hpq hp hq using htwo
+  -- assign to each line the unordered pair of its two chosen points
+  set f : L → Finset P := fun l => {p l, q l} with hf
+  -- every member of `f l` is a point of `l`
+  have hsub : ∀ l, ∀ r ∈ f l, r ∈ l := by
+    intro l r hr
+    simp only [hf, Finset.mem_insert, Finset.mem_singleton] at hr
+    rcases hr with rfl | rfl
+    · exact hp l
+    · exact hq l
+  -- the assignment is injective: a shared pair forces equal lines
+  have hinj : Function.Injective f := by
+    intro l₁ l₂ h
+    have h1 : p l₂ ∈ l₁ := hsub l₁ (p l₂) (by rw [h]; simp [hf])
+    have h2 : q l₂ ∈ l₁ := hsub l₁ (q l₂) (by rw [h]; simp [hf])
+    rcases Nondegenerate.eq_or_eq h1 h2 (hp l₂) (hq l₂) with hpq2 | hl
+    · exact absurd hpq2 (hpq l₂)
+    · exact hl
+  -- each `f l` is a 2-element subset of the points
+  have hcard : ∀ l, (f l).card = 2 := fun l => Finset.card_pair (hpq l)
+  calc
+    Fintype.card L = (Finset.univ : Finset L).card := (Finset.card_univ).symm
+    _ = (Finset.univ.image f).card := (Finset.card_image_of_injective _ hinj).symm
+    _ ≤ ((Finset.univ : Finset P).powersetCard 2).card := by
+        refine Finset.card_le_card ?_
+        intro s hs
+        obtain ⟨l, -, rfl⟩ := Finset.mem_image.mp hs
+        rw [Finset.mem_powersetCard]
+        exact ⟨Finset.subset_univ _, hcard l⟩
+    _ = (Fintype.card P).choose 2 := by
+        rw [Finset.card_powersetCard, Finset.card_univ]
+
+/-- **The Erdős 606 line-count sandwich.**
+
+For a finite point configuration in which any two distinct points determine a unique
+line and every line passes through at least two points, the number of determined lines
+`m` satisfies `n ≤ m ≤ C(n, 2)`, where `n` is the number of points. The lower bound is
+de Bruijn–Erdős; the upper bound is the pair-counting injection. -/
+theorem line_count_sandwich [HasLines P L] [Fintype P] [Fintype L]
+    (htwo : ∀ l : L, ∃ p q : P, p ≠ q ∧ p ∈ l ∧ q ∈ l) :
+    Fintype.card P ≤ Fintype.card L ∧
+      Fintype.card L ≤ (Fintype.card P).choose 2 :=
+  ⟨HasLines.card_le P L, card_le_choose_two htwo⟩
+
+end Erdos606OQ03WIP01
+
+#print axioms Erdos606OQ03WIP01.line_count_sandwich
+#print axioms Erdos606OQ03WIP01.card_le_choose_two

--- a/src/data/proofs/erdos-606-oq-03-wip-01/annotations.json
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-erdos606-oq03-wip01-lower",
+    "proofId": "erdos-606-oq-03-wip-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 59
+    },
+    "type": "insight",
+    "title": "de Bruijn–Erdős: At Least n Lines",
+    "content": "deBruijn_erdos states |P| ≤ |L|: a finite set of points in which any two determine a unique line gives at least as many lines as points. This is the de Bruijn–Erdős theorem (1948) — the correct attribution for the parent entry's prose claim 'at least n lines', which had been mislabeled Sylvester–Gallai (a different statement about ordinary lines). The proof delegates to Mathlib's Configuration.HasLines.card_le, a double-counting argument over line- and point-incidence counts.",
+    "mathContext": "$|P| \\le |L|$: $n$ non-collinear points determine at least $n$ distinct lines.",
+    "significance": "key",
+    "relatedConcepts": [
+      "de Bruijn–Erdős theorem",
+      "incidence geometry",
+      "HasLines configuration"
+    ],
+    "prerequisites": [
+      "Configuration.HasLines.card_le"
+    ]
+  },
+  {
+    "id": "ann-erdos606-oq03-wip01-upper",
+    "proofId": "erdos-606-oq-03-wip-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 100
+    },
+    "type": "insight",
+    "title": "Upper Bound C(n,2) by Pair Counting",
+    "content": "card_le_choose_two proves |L| ≤ C(|P|,2). Assuming every line passes through at least two points, it assigns to each line a 2-element subset {p_l, q_l} of points on it. The map L → Finset P is injective: if two lines carried the same pair, both would pass through those two distinct points, contradicting Nondegenerate.eq_or_eq (two points lie on at most one line). Finset.card_image_of_injective and Finset.card_powersetCard then count: the number of lines is at most the number of point-pairs, C(n,2).",
+    "mathContext": "$|L| \\le \\binom{|P|}{2}$: distinct lines carry distinct point-pairs.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counting injection",
+      "uniqueness of the line through two points",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "Nondegenerate.eq_or_eq",
+      "Finset.card_powersetCard"
+    ]
+  },
+  {
+    "id": "ann-erdos606-oq03-wip01-sandwich",
+    "proofId": "erdos-606-oq-03-wip-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "The Line-Count Sandwich n ≤ #L ≤ C(n,2)",
+    "content": "line_count_sandwich packages both bounds: the number of lines determined by n points lies in [n, C(n,2)]. The lower bound is de Bruijn–Erdős, the upper bound the pair-counting injection — and both rest on the same uniqueness axiom (two points determine at most one line). This is the verified combinatorial range underlying Erdős 606; which intermediate counts are actually achievable is the deeper open question.",
+    "mathContext": "$n \\le (\\text{number of determined lines}) \\le \\binom{n}{2}$.",
+    "significance": "major",
+    "relatedConcepts": [
+      "Erdős 606",
+      "extremal incidence geometry"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-wip-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "erdos-606-oq-03-wip-01",
+  "title": "The de Bruijn–Erdős Lower Bound and the Line-Count Sandwich",
+  "slug": "erdos-606-oq-03-wip-01",
+  "description": "Turns the parent entry's prose claim 'n non-collinear points determine at least n lines' into a machine-checked theorem via Mathlib's Configuration.HasLines.card_le (the de Bruijn–Erdős theorem, correctly attributed — not Sylvester–Gallai), and complements it with an original pair-counting injection giving the upper bound C(n,2). Result: the full sandwich n ≤ (number of determined lines) ≤ C(n,2).",
+  "meta": {
+    "author": "de Bruijn–Erdős (1948), Erdős (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/De_Bruijn%E2%80%93Erd%C5%91s_theorem_(incidence_geometry)",
+    "date": "1948",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos606OQ03WIP01.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "de-bruijn-erdos",
+      "incidence-geometry",
+      "sylvester-gallai",
+      "erdos",
+      "open-question"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Configuration.HasLines.card_le",
+        "description": "de Bruijn–Erdős: in a nondegenerate configuration where two points determine a unique line, the number of points is at most the number of lines",
+        "module": "Mathlib.Combinatorics.Configuration"
+      },
+      {
+        "theorem": "Configuration.Nondegenerate.eq_or_eq",
+        "description": "Two points lie on at most one common line (used to prove the pair-to-line assignment is injective)",
+        "module": "Mathlib.Combinatorics.Configuration"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "The number of k-subsets of an n-set is C(n,k), used for the C(n,2) upper bound",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "An injective image preserves cardinality, used to count distinct point-pairs",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "Identified that the parent entry's prose lower bound ('n non-collinear points determine at least n lines') is the de Bruijn–Erdős theorem (1948), correcting the mis-attribution to Sylvester–Gallai (which instead asserts the existence of an ordinary line)",
+      "Stated and proved deBruijn_erdos as a machine-checked theorem by delegating to Mathlib's Configuration.HasLines.card_le, replacing a comment-only claim with a verified result",
+      "Proved card_le_choose_two (number of lines ≤ C(n,2)) by an original counting injection: assigning to each line an unordered pair of two of its points, with injectivity following from the uniqueness of the line through two points (Nondegenerate.eq_or_eq)",
+      "Combined the two bounds into line_count_sandwich: n ≤ (number of determined lines) ≤ C(n,2), the full combinatorial line-count range underlying Erdős 606"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "0 axioms, 0 sorries. The lower bound (de Bruijn–Erdős) is Mathlib's Configuration.HasLines.card_le; the upper bound C(n,2) and the sandwich are original. Hypotheses are the abstract incidence axioms (HasLines: any two points determine a unique line) plus 'every line contains at least two of the points' — exactly the conditions satisfied by a finite, not-all-collinear point set in the plane. Only the foundational axioms propext, Classical.choice, Quot.sound are used (none counted).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Erdős's problem 606 concerns the number of distinct lines determined by n points in the plane. The basic lower bound — n points, not all collinear, determine at least n distinct lines — is the de Bruijn–Erdős theorem (Nicolaas Govert de Bruijn and Paul Erdős, 1948), a cornerstone of incidence geometry. It is frequently confused with the Sylvester–Gallai theorem, which is a different statement: that such a point set always admits an *ordinary* line (one through exactly two points). The parent entry erdos-606-oq-03 recorded the 'at least n lines' bound only in prose comments, and attributed it to Sylvester–Gallai. This work-in-progress turns the bound into a verified theorem and fixes the attribution, leveraging the fact that Mathlib already formalizes de Bruijn–Erdős in the abstract incidence setting as Configuration.HasLines.card_le. Together with a short original counting argument for the C(n,2) upper bound, it pins the number of determined lines to the interval [n, C(n,2)].",
+    "problemStatement": "**Setting**: a finite incidence configuration of points P and lines L in which any two distinct points lie on a unique common line (the abstract HasLines property), and every line passes through at least two of the points.\n\n**Main Results**:\n\n1. **de Bruijn–Erdős (lower bound)**: |P| ≤ |L| — n points determine at least n lines.\n2. **Upper bound**: |L| ≤ C(|P|, 2) — each line carries a distinct pair of points.\n3. **Sandwich**: n ≤ (number of determined lines) ≤ C(n, 2).",
+    "text": "Formalizes the de Bruijn–Erdős lower bound (n points determine at least n lines) via Mathlib's Configuration.HasLines.card_le and complements it with a C(n,2) upper bound, giving the full line-count sandwich for Erdős 606.",
+    "proofStrategy": "The lower bound deBruijn_erdos is Mathlib's Configuration.HasLines.card_le, which proves |P| ≤ |L| for any nondegenerate HasLines configuration by a double-counting argument on line- and point-counts. The upper bound card_le_choose_two is original: using the hypothesis that every line passes through at least two points, choose for each line l an unordered pair {p_l, q_l} of distinct points on l; the resulting map L → Finset P lands in the 2-element subsets, and is injective because if two lines shared the same pair they would both contain those two distinct points, contradicting the uniqueness axiom Nondegenerate.eq_or_eq. Counting via Finset.card_image_of_injective and Finset.card_powersetCard yields |L| ≤ C(|P|, 2). line_count_sandwich packages both bounds.",
+    "keyInsights": [
+      "The 'at least n lines' bound is de Bruijn–Erdős (1948), not Sylvester–Gallai; Mathlib already proves it abstractly as Configuration.HasLines.card_le",
+      "The abstract HasLines hypothesis ('any two points determine a unique line') is exactly the incidence axiom satisfied by a finite, not-all-collinear planar point set, so the abstract theorem specialises directly to Erdős 606",
+      "The upper bound C(n,2) follows from a single observation: distinct lines carry distinct point-pairs, because two points determine at most one line — the same uniqueness axiom that powers the lower bound",
+      "Replacing prose claims with verified theorems is itself the contribution here: the parent entry only asserted these bounds in comments"
+    ],
+    "prerequisites": [
+      "Incidence geometry (points, lines, and their incidence relation)",
+      "Basic combinatorics (binomial coefficients, counting injections)",
+      "Erdős 606 (number of lines determined by n points)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-and-docstring",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports Mathlib and opens the Configuration and Finset namespaces. The docstring states the de Bruijn–Erdős attribution correction, the sandwich goal n ≤ #L ≤ C(n,2), and an explicit honest-scope note that the deeper open questions (Sylvester–Gallai, Green–Tao, exact achievable set) remain open.",
+      "mathContext": "Setup for the abstract incidence-geometry formalization of the Erdős 606 line-count bounds."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Section I: The de Bruijn–Erdős Lower Bound",
+      "startLine": 50,
+      "endLine": 59,
+      "summary": "Proves deBruijn_erdos: |P| ≤ |L| for any nondegenerate HasLines configuration, by delegating to Mathlib's Configuration.HasLines.card_le. This is the machine-checked version of the parent entry's prose 'at least n lines' claim.",
+      "mathContext": "n points, not all collinear, determine at least n distinct lines (de Bruijn–Erdős, 1948)."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Section II: The C(n,2) Upper Bound via Pair Counting",
+      "startLine": 61,
+      "endLine": 100,
+      "summary": "Proves card_le_choose_two: if every line passes through at least two points, then |L| ≤ C(|P|,2). Chooses a distinct point-pair on each line and shows the assignment L → 2-subsets is injective using the uniqueness axiom Nondegenerate.eq_or_eq, then counts with Finset.card_image_of_injective and Finset.card_powersetCard.",
+      "mathContext": "Each determined line carries a distinct unordered pair of points, so the number of lines is at most C(n,2)."
+    },
+    {
+      "id": "sandwich",
+      "title": "Section III: The Line-Count Sandwich",
+      "startLine": 102,
+      "endLine": 113,
+      "summary": "Proves line_count_sandwich: n ≤ |L| ≤ C(n,2), combining the de Bruijn–Erdős lower bound with the pair-counting upper bound — the full combinatorial range for the number of lines determined by n points.",
+      "mathContext": "n ≤ (number of determined lines) ≤ C(n, 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This work-in-progress entry converts the parent's prose lower bound into a verified theorem: n non-collinear points determine at least n lines, attributed correctly to de Bruijn–Erdős (1948) and proved via Mathlib's Configuration.HasLines.card_le. An original pair-counting injection supplies the upper bound C(n,2), and the two combine into the line-count sandwich n ≤ #lines ≤ C(n,2). It strengthens the parent entry (which was axiomatized / wip) to a fully verified, 0-axiom result on the combinatorial core of Erdős 606.",
+    "implications": "**Theoretical Significance**: The de Bruijn–Erdős theorem is the entry point to extremal incidence geometry. Having it as a verified, reusable theorem (and correctly attributed) provides a foundation for the harder open questions of the parent entry. The upper-bound injection is a reusable counting template for 'distinct objects carry distinct pairs' arguments.",
+    "openQuestions": [
+      "Can a concrete geometric instance be built — a finite set of points in EuclideanSpace ℝ (Fin 2) with the 'lines through ≥ 2 points' configuration — and shown to be a Configuration.HasLines, instantiating the abstract sandwich for genuine planar point sets?",
+      "Can the Sylvester–Gallai theorem (existence of an ordinary line) be formalized and connected to this configuration framework, sharpening the lower bound's structural content?",
+      "Which line counts in [n, C(n,2)] are actually achievable? Characterizing the 'forbidden' values is the deeper combinatorial question behind Erdős 606."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-606-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry (Hyperplane Determination in Higher Dimensions), which recorded the 'at least n lines' lower bound only in prose comments and attributed it to Sylvester–Gallai. This WIP entry proves the bound as a theorem (via de Bruijn–Erdős) and adds the matching C(n,2) upper bound."
+    },
+    {
+      "targetId": "erdos-606",
+      "relationship": "related",
+      "description": "The root Erdős 606 problem on the number of distinct lines determined by n points in the plane, whose basic [n, C(n,2)] range this entry establishes rigorously."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Configuration",
+      "Finset"
+    ],
+    "namespace": "Erdos606OQ03WIP01",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos606OQ03WIP01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Turns the parent entry `erdos-606-oq-03`'s **prose-only** lower-bound claim — *"n non-collinear points determine at least n lines"* — into a machine-checked theorem, and complements it with an original upper bound, giving the full line-count sandwich for Erdős 606:

```
n ≤ (number of determined lines) ≤ C(n, 2)
```

## Results (`proofs/Proofs/Erdos606OQ03WIP01.lean`, 3 theorems)

1. **`deBruijn_erdos`** — `|P| ≤ |L|` (lower bound). Delegates to Mathlib's `Configuration.HasLines.card_le`. Crucially **corrects the attribution**: the "≥ n lines" bound is the **de Bruijn–Erdős theorem (1948)**, *not* Sylvester–Gallai (which is the distinct statement about the existence of an *ordinary* line). The parent entry had mislabeled it.
2. **`card_le_choose_two`** — `|L| ≤ C(n,2)` (upper bound). **Original** pair-counting injection: assign each line an unordered pair of two of its points; injectivity follows from uniqueness of the line through two points (`Nondegenerate.eq_or_eq`).
3. **`line_count_sandwich`** — packages `n ≤ |L| ≤ C(n,2)`.

## Verification

- Built with `lake env lean` (Lean 4.26.0 + Mathlib).
- `#print axioms` for both nontrivial results: `[propext, Classical.choice, Quot.sound]` only — **0 counted axioms, 0 sorries**.

## Honest scope

This is the **combinatorial incidence** content of Erdős 606. The deeper open questions of the parent (Sylvester–Gallai existence, Green–Tao `≥ n/2` ordinary lines, exact achievable line counts) require projective-geometry / polynomial-method machinery and remain open. The abstract `HasLines` hypothesis is exactly the "any two points determine a unique line" axiom satisfied by a finite, not-all-collinear planar point set; no concrete geometric instance is constructed here.

## Status

**Outcome**: completed (verified, 0-axiom, lower bound = mathlib / upper bound + sandwich = original)

🤖 Generated by researcher-1