### PR TITLE
Enrich Cosecant Distance Bound |sin(πθ)|≥2‖θ‖ (bounded-prime-gaps-oq-04-oq-01-incomplete-01)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "Why the cosecant→distance conversion matters",
+    "content": "The module docstring frames the file as one self-contained ingredient of Pólya–Vinogradov. The sibling WIP01 bounds the geometric exponential sum |∑ e^{2πiθn}| by 1/|sin(πθ)|; analytic number theory needs the geometry-free form 1/(2‖θ‖) with ‖θ‖ the distance to the nearest integer. This file proves the bridge |sin(πθ)| ≥ 2‖θ‖. The engine is Mathlib's Jordan inequality plus π·ℤ-periodicity of |sin|.",
+    "mathContext": "$\\|\\theta\\| = |\\theta - \\operatorname{round}\\theta| \\in [0,\\tfrac12]$; goal $|\\sin(\\pi\\theta)| \\ge 2\\|\\theta\\|$.",
+    "significance": "context",
+    "relatedConcepts": ["Pólya–Vinogradov inequality", "character sums", "exponential sums", "distance to nearest integer"],
+    "prerequisites": ["analytic number theory", "trigonometric inequalities"]
+  },
+  {
+    "id": "ann-chord-bound",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+    "range": { "startLine": 45, "endLine": 52 },
+    "type": "theorem",
+    "title": "Concavity chord bound on [0, 1/2]",
+    "content": "two_mul_le_sin_pi_mul proves 2θ ≤ sin(πθ) for θ ∈ [0,1/2]: the concave sine curve on [0,π/2] lies above the chord from (0,0) to (1/2,1). The proof rescales Mathlib's Real.le_sin_mul (x ≤ sin(π/2·x) on [0,1]) by substituting x = 2θ and rewriting π/2·(2θ) = πθ. A companion to the absolute-value form used downstream.",
+    "mathContext": "$2\\theta \\le \\sin(\\pi\\theta)$ for $\\theta \\in [0, \\tfrac12]$, since $\\sin$ is concave on $[0,\\tfrac{\\pi}{2}]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["concavity", "chord bound", "Jordan inequality", "Real.le_sin_mul"],
+    "prerequisites": ["concave functions", "linear interpolation"]
+  },
+  {
+    "id": "ann-jordan-local",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+    "range": { "startLine": 54, "endLine": 64 },
+    "type": "theorem",
+    "title": "Local cosecant bound via Jordan's inequality",
+    "content": "two_mul_abs_le_abs_sin_pi_mul gives 2|θ| ≤ |sin(πθ)| for |θ| ≤ 1/2. It applies Mathlib's Jordan inequality Real.mul_abs_le_abs_sin (2/π·|x| ≤ |sin x| on |x| ≤ π/2) at x = πθ: the hypothesis |πθ| ≤ π/2 follows from |θ| ≤ 1/2, and the factor 2/π·(π|θ|) collapses to 2|θ| by field_simp — the π cancels exactly, which is what makes the constant 2 clean.",
+    "mathContext": "$2|\\theta| \\le |\\sin(\\pi\\theta)|$ for $|\\theta| \\le \\tfrac12$; from $\\tfrac{2}{\\pi}|x| \\le |\\sin x|$ at $x=\\pi\\theta$.",
+    "significance": "key",
+    "relatedConcepts": ["Jordan's inequality", "absolute value", "Real.mul_abs_le_abs_sin"],
+    "prerequisites": ["trigonometric bounds", "field_simp"]
+  },
+  {
+    "id": "ann-distance-bound",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+    "range": { "startLine": 66, "endLine": 81 },
+    "type": "theorem",
+    "title": "Periodized distance bound (main result)",
+    "content": "two_mul_dist_round_le_abs_sin extends the local bound to every real θ: 2‖θ‖ ≤ |sin(πθ)|. Setting m = round θ, the residual θ − m lies in [−1/2,1/2] (abs_sub_round), and the integer-shift identity sin(π(θ−m)) = (−1)^m sin(πθ) (Real.sin_sub_int_mul_pi) shows |sin(π(θ−m))| = |sin(πθ)|. Applying the local bound to θ−m and simplifying the |(−1)^m| factor to 1 gives the result. This is the π·ℤ-periodicity of |sin| made precise.",
+    "mathContext": "$2\\|\\theta\\| \\le |\\sin(\\pi\\theta)|$ for all $\\theta$; uses $\\sin(\\pi(\\theta-m)) = (-1)^m \\sin(\\pi\\theta)$. Tight at $\\theta = \\tfrac12$: $\\sin(\\tfrac\\pi2)=1=2\\cdot\\tfrac12$.",
+    "significance": "critical",
+    "relatedConcepts": ["periodicity", "round function", "nearest integer", "sharp inequality"],
+    "prerequisites": ["periodic functions", "Mathlib round/abs_sub_round"]
+  },
+  {
+    "id": "ann-cosecant-form",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+    "range": { "startLine": 83, "endLine": 92 },
+    "type": "theorem",
+    "title": "Reciprocal (cosecant) form",
+    "content": "one_div_abs_sin_le_one_div_two_mul_dist takes reciprocals for θ ∉ ℤ: 1/|sin(πθ)| ≤ 1/(2‖θ‖). Since θ − round θ ≠ 0 gives 2‖θ‖ > 0 (abs_pos, positivity), one_div_le_one_div_of_le flips the main inequality. This is the form directly composable with the sibling's bound to yield |∑ e^{2πiθn}| ≤ 1/(2‖θ‖) — the exact input the Pólya–Vinogradov cotangent aggregation consumes.",
+    "mathContext": "$\\dfrac{1}{|\\sin(\\pi\\theta)|} \\le \\dfrac{1}{2\\|\\theta\\|}$ for $\\theta \\notin \\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["reciprocal inequality", "cosecant", "Pólya–Vinogradov aggregation"],
+    "prerequisites": ["order of reciprocals", "positivity"]
+  }
+]

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BoundedPrimeGapsOQ04OQ01Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const boundedPrimeGapsOQ04OQ01Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const boundedPrimeGapsOQ04OQ01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const boundedPrimeGapsOQ04OQ01Incomplete01Data: ProofData = {
+  proof: boundedPrimeGapsOQ04OQ01Incomplete01Proof,
+  annotations: boundedPrimeGapsOQ04OQ01Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-04-oq-01-incomplete-01` (The Distance-to-Nearest-Integer Cosecant Bound — a Pólya–Vinogradov ingredient). The `meta.json` was already complete (full overview, sections, conclusion, crossReferences, mainTheorems, mathlibDependencies). What was missing was the inline annotations and the Vite entry point.

## Changes
- **Created `index.ts`** — was missing, so the proof page would render "proof not found" on the live site despite appearing in the gallery listing.
- **Created `annotations.json`** — 5 annotations covering the docstring framing, the concavity chord bound `2θ≤sin(πθ)`, the local Jordan bound `2|θ|≤|sin(πθ)|`, the periodized main result `2‖θ‖≤|sin(πθ)|` (via `sin_sub_int_mul_pi` + `abs_sub_round`), and the reciprocal cosecant form. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Axiom integrity
Verified `status: verified` / `badge: original` / `axiomCount: 0` is accurate: the Lean file has 0 `sorry`, 0 `axiom`, no `native_decide` (despite the "incomplete-01" slug, all 4 theorems are fully proved — `#print axioms` reports only propext/Classical.choice/Quot.sound).

## Verification
`tsc -b` and `vite build` both pass (exit 0). All proof JSON validates.