### PR TITLE
research(little-wedderburn-oq-02-oq-02): Gauss necklace formula — counting monic irreducibles over 𝔽_p [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3369,6 +3369,7 @@ import Proofs.LittleWedderburnOQ01
 import Proofs.LittleWedderburnOQ02
 import Proofs.LittleWedderburnOQ01OQ01
 import Proofs.LittleWedderburnOQ01OQ01OQ01
+import Proofs.LittleWedderburnOQ02OQ02
 import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle

--- a/proofs/Proofs/LittleWedderburnOQ02OQ02.lean
+++ b/proofs/Proofs/LittleWedderburnOQ02OQ02.lean
@@ -1,0 +1,201 @@
+import Mathlib
+
+/-
+# Gauss's necklace formula: counting monic irreducible polynomials over a finite field
+
+The parent entry (`LittleWedderburnOQ02`) classified finite fields: for every prime power
+`q = p ^ n` there is, up to isomorphism, a unique field `GF(q)` of that order.  This entry
+answers the second open question raised there:
+
+> Count the monic irreducible polynomials of each degree over `𝔽_p` by Möbius inversion of
+> the classification.
+
+Write `N(d)` for the number of monic irreducible polynomials of degree `d` over `𝔽_p`.
+Every element `x` of `GF(p ^ n)` has a monic irreducible minimal polynomial whose degree
+divides `n`, and conversely every monic irreducible of degree `d ∣ n` is the minimal
+polynomial of exactly `d` elements of `GF(p ^ n)` (its distinct conjugates).  Partitioning
+`GF(p ^ n)` by minimal polynomial therefore gives **Gauss's degree identity**
+
+  `p ^ n = ∑_{d ∣ n} d · N(d)`,
+
+and Möbius inversion turns this into the **necklace / Gauss formula**
+
+  `n · N(n) = ∑_{d ∣ n} μ(n / d) · p ^ d`.
+
+The only nontrivial inputs are standard finite-field facts already in Mathlib: a finite field
+is a separable normal (Galois) extension of its prime subfield, so a minimal polynomial splits
+there with exactly `deg` distinct roots; and `GF(p ^ d)` embeds in `GF(p ^ n)` whenever `d ∣ n`,
+so every monic irreducible of degree `d ∣ n` acquires a root.  We realise `N(d)` concretely as
+the number of distinct degree-`d` minimal polynomials occurring in `GF(p ^ d)` and prove this
+count is the same whichever field `GF(p ^ n)` (`d ∣ n`) we read it off — the ambient
+independence that makes the Möbius inversion meaningful.
+
+Everything is fully machine-checked with no axioms or sorries.
+-/
+
+open Polynomial Finset
+
+namespace LittleWedderburnOQ0202
+
+variable (p : ℕ) [Fact p.Prime]
+
+noncomputable local instance instDecEqPoly : DecidableEq ((ZMod p)[X]) := Classical.decEq _
+noncomputable local instance instFintypeGF (m : ℕ) : Fintype (GaloisField p m) := Fintype.ofFinite _
+noncomputable local instance instDecEqGF (m : ℕ) : DecidableEq (GaloisField p m) := Classical.decEq _
+
+/-- `Nfield p m d` is the number of distinct degree-`d` minimal polynomials realised by
+elements of `GF(p ^ m)`. -/
+noncomputable def Nfield (m d : ℕ) : ℕ :=
+  (((univ : Finset (GaloisField p m)).image (minpoly (ZMod p))).filter
+    (fun g => g.natDegree = d)).card
+
+/-! ## The per-field degree partition -/
+
+/-- A monic irreducible polynomial occurring as a minimal polynomial of `GF(p ^ m)` has exactly
+`deg` distinct roots there: the elements sharing a given minimal polynomial number `deg`. -/
+lemma card_minpoly_fiber {m : ℕ} (x : GaloisField p m) :
+    ((univ : Finset (GaloisField p m)).filter
+      (fun y => minpoly (ZMod p) y = minpoly (ZMod p) x)).card
+      = (minpoly (ZMod p) x).natDegree := by
+  have hxI : IsIntegral (ZMod p) x := Algebra.IsIntegral.isIntegral x
+  set g := minpoly (ZMod p) x with hg
+  have hgmonic : g.Monic := minpoly.monic hxI
+  have hgirr : Irreducible g := minpoly.irreducible hxI
+  have hgsep : g.Separable := Algebra.IsSeparable.isSeparable (ZMod p) x
+  set φ := algebraMap (ZMod p) (GaloisField p m) with hφ
+  have hsplit : (g.map φ).Splits := Normal.splits inferInstance x
+  have hmapne : g.map φ ≠ 0 := by simpa [hφ] using (hgmonic.map φ).ne_zero
+  have hset : ((univ : Finset (GaloisField p m)).filter
+      (fun y => minpoly (ZMod p) y = g)) = (g.map φ).roots.toFinset := by
+    ext y
+    simp only [mem_filter, mem_univ, true_and, Multiset.mem_toFinset, mem_roots hmapne,
+      IsRoot.def, eval_map]
+    constructor
+    · intro hy
+      have h0 : aeval y (minpoly (ZMod p) y) = 0 := minpoly.aeval _ _
+      rw [hy] at h0
+      rwa [← aeval_def]
+    · intro hy
+      rw [← aeval_def] at hy
+      exact (minpoly.eq_of_irreducible_of_monic hgirr hy hgmonic).symm
+  rw [hset, Multiset.toFinset_card_of_nodup (nodup_roots (hgsep.map)),
+    ← hsplit.natDegree_eq_card_roots, hgmonic.natDegree_map φ]
+
+/-- The degree of every minimal polynomial of `GF(p ^ m)` divides `m`. -/
+lemma mdeg_dvd {m : ℕ} (hm : m ≠ 0) (x : GaloisField p m) :
+    (minpoly (ZMod p) x).natDegree ∣ m := by
+  have hxI : IsIntegral (ZMod p) x := Algebra.IsIntegral.isIntegral x
+  have key : (minpoly (ZMod p) x).natDegree ∣ Module.finrank (ZMod p) (GaloisField p m) := by
+    rw [← IntermediateField.adjoin.finrank hxI]
+    exact ⟨_, (Module.finrank_mul_finrank (ZMod p) _ (GaloisField p m)).symm⟩
+  rwa [GaloisField.finrank p hm] at key
+
+/-- **Gauss's degree identity (per field).** `p ^ m = ∑_{d ∣ m} d · N(m, d)`. -/
+theorem degree_identity_field (m : ℕ) (hm : m ≠ 0) :
+    p ^ m = ∑ d ∈ m.divisors, d * Nfield p m d := by
+  have hcard : Fintype.card (GaloisField p m) = p ^ m := by
+    rw [Fintype.card_eq_nat_card]; exact GaloisField.card p m hm
+  have hmaps : ∀ x ∈ (univ : Finset (GaloisField p m)),
+      minpoly (ZMod p) x ∈ (univ : Finset (GaloisField p m)).image (minpoly (ZMod p)) :=
+    fun x _ => mem_image_of_mem _ (mem_univ x)
+  have hstep : Fintype.card (GaloisField p m)
+      = ∑ g ∈ (univ : Finset (GaloisField p m)).image (minpoly (ZMod p)), g.natDegree := by
+    rw [← Finset.card_univ, Finset.card_eq_sum_card_fiberwise hmaps]
+    refine Finset.sum_congr rfl ?_
+    intro g hg
+    rw [mem_image] at hg
+    obtain ⟨x, _, rfl⟩ := hg
+    exact card_minpoly_fiber p x
+  have hdvd : ∀ g ∈ (univ : Finset (GaloisField p m)).image (minpoly (ZMod p)),
+      g.natDegree ∈ m.divisors := by
+    intro g hg
+    rw [mem_image] at hg
+    obtain ⟨x, _, rfl⟩ := hg
+    exact Nat.mem_divisors.mpr ⟨mdeg_dvd p hm x, hm⟩
+  rw [← hcard, hstep, ← Finset.sum_fiberwise_of_maps_to hdvd]
+  refine Finset.sum_congr rfl ?_
+  intro d _
+  have h1 : ∑ g ∈ ((univ : Finset (GaloisField p m)).image (minpoly (ZMod p))).filter
+        (fun g => g.natDegree = d), g.natDegree
+      = ∑ _g ∈ ((univ : Finset (GaloisField p m)).image (minpoly (ZMod p))).filter
+        (fun g => g.natDegree = d), d :=
+    Finset.sum_congr rfl (fun g hg => (mem_filter.mp hg).2)
+  rw [h1, Finset.sum_const, smul_eq_mul, mul_comm]
+  rfl
+
+/-! ## Ambient independence of the count -/
+
+/-- If `d ∣ k` then every monic irreducible of degree `d` has a root in `GF(p ^ k)`:
+`𝔽_p[X]/(g) ≅ GF(p ^ d)` embeds into `GF(p ^ k)`. -/
+lemma exists_root_of_dvd (k d : ℕ) (hk : k ≠ 0) (hd : d ∣ k) {g : (ZMod p)[X]}
+    (hmonic : g.Monic) (hirr : Irreducible g) (hdeg : g.natDegree = d) :
+    ∃ y : GaloisField p k, aeval y g = 0 := by
+  haveI : Fact (Irreducible g) := ⟨hirr⟩
+  have hfr : Module.finrank (ZMod p) (AdjoinRoot g) = d := by
+    rw [(AdjoinRoot.powerBasis hmonic.ne_zero).finrank, AdjoinRoot.powerBasis_dim, hdeg]
+  have hdvd : Module.finrank (ZMod p) (AdjoinRoot g) ∣
+      Module.finrank (ZMod p) (GaloisField p k) := by
+    rw [hfr, GaloisField.finrank p hk]; exact hd
+  obtain ⟨φ⟩ := FiniteField.nonempty_algHom_of_finrank_dvd hdvd
+  have hroot : aeval (AdjoinRoot.root g) g = 0 := by
+    rw [aeval_def, AdjoinRoot.algebraMap_eq]; exact AdjoinRoot.eval₂_root g
+  exact ⟨φ (AdjoinRoot.root g), by rw [aeval_algHom_apply, hroot, map_zero]⟩
+
+/-- Membership in the degree-`d` minimal-polynomial image of `GF(p ^ k)` (when `d ∣ k`,
+`d ≠ 0`) is exactly being a monic irreducible of degree `d`. -/
+lemma mem_image_filter_iff (k d : ℕ) (hk : k ≠ 0) (hd : d ∣ k)
+    (g : (ZMod p)[X]) :
+    g ∈ ((univ : Finset (GaloisField p k)).image (minpoly (ZMod p))).filter
+      (fun g => g.natDegree = d) ↔ (g.Monic ∧ Irreducible g ∧ g.natDegree = d) := by
+  rw [mem_filter, mem_image]
+  constructor
+  · rintro ⟨⟨x, _, rfl⟩, hdeg⟩
+    exact ⟨minpoly.monic (Algebra.IsIntegral.isIntegral x),
+      minpoly.irreducible (Algebra.IsIntegral.isIntegral x), hdeg⟩
+  · rintro ⟨hmonic, hirr, hdeg⟩
+    obtain ⟨y, hy⟩ := exists_root_of_dvd p k d hk hd hmonic hirr hdeg
+    exact ⟨⟨y, mem_univ y, (minpoly.eq_of_irreducible_of_monic hirr hy hmonic).symm⟩, hdeg⟩
+
+/-- **Ambient independence.** For `d ∣ m` the degree-`d` count read off `GF(p ^ m)` agrees with
+the one read off `GF(p ^ d)`. -/
+lemma Nfield_eq (m d : ℕ) (hm : m ≠ 0) (hd : d ∣ m) (hd0 : d ≠ 0) :
+    Nfield p m d = Nfield p d d := by
+  have e : ((univ : Finset (GaloisField p m)).image (minpoly (ZMod p))).filter
+        (fun g => g.natDegree = d)
+      = ((univ : Finset (GaloisField p d)).image (minpoly (ZMod p))).filter
+        (fun g => g.natDegree = d) := by
+    ext g
+    rw [mem_image_filter_iff p m d hm hd g, mem_image_filter_iff p d d hd0 (dvd_refl d) g]
+  simp only [Nfield, e]
+
+/-- The intrinsic count: the number of monic irreducible polynomials of degree `n` over `𝔽_p`. -/
+noncomputable def Nirr (n : ℕ) : ℕ := Nfield p n n
+
+/-- **Gauss's degree identity.** `p ^ m = ∑_{d ∣ m} d · N(d)` with the intrinsic count `N`. -/
+theorem degree_identity (m : ℕ) (hm : m ≠ 0) :
+    p ^ m = ∑ d ∈ m.divisors, d * Nirr p d := by
+  rw [degree_identity_field p m hm]
+  refine Finset.sum_congr rfl ?_
+  intro d hd
+  obtain ⟨hdvd, _⟩ := Nat.mem_divisors.mp hd
+  have hd0 : d ≠ 0 := (Nat.pos_of_mem_divisors hd).ne'
+  rw [Nirr, Nfield_eq p m d hm hdvd hd0]
+
+/-! ## Möbius inversion: the necklace formula -/
+
+/-- **Gauss's necklace formula.** `n · N(n) = ∑_{d ∣ n} μ(n / d) · p ^ d`, expressed via the
+divisor antidiagonal `(a, b)` with `a * b = n` (so `a = n / d`, `b = d`). -/
+theorem necklace_formula (n : ℕ) (hn : n ≠ 0) :
+    (n : ℤ) * Nirr p n
+      = ∑ x ∈ n.divisorsAntidiagonal,
+          (ArithmeticFunction.moebius x.1 : ℤ) * (p : ℤ) ^ x.2 := by
+  have hfwd : ∀ k > 0, ∑ d ∈ k.divisors, ((d * Nirr p d : ℕ) : ℤ) = (p : ℤ) ^ k := by
+    intro k hk
+    rw [← Nat.cast_sum, ← degree_identity p k hk.ne', Nat.cast_pow]
+  have key := (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (R := ℤ)
+      (f := fun d => ((d * Nirr p d : ℕ) : ℤ)) (g := fun n => (p : ℤ) ^ n)).mp hfwd n
+      (Nat.pos_of_ne_zero hn)
+  rw [Nat.cast_mul] at key
+  exact key.symm
+
+end LittleWedderburnOQ0202

--- a/src/data/proofs/little-wedderburn-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/little-wedderburn-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "necklace-docstring",
+    "proofId": "little-wedderburn-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "concept",
+    "title": "The Necklace Formula and the Partition Route",
+    "content": "Writing N(d) for the number of monic irreducible polynomials of degree d over 𝔽_p, the goal is Gauss's degree identity p^n = Σ_{d∣n} d·N(d) and its Möbius inversion n·N(n) = Σ_{d∣n} μ(n/d)·p^d. Rather than factoring X^(p^n) − X into irreducibles, the proof partitions the field GF(p^n) by the degree of each element's minimal polynomial. The two finite-field facts that drive everything are already in Mathlib: GF(p^n)/𝔽_p is a separable normal (Galois) extension, so each minimal polynomial splits with exactly deg distinct roots; and GF(p^d) embeds in GF(p^n) iff d∣n, so every monic irreducible of degree d∣n acquires a root.",
+    "mathContext": "$p^n = \\sum_{d\\mid n} d\\,N(d) \\;\\Longleftrightarrow\\; n\\,N(n) = \\sum_{d\\mid n}\\mu(n/d)\\,p^d$.",
+    "significance": "key",
+    "relatedConcepts": ["finite field", "irreducible polynomial", "Möbius inversion", "necklace counting"],
+    "prerequisites": ["finite fields", "minimal polynomials"]
+  },
+  {
+    "id": "conjugate-count",
+    "proofId": "little-wedderburn-oq-02-oq-02",
+    "range": { "startLine": 49, "endLine": 91 },
+    "type": "lemma",
+    "title": "Each Minimal Polynomial Has deg Conjugate Roots",
+    "content": "card_minpoly_fiber proves that the elements of GF(p^m) sharing a given minimal polynomial g number exactly deg g. The fibre {y : minpoly y = g} is identified with the root set of g in GF(p^m): y is a root of g iff g, being monic irreducible, is the minimal polynomial of y. That root set has deg g elements because g splits in the normal extension (Normal.splits) and is separable over the perfect field 𝔽_p (Algebra.IsSeparable), so its roots are distinct (nodup_roots) and number its degree (Splits.natDegree_eq_card_roots). mdeg_dvd records that every such degree divides m, by the tower law finrank 𝔽_p 𝔽_p⟮x⟯ · finrank 𝔽_p⟮x⟯ GF = m.",
+    "mathContext": "$\\#\\{y \\in \\mathrm{GF}(p^m) : \\mathrm{minpoly}\\,y = g\\} = \\deg g$, with $\\deg g \\mid m$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugate elements", "separable extension", "normal extension", "tower law"],
+    "prerequisites": ["minimal polynomials", "splitting of polynomials", "field degree"]
+  },
+  {
+    "id": "per-field-identity",
+    "proofId": "little-wedderburn-oq-02-oq-02",
+    "range": { "startLine": 93, "endLine": 127 },
+    "type": "theorem",
+    "title": "Per-Field Degree Partition",
+    "content": "degree_identity_field assembles the partition into p^m = Σ_{d∣m} d·N(m,d). The field is counted fiberwise over the image of the minimal-polynomial map (Finset.card_eq_sum_card_fiberwise), each fibre contributing its degree (card_minpoly_fiber); the resulting sum over minimal polynomials is regrouped by degree over the divisors of m, each degree-d group contributing d·(number of degree-d minimal polynomials).",
+    "mathContext": "$p^m = \\sum_{d\\mid m} d\\,N(m,d)$, where $N(m,d)$ is the number of degree-$d$ minimal polynomials of $\\mathrm{GF}(p^m)$.",
+    "significance": "key",
+    "relatedConcepts": ["fiberwise counting", "divisor sum", "partition"],
+    "prerequisites": ["finite sums", "field cardinality"]
+  },
+  {
+    "id": "ambient-independence",
+    "proofId": "little-wedderburn-oq-02-oq-02",
+    "range": { "startLine": 129, "endLine": 169 },
+    "type": "theorem",
+    "title": "The Count Depends Only on the Degree",
+    "content": "For the Möbius inversion to make sense the count N(m,d) must not depend on the ambient field GF(p^m). exists_root_of_dvd shows that whenever d∣k every monic irreducible g of degree d has a root in GF(p^k): the quotient 𝔽_p[X]/(g) = AdjoinRoot g is a degree-d field carrying a root of g, and the embedding criterion FiniteField.nonempty_algHom_of_finrank_dvd drops it into GF(p^k). mem_image_filter_iff then characterizes the degree-d minimal polynomials of GF(p^k) as exactly all monic irreducibles of degree d, and Nfield_eq concludes N(m,d) = N(d,d) for d∣m — an intrinsic degree-only count.",
+    "mathContext": "For $d \\mid m$, every degree-$d$ monic irreducible has a root in $\\mathrm{GF}(p^m)$, so $N(m,d) = N(d)$.",
+    "significance": "key",
+    "relatedConcepts": ["embedding criterion", "AdjoinRoot", "subfield lattice", "intrinsic count"],
+    "prerequisites": ["quotient fields", "algebra homomorphisms", "field degree divisibility"]
+  },
+  {
+    "id": "moebius-necklace",
+    "proofId": "little-wedderburn-oq-02-oq-02",
+    "range": { "startLine": 171, "endLine": 202 },
+    "type": "theorem",
+    "title": "Möbius Inversion: Gauss's Necklace Formula",
+    "content": "With the intrinsic count Nirr p d in hand, degree_identity reads p^m = Σ_{d∣m} d·N(d) for all m. Casting to ℤ and applying ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq inverts this divisor-sum relation into necklace_formula: n·N(n) = Σ_{(a,b): ab=n} μ(a)·p^b, i.e. n·N(n) = Σ_{d∣n} μ(n/d)·p^d — Gauss's count of monic irreducible polynomials of degree n over 𝔽_p.",
+    "mathContext": "$n\\,N(n) = \\sum_{d\\mid n}\\mu(n/d)\\,p^d$.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius function", "Möbius inversion", "divisor antidiagonal", "arithmetic functions"],
+    "prerequisites": ["Möbius inversion", "Möbius function"]
+  }
+]

--- a/src/data/proofs/little-wedderburn-oq-02-oq-02/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-02-oq-02/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "little-wedderburn-oq-02-oq-02",
+  "slug": "little-wedderburn-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset"
+    ],
+    "namespace": "LittleWedderburnOQ0202",
+    "lineCount": 201,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/LittleWedderburnOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Gauss's Necklace Formula: Counting Monic Irreducibles over a Finite Field",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LittleWedderburnOQ02OQ02.lean",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "finite-field",
+      "galois-field",
+      "irreducible-polynomial",
+      "moebius-inversion",
+      "necklace-formula",
+      "wedderburn",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 201,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "badge": "original",
+    "originalContributions": [
+      "necklace_formula: Gauss's formula n·N(n) = Σ_{d∣n} μ(n/d)·p^d for the number N(n) of monic irreducible polynomials of degree n over 𝔽_p, expressed via the divisor antidiagonal — absent from Mathlib (Mathlib has Möbius inversion and the GaloisField machinery, but not the count of irreducibles)",
+      "degree_identity: Gauss's degree identity p^m = Σ_{d∣m} d·N(d) for the intrinsic count N(d), the input that Möbius inversion turns into the necklace formula",
+      "degree_identity_field: the per-field form p^m = Σ_{d∣m} d·N(m,d) obtained by partitioning GF(p^m) by the degree of the minimal polynomial of each element",
+      "card_minpoly_fiber: in a finite field, the elements sharing a given minimal polynomial number exactly its degree — a monic irreducible occurring as a minimal polynomial splits with deg distinct roots (separable + normal)",
+      "Nfield_eq (ambient independence): the degree-d count read off GF(p^m) is the same for every m with d∣m, so the intrinsic count N(d) is well defined; proved by embedding GF(p^d) ↪ GF(p^m) to give every degree-d monic irreducible a root",
+      "exists_root_of_dvd: every monic irreducible of degree d acquires a root in GF(p^k) whenever d∣k, via 𝔽_p[X]/(g) ≅ GF(p^d) and the finrank-divisibility embedding criterion",
+      "mem_image_filter_iff: membership in the degree-d minimal-polynomial image of GF(p^k) (for d∣k) is exactly being a monic irreducible of degree d — the characterization underlying ambient independence",
+      "mdeg_dvd: the degree of any minimal polynomial of GF(p^m) divides m (tower law finrank 𝔽_p⟮x⟯ · finrank ⟮x⟯ GF = m)"
+    ],
+    "prerequisites": [
+      "Mathlib's GaloisField p n with GaloisField.card (|GF(p^n)| = p^n) and GaloisField.finrank (finrank 𝔽_p GF(p^n) = n)",
+      "Finite fields are Galois over their prime subfield: Normal.splits (minimal polynomials split) and Algebra.IsSeparable (minimal polynomials are separable, the field being perfect)",
+      "Splits.natDegree_eq_card_roots and nodup_roots: a separable polynomial that splits has deg distinct roots",
+      "FiniteField.nonempty_algHom_of_finrank_dvd: GF(p^d) embeds in GF(p^k) iff d ∣ k (the embedding criterion)",
+      "AdjoinRoot g ≅ 𝔽_p[X]/(g) as a degree-(deg g) field for irreducible g (AdjoinRoot.powerBasis, AdjoinRoot.eval₂_root)",
+      "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq: Möbius inversion over a commutative ring"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "GaloisField.card / GaloisField.finrank",
+        "description": "The Galois field GF(p^n) has p^n elements and degree n over 𝔽_p; supplies both the cardinality counted in the degree identity and the divisibility of minimal-polynomial degrees.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "Normal.splits / Algebra.IsSeparable.isSeparable",
+        "description": "A finite field is a normal, separable extension of its prime subfield, so each minimal polynomial splits there with distinct roots; the engine behind card_minpoly_fiber.",
+        "module": "Mathlib.FieldTheory.Normal.Defs / Mathlib.FieldTheory.Separable"
+      },
+      {
+        "theorem": "FiniteField.nonempty_algHom_of_finrank_dvd",
+        "description": "An algebra embedding K → L of finite fields exists iff the degrees divide; gives GF(p^d) ↪ GF(p^k) for d ∣ k, hence roots for every degree-d irreducible — the heart of ambient independence.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq",
+        "description": "Möbius inversion: Σ_{d∣n} f(d) = g(n) for all n iff f(n) = Σ_{(a,b): ab=n} μ(a)·g(b); converts the degree identity into the necklace formula.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      },
+      {
+        "theorem": "AdjoinRoot.powerBasis / AdjoinRoot.eval₂_root",
+        "description": "For irreducible g, 𝔽_p[X]/(g) is a field of degree deg g in which the class of X is a root of g; used to manufacture a root of any degree-d irreducible inside GF(p^k).",
+        "module": "Mathlib.RingTheory.AdjoinRoot"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Counting irreducible polynomials over a finite field is one of the oldest applications of Möbius inversion. Gauss, in the unpublished section seven of the Disquisitiones, computed the number of monic irreducible polynomials of degree n modulo a prime p and found N(n) = (1/n)·Σ_{d∣n} μ(n/d)·p^d. The same number counts aperiodic necklaces of n beads in p colours (Moreau's 1872 necklace-counting formula) and the dimension contributions in the free Lie algebra (Witt's formula), so the identity recurs across combinatorics, algebra, and dynamics. The mechanism is uniform: the polynomial X^(p^n) − X over 𝔽_p is the product of all monic irreducibles whose degree divides n, each occurring once because the polynomial is separable; comparing degrees gives p^n = Σ_{d∣n} d·N(d), and Möbius inversion isolates N(n). Equivalently — the route taken here — one partitions the field GF(p^n) itself by the degree of each element's minimal polynomial: an element of degree d is one of the d conjugate roots of a degree-d monic irreducible, and every degree-d irreducible (d∣n) contributes its d roots, so the count of degree-d elements is d·N(d).",
+    "problemStatement": "Answer the parent classification's second open question (little-wedderburn-oq-02-oq-02): count the monic irreducible polynomials of degree n over 𝔽_p by Möbius inversion. Concretely, let N(d) be the number of monic irreducible polynomials of degree d over 𝔽_p. Prove Gauss's degree identity p^n = Σ_{d∣n} d·N(d) and invert it to the necklace/Gauss formula n·N(n) = Σ_{d∣n} μ(n/d)·p^d, with N(d) realised intrinsically (independent of any ambient field) as the number of distinct degree-d minimal polynomials.",
+    "proofStrategy": "Work inside K = GF(p^m). Each element x has a monic irreducible minimal polynomial g = minpoly 𝔽_p x; the map x ↦ g partitions K. card_minpoly_fiber shows each fibre {y : minpoly y = g} equals the root set of g in K and has cardinality deg g — because K is a separable normal extension of 𝔽_p, g splits there with deg g distinct roots (Normal.splits, Algebra.IsSeparable, Splits.natDegree_eq_card_roots, nodup_roots). mdeg_dvd shows deg g ∣ m by the tower law. Summing over the partition (Finset.card_eq_sum_card_fiberwise, then regrouping by degree over m.divisors) yields the per-field identity degree_identity_field: p^m = Σ_{d∣m} d·N(m,d), where N(m,d) counts distinct degree-d minimal polynomials of K. Ambient independence (Nfield_eq) upgrades N(m,d) to a degree-only quantity N(d): for d∣m every monic irreducible of degree d has a root in GF(p^m) (exists_root_of_dvd, built from AdjoinRoot g ≅ GF(p^d) and the embedding criterion FiniteField.nonempty_algHom_of_finrank_dvd), so the degree-d minimal polynomials of GF(p^m) are exactly all monic irreducibles of degree d (mem_image_filter_iff) — independent of m. This gives degree_identity p^m = Σ_{d∣m} d·N(d). Finally ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (after casting to ℤ) inverts it to necklace_formula: n·N(n) = Σ_{(a,b): ab=n} μ(a)·p^b.",
+    "keyInsights": [
+      "Partition, don't factor: instead of factoring X^(p^n) − X into irreducibles (which needs squarefree/radical machinery), partition the field GF(p^n) by the degree of each element's minimal polynomial. The counting then rides on Mathlib's strong minpoly + Galois-extension support.",
+      "Each monic irreducible of degree d contributes exactly d field elements — its d conjugate roots. This factor of d is the whole content of the degree identity; it comes from separability (distinct roots) plus normality (the polynomial actually splits in the field).",
+      "Ambient independence is the subtle step. The count N(m,d) is defined relative to GF(p^m), but the necklace formula needs a single function of d. The key fact: for d∣m every degree-d monic irreducible already has all its roots in GF(p^m), so reading the count off any GF(p^m) with d∣m gives the same number — proved by embedding GF(p^d) ↪ GF(p^m).",
+      "AdjoinRoot manufactures roots without naming GF(p^d): for an abstract monic irreducible g of degree d, 𝔽_p[X]/(g) is a degree-d field carrying a root of g, and the finrank-divisibility embedding criterion drops that root into GF(p^k) whenever d∣k.",
+      "Möbius inversion is the easy half once the degree identity holds for ALL exponents simultaneously — which is exactly why ambient independence (a single N(d) valid in every GF(p^m)) is needed before the inversion can even be stated."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Necklace Formula",
+      "startLine": 3,
+      "endLine": 34,
+      "summary": "Frames the count of monic irreducibles as the second open question of the finite-field classification. States Gauss's degree identity and its Möbius inversion, and outlines the field-partition route: separability and normality give each minimal polynomial deg distinct roots, the embedding criterion gives ambient independence.",
+      "mathContext": "$p^n = \\sum_{d\\mid n} d\\,N(d)$ inverts to $n\\,N(n) = \\sum_{d\\mid n}\\mu(n/d)\\,p^d$."
+    },
+    {
+      "id": "fiber",
+      "title": "Conjugate Count: deg Roots per Minimal Polynomial",
+      "startLine": 46,
+      "endLine": 91,
+      "summary": "Nfield defines the degree-d count via the minimal-polynomial image. card_minpoly_fiber proves the elements of GF(p^m) sharing a given minimal polynomial g number exactly deg g, identifying the fibre with the (separable, splitting) root set of g. mdeg_dvd shows every such degree divides m.",
+      "mathContext": "$\\#\\{y : \\mathrm{minpoly}\\,y = g\\} = \\deg g$, and $\\deg g \\mid m$."
+    },
+    {
+      "id": "degree-identity-field",
+      "title": "Per-Field Degree Partition",
+      "startLine": 93,
+      "endLine": 124,
+      "summary": "degree_identity_field assembles the partition: card GF(p^m) = Σ over minimal polynomials of (deg) = Σ_{d∣m} d·N(m,d), via fiberwise counting and regrouping by degree over the divisors of m.",
+      "mathContext": "$p^m = \\sum_{d\\mid m} d\\,N(m,d)$ where $N(m,d)$ counts degree-$d$ minimal polynomials of $\\mathrm{GF}(p^m)$."
+    },
+    {
+      "id": "ambient-independence",
+      "title": "Ambient Independence: a Degree-Only Count",
+      "startLine": 126,
+      "endLine": 169,
+      "summary": "exists_root_of_dvd embeds GF(p^d) ↪ GF(p^k) (d∣k) to give every degree-d monic irreducible a root. mem_image_filter_iff characterizes the degree-d image as exactly the monic irreducibles of degree d. Nfield_eq concludes N(m,d) = N(d,d) for d∣m: the count depends only on d.",
+      "mathContext": "For $d\\mid m$, $N(m,d) = N(d)$: the degree-$d$ count is intrinsic."
+    },
+    {
+      "id": "necklace",
+      "title": "Möbius Inversion: Gauss's Necklace Formula",
+      "startLine": 171,
+      "endLine": 200,
+      "summary": "Nirr packages the intrinsic count N(d). degree_identity restates p^m = Σ_{d∣m} d·N(d) with it. necklace_formula casts to ℤ and applies ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq to obtain n·N(n) = Σ_{(a,b): ab=n} μ(a)·p^b.",
+      "mathContext": "$n\\,N(n) = \\sum_{d\\mid n}\\mu(n/d)\\,p^d$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "little-wedderburn-oq-02-oq-02-oq-01",
+      "question": "Derive the explicit lower bound N(n) ≥ (p^n − p^{n/2+1})/n > 0 from the necklace formula, giving an independent proof that monic irreducibles of every degree exist over every 𝔽_p (and hence that GF(p^n) exists for all n).",
+      "significance": "medium"
+    },
+    {
+      "id": "little-wedderburn-oq-02-oq-02-oq-02",
+      "question": "Prove the polynomial form X^(p^n) − X = ∏_{d∣n} ∏_{g monic irreducible, deg g = d} g over 𝔽_p, recovering the degree identity by taking degrees and giving the factorization directly.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-02",
+      "relationship": "parent",
+      "description": "The parent establishes the existence-and-uniqueness classification of finite fields; this entry answers its second open question by counting the monic irreducible polynomials of each degree via Möbius inversion of the field partition."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae (Section Seven, unpublished) / Werke vol. 2",
+      "author": "C. F. Gauss",
+      "year": "1863",
+      "venue": "Gauss, Werke",
+      "description": "Gauss's original count of monic irreducible polynomials modulo a prime, the source of the formula N(n) = (1/n) Σ_{d∣n} μ(n/d) p^d."
+    },
+    {
+      "title": "Sur les permutations circulaires distinctes",
+      "author": "C. Moreau",
+      "year": "1872",
+      "venue": "Nouvelles annales de mathématiques",
+      "description": "The necklace-counting formula, combinatorially identical to Gauss's count of irreducibles."
+    },
+    {
+      "title": "Mathlib4: NumberTheory.ArithmeticFunction.Moebius",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of sum_eq_iff_sum_mul_moebius_eq, the Möbius inversion used to invert the degree identity."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Gauss's necklace formula for the number N(n) of monic irreducible polynomials of degree n over 𝔽_p is established by Möbius inversion of a field-partition identity. Partitioning GF(p^m) by the degree of each element's minimal polynomial — and using that a minimal polynomial in this separable normal extension splits with exactly deg distinct roots — gives the per-field degree identity p^m = Σ_{d∣m} d·N(m,d). Embedding GF(p^d) ↪ GF(p^m) for d∣m shows the degree-d count is intrinsic, N(m,d) = N(d), yielding p^m = Σ_{d∣m} d·N(d). Möbius inversion then gives the necklace formula n·N(n) = Σ_{d∣n} μ(n/d)·p^d. 204 lines, 8 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib supplies the finite-field machinery (GaloisField, normality, separability, the embedding criterion) and Möbius inversion, but not the count of irreducible polynomials; the degree identity, its ambient independence, and the necklace formula are new. The partition route deliberately avoids polynomial factorization into irreducibles (radical/squarefree machinery), trading it for minimal-polynomial conjugate-counting in a Galois extension.",
+    "openQuestions": [
+      "Extract the explicit positive lower bound N(n) ≥ (p^n − p^{n/2+1})/n and re-derive existence of GF(p^n).",
+      "Prove the polynomial factorization X^(p^n) − X = ∏_{d∣n} ∏_{deg g = d} g recovering the degree identity directly."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the second open question of the finite-field classification (`little-wedderburn-oq-02`): **count the monic irreducible polynomials of degree `n` over `𝔽_p` by Möbius inversion**.

Writing `N(d)` for the number of monic irreducible polynomials of degree `d` over `𝔽_p`, this entry proves:

- **Gauss's degree identity** — `p^n = Σ_{d∣n} d·N(d)`
- **Gauss's necklace formula** — `n·N(n) = Σ_{d∣n} μ(n/d)·p^d`

## Approach: partition, don't factor

Mathlib has the `GaloisField` machinery and Möbius inversion, but **not** the count of irreducibles, nor the factorization `X^(p^n) − X = ∏ irreducibles` (which would need radical/squarefree UFD machinery). Instead the proof **partitions the field `GF(p^n)` by the degree of each element's minimal polynomial**, riding Mathlib's strong `minpoly` + Galois-extension support:

- `card_minpoly_fiber` — the elements sharing a minimal polynomial `g` number exactly `deg g`: in the separable normal extension `GF(p^m)/𝔽_p`, `g` splits with `deg g` distinct roots.
- `degree_identity_field` — fiberwise counting gives `p^m = Σ_{d∣m} d·N(m,d)`.
- `exists_root_of_dvd` + `Nfield_eq` — **ambient independence**: every monic irreducible of degree `d∣m` has a root in `GF(p^m)` (via `AdjoinRoot g ≅ GF(p^d)` and the embedding criterion `FiniteField.nonempty_algHom_of_finrank_dvd`), so the count `N(d)` is intrinsic.
- `necklace_formula` — Möbius inversion (`ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`).

## Verification

- **201 lines, 8 theorems, 2 definitions, 0 sorries.**
- `#print axioms necklace_formula` / `degree_identity` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`). **Verified, 0-axiom.**
- Badge `original` (Mathlib lacks the irreducible count).
- Builds clean via `./proofs/scripts/docker-build.sh` equivalent (`lake env lean Proofs/LittleWedderburnOQ02OQ02.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)