### PR TITLE
Enrich Dirichlet via Minkowski (minkowski-theorem-oq-06)

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-06/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-06/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 6, "endLine": 54 },
+    "type": "context",
+    "title": "Geometry of numbers vs. pigeonhole",
+    "content": "The docstring frames the contribution: Mathlib already proves Dirichlet's theorem by the pigeonhole principle, but this file gives the geometry-of-numbers proof, deriving it from the gallery's integer-lattice Minkowski theorem. The region R = {|x| ≤ N+½, |αx−y| ≤ 1/N} has area 4+2/N > 4, so the strict form of Minkowski applies with no boundary/compactness case. Honesty notes: the Minkowski-route bound is 1/N (not the sharper pigeonhole 1/(N+1)), and N=1 is trivial.",
+    "mathContext": "$R = \\{(x,y) : |x| \\le N+\\tfrac12,\\ |\\alpha x - y| \\le \\tfrac1N\\}$, $\\;\\text{area} = 4 + \\tfrac2N > 4$.",
+    "significance": "context",
+    "relatedConcepts": ["geometry of numbers", "Minkowski's theorem", "Dirichlet approximation", "pigeonhole principle"],
+    "prerequisites": ["lattices", "convex bodies", "Diophantine approximation"]
+  },
+  {
+    "id": "ann-shear",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 56, "endLine": 78 },
+    "type": "definition",
+    "title": "The area-preserving shear (det = 1)",
+    "content": "Defines the shear (x,t) ↦ (x, αx+t) as Matrix.toLin' of the 2×2 matrix [[1,0],[α,1]], with simp lemmas computing its two output coordinates, and proves shear_det = 1 via LinearMap.det_toLin' and Matrix.det_fin_two_of. Determinant 1 is precisely what makes the linear change of variables area-preserving, so the sheared region inherits the box's area with no Jacobian correction beyond the factor |det| = 1.",
+    "mathContext": "$S = \\begin{pmatrix}1&0\\\\\\alpha&1\\end{pmatrix}$, $\\;S(x,t) = (x, \\alpha x + t)$, $\\;\\det S = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["shear transformation", "determinant", "linear map", "area preservation", "Matrix.toLin'"],
+    "prerequisites": ["linear algebra", "2×2 determinants"]
+  },
+  {
+    "id": "ann-box",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 80, "endLine": 107 },
+    "type": "definition",
+    "title": "The inflated axis-aligned box and its volume",
+    "content": "Builds the box [−(N+½),N+½]×[−1/N,1/N] as a product of intervals (box, with half-lengths boxR), and proves it is convex and centrally symmetric. box_volume computes its Lebesgue measure (2(N+½))·(2/N) via volume_pi_pi and Real.volume_Icc. Inflating the x-half-width to N+½ (rather than N) is what pushes the area strictly above 4 so the strict Minkowski theorem applies.",
+    "mathContext": "$\\text{vol}(\\text{box}) = \\big(2(N+\\tfrac12)\\big)\\cdot\\big(2\\cdot\\tfrac1N\\big) = (2N+1)\\tfrac2N$.",
+    "significance": "supporting",
+    "relatedConcepts": ["product measure", "interval volume", "central symmetry", "convexity"],
+    "prerequisites": ["Lebesgue measure", "product sets"]
+  },
+  {
+    "id": "ann-region-volume",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 108, "endLine": 137 },
+    "type": "theorem",
+    "title": "The region has area 4 + 2/N > 4",
+    "content": "Defines region = shear '' box and transports convexity and central symmetry through the linear map. region_volume_gt is the quantitative heart: by Measure.addHaar_image_linearMap the area is |det shear|·(box area) = 1·(4+2/N), which exceeds 2² = 4 for N > 0. This is the precise hypothesis Minkowski's strict theorem consumes.",
+    "mathContext": "$\\text{vol}(\\text{region}) = |\\det S|\\cdot\\text{vol}(\\text{box}) = 4 + \\tfrac2N > 4 = 2^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["change of variables", "addHaar_image_linearMap", "Minkowski hypothesis", "volume of linear image"],
+    "prerequisites": ["Haar measure", "linear image volume formula"]
+  },
+  {
+    "id": "ann-lattice-coords",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 139, "endLine": 150 },
+    "type": "theorem",
+    "title": "Integer coordinates of a lattice point",
+    "content": "stdLattice_coord_int shows that a point of the standard integer lattice ℤ² has integer coordinates, using Module.Basis.mem_span_iff_repr_mem on the standard basis. This is the single bridge converting the abstract lattice point Minkowski returns (a member of the ℤ-span of the standard basis) into the concrete integers p, q of the approximation.",
+    "mathContext": "$v \\in \\text{span}_{\\mathbb{Z}}(\\text{stdBasis}) \\Rightarrow \\forall i,\\ \\exists k \\in \\mathbb{Z},\\ v_i = k$.",
+    "significance": "key",
+    "relatedConcepts": ["integer lattice", "ℤ-span", "basis representation", "Module.Basis.mem_span_iff_repr_mem"],
+    "prerequisites": ["modules over ℤ", "bases and coordinates"]
+  },
+  {
+    "id": "ann-dirichlet-approx",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 152, "endLine": 245 },
+    "type": "theorem",
+    "title": "Dirichlet's approximation theorem (main result)",
+    "content": "dirichlet_approx: for every α and N ≥ 1 there are integers 0 < q ≤ N, p with |qα−p| ≤ 1/N. N=1 is the rounding bound abs_sub_round. For N ≥ 2, Minkowski yields a nonzero lattice point in region; unpacking it as a sheared box point gives |q₀| ≤ N+½ (so |q₀| ≤ N by integrality) and |αq₀−p₀| ≤ 1/N. Crucially q₀ ≠ 0 — else |p₀| ≤ 1/N < 1 forces p₀ = 0 and the whole point to vanish, contradicting nonzeroness — and a sign flip arranges q > 0.",
+    "mathContext": "$\\exists\\, q,p \\in \\mathbb{Z}:\\ 0 < q \\le N \\;\\wedge\\; |q\\alpha - p| \\le \\tfrac1N$.",
+    "significance": "critical",
+    "relatedConcepts": ["Dirichlet's theorem", "lattice point extraction", "sign normalisation", "nonzero point argument"],
+    "prerequisites": ["Minkowski's theorem", "integer rounding", "case analysis"]
+  },
+  {
+    "id": "ann-dirichlet-sq",
+    "proofId": "minkowski-theorem-oq-06",
+    "range": { "startLine": 246, "endLine": 269 },
+    "type": "theorem",
+    "title": "Corollary: the 1/q² bound",
+    "content": "dirichlet_sq_bound divides the main inequality by q to recover the classical form |α − p/q| ≤ 1/(qN) ≤ 1/q². The step uses q ≤ N to bound 1/(qN) ≤ 1/q² (one_div_le_one_div_of_le with q² ≤ qN), gcongr, and field manipulation. This is the consequence that seeds continued-fraction and Hurwitz-type results.",
+    "mathContext": "$|\\alpha - p/q| \\le \\dfrac{1}{qN} \\le \\dfrac{1}{q^2}$, using $q \\le N$.",
+    "significance": "key",
+    "relatedConcepts": ["rational approximation", "1/q² bound", "continued fractions", "Hurwitz's theorem"],
+    "prerequisites": ["inequality manipulation", "division of reals"]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-06/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MinkowskiTheoremOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const minkowskiTheoremOQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const minkowskiTheoremOQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const minkowskiTheoremOQ06Data: ProofData = {
+  proof: minkowskiTheoremOQ06Proof,
+  annotations: minkowskiTheoremOQ06Annotations,
+}

--- a/src/data/proofs/minkowski-theorem-oq-06/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-06/meta.json
@@ -121,5 +121,68 @@
       "The standard lattice ℤ² ⊂ ℝ² and integer coordinates of span members"
     ]
   },
+  "sections": [
+    {
+      "id": "header-docstring",
+      "title": "Overview: Dirichlet via geometry of numbers",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Imports the gallery's Minkowski development plus the Lebesgue/linear-map measure machinery, and the docstring states the goal (Dirichlet's theorem for every α and N ≥ 1) and the strategy: exhibit a centrally symmetric convex region of area > 4 in ℝ² and read off a nonzero lattice point. Honesty notes record that the Minkowski-route bound is |qα−p| ≤ 1/N (not the sharper pigeonhole 1/(N+1)) and that N=1 is the trivial rounding case.",
+      "mathContext": "Region $R = \\{(x,y) : |x| \\le N+\\tfrac12,\\ |\\alpha x - y| \\le 1/N\\}$, area $4 + 2/N > 4 = 2^2$."
+    },
+    {
+      "id": "shear",
+      "title": "§1: The area-preserving shear",
+      "startLine": 56,
+      "endLine": 78,
+      "summary": "Defines the 2×2 shear matrix [[1,0],[α,1]] and the shear endomorphism (x,t) ↦ (x, αx+t) as Matrix.toLin', with simp lemmas for its two coordinates, and proves shear_det: det = 1 via LinearMap.det_toLin' and Matrix.det_fin_two_of.",
+      "mathContext": "$S(x,t) = (x,\\ \\alpha x + t)$, $\\det S = 1$ — area-preserving."
+    },
+    {
+      "id": "convex-body",
+      "title": "§2: The convex body (inflated, sheared box)",
+      "startLine": 80,
+      "endLine": 137,
+      "summary": "Builds the axis-aligned box [−(N+½),N+½]×[−1/N,1/N] (boxR, box), proving convexity, central symmetry, and its volume (2(N+½))·(2/N) via volume_pi_pi. Defines region = shear '' box, transports convexity and symmetry through the linear map, and proves region_volume_gt: the area is |det S|·(box area) = 4 + 2/N, strictly above 2² = 4 (the key quantitative input for Minkowski).",
+      "mathContext": "$\\text{vol}(\\text{region}) = |\\det S|\\cdot\\text{vol}(\\text{box}) = 1\\cdot(2N+1)\\tfrac2N = 4 + \\tfrac2N$."
+    },
+    {
+      "id": "lattice-coords",
+      "title": "§3: Extracting integer coordinates",
+      "startLine": 139,
+      "endLine": 150,
+      "summary": "stdLattice_coord_int: a point of the standard integer lattice ℤ² has integer coordinates, via Module.Basis.mem_span_iff_repr_mem on the standard basis. This is the only step connecting the measure-theoretic lattice point to elementary number theory.",
+      "mathContext": "$v \\in \\mathbb{Z}^2 \\Rightarrow \\forall i,\\ \\exists k \\in \\mathbb{Z},\\ v_i = k$."
+    },
+    {
+      "id": "dirichlet",
+      "title": "§4: Dirichlet's approximation theorem and the 1/q² corollary",
+      "startLine": 152,
+      "endLine": 269,
+      "summary": "dirichlet_approx: for α real and N ≥ 1 there exist integers 0 < q ≤ N, p with |qα−p| ≤ 1/N. N=1 is the rounding bound; for N ≥ 2, Minkowski gives a nonzero lattice point in region, whose coordinates q₀,p₀ satisfy |q₀| ≤ N (integrality collapses N+½) and |αq₀−p₀| ≤ 1/N, with q₀ ≠ 0 forced (else x = 0) and a sign flip making q > 0. dirichlet_sq_bound divides by q to get |α − p/q| ≤ 1/(qN) ≤ 1/q².",
+      "mathContext": "$\\exists\\, 0 < q \\le N,\\ p:\\ |q\\alpha - p| \\le 1/N$, hence $|\\alpha - p/q| \\le 1/(qN) \\le 1/q^2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Dirichlet's approximation theorem is obtained as a direct corollary of the gallery's integer-lattice Minkowski theorem: the centrally symmetric convex region {|x| ≤ N+½, |αx−y| ≤ 1/N} is a determinant-1 shear of an axis-aligned box, so its area is exactly 4 + 2/N > 4, and Minkowski's strict theorem forces a nonzero lattice point whose coordinates give integers 0 < q ≤ N, p with |qα−p| ≤ 1/N — hence |α − p/q| ≤ 1/q². 12 theorems, 5 definitions, 269 lines, 0 sorries, 0 axioms.",
+    "implications": "Provides the geometry-of-numbers proof of a theorem Mathlib derives only by pigeonhole, making explicit that the lattice-point count is the structural reason the approximation exists. The shear-of-a-box technique — turn a Diophantine inequality region into a rectangle via a determinant-1 linear map, then apply Minkowski — is the reusable template behind many geometry-of-numbers results (the two-squares theorem, Minkowski's linear-forms theorem, and simultaneous approximation in higher dimensions).",
+    "openQuestions": [
+      "Extend to simultaneous Diophantine approximation: derive |qα_i − p_i| ≤ q^{−1/n} for a vector (α_1,…,α_n) by applying the n+1 dimensional Minkowski theorem to the analogous sheared box.",
+      "Recover the infinitude of good approximations (|α − p/q| < 1/q² for infinitely many q) — the standard corollary for irrational α — by iterating dirichlet_sq_bound with growing N and ruling out a finite approximation set.",
+      "Quantify the gap to the optimal Hurwitz constant: the Minkowski route gives 1/q², but the sharp |α − p/q| < 1/(√5 q²) requires a finer (non-box) convex body — can such a body be formalized in the same framework?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "minkowski-theorem",
+      "relationship": "parent",
+      "description": "Supplies the engine minkowski_integer_lattice_proved — the ℤⁿ form of Minkowski's convex body theorem (a centrally symmetric convex set of volume > 2ⁿ contains a nonzero lattice point). This entry answers that parent's listed open question on deriving Dirichlet's theorem as a corollary."
+    },
+    {
+      "proofId": "dirichlet-approximation-theorem",
+      "relationship": "related",
+      "description": "The classical theorem proved here by geometry of numbers. The gallery's dedicated Dirichlet entry treats the result directly (and Mathlib derives it by pigeonhole); this entry gives the alternative Minkowski/lattice-point proof."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `minkowski-theorem-oq-06` (Dirichlet's approximation theorem as a corollary of Minkowski's convex body theorem). The entry had a strong `overview` but was missing inline annotations, `index.ts`, sections, conclusion, and cross-references.

## Changes
- **Created `index.ts`** — was missing, so the proof page would render "proof not found" on the live site despite appearing in the gallery listing.
- **Created `annotations.json`** — 7 annotations covering the docstring framing, the determinant-1 shear, the inflated box and its volume, the area-exceeds-4 computation (`addHaar_image_linearMap`), the integer-coordinate extraction, the main `dirichlet_approx`, and the `1/q²` corollary. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **`sections`** added — 5 sections covering all 269 lines, each with `mathContext`.
- **`conclusion`** added — summary, implications (the shear-of-a-box geometry-of-numbers template), 3 open questions (simultaneous approximation, infinitude of good approximations, the Hurwitz constant gap).
- **`crossReferences`** added — parent `minkowski-theorem` (the engine) and related `dirichlet-approximation-theorem`.

## Axiom integrity
Verified `status: verified` / `badge: original` / `axiomCount: 0` is accurate: 0 `sorry`, 0 `axiom`, no `native_decide`; `#print axioms` reports only propext/Classical.choice/Quot.sound. The result depends on the gallery Minkowski development, which is itself verified/0-axiom.

## Verification
`tsc -b` and `vite build` both pass (exit 0). All proof JSON validates.