### PR TITLE
research(cayley-hamilton-oq-04-oq-01): explicit 3×3 Cayley–Hamilton [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -713,6 +713,7 @@ import Proofs.CayleyHamiltonOQ01OQ04
 import Proofs.CayleyHamiltonOQ02
 import Proofs.CayleyHamiltonOQ02OQ02
 import Proofs.CayleyHamiltonOQ04
+import Proofs.CayleyHamiltonOQ04OQ01
 import Proofs.CayleyHamiltonReductionOQ01
 import Proofs.CayleyHamiltonReductionOQ01OQ02
 import Proofs.CayleyHamiltonReductionOQ02

--- a/proofs/Proofs/CayleyHamiltonOQ04OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ04OQ01.lean
@@ -1,0 +1,90 @@
+import Mathlib.LinearAlgebra.Matrix.Adjugate
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Tactic
+
+/-
+# Explicit 3×3 Cayley–Hamilton in Trace / Principal-Minor / Determinant Form
+
+## What This Proves
+For an arbitrary 3×3 matrix `A` over a commutative ring `R`, the characteristic
+polynomial is `X³ − (tr A)X² + c₂ X − det A`, where `c₂` is the sum of the three
+2×2 principal minors of `A`. This file proves, *by direct entrywise computation*
+(not the general `Matrix.aeval_self_charpoly` machinery):
+
+1. **Explicit 3×3 Cayley–Hamilton**:
+   `A³ − (tr A) • A² + c₂ • A − (det A) • 1 = 0`.
+2. **Square/cube reductions**: rearranged forms expressing `A³` as a linear
+   combination of `A²`, `A`, and `1`.
+
+## Why This Is Not Just a Re-export
+Mathlib's `Matrix.aeval_self_charpoly` states Cayley–Hamilton in terms of
+`charpoly`, the determinant of `X • 1 − A`; it does *not* hand you the bare
+identity `A³ − (tr A) • A² + c₂ • A − (det A) • 1 = 0` in trace / minor /
+determinant form. The result here is proved from scratch by expanding
+`Matrix.mul_apply` over `Fin 3` and closing with `ring`, so the file is
+self-contained down to `ring`. It is the exact 3×3 analogue of the 2×2 identity
+`A² − (tr A) • A + (det A) • 1 = 0` proved in `CayleyHamiltonOQ04.lean`, ported by
+the same method as requested by open question OQ-04 of the Cayley–Hamilton entry.
+
+## The middle coefficient `c₂`
+For `A = (aᵢⱼ)`, the coefficient of `X` in the characteristic polynomial is the
+sum of the 2×2 principal minors (the second elementary symmetric function of the
+eigenvalues):
+`c₂ = (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁)`.
+
+## Mathematical Significance
+The 3×3 case underlies spatial linear algebra: rotations in `ℝ³`, the inertia
+tensor, and the cross-product/triple-product identities all live here. The
+trace/minor/determinant coefficients are the three elementary symmetric
+polynomials in the eigenvalues, so this identity is the degree-3 instance of the
+Newton-style passage from power sums to the characteristic polynomial.
+
+## Extends
+- CayleyHamiltonOQ04.lean (Explicit 2×2 Cayley–Hamilton)
+- CayleyHamilton.lean (Wiedijk #49)
+- Open question OQ-04 of the Cayley–Hamilton entry (the explicit 3×3 analogue).
+
+## Status
+- [x] Complete proof (no sorries, no axioms)
+-/
+
+namespace CayleyHamiltonOQ04OQ01
+
+open Matrix
+
+variable {R : Type*} [CommRing R]
+
+/-- The middle characteristic coefficient `c₂` of a 3×3 matrix: the sum of its
+three 2×2 principal minors,
+`(a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁)`. This is the second
+elementary symmetric function of the eigenvalues, i.e. the coefficient of `X` in
+the characteristic polynomial `X³ − (tr A)X² + c₂X − det A`. -/
+def c2 (A : Matrix (Fin 3) (Fin 3) R) : R :=
+  (A 0 0 * A 1 1 - A 0 1 * A 1 0)
+    + (A 0 0 * A 2 2 - A 0 2 * A 2 0)
+    + (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+
+/-- **Explicit 3×3 Cayley–Hamilton.** Every 3×3 matrix satisfies its own
+characteristic polynomial `X³ − (tr A)X² + c₂X − det A`, proved by direct
+entrywise expansion over `Fin 3` and `ring`. -/
+theorem cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul
+    (A : Matrix (Fin 3) (Fin 3) R) :
+    A ^ 3 - A.trace • A ^ 2 + c2 A • A - A.det • 1 = 0 := by
+  have h3 : A ^ 3 = A * A * A := by rw [pow_succ, pow_succ, pow_one]
+  rw [h3, pow_two]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_three, Matrix.trace_fin_three,
+      Matrix.det_fin_three, c2, Matrix.add_apply, Matrix.sub_apply,
+      Matrix.smul_apply, Matrix.zero_apply] <;> ring
+
+/-- A convenient restatement: `A³ = (tr A) • A² − c₂ • A + (det A) • 1`, expressing
+the cube of any 3×3 matrix as a linear combination of `A²`, `A`, and the
+identity. -/
+theorem cube_eq (A : Matrix (Fin 3) (Fin 3) R) :
+    A ^ 3 = A.trace • A ^ 2 - c2 A • A + A.det • 1 := by
+  have h := cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul A
+  linear_combination (norm := module) h
+
+end CayleyHamiltonOQ04OQ01

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/annotations.json
@@ -1,0 +1,67 @@
+[
+  {
+    "id": "ann-ch0401-background",
+    "proofId": "cayley-hamilton-oq-04-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "The 3×3 Case Cayley Computed by Hand",
+    "content": "The module docstring frames the file as the explicit 3×3 analogue of the parent's 2×2 identity, answering OQ-04 of the Cayley–Hamilton entry. As in the 2×2 case, Mathlib's `Matrix.aeval_self_charpoly` phrases Cayley–Hamilton via the abstract `charpoly` polynomial, not the bare trace/principal-minor/determinant identity A³ − (tr A)·A² + c₂·A − (det A)·1 = 0. That identity is proved here from scratch by entrywise expansion over Fin 3 closed with `ring`, exactly the 3×3 computation Cayley described in his 1858 'Memoir on the Theory of Matrices'.",
+    "mathContext": "For a 3×3 matrix $A=(a_{ij})$ the characteristic polynomial is $\\chi_A(X)=X^3-(\\operatorname{tr}A)X^2+c_2X-\\det A$, where $\\operatorname{tr}A=a_{00}+a_{11}+a_{22}$, $c_2$ is the sum of the three $2\\times2$ principal minors, and $\\det A$ is the full determinant. Cayley–Hamilton asserts $\\chi_A(A)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cayley-Hamilton theorem",
+      "characteristic polynomial",
+      "elementary symmetric functions",
+      "principal minors"
+    ],
+    "prerequisites": [
+      "3×3 matrix arithmetic",
+      "trace, determinant, and principal minors"
+    ]
+  },
+  {
+    "id": "ann-ch0401-c2",
+    "proofId": "cayley-hamilton-oq-04-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "The Middle Coefficient c₂ as a Sum of Principal Minors",
+    "content": "`c2 A` is defined as (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the sum of the three 2×2 principal minors of A. This is the second elementary symmetric function e₂(λ₁,λ₂,λ₃) of the eigenvalues and the coefficient of X in the characteristic polynomial. Naming it as a definition makes the main identity read like the textbook characteristic polynomial.",
+    "mathContext": "$c_2=\\sum_{i<j}(a_{ii}a_{jj}-a_{ij}a_{ji})=\\lambda_1\\lambda_2+\\lambda_1\\lambda_3+\\lambda_2\\lambda_3=e_2(\\lambda)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "principal minors",
+      "elementary symmetric polynomials"
+    ],
+    "prerequisites": [
+      "2×2 minors of a matrix"
+    ]
+  },
+  {
+    "id": "ann-ch0401-main",
+    "proofId": "cayley-hamilton-oq-04-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 90
+    },
+    "type": "proof-technique",
+    "title": "Entrywise Fin 3 Expansion Closed by ring",
+    "content": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul` proves A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 by first rewriting A³ = A·A·A and A² = A·A, then reducing to the nine scalar entries with `Matrix.ext` and `fin_cases` over Fin 3 × Fin 3. Each entry is expanded with `Matrix.mul_apply`, `Fin.sum_univ_three`, `Matrix.trace_fin_three`, `Matrix.det_fin_three`, and the smul/add/sub entry lemmas, then closed with `ring` — every entry equation is a degree-3 polynomial identity in the nine entries. `cube_eq` rearranges this to the cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 via `linear_combination (norm := module)`.",
+    "mathContext": "Entry $(i,j)$ of $A^3$ is $\\sum_{k,l}a_{ik}a_{kl}a_{lj}$; subtracting $(\\operatorname{tr}A)(A^2)_{ij}$, adding $c_2 a_{ij}$, and subtracting $(\\det A)\\delta_{ij}$ gives $0$ as a polynomial identity.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cayley-Hamilton theorem",
+      "matrix multiplication",
+      "polynomial identities"
+    ],
+    "prerequisites": [
+      "matrix multiplication via Matrix.mul_apply",
+      "the ring tactic"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "cayley-hamilton-oq-04-oq-01",
+  "title": "Explicit 3×3 Cayley–Hamilton in Trace/Principal-Minor/Determinant Form",
+  "slug": "cayley-hamilton-oq-04-oq-01",
+  "description": "The explicit 3×3 analogue of the parent's 2×2 Cayley–Hamilton identity, proved by direct entrywise computation over Fin 3 rather than the general charpoly machinery. Establishes A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 over any commutative ring, where c₂ is the sum of the three 2×2 principal minors (the second elementary symmetric function of the eigenvalues), together with the rearranged cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1. 2 theorems, 1 definition, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ04OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "matrices",
+      "determinant",
+      "principal-minors",
+      "characteristic-polynomial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). The 3×3 Cayley–Hamilton identity is proved from scratch by entrywise Fin 3 expansion (Matrix.mul_apply / Fin.sum_univ_three / trace_fin_three / det_fin_three) closed with `ring`; the cube reduction follows by `linear_combination`.",
+    "lineCount": 90,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "originalContributions": [
+      "cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul: explicit 3×3 Cayley–Hamilton A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 in trace/principal-minor/determinant form, proved entrywise over Fin 3 (Mathlib only provides the abstract charpoly form)",
+      "c2: named definition of the middle characteristic coefficient as the sum of the three 2×2 principal minors, the second elementary symmetric function of the eigenvalues",
+      "cube_eq: rearrangement A³ = (tr A)·A² − c₂·A + (det A)·1 expressing the cube as a linear combination of A², A, and 1"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cayley's 1858 'Memoir on the Theory of Matrices' verified the Cayley–Hamilton theorem explicitly precisely in the 2×2 and 3×3 cases by direct computation, declining 'the labour of a formal proof' in the general case. This file carries out exactly the 3×3 computation Cayley described, in the trace/principal-minor/determinant form. The coefficients (tr A, c₂, det A) of the characteristic polynomial X³ − (tr A)X² + c₂X − det A are the three elementary symmetric functions of the eigenvalues, so the identity is the degree-3 instance of the passage from a matrix's invariants to its annihilating polynomial.",
+    "problemStatement": "For any 3×3 matrix A over a commutative ring, prove A³ − (tr A)·A² + c₂·A − (det A)·1 = 0, where c₂ = (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁) is the sum of the three 2×2 principal minors.",
+    "text": "The characteristic polynomial of a 3×3 matrix A is X³ − (tr A)X² + c₂X − det A, where tr A = a₀₀+a₁₁+a₂₂, c₂ is the sum of the three 2×2 principal minors, and det A is the full determinant. Expanding A² and A³ entrywise and forming the combination A³ − (tr A)·A² + c₂·A − (det A)·1 yields the zero matrix in every one of the nine entries — a polynomial identity in the nine entries of A. Rearranging gives the cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1, the degree-3 recurrence that expresses every power Aⁿ (n ≥ 3) as a linear combination of 1, A, A².",
+    "proofStrategy": "A³ is rewritten as A·A·A (via `pow_succ`/`pow_one`) and A² as A·A (`pow_two`). The matrix equation is reduced to its nine scalar-entry identities by `Matrix.ext` and `fin_cases` over Fin 3 × Fin 3; each entry is expanded with `Matrix.mul_apply`, `Fin.sum_univ_three`, `Matrix.trace_fin_three`, `Matrix.det_fin_three`, and the smul/add/sub entry lemmas, then closed with `ring`. The cube reduction is obtained from the main identity by `linear_combination (norm := module)`.",
+    "keyInsights": [
+      "The trace/principal-minor/determinant Cayley–Hamilton identity is NOT what Mathlib's `Matrix.aeval_self_charpoly` provides — that theorem is phrased via the abstract `charpoly` polynomial — so the bare 3×3 identity must be proved from scratch, exactly as in the parent's 2×2 case.",
+      "The middle coefficient c₂ is the sum of the three 2×2 principal minors, i.e. the second elementary symmetric function of the eigenvalues; naming it as a definition makes the identity read like the textbook characteristic polynomial X³ − (tr A)X² + c₂X − det A.",
+      "Once reduced to entries by `fin_cases` over Fin 3, each of the nine matrix-entry equations is a polynomial identity of degree 3 in the nine entries that `ring` closes, keeping the file self-contained down to the ring axioms.",
+      "The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the degree-3 linear recurrence underlying closed forms for Aⁿ, matrix exponentials, and resolvents of 3×3 matrices."
+    ],
+    "prerequisites": [
+      "3×3 matrix arithmetic: trace, determinant, matrix multiplication",
+      "Principal minors and the elementary symmetric functions of the eigenvalues",
+      "The characteristic polynomial and the Cayley–Hamilton theorem"
+    ]
+  },
+  "conclusion": {
+    "summary": "2 theorems, 1 definition, 90 lines, 0 axioms. The explicit 3×3 analogue of the parent's 2×2 Cayley–Hamilton identity, in trace/principal-minor/determinant form, proved entirely by entrywise Fin 3 expansion closed with `ring`. Answers open question OQ-04 of the Cayley–Hamilton entry verbatim.",
+    "implications": "The 3×3 case underlies spatial linear algebra: rotation matrices in ℝ³, the inertia tensor, and triple-product identities. The cube reduction A³ = (tr A)·A² − c₂·A + (det A)·1 is the recurrence behind closed forms for powers, exponentials, and resolvents of 3×3 matrices. Together with the parent 2×2 file it provides fully explicit, axiom-free witnesses of Cayley–Hamilton in the two cases Cayley himself computed by hand.",
+    "openQuestions": [
+      "Derive a closed form for Aⁿ of a 3×3 matrix by solving the degree-3 linear recurrence cube_eq for the scalar coefficients of 1, A, A², in terms of the eigenvalues or the invariants (tr A, c₂, det A).",
+      "Express c₂ intrinsically as ((tr A)² − tr(A²))/2 over a commutative ring where 2 is invertible, linking the principal-minor sum to the power sums via the degree-2 Newton identity."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonOQ04OQ01",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-04",
+      "relationship": "extends",
+      "description": "Answers OQ-04 of the parent: the explicit 3×3 Cayley–Hamilton identity by the same entrywise method used there for the 2×2 case."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "extends",
+      "description": "The 3×3 case of the Cayley–Hamilton theorem, proved explicitly in trace/principal-minor/determinant form."
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Header stating the explicit 3×3 Cayley–Hamilton identity and the cube reduction, the definition of the middle coefficient c₂ as the sum of the three 2×2 principal minors, the entrywise from-scratch proof strategy, and why it is not a re-export of Mathlib's charpoly Cayley–Hamilton."
+    },
+    {
+      "id": "c2",
+      "title": "The Middle Characteristic Coefficient c₂",
+      "startLine": 56,
+      "endLine": 64,
+      "summary": "Defines `c2 A` as the sum of the three 2×2 principal minors (a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁), the second elementary symmetric function of the eigenvalues."
+    },
+    {
+      "id": "cayley-hamilton",
+      "title": "Explicit 3×3 Cayley–Hamilton",
+      "startLine": 66,
+      "endLine": 90,
+      "summary": "`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul`: A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 by entrywise `fin_cases`/`ring` over Fin 3. `cube_eq`: the rearrangement A³ = (tr A)·A² − c₂·A + (det A)·1 via `linear_combination`."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-04** of the Cayley–Hamilton entry (`cayley-hamilton-oq-04`) **verbatim**:

> "Prove the analogous explicit 3×3 Cayley–Hamilton identity A³ − (tr A)·A² + c₂·A − (det A)·1 = 0 where c₂ is the sum of the 2×2 principal minors, by the same entrywise method."

This is the explicit 3×3 analogue of the parent's 2×2 identity, proved by direct entrywise computation over `Fin 3` rather than Mathlib's abstract `charpoly` machinery (`Matrix.aeval_self_charpoly` gives only the polynomial form, not the bare trace/minor/determinant identity).

## Contents (`Proofs/CayleyHamiltonOQ04OQ01.lean`, 90 lines)

- **`c2`** — the middle characteristic coefficient as the sum of the three 2×2 principal minors `(a₀₀a₁₁ − a₀₁a₁₀) + (a₀₀a₂₂ − a₀₂a₂₀) + (a₁₁a₂₂ − a₁₂a₂₁)`, i.e. the second elementary symmetric function of the eigenvalues.
- **`cube_sub_trace_smul_sq_add_c2_smul_sub_det_smul`** — `A³ − (tr A)·A² + c₂·A − (det A)·1 = 0` over any `CommRing`. Proof: rewrite `A³ = A·A·A`, `A² = A·A`, reduce to the nine scalar entries with `fin_cases` over `Fin 3 × Fin 3`, expand via `Matrix.mul_apply`/`Fin.sum_univ_three`/`trace_fin_three`/`det_fin_three`, close each with `ring`.
- **`cube_eq`** — rearrangement `A³ = (tr A)·A² − c₂·A + (det A)·1` via `linear_combination`.

## Verification

- **2 theorems, 1 definition, 0 axioms.** `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (standard foundations; no `sorryAx`, no `Lean.ofReduceBool`).
- Builds clean on `leanprover/lean4:v4.26.0` against current Mathlib.
- Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)