### PR TITLE
Enrich Pell Norm Homomorphism (pell-equation-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/pell-equation-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 3, "endLine": 37 },
+    "type": "context",
+    "title": "Why the regulator is the right invariant",
+    "content": "The docstring explains the gap this file fills: the parent defines the Pell norm x+y√d and regulator log(x+y√d) and bounds them, but leaves open how they interact with the group law on Pell.Solution₁ d. This file proves the norm is a multiplicative homomorphism (Brahmagupta), making the regulator additive and linear on powers — the structural reason a fundamental solution of regulator R(D) generates a tower with regulators R(D), 2R(D), 3R(D), ….",
+    "mathContext": "$\\text{Solution}_1\\,d = \\{(x,y) : x^2 - dy^2 = 1\\}$, a group; $\\;\\mathrm{pellNorm} = x + y\\sqrt d$.",
+    "significance": "context",
+    "relatedConcepts": ["Pell's equation", "norm form", "regulator", "fundamental solution", "geometry of numbers"],
+    "prerequisites": ["Pell equation", "logarithms", "group theory"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "definition",
+    "title": "Pell norm and regulator",
+    "content": "Defines pellNorm d x y = x + y√d (the real embedding of the quadratic integer x+y√d) and pellRegulator d a = log(pellNorm d a.x a.y), matching the parent's definitions verbatim so the homomorphism results plug directly back in. Both are noncomputable (they involve Real.sqrt and Real.log).",
+    "mathContext": "$\\mathrm{pellNorm}(d,x,y) = x + y\\sqrt d$, $\\;\\mathrm{pellRegulator}(d,a) = \\log(x + y\\sqrt d)$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic field embedding", "field norm", "regulator"],
+    "prerequisites": ["real square roots", "real logarithm"]
+  },
+  {
+    "id": "ann-norm-one",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 53, "endLine": 57 },
+    "type": "theorem",
+    "title": "Norm of the identity is 1",
+    "content": "pellNorm_one: the identity solution (1,0) has norm 1+0·√d = 1. This is the unit-preserving part of the homomorphism property, discharged by rewriting Solution₁.x_one/y_one and simp.",
+    "mathContext": "$\\mathrm{pellNorm}(1,0) = 1 + 0\\cdot\\sqrt d = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["group identity", "monoid homomorphism", "unit"],
+    "prerequisites": ["group identity element"]
+  },
+  {
+    "id": "ann-brahmagupta",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 59, "endLine": 67 },
+    "type": "theorem",
+    "title": "Brahmagupta multiplicativity (the homomorphism)",
+    "content": "pellNorm_mul is the heart: composing two Pell solutions multiplies their norms, pellNorm(a·b) = pellNorm(a)·pellNorm(b). This is Brahmagupta's 7th-century composition identity (x₁+y₁√d)(x₂+y₂√d) = (x₁x₂+dy₁y₂) + (x₁y₂+x₂y₁)√d. The proof unfolds Solution₁.x_mul/y_mul and closes by linear_combination with the single fact (√d)² = d (requiring d ≥ 0).",
+    "mathContext": "$\\mathrm{pellNorm}(a\\cdot b) = \\mathrm{pellNorm}(a)\\,\\mathrm{pellNorm}(b)$, via $(\\sqrt d)^2 = d$.",
+    "significance": "critical",
+    "relatedConcepts": ["Brahmagupta's identity", "multiplicative norm", "composition of forms", "quadratic forms"],
+    "prerequisites": ["norm of products", "linear_combination tactic"]
+  },
+  {
+    "id": "ann-conjugate-nonzero",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 69, "endLine": 87 },
+    "type": "theorem",
+    "title": "Conjugate identity and nonvanishing",
+    "content": "pellNorm_mul_inv: pellNorm(a)·pellNorm(a⁻¹) = 1, i.e. (x+y√d)(x−y√d) = x²−dy² = 1, since a⁻¹ = (x,−y). It uses both (√d)²=d and the defining relation a.prop. pellNorm_ne_zero then concludes the norm never vanishes (a product equal to 1 cannot have a zero factor) — the prerequisite for taking logarithms in the regulator.",
+    "mathContext": "$(x+y\\sqrt d)(x-y\\sqrt d) = x^2 - dy^2 = 1$, hence $\\mathrm{pellNorm}(a) \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugate", "norm of inverse", "Pell relation x²−dy²=1", "nonvanishing"],
+    "prerequisites": ["multiplicative inverse", "Pell's defining relation"]
+  },
+  {
+    "id": "ann-regulator-additive",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 89, "endLine": 95 },
+    "type": "theorem",
+    "title": "The regulator is additive",
+    "content": "pellRegulator_mul: R(a·b) = R(a) + R(b). The logarithm turns norm multiplicativity into regulator additivity, using Real.log_mul (valid because both norms are nonzero by pellNorm_ne_zero). This is what makes the regulator a group homomorphism Solution₁ d → (ℝ, +).",
+    "mathContext": "$R(a\\cdot b) = \\log(N_a N_b) = \\log N_a + \\log N_b = R(a) + R(b)$.",
+    "significance": "critical",
+    "relatedConcepts": ["additive homomorphism", "logarithm of products", "regulator", "Real.log_mul"],
+    "prerequisites": ["logarithm identities"]
+  },
+  {
+    "id": "ann-power-scaling",
+    "proofId": "pell-equation-oq-01-oq-04",
+    "range": { "startLine": 97, "endLine": 112 },
+    "type": "theorem",
+    "title": "Linear scaling along powers",
+    "content": "pellNorm_pow: pellNorm(aⁿ) = (pellNorm a)ⁿ (induction using pellNorm_mul and pellNorm_one). pellRegulator_pow: R(aⁿ) = n·R(a) (Real.log_pow). This is the arithmetic backbone of the parent's regulator: a fundamental solution of regulator R(D) generates the tower of solutions with regulators R(D), 2R(D), 3R(D), ….",
+    "mathContext": "$\\mathrm{pellNorm}(a^n) = (\\mathrm{pellNorm}\\,a)^n$; $\\;R(a^n) = n\\,R(a)$.",
+    "significance": "key",
+    "relatedConcepts": ["powers in a group", "linear scaling", "fundamental solution tower", "Real.log_pow"],
+    "prerequisites": ["induction", "logarithm of powers"]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-01-oq-04/index.ts
+++ b/src/data/proofs/pell-equation-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOQ01OQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOQ01OQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOQ01OQ04Data: ProofData = {
+  proof: pellEquationOQ01OQ04Proof,
+  annotations: pellEquationOQ01OQ04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-01-oq-04` (The Pell Norm is a Homomorphism: Brahmagupta Multiplicativity and Regulator Additivity). The `meta.json` had a full overview, sections, conclusion, and crossReferences — what was missing was the inline annotations and the Vite entry point.

## Changes
- **Created `index.ts`** — was missing, so the proof page would render "proof not found" on the live site despite appearing in the gallery listing.
- **Created `annotations.json`** — 7 annotations covering the docstring framing, the norm/regulator definitions, `pellNorm_one`, Brahmagupta multiplicativity `pellNorm_mul`, the conjugate identity + nonvanishing, regulator additivity `pellRegulator_mul`, and the linear power-scaling `pellRegulator_pow`. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Axiom integrity
Verified `status: verified` / `badge: original` / `axiomCount: 0` is accurate: the Lean file has 0 `sorry`, 0 `axiom`, no `native_decide`, no assumption-carrying structures.

## Verification
`tsc -b` and `vite build` both pass (exit 0). All proof JSON validates.