### PR TITLE
Enrich Char-p multiplicity discrepancy (factor-remainder-theorem-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "frt010101-overview",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "concept",
+    "title": "Why ordinary derivatives fail in characteristic p",
+    "content": "The module docstring frames the discrepancy. In characteristic 0, root multiplicity is detected by ordinary derivatives because the conversion factor between the m-th ordinary derivative and the m-th Taylor coefficient is m!, which is invertible. Over 𝔽ₚ that factor p! ≡ 0, so ordinary derivatives of order ≥ p carry no information. The witness f = Xᵖ exhibits all three phenomena: the ordinary test goes vacuous, the characteristic-free Taylor/coefficient test stays sharp, and the gap between them is measured exactly by the Hasse-derivative bridge derivative^[m] = m!·hasseDeriv m.",
+    "mathContext": "$(\\,\\partial^{[m]} p\\,)(a) = m!\\cdot(\\operatorname{taylor}_a p)_m$, and $m!$ is invertible $\\iff \\operatorname{char} = 0$ or $\\operatorname{char} > m$.",
+    "significance": "key",
+    "relatedConcepts": ["root multiplicity", "positive characteristic", "Hasse derivative", "Taylor coefficients", "finite field 𝔽ₚ"],
+    "prerequisites": ["polynomial derivatives", "characteristic of a ring", "ZMod p"]
+  },
+  {
+    "id": "frt010101-deriv-zero",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 53, "endLine": 56 },
+    "type": "theorem",
+    "title": "The ordinary derivative of Xᵖ vanishes",
+    "content": "`derivative_X_pow_eq_zero`: over 𝔽ₚ, `derivative(Xᵖ) = C(p)·X^{p−1} = 0`, because the leading coefficient `p` becomes `0` in `ZMod p` (`ZMod.natCast_self`). This single vanishing is the root cause of the whole collapse: the derivative operator loses the top-degree information that distinguishes Xᵖ from a constant.",
+    "mathContext": "$\\frac{d}{dX}(X^p) = p\\,X^{p-1} = 0 \\quad\\text{in } \\mathbb{F}_p[X]$",
+    "significance": "key",
+    "relatedConcepts": ["formal derivative", "Frobenius", "ZMod.natCast_self", "p-th power map"],
+    "prerequisites": ["polynomial derivative rules", "arithmetic in ZMod p"]
+  },
+  {
+    "id": "frt010101-vacuous",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 74 },
+    "type": "insight",
+    "title": "The ordinary-derivative criterion is vacuous",
+    "content": "`iterate_derivative_X_pow_eq_zero` lifts the first-order vanishing to all positive orders (one derivative is already 0, so all further ones are), and `ordinary_criterion_vacuous` concludes that every condition `(derivative^[j] Xᵖ).eval 0 = 0` holds — order 0 because Xᵖ vanishes at 0, orders ≥ 1 because the derivative is identically 0. The criterion therefore certifies *no* finite multiplicity: it would falsely assert Xᵏ ∣ Xᵖ for every k. The test is not merely weaker in characteristic p — it is information-free.",
+    "mathContext": "$\\forall j,\\ (\\partial^{[j]} X^p)(0) = 0$, so the ordinary criterion never obstructs any $X^k \\mid X^p$.",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicity test", "vacuous criterion", "iterated derivative", "counterexample"],
+    "prerequisites": ["iterated formal derivatives", "polynomial evaluation"]
+  },
+  {
+    "id": "frt010101-sharp",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 78, "endLine": 93 },
+    "type": "theorem",
+    "title": "The coefficient/Taylor test stays sharp",
+    "content": "`coeff_criterion_correct`: `Xᵏ ∣ Xᵖ ↔ k ≤ p`, proved from `X_pow_dvd_iff` (the a = 0 Taylor-coefficient criterion: Xᵏ ∣ f iff f's first k coefficients vanish) together with `coeff_X_pow`. Because this test reads coefficients directly — no division by factorials — it is characteristic-free and recovers the exact multiplicity p that the ordinary-derivative test lost. The forward direction argues by contradiction at the degree-p coefficient (which is 1, not 0).",
+    "mathContext": "$X^k \\mid X^p \\iff \\forall d<k,\\ (X^p)_d = 0 \\iff k \\le p$",
+    "significance": "critical",
+    "relatedConcepts": ["Taylor coefficient test", "X_pow_dvd_iff", "characteristic-free criterion", "divisibility of polynomials"],
+    "prerequisites": ["polynomial coefficients", "divisibility", "proof by contradiction"]
+  },
+  {
+    "id": "frt010101-mult-p",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 100 },
+    "type": "theorem",
+    "title": "The true multiplicity is exactly p",
+    "content": "`multiplicity_eq_p` packages the consequence: `Xᵖ ∣ Xᵖ` but `X^{p+1} ∤ Xᵖ`, so the root 0 has multiplicity exactly p — in flat contradiction with the ordinary-derivative certificate, which placed no upper bound at all. This is the crisp statement of the discrepancy the parent's open question asked to exhibit.",
+    "mathContext": "$X^p \\mid X^p \\ \\wedge\\ X^{p+1} \\nmid X^p \\;\\Rightarrow\\; \\operatorname{mult}_0(X^p) = p$",
+    "significance": "key",
+    "relatedConcepts": ["root multiplicity", "sharpness", "divisibility"],
+    "prerequisites": ["polynomial divisibility", "the coefficient criterion above"]
+  },
+  {
+    "id": "frt010101-hasse-survives",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 104, "endLine": 110 },
+    "type": "theorem",
+    "title": "The Hasse derivative survives",
+    "content": "`hasseDeriv_ne_zero`: the p-th Hasse derivative of Xᵖ is nonzero, even though the p-th *ordinary* derivative is 0. Its constant coefficient is the binomial `C(p,p) = 1` (via `hasseDeriv_coeff`), a unit in any ring. The Hasse (divided) derivative replaces the factorial-laden ordinary derivative with binomial coefficients, which is exactly why it — and the equal Taylor-coefficient test — never degenerates.",
+    "mathContext": "$(\\operatorname{hasse}_p X^p)_0 = \\binom{p}{p} = 1 \\neq 0,\\quad\\text{while } \\partial^{[p]}X^p = 0$",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "divided derivative", "binomial coefficient", "hasseDeriv_coeff"],
+    "prerequisites": ["Hasse derivatives in Mathlib", "binomial coefficients"]
+  },
+  {
+    "id": "frt010101-factorial-obstruction",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 124 },
+    "type": "insight",
+    "title": "The factorial is exactly the obstruction",
+    "content": "`factorial_annihilates_hasseDeriv` makes the discrepancy quantitative through the bridge `derivative^[p] f = p! · hasseDeriv p f`. The p-th Hasse derivative is a nonzero unit, but scaling it by p! kills it: `p! • hasseDeriv p (Xᵖ) = derivative^[p](Xᵖ) = 0`, precisely because `p! ≡ 0 (mod p)`. This isolates the single arithmetic fact — invertibility of k! — on which the characteristic-zero ordinary-derivative equivalence rests and which the Hasse/Taylor test does without.",
+    "mathContext": "$\\partial^{[p]} = p!\\cdot\\operatorname{hasse}_p$; $\\operatorname{hasse}_p(X^p)\\neq 0$ but $p!\\equiv 0 \\Rightarrow \\partial^{[p]}(X^p) = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["factorial_smul_hasseDeriv", "Wilson-type factorial vanishing", "obstruction", "characteristic-zero hypothesis"],
+    "prerequisites": ["Hasse derivative identity", "factorial mod p", "scalar action on polynomials"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-01-oq-01` (The Sharp Positive-Characteristic Discrepancy: Ordinary vs Hasse/Taylor Multiplicity over 𝔽ₚ). The entry had rich meta.json but no annotation layer.

## Quality improvements (quality 39 → ~94)
- **annotations.json (new, 7 annotations, resolver-aligned 7/7)** — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the char-p framing (overview), `derivative(Xᵖ)=0`, the vacuous ordinary criterion, the sharp coefficient/Taylor test (`X_pow_dvd_iff`), multiplicity = p, the surviving Hasse derivative, and the `p! ≡ 0` obstruction (`factorial_smul_hasseDeriv` bridge).

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 7, Misaligned: 0.
- `pnpm build` passes (tsc + vite); no build errors reference this entry.
- Axiom integrity preserved: verified / original / axiomCount 0, consistent with the Lean file (0 sorries, only propext/Classical.choice/Quot.sound).