### PR TITLE
research(cayleys-theorem-oq-01-oq-02): conjugation representation — C(g)=L(g)·R(g), ker C = Z(G), G/Z(G) ≅ Inn(G) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -725,6 +725,7 @@ import Proofs.CayleysTheoremOQ01OQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ02
 import Proofs.CayleysTheoremOQ01OQ01OQ02OQ01OQ02OQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ02OQ02
+import Proofs.CayleysTheoremOQ01OQ02
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleysTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ02.lean
@@ -1,0 +1,122 @@
+/-
+Proof: The conjugation representation and the unification of the three regular
+representations of a group.
+Research: cayleys-theorem-oq-01-oq-02
+
+Open question (from the `cayleys-theorem-oq-01` chain, second open question):
+  Cayley's theorem realises a group `G` as permutations of itself in three
+  classical ways:
+
+  * the **left-regular** representation   `L g : x ↦ g * x`   (the parent),
+  * the **right-regular** representation  `R g : x ↦ x * g⁻¹`  (sibling
+    `cayleys-theorem-oq-01-oq-01-oq-02-oq-02`),
+  * the **conjugation** representation     `C g : x ↦ g * x * g⁻¹`.
+
+  The left- and right-regular companions are already in the gallery; this file
+  formalises the *conjugation* companion as a first-class member of the family
+  and proves the three structural facts that distinguish it from the other two:
+
+  1.  **Unification.**  Conjugation is literally "left-multiply, then undo a
+      right-multiply":
+        `conjRep G g = leftReg G g * rightReg G g`   (composition in `Sym G`).
+  2.  **Kernel = centre.**  Unlike the faithful regular reps, `C` has a kernel,
+      and it is exactly the centre:  `(conjRep G).ker = Subgroup.center G`.
+  3.  **First isomorphism theorem.**  Hence
+        `G ⧸ Z(G) ≃* (conjRep G).range`,
+      identifying the image of `C` — the inner automorphism group `Inn(G)` —
+      with `G / Z(G)`.
+
+We work directly over `Equiv.Perm G` for an arbitrary group `G` (no finiteness
+assumption), matching the sibling files.  `leftReg`/`rightReg` are re-declared
+self-containedly (identical conventions to
+`cayleys-theorem-oq-01-oq-01-oq-02-oq-02`) so the entry compiles without
+depending on absent oleans.
+
+Mathlib supplies every primitive (`MulAut.conj`, `Subgroup.center`,
+`QuotientGroup.quotientKerEquivRange`); the content here is the *assembly* tying
+conjugation to the two regular representations and isolating its kernel.
+-/
+
+import Mathlib.Algebra.Group.End
+import Mathlib.GroupTheory.Subgroup.Center
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Tactic
+
+namespace CayleyConjugation
+
+variable {G : Type*} [Group G]
+
+/-- The **left-regular representation** `g ↦ (x ↦ g * x)` as a group
+homomorphism into the symmetric group on `G`.  It is a homomorphism on the nose
+because `Equiv.mulLeft` turns multiplication into composition. -/
+def leftReg (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun := Equiv.mulLeft
+  map_one' := Equiv.mulLeft_one
+  map_mul' := Equiv.mulLeft_mul
+
+/-- The **right-regular representation** `g ↦ (x ↦ x * g⁻¹)` as a group
+homomorphism.  The inverse on the argument is forced: plain right multiplication
+is an *anti*-homomorphism, so inverting the argument repairs the order. -/
+def rightReg (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun g := Equiv.mulRight g⁻¹
+  map_one' := by rw [inv_one, Equiv.mulRight_one]
+  map_mul' a b := by rw [mul_inv_rev, Equiv.mulRight_mul]
+
+@[simp] theorem leftReg_apply (g x : G) : leftReg G g x = g * x := rfl
+
+@[simp] theorem rightReg_apply (g x : G) : rightReg G g x = x * g⁻¹ := rfl
+
+/-- The **conjugation representation** `g ↦ (x ↦ g * x * g⁻¹)` as a group
+homomorphism into `Equiv.Perm G`.  Built from Mathlib's inner-automorphism
+homomorphism `MulAut.conj`; since `MulAut` composes with the same convention as
+`Equiv.Perm`, conjugation is a genuine homomorphism (not an anti-homomorphism). -/
+def conjRep (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun g := (MulAut.conj g).toEquiv
+  map_one' := by ext x; simp
+  map_mul' a b := by ext x; simp [MulAut.conj_apply, mul_assoc]
+
+@[simp] theorem conjRep_apply (g x : G) : conjRep G g x = g * x * g⁻¹ := by
+  simp [conjRep, MulAut.conj_apply]
+
+/-- **Unification of the three regular representations.**  Conjugation by `g`
+factors as left-multiplication by `g` followed by (undoing) right-multiplication
+by `g`:  `C(g) = L(g) · R(g)` in `Sym G`.  This makes precise the folklore that
+conjugation is the "commutator" of the two regular actions. -/
+theorem conjRep_eq_leftReg_mul_rightReg (g : G) :
+    conjRep G g = leftReg G g * rightReg G g := by
+  ext x
+  simp [Equiv.Perm.mul_apply, mul_assoc]
+
+/-- **The kernel of the conjugation representation is the centre.**  An element
+`g` acts trivially by conjugation exactly when it commutes with everything. -/
+theorem ker_conjRep : (conjRep G).ker = Subgroup.center G := by
+  ext g
+  rw [MonoidHom.mem_ker, Subgroup.mem_center_iff, Equiv.ext_iff]
+  constructor
+  · intro h x
+    have hx := h x
+    rw [conjRep_apply, Equiv.Perm.one_apply, mul_inv_eq_iff_eq_mul] at hx
+    exact hx.symm
+  · intro h x
+    rw [conjRep_apply, Equiv.Perm.one_apply, mul_inv_eq_iff_eq_mul]
+    exact (h x).symm
+
+/-- **The conjugation representation is faithful iff the centre is trivial.**
+The regular representations are always faithful; conjugation is faithful exactly
+for centreless groups. -/
+theorem conjRep_injective_iff :
+    Function.Injective (conjRep G) ↔ Subgroup.center G = ⊥ := by
+  rw [← MonoidHom.ker_eq_bot_iff, ker_conjRep]
+
+/-- **First isomorphism theorem for the conjugation representation:**
+`G ⧸ Z(G) ≃* (conjRep G).range`.  The image of `C` is the inner automorphism
+group `Inn(G)`, here exhibited as a subgroup of `Equiv.Perm G`, and it is
+isomorphic to the quotient of `G` by its centre. -/
+noncomputable def quotientCenterEquivInn :
+    G ⧸ Subgroup.center G ≃* (conjRep G).range :=
+  (QuotientGroup.quotientMulEquivOfEq ker_conjRep.symm).trans
+    (QuotientGroup.quotientKerEquivRange (conjRep G))
+
+end CayleyConjugation

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "cay-oq0102-ann-docstring",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "The conjugation companion of the regular representations",
+    "content": "The module docstring poses the second open question of the cayleys-theorem chain: alongside the left-regular representation L g : x ↦ g·x (the parent) and the right-regular representation R g : x ↦ x·g⁻¹ (an existing sibling), formalize the conjugation representation C g : x ↦ g·x·g⁻¹ and relate all three. The three deliverables are the unification C(g) = L(g)·R(g), the kernel computation ker C = Z(G), and the first-isomorphism consequence G/Z(G) ≅ Inn(G). Everything is over an arbitrary, possibly infinite, group G.",
+    "mathContext": "$L,R,C : G \\to \\operatorname{Sym}(G)$, $C(g): x \\mapsto gxg^{-1}$; goals: $C=L\\cdot R$, $\\ker C = Z(G)$, $G/Z(G)\\cong\\operatorname{Inn}(G)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Cayley's theorem",
+      "regular representation",
+      "conjugation",
+      "inner automorphism",
+      "center"
+    ],
+    "prerequisites": [
+      "group actions by translation and conjugation",
+      "permutation groups"
+    ]
+  },
+  {
+    "id": "cay-oq0102-ann-regreps",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 70 },
+    "type": "definition",
+    "title": "The two regular representations, re-declared",
+    "content": "leftReg G : G →* Equiv.Perm G is Equiv.mulLeft (x ↦ g·x), a homomorphism on the nose since mulLeft (a·b) = mulLeft a * mulLeft b. rightReg G : G →* Equiv.Perm G is g ↦ Equiv.mulRight g⁻¹ (x ↦ x·g⁻¹); the inverse is forced because plain right multiplication is an anti-homomorphism, and inverting the argument (with mul_inv_rev) repairs the order. These match the conventions of the right-regular sibling so the file is self-contained. The apply lemmas leftReg_apply and rightReg_apply are definitional (rfl).",
+    "mathContext": "$L(g): x \\mapsto gx$, $R(g): x \\mapsto x g^{-1}$.",
+    "significance": "Sets up the two factors of the unification identity with the established gallery conventions.",
+    "relatedConcepts": [
+      "left-regular representation",
+      "right-regular representation",
+      "anti-homomorphism",
+      "Equiv.mulLeft / Equiv.mulRight"
+    ],
+    "prerequisites": [
+      "group homomorphisms into Equiv.Perm",
+      "the anti-homomorphism law for right multiplication"
+    ]
+  },
+  {
+    "id": "cay-oq0102-ann-conjrep",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 84 },
+    "type": "definition",
+    "title": "The conjugation representation conjRep",
+    "content": "conjRep G : G →* Equiv.Perm G is defined as (MulAut.conj g).toEquiv — the underlying permutation of Mathlib's inner-automorphism automorphism. Because MulAut multiplies with the same convention as Equiv.Perm composition, map_one' and map_mul' close by ext + simp [MulAut.conj_apply, mul_assoc]: no compensating inverse twist is needed, in contrast to the right-regular representation. conjRep_apply : conjRep G g x = g·x·g⁻¹ unfolds the coercion through MulAut.conj_apply.",
+    "mathContext": "$C(g): x \\mapsto g x g^{-1}$ as a genuine homomorphism $G \\to_* \\operatorname{Sym}(G)$.",
+    "significance": "Establishes the third companion as a homomorphism without an inverse twist — the key convention check.",
+    "relatedConcepts": [
+      "conjugation",
+      "MulAut.conj",
+      "inner automorphism",
+      "group homomorphism"
+    ],
+    "prerequisites": [
+      "MulAut.conj and its action law",
+      "coercion MulAut G → Equiv.Perm G"
+    ]
+  },
+  {
+    "id": "cay-oq0102-ann-unification",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 85, "endLine": 92 },
+    "type": "insight",
+    "title": "Unification: C(g) = L(g)·R(g)",
+    "content": "conjRep_eq_leftReg_mul_rightReg proves conjRep G g = leftReg G g * rightReg G g. Evaluating both sides at x, the composite (leftReg G g * rightReg G g) x = leftReg G g (rightReg G g x) = g·(x·g⁻¹) = g·x·g⁻¹ by mul_assoc, matching conjRep. The whole proof is one ext + simp [Equiv.Perm.mul_apply, mul_assoc]. This is the rigorous form of the folklore that conjugation is the composite of the two regular actions — 'left-multiply by g, then undo a right-multiply by g.'",
+    "mathContext": "$C(g) = L(g)\\,R(g)$ in $\\operatorname{Sym}(G)$, by $g(x g^{-1}) = gxg^{-1}$.",
+    "significance": "The headline structural identity tying all three representations together; pure associativity.",
+    "relatedConcepts": [
+      "composition of permutations",
+      "associativity",
+      "regular representations"
+    ],
+    "prerequisites": [
+      "multiplication of permutations (Equiv.Perm.mul_apply)",
+      "associativity in a group"
+    ]
+  },
+  {
+    "id": "cay-oq0102-ann-kernel",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 115 },
+    "type": "technique",
+    "title": "Kernel is the centre; faithful iff centreless",
+    "content": "ker_conjRep proves (conjRep G).ker = Subgroup.center G. After rewriting with MonoidHom.mem_ker, Subgroup.mem_center_iff and Equiv.ext_iff, kernel membership becomes ∀ x, g·x·g⁻¹ = x. The single lemma mul_inv_eq_iff_eq_mul converts g·x·g⁻¹ = x into g·x = x·g, which is centrality (up to the symmetry built into mem_center_iff); both inclusions are one rewrite each. conjRep_injective_iff then reads off Function.Injective (conjRep G) ↔ Subgroup.center G = ⊥ from MonoidHom.ker_eq_bot_iff — the conjugation representation is faithful exactly for centreless groups, unlike the always-faithful regular representations.",
+    "mathContext": "$\\ker C = Z(G)$ via $gxg^{-1}=x \\iff gx = xg$; $C$ faithful $\\iff Z(G)=\\{1\\}$.",
+    "significance": "Locates the centre as precisely the obstruction to faithfulness — where the internal structure of G first appears.",
+    "relatedConcepts": [
+      "kernel of a homomorphism",
+      "center of a group",
+      "faithful action",
+      "mul_inv_eq_iff_eq_mul"
+    ],
+    "prerequisites": [
+      "MonoidHom kernels and ker_eq_bot_iff",
+      "Subgroup.mem_center_iff",
+      "pointwise equality of permutations (Equiv.ext_iff)"
+    ]
+  },
+  {
+    "id": "cay-oq0102-ann-firstiso",
+    "proofId": "cayleys-theorem-oq-01-oq-02",
+    "range": { "startLine": 116, "endLine": 122 },
+    "type": "concept",
+    "title": "First isomorphism theorem: G/Z(G) ≅ Inn(G)",
+    "content": "quotientCenterEquivInn : G ⧸ Subgroup.center G ≃* (conjRep G).range. The construction rewrites the centre as the kernel using QuotientGroup.quotientMulEquivOfEq (ker_conjRep.symm), then composes with QuotientGroup.quotientKerEquivRange (conjRep G), the first isomorphism theorem. The range of conjRep is the inner automorphism group Inn(G), realised as a subgroup of Equiv.Perm G. The definition is noncomputable as it transports through the quotient.",
+    "mathContext": "$G/Z(G) \\cong \\operatorname{Inn}(G) = \\operatorname{range} C$.",
+    "significance": "Packages the inner automorphism group as G/Z(G) — the springboard for the automorphism tower, the class equation, and Sylow theory.",
+    "relatedConcepts": [
+      "first isomorphism theorem",
+      "inner automorphism group",
+      "quotient group",
+      "MulEquiv"
+    ],
+    "prerequisites": [
+      "QuotientGroup.quotientKerEquivRange",
+      "quotientMulEquivOfEq",
+      "normal subgroups (centre and kernel)"
+    ]
+  }
+]

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-02",
+  "title": "The Conjugation Representation: C(g) = L(g)·R(g), ker C = Z(G), and G/Z(G) ≅ Inn(G)",
+  "slug": "cayleys-theorem-oq-01-oq-02",
+  "description": "Cayley's theorem realises a group G as permutations of itself in three classical ways: the left-regular representation L g : x ↦ g·x (the parent), the right-regular representation R g : x ↦ x·g⁻¹ (an existing sibling), and the conjugation representation C g : x ↦ g·x·g⁻¹. The left- and right-regular companions are already in the gallery; this entry formalises the conjugation companion as a first-class member of the family and proves the three structural facts that set it apart. conjRep G : G →* Equiv.Perm G is built from Mathlib's inner-automorphism homomorphism MulAut.conj, which composes with the same convention as Equiv.Perm — so conjugation is a genuine homomorphism, not an anti-homomorphism (no inverse twist is needed, unlike the right-regular case). The unification theorem conjRep_eq_leftReg_mul_rightReg proves conjRep G g = leftReg G g * rightReg G g: conjugation by g is literally left-multiply by g then undo a right-multiply by g, making precise the folklore that conjugation is the composite of the two regular actions. Unlike the faithful regular representations, C has a kernel, and ker_conjRep identifies it exactly: (conjRep G).ker = Subgroup.center G — an element acts trivially by conjugation iff it commutes with everything. conjRep_injective_iff records the consequent faithfulness criterion: C is faithful iff Z(G) = ⊥ (G is centreless). Finally the first isomorphism theorem quotientCenterEquivInn delivers G ⧸ Z(G) ≃* (conjRep G).range, identifying the image of C — the inner automorphism group Inn(G), realised as a subgroup of Equiv.Perm G — with the quotient G/Z(G). Everything is over an arbitrary (possibly infinite) group G; leftReg/rightReg are re-declared self-containedly with the same conventions as the right-regular sibling so the file compiles independently.",
+  "meta": {
+    "author": "Classical (conjugation / inner automorphisms); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inner_automorphism",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "regular-representation",
+      "conjugation",
+      "inner-automorphism",
+      "center",
+      "first-isomorphism-theorem",
+      "group-homomorphism",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAut.conj",
+        "description": "Group conjugation g ↦ (h ↦ g·h·g⁻¹) packaged as a monoid homomorphism G →* MulAut G; MulAut composes with the same order convention as Equiv.Perm, so coercing through it yields a genuine homomorphism into the symmetric group",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "MulAut.conj_apply",
+        "description": "MulAut.conj g h = g * h * g⁻¹ — the explicit action of the conjugation automorphism, used to discharge map_mul' and the conjRep_apply formula",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Subgroup.mem_center_iff",
+        "description": "g ∈ Subgroup.center G ↔ ∀ h, h * g = g * h — the working characterisation of the centre, the target of the kernel computation",
+        "module": "Mathlib.GroupTheory.Subgroup.Center"
+      },
+      {
+        "theorem": "MonoidHom.mem_ker",
+        "description": "g ∈ f.ker ↔ f g = 1 — reduces kernel membership of conjRep to the permutation equation conjRep G g = 1",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.quotientKerEquivRange",
+        "description": "The first isomorphism theorem G ⧸ f.ker ≃* f.range — supplies G ⧸ (conjRep G).ker ≃* (conjRep G).range, the backbone of G/Z(G) ≅ Inn(G)",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.quotientMulEquivOfEq",
+        "description": "Equal normal subgroups give isomorphic quotients; combined with ker_conjRep it rewrites G ⧸ Z(G) as G ⧸ (conjRep G).ker before applying the first isomorphism theorem",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "mul_inv_eq_iff_eq_mul",
+        "description": "a * b⁻¹ = c ↔ a = c * b — the single group-manipulation lemma converting the conjugation-fixes-x equation g·x·g⁻¹ = x into the commutation g·x = x·g in both directions of the kernel proof",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "originalContributions": [
+      "conjRep G : G →* Equiv.Perm G — the conjugation representation packaged as a genuine group homomorphism over an arbitrary group G, built through Mathlib's MulAut.conj so that no anti-homomorphism inverse twist is required",
+      "conjRep_eq_leftReg_mul_rightReg: conjRep G g = leftReg G g * rightReg G g — the unification identity exhibiting conjugation as the composite of the left- and right-regular representations, tying the third companion to the two already in the gallery",
+      "ker_conjRep: (conjRep G).ker = Subgroup.center G — the kernel of the conjugation representation is exactly the centre (an element acts trivially by conjugation iff it is central)",
+      "conjRep_injective_iff: Function.Injective (conjRep G) ↔ Subgroup.center G = ⊥ — the conjugation representation is faithful precisely for centreless groups, contrasting with the always-faithful regular representations",
+      "quotientCenterEquivInn: G ⧸ Subgroup.center G ≃* (conjRep G).range — the first-isomorphism-theorem consequence identifying Inn(G) (the image of C, as a permutation subgroup) with G/Z(G)"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 122,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used. Holds for an arbitrary (possibly infinite) group G.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem realises an abstract group G inside Sym(G) via the left-regular action x ↦ g·x. Two further canonical actions accompany it: right multiplication x ↦ x·g⁻¹ and conjugation x ↦ g·x·g⁻¹. The first two are faithful — they exhibit G itself — but conjugation is the action where the internal structure of G first surfaces. Its kernel is the centre Z(G), and by the first isomorphism theorem its image, the inner automorphism group Inn(G), is isomorphic to G/Z(G). This quotient is the springboard for the automorphism tower, the class equation, and Sylow theory. The three actions are not independent: conjugation by g is left-multiplication by g followed by right-multiplication by g⁻¹, i.e. C(g) = L(g)·R(g), the precise form of the folklore that conjugation is the 'commutator' of the two regular actions. The conventions matter — right multiplication is an anti-homomorphism and the right-regular representation must use g⁻¹ to repair the order, whereas conjugation, mediated by MulAut.conj, is a homomorphism on the nose.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01, second follow-up)**: Alongside the left-regular representation (parent) and the right-regular representation (sibling), formalize the conjugation representation C : G → Sym(G), C(g) = (x ↦ g·x·g⁻¹), as a genuine homomorphism; prove the unification C(g) = L(g)·R(g), the kernel computation ker C = Z(G), and the first-isomorphism consequence G/Z(G) ≅ Inn(G).\n\n**Result**: conjRep G as a MonoidHom into Equiv.Perm G, with conjRep_eq_leftReg_mul_rightReg (unification), ker_conjRep (kernel is the centre), conjRep_injective_iff (faithful iff centreless), and quotientCenterEquivInn (G/Z(G) ≅ Inn(G)).",
+    "text": "Let G be any group. Embed it into Equiv.Perm G by the left-regular representation L g : x ↦ g·x, the right-regular representation R g : x ↦ x·g⁻¹, and the conjugation representation C g : x ↦ g·x·g⁻¹. Then C(g) = L(g)·R(g) (composition in the symmetric group), the kernel of C is exactly the centre Z(G), and consequently the image of C — the inner automorphism group Inn(G) — is isomorphic to the quotient G/Z(G).",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The conjugation representation as a homomorphism. conjRep G g := (MulAut.conj g).toEquiv, the underlying permutation of Mathlib's inner-automorphism automorphism. Because MulAut multiplies with the same convention as Equiv.Perm, map_one' and map_mul' close by ext + simp [MulAut.conj_apply, mul_assoc] — no inverse twist is needed (contrast the right-regular rep). conjRep_apply : conjRep G g x = g·x·g⁻¹ unfolds the coercion via MulAut.conj_apply.\n2. Unification. conjRep_eq_leftReg_mul_rightReg: evaluate both sides at x. The right side (leftReg G g * rightReg G g) x = leftReg G g (rightReg G g x) = g·(x·g⁻¹) = g·x·g⁻¹ by mul_assoc, matching the left. One ext + simp.\n3. Kernel = centre. ker_conjRep: rewrite membership with MonoidHom.mem_ker, Subgroup.mem_center_iff, and Equiv.ext_iff. The permutation equation conjRep G g = 1 becomes ∀ x, g·x·g⁻¹ = x; the lemma mul_inv_eq_iff_eq_mul turns g·x·g⁻¹ = x into g·x = x·g, which is centrality (up to the symmetry in mem_center_iff). Both inclusions are one rewrite each.\n4. Faithfulness criterion. conjRep_injective_iff: MonoidHom.ker_eq_bot_iff together with ker_conjRep gives Injective (conjRep G) ↔ Z(G) = ⊥.\n5. First isomorphism theorem. quotientCenterEquivInn: QuotientGroup.quotientMulEquivOfEq (ker_conjRep.symm) rewrites G ⧸ Z(G) as G ⧸ (conjRep G).ker, then QuotientGroup.quotientKerEquivRange composes to (conjRep G).range. The result is noncomputable (it transports through the quotient).",
+    "keyInsights": [
+      "**Conjugation is a homomorphism on the nose — no inverse twist.** Right multiplication is an anti-homomorphism, forcing the right-regular representation to use g⁻¹. Conjugation, routed through MulAut.conj (whose multiplication matches Equiv.Perm composition), is a genuine homomorphism directly, so conjRep needs no compensating inverse.",
+      "**The unification identity C(g) = L(g)·R(g) is pure associativity.** Composing left-multiply-by-g with right-multiply-by-g⁻¹ sends x to g·(x·g⁻¹) = g·x·g⁻¹; the only ingredient is mul_assoc. This is the rigorous form of 'conjugation is the commutator of the two regular actions.'",
+      "**The kernel is the centre, reduced to one group lemma.** g·x·g⁻¹ = x ⟺ g·x = x·g via mul_inv_eq_iff_eq_mul, so the conjugation-fixes-everything condition is exactly centrality. This is where the internal structure of G — invisible to the faithful regular reps — first appears.",
+      "**Faithful iff centreless.** Because ker C = Z(G), the conjugation representation is injective exactly when Z(G) is trivial, in sharp contrast to the left- and right-regular representations, which are always faithful.",
+      "**G/Z(G) ≅ Inn(G) is the first isomorphism theorem applied to C.** The image of conjugation, realised as a subgroup of Equiv.Perm G, is the inner automorphism group; quotienting out its kernel (the centre) yields the standard iso, here assembled as a single MulEquiv. No finiteness is used anywhere — the whole development holds for arbitrary G."
+    ],
+    "prerequisites": [
+      "The conjugation/inner-automorphism homomorphism MulAut.conj and its action law MulAut.conj_apply (g·h·g⁻¹)",
+      "The centre of a group: Subgroup.center and Subgroup.mem_center_iff, plus MonoidHom kernels (MonoidHom.mem_ker, MonoidHom.ker_eq_bot_iff)",
+      "The first isomorphism theorem for groups: QuotientGroup.quotientKerEquivRange and quotientMulEquivOfEq, and evaluating equalities of permutations pointwise (Equiv.ext_iff, Equiv.Perm.mul_apply)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring posing the second open question of the cayleys-theorem chain — formalize the conjugation companion alongside the two regular representations and prove unification, kernel, and the first isomorphism consequence — followed by imports (Algebra.Group.End for MulAut.conj, Subgroup.Center, QuotientGroup.Basic, Perm.Basic) and the namespace with an arbitrary group variable G.",
+      "mathContext": "$L,R,C : G \\to \\mathrm{Sym}(G)$ for an arbitrary group $G$; $C(g): x \\mapsto gxg^{-1}$."
+    },
+    {
+      "id": "regular-reps",
+      "title": "The Two Regular Representations (self-contained)",
+      "startLine": 50,
+      "endLine": 70,
+      "summary": "Self-contained re-declaration of leftReg G : G →* Equiv.Perm G (Equiv.mulLeft, x ↦ g·x) and rightReg G : G →* Equiv.Perm G (Equiv.mulRight g⁻¹, x ↦ x·g⁻¹, the inverse repairing the anti-homomorphism), matching the conventions of the right-regular sibling, with the apply lemmas leftReg_apply and rightReg_apply.",
+      "mathContext": "$L(g): x \\mapsto gx,\\quad R(g): x \\mapsto x g^{-1}$."
+    },
+    {
+      "id": "conjrep",
+      "title": "The Conjugation Representation",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "conjRep G : G →* Equiv.Perm G defined as (MulAut.conj g).toEquiv, a homomorphism because MulAut composes like Equiv.Perm (map_one'/map_mul' by ext + simp [MulAut.conj_apply, mul_assoc]); conjRep_apply : conjRep G g x = g·x·g⁻¹ unfolds the coercion.",
+      "mathContext": "$C(g): x \\mapsto g x g^{-1}$ as a genuine homomorphism $G \\to_* \\mathrm{Sym}(G)$."
+    },
+    {
+      "id": "unification",
+      "title": "Unification: C(g) = L(g)·R(g)",
+      "startLine": 85,
+      "endLine": 92,
+      "summary": "conjRep_eq_leftReg_mul_rightReg: conjRep G g = leftReg G g * rightReg G g. Evaluating at x, the right side is g·(x·g⁻¹) = g·x·g⁻¹ by associativity — conjugation factors as left-multiply then undo a right-multiply.",
+      "mathContext": "$C(g) = L(g)\\,R(g)$ in $\\mathrm{Sym}(G)$."
+    },
+    {
+      "id": "kernel",
+      "title": "Kernel is the Centre, and Faithfulness",
+      "startLine": 93,
+      "endLine": 115,
+      "summary": "ker_conjRep: (conjRep G).ker = Subgroup.center G, via MonoidHom.mem_ker + Subgroup.mem_center_iff + Equiv.ext_iff, with mul_inv_eq_iff_eq_mul converting g·x·g⁻¹ = x into g·x = x·g in both directions. conjRep_injective_iff then derives Injective (conjRep G) ↔ Z(G) = ⊥ from MonoidHom.ker_eq_bot_iff.",
+      "mathContext": "$\\ker C = Z(G)$; $C$ faithful $\\iff Z(G) = \\{1\\}$."
+    },
+    {
+      "id": "first-iso",
+      "title": "First Isomorphism Theorem: G/Z(G) ≅ Inn(G)",
+      "startLine": 116,
+      "endLine": 122,
+      "summary": "quotientCenterEquivInn: G ⧸ Subgroup.center G ≃* (conjRep G).range, built by rewriting the centre as the kernel (quotientMulEquivOfEq ker_conjRep.symm) and applying the first isomorphism theorem (quotientKerEquivRange). The image of conjugation is Inn(G), here a subgroup of Equiv.Perm G.",
+      "mathContext": "$G/Z(G) \\cong \\operatorname{Inn}(G) = \\operatorname{range} C$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the abstract left-regular representation G ↪ Sym(G). This entry formalises the conjugation companion C(g) : x ↦ g·x·g⁻¹ posed in the parent's second open question, and ties it to the left-regular rep via C(g) = L(g)·R(g)."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02",
+      "relationship": "builds-on",
+      "description": "Sibling entry: defines the right-regular representation rightReg and studies its interaction with the left-regular image (centralizer duality). This entry reuses the same leftReg/rightReg conventions and adds the third companion, conjugation, with the unification identity C(g) = L(g)·R(g)."
+    },
+    {
+      "targetId": "conjugacy-class-equation-oq-01",
+      "relationship": "related",
+      "description": "Downstream payoff: the conjugation action, its kernel (the centre), and Inn(G) ≅ G/Z(G) are the foundation of the class equation and the centre-based counting it formalises."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the conjugation representation conjRep G : G →* Equiv.Perm G as the third member of the regular-representation family. The unification identity conjRep_eq_leftReg_mul_rightReg shows conjugation factors as the composite of the left- and right-regular representations, C(g) = L(g)·R(g). The kernel computation ker_conjRep proves (conjRep G).ker = Subgroup.center G, conjRep_injective_iff records that C is faithful iff G is centreless, and quotientCenterEquivInn delivers the first-isomorphism iso G ⧸ Z(G) ≃* (conjRep G).range, identifying Inn(G) with G/Z(G). The whole development holds for an arbitrary (possibly infinite) group G.",
+    "implications": "Completes the canonical trio of group actions taught immediately after Cayley's theorem: left-regular, right-regular, and conjugation. The unification identity makes precise the folklore that conjugation is the composite of the two regular actions; the kernel computation locates the centre as the obstruction to faithfulness; and the first isomorphism theorem packages the inner automorphism group as G/Z(G) — the springboard for the automorphism tower, the class equation, and Sylow theory. Being convention-checked against MulAut.conj, the formalization also confirms that conjugation (unlike right multiplication) is a homomorphism without an inverse twist.",
+    "openQuestions": [
+      "Identify the range of conjRep with Mathlib's inner automorphism group as an automorphism subgroup: produce an explicit MulEquiv (conjRep G).range ≃* Inn(G) where Inn(G) is realised inside MulAut G, bridging the permutation-subgroup image to the automorphism-group picture.",
+      "Prove the outer automorphism exact sequence at the formalized level: 1 → Inn(G) → Aut(G) → Out(G) → 1, building on G/Z(G) ≅ Inn(G) established here to define Out(G) = Aut(G)/Inn(G)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Group.End",
+      "Mathlib.GroupTheory.Subgroup.Center",
+      "Mathlib.GroupTheory.QuotientGroup.Basic",
+      "Mathlib.GroupTheory.Perm.Basic",
+      "Mathlib.Algebra.Group.Units.Equiv",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CayleyConjugation",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "path": "Proofs/CayleysTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group is a group of permutations — the regular representation"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §4.2–4.4",
+      "note": "Left/right regular and conjugation actions; inner automorphisms and Inn(G) ≅ G/Z(G)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **conjugation representation** as the third member of the regular-representation family from Cayley's theorem, answering the second open question of `cayleys-theorem-oq-01`. The left-regular (parent) and right-regular (sibling `cayleys-theorem-oq-01-oq-01-oq-02-oq-02`) companions are already in the gallery; this adds conjugation and ties all three together.

Over an arbitrary (possibly infinite) group `G`, working in `Equiv.Perm G`:

- **`conjRep G : G →* Equiv.Perm G`** — conjugation `x ↦ g·x·g⁻¹`, built from Mathlib's `MulAut.conj` so it is a genuine homomorphism with **no anti-homomorphism inverse twist** (contrast the right-regular rep).
- **Unification** `conjRep_eq_leftReg_mul_rightReg`: `conjRep G g = leftReg G g * rightReg G g` — conjugation is "left-multiply by `g`, then undo a right-multiply by `g`" (pure `mul_assoc`).
- **Kernel = centre** `ker_conjRep`: `(conjRep G).ker = Subgroup.center G`.
- **Faithful iff centreless** `conjRep_injective_iff`: `Injective (conjRep G) ↔ Subgroup.center G = ⊥`.
- **First isomorphism theorem** `quotientCenterEquivInn`: `G ⧸ Z(G) ≃* (conjRep G).range`, identifying `Inn(G)` with `G/Z(G)`.

`leftReg`/`rightReg` are re-declared self-containedly with the same conventions as the right-regular sibling, so the file compiles independently.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on every result lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). No `decide`/`native_decide`.
- Compiled with `lake env lean` against Mathlib v4.26.0.
- 6 theorems, 4 definitions, 122 lines.

## Note

`MulAut.conj` lives in `Mathlib.Algebra.Group.End` (not `Mathlib.Algebra.Group.Aut`, which does not exist in v4.26.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)