### PR TITLE
research(erdos-1066-oq-04-oq-03): prove greedy_independence axiom — general n/(Δ+1) bound [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos1066OQ04OQ03.lean
+++ b/proofs/Proofs/Erdos1066OQ04OQ03.lean
@@ -1,0 +1,240 @@
+import Mathlib
+
+/-
+# Erdős 1066 — OQ-04-OQ-03: Proving the kissing-number axioms in Lean
+
+## Research Problem: erdos-1066-oq-04-oq-03
+
+The parent entry `erdos-1066-oq-04` (Higher-Dimensional Unit Distance
+Independence) develops the bound
+
+    g_d(n) ≥ n / (τ(d) + 1)
+
+for the independence number of unit-distance graphs on n separated points
+in ℝ^d, where τ(d) is the kissing number.  That development rests on two
+`axiom` declarations:
+
+  * `degree_le_kissing`   — each vertex has unit-degree ≤ τ(d), a purely
+                            geometric / sphere-packing fact;
+  * `greedy_independence` — a graph with max degree ≤ τ(d) has an
+                            independent set of size ≥ n/(τ(d)+1), a general
+                            graph-theory fact.
+
+Its open question asks: *Can the 2 axioms be proved in Lean?*  This entry
+answers the **graph-theory half** completely and 0-axiom, and pins down the
+exact mathematical residue of the geometric half.
+
+## What is proved here (0 axioms, self-contained)
+
+`greedy_independence_of_maxDegree` — **the general greedy / Turán-type
+independence bound**: for *any* degree bound `Δ`, any separated configuration
+whose every vertex has unit-degree ≤ `Δ` admits an independent set of size
+≥ `n/(Δ+1)`.  No kissing numbers, no axioms.  The proof is the classic
+"a maximum independent set is dominating" argument:
+
+    n  ≤  Σ_{u ∈ S} (1 + deg u)  ≤  |S| · (Δ + 1).
+
+`greedy_independence_kissing` — instantiating `Δ := τ(d)` recovers exactly the
+parent's `greedy_independence` statement, now as a **theorem** whose only
+remaining hypothesis is the degree bound `degree_le_kissing`.
+
+## The residue: `degree_le_kissing` is genuinely hard
+
+`degree_le_kissing` is *not* a one-session Lean target: with the exact kissing
+numbers τ(4)=24, τ(8)=240, τ(24)=196560, the bound `unitDegree ≤ τ(d)` is
+the kissing-number problem itself (the d=8, 24 cases are Viazovska-level
+theorems).  So this entry honestly reduces the parent's axiom budget from
+**2 → 1**: the combinatorial axiom is eliminated; the geometric one is
+isolated as the true open formalization target.
+
+Tags: combinatorial-geometry, unit-distance, independence-number, graph-theory
+-/
+
+open scoped Classical
+
+namespace Erdos1066OQ04OQ03
+
+-- ============================================================
+-- Part I: Self-contained re-declaration of the framework
+-- (parent file is axiom-bearing; we re-declare to stay 0-axiom)
+-- ============================================================
+
+/-- A separated configuration: `n` points in ℝ^d with pairwise distance ≥ 1. -/
+structure SepConfig (d n : ℕ) where
+  points : Fin n → EuclideanSpace ℝ (Fin d)
+  separated : ∀ i j : Fin n, i ≠ j → dist (points i) (points j) ≥ 1
+
+variable {d n : ℕ}
+
+/-- The unit-distance graph: an edge between points at distance exactly 1. -/
+def unitEdge (C : SepConfig d n) (i j : Fin n) : Prop :=
+  i ≠ j ∧ dist (C.points i) (C.points j) = 1
+
+/-- The unit-distance relation is symmetric. -/
+theorem unitEdge_symm (C : SepConfig d n) {i j : Fin n} :
+    unitEdge C i j → unitEdge C j i := by
+  rintro ⟨hij, hd⟩
+  exact ⟨hij.symm, by rw [dist_comm]; exact hd⟩
+
+/-- The unit degree of a vertex: number of unit-distance neighbours. -/
+noncomputable def unitDegree (C : SepConfig d n) (i : Fin n) : ℕ :=
+  (Finset.univ.filter (fun j => unitEdge C i j)).card
+
+/-- An independent set in the unit-distance graph: no pair shares a unit edge. -/
+def IsIndepSet (C : SepConfig d n) (S : Finset (Fin n)) : Prop :=
+  ∀ i ∈ S, ∀ j ∈ S, ¬ unitEdge C i j
+
+-- ============================================================
+-- Part II: The general greedy independence bound (0 axioms)
+-- ============================================================
+
+/-- The closed neighbourhood of `u`: `u` together with its unit-neighbours. -/
+private noncomputable def closedNbhd (C : SepConfig d n) (u : Fin n) : Finset (Fin n) :=
+  insert u (Finset.univ.filter (fun w => unitEdge C u w))
+
+private theorem card_closedNbhd_le (C : SepConfig d n) (u : Fin n) :
+    (closedNbhd C u).card ≤ 1 + unitDegree C u := by
+  unfold closedNbhd unitDegree
+  calc (insert u (Finset.univ.filter (fun w => unitEdge C u w))).card
+      ≤ 1 + (Finset.univ.filter (fun w => unitEdge C u w)).card :=
+        (Finset.card_insert_le _ _).trans (by ring_nf; rfl)
+    _ = 1 + (Finset.univ.filter (fun j => unitEdge C u j)).card := rfl
+
+/-- **General greedy independence bound.**  If every vertex of a separated
+    configuration has unit-degree at most `Δ`, then there is an independent set
+    of size at least `n / (Δ + 1)`.
+
+    Proof: take an independent set `S` of *maximum* cardinality.  By
+    maximality `S` is dominating — every vertex is in `S` or adjacent to `S` —
+    so the closed neighbourhoods of `S` cover all `n` vertices:
+    `n ≤ Σ_{u∈S}(1 + deg u) ≤ |S|·(Δ+1)`, whence `|S| ≥ n/(Δ+1)`. -/
+theorem greedy_independence_of_maxDegree (C : SepConfig d n) (Δ : ℕ)
+    (hdeg : ∀ i, unitDegree C i ≤ Δ) :
+    ∃ S : Finset (Fin n), IsIndepSet C S ∧ S.card ≥ n / (Δ + 1) := by
+  classical
+  -- The family of independent finsets, as a finset of finsets.
+  set 𝓘 : Finset (Finset (Fin n)) := Finset.univ.filter (fun S => IsIndepSet C S) with h𝓘
+  have hmem : ∀ S, S ∈ 𝓘 ↔ IsIndepSet C S := by
+    intro S; simp [h𝓘]
+  -- ∅ is independent, so 𝓘 is nonempty.
+  have hne : 𝓘.Nonempty := by
+    refine ⟨∅, (hmem _).2 ?_⟩
+    intro i hi; simp at hi
+  -- Choose an independent set of maximum cardinality.
+  obtain ⟨S, hS𝓘, hSmax⟩ := 𝓘.exists_max_image Finset.card hne
+  have hSind : IsIndepSet C S := (hmem _).1 hS𝓘
+  refine ⟨S, hSind, ?_⟩
+  -- Domination: every vertex lies in the closed neighbourhood of some u ∈ S.
+  have hdom : ∀ v : Fin n, ∃ u ∈ S, v ∈ closedNbhd C u := by
+    intro v
+    by_cases hv : v ∈ S
+    · exact ⟨v, hv, Finset.mem_insert_self _ _⟩
+    · -- if v has no neighbour in S, S ∪ {v} is a larger independent set
+      by_contra hcon
+      push_neg at hcon
+      -- no u ∈ S is adjacent to v
+      have hno : ∀ u ∈ S, ¬ unitEdge C u v := by
+        intro u hu hedge
+        exact (hcon u hu) (by
+          unfold closedNbhd
+          exact Finset.mem_insert_of_mem (by
+            simp only [Finset.mem_filter, Finset.mem_univ, true_and]; exact hedge))
+      -- insert v S is independent
+      have hins : IsIndepSet C (insert v S) := by
+        intro i hi j hj
+        rcases Finset.mem_insert.1 hi with rfl | hiS
+        · rcases Finset.mem_insert.1 hj with rfl | hjS
+          · rintro ⟨h, _⟩; exact h rfl
+          · intro hedge; exact hno j hjS (unitEdge_symm C hedge)
+        · rcases Finset.mem_insert.1 hj with rfl | hjS
+          · intro hedge; exact hno i hiS hedge
+          · exact hSind i hiS j hjS
+      -- contradiction with maximality
+      have hle : (insert v S).card ≤ S.card := hSmax _ ((hmem _).2 hins)
+      rw [Finset.card_insert_of_notMem hv] at hle
+      omega
+  -- The closed neighbourhoods of S cover everything.
+  have hcover : (Finset.univ : Finset (Fin n)) ⊆ S.biUnion (closedNbhd C) := by
+    intro v _
+    obtain ⟨u, hu, hvu⟩ := hdom v
+    exact Finset.mem_biUnion.2 ⟨u, hu, hvu⟩
+  -- Cardinality bound.
+  have hn : n ≤ S.card * (Δ + 1) := by
+    have h1 : (Finset.univ : Finset (Fin n)).card ≤ (S.biUnion (closedNbhd C)).card :=
+      Finset.card_le_card hcover
+    have h2 : (S.biUnion (closedNbhd C)).card ≤ ∑ u ∈ S, (closedNbhd C u).card :=
+      Finset.card_biUnion_le
+    have h3 : ∑ u ∈ S, (closedNbhd C u).card ≤ ∑ _u ∈ S, (Δ + 1) := by
+      apply Finset.sum_le_sum
+      intro u _
+      calc (closedNbhd C u).card ≤ 1 + unitDegree C u := card_closedNbhd_le C u
+        _ ≤ 1 + Δ := by have := hdeg u; omega
+        _ = Δ + 1 := by ring
+    have h4 : ∑ _u ∈ S, (Δ + 1) = S.card * (Δ + 1) := by
+      rw [Finset.sum_const, smul_eq_mul]
+    simp only [Finset.card_univ, Fintype.card_fin] at h1
+    omega
+  exact Nat.div_le_of_le_mul (by rw [Nat.mul_comm] at hn; exact hn)
+
+-- ============================================================
+-- Part III: Specialisation to the kissing number
+-- ============================================================
+
+/-- The kissing number τ(d) (re-declared self-contained, matching the parent).
+    Known: τ(1)=2, τ(2)=6, τ(3)=12, τ(4)=24, τ(8)=240, τ(24)=196560. -/
+noncomputable def kissingNumber : ℕ → ℕ
+  | 1 => 2
+  | 2 => 6
+  | 3 => 12
+  | 4 => 24
+  | 8 => 240
+  | 24 => 196560
+  | d => 3 ^ d
+
+/-- **The parent's `greedy_independence`, now a theorem.**  Given the geometric
+    degree bound `unitDegree ≤ τ(d)` (the parent's `degree_le_kissing`), the
+    `n/(τ(d)+1)` independence bound follows with **no further axioms** — the
+    graph-theory content is fully discharged by
+    `greedy_independence_of_maxDegree`. -/
+theorem greedy_independence_kissing (C : SepConfig d n)
+    (hkiss : ∀ i, unitDegree C i ≤ kissingNumber d) :
+    ∃ S : Finset (Fin n), IsIndepSet C S ∧ S.card ≥ n / (kissingNumber d + 1) :=
+  greedy_independence_of_maxDegree C (kissingNumber d) hkiss
+
+-- ============================================================
+-- Part IV: Sanity checks on the kissing values
+-- ============================================================
+
+theorem g1_exact : kissingNumber 1 + 1 = 3 := by decide
+theorem g2_greedy : kissingNumber 2 + 1 = 7 := by decide
+theorem g3_greedy : kissingNumber 3 + 1 = 13 := by decide
+
+/-- A trivial uniform degree bound is always available: every vertex has
+    unit-degree ≤ n, giving an (uninformative) independent set of size ≥ n/(n+1).
+    This exhibits `greedy_independence_of_maxDegree` with a *provable* bound,
+    independent of any kissing-number axiom. -/
+theorem greedy_trivial (C : SepConfig d n) :
+    ∃ S : Finset (Fin n), IsIndepSet C S ∧ S.card ≥ n / (n + 1) := by
+  refine greedy_independence_of_maxDegree C n (fun i => ?_)
+  unfold unitDegree
+  calc (Finset.univ.filter (fun j => unitEdge C i j)).card
+      ≤ (Finset.univ : Finset (Fin n)).card := Finset.card_filter_le _ _
+    _ = n := by simp
+
+/-
+  Summary
+
+  * `greedy_independence_of_maxDegree` — general 0-axiom greedy bound
+    (max independent set is dominating ⇒ n ≤ |S|·(Δ+1)).
+  * `greedy_independence_kissing` — the parent's `greedy_independence`
+    axiom, recovered as a theorem modulo only the geometric degree bound.
+  * `greedy_trivial` — a fully unconditional instantiation (Δ := n).
+
+  Net effect: the parent entry's combinatorial axiom `greedy_independence`
+  is ELIMINATED; only the geometric `degree_le_kissing` (= the kissing
+  number problem) remains, isolated as the genuine open target.
+
+  0 axioms, 0 sorries.
+-/
+
+end Erdos1066OQ04OQ03

--- a/src/data/proofs/erdos-1066-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1066-oq-04-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-framework",
+    "proofId": "erdos-1066-oq-04-oq-03",
+    "range": { "startLine": 62, "endLine": 85 },
+    "type": "definition",
+    "title": "Self-contained unit-distance framework",
+    "content": "Re-declares SepConfig (n points in ℝ^d, pairwise distance ≥ 1), unitEdge (distance exactly 1), unitDegree (neighbour count) and IsIndepSet, keeping the file independent of the axiom-bearing parent so it can be certified 0-axiom. unitEdge_symm proves the relation is symmetric via dist_comm — needed so that 'v adjacent to u' and 'u adjacent to v' coincide in the domination step."
+  },
+  {
+    "id": "ann-closed-nbhd",
+    "proofId": "erdos-1066-oq-04-oq-03",
+    "range": { "startLine": 91, "endLine": 101 },
+    "type": "lemma",
+    "title": "Closed neighbourhood cardinality bound",
+    "content": "closedNbhd u = insert u {unit-neighbours of u}. card_closedNbhd_le shows |N[u]| ≤ 1 + deg(u) via Finset.card_insert_le. This is the per-vertex ingredient that, summed over a dominating set S, produces the covering bound n ≤ |S|·(Δ+1)."
+  },
+  {
+    "id": "ann-greedy-general",
+    "proofId": "erdos-1066-oq-04-oq-03",
+    "range": { "startLine": 103, "endLine": 182 },
+    "type": "theorem",
+    "title": "greedy_independence_of_maxDegree (the 0-axiom greedy bound)",
+    "content": "For any degree bound Δ with unit-degree ≤ Δ everywhere, there is an independent set of size ≥ n/(Δ+1). Proof: choose an independent set S of MAXIMUM cardinality (Finset.exists_max_image over the finite family of independent finsets). Domination — if v∉S had no neighbour in S, then insert v S would be a strictly larger independent set, contradicting maximality. Hence the closed neighbourhoods of S cover univ, giving n ≤ Σ_{u∈S}(1+deg u) ≤ |S|(Δ+1), and Nat.div_le_of_le_mul finishes. No greedy ordering, no axioms."
+  },
+  {
+    "id": "ann-kissing-cor",
+    "proofId": "erdos-1066-oq-04-oq-03",
+    "range": { "startLine": 184, "endLine": 206 },
+    "type": "theorem",
+    "title": "greedy_independence_kissing (parent axiom recovered)",
+    "content": "Instantiating Δ := τ(d) recovers the parent entry's axiomatized greedy_independence as a genuine theorem, now taking the geometric degree bound (degree_le_kissing) as an explicit hypothesis. This discharges the combinatorial half of the parent's open question and isolates degree_le_kissing — the kissing-number problem itself — as the sole residual axiom (budget 2 → 1)."
+  },
+  {
+    "id": "ann-trivial",
+    "proofId": "erdos-1066-oq-04-oq-03",
+    "range": { "startLine": 211, "endLine": 224 },
+    "type": "theorem",
+    "title": "greedy_trivial (fully unconditional instantiation)",
+    "content": "Using the always-valid bound unit-degree ≤ n (a filter of univ has card ≤ |univ| = n), greedy_trivial yields the unconditional independent-set bound n/(n+1) with no geometric input — a degenerate but completely axiom-free witness of the general theorem."
+  }
+]

--- a/src/data/proofs/erdos-1066-oq-04-oq-03/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04-oq-03/meta.json
@@ -1,0 +1,132 @@
+{
+  "id": "erdos-1066-oq-04-oq-03",
+  "title": "Proving the Kissing-Number Axioms: the Greedy Independence Bound",
+  "slug": "erdos-1066-oq-04-oq-03",
+  "description": "Answers the open question of the parent Erdős 1066 OQ-04 entry — can its two kissing-number axioms be proved in Lean? — by discharging the combinatorial half completely and 0-axiom. greedy_independence_of_maxDegree proves the general greedy/Turán-type bound: any separated configuration whose vertices have unit-degree ≤ Δ has an independent set of size ≥ n/(Δ+1), via the classic 'a maximum independent set is dominating' covering argument n ≤ |S|·(Δ+1). Specialising Δ := τ(d) recovers the parent's greedy_independence as a theorem. The geometric degree_le_kissing axiom is shown to BE the kissing-number problem (Viazovska-level for d=8,24), isolating it as the true residual open target. Net: the parent's axiom budget drops 2 → 1.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/1066",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1066OQ04OQ03.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "unit-distance",
+      "independence-number",
+      "graph-theory",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 240,
+    "assumptions": "None. All results are fully machine-checked with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound are used). The main theorem greedy_independence_of_maxDegree is unconditional in the degree bound Δ; greedy_independence_kissing takes the geometric degree bound (the parent's degree_le_kissing) as an explicit hypothesis rather than an axiom; greedy_trivial is fully unconditional.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "greedy_independence_of_maxDegree: a 0-axiom proof of the general greedy independence bound — for any degree bound Δ, a separated configuration with unit-degree ≤ Δ everywhere has an independent set of size ≥ n/(Δ+1)",
+      "Covering-via-domination proof technique: a maximum-cardinality independent set S is dominating, so the closed neighbourhoods of S cover all n vertices, giving n ≤ Σ_{u∈S}(1+deg u) ≤ |S|·(Δ+1)",
+      "greedy_independence_kissing: recovers the parent entry's axiomatized greedy_independence as a genuine theorem, modulo only the geometric degree bound degree_le_kissing",
+      "greedy_trivial: a fully unconditional instantiation with Δ := n (unit-degree ≤ n always), exhibiting the bound n/(n+1) with no geometric input",
+      "Identification of degree_le_kissing as the irreducible residue: with exact kissing numbers τ(8)=240, τ(24)=196560 it is the kissing-number problem itself, hence not a session-scale Lean target — reducing the parent's axiom budget from 2 to 1"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "The Erdős 1066 OQ-04 entry formalizes the higher-dimensional unit-distance independence number $g_d(n)$ and bounds it below by $n/(\\tau(d)+1)$, where $\\tau(d)$ is the kissing number. That formalization rests on two `axiom` declarations and its open question asks whether they can be proved in Lean. The two axioms are of very different mathematical character. `greedy_independence` is the statement that a graph of maximum degree $\\Delta$ has an independent set of size at least $n/(\\Delta+1)$ — a classical, elementary graph-theory fact going back to the greedy colouring / Turán bound. `degree_le_kissing` is the statement that a point in a separated configuration has at most $\\tau(d)$ unit-distance neighbours — a deep geometric fact equivalent to the kissing-number problem, whose exact values in dimensions 8 and 24 (240 and 196560) are among the celebrated recent theorems of Viazovska and of Cohn–Kumar–Miller–Radchenko–Viazovska. This entry separates the two: it proves the elementary half completely and 0-axiom, and isolates the geometric half as the genuine open target.",
+    "keyInsight": "The $n/(\\Delta+1)$ greedy bound needs no greedy *ordering* at all: take an independent set $S$ of maximum cardinality. If some vertex $v$ had no neighbour in $S$, then $S\\cup\\{v\\}$ would be a strictly larger independent set, contradicting maximality. Hence $S$ is *dominating* — every vertex lies in the closed neighbourhood of some $u\\in S$. The closed neighbourhoods therefore cover all $n$ vertices, so $n \\le \\sum_{u\\in S}(1+\\deg u) \\le |S|\\,(\\Delta+1)$, i.e. $|S| \\ge n/(\\Delta+1)$. This avoids any explicit colouring or induction and is fully constructive modulo classical choice of the maximizer."
+  },
+  "sections": [
+    {
+      "id": "framework",
+      "title": "Part I: Self-contained Framework",
+      "startLine": 57,
+      "endLine": 85,
+      "summary": "Re-declares SepConfig, unitEdge, unitDegree and IsIndepSet so the file stays independent of the axiom-bearing parent. Proves unitEdge_symm (the unit-distance relation is symmetric via dist_comm).",
+      "mathContext": "$\\mathrm{SepConfig}(d,n)$ is $n$ points in $\\mathbb{R}^d$ with pairwise distance $\\ge 1$; $\\mathrm{unitEdge}(C,i,j) :\\!\\iff i\\ne j \\land \\mathrm{dist}(p_i,p_j)=1$; $\\deg(C,i)=|\\{j:\\mathrm{unitEdge}(C,i,j)\\}|$. The relation is symmetric since $\\mathrm{dist}$ is symmetric, so it defines a genuine (simple) graph."
+    },
+    {
+      "id": "greedy",
+      "title": "Part II: The General Greedy Bound (0 axioms)",
+      "startLine": 87,
+      "endLine": 182,
+      "summary": "greedy_independence_of_maxDegree: for any degree bound Δ with unit-degree ≤ Δ everywhere, there is an independent set of size ≥ n/(Δ+1). Proof picks a maximum-cardinality independent set (Finset.exists_max_image over the finite family of independent finsets), shows it is dominating, and covers univ by closed neighbourhoods.",
+      "mathContext": "Let $S$ maximize $|S|$ among independent sets. Domination: for $v\\notin S$, if no $u\\in S$ were adjacent to $v$ then $\\mathrm{insert}\\,v\\,S$ would be independent with cardinality $|S|+1$, contradicting maximality. Covering: $\\mathrm{univ}\\subseteq\\bigcup_{u\\in S}N[u]$ with $|N[u]|\\le 1+\\deg u\\le \\Delta+1$, so $n=|\\mathrm{univ}|\\le |S|(\\Delta+1)$ and $n/(\\Delta+1)\\le|S|$ by `Nat.div_le_of_le_mul`."
+    },
+    {
+      "id": "kissing",
+      "title": "Part III: Specialisation to the Kissing Number",
+      "startLine": 183,
+      "endLine": 206,
+      "summary": "Re-declares kissingNumber τ(d) and derives greedy_independence_kissing by instantiating Δ := τ(d). This recovers the parent's greedy_independence as a theorem whose only remaining hypothesis is the geometric degree bound degree_le_kissing.",
+      "mathContext": "With $\\Delta=\\tau(d)$ the general bound yields an independent set of size $\\ge n/(\\tau(d)+1)$. The hypothesis $\\forall i,\\ \\deg(C,i)\\le\\tau(d)$ is exactly the parent's `degree_le_kissing`; supplying it as a hypothesis (not an axiom) makes explicit that the combinatorial content is fully discharged."
+    },
+    {
+      "id": "checks",
+      "title": "Part IV: Sanity Checks and Unconditional Bound",
+      "startLine": 207,
+      "endLine": 240,
+      "summary": "Confirms τ(1)+1=3, τ(2)+1=7, τ(3)+1=13 by decide, and proves greedy_trivial: the unconditional bound n/(n+1) using the always-valid degree bound unit-degree ≤ n (card of a filter ≤ card of univ).",
+      "mathContext": "greedy_trivial instantiates $\\Delta:=n$ via $\\deg(C,i)=|\\{j:\\dots\\}|\\le|\\mathrm{univ}|=n$, yielding $g_d(n)\\ge n/(n+1)$ with no geometric input — a degenerate but axiom-free corollary witnessing the general theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's open question 'can the 2 kissing-number axioms be proved in Lean?' for the combinatorial axiom: greedy_independence is proved completely and 0-axiom as a special case of greedy_independence_of_maxDegree, the general bound that a graph of maximum degree Δ has an independent set of size ≥ n/(Δ+1). The proof uses the 'maximum independent set is dominating' covering argument, avoiding any explicit greedy ordering. The geometric axiom degree_le_kissing is shown to coincide with the kissing-number problem itself and is isolated as the genuine residual open target, dropping the parent's axiom budget from 2 to 1.",
+    "implications": "The clean separation clarifies exactly where the mathematical difficulty in g_d(n) ≥ n/(τ(d)+1) lives: not in the combinatorics (a three-line covering argument) but in the geometry of the kissing number. Any future formalization of degree_le_kissing in a fixed dimension d will combine with greedy_independence_of_maxDegree to give a fully verified, axiom-free bound on g_d(n) in that dimension. The general theorem is reusable: it bounds the independence number of ANY unit-distance (indeed any finite) graph once a uniform degree bound is supplied.",
+    "openQuestions": [
+      "Prove degree_le_kissing for a fixed low dimension (e.g. d=1: unit neighbours of a point on a line number at most 2; d=2: at most 6), giving a fully axiom-free g_d(n) bound there.",
+      "Connect greedy_independence_of_maxDegree to Mathlib's SimpleGraph independence/chromatic-number API, or upstream the general bound as α(G) ≥ |V|/(Δ(G)+1).",
+      "Sharpen beyond greedy: formalize the Caro–Wei bound α(G) ≥ Σ_v 1/(deg(v)+1), which strictly improves n/(Δ+1) for irregular configurations."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1066-oq-04",
+      "relationship": "parent-problem",
+      "description": "The parent entry axiomatizes greedy_independence and degree_le_kissing; this entry proves the former and isolates the latter, reducing its axiom budget from 2 to 1."
+    },
+    {
+      "targetId": "erdos-1066",
+      "relationship": "ancestor-problem",
+      "description": "The original Erdős 1066 unit-distance independence formalization (2D case)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1066OQ04OQ03",
+    "lineCount": 240,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1066OQ04OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "On sets of distances of n points",
+      "year": "1946",
+      "venue": "American Mathematical Monthly 53, 248–250",
+      "note": "Originates the unit-distance problem; the independence number g(n) measures the structural sparseness of unit-distance graphs."
+    },
+    {
+      "authors": "Caro, Yair and Wei, V. K.",
+      "title": "A lower bound on the independence number of a graph (independently obtained)",
+      "year": "1979/1981",
+      "venue": "Technical report / Congressus Numerantium",
+      "note": "The Caro–Wei bound α(G) ≥ Σ_v 1/(deg(v)+1) refines the greedy bound n/(Δ+1) proved here as greedy_independence_of_maxDegree."
+    },
+    {
+      "authors": "Viazovska, Maryna S.",
+      "title": "The sphere packing problem in dimension 8",
+      "year": "2017",
+      "venue": "Annals of Mathematics 185(3), 991–1015",
+      "note": "Establishes τ(8)=240 optimal; together with the Leech-lattice result τ(24)=196560 this is why the residual degree_le_kissing axiom is not a session-scale Lean target."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent **erdos-1066-oq-04** (Higher-Dimensional Unit Distance Independence): *"Can the 2 kissing-number axioms be proved in Lean?"* — for the **combinatorial** axiom `greedy_independence`, which is discharged completely and **0-axiom**.

## What is proved

- **`greedy_independence_of_maxDegree`** (the general bound, 0 axioms): for any degree bound `Δ` with `unitDegree ≤ Δ` everywhere, a separated configuration has an independent set of size `≥ n/(Δ+1)`. Proof uses the classic *"a maximum independent set is dominating"* covering argument — no greedy ordering:
  > Take a max-cardinality independent set `S`. If `v∉S` had no neighbour in `S`, then `insert v S` would be a larger independent set — contradiction. So the closed neighbourhoods of `S` cover all `n` vertices: `n ≤ Σ_{u∈S}(1+deg u) ≤ |S|·(Δ+1)`.
- **`greedy_independence_kissing`**: instantiating `Δ := τ(d)` recovers the parent's axiomatized `greedy_independence` as a genuine **theorem**, modulo only the geometric degree bound.
- **`greedy_trivial`**: a fully unconditional instantiation (`Δ := n`), giving `n/(n+1)` with no geometric input.

## The residue

`degree_le_kissing` is shown to *be* the kissing-number problem itself (exact `τ(8)=240`, `τ(24)=196560` are Viazovska-level theorems), so it is not a session-scale Lean target. **Net: the parent's axiom budget drops from 2 → 1.**

## Verification

- `lake env lean` clean (only foundational `propext`/`Classical.choice`/`Quot.sound`; **0 axioms, 0 sorries**)
- `#print axioms` confirmed for all three main theorems
- `pnpm build` passes (gallery integrates)
- 8 theorems, 6 definitions, 240 lines; self-contained (no import of the axiom-bearing parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)