### PR TITLE
research(abundant-number-oq-04-oq-01): strict lower-bounded abundancy-index monotonicity n·σ(d)+d ≤ d·σ(n) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -48,6 +48,7 @@ import Proofs.AbundantMultiplesOQ01
 import Proofs.AbundantNumberOQ01
 import Proofs.AbundantNumberOQ02
 import Proofs.AbundantOddInfiniteOQ03
+import Proofs.AbundantStrictAbundancyOQ0401
 import Proofs.AlgebraicNumbersCountable
 import Proofs.AlgebraicNumbersCountableAristotle
 import Proofs.AlgebraicNumbersCountableOQ01

--- a/proofs/Proofs/AbundantStrictAbundancyOQ0401.lean
+++ b/proofs/Proofs/AbundantStrictAbundancyOQ0401.lean
@@ -1,0 +1,170 @@
+/-
+  Strict, lower-bounded sharpening of the abundancy-index monotonicity along
+  divisibility.
+
+  The parent entry `abundant-number-oq-04`
+  (`Proofs.AbundantDeficientDvdOQ04`) proves the *non-strict* monotonicity
+
+  * `sigma_dvd_mono` — if `d ∣ n` and `n > 0` then `n · σ(d) ≤ d · σ(n)`,
+    i.e. `σ(d)/d ≤ σ(n)/n`,
+
+  via the scaled-divisor injection `e ↦ (n/d)·e`, which embeds `divisors d`
+  into `divisors n`. This file sharpens that bound to a *strict* one at a
+  *proper* divisor, and pins down a concrete minimum size for the jump.
+
+  * `scaled_sigma_lt` — the strict scaled-divisor bound. For `0 < d` and
+    `2 ≤ t`, the image `{t·e : e ∣ d}` is a subset of `divisors (d*t)` that
+    omits the divisor `1` (since `t·e ≥ t ≥ 2 > 1`), so summing over the larger
+    set gains at least that one extra term:
+    `t · σ(d) + 1 ≤ σ(d*t)`.
+
+  * `sigma_dvd_strict_mono` — the strict, lower-bounded monotonicity. If
+    `d ∣ n` and `d < n` then
+    `n · σ(d) + d ≤ d · σ(n)`,
+    i.e. `d · σ(n) − n · σ(d) ≥ d > 0`. In abundancy-index form this quantifies
+    the gap as `σ(n)/n − σ(d)/d ≥ 1/n > 0`.
+
+  * `abundancy_gap_ge` — the rational corollary over `ℚ`:
+    `σ(d)/d + 1/n ≤ σ(n)/n` for `d ∣ n`, `d < n`.
+
+  As a sanity check we re-derive the parent's
+  `deficient_of_proper_dvd_perfect` directly from the strict bound (no detour
+  through the abundant-side closure lemmas): a proper divisor `d` of a perfect
+  number `n` satisfies `σ(d) < 2d` because the strict gap forces
+  `n · σ(d) < n · (2d)`.
+
+  The intuition behind the strict gain is elementary: the divisors of `n = d·t`
+  include all of the scaled divisors `{t·e : e ∣ d}` (already accounting for
+  `t·σ(d)`), but they *also* include `1`, which is never of the form `t·e` when
+  `t ≥ 2`. That one extra, otherwise-uncounted divisor forces the `+1`.
+
+  The proof is axiom-free (no `sorry`, no `axiom`, no `native_decide`).
+-/
+import Mathlib
+import Proofs.AbundantDeficientDvdOQ04
+
+namespace AbundantStrictAbundancyOQ0401
+
+open Finset
+open AbundantDeficientDvdOQ04
+
+/-- **Strict scaled-divisor bound.** For `0 < d` and `2 ≤ t`, the map `e ↦ t·e`
+injects `divisors d` into `divisors (d*t)`, and the divisor `1` of `d*t` lies
+outside the image (since every `t·e ≥ t ≥ 2`). Hence the sum over `divisors (d*t)`
+strictly exceeds `t·σ(d)`, by at least the missing term `1`:
+`t · σ(d) + 1 ≤ σ(d*t)`. This is the strict refinement of the parent's
+`scaled_sigma_le`. -/
+theorem scaled_sigma_lt (d t : ℕ) (hd : 0 < d) (ht : 2 ≤ t) :
+    t * (∑ e ∈ d.divisors, e) + 1 ≤ ∑ e ∈ (d * t).divisors, e := by
+  have htpos : 0 < t := by omega
+  have hm : 0 < d * t := Nat.mul_pos hd htpos
+  -- scaled divisors of `d` sit inside the divisors of `d * t`
+  have hsub : d.divisors.image (fun e => t * e) ⊆ (d * t).divisors := by
+    intro x hx
+    rw [Finset.mem_image] at hx
+    obtain ⟨e, he, rfl⟩ := hx
+    rw [Nat.mem_divisors] at he ⊢
+    refine ⟨?_, hm.ne'⟩
+    rw [mul_comm d t]
+    exact mul_dvd_mul_left t he.1
+  -- scaling is injective on `divisors d` since `t > 0`
+  have hinj : Set.InjOn (fun e => t * e) (d.divisors : Set ℕ) :=
+    fun x _ y _ h => Nat.eq_of_mul_eq_mul_left htpos h
+  have himg : ∑ x ∈ d.divisors.image (fun e => t * e), x = t * (∑ e ∈ d.divisors, e) := by
+    rw [Finset.sum_image hinj, Finset.mul_sum]
+  -- `1` is a divisor of `d*t` but is not a scaled divisor (every `t·e ≥ 2`)
+  have h1mem : (1 : ℕ) ∈ (d * t).divisors := Nat.one_mem_divisors.mpr hm.ne'
+  have h1notmem : (1 : ℕ) ∉ d.divisors.image (fun e => t * e) := by
+    rw [Finset.mem_image]
+    rintro ⟨e, he, heq⟩
+    have hepos : 0 < e := Nat.pos_of_mem_divisors he
+    have hge : 2 * 1 ≤ t * e := Nat.mul_le_mul ht hepos
+    omega
+  -- strict subset-sum: the larger set has the extra positive term `1`
+  have hstrict :
+      (∑ x ∈ d.divisors.image (fun e => t * e), x) < ∑ e ∈ (d * t).divisors, e :=
+    Finset.sum_lt_sum_of_subset hsub h1mem h1notmem (by norm_num) (fun j _ _ => Nat.zero_le j)
+  rw [himg] at hstrict
+  omega
+
+/-- **Strict, lower-bounded monotonicity of the abundancy index.** If `d ∣ n` and
+`d < n` then
+`n · σ(d) + d ≤ d · σ(n)`,
+equivalently `d · σ(n) − n · σ(d) ≥ d > 0`, i.e. the abundancy index strictly
+increases by at least `1/n` when passing to a proper multiple:
+`σ(n)/n − σ(d)/d ≥ 1/n`. This sharpens the parent's non-strict `sigma_dvd_mono`.
+The extra `+d` comes from the divisor `1` of `n`, which is never a scaled divisor
+`(n/d)·e` of `d`. -/
+theorem sigma_dvd_strict_mono {d n : ℕ} (hdvd : d ∣ n) (hlt : d < n) :
+    n * (∑ e ∈ d.divisors, e) + d ≤ d * (∑ e ∈ n.divisors, e) := by
+  obtain ⟨t, rfl⟩ := hdvd
+  have hd : 0 < d := by
+    rcases Nat.eq_zero_or_pos d with rfl | h
+    · simp at hlt
+    · exact h
+  -- `d < d*t` forces `t ≥ 2`
+  have ht2 : 2 ≤ t := by
+    have h1 : d * 1 < d * t := by simpa [Nat.mul_one] using hlt
+    have := Nat.lt_of_mul_lt_mul_left h1
+    omega
+  have key : t * (∑ e ∈ d.divisors, e) + 1 ≤ ∑ e ∈ (d * t).divisors, e :=
+    scaled_sigma_lt d t hd ht2
+  calc (d * t) * (∑ e ∈ d.divisors, e) + d
+      = d * (t * (∑ e ∈ d.divisors, e) + 1) := by ring
+    _ ≤ d * (∑ e ∈ (d * t).divisors, e) := Nat.mul_le_mul_left d key
+
+/-- **Abundancy gap over `ℚ`.** The cross-multiplied integer bound rephrased as a
+genuine rational inequality: for `d ∣ n` with `d < n`,
+`σ(d)/d + 1/n ≤ σ(n)/n`.
+Thus the abundancy index `σ(·)/(·)` gains at least `1/n` on passing from `d` to
+its proper multiple `n`. -/
+theorem abundancy_gap_ge {d n : ℕ} (hdvd : d ∣ n) (hlt : d < n) :
+    ((∑ e ∈ d.divisors, (e : ℚ)) / d) + 1 / n ≤ (∑ e ∈ n.divisors, (e : ℚ)) / n := by
+  have hn : 0 < n := lt_of_le_of_lt (Nat.zero_le d) hlt
+  have hd : 0 < d := Nat.pos_of_dvd_of_pos hdvd hn
+  have hdq : (0 : ℚ) < d := by exact_mod_cast hd
+  have hnq : (0 : ℚ) < n := by exact_mod_cast hn
+  have hdne : (d : ℚ) ≠ 0 := ne_of_gt hdq
+  have hnne : (n : ℚ) ≠ 0 := ne_of_gt hnq
+  have hkey : n * (∑ e ∈ d.divisors, e) + d ≤ d * (∑ e ∈ n.divisors, e) :=
+    sigma_dvd_strict_mono hdvd hlt
+  -- cast the integer bound to ℚ (with the sums pushed inside the cast)
+  have hkeyq : (n : ℚ) * (∑ e ∈ d.divisors, (e : ℚ)) + d ≤ d * (∑ e ∈ n.divisors, (e : ℚ)) := by
+    have h : ((n * (∑ e ∈ d.divisors, e) + d : ℕ) : ℚ)
+        ≤ ((d * (∑ e ∈ n.divisors, e) : ℕ) : ℚ) := by exact_mod_cast hkey
+    push_cast at h
+    linarith [h]
+  rw [← sub_nonneg]
+  have hrw :
+      (∑ e ∈ n.divisors, (e : ℚ)) / n - ((∑ e ∈ d.divisors, (e : ℚ)) / d + 1 / n)
+        = (d * (∑ e ∈ n.divisors, (e : ℚ)) - (n * (∑ e ∈ d.divisors, (e : ℚ)) + d))
+            / (d * n) := by
+    field_simp
+  rw [hrw]
+  apply div_nonneg
+  · linarith [hkeyq]
+  · positivity
+
+/-- **Sanity check: every proper divisor of a perfect number is deficient.**
+Re-derived directly from the strict gap `sigma_dvd_strict_mono` (rather than the
+parent's detour through the abundant-side closure lemmas). If `n` is perfect with
+`σ(n) = 2n`, a proper divisor `d` satisfies `n·σ(d) + d ≤ d·σ(n) = d·(2n)`, so
+`n·σ(d) < n·(2d)`, whence `σ(d) < 2d`: `d` is deficient. -/
+theorem deficient_of_proper_dvd_perfect' {d n : ℕ}
+    (hp : n.Perfect) (hdvd : d ∣ n) (hlt : d < n) : d.Deficient := by
+  have hnpos : 0 < n := hp.2
+  have hdpos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hnpos
+  -- `σ(n) = 2n` from perfection (Mathlib's `Nat.Perfect` is stated on properDivisors)
+  have hσn : ∑ e ∈ n.divisors, e = 2 * n := by
+    have h := hp.1
+    rw [Nat.sum_divisors_eq_sum_properDivisors_add_self]
+    omega
+  have hkey : n * (∑ e ∈ d.divisors, e) + d ≤ d * (∑ e ∈ n.divisors, e) :=
+    sigma_dvd_strict_mono hdvd hlt
+  rw [hσn] at hkey
+  -- `n·σ(d) + d ≤ d·(2n) = n·(2d)`, so `n·σ(d) < n·(2d)`, giving `σ(d) < 2d`
+  have hchain : n * (∑ e ∈ d.divisors, e) < n * (2 * d) := by nlinarith [hkey, hdpos, hnpos]
+  have hσd : ∑ e ∈ d.divisors, e < 2 * d := Nat.lt_of_mul_lt_mul_left hchain
+  exact (deficient_iff_sigma_lt_two_mul).mpr hσd
+
+end AbundantStrictAbundancyOQ0401

--- a/src/data/proofs/abundant-number-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abundant-number-oq-04-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "abundant-number-oq-04-oq-01",
+  "title": "Strict, Lower-Bounded Sharpening of Abundancy-Index Monotonicity: the Jump at a Proper Multiple Is at Least 1/n",
+  "slug": "abundant-number-oq-04-oq-01",
+  "description": "The parent entry abundant-number-oq-04 proves the NON-strict monotonicity of the abundancy index along divisibility: if d ∣ n (n > 0) then n·σ(d) ≤ d·σ(n), i.e. σ(d)/d ≤ σ(n)/n. This entry sharpens that bound to a STRICT, lower-bounded inequality at a PROPER divisor: for d ∣ n with d < n, n·σ(d) + d ≤ d·σ(n), equivalently d·σ(n) − n·σ(d) ≥ d > 0. In abundancy-index form this quantifies the size of the jump: σ(n)/n − σ(d)/d ≥ 1/n > 0. The mechanism is elementary. Writing n = d·t with t ≥ 2, the divisors of n include the whole scaled image {t·e : e ∣ d} (already accounting for t·σ(d)), but they ALSO include the divisor 1, which is never of the form t·e when t ≥ 2 (every t·e ≥ t ≥ 2). That single extra, otherwise-uncounted divisor forces the strict gain σ(d·t) ≥ t·σ(d) + 1, and multiplying by d yields the +d gap. The result is packaged over ℚ as σ(d)/d + 1/n ≤ σ(n)/n, and is used to re-derive the parent's deficient_of_proper_dvd_perfect directly from the strict gap (no detour through the abundant-side closure lemmas). Fully machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A005100 (deficient numbers), A000396 (perfect numbers)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantStrictAbundancyOQ0401.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "deficient-numbers",
+      "perfect-numbers",
+      "divisibility",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 170,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms` on scaled_sigma_lt, sigma_dvd_strict_mono, abundancy_gap_ge, and deficient_of_proper_dvd_perfect' reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no native_decide, hence no Lean.ofReduceBool. The proofs are purely arithmetic over ℕ (with a ℚ-cast corollary) and reuse only the parent's deficient bridge deficient_iff_sigma_lt_two_mul.",
+    "originalContributions": [
+      "Proves `scaled_sigma_lt : 0 < d → 2 ≤ t → t·σ(d) + 1 ≤ σ(d·t)` — the STRICT refinement of the parent's scaled_sigma_le. The scaled image {t·e : e ∣ d} is a proper subset of divisors (d·t) that omits the divisor 1 (since t·e ≥ t ≥ 2), so Finset.sum_lt_sum_of_subset gains exactly that missing term.",
+      "Proves `sigma_dvd_strict_mono : d ∣ n → d < n → n·σ(d) + d ≤ d·σ(n)` — the strict, lower-bounded monotonicity of the abundancy index. The explicit +d quantifies the jump: d·σ(n) − n·σ(d) ≥ d, i.e. σ(n)/n − σ(d)/d ≥ 1/n. This is exactly the strict sharpening requested as open question index 0 of the parent abundant-number-oq-04.",
+      "Proves the rational corollary `abundancy_gap_ge : d ∣ n → d < n → σ(d)/d + 1/n ≤ σ(n)/n` over ℚ, exhibiting the abundancy index as gaining at least 1/n on passing to a proper multiple.",
+      "Re-derives the parent's boundary result as `deficient_of_proper_dvd_perfect'` directly from the strict gap: for a perfect n with σ(n) = 2n, a proper divisor d satisfies n·σ(d) + d ≤ d·(2n) = n·(2d), so n·σ(d) < n·(2d) and σ(d) < 2d — bypassing the trichotomy / abundant-side closure argument the parent needed."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The abundancy index h(n) = σ(n)/n is monotone non-decreasing along divisibility: d ∣ n ⟹ h(d) ≤ h(n). The parent entry abundant-number-oq-04 formalizes exactly this non-strict statement and uses it to drive the deficient-side closure laws. But monotonicity alone gives only ≤, which is why the parent had to detour through a trichotomy argument to certify that proper divisors of perfect numbers are STRICTLY deficient. Strengthening the monotonicity to a strict, quantitative inequality — pinning down how fast h climbs along a divisor chain — is the natural next step, and the value 1/n is the sharp first-order gap coming from the always-present divisor 1.",
+    "problemStatement": "Sharpen the parent's non-strict abundancy-index monotonicity n·σ(d) ≤ d·σ(n) (for d ∣ n, n > 0) to a strict, lower-bounded inequality at a PROPER divisor: prove n·σ(d) + d ≤ d·σ(n) for d ∣ n with d < n, equivalently σ(n)/n − σ(d)/d ≥ 1/n, keeping everything axiom-free and re-deriving the perfect-boundary deficiency as a sanity check.",
+    "text": "A self-contained Lean 4 / Mathlib formalization (170 lines, 0 sorries, 0 axioms) that sharpens the abundancy-index monotonicity of abundant-number-oq-04 to a strict, quantitatively lower-bounded form. The conceptual core is scaled_sigma_lt: for d > 0 and t ≥ 2, the injection e ↦ t·e embeds divisors d into divisors (d·t) as a subset that misses the divisor 1 (because every scaled divisor t·e is at least t ≥ 2), so Finset.sum_lt_sum_of_subset upgrades the parent's ≤ to t·σ(d) + 1 ≤ σ(d·t). Multiplying by d gives sigma_dvd_strict_mono : n·σ(d) + d ≤ d·σ(n) for a proper divisor d of n, whose abundancy-index reading is σ(n)/n − σ(d)/d ≥ 1/n (formalized over ℚ as abundancy_gap_ge). As a sanity check, deficient_of_proper_dvd_perfect' recovers the parent's boundary result directly from the strict gap, avoiding the trichotomy.",
+    "proofStrategy": "1. **Strict scaled-divisor bound (scaled_sigma_lt).** With d > 0, t ≥ 2: the image S = (divisors d).image (·t) is a subset of divisors (d·t) (mul_dvd_mul_left), summing to t·σ(d) (Finset.sum_image, injectivity by left-cancellation). The divisor 1 ∈ divisors (d·t) (Nat.one_mem_divisors) lies outside S since t·e ≥ 2·1 = 2 > 1 for e ≥ 1 (Nat.mul_le_mul). Finset.sum_lt_sum_of_subset with the extra positive term 1 gives t·σ(d) < σ(d·t), i.e. t·σ(d) + 1 ≤ σ(d·t) over ℕ.\n\n2. **Strict monotonicity (sigma_dvd_strict_mono).** Write n = d·t. From d < d·t and d > 0 deduce t ≥ 2 (Nat.lt_of_mul_lt_mul_left). Then (d·t)·σ(d) + d = d·(t·σ(d) + 1) ≤ d·σ(d·t) by Nat.mul_le_mul_left on step 1.\n\n3. **Rational corollary (abundancy_gap_ge).** Cast step 2 to ℚ (push_cast); rewrite σ(n)/n − (σ(d)/d + 1/n) as (d·σ(n) − (n·σ(d) + d))/(d·n) (field_simp) and conclude by div_nonneg with linarith on the cast bound.\n\n4. **Perfect-boundary deficiency (deficient_of_proper_dvd_perfect').** For perfect n, σ(n) = 2n (from the properDivisors definition + Nat.sum_divisors_eq_sum_properDivisors_add_self). Step 2 gives n·σ(d) + d ≤ d·(2n) = n·(2d), so n·σ(d) < n·(2d); cancel n (Nat.lt_of_mul_lt_mul_left) to get σ(d) < 2d, i.e. d deficient via the parent's deficient_iff_sigma_lt_two_mul.",
+    "keyInsights": [
+      "**The divisor 1 is the source of strictness.** The parent's non-strict bound comes from the scaled-divisor subset {t·e : e ∣ d} ⊆ divisors(d·t). The single divisor that this subset can never contain (when t ≥ 2) is 1 itself, because every scaled divisor is at least t ≥ 2. Counting that one omitted, strictly positive divisor is exactly the +1 that upgrades ≤ to <, and after multiplying by d, the +d gap.",
+      "**1/n is the sharp first-order gap.** The quantitative reading σ(n)/n − σ(d)/d ≥ 1/n is sharp in its dependence on the omitted divisor 1: a single guaranteed extra divisor contributes 1 to σ(n), hence 1/n to the index. Accounting for further guaranteed divisors of n would only enlarge the gap, never shrink it.",
+      "**Strictness for free at the boundary.** The parent needed a trichotomy (a non-deficient proper divisor would make the perfect number abundant) precisely because non-strict monotonicity gives only σ(d) ≤ 2d. The strict gap delivers σ(d) < 2d immediately: n·σ(d) + d ≤ d·σ(n) = n·(2d) forces the strict inequality with slack d, so the perfect-boundary deficiency drops out without any case analysis.",
+      "**A one-line strengthening reusing the parent's engine.** scaled_sigma_lt is structurally the parent's scaled_sigma_le with Finset.sum_le_sum_of_subset replaced by Finset.sum_lt_sum_of_subset plus the canonical witness 1 ∉ image. No new divisor-sum machinery is introduced."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ(n) = ∑_{e ∣ n} e and the abundant / deficient / perfect classification (Nat.Abundant, Nat.Perfect, Nat.Deficient)",
+      "The parent's non-strict monotonicity sigma_dvd_mono and scaled_sigma_le, and the deficient bridge deficient_iff_sigma_lt_two_mul (abundant-number-oq-04)",
+      "Finset image/subset reasoning for divisor sums, in particular Finset.sum_lt_sum_of_subset, Finset.sum_image, Nat.one_mem_divisors, Nat.pos_of_mem_divisors",
+      "ℕ-to-ℚ casting (push_cast / exact_mod_cast) and field_simp / div_nonneg for the rational corollary"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring: a strict, lower-bounded sharpening of the parent's abundancy-index monotonicity. States the strict scaled-divisor bound, the +d gap n·σ(d) + d ≤ d·σ(n) at a proper divisor, the 1/n abundancy-index reading, and the re-derivation of the perfect-boundary deficiency.",
+      "mathContext": "Monotonicity gives ≤; the omitted divisor 1 of a proper multiple supplies the strict, quantitative gain."
+    },
+    {
+      "id": "strict-scaled",
+      "title": "Strict Scaled-Divisor Bound",
+      "startLine": 51,
+      "endLine": 89,
+      "summary": "`scaled_sigma_lt`: for d > 0, t ≥ 2, the scaled image {t·e : e ∣ d} ⊆ divisors(d·t) omits the divisor 1 (every t·e ≥ 2), so Finset.sum_lt_sum_of_subset gives t·σ(d) + 1 ≤ σ(d·t).",
+      "mathContext": "The single omitted divisor 1 strictly increases the divisor sum of a proper multiple."
+    },
+    {
+      "id": "strict-mono",
+      "title": "Strict, Lower-Bounded Monotonicity",
+      "startLine": 90,
+      "endLine": 115,
+      "summary": "`sigma_dvd_strict_mono`: writing n = d·t with t ≥ 2, multiply the strict scaled bound by d to obtain n·σ(d) + d ≤ d·σ(n), i.e. d·σ(n) − n·σ(d) ≥ d > 0.",
+      "mathContext": "The abundancy index jumps by at least 1/n when passing to a proper multiple."
+    },
+    {
+      "id": "rational-gap",
+      "title": "Abundancy Gap over ℚ",
+      "startLine": 116,
+      "endLine": 147,
+      "summary": "`abundancy_gap_ge`: casts the integer bound to ℚ and rewrites σ(n)/n − (σ(d)/d + 1/n) as a single nonnegative fraction (field_simp, div_nonneg), giving σ(d)/d + 1/n ≤ σ(n)/n.",
+      "mathContext": "The cross-multiplied integer gap, stated as a genuine rational inequality on the index."
+    },
+    {
+      "id": "perfect-boundary",
+      "title": "Perfect-Boundary Deficiency, Re-derived",
+      "startLine": 148,
+      "endLine": 170,
+      "summary": "`deficient_of_proper_dvd_perfect'`: for perfect n (σ(n) = 2n), the strict gap forces n·σ(d) < n·(2d), hence σ(d) < 2d; a proper divisor of a perfect number is deficient — no trichotomy needed.",
+      "mathContext": "Strictness at the boundary now drops out directly from the quantitative gap."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "sigma_dvd_strict_mono",
+      "type": "core",
+      "description": "d ∣ n → d < n → n·σ(d) + d ≤ d·σ(n): the strict, lower-bounded sharpening of the parent's sigma_dvd_mono. The explicit +d quantifies the abundancy-index jump as σ(n)/n − σ(d)/d ≥ 1/n. Answers open question index 0 of abundant-number-oq-04.",
+      "leanType": "n * (∑ e ∈ d.divisors, e) + d ≤ d * (∑ e ∈ n.divisors, e)"
+    },
+    {
+      "name": "scaled_sigma_lt",
+      "type": "core",
+      "description": "0 < d → 2 ≤ t → t·σ(d) + 1 ≤ σ(d·t): the strict scaled-divisor bound. The scaled image of divisors d misses the divisor 1 of d·t, so the divisor sum strictly exceeds t·σ(d) by at least 1.",
+      "leanType": "t * (∑ e ∈ d.divisors, e) + 1 ≤ ∑ e ∈ (d * t).divisors, e"
+    },
+    {
+      "name": "abundancy_gap_ge",
+      "type": "core",
+      "description": "d ∣ n → d < n → σ(d)/d + 1/n ≤ σ(n)/n: the rational corollary, exhibiting the abundancy index as gaining at least 1/n on passing to a proper multiple.",
+      "leanType": "(∑ e ∈ d.divisors, (e : ℚ)) / d + 1 / n ≤ (∑ e ∈ n.divisors, (e : ℚ)) / n"
+    },
+    {
+      "name": "deficient_of_proper_dvd_perfect'",
+      "type": "supporting",
+      "description": "n.Perfect → d ∣ n → d < n → d.Deficient: the parent's perfect-boundary result re-derived directly from the strict gap (σ(n) = 2n forces n·σ(d) < n·(2d), so σ(d) < 2d), bypassing the trichotomy argument.",
+      "leanType": "n.Perfect → d ∣ n → d < n → d.Deficient"
+    }
+  ],
+  "conclusion": {
+    "summary": "Sharpens the abundancy-index monotonicity of abundant-number-oq-04 to a strict, quantitatively lower-bounded inequality at a proper divisor: for d ∣ n with d < n, n·σ(d) + d ≤ d·σ(n), equivalently σ(n)/n − σ(d)/d ≥ 1/n. The strict gain comes from the divisor 1 of the proper multiple n = d·t, which is never a scaled divisor t·e (t ≥ 2). The result is packaged over ℚ and used to re-derive the parent's perfect-boundary deficiency directly. Fully machine-checked, 0 axioms and 0 sorries.",
+    "implications": "The strict, lower-bounded version supplies the < that non-strict monotonicity could not, re-proving that proper divisors of perfect numbers are deficient with quantitative slack and bypassing the parent's trichotomy detour. The explicit 1/n gap gives a reusable, quantitative handle on how fast the abundancy index climbs along a divisor chain — the kind of input needed for results on primitive abundant numbers and on abundancy-index gaps, neither of which Mathlib records.",
+    "openQuestions": [
+      "Sharpen the constant: identify the best guaranteed gap d·σ(n) − n·σ(d) by accounting for further divisors of n = d·t that are never scaled divisors of d (e.g. small divisors t', or 1 together with t when t ∤ any e), and characterize the equality cases of the ≥ 1/n bound.",
+      "Use the strict gap to study primitive abundant numbers: an abundant number all of whose proper divisors are deficient: deficient_of_proper_dvd_perfect' is the perfect-number boundary case, and the quantitative jump constrains how close a proper divisor's index can approach 2."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A005100: Deficient numbers (n with σ(n) < 2n)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "The deficient numbers; this entry quantifies how the abundancy index climbs toward the perfect threshold."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-04",
+      "relationship": "extends",
+      "description": "Direct parent. abundant-number-oq-04 proves the non-strict abundancy-index monotonicity n·σ(d) ≤ d·σ(n) (sigma_dvd_mono) and supplies scaled_sigma_le and the deficient bridge deficient_iff_sigma_lt_two_mul. This entry sharpens that bound to the strict, lower-bounded n·σ(d) + d ≤ d·σ(n) for proper divisors — exactly the parent's open question index 0 — and re-derives its perfect-boundary deficiency directly from the strict gap."
+    },
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "related",
+      "description": "The oq-01 entry establishes the abundant-side closure lemmas (abundant_mul_right, abundant_of_perfect_mul) via the same scaled-divisor injection that, in strict form, powers this entry's sigma_dvd_strict_mono."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantStrictAbundancyOQ0401.lean",
+    "namespace": "AbundantStrictAbundancyOQ0401",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantDeficientDvdOQ04"
+    ],
+    "lineCount": 170,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry **abundant-number-oq-04**'s non-strict abundancy-index monotonicity to a **strict, lower-bounded** inequality at a *proper* divisor — exactly the parent's open question index 0.

For `d ∣ n` with `d < n`:
$$ n\,\sigma(d) + d \;\le\; d\,\sigma(n), \qquad\text{i.e.}\qquad \frac{\sigma(n)}{n} - \frac{\sigma(d)}{d} \;\ge\; \frac1n > 0. $$

**Mechanism (elementary):** writing `n = d·t` with `t ≥ 2`, the divisors of `n` contain the whole scaled image `{t·e : e ∣ d}` (summing to `t·σ(d)`) but *also* the divisor `1`, which is never of the form `t·e` when `t ≥ 2` (every `t·e ≥ t ≥ 2`). That one omitted divisor forces `σ(d·t) ≥ t·σ(d) + 1`; multiplying by `d` gives the `+d` gap.

## Theorems (4, 0 sorries, 0 axioms)

- `scaled_sigma_lt : 0 < d → 2 ≤ t → t·σ(d) + 1 ≤ σ(d·t)` — strict refinement of the parent's `scaled_sigma_le` via `Finset.sum_lt_sum_of_subset` with the omitted witness `1`.
- `sigma_dvd_strict_mono : d ∣ n → d < n → n·σ(d) + d ≤ d·σ(n)` — the strict, lower-bounded monotonicity (answers parent OQ index 0).
- `abundancy_gap_ge : d ∣ n → d < n → σ(d)/d + 1/n ≤ σ(n)/n` — the rational corollary over ℚ.
- `deficient_of_proper_dvd_perfect'` — re-derives the parent's perfect-boundary deficiency *directly* from the strict gap, bypassing its trichotomy argument.

## Verification

- `lake env lean` (Lean v4.26.0 / Mathlib): compiles clean.
- `#print axioms` on all four theorems: only `propext, Classical.choice, Quot.sound` — no `native_decide`, no `sorryAx`. **0-axiom, verified.**

Gallery entry: `src/data/proofs/abundant-number-oq-04-oq-01/meta.json` (badge `original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)