### PR TITLE
Enrich Explicit √(−1) from Wilson's theorem (wilsons-theorem-oq-07)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-07/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-07/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "wilson07-overview",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 3, "endLine": 29 },
+    "type": "concept",
+    "title": "From Wilson's theorem to an explicit √(−1)",
+    "content": "Wilson's theorem gives `(p−1)! ≡ −1 (mod p)` but is purely existential about square roots of −1. The docstring frames the constructive refinement: pair each residue k with its reflection p−k ≡ −k, splitting the factorial at the midpoint m = (p−1)/2 into `(p−1)! ≡ (−1)^m·(m!)²`. The parity of m then decides everything — for p ≡ 1 (mod 4), m is even and `m! = ((p−1)/2)!` is an *explicit* square root of −1, the witness Mathlib's `ZMod.exists_sq_eq_neg_one_iff` only asserts to exist.",
+    "mathContext": "$(p-1)! \\equiv (-1)^m (m!)^2 \\pmod p,\\quad m = \\tfrac{p-1}{2}$",
+    "significance": "key",
+    "relatedConcepts": ["Wilson's theorem", "quadratic residue", "square root of −1", "reflection pairing", "constructive witness"],
+    "prerequisites": ["modular arithmetic", "ZMod p", "factorials"]
+  },
+  {
+    "id": "wilson07-reflection",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 39, "endLine": 81 },
+    "type": "theorem",
+    "title": "The reflection identity (p−1)! ≡ (−1)^m (m!)²",
+    "content": "`neg_one_pow_mul_factorial_sq` is the core. Setting m = (p−1)/2 and p = 2m+1, the lower-half product ∏_{i=1}^{m} i equals m! (`Finset.prod_Ico_id_eq_factorial`). The upper half {m+1,…,p−1} is reindexed by reflection j ↦ p−j (`Finset.prod_Ico_reflect`), and each factor `↑(p−j) = −↑j` (`Nat.cast_sub` + `ZMod.natCast_self`), so `Finset.prod_neg` turns it into (−1)^m·m!. Concatenating the halves (`Finset.prod_Ico_consecutive`) and applying Wilson (`ZMod.prod_Ico_one_prime` = −1) gives m!·((−1)^m·m!) = −1, rearranged to the claim. This is the sign-controlled identity that makes the parity of m the deciding factor.",
+    "mathContext": "$\\prod_{i=1}^{p-1} i = \\Bigl(\\prod_{i=1}^{m} i\\Bigr)\\Bigl(\\prod_{i=m+1}^{p-1} i\\Bigr) = m!\\cdot(-1)^m m! = -1$",
+    "significance": "critical",
+    "relatedConcepts": ["Finset.prod_Ico_reflect", "prod_neg", "prod_Ico_consecutive", "Wilson product", "midpoint splitting"],
+    "prerequisites": ["finite products over Ico", "Nat.cast_sub", "Wilson's theorem in Mathlib"]
+  },
+  {
+    "id": "wilson07-root",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 83, "endLine": 91 },
+    "type": "theorem",
+    "title": "The explicit square root for p ≡ 1 (mod 4)",
+    "content": "`factorial_half_sq_eq_neg_one`: when p ≡ 1 (mod 4), m = (p−1)/2 is even, so `(−1)^m = 1` (`Even.neg_one_pow`) collapses the reflection identity to `(((p−1)/2)!)² = −1`. The factorial ((p−1)/2)! is therefore a concrete, computable square root of −1 modulo p — the headline result.",
+    "mathContext": "$p \\equiv 1 \\pmod 4 \\Rightarrow \\Bigl(\\tfrac{p-1}{2}!\\Bigr)^2 \\equiv -1 \\pmod p$",
+    "significance": "key",
+    "relatedConcepts": ["square root of −1", "Even.neg_one_pow", "p ≡ 1 mod 4", "Gaussian integers"],
+    "prerequisites": ["the reflection identity", "parity of (p−1)/2"]
+  },
+  {
+    "id": "wilson07-companion",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 93, "endLine": 101 },
+    "type": "theorem",
+    "title": "Companion case p ≡ 3 (mod 4)",
+    "content": "`factorial_half_sq_eq_one`: when p ≡ 3 (mod 4), m is odd, so `(−1)^m = −1` and the identity gives `(((p−1)/2)!)² = +1` — hence ((p−1)/2)! ≡ ±1 and is never a root of −1. This is the sharp dichotomy: the same factorial is √(−1) exactly in the p ≡ 1 (mod 4) case, consistent with −1 being a quadratic residue iff p % 4 ≠ 3.",
+    "mathContext": "$p \\equiv 3 \\pmod 4 \\Rightarrow \\Bigl(\\tfrac{p-1}{2}!\\Bigr)^2 \\equiv +1 \\pmod p$",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic non-residue", "Odd.neg_one_pow", "p ≡ 3 mod 4", "dichotomy"],
+    "prerequisites": ["the reflection identity", "parity of (p−1)/2"]
+  },
+  {
+    "id": "wilson07-constructive",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 103, "endLine": 112 },
+    "type": "theorem",
+    "title": "Constructive recovery of Mathlib's existential",
+    "content": "`exists_sq_eq_neg_one_of_one_mod_four` packages the witness: it proves `∃ y, y² = −1` for p ≡ 1 (mod 4) by exhibiting `((p−1)/2)!`, recovering the forward direction of Mathlib's existential `ZMod.exists_sq_eq_neg_one_iff` *constructively*. The following `example` checks the consistency that p % 4 = 1 ⇒ p % 4 ≠ 3, matching Mathlib's criterion.",
+    "mathContext": "$\\exists y \\in \\mathbb{Z}/p,\\ y^2 = -1,\\quad y = \\tfrac{p-1}{2}!$",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod.exists_sq_eq_neg_one_iff", "constructive vs existential", "explicit witness"],
+    "prerequisites": ["the explicit root above", "existential introduction"]
+  },
+  {
+    "id": "wilson07-numeric",
+    "proofId": "wilsons-theorem-oq-07",
+    "range": { "startLine": 114, "endLine": 121 },
+    "type": "tactic",
+    "title": "Kernel-checked numeric instances",
+    "content": "Three `decide` examples confirm the theorems concretely: p = 5 gives 2! = 2, 2² = 4 ≡ −1; p = 13 gives 6! ≡ 5, 5² = 25 ≡ −1; and p = 7 ≡ 3 (mod 4) gives 3! = 6 ≡ −1, (−1)² = 1. These use `decide` (kernel reduction on small numerals), not `native_decide`, so they introduce no `Lean.ofReduceBool` and the entry remains axiom-free.",
+    "mathContext": "$2!^2 \\equiv -1\\ (5),\\quad 6!^2 \\equiv -1\\ (13),\\quad 3!^2 \\equiv 1\\ (7)$",
+    "significance": "supporting",
+    "relatedConcepts": ["decide tactic", "kernel reduction", "worked examples", "axiom-free verification"],
+    "prerequisites": ["decidable equality in ZMod p"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-07` (An Explicit Square Root of −1 Modulo p ≡ 1 (mod 4) from Wilson's Theorem). Rich meta.json; gap was the annotation layer.

## Quality improvements (quality 41 → ~96)
- **annotations.json (new, 6 annotations, resolver-aligned 6/6)** — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the Wilson→√(−1) overview, the reflection identity `(p−1)! ≡ (−1)^m (m!)²` (`neg_one_pow_mul_factorial_sq`, the core), the explicit root for p ≡ 1 (mod 4), the p ≡ 3 (mod 4) companion case, the constructive recovery of `ZMod.exists_sq_eq_neg_one_iff`, and the kernel-`decide` numeric instances (noted as not `native_decide`, so axiom-free).

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 6, Misaligned: 0.
- `pnpm build` passes (tsc + vite).
- Axiom integrity preserved: verified / original / axiomCount 0 (uses `decide`, not `native_decide`; no Lean.ofReduceBool).