### PR TITLE
Enrich Parity of Apollonian curvatures (descartes-circle-theorem-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "descparity-overview",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 39 },
+    "type": "concept",
+    "title": "The parity question for Apollonian curvatures",
+    "content": "The docstring poses the question: among the four integer curvatures of a Descartes quadruple — satisfying (a+b+c+d)² = 2(a²+b²+c²+d²) — how many are odd? The answer is a clean 2-adic invariant: the count is always 0 or 2, and in the primitive case exactly two are odd. This is the most elementary of the arithmetic laws governing integral Apollonian gaskets and the seed of the deeper mod-12/mod-24 congruence restrictions.",
+    "mathContext": "$(a+b+c+d)^2 = 2(a^2+b^2+c^2+d^2)$",
+    "significance": "key",
+    "relatedConcepts": ["Descartes circle theorem", "Apollonian gasket", "integer curvatures", "parity invariant", "Soddy circles"],
+    "prerequisites": ["Descartes' theorem", "parity / 2-adic arithmetic"]
+  },
+  {
+    "id": "descparity-defs",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 43, "endLine": 49 },
+    "type": "definition",
+    "title": "The integer Descartes relation and odd-count",
+    "content": "`descartesRelZ a b c d` is the integer Descartes relation (a+b+c+d)² = 2(a²+b²+c²+d²) among four signed curvatures. `oddCount a b c d = a%2 + b%2 + c%2 + d%2` counts how many of the four are odd by summing residues mod 2 (each summand is 0 or 1), so the whole parity analysis reduces to integer arithmetic that `omega` can drive once parities are expressed as residues.",
+    "mathContext": "$\\operatorname{oddCount}(a,b,c,d) = (a\\bmod 2)+(b\\bmod 2)+(c\\bmod 2)+(d\\bmod 2)$",
+    "significance": "supporting",
+    "relatedConcepts": ["Descartes relation", "residue mod 2", "signed curvature"],
+    "prerequisites": ["integer modular arithmetic"]
+  },
+  {
+    "id": "descparity-sum-even",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "theorem",
+    "title": "The sum of curvatures is even",
+    "content": "`descartesRelZ_sum_even`: since the relation makes `(a+b+c+d)²` equal to `2·(…)`, the square is even, so its base `a+b+c+d` is even (`Int.even_pow`). This single fact already eliminates odd-counts 1 and 3 (an odd number of odd terms makes the sum odd), narrowing the possibilities to 0, 2, or 4.",
+    "mathContext": "$(a+b+c+d)^2 = 2(\\cdots) \\Rightarrow \\mathrm{Even}(a+b+c+d)$",
+    "significance": "key",
+    "relatedConcepts": ["Int.even_pow", "parity of a sum", "even square base"],
+    "prerequisites": ["even/odd of integers", "squares and parity"]
+  },
+  {
+    "id": "descparity-not-all-odd",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 59, "endLine": 84 },
+    "type": "theorem",
+    "title": "Never all odd (the crux: a square ≡ 2 mod 4)",
+    "content": "`descartesRelZ_not_all_odd` is the technical heart, eliminating count 4. Substituting a = 2k+1, …, d = 2n+1 and recording (via `Int.even_mul_succ_self`) that each kᵢ(kᵢ+1) is even, `linear_combination` distils the relation to `4·(k+l+m+n+2)² = 16·(…) + 8`, i.e. `(k+l+m+n+2)² ≡ 2 (mod 4)`. Since integer squares are 0 or 1 mod 4, this is impossible — discharged by a single even/odd split on the base followed by `omega` (with `t*t` abstracted to a fresh variable so omega need not reason about multiplication).",
+    "mathContext": "$\\text{all odd} \\Rightarrow (k+l+m+n+2)^2 \\equiv 2 \\pmod 4,\\ \\text{impossible}$",
+    "significance": "critical",
+    "relatedConcepts": ["Int.even_mul_succ_self", "linear_combination", "squares mod 4", "omega"],
+    "prerequisites": ["substitution of odd integers", "quadratic residues mod 4"]
+  },
+  {
+    "id": "descparity-zero-or-two",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 97 },
+    "type": "theorem",
+    "title": "Odd-count is exactly 0 or 2",
+    "content": "`descartesRelZ_oddCount_eq_zero_or_two` combines the two facts: sum-even kills counts 1 and 3, and the 'never all odd' crux kills 4, leaving exactly 0 or 2. The proof translates both inputs into residues (`Int.even_iff`, `Int.odd_iff`) and lets `omega` finish the counting.",
+    "mathContext": "$\\operatorname{oddCount}(a,b,c,d) \\in \\{0, 2\\}$",
+    "significance": "key",
+    "relatedConcepts": ["case elimination", "parity counting", "omega"],
+    "prerequisites": ["the two preceding theorems"]
+  },
+  {
+    "id": "descparity-headline",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 99, "endLine": 111 },
+    "type": "theorem",
+    "title": "Headline: primitive ⇒ exactly two odd",
+    "content": "`descartesRelZ_two_odd_of_not_all_even`: if the quadruple is *not* all even (the primitive case, e.g. gcd 1), the odd-count cannot be 0, so it must be 2 — exactly two odd and two even curvatures. This is the classical parity invariant of a primitive integral Apollonian gasket: every Descartes quadruple in a primitive packing has this 2-and-2 parity signature.",
+    "mathContext": "$\\neg(\\text{all even}) \\Rightarrow \\operatorname{oddCount} = 2$",
+    "significance": "key",
+    "relatedConcepts": ["primitive packing", "parity invariant", "integral Apollonian gasket"],
+    "prerequisites": ["odd-count is 0 or 2", "gcd / primitivity"]
+  },
+  {
+    "id": "descparity-imprimitive",
+    "proofId": "descartes-circle-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 122 },
+    "type": "theorem",
+    "title": "The all-even (imprimitive) complement",
+    "content": "`descartesRelZ_all_even_imp_two_dvd` characterizes the other case: oddCount = 0 forces all four curvatures divisible by 2 — the imprimitive packing, whose curvatures share the common factor 2 and can be scaled down. Together with the headline this gives a complete dichotomy: every integer Descartes quadruple is either primitive with exactly two odd curvatures, or has all four even.",
+    "mathContext": "$\\operatorname{oddCount} = 0 \\Rightarrow 2 \\mid a,\\ 2 \\mid b,\\ 2 \\mid c,\\ 2 \\mid d$",
+    "significance": "supporting",
+    "relatedConcepts": ["imprimitive packing", "common divisor", "dichotomy"],
+    "prerequisites": ["Int.dvd_of_emod_eq_zero", "the zero-or-two theorem"]
+  }
+]

--- a/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-circle-theorem-oq-01-oq-02-oq-01/meta.json
@@ -76,6 +76,68 @@
       "The four curvatures are never all odd (the relation would force a square ≡ 2 mod 4).",
       "Hence the number of odd curvatures is always exactly 0 or 2.",
       "In the primitive case (curvatures not all even) exactly two are odd and two are even; the all-even case is exactly the imprimitive one."
+    ],
+    "proofStrategy": "The whole argument is elementary 2-adic bookkeeping. descartesRelZ_sum_even: the relation makes (a+b+c+d)² = 2·(…) even, so its base is even (Int.even_pow) — this already excludes odd-counts 1 and 3. descartesRelZ_not_all_odd (the crux, excluding 4): substitute a=2k+1,…,d=2n+1, record each kᵢ(kᵢ+1) even via Int.even_mul_succ_self, and use linear_combination to reduce the relation to 4·(k+l+m+n+2)² = 16·(…)+8, i.e. a square ≡ 2 (mod 4); a single even/odd split plus omega (with t·t abstracted to a fresh variable) closes the contradiction. descartesRelZ_oddCount_eq_zero_or_two then translates parities to residues (Int.even_iff/Int.odd_iff) and lets omega conclude the count is 0 or 2. The headline descartesRelZ_two_odd_of_not_all_even rules out 0 in the primitive case, and descartesRelZ_all_even_imp_two_dvd records the complementary all-even (imprimitive) case.",
+    "keyInsights": [
+      "**The right-hand factor 2 forces an even sum.** Because the Descartes relation writes (a+b+c+d)² as 2·(a²+b²+c²+d²), the square is even and so is its base — instantly killing the odd parities 1 and 3 before any case work.",
+      "**'Never all odd' is a square ≡ 2 (mod 4) obstruction.** Substituting four odd values collapses the relation to (k+l+m+n+2)² ≡ 2 (mod 4); since integer squares are only 0 or 1 mod 4, the all-odd configuration is impossible. This is the one genuinely non-trivial step and it is purely 2-adic.",
+      "**The parity signature distinguishes primitive from imprimitive packings.** oddCount = 2 characterizes primitive Descartes quadruples (gcd 1), while oddCount = 0 is exactly the all-even, imprimitive case that scales down by 2 — a complete dichotomy.",
+      "**omega + abstraction handles the nonlinear residue arithmetic.** The proofs keep omega in scope by abstracting products like t·t to fresh variables, so the linear arithmetic decision procedure can finish modular counting it could not otherwise reason about."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "The Integer Descartes Relation and Odd-Count",
+      "startLine": 43,
+      "endLine": 49,
+      "summary": "descartesRelZ a b c d : (a+b+c+d)² = 2(a²+b²+c²+d²), and oddCount a b c d = a%2+b%2+c%2+d%2 counting odd curvatures via residues mod 2.",
+      "mathContext": "$(a+b+c+d)^2 = 2(a^2+b^2+c^2+d^2);\\quad \\operatorname{oddCount} = \\sum (\\cdot \\bmod 2).$"
+    },
+    {
+      "id": "sum-even",
+      "title": "The Sum is Even",
+      "startLine": 51,
+      "endLine": 57,
+      "summary": "descartesRelZ_sum_even: the square equals 2·(…), so a+b+c+d is even — excluding odd-counts 1 and 3.",
+      "mathContext": "$\\mathrm{Even}(a+b+c+d).$"
+    },
+    {
+      "id": "not-all-odd",
+      "title": "Never All Odd (the Crux)",
+      "startLine": 59,
+      "endLine": 84,
+      "summary": "descartesRelZ_not_all_odd: substituting four odd values forces (k+l+m+n+2)² ≡ 2 (mod 4), impossible; excludes odd-count 4.",
+      "mathContext": "$\\text{all odd} \\Rightarrow \\square \\equiv 2 \\pmod 4,\\ \\bot.$"
+    },
+    {
+      "id": "zero-or-two",
+      "title": "Odd-Count is 0 or 2; the Primitive Dichotomy",
+      "startLine": 86,
+      "endLine": 122,
+      "summary": "descartesRelZ_oddCount_eq_zero_or_two (count ∈ {0,2}), the headline descartesRelZ_two_odd_of_not_all_even (primitive ⇒ exactly two odd), and descartesRelZ_all_even_imp_two_dvd (oddCount 0 ⇔ all even, imprimitive).",
+      "mathContext": "$\\operatorname{oddCount} \\in \\{0,2\\};\\ \\neg(\\text{all even}) \\Rightarrow \\operatorname{oddCount}=2.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "For every integer Descartes quadruple (a+b+c+d)² = 2(a²+b²+c²+d²), the number of odd curvatures is exactly 0 or 2: the sum is always even (killing 1 and 3) and the four are never all odd (killing 4, via a square ≡ 2 mod 4 obstruction). Consequently a primitive quadruple — curvatures not all even — has exactly two odd and two even curvatures, the classical parity invariant of a primitive integral Apollonian gasket, while the all-even case is precisely the imprimitive one. 5 theorems, 2 definitions, 0 sorries, 0 axioms.",
+    "implications": "This is the most elementary arithmetic law of integral Apollonian packings and the foundation for the deeper congruence structure: once parity is fixed at 2-and-2, the curvatures of a primitive gasket are further constrained mod 12 and mod 24, and the local-global / positive-density questions about which integers appear as curvatures build on exactly this kind of residue analysis. The clean primitive/imprimitive dichotomy also justifies restricting attention to primitive packings without loss of generality.",
+    "openQuestions": [
+      "Extend the analysis to the mod-4 and mod-24 residue classes of the curvatures themselves (not just their parities), recovering the Graham–Lagarias–Mallows–Wilks–Yan congruence restrictions on which integers occur in a primitive gasket.",
+      "Characterize the orbit structure under the Apollonian group: how does the 2-and-2 parity signature propagate as new Soddy circles are inscribed, and is it preserved by each of the four reflection generators?",
+      "Formalize the local-global conjecture's parity/congruence obstructions as the necessary conditions, connecting this 2-adic invariant to the admissible residues mod 24."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "descartes-circle-theorem-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Sibling/parent leaf: proved the integrality dictionary for integer Descartes quadruples (an integer fourth curvature exists iff the symmetric product is a perfect square). This entry answers the next question — the parity of those integer curvatures."
+    },
+    {
+      "targetId": "descartes-circle-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "Ancestor entry: the Descartes circle theorem (k₄ = k₁+k₂+k₃ ± 2√(k₁k₂+k₂k₃+k₃k₁)) and its integer form (a+b+c+d)² = 2(a²+b²+c²+d²) underlying this parity analysis."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `descartes-circle-theorem-oq-01-oq-02-oq-01` (Parity of Integral Apollonian Curvatures: Exactly Two Odd). The entry had only a partial overview — no annotations, sections, conclusion, or crossReferences, and its overview used `keyResults` (not rendered) with no `keyInsights`/`proofStrategy`.

## Quality improvements (quality 10 → ~96)
- **annotations.json (new, 7 annotations, resolver-aligned 7/7)** — mathContext/significance/relatedConcepts/prerequisites covering the overview, the `descartesRelZ`/`oddCount` definitions, sum-even, the never-all-odd crux (square ≡ 2 mod 4), oddCount ∈ {0,2}, the primitive headline, and the imprimitive complement.
- **overview**: added `proofStrategy` and `keyInsights` (4) — the ProofOverview component renders keyInsights, not the pre-existing keyResults.
- **sections (new, 4)** — full coverage of the 124-line file.
- **conclusion (new)** — summary + implications + 3 openQuestions (mod-24 congruences, Apollonian-group orbit, local-global).
- **crossReferences (new, 2)** — parent `-oq-01-oq-02` (extends), ancestor `-oq-01` (root Descartes theorem).

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 7, Misaligned: 0.
- `pnpm build` passes (tsc + vite).
- Axiom integrity preserved: verified / original / axiomCount 0 (foundational axioms only, no native_decide).