### PR TITLE
audit: mark 24 freshly-shipped research entries clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22373,6 +22373,150 @@
       "lastAudited": "2026-06-24T21:43:00Z",
       "result": "clean",
       "issues": []
+    },
+    "cayleys-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-circle-theorem-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dyck-catalan-count-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-191-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-606-oq-03-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-divisibility-pigeonhole-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-criterion-squares-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-endomorphism-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lifting-the-exponent-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "little-wedderburn-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lucas-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "maschke-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mason-stothers-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pentagonal-number-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-06-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "second-isomorphism-theorem-modules-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-source-coding-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-second-kind-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:05:02Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T22:10:00Z",
+      "result": "clean"
+    },
+    "erdos-ginzburg-ziv-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T22:10:00Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited all 24 previously-unaudited gallery entries (research outputs shipped 2026-06-24). Result: **all clean**.

### Mechanical checks (sorry / axiom / native_decide)
Every entry: 0 real sorries, 0 axioms, 0 `native_decide`. Every grep hit for these tokens was docstring prose asserting their *absence* (e.g. "0 sorry, no native_decide") — no actual violations.

### Narrative / badge / status review
- **Badges honest**: `original` where proved from scratch; `mathlib` where the core result is a Mathlib theorem (`frobenius-endomorphism`, `lifting-the-exponent`, `mason-stothers`, and `erdos-606`'s de Bruijn–Erdős lower bound — correctly attributed, original upper bound flagged separately).
- **Famous-theorem slugs honestly scoped**:
  - `erdos-ginzburg-ziv-oq-01-oq-01` proves the Davenport constant D(ℤ/nℤ)=n as a full `IsLeast` (both bounds), explicitly *not* claiming the EGZ constant s(G)=2n−1.
  - `erdos-191-incomplete-01` discharges 1 of 4 axioms and states the other 3 remain — no overclaim of solving Erdős 191.
  - `cayley-hamilton-oq-04-oq-01` is the explicit 3×3 identity proved entrywise from scratch, documented as *not* a Mathlib charpoly re-export.

No integrity issues found. Updates `audit-tracker.json` to record the 24 clean audits.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)