### PR TITLE
Enrich Apéry set of ⟨a,b⟩ (frobenius-number-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/frobenius-number-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "frobapery-overview",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "The Apéry set of a two-generator numerical semigroup",
+    "content": "The docstring introduces the central computational device of numerical-semigroup theory. For coprime a, b the semigroup S = ⟨a,b⟩ has Apéry set Ap(S,a) = {0, b, 2b, …, (a−1)b}: the least element of S in each residue class mod a. Because gcd(a,b)=1, the values w_k = k·b for k < a hit all a residue classes exactly once. The file proves the Apéry characterization (membership = one comparison), the reflection symmetry k ↦ a−1−k, and re-derives the Frobenius number's non-representability from Apéry minimality.",
+    "mathContext": "$\\operatorname{Ap}(S,a) = \\{0, b, 2b, \\dots, (a-1)b\\},\\quad w_k = k\\cdot b$",
+    "significance": "key",
+    "relatedConcepts": ["Apéry set", "numerical semigroup", "Frobenius number", "residue classes", "Selmer genus formula"],
+    "prerequisites": ["numerical semigroups", "modular arithmetic", "coprimality"]
+  },
+  {
+    "id": "frobapery-index",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 56, "endLine": 74 },
+    "type": "theorem",
+    "title": "Every residue class has an Apéry index",
+    "content": "`aperyIndex_inj` shows k ↦ k·b mod a is injective on `Fin a` — coprimality lets `Nat.ModEq.cancel_right_of_coprime` cancel b. On the finite type `Fin a`, injective ⟹ surjective (`Finite.injective_iff_surjective`), so `exists_aperyIndex` concludes every n is congruent mod a to a unique k·b with k < a. This pigeonhole packaging is what makes the Apéry set well-defined: exactly one representative per class.",
+    "mathContext": "$\\forall n,\\ \\exists!\\, k < a,\\ n \\equiv k\\cdot b \\pmod a$",
+    "significance": "key",
+    "relatedConcepts": ["injective ⟹ surjective on finite types", "ModEq cancellation", "pigeonhole", "Fin a"],
+    "prerequisites": ["Nat.ModEq.cancel_right_of_coprime", "Finite.injective_iff_surjective"]
+  },
+  {
+    "id": "frobapery-minimality",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 78, "endLine": 113 },
+    "type": "theorem",
+    "title": "Apéry minimality: w_k is least in its class",
+    "content": "Two complementary results. `representable_of_aperyIndex`: if n ≡ k·b (mod a) and k·b ≤ n, then n is representable (write n = a·q + b·k from `Nat.modEq_iff_dvd'`). `aperyIndex_le_of_representable` is the converse and the crux: a representable n = a·x + b·y in the class of k·b satisfies k·b ≤ n. The engine is coprime cancellation — n ≡ b·y forces b·y ≡ b·k, cancel b to get y ≡ k (mod a), and since k < a is the minimal residue, k ≤ y, hence k·b ≤ b·y ≤ n. So w_k = k·b really is the smallest element of ⟨a,b⟩ in its class.",
+    "mathContext": "$n \\equiv k b \\pmod a,\\ k<a,\\ \\text{representable} \\Rightarrow k b \\le n$",
+    "significance": "critical",
+    "relatedConcepts": ["Apéry minimality", "coprime cancellation", "minimal residue representative", "Nat.modEq_iff_dvd'"],
+    "prerequisites": ["Nat.ModEq.cancel_left_of_coprime", "Representable predicate"]
+  },
+  {
+    "id": "frobapery-characterization",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 115, "endLine": 120 },
+    "type": "theorem",
+    "title": "Apéry characterization (one comparison)",
+    "content": "`apery_le_iff_representable` packages both directions: inside the residue class of k·b (k < a), a number is representable iff it is ≥ the Apéry element k·b. Membership in the numerical semigroup is thus decided by a single comparison against the class's Apéry element — the practical payoff of the Apéry set.",
+    "mathContext": "$n \\equiv k b \\pmod a \\ (k<a) \\;\\Rightarrow\\; (k b \\le n \\iff \\mathrm{Representable}\\ n)$",
+    "significance": "key",
+    "relatedConcepts": ["membership test", "Apéry characterization", "biconditional"],
+    "prerequisites": ["the two minimality directions above"]
+  },
+  {
+    "id": "frobapery-reflection",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 124, "endLine": 142 },
+    "type": "theorem",
+    "title": "Reflection symmetry and the maximal Apéry element",
+    "content": "`apery_symm`: the involution k ↦ a−1−k reflects the Apéry set, with w_k + w_{a−1−k} = (a−1)·b — pairing each element with its mirror about the maximum. `apery_max`: that maximum is `(a−1)·b = g + a`, where g = ab − a − b is the Frobenius number. This reflection is the Apéry-set origin of the classical Frobenius involution n ↦ g − n on the gaps of the semigroup.",
+    "mathContext": "$w_k + w_{a-1-k} = (a-1)b = g + a$",
+    "significance": "key",
+    "relatedConcepts": ["Frobenius involution", "symmetric numerical semigroup", "reflection", "maximal Apéry element"],
+    "prerequisites": ["the Apéry set", "frobeniusNumber = ab − a − b"]
+  },
+  {
+    "id": "frobapery-global",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 150, "endLine": 160 },
+    "type": "theorem",
+    "title": "Global characterization of membership",
+    "content": "`representable_iff_aperyIndex` combines index existence with the per-class characterization: n ∈ ⟨a,b⟩ iff there is k < a with n ≡ k·b (mod a) and k·b ≤ n — i.e. n dominates the Apéry element of its own residue class. This is a complete, computable description of the semigroup purely in terms of the Apéry set.",
+    "mathContext": "$\\mathrm{Representable}\\ n \\iff \\exists k<a,\\ n \\equiv k b \\pmod a \\wedge k b \\le n$",
+    "significance": "supporting",
+    "relatedConcepts": ["global characterization", "Apéry set membership", "computable semigroup"],
+    "prerequisites": ["exists_aperyIndex", "apery_le_iff_representable"]
+  },
+  {
+    "id": "frobapery-gap",
+    "proofId": "frobenius-number-oq-01-oq-04",
+    "range": { "startLine": 162, "endLine": 184 },
+    "type": "theorem",
+    "title": "Frobenius number is a gap, via Apéry minimality",
+    "content": "`frobeniusNumber_mod` places g in the residue class of the maximal Apéry element (a−1)·b (since (a−1)·b − g = a). `frobeniusNumber_not_representable` then concludes g ∉ S: if g were representable, Apéry minimality would force (a−1)·b ≤ g, contradicting (a−1)·b = g + a > g. This is an Apéry-set re-derivation of Sylvester's non-representability of the Frobenius number — the largest gap sits exactly one step a below the smallest semigroup element of its class.",
+    "mathContext": "$g \\equiv (a-1)b \\pmod a,\\ g < (a-1)b = \\min_S\\text{-in-class} \\Rightarrow g \\notin S$",
+    "significance": "key",
+    "relatedConcepts": ["Sylvester non-representability", "Frobenius number", "Apéry minimality", "largest gap"],
+    "prerequisites": ["apery_max", "aperyIndex_le_of_representable"]
+  }
+]

--- a/src/data/proofs/frobenius-number-oq-01-oq-04/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01-oq-04/meta.json
@@ -75,6 +75,69 @@
     "dateAdded": "2026-06-24",
     "mathlib_version": "4.26.0"
   },
+  "overview": {
+    "historicalContext": "The Apéry set, introduced by Roger Apéry in 1946 and developed by Ernst Selmer in 1977, is the central computational object of numerical-semigroup theory. For a numerical semigroup S and a nonzero element a ∈ S, Ap(S, a) collects the least element of S in each residue class mod a; from it one reads off the Frobenius number, the genus (number of gaps), and the symmetric/Gorenstein property. For the two-generator semigroup ⟨a,b⟩ with gcd(a,b)=1 the Apéry set is completely explicit — {0, b, 2b, …, (a−1)b} — making it the ideal first formalization. The parent gallery entries proved Sylvester's Frobenius number g = ab − a − b and the gap count (a−1)(b−1)/2 directly via the Representable predicate, never naming the Apéry set; this entry supplies it.",
+    "problemStatement": "For coprime a, b ≥ 2, construct the Apéry set of ⟨a,b⟩ with respect to a and prove: (i) the Apéry characterization — w_k = k·b is the least element of ⟨a,b⟩ in its residue class mod a, so membership reduces to one comparison; (ii) reflection symmetry — k ↦ a−1−k fixes the Apéry set with w_k + w_{a−1−k} = (a−1)b = g + a; (iii) the Frobenius number's non-representability, re-derived from Apéry minimality. This answers the 'via Apéry sets' direction of the parent open question for the two-generator case.",
+    "proofStrategy": "Index existence: k ↦ k·b mod a is injective on Fin a by coprime cancellation (Nat.ModEq.cancel_right_of_coprime); injective ⟹ surjective on a finite type (Finite.injective_iff_surjective) gives, for every n, a unique k < a with n ≡ k·b (mod a). Apéry minimality (aperyIndex_le_of_representable): a representable n = a·x + b·y in the class of k·b satisfies n ≡ b·y, so b·y ≡ b·k, cancel b to get y ≡ k (mod a), and k < a minimal forces k ≤ y, hence k·b ≤ n. The converse representable_of_aperyIndex writes n = a·q + b·k from Nat.modEq_iff_dvd'. Reflection: apery_symm is the algebraic identity k·b + (a−1−k)·b = (a−1)·b; apery_max identifies (a−1)·b = g + a by omega from frobeniusNumber. The Frobenius gap: g lies in the class of (a−1)·b (difference exactly a), and minimality of (a−1)·b in that class rules out g ∈ S.",
+    "keyInsights": [
+      "**The Apéry set turns membership into a single comparison.** Once the least representative w_k = k·b of each residue class mod a is known, n ∈ ⟨a,b⟩ iff n ≡ k·b (mod a) and n ≥ k·b — replacing the existential Representable predicate by one inequality.",
+      "**Coprime cancellation is the whole engine.** Every minimality argument reduces b·y ≡ b·k (mod a) to y ≡ k (mod a); gcd(a,b)=1 is exactly what licenses cancelling b, and it is also why the a multiples 0, b, …, (a−1)b hit all residue classes.",
+      "**Reflection symmetry encodes the Frobenius involution.** The pairing w_k + w_{a−1−k} = (a−1)b = g + a on the Apéry set is the source of the gap involution n ↦ g − n; symmetric (Gorenstein) numerical semigroups are precisely those whose Apéry set is symmetric under this reflection.",
+      "**Non-representability of g is Apéry minimality, not a separate miracle.** The Frobenius number sits one step a below the maximal Apéry element (a−1)·b of its class; since that element is the least element of S in the class, g cannot be in S — recovering Sylvester's result structurally."
+    ],
+    "prerequisites": [
+      "Numerical semigroups and the Representable predicate (parent frobenius-number)",
+      "The Apéry set / least residue-class representatives (Apéry 1946, Selmer 1977)",
+      "Modular arithmetic with coprime cancellation (Nat.ModEq)",
+      "Injective ⟹ surjective on finite types"
+    ]
+  },
+  "sections": [
+    {
+      "id": "apery-index",
+      "title": "The Apéry Index of a Residue Class",
+      "startLine": 50,
+      "endLine": 74,
+      "summary": "aperyIndex_inj (k ↦ k·b mod a injective on Fin a via coprime cancellation) and exists_aperyIndex (injective ⟹ surjective gives a unique k < a with n ≡ k·b mod a) — establishing the Apéry set is well-defined, one representative per class.",
+      "mathContext": "$\\forall n,\\ \\exists!\\, k<a,\\ n \\equiv k b \\pmod a.$"
+    },
+    {
+      "id": "apery-characterization",
+      "title": "Apéry Minimality and Characterization",
+      "startLine": 76,
+      "endLine": 120,
+      "summary": "representable_of_aperyIndex and aperyIndex_le_of_representable establish that w_k = k·b is the least element of ⟨a,b⟩ in its class (coprime cancellation y ≡ k mod a, k ≤ y), packaged as the biconditional apery_le_iff_representable.",
+      "mathContext": "$n \\equiv k b\\ (k<a) \\Rightarrow (k b \\le n \\iff \\mathrm{Representable}\\ n).$"
+    },
+    {
+      "id": "reflection",
+      "title": "Reflection Symmetry of the Apéry Set",
+      "startLine": 122,
+      "endLine": 142,
+      "summary": "apery_symm (the involution k ↦ a−1−k with w_k + w_{a−1−k} = (a−1)b) and apery_max ((a−1)b = g + a, the maximal Apéry element).",
+      "mathContext": "$w_k + w_{a-1-k} = (a-1)b = g + a.$"
+    },
+    {
+      "id": "frobenius-gap",
+      "title": "Global Characterization and the Frobenius Gap",
+      "startLine": 144,
+      "endLine": 186,
+      "summary": "representable_iff_aperyIndex (membership = dominating the Apéry element of n's class), frobeniusNumber_mod (g in the class of (a−1)b), and frobeniusNumber_not_representable (g ∉ S by Apéry minimality — Sylvester re-derived).",
+      "mathContext": "$g \\equiv (a-1)b \\pmod a,\\ g < (a-1)b \\Rightarrow g \\notin \\langle a,b\\rangle.$"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-01",
+      "relationship": "extends",
+      "description": "Parent: Sylvester's gap count (a−1)(b−1)/2 for ⟨a,b⟩, proved directly via the Representable predicate. This entry introduces the Apéry set as the standard machine behind that count and sets up Selmer's genus formula."
+    },
+    {
+      "targetId": "frobenius-number",
+      "relationship": "ancestor",
+      "description": "Root: Sylvester's Frobenius number g(a,b) = ab − a − b, whose non-representability is here re-derived from Apéry minimality and reflection symmetry."
+    }
+  ],
   "conclusion": {
     "summary": "The Apéry set Ap(⟨a,b⟩, a) = {0, b, …, (a−1)b} is the family of least residue-class representatives of the two-generator numerical semigroup: representability inside a class is one comparison against its Apéry element, the involution k ↦ a−1−k reflects the set about its maximum (a−1)b = g + a, and the Frobenius number's non-representability falls out of Apéry minimality. This packages the standard Apéry machinery for ⟨a,b⟩ and sets up Selmer's genus formula.",
     "implications": [


### PR DESCRIPTION
Enrichment pass for `frobenius-number-oq-01-oq-04` (The Apéry Set of ⟨a,b⟩: Minimal Representatives and Reflection Symmetry). The entry was missing its `overview` entirely, plus sections, crossReferences, and annotations.

## Quality improvements (quality 15 → ~96)
- **overview (new)** — historicalContext (Apéry 1946 / Selmer 1977), problemStatement, proofStrategy, 4 keyInsights, prerequisites.
- **annotations.json (new, 7 annotations, resolver-aligned 7/7)** — mathContext/significance/relatedConcepts/prerequisites covering the overview, Apéry index existence (injective⟹surjective), Apéry minimality (coprime cancellation, the crux), the one-comparison characterization, reflection symmetry / Frobenius involution, the global membership characterization, and the Frobenius number as a gap.
- **sections (new, 4)** — full coverage of the 186-line file.
- **crossReferences (new, 2)** — parent `frobenius-number-oq-01` (extends), root `frobenius-number` (ancestor).

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 7, Misaligned: 0.
- `pnpm build` passes (tsc + vite).
- Axiom integrity preserved: verified / original / axiomCount 0 (foundational axioms only, no native_decide).