### PR TITLE
research(kummer-theorem-oq-04-oq-01-oq-01): C(2n,n) divisible by 4 exactly ⟺ n = 2^a+2^b (popcount 2) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3253,6 +3253,7 @@ import Proofs.KummerTheoremOQ02
 import Proofs.KummerTheoremOQ02OQ03
 import Proofs.KummerTheoremOQ03
 import Proofs.KummerTheoremOQ04
+import Proofs.KummerTheoremOQ04OQ01OQ01
 import Proofs.KummerTheoremOQ04OQ02
 import Proofs.LHopital
 import Proofs.LHopitalOQ01

--- a/proofs/Proofs/KummerTheoremOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ04OQ01OQ01.lean
@@ -1,0 +1,241 @@
+import Mathlib
+
+/-
+# When is the Central Binomial Coefficient `C(2n, n)` Divisible by `4` Exactly?
+
+## The Open Question
+
+The parent result (`KummerTheoremOQ04OQ01`) characterises the *minimal* case of the
+2-adic valuation of the central binomial coefficient:
+
+$$\nu_2\binom{2n}{n} \;=\; s_2(n) \;=\; 1 \iff n = 2^k,$$
+
+where `s₂(n) = (Nat.digits 2 n).sum` is the binary digit sum (popcount) of `n`. Its
+first listed open question asks for the **next level set of popcount**:
+
+> Characterise the `n` with `v₂(C(2n,n)) = 2` (exactly two 1-bits): is there a clean
+> closed description of this level set of popcount?
+
+## Answer: exactly the sums of two distinct powers of two
+
+$$\nu_2\binom{2n}{n} = 2 \iff \exists\, a > b,\; n = 2^a + 2^b.$$
+
+### Why this is true
+
+By the parent valuation formula `v₂(C(2n,n)) = s₂(n)`, the statement reduces to the
+purely number-theoretic popcount characterisation
+
+$$s_2(n) = 2 \iff \exists\, a > b,\; n = 2^a + 2^b,$$
+
+i.e. `n` has exactly two `1`-bits, in positions `a > b`.
+
+* **Forward** (`s₂(n) = 2 ⟹ two distinct powers`): strong induction peeling the lowest
+  bit, `s₂(n) = (n % 2) + s₂(n / 2)`. If `n` is even the two bits live in `n/2`
+  (shift both up by one); if `n` is odd the lowest bit is one of the two, so
+  `s₂(n/2) = 1`, hence `n/2` is a *single* power of two — exactly the parent's
+  `popcount = 1` lemma reused as a black box, giving `n = 2^{k+1} + 2^0`.
+* **Converse**: factor `2^a + 2^b = 2^b·(2^{a-b}+1)` and use
+  `Nat.digits_base_pow_mul` to strip the `b` trailing zero bits, reducing to
+  `s₂(2^c + 1) = 2` for `c ≥ 1`, which is `1` (lowest bit) plus `s₂(2^{c-1}) = 1`.
+
+This is a genuinely new level-set description: the parent stops at `popcount = 1`, and
+Mathlib has no `popcount = 2` characterisation.
+
+## Results in this file (original content, 0 axioms / 0 sorries)
+
+* `sum_digits_two_two_pow_add_one` : `s₂(2^c + 1) = 2` for `c ≥ 1`
+* `sum_digits_two_eq_two_iff`      : `s₂(n) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`  ← core
+* `padicValNat_two_centralBinom_eq_two_iff`
+                                   : `v₂(C(2n,n)) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`
+* `four_exactDvd_centralBinom_of_two_bits`
+                                   : two distinct bits ⟹ `4 ∣ C(2n,n) ∧ ¬ 8 ∣ C(2n,n)`
+* worked numeric witnesses (`n = 3,5,6` give `v₂ = 2`; `n = 7` (popcount 3) does not).
+-/
+
+namespace KummerCentralBinomTwoBits
+
+open Nat
+
+/-- **Doubling-invariance of the binary digit sum.** `s₂(2n) = s₂(n)` (multiplying by
+the base prepends a `0` digit). -/
+theorem sum_digits_two_mul (n : ℕ) :
+    (Nat.digits 2 (2 * n)).sum = (Nat.digits 2 n).sum := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  · rw [Nat.digits_base_mul one_lt_two hn]; simp
+
+/-- For `n > 0` the binary digit sum is positive (the leading digit is nonzero). -/
+theorem sum_digits_two_pos {n : ℕ} (hn : 0 < n) : 0 < (Nat.digits 2 n).sum := by
+  have hnil : Nat.digits 2 n ≠ [] := Nat.digits_ne_nil_iff_ne_zero.mpr hn.ne'
+  exact Nat.sum_pos_iff_exists_pos.mpr
+    ⟨_, List.getLast_mem hnil, Nat.pos_of_ne_zero (Nat.getLast_digit_ne_zero 2 hn.ne')⟩
+
+/-- **Digit sum of a pure power of two is one.** `s₂(2^k) = 1`. -/
+theorem sum_digits_two_pow (k : ℕ) :
+    (Nat.digits 2 (2 ^ k)).sum = 1 := by
+  rw [show (2 : ℕ) ^ k = 2 ^ k * 1 by ring, Nat.digits_base_pow_mul one_lt_two one_pos]
+  simp
+
+/-- **`s₂(n) = 1 ⟹ n` is a power of two** (parent `popcount = 1` lemma, re-derived to
+keep this file self-contained). Strong induction peeling the lowest bit. -/
+theorem sum_digits_two_eq_one_imp (n : ℕ) :
+    (Nat.digits 2 n).sum = 1 → ∃ k, n = 2 ^ k := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    intro h
+    have hn : 0 < n := by
+      rcases Nat.eq_zero_or_pos n with rfl | hp
+      · simp at h
+      · exact hp
+    rw [Nat.digits_def' one_lt_two hn, List.sum_cons] at h
+    have hhalf : n / 2 < n := Nat.div_lt_self hn one_lt_two
+    rcases Nat.even_or_odd n with he | ho
+    · have h0 : n % 2 = 0 := Nat.even_iff.mp he
+      rw [h0, Nat.zero_add] at h
+      obtain ⟨j, hj⟩ := ih (n / 2) hhalf h
+      refine ⟨j + 1, ?_⟩
+      have he2 : n = 2 * (n / 2) := by omega
+      rw [he2, hj]; ring
+    · have h1 : n % 2 = 1 := Nat.odd_iff.mp ho
+      rw [h1] at h
+      have hz : (Nat.digits 2 (n / 2)).sum = 0 := by omega
+      have hz2 : n / 2 = 0 := by
+        by_contra hne
+        have := sum_digits_two_pos (Nat.pos_of_ne_zero hne)
+        omega
+      exact ⟨0, by rw [pow_zero]; omega⟩
+
+/-- **The 2-adic valuation of the central binomial coefficient is the binary digit
+sum** (parent headline, re-derived self-contained): `v₂(C(2n, n)) = s₂(n)`. -/
+theorem padicValNat_two_centralBinom (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = (Nat.digits 2 n).sum := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have h : n ≤ 2 * n := by omega
+  have key := sub_one_mul_padicValNat_choose_eq_sub_sum_digits (p := 2) (k := n) (n := 2 * n) h
+  have e1 : (2 : ℕ) * n - n = n := by omega
+  rw [e1, sum_digits_two_mul] at key
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  omega
+
+/-- **Digit sum of `2^c + 1` (for `c ≥ 1`) is two.** The lowest bit is `1`, and the
+remaining `2^{c-1}` contributes its single bit. -/
+theorem sum_digits_two_two_pow_add_one {c : ℕ} (hc : 0 < c) :
+    (Nat.digits 2 (2 ^ c + 1)).sum = 2 := by
+  obtain ⟨d, rfl⟩ : ∃ d, c = d + 1 := ⟨c - 1, by omega⟩
+  have hpos : 0 < 2 ^ (d + 1) + 1 := by positivity
+  rw [Nat.digits_def' one_lt_two hpos, List.sum_cons]
+  -- lowest bit: (2^{d+1}+1) % 2 = 1 ; remaining: (2^{d+1}+1) / 2 = 2^d
+  have hpow : (2 : ℕ) ^ (d + 1) = 2 * 2 ^ d := by rw [pow_succ]; ring
+  have hmod : (2 ^ (d + 1) + 1) % 2 = 1 := by rw [hpow]; omega
+  have hdiv : (2 ^ (d + 1) + 1) / 2 = 2 ^ d := by rw [hpow]; omega
+  rw [hmod, hdiv, sum_digits_two_pow]
+
+/-- **Forward direction.** If `s₂(n) = 2` then `n` is a sum of two distinct powers of
+two: `∃ a b, b < a ∧ n = 2^a + 2^b`. Strong induction peeling the lowest bit. -/
+theorem sum_digits_two_eq_two_imp (n : ℕ) :
+    (Nat.digits 2 n).sum = 2 → ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    intro h
+    have hn : 0 < n := by
+      rcases Nat.eq_zero_or_pos n with rfl | hp
+      · simp at h
+      · exact hp
+    rw [Nat.digits_def' one_lt_two hn, List.sum_cons] at h
+    have hhalf : n / 2 < n := Nat.div_lt_self hn one_lt_two
+    rcases Nat.even_or_odd n with he | ho
+    · -- n even: both bits live in n/2; shift up by one
+      have h0 : n % 2 = 0 := Nat.even_iff.mp he
+      rw [h0, Nat.zero_add] at h
+      obtain ⟨a, b, hba, hab⟩ := ih (n / 2) hhalf h
+      refine ⟨a + 1, b + 1, by omega, ?_⟩
+      have he2 : n = 2 * (n / 2) := by omega
+      rw [he2, hab, pow_succ, pow_succ]; ring
+    · -- n odd: lowest bit is one of the two, so n/2 has a single bit (a power of two)
+      have h1 : n % 2 = 1 := Nat.odd_iff.mp ho
+      rw [h1] at h
+      have hsum : (Nat.digits 2 (n / 2)).sum = 1 := by omega
+      obtain ⟨k, hk⟩ := sum_digits_two_eq_one_imp (n / 2) hsum
+      refine ⟨k + 1, 0, by omega, ?_⟩
+      have he2 : n = 2 * (n / 2) + 1 := by omega
+      rw [he2, hk, pow_succ, pow_zero]; ring
+
+/-- **Core characterisation: the binary digit sum equals two exactly for sums of two
+distinct powers of two.** `s₂(n) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`.
+(Not available in Mathlib.) -/
+theorem sum_digits_two_eq_two_iff (n : ℕ) :
+    (Nat.digits 2 n).sum = 2 ↔ ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  constructor
+  · exact sum_digits_two_eq_two_imp n
+  · rintro ⟨a, b, hba, rfl⟩
+    obtain ⟨c, rfl⟩ : ∃ c, a = b + c := ⟨a - b, by omega⟩
+    have hc : 0 < c := by omega
+    have hfact : (2 : ℕ) ^ (b + c) + 2 ^ b = 2 ^ b * (2 ^ c + 1) := by
+      rw [pow_add]; ring
+    rw [hfact, Nat.digits_base_pow_mul one_lt_two (by positivity), List.sum_append]
+    simp only [List.sum_replicate, smul_eq_mul, Nat.mul_zero, Nat.zero_add]
+    exact sum_digits_two_two_pow_add_one hc
+
+/-- **Headline characterisation.** The central binomial coefficient `C(2n, n)` is
+divisible by `2` *exactly twice* iff `n` is a sum of two distinct powers of two:
+`v₂(C(2n, n)) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`. -/
+theorem padicValNat_two_centralBinom_eq_two_iff (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = 2 ↔ ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  rw [padicValNat_two_centralBinom]
+  exact sum_digits_two_eq_two_iff n
+
+/-- **Sharp divisibility at a two-bit `n`.** When `n = 2^a + 2^b` with `b < a`, the
+central binomial coefficient is divisible by `4` but not by `8`:
+`4 ∣ C(2n,n)` and `¬ 8 ∣ C(2n,n)`. -/
+theorem four_exactDvd_centralBinom_of_two_bits {a b : ℕ} (hba : b < a) :
+    4 ∣ Nat.centralBinom (2 ^ a + 2 ^ b) ∧ ¬ (8 ∣ Nat.centralBinom (2 ^ a + 2 ^ b)) := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have hv : padicValNat 2 (Nat.centralBinom (2 ^ a + 2 ^ b)) = 2 :=
+    (padicValNat_two_centralBinom_eq_two_iff _).mpr ⟨a, b, hba, rfl⟩
+  refine ⟨?_, ?_⟩
+  · have hd : (2 : ℕ) ^ padicValNat 2 (Nat.centralBinom (2 ^ a + 2 ^ b)) ∣
+        Nat.centralBinom (2 ^ a + 2 ^ b) := pow_padicValNat_dvd
+    rw [hv] at hd
+    rwa [show (4 : ℕ) = 2 ^ 2 by norm_num]
+  · intro h8
+    have h8' : (2 : ℕ) ^ 3 ∣ Nat.centralBinom (2 ^ a + 2 ^ b) := by
+      rwa [show (8 : ℕ) = 2 ^ 3 by norm_num] at h8
+    have hle := (padicValNat_dvd_iff_le (Nat.centralBinom_ne_zero _)).mp h8'
+    rw [hv] at hle; omega
+
+/-! ### Worked numeric witnesses (0-axiom)
+
+Concrete `centralBinom` values are evaluated by kernel `decide`; valuations are read
+off from the characterisation above. -/
+
+/-- `n = 3 = 2^1 + 2^0`: `C(6,3) = 20 = 2^2 · 5`, so `v₂ = 2`. -/
+example : Nat.centralBinom 3 = 20 := by decide
+example : padicValNat 2 (Nat.centralBinom 3) = 2 :=
+  (padicValNat_two_centralBinom_eq_two_iff 3).mpr ⟨1, 0, by norm_num, by norm_num⟩
+
+/-- `n = 5 = 2^2 + 2^0`: `C(10,5) = 252 = 2^2 · 63`, so `v₂ = 2`. -/
+example : Nat.centralBinom 5 = 252 := by decide
+example : padicValNat 2 (Nat.centralBinom 5) = 2 :=
+  (padicValNat_two_centralBinom_eq_two_iff 5).mpr ⟨2, 0, by norm_num, by norm_num⟩
+
+/-- `n = 6 = 2^2 + 2^1`: `C(12,6) = 924 = 2^2 · 231`, so `v₂ = 2`. -/
+example : Nat.centralBinom 6 = 924 := by decide
+example : padicValNat 2 (Nat.centralBinom 6) = 2 :=
+  (padicValNat_two_centralBinom_eq_two_iff 6).mpr ⟨2, 1, by norm_num, by norm_num⟩
+
+/-- `n = 7 = 111₂` has popcount `3`, so `v₂(C(14,7)) ≠ 2` (indeed `C(14,7) = 3432 =
+2^3 · 429`). -/
+example : Nat.centralBinom 7 = 3432 := by decide
+example : padicValNat 2 (Nat.centralBinom 7) ≠ 2 := by
+  rw [ne_eq, padicValNat_two_centralBinom_eq_two_iff]
+  rintro ⟨a, b, hba, hk⟩
+  -- 2^a + 2^b = 7 is impossible: a ≤ 2 forces small cases, none equal 7
+  have ha : a ≤ 2 := by
+    by_contra hcon
+    push_neg at hcon
+    have : (2 : ℕ) ^ 3 ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) hcon
+    have hb : (1 : ℕ) ≤ 2 ^ b := Nat.one_le_two_pow
+    omega
+  interval_cases a <;> interval_cases b <;> omega
+
+end KummerCentralBinomTwoBits

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "ann-kummer-oq040101-headline",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 182,
+      "endLine": 188
+    },
+    "type": "insight",
+    "title": "Headline: v₂(C(2n,n)) = 2 ⟺ n is a Sum of Two Distinct Powers of Two",
+    "content": "`padicValNat_two_centralBinom_eq_two_iff` is the main result: the central binomial coefficient is divisible by 2 exactly twice iff n = 2^a + 2^b with a > b. The proof is a single `rw [padicValNat_two_centralBinom]` rewriting the valuation as the binary digit sum s₂(n), followed by `exact sum_digits_two_eq_two_iff n`. All the real work is in the popcount=2 lemma; the binomial coefficient contributes only through the parent valuation formula.",
+    "mathContext": "Since $v_2(\\binom{2n}{n}) = s_2(n)$, the valuation $2$ occurs exactly when the binary expansion of $n$ has two $1$-bits — i.e. $n = 2^a + 2^b$ with $a > b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "2-adic valuation",
+      "popcount",
+      "sum of two powers of two"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom",
+      "padicValNat",
+      "binary digit sum"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq040101-popcount-iff",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 166,
+      "endLine": 180
+    },
+    "type": "insight",
+    "title": "The New Lemma: s₂(n) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b",
+    "content": "`sum_digits_two_eq_two_iff` characterises when the binary digit sum (popcount) equals 2: exactly for sums of two distinct powers of two. This is the next level set beyond the parent's popcount = 1, and Mathlib's `Mathlib.Data.Nat.Digits` has no such statement. The forward direction is `sum_digits_two_eq_two_imp` (strong induction); the converse factors n = 2^b(2^{a-b}+1), strips the b trailing zeros with `Nat.digits_base_pow_mul`, and reduces to s₂(2^c+1)=2.",
+    "mathContext": "A natural number has Hamming weight (popcount) $2$ precisely when it is $2^a + 2^b$ for distinct exponents — its binary string has exactly two $1$s.",
+    "significance": "key",
+    "relatedConcepts": [
+      "popcount",
+      "Hamming weight",
+      "binary representation",
+      "level sets of popcount"
+    ],
+    "prerequisites": [
+      "Nat.digits",
+      "Nat.digits_base_pow_mul",
+      "strong induction"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq040101-forward",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 135,
+      "endLine": 164
+    },
+    "type": "proof-technique",
+    "title": "Forward Direction: Peeling the Lowest Bit, Reusing popcount = 1",
+    "content": "`sum_digits_two_eq_two_imp` runs strong induction on n via s₂(n) = (n%2) + s₂(n/2) from `Nat.digits_def'`. The even case (low bit 0) recurses: the induction hypothesis gives n/2 = 2^a + 2^b and n = 2·(n/2) shifts both exponents up by one. The odd case (low bit 1) is the elegant step: the lowest bit is one of the two, so s₂(n/2) = 1, and the parent's popcount=1 lemma `sum_digits_two_eq_one_imp` makes n/2 = 2^k a single power, giving n = 2^{k+1} + 2^0.",
+    "mathContext": "The level sets of popcount are built recursively: popcount $=2$ on odd $n$ drops to popcount $=1$ on $n/2$, so the two-bit characterisation rests on the one-bit characterisation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strong induction",
+      "parity descent",
+      "binary digit recursion"
+    ],
+    "prerequisites": [
+      "Nat.strongRecOn",
+      "Nat.digits_def'",
+      "sum_digits_two_eq_one_imp"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq040101-converse",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 122,
+      "endLine": 134
+    },
+    "type": "proof-technique",
+    "title": "Converse Ingredient: s₂(2^c + 1) = 2 and Stripping Trailing Zeros",
+    "content": "`sum_digits_two_two_pow_add_one` proves s₂(2^c+1) = 2 for c ≥ 1 by peeling the lowest bit: (2^{d+1}+1) % 2 = 1 and (2^{d+1}+1)/2 = 2^d, so the digit sum is 1 + s₂(2^d) = 2. The converse of the main iff then writes 2^a + 2^b = 2^b·(2^{a-b}+1), applies `Nat.digits_base_pow_mul` to drop the b leading zero digits (which contribute 0 to the sum), and finishes with this lemma.",
+    "mathContext": "Multiplying by $2^b$ shifts the binary expansion left by $b$ positions, prepending zeros that do not change the digit sum; so the popcount of $2^a+2^b$ equals that of $2^{a-b}+1$, which is $2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.digits_base_pow_mul",
+      "binary shift",
+      "digit sum invariance"
+    ],
+    "prerequisites": [
+      "Nat.digits_def'",
+      "Nat.digits_base_pow_mul"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq040101-sharp",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 190,
+      "endLine": 205
+    },
+    "type": "insight",
+    "title": "Sharp Divisibility: 4 ∥ C(2n,n) at Two-Bit n",
+    "content": "`four_exactDvd_centralBinom_of_two_bits` upgrades the valuation equality to exact divisibility: for n = 2^a + 2^b (b < a), 4 ∣ C(2n,n) but ¬ 8 ∣ C(2n,n). From v₂ = 2, `pow_padicValNat_dvd` gives 2² = 4 ∣ C(2n,n); and `padicValNat_dvd_iff_le` shows 2³ = 8 ∣ would force 3 ≤ 2, a contradiction.",
+    "mathContext": "At a two-bit $n$ the 2-adic valuation is exactly $2$, the second-minimal nonzero value — one step above the powers of two where it equals $1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "exact divisibility",
+      "2-adic valuation",
+      "pow_padicValNat_dvd"
+    ],
+    "prerequisites": [
+      "pow_padicValNat_dvd",
+      "padicValNat_dvd_iff_le"
+    ]
+  },
+  {
+    "id": "ann-kummer-oq040101-witnesses",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 206,
+      "endLine": 241
+    },
+    "type": "example",
+    "title": "Numeric Witnesses Across the Two-Bit Residues",
+    "content": "Kernel-decidable checks confirm the characterisation: n=3=2¹+2⁰ gives C(6,3)=20=2²·5; n=5=2²+2⁰ gives C(10,5)=252=2²·63; n=6=2²+2¹ gives C(12,6)=924=2²·231 — all with v₂=2. The non-example n=7=111₂ (popcount 3) gives C(14,7)=3432=2³·429 with v₂=3≠2, verified by ruling out 2^a+2^b=7 via interval_cases. Uses kernel `decide`, not native_decide, so no Lean.ofReduceBool dependency.",
+    "mathContext": "The three two-bit numbers below 8 (3, 5, 6) all satisfy v₂=2, while the first three-bit number 7 does not — confirming the level set is precisely popcount 2.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "central binomial coefficient",
+      "popcount"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom"
+    ]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "kummer-theorem-oq-04-oq-01-oq-01",
+  "title": "Kummer OQ-04-OQ-01-OQ-01: C(2n,n) Divisible by 4 Exactly ⟺ n a Sum of Two Distinct Powers of Two",
+  "slug": "kummer-theorem-oq-04-oq-01-oq-01",
+  "description": "The next level set of popcount for the central binomial coefficient: v₂(C(2n,n)) = 2 if and only if n = 2^a + 2^b with a > b (binary popcount 2). Reduces, via the parent closed form v₂(C(2n,n)) = s₂(n), to the binary-digit-sum lemma s₂(n) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b — a popcount=2 characterisation Mathlib does not provide. Includes the sharp 4-exact-divisibility 4 ∥ C(2n,n).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KummerTheoremOQ04OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "kummer-theorem",
+      "p-adic",
+      "binomial-coefficient",
+      "central-binomial-coefficient",
+      "popcount",
+      "powers-of-two"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 241,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "assumptions": "None. 0 axioms, 0 sorries. The headline v₂(C(2n,n)) = s₂(n) is re-derived locally from Mathlib's digit-sum Kummer theorem (sub_one_mul_padicValNat_choose_eq_sub_sum_digits); the new content is the popcount = 2 ⟺ sum-of-two-distinct-powers characterisation proved by strong induction (reusing the parent's popcount = 1 lemma as a black box for the odd-bit case). Numeric witnesses use kernel `decide` (not native_decide), so no Lean.ofReduceBool dependency. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "originalContributions": [
+      "sum_digits_two_eq_two_iff: the binary digit sum equals 2 exactly for sums of two distinct powers of two, s₂(n) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b — the core new lemma, absent from Mathlib (no popcount = 2 characterisation in Mathlib.Data.Nat.Digits), and the next level set beyond the parent's popcount = 1",
+      "sum_digits_two_eq_two_imp: forward direction by strong induction peeling the lowest bit s₂(n) = (n%2) + s₂(n/2): even n shifts both bits up from n/2; odd n forces s₂(n/2) = 1, so n/2 is a single power of two (parent popcount=1 lemma reused), giving n = 2^{k+1} + 2^0",
+      "sum_digits_two_two_pow_add_one: digit sum of 2^c + 1 is 2 for c ≥ 1 — the lowest bit plus the single bit of 2^{c-1}; drives the converse after factoring out trailing zeros",
+      "padicValNat_two_centralBinom_eq_two_iff: the headline characterisation v₂(C(2n,n)) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b, packaging the parent valuation formula with the new popcount lemma",
+      "four_exactDvd_centralBinom_of_two_bits: sharp divisibility — for n = 2^a + 2^b (b < a), 4 ∣ C(2n,n) but ¬ 8 ∣ C(2n,n), i.e. 4 ∥ C(2n,n)",
+      "worked numeric witnesses: C(6,3)=20=2²·5 (n=3=2+1), C(10,5)=252=2²·63 (n=5=4+1), C(12,6)=924=2²·231 (n=6=4+2), and the non-example n=7=111₂ (popcount 3) with C(14,7)=3432=2³·429 showing v₂≠2 for three-bit numbers"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits",
+        "description": "Legendre/Kummer digit-sum identity: (p-1)·v_p(C(n,k)) = s_p(k) + s_p(n-k) - s_p(n), specialised here to p=2 on the diagonal",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "digits b n = n % b :: digits b (n / b) for 1 < b, 0 < n — the lowest-bit peel driving the strong induction",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.digits_base_pow_mul",
+        "description": "digits b (b^k * m) = replicate k 0 ++ digits b m — strips the b trailing zero bits when factoring 2^a + 2^b = 2^b·(2^{a-b}+1)",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "pow_padicValNat_dvd / padicValNat_dvd_iff_le",
+        "description": "p^{v_p(m)} ∣ m and p^n ∣ m ↔ n ≤ v_p(m) — used for the sharp 4 ∥ C(2n,n) corollary",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) computes the $p$-adic valuation $v_p(\\binom{n}{k})$ as the number of carries when adding $k$ and $n-k$ in base $p$; the digit-sum form gives $(p-1)v_p(\\binom{n}{k}) = s_p(k)+s_p(n-k)-s_p(n)$. The grandparent specialises this to the central binomial coefficient as $v_2(\\binom{2n}{n}) = s_2(n)$, the binary popcount of $n$. The parent entry pinned down the minimal case popcount $=1$ (exactly the powers of two). This follow-up advances to the next level set, popcount $=2$: the central coefficient is divisible by exactly $4$ precisely when $n$ has two $1$-bits, i.e. $n$ is a sum of two distinct powers of two. As with popcount $=1$, the underlying bit-counting fact has no direct statement in Mathlib's digit library.",
+    "problemStatement": "Characterise the natural numbers $n$ for which the central binomial coefficient $\\binom{2n}{n}$ is divisible by $2$ exactly twice, $v_2(\\binom{2n}{n}) = 2$ — the first listed open question of the parent entry.",
+    "text": "Via the parent closed form $v_2(\\binom{2n}{n}) = s_2(n)$, the answer is exactly the sums of two distinct powers of two: $v_2(\\binom{2n}{n}) = 2 \\iff \\exists\\, a > b,\\, n = 2^a + 2^b$.",
+    "proofStrategy": "Reduce $v_2(\\binom{2n}{n}) = 2$ to $s_2(n) = 2$ using the parent valuation formula (re-derived locally to stay self-contained). Then prove $s_2(n) = 2 \\iff \\exists a\\, b,\\, b < a \\wedge n = 2^a + 2^b$. Forward: strong induction on $n$ using $s_2(n) = (n \\bmod 2) + s_2(n/2)$ from `Nat.digits_def'`. If $n$ is even, both bits live in $n/2$, so the induction hypothesis gives $n/2 = 2^a + 2^b$ and shifting up yields $n = 2^{a+1} + 2^{b+1}$; if $n$ is odd, the low bit is one of the two, so $s_2(n/2) = 1$ and the parent popcount=1 lemma gives $n/2 = 2^k$, hence $n = 2^{k+1} + 2^0$. Converse: factor $2^a + 2^b = 2^b(2^{a-b}+1)$, strip the $b$ trailing zeros via `Nat.digits_base_pow_mul`, and compute $s_2(2^c + 1) = 2$ for $c \\geq 1$. The sharp divisibility corollary reads $4 \\parallel \\binom{2n}{n}$ off the valuation via the `padicValNat` API.",
+    "keyInsights": [
+      "**Popcount = 2 is the whole content.** Stripping away the binomial coefficient, the theorem is the bit-counting fact that a natural number has exactly two $1$-bits iff it is a sum of two distinct powers of two. The central binomial coefficient enters only through the parent identity $v_2 = s_2$.",
+      "**The odd case reuses the parent as a black box.** When $n$ is odd, the lowest bit accounts for one of the two, leaving $s_2(n/2) = 1$ — exactly the parent's popcount $=1$ situation, so $n/2$ is a single power of two and $n = 2^{k+1} + 2^0$. The level sets build on each other.",
+      "**The even case shifts both bits up.** An even $n$ has its two bits inherited from $n/2$; the induction hypothesis supplies $n/2 = 2^a + 2^b$ and $n = 2 \\cdot (n/2)$ shifts both exponents by one.",
+      "**The converse factors out the trailing zeros.** Writing $2^a + 2^b = 2^b(2^{a-b}+1)$ and applying `Nat.digits_base_pow_mul` reduces the digit sum to $s_2(2^c + 1) = 2$, which is the lowest bit plus the single bit of $2^{c-1}$.",
+      "**Sharpness, not just divisibility.** At a two-bit $n$ the valuation is exactly $2$: $4 \\mid \\binom{2n}{n}$ but $8 \\nmid \\binom{2n}{n}$, the second-minimal nonzero $2$-adic valuation."
+    ],
+    "prerequisites": [
+      "The parent closed form v₂(C(2n,n)) = s₂(n) (Kummer specialised to p=2 on the diagonal)",
+      "The parent popcount = 1 lemma s₂(n) = 1 ⟺ ∃k, n = 2^k (reused for the odd-bit case)",
+      "Base-2 digit representations and the recursion digits 2 n = n%2 :: digits 2 (n/2)",
+      "Strong induction on ℕ (Nat.strongRecOn)",
+      "The padicValNat divisibility API: pow_padicValNat_dvd, padicValNat_dvd_iff_le"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Research Question and Answer",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "File header: the open question (when is C(2n,n) divisible by 2 exactly twice), the answer (exactly the sums of two distinct powers of two), the reduction to s₂(n)=2, and the proof outline for both directions."
+    },
+    {
+      "id": "reused-building-blocks",
+      "title": "Reused Building Blocks: Doubling, Positivity, v₂ = s₂, popcount = 1",
+      "startLine": 55,
+      "endLine": 108,
+      "summary": "sum_digits_two_mul (s₂(2n)=s₂(n)), sum_digits_two_pos (s₂(n)>0 for n>0), sum_digits_two_pow (s₂(2^k)=1), and sum_digits_two_eq_one_imp (the parent popcount=1 forward lemma, re-derived self-contained for use in the odd-bit case).",
+      "mathContext": "These lemmas reproduce just enough of the parent and grandparent to translate the valuation question into a pure digit-sum question and to handle the odd case."
+    },
+    {
+      "id": "valuation-formula",
+      "title": "The Valuation Formula v₂(C(2n,n)) = s₂(n)",
+      "startLine": 110,
+      "endLine": 121,
+      "summary": "padicValNat_two_centralBinom: the parent/grandparent headline re-derived locally from Mathlib's digit-sum Kummer theorem, translating the binomial valuation into the binary digit sum.",
+      "mathContext": "Kummer specialised to $p=2$ on the diagonal $\\binom{2n}{n}$ gives $v_2 = s_2(n)$."
+    },
+    {
+      "id": "two-pow-add-one",
+      "title": "Digit Sum of 2^c + 1 is Two",
+      "startLine": 122,
+      "endLine": 134,
+      "summary": "sum_digits_two_two_pow_add_one: s₂(2^c+1)=2 for c≥1, the lowest bit (1) plus s₂(2^{c-1})=1 after the peel. Drives the converse direction.",
+      "mathContext": "$2^c + 1$ for $c \\geq 1$ has bits at positions $0$ and $c$, a two-bit number."
+    },
+    {
+      "id": "forward-induction",
+      "title": "Forward Direction: s₂(n)=2 ⟹ Two Distinct Powers",
+      "startLine": 135,
+      "endLine": 164,
+      "summary": "sum_digits_two_eq_two_imp: strong induction peeling the lowest bit. Even n: both bits in n/2, shift up to get 2^{a+1}+2^{b+1}. Odd n: low bit is one, s₂(n/2)=1 forces n/2=2^k (parent lemma), giving 2^{k+1}+2^0.",
+      "mathContext": "Spending a digit-sum budget of 2 means two 1-bits; parity descent locates them as two distinct powers of two."
+    },
+    {
+      "id": "characterisations",
+      "title": "The Characterisations: Digit Sum and Valuation",
+      "startLine": 166,
+      "endLine": 188,
+      "summary": "sum_digits_two_eq_two_iff (s₂(n)=2 ⟺ ∃ a b, b<a ∧ n=2^a+2^b) combining both directions via the factor-and-strip converse, and padicValNat_two_centralBinom_eq_two_iff (v₂(C(2n,n))=2 ⟺ two distinct powers), the headline result.",
+      "mathContext": "Rewriting the valuation by the parent formula turns the binomial statement into the popcount=2 statement."
+    },
+    {
+      "id": "sharp-divisibility",
+      "title": "Sharp 4-Exact Divisibility at Two-Bit n",
+      "startLine": 190,
+      "endLine": 205,
+      "summary": "four_exactDvd_centralBinom_of_two_bits: for n=2^a+2^b (b<a), 4 ∣ C(2n,n) and ¬ 8 ∣ C(2n,n), i.e. 4 ∥ C(2n,n), derived from v₂=2 via pow_padicValNat_dvd and padicValNat_dvd_iff_le.",
+      "mathContext": "At two-bit n the 2-adic valuation attains its second-minimal nonzero value 2."
+    },
+    {
+      "id": "numeric-witnesses",
+      "title": "Worked Numeric Witnesses",
+      "startLine": 206,
+      "endLine": 241,
+      "summary": "Kernel-decidable evaluations: C(6,3)=20 (n=3=2+1), C(10,5)=252 (n=5=4+1), C(12,6)=924 (n=6=4+2), and the non-example n=7=111₂ with C(14,7)=3432 showing v₂=3≠2 for a three-bit number. Ends namespace KummerCentralBinomTwoBits.",
+      "mathContext": "Sanity checks confirm the positive characterisation on all three two-bit residues and its failure on a three-bit number."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, self-contained Lean 4 formalization characterising the second level set of the central binomial coefficient's 2-adic valuation: v₂(C(2n,n)) = 2 ⟺ n = 2^a + 2^b with a > b. The crux is a new popcount lemma s₂(n)=2 ⟺ sum of two distinct powers of two (strong induction reusing the parent's popcount=1 lemma for the odd-bit case), which Mathlib does not provide. 10 theorems, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent (popcount=1 ⟺ power of two) this maps the bottom of the popcount hierarchy for central binomial coefficients: v₂=1 at one-bit n, v₂=2 at two-bit n. The standalone popcount=2 characterisation is reusable for any digit-sum argument over ℕ, and the inductive method (peel lowest bit, drop to the next-lower level set) extends in principle to popcount=k.",
+    "openQuestions": [
+      "Does the inductive method generalise to a uniform popcount = k ⟺ sum of k distinct powers of two, giving v₂(C(2n,n)) = k as a single parametrized family?",
+      "For an odd prime p, characterise the n with v_p(C(2n,n)) = 2 in terms of base-p digits (two single carries, or one digit ≥ ⌈p/2⌉)?",
+      "Transfer the v₂=2 characterisation to the Catalan number C_n = C(2n,n)/(n+1): for which two-bit n is C_n divisible by exactly 4?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry characterising the minimal case v₂(C(2n,n)) = 1 as exactly the powers of two; this follow-up advances to the next level set v₂ = 2, answering its first open question."
+    },
+    {
+      "targetId": "kummer-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent entry proving the closed form v₂(C(2n,n)) = s₂(n)."
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "extends",
+      "description": "Root Kummer's theorem on p-adic valuations of binomial coefficients via carry counts."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Kummer, E.E."
+      ],
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "venue": "Journal für die reine und angewandte Mathematik 44, pp. 93-146",
+      "note": "Original carry-count theorem for v_p(C(n,k)); the digit-sum form specialised here"
+    },
+    {
+      "authors": [
+        "Legendre, A.-M."
+      ],
+      "title": "Théorie des nombres",
+      "year": "1830",
+      "venue": "3rd edition, Firmin Didot Frères, Paris",
+      "note": "Legendre's formula v_p(n!) = (n - s_p(n))/(p-1), source of the digit-sum identity"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "KummerCentralBinomTwoBits",
+    "lineCount": 241,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/KummerTheoremOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `kummer-theorem-oq-04-oq-01` ("Characterise the n with v₂(C(2n,n)) = 2 — the next level set of popcount"). Via the grandparent closed form `v₂(C(2n,n)) = s₂(n)`, proves the clean characterisation

$$\nu_2\binom{2n}{n} = 2 \iff \exists\, a > b,\; n = 2^a + 2^b.$$

The parent stopped at popcount = 1 (powers of two); this advances to popcount = 2 (sums of two distinct powers of two).

## Mathematical content

- **`sum_digits_two_eq_two_iff`** (core, new — not in Mathlib): `s₂(n) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b`.
  - *Forward* — strong induction peeling the lowest bit `s₂(n) = (n%2) + s₂(n/2)`: the **odd** case drops to the parent's popcount = 1 lemma (`n/2` a single power of two → `n = 2^{k+1}+2^0`); the **even** case shifts both bits up from `n/2`.
  - *Converse* — factor `2^a+2^b = 2^b·(2^{a-b}+1)`, strip the `b` trailing zero bits with `Nat.digits_base_pow_mul`, reduce to `s₂(2^c+1)=2`.
- **`padicValNat_two_centralBinom_eq_two_iff`** — the headline, packaging the valuation formula with the popcount lemma.
- **`four_exactDvd_centralBinom_of_two_bits`** — sharp: `4 ∣ C(2n,n) ∧ ¬ 8 ∣ C(2n,n)` at two-bit `n`.
- Worked witnesses: `n=3,5,6` (the three two-bit residues < 8) give `v₂=2`; `n=7` (popcount 3) does not.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` on the three main results reports only `propext, Classical.choice, Quot.sound`.
- Numeric witnesses use **kernel `decide`** (not `native_decide`) — no `Lean.ofReduceBool` dependency.
- 10 theorems, 0 definitions, 241 lines. Compiles against Mathlib v4.26.0.
- Self-contained: the valuation formula `v₂ = s₂` and the parent popcount = 1 lemma are re-derived locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)