### PR TITLE
Enrich Two Supplementary Laws of Quadratic Reciprocity (euler-criterion oq-01-oq-02)

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-euler0102-overview",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "The two supplementary laws of quadratic reciprocity",
+    "content": "The docstring lays out the goal: derive the two supplements to Gauss's reciprocity law from Euler's criterion (proved in the parent entry). The first supplement, the value of (−1 | p), follows immediately by substituting a = −1 into the criterion; the second, the value of (2 | p), is governed by p mod 8 and rests on a Gauss-sum evaluation supplied by Mathlib. The honest scope is stated up front: the first law is genuinely re-derived from the parent's criterion, while the second packages Mathlib's deep result into an explicit residue dictionary.",
+    "mathContext": "First supplement: $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$, so $-1$ is a QR iff $p\\equiv 1\\pmod 4$. Second: $\\left(\\tfrac{2}{p}\\right) = (-1)^{(p^2-1)/8}$, so $2$ is a QR iff $p\\equiv \\pm1\\pmod 8$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic reciprocity", "Legendre symbol", "Euler's criterion", "quadratic residue"],
+    "prerequisites": ["modular arithmetic", "Legendre symbol"]
+  },
+  {
+    "id": "ann-euler0102-oddness",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 45, "endLine": 51 },
+    "type": "technique",
+    "title": "p is odd and p ≠ 2",
+    "content": "Two private helpers extract the arithmetic facts the rest of the file needs from the typeclass hypotheses `[Fact p.Prime]` and `[Fact (2 < p)]`. `p_odd` uses `Prime.eq_two_or_odd` and discharges the `p = 2` branch by `omega` against `2 < p`, giving `p % 2 = 1`. `p_ne_two` is the bare inequality Mathlib's supplementary-law lemmas demand. The `omit [Fact p.Prime]` on `p_ne_two` drops the unused primality instance so the lemma is stated with only the hypothesis it really uses.",
+    "mathContext": "From $2 < p$ prime: $p$ is odd, $p\\bmod 2 = 1$, and $p \\neq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["odd prime", "Fact typeclass", "Prime.eq_two_or_odd"],
+    "prerequisites": ["primes", "omega tactic"]
+  },
+  {
+    "id": "ann-euler0102-bridge",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 62 },
+    "type": "insight",
+    "title": "Lifting Euler's congruence to an equality of ±1",
+    "content": "The reusable bridge lemma intCast_inj_of_pm_one. Euler's criterion only gives a *congruence* `(a | p) ≡ a^((p−1)/2) (mod p)`, but both sides are integers in {−1, 1}; this lemma upgrades the congruence to an honest *equality*. The proof is a 2×2 case split: the diagonal cases are `rfl`, and the off-diagonal cases (1 ≡ −1) contradict the parent's `one_ne_neg_one p` — the fact that 1 and −1 are distinct in ZMod p precisely because p is an odd prime (for p = 2 they coincide!). This distinctness is the entire reason an odd modulus is required.",
+    "mathContext": "If $x,y\\in\\{1,-1\\}$ and $x\\equiv y\\pmod p$ with $p$ an odd prime, then $x=y$ — because $1\\not\\equiv -1\\pmod p$ once $p>2$.",
+    "significance": "key",
+    "relatedConcepts": ["lifting congruence to equality", "one_ne_neg_one", "ZMod p", "injectivity on {±1}"],
+    "prerequisites": ["ZMod arithmetic", "case analysis"]
+  },
+  {
+    "id": "ann-euler0102-first-law",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 64, "endLine": 84 },
+    "type": "theorem",
+    "title": "First supplementary law: (−1 | p) = (−1)^((p−1)/2)",
+    "content": "legendreSym_neg_one is the headline of the first law, derived straight from the parent's Euler criterion. The helper neg_one_pow_pm records that (−1)^n ∈ {1, −1} by parity. Then intCast_inj_of_pm_one is fed two facts: (−1 | p) ∈ {±1} (via legendreSym.eq_one_or_neg_one, since −1 ≠ 0 in ZMod p), and the congruence (−1 | p) ≡ (−1)^((p−1)/2) which is exactly `legendreSym_eq_pow` applied at a = −1. This is an *original route*: Mathlib has `legendreSym.at_neg_one`, but here the value is obtained from the criterion the parent proved, not from the library lemma.",
+    "mathContext": "$\\left(\\tfrac{-1}{p}\\right) \\equiv (-1)^{(p-1)/2} \\pmod p$ (Euler) and both sides $\\in\\{\\pm1\\}$, so $\\left(\\tfrac{-1}{p}\\right) = (-1)^{(p-1)/2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's criterion", "legendreSym_eq_pow", "first supplement", "parity of (p−1)/2"],
+    "prerequisites": ["Euler's criterion", "Legendre symbol values"]
+  },
+  {
+    "id": "ann-euler0102-mod4",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 97 },
+    "type": "theorem",
+    "title": "Residue form: −1 is a square iff p ≡ 1 (mod 4)",
+    "content": "neg_one_isSquare_iff restates the first law as a residue criterion: IsSquare(−1 : ZMod p) ↔ p % 4 = 1. It rewrites with Mathlib's `ZMod.exists_sq_eq_neg_one_iff` (giving p % 4 ≠ 3) and closes the gap to `p % 4 = 1` with `omega`, using oddness (p % 2 = 1 forces p % 4 ∈ {1, 3}). legendreSym_neg_one_eq_one_iff then converts this into Legendre-value form `(−1 | p) = 1 ↔ p % 4 = 1` via `legendreSym.eq_one_iff`, after normalising the cast `((-1 : ℤ) : ZMod p) = (-1 : ZMod p)`.",
+    "mathContext": "$\\mathrm{IsSquare}(-1)\\iff p\\bmod 4 = 1$; equivalently $\\left(\\tfrac{-1}{p}\\right)=1\\iff p\\equiv1\\pmod4$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.exists_sq_eq_neg_one_iff", "Gaussian primes", "sum of two squares", "p ≡ 1 mod 4"],
+    "prerequisites": ["quadratic residues", "omega for modular case-splitting"]
+  },
+  {
+    "id": "ann-euler0102-two-square",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 99, "endLine": 120 },
+    "type": "theorem",
+    "title": "Second supplementary law: 2 is a square iff p ≡ ±1 (mod 8)",
+    "content": "The second law. The private two_ne_zero' certifies 2 ≠ 0 in ZMod p (p > 2 prime cannot divide 2). two_isSquare_iff is then a thin wrapper over Mathlib's `ZMod.exists_sq_eq_two_iff` — the genuinely deep input, whose proof is the Gauss-sum evaluation (2 | p) = χ₈(p). legendreSym_two_eq_one_iff packages it as `(2 | p) = 1 ↔ p % 8 = 1 ∨ p % 8 = 7`. The entry is explicit that it *packages* rather than re-derives the Gauss-sum content, keeping the originality claim honest.",
+    "mathContext": "$\\mathrm{IsSquare}(2)\\iff p\\bmod 8\\in\\{1,7\\}$; $\\left(\\tfrac{2}{p}\\right)=1 \\iff p\\equiv 1,7\\pmod 8$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.exists_sq_eq_two_iff", "Gauss sums", "character χ₈", "second supplement"],
+    "prerequisites": ["quadratic residues", "Gauss sums (background)"]
+  },
+  {
+    "id": "ann-euler0102-two-nonsquare",
+    "proofId": "euler-criterion-squares-oq-01-oq-02",
+    "range": { "startLine": 122, "endLine": 129 },
+    "type": "theorem",
+    "title": "Non-residue case: (2 | p) = −1 iff p ≡ 3, 5 (mod 8)",
+    "content": "legendreSym_two_eq_neg_one_iff completes the explicit mod-8 dictionary by handling the non-residue case. It rewrites with `legendreSym.eq_neg_one_iff` (a non-zero non-square has symbol −1), then with two_isSquare_iff, and lets `omega` (knowing p is odd, so p % 8 ∈ {1,3,5,7}) deduce that 'not a square' means exactly p % 8 ∈ {3, 5}. Together with the residue case this gives the complete partition of odd residues mod 8 into QR/non-QR for the prime 2.",
+    "mathContext": "$\\left(\\tfrac{2}{p}\\right) = -1 \\iff p\\equiv 3,5\\pmod 8$. The odd residues split as QR $\\{1,7\\}$ / non-QR $\\{3,5\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["legendreSym.eq_neg_one_iff", "non-residue", "complementary residue classes"],
+    "prerequisites": ["Legendre symbol values", "omega tactic"]
+  }
+]

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02/index.ts
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerCriterionSquaresOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerCriterionSquaresOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerCriterionSquaresOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerCriterionSquaresOQ01OQ02Data: ProofData = {
+  proof: eulerCriterionSquaresOQ01OQ02Proof,
+  annotations: eulerCriterionSquaresOQ01OQ02Annotations,
+}

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-02/meta.json
@@ -79,6 +79,74 @@
       "First supplementary law: (−1 | p) = (−1)^((p−1)/2), derived directly from the parent's Euler criterion; equivalently −1 is a square mod p iff p ≡ 1 (mod 4).",
       "Second supplementary law: 2 is a square mod p iff p ≡ ±1 (mod 8); explicitly (2 | p) = 1 iff p ≡ 1, 7 (mod 8) and (2 | p) = −1 iff p ≡ 3, 5 (mod 8).",
       "A reusable lemma lifting Euler's congruence to an equality of Legendre values: distinct elements of {−1, 1} stay distinct modulo an odd prime."
+    ],
+    "proofStrategy": "The first law is derived from the parent's Euler criterion: legendreSym_neg_one applies the bridge lemma intCast_inj_of_pm_one to the two facts (−1 | p) ∈ {±1} (legendreSym.eq_one_or_neg_one) and (−1 | p) ≡ (−1)^((p−1)/2) (mod p) (the criterion legendreSym_eq_pow at a = −1), promoting the congruence to equality. Its residue form neg_one_isSquare_iff rewrites Mathlib's ZMod.exists_sq_eq_neg_one_iff (p % 4 ≠ 3) to p % 4 = 1 via omega using oddness. The second law packages Mathlib's Gauss-sum result ZMod.exists_sq_eq_two_iff into the explicit mod-8 dictionary: two_isSquare_iff wraps it, and the value forms legendreSym_two_eq_one_iff / legendreSym_two_eq_neg_one_iff convert IsSquare statements to Legendre values via legendreSym.eq_one_iff / eq_neg_one_iff, with omega partitioning the odd residues mod 8 into QR {1,7} and non-QR {3,5}.",
+    "keyInsights": [
+      "**Euler's criterion does the first supplement for free.** Substituting a = −1 turns the criterion into (−1 | p) ≡ (−1)^((p−1)/2) (mod p); since both sides are ±1, congruence already forces equality — no Gauss's lemma needed for the first law.",
+      "**The {±1} bridge is the technical crux.** A mod-p congruence is weaker than an equation, but on the two-element set {−1, 1} it is equivalent — precisely because 1 ≢ −1 (mod p) for an odd prime. This is exactly where the hypothesis p > 2 is consumed, and the lemma intCast_inj_of_pm_one isolates it for reuse.",
+      "**The two supplements have genuinely different depth.** (−1 | p) is elementary (parity of (p−1)/2), while (2 | p) encodes a Gauss-sum evaluation (2 | p) = χ₈(p); the entry is scrupulous about deriving the first and only *packaging* the second from Mathlib.",
+      "**The mod-8 dictionary is a clean residue partition.** Among odd residues mod 8 the prime 2 is a QR exactly for p ≡ ±1 and a non-residue for p ≡ ±3 — a symmetric split that omega reads off mechanically once oddness pins p % 8 ∈ {1,3,5,7}.",
+      "**Residue form and value form are interchangeable.** Each law is stated both as IsSquare in ZMod p and as a Legendre value in {±1}; legendreSym.eq_one_iff / eq_neg_one_iff translate between them, so downstream proofs can use whichever is convenient."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "oddness-helpers",
+      "title": "Oddness of p",
+      "startLine": 45,
+      "endLine": 51,
+      "summary": "Private helpers p_odd (p % 2 = 1, from Prime.eq_two_or_odd) and p_ne_two (p ≠ 2), extracting the arithmetic content of the [Fact p.Prime] / [Fact (2 < p)] hypotheses needed throughout.",
+      "mathContext": "$p$ odd: $p\\bmod2=1$, $p\\neq2$."
+    },
+    {
+      "id": "pm-one-bridge",
+      "title": "Lifting congruence to equality on {±1}",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "intCast_inj_of_pm_one: two integers in {−1, 1} with equal image in ZMod p are equal (2×2 case split; off-diagonal cases use the parent's one_ne_neg_one). neg_one_pow_pm: (−1)^n ∈ {1,−1} by parity. This bridge turns Euler's mod-p congruence into an equality of Legendre values.",
+      "mathContext": "$x,y\\in\\{\\pm1\\},\\ x\\equiv y\\ (p) \\Rightarrow x=y$."
+    },
+    {
+      "id": "first-law",
+      "title": "First supplementary law (value of (−1 | p))",
+      "startLine": 70,
+      "endLine": 97,
+      "summary": "legendreSym_neg_one: (−1 | p) = (−1)^((p−1)/2), from the parent's Euler criterion via the {±1} bridge. neg_one_isSquare_iff / legendreSym_neg_one_eq_one_iff: residue (p % 4 = 1) and Legendre-value forms.",
+      "mathContext": "$\\left(\\tfrac{-1}{p}\\right)=(-1)^{(p-1)/2}$; QR iff $p\\equiv1\\ (4)$."
+    },
+    {
+      "id": "second-law",
+      "title": "Second supplementary law (value of (2 | p))",
+      "startLine": 99,
+      "endLine": 131,
+      "summary": "two_ne_zero': 2 ≠ 0 in ZMod p. two_isSquare_iff: wraps Mathlib's Gauss-sum result ZMod.exists_sq_eq_two_iff. legendreSym_two_eq_one_iff / legendreSym_two_eq_neg_one_iff: the explicit mod-8 dictionary, QR for p ≡ 1,7 and non-QR for p ≡ 3,5, separated by omega from oddness.",
+      "mathContext": "$\\left(\\tfrac{2}{p}\\right)=1\\iff p\\equiv1,7\\ (8)$; $=-1\\iff p\\equiv3,5\\ (8)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Derives the two supplementary laws of quadratic reciprocity for an odd prime p. The first, (−1 | p) = (−1)^((p−1)/2), is obtained directly from the parent's Euler criterion through a reusable {±1}-congruence-to-equality bridge, with residue form −1 is a QR ⟺ p ≡ 1 (mod 4). The second, the value of (2 | p), is packaged from Mathlib's Gauss-sum result into the explicit mod-8 dictionary: QR for p ≡ 1,7 and non-QR for p ≡ 3,5. 11 theorems, 0 sorries, 0 axioms.",
+    "implications": "Completes the elementary half of the reciprocity package: together with the main reciprocity law (a | q)(q | a) = (−1)^… these supplements determine every Legendre symbol (a | p) by reducing a to its prime factorization and the units −1 and 2. The {±1} bridge lemma intCast_inj_of_pm_one is a generally useful tool wherever an Euler-criterion-style congruence must be upgraded to a value equality.",
+    "openQuestions": [
+      "Combine the supplements with the main quadratic reciprocity law to give a fully algorithmic evaluation of (a | p) for arbitrary a, via factorization and multiplicativity of the Legendre symbol.",
+      "Re-derive the second supplementary law's Gauss-sum content (2 | p) = χ₈(p) from first principles (Gauss's lemma / the count of lattice points), so the entry depends on no black-box Mathlib evaluation.",
+      "Extend to the Jacobi symbol, where the same mod-4 and mod-8 formulas hold for odd composite moduli, and connect to the parent's Euler-criterion framework."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves Euler's criterion in Legendre form (legendreSym_eq_pow) and the distinctness one_ne_neg_one; this leaf substitutes a = −1 into that criterion and reuses one_ne_neg_one to lift the resulting congruence to the first supplementary law."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A sibling leaf of the same Euler-criterion parent, developing a complementary consequence of the criterion."
+    },
+    {
+      "proofId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The main quadratic reciprocity law that these two supplementary laws accompany; together they evaluate every Legendre symbol."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-02` (quality was 10 — thinnest tier).

## Gaps addressed
Entry had **only meta.json** with a minimal overview: no annotations, no sections, no conclusion, no cross-references, no index.ts.

## Added
- **annotations.json** — 7 annotations (overview, oddness helpers, the {±1} congruence→equality bridge, first-law value/residue forms, second-law mod-8 dictionary, non-residue case), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **overview.proofStrategy** + **5 keyInsights** distinguishing the elementary first supplement from the Gauss-sum-backed second.
- **sections** — 4 sections covering all 131 lines.
- **conclusion** — summary, implications, 3 open questions.
- **crossReferences** — parent, sibling, and the main reciprocity law.
- **index.ts** entry point.

## Verification
- Both JSON files validate; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms. Honest scope preserved (second law packages Mathlib's `ZMod.exists_sq_eq_two_iff`).