### PR TITLE
research(burnside-counting-oq-03-oq-02): general orbit-counting for colorings under an arbitrary finite group [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03OQ02.lean
@@ -1,0 +1,159 @@
+/-
+# General Orbit-Counting for Colorings under an Arbitrary Finite Group
+## (burnside-counting-oq-03-oq-02)
+
+**Open question** (from `burnside-counting-oq-03`): generalize the cyclic necklace
+orbit-counting result to an **arbitrary finite group** acting on the positions — the
+unweighted Cauchy–Frobenius / Burnside count for colorings.
+
+Let `G` be a finite group acting on a finite set `X` (the positions), and color the
+positions with `k` colors, i.e. a coloring is a function `c : X → Fin k`. The group acts
+on colorings by `(g • c) x = c (g⁻¹ • x)`. For `g : G`, let
+
+  `cyc g := Nat.card (orbitRel.Quotient (Subgroup.zpowers g) X)`
+
+be the number of orbits of the cyclic subgroup `⟨g⟩` on `X` (equivalently, the number of
+cycles of the permutation `x ↦ g • x`). We prove:
+
+* **(A) Per-element fixed-point count** (`card_fixedBy_eq_pow_cyc`):
+    `Nat.card (fixedBy (X → Fin k) g) = k ^ cyc g`.
+  A coloring is fixed by `g` iff it is constant on each `⟨g⟩`-orbit, so fixed colorings
+  biject with functions `(⟨g⟩-orbit quotient) → Fin k`.
+
+* **(B) Burnside orbit-counting** (`sum_pow_cyc_eq_card_orbits_mul_card`):
+    `∑ g : G, k ^ cyc g = (#distinct colorings) * |G|`,
+  obtained from `(A)` and Mathlib's Burnside identity
+  `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`. Hence the number of distinct
+  colorings up to the `G`-symmetry is `(1/|G|) ∑_g k^{cyc g}`.
+
+This is the group-agnostic master formula behind every concrete necklace/bracelet count in
+the gallery: the cyclic value `k^{gcd(r,n)}` and the dihedral reflection counts are all
+instances of `k^{cyc g}`.
+
+The **full weighted Pólya cycle-index theorem** (cycle-index polynomial + weighted
+generating function) is *out of scope*: Mathlib lacks cycle-index machinery. This leaf
+proves the honest, tractable **unweighted** generalization, which is the genuine gallery gap.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+import Mathlib
+
+open MulAction Finset
+
+namespace BurnsideCountingOQ03OQ02
+
+variable {G X : Type*} [Group G] [MulAction G X] {k : ℕ}
+
+/-! ## Section I: The coloring action
+
+`G` acts on colorings `X → Fin k` by permuting the domain: `(g • c) x = c (g⁻¹ • x)`.
+The inverse makes this a genuine left action. There is no clash with Mathlib's
+`Pi.mulAction` because `Fin k` carries no `G`-action. -/
+
+/-- The domain-permutation action of `G` on colorings `X → Fin k`. -/
+instance coloringAction : MulAction G (X → Fin k) where
+  smul g c := fun x => c (g⁻¹ • x)
+  one_smul c := by
+    funext x
+    show c (1⁻¹ • x) = c x
+    rw [inv_one, one_smul]
+  mul_smul g h c := by
+    funext x
+    change c ((g * h)⁻¹ • x) = c (h⁻¹ • (g⁻¹ • x))
+    rw [mul_inv_rev, mul_smul]
+
+/-- Unfold the coloring action. -/
+@[simp] lemma coloring_smul_apply (g : G) (c : X → Fin k) (x : X) :
+    (g • c) x = c (g⁻¹ • x) := rfl
+
+/-! ## Section II: Fixed colorings are constant on `⟨g⟩`-orbits -/
+
+/-- If `c` is fixed by `g`, then every element of the cyclic subgroup `⟨g⟩` fixes `c`.
+    (The stabilizer of `c` is a subgroup containing `g`, hence contains `⟨g⟩`.) -/
+lemma zpowers_smul_eq_of_fixed {g : G} {c : X → Fin k} (hc : g • c = c)
+    {h : G} (hh : h ∈ Subgroup.zpowers g) : h • c = c := by
+  have hg : g ∈ stabilizer G c := (mem_stabilizer_iff).2 hc
+  exact (mem_stabilizer_iff).1 ((Subgroup.zpowers_le).2 hg hh)
+
+/-- If `c` is fixed by `g`, it is constant along the `⟨g⟩`-action:
+    `c (h • x) = c x` for any `h ∈ ⟨g⟩`. -/
+lemma const_on_zpowers {g : G} {c : X → Fin k} (hc : g • c = c)
+    {h : G} (hh : h ∈ Subgroup.zpowers g) (x : X) : c (h • x) = c x := by
+  have hfix : h • c = c := zpowers_smul_eq_of_fixed hc hh
+  have key := congrFun hfix (h • x)
+  rw [coloring_smul_apply, inv_smul_smul] at key
+  exact key.symm
+
+/-! ## Section III: The orbit-quotient bijection
+
+Fixed colorings of `g` biject with functions on the `⟨g⟩`-orbit quotient of `X`. -/
+
+/-- The orbit quotient of the cyclic subgroup `⟨g⟩` acting on `X`. -/
+abbrev CycQuot (g : G) : Type _ := orbitRel.Quotient (Subgroup.zpowers g) X
+
+/-- The number of `⟨g⟩`-orbits on `X` (= number of cycles of `x ↦ g • x`). -/
+noncomputable def cyc (g : G) : ℕ := Nat.card (CycQuot (X := X) g)
+
+/-- **Key bijection.** A coloring fixed by `g` descends to a function on the
+    `⟨g⟩`-orbit quotient (it is constant on orbits), and any such function pulls back to a
+    fixed coloring. -/
+noncomputable def fixedColoringEquiv (g : G) :
+    {c : X → Fin k // g • c = c} ≃ (CycQuot (X := X) g → Fin k) where
+  toFun := fun ⟨c, hc⟩ =>
+    Quotient.lift c (by
+      intro a b hab
+      have hab' : a ∈ orbit (Subgroup.zpowers g) b := hab
+      rw [mem_orbit_iff] at hab'
+      obtain ⟨h, rfl⟩ := hab'
+      exact const_on_zpowers hc h.2 b)
+  invFun := fun f =>
+    ⟨fun x => f (Quotient.mk _ x), by
+      funext x
+      show f (Quotient.mk _ (g⁻¹ • x)) = f (Quotient.mk _ x)
+      congr 1
+      exact Quotient.sound ⟨⟨g⁻¹, Subgroup.inv_mem _ (Subgroup.mem_zpowers g)⟩, rfl⟩⟩
+  left_inv := by
+    rintro ⟨c, hc⟩
+    apply Subtype.ext
+    funext x
+    rfl
+  right_inv := by
+    intro f
+    funext q
+    induction q using Quotient.inductionOn with
+    | _ x => rfl
+
+/-! ## Section IV: (A) per-element fixed-point count -/
+
+/-- **(A)** The number of colorings fixed by `g` is `k ^ cyc g`. -/
+theorem card_fixedBy_eq_pow_cyc [Finite X] (g : G) :
+    Nat.card (fixedBy (X → Fin k) g) = k ^ cyc (X := X) g := by
+  have e : (fixedBy (X → Fin k) g) ≃ (CycQuot (X := X) g → Fin k) :=
+    (Equiv.subtypeEquivRight (fun c => mem_fixedBy)).trans (fixedColoringEquiv g)
+  rw [Nat.card_congr e, Nat.card_fun, Nat.card_eq_fintype_card (α := Fin k), Fintype.card_fin]
+  rfl
+
+/-! ## Section V: (B) Burnside orbit-counting (average over the group) -/
+
+/-- The orbit quotient of the full coloring action: distinct colorings up to `G`-symmetry. -/
+abbrev ColorOrbits : Type _ := orbitRel.Quotient G (X → Fin k)
+
+/-- **(B)** Sum of the per-element fixed counts equals the number of distinct colorings
+    times the group order: `∑ g, k ^ cyc g = (#distinct colorings) * |G|`. This is
+    Burnside's averaging formula `#orbits = (1/|G|) ∑_g k^{cyc g}` in integer form. -/
+theorem sum_pow_cyc_eq_card_orbits_mul_card [Fintype G] [Finite X] :
+    (∑ g : G, k ^ cyc (X := X) g)
+      = Nat.card (ColorOrbits (G := G) (X := X) (k := k)) * Nat.card G := by
+  classical
+  haveI : ∀ a : G, Fintype (fixedBy (X → Fin k) a) := fun a => Fintype.ofFinite _
+  haveI : Fintype (ColorOrbits (G := G) (X := X) (k := k)) := Fintype.ofFinite _
+  have h := MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group G (X → Fin k)
+  simp only [← Nat.card_eq_fintype_card] at h
+  rw [← h]
+  exact Finset.sum_congr rfl (fun g _ => (card_fixedBy_eq_pow_cyc g).symm)
+
+#check @card_fixedBy_eq_pow_cyc
+#check @sum_pow_cyc_eq_card_orbits_mul_card
+
+end BurnsideCountingOQ03OQ02

--- a/src/data/proofs/burnside-counting-oq-03-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "burnside-counting-oq-03-oq-02",
+  "title": "General Orbit-Counting for Colorings under an Arbitrary Finite Group",
+  "slug": "burnside-counting-oq-03-oq-02",
+  "description": "The unweighted Cauchy–Frobenius / Burnside count for colorings under an arbitrary finite group action, generalizing the cyclic necklace case. A finite group G acts on a finite set X of positions, and colorings are functions c : X → Fin k with the domain-permutation action (g • c) x = c (g⁻¹ • x). The per-element fixed-point count is |Fix(g)| = k^cyc(g), where cyc(g) is the number of orbits of the cyclic subgroup ⟨g⟩ on X (the number of cycles of x ↦ g • x). Combined with Mathlib's Burnside identity this yields ∑_{g∈G} k^cyc(g) = (#distinct colorings)·|G|, i.e. #orbits = (1/|G|) ∑_g k^cyc(g). This is the group-agnostic master formula behind every concrete necklace/bracelet count in the gallery (the cyclic k^gcd(r,n) and the dihedral reflection counts are all instances of k^cyc(g)).",
+  "meta": {
+    "author": "Cauchy–Frobenius–Burnside; formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Burnside%27s_lemma",
+    "date": "1887",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "counting",
+      "necklaces",
+      "burnside",
+      "orbit-counting",
+      "group-action",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: both main theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 159,
+    "theoremCount": 5,
+    "definitionCount": 4,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside's lemma: Σ_g |Fix(g)| = |orbits| × |G| for any finite group action",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Subgroup.zpowers_le",
+        "description": "⟨g⟩ ≤ H ↔ g ∈ H; lets the stabilizer of a fixed coloring absorb the whole cyclic subgroup",
+        "module": "Mathlib.Algebra.Group.Subgroup.ZPowers.Basic"
+      },
+      {
+        "theorem": "MulAction.mem_stabilizer_iff",
+        "description": "a ∈ stabilizer G b ↔ a • b = b",
+        "module": "Mathlib.GroupTheory.GroupAction.Basic"
+      },
+      {
+        "theorem": "Nat.card_fun",
+        "description": "Nat.card (α → β) = Nat.card β ^ Nat.card α for finite α",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "MulAction.orbitRel.Quotient",
+        "description": "Quotient of X by the orbit equivalence of a group action; used for ⟨g⟩ and for the full G-action on colorings",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      }
+    ],
+    "originalContributions": [
+      "coloringAction: the domain-permutation MulAction G (X → Fin k), (g • c) x = c (g⁻¹ • x), a genuine left action with no clash with Pi.mulAction (Fin k carries no G-action)",
+      "zpowers_smul_eq_of_fixed: a coloring fixed by g is fixed by the entire cyclic subgroup ⟨g⟩ (via stabilizer ⊇ ⟨g⟩)",
+      "const_on_zpowers: a g-fixed coloring is constant along the ⟨g⟩-action, c (h • x) = c x for h ∈ ⟨g⟩",
+      "cyc: the number of ⟨g⟩-orbits on X = Nat.card (orbitRel.Quotient (Subgroup.zpowers g) X)",
+      "fixedColoringEquiv: the key bijection {c // g • c = c} ≃ (⟨g⟩-orbit quotient → Fin k), built explicitly with Quotient.lift / Quotient.sound",
+      "card_fixedBy_eq_pow_cyc (A): Nat.card (fixedBy (X → Fin k) g) = k ^ cyc g for an arbitrary g in an arbitrary group",
+      "sum_pow_cyc_eq_card_orbits_mul_card (B): Σ_{g:G} k^cyc(g) = (#distinct colorings) · |G|, derived from (A) and Mathlib's Burnside identity"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The orbit-counting theorem — that the number of orbits of a finite group action equals the average number of fixed points (1/|G|)·Σ_g |Fix(g)| — is classically attributed to William Burnside (who stated it in his 1897 group theory text) but was known earlier to Cauchy (1845) and Frobenius (1887), hence 'Cauchy–Frobenius lemma'. Specialized to colorings of n objects under a permutation group, the fixed colorings of an element g are exactly those constant on the cycles of g, giving |Fix(g)| = k^{c(g)} where c(g) is the number of cycles. This is the unweighted core of Pólya's 1937 enumeration theorem. The parent gallery entry burnside-counting-oq-03 established the cyclic (necklace) case |Fix(rotation r)| = k^{gcd(r,n)}; this entry proves the statement for an arbitrary finite group acting on arbitrary positions.",
+    "problemStatement": "Let a finite group G act on a finite set X, and let colorings be functions c : X → Fin k with the action (g • c) x = c (g⁻¹ • x). Writing cyc(g) for the number of orbits of ⟨g⟩ on X, prove (A) |Fix(g)| = k^{cyc(g)} for every g ∈ G, and (B) Σ_{g∈G} k^{cyc(g)} = (#distinct colorings)·|G|, i.e. the number of distinct colorings up to the G-symmetry is (1/|G|)·Σ_g k^{cyc(g)}.",
+    "proofStrategy": "**(A) Per-element count.** A coloring c is fixed by g iff it is constant on each orbit of the cyclic subgroup ⟨g⟩ on X. Forward: if g • c = c then g lies in the stabilizer of c, a subgroup, so the whole of ⟨g⟩ = Subgroup.zpowers g lies in the stabilizer (Subgroup.zpowers_le); evaluating the resulting invariance gives c (h • x) = c x for every h ∈ ⟨g⟩, i.e. c is constant on ⟨g⟩-orbits. This yields an explicit bijection {c // g • c = c} ≃ (orbit-quotient → Fin k): the forward map is Quotient.lift c (well-defined because c is constant on orbits), the inverse pulls a function on the quotient back through Quotient.mk (automatically g-invariant, since g⁻¹ ∈ ⟨g⟩ keeps points in their orbit). Counting with Nat.card_fun gives |Fix(g)| = (Nat.card (Fin k))^{#orbits} = k^{cyc(g)}.\n\n**(B) Averaging.** Mathlib's Burnside identity MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group applied to the coloring action gives Σ_g |Fix(g)| = (#distinct colorings)·|G|. Substituting (A) for each term yields Σ_g k^{cyc(g)} = (#distinct colorings)·|G|.",
+    "keyInsights": [
+      "**Fixed by g ⟺ constant on ⟨g⟩-orbits.** The defining feature of the fixed colorings is invariance under the cyclic subgroup generated by g, not merely under g — captured cleanly by the stabilizer being a subgroup, so Subgroup.zpowers_le upgrades fixed-by-g to fixed-by-⟨g⟩ in one step.",
+      "**Counting via the orbit quotient.** Once colorings fixed by g are identified with functions on the ⟨g⟩-orbit quotient of X, the count is forced: a function on a finite quotient of size cyc(g) into Fin k is one of k^{cyc(g)} possibilities (Nat.card_fun).",
+      "**No cycle-index machinery needed for the unweighted case.** The weighted Pólya theorem (cycle-index polynomial, weighted generating functions) is genuinely missing from Mathlib, but the unweighted orbit-count is exactly Mathlib's Burnside identity plus the per-element evaluation k^{cyc(g)}, which this entry supplies.",
+      "**Self-contained left action.** The domain-permutation action (g • c) x = c (g⁻¹ • x) needs the inverse to satisfy mul_smul; it does not collide with Mathlib's Pi.mulAction because the codomain Fin k carries no G-action, so the orbit/fixedBy API applies directly to colorings."
+    ],
+    "prerequisites": [
+      "Group actions, orbits, stabilizers (MulAction)",
+      "Burnside's lemma (Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
+      "Cyclic subgroups Subgroup.zpowers and zpowers_le",
+      "Quotient by an equivalence relation (Quotient.lift, Quotient.sound)",
+      "Cardinality of function types (Nat.card_fun)"
+    ],
+    "what": "Burnside's orbit-counting formula, specialized to k-colorings of a finite set X under an arbitrary finite group G: each g fixes exactly k^{cyc(g)} colorings (cyc(g) = number of ⟨g⟩-orbits on X), and the number of distinct colorings is the average (1/|G|)·Σ_g k^{cyc(g)}.",
+    "how": "Prove the per-element count |Fix(g)| = k^{cyc(g)} by an explicit bijection between g-fixed colorings and functions on the ⟨g⟩-orbit quotient of X (a coloring is fixed by g iff constant on ⟨g⟩-orbits), then combine with Mathlib's Burnside identity to average over the group.",
+    "significance": "This is the group-agnostic master formula behind every concrete necklace/bracelet count in the gallery. The cyclic value k^{gcd(r,n)} (since cyc(rotation r) = gcd(r,n)) and the dihedral reflection counts k^{(n+1)/2}, k^{n/2+1}, k^{n/2} are all instances of k^{cyc(g)}, turning per-group ad-hoc computations into specializations of one theorem and supplying the bridge the parent entry asked for between the bespoke cyclic formalization and Mathlib's abstract MulAction orbit-counting API."
+  },
+  "conclusion": {
+    "summary": "Proves the unweighted Burnside / Cauchy–Frobenius orbit-counting theorem for k-colorings of a finite set under an arbitrary finite group: (A) the per-element fixed-point count |Fix(g)| = k^{cyc(g)} via an explicit bijection with functions on the ⟨g⟩-orbit quotient, and (B) the averaging form Σ_g k^{cyc(g)} = (#distinct colorings)·|G|. Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Generalizes the parent's cyclic necklace count to an arbitrary finite group acting on arbitrary positions, the honest tractable answer to the parent's open question 'generalize from cyclic groups to arbitrary finite groups'. It is the unweighted core on top of which a future weighted Pólya cycle-index development could be built, and it directly subsumes the cyclic and dihedral counts elsewhere in the gallery.",
+    "openQuestions": [
+      "Recover the cyclic specialization as a corollary: prove cyc(rotation r) = gcd(r, n) for the ZMod n rotation action, deriving the parent's k^{gcd(r,n)} from k^{cyc(g)}.",
+      "Recover the dihedral reflection counts k^{(n+1)/2}, k^{n/2+1}, k^{n/2} as instances of k^{cyc(g)} by computing the cycle count of each reflection.",
+      "Build the weighted Pólya cycle-index theorem: introduce the cycle-index monomial ∏ x_{cycle length} for each g and the weighted generating function obtained by the substitution x_i ↦ Σ_j w_j^i — the remaining genuinely missing Mathlib infrastructure."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq03-parent",
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "extends",
+      "description": "Answers the parent's open question to generalize the cyclic necklace orbit-count to an arbitrary finite group. The parent proves |Fix(rotation r)| = k^{gcd(r,n)} for the cyclic group; this entry proves |Fix(g)| = k^{cyc(g)} for every element of an arbitrary finite group, with the cyclic value the special case cyc(rotation r) = gcd(r,n)."
+    },
+    {
+      "id": "xref-burnside-root",
+      "targetId": "burnside-counting",
+      "relationship": "extends",
+      "description": "The root entry axiomatized concrete binary 4-necklace counts; this entry establishes the general orbit-counting identity Σ_g k^{cyc(g)} = (#orbits)·|G| from which such concrete counts follow as instances."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 159,
+    "path": "Proofs/BurnsideCountingOQ03OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the parent **burnside-counting-oq-03** (cyclic necklace count `|Fix(rotation r)| = k^gcd(r,n)`) to an **arbitrary finite group** — the honest, tractable answer to its open question *"generalize from cyclic groups to arbitrary finite groups: a general orbit-counting result for colorings."*

A finite group `G` acts on a finite set `X` of positions; colorings are `c : X → Fin k` with the domain-permutation action `(g • c) x = c (g⁻¹ • x)`. Writing `cyc g` for the number of orbits of the cyclic subgroup `⟨g⟩` on `X` (= number of cycles of `x ↦ g • x`):

- **(A) `card_fixedBy_eq_pow_cyc`** — `Nat.card (fixedBy (X → Fin k) g) = k ^ cyc g`.
  A coloring is fixed by `g` iff it is constant on each `⟨g⟩`-orbit, giving an explicit bijection `{c // g • c = c} ≃ (⟨g⟩-orbit quotient → Fin k)`; counting with `Nat.card_fun` yields `k ^ cyc g`.
- **(B) `sum_pow_cyc_eq_card_orbits_mul_card`** — `∑ g : G, k ^ cyc g = (#distinct colorings) · |G|`,
  from (A) and Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`. Equivalently `#orbits = (1/|G|) ∑_g k^cyc(g)`.

This is the group-agnostic master formula behind every concrete necklace/bracelet count in the gallery: the cyclic `k^gcd(r,n)` and the dihedral reflection counts are all instances of `k^cyc(g)`.

## Key construction

- `coloringAction`: the domain-permutation `MulAction G (X → Fin k)` (no clash with `Pi.mulAction` — `Fin k` carries no `G`-action).
- `zpowers_smul_eq_of_fixed` + `const_on_zpowers`: a `g`-fixed coloring is fixed by all of `⟨g⟩` (stabilizer is a subgroup ⊇ `Subgroup.zpowers g` via `zpowers_le`), hence constant on `⟨g⟩`-orbits.
- `fixedColoringEquiv`: the bijection, built with `Quotient.lift` / `Quotient.sound`.

## Scope

The **weighted Pólya cycle-index theorem** (cycle-index polynomial + weighted generating function) is deliberately out of scope — Mathlib has no cycle-index machinery. This entry proves the **unweighted** orbit-count, the genuine gallery gap and the core on which a future weighted development could build.

## Verification

- **0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.**
- `#print axioms` for both main theorems: `{propext, Classical.choice, Quot.sound}` only — no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`.
- 5 theorems/lemmas, 4 defs, 1 instance, 159 lines. Compiled against Mathlib (lean4 v4.26.0).

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)