### PR TITLE
Enrich Kummer carry count & zero-carry stratum (lucas-theorem-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01-oq-02/meta.json
@@ -4,8 +4,14 @@
   "title": "Kummer's carry count and the zero-carry stratum of Lucas/Fine",
   "description": "Strengthens the divisibility statement of Lucas' theorem (whether a prime p divides a binomial coefficient C(n,k)) to the full p-adic valuation. Kummer's theorem (1852) identifies ν_p(C(n,k)) — the exact power of p dividing C(n,k) — with the number of carries that occur when adding k and n−k in base p; Mathlib packages this as Nat.factorization_choose. This entry first proves Lucas' divisibility criterion, which is NOT a named Mathlib lemma: ¬ p ∣ C(n,k) ↔ every base-p digit of k is ≤ the corresponding digit of n (digit-dominance), with the dual p ∣ C(n,k) ↔ ∃ i, nᵢ < kᵢ. The criterion is derived from Mathlib's Lucas congruence Choose.choose_modEq_prod_range_choose_nat (C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) mod p): the prime divides the product iff it divides a single-digit factor C(nᵢ,kᵢ), and for a digit row nᵢ < p the only way p ∣ C(nᵢ,kᵢ) is the trivial vanishing kᵢ > nᵢ (since C(nᵢ,kᵢ) ∣ nᵢ! and p ∤ nᵢ!). Combining the Kummer valuation with this criterion yields the zero-carry stratum that unifies all three classical theorems: for k ≤ n, kummerCarries p n k = 0 ↔ (∀ i, kᵢ ≤ nᵢ) ↔ ¬ p ∣ C(n,k). Reading the three sides: no carries (Kummer) ⟺ digit dominance (Lucas) ⟺ survives mod p (Fine). Finally fineRow_eq_digitDominated rewrites Fine's surviving column set fineRow p n as exactly the digit-dominated columns, so the parent's Fine count ∏ᵢ(nᵢ+1) is literally the size of the zero-carry stratum. Verified with 0 axioms, 0 sorries, no native_decide (concrete row checks use kernel decide).",
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.LucasTheoremOQ01OQ01"],
-    "opens": ["Nat", "Finset"],
+    "imports": [
+      "Mathlib",
+      "Proofs.LucasTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
     "namespace": "LucasKummerCarries",
     "lineCount": 219,
     "axiomCount": 0,
@@ -15,7 +21,16 @@
     "sorries": 0
   },
   "overview": {
-    "text": "The parent Fine's-theorem entry counts how many entries of row n of Pascal's triangle survive mod p, but never says WHICH columns survive. That characterisation is Lucas' divisibility criterion: column k survives iff k is digit-dominated by n in base p. This entry proves the criterion from Mathlib's Lucas congruence, then upgrades the binary survives/dies dichotomy to the full p-adic valuation via Kummer's theorem, which reads ν_p(C(n,k)) off the carries of the base-p addition k + (n−k). The keystone is the zero-carry stratum: no carries ⟺ digit dominance ⟺ not divisible by p — a single biconditional fusing Kummer (1852), Lucas (1878), and Fine (1947). The parent's surviving set is then identified as exactly the carry-free columns."
+    "text": "The parent Fine's-theorem entry counts how many entries of row n of Pascal's triangle survive mod p, but never says WHICH columns survive. That characterisation is Lucas' divisibility criterion: column k survives iff k is digit-dominated by n in base p. This entry proves the criterion from Mathlib's Lucas congruence, then upgrades the binary survives/dies dichotomy to the full p-adic valuation via Kummer's theorem, which reads ν_p(C(n,k)) off the carries of the base-p addition k + (n−k). The keystone is the zero-carry stratum: no carries ⟺ digit dominance ⟺ not divisible by p — a single biconditional fusing Kummer (1852), Lucas (1878), and Fine (1947). The parent's surviving set is then identified as exactly the carry-free columns.",
+    "historicalContext": "Three nineteenth- and twentieth-century results describe the behaviour of binomial coefficients modulo a prime. Kummer (1852) found that the exact power of p dividing C(m+n, m) equals the number of carries when adding m and n in base p. Lucas (1878) gave the congruence C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) (mod p) over the base-p digits, with the corollary that p ∤ C(n,k) iff every digit of k is dominated by the corresponding digit of n. Fine (1947) counted the surviving entries in row n as ∏ᵢ(nᵢ+1). Granville's 1997 survey unified this circle of results. Mathlib has Kummer's valuation (Nat.factorization_choose) and the Lucas congruence, but not Lucas' divisibility criterion in digit-dominance form; this entry supplies it and shows all three theorems are facets of one zero-carry biconditional.",
+    "problemStatement": "Characterise WHICH columns of row n of Pascal's triangle survive mod p (the parent only counts how many), and upgrade that binary survives/dies fact to the full p-adic valuation. Concretely: (i) prove Lucas' divisibility criterion ¬ p ∣ C(n,k) ↔ ∀ i, kᵢ ≤ nᵢ; (ii) state Kummer's theorem ν_p(C(n,k)) = (carry count of k + (n−k) in base p); (iii) prove the zero-carry stratum kummerCarries p n k = 0 ↔ (∀ i, kᵢ ≤ nᵢ) ↔ ¬ p ∣ C(n,k) and identify the parent's Fine surviving set with it.",
+    "proofStrategy": "Single-digit step (not_dvd_choose_lt_iff): for a < p, C(a,b) ∣ a! and p ∤ a!, so p ∣ C(a,b) only via the trivial vanishing b > a; hence ¬ p ∣ C(a,b) ↔ b ≤ a. Lucas' criterion (dvd_choose_iff_exists_digit_lt): choose a with n,k < pᵃ, push the Lucas congruence C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) through Nat.Prime.dvd_finset_prod_iff and the single-digit step to get p ∣ C(n,k) ↔ ∃ i, nᵢ < kᵢ; negate for digit-dominance. Kummer (factorization_choose_eq_carries): instantiate Nat.factorization_choose at b = n+1. Zero-carry stratum: for k ≤ n, C(n,k) ≠ 0 gives ¬ p ∣ C(n,k) ↔ ν_p = 0 = kummerCarries (dvd_iff_one_le_factorization + omega); compose with the criterion. Fine recovery (fineRow_eq_digitDominated): rewrite the parent's filtered set column-by-column via the criterion.",
+    "keyInsights": [
+      "**A single biconditional fuses three classical theorems.** kummerCarries = 0 ⟺ digit dominance ⟺ ¬ p ∣ C(n,k) reads, left to right, as Kummer's carry count (1852), Lucas' digit criterion (1878), and Fine's survival (1947) — three independently discovered facts shown to be one statement.",
+      "**The first p rows contain no nontrivial multiples of p.** Because C(a,b) ∣ a! and p ∤ a! for a < p, the only way a prime divides a single-digit binomial is the trivial zero b > a. This is the atomic input that the Lucas congruence amplifies to all of Pascal's triangle.",
+      "**Carries, borrows, and divisibility are the same obstruction.** A carry in adding k + (n−k), a borrow in subtracting k from n, and a digit of k exceeding the matching digit of n are three descriptions of the single event that makes p divide C(n,k).",
+      "**Fine's count is the cardinality of an explicit set.** Identifying fineRow with the digit-dominated columns turns the abstract count ∏ᵢ(nᵢ+1) into the size of a concrete, carry-free stratum — exposing the per-column structure the parent's count alone hides."
+    ]
   },
   "meta": {
     "author": "Classical (Kummer 1852; Lucas 1878; Fine 1947; Granville 1997 survey). Lean formalization original",
@@ -86,23 +101,43 @@
   },
   "sections": [
     {
+      "id": "single-digit",
       "title": "The single-digit Lucas step (not_dvd_choose_lt_iff)",
+      "startLine": 67,
+      "endLine": 93,
+      "summary": "Within the first p rows of Pascal's triangle there are no nontrivial multiples of p: for a < p, every nonzero entry C(a,b) is coprime to p. The proof observes C(a,b) ∣ a! (from choose_mul_factorial_mul_factorial) and p ∤ a! (since a < p, via Nat.Prime.dvd_factorial). Hence p ∣ C(a,b) forces the trivial vanishing C(a,b) = 0, i.e. b > a, giving ¬ p ∣ C(a,b) ↔ b ≤ a.",
       "text": "Within the first p rows of Pascal's triangle there are no nontrivial multiples of p: for a < p, every nonzero entry C(a,b) is coprime to p. The proof observes C(a,b) ∣ a! (from choose_mul_factorial_mul_factorial) and p ∤ a! (since a < p, via Nat.Prime.dvd_factorial). Hence p ∣ C(a,b) forces the trivial vanishing C(a,b) = 0, i.e. b > a, giving ¬ p ∣ C(a,b) ↔ b ≤ a."
     },
     {
+      "id": "divisibility-criterion",
       "title": "Lucas' divisibility criterion (dvd_choose_iff_exists_digit_lt)",
+      "startLine": 95,
+      "endLine": 144,
+      "summary": "Choose a with n, k < pᵃ so all higher base-p digits vanish. Mathlib's Lucas congruence gives C(n,k) ≡ ∏_{i<a} C(nᵢ,kᵢ) (mod p), so p ∣ C(n,k) iff p divides the digit product. By Nat.Prime.dvd_finset_prod_iff this happens iff p ∣ C(nᵢ,kᵢ) for some i, and the single-digit step turns that into nᵢ < kᵢ. Digit positions i ≥ a contribute nothing since both digits are 0 there. Negating gives the digit-dominance form ¬ p ∣ C(n,k) ↔ ∀ i, kᵢ ≤ nᵢ.",
       "text": "Choose a with n, k < pᵃ so all higher base-p digits vanish. Mathlib's Lucas congruence gives C(n,k) ≡ ∏_{i<a} C(nᵢ,kᵢ) (mod p), so p ∣ C(n,k) iff p divides the digit product. By Nat.Prime.dvd_finset_prod_iff this happens iff p ∣ C(nᵢ,kᵢ) for some i, and the single-digit step turns that into nᵢ < kᵢ. Digit positions i ≥ a contribute nothing since both digits are 0 there. Negating gives the digit-dominance form ¬ p ∣ C(n,k) ↔ ∀ i, kᵢ ≤ nᵢ."
     },
     {
+      "id": "kummer-carries",
       "title": "Kummer's carry count (factorization_choose_eq_carries)",
+      "startLine": 146,
+      "endLine": 161,
+      "summary": "Define kummerCarries p n k as the number of positions i ≥ 1 at which the partial sums overflow pⁱ, i.e. p^i ≤ k % p^i + (n−k) % p^i. Kummer's theorem ν_p(C(n,k)) = kummerCarries p n k is Mathlib's Nat.factorization_choose instantiated at the bound b = n+1, which is admissible because log p n ≤ n.",
       "text": "Define kummerCarries p n k as the number of positions i ≥ 1 at which the partial sums overflow pⁱ, i.e. p^i ≤ k % p^i + (n−k) % p^i. Kummer's theorem ν_p(C(n,k)) = kummerCarries p n k is Mathlib's Nat.factorization_choose instantiated at the bound b = n+1, which is admissible because log p n ≤ n."
     },
     {
+      "id": "zero-carry-stratum",
       "title": "The zero-carry stratum (carries_eq_zero_iff_forall_digit_le)",
+      "startLine": 163,
+      "endLine": 177,
+      "summary": "For k ≤ n, C(n,k) ≠ 0, so p ∣ C(n,k) ↔ 1 ≤ ν_p(C(n,k)) = kummerCarries p n k. Therefore ¬ p ∣ C(n,k) ↔ kummerCarries p n k = 0. Composing with the divisibility criterion yields the central biconditional kummerCarries p n k = 0 ↔ ∀ i, kᵢ ≤ nᵢ: the base-p addition k + (n−k) is carry-free exactly when k is digit-dominated by n (equivalently, the subtraction n − k needs no borrow).",
       "text": "For k ≤ n, C(n,k) ≠ 0, so p ∣ C(n,k) ↔ 1 ≤ ν_p(C(n,k)) = kummerCarries p n k. Therefore ¬ p ∣ C(n,k) ↔ kummerCarries p n k = 0. Composing with the divisibility criterion yields the central biconditional kummerCarries p n k = 0 ↔ ∀ i, kᵢ ≤ nᵢ: the base-p addition k + (n−k) is carry-free exactly when k is digit-dominated by n (equivalently, the subtraction n − k needs no borrow)."
     },
     {
+      "id": "fine-recovery",
       "title": "Recovering Fine's count as the zero-carry stratum (fineRow_eq_digitDominated)",
+      "startLine": 179,
+      "endLine": 211,
+      "summary": "The parent's Fine surviving set fineRow p n = (range (n+1)).filter (fun k => ¬ p ∣ C(n,k)) is rewritten column-by-column as the digit-dominated columns {k ∈ range (n+1) | ∀ i, kᵢ ≤ nᵢ}. Thus Fine's count ∏ᵢ(nᵢ+1) is exactly the number of carry-free columns of row n — the size of the zero-carry stratum. Four kernel-`decide` examples instantiate the chain at p = 2.",
       "text": "The parent's Fine surviving set fineRow p n = (range (n+1)).filter (fun k => ¬ p ∣ C(n,k)) is rewritten column-by-column as the digit-dominated columns {k ∈ range (n+1) | ∀ i, kᵢ ≤ nᵢ}. Thus Fine's count ∏ᵢ(nᵢ+1) is exactly the number of carry-free columns of row n — the size of the zero-carry stratum. Four kernel-`decide` examples instantiate the chain at p = 2."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `lucas-theorem-oq-01-oq-01-oq-02` (Kummer's carry count and the zero-carry stratum of Lucas/Fine). Rich references/conclusion, but the overview was text-only, sections lacked line ranges, and there was no annotation layer.

## Quality improvements (quality 25 → ~98)
- **annotations.json (new, 8 annotations, resolver-aligned 8/8)** — mathContext/significance/relatedConcepts/prerequisites covering the overview, the single-digit Lucas step, Lucas' divisibility criterion, the digit-dominance form, Kummer's carry count, the zero-carry stratum (keystone biconditional), the Fine-count recovery, and the kernel-`decide` examples.
- **overview**: added `historicalContext` (Kummer 1852 / Lucas 1878 / Fine 1947 / Granville 1997), `problemStatement`, `proofStrategy`, and 4 `keyInsights` (was `text` only).
- **sections**: added `id`/`startLine`/`endLine`/`summary` to all 5 (were `title`/`text` only), giving full line-anchored coverage.

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 8, Misaligned: 0.
- `pnpm build` passes (tsc + vite).
- Axiom integrity preserved: verified / original / axiomCount 0 (uses `decide`, not `native_decide`; no Lean.ofReduceBool).