### PR TITLE
Enrich Erdős #191: Eliminating the tripleLog_unbounded Axiom (erdos-191-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-191-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-191-incomplete-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-erdos191inc-overview",
+    "proofId": "erdos-191-incomplete-01",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "context",
+    "title": "Retiring a non-deep axiom from Erdős #191",
+    "content": "The docstring explains the surgical goal: the parent erdos-191 entry formalizes a solved Ramsey-type problem and carries four axioms, but one of them — tripleLog_unbounded, that log(log(log n)) → ∞ — is elementary, not research-level. This file proves it axiom-free so the assumption count drops from 4 to 3. It is built standalone because Erdos191Problem.lean does not currently compile under the present Mathlib (missing rpow / Real.log_two_gt_d9 imports), so tripleLog is re-stated here, ready to drop in once that file is repaired.",
+    "mathContext": "Erdős #191: any 2-colouring of edges of $K_{\\{2,\\dots,n\\}}$ yields a monochromatic $X$ with $\\sum_{x\\in X}1/\\log x$ large; the tight scale is $\\Theta(\\log\\log\\log n)$ (Rödl 2003; Conlon–Fox–Sudakov 2013).",
+    "significance": "context",
+    "relatedConcepts": ["axiom elimination", "Ramsey theory", "Erdős problems", "asymptotic divergence"],
+    "prerequisites": ["filters / limits at infinity", "Erdős problem context"]
+  },
+  {
+    "id": "ann-erdos191inc-def",
+    "proofId": "erdos-191-incomplete-01",
+    "range": { "startLine": 37, "endLine": 39 },
+    "type": "definition",
+    "title": "tripleLog n = log(log(log n))",
+    "content": "tripleLog re-states the parent's triple-logarithm scale on the ℕ→ℝ cast: tripleLog n := Real.log (Real.log (Real.log n)). It is noncomputable because Real.log is. This is the natural growth scale appearing in the tight Conlon–Fox–Sudakov bounds for Erdős #191; the definition is kept identical to the parent's so the discharged axiom plugs back in verbatim.",
+    "mathContext": "$\\mathrm{tripleLog}(n) = \\log(\\log(\\log n))$, defined via the cast $n\\mapsto(n:\\mathbb{R})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["iterated logarithm", "Real.log", "growth scale"],
+    "prerequisites": ["real logarithm", "ℕ → ℝ coercion"]
+  },
+  {
+    "id": "ann-erdos191inc-tendsto",
+    "proofId": "erdos-191-incomplete-01",
+    "range": { "startLine": 41, "endLine": 49 },
+    "type": "insight",
+    "title": "Divergence composes: triple log → ∞",
+    "content": "tripleLog_tendsto_atTop is the mathematical core, in one line. The cast ℕ → ℝ tends to atTop (tendsto_natCast_atTop_atTop), and Real.log preserves atTop (Real.tendsto_log_atTop). Composing the log limit threefold over the cast — `Real.tendsto_log_atTop.comp (… .comp (… .comp hcast))` — gives Tendsto (log∘log∘log∘cast) atTop atTop, and `simpa [Function.comp_def, tripleLog]` rewrites the composition back to tripleLog. The structural point: because log maps atTop to atTop, *any* finite tower of logarithms still diverges, however slowly.",
+    "mathContext": "$\\mathrm{Tendsto}\\ \\log\\ \\mathrm{atTop}\\ \\mathrm{atTop}$ composed $3\\times$ over $\\mathrm{Tendsto}\\,(n\\mapsto n)\\,\\mathrm{atTop}\\,\\mathrm{atTop}$ gives $\\mathrm{Tendsto}\\,\\mathrm{tripleLog}\\,\\mathrm{atTop}\\,\\mathrm{atTop}$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto.comp", "Real.tendsto_log_atTop", "atTop filter", "function composition"],
+    "prerequisites": ["filters and Tendsto", "composition of limits"]
+  },
+  {
+    "id": "ann-erdos191inc-epsN",
+    "proofId": "erdos-191-incomplete-01",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "theorem",
+    "title": "From Tendsto to the ε–N axiom statement",
+    "content": "tripleLog_unbounded reproduces the parent's axiom verbatim: ∀ M, ∃ N, ∀ n ≥ N, tripleLog n > M. It is extracted from the filter statement: `tripleLog_tendsto_atTop.eventually (eventually_gt_atTop M)` says tripleLog n > M holds eventually along atTop, and `eventually_atTop` unpacks 'eventually' into the explicit ∃ N ∀ n ≥ N form. This shows the Tendsto … atTop formulation is strictly stronger than the quantifier form and discharges the axiom completely — reducing erdos-191 from 4 genuine assumptions to 3.",
+    "mathContext": "$\\mathrm{Tendsto}\\,f\\,\\mathrm{atTop}\\,\\mathrm{atTop} \\Rightarrow \\forall M,\\exists N,\\forall n\\ge N,\\ f(n)>M$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.eventually_atTop", "eventually_gt_atTop", "ε–N definition of divergence", "axiom discharge"],
+    "prerequisites": ["filter eventually", "unfolding atTop limits"]
+  }
+]

--- a/src/data/proofs/erdos-191-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-191-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos191Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos191Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos191Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos191Incomplete01Data: ProofData = {
+  proof: erdos191Incomplete01Proof,
+  annotations: erdos191Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-191-incomplete-01`.

## Gap addressed
Entry had **only meta.json** — no annotations.json — so the proof page rendered with no inline annotations.

## Added
- **annotations.json** with **4 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Overview — retiring a non-deep axiom from the Erdős #191 formalization
  2. `tripleLog` definition (log∘log∘log on the ℕ→ℝ cast)
  3. Divergence composes — `Real.tendsto_log_atTop` applied threefold
  4. `Tendsto … atTop` ⇒ the ε–N axiom statement (discharge: 4→3 assumptions)
- **index.ts** entry point.

## Verification
- JSON validates; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms / badge original. The meta correctly frames this as discharging *one* elementary axiom of erdos-191; the three deep Rödl / Conlon–Fox–Sudakov axioms remain.