### PR TITLE
Enrich Entropy additivity for independent sources (shannon-source-coding-wip-01)

### DIFF
--- a/src/data/proofs/shannon-source-coding-wip-01/annotations.json
+++ b/src/data/proofs/shannon-source-coding-wip-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "shannon-add-overview",
+    "proofId": "shannon-source-coding-wip-01",
+    "range": { "startLine": 3, "endLine": 32 },
+    "type": "concept",
+    "title": "The equality case of entropy subadditivity",
+    "content": "The docstring frames the result: the gallery's ShannonEntropy file proves subadditivity H(X,Y) ≤ H(X)+H(Y) for arbitrary joint distributions; this file proves the matching equality H(pX ⊗ pY) = H(pX)+H(pY) for an independent (product) source. Equality holds precisely when X and Y are independent — the exact boundary of subadditivity — and it is the source-coding fact that n i.i.d. symbols carry n·H bits, underlying the AEP and the rate H of Shannon's source coding theorem.",
+    "mathContext": "$H(p_X \\otimes p_Y) = H(p_X) + H(p_Y),\\qquad H(p) = \\sum_x \\mathrm{negMulLog}(p_x)$",
+    "significance": "key",
+    "relatedConcepts": ["Shannon entropy", "subadditivity", "independence", "source coding theorem", "entropy rate"],
+    "prerequisites": ["Shannon entropy", "product distributions", "information theory basics"]
+  },
+  {
+    "id": "shannon-add-def",
+    "proofId": "shannon-source-coding-wip-01",
+    "range": { "startLine": 40, "endLine": 41 },
+    "type": "definition",
+    "title": "Entropy in negMulLog form",
+    "content": "`entropy p = ∑ₓ negMulLog (p x)`, where `negMulLog t = −t·log t` (with the convention 0·log 0 = 0 built in). Working in negMulLog form rather than the literal −∑ p log p is what lets the proof apply Mathlib's `Real.negMulLog_mul` directly, avoiding any case split on zero probabilities.",
+    "mathContext": "$\\mathrm{entropy}(p) = \\sum_x \\mathrm{negMulLog}(p_x),\\quad \\mathrm{negMulLog}\\,t = -t\\log t$",
+    "significance": "supporting",
+    "relatedConcepts": ["negMulLog", "Shannon entropy", "0 log 0 = 0 convention"],
+    "prerequisites": ["finite sums", "Real.negMulLog"]
+  },
+  {
+    "id": "shannon-add-agreement",
+    "proofId": "shannon-source-coding-wip-01",
+    "range": { "startLine": 43, "endLine": 49 },
+    "type": "lemma",
+    "title": "Agreement with the standard definition",
+    "content": "`entropy_eq_neg_sum`: the negMulLog-form entropy equals the textbook `−∑ₓ p x · log (p x)`, valid for all p. The proof distributes the negation over the sum and rewrites each `negMulLog t = −t·log t` by `ring`. This bridges the working definition to the gallery's standard entropy so the additivity result is stated in the recognizable form.",
+    "mathContext": "$\\mathrm{entropy}(p) = -\\sum_x p_x \\log p_x$",
+    "significance": "supporting",
+    "relatedConcepts": ["definitional agreement", "sum_neg_distrib", "negMulLog"],
+    "prerequisites": ["Real.negMulLog", "finite-sum manipulation"]
+  },
+  {
+    "id": "shannon-add-prod",
+    "proofId": "shannon-source-coding-wip-01",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "theorem",
+    "title": "Additivity for independent sources",
+    "content": "`entropy_prod`: for a product distribution pXY(x,y) = pX(x)·pY(y) with ∑ pX = ∑ pY = 1, the entropy is exactly H(pX ⊗ pY) = H(pX) + H(pY). This is the headline — the equality case of subadditivity, holding precisely when the two sources are independent, and the quantitative statement that independent sources add their information content.",
+    "mathContext": "$\\sum_x p_X(x) = \\sum_y p_Y(y) = 1 \\;\\Rightarrow\\; H(p_X \\otimes p_Y) = H(p_X) + H(p_Y)$",
+    "significance": "critical",
+    "relatedConcepts": ["additivity", "product distribution", "independence", "joint entropy"],
+    "prerequisites": ["entropy definition", "normalized distributions"]
+  },
+  {
+    "id": "shannon-add-proof",
+    "proofId": "shannon-source-coding-wip-01",
+    "range": { "startLine": 62, "endLine": 70 },
+    "type": "tactic",
+    "title": "Linearize, then collapse the marginals",
+    "content": "The proof factors the sum over α × β into a double sum (`Fintype.sum_prod_type`), then applies `Real.negMulLog_mul` symbol-by-symbol: negMulLog(pX x · pY y) = pY y · negMulLog(pX x) + pX x · negMulLog(pY y). The inner `key` lemma sums over y: the first term collapses via ∑ pY = 1 to negMulLog(pX x), the second pulls out pX x times H(pY). Summing over x and using ∑ pX = 1 collapses the cross term to H(pY), leaving H(pX) + H(pY). Normalization (∑ = 1) is exactly where independence turns the subadditivity inequality into an equality.",
+    "mathContext": "$\\sum_y \\mathrm{negMulLog}(p_X(x) p_Y(y)) = \\mathrm{negMulLog}(p_X(x)) + p_X(x)\\,H(p_Y)$",
+    "significance": "key",
+    "relatedConcepts": ["Real.negMulLog_mul", "Fintype.sum_prod_type", "marginal collapse", "sum_mul / mul_sum"],
+    "prerequisites": ["double sums over products", "pulling constants through finite sums"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `shannon-source-coding-wip-01` (Entropy is Additive for Independent Sources: H(pX ⊗ pY) = H(pX) + H(pY)). Rich meta.json; gap was the annotation layer.

## Quality improvements (quality 37 → ~92)
- **annotations.json (new, 5 annotations, resolver-aligned 5/5)** — mathContext/significance/relatedConcepts/prerequisites covering: the equality-case-of-subadditivity framing, the negMulLog entropy definition, agreement with −∑ p log p (`entropy_eq_neg_sum`), the additivity theorem (`entropy_prod`), and the linearize-then-collapse proof (`Real.negMulLog_mul` + marginal collapse via ∑ = 1).

## Verification
- `npx tsx scripts/annotations/resolver.ts validate` → Valid: 5, Misaligned: 0.
- `pnpm build` passes (tsc + vite).
- Axiom integrity preserved: verified / original / axiomCount 0 (foundational axioms only).