### PR TITLE
research(combinations-formula-oq-06-oq-01): simplicial figurate tower as a single parametrized family [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CombinationsFigurateTower.lean
+++ b/proofs/Proofs/CombinationsFigurateTower.lean
@@ -1,0 +1,132 @@
+import Mathlib
+
+/-
+# The Simplicial Figurate-Number Tower as a Single Parametrized Family
+
+## Open Question (combinations-formula-oq-06, OQ-01)
+
+The parent entry `combinations-formula-oq-06` formalized the general hockey-stick
+identity `∑_{m ∈ Icc k n} C(m, k) = C(n+1, k+1)` and then *read off* its figurate
+consequences only at the first two rungs `k = 1` (triangular) and `k = 2` (tetrahedral)
+as separate hand-built theorems.  Its conclusion explicitly raises the question of
+whether the uniform statement specializes to arbitrary `k`-dimensional figurate numbers
+`C(n+k-1, k)`, "giving the full Pythagorean tower as a single parametrized family."
+
+## Contribution
+
+We package the *entire* simplicial ladder as one Lean object.  The `k`-dimensional
+figurate number is the multiset coefficient
+
+  `S(k, n) = C(n + k - 1, k) = multichoose n k`,
+
+so `S(1, n) = n` (linear), `S(2, n) = C(n+1, 2)` (triangular),
+`S(3, n) = C(n+2, 3)` (tetrahedral), and so on up the dimensional ladder.  We prove,
+*uniformly in the dimension* `k`:
+
+1. `S_succ_succ`   — the Pascal-type recurrence `S(k+1, n+1) = S(k+1, n) + S(k, n+1)`,
+   the single recurrence that drives the whole family.
+2. `sum_Icc_S`     — the **tower identity** `∑_{m=1}^{n} S(k, m) = S(k+1, n)`: each
+   dimension is the running total of the one beneath it.  The induction step is *exactly*
+   the recurrence (1), so the proof is the same one line for every `k`.
+3. `sum_Icc_S_pred`— the classical figurate restatement `∑_{m=1}^{n} S(k-1, m) = S(k, n)`
+   for `k ≥ 1` (the triangular → tetrahedral → pentatope → … stacking of antiquity).
+4. `S_one`, `S_two`, `S_three` — the `k = 1, 2, 3` slices recover the natural, triangular,
+   and tetrahedral numbers, subsuming the parent's hand-built instances; `S_two_closed`
+   recovers the closed form `n(n+1)/2`.
+5. `sum_triangular`, `sum_tetrahedral` — the parent's `triangular` and `tetrahedral`
+   tower steps fall out as the `k = 1` and `k = 2` cases of the single theorem (2).
+
+## Mathematical Context
+
+The whole development rests on `Nat.multichoose` and its Pascal recurrence
+`Nat.multichoose_succ_succ`.  Reading that recurrence as a statement about partial sums
+gives the figurate recurrences `T_n = T_{n-1} + n`, `Te_n = Te_{n-1} + T_n`, … all at
+once — which is precisely why a *single* induction, parametrized by the dimension `k`,
+covers every column of Pascal's triangle simultaneously.  The bridge to binomial form is
+`Nat.multichoose_eq : multichoose n k = C(n + k - 1, k)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFigurateTower
+
+open Finset
+
+/-- The `k`-dimensional simplicial (figurate) number,
+    `S(k, n) = C(n + k - 1, k) = multichoose n k`.  The index `k` is the "dimension":
+    `k = 1` counts points on a line, `k = 2` triangles, `k = 3` tetrahedra, and so on. -/
+def S (k n : ℕ) : ℕ := Nat.multichoose n k
+
+theorem S_def (k n : ℕ) : S k n = Nat.multichoose n k := rfl
+
+/-- `S(k, n)` in pure binomial form: the multiset coefficient `C(n + k - 1, k)`. -/
+theorem S_eq_choose (k n : ℕ) : S k n = Nat.choose (n + k - 1) k := by
+  rw [S_def, Nat.multichoose_eq]
+
+/-- **Pascal-type recurrence.**  Each figurate number is its predecessor in the same
+    dimension plus the figurate number one dimension down:
+    `S(k+1, n+1) = S(k+1, n) + S(k, n+1)`.  This single recurrence drives the entire
+    simplicial family. -/
+theorem S_succ_succ (k n : ℕ) : S (k + 1) (n + 1) = S (k + 1) n + S k (n + 1) := by
+  simp only [S_def]
+  rw [Nat.multichoose_succ_succ]
+
+/-- **The figurate tower (parametrized form).**  Uniformly in the dimension `k`, each
+    layer is the running total of the layer below it: `∑_{m=1}^{n} S(k, m) = S(k+1, n)`.
+    The induction step is exactly the recurrence `S_succ_succ`, so one proof serves every
+    dimension at once. -/
+theorem sum_Icc_S (k n : ℕ) :
+    ∑ m ∈ Finset.Icc 1 n, S k m = S (k + 1) n := by
+  induction n with
+  | zero => simp [S]
+  | succ n ih =>
+      rw [Finset.sum_Icc_succ_top (show (1 : ℕ) ≤ n + 1 by omega), ih, S_succ_succ]
+
+/-- **The figurate tower (classical figurate form).**  For `k ≥ 1`, the `k`-dimensional
+    figurate numbers are the running totals of the `(k-1)`-dimensional ones:
+    `∑_{m=1}^{n} S(k-1, m) = S(k, n)`.  With `k ≥ 2` this is the
+    triangular → tetrahedral → pentatope → … stacking of antiquity. -/
+theorem sum_Icc_S_pred (k n : ℕ) (hk : 1 ≤ k) :
+    ∑ m ∈ Finset.Icc 1 n, S (k - 1) m = S k n := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, (Nat.succ_pred_eq_of_pos hk).symm⟩
+  simpa using sum_Icc_S j n
+
+/-- `S(1, n) = n`: the linear (counting) numbers. -/
+@[simp] theorem S_one (n : ℕ) : S 1 n = n := Nat.multichoose_one_right n
+
+/-- `S(2, n) = C(n+1, 2)`: the triangular numbers. -/
+theorem S_two (n : ℕ) : S 2 n = Nat.choose (n + 1) 2 := by
+  rw [S_eq_choose, show n + 2 - 1 = n + 1 by omega]
+
+/-- `S(3, n) = C(n+2, 3)`: the tetrahedral numbers. -/
+theorem S_three (n : ℕ) : S 3 n = Nat.choose (n + 2) 3 := by
+  rw [S_eq_choose, show n + 3 - 1 = n + 2 by omega]
+
+/-- The triangular number `S(2, n) = C(n+1, 2)` in its familiar closed form `n(n+1)/2`,
+    recovering the parent's `triangular_closed_form`. -/
+theorem S_two_closed (n : ℕ) : S 2 n = n * (n + 1) / 2 := by
+  rw [S_two, Nat.choose_two_right, Nat.add_sub_cancel, Nat.mul_comm]
+
+/-- Recovers the parent's triangular identity as the `k = 1` case of the tower:
+    the running total of `1, 2, …, n` is the triangular number `C(n+1, 2)`. -/
+theorem sum_triangular (n : ℕ) :
+    ∑ m ∈ Finset.Icc 1 n, m = Nat.choose (n + 1) 2 := by
+  simpa [S_two] using sum_Icc_S 1 n
+
+/-- Recovers the parent's tetrahedral tower as the `k = 2` case of the tower:
+    the running total of the triangular numbers `T_m = C(m+1, 2)` is the tetrahedral
+    number `C(n+2, 3)`. -/
+theorem sum_tetrahedral (n : ℕ) :
+    ∑ m ∈ Finset.Icc 1 n, Nat.choose (m + 1) 2 = Nat.choose (n + 2) 3 := by
+  simpa [S_two, S_three] using sum_Icc_S 2 n
+
+-- Concrete verifications.  (`multichoose` is compiled by well-founded recursion, so we
+-- route these through the binomial form, which the kernel `decide` can evaluate.)
+/-- Tetrahedral number `S(3, 4) = C(6, 3) = 20`. -/
+example : S 3 4 = 20 := by rw [S_three]; decide
+/-- The tower at `k = 2`: `T_1 + T_2 + T_3 + T_4 = 1 + 3 + 6 + 10 = 20 = S(3, 4)`. -/
+example : ∑ m ∈ Finset.Icc 1 4, S 2 m = S 3 4 := by simp only [S_two, S_three]; decide
+/-- The Pascal recurrence numerically: `S(3, 5) = S(3, 4) + S(2, 5) = 20 + 15 = 35`. -/
+example : S 3 5 = S 3 4 + S 2 5 := by simp only [S_three, S_two]; decide
+
+end CombinationsFigurateTower

--- a/src/data/proofs/combinations-formula-oq-06-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "combinations-formula-oq-06-oq-01",
+  "title": "The Simplicial Figurate-Number Tower as a Single Parametrized Family",
+  "slug": "combinations-formula-oq-06-oq-01",
+  "description": "Packages the entire simplicial figurate-number hierarchy as one Lean object S(k,n) = C(n+k-1,k) = multichoose n k, parametrized by the dimension k. Proves, uniformly in k: the Pascal-type recurrence S(k+1,n+1) = S(k+1,n) + S(k,n+1); the tower identity ∑_{m=1}^{n} S(k,m) = S(k+1,n) (each dimension is the running total of the one beneath it); and the classical figurate restatement ∑_{m=1}^{n} S(k-1,m) = S(k,n) for k ≥ 1. The k = 1,2,3 slices recover the natural, triangular, and tetrahedral numbers, subsuming the parent entry's hand-built instances. Answers the parent open question oq-06[0] verbatim.",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFigurateTower.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "assumptions": "None. All identities hold for every natural number n and every dimension k and are fully machine-checked. #print axioms reports only the foundational axioms propext, Classical.choice, Quot.sound; the concrete checks use kernel `decide`, not `native_decide`, so there is no Lean.ofReduceBool dependency.",
+    "tags": [
+      "combinatorics",
+      "hockey-stick-identity",
+      "binomial-coefficients",
+      "figurate-numbers",
+      "simplicial-numbers",
+      "multiset-coefficients",
+      "triangular-numbers",
+      "tetrahedral-numbers",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-24",
+    "originalContributions": [
+      "S: the k-dimensional simplicial figurate number defined as the multiset coefficient S(k,n) = multichoose n k = C(n+k-1,k), unifying the natural (k=1), triangular (k=2), tetrahedral (k=3), pentatope (k=4), and all higher figurate sequences as one parametrized family — the object the parent entry's open question asked for",
+      "sum_Icc_S: the figurate tower ∑_{m∈Icc 1 n} S(k,m) = S(k+1,n) proved uniformly in the dimension k by a single induction on n whose step is exactly the Pascal recurrence, so one proof serves every column of Pascal's triangle at once (the parent only handled k=1,2 by hand)",
+      "S_succ_succ: the Pascal-type recurrence S(k+1,n+1) = S(k+1,n) + S(k,n+1), the single recurrence driving the whole simplicial family, read off Nat.multichoose_succ_succ",
+      "sum_Icc_S_pred: the classical figurate restatement ∑_{m∈Icc 1 n} S(k-1,m) = S(k,n) for k ≥ 1 (the triangular→tetrahedral→pentatope→… stacking of antiquity), obtained from the parametrized tower by an index decomposition k = (k-1)+1",
+      "S_one / S_two / S_three / S_two_closed: the k=1,2,3 slices recovering the natural numbers, the triangular numbers C(n+1,2)=n(n+1)/2, and the tetrahedral numbers C(n+2,3), subsuming the parent's triangular_eq_choose / triangular_closed_form / tetrahedral_eq_choose; and sum_triangular / sum_tetrahedral exhibiting the parent's two tower steps as the k=1 and k=2 instances of the single theorem sum_Icc_S"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFigurateTower.lean",
+    "namespace": "CombinationsFigurateTower",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 132,
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Figurate numbers — points arranged in geometric shapes of increasing dimension — were studied systematically by the Pythagoreans and by Nicomachus of Gerasa (c. 100 AD): the natural numbers count points on a line, triangular numbers count points in a triangle, tetrahedral numbers count points in a tetrahedron, and so on up the simplicial ladder. The classical fact, recorded since antiquity, is that each shape's count is the running total of the shape one dimension down. In Pascal's triangle these are exactly the columns, linked by the hockey-stick identity. The parent entry combinations-formula-oq-06 formalized the hockey-stick identity for a general column index but read off only the first two figurate rungs by hand; its open question asked whether the whole tower could be captured as a single Lean theorem parametrized by the dimension. This entry answers that question.",
+    "problemStatement": "Parent open question (combinations-formula-oq-06, OQ index 0): does the uniform hockey-stick statement admit a clean Lean specialization to arbitrary simplicial (k-dimensional figurate) numbers C(n+k-1,k), giving the full Pythagorean tower as a single parametrized family? Concretely: define S(k,n) = C(n+k-1,k) = multichoose n k and prove, uniformly in k, the tower identity ∑_{m=1}^{n} S(k-1,m) = S(k,n) and the Pascal recurrence S(k,n) = S(k,n-1) + S(k-1,n), with the k=1,2,3 instances reproducing the natural, triangular, and tetrahedral numbers.",
+    "proofStrategy": "Take the figurate object directly from Mathlib's multiset coefficient: define S(k,n) := Nat.multichoose n k, so S(k,n) = C(n+k-1,k) by Nat.multichoose_eq. The driver is Nat.multichoose_succ_succ, which is precisely the Pascal recurrence S(k+1,n+1) = S(k+1,n) + S(k,n+1). The tower ∑_{m∈Icc 1 n} S(k,m) = S(k+1,n) is then proved by induction on n: the empty base case is multichoose 0 (k+1) = 0, and the successor step splits the interval sum with Finset.sum_Icc_succ_top and closes with the induction hypothesis followed by the recurrence — a single line that works for every dimension k simultaneously. The classical k-1 form follows by the decomposition k = (k-1)+1 for k ≥ 1. The figurate instances come from multichoose_one_right (k=1) and multichoose_eq plus an index simplification (k=2,3), with the triangular closed form n(n+1)/2 from Nat.choose_two_right; the parent's triangular and tetrahedral tower steps reappear as the k=1 and k=2 specializations of the one theorem.",
+    "keyInsights": [
+      "Choosing the multiset coefficient multichoose n k (rather than a raw binomial with a subtraction n+k-1) as the family object is what makes the proof uniform: its built-in Pascal recurrence multichoose_succ_succ is the figurate recurrence, so the dimension k never needs case analysis and truncated ℕ-subtraction is confined to the cosmetic binomial restatement.",
+      "The induction step of the tower identity is literally the recurrence — ∑_{Icc 1 (n+1)} = ∑_{Icc 1 n} + S(k,n+1) = S(k+1,n) + S(k,n+1) = S(k+1,n+1) — so a single induction on n proves the statement for all dimensions at once, replacing the parent's separate hand-built k=1 and k=2 derivations.",
+      "Reading the one identity ∑_{m=1}^{n} S(k-1,m) = S(k,n) down the ladder gives the figurate recurrences T_n = T_{n-1} + n and Te_n = Te_{n-1} + T_n as the k=2 and k=3 instances, making explicit that 'each figurate layer is the partial-sum sequence of the one below it' is a single parametrized theorem rather than a family of coincidences.",
+      "The empty-interval base case is mathematically meaningful: multichoose 0 (k+1) = C(k,k+1) = 0 says the (k+1)-dimensional figurate number at index 0 vanishes, which is exactly what makes the running-total recursion start correctly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Header stating the parent open question (combinations-formula-oq-06 OQ-0) and how this entry packages the whole simplicial figurate hierarchy S(k,n) = C(n+k-1,k) = multichoose n k as one parametrized family driven by the Pascal recurrence multichoose_succ_succ."
+    },
+    {
+      "id": "definition",
+      "title": "The Simplicial Figurate Number",
+      "startLine": 55,
+      "endLine": 64,
+      "summary": "def S (k n) := Nat.multichoose n k, the k-dimensional figurate number, with S_eq_choose : S(k,n) = C(n+k-1,k) bridging to the binomial form via Nat.multichoose_eq."
+    },
+    {
+      "id": "recurrence",
+      "title": "Pascal-Type Recurrence",
+      "startLine": 66,
+      "endLine": 73,
+      "summary": "S_succ_succ : S(k+1,n+1) = S(k+1,n) + S(k,n+1), the single recurrence driving the whole family, obtained directly from Nat.multichoose_succ_succ."
+    },
+    {
+      "id": "tower",
+      "title": "The Figurate Tower (Parametrized Form)",
+      "startLine": 74,
+      "endLine": 83,
+      "summary": "sum_Icc_S : ∑_{m∈Icc 1 n} S(k,m) = S(k+1,n), proved by induction on n with Finset.sum_Icc_succ_top; the induction step is exactly S_succ_succ, so one proof covers every dimension k."
+    },
+    {
+      "id": "tower-pred",
+      "title": "The Figurate Tower (Classical Form)",
+      "startLine": 85,
+      "endLine": 92,
+      "summary": "sum_Icc_S_pred : for k ≥ 1, ∑_{m∈Icc 1 n} S(k-1,m) = S(k,n) — the triangular→tetrahedral→pentatope stacking of antiquity, derived from the parametrized tower by the decomposition k = (k-1)+1."
+    },
+    {
+      "id": "instances",
+      "title": "Figurate Instances (k = 1, 2, 3)",
+      "startLine": 94,
+      "endLine": 108,
+      "summary": "S_one : S(1,n)=n (natural numbers); S_two : S(2,n)=C(n+1,2) (triangular); S_three : S(3,n)=C(n+2,3) (tetrahedral); S_two_closed : S(2,n)=n(n+1)/2 via Nat.choose_two_right — subsuming the parent's hand-built instances."
+    },
+    {
+      "id": "parent-recovery",
+      "title": "Recovering the Parent's Tower Steps",
+      "startLine": 110,
+      "endLine": 121,
+      "summary": "sum_triangular : ∑_{m∈Icc 1 n} m = C(n+1,2) and sum_tetrahedral : ∑_{m∈Icc 1 n} C(m+1,2) = C(n+2,3), exhibiting the parent's two separate tower steps as the k=1 and k=2 specializations of the single theorem sum_Icc_S."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 123,
+      "endLine": 132,
+      "summary": "Concrete checks via kernel decide (routed through the binomial form, since multichoose is compiled by well-founded recursion): S(3,4)=C(6,3)=20; the tower T_1+T_2+T_3+T_4=20=S(3,4); and the recurrence S(3,5)=S(3,4)+S(2,5)=35."
+    }
+  ],
+  "conclusion": {
+    "summary": "11 theorems, 1 definition, 0 sorries, 0 axioms. The simplicial figurate-number hierarchy is captured as a single Lean object S(k,n) = C(n+k-1,k) = multichoose n k. Proved uniformly in the dimension k: the Pascal recurrence S(k+1,n+1) = S(k+1,n) + S(k,n+1), the tower identity ∑_{m=1}^{n} S(k,m) = S(k+1,n) (and its classical k-1 form), and the k=1,2,3 instances recovering the natural, triangular C(n+1,2)=n(n+1)/2, and tetrahedral C(n+2,3) numbers. The parent's hand-built triangular and tetrahedral tower steps reappear as the k=1 and k=2 cases of the one theorem.",
+    "implications": "Treating the dimension k as a free parameter on the multiset coefficient turns a sequence of ad-hoc figurate identities into one structural theorem about the simplicial hierarchy, connecting Pascal's triangle, multichoose, and the figurate numbers of antiquity into a single Lean object. Because the family object carries its own Pascal recurrence, the induction step is dimension-independent — a reusable template for 'diagonal-of-Pascal as a partial-sum sequence' reasoning that needs no per-column case analysis.",
+    "openQuestions": [
+      "Can the higher closed forms (tetrahedral n(n+1)(n+2)/6, pentatope n(n+1)(n+2)(n+3)/24, and in general the rising-factorial form C(n+k-1,k) = (∏_{i<k}(n+i))/k!) be derived inside Lean uniformly in k from the recurrence S_succ_succ, rather than instance-by-instance — closing the parent's second open question for the whole family at once?",
+      "Does the tower identity extend to a generating-function statement, e.g. ∑_n S(k,n) x^n = x/(1-x)^{k+1}, giving the simplicial columns as coefficients of a single rational generating function parametrized by the dimension k?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-06",
+      "relationship": "parent — formalized the hockey-stick identity and the k=1,2 figurate instances by hand; this entry answers its open question by packaging the whole tower as one parametrized family and subsuming those instances"
+    },
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "sibling — proves the shifted hockey-stick form ∑ C(i+r,r) = C(n+r+1,r+1); this entry gives the multichoose-indexed simplicial family instead"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+      "relationship": "complementary — the closed-form / rising-factorial side C(n+k-1,k)·k! = ascFactorial on the same multichoose object"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **combinations-formula-oq-06**'s open question (index 0) verbatim: *"does the uniform hockey-stick statement admit a clean Lean specialization to arbitrary simplicial (k-dimensional figurate) numbers C(n+k-1,k), giving the full Pythagorean tower as a single parametrized family?"*

The parent formalized the hockey-stick identity and read off only the first two figurate rungs (k=1 triangular, k=2 tetrahedral) **by hand**. This entry packages the **entire** simplicial hierarchy as one Lean object parametrized by the dimension k:

```
S(k, n) = C(n + k - 1, k) = Nat.multichoose n k
```

## Results (all uniform in the dimension k)

| Theorem | Statement |
|---------|-----------|
| `S_succ_succ` | Pascal recurrence `S(k+1,n+1) = S(k+1,n) + S(k,n+1)` |
| `sum_Icc_S` | **Tower identity** `∑_{m=1}^{n} S(k,m) = S(k+1,n)` — one induction, every dimension |
| `sum_Icc_S_pred` | Classical form `∑_{m=1}^{n} S(k-1,m) = S(k,n)` for `k ≥ 1` |
| `S_one`/`S_two`/`S_three` | k=1,2,3 recover natural, triangular `C(n+1,2)`, tetrahedral `C(n+2,3)` |
| `S_two_closed` | triangular closed form `n(n+1)/2` |
| `sum_triangular`/`sum_tetrahedral` | parent's two tower steps as the k=1, k=2 instances |

**Key idea:** taking the family object to be Mathlib's multiset coefficient `multichoose` makes the induction step *exactly* its built-in recurrence `Nat.multichoose_succ_succ`, so a single induction on n proves the tower for **all** dimensions k at once — no per-column case analysis, and truncated ℕ-subtraction stays confined to the cosmetic binomial restatement.

## Verification

- **11 theorems, 1 definition, 132 lines, 0 sorries, 0 axioms.**
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`. Concrete checks use **kernel `decide`** (not `native_decide`), so there is **no `Lean.ofReduceBool`** dependency.
- Compiled with `lake env lean Proofs/CombinationsFigurateTower.lean` (single-file host compile; docker daemon was down this cycle).

Status: `verified` / badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)