### PR TITLE
Enrich Erdős #305: Egyptian-Representation Existence (erdos-305-incomplete-01)

### DIFF
--- a/src/data/proofs/erdos-305-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-305-incomplete-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos305-overview",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Existence of Egyptian fractions is a theorem, not an axiom",
+    "content": "The docstring states the surgical goal: the parent Erdős #305 entry asserts `axiom egyptian_representation_exists` — that every proper fraction a/b has an Egyptian-fraction representation — but this is the classical Fibonacci–Sylvester greedy theorem and needs no axiom. This file proves it from scratch, discharging that one assumption. It is explicit about scope: the genuinely hard part of #305, the asymptotic bound D(b) ≪ b(log b)^{1+o(1)} (Yokota 1988 / Liu–Sawhney 2024), remains a sorry in the parent and is untouched here.",
+    "mathContext": "Egyptian fraction: $\\tfrac{a}{b} = \\sum_{n\\in S}\\tfrac1n$ with distinct positive $n$. Existence for all $0<a<b$ is Fibonacci–Sylvester (greedy); Erdős #305 concerns the size of the largest denominator $D(b)$.",
+    "significance": "context",
+    "relatedConcepts": ["Egyptian fractions", "Fibonacci–Sylvester greedy algorithm", "Erdős problems", "axiom elimination"],
+    "prerequisites": ["unit fractions", "strong induction"]
+  },
+  {
+    "id": "ann-erdos305-defs",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 41, "endLine": 54 },
+    "type": "definition",
+    "title": "Egyptian-fraction support, sum, and representation",
+    "content": "Three definitions set the stage. isEgyptianFraction S requires every denominator ≥ 1 (distinctness is automatic because S is a Finset — a key modelling choice that avoids a separate injectivity hypothesis). unitFractionSum S = ∑_{n∈S} 1/n as a rational, with an `if n = 0` guard keeping it total (never triggered on valid supports). isEgyptianRepresentation S a b bundles a < b, b > 0, positivity of denominators, and the sum condition ∑ 1/n = a/b.",
+    "mathContext": "$\\mathrm{unitFractionSum}(S) = \\sum_{n\\in S}\\tfrac1n\\in\\mathbb{Q}$; $S$ represents $a/b$ iff $a<b$, $b>0$, all $n\\ge1$, and the sum equals $a/b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset", "distinct denominators", "rational sum", "total function guard"],
+    "prerequisites": ["Finset.sum", "rational arithmetic"]
+  },
+  {
+    "id": "ann-erdos305-greedy-setup",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 56, "endLine": 80 },
+    "type": "insight",
+    "title": "The greedy step: n = ⌈b/a⌉ and the ceiling estimates",
+    "content": "exists_egyptian_aux is the strengthened existence lemma, proved by strong induction on the numerator a. The strengthening — every denominator is ≥ the greedy choice n = ⌈b/a⌉ = (b+a−1)/a — is precisely what later forces a freshly inserted denominator to be new. The setup derives the two-sided ceiling estimate b ≤ a·n ≤ b+a−1 from Nat.div_add_mod and the mod bound, all discharged by omega. From a·n < b+a it follows that the new numerator a' = a·n − b satisfies a' < a, so the induction descends.",
+    "mathContext": "$n=\\lceil b/a\\rceil=(b+a-1)/a$ gives $b\\le an\\le b+a-1$, so $a' := an-b < a$ and $1/n$ is the greedy unit fraction $\\le a/b$.",
+    "significance": "key",
+    "relatedConcepts": ["greedy algorithm", "ceiling function", "Nat.div_add_mod", "induction strengthening", "omega"],
+    "prerequisites": ["integer division and ceilings", "strong induction on ℕ"]
+  },
+  {
+    "id": "ann-erdos305-basecase",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 81, "endLine": 93 },
+    "type": "technique",
+    "title": "Base case: a·n = b gives a/b = 1/n exactly",
+    "content": "When the new numerator a' = a·n − b is zero, the greedy fraction is exact: a·n = b means a/b = 1/n, so the singleton {n} represents a/b. The sum is evaluated by sum_singleton and the `if_neg` discharging the n = 0 guard, then field_simp closes a/b = 1/n using a·n = b. This is the recursion's terminating case.",
+    "mathContext": "If $an=b$ then $\\tfrac{a}{b}=\\tfrac{a}{an}=\\tfrac1n$; the support is the singleton $\\{n\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["base case", "Finset.sum_singleton", "field_simp", "exact greedy hit"],
+    "prerequisites": ["singleton sums", "rational simplification"]
+  },
+  {
+    "id": "ann-erdos305-recursion",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 94, "endLine": 134 },
+    "type": "insight",
+    "title": "Recursive step: distinctness via strictly increasing denominators",
+    "content": "When 0 < a' < a, the lemma recurses on a'/(b·n), obtaining a support S' all of whose denominators are ≥ the next greedy denominator q = ⌈(b·n)/a'⌉. The crux hgt shows every m ∈ S' strictly exceeds n: from a'·q ≥ b·n and a'·n < b·n (as a' < b, n > 0) one gets a'·n < a'·q, hence n < q ≤ m. Therefore n ∉ S', so `insert n S'` is genuinely larger — distinctness comes for free from the Finset plus this strict inequality. The sum identity a/b = 1/n + a'/(b·n) is closed by field_simp + ring after casting a' = a·n − b over ℚ.",
+    "mathContext": "Recurse on $\\tfrac{a'}{bn}$ with $a'=an-b$. New denominators $> n$ (since $\\lceil bn/a'\\rceil > n$), so $n\\notin S'$ and $\\tfrac{a}{b}=\\tfrac1n+\\tfrac{a'}{bn}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.insert", "strictly increasing denominators", "Nat.lt_of_mul_lt_mul_left", "telescoping unit fractions"],
+    "prerequisites": ["monotonicity of multiplication", "rational identities", "field_simp / ring"]
+  },
+  {
+    "id": "ann-erdos305-discharge",
+    "proofId": "erdos-305-incomplete-01",
+    "range": { "startLine": 136, "endLine": 149 },
+    "type": "theorem",
+    "title": "Discharging the axiom",
+    "content": "egyptian_representation_exists is the exact statement that was `axiom` in the parent file, now a theorem. It unwraps the strengthened auxiliary lemma and repackages it as an isEgyptianRepresentation: a < b and b > 0 are immediate, the sum condition is inherited, and positivity of every denominator follows since each is ≥ (b+a−1)/a ≥ 1. With this, the Erdős #305 development loses one of its assumptions, leaving only the genuinely deep asymptotic bound as an open sorry.",
+    "mathContext": "$\\forall a,b,\\ 0<a<b \\Rightarrow \\exists S,\\ \\mathrm{isEgyptianRepresentation}\\,S\\,a\\,b$ — the former axiom, derived from $\\mathrm{exists\\_egyptian\\_aux}$.",
+    "significance": "key",
+    "relatedConcepts": ["axiom discharge", "Erdős #305", "Egyptian representation", "assumption reduction"],
+    "prerequisites": ["the auxiliary existence lemma", "Nat.le_div_iff_mul_le"]
+  }
+]

--- a/src/data/proofs/erdos-305-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-305-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos305EgyptianExists.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos305EgyptianExistsProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos305EgyptianExistsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos305EgyptianExistsData: ProofData = {
+  proof: erdos305EgyptianExistsProof,
+  annotations: erdos305EgyptianExistsAnnotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-305-incomplete-01`.

## Gap addressed
Entry had **only meta.json** — no annotations.json — so the proof page rendered with no inline annotations.

## Added
- **annotations.json** with **6 annotations** (overview, the three Egyptian-fraction definitions, the greedy step n=⌈b/a⌉ with its ceiling estimates, the exact base case a·n=b, the recursive step proving distinctness via strictly increasing denominators, and the axiom discharge), each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts** entry point.

## Verification
- JSON validates; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms / badge original. The meta correctly frames this as discharging the elementary Fibonacci–Sylvester existence axiom of Erdős #305; the deep asymptotic bound (Yokota / Liu–Sawhney) remains an untouched sorry in the parent.