### PR TITLE
research(kummer-theorem-oq-04-oq-01-oq-01): C(2n,n) divisible by exactly 4 ⟺ n has two 1-bits [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ04OQ01OQ01.lean
@@ -1,0 +1,163 @@
+import Mathlib
+import Proofs.KummerTheoremOQ04OQ01
+
+/-
+# Central binomial coefficients divisible by exactly four ⟺ `n` has two `1`-bits
+
+By Kummer's theorem the exact power of two dividing the central binomial
+coefficient `C(2n, n)` equals the binary digit sum (popcount) `s₂(n)`
+(the parent file `KummerTheoremOQ04OQ01` re-derives this as
+`padicValNat_two_centralBinom : v₂(C(2n,n)) = s₂(n)`, and characterises the
+popcount-`1` level: `s₂(n) = 1 ↔ ∃ k, n = 2^k`).
+
+This file advances the correspondence one level, to popcount `2`.  The
+combinatorial heart is a clean classification of the naturals whose binary
+digit sum equals `2`:
+
+  `s₂(n) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`
+
+i.e. the numbers with exactly two `1`-bits.  Transporting it through the parent
+valuation identity gives
+
+  `v₂(C(2n, n)) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`
+
+and the exact-divisibility form
+
+  `4 ∣ C(2n, n) ∧ ¬ 8 ∣ C(2n, n) ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`.
+
+Mathlib provides `Nat.digits`, the digit recursion `Nat.digits_def'`, and
+`padicValNat_dvd_iff_le` (`p^k ∣ a ↔ k ≤ v_p a` for `a ≠ 0`), but it has no
+`popcount = 2 ↔ two distinct powers of two`.  The proof is fully finite and
+`0`-axiom: the forward classification is a strong induction peeling the lowest
+bit (even branch recurses, odd branch lands on the parent's popcount-`1`
+lemma), and the converse computes the digit sum of `2^b · (2^m + 1)` via
+doubling-invariance.
+-/
+
+namespace KummerCentralBinomTwoBits
+
+open Nat
+open KummerCentralBinomPowerTwo
+
+/-- **Doubling a power of two leaves the binary digit sum unchanged.**
+`s₂(2^c · x) = s₂(x)`: each multiplication by `2` prepends a zero digit. -/
+theorem sum_digits_two_pow_mul (c x : ℕ) :
+    (Nat.digits 2 (2 ^ c * x)).sum = (Nat.digits 2 x).sum := by
+  induction c with
+  | zero => simp
+  | succ d ih =>
+    have hrw : 2 ^ (d + 1) * x = 2 * (2 ^ d * x) := by ring
+    rw [hrw, sum_digits_two_mul, ih]
+
+/-- **Digit sum of `2^(m+1) + 1` is two.** The number `2^(m+1)+1` is odd with a
+single high bit, so its binary expansion is `1 0…0 1`: digit sum `1 + s₂(2^m) = 2`. -/
+theorem sum_digits_two_pow_succ_add_one (m : ℕ) :
+    (Nat.digits 2 (2 ^ (m + 1) + 1)).sum = 2 := by
+  have hpos : 0 < 2 ^ (m + 1) + 1 := by positivity
+  rw [Nat.digits_def' one_lt_two hpos, List.sum_cons]
+  have hpow : 2 ^ (m + 1) = 2 * 2 ^ m := by ring
+  have hmod : (2 ^ (m + 1) + 1) % 2 = 1 := by omega
+  have hdiv : (2 ^ (m + 1) + 1) / 2 = 2 ^ m := by omega
+  rw [hmod, hdiv, sum_digits_two_pow]
+
+/-- **Forward direction.** If the binary digit sum of `n` is `2`, then `n` is a sum
+of two distinct powers of two.  Strong induction peeling the lowest bit
+`s₂(n) = (n % 2) + s₂(n / 2)`: the even branch recurses on `n / 2`, while the odd
+branch reduces `s₂(n/2) = 1` to the parent's popcount-one lemma. -/
+theorem sum_digits_two_eq_two_imp (n : ℕ) :
+    (Nat.digits 2 n).sum = 2 → ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    intro h
+    have hn : 0 < n := by
+      rcases Nat.eq_zero_or_pos n with rfl | hp
+      · simp at h
+      · exact hp
+    rw [Nat.digits_def' one_lt_two hn, List.sum_cons] at h
+    have hhalf : n / 2 < n := Nat.div_lt_self hn one_lt_two
+    rcases Nat.even_or_odd n with he | ho
+    · -- `n` even: lowest bit `0`, so `s₂(n/2) = 2`; recurse and double the exponents.
+      have h0 : n % 2 = 0 := Nat.even_iff.mp he
+      rw [h0, Nat.zero_add] at h
+      obtain ⟨a, b, hab, hres⟩ := ih (n / 2) hhalf h
+      refine ⟨a + 1, b + 1, by omega, ?_⟩
+      have he2 : n = 2 * (n / 2) := by omega
+      rw [he2, hres]; ring
+    · -- `n` odd: lowest bit `1`, so `s₂(n/2) = 1`, hence `n/2 = 2^k` (parent lemma).
+      have h1 : n % 2 = 1 := Nat.odd_iff.mp ho
+      rw [h1] at h
+      have hk : (Nat.digits 2 (n / 2)).sum = 1 := by omega
+      obtain ⟨k, hkk⟩ := sum_digits_two_eq_one_imp (n / 2) hk
+      refine ⟨k + 1, 0, by omega, ?_⟩
+      have he2 : n = 2 * (n / 2) + 1 := by omega
+      rw [he2, hkk]; ring
+
+/-- **Converse direction.** A sum of two distinct powers of two has binary digit
+sum `2`.  Factor `2^a + 2^b = 2^b · (2^(a-b) + 1)`, strip the `2^b` factor by
+doubling-invariance, and evaluate `s₂(2^(a-b) + 1) = 2`. -/
+theorem sum_digits_two_eq_two_of (a b : ℕ) (hab : b < a) :
+    (Nat.digits 2 (2 ^ a + 2 ^ b)).sum = 2 := by
+  obtain ⟨m, rfl⟩ : ∃ m, a = b + (m + 1) := ⟨a - b - 1, by omega⟩
+  have hfac : 2 ^ (b + (m + 1)) + 2 ^ b = 2 ^ b * (2 ^ (m + 1) + 1) := by
+    rw [pow_add]; ring
+  rw [hfac, sum_digits_two_pow_mul, sum_digits_two_pow_succ_add_one]
+
+/-- **The binary digit sum equals two exactly for the two-bit numbers.**
+`s₂(n) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`.  (Not available in Mathlib.) -/
+theorem sum_digits_two_eq_two_iff (n : ℕ) :
+    (Nat.digits 2 n).sum = 2 ↔ ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  constructor
+  · exact sum_digits_two_eq_two_imp n
+  · rintro ⟨a, b, hab, rfl⟩
+    exact sum_digits_two_eq_two_of a b hab
+
+/-- **Headline valuation characterisation.** The central binomial coefficient
+`C(2n, n)` has `2`-adic valuation exactly `2` iff `n` has precisely two `1`-bits:
+`v₂(C(2n, n)) = 2 ↔ ∃ a b, b < a ∧ n = 2^a + 2^b`. -/
+theorem padicValNat_two_centralBinom_eq_two_iff (n : ℕ) :
+    padicValNat 2 (Nat.centralBinom n) = 2 ↔ ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  rw [padicValNat_two_centralBinom]
+  exact sum_digits_two_eq_two_iff n
+
+/-- **Exact-divisibility bridge.** For `m > 0`, having `2`-adic valuation exactly `2`
+is the same as `4 ∣ m` but `8 ∤ m`, since `4 = 2²` and `8 = 2³`. -/
+theorem exactDvd_four_iff_padicValNat_two {m : ℕ} (hm : 0 < m) :
+    (4 ∣ m ∧ ¬ (8 ∣ m)) ↔ padicValNat 2 m = 2 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  have h4 : (4 : ℕ) = 2 ^ 2 := by norm_num
+  have h8 : (8 : ℕ) = 2 ^ 3 := by norm_num
+  rw [h4, h8, padicValNat_dvd_iff_le hm.ne', padicValNat_dvd_iff_le hm.ne']
+  omega
+
+/-- **Headline exact-divisibility form.** `C(2n, n)` is divisible by `4` but not by
+`8` exactly when `n` is a sum of two distinct powers of two. -/
+theorem four_exactDvd_centralBinom_iff (n : ℕ) :
+    (4 ∣ Nat.centralBinom n ∧ ¬ (8 ∣ Nat.centralBinom n)) ↔
+      ∃ a b, b < a ∧ n = 2 ^ a + 2 ^ b := by
+  rw [exactDvd_four_iff_padicValNat_two (Nat.centralBinom_pos n)]
+  exact padicValNat_two_centralBinom_eq_two_iff n
+
+/-! ### Sanity checks (anonymous examples; not part of the API) -/
+
+/-- `n = 3 = 11₂ = 2¹ + 2⁰`: two bits, so `v₂(C(6,3)) = v₂(20) = 2`. -/
+example : padicValNat 2 (Nat.centralBinom 3) = 2 :=
+  (padicValNat_two_centralBinom_eq_two_iff 3).mpr ⟨1, 0, by omega, by norm_num⟩
+
+/-- `n = 6 = 110₂ = 2² + 2¹`: two bits, so `C(12,6) = 924` is `4 ∣ · ∧ ¬ 8 ∣ ·`. -/
+example : 4 ∣ Nat.centralBinom 6 ∧ ¬ (8 ∣ Nat.centralBinom 6) :=
+  (four_exactDvd_centralBinom_iff 6).mpr ⟨2, 1, by omega, by norm_num⟩
+
+/-- `n = 7 = 111₂` has three bits, so `v₂(C(14,7)) ≠ 2`: `7` is not a sum of two
+distinct powers of two. -/
+example : padicValNat 2 (Nat.centralBinom 7) ≠ 2 := by
+  rw [ne_eq, padicValNat_two_centralBinom_eq_two_iff]
+  rintro ⟨a, b, hab, hc⟩
+  have hb1 : 1 ≤ 2 ^ b := Nat.one_le_two_pow
+  have ha1 : 1 ≤ 2 ^ a := Nat.one_le_two_pow
+  have haa : a ≤ 2 := by
+    by_contra h
+    have h3 : 2 ^ 3 ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) (by omega)
+    norm_num at h3; omega
+  interval_cases a <;> interval_cases b <;> simp_all
+
+end KummerCentralBinomTwoBits

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-kummer-oq040101-twobit",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 115
+    },
+    "type": "insight",
+    "title": "Core New Lemma: s₂(n) = 2 ⟺ Two Distinct Powers of Two",
+    "content": "`sum_digits_two_eq_two_iff` is the combinatorial heart: a natural number has binary digit sum (popcount) 2 exactly when it is a sum of two distinct powers of two, n = 2^a + 2^b with a > b. Mathlib has no popcount-2 characterisation; this advances the parent's popcount-1 (powers-of-two) result one level up the ladder."
+  },
+  {
+    "id": "ann-kummer-oq040101-descent",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "Parity Descent: Popcount-2 Reduces to Popcount-1",
+    "content": "The forward direction is strong induction on n peeling the lowest bit via s₂(n) = (n%2) + s₂(n/2). An even n inherits both bits from n/2 (recurse, doubling both exponents); an odd n spends one bit on 2^0 and the remaining digit sum 1 lands exactly on the parent's popcount-one lemma `sum_digits_two_eq_one_imp`. The popcount ladder climbs by feeding level k into level k-1."
+  },
+  {
+    "id": "ann-kummer-oq040101-converse",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 105
+    },
+    "type": "technique",
+    "title": "Converse by a Single Factorisation",
+    "content": "`sum_digits_two_eq_two_of` factors 2^a + 2^b = 2^b·(2^(a-b)+1). Multiplying by a power of two only prepends zero digits (`sum_digits_two_pow_mul`), so the digit sum equals that of the odd part 2^m+1, whose binary string 1 0…0 1 has digit sum 2 (`sum_digits_two_pow_succ_add_one`)."
+  },
+  {
+    "id": "ann-kummer-oq040101-headline",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 122
+    },
+    "type": "insight",
+    "title": "Headline: v₂(C(2n,n)) = 2 ⟺ n Has Two 1-Bits",
+    "content": "`padicValNat_two_centralBinom_eq_two_iff` rewrites the valuation as the binary digit sum via the parent identity v₂(C(2n,n)) = s₂(n), then applies the popcount-2 classification. The binomial coefficient contributes only through that valuation formula."
+  },
+  {
+    "id": "ann-kummer-oq040101-exactdvd",
+    "proofId": "kummer-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 142
+    },
+    "type": "insight",
+    "title": "Exact Divisibility as a Valuation Window",
+    "content": "`four_exactDvd_centralBinom_iff` recasts the result as 4 ∣ C(2n,n) ∧ 8 ∤ C(2n,n). The bridge `exactDvd_four_iff_padicValNat_two` uses `padicValNat_dvd_iff_le` on 4 = 2² and 8 = 2³ to bracket the valuation: 4 ∣ m ∧ 8 ∤ m is exactly 2 ≤ v₂(m) < 3, i.e. v₂(m) = 2."
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,201 @@
+{
+  "id": "kummer-theorem-oq-04-oq-01-oq-01",
+  "title": "Kummer OQ-04-OQ-01-OQ-01: C(2n,n) Divisible by Exactly 4 ⟺ n Has Two 1-Bits",
+  "slug": "kummer-theorem-oq-04-oq-01-oq-01",
+  "description": "Advances the popcount/2-adic-valuation correspondence one level past the parent's power-of-two case: v₂(C(2n,n)) = 2 if and only if n is a sum of two distinct powers of two (binary popcount 2). The crux is the digit-sum classification s₂(n) = 2 ⟺ ∃ a > b, n = 2^a + 2^b — a popcount-2 characterisation Mathlib does not provide — together with its exact-divisibility form 4 ∣ C(2n,n) ∧ 8 ∤ C(2n,n).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KummerTheoremOQ04OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "kummer-theorem",
+      "p-adic",
+      "binomial-coefficient",
+      "central-binomial-coefficient",
+      "popcount",
+      "powers-of-two"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 163,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "assumptions": "None. 0 axioms, 0 sorries. Only the foundational propext / Classical.choice / Quot.sound are used (confirmed by #print axioms); no sorryAx, no Lean.ofReduceBool. The headline v₂(C(2n,n)) = s₂(n) is inherited from the parent file KummerTheoremOQ04OQ01; the new content is the popcount = 2 ⟺ two distinct powers of two characterisation, proved by strong induction. Numeric witnesses use kernel-checkable tactics (omega / norm_num / interval_cases), not native_decide.",
+    "originalContributions": [
+      "sum_digits_two_eq_two_iff: the binary digit sum equals 2 exactly for sums of two distinct powers of two, s₂(n) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b — the core new lemma, absent from Mathlib (no popcount-2 / two-bit characterisation in Mathlib.Data.Nat.Digits), advancing the parent's popcount-1 result one level",
+      "sum_digits_two_eq_two_imp: forward direction by strong induction peeling the lowest bit s₂(n) = (n%2) + s₂(n/2): even n recurses on n/2 (doubling both exponents), odd n reduces s₂(n/2) = 1 to the parent's popcount-one lemma, contributing the bit 2^0",
+      "sum_digits_two_eq_two_of: converse by factoring 2^a + 2^b = 2^b·(2^(a-b)+1), stripping the 2^b factor via doubling-invariance, and evaluating s₂(2^(a-b)+1) = 2",
+      "padicValNat_two_centralBinom_eq_two_iff: the headline valuation characterisation v₂(C(2n,n)) = 2 ⟺ ∃ a b, b < a ∧ n = 2^a + 2^b, packaging the parent valuation formula with the new popcount-2 lemma",
+      "four_exactDvd_centralBinom_iff: the exact-divisibility form 4 ∣ C(2n,n) ∧ ¬ 8 ∣ C(2n,n) ⟺ n is a sum of two distinct powers of two, via the bridge v₂(m) = 2 ⟺ (4 ∣ m ∧ ¬ 8 ∣ m) for m > 0",
+      "sum_digits_two_pow_mul / sum_digits_two_pow_succ_add_one: reusable digit-sum helpers — s₂(2^c·x) = s₂(x) (doubling-invariance iterated) and s₂(2^(m+1)+1) = 2 (the two-bit number 1 0…0 1)",
+      "worked numeric witnesses: n=3=11₂ giving v₂(C(6,3))=2, n=6=110₂ giving 4 ∣ C(12,6)=924 but 8 ∤, and the non-example n=7=111₂ (three bits) with v₂(C(14,7)) ≠ 2"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sub_one_mul_padicValNat_choose_eq_sub_sum_digits",
+        "description": "Legendre/Kummer digit-sum identity inherited via the parent's padicValNat_two_centralBinom: v₂(C(2n,n)) = s₂(n)",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "digits b n = n % b :: digits b (n / b) for 1 < b, 0 < n — the lowest-bit peel driving the strong induction",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "padicValNat_dvd_iff_le",
+        "description": "p^k ∣ a ↔ k ≤ v_p(a) for a ≠ 0 — turns 4 = 2² and 8 = 2³ divisibility into bounds on the valuation, giving the 4 ∣ · ∧ 8 ∤ · ⟺ v₂ = 2 bridge",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "C(2n,n) > 0, needed to apply the nonzero hypothesis of padicValNat_dvd_iff_le",
+        "module": "Mathlib.Combinatorics.Choose.Central"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) computes the $p$-adic valuation $v_p(\\binom{n}{k})$ as the number of carries when adding $k$ and $n-k$ in base $p$; on the central diagonal it gives $v_2(\\binom{2n}{n}) = s_2(n)$, the binary popcount of $n$. The parent entry pinned down the minimal case $v_2 = 1$ as exactly the powers of two (popcount $1$). This follow-up advances the level sets of popcount one step: $v_2(\\binom{2n}{n}) = 2$ exactly when $n$ has two $1$-bits, $n = 2^a + 2^b$ with $a > b$. As with the popcount-$1$ case, the underlying arithmetic fact — popcount equals $2$ iff a sum of two distinct powers of two — has no direct statement in Mathlib's digit library.",
+    "problemStatement": "Characterise the natural numbers $n$ for which the central binomial coefficient $\\binom{2n}{n}$ is divisible by $4$ but not by $8$, i.e. $v_2(\\binom{2n}{n}) = 2$.",
+    "text": "Via the parent closed form $v_2(\\binom{2n}{n}) = s_2(n)$, the answer is exactly the two-bit numbers: $v_2(\\binom{2n}{n}) = 2 \\iff \\exists\\, a > b,\\ n = 2^a + 2^b$, equivalently $4 \\mid \\binom{2n}{n}$ and $8 \\nmid \\binom{2n}{n}$.",
+    "proofStrategy": "Reduce $v_2(\\binom{2n}{n}) = 2$ to $s_2(n) = 2$ using the parent valuation formula. Then prove $s_2(n) = 2 \\iff \\exists a > b, n = 2^a + 2^b$. Forward: strong induction on $n$ via $s_2(n) = (n \\bmod 2) + s_2(n/2)$ from `Nat.digits_def'`. If $n$ is even the low bit is $0$ so $s_2(n/2)=2$ and the induction hypothesis gives $n/2 = 2^a + 2^b$, hence $n = 2^{a+1} + 2^{b+1}$; if $n$ is odd the low bit is $1$ so $s_2(n/2)=1$, and the parent's popcount-one lemma gives $n/2 = 2^k$, hence $n = 2^{k+1} + 2^0$. Converse: factor $2^a + 2^b = 2^b(2^{a-b}+1)$, strip $2^b$ by doubling-invariance $s_2(2^c x)=s_2(x)$, and compute $s_2(2^{m+1}+1)=2$ directly. The exact-divisibility form follows from $v_2(m)=2 \\iff (4 \\mid m \\wedge 8 \\nmid m)$ via `padicValNat_dvd_iff_le` and $\\binom{2n}{n}>0$.",
+    "keyInsights": [
+      "**Popcount = 2 is the whole content.** Stripping away the binomial coefficient, the theorem is the bit-counting fact that a natural number has exactly two $1$-bits iff it is a sum of two distinct powers of two. The central binomial coefficient enters only through the parent identity $v_2 = s_2$.",
+      "**Parity descent reuses the level below.** The recursion $s_2(n) = (n \\bmod 2) + s_2(n/2)$ splits on parity: an even $n$ inherits both bits from $n/2$ (recurse), while an odd $n$ spends one bit on $2^0$ and reduces the remaining budget to the parent's popcount-$1$ (power-of-two) characterisation. The popcount-$k$ ladder climbs by feeding into popcount-$(k-1)$.",
+      "**The converse is a single factorisation.** $2^a + 2^b = 2^b(2^{a-b}+1)$, and multiplying by a power of two leaves the digit sum unchanged, so it suffices to see $s_2(2^m+1) = 2$ for $m \\geq 1$ — the binary string $1\\,0\\cdots0\\,1$.",
+      "**Exact divisibility is a valuation window.** $4 \\mid m \\wedge 8 \\nmid m$ is precisely $2 \\leq v_2(m) < 3$, i.e. $v_2(m) = 2$; `padicValNat_dvd_iff_le` converts the two divisibilities into the two-sided bound."
+    ],
+    "prerequisites": [
+      "The parent closed form v₂(C(2n,n)) = s₂(n) and its popcount-1 characterisation s₂(n)=1 ⟺ ∃k, n=2^k (file KummerTheoremOQ04OQ01)",
+      "Base-2 digit representations and the recursion digits 2 n = n%2 :: digits 2 (n/2)",
+      "Strong induction on ℕ (Nat.strongRecOn)",
+      "The padicValNat divisibility API: padicValNat_dvd_iff_le"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Research Question and Answer",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "File header: the open question (when is C(2n,n) divisible by exactly 4), the answer (exactly the two-bit numbers n = 2^a + 2^b), the reduction to s₂(n)=2, and a note that the popcount-2 characterisation is the new content absent from Mathlib."
+    },
+    {
+      "id": "digit-helpers",
+      "title": "Digit-Sum Helpers: Doubling-Invariance and the Two-Bit Number",
+      "startLine": 43,
+      "endLine": 65,
+      "summary": "sum_digits_two_pow_mul (s₂(2^c·x)=s₂(x), iterating the parent's doubling-invariance) and sum_digits_two_pow_succ_add_one (s₂(2^(m+1)+1)=2, the binary string 1 0…0 1).",
+      "mathContext": "Two reusable lemmas isolating how powers of two interact with the binary digit sum."
+    },
+    {
+      "id": "forward-induction",
+      "title": "Forward Direction: s₂(n)=2 ⟹ Two Distinct Powers of Two",
+      "startLine": 66,
+      "endLine": 96,
+      "summary": "sum_digits_two_eq_two_imp: strong induction peeling the lowest bit. Even n: low bit 0, recurse on n/2 and double both exponents. Odd n: low bit 1, remaining digit sum 1 lands on the parent's popcount-one lemma, contributing 2^0.",
+      "mathContext": "A digit-sum budget of 2 is spent as two 1-bits; parity descent reduces to the popcount-1 case already proved."
+    },
+    {
+      "id": "converse",
+      "title": "Converse Direction: Two Powers of Two Have Digit Sum 2",
+      "startLine": 97,
+      "endLine": 105,
+      "summary": "sum_digits_two_eq_two_of: factor 2^a + 2^b = 2^b·(2^(a-b)+1), strip the 2^b factor via sum_digits_two_pow_mul, and evaluate s₂(2^(a-b)+1)=2.",
+      "mathContext": "Multiplying by a power of two only prepends zeros, so the digit sum is that of the odd part 2^m+1."
+    },
+    {
+      "id": "characterisation",
+      "title": "The Characterisations: Digit Sum and Valuation",
+      "startLine": 106,
+      "endLine": 122,
+      "summary": "sum_digits_two_eq_two_iff (s₂(n)=2 ⟺ ∃ a>b, n=2^a+2^b) combining both directions, and padicValNat_two_centralBinom_eq_two_iff (v₂(C(2n,n))=2 ⟺ ∃ a>b, n=2^a+2^b), the headline result.",
+      "mathContext": "Rewriting the valuation by the parent formula turns the binomial statement into the popcount-2 statement."
+    },
+    {
+      "id": "exact-divisibility",
+      "title": "Exact-Divisibility Form: 4 ∣ C(2n,n) but 8 ∤",
+      "startLine": 123,
+      "endLine": 142,
+      "summary": "exactDvd_four_iff_padicValNat_two (for m>0, 4∣m ∧ ¬8∣m ⟺ v₂(m)=2, via padicValNat_dvd_iff_le on 4=2² and 8=2³) and four_exactDvd_centralBinom_iff, the headline divisibility characterisation using C(2n,n)>0.",
+      "mathContext": "Two divisibilities bracket the valuation into the single value 2."
+    },
+    {
+      "id": "numeric-witnesses",
+      "title": "Worked Numeric Witnesses",
+      "startLine": 143,
+      "endLine": 163,
+      "summary": "Sanity checks: n=3=11₂ giving v₂(C(6,3))=2, n=6=110₂ giving 4 ∣ C(12,6)=924 but 8 ∤, and the non-example n=7=111₂ (three 1-bits) with v₂(C(14,7)) ≠ 2. Ends namespace KummerCentralBinomTwoBits.",
+      "mathContext": "Confirms both the positive characterisation and its failure on a three-bit number."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, self-contained Lean 4 formalization characterising the second 2-adic-valuation level of the central binomial coefficient: v₂(C(2n,n)) = 2 ⟺ n is a sum of two distinct powers of two, equivalently 4 ∣ C(2n,n) ∧ 8 ∤ C(2n,n). The crux is a new popcount-2 lemma s₂(n)=2 ⟺ ∃ a>b, n=2^a+2^b (strong induction reducing to the parent's popcount-1 case). 8 theorems, 0 axioms, 0 sorries.",
+    "implications": "Pins down exactly which central binomial coefficients are divisible by 4 but not 8, the next level above the parent's minimal-valuation (powers-of-two) case. The standalone popcount-2 characterisation s₂(n)=2 ⟺ two distinct powers of two is reusable for any digit-sum/popcount argument over ℕ, and the parity-descent template (reduce popcount-k to popcount-(k-1)) extends to higher levels.",
+    "openQuestions": [
+      "Does the parity-descent ladder give a uniform closed description of every popcount level set s₂(n) = k (and hence of v₂(C(2n,n)) = k) as the symmetric configurations of k distinct powers of two?",
+      "For an odd prime p, characterise v_p(C(2n,n)) = 2 in terms of base-p digits — is there a two-carry analogue of the two-bit description?",
+      "Transfer the v₂ = 2 characterisation to the Catalan number C_n = C(2n,n)/(n+1): for which n is v₂(C_n) = 2?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent characterising v₂ = 1 (popcount 1, powers of two); this follow-up does the v₂ = 2 (popcount 2) level and reuses the parent's popcount-1 lemma in the odd induction branch."
+    },
+    {
+      "targetId": "kummer-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Grandparent entry proving the valuation closed form v₂(C(2n,n)) = s₂(n)."
+    },
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "extends",
+      "description": "Root Kummer's theorem on p-adic valuations of binomial coefficients via carry counts."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Kummer, E.E."
+      ],
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "venue": "Journal für die reine und angewandte Mathematik 44, pp. 93-146",
+      "note": "Original carry-count theorem for v_p(C(n,k)); the digit-sum form underlies the v₂ = s₂ identity"
+    },
+    {
+      "authors": [
+        "Legendre, A.-M."
+      ],
+      "title": "Théorie des nombres",
+      "year": "1830",
+      "venue": "3rd edition, Firmin Didot Frères, Paris",
+      "note": "Legendre's formula v_p(n!) = (n - s_p(n))/(p-1), source of the digit-sum identity"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.KummerTheoremOQ04OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "KummerCentralBinomPowerTwo"
+    ],
+    "namespace": "KummerCentralBinomTwoBits",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/KummerTheoremOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Advances the popcount / 2-adic-valuation correspondence for the central binomial coefficient **one level past the parent's power-of-two case**. The parent (`kummer-theorem-oq-04-oq-01`) characterised $v_2(\binom{2n}{n}) = 1$ as exactly the powers of two (popcount 1). This entry does the next level:

$$v_2\!\left(\binom{2n}{n}\right) = 2 \iff \exists\, a > b,\ n = 2^a + 2^b \iff 4 \mid \tbinom{2n}{n} \,\wedge\, 8 \nmid \tbinom{2n}{n}.$$

## New content (0-axiom, original)

- **`sum_digits_two_eq_two_iff`** — the combinatorial heart: $s_2(n) = 2 \iff \exists a{>}b,\ n = 2^a + 2^b$, a **popcount-2 classification absent from Mathlib**.
- **`padicValNat_two_centralBinom_eq_two_iff`** — headline: $v_2(\binom{2n}{n}) = 2 \iff$ two 1-bits, via the parent identity $v_2 = s_2$.
- **`four_exactDvd_centralBinom_iff`** — exact-divisibility form $4 \mid \binom{2n}{n} \wedge 8 \nmid \binom{2n}{n}$, through the window $2 \le v_2 < 3$ (`padicValNat_dvd_iff_le`).

## Proof

- **Forward**: strong induction peeling the lowest bit $s_2(n) = (n\bmod 2) + s_2(n/2)$. Even $n$ recurses (doubling both exponents); odd $n$ spends one bit on $2^0$ and reduces the remaining digit sum 1 to the **parent's popcount-1 lemma** — the popcount ladder climbs by feeding level $k$ into level $k-1$.
- **Converse**: factor $2^a + 2^b = 2^b(2^{a-b}+1)$, strip the $2^b$ by doubling-invariance $s_2(2^c x) = s_2(x)$, evaluate $s_2(2^m+1) = 2$.

## Verification

- **8 theorems, 0 definitions, 0 sorries, 0 axioms** (`#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool`). Numeric witnesses use kernel-checkable tactics, not `native_decide`.
- Builds against Mathlib 4.26.0 on top of the parent file `Proofs/KummerTheoremOQ04OQ01.lean`.

Answers the first open question of `kummer-theorem-oq-04-oq-01` ("Characterise the n with v₂(C(2n,n)) = 2").

🤖 Generated with [Claude Code](https://claude.com/claude-code)