### PR TITLE
Enrich Strict Abundancy-Index Monotonicity (abundant-number-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/abundant-number-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abundant-number-oq-04-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-abund0401-overview",
+    "proofId": "abundant-number-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Sharpening abundancy-index monotonicity to a strict, quantified jump",
+    "content": "The docstring frames the contribution relative to the parent abundant-number-oq-04, which proved only the non-strict monotonicity σ(d)/d ≤ σ(n)/n for d ∣ n. This entry sharpens it at a *proper* divisor (d < n) to a strict inequality with an explicit lower bound on the gap: n·σ(d) + d ≤ d·σ(n), i.e. σ(n)/n − σ(d)/d ≥ 1/n. The whole gain is traced to one elementary observation: among the divisors of n = d·t the scaled divisors {t·e : e ∣ d} account for t·σ(d), but 1 is also a divisor of n and is never of the form t·e when t ≥ 2 — that single uncounted divisor is the source of the strict '+1'.",
+    "mathContext": "Abundancy index $\\sigma(n)/n$. Parent: $d\\mid n\\Rightarrow \\sigma(d)/d\\le\\sigma(n)/n$. Here, for $d\\mid n$, $d<n$: $\\sigma(n)/n-\\sigma(d)/d\\ge 1/n>0$.",
+    "significance": "context",
+    "relatedConcepts": ["abundancy index", "sum-of-divisors σ", "perfect / abundant / deficient numbers", "divisor sum monotonicity"],
+    "prerequisites": ["divisor functions", "divisibility"]
+  },
+  {
+    "id": "ann-abund0401-scaled",
+    "proofId": "abundant-number-oq-04-oq-01",
+    "range": { "startLine": 51, "endLine": 88 },
+    "type": "insight",
+    "title": "The strict scaled-divisor bound: t·σ(d) + 1 ≤ σ(d·t)",
+    "content": "scaled_sigma_lt is the engine. For 0 < d and t ≥ 2, the map e ↦ t·e injects divisors d into divisors (d·t) (mul_dvd_mul_left), and the image sums to exactly t·σ(d) (Finset.sum_image with injectivity from left-cancellation, then mul_sum). The decisive point: 1 ∈ divisors (d·t) but 1 is NOT in the image, because every t·e ≥ t ≥ 2 > 1. So Finset.sum_lt_sum_of_subset adds that one extra positive term, giving a strict gain — t·σ(d) < σ(d·t), i.e. t·σ(d) + 1 ≤ σ(d·t) over ℕ. This is the strict refinement of the parent's non-strict scaled_sigma_le.",
+    "mathContext": "$\\{t e : e\\mid d\\}\\subseteq \\mathrm{divisors}(dt)$, $\\sum = t\\sigma(d)$; but $1\\in\\mathrm{divisors}(dt)\\setminus\\{te\\}$, so $t\\sigma(d)+1\\le\\sigma(dt)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_lt_sum_of_subset", "Finset.sum_image", "scaled-divisor injection", "strict subset sum"],
+    "prerequisites": ["Finset images and injectivity", "divisor sets in Mathlib"]
+  },
+  {
+    "id": "ann-abund0401-strictmono",
+    "proofId": "abundant-number-oq-04-oq-01",
+    "range": { "startLine": 90, "endLine": 115 },
+    "type": "theorem",
+    "title": "Strict, lower-bounded monotonicity: n·σ(d) + d ≤ d·σ(n)",
+    "content": "sigma_dvd_strict_mono is the headline. Writing n = d·t, the hypothesis d < n forces t ≥ 2 (via Nat.lt_of_mul_lt_mul_left on d·1 < d·t). Feeding scaled_sigma_lt and scaling by d through the algebraic identity (d·t)·σ(d) + d = d·(t·σ(d) + 1) gives n·σ(d) + d ≤ d·σ(n). The '+d' on the integer side is exactly the '+1' from the missing divisor 1, scaled by d — which in abundancy-index form becomes the +1/n jump.",
+    "mathContext": "$d\\mid n,\\ d<n \\Rightarrow n\\sigma(d)+d\\le d\\sigma(n)$, i.e. $d\\sigma(n)-n\\sigma(d)\\ge d>0$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.lt_of_mul_lt_mul_left", "abundancy monotonicity", "proper divisor", "scaling identity"],
+    "prerequisites": ["the scaled-divisor bound", "ℕ multiplication monotonicity"]
+  },
+  {
+    "id": "ann-abund0401-rational",
+    "proofId": "abundant-number-oq-04-oq-01",
+    "range": { "startLine": 116, "endLine": 147 },
+    "type": "technique",
+    "title": "Rational form of the gap: σ(d)/d + 1/n ≤ σ(n)/n",
+    "content": "abundancy_gap_ge transports the cross-multiplied ℕ bound into a genuine ℚ inequality on the abundancy index. After casting sigma_dvd_strict_mono to ℚ (exact_mod_cast + push_cast), the goal is rearranged via sub_nonneg into a single fraction (d·σ(n) − (n·σ(d) + d))/(d·n) using field_simp, whose numerator is ≥ 0 by the cast bound and whose denominator is positive. This is the clean statement that the abundancy index gains at least 1/n on passing to a proper multiple.",
+    "mathContext": "$\\dfrac{\\sigma(d)}{d} + \\dfrac1n \\le \\dfrac{\\sigma(n)}{n}$ for $d\\mid n$, $d<n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["field_simp", "exact_mod_cast / push_cast", "div_nonneg", "rational reformulation"],
+    "prerequisites": ["ℕ→ℚ casts", "fraction manipulation"]
+  },
+  {
+    "id": "ann-abund0401-perfect",
+    "proofId": "abundant-number-oq-04-oq-01",
+    "range": { "startLine": 148, "endLine": 169 },
+    "type": "theorem",
+    "title": "Sanity check: proper divisors of perfect numbers are deficient",
+    "content": "deficient_of_proper_dvd_perfect' re-derives a parent result straight from the strict gap, bypassing the abundant-side closure machinery. For a perfect n (σ(n) = 2n, obtained from Mathlib's properDivisors-based Nat.Perfect via sum_divisors_eq_sum_properDivisors_add_self), the strict bound gives n·σ(d) + d ≤ d·(2n) = n·(2d), so n·σ(d) < n·(2d), and cancelling n yields σ(d) < 2d — d is deficient. A compact illustration that the strict bound is genuinely stronger than the non-strict one.",
+    "mathContext": "$n$ perfect, $d\\mid n$, $d<n \\Rightarrow \\sigma(d)<2d$ (d deficient), since $n\\sigma(d)+d\\le d\\cdot 2n = n\\cdot 2d$.",
+    "significance": "supporting",
+    "relatedConcepts": ["perfect number", "deficient number", "Nat.Perfect", "deficient_iff_sigma_lt_two_mul"],
+    "prerequisites": ["perfect-number definition", "Nat.lt_of_mul_lt_mul_left"]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-04-oq-01/index.ts
+++ b/src/data/proofs/abundant-number-oq-04-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbundantStrictAbundancyOQ0401.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abundantStrictAbundancyOQ0401Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abundantStrictAbundancyOQ0401Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abundantStrictAbundancyOQ0401Data: ProofData = {
+  proof: abundantStrictAbundancyOQ0401Proof,
+  annotations: abundantStrictAbundancyOQ0401Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abundant-number-oq-04-oq-01`.

## Gap addressed
Entry had **only meta.json** — no annotations.json.

## Added
- **annotations.json** with **5 annotations** (overview; the strict scaled-divisor bound t·σ(d)+1≤σ(d·t); the strict lower-bounded monotonicity n·σ(d)+d≤d·σ(n); the rational gap σ(d)/d+1/n≤σ(n)/n; and the perfect-divisor deficiency sanity check), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts** entry point.

## Verification
- JSON validates; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms / badge original.