### PR TITLE
research(varignon-theorem-oq-01-oq-01): signed-area law — Varignon parallelogram = ½ signed area of ANY quadrilateral [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4052,6 +4052,7 @@ import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VandermondeInterpolationOQ01OQ02
 import Proofs.VandermondeInterpolationOQ01OQ02OQ01
 import Proofs.VarignonTheorem
+import Proofs.VarignonTheoremOQ01OQ01
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02
 import Proofs.VietasFormulasOQ03

--- a/proofs/Proofs/VarignonTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/VarignonTheoremOQ01OQ01.lean
@@ -1,0 +1,145 @@
+/-
+Proof: The signed-area law for the Varignon parallelogram.
+Research: varignon-theorem-oq-01-oq-01
+
+Open question (parent `varignon-theorem-oq-01`, first open question):
+  "What is the relationship between the Varignon parallelogram's area and the
+   original quadrilateral's area in the *self-intersecting* case?"
+
+The parent file proves the affine skeleton of Varignon's theorem — the midpoints
+of the sides of any quadrilateral form a parallelogram — using only the midpoint
+structure.  That argument never mentions area, and it is silent on the classical
+"half the area" statement, which is usually proved for *convex* quadrilaterals by
+a picture.  The picture breaks for self-intersecting (crossed) quadrilaterals.
+
+This file resolves the question by replacing area-by-picture with the **signed**
+shoelace area, which is a polynomial in the coordinates and therefore makes no
+distinction between convex, concave, and self-intersecting quadrilaterals.  We
+prove, as a single ring identity in the eight coordinates of `A, B, C, D`:
+
+  * **Diagonal form of the quadrilateral area.**
+      `signedArea A B C D = cross (C - A) (D - B) / 2`,
+    i.e. the signed area depends only on the two diagonals `AC` and `BD`.
+  * **Diagonal form of the Varignon area.**
+      `varignonArea A B C D = cross (C - A) (D - B) / 4`.
+  * **The half-area law (headline).**
+      `varignonArea A B C D = signedArea A B C D / 2`,
+    valid for *every* quadrilateral, with no convexity or simplicity hypothesis.
+
+Because the statements are identities of real polynomials, the self-intersecting
+case is not a separate case at all — it is the same identity.  We exhibit a
+crossed quadrilateral with *negative* signed area to show the law is genuinely
+signed (the unsigned "half the area" slogan would be false there, but the signed
+law holds exactly).
+
+Conventions match the parent (`Point := ℝ × ℝ`, `midpoint2` the componentwise
+average); `signedArea`/`cross` are declared self-containedly so the entry
+compiles without the parent's olean.
+-/
+
+import Mathlib.Tactic
+
+namespace VarignonArea
+
+/-- A point of the plane, modeled as a pair of real coordinates (matches the
+parent `VarignonTheorem.Point`). -/
+abbrev Point := ℝ × ℝ
+
+/-- The midpoint of two points (the componentwise average), as in the parent. -/
+noncomputable def midpoint2 (X Y : Point) : Point :=
+  ((X.1 + Y.1) / 2, (X.2 + Y.2) / 2)
+
+/-- The 2-D cross product (the `z`-component of the 3-D cross product, a.k.a. the
+wedge / signed parallelogram area of two vectors):
+`cross U V = U.x · V.y − U.y · V.x`. -/
+def cross (U V : Point) : ℝ := U.1 * V.2 - U.2 * V.1
+
+/-- Vector difference of two points. -/
+def sub2 (X Y : Point) : Point := (X.1 - Y.1, X.2 - Y.2)
+
+/-- The **signed area** of the quadrilateral `A → B → C → D` via the shoelace
+formula.  Unlike the unsigned area this is a polynomial in the coordinates, so it
+is defined uniformly for convex, concave, and self-intersecting quadrilaterals
+(the sign records orientation, and is negative for a clockwise traversal). -/
+noncomputable def signedArea (A B C D : Point) : ℝ :=
+  (cross A B + cross B C + cross C D + cross D A) / 2
+
+/-- The **signed area of the Varignon parallelogram** `PQRS`, where
+`P = mid(A,B)`, `Q = mid(B,C)`, `R = mid(C,D)`, `S = mid(D,A)`. -/
+noncomputable def varignonArea (A B C D : Point) : ℝ :=
+  signedArea (midpoint2 A B) (midpoint2 B C) (midpoint2 C D) (midpoint2 D A)
+
+/-- **The quadrilateral's signed area depends only on its diagonals.**
+For any quadrilateral `ABCD`, the shoelace area equals half the cross product of
+the diagonal vectors `AC = C − A` and `BD = D − B`:
+`signedArea A B C D = cross (C − A) (D − B) / 2`.  This is the key reformulation
+that makes the self-intersecting case automatic. -/
+theorem signedArea_eq_half_cross_diagonals (A B C D : Point) :
+    signedArea A B C D = cross (sub2 C A) (sub2 D B) / 2 := by
+  simp only [signedArea, cross, sub2]
+  ring
+
+/-- **The Varignon parallelogram's signed area is a quarter of the diagonal
+cross product.**  Its sides are the half-diagonals `(C − A)/2` and `(D − B)/2`,
+so its signed area is `cross (C − A) (D − B) / 4`. -/
+theorem varignonArea_eq_quarter_cross_diagonals (A B C D : Point) :
+    varignonArea A B C D = cross (sub2 C A) (sub2 D B) / 4 := by
+  simp only [varignonArea, signedArea, varignonArea, midpoint2, cross, sub2]
+  ring
+
+/-- **Varignon's area law (headline).**  The Varignon parallelogram has exactly
+half the signed area of the original quadrilateral:
+`varignonArea A B C D = signedArea A B C D / 2`.
+
+This is a polynomial identity in the eight coordinates, so it holds with **no**
+convexity or simplicity hypothesis — in particular it answers the parent's open
+question by covering the self-intersecting case on the same footing as the convex
+one. -/
+theorem varignonArea_eq_half_signedArea (A B C D : Point) :
+    varignonArea A B C D = signedArea A B C D / 2 := by
+  rw [varignonArea_eq_quarter_cross_diagonals, signedArea_eq_half_cross_diagonals]
+  ring
+
+/-- Equivalent multiplicative phrasing: twice the Varignon area equals the
+quadrilateral area, `2 · varignonArea = signedArea`. -/
+theorem two_mul_varignonArea (A B C D : Point) :
+    2 * varignonArea A B C D = signedArea A B C D := by
+  rw [varignonArea_eq_half_signedArea]; ring
+
+/-- **The Varignon parallelogram is never collapsed unless the diagonals are
+parallel.**  Its signed area vanishes exactly when the diagonal cross product
+does, i.e. when `AC ∥ BD`. -/
+theorem varignonArea_eq_zero_iff (A B C D : Point) :
+    varignonArea A B C D = 0 ↔ cross (sub2 C A) (sub2 D B) = 0 := by
+  rw [varignonArea_eq_quarter_cross_diagonals]
+  constructor
+  · intro h; linarith [h]
+  · intro h; rw [h]; ring
+
+/-! ### Self-intersecting witness
+
+A *crossed* (self-intersecting) quadrilateral, traversed `A → B → C → D` so that
+edges `BC` and `DA` cross.  Its signed shoelace area is **negative**, so the
+naive unsigned "half the area" slogan is ambiguous there, yet the signed law
+`varignonArea = signedArea / 2` holds exactly. -/
+
+/-- Vertices of a self-intersecting quadrilateral: with the order
+`(0,0) → (0,3) → (3,0) → (3,1)` the edges `BC` (from `(0,3)` to `(3,0)`) and `DA`
+(from `(3,1)` to `(0,0)`) cross at `(9/4, 3/4)`. -/
+def Ax : Point := (0, 0)
+def Bx : Point := (0, 3)
+def Cx : Point := (3, 0)
+def Dx : Point := (3, 1)
+
+/-- The crossed quadrilateral has **negative** signed area (clockwise net
+orientation): the unsigned-area picture proof cannot apply, only the signed
+identity. -/
+theorem crossed_signedArea_neg : signedArea Ax Bx Cx Dx = -3 := by
+  simp only [signedArea, cross, Ax, Bx, Cx, Dx]; norm_num
+
+/-- Even for that crossed quadrilateral the half-area law holds on the nose:
+`varignonArea = signedArea / 2 = -3/2`. -/
+theorem crossed_varignonArea : varignonArea Ax Bx Cx Dx = -3 / 2 := by
+  rw [varignonArea_eq_half_signedArea, crossed_signedArea_neg]
+
+end VarignonArea

--- a/src/data/proofs/varignon-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/varignon-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "var-oq0101-ann-docstring",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Resolving the self-intersecting area question via signed area",
+    "content": "The module docstring takes up the parent's first open question — the relationship between the Varignon parallelogram's area and the quadrilateral's area in the self-intersecting case. The classical 'half the area' proof is a picture for convex quadrilaterals and breaks for crossed ones. The fix is to use the signed shoelace area, which is a polynomial in the coordinates and so treats convex, concave, and self-intersecting quadrilaterals identically. The three deliverables are the diagonal reformulation, the headline half-area law, and an explicit crossed witness with negative signed area.",
+    "mathContext": "Goal: $\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$, hypothesis-free.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "signed area",
+      "shoelace formula",
+      "self-intersecting polygon",
+      "oriented area"
+    ],
+    "prerequisites": [
+      "coordinate geometry of the plane",
+      "the shoelace formula for polygon area"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-defs",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 44, "endLine": 70 },
+    "type": "definition",
+    "title": "Cross product, shoelace area, and the Varignon area",
+    "content": "Points are pairs in ℝ × ℝ and midpoint2 is the componentwise average (matching the parent). The 2-D cross product cross U V = U.x·V.y − U.y·V.x is the oriented area of the parallelogram on U and V. signedArea A B C D is the shoelace sum (cross A B + cross B C + cross C D + cross D A)/2, defined uniformly regardless of orientation or self-intersection. varignonArea A B C D applies signedArea to the four side midpoints P = mid(A,B), Q = mid(B,C), R = mid(C,D), S = mid(D,A).",
+    "mathContext": "$\\operatorname{signedArea}(A,B,C,D)=\\tfrac12\\big(\\operatorname{cross}(A,B)+\\operatorname{cross}(B,C)+\\operatorname{cross}(C,D)+\\operatorname{cross}(D,A)\\big)$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "cross product",
+      "shoelace formula",
+      "midpoint",
+      "oriented area"
+    ],
+    "prerequisites": [
+      "vectors and the midpoint formula",
+      "the 2-D cross product as signed area"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-diagonal",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 96 },
+    "type": "technique",
+    "title": "The shoelace sum telescopes to the diagonal cross product",
+    "content": "The pivotal lemma signedArea_eq_half_cross_diagonals shows the four-edge shoelace sum collapses to a single cross product of the diagonals: signedArea A B C D = cross (C − A) (D − B) / 2. So a quadrilateral's signed area depends only on its diagonals AC and BD. Applying the same to the four midpoints gives varignonArea = cross (C − A) (D − B) / 4 — the Varignon sides are the half-diagonals (C−A)/2 and (D−B)/2. Both identities are closed by `ring` after unfolding the definitions.",
+    "mathContext": "$\\operatorname{signedArea}=\\tfrac12\\operatorname{cross}(C-A,D-B)$ and $\\operatorname{varignonArea}=\\tfrac14\\operatorname{cross}(C-A,D-B)$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "diagonals of a quadrilateral",
+      "telescoping",
+      "ring tactic",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "algebraic manipulation of coordinates"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-halfarea",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 118 },
+    "type": "key-step",
+    "title": "The half-area law (headline)",
+    "content": "Dividing the two diagonal forms gives the headline theorem varignonArea_eq_half_signedArea: varignonArea A B C D = signedArea A B C D / 2, with the equivalent multiplicative phrasing 2·varignonArea = signedArea. Because both sides are polynomials in the eight coordinates, this carries NO convexity, simplicity, or non-degeneracy hypothesis — the self-intersecting case is the same theorem. The companion varignonArea_eq_zero_iff reads off the collapse criterion: the Varignon parallelogram is degenerate exactly when the diagonal cross product vanishes, i.e. AC ∥ BD.",
+    "mathContext": "$\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$; degenerate $\\iff \\operatorname{cross}(C-A,D-B)=0$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "area ratio",
+      "parallel diagonals",
+      "degenerate parallelogram"
+    ],
+    "prerequisites": [
+      "the diagonal reformulation lemmas"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-witness",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 119, "endLine": 145 },
+    "type": "example",
+    "title": "A crossed quadrilateral with negative signed area",
+    "content": "The witness (0,0)→(0,3)→(3,0)→(3,1) is genuinely self-intersecting: edges BC (from (0,3) to (3,0)) and DA (from (3,1) to (0,0)) cross at (9/4, 3/4). Its signed shoelace area is −3 (clockwise net orientation), so the unsigned 'half the area' slogan is ambiguous as drawn. Nevertheless crossed_varignonArea confirms the signed law on the nose: varignonArea = −3/2 = (−3)/2. This is the concrete payoff of using signed area — the crossed case needs no separate argument.",
+    "mathContext": "$\\operatorname{signedArea}=-3$, $\\operatorname{varignonArea}=-\\tfrac32$ for the crossed quadrilateral.",
+    "significance": "illustrative",
+    "relatedConcepts": [
+      "self-intersecting quadrilateral",
+      "bowtie / crossed quadrilateral",
+      "negative oriented area"
+    ],
+    "prerequisites": [
+      "the half-area law"
+    ]
+  }
+]

--- a/src/data/proofs/varignon-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/varignon-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "varignon-theorem-oq-01-oq-01",
+  "slug": "varignon-theorem-oq-01-oq-01",
+  "title": "The Signed-Area Law for the Varignon Parallelogram (incl. the self-intersecting case)",
+  "description": "Using the signed shoelace area, the Varignon parallelogram has exactly half the signed area of its quadrilateral — a single polynomial identity that holds with no convexity or simplicity hypothesis, resolving the self-intersecting case posed in the parent's open question.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VarignonTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "quadrilateral",
+      "parallelogram",
+      "signed-area",
+      "shoelace-formula",
+      "coordinate-geometry",
+      "classical"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ring",
+        "description": "Commutative-ring normalization tactic; discharges every coordinate identity (the diagonal-cross reformulation and the half-area law).",
+        "module": "Mathlib.Tactic.Ring"
+      },
+      {
+        "theorem": "norm_num",
+        "description": "Numerical normalization used to evaluate the signed area of the explicit self-intersecting witness.",
+        "module": "Mathlib.Tactic.NormNum"
+      }
+    ],
+    "originalContributions": [
+      "Signed (shoelace) area of a quadrilateral formalized over ℝ × ℝ as a polynomial in the eight coordinates, defined uniformly for convex, concave, and self-intersecting quadrilaterals",
+      "Diagonal reformulation: signedArea A B C D = cross (C − A) (D − B) / 2 — the quadrilateral's signed area depends only on its two diagonals",
+      "Headline half-area law: varignonArea A B C D = signedArea A B C D / 2, proved as a single ring identity with NO convexity, simplicity, or non-degeneracy hypothesis — directly answering the parent's open question for the self-intersecting case",
+      "Collapse criterion: the Varignon parallelogram is degenerate iff the diagonals are parallel (cross of diagonals = 0)",
+      "Explicit self-intersecting witness ((0,0)→(0,3)→(3,0)→(3,1)) with NEGATIVE signed area −3, showing the unsigned 'half the area' slogan is ambiguous there while the signed law holds exactly (varignonArea = −3/2)"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide. The half-area law is a polynomial identity, so it holds for every quadrilateral — convex, concave, or self-intersecting.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 6,
+    "sourceUrl": ""
+  },
+  "overview": {
+    "historicalContext": "Varignon's midpoint theorem (published posthumously in 1731) states that the side midpoints of any quadrilateral form a parallelogram. The companion metric fact — that this Varignon parallelogram has half the area of the quadrilateral — is classically proved for convex quadrilaterals by an area-decomposition picture, and the picture is what fails when the quadrilateral is self-intersecting (crossed). The parent gallery entry formalizes the affine skeleton (the parallelogram property) and explicitly leaves the self-intersecting area relationship as an open question. The resolution is to use signed area: the shoelace formula assigns every closed polygon a signed area that is a polynomial in the vertex coordinates, so it makes no distinction between convex, concave, and self-intersecting polygons. The half-area law then becomes a single algebraic identity valid in all cases at once.",
+    "problemStatement": "Let ABCD be a quadrilateral with side midpoints P = mid(A,B), Q = mid(B,C), R = mid(C,D), S = mid(D,A). Working with the signed shoelace area, prove that the Varignon parallelogram PQRS satisfies area(PQRS) = ½·area(ABCD), and that this holds for an arbitrary quadrilateral — in particular for the self-intersecting case where the unsigned 'half the area' statement is no longer meaningful as drawn.",
+    "text": "The Varignon parallelogram has exactly half the signed area of the quadrilateral, in every case including self-intersecting ones.",
+    "proofStrategy": "Model points as ℝ × ℝ and define the 2-D cross product cross U V = U.x·V.y − U.y·V.x. The signed area of A→B→C→D is the shoelace sum (cross A B + cross B C + cross C D + cross D A)/2, and the Varignon area is the same functional applied to the four midpoints. The key reformulation, proved by `ring`, is that the shoelace sum telescopes to the cross product of the diagonals: signedArea A B C D = cross (C−A) (D−B) / 2. The Varignon parallelogram has side vectors equal to the half-diagonals (C−A)/2 and (D−B)/2, so the same computation gives varignonArea = cross (C−A) (D−B) / 4. Dividing, varignonArea = signedArea / 2. Because both sides are real polynomials in the eight coordinates, the identity is hypothesis-free, so the self-intersecting case is literally the same theorem. An explicit crossed quadrilateral with negative signed area is exhibited to confirm the law is genuinely signed.",
+    "keyInsights": [
+      "Replacing unsigned area (a piecewise, picture-dependent quantity) with the signed shoelace area (a single polynomial) is what makes the self-intersecting case disappear as a special case — there is only one identity to prove",
+      "The quadrilateral's signed area depends only on its diagonals: signedArea A B C D = ½·cross(AC, BD). The shoelace sum over the four edges telescopes to one cross product of the diagonal vectors",
+      "The Varignon parallelogram's sides are exactly the half-diagonals (C−A)/2 and (D−B)/2, so its signed area is ¼·cross(AC, BD) — a quarter of the diagonal cross product, hence half the quadrilateral's area",
+      "The half-area law varignonArea = signedArea/2 carries no convexity, simplicity, planarity, or non-degeneracy hypothesis; it is an identity of polynomials and therefore covers degenerate, concave, and self-intersecting quadrilaterals verbatim",
+      "Signed area can be negative: the crossed witness (0,0)→(0,3)→(3,0)→(3,1) has signed area −3 (clockwise net orientation). The unsigned slogan 'half the area' is ambiguous for such a bowtie, but the signed identity varignonArea = −3/2 = (−3)/2 holds on the nose",
+      "The Varignon parallelogram collapses to a segment exactly when the diagonal cross product vanishes, i.e. when the diagonals AC and BD are parallel — a clean affine non-degeneracy criterion read straight off the diagonal formula"
+    ],
+    "prerequisites": [
+      "Coordinate geometry of the plane (points as ordered pairs)",
+      "The shoelace (Gauss) formula for the signed area of a polygon",
+      "The 2-D cross product / wedge as oriented parallelogram area",
+      "Varignon's parallelogram theorem (the parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Docstring posing the parent's self-intersecting open question and the signed-area strategy, followed by the imports and the core definitions: Point = ℝ × ℝ, the componentwise midpoint2 (matching the parent), the 2-D cross product `cross`, vector difference `sub2`, the shoelace `signedArea` of a quadrilateral, and `varignonArea` (signedArea of the four side midpoints).",
+      "mathContext": "$\\operatorname{cross}(U,V)=U_xV_y-U_yV_x$; $\\operatorname{signedArea}(A,B,C,D)=\\tfrac12\\sum_{\\text{edges}}\\operatorname{cross}$."
+    },
+    {
+      "id": "diagonal-forms",
+      "title": "Diagonal Reformulations",
+      "startLine": 71,
+      "endLine": 96,
+      "summary": "The two telescoping identities proved by `ring`: the quadrilateral's signed area equals half the cross product of its diagonals (signedArea = cross(C−A, D−B)/2), and the Varignon area equals a quarter of the same diagonal cross product (varignonArea = cross(C−A, D−B)/4).",
+      "mathContext": "$\\operatorname{signedArea}=\\tfrac12\\operatorname{cross}(C-A,D-B)$, $\\operatorname{varignonArea}=\\tfrac14\\operatorname{cross}(C-A,D-B)$."
+    },
+    {
+      "id": "half-area-law",
+      "title": "The Half-Area Law",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "The headline identity varignonArea = signedArea/2 (with the equivalent multiplicative form 2·varignonArea = signedArea), obtained by dividing the two diagonal forms — a hypothesis-free polynomial identity. Plus the collapse criterion varignonArea = 0 ⟺ diagonals parallel.",
+      "mathContext": "$\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$."
+    },
+    {
+      "id": "self-intersecting-witness",
+      "title": "Self-Intersecting Witness",
+      "startLine": 119,
+      "endLine": 145,
+      "summary": "An explicit crossed quadrilateral (0,0)→(0,3)→(3,0)→(3,1) whose edges BC and DA cross, with NEGATIVE signed area −3. It demonstrates that the law is genuinely signed: the unsigned 'half the area' picture cannot apply, yet varignonArea = −3/2 holds exactly.",
+      "mathContext": "$\\operatorname{signedArea}=-3$, $\\operatorname{varignonArea}=-\\tfrac32$ for the crossed witness."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "varignon-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the affine Varignon theorem (side midpoints form a parallelogram, with sides half the diagonals). This entry adds the metric/area layer with signed area and resolves the parent's first open question — the area relationship in the self-intersecting case — by proving varignonArea = signedArea/2 as a hypothesis-free polynomial identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Working with the signed shoelace area over ℝ × ℝ, the Varignon parallelogram has exactly half the signed area of its quadrilateral: varignonArea A B C D = signedArea A B C D / 2. The proof factors through a diagonal reformulation — the signed area of any quadrilateral is half the cross product of its diagonals — so both the quadrilateral and its Varignon parallelogram have areas proportional to cross(AC, BD), in ratio 2:1. The result is a single ring identity, fully verified with 0 axioms and 0 sorries.",
+    "implications": "Because the half-area law is an identity of polynomials, it covers every quadrilateral — convex, concave, degenerate, or self-intersecting — with no case split, which is the precise sense in which the parent's open question is resolved. An explicit crossed quadrilateral with signed area −3 shows the identity is genuinely signed (varignonArea = −3/2), where the classical unsigned 'half the area' picture proof has no meaning. The diagonal formula also yields the collapse criterion: the Varignon parallelogram degenerates exactly when the diagonals are parallel.",
+    "openQuestions": [
+      "Does the same signed-area identity extend to the n-gon midpoint polygon, and what is the area ratio there (it is not constant for n > 4)?",
+      "What signed-area identity governs the iterated midpoint quadrilaterals, whose signed areas form a geometric-like sequence converging to 0 as the iterates shrink to the centroid?"
+    ]
+  },
+  "references": [
+    {
+      "title": "Varignon's theorem",
+      "url": "https://en.wikipedia.org/wiki/Varignon%27s_theorem",
+      "type": "encyclopedia"
+    },
+    {
+      "title": "Shoelace formula (Gauss's area formula)",
+      "url": "https://en.wikipedia.org/wiki/Shoelace_formula",
+      "type": "encyclopedia"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "VarignonArea",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 6,
+    "path": "Proofs/VarignonTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** of `varignon-theorem-oq-01`: the relationship between the Varignon parallelogram's area and the quadrilateral's area in the **self-intersecting case**.

The classical "half the area" fact is normally proved by an area-decomposition picture valid only for convex quadrilaterals. This entry replaces the picture with the **signed shoelace area**, a polynomial in the eight vertex coordinates, so convex, concave, and self-intersecting quadrilaterals are all the same identity.

## Results (`proofs/Proofs/VarignonTheoremOQ01OQ01.lean`, namespace `VarignonArea`)

- **Diagonal reformulation** — `signedArea A B C D = cross (C−A) (D−B) / 2`: a quadrilateral's signed area depends only on its diagonals AC, BD.
- **Varignon diagonal form** — `varignonArea A B C D = cross (C−A) (D−B) / 4` (sides are the half-diagonals).
- **Headline half-area law** — `varignonArea A B C D = signedArea A B C D / 2`, a hypothesis-free `ring` identity (no convexity / simplicity / non-degeneracy), so the self-intersecting case is literally the same theorem.
- **Collapse criterion** — `varignonArea = 0 ↔ diagonals parallel`.
- **Self-intersecting witness** — `(0,0)→(0,3)→(3,0)→(3,1)` (edges BC, DA cross) has **negative** signed area −3, with `varignonArea = −3/2` holding exactly. The unsigned "half the area" slogan is ambiguous there; the signed law is not.

## Verification

- 7 theorems, 6 definitions, 145 lines.
- **0 axioms, 0 sorries** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`. No `decide`/`native_decide`.
- Built on Lean v4.26.0 (`lake env lean`, single-file; docker daemon down this cycle).
- Conventions (`Point := ℝ × ℝ`, `midpoint2`) match the parent; `signedArea`/`cross` declared self-containedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)