### PR TITLE
Fix: erdos-125 sorry count 17->0 to match canonical statement file

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,13 +21,13 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 17,
+    "sorries": 0,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 92,
-    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 12 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The Aristotle companion Erdos125PositiveLowerDensityAristotle.lean (114 lines) exposes 5 additional routine digit-combinatorics targets (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`) as `sorry` for automated proof search. Chain-aggregate sorry count: 12 + 5 = 17. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
+    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 14 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The Aristotle companion Erdos125PositiveLowerDensityAristotle.lean (114 lines) exposes 6 additional routine digit-combinatorics targets (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`) as `sorry` for automated proof search. The canonical statement file (proofRepoPath) carries 0 sorries; the two WIP companion files contain 14 + 6 = 20 sorries between them, tracked separately in #20842. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
     "definitionCount": 7
@@ -203,5 +203,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 17
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-125/meta.json` claimed `sorries: 17`, but its declared `proofRepoPath` (`Proofs/Erdos125Problem.lean`) is a definitions-only open-problem statement file with **0 sorries**. Set the sorry counts to 0 and corrected the inaccurate companion-file sorry counts in the `assumptions` prose.

## Evidence

**Before**:
- `meta.sorries = 17`, top-level `sorries = 17` — a stale "chain-aggregate" across two non-canonical WIP companion files.
- `assumptions` prose claimed "12 sorry placeholders" + "5 additional ... targets" / "12 + 5 = 17".

**After** (host `grep -c '\bsorry\b'`):
| File | role | sorries |
|---|---|---|
| `Erdos125Problem.lean` | proofRepoPath (canonical) | **0** |
| `Erdos125PositiveLowerDensity.lean` | additionalFiles (WIP) | 14 |
| `Erdos125PositiveLowerDensityAristotle.lean` | additionalFiles (WIP) | 6 |

- `meta.sorries = 0`, top-level `sorries = 0` (now matches the canonical file; `leanFile.sorries` was already 0).
- `assumptions` prose corrected to 14 + 6 = 20 companion sorries, with the canonical statement file at 0; companion mechanization tracked in #20842.

**Coherent triple**: `proofRepoPath` (statement file) ↔ `sorries: 0` ↔ `status: axiomatized` / `badge: wip`. Status/badge are unchanged — this matches the gallery convention for open Erdős conjecture statement entries (43 sibling definitions-only entries use `axiomatized`/`wip` with `axiomCount: 0`; CLAUDE.md: "open conjectures: always axiomatized").

Scope: metadata-only, no Lean changes. The 20 companion sorries are out of scope (tracked in #20842).

Closes #29458

---
Automated fix by lean-mechanic agent.