### PR TITLE
Enrich First-Order Characterization of Convex Minimizers (hilbert-23-oq-01)

### DIFF
--- a/src/data/proofs/hilbert-23-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-23-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-h23oq01-overview",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "First-order theory for convex variational problems",
+    "content": "The docstring frames a clean, self-contained slice of the regularity/sufficiency theory that Hilbert's 23rd problem asks for. For a convex functional J, the Euler–Lagrange / first-variation condition is not just necessary for a minimizer but also sufficient, and strict convexity upgrades this to uniqueness. Strikingly, the whole package is proved with zero axioms over an arbitrary real vector space E — no norm, no measure theory — because everything reduces to Mathlib's convexity slope monotonicity. The 'first variation' is the right-hand derivative at t=0 of t ↦ J(y₀ + t(y−y₀)), i.e. the Gateaux derivative along admissible directions.",
+    "mathContext": "For convex $J$: $y_0$ minimizes $\\iff$ all first variations $\\delta J(y_0; y-y_0)\\ge 0$. Strict convexity $\\Rightarrow$ unique minimizer.",
+    "significance": "key",
+    "relatedConcepts": ["calculus of variations", "Euler–Lagrange equation", "convex functional", "Gateaux derivative", "well-posedness"],
+    "prerequisites": ["convex analysis", "directional derivatives", "real vector spaces"]
+  },
+  {
+    "id": "ann-h23oq01-segpath",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 40, "endLine": 54 },
+    "type": "definition",
+    "title": "The variational path and its convex-combination form",
+    "content": "segPath J y₀ y t := J(y₀ + t·(y − y₀)) is the value of J along the segment from y₀ toward y; its right derivative at 0 is the first variation. Two helper lemmas: segPath_zero (the path starts at J y₀) and segPath_eq_combo, which rewrites the path point as the convex combination (1−t)·y₀ + t·y — the bridge that lets ConvexOn's slope inequality apply directly. The `module` tactic discharges the vector-space identity y₀ + t(y−y₀) = (1−t)y₀ + ty.",
+    "mathContext": "$\\mathrm{segPath}(t) = J(y_0 + t(y-y_0)) = J((1-t)y_0 + t y)$, $\\mathrm{segPath}(0)=J(y_0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["line segment", "convex combination", "module tactic", "parametrized path"],
+    "prerequisites": ["vector space operations", "convex sets"]
+  },
+  {
+    "id": "ann-h23oq01-engine",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 56, "endLine": 84 },
+    "type": "insight",
+    "title": "Convexity engine: the first variation is bounded by J y − J y₀",
+    "content": "firstVariation_le_sub is the technical heart. For convex J, the right derivative d of segPath at 0 satisfies d ≤ J y − J y₀ — the quantitative 'tangent line lies below the convex curve.' The proof first establishes the slope bound segPath(t) − J y₀ ≤ t·(J y − J y₀) for t ∈ (0,1] directly from ConvexOn's defining inequality (via segPath_eq_combo and nlinarith), then passes to the limit t → 0⁺: the right derivative is ≤ every such slope, using hasDerivWithinAt_iff_tendsto_slope and le_of_tendsto with a filter_upwards restricting to t < 1.",
+    "mathContext": "$\\delta J(y_0; y-y_0) \\le J y - J y_0$ — the supporting-tangent inequality for convex $J$.",
+    "significance": "critical",
+    "relatedConcepts": ["supporting hyperplane", "slope monotonicity", "hasDerivWithinAt_iff_tendsto_slope", "le_of_tendsto", "ConvexOn"],
+    "prerequisites": ["one-sided derivatives", "limits of slopes", "convexity inequality"]
+  },
+  {
+    "id": "ann-h23oq01-necessity",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 86, "endLine": 99 },
+    "type": "theorem",
+    "title": "Necessity: a minimizer has nonnegative first variation",
+    "content": "firstVariation_nonneg_of_isMinOn is the classical necessary condition (no convexity needed): if y₀ minimizes J, then every first variation d ≥ 0. Each slope (segPath(t) − J y₀)/t has nonnegative numerator (minimality) and positive denominator, so is ≥ 0; the right derivative inherits the bound by ge_of_tendsto. This is the Euler–Lagrange necessary condition in directional-derivative form.",
+    "mathContext": "$y_0$ minimizes $\\Rightarrow \\delta J(y_0; y-y_0)\\ge 0$ for all directions, since $\\frac{J(y_0+t(y-y_0))-J(y_0)}{t}\\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["necessary condition", "ge_of_tendsto", "minimality", "Euler–Lagrange"],
+    "prerequisites": ["nonnegative slopes", "limit inequalities"]
+  },
+  {
+    "id": "ann-h23oq01-sufficiency",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 101, "endLine": 127 },
+    "type": "theorem",
+    "title": "Sufficiency and the first-order characterization",
+    "content": "isMinOn_of_firstVariation_nonneg is the converse that convexity buys: if every first variation at y₀ is ≥ 0, then for each y, 0 ≤ d ≤ J y − J y₀ (combining nonnegativity with the convexity engine), so y₀ is a global minimizer. isMinOn_iff_firstVariation_nonneg packages necessity and sufficiency into a biconditional — the full Euler–Lagrange characterization: for convex problems the first-order condition is exactly minimality. This sufficiency is what makes convex variational problems tractable; without convexity the first-order condition is necessary only.",
+    "mathContext": "Convex $J$: $\\big(\\forall y,\\ J y_0\\le J y\\big) \\iff \\big(\\forall y\\ d,\\ \\text{deriv}=d \\Rightarrow d\\ge0\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["sufficient condition", "first-order characterization", "biconditional", "convex optimization"],
+    "prerequisites": ["the convexity engine", "the necessity lemma"]
+  },
+  {
+    "id": "ann-h23oq01-uniqueness",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 129, "endLine": 142 },
+    "type": "theorem",
+    "title": "Uniqueness from strict convexity",
+    "content": "subsingleton_minimizers_of_strictConvex shows a strictly convex J has at most one global minimizer. If a ≠ b were both minimizers, strict convexity gives J(½a + ½b) < ½J a + ½J b = J a (since minimizers share the same value J a = J b), contradicting that a is a minimizer (J a ≤ J(midpoint)). Combined with sufficiency, this is the classical well-posedness statement: a strictly convex variational problem has a unique solution, and any Euler–Lagrange solution is THE minimizer.",
+    "mathContext": "Strictly convex $J$: $J(\\tfrac{a+b}{2}) < \\tfrac12 J a + \\tfrac12 J b = J a$ if $a\\ne b$ both minimize — contradiction. So the minimizer is unique.",
+    "significance": "key",
+    "relatedConcepts": ["StrictConvexOn", "uniqueness", "well-posed problem", "midpoint strict inequality"],
+    "prerequisites": ["strict convexity", "proof by contradiction"]
+  },
+  {
+    "id": "ann-h23oq01-instance",
+    "proofId": "hilbert-23-oq-01",
+    "range": { "startLine": 149, "endLine": 164 },
+    "type": "technique",
+    "title": "Concrete instance: minimizing J(y) = y²",
+    "content": "The simplest variational problem grounds the abstract theory. example_convex / example_strictConvex establish that y² is (strictly) convex on ℝ via Even.strictConvexOn_pow; example_zero_isMin shows 0 minimizes (y² ≥ 0); and example_unique_minimizer applies subsingleton_minimizers_of_strictConvex to conclude 0 is THE unique minimizer. A clean end-to-end demonstration that the general machinery instantiates to a familiar concrete case.",
+    "mathContext": "$J(y)=y^2$ is strictly convex on $\\mathbb{R}$; its unique minimizer is $0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Even.strictConvexOn_pow", "energy functional", "worked example"],
+    "prerequisites": ["the uniqueness theorem", "convexity of powers"]
+  }
+]

--- a/src/data/proofs/hilbert-23-oq-01/index.ts
+++ b/src/data/proofs/hilbert-23-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert23CalculusVariationsOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert23CalculusVariationsOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert23CalculusVariationsOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert23CalculusVariationsOQ01Data: ProofData = {
+  proof: hilbert23CalculusVariationsOQ01Proof,
+  annotations: hilbert23CalculusVariationsOQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hilbert-23-oq-01`.

## Gap addressed
Entry had **only meta.json** — no annotations.json.

## Added
- **annotations.json** with **7 annotations** (overview; the variational path segPath; the convexity engine bounding the first variation by J y − J y₀; necessity; sufficiency + the necessary-and-sufficient first-order characterization; uniqueness from strict convexity; and the concrete J(y)=y² instance), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts** entry point.

## Verification
- JSON validates; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms / badge verified.