### PR TITLE
research(open-mapping-theorem-oq-01-oq-01): Hellinger–Toeplitz is sharp — an everywhere-defined symmetric operator that is unbounded

### DIFF
--- a/proofs/Proofs/HellingerToeplitzSharpOQ010101.lean
+++ b/proofs/Proofs/HellingerToeplitzSharpOQ010101.lean
@@ -1,0 +1,227 @@
+import Mathlib
+
+/-
+# Hellinger–Toeplitz is sharp: completeness cannot be dropped
+
+The **Hellinger–Toeplitz theorem** states that a symmetric, *everywhere-defined* linear
+operator `T` on a Hilbert space is automatically continuous (bounded), and hence a bounded
+self-adjoint operator.  In Mathlib this is `LinearMap.IsSymmetric.continuous`, proved via the
+closed graph theorem, with the bundling into a bounded self-adjoint operator supplied by
+`LinearMap.IsSymmetric.toSelfAdjoint`.  The hypothesis that `T` is everywhere defined is what
+makes this surprising: for *densely* defined symmetric operators (the typical situation in
+quantum mechanics, e.g. position and momentum) unboundedness is the norm.
+
+The forward theorem crucially uses **completeness** of the space.  This entry proves that the
+completeness hypothesis is *sharp* — it cannot be dropped — by exhibiting, on an explicit
+**incomplete** inner product space, an everywhere-defined symmetric operator that is **not
+bounded**.
+
+The space is `ℕ →₀ ℝ`, the finitely supported real sequences, equipped with the `ℓ²` inner
+product `⟪x, y⟫ = ∑ᵢ xᵢ yᵢ` (a finite sum since the sequences have finite support).  Its
+completion is the Hilbert space `ℓ²(ℕ)`, but the space itself is a proper dense subspace and so
+is not complete.  On it we put the **diagonal operator**
+
+      `D x = (n ↦ n · xₙ)`,
+
+which is everywhere defined, linear, and symmetric, yet sends the unit basis vector `eₖ` to
+`k · eₖ`, so `‖D eₖ‖ / ‖eₖ‖ = k → ∞`: `D` is unbounded.
+
+The punchline is a clean structural consequence: because Mathlib's Hellinger–Toeplitz theorem
+forces every symmetric operator on a *complete* space to be continuous, the mere existence of
+our symmetric **discontinuous** `D` re-proves that the finitely supported `ℓ²` space is **not
+complete** (`not_completeSpace`).
+
+All results are fully machine-checked with no axioms or sorries.  The forward Hellinger–Toeplitz
+statement is recorded for context and is a thin wrapper around Mathlib; the original content is
+the sharpness construction and its consequences.
+-/
+
+namespace HellingerToeplitzSharp
+
+open scoped BigOperators
+
+/-! ## The `ℓ²` inner product on finitely supported sequences -/
+
+/-- The `ℓ²` inner product on finitely supported real sequences:
+`⟪x, y⟫ = ∑ᵢ xᵢ yᵢ`, a finite sum over the (finite) support of `x`. -/
+def ip (x y : ℕ →₀ ℝ) : ℝ := x.sum fun i a => a * y i
+
+/-- `ip` written as a finite sum over any finset containing the support of its first argument. -/
+theorem ip_eq_sum_of_subset (x y : ℕ →₀ ℝ) {s : Finset ℕ} (hs : x.support ⊆ s) :
+    ip x y = ∑ i ∈ s, x i * y i := by
+  rw [ip, Finsupp.sum]
+  refine Finset.sum_subset hs ?_
+  intro i _ hi
+  rw [Finsupp.notMem_support_iff.1 hi, zero_mul]
+
+/-- The inner product is symmetric. -/
+theorem ip_comm (x y : ℕ →₀ ℝ) : ip x y = ip y x := by
+  rw [ip_eq_sum_of_subset x y (s := x.support ∪ y.support) Finset.subset_union_left,
+      ip_eq_sum_of_subset y x (s := x.support ∪ y.support) Finset.subset_union_right]
+  exact Finset.sum_congr rfl fun i _ => mul_comm _ _
+
+/-- Additivity in the first coordinate. -/
+theorem ip_add_left (x y z : ℕ →₀ ℝ) : ip (x + y) z = ip x z + ip y z := by
+  simp only [ip]
+  exact Finsupp.sum_add_index' (fun i => by rw [zero_mul]) (fun i b₁ b₂ => by rw [add_mul])
+
+/-- Homogeneity in the first coordinate. -/
+theorem ip_smul_left (r : ℝ) (x y : ℕ →₀ ℝ) : ip (r • x) y = r * ip x y := by
+  simp only [ip]
+  rw [Finsupp.sum_smul_index' (fun i => by rw [zero_mul])]
+  simp only [smul_eq_mul, Finsupp.sum, Finset.mul_sum]
+  exact Finset.sum_congr rfl fun i _ => by ring
+
+/-- The inner product is positive semidefinite. -/
+theorem ip_self_nonneg (x : ℕ →₀ ℝ) : 0 ≤ ip x x := by
+  rw [ip, Finsupp.sum]
+  exact Finset.sum_nonneg fun i _ => mul_self_nonneg _
+
+/-- The inner product is definite. -/
+theorem ip_definite (x : ℕ →₀ ℝ) (h : ip x x = 0) : x = 0 := by
+  rw [ip, Finsupp.sum] at h
+  have hz : ∀ i ∈ x.support, x i * x i = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg fun i _ => mul_self_nonneg _).1 h
+  ext i
+  by_cases hi : i ∈ x.support
+  · rw [Finsupp.zero_apply, ← mul_self_eq_zero]
+    exact hz i hi
+  · rw [Finsupp.notMem_support_iff.1 hi, Finsupp.zero_apply]
+
+/-- The inner product of a basis-like single with itself. -/
+theorem ip_single_self (k : ℕ) (a : ℝ) :
+    ip (Finsupp.single k a) (Finsupp.single k a) = a * a := by
+  rw [ip_eq_sum_of_subset _ _ (s := {k}) Finsupp.support_single_subset,
+      Finset.sum_singleton, Finsupp.single_eq_same]
+
+/-! ## The inner product space structure on `ℕ →₀ ℝ` -/
+
+instance : Inner ℝ (ℕ →₀ ℝ) := ⟨ip⟩
+
+theorem real_inner_eq (x y : ℕ →₀ ℝ) : (inner ℝ x y : ℝ) = ip x y := rfl
+
+noncomputable instance instNAG : NormedAddCommGroup (ℕ →₀ ℝ) :=
+  @InnerProductSpace.Core.toNormedAddCommGroup ℝ (ℕ →₀ ℝ) _ _ _
+    { toInner := inferInstance
+      conj_inner_symm := fun x y => by
+        simp only [starRingEnd_apply, star_trivial]; exact ip_comm y x
+      re_inner_nonneg := fun x => ip_self_nonneg x
+      definite := fun x h => ip_definite x h
+      add_left := fun x y z => ip_add_left x y z
+      smul_left := fun x y r => by
+        simp only [starRingEnd_apply, star_trivial]; exact ip_smul_left r x y }
+
+noncomputable instance : InnerProductSpace ℝ (ℕ →₀ ℝ) := InnerProductSpace.ofCore _
+
+/-- The norm of a nonnegative single equals its value. -/
+theorem norm_single {k : ℕ} {a : ℝ} (ha : 0 ≤ a) : ‖Finsupp.single k a‖ = a := by
+  have hsq : ‖Finsupp.single k a‖ * ‖Finsupp.single k a‖ = a * a := by
+    rw [← real_inner_self_eq_norm_mul_norm, real_inner_eq, ip_single_self]
+  exact (mul_self_inj (norm_nonneg _) ha).1 hsq
+
+/-! ## The unbounded symmetric diagonal operator -/
+
+/-- The diagonal-weighted sequence `n ↦ n · xₙ` has finite support. -/
+theorem diag_support_finite (x : ℕ →₀ ℝ) :
+    (Function.support fun i : ℕ => (i : ℝ) * x i).Finite := by
+  refine Set.Finite.subset x.support.finite_toSet ?_
+  intro i hi
+  simp only [Function.mem_support] at hi
+  exact Finsupp.mem_support_iff.2 fun h => hi (by rw [h, mul_zero])
+
+/-- The everywhere-defined **diagonal operator** `D x = (n ↦ n · xₙ)`. -/
+noncomputable def D : (ℕ →₀ ℝ) →ₗ[ℝ] (ℕ →₀ ℝ) where
+  toFun x := Finsupp.ofSupportFinite (fun i : ℕ => (i : ℝ) * x i) (diag_support_finite x)
+  map_add' x y := by
+    ext i
+    simp only [Finsupp.ofSupportFinite_coe, Finsupp.add_apply, mul_add]
+  map_smul' r x := by
+    ext i
+    simp only [Finsupp.ofSupportFinite_coe, Finsupp.coe_smul, Pi.smul_apply, smul_eq_mul,
+      RingHom.id_apply]
+    ring
+
+@[simp] theorem D_apply (x : ℕ →₀ ℝ) (i : ℕ) : D x i = (i : ℝ) * x i := rfl
+
+/-- `D` maps the unit basis vector `eₖ = single k 1` to `k · eₖ = single k k`. -/
+theorem D_single (k : ℕ) : D (Finsupp.single k (1 : ℝ)) = Finsupp.single k (k : ℝ) := by
+  ext i
+  rw [D_apply, Finsupp.single_apply, Finsupp.single_apply]
+  split_ifs with h
+  · rw [h, mul_one]
+  · rw [mul_zero]
+
+/-- `D` is **symmetric**: `⟪D x, y⟫ = ⟪x, D y⟫` for all `x, y`. -/
+theorem D_isSymmetric : (D).IsSymmetric := by
+  intro x y
+  rw [real_inner_eq, real_inner_eq]
+  have hsub1 : (D x).support ⊆ x.support ∪ y.support := by
+    refine Finset.Subset.trans ?_ Finset.subset_union_left
+    intro i hi
+    rw [Finsupp.mem_support_iff] at hi ⊢
+    exact fun hx => hi (by rw [D_apply, hx, mul_zero])
+  have hsub2 : (D y).support ⊆ x.support ∪ y.support := by
+    refine Finset.Subset.trans ?_ Finset.subset_union_right
+    intro i hi
+    rw [Finsupp.mem_support_iff] at hi ⊢
+    exact fun hy => hi (by rw [D_apply, hy, mul_zero])
+  rw [ip_comm x (D y), ip_eq_sum_of_subset (D x) y hsub1,
+      ip_eq_sum_of_subset (D y) x hsub2]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [D_apply, D_apply]; ring
+
+/-- `D` is **not continuous**: it is unbounded, witnessed by `‖D eₖ‖ = k‖eₖ‖`. -/
+theorem D_not_continuous : ¬ Continuous (D : (ℕ →₀ ℝ) → (ℕ →₀ ℝ)) := by
+  intro hcont
+  obtain ⟨C, _, hbound⟩ := SemilinearMapClass.bound_of_continuous D hcont
+  obtain ⟨k, hk⟩ := exists_nat_gt C
+  have h1 : ‖Finsupp.single k (1 : ℝ)‖ = 1 := norm_single zero_le_one
+  have h2 : ‖D (Finsupp.single k (1 : ℝ))‖ = (k : ℝ) := by
+    rw [D_single, norm_single (Nat.cast_nonneg k)]
+  have hb := hbound (Finsupp.single k (1 : ℝ))
+  rw [h1, h2, mul_one] at hb
+  linarith
+
+/-! ## Sharpness: completeness is necessary
+
+A symmetric operator on a *complete* inner product space is continuous (the Hellinger–Toeplitz
+theorem, `LinearMap.IsSymmetric.continuous`).  Our `D` is symmetric but discontinuous, so the
+space it lives on cannot be complete. -/
+
+/-- The finitely supported `ℓ²` space is **not complete**: a clean corollary of the existence of
+a symmetric discontinuous operator, via the contrapositive of Hellinger–Toeplitz. -/
+theorem not_completeSpace : ¬ CompleteSpace (ℕ →₀ ℝ) := by
+  intro hcomplete
+  haveI := hcomplete
+  exact D_not_continuous D_isSymmetric.continuous
+
+/-! ## The forward Hellinger–Toeplitz theorem (context, from Mathlib)
+
+For contrast, the forward direction: on a *complete* inner product space the symmetry hypothesis
+alone forces continuity, and the operator is then a bounded self-adjoint operator.  This is a thin
+wrapper around Mathlib's `LinearMap.IsSymmetric.continuous`; it is recorded only to frame the
+sharpness result above. -/
+
+/-- **Hellinger–Toeplitz theorem.** A symmetric everywhere-defined operator on a complete inner
+product space is continuous. -/
+theorem hellinger_toeplitz {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] [CompleteSpace E] {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) :
+    Continuous T := hT.continuous
+
+/-- On a complete space, a symmetric operator bundles into a bounded **self-adjoint** operator. -/
+theorem hellinger_toeplitz_selfAdjoint {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] [CompleteSpace E] {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) :
+    IsSelfAdjoint (hT.toSelfAdjoint : E →L[𝕜] E) :=
+  (hT.toSelfAdjoint).2
+
+/-! ## Sanity checks confirming the hypotheses are not vacuous -/
+
+/-- `D` genuinely moves vectors: `D e₂ = 2 e₂ ≠ e₂`. -/
+example : D (Finsupp.single 2 (1 : ℝ)) = Finsupp.single 2 (2 : ℝ) := by
+  rw [D_single]; norm_num
+
+/-- The unbounded growth is explicit: `‖D eₖ‖ = k`. -/
+example (k : ℕ) : ‖D (Finsupp.single k (1 : ℝ))‖ = (k : ℝ) := by
+  rw [D_single, norm_single (Nat.cast_nonneg k)]
+
+end HellingerToeplitzSharp

--- a/src/data/proofs/open-mapping-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/open-mapping-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 37 },
+    "type": "context",
+    "title": "Why Completeness Matters",
+    "content": "The Hellinger–Toeplitz theorem is an automatic-continuity result: a symmetric operator defined on the *whole* Hilbert space is automatically bounded. The surprise is entirely in the word 'whole' — the unbounded symmetric operators of quantum mechanics (position, momentum) escape the theorem only by being densely, not everywhere, defined. The proof goes through the closed graph theorem, hence depends on completeness. This entry isolates that dependence and proves it is unavoidable: on an incomplete inner product space, an everywhere-defined symmetric operator can be unbounded.",
+    "mathContext": "Symmetric: $\\langle Tx, y\\rangle = \\langle x, Ty\\rangle$. Hellinger–Toeplitz: symmetric + everywhere-defined + complete $\\Rightarrow$ bounded.",
+    "significance": "context",
+    "relatedConcepts": ["Hellinger–Toeplitz theorem", "closed graph theorem", "automatic continuity", "unbounded operators", "completeness"],
+    "prerequisites": ["inner product spaces", "bounded linear operators", "Hilbert spaces"]
+  },
+  {
+    "id": "ann-inner-product",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 95 },
+    "type": "definition",
+    "title": "The ℓ² Inner Product as a Finite Sum",
+    "content": "On finitely supported sequences ℕ →₀ ℝ the ℓ² inner product ⟪x,y⟫ = ∑ᵢ xᵢyᵢ is a genuinely *finite* sum, so it needs no convergence theory — every identity is an elementary Finsupp.sum manipulation. The lemma ip_eq_sum_of_subset re-expresses it as a sum over any finset containing supp x (extra terms vanish), which is the uniform workhorse for the symmetry and basis-vector calculations. The five form axioms — symmetry (ip_comm), additivity and homogeneity in the first slot (ip_add_left via sum_add_index', ip_smul_left via sum_smul_index'), positivity (ip_self_nonneg, a sum of squares), and definiteness (ip_definite, ∑(xᵢ)² = 0 forces every xᵢ = 0) — are exactly the fields of an InnerProductSpace.Core.",
+    "mathContext": "$\\langle x, y\\rangle = \\sum_{i \\in \\mathrm{supp}\\,x} x_i y_i$, a positive-definite Hermitian form.",
+    "significance": "key",
+    "relatedConcepts": ["inner product", "Finsupp.sum", "positive definiteness", "bilinear form", "pre-Hilbert space"],
+    "prerequisites": ["finitely supported functions", "finite sums", "inner product axioms"]
+  },
+  {
+    "id": "ann-ips-structure",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 120 },
+    "type": "technique",
+    "title": "Building the Inner Product Space from a Core",
+    "content": "Mathlib has no inner product on Finsupp, so the space is built from scratch. With Inner ℝ (ℕ →₀ ℝ) := ⟨ip⟩ registered, InnerProductSpace.Core.toNormedAddCommGroup turns the positive-definite form into a NormedAddCommGroup (the norm ‖x‖ = √⟪x,x⟫), and InnerProductSpace.ofCore supplies the InnerProductSpace instance. This is the same ofCore route Mathlib uses for the quaternions. norm_single then computes ‖single k a‖ = a for a ≥ 0 from ‖x‖·‖x‖ = ⟪x,x⟫ = a², pinning down the unit basis vectors ‖eₖ‖ = 1.",
+    "mathContext": "$\\mathbb{N} \\to_0 \\mathbb{R}$ with $\\lVert x\\rVert = \\sqrt{\\langle x,x\\rangle}$ is a (necessarily incomplete) inner product space.",
+    "significance": "key",
+    "relatedConcepts": ["InnerProductSpace.Core", "ofCore", "norm from inner product", "NormedAddCommGroup", "type class instances"],
+    "prerequisites": ["inner product spaces", "norms", "Lean instances"]
+  },
+  {
+    "id": "ann-operator",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 152 },
+    "type": "definition",
+    "title": "The Diagonal Operator D x = (n ↦ n·xₙ)",
+    "content": "The witness operator multiplies the n-th coordinate by n. Its weighted sequence n ↦ n·xₙ has support inside that of x (diag_support_finite), so Finsupp.ofSupportFinite makes it a finitely supported function, and the bundled ℝ-linear map D has D_apply: (D x) i = i·xᵢ definitionally. The key computation D_single: D (single k 1) = single k k shows the basis vector eₖ is an eigenvector with eigenvalue k — the same real eigenvalues that will make D symmetric (real spectrum) and unbounded (spectrum → ∞).",
+    "mathContext": "$D e_k = k\\, e_k$; the diagonal weights are the eigenvalues $0, 1, 2, \\ldots$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal operator", "linear map", "Finsupp.ofSupportFinite", "eigenvalues", "standard basis"],
+    "prerequisites": ["linear maps", "finitely supported functions"]
+  },
+  {
+    "id": "ann-symmetry",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 154, "endLine": 172 },
+    "type": "concept",
+    "title": "Symmetry of the Diagonal Operator",
+    "content": "D_isSymmetric proves ⟪D x, y⟫ = ⟪x, D y⟫. Reducing both inner products over the common finset x.support ∪ y.support (via ip_eq_sum_of_subset), the left side is ∑ᵢ (i·xᵢ)·yᵢ and the right is ∑ᵢ (i·yᵢ)·xᵢ, equal termwise by commutativity. Real diagonal weights are automatically symmetric — this is the everywhere-defined symmetric operator that the Hellinger–Toeplitz theorem would, on a complete space, force to be bounded.",
+    "mathContext": "$\\langle Dx, y\\rangle = \\sum_i i\\,x_i y_i = \\langle x, Dy\\rangle$ — symmetric because the weights $i$ are real.",
+    "significance": "key",
+    "relatedConcepts": ["symmetric operator", "self-adjointness", "diagonal operator", "real spectrum"],
+    "prerequisites": ["inner products", "symmetric operators"]
+  },
+  {
+    "id": "ann-unbounded",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 174, "endLine": 185 },
+    "type": "concept",
+    "title": "Unboundedness via the Basis Vectors",
+    "content": "D_not_continuous is a proof by contradiction: a continuous linear map is bounded (SemilinearMapClass.bound_of_continuous gives ∃ C, ∀ x, ‖D x‖ ≤ C‖x‖). Testing the bound on eₖ = single k 1 for any k > C yields ‖D eₖ‖ = k ≤ C·‖eₖ‖ = C, impossible. The ratio ‖D eₖ‖/‖eₖ‖ = k is unbounded — the eigenvalues k → ∞ are exactly the obstruction. This is the everywhere-defined symmetric operator that is *not* bounded.",
+    "mathContext": "$\\lVert D e_k\\rVert / \\lVert e_k\\rVert = k \\to \\infty$: no finite operator norm exists.",
+    "significance": "key",
+    "relatedConcepts": ["bounded operator", "operator norm", "continuity of linear maps", "unbounded operator"],
+    "prerequisites": ["operator norms", "continuity", "proof by contradiction"]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 187, "endLine": 204 },
+    "type": "concept",
+    "title": "Incompleteness as a Free Corollary",
+    "content": "not_completeSpace is the punchline. If ℕ →₀ ℝ were complete, the Hellinger–Toeplitz theorem (Mathlib's IsSymmetric.continuous) would make our symmetric D continuous — contradicting D_not_continuous. So the space is not complete. This delivers incompleteness without exhibiting any explicit non-convergent Cauchy sequence: the contrapositive of an automatic-continuity theorem turns one unbounded symmetric operator into a proof that the space is not Hilbert. It also certifies sharpness — the completeness hypothesis in Hellinger–Toeplitz cannot be removed.",
+    "mathContext": "$D$ symmetric + discontinuous $\\Rightarrow \\neg\\,\\mathrm{CompleteSpace}\\,(\\mathbb{N} \\to_0 \\mathbb{R})$.",
+    "significance": "key",
+    "relatedConcepts": ["completeness", "contrapositive", "sharpness", "Cauchy sequence", "dense subspace"],
+    "prerequisites": ["complete metric spaces", "Hellinger–Toeplitz theorem", "contrapositive reasoning"]
+  },
+  {
+    "id": "ann-forward",
+    "proofId": "open-mapping-theorem-oq-01-oq-01",
+    "range": { "startLine": 206, "endLine": 226 },
+    "type": "context",
+    "title": "The Forward Theorem and Self-Adjoint Bundling",
+    "content": "For contrast, hellinger_toeplitz wraps Mathlib's IsSymmetric.continuous: on a complete inner product space the symmetry hypothesis alone forces continuity. hellinger_toeplitz_selfAdjoint records the further upgrade — a symmetric operator on a complete space bundles into the bounded self-adjoint operators (IsSymmetric.toSelfAdjoint). These thin wrappers frame the original sharpness result: completeness is exactly what buys boundedness and self-adjointness, and the entry above shows what is lost without it. The closing examples confirm D moves vectors and grows linearly in the index.",
+    "mathContext": "Complete $\\Rightarrow$ (symmetric $\\Rightarrow$ continuous $\\Rightarrow$ bounded self-adjoint).",
+    "significance": "context",
+    "relatedConcepts": ["self-adjoint operator", "bounded operator", "IsSymmetric.toSelfAdjoint", "automatic continuity"],
+    "prerequisites": ["self-adjoint operators", "Hilbert spaces"]
+  }
+]

--- a/src/data/proofs/open-mapping-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/open-mapping-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HellingerToeplitzSharpOQ010101.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const openMappingTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const openMappingTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const openMappingTheoremOQ01OQ01Data: ProofData = {
+  proof: openMappingTheoremOQ01OQ01Proof,
+  annotations: openMappingTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/open-mapping-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/open-mapping-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "open-mapping-theorem-oq-01-oq-01",
+  "title": "Hellinger–Toeplitz Is Sharp: An Everywhere-Defined Symmetric Operator That Is Unbounded",
+  "slug": "open-mapping-theorem-oq-01-oq-01",
+  "description": "A fully verified, axiom-free certificate that the completeness hypothesis in the Hellinger–Toeplitz theorem cannot be dropped. The Hellinger–Toeplitz theorem (Mathlib's LinearMap.IsSymmetric.continuous, a closed-graph-theorem consequence of the parent open-mapping development) says a symmetric everywhere-defined operator on a *complete* inner product space is automatically continuous, hence a bounded self-adjoint operator. We prove this is sharp by construction: on the *incomplete* inner product space ℕ →₀ ℝ of finitely supported real sequences (the ℓ² inner product ⟪x,y⟫ = ∑ᵢ xᵢyᵢ, whose completion is ℓ²(ℕ)), the diagonal operator D x = (n ↦ n·xₙ) is everywhere defined, linear, and symmetric, yet unbounded — ‖D eₖ‖ = k‖eₖ‖ for the unit basis vectors. The payoff is a clean structural corollary: since Hellinger–Toeplitz forces every symmetric operator on a complete space to be continuous, the existence of our symmetric discontinuous D re-proves that the finitely supported ℓ² space is not complete (not_completeSpace). The inner product space structure is built from scratch on ℕ →₀ ℝ via InnerProductSpace.Core (positive-definite bilinear form over finite sums), so the result is entirely self-contained.",
+  "meta": {
+    "author": "lean-genius researcher agents, formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hellinger%E2%80%93Toeplitz_theorem",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "functional-analysis",
+      "operator-theory",
+      "hellinger-toeplitz",
+      "symmetric-operator",
+      "unbounded-operator",
+      "inner-product-space",
+      "completeness",
+      "sharpness",
+      "closed-graph-theorem",
+      "counterexample"
+    ],
+    "proofRepoPath": "Proofs/HellingerToeplitzSharpOQ010101.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "LinearMap.IsSymmetric.continuous",
+        "description": "The Hellinger–Toeplitz theorem: a symmetric operator on a complete inner product space is continuous. Used in its contrapositive to deduce incompleteness from the existence of a symmetric discontinuous operator.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Symmetric"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.toSelfAdjoint",
+        "description": "Bundles a symmetric operator on a complete space into the bounded self-adjoint operators selfAdjoint (E →L[𝕜] E); used to state the forward Hellinger–Toeplitz self-adjointness corollary.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Adjoint"
+      },
+      {
+        "theorem": "InnerProductSpace.Core.toNormedAddCommGroup / InnerProductSpace.ofCore",
+        "description": "Turns a positive-definite Hermitian form (an InnerProductSpace.Core) into the normed and inner-product-space instances; the mechanism by which ℕ →₀ ℝ is made an inner product space from the ℓ² form built here.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Defs"
+      },
+      {
+        "theorem": "SemilinearMapClass.bound_of_continuous",
+        "description": "A continuous linear map between normed spaces over a nontrivially normed field is bounded (∃ C, ∀ x, ‖f x‖ ≤ C‖x‖); contradicted by the unbounded growth ‖D eₖ‖ = k to prove D is not continuous.",
+        "module": "Mathlib.Analysis.Normed.Operator.Basic"
+      },
+      {
+        "theorem": "Finsupp.ofSupportFinite / Finsupp.sum_add_index' / Finsupp.sum_smul_index'",
+        "description": "Construct a finitely supported function from a finite-support raw function, and the additive/scalar laws for Finsupp.sum; used to define the diagonal operator and prove bilinearity of the inner product over finite sums.",
+        "module": "Mathlib.Data.Finsupp.Basic"
+      },
+      {
+        "theorem": "real_inner_self_eq_norm_mul_norm",
+        "description": "⟪x, x⟫_ℝ = ‖x‖·‖x‖, the bridge from the constructed inner product back to the norm; used to compute ‖single k a‖ = |a| and hence the basis-vector norms.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      }
+    ],
+    "originalContributions": [
+      "ip and the inner-product-space structure on ℕ →₀ ℝ: the ℓ² form ⟪x,y⟫ = ∑ᵢ xᵢyᵢ defined as a finite Finsupp.sum, proved symmetric, bilinear, positive (ip_self_nonneg) and definite (ip_definite), then packaged via InnerProductSpace.Core.toNormedAddCommGroup + InnerProductSpace.ofCore into a genuine (incomplete) inner product space — built from scratch since Mathlib has no inner product on Finsupp",
+      "ip_eq_sum_of_subset: a reusable lemma expressing the inner product as a finite sum over any finset containing the support of the first argument, the workhorse that makes the symmetry and basis-vector computations uniform",
+      "D: the everywhere-defined diagonal operator D x = (n ↦ n·xₙ) as a bundled ℝ-linear map on ℕ →₀ ℝ, via Finsupp.ofSupportFinite with the finite-support certificate diag_support_finite",
+      "D_isSymmetric: the diagonal operator is symmetric — ⟪D x, y⟫ = ⟪x, D y⟫ — reducing both sides to ∑ᵢ (i·xᵢ)·yᵢ over the common support union",
+      "D_not_continuous: the diagonal operator is unbounded, hence not continuous; ‖D eₖ‖ = k = k·‖eₖ‖ for the unit basis vectors eₖ contradicts any continuity bound (norm_single computes ‖single k a‖ = a for a ≥ 0, and D_single gives D eₖ = k·eₖ)",
+      "not_completeSpace: the headline sharpness corollary — the finitely supported ℓ² space ℕ →₀ ℝ is NOT complete — obtained for free from the contrapositive of Hellinger–Toeplitz applied to the symmetric discontinuous D, a structural re-proof of incompleteness that needs no explicit non-convergent Cauchy sequence",
+      "hellinger_toeplitz / hellinger_toeplitz_selfAdjoint: the forward direction recorded for context (thin wrappers around Mathlib), framing the sharpness result and exhibiting the bounded self-adjoint bundling that completeness buys"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCountNote": "0 axiom declarations, 0 sorries, 0 structure-encoded assumptions, no native_decide. #print axioms on not_completeSpace, D_isSymmetric, D_not_continuous, and hellinger_toeplitz_selfAdjoint reports only propext / Classical.choice / Quot.sound, the foundational axioms the project does not count. The InnerProductSpace.Core fields are discharged proofs (symmetry, bilinearity, positivity, definiteness), not assumptions."
+  },
+  "overview": {
+    "historicalContext": "The Hellinger–Toeplitz theorem (Ernst Hellinger and Otto Toeplitz, 1910) is a striking automatic-continuity result: a linear operator on a Hilbert space that is symmetric (⟪Tx,y⟫ = ⟪x,Ty⟫) and defined on the *whole* space must be bounded. Its physical significance is the contrapositive — the unbounded symmetric operators of quantum mechanics (position, momentum, energy) cannot be everywhere defined; they are only densely defined, which is the entire reason the theory of unbounded self-adjoint operators and their domains exists. The proof is a clean application of the closed graph theorem, itself a consequence of the open mapping theorem (the parent entry), and so depends essentially on completeness of the space. This entry isolates that dependence and shows it is unavoidable.",
+    "problemStatement": "Show that the completeness hypothesis in Hellinger–Toeplitz is necessary: exhibit an inner product space that is not complete together with an everywhere-defined symmetric linear operator on it that is unbounded (not continuous). Concretely, equip the finitely supported real sequences ℕ →₀ ℝ with the ℓ² inner product and prove the diagonal operator D x = (n ↦ n·xₙ) is symmetric but not continuous, deducing that the space is not complete.",
+    "proofStrategy": "(1) Inner product: define ip x y = ∑ᵢ xᵢyᵢ as a finite Finsupp.sum and prove it is a positive-definite Hermitian bilinear form (ip_comm, ip_add_left, ip_smul_left, ip_self_nonneg, ip_definite). Package it via InnerProductSpace.Core.toNormedAddCommGroup and InnerProductSpace.ofCore to make ℕ →₀ ℝ a genuine inner product space; the inner product of a basis vector with itself is ip_single_self: ⟪single k a, single k a⟫ = a². (2) Operator: define D x = (n ↦ n·xₙ) with Finsupp.ofSupportFinite (finite support via diag_support_finite), and compute D (single k 1) = single k k (D_single). (3) Symmetry: reduce ⟪D x, y⟫ and ⟪x, D y⟫ to the same finite sum ∑ᵢ (i·xᵢ)·yᵢ over the support union (D_isSymmetric). (4) Unboundedness: norm_single gives ‖single k a‖ = a (a ≥ 0), so ‖eₖ‖ = 1 and ‖D eₖ‖ = ‖single k k‖ = k; any continuity bound ‖D x‖ ≤ C‖x‖ would force k ≤ C for all k, impossible (D_not_continuous). (5) Sharpness: were the space complete, Hellinger–Toeplitz (IsSymmetric.continuous) would make the symmetric D continuous — contradiction; hence ℕ →₀ ℝ is not complete (not_completeSpace).",
+    "keyInsights": [
+      "Completeness is the load-bearing hypothesis of Hellinger–Toeplitz, not a technicality: drop it and everywhere-defined symmetric operators can be wildly unbounded. The diagonal operator with eigenvalues 0,1,2,3,… on the finitely supported sequences is the canonical witness.",
+      "The construction needs an incomplete inner product space, and the cleanest one is the dense pre-Hilbert space ℕ →₀ ℝ whose completion is ℓ²(ℕ). Working with finite support means every inner product is a finite sum — no convergence analysis, no ℓ² summability — so the whole inner product space can be built from elementary Finsupp.sum identities.",
+      "Symmetry of a diagonal operator is immediate: ⟪D x, y⟫ and ⟪x, D y⟫ are both ∑ᵢ i·xᵢ·yᵢ. The same diagonal weights that make it symmetric (real eigenvalues i) are what make it unbounded (eigenvalues → ∞).",
+      "Incompleteness comes out as a *corollary*, not an input: rather than exhibiting an explicit Cauchy sequence with no limit (e.g. partial sums of ∑ 2⁻ⁿeₙ), we get not_completeSpace for free from the contrapositive of Hellinger–Toeplitz. The existence of one symmetric discontinuous operator certifies the space is not Hilbert.",
+      "This is the sharp boundary of an automatic-continuity phenomenon: the parent open mapping / closed graph theorems give continuity for free under completeness, and this entry shows exactly where that free lunch ends."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, axiom-free and sorry-free demonstration that the completeness hypothesis in the Hellinger–Toeplitz theorem is sharp. On the incomplete inner product space ℕ →₀ ℝ (finitely supported real sequences with the ℓ² inner product, built here from scratch), the diagonal operator D x = (n ↦ n·xₙ) is everywhere defined, linear, and symmetric, yet unbounded (‖D eₖ‖ = k‖eₖ‖). As a corollary, the space is not complete — a structural re-proof of incompleteness via the contrapositive of Hellinger–Toeplitz.",
+    "implications": "Pins down the role of completeness in the parent open-mapping / closed-graph theory: it is exactly what forces everywhere-defined symmetric operators to be bounded, and removing it allows the unbounded symmetric operators that pervade quantum mechanics. The self-contained inner product space on ℕ →₀ ℝ and the lemma ip_eq_sum_of_subset are reusable for any finite-support pre-Hilbert construction.",
+    "openQuestions": [
+      "Exhibit the explicit non-convergent Cauchy sequence underlying not_completeSpace (e.g. partial sums of ∑ₙ 2⁻ⁿ eₙ) and prove directly that ℕ →₀ ℝ embeds as a proper dense subspace of ℓ²(ℕ), identifying the completion.",
+      "Characterize which diagonal operators D_w x = (n ↦ wₙ·xₙ) on ℕ →₀ ℝ are bounded — precisely the bounded weight sequences w ∈ ℓ^∞ — giving a full bounded/unbounded dichotomy for everywhere-defined diagonal symmetric operators on the pre-Hilbert space."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring framing the result as the sharpness certificate for Hellinger–Toeplitz: completeness cannot be dropped. Names the witness — the diagonal operator on the finitely supported ℓ² space — and previews the incompleteness corollary. Single import Mathlib.",
+      "mathContext": "Hellinger–Toeplitz needs completeness; this entry builds an incomplete inner product space carrying an unbounded symmetric operator."
+    },
+    {
+      "id": "inner-product",
+      "title": "The ℓ² Inner Product on Finitely Supported Sequences",
+      "startLine": 45,
+      "endLine": 95,
+      "summary": "ip x y = ∑ᵢ xᵢyᵢ as a finite Finsupp.sum, with ip_eq_sum_of_subset expressing it over any finset containing the support. Proves the Hermitian-bilinear-form axioms: ip_comm (symmetry), ip_add_left and ip_smul_left (bilinearity in the first slot), ip_self_nonneg (positivity), ip_definite (definiteness via ∑(xᵢ)² = 0 ⇒ x = 0), and ip_single_self: ⟪single k a, single k a⟫ = a².",
+      "mathContext": "$\\langle x,y\\rangle = \\sum_i x_i y_i$ is a positive-definite Hermitian form on $\\mathbb{N} \\to_0 \\mathbb{R}$."
+    },
+    {
+      "id": "ips-structure",
+      "title": "Inner Product Space Structure",
+      "startLine": 97,
+      "endLine": 120,
+      "summary": "Registers Inner ℝ (ℕ →₀ ℝ) := ⟨ip⟩, then turns the InnerProductSpace.Core into the NormedAddCommGroup (toNormedAddCommGroup) and InnerProductSpace (ofCore) instances. norm_single computes ‖single k a‖ = a for a ≥ 0 by ‖x‖² = ⟪x,x⟫ = a² and nonnegativity, giving the basis-vector norms.",
+      "mathContext": "$\\mathbb{N} \\to_0 \\mathbb{R}$ becomes a (necessarily incomplete) inner product space; $\\lVert \\mathrm{single}\\,k\\,a\\rVert = |a|$."
+    },
+    {
+      "id": "operator",
+      "title": "The Diagonal Operator",
+      "startLine": 122,
+      "endLine": 152,
+      "summary": "diag_support_finite certifies the weighted sequence n ↦ n·xₙ has finite support (contained in x's). D is the bundled ℝ-linear map x ↦ (n ↦ n·xₙ) built with Finsupp.ofSupportFinite, with D_apply: (D x) i = i·xᵢ and D_single: D (single k 1) = single k k — the unit basis vector eₖ is scaled by its index.",
+      "mathContext": "$D x = (n \\mapsto n\\cdot x_n)$, so $D e_k = k\\, e_k$ (eigenvalue $k$)."
+    },
+    {
+      "id": "symmetry",
+      "title": "The Operator Is Symmetric",
+      "startLine": 154,
+      "endLine": 172,
+      "summary": "D_isSymmetric: ⟪D x, y⟫ = ⟪x, D y⟫. Both sides are rewritten via ip_eq_sum_of_subset over the support union x.support ∪ y.support to the common finite sum ∑ᵢ (i·xᵢ)·yᵢ = ∑ᵢ (i·yᵢ)·xᵢ, equal termwise by commutativity.",
+      "mathContext": "$\\langle Dx, y\\rangle = \\sum_i i\\,x_i y_i = \\langle x, Dy\\rangle$."
+    },
+    {
+      "id": "unbounded",
+      "title": "The Operator Is Unbounded",
+      "startLine": 174,
+      "endLine": 185,
+      "summary": "D_not_continuous: if D were continuous it would satisfy a bound ‖D x‖ ≤ C‖x‖ (bound_of_continuous). Evaluated at eₖ = single k 1 with k > C this gives ‖D eₖ‖ = k ≤ C·‖eₖ‖ = C, contradicting k > C. The basis vectors witness ‖D eₖ‖/‖eₖ‖ = k → ∞.",
+      "mathContext": "$\\lVert D e_k\\rVert = k = k\\,\\lVert e_k\\rVert$, so $D$ has no finite operator bound."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: Completeness Is Necessary",
+      "startLine": 187,
+      "endLine": 204,
+      "summary": "not_completeSpace: ℕ →₀ ℝ is not complete. If it were, Hellinger–Toeplitz (IsSymmetric.continuous) would force the symmetric D to be continuous, contradicting D_not_continuous. Incompleteness falls out as a contrapositive corollary, with no explicit non-convergent Cauchy sequence needed.",
+      "mathContext": "$D$ symmetric and discontinuous $\\Rightarrow \\mathbb{N} \\to_0 \\mathbb{R}$ is not complete."
+    },
+    {
+      "id": "forward",
+      "title": "The Forward Hellinger–Toeplitz Theorem (Context)",
+      "startLine": 206,
+      "endLine": 226,
+      "summary": "For contrast, hellinger_toeplitz wraps Mathlib's IsSymmetric.continuous (symmetric + complete ⇒ continuous) and hellinger_toeplitz_selfAdjoint records the bounded self-adjoint bundling that completeness buys. Closing sanity examples confirm D 2·e₂ = 2·e₂ and the explicit growth ‖D eₖ‖ = k.",
+      "mathContext": "On a complete space, symmetric $\\Rightarrow$ continuous $\\Rightarrow$ bounded self-adjoint."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "open-mapping-theorem-oq-01",
+      "relationship": "extends",
+      "description": "The parent packages the open mapping theorem and its Banach-space consequences, including the closed graph theorem, and asks (first open question) to apply the closed graph theorem to obtain a Hellinger–Toeplitz boundedness result. This entry answers that question and goes further: it records the forward Hellinger–Toeplitz theorem (a closed-graph corollary) and proves its completeness hypothesis is sharp via an explicit unbounded symmetric operator on an incomplete inner product space."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "HellingerToeplitzSharp",
+    "lineCount": 227,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "path": "Proofs/HellingerToeplitzSharpOQ010101.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    "ip_eq_sum_of_subset",
+    "ip_definite",
+    "ip_single_self",
+    "norm_single",
+    "D_single",
+    "D_isSymmetric",
+    "D_not_continuous",
+    "not_completeSpace",
+    "hellinger_toeplitz"
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **open-mapping-theorem-oq-01** entry's first open question — *"apply the closed graph theorem to obtain a Hellinger–Toeplitz boundedness result"* — and goes further by proving the **completeness hypothesis is sharp**.

The **Hellinger–Toeplitz theorem** says a symmetric, everywhere-defined operator on a *complete* inner product space is automatically continuous (hence a bounded self-adjoint operator). Mathlib already has the forward direction (`LinearMap.IsSymmetric.continuous`, a closed-graph corollary), so a restatement would be a mere re-export. **The original content of this entry is the counterexample establishing sharpness.**

## The construction

On the **incomplete** inner product space `ℕ →₀ ℝ` of finitely supported real sequences (the ℓ² inner product `⟪x,y⟫ = ∑ᵢ xᵢyᵢ`, a finite sum; its completion is `ℓ²(ℕ)`), the **diagonal operator** `D x = (n ↦ n·xₙ)` is:

- **everywhere defined** and **ℝ-linear** (`D`)
- **symmetric**: `⟪D x, y⟫ = ⟪x, D y⟫` (`D_isSymmetric`)
- **unbounded** / not continuous: `‖D eₖ‖ = k·‖eₖ‖ → ∞` on the unit basis vectors (`D_not_continuous`)

The inner product space structure is built **from scratch** on `ℕ →₀ ℝ` (Mathlib has no inner product on `Finsupp`) via a positive-definite Hermitian form over finite sums and `InnerProductSpace.Core` → `ofCore`.

## Punchline

Since Hellinger–Toeplitz forces every symmetric operator on a *complete* space to be continuous, the existence of our symmetric **discontinuous** `D` re-proves — by contrapositive — that the finitely-supported ℓ² space is **not complete** (`not_completeSpace`). Incompleteness as a free corollary, with no explicit non-convergent Cauchy sequence required.

## Verification

- **227 lines**, 17 theorems / 2 defs
- `#print axioms` on `not_completeSpace`, `D_isSymmetric`, `D_not_continuous`, `hellinger_toeplitz_selfAdjoint` → only `propext` / `Classical.choice` / `Quot.sound`
- **0 counted axioms, 0 sorries, no native_decide** — `status: verified`, `badge: original`
- Builds against current Mathlib (host `lake env lean`; Docker unavailable this cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)