### PR TITLE
Enrich Mixed-Radix Kummer Carry Law (kummer-theorem-oq-02-oq-03)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-kummer0203-overview",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Kummer's carry law generalized to mixed-radix systems",
+    "content": "The docstring states the goal answering parent OQ-03: lift Kummer's single-base carry/floor-deficiency interpretation to an arbitrary mixed-radix numeral system with base sequence b and positional weights W₀ = 1, W_{i+1} = W_i·b_i. The per-weight floor deficiency δ(j) = ⌊(a+c)/W_j⌋ − ⌊a/W_j⌋ − ⌊c/W_j⌋ ∈ {0,1} is exactly the carry out of digit position j−1, and the headline identity (★) is S(a) + S(c) = S(a+c) + Σ δ(i+1)(b_i − 1). Setting every b_i = d recovers the classical s_d(a) + s_d(c) − s_d(a+c) = (d−1)·#carries. Everything is elementary ℕ/ℤ arithmetic plus Finset telescoping, axiom-free.",
+    "mathContext": "Weights $W_{i+1}=W_i b_i$; deficiency $\\delta(j)=\\lfloor\\tfrac{a+c}{W_j}\\rfloor-\\lfloor\\tfrac{a}{W_j}\\rfloor-\\lfloor\\tfrac{c}{W_j}\\rfloor\\in\\{0,1\\}$; $(\\star)\\ S(a)+S(c)=S(a+c)+\\sum_i\\delta(i+1)(b_i-1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's theorem", "mixed-radix numeral system", "carries in addition", "digit sum", "floor deficiency"],
+    "prerequisites": ["base-b representations", "Legendre's formula", "Finset sums"]
+  },
+  {
+    "id": "ann-kummer0203-defs",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 63, "endLine": 93 },
+    "type": "definition",
+    "title": "Weights, digits, digit sums, and the deficiency",
+    "content": "Part I sets up the mixed-radix apparatus. mixedWeight b is the recursively-defined weight sequence (W₀ = 1, W_{i+1} = W_i·b_i), proved positive when every base is (mixedWeight_pos). mixedDigit b i x = ⌊x/W_i⌋ mod b_i is the i-th digit, and mixedDigitSum sums the first N digits. defc b a c j is the integer floor deficiency δ(j) of a+c at weight W_j — the central quantity the carry law revolves around.",
+    "mathContext": "$\\mathrm{dig}_i(x)=\\lfloor x/W_i\\rfloor \\bmod b_i$; $S(x)=\\sum_{i<N}\\mathrm{dig}_i(x)$; $\\delta(j)=\\lfloor\\tfrac{a+c}{W_j}\\rfloor-\\lfloor\\tfrac{a}{W_j}\\rfloor-\\lfloor\\tfrac{c}{W_j}\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": ["positional weights", "recursive definition", "digit extraction", "Nat.mul_pos"],
+    "prerequisites": ["integer division and mod", "recursive ℕ functions"]
+  },
+  {
+    "id": "ann-kummer0203-carry",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 99, "endLine": 140 },
+    "type": "insight",
+    "title": "The deficiency IS the carry indicator (engine: Nat.add_div)",
+    "content": "Part II's key fact: defc_eq_indicator shows δ(j+1) equals the {0,1} indicator of whether the low parts overflow — `W_{j+1} ≤ a mod W_{j+1} + c mod W_{j+1}`. The engine is Mathlib's Nat.add_div, which expresses (a+c)/W as a/W + c/W + (overflow indicator); substituting into the definition and casting collapses δ to that indicator. Corollaries: δ ∈ {0,1} (defc_mem_zero_one, needs b_i ≥ 1 so W_{j+1} > 0) and δ = 1 ⟺ overflow (defc_eq_one_iff). This is Kummer's 'carry' reading, now at a mixed-radix weight; defc_zero and defc_high handle the boundary cases W₀ = 1 and a+c < W_N.",
+    "mathContext": "$\\delta(j+1) = [\\,W_{j+1}\\le a\\bmod W_{j+1} + c\\bmod W_{j+1}\\,]\\in\\{0,1\\}$ — the carry out of position $j$, via $\\mathrm{Nat.add\\_div}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.add_div", "carry bit", "overflow indicator", "if-then-else split"],
+    "prerequisites": ["division-with-remainder", "the add_div carry formula"]
+  },
+  {
+    "id": "ann-kummer0203-recurrence",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 146, "endLine": 173 },
+    "type": "technique",
+    "title": "Digit recurrence and telescoping-ready expansion",
+    "content": "Part III rewrites each digit for telescoping. mixedDigit_eq expresses digᵢ(x) over ℤ as ⌊x/W_i⌋ − b_i·⌊x/W_{i+1}⌋, using Nat.mod_add_div together with ⌊⌊x/W_i⌋/b_i⌋ = ⌊x/W_{i+1}⌋ (from Nat.div_div_eq_div_mul). mixedDigitSum_expand sums this over range N, turning the digit sum into a sum of consecutive-floor differences — the form that makes the later carry-law telescoping work.",
+    "mathContext": "$\\mathrm{dig}_i(x) = \\lfloor x/W_i\\rfloor - b_i\\lfloor x/W_{i+1}\\rfloor$; $S(x)=\\sum_{i<N}\\big(\\lfloor x/W_i\\rfloor - b_i\\lfloor x/W_{i+1}\\rfloor\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.mod_add_div", "Nat.div_div_eq_div_mul", "telescoping setup", "digit recurrence"],
+    "prerequisites": ["nested floor identities", "Finset.sum_congr"]
+  },
+  {
+    "id": "ann-kummer0203-law",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 179, "endLine": 227 },
+    "type": "insight",
+    "title": "The mixed-radix Kummer carry law via telescoping",
+    "content": "Part IV's headline. mixedDigitSum_diff first reduces S(a) + S(c) − S(a+c) to Σ (b_i·δ(i+1) − δ(i)) by aligning the three expansions term-by-term (push_cast + ring). mixedRadix_kummer then splits each term as δ(i+1)(b_i − 1) + (δ(i+1) − δ(i)), and the second part telescopes (Finset.sum_range_sub) to δ(N) − δ(0); with δ(0) = 0 and δ(N) = 0 (since a+c < W_N) the telescope vanishes, leaving exactly S(a) + S(c) = S(a+c) + Σ δ(i+1)(b_i − 1) — the identity (★). Note the algebraic identity needs no hypothesis on the bases; only the {0,1} carry-counting interpretation does.",
+    "mathContext": "$S(a)+S(c)-S(a+c)=\\sum_i\\big(b_i\\delta(i{+}1)-\\delta(i)\\big)=\\sum_i\\delta(i{+}1)(b_i{-}1)+\\big(\\delta(N)-\\delta(0)\\big)$, telescope $=0$.",
+    "significance": "critical",
+    "relatedConcepts": ["telescoping sum", "Finset.sum_range_sub", "Kummer carry identity", "boundary vanishing"],
+    "prerequisites": ["the digit-sum expansion", "telescoping sums", "the carry indicator"]
+  },
+  {
+    "id": "ann-kummer0203-const",
+    "proofId": "kummer-theorem-oq-02-oq-03",
+    "range": { "startLine": 233, "endLine": 261 },
+    "type": "theorem",
+    "title": "Recovering the classical single-base law",
+    "content": "Part V specializes to a constant base. mixedWeight_const shows a constant base d gives the ordinary powers W_i = d^i. const_base_carry_law then instantiates (★) at b ≡ d and factors the constant (d − 1) out of the carry sum (Finset.mul_sum), recovering s_d(a) + s_d(c) − s_d(a+c) = (d − 1)·(number of carries) — the standard Kummer/Legendre digit-sum law for ordinary base-d addition. This confirms the mixed-radix law is a genuine generalization.",
+    "mathContext": "$b\\equiv d \\Rightarrow W_i=d^i$ and $s_d(a)+s_d(c)=s_d(a+c)+(d-1)\\sum_i\\delta(i+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["constant base", "powers d^i", "Finset.mul_sum", "classical Kummer law"],
+    "prerequisites": ["the mixed-radix law", "specialization"]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-02-oq-03/index.ts
+++ b/src/data/proofs/kummer-theorem-oq-02-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/KummerTheoremOQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const kummerTheoremOQ02OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const kummerTheoremOQ02OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const kummerTheoremOQ02OQ03Data: ProofData = {
+  proof: kummerTheoremOQ02OQ03Proof,
+  annotations: kummerTheoremOQ02OQ03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `kummer-theorem-oq-02-oq-03` (263-line mixed-radix generalization of Kummer's carry law).

## Gap addressed
Entry had **only meta.json** — no annotations.json.

## Added
- **annotations.json** with **6 annotations** tracking the 5-part development (overview; the weight/digit/digit-sum/deficiency definitions; the carry-indicator identity δ(j+1) = overflow via Nat.add_div; the digit recurrence and telescoping-ready expansion; the carry law (★) via telescoping; and the single-base recovery of the classical Kummer/Legendre law), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts** entry point.

## Verification
- JSON validates; build annotation-range validator reports **0 errors** for this entry.
- Axiom integrity unchanged: verified / 0 axioms / badge original.