### PR TITLE
Enrich Shapiro's cyclic inequality n=4 (nesbitt-inequality-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/nesbitt-inequality-oq-01-oq-01/index.ts
+++ b/src/data/proofs/nesbitt-inequality-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/NesbittInequalityOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const nesbittInequalityOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const nesbittInequalityOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const nesbittInequalityOQ01OQ01Data: ProofData = {
+  proof: nesbittInequalityOQ01OQ01Proof,
+  annotations: nesbittInequalityOQ01OQ01Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `nesbitt-inequality-oq-01-oq-01`

The entry "Shapiro's Cyclic Inequality for n = 4, with a Two-Parameter Equality Locus" had a comprehensive `meta.json` but was **missing both `index.ts` and `annotations.json`** — without `index.ts` the page renders "proof not found" on the live site.

### Added
- **`index.ts`** — Vite entry point so the proof loads.
- **`annotations.json`** — 5 annotations covering the full 152-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. `engel2` — two-term Engel/Titu Cauchy–Schwarz with its exact square deficit `(py−qx)²/(xy(x+y))`
  2. `titu2` — the fraction-form repackaging `p/u + q/v ≥ (p+q)²/(pu+qv)`
  3. `shapiro_four_lower` — opposite-pairing + folding sharp deficit bound
  4. `shapiro_four` — the n=4 inequality `Σ ≥ 2`
  5. `shapiro_four_eq_iff` — the two-parameter equality locus `a=c ∧ b=d`

### Verification
- `pnpm build` ✓ — no warnings for this entry.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0-axiom/0-sorry, no `native_decide`).