### PR TITLE
research(cayleys-theorem-oq-01-oq-02-oq-02): outer automorphism exact sequence 1→Inn(G)→Aut(G)→Out(G)→1

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4052,6 +4052,7 @@ import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VandermondeInterpolationOQ01OQ02
 import Proofs.VandermondeInterpolationOQ01OQ02OQ01
 import Proofs.VarignonTheorem
+import Proofs.VarignonTheoremOQ01OQ01
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02
 import Proofs.VietasFormulasOQ03

--- a/proofs/Proofs/CayleysTheoremOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ02OQ02.lean
@@ -1,0 +1,156 @@
+/-
+Proof: The inner automorphism group is normal in the automorphism group, and the
+outer automorphism group as the quotient — the short exact sequence
+
+        1 ⟶ Inn(G) ⟶ Aut(G) ⟶ Out(G) ⟶ 1.
+
+Research: cayleys-theorem-oq-01-oq-02-oq-02
+
+Open question (from the parent `cayleys-theorem-oq-01-oq-02`, second open
+question): "Prove the outer automorphism exact sequence at the formalized level:
+1 → Inn(G) → Aut(G) → Out(G) → 1, building on G/Z(G) ≅ Inn(G) established there to
+define Out(G) = Aut(G)/Inn(G)."
+
+The parent established the conjugation representation `C : G →* Equiv.Perm G`, its
+kernel `Z(G)`, and `G/Z(G) ≃* (conjRep G).range`.  That image lived inside the
+symmetric group `Sym(G)`.  Here we move into the *automorphism* group `MulAut G`,
+where the same image is the classical **inner automorphism group** `Inn(G)`, and
+we complete the structural picture:
+
+  1.  **Covariance of conjugation.**  For any automorphism `φ` and any `g`,
+        `φ · conj g · φ⁻¹ = conj (φ g)`     (in `MulAut G`).
+      Conjugating an inner automorphism by *any* automorphism is again inner.
+
+  2.  **`Inn(G) ◁ Aut(G)`.**  Consequently the inner automorphism group
+      `Inn G := (MulAut.conj).range` is a *normal* subgroup of `MulAut G`.
+
+  3.  **`Out(G) := Aut(G) / Inn(G)`** is therefore a well-defined group, the
+      **outer automorphism group**.
+
+  4.  **Exactness of `1 → Inn(G) → Aut(G) → Out(G) → 1`.**  The inclusion
+      `Inn(G).subtype` is injective, the quotient map `Aut(G) → Out(G)` is
+      surjective, and the image of the inclusion equals the kernel of the
+      quotient map:
+        `(Inn G).subtype.range = (QuotientGroup.mk' (Inn G)).ker`.
+
+  5.  **`G/Z(G) ≃* Inn(G)`** realised inside `MulAut G` (the parent's isomorphism
+      transported from `Sym(G)` to `MulAut G`), via `ker (MulAut.conj) = Z(G)`.
+
+  6.  **Order formula** for finite `G`:
+        `|Aut(G)| = |Out(G)| · |Inn(G)| = |Out(G)| · |G/Z(G)|`.
+
+Mathlib supplies the primitives (`MulAut.conj`, `QuotientGroup`,
+`Subgroup.center`); the content here is proving the covariance lemma, hence the
+normality that turns `Out(G)` into a group, and assembling the exact sequence.
+-/
+
+import Mathlib.Algebra.Group.End
+import Mathlib.GroupTheory.Subgroup.Center
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Coset.Card
+import Mathlib.Tactic
+
+namespace CayleyOuter
+
+variable {G : Type*} [Group G]
+
+/-! ### The inner automorphism group -/
+
+/-- The **inner automorphism group** `Inn(G) ≤ Aut(G)`, defined as the range of
+the inner-automorphism homomorphism `MulAut.conj : G →* MulAut G`.  Its elements
+are exactly the automorphisms `x ↦ g * x * g⁻¹`. -/
+def Inn (G : Type*) [Group G] : Subgroup (MulAut G) := (MulAut.conj (G := G)).range
+
+@[simp] theorem mem_Inn_iff {φ : MulAut G} :
+    φ ∈ Inn G ↔ ∃ g : G, MulAut.conj g = φ := Iff.rfl
+
+/-- **Covariance of conjugation.**  Conjugating the inner automorphism `conj g`
+by an arbitrary automorphism `φ` yields the inner automorphism `conj (φ g)`.
+This is the engine behind the normality of `Inn(G)`: the inner automorphisms are
+permuted among themselves by every automorphism. -/
+theorem conj_mulAut_conj (φ : MulAut G) (g : G) :
+    φ * MulAut.conj g * φ⁻¹ = MulAut.conj (φ g) := by
+  ext x
+  simp only [MulAut.mul_apply, MulAut.inv_apply, MulAut.conj_apply, map_mul, map_inv,
+    MulEquiv.apply_symm_apply]
+
+/-- **`Inn(G)` is normal in `Aut(G)`.**  Immediate from covariance: any conjugate
+of an inner automorphism is again inner. -/
+instance : (Inn G).Normal where
+  conj_mem := by
+    rintro _ ⟨g, rfl⟩ φ
+    exact ⟨φ g, (conj_mulAut_conj φ g).symm⟩
+
+/-! ### The outer automorphism group -/
+
+/-- The **outer automorphism group** `Out(G) := Aut(G) / Inn(G)`.  Well-defined as
+a group precisely because `Inn(G)` is normal (the instance above). -/
+def Out (G : Type*) [Group G] : Type _ := MulAut G ⧸ Inn G
+
+noncomputable instance : Group (Out G) := QuotientGroup.Quotient.group (Inn G)
+
+/-- The canonical surjection `Aut(G) → Out(G)`. -/
+def outMk (G : Type*) [Group G] : MulAut G →* Out G := QuotientGroup.mk' (Inn G)
+
+/-! ### Exactness of `1 → Inn(G) → Aut(G) → Out(G) → 1` -/
+
+/-- **Injectivity at `Inn(G)`.**  The inclusion `Inn(G) ↪ Aut(G)` is injective —
+the left end of the exact sequence. -/
+theorem inn_subtype_injective : Function.Injective (Inn G).subtype :=
+  (Inn G).subtype_injective
+
+/-- **Surjectivity at `Out(G)`.**  The quotient map `Aut(G) → Out(G)` is
+surjective — the right end of the exact sequence. -/
+theorem outMk_surjective : Function.Surjective (outMk G) :=
+  QuotientGroup.mk'_surjective (Inn G)
+
+/-- **Exactness in the middle.**  The image of the inclusion `Inn(G) ↪ Aut(G)`
+equals the kernel of the quotient map `Aut(G) → Out(G)`:
+  `range (Inn(G).subtype) = ker (Aut(G) → Out(G))`.
+Together with injectivity and surjectivity this is the short exact sequence
+`1 → Inn(G) → Aut(G) → Out(G) → 1`. -/
+theorem range_inn_subtype_eq_ker_outMk :
+    (Inn G).subtype.range = (outMk G).ker := by
+  rw [Subgroup.range_subtype, outMk, QuotientGroup.ker_mk']
+
+/-! ### Identification of `Inn(G)` with `G / Z(G)` -/
+
+/-- **The kernel of the inner-automorphism homomorphism is the centre.**  An
+element `g` induces the identity inner automorphism exactly when it commutes with
+everything.  (This is the `MulAut`-level twin of the parent's `ker_conjRep`.) -/
+theorem ker_mulAutConj : (MulAut.conj (G := G)).ker = Subgroup.center G := by
+  ext g
+  rw [MonoidHom.mem_ker, Subgroup.mem_center_iff, MulEquiv.ext_iff]
+  constructor
+  · intro h x
+    have hx := h x
+    rw [MulAut.conj_apply, MulAut.one_apply, mul_inv_eq_iff_eq_mul] at hx
+    exact hx.symm
+  · intro h x
+    rw [MulAut.conj_apply, MulAut.one_apply, mul_inv_eq_iff_eq_mul]
+    exact (h x).symm
+
+/-- **First isomorphism theorem for the inner automorphism group:**
+`G ⧸ Z(G) ≃* Inn(G)`.  Realises the parent's `G/Z(G) ≅ Inn(G)` directly as an
+isomorphism onto the automorphism subgroup `Inn(G) ≤ Aut(G)`. -/
+noncomputable def quotientCenterEquivInn :
+    G ⧸ Subgroup.center G ≃* Inn G :=
+  (QuotientGroup.quotientMulEquivOfEq ker_mulAutConj.symm).trans
+    (QuotientGroup.quotientKerEquivRange (MulAut.conj (G := G)))
+
+/-! ### Order formula for finite groups -/
+
+/-- **Order formula.**  For a finite group `G`,
+  `|Aut(G)| = |Out(G)| · |Inn(G)|`,
+the Lagrange factorisation of the automorphism group along `Inn(G) ◁ Aut(G)`. -/
+theorem card_mulAut_eq_card_out_mul_card_inn [Finite G] :
+    Nat.card (MulAut G) = Nat.card (Out G) * Nat.card (Inn G) :=
+  Subgroup.card_eq_card_quotient_mul_card_subgroup (Inn G)
+
+/-- **Order formula, refined.**  Combining with `G/Z(G) ≃* Inn(G)`:
+  `|Aut(G)| = |Out(G)| · |G / Z(G)|`. -/
+theorem card_mulAut_eq_card_out_mul_card_quotient_center [Finite G] :
+    Nat.card (MulAut G) = Nat.card (Out G) * Nat.card (G ⧸ Subgroup.center G) := by
+  rw [card_mulAut_eq_card_out_mul_card_inn, Nat.card_congr quotientCenterEquivInn.toEquiv]
+
+end CayleyOuter

--- a/proofs/Proofs/VarignonTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/VarignonTheoremOQ01OQ01.lean
@@ -1,0 +1,145 @@
+/-
+Proof: The signed-area law for the Varignon parallelogram.
+Research: varignon-theorem-oq-01-oq-01
+
+Open question (parent `varignon-theorem-oq-01`, first open question):
+  "What is the relationship between the Varignon parallelogram's area and the
+   original quadrilateral's area in the *self-intersecting* case?"
+
+The parent file proves the affine skeleton of Varignon's theorem — the midpoints
+of the sides of any quadrilateral form a parallelogram — using only the midpoint
+structure.  That argument never mentions area, and it is silent on the classical
+"half the area" statement, which is usually proved for *convex* quadrilaterals by
+a picture.  The picture breaks for self-intersecting (crossed) quadrilaterals.
+
+This file resolves the question by replacing area-by-picture with the **signed**
+shoelace area, which is a polynomial in the coordinates and therefore makes no
+distinction between convex, concave, and self-intersecting quadrilaterals.  We
+prove, as a single ring identity in the eight coordinates of `A, B, C, D`:
+
+  * **Diagonal form of the quadrilateral area.**
+      `signedArea A B C D = cross (C - A) (D - B) / 2`,
+    i.e. the signed area depends only on the two diagonals `AC` and `BD`.
+  * **Diagonal form of the Varignon area.**
+      `varignonArea A B C D = cross (C - A) (D - B) / 4`.
+  * **The half-area law (headline).**
+      `varignonArea A B C D = signedArea A B C D / 2`,
+    valid for *every* quadrilateral, with no convexity or simplicity hypothesis.
+
+Because the statements are identities of real polynomials, the self-intersecting
+case is not a separate case at all — it is the same identity.  We exhibit a
+crossed quadrilateral with *negative* signed area to show the law is genuinely
+signed (the unsigned "half the area" slogan would be false there, but the signed
+law holds exactly).
+
+Conventions match the parent (`Point := ℝ × ℝ`, `midpoint2` the componentwise
+average); `signedArea`/`cross` are declared self-containedly so the entry
+compiles without the parent's olean.
+-/
+
+import Mathlib.Tactic
+
+namespace VarignonArea
+
+/-- A point of the plane, modeled as a pair of real coordinates (matches the
+parent `VarignonTheorem.Point`). -/
+abbrev Point := ℝ × ℝ
+
+/-- The midpoint of two points (the componentwise average), as in the parent. -/
+noncomputable def midpoint2 (X Y : Point) : Point :=
+  ((X.1 + Y.1) / 2, (X.2 + Y.2) / 2)
+
+/-- The 2-D cross product (the `z`-component of the 3-D cross product, a.k.a. the
+wedge / signed parallelogram area of two vectors):
+`cross U V = U.x · V.y − U.y · V.x`. -/
+def cross (U V : Point) : ℝ := U.1 * V.2 - U.2 * V.1
+
+/-- Vector difference of two points. -/
+def sub2 (X Y : Point) : Point := (X.1 - Y.1, X.2 - Y.2)
+
+/-- The **signed area** of the quadrilateral `A → B → C → D` via the shoelace
+formula.  Unlike the unsigned area this is a polynomial in the coordinates, so it
+is defined uniformly for convex, concave, and self-intersecting quadrilaterals
+(the sign records orientation, and is negative for a clockwise traversal). -/
+noncomputable def signedArea (A B C D : Point) : ℝ :=
+  (cross A B + cross B C + cross C D + cross D A) / 2
+
+/-- The **signed area of the Varignon parallelogram** `PQRS`, where
+`P = mid(A,B)`, `Q = mid(B,C)`, `R = mid(C,D)`, `S = mid(D,A)`. -/
+noncomputable def varignonArea (A B C D : Point) : ℝ :=
+  signedArea (midpoint2 A B) (midpoint2 B C) (midpoint2 C D) (midpoint2 D A)
+
+/-- **The quadrilateral's signed area depends only on its diagonals.**
+For any quadrilateral `ABCD`, the shoelace area equals half the cross product of
+the diagonal vectors `AC = C − A` and `BD = D − B`:
+`signedArea A B C D = cross (C − A) (D − B) / 2`.  This is the key reformulation
+that makes the self-intersecting case automatic. -/
+theorem signedArea_eq_half_cross_diagonals (A B C D : Point) :
+    signedArea A B C D = cross (sub2 C A) (sub2 D B) / 2 := by
+  simp only [signedArea, cross, sub2]
+  ring
+
+/-- **The Varignon parallelogram's signed area is a quarter of the diagonal
+cross product.**  Its sides are the half-diagonals `(C − A)/2` and `(D − B)/2`,
+so its signed area is `cross (C − A) (D − B) / 4`. -/
+theorem varignonArea_eq_quarter_cross_diagonals (A B C D : Point) :
+    varignonArea A B C D = cross (sub2 C A) (sub2 D B) / 4 := by
+  simp only [varignonArea, signedArea, varignonArea, midpoint2, cross, sub2]
+  ring
+
+/-- **Varignon's area law (headline).**  The Varignon parallelogram has exactly
+half the signed area of the original quadrilateral:
+`varignonArea A B C D = signedArea A B C D / 2`.
+
+This is a polynomial identity in the eight coordinates, so it holds with **no**
+convexity or simplicity hypothesis — in particular it answers the parent's open
+question by covering the self-intersecting case on the same footing as the convex
+one. -/
+theorem varignonArea_eq_half_signedArea (A B C D : Point) :
+    varignonArea A B C D = signedArea A B C D / 2 := by
+  rw [varignonArea_eq_quarter_cross_diagonals, signedArea_eq_half_cross_diagonals]
+  ring
+
+/-- Equivalent multiplicative phrasing: twice the Varignon area equals the
+quadrilateral area, `2 · varignonArea = signedArea`. -/
+theorem two_mul_varignonArea (A B C D : Point) :
+    2 * varignonArea A B C D = signedArea A B C D := by
+  rw [varignonArea_eq_half_signedArea]; ring
+
+/-- **The Varignon parallelogram is never collapsed unless the diagonals are
+parallel.**  Its signed area vanishes exactly when the diagonal cross product
+does, i.e. when `AC ∥ BD`. -/
+theorem varignonArea_eq_zero_iff (A B C D : Point) :
+    varignonArea A B C D = 0 ↔ cross (sub2 C A) (sub2 D B) = 0 := by
+  rw [varignonArea_eq_quarter_cross_diagonals]
+  constructor
+  · intro h; linarith [h]
+  · intro h; rw [h]; ring
+
+/-! ### Self-intersecting witness
+
+A *crossed* (self-intersecting) quadrilateral, traversed `A → B → C → D` so that
+edges `BC` and `DA` cross.  Its signed shoelace area is **negative**, so the
+naive unsigned "half the area" slogan is ambiguous there, yet the signed law
+`varignonArea = signedArea / 2` holds exactly. -/
+
+/-- Vertices of a self-intersecting quadrilateral: with the order
+`(0,0) → (0,3) → (3,0) → (3,1)` the edges `BC` (from `(0,3)` to `(3,0)`) and `DA`
+(from `(3,1)` to `(0,0)`) cross at `(9/4, 3/4)`. -/
+def Ax : Point := (0, 0)
+def Bx : Point := (0, 3)
+def Cx : Point := (3, 0)
+def Dx : Point := (3, 1)
+
+/-- The crossed quadrilateral has **negative** signed area (clockwise net
+orientation): the unsigned-area picture proof cannot apply, only the signed
+identity. -/
+theorem crossed_signedArea_neg : signedArea Ax Bx Cx Dx = -3 := by
+  simp only [signedArea, cross, Ax, Bx, Cx, Dx]; norm_num
+
+/-- Even for that crossed quadrilateral the half-area law holds on the nose:
+`varignonArea = signedArea / 2 = -3/2`. -/
+theorem crossed_varignonArea : varignonArea Ax Bx Cx Dx = -3 / 2 := by
+  rw [varignonArea_eq_half_signedArea, crossed_signedArea_neg]
+
+end VarignonArea

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "cay-oq010202-ann-docstring",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "From the conjugation representation to the outer automorphism exact sequence",
+    "content": "The module docstring answers the parent's second open question. The parent built the conjugation representation C : G →* Sym(G), found ker C = Z(G), and realised Inn(G) ≅ G/Z(G) inside Sym(G). Here the picture moves into the automorphism group Aut(G) = MulAut G, where Inn(G) := (MulAut.conj).range lives as a subgroup, and completes the structural story: a single covariance identity makes Inn(G) normal in Aut(G), which makes Out(G) = Aut(G)/Inn(G) a group and yields the exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1, the isomorphism G/Z(G) ≅ Inn(G), and the order formula |Aut(G)| = |Out(G)|·|Inn(G)|.",
+    "mathContext": "$\\operatorname{Inn}(G) \\trianglelefteq \\operatorname{Aut}(G)$, $\\operatorname{Out}(G) = \\operatorname{Aut}(G)/\\operatorname{Inn}(G)$, exact $1 \\to \\operatorname{Inn} \\to \\operatorname{Aut} \\to \\operatorname{Out} \\to 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "inner automorphism",
+      "outer automorphism group",
+      "normal subgroup",
+      "short exact sequence",
+      "center"
+    ],
+    "prerequisites": [
+      "automorphism group MulAut G",
+      "normal subgroups and quotient groups",
+      "first isomorphism theorem"
+    ]
+  },
+  {
+    "id": "cay-oq010202-ann-covariance",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 62, "endLine": 85 },
+    "type": "key-step",
+    "title": "Covariance of conjugation drives normality of Inn(G)",
+    "content": "Inn G := (MulAut.conj).range is the inner automorphism group as a subgroup of MulAut G. The covariance identity conj_mulAut_conj proves φ · (conj g) · φ⁻¹ = conj (φ g) for any automorphism φ: evaluating both automorphisms at x, the left side is φ(g · φ⁻¹(x) · g⁻¹) = φ(g)·x·φ(g)⁻¹ using that φ is a multiplicative equivalence (map_mul, map_inv) and φ(φ⁻¹ x) = x, matching conj(φ g) x. The instance (Inn G).Normal is then immediate: a conjugate of conj g is conj(φ g), still in the range, with explicit witness φ(g).",
+    "mathContext": "$\\varphi\\,(\\operatorname{conj} g)\\,\\varphi^{-1} = \\operatorname{conj}(\\varphi g) \\;\\Rightarrow\\; \\operatorname{Inn}(G) \\trianglelefteq \\operatorname{Aut}(G)$.",
+    "significance": "critical",
+    "relatedConcepts": ["inner automorphism", "covariance", "normal subgroup"],
+    "prerequisites": ["MulAut.conj", "MulEquiv map_mul/map_inv", "Subgroup.Normal"]
+  },
+  {
+    "id": "cay-oq010202-ann-out",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 94 },
+    "type": "definition",
+    "title": "The outer automorphism group Out(G) = Aut(G)/Inn(G)",
+    "content": "Out G := MulAut G ⧸ Inn G inherits a Group instance from QuotientGroup.Quotient.group precisely because Inn(G) is normal — the Lean development makes this dependency explicit, synthesising the Group instance from the (Inn G).Normal instance. The canonical surjection outMk := QuotientGroup.mk' (Inn G) is the quotient homomorphism Aut(G) →* Out(G).",
+    "mathContext": "$\\operatorname{Out}(G) := \\operatorname{Aut}(G)/\\operatorname{Inn}(G)$.",
+    "significance": "important",
+    "relatedConcepts": ["outer automorphism group", "quotient group"],
+    "prerequisites": ["normal subgroup", "QuotientGroup.mk'"]
+  },
+  {
+    "id": "cay-oq010202-ann-exactness",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 95, "endLine": 118 },
+    "type": "key-step",
+    "title": "Exactness of 1 → Inn(G) → Aut(G) → Out(G) → 1",
+    "content": "Three facts assemble the short exact sequence. inn_subtype_injective (Subgroup.subtype_injective) is injectivity of the inclusion Inn(G) ↪ Aut(G) at the left. outMk_surjective (QuotientGroup.mk'_surjective) is surjectivity of the quotient map at the right. range_inn_subtype_eq_ker_outMk proves range(Inn(G).subtype) = ker(outMk) — exactness in the middle — by Subgroup.range_subtype (image of the inclusion is Inn(G)) and QuotientGroup.ker_mk' (kernel of the quotient map is Inn(G)). Once the objects exist, each is a one-line consequence of Mathlib's QuotientGroup API.",
+    "mathContext": "$\\operatorname{im}(\\iota) = \\ker(\\pi)$, $\\iota$ injective, $\\pi$ surjective.",
+    "significance": "critical",
+    "relatedConcepts": ["short exact sequence", "kernel", "image"],
+    "prerequisites": ["Subgroup.range_subtype", "QuotientGroup.ker_mk'", "mk'_surjective"]
+  },
+  {
+    "id": "cay-oq010202-ann-center",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 119, "endLine": 144 },
+    "type": "key-step",
+    "title": "G/Z(G) ≅ Inn(G), realised inside Aut(G)",
+    "content": "ker_mulAutConj proves (MulAut.conj).ker = Subgroup.center G directly at the automorphism level, by the same mul_inv_eq_iff_eq_mul manipulation as the parent's ker_conjRep but using MulEquiv.ext_iff and MulAut.one_apply. quotientCenterEquivInn then composes QuotientGroup.quotientMulEquivOfEq ker_mulAutConj.symm with the first isomorphism theorem quotientKerEquivRange to deliver G ⧸ Z(G) ≃* Inn(G) — the parent's isomorphism now landing on the automorphism subgroup Inn(G) ≤ Aut(G).",
+    "mathContext": "$\\ker(\\operatorname{conj}) = Z(G)$, $G/Z(G) \\cong \\operatorname{Inn}(G)$.",
+    "significance": "important",
+    "relatedConcepts": ["center", "first isomorphism theorem", "inner automorphism"],
+    "prerequisites": ["Subgroup.mem_center_iff", "quotientKerEquivRange"]
+  },
+  {
+    "id": "cay-oq010202-ann-order",
+    "proofId": "cayleys-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 145, "endLine": 156 },
+    "type": "key-step",
+    "title": "Order formula |Aut(G)| = |Out(G)|·|Inn(G)| for finite G",
+    "content": "card_mulAut_eq_card_out_mul_card_inn is the Lagrange factorisation Subgroup.card_eq_card_quotient_mul_card_subgroup applied to Inn(G) ◁ Aut(G), giving |Aut(G)| = |Out(G)|·|Inn(G)|. Rewriting Nat.card (Inn G) through the isomorphism quotientCenterEquivInn (Nat.card_congr) refines it to |Aut(G)| = |Out(G)|·|G/Z(G)| in card_mulAut_eq_card_out_mul_card_quotient_center.",
+    "mathContext": "$|\\operatorname{Aut}(G)| = |\\operatorname{Out}(G)|\\cdot|\\operatorname{Inn}(G)| = |\\operatorname{Out}(G)|\\cdot|G/Z(G)|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's theorem", "group order", "index"],
+    "prerequisites": ["card_eq_card_quotient_mul_card_subgroup", "Nat.card_congr"]
+  }
+]

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,223 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-02-oq-02",
+  "title": "The Outer Automorphism Exact Sequence: Inn(G) ◁ Aut(G) and Out(G) = Aut(G)/Inn(G)",
+  "slug": "cayleys-theorem-oq-01-oq-02-oq-02",
+  "description": "The parent entry built the conjugation representation C : G →* Equiv.Perm G, computed its kernel ker C = Z(G), and realised its image — the inner automorphism group Inn(G) — as G/Z(G) inside the symmetric group Sym(G). This entry answers the parent's second open question: it moves from Sym(G) into the automorphism group Aut(G) = MulAut G and completes the structural picture by formalizing the short exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1. The inner automorphism group is defined as Inn G := (MulAut.conj).range ≤ MulAut G, the range of Mathlib's inner-automorphism homomorphism. The engine of the whole development is a single covariance identity, conj_mulAut_conj: for any automorphism φ and any g, φ · (conj g) · φ⁻¹ = conj (φ g) — conjugating an inner automorphism by an arbitrary automorphism is again inner, with explicit witness φ(g). This immediately yields the central new fact, an instance (Inn G).Normal: Inn(G) is a normal subgroup of Aut(G). Normality is exactly what is needed to form the outer automorphism group Out G := MulAut G ⧸ Inn G as a genuine Group, with quotient map outMk : Aut(G) → Out(G). Exactness of 1 → Inn(G) → Aut(G) → Out(G) → 1 is then assembled from three facts: inn_subtype_injective (injectivity of the inclusion at the left), outMk_surjective (surjectivity of the quotient map at the right), and range_inn_subtype_eq_ker_outMk: range(Inn(G).subtype) = ker(outMk) (exactness in the middle). To tie back to the parent, ker_mulAutConj proves ker(MulAut.conj) = Z(G) directly at the MulAut level, and quotientCenterEquivInn delivers G ⧸ Z(G) ≃* Inn(G) realised as an isomorphism onto the automorphism subgroup Inn(G) ≤ Aut(G). Finally, for finite G, card_mulAut_eq_card_out_mul_card_inn gives the Lagrange order formula |Aut(G)| = |Out(G)| · |Inn(G)|, refined to |Aut(G)| = |Out(G)| · |G/Z(G)| via the isomorphism. Everything holds for an arbitrary group G (finiteness only for the order formula).",
+  "meta": {
+    "author": "Classical (inner and outer automorphism groups); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Outer_automorphism_group",
+    "date": "1894",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "inner-automorphism",
+      "outer-automorphism",
+      "automorphism-group",
+      "normal-subgroup",
+      "quotient-group",
+      "exact-sequence",
+      "center",
+      "first-isomorphism-theorem",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAut.conj",
+        "description": "Group conjugation g ↦ (h ↦ g·h·g⁻¹) packaged as a monoid homomorphism G →* MulAut G; its range is the inner automorphism group Inn(G), the kernel object of this entry",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "MulAut.mul_apply",
+        "description": "(e₁ * e₂) m = e₁ (e₂ m) — the composition convention for automorphisms, used to evaluate φ · conj g · φ⁻¹ pointwise in the covariance lemma",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Subgroup.Normal",
+        "description": "The normality structure; (Inn G).Normal is established here from the covariance identity conjugating inner automorphisms back into Inn(G)",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.Quotient.group",
+        "description": "The group structure on G ⧸ N for normal N; supplies the Group instance on Out(G) = MulAut G ⧸ Inn G once (Inn G).Normal is in scope",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Defs"
+      },
+      {
+        "theorem": "QuotientGroup.mk'_surjective",
+        "description": "The quotient map mk' N : G →* G ⧸ N is surjective — supplies surjectivity of outMk at the right end of the exact sequence",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Defs"
+      },
+      {
+        "theorem": "QuotientGroup.ker_mk'",
+        "description": "ker (mk' N) = N — combined with Subgroup.range_subtype it gives exactness in the middle: range(Inn(G).subtype) = ker(outMk)",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Defs"
+      },
+      {
+        "theorem": "Subgroup.range_subtype",
+        "description": "H.subtype.range = H — identifies the image of the inclusion Inn(G) ↪ Aut(G) with Inn(G) itself for the exactness statement",
+        "module": "Mathlib.Algebra.Group.Subgroup.Ker"
+      },
+      {
+        "theorem": "QuotientGroup.quotientKerEquivRange",
+        "description": "First isomorphism theorem G ⧸ f.ker ≃* f.range; applied to MulAut.conj it yields G ⧸ ker ≃* Inn(G)",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.quotientMulEquivOfEq",
+        "description": "Equal normal subgroups give isomorphic quotients; with ker_mulAutConj it rewrites G ⧸ Z(G) as G ⧸ ker before the first isomorphism theorem",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.card_eq_card_quotient_mul_card_subgroup",
+        "description": "Nat.card G = Nat.card (G ⧸ H) · Nat.card H — the Lagrange factorisation giving |Aut(G)| = |Out(G)| · |Inn(G)| for finite G",
+        "module": "Mathlib.GroupTheory.Coset.Card"
+      }
+    ],
+    "originalContributions": [
+      "conj_mulAut_conj: φ · (MulAut.conj g) · φ⁻¹ = MulAut.conj (φ g) — the covariance identity proving that conjugating an inner automorphism by an arbitrary automorphism is again inner, with explicit witness φ(g); the engine behind normality",
+      "instance (Inn G).Normal — the inner automorphism group Inn G := (MulAut.conj).range is a normal subgroup of Aut(G) = MulAut G, derived directly from the covariance identity",
+      "Out G := MulAut G ⧸ Inn G with its Group instance — the outer automorphism group, well-defined precisely because Inn(G) is normal, together with the quotient map outMk : Aut(G) →* Out(G)",
+      "range_inn_subtype_eq_ker_outMk: (Inn G).subtype.range = (outMk G).ker — exactness in the middle of 1 → Inn(G) → Aut(G) → Out(G) → 1, completed by inn_subtype_injective (injectivity at the left) and outMk_surjective (surjectivity at the right)",
+      "ker_mulAutConj: (MulAut.conj).ker = Subgroup.center G and quotientCenterEquivInn: G ⧸ Z(G) ≃* Inn(G) — the parent's G/Z(G) ≅ Inn(G) re-realised as an isomorphism onto the automorphism subgroup Inn(G) ≤ Aut(G)",
+      "card_mulAut_eq_card_out_mul_card_inn / card_mulAut_eq_card_out_mul_card_quotient_center: |Aut(G)| = |Out(G)| · |Inn(G)| = |Out(G)| · |G/Z(G)| for finite G — the Lagrange order formula for the automorphism group along the exact sequence"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 156,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used. The exact sequence and isomorphism hold for an arbitrary (possibly infinite) group G; finiteness of G is assumed only for the two order-formula theorems.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Every automorphism of a group G that arises as conjugation by a group element x ↦ g·x·g⁻¹ is called inner; the inner automorphisms form a subgroup Inn(G) of the full automorphism group Aut(G). The classical observation — going back to the late nineteenth-century study of automorphisms (Hölder, 1893–95) — is that Inn(G) is normal in Aut(G), because conjugating an inner automorphism by any automorphism φ produces conjugation by φ(g), again inner. The quotient Aut(G)/Inn(G) is the outer automorphism group Out(G), which measures the automorphisms of G that are not realised internally. The resulting short exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1, together with the first-isomorphism identification Inn(G) ≅ G/Z(G) from the parent entry, organises the entire automorphism structure of a group and is the starting point of the automorphism tower problem and of cohomological extension theory.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01-oq-02, second follow-up)**: Building on the parent's conjugation representation and its isomorphism G/Z(G) ≅ Inn(G) (realised in Sym(G)), prove the outer automorphism exact sequence at the formalized level: define Inn(G) and Out(G) = Aut(G)/Inn(G) inside the automorphism group Aut(G) = MulAut G, show Inn(G) ◁ Aut(G), and exhibit the exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1.\n\n**Result**: Inn G := (MulAut.conj).range with instance (Inn G).Normal (via the covariance identity conj_mulAut_conj), Out G := MulAut G ⧸ Inn G as a Group, and the exactness data inn_subtype_injective, outMk_surjective, range_inn_subtype_eq_ker_outMk; plus ker_mulAutConj, quotientCenterEquivInn (G/Z(G) ≃* Inn(G)) and the finite order formula |Aut(G)| = |Out(G)| · |Inn(G)|.",
+    "text": "Let G be any group, Aut(G) = MulAut G its automorphism group, and Inn(G) = (MulAut.conj).range ≤ Aut(G) the subgroup of inner automorphisms. Then Inn(G) is normal in Aut(G), so the outer automorphism group Out(G) := Aut(G)/Inn(G) is a group, and the sequence 1 → Inn(G) → Aut(G) → Out(G) → 1 is exact: the inclusion is injective, the quotient map is surjective, and the image of the inclusion equals the kernel of the quotient map. Moreover ker(MulAut.conj) = Z(G) gives G/Z(G) ≅ Inn(G), and for finite G one has |Aut(G)| = |Out(G)|·|Inn(G)| = |Out(G)|·|G/Z(G)|.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Covariance. conj_mulAut_conj proves φ · (MulAut.conj g) · φ⁻¹ = MulAut.conj (φ g). Evaluate at x: the left side is φ(g · φ⁻¹(x) · g⁻¹) = φ(g)·x·φ(g)⁻¹ using map_mul, map_inv and MulEquiv.apply_symm_apply (φ(φ⁻¹ x) = x); the right side is φ(g)·x·φ(g)⁻¹ by MulAut.conj_apply. One ext + simp.\n2. Normality. (Inn G).Normal: an element of Inn(G) is conj g for some g; its conjugate by φ is φ · conj g · φ⁻¹ = conj (φ g) ∈ Inn(G) by step 1. The instance's conj_mem closes by rintro ⟨g, rfl⟩ and exhibiting the witness φ(g).\n3. Out(G). With normality in scope, Out G := MulAut G ⧸ Inn G inherits QuotientGroup.Quotient.group, and outMk := QuotientGroup.mk' (Inn G) is the quotient homomorphism.\n4. Exactness. inn_subtype_injective is Subgroup.subtype_injective; outMk_surjective is QuotientGroup.mk'_surjective; range_inn_subtype_eq_ker_outMk rewrites with Subgroup.range_subtype (image of the inclusion is Inn(G)) and QuotientGroup.ker_mk' (kernel of mk' is Inn(G)), so the two coincide.\n5. Tie to the centre. ker_mulAutConj proves (MulAut.conj).ker = Z(G) by the same mul_inv_eq_iff_eq_mul manipulation as the parent's ker_conjRep, now at the MulAut level via MulEquiv.ext_iff and MulAut.one_apply. quotientCenterEquivInn composes quotientMulEquivOfEq ker_mulAutConj.symm with quotientKerEquivRange to give G ⧸ Z(G) ≃* Inn(G).\n6. Order formula. card_mulAut_eq_card_out_mul_card_inn is Subgroup.card_eq_card_quotient_mul_card_subgroup (Inn G); rewriting Nat.card (Inn G) with quotientCenterEquivInn yields |Aut(G)| = |Out(G)| · |G/Z(G)|.",
+    "keyInsights": [
+      "**One covariance identity does all the work.** The single equation φ · conj(g) · φ⁻¹ = conj(φ(g)) is the entire mathematical content of normality: it says the set of inner automorphisms is closed under conjugation by arbitrary automorphisms, with the conjugated element computed explicitly as φ(g). Everything downstream — Out(G), the exact sequence, the order formula — is bookkeeping over this fact.",
+      "**Normality is exactly the licence to form Out(G).** Out(G) = Aut(G)/Inn(G) is only a group because Inn(G) ◁ Aut(G); the Lean development makes this dependency explicit — the Group instance on Out(G) is synthesised from the (Inn G).Normal instance, which in turn is synthesised from the covariance lemma.",
+      "**The exact sequence is three one-line facts once the objects exist.** Injectivity of the inclusion (subtype_injective), surjectivity of the quotient map (mk'_surjective), and the matching of image with kernel (range_subtype together with ker_mk') are each immediate from Mathlib's QuotientGroup API — the genuine work was establishing normality so that these objects are well-typed.",
+      "**Moving from Sym(G) to Aut(G) sharpens the parent's picture.** The parent realised Inn(G) as a permutation subgroup of Sym(G); here it lives where it belongs, inside Aut(G) = MulAut G, so that Inn(G) ◁ Aut(G) and Out(G) are even statable. ker_mulAutConj re-establishes the centre as the kernel directly at the automorphism level.",
+      "**The order formula is Lagrange along the sequence.** For finite G, |Aut(G)| = |Out(G)|·|Inn(G)| is the index–order factorisation for Inn(G) ◁ Aut(G), and |Inn(G)| = |G/Z(G)| substitutes the parent's isomorphism — a clean numerical consequence of the exact sequence."
+    ],
+    "prerequisites": [
+      "The conjugation/inner-automorphism homomorphism MulAut.conj, the automorphism group MulAut G and its composition convention (MulAut.mul_apply, MulAut.inv_apply)",
+      "Normal subgroups (Subgroup.Normal) and quotient groups (QuotientGroup.Quotient.group, mk', ker_mk', mk'_surjective)",
+      "The first isomorphism theorem (QuotientGroup.quotientKerEquivRange, quotientMulEquivOfEq) and Lagrange's theorem in cardinality form (Subgroup.card_eq_card_quotient_mul_card_subgroup)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring posing the parent's second open question — the outer automorphism exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1 — and listing the six deliverables (covariance, normality, Out(G), exactness, G/Z(G) ≅ Inn(G), order formula), followed by imports (Algebra.Group.End, Subgroup.Center, QuotientGroup.Basic, Coset.Card) and the namespace with an arbitrary group variable G.",
+      "mathContext": "$\\operatorname{Aut}(G) = \\mathrm{MulAut}\\,G$, $\\operatorname{Inn}(G) \\trianglelefteq \\operatorname{Aut}(G)$, $\\operatorname{Out}(G) = \\operatorname{Aut}(G)/\\operatorname{Inn}(G)$."
+    },
+    {
+      "id": "inn",
+      "title": "The Inner Automorphism Group and Covariance",
+      "startLine": 57,
+      "endLine": 85,
+      "summary": "Inn G := (MulAut.conj).range ≤ MulAut G with the membership characterisation mem_Inn_iff, then the covariance identity conj_mulAut_conj: φ · (conj g) · φ⁻¹ = conj (φ g), proved by evaluating both automorphisms at x (map_mul, map_inv, MulEquiv.apply_symm_apply). This drives the instance (Inn G).Normal: conjugating an inner automorphism by any automorphism is inner, witness φ(g).",
+      "mathContext": "$\\varphi\\,(\\operatorname{conj} g)\\,\\varphi^{-1} = \\operatorname{conj}(\\varphi g)$, hence $\\operatorname{Inn}(G) \\trianglelefteq \\operatorname{Aut}(G)$."
+    },
+    {
+      "id": "out",
+      "title": "The Outer Automorphism Group",
+      "startLine": 86,
+      "endLine": 94,
+      "summary": "Out G := MulAut G ⧸ Inn G with its Group instance (QuotientGroup.Quotient.group, available because Inn(G) is normal), and the canonical surjection outMk := QuotientGroup.mk' (Inn G) : Aut(G) →* Out(G).",
+      "mathContext": "$\\operatorname{Out}(G) := \\operatorname{Aut}(G)/\\operatorname{Inn}(G)$, well-defined by normality."
+    },
+    {
+      "id": "exactness",
+      "title": "Exactness of 1 → Inn(G) → Aut(G) → Out(G) → 1",
+      "startLine": 95,
+      "endLine": 118,
+      "summary": "inn_subtype_injective (Subgroup.subtype_injective) — injectivity at the left; outMk_surjective (QuotientGroup.mk'_surjective) — surjectivity at the right; range_inn_subtype_eq_ker_outMk — exactness in the middle, proved by Subgroup.range_subtype and QuotientGroup.ker_mk', giving range(Inn(G).subtype) = ker(outMk).",
+      "mathContext": "$\\operatorname{im}(\\iota) = \\ker(\\pi)$ with $\\iota$ injective and $\\pi$ surjective."
+    },
+    {
+      "id": "center",
+      "title": "Identification G/Z(G) ≅ Inn(G)",
+      "startLine": 119,
+      "endLine": 144,
+      "summary": "ker_mulAutConj: (MulAut.conj).ker = Subgroup.center G, via MonoidHom.mem_ker, Subgroup.mem_center_iff, MulEquiv.ext_iff and mul_inv_eq_iff_eq_mul. quotientCenterEquivInn: G ⧸ Z(G) ≃* Inn(G) composes quotientMulEquivOfEq ker_mulAutConj.symm with quotientKerEquivRange — the parent's isomorphism now landing on the automorphism subgroup Inn(G).",
+      "mathContext": "$\\ker(\\operatorname{conj}) = Z(G)$, so $G/Z(G) \\cong \\operatorname{Inn}(G)$."
+    },
+    {
+      "id": "order-formula",
+      "title": "Order Formula for Finite Groups",
+      "startLine": 145,
+      "endLine": 156,
+      "summary": "card_mulAut_eq_card_out_mul_card_inn: |Aut(G)| = |Out(G)|·|Inn(G)| (Subgroup.card_eq_card_quotient_mul_card_subgroup), refined by card_mulAut_eq_card_out_mul_card_quotient_center to |Aut(G)| = |Out(G)|·|G/Z(G)| via Nat.card_congr quotientCenterEquivInn.",
+      "mathContext": "$|\\operatorname{Aut}(G)| = |\\operatorname{Out}(G)|\\cdot|\\operatorname{Inn}(G)| = |\\operatorname{Out}(G)|\\cdot|G/Z(G)|$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: builds the conjugation representation C : G →* Sym(G), proves ker C = Z(G), and realises Inn(G) ≅ G/Z(G) inside Sym(G). This entry answers its second open question by moving Inn(G) into Aut(G) = MulAut G, proving Inn(G) ◁ Aut(G), and exhibiting the exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "builds-on",
+      "description": "Root of the chain: Cayley's theorem G ↪ Sym(G). The automorphism-group structure formalized here is the natural endpoint of the conjugation-action branch of that chain."
+    },
+    {
+      "targetId": "conjugacy-class-equation-oq-01",
+      "relationship": "related",
+      "description": "The inner automorphism group and the centre Z(G) = ker(conj) underpin the class equation; Out(G) = Aut(G)/Inn(G) is the complementary quotient measuring non-inner symmetry."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the outer automorphism exact sequence 1 → Inn(G) → Aut(G) → Out(G) → 1 for an arbitrary group G. The covariance identity conj_mulAut_conj (φ·conj(g)·φ⁻¹ = conj(φ(g))) yields the instance (Inn G).Normal, which makes Out G := MulAut G ⧸ Inn G a group with quotient map outMk. Exactness is captured by inn_subtype_injective, outMk_surjective, and range_inn_subtype_eq_ker_outMk. ker_mulAutConj and quotientCenterEquivInn re-realise the parent's G/Z(G) ≅ Inn(G) as an isomorphism onto the automorphism subgroup, and the finite order formula |Aut(G)| = |Out(G)|·|Inn(G)| = |Out(G)|·|G/Z(G)| follows by Lagrange.",
+    "implications": "Completes the conjugation branch of the Cayley chain by organising the full automorphism structure of a group into a short exact sequence. Inn(G) ◁ Aut(G) and Out(G) = Aut(G)/Inn(G) are the objects underlying the automorphism tower problem, complete groups (where Out(G) and Z(G) both vanish), and the cohomological classification of group extensions. The development isolates the covariance identity as the single nontrivial input and shows the rest is standard quotient-group bookkeeping, making explicit how normality is the precise prerequisite for the outer automorphism group to exist.",
+    "openQuestions": [
+      "Characterise complete groups in this framework: prove that Out(G) is trivial and Z(G) = ⊥ together are equivalent to MulAut.conj : G ≃* MulAut G being an isomorphism (Aut(G) = Inn(G) with trivial centre), and exhibit the symmetric groups Sₙ (n ≠ 2, 6) as instances.",
+      "Promote exactness to the splitting/extension picture: identify when 1 → Inn(G) → Aut(G) → Out(G) → 1 splits (Out(G) lifts to a subgroup of Aut(G)) and relate the obstruction to the cohomology class in H²(Out(G), Z(Inn(G)))."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Group.End",
+      "Mathlib.GroupTheory.Subgroup.Center",
+      "Mathlib.GroupTheory.QuotientGroup.Basic",
+      "Mathlib.GroupTheory.Coset.Card",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CayleyOuter",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 4,
+    "path": "Proofs/CayleysTheoremOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hölder, Otto",
+      "title": "Bildung zusammengesetzter Gruppen",
+      "year": "1895",
+      "venue": "Mathematische Annalen 46",
+      "note": "Early systematic study of automorphisms, inner vs. outer, and the holomorph"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §4.4",
+      "note": "Inner and outer automorphism groups; Inn(G) ◁ Aut(G) and Inn(G) ≅ G/Z(G)"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/varignon-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/varignon-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "var-oq0101-ann-docstring",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Resolving the self-intersecting area question via signed area",
+    "content": "The module docstring takes up the parent's first open question — the relationship between the Varignon parallelogram's area and the quadrilateral's area in the self-intersecting case. The classical 'half the area' proof is a picture for convex quadrilaterals and breaks for crossed ones. The fix is to use the signed shoelace area, which is a polynomial in the coordinates and so treats convex, concave, and self-intersecting quadrilaterals identically. The three deliverables are the diagonal reformulation, the headline half-area law, and an explicit crossed witness with negative signed area.",
+    "mathContext": "Goal: $\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$, hypothesis-free.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "signed area",
+      "shoelace formula",
+      "self-intersecting polygon",
+      "oriented area"
+    ],
+    "prerequisites": [
+      "coordinate geometry of the plane",
+      "the shoelace formula for polygon area"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-defs",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 44, "endLine": 70 },
+    "type": "definition",
+    "title": "Cross product, shoelace area, and the Varignon area",
+    "content": "Points are pairs in ℝ × ℝ and midpoint2 is the componentwise average (matching the parent). The 2-D cross product cross U V = U.x·V.y − U.y·V.x is the oriented area of the parallelogram on U and V. signedArea A B C D is the shoelace sum (cross A B + cross B C + cross C D + cross D A)/2, defined uniformly regardless of orientation or self-intersection. varignonArea A B C D applies signedArea to the four side midpoints P = mid(A,B), Q = mid(B,C), R = mid(C,D), S = mid(D,A).",
+    "mathContext": "$\\operatorname{signedArea}(A,B,C,D)=\\tfrac12\\big(\\operatorname{cross}(A,B)+\\operatorname{cross}(B,C)+\\operatorname{cross}(C,D)+\\operatorname{cross}(D,A)\\big)$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "cross product",
+      "shoelace formula",
+      "midpoint",
+      "oriented area"
+    ],
+    "prerequisites": [
+      "vectors and the midpoint formula",
+      "the 2-D cross product as signed area"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-diagonal",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 96 },
+    "type": "technique",
+    "title": "The shoelace sum telescopes to the diagonal cross product",
+    "content": "The pivotal lemma signedArea_eq_half_cross_diagonals shows the four-edge shoelace sum collapses to a single cross product of the diagonals: signedArea A B C D = cross (C − A) (D − B) / 2. So a quadrilateral's signed area depends only on its diagonals AC and BD. Applying the same to the four midpoints gives varignonArea = cross (C − A) (D − B) / 4 — the Varignon sides are the half-diagonals (C−A)/2 and (D−B)/2. Both identities are closed by `ring` after unfolding the definitions.",
+    "mathContext": "$\\operatorname{signedArea}=\\tfrac12\\operatorname{cross}(C-A,D-B)$ and $\\operatorname{varignonArea}=\\tfrac14\\operatorname{cross}(C-A,D-B)$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "diagonals of a quadrilateral",
+      "telescoping",
+      "ring tactic",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "algebraic manipulation of coordinates"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-halfarea",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 118 },
+    "type": "key-step",
+    "title": "The half-area law (headline)",
+    "content": "Dividing the two diagonal forms gives the headline theorem varignonArea_eq_half_signedArea: varignonArea A B C D = signedArea A B C D / 2, with the equivalent multiplicative phrasing 2·varignonArea = signedArea. Because both sides are polynomials in the eight coordinates, this carries NO convexity, simplicity, or non-degeneracy hypothesis — the self-intersecting case is the same theorem. The companion varignonArea_eq_zero_iff reads off the collapse criterion: the Varignon parallelogram is degenerate exactly when the diagonal cross product vanishes, i.e. AC ∥ BD.",
+    "mathContext": "$\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$; degenerate $\\iff \\operatorname{cross}(C-A,D-B)=0$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Varignon's theorem",
+      "area ratio",
+      "parallel diagonals",
+      "degenerate parallelogram"
+    ],
+    "prerequisites": [
+      "the diagonal reformulation lemmas"
+    ]
+  },
+  {
+    "id": "var-oq0101-ann-witness",
+    "proofId": "varignon-theorem-oq-01-oq-01",
+    "range": { "startLine": 119, "endLine": 145 },
+    "type": "example",
+    "title": "A crossed quadrilateral with negative signed area",
+    "content": "The witness (0,0)→(0,3)→(3,0)→(3,1) is genuinely self-intersecting: edges BC (from (0,3) to (3,0)) and DA (from (3,1) to (0,0)) cross at (9/4, 3/4). Its signed shoelace area is −3 (clockwise net orientation), so the unsigned 'half the area' slogan is ambiguous as drawn. Nevertheless crossed_varignonArea confirms the signed law on the nose: varignonArea = −3/2 = (−3)/2. This is the concrete payoff of using signed area — the crossed case needs no separate argument.",
+    "mathContext": "$\\operatorname{signedArea}=-3$, $\\operatorname{varignonArea}=-\\tfrac32$ for the crossed quadrilateral.",
+    "significance": "illustrative",
+    "relatedConcepts": [
+      "self-intersecting quadrilateral",
+      "bowtie / crossed quadrilateral",
+      "negative oriented area"
+    ],
+    "prerequisites": [
+      "the half-area law"
+    ]
+  }
+]

--- a/src/data/proofs/varignon-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/varignon-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "varignon-theorem-oq-01-oq-01",
+  "slug": "varignon-theorem-oq-01-oq-01",
+  "title": "The Signed-Area Law for the Varignon Parallelogram (incl. the self-intersecting case)",
+  "description": "Using the signed shoelace area, the Varignon parallelogram has exactly half the signed area of its quadrilateral — a single polynomial identity that holds with no convexity or simplicity hypothesis, resolving the self-intersecting case posed in the parent's open question.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VarignonTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "quadrilateral",
+      "parallelogram",
+      "signed-area",
+      "shoelace-formula",
+      "coordinate-geometry",
+      "classical"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ring",
+        "description": "Commutative-ring normalization tactic; discharges every coordinate identity (the diagonal-cross reformulation and the half-area law).",
+        "module": "Mathlib.Tactic.Ring"
+      },
+      {
+        "theorem": "norm_num",
+        "description": "Numerical normalization used to evaluate the signed area of the explicit self-intersecting witness.",
+        "module": "Mathlib.Tactic.NormNum"
+      }
+    ],
+    "originalContributions": [
+      "Signed (shoelace) area of a quadrilateral formalized over ℝ × ℝ as a polynomial in the eight coordinates, defined uniformly for convex, concave, and self-intersecting quadrilaterals",
+      "Diagonal reformulation: signedArea A B C D = cross (C − A) (D − B) / 2 — the quadrilateral's signed area depends only on its two diagonals",
+      "Headline half-area law: varignonArea A B C D = signedArea A B C D / 2, proved as a single ring identity with NO convexity, simplicity, or non-degeneracy hypothesis — directly answering the parent's open question for the self-intersecting case",
+      "Collapse criterion: the Varignon parallelogram is degenerate iff the diagonals are parallel (cross of diagonals = 0)",
+      "Explicit self-intersecting witness ((0,0)→(0,3)→(3,0)→(3,1)) with NEGATIVE signed area −3, showing the unsigned 'half the area' slogan is ambiguous there while the signed law holds exactly (varignonArea = −3/2)"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide. The half-area law is a polynomial identity, so it holds for every quadrilateral — convex, concave, or self-intersecting.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 6,
+    "sourceUrl": ""
+  },
+  "overview": {
+    "historicalContext": "Varignon's midpoint theorem (published posthumously in 1731) states that the side midpoints of any quadrilateral form a parallelogram. The companion metric fact — that this Varignon parallelogram has half the area of the quadrilateral — is classically proved for convex quadrilaterals by an area-decomposition picture, and the picture is what fails when the quadrilateral is self-intersecting (crossed). The parent gallery entry formalizes the affine skeleton (the parallelogram property) and explicitly leaves the self-intersecting area relationship as an open question. The resolution is to use signed area: the shoelace formula assigns every closed polygon a signed area that is a polynomial in the vertex coordinates, so it makes no distinction between convex, concave, and self-intersecting polygons. The half-area law then becomes a single algebraic identity valid in all cases at once.",
+    "problemStatement": "Let ABCD be a quadrilateral with side midpoints P = mid(A,B), Q = mid(B,C), R = mid(C,D), S = mid(D,A). Working with the signed shoelace area, prove that the Varignon parallelogram PQRS satisfies area(PQRS) = ½·area(ABCD), and that this holds for an arbitrary quadrilateral — in particular for the self-intersecting case where the unsigned 'half the area' statement is no longer meaningful as drawn.",
+    "text": "The Varignon parallelogram has exactly half the signed area of the quadrilateral, in every case including self-intersecting ones.",
+    "proofStrategy": "Model points as ℝ × ℝ and define the 2-D cross product cross U V = U.x·V.y − U.y·V.x. The signed area of A→B→C→D is the shoelace sum (cross A B + cross B C + cross C D + cross D A)/2, and the Varignon area is the same functional applied to the four midpoints. The key reformulation, proved by `ring`, is that the shoelace sum telescopes to the cross product of the diagonals: signedArea A B C D = cross (C−A) (D−B) / 2. The Varignon parallelogram has side vectors equal to the half-diagonals (C−A)/2 and (D−B)/2, so the same computation gives varignonArea = cross (C−A) (D−B) / 4. Dividing, varignonArea = signedArea / 2. Because both sides are real polynomials in the eight coordinates, the identity is hypothesis-free, so the self-intersecting case is literally the same theorem. An explicit crossed quadrilateral with negative signed area is exhibited to confirm the law is genuinely signed.",
+    "keyInsights": [
+      "Replacing unsigned area (a piecewise, picture-dependent quantity) with the signed shoelace area (a single polynomial) is what makes the self-intersecting case disappear as a special case — there is only one identity to prove",
+      "The quadrilateral's signed area depends only on its diagonals: signedArea A B C D = ½·cross(AC, BD). The shoelace sum over the four edges telescopes to one cross product of the diagonal vectors",
+      "The Varignon parallelogram's sides are exactly the half-diagonals (C−A)/2 and (D−B)/2, so its signed area is ¼·cross(AC, BD) — a quarter of the diagonal cross product, hence half the quadrilateral's area",
+      "The half-area law varignonArea = signedArea/2 carries no convexity, simplicity, planarity, or non-degeneracy hypothesis; it is an identity of polynomials and therefore covers degenerate, concave, and self-intersecting quadrilaterals verbatim",
+      "Signed area can be negative: the crossed witness (0,0)→(0,3)→(3,0)→(3,1) has signed area −3 (clockwise net orientation). The unsigned slogan 'half the area' is ambiguous for such a bowtie, but the signed identity varignonArea = −3/2 = (−3)/2 holds on the nose",
+      "The Varignon parallelogram collapses to a segment exactly when the diagonal cross product vanishes, i.e. when the diagonals AC and BD are parallel — a clean affine non-degeneracy criterion read straight off the diagonal formula"
+    ],
+    "prerequisites": [
+      "Coordinate geometry of the plane (points as ordered pairs)",
+      "The shoelace (Gauss) formula for the signed area of a polygon",
+      "The 2-D cross product / wedge as oriented parallelogram area",
+      "Varignon's parallelogram theorem (the parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Docstring posing the parent's self-intersecting open question and the signed-area strategy, followed by the imports and the core definitions: Point = ℝ × ℝ, the componentwise midpoint2 (matching the parent), the 2-D cross product `cross`, vector difference `sub2`, the shoelace `signedArea` of a quadrilateral, and `varignonArea` (signedArea of the four side midpoints).",
+      "mathContext": "$\\operatorname{cross}(U,V)=U_xV_y-U_yV_x$; $\\operatorname{signedArea}(A,B,C,D)=\\tfrac12\\sum_{\\text{edges}}\\operatorname{cross}$."
+    },
+    {
+      "id": "diagonal-forms",
+      "title": "Diagonal Reformulations",
+      "startLine": 71,
+      "endLine": 96,
+      "summary": "The two telescoping identities proved by `ring`: the quadrilateral's signed area equals half the cross product of its diagonals (signedArea = cross(C−A, D−B)/2), and the Varignon area equals a quarter of the same diagonal cross product (varignonArea = cross(C−A, D−B)/4).",
+      "mathContext": "$\\operatorname{signedArea}=\\tfrac12\\operatorname{cross}(C-A,D-B)$, $\\operatorname{varignonArea}=\\tfrac14\\operatorname{cross}(C-A,D-B)$."
+    },
+    {
+      "id": "half-area-law",
+      "title": "The Half-Area Law",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "The headline identity varignonArea = signedArea/2 (with the equivalent multiplicative form 2·varignonArea = signedArea), obtained by dividing the two diagonal forms — a hypothesis-free polynomial identity. Plus the collapse criterion varignonArea = 0 ⟺ diagonals parallel.",
+      "mathContext": "$\\operatorname{varignonArea}(A,B,C,D)=\\tfrac12\\operatorname{signedArea}(A,B,C,D)$."
+    },
+    {
+      "id": "self-intersecting-witness",
+      "title": "Self-Intersecting Witness",
+      "startLine": 119,
+      "endLine": 145,
+      "summary": "An explicit crossed quadrilateral (0,0)→(0,3)→(3,0)→(3,1) whose edges BC and DA cross, with NEGATIVE signed area −3. It demonstrates that the law is genuinely signed: the unsigned 'half the area' picture cannot apply, yet varignonArea = −3/2 holds exactly.",
+      "mathContext": "$\\operatorname{signedArea}=-3$, $\\operatorname{varignonArea}=-\\tfrac32$ for the crossed witness."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "varignon-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the affine Varignon theorem (side midpoints form a parallelogram, with sides half the diagonals). This entry adds the metric/area layer with signed area and resolves the parent's first open question — the area relationship in the self-intersecting case — by proving varignonArea = signedArea/2 as a hypothesis-free polynomial identity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Working with the signed shoelace area over ℝ × ℝ, the Varignon parallelogram has exactly half the signed area of its quadrilateral: varignonArea A B C D = signedArea A B C D / 2. The proof factors through a diagonal reformulation — the signed area of any quadrilateral is half the cross product of its diagonals — so both the quadrilateral and its Varignon parallelogram have areas proportional to cross(AC, BD), in ratio 2:1. The result is a single ring identity, fully verified with 0 axioms and 0 sorries.",
+    "implications": "Because the half-area law is an identity of polynomials, it covers every quadrilateral — convex, concave, degenerate, or self-intersecting — with no case split, which is the precise sense in which the parent's open question is resolved. An explicit crossed quadrilateral with signed area −3 shows the identity is genuinely signed (varignonArea = −3/2), where the classical unsigned 'half the area' picture proof has no meaning. The diagonal formula also yields the collapse criterion: the Varignon parallelogram degenerates exactly when the diagonals are parallel.",
+    "openQuestions": [
+      "Does the same signed-area identity extend to the n-gon midpoint polygon, and what is the area ratio there (it is not constant for n > 4)?",
+      "What signed-area identity governs the iterated midpoint quadrilaterals, whose signed areas form a geometric-like sequence converging to 0 as the iterates shrink to the centroid?"
+    ]
+  },
+  "references": [
+    {
+      "title": "Varignon's theorem",
+      "url": "https://en.wikipedia.org/wiki/Varignon%27s_theorem",
+      "type": "encyclopedia"
+    },
+    {
+      "title": "Shoelace formula (Gauss's area formula)",
+      "url": "https://en.wikipedia.org/wiki/Shoelace_formula",
+      "type": "encyclopedia"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "VarignonArea",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 6,
+    "path": "Proofs/VarignonTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent `cayleys-theorem-oq-01-oq-02` (the conjugation representation): formalize the outer automorphism exact sequence `1 → Inn(G) → Aut(G) → Out(G) → 1` at the formalized level, building on the parent's `G/Z(G) ≅ Inn(G)`.

The parent realised `Inn(G)` as a permutation subgroup of `Sym(G)`. This entry moves into the automorphism group `Aut(G) = MulAut G` — where `Inn(G) ◁ Aut(G)` and `Out(G)` are even statable — and completes the structural picture.

## Results (`Proofs/CayleysTheoremOQ01OQ02OQ02.lean`, namespace `CayleyOuter`)

- **`conj_mulAut_conj`** — the covariance identity `φ · (conj g) · φ⁻¹ = conj (φ g)`: conjugating an inner automorphism by *any* automorphism is again inner, witness `φ(g)`. The single nontrivial input.
- **`instance (Inn G).Normal`** — `Inn G := (MulAut.conj).range` is normal in `Aut(G)`, from the covariance identity.
- **`Out G := MulAut G ⧸ Inn G`** with its `Group` instance and quotient map `outMk` — well-defined precisely because `Inn(G)` is normal.
- **Exactness**: `inn_subtype_injective` (left), `outMk_surjective` (right), and `range_inn_subtype_eq_ker_outMk`: `range(Inn(G).subtype) = ker(outMk)` (middle).
- **`ker_mulAutConj`** `(MulAut.conj).ker = Z(G)` and **`quotientCenterEquivInn`** `G ⧸ Z(G) ≃* Inn(G)` — the parent's isomorphism re-realised onto the automorphism subgroup.
- **Order formula** (finite `G`): `|Aut(G)| = |Out(G)|·|Inn(G)| = |Out(G)|·|G/Z(G)|`.

Everything holds for an arbitrary group `G`; finiteness is used only for the order formula.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound`. No `decide`/`native_decide`.
- 8 theorems, 4 definitions (+ the `Normal` and `Group` instances), 156 lines.
- Built clean on host (docker down): `lake env lean Proofs/CayleysTheoremOQ01OQ02OQ02.lean`, exit 0.
- `status: verified`, `badge: original`.
- Gallery data added: `src/data/proofs/cayleys-theorem-oq-01-oq-02-oq-02/{meta,annotations}.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)