### PR TITLE
research(herons-formula-oq-05-oq-03): Cayley–Menger polynomials are literally determinants [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -721,6 +721,7 @@ import Proofs.CayleyHamiltonReductionOQ02
 import Proofs.CayleyHamiltonReductionOQ02OQ01
 import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
 import Proofs.CayleyMengerHeronOQ05
+import Proofs.CayleyMengerHeronOQ0503
 import Proofs.CayleysTheoremOQ01
 import Proofs.CayleysTheoremOQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ01

--- a/proofs/Proofs/CayleyMengerHeronOQ0503.lean
+++ b/proofs/Proofs/CayleyMengerHeronOQ0503.lean
@@ -1,0 +1,189 @@
+import Mathlib
+
+/-
+# The Cayley–Menger polynomials are *literally* determinants
+
+The parent entry (`CayleyMengerHeronOQ05`) introduces the Cayley–Menger
+*polynomials* `cmDet3` (triangle) and `cmDet4` (tetrahedron) in the squared edge
+lengths and proves they reproduce `−16·Area²` and `288·V²`.  Their docstrings
+*assert* that these polynomials are the determinants of the bordered
+squared-distance matrices
+
+      ⎡ 0  1   1   1  ⎤                  ⎡ 0  1   1   1   1  ⎤
+      ⎢ 1  0  d₀₁ d₀₂ ⎥                  ⎢ 1  0  d₀₁ d₀₂ d₀₃ ⎥
+      ⎢ 1 d₀₁  0  d₁₂ ⎥   and           ⎢ 1 d₀₁  0  d₁₂ d₁₃ ⎥
+      ⎣ 1 d₀₂ d₁₂  0  ⎦                  ⎢ 1 d₀₂ d₁₂  0  d₂₃ ⎥
+                                         ⎣ 1 d₀₃ d₁₃ d₂₃  0  ⎦
+
+but never *certify* that claim: `cmDet3`/`cmDet4` are entered as hand-expanded
+polynomials.  This entry closes that gap (parent open question oq-03): it builds
+the bordered matrices as honest `Matrix (Fin 4) (Fin 4) ℝ` / `Matrix (Fin 5)
+(Fin 5) ℝ` objects and proves, by Laplace cofactor expansion, that
+`Matrix.det` of each **equals** the parent polynomial.  Combined with the parent
+identities this gives the textbook determinant forms of Heron's formula and the
+tetrahedron-volume formula:
+
+* `det (bordered 4×4) = −16·Area²`,
+* `det (bordered 5×5) =  288·V²`.
+
+Mathlib has `Matrix.det_fin_three` but no `det_fin_four`/`det_fin_five`; the 4×4
+and 5×5 determinants are obtained from the general Laplace expansion
+`Matrix.det_succ_row_zero` down to the 3×3 base case.
+
+The polynomial definitions `cmDet3`, `cmDet4` and the geometric scalars
+`sqDist2`, `area2`, `sqDist3`, `vol6` are reproduced verbatim from the parent so
+this file is self-contained and machine-checks standalone.
+
+No axioms, no sorries.
+-/
+
+namespace CayleyMengerHeronOQ0503
+
+open Matrix
+
+/-! ## A 4×4 determinant expansion
+
+Mathlib provides `Matrix.det_fin_three` but stops there.  We record the Laplace
+cofactor expansion of a general 4×4 matrix along its first row; this is the
+engine for evaluating the 5×5 Cayley–Menger determinant below. -/
+
+set_option maxHeartbeats 1000000 in
+/-- Cofactor (Laplace) expansion of a 4×4 determinant along the first row. -/
+theorem det_fin_four {R : Type*} [CommRing R] (M : Matrix (Fin 4) (Fin 4) R) :
+    M.det =
+      M 0 0 * (M 1 1 * (M 2 2 * M 3 3 - M 2 3 * M 3 2)
+             - M 1 2 * (M 2 1 * M 3 3 - M 2 3 * M 3 1)
+             + M 1 3 * (M 2 1 * M 3 2 - M 2 2 * M 3 1))
+    - M 0 1 * (M 1 0 * (M 2 2 * M 3 3 - M 2 3 * M 3 2)
+             - M 1 2 * (M 2 0 * M 3 3 - M 2 3 * M 3 0)
+             + M 1 3 * (M 2 0 * M 3 2 - M 2 2 * M 3 0))
+    + M 0 2 * (M 1 0 * (M 2 1 * M 3 3 - M 2 3 * M 3 1)
+             - M 1 1 * (M 2 0 * M 3 3 - M 2 3 * M 3 0)
+             + M 1 3 * (M 2 0 * M 3 1 - M 2 1 * M 3 0))
+    - M 0 3 * (M 1 0 * (M 2 1 * M 3 2 - M 2 2 * M 3 1)
+             - M 1 1 * (M 2 0 * M 3 2 - M 2 2 * M 3 0)
+             + M 1 2 * (M 2 0 * M 3 1 - M 2 1 * M 3 0)) := by
+  simp only [Matrix.det_succ_row_zero, Matrix.submatrix_apply, Fin.succ_zero_eq_one,
+    Matrix.submatrix_submatrix, Matrix.det_unique, Fin.default_eq_zero, Function.comp_apply,
+    Fin.succ_one_eq_two, Fin.sum_univ_succ, Fin.val_zero, Fin.zero_succAbove, Finset.univ_unique,
+    Fin.val_succ, Fin.val_eq_zero, Fin.succ_succAbove_zero, Finset.sum_singleton,
+    Fin.succ_succAbove_one, Fin.succ_succAbove_succ,
+    show Fin.succ (2 : Fin 3) = (3 : Fin 4) from rfl,
+    show Fin.succAbove (1 : Fin 4) (2 : Fin 3) = (3 : Fin 4) from rfl,
+    show Fin.succAbove (2 : Fin 4) (2 : Fin 3) = (3 : Fin 4) from rfl,
+    show Fin.succAbove (3 : Fin 4) (2 : Fin 3) = (2 : Fin 4) from rfl]
+  ring
+
+/-! ## Triangle (n = 2): the 4×4 Cayley–Menger determinant -/
+
+abbrev Point2 := ℝ × ℝ
+
+/-- Squared Euclidean distance between two points of the plane. -/
+def sqDist2 (p q : Point2) : ℝ :=
+  (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2
+
+/-- Twice the signed area of triangle `P₀P₁P₂`. -/
+def area2 (P₀ P₁ P₂ : Point2) : ℝ :=
+  (P₁.1 - P₀.1) * (P₂.2 - P₀.2) - (P₂.1 - P₀.1) * (P₁.2 - P₀.2)
+
+/-- The Cayley–Menger polynomial of a triangle (parent `cmDet3`). -/
+def cmDet3 (d01 d02 d12 : ℝ) : ℝ :=
+  d01 ^ 2 - 2 * d01 * d02 - 2 * d01 * d12 + d02 ^ 2 - 2 * d02 * d12 + d12 ^ 2
+
+/-- The bordered squared-distance matrix of a triangle. -/
+def cmMatrix3 (d01 d02 d12 : ℝ) : Matrix (Fin 4) (Fin 4) ℝ :=
+  !![0, 1, 1, 1;
+     1, 0, d01, d02;
+     1, d01, 0, d12;
+     1, d02, d12, 0]
+
+/-- **The triangle Cayley–Menger polynomial is literally a determinant.** -/
+theorem cmDet3_eq_det (d01 d02 d12 : ℝ) :
+    (cmMatrix3 d01 d02 d12).det = cmDet3 d01 d02 d12 := by
+  rw [Matrix.det_succ_row_zero, Fin.sum_univ_four]
+  simp only [cmMatrix3, Matrix.det_fin_three, Matrix.submatrix_apply, Matrix.of_apply,
+    Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.head_fin_const, Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.cons_val_succ,
+    Matrix.cons_val, Fin.isValue, Fin.succAbove, Fin.succ, Fin.castSucc, Fin.castAdd,
+    Fin.castLE, Fin.lt_def]
+  norm_num [cmDet3]
+  ring
+
+/-- **Heron's formula, determinant form.** The determinant of the bordered
+squared-distance matrix of three planar points equals `-16·Area²`, where
+`Area = |area2|/2` is the triangle's area. This is `cmDet3_eq_det` combined with
+the parent Cayley–Menger identity `cmDet3 = -4·(2·Area)²`. -/
+theorem det_cmMatrix3_eq_area (P₀ P₁ P₂ : Point2) :
+    (cmMatrix3 (sqDist2 P₀ P₁) (sqDist2 P₀ P₂) (sqDist2 P₁ P₂)).det
+      = -16 * (|area2 P₀ P₁ P₂| / 2) ^ 2 := by
+  rw [cmDet3_eq_det, cmDet3, sqDist2, sqDist2, sqDist2, area2, div_pow, sq_abs]
+  ring
+
+/-! ## Tetrahedron (n = 3): the 5×5 Cayley–Menger determinant -/
+
+abbrev Point3 := ℝ × ℝ × ℝ
+
+/-- Squared Euclidean distance between two points of space. -/
+def sqDist3 (p q : Point3) : ℝ :=
+  (p.1 - q.1) ^ 2 + (p.2.1 - q.2.1) ^ 2 + (p.2.2 - q.2.2) ^ 2
+
+/-- Six times the signed volume of tetrahedron `P₀P₁P₂P₃` (the `3!·V` scalar). -/
+def vol6 (P₀ P₁ P₂ P₃ : Point3) : ℝ :=
+  (P₁.1 - P₀.1) *
+      ((P₂.2.1 - P₀.2.1) * (P₃.2.2 - P₀.2.2) - (P₂.2.2 - P₀.2.2) * (P₃.2.1 - P₀.2.1))
+  - (P₁.2.1 - P₀.2.1) *
+      ((P₂.1 - P₀.1) * (P₃.2.2 - P₀.2.2) - (P₂.2.2 - P₀.2.2) * (P₃.1 - P₀.1))
+  + (P₁.2.2 - P₀.2.2) *
+      ((P₂.1 - P₀.1) * (P₃.2.1 - P₀.2.1) - (P₂.2.1 - P₀.2.1) * (P₃.1 - P₀.1))
+
+/-- The Cayley–Menger polynomial of a tetrahedron (parent `cmDet4`). -/
+def cmDet4 (d01 d02 d03 d12 d13 d23 : ℝ) : ℝ :=
+  -2 * d01 ^ 2 * d23 - 2 * d01 * d02 * d12 + 2 * d01 * d02 * d13
+  + 2 * d01 * d02 * d23 + 2 * d01 * d03 * d12 - 2 * d01 * d03 * d13
+  + 2 * d01 * d03 * d23 + 2 * d01 * d12 * d23 + 2 * d01 * d13 * d23
+  - 2 * d01 * d23 ^ 2 - 2 * d02 ^ 2 * d13 + 2 * d02 * d03 * d12
+  + 2 * d02 * d03 * d13 - 2 * d02 * d03 * d23 + 2 * d02 * d12 * d13
+  - 2 * d02 * d13 ^ 2 + 2 * d02 * d13 * d23 - 2 * d03 ^ 2 * d12
+  - 2 * d03 * d12 ^ 2 + 2 * d03 * d12 * d13 + 2 * d03 * d12 * d23
+  - 2 * d12 * d13 * d23
+
+/-- The bordered squared-distance matrix of a tetrahedron. -/
+def cmMatrix4 (d01 d02 d03 d12 d13 d23 : ℝ) : Matrix (Fin 5) (Fin 5) ℝ :=
+  !![0, 1, 1, 1, 1;
+     1, 0, d01, d02, d03;
+     1, d01, 0, d12, d13;
+     1, d02, d12, 0, d23;
+     1, d03, d13, d23, 0]
+
+set_option maxHeartbeats 1000000 in
+/-- **The tetrahedron Cayley–Menger polynomial is literally a determinant.** -/
+theorem cmDet4_eq_det (d01 d02 d03 d12 d13 d23 : ℝ) :
+    (cmMatrix4 d01 d02 d03 d12 d13 d23).det = cmDet4 d01 d02 d03 d12 d13 d23 := by
+  rw [Matrix.det_succ_row_zero, Fin.sum_univ_five]
+  simp only [cmMatrix4, det_fin_four, Matrix.submatrix_apply, Matrix.of_apply,
+    Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.head_fin_const, Matrix.empty_val', Matrix.cons_val_fin_one, Matrix.cons_val_succ,
+    Matrix.cons_val, Fin.isValue, Fin.succAbove, Fin.succ, Fin.castSucc, Fin.castAdd,
+    Fin.castLE, Fin.lt_def]
+  norm_num [cmDet4]
+  ring
+
+/-- **Tetrahedron volume, determinant form.** The determinant of the bordered
+squared-distance matrix of four points in space equals `288·V²`, where
+`V = |vol6|/6` is the tetrahedron's volume. -/
+theorem det_cmMatrix4_eq_vol (P₀ P₁ P₂ P₃ : Point3) :
+    (cmMatrix4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+               (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃)).det
+      = 288 * (|vol6 P₀ P₁ P₂ P₃| / 6) ^ 2 := by
+  rw [cmDet4_eq_det, cmDet4]
+  simp only [sqDist3, vol6, div_pow, sq_abs]
+  ring
+
+/-- The Cayley–Menger determinant of four points in space is always nonnegative
+(equivalently `288·V² ≥ 0`), recovered directly from the matrix determinant. -/
+theorem det_cmMatrix4_nonneg (P₀ P₁ P₂ P₃ : Point3) :
+    0 ≤ (cmMatrix4 (sqDist3 P₀ P₁) (sqDist3 P₀ P₂) (sqDist3 P₀ P₃)
+               (sqDist3 P₁ P₂) (sqDist3 P₁ P₃) (sqDist3 P₂ P₃)).det := by
+  rw [det_cmMatrix4_eq_vol]; positivity
+
+end CayleyMengerHeronOQ0503

--- a/src/data/proofs/herons-formula-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/herons-formula-oq-05-oq-03/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-det-fin-four",
+    "proofId": "herons-formula-oq-05-oq-03",
+    "range": {
+      "startLine": 45,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "A Reusable 4×4 Determinant Expansion",
+    "content": "Mathlib provides `Matrix.det_fin_two` and `Matrix.det_fin_three` but stops there. `det_fin_four` records the Laplace (cofactor) expansion of an arbitrary 4×4 matrix along its first row: `det M = Σ_j (-1)^j · M 0 j · det(minor_j)`, with each of the four 3×3 minors written out. The proof mirrors Mathlib's own `det_fin_three`: a single fixed `simp only` set built from `Matrix.det_succ_row_zero`, `Fin.sum_univ_succ`, and the `Fin.succAbove` normalization lemmas drives the recursion down to the `Fin 1` base case (`Matrix.det_unique`), after which `ring` certifies the polynomial. A handful of explicit `Fin.succ`/`Fin.succAbove` numeral reductions (e.g. `Fin.succ 2 = 3`) are supplied because the named lemmas only fire on `succ`-form indices. This lemma is the engine for the 5×5 Cayley–Menger determinant below.",
+    "mathContext": "$\\det M = M_{00}\\,C_{00} - M_{01}\\,C_{01} + M_{02}\\,C_{02} - M_{03}\\,C_{03}$, each cofactor $C_{0j}$ a 3×3 determinant.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Laplace expansion",
+      "cofactor",
+      "determinant",
+      "Matrix.det_fin_three"
+    ],
+    "prerequisites": [
+      "determinants",
+      "cofactor expansion"
+    ],
+    "crossReferences": []
+  },
+  {
+    "id": "ann-triangle",
+    "proofId": "herons-formula-oq-05-oq-03",
+    "range": {
+      "startLine": 77,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "The Triangle Polynomial Is the 4×4 Determinant",
+    "content": "`cmMatrix3 d01 d02 d12` is the bordered squared-distance matrix of a triangle — a row and column of ones around the 3×3 matrix of squared edge lengths — built as an honest `Matrix (Fin 4) (Fin 4) ℝ` with `!!` notation. `cmDet3_eq_det` proves `Matrix.det (cmMatrix3 …) = cmDet3 …`, the parent's hand-expanded polynomial: expand once along row 0 (`Matrix.det_succ_row_zero` + `Fin.sum_univ_four`), evaluate the four 3×3 minors with `Matrix.det_fin_three`, reduce the `!!` entry lookups via the `cons_val` simp lemmas, and close with `ring`. Because the matrix is concrete, every entry collapses to an actual real, sidestepping the Fin-literal bookkeeping. `det_cmMatrix3_eq_area` then composes with the parent identity `cmDet3 = −4·(2·Area)²` to give Heron's formula in its determinantal form: the bordered determinant equals `−16·Area²`.",
+    "mathContext": "$\\det\\begin{pmatrix}0&1&1&1\\\\1&0&d_{01}&d_{02}\\\\1&d_{01}&0&d_{12}\\\\1&d_{02}&d_{12}&0\\end{pmatrix} = \\mathrm{cmDet3} = -16\\,\\mathrm{Area}^2.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cayley–Menger determinant",
+      "Heron's formula",
+      "bordered matrix",
+      "squared distance"
+    ],
+    "prerequisites": [
+      "determinants",
+      "coordinate geometry"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "herons-formula-oq-05",
+        "relationship": "parent"
+      }
+    ]
+  },
+  {
+    "id": "ann-tetrahedron",
+    "proofId": "herons-formula-oq-05-oq-03",
+    "range": {
+      "startLine": 123,
+      "endLine": 189
+    },
+    "type": "theorem",
+    "title": "The Tetrahedron Polynomial Is the 5×5 Determinant",
+    "content": "`cmMatrix4` is the bordered 5×5 squared-distance matrix of a tetrahedron. `cmDet4_eq_det` proves `Matrix.det (cmMatrix4 …) = cmDet4 …`, the parent's 22-term polynomial, by a single cofactor expansion along row 0 (`Fin.sum_univ_five`) followed by `det_fin_four` on each of the five 4×4 minors — proving the generic `det_fin_four` first keeps this from exploding into a deep recursive `simp`. `det_cmMatrix4_eq_vol` composes with the parent identity `cmDet4 = 8·(6·V)²` to give the tetrahedron volume law in determinantal form, `det = 288·V²`, and `det_cmMatrix4_nonneg` reads realizability (`det ≥ 0`) directly off the bordered matrix via `positivity`. Together with the triangle case this certifies that the Cayley–Menger *polynomials* really are the Cayley–Menger *determinants*.",
+    "mathContext": "$\\det(\\text{bordered }5\\times5) = \\mathrm{cmDet4} = 288\\,V^2 \\geq 0,$ with $V = |\\mathrm{vol6}|/6$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Cayley–Menger determinant",
+      "tetrahedron volume",
+      "realizability",
+      "distance geometry"
+    ],
+    "prerequisites": [
+      "determinants",
+      "cofactor expansion",
+      "coordinate geometry"
+    ],
+    "crossReferences": [
+      {
+        "proofId": "herons-formula-oq-05",
+        "relationship": "parent"
+      }
+    ]
+  }
+]

--- a/src/data/proofs/herons-formula-oq-05-oq-03/meta.json
+++ b/src/data/proofs/herons-formula-oq-05-oq-03/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "herons-formula-oq-05-oq-03",
+  "title": "The Cayley–Menger Polynomials Are Literally Determinants",
+  "slug": "herons-formula-oq-05-oq-03",
+  "description": "Certifies the open claim of the parent entry: the hand-expanded Cayley–Menger polynomials cmDet3 (triangle) and cmDet4 (tetrahedron) are genuinely the determinants of the bordered squared-distance matrices. Builds the 4×4 and 5×5 matrices as honest Matrix objects and proves Matrix.det of each equals the parent polynomial by Laplace cofactor expansion. Includes a reusable det_fin_four expansion lemma (absent from Mathlib) and the determinant forms of Heron's formula (det = −16·Area²) and the tetrahedron volume law (det = 288·V²). 6 theorems, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyMengerHeronOQ0503.lean",
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "triangle",
+      "tetrahedron",
+      "heron",
+      "cayley-menger",
+      "determinant",
+      "matrix",
+      "cofactor-expansion",
+      "distance-geometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound).",
+    "lineCount": 189,
+    "theoremCount": 6,
+    "definitionCount": 10,
+    "originalContributions": [
+      "cmDet3_eq_det: the triangle Cayley–Menger polynomial cmDet3 equals Matrix.det of the bordered 4×4 squared-distance matrix, proved by Laplace expansion along the first row down to Matrix.det_fin_three — closing the parent's unproved docstring claim.",
+      "cmDet4_eq_det: the tetrahedron Cayley–Menger polynomial cmDet4 equals Matrix.det of the bordered 5×5 squared-distance matrix, via two levels of cofactor expansion.",
+      "det_fin_four: a reusable cofactor (Laplace) expansion of a general 4×4 determinant along the first row, which Mathlib does not provide (it stops at Matrix.det_fin_three); this is the engine for the 5×5 case.",
+      "det_cmMatrix3_eq_area: the determinant form of Heron's formula — the bordered 4×4 squared-distance determinant equals −16·Area².",
+      "det_cmMatrix4_eq_vol: the determinant form of the tetrahedron volume law — the bordered 5×5 squared-distance determinant equals 288·V².",
+      "det_cmMatrix4_nonneg: realizability read directly off the matrix determinant — the 5×5 Cayley–Menger determinant is always nonnegative."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Cayley–Menger determinant (Arthur Cayley 1841, Karl Menger 1928) is, by definition, the determinant of the bordered matrix of squared pairwise distances: a row and column of ones surrounding the symmetric matrix (dᵢⱼ) with dᵢⱼ = ‖Pᵢ−Pⱼ‖². The parent entry (herons-formula-oq-05) recovered Heron's formula and the tetrahedron volume law from the *expanded polynomial* forms cmDet3 and cmDet4, but only asserted in prose that these polynomials are the determinants of the bordered matrices. Certifying that assertion — that the hand-entered polynomials really are Matrix.det of the named matrices — closes the loop between the algebraic identity and its determinantal definition. Mathlib formalizes determinant cofactor expansion in general (Matrix.det_succ_row_zero) and the explicit 3×3 expansion (Matrix.det_fin_three), but provides no det_fin_four or det_fin_five, so the 4×4 and 5×5 cases must be assembled from the Laplace expansion.",
+    "problemStatement": "Connect cmDet3 and cmDet4 to actual Matrix.det of the bordered squared-distance matrices via cofactor expansion, certifying that the parent's polynomials are literally the determinants (parent open question 3).",
+    "proofStrategy": "Define the bordered matrices cmMatrix3 : Matrix (Fin 4) (Fin 4) ℝ and cmMatrix4 : Matrix (Fin 5) (Fin 5) ℝ with the textbook border-of-ones layout. For the 4×4: expand once along row 0 with Matrix.det_succ_row_zero, unfold the sum with Fin.sum_univ_four, evaluate the four 3×3 minors with Matrix.det_fin_three, reduce the !! matrix entry lookups, and close with ring. Mathlib has no 4×4 expansion lemma, so first prove a reusable det_fin_four for an arbitrary 4×4 (mirroring Mathlib's det_fin_three proof: a fixed simp-only set built from det_succ_row_zero and the Fin.succAbove normalization lemmas, then ring). The 5×5 case then expands once along row 0 (Fin.sum_univ_five) and applies det_fin_four to each of the five 4×4 minors. The geometric capstones compose these determinant identities with the parent's polynomial-to-content identities (cmDet3 = −4·area2², cmDet4 = 8·vol6²) via div_pow + sq_abs.",
+    "keyInsights": [
+      "The parent's cmDet3/cmDet4 are not just *equal in value* to the Cayley–Menger determinants — they are syntactically the cofactor expansions of the bordered matrices, verified term-by-term by ring after the Laplace expansion.",
+      "Mathlib's determinant API stops at Matrix.det_fin_three; the 4×4 and 5×5 cases require the general Laplace expansion Matrix.det_succ_row_zero, with the Fin.succAbove index bookkeeping being the only real obstacle.",
+      "Proving a generic det_fin_four once (an arbitrary 4×4 matrix) makes the 5×5 expansion a clean single application per minor, avoiding an exponential simp blow-up from recursively unfolding det_succ_row_zero inside the 5×5.",
+      "Concrete !! matrices sidestep the Fin-literal normalization pain that bites the generic lemma: entry lookups collapse to actual reals via the cons_val simp lemmas regardless of how the Fin index is presented.",
+      "Once the determinants are certified, Heron (det = −16·Area²), the volume law (det = 288·V²), and realizability (det ≥ 0) read off directly from the bordered matrix, the form in which the Cayley–Menger determinant is classically stated."
+    ]
+  },
+  "sections": [
+    {
+      "id": "det-fin-four",
+      "title": "A 4×4 Determinant Expansion (det_fin_four)",
+      "startLine": 45,
+      "endLine": 76,
+      "summary": "det_fin_four: the Laplace cofactor expansion of a general 4×4 matrix along its first row, recorded as a reusable lemma since Mathlib provides only Matrix.det_fin_three. Proved with a fixed simp-only set built from Matrix.det_succ_row_zero and the Fin.succAbove normalization lemmas, closed by ring. This is the engine for the 5×5 Cayley–Menger determinant.",
+      "mathContext": "$\\det M = \\sum_{j} (-1)^{j} M_{0j} \\det(M^{(0,j)})$, the cofactor expansion along row 0, written out as four 3×3 minors."
+    },
+    {
+      "id": "triangle",
+      "title": "Triangle: cmDet3 Is the 4×4 Determinant",
+      "startLine": 77,
+      "endLine": 122,
+      "summary": "Reproduces sqDist2, area2, cmDet3 from the parent and defines cmMatrix3, the bordered 4×4 squared-distance matrix. cmDet3_eq_det proves Matrix.det cmMatrix3 = cmDet3 by one cofactor expansion + det_fin_three on the minors. det_cmMatrix3_eq_area gives Heron's determinant form: det = −16·Area².",
+      "mathContext": "$\\det\\begin{pmatrix}0&1&1&1\\\\1&0&d_{01}&d_{02}\\\\1&d_{01}&0&d_{12}\\\\1&d_{02}&d_{12}&0\\end{pmatrix} = \\mathrm{cmDet3} = -16\\,\\mathrm{Area}^2.$"
+    },
+    {
+      "id": "tetrahedron",
+      "title": "Tetrahedron: cmDet4 Is the 5×5 Determinant",
+      "startLine": 123,
+      "endLine": 189,
+      "summary": "Reproduces sqDist3, vol6, cmDet4 from the parent and defines cmMatrix4, the bordered 5×5 squared-distance matrix. cmDet4_eq_det proves Matrix.det cmMatrix4 = cmDet4 by one cofactor expansion (Fin.sum_univ_five) + det_fin_four on the five 4×4 minors. det_cmMatrix4_eq_vol gives the volume determinant form det = 288·V², and det_cmMatrix4_nonneg reads realizability (det ≥ 0) off the matrix.",
+      "mathContext": "$\\det(\\text{bordered }5\\times5) = \\mathrm{cmDet4} = 288\\,V^2 \\geq 0.$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Certifies the parent's prose claim with proof: the Cayley–Menger polynomials cmDet3 and cmDet4 are exactly the determinants of the bordered squared-distance matrices cmMatrix3 (4×4) and cmMatrix4 (5×5), proved by Laplace cofactor expansion. A reusable det_fin_four lemma is contributed to fill the gap above Mathlib's Matrix.det_fin_three. The determinant forms of Heron's formula (det = −16·Area²) and the tetrahedron volume law (det = 288·V²), and realizability (det ≥ 0), follow by composing with the parent identities. 6 theorems, 10 definitions, 0 axioms, 0 sorries.",
+    "implications": "With the polynomials certified as genuine determinants, the entry connects the gallery's elementary coordinate proof of Heron/Cayley–Menger to the classical determinantal definition used in distance geometry, multidimensional scaling, and molecular conformation. The det_fin_four expansion is independently reusable for any 4×4 determinant computation. The border-of-ones determinant pattern and its cofactor expansion extend verbatim to every dimension.",
+    "openQuestions": [
+      "Generalize det_fin_four / det_fin_five to a uniform det_fin_succ-driven expansion for the (n+2)×(n+2) Cayley–Menger matrix in arbitrary dimension.",
+      "Prove the general n-dimensional identity (−1)^(n+1)·2ⁿ·(n!)²·V² = det of the bordered (n+2)×(n+2) squared-distance matrix as a single Matrix.det statement."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "herons-formula-oq-05",
+      "relationship": "parent"
+    },
+    {
+      "proofId": "herons-formula",
+      "relationship": "related"
+    }
+  ],
+  "leanFile": {
+    "namespace": "CayleyMengerHeronOQ0503",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 10,
+    "path": "Proofs/CayleyMengerHeronOQ0503.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/herons-formula-oq-05-oq-03.json
+++ b/src/data/research/problems/herons-formula-oq-05-oq-03.json
@@ -1,0 +1,56 @@
+{
+  "slug": "herons-formula-oq-05-oq-03",
+  "title": "The Cayley–Menger Polynomials Are Literally Determinants",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 7,
+  "significance": 6,
+  "problemStatement": "Connect cmDet3/cmDet4 to an actual Matrix.det of the bordered squared-distance matrix via cofactor expansion, certifying the parent's hand-expanded polynomials are literally the Cayley–Menger determinants (parent herons-formula-oq-05 open question 3).",
+  "knowledge": {
+    "progressSummary": "COMPLETE: cmDet3_eq_det (4×4) and cmDet4_eq_det (5×5) proved by Laplace expansion (0 sorries, 0 axioms). Reusable det_fin_four lemma contributed (absent from Mathlib). Determinant forms of Heron (−16·Area²) and tetrahedron volume (288·V²) + realizability included. Gallery entry created.",
+    "builtItems": [
+      "CayleyMengerHeronOQ0503.lean: det_fin_four — Laplace cofactor expansion of a general 4×4 matrix along row 0 (line 52), the engine Mathlib lacks above det_fin_three",
+      "cmDet3_eq_det — Matrix.det of the bordered 4×4 squared-distance matrix = parent cmDet3 (line 101)",
+      "cmDet4_eq_det — Matrix.det of the bordered 5×5 squared-distance matrix = parent cmDet4, via det_fin_four on the five minors (line 160)",
+      "det_cmMatrix3_eq_area / det_cmMatrix4_eq_vol — determinant forms of Heron (det = −16·Area²) and the tetrahedron volume law (det = 288·V²) (lines 116, 174)",
+      "det_cmMatrix4_nonneg — realizability (det ≥ 0) read off the bordered matrix (line 184)",
+      "Gallery entry src/data/proofs/herons-formula-oq-05-oq-03/ (meta.json + 3 annotations)"
+    ],
+    "insights": [
+      "Mathlib's explicit determinant API stops at Matrix.det_fin_three; det_fin_four/det_fin_five must be built from the general Laplace expansion Matrix.det_succ_row_zero.",
+      "Proving a generic det_fin_four once turns the 5×5 expansion into a clean single application per minor, avoiding the exponential simp blow-up of recursively unfolding det_succ_row_zero inside a 5×5.",
+      "Concrete !! matrices sidestep the Fin-literal normalization that bites the generic lemma: entry lookups collapse to actual reals via cons_val regardless of Fin index presentation. The generic lemma instead needs explicit Fin.succ/Fin.succAbove numeral reductions (e.g. Fin.succ 2 = 3) because the named lemmas only fire on succ-form indices.",
+      "Once certified, Heron (det = −16·Area²), the volume law (det = 288·V²) and realizability (det ≥ 0) compose directly from the parent polynomial identities cmDet3 = −4·area2², cmDet4 = 8·vol6²."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Matrix.det_fin_four or Matrix.det_fin_five (only det_fin_two/det_fin_three); contributed det_fin_four locally."
+    ],
+    "nextSteps": []
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "Complete: cmDet3/cmDet4 certified as Matrix.det of the bordered squared-distance matrices (0 sorry/0 axiom); gallery entry created.",
+    "blockers": [],
+    "nextAction": "None — graduated to gallery.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knownResults": [],
+  "tags": [
+    "geometry",
+    "cayley-menger",
+    "determinant",
+    "cofactor-expansion",
+    "heron",
+    "distance-geometry"
+  ],
+  "path": "Proofs/CayleyMengerHeronOQ0503.lean",
+  "lastUpdate": "2026-06-24T12:00:00-08:00",
+  "started": "2026-06-24T11:00:00-08:00"
+}


### PR DESCRIPTION
## Summary

Closes **parent open question 3** of `herons-formula-oq-05` ("Heron's Formula via the Cayley–Menger Determinant"):

> *Connect cmDet3/cmDet4 to an actual Matrix.det of the bordered squared-distance matrix via cofactor expansion, certifying the polynomials are literally the determinants.*

The parent recovered Heron's formula and the tetrahedron volume law from the **expanded polynomials** `cmDet3`/`cmDet4`, but only *asserted in docstrings* that these are the determinants of the bordered squared-distance matrices. This entry **proves it**.

## Results (`Proofs/CayleyMengerHeronOQ0503.lean`)

| Theorem | Statement |
|---|---|
| `cmDet3_eq_det` | `Matrix.det` of the bordered **4×4** squared-distance matrix `= cmDet3` |
| `cmDet4_eq_det` | `Matrix.det` of the bordered **5×5** squared-distance matrix `= cmDet4` |
| `det_fin_four` | reusable Laplace expansion of a **general 4×4** determinant (Mathlib stops at `det_fin_three`) |
| `det_cmMatrix3_eq_area` | Heron, determinant form: `det = −16·Area²` |
| `det_cmMatrix4_eq_vol` | tetrahedron volume, determinant form: `det = 288·V²` |
| `det_cmMatrix4_nonneg` | realizability `det ≥ 0`, read off the bordered matrix |

## Method

Mathlib provides the general Laplace expansion `Matrix.det_succ_row_zero` and the explicit `Matrix.det_fin_three`, but **no `det_fin_four`/`det_fin_five`**. The 4×4 is expanded once along row 0 down to `det_fin_three`; a generic `det_fin_four` is proved (mirroring Mathlib's `det_fin_three` recipe) so the 5×5 reduces to a single application per minor — avoiding an exponential `simp` blow-up. The geometric capstones compose with the parent identities `cmDet3 = −4·area2²`, `cmDet4 = 8·vol6²`.

## Verification

- **6 theorems, 10 definitions, 189 lines, 0 sorries, 0 axioms.**
- `#print axioms` on `cmDet4_eq_det` / `det_cmMatrix4_eq_vol`: `[propext, Classical.choice, Quot.sound]` only — no `native_decide`, no custom axioms.
- Self-contained: parent defs reproduced verbatim so the file machine-checks standalone (registered in `Proofs.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)