### PR TITLE
audit: mark 3 fresh research entries clean (open-mapping/sophie-germain-oq03/zeckendorf)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22565,6 +22565,24 @@
       "lastAudited": "2026-06-24T23:31:42Z",
       "result": "clean",
       "issues": []
+    },
+    "open-mapping-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:40:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sophie-germain-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:40:31Z",
+      "result": "clean",
+      "issues": []
+    },
+    "zeckendorf-representation-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T23:40:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit

Three never-audited research entries independently verified and marked **clean** in the audit tracker.

| Slug | Status/Badge | Verdict |
|------|-------------|---------|
| open-mapping-theorem-oq-01-oq-01 | verified/original | Hellinger–Toeplitz sharpness: from-scratch inner product space on `ℕ →₀ ℝ` + unbounded symmetric diagonal operator, incompleteness as free contrapositive. Substantive, original. |
| sophie-germain-oq-03 | verified/original | Cunningham-chain length bounds via Fermat's little theorem (`Nat.ModEq.pow_card_sub_one_eq_one`) + concrete chain witnesses. |
| zeckendorf-representation-oq-01 | verified/mathlib | Existence/uniqueness/bijectivity wrapping Mathlib's `Nat.zeckendorfEquiv`. Correctly badged `mathlib` (bridge), not `original`. |

### Checks (all pass)
- 0 sorries, 0 `admit`, 0 `axiom` declarations, 0 `native_decide`, 0 `True` stubs (comment-stripped grep)
- `status`/`badge`/`sorries`/`axiomCount` in meta.json match Lean source
- `assumptions` fields honestly disclose Mathlib reliance where applicable
- No overclaiming; badges fit the proof tier

Tracker re-serialized with `ensure_ascii=True` to avoid the unicode-escape phantom diff; net change is exactly the 3 new entries.