### PR TITLE
research(schroder-numbers-oq-01-oq-01): sharp tripling step 3·L(n)≤L(n+1) and bound L(n)≥2·3^(n-1) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SchroderNumbersOQ0101.lean
+++ b/proofs/Proofs/SchroderNumbersOQ0101.lean
@@ -1,0 +1,111 @@
+/-
+Large Schröder numbers: the sharp tripling step and the `2·3^(n-1)` lower bound
+
+Source: Open question (oq-01-oq-01) from the schroder-numbers gallery family.
+Status: VERIFIED (0 axioms, 0 sorries).
+
+The parent entry (`SchroderNumbersOQ01`) established the **doubling step**
+`2·L n ≤ L (n+1)` by keeping only the `i = 0` term `L 0 · L n = L n` of the
+convolution sum
+
+    L (n + 1) = L n + ∑ i ≤ n, L i · L (n - i).
+
+That is wasteful for `n ≥ 1`: the symmetric `i = n` term `L n · L 0 = L n` is a
+*second, distinct* summand, so the sum is at least `2·L n` and therefore
+
+    L (n + 1) = L n + (sum) ≥ L n + 2·L n = 3·L n.
+
+This file proves that **tripling** step and its exponential consequence:
+
+  * `two_mul_largeSchroder_le_sum`      :  2·L n ≤ ∑ i ≤ n, L i·L (n-i)   (n ≥ 1)
+  * `three_mul_largeSchroder_le_succ`   :  3·L n ≤ L (n+1)                (n ≥ 1)
+  * `two_mul_three_pow_le_largeSchroder_succ` : 2·3^n ≤ L (n+1)           (all n)
+  * `two_mul_three_pow_pred_le_largeSchroder` : 2·3^(n-1) ≤ L n           (n ≥ 1)
+
+**Sharpness.** The constant `3` cannot be raised: equality `3·L 1 = L 2 = 6`
+holds at `n = 1`, so no constant `c > 3` satisfies `c·L n ≤ L (n+1)` for all
+`n ≥ 1`. Likewise the lower bound is attained, `L 1 = 2·3^0` and `L 2 = 2·3^1`.
+The hypothesis `n ≥ 1` is genuinely needed: at `n = 0` we have
+`3·L 0 = 3 > 2 = L 1`, so tripling fails. (All three facts are recorded as
+`example`s below.)
+
+The large Schröder numbers `Nat.largeSchroder` (OEIS A006318: 1, 2, 6, 22, 90, …)
+and the recurrence `Nat.largeSchroder_succ` are from Mathlib
+(`Mathlib/Combinatorics/Enumerative/Schroder.lean`). All proofs are
+kernel-checked with no `axiom`, `sorry`, or `native_decide`.
+-/
+import Mathlib
+
+namespace SchroderNumbersOQ0101
+
+open Finset
+open Nat (largeSchroder)
+
+/-- **Two-term sum bound** (the engine behind tripling). For `n ≥ 1` the indices
+`0` and `n` are distinct, and the corresponding convolution terms are
+`L 0 · L n = L n` and `L n · L 0 = L n`. Their sum `2·L n` is a lower bound for
+the full nonnegative sum. -/
+theorem two_mul_largeSchroder_le_sum (n : ℕ) (hn : 1 ≤ n) :
+    2 * largeSchroder n ≤ ∑ i ≤ n, largeSchroder i * largeSchroder (n - i) := by
+  have hne : (0 : ℕ) ≠ n := by omega
+  have hsub : ({0, n} : Finset ℕ) ⊆ Finset.Iic n := by
+    intro x hx
+    rcases Finset.mem_insert.mp hx with h | h
+    · subst h; exact Finset.mem_Iic.mpr (Nat.zero_le n)
+    · rw [Finset.mem_singleton] at h; subst h; exact Finset.mem_Iic.mpr le_rfl
+  -- The pair `{0, n}` contributes exactly `2 * L n`.
+  have hpair :
+      ∑ i ∈ ({0, n} : Finset ℕ), largeSchroder i * largeSchroder (n - i)
+        = 2 * largeSchroder n := by
+    rw [Finset.sum_pair hne]
+    simp [two_mul]
+  calc 2 * largeSchroder n
+      = ∑ i ∈ ({0, n} : Finset ℕ), largeSchroder i * largeSchroder (n - i) := hpair.symm
+    _ ≤ ∑ i ≤ n, largeSchroder i * largeSchroder (n - i) :=
+        Finset.sum_le_sum_of_subset hsub
+
+/-- The **tripling step**: for `n ≥ 1`, each large Schröder number is at least
+three times its predecessor. Sharp at `n = 1` (`3·L 1 = L 2 = 6`). -/
+theorem three_mul_largeSchroder_le_succ (n : ℕ) (hn : 1 ≤ n) :
+    3 * largeSchroder n ≤ largeSchroder (n + 1) := by
+  rw [Nat.largeSchroder_succ]
+  have h := two_mul_largeSchroder_le_sum n hn
+  omega
+
+/-- **Exponential lower bound**, shift-indexed to avoid `n - 1`: `2·3^n ≤ L (n+1)`
+for every `n`. Proof by induction, driving each step with the tripling lemma. -/
+theorem two_mul_three_pow_le_largeSchroder_succ (n : ℕ) :
+    2 * 3 ^ n ≤ largeSchroder (n + 1) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      have htrip := three_mul_largeSchroder_le_succ (n + 1) (by omega)
+      calc 2 * 3 ^ (n + 1)
+          = 3 * (2 * 3 ^ n) := by ring
+        _ ≤ 3 * largeSchroder (n + 1) := by gcongr
+        _ ≤ largeSchroder (n + 1 + 1) := htrip
+
+/-- **Exponential lower bound** in the stated form: `2·3^(n-1) ≤ L n` for `n ≥ 1`.
+Attained at `n = 1` and `n = 2`. -/
+theorem two_mul_three_pow_pred_le_largeSchroder (n : ℕ) (hn : 1 ≤ n) :
+    2 * 3 ^ (n - 1) ≤ largeSchroder n := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  simpa using two_mul_three_pow_le_largeSchroder_succ m
+
+/-! ### Sharpness witnesses -/
+
+/-- Tripling is attained at `n = 1`: `3·L 1 = L 2 = 6`. Hence the constant `3` is
+the largest possible: no `c > 3` has `c·L n ≤ L (n+1)` for all `n ≥ 1`. -/
+example : 3 * largeSchroder 1 = largeSchroder 2 := by
+  norm_num [Nat.largeSchroder_one, Nat.largeSchroder_two]
+
+/-- The lower bound is attained at `n = 2`: `2·3^(2-1) = 6 = L 2`. -/
+example : 2 * 3 ^ (2 - 1) = largeSchroder 2 := by
+  norm_num [Nat.largeSchroder_two]
+
+/-- The hypothesis `n ≥ 1` is necessary: at `n = 0`, tripling fails because
+`3·L 0 = 3 > 2 = L 1`. -/
+example : ¬ 3 * largeSchroder 0 ≤ largeSchroder 1 := by
+  norm_num [Nat.largeSchroder_zero, Nat.largeSchroder_one]
+
+end SchroderNumbersOQ0101

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "schroder-numbers-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "From Doubling to Tripling",
+    "content": "The parent entry proved the doubling step 2·L(n) ≤ L(n+1) by keeping only the i=0 term L(0)·L(n) = L(n) of the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i). That is wasteful for n ≥ 1: the recurrence is symmetric, so the i=n term L(n)·L(0) = L(n) is a second, distinct copy of L(n). Keeping both upgrades the sum's lower bound to 2·L(n) and hence L(n+1) ≥ 3·L(n). This file formalizes that tripling step and its exponential consequence L(n) ≥ 2·3^(n−1), answering the parent's first open question."
+  },
+  {
+    "id": "ann-two-term",
+    "proofId": "schroder-numbers-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 78 },
+    "type": "key-step",
+    "title": "Both Extreme Terms of the Convolution",
+    "content": "two_mul_largeSchroder_le_sum is the engine. For n ≥ 1 the indices 0 and n are distinct (hne), so {0, n} is a genuine two-element subset of Iic n. Finset.sum_pair evaluates the convolution over this pair: L(0)·L(n−0) + L(n)·L(n−n) = L(n) + L(n) = 2·L(n). Since ℕ is canonically ordered, Finset.sum_le_sum_of_subset bounds the full sum below by this pair contribution — no nonnegativity hypothesis is needed."
+  },
+  {
+    "id": "ann-tripling",
+    "proofId": "schroder-numbers-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 84 },
+    "type": "key-step",
+    "title": "The Sharp Tripling Step",
+    "content": "three_mul_largeSchroder_le_succ rewrites L(n+1) by the recurrence to L(n) + sum, then omega closes 3·L(n) ≤ L(n) + sum from the two-term bound 2·L(n) ≤ sum. The constant 3 is sharp: at n = 1 equality 3·L(1) = L(2) = 6 holds, so no larger constant works for all n ≥ 1. The asymptotic ratio L(n+1)/L(n) → 3 + 2√2 ≈ 5.828 is larger, but only because the discarded interior terms contribute."
+  },
+  {
+    "id": "ann-exponential",
+    "proofId": "schroder-numbers-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 104 },
+    "type": "key-step",
+    "title": "Exponential Lower Bound L(n) ≥ 2·3^(n−1)",
+    "content": "two_mul_three_pow_le_largeSchroder_succ proves 2·3^n ≤ L(n+1) by induction: the step computes 2·3^(n+1) = 3·(2·3^n) ≤ 3·L(n+1) ≤ L(n+2) using gcongr and the tripling lemma. Working in the shift-indexed form avoids ℕ-truncated subtraction; two_mul_three_pow_pred_le_largeSchroder then restates it as the advertised 2·3^(n−1) ≤ L(n) for n ≥ 1 by substituting n = m+1. This beats the parent's 2^n bound."
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "schroder-numbers-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 111 },
+    "type": "observation",
+    "title": "Both the Constant and the Hypothesis Are Sharp",
+    "content": "Three witnesses, each a norm_num evaluation on Mathlib's named Schröder values: equality 3·L(1) = L(2) shows the tripling constant 3 cannot be raised; 2·3^(2−1) = L(2) shows the lower bound is attained; and ¬ 3·L(0) ≤ L(1) (since 3 > 2) shows the n ≥ 1 hypothesis is necessary — at n = 0 the indices 0 and n collapse to a single term."
+  }
+]

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01/index.ts
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchroderNumbersOQ0101.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schroderNumbersOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schroderNumbersOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schroderNumbersOq01Oq01Data: ProofData = {
+  proof: schroderNumbersOq01Oq01Proof,
+  annotations: schroderNumbersOq01Oq01Annotations,
+}

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "schroder-numbers-oq-01-oq-01",
+  "title": "Large Schröder numbers: the sharp tripling step 3·L(n) ≤ L(n+1) and the lower bound L(n) ≥ 2·3^(n−1)",
+  "slug": "schroder-numbers-oq-01-oq-01",
+  "description": "Sharpening the parent's doubling step, this entry proves the tripling step 3·L(n) ≤ L(n+1) for the large Schröder numbers (n ≥ 1) and the resulting exponential lower bound L(n) ≥ 2·3^(n−1). The parent kept only the i=0 term L(0)·L(n) = L(n) of the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i); for n ≥ 1 the symmetric i=n term L(n)·L(0) = L(n) is a second distinct summand, so the sum is at least 2·L(n) and L(n+1) ≥ 3·L(n). The constant 3 is sharp — equality 3·L(1) = L(2) = 6 holds — and at n = 0 tripling fails (3·L(0) = 3 > 2 = L(1)).",
+  "meta": {
+    "author": "Robb Walters",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroderNumbersOQ0101.lean",
+    "tags": [
+      "combinatorics",
+      "schroder-numbers",
+      "enumerative",
+      "recurrence",
+      "growth-bound",
+      "lattice-paths"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.largeSchroder_succ",
+        "description": "The convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i) for the large Schröder numbers",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Finset.sum_pair",
+        "description": "The sum over a two-element set {0, n} (with 0 ≠ n) splits as f(0) + f(n); used to evaluate the i=0 and i=n convolution terms to L(n) + L(n) = 2·L(n)",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset",
+        "description": "Over ℕ (canonically ordered), the sum over a subset lower-bounds the sum over the superset; used to bound the full convolution below by its {0, n} pair contribution",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "two_mul_largeSchroder_le_sum: for n ≥ 1 the convolution sum is at least 2·L(n), extracting BOTH the i=0 and i=n terms L(0)·L(n) = L(n)·L(0) = L(n) via the distinct pair {0, n}",
+      "three_mul_largeSchroder_le_succ: the sharp tripling step 3·L(n) ≤ L(n+1) for n ≥ 1, strengthening the parent's doubling step",
+      "two_mul_three_pow_le_largeSchroder_succ: the shift-indexed exponential lower bound 2·3^n ≤ L(n+1) for all n, proved by induction driven by tripling",
+      "two_mul_three_pow_pred_le_largeSchroder: the stated lower bound 2·3^(n−1) ≤ L(n) for n ≥ 1",
+      "Sharpness witnesses: equality 3·L(1) = L(2) at n = 1 (the constant 3 cannot be raised), attainment 2·3^(2−1) = L(2), and failure of tripling at n = 0 (necessity of n ≥ 1)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound (confirmed by #print axioms). No `native_decide`, so no `Lean.ofReduceBool`; the three sharpness witnesses are discharged by `norm_num` with Mathlib's named Schröder value lemmas.",
+    "lineCount": 111,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The large Schröder numbers L(n) = 1, 2, 6, 22, 90, 394, … (OEIS A006318) count Schröder lattice paths from (0,0) to (n,n) with steps East, North, Diagonal that never rise above the diagonal. Their generating function f(x) satisfies x·f² − (1−x)·f + 1 = 0, giving the asymptotic growth ratio L(n+1)/L(n) → 3 + 2√2 ≈ 5.828. The parent entry (schroder-numbers-oq-01) supplied the first order-theoretic facts — positivity, the doubling step 2·L(n) ≤ L(n+1), strict monotonicity, and 2^n ≤ L(n) — using only the lone i=0 term of the convolution. Its first open question asked for the sharper tripling step and the corresponding 2·3^(n−1) bound.",
+    "problemStatement": "Sharpen the parent's doubling step to a tripling step 3·L(n) ≤ L(n+1) (n ≥ 1) by exploiting both the i=0 and i=n terms of the convolution recurrence, and derive the exponential lower bound L(n) ≥ 2·3^(n−1).",
+    "text": "For n ≥ 1 the convolution ∑_{i≤n} L(i)·L(n−i) contains the two distinct summands i=0 and i=n, each equal to L(0)·L(n) = L(n); hence the sum is at least 2·L(n) and L(n+1) = L(n) + sum ≥ 3·L(n). Iterating gives 2·3^n ≤ L(n+1), i.e. L(n) ≥ 2·3^(n−1).",
+    "proofStrategy": "1. two_mul_largeSchroder_le_sum: for n ≥ 1, exhibit {0, n} ⊆ Iic n with 0 ≠ n; Finset.sum_pair evaluates the two convolution terms to L(n) + L(n) = 2·L(n), and Finset.sum_le_sum_of_subset (over canonically-ordered ℕ) bounds the full sum below.\n2. three_mul_largeSchroder_le_succ: rewrite by largeSchroder_succ; with 2·L(n) ≤ sum in hand, omega closes 3·L(n) ≤ L(n) + sum.\n3. two_mul_three_pow_le_largeSchroder_succ: induction; 2·3^(n+1) = 3·(2·3^n) ≤ 3·L(n+1) ≤ L(n+2) by gcongr and tripling.\n4. two_mul_three_pow_pred_le_largeSchroder: substitute n = m+1 to remove the n−1 truncated subtraction.\n5. Sharpness: norm_num on the named Schröder values confirms equality at n = 1, attainment at n = 2, and failure at n = 0.",
+    "keyInsights": [
+      "**Two terms, not one**: the parent's doubling step throws away all but the i=0 summand. For n ≥ 1 the recurrence is symmetric, so the i=n term L(n)·L(0) is a *second* copy of L(n) at a distinct index — keeping both is exactly what upgrades doubling to tripling, with no harder analysis.",
+      "**Sharp, but not asymptotically tight**: the constant 3 is the largest valid for all n ≥ 1 because equality 3·L(1) = L(2) = 6 holds at n = 1. It is genuinely a lower-bound constant, not the true growth rate, which is 3 + 2√2 ≈ 5.828 — the remaining convolution terms (discarded here) account for the gap.",
+      "**The hypothesis n ≥ 1 is real**: at n = 0 the indices 0 and n coincide, only one term L(0)·L(0) = 1 is available, and tripling fails (3·L(0) = 3 > 2 = L(1)). The proof records this as an explicit non-example.",
+      "**Shift-indexing dodges truncated subtraction**: proving 2·3^n ≤ L(n+1) for all n (rather than 2·3^(n−1) ≤ L(n) for n ≥ 1) keeps the induction free of ℕ-subtraction; the stated form follows by a one-line substitution."
+    ],
+    "prerequisites": [
+      "The large Schröder numbers and their convolution recurrence (Nat.largeSchroder_succ)",
+      "Summing over a two-element Finset and bounding a sum below by a sub-sum",
+      "Induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "File-level docstring explaining how the symmetric i=n term upgrades the parent's doubling step to tripling, the sharpness of the constant 3, and the necessity of n ≥ 1. Imports Mathlib and opens Finset / Nat.largeSchroder.",
+      "mathContext": "L(n) is the nth large Schröder number; Mathlib supplies the convolution recurrence largeSchroder_succ and the base values."
+    },
+    {
+      "id": "two-term-bound",
+      "title": "The Two-Term Sum Bound",
+      "startLine": 49,
+      "endLine": 78,
+      "summary": "two_mul_largeSchroder_le_sum: for n ≥ 1 the pair {0, n} ⊆ Iic n is a two-element subset whose convolution terms sum (via Finset.sum_pair) to L(n) + L(n) = 2·L(n); Finset.sum_le_sum_of_subset bounds the full sum below.",
+      "mathContext": "2·L(n) ≤ ∑_{i≤n} L(i)·L(n−i): both the i=0 and i=n summands equal L(n)."
+    },
+    {
+      "id": "tripling-step",
+      "title": "The Sharp Tripling Step",
+      "startLine": 79,
+      "endLine": 84,
+      "summary": "three_mul_largeSchroder_le_succ: rewrite by the recurrence and discharge 3·L(n) ≤ L(n) + sum with omega, using the two-term bound.",
+      "mathContext": "3·L(n) ≤ L(n+1) for n ≥ 1, sharp at n = 1 where 3·L(1) = L(2) = 6."
+    },
+    {
+      "id": "exponential-bound",
+      "title": "The Exponential Lower Bound",
+      "startLine": 85,
+      "endLine": 104,
+      "summary": "two_mul_three_pow_le_largeSchroder_succ proves 2·3^n ≤ L(n+1) by induction driven by tripling; two_mul_three_pow_pred_le_largeSchroder restates it as 2·3^(n−1) ≤ L(n) for n ≥ 1.",
+      "mathContext": "L(n) ≥ 2·3^(n−1): the large Schröder numbers grow at least like 2·3^(n−1), beating the parent's 2^n."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness Witnesses",
+      "startLine": 105,
+      "endLine": 111,
+      "summary": "Three examples: equality 3·L(1) = L(2) (constant 3 is maximal), attainment 2·3^(2−1) = L(2), and the non-example ¬ 3·L(0) ≤ L(1) (necessity of n ≥ 1).",
+      "mathContext": "Demonstrates that both the tripling constant and the n ≥ 1 hypothesis are sharp."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Schröder, Ernst",
+      "title": "Vier combinatorische Probleme",
+      "year": "1870",
+      "note": "Origin of the Schröder numbers"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Generating function and asymptotics of the Schröder numbers, including the growth ratio 3 + 2√2"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "schroder-numbers-oq-01",
+      "relationship": "extends",
+      "description": "Sharpens the parent's doubling step 2·L(n) ≤ L(n+1) and the bound 2^n ≤ L(n), answering its first open question"
+    }
+  ],
+  "conclusion": {
+    "summary": "Exploiting both the i=0 and i=n terms of the convolution recurrence, the large Schröder numbers satisfy the sharp tripling step 3·L(n) ≤ L(n+1) for n ≥ 1 (three_mul_largeSchroder_le_succ) and the exponential lower bound L(n) ≥ 2·3^(n−1) (two_mul_three_pow_pred_le_largeSchroder). The constant 3 is sharp (equality at n = 1) and the hypothesis n ≥ 1 is necessary (tripling fails at n = 0). All four theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Upgrades the parent's geometric lower bound from base 2 to base 3, the best constant attainable from the two extreme convolution terms, and isolates the gap to the true growth rate 3 + 2√2 as exactly the contribution of the discarded interior terms.",
+    "openQuestions": [
+      "Can the interior convolution terms be bounded below to push the constant past 3 toward the true ratio 3 + 2√2 — e.g. a step c·L(n) ≤ L(n+1) with c → 3 + 2√2 for large n?",
+      "Can the dominance L(n) ≥ catalan(n) over the Catalan numbers be proved by comparing their recurrences, formalizing the lattice-path inclusion of Dyck paths into Schröder paths?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "SchroderNumbersOQ0101",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SchroderNumbersOQ0101.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/schroder-numbers-oq-01-oq-01.json
+++ b/src/data/research/problems/schroder-numbers-oq-01-oq-01.json
@@ -1,0 +1,82 @@
+{
+  "slug": "schroder-numbers-oq-01-oq-01",
+  "title": "Large Schröder numbers: the sharp tripling step 3·L(n) ≤ L(n+1) and the lower bound L(n) ≥ 2·3^(n-1)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "L(0) = 1, \\qquad L(n+1) = L(n) + \\sum_{i=0}^{n} L(i)\\,L(n-i).",
+    "plain": "The large Schröder numbers count lattice paths from (0,0) to (n,n) using steps East, North, and Diagonal that never go above the main diagonal (equivalently, certain Schröder paths / super-Catalan structures). They satisfy a self-convolution recurrence: the next term is the current term plus the convolution sum of all earlier terms.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T16:22:20-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: tripling step 3·L(n)≤L(n+1) (n≥1) + lower bound L(n)≥2·3^(n-1), verified 0-axiom",
+    "builtItems": [
+      "two_mul_largeSchroder_le_sum (Proofs/SchroderNumbersOQ0101.lean:48): 2·L(n)≤sum for n≥1 via Finset.sum_pair on {0,n} + sum_le_sum_of_subset",
+      "three_mul_largeSchroder_le_succ (:69): 3·L(n)≤L(n+1) for n≥1",
+      "two_mul_three_pow_le_largeSchroder_succ (:77): 2·3^n≤L(n+1) all n by tripling-driven induction",
+      "two_mul_three_pow_pred_le_largeSchroder (:90): 2·3^(n-1)≤L(n) for n≥1"
+    ],
+    "insights": [
+      "Tripling comes from keeping BOTH extreme convolution terms i=0 and i=n (each = L(0)·L(n)=L(n)); parent kept only i=0 → doubling.",
+      "Constant 3 is SHARP: equality 3·L(1)=L(2)=6 at n=1. Asymptotic ratio is larger (3+2√2≈5.828); gap = discarded interior terms.",
+      "Hypothesis n≥1 necessary: at n=0 indices 0 and n collapse to one term, tripling fails (3·L0=3>2=L1)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Push constant past 3 toward 3+2√2 by bounding interior convolution terms.",
+      "Prove dominance L(n)≥catalan(n) by recurrence comparison (Dyck⊂Schröder paths)."
+    ],
+    "markdown": "# Knowledge Base: schroder-numbers-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "schroder-numbers",
+    "enumerative",
+    "recurrence",
+    "growth-bound",
+    "lattice-paths"
+  ],
+  "relatedProofs": [
+    "schroder-numbers-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T23:28:08.378Z",
+  "lastUpdate": "2026-06-24T23:41:29Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/SchroderNumbersOQ0101.lean",
+      "filename": "SchroderNumbersOQ0101.lean",
+      "lineCount": 111,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchroderNumbersOQ0101.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `schroder-numbers-oq-01`: formalize the sharp tripling step `3·L(n) ≤ L(n+1)` (n ≥ 1) and derive `L(n) ≥ 2·3^(n−1)`.

The large Schröder numbers (OEIS A006318: 1, 2, 6, 22, 90, …) satisfy the convolution recurrence `L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i)`. The parent proved **doubling** `2·L(n) ≤ L(n+1)` by keeping only the lone `i=0` term `L(0)·L(n) = L(n)`. For `n ≥ 1` the recurrence is symmetric, so the `i=n` term `L(n)·L(0) = L(n)` is a **second, distinct** copy of `L(n)`; keeping both gives sum ≥ `2·L(n)` and hence `L(n+1) ≥ 3·L(n)`.

## Results (4 theorems, 0 axioms, 0 sorries)

- `two_mul_largeSchroder_le_sum` — `2·L(n) ≤ ∑_{i≤n} L(i)·L(n−i)` for n ≥ 1, via `Finset.sum_pair` on `{0, n}` + `Finset.sum_le_sum_of_subset`
- `three_mul_largeSchroder_le_succ` — the sharp tripling step `3·L(n) ≤ L(n+1)` for n ≥ 1
- `two_mul_three_pow_le_largeSchroder_succ` — `2·3^n ≤ L(n+1)` for all n (induction driven by tripling)
- `two_mul_three_pow_pred_le_largeSchroder` — `2·3^(n−1) ≤ L(n)` for n ≥ 1

## Sharpness (3 example witnesses)

- **Constant 3 is maximal**: equality `3·L(1) = L(2) = 6` at n = 1, so no larger constant works for all n ≥ 1
- **Bound attained**: `2·3^(2−1) = L(2) = 6`
- **n ≥ 1 is necessary**: `3·L(0) = 3 > 2 = L(1)`, so tripling fails at n = 0

The asymptotic ratio `L(n+1)/L(n) → 3 + 2√2 ≈ 5.828` is larger; the gap is exactly the discarded interior convolution terms.

## Verification

`#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`. Typechecked against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)