### PR TITLE
Enrich deficient-side divisibility (abundant-number-oq-04)

### DIFF
--- a/src/data/proofs/abundant-number-oq-04/annotations.json
+++ b/src/data/proofs/abundant-number-oq-04/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "abundant-oq04-ann-scaled-injection",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 50, "endLine": 74 },
+    "type": "technique",
+    "title": "The Scaled-Divisor Injection: t·σ(d) ≤ σ(d·t)",
+    "content": "The combinatorial seed shared with the abundant-side companion. For t > 0 the map e ↦ t·e sends each divisor of d to a divisor of d·t (mul_dvd_mul_left), and is injective by left-cancellation (Nat.eq_of_mul_eq_mul_left). Summing over the image, which is a subset of divisors(d·t), gives t·σ(d) = ∑ (t·e) ≤ σ(d·t) via Finset.sum_le_sum_of_subset and Finset.sum_image. The d = 0 case is trivially 0 ≤ 0. This single embedding underwrites both abundant-closure (multiples) and the deficient results proved here.",
+    "mathContext": "$t \\cdot \\sigma(d) = \\sum_{e \\mid d} t e \\ \\le\\ \\sum_{f \\mid dt} f = \\sigma(dt), \\quad e \\mapsto te \\text{ injective}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "injection of divisor sets",
+      "Finset.sum_image / sum_le_sum_of_subset",
+      "monotonicity of σ under scaling"
+    ],
+    "prerequisites": [
+      "Nat.mem_divisors, mul_dvd_mul_left",
+      "Set.InjOn and Nat.eq_of_mul_eq_mul_left",
+      "Finset image/subset sum lemmas"
+    ]
+  },
+  {
+    "id": "abundant-oq04-ann-mono",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 76, "endLine": 95 },
+    "type": "theorem",
+    "title": "Abundancy-Index Monotonicity: n·σ(d) ≤ d·σ(n) for d ∣ n",
+    "content": "The structural engine. Writing n = d·t, the scaled-divisor bound t·σ(d) ≤ σ(d·t) is multiplied through by d to clear the division: (d·t)·σ(d) = d·(t·σ(d)) ≤ d·σ(d·t), i.e. n·σ(d) ≤ d·σ(n). Cross-multiplied, this says σ(d)/d ≤ σ(n)/n — the abundancy index h(m) = σ(m)/m never decreases when passing to a multiple. Mathlib records the σ function and the abundant/perfect/deficient predicates but NOT this monotonicity, which is the one new arithmetic inequality the whole file rests on.",
+    "mathContext": "$d \\mid n,\\ n>0 \\implies n\\,\\sigma(d) \\le d\\,\\sigma(n), \\quad\\text{i.e.}\\quad \\frac{\\sigma(d)}{d} \\le \\frac{\\sigma(n)}{n}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "abundancy index σ(n)/n",
+      "monotonicity along the divisibility order",
+      "clearing division by cross-multiplication in ℕ"
+    ],
+    "prerequisites": [
+      "scaled_sigma_le",
+      "Nat.mul_le_mul",
+      "writing d ∣ n as n = d·t"
+    ]
+  },
+  {
+    "id": "abundant-oq04-ann-bridge",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 97, "endLine": 110 },
+    "type": "definition",
+    "title": "Divisor-Sum Bridge: Deficient ⟺ σ(n) < 2n",
+    "content": "Mathlib defines deficiency via the proper-divisor sum; this bridge restates it in terms of the full σ. From σ(n) = (∑ properDivisors n) + n (Nat.sum_divisors_eq_sum_properDivisors_add_self), omega gives n.Deficient ↔ σ(n) < 2n for every n. `pos_of_deficient` records the easy fact that a deficient number is positive (0 is not deficient). These two helpers convert the predicate-level statements into the arithmetic inequalities that the monotonicity lemma can act on.",
+    "mathContext": "$n.\\text{Deficient} \\iff \\sigma(n) < 2n, \\qquad \\sigma(n) = \\Big(\\sum_{e \\mid n,\\, e<n} e\\Big) + n.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "proper-divisor sum vs full σ",
+      "deficient analogue of the abundant bridge",
+      "omega for linear ℕ reasoning"
+    ],
+    "prerequisites": [
+      "Nat.Deficient definition",
+      "Nat.sum_divisors_eq_sum_properDivisors_add_self"
+    ]
+  },
+  {
+    "id": "abundant-oq04-ann-propagation",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 112, "endLine": 127 },
+    "type": "theorem",
+    "title": "Deficiency Propagates to Divisors",
+    "content": "The deficient mirror of abundant_mul_right. If d ∣ n and n is deficient, then d is deficient. The chain n·σ(d) ≤ d·σ(n) < d·(2n) = n·(2d) combines monotonicity with the bridge σ(n) < 2n; cancelling the positive factor n (Nat.lt_of_mul_lt_mul_left) yields σ(d) < 2d. Because n sits strictly below the perfect threshold 2n, the non-strict monotonicity inequality already forces d strictly below its own threshold — no extra strictness argument needed here (contrast the perfect-boundary case).",
+    "mathContext": "$d \\mid n,\\ \\sigma(n) < 2n \\implies n\\,\\sigma(d) \\le d\\,\\sigma(n) < n\\,(2d) \\implies \\sigma(d) < 2d.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "downward closure of deficient numbers",
+      "cancelling a positive factor in a strict inequality",
+      "contrapositive of abundant upward closure"
+    ],
+    "prerequisites": [
+      "sigma_dvd_mono",
+      "deficient_iff_sigma_lt_two_mul",
+      "Nat.lt_of_mul_lt_mul_left, mul_lt_mul_of_pos_left"
+    ]
+  },
+  {
+    "id": "abundant-oq04-ann-boundary",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 129, "endLine": 153 },
+    "type": "insight",
+    "title": "Perfect Numbers Are the Exact Deficient/Abundant Boundary",
+    "content": "The classical boundary result: every proper divisor of a perfect number is deficient. Here monotonicity alone is too weak — it only gives σ(d) ≤ 2d, not the strict σ(d) < 2d — so the proof argues by trichotomy instead. Write n = d·t with t ≥ 2 (from d < n, d > 0). A perfect n is not abundant; but if the proper divisor d were abundant then n = d·t would be abundant (abundant_mul_right), and if d were perfect then the proper multiple n would be abundant (abundant_of_perfect_mul, t ≥ 2). Both contradict perfection, so by Nat.deficient_iff_not_abundant_and_not_perfect, d is deficient. Combined with the multiple-side companion, this pins perfect numbers exactly between the deficient and abundant regions.",
+    "mathContext": "$n \\text{ perfect},\\ d \\mid n,\\ d < n \\implies d \\text{ deficient}; \\quad n = d\\,t,\\ t \\ge 2.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect numbers on the abundancy threshold h = 2",
+      "trichotomy deficient / perfect / abundant",
+      "why ≤ from monotonicity needs upgrading to <"
+    ],
+    "prerequisites": [
+      "abundant_mul_right, abundant_of_perfect_mul (companion entry)",
+      "Nat.perfect_iff_not_abundant_and_not_deficient",
+      "Nat.deficient_iff_not_abundant_and_not_perfect"
+    ]
+  },
+  {
+    "id": "abundant-oq04-ann-instances",
+    "proofId": "abundant-number-oq-04",
+    "range": { "startLine": 155, "endLine": 173 },
+    "type": "context",
+    "title": "Concrete Instances: 14 Deficient Beyond Prime Powers",
+    "content": "The payoff instances. `perfect_28` (28 = 2²·7, since 1+2+4+7+14 = 28) is discharged by kernel `decide` over its small divisor sum — kernel reduction, NOT native_decide, so no Lean.ofReduceBool enters the axiom set (the file stays 0-axiom). `deficient_14` then certifies 14 = 2·7 deficient purely as a proper divisor of the perfect 28, and `deficient_three_via_six` does the same for 3 as a proper divisor of 6. Crucially, 14 is not a prime power, so Mathlib's Nat.IsPrimePow.deficient cannot reach it — the proper-divisor-of-perfect route supplies a strictly larger supply of certified deficient numbers for free.",
+    "mathContext": "$\\sigma(28) = 56 = 2\\cdot 28 \\ (\\text{perfect}); \\quad 14 \\mid 28,\\ 14 < 28 \\implies 14 \\text{ deficient}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide vs native_decide (axiom integrity)",
+      "perfect numbers 6 and 28",
+      "deficiency beyond Nat.IsPrimePow.deficient"
+    ],
+    "prerequisites": [
+      "deficient_of_proper_dvd_perfect",
+      "decidability of σ on small numbers"
+    ]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-04/index.ts
+++ b/src/data/proofs/abundant-number-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbundantDeficientDvdOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abundantNumberOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abundantNumberOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abundantNumberOQ04Data: ProofData = {
+  proof: abundantNumberOQ04Proof,
+  annotations: abundantNumberOQ04Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `abundant-number-oq-04`

The entry "The Deficient Side: Divisors of Deficient Numbers Are Deficient, and Abundancy Is Monotone Along Divisibility" had a comprehensive `meta.json` but was **missing both `index.ts` and `annotations.json`** — without `index.ts` the page renders "proof not found" on the live site.

### Added
- **`index.ts`** — Vite entry point so the proof loads.
- **`annotations.json`** — 6 annotations covering the full 174-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. `scaled_sigma_le` — the scaled-divisor injection `t·σ(d) ≤ σ(d·t)`
  2. `sigma_dvd_mono` — abundancy-index monotonicity `n·σ(d) ≤ d·σ(n)`
  3. `deficient_iff_sigma_lt_two_mul` — the divisor-sum bridge
  4. `deficient_of_dvd` — deficiency propagates to divisors
  5. `deficient_of_proper_dvd_perfect` — perfect numbers as the exact boundary
  6. concrete instances (`perfect_28`, `deficient_14` beyond prime powers)

### Verification
- `pnpm build` ✓ — no warnings for this entry.
- Axiom integrity unchanged: `status: verified`, `badge: verified`, `axiomCount: 0` (0-axiom/0-sorry; `perfect_28` uses kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool`).