### PR TITLE
research(fibonacci-identities-oq-05-oq-03): gap-two product sum ∑ Fₖ Fₖ₊₂ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ05OQ03.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ05OQ03.lean
@@ -1,0 +1,144 @@
+import Mathlib
+
+/-!
+# Fibonacci gap-two product-sum identity (`∑ Fₖ Fₖ₊₂`)
+
+The parent file `FibonacciIdentitiesOQ05.lean` records the **consecutive** product sum
+`∑ Fₖ Fₖ₊₁` and its parity-governed closed form `Fₙ₊₁²` (up to the constant `[n even]`).
+This entry answers the parent's open question for the **gap-two** companion:
+
+> Prove the companion identity for products at a fixed gap, `∑ Fₖ Fₖ₊₂`,
+> and relate its closed form to `Fₙ₊₁ Fₙ₊₂`.
+
+The headline result is
+
+* `fib_gap_two_prod_sum` — the unified closed form, stated additively to stay inside `ℕ`:
+  `Fₙ₊₁ · Fₙ₊₂ = (F₀F₂ + F₁F₃ + ⋯ + FₙFₙ₊₂) + [n even]`,
+  where `[n even]` contributes `1` for even `n` and `0` for odd `n`.
+
+* `fib_gap_two_even` / `fib_gap_two_odd` — the two explicit branches:
+  `∑ = Fₙ₊₁Fₙ₊₂ − 1` for even `n`, and `∑ = Fₙ₊₁Fₙ₊₂` for odd `n`.
+
+Unlike the consecutive case, whose engine is Cassini's quadratic identity, the gap-two
+recurrence step is governed by the **d'Ocagne / Catalan-type** identity
+`Fₙ₊₁ Fₙ₊₄ − Fₙ₊₂ Fₙ₊₃ = (−1)ⁿ`, which we derive here (in `ℤ`) directly from Cassini
+together with the defining recurrence `Fₙ₊₄ = Fₙ₊₂ + Fₙ₊₃`. From it we read off the
+single linear product relation `Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹` that closes
+the induction step by `omega` (the three products enter linearly, as atoms).
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace FibonacciIdentitiesOQ05OQ03
+
+open Finset
+
+/-- **Cassini's identity** (integer form).
+`Fₙ₊₂² = Fₙ₊₁ · Fₙ₊₃ + (−1)ⁿ⁺¹`. Proved by induction off `Nat.fib_add_two`. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) ^ 2 = Nat.fib (n + 1) * Nat.fib (n + 3) + (-1) ^ (n + 1) := by
+  induction n with
+  | zero => norm_num [Nat.fib]
+  | succ k ih =>
+    have e1 : (Nat.fib (k + 3) : ℤ) = Nat.fib (k + 1) + Nat.fib (k + 2) := by
+      rw [show k + 3 = (k + 1) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+    have e2 : (Nat.fib (k + 4) : ℤ) = Nat.fib (k + 2) + Nat.fib (k + 3) := by
+      rw [show k + 4 = (k + 2) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+    rw [show k + 1 + 3 = k + 4 from rfl, show k + 1 + 2 = k + 3 from rfl,
+      show k + 1 + 1 = k + 2 from rfl, e2]
+    have hsign : (-1 : ℤ) ^ (k + 2) = -((-1) ^ (k + 1)) := by ring
+    rw [hsign]
+    linear_combination -ih + (Nat.fib (k + 3) : ℤ) * e1
+
+/-- **d'Ocagne / Catalan-type identity** (integer form).
+`Fₙ₊₁ · Fₙ₊₄ − Fₙ₊₂ · Fₙ₊₃ = (−1)ⁿ`. Derived from Cassini (at index `n+1`) and the
+recurrences `Fₙ₊₃ = Fₙ₊₁ + Fₙ₊₂`, `Fₙ₊₄ = Fₙ₊₂ + Fₙ₊₃`. -/
+theorem fib_docagne (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) * Nat.fib (n + 4) - Nat.fib (n + 2) * Nat.fib (n + 3)
+      = (-1) ^ n := by
+  have hc := fib_cassini (n + 1)
+  have hsign : ((-1 : ℤ)) ^ (n + 1 + 1) = (-1) ^ n := by ring
+  rw [hsign] at hc
+  -- hc : (Fₙ₊₃)² = Fₙ₊₂ · Fₙ₊₄ + (−1)ⁿ
+  have e3 : (Nat.fib (n + 3) : ℤ) = Nat.fib (n + 1) + Nat.fib (n + 2) := by
+    rw [show n + 3 = (n + 1) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+  have e4 : (Nat.fib (n + 4) : ℤ) = Nat.fib (n + 2) + Nat.fib (n + 3) := by
+    rw [show n + 4 = (n + 2) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+  linear_combination hc - (Nat.fib (n + 4) : ℤ) * e3 + (Nat.fib (n + 3) : ℤ) * e4
+
+/-- The linear product relation driving the gap-two recurrence step (integer form):
+`Fₖ₊₂ · Fₖ₊₃ − Fₖ₊₁ · Fₖ₊₂ − Fₖ₊₁ · Fₖ₊₃ = (−1)ᵏ⁺¹`. -/
+theorem fib_gap_rel (k : ℕ) :
+    (Nat.fib (k + 2) : ℤ) * Nat.fib (k + 3)
+        - Nat.fib (k + 1) * Nat.fib (k + 2) - Nat.fib (k + 1) * Nat.fib (k + 3)
+      = (-1) ^ (k + 1) := by
+  have hd := fib_docagne k
+  have e4 : (Nat.fib (k + 4) : ℤ) = Nat.fib (k + 2) + Nat.fib (k + 3) := by
+    rw [show k + 4 = (k + 2) + 2 from rfl, Nat.fib_add_two]; push_cast; ring
+  have hsign : ((-1 : ℤ)) ^ (k + 1) = -((-1) ^ k) := by ring
+  rw [hsign]
+  linear_combination -hd + (Nat.fib (k + 1) : ℤ) * e4
+
+/-- Even-index specialization (natural numbers): for even `k`,
+`Fₖ₊₁Fₖ₊₂ + Fₖ₊₁Fₖ₊₃ = Fₖ₊₂Fₖ₊₃ + 1`. -/
+theorem gap_nat_even {k : ℕ} (hk : Even k) :
+    Nat.fib (k + 1) * Nat.fib (k + 2) + Nat.fib (k + 1) * Nat.fib (k + 3)
+      = Nat.fib (k + 2) * Nat.fib (k + 3) + 1 := by
+  have h := fib_gap_rel k
+  rw [(hk.add_one).neg_one_pow] at h
+  -- h : Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = −1
+  zify
+  linarith [h]
+
+/-- Odd-index specialization (natural numbers): for odd `k`,
+`Fₖ₊₂Fₖ₊₃ = Fₖ₊₁Fₖ₊₂ + Fₖ₊₁Fₖ₊₃ + 1`. -/
+theorem gap_nat_odd {k : ℕ} (hk : Odd k) :
+    Nat.fib (k + 2) * Nat.fib (k + 3)
+      = Nat.fib (k + 1) * Nat.fib (k + 2) + Nat.fib (k + 1) * Nat.fib (k + 3) + 1 := by
+  have h := fib_gap_rel k
+  rw [(hk.add_one).neg_one_pow] at h
+  -- h : Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = 1
+  zify
+  linarith [h]
+
+/-- **Fibonacci gap-two product-sum identity** (unified, additive form).
+`Fₙ₊₁ · Fₙ₊₂ = (F₀F₂ + F₁F₃ + ⋯ + FₙFₙ₊₂) + [n even]`. -/
+theorem fib_gap_two_prod_sum (n : ℕ) :
+    Nat.fib (n + 1) * Nat.fib (n + 2)
+      = (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 2))
+        + (if Even n then 1 else 0) := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+    rw [Finset.sum_range_succ]
+    rcases Nat.even_or_odd k with hk | hk
+    · -- k even, so k+1 is odd
+      have hc := gap_nat_even hk
+      rw [if_pos hk] at ih
+      have hodd : ¬ Even (k + 1) := by simp [Nat.even_add_one, hk]
+      rw [show k + 1 + 1 = k + 2 from rfl, show k + 1 + 2 = k + 3 from rfl, if_neg hodd]
+      omega
+    · -- k odd, so k+1 is even
+      have hc := gap_nat_odd hk
+      rw [if_neg (by simpa [Nat.not_even_iff_odd] using hk)] at ih
+      have heven : Even (k + 1) := hk.add_one
+      rw [show k + 1 + 1 = k + 2 from rfl, show k + 1 + 2 = k + 3 from rfl, if_pos heven]
+      omega
+
+/-- Even branch: `F₀F₂ + ⋯ + FₙFₙ₊₂ = Fₙ₊₁Fₙ₊₂ − 1` when `n` is even. -/
+theorem fib_gap_two_even {n : ℕ} (hn : Even n) :
+    (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 2))
+      = Nat.fib (n + 1) * Nat.fib (n + 2) - 1 := by
+  have h := fib_gap_two_prod_sum n
+  rw [if_pos hn] at h
+  omega
+
+/-- Odd branch: `F₀F₂ + ⋯ + FₙFₙ₊₂ = Fₙ₊₁Fₙ₊₂` when `n` is odd. -/
+theorem fib_gap_two_odd {n : ℕ} (hn : Odd n) :
+    (∑ i ∈ Finset.range (n + 1), Nat.fib i * Nat.fib (i + 2))
+      = Nat.fib (n + 1) * Nat.fib (n + 2) := by
+  have h := fib_gap_two_prod_sum n
+  rw [if_neg (by simpa [Nat.not_even_iff_odd] using hn)] at h
+  omega
+
+end FibonacciIdentitiesOQ05OQ03

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-fiboq0503-1",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 3, "endLine": 30 },
+    "type": "context",
+    "title": "From Consecutive Products to a Fixed Gap",
+    "content": "**Module framing.** The parent entry proves the consecutive product staircase $F_0F_1 + \\cdots + F_nF_{n+1} = F_{n+1}^2 - [n\\text{ even}]$ and asks for the fixed-gap companion $\\sum F_k F_{k+2}$. This file settles the gap-two case: the sum closes on the *adjacent product* $F_{n+1}F_{n+2}$ rather than the square $F_{n+1}^2$, with the identical $\\pm[n\\text{ even}]$ parity correction. The reframing is the point — widening the summand gap by one widens the index gap of the closed-form product by one.",
+    "mathContext": "$\\sum_{k=0}^{n} F_k F_{k+2} = F_{n+1}F_{n+2} - [n\\text{ even}]$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Consecutive product staircase (parent entry)",
+      "Fixed-gap Fibonacci product sums",
+      "Parity-governed summation identities"
+    ],
+    "prerequisites": [
+      "The 0-indexed Fibonacci sequence Nat.fib",
+      "Classical Fibonacci summation identities"
+    ],
+    "tags": ["module-header", "framing", "fibonacci"]
+  },
+  {
+    "id": "ann-fiboq0503-2",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 37, "endLine": 54 },
+    "type": "technique",
+    "title": "Cassini's Identity for Nat.fib",
+    "content": "**The source identity.** $F_{n+2}^2 = F_{n+1}F_{n+3} + (-1)^{n+1}$ over $\\mathbb{Z}$, by a one-line induction off `Nat.fib_add_two`: rewrite the sign as $(-1)^{n+2} = -(-1)^{n+1}$, substitute the recurrence, and close with `linear_combination -ih + F_{k+3}·e1`. Mathlib records Cassini only over `Int.fib`, so the `Nat.fib` version is supplied here — and it is the seed from which the d'Ocagne identity (the actual engine of this entry) is grown.",
+    "mathContext": "$F_{n+2}^2 = F_{n+1}F_{n+3} + (-1)^{n+1}$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "linear_combination tactic",
+      "Fibonacci recurrence Nat.fib_add_two"
+    ],
+    "prerequisites": ["Induction over ℤ", "The Fibonacci recurrence"],
+    "tags": ["cassini", "engine", "linear_combination"]
+  },
+  {
+    "id": "ann-fiboq0503-3",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 56, "endLine": 70 },
+    "type": "technique",
+    "title": "The d'Ocagne / Catalan Identity from Cassini",
+    "content": "**The engine.** $F_{n+1}F_{n+4} - F_{n+2}F_{n+3} = (-1)^n$. This is *not* proved by a fresh induction: it falls out of Cassini at index $n+1$ (giving $F_{n+3}^2 = F_{n+2}F_{n+4} + (-1)^n$) together with the recurrences $F_{n+3} = F_{n+1}+F_{n+2}$ and $F_{n+4} = F_{n+2}+F_{n+3}$. A single `linear_combination hc - F_{n+4}·e3 + F_{n+3}·e4` discharges it. Where Cassini is the quadratic identity behind the consecutive product sum, d'Ocagne is the bilinear identity behind the gap-two sum.",
+    "mathContext": "$F_{n+1}F_{n+4} - F_{n+2}F_{n+3} = (-1)^n$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "d'Ocagne's identity",
+      "Catalan's identity",
+      "Deriving identities by linear_combination"
+    ],
+    "prerequisites": ["Cassini's identity", "The Fibonacci recurrence"],
+    "tags": ["docagne", "catalan", "engine"]
+  },
+  {
+    "id": "ann-fiboq0503-4",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 71, "endLine": 104 },
+    "type": "technique",
+    "title": "Linearizing the Step: a Product Relation omega Can Use",
+    "content": "**Making the step linear.** Substituting $F_{k+4} = F_{k+2}+F_{k+3}$ into d'Ocagne yields $F_{k+2}F_{k+3} - F_{k+1}F_{k+2} - F_{k+1}F_{k+3} = (-1)^{k+1}$ (`fib_gap_rel`). The three products now appear *linearly*. Collapsing the sign by parity (`Even.neg_one_pow` / `Odd.neg_one_pow`) gives the two natural-number specializations `gap_nat_even` ($F_{k+1}F_{k+2} + F_{k+1}F_{k+3} = F_{k+2}F_{k+3} + 1$) and `gap_nat_odd`. These are precisely the equations `omega` needs to combine with the inductive hypothesis, treating each product as an opaque atom.",
+    "mathContext": "$F_{k+2}F_{k+3} - F_{k+1}F_{k+2} - F_{k+1}F_{k+3} = (-1)^{k+1}$.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "Linearization for omega",
+      "Parity collapse of (−1)ⁿ",
+      "Treating products as atoms"
+    ],
+    "prerequisites": ["The d'Ocagne identity", "Even/Odd.neg_one_pow"],
+    "tags": ["linearization", "omega", "parity"]
+  },
+  {
+    "id": "ann-fiboq0503-5",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 106, "endLine": 127 },
+    "type": "technique",
+    "title": "The Main Induction: Parity Split Closed by omega",
+    "content": "**The headline.** $F_{n+1}F_{n+2} = (\\sum_{i=0}^{n} F_i F_{i+2}) + [n\\text{ even}]$, by induction on $n$. Peel the last term with `Finset.sum_range_succ`, split on `Nat.even_or_odd`, and flip the parity indicator with `Nat.even_add_one`. In each branch the inductive hypothesis plus the matching `gap_nat_even`/`gap_nat_odd` relation are a system of linear equations in the Fibonacci products, so `omega` finishes. The additive phrasing keeps everything in $\\mathbb{N}$ despite the sign-flipping correction.",
+    "mathContext": "$F_{n+1}F_{n+2} = \\left(\\sum_{i=0}^{n} F_i F_{i+2}\\right) + [n\\text{ even}]$.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "Induction with Finset.sum_range_succ",
+      "Parity indicator flip (Nat.even_add_one)",
+      "omega over ℕ"
+    ],
+    "prerequisites": ["The linear product relation", "Finset induction"],
+    "tags": ["induction", "main-theorem", "omega"]
+  },
+  {
+    "id": "ann-fiboq0503-6",
+    "proofId": "fibonacci-identities-oq-05-oq-03",
+    "range": { "startLine": 129, "endLine": 144 },
+    "type": "technique",
+    "title": "The Two Explicit Branches",
+    "content": "**Reading off the subtractive form.** `fib_gap_two_even` gives $\\sum F_kF_{k+2} = F_{n+1}F_{n+2} - 1$ for even $n$ and `fib_gap_two_odd` gives $\\sum F_kF_{k+2} = F_{n+1}F_{n+2}$ for odd $n$. Both are immediate specializations of the unified additive form, with `omega` discharging the (now valid) truncated subtraction over $\\mathbb{N}$. Side by side with the consecutive case ($F_{n+1}^2 - 1$ / $F_{n+1}^2$) they make the gap-zero → gap-two pattern visible.",
+    "mathContext": "$\\sum F_kF_{k+2} = F_{n+1}F_{n+2} - [n\\text{ even}]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Truncated ℕ subtraction",
+      "Parity branches",
+      "Comparison with the consecutive product sum"
+    ],
+    "prerequisites": ["The unified additive identity"],
+    "tags": ["corollary", "branches", "parity"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ05OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ05OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ05OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ05OQ03Data: ProofData = {
+  proof: fibonacciIdentitiesOQ05OQ03Proof,
+  annotations: fibonacciIdentitiesOQ05OQ03Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-05-oq-03/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "fibonacci-identities-oq-05-oq-03",
+  "title": "Fibonacci Gap-Two Product-Sum: ∑ Fₖ Fₖ₊₂",
+  "slug": "fibonacci-identities-oq-05-oq-03",
+  "description": "Answers the third open question of the parent entry fibonacci-identities-oq-05 (the consecutive product-sum staircase F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − [n even]): prove the companion identity for products at a fixed gap of two, ∑ Fₖ Fₖ₊₂, and relate its closed form to Fₙ₊₁ Fₙ₊₂. The headline fib_gap_two_prod_sum gives the unified, parity-governed closed form, stated additively to stay inside ℕ: Fₙ₊₁ · Fₙ₊₂ = (F₀F₂ + F₁F₃ + ⋯ + FₙFₙ₊₂) + [n even]. Equivalently (fib_gap_two_even / fib_gap_two_odd) ∑ FₖFₖ₊₂ = Fₙ₊₁Fₙ₊₂ − 1 for even n and = Fₙ₊₁Fₙ₊₂ for odd n — so unlike the consecutive case (whose closed form is the square Fₙ₊₁²) the gap-two sum lands on the adjacent product Fₙ₊₁Fₙ₊₂, with the same ±[n even] parity correction. Where the consecutive staircase is driven by Cassini's quadratic identity, the gap-two recurrence step is governed by the d'Ocagne / Catalan-type identity Fₙ₊₁Fₙ₊₄ − Fₙ₊₂Fₙ₊₃ = (−1)ⁿ, proved here over ℤ from Cassini and the recurrence; it yields the single linear product relation Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹ that closes the induction by omega. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Lucas; Catalan/d'Ocagne; Fibonacci summation folklore); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence",
+    "date": "1878",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "docagne-identity",
+      "summation-identity",
+      "fixed-gap",
+      "parity",
+      "telescoping",
+      "integer-sequences",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ05OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence; drives the Cassini induction and supplies the substitutions Fₙ₊₃ = Fₙ₊₁ + Fₙ₊₂, Fₙ₊₄ = Fₙ₊₂ + Fₙ₊₃ used to turn d'Ocagne into the linear product relation",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — peels the last term off each partial sum in the inductive step",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)ⁿ = 1 for even n and −1 for odd n — collapses the d'Ocagne sign to the concrete constant ±1 in each parity branch, giving the natural-number specializations gap_nat_even / gap_nat_odd",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.even_or_odd",
+        "description": "every natural number is even or odd — drives the two-way parity split in the main induction step",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Nat.even_add_one",
+        "description": "Even (n+1) ↔ ¬ Even n — flips the parity indicator [n even] ↦ [n+1 even] between consecutive inductive steps",
+        "module": "Mathlib.Algebra.Parity"
+      }
+    ],
+    "originalContributions": [
+      "fib_gap_two_prod_sum: ∀ n, Fₙ₊₁·Fₙ₊₂ = (∑_{i≤n} FᵢFᵢ₊₂) + [n even] — the unified closed form for the gap-two product sum, landing on the adjacent product Fₙ₊₁Fₙ₊₂ (vs the square Fₙ₊₁² of the consecutive case); absent from Mathlib",
+      "fib_gap_two_even / fib_gap_two_odd: ∑_{i≤n} FᵢFᵢ₊₂ = Fₙ₊₁Fₙ₊₂ − 1 for even n, = Fₙ₊₁Fₙ₊₂ for odd n — the two explicit parity branches",
+      "fib_docagne: ∀ n, (Fₙ₊₁·Fₙ₊₄ − Fₙ₊₂·Fₙ₊₃ : ℤ) = (−1)ⁿ — the d'Ocagne / Catalan-type identity for Nat.fib, derived from Cassini (absent from Mathlib for Nat.fib)",
+      "fib_gap_rel: ∀ k, (Fₖ₊₂·Fₖ₊₃ − Fₖ₊₁·Fₖ₊₂ − Fₖ₊₁·Fₖ₊₃ : ℤ) = (−1)ᵏ⁺¹ — the single linear product relation that drives the gap-two recurrence step, the exact analogue of Cassini's role in the consecutive case",
+      "fib_cassini: ∀ n, (Fₙ₊₂² : ℤ) = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹ — Cassini for Nat.fib (Mathlib records it only over Int.fib)"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 144,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry formalizes the classical consecutive product-sum staircase F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − [n even], the product companion of the Lucas-era sum-of-squares identity ∑ Fₖ² = Fₙ Fₙ₊₁. The natural next question — explicitly posed by the parent — is what happens at a fixed gap larger than one: does ∑ Fₖ Fₖ₊₂ admit a comparably clean closed form, and what plays the role of the square Fₙ₊₁²? This entry settles the gap-two case.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-05)**: Prove the companion identity for products at a fixed gap, ∑ Fₖ Fₖ₊₂, and relate its closed form to Fₙ₊₁ Fₙ₊₂.\n\n**Result**: ∑_{k=0}^{n} Fₖ Fₖ₊₂ = Fₙ₊₁ Fₙ₊₂ − [n even] — the gap-two sum lands on the adjacent product Fₙ₊₁ Fₙ₊₂ (not the square Fₙ₊₁² of the consecutive case), carrying the same parity correction. Stated additively over ℕ as Fₙ₊₁ Fₙ₊₂ = (∑ Fₖ Fₖ₊₂) + [n even] (fib_gap_two_prod_sum), with explicit even/odd branches.",
+    "text": "Using Mathlib's 0-indexed Nat.fib (F₀ = 0, F₁ = 1): the gap-two partial sum satisfies ∑_{k=0}^{n} Fₖ Fₖ₊₂ = Fₙ₊₁ Fₙ₊₂ − (if n even then 1 else 0). The clean way to see the parity correction is to compare with the consecutive case: there the closed form is the perfect square Fₙ₊₁², here it is the adjacent product Fₙ₊₁ Fₙ₊₂, and in both the constant flips ±1 with the parity of n. The driving step identity is the d'Ocagne / Catalan relation Fₙ₊₁ Fₙ₊₄ − Fₙ₊₂ Fₙ₊₃ = (−1)ⁿ.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Cassini (`fib_cassini`).** Prove Fₙ₊₂² = Fₙ₊₁ Fₙ₊₃ + (−1)ⁿ⁺¹ over ℤ by induction off Nat.fib_add_two, closed with `linear_combination`.\n2. **d'Ocagne (`fib_docagne`).** Derive Fₙ₊₁ Fₙ₊₄ − Fₙ₊₂ Fₙ₊₃ = (−1)ⁿ algebraically from Cassini at index n+1 together with the recurrences Fₙ₊₃ = Fₙ₊₁ + Fₙ₊₂ and Fₙ₊₄ = Fₙ₊₂ + Fₙ₊₃ — a single `linear_combination`, no second induction.\n3. **Linear product relation (`fib_gap_rel`).** Substitute Fₙ₊₄ = Fₙ₊₂ + Fₙ₊₃ into d'Ocagne to get Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹, then read off the natural-number branches gap_nat_even / gap_nat_odd via Even.neg_one_pow / Odd.neg_one_pow.\n4. **Main identity (`fib_gap_two_prod_sum`).** Induct on n. Peel the last term with Finset.sum_range_succ, split on Nat.even_or_odd, evaluate both parity `if`s (Nat.even_add_one flips the indicator), and close each branch by `omega` — the three products enter the gap relation linearly, as atoms, exactly as Cassini's quadratic relation closes the consecutive case.\n5. **Branches (`fib_gap_two_even` / `fib_gap_two_odd`).** Specialize the unified form and discharge the ℕ subtraction with `omega`.",
+    "keyInsights": [
+      "**Gap two lands on the adjacent product, not the square.** The consecutive sum ∑ FₖFₖ₊₁ closes to Fₙ₊₁²; widening the gap by one shifts the closed form to Fₙ₊₁ Fₙ₊₂. The parity correction [n even] is identical in both — a clean illustration that the parity governance is a feature of the product-sum mechanism, not of the specific gap.",
+      "**d'Ocagne replaces Cassini as the engine.** For consecutive products the recurrence step is closed by Cassini's quadratic identity; for gap-two products the relevant relation is the d'Ocagne / Catalan identity Fₙ₊₁Fₙ₊₄ − Fₙ₊₂Fₙ₊₃ = (−1)ⁿ. It is not an independent fact: it falls out of Cassini in one `linear_combination` once the recurrence is substituted.",
+      "**A linear product relation lets omega finish.** Rewriting d'Ocagne as Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹ makes the three products enter linearly. Treated as atoms, the inductive step combining this relation with the hypothesis is pure linear arithmetic over ℤ/ℕ, so `omega` closes it after the parity `if`s are resolved.",
+      "**The additive ℕ phrasing dodges truncated subtraction.** Because the parity constant flips sign with n, the subtractive closed form ∑ = Fₙ₊₁Fₙ₊₂ − [n even] is awkward over ℕ; stating the headline as Fₙ₊₁Fₙ₊₂ = (∑) + [n even] keeps everything in ℕ, and the explicit even/odd branches recover the subtractive form where it is valid."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "Cassini's identity and the d'Ocagne / Catalan identity, with their alternating sign (−1)ⁿ",
+      "Induction with Finset.sum_range_succ; the parity split Nat.even_or_odd and the indicator flip Nat.even_add_one; linear_combination and omega over ℤ/ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring framing the gap-two product sum as the parent's third open question, previewing the closed form Fₙ₊₁Fₙ₊₂ − [n even] and the shift from Cassini (consecutive case) to the d'Ocagne identity (gap-two case). Import, namespace, and open Finset setup.",
+      "mathContext": "$\\sum_{k=0}^{n} F_k F_{k+2} = F_{n+1}F_{n+2} - [n\\text{ even}]$."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini's Identity for Nat.fib",
+      "startLine": 37,
+      "endLine": 54,
+      "summary": "fib_cassini: Fₙ₊₂² = Fₙ₊₁·Fₙ₊₃ + (−1)ⁿ⁺¹ over ℤ, by induction off the recurrence, closed with linear_combination. Mathlib records Cassini only over Int.fib; supplied here as the source of the d'Ocagne identity.",
+      "mathContext": "$F_{n+2}^2 = F_{n+1}F_{n+3} + (-1)^{n+1}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "docagne",
+      "title": "The d'Ocagne / Catalan Identity",
+      "startLine": 56,
+      "endLine": 70,
+      "summary": "fib_docagne: Fₙ₊₁·Fₙ₊₄ − Fₙ₊₂·Fₙ₊₃ = (−1)ⁿ over ℤ, derived from Cassini at index n+1 plus the recurrences Fₙ₊₃ = Fₙ₊₁+Fₙ₊₂, Fₙ₊₄ = Fₙ₊₂+Fₙ₊₃ in a single linear_combination — no second induction.",
+      "mathContext": "$F_{n+1}F_{n+4} - F_{n+2}F_{n+3} = (-1)^n$."
+    },
+    {
+      "id": "gap-rel",
+      "title": "The Linear Product Relation",
+      "startLine": 71,
+      "endLine": 104,
+      "summary": "fib_gap_rel: Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹ over ℤ (from d'Ocagne via Fₖ₊₄ = Fₖ₊₂+Fₖ₊₃), and its natural-number parity branches gap_nat_even / gap_nat_odd via Even.neg_one_pow / Odd.neg_one_pow.",
+      "mathContext": "$F_{k+2}F_{k+3} - F_{k+1}F_{k+2} - F_{k+1}F_{k+3} = (-1)^{k+1}$."
+    },
+    {
+      "id": "main",
+      "title": "The Gap-Two Product-Sum Closed Form",
+      "startLine": 106,
+      "endLine": 127,
+      "summary": "fib_gap_two_prod_sum: Fₙ₊₁·Fₙ₊₂ = (∑_{i≤n} FᵢFᵢ₊₂) + [n even]. Induction on n: peel the last term, split on parity, flip the indicator with Nat.even_add_one, and close each branch by omega using the linear product relation.",
+      "mathContext": "$F_{n+1}F_{n+2} = \\left(\\sum_{i=0}^{n} F_i F_{i+2}\\right) + [n\\text{ even}]$."
+    },
+    {
+      "id": "branches",
+      "title": "Explicit Even/Odd Branches",
+      "startLine": 129,
+      "endLine": 144,
+      "summary": "fib_gap_two_even: ∑ FₖFₖ₊₂ = Fₙ₊₁Fₙ₊₂ − 1 for even n; fib_gap_two_odd: ∑ FₖFₖ₊₂ = Fₙ₊₁Fₙ₊₂ for odd n. Specializations of the unified form, discharging the ℕ subtraction with omega.",
+      "mathContext": "$\\sum F_kF_{k+2} = F_{n+1}F_{n+2} - [n\\text{ even}]$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-05",
+      "relationship": "answers",
+      "description": "Settles the third open question of the parent entry — the closed form for the fixed-gap product sum ∑ Fₖ Fₖ₊₂ — relating it to Fₙ₊₁ Fₙ₊₂ and reusing the parent's Cassini engine via the d'Ocagne identity."
+    },
+    {
+      "targetId": "fibonacci-identities-oq-05-oq-01",
+      "relationship": "relatedTo",
+      "description": "Sibling refinement of the same parent: there the gap is fixed at one and the sum is weighted/alternated; here the gap is widened to two. Both reduce their inductive step to a Cassini-derived product identity."
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "relatedTo",
+      "description": "The base entry's sum-of-squares identity ∑ Fₖ² = Fₙ Fₙ₊₁ is the gap-zero member of the same family; this entry supplies the gap-two member, landing on Fₙ₊₁ Fₙ₊₂."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) resolution of the parent's third open question. The gap-two product sum has the closed form ∑_{k=0}^{n} Fₖ Fₖ₊₂ = Fₙ₊₁ Fₙ₊₂ − [n even], stated additively over ℕ as Fₙ₊₁ Fₙ₊₂ = (∑ Fₖ Fₖ₊₂) + [n even], with explicit even/odd branches. Where the consecutive case closes on the square Fₙ₊₁², widening the gap by one shifts the closed form to the adjacent product Fₙ₊₁ Fₙ₊₂, with the same ±[n even] parity correction.",
+    "implications": "Adds the gap-two product-sum identity to the formalized record (it is not in Mathlib) and isolates the structural mechanism: the closed form is a product of consecutive Fibonacci numbers whose index gap mirrors the summand gap, and the parity correction is universal. As reusable byproducts it supplies Cassini and the d'Ocagne / Catalan identity for Nat.fib, the latter not previously in the gallery.",
+    "openQuestions": [
+      "Prove the general fixed-gap closed form ∑_{k=0}^{n} Fₖ Fₖ₊ₘ as a single Fₙ₊₁-indexed product (or Fₙ₊₁, Fₙ₊₂-bilinear form) times a parity/period-m correction, recovering the gap-zero (square), gap-one, and gap-two cases as m = 0, 1, 2.",
+      "Establish the Lucas-number companion ∑ Lₖ Lₖ₊₂ and the general Gibonacci (Horadam) version, tracking how the parity constant becomes a discriminant.",
+      "Give the gap-two analogue of the weighted sum ∑ k Fₖ Fₖ₊₂ by an Abel transform against the closed form proved here."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "FibonacciIdentitiesOQ05OQ03",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ05OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Lucas, Édouard",
+      "title": "Théorie des fonctions numériques simplement périodiques",
+      "year": "1878",
+      "venue": "American Journal of Mathematics",
+      "note": "Foundational catalogue of elementary Fibonacci summation and product identities"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Fixed-gap Fibonacci product sums; Cassini, Catalan, and d'Ocagne identities"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Catalan/d'Ocagne identities and product summation identities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `fibonacci-identities-oq-05` (the consecutive product staircase `F₀F₁ + ⋯ + FₙFₙ₊₁ = Fₙ₊₁² − [n even]`):

> Prove the companion identity for products at a fixed gap, `∑ Fₖ Fₖ₊₂`, and relate its closed form to `Fₙ₊₁ Fₙ₊₂`.

**Result.** `∑_{k=0}^{n} Fₖ Fₖ₊₂ = Fₙ₊₁ Fₙ₊₂ − [n even]`. The gap-two sum lands on the **adjacent product** `Fₙ₊₁ Fₙ₊₂` — not the square `Fₙ₊₁²` of the consecutive case — carrying the identical `[n even]` parity correction. Stated additively over ℕ as `Fₙ₊₁ Fₙ₊₂ = (∑ Fₖ Fₖ₊₂) + [n even]` to dodge truncated subtraction, with explicit even/odd branches.

## Mathematical content

- **`fib_gap_two_prod_sum`** — the unified parity-governed closed form.
- **`fib_gap_two_even` / `fib_gap_two_odd`** — `∑ = Fₙ₊₁Fₙ₊₂ − 1` (even), `= Fₙ₊₁Fₙ₊₂` (odd).
- **`fib_docagne`** — d'Ocagne/Catalan identity `Fₙ₊₁Fₙ₊₄ − Fₙ₊₂Fₙ₊₃ = (−1)ⁿ` for `Nat.fib`, derived from Cassini in **one `linear_combination`** (no second induction).
- **`fib_gap_rel`** — its linearization `Fₖ₊₂Fₖ₊₃ − Fₖ₊₁Fₖ₊₂ − Fₖ₊₁Fₖ₊₃ = (−1)ᵏ⁺¹`, the relation that lets `omega` close the main induction step.
- **`fib_cassini`** — Cassini for `Nat.fib`.

Mathlib records Cassini and d'Ocagne only over `Int.fib`; both are supplied here for `Nat.fib`.

### Key idea
Where the consecutive case's step is closed by Cassini's *quadratic* identity, the gap-two step is governed by the *bilinear* d'Ocagne identity. Rewriting it so the three Fibonacci products enter linearly turns the inductive step into pure linear arithmetic, so `omega` finishes after the parity `if`s are resolved.

## Verification

- **7 theorems, 0 definitions, 144 lines.**
- `#print axioms` → only `propext`, `Classical.choice`, `Quot.sound`.
- **0 sorries, 0 axioms, no `native_decide`.** Status `verified`, badge `original`.
- Built with `lake env lean` (Mathlib 4.26.0); gallery annotations validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)