### PR TITLE
Enrich Shapiro n=4 (nesbitt-inequality-oq-01-oq-01): add annotations

### DIFF
--- a/src/data/proofs/nesbitt-inequality-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/nesbitt-inequality-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "shapiro4-header",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 41 },
+    "type": "context",
+    "title": "Shapiro's cyclic inequality and the n = 4 case",
+    "content": "The header frames the entry: Nesbitt's inequality is the n = 3 instance of Shapiro's cyclic inequality Σ aᵢ/(aᵢ₊₁ + aᵢ₊₂) ≥ n/2. Shapiro's inequality is famously subtle — true for n ≤ 12 (even) and n ≤ 23 (odd), and false beyond, with explicit counterexamples at n = 14 and n = 25 (Lighthill, Rankin, and others). This file settles the next case past Nesbitt, n = 4: a/(b+c) + b/(c+d) + c/(d+a) + d/(a+b) ≥ 2. The qualitative novelty is the equality structure — for n = 3 the minimum is the single ray a = b = c, whereas for n = 4 it is the two-parameter family a = c, b = d, so the minimiser set becomes positive-dimensional.",
+    "mathContext": "$\\sum_{i} \\frac{a_i}{a_{i+1}+a_{i+2}} \\ge \\frac{n}{2}, \\qquad n=4:\\ \\frac{a}{b+c}+\\frac{b}{c+d}+\\frac{c}{d+a}+\\frac{d}{a+b} \\ge 2$",
+    "significance": "context",
+    "relatedConcepts": ["Shapiro cyclic inequality", "Nesbitt's inequality", "equality locus", "sum-of-squares certificate"],
+    "prerequisites": ["cyclic sums", "ordered fields", "real fractions"]
+  },
+  {
+    "id": "shapiro4-engel2",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 58 },
+    "type": "theorem",
+    "title": "engel2: two-term Titu / Engel-form Cauchy–Schwarz",
+    "content": "`engel2` is the proof's engine: for positive x, y and arbitrary p, q, (p+q)²/(x+y) ≤ p²/x + q²/y. Rather than invoking a named Mathlib Cauchy–Schwarz lemma, it is proved through its exact deficit identity p²/x + q²/y − (p+q)²/(x+y) = (py − qx)²/(xy(x+y)). The tactic skeleton is canonical for such certified inequalities: `sub_nonneg` reduces ≤ to 0 ≤ (difference), `field_simp; ring` proves the deficit identity after clearing the positive denominators, and `positivity` finishes since the right side is a square over a positive product. Because the gap is an explicit square, the estimate is self-certifying and tight exactly when py = qx.",
+    "mathContext": "$\\frac{p^2}{x} + \\frac{q^2}{y} - \\frac{(p+q)^2}{x+y} = \\frac{(py-qx)^2}{xy(x+y)} \\ge 0$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy–Schwarz inequality", "Engel form", "Titu's lemma", "sum of squares", "field_simp", "positivity"],
+    "prerequisites": ["clearing denominators", "nonnegativity of squares"]
+  },
+  {
+    "id": "shapiro4-titu2",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 69 },
+    "type": "theorem",
+    "title": "titu2: Titu in directly applicable fraction form",
+    "content": "`titu2` repackages `engel2` into the shape the cyclic sum actually needs: for positive p, q, u, v, p/u + q/v ≥ (p+q)²/(p·u + q·v). The bridge is the rewrite p/u = p²/(p·u) (via `mul_div_mul_left` cancelling the common p), turning each linear fraction into the squared form `engel2` consumes with x = p·u and y = q·v. This is the lemma applied to each pair of cyclic terms, where p, q are the numerators a, c (or b, d) and u, v are the corresponding denominators.",
+    "mathContext": "$\\frac{p}{u} + \\frac{q}{v} \\ge \\frac{(p+q)^2}{pu+qv}, \\qquad \\frac{p}{u} = \\frac{p^2}{p\\,u}$",
+    "significance": "key",
+    "relatedConcepts": ["Titu's lemma", "Engel form", "mul_div_mul_left", "cyclic sums"],
+    "prerequisites": ["engel2", "fraction manipulation"]
+  },
+  {
+    "id": "shapiro4-deficit",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 103 },
+    "type": "theorem",
+    "title": "shapiro_four_lower: the sharp deficit lower bound",
+    "content": "`shapiro_four_lower` is the structural heart, yielding Σ ≥ 2 + ((a−c)² + (b−d)²)/(X+Y) with X = a(b+c) + c(d+a) and Y = b(c+d) + d(a+b). The decisive choice is to pair the OPPOSITE terms (1,3) and (2,4): titu2 gives a/(b+c) + c/(d+a) ≥ (a+c)²/X and b/(c+d) + d/(a+b) ≥ (b+d)²/Y, and a third application of engel2 folds these two squared quotients into a single ((a+c)+(b+d))²/(X+Y). The polynomial identity (a+b+c+d)² = 2(X+Y) + (a−c)² + (b−d)² (closed by `ring`) then splits that quotient into the constant 2 plus the explicit squared deficit. Adjacent pairing would not telescope this cleanly — the opposite pairing is what makes the 4-cycle collapse.",
+    "mathContext": "$(a+b+c+d)^2 = 2(X+Y) + (a-c)^2 + (b-d)^2,\\quad \\sum \\ge 2 + \\frac{(a-c)^2+(b-d)^2}{X+Y}$",
+    "significance": "key",
+    "relatedConcepts": ["opposite-term pairing", "telescoping", "polynomial identity", "sum-of-squares certificate", "calc proof"],
+    "prerequisites": ["titu2", "engel2", "ring identities"]
+  },
+  {
+    "id": "shapiro4-inequality",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 112 },
+    "type": "theorem",
+    "title": "shapiro_four: the n = 4 inequality",
+    "content": "`shapiro_four` extracts the headline bound a/(b+c) + b/(c+d) + c/(d+a) + d/(a+b) ≥ 2 in one step: the deficit term in `shapiro_four_lower` is a sum of squares over a positive denominator, hence nonnegative by `positivity`, so `linarith` drops it to leave 2 ≤ Σ. The deficit form does all the work; this theorem is just the corollary that discards the nonnegative remainder.",
+    "mathContext": "$\\frac{a}{b+c}+\\frac{b}{c+d}+\\frac{c}{d+a}+\\frac{d}{a+b} \\ge 2$",
+    "significance": "key",
+    "relatedConcepts": ["positivity", "linarith", "deficit bound"],
+    "prerequisites": ["shapiro_four_lower"]
+  },
+  {
+    "id": "shapiro4-eq-iff",
+    "proofId": "nesbitt-inequality-oq-01-oq-01",
+    "range": { "startLine": 114, "endLine": 151 },
+    "type": "theorem",
+    "title": "shapiro_four_eq_iff: the two-parameter equality locus",
+    "content": "`shapiro_four_eq_iff` characterises equality: Σ = 2 ↔ (a = c ∧ b = d). Necessity runs through the deficit bound — if Σ = 2 then the nonnegative deficit (a−c)²+(b−d)² over a positive denominator must be ≤ 0, forcing the numerator to 0; `nlinarith` with sq_nonneg hints isolates each square, `pow_eq_zero_iff` turns (a−c)² = 0 into a − c = 0, and likewise for b − d. Sufficiency substitutes a = c, b = d and closes with `field_simp; ring`, every estimate collapsing to equality. The contrast with Nesbitt is the point: n = 3 forces a = b = c (a single ray), whereas n = 4 admits the genuinely two-parameter family a = c, b = d — e.g. (1,2,1,2) gives Σ = 2 — so the minimiser set is positive-dimensional.",
+    "mathContext": "$\\sum = 2 \\iff (a = c \\wedge b = d); \\quad (a-c)^2+(b-d)^2 = 0 \\iff a=c,\\, b=d$",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "pow_eq_zero_iff", "nlinarith", "positive-dimensional minimiser", "Nesbitt contrast"],
+    "prerequisites": ["shapiro_four_lower", "vanishing of a sum of squares"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `nesbitt-inequality-oq-01-oq-01` (Shapiro's cyclic inequality, n=4).

## Gap addressed
The entry had a rich `meta.json` but **no `annotations.json`**, so the proof page had zero inline annotations.

## Changes
Added `annotations.json` with **6 annotations** covering the header and all four theorems, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
- **header** — Shapiro's cyclic inequality framing and the n=4 novelty (positive-dimensional equality locus)
- **engel2** — two-term Titu/Engel-form Cauchy–Schwarz via its exact square deficit
- **titu2** — fraction-form repackaging applied to each cyclic pair
- **shapiro_four_lower** — sharp deficit bound via opposite-term pairing + folding identity
- **shapiro_four** — the headline ≥ 2 inequality
- **shapiro_four_eq_iff** — equality locus a = c ∧ b = d (vs Nesbitt's single ray a = b = c)

## Validation
- `pnpm annotations:build` passes with **no warnings for this entry** (all 6 line ranges resolve to Lean constructs); `research:build`/`research:enrich` also pass.
- Full `tsc`/`vite` stages not run locally (worktree has no `node_modules`); change is JSON-only and the data pipeline validates it.
- Verified `status: verified`, `badge: original`, `axiomCount: 0` in meta.json match the Lean file (0 sorries, 0 axiom decls, no assumption-carrying structures).