### PR TITLE
Enrich weighted Nesbitt via parametrised SOS (nesbitt-inequality-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/nesbitt-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/nesbitt-inequality-oq-01-oq-02/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "nesbitt-oq0102-ann-titu3",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 44, "endLine": 58 },
+    "type": "theorem",
+    "title": "Three-Term Cauchy–Schwarz (Engel/Titu) with Explicit SOS Remainder",
+    "content": "The certificate engine. For positive denominators y₁,y₂,y₃, (x₁+x₂+x₃)²/(y₁+y₂+y₃) ≤ x₁²/y₁ + x₂²/y₂ + x₃²/y₃ — the three-term Engel (Titu) form of Cauchy–Schwarz. Rather than invoke Mathlib's abstract inner-product Cauchy–Schwarz, the proof clears denominators (div_add_div, div_le_div_iff₀) and hands nlinarith the EXACT Lagrange defect y₃(x₁y₂−x₂y₁)² + y₂(x₁y₃−x₃y₁)² + y₁(x₂y₃−x₃y₂)² ≥ 0. Because this defect is a manifest sum of squares, the whole bound is a self-certifying SOS proof — and when the yᵢ carry the weight parameter t, these squares become the parametrised SOS family the parent asked for.",
+    "mathContext": "$\\Big(\\sum \\tfrac{x_i^2}{y_i}\\Big)\\Big(\\sum y_i\\Big) - \\Big(\\sum x_i\\Big)^2 = y_3(x_1y_2-x_2y_1)^2 + y_2(x_1y_3-x_3y_1)^2 + y_1(x_2y_3-x_3y_2)^2 \\ge 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Schwarz / Engel (Titu) form",
+      "Lagrange identity sum-of-squares remainder",
+      "nlinarith with square hints",
+      "self-certifying SOS proof"
+    ],
+    "prerequisites": [
+      "div_add_div, div_le_div_iff₀",
+      "sq_nonneg, mul_nonneg",
+      "Mathlib.Tactic.Linarith (nlinarith)"
+    ]
+  },
+  {
+    "id": "nesbitt-oq0102-ann-denom-sum",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 63 },
+    "type": "technique",
+    "title": "Weighted Denominator Sum = (t+1)(ab+bc+ca)",
+    "content": "A one-line ring identity that is the linchpin of the sharp constant: a(t·b+c) + b(t·c+a) + c(t·a+b) = (t+1)(ab+bc+ca). The weighted denominators yᵢ each split into a t-scaled cross term and a plain cross term; summing cyclically, every product ab, bc, ca appears once with coefficient t and once with coefficient 1. This collapses the Cauchy–Schwarz denominator ∑ yᵢ to (t+1)(ab+bc+ca), so no per-t optimisation is needed to extract the constant 3/(t+1).",
+    "mathContext": "$a(tb+c) + b(tc+a) + c(ta+b) = (t+1)(ab+bc+ca).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric functions ab+bc+ca",
+      "ring normalization",
+      "fixing the sharp constant without optimisation"
+    ],
+    "prerequisites": [
+      "polynomial identity via ring"
+    ]
+  },
+  {
+    "id": "nesbitt-oq0102-ann-main",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 96 },
+    "type": "theorem",
+    "title": "The Weighted Nesbitt Inequality: Σ ≥ 3/(t+1)",
+    "content": "The headline result: for positive a,b,c and weight t > 0, a/(t·b+c) + b/(t·c+a) + c/(t·a+b) ≥ 3/(t+1). Each term is put in Titu form a/(t·b+c) = a²/(a(t·b+c)) (mul_div_mul_left), so titu3 with yᵢ the weighted denominators gives Σ ≥ (a+b+c)²/∑yᵢ. Substituting ∑yᵢ = (t+1)(ab+bc+ca) reduces the goal to (a+b+c)²/((t+1)(ab+bc+ca)) ≥ 3/(t+1), i.e. the parameter-free estimate (a+b+c)² ≥ 3(ab+bc+ca) = ½∑(a−b)² ≥ 0, dispatched by nlinarith. A calc chain stitches the three steps.",
+    "mathContext": "$\\frac{3}{t+1} \\le \\frac{(a+b+c)^2}{(t+1)(ab+bc+ca)} \\le \\frac{a}{tb+c}+\\frac{b}{tc+a}+\\frac{c}{ta+b}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "one-parameter family of inequalities",
+      "Titu form a/(tb+c) = a²/(a(tb+c))",
+      "(a+b+c)² ≥ 3(ab+bc+ca)",
+      "sharp constant 3/(t+1)"
+    ],
+    "prerequisites": [
+      "titu3, weighted_denoms_sum",
+      "div_le_div_iff₀, calc chaining"
+    ]
+  },
+  {
+    "id": "nesbitt-oq0102-ann-classical",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 103 },
+    "type": "context",
+    "title": "Specialisation t = 1 Recovers Classical Nesbitt 3/2",
+    "content": "Sanity check and embedding of the classical theorem: setting t = 1 in the weighted bound, the weights collapse (one_mul) and 3/(t+1) = 3/2, recovering the original Nesbitt inequality a/(b+c) + b/(c+a) + c/(a+b) ≥ 3/2. This exhibits the parent entry's unweighted result as the single point t = 1 of the continuous family proved here, confirming the deformation is a genuine generalisation rather than a different inequality.",
+    "mathContext": "$t = 1 \\implies \\frac{3}{2} \\le \\frac{a}{b+c} + \\frac{b}{c+a} + \\frac{c}{a+b}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "classical Nesbitt inequality (t = 1)",
+      "specialisation of a parametrised bound"
+    ],
+    "prerequisites": [
+      "weighted_nesbitt",
+      "one_mul simplification"
+    ]
+  },
+  {
+    "id": "nesbitt-oq0102-ann-equality",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 105, "endLine": 162 },
+    "type": "insight",
+    "title": "Equality iff a = b = c (Uniform in t)",
+    "content": "The minimiser characterisation. For every weight t > 0, equality Σ = 3/(t+1) holds iff a = b = c. Necessity squeezes the two inequalities of the main proof to equalities: from heq plus titu3 (upper) and the (a+b+c)²≥3(ab+bc+ca) step (lower), le_antisymm forces (a+b+c)²/∑yᵢ = 3/(t+1); cross-multiplying (div_eq_div_iff) and cancelling the positive factor t+1 gives (a+b+c)² = 3(ab+bc+ca), whose SOS form makes (a−b)² = (b−c)² = 0 (nlinarith + pow_eq_zero_iff), hence a = b = c. Sufficiency substitutes a = b = c and clears denominators with field_simp + ring. The equality locus is the single diagonal ray, independent of t.",
+    "mathContext": "$\\sum = \\tfrac{3}{t+1} \\iff (a+b+c)^2 = 3(ab+bc+ca) \\iff a=b=c.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_antisymm squeezing two bounds to equality",
+      "sum of squares vanishing forces equality",
+      "t-uniform minimiser"
+    ],
+    "prerequisites": [
+      "div_eq_div_iff, mul_right_cancel₀",
+      "pow_eq_zero_iff, sub_eq_zero",
+      "field_simp + ring"
+    ]
+  },
+  {
+    "id": "nesbitt-oq0102-ann-strict",
+    "proofId": "nesbitt-inequality-oq-01-oq-02",
+    "range": { "startLine": 164, "endLine": 170 },
+    "type": "theorem",
+    "title": "Strict Inequality off the Diagonal",
+    "content": "Completes the picture: unless a = b = c, the weighted bound is strict, 3/(t+1) < Σ. The proof splits the non-strict weighted_nesbitt into the strict case (done) or the equality case; in the latter, weighted_nesbitt_eq_iff would force a = b ∧ b = c, contradicting the hypothesis ¬(a = b ∧ b = c). Together with the equality characterisation this pins the exact behaviour: the minimum 3/(t+1) is attained only on the diagonal and strictly exceeded everywhere else, for every weight t.",
+    "mathContext": "$\\neg(a=b=c) \\implies \\frac{3}{t+1} < \\frac{a}{tb+c}+\\frac{b}{tc+a}+\\frac{c}{ta+b}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict vs non-strict inequality",
+      "case split via lt_or_eq_of_le",
+      "contradiction from the equality characterisation"
+    ],
+    "prerequisites": [
+      "weighted_nesbitt, weighted_nesbitt_eq_iff",
+      "lt_or_eq_of_le"
+    ]
+  }
+]

--- a/src/data/proofs/nesbitt-inequality-oq-01-oq-02/index.ts
+++ b/src/data/proofs/nesbitt-inequality-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/NesbittInequalityOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const nesbittInequalityOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const nesbittInequalityOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const nesbittInequalityOQ01OQ02Data: ProofData = {
+  proof: nesbittInequalityOQ01OQ02Proof,
+  annotations: nesbittInequalityOQ01OQ02Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `nesbitt-inequality-oq-01-oq-02`

The entry "Weighted Nesbitt Inequality via a Parametrised SOS Certificate" had a comprehensive `meta.json` but was **missing both `index.ts` and `annotations.json`** — without `index.ts` the page renders "proof not found" on the live site.

### Added
- **`index.ts`** — Vite entry point so the proof loads.
- **`annotations.json`** — 6 annotations covering the full 172-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. `titu3` — three-term Engel/Titu Cauchy–Schwarz with its explicit Lagrange SOS remainder
  2. `weighted_denoms_sum` — the identity `Σyᵢ = (t+1)(ab+bc+ca)` that fixes the sharp constant
  3. `weighted_nesbitt` — the main `Σ ≥ 3/(t+1)` bound
  4. `weighted_nesbitt_one` — the `t=1` classical specialisation `3/2`
  5. `weighted_nesbitt_eq_iff` — equality locus `a=b=c`, uniform in t
  6. `weighted_nesbitt_lt` — strict off-diagonal inequality

### Verification
- tsc + annotation build clean — no warnings for this entry.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0-axiom/0-sorry, no `native_decide`).