### PR TITLE
Enrich improper integral ∫_1^b 1/√(t²−1)=arcosh b (arsinh-log-formula-oq-01-oq-02-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": "arsinh-oq01020101-ann-deriv",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 82 },
+    "type": "theorem",
+    "title": "arcosh Is an Antiderivative of 1/√(t²−1) on (1,∞)",
+    "content": "The antiderivative fact, reproved from the parent so the file is self-contained. Using Mathlib's logarithmic form arcosh t = log(t + √(t²−1)), the chain rule assembles the derivative in stages: d/dt(t²−1) = 2t, then √(t²−1) via HasDerivAt.sqrt (radicand positive for t > 1), then the inner sum, then the outer log via HasDerivAt.log (argument t+√(t²−1) > 0). The accumulated derivative (1 + 2t/(2√(t²−1)))/(t+√(t²−1)) is simplified by field_simp + ring to exactly 1/√(t²−1). The strict positivity of the radicand for t > 1 (sqrt_sq_sub_one_pos) is what keeps every step well-defined — and what fails at the singular endpoint t = 1.",
+    "mathContext": "$\\frac{d}{dt}\\operatorname{arcosh} t = \\frac{1}{\\sqrt{t^2-1}}, \\quad \\operatorname{arcosh} t = \\log\\!\\big(t + \\sqrt{t^2-1}\\big),\\ t>1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "logarithmic form of arcosh",
+      "chain rule (HasDerivAt.sqrt / .log)",
+      "antiderivative on the open interior"
+    ],
+    "prerequisites": [
+      "HasDerivAt.sqrt, HasDerivAt.log",
+      "field_simp + ring",
+      "sqrt_sq_sub_one_pos"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-proper-ftc",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 109 },
+    "type": "context",
+    "title": "Parent Proper FTC on [a,b] ⊂ (1,∞)",
+    "content": "The reproved parent baseline. Away from the singularity the integrand is continuous (continuousOn_integrand: the denominator √(t²−1) stays positive on [a,b] ⊂ (1,∞)), hence interval-integrable, and the ordinary two-endpoint FTC integral_eq_sub_of_hasDerivAt gives ∫_a^b 1/√(t²−1) dt = arcosh b − arcosh a for 1 < a, b. This is exactly the result the parent entry proved; the present file's contribution is to push the lower limit down to the singular endpoint a = 1, which this proper FTC cannot reach because it requires differentiability of arcosh on the CLOSED interval.",
+    "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b - \\operatorname{arcosh} a, \\quad [a,b] \\subset (1,\\infty).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fundamental Theorem of Calculus (two-endpoint form)",
+      "continuity away from the singularity",
+      "the parent result being extended"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+      "ContinuousOn.intervalIntegrable"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-continuity",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 127 },
+    "type": "theorem",
+    "title": "arcosh Is Continuous at the Singular Endpoint t = 1",
+    "content": "A Mathlib gap filled here. arcosh is continuous on the CLOSED ray [1,∞) — including the endpoint 1, where its derivative 1/√(t²−1) blows up. The key observation is that continuity and differentiability are independent: through the logarithmic form arcosh x = log(x + √(x²−1)), the argument x + √(x²−1) ≥ 1 > 0 stays bounded away from 0 on [1,∞), so ContinuousOn.log composes a continuous nowhere-vanishing function with log. Mathlib's Arcosh file records monotonicity and inverse facts but no continuity lemma, so continuousOn_arcosh is new — and it is precisely what makes the endpoint-aware FTC applicable at t = 1.",
+    "mathContext": "$\\operatorname{arcosh} \\in C\\big([1,\\infty)\\big); \\quad x + \\sqrt{x^2-1} \\ge 1 > 0 \\text{ on } [1,\\infty).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "continuity vs differentiability at an endpoint",
+      "ContinuousOn.log of a nowhere-vanishing function",
+      "filling a Mathlib API gap"
+    ],
+    "prerequisites": [
+      "ContinuousOn.log",
+      "Real.continuous_sqrt",
+      "logarithmic form of arcosh"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-integrability",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 131, "endLine": 179 },
+    "type": "theorem",
+    "title": "Integrability Across the Singularity by rpow Domination",
+    "content": "The technical crux: the unbounded integrand 1/√(t²−1) is interval-integrable on the CLOSED [1,b]. The argument dominates it by the inverse-square-root model (t−1)^(−1/2), which is integrable (intervalIntegrable_model) as the unit shift (IntervalIntegrable.comp_sub_right) of x^(−1/2) — integrable across 0 because the exponent −1/2 > −1 (intervalIntegrable_rpow'). The pointwise bound 1/√(t²−1) ≤ 1/√(t−1) = (t−1)^(−1/2) on (1,b] follows from √(t−1) ≤ √(t²−1) (monotonicity of √, since t²−1 = (t−1)(t+1) ≥ t−1). IntervalIntegrable.mono_fun' assembles the domination with the a.e.-strong-measurability of the continuous-on-(1,b] integrand. This is what makes ∫_1^b a genuine Lebesgue integral, not merely a limit.",
+    "mathContext": "$\\frac{1}{\\sqrt{t^2-1}} \\le \\frac{1}{\\sqrt{t-1}} = (t-1)^{-1/2}, \\quad (t-1)^{-1/2} \\text{ integrable since } -\\tfrac12 > -1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "integrable singularity / inverse-square-root model",
+      "dominated comparison (mono_fun')",
+      "rpow integrability across 0",
+      "translation of integrability (comp_sub_right)"
+    ],
+    "prerequisites": [
+      "intervalIntegral.intervalIntegrable_rpow'",
+      "IntervalIntegrable.mono_fun' / .comp_sub_right",
+      "Real.sqrt_le_sqrt, one_div_le_one_div_of_le"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-improper",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 183, "endLine": 202 },
+    "type": "insight",
+    "title": "The Improper Integral ∫_1^b 1/√(t²−1) dt = arcosh b",
+    "content": "The headline result, evaluating the integral right down to the singularity. The endpoint-aware FTC integral_eq_sub_of_hasDeriv_right_of_le is the perfect instrument: it requires only (i) continuity of the antiderivative on the CLOSED [1,b] (continuousOn_arcosh), (ii) the right-derivative on the OPEN (1,b) (hasDerivAt_arcosh), and (iii) integrability of the derivative (intervalIntegrable_one) — never differentiability AT the singular point, so the blow-up of arcosh' at t = 1 is harmless. It yields arcosh b − arcosh 1, and arcosh 1 = 0 (Real.arcosh_zero) collapses the two-endpoint formula to the clean one-sided value arcosh b. This is strictly stronger than the parent's proper FTC.",
+    "mathContext": "$\\int_1^b \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh} b - \\operatorname{arcosh} 1 = \\operatorname{arcosh} b, \\quad \\operatorname{arcosh} 1 = 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "endpoint-aware FTC (hasDeriv_right form)",
+      "integrable endpoint singularity",
+      "arcosh 1 = 0 collapsing the formula"
+    ],
+    "prerequisites": [
+      "integral_eq_sub_of_hasDeriv_right_of_le",
+      "continuousOn_arcosh, hasDerivAt_arcosh, intervalIntegrable_one",
+      "Real.arcosh_zero"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-limit",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 204, "endLine": 223 },
+    "type": "theorem",
+    "title": "The Improper Integral as a Limit (a → 1⁺)",
+    "content": "The classical reading: ∫_a^b 1/√(t²−1) dt → arcosh b as a → 1⁺. Eventually (for a > 1) the integral equals the parent closed form arcosh b − arcosh a (tendsto_congr' on a filter_upwards), and arcosh a → arcosh 1 = 0 by the right-continuity of arcosh at 1 (continuousOn_arcosh.continuousWithinAt, restricted from Ici to Ioi). So the integral tends to arcosh b − 0 = arcosh b. Proving both this limit form AND the genuine Lebesgue integral exhibits the two standard meanings of an improper integral — and that they coincide precisely because the singularity is integrable.",
+    "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{t^2-1}} \\xrightarrow[a\\to 1^+]{} \\operatorname{arcosh} b, \\quad \\operatorname{arcosh} a \\to \\operatorname{arcosh} 1 = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "improper integral as a one-sided limit",
+      "right-continuity / nhdsWithin",
+      "equivalence of Lebesgue and limit readings"
+    ],
+    "prerequisites": [
+      "Tendsto, nhdsWithin, tendsto_congr'",
+      "ContinuousWithinAt.mono_left",
+      "integral_one_div_sqrt_sq_sub_one"
+    ]
+  },
+  {
+    "id": "arsinh-oq01020101-ann-concrete",
+    "proofId": "arsinh-log-formula-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 227, "endLine": 237 },
+    "type": "context",
+    "title": "Concrete Corollary: ∫_1^{5/3} 1/√(t²−1) dt = log 3",
+    "content": "A clean numerical instance grounding the abstract theorem. Applying improper_integral_eq_arcosh at b = 5/3 gives arcosh(5/3), and the radicand there is (5/3)²−1 = 16/9 = (4/3)², so √ = 4/3 and arcosh(5/3) = log(5/3 + 4/3) = log 3. The choice 5/3 is exactly the value for which the inner square root rationalises, making the logarithm a clean log 3 — a memorable closed-form improper integral.",
+    "mathContext": "$\\int_1^{5/3} \\frac{dt}{\\sqrt{t^2-1}} = \\operatorname{arcosh}\\tfrac53 = \\log\\!\\big(\\tfrac53+\\tfrac43\\big) = \\log 3.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "arcosh(5/3) = log 3",
+      "rationalising the radicand",
+      "concrete closed-form improper integral"
+    ],
+    "prerequisites": [
+      "improper_integral_eq_arcosh",
+      "Real.sqrt_sq, norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArsinhLogFormulaOQ01OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arsinhLogFormulaOQ01OQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arsinhLogFormulaOQ01OQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arsinhLogFormulaOQ01OQ02OQ01OQ01Data: ProofData = {
+  proof: arsinhLogFormulaOQ01OQ02OQ01OQ01Proof,
+  annotations: arsinhLogFormulaOQ01OQ02OQ01OQ01Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `arsinh-log-formula-oq-01-oq-02-oq-01-oq-01`

The entry "The Improper Integral ∫_1^b 1/√(t²−1) dt = arcosh b" had a comprehensive `meta.json` but was **missing both `index.ts` and `annotations.json`** — without `index.ts` the page renders "proof not found" on the live site.

### Added
- **`index.ts`** — Vite entry point so the proof loads.
- **`annotations.json`** — 7 annotations covering the full 238-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. `hasDerivAt_arcosh` — arcosh as antiderivative via the log form + chain rule
  2. the reproved parent proper FTC on `[a,b] ⊂ (1,∞)`
  3. `continuousOn_arcosh` — continuity at the singular endpoint (a Mathlib gap)
  4. `intervalIntegrable_one` — integrability across the singularity by rpow domination
  5. `improper_integral_eq_arcosh` — the endpoint-aware-FTC evaluation
  6. `integral_tendsto_arcosh` — the limit form `a→1⁺`
  7. `improper_integral_one_to_five_thirds` — the concrete `= log 3` corollary

### Verification
- `pnpm annotations:build` + JSON validation clean — no warnings for this entry.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` (0-axiom/0-sorry, no `native_decide`).