### PR TITLE
Enrich dissection-of-cubes-oq-01-oq-02 (minimum collision number is 2): add annotations

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "diss-oq0102-header",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 7, "endLine": 48 },
+    "type": "context",
+    "title": "The actual minimum collision count, and its caveat",
+    "content": "The header states the parent open question (OQ-01, item 2: the actual minimum of collidingCubes.card over all valid dissections) and answers it: within the combinatorial model the minimum is exactly 2. It packages two separately-proved facts — the OQ-01 lower bound (every nonempty dissection has ≥ 2 colliding cubes) and the OQ-01-OQ-01 achievability witness (a dissection attaining exactly 2) — into IsLeast collisionSpectrum 2. The caveat is essential to the axiom accounting: the CubeDissection structure carries covers_unit_cube : True as a placeholder for the true 3D tiling constraint, so every statement concerns the combinatorial model (containment + pairwise interior-disjointness), and the lower-bound half inherits one base axiom (all_different_implies_long_chains_axiom) from Wiedijk #82. The genuine geometric minimum remains open.",
+    "mathContext": "$\\min_{d}\\, |\\mathrm{collidingCubes}(d)| = 2 \\ \\text{(combinatorial model)};\\quad \\mathrm{covers\\_unit\\_cube} := \\mathrm{True}.$",
+    "significance": "context",
+    "relatedConcepts": ["Wiedijk #82", "squaring the square", "collision spectrum", "axiom integrity", "combinatorial vs geometric model"],
+    "prerequisites": ["cube dissections", "order theory (IsLeast)", "the OQ-01 lower bound and OQ-01-OQ-01 witness"]
+  },
+  {
+    "id": "diss-oq0102-spectrum",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 73 },
+    "type": "definition",
+    "title": "collisionSpectrum and its two bounding facts",
+    "content": "`collisionSpectrum` is defined as the set of collision counts attainable by some nonempty dissection: { n | ∃ d, d.cubes.Nonempty ∧ (collidingCubes d).card = n }. The two facts that pin its minimum are stated immediately: `two_mem_collisionSpectrum` reuses OQ-01-OQ-01's exampleDissection (witnessed nonempty by cubeA) to show 2 is attained, and `collisionSpectrum_lower_bound` destructures any spectrum element and applies the inherited at_least_two_colliding_cubes to show every attained value is ≥ 2.",
+    "mathContext": "$\\mathrm{collisionSpectrum} := \\{\\, n \\mid \\exists d,\\ d.\\mathrm{cubes} \\ne \\varnothing \\wedge |\\mathrm{collidingCubes}(d)| = n \\,\\}$",
+    "significance": "key",
+    "relatedConcepts": ["set-builder over ℕ", "achievability witness", "lower bound"],
+    "prerequisites": ["collidingCubes definition", "exampleDissection from OQ-01-OQ-01"]
+  },
+  {
+    "id": "diss-oq0102-isleast",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "theorem",
+    "title": "isLeast_collisionSpectrum: the minimum is exactly 2",
+    "content": "The main result `isLeast_collisionSpectrum : IsLeast collisionSpectrum 2` is the pair ⟨attainability, lower bound⟩ — exactly the meaning of 'the actual minimum'. `sInf_collisionSpectrum` then converts the least element into the infimum via IsLeast.csInf_eq (valid in the conditionally complete lattice ℕ), giving sInf collisionSpectrum = 2. `minimum_collision_count_is_two` restates the same content without the spectrum abstraction, directly as 'a dissection attains 2, and none attains less'.",
+    "mathContext": "$\\mathrm{IsLeast}\\ \\mathrm{collisionSpectrum}\\ 2 \\iff \\sInf\\,\\mathrm{collisionSpectrum} = 2$",
+    "significance": "key",
+    "relatedConcepts": ["IsLeast", "IsLeast.csInf_eq", "conditionally complete lattice", "infimum"],
+    "prerequisites": ["two_mem_collisionSpectrum", "collisionSpectrum_lower_bound"]
+  },
+  {
+    "id": "diss-oq0102-exclusions",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 111 },
+    "type": "technique",
+    "title": "0 and 1 are not attainable",
+    "content": "`zero_not_mem_collisionSpectrum` and `one_not_mem_collisionSpectrum` rule out the two values below the minimum: assuming membership, the lower bound gives 2 ≤ 0 (resp. 2 ≤ 1), which `omega` refutes. Conceptually, collisions come in at least pairs — a single colliding cube has no equal-size partner — so 1 in particular is impossible, not merely below the bound.",
+    "mathContext": "$0,1 \\notin \\mathrm{collisionSpectrum}\\quad(\\text{from } 2 \\le n \\text{ via omega})$",
+    "significance": "supporting",
+    "relatedConcepts": ["omega", "collisions come in pairs"],
+    "prerequisites": ["collisionSpectrum_lower_bound"]
+  },
+  {
+    "id": "diss-oq0102-cubeD",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 117, "endLine": 194 },
+    "type": "definition",
+    "title": "A third witness: three equal cubes side-by-side",
+    "content": "To show 2 is the bottom of a genuine spectrum (not the only value), this section builds a second dissection. `cubeD` (corner (1/4,0,0), side 1/4) fills the gap between the existing cubeA (x=0) and cubeB (x=1/2), so three equal-size cubes sit side-by-side at x = 0, 1/4, 1/2. Distinctness (cubeA_ne_cubeD, cubeB_ne_cubeD) is read off the x-coordinates, and pairwise interior-disjointness holds with boundary-touching allowed (A.x + 1/4 = 1/4 = D.x, etc.). `triDissection` assembles the three-element Finset {A,B,D} into a CubeDissection, discharging all_contained and pairwise_disjoint by case analysis and covers_unit_cube by `trivial` (the placeholder).",
+    "mathContext": "$A,D,B \\text{ at } x = 0, \\tfrac14, \\tfrac12, \\text{ all side } \\tfrac14;\\ \\text{boundary-touching disjoint}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["explicit construction", "interior-disjointness", "boundary touching", "CubeDissection structure"],
+    "prerequisites": ["Cube and CubeDissection definitions", "cubeA / cubeB from OQ-01-OQ-01"]
+  },
+  {
+    "id": "diss-oq0102-three",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 206, "endLine": 250 },
+    "type": "theorem",
+    "title": "tri_has_three_collisions and 3 ∈ collisionSpectrum",
+    "content": "Each of A, B, D collides because all three share size 1/4, so each has an equal-size partner (cubeA_collides_tri etc. via the filter characterisation mem_collidingCubes_tri_iff). `colliding_eq_tri` proves collidingCubes triDissection = {A,B,D} by antisymmetry, and `tri_has_three_collisions` computes the cardinality as 3 using Finset.card_insert_of_not_mem and Finset.card_pair on the distinctness lemmas. Hence `three_mem_collisionSpectrum` gives 3 ∈ collisionSpectrum, and `collisionSpectrum_nontrivial` concludes {2,3} ⊆ collisionSpectrum with 2 the least element — the minimum is a real boundary of a nontrivial set.",
+    "mathContext": "$|\\mathrm{collidingCubes}(\\mathrm{triDissection})| = 3,\\quad \\{2,3\\} \\subseteq \\mathrm{collisionSpectrum}.$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_insert_of_not_mem", "Finset.card_pair", "Finset.Subset.antisymm", "collision via equal size"],
+    "prerequisites": ["triDissection", "collidingCubes filter definition"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-02` (the minimum collision number over combinatorial cube dissections is exactly 2).

## Gap addressed
The entry had a rich `meta.json` but **no `annotations.json`**, so the proof page had zero inline annotations.

## Changes
Added `annotations.json` with **6 annotations** covering the header and all key results, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
- **header** — the OQ-01 item-2 question, the answer, and the axiom caveat
- **collisionSpectrum** — definition plus its two bounding facts
- **isLeast_collisionSpectrum** — main result (= 2), plus sInf and direct restatements
- **0/1 exclusions** — not attainable, via omega against the lower bound
- **three-cube witness** — cubeD construction giving three equal cubes side-by-side
- **tri_has_three_collisions** — 3 ∈ spectrum, so {2,3} ⊆ spectrum with 2 least

## Axiom integrity
Verified honest: `status: axiomatized`, `badge: axiom`, `axiomCount: 1`. The Lean file declares 0 `axiom`s but inherits `all_different_implies_long_chains_axiom` through the OQ-01 lower bound, and `CubeDissection` carries `covers_unit_cube : True` as a placeholder. Both disclosed in the annotations.

## Validation
- `pnpm annotations:build` passes with **no warnings for this entry**; JSON validated.

(Note: this branch is reused across enrichment passes; an earlier abundant-number-oq-04 commit was superseded on main by a concurrent PR, so this PR now carries only the dissection change.)