### PR TITLE
research(euler-totient-oq-05-oq-01): full RSA correctness without coprimality via CRT

### DIFF
--- a/proofs/Proofs/EulerTotientOQ05OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ05OQ01.lean
@@ -1,0 +1,158 @@
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+/-
+# Full RSA Correctness Without Coprimality, via CRT over `n = p · q`
+
+## What This Proves
+
+The parent entry `euler-totient-oq-05` proves RSA correctness
+`(m ^ e) ^ d ≡ m [MOD n]` **only under the hypothesis `Nat.Coprime m n`**
+(its `rsa_correctness`). That hypothesis is mathematically unnecessary: real RSA
+moduli are products of two distinct primes `n = p · q`, and on such a modulus
+decryption recovers **every** message `m`, including the measure-zero but
+cryptographically real cases where `p ∣ m` or `q ∣ m` (so `m` is *not* a unit).
+
+This entry answers the parent's first open question verbatim — *"Prove RSA
+correctness without the coprimality hypothesis on `m`, via CRT over the prime
+factorization `n = pq` (the full RSA correctness theorem)"* — by the standard
+prime-by-prime / Chinese-Remainder argument:
+
+1. `pow_modEq_self_of_prime` : for a prime `p`, if `k ≡ 1 [MOD p-1]` and `0 < k`,
+   then `m ^ k ≡ m [MOD p]` for **all** `m`. This is the per-prime fixed-point
+   form of Fermat's little theorem (`x ↦ x ^ k` fixes every residue mod `p`),
+   handling `p ∣ m` (both sides `≡ 0`) and `p ∤ m` (Fermat) uniformly.
+2. `rsa_correctness_full` : with `p ≠ q` prime and the Carmichael key condition
+   `e * d ≡ 1 [MOD lcm (p-1) (q-1)]`, `(m ^ e) ^ d ≡ m [MOD p * q]` for all `m`.
+3. `rsa_correctness_full_phi` : the same with the classical Euler condition
+   `e * d ≡ 1 [MOD (p-1) * (q-1)]` (a multiple of `lcm`, hence weaker).
+4. `rsa_correctness_full_totient` : restated with `Nat.totient (p * q)` in the key
+   condition, the exact strengthening of the parent's `rsa_correctness` from
+   "`m` coprime to `n`" to "all `m`".
+
+## Distinctness
+
+The parent `rsa_correctness` requires `Nat.Coprime m n` and applies Euler's
+theorem to a single modulus. The theorem here drops that hypothesis entirely and
+is *strictly stronger* on `n = p · q`: it covers the non-unit messages on which
+the parent statement is silent. The engine is the CRT splitting
+`a ≡ b [MOD p*q] ↔ a ≡ b [MOD p] ∧ a ≡ b [MOD q]` together with the all-`m`
+fixed-point lemma `pow_modEq_self_of_prime`, neither of which appears upstream.
+
+## Mathlib foundation
+
+`ZMod.pow_card_sub_one_eq_one`, `ZMod.natCast_eq_natCast_iff`,
+`Nat.modEq_and_modEq_iff_modEq_mul`, `Nat.ModEq.of_dvd`, `Nat.modEq_iff_dvd'`,
+`Nat.coprime_primes`, `Nat.totient_mul`, `Nat.totient_prime`.
+-/
+
+namespace EulerTotientOQ05OQ01
+
+open Nat
+
+/-! ## The all-`m` fixed-point form of Fermat's little theorem -/
+
+/-- **Per-prime fixed point.** For a prime `p`, if the exponent `k` is `≡ 1`
+modulo `p - 1` and positive, then `m ^ k ≡ m [MOD p]` for **every** natural
+number `m` — no coprimality assumption.
+
+This is the uniform version of Fermat's little theorem: the map `x ↦ x ^ k` fixes
+every residue class mod `p`. When `p ∤ m`, `m ^ (p-1) ≡ 1` (Fermat) collapses the
+surplus exponent; when `p ∣ m`, both `m ^ k` (since `k ≥ 1`) and `m` are `≡ 0`. -/
+theorem pow_modEq_self_of_prime {p k m : ℕ} (hp : p.Prime) (hk : 0 < k)
+    (hkmod : k ≡ 1 [MOD p - 1]) : m ^ k ≡ m [MOD p] := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- `p - 1 ∣ k - 1`, so `k = (p-1) * t + 1` for some `t`.
+  obtain ⟨t, ht⟩ : (p - 1) ∣ (k - 1) := (Nat.modEq_iff_dvd' hk).mp hkmod.symm
+  have hk_eq : k = (p - 1) * t + 1 := by omega
+  -- Transport the goal into the field `ZMod p`.
+  rw [← ZMod.natCast_eq_natCast_iff]
+  push_cast
+  rw [hk_eq, pow_add, pow_mul, pow_one]
+  rcases eq_or_ne (m : ZMod p) 0 with h | h
+  · -- `p ∣ m`: the left factor is killed by the trailing `* m = * 0`.
+    rw [h, mul_zero]
+  · -- `p ∤ m`: Fermat gives `m ^ (p-1) = 1`, so the surplus power vanishes.
+    rw [ZMod.pow_card_sub_one_eq_one h, one_pow, one_mul]
+
+/-! ## Full RSA correctness on `n = p · q` -/
+
+/-- **Full RSA correctness (Carmichael key condition).** Let `p ≠ q` be primes,
+`e, d > 0`, and suppose the RSA key relation `e * d ≡ 1 [MOD lcm (p-1) (q-1)]`
+holds. Then decryption recovers **every** message: `(m ^ e) ^ d ≡ m [MOD p * q]`
+for all `m`, with no coprimality hypothesis on `m`.
+
+`lcm (p-1) (q-1)` is Carmichael's `λ(p·q)`; the relation forces `e * d ≡ 1`
+modulo each of `p-1` and `q-1`, and the two per-prime congruences glue by CRT. -/
+theorem rsa_correctness_full {p q e d m : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (he : 0 < e) (hd : 0 < d)
+    (hed : e * d ≡ 1 [MOD Nat.lcm (p - 1) (q - 1)]) :
+    (m ^ e) ^ d ≡ m [MOD p * q] := by
+  rw [← pow_mul]
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr hpq
+  -- CRT: a congruence mod `p*q` splits as the pair of congruences mod `p`, `q`.
+  rw [← Nat.modEq_and_modEq_iff_modEq_mul hcop]
+  have hed_pos : 0 < e * d := Nat.mul_pos he hd
+  refine ⟨?_, ?_⟩
+  · exact pow_modEq_self_of_prime hp hed_pos (hed.of_dvd (Nat.dvd_lcm_left _ _))
+  · exact pow_modEq_self_of_prime hq hed_pos (hed.of_dvd (Nat.dvd_lcm_right _ _))
+
+/-- **Full RSA correctness (classical Euler key condition).** The same conclusion
+under the textbook relation `e * d ≡ 1 [MOD (p-1) * (q-1)]`. Since
+`lcm (p-1) (q-1) ∣ (p-1) * (q-1)`, this hypothesis is *weaker* (the modulus is a
+multiple of Carmichael's `λ`), yet still recovers every message. -/
+theorem rsa_correctness_full_phi {p q e d m : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (he : 0 < e) (hd : 0 < d)
+    (hed : e * d ≡ 1 [MOD (p - 1) * (q - 1)]) :
+    (m ^ e) ^ d ≡ m [MOD p * q] := by
+  refine rsa_correctness_full hp hq hpq he hd ?_
+  exact hed.of_dvd (Nat.lcm_dvd (dvd_mul_right _ _) (dvd_mul_left _ _))
+
+/-- **Full RSA correctness, `φ`-phrased.** Exactly the parent's `rsa_correctness`
+key condition `e * d ≡ 1 [MOD φ(n)]`, with `n = p * q`, but now with the
+coprimality hypothesis on `m` **removed**. This is the precise statement of how
+the open question strengthens the parent: same hypotheses on the key, conclusion
+for *all* messages. -/
+theorem rsa_correctness_full_totient {p q e d m : ℕ} (hp : p.Prime) (hq : q.Prime)
+    (hpq : p ≠ q) (he : 0 < e) (hd : 0 < d)
+    (hed : e * d ≡ 1 [MOD Nat.totient (p * q)]) :
+    (m ^ e) ^ d ≡ m [MOD p * q] := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes hp hq).mpr hpq
+  have hφ : Nat.totient (p * q) = (p - 1) * (q - 1) := by
+    rw [Nat.totient_mul hcop, Nat.totient_prime hp, Nat.totient_prime hq]
+  rw [hφ] at hed
+  exact rsa_correctness_full_phi hp hq hpq he hd hed
+
+/-! ## Worked examples
+
+Concrete RSA round-trips on `n = p·q`, including the non-coprime message that the
+parent's `rsa_correctness` cannot reach. -/
+
+/-- The standard textbook RSA: `p = 3`, `q = 11`, `n = 33`, `φ(33) = 20`, public
+`e = 7`, private `d = 3` (since `7 * 3 = 21 ≡ 1 mod 20`). Message `m = 5` is
+recovered. -/
+example : (5 ^ 7) ^ 3 ≡ 5 [MOD 3 * 11] := by
+  refine rsa_correctness_full_totient (p := 3) (q := 11) (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num) (by decide)
+
+/-- The case the parent **cannot** handle: a message divisible by a prime factor.
+Here `m = 6` is divisible by `p = 3`, so `Nat.Coprime 6 33` fails — yet full RSA
+correctness still recovers it. -/
+example : (6 ^ 7) ^ 3 ≡ 6 [MOD 3 * 11] := by
+  refine rsa_correctness_full_totient (p := 3) (q := 11) (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num) (by decide)
+
+/-- And the message `m = 0`, the extreme non-unit, is recovered too. -/
+example : (0 ^ 7) ^ 3 ≡ 0 [MOD 3 * 11] := by
+  refine rsa_correctness_full_totient (p := 3) (q := 11) (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num) (by norm_num) (by decide)
+
+#check @pow_modEq_self_of_prime
+#check @rsa_correctness_full
+#check @rsa_correctness_full_phi
+#check @rsa_correctness_full_totient
+
+end EulerTotientOQ05OQ01

--- a/src/data/proofs/euler-totient-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-05-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-rsa-full-fixedpoint",
+    "proofId": "euler-totient-oq-05-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Per-prime fixed point of Fermat's little theorem",
+    "content": "For a prime p and an exponent k with k ≡ 1 (mod p−1) and k > 0, m^k ≡ m (mod p) for EVERY m — no coprimality required. Writing k = (p−1)·t + 1 from p−1 ∣ k−1 and casting into the field ZMod p, the proof splits on m ≡ 0: when m ≡ 0 the trailing factor kills the product, and when m ≢ 0 Mathlib's ZMod.pow_card_sub_one_eq_one collapses (m^(p−1))^t to 1. This uniform fixed-point statement, rather than the unit form m^(p−1) ≡ 1, is exactly what survives the non-coprime case.",
+    "mathContext": "$k \\equiv 1 \\pmod{p-1},\\ k>0 \\implies m^{k} \\equiv m \\pmod p\\quad\\forall m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's little theorem",
+      "fixed point",
+      "finite field",
+      "modular congruence"
+    ],
+    "prerequisites": [
+      "ZMod.pow_card_sub_one_eq_one",
+      "Nat.modEq_iff_dvd'",
+      "ZMod.natCast_eq_natCast_iff"
+    ]
+  },
+  {
+    "id": "ann-rsa-full-carmichael",
+    "proofId": "euler-totient-oq-05-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "Full RSA correctness (Carmichael key condition)",
+    "content": "With p ≠ q prime, e, d > 0, and the Carmichael key relation e·d ≡ 1 (mod lcm(p−1,q−1)), decryption recovers every message: (m^e)^d ≡ m (mod p·q) for all m. The Chinese Remainder Theorem (Nat.modEq_and_modEq_iff_modEq_mul) splits the congruence modulo p·q into one modulo p and one modulo q; each follows from the per-prime fixed point after pushing the key condition down via lcm(p−1,q−1) being divisible by p−1 and by q−1 (Nat.ModEq.of_dvd).",
+    "mathContext": "$e d \\equiv 1 \\pmod{\\operatorname{lcm}(p-1,q-1)} \\implies (m^e)^d \\equiv m \\pmod{pq}\\quad\\forall m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RSA",
+      "Chinese Remainder Theorem",
+      "Carmichael function",
+      "cryptography"
+    ],
+    "prerequisites": [
+      "Nat.modEq_and_modEq_iff_modEq_mul",
+      "Nat.coprime_primes",
+      "Nat.ModEq.of_dvd"
+    ]
+  },
+  {
+    "id": "ann-rsa-full-euler",
+    "proofId": "euler-totient-oq-05-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "Full RSA correctness (classical Euler key condition)",
+    "content": "The same all-m conclusion under the textbook relation e·d ≡ 1 (mod (p−1)(q−1)). Because lcm(p−1,q−1) divides the product (p−1)(q−1), this hypothesis is strictly weaker than the Carmichael one, and the theorem reduces to rsa_correctness_full by Nat.ModEq.of_dvd against Nat.lcm_dvd.",
+    "mathContext": "$\\operatorname{lcm}(p-1,q-1) \\mid (p-1)(q-1)$, so the Euler condition implies the Carmichael condition.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "RSA",
+      "Euler's totient",
+      "least common multiple"
+    ],
+    "prerequisites": [
+      "Nat.lcm_dvd",
+      "Nat.ModEq.of_dvd"
+    ]
+  },
+  {
+    "id": "ann-rsa-full-totient",
+    "proofId": "euler-totient-oq-05-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 127
+    },
+    "type": "theorem",
+    "title": "Full RSA correctness, φ-phrased — the parent's hypothesis minus coprimality",
+    "content": "Restates correctness with the parent entry's exact key condition e·d ≡ 1 (mod φ(p·q)), now with the coprimality hypothesis on m removed. Rewriting φ(p·q) = (p−1)(q−1) via Nat.totient_mul and Nat.totient_prime reduces it to the Euler-condition version. This is the precise sense in which the open question strengthens the parent's rsa_correctness: identical hypotheses on the key, conclusion for all messages.",
+    "mathContext": "$e d \\equiv 1 \\pmod{\\varphi(pq)} \\implies (m^e)^d \\equiv m \\pmod{pq}\\quad\\forall m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "RSA",
+      "Euler's totient",
+      "Euler's theorem"
+    ],
+    "prerequisites": [
+      "Nat.totient_mul",
+      "Nat.totient_prime"
+    ]
+  },
+  {
+    "id": "ann-rsa-full-examples",
+    "proofId": "euler-totient-oq-05-oq-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 151
+    },
+    "type": "example",
+    "title": "Worked round-trips on n = 33, including a non-coprime message",
+    "content": "Three concrete decryptions on n = 33 = 3·11 with e = 7, d = 3 (since 7·3 = 21 ≡ 1 mod φ(33) = 20): m = 5 (a unit), m = 6 (divisible by p = 3, so NOT coprime to 33 — the case the parent's rsa_correctness cannot reach), and m = 0 (the extreme non-unit). All three use kernel decide, keeping the entry free of Lean.ofReduceBool.",
+    "mathContext": "$(6^7)^3 \\equiv 6 \\pmod{33}$ with $\\gcd(6,33)=3\\neq 1$.",
+    "significance": "illustrative",
+    "relatedConcepts": [
+      "RSA",
+      "worked example",
+      "decidability"
+    ],
+    "prerequisites": [
+      "decide"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-05-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-05-oq-01/meta.json
@@ -1,0 +1,83 @@
+{
+  "id": "euler-totient-oq-05-oq-01",
+  "title": "Full RSA Correctness Without Coprimality, via CRT over n = p·q",
+  "slug": "euler-totient-oq-05-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.FieldTheory.Finite.Basic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "EulerTotientOQ05OQ01",
+    "lineCount": 158,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/EulerTotientOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Proves the full RSA correctness theorem (m^e)^d ≡ m (mod p·q) for ALL messages m, dropping the coprimality hypothesis Nat.Coprime m n that the parent entry euler-totient-oq-05 required. The engine is the all-m fixed-point form of Fermat's little theorem (m^k ≡ m mod p whenever k ≡ 1 mod p−1, handling p∣m and p∤m uniformly) combined with the Chinese Remainder splitting a≡b mod p·q ↔ a≡b mod p ∧ a≡b mod q. Stated under the Carmichael key condition e·d ≡ 1 mod lcm(p−1,q−1), the classical Euler condition e·d ≡ 1 mod (p−1)(q−1), and the φ-phrased condition e·d ≡ 1 mod φ(p·q). 4 theorems, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "modular-arithmetic",
+      "fermat-little-theorem",
+      "chinese-remainder-theorem",
+      "rsa",
+      "cryptography",
+      "carmichael-lambda"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified using Mathlib's ZMod.pow_card_sub_one_eq_one, ZMod.natCast_eq_natCast_iff, Nat.modEq_and_modEq_iff_modEq_mul, Nat.ModEq.of_dvd, Nat.modEq_iff_dvd', Nat.coprime_primes, Nat.totient_mul, and Nat.totient_prime. The three concrete RSA round-trips use kernel decide (not native_decide), so there is no Lean.ofReduceBool dependency.",
+    "lineCount": 158,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "pow_modEq_self_of_prime: m^k ≡ m (mod p) for ALL m whenever p is prime, k > 0, and k ≡ 1 (mod p−1) — the uniform fixed-point form of Fermat's little theorem, covering both p∣m (both sides ≡ 0) and p∤m (Fermat collapses the surplus exponent) without a coprimality hypothesis",
+      "rsa_correctness_full: (m^e)^d ≡ m (mod p·q) for all m under the Carmichael key condition e·d ≡ 1 (mod lcm(p−1,q−1)), proved by splitting the modulus via the Chinese Remainder Theorem and applying the per-prime fixed point at p and q",
+      "rsa_correctness_full_phi: the same conclusion under the classical Euler key condition e·d ≡ 1 (mod (p−1)(q−1)), a weaker hypothesis since lcm(p−1,q−1) ∣ (p−1)(q−1)",
+      "rsa_correctness_full_totient: the φ-phrased statement e·d ≡ 1 (mod φ(p·q)) ⟹ (m^e)^d ≡ m (mod p·q) for all m — the exact strengthening of the parent's rsa_correctness, with the coprimality hypothesis on m removed",
+      "Worked examples on n = 33 = 3·11 recovering m = 5 (a unit), m = 6 (divisible by p = 3, so NOT coprime to n — the case the parent cannot reach), and m = 0 (the extreme non-unit)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The RSA cryptosystem (Rivest–Shamir–Adleman, 1977) publishes a modulus n = p·q and an encryption exponent e, with a private decryption exponent d satisfying e·d ≡ 1 (mod φ(n)). Textbook treatments often prove the round-trip (m^e)^d ≡ m (mod n) only for messages m coprime to n, invoking Euler's theorem directly. But correctness in fact holds for every message — including the cryptographically real (if improbable) cases where the message shares a factor with n. The standard remedy is to work prime-by-prime: m^(ed) ≡ m holds modulo p and modulo q individually (each by Fermat's little theorem, which fixes 0 as well as the units), and the Chinese Remainder Theorem glues the two congruences into one modulo p·q. The sharpest hypothesis uses Carmichael's λ(n) = lcm(p−1, q−1) rather than φ(n) = (p−1)(q−1); since λ(n) ∣ φ(n), the classical condition is a special case.",
+    "problemStatement": "Prove the full RSA correctness theorem (m^e)^d ≡ m (mod n) for n = p·q a product of two distinct primes and for EVERY message m (no coprimality assumption), given the key condition e·d ≡ 1 modulo lcm(p−1,q−1), or modulo (p−1)(q−1), or modulo φ(n). This answers the first open question of the parent entry euler-totient-oq-05.",
+    "text": "The parent entry euler-totient-oq-05 proves RSA correctness as rsa_correctness, but its hypothesis Nat.Coprime m n restricts attention to messages that are units modulo n. This entry removes that restriction for moduli n = p·q. The key lemma pow_modEq_self_of_prime establishes m^k ≡ m (mod p) for all m whenever the prime p, the exponent k > 0, and the congruence k ≡ 1 (mod p−1) are given: writing k = (p−1)·t + 1 (from p−1 ∣ k−1) and casting into the field ZMod p, the case m ≡ 0 collapses because the trailing factor is 0, while the case m ≢ 0 uses ZMod.pow_card_sub_one_eq_one to kill the (m^(p−1))^t factor. With this in hand, full correctness is immediate: e·d ≡ 1 (mod lcm(p−1,q−1)) forces e·d ≡ 1 modulo each of p−1 and q−1 (via Nat.ModEq.of_dvd against dvd_lcm_left/right), the per-prime fixed point gives m^(ed) ≡ m modulo p and modulo q, and Nat.modEq_and_modEq_iff_modEq_mul (the CRT for coprime moduli) glues them into m^(ed) ≡ m (mod p·q). Two further restatements specialize the key condition to (p−1)(q−1) and to φ(p·q), the latter being precisely the parent's hypothesis with the coprimality requirement on m dropped.",
+    "proofStrategy": "Reduce the composite modulus to its two prime factors by the Chinese Remainder Theorem (Nat.modEq_and_modEq_iff_modEq_mul, using Nat.coprime_primes for the coprimality of p and q), prove the per-prime statement once as a uniform fixed point of x ↦ x^k via Fermat's little theorem in ZMod p (case-splitting on m ≡ 0 vs m ≢ 0), and propagate the Carmichael key condition down to each prime by divisibility lcm(p−1,q−1) ∣ ... with Nat.ModEq.of_dvd. The φ-phrased and (p−1)(q−1)-phrased versions follow by rewriting φ(p·q) = (p−1)(q−1) (Nat.totient_mul, Nat.totient_prime) and by lcm ∣ product.",
+    "keyInsights": [
+      "Coprimality is unnecessary for RSA correctness on n = p·q: the per-prime statement m^(ed) ≡ m holds for ALL residues mod p, because Fermat's little theorem fixes 0 (as 0^k = 0 for k ≥ 1) in addition to the units",
+      "The right primitive is the fixed-point form 'm^k ≡ m (mod p) when k ≡ 1 mod p−1', not the unit form 'm^(p−1) ≡ 1', because only the former survives the non-coprime case",
+      "The Chinese Remainder Theorem is the structural device: one congruence modulo p·q splits into independent congruences modulo p and modulo q, each handled by the same lemma",
+      "Carmichael's λ(n) = lcm(p−1,q−1) is the sharp exponent; the classical Euler condition mod (p−1)(q−1) is the special case obtained from λ(n) ∣ φ(n)",
+      "The φ-phrased statement is exactly the parent's rsa_correctness hypothesis with 'm coprime to n' deleted — making precise that the coprimality clause was removable, not essential"
+    ],
+    "prerequisites": [
+      "Fermat's little theorem in a finite field: ZMod.pow_card_sub_one_eq_one",
+      "The Chinese Remainder Theorem for coprime moduli: Nat.modEq_and_modEq_iff_modEq_mul",
+      "Modular congruence and its divisibility characterization: Nat.ModEq, Nat.modEq_iff_dvd', Nat.ModEq.of_dvd",
+      "Euler's totient on prime products: Nat.totient_mul, Nat.totient_prime, and Carmichael's λ as lcm(p−1,q−1)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Full RSA correctness (m^e)^d ≡ m (mod p·q) for ALL messages m, under each of three equivalent key conditions (Carmichael lcm(p−1,q−1), Euler (p−1)(q−1), and φ(p·q)), proved by a uniform per-prime fixed point of Fermat's little theorem glued via the Chinese Remainder Theorem. Drops the parent's coprimality hypothesis. 4 theorems, 0 axioms, 158 lines.",
+    "implications": "Settles the parent entry's first open question: the coprimality hypothesis on the RSA message is removable on n = p·q, and the resulting full correctness theorem covers the non-unit messages (those sharing a prime factor with n) on which the parent statement was silent. The fixed-point lemma pow_modEq_self_of_prime is a reusable all-m strengthening of Fermat's little theorem.",
+    "openQuestions": [
+      "Extend full correctness to squarefree moduli n = p_1 ⋯ p_k with k > 2 prime factors, iterating the CRT gluing over the prime factorization",
+      "Characterize the exact set of messages recovered when n is NOT squarefree (e.g. n = p^2·q), where Fermat's fixed point fails for residues divisible by p but not by p^2"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `euler-totient-oq-05` verbatim — *"Prove RSA correctness without the coprimality hypothesis on m, via CRT over the prime factorization n = pq (the full RSA correctness theorem)."*

The parent's `rsa_correctness` proves `(m^e)^d ≡ m (mod n)` **only for `Nat.Coprime m n`**. This entry removes that hypothesis for `n = p·q`: decryption recovers **every** message, including the cryptographically real cases where the message shares a prime factor with the modulus (so `m` is not a unit).

## Mathematical content

- **`pow_modEq_self_of_prime`** — the engine. For prime `p`, `k > 0`, and `k ≡ 1 (mod p−1)`, `m^k ≡ m (mod p)` for **all** `m`. This uniform fixed-point form of Fermat's little theorem handles `p ∣ m` (both sides `≡ 0`) and `p ∤ m` (Fermat collapses the surplus exponent) without a coprimality split.
- **`rsa_correctness_full`** — Carmichael key condition `e·d ≡ 1 (mod lcm(p−1,q−1))`. The composite modulus splits by CRT (`Nat.modEq_and_modEq_iff_modEq_mul`) into per-prime congruences, each discharged by the fixed-point lemma.
- **`rsa_correctness_full_phi`** — classical Euler condition `e·d ≡ 1 (mod (p−1)(q−1))` (weaker, since `lcm ∣ product`).
- **`rsa_correctness_full_totient`** — `φ`-phrased: exactly the parent's key hypothesis with the coprimality clause on `m` deleted.

Worked examples on `n = 33 = 3·11` recover `m = 5` (unit), **`m = 6`** (divisible by `p = 3`, the non-coprime case the parent cannot reach), and `m = 0`.

## Verification

- **Status**: verified, badge `original`
- **0 axioms**: `#print axioms` shows only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool` (examples use kernel `decide`, not `native_decide`)
- 4 theorems, 0 sorries, 158 lines
- Builds clean against Mathlib (Lean 4.26.0) via host `lake env lean`
- Annotation builder: entry passes (0 errors for this slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)