### PR TITLE
research(quadratic-gauss-sum-square-oq-02-oq-01): equidistribution of squares/non-squares in any finite field

### DIFF
--- a/proofs/Proofs/QuadraticGaussSumSquareOQ02OQ01.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ02OQ01.lean
@@ -1,0 +1,190 @@
+/-
+  Equidistribution of squares and non-squares in an arbitrary finite field.
+
+  This is the finite-field generalization of the parent's mod-`p` count.  Let
+  `F` be a finite field of odd order `q = |F|` (equivalently `ringChar F ≠ 2`),
+  and let `χ = quadraticChar F` be its quadratic character: `χ 0 = 0`, `χ a = 1`
+  exactly when `a ≠ 0` is a square, and `χ a = -1` exactly when `a` is a
+  non-square.  Mathlib's `quadraticChar_sum_zero` records the orthogonality
+  fact that the full character sum vanishes:
+
+      ∑ a : F, χ a = 0.
+
+  The parent file (`QuadraticGaussSumSquareOQ02`) extracted the counting
+  consequence over `ZMod p`.  Here we answer the parent's open question: the
+  *same* vanishing-sum / quadraticity mechanism works verbatim over any finite
+  field `F` of odd characteristic, and we phrase the conclusion directly in
+  terms of `IsSquare` rather than the character-value filters:
+
+      #{ a : F | a ≠ 0 ∧ IsSquare a }  =  (q - 1) / 2,
+      #{ a : F | ¬ IsSquare a }        =  (q - 1) / 2.
+
+  The argument is a pure sign count.  Because `χ` is quadratic it takes only the
+  values `0, 1, -1`, so
+
+      ∑ a, χ a  =  #{a : χ a = 1}  −  #{a : χ a = -1}.
+
+  The left side is `0`, giving `#{χ = 1} = #{χ = -1}`.  Separately `χ a = 0 ↔
+  a = 0`, so the two classes exhaust the `q - 1` nonzero elements; together this
+  pins each count at `(q-1)/2`.  Finally `quadraticChar_one_iff_isSquare` and
+  `quadraticChar_neg_one_iff_not_isSquare` translate the character-value filters
+  into the `IsSquare` description.
+
+  This generalizes the parent over `ZMod p` (the prime case is `F = ZMod p`) and
+  is logically independent of the algebraic square identity
+  `g² = (-1)^((q-1)/2)·…` on the Gauss-sum side.
+-/
+import Mathlib
+
+open scoped BigOperators
+open Finset
+
+namespace QuadraticGaussSumSquareOQ02OQ01
+
+variable {F : Type*} [Field F] [Fintype F] [DecidableEq F]
+
+/-- The quadratic character of a finite field `F` of odd characteristic has a
+vanishing total sum: `∑ a, χ a = 0`.  This is `quadraticChar_sum_zero`. -/
+theorem quadraticChar_sum_eq_zero (hF : ringChar F ≠ 2) :
+    ∑ a : F, quadraticChar F a = 0 :=
+  quadraticChar_sum_zero hF
+
+/-- The squares filter: nonzero quadratic residues are exactly `{a : χ a = 1}`. -/
+def residues (F : Type*) [Field F] [Fintype F] [DecidableEq F] : Finset F :=
+  univ.filter (fun a => quadraticChar F a = 1)
+
+/-- The non-residues filter: non-squares are exactly `{a : χ a = -1}`. -/
+def nonresidues (F : Type*) [Field F] [Fintype F] [DecidableEq F] : Finset F :=
+  univ.filter (fun a => quadraticChar F a = -1)
+
+/-- The character sum splits as `#residues − #nonresidues`, because the quadratic
+character takes only the values `0, 1, -1`. -/
+theorem sum_eq_card_sub_card :
+    (∑ a : F, quadraticChar F a)
+      = (residues F).card - (nonresidues F).card := by
+  have hval : ∀ a : F,
+      (quadraticChar F a : ℤ)
+        = (if quadraticChar F a = 1 then (1 : ℤ) else 0)
+          - (if quadraticChar F a = -1 then (1 : ℤ) else 0) := by
+    intro a
+    rcases quadraticChar_isQuadratic F a with h | h | h <;> rw [h] <;> simp
+  calc
+    (∑ a : F, quadraticChar F a)
+        = ∑ a : F,
+            ((if quadraticChar F a = 1 then (1 : ℤ) else 0)
+              - (if quadraticChar F a = -1 then (1 : ℤ) else 0)) :=
+          Finset.sum_congr rfl (fun a _ => hval a)
+    _ = (∑ a : F, if quadraticChar F a = 1 then (1 : ℤ) else 0)
+          - (∑ a : F, if quadraticChar F a = -1 then (1 : ℤ) else 0) := by
+          rw [Finset.sum_sub_distrib]
+    _ = (residues F).card - (nonresidues F).card := by
+          rw [Finset.sum_boole, Finset.sum_boole]; rfl
+
+/-- **Equidistribution.** The number of quadratic residues equals the number of
+non-residues in any finite field of odd characteristic. -/
+theorem card_residues_eq_card_nonresidues (hF : ringChar F ≠ 2) :
+    (residues F).card = (nonresidues F).card := by
+  have h := sum_eq_card_sub_card (F := F)
+  rw [quadraticChar_sum_eq_zero hF] at h
+  have : ((residues F).card : ℤ) = (nonresidues F).card := by linarith
+  exact_mod_cast this
+
+/-- The residues and non-residues together exhaust the `q - 1` nonzero elements. -/
+theorem card_residues_add_card_nonresidues :
+    (residues F).card + (nonresidues F).card = Fintype.card F - 1 := by
+  classical
+  -- the two classes are disjoint (`χ a` cannot be both `1` and `-1`)
+  have hdisj : Disjoint (residues F) (nonresidues F) := by
+    rw [residues, nonresidues, Finset.disjoint_filter]
+    intro a _ h1 h2
+    rw [h1] at h2
+    exact (by decide : ¬ (1 : ℤ) = -1) h2
+  -- their union is exactly the set of nonzero elements
+  have hunion : residues F ∪ nonresidues F = univ.filter (fun a : F => a ≠ 0) := by
+    rw [residues, nonresidues, ← Finset.filter_or]
+    apply Finset.filter_congr
+    intro a _
+    constructor
+    · rintro (h | h) hz
+      · rw [(quadraticChar_eq_zero_iff.mpr hz)] at h; exact (by decide : ¬ (0 : ℤ) = 1) h
+      · rw [(quadraticChar_eq_zero_iff.mpr hz)] at h; exact (by decide : ¬ (0 : ℤ) = -1) h
+    · intro hz
+      rcases quadraticChar_isQuadratic F a with h | h | h
+      · exact absurd (quadraticChar_eq_zero_iff.mp h) hz
+      · exact Or.inl h
+      · exact Or.inr h
+  -- count the nonzero elements: `q - 1`
+  have hcard_nonzero : (univ.filter (fun a : F => a ≠ 0)).card = Fintype.card F - 1 := by
+    have : (univ.filter (fun a : F => a ≠ 0)) = univ.erase (0 : F) := by
+      ext a; simp [Finset.mem_erase]
+    rw [this, Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ]
+  rw [← Finset.card_union_of_disjoint hdisj, hunion, hcard_nonzero]
+
+/-- **Count of quadratic residues.** In a finite field `F` of odd order `q`,
+exactly `(q-1)/2` of the elements are nonzero squares (as character values). -/
+theorem card_residues_eq (hF : ringChar F ≠ 2) :
+    (residues F).card = (Fintype.card F - 1) / 2 := by
+  have heq := card_residues_eq_card_nonresidues (F := F) hF
+  have hsum := card_residues_add_card_nonresidues (F := F)
+  rw [← heq] at hsum
+  omega
+
+/-- **Count of non-residues.** Symmetrically, exactly `(q-1)/2` elements are
+non-squares (as character values). -/
+theorem card_nonresidues_eq (hF : ringChar F ≠ 2) :
+    (nonresidues F).card = (Fintype.card F - 1) / 2 := by
+  rw [← card_residues_eq_card_nonresidues (F := F) hF]
+  exact card_residues_eq (F := F) hF
+
+/-! ### `IsSquare`-phrased counts
+
+The character-value filters translate into the natural predicates: `χ a = 1` for
+a nonzero `a` means `IsSquare a`, and `χ a = -1` means `¬ IsSquare a`.  These give
+the reader-facing form of the equidistribution theorem. -/
+
+/-- The residue filter is exactly the set of nonzero squares. -/
+theorem residues_eq_filter_isSquare :
+    residues F = univ.filter (fun a : F => a ≠ 0 ∧ IsSquare a) := by
+  rw [residues]
+  apply Finset.filter_congr
+  intro a _
+  constructor
+  · intro h
+    have ha : a ≠ 0 := by
+      rintro rfl; rw [quadraticChar_zero] at h; exact (by decide : ¬ (0 : ℤ) = 1) h
+    exact ⟨ha, (quadraticChar_one_iff_isSquare ha).mp h⟩
+  · rintro ⟨ha, hsq⟩
+    exact (quadraticChar_one_iff_isSquare ha).mpr hsq
+
+/-- The non-residue filter is exactly the set of non-squares (`0` is a square, so
+it is automatically excluded). -/
+theorem nonresidues_eq_filter_not_isSquare :
+    nonresidues F = univ.filter (fun a : F => ¬ IsSquare a) := by
+  rw [nonresidues]
+  apply Finset.filter_congr
+  intro a _
+  exact ⟨fun h => quadraticChar_neg_one_iff_not_isSquare.mp h,
+         fun h => quadraticChar_neg_one_iff_not_isSquare.mpr h⟩
+
+/-- **Main theorem (nonzero squares).** In a finite field of odd order `q`, the
+number of nonzero squares is exactly `(q-1)/2`. -/
+theorem card_nonzero_isSquare_eq (hF : ringChar F ≠ 2) :
+    (univ.filter (fun a : F => a ≠ 0 ∧ IsSquare a)).card = (Fintype.card F - 1) / 2 := by
+  rw [← residues_eq_filter_isSquare]
+  exact card_residues_eq hF
+
+/-- **Main theorem (non-squares).** In a finite field of odd order `q`, the number
+of non-squares is exactly `(q-1)/2`. -/
+theorem card_not_isSquare_eq (hF : ringChar F ≠ 2) :
+    (univ.filter (fun a : F => ¬ IsSquare a)).card = (Fintype.card F - 1) / 2 := by
+  rw [← nonresidues_eq_filter_not_isSquare]
+  exact card_nonresidues_eq hF
+
+/-- **Equidistribution, `IsSquare` form.** The nonzero squares and the non-squares
+are equinumerous. -/
+theorem card_nonzero_isSquare_eq_card_not_isSquare (hF : ringChar F ≠ 2) :
+    (univ.filter (fun a : F => a ≠ 0 ∧ IsSquare a)).card
+      = (univ.filter (fun a : F => ¬ IsSquare a)).card := by
+  rw [card_nonzero_isSquare_eq hF, card_not_isSquare_eq hF]
+
+end QuadraticGaussSumSquareOQ02OQ01

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "context",
+    "title": "From mod p to an Arbitrary Finite Field",
+    "content": "The parent counts quadratic residues mod an odd prime p over ZMod p. This entry answers its open question by carrying the identical vanishing-sum / quadraticity mechanism to any finite field F of odd order q = |F|. Over F the squaring map x ↦ x² on F× is two-to-one (kernel {±1} has order 2 for odd q), so the nonzero squares number (q−1)/2. The quadratic character χ packages this, and its orthogonality identity ∑ χ(a) = 0 holds verbatim over any odd-characteristic finite field. The conclusion is phrased directly via IsSquare rather than character values.",
+    "mathContext": "$\\chi = \\operatorname{quadraticChar} F$, $\\sum_{a \\in F} \\chi(a) = 0$; nonzero squares and non-squares each number $(q-1)/2$.",
+    "significance": "context",
+    "relatedConcepts": ["finite fields", "quadratic character", "character orthogonality", "IsSquare", "Gauss sums"],
+    "prerequisites": ["finite fields", "quadratic residues"]
+  },
+  {
+    "id": "ann-vanishing-sum",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+    "range": { "startLine": 48, "endLine": 51 },
+    "type": "technique",
+    "title": "The Vanishing Character Sum over F",
+    "content": "quadraticChar_sum_eq_zero is just Mathlib's quadraticChar_sum_zero for F, taking the hypothesis ringChar F ≠ 2 directly. Unlike the parent (which specialised to ZMod p and discharged the characteristic via ZMod.ringChar_zmod_n), no specialisation is needed: the general lemma already lives over an arbitrary finite field. This single orthogonality fact ∑ χ(a) = 0 is the entire analytic input.",
+    "mathContext": "$\\sum_{a \\in F} \\chi(a) = 0$ for any finite field $F$ with $\\operatorname{ringChar} F \\neq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["character orthogonality", "ring characteristic", "quadraticChar_sum_zero"],
+    "prerequisites": ["finite fields", "ring characteristic"]
+  },
+  {
+    "id": "ann-filters-split",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+    "range": { "startLine": 53, "endLine": 91 },
+    "type": "insight",
+    "title": "The Character Sum Is a Signed Count",
+    "content": "Because quadraticChar_isQuadratic says χ(a) ∈ {0, 1, −1}, each summand χ(a) rewrites as the difference of Boolean indicators [χ(a)=1] − [χ(a)=−1]. Distributing and applying Finset.sum_boole turns ∑ χ(a) into #residues − #nonresidues. This step is identical to the parent — it never used primality, only quadraticity — making the generalization to F immediate.",
+    "mathContext": "$\\chi(a) = [\\chi(a)=1] - [\\chi(a)=-1]$, so $\\sum_a \\chi(a) = \\#\\{\\chi=1\\} - \\#\\{\\chi=-1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Boolean indicators", "Finset.sum_boole", "signed counting", "quadraticity"],
+    "prerequisites": ["finite sums", "indicator functions"]
+  },
+  {
+    "id": "ann-partition",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+    "range": { "startLine": 85, "endLine": 137 },
+    "type": "technique",
+    "title": "Equidistribution and the (q−1)/2 Count",
+    "content": "card_residues_eq_card_nonresidues substitutes ∑ χ(a) = 0 into the signed count to force the two cardinalities equal. card_residues_add_card_nonresidues shows the filters are disjoint and union to the nonzero elements (χ(a) = 0 ⟺ a = 0 via quadraticChar_eq_zero_iff), whose count is Fintype.card F − 1 via univ.erase 0 and Finset.card_erase_of_mem — the only place ZMod.card is replaced by the generic Fintype.card. Two equal halves summing to q−1 give (q−1)/2 each by omega.",
+    "mathContext": "$\\#\\text{res} = \\#\\text{nonres}$ and $\\#\\text{res} + \\#\\text{nonres} = q - 1 \\Rightarrow$ each $= (q-1)/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["disjoint union", "Finset.card_erase_of_mem", "Fintype.card", "omega"],
+    "prerequisites": ["finite cardinalities", "Euclidean division"]
+  },
+  {
+    "id": "ann-is-square",
+    "proofId": "quadratic-gauss-sum-square-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 190 },
+    "type": "insight",
+    "title": "Recasting the Count via IsSquare",
+    "content": "The substantive upgrade over the parent: the character-value filters are translated into the natural predicates. quadraticChar_one_iff_isSquare (needing a ≠ 0, which χ(0)=0 supplies) identifies the residues with {a : a ≠ 0 ∧ IsSquare a}; quadraticChar_neg_one_iff_not_isSquare (needing no nonzero hypothesis, since ¬IsSquare 0 is false) identifies the non-residues with {a : ¬ IsSquare a}. The main theorems then state #{nonzero squares} = #{non-squares} = (q−1)/2 directly in terms of IsSquare.",
+    "mathContext": "$\\{a : \\chi(a)=1\\} = \\{a \\neq 0 \\wedge \\operatorname{IsSquare} a\\}$ and $\\{a : \\chi(a)=-1\\} = \\{\\neg \\operatorname{IsSquare} a\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["IsSquare", "quadraticChar_one_iff_isSquare", "quadraticChar_neg_one_iff_not_isSquare", "filter congruence"],
+    "prerequisites": ["squares in fields", "iff-rewriting"]
+  }
+]

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/index.ts
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/QuadraticGaussSumSquareOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const quadraticGaussSumSquareOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const quadraticGaussSumSquareOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const quadraticGaussSumSquareOQ02OQ01Data: ProofData = {
+  proof: quadraticGaussSumSquareOQ02OQ01Proof,
+  annotations: quadraticGaussSumSquareOQ02OQ01Annotations,
+}

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02-oq-01/meta.json
@@ -1,0 +1,118 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-02-oq-01",
+  "title": "Equidistribution of Squares and Non-Squares in Any Finite Field",
+  "slug": "quadratic-gauss-sum-square-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Finset"
+    ],
+    "namespace": "QuadraticGaussSumSquareOQ02OQ01",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "path": "Proofs/QuadraticGaussSumSquareOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "description": "The parent counts quadratic residues mod an odd prime p; this entry answers its open question by carrying the identical vanishing-sum / quadraticity mechanism to an arbitrary finite field F of odd order q = |F|. From Mathlib's quadraticChar_sum_zero (∑ₐ χ(a) = 0 over F) the nonzero squares and the non-squares are equinumerous, each class containing exactly (q−1)/2 elements. Because the quadratic character χ takes only the values 0, 1, −1, the character sum equals #{χ = 1} − #{χ = −1}; vanishing of the sum forces the counts to agree, and χ(a) = 0 ⟺ a = 0 partitions the q−1 nonzero elements. The conclusion is then stated directly in terms of IsSquare — #{a : a ≠ 0 ∧ IsSquare a} = #{a : ¬ IsSquare a} = (q−1)/2 — via quadraticChar_one_iff_isSquare and quadraticChar_neg_one_iff_not_isSquare. The prime case F = ZMod p recovers the parent.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "quadratic-residue",
+      "quadratic-character",
+      "gauss-sum",
+      "counting",
+      "equidistribution",
+      "is-square"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 190,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "That exactly half of the nonzero elements of an odd-order finite field are squares generalizes the classical mod-$p$ fact. Over $\\mathbb{F}_q$ the squaring map $x \\mapsto x^2$ on $\\mathbb{F}_q^\\times$ is two-to-one (its kernel is $\\{\\pm 1\\}$, which has order $2$ when $q$ is odd), so its image — the nonzero squares — has order $(q-1)/2$. The quadratic character $\\chi$ encodes this with values $+1$ on squares, $-1$ on non-squares, $0$ at zero, and its orthogonality identity $\\sum_a \\chi(a) = 0$ holds verbatim over any finite field of odd characteristic. This same orthogonality is the engine behind Gauss-sum evaluations and the functional equations of Dirichlet and Hecke $L$-functions; the present entry isolates its bare counting content over a general $\\mathbb{F}_q$.",
+    "problemStatement": "Let $F$ be a finite field of odd order $q = |F|$ (equivalently $\\operatorname{ringChar} F \\neq 2$) and $\\chi = \\operatorname{quadraticChar} F$. Granting orthogonality $\\sum_{a \\in F} \\chi(a) = 0$, prove that the nonzero squares $\\{a : a \\neq 0 \\wedge \\operatorname{IsSquare} a\\}$ and the non-squares $\\{a : \\neg \\operatorname{IsSquare} a\\}$ are equinumerous, each having cardinality exactly $(q-1)/2$.",
+    "proofStrategy": "The argument ports the parent's structure from $\\mathbb{Z}/p$ to a general finite field, then re-expresses the conclusion through $\\operatorname{IsSquare}$. (1) `quadraticChar_sum_eq_zero` is `quadraticChar_sum_zero` for $F$, taking $\\operatorname{ringChar} F \\neq 2$ directly (no $\\mathbb{Z}/p$ specialisation needed). (2) `sum_eq_card_sub_card` rewrites each $\\chi(a)$ as $[\\chi(a)=1] - [\\chi(a)=-1]$ — valid since `quadraticChar_isQuadratic` gives $\\chi(a) \\in \\{0,1,-1\\}$ — and `Finset.sum_boole` turns the indicator sums into the cardinalities of the `residues`/`nonresidues` filters, so $\\sum_a \\chi(a) = \\#\\text{residues} - \\#\\text{nonresidues}$. (3) `card_residues_eq_card_nonresidues` reads equidistribution off the vanishing sum; `card_residues_add_card_nonresidues` shows the filters are disjoint and union to the nonzero elements (via $\\chi(a)=0 \\iff a=0$), whose count is $\\operatorname{Fintype.card} F - 1$ by `Finset.card_erase_of_mem`; `omega` then pins each count at $(q-1)/2$. (4) `residues_eq_filter_isSquare` and `nonresidues_eq_filter_not_isSquare` translate the character-value filters into the $\\operatorname{IsSquare}$ predicates using `quadraticChar_one_iff_isSquare` and `quadraticChar_neg_one_iff_not_isSquare`, yielding the reader-facing `card_nonzero_isSquare_eq`, `card_not_isSquare_eq`, and their equality.",
+    "keyInsights": [
+      "Nothing in the mod-$p$ count actually used primality: the only inputs are orthogonality ($\\sum_a \\chi(a) = 0$), quadraticity ($\\chi(a) \\in \\{0,1,-1\\}$), and the zero-fibre lemma ($\\chi(a) = 0 \\iff a = 0$), all of which Mathlib states for an arbitrary finite field of odd characteristic. Replacing `ZMod.card`/`ZMod.ringChar_zmod_n` by `Fintype.card F` and the hypothesis $\\operatorname{ringChar} F \\neq 2$ is the entire generalization.",
+      "The vanishing character sum is literally a signed count: squares contribute $+1$, non-squares $-1$, zero contributes $0$, so $\\sum_a \\chi(a) = \\#\\text{squares} - \\#\\text{non-squares}$. Equidistribution is a reading of orthogonality, not a separate theorem.",
+      "Phrasing the conclusion through $\\operatorname{IsSquare}$ rather than character values is the substantive upgrade over the parent. `quadraticChar_one_iff_isSquare` needs $a \\neq 0$, so the residue filter becomes $\\{a \\neq 0 \\wedge \\operatorname{IsSquare} a\\}$; `quadraticChar_neg_one_iff_not_isSquare` needs no nonzero hypothesis (since $0$ is a square, $\\neg\\operatorname{IsSquare} 0$ is false and is excluded automatically), so the non-residue filter is exactly $\\{\\neg \\operatorname{IsSquare} a\\}$.",
+      "The result is logically independent of the algebraic square identity $g^2 = \\pm q$ on the Gauss-sum side; it lives entirely on the orthogonality/equidistribution side and requires only that the total character sum vanishes."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every finite field $F$ of odd order $q$, the nonzero squares and the non-squares are machine-verified to be equinumerous, each class having exactly $(q-1)/2$ elements, with the count stated directly via $\\operatorname{IsSquare}$. The proof reads off Mathlib's vanishing quadratic-character sum together with quadraticity, with no axioms and no sorries. The prime case $F = \\mathbb{Z}/p$ recovers the parent verbatim.",
+    "implications": "Equidistribution of squares over $\\mathbb{F}_q$ is the input to counting points on conics and diagonal curves, to estimates for character and Gauss sums in the Weil-bound circle of ideas, and to the elementary $\\pm 1$ balance that makes finite-field character sums tractable. Deriving it over a general $\\mathbb{F}_q$ purely from orthogonality complements the parent's mod-$p$ count and the algebraic square identity of the Gauss-sum family.",
+    "openQuestions": [
+      "Does the same signed-indicator decomposition extend to higher-order multiplicative characters (cubic, quartic) to count the fibres of $x \\mapsto x^k$ over $\\mathbb{F}_q$ from the orthogonality relations of those characters?",
+      "Can the squaring-map kernel picture ($\\#\\text{squares} = (q-1)/\\gcd(2, q-1)$) be unified with the character-sum count to give a single statement valid in even characteristic, where every element is a square?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-02",
+      "relationship": "specializes",
+      "description": "The parent proves equidistribution of quadratic residues mod an odd prime p over ZMod p. This entry answers the parent's first open question by generalizing the identical mechanism to an arbitrary finite field F of odd order, and recasts the conclusion in terms of IsSquare; the prime case F = ZMod p recovers the parent."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "related",
+      "description": "The grandparent establishes the algebraic square identity g² = (-1)^((p-1)/2)·p for the quadratic Gauss sum. This entry develops the complementary orthogonality side — the vanishing character sum and its counting consequence — over a general finite field, independently of the square identity."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "Equidistribution of squares and non-squares in finite fields is part of the elementary theory of quadratic characters underlying quadratic reciprocity and Gauss-sum evaluations."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Equidistribution over an Arbitrary Finite Field",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Docstring framing the finite-field generalization: over a finite field F of odd order q, the quadratic character χ = quadraticChar F has vanishing total sum ∑ χ(a) = 0 (quadraticChar_sum_zero), and the nonzero squares and non-squares are equinumerous with (q−1)/2 elements each, stated via IsSquare. Notes the prime case F = ZMod p recovers the parent and the logical independence from the algebraic square identity. Imports Mathlib, opens BigOperators/Finset, opens the namespace with F a finite field. The lemma quadraticChar_sum_eq_zero re-exports quadraticChar_sum_zero taking ringChar F ≠ 2 directly."
+    },
+    {
+      "id": "filters-split",
+      "title": "Splitting the Sum into Filter Cardinalities",
+      "startLine": 53,
+      "endLine": 91,
+      "summary": "Defines the residues filter {a : χ(a) = 1} and nonresidues filter {a : χ(a) = −1} over univ. sum_eq_card_sub_card rewrites each summand χ(a) as the difference of Boolean indicators [χ(a)=1] − [χ(a)=−1] — valid because quadraticChar_isQuadratic says χ(a) ∈ {0,1,−1} — and applies Finset.sum_boole to obtain ∑ χ(a) = #residues − #nonresidues."
+    },
+    {
+      "id": "partition",
+      "title": "Equidistribution and the Nonzero Partition",
+      "startLine": 85,
+      "endLine": 123,
+      "summary": "card_residues_eq_card_nonresidues substitutes ∑ χ(a) = 0 into the signed count to force #residues = #nonresidues. card_residues_add_card_nonresidues shows the filters are disjoint (χ(a) cannot be both 1 and −1) and their union is exactly the nonzero elements (χ(a)=0 ⟺ a=0 via quadraticChar_eq_zero_iff), whose count is Fintype.card F − 1 via univ.erase 0 and Finset.card_erase_of_mem."
+    },
+    {
+      "id": "counts",
+      "title": "Each Class Has Exactly (q−1)/2 Elements",
+      "startLine": 125,
+      "endLine": 137,
+      "summary": "card_residues_eq and card_nonresidues_eq: two equal halves summing to q−1 give (q−1)/2 each, discharged by omega — the character-value form of the count over a general finite field."
+    },
+    {
+      "id": "is-square",
+      "title": "IsSquare-Phrased Counts",
+      "startLine": 139,
+      "endLine": 190,
+      "summary": "residues_eq_filter_isSquare identifies the residue filter with {a : a ≠ 0 ∧ IsSquare a} (via quadraticChar_one_iff_isSquare, with a ≠ 0 forced by χ(0)=0), and nonresidues_eq_filter_not_isSquare identifies the non-residue filter with {a : ¬ IsSquare a} (via quadraticChar_neg_one_iff_not_isSquare, with 0 excluded automatically). The main theorems card_nonzero_isSquare_eq, card_not_isSquare_eq, and card_nonzero_isSquare_eq_card_not_isSquare state the (q−1)/2 counts and their equality directly in terms of IsSquare."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `quadratic-gauss-sum-square-oq-02`: carry the vanishing-sum / quadraticity counting mechanism from `ZMod p` to an **arbitrary finite field $F$ of odd order $q = |F|$**.

From Mathlib's `quadraticChar_sum_zero` ($\sum_a \chi(a) = 0$ over $F$) the nonzero squares and the non-squares are equinumerous, each class of size $(q-1)/2$. The conclusion is phrased **directly via `IsSquare`** rather than character values — the substantive upgrade over the parent:

- `card_nonzero_isSquare_eq`: $\#\{a : a \neq 0 \wedge \operatorname{IsSquare} a\} = (q-1)/2$
- `card_not_isSquare_eq`: $\#\{a : \neg \operatorname{IsSquare} a\} = (q-1)/2$
- `card_nonzero_isSquare_eq_card_not_isSquare`: the two are equal

The prime case $F = \mathbb{Z}/p$ recovers the parent verbatim.

## Technique

Nothing in the mod-$p$ count used primality — only orthogonality ($\sum_a \chi(a) = 0$), quadraticity ($\chi(a) \in \{0,1,-1\}$ via `quadraticChar_isQuadratic`), and the zero-fibre lemma ($\chi(a)=0 \iff a=0$). Replacing `ZMod.card` by `Fintype.card F` and taking $\operatorname{ringChar} F \neq 2$ is the whole generalization. `quadraticChar_one_iff_isSquare` and `quadraticChar_neg_one_iff_not_isSquare` then translate the character-value filters into the `IsSquare` predicates.

## Verification

- **Status**: verified / 0-axiom / original
- 11 theorems, 2 definitions, 190 lines
- `#print axioms` on the three main theorems: only `propext`, `Classical.choice`, `Quot.sound` (foundational; not counted)
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- Compiles against Mathlib (Lean v4.26.0); gallery `annotations:build` registers the entry with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)