### PR TITLE
research(spectral-trace-det-eigenvalues-oq-02-oq-01): Frobenius trace form is a genuine inner product [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean
@@ -1,0 +1,163 @@
+import Mathlib
+
+/-!
+# The Frobenius trace form is a genuine inner product
+
+This entry answers the first open question recorded with the parent entry
+[`spectral-trace-det-eigenvalues-oq-02`] (cyclic invariance of the trace):
+
+> Prove the trace form `tr(Aᵀ · B) = Σ Aᵢⱼ Bᵢⱼ` is a *genuine* inner product — the
+> Frobenius / Hilbert–Schmidt inner product — on the space of real matrices.
+
+The point is that Mathlib does **not** equip `Matrix m n ℝ` with an inner product (nor
+even a default norm: its Frobenius norm lives in the *scoped* `def`s
+`Matrix.frobeniusNormedAddCommGroup` etc., deliberately kept out of instance resolution to
+avoid a norm diamond against the sup-norm).  So the inner-product structure is genuinely
+content to build, not a re-export.
+
+We define
+`frobInner A B := (Aᵀ * B).trace`
+and prove the full slate of inner-product axioms from first principles:
+
+* `frobInner_eq_sum` — the entrywise formula `⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ`;
+* `frobInner_comm` — **symmetry** `⟪A, B⟫ = ⟪B, A⟫`;
+* `frobInner_add_left` / `frobInner_add_right`,
+  `frobInner_smul_left` / `frobInner_smul_right` — **bilinearity**;
+* `frobInner_self_eq_sum_sq` — `⟪A, A⟫ = Σᵢⱼ Aᵢⱼ²`, the squared **Frobenius norm**;
+* `frobInner_self_nonneg` — positive semidefiniteness `0 ≤ ⟪A, A⟫`;
+* `frobInner_self_eq_zero_iff` — **positive definiteness** `⟪A, A⟫ = 0 ↔ A = 0`.
+
+These are then packaged into the bundled Mathlib certificate
+`frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ)`, whose mere existence *is* the formal
+statement that the Frobenius form is a genuine real inner product.  (The `Core` is the right
+certificate here precisely because `Matrix m n ℝ` carries no norm instance — one cannot even
+*state* `InnerProductSpace ℝ (Matrix m n ℝ)` without first committing to a norm, which is the
+very diamond Mathlib avoids; `InnerProductSpace.ofCore frobCore` would manufacture that norm.)
+We close by recording that the norm this inner product induces is exactly the Frobenius norm
+`√(Σ Aᵢⱼ²)` (`frob_sqrt_self_eq_frobenius_norm`).
+
+Singular-value content (relating the norm to `Σ σᵢ²`) is left out of scope, as flagged in
+the open question.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ02OQ01
+
+open Matrix Finset
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+
+/-- The **Frobenius (Hilbert–Schmidt) inner product** of two real matrices,
+`⟪A, B⟫ = tr(Aᵀ · B)`. -/
+def frobInner (A B : Matrix m n ℝ) : ℝ := (Aᵀ * B).trace
+
+/-- The entrywise formula: `⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ`. -/
+theorem frobInner_eq_sum (A B : Matrix m n ℝ) :
+    frobInner A B = ∑ i, ∑ j, A i j * B i j := by
+  unfold frobInner
+  simp only [trace, diag_apply, mul_apply, transpose_apply]
+  rw [Finset.sum_comm]
+
+/-- **Symmetry** of the Frobenius inner product. -/
+theorem frobInner_comm (A B : Matrix m n ℝ) : frobInner A B = frobInner B A := by
+  simp only [frobInner_eq_sum]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  ring
+
+/-! ### Bilinearity -/
+
+/-- Additivity in the first argument. -/
+theorem frobInner_add_left (A B C : Matrix m n ℝ) :
+    frobInner (A + B) C = frobInner A C + frobInner B C := by
+  simp only [frobInner_eq_sum, Matrix.add_apply, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  ring
+
+/-- Additivity in the second argument. -/
+theorem frobInner_add_right (A B C : Matrix m n ℝ) :
+    frobInner A (B + C) = frobInner A B + frobInner A C := by
+  rw [frobInner_comm, frobInner_add_left, frobInner_comm A B, frobInner_comm A C]
+
+/-- Homogeneity in the first argument. -/
+theorem frobInner_smul_left (r : ℝ) (A B : Matrix m n ℝ) :
+    frobInner (r • A) B = r * frobInner A B := by
+  simp only [frobInner_eq_sum, Matrix.smul_apply, smul_eq_mul, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun i _ => Finset.sum_congr rfl (fun j _ => ?_))
+  ring
+
+/-- Homogeneity in the second argument. -/
+theorem frobInner_smul_right (r : ℝ) (A B : Matrix m n ℝ) :
+    frobInner A (r • B) = r * frobInner A B := by
+  rw [frobInner_comm, frobInner_smul_left, frobInner_comm A B]
+
+/-! ### Positive definiteness -/
+
+/-- The induced quadratic form is the squared Frobenius norm `Σᵢⱼ Aᵢⱼ²`. -/
+theorem frobInner_self_eq_sum_sq (A : Matrix m n ℝ) :
+    frobInner A A = ∑ i, ∑ j, (A i j) ^ 2 := by
+  simp only [frobInner_eq_sum, sq]
+
+/-- **Positive semidefiniteness**: `0 ≤ ⟪A, A⟫`. -/
+theorem frobInner_self_nonneg (A : Matrix m n ℝ) : 0 ≤ frobInner A A := by
+  rw [frobInner_self_eq_sum_sq]
+  exact Finset.sum_nonneg (fun i _ => Finset.sum_nonneg (fun j _ => sq_nonneg _))
+
+/-- **Positive definiteness**: `⟪A, A⟫ = 0 ↔ A = 0`. -/
+theorem frobInner_self_eq_zero_iff (A : Matrix m n ℝ) :
+    frobInner A A = 0 ↔ A = 0 := by
+  rw [frobInner_self_eq_sum_sq]
+  constructor
+  · intro h
+    ext i j
+    have hi : ∀ i ∈ Finset.univ, (0 : ℝ) ≤ ∑ j, (A i j) ^ 2 :=
+      fun i _ => Finset.sum_nonneg (fun j _ => sq_nonneg _)
+    have h1 : ∑ j, (A i j) ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg hi).1 h i (Finset.mem_univ i)
+    have hj : ∀ j ∈ Finset.univ, (0 : ℝ) ≤ (A i j) ^ 2 := fun j _ => sq_nonneg _
+    have h2 : (A i j) ^ 2 = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonneg hj).1 h1 j (Finset.mem_univ j)
+    simpa using pow_eq_zero_iff (n := 2) (by norm_num) |>.1 h2
+  · intro h
+    subst h
+    simp
+
+/-! ### The bundled inner-product certificate -/
+
+/-- The Frobenius form, packaged as a Mathlib `InnerProductSpace.Core` over `ℝ`.  Its very
+existence certifies that `frobInner` satisfies *all* the inner-product axioms: Hermitian
+symmetry, positive semidefiniteness, additivity and homogeneity in the first slot, and
+positive definiteness. -/
+noncomputable def frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ) where
+  inner := frobInner
+  conj_inner_symm x y := by
+    simp only [RCLike.conj_to_real]
+    exact frobInner_comm y x
+  re_inner_nonneg x := by
+    simpa only [RCLike.re_to_real] using frobInner_self_nonneg x
+  add_left x y z := frobInner_add_left x y z
+  smul_left x y r := by
+    simp only [RCLike.conj_to_real]
+    exact frobInner_smul_left r x y
+  definite x hx := (frobInner_self_eq_zero_iff x).1 hx
+
+/-- The norm any inner-product space attaches to `⟪·,·⟫` is `√⟪A, A⟫`; here that is the
+**Frobenius norm** `√(Σᵢⱼ Aᵢⱼ²)`.  We record the radicand identity directly, independent of
+the inner-product-space norm plumbing. -/
+theorem frob_sqrt_self_eq_frobenius_norm (A : Matrix m n ℝ) :
+    Real.sqrt (frobInner A A) = Real.sqrt (∑ i, ∑ j, (A i j) ^ 2) := by
+  rw [frobInner_self_eq_sum_sq]
+
+/-! ### Sanity checks -/
+
+/-- Over `ℝ`, `⟪A, A⟫` for the `2×2` matrix `![![3, 4], ![0, 0]]` is `9 + 16 = 25`. -/
+example : frobInner (![![(3 : ℝ), 4], ![0, 0]] : Matrix (Fin 2) (Fin 2) ℝ)
+    (![![(3 : ℝ), 4], ![0, 0]]) = 25 := by
+  simp [frobInner_eq_sum, Fin.sum_univ_succ]
+  norm_num
+
+/-- Symmetry, on a concrete pair. -/
+example (A B : Matrix (Fin 2) (Fin 3) ℝ) : frobInner A B = frobInner B A :=
+  frobInner_comm A B
+
+end SpectralTraceDetEigenvaluesOQ02OQ01

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-spectraloq0201-1",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 43 },
+    "type": "context",
+    "title": "Why This Is Content, Not a Re-export",
+    "content": "**Module framing.** The parent entry proves cyclic invariance of the trace and asks whether the trace form ⟪A, B⟫ = tr(AᵀB) = Σ Aᵢⱼ Bᵢⱼ is a *genuine* inner product. The subtlety is that Mathlib equips `Matrix m n ℝ` with **no** inner product and **no** default norm: its Frobenius norm lives in the *scoped* defs `Matrix.frobeniusNormedAddCommGroup` etc., deliberately kept out of instance resolution to avoid a norm diamond against the entrywise sup-norm. So the inner-product structure is built here from first principles, and the right certificate is `InnerProductSpace.Core ℝ (Matrix m n ℝ)` — one cannot even *state* `InnerProductSpace ℝ (Matrix m n ℝ)` without first committing to a norm, the very diamond Mathlib avoids.",
+    "mathContext": "$\\langle A, B\\rangle = \\operatorname{tr}(A^{\\mathsf T} B) = \\sum_{i,j} A_{ij} B_{ij}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Frobenius / Hilbert–Schmidt inner product",
+      "Norm diamonds and scoped instances in Mathlib",
+      "Cyclic invariance of the trace (parent entry)"
+    ],
+    "prerequisites": [
+      "The trace of a matrix",
+      "Inner-product spaces over ℝ"
+    ],
+    "tags": ["module-header", "framing", "inner-product"]
+  },
+  {
+    "id": "ann-spectraloq0201-2",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "technique",
+    "title": "From the Trace to the Entrywise Pairing",
+    "content": "**The bridge lemma.** `frobInner A B := (Aᵀ * B).trace` is coordinate-free; every later property needs the entrywise form. Unfolding `trace`, `diag_apply`, `mul_apply`, `transpose_apply` turns ⟪A, B⟫ into ΣᵢΣⱼ Aᵢⱼ Bᵢⱼ after a single `Finset.sum_comm` to swap the order of summation. From this point on the proof never touches matrix multiplication again — symmetry, bilinearity, and definiteness all read off the double sum.",
+    "mathContext": "$\\operatorname{tr}(A^{\\mathsf T} B) = \\sum_i \\sum_j A_{ij} B_{ij}$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Matrix.trace and Matrix.mul_apply",
+      "Finset.sum_comm",
+      "Bilinear pairing"
+    ],
+    "prerequisites": ["The trace–product formula", "Double sums over Finset.univ"],
+    "tags": ["entrywise-formula", "engine", "trace"]
+  },
+  {
+    "id": "ann-spectraloq0201-3",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 62, "endLine": 92 },
+    "type": "technique",
+    "title": "Symmetry and Bilinearity by Reduction to ring",
+    "content": "**Term-by-term algebra.** With the entrywise formula in hand, symmetry ⟪A, B⟫ = ⟪B, A⟫ and additivity/homogeneity in the first slot reduce to a per-entry identity discharged by `ring` under nested `Finset.sum_congr`. The second-slot laws (`frobInner_add_right`, `frobInner_smul_right`) are *not* re-derived: they follow from the first-slot versions composed with `frobInner_comm`, mirroring how an inner product's right-linearity is conventionally obtained from left-linearity plus symmetry.",
+    "mathContext": "$\\langle rA + B, C\\rangle = r\\langle A, C\\rangle + \\langle B, C\\rangle,\\quad \\langle A, B\\rangle = \\langle B, A\\rangle$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bilinearity from left-linearity plus symmetry",
+      "Finset.sum_congr",
+      "ring tactic"
+    ],
+    "prerequisites": ["The entrywise formula", "Commutative-ring arithmetic"],
+    "tags": ["bilinearity", "symmetry", "ring"]
+  },
+  {
+    "id": "ann-spectraloq0201-4",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 94, "endLine": 123 },
+    "type": "key-step",
+    "title": "Positive Definiteness: the Only Non-formal Step",
+    "content": "**Sum of squares vanishes iff each entry does.** Specialising the pairing to ⟪A, A⟫ = Σᵢⱼ Aᵢⱼ² makes nonnegativity immediate (`Finset.sum_nonneg` of squares). Definiteness is the real content: from Σᵢⱼ Aᵢⱼ² = 0, apply `Finset.sum_eq_zero_iff_of_nonneg` over the rows to get Σⱼ Aᵢⱼ² = 0 for each i, then again over the columns to get Aᵢⱼ² = 0, then `pow_eq_zero_iff` to conclude Aᵢⱼ = 0 and `ext` to finish A = 0. This two-dimensional descent is exactly what distinguishes positive-*definiteness* from mere positive-semidefiniteness.",
+    "mathContext": "$\\langle A, A\\rangle = \\sum_{i,j} A_{ij}^2 = 0 \\iff A_{ij} = 0\\ \\forall i,j \\iff A = 0$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Finset.sum_eq_zero_iff_of_nonneg",
+      "Positive definiteness",
+      "pow_eq_zero_iff"
+    ],
+    "prerequisites": ["Sum-of-nonnegatives vanishing criterion", "Matrix extensionality"],
+    "tags": ["positive-definite", "key-step", "sum-of-squares"]
+  },
+  {
+    "id": "ann-spectraloq0201-5",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 125, "endLine": 150 },
+    "type": "key-step",
+    "title": "Packaging the Bundled Certificate",
+    "content": "**The existence of frobCore is the theorem.** `frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ)` collects the five structural fields — `conj_inner_symm`, `re_inner_nonneg`, `add_left`, `smul_left`, `definite` — each discharged by a lemma above (the Hermitian fields specialise to ℝ via `RCLike.conj_to_real` / `RCLike.re_to_real`). Because `Matrix m n ℝ` carries no norm instance, this `Core` is the cleanest possible formal assertion that frobInner is a genuine inner product: `InnerProductSpace.ofCore frobCore` would manufacture the induced norm on demand without committing the global instance graph to it.",
+    "mathContext": "$\\text{frobCore} : \\text{InnerProductSpace.Core}\\ \\mathbb{R}\\ (\\text{Matrix}\\ m\\ n\\ \\mathbb{R})$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "InnerProductSpace.Core",
+      "InnerProductSpace.ofCore",
+      "RCLike specialisation to ℝ"
+    ],
+    "prerequisites": ["The inner-product axioms above", "Bundled structures in Mathlib"],
+    "tags": ["core-certificate", "key-step", "inner-product-space"]
+  },
+  {
+    "id": "ann-spectraloq0201-6",
+    "proofId": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+    "range": { "startLine": 144, "endLine": 163 },
+    "type": "context",
+    "title": "The Induced Norm and Sanity Checks",
+    "content": "**Naming the Frobenius norm.** `frob_sqrt_self_eq_frobenius_norm` records √⟪A, A⟫ = √(Σᵢⱼ Aᵢⱼ²): the norm any inner-product space attaches to the form is exactly the Frobenius norm. The concrete checks make the structure tangible — ⟪A, A⟫ = 25 on `![![3,4],![0,0]]` is the 3-4-5 Pythagorean instance (9 + 16 = 25) of the Frobenius length, and symmetry holds on a rectangular 2×3 pair. The singular-value relation ‖A‖_F² = Σ σᵢ² is left out of scope, as the open question flags.",
+    "mathContext": "$\\sqrt{\\langle A, A\\rangle} = \\sqrt{\\textstyle\\sum_{i,j} A_{ij}^2} = \\lVert A\\rVert_F$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Frobenius norm",
+      "Singular values (out of scope)",
+      "Worked numeric witnesses"
+    ],
+    "prerequisites": ["Real.sqrt", "The squared-norm identity"],
+    "tags": ["frobenius-norm", "sanity-checks", "scope"]
+  }
+]

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOQ02OQ01Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOQ02OQ01Proof,
+  annotations: spectralTraceDetEigenvaluesOQ02OQ01Annotations,
+}

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+  "title": "The Frobenius Trace Form is a Genuine Inner Product",
+  "slug": "spectral-trace-det-eigenvalues-oq-02-oq-01",
+  "description": "Answers the first open question of the parent entry (cyclic invariance of the trace): the trace form ⟪A, B⟫ = tr(Aᵀ·B) = Σᵢⱼ Aᵢⱼ Bᵢⱼ on real matrices is a genuine inner product — the Frobenius / Hilbert–Schmidt inner product. This is real content rather than a re-export: Mathlib deliberately keeps the Frobenius norm out of instance resolution (the scoped Matrix.frobeniusNormedAddCommGroup etc.) to avoid a norm diamond against the sup-norm, so Matrix m n ℝ carries no inner-product (nor even a default norm) instance. We define frobInner A B := (Aᵀ * B).trace and prove the full slate of inner-product axioms from first principles: the entrywise formula, symmetry, additivity and homogeneity in each slot, the squared-Frobenius-norm identity ⟪A, A⟫ = Σ Aᵢⱼ², positive semidefiniteness, and positive definiteness ⟪A, A⟫ = 0 ↔ A = 0. These are packaged into the bundled Mathlib certificate frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ), whose mere existence is the formal statement that the form is a genuine real inner product (the Core is the right certificate precisely because the space carries no norm instance — one cannot even state InnerProductSpace ℝ (Matrix m n ℝ) without first committing to the very norm Mathlib avoids). The norm this inner product induces is exactly the Frobenius norm √(Σ Aᵢⱼ²). Singular-value content is out of scope, as flagged in the open question. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (Frobenius / Hilbert–Schmidt inner product); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_inner_product",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "matrix-theory",
+      "inner-product-space",
+      "frobenius-norm",
+      "hilbert-schmidt",
+      "trace",
+      "positive-definite",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.trace",
+        "description": "The trace tr(M) = Σᵢ Mᵢᵢ. The Frobenius inner product is defined as frobInner A B := (Aᵀ * B).trace; unfolding trace, diag, and mul_apply and commuting the double sum gives the entrywise formula Σᵢⱼ Aᵢⱼ Bᵢⱼ.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Trace"
+      },
+      {
+        "theorem": "InnerProductSpace.Core",
+        "description": "The bundled certificate of an inner product over an RCLike field: an inner map together with conjugate symmetry, nonnegativity, additivity and homogeneity in the first slot, and definiteness. frobCore instantiates this structure for ℝ, so its existence certifies that frobInner satisfies every inner-product axiom.",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "A finite sum of nonnegative reals is zero iff every term is zero. Applied twice (over rows, then columns) to turn ⟪A, A⟫ = Σ Aᵢⱼ² = 0 into Aᵢⱼ² = 0 for every entry, then pow_eq_zero_iff gives A = 0 — the positive-definiteness direction.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "frobInner: the Frobenius / Hilbert–Schmidt inner product ⟪A, B⟫ = tr(Aᵀ·B) on Matrix m n ℝ, defined where Mathlib provides no inner-product instance (the Frobenius norm is deliberately scoped out of instance resolution to avoid a norm diamond).",
+      "frobInner_eq_sum: the entrywise formula ⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ, obtained by unfolding the trace of Aᵀ·B and commuting the double sum — the bridge between the coordinate-free trace definition and the bilinear-pairing picture.",
+      "frobInner_comm: symmetry ⟪A, B⟫ = ⟪B, A⟫ from the entrywise formula.",
+      "frobInner_add_left / frobInner_add_right / frobInner_smul_left / frobInner_smul_right: full bilinearity in both slots.",
+      "frobInner_self_eq_sum_sq: the induced quadratic form is the squared Frobenius norm ⟪A, A⟫ = Σᵢⱼ Aᵢⱼ².",
+      "frobInner_self_nonneg: positive semidefiniteness 0 ≤ ⟪A, A⟫ as a sum of squares.",
+      "frobInner_self_eq_zero_iff: positive definiteness ⟪A, A⟫ = 0 ↔ A = 0, via two nested applications of Finset.sum_eq_zero_iff_of_nonneg.",
+      "frobCore: the bundled certificate InnerProductSpace.Core ℝ (Matrix m n ℝ) assembled from the axioms above — its existence IS the formal statement that the Frobenius form is a genuine real inner product, and it is the right certificate because the matrix space carries no norm instance to state InnerProductSpace directly.",
+      "frob_sqrt_self_eq_frobenius_norm: the radicand identity √⟪A, A⟫ = √(Σᵢⱼ Aᵢⱼ²), recording that the induced norm is exactly the Frobenius norm.",
+      "Concrete witnesses: ⟪A, A⟫ = 25 for ![![3,4],![0,0]] (= 9 + 16, the 3-4-5 Pythagorean instance of the Frobenius norm) and symmetry on a rectangular 2×3 pair."
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 163,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No native_decide is used, so Lean.ofReduceBool is not introduced. All results hold for arbitrary finite index types m, n and real entries; the inner-product Core is over ℝ.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Frobenius (or Hilbert–Schmidt) inner product ⟪A, B⟫ = tr(AᵀB) = Σ Aᵢⱼ Bᵢⱼ is the canonical inner product on the space of matrices: it is the Euclidean inner product under the obvious identification of an m×n matrix with a vector in ℝ^{mn}, and the norm it induces, the Frobenius norm √(Σ Aᵢⱼ²), is the most-used matrix norm after the operator norm. Its infinite-dimensional analogue, the Hilbert–Schmidt inner product on Hilbert–Schmidt operators, underlies trace-class theory and quantum information. The form is the natural companion to cyclic invariance of the trace from the parent entry: symmetry ⟪A, B⟫ = ⟪B, A⟫ is exactly tr(AᵀB) = tr(BᵀA), the trace-pairing read in two directions.",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-02, Q1)**: Prove the trace form tr(Aᵀ·B) = Σ Aᵢⱼ Bᵢⱼ is a *genuine* inner product — the Frobenius / Hilbert–Schmidt inner product — on the real matrices, and relate its induced norm to the singular values.\n\n**Result**: frobInner A B := tr(Aᵀ·B) is shown to satisfy every inner-product axiom from first principles (entrywise formula, symmetry, bilinearity, positive definiteness) and packaged as InnerProductSpace.Core ℝ (Matrix m n ℝ); the induced norm is identified as the Frobenius norm √(Σ Aᵢⱼ²). The singular-value relation (‖A‖_F² = Σ σᵢ²) is explicitly left out of scope, as flagged in the question.",
+    "text": "For real matrices A, B : Matrix m n ℝ over finite index types m, n, define ⟪A, B⟫ := tr(Aᵀ·B). Then ⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ, the form is symmetric and bilinear, ⟪A, A⟫ = Σᵢⱼ Aᵢⱼ² ≥ 0, and ⟪A, A⟫ = 0 iff A = 0. These are the axioms of a real inner product; bundling them gives InnerProductSpace.Core ℝ (Matrix m n ℝ), and the induced norm is the Frobenius norm √(Σ Aᵢⱼ²).",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Unfold frobInner A B = (Aᵀ * B).trace through trace, diag_apply, mul_apply, transpose_apply, and commute the resulting double sum to land on the entrywise formula Σᵢⱼ Aᵢⱼ Bᵢⱼ. Every later property is proved from this formula.\n\n2. Symmetry and bilinearity reduce, term by term, to ring identities on the entries: Finset.sum_congr down to each (i, j) and ring. Additivity and homogeneity in the second slot are obtained from the first slot by frobInner_comm rather than re-deriving them.\n\n3. Specialise to ⟪A, A⟫ = Σ Aᵢⱼ²; nonnegativity is Finset.sum_nonneg of squares.\n\n4. Definiteness: from Σ Aᵢⱼ² = 0, apply Finset.sum_eq_zero_iff_of_nonneg over rows then columns to force every Aᵢⱼ² = 0, then pow_eq_zero_iff to get Aᵢⱼ = 0, hence A = 0 by ext; the converse is simp after subst.\n\n5. Assemble the four structural fields (conj_inner_symm, re_inner_nonneg, add_left, smul_left, definite) into frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ), using RCLike.conj_to_real / RCLike.re_to_real to discharge the real specialisations of the Hermitian fields.\n\n6. Record √⟪A, A⟫ = √(Σ Aᵢⱼ²) to name the induced norm as the Frobenius norm.",
+    "keyInsights": [
+      "**This is genuine content, not a re-export.** Mathlib equips Matrix m n ℝ with no inner product and no default norm: the Frobenius norm lives in scoped defs (frobeniusNormedAddCommGroup) kept out of instance resolution to avoid a norm diamond against the sup-norm. So the inner-product structure must be built from scratch.",
+      "**The Core is the right certificate.** Because the space has no norm instance, one cannot even *state* InnerProductSpace ℝ (Matrix m n ℝ) without first committing to a norm — the very diamond Mathlib avoids. InnerProductSpace.Core packages all the inner-product axioms without forcing that choice, so its mere existence is the cleanest formal statement of the result.",
+      "**Symmetry is cyclic invariance of the trace, read twice.** ⟪A, B⟫ = ⟪B, A⟫ is tr(AᵀB) = tr(BᵀA) = Σ Aᵢⱼ Bᵢⱼ — the same bilinear trace-pairing that the parent entry studies as tr(AB) = tr(BA), now in the inner-product guise.",
+      "**Positive definiteness is the only non-formal step.** Bilinearity and symmetry are entrywise ring identities; the content is that a sum of squares vanishes iff each entry does, which needs Finset.sum_eq_zero_iff_of_nonneg applied across the two-dimensional index."
+    ],
+    "prerequisites": [
+      "The trace tr(M) = Σ Mᵢᵢ and the product formula (Aᵀ·B)ᵢⱼ entries",
+      "Finite sums over Finset.univ and the sum-of-nonnegatives vanishing criterion",
+      "Mathlib's InnerProductSpace.Core certificate and the RCLike specialisation to ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Frobenius Inner Product and its Entrywise Formula",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring explaining why Mathlib provides no inner-product instance on Matrix m n ℝ (scoped Frobenius norm, norm diamond); definition frobInner A B := (Aᵀ * B).trace; and frobInner_eq_sum, the entrywise formula ⟪A, B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ obtained by unfolding the trace and commuting the double sum.",
+      "mathContext": "$\\langle A, B\\rangle = \\operatorname{tr}(A^{\\mathsf T} B) = \\sum_{i,j} A_{ij} B_{ij}$."
+    },
+    {
+      "id": "bilinearity",
+      "title": "Symmetry and Bilinearity",
+      "startLine": 62,
+      "endLine": 92,
+      "summary": "frobInner_comm (symmetry), frobInner_add_left / frobInner_add_right (additivity), and frobInner_smul_left / frobInner_smul_right (homogeneity). All reduce through the entrywise formula to per-entry ring identities; the second-slot laws are derived from the first slot via symmetry.",
+      "mathContext": "$\\langle A, B\\rangle = \\langle B, A\\rangle,\\quad \\langle rA, B\\rangle = r\\langle A, B\\rangle$."
+    },
+    {
+      "id": "positive-definiteness",
+      "title": "Positive Definiteness",
+      "startLine": 94,
+      "endLine": 123,
+      "summary": "frobInner_self_eq_sum_sq (⟪A, A⟫ = Σ Aᵢⱼ²), frobInner_self_nonneg (sum of squares ≥ 0), and frobInner_self_eq_zero_iff (⟪A, A⟫ = 0 ↔ A = 0) via two nested applications of Finset.sum_eq_zero_iff_of_nonneg and pow_eq_zero_iff.",
+      "mathContext": "$\\langle A, A\\rangle = \\sum_{i,j} A_{ij}^2 = 0 \\iff A = 0$."
+    },
+    {
+      "id": "core-and-norm",
+      "title": "The Bundled Inner-Product Certificate and the Frobenius Norm",
+      "startLine": 125,
+      "endLine": 163,
+      "summary": "frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ) assembled from the axioms; frob_sqrt_self_eq_frobenius_norm identifying the induced norm √⟪A, A⟫ as the Frobenius norm √(Σ Aᵢⱼ²); and concrete sanity checks (⟪·,·⟫ = 25 on a 2×2 witness, symmetry on a 2×3 pair).",
+      "mathContext": "$\\text{frobCore} : \\text{InnerProductSpace.Core}\\ \\mathbb{R}\\ (\\text{Matrix}\\ m\\ n\\ \\mathbb{R})$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry on cyclic invariance of the trace, whose first open question — prove tr(AᵀB) = Σ Aᵢⱼ Bᵢⱼ is a genuine inner product — this entry answers. The parent's bilinear trace-pairing tr(AB) = tr(BA) becomes the symmetry axiom ⟪A, B⟫ = ⟪B, A⟫ here."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) construction of the Frobenius / Hilbert–Schmidt inner product ⟪A, B⟫ = tr(Aᵀ·B) on real matrices: the entrywise formula, symmetry, full bilinearity, the squared-Frobenius-norm identity, positive semidefiniteness, and positive definiteness, packaged into the bundled certificate InnerProductSpace.Core ℝ (Matrix m n ℝ) and with the induced norm identified as the Frobenius norm.",
+    "implications": "Supplies the inner-product structure Mathlib deliberately withholds from Matrix m n ℝ (to avoid a norm diamond), giving a usable certificate that the trace form is a genuine inner product. Answers the parent entry's first open question and exhibits symmetry of the form as cyclic invariance of the trace in inner-product clothing.",
+    "openQuestions": [
+      "Relate the induced Frobenius norm to the singular values: ‖A‖_F² = Σ σᵢ²(A), the part of the parent question deliberately left out of scope here, which would require Mathlib's singular-value decomposition or the eigenvalues of AᵀA.",
+      "Promote frobCore to a full InnerProductSpace ℝ (Matrix m n ℝ) instance via InnerProductSpace.ofCore and verify it agrees with the scoped Matrix.frobeniusNormedAddCommGroup norm, making the Cauchy–Schwarz inequality |tr(AᵀB)| ≤ ‖A‖_F ‖B‖_F available directly."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Finset"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ02OQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for the Frobenius inner product, the Frobenius norm, and its relation to the singular values."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Analysis.InnerProductSpace.Basic and Mathlib.LinearAlgebra.Matrix.Trace",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the InnerProductSpace.Core certificate and Matrix.trace used to build and package the Frobenius inner product."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry [`spectral-trace-det-eigenvalues-oq-02`](../tree/main/src/data/proofs/spectral-trace-det-eigenvalues-oq-02) (cyclic invariance of the trace):

> Prove the trace form `tr(Aᵀ·B) = Σ Aᵢⱼ Bᵢⱼ` is a *genuine* inner product — the Frobenius / Hilbert–Schmidt inner product — on the real matrices.

## Why this is content, not a re-export

Mathlib equips `Matrix m n ℝ` with **no** inner product and **no** default norm: its Frobenius norm lives in the *scoped* defs `Matrix.frobeniusNormedAddCommGroup` etc., deliberately kept out of instance resolution to avoid a norm diamond against the sup-norm. So the inner-product structure is built here from first principles, and the right certificate is `InnerProductSpace.Core ℝ (Matrix m n ℝ)` — one cannot even *state* `InnerProductSpace ℝ (Matrix m n ℝ)` without first committing to the very norm Mathlib avoids.

## What is proved

`frobInner A B := (Aᵀ * B).trace`, with the full inner-product slate from first principles:

- `frobInner_eq_sum` — entrywise formula `⟪A,B⟫ = Σᵢⱼ Aᵢⱼ Bᵢⱼ`
- `frobInner_comm` — symmetry
- `frobInner_add_left/right`, `frobInner_smul_left/right` — bilinearity in both slots
- `frobInner_self_eq_sum_sq` — `⟪A,A⟫ = Σ Aᵢⱼ²` (squared Frobenius norm)
- `frobInner_self_nonneg` — positive semidefiniteness
- `frobInner_self_eq_zero_iff` — positive definiteness `⟪A,A⟫ = 0 ↔ A = 0`
- `frobCore : InnerProductSpace.Core ℝ (Matrix m n ℝ)` — the bundled certificate
- `frob_sqrt_self_eq_frobenius_norm` — induced norm is the Frobenius norm `√(Σ Aᵢⱼ²)`

Singular-value content (`‖A‖_F² = Σ σᵢ²`) is left out of scope, as the open question flags.

## Verification

- **10 theorems, 2 definitions, 163 lines**
- `status: verified`, `badge: original`, **0 sorries, 0 axioms**
- `#print axioms` lists only foundational `propext / Classical.choice / Quot.sound` (which do not count); no `native_decide`, so no `Lean.ofReduceBool`
- Builds against Mathlib v4.26.0
- Gallery `annotations:build` validates the entry clean (meta.json + 6 annotations + index.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)