### PR TITLE
Enrich 'The Minimum Collision Number is Exactly 2': index.ts + annotations + sections

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 7, "endLine": 48 },
+    "type": "context",
+    "title": "Question, answer, and the combinatorial caveat",
+    "content": "The docstring frames the parent's second open question — the actual minimum of collidingCubes.card — and answers it: exactly 2, as an IsLeast statement. It records the two ingredients (the OQ-01 lower bound ≥ 2 and the OQ-01-OQ-01 achievability witness = 2), promises a third three-cube witness to show the spectrum is nontrivial, and states the honesty caveat: because CubeDissection carries `covers_unit_cube : True` as a placeholder for the real 3D tiling constraint, every result is about the COMBINATORIAL model (containment + interior-disjointness), and the lower-bound half inherits one base axiom.",
+    "mathContext": "Goal: $\\min \\{\\,|\\mathrm{collidingCubes}(d)| : d \\text{ nonempty}\\,\\} = 2$, i.e. $\\mathrm{IsLeast}\\;\\mathrm{collisionSpectrum}\\;2$.",
+    "significance": "context",
+    "relatedConcepts": ["squaring the square", "Wiedijk #82", "combinatorial vs geometric model", "interior-disjointness"],
+    "prerequisites": ["cube dissection model", "Littlewood cascade argument"]
+  },
+  {
+    "id": "ann-spectrum-def",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 64 },
+    "type": "definition",
+    "title": "The collision spectrum",
+    "content": "Defines collisionSpectrum ⊆ ℕ as the set of collision counts realized by some nonempty cube dissection. Phrasing the 'set of attainable values' as an explicit subset of ℕ is the move that lets the minimum be expressed order-theoretically as a least element / infimum, rather than as an ad-hoc pair of inequalities.",
+    "mathContext": "$\\mathrm{collisionSpectrum} = \\{\\, n \\mid \\exists d,\\ d.\\mathrm{cubes} \\ne \\emptyset \\wedge |\\mathrm{collidingCubes}(d)| = n \\,\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["attainable set", "subset of ℕ", "extremal combinatorics"],
+    "prerequisites": ["set-builder notation", "Finset cardinality"]
+  },
+  {
+    "id": "ann-membership-lower",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 66, "endLine": 73 },
+    "type": "technique",
+    "title": "2 is attained; every value is ≥ 2",
+    "content": "Two halves of the IsLeast claim. `two_mem_collisionSpectrum` packages the sibling achievability witness (exampleDissection of OQ-01-OQ-01) as a spectrum membership. `collisionSpectrum_lower_bound` destructs an arbitrary spectrum element with `rintro ⟨d, hne, rfl⟩` and applies the OQ-01 base lemma `at_least_two_colliding_cubes`. The `rfl` pattern substitutes n by the actual card, so the goal becomes the lower bound directly.",
+    "mathContext": "$2 \\in \\mathrm{collisionSpectrum}$ via the explicit witness; $\\forall n \\in \\mathrm{collisionSpectrum},\\ 2 \\le n$ via $|\\mathrm{collidingCubes}(d)| \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lower bound", "existential witness", "rintro destructuring"],
+    "prerequisites": ["at_least_two_colliding_cubes (OQ-01)", "achievability witness (OQ-01-OQ-01)"]
+  },
+  {
+    "id": "ann-isleast",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "insight",
+    "title": "The minimum is exactly 2 — IsLeast and sInf",
+    "content": "The headline. `isLeast_collisionSpectrum` is just the pair ⟨membership, lower bound⟩ — the literal definition of IsLeast (the value lies in the set and bounds it below). `sInf_collisionSpectrum` then converts the least element into the infimum via `IsLeast.csInf_eq`, valid because ℕ is a conditionally complete lattice. `minimum_collision_count_is_two` restates the same content without the order-theory vocabulary — useful for readers who want the bare 'attainable + bounded' form.",
+    "mathContext": "$\\mathrm{IsLeast}\\;S\\;2 \\equiv (2 \\in S) \\wedge (\\forall x \\in S,\\ 2 \\le x)$; hence $\\inf S = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["IsLeast", "infimum", "conditionally complete lattice", "least element"],
+    "prerequisites": ["order theory", "sInf in ℕ"]
+  },
+  {
+    "id": "ann-exclusions",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 111 },
+    "type": "technique",
+    "title": "0 and 1 are impossible",
+    "content": "Corollaries that 0 and 1 are not in the spectrum: assume membership, derive the ≥ 2 lower bound for that value, and let `omega` close the arithmetic contradiction (0 ≥ 2 and 1 ≥ 2 are both false). This makes the sharpness of the minimum explicit — collisions genuinely come in pairs, so a single colliding cube can never occur.",
+    "mathContext": "$0 \\notin S$ and $1 \\notin S$ because $n \\in S \\Rightarrow n \\ge 2$, contradicting $n \\in \\{0,1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof by contradiction", "omega", "sharpness"],
+    "prerequisites": ["linear arithmetic over ℕ"]
+  },
+  {
+    "id": "ann-cubeD-construction",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 128, "endLine": 194 },
+    "type": "definition",
+    "title": "A third cube: building the three-cube dissection",
+    "content": "To prove the spectrum is more than the singleton {2}, a new cube `cubeD` at (1/4,0,0) with side 1/4 is dropped between the existing cubeA (x=0) and cubeB (x=1/2). The block establishes its containment, distinctness (differing x-coordinates), and pairwise interior-disjointness — boundary-touching is allowed, so A|D meet at x=1/4 and D|B at x=1/2 without overlapping interiors. `triDissection` then assembles {A,B,D} into a valid CubeDissection, discharging `covers_unit_cube` trivially since it is the `True` placeholder.",
+    "mathContext": "Three equal cubes of side $1/4$ at $x = 0, \\tfrac14, \\tfrac12$: $A.x + A.\\mathrm{side} = \\tfrac14 \\le D.x$ and $D.x + D.\\mathrm{side} = \\tfrac12 \\le B.x$ give interior-disjointness.",
+    "significance": "supporting",
+    "relatedConcepts": ["explicit construction", "interior-disjointness", "boundary touching", "structure instance"],
+    "prerequisites": ["Cube/CubeDissection definitions", "norm_num"]
+  },
+  {
+    "id": "ann-three-collisions",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 206, "endLine": 250 },
+    "type": "technique",
+    "title": "All three collide ⟹ card 3 ⟹ 3 in the spectrum",
+    "content": "Each of A, B, D has an equal-size (1/4) partner among the others, so all three lie in collidingCubes (via the filter characterization `mem_collidingCubes_tri_iff`). `colliding_eq_tri` proves collidingCubes triDissection = {A,B,D} by antisymmetric subset inclusion, and `tri_has_three_collisions` computes the cardinality 3 using `Finset.card_insert_of_not_mem` + `Finset.card_pair` (the distinctness lemmas feed the not-mem side conditions). `three_mem_collisionSpectrum` then witnesses 3 ∈ spectrum.",
+    "mathContext": "$\\mathrm{collidingCubes}(\\mathrm{triDissection}) = \\{A,B,D\\}$, $|\\{A,B,D\\}| = 3$ (all distinct), so $3 \\in \\mathrm{collisionSpectrum}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_insert_of_not_mem", "Finset.card_pair", "antisymmetry of subset", "filter membership"],
+    "prerequisites": ["Finset cardinality", "collidingCubes filter definition"]
+  },
+  {
+    "id": "ann-nontrivial",
+    "proofId": "dissection-of-cubes-oq-01-oq-02",
+    "range": { "startLine": 252, "endLine": 261 },
+    "type": "insight",
+    "title": "2 is the bottom of a genuine spectrum",
+    "content": "The closing theorem combines everything: {2,3} ⊆ collisionSpectrum AND IsLeast collisionSpectrum 2. This certifies that 2 is not the only attainable value — it is the genuine minimum of a set that also contains 3 — so the 'minimum is 2' result is a real extremal boundary rather than a degenerate single-point set. The first open question (whether every n ≥ 2 is attainable) is left for future work.",
+    "mathContext": "$\\{2,3\\} \\subseteq \\mathrm{collisionSpectrum} \\wedge \\mathrm{IsLeast}\\;\\mathrm{collisionSpectrum}\\;2$.",
+    "significance": "key",
+    "relatedConcepts": ["extremal value", "nontrivial spectrum", "subset inclusion"],
+    "prerequisites": ["IsLeast", "set membership"]
+  }
+]

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/index.ts
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DissectionOfCubesOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const dissectionOfCubesOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const dissectionOfCubesOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const dissectionOfCubesOQ01OQ02Data: ProofData = {
+  proof: dissectionOfCubesOQ01OQ02Proof,
+  annotations: dissectionOfCubesOQ01OQ02Annotations,
+}

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-02/meta.json
@@ -90,6 +90,40 @@
    "DissectionOfCubesOQ01OQ01 (achievability witness, cube constructions)"
   ]
  },
+ "sections": [
+  {
+   "id": "sec-docstring",
+   "title": "Question, Answer, and Caveat",
+   "startLine": 7,
+   "endLine": 48,
+   "summary": "Docstring framing the parent OQ-01 item 2 (the actual minimum of collidingCubes.card), stating the answer 2 as IsLeast, naming the lower-bound and achievability ingredients, promising a third witness for nontriviality, and recording the combinatorial caveat that covers_unit_cube is the True placeholder so the lower-bound half inherits one base axiom.",
+   "mathContext": "$\\min\\{|\\mathrm{collidingCubes}(d)|\\} = 2$, i.e. $\\mathrm{IsLeast}\\;\\mathrm{collisionSpectrum}\\;2$."
+  },
+  {
+   "id": "sec-spectrum",
+   "title": "The Collision Spectrum",
+   "startLine": 56,
+   "endLine": 73,
+   "summary": "Defines collisionSpectrum := { n | ∃ nonempty dissection with collidingCubes.card = n }. Proves 2 ∈ spectrum via the OQ-01-OQ-01 achievability witness, and that every spectrum element is ≥ 2 via the OQ-01 lower bound at_least_two_colliding_cubes.",
+   "mathContext": "$\\mathrm{collisionSpectrum} = \\{n \\mid \\exists d,\\ d.\\mathrm{cubes}\\ne\\emptyset \\wedge |\\mathrm{collidingCubes}(d)| = n\\}$."
+  },
+  {
+   "id": "sec-minimum",
+   "title": "The Minimum is Exactly 2",
+   "startLine": 75,
+   "endLine": 111,
+   "summary": "isLeast_collisionSpectrum = ⟨membership, lower bound⟩; sInf_collisionSpectrum via IsLeast.csInf_eq; minimum_collision_count_is_two as the bare attainable+bounded form; zero_not_mem and one_not_mem ruling out 0 and 1 by omega against the ≥ 2 bound.",
+   "mathContext": "$\\mathrm{IsLeast}\\;S\\;2 \\equiv (2\\in S)\\wedge(\\forall x\\in S,\\ 2\\le x) \\Rightarrow \\inf S = 2$; $0,1 \\notin S$."
+  },
+  {
+   "id": "sec-third-witness",
+   "title": "A Third Witness — The Spectrum is Nontrivial",
+   "startLine": 113,
+   "endLine": 263,
+   "summary": "Adds cubeD at (1/4,0,0) side 1/4 between cubeA and cubeB, with containment, distinctness and interior-disjointness lemmas; assembles triDissection = {A,B,D}; shows all three collide (equal size 1/4), computes card = 3 via card_insert_of_not_mem + card_pair, gives 3 ∈ collisionSpectrum, and concludes collisionSpectrum_nontrivial: {2,3} ⊆ spectrum with 2 least.",
+   "mathContext": "Three cubes of side $1/4$ at $x=0,\\tfrac14,\\tfrac12$ all collide $\\Rightarrow |\\mathrm{collidingCubes}|=3$, so $\\{2,3\\}\\subseteq\\mathrm{collisionSpectrum}$."
+  }
+ ],
  "conclusion": {
   "summary": "The minimum collision number over all nonempty (combinatorial) cube dissections is exactly 2: IsLeast collisionSpectrum 2, equivalently sInf collisionSpectrum = 2. Neither 0 nor 1 is attainable. A second three-cube construction shows 3 is also attainable, so 2 is the genuine bottom of a nontrivial spectrum rather than its only value.",
   "implications": "**Sharp answer to OQ-01 item 2**: the parent left the minimum collidingCubes.card open with only a lower bound of 2; combining the sibling achievability result yields the exact value via the canonical IsLeast/sInf packaging. **Combinatorial vs geometric**: the achievability half is fully axiom-free, isolating the single inherited base axiom (all_different_implies_long_chains_axiom) as the only place where the unformalized 3D covering argument enters. The genuine geometric minimum — whether Littlewood's cascade forces strictly more than 2 once covers_unit_cube is replaced by a real covering predicate — remains open.",


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-02` (quality 32, 0 prior passes).

## Gaps addressed
The entry had **only meta.json** — both `index.ts` and `annotations.json` were missing, and meta.json had no `sections` array.

1. **Created `index.ts`** (REQUIRED) — without it the proof page renders 'proof not found' on the live site despite appearing in the gallery listing.
2. **Added `annotations.json`** with **8 annotations** spanning the full Lean file (docstring/caveat, spectrum definition, membership + lower bound, IsLeast/sInf, the 0/1 exclusions, the cubeD construction, the three-collision count, and the nontriviality theorem). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
3. **Added a `sections` array** to meta.json covering all four source sections with summaries and `mathContext`.

## Verification
- meta.json and annotations.json validate as JSON; `pnpm build` passes end-to-end (annotations:build, research:build, research:enrich, tsc, vite).
- Axiom integrity preserved: meta already declares `status: axiomatized`, `badge: axiom`, `axiomCount: 1` (the inherited `all_different_implies_long_chains_axiom` from the Wiedijk #82 base, with `covers_unit_cube : True` placeholder disclosed). No status/badge/axiom claims were changed.