### PR TITLE
research(connected-space-oq-01-oq-02): the topologist's sine curve is connected [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/ConnectedSpaceOQ01OQ02.lean
+++ b/proofs/Proofs/ConnectedSpaceOQ01OQ02.lean
@@ -1,0 +1,104 @@
+import Mathlib
+
+/-!
+# The topologist's sine curve is connected
+
+The parent entry `ConnectedSpaceOQ01.lean` proves that connectedness is stable under
+closure — and, sharper, that *any* set wedged between a connected set and its closure is
+connected (`connected_of_subset_closure`: if `s` is connected and `s ⊆ t ⊆ closure s`,
+then `t` is connected). Its open question asks to **use that "bark and tree" corollary on a
+concrete space built from a dense connected skeleton.**
+
+This entry supplies the canonical example: the **topologist's sine curve**
+
+`T = { (x, sin x⁻¹) : x > 0 } ∪ ( {0} × [−1, 1] )`,
+
+the textbook witness of a space that is connected but not path-connected. We formalize the
+connectedness half — exactly the consequence the parent's corollary delivers.
+
+## Strategy
+
+* `sineCurve = (fun x => (x, sin x⁻¹)) '' Ioi 0` is the graph over the positive reals. It is
+  the continuous image of the connected set `Ioi 0`, hence **connected**
+  (`isConnected_sineCurve`).
+* The limit segment `{0} × [−1, 1]` lies in the **closure** of the graph
+  (`limitSegment_subset_closure`): given `y ∈ [−1, 1]`, the points
+  `(aₙ⁻¹, sin aₙ)` with `aₙ = arcsin y + n·2π` satisfy `sin aₙ = y` (periodicity +
+  `sin (arcsin y) = y`) and `aₙ⁻¹ → 0`, so `(0, y)` is a limit of graph points.
+* Therefore `sineCurve ⊆ T ⊆ closure sineCurve`, and the parent's "bark and tree" corollary
+  (here `IsConnected.subset_closure`) gives `IsConnected T` (`isConnected_topologistSineCurve`).
+
+Path-connectedness *fails* for `T` (no path joins the segment to the oscillating graph); that
+is recorded as a follow-up question, not formalized here.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace ConnectedSpaceOQ01OQ02
+
+open Set Topology Real
+
+/-- The graph of `x ↦ sin x⁻¹` over the positive reals — the oscillating part of the curve. -/
+def sineCurve : Set (ℝ × ℝ) := (fun x : ℝ => (x, Real.sin x⁻¹)) '' Set.Ioi 0
+
+/-- The limit segment `{0} × [−1, 1]` that the graph accumulates onto. -/
+def limitSegment : Set (ℝ × ℝ) := {0} ×ˢ Set.Icc (-1) 1
+
+/-- The **topologist's sine curve**: the graph together with its limit segment. -/
+def topologistSineCurve : Set (ℝ × ℝ) := sineCurve ∪ limitSegment
+
+/-- The parametrization `x ↦ (x, sin x⁻¹)` is continuous on `Ioi 0` (away from the
+singularity of `x⁻¹` at `0`). -/
+theorem continuousOn_param :
+    ContinuousOn (fun x : ℝ => (x, Real.sin x⁻¹)) (Set.Ioi 0) := by
+  have hinv : ContinuousOn (fun x : ℝ => x⁻¹) (Set.Ioi 0) :=
+    continuousOn_id.inv₀ (fun x hx => ne_of_gt (Set.mem_Ioi.mp hx))
+  exact continuousOn_id.prodMk (Real.continuous_sin.comp_continuousOn hinv)
+
+/-- **The graph is connected**, being the continuous image of the connected set `Ioi 0`. -/
+theorem isConnected_sineCurve : IsConnected sineCurve :=
+  isConnected_Ioi.image _ continuousOn_param
+
+/-- **The limit segment lies in the closure of the graph.** For `(0, y)` with `y ∈ [−1, 1]`,
+the graph points `(aₙ⁻¹, sin aₙ)` with `aₙ = arcsin y + n·2π` have second coordinate `y`
+(periodicity of `sin` plus `sin (arcsin y) = y`) and first coordinate `aₙ⁻¹ → 0`. -/
+theorem limitSegment_subset_closure : limitSegment ⊆ closure sineCurve := by
+  rintro p hp
+  obtain ⟨hp1, hp2⟩ := hp
+  rw [Set.mem_singleton_iff] at hp1
+  obtain ⟨hy1, hy2⟩ := hp2
+  rw [Metric.mem_closure_iff]
+  intro ε hε
+  set θ := Real.arcsin p.2 with hθ
+  have hθlb : -(π / 2) ≤ θ := (Real.arcsin_mem_Icc p.2).1
+  have hpi : (0 : ℝ) < 2 * π := by positivity
+  obtain ⟨n, hn⟩ := exists_nat_gt ((ε⁻¹ + π / 2 + 1) / (2 * π))
+  rw [div_lt_iff₀ hpi] at hn
+  set a := θ + (n : ℝ) * (2 * π) with ha_def
+  have ha_big : ε⁻¹ < a := by rw [ha_def]; linarith [hθlb, hn]
+  have ha_pos : 0 < a := lt_trans (inv_pos.mpr hε) ha_big
+  have hx_pos : 0 < a⁻¹ := inv_pos.mpr ha_pos
+  refine ⟨(a⁻¹, Real.sin (a⁻¹)⁻¹), ⟨a⁻¹, Set.mem_Ioi.mpr hx_pos, rfl⟩, ?_⟩
+  have hsin : Real.sin (a⁻¹)⁻¹ = p.2 := by
+    rw [inv_inv, ha_def, Real.sin_add_nat_mul_two_pi, hθ, Real.sin_arcsin hy1 hy2]
+  rw [hsin, Prod.dist_eq]
+  have h1 : dist p.1 a⁻¹ = a⁻¹ := by
+    rw [hp1, Real.dist_eq, zero_sub, abs_neg, abs_of_pos hx_pos]
+  rw [h1, dist_self, max_eq_left (le_of_lt hx_pos)]
+  exact (inv_lt_comm₀ ha_pos hε).mpr ha_big
+
+/-- **The topologist's sine curve is connected.** It is sandwiched between the connected
+graph and the graph's closure, so the parent's "bark and tree" corollary applies. -/
+theorem isConnected_topologistSineCurve : IsConnected topologistSineCurve := by
+  have hsub : topologistSineCurve ⊆ closure sineCurve := by
+    unfold topologistSineCurve
+    rw [union_subset_iff]
+    exact ⟨subset_closure, limitSegment_subset_closure⟩
+  have hsk : sineCurve ⊆ topologistSineCurve := Set.subset_union_left
+  exact isConnected_sineCurve.subset_closure hsk hsub
+
+/-- The topologist's sine curve is in particular **preconnected**. -/
+theorem isPreconnected_topologistSineCurve : IsPreconnected topologistSineCurve :=
+  isConnected_topologistSineCurve.isPreconnected
+
+end ConnectedSpaceOQ01OQ02

--- a/research/problems/connected-space-oq-01-oq-02/knowledge.md
+++ b/research/problems/connected-space-oq-01-oq-02/knowledge.md
@@ -1,0 +1,46 @@
+# connected-space-oq-01-oq-02 — The Topologist's Sine Curve Is Connected
+
+**Status:** COMPLETED (verified, 0 sorries, 0 axioms, original)
+**Lean file:** `proofs/Proofs/ConnectedSpaceOQ01OQ02.lean`
+**Answers:** parent `connected-space-oq-01` second open question (use the bark-and-tree
+corollary on a concrete dense-connected-skeleton space).
+
+## Summary
+
+Formalized T = {(x, sin x⁻¹) : x > 0} ∪ ({0} × [−1,1]) in ℝ × ℝ and proved `IsConnected T`.
+Graph G = continuous image of `Ioi 0` ⇒ connected; limit segment ⊆ closure G; then the
+parent's `IsConnected.subset_closure` (bark and tree) on G ⊆ T ⊆ closure G closes it.
+
+## Session 2026-06-24 (Session 1) — FRESH
+
+**Mode:** FRESH · **Outcome:** completed
+
+### What I Did
+- Defined sineCurve / limitSegment / topologistSineCurve.
+- isConnected_sineCurve via isConnected_Ioi.image + continuousOn_param.
+- limitSegment_subset_closure: the meat — Metric.mem_closure_iff + approximants
+  aₙ = arcsin y + n·2π giving sin aₙ = y exactly (periodicity + sin_arcsin), aₙ⁻¹ → 0.
+- isConnected_topologistSineCurve via IsConnected.subset_closure.
+- Built clean on host `lake env lean` (docker down); axiom-checked → only foundational.
+
+### Key Findings / gotchas
+- Pairing continuous functions on a set: `ContinuousOn.prodMk` (NOT `.prod`).
+- `inv_lt_comm₀ (0<a) (0<b) : a⁻¹ < b ↔ b⁻¹ < a` turns ε⁻¹ < aₙ into aₙ⁻¹ < ε.
+- `div_lt_iff₀` (not `div_lt_iff`) on current Mathlib.
+- Unfold the `def topologistSineCurve` (`unfold`) before `rw [union_subset_iff]`.
+- Product distance to a same-second-coordinate point collapses to first coord via Prod.dist_eq.
+- The approximation is EXACT in the y-coordinate (sin hits y on the nose every period); only
+  the x-coordinate needs a limit, so closure membership is a one-axis Archimedean estimate.
+
+### Files Modified
+- `proofs/Proofs/ConnectedSpaceOQ01OQ02.lean` (new, 104 lines, 5 thm / 3 def)
+- `src/data/proofs/connected-space-oq-01-oq-02/{meta,annotations,index}`
+
+### Next Steps (follow-up open questions)
+- Formalize NOT path-connected (the interesting half; needs a no-path argument).
+- Local connectedness failure at the segment; closed-curve path-connected variant.
+
+### Note
+- This session also lost a race on fibonacci-identities-oq-05-oq-03 (already shipped to main
+  as PR #29493 while I was building an identical proof). Pool "available" is stale; now I
+  check origin/main + worktrees before claiming. See memory.

--- a/src/data/proofs/connected-space-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/connected-space-oq-01-oq-02/annotations.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "ann-connoq0102-1",
+    "proofId": "connected-space-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 35 },
+    "type": "context",
+    "title": "A Concrete Dense-Skeleton Space",
+    "content": "**Module framing.** The parent entry proves that connectedness survives closure, and the sharper 'bark and tree' corollary: any set $t$ with $s \\subseteq t \\subseteq \\overline{s}$ for connected $s$ is itself connected. Its open question asks to deploy this on a concrete space built from a dense connected skeleton. The canonical such space is the **topologist's sine curve** $T = \\{(x, \\sin x^{-1}) : x > 0\\} \\cup (\\{0\\} \\times [-1,1])$ — the textbook witness that *connected* does not imply *path-connected*. This file formalizes the connectedness half, exactly what the corollary delivers.",
+    "mathContext": "$T = \\{(x, \\sin x^{-1}) : x > 0\\} \\cup (\\{0\\} \\times [-1,1])$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Closure-stability of connectedness (parent entry)",
+      "Bark-and-tree corollary IsConnected.subset_closure",
+      "Connected vs path-connected"
+    ],
+    "prerequisites": [
+      "Connectedness and the closure operator",
+      "The graph of an oscillatory function near a singularity"
+    ],
+    "tags": ["module-header", "framing", "topology"]
+  },
+  {
+    "id": "ann-connoq0102-2",
+    "proofId": "connected-space-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 63 },
+    "type": "technique",
+    "title": "The Graph Is a Connected Skeleton",
+    "content": "**Continuous image of a ray.** The oscillating graph $G = \\{(x, \\sin x^{-1}) : x > 0\\}$ is the image of the connected ray $(0,\\infty)$ (`isConnected_Ioi`) under the parametrization $x \\mapsto (x, \\sin x^{-1})$, which is continuous on $(0,\\infty)$ — there $x^{-1}$ is continuous (`ContinuousOn.inv₀`, since $x \\neq 0$), $\\sin$ is continuous, and the pairing is `ContinuousOn.prodMk`. By `IsConnected.image`, $G$ is connected. This is the dense skeleton the rest of the argument hangs on.",
+    "mathContext": "$G = (x \\mapsto (x,\\sin x^{-1}))(\\,(0,\\infty)\\,)$ is connected.",
+    "significance": "foundational",
+    "relatedConcepts": ["Continuous image of connected is connected", "Continuity away from a singularity"],
+    "prerequisites": ["isConnected_Ioi", "IsConnected.image", "ContinuousOn.inv₀"],
+    "tags": ["connectedness", "continuous-image"]
+  },
+  {
+    "id": "ann-connoq0102-3",
+    "proofId": "connected-space-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 90 },
+    "type": "key-step",
+    "title": "The Segment Lies in the Closure",
+    "content": "**Exact-height approximants.** The heart of the proof: every $(0,y)$ with $y \\in [-1,1]$ is a limit of graph points. Set $a_n = \\arcsin y + n\\cdot 2\\pi$; then $\\sin a_n = \\sin(\\arcsin y) = y$ *exactly* (2π-periodicity via `Real.sin_add_nat_mul_two_pi`, plus `Real.sin_arcsin`), and $a_n > 0$ because $\\arcsin y \\ge -\\pi/2$ (`Real.arcsin_mem_Icc`). So $(a_n^{-1}, \\sin a_n) = (a_n^{-1}, y)$, and an Archimedean choice (`exists_nat_gt`) makes $a_n^{-1} < \\varepsilon$. The product distance to $(0,y)$ collapses (`Prod.dist_eq`, second coordinate equal) to $a_n^{-1}$, which is $< \\varepsilon$ by `inv_lt_comm₀`. `Metric.mem_closure_iff` then places $(0,y)$ in $\\overline{G}$.",
+    "mathContext": "$(0,y) = \\lim_n (a_n^{-1}, y)$, $a_n = \\arcsin y + 2\\pi n$.",
+    "significance": "foundational",
+    "relatedConcepts": ["ε-characterization of closure", "2π-periodicity of sin", "Archimedean property", "Product metric"],
+    "prerequisites": ["Metric.mem_closure_iff", "Real.sin_add_nat_mul_two_pi", "Real.sin_arcsin", "inv_lt_comm₀"],
+    "tags": ["closure", "approximation", "main-step"]
+  },
+  {
+    "id": "ann-connoq0102-4",
+    "proofId": "connected-space-oq-01-oq-02",
+    "range": { "startLine": 92, "endLine": 104 },
+    "type": "result",
+    "title": "Connectedness via Bark and Tree",
+    "content": "**Closing the argument.** With $G$ connected and $G \\subseteq T \\subseteq \\overline{G}$ (the first inclusion trivial, the second from `subset_closure` on the graph and the segment-in-closure step), the parent's bark-and-tree corollary `IsConnected.subset_closure` gives `IsConnected T` directly — no separation argument needed. `isPreconnected_topologistSineCurve` records the preconnected consequence. Path-connectedness, by contrast, fails for $T$ (left as a follow-up).",
+    "mathContext": "$G \\subseteq T \\subseteq \\overline{G} \\Rightarrow T \\text{ connected}$.",
+    "significance": "foundational",
+    "relatedConcepts": ["Bark-and-tree corollary", "Connected but not path-connected"],
+    "prerequisites": ["IsConnected.subset_closure", "subset_closure"],
+    "tags": ["result", "connectedness", "counterexample"]
+  }
+]

--- a/src/data/proofs/connected-space-oq-01-oq-02/index.ts
+++ b/src/data/proofs/connected-space-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ConnectedSpaceOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const connectedSpaceOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const connectedSpaceOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const connectedSpaceOQ01OQ02Data: ProofData = {
+  proof: connectedSpaceOQ01OQ02Proof,
+  annotations: connectedSpaceOQ01OQ02Annotations,
+}

--- a/src/data/proofs/connected-space-oq-01-oq-02/meta.json
+++ b/src/data/proofs/connected-space-oq-01-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "connected-space-oq-01-oq-02",
+  "title": "The Topologist's Sine Curve Is Connected",
+  "slug": "connected-space-oq-01-oq-02",
+  "description": "Answers the second open question of the parent entry connected-space-oq-01 (closure-stability of connectedness, including the 'bark and tree' corollary connected_of_subset_closure: any set wedged between a connected set and its closure is connected) by applying it to the canonical concrete space built from a dense connected skeleton — the topologist's sine curve T = {(x, sin x⁻¹) : x > 0} ∪ ({0} × [−1,1]), the textbook witness of a connected but not path-connected space. isConnected_sineCurve shows the graph over the positive reals is connected as the continuous image of the connected set Ioi 0. limitSegment_subset_closure shows the limit segment {0} × [−1,1] lies in the graph's closure: for y ∈ [−1,1], the graph points (aₙ⁻¹, sin aₙ) with aₙ = arcsin y + n·2π have second coordinate exactly y (2π-periodicity of sin plus sin(arcsin y) = y) and first coordinate aₙ⁻¹ → 0, so (0,y) is a limit of graph points. Hence sineCurve ⊆ T ⊆ closure sineCurve, and the parent's corollary (IsConnected.subset_closure) gives isConnected_topologistSineCurve. Path-connectedness fails for T but is not formalized here (recorded as a follow-up). Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (point-set topology folklore; the topologist's sine curve); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Topologist%27s_sine_curve",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "topology",
+      "connectedness",
+      "topologists-sine-curve",
+      "closure",
+      "counterexample",
+      "point-set-topology",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ConnectedSpaceOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "isConnected_Ioi",
+        "description": "IsConnected (Set.Ioi a) in a densely-ordered conditionally-complete linear order without max element — supplies connectedness of the parameter domain Ioi 0 ⊆ ℝ",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "IsConnected.image",
+        "description": "the continuous image of a connected set is connected — turns connectedness of Ioi 0 into connectedness of the graph",
+        "module": "Mathlib.Topology.Connected.Basic"
+      },
+      {
+        "theorem": "IsConnected.subset_closure",
+        "description": "if s is connected and s ⊆ t ⊆ closure s then t is connected ('bark and tree') — the parent's corollary, applied with s = graph, t = the full curve",
+        "module": "Mathlib.Topology.Connected.Basic"
+      },
+      {
+        "theorem": "Metric.mem_closure_iff",
+        "description": "a ∈ closure s ↔ ∀ ε > 0, ∃ b ∈ s, dist a b < ε — the ε-characterization used to place each segment point in the closure of the graph",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Defs"
+      },
+      {
+        "theorem": "Real.sin_add_nat_mul_two_pi",
+        "description": "sin (x + n·(2π)) = sin x — 2π-periodicity that makes every aₙ = arcsin y + n·2π satisfy sin aₙ = sin(arcsin y)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_arcsin",
+        "description": "−1 ≤ y → y ≤ 1 → sin (arcsin y) = y — pins the second coordinate of the approximating points to the target y",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+      },
+      {
+        "theorem": "Real.arcsin_mem_Icc",
+        "description": "arcsin y ∈ [−π/2, π/2] — the lower bound −π/2 ≤ arcsin y gives positivity of aₙ for the inverse to land in Ioi 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+      },
+      {
+        "theorem": "ContinuousOn.inv₀",
+        "description": "f continuous and nonzero on s ⟹ x ↦ (f x)⁻¹ continuous on s — gives continuity of x⁻¹ on Ioi 0 (where x ≠ 0)",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      },
+      {
+        "theorem": "inv_lt_comm₀ / Prod.dist_eq",
+        "description": "0 < a → 0 < b → (a⁻¹ < b ↔ b⁻¹ < a), and dist on a product is the max of coordinate distances — convert ε⁻¹ < aₙ into aₙ⁻¹ < ε and reduce the product distance to the first coordinate",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic / Mathlib.Topology.MetricSpace.Pseudo.Constructions"
+      }
+    ],
+    "originalContributions": [
+      "sineCurve / limitSegment / topologistSineCurve: the topologist's sine curve formalized in ℝ × ℝ as the graph of x ↦ (x, sin x⁻¹) over Ioi 0 together with its limit segment {0} × [−1,1]",
+      "isConnected_sineCurve: the oscillating graph is connected (continuous image of the connected set Ioi 0)",
+      "limitSegment_subset_closure: the limit segment lies in the closure of the graph, via the explicit approximants (aₙ⁻¹, sin aₙ) with aₙ = arcsin y + n·2π (periodicity + sin(arcsin y) = y, and aₙ⁻¹ → 0 by an Archimedean choice)",
+      "isConnected_topologistSineCurve: the topologist's sine curve is connected, by the parent's bark-and-tree corollary applied to sineCurve ⊆ T ⊆ closure sineCurve",
+      "isPreconnected_topologistSineCurve: the preconnected corollary"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 104,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The parent entry connected-space-oq-01 formalizes that connectedness survives closure, and, sharper, the 'bark and tree' fact that any set between a connected set and its closure is connected. Its open question asks to deploy that corollary on a concrete space assembled from a dense connected skeleton. The textbook such space is the topologist's sine curve — the standard counterexample showing connected ⇏ path-connected.",
+    "problemStatement": "**Open Question (connected-space-oq-01, second question)**: Use the dense-connected / bark-and-tree corollary to prove connectedness of specific spaces built from dense connected skeletons.\n\n**Result**: The topologist's sine curve T = {(x, sin x⁻¹) : x > 0} ∪ ({0} × [−1,1]) is connected. Its oscillating graph is a connected skeleton whose closure contains the limit segment, so T is sandwiched between the graph and its closure and the parent's corollary applies.",
+    "text": "Work in ℝ × ℝ. The graph G = {(x, sin x⁻¹) : x > 0} is the continuous image of the connected ray (0, ∞), hence connected. Every segment point (0, y) with y ∈ [−1,1] is a limit of graph points: take aₙ = arcsin y + n·2π, then sin aₙ = y for all n while aₙ⁻¹ → 0, so (aₙ⁻¹, sin aₙ) = (aₙ⁻¹, y) → (0, y). Thus G ⊆ T ⊆ closure G, and 'bark and tree' (IsConnected.subset_closure) yields that T is connected.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Graph connected (`isConnected_sineCurve`).** `Ioi 0` is connected (`isConnected_Ioi`); the parametrization x ↦ (x, sin x⁻¹) is continuous on it (`continuousOn_id.prodMk` with `ContinuousOn.inv₀` for x⁻¹ and `Real.continuous_sin`); apply `IsConnected.image`.\n2. **Segment in closure (`limitSegment_subset_closure`).** Fix (0, y), y ∈ [−1,1]. By `Metric.mem_closure_iff`, given ε > 0 choose (Archimedean, `exists_nat_gt`) n with aₙ = arcsin y + n·2π > ε⁻¹ > 0 (using −π/2 ≤ arcsin y from `Real.arcsin_mem_Icc`). Then aₙ⁻¹ ∈ Ioi 0, sin (aₙ⁻¹)⁻¹ = sin aₙ = sin(arcsin y) = y (by `inv_inv`, `Real.sin_add_nat_mul_two_pi`, `Real.sin_arcsin`), and dist((0,y),(aₙ⁻¹,y)) = aₙ⁻¹ < ε (by `Prod.dist_eq` and `inv_lt_comm₀`).\n3. **Curve connected (`isConnected_topologistSineCurve`).** sineCurve ⊆ T = sineCurve ∪ limitSegment ⊆ closure sineCurve (from `subset_closure` and step 2), so `IsConnected.subset_closure` gives the result; `isPreconnected_topologistSineCurve` follows.",
+    "keyInsights": [
+      "**The graph is the connected skeleton; the curve is its 'bark'.** The whole curve is not obviously connected, but it is squeezed between the manifestly-connected graph and that graph's closure — exactly the hypothesis of the parent's bark-and-tree corollary, so no separate separation argument is needed.",
+      "**Density of the oscillation is exact, not approximate.** Because sin is 2π-periodic and surjective onto [−1,1], every target height y is hit *exactly* by sin aₙ with aₙ = arcsin y + n·2π; only the x-coordinate aₙ⁻¹ → 0 needs limiting. This makes the closure computation a one-coordinate estimate.",
+      "**Connectedness, not path-connectedness, is what closure delivers.** The topologist's sine curve is the standard example separating the two notions. Closure preserves connectedness (this entry) but destroys path-connectedness (the graph is path-connected, the curve is not) — the latter is recorded as a follow-up, not proved here.",
+      "**The product-metric estimate collapses to one axis.** With the second coordinate forced to equal y exactly, the product distance dist((0,y),(aₙ⁻¹,y)) reduces via Prod.dist_eq to |aₙ⁻¹|, turning the closure membership into a single Archimedean inequality aₙ⁻¹ < ε."
+    ],
+    "prerequisites": [
+      "Connectedness, preconnectedness, and the closure operator in topology",
+      "The parent's bark-and-tree corollary IsConnected.subset_closure",
+      "Continuity of x⁻¹ away from 0 and of sin; arcsin and 2π-periodicity of sin",
+      "The ε-characterization of closure in metric spaces and the product metric"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Docstring framing the topologist's sine curve as the parent's requested dense-connected-skeleton example and previewing the bark-and-tree strategy. Defines sineCurve (graph over Ioi 0), limitSegment ({0} × [−1,1]), and topologistSineCurve (their union).",
+      "mathContext": "$T = \\{(x, \\sin x^{-1}) : x > 0\\} \\cup (\\{0\\} \\times [-1,1])$."
+    },
+    {
+      "id": "graph-connected",
+      "title": "The Graph Is Connected",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "continuousOn_param: the parametrization x ↦ (x, sin x⁻¹) is continuous on Ioi 0 (ContinuousOn.inv₀ for x⁻¹, composed with sin, paired by ContinuousOn.prodMk). isConnected_sineCurve: the graph is connected as the continuous image of the connected ray Ioi 0.",
+      "mathContext": "$G = (x \\mapsto (x, \\sin x^{-1}))(\\,(0,\\infty)\\,)$ is connected."
+    },
+    {
+      "id": "segment-closure",
+      "title": "The Limit Segment Lies in the Closure",
+      "startLine": 65,
+      "endLine": 90,
+      "summary": "limitSegment_subset_closure: each (0,y), y ∈ [−1,1], is in closure G. Via Metric.mem_closure_iff and an Archimedean choice of n, the point (aₙ⁻¹, sin aₙ) with aₙ = arcsin y + n·2π has second coordinate y (periodicity + sin∘arcsin) and lies within ε of (0,y) (product metric collapses to aₙ⁻¹ < ε).",
+      "mathContext": "$(0,y) = \\lim_n (a_n^{-1}, \\sin a_n)$, $a_n = \\arcsin y + 2\\pi n$."
+    },
+    {
+      "id": "curve-connected",
+      "title": "The Topologist's Sine Curve Is Connected",
+      "startLine": 92,
+      "endLine": 104,
+      "summary": "isConnected_topologistSineCurve: sineCurve ⊆ T ⊆ closure sineCurve, so IsConnected.subset_closure (the parent's bark-and-tree corollary) gives connectedness. isPreconnected_topologistSineCurve records the preconnected consequence.",
+      "mathContext": "$G \\subseteq T \\subseteq \\overline{G} \\Rightarrow T$ connected."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "connected-space-oq-01",
+      "relationship": "answers",
+      "description": "Settles the parent's second open question by applying its bark-and-tree corollary (IsConnected.subset_closure) to a concrete dense-connected-skeleton space, the topologist's sine curve."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization that the topologist's sine curve T = {(x, sin x⁻¹) : x > 0} ∪ ({0} × [−1,1]) is connected. The oscillating graph is a connected skeleton whose closure contains the limit segment, so T is sandwiched between the graph and its closure and the parent's bark-and-tree corollary applies directly.",
+    "implications": "Provides the canonical concrete instance the parent's open question asked for, and adds the textbook connected-but-not-path-connected space to the formalized record. The closure computation is reduced to an exact periodicity argument plus a one-coordinate Archimedean estimate.",
+    "openQuestions": [
+      "Formalize that the topologist's sine curve is NOT path-connected (no continuous path joins the limit segment to the oscillating graph), completing the standard separation of connectedness from path-connectedness.",
+      "Show the closed topologist's sine curve (graph plus segment plus a connecting arc) is path-connected, and contrast local connectedness, which also fails at the segment.",
+      "Generalize the dense-skeleton construction to other graphs of functions with an essential oscillatory singularity (e.g. x·sin x⁻¹) and characterize when the closure adds a connected limit set."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Topology",
+      "Real"
+    ],
+    "namespace": "ConnectedSpaceOQ01OQ02",
+    "lineCount": 104,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "path": "Proofs/ConnectedSpaceOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Steen, Lynn Arthur; Seebach, J. Arthur",
+      "title": "Counterexamples in Topology",
+      "year": "1978",
+      "venue": "Springer",
+      "note": "Example 117–118: the topologist's sine curve as a connected, non-path-connected space"
+    },
+    {
+      "authors": "Munkres, James R.",
+      "title": "Topology",
+      "year": "2000",
+      "venue": "Prentice Hall",
+      "note": "§24: the topologist's sine curve; closure of a connected set is connected"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent entry `connected-space-oq-01` (closure-stability of connectedness, incl. the *bark-and-tree* corollary `connected_of_subset_closure`): apply that corollary to a concrete space built from a **dense connected skeleton**.

The canonical such space is the **topologist's sine curve**
`T = {(x, sin x⁻¹) : x > 0} ∪ ({0} × [−1,1])` — the textbook witness of a space that is connected but **not** path-connected. This PR formalizes the connectedness half (exactly what the corollary delivers) in `ℝ × ℝ`.

## Results (`proofs/Proofs/ConnectedSpaceOQ01OQ02.lean`)

- `isConnected_sineCurve` — the oscillating graph is connected, as the continuous image of the connected ray `Ioi 0`.
- `limitSegment_subset_closure` — the limit segment `{0} × [−1,1]` lies in the graph's closure. For `y ∈ [−1,1]`, the approximants `(aₙ⁻¹, sin aₙ)` with `aₙ = arcsin y + n·2π` have second coordinate **exactly** `y` (2π-periodicity of `sin` + `sin(arcsin y) = y`) and first coordinate `aₙ⁻¹ → 0`.
- `isConnected_topologistSineCurve` — since `sineCurve ⊆ T ⊆ closure sineCurve`, the parent's bark-and-tree corollary (`IsConnected.subset_closure`) gives connectedness.
- `isPreconnected_topologistSineCurve` — the preconnected consequence.

## Verification

- **5 theorems / 3 definitions / 104 lines.**
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- `#print axioms isConnected_topologistSineCurve` → `[propext, Classical.choice, Quot.sound]` only.
- Builds clean via host `lake env lean` (docker daemon was down this cycle).

Status `verified`, badge `original`. Path-connectedness fails for `T` but is not formalized here (recorded as a follow-up open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)