### PR TITLE
research(conjugacy-class-equation-oq-01-oq-02): finite p-groups have nontrivial center via the class equation [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ConjugacyClassEquationOQ0102.lean
+++ b/proofs/Proofs/ConjugacyClassEquationOQ0102.lean
@@ -1,0 +1,123 @@
+import Mathlib
+import Proofs.ConjugacyClassEquationOQ01
+
+/-!
+# Finite `p`-groups have nontrivial center, via the class equation
+
+This file answers the second open question recorded on the parent entry
+`conjugacy-class-equation-oq-01` (Proofs/ConjugacyClassEquationOQ01.lean):
+
+> Deduce that a nontrivial finite `p`-group has nontrivial center by combining
+> per-class divisibility with the observation that every noncentral class size
+> is a positive power of `p`.
+
+The argument is the **class-equation route**, which is genuinely different from the
+proof Mathlib ships (`IsPGroup.center_nontrivial`, which counts the fixed points of
+the conjugation action via `IsPGroup.card_modEq_card_fixedPoints`).  Here we instead:
+
+1. lift the parent's per-class divisibility `|class(g)| ∣ |G|` from chosen
+   representatives to arbitrary conjugacy classes (`conjClass_carrier_card_dvd_card`);
+2. observe that for a `p`-group `|G| = pⁿ`, so every conjugacy class size is a power
+   of `p`, and a *noncentral* class — one whose carrier has more than one element —
+   has size a **positive** power of `p`, hence is divisible by `p`
+   (`noncentral_class_card_eq_prime_pow`);
+3. feed this into Mathlib's numeric class equation
+   `Group.nat_card_center_add_sum_card_noncenter_eq_card`,
+
+       |Z(G)| + Σ_{noncentral classes} |class| = |G|,
+
+   to get `p ∣ |Z(G)|` (both `|G|` and the noncentral sum are divisible by `p`);
+4. conclude `1 < |Z(G)|`, i.e. `Z(G)` is nontrivial (`center_nontrivial_of_isPGroup`).
+
+Everything is `0`-axiom and builds on the parent's `conjClass_card_dvd_card`.
+Mathlib already knows the headline theorem; the content here is the explicit
+class-equation derivation requested by the open question, with the intermediate
+"noncentral classes have size a positive power of `p`" stated as its own result.
+-/
+
+open MulAction ConjClasses Subgroup
+
+namespace ConjugacyClassEquationOQ0102
+
+variable {G : Type*} [Group G]
+
+/-- **Per-class divisibility for arbitrary conjugacy classes.** The cardinality of any
+conjugacy class `x : ConjClasses G` divides the order of the group.  This lifts the
+parent's `conjClass_card_dvd_card`, which is stated for the class of a chosen
+representative `g`, to a statement about the quotient `ConjClasses G` directly. -/
+theorem conjClass_carrier_card_dvd_card (x : ConjClasses G) :
+    Nat.card x.carrier ∣ Nat.card G := by
+  obtain ⟨g, rfl⟩ := ConjClasses.mk_surjective x
+  exact ConjugacyClassEquationOQ01.conjClass_card_dvd_card g
+
+variable {p : ℕ}
+
+/-- **Noncentral classes of a finite `p`-group have size a positive power of `p`.**
+If `G` is a finite `p`-group and `x` is a conjugacy class with more than one element
+(i.e. `x ∈ ConjClasses.noncenter G`), then `|x| = p^k` for some `k > 0`; in particular
+`p ∣ |x|`.  This is the key arithmetic input to the class equation. -/
+theorem noncentral_class_card_eq_prime_pow [Fact p.Prime] [Finite G] (hG : IsPGroup p G)
+    {x : ConjClasses G} (hx : x ∈ noncenter G) :
+    ∃ k > 0, Nat.card x.carrier = p ^ k := by
+  obtain ⟨n, hcard⟩ := IsPGroup.iff_card.mp hG
+  have hdvd : Nat.card x.carrier ∣ p ^ n := hcard ▸ conjClass_carrier_card_dvd_card x
+  obtain ⟨k, _, hk⟩ := (Nat.dvd_prime_pow (Fact.out : p.Prime)).mp hdvd
+  -- a noncentral class carrier is a nontrivial set, so it has more than one element
+  have h1lt : 1 < Nat.card x.carrier :=
+    Finite.one_lt_card_iff_nontrivial.mpr
+      (Set.nontrivial_coe_sort.mpr ((mem_noncenter x).mp hx))
+  refine ⟨k, ?_, hk⟩
+  rcases Nat.eq_zero_or_pos k with rfl | hk0
+  · rw [hk, pow_zero] at h1lt
+    exact absurd h1lt (lt_irrefl 1)
+  · exact hk0
+
+/-- **A nontrivial finite `p`-group has nontrivial center** (class-equation proof).
+
+`p` divides the order `|G| = pⁿ` (with `n > 0` since `G` is nontrivial) and divides the
+total size of the noncentral conjugacy classes (each summand is a positive power of `p`),
+so by the class equation `|Z(G)| + Σ = |G|` it divides `|Z(G)|`.  Since `Z(G)` is a
+nonempty finite set with `p ∣ |Z(G)|` and `p ≥ 2`, we get `1 < |Z(G)|`. -/
+theorem center_nontrivial_of_isPGroup [Fact p.Prime] [Finite G] [Nontrivial G]
+    (hG : IsPGroup p G) : Nontrivial (Subgroup.center G) := by
+  classical
+  have hp : p.Prime := Fact.out
+  -- `p ∣ |G|`, since `|G| = pⁿ` with `n > 0`
+  obtain ⟨n, hn0, hcard⟩ := hG.nontrivial_iff_card.mp ‹Nontrivial G›
+  have hpG : p ∣ Nat.card G := hcard ▸ dvd_pow_self p hn0.ne'
+  -- `p` divides the sum of the noncentral class sizes
+  have hpsum : p ∣ ∑ᶠ x ∈ noncenter G, Nat.card x.carrier := by
+    have key : ∀ x ∈ noncenter G, p ∣ Nat.card x.carrier := by
+      intro x hx
+      obtain ⟨k, hk0, hk⟩ := noncentral_class_card_eq_prime_pow hG hx
+      exact hk ▸ dvd_pow_self p hk0.ne'
+    have hfin : (noncenter G).Finite := Set.toFinite _
+    have hrw : (∑ᶠ x ∈ noncenter G, Nat.card x.carrier)
+        = ∑ x ∈ hfin.toFinset, Nat.card x.carrier := by
+      rw [← finsum_mem_coe_finset, hfin.coe_toFinset]
+    rw [hrw]
+    exact Finset.dvd_sum fun x hx => key x (hfin.mem_toFinset.mp hx)
+  -- the class equation: `|Z(G)| + Σ = |G|`
+  have heq := Group.nat_card_center_add_sum_card_noncenter_eq_card G
+  -- therefore `p ∣ |Z(G)|`
+  have hcenter_eq : Nat.card (Subgroup.center G)
+      = Nat.card G - ∑ᶠ x ∈ noncenter G, Nat.card x.carrier := by omega
+  have hpc : p ∣ Nat.card (Subgroup.center G) := hcenter_eq ▸ Nat.dvd_sub hpG hpsum
+  -- a nonempty finite set with `p ∣ card` and `p ≥ 2` has `> 1` element
+  have hpos : 0 < Nat.card (Subgroup.center G) := Finite.card_pos
+  have h1lt : 1 < Nat.card (Subgroup.center G) :=
+    lt_of_lt_of_le hp.one_lt (Nat.le_of_dvd hpos hpc)
+  exact Finite.one_lt_card_iff_nontrivial.mp h1lt
+
+/-- Concrete instance: apply the theorem to the order-`4` `2`-group
+`Multiplicative (ZMod 4)`.  Its center is nontrivial (in fact the group is abelian, so
+the center is everything — but the point is that the class-equation theorem fires). -/
+example : Nontrivial (Subgroup.center (Multiplicative (ZMod 4))) := by
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  haveI : Nontrivial (ZMod 4) := ⟨0, 1, by decide⟩
+  haveI : Nontrivial (Multiplicative (ZMod 4)) := inferInstanceAs (Nontrivial (ZMod 4))
+  have hG : IsPGroup 2 (Multiplicative (ZMod 4)) :=
+    IsPGroup.of_card (n := 2) (by rw [Nat.card_eq_fintype_card]; decide)
+  exact center_nontrivial_of_isPGroup hG
+
+end ConjugacyClassEquationOQ0102

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "pgroup-center-overview",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 45 },
+    "type": "concept",
+    "title": "p-group center theorem via the class equation",
+    "content": "The docstring states the target — a nontrivial finite p-group has nontrivial center — and the strategy. Mathlib already proves this as IsPGroup.center_nontrivial by counting fixed points of the conjugation action (card_modEq_card_fixedPoints). This entry instead gives the textbook class-equation derivation requested by the parent's second open question: lift per-class divisibility to the quotient, show every noncentral class has size a positive power of p, and read |Z(G)| + Σ = |G| modulo p.",
+    "mathContext": "$|G| = |Z(G)| + \\sum_i [G : C_G(g_i)]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "class equation",
+      "p-group",
+      "center of a group",
+      "conjugacy classes",
+      "prime-power order"
+    ],
+    "prerequisites": [
+      "conjugacy classes as orbits",
+      "orbit–stabilizer / per-class divisibility",
+      "p-groups have prime-power order"
+    ]
+  },
+  {
+    "id": "carrier-card-dvd",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 47, "endLine": 57 },
+    "type": "lemma",
+    "title": "Per-class divisibility on the quotient ConjClasses G",
+    "content": "conjClass_carrier_card_dvd_card promotes the parent's conjClass_card_dvd_card — stated for the class of a chosen representative g — to an arbitrary class x : ConjClasses G. Since ConjClasses.mk is surjective, x = ConjClasses.mk g for some g, and x.carrier is then literally (ConjClasses.mk g).carrier, so the parent lemma applies verbatim. This is the bridge that lets the class equation, indexed by ConjClasses G, plug into the divisibility count.",
+    "mathContext": "$|x| \\mid |G|\\quad\\text{for all } x : \\mathrm{ConjClasses}\\,G$",
+    "significance": "supporting",
+    "relatedConcepts": ["ConjClasses.mk_surjective", "conjugacy class carrier"],
+    "prerequisites": ["the parent's per-class divisibility lemma"]
+  },
+  {
+    "id": "noncentral-prime-power",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 59, "endLine": 80 },
+    "type": "lemma",
+    "title": "Noncentral classes have size a positive power of p",
+    "content": "noncentral_class_card_eq_prime_pow is the arithmetic heart. For a finite p-group, IsPGroup.iff_card gives |G| = pⁿ; any class size divides pⁿ, so by Nat.dvd_prime_pow it equals pᵏ for some k. A class lies in ConjClasses.noncenter G exactly when its carrier is a nontrivial set — more than one element — which forces 1 < pᵏ and hence k > 0. Thus p divides every noncentral class size. Mathlib does not package this intermediate fact on its own.",
+    "mathContext": "$x \\in \\mathrm{noncenter}\\,G \\Rightarrow |x| = p^k,\\ k>0$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.dvd_prime_pow", "noncenter", "nontrivial set", "prime power"],
+    "prerequisites": ["divisors of a prime power", "IsPGroup.iff_card"]
+  },
+  {
+    "id": "center-nontrivial-main",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 82, "endLine": 113 },
+    "type": "theorem",
+    "title": "The center is nontrivial",
+    "content": "center_nontrivial_of_isPGroup assembles the result. p divides |G| (since |G| = pⁿ with n > 0 by IsPGroup.nontrivial_iff_card) and p divides the noncentral sum (each term is a positive power of p; the finsum over noncenter G is rewritten as a Finset sum and handled by Finset.dvd_sum). The numeric class equation Group.nat_card_center_add_sum_card_noncenter_eq_card then gives |Z(G)| = |G| − Σ, so Nat.dvd_sub yields p ∣ |Z(G)|. As Z(G) is nonempty and finite, |Z(G)| > 0; with p ≥ 2 we get p ≤ |Z(G)|, so 1 < |Z(G)| and the center is nontrivial.",
+    "mathContext": "$p \\mid |Z(G)|,\\ |Z(G)|>0 \\Rightarrow \\mathrm{Nontrivial}(Z(G))$",
+    "significance": "key",
+    "relatedConcepts": [
+      "class equation",
+      "Nat.dvd_sub",
+      "Finset.dvd_sum",
+      "Finite.one_lt_card_iff_nontrivial"
+    ],
+    "prerequisites": ["the numeric class equation", "divisibility of natural-number subtraction"]
+  },
+  {
+    "id": "example-zmod4",
+    "proofId": "conjugacy-class-equation-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 123 },
+    "type": "example",
+    "title": "Concrete 2-group instance",
+    "content": "The closing example applies the theorem to Multiplicative (ZMod 4), the cyclic 2-group of order 4, exhibiting a nontrivial center. It supplies the Fact (Nat.Prime 2), Nontrivial, and IsPGroup 2 instances (the last via IsPGroup.of_card with |G| = 2²) and fires the main theorem.",
+    "mathContext": "$Z(\\mathrm{Mult}(\\mathbb{Z}/4))$ is nontrivial",
+    "significance": "supporting",
+    "relatedConcepts": ["IsPGroup.of_card", "ZMod", "Multiplicative"],
+    "prerequisites": ["the main theorem"]
+  }
+]

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-02/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "conjugacy-class-equation-oq-01-oq-02",
+  "title": "Finite p-Groups Have Nontrivial Center, via the Class Equation",
+  "slug": "conjugacy-class-equation-oq-01-oq-02",
+  "description": "Answers the second open question of the parent entry (conjugacy-class-equation-oq-01): deduce that a nontrivial finite p-group has nontrivial center by combining per-class divisibility with the observation that every noncentral conjugacy class has size a positive power of p. The argument is the classical class-equation route, which differs from the proof Mathlib ships (IsPGroup.center_nontrivial, which counts the fixed points of the conjugation action via IsPGroup.card_modEq_card_fixedPoints). It first lifts the parent's per-class divisibility |class(g)| ∣ |G| from chosen representatives to arbitrary conjugacy classes (conjClass_carrier_card_dvd_card); observes that for a p-group |G| = pⁿ, so every conjugacy class size is a power of p, and a noncentral class — one whose carrier has more than one element — has size a positive power of p, hence is divisible by p (noncentral_class_card_eq_prime_pow); feeds this into Mathlib's numeric class equation Group.nat_card_center_add_sum_card_noncenter_eq_card, |Z(G)| + Σ |class| = |G|, to get p ∣ |Z(G)|; and concludes 1 < |Z(G)|. Fully verified, 0 axioms, building on the parent's conjClass_card_dvd_card.",
+  "meta": {
+    "author": "Classical group theory (Burnside, Frobenius, Cauchy); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/P-group#Non-trivial_center",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "p-groups",
+      "center",
+      "class-equation",
+      "conjugacy-classes",
+      "prime-power",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ConjugacyClassEquationOQ0102.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Group.nat_card_center_add_sum_card_noncenter_eq_card",
+        "description": "Nat.card (center G) + ∑ᶠ x ∈ noncenter G, Nat.card x.carrier = Nat.card G — the numeric class equation for finite groups, the backbone of the derivation",
+        "module": "Mathlib.GroupTheory.ClassEquation"
+      },
+      {
+        "theorem": "IsPGroup.iff_card",
+        "description": "For a finite group, IsPGroup p G ↔ ∃ n, Nat.card G = p ^ n — turns the p-group hypothesis into |G| = pⁿ",
+        "module": "Mathlib.GroupTheory.PGroup"
+      },
+      {
+        "theorem": "IsPGroup.nontrivial_iff_card",
+        "description": "For a finite group, Nontrivial G ↔ ∃ n > 0, Nat.card G = p ^ n — supplies n > 0, hence p ∣ |G|",
+        "module": "Mathlib.GroupTheory.PGroup"
+      },
+      {
+        "theorem": "Nat.dvd_prime_pow",
+        "description": "i ∣ p ^ m ↔ ∃ k ≤ m, i = p ^ k — a divisor of a prime power is itself a prime power; gives every class size the form pᵏ",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "ConjClasses.mk_surjective",
+        "description": "ConjClasses.mk is surjective — lets us pick a representative g for any class x : ConjClasses G to reuse the parent's per-class divisibility",
+        "module": "Mathlib.Algebra.Group.Conj"
+      },
+      {
+        "theorem": "Finite.one_lt_card_iff_nontrivial",
+        "description": "For a finite type, 1 < Nat.card α ↔ Nontrivial α — converts the size lower bound p ≤ |Z(G)| into nontriviality of the center",
+        "module": "Mathlib.Data.Finite.Card"
+      }
+    ],
+    "originalContributions": [
+      "conjClass_carrier_card_dvd_card: |x| ∣ |G| for any conjugacy class x : ConjClasses G — lifts the parent's representative-level conjClass_card_dvd_card to the quotient ConjClasses G via ConjClasses.mk_surjective",
+      "noncentral_class_card_eq_prime_pow: in a finite p-group, every noncentral conjugacy class has size pᵏ with k > 0 (so p divides it) — the arithmetic input to the class equation that Mathlib does not package separately",
+      "center_nontrivial_of_isPGroup: a nontrivial finite p-group has nontrivial center, derived from the numeric class equation |Z(G)| + Σ = |G| by showing p divides both |G| and the noncentral sum, hence p ∣ |Z(G)| and 1 < |Z(G)| — a class-equation derivation distinct from Mathlib's fixed-point proof IsPGroup.center_nontrivial",
+      "Concrete instance: the order-4 2-group Multiplicative (ZMod 4) has nontrivial center"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 123,
+    "assumptions": "None beyond Mathlib's foundations. Fully verified with 0 axioms and 0 sorries; #print axioms reports only propext / Classical.choice / Quot.sound for all three theorems (no Lean.ofReduceBool, no sorryAx; the concrete example uses kernel decide, not native_decide). HONESTY: the headline result (a nontrivial finite p-group has nontrivial center) is already in Mathlib as IsPGroup.center_nontrivial, proved there by counting fixed points of the conjugation action. The contribution here is the alternative class-equation derivation requested by the parent's open question, together with the intermediate lemma noncentral_class_card_eq_prime_pow (noncentral classes have size a positive power of p), which Mathlib does not state on its own.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That every nontrivial finite p-group has a nontrivial center is a cornerstone of finite group theory: it drives the proof that p-groups are nilpotent, the classification of groups of order p² (all abelian), and the inductive step in many Sylow-theoretic arguments. The standard textbook proof is exactly the class-equation argument formalized here — |G| = |Z(G)| + Σ [G : C_G(gᵢ)] with every noncentral index a positive power of p — which Burnside and Frobenius made into a routine counting tool.",
+    "problemStatement": "**Open Question (conjugacy-class-equation-oq-01, #2)**: Deduce that a nontrivial finite p-group has nontrivial center by combining the parent's per-class divisibility with the observation that every noncentral conjugacy class size is a positive power of p.\n\n**Result**: center_nontrivial_of_isPGroup — for [Fact p.Prime] [Finite G] [Nontrivial G] and hG : IsPGroup p G, Nontrivial (Subgroup.center G), proved through the numeric class equation rather than Mathlib's fixed-point count.",
+    "text": "Let G be a nontrivial finite p-group, so |G| = pⁿ with n > 0 and p ∣ |G|. Every conjugacy class is an orbit of the conjugation action, so its size divides |G| = pⁿ and is therefore a power of p; a noncentral class has more than one element, so its size is a positive power of p and is divisible by p. The numeric class equation |Z(G)| + Σ_{noncentral} |class| = |G| then exhibits |Z(G)| as |G| minus a sum each of whose terms is divisible by p, so p ∣ |Z(G)|. Since Z(G) is a nonempty finite set and p ≥ 2, we get 1 < |Z(G)|, i.e. the center is nontrivial.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Per-class divisibility, on the quotient.** conjClass_carrier_card_dvd_card lifts the parent's conjClass_card_dvd_card (stated for the class of a representative g) to an arbitrary class x : ConjClasses G, by writing x = ConjClasses.mk g via ConjClasses.mk_surjective.\n\n2. **Noncentral ⟹ positive power of p.** noncentral_class_card_eq_prime_pow: from IsPGroup.iff_card we have |G| = pⁿ; a class size divides pⁿ so equals pᵏ (Nat.dvd_prime_pow); a noncentral class carrier is a nontrivial set, so it has more than one element, forcing k > 0 and hence p ∣ |x|.\n\n3. **p divides the noncentral sum.** Rewriting the finsum ∑ᶠ x ∈ noncenter G over the finite set noncenter G as a Finset sum (finsum_mem_coe_finset on Set.Finite.toFinset), Finset.dvd_sum gives p ∣ Σ.\n\n4. **p divides |G|.** IsPGroup.nontrivial_iff_card gives n > 0, so p ∣ pⁿ = |G|.\n\n5. **p divides |Z(G)|.** From Group.nat_card_center_add_sum_card_noncenter_eq_card, |Z(G)| = |G| − Σ; with p ∣ |G| and p ∣ Σ, Nat.dvd_sub gives p ∣ |Z(G)|.\n\n6. **Center nontrivial.** |Z(G)| > 0 (nonempty finite, Finite.card_pos) and p ∣ |Z(G)| with p ≥ 2 give p ≤ |Z(G)|, so 1 < |Z(G)|; Finite.one_lt_card_iff_nontrivial concludes Nontrivial (center G).",
+    "keyInsights": [
+      "**Noncentral classes carry the prime.** The whole argument turns on one fact: a conjugacy class with more than one element has size a *positive* power of p, so p divides it. Central elements are exactly the singleton classes, which the class equation peels off as |Z(G)|.",
+      "**Class equation as a divisibility statement.** Reading |Z(G)| + Σ = |G| modulo p, both |G| and Σ vanish, forcing |Z(G)| ≡ 0 (mod p); a nonempty center then cannot be just the identity.",
+      "**A genuinely different route than Mathlib's.** Mathlib proves the same theorem (IsPGroup.center_nontrivial) by counting fixed points of the conjugation action (card_modEq_card_fixedPoints). Here the engine is instead the explicit numeric class equation built on the parent's per-class divisibility — the textbook proof.",
+      "**Reuse across the quotient.** The parent stated per-class divisibility for a representative; lifting it to ConjClasses G via mk_surjective is what lets the class equation, indexed by ConjClasses G, plug straight into the divisibility count."
+    ],
+    "prerequisites": [
+      "The parent entry conjugacy-class-equation-oq-01 (per-class divisibility |class(g)| ∣ |G|)",
+      "The numeric class equation (Mathlib.GroupTheory.ClassEquation)",
+      "p-groups and prime-power cardinalities (Mathlib.GroupTheory.PGroup), and divisors of prime powers (Nat.dvd_prime_pow)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring stating the open question and the class-equation strategy, contrasting it with Mathlib's fixed-point proof. Imports Mathlib and the parent file Proofs.ConjugacyClassEquationOQ01; opens MulAction, ConjClasses, Subgroup; variable {G : Type*} [Group G].",
+      "mathContext": "$|Z(G)| + \\sum_{\\text{noncentral } x} |x| = |G|$, with $p \\mid |x|$ for each noncentral $x$."
+    },
+    {
+      "id": "per-class-dvd",
+      "title": "Per-Class Divisibility on the Quotient",
+      "startLine": 47,
+      "endLine": 57,
+      "summary": "conjClass_carrier_card_dvd_card: |x| ∣ |G| for any x : ConjClasses G, obtained by choosing a representative via ConjClasses.mk_surjective and applying the parent's conjClass_card_dvd_card.",
+      "mathContext": "$|x| \\mid |G|$ for every conjugacy class $x$."
+    },
+    {
+      "id": "noncentral-prime-pow",
+      "title": "Noncentral Classes Have Size a Positive Power of p",
+      "startLine": 59,
+      "endLine": 80,
+      "summary": "noncentral_class_card_eq_prime_pow: with |G| = pⁿ (IsPGroup.iff_card), a class size divides pⁿ so equals pᵏ (Nat.dvd_prime_pow); a noncentral carrier is a nontrivial set with more than one element, forcing k > 0.",
+      "mathContext": "Noncentral $\\Rightarrow |x| = p^k,\\ k > 0 \\Rightarrow p \\mid |x|$."
+    },
+    {
+      "id": "center-nontrivial",
+      "title": "The Center Is Nontrivial",
+      "startLine": 82,
+      "endLine": 113,
+      "summary": "center_nontrivial_of_isPGroup: p ∣ |G| and p ∣ Σ (noncentral sum, via finsum→Finset and Finset.dvd_sum) give p ∣ |Z(G)| through the class equation and Nat.dvd_sub; with |Z(G)| > 0 and p ≥ 2, conclude 1 < |Z(G)| and Nontrivial (center G).",
+      "mathContext": "$p \\mid |Z(G)|,\\ |Z(G)| > 0 \\Rightarrow 1 < |Z(G)|$."
+    },
+    {
+      "id": "example",
+      "title": "Concrete 2-Group Instance",
+      "startLine": 115,
+      "endLine": 123,
+      "summary": "Applies the theorem to Multiplicative (ZMod 4), the cyclic 2-group of order 4, showing its center is nontrivial.",
+      "mathContext": "$Z(\\mathrm{Mult}(\\mathbb{Z}/4))$ is nontrivial."
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) class-equation proof that a nontrivial finite p-group has nontrivial center. The derivation lifts the parent's per-class divisibility to arbitrary classes, shows every noncentral class has size a positive power of p, and reads the numeric class equation |Z(G)| + Σ = |G| modulo p to get p ∣ |Z(G)|, hence 1 < |Z(G)|.",
+    "implications": "Realizes the textbook class-equation proof of the p-group center theorem inside the gallery's conjugacy-class chain, distinct from Mathlib's fixed-point proof, and isolates the reusable lemma noncentral_class_card_eq_prime_pow (noncentral classes have prime-power size).",
+    "openQuestions": [
+      "Iterate the center theorem to show every finite p-group is nilpotent, by passing to the quotient G/Z(G) and inducting on order.",
+      "Sharpen the count to |Z(G)| ≡ |G| (mod p) directly from the class equation, recovering p ∣ |Z(G)| as the special case and matching IsPGroup.card_modEq_card_fixedPoints."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ConjugacyClassEquationOQ01"
+    ],
+    "opens": [
+      "MulAction",
+      "ConjClasses",
+      "Subgroup"
+    ],
+    "namespace": "ConjugacyClassEquationOQ0102",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/ConjugacyClassEquationOQ0102.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "Wiley, §4.3 (The Class Equation), Theorem 8",
+      "note": "Standard reference: nontrivial finite p-groups have nontrivial center via the class equation"
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "AMS Graduate Studies in Mathematics 92",
+      "note": "Class equation, p-groups, and nilpotency"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question #2** of the parent entry `conjugacy-class-equation-oq-01`: *deduce that a nontrivial finite p-group has nontrivial center by combining per-class divisibility with the observation that every noncentral class size is a positive power of p.*

This is the classical **class-equation** proof, distinct from the proof Mathlib ships (`IsPGroup.center_nontrivial`, which counts fixed points of the conjugation action via `card_modEq_card_fixedPoints`).

## Verified results (`Proofs/ConjugacyClassEquationOQ0102.lean`)

- **`conjClass_carrier_card_dvd_card`** — `|x| ∣ |G|` for any conjugacy class `x : ConjClasses G`, lifting the parent's representative-level `conjClass_card_dvd_card` to the quotient via `ConjClasses.mk_surjective`.
- **`noncentral_class_card_eq_prime_pow`** — in a finite p-group, every noncentral class has size `pᵏ` with `k > 0` (so `p ∣ |x|`). The arithmetic input the class equation needs, which Mathlib does not package on its own.
- **`center_nontrivial_of_isPGroup`** — reads the numeric class equation `|Z(G)| + Σ = |G|` modulo `p` (`p ∣ |G|`, `p ∣ Σ` ⟹ `p ∣ |Z(G)|`), then `|Z(G)| > 0` and `p ≥ 2` give `1 < |Z(G)|`.

Plus a concrete instance on the order-4 2-group `Multiplicative (ZMod 4)`.

## Status

- **3 theorems, 0 defs, 0 sorries, 0 axioms, 123 lines.**
- `#print axioms` on all three theorems: `propext / Classical.choice / Quot.sound` only — no `Lean.ofReduceBool`, no `sorryAx`. Verified via single-file `lake env lean` (docker build host was down).
- **Honesty / badge `mathlib`:** the headline theorem is already in Mathlib via a different proof; the original content here is the alternative class-equation derivation requested by the open question, plus the intermediate lemma `noncentral_class_card_eq_prime_pow`. Builds on the parent's `conjClass_card_dvd_card`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)