### PR TITLE
research(erdos-453-oq-02-oq-01): eliminate PNT axiom log p_n/n→0 via elementary Chebyshev lower bound

### DIFF
--- a/proofs/Proofs/Erdos453OQ02OQ01.lean
+++ b/proofs/Proofs/Erdos453OQ02OQ01.lean
@@ -1,0 +1,340 @@
+/-
+  Erdős 453 OQ-02 OQ-01: Eliminating the PNT axiom `log p_n / n → 0`
+
+  Open Question: erdos-453-oq-02-oq-01
+  Parent: Erdos453OQ02.lean  (which itself reduced Erdős #453 from 4 axioms to 2)
+
+  Statement (parent OQ-02, open question 1):
+    "Can `logPrime_ratio_tendsto_zero` be proved by connecting Mathlib's prime-counting
+     machinery to the 1-indexed `nthPrime`? The missing step is extracting log(p_n)/n → 0."
+
+  This file ANSWERS that question affirmatively, eliminating the axiom.
+
+  Key point: `log p_n / n → 0` (equivalently `p_n^{1/n} → 1`, the n-th prime grows
+  subexponentially) is FAR weaker than the full Prime Number Theorem. It needs only a
+  Chebyshev-type LOWER bound on the prime-counting function `π`, which we derive here
+  entirely from the central binomial coefficient `C(2n, n)`:
+
+    * 4^n < n · C(2n,n)                      (Mathlib: `four_pow_lt_mul_centralBinom`)
+    * C(2n,n) = ∏_{p ≤ 2n} p^{e_p},  p^{e_p} ≤ 2n   (Mathlib: `pow_factorization_choose_le`)
+      hence  C(2n,n) ≤ (2n)^{π(2n)}.
+
+  Combining: (2n)^{π(2n)} > 4^n / n, i.e. π(2n) ≳ n / log n. Inverting this bound gives the
+  explicit estimate  p_k ≤ 2(k+1)^3  for the k-th prime (0-indexed), which is loose but more
+  than enough: log p_k = O(log k) = o(k). A squeeze finishes `log p_n / n → 0`.
+
+  RESULT: Parent OQ-02 had 2 axioms; this file removes `logPrime_ratio_tendsto_zero`,
+  leaving exactly ONE axiom — Pomerance's discrete convex-hull lemma
+  (`pomerance_convex_hull_lemma`), the genuine geometric core of the 1979 proof.
+
+  The main consequence `pomerance_1979` (infinitely many n with p_n² > p_{n-i}·p_{n+i})
+  is re-derived from that single remaining axiom.
+
+  References:
+  - Pomerance (1979): "The prime number graph", Math. Comp. 33, 399–408.
+  - Chebyshev (1852): elementary bounds on π via central binomial coefficients.
+  - Mathlib: `Nat.centralBinom`, `Nat.four_pow_lt_mul_centralBinom`,
+    `Nat.pow_factorization_choose_le`, `Nat.nth`, `Real.isLittleO_log_id_atTop`.
+-/
+
+import Mathlib
+
+open Nat Real Filter Finset
+open scoped Nat.Prime BigOperators Topology
+
+namespace Erdos453OQ02OQ01
+
+/-!
+## Part I: The prime sequence (axiom-free)
+
+`p_n` is the n-th prime, 1-indexed (`p_1 = 2, p_2 = 3, …`). As in the parent files we set
+`nthPrime n = Nat.nth Nat.Prime (n-1)` for `n ≥ 1`.
+-/
+
+/-- The n-th prime (1-indexed): `nthPrime 1 = 2`, `nthPrime 2 = 3`, … -/
+noncomputable def nthPrime (n : ℕ) : ℕ :=
+  if n = 0 then 0 else Nat.nth Nat.Prime (n - 1)
+
+/-- `p_n` is prime for `n ≥ 1` (proved, not axiomatized). -/
+theorem nthPrime_is_prime (n : ℕ) (hn : n ≥ 1) : (nthPrime n).Prime := by
+  unfold nthPrime
+  rw [if_neg (by omega)]
+  exact Nat.prime_nth_prime (n - 1)
+
+/-!
+## Part II: A Chebyshev lower bound for `π`, from the central binomial coefficient
+
+The classical elementary estimate `π(x) ≳ x / log x`, in the explicit packaged form
+`4^n < n · (2n)^{π(2n)}`, followed by its inversion into an upper bound on the n-th prime.
+-/
+
+/-- The `n`-th central binomial coefficient is at most `(2n)^{π(2n)}`: each prime power
+dividing it is `≤ 2n`, and the number of distinct prime divisors is at most `π(2n)`. -/
+theorem centralBinom_le_pow_primeCounting (n : ℕ) :
+    n.centralBinom ≤ (2 * n) ^ (Nat.primeCounting (2 * n)) := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; norm_num [Nat.centralBinom, Nat.primeCounting_zero]
+  have h2n : 0 < 2 * n := by omega
+  have hne : n.centralBinom ≠ 0 := (Nat.centralBinom_pos n).ne'
+  set S := (n.centralBinom).factorization.support with hS
+  -- every prime in the support is `≤ 2n`, so `S ⊆ {primes < 2n+1}`
+  have hsub : S ⊆ (Finset.range (2 * n + 1)).filter Nat.Prime := by
+    intro p hp
+    rw [hS, Nat.support_factorization, Nat.mem_primeFactors] at hp
+    obtain ⟨hpprime, hpdvd, hcbne⟩ := hp
+    have hpos : 0 < (n.centralBinom).factorization p :=
+      hpprime.factorization_pos_of_dvd hcbne hpdvd
+    have hple : p ≤ 2 * n := Nat.le_two_mul_of_factorization_centralBinom_pos hpos
+    rw [Finset.mem_filter, Finset.mem_range]
+    exact ⟨by omega, hpprime⟩
+  -- hence `|S| ≤ π(2n)`
+  have hcard : S.card ≤ Nat.primeCounting (2 * n) := by
+    refine (Finset.card_le_card hsub).trans ?_
+    rw [← Nat.count_eq_card_filter_range]
+    have heq : Nat.primeCounting (2 * n) = Nat.count Nat.Prime (2 * n + 1) := by
+      simp only [Nat.primeCounting, Nat.primeCounting']
+    rw [heq]
+  -- bound the product term by term, then by the cardinality
+  calc n.centralBinom
+      = n.centralBinom.factorization.prod (· ^ ·) := (Nat.factorization_prod_pow_eq_self hne).symm
+    _ = ∏ p ∈ S, p ^ (n.centralBinom.factorization p) := by rw [Finsupp.prod]
+    _ ≤ ∏ _p ∈ S, (2 * n) := by
+        apply Finset.prod_le_prod'
+        intro p _
+        exact Nat.pow_factorization_choose_le h2n
+    _ = (2 * n) ^ S.card := by rw [Finset.prod_const]
+    _ ≤ (2 * n) ^ (Nat.primeCounting (2 * n)) := Nat.pow_le_pow_right h2n hcard
+
+/-- **Chebyshev lower bound (packaged).** For `n ≥ 4`, `4^n < n · (2n)^{π(2n)}`.
+Equivalently `π(2n) > (n log 4 − log n) / log(2n) ≳ n / log n`. -/
+theorem four_pow_lt_mul_pow_primeCounting (n : ℕ) (hn : 4 ≤ n) :
+    4 ^ n < n * (2 * n) ^ (Nat.primeCounting (2 * n)) :=
+  lt_of_lt_of_le (Nat.four_pow_lt_mul_centralBinom n hn)
+    (Nat.mul_le_mul_left n (centralBinom_le_pow_primeCounting n))
+
+/-- **Inversion.** If `n ≥ 4` and the explicit inequality `n·(2n)^k ≤ 4^n` holds, then the
+`k`-th prime (0-indexed) is at most `2n`. (Such an `n` exists with `2n` polynomial in `k`,
+which is all we need below.) -/
+theorem nth_prime_le_two_mul (k n : ℕ) (hn : 4 ≤ n)
+    (hineq : n * (2 * n) ^ k ≤ 4 ^ n) :
+    Nat.nth Nat.Prime k ≤ 2 * n := by
+  -- the Chebyshev bound forces `π(2n) > k`
+  have hk : k < Nat.primeCounting (2 * n) := by
+    by_contra hcon
+    push_neg at hcon
+    have hmono : n * (2 * n) ^ (Nat.primeCounting (2 * n)) ≤ n * (2 * n) ^ k :=
+      Nat.mul_le_mul_left n (Nat.pow_le_pow_right (by omega) hcon)
+    have := four_pow_lt_mul_pow_primeCounting n hn
+    omega
+  -- and `π(2n) = #{primes ≤ 2n}`, so `nth Prime k < 2n+1`
+  have heq : Nat.primeCounting (2 * n) = Nat.count Nat.Prime (2 * n + 1) := by
+    simp only [Nat.primeCounting, Nat.primeCounting']
+  rw [heq] at hk
+  have := Nat.nth_lt_of_lt_count hk
+  omega
+
+/-- The explicit `ℕ` inequality that lets us take `n = (k+1)^3` in `nth_prime_le_two_mul`.
+For `k ≥ 1`, `(k+1)^3 · (2(k+1)^3)^k ≤ 4^{(k+1)^3}`. Both sides reduce to powers of `2`;
+the estimate `k+1 ≤ 2^{k+1}` closes the gap. -/
+theorem nat_pow_ineq (k : ℕ) (hk : 1 ≤ k) :
+    (k + 1) ^ 3 * (2 * (k + 1) ^ 3) ^ k ≤ 4 ^ ((k + 1) ^ 3) := by
+  -- LHS = 2^k · (k+1)^(3k+3)
+  have eLHS : (k + 1) ^ 3 * (2 * (k + 1) ^ 3) ^ k = 2 ^ k * (k + 1) ^ (3 * k + 3) := by
+    rw [mul_pow, ← pow_mul, mul_comm ((k + 1) ^ 3) (2 ^ k * (k + 1) ^ (3 * k)),
+      mul_assoc, ← pow_add]
+  -- (k+1)^(3k+3) ≤ 2^(3(k+1)^2)
+  have hb : (k + 1) ^ (3 * k + 3) ≤ 2 ^ (3 * (k + 1) ^ 2) := by
+    calc (k + 1) ^ (3 * k + 3)
+        ≤ (2 ^ (k + 1)) ^ (3 * k + 3) :=
+          Nat.pow_le_pow_left (Nat.le_of_lt (Nat.lt_two_pow_self)) _
+      _ = 2 ^ ((k + 1) * (3 * k + 3)) := by rw [← pow_mul]
+      _ = 2 ^ (3 * (k + 1) ^ 2) := by congr 1; ring
+  -- RHS = 2^(2(k+1)^3)
+  have eRHS : (4 : ℕ) ^ ((k + 1) ^ 3) = 2 ^ (2 * (k + 1) ^ 3) := by
+    rw [show (4 : ℕ) = 2 ^ 2 from rfl, ← pow_mul]
+  rw [eLHS, eRHS]
+  calc 2 ^ k * (k + 1) ^ (3 * k + 3)
+      ≤ 2 ^ k * 2 ^ (3 * (k + 1) ^ 2) := Nat.mul_le_mul_left _ hb
+    _ = 2 ^ (k + 3 * (k + 1) ^ 2) := by rw [← pow_add]
+    _ ≤ 2 ^ (2 * (k + 1) ^ 3) := by
+        apply Nat.pow_le_pow_right (by norm_num)
+        nlinarith [hk]
+
+/-- **Explicit prime upper bound.** For `k ≥ 1`, the `k`-th prime (0-indexed) satisfies
+`nth Prime k ≤ 2(k+1)^3`. (The truth is `~ k log k`; the cubic bound is deliberately loose
+but elementary and entirely sufficient for the asymptotics below.) -/
+theorem nth_prime_le_cube (k : ℕ) (hk : 1 ≤ k) :
+    Nat.nth Nat.Prime k ≤ 2 * (k + 1) ^ 3 := by
+  refine nth_prime_le_two_mul k ((k + 1) ^ 3) ?_ (nat_pow_ineq k hk)
+  calc (4 : ℕ) ≤ 2 ^ 3 := by norm_num
+    _ ≤ (k + 1) ^ 3 := Nat.pow_le_pow_left (by omega) 3
+
+/-- 1-indexed restatement: for `n ≥ 2`, `p_n ≤ 2 n^3`. -/
+theorem nthPrime_le_cube {n : ℕ} (hn : 2 ≤ n) : nthPrime n ≤ 2 * n ^ 3 := by
+  unfold nthPrime
+  rw [if_neg (by omega)]
+  have hk : 1 ≤ n - 1 := by omega
+  have hb := nth_prime_le_cube (n - 1) hk
+  have he : (n - 1) + 1 = n := by omega
+  rwa [he] at hb
+
+/-!
+## Part III: `log p_n / n → 0` (the eliminated axiom)
+-/
+
+/-- The log-prime function `a_n = log p_n`, exactly as in the parent files. -/
+noncomputable def logPrime (n : ℕ) : ℝ :=
+  Real.log (nthPrime n)
+
+/-- The upper envelope `log(2 n^3) / n → 0`, the squeeze majorant. -/
+theorem upper_tendsto_zero :
+    Tendsto (fun n : ℕ => Real.log (2 * (n : ℝ) ^ 3) / n) atTop (𝓝 0) := by
+  -- `log n / n → 0` (Mathlib) and `log 2 / n → 0`, then split `log(2 n^3) = log 2 + 3 log n`
+  have hlog : Tendsto (fun n : ℕ => Real.log (n : ℝ) / (n : ℝ)) atTop (𝓝 0) :=
+    Real.isLittleO_log_id_atTop.tendsto_div_nhds_zero.comp tendsto_natCast_atTop_atTop
+  have hconst : Tendsto (fun n : ℕ => Real.log 2 / (n : ℝ)) atTop (𝓝 0) :=
+    tendsto_const_div_atTop_nhds_zero_nat (Real.log 2)
+  have hsum : Tendsto
+      (fun n : ℕ => Real.log 2 / (n : ℝ) + 3 * (Real.log (n : ℝ) / (n : ℝ)))
+      atTop (𝓝 0) := by
+    have := hconst.add (hlog.const_mul 3)
+    simpa using this
+  refine hsum.congr' ?_
+  filter_upwards [eventually_gt_atTop 0] with n hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  rw [Real.log_mul (by norm_num) (by positivity), Real.log_pow]
+  field_simp
+  ring
+
+/-- **Axiom eliminated.** `log p_n / n → 0`, where `p_n` is the 1-indexed `n`-th prime.
+
+This is the PNT consequence that the parent file `Erdos453OQ02.lean` axiomatized as
+`logPrime_ratio_tendsto_zero`. It is proved here purely from the elementary Chebyshev lower
+bound (via the central binomial coefficient), with no appeal to the full Prime Number
+Theorem. -/
+theorem logPrime_ratio_tendsto_zero :
+    Tendsto (fun n => logPrime n / n) atTop (𝓝 0) := by
+  refine squeeze_zero' ?_ ?_ upper_tendsto_zero
+  · -- `0 ≤ log p_n / n` eventually (in fact `p_n ≥ 2`, so `log p_n ≥ 0`)
+    filter_upwards [eventually_ge_atTop 2] with n hn
+    apply div_nonneg _ (by positivity)
+    unfold logPrime
+    apply Real.log_nonneg
+    unfold nthPrime
+    rw [if_neg (by omega)]
+    have : Nat.Prime (Nat.nth Nat.Prime (n - 1)) := Nat.prime_nth_prime (n - 1)
+    exact_mod_cast this.one_lt.le
+  · -- `log p_n / n ≤ log(2 n^3) / n` eventually
+    filter_upwards [eventually_ge_atTop 2] with n hn
+    have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (by omega : 0 < n)
+    have hle : logPrime n ≤ Real.log (2 * (n : ℝ) ^ 3) := by
+      unfold logPrime
+      apply Real.log_le_log
+      · have : Nat.Prime (nthPrime n) := by
+          unfold nthPrime; rw [if_neg (by omega)]; exact Nat.prime_nth_prime (n - 1)
+        exact_mod_cast this.pos
+      · have hb := nthPrime_le_cube hn
+        have : ((nthPrime n : ℕ) : ℝ) ≤ ((2 * n ^ 3 : ℕ) : ℝ) := by exact_mod_cast hb
+        push_cast at this ⊢
+        linarith
+    gcongr
+
+/-!
+## Part IV: The one remaining axiom (Pomerance's geometric lemma)
+
+The PNT-consequence axiom is gone. What remains is the genuine mathematical core of
+Pomerance's 1979 argument: a sublinear discrete curve has infinitely many upper convex-hull
+vertices. Formalizing this requires discrete convex-hull theory not yet in Mathlib, so it
+stays as the single remaining axiom.
+-/
+
+/-- `(n, a_n)` is an upper convex-hull vertex if `2 a_n > a_{n-i} + a_{n+i}` for all `0 < i < n`. -/
+def IsConvexHullVertex (a : ℕ → ℝ) (n : ℕ) : Prop :=
+  ∀ i : ℕ, 0 < i → i < n → 2 * a n > a (n - i) + a (n + i)
+
+/-- **Axiom (Pomerance's key lemma).** Any sequence with `a_n = o(n)` has infinitely many
+upper convex-hull vertices. The deep geometric result from Pomerance (1979); a full proof
+needs discrete convex-hull theory for `ℕ → ℝ` sequences, not yet available in Mathlib. -/
+axiom pomerance_convex_hull_lemma (a : ℕ → ℝ)
+    (h : Filter.Tendsto (fun n => a n / n) Filter.atTop (nhds 0)) :
+    ∀ N : ℕ, ∃ n ≥ N, IsConvexHullVertex a n
+
+/-!
+## Part V: Re-deriving Pomerance's theorem with a single axiom
+-/
+
+/-- If `(n, log p_n)` is an upper convex-hull vertex then `p_n² > p_{n-i}·p_{n+i}` for all `i`. -/
+theorem convexity_implies_product_bound (n : ℕ) (hn : n ≥ 2)
+    (hv : IsConvexHullVertex logPrime n) :
+    ∀ i : ℕ, 0 < i → i < n →
+      (nthPrime n : ℤ) ^ 2 > (nthPrime (n + i) : ℤ) * (nthPrime (n - i) : ℤ) := by
+  intro i hi_pos hi_lt
+  have hvi := hv i hi_pos hi_lt
+  unfold logPrime at hvi
+  have hp_n : (0 : ℝ) < nthPrime n :=
+    Nat.cast_pos.mpr (Nat.Prime.pos (nthPrime_is_prime n (by omega)))
+  have hp_ni : (0 : ℝ) < nthPrime (n - i) :=
+    Nat.cast_pos.mpr (Nat.Prime.pos (nthPrime_is_prime (n - i) (by omega)))
+  have hp_pi : (0 : ℝ) < nthPrime (n + i) :=
+    Nat.cast_pos.mpr (Nat.Prime.pos (nthPrime_is_prime (n + i) (by omega)))
+  have h_log : Real.log ((nthPrime (n - i) : ℝ) * nthPrime (n + i)) <
+      Real.log ((nthPrime n : ℝ) ^ 2) := by
+    calc Real.log ((nthPrime (n - i) : ℝ) * nthPrime (n + i))
+        = Real.log (nthPrime (n - i)) + Real.log (nthPrime (n + i)) :=
+          Real.log_mul (ne_of_gt hp_ni) (ne_of_gt hp_pi)
+      _ < 2 * Real.log (nthPrime n) := by linarith
+      _ = Real.log ((nthPrime n : ℝ) ^ 2) := by rw [Real.log_pow]; ring
+  have h_real : (nthPrime (n - i) : ℝ) * nthPrime (n + i) < (nthPrime n : ℝ) ^ 2 :=
+    (Real.log_lt_log_iff (mul_pos hp_ni hp_pi) (pow_pos hp_n 2)).mp h_log
+  exact_mod_cast show nthPrime n ^ 2 > nthPrime (n + i) * nthPrime (n - i) by
+    calc nthPrime n ^ 2
+        > nthPrime (n - i) * nthPrime (n + i) := by exact_mod_cast h_real
+      _ = nthPrime (n + i) * nthPrime (n - i) := Nat.mul_comm _ _
+
+/-- **Pomerance (1979), with a single axiom.** There are infinitely many `n` such that
+`p_n² > p_{n+i}·p_{n-i}` for all `0 < i < n`. Now depends only on
+`pomerance_convex_hull_lemma`; the PNT-consequence axiom has been discharged. -/
+theorem pomerance_1979 :
+    ∀ N : ℕ, ∃ n ≥ N,
+      ∀ i : ℕ, 0 < i → i < n →
+        (nthPrime n : ℤ) ^ 2 > (nthPrime (n + i) : ℤ) * (nthPrime (n - i) : ℤ) := by
+  intro N
+  obtain ⟨n, hn, hv⟩ :=
+    pomerance_convex_hull_lemma logPrime logPrime_ratio_tendsto_zero (max N 2)
+  refine ⟨n, by omega, ?_⟩
+  exact convexity_implies_product_bound n (by omega) hv
+
+/-- **Consecutive-primes corollary (`i = 1`).** Infinitely many `n ≥ 2` with
+`p_n² > p_{n-1}·p_{n+1}`. -/
+theorem pomerance_consecutive_primes :
+    ∀ N : ℕ, ∃ n ≥ max N 2,
+      (nthPrime n : ℤ) ^ 2 > (nthPrime (n + 1) : ℤ) * (nthPrime (n - 1) : ℤ) := by
+  intro N
+  obtain ⟨n, hn_ge, hn_main⟩ := pomerance_1979 (max N 2)
+  refine ⟨n, hn_ge, ?_⟩
+  have hn2 : n ≥ 2 := le_trans (le_max_right N 2) hn_ge
+  exact hn_main 1 (by omega) (by omega)
+
+/-!
+## Part VI: Summary of axiom elimination
+
+| File                  | axioms | sorries |
+|-----------------------|--------|---------|
+| Erdos453Problem.lean  |   4    |   1     |
+| Erdos453OQ02.lean     |   2    |   0     |
+| Erdos453OQ02OQ01.lean |   1    |   0     |   ← this file
+
+Eliminated here: `logPrime_ratio_tendsto_zero` (PNT consequence), proved from the
+elementary Chebyshev lower bound `π(2n) ≳ n/log n` via the central binomial coefficient.
+
+Remaining axiom: `pomerance_convex_hull_lemma` — the discrete convex-hull lemma that is the
+true geometric heart of Pomerance's proof.
+-/
+
+theorem axiom_elimination_summary :
+    ∀ N : ℕ, ∃ n ≥ N,
+      ∀ i : ℕ, 0 < i → i < n →
+        (nthPrime n : ℤ) ^ 2 > (nthPrime (n + i) : ℤ) * (nthPrime (n - i) : ℤ) :=
+  pomerance_1979
+
+end Erdos453OQ02OQ01

--- a/src/data/proofs/erdos-453-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-453-oq-02-oq-01/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "erdos-453-oq-02-oq-01",
+  "title": "Erdős 453: Eliminating the PNT Axiom log p_n / n → 0",
+  "slug": "erdos-453-oq-02-oq-01",
+  "description": "Eliminates the axiom logPrime_ratio_tendsto_zero from Erdős #453's OQ-02 formalization by proving log p_n / n → 0 directly from an elementary Chebyshev lower bound π(2n) ≳ n/log n, derived from the central binomial coefficient — no full Prime Number Theorem required. The parent's axiom count drops from 2 to 1.",
+  "meta": {
+    "author": "Researcher Agent (Lean Genius)",
+    "sourceUrl": "https://erdosproblems.com/453",
+    "date": "1979",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos453OQ02OQ01.lean",
+    "tags": ["erdos", "number-theory", "primes", "prime-counting", "chebyshev", "axiom-elimination", "central-binomial"],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 453,
+    "erdosUrl": "https://erdosproblems.com/453",
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {"theorem": "Nat.four_pow_lt_mul_centralBinom", "description": "4^n < n · C(2n,n): exponential lower bound on the central binomial coefficient", "module": "Mathlib.Data.Nat.Choose.Central"},
+      {"theorem": "Nat.pow_factorization_choose_le", "description": "Each prime power dividing a binomial coefficient C(n,k) is at most n", "module": "Mathlib.Data.Nat.Choose.Factorization"},
+      {"theorem": "Nat.factorization_prod_pow_eq_self", "description": "A positive natural equals the product over its prime support of p^{e_p}", "module": "Mathlib.Data.Nat.Factorization.Defs"},
+      {"theorem": "Nat.nth_lt_of_lt_count", "description": "k < count p N → nth p k < N: the count/nth Galois inversion", "module": "Mathlib.Data.Nat.Nth"},
+      {"theorem": "Nat.lt_two_pow_self", "description": "n < 2^n", "module": "Mathlib.Algebra.Order.Monoid.Lemmas"},
+      {"theorem": "Real.isLittleO_log_id_atTop", "description": "log =o[atTop] id, giving log x / x → 0", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"},
+      {"theorem": "tendsto_const_div_atTop_nhds_zero_nat", "description": "c / n → 0 as n → ∞ over ℕ", "module": "Mathlib.Order.Filter.AtTopBot.Archimedean"}
+    ],
+    "originalContributions": [
+      "centralBinom_le_pow_primeCounting: C(2n,n) ≤ (2n)^{π(2n)}, bounding the central binomial coefficient by its prime support",
+      "four_pow_lt_mul_pow_primeCounting: the packaged Chebyshev lower bound 4^n < n·(2n)^{π(2n)} for n ≥ 4",
+      "nth_prime_le_two_mul: inversion of the Chebyshev bound — if n·(2n)^k ≤ 4^n then the k-th prime is ≤ 2n",
+      "nat_pow_ineq: the explicit ℕ inequality (k+1)^3·(2(k+1)^3)^k ≤ 4^{(k+1)^3} via reduction to powers of 2",
+      "nth_prime_le_cube: explicit elementary bound nth Prime k ≤ 2(k+1)^3 for the k-th prime",
+      "upper_tendsto_zero: the squeeze majorant log(2n^3)/n → 0",
+      "logPrime_ratio_tendsto_zero: PROVED (was an axiom in the parent) — log p_n / n → 0 with no full PNT",
+      "pomerance_1979 and pomerance_consecutive_primes: re-derived from the single remaining axiom"
+    ],
+    "axiomCount": 1,
+    "lineCount": 340,
+    "assumptions": "1 axiom remains: pomerance_convex_hull_lemma (Pomerance's discrete convex-hull lemma — a sublinear ℕ→ℝ sequence has infinitely many upper convex-hull vertices; requires discrete convex-hull theory not yet in Mathlib). The PNT-consequence axiom logPrime_ratio_tendsto_zero has been eliminated, reducing the parent OQ-02 from 2 axioms to 1.",
+    "theoremCount": 13,
+    "definitionCount": 3
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat", "Real", "Filter", "Finset"],
+    "namespace": "Erdos453OQ02OQ01",
+    "lineCount": 340,
+    "axiomCount": 1,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos453OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {"targetId": "erdos-453-oq-02", "relationship": "parent", "description": "Parent axiom-elimination file (4 → 2 axioms). This OQ answers its first open question, proving the axiom logPrime_ratio_tendsto_zero and reducing the count from 2 to 1."},
+    {"targetId": "erdos-453", "relationship": "ancestor", "description": "Original Erdős #453 formalization (4 axioms + 1 sorry)."}
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #453 asks whether infinitely many primes p_n satisfy p_n² > p_{n+i}·p_{n-i} for all i. Pomerance (1979) solved it via the 'prime number graph': plot (n, log p_n). By the Prime Number Theorem log p_n ~ log n = o(n), so the curve is sublinear, and a sublinear discrete curve has infinitely many upper convex-hull vertices; at each such vertex the concavity 2 log p_n > log p_{n-i} + log p_{n+i} is exactly p_n² > p_{n-i}·p_{n+i}. The Lean formalization split into two axioms: (1) the sublinearity input log p_n / n → 0, and (2) the convex-hull lemma. This file discharges (1).",
+    "problemStatement": "Open question 1 of Erdos453OQ02.lean: can logPrime_ratio_tendsto_zero (log p_n / n → 0) be proved from Mathlib's prime-counting machinery rather than left as an axiom?",
+    "text": "The crucial observation is that log p_n / n → 0 is much weaker than the full Prime Number Theorem: it only asserts that the n-th prime grows subexponentially (p_n^{1/n} → 1), which follows from an elementary Chebyshev-type LOWER bound on π. We build that lower bound from the central binomial coefficient C(2n,n): on one hand 4^n < n·C(2n,n) (Mathlib), and on the other C(2n,n) = ∏_{p≤2n} p^{e_p} with each prime power p^{e_p} ≤ 2n, so C(2n,n) ≤ (2n)^{π(2n)}. Combining gives (2n)^{π(2n)} > 4^n/n, i.e. π(2n) ≳ n/log n. Inverting through the Nat.count/Nat.nth Galois connection yields the explicit (loose) bound p_k ≤ 2(k+1)^3, whence log p_k = O(log k) = o(k), and a squeeze delivers the limit.",
+    "proofStrategy": "(I) Bound C(2n,n) ≤ (2n)^{π(2n)} via prime factorization. (II) Combine with 4^n < n·C(2n,n) to get the Chebyshev lower bound 4^n < n·(2n)^{π(2n)}. (III) Invert: choosing n = (k+1)^3 and proving the elementary inequality n·(2n)^k ≤ 4^n shows π(2n) > k, hence nth Prime k ≤ 2n = 2(k+1)^3. (IV) log(2(k+1)^3) = O(log k), so log p_n / n is squeezed between 0 and log(2n^3)/n → 0.",
+    "keyInsights": [
+      "log p_n / n → 0 needs only a Chebyshev LOWER bound on π, not the full PNT — Mathlib supplies all the central-binomial ingredients.",
+      "The bound C(2n,n) ≤ (2n)^{π(2n)} converts the multiplicative structure of the central binomial coefficient into a count of primes.",
+      "A deliberately loose cubic upper bound p_k ≤ 2(k+1)^3 keeps the supporting ℕ inequality provable by reducing both sides to powers of 2, while still being o(exponential) — enough for the asymptotics.",
+      "The Nat.count / Nat.nth Galois connection (nth_lt_of_lt_count) cleanly inverts a lower bound on π into an upper bound on the n-th prime."
+    ],
+    "prerequisites": ["Central binomial coefficients", "Chebyshev's elementary prime bounds", "Prime counting function π", "Asymptotic (little-o) notation", "Squeeze theorem for filters"]
+  },
+  "sections": [
+    {"id": "part-1", "title": "Part I: The Prime Sequence (Axiom-Free)", "startLine": 53, "endLine": 70, "summary": "Defines the 1-indexed nthPrime and proves nthPrime_is_prime.", "mathContext": "p_n = Nat.nth Nat.Prime (n-1)."},
+    {"id": "part-2", "title": "Part II: Chebyshev Lower Bound from the Central Binomial Coefficient", "startLine": 72, "endLine": 175, "summary": "C(2n,n) ≤ (2n)^{π(2n)}; the packaged bound 4^n < n·(2n)^{π(2n)}; inversion to nth Prime k ≤ 2(k+1)^3.", "mathContext": "π(2n) ≳ n/log n, inverted to an explicit prime bound."},
+    {"id": "part-3", "title": "Part III: log p_n / n → 0 (the eliminated axiom)", "startLine": 177, "endLine": 240, "summary": "Squeeze between 0 and log(2n^3)/n to prove logPrime_ratio_tendsto_zero as a theorem.", "mathContext": "Subexponential prime growth from the Chebyshev bound."},
+    {"id": "part-4", "title": "Part IV: The One Remaining Axiom (Pomerance's geometric lemma)", "startLine": 242, "endLine": 270, "summary": "States the single remaining axiom: a sublinear discrete curve has infinitely many upper convex-hull vertices.", "mathContext": "Discrete convex-hull theory, not yet in Mathlib."},
+    {"id": "part-5", "title": "Part V: Re-deriving Pomerance's Theorem with a Single Axiom", "startLine": 272, "endLine": 330, "summary": "Re-derives pomerance_1979 and the consecutive-primes corollary from the one remaining axiom plus the proved limit.", "mathContext": "p_n² > p_{n-i}·p_{n+i} for infinitely many n."}
+  ],
+  "conclusion": {
+    "summary": "The PNT-consequence axiom logPrime_ratio_tendsto_zero is eliminated. log p_n / n → 0 is proved from scratch using an elementary Chebyshev lower bound π(2n) ≳ n/log n built from the central binomial coefficient, requiring no full Prime Number Theorem. Erdős #453's OQ-02 axiom count drops from 2 to 1; the only remaining axiom is Pomerance's discrete convex-hull lemma.",
+    "implications": "This isolates the genuine mathematical depth of Problem #453. Of the two OQ-02 axioms, the analytic-number-theory input (subexponential prime growth) turns out to be elementary and fully formalizable, while the combinatorial-geometry input (infinitely many convex-hull vertices of a sublinear curve) is the real obstacle. The reusable contribution is the verified, axiom-free Chebyshev lower bound π(2n) ≳ n/log n in the packaged form 4^n < n·(2n)^{π(2n)}, together with its inversion into an explicit upper bound on the n-th prime — a building block usable wherever a cheap p_n = O(poly) estimate is needed.",
+    "openQuestions": [
+      "Can pomerance_convex_hull_lemma be discharged by developing discrete convex-hull theory for ℕ → ℝ sequences in Mathlib, completing a fully verified (0-axiom) proof of Erdős #453?",
+      "Can the cubic bound nth Prime k ≤ 2(k+1)^3 be sharpened to the true p_k = O(k log k) using the matching upper Chebyshev bound (Mathlib's theta_le_log4_mul_x), and is the sharper bound worth the extra cost for any downstream application?",
+      "Does the verified Chebyshev lower bound 4^n < n·(2n)^{π(2n)} suffice to prove other elementary prime-density statements in the gallery (e.g. divergence of ∑ 1/p_n with an explicit rate)?"
+    ]
+  },
+  "references": [
+    {"key": "pomerance1979", "title": "The prime number graph", "author": "C. Pomerance", "year": "1979", "volume": "33", "pages": "399-408", "venue": "Mathematics of Computation"},
+    {"key": "chebyshev1852", "title": "Mémoire sur les nombres premiers", "author": "P. L. Chebyshev", "year": "1852", "venue": "J. Math. Pures Appl."},
+    {"key": "mathlib-central", "title": "Mathlib: Central Binomial Coefficients and Prime Factorization", "author": "Mathlib Contributors", "year": "2024", "venue": "Mathlib4"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 1** of `Erdos453OQ02.lean`: it proves the axiom `logPrime_ratio_tendsto_zero` (`log p_n / n → 0`) as a **theorem**, with **no appeal to the full Prime Number Theorem**. This reduces the parent OQ-02's axiom count from **2 → 1**.

## Mathematical content

`log p_n / n → 0` (equivalently `p_n^{1/n} → 1`: the n-th prime grows subexponentially) is far weaker than PNT — it needs only an elementary **Chebyshev lower bound** on the prime-counting function `π`, built here from the central binomial coefficient:

- `4^n < n · C(2n,n)`  (Mathlib: `Nat.four_pow_lt_mul_centralBinom`)
- `C(2n,n) = ∏_{p ≤ 2n} p^{e_p}` with each prime power `p^{e_p} ≤ 2n`, hence `C(2n,n) ≤ (2n)^{π(2n)}`

Combining: `(2n)^{π(2n)} > 4^n / n`, i.e. `π(2n) ≳ n / log n`. Inverting through the `Nat.count`/`Nat.nth` Galois connection gives the explicit (loose but elementary) bound `nth Prime k ≤ 2(k+1)^3`, so `log p_n = O(log n) = o(n)`, and a squeeze finishes the limit.

## Axiom status

| File | axioms | sorries |
|------|--------|---------|
| Erdos453Problem.lean | 4 | 1 |
| Erdos453OQ02.lean | 2 | 0 |
| **Erdos453OQ02OQ01.lean (this PR)** | **1** | **0** |

`#print axioms logPrime_ratio_tendsto_zero` → `[propext, Classical.choice, Quot.sound]` only (**axiom-free** by the project's axiom-integrity policy). The sole remaining axiom is `pomerance_convex_hull_lemma` (the discrete convex-hull lemma — genuine geometric core, needs convex-hull theory not yet in Mathlib). The main result `pomerance_1979` and the consecutive-primes corollary are re-derived from that single axiom.

## Verification

- `lean v4.26.0`, `import Mathlib`; typechecks clean (EXIT 0), **0 sorries**.
- 13 theorems, 3 definitions, 1 axiom, 340 lines.
- Reusable artifact: the verified Chebyshev lower bound `4^n < n·(2n)^{π(2n)}` and its inversion to an explicit prime upper bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)