### PR TITLE
Enrich 'General Orbit-Counting under an Arbitrary Finite Group': index.ts + annotations + sections

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "The unweighted Cauchy–Frobenius generalization",
+    "content": "The docstring states the parent's open question — generalize the cyclic necklace orbit-count to an arbitrary finite group — and the two results delivered: (A) the per-element count |Fix(g)| = k^cyc(g), and (B) the Burnside averaging Σ_g k^cyc(g) = (#distinct colorings)·|G|. It is explicit that the WEIGHTED Pólya cycle-index theorem is out of scope because Mathlib lacks cycle-index machinery; this leaf proves the honest unweighted core, which is the genuine gallery gap. cyc(g) is the number of orbits of the cyclic subgroup ⟨g⟩ on X, i.e. the number of cycles of the permutation x ↦ g•x.",
+    "mathContext": "$\\#\\text{orbits} = \\tfrac{1}{|G|}\\sum_{g\\in G} k^{\\mathrm{cyc}(g)}$, where $\\mathrm{cyc}(g) = $ number of $\\langle g\\rangle$-orbits on $X$.",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "Cauchy–Frobenius lemma", "Pólya enumeration", "necklace counting"],
+    "prerequisites": ["group actions", "orbits and stabilizers"]
+  },
+  {
+    "id": "ann-coloring-action",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 48, "endLine": 68 },
+    "type": "definition",
+    "title": "The domain-permutation coloring action",
+    "content": "Defines how G acts on colorings c : X → Fin k by permuting the domain: (g • c) x = c (g⁻¹ • x). The inverse on the argument is exactly what makes this a genuine LEFT action — `mul_smul` works because (gh)⁻¹ = h⁻¹g⁻¹ matches applying h then g. Crucially this does not clash with Mathlib's generic `Pi.mulAction`, because the codomain Fin k carries no G-action, so the standard orbit/fixedBy/stabilizer API applies directly to colorings. The `coloring_smul_apply` simp lemma unfolds the action definitionally (rfl).",
+    "mathContext": "$(g \\cdot c)(x) = c(g^{-1}\\cdot x)$; the inverse gives $((gh)\\cdot c)(x) = c((gh)^{-1}x) = c(h^{-1}g^{-1}x) = (g\\cdot(h\\cdot c))(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["left group action", "MulAction instance", "Pi.mulAction", "mul_smul"],
+    "prerequisites": ["MulAction typeclass", "group inverse identities"]
+  },
+  {
+    "id": "ann-zpowers-fixed",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 70, "endLine": 86 },
+    "type": "technique",
+    "title": "Fixed by g ⟹ fixed by the whole cyclic subgroup ⟨g⟩",
+    "content": "The conceptual heart of (A). If g•c = c then g lies in the stabilizer of c, which is a SUBGROUP; hence the entire cyclic subgroup ⟨g⟩ = Subgroup.zpowers g sits inside the stabilizer (via `Subgroup.zpowers_le`). `zpowers_smul_eq_of_fixed` packages this: every h ∈ ⟨g⟩ fixes c. `const_on_zpowers` then evaluates the invariance pointwise — c (h • x) = c x for h ∈ ⟨g⟩ — by applying the fixed equation at h•x and cancelling with `inv_smul_smul`. So a g-fixed coloring is exactly one that is constant on each ⟨g⟩-orbit.",
+    "mathContext": "$g \\in \\mathrm{stab}(c) \\Rightarrow \\langle g\\rangle \\le \\mathrm{stab}(c) \\Rightarrow \\forall h\\in\\langle g\\rangle,\\ c(h\\cdot x) = c(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["stabilizer is a subgroup", "Subgroup.zpowers", "cyclic subgroup", "invariance"],
+    "prerequisites": ["stabilizer subgroup", "zpowers_le"]
+  },
+  {
+    "id": "ann-bijection",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 88, "endLine": 125 },
+    "type": "insight",
+    "title": "The orbit-quotient bijection",
+    "content": "The key equivalence: g-fixed colorings biject with functions on the ⟨g⟩-orbit quotient `CycQuot g`. The forward map is `Quotient.lift c`, well-defined precisely because c is constant on orbits (the previous lemma supplies the descent condition via `mem_orbit_iff`). The inverse pulls a function f on the quotient back through `Quotient.mk`; the resulting coloring is automatically g-invariant because g⁻¹ ∈ ⟨g⟩ keeps each point in its orbit (`Quotient.sound`). Both round-trips are rfl/induction on the quotient. Identifying the fixed set with a function space on a size-cyc(g) quotient is what makes the cardinality count forced.",
+    "mathContext": "$\\{c : g\\cdot c = c\\} \\;\\simeq\\; (\\langle g\\rangle\\text{-orbit quotient}) \\to \\mathrm{Fin}\\,k$, via $\\mathrm{Quotient.lift}$ / $\\mathrm{Quotient.mk}$.",
+    "significance": "key",
+    "relatedConcepts": ["Quotient.lift", "Quotient.sound", "orbit quotient", "type equivalence"],
+    "prerequisites": ["quotient types", "orbitRel.Quotient", "Equiv"]
+  },
+  {
+    "id": "ann-card-fixed",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 127, "endLine": 135 },
+    "type": "technique",
+    "title": "(A) Per-element count: |Fix(g)| = k^cyc(g)",
+    "content": "Result (A). The fixedBy set is rewritten to the subtype {c // g•c = c} via `Equiv.subtypeEquivRight` and `mem_fixedBy`, then through the orbit-quotient bijection to (CycQuot g → Fin k). Counting with `Nat.card_fun` (Nat.card of a function type is |codomain|^|domain|) and `Fintype.card_fin` gives k raised to the number of ⟨g⟩-orbits, which is cyc(g) by definition. This holds for an arbitrary g in an arbitrary finite group — no cyclic-group assumption.",
+    "mathContext": "$\\mathrm{Nat.card}(\\mathrm{fixedBy}\\,g) = (\\#\\mathrm{Fin}\\,k)^{\\mathrm{cyc}(g)} = k^{\\mathrm{cyc}(g)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_fun", "fixedBy", "cardinality of function types", "Equiv.subtypeEquivRight"],
+    "prerequisites": ["finite cardinality", "function space cardinality"]
+  },
+  {
+    "id": "ann-burnside-average",
+    "proofId": "burnside-counting-oq-03-oq-02",
+    "range": { "startLine": 137, "endLine": 157 },
+    "type": "insight",
+    "title": "(B) Burnside averaging over the group",
+    "content": "Result (B), the headline orbit-counting identity. Mathlib's `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` applied to the coloring action gives Σ_g |Fix(g)| = (#color-orbits)·|G|. Substituting (A) for each summand via `Finset.sum_congr` turns the left side into Σ_g k^cyc(g), yielding the integer form of Burnside's average #orbits = (1/|G|) Σ_g k^cyc(g). The `Fintype.ofFinite` instances bridge Mathlib's Fintype-stated lemma to the Nat.card formulation. This is the group-agnostic master formula specializing to every concrete necklace/bracelet count in the gallery.",
+    "mathContext": "$\\sum_{g\\in G} k^{\\mathrm{cyc}(g)} = \\#\\mathrm{ColorOrbits}\\cdot |G|$, i.e. $\\#\\text{distinct colorings} = \\tfrac{1}{|G|}\\sum_g k^{\\mathrm{cyc}(g)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "orbit counting", "Finset.sum_congr", "Fintype.ofFinite"],
+    "prerequisites": ["Burnside identity in Mathlib", "summation over a finite group"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-03-oq-02/index.ts
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BurnsideCountingOQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const burnsideCountingOQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const burnsideCountingOQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const burnsideCountingOQ03OQ02Data: ProofData = {
+  proof: burnsideCountingOQ03OQ02Proof,
+  annotations: burnsideCountingOQ03OQ02Annotations,
+}

--- a/src/data/proofs/burnside-counting-oq-03-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02/meta.json
@@ -86,6 +86,56 @@
     "how": "Prove the per-element count |Fix(g)| = k^{cyc(g)} by an explicit bijection between g-fixed colorings and functions on the ⟨g⟩-orbit quotient of X (a coloring is fixed by g iff constant on ⟨g⟩-orbits), then combine with Mathlib's Burnside identity to average over the group.",
     "significance": "This is the group-agnostic master formula behind every concrete necklace/bracelet count in the gallery. The cyclic value k^{gcd(r,n)} (since cyc(rotation r) = gcd(r,n)) and the dihedral reflection counts k^{(n+1)/2}, k^{n/2+1}, k^{n/2} are all instances of k^{cyc(g)}, turning per-group ad-hoc computations into specializations of one theorem and supplying the bridge the parent entry asked for between the bespoke cyclic formalization and Mathlib's abstract MulAction orbit-counting API."
   },
+  "sections": [
+    {
+      "id": "sec-docstring",
+      "title": "Statement and Scope",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Docstring framing the parent open question (generalize cyclic necklace counting to an arbitrary finite group), stating results (A) |Fix(g)| = k^cyc(g) and (B) Σ_g k^cyc(g) = (#distinct colorings)·|G|, defining cyc(g) as the number of ⟨g⟩-orbits, and scoping out the weighted Pólya cycle-index theorem (Mathlib-absent).",
+      "mathContext": "$\\#\\text{orbits} = \\tfrac{1}{|G|}\\sum_{g} k^{\\mathrm{cyc}(g)}$."
+    },
+    {
+      "id": "sec-action",
+      "title": "Section I: The Coloring Action",
+      "startLine": 48,
+      "endLine": 68,
+      "summary": "Defines the domain-permutation MulAction G (X → Fin k) by (g • c) x = c (g⁻¹ • x); the inverse makes it a left action, with no clash with Pi.mulAction since Fin k carries no G-action. Includes the coloring_smul_apply simp lemma.",
+      "mathContext": "$(g\\cdot c)(x) = c(g^{-1}\\cdot x)$, a genuine left action via $(gh)^{-1} = h^{-1}g^{-1}$."
+    },
+    {
+      "id": "sec-constant-orbits",
+      "title": "Section II: Fixed ⟹ Constant on ⟨g⟩-orbits",
+      "startLine": 70,
+      "endLine": 86,
+      "summary": "zpowers_smul_eq_of_fixed: a g-fixed coloring is fixed by the whole cyclic subgroup ⟨g⟩ (stabilizer is a subgroup ⊇ ⟨g⟩ via Subgroup.zpowers_le). const_on_zpowers: hence c (h • x) = c x for h ∈ ⟨g⟩, proved by evaluating invariance and cancelling with inv_smul_smul.",
+      "mathContext": "$g\\in\\mathrm{stab}(c)\\Rightarrow\\langle g\\rangle\\le\\mathrm{stab}(c)\\Rightarrow c(h\\cdot x)=c(x)$ for $h\\in\\langle g\\rangle$."
+    },
+    {
+      "id": "sec-bijection",
+      "title": "Section III: The Orbit-Quotient Bijection",
+      "startLine": 88,
+      "endLine": 125,
+      "summary": "Defines CycQuot g (the ⟨g⟩-orbit quotient of X) and cyc g = Nat.card CycQuot g. fixedColoringEquiv: g-fixed colorings ≃ functions on the orbit quotient — forward via Quotient.lift (well-defined since c is constant on orbits), inverse via Quotient.mk (g-invariant since g⁻¹ ∈ ⟨g⟩), round-trips by rfl/induction.",
+      "mathContext": "$\\{c : g\\cdot c=c\\}\\simeq (\\langle g\\rangle\\text{-orbit quotient})\\to\\mathrm{Fin}\\,k$."
+    },
+    {
+      "id": "sec-per-element",
+      "title": "Section IV: (A) Per-Element Fixed-Point Count",
+      "startLine": 127,
+      "endLine": 135,
+      "summary": "card_fixedBy_eq_pow_cyc: Nat.card (fixedBy (X → Fin k) g) = k^cyc(g). Combines Equiv.subtypeEquivRight + fixedColoringEquiv with Nat.card_fun and Fintype.card_fin to count functions on a size-cyc(g) quotient into Fin k.",
+      "mathContext": "$\\mathrm{Nat.card}(\\mathrm{fixedBy}\\,g) = k^{\\mathrm{cyc}(g)}$."
+    },
+    {
+      "id": "sec-averaging",
+      "title": "Section V: (B) Burnside Orbit-Counting",
+      "startLine": 137,
+      "endLine": 159,
+      "summary": "sum_pow_cyc_eq_card_orbits_mul_card: Σ_g k^cyc(g) = (#ColorOrbits)·|G|, from Mathlib's Burnside identity sum_card_fixedBy_eq_card_orbits_mul_card_group with (A) substituted termwise via Finset.sum_congr. ColorOrbits is the orbit quotient of the full G-action on colorings.",
+      "mathContext": "$\\sum_{g} k^{\\mathrm{cyc}(g)} = \\#\\mathrm{ColorOrbits}\\cdot|G|$."
+    }
+  ],
   "conclusion": {
     "summary": "Proves the unweighted Burnside / Cauchy–Frobenius orbit-counting theorem for k-colorings of a finite set under an arbitrary finite group: (A) the per-element fixed-point count |Fix(g)| = k^{cyc(g)} via an explicit bijection with functions on the ⟨g⟩-orbit quotient, and (B) the averaging form Σ_g k^{cyc(g)} = (#distinct colorings)·|G|. Fully verified with 0 sorries and 0 axioms.",
     "implications": "Generalizes the parent's cyclic necklace count to an arbitrary finite group acting on arbitrary positions, the honest tractable answer to the parent's open question 'generalize from cyclic groups to arbitrary finite groups'. It is the unweighted core on top of which a future weighted Pólya cycle-index development could be built, and it directly subsumes the cyclic and dihedral counts elsewhere in the gallery.",


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-03-oq-02` (quality 33, 0 prior passes).

## Gaps addressed
The entry had **only meta.json** — `index.ts` and `annotations.json` were missing, and meta.json had no `sections` array.

1. **Created `index.ts`** (REQUIRED) — without it the proof page renders 'proof not found' on the live site.
2. **Added `annotations.json`** with **6 annotations** covering the full Lean file: the docstring/scope, the coloring action, fixed ⟹ constant on ⟨g⟩-orbits, the orbit-quotient bijection, the per-element count (A) |Fix(g)| = k^cyc(g), and the Burnside averaging (B). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
3. **Added a `sections` array** to meta.json covering all five source sections with summaries and `mathContext`.

## Verification
- meta.json and annotations.json validate as JSON; `pnpm build` passes end-to-end (annotations:build, research:build, research:enrich, tsc, vite).
- Axiom integrity preserved: meta declares `status: verified`, `badge: original`, `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom declarations, no structure-encoded assumptions, no native_decide; #print axioms confirms only propext/Classical.choice/Quot.sound). No claims changed.