### PR TITLE
research(inclusion-exclusion-oq-03-oq-01): fast zeta transform correctness [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/InclusionExclusionOQ03.lean
+++ b/proofs/Proofs/InclusionExclusionOQ03.lean
@@ -122,8 +122,8 @@ theorem signed_sum_subsets (S : Finset α) :
       apply sum_congr rfl; intro T _; simp [prod_const]
     linarith
 
-/-- **Möbius inversion theorem**: μ ∘ ζ = id on subset functions.
-    For any f : 2^α → ℤ, if g = ζf then μg = f. -/
+/- **Möbius inversion theorem**: μ ∘ ζ = id on subset functions.
+   For any f : 2^α → ℤ, if g = ζf then μg = f.  (proved as `mobius_inverts_zeta` below) -/
 /-- Inner sum identity: ∑_{T: U⊆T⊆S} (-1)^|S\T| = [U = S].
     Via bijection T ↦ T\U between {T : U⊆T⊆S} and (S\U).powerset,
     this reduces to signed_sum_subsets. -/
@@ -134,37 +134,47 @@ private theorem inner_sum_eq (S U : Finset α) (hU : U ⊆ S) :
   -- Under this bijection |S\T| = |(S\U)\(T\U)|, so the sum equals signed_sum_subsets(S\U).
   -- First establish: S\U = ∅ ↔ U = S
   have sdiff_empty_iff : S \ U = ∅ ↔ U = S := by
-    rw [Finset.sdiff_eq_empty_iff_subset]; exact ⟨fun h => le_antisymm hU h, fun h => h ▸ le_refl _⟩
+    rw [Finset.sdiff_eq_empty_iff_subset]; exact ⟨fun h => le_antisymm hU h, fun h => h.ge⟩
   -- Rewrite each term: |S\T| = |(S\U)\(T\U)| when U ⊆ T ⊆ S
   have card_eq : ∀ T ∈ S.powerset.filter (U ⊆ ·),
       (S \ T).card = ((S \ U) \ (T \ U)).card := by
     intro T hT
     simp only [Finset.mem_filter, Finset.mem_powerset] at hT
     congr 1; ext x; simp only [Finset.mem_sdiff]; tauto
-  conv_lhs => arg 2; ext T; rw [card_eq T (by assumption)]
-  -- Bijection via sum_nbij: T ↦ T\U from {T:U⊆T⊆S} to (S\U).powerset
-  rw [Finset.sum_nbij (fun T => T \ U)
-    (fun T hT => by
+  rw [Finset.sum_congr rfl (fun T hT => by rw [card_eq T hT])]
+  -- Bijection T ↦ T\U (inverse W ↦ W∪U) between {T : U⊆T⊆S} and (S\U).powerset.
+  have hbij :
+      (∑ T ∈ S.powerset.filter (U ⊆ ·), (-1 : ℤ) ^ ((S \ U) \ (T \ U)).card)
+        = ∑ W ∈ (S \ U).powerset, (-1 : ℤ) ^ ((S \ U) \ W).card := by
+    apply Finset.sum_nbij' (fun T => T \ U) (fun W => W ∪ U)
+    · -- maps into target
+      intro T hT
       simp only [Finset.mem_filter, Finset.mem_powerset] at hT ⊢
-      exact Finset.sdiff_subset_sdiff_left hT.1)
-    (fun T₁ hT₁ T₂ hT₂ h => by
-      simp only [Finset.mem_filter, Finset.mem_powerset] at hT₁ hT₂
-      ext x; by_cases hx : x ∈ U
-      · exact ⟨fun _ => hT₂.2 hx, fun _ => hT₁.2 hx⟩
-      · have := Finset.ext_iff.mp h x
-        simp only [Finset.mem_sdiff] at this
-        constructor
-        · intro hx1; exact (this.mp ⟨hx1, hx⟩).1
-        · intro hx2; exact (this.mpr ⟨hx2, hx⟩).1)
-    (fun W hW => by
+      exact Finset.sdiff_subset_sdiff hT.1 (le_refl U)
+    · -- inverse maps back
+      intro W hW
       simp only [Finset.mem_powerset] at hW
-      exact ⟨W ∪ U, by
-        simp only [Finset.mem_filter, Finset.mem_powerset]
-        exact ⟨Finset.union_subset (hW.trans Finset.sdiff_subset) hU, Finset.subset_union_right⟩,
-        by ext x; simp only [Finset.mem_sdiff, Finset.mem_union]; tauto⟩)
-    (fun T _ => rfl)]
+      simp only [Finset.mem_filter, Finset.mem_powerset]
+      exact ⟨Finset.union_subset (hW.trans Finset.sdiff_subset) hU, Finset.subset_union_right⟩
+    · -- left inverse: (T\U)∪U = T  (uses U ⊆ T)
+      intro T hT
+      simp only [Finset.mem_filter, Finset.mem_powerset] at hT
+      exact Finset.sdiff_union_of_subset hT.2
+    · -- right inverse: (W∪U)\U = W  (uses W ⊆ S\U disjoint from U)
+      intro W hW
+      simp only [Finset.mem_powerset] at hW
+      ext x
+      simp only [Finset.mem_sdiff, Finset.mem_union]
+      constructor
+      · rintro ⟨hx | hxU, hxnU⟩
+        · exact hx
+        · exact absurd hxU hxnU
+      · intro hxW
+        exact ⟨Or.inl hxW, fun hxU => (Finset.mem_sdiff.mp (hW hxW)).2 hxU⟩
+    · -- summands agree
+      intro T _; rfl
   -- Now goal: ∑ W ∈ (S\U).powerset, (-1)^|(S\U)\W| = if U = S then 1 else 0
-  rw [signed_sum_subsets]
+  rw [hbij, signed_sum_subsets]
   simp [sdiff_empty_iff]
 
 theorem mobius_inverts_zeta (f : SubsetFn α) :
@@ -172,12 +182,12 @@ theorem mobius_inverts_zeta (f : SubsetFn α) :
   ext S
   simp only [mobiusTransform, zetaTransform]
   simp_rw [Finset.mul_sum]
-  rw [Finset.sum_comm' (s' := S.powerset)
-    (t' := fun U => S.powerset.filter (U ⊆ ·))
+  rw [Finset.sum_comm' (t' := S.powerset)
+    (s' := fun U => S.powerset.filter (U ⊆ ·))
     (h := fun T U => by
       simp only [Finset.mem_powerset, Finset.mem_filter]
-      exact ⟨fun ⟨hTS, hUT⟩ => ⟨hUT.trans hTS, hTS, hUT⟩,
-             fun ⟨_, hTS, hUT⟩ => ⟨hTS, hUT⟩⟩)]
+      exact ⟨fun ⟨hTS, hUT⟩ => ⟨⟨hTS, hUT⟩, hUT.trans hTS⟩,
+             fun ⟨⟨hTS, hUT⟩, _⟩ => ⟨hTS, hUT⟩⟩)]
   conv_lhs => arg 2; ext U; rw [← Finset.sum_mul]; rw [mul_comm]
   have : ∀ U ∈ S.powerset,
       f U * (∑ T ∈ S.powerset.filter (U ⊆ ·), (-1 : ℤ) ^ (S \ T).card) =

--- a/proofs/Proofs/InclusionExclusionOQ0301.lean
+++ b/proofs/Proofs/InclusionExclusionOQ0301.lean
@@ -1,0 +1,174 @@
+import Proofs.InclusionExclusionOQ03
+import Mathlib.Tactic
+
+/-
+# Fast Zeta Transform Correctness: Folding the SOS Step Computes the Subset Sum
+
+## Research Problem: inclusion-exclusion-oq-03-oq-01
+(parent open question #1 of `inclusion-exclusion-oq-03`)
+
+The parent entry defines the single-element "sum over subsets" (SOS) update step
+
+  (ζ_a f)(S) = f(S) + f(S \ {a})   if a ∈ S,     f(S)   if a ∉ S
+
+and proves its two pointwise laws (`zetaStep_mem`, `zetaStep_not_mem`), but stops
+short of proving that *iterating* the step over every element reproduces the full
+zeta transform
+
+  (ζ f)(S) = ∑_{T ⊆ S} f(T).
+
+This file closes that gap: the correctness theorem of the O(n·2ⁿ) fast subset-sum
+dynamic program (Yates / "sum over subsets" DP), which underlies fast subset
+convolution, the Björklund–Husfeldt–Kaski–Koivisto "Fourier meets Möbius"
+algorithm, and many exponential-time exact algorithms.
+
+## Main results (0 axioms, 0 sorries)
+- `zetaFoldList_apply` — the **partial-sweep invariant**: after folding the step
+  over a duplicate-free list `l`, the running array at `S` equals
+  `∑_{T : S \ l.toFinset ⊆ T ⊆ S} f(T)` — exactly the subsets of `S` that agree
+  with `S` outside the already-processed elements `l`.
+- `zetaFold_eq_zetaTransform` — specializing the invariant to `l = univ.toList`
+  collapses the constraint `S \ univ = ∅` and yields the full transform:
+  `zetaFold f = zetaTransform f`.
+- `zetaFold_apply` — the pointwise corollary `zetaFold f S = ∑_{T ⊆ S} f(T)`.
+- `mobius_inverts_zetaFold` — combined with the parent's Möbius inversion, the
+  fast fold is inverted by the Möbius transform: `μ (zetaFold f) = f`.
+
+## References
+- Yates (1937); Knuth, TAOCP vol. 4A §7.1.3 (the SOS DP).
+- Björklund, Husfeldt, Kaski, Koivisto (2007), "Fourier Meets Möbius".
+-/
+
+set_option linter.unusedVariables false
+
+namespace IEOQ03
+
+open Finset
+
+variable {α : Type*} [DecidableEq α] [Fintype α]
+
+-- ============================================================
+-- The fold of the single-element SOS step
+-- ============================================================
+
+/-- Fold the single-element SOS step `zetaStep` over a list of elements.
+    `zetaFoldList [a₁, …, aₙ] f = ζ_{a₁} (ζ_{a₂} (⋯ (ζ_{aₙ} f)))`. -/
+noncomputable def zetaFoldList (l : List α) (f : SubsetFn α) : SubsetFn α :=
+  l.foldr zetaStep f
+
+/-- The fast zeta transform: fold the SOS step over *every* element of the type. -/
+noncomputable def zetaFold (f : SubsetFn α) : SubsetFn α :=
+  zetaFoldList Finset.univ.toList f
+
+-- ============================================================
+-- The partial-sweep invariant
+-- ============================================================
+
+/-- **Partial-sweep invariant.** After folding the SOS step over a duplicate-free
+    list `l`, the value stored at `S` is the sum of `f` over exactly those subsets
+    `T ⊆ S` that agree with `S` on the *un*processed elements, i.e. that contain
+    `S \ l.toFinset`.
+
+    Processing one more (fresh) element `a ∈ S` relaxes the constraint by one
+    coordinate: it lets `T` either keep `a` (the `f S` branch) or drop it (the
+    `f (S.erase a)` branch), which is precisely the SOS recurrence. -/
+theorem zetaFoldList_apply (f : SubsetFn α) :
+    ∀ (l : List α), l.Nodup → ∀ S : Finset α,
+      zetaFoldList l f S
+        = ∑ T ∈ S.powerset.filter (fun T => S \ l.toFinset ⊆ T), f T := by
+  intro l
+  induction l with
+  | nil =>
+    intro _ S
+    -- l = [] : only T = S survives (constraint S ⊆ T together with T ⊆ S)
+    simp only [zetaFoldList, List.foldr_nil, List.toFinset_nil, Finset.sdiff_empty]
+    have hfilter : S.powerset.filter (fun T => S ⊆ T) = {S} := by
+      ext T
+      simp only [Finset.mem_filter, Finset.mem_powerset, Finset.mem_singleton]
+      exact ⟨fun ⟨h1, h2⟩ => le_antisymm h1 h2, fun h => ⟨h.le, h.ge⟩⟩
+    rw [hfilter, Finset.sum_singleton]
+  | cons a rest ih =>
+    intro hnd S
+    rw [List.nodup_cons] at hnd
+    obtain ⟨ha_rest, hrest_nd⟩ := hnd
+    have ha_fin : a ∉ rest.toFinset := by rwa [List.mem_toFinset]
+    have htf : (a :: rest).toFinset = insert a rest.toFinset := by
+      simp [List.toFinset_cons]
+    -- one fold step
+    have hstep : zetaFoldList (a :: rest) f S
+        = zetaStep a (zetaFoldList rest f) S := by
+      simp [zetaFoldList, List.foldr_cons]
+    rw [hstep]
+    by_cases haS : a ∈ S
+    · -- a ∈ S : the SOS recurrence splits the target sum by membership of a.
+      rw [zetaStep_mem a _ S haS, ih hrest_nd S, ih hrest_nd (S.erase a),
+          htf, Finset.sdiff_insert]
+      -- a is forced into S \ rest.toFinset (it is in S and not yet processed)
+      have hmemD : a ∈ S \ rest.toFinset := by
+        rw [Finset.mem_sdiff]; exact ⟨haS, ha_fin⟩
+      -- (S.erase a) \ rest.toFinset = (S \ rest.toFinset).erase a
+      have hE : (S.erase a) \ rest.toFinset = (S \ rest.toFinset).erase a := by
+        ext x; simp only [Finset.mem_sdiff, Finset.mem_erase]; tauto
+      -- P1 (keep a) = (target).filter (a ∈ ·)
+      have hP1 : S.powerset.filter (fun T => S \ rest.toFinset ⊆ T)
+          = (S.powerset.filter (fun T => (S \ rest.toFinset).erase a ⊆ T)).filter
+              (fun T => a ∈ T) := by
+        ext T
+        simp only [Finset.mem_filter, Finset.mem_powerset]
+        constructor
+        · rintro ⟨hTS, hsub⟩
+          exact ⟨⟨hTS, (Finset.erase_subset _ _).trans hsub⟩, hsub hmemD⟩
+        · rintro ⟨⟨hTS, hsub⟩, haT⟩
+          refine ⟨hTS, ?_⟩
+          rw [← Finset.insert_erase hmemD, Finset.insert_subset_iff]
+          exact ⟨haT, hsub⟩
+      -- P2 (drop a) = (target).filter (a ∉ ·)
+      have hP2 : (S.erase a).powerset.filter (fun T => (S.erase a) \ rest.toFinset ⊆ T)
+          = (S.powerset.filter (fun T => (S \ rest.toFinset).erase a ⊆ T)).filter
+              (fun T => ¬ a ∈ T) := by
+        ext T
+        simp only [Finset.mem_filter, Finset.mem_powerset, Finset.subset_erase, hE]
+        tauto
+      rw [hP1, hP2]
+      exact Finset.sum_filter_add_sum_filter_not _ _ _
+    · -- a ∉ S : processing a leaves S untouched; the constraint is unchanged.
+      rw [zetaStep_not_mem a _ S haS, ih hrest_nd S, htf, Finset.sdiff_insert,
+          Finset.erase_eq_of_notMem (by rw [Finset.mem_sdiff]; tauto)]
+
+-- ============================================================
+-- Correctness of the fast zeta transform
+-- ============================================================
+
+/-- **Fast zeta transform correctness.** Folding the single-element SOS step over
+    every element of the (finite) ground type computes the full zeta transform:
+    `zetaFold f = zetaTransform f`. This is the correctness statement of the
+    O(n·2ⁿ) fast subset-sum dynamic program. -/
+theorem zetaFold_eq_zetaTransform (f : SubsetFn α) :
+    zetaFold f = zetaTransform f := by
+  ext S
+  rw [zetaFold, zetaFoldList_apply f Finset.univ.toList (Finset.nodup_toList _), zetaTransform]
+  have huniv : (Finset.univ.toList).toFinset = (Finset.univ : Finset α) := by
+    ext x; simp
+  have hfilter : S.powerset.filter (fun T => S \ (Finset.univ.toList).toFinset ⊆ T)
+      = S.powerset := by
+    apply Finset.filter_true_of_mem
+    intro T _
+    have : S \ (Finset.univ.toList).toFinset = ∅ := by
+      rw [huniv]
+      exact Finset.sdiff_eq_empty_iff_subset.mpr (Finset.subset_univ S)
+    rw [this]
+    exact Finset.empty_subset T
+  rw [hfilter]
+
+/-- Pointwise form of the correctness theorem. -/
+theorem zetaFold_apply (f : SubsetFn α) (S : Finset α) :
+    zetaFold f S = ∑ T ∈ S.powerset, f T := by
+  rw [zetaFold_eq_zetaTransform]; rfl
+
+/-- The fast fold and the Möbius transform are an inverse transform pair:
+    Möbius inversion (from the parent) recovers `f` from the fast fold. -/
+theorem mobius_inverts_zetaFold (f : SubsetFn α) :
+    mobiusTransform (zetaFold f) = f := by
+  rw [zetaFold_eq_zetaTransform]; exact mobius_inverts_zeta f
+
+end IEOQ03

--- a/src/data/proofs/inclusion-exclusion-oq-03-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "inclusion-exclusion-oq-03-oq-01",
+  "slug": "inclusion-exclusion-oq-03-oq-01",
+  "title": "Fast Zeta Transform Correctness: Folding the SOS Step Computes the Subset Sum",
+  "description": "Proves that iterating the parent's single-element sum-over-subsets (SOS) update step over every element of a finite ground type reproduces the full zeta transform — the correctness theorem of the O(n·2ⁿ) fast subset-sum dynamic program. The key device is a partial-sweep invariant: after folding the step over a duplicate-free list l, the running value at S is the sum of f over exactly the subsets of S that agree with S outside l. Directly answers the parent's open question #1.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InclusionExclusionOQ0301.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "zeta-transform",
+      "subset-lattice",
+      "dynamic-programming",
+      "algorithm-correctness",
+      "fast-subset-sum",
+      "sos-dp"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "Splits a sum over a finset by a decidable predicate; used to break the target subset-sum at S into the keep-a and drop-a branches, mirroring the SOS recurrence f(S) = f(S) + f(S\\{a}).",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sdiff_insert",
+        "description": "s \\ insert a t = (s \\ t).erase a; relates the partial-sweep constraint before and after processing one more element a.",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.insert_erase",
+        "description": "Re-inserts the just-processed element a into the constraint set to identify the keep-a branch with the previous-step index set.",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.nodup_toList",
+        "description": "univ.toList is duplicate-free, the hypothesis the partial-sweep invariant needs so each element is absorbed exactly once.",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "zetaFoldList / zetaFold: the fast subset-sum DP as a fold of the parent's single-element step zetaStep over a list (resp. all) of the ground elements",
+      "zetaFoldList_apply: the partial-sweep invariant — after folding over a duplicate-free list l, the value at S equals ∑_{T : S \\ l.toFinset ⊆ T ⊆ S} f(T), the subsets of S that agree with S outside the processed elements. Proved by list induction; the a∈S step is exactly the SOS recurrence, split by membership of a via sum_filter_add_sum_filter_not",
+      "zetaFold_eq_zetaTransform: fast SOS correctness — folding zetaStep over every element equals the full zeta transform ζf(S) = ∑_{T⊆S} f(T); the constraint collapses because S \\ univ = ∅",
+      "mobius_inverts_zetaFold: the fast fold and the parent's Möbius transform form an inverse transform pair (μ ∘ zetaFold = id), giving a fully verified forward-and-inverse fast transform"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "None. Fully machine-verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide. Builds on the parent inclusion-exclusion-oq-03 (zetaStep and its pointwise laws, zetaTransform, mobiusTransform, mobius_inverts_zeta).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "sourceUrl": ""
+  },
+  "overview": {
+    "historicalContext": "The sum-over-subsets (SOS) dynamic program — also called the fast zeta transform or Yates's algorithm — computes, for a function f on the 2ⁿ subsets of an n-element ground set, all values of the zeta transform ζf(S) = ∑_{T⊆S} f(T) in O(n·2ⁿ) arithmetic operations rather than the naive O(3ⁿ). It sweeps the n elements one at a time: when processing element a, every set S containing a absorbs the value currently stored at S\\{a}. The technique is the Boolean-lattice analogue of the FFT butterfly and underlies fast subset convolution and the Björklund–Husfeldt–Kaski–Koivisto 'Fourier meets Möbius' framework (STOC 2007), itself the engine behind many exponential-time exact algorithms (graph coloring, Hamiltonicity, Steiner tree). The parent gallery entry inclusion-exclusion-oq-03 defines the one-element step and proves its two pointwise update laws, but explicitly left the correctness of iterating the step — that the whole sweep computes the transform — as its first open question.",
+    "problemStatement": "The parent defines the single-element SOS step (ζ_a f)(S) = f(S) + f(S\\{a}) if a ∈ S, else f(S), and proves its pointwise laws, but stops short of proving that composing the step once for every element reproduces the full zeta transform. Prove the fast SOS / fast zeta transform correctness theorem: folding ζ_a over all elements a of the finite ground type equals ζ, i.e. zetaFold f = zetaTransform f as functions Finset α → ℤ.",
+    "text": "Folding the parent's one-element SOS update over every element of the ground type computes the full zeta transform ζf(S) = ∑_{T⊆S} f(T). The proof goes through a partial-sweep invariant that pins down the running array after any prefix of elements has been processed.",
+    "proofStrategy": "Define zetaFoldList l f = l.foldr zetaStep f and zetaFold f = zetaFoldList univ.toList f. The crux is the partial-sweep invariant zetaFoldList_apply: for any duplicate-free list l and every S, the running value at S equals ∑ over T with S \\ l.toFinset ⊆ T ⊆ S of f(T) — the subsets of S that have not yet been allowed to differ from S on the unprocessed coordinates. Induct on l. Base case l = []: the constraint S ⊆ T ⊆ S forces T = S, leaving f(S). Inductive step l = a :: rest with a ∉ rest (from Nodup): if a ∉ S the step leaves S untouched and the constraint is unchanged (S \\ insert a rest.toFinset = S \\ rest.toFinset since a ∉ S); if a ∈ S the step gives f-value(S) + f-value(S.erase a), and the target index set {T : (S \\ rest.toFinset).erase a ⊆ T ⊆ S} splits by membership of a into exactly the keep-a set (= the previous index set at S, since a is forced in by insert_erase) and the drop-a set (= the previous index set at S.erase a), so the recurrence matches the sum split by sum_filter_add_sum_filter_not. Specializing to l = univ.toList makes S \\ univ = ∅, dropping the constraint to T ⊆ S and yielding the full transform.",
+    "keyInsights": [
+      "The right strengthening is a partial-sweep invariant: tracking the running array after a prefix of elements, expressed as a sum over the subsets of S that still agree with S on the not-yet-processed coordinates (S \\ l.toFinset ⊆ T). The full theorem is the special case l = univ.toList, where S \\ univ = ∅ removes the constraint.",
+      "The duplicate-freeness of univ.toList is essential and is exactly what the induction consumes: each element must be absorbed once, so the cons step needs a ∉ rest.toFinset to keep the keep-a / drop-a split disjoint.",
+      "The SOS recurrence f(S) = f(S) + f(S\\{a}) for a ∈ S is, after the IH rewrite, the statement that the index set {T : (S\\rest).erase a ⊆ T ⊆ S} partitions by 'does T contain a' into the S-index set and the (S.erase a)-index set. Finset.sum_filter_add_sum_filter_not turns that partition into the additive recurrence with no arithmetic.",
+      "sdiff_insert (s \\ insert a t = (s \\ t).erase a) and insert_erase are the two algebraic identities that move the constraint set across one processing step: erasing a coordinate from the difference is the same as relaxing the membership constraint on a by one.",
+      "Composed with the parent's mobius_inverts_zeta, the result upgrades to mobius_inverts_zetaFold: the fast fold is exactly inverted by the Möbius transform, giving a verified forward/inverse fast transform pair."
+    ],
+    "prerequisites": [
+      "Parent inclusion-exclusion-oq-03: zetaStep, zetaStep_mem, zetaStep_not_mem, zetaTransform, mobiusTransform, mobius_inverts_zeta",
+      "List.foldr and List.Nodup / List.toFinset API",
+      "Finset.powerset, Finset.filter, Finset.sdiff, Finset.erase",
+      "Finset.sum_filter_add_sum_filter_not (sum partition by a predicate)",
+      "Finset.sdiff_insert, Finset.insert_erase, Finset.subset_erase"
+    ]
+  },
+  "sections": [
+    {
+      "id": "fold-definitions",
+      "title": "The fold of the single-element SOS step",
+      "startLine": 49,
+      "endLine": 61,
+      "summary": "Defines zetaFoldList l f = l.foldr zetaStep f (process the elements of a list one at a time) and zetaFold f = zetaFoldList univ.toList f (the full fast subset-sum sweep over the ground type).",
+      "mathContext": "$\\mathrm{zetaFold}\\,f = \\zeta_{a_1}(\\zeta_{a_2}(\\cdots \\zeta_{a_n} f))$"
+    },
+    {
+      "id": "partial-sweep-invariant",
+      "title": "The partial-sweep invariant",
+      "startLine": 63,
+      "endLine": 143,
+      "summary": "zetaFoldList_apply: by induction on a duplicate-free list l, the value at S after folding equals ∑_{T : S\\l.toFinset ⊆ T ⊆ S} f(T). The a∈S inductive step is the SOS recurrence, with the target index set split by membership of a via sum_filter_add_sum_filter_not.",
+      "mathContext": "$(\\,l.\\mathrm{foldr}\\,\\zeta_\\bullet\\,f\\,)(S) = \\sum_{S\\setminus l \\subseteq T \\subseteq S} f(T)$"
+    },
+    {
+      "id": "correctness",
+      "title": "Correctness of the fast zeta transform",
+      "startLine": 145,
+      "endLine": 174,
+      "summary": "zetaFold_eq_zetaTransform: folding over every element equals the full zeta transform (S \\ univ = ∅ collapses the constraint). zetaFold_apply gives the pointwise form, and mobius_inverts_zetaFold combines with the parent's Möbius inversion to invert the fast fold.",
+      "mathContext": "$\\mathrm{zetaFold}\\,f = \\zeta f,\\qquad \\mu(\\mathrm{zetaFold}\\,f) = f$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves 4 theorems and 2 definitions (0 axioms, 0 sorries) establishing the correctness of the O(n·2ⁿ) fast subset-sum dynamic program: folding the parent's single-element SOS step over every element of a finite ground type reproduces the full zeta transform. The proof rests on a partial-sweep invariant proved by list induction, with the SOS recurrence emerging as a sum partition by the membership of the currently-processed element.",
+    "implications": "Turns the parent's definition-with-local-lemmas into a verified algorithm. Combined with the parent's mobius_inverts_zeta, it yields a fully verified forward-and-inverse fast transform pair (the same fold, inverted by the Möbius transform). It is also a clean, reusable instance of a recurring formal-verification pattern: proving that a fold of a local rewrite computes a global closed form, with the right partial invariant doing all the work.",
+    "openQuestions": [
+      "Prove the fast Möbius (inverse) transform directly: a signed single-element step whose fold computes μ in O(n·2ⁿ), and show it is the literal inverse fold of zetaFold.",
+      "Establish the analogous foldl correctness (processing elements left-to-right) and that any processing order yields the same result, since the per-coordinate steps commute."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry: defines zetaStep and its pointwise laws (zetaStep_mem, zetaStep_not_mem), the zeta/Möbius transforms, and Möbius inversion. This entry proves the parent's open question #1 — that folding zetaStep over all elements computes the transform."
+    },
+    {
+      "targetId": "inclusion-exclusion",
+      "relationship": "ancestor",
+      "description": "Root inclusion–exclusion principle; the zeta transform being computed here is its algebraic engine."
+    }
+  ],
+  "references": [
+    {
+      "authors": "F. Yates",
+      "title": "The Design and Analysis of Factorial Experiments",
+      "year": "1937",
+      "venue": "Imperial Bureau of Soil Science",
+      "note": "Origin of the sum-over-subsets sweep (Yates's algorithm)"
+    },
+    {
+      "authors": "A. Björklund, T. Husfeldt, P. Kaski, M. Koivisto",
+      "title": "Fourier Meets Möbius: Fast Subset Convolution",
+      "year": "2007",
+      "venue": "STOC 2007",
+      "note": "O(n·2ⁿ) fast subset convolution; the fast zeta transform proved correct here is its core subroutine"
+    },
+    {
+      "authors": "D. E. Knuth",
+      "title": "The Art of Computer Programming, Vol. 4A",
+      "year": "2011",
+      "venue": "Addison-Wesley, §7.1.3",
+      "note": "Textbook treatment of the SOS / fast subset-sum transform"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/InclusionExclusionOQ0301.lean",
+    "filename": "InclusionExclusionOQ0301.lean",
+    "lineCount": 174,
+    "theoremCount": 4,
+    "axiomCount": 0,
+    "defCount": 2,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionOQ0301.lean",
+    "sorries": 0,
+    "definitionCount": 2
+  }
+}

--- a/src/data/proofs/inclusion-exclusion-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03/meta.json
@@ -22,7 +22,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's Finset combinatorics.",
-    "lineCount": 337,
+    "lineCount": 347,
     "theoremCount": 12,
     "definitionCount": 4,
     "originalContributions": [
@@ -159,7 +159,7 @@
   "leanFile": {
     "path": "Proofs/InclusionExclusionOQ03.lean",
     "filename": "InclusionExclusionOQ03.lean",
-    "lineCount": 337,
+    "lineCount": 347,
     "theoremCount": 12,
     "axiomCount": 0,
     "defCount": 4,


### PR DESCRIPTION
## Summary

Answers **parent open question #1** of `inclusion-exclusion-oq-03`: proves that iterating the parent's single-element sum-over-subsets (SOS) update step `zetaStep` over every element of a finite ground type reproduces the full zeta transform

  ζf(S) = ∑_{T ⊆ S} f(T)

— the correctness statement of the O(n·2ⁿ) Yates / "sum over subsets" dynamic program that underlies fast subset convolution and the Björklund–Husfeldt–Kaski–Koivisto "Fourier meets Möbius" algorithm.

## New entry — `Proofs/InclusionExclusionOQ0301.lean` (4 thm / 2 def, **0 axioms, 0 sorries**)

- `zetaFoldList` / `zetaFold` — the DP as a `foldr` of `zetaStep` over a list (resp. `univ`)
- `zetaFoldList_apply` — the **partial-sweep invariant**: after folding over a duplicate-free list `l`, the value at `S` is `∑_{T : S \ l.toFinset ⊆ T ⊆ S} f(T)`. Proved by list induction; the `a ∈ S` step is exactly the SOS recurrence, split by membership of `a` via `sum_filter_add_sum_filter_not`.
- `zetaFold_eq_zetaTransform` / `zetaFold_apply` — full correctness (the `l = univ.toList` specialization collapses the constraint `S \ univ = ∅`)
- `mobius_inverts_zetaFold` — combined with the parent's Möbius inversion, the fast fold is inverted by the Möbius transform

## Drive-by repair of the parent `Proofs/InclusionExclusionOQ03.lean`

While building, I found the **parent entry did not compile** against the pinned Mathlib (`v4.26.0` / `2df2f0150c27`), so its gallery `"verified"` status was inaccurate. Fixes are **proof-internal only** (no statement or theorem-name changes); the parent is now genuinely 0-axiom:

- `Finset.sum_comm'` — `s'`/`t'` arguments were swapped relative to the current signature
- `inner_sum_eq` — replaced an under-determined `rw [Finset.sum_nbij ...]` with `Finset.sum_nbij'` (explicit inverse `W ↦ W ∪ U`) applied via `apply`
- an orphaned doubled docstring before `inner_sum_eq` (a parse error) → block comment
- `Eq.mpr` `▸ le_refl` motive failures → `.ge`; a `conv`-mode `assumption` with no membership hypothesis → `Finset.sum_congr`
- updated `inclusion-exclusion-oq-03` meta `lineCount` 337 → 347

## Verification

```
#print axioms zetaFold_eq_zetaTransform   -- [propext, Classical.choice, Quot.sound]
#print axioms zetaFold_apply              -- [propext, Classical.choice, Quot.sound]
#print axioms zetaFoldList_apply          -- [propext, Classical.choice, Quot.sound]
#print axioms mobius_inverts_zetaFold     -- [propext, Classical.choice, Quot.sound]
#print axioms mobius_inverts_zeta (parent)-- [propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no `Lean.ofReduceBool`. Both files build via single-file `lake env lean` (Docker daemon was unresponsive this session); `pnpm annotations:build` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)