### PR TITLE
research(fibonacci-identities-oq-03-oq-02-oq-02): Sum of squares of Lucas numbers ∑Lᵢ²=Lₙ·Lₙ₊₁−2 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ02.lean
@@ -1,0 +1,117 @@
+import Mathlib
+
+/-
+# Sum of squares of Lucas numbers: ∑ L_i² = L_n · L_{n+1} − 2
+
+The Lucas analogue of the Fibonacci square-sum identity
+`F_1² + ⋯ + F_n² = F_n · F_{n+1}` (entry `fibonacci-identities-oq-03-oq-02`).
+
+The Lucas numbers `L_n` satisfy the Fibonacci recurrence `L_{n+2} = L_n + L_{n+1}`
+but start `L_0 = 2`, `L_1 = 1`, giving `2, 1, 3, 4, 7, 11, 18, …`.  Their squares
+sum to a consecutive Lucas product, shifted by the constant `2`:
+
+  `L_1² + L_2² + ⋯ + L_n² = L_n · L_{n+1} − 2`.
+
+The constant correction `−2` is the signature difference from the Fibonacci case
+(where the analogous sum is *exactly* `F_n · F_{n+1}`): it is exactly the leftover
+`L_0² − 2 = 4 − 2` carried by the `L_0 = 2` initial value.  Concretely the clean,
+subtraction-free statement is the `0`-indexed form
+
+  `L_0² + L_1² + ⋯ + L_n² = L_n · L_{n+1} + 2`,
+
+and discarding the `L_0² = 4` term turns the `+2` into the classical `−2`.
+
+Lucas numbers are not packaged in Mathlib, so we define the sequence locally
+(matching the convention used elsewhere in the Fibonacci gallery) and prove the
+identity by the textbook one-line induction.  The inductive step is the telescoping
+observation
+  `L_{n+1} · L_{n+2} − L_n · L_{n+1} = L_{n+1} · (L_{n+2} − L_n) = L_{n+1}²`,
+i.e. adding the next square `L_{n+1}²` advances the running product from
+`L_n · L_{n+1}` to `L_{n+1} · L_{n+2}` using only `L_{n+2} = L_n + L_{n+1}` and `ring`.
+-/
+
+namespace FibonacciIdentitiesOQ03OQ02OQ02
+
+/-- **Lucas numbers** `L_n`: `L_0 = 2`, `L_1 = 1`, `L_{n+2} = L_n + L_{n+1}`.
+The Lucas sequence shares the Fibonacci recurrence but starts `2, 1, 3, 4, 7, 11, …`. -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas n + lucas (n + 1)
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining Lucas recurrence `L_{n+2} = L_n + L_{n+1}`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-- **Sum of squares of Lucas numbers** (`0`-indexed, subtraction-free form).
+`∑_{i ∈ range (n+1)} L_i² = L_n · L_{n+1} + 2`.
+
+Proof by induction on `n`: `Finset.sum_range_succ` peels off the top square
+`L_{k+1}²`, the induction hypothesis rewrites the remaining sum to `L_k · L_{k+1} + 2`,
+and the recurrence `L_{k+2} = L_k + L_{k+1}` together with `ring` closes
+`L_k · L_{k+1} + 2 + L_{k+1}² = L_{k+1} · L_{k+2} + 2`. -/
+theorem lucas_sum_sq (n : ℕ) :
+    ∑ i ∈ Finset.range (n + 1), lucas i ^ 2 = lucas n * lucas (n + 1) + 2 := by
+  induction n with
+  | zero => decide
+  | succ k ih =>
+    rw [Finset.sum_range_succ, ih]
+    have hrec : lucas (k + 1 + 1) = lucas k + lucas (k + 1) := lucas_add_two k
+    rw [hrec]
+    ring
+
+/-- **Sum of squares of Lucas numbers** (`1`-indexed, subtraction-free `ℕ` form).
+`(∑_{i ∈ Icc 1 n} L_i²) + 2 = L_n · L_{n+1}`.
+
+This is the classical `∑_{i=1}^n L_i² = L_n · L_{n+1} − 2` rearranged to avoid `ℕ`
+truncated subtraction.  Derived from `lucas_sum_sq` by discarding the `i = 0` term
+`L_0² = 4`: `range (n+1) = insert 0 (Icc 1 n)`, so the `0`-indexed `+2` loses `4` and
+becomes `−2`. -/
+theorem lucas_sum_sq_Icc_add_two (n : ℕ) :
+    (∑ i ∈ Finset.Icc 1 n, lucas i ^ 2) + 2 = lucas n * lucas (n + 1) := by
+  have hsplit : Finset.range (n + 1) = insert 0 (Finset.Icc 1 n) := by
+    ext x
+    simp only [Finset.mem_range, Finset.mem_insert, Finset.mem_Icc]
+    omega
+  have h := lucas_sum_sq n
+  rw [hsplit, Finset.sum_insert (by simp)] at h
+  simp only [lucas_zero] at h
+  -- h : 2 ^ 2 + ∑ i ∈ Icc 1 n, lucas i ^ 2 = lucas n * lucas (n + 1) + 2
+  omega
+
+/-- **Integer form** matching the classical statement verbatim.
+`∑_{i ∈ Icc 1 n} (L_i : ℤ)² = L_n · L_{n+1} − 2`.
+
+Over `ℤ` the `−2` is literal (no truncation), obtained by moving the `+2` of
+`lucas_sum_sq_Icc_add_two` to the right-hand side. -/
+theorem lucas_sum_sq_Icc_int (n : ℕ) :
+    ∑ i ∈ Finset.Icc 1 n, (lucas i : ℤ) ^ 2 = (lucas n : ℤ) * (lucas (n + 1) : ℤ) - 2 := by
+  have h : ((∑ i ∈ Finset.Icc 1 n, lucas i ^ 2) + 2 : ℤ) = (lucas n * lucas (n + 1) : ℤ) := by
+    exact_mod_cast lucas_sum_sq_Icc_add_two n
+  push_cast at h ⊢
+  linarith
+
+/-- **Telescoping reading.** Adding the next square advances the running product by one
+index: `(∑_{i ∈ range (n+1)} L_i²) + L_{n+1}² = L_{n+1} · L_{n+2} + 2`.  This is the
+inductive step in standalone form, exhibiting the partial sums as the consecutive
+products `L_n · L_{n+1} + 2`. -/
+theorem lucas_sum_sq_succ (n : ℕ) :
+    (∑ i ∈ Finset.range (n + 1), lucas i ^ 2) + lucas (n + 1) ^ 2
+      = lucas (n + 1) * lucas (n + 2) + 2 := by
+  rw [lucas_sum_sq, lucas_add_two]
+  ring
+
+/-- Numerical check at `n = 4`: the `1`-indexed sum
+`1 + 9 + 16 + 49 = 75` equals `L_4 · L_5 − 2 = 7 · 11 − 2 = 75`.
+Verified by `decide` (kernel reduction — no `native_decide`, so the entry stays
+`Lean.ofReduceBool`-free). -/
+example : (∑ i ∈ Finset.Icc 1 4, lucas i ^ 2) + 2 = lucas 4 * lucas 5 := lucas_sum_sq_Icc_add_two 4
+
+example : lucas 4 * lucas 5 = 77 := by decide
+
+example : ∑ i ∈ Finset.range 5, lucas i ^ 2 = lucas 4 * lucas 5 + 2 := lucas_sum_sq 4
+
+end FibonacciIdentitiesOQ03OQ02OQ02

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-fiboq030202-1",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "context",
+    "title": "The Lucas Square-Sum and Its −2 Correction",
+    "content": "**Module framing.** The sum of the squares of the first $n$ Lucas numbers is a consecutive Lucas product shifted by a constant, $L_1^2 + L_2^2 + \\cdots + L_n^2 = L_n L_{n+1} - 2$. This is the Lucas analogue of the *exact* Fibonacci square-sum $\\sum F_i^2 = F_n F_{n+1}$ (entry `fibonacci-identities-oq-03-oq-02`). The $-2$ is the fingerprint of the Lucas seed: where Fibonacci has $F_0 = 0$ (a vanishing square), Lucas has $L_0 = 2$, contributing $L_0^2 = 4$, and $4 - 2 = 2$ is exactly the constant the clean $0$-indexed form $\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2 = L_n L_{n+1} + 2$ carries. Mathlib packages neither the Lucas sequence nor either square-sum, so this is a genuine gap."
+  },
+  {
+    "id": "ann-fiboq030202-2",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
+    "range": { "startLine": 33, "endLine": 47 },
+    "type": "definition",
+    "title": "The Lucas Sequence (defined locally)",
+    "content": "**Lucas numbers are not in Mathlib.** The sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$ — i.e. $2, 1, 3, 4, 7, 11, 18, \\dots$ — is defined locally, matching the convention used elsewhere in the Fibonacci gallery. The seeds get `@[simp]` lemmas and the recurrence `lucas_add_two` is a definitional `rfl`, supplying everything the induction needs."
+  },
+  {
+    "id": "ann-fiboq030202-3",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
+    "range": { "startLine": 49, "endLine": 64 },
+    "type": "key-step",
+    "title": "One-Line Induction: ∑ Lᵢ² = Lₙ·Lₙ₊₁ + 2",
+    "content": "**Telescoping, with the constant inert.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} L_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} L_i^2\\big) + L_{k+1}^2$. The induction hypothesis rewrites the first summand to $L_k L_{k+1} + 2$, and the recurrence `lucas_add_two` ($L_{k+2} = L_k + L_{k+1}$) plus `ring` close $L_k L_{k+1} + 2 + L_{k+1}^2 = L_{k+1} L_{k+2} + 2$. The telescoping $L_{k+1} L_{k+2} - L_k L_{k+1} = L_{k+1}^2$ is identical to the Fibonacci case; the additive constant simply rides along. The base case $n = 0$ ($L_0^2 = 4 = 2 \\cdot 1 + 2$) is `decide`."
+  },
+  {
+    "id": "ann-fiboq030202-4",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
+    "range": { "startLine": 66, "endLine": 96 },
+    "type": "key-step",
+    "title": "Recovering the Classical −2 (ℕ and ℤ forms)",
+    "content": "**The $i = 0$ term is where the $-2$ appears.** To reach the textbook statement over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is now $L_0^2 = 4$ (not $0$, as it was for Fibonacci), so `omega` rearranges $4 + \\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2 = L_n L_{n+1} + 2$ into the subtraction-free $\\big(\\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2\\big) + 2 = L_n L_{n+1}$ — staying inside $\\mathbb{N}$. `lucas_sum_sq_Icc_int` then `push_cast`s into $\\mathbb{Z}$ and `linarith` exposes the literal $\\sum_{i=1}^n L_i^2 = L_n L_{n+1} - 2$."
+  },
+  {
+    "id": "ann-fiboq030202-5",
+    "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
+    "range": { "startLine": 97, "endLine": 117 },
+    "type": "key-step",
+    "title": "Telescoping Step and Numerical Check",
+    "content": "**Packaging.** `lucas_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2\\big) + L_{n+1}^2 = L_{n+1} L_{n+2} + 2$, exhibiting the partial sums as the shifted consecutive products $L_n L_{n+1} + 2$. The numerical check at $n = 4$, $1 + 9 + 16 + 49 = 75 = L_4 L_5 - 2 = 7 \\cdot 11 - 2$, uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom."
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ03OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ03OQ02OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ03OQ02OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ03OQ02OQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ03OQ02OQ02Proof,
+  annotations: fibonacciIdentitiesOQ03OQ02OQ02Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "fibonacci-identities-oq-03-oq-02-oq-02",
+  "title": "Sum of Squares of Lucas Numbers: ∑ Lᵢ² = Lₙ·Lₙ₊₁ − 2",
+  "slug": "fibonacci-identities-oq-03-oq-02-oq-02",
+  "description": "The Lucas-number analogue of the Fibonacci square-sum identity. The Lucas numbers Lₙ obey the Fibonacci recurrence Lₙ₊₂ = Lₙ + Lₙ₊₁ but start L₀ = 2, L₁ = 1 (2, 1, 3, 4, 7, 11, …); their squares sum to a consecutive Lucas product shifted by a constant: L₁² + L₂² + ⋯ + Lₙ² = Lₙ·Lₙ₊₁ − 2. The signature −2 correction (versus the Fibonacci case, where ∑ Fᵢ² = Fₙ·Fₙ₊₁ exactly) is precisely the leftover L₀² − 2 = 4 − 2 carried by the L₀ = 2 initial value: the clean, subtraction-free 0-indexed form is ∑_{i ∈ range (n+1)} Lᵢ² = Lₙ·Lₙ₊₁ + 2, and discarding the L₀² = 4 term turns the +2 into the classical −2. Lucas numbers are not packaged in Mathlib, so the sequence is defined locally (matching the convention used elsewhere in the Fibonacci gallery), and the identity is proved by the textbook one-line induction: Finset.sum_range_succ peels the top square, the induction hypothesis rewrites the rest, and the recurrence Lₙ₊₂ = Lₙ + Lₙ₊₁ closes the telescoping step by ring (Lₙ₊₁·Lₙ₊₂ − Lₙ·Lₙ₊₁ = Lₙ₊₁²). The entry also supplies a subtraction-free 1-indexed ℕ form, an integer form carrying the literal −2, and a standalone telescoping step — all fully verified with 0 axioms and 0 sorries. This answers open question oq-02 of the parent Fibonacci square-sum entry verbatim.",
+  "meta": {
+    "author": "Classical (Lucas-number square-sum identity); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number#Identities",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "lucas-numbers",
+      "fibonacci",
+      "sum-of-squares",
+      "finite-sum",
+      "telescoping",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ03OQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{i ∈ range (n+1)} f i = (∑_{i ∈ range n} f i) + f n — peels the top square Lₙ² off the running sum in the inductive step",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_insert",
+        "description": "∑_{i ∈ insert a s} f i = f a + ∑_{i ∈ s} f i (for a ∉ s) — bridges the 0-indexed range form to the 1-indexed Icc 1 n form by splitting off the i = 0 term L₀² = 4",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "lucas: the local Lucas sequence L₀ = 2, L₁ = 1, Lₙ₊₂ = Lₙ + Lₙ₊₁ (Lucas numbers are not packaged in Mathlib)",
+      "lucas_sum_sq: ∀ n, ∑_{i ∈ range (n+1)} Lᵢ² = Lₙ·Lₙ₊₁ + 2 — the subtraction-free 0-indexed square-sum closed form, proved by one-line induction",
+      "lucas_sum_sq_Icc_add_two: ∀ n, (∑_{i ∈ Icc 1 n} Lᵢ²) + 2 = Lₙ·Lₙ₊₁ — the classical 1-indexed statement (∑ = Lₙ·Lₙ₊₁ − 2) rearranged to avoid ℕ truncated subtraction, derived by discarding the i = 0 term L₀² = 4",
+      "lucas_sum_sq_Icc_int: ∀ n, ∑_{i ∈ Icc 1 n} (Lᵢ:ℤ)² = Lₙ·Lₙ₊₁ − 2 — the classical statement over ℤ with the literal −2 (no truncation)",
+      "lucas_sum_sq_succ: ∀ n, (∑_{i ∈ range (n+1)} Lᵢ²) + Lₙ₊₁² = Lₙ₊₁·Lₙ₊₂ + 2 — the telescoping step in standalone form, exhibiting the partial sums as the shifted consecutive products Lₙ·Lₙ₊₁ + 2"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 117,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext / Classical.choice / Quot.sound — confirmed by #print axioms on all four theorems). The numerical sanity checks use decide (kernel reduction, no native_decide / Lean.ofReduceBool).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci square-sum ∑_{i=1}^n F_i² = F_n F_{n+1} (entry fibonacci-identities-oq-03-oq-02) has a clean rectangle-tiling proof and a one-line induction. Its Lucas companion ∑_{i=1}^n L_i² = L_n L_{n+1} − 2 is the natural analogue: the same telescoping induction goes through, but the differing initial value L_0 = 2 (against F_0 = 0) injects a constant correction. Lucas numbers — Édouard Lucas's companion sequence to the Fibonacci numbers — satisfy the same recurrence with seeds 2, 1; the square-sum identity sits alongside the familiar L_n = F_{n-1} + F_{n+1} conversion and the Fibonacci–Lucas doubling F_{2n} = F_n L_n. Mathlib packages neither the Lucas sequence nor either square-sum, leaving this a genuine gallery gap.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-03-oq-02 → oq-02)**: Prove the Lucas-number analogue ∑ L_i² = L_n L_{n+1} − 2 and relate it to the Fibonacci square-sum entry.\n\n**Result**: lucas_sum_sq (the 0-indexed subtraction-free closed form ∑_{i ∈ range (n+1)} L_i² = L_n L_{n+1} + 2), lucas_sum_sq_Icc_add_two (the classical 1-indexed form over ℕ), lucas_sum_sq_Icc_int (the ℤ form with literal −2), and lucas_sum_sq_succ (the telescoping step).",
+    "text": "For every n, the sum of the squares of the first n Lucas numbers is a product of two consecutive Lucas numbers minus two: L_1² + L_2² + ⋯ + L_n² = L_n · L_{n+1} − 2. Equivalently the 0-indexed partial sums are the shifted products L_n · L_{n+1} + 2, advancing by exactly the next square at each step; the constant +2 (or −2 in the 1-indexed form) is the fingerprint of the L_0 = 2 seed, the one place the Lucas identity departs from the exact Fibonacci square-sum.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Local Lucas sequence.** Define lucas with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}; record the recurrence lucas_add_two (a rfl).\n2. **0-indexed induction (lucas_sum_sq).** Induct on n. Base n = 0: ∑_{range 1} L_i² = L_0² = 4 = L_0·L_1 + 2 = 2·1 + 2, closed by decide. Step: Finset.sum_range_succ rewrites ∑_{range (k+2)} L_i² = (∑_{range (k+1)} L_i²) + L_{k+1}²; the induction hypothesis rewrites the first summand to L_k·L_{k+1} + 2; the recurrence L_{k+2} = L_k + L_{k+1} and ring close L_k·L_{k+1} + 2 + L_{k+1}² = L_{k+1}·L_{k+2} + 2.\n3. **1-indexed ℕ form (lucas_sum_sq_Icc_add_two).** Write range (n+1) = insert 0 (Icc 1 n) (an ext/omega set identity), split off the head with Finset.sum_insert; the discarded term is L_0² = 4, and omega rearranges 4 + ∑_{Icc 1 n} L_i² = L_n·L_{n+1} + 2 into (∑_{Icc 1 n} L_i²) + 2 = L_n·L_{n+1}.\n4. **Integer form (lucas_sum_sq_Icc_int).** push_cast the ℕ identity into ℤ and move the +2 across with linarith, yielding the literal ∑_{Icc 1 n} (L_i:ℤ)² = L_n·L_{n+1} − 2.\n5. **Telescoping step (lucas_sum_sq_succ).** The inductive step in standalone form: rw lucas_sum_sq + lucas_add_two + ring.\n6. The numerical check at n = 4 (1 + 9 + 16 + 49 = 75 = 7·11 − 2) is confirmed by decide; the sum side is the theorem instance lucas_sum_sq_Icc_add_two 4.",
+    "keyInsights": [
+      "**The −2 is the L₀ = 2 seed, nothing more.** The Fibonacci square-sum is exact because F₀ = 0 contributes a vanishing square; the Lucas seed L₀ = 2 contributes L₀² = 4, and 4 − 2 = 2 is exactly the constant the 0-indexed sum carries. Discarding the i = 0 term converts the clean +2 into the classical −2.",
+      "**Telescoping is the whole proof.** The inductive step is Lₙ₊₁·Lₙ₊₂ − Lₙ·Lₙ₊₁ = Lₙ₊₁(Lₙ₊₂ − Lₙ) = Lₙ₊₁² — identical to the Fibonacci case — so adding the next square advances the consecutive product by one index, with the additive constant inert. No Lucas machinery beyond the defining recurrence is needed; ring does the algebra.",
+      "**Stay subtraction-free in ℕ.** The headline −2 invites ℕ truncated subtraction; the entry instead proves the +2 / +2 forms over ℕ (lucas_sum_sq, lucas_sum_sq_Icc_add_two) and exposes the literal −2 only over ℤ (lucas_sum_sq_Icc_int), keeping every step a genuine equality.",
+      "**Fills a Mathlib gap.** Mathlib packages neither the Lucas sequence nor any Lucas square-sum; this entry defines the sequence locally and supplies the closed form in ℕ and ℤ together with a telescoping reading."
+    ],
+    "prerequisites": [
+      "The Lucas recurrence L_{n+2} = L_n + L_{n+1} and the seeds L_0 = 2, L_1 = 1 (defined locally)",
+      "Finset.sum_range_succ for the inductive unfolding of finite sums",
+      "Finset.sum_insert for splitting off the i = 0 term L_0² = 4",
+      "The ring, omega, push_cast, and linarith tactics for the algebra and the ℕ→ℤ transfer"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 3,
+      "endLine": 31,
+      "summary": "Module docstring: the Lucas square-sum identity ∑ L_i² = L_n L_{n+1} − 2, its relation to the exact Fibonacci square-sum, the −2 constant as the L_0 = 2 leftover, the Mathlib gap (no Lucas sequence, no square-sum), and the telescoping inductive step.",
+      "mathContext": "$\\sum_{i=1}^{n} L_i^2 = L_n \\, L_{n+1} - 2$; the $-2$ is the $L_0^2 - 2 = 4 - 2$ carried by the seed $L_0 = 2$."
+    },
+    {
+      "id": "lucas-def",
+      "title": "The Lucas Sequence",
+      "startLine": 33,
+      "endLine": 47,
+      "summary": "Local definition of the Lucas numbers (L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}) with simp lemmas for the seeds and the recurrence lucas_add_two (a definitional rfl). Lucas numbers are not in Mathlib.",
+      "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$ — the sequence $2, 1, 3, 4, 7, 11, \\dots$"
+    },
+    {
+      "id": "main",
+      "title": "The Square-Sum Closed Form (0-indexed)",
+      "startLine": 49,
+      "endLine": 64,
+      "summary": "lucas_sum_sq: one-line induction. Finset.sum_range_succ peels the top square, the IH rewrites the remaining sum to L_k · L_{k+1} + 2, and lucas_add_two + ring close the telescoping step with the additive constant inert. Base case by decide.",
+      "mathContext": "$\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2 = L_n L_{n+1} + 2$."
+    },
+    {
+      "id": "icc",
+      "title": "Classical 1-indexed and Integer Forms",
+      "startLine": 66,
+      "endLine": 96,
+      "summary": "lucas_sum_sq_Icc_add_two: writes range (n+1) = insert 0 (Icc 1 n), splits off the i = 0 term L_0² = 4 via Finset.sum_insert, and omega yields the subtraction-free (∑_{Icc 1 n}) + 2 = L_n · L_{n+1}. lucas_sum_sq_Icc_int: push_cast + linarith expose the literal −2 over ℤ.",
+      "mathContext": "$\\sum_{i=1}^{n} L_i^2 = L_n L_{n+1} - 2$ (literal over $\\mathbb{Z}$; the $i = 0$ term is $L_0^2 = 4$)."
+    },
+    {
+      "id": "telescope-checks",
+      "title": "Telescoping Step and Numerical Checks",
+      "startLine": 97,
+      "endLine": 117,
+      "summary": "lucas_sum_sq_succ: the inductive step in standalone form, (∑_{range (n+1)} L_i²) + L_{n+1}² = L_{n+1} · L_{n+2} + 2. The n = 4 check 1 + 9 + 16 + 49 = 75 = 7·11 − 2 is confirmed by decide (kernel reduction, no native_decide, so the entry stays 0-axiom).",
+      "mathContext": "$1 + 9 + 16 + 49 = 75 = L_4 L_5 - 2 = 7 \\cdot 11 - 2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Answers open question oq-02 of the Fibonacci square-sum entry verbatim — the Lucas analogue ∑ L_i² = L_n L_{n+1} − 2 — mirroring its induction and exhibiting the −2 as the L_0 = 2 seed correction to the exact Fibonacci sum"
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "complements",
+      "description": "The base Fibonacci entry records per-term and linear-sum identities; this entry adds the Lucas-number sum-of-squares closed form"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) treatment of the Lucas square-sum identity ∑_{i=1}^n L_i² = L_n · L_{n+1} − 2: a local Lucas sequence, the 0-indexed subtraction-free closed form by one-line induction, the classical 1-indexed ℕ form, the literal ℤ form, and the telescoping step. Answers open question oq-02 of the Fibonacci square-sum entry verbatim.",
+    "implications": "Supplies a reusable closed form for sums of Lucas squares, filling a gap left by Mathlib (which packages neither the Lucas sequence nor either square-sum). The +2 / −2 constant is isolated as the L_0 = 2 seed effect, clarifying exactly how the Lucas identity departs from the exact Fibonacci square-sum.",
+    "openQuestions": [
+      "Formalize the mixed Fibonacci–Lucas square-sum and product-sum identities (e.g. ∑ F_i L_i and ∑ L_i L_{i+1}) and their closed forms.",
+      "Derive the Lucas square-sum from the Fibonacci square-sum directly via the conversion L_n = F_{n-1} + F_{n+1}, avoiding a separate induction."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FibonacciIdentitiesOQ03OQ02OQ02",
+    "lineCount": 117,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ03OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Lucas-number identities, including the sum of squares ∑ L_i² = L_n L_{n+1} − 2"
+    },
+    {
+      "authors": "Vorobiev, N. N.",
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser",
+      "note": "Companion Fibonacci/Lucas summation identities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question oq-02** of the Fibonacci square-sum entry (`fibonacci-identities-oq-03-oq-02`) **verbatim**: the Lucas-number analogue

  ∑_{i=1}^n L_i² = L_n · L_{n+1} − 2.

Lucas numbers (L₀=2, L₁=1, Lₙ₊₂=Lₙ+Lₙ₊₁ — the sequence 2,1,3,4,7,11,…) are **not packaged in Mathlib**, so the sequence is defined locally (matching the Fibonacci gallery convention).

## The −2 is the seed effect

The Fibonacci square-sum ∑Fᵢ² = Fₙ·Fₙ₊₁ is *exact* because F₀=0 has a vanishing square. The Lucas seed L₀=2 contributes L₀²=4, and 4−2=2 is exactly the constant the clean **subtraction-free 0-indexed** form carries:

  ∑_{i∈range(n+1)} Lᵢ² = Lₙ·Lₙ₊₁ + 2   (one-line telescoping induction)

Discarding the i=0 term (L₀²=4) turns the +2 into the classical −2.

## Contents (6 theorems, 1 def, 117 lines)

- `lucas` — local Lucas sequence + recurrence
- `lucas_sum_sq` — 0-indexed closed form (+2), the main induction
- `lucas_sum_sq_Icc_add_two` — 1-indexed ℕ form, subtraction-free `(∑)+2 = Lₙ·Lₙ₊₁`
- `lucas_sum_sq_Icc_int` — ℤ form with the literal `− 2`
- `lucas_sum_sq_succ` — standalone telescoping step

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on all four theorems shows only `propext` / `Classical.choice` / `Quot.sound`.
- Numerical checks use `decide` (kernel reduction, **no** `native_decide`), so the entry stays `Lean.ofReduceBool`-free.
- Built with `lake env lean` against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)