### PR TITLE
Enrich banach-fixed-point-oq-01-oq-02-oq-01 (Picard inverse): add annotations

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "banach-picard-oq010201-header",
+    "proofId": "banach-fixed-point-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 41 },
+    "type": "context",
+    "title": "Making the inverse of id + g constructive and quantitative",
+    "content": "The header explains the gap this entry fills. The parent oq-01-oq-02 proves that f x = x + g x (g k-Lipschitz, k < 1, E complete) is a homeomorphism with (1−k)⁻¹-Lipschitz inverse — but only existentially, via the contraction-mapping theorem, with no recipe for computing f⁻¹. Solving f x = y means solving the fixed-point equation x = y − g x for the Picard operator T_y x = y − g x, itself a k-contraction. The entry defines f⁻¹ y as the fixed point of T_y and turns Mathlib's generic ContractingWith error estimates into explicit, computable bounds: a priori, a posteriori, linear rate, and the seed-at-target specialisation. The contraction machinery is the Mathlib input; the new content is identifying the fixed point with the inverse of id + g and extracting geometric error bounds. Fully verified: 0 sorries, 0 axioms; the file re-introduces f = id + g locally rather than importing the parent.",
+    "mathContext": "$f x = x + g x,\\ T_y x = y - g x;\\quad f^{-1}y = \\mathrm{fixedPoint}(T_y)$",
+    "significance": "context",
+    "relatedConcepts": ["Banach fixed-point theorem", "Picard iteration", "contraction mapping", "Lipschitz perturbation of identity", "constructive inverse"],
+    "prerequisites": ["complete normed groups", "Lipschitz maps", "the parent existential inverse"]
+  },
+  {
+    "id": "banach-picard-oq010201-operator",
+    "proofId": "banach-fixed-point-oq-01-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 78 },
+    "type": "definition",
+    "title": "The Picard operator T_y x = y − g x and its contraction property",
+    "content": "Defines pmap g (the perturbed map f = id + g) and picard g y (the operator T_y x = y − g x), whose fixed points are exactly the solutions of f x = y (both with @[simp] unfolding lemmas). `picard_lipschitz` shows T_y inherits g's Lipschitz constant k: the y cancels in (y − g a) − (y − g b) = −(g a − g b), so dist(T_y a, T_y b) = ‖g a − g b‖ ≤ k‖a − b‖ (proved via LipschitzWith.of_dist_le_mul and abel). `picard_contracting` then packages ⟨hk, picard_lipschitz⟩ into a ContractingWith k structure, the input Mathlib's fixed-point API requires.",
+    "mathContext": "$\\mathrm{dist}(T_y a, T_y b) = \\|g a - g b\\| \\le k\\,\\|a-b\\|,\\quad k < 1$",
+    "significance": "key",
+    "relatedConcepts": ["ContractingWith", "LipschitzWith.of_dist_le_mul", "translation invariance of the norm"],
+    "prerequisites": ["Lipschitz constants", "norm of a difference"]
+  },
+  {
+    "id": "banach-picard-oq010201-inverse",
+    "proofId": "banach-fixed-point-oq-01-oq-02-oq-01",
+    "range": { "startLine": 80, "endLine": 111 },
+    "type": "theorem",
+    "title": "The constructive inverse: fixed point, solves, unique",
+    "content": "`inverse hg hk y` is defined as ContractingWith.fixedPoint (picard g y) — the unique fixed point of T_y (a Nonempty E instance is supplied via ⟨0⟩). `isFixedPt_inverse` confirms it is genuinely fixed. `inverse_solves` shows f(f⁻¹ y) = y: unfolding the fixed-point equation y − g(inv) = inv and rearranging with sub_eq_iff_eq_add gives inv + g(inv) = y. `inverse_unique` shows any solution x of x + g x = y is a fixed point of T_y (from x + g x = y deduce y − g x = x by abel) and hence equals inverse by fixedPoint_unique — so id + g is injective and inverse is its honest two-sided inverse.",
+    "mathContext": "$f(f^{-1}y) = y;\\quad x + g x = y \\implies x = f^{-1}y$",
+    "significance": "key",
+    "relatedConcepts": ["ContractingWith.fixedPoint", "fixedPoint_unique", "two-sided inverse", "injectivity"],
+    "prerequisites": ["picard_contracting", "fixed-point equation manipulation"]
+  },
+  {
+    "id": "banach-picard-oq010201-convergence",
+    "proofId": "banach-fixed-point-oq-01-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 134 },
+    "type": "theorem",
+    "title": "Convergence and a priori / a posteriori error bounds",
+    "content": "`tendsto_picard`: from any seed x₀, the iterates (T_y)^[n] x₀ converge to f⁻¹ y (tendsto_iterate_fixedPoint). `apriori_error`: the predictable bound ‖xₙ − f⁻¹ y‖ ≤ ‖x₀ − x₁‖·kⁿ/(1−k), computable before iterating. `aposteriori_error`: the sharper running bound ‖xₙ − f⁻¹ y‖ ≤ ‖xₙ − xₙ₊₁‖/(1−k), using the observed last increment as a stopping criterion. Both are direct specialisations of Mathlib's ContractingWith estimates to the Picard operator.",
+    "mathContext": "$\\|x_n - f^{-1}y\\| \\le \\frac{\\|x_0 - x_1\\|\\,k^n}{1-k}\\ \\text{(a priori)},\\quad \\le \\frac{\\|x_n - x_{n+1}\\|}{1-k}\\ \\text{(a posteriori)}$",
+    "significance": "key",
+    "relatedConcepts": ["Picard iteration convergence", "a priori vs a posteriori bounds", "geometric error decay", "stopping criterion"],
+    "prerequisites": ["ContractingWith error estimates", "inverse as fixed point"]
+  },
+  {
+    "id": "banach-picard-oq010201-rate-seed",
+    "proofId": "banach-fixed-point-oq-01-oq-02-oq-01",
+    "range": { "startLine": 136, "endLine": 155 },
+    "type": "theorem",
+    "title": "Linear rate and the seed-at-target specialisation",
+    "content": "`linear_rate`: one Picard step shrinks the error by the factor k, dist(T_y x, f⁻¹ y) ≤ k·dist(x, f⁻¹ y), proved by rewriting f⁻¹ y as a fixed point and applying picard_lipschitz — the cleanest statement of geometric (linear) convergence. `apriori_error_seed_target`: choosing the natural seed x₀ = y, the first increment is ‖y − T_y y‖ = ‖g y‖, so the a priori bound becomes the tidy ‖(T_y)ⁿ y − f⁻¹ y‖ ≤ ‖g y‖·kⁿ/(1−k) — error controlled directly by the perturbation size at the target.",
+    "mathContext": "$\\mathrm{dist}(T_y x, f^{-1}y) \\le k\\,\\mathrm{dist}(x, f^{-1}y);\\quad \\|(T_y)^n y - f^{-1}y\\| \\le \\frac{\\|g y\\|\\,k^n}{1-k}$",
+    "significance": "key",
+    "relatedConcepts": ["linear convergence", "natural seed", "perturbation size ‖g y‖"],
+    "prerequisites": ["apriori_error", "picard_lipschitz"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01-oq-02-oq-01` (explicit Picard iteration and geometric error bounds for the inverse of id + g).

## Gap addressed
The entry had a rich `meta.json` (5 sections) but **no `annotations.json`**.

## Changes
Added `annotations.json` with **5 annotations**, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
- **header** — the constructive/quantitative layer over the parent's existential inverse
- **Picard operator** — T_y x = y − g x and its k-contraction property
- **constructive inverse** — fixed point, solves the equation, uniqueness (two-sided inverse)
- **convergence bounds** — tendsto + a priori / a posteriori error estimates
- **linear rate + seed-at-target** — geometric rate and the ‖g y‖·kⁿ/(1−k) specialisation

## Validation
- `pnpm annotations:build` passes with **no warnings for this entry** (all line ranges resolve to Lean constructs); JSON validated.
- Verified `status: verified`, `badge: verified`, `axiomCount: 0` match the Lean file (0 sorries, 0 axiom decls).