### PR TITLE
research(alternating-series-test-oq-01-oq-01-oq-02): two-term error trap for eventually-antitone coefficients [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesTestOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AlternatingSeriesTestOQ01OQ01OQ02.lean
@@ -1,0 +1,206 @@
+import Mathlib
+import Proofs.AlternatingSeriesTestOQ01OQ01
+
+/-
+# Two-Sided Error Trapping for *Eventually* Antitone Alternating Series
+
+The parent result (`AlternatingSeriesTestOQ01OQ01`) traps the truncation error of an
+alternating series `S_N = ∑_{i<N} (-1)^i f i` between two consecutive omitted terms,
+
+`f N - f (N+1) ≤ |S_N - l| ≤ f N`,
+
+under the *global* hypothesis that `f` is antitone and `f → 0`. The parent's own open
+question (index 1) asks whether the same two-sided bound survives when the monotonicity is
+only **eventual** — `f` antitone on `[M, ∞)` rather than on all of `ℕ`. This file answers
+it: **yes, verbatim, for every `N ≥ M`.**
+
+The mechanism is a *shift reduction*. Write the tail of the series starting at index `M` as
+its own alternating series with coefficients `g j = f (j + M)`. Then `g` is globally
+antitone and `g → 0`, so the parent theorem applies to `g`. The two series are linked by the
+exact splitting
+
+`S_{n+M} = S_M + (-1)^M · T_n`,   where `T_n = ∑_{j<n} (-1)^j g j`,
+
+so the truncation errors coincide up to a sign of modulus one: `|S_N - l| = |T_{N-M} - t|`.
+Feeding the parent's trap for `g` back through `g (N-M) = f N` and `g (N-M+1) = f (N+1)`
+reproduces the original two-term trap, now valid from the antitonicity threshold `M` onward.
+
+Two further points are established along the way and are genuinely new content:
+
+* **Convergence is derived, not assumed.** Eventual antitonicity plus `f → 0` already forces
+  `S_N` to converge (the shifted series does, by Leibniz). So the limit `l` need not be
+  hypothesised.
+* **The hypothesis is strictly weaker.** An explicit `f` (a single upward "bump" at the
+  start, antitone only from `M = 1` on) satisfies the eventual hypothesis but not the global
+  one, so the parent theorem does not apply to it while this one does.
+
+All results are over `ℝ` and the proof is axiom-free.
+-/
+
+namespace AlternatingSeriesTestOQ01OQ01OQ02
+
+open Finset Filter Topology
+
+variable {f : ℕ → ℝ} {M : ℕ}
+
+/-- The shifted tail coefficients `g j = f (j + M)`. When `f` is antitone on `[M, ∞)` these
+are globally antitone, which is the whole point of the reduction. -/
+theorem antitone_shift (hfa : AntitoneOn f (Set.Ici M)) :
+    Antitone (fun j : ℕ => f (j + M)) := by
+  intro j k hjk
+  exact hfa (Set.mem_Ici.mpr (by omega)) (Set.mem_Ici.mpr (by omega)) (by omega)
+
+/-- The shifted coefficients still tend to `0`. -/
+theorem tendsto_shift_zero (hf0 : Tendsto f atTop (𝓝 0)) :
+    Tendsto (fun j : ℕ => f (j + M)) atTop (𝓝 0) :=
+  hf0.comp (tendsto_add_atTop_nat M)
+
+/-- **Shift splitting of partial sums.** The partial sum of the full series at index `n + M`
+splits as the fixed head `S_M` plus a `±` copy of the shifted series' partial sum:
+
+`∑_{i<n+M} (-1)^i f i = ∑_{i<M} (-1)^i f i + (-1)^M ∑_{j<n} (-1)^j f (j+M)`.
+
+Proved by induction on `n`: each new term `(-1)^{n+M} f (n+M)` on the left matches
+`(-1)^M · (-1)^n f (n+M)` on the right via `(-1)^{n+M} = (-1)^M (-1)^n`. -/
+theorem partialSum_shift (n : ℕ) :
+    (∑ i ∈ range (n + M), (-1 : ℝ) ^ i * f i)
+      = (∑ i ∈ range M, (-1 : ℝ) ^ i * f i)
+        + (-1 : ℝ) ^ M * ∑ j ∈ range n, (-1 : ℝ) ^ j * f (j + M) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [show n + 1 + M = (n + M) + 1 by ring, Finset.sum_range_succ (n := n + M), ih,
+      Finset.sum_range_succ (n := n), pow_add]
+    ring
+
+/-- **Convergence from eventual antitonicity.** If `f` is antitone on `[M, ∞)` and `f → 0`,
+the alternating partial sums converge. The limit is exhibited explicitly as
+`l = S_M + (-1)^M t`, where `t` is the Leibniz limit of the shifted series. -/
+theorem tendsto_partialSum_of_eventually_antitone
+    (hfa : AntitoneOn f (Set.Ici M)) (hf0 : Tendsto f atTop (𝓝 0)) :
+    ∃ l : ℝ, Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * f i) atTop (𝓝 l) := by
+  obtain ⟨t, ht⟩ :=
+    (antitone_shift hfa).tendsto_alternating_series_of_tendsto_zero (tendsto_shift_zero hf0)
+  refine ⟨(∑ i ∈ range M, (-1 : ℝ) ^ i * f i) + (-1 : ℝ) ^ M * t, ?_⟩
+  rw [← tendsto_add_atTop_iff_nat M]
+  refine (ht.const_mul ((-1 : ℝ) ^ M)).const_add _ |>.congr (fun n => ?_)
+  rw [partialSum_shift n]
+
+/-- **Two-sided two-term error trap, eventually-antitone form.** Suppose `f` is antitone on
+`[M, ∞)`, `f → 0`, and the alternating series converges to `l`. Then for **every** index
+`N ≥ M` the truncation error is trapped exactly as in the globally-antitone case:
+
+`f N - f (N+1) ≤ |S_N - l| ≤ f N`.
+
+The proof reduces to the parent theorem applied to the shifted series `g j = f (j+M)`:
+the error `|S_N - l|` equals `|T_{N-M} - t|` (the limits differ by the same `(-1)^M` factor),
+and `g (N-M) = f N`, `g (N-M+1) = f (N+1)`. -/
+theorem abs_partialSum_sub_limit_trapped_eventually
+    (hfa : AntitoneOn f (Set.Ici M)) (hf0 : Tendsto f atTop (𝓝 0))
+    (hl : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * f i) atTop (𝓝 l)) {N : ℕ}
+    (hN : M ≤ N) :
+    f N - f (N + 1) ≤ |(∑ i ∈ range N, (-1 : ℝ) ^ i * f i) - l|
+      ∧ |(∑ i ∈ range N, (-1 : ℝ) ^ i * f i) - l| ≤ f N := by
+  -- shifted coefficients and their (global) Leibniz limit `t`
+  set g : ℕ → ℝ := fun j => f (j + M) with hg
+  have hga : Antitone g := antitone_shift hfa
+  have hg0 : Tendsto g atTop (𝓝 0) := tendsto_shift_zero hf0
+  obtain ⟨t, ht⟩ := hga.tendsto_alternating_series_of_tendsto_zero hg0
+  -- the full limit `l` is forced to be `S_M + (-1)^M t`
+  have hl' : l = (∑ i ∈ range M, (-1 : ℝ) ^ i * f i) + (-1 : ℝ) ^ M * t := by
+    have hconv : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * f i) atTop
+        (𝓝 ((∑ i ∈ range M, (-1 : ℝ) ^ i * f i) + (-1 : ℝ) ^ M * t)) := by
+      rw [← tendsto_add_atTop_iff_nat M]
+      refine (ht.const_mul ((-1 : ℝ) ^ M)).const_add _ |>.congr (fun n => ?_)
+      rw [partialSum_shift n]
+    exact tendsto_nhds_unique hl hconv
+  -- write `N = (N - M) + M` so the shift splitting applies at `n = N - M`
+  obtain ⟨m, rfl⟩ : ∃ m, N = m + M := ⟨N - M, by omega⟩
+  -- key identity: `S_N - l = (-1)^M (T_m - t)`, hence `|S_N - l| = |T_m - t|`
+  have hsplit : (∑ i ∈ range (m + M), (-1 : ℝ) ^ i * f i) - l
+      = (-1 : ℝ) ^ M * ((∑ j ∈ range m, (-1 : ℝ) ^ j * g j) - t) := by
+    rw [partialSum_shift m, hl']; ring
+  have habs : |(∑ i ∈ range (m + M), (-1 : ℝ) ^ i * f i) - l|
+      = |(∑ j ∈ range m, (-1 : ℝ) ^ j * g j) - t| := by
+    rw [hsplit, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul]
+  -- parent trap for the shifted (globally antitone) series at index `m`
+  have hpar := AlternatingSeriesTestOQ01OQ01.abs_partialSum_sub_limit_trapped hga hg0 ht m
+  -- translate `g m = f N`, `g (m+1) = f (N+1)`
+  have hgm : g m = f (m + M) := rfl
+  have hgm1 : g (m + 1) = f (m + M + 1) := by simp only [hg]; congr 1; omega
+  rw [habs, ← hgm, ← hgm1]
+  exact hpar
+
+/-- The upper (Leibniz) half, extracted: `|S_N - l| ≤ f N` for `N ≥ M`. -/
+theorem abs_partialSum_sub_limit_le_eventually
+    (hfa : AntitoneOn f (Set.Ici M)) (hf0 : Tendsto f atTop (𝓝 0))
+    (hl : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * f i) atTop (𝓝 l)) {N : ℕ}
+    (hN : M ≤ N) :
+    |(∑ i ∈ range N, (-1 : ℝ) ^ i * f i) - l| ≤ f N :=
+  (abs_partialSum_sub_limit_trapped_eventually hfa hf0 hl hN).2
+
+/-- The lower (sharpness) half, extracted: `f N - f (N+1) ≤ |S_N - l|` for `N ≥ M`. -/
+theorem sub_le_abs_partialSum_sub_limit_eventually
+    (hfa : AntitoneOn f (Set.Ici M)) (hf0 : Tendsto f atTop (𝓝 0))
+    (hl : Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * f i) atTop (𝓝 l)) {N : ℕ}
+    (hN : M ≤ N) :
+    f N - f (N + 1) ≤ |(∑ i ∈ range N, (-1 : ℝ) ^ i * f i) - l| :=
+  (abs_partialSum_sub_limit_trapped_eventually hfa hf0 hl hN).1
+
+/-!
+## The hypothesis is strictly weaker
+
+We exhibit a concrete coefficient sequence that is antitone on `[1, ∞)` but **not** antitone
+on all of `ℕ`, witnessing that the eventually-antitone trap covers cases the parent's global
+hypothesis cannot. The sequence is the alternating-harmonic profile with an upward bump
+planted at the start: `b 0 = 0`, `b i = 1/(i+1)` for `i ≥ 1`. Since `b 0 = 0 < 1/2 = b 1`,
+it fails global antitonicity, yet from index `1` on it is the usual antitone `1/(i+1)`.
+-/
+
+/-- The bumped coefficient sequence: `0` at the origin, then `1/(i+1)`. -/
+noncomputable def bumped (i : ℕ) : ℝ := if i = 0 then 0 else 1 / ((i : ℝ) + 1)
+
+/-- `bumped` is antitone on `[1, ∞)`: there the `if` is uniformly in its `i ≠ 0` branch and
+the coefficients are the standard decreasing `1/(i+1)`. -/
+theorem antitoneOn_bumped : AntitoneOn bumped (Set.Ici 1) := by
+  intro i hi j hj hij
+  simp only [Set.mem_Ici] at hi hj
+  have hi0 : i ≠ 0 := by omega
+  have hj0 : j ≠ 0 := by omega
+  simp only [bumped, hi0, hj0, if_false]
+  have hipos : (0 : ℝ) < (i : ℝ) + 1 := by positivity
+  apply one_div_le_one_div_of_le hipos
+  exact_mod_cast by simpa using hij
+
+/-- `bumped → 0`. -/
+theorem tendsto_bumped_zero : Tendsto bumped atTop (𝓝 0) := by
+  have h : Tendsto (fun i : ℕ => 1 / ((i : ℝ) + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  refine h.congr' ?_
+  filter_upwards [eventually_ge_atTop 1] with i hi
+  simp only [bumped, if_neg (by omega : i ≠ 0)]
+
+/-- `bumped` is **not** globally antitone: it rises from `b 0 = 0` to `b 1 = 1/2`. Hence the
+parent theorem's global hypothesis genuinely fails on it, while the eventually-antitone trap
+of this file applies with `M = 1`. -/
+theorem not_antitone_bumped : ¬ Antitone bumped := by
+  intro h
+  have := h (show (0 : ℕ) ≤ 1 by norm_num)
+  simp only [bumped, if_neg (by norm_num : (1 : ℕ) ≠ 0)] at this
+  norm_num at this
+
+/-- **Capstone: the eventually-antitone trap applies to the bumped series.** The series
+`∑ (-1)^i bumped i` converges to some `l`, and for every `N ≥ 1` its error is trapped between
+the consecutive-term gap and the first omitted term — even though `bumped` is not globally
+antitone, so the parent result does not cover it. -/
+theorem bumped_error_trapped :
+    ∃ l : ℝ, Tendsto (fun n => ∑ i ∈ range n, (-1 : ℝ) ^ i * bumped i) atTop (𝓝 l) ∧
+      ∀ N : ℕ, 1 ≤ N →
+        bumped N - bumped (N + 1) ≤ |(∑ i ∈ range N, (-1 : ℝ) ^ i * bumped i) - l|
+          ∧ |(∑ i ∈ range N, (-1 : ℝ) ^ i * bumped i) - l| ≤ bumped N := by
+  obtain ⟨l, hl⟩ :=
+    tendsto_partialSum_of_eventually_antitone antitoneOn_bumped tendsto_bumped_zero
+  exact ⟨l, hl, fun N hN =>
+    abs_partialSum_sub_limit_trapped_eventually antitoneOn_bumped tendsto_bumped_zero hl hN⟩
+
+end AlternatingSeriesTestOQ01OQ01OQ02

--- a/src/data/proofs/alternating-series-test-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "alternating-series-test-oq-01-oq-01-oq-02",
+  "title": "Two-Sided Error Trap for Eventually-Antitone Alternating Series",
+  "slug": "alternating-series-test-oq-01-oq-01-oq-02",
+  "description": "Answers the parent entry's open question (index 1): does the two-sided two-term error trap f N − f (N+1) ≤ |S_N − l| ≤ f N survive when the coefficients are only eventually antitone — antitone on [M, ∞) rather than on all of ℕ? Yes, verbatim, for every N ≥ M. The proof is a shift reduction: write the tail from index M as its own alternating series with coefficients g j = f (j+M), which is globally antitone and tends to 0, so the parent theorem applies to g. The two series are linked by the exact splitting S_{n+M} = S_M + (-1)^M T_n, so the errors coincide up to a sign of modulus one: |S_N − l| = |T_{N-M} − t|. Feeding the parent trap for g back through g(N-M) = f N and g(N-M+1) = f(N+1) reproduces the original trap from the threshold M onward. Two further results: convergence of S_N is derived (not assumed) from eventual antitonicity plus f → 0; and the hypothesis is shown strictly weaker via an explicit bumped sequence (b 0 = 0, b i = 1/(i+1)) that is antitone only from M = 1 on, so the parent theorem cannot cover it while this one does.",
+  "meta": {
+    "author": "Shift-reduction extension formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesTestOQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "convergence",
+      "alternating-series",
+      "error-bound",
+      "sharpness",
+      "eventually-monotone",
+      "shift-reduction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Antitone.tendsto_alternating_series_of_tendsto_zero",
+        "description": "Convergence of the alternating series for the shifted (globally antitone) coefficients g → 0 — supplies the tail limit t and forces convergence of the full series",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Filter.tendsto_add_atTop_iff_nat",
+        "description": "Tendsto of a shifted sequence (fun n => u (n + M)) is equivalent to Tendsto of u — transports the limit of the index-shifted partial sums back to the original series",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "Filter.tendsto_add_atTop_nat",
+        "description": "(fun n => n + M) tends to atTop — shows the shifted coefficients g j = f (j+M) still tend to 0",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0 — drives the bumped witness sequence to 0",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ],
+    "originalContributions": [
+      "antitone_shift / tendsto_shift_zero: the tail coefficients g j = f (j+M) inherit global antitonicity and convergence to 0 from f's eventual antitonicity, enabling the reduction to the parent theorem",
+      "partialSum_shift: the exact shift splitting S_{n+M} = S_M + (-1)^M T_n linking the full series to its tail (proved by induction)",
+      "tendsto_partialSum_of_eventually_antitone: convergence of the alternating series is DERIVED from eventual antitonicity plus f → 0, with explicit limit l = S_M + (-1)^M t — it need not be assumed",
+      "abs_partialSum_sub_limit_trapped_eventually: the two-sided two-term trap f N − f (N+1) ≤ |S_N − l| ≤ f N holds for every N ≥ M when f is antitone only on [M, ∞), answering the parent's open question",
+      "sub_le_abs_partialSum_sub_limit_eventually / abs_partialSum_sub_limit_le_eventually: the lower and upper halves extracted as standalone lemmas",
+      "bumped + antitoneOn_bumped + not_antitone_bumped + bumped_error_trapped: an explicit witness (b 0 = 0, b i = 1/(i+1)) antitone only on [1, ∞), proving the eventual hypothesis is strictly weaker than the parent's global one and that the trap genuinely applies where the parent cannot"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 206,
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Leibniz alternating series test, and its parent two-term sharpening f N − f (N+1) ≤ |S_N − l| ≤ f N, both require the coefficient sequence to be antitone on all of ℕ. In practice coefficients are frequently antitone only eventually — a finite initial segment may misbehave (transients, a startup bump, reindexing artifacts) before the monotone tail sets in. The parent entry flagged exactly this as an open question. The classical resolution is a shift: throw away the finite head and apply the monotone theory to the tail. Packaging that reduction formally shows the entire two-sided trap survives, valid from the antitonicity threshold onward, with the same two-term bounds and no loss.",
+    "problemStatement": "Suppose f : ℕ → ℝ is antitone only on [M, ∞) (AntitoneOn f (Set.Ici M)) and f → 0. Does the parent's two-term trap still hold?\n\n**Answer: yes, for every N ≥ M:** f N − f (N+1) ≤ |S_N − l| ≤ f N, where S_N = ∑_{i<N} (-1)^i f i. Moreover the limit l exists by virtue of the hypotheses alone (it equals S_M + (-1)^M t with t the Leibniz limit of the tail), so convergence need not be assumed. The eventual hypothesis is strictly weaker: the bumped sequence b 0 = 0, b i = 1/(i+1) is antitone on [1,∞) but not on ℕ, so the parent theorem does not apply to it while this one does.",
+    "text": "The two-sided two-term Leibniz error trap holds for alternating series whose coefficients are antitone only eventually, valid from the antitonicity threshold M onward — proved by shifting the monotone tail into the parent theorem.",
+    "proofStrategy": "Reduce to the parent theorem by a shift. Set g j = f (j+M); from AntitoneOn f (Ici M) deduce Antitone g, and from f → 0 deduce g → 0. The partial sums split exactly as S_{n+M} = S_M + (-1)^M T_n (induction on n, each new term matching via (-1)^{n+M} = (-1)^M (-1)^n), where T_n = ∑_{j<n} (-1)^j g j. By Mathlib's Leibniz convergence g has a limit t, and the splitting plus tendsto_add_atTop_iff_nat forces S_N → l = S_M + (-1)^M t. Writing N = m + M, the splitting gives S_N − l = (-1)^M (T_m − t), so |S_N − l| = |T_m − t|. The parent trap for g at index m reads g m − g (m+1) ≤ |T_m − t| ≤ g m, and g m = f N, g (m+1) = f (N+1), reproducing the trap. The strict-weakening witness is verified directly: antitoneOn_bumped (the if-branch is uniform on [1,∞)), tendsto_bumped_zero, and not_antitone_bumped (b 0 = 0 < 1/2 = b 1).",
+    "keyInsights": [
+      "A finite non-monotone head is irrelevant to the asymptotic error: shifting the index past the threshold M turns the eventually-antitone problem into the globally-antitone parent problem on the tail",
+      "The exact splitting S_{n+M} = S_M + (-1)^M T_n means the truncation errors of the full and shifted series are literally equal in modulus, |S_N − l| = |T_{N-M} − t|, so the parent's bounds transfer with no slack",
+      "Convergence is a consequence, not a hypothesis: eventual antitonicity plus f → 0 already supplies the limit l = S_M + (-1)^M t",
+      "The eventual hypothesis is strictly more general — the bumped witness antitone only from index 1 is covered here but not by the parent theorem"
+    ],
+    "prerequisites": [
+      "Convergence of sequences and series in ℝ",
+      "Monotone/antitone sequences and the alternating series (Leibniz) test",
+      "The parent entry's two-term trap f N − f (N+1) ≤ |S_N − l| ≤ f N",
+      "Finite sums and index shifts: Finset.sum_range_succ, Filter.tendsto_add_atTop_iff_nat"
+    ]
+  },
+  "sections": [
+    {
+      "id": "shift-reduction",
+      "title": "The Shift Reduction",
+      "startLine": 47,
+      "endLine": 76,
+      "summary": "The tail coefficients g j = f (j+M) are globally antitone and tend to 0, and the partial sums split exactly as S_{n+M} = S_M + (-1)^M T_n.",
+      "mathContext": "$S_{n+M} = S_M + (-1)^M \\sum_{j<n} (-1)^j f(j+M)$."
+    },
+    {
+      "id": "convergence-and-trap",
+      "title": "Derived Convergence and the Eventual Trap",
+      "startLine": 78,
+      "endLine": 148,
+      "summary": "Convergence S_N → l = S_M + (-1)^M t is derived from the hypotheses; then |S_N − l| = |T_{N-M} − t| feeds the parent trap to give f N − f (N+1) ≤ |S_N − l| ≤ f N for all N ≥ M.",
+      "mathContext": "$f_N - f_{N+1} \\le |S_N - l| \\le f_N \\quad (N \\ge M)$."
+    },
+    {
+      "id": "strictly-weaker-witness",
+      "title": "The Hypothesis Is Strictly Weaker",
+      "startLine": 150,
+      "endLine": 205,
+      "summary": "The bumped sequence b 0 = 0, b i = 1/(i+1) is antitone on [1,∞) but not on ℕ; the eventual trap applies to it with M = 1, witnessing genuine generalization beyond the parent.",
+      "mathContext": "$b_0 = 0 < \\tfrac12 = b_1$, yet $b$ is antitone on $[1,\\infty)$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Leibniz, G. W.",
+      "title": "Letter to Johann Bernoulli",
+      "year": "1714",
+      "note": "The alternating series convergence criterion"
+    },
+    {
+      "authors": "Rudin, W.",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "Alternating series test and the truncation error bound (Theorem 3.43)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-test-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: proves the two-term trap f N − f (N+1) ≤ |S_N − l| ≤ f N for globally antitone f and asks (open question index 1) whether it survives for eventually-antitone coefficients. This entry answers yes, valid for all N ≥ M, by shifting the monotone tail into the parent theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's two-sided two-term Leibniz trap f N − f (N+1) ≤ |S_N − l| ≤ f N extends verbatim to coefficients that are antitone only on [M, ∞), valid for every N ≥ M, proved with 0 axioms by a shift reduction: the tail g j = f (j+M) is globally antitone, S_{n+M} = S_M + (-1)^M T_n links the series, and |S_N − l| = |T_{N-M} − t| transfers the parent bounds. Convergence is derived from the hypotheses, and an explicit bumped witness shows the eventual hypothesis is strictly weaker than the global one.",
+    "implications": "Removes the global-monotonicity restriction from the sharp Leibniz error estimate, covering the common situation of a transient initial segment followed by a monotone tail; the same two-term bounds hold from the threshold M onward with no degradation.",
+    "openQuestions": [
+      "Can the trap be pushed below the threshold to all N (not just N ≥ M) with an explicit correction term accounting for the finite non-monotone head?",
+      "Does an analogous shift reduction yield two-sided bounds for coefficients of bounded variation (not eventually monotone) via Abel summation, as the parent's second open question hints?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AlternatingSeriesTestOQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "AlternatingSeriesTestOQ01OQ01OQ02",
+    "lineCount": 206,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/AlternatingSeriesTestOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **alternating-series-test-oq-01-oq-01**'s open question (index 1):

> *Can two-sided bounds of this kind be recovered for alternating series whose coefficients are eventually antitone …?*

**Yes — verbatim, for every `N ≥ M`.** If `f` is antitone only on `[M, ∞)` (`AntitoneOn f (Set.Ici M)`) and `f → 0`, then the parent's two-term Leibniz trap holds for all `N ≥ M`:

```
f N − f (N+1) ≤ |S_N − l| ≤ f N,   S_N = ∑_{i<N} (-1)^i f i.
```

## Mechanism — shift reduction

- Set `g j = f (j+M)`. Eventual antitonicity of `f` makes `g` **globally** antitone, and `f → 0` makes `g → 0`, so the parent theorem applies to `g`.
- Exact splitting `S_{n+M} = S_M + (-1)^M T_n` (induction) links the two series, where `T_n = ∑_{j<n} (-1)^j g j`.
- Hence `S_N − l = (-1)^M (T_{N-M} − t)`, so `|S_N − l| = |T_{N-M} − t|` — the parent bounds transfer with **no slack**. Finally `g (N-M) = f N` and `g (N-M+1) = f (N+1)` reproduce the original trap.

## Beyond the parent

- **Convergence is derived, not assumed.** `tendsto_partialSum_of_eventually_antitone`: eventual antitonicity + `f → 0` already forces `S_N → l = S_M + (-1)^M t`.
- **The hypothesis is strictly weaker.** Explicit witness `bumped` (`b 0 = 0`, `b i = 1/(i+1)`), antitone only on `[1, ∞)` (`not_antitone_bumped`: `b 0 = 0 < 1/2 = b 1`). The eventual trap applies to it with `M = 1`; the parent theorem cannot.

## Verification

- **11 theorems, 1 definition, 206 lines**, 0 sorries.
- **0 axioms** — `#print axioms` shows only the standard foundational `propext, Classical.choice, Quot.sound`.
- Compiles against Mathlib 4.26.0 (`Proofs/AlternatingSeriesTestOQ01OQ01OQ02.lean`, importing the parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)