### PR TITLE
Enrich combinations-formula-oq-06-oq-01 (figurate tower): add annotations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-06-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "figtower-oq0601-header",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "context",
+    "title": "The whole simplicial figurate ladder as one parametrized family",
+    "content": "The header states the parent's open question: combinations-formula-oq-06 proved the hockey-stick identity ∑_{m∈Icc k n} C(m,k) = C(n+1,k+1) but only read off the figurate consequences at k=1 (triangular) and k=2 (tetrahedral) as separate hand-built theorems, asking whether the uniform statement specializes to arbitrary k-dimensional figurate numbers C(n+k−1,k) — the full Pythagorean tower as a single family. This entry packages the entire ladder as one Lean object S(k,n) = C(n+k−1,k) = multichoose n k. The key is that the single Pascal recurrence S(k+1,n+1) = S(k+1,n) + S(k,n+1) drives every dimension, so one induction parametrized by k covers every column of Pascal's triangle simultaneously. 0 axioms, 0 sorries.",
+    "mathContext": "$S(k,n) = \\binom{n+k-1}{k} = \\mathrm{multichoose}(n,k);\\quad S(1,n)=n,\\ S(2,n)=\\binom{n+1}{2},\\ S(3,n)=\\binom{n+2}{3}$",
+    "significance": "context",
+    "relatedConcepts": ["figurate numbers", "hockey-stick identity", "multiset coefficient", "Pascal's triangle", "simplicial numbers"],
+    "prerequisites": ["binomial coefficients", "Nat.multichoose", "the parent hockey-stick entry"]
+  },
+  {
+    "id": "figtower-oq0601-def",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "definition",
+    "title": "S(k,n): the k-dimensional simplicial figurate number",
+    "content": "`S k n` is defined as Nat.multichoose n k, the k-dimensional figurate number, with k read as the dimension (k=1 points on a line, k=2 triangles, k=3 tetrahedra). `S_def` is the definitional rfl, and `S_eq_choose` bridges to pure binomial form S(k,n) = C(n+k−1,k) via Nat.multichoose_eq. Using multichoose rather than the raw binomial keeps the Pascal recurrence clean and dimension-uniform.",
+    "mathContext": "$S(k,n) := \\mathrm{multichoose}(n,k) = \\binom{n+k-1}{k}$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.multichoose", "Nat.multichoose_eq", "multiset coefficient"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "figtower-oq0601-recurrence",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 66, "endLine": 72 },
+    "type": "theorem",
+    "title": "S_succ_succ: the single Pascal-type recurrence",
+    "content": "`S_succ_succ` is the one recurrence that drives the entire family: S(k+1,n+1) = S(k+1,n) + S(k,n+1) — each figurate number is its predecessor in the same dimension plus the figurate number one dimension down. It is immediate from Nat.multichoose_succ_succ after unfolding S. Reading this as a statement about partial sums yields T_n = T_{n−1} + n, Te_n = Te_{n−1} + T_n, … all at once.",
+    "mathContext": "$S(k{+}1,n{+}1) = S(k{+}1,n) + S(k,n{+}1)$",
+    "significance": "key",
+    "relatedConcepts": ["Pascal recurrence", "Nat.multichoose_succ_succ", "figurate recurrences"],
+    "prerequisites": ["S definition"]
+  },
+  {
+    "id": "figtower-oq0601-tower",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "theorem",
+    "title": "sum_Icc_S: the tower identity, uniform in dimension",
+    "content": "`sum_Icc_S` is the headline result: ∑_{m=1}^{n} S(k,m) = S(k+1,n) for every dimension k — each layer is the running total of the layer below it. The induction on n has base case S(k+1,0) = 0 and a successor step that is EXACTLY the recurrence S_succ_succ (via Finset.sum_Icc_succ_top and the inductive hypothesis), so one identical one-line proof serves every k. This is the single-family answer the parent asked for.",
+    "mathContext": "$\\sum_{m=1}^{n} S(k,m) = S(k{+}1,n)$",
+    "significance": "key",
+    "relatedConcepts": ["telescoping by recurrence", "Finset.sum_Icc_succ_top", "induction", "dimension-uniform proof"],
+    "prerequisites": ["S_succ_succ"]
+  },
+  {
+    "id": "figtower-oq0601-tower-pred",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 85, "endLine": 92 },
+    "type": "theorem",
+    "title": "sum_Icc_S_pred: the classical figurate stacking form",
+    "content": "`sum_Icc_S_pred` restates the tower in the classical index convention: for k ≥ 1, ∑_{m=1}^{n} S(k−1,m) = S(k,n) — the triangular → tetrahedral → pentatope → … stacking of antiquity. It is obtained from sum_Icc_S by writing k = j+1 (Nat.succ_pred_eq_of_pos) so the predecessor subtraction disappears.",
+    "mathContext": "$\\sum_{m=1}^{n} S(k{-}1,m) = S(k,n)\\quad(k \\ge 1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["classical figurate stacking", "Nat.succ_pred_eq_of_pos"],
+    "prerequisites": ["sum_Icc_S"]
+  },
+  {
+    "id": "figtower-oq0601-instances",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 94, "endLine": 108 },
+    "type": "technique",
+    "title": "Slices k = 1, 2, 3 recover natural, triangular, tetrahedral numbers",
+    "content": "The dimension slices recover the classical sequences: `S_one` gives S(1,n) = n (Nat.multichoose_one_right), `S_two` gives S(2,n) = C(n+1,2) (triangular), `S_three` gives S(3,n) = C(n+2,3) (tetrahedral) — each via S_eq_choose plus an omega index simplification. `S_two_closed` recovers the familiar closed form n(n+1)/2 via Nat.choose_two_right, subsuming the parent's hand-built triangular_closed_form.",
+    "mathContext": "$S(1,n)=n,\\ S(2,n)=\\binom{n+1}{2}=\\tfrac{n(n+1)}{2},\\ S(3,n)=\\binom{n+2}{3}$",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "tetrahedral numbers", "Nat.choose_two_right", "closed form"],
+    "prerequisites": ["S_eq_choose"]
+  },
+  {
+    "id": "figtower-oq0601-parent-recovery",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 110, "endLine": 121 },
+    "type": "theorem",
+    "title": "Parent's tower steps as k = 1 and k = 2 cases",
+    "content": "`sum_triangular` recovers the parent's triangular identity (∑_{m=1}^{n} m = C(n+1,2)) as the k=1 case of sum_Icc_S, and `sum_tetrahedral` recovers the tetrahedral tower (∑_{m=1}^{n} C(m+1,2) = C(n+2,3)) as the k=2 case — both by `simpa` rewriting S to its binomial slice. This demonstrates concretely that the parent's two separate hand-built theorems are instances of the single parametrized theorem.",
+    "mathContext": "$\\sum_{m=1}^{n} m = \\binom{n+1}{2};\\quad \\sum_{m=1}^{n}\\binom{m+1}{2} = \\binom{n+2}{3}$",
+    "significance": "key",
+    "relatedConcepts": ["specialization", "subsuming hand-built instances"],
+    "prerequisites": ["sum_Icc_S", "S_two", "S_three"]
+  },
+  {
+    "id": "figtower-oq0601-verification",
+    "proofId": "combinations-formula-oq-06-oq-01",
+    "range": { "startLine": 126, "endLine": 130 },
+    "type": "context",
+    "title": "Concrete numerical verifications",
+    "content": "Three example sanity checks confirm the development on small numbers: S(3,4) = C(6,3) = 20; the tower at k=2 (T₁+T₂+T₃+T₄ = 1+3+6+10 = 20 = S(3,4)); and the Pascal recurrence S(3,5) = S(3,4) + S(2,5) = 20+15 = 35. Each is routed through the binomial form S_eq_choose so kernel `decide` can evaluate it (multichoose is compiled by well-founded recursion and does not reduce by decide directly). These are anonymous `example`s, so the decide does not pull Lean.ofReduceBool into any named result's axiom set.",
+    "mathContext": "$S(3,4)=20,\\quad \\sum_{m=1}^{4} S(2,m) = 20,\\quad S(3,5) = 20+15 = 35$",
+    "significance": "context",
+    "relatedConcepts": ["kernel decide", "sanity checks", "well-founded recursion"],
+    "prerequisites": ["S_eq_choose", "the tower and recurrence theorems"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-06-oq-01` (the simplicial figurate-number tower as a single parametrized family).

## Gap addressed
The entry had a rich `meta.json` (8 sections) but **no `annotations.json`**.

## Changes
Added `annotations.json` with **8 annotations** (one per section), each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
- **header** — the parent's open question and the single-family contribution
- **definition** — S(k,n) = multichoose n k = C(n+k−1,k)
- **recurrence** — the single Pascal-type recurrence S_succ_succ
- **tower** — sum_Icc_S, the dimension-uniform tower identity
- **tower (classical)** — sum_Icc_S_pred, the antiquity stacking form
- **instances** — k=1/2/3 slices (natural, triangular, tetrahedral)
- **parent-recovery** — the parent's triangular/tetrahedral steps as k=1/2 cases
- **verification** — concrete numerical checks (anonymous examples, kernel decide)

## Validation
- `pnpm annotations:build` passes with **no warnings for this entry** (all line ranges resolve to constructs); JSON validated.
- Verified `status: verified`, `badge: original`, `axiomCount: 0` match the Lean file (0 sorries, 0 axiom decls; decide confined to anonymous examples).