### PR TITLE
research(erdos-138): eliminate the file's only sorry — W(k)^{1/k}→∞ ⟹ W(k)/2^k→∞

### DIFF
--- a/proofs/Proofs/Erdos138Problem.lean
+++ b/proofs/Proofs/Erdos138Problem.lean
@@ -839,11 +839,36 @@ theorem W_difference_diverges : DifferenceDiverges := by
 /-! ## Logical Relationships -/
 
 /-- If the main conjecture holds (W(k)^{1/k} → ∞), then W(k)/2^k → ∞.
-    Formal proof requires careful filter limit manipulation. -/
+
+    Proof: if `W(k)^{1/k} → ∞` then eventually `W(k)^{1/k} ≥ 4`, hence
+    `W(k) = (W(k)^{1/k})^k ≥ 4^k`, so `W(k)/2^k ≥ 4^k/2^k = 2^k → ∞`. The result
+    then follows by comparison with `2^k`. -/
 theorem main_conjecture_implies_exponential :
     Erdos138Conjecture → ExponentialDiverges := by
-  intro _hconj
-  sorry
+  intro hconj
+  unfold Erdos138Conjecture at hconj
+  unfold ExponentialDiverges
+  -- Eventually `W(k)^{1/k} ≥ 4`, and eventually `k ≥ 1`.
+  have h4 : ∀ᶠ k in atTop, (4 : ℝ) ≤ (W k : ℝ) ^ ((k : ℝ)⁻¹) :=
+    hconj.eventually_ge_atTop 4
+  have hk1 : ∀ᶠ k in atTop, 1 ≤ k := eventually_ge_atTop 1
+  -- Eventually `W(k)/2^k ≥ 2^k`.
+  have hlb : ∀ᶠ k in atTop, (2 : ℝ) ^ k ≤ (W k : ℝ) / 2 ^ k := by
+    filter_upwards [h4, hk1] with k hk4 hk1
+    have hWnonneg : (0 : ℝ) ≤ (W k : ℝ) := by positivity
+    have hkne : (k : ℝ) ≠ 0 := by exact_mod_cast Nat.one_le_iff_ne_zero.mp hk1
+    -- `(W(k)^{1/k})^k = W(k)` for `k ≥ 1`.
+    have hroot : ((W k : ℝ) ^ ((k : ℝ)⁻¹)) ^ k = (W k : ℝ) := by
+      rw [← Real.rpow_natCast ((W k : ℝ) ^ ((k : ℝ)⁻¹)) k, ← Real.rpow_mul hWnonneg,
+        inv_mul_cancel₀ hkne, Real.rpow_one]
+    have hWge : (4 : ℝ) ^ k ≤ (W k : ℝ) := by
+      rw [← hroot]
+      exact pow_le_pow_left₀ (by norm_num) hk4 k
+    rw [le_div_iff₀ (by positivity)]
+    calc (2 : ℝ) ^ k * 2 ^ k = 4 ^ k := by rw [← mul_pow]; norm_num
+      _ ≤ (W k : ℝ) := hWge
+  -- `2^k → ∞`, so by comparison `W(k)/2^k → ∞`.
+  exact tendsto_atTop_mono' atTop hlb (tendsto_pow_atTop_atTop_of_one_lt (by norm_num))
 
 theorem implication_hierarchy :
     Erdos138Conjecture → ExponentialDiverges :=

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -46,10 +46,11 @@
       "Coloring-extension lemmas (ap_must_end, extend_one_step, extend_j_steps) yielding the unconditional bound W(k+1) − W(k) ≥ k",
       "Theorem W_difference_diverges_nat formalizing the resolved difference variant via Filter.tendsto_atTop_mono",
       "Axiomatized Berlekamp, Gowers, and Kozik-Shabanov bounds plus exact values W(3)…W(6)",
-      "Filter.Tendsto formulation of Erdős's k-th root conjecture (still OPEN) and the strict implication Erdos138Conjecture → ExponentialDiverges"
+      "Filter.Tendsto formulation of Erdős's k-th root conjecture (still OPEN) and the strict implication Erdos138Conjecture → ExponentialDiverges",
+      "main_conjecture_implies_exponential: proved (was the file's only sorry) — W(k)^{1/k}→∞ ⟹ W(k)/2^k→∞, via eventually W(k)^{1/k}≥4 ⟹ W(k)≥4^k ⟹ W(k)/2^k≥2^k→∞"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
@@ -160,7 +161,7 @@
     "theoremCount": 23,
     "definitionCount": 13,
     "path": "Proofs/Erdos138Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Stubs/Erdos138Aristotle.lean"
     ]
@@ -228,5 +229,5 @@
       "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Eliminates the **only sorry** in `Erdos138Problem.lean` (van der Waerden numbers, Erdős #138). Proves `main_conjecture_implies_exponential`: the main conjecture `W(k)^{1/k} → ∞` implies the exponential-growth variant `W(k)/2^k → ∞`.

## Proof

From the conjecture `Tendsto (W(k)^{1/k}) atTop atTop`, eventually `W(k)^{1/k} ≥ 4`. The rpow root identity `(W(k)^{1/k})^k = W(k)` (valid for `k ≥ 1`, `W(k) ≥ 0`) gives `W(k) ≥ 4^k`, so

```
W(k)/2^k ≥ 4^k/2^k = 2^k → ∞,
```

and the result follows by comparison (`tendsto_atTop_mono'` with `2^k → ∞`).

## Status

- File now builds with **0 sorries** (was 1). Verified with `lean v4.26.0`.
- `#print axioms main_conjecture_implies_exponential` → `[propext, Classical.choice, Quot.sound]` only — **axiom-free**; the implication is a pure conditional and uses none of the file's 8 problem axioms.
- The 8 axioms are unchanged and remain genuinely deep / infeasible: van der Waerden existence (`W_is_nonempty`; not yet in pinned Mathlib v4.26.0), the Berlekamp / Gowers / Kozik–Shabanov bounds, and the exact values `W(3..6)` (established by literature-scale computation). None are routine Mathlib lemmas, so the entry remains `axiomatized`.
- Gallery meta `erdos-138` sorry count updated 1 → 0.

The main conjecture `W(k)^{1/k} → ∞` itself remains **OPEN** ($500 prize); this PR only formalizes one of its logical consequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)