### PR TITLE
research(matrix-similarity-oq-01-oq-01-oq-02): functorial kernel isomorphism for similar matrices

### DIFF
--- a/proofs/Proofs/MatrixSimilarityInvariantsOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/MatrixSimilarityInvariantsOQ01OQ01OQ02.lean
@@ -1,0 +1,163 @@
+import Mathlib
+
+/-
+# Functorial Kernel Isomorphism for Similar Matrices
+
+The companion entry [oq-01-oq-01] (`MatrixSimilarityInvariantsOQ01OQ01`) proves that the
+**nullity** — the dimension of the kernel of the associated linear map `A.mulVecLin` — is a
+similarity invariant: if `B = P A P⁻¹` then `dim (ker B) = dim (ker A)`.  That is an equality
+of *numbers*; it tells us the two kernels have the same size but produces no actual map
+between them.
+
+This entry upgrades the equality of dimensions to an **explicit linear isomorphism of the
+kernels themselves**, answering the parent's second open question:
+
+> *Does the kernel of `A.mulVecLin` transport functorially under conjugation, giving an
+> explicit linear isomorphism of kernels rather than only equality of dimensions?*
+
+The isomorphism is the conceptual one.  Conjugation `B = P A P⁻¹` is a change of basis by
+the invertible matrix `P`, and that very change of basis carries kernel to kernel:
+
+* `x ∈ ker B  ⟹  P⁻¹ *ᵥ x ∈ ker A`   (because `A (P⁻¹ x) = P⁻¹ (B x) = 0`), and
+* `y ∈ ker A  ⟹  P *ᵥ y ∈ ker B`     (because `B (P y) = P (A y) = 0`).
+
+These two maps are mutually inverse — `P⁻¹ *ᵥ (P *ᵥ y) = y` and `P *ᵥ (P⁻¹ *ᵥ x) = x` — so
+they assemble into a `LinearEquiv`
+
+  `kerEquiv : ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin`.
+
+Main results:
+
+* `kerEquiv` — the explicit linear isomorphism of kernels, built from the witness `P`.
+* `kerEquiv_apply` / `kerEquiv_symm_apply` — it acts as `P⁻¹ *ᵥ ·` (and its inverse as
+  `P *ᵥ ·`), so it is genuinely the change-of-basis map, not an abstract dimension-counting
+  artefact.
+* `kerEquiv_refl` — the witness `P = 1` for `A ~ A` gives the identity isomorphism
+  (the *functor-on-identities* law).
+* `kerEquiv_trans` — stacking two conjugations `B = P A P⁻¹`, `C = Q B Q⁻¹` (so
+  `C = (QP) A (QP)⁻¹`) composes the kernel isomorphisms (the *functor-on-composition* law).
+* `nullity_eq_of_conj` — recovering the parent's equality of dimensions as a one-line
+  corollary (`LinearEquiv.finrank_eq`), confirming the iso refines the numeric statement.
+* `Similar.nonempty_kerEquiv` — the basis-free existence form for the `Similar` relation.
+
+The functoriality laws `kerEquiv_refl` and `kerEquiv_trans` are exactly what justifies the
+word "functorial": the kernel construction is a functor from the groupoid of matrices and
+conjugations to `K`-vector spaces and linear isomorphisms.
+
+Mathlib has all the ingredients (`Matrix.mulVecLin`, `Matrix.mulVec_mulVec`,
+`LinearEquiv.ofLinear`, `LinearMap.restrict`) but states neither the conjugation-transports-
+kernels isomorphism nor its functoriality.  Absent from Mathlib.
+-/
+
+namespace MatrixSimilarityInvariantsOQ01OQ01OQ02
+
+open Matrix Module
+
+variable {n : Type*} [Fintype n] [DecidableEq n] {K : Type*} [Field K]
+
+/-- Two square matrices are **similar** if one is a conjugate of the other by an invertible
+matrix: `B = P * A * P⁻¹`.  (Same definition as the companion entries.) -/
+def Similar (A B : Matrix n n K) : Prop :=
+  ∃ P : (Matrix n n K)ˣ, B = P.val * A * P⁻¹.val
+
+/-! ## The conjugation identities
+
+From `B = P A P⁻¹` we extract the two "intertwining" identities that make conjugation move
+kernels around: `A` commutes with `P⁻¹` up to `B`, and `B` commutes with `P` up to `A`. -/
+
+variable {A B : Matrix n n K} {P : (Matrix n n K)ˣ}
+
+/-- `A * P⁻¹ = P⁻¹ * B`: the intertwining identity pushing `A` through `P⁻¹`. -/
+theorem conj_intertwine_left (hB : B = P.val * A * P⁻¹.val) :
+    A * P⁻¹.val = P⁻¹.val * B := by
+  rw [hB, ← mul_assoc P⁻¹.val (P.val * A) P⁻¹.val, ← mul_assoc P⁻¹.val P.val A,
+    Units.inv_mul, one_mul]
+
+/-- `B * P = P * A`: the intertwining identity pushing `B` through `P`. -/
+theorem conj_intertwine_right (hB : B = P.val * A * P⁻¹.val) :
+    B * P.val = P.val * A := by
+  rw [hB, mul_assoc (P.val * A), Units.inv_mul, mul_one]
+
+/-! ## Kernel transport -/
+
+/-- The change of basis `P⁻¹` carries `ker B` into `ker A`. -/
+theorem mapsTo_ker_left (hB : B = P.val * A * P⁻¹.val) (x : n → K)
+    (hx : x ∈ LinearMap.ker B.mulVecLin) :
+    P⁻¹.val.mulVecLin x ∈ LinearMap.ker A.mulVecLin := by
+  simp only [LinearMap.mem_ker, mulVecLin_apply] at hx ⊢
+  rw [mulVec_mulVec, conj_intertwine_left hB, ← mulVec_mulVec, hx, mulVec_zero]
+
+/-- The change of basis `P` carries `ker A` into `ker B`. -/
+theorem mapsTo_ker_right (hB : B = P.val * A * P⁻¹.val) (y : n → K)
+    (hy : y ∈ LinearMap.ker A.mulVecLin) :
+    P.val.mulVecLin y ∈ LinearMap.ker B.mulVecLin := by
+  simp only [LinearMap.mem_ker, mulVecLin_apply] at hy ⊢
+  rw [mulVec_mulVec, conj_intertwine_right hB, ← mulVec_mulVec, hy, mulVec_zero]
+
+/-! ## The explicit kernel isomorphism -/
+
+/-- **Functorial kernel isomorphism.** If `B = P A P⁻¹`, the change of basis `P⁻¹` restricts
+to an explicit linear isomorphism `ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin`, with inverse the
+restriction of `P`. -/
+noncomputable def kerEquiv (hB : B = P.val * A * P⁻¹.val) :
+    (LinearMap.ker B.mulVecLin) ≃ₗ[K] (LinearMap.ker A.mulVecLin) :=
+  LinearEquiv.ofLinear
+    (P⁻¹.val.mulVecLin.restrict (mapsTo_ker_left hB))
+    (P.val.mulVecLin.restrict (mapsTo_ker_right hB))
+    (by
+      refine LinearMap.ext fun y => Subtype.ext ?_
+      simp only [LinearMap.comp_apply, LinearMap.restrict_coe_apply, LinearMap.id_coe, id_eq,
+        mulVecLin_apply]
+      rw [mulVec_mulVec, Units.inv_mul, one_mulVec])
+    (by
+      refine LinearMap.ext fun x => Subtype.ext ?_
+      simp only [LinearMap.comp_apply, LinearMap.restrict_coe_apply, LinearMap.id_coe, id_eq,
+        mulVecLin_apply]
+      rw [mulVec_mulVec, Units.mul_inv, one_mulVec])
+
+@[simp]
+theorem kerEquiv_apply (hB : B = P.val * A * P⁻¹.val) (x : LinearMap.ker B.mulVecLin) :
+    (kerEquiv hB x : n → K) = P⁻¹.val *ᵥ (x : n → K) := rfl
+
+@[simp]
+theorem kerEquiv_symm_apply (hB : B = P.val * A * P⁻¹.val) (y : LinearMap.ker A.mulVecLin) :
+    ((kerEquiv hB).symm y : n → K) = P.val *ᵥ (y : n → K) := rfl
+
+/-! ## Functoriality -/
+
+/-- **Functor on identities.** The trivial conjugation `A = 1 * A * 1⁻¹` gives the identity
+isomorphism of `ker A` with itself. -/
+theorem kerEquiv_refl (A : Matrix n n K) (hA : A = (1 : (Matrix n n K)ˣ).val * A * (1 : (Matrix n n K)ˣ)⁻¹.val) :
+    kerEquiv hA = LinearEquiv.refl K (LinearMap.ker A.mulVecLin) := by
+  refine LinearEquiv.ext fun x => Subtype.ext ?_
+  simp [kerEquiv_apply]
+
+/-- **Functor on composition.** Two stacked conjugations `B = P A P⁻¹` and `C = Q B Q⁻¹`
+realise `C = (Q*P) A (Q*P)⁻¹`, and the kernel isomorphisms compose accordingly:
+the `A ← C` map is the `A ← B` map after the `B ← C` map. -/
+theorem kerEquiv_trans {C : Matrix n n K} {Q : (Matrix n n K)ˣ}
+    (hB : B = P.val * A * P⁻¹.val) (hC : C = Q.val * B * Q⁻¹.val)
+    (hCA : C = (Q * P).val * A * (Q * P)⁻¹.val) (x : LinearMap.ker C.mulVecLin) :
+    (kerEquiv hCA x : n → K) = (kerEquiv hB (kerEquiv hC x) : n → K) := by
+  simp only [kerEquiv_apply]
+  rw [mulVec_mulVec, _root_.mul_inv_rev, Units.val_mul]
+
+/-! ## Recovering the numeric invariant -/
+
+/-- **The isomorphism refines the parent's equality of dimensions.** Taking finrank of both
+sides of `kerEquiv` recovers `nullity B = nullity A` of the companion entry. -/
+theorem nullity_eq_of_conj (hB : B = P.val * A * P⁻¹.val) :
+    finrank K (LinearMap.ker B.mulVecLin) = finrank K (LinearMap.ker A.mulVecLin) :=
+  (kerEquiv hB).finrank_eq
+
+/-! ## Basis-free existence form -/
+
+/-- **Existence form for the `Similar` relation.** Similar matrices have isomorphic kernels.
+This is the basis-free packaging: `Similar A B` only asserts *some* conjugator exists, and we
+produce an isomorphism from it. -/
+theorem Similar.nonempty_kerEquiv (h : Similar A B) :
+    Nonempty ((LinearMap.ker B.mulVecLin) ≃ₗ[K] (LinearMap.ker A.mulVecLin)) := by
+  obtain ⟨P, hP⟩ := h
+  exact ⟨kerEquiv hP⟩
+
+end MatrixSimilarityInvariantsOQ01OQ01OQ02

--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "matrix-similarity-invariants-oq-01-oq-01-oq-02",
+  "title": "Functorial Kernel Isomorphism for Similar Matrices",
+  "slug": "matrix-similarity-invariants-oq-01-oq-01-oq-02",
+  "description": "The companion entry [oq-01-oq-01] proves nullity is a similarity invariant: if B = P·A·P⁻¹ then dim(ker B) = dim(ker A). That is an equality of numbers and produces no map between the kernels. This entry upgrades it to an explicit linear isomorphism kerEquiv : ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin, realised by the change of basis itself (x ↦ P⁻¹ ·ᵥ x, with inverse y ↦ P ·ᵥ y), and proves the two functoriality laws — identity conjugation gives the identity isomorphism, composed conjugations compose the isomorphisms — that justify calling the construction functorial. Taking finrank recovers the parent's equality of dimensions as a one-line corollary. Mathlib has the ingredients (Matrix.mulVecLin, Matrix.mulVec_mulVec, LinearEquiv.ofLinear, LinearMap.restrict) but states neither the conjugation-transports-kernels isomorphism nor its functoriality.",
+  "meta": {
+    "author": "classical linear algebra; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MatrixSimilarityInvariantsOQ01OQ01OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "similarity",
+      "kernel",
+      "linear-equiv",
+      "functoriality",
+      "change-of-basis",
+      "invariants"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mulVecLin",
+        "description": "The linear map (n → K) →ₗ[K] (n → K) associated to a matrix, x ↦ A ·ᵥ x; its kernel is the object being transported",
+        "module": "Mathlib.LinearAlgebra.Matrix.ToLin"
+      },
+      {
+        "theorem": "Matrix.mulVec_mulVec",
+        "description": "M ·ᵥ (N ·ᵥ v) = (M * N) ·ᵥ v — the associativity identity driving every membership and round-trip computation",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "LinearMap.restrict",
+        "description": "Restricts a linear map to a submodule of the domain and codomain given a maps-into proof; builds the forward and backward kernel maps from P⁻¹.mulVecLin and P.mulVecLin",
+        "module": "Mathlib.Algebra.Module.Submodule.LinearMap"
+      },
+      {
+        "theorem": "LinearEquiv.ofLinear",
+        "description": "Assembles two mutually inverse linear maps into a linear equivalence; turns the restricted maps into kerEquiv",
+        "module": "Mathlib.Algebra.Module.Equiv.Basic"
+      },
+      {
+        "theorem": "LinearEquiv.finrank_eq",
+        "description": "Equivalent spaces have equal finrank; recovers the parent's nullity equality from the isomorphism",
+        "module": "Mathlib.LinearAlgebra.FiniteDimensional"
+      }
+    ],
+    "originalContributions": [
+      "kerEquiv: an explicit linear isomorphism ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin from the conjugation witness B = P·A·P⁻¹, built by restricting the change-of-basis maps P⁻¹·ᵥ· and P·ᵥ· to the kernels",
+      "conj_intertwine_left / conj_intertwine_right: the intertwining identities A·P⁻¹ = P⁻¹·B and B·P = P·A extracted from the conjugation, the algebraic engine of kernel transport",
+      "mapsTo_ker_left / mapsTo_ker_right: P⁻¹ carries ker B into ker A and P carries ker A into ker B",
+      "kerEquiv_apply / kerEquiv_symm_apply: the isomorphism acts as P⁻¹·ᵥ· (inverse P·ᵥ·), certifying it is the genuine change-of-basis map and not an abstract dimension-counting artefact",
+      "kerEquiv_refl: the identity-conjugation witness gives the identity isomorphism (functor-on-identities law)",
+      "kerEquiv_trans: stacked conjugations B = P·A·P⁻¹, C = Q·B·Q⁻¹ compose the kernel isomorphisms (functor-on-composition law)",
+      "nullity_eq_of_conj: taking finrank recovers the parent's equality of kernel dimensions, confirming the isomorphism refines the numeric invariant",
+      "Similar.nonempty_kerEquiv: the basis-free existence form for the Similar relation"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound. Stated over an arbitrary field K and finite index type n.",
+    "lineCount": 163,
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Equality of dimensions is the shadow that an isomorphism casts on the level of numbers. The companion entry showed that similar matrices have kernels of equal dimension; the natural next question — the one a category theorist asks reflexively — is whether that equality is witnessed by an actual map, and whether the assignment of that map respects identities and composition. Conjugation B = P·A·P⁻¹ is literally a change of basis, so the expectation is that the change of basis itself carries kernel to kernel; making this precise turns a dimension count into a functor from the groupoid of matrices-and-conjugations to vector-spaces-and-isomorphisms.",
+    "problemStatement": "Does the kernel of A.mulVecLin transport functorially under conjugation B = P·A·P⁻¹, giving an explicit linear isomorphism of kernels rather than only equality of dimensions?\n\n**Answer:** yes. The change of basis P⁻¹ restricts to a linear isomorphism kerEquiv : ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin (with inverse the restriction of P), it acts as x ↦ P⁻¹ ·ᵥ x, it sends the identity conjugation to the identity isomorphism, and it composes under stacked conjugations. Taking finrank recovers the equality of dimensions.",
+    "text": "Conjugation transports kernels by an explicit linear isomorphism — the change of basis itself — and this assignment is functorial: identities go to identities and composites to composites.",
+    "proofStrategy": "From B = P·A·P⁻¹ extract the intertwining identities A·P⁻¹ = P⁻¹·B (conj_intertwine_left) and B·P = P·A (conj_intertwine_right) by cancelling the surrounding unit P with Units.inv_mul. These give the maps-into facts: for x ∈ ker B, A ·ᵥ (P⁻¹ ·ᵥ x) = (A·P⁻¹) ·ᵥ x = (P⁻¹·B) ·ᵥ x = P⁻¹ ·ᵥ (B ·ᵥ x) = 0, so P⁻¹ carries ker B into ker A (mapsTo_ker_left), and symmetrically P carries ker A into ker B. Restrict P⁻¹.mulVecLin and P.mulVecLin to the kernels with LinearMap.restrict and assemble them with LinearEquiv.ofLinear; the two round-trip identities reduce, via Matrix.mulVec_mulVec and Units.inv_mul / Units.mul_inv, to 1 ·ᵥ v = v. The action lemmas kerEquiv_apply / kerEquiv_symm_apply hold by rfl. Functoriality: kerEquiv_refl follows because 1⁻¹ ·ᵥ x = x; kerEquiv_trans because (Q·P)⁻¹ = P⁻¹·Q⁻¹ (mul_inv_rev) matches the composite P⁻¹ ·ᵥ (Q⁻¹ ·ᵥ x) (mulVec_mulVec). Finally nullity_eq_of_conj is LinearEquiv.finrank_eq applied to kerEquiv.",
+    "keyInsights": [
+      "The isomorphism is not abstract: it is the change-of-basis map P⁻¹ ·ᵥ · restricted to the kernel, made precise by kerEquiv_apply being true by rfl — the same P that conjugates A into B is the one that moves the solution spaces",
+      "Everything reduces to one matrix identity, mulVec_mulVec (M ·ᵥ (N ·ᵥ v) = (M*N) ·ᵥ v): membership, the two round trips, and the composition law are all instances of pushing a product of matrices through a vector",
+      "The intertwining identities A·P⁻¹ = P⁻¹·B and B·P = P·A are the conceptual core — they say A and B are the same operator read through P, and a single unit cancellation (Units.inv_mul) produces each",
+      "Functoriality is what upgrades 'isomorphic kernels' to 'the kernel is a functor': kerEquiv_refl and kerEquiv_trans verify the identity and composition laws on the groupoid of matrices under conjugation",
+      "The equality of dimensions from the parent entry is recovered for free by LinearEquiv.finrank_eq, exhibiting it as the decategorification of the isomorphism rather than an independent fact"
+    ],
+    "prerequisites": [
+      "Matrices over a field and the associated linear map A.mulVecLin",
+      "Kernels as submodules and restriction of linear maps to submodules",
+      "Linear equivalences and how to build one from two mutually inverse maps (LinearEquiv.ofLinear)",
+      "The unit (invertible-matrix) group and its inverse identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "intertwine",
+      "title": "The Conjugation Identities",
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "From B = P·A·P⁻¹, cancel the unit P to obtain the intertwining identities A·P⁻¹ = P⁻¹·B and B·P = P·A.",
+      "mathContext": "$A P^{-1} = P^{-1} B,\\qquad B P = P A.$"
+    },
+    {
+      "id": "transport",
+      "title": "Kernel Transport",
+      "startLine": 81,
+      "endLine": 95,
+      "summary": "The change of basis P⁻¹ carries ker B into ker A and P carries ker A into ker B, via the intertwining identities and mulVec_mulVec.",
+      "mathContext": "$x \\in \\ker B \\Rightarrow P^{-1} x \\in \\ker A,\\quad y \\in \\ker A \\Rightarrow P y \\in \\ker B.$"
+    },
+    {
+      "id": "equiv",
+      "title": "The Explicit Kernel Isomorphism",
+      "startLine": 97,
+      "endLine": 124,
+      "summary": "Restricting P⁻¹·ᵥ· and P·ᵥ· to the kernels and assembling with LinearEquiv.ofLinear yields kerEquiv : ker B ≃ₗ ker A; it acts as x ↦ P⁻¹ ·ᵥ x.",
+      "mathContext": "$\\operatorname{kerEquiv} : \\ker B \\xrightarrow{\\ \\sim\\ } \\ker A,\\quad x \\mapsto P^{-1} x.$"
+    },
+    {
+      "id": "functoriality",
+      "title": "Functoriality",
+      "startLine": 126,
+      "endLine": 143,
+      "summary": "Identity conjugation gives the identity isomorphism (kerEquiv_refl); stacked conjugations C = Q·B·Q⁻¹ over B = P·A·P⁻¹ compose the isomorphisms (kerEquiv_trans), using (Q·P)⁻¹ = P⁻¹·Q⁻¹.",
+      "mathContext": "$\\operatorname{kerEquiv}_{1} = \\mathrm{id},\\qquad \\operatorname{kerEquiv}_{QP} = \\operatorname{kerEquiv}_{P} \\circ \\operatorname{kerEquiv}_{Q}.$"
+    },
+    {
+      "id": "recover",
+      "title": "Recovering the Numeric Invariant",
+      "startLine": 145,
+      "endLine": 162,
+      "summary": "Taking finrank of kerEquiv recovers the parent's nullity equality (nullity_eq_of_conj); Similar.nonempty_kerEquiv gives the basis-free existence form.",
+      "mathContext": "$\\dim \\ker B = \\dim \\ker A.$"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hoffman, K.; Kunze, R.",
+      "title": "Linear Algebra",
+      "year": "1971",
+      "note": "Similarity, change of basis, and the kernel/range of a linear operator"
+    },
+    {
+      "authors": "Mac Lane, S.",
+      "title": "Categories for the Working Mathematician",
+      "year": "1971",
+      "note": "Functoriality: identity and composition laws as the defining structure of a functor"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "matrix-similarity-invariants-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: proves nullity (dimension of ker A.mulVecLin) is a similarity invariant — an equality of numbers. This entry upgrades that equality to an explicit functorial linear isomorphism of the kernels and recovers the dimension equality as a corollary."
+    }
+  ],
+  "conclusion": {
+    "summary": "The kernel of A.mulVecLin transports under conjugation B = P·A·P⁻¹ by an explicit linear isomorphism kerEquiv : ker B ≃ₗ[K] ker A — the change of basis P⁻¹ itself — which acts as x ↦ P⁻¹ ·ᵥ x, sends identity conjugations to identity isomorphisms and composed conjugations to composed isomorphisms, and refines the parent's equality of kernel dimensions (recovered by finrank). Verified with 0 axioms on top of Mathlib's mulVec arithmetic and LinearEquiv.ofLinear.",
+    "implications": "Upgrades the structural similarity invariant from a dimension count to a functor on the groupoid of matrices under conjugation, the categorified form of nullity invariance. The same pattern — restrict the conjugator, assemble with ofLinear, verify identity/composition — applies to eigenspaces, generalized eigenspaces, and invariant-subspace lattices, the natural next layer toward canonical-form theory.",
+    "openQuestions": [
+      "Does the same change of basis transport the full eigenspace and generalized-eigenspace decompositions functorially, assembling into an isomorphism of the invariant-subspace lattices of similar matrices?",
+      "Can kerEquiv be packaged as an honest functor out of a groupoid of matrices-and-conjugations into K-vector spaces, with the refl/trans laws becoming the functor axioms definitionally?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Module"
+    ],
+    "namespace": "MatrixSimilarityInvariantsOQ01OQ01OQ02",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/MatrixSimilarityInvariantsOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent entry `matrix-similarity-invariants-oq-01-oq-01`:

> *Does the kernel of `A.mulVecLin` transport functorially under conjugation, giving an explicit linear isomorphism of kernels rather than only equality of dimensions?*

The parent proves nullity is a similarity invariant — `dim(ker B) = dim(ker A)` when `B = P·A·P⁻¹` — an equality of *numbers* producing no map between the kernels. This entry upgrades it to an **explicit linear isomorphism**

```
kerEquiv : ker B.mulVecLin ≃ₗ[K] ker A.mulVecLin
```

realised by the change of basis itself (`x ↦ P⁻¹ ·ᵥ x`, inverse `y ↦ P ·ᵥ y`), and proves the two **functoriality laws** that justify the word "functorial".

## Results

- `conj_intertwine_left` / `conj_intertwine_right` — the intertwining identities `A·P⁻¹ = P⁻¹·B` and `B·P = P·A`
- `mapsTo_ker_left` / `mapsTo_ker_right` — `P⁻¹` carries `ker B → ker A`, `P` carries `ker A → ker B`
- `kerEquiv` — the explicit isomorphism (`LinearMap.restrict` + `LinearEquiv.ofLinear`)
- `kerEquiv_apply` / `kerEquiv_symm_apply` — it acts as `P⁻¹ ·ᵥ ·` (by `rfl`), the genuine change of basis
- `kerEquiv_refl` — identity conjugation → identity isomorphism (functor on identities)
- `kerEquiv_trans` — stacked conjugations compose the isomorphisms (functor on composition), via `(Q·P)⁻¹ = P⁻¹·Q⁻¹`
- `nullity_eq_of_conj` — recovers the parent's dimension equality via `LinearEquiv.finrank_eq`
- `Similar.nonempty_kerEquiv` — basis-free existence form

## Verification

- **10 theorems, 2 definitions, 163 lines**
- **Verified, 0 axioms** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`
- 0 sorries
- Absent from Mathlib (Mathlib has the ingredients but not this construction or its functoriality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)