### PR TITLE
research(stirling-first-kind-oq-02-oq-02): alternating row sum ∑ₖ(−1)ᵏc(n,k)=0 for n≥2 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/StirlingFirstKindOQ02OQ02.lean
+++ b/proofs/Proofs/StirlingFirstKindOQ02OQ02.lean
@@ -1,0 +1,145 @@
+/-
+Stirling Numbers of the First Kind, III: the ALTERNATING row sum
+  ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1),
+which vanishes for every n ≥ 2.
+
+Source: Follow-up open question to stirling-first-kind-oq-02 (the rising-factorial
+generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n).
+Status: VERIFIED (0 axioms, 0 sorries)
+
+`Nat.stirlingFirst n k` is the unsigned Stirling number of the first kind: the
+number of permutations of an n-element set with exactly k disjoint cycles. The
+parent gallery entry `stirling-first-kind-oq-02` proved the generating identity
+
+      X(X+1)(X+2)⋯(X+n−1)  =  ∑ₖ c(n,k)·Xᵏ,        i.e.
+      (ascPochhammer ℤ n).coeff k  =  c(n,k),
+
+and recovered the ORDINARY row sum ∑ₖ c(n,k) = n! by evaluating the polynomial at
+X = 1 (every Xᵏ ↦ 1, collapsing the coefficient list to its sum).
+
+This entry asks the complementary question: what happens at the OTHER unit, X = −1?
+Now Xᵏ ↦ (−1)ᵏ, so the same collapse turns the polynomial value into the
+*alternating* row sum:
+
+      ∑ₖ (−1)ᵏ c(n,k)  =  (ascPochhammer ℤ n).eval (−1).
+
+The rising factorial `ascPochhammer ℤ n = X(X+1)⋯(X+n−1)` contains the factor
+`(X + 1)` as soon as n ≥ 2, and that factor vanishes at X = −1. Hence the product
+is zero for every n ≥ 2:
+
+      ∑ₖ (−1)ᵏ c(n,k)  =  0      (n ≥ 2),
+
+while the two small rows are exceptional: n = 0 gives 1 (empty product), n = 1 gives
+−1 (the single factor X at −1). Equivalently, since the SIGNED Stirling number is
+s(n,k) = (−1)^{n−k} c(n,k), the identity says the signed row sum ∑ₖ s(n,k) is 0 for
+n ≥ 2 — the well-known statement that the falling factorial x(x−1)⋯(x−n+1) vanishes
+at x = 1 for n ≥ 2.
+
+We prove:
+1. `stirlingFirst_eq_ascPochhammer_coeff` — c(n,k) = [Xᵏ] ascPochhammer ℤ n
+                                            (the parent's generating identity).
+2. `alternating_row_sum_eq_eval`   — ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1)
+                                     for all n (the generating-function reduction).
+3. `ascPochhammer_eval_neg_one`    — (ascPochhammer ℤ (m+2)).eval (−1) = 0.
+4. `alternating_row_sum_eq_zero`   — ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2 (the headline).
+5. `alternating_row_sum_zero`,
+   `alternating_row_sum_one`       — the two exceptional small rows: 1 and −1.
+6. `alternating_row_four`          — numeric sanity check: 0 − 6 + 11 − 6 + 1 = 0.
+-/
+
+import Mathlib
+
+open Nat Polynomial
+
+namespace StirlingFirstKindOQ02OQ02
+
+/-- The unsigned Stirling number `c(n,k)` is the `Xᵏ`-coefficient of the rising
+factorial `ascPochhammer ℤ n` (the generating identity of `stirling-first-kind-oq-02`).
+Reproved here so this file is self-contained.
+
+Proof by induction on `n`, using `ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + n)`
+(`ascPochhammer_succ_right`): `coeff_mul_X` (index shift) and `coeff_mul_C` reproduce
+the Pascal recurrence `c(n+1,k+1) = n·c(n,k+1) + c(n,k)`. -/
+theorem stirlingFirst_eq_ascPochhammer_coeff (n k : ℕ) :
+    (ascPochhammer ℤ n).coeff k = (Nat.stirlingFirst n k : ℤ) := by
+  induction n generalizing k with
+  | zero =>
+    rw [ascPochhammer_zero, Polynomial.coeff_one]
+    cases k with
+    | zero => simp
+    | succ k => simp [Nat.stirlingFirst_zero_succ]
+  | succ n ih =>
+    rw [ascPochhammer_succ_right, ← Polynomial.C_eq_natCast, mul_add,
+      Polynomial.coeff_add, Polynomial.coeff_mul_C]
+    cases k with
+    | zero =>
+      rw [Polynomial.coeff_mul_X_zero, zero_add, ih, Nat.stirlingFirst_succ_zero]
+      have hz : Nat.stirlingFirst n 0 * n = 0 := by
+        cases n with
+        | zero => simp
+        | succ m => simp [Nat.stirlingFirst_succ_zero]
+      push_cast
+      exact_mod_cast hz
+    | succ j =>
+      rw [Polynomial.coeff_mul_X, ih, ih, Nat.stirlingFirst_succ_succ]
+      push_cast
+      ring
+
+/-- **Alternating row sum as a polynomial value.** `∑_{k=0}^{n} (−1)ᵏ c(n,k)` equals
+the rising factorial evaluated at `X = −1`.
+
+`(ascPochhammer ℤ n).eval (−1)` expands (`eval_eq_sum_range`,
+`ascPochhammer_natDegree`) as `∑_{k<n+1} coeff k · (−1)ᵏ`; replacing each coefficient
+by `c(n,k)` via the generating identity gives the alternating sum. This is the exact
+analogue of the parent's `X = 1` route for the ordinary row sum. -/
+theorem alternating_row_sum_eq_eval (n : ℕ) :
+    ∑ k ∈ Finset.range (n + 1), (-1 : ℤ) ^ k * (Nat.stirlingFirst n k : ℤ)
+      = (ascPochhammer ℤ n).eval (-1) := by
+  rw [Polynomial.eval_eq_sum_range, ascPochhammer_natDegree ℤ n]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [stirlingFirst_eq_ascPochhammer_coeff n k]
+  ring
+
+/-- **The rising factorial vanishes at `−1` from `n = 2` on.** Induction on `m`.
+
+Base `m = 0`: `ascPochhammer ℤ 2 = X·(X+1)` (two applications of `ascPochhammer_succ_right`
+off `ascPochhammer ℤ 0 = 1`), whose value at `−1` is `(−1)·0 = 0`.
+
+Step: `ascPochhammer ℤ (m+3) = ascPochhammer ℤ (m+2) · (X + (m+2))`
+(`ascPochhammer_succ_right`), so its value at `−1` is `0 · (…) = 0` by the induction
+hypothesis — the already-present `(X+1)` factor keeps the product zero. -/
+theorem ascPochhammer_eval_neg_one (m : ℕ) :
+    (ascPochhammer ℤ (m + 2)).eval (-1 : ℤ) = 0 := by
+  induction m with
+  | zero =>
+    rw [ascPochhammer_succ_right, ascPochhammer_succ_right, ascPochhammer_zero]
+    simp [Polynomial.eval_mul]
+  | succ k ih =>
+    rw [ascPochhammer_succ_right, Polynomial.eval_mul, ih, zero_mul]
+
+/-- **Headline: the alternating row sum vanishes for `n ≥ 2`.**
+`∑_{k=0}^{n} (−1)ᵏ c(n,k) = 0`. Combine the generating-function reduction (theorem 2)
+with the vanishing of `ascPochhammer ℤ n` at `−1` (theorem 3). -/
+theorem alternating_row_sum_eq_zero (n : ℕ) (hn : 2 ≤ n) :
+    ∑ k ∈ Finset.range (n + 1), (-1 : ℤ) ^ k * (Nat.stirlingFirst n k : ℤ) = 0 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  rw [alternating_row_sum_eq_eval, Nat.add_comm 2 m]
+  exact ascPochhammer_eval_neg_one m
+
+/-- **Exceptional small row `n = 0`.** The empty product gives alternating sum `1`. -/
+theorem alternating_row_sum_zero :
+    ∑ k ∈ Finset.range 1, (-1 : ℤ) ^ k * (Nat.stirlingFirst 0 k : ℤ) = 1 := by
+  simp [Nat.stirlingFirst]
+
+/-- **Exceptional small row `n = 1`.** The single factor `X` at `−1` gives `−1`. -/
+theorem alternating_row_sum_one :
+    ∑ k ∈ Finset.range 2, (-1 : ℤ) ^ k * (Nat.stirlingFirst 1 k : ℤ) = -1 := by
+  simp [Finset.sum_range_succ, Nat.stirlingFirst]
+
+/-- **Numeric sanity check.** Row 4 is `c(4,0..4) = 0, 6, 11, 6, 1`; the alternating
+sum is `0 − 6 + 11 − 6 + 1 = 0`, matching `alternating_row_sum_eq_zero`. -/
+theorem alternating_row_four :
+    ∑ k ∈ Finset.range 5, (-1 : ℤ) ^ k * (Nat.stirlingFirst 4 k : ℤ) = 0 := by
+  simp [Finset.sum_range_succ, Nat.stirlingFirst]
+
+end StirlingFirstKindOQ02OQ02

--- a/src/data/proofs/stirling-first-kind-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/stirling-first-kind-oq-02-oq-02/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "stirling-first-kind-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 61
+    },
+    "type": "concept",
+    "title": "The Other Unit: Evaluating the Generating Function at X = −1",
+    "content": "The parent entry proved the rising-factorial generating identity X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ and recovered the ordinary row sum ∑ₖ c(n,k) = n! by evaluating at X=1. A rising factorial has exactly two integer units available as evaluation points, 1 and −1. This file uses the other one: at X=−1 every Xᵏ becomes (−1)ᵏ, so the polynomial value is the alternating row sum ∑ₖ (−1)ᵏ c(n,k). Since the rising factorial contains the factor (X+1) as soon as n ≥ 2, and that factor is zero at X=−1, the alternating row sum vanishes for all n ≥ 2; the rows n=0 and n=1 are exceptional (values 1 and −1).",
+    "mathContext": "$\\left.\\sum_k c(n,k)X^k\\right|_{X=-1} = \\sum_k (-1)^k c(n,k) = (\\text{ascPochhammer}\\,\\mathbb{Z}\\,n)(-1)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Stirling numbers of the first kind",
+      "rising factorial (ascPochhammer)",
+      "generating functions",
+      "alternating sums"
+    ],
+    "prerequisites": [
+      "polynomials and their coefficients",
+      "the parent generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n"
+    ]
+  },
+  {
+    "id": "ann-generating-identity",
+    "proofId": "stirling-first-kind-oq-02-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "c(n,k) is the Xᵏ-Coefficient of the Rising Factorial (self-contained)",
+    "content": "stirlingFirst_eq_ascPochhammer_coeff reproves the parent's generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n so this file stands alone. Induction on n (generalizing k): the base uses ascPochhammer ℤ 0 = 1; the step rewrites ascPochhammer ℤ (n+1) = ascPochhammer ℤ n · (X + C n) and extracts the Xᵏ-coefficient with Polynomial.coeff_mul_X (index shift, giving c(n,k−1)) and Polynomial.coeff_mul_C (constant n, giving n·c(n,k)), reproducing the Pascal recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k).",
+    "mathContext": "$c(n,k) = (\\text{ascPochhammer}\\,\\mathbb{Z}\\,n).\\mathrm{coeff}\\,k$, by coefficient extraction from $(X+n)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ascPochhammer_succ_right",
+      "Polynomial.coeff_mul_X",
+      "Polynomial.coeff_mul_C",
+      "Nat.stirlingFirst_succ_succ"
+    ],
+    "prerequisites": [
+      "polynomial coefficient lemmas",
+      "the rising-factorial recurrence in Mathlib"
+    ]
+  },
+  {
+    "id": "ann-alternating-as-eval",
+    "proofId": "stirling-first-kind-oq-02-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 109
+    },
+    "type": "key-step",
+    "title": "Alternating Row Sum = Value at X = −1",
+    "content": "alternating_row_sum_eq_eval shows ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1). Polynomial.eval_eq_sum_range expands the evaluation as ∑_{k < natDegree+1} coeff k · (−1)ᵏ; ascPochhammer_natDegree fixes natDegree = n, so the range is range (n+1). Substituting coeff k = (c(n,k):ℤ) from the generating identity gives the alternating row sum. This is the exact X=−1 analogue of the parent's X=1 reduction of the evaluation to a coefficient sum.",
+    "mathContext": "$\\sum_k (-1)^k c(n,k) = \\sum_{k<n+1} \\mathrm{coeff}\\,k\\cdot(-1)^k = (\\text{ascPochhammer}\\,\\mathbb{Z}\\,n)(-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Polynomial.eval_eq_sum_range",
+      "ascPochhammer_natDegree",
+      "alternating sums"
+    ],
+    "prerequisites": [
+      "polynomial evaluation as a sum over coefficients"
+    ]
+  },
+  {
+    "id": "ann-vanishing",
+    "proofId": "stirling-first-kind-oq-02-oq-02",
+    "range": {
+      "startLine": 111,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "The Rising Factorial Vanishes at −1 for n ≥ 2",
+    "content": "ascPochhammer_eval_neg_one proves (ascPochhammer ℤ (m+2)).eval (−1) = 0 by induction on m. The base m=0 is ascPochhammer ℤ 2 = X·(X+1), whose value at −1 is (−1)·0 = 0 — the decisive (X+1) factor. The step uses ascPochhammer ℤ (m+3) = ascPochhammer ℤ (m+2)·(X+(m+2)): the new factor only multiplies the already-zero value, so the product stays 0. The vanishing is structural — one factor (X+1) is zero at −1 — not a term-by-term cancellation.",
+    "mathContext": "$(\\text{ascPochhammer}\\,\\mathbb{Z}\\,(m+2))(-1)=0$ because the factor $(X+1)$ vanishes at $X=-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ascPochhammer_succ_right",
+      "induction on the recurrence",
+      "vanishing factor"
+    ],
+    "prerequisites": [
+      "the rising-factorial recurrence",
+      "polynomial evaluation of products"
+    ]
+  },
+  {
+    "id": "ann-headline-and-small-rows",
+    "proofId": "stirling-first-kind-oq-02-oq-02",
+    "range": {
+      "startLine": 120,
+      "endLine": 145
+    },
+    "type": "theorem",
+    "title": "Headline Vanishing and the Exceptional Small Rows",
+    "content": "alternating_row_sum_eq_zero is the headline: ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2, obtained by writing n = m+2 and combining the reduction (value at −1) with the vanishing lemma. The two exceptional rows are computed directly: alternating_row_sum_zero gives n=0 ↦ 1 (the empty product) and alternating_row_sum_one gives n=1 ↦ −1 (the single factor X at −1). alternating_row_four is a numeric sanity check, 0 − 6 + 11 − 6 + 1 = 0, closed by simp on the recursive definition (kernel reduction, no native_decide). The complete sequence of alternating row sums is 1, −1, 0, 0, 0, ….",
+    "mathContext": "$\\sum_k (-1)^k c(n,k) = 0$ for $n\\ge 2$; values $1,-1$ for $n=0,1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "alternating row sum",
+      "signed Stirling numbers s(n,k) = (−1)^{n−k} c(n,k)",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "the reduction to the value at −1",
+      "evaluating the Stirling recurrence on small rows"
+    ]
+  }
+]

--- a/src/data/proofs/stirling-first-kind-oq-02-oq-02/meta.json
+++ b/src/data/proofs/stirling-first-kind-oq-02-oq-02/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "stirling-first-kind-oq-02-oq-02",
+  "title": "Stirling Numbers of the First Kind, III: the alternating row sum ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2",
+  "slug": "stirling-first-kind-oq-02-oq-02",
+  "description": "The complement of the parent's row sum: where evaluating the rising-factorial generating function X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ at X=1 gives the ordinary row sum n!, evaluating it at the OTHER unit X=−1 gives the alternating row sum ∑ₖ (−1)ᵏ c(n,k). Because the factor (X+1) of the rising factorial vanishes at X=−1 as soon as n ≥ 2, the alternating row sum is 0 for every n ≥ 2 — with the two exceptional small rows n=0 (value 1) and n=1 (value −1). Answers the parent oq-02's open question verbatim.",
+  "meta": {
+    "author": "James Stirling (1730)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFirstKindOQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "permutations",
+      "cycles",
+      "enumerative",
+      "generating-functions",
+      "rising-factorial",
+      "ascPochhammer",
+      "alternating-sum",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ascPochhammer_succ_right",
+        "description": "ascPochhammer S (n+1) = ascPochhammer S n · (X + n); drives both the coefficient induction and the X=−1 vanishing (the new (X+n) factor leaves the existing zero product unchanged)",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "ascPochhammer_natDegree",
+        "description": "(ascPochhammer S n).natDegree = n over a nontrivial domain, fixing the summation range as range (n+1) when expanding the evaluation",
+        "module": "Mathlib.RingTheory.Polynomial.Pochhammer"
+      },
+      {
+        "theorem": "Polynomial.eval_eq_sum_range",
+        "description": "p.eval x = ∑_{i<natDegree+1} coeff i · xⁱ; at x=−1 this is exactly the alternating sum of coefficients",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Degree"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul_X",
+        "description": "coeff (p·X) (k+1) = coeff p k, the index shift reproducing the c(n,k) term of the Pascal recurrence",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Nat.stirlingFirst_succ_succ",
+        "description": "Pascal recurrence c(n+1,k+1) = n·c(n,k+1) + c(n,k), recovered by coefficient extraction in the self-contained generating identity",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      }
+    ],
+    "originalContributions": [
+      "alternating_row_sum_eq_eval: the reduction ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1), the X=−1 analogue of the parent's X=1 row-sum route",
+      "ascPochhammer_eval_neg_one: (ascPochhammer ℤ (m+2)).eval (−1) = 0 — the rising factorial vanishes at −1 from n=2 on, by induction off the base X(X+1)|_{−1}=0 with the recurrence preserving the zero product",
+      "alternating_row_sum_eq_zero: the headline ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2, answering the parent oq-02's stated open question",
+      "alternating_row_sum_zero / alternating_row_sum_one: the two exceptional small rows n=0 (value 1) and n=1 (value −1)",
+      "alternating_row_four: numeric sanity check that 0 − 6 + 11 − 6 + 1 = 0 for row 4"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. No `decide`/`native_decide` (so no Lean.ofReduceBool); numeric checks close by `simp` unfolding the recursive definition.",
+    "lineCount": 145,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The unsigned Stirling numbers of the first kind c(n,k) count permutations of n elements into exactly k disjoint cycles, and classically arise as the coefficients of the rising factorial x(x+1)⋯(x+n−1) = ∑ₖ c(n,k) xᵏ (Stirling, 1730). The parent gallery entry stirling-first-kind-oq-02 formalized that generating identity over ℤ as (ascPochhammer ℤ n).coeff k = c(n,k), and recovered the ordinary row sum ∑ₖ c(n,k) = n! by evaluating the polynomial at x=1. A rising factorial has exactly the two integer units 1 and −1 available as evaluation points that send xᵏ to the simplest possible weights; the parent used x=1. This entry uses the other one, x=−1, which weights the row by the alternating signs (−1)ᵏ. The resulting alternating row sum is the value of the polynomial at −1, and because the second rising factor (x+1) is zero there, the whole product collapses for every n ≥ 2.",
+    "problemStatement": "Use the rising-factorial generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n to evaluate the alternating row sum ∑ₖ (−1)ᵏ c(n,k), proving it equals 0 for every n ≥ 2 (and identifying the exceptional small rows n=0 and n=1).",
+    "text": "Evaluating the rising-factorial generating function X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ at X=−1 sends Xᵏ to (−1)ᵏ, so the polynomial value equals the alternating row sum ∑ₖ (−1)ᵏ c(n,k). The factor (X+1) of the rising factorial vanishes at X=−1 whenever n ≥ 2, so this value is 0; the rows n=0 and n=1 are exceptional with values 1 and −1. Verified in Lean with no axioms.",
+    "proofStrategy": "1. stirlingFirst_eq_ascPochhammer_coeff (reproved self-contained from the parent): c(n,k) = [Xᵏ] ascPochhammer ℤ n, by induction on n extracting the Xᵏ-coefficient of ascPochhammer (n+1) = ascPochhammer n · (X + n).\n2. alternating_row_sum_eq_eval: expand (ascPochhammer ℤ n).eval (−1) via eval_eq_sum_range over range (natDegree+1); ascPochhammer_natDegree fixes the range to range (n+1), and each coefficient becomes c(n,k) by theorem 1, so the value equals ∑ₖ (−1)ᵏ c(n,k).\n3. ascPochhammer_eval_neg_one: (ascPochhammer ℤ (m+2)).eval (−1) = 0 by induction on m. Base m=0: ascPochhammer ℤ 2 = X·(X+1), value (−1)·0 = 0. Step: ascPochhammer ℤ (m+3) = ascPochhammer ℤ (m+2)·(X+(m+2)), value 0·(…) = 0 by the induction hypothesis.\n4. alternating_row_sum_eq_zero: for n ≥ 2 write n = m+2 and combine 2 and 3.\n5. alternating_row_sum_zero / alternating_row_sum_one: simp-evaluate the small rows directly to 1 and −1.\n6. alternating_row_four: simp checks 0 − 6 + 11 − 6 + 1 = 0.",
+    "keyInsights": [
+      "**Two units, two row sums**: a rising factorial can be evaluated at the integer units 1 and −1. The parent used X=1 (every Xᵏ ↦ 1) to get the ordinary row sum n!; this entry uses X=−1 (Xᵏ ↦ (−1)ᵏ) to get the alternating row sum. Same generating polynomial, complementary evaluations.",
+      "**The vanishing is structural, not arithmetic**: ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2 is not a cancellation identity to be checked term-by-term — it is the single fact that the rising factorial X(X+1)⋯(X+n−1) literally contains the factor (X+1), which is zero at X=−1. One factor kills the whole product.",
+      "**The recurrence propagates the zero for free**: once n ≥ 2 supplies the (X+1) factor, every later factor (X+n) only multiplies an already-zero value, so a one-line induction off the base case X(X+1)|_{X=−1}=0 covers all n ≥ 2.",
+      "**Signed-Stirling reading**: since the signed first-kind number is s(n,k) = (−1)^{n−k} c(n,k), the result is equivalent to the signed row sum ∑ₖ s(n,k) = 0 for n ≥ 2 — i.e. the falling factorial x(x−1)⋯(x−n+1) vanishes at x=1 for n ≥ 2."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the first kind and the cycle decomposition of permutations",
+      "The rising factorial / Pochhammer polynomial (ascPochhammer) and its recurrence",
+      "Polynomial coefficients, degree, and evaluation; the generating-function viewpoint",
+      "Induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "File-level docstring contrasting the parent's X=1 row sum with the X=−1 alternating row sum, explaining the (X+1)-factor vanishing for n ≥ 2 and the exceptional rows n=0,1, plus the signed-Stirling reading. Imports Mathlib; opens Nat and Polynomial.",
+      "mathContext": "X(X+1)⋯(X+n−1) = ∑ₖ c(n,k) Xᵏ; at X=−1 the value is ∑ₖ (−1)ᵏ c(n,k)."
+    },
+    {
+      "id": "generating-identity",
+      "title": "The Generating Identity (self-contained from the parent)",
+      "startLine": 63,
+      "endLine": 92,
+      "summary": "stirlingFirst_eq_ascPochhammer_coeff: c(n,k) = [Xᵏ] ascPochhammer ℤ n, by induction on n extracting the Xᵏ-coefficient of ascPochhammer (n+1) = ascPochhammer n · (X + n), reproducing the Pascal recurrence.",
+      "mathContext": "Reproduces the parent's bridge between ascPochhammer and the Stirling recurrence so this file stands alone."
+    },
+    {
+      "id": "alternating-as-eval",
+      "title": "Alternating Row Sum = Value at X = −1",
+      "startLine": 94,
+      "endLine": 109,
+      "summary": "alternating_row_sum_eq_eval: expand (ascPochhammer ℤ n).eval (−1) by eval_eq_sum_range, fix the range to range (n+1) via ascPochhammer_natDegree, and replace each coefficient by c(n,k) to get ∑ₖ (−1)ᵏ c(n,k).",
+      "mathContext": "The X=−1 analogue of the parent's X=1 reduction of eval to a coefficient sum."
+    },
+    {
+      "id": "vanishing",
+      "title": "The Rising Factorial Vanishes at −1 for n ≥ 2",
+      "startLine": 111,
+      "endLine": 118,
+      "summary": "ascPochhammer_eval_neg_one: (ascPochhammer ℤ (m+2)).eval (−1) = 0 by induction on m. Base ascPochhammer ℤ 2 = X·(X+1) gives (−1)·0; the recurrence multiplies the zero by (X+(m+2)), preserving it.",
+      "mathContext": "The (X+1) factor present from n=2 on is zero at X=−1, collapsing the whole product."
+    },
+    {
+      "id": "headline-and-small-rows",
+      "title": "Headline Vanishing and Exceptional Small Rows",
+      "startLine": 120,
+      "endLine": 145,
+      "summary": "alternating_row_sum_eq_zero: ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2, combining the two previous theorems (write n = m+2). alternating_row_sum_zero / alternating_row_sum_one evaluate the exceptional rows n=0 (value 1) and n=1 (value −1); alternating_row_four checks 0 − 6 + 11 − 6 + 1 = 0.",
+      "mathContext": "The complete picture: 1, −1, 0, 0, 0, … for n = 0, 1, 2, 3, 4, …"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "Introduces the first-kind numbers as coefficients of the rising factorial — the generating function evaluated here at X=−1"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6: the rising-factorial generating function xⁿ̄ = ∑ₖ [n;k] xᵏ; the alternating row sum is its value at x=−1, vanishing for n ≥ 2"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-first-kind-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: oq-02 proves the generating identity c(n,k) = [Xᵏ] ascPochhammer ℤ n and the ordinary row sum n! by evaluating at X=1. This entry answers oq-02's stated open question by evaluating the same polynomial at X=−1 to get the alternating row sum, which vanishes for n ≥ 2."
+    },
+    {
+      "targetId": "stirling-first-kind-oq-01",
+      "relationship": "related",
+      "description": "The grandparent row-sum entry ∑ₖ c(n,k) = n!; the alternating row sum here is its signed counterpart."
+    }
+  ],
+  "conclusion": {
+    "summary": "Evaluating the rising-factorial generating function at X=−1 gives the alternating row sum of the unsigned first-kind Stirling numbers: ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1). Because the rising factorial contains the factor (X+1), which is zero at X=−1, this value is 0 for every n ≥ 2 (alternating_row_sum_eq_zero); the rows n=0 and n=1 are exceptional with values 1 and −1. Verified with 0 axioms and 0 sorries, answering the parent oq-02's open question.",
+    "implications": "Completes the evaluation picture for the first-kind generating polynomial at both integer units: X=1 yields the ordinary row sum n!, X=−1 yields the alternating row sum 0 (n ≥ 2). Equivalently it records the signed row sum ∑ₖ s(n,k) = 0 for n ≥ 2 as a machine-checked, citable fact.",
+    "openQuestions": [
+      "What is the value of the row sum ∑ₖ c(n,k) wᵏ at a general root of unity w, and which residues of n make it vanish? (X=−1 is the order-2 case treated here.)",
+      "Can the same coefficient-extraction style evaluate the second derivative / weighted sums ∑ₖ k·c(n,k) (the total number of cycles over all permutations) directly from the ascPochhammer polynomial?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Polynomial"
+    ],
+    "namespace": "StirlingFirstKindOQ02OQ02",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/StirlingFirstKindOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **open question** stated by the parent entry `stirling-first-kind-oq-02`:

> *Does the generating identity give a clean Lean proof of the alternating row sum ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2 (the value of the polynomial at X = −1)?*

Yes. The parent proved the rising-factorial generating identity `c(n,k) = [Xᵏ] ascPochhammer ℤ n` and recovered the **ordinary** row sum `∑ₖ c(n,k) = n!` by evaluating the polynomial at the unit `X = 1`. This entry evaluates the *same* polynomial at the **other** integer unit `X = −1`, where `Xᵏ ↦ (−1)ᵏ`, so the value is the **alternating** row sum `∑ₖ (−1)ᵏ c(n,k)`.

The rising factorial `X(X+1)⋯(X+n−1)` contains the factor `(X+1)` as soon as `n ≥ 2`, and that factor is **zero at X = −1** — so the alternating row sum vanishes for every `n ≥ 2`. The two small rows are exceptional: `n = 0 ↦ 1`, `n = 1 ↦ −1`. The full sequence is `1, −1, 0, 0, 0, …`.

## Theorems (7 total, 0 defs, 145 lines)

- `alternating_row_sum_eq_eval` — ∑ₖ (−1)ᵏ c(n,k) = (ascPochhammer ℤ n).eval (−1)
- `ascPochhammer_eval_neg_one` — (ascPochhammer ℤ (m+2)).eval (−1) = 0 (induction off the base X(X+1)|₋₁=0)
- `alternating_row_sum_eq_zero` — **headline**: ∑ₖ (−1)ᵏ c(n,k) = 0 for n ≥ 2
- `alternating_row_sum_zero` / `alternating_row_sum_one` — exceptional rows 1 and −1
- `alternating_row_four` — numeric check 0 − 6 + 11 − 6 + 1 = 0

Equivalently (since s(n,k) = (−1)^{n−k} c(n,k)) this is the signed row sum ∑ₖ s(n,k) = 0 for n ≥ 2.

## Verification

- **0 sorries, 0 axioms** — `#print axioms alternating_row_sum_eq_zero` lists only `propext, Classical.choice, Quot.sound`. No `decide`/`native_decide`.
- Compiles against Mathlib v4.26.0 (`lake env lean`).
- Gallery: `pnpm annotations:build` resolves all annotation ranges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)