### PR TITLE
Enrich 'Eisenstein's Criterion' (eisenstein-criterion-oq-01): deepen annotations + sections

### DIFF
--- a/src/data/proofs/eisenstein-criterion-oq-01/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/annotations.json
@@ -3,44 +3,60 @@
     "id": "eisenstein-criterion-oq-01-module-header",
     "proofId": "eisenstein-criterion-oq-01",
     "type": "concept",
-    "range": {
-      "startLine": 1,
-      "endLine": 34
-    },
+    "range": { "startLine": 1, "endLine": 29 },
     "title": "Module Header: Eisenstein's Criterion",
-    "content": "**Eisenstein's criterion** is the most-used elementary irreducibility test. Over an integral domain with a prime ideal $P$, a primitive polynomial $f$ of positive degree is irreducible whenever\n\n- its **leading** coefficient lies *outside* $P$,\n- all **lower** coefficients lie *inside* $P$,\n- its **constant** coefficient lies *outside* $P^2$.\n\nThe archetypal consequence over $\\mathbb{Z}$: $X^n - p$ is irreducible for every prime $p$ and $n \\ge 1$. Taking $P = (p)$, the coefficients $1, 0, \\dots, 0, -p$ satisfy the three conditions, so $\\sqrt[n]{p}$ has minimal polynomial of degree exactly $n$ — algebraic numbers of every degree, on demand."
+    "content": "**Eisenstein's criterion** is the most-used elementary irreducibility test. Over an integral domain with a prime ideal $P$, a primitive polynomial $f$ of positive degree is irreducible whenever\n\n- its **leading** coefficient lies *outside* $P$,\n- all **lower** coefficients lie *inside* $P$,\n- its **constant** coefficient lies *outside* $P^2$.\n\nThe archetypal consequence over $\\mathbb{Z}$: $X^n - p$ is irreducible for every prime $p$ and $n \\ge 1$. Taking $P = (p)$, the coefficients $1, 0, \\dots, 0, -p$ satisfy the three conditions, so $\\sqrt[n]{p}$ has minimal polynomial of degree exactly $n$ — algebraic numbers of every degree, on demand.",
+    "mathContext": "$f$ primitive, $\\deg f > 0$, $f_{\\deg}\\notin P$, $f_k\\in P\\ (k<\\deg)$, $f_0\\notin P^2\\Rightarrow f$ irreducible. Over $\\mathbb{Z}$ with $P=(p)$: $X^n-p$ irreducible.",
+    "significance": "context",
+    "relatedConcepts": ["irreducibility criterion", "prime ideal", "minimal polynomial", "algebraic numbers of every degree"],
+    "prerequisites": ["integral domains", "prime ideals", "primitive polynomials"]
   },
   {
     "id": "eisenstein-criterion-oq-01-general",
     "proofId": "eisenstein-criterion-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 38,
-      "endLine": 53
-    },
+    "range": { "startLine": 38, "endLine": 49 },
     "title": "The General Criterion",
-    "content": "`irreducible_of_eisenstein`: the criterion in clean ideal-theoretic form, over a commutative integral domain $R$ with a prime ideal $P$. The hypotheses are named — `hlead` (leading coefficient $\\notin P$), `hlow` (every coefficient below the degree $\\in P$), `hdeg` (positive degree), `hconst` (constant coefficient $\\notin P^2$), `hprim` (primitive) — and the conclusion is `Irreducible f`. It is a direct restatement of Mathlib's `Polynomial.irreducible_of_eisenstein_criterion`, packaged for the application that follows."
+    "content": "`irreducible_of_eisenstein`: the criterion in clean ideal-theoretic form, over a commutative integral domain $R$ with a prime ideal $P$. The hypotheses are named — `hlead` (leading coefficient $\\notin P$), `hlow` (every coefficient below the degree $\\in P$), `hdeg` (positive degree), `hconst` (constant coefficient $\\notin P^2$), `hprim` (primitive) — and the conclusion is `Irreducible f`. It is a direct restatement of Mathlib's `Polynomial.irreducible_of_eisenstein_criterion`, packaged for the application that follows.",
+    "mathContext": "Hypotheses use $\\deg$ in $\\mathrm{WithBot}\\,\\mathbb{N}$; $\\mathrm{hlow}: \\forall k,\\ (k:\\mathrm{WithBot}\\,\\mathbb{N}) < \\deg f \\Rightarrow f_k\\in P$.",
+    "significance": "key",
+    "relatedConcepts": ["irreducible_of_eisenstein_criterion", "ideal-theoretic formulation", "WithBot degree", "Irreducible"],
+    "prerequisites": ["polynomial degree in WithBot ℕ", "ideal membership"]
   },
   {
     "id": "eisenstein-criterion-oq-01-xn-minus-p",
     "proofId": "eisenstein-criterion-oq-01",
-    "type": "theorem",
-    "range": {
-      "startLine": 55,
-      "endLine": 92
-    },
-    "title": "Xⁿ − p Is Irreducible over ℤ",
-    "content": "`irreducible_X_pow_sub_C_prime`: the flagship family. With $P = (p) = $ `Ideal.span {p}` (prime by `Ideal.span_singleton_prime`), the polynomial $X^n - p$ is monic of degree $n$. Its coefficients are computed once,\n$$\\mathrm{coeff}\\,k = [k = n] \\cdot 1 - [k = 0]\\cdot p,$$\nso the five Eisenstein conditions become elementary divisibility facts: the leading $1 \\notin (p)$ (else $p \\mid 1$); each lower coefficient is $0$ or $-p$, both in $(p)$; the degree is $n > 0$; and the constant $-p \\notin (p^2)$ — because $p^2 \\mid p$ would force $p \\mid 1$ after cancelling one factor of $p$ (`mul_dvd_mul_iff_left`). Primitivity comes from `Monic.isPrimitive`."
+    "type": "technique",
+    "range": { "startLine": 55, "endLine": 78 },
+    "title": "Xⁿ − p: setup and coefficient bookkeeping",
+    "content": "`irreducible_X_pow_sub_C_prime`: the flagship family. Take $P = (p) = $ `Ideal.span {p}`, prime by `Ideal.span_singleton_prime`. $X^n - p$ is monic of degree $n$ (`monic_X_pow_sub_C`, `degree_X_pow_sub_C`). The coefficients are computed once via `coeff_sub`/`coeff_X_pow`/`coeff_C`: $\\mathrm{coeff}\\,k = [k=n] - [k=0]\\cdot p$. The five Eisenstein obligations then reduce to elementary facts: leading $1 \\notin (p)$ (else $p\\mid 1$); each lower coefficient ($0$ or $-p$) lies in $(p)$; degree $n > 0$; primitivity from `Monic.isPrimitive`.",
+    "mathContext": "$\\mathrm{coeff}_k(X^n - p) = [k=n]\\cdot 1 - [k=0]\\cdot p$; leading $1\\notin(p)$, lower coeffs $\\in(p)$, $\\deg = n > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Ideal.span_singleton_prime", "coeff_X_pow", "Monic.isPrimitive", "monic_X_pow_sub_C"],
+    "prerequisites": ["polynomial coefficients", "span of a singleton ideal"]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-const-p2",
+    "proofId": "eisenstein-criterion-oq-01",
+    "type": "insight",
+    "range": { "startLine": 79, "endLine": 86 },
+    "title": "The crux: constant coefficient −p ∉ (p²)",
+    "content": "The one nontrivial Eisenstein condition. The constant coefficient is $-p$, and $-p \\notin (p^2)$ is exactly the requirement that $p^2 \\nmid p$. Suppose $p^2 \\mid p$; rewriting $p = p\\cdot 1$ gives $p\\cdot p \\mid p\\cdot 1$, and cancelling one factor of $p$ (`mul_dvd_mul_iff_left`, valid since $p \\neq 0$ in the domain) yields $p \\mid 1$, making $p$ a unit — contradicting primality. This is precisely the Eisenstein condition that fails for, e.g., $X^2 - p^2$, which is why the $P^2$ hypothesis cannot be dropped.",
+    "mathContext": "$p^2\\mid p \\Rightarrow p\\cdot p\\mid p\\cdot 1 \\Rightarrow p\\mid 1$ (cancel $p$), contradicting $p$ prime. Hence $-p\\notin(p^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["mul_dvd_mul_iff_left", "square of an ideal", "why P² is necessary", "unit obstruction"],
+    "prerequisites": ["divisibility cancellation in a domain", "Ideal.span_singleton_pow"]
   },
   {
     "id": "eisenstein-criterion-oq-01-instances",
     "proofId": "eisenstein-criterion-oq-01",
-    "type": "theorem",
-    "range": {
-      "startLine": 94,
-      "endLine": 102
-    },
+    "type": "technique",
+    "range": { "startLine": 90, "endLine": 100 },
     "title": "Concrete Instances",
-    "content": "Specializing the family gives `irreducible_X_sq_sub_two` ($X^2 - 2$, the minimal polynomial of $\\sqrt 2$), `irreducible_X_cube_sub_two` ($X^3 - 2$, for $\\sqrt[3]{2}$), and `irreducible_X_pow_five_sub_three` ($X^5 - 3$). Each is a one-line application of `irreducible_X_pow_sub_C_prime` to `Int.prime_two` or `Int.prime_three` with the relevant exponent — concrete witnesses that the criterion runs end-to-end."
+    "content": "Specializing the family gives `irreducible_X_sq_sub_two` ($X^2 - 2$, the minimal polynomial of $\\sqrt 2$), `irreducible_X_cube_sub_two` ($X^3 - 2$, for $\\sqrt[3]{2}$), and `irreducible_X_pow_five_sub_three` ($X^5 - 3$). Each is a one-line application of `irreducible_X_pow_sub_C_prime` to `Int.prime_two` or `Int.prime_three` with the relevant exponent — concrete witnesses that the criterion runs end-to-end and a direct certificate that $\\sqrt 2,\\ \\sqrt[3]{2},\\ \\sqrt[5]{3}$ are algebraic of degrees $2, 3, 5$.",
+    "mathContext": "$X^2-2,\\ X^3-2,\\ X^5-3$ irreducible $\\Rightarrow [\\mathbb{Q}(\\sqrt2):\\mathbb{Q}]=2,\\ [\\mathbb{Q}(\\sqrt[3]2):\\mathbb{Q}]=3,\\ [\\mathbb{Q}(\\sqrt[5]3):\\mathbb{Q}]=5$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.prime_two", "Int.prime_three", "minimal polynomial degree", "field extension degree"],
+    "prerequisites": ["primality of small integers", "specialization of a general theorem"]
   }
 ]

--- a/src/data/proofs/eisenstein-criterion-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01/meta.json
@@ -69,6 +69,40 @@
       "Basic divisibility in ℤ: p ∣ 1 ↔ IsUnit p, and cancelling a factor of p (mul_dvd_mul_iff_left)"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Docstring stating Eisenstein's criterion (leading coeff ∉ P, lower coeffs ∈ P, constant coeff ∉ P²) over an integral domain with a prime ideal, and the flagship consequence that Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1, giving ⁿ√p minimal polynomials of degree n. Fully verified (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "$f_{\\deg}\\notin P,\\ f_k\\in P\\ (k<\\deg),\\ f_0\\notin P^2\\Rightarrow f$ irreducible; over $\\mathbb{Z}$, $X^n-p$ irreducible."
+    },
+    {
+      "id": "sec-general",
+      "title": "Eisenstein's Criterion (General Form)",
+      "startLine": 36,
+      "endLine": 49,
+      "summary": "irreducible_of_eisenstein: the criterion in ideal-theoretic form over a commutative integral domain R with prime ideal P, with named hypotheses (hlead, hlow, hdeg, hconst, hprim). A packaged restatement of Mathlib's irreducible_of_eisenstein_criterion.",
+      "mathContext": "Conclusion $\\mathrm{Irreducible}\\,f$ from the five Eisenstein hypotheses; degree compared in $\\mathrm{WithBot}\\,\\mathbb{N}$."
+    },
+    {
+      "id": "sec-xn",
+      "title": "The Eisenstein Polynomials Xⁿ − p over ℤ",
+      "startLine": 51,
+      "endLine": 86,
+      "summary": "irreducible_X_pow_sub_C_prime: applies the criterion with P = (p). Computes coeff k = [k=n] − [k=0]·p once, then discharges the five conditions — leading 1 ∉ (p), lower coeffs ∈ (p), degree n > 0, primitivity from Monic, and the crux constant coeff −p ∉ (p²) via cancelling a factor of p (mul_dvd_mul_iff_left).",
+      "mathContext": "$\\mathrm{coeff}_k = [k=n] - [k=0]p$; the only subtle condition $-p\\notin(p^2)$ reduces to $p^2\\nmid p$."
+    },
+    {
+      "id": "sec-instances",
+      "title": "Concrete Instances",
+      "startLine": 88,
+      "endLine": 102,
+      "summary": "One-line specializations: irreducible_X_sq_sub_two (X²−2), irreducible_X_cube_sub_two (X³−2), irreducible_X_pow_five_sub_three (X⁵−3), via Int.prime_two / Int.prime_three — certifying √2, ∛2, ⁵√3 algebraic of degrees 2, 3, 5.",
+      "mathContext": "$X^2-2,\\ X^3-2,\\ X^5-3$ irreducible over $\\mathbb{Z}$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "cyclotomic-polynomials-oq-01",


### PR DESCRIPTION
Enrichment (deepening) pass for `eisenstein-criterion-oq-01` (quality 55, 0 prior passes).

## Gaps addressed
The entry had 4 annotations but **none carried `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**, and meta.json had **no `sections` array**.

1. **Deepened all annotations** — added the 4 structured fields to each (preserving existing prose).
2. **Added a 5th annotation** isolating the one nontrivial Eisenstein condition: constant coeff −p ∉ (p²), proved by cancelling a factor of p (`mul_dvd_mul_iff_left`) — explaining *why* the P² hypothesis is necessary.
3. **Added a `sections` array** to meta.json covering all four source sections (header, general criterion, Xⁿ−p family, concrete instances).

## Verification
- meta.json and annotations.json validate as JSON; `pnpm annotations:build` reports no errors for this entry (ranges snapped to Lean constructs).
- Axiom integrity preserved: meta declares `status: verified`, `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom decls, no `native_decide`). No claims changed.