### PR TITLE
Enrich 'Euler's Criterion' (euler-criterion-squares-oq-01): deepen annotations + sections

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01/annotations.json
@@ -3,44 +3,60 @@
     "id": "euler-criterion-squares-oq-01-module-header",
     "proofId": "euler-criterion-squares-oq-01",
     "type": "concept",
-    "range": {
-      "startLine": 1,
-      "endLine": 31
-    },
+    "range": { "startLine": 1, "endLine": 25 },
     "title": "Module Header: Euler's Criterion",
-    "content": "For an odd prime $p$ and $a \\not\\equiv 0$, **Euler's criterion** decides quadratic residuosity by a single exponentiation:\n$$a \\text{ is a square} \\iff a^{(p-1)/2} \\equiv 1, \\qquad a \\text{ is a non-residue} \\iff a^{(p-1)/2} \\equiv -1.$$\nThe value is always $\\pm 1$ because it squares to $a^{p-1} = 1$ (Fermat) and $\\mathbb{Z}/p$ is a field. The **Legendre symbol** $(a \\mid p) \\equiv a^{(p-1)/2}$ packages this, and is completely multiplicative. Mathlib's `ZMod.euler_criterion` uses the exponent $p/2 = (p-1)/2$ (for odd $p$); this file states the textbook $(p-1)/2$ forms and confirms them modulo 7."
+    "content": "For an odd prime $p$ and $a \\not\\equiv 0$, **Euler's criterion** decides quadratic residuosity by a single exponentiation:\n$$a \\text{ is a square} \\iff a^{(p-1)/2} \\equiv 1, \\qquad a \\text{ is a non-residue} \\iff a^{(p-1)/2} \\equiv -1.$$\nThe value is always $\\pm 1$ because it squares to $a^{p-1} = 1$ (Fermat) and $\\mathbb{Z}/p$ is a field. The **Legendre symbol** $(a \\mid p) \\equiv a^{(p-1)/2}$ packages this, and is completely multiplicative. Mathlib's `ZMod.euler_criterion` uses the exponent $p/2 = (p-1)/2$ (for odd $p$); this file states the textbook $(p-1)/2$ forms and confirms them modulo 7.",
+    "mathContext": "$a^{(p-1)/2}\\equiv\\left(\\tfrac{a}{p}\\right)\\pmod p$: $+1$ for residues, $-1$ for non-residues; $\\bigl(a^{(p-1)/2}\\bigr)^2 = a^{p-1} = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic residue", "Legendre symbol", "Fermat's little theorem", "quadratic reciprocity"],
+    "prerequisites": ["modular arithmetic", "the field Z/p", "odd primes"]
   },
   {
     "id": "euler-criterion-squares-oq-01-criterion",
     "proofId": "euler-criterion-squares-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 35,
-      "endLine": 56
-    },
+    "range": { "startLine": 34, "endLine": 53 },
     "title": "The Criterion and the ±1 Dichotomy",
-    "content": "`half_eq`: $p/2 = (p-1)/2$ for an odd prime (from `Nat.Prime.eq_two_or_odd` and `omega`), reconciling Mathlib's exponent with the textbook one.\n\n`isSquare_iff_pow`: **Euler's criterion** — $\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2} = 1$, by rewriting the exponent and applying `ZMod.euler_criterion`.\n\n`pow_half_eq_one_or_neg_one`: the value $a^{(p-1)/2}$ is always $\\pm 1$. Via `mul_self_eq_one_iff` it suffices that $a^{(p-1)/2}\\cdot a^{(p-1)/2} = a^{p-1} = 1$, which is Fermat's little theorem (`ZMod.pow_card_sub_one_eq_one`)."
+    "content": "`half_eq`: $p/2 = (p-1)/2$ for an odd prime (from `Nat.Prime.eq_two_or_odd` and `omega`), reconciling Mathlib's exponent with the textbook one.\n\n`isSquare_iff_pow`: **Euler's criterion** — $\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2} = 1$, by rewriting the exponent and applying `ZMod.euler_criterion`.\n\n`pow_half_eq_one_or_neg_one`: the value $a^{(p-1)/2}$ is always $\\pm 1$. Via `mul_self_eq_one_iff` it suffices that $a^{(p-1)/2}\\cdot a^{(p-1)/2} = a^{p-1} = 1$, which is Fermat's little theorem (`ZMod.pow_card_sub_one_eq_one`).",
+    "mathContext": "$\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2}=1$; and $a^{(p-1)/2}\\in\\{1,-1\\}$ since its square is $a^{p-1}=1$ in the field $\\mathbb{Z}/p$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.euler_criterion", "Fermat's little theorem", "mul_self_eq_one_iff", "field has no nontrivial square roots of 1"],
+    "prerequisites": ["multiplicative order", "Euler's criterion statement"]
   },
   {
     "id": "euler-criterion-squares-oq-01-nonresidue",
     "proofId": "euler-criterion-squares-oq-01",
+    "type": "insight",
+    "range": { "startLine": 55, "endLine": 76 },
+    "title": "Non-residues: the −1 characterization",
+    "content": "`one_ne_neg_one`: $1 \\ne -1$ in $\\mathbb{Z}/p$ for an odd prime — otherwise $2 = 0$, forcing $p \\mid 2$, impossible for $p > 2$ (this is exactly where oddness of $p$ is used). `not_isSquare_iff_pow`: the **non-residue** characterization $\\neg\\,\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2} = -1$, obtained by combining Euler's criterion (square $\\iff = 1$) with the $\\pm 1$ dichotomy and the separation $1 \\ne -1$: not equal to $1$ leaves only $-1$.",
+    "mathContext": "$1\\ne-1$ in $\\mathbb{Z}/p$ ($p>2$); so $\\neg\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2}\\ne 1 \\iff a^{(p-1)/2}=-1$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic non-residue", "ZMod.natCast_eq_zero_iff", "dichotomy", "why p must be odd"],
+    "prerequisites": ["the ±1 dichotomy", "characteristic of Z/p"]
+  },
+  {
+    "id": "euler-criterion-squares-oq-01-legendre",
+    "proofId": "euler-criterion-squares-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 58,
-      "endLine": 81
-    },
-    "title": "Non-residues and the Legendre Symbol",
-    "content": "`one_ne_neg_one`: $1 \\ne -1$ in $\\mathbb{Z}/p$ for an odd prime — otherwise $2 = 0$, forcing $p \\mid 2$, impossible for $p > 2$.\n\n`not_isSquare_iff_pow`: the **non-residue** characterization $\\neg\\,\\mathrm{IsSquare}\\,a \\iff a^{(p-1)/2} = -1$, combining the criterion with the $\\pm 1$ dichotomy and $1 \\ne -1$.\n\n`legendreSym_eq_pow`: the **Legendre symbol as a power**, $(a \\mid p) \\equiv a^{(p-1)/2}$ in $\\mathbb{Z}/p$. `legendreSym_mul`: its **multiplicativity** $(ab \\mid p) = (a \\mid p)(b \\mid p)$ — the property behind quadratic reciprocity."
+    "range": { "startLine": 78, "endLine": 88 },
+    "title": "The Legendre Symbol as a Power, and Multiplicativity",
+    "content": "`legendreSym_eq_pow`: the **Legendre symbol as a power**, $(a \\mid p) \\equiv a^{(p-1)/2}$ in $\\mathbb{Z}/p$ (rewriting the exponent and using `legendreSym.eq_pow`). `legendreSym_mul`: its **complete multiplicativity** $(ab \\mid p) = (a \\mid p)(b \\mid p)$ — note this one drops the oddness hypothesis (`omit [Fact (2 < p)]`). Multiplicativity is the structural property that, together with the value at $-1$ and $2$, drives quadratic reciprocity.",
+    "mathContext": "$\\left(\\tfrac{a}{p}\\right)\\equiv a^{(p-1)/2}\\pmod p$ and $\\left(\\tfrac{ab}{p}\\right)=\\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre symbol", "complete multiplicativity", "legendreSym.eq_pow", "quadratic reciprocity"],
+    "prerequisites": ["Legendre symbol definition", "integer-to-ZMod cast"]
   },
   {
     "id": "euler-criterion-squares-oq-01-mod7",
     "proofId": "euler-criterion-squares-oq-01",
-    "type": "theorem",
-    "range": {
-      "startLine": 83,
-      "endLine": 105
-    },
+    "type": "technique",
+    "range": { "startLine": 92, "endLine": 103 },
     "title": "Concrete Checks Modulo 7",
-    "content": "Euler's criterion in action on $p = 7$, with $(7-1)/2 = 3$:\n\n- `isSquare_two_mod_seven`: $2$ is a residue, witnessed by $3^2 = 9 \\equiv 2$; and `two_pow_three_mod_seven`: $2^3 = 1$.\n- `not_isSquare_three_mod_seven`: $3$ is a non-residue; and `three_pow_three_mod_seven`: $3^3 = -1$.\n\nEach is checked by `decide` — kernel reduction over the finite type $\\mathbb{Z}/7$ — so no `native_decide` and no extra axioms are introduced."
+    "content": "Euler's criterion in action on $p = 7$, with $(7-1)/2 = 3$:\n\n- `isSquare_two_mod_seven`: $2$ is a residue, witnessed by $3^2 = 9 \\equiv 2$; and `two_pow_three_mod_seven`: $2^3 = 1$.\n- `not_isSquare_three_mod_seven`: $3$ is a non-residue; and `three_pow_three_mod_seven`: $3^3 = -1$.\n\nEach is checked by `decide` — kernel reduction over the finite type $\\mathbb{Z}/7$ — so no `native_decide` and no extra axioms are introduced.",
+    "mathContext": "In $\\mathbb{Z}/7$: $2 = 3^2$ (residue), $2^3 = 1$; $3$ a non-residue, $3^3 = 27\\equiv -1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide vs native_decide", "kernel reduction", "quadratic residues mod 7", "axiom-free verification"],
+    "prerequisites": ["arithmetic in Z/7", "decidability over finite types"]
   }
 ]

--- a/src/data/proofs/euler-criterion-squares-oq-01/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01/meta.json
@@ -54,6 +54,40 @@
       "Decidability of IsSquare and equality over the finite type ZMod 7 (decide)"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Docstring stating Euler's criterion (a a square ⟺ a^((p−1)/2) ≡ 1, non-residue ⟺ ≡ −1), the ±1 dichotomy from Fermat, and the Legendre symbol (a|p) ≡ a^((p−1)/2) with its multiplicativity. Notes Mathlib's exponent is p/2 = (p−1)/2 for odd p, and that everything is checked mod 7. Fully verified (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "$a^{(p-1)/2}\\equiv\\pm1\\pmod p$ decides residuosity; $\\left(\\tfrac{a}{p}\\right)\\equiv a^{(p-1)/2}$."
+    },
+    {
+      "id": "sec-criterion",
+      "title": "The Criterion and the ±1 Dichotomy",
+      "startLine": 32,
+      "endLine": 53,
+      "summary": "half_eq (p/2 = (p−1)/2 for odd primes), isSquare_iff_pow (Euler's criterion: IsSquare a ⟺ a^((p−1)/2) = 1 via ZMod.euler_criterion), and pow_half_eq_one_or_neg_one (the value is ±1, since its square is a^(p−1) = 1 by Fermat in the field Z/p).",
+      "mathContext": "$\\mathrm{IsSquare}\\,a\\iff a^{(p-1)/2}=1$; $a^{(p-1)/2}\\in\\{1,-1\\}$."
+    },
+    {
+      "id": "sec-nonresidue",
+      "title": "Non-residues and the Legendre Symbol",
+      "startLine": 55,
+      "endLine": 88,
+      "summary": "one_ne_neg_one (1 ≠ −1 in Z/p for odd p, else p ∣ 2), not_isSquare_iff_pow (non-residue ⟺ a^((p−1)/2) = −1, from the dichotomy + separation), legendreSym_eq_pow ((a|p) ≡ a^((p−1)/2)), and legendreSym_mul (complete multiplicativity (ab|p) = (a|p)(b|p), dropping the oddness hypothesis).",
+      "mathContext": "$\\neg\\mathrm{IsSquare}\\,a\\iff a^{(p-1)/2}=-1$; $\\left(\\tfrac{ab}{p}\\right)=\\left(\\tfrac{a}{p}\\right)\\left(\\tfrac{b}{p}\\right)$."
+    },
+    {
+      "id": "sec-mod7",
+      "title": "Concrete Checks Modulo 7 (decide)",
+      "startLine": 90,
+      "endLine": 105,
+      "summary": "isSquare_two_mod_seven (2 = 3² mod 7) with two_pow_three_mod_seven (2³ = 1), and not_isSquare_three_mod_seven with three_pow_three_mod_seven (3³ = −1). All closed by kernel `decide` over Z/7 — no native_decide.",
+      "mathContext": "$2\\equiv3^2$, $2^3=1$; $3$ non-residue, $3^3\\equiv-1$ in $\\mathbb{Z}/7$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "primitive-roots-oq-03",


### PR DESCRIPTION
Enrichment (deepening) pass for `euler-criterion-squares-oq-01` (quality 50, 0 prior passes).

## Gaps addressed
The entry had 4 annotations but **none carried `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**, and meta.json had **no `sections` array**.

1. **Deepened all annotations** — added the 4 structured fields to each (preserving existing prose).
2. **Split** the combined non-residue / Legendre-symbol annotation into two (non-residue −1 characterization; Legendre symbol as a power + multiplicativity), giving **5 annotations**.
3. **Added a `sections` array** covering all four source sections (header, criterion + ±1 dichotomy, non-residues + Legendre symbol, mod-7 checks).

## Verification
- meta.json and annotations.json validate as JSON; `pnpm annotations:build` reports no errors for this entry (ranges snapped to Lean constructs).
- Axiom integrity preserved: meta declares `status: verified`, `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom decls; concrete mod-7 checks use `decide` (kernel), not `native_decide`). No claims changed.