### PR TITLE
research(viviani-theorem-oq-01-oq-01): converse of Viviani — constant distance-sum ⇔ equilateral [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/VivianiTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/VivianiTheoremOQ01OQ01.lean
@@ -1,0 +1,219 @@
+import Mathlib
+
+/-
+# Viviani's Theorem — OQ-01-OQ-01: the converse
+
+## Research Problem: viviani-theorem-oq-01-oq-01
+
+Viviani's theorem (parent `viviani-theorem-oq-01`) proves the *forward* direction:
+inside an equilateral triangle the sum of the perpendicular distances from an
+interior point to the three sides is constant (the altitude). Here we prove the
+**converse**, turning the theorem into a characterisation:
+
+    the distance-sum S(P) is independent of P   ⇔   the triangle is equilateral.
+
+Following the problem's own reduction, the proof has two crisp parts.
+
+* **Affine / gradient reduction.** Each signed distance `d_i(P) = ⟪n_i, P⟫ + cᵢ`
+  is affine with gradient the inward unit normal `n_i`, so the distance sum
+  `S(P) = ⟪n_a + n_b + n_c, P⟫ + K` is constant in `P` **iff** the normal sum
+  `n_a + n_b + n_c` is the zero vector.
+
+* **Normal-vector lemma.** For the three inward unit normals of a non-degenerate
+  triangle, `n_a + n_b + n_c = 0` **iff** `a = b = c`. The input is the classical
+  polygon closing-normal identity `a·n_a + b·n_b + c·n_c = 0` (here free: the
+  normals are `90°` rotations of the directed edges, whose vector sum is zero)
+  together with the linear independence of two of the normals (non-degeneracy).
+
+We model the Euclidean plane as `ℂ`; rotation by `90°` is multiplication by `I`,
+which makes the closing identity `a·n_a + b·n_b + c·n_c = (rotation of)
+(edge sum) = 0` immediate.  The signed-distance sum is built from an explicit real
+inner product `rdot` on `ℂ`.  The converse is proved for the signed distance sum
+over the whole plane; on the interior of the triangle all three inward distances
+are positive, so the signed sum equals the perpendicular-distance sum there and
+the characterisation transfers verbatim.
+
+Tags: geometry, viviani, converse, equilateral-triangle, inner-product, normals
+-/
+
+namespace VivianiTheoremOQ01OQ01
+
+open Complex
+
+/-! ## A real inner product on the plane `ℂ` -/
+
+/-- The standard real inner product on the Euclidean plane `ℂ`. -/
+def rdot (z w : ℂ) : ℝ := z.re * w.re + z.im * w.im
+
+@[simp] lemma rdot_add_left (x y w : ℂ) : rdot (x + y) w = rdot x w + rdot y w := by
+  simp only [rdot, Complex.add_re, Complex.add_im]; ring
+
+@[simp] lemma rdot_add_right (x y w : ℂ) : rdot w (x + y) = rdot w x + rdot w y := by
+  simp only [rdot, Complex.add_re, Complex.add_im]; ring
+
+@[simp] lemma rdot_sub_right (x y w : ℂ) : rdot w (x - y) = rdot w x - rdot w y := by
+  simp only [rdot, Complex.sub_re, Complex.sub_im]; ring
+
+@[simp] lemma rdot_smul_left (r : ℝ) (z w : ℂ) : rdot (r • z) w = r * rdot z w := by
+  simp only [rdot, Complex.real_smul, Complex.mul_re, Complex.mul_im,
+    Complex.ofReal_re, Complex.ofReal_im]; ring
+
+/-- `rdot` is positive definite: `rdot z z = 0 ↔ z = 0`. -/
+lemma rdot_self_eq_zero {z : ℂ} : rdot z z = 0 ↔ z = 0 := by
+  constructor
+  · intro h
+    have hre : z.re = 0 ∧ z.im = 0 := by
+      have h1 : z.re ^ 2 + z.im ^ 2 = 0 := by simpa [rdot, sq] using h
+      constructor
+      · nlinarith [sq_nonneg z.re, sq_nonneg z.im]
+      · nlinarith [sq_nonneg z.re, sq_nonneg z.im]
+    exact Complex.ext hre.1 hre.2
+  · rintro rfl; simp [rdot]
+
+/-! ## Linear independence from a non-zero determinant -/
+
+/-- Two plane vectors `u, v` with non-zero determinant `uₓvy − uy vₓ` are
+`ℝ`-linearly independent: the only real combination summing to `0` is trivial. -/
+lemma indep_of_det {u v : ℂ} (h : u.re * v.im - u.im * v.re ≠ 0) :
+    ∀ s t : ℝ, s • u + t • v = 0 → s = 0 ∧ t = 0 := by
+  intro s t hst
+  have e1 : s * u.re + t * v.re = 0 := by
+    have := congrArg Complex.re hst
+    simpa [Complex.add_re, Complex.real_smul, Complex.mul_re, Complex.ofReal_re,
+      Complex.ofReal_im] using this
+  have e2 : s * u.im + t * v.im = 0 := by
+    have := congrArg Complex.im hst
+    simpa [Complex.add_im, Complex.real_smul, Complex.mul_im, Complex.ofReal_re,
+      Complex.ofReal_im] using this
+  constructor
+  · have : s * (u.re * v.im - u.im * v.re) = 0 := by
+      linear_combination v.im * e1 - v.re * e2
+    rcases mul_eq_zero.mp this with h' | h'
+    · exact h'
+    · exact absurd h' h
+  · have : t * (u.re * v.im - u.im * v.re) = 0 := by
+      linear_combination u.re * e2 - u.im * e1
+    rcases mul_eq_zero.mp this with h' | h'
+    · exact h'
+    · exact absurd h' h
+
+/-! ## The normal-vector heart: `n_a + n_b + n_c = 0 ⇔ a = b = c` -/
+
+/-- **Normal-sum lemma.** Let `Na, Nb, Nc` be the (un-normalised, equal-length to
+the sides) inward normals of a triangle, with positive side lengths `a, b, c` and
+unit normals `nᵢ = ‖Nᵢ‖⁻¹ • Nᵢ = aᵢ⁻¹ • Nᵢ`. Given the closing-normal identity
+`Na + Nb + Nc = 0` and the linear independence of two of the normals
+(non-degeneracy), the unit normals sum to zero **iff** the triangle is
+equilateral. This is the algebraic core of the converse of Viviani's theorem. -/
+theorem normalSum_zero_iff_equilateral
+    {Na Nb Nc : ℂ} {a b c : ℝ}
+    (hclose : Na + Nb + Nc = 0)
+    (hindep : ∀ s t : ℝ, s • Na + t • Nb = 0 → s = 0 ∧ t = 0) :
+    ((a⁻¹ • Na + b⁻¹ • Nb + c⁻¹ • Nc : ℂ) = 0) ↔ (a = b ∧ b = c) := by
+  constructor
+  · intro h
+    -- Subtract `c⁻¹ • (closing identity)` to kill `Nc`.
+    have h2 : (a⁻¹ - c⁻¹) • Na + (b⁻¹ - c⁻¹) • Nb = 0 := by
+      have key : (a⁻¹ - c⁻¹) • Na + (b⁻¹ - c⁻¹) • Nb
+          = (a⁻¹ • Na + b⁻¹ • Nb + c⁻¹ • Nc) - c⁻¹ • (Na + Nb + Nc) := by
+        module
+      rw [key, h, hclose, smul_zero, sub_zero]
+    obtain ⟨h3, h4⟩ := hindep _ _ h2
+    have hac : a⁻¹ = c⁻¹ := by linarith
+    have hbc : b⁻¹ = c⁻¹ := by linarith
+    have ha_eq_c : a = c := inv_inj.mp hac
+    have hb_eq_c : b = c := inv_inj.mp hbc
+    exact ⟨ha_eq_c.trans hb_eq_c.symm, hb_eq_c⟩
+  · rintro ⟨hab, hbc⟩
+    have hba : b = a := hab.symm
+    have hca : c = a := (hbc.symm).trans hab.symm
+    rw [hba, hca]
+    have hcollect : a⁻¹ • Na + a⁻¹ • Nb + a⁻¹ • Nc = a⁻¹ • (Na + Nb + Nc) := by
+      module
+    rw [hcollect, hclose, smul_zero]
+
+/-! ## The affine / gradient reduction -/
+
+/-- The difference of the signed distance sums at two points `P, Q` depends only on
+the normal sum: it equals `⟪n_a + n_b + n_c, P − Q⟫`. -/
+lemma sumDist_sub (na nb nc B C A P Q : ℂ) :
+    (rdot na (P - B) + rdot nb (P - C) + rdot nc (P - A))
+      - (rdot na (Q - B) + rdot nb (Q - C) + rdot nc (Q - A))
+      = rdot (na + nb + nc) (P - Q) := by
+  simp only [rdot, Complex.add_re, Complex.add_im, Complex.sub_re, Complex.sub_im]
+  ring
+
+/-- **Affine reduction.** The signed distance sum `P ↦ ∑ ⟪nᵢ, P − vᵢ⟫` is constant
+on the whole plane **iff** the normal sum `n_a + n_b + n_c` vanishes. -/
+lemma const_iff_normalSum_zero (na nb nc B C A : ℂ) :
+    (∀ P Q : ℂ,
+        rdot na (P - B) + rdot nb (P - C) + rdot nc (P - A)
+          = rdot na (Q - B) + rdot nb (Q - C) + rdot nc (Q - A))
+      ↔ na + nb + nc = 0 := by
+  constructor
+  · intro hconst
+    have hsub := sumDist_sub na nb nc B C A (na + nb + nc) 0
+    rw [hconst (na + nb + nc) 0, sub_self] at hsub
+    have : rdot (na + nb + nc) (na + nb + nc) = 0 := by
+      simpa using hsub.symm
+    exact rdot_self_eq_zero.mp this
+  · intro h P Q
+    have hsub := sumDist_sub na nb nc B C A P Q
+    rw [h] at hsub
+    have hz : rdot (0 : ℂ) (P - Q) = 0 := by simp [rdot]
+    rw [hz] at hsub
+    linarith [hsub]
+
+/-! ## The converse of Viviani's theorem -/
+
+/-- Inward unit normal to side `BC` (opposite `A`): the directed edge `C − B`
+rotated by `90°` (multiplication by `I`) and normalised. -/
+noncomputable def nA (A B C : ℂ) : ℂ := ‖C - B‖⁻¹ • (Complex.I * (C - B))
+
+/-- Inward unit normal to side `CA` (opposite `B`). -/
+noncomputable def nB (A B C : ℂ) : ℂ := ‖A - C‖⁻¹ • (Complex.I * (A - C))
+
+/-- Inward unit normal to side `AB` (opposite `C`). -/
+noncomputable def nC (A B C : ℂ) : ℂ := ‖B - A‖⁻¹ • (Complex.I * (B - A))
+
+/-- The signed perpendicular-distance sum from a point `P` to the three sides of
+the triangle `A B C`. (Each summand is the signed distance to a side; on the
+interior, where all three inward distances are positive, this equals the
+perpendicular-distance sum of the classical statement.) -/
+noncomputable def sumDist (A B C P : ℂ) : ℝ :=
+  rdot (nA A B C) (P - B) + rdot (nB A B C) (P - C) + rdot (nC A B C) (P - A)
+
+/-- **Converse of Viviani's theorem.** For a non-degenerate planar triangle
+`A B C` (encoded by the non-vanishing of the signed area / edge determinant), the
+signed perpendicular-distance sum `sumDist` is independent of the point **iff** the
+triangle is equilateral, i.e. its three sides have equal length. Combined with the
+parent's forward direction this is the full characterisation:
+
+    the distance-sum is constant   ⇔   the triangle is equilateral. -/
+theorem viviani_converse {A B C : ℂ}
+    (hnd : (C - B).re * (A - C).im - (C - B).im * (A - C).re ≠ 0) :
+    (∀ P Q : ℂ, sumDist A B C P = sumDist A B C Q)
+      ↔ (‖C - B‖ = ‖A - C‖ ∧ ‖A - C‖ = ‖B - A‖) := by
+  -- closing-normal identity: the rotated directed edges sum to zero
+  have hclose :
+      Complex.I * (C - B) + Complex.I * (A - C) + Complex.I * (B - A) = 0 := by
+    ring
+  -- linear independence of two normals from the non-zero determinant
+  have hdet :
+      (Complex.I * (C - B)).re * (Complex.I * (A - C)).im
+        - (Complex.I * (C - B)).im * (Complex.I * (A - C)).re
+      = (C - B).re * (A - C).im - (C - B).im * (A - C).re := by
+    simp only [Complex.I_mul_re, Complex.I_mul_im]; ring
+  have hindep :
+      ∀ s t : ℝ, s • (Complex.I * (C - B)) + t • (Complex.I * (A - C)) = 0
+        → s = 0 ∧ t = 0 :=
+    indep_of_det (by rw [hdet]; exact hnd)
+  -- the heart, instantiated at the rotated edges and the side lengths
+  have heart := normalSum_zero_iff_equilateral
+    (Na := Complex.I * (C - B)) (Nb := Complex.I * (A - C)) (Nc := Complex.I * (B - A))
+    (a := ‖C - B‖) (b := ‖A - C‖) (c := ‖B - A‖) hclose hindep
+  -- chain: constancy ⇔ normal sum zero ⇔ equilateral
+  refine (const_iff_normalSum_zero (nA A B C) (nB A B C) (nC A B C) B C A).trans ?_
+  simpa only [nA, nB, nC] using heart
+
+end VivianiTheoremOQ01OQ01

--- a/src/data/proofs/viviani-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-rdot",
+    "proofId": "viviani-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 71
+    },
+    "type": "technique",
+    "title": "A Self-Contained Real Inner Product on ℂ",
+    "content": "The plane is modeled as ℂ, and rdot z w = z.re·w.re + z.im·w.im is the standard real inner product. Its bilinearity (rdot_add_left/right, rdot_smul_left, rdot_sub_right) lets the signed distances be manipulated as affine functionals, and its positive-definiteness rdot z z = 0 ↔ z = 0 is the lever that turns 'constant distance-sum' into the vector equation n_a+n_b+n_c = 0. Building rdot by hand keeps the file independent of any particular inner-product instance on ℂ.",
+    "mathContext": "$\\langle z,w\\rangle = z_1 w_1 + z_2 w_2$; $\\langle z,z\\rangle = 0 \\iff z = 0$.",
+    "significance": "key-technique",
+    "relatedConcepts": [
+      "real inner product",
+      "positive-definiteness",
+      "affine functional gradient"
+    ],
+    "prerequisites": [
+      "Complex.re / Complex.im",
+      "bilinearity"
+    ]
+  },
+  {
+    "id": "ann-indep-det",
+    "proofId": "viviani-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Non-Degeneracy as a Non-Zero Determinant",
+    "content": "indep_of_det shows two plane vectors u, v with uₓvy − uy vₓ ≠ 0 are ℝ-linearly independent: from s•u+t•v=0 the real and imaginary parts give a 2×2 system, and eliminating with linear_combination yields s·det = 0 and t·det = 0, forcing s=t=0. The determinant is twice the signed area of the triangle, so this is exactly the encoding of non-degeneracy used by the main theorem — a genuine mathematical hypothesis, not an axiom.",
+    "mathContext": "$\\det(u,v) = u_x v_y - u_y v_x \\ne 0 \\Rightarrow \\{u,v\\}$ linearly independent over $\\mathbb{R}$.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "linear independence",
+      "signed area / determinant",
+      "triangle non-degeneracy"
+    ],
+    "prerequisites": [
+      "2×2 linear systems",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "ann-heart",
+    "proofId": "viviani-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 133
+    },
+    "type": "insight",
+    "title": "The Normal-Vector Heart: Equal Sides ⇔ Vanishing Unit-Normal Sum",
+    "content": "normalSum_zero_iff_equilateral is the algebraic core. Given the closing-normal identity Na+Nb+Nc=0 and linear independence of two normals, the ⇒ direction subtracts c⁻¹·(closing) to eliminate Nc, leaving (a⁻¹−c⁻¹)•Na+(b⁻¹−c⁻¹)•Nb=0 (proved by the module tactic); independence collapses this to a⁻¹=b⁻¹=c⁻¹, hence a=b=c via inv_inj. The ⇐ direction collects a⁻¹•(Na+Nb+Nc)=0. No positivity of the side lengths is needed — inv_inj holds in any group with zero.",
+    "mathContext": "$a^{-1}n_a + b^{-1}n_b + c^{-1}n_c = 0 \\iff a=b=c$, given $a n_a + b n_b + c n_c = 0$ and $n_a, n_b$ independent.",
+    "significance": "core-result",
+    "relatedConcepts": [
+      "closing-normal identity",
+      "unit normals",
+      "linear elimination"
+    ],
+    "prerequisites": [
+      "module tactic",
+      "inv_inj",
+      "linear independence"
+    ]
+  },
+  {
+    "id": "ann-affine",
+    "proofId": "viviani-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 139,
+      "endLine": 165
+    },
+    "type": "insight",
+    "title": "The Affine Reduction: Constant ⇔ Vanishing Gradient",
+    "content": "sumDist_sub computes S(P) − S(Q) = ⟪n_a+n_b+n_c, P−Q⟫ by bilinearity of rdot, exposing n_a+n_b+n_c as the gradient of the affine functional S. const_iff_normalSum_zero then shows S is constant on the whole plane iff this gradient vanishes: if S is constant, choosing the test points so that P−Q equals the normal sum w forces rdot w w = 0, hence w = 0 by positive-definiteness.",
+    "mathContext": "$S(P)-S(Q) = \\langle n_a+n_b+n_c,\\ P-Q\\rangle$; $S$ constant $\\iff n_a+n_b+n_c = 0$.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "affine functional",
+      "gradient",
+      "positive-definiteness"
+    ],
+    "prerequisites": [
+      "bilinearity of rdot",
+      "rdot_self_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "viviani-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 193,
+      "endLine": 218
+    },
+    "type": "insight",
+    "title": "Assembling the Converse",
+    "content": "viviani_converse defines the inward unit normals nA, nB, nC as the directed edges rotated by I and normalized, and sumDist as their signed-distance sum. The closing identity I·(C−B)+I·(A−C)+I·(B−A)=0 is free (ring); independence of two normals follows from the non-zero edge determinant via indep_of_det (the rotation by I preserves the determinant). Chaining const_iff_normalSum_zero with normalSum_zero_iff_equilateral gives: the distance-sum is constant ⇔ the triangle is equilateral.",
+    "mathContext": "$\\big(\\forall P\\,Q,\\ S(P)=S(Q)\\big) \\iff \\lVert C-B\\rVert = \\lVert A-C\\rVert = \\lVert B-A\\rVert$.",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "converse of Viviani's theorem",
+      "rotation by I",
+      "equilateral characterization"
+    ],
+    "prerequisites": [
+      "normalSum_zero_iff_equilateral",
+      "const_iff_normalSum_zero",
+      "Complex.I_mul_re / Complex.I_mul_im"
+    ]
+  }
+]

--- a/src/data/proofs/viviani-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "viviani-theorem-oq-01-oq-01",
+  "title": "Converse of Viviani's Theorem: Constant Distance-Sum Characterizes Equilateral Triangles",
+  "slug": "viviani-theorem-oq-01-oq-01",
+  "description": "The converse of Viviani's theorem: for a non-degenerate planar triangle, the sum of the (signed) perpendicular distances from a point to the three sides is independent of the point if and only if the triangle is equilateral. Proved in the plane ℂ via two crisp parts — an affine/gradient reduction (the distance sum is constant ⇔ the sum of the three inward unit normals is zero) and a normal-vector lemma (n_a+n_b+n_c=0 ⇔ a=b=c, from the closing-normal identity and linear independence of two normals). Verified, 0 axioms. Answers the openQuestion of viviani-theorem-oq-01.",
+  "meta": {
+    "author": "Robb Walters (researcher-6)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VivianiTheoremOQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "viviani",
+      "converse",
+      "equilateral-triangle",
+      "metric-geometry",
+      "inner-product",
+      "normals",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 219,
+    "assumptions": "No axioms or sorries. Theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions). Verified via #print axioms. The converse carries a non-degeneracy hypothesis (the edge determinant / signed area is non-zero) — a standard mathematical hypothesis on the triangle, not an axiom.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Converse of Viviani's theorem for a general (non-coordinate-fixed) planar triangle: the signed distance-sum is constant ⇔ the triangle is equilateral, proved in the plane ℂ",
+      "The normal-vector heart normalSum_zero_iff_equilateral: for inward normals with the closing identity Na+Nb+Nc=0 and two of them linearly independent, the unit-normal sum a⁻¹•Na+b⁻¹•Nb+c⁻¹•Nc vanishes iff a=b=c",
+      "The affine/gradient reduction const_iff_normalSum_zero: the signed distance-sum P ↦ ∑⟪nᵢ,P−vᵢ⟫ is constant on the whole plane iff n_a+n_b+n_c=0, via a self-contained real inner product rdot on ℂ",
+      "Closing-normal identity obtained for free: the inward normals are the directed edges rotated by 90° (multiplication by I), whose vector sum is zero — so Na+Nb+Nc = I·(edge sum) = 0 by ring",
+      "indep_of_det: two plane vectors with non-zero determinant are ℝ-linearly independent, the algebraic encoding of triangle non-degeneracy"
+    ],
+    "theoremCount": 10,
+    "definitionCount": 5
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "VivianiTheoremOQ01OQ01",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 5,
+    "path": "Proofs/VivianiTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Viviani's theorem (1659) states that inside an equilateral triangle the sum of the perpendicular distances from any interior point to the three sides is constant, equal to the altitude. The parent gallery entry viviani-theorem-oq-01 proves this forward direction with explicit coordinates. The natural converse — that equilateral is the only triangle shape with the constant-sum property — turns the theorem from an isolated identity into a full characterization. The mechanism is that each perpendicular distance is an affine functional whose gradient is the side's inward unit normal, so the distance-sum is constant exactly when the three normals cancel; and three unit normals of a triangle cancel exactly when the triangle is equilateral. This pattern (affine distance functionals, normal-vector identities, the polygon closing-normal relation) recurs throughout Euclidean geometry.",
+    "problemStatement": "Let $T$ be a non-degenerate planar triangle with vertices $A,B,C$, side lengths $a=\\lVert C-B\\rVert$, $b=\\lVert A-C\\rVert$, $c=\\lVert B-A\\rVert$, and inward unit normals $n_a,n_b,n_c$. For a point $P$ let $S(P)$ be the sum of the (signed) perpendicular distances from $P$ to the three sides. Prove that $S$ is independent of $P$ if and only if $a=b=c$ (the triangle is equilateral).",
+    "text": "The plane is modeled as ℂ so that rotation by 90° is multiplication by I. The inward unit normals are the directed edges rotated by I and normalized; the signed distance sum is built from a self-contained real inner product rdot on ℂ. The converse is proved by chaining two equivalences: constancy ⇔ vanishing normal sum (affine reduction) and vanishing normal sum ⇔ equilateral (normal-vector lemma).",
+    "proofStrategy": "1. rdot: define the real inner product z₁w₁+z₂w₂ on ℂ with its bilinearity and positive-definiteness (rdot z z = 0 ↔ z = 0). 2. indep_of_det: two plane vectors with non-zero determinant are ℝ-linearly independent (eliminate via the 2×2 determinant with linear_combination). 3. normalSum_zero_iff_equilateral: from the closing identity Na+Nb+Nc=0, subtract c⁻¹·(closing) to reduce a⁻¹•Na+b⁻¹•Nb+c⁻¹•Nc=0 to (a⁻¹−c⁻¹)•Na+(b⁻¹−c⁻¹)•Nb=0 (module tactic), apply linear independence to get a⁻¹=c⁻¹, b⁻¹=c⁻¹, hence a=b=c via inv_inj; the converse collects a⁻¹•(Na+Nb+Nc)=0. 4. sumDist_sub / const_iff_normalSum_zero: S(P)−S(Q)=⟪n_a+n_b+n_c, P−Q⟫, so constancy forces rdot w w = 0 hence w = 0 (choosing P−Q=w). 5. viviani_converse: instantiate the heart at the rotated edges (closing identity by ring, independence from the non-zero edge determinant) and chain with the affine reduction.",
+    "keyInsights": [
+      "Modeling the plane as ℂ makes the closing-normal identity completely free: the inward normals are the directed edges rotated by I, and the directed edges sum to zero, so Na+Nb+Nc = I·((C−B)+(A−C)+(B−A)) = I·0 = 0, closed by ring.",
+      "The entire converse reduces to two linear-algebra facts: an affine functional ⟪w,·⟫+const is constant on an open set iff w=0, and three vectors satisfying a·n_a+b·n_b+c·n_c=0 with two of them independent have n_a+n_b+n_c=0 iff a=b=c.",
+      "The ⇒ direction of the heart is a one-step elimination: subtracting c⁻¹ times the closing identity kills the third normal, leaving (a⁻¹−c⁻¹)•Na+(b⁻¹−c⁻¹)•Nb=0, which linear independence collapses to a⁻¹=b⁻¹=c⁻¹.",
+      "Positive-definiteness of the real inner product is exactly what converts 'constant distance-sum' into the vector equation w=0: picking the two test points so that P−Q=w forces rdot w w = 0.",
+      "Non-degeneracy is encoded as a non-zero edge determinant (twice the signed area); it is a genuine mathematical hypothesis on the triangle, so the result remains fully verified and 0-axiom."
+    ],
+    "prerequisites": [
+      "The plane ℂ, the imaginary unit as a 90° rotation, and (C−B)+(A−C)+(B−A)=0",
+      "Real inner products: bilinearity, positive-definiteness, and the gradient of an affine distance functional",
+      "Linear independence via a 2×2 determinant; the closing-normal identity for a triangle",
+      "Lean 4 tactics module, linear_combination, and the lemma inv_inj"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-rdot",
+      "title": "Part I: A Real Inner Product on the Plane ℂ",
+      "startLine": 43,
+      "endLine": 71,
+      "summary": "rdot z w = z.re·w.re + z.im·w.im with its bilinearity simp lemmas and positive-definiteness rdot z z = 0 ↔ z = 0, providing the gradient/inner-product machinery for the signed distances."
+    },
+    {
+      "id": "part2-indep",
+      "title": "Part II: Linear Independence from a Non-Zero Determinant",
+      "startLine": 73,
+      "endLine": 98,
+      "summary": "indep_of_det: two plane vectors u, v with uₓvy − uy vₓ ≠ 0 are ℝ-linearly independent — the algebraic form of triangle non-degeneracy, proved by eliminating the 2×2 system with linear_combination."
+    },
+    {
+      "id": "part3-heart",
+      "title": "Part III: The Normal-Vector Heart",
+      "startLine": 100,
+      "endLine": 133,
+      "summary": "normalSum_zero_iff_equilateral: given the closing identity Na+Nb+Nc=0 and independence of two normals, the unit-normal sum a⁻¹•Na+b⁻¹•Nb+c⁻¹•Nc vanishes iff a=b=c."
+    },
+    {
+      "id": "part4-affine",
+      "title": "Part IV: The Affine / Gradient Reduction",
+      "startLine": 135,
+      "endLine": 165,
+      "summary": "sumDist_sub expresses S(P)−S(Q) = ⟪n_a+n_b+n_c, P−Q⟫; const_iff_normalSum_zero deduces that the signed distance-sum is constant iff the normal sum is zero, using positive-definiteness of rdot."
+    },
+    {
+      "id": "part5-converse",
+      "title": "Part V: The Converse of Viviani's Theorem",
+      "startLine": 167,
+      "endLine": 218,
+      "summary": "The inward unit normals nA, nB, nC and the signed distance-sum sumDist are defined from the vertices; viviani_converse instantiates the heart at the rotated edges (closing identity free by ring) and chains with the affine reduction to prove constancy ⇔ equilateral."
+    }
+  ],
+  "conclusion": {
+    "summary": "The converse of Viviani's theorem is proved for a general non-degenerate planar triangle: the signed perpendicular-distance sum is independent of the point if and only if the triangle is equilateral. The proof factors through an affine reduction (constant ⇔ normal sum zero) and a normal-vector lemma (normal sum zero ⇔ equal sides), both elementary linear algebra over the plane ℂ. Verified, 0 axioms, 0 sorries. Answers the openQuestion of viviani-theorem-oq-01 verbatim.",
+    "openQuestions": [
+      "The regular-polygon / n-gon generalization: for a convex n-gon the perpendicular-distance sum is constant iff the n outward unit normals sum to zero; characterize exactly which n-gons (beyond the regular ones) have this property in terms of their edge-length / normal data.",
+      "An interior-only statement: prove directly that for a non-equilateral triangle there exist two interior points with different distance-sums (the contrapositive localized to the open interior), constructing the witnesses from the non-zero normal sum n_a+n_b+n_c."
+    ],
+    "implications": "Completes the logical picture around Viviani's theorem, upgrading it from an identity special to equilateral triangles to a characterization of them. It also exposes the underlying mechanism — the constant-sum property is a statement about the gradient of an affine functional and the polygon closing-normal identity — a reusable pattern for barycentric, distance-functional, and normal-vector arguments in Euclidean geometry."
+  },
+  "crossReferences": [
+    {
+      "targetId": "viviani-theorem-oq-01",
+      "relationship": "parent-problem",
+      "description": "Directly answers the parent's openQuestion. The parent proves the forward direction (inside an equilateral triangle the perpendicular-distance sum is constant, the altitude); this entry proves the converse, that equilateral is the only triangle with the constant-sum property, completing the characterization."
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related",
+      "description": "Side/length and normal relations underlying the closing-normal identity a·n_a+b·n_b+c·n_c=0 used in the normal-vector heart."
+    }
+  ],
+  "references": [
+    {
+      "author": "Vincenzo Viviani",
+      "title": "Viviani's theorem (constant sum of distances to the sides of an equilateral triangle)",
+      "year": 1659,
+      "note": "Classical forward direction; this entry establishes the converse characterization."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **converse of Viviani's theorem** for a general non-degenerate planar triangle, answering the openQuestion of `viviani-theorem-oq-01` verbatim:

> The (signed) perpendicular-distance sum from a point to the three sides is independent of the point **⇔** the triangle is equilateral.

The parent entry proves the *forward* direction (inside an equilateral triangle the distance-sum is the constant altitude). This entry completes the characterization.

## Approach

The plane is modeled as `ℂ`, so rotation by 90° is multiplication by `I`. The proof follows the problem's own two-part reduction:

- **`const_iff_normalSum_zero`** (affine/gradient reduction): the signed distance-sum `P ↦ ∑ ⟪nᵢ, P − vᵢ⟫` is constant on the whole plane ⇔ `n_a + n_b + n_c = 0`. Built on a self-contained real inner product `rdot` on `ℂ`; positive-definiteness `rdot z z = 0 ↔ z = 0` converts constancy into the vector equation.
- **`normalSum_zero_iff_equilateral`** (normal-vector heart): given the closing-normal identity `Na + Nb + Nc = 0` and linear independence of two normals, `a⁻¹•Na + b⁻¹•Nb + c⁻¹•Nc = 0 ⇔ a = b = c`. The ⇒ direction subtracts `c⁻¹·(closing)` to eliminate `Nc`, then independence collapses to `a⁻¹ = b⁻¹ = c⁻¹`.

The closing-normal identity is **free**: the inward normals are the directed edges rotated by `I`, and the directed edges sum to zero, so `Na + Nb + Nc = I·(edge sum) = 0` by `ring`. Non-degeneracy is encoded as a non-zero edge determinant (twice the signed area) and converted to linear independence by `indep_of_det`.

## Verification

- **10 theorems/lemmas, 5 definitions, 219 lines.**
- `#print axioms viviani_converse` → only `propext`, `Classical.choice`, `Quot.sound` (the Lean/Mathlib standard).
- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.** Status: `verified` / badge `original`.
- The converse carries a non-degeneracy hypothesis (edge determinant ≠ 0) — a standard mathematical hypothesis on the triangle, not an axiom.

## Files

- `proofs/Proofs/VivianiTheoremOQ01OQ01.lean`
- `src/data/proofs/viviani-theorem-oq-01-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)