### PR TITLE
research(borsuk-ulam-oq-02-oq-01-oq-03-oq-01): uniform dihedral lower bound + tightness ⇔ one upper bound

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ01.lean
@@ -1,0 +1,162 @@
+/-
+  Borsuk-Ulam for Dihedral Groups: the Prime-Subgroup Lower Bound is General,
+  and Tightness Reduces to a Single Upper Bound  (OQ-02-OQ-01-OQ-03-OQ-01)
+
+  Open question from BorsukUlamOQ02OQ01OQ03 (openQuestions[0]):
+    "Are the dihedral lower bounds tight? Is
+       dihedralBUDim n d = max(buDim 2 d, max_{p odd prime | n} buDim p d)?
+     This would require RO(D_n)-graded equivariant cohomology to prove the
+     matching upper bound."
+
+  The parent file proved the lower bound only for individual small cases
+  (D_p, D_5, D_6) by hand. Here we:
+
+  1. State the conjectured exact value uniformly in n as a `Finset.sup` over the
+     prime divisors of n, combined with the reflection Z/2 contribution:
+         dihedralLowerBound n d = max (buDim 2 d) (∑⁻ over p ∣ n of buDim p d).
+     (Including p = 2 in the sup is harmless: its contribution buDim 2 d is
+     already the left argument of the outer `max`, so this equals the
+     "odd-prime" formula in the open question.)
+
+  2. Prove `dihedralLowerBound n d ≤ dihedralBUDim n d` for every n ≥ 1, using
+     ONLY the parent framework's existing axioms (`dihedral_has_Z2`,
+     `dihedral_has_rotation_prime`). This adds **0 new axioms** and subsumes the
+     parent's case-by-case bounds as immediate corollaries.
+
+  3. Prove that the conjectured exact equality holds **iff** a matching upper
+     bound holds. This isolates the single deep topological input — the
+     Fadell–Husseini upper bound from RO(D_n)-graded equivariant cohomology — as
+     an explicit hypothesis rather than a new global axiom. That upper bound
+     itself remains genuinely open (beyond current Mathlib).
+
+  Honesty note: all topological content is inherited from the parent's abstract
+  axiomatization of `buDim` / `dihedralBUDim`. The new mathematical content here
+  is the uniform-in-n lower bound (a `Finset.sup` statement the parent did not
+  formalize) and the precise reduction of tightness to one upper bound. No new
+  axioms are introduced.
+
+  References:
+  - Fadell & Husseini, "An ideal-valued cohomological index theory" (1988)
+  - tom Dieck, "Transformation Groups" (1987), §5.4, §7.1
+  - Matoušek, "Using the Borsuk-Ulam Theorem" (2003), Ch. 6
+-/
+
+import Mathlib
+import Proofs.BorsukUlamOQ02OQ01
+import Proofs.BorsukUlamOQ02OQ01OQ03
+
+namespace BorsukUlamDihedralTight
+
+open BorsukUlamOQ02OQ01 BorsukUlamNonCyclic Nat
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- The conjectured exact value, uniform in n
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- The prime-subgroup lower bound for the dihedral group `D_n`, uniform in `n`.
+
+    `D_n` always contains a reflection `Z/2` (the `buDim 2 d` term) and contains
+    `Z/p` for every prime divisor `p ∣ n` coming from the rotation subgroup
+    `Z/n` (the `Finset.sup` term). This is the value conjectured to equal
+    `dihedralBUDim n d`. -/
+noncomputable def dihedralLowerBound (n d : ℕ) : ℕ :=
+  max (buDim 2 d) (n.primeFactors.sup fun p => buDim p d)
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART I: THE GENERAL LOWER BOUND (0 new axioms)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **General dihedral lower bound.** For every `n ≥ 1`,
+    `dihedralLowerBound n d ≤ dihedralBUDim n d`.
+
+    Proof: the reflection axiom `dihedral_has_Z2` handles the `buDim 2 d` term;
+    each prime divisor `p ∣ n` is handled by `dihedral_has_rotation_prime`, and
+    `Finset.sup_le` combines them. Uses only the parent's axioms. -/
+theorem dihedralLowerBound_le (n d : ℕ) (hn : 1 ≤ n) :
+    dihedralLowerBound n d ≤ dihedralBUDim n d := by
+  refine Nat.max_le.mpr ⟨dihedral_has_Z2 n d hn, ?_⟩
+  refine Finset.sup_le ?_
+  intro p hp
+  exact dihedral_has_rotation_prime n d p
+    (Nat.prime_of_mem_primeFactors hp) (Nat.dvd_of_mem_primeFactors hp)
+
+/-- Every prime divisor of `n` contributes its cyclic bound to `dihedralBUDim`. -/
+theorem dihedralBUDim_ge_of_prime_dvd (n d p : ℕ) (hn : 1 ≤ n)
+    (hp : Nat.Prime p) (hdvd : p ∣ n) :
+    buDim p d ≤ dihedralBUDim n d := by
+  have hmem : p ∈ n.primeFactors :=
+    Nat.mem_primeFactors.mpr ⟨hp, hdvd, by omega⟩
+  calc buDim p d ≤ n.primeFactors.sup (fun q => buDim q d) :=
+        Finset.le_sup (f := fun q => buDim q d) hmem
+    _ ≤ dihedralLowerBound n d := le_max_right _ _
+    _ ≤ dihedralBUDim n d := dihedralLowerBound_le n d hn
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART II: TIGHTNESS REDUCES TO A SINGLE UPPER BOUND
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Tightness ⇔ matching upper bound.** The conjectured exact value
+    `dihedralBUDim n d = dihedralLowerBound n d` holds precisely when the
+    upper bound `dihedralBUDim n d ≤ dihedralLowerBound n d` holds.
+
+    The lower bound is supplied unconditionally (Part I); the upper bound is the
+    open Fadell–Husseini equivariant-cohomology input. This theorem pins down
+    *exactly* what is missing to close the open question. -/
+theorem dihedral_tight_iff_upper (n d : ℕ) (hn : 1 ≤ n) :
+    dihedralBUDim n d = dihedralLowerBound n d ↔
+      dihedralBUDim n d ≤ dihedralLowerBound n d :=
+  ⟨fun h => h.le, fun hupper => le_antisymm hupper (dihedralLowerBound_le n d hn)⟩
+
+/-- The exact dihedral BU dimension, conditional on the upper bound. -/
+theorem dihedral_exact_of_upper (n d : ℕ) (hn : 1 ≤ n)
+    (hupper : dihedralBUDim n d ≤ dihedralLowerBound n d) :
+    dihedralBUDim n d = dihedralLowerBound n d :=
+  le_antisymm hupper (dihedralLowerBound_le n d hn)
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART III: THE GENERAL BOUND SUBSUMES THE PARENT'S SPECIAL CASES
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Recover the parent's `D_6 ⊇ Z/3` bound from the general Finset-sup bound. -/
+theorem dihedralBUDim_six_ge_buDim_three (d : ℕ) :
+    buDim 3 d ≤ dihedralBUDim 6 d :=
+  dihedralBUDim_ge_of_prime_dvd 6 d 3 (by norm_num) (by norm_num) (by norm_num)
+
+/-- Recover the parent's `D_6` Yang–Borsuk bound `2n-1 ≤ dihedralBUDim 6 (2n)`
+    as a corollary of the uniform lower bound (via the `Z/3` rotation). -/
+theorem dihedralBUDim_six_yang_borsuk (n : ℕ) (hn : 0 < n) :
+    2 * n - 1 ≤ dihedralBUDim 6 (2 * n) := by
+  have h := dihedralBUDim_six_ge_buDim_three (2 * n)
+  rwa [buDim_prime 3 n (by norm_num) hn] at h
+
+/-- For an odd prime `p`, `D_p` lower bound `max(buDim 2 d, buDim p d)` follows
+    from the general bound (`p.primeFactors = {p}`, plus the reflection term). -/
+theorem dihedralBUDim_odd_prime_ge (p d : ℕ) (hp : Nat.Prime p) :
+    max (buDim 2 d) (buDim p d) ≤ dihedralBUDim p d :=
+  Nat.max_le.mpr
+    ⟨dihedral_has_Z2 p d hp.one_le,
+     dihedralBUDim_ge_of_prime_dvd p d p hp.one_le hp (dvd_refl p)⟩
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART IV: SANITY CHECKS
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- The reflection term alone always bounds the dihedral dimension.
+example (n d : ℕ) (hn : 1 ≤ n) : buDim 2 d ≤ dihedralBUDim n d :=
+  (le_max_left _ _).trans (dihedralLowerBound_le n d hn)
+
+-- D_12 contains Z/3 (3 ∣ 12): general bound applies.
+example (d : ℕ) : buDim 3 d ≤ dihedralBUDim 12 d :=
+  dihedralBUDim_ge_of_prime_dvd 12 d 3 (by norm_num) (by norm_num) (by norm_num)
+
+-- D_15 contains Z/5 (5 ∣ 15): general bound applies even with no factor of 2.
+example (d : ℕ) : buDim 5 d ≤ dihedralBUDim 15 d :=
+  dihedralBUDim_ge_of_prime_dvd 15 d 5 (by norm_num) (by norm_num) (by norm_num)
+
+-- Tightness for D_6 in dimension 2n would give the exact value, given the
+-- (open) upper bound; here we only assert the reduction compiles.
+example (d : ℕ) (hupper : dihedralBUDim 6 d ≤ dihedralLowerBound 6 d) :
+    dihedralBUDim 6 d = dihedralLowerBound 6 d :=
+  dihedral_exact_of_upper 6 d (by norm_num) hupper
+
+end BorsukUlamDihedralTight

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-01-strategy",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Tightness of the Dihedral Lower Bound: Strategy",
+    "content": "The parent file proved the dihedral lower bound only for individual small cases (D_p, D_5, D_6). Its first open question asks whether that bound is the exact value: is dihedralBUDim n d = max(buDim 2 d, max over odd primes p|n of buDim p d)? The exact value needs an upper bound from RO(D_n)-graded equivariant cohomology (Fadell-Husseini), which is beyond current Mathlib. This file does three honest things without that machinery: (1) packages the conjectured value uniformly in n as a single Finset.sup expression; (2) proves the lower-bound direction for every n using ONLY the parent's existing axioms — adding 0 new axioms; (3) proves tightness is logically equivalent to one matching upper bound, so the entire open question collapses to supplying that single inequality.",
+    "mathContext": "The lower bound is unconditional; the upper bound is the open input. `le_antisymm` turns 'lower + upper' into the conjectured equality."
+  },
+  {
+    "id": "ann-02-uniform-formula",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 74
+    },
+    "type": "definition",
+    "title": "dihedralLowerBound: the conjectured value as a Finset.sup",
+    "content": "dihedralLowerBound n d := max (buDim 2 d) (n.primeFactors.sup fun p => buDim p d). The reflection Z/2 always present in D_n gives the left `max` argument; the rotation subgroup Z/n contributes Z/p for each prime divisor p|n, collected by the Finset.sup over n.primeFactors. Including p=2 in the sup is harmless: its value buDim 2 d is already the outer max's left argument, so this equals the 'odd primes only' formula in the open question. Marked noncomputable because buDim is an opaque axiom.",
+    "mathContext": "$\\text{dihedralLowerBound}\\,n\\,d = \\max\\bigl(\\text{buDim}\\,2\\,d,\\ \\bigsqcup_{p \\in n.\\text{primeFactors}} \\text{buDim}\\,p\\,d\\bigr)$."
+  },
+  {
+    "id": "ann-03-general-lower-bound",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "dihedralLowerBound_le: the general bound, 0 new axioms",
+    "content": "For n ≥ 1, Nat.max_le splits the goal into two parts. The reflection term buDim 2 d ≤ dihedralBUDim n d is exactly the parent axiom dihedral_has_Z2. The sup term is discharged by Finset.sup_le, which reduces it to a per-prime obligation: for each p ∈ n.primeFactors, Nat.prime_of_mem_primeFactors and Nat.dvd_of_mem_primeFactors recover p.Prime and p ∣ n, which feed the parent axiom dihedral_has_rotation_prime. dihedralBUDim_ge_of_prime_dvd is the companion that extracts the bound for one chosen prime divisor via Finset.le_sup (note the explicit (f := ...) to fix the sup's function).",
+    "mathContext": "Subgroup monotonicity transfers each cyclic prime subgroup's bound to D_n; `Finset.sup_le` aggregates them."
+  },
+  {
+    "id": "ann-04-tightness",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 114
+    },
+    "type": "theorem",
+    "title": "dihedral_tight_iff_upper: reduction to one upper bound",
+    "content": "Because the lower bound holds unconditionally (Part I), the conjectured equality dihedralBUDim n d = dihedralLowerBound n d is equivalent to the single inequality dihedralBUDim n d ≤ dihedralLowerBound n d. The forward direction is h.le; the reverse is le_antisymm hupper (dihedralLowerBound_le ...). dihedral_exact_of_upper packages the conditional exact value. Crucially the upper bound is a hypothesis, never a global axiom — #print axioms confirms the file adds 0 axioms beyond the 5 inherited from the parent framework.",
+    "mathContext": "This isolates exactly the Fadell-Husseini equivariant-cohomology upper bound as the only missing ingredient."
+  },
+  {
+    "id": "ann-05-subsumption",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 132,
+      "endLine": 162
+    },
+    "type": "example",
+    "title": "Recovering the parent's D_6 and D_p bounds",
+    "content": "dihedralBUDim_six_ge_buDim_three obtains buDim 3 d ≤ dihedralBUDim 6 d from 3 ∈ (6).primeFactors (via Nat.mem_primeFactors) — no symbolic factorization needed. Rewriting with buDim_prime then gives the parent's Yang-Borsuk bound 2n-1 ≤ dihedralBUDim 6 (2n) (dihedralBUDim_six_yang_borsuk). dihedralBUDim_odd_prime_ge re-derives the parent's D_p bound max(buDim 2 d, buDim p d) ≤ dihedralBUDim p d. The anonymous examples (D_12, D_15 with no factor of 2, and the D_6 tightness reduction) act as regression checks that the uniform machinery specializes correctly.",
+    "mathContext": "$D_{15} \\supseteq \\mathbb{Z}/5$ even though $2 \\nmid 15$: the all-primes sup picks up every prime divisor."
+  }
+]

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,209 @@
+{
+  "id": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+  "title": "Borsuk-Ulam for Dihedral Groups: A Uniform Lower Bound and the Reduction of Tightness to One Upper Bound",
+  "slug": "borsuk-ulam-oq-02-oq-01-oq-03-oq-01",
+  "description": "Addresses the parent's open question on whether the dihedral lower bounds are tight. States the conjectured exact value dihedralBUDim n d = max(buDim 2 d, sup over primes p|n of buDim p d) uniformly in n as a Finset.sup, proves the lower-bound direction for all n with 0 new axioms (reusing only the parent framework's axioms), and proves tightness holds iff a single matching upper bound holds — isolating the open Fadell-Husseini equivariant-cohomology input. Subsumes the parent's case-by-case D_p, D_5, D_6 bounds as corollaries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Borsuk%E2%80%93Ulam_theorem",
+    "date": "2026-06-24",
+    "status": "axiomatized",
+    "tags": [
+      "topology",
+      "borsuk-ulam",
+      "equivariant",
+      "dihedral-groups",
+      "finset-sup",
+      "advanced"
+    ],
+    "proofRepoPath": "Proofs/BorsukUlamOQ02OQ01OQ03OQ01.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 5,
+    "lineCount": 162,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sup_le",
+        "description": "(∀ b ∈ s, f b ≤ a) → s.sup f ≤ a",
+        "module": "Mathlib.Order.Lattice"
+      },
+      {
+        "theorem": "Finset.le_sup",
+        "description": "b ∈ s → f b ≤ s.sup f",
+        "module": "Mathlib.Order.Lattice"
+      },
+      {
+        "theorem": "Nat.mem_primeFactors",
+        "description": "p ∈ n.primeFactors ↔ p.Prime ∧ p ∣ n ∧ n ≠ 0",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.prime_of_mem_primeFactors",
+        "description": "p ∈ n.primeFactors → p.Prime",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.dvd_of_mem_primeFactors",
+        "description": "p ∈ n.primeFactors → p ∣ n",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Nat.max_le",
+        "description": "max a b ≤ c ↔ a ≤ c ∧ b ≤ c",
+        "module": "Mathlib.Order.Defs"
+      }
+    ],
+    "originalContributions": [
+      "dihedralLowerBound: the conjectured exact dihedral BU dimension, expressed uniformly in n as max(buDim 2 d, Finset.sup over n.primeFactors of buDim p d) — a uniform-in-n formula the parent did not formalize",
+      "dihedralLowerBound_le: the general lower bound dihedralLowerBound n d ≤ dihedralBUDim n d for all n ≥ 1, using only the parent's existing axioms (0 new axioms)",
+      "dihedralBUDim_ge_of_prime_dvd: every prime divisor p|n contributes buDim p d ≤ dihedralBUDim n d via Finset.le_sup",
+      "dihedral_tight_iff_upper: tightness (the conjectured equality) holds iff a single matching upper bound holds — isolates exactly the open Fadell-Husseini input",
+      "dihedral_exact_of_upper: the exact dimension, conditional on the (open) upper bound",
+      "dihedralBUDim_six_yang_borsuk, dihedralBUDim_odd_prime_ge: the parent's case-by-case D_6 and D_p bounds re-derived as corollaries of the uniform bound"
+    ],
+    "assumptions": "Declares 0 axioms of its own. All results rest on the parent framework's abstract axiomatization: 5 inherited axioms (buDim, buDim_prime from BorsukUlamOQ02OQ01; dihedralBUDim, dihedral_has_Z2, dihedral_has_rotation_prime from BorsukUlamOQ02OQ01OQ03), confirmed by #print axioms. The matching upper bound that would make the lower bound tight is NOT assumed — it appears only as an explicit hypothesis to dihedral_tight_iff_upper / dihedral_exact_of_upper, and remains genuinely open (requires RO(D_n)-graded equivariant cohomology beyond current Mathlib).",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The equivariant Borsuk-Ulam theorem assigns to a group $G$ acting on representation spheres a 'BU dimension' measuring how strongly equivariant maps are forced to have zeros. For cyclic prime groups $\\mathbb{Z}/p$ the Yang-Borsuk theorem (1954) gives the exact value $\\text{buDim}(\\mathbb{Z}/p, 2k) = 2k-1$, and Bourgin-Conner-Floyd monotonicity ($H \\leq G \\Rightarrow \\text{buDim}(H) \\leq \\text{buDim}(G)$) transfers lower bounds to larger groups. For the dihedral group $D_n$ the prime cyclic subgroups (a reflection $\\mathbb{Z}/2$, and $\\mathbb{Z}/p$ for each $p \\mid n$ inside the rotation $\\mathbb{Z}/n$) give a lower bound, but whether that lower bound is the exact value is a genuinely open question requiring the Fadell-Husseini ideal-valued cohomological index (1988) over the RO($D_n$)-graded equivariant cohomology — beyond current Mathlib.",
+    "problemStatement": "**Open question from BorsukUlamOQ02OQ01OQ03 (openQuestions[0])**:\n\n'Are the dihedral lower bounds tight? Is $\\text{dihedralBUDim}\\,n\\,d = \\max(\\text{buDim}\\,2\\,d,\\ \\max_{p\\ \\text{odd prime}\\,\\mid\\,n} \\text{buDim}\\,p\\,d)$? This would require RO($D_n$)-graded equivariant cohomology to prove the matching upper bound.'",
+    "text": "We give the lower-bound half of the conjecture uniformly in n (a Finset.sup statement the parent proved only case-by-case) and reduce the remaining content to a single upper bound, all without introducing any new axioms.",
+    "proofStrategy": "**Uniform formula.** Define $\\text{dihedralLowerBound}\\,n\\,d = \\max(\\text{buDim}\\,2\\,d,\\ \\bigsqcup_{p \\in n.\\text{primeFactors}} \\text{buDim}\\,p\\,d)$ as a `Finset.sup` over the prime divisors of $n$. Including $p=2$ in the sup is harmless because its contribution $\\text{buDim}\\,2\\,d$ is already the left argument of the outer `max`, so this equals the odd-prime formula in the open question.\n\n**Lower bound (unconditional, 0 new axioms).** `Nat.max_le` splits the goal into the reflection term (parent axiom `dihedral_has_Z2`) and the sup term. `Finset.sup_le` reduces the sup term to a per-prime claim: for $p \\in n.\\text{primeFactors}$, `Nat.prime_of_mem_primeFactors` and `Nat.dvd_of_mem_primeFactors` feed the parent axiom `dihedral_has_rotation_prime`.\n\n**Tightness reduction.** `dihedral_tight_iff_upper` is just `le_antisymm` packaged: the equality is equivalent to the upper bound because the lower bound is already supplied. This pins down that the *only* missing ingredient is the Fadell-Husseini upper bound.\n\n**Subsumption.** The parent's $D_6$ Yang-Borsuk bound and $D_p$ bound fall out by selecting a single prime via `Finset.le_sup` and rewriting with `buDim_prime`.",
+    "keyInsights": [
+      "**The lower bound is uniform in n via Finset.sup.** The parent proved $D_p$, $D_5$, $D_6$ one at a time; packaging the prime contributions as `n.primeFactors.sup (fun p => buDim p d)` gives a single statement valid for every $n$, and `Finset.sup_le` / `Finset.le_sup` are exactly the lattice lemmas needed to push it through and to extract individual primes.",
+      "**Tightness is exactly one upper bound.** `dihedral_tight_iff_upper` shows the conjectured equality is logically equivalent to `dihedralBUDim n d ≤ dihedralLowerBound n d`. Since the lower bound is unconditional, the entire open question collapses to supplying this one Fadell-Husseini upper bound — nothing else is missing.",
+      "**Conditional results keep the axiom budget honest.** The upper bound is introduced as a *hypothesis* to a theorem, not as a global axiom. `#print axioms` confirms the file adds 0 axioms beyond the 5 it inherits from the parent framework; the deep topological input is never silently assumed.",
+      "**Including the prime 2 in the sup is free.** Whether or not $2 \\mid n$, the reflection term $\\text{buDim}\\,2\\,d$ is the left argument of the outer `max`, so the all-primes sup and the odd-primes-only sup of the open question define the same value.",
+      "**Membership beats computation for corollaries.** Rather than evaluating `(6).primeFactors = {2,3}` symbolically, the $D_6$ bound is obtained from `3 ∈ (6).primeFactors` (via `Nat.mem_primeFactors`) and `Finset.le_sup` — avoiding any reduction of the prime-factorization."
+    ],
+    "prerequisites": [
+      "BorsukUlamOQ02OQ01.lean (buDim, buDim_prime, buDim_mono for cyclic groups)",
+      "BorsukUlamOQ02OQ01OQ03.lean (dihedralBUDim, dihedral_has_Z2, dihedral_has_rotation_prime)",
+      "Finset.sup over a SemilatticeSup with OrderBot (ℕ); Nat.primeFactors API"
+    ]
+  },
+  "sections": [
+    {
+      "id": "uniform-formula",
+      "title": "The Conjectured Exact Value, Uniform in n",
+      "startLine": 60,
+      "endLine": 74,
+      "summary": "dihedralLowerBound (n d : ℕ) : ℕ := max (buDim 2 d) (n.primeFactors.sup fun p => buDim p d). Packages the reflection Z/2 contribution and the rotation Z/p contributions (over all prime divisors of n) into a single Finset.sup expression — the value conjectured to equal dihedralBUDim n d.",
+      "mathContext": "$D_n$ contains a reflection $\\mathbb{Z}/2$ and, inside the rotation subgroup $\\mathbb{Z}/n$, a copy of $\\mathbb{Z}/p$ for every prime $p \\mid n$. The conjectured exact BU dimension is $\\max(\\text{buDim}\\,2\\,d,\\ \\bigsqcup_{p \\mid n}\\text{buDim}\\,p\\,d)$."
+    },
+    {
+      "id": "general-lower-bound",
+      "title": "The General Lower Bound (0 New Axioms)",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "dihedralLowerBound_le: for n ≥ 1, dihedralLowerBound n d ≤ dihedralBUDim n d, via Nat.max_le + Finset.sup_le + the parent axioms dihedral_has_Z2 and dihedral_has_rotation_prime. dihedralBUDim_ge_of_prime_dvd extracts the bound for any single prime divisor via Finset.le_sup.",
+      "mathContext": "By subgroup monotonicity each prime cyclic subgroup contributes its Yang-Borsuk bound; `Finset.sup_le` combines them and the reflection $\\mathbb{Z}/2$ gives the remaining term. No topological input beyond the inherited monotonicity axioms is used."
+    },
+    {
+      "id": "tightness-reduction",
+      "title": "Tightness Reduces to a Single Upper Bound",
+      "startLine": 102,
+      "endLine": 130,
+      "summary": "dihedral_tight_iff_upper: dihedralBUDim n d = dihedralLowerBound n d ↔ dihedralBUDim n d ≤ dihedralLowerBound n d. dihedral_exact_of_upper gives the exact value from the (open) upper bound. The upper bound is an explicit hypothesis, never a global axiom.",
+      "mathContext": "Since the lower bound holds unconditionally, `le_antisymm` makes the conjectured equality equivalent to the upper bound $\\text{dihedralBUDim}\\,n\\,d \\leq \\text{dihedralLowerBound}\\,n\\,d$ — the Fadell-Husseini equivariant-cohomology input that remains open."
+    },
+    {
+      "id": "subsumption-corollaries",
+      "title": "The Uniform Bound Subsumes the Parent's Special Cases",
+      "startLine": 132,
+      "endLine": 162,
+      "summary": "dihedralBUDim_six_ge_buDim_three and dihedralBUDim_six_yang_borsuk re-derive the parent's D_6 bounds; dihedralBUDim_odd_prime_ge re-derives the D_p bound max(buDim 2 d, buDim p d) ≤ dihedralBUDim p d. Anonymous examples (D_12, D_15, D_6 tightness) serve as regression checks.",
+      "mathContext": "$D_6 \\supseteq \\mathbb{Z}/3$ gives $\\text{buDim}\\,3\\,(2n) = 2n-1 \\leq \\text{dihedralBUDim}\\,6\\,(2n)$; $D_{15} \\supseteq \\mathbb{Z}/5$ even though $2 \\nmid 15$. These follow from the uniform bound by choosing one prime, without case-specific axioms."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "borsuk-ulam-oq-02-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Answers openQuestions[0] of the parent (whether the dihedral lower bounds are tight): gives the uniform-in-n lower bound and reduces tightness to a single upper bound."
+    },
+    {
+      "targetId": "borsuk-ulam-oq-02-oq-01-oq-04",
+      "relationship": "related",
+      "description": "BorsukUlamOQ02OQ01OQ04 (Fadell-Husseini index) is the cohomological machinery that would supply the missing upper bound isolated by dihedral_tight_iff_upper."
+    }
+  ],
+  "conclusion": {
+    "summary": "The prime-subgroup lower bound for dihedralBUDim is established uniformly in n as a Finset.sup, with 0 new axioms, subsuming the parent's case-by-case bounds. Tightness of this lower bound is shown to be logically equivalent to a single matching upper bound, which remains the open Fadell-Husseini equivariant-cohomology input.",
+    "implications": "The open question 'are the dihedral lower bounds tight?' is reduced to a precise, self-contained statement: supply dihedralBUDim n d ≤ dihedralLowerBound n d. The lower bound, previously proved only for individual n, now holds for all n in one theorem. The conditional theorems make explicit exactly what additional topology is needed without inflating the axiom count.",
+    "openQuestions": [
+      "Prove the matching upper bound dihedralBUDim n d ≤ dihedralLowerBound n d (Fadell-Husseini ideal-valued index over RO(D_n)-graded equivariant cohomology), which by dihedral_tight_iff_upper would close the tightness question for all n.",
+      "Formalize the analogous uniform Finset.sup lower bound for the symmetric groups S_n (sup over primes p ≤ n), the natural counterpart of openQuestions[1] of the parent.",
+      "Is the dihedral lower bound ever strict (dihedralBUDim n d > dihedralLowerBound n d) for some exotic representation, or is tightness universal? A single counterexample or a general upper bound would settle it."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BorsukUlamOQ02OQ01",
+      "Proofs.BorsukUlamOQ02OQ01OQ03"
+    ],
+    "opens": [
+      "BorsukUlamOQ02OQ01",
+      "BorsukUlamNonCyclic",
+      "Nat"
+    ],
+    "namespace": "BorsukUlamDihedralTight",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Fadell, E.R. and Husseini, S.Y.",
+      "title": "An ideal-valued cohomological index theory with applications to Borsuk-Ulam and Bourgin-Yang theorems",
+      "year": "1988",
+      "note": "Ergodic Theory and Dynamical Systems 8*, 73-85. Supplies the upper bound isolated here."
+    },
+    {
+      "authors": "Matoušek, J.",
+      "title": "Using the Borsuk-Ulam Theorem",
+      "year": "2003",
+      "note": "Springer, Berlin. Chapter 6: equivariant methods for non-cyclic groups."
+    },
+    {
+      "authors": "tom Dieck, T.",
+      "title": "Transformation Groups",
+      "year": "1987",
+      "note": "De Gruyter, Berlin. Sections 5.4 and 7.1: RO(G)-graded equivariant cohomology."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "dihedralLowerBound_le",
+      "type": "core",
+      "description": "Uniform prime-subgroup lower bound: dihedralLowerBound n d ≤ dihedralBUDim n d for all n ≥ 1 (0 new axioms)",
+      "leanType": "(n d : ℕ) → 1 ≤ n → dihedralLowerBound n d ≤ dihedralBUDim n d"
+    },
+    {
+      "name": "dihedral_tight_iff_upper",
+      "type": "core",
+      "description": "Tightness is equivalent to a single matching upper bound, isolating the open Fadell-Husseini input",
+      "leanType": "(n d : ℕ) → 1 ≤ n → (dihedralBUDim n d = dihedralLowerBound n d ↔ dihedralBUDim n d ≤ dihedralLowerBound n d)"
+    },
+    {
+      "name": "dihedralBUDim_ge_of_prime_dvd",
+      "type": "supporting",
+      "description": "Each prime divisor p|n contributes buDim p d ≤ dihedralBUDim n d",
+      "leanType": "(n d p : ℕ) → 1 ≤ n → Nat.Prime p → p ∣ n → buDim p d ≤ dihedralBUDim n d"
+    },
+    {
+      "name": "dihedralBUDim_six_yang_borsuk",
+      "type": "supporting",
+      "description": "Parent's D_6 Yang-Borsuk bound 2n-1 ≤ dihedralBUDim 6 (2n) re-derived from the uniform bound",
+      "leanType": "(n : ℕ) → 0 < n → 2 * n - 1 ≤ dihedralBUDim 6 (2 * n)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **openQuestions[0]** of the parent `borsuk-ulam-oq-02-oq-01-oq-03`:
*"Are the dihedral lower bounds tight? Is `dihedralBUDim n d = max(buDim 2 d, max_{p odd prime | n} buDim p d)`?"*

The parent proved the dihedral lower bound only for individual small cases (D_p, D_5, D_6). This entry makes the bound **uniform in n** and reduces the open tightness question to a single inequality — **without adding any new axioms**.

## What's proved

- **`dihedralLowerBound n d := max (buDim 2 d) (n.primeFactors.sup (buDim · d))`** — the conjectured exact value stated uniformly in `n` as a `Finset.sup` over the prime divisors. (Including `p=2` in the sup is harmless: `buDim 2 d` is already the outer `max`'s left argument, so this equals the "odd-prime" formula in the open question.)
- **`dihedralLowerBound_le`** — the lower-bound direction for every `n ≥ 1`, via `Nat.max_le` + `Finset.sup_le` and the parent's existing axioms `dihedral_has_Z2`, `dihedral_has_rotation_prime`.
- **`dihedral_tight_iff_upper`** / **`dihedral_exact_of_upper`** — tightness (the conjectured equality) is logically equivalent to a single matching upper bound. This isolates *exactly* the open Fadell–Husseini equivariant-cohomology input as an explicit hypothesis, never a global axiom.
- **`dihedralBUDim_six_yang_borsuk`**, **`dihedralBUDim_odd_prime_ge`** — the parent's D_6 and D_p bounds re-derived as corollaries of the uniform bound.

## Axiom honesty

The file declares **0 axioms** of its own. `#print axioms` confirms the headline results depend only on the parent framework's 5 abstract axioms (`buDim`, `buDim_prime`, `dihedralBUDim`, `dihedral_has_Z2`, `dihedral_has_rotation_prime`) plus `propext`/`Classical.choice`/`Quot.sound`. No `sorryAx`, no `native_decide`. The missing upper bound is genuinely open (needs RO(D_n)-graded equivariant cohomology, beyond current Mathlib) and is only ever an explicit hypothesis.

Status: `axiomatized` (rests on the parent's abstract framework), badge `axiom`, `axiomCount: 5` (inherited), 0 sorries.

## Verification

- Compiles against pinned Mathlib **v4.26** (`lake env lean`, docker unavailable this session).
- `pnpm annotations:build` clean for `borsuk-ulam-oq-02-oq-01-oq-03-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)