### PR TITLE
Enrich 'Equality Case of Hölder's Inequality' (amgm-inequality-oq-05-oq-01): deepen annotations + sections

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-01/annotations.json
@@ -1,46 +1,62 @@
 [
   {
+    "id": "ann-module-header",
+    "proofId": "amgm-inequality-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "concept",
+    "title": "Module Header: Equality Case of Hölder's Inequality",
+    "content": "Mathlib proves Hölder's inequality for finite sums ($\\sum f_i g_i \\le (\\sum f_i^p)^{1/p}(\\sum g_i^q)^{1/q}$) but does NOT characterize when equality holds. This file fills that gap: writing $F = \\sum f_i^p$, $G = \\sum g_i^q$, equality holds iff the power-vectors $(f_i^p)$ and $(g_i^q)$ are proportional, stated in cross-multiplied form $G\\,f_i^p = F\\,g_i^q$ so it degenerates gracefully when $F = 0$ or $G = 0$. The engine is the equality case of Young's inequality summed pointwise on unit-normalized vectors. All exponents are real, so `^` is `Real.rpow` throughout.",
+    "mathContext": "$\\sum_i f_i g_i = F^{1/p}G^{1/q} \\iff \\forall i,\\ G f_i^p = F g_i^q$, with $F=\\sum f_i^p,\\ G=\\sum g_i^q$ and $p^{-1}+q^{-1}=1$.",
+    "significance": "context",
+    "relatedConcepts": ["Hölder's inequality", "Young's inequality", "equality cases", "Lᵖ/Lq duality", "Real.rpow"],
+    "prerequisites": ["Hölder conjugate exponents", "finite sums", "real powers"]
+  },
+  {
     "id": "ann-young-eq-iff-nonneg",
     "proofId": "amgm-inequality-oq-05-oq-01",
-    "range": {
-      "startLine": 42,
-      "endLine": 58
-    },
+    "range": { "startLine": 37, "endLine": 58 },
     "type": "theorem",
     "title": "young_eq_iff_nonneg: Young equality case for a, b ≥ 0",
-    "content": "Extends the parent entry's Young equality case from a, b > 0 to a, b ≥ 0: a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q. The interior case a, b > 0 delegates to AmgmInequalityOQ05.young_inequality_eq_iff; the boundary cases a = 0 and b = 0 are dispatched directly, where both sides collapse to 'the other variable is 0' (via zero_rpow and div_eq_zero_iff). This full-range version is what is summed in the Hölder argument, since normalized vectors may have zero entries."
+    "content": "Extends the parent entry's Young equality case from a, b > 0 to a, b ≥ 0: a·b = aᵖ/p + b^q/q ↔ aᵖ = b^q. The interior case a, b > 0 delegates to AmgmInequalityOQ05.young_inequality_eq_iff; the boundary cases a = 0 and b = 0 are dispatched directly, where both sides collapse to 'the other variable is 0' (via zero_rpow and div_eq_zero_iff). This full-range version is what is summed in the Hölder argument, since normalized vectors may have zero entries.",
+    "mathContext": "$ab = \\tfrac{a^p}{p} + \\tfrac{b^q}{q} \\iff a^p = b^q$, now for $a,b\\ge 0$ (boundary $a=0$ or $b=0$ included).",
+    "significance": "key",
+    "relatedConcepts": ["Young's inequality equality case", "HolderConjugate", "zero_rpow", "boundary cases"],
+    "prerequisites": ["Young's inequality", "parent entry AmgmInequalityOQ05"]
   },
   {
     "id": "ann-holder-sum-le",
     "proofId": "amgm-inequality-oq-05-oq-01",
-    "range": {
-      "startLine": 62,
-      "endLine": 65
-    },
+    "range": { "startLine": 60, "endLine": 65 },
     "type": "theorem",
     "title": "holder_sum_le: Hölder's inequality for finite sums",
-    "content": "The Hölder inequality itself, ∑ fᵢgᵢ ≤ (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) for nonnegative ℝ-valued f, g, recorded as a re-export of Mathlib's Real.inner_le_Lp_mul_Lq_of_nonneg so the entry is self-contained alongside its equality case."
+    "content": "The Hölder inequality itself, ∑ fᵢgᵢ ≤ (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) for nonnegative ℝ-valued f, g, recorded as a re-export of Mathlib's Real.inner_le_Lp_mul_Lq_of_nonneg so the entry is self-contained alongside its equality case.",
+    "mathContext": "$\\sum_i f_i g_i \\le \\bigl(\\sum_i f_i^p\\bigr)^{1/p}\\bigl(\\sum_i g_i^q\\bigr)^{1/q}$ for $f,g\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.inner_le_Lp_mul_Lq_of_nonneg", "Hölder's inequality", "self-contained re-export"],
+    "prerequisites": ["nonnegative functions on a Finset", "Hölder conjugate exponents"]
   },
   {
     "id": "ann-holder-eq-normalized",
     "proofId": "amgm-inequality-oq-05-oq-01",
-    "range": {
-      "startLine": 73,
-      "endLine": 106
-    },
-    "type": "theorem",
+    "range": { "startLine": 67, "endLine": 106 },
+    "type": "insight",
     "title": "holder_sum_eq_iff_of_normalized: the heart of the equality case",
-    "content": "For unit-norm vectors (∑ fᵢᵖ = ∑ gᵢ^q = 1), Hölder equality ∑ fᵢgᵢ = 1 holds iff fᵢᵖ = gᵢ^q for every i ∈ s. Proof: the slack dᵢ = (fᵢᵖ/p + gᵢ^q/q) − fᵢgᵢ is nonnegative by pointwise Young, and ∑(fᵢᵖ/p + gᵢ^q/q) = 1/p + 1/q = 1, so ∑ dᵢ = 1 − ∑ fᵢgᵢ. Hence ∑ fᵢgᵢ = 1 iff ∑ dᵢ = 0 iff every dᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg) iff each Young inequality is tight iff fᵢᵖ = gᵢ^q (young_eq_iff_nonneg). This localizes the aggregate equality to a pointwise one — the standard nonnegative-slack device."
+    "content": "For unit-norm vectors (∑ fᵢᵖ = ∑ gᵢ^q = 1), Hölder equality ∑ fᵢgᵢ = 1 holds iff fᵢᵖ = gᵢ^q for every i ∈ s. Proof: the slack dᵢ = (fᵢᵖ/p + gᵢ^q/q) − fᵢgᵢ is nonnegative by pointwise Young, and ∑(fᵢᵖ/p + gᵢ^q/q) = 1/p + 1/q = 1, so ∑ dᵢ = 1 − ∑ fᵢgᵢ. Hence ∑ fᵢgᵢ = 1 iff ∑ dᵢ = 0 iff every dᵢ = 0 (Finset.sum_eq_zero_iff_of_nonneg) iff each Young inequality is tight iff fᵢᵖ = gᵢ^q (young_eq_iff_nonneg). This localizes the aggregate equality to a pointwise one — the standard nonnegative-slack device.",
+    "mathContext": "With $\\sum f_i^p=\\sum g_i^q=1$: $\\sum d_i = 1 - \\sum f_i g_i$ where $d_i\\ge 0$; so $\\sum f_i g_i = 1 \\iff \\forall i,\\ f_i^p = g_i^q$.",
+    "significance": "key",
+    "relatedConcepts": ["nonnegative-slack device", "Finset.sum_eq_zero_iff_of_nonneg", "pointwise Young", "inv_add_inv_eq_one"],
+    "prerequisites": ["young_eq_iff_nonneg", "sums of nonnegative terms vanish termwise"]
   },
   {
     "id": "ann-holder-eq-general",
     "proofId": "amgm-inequality-oq-05-oq-01",
-    "range": {
-      "startLine": 119,
-      "endLine": 199
-    },
-    "type": "theorem",
+    "range": { "startLine": 108, "endLine": 199 },
+    "type": "insight",
     "title": "holder_sum_eq_iff: equality iff power-vectors are proportional",
-    "content": "The headline result. With F = ∑ fᵢᵖ and G = ∑ gᵢ^q, equality ∑ fᵢgᵢ = F^(1/p)·G^(1/q) holds iff (∑ gⱼ^q)·fᵢᵖ = (∑ fⱼᵖ)·gᵢ^q for all i — i.e. (fᵢᵖ) and (gᵢ^q) are proportional. When F, G > 0 the proof rescales by cF = F^(1/p), cG = G^(1/q): the identity (cF)ᵖ = F (rpow arithmetic) makes f/cF, g/cG unit-norm, the normalized theorem applies, and div_eq_div_iff converts fᵢᵖ/F = gᵢ^q/G into the cross-multiplied form. The degenerate F = 0 (all fᵢ = 0) and G = 0 cases hold trivially on both sides; cross-multiplication keeps the condition well-posed there."
+    "content": "The headline result. With F = ∑ fᵢᵖ and G = ∑ gᵢ^q, equality ∑ fᵢgᵢ = F^(1/p)·G^(1/q) holds iff (∑ gⱼ^q)·fᵢᵖ = (∑ fⱼᵖ)·gᵢ^q for all i — i.e. (fᵢᵖ) and (gᵢ^q) are proportional. When F, G > 0 the proof rescales by cF = F^(1/p), cG = G^(1/q): the identity (cF)ᵖ = F (rpow arithmetic) makes f/cF, g/cG unit-norm, the normalized theorem applies, and div_eq_div_iff converts fᵢᵖ/F = gᵢ^q/G into the cross-multiplied form. The degenerate F = 0 (all fᵢ = 0) and G = 0 cases hold trivially on both sides; cross-multiplication keeps the condition well-posed there.",
+    "mathContext": "$\\sum f_i g_i = F^{1/p}G^{1/q} \\iff \\forall i,\\ G f_i^p = F g_i^q$; rescale by $c_F=F^{1/p}$ ($c_F^p = F$) to the normalized case, then $\\tfrac{f_i^p}{F}=\\tfrac{g_i^q}{G}$.",
+    "significance": "key",
+    "relatedConcepts": ["proportional power-vectors", "Real.div_rpow", "div_eq_div_iff", "rescaling to unit norm", "degenerate cases"],
+    "prerequisites": ["the normalized equality case", "Real.rpow arithmetic (rpow_mul, div_rpow)"]
   }
 ]

--- a/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-01/meta.json
@@ -48,6 +48,48 @@
       "Finset.sum_eq_zero_iff_of_nonneg: a finite sum of nonnegative terms is zero iff each term is zero"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Docstring stating that Mathlib proves Hölder's finite-sum inequality but not its equality case, and that this file characterizes equality as proportionality of the power-vectors (fᵢᵖ) and (gᵢ^q), in cross-multiplied form G·fᵢᵖ = F·gᵢ^q (degenerating gracefully at F = 0 or G = 0). Notes the engine is the summed equality case of Young's inequality and that ^ is Real.rpow. Verified (0 sorries, 0 axioms).",
+      "mathContext": "$\\sum f_i g_i = F^{1/p}G^{1/q}\\iff\\forall i,\\ Gf_i^p = Fg_i^q$."
+    },
+    {
+      "id": "sec-young",
+      "title": "Young Equality Case (nonnegative form)",
+      "startLine": 37,
+      "endLine": 58,
+      "summary": "young_eq_iff_nonneg: ab = aᵖ/p + b^q/q ⟺ aᵖ = b^q for a, b ≥ 0, extending the parent's a, b > 0 version by dispatching the boundary cases a = 0, b = 0 (via zero_rpow, div_eq_zero_iff). Needed because normalized vectors can have zero entries.",
+      "mathContext": "$ab=\\tfrac{a^p}{p}+\\tfrac{b^q}{q}\\iff a^p=b^q$ for $a,b\\ge 0$."
+    },
+    {
+      "id": "sec-holder-le",
+      "title": "Hölder's Inequality (re-export)",
+      "startLine": 60,
+      "endLine": 65,
+      "summary": "holder_sum_le: ∑ fᵢgᵢ ≤ (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) for nonnegative f, g, re-exported from Real.inner_le_Lp_mul_Lq_of_nonneg so the equality case sits alongside the inequality.",
+      "mathContext": "$\\sum f_i g_i \\le (\\sum f_i^p)^{1/p}(\\sum g_i^q)^{1/q}$."
+    },
+    {
+      "id": "sec-normalized",
+      "title": "Equality Case — Normalized Form",
+      "startLine": 67,
+      "endLine": 106,
+      "summary": "holder_sum_eq_iff_of_normalized: for ∑ fᵢᵖ = ∑ gᵢ^q = 1, equality ∑ fᵢgᵢ = 1 ⟺ fᵢᵖ = gᵢ^q ∀ i. The slack dᵢ = (fᵢᵖ/p + gᵢ^q/q) − fᵢgᵢ ≥ 0 sums to 1 − ∑ fᵢgᵢ, so equality ⟺ ∑ dᵢ = 0 ⟺ every dᵢ = 0 ⟺ each Young inequality is tight (the nonnegative-slack device).",
+      "mathContext": "$\\sum d_i = 1-\\sum f_i g_i,\\ d_i\\ge 0\\Rightarrow$ equality $\\iff\\forall i,\\ f_i^p=g_i^q$."
+    },
+    {
+      "id": "sec-general",
+      "title": "Equality Case — General Form",
+      "startLine": 108,
+      "endLine": 200,
+      "summary": "holder_sum_eq_iff: ∑ fᵢgᵢ = F^(1/p)G^(1/q) ⟺ ∀ i, G·fᵢᵖ = F·gᵢ^q (proportional power-vectors). For F, G > 0, rescale by cF = F^(1/p), cG = G^(1/q) (cF^p = F) to unit-norm vectors, apply the normalized theorem, and convert fᵢᵖ/F = gᵢ^q/G to cross-multiplied form via div_eq_div_iff. Degenerate F = 0 / G = 0 cases hold trivially.",
+      "mathContext": "$\\sum f_i g_i = F^{1/p}G^{1/q}\\iff\\forall i,\\ Gf_i^p=Fg_i^q$; rescale to unit norm."
+    }
+  ],
   "conclusion": {
     "summary": "The equality case of Hölder's inequality for finite sums is fully verified: 4 theorems, 0 definitions, 0 axioms, 0 sorries. The inequality is re-exported from Mathlib; the new content is the equality characterization — ∑ fᵢgᵢ = (∑ fᵢᵖ)^(1/p)(∑ gᵢ^q)^(1/q) iff the power-vectors (fᵢᵖ), (gᵢ^q) are proportional — proved by summing the parent entry's pointwise Young equality case over rescaled (unit-norm) vectors, with the degenerate zero-norm cases dispatched directly.",
     "implications": "This completes, for finite sums, the equality-case program initiated for Young's inequality: it pins down exactly when the Hölder estimate is tight, recovering the Cauchy–Schwarz linear-dependence condition at p = q = 2. The normalized form holder_sum_eq_iff_of_normalized is reusable infrastructure for any tightness analysis of Hölder-type bounds, and the proof exhibits the canonical pattern (sum a pointwise sharp inequality; a vanishing nonnegative slack-sum localizes equality to every index).",


### PR DESCRIPTION
Enrichment (deepening) pass for `amgm-inequality-oq-05-oq-01` (quality 56, 0 prior passes).

## Gaps addressed
The entry had 4 detailed annotations but **none carried `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**, and meta.json had **no `sections` array**.

1. **Deepened all annotations** — added the 4 structured fields to each (preserving existing prose).
2. **Added a module-header annotation**, giving **5 annotations** (header; Young equality case; Hölder re-export; normalized equality case; general/proportional form).
3. **Added a `sections` array** to meta.json covering all five source sections.

## Verification
- meta.json and annotations.json validate as JSON; `pnpm annotations:build` reports no errors for this entry (ranges snapped to Lean constructs).
- Axiom integrity preserved: meta declares `status: verified`, `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom decls, no native_decide). No claims changed.