### PR TITLE
research(british-flag-theorem-oq-01-oq-02-oq-01): general parallelepiped defect formula [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BritishFlagParallelepipedOQ010201.lean
+++ b/proofs/Proofs/BritishFlagParallelepipedOQ010201.lean
@@ -1,0 +1,300 @@
+/-
+  British Flag Defect for a General (Non-Orthogonal) Parallelepiped
+  Open Question: british-flag-theorem-oq-01-oq-02-oq-01
+
+  The parent entry (`british-flag-theorem-oq-01-oq-02`) proves the British Flag
+  defect identity for an *axis-aligned box* (orthotope) in `n` dimensions: the
+  alternating sum of squared distances over the `2ⁿ` vertices,
+
+      ∑_{t ⊆ {0,…,n-1}} (-1)^{|t|} · ‖X − vertex t‖²,
+
+  vanishes for every `n ≥ 2`. A box has mutually orthogonal edge vectors, so all
+  pairwise inner products are zero.
+
+  This file removes the orthogonality assumption. Fix a base point `c` and edge
+  vectors `u₀,…,u_{n-1}` in a real inner product space `V`. The parallelepiped
+  vertex indexed by `t ⊆ {0,…,n-1}` is
+
+      vertex t = c + ∑_{i ∈ t} uᵢ,
+
+  and for an observer `X` we study the alternating squared-distance defect
+
+      defect = ∑_{t} (-1)^{|t|} · ‖X − vertex t‖².
+
+  ## Why a clean defect formula exists
+
+  Writing `w = X − c`, expanding `‖X − vertex t‖² = ‖w − ∑_{i∈t} uᵢ‖²` shows that
+  `sqDist t` is a polynomial of **degree ≤ 2** in the membership indicators
+  `[i ∈ t]`:
+
+      sqDist t = ‖w‖²  −  2 ∑_{i∈t} ⟪w, uᵢ⟫  +  ∑_{i∈t} ∑_{j∈t} ⟪uᵢ, uⱼ⟫.
+
+  The operator `g ↦ ∑_t (-1)^{|t|} g t` is (up to sign) the `n`-th iterated finite
+  difference; it annihilates every monomial in the indicators that omits at least
+  one coordinate. Hence:
+
+  * **`n ≥ 3`**: every term has degree ≤ 2 < n, so the defect is **identically 0**,
+    independent of the observer `X`, the base `c`, and the (arbitrary, possibly
+    skew) edge vectors. This is the general defect formula requested by the open
+    question — the orthotope of the parent is just the special case where the
+    `⟪uᵢ,uⱼ⟫` happen to vanish.
+  * **`n = 2`**: the only surviving monomial is `[0 ∈ t][1 ∈ t]`, giving the defect
+    `2 ⟪u₀, u₁⟫`. For orthogonal edges this is `0`, recovering the classical
+    British Flag Theorem; in general it measures the failure of orthogonality.
+
+  ## Main results
+
+  * `alt_sum_eq_zero_of_indep` — structural heart: if `g` does not depend on a
+    coordinate `k`, the signed powerset sum `∑_t (-1)^{|t|} g t` vanishes
+    (pairing `s` with `insert k s`).
+  * `sqDist_expand` — the degree-≤2 inner-product expansion of `‖X − vertex t‖²`.
+  * `parallelepiped_defect_eq_zero` — for `n ≥ 3`, `defect = 0`.
+  * `parallelepiped_defect_two` — for `n = 2`, `defect = 2 ⟪u 0, u 1⟫`.
+  * `parallelepiped_defect_two_orthogonal` — orthogonal edges (`n = 2`) ⟹ defect
+    `0`, the British Flag Theorem, unifying with the parent.
+
+  Everything is `sorry`-free and axiom-free.
+-/
+
+import Mathlib
+
+open Finset
+open scoped RealInnerProductSpace
+
+namespace BritishFlagParallelepipedOQ010201
+
+variable {n : ℕ} {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-- The vertex of the parallelepiped with base `c` and edge vectors `u`, indexed by
+    `t`: starting from `c`, add the edges `uᵢ` for `i ∈ t`. -/
+def pVertex (c : V) (u : Fin n → V) (t : Finset (Fin n)) : V :=
+  c + ∑ i ∈ t, u i
+
+/-- Squared Euclidean distance from the observer `X` to the parallelepiped vertex
+    indexed by `t`. -/
+def sqDist (X c : V) (u : Fin n → V) (t : Finset (Fin n)) : ℝ :=
+  ‖X - pVertex c u t‖ ^ 2
+
+/-- The British Flag defect: the alternating (`(-1)^{|t|}`-weighted) sum of squared
+    distances over all `2ⁿ` vertices of the parallelepiped. -/
+def defect (X c : V) (u : Fin n → V) : ℝ :=
+  ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * sqDist X c u t
+
+/-! ### Structural heart: alternating powerset sums kill coordinate-independent functions -/
+
+/-- **Structural heart.** If `g t` does not change when the coordinate `k` is
+    inserted into a `k`-free set, then the signed powerset sum vanishes. The
+    powerset of `univ` splits into the subsets `s ⊆ univ.erase k` and their images
+    `insert k s`; the two have equal `g`-value but opposite sign `(-1)^{|·|}`, so
+    they cancel in pairs. -/
+theorem alt_sum_eq_zero_of_indep (k : Fin n) (g : Finset (Fin n) → ℝ)
+    (hg : ∀ s : Finset (Fin n), k ∉ s → g (insert k s) = g s) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * g t = 0 := by
+  classical
+  set E := (univ : Finset (Fin n)).erase k with hE
+  have hins : (univ : Finset (Fin n)) = insert k E := (insert_erase (mem_univ k)).symm
+  have hk : k ∉ E := notMem_erase k univ
+  have hinj : Set.InjOn (insert k) (E.powerset : Set (Finset (Fin n))) := by
+    intro a ha b hb hab
+    rw [Finset.mem_coe, mem_powerset] at ha hb
+    have hka : k ∉ a := fun h => hk (ha h)
+    have hkb : k ∉ b := fun h => hk (hb h)
+    have := congrArg (·.erase k) hab
+    simpa [erase_insert hka, erase_insert hkb] using this
+  have hdisj : Disjoint E.powerset (E.powerset.image (insert k)) := by
+    rw [Finset.disjoint_left]
+    intro t ht htimg
+    rw [mem_powerset] at ht
+    rw [mem_image] at htimg
+    obtain ⟨v, _, rfl⟩ := htimg
+    exact hk (ht (mem_insert_self k v))
+  rw [hins, powerset_insert, sum_union hdisj, sum_image hinj]
+  -- second sum: insert k s has card |s|+1 and equal g-value, so it negates the first
+  have hsecond : ∑ s ∈ E.powerset, (-1 : ℝ) ^ (insert k s).card * g (insert k s)
+               = ∑ s ∈ E.powerset, -((-1 : ℝ) ^ s.card * g s) := by
+    apply sum_congr rfl
+    intro s hs
+    rw [mem_powerset] at hs
+    have hks : k ∉ s := fun h => hk (hs h)
+    rw [card_insert_of_notMem hks, hg s hks, pow_succ]
+    ring
+  rw [hsecond, sum_neg_distrib, add_neg_cancel]
+
+/-! ### Existence of an unused coordinate -/
+
+/-- For `n ≥ 2` there is a coordinate distinct from any given one. -/
+theorem exists_coord_ne (hn : 2 ≤ n) (i : Fin n) : ∃ k : Fin n, k ≠ i := by
+  haveI : Nontrivial (Fin n) := Fin.nontrivial_iff_two_le.mpr hn
+  exact _root_.exists_ne i
+
+/-- For `n ≥ 3` there is a coordinate distinct from any two given ones. -/
+theorem exists_coord_ne_two (hn : 3 ≤ n) (i j : Fin n) : ∃ k : Fin n, k ≠ i ∧ k ≠ j := by
+  classical
+  by_contra h
+  push_neg at h
+  have hsub : (univ : Finset (Fin n)) ⊆ {i, j} := by
+    intro k _
+    rcases eq_or_ne k i with hki | hki
+    · simp [hki]
+    · have := h k hki
+      simp [this]
+  have hc := Finset.card_le_card hsub
+  rw [Finset.card_univ, Fintype.card_fin] at hc
+  have hpair : ({i, j} : Finset (Fin n)).card ≤ 2 :=
+    (Finset.card_insert_le _ _).trans (by simp)
+  omega
+
+/-! ### Inner-product expansion of the squared distance -/
+
+/-- `sqDist` is a degree-≤2 polynomial in the membership indicators: it expands as
+    `‖w‖² − 2 ∑_{i∈t} ⟪w,uᵢ⟫ + ∑_{i∈t} ∑_{j∈t} ⟪uᵢ,uⱼ⟫` where `w = X − c`. -/
+theorem sqDist_expand (X c : V) (u : Fin n → V) (t : Finset (Fin n)) :
+    sqDist X c u t
+      = ‖X - c‖ ^ 2 - 2 * (∑ i ∈ t, ⟪X - c, u i⟫)
+        + ∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫ := by
+  have hsub : X - pVertex c u t = (X - c) - ∑ i ∈ t, u i := by
+    simp only [pVertex]; abel
+  -- expand ‖∑ uᵢ‖² = ⟪∑,∑⟫ = ∑∑⟪uᵢ,uⱼ⟫ as a standalone equation to avoid touching ‖w‖²
+  have hnorm : ‖∑ i ∈ t, u i‖ ^ 2 = ∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫ := by
+    rw [← real_inner_self_eq_norm_sq, sum_inner]
+    simp_rw [inner_sum]
+  rw [sqDist, hsub, norm_sub_sq_real, inner_sum, hnorm]
+
+/-! ### The three monomial pieces vanish -/
+
+/-- The constant piece `‖w‖² · ∑_t (-1)^{|t|}` vanishes for `n ≥ 1`. -/
+theorem const_term_zero (hn : 1 ≤ n) (r : ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * r = 0 := by
+  have : Nonempty (Fin n) := ⟨⟨0, by omega⟩⟩
+  obtain ⟨k⟩ := this
+  exact alt_sum_eq_zero_of_indep k (fun _ => r) (fun _ _ => rfl)
+
+/-- The linear piece `∑_t (-1)^{|t|} ∑_{i∈t} a i` vanishes for `n ≥ 2`. -/
+theorem linear_term_zero (hn : 2 ≤ n) (a : Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, a i) = 0 := by
+  classical
+  -- rewrite ∑_{i∈t} a i as a sum over univ with an indicator, push the sign in, swap
+  have hrw : ∀ t : Finset (Fin n),
+      (∑ i ∈ t, a i) = ∑ i, (if i ∈ t then a i else 0) := fun t => by
+    rw [Finset.sum_ite_mem_eq]
+  simp_rw [hrw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro i _
+  obtain ⟨k, hk⟩ := exists_coord_ne hn i
+  refine alt_sum_eq_zero_of_indep k (fun t => if i ∈ t then a i else 0) ?_
+  intro s hks
+  have e1 : i ∈ insert k s ↔ i ∈ s := by
+    simp only [mem_insert]; exact or_iff_right (fun h => hk h.symm)
+  simp only [e1]
+
+/-- The quadratic piece `∑_t (-1)^{|t|} ∑_{i∈t} ∑_{j∈t} b i j` vanishes for `n ≥ 3`. -/
+theorem quadratic_term_zero (hn : 3 ≤ n) (b : Fin n → Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, b i j) = 0 := by
+  classical
+  -- rewrite the double `∑_{i∈t}∑_{j∈t}` as a double `∑_i ∑_j` of indicators
+  have hrw : ∀ t : Finset (Fin n),
+      (∑ i ∈ t, ∑ j ∈ t, b i j)
+        = ∑ i, ∑ j, (if i ∈ t ∧ j ∈ t then b i j else 0) := by
+    intro t
+    have inner : ∀ i, (∑ j ∈ t, b i j) = ∑ j, if j ∈ t then b i j else 0 :=
+      fun i => (Finset.sum_ite_mem_eq t (b i)).symm
+    simp_rw [inner]
+    rw [← Finset.sum_ite_mem_eq t (fun i => ∑ j, if j ∈ t then b i j else 0)]
+    apply Finset.sum_congr rfl
+    intro i _
+    by_cases hi : i ∈ t
+    · rw [if_pos hi]
+      apply Finset.sum_congr rfl
+      intro j _
+      by_cases hj : j ∈ t
+      · rw [if_pos hj, if_pos ⟨hi, hj⟩]
+      · rw [if_neg hj, if_neg (by tauto)]
+    · rw [if_neg hi, eq_comm]
+      apply Finset.sum_eq_zero
+      intro j _
+      rw [if_neg (by tauto)]
+  simp_rw [hrw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro i _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro j _
+  obtain ⟨k, hki, hkj⟩ := exists_coord_ne_two hn i j
+  refine alt_sum_eq_zero_of_indep k (fun t => if i ∈ t ∧ j ∈ t then b i j else 0) ?_
+  intro s hks
+  have e1 : i ∈ insert k s ↔ i ∈ s := by
+    simp only [mem_insert]; exact or_iff_right (fun h => hki h.symm)
+  have e2 : j ∈ insert k s ↔ j ∈ s := by
+    simp only [mem_insert]; exact or_iff_right (fun h => hkj h.symm)
+  simp only [e1, e2]
+
+/-! ### Main theorems -/
+
+/-- **General defect formula, `n ≥ 3`.** For any parallelepiped in a real inner
+    product space with base `c`, arbitrary (possibly skew) edge vectors `u`, and
+    any observer `X`, the alternating squared-distance defect over the `2ⁿ`
+    vertices is identically zero whenever `n ≥ 3`. This is the requested general
+    defect formula: it holds for *every* configuration, the orthotope of the parent
+    being the special case in which the pairwise inner products vanish. -/
+theorem parallelepiped_defect_eq_zero (hn : 3 ≤ n) (X c : V) (u : Fin n → V) :
+    defect X c u = 0 := by
+  unfold defect
+  simp_rw [sqDist_expand, mul_add, mul_sub]
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  rw [const_term_zero (by omega) (‖X - c‖ ^ 2),
+      quadratic_term_zero hn (fun i j => ⟪u i, u j⟫)]
+  have hmid : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (2 * ∑ i ∈ t, ⟪X - c, u i⟫) = 0 := by
+    have h : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (2 * ∑ i ∈ t, ⟪X - c, u i⟫)
+          = 2 * ((-1 : ℝ) ^ t.card * ∑ i ∈ t, ⟪X - c, u i⟫) := fun t => by ring
+    simp_rw [h]
+    rw [← Finset.mul_sum, linear_term_zero (by omega) (fun i => ⟪X - c, u i⟫), mul_zero]
+  rw [hmid]; ring
+
+/-- Enumeration of the `n = 2` quadratic piece: the four subsets of `{0,1}` give
+    `b 0 1 + b 1 0`. -/
+theorem quadSum_two (b : Fin 2 → Fin 2 → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin 2)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, b i j)
+      = b 0 1 + b 1 0 := by
+  have hps : (univ : Finset (Fin 2)).powerset = {∅, {0}, {1}, {0, 1}} := by decide
+  rw [hps, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide)]
+  simp only [Finset.card_empty, Finset.card_singleton, Finset.sum_empty,
+    Finset.sum_singleton, Finset.sum_pair (by decide : (0 : Fin 2) ≠ 1),
+    Finset.card_pair (by decide : (0 : Fin 2) ≠ 1)]
+  ring
+
+/-- **`n = 2` defect.** For a (possibly skew) parallelogram with edge vectors
+    `u 0, u 1`, the alternating squared-distance defect equals `2 ⟪u 0, u 1⟫`,
+    independent of the observer `X` and the base `c`. -/
+theorem parallelepiped_defect_two (X c : V) (u : Fin 2 → V) :
+    defect X c u = 2 * ⟪u 0, u 1⟫ := by
+  unfold defect
+  simp_rw [sqDist_expand, mul_add, mul_sub]
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  rw [const_term_zero (by omega) (‖X - c‖ ^ 2)]
+  have hmid : ∑ t ∈ (univ : Finset (Fin 2)).powerset,
+      (-1 : ℝ) ^ t.card * (2 * ∑ i ∈ t, ⟪X - c, u i⟫) = 0 := by
+    have h : ∀ t : Finset (Fin 2),
+        (-1 : ℝ) ^ t.card * (2 * ∑ i ∈ t, ⟪X - c, u i⟫)
+          = 2 * ((-1 : ℝ) ^ t.card * ∑ i ∈ t, ⟪X - c, u i⟫) := fun t => by ring
+    simp_rw [h]
+    rw [← Finset.mul_sum, linear_term_zero (by omega) (fun i => ⟪X - c, u i⟫), mul_zero]
+  rw [hmid, quadSum_two (fun i j => ⟪u i, u j⟫), real_inner_comm (u 0) (u 1)]
+  ring
+
+/-- **Recovery of the British Flag Theorem.** For `n = 2` with orthogonal edges
+    (`⟪u 0, u 1⟫ = 0`) the defect vanishes — the classical British Flag Theorem,
+    unifying this entry with the orthotope parent. -/
+theorem parallelepiped_defect_two_orthogonal (X c : V) (u : Fin 2 → V)
+    (h : ⟪u 0, u 1⟫ = 0) :
+    defect X c u = 0 := by
+  rw [parallelepiped_defect_two, h, mul_zero]
+
+end BritishFlagParallelepipedOQ010201

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "ann-bftoq010201-header",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 81
+    },
+    "type": "concept",
+    "title": "Module Overview: Defect of a General Parallelepiped",
+    "content": "This module answers the parent orthotope entry's first open question: drop the right angles. A parallelepiped in a real inner product space V is given by a base point c and edge vectors u : Fin n → V; the vertex indexed by t ⊆ {0,…,n−1} is `pVertex c u t = c + ∑_{i∈t} uᵢ`. The British Flag defect is the alternating sum `defect X c u = ∑_t (−1)^{|t|}·‖X − pVertex c u t‖²` over the 2ⁿ vertices. The key observation is that this squared distance is a polynomial of degree ≤ 2 in the membership indicators [i ∈ t], and the alternating powerset sum is the n-th iterated finite difference, which annihilates everything of degree < n. So the defect is identically 0 for n ≥ 3 and equals 2⟪u₀,u₁⟫ for n = 2.",
+    "mathContext": "Unlike the parent's axis-aligned box, the edge vectors uᵢ are arbitrary, so the pairwise inner products ⟪uᵢ,uⱼ⟫ — the quadratic coefficients of the squared-distance polynomial — need not vanish. The parent orthotope is the special case where they all do.",
+    "significance": "key",
+    "relatedConcepts": [
+      "British Flag Theorem",
+      "parallelepiped",
+      "inner product space",
+      "finite differences",
+      "Boolean cube vertices"
+    ],
+    "prerequisites": [
+      "Real inner product spaces and squared distance",
+      "Finset (Fin n) as a vertex index over the 2ⁿ vertices"
+    ]
+  },
+  {
+    "id": "ann-bftoq010201-heart",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 121
+    },
+    "type": "technique",
+    "title": "Structural Heart: Finite-Difference Annihilation",
+    "content": "`alt_sum_eq_zero_of_indep` is the engine: if a function g : Finset (Fin n) → ℝ does not change when a coordinate k is inserted into a k-free set (g (insert k s) = g s for k ∉ s), then ∑_t (−1)^{|t|}·g t = 0. The proof writes univ = insert k (univ∖{k}) and uses `Finset.powerset_insert` to split the powerset into the subsets s ⊆ univ∖{k} and their images insert k s. These pair up: since card(insert k s) = |s|+1 and g agrees on the pair, the (−1)^{|t|} weights are opposite, so the second sum is the negation of the first and they cancel.",
+    "mathContext": "This is precisely the statement that the n-th iterated finite difference (the alternating sum over the Boolean cube) annihilates any function that is constant in at least one coordinate — equivalently, any indicator monomial that omits a coordinate.",
+    "significance": "key",
+    "relatedConcepts": [
+      "iterated finite differences",
+      "inclusion–exclusion",
+      "powerset_insert",
+      "sign-reversing involution",
+      "Boolean cube"
+    ],
+    "prerequisites": [
+      "Splitting a powerset by membership of a fixed element",
+      "Reindexing a subset sum by insert"
+    ]
+  },
+  {
+    "id": "ann-bftoq010201-exists",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 145
+    },
+    "type": "technique",
+    "title": "Unused Coordinates and the Dimension Thresholds",
+    "content": "`exists_coord_ne` (n ≥ 2 gives some k ≠ i) and `exists_coord_ne_two` (n ≥ 3 gives some k distinct from both i and j) supply the free coordinate that the finite-difference lemma consumes. The two-coordinate version is a short counting argument: if every coordinate equalled i or j then univ ⊆ {i,j}, forcing n = #univ ≤ #{i,j} ≤ 2, contradicting n ≥ 3.",
+    "mathContext": "A degree-d indicator monomial constrains d coordinates; it has a free coordinate exactly when n > d. These lemmas make the thresholds n ≥ 2 (linear, d = 1) and n ≥ 3 (quadratic, d = 2) explicit.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole",
+      "Fintype.card",
+      "Nontrivial (Fin n)",
+      "degree vs dimension"
+    ],
+    "prerequisites": [
+      "Finset cardinality bounds",
+      "card_le_card for subsets"
+    ]
+  },
+  {
+    "id": "ann-bftoq010201-expand",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 147,
+      "endLine": 160
+    },
+    "type": "technique",
+    "title": "Squared Distance as a Degree-2 Polynomial",
+    "content": "`sqDist_expand` rewrites X − pVertex c u t = (X − c) − ∑_{i∈t} uᵢ, applies polarization (`norm_sub_sq_real`: ‖a − b‖² = ‖a‖² − 2⟪a,b⟫ + ‖b‖²), and expands the edge-sum norm via `real_inner_self_eq_norm_sq` and inner-product bilinearity (`inner_sum`, `sum_inner`). The result, ‖X−c‖² − 2∑_{i∈t}⟪X−c,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫, exhibits the squared distance as a quadratic in the indicators [i ∈ t] with coefficients ‖w‖² (constant), ⟪w,uᵢ⟫ (linear), ⟪uᵢ,uⱼ⟫ (quadratic).",
+    "mathContext": "Making the polynomial degree explicit is the whole point: the finite-difference operator's behaviour depends only on the degree, so this expansion reduces the geometry to bookkeeping over three monomial classes.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polarization identity",
+      "bilinearity of the inner product",
+      "norm_sub_sq_real",
+      "real_inner_self_eq_norm_sq"
+    ],
+    "prerequisites": [
+      "Inner product expansion of ‖x − y‖²",
+      "Distributing the inner product over Finset sums"
+    ]
+  },
+  {
+    "id": "ann-bftoq010201-pieces",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 163,
+      "endLine": 234
+    },
+    "type": "technique",
+    "title": "The Three Monomial Pieces Vanish",
+    "content": "`const_term_zero` (n ≥ 1), `linear_term_zero` (n ≥ 2), and `quadratic_term_zero` (n ≥ 3) show each piece of the expansion has zero alternating sum. The constant piece is immediate (g is coordinate-independent). For the linear and quadratic pieces, the membership-restricted sums ∑_{i∈t} are first turned into indicator sums over univ (`Finset.sum_ite_mem_eq`), the (−1)^{|t|} weight is pushed inside, and the powerset sum is swapped innermost (`Finset.sum_comm`). Each resulting monomial — an indicator in i, or in i and j — is independent of some unused coordinate, so `alt_sum_eq_zero_of_indep` makes it vanish.",
+    "mathContext": "The degree-d piece needs one free coordinate, available exactly when n > d. This is where the dichotomy is decided: at n ≥ 3 all three vanish; at n = 2 the quadratic off-diagonal monomial [0∈t][1∈t] is the full cube and survives.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum_ite_mem_eq",
+      "sum_comm",
+      "monomial decomposition",
+      "degree-vs-dimension threshold"
+    ],
+    "prerequisites": [
+      "Indicator reformulation of restricted sums",
+      "Swapping order of double and triple sums"
+    ]
+  },
+  {
+    "id": "ann-bftoq010201-main",
+    "proofId": "british-flag-theorem-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 235,
+      "endLine": 300
+    },
+    "type": "main-result",
+    "title": "Main Theorems: General Defect Formula",
+    "content": "`parallelepiped_defect_eq_zero` (n ≥ 3 ⟹ defect = 0) distributes the alternating sum over the three pieces via `Finset.sum_add_distrib`/`sum_sub_distrib`, each vanishing by the previous lemmas — the general defect formula the parent asked for, holding for every parallelepiped with no orthogonality hypothesis. `quadSum_two` enumerates the four subsets of {0,1} to evaluate the n = 2 quadratic piece as ⟪u₀,u₁⟫ + ⟪u₁,u₀⟫. `parallelepiped_defect_two` (n = 2 ⟹ defect = 2⟪u₀,u₁⟫) combines the vanishing constant/linear pieces with quadSum_two and `real_inner_comm`. `parallelepiped_defect_two_orthogonal` specializes to ⟪u₀,u₁⟫ = 0, recovering the classical British Flag Theorem.",
+    "mathContext": "The n ≥ 3 result is observer-, base-, and edge-independent (it is the constant 0); the n = 2 result is the parallelogram defect; the orthogonal corollary closes the loop with the parent orthotope and the grandparent rectangle.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum_add_distrib",
+      "real_inner_comm",
+      "British Flag Theorem recovery",
+      "parallelogram defect 2⟪u,v⟫"
+    ],
+    "prerequisites": [
+      "Linearity of the alternating sum over the three pieces",
+      "Symmetry ⟪u₁,u₀⟫ = ⟪u₀,u₁⟫ of the real inner product"
+    ]
+  }
+]

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,232 @@
+{
+  "id": "british-flag-theorem-oq-01-oq-02-oq-01",
+  "title": "British Flag Defect for a General Non-Orthogonal Parallelepiped",
+  "slug": "british-flag-theorem-oq-01-oq-02-oq-01",
+  "description": "Answers the parent orthotope entry's first open question: drop the right angles. For a parallelepiped in a real inner product space with base point c and arbitrary edge vectors u₀,…,u_{n−1}, the vertex indexed by t ⊆ {0,…,n−1} is c + ∑_{i∈t} uᵢ, and the British Flag defect is the alternating sum ∑_t (−1)^{|t|}·‖X − vertex t‖² over the 2ⁿ vertices. Writing w = X − c, the squared distance is a degree-≤2 polynomial in the membership indicators [i ∈ t]: ‖w‖² − 2∑_{i∈t}⟪w,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫. The alternating powerset sum is the n-th iterated finite difference, which annihilates every monomial omitting a coordinate. Hence for n ≥ 3 the defect is identically 0 — independent of the observer X, the base c, and the (possibly skew) edges — and for n = 2 it equals 2⟪u₀,u₁⟫. The orthotope of the parent is the special case where all pairwise inner products vanish; orthogonal edges in n = 2 recover the classical British Flag Theorem.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BritishFlagParallelepipedOQ010201.lean",
+    "tags": [
+      "geometry",
+      "inner-product-space",
+      "british-flag-theorem",
+      "parallelepiped",
+      "finite-differences",
+      "inclusion-exclusion",
+      "powerset",
+      "alternating-sum",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. All results are fully machine-checked in an arbitrary real inner product space V (NormedAddCommGroup V, InnerProductSpace ℝ V). The only axioms used are the foundational propext, Classical.choice, Quot.sound (confirmed via #print axioms on parallelepiped_defect_eq_zero and parallelepiped_defect_two); there are no axiom declarations, no native_decide, and no sorries.",
+    "dateAdded": "2026-06-24",
+    "lineCount": 300,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "parallelepiped_defect_eq_zero (PROVED, MAIN): for any parallelepiped in a real inner product space with base c, arbitrary edge vectors u : Fin n → V, and any observer X, the alternating squared-distance defect ∑_t (−1)^{|t|}·‖X − (c + ∑_{i∈t} uᵢ)‖² over the 2ⁿ vertices is identically zero whenever n ≥ 3 — the general defect formula requested by the parent's open question, holding for every configuration with no orthogonality hypothesis",
+      "parallelepiped_defect_two (PROVED): for n = 2 the defect equals 2⟪u₀,u₁⟫, independent of the observer X and the base c; this is the unique surviving monomial [0∈t][1∈t] and measures the failure of orthogonality, unifying the orthotope parent (inner products zero) with the sibling oq-01-oq-01 parallelogram defect",
+      "parallelepiped_defect_two_orthogonal (PROVED): orthogonal edges (⟪u₀,u₁⟫ = 0) in n = 2 force the defect to vanish — the classical British Flag Theorem recovered as a corollary, explicitly closing the loop with the parent orthotope entry",
+      "alt_sum_eq_zero_of_indep (PROVED, structural heart): if g t does not change when a coordinate k is inserted into a k-free set, the signed powerset sum ∑_t (−1)^{|t|}·g t = 0; proved by pairing each subset s ⊆ univ∖{k} with insert k s (equal g-value, opposite sign). This is the finite-difference annihilation lemma that kills every coordinate-independent monomial",
+      "sqDist_expand (PROVED, support): the explicit degree-≤2 inner-product expansion ‖X − vertex t‖² = ‖X−c‖² − 2∑_{i∈t}⟪X−c,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫, exhibiting the squared distance as a quadratic in the membership indicators",
+      "const_term_zero / linear_term_zero / quadratic_term_zero (PROVED): the constant, linear, and quadratic pieces of the expansion have vanishing alternating sum for n ≥ 1, n ≥ 2, n ≥ 3 respectively — each reduced to alt_sum_eq_zero_of_indep by exhibiting an unused coordinate, the degree-vs-dimension threshold that makes n ≥ 3 the exact hypothesis for total vanishing"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x − y‖² = ‖x‖² − 2⟪x,y⟫ + ‖y‖² over a real inner product space — the polarization expansion that turns the squared distance into a quadratic in the edge sum",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "real_inner_self_eq_norm_sq",
+        "description": "⟪x,x⟫ = ‖x‖² — used to convert ‖∑_{i∈t} uᵢ‖² into the double inner-product sum ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_sum / sum_inner",
+        "description": "Bilinearity of the inner product over Finset sums, distributing ⟪w, ∑uᵢ⟫ and ⟪∑uᵢ, ∑uⱼ⟫ into iterated sums",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Finset.powerset_insert",
+        "description": "(insert a s).powerset = s.powerset ∪ s.powerset.image (insert a) — splits the powerset of univ by membership of the unused coordinate k in the finite-difference pairing",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.sum_ite_mem_eq",
+        "description": "(∑ i, if i ∈ s then f i else 0) = ∑ i ∈ s, f i — converts the membership-restricted sums ∑_{i∈t} into full sums over univ with indicators, enabling the order swap that isolates each monomial",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of double/triple sums, moving the powerset sum innermost so the finite-difference lemma applies to a fixed monomial",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The British Flag Theorem states |PA|² + |PC|² = |PB|² + |PD|² for any point P and rectangle ABCD. The parent entry british-flag-theorem-oq-01-oq-02 lifted it to an axis-aligned box in n dimensions, proving the alternating-parity vertex sum vanishes for every n ≥ 2 — but only for right-angled boxes, whose edge vectors are mutually orthogonal. Its first open question asked what happens when the box is sheared into a general parallelepiped with arbitrary edge vectors uᵢ, conjecturing a fixed defect Σ ±2⟪uᵢ,uⱼ⟫ independent of the observer, unifying the orthotope (all inner products zero) with the 2-dimensional parallelogram defect 2⟪u,v⟫ of the sibling entry oq-01-oq-01. This entry settles it: the defect is the n-th finite difference of a degree-2 polynomial, so it vanishes outright for n ≥ 3 and equals 2⟪u₀,u₁⟫ for n = 2.",
+    "problemStatement": "**OQ-01-02-01 of british-flag-theorem (the parent's first open question)**\n\nFor a parallelepiped with base point c and edge vectors u₁,…,uₙ in an inner product space, the alternating vertex sum ∑_t (−1)^{|t|}·‖X − vertex t‖² should equal a fixed defect Σ_{i<j} ±2⟪uᵢ,uⱼ⟫ independent of the observer X — unifying the orthotope (all inner products zero) with the n = 2 parallelogram (defect 2⟪u₁,u₂⟫). Prove the general defect formula.",
+    "text": "Let V be a real inner product space, c, X : V, and u : Fin n → V. Index each parallelepiped vertex by t ⊆ {0,…,n−1} via vertex t = c + ∑_{i∈t} uᵢ, and set defect = ∑_{t} (−1)^{|t|}·‖X − vertex t‖². Then: (i) if n ≥ 3, defect = 0 for all X, c, u; (ii) if n = 2, defect = 2⟪u₀,u₁⟫; (iii) in particular for n = 2 with ⟪u₀,u₁⟫ = 0 the defect vanishes — the classical British Flag Theorem.",
+    "proofStrategy": "Write w = X − c and expand ‖X − vertex t‖² = ‖w − ∑_{i∈t} uᵢ‖² via polarization (norm_sub_sq_real) and bilinearity into the explicit quadratic sqDist t = ‖w‖² − 2∑_{i∈t}⟪w,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫ (sqDist_expand). This is a polynomial of degree ≤ 2 in the membership indicators [i ∈ t]. The operator g ↦ ∑_t (−1)^{|t|}·g t is, up to sign, the n-th iterated finite difference; the structural lemma alt_sum_eq_zero_of_indep shows it annihilates any g that is independent of some coordinate k (pair s with insert k s: equal value, opposite sign). Distribute the alternating sum over the three pieces. The constant piece (degree 0) vanishes for n ≥ 1, the linear piece (degree 1) for n ≥ 2, and the quadratic piece (degree 2) for n ≥ 3 — in each case by converting ∑_{i∈t} into ∑ over univ with indicators (Finset.sum_ite_mem_eq), swapping sums (Finset.sum_comm), and exhibiting an unused coordinate so the finite-difference lemma applies monomial-by-monomial. For n ≥ 3 all three vanish, giving defect = 0. For n = 2 only the off-diagonal of the quadratic piece survives; enumerating the four subsets of {0,1} (quadSum_two) gives ∑_t (−1)^{|t|}∑∑⟪uᵢ,uⱼ⟫ = ⟪u₀,u₁⟫ + ⟪u₁,u₀⟫ = 2⟪u₀,u₁⟫.",
+    "keyInsights": [
+      "The squared distance to a parallelepiped vertex is a degree-2 polynomial in the membership indicators [i ∈ t], with the inner products ⟪uᵢ,uⱼ⟫ as the quadratic coefficients. This is the structural fact the parent's orthotope special case obscured (there all those coefficients are zero).",
+      "The alternating powerset sum ∑_t (−1)^{|t|}·g(t) is the n-th iterated finite difference of g viewed as a function on the Boolean cube. A finite difference of order n annihilates every polynomial of degree < n — this is exactly why n ≥ 3 kills a degree-2 form and n = 2 leaves only its top (degree-2) monomial.",
+      "The clean way to formalize 'finite difference kills low degree' is monomial-by-monomial: a single indicator monomial omitting coordinate k is invariant under inserting k, so its alternating sum vanishes by pairing s ↔ insert k s. The degree of the monomial is the number of coordinates it constrains; if that is < n some coordinate is free.",
+      "n ≥ 3 is the sharp threshold for unconditional vanishing: the squared distance has degree exactly 2, so the defect vanishes for all configurations precisely when n > 2. At n = 2 the degree-2 monomial [0∈t][1∈t] is the full cube and survives with coefficient 2⟪u₀,u₁⟫; at n = 1 even the linear term survives and the defect depends on the observer.",
+      "The result unifies two prior directions in one formula: the parent orthotope (defect 0 because ⟪uᵢ,uⱼ⟫ = 0) and the sibling 2-dimensional parallelogram (defect 2⟪u,v⟫). Both are slices of the single statement 'defect = n-th finite difference of a quadratic'."
+    ],
+    "prerequisites": [
+      "Real inner product spaces: polarization ‖x−y‖² = ‖x‖² − 2⟪x,y⟫ + ‖y‖² and bilinearity over Finset sums",
+      "Finset powersets and the finite-difference pairing s ↔ insert k s on subsets",
+      "Converting membership-restricted sums ∑_{i∈t} into indicator sums over univ and swapping summation order",
+      "Iterated finite differences and the fact that an order-n difference annihilates polynomials of degree < n"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Definitions",
+      "startLine": 1,
+      "endLine": 81,
+      "summary": "Module docstring explaining the degree-≤2 / finite-difference mechanism and the n ≥ 3 vs n = 2 dichotomy. Imports Mathlib, opens Finset and the RealInnerProductSpace notation, and defines `pVertex c u t = c + ∑_{i∈t} uᵢ`, `sqDist X c u t = ‖X − pVertex c u t‖²`, and `defect X c u = ∑_t (−1)^{|t|}·sqDist X c u t`.",
+      "mathContext": "Vertices are indexed by t : Finset (Fin n) recording which edges uᵢ are added to the base c; the defect is the alternating sum of squared distances over the 2ⁿ vertices."
+    },
+    {
+      "id": "sec-heart",
+      "title": "Structural Heart: Finite-Difference Annihilation",
+      "startLine": 83,
+      "endLine": 121,
+      "summary": "alt_sum_eq_zero_of_indep: if g(insert k s) = g(s) whenever k ∉ s, then ∑_t (−1)^{|t|}·g(t) = 0. Proof writes univ = insert k (univ∖{k}), splits the powerset (powerset_insert) into subsets avoiding k and their insert-k images, and shows the second sum negates the first since card(insert k s) = |s|+1 and the g-values agree.",
+      "mathContext": "This is the n-th finite difference annihilating any function constant in a coordinate: the cube splits into antipodal pairs s ↔ insert k s carrying opposite signs (−1)^{|s|} and (−1)^{|s|+1}."
+    },
+    {
+      "id": "sec-exists",
+      "title": "Existence of Unused Coordinates",
+      "startLine": 123,
+      "endLine": 145,
+      "summary": "exists_coord_ne (n ≥ 2 ⟹ some k ≠ i) and exists_coord_ne_two (n ≥ 3 ⟹ some k ≠ i and k ≠ j). The latter is a counting argument: if every coordinate were i or j then univ ⊆ {i,j} forces n ≤ 2.",
+      "mathContext": "These supply the free coordinate the finite-difference lemma needs; the dimension thresholds n ≥ 2 and n ≥ 3 enter here, matching the degrees of the linear and quadratic pieces."
+    },
+    {
+      "id": "sec-expand",
+      "title": "Inner-Product Expansion of the Squared Distance",
+      "startLine": 147,
+      "endLine": 160,
+      "summary": "sqDist_expand: ‖X − vertex t‖² = ‖X−c‖² − 2∑_{i∈t}⟪X−c,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫. Proof rewrites X − pVertex c u t = (X−c) − ∑uᵢ, applies polarization (norm_sub_sq_real), and expands the edge-sum norm via real_inner_self_eq_norm_sq and bilinearity.",
+      "mathContext": "Exhibits the squared distance as a degree-2 polynomial in the indicators [i ∈ t]; the constant, linear, and quadratic coefficients are ‖w‖², ⟪w,uᵢ⟫, and ⟪uᵢ,uⱼ⟫."
+    },
+    {
+      "id": "sec-pieces",
+      "title": "The Three Monomial Pieces Vanish",
+      "startLine": 162,
+      "endLine": 241,
+      "summary": "const_term_zero (n ≥ 1), linear_term_zero (n ≥ 2), and quadratic_term_zero (n ≥ 3): each piece of the expansion has vanishing alternating sum. The linear and quadratic pieces rewrite ∑_{i∈t} as indicator sums over univ (Finset.sum_ite_mem_eq), swap summation order (Finset.sum_comm), and apply alt_sum_eq_zero_of_indep to each monomial using a coordinate not constrained by it.",
+      "mathContext": "Degree d piece needs a free coordinate, available when n > d; hence the thresholds 1, 2, 3 for the degree-0, 1, 2 pieces."
+    },
+    {
+      "id": "sec-main",
+      "title": "Main Theorems: General Defect Formula",
+      "startLine": 243,
+      "endLine": 300,
+      "summary": "parallelepiped_defect_eq_zero (n ≥ 3 ⟹ defect = 0) distributes the alternating sum over the three pieces, all of which vanish. quadSum_two enumerates the four subsets of {0,1} to evaluate the n = 2 quadratic piece as ⟪u₀,u₁⟫ + ⟪u₁,u₀⟫. parallelepiped_defect_two (n = 2 ⟹ defect = 2⟪u₀,u₁⟫) combines the vanishing constant/linear pieces with quadSum_two and real_inner_comm. parallelepiped_defect_two_orthogonal specializes to ⟪u₀,u₁⟫ = 0, recovering the British Flag Theorem.",
+      "mathContext": "The n ≥ 3 case is the requested general defect formula (identically zero, observer-independent); the n = 2 case is the parallelogram defect; the orthogonal corollary is the classical theorem."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the orthotope British Flag identity for axis-aligned boxes in n dimensions. This entry answers its first open question by dropping orthogonality — the orthotope is the special case where all pairwise inner products ⟪uᵢ,uⱼ⟫ vanish, so the parent's 'defect = 0 for n ≥ 2' is subsumed (n ≥ 3 always, and n = 2 via the orthogonal corollary)."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling: the 2-dimensional parallelogram defect 2⟪u,v⟫ in an inner product space. parallelepiped_defect_two reproduces exactly that defect as the n = 2 slice of the general formula, unifying the two prior generalizations under one finite-difference statement."
+    },
+    {
+      "targetId": "british-flag-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the classical British Flag Theorem in ℝ². Recovered by parallelepiped_defect_two_orthogonal (n = 2, orthogonal edges)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Machine-verified in an arbitrary real inner product space: the British Flag defect of a general parallelepiped is the n-th finite difference of the degree-2 squared-distance polynomial, hence identically zero for n ≥ 3 (independent of observer, base, and edges) and equal to 2⟪u₀,u₁⟫ for n = 2. The orthotope of the parent and the parallelogram defect of the sibling are unified as the two slices of one formula; orthogonal n = 2 edges recover the classical theorem. Zero sorries, zero extra axioms.",
+    "implications": "**General defect formula proved**: the parent's first open question is settled in full generality — for n ≥ 3 the alternating vertex sum vanishes for every parallelepiped, skew or not, answering 'prove the general defect formula' affirmatively with the cleanest possible answer (it is zero).\\n\\n**Sharp dimension threshold**: n ≥ 3 is exactly the regime of unconditional vanishing because the squared distance has degree exactly 2; n = 2 is the boundary where the top monomial survives as 2⟪u₀,u₁⟫ and n = 1 is observer-dependent.\\n\\n**Finite differences as the organizing principle**: recasting the metric defect as an iterated finite difference on the Boolean cube explains both the vanishing and the surviving defect in one stroke, and generalizes to any vertex functional that is polynomial of bounded degree in the indicators.",
+    "openQuestions": [
+      "Higher moments: replace ‖X − vertex‖² by ‖X − vertex‖^{2k}. This is a degree-2k polynomial in the indicators, so the defect should vanish for n ≥ 2k+1 and have an explicit top-degree defect at the threshold n = 2k — determine that defect (a sum over perfect matchings / pairings of the 2k edge slots) and the sharp dimension boundary.",
+      "Exact n = 2 defect in terms of signed area: ⟪u₀,u₁⟫ = ‖u₀‖‖u₁‖cos θ; relate the defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the discrete Laplacian / mixed second difference of the squared-distance field over the cube."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "parallelepiped_defect_eq_zero",
+      "type": "core",
+      "description": "General defect formula: for any parallelepiped in a real inner product space with base c, arbitrary edge vectors u, and any observer X, the alternating squared-distance defect over the 2ⁿ vertices is identically zero when n ≥ 3.",
+      "leanType": "(hn : 3 ≤ n) → (X c : V) → (u : Fin n → V) → defect X c u = 0"
+    },
+    {
+      "name": "parallelepiped_defect_two",
+      "type": "core",
+      "description": "For n = 2 the defect equals 2⟪u₀,u₁⟫, independent of the observer X and base c — the parallelogram defect measuring the failure of orthogonality.",
+      "leanType": "(X c : V) → (u : Fin 2 → V) → defect X c u = 2 * ⟪u 0, u 1⟫"
+    },
+    {
+      "name": "parallelepiped_defect_two_orthogonal",
+      "type": "core",
+      "description": "Recovery of the classical British Flag Theorem: orthogonal edges in n = 2 force the defect to vanish.",
+      "leanType": "(X c : V) → (u : Fin 2 → V) → ⟪u 0, u 1⟫ = 0 → defect X c u = 0"
+    },
+    {
+      "name": "alt_sum_eq_zero_of_indep",
+      "type": "supporting",
+      "description": "Finite-difference annihilation: if g does not depend on a coordinate k, the signed powerset sum ∑_t (−1)^{|t|}·g t vanishes.",
+      "leanType": "(k : Fin n) → (g : Finset (Fin n) → ℝ) → (∀ s, k ∉ s → g (insert k s) = g s) → ∑ t ∈ univ.powerset, (-1)^t.card * g t = 0"
+    },
+    {
+      "name": "sqDist_expand",
+      "type": "supporting",
+      "description": "Degree-≤2 inner-product expansion of the squared distance to a parallelepiped vertex.",
+      "leanType": "(X c : V) → (u : Fin n → V) → (t : Finset (Fin n)) → sqDist X c u t = ‖X − c‖² − 2 * (∑ i ∈ t, ⟪X − c, u i⟫) + ∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "RealInnerProductSpace"
+    ],
+    "namespace": "BritishFlagParallelepipedOQ010201",
+    "lineCount": 300,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "substantiveTheoremCount": 11,
+    "duplicateTheorems": 0,
+    "definitionCount": 3,
+    "path": "Proofs/BritishFlagParallelepipedOQ010201.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Martin Gardner",
+      "title": "Mathematical Games",
+      "year": "1970",
+      "venue": "Scientific American",
+      "note": "Popularized the British Flag Theorem; the rectangle identity is the n = 2 orthogonal case recovered here as a corollary."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge University Press",
+      "note": "Inclusion–exclusion and alternating subset sums; here read as iterated finite differences on the Boolean cube, the mechanism behind the degree-vs-dimension vanishing."
+    }
+  ]
+}

--- a/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
@@ -1,0 +1,52 @@
+{
+  "id": "british-flag-theorem-oq-01-oq-02-oq-01",
+  "slug": "british-flag-theorem-oq-01-oq-02-oq-01",
+  "title": "British Flag Defect for a General Non-Orthogonal Parallelepiped",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 8,
+  "significance": 6,
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "path": "proofs/Proofs/BritishFlagParallelepipedOQ010201.lean",
+  "tags": [
+    "geometry",
+    "inner-product-space",
+    "british-flag-theorem",
+    "parallelepiped",
+    "finite-differences",
+    "alternating-sum",
+    "seeker-selected"
+  ],
+  "problemStatement": "Parent british-flag-theorem-oq-01-oq-02's first open question. For a parallelepiped with base c and edge vectors u₁,…,uₙ in a real inner product space, the alternating vertex sum ∑_t (−1)^{|t|}·‖X − vertex t‖² (vertex t = c + ∑_{i∈t} uᵢ) should equal a fixed defect independent of the observer X, unifying the orthotope parent (all inner products zero) with the n = 2 parallelogram (defect 2⟪u₁,u₂⟫). Prove the general defect formula.",
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "Proved the general defect formula in full: defect ≡ 0 for n ≥ 3 (any configuration), defect = 2⟪u₀,u₁⟫ for n = 2, orthogonal n=2 recovers the classical British Flag Theorem. Verified, 0 axioms, 0 sorries."
+  },
+  "knownResults": "Parent oq-01-oq-02 proved the orthotope (orthogonal-edge) case vanishes for n ≥ 2. Sibling oq-01-oq-01 proved the n = 2 parallelogram defect 2⟪u,v⟫. Mathlib supplies polarization (norm_sub_sq_real), inner-product bilinearity, and powerset machinery.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: general defect formula proved. The squared distance to a parallelepiped vertex is a degree-2 polynomial in the membership indicators; the alternating powerset sum is the n-th finite difference, which annihilates degree < n. Hence defect ≡ 0 for n ≥ 3 and = 2⟪u₀,u₁⟫ for n = 2. Verified / 0-axiom / original, 300 lines, 11 theorems, 3 definitions.",
+    "insights": [
+      "The squared distance ‖X − vertex t‖² is a polynomial of degree exactly 2 in the membership indicators [i ∈ t], with constant coeff ‖X−c‖², linear coeffs ⟪X−c,uᵢ⟫, and quadratic coeffs ⟪uᵢ,uⱼ⟫. The parent's orthotope hid this because there the quadratic coefficients are all zero.",
+      "The alternating powerset sum g ↦ ∑_t (−1)^{|t|}·g t is the n-th iterated finite difference on the Boolean cube; it annihilates every monomial omitting a coordinate, hence every polynomial of degree < n. This single fact explains both the n ≥ 3 vanishing and the surviving n = 2 defect.",
+      "n ≥ 3 is the SHARP threshold for unconditional vanishing because the squared distance has degree exactly 2: the defect vanishes for all configurations iff n > 2. At n = 2 only the top monomial [0∈t][1∈t] survives (coefficient 2⟪u₀,u₁⟫); at n = 1 even the linear term survives and the defect is observer-dependent.",
+      "The cleanest formalization of 'finite difference kills low degree' is monomial-by-monomial: an indicator monomial constant in coordinate k is invariant under inserting k, so its alternating sum vanishes by the antipodal pairing s ↔ insert k s. Free coordinate exists exactly when the monomial degree < n."
+    ],
+    "builtItems": [
+      "alt_sum_eq_zero_of_indep (BritishFlagParallelepipedOQ010201.lean:90): finite-difference annihilation — coordinate-independent g ⟹ ∑_t (−1)^{|t|}·g t = 0",
+      "sqDist_expand (BritishFlagParallelepipedOQ010201.lean:151): degree-≤2 inner-product expansion of the squared distance",
+      "const_term_zero / linear_term_zero / quadratic_term_zero (lines 166/173/193): the three monomial pieces vanish for n ≥ 1 / 2 / 3",
+      "parallelepiped_defect_eq_zero (line 243): MAIN — n ≥ 3 ⟹ defect = 0 for any parallelepiped",
+      "parallelepiped_defect_two (line 276): n = 2 ⟹ defect = 2⟪u₀,u₁⟫; quadSum_two (line 261) enumerates the four subsets of {0,1}",
+      "parallelepiped_defect_two_orthogonal (line 295): orthogonal n = 2 recovers the classical British Flag Theorem"
+    ],
+    "mathlibGaps": "none — the proof is self-contained over Mathlib's inner-product and Finset libraries.",
+    "nextSteps": [
+      "Higher moments: ‖X − vertex‖^{2k} is degree 2k in the indicators, so the defect should vanish for n ≥ 2k+1 with an explicit top-degree defect (sum over pairings) at n = 2k.",
+      "Relate the n = 2 defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the mixed second difference of the squared-distance field over the cube."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `british-flag-theorem-oq-01-oq-02` (orthotope British Flag identity): *drop the orthogonality assumption and prove the general defect formula for a sheared parallelepiped.*

For a parallelepiped in a real inner product space `V` with base point `c` and **arbitrary** edge vectors `u : Fin n → V`, the vertex indexed by `t ⊆ {0,…,n−1}` is `c + ∑_{i∈t} uᵢ`, and the British Flag defect is the alternating sum
```
defect X c u = ∑_t (−1)^|t| · ‖X − vertex t‖²
```
over the 2ⁿ vertices.

**Key idea.** Writing `w = X − c`, the squared distance is a polynomial of **degree exactly 2** in the membership indicators `[i ∈ t]`:
```
‖X − vertex t‖² = ‖w‖² − 2∑_{i∈t}⟪w,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫
```
The operator `g ↦ ∑_t (−1)^|t|·g t` is the n-th iterated finite difference on the Boolean cube, which annihilates every monomial of degree < n. So the dimension threshold is sharp.

## Results (all verified, 0 axioms, 0 sorries)

| Theorem | Statement |
|---|---|
| `parallelepiped_defect_eq_zero` | **n ≥ 3 ⟹ defect = 0** for *every* configuration (observer-, base-, edge-independent) — the requested general defect formula |
| `parallelepiped_defect_two` | **n = 2 ⟹ defect = 2⟪u₀,u₁⟫** — the parallelogram defect measuring failure of orthogonality |
| `parallelepiped_defect_two_orthogonal` | orthogonal n=2 edges ⟹ defect 0 — the **classical British Flag Theorem** recovered |
| `alt_sum_eq_zero_of_indep` | structural heart: finite-difference annihilation of coordinate-independent functions |
| `sqDist_expand` | degree-≤2 inner-product expansion of the squared distance |

This **unifies** the orthotope parent (defect 0 because all ⟪uᵢ,uⱼ⟫ = 0) and the sibling `oq-01-oq-01` 2D parallelogram defect `2⟪u,v⟫` as the two slices of one finite-difference statement.

## Verification

- `proofs/Proofs/BritishFlagParallelepipedOQ010201.lean` — 300 lines, 11 theorems, 3 definitions
- Builds cleanly against Mathlib (`lake env lean`)
- `#print axioms parallelepiped_defect_eq_zero` / `parallelepiped_defect_two` → only `propext, Classical.choice, Quot.sound` (no `axiom` declarations, no `native_decide`, no `sorry`)
- Annotations pass `pnpm annotations:validate` (no errors for this slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)