### PR TITLE
research(abundant-number-oq-04-oq-01-oq-02): propagation of abundance & primitive abundant numbers — 20 is the least

### DIFF
--- a/proofs/Proofs/AbundantPrimitiveOQ040102.lean
+++ b/proofs/Proofs/AbundantPrimitiveOQ040102.lean
@@ -1,0 +1,128 @@
+/-
+# Propagation of Abundance and Primitive Abundant Numbers
+
+This entry extends `abundant-number-oq-04-oq-01` (the strict abundancy gap
+`sigma_dvd_strict_mono : n·σ(d) + d ≤ d·σ(n)` for `d ∣ n`, `d < n`) in two
+directions.
+
+* **Propagation of abundance.** A proper multiple of an abundant *or* perfect
+  number is strictly abundant. The single inequality
+  `2·d ≤ σ(d)` (which holds for both abundant `d`, where it is strict, and
+  perfect `d`, where it is an equality) feeds the parent's strict gap to give
+  `2·n < σ(n)`.
+
+* **Primitive abundant numbers.** `IsPrimitiveAbundant n` means `n` is abundant
+  but every proper divisor is deficient. We characterise these as the abundant
+  numbers none of whose proper divisors is abundant or perfect, deduce from the
+  propagation law that no proper multiple of a primitive abundant number is
+  primitive abundant, and exhibit `20` as the least primitive abundant number
+  (`12` and `18` fail because their proper divisor `6` is perfect).
+
+All results are elementary and axiom-free.
+-/
+import Mathlib
+import Proofs.AbundantStrictAbundancyOQ0401
+
+namespace AbundantPrimitiveOQ040102
+
+open Finset
+open AbundantMultiplesOQ01
+open AbundantDeficientDvdOQ04
+open AbundantStrictAbundancyOQ0401
+
+/-! ### Decidability of the factorisation predicates
+
+Mathlib's `Nat.Abundant`, `Nat.Deficient`, `Nat.Perfect` are plain `def`s, so the
+`Decidable` instances behind them are not found by typeclass search. We expose
+them here (each reduces to a decidable inequality / equality on a computable
+divisor sum) so that concrete numerical claims can be discharged by `decide`. -/
+
+instance decidableAbundant (n : ℕ) : Decidable (Nat.Abundant n) := by
+  unfold Nat.Abundant; infer_instance
+
+instance decidableDeficient (n : ℕ) : Decidable (Nat.Deficient n) := by
+  unfold Nat.Deficient; infer_instance
+
+instance decidablePerfect (n : ℕ) : Decidable (Nat.Perfect n) := by
+  unfold Nat.Perfect; infer_instance
+
+/-! ### Propagation of abundance -/
+
+/-- For an abundant **or** perfect `d`, the divisor sum is at least `2·d`.
+For abundant `d` this is the strict `2d < σ(d)`; for perfect `d` it is the
+equality `σ(d) = 2d`. -/
+theorem two_mul_le_sigma_of_abundant_or_perfect {d : ℕ}
+    (h : d.Abundant ∨ d.Perfect) : 2 * d ≤ ∑ e ∈ d.divisors, e := by
+  rcases h with hab | hp
+  · exact le_of_lt ((abundant_iff_two_mul_lt_sigma d).mp hab)
+  · have hσ : ∑ e ∈ d.divisors, e = 2 * d := by
+      rw [Nat.sum_divisors_eq_sum_properDivisors_add_self, hp.1]; ring
+    omega
+
+/-- **Propagation of abundance.** If `d ∣ n`, `d < n`, and `d` is abundant or
+perfect, then `n` is abundant. The parent strict gap gives
+`n·σ(d) + d ≤ d·σ(n)`; combined with `2d ≤ σ(d)` this yields
+`d·(2n) < d·σ(n)`, hence `2n < σ(n)`. -/
+theorem abundant_of_proper_dvd_abundant_or_perfect {d n : ℕ}
+    (hdvd : d ∣ n) (hlt : d < n) (h : d.Abundant ∨ d.Perfect) : n.Abundant := by
+  have hnpos : 0 < n := lt_of_le_of_lt (Nat.zero_le d) hlt
+  have hdpos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hnpos
+  have hge : 2 * d ≤ ∑ e ∈ d.divisors, e := two_mul_le_sigma_of_abundant_or_perfect h
+  have hkey : n * (∑ e ∈ d.divisors, e) + d ≤ d * (∑ e ∈ n.divisors, e) :=
+    sigma_dvd_strict_mono hdvd hlt
+  have h1 : n * (2 * d) ≤ n * (∑ e ∈ d.divisors, e) := by gcongr
+  rw [abundant_iff_two_mul_lt_sigma]
+  nlinarith [hkey, h1, hdpos, hnpos]
+
+/-! ### Primitive abundant numbers -/
+
+/-- A **primitive abundant number**: abundant, yet every proper divisor is
+deficient. These are the minimal abundant numbers under divisibility. -/
+abbrev IsPrimitiveAbundant (n : ℕ) : Prop :=
+  n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient
+
+/-- **Characterisation.** `n` is primitive abundant iff it is abundant and none
+of its proper divisors is abundant or perfect. (Immediate from the trichotomy
+`Deficient d ↔ ¬Abundant d ∧ ¬Perfect d` applied to each positive proper
+divisor.) -/
+theorem isPrimitiveAbundant_iff {n : ℕ} :
+    IsPrimitiveAbundant n ↔
+      n.Abundant ∧ ∀ d ∈ n.properDivisors, ¬ d.Abundant ∧ ¬ d.Perfect := by
+  refine and_congr_right (fun _ => ?_)
+  refine ⟨fun H d hd => ?_, fun H d hd => ?_⟩
+  · have hdpos : 0 < d := Nat.pos_of_mem_properDivisors hd
+    exact (Nat.deficient_iff_not_abundant_and_not_perfect hdpos.ne').mp (H d hd)
+  · have hdpos : 0 < d := Nat.pos_of_mem_properDivisors hd
+    exact (Nat.deficient_iff_not_abundant_and_not_perfect hdpos.ne').mpr (H d hd)
+
+/-- **No proper multiple of a primitive abundant number is primitive abundant.**
+Contrapositive of propagation: a primitive abundant `d` is abundant, hence not
+deficient, so it cannot be a (necessarily deficient) proper divisor of another
+primitive abundant number. -/
+theorem not_isPrimitiveAbundant_of_proper_multiple {d n : ℕ}
+    (hd : IsPrimitiveAbundant d) (hdvd : d ∣ n) (hlt : d < n) :
+    ¬ IsPrimitiveAbundant n := by
+  rintro ⟨_, hall⟩
+  have hdmem : d ∈ n.properDivisors := Nat.mem_properDivisors.mpr ⟨hdvd, hlt⟩
+  have hdef : d.Deficient := hall d hdmem
+  have hdpos : 0 < d := pos_of_abundant hd.1
+  rw [Nat.deficient_iff_not_abundant_and_not_perfect hdpos.ne'] at hdef
+  exact hdef.1 hd.1
+
+/-! ### The least primitive abundant number -/
+
+/-- `20` is primitive abundant: it is abundant (`σ(20)=42>40`) while its proper
+divisors `1,2,4,5,10` are all deficient. -/
+theorem isPrimitiveAbundant_twenty : IsPrimitiveAbundant 20 := by decide
+
+/-- `20` is the **least** primitive abundant number. Every smaller candidate
+fails; in particular the abundant numbers `12` and `18` are disqualified because
+their proper divisor `6` is perfect. -/
+theorem twenty_least_isPrimitiveAbundant :
+    ∀ m, m < 20 → ¬ IsPrimitiveAbundant m := by decide
+
+/-- Sanity check on the obstruction for `12`: its proper divisor `6` is perfect,
+hence not deficient, so `12` is not primitive abundant despite being abundant. -/
+theorem twelve_not_isPrimitiveAbundant : ¬ IsPrimitiveAbundant 12 := by decide
+
+end AbundantPrimitiveOQ040102

--- a/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-abund040102-overview",
+    "proofId": "abundant-number-oq-04-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "From a quantitative gap to structural laws on abundant numbers",
+    "content": "The docstring frames this entry as the structural payoff of the parent abundant-number-oq-04-oq-01, whose strict gap n·σ(d) + d ≤ d·σ(n) measured how fast the abundancy index climbs at a proper multiple. Two consequences are drawn: abundance is contagious upward (a proper multiple of an abundant or perfect number is abundant), and the minimal abundant numbers under divisibility — the primitive abundant numbers — are characterised, shown to have no primitive abundant proper multiple, and pinned down at their least element 20.",
+    "mathContext": "Abundancy index $h(n)=\\sigma(n)/n$. Parent gap: $d\\mid n,\\,d<n\\Rightarrow d\\,\\sigma(n)-n\\,\\sigma(d)\\ge d$. Abundant: $h(n)>2$; perfect: $h(n)=2$; deficient: $h(n)<2$.",
+    "significance": "context",
+    "relatedConcepts": ["abundancy index", "primitive abundant numbers", "perfect / abundant / deficient numbers", "divisor lattice"],
+    "prerequisites": ["divisor functions", "divisibility"]
+  },
+  {
+    "id": "ann-abund040102-decidability",
+    "proofId": "abundant-number-oq-04-oq-01-oq-02",
+    "range": { "startLine": 32, "endLine": 48 },
+    "type": "technique",
+    "title": "Exposing Decidable instances for the factorisation predicates",
+    "content": "Nat.Abundant, Nat.Deficient and Nat.Perfect are plain `def`s, so typeclass search will not look through them to find the underlying Decidable instance on the divisor-sum inequality/equality. Each instance is recovered by `unfold; infer_instance`: after unfolding, the goal is a decidable `<`, `=` or `∧` on a computable Finset sum, for which Lean already has instances. With these in scope, concrete claims like `IsPrimitiveAbundant 20` reduce to kernel `decide` — crucially NOT native_decide, so no Lean.ofReduceBool enters the axiom set.",
+    "mathContext": "Decidability of $n<\\sum_{e\\mid n}e$, $\\sum_{e\\mid n}e<n$, and $\\sum_{e\\in\\mathrm{proper}(n)}e=n\\wedge 0<n$.",
+    "significance": "Makes the finite witness/minimality checks available to the kernel without touching the trusted-compiler `native_decide` path.",
+    "relatedConcepts": ["Decidable instances", "kernel decide vs native_decide", "computable divisor sums"],
+    "prerequisites": ["typeclass resolution", "decidability"]
+  },
+  {
+    "id": "ann-abund040102-propagation",
+    "proofId": "abundant-number-oq-04-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 76 },
+    "type": "insight",
+    "title": "One inequality 2d ≤ σ(d) unifies the abundant and perfect cases",
+    "content": "two_mul_le_sigma_of_abundant_or_perfect packages both hypotheses as the single bound 2·d ≤ σ(d): for abundant d this is the strict 2d < σ(d), for perfect d the equality σ(d) = 2d. In abundant_of_proper_dvd_abundant_or_perfect this bound combines with the parent strict gap n·σ(d) + d ≤ d·σ(n): monotonicity (gcongr) gives n·(2d) ≤ n·σ(d), so d·σ(n) ≥ n·σ(d) + d ≥ 2nd + d > 2nd = d·(2n); cancelling d > 0 yields 2n < σ(n), i.e. n is abundant. The strict '+d' of the parent is exactly what upgrades the non-strict 2nd ≤ d·σ(n) to a strict inequality, so no case analysis on abundant-vs-perfect survives downstream.",
+    "mathContext": "$2d\\le\\sigma(d)$ and $n\\,\\sigma(d)+d\\le d\\,\\sigma(n)$ give $d\\,(2n)<d\\,\\sigma(n)$, hence $2n<\\sigma(n)$.",
+    "significance": "A single uniform bound and the parent's quantitative slack remove the need to split the abundant and perfect cases.",
+    "relatedConcepts": ["abundant_iff_two_mul_lt_sigma", "perfect number σ = 2n", "monotonicity (gcongr)", "nlinarith"],
+    "prerequisites": ["divisor-sum inequalities", "ℕ arithmetic"]
+  },
+  {
+    "id": "ann-abund040102-primitive",
+    "proofId": "abundant-number-oq-04-oq-01-oq-02",
+    "range": { "startLine": 77, "endLine": 111 },
+    "type": "definition",
+    "title": "Primitive abundant numbers as the trichotomy in disguise",
+    "content": "IsPrimitiveAbundant n is defined as 'n abundant and every proper divisor deficient'. isPrimitiveAbundant_iff rewrites 'every proper divisor deficient' to 'no proper divisor abundant or perfect' by applying Nat.deficient_iff_not_abundant_and_not_perfect to each proper divisor — which is positive by Nat.pos_of_mem_properDivisors — so the characterisation is just the deficient/abundant/perfect trichotomy applied divisor-by-divisor. not_isPrimitiveAbundant_of_proper_multiple then reads off the contrapositive of propagation: a primitive abundant d, being abundant hence not deficient, cannot be the (necessarily deficient) proper divisor of another primitive abundant number.",
+    "mathContext": "$\\mathrm{IsPrimitiveAbundant}(n)\\iff n\\text{ abundant}\\wedge\\forall d\\in\\mathrm{proper}(n),\\ \\neg\\mathrm{Abundant}(d)\\wedge\\neg\\mathrm{Perfect}(d)$.",
+    "significance": "Identifies primitive abundant numbers as the minimal generators of the abundant numbers under divisibility.",
+    "relatedConcepts": ["primitive abundant numbers", "deficient/abundant/perfect trichotomy", "proper divisors", "minimal generators"],
+    "prerequisites": ["Finset properDivisors", "trichotomy lemma"]
+  },
+  {
+    "id": "ann-abund040102-least",
+    "proofId": "abundant-number-oq-04-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 128 },
+    "type": "insight",
+    "title": "20 is the least primitive abundant number — and 6 is the obstruction",
+    "content": "isPrimitiveAbundant_twenty checks σ(20)=42>40 with proper divisors 1,2,4,5,10 all deficient; twenty_least_isPrimitiveAbundant verifies ∀ m < 20, ¬IsPrimitiveAbundant m (Nat.decidableBallLT discharges the bounded quantifier). Both are kernel `decide`. The conceptual content of the minimality is that the only abundant numbers below 20 are 12 and 18, and each contains the perfect number 6 as a proper divisor, so by propagation neither is primitive — recorded explicitly as twelve_not_isPrimitiveAbundant. Thus 20 = A091191(1).",
+    "mathContext": "$\\sigma(20)=42>40$; $\\sigma(12)=28,\\sigma(18)=39$ are abundant but $6\\mid 12,\\,6\\mid 18$ with $6$ perfect.",
+    "significance": "A finite, fully kernel-checked extremal certificate identifying the smallest primitive abundant number.",
+    "relatedConcepts": ["OEIS A091191", "Nat.decidableBallLT", "kernel decide", "extremal witness"],
+    "prerequisites": ["bounded decidability", "concrete divisor sums"]
+  }
+]

--- a/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/index.ts
+++ b/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbundantPrimitiveOQ040102.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abundantPrimitiveOQ040102Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abundantPrimitiveOQ040102Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abundantPrimitiveOQ040102Data: ProofData = {
+  proof: abundantPrimitiveOQ040102Proof,
+  annotations: abundantPrimitiveOQ040102Annotations,
+}

--- a/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abundant-number-oq-04-oq-01-oq-02/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "abundant-number-oq-04-oq-01-oq-02",
+  "title": "Propagation of Abundance and Primitive Abundant Numbers: 20 Is the Least, via the Strict Abundancy Gap",
+  "slug": "abundant-number-oq-04-oq-01-oq-02",
+  "description": "The parent entry abundant-number-oq-04-oq-01 proves the strict, lower-bounded abundancy gap: for d ∣ n with d < n, n·σ(d) + d ≤ d·σ(n) (sigma_dvd_strict_mono), i.e. the abundancy index σ(·)/(·) jumps by at least 1/n at a proper multiple. This entry turns that quantitative gap into two structural theorems about the divisor lattice of abundant numbers. (1) Propagation of abundance: a proper multiple of an abundant OR perfect number is strictly abundant. The single inequality 2·d ≤ σ(d) — strict for abundant d, an equality for perfect d — feeds the parent strict gap to give 2·n < σ(n). (2) Primitive abundant numbers: defining IsPrimitiveAbundant n as 'n is abundant and every proper divisor is deficient', we prove the characterisation that these are exactly the abundant numbers none of whose proper divisors is abundant or perfect (immediate from the deficient/abundant/perfect trichotomy on positive divisors), deduce that no proper multiple of a primitive abundant number is itself primitive abundant, and certify that 20 is the LEAST primitive abundant number (σ(20)=42>40, proper divisors 1,2,4,5,10 all deficient; the smaller abundant numbers 12 and 18 are disqualified because their proper divisor 6 is perfect). Mathlib defines Nat.Abundant / Nat.Deficient / Nat.Perfect but records no closure-under-multiples law and no notion of primitive abundant number. Fully machine-checked with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abundant_number",
+    "date": "Classical; OEIS A091191 (primitive abundant numbers), A005101 (abundant), A000396 (perfect)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbundantPrimitiveOQ040102.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "divisor-sum",
+      "abundant-numbers",
+      "deficient-numbers",
+      "perfect-numbers",
+      "primitive-abundant",
+      "divisibility",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 128,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked with 0 axioms and 0 sorries. `#print axioms` on abundant_of_proper_dvd_abundant_or_perfect, isPrimitiveAbundant_iff, not_isPrimitiveAbundant_of_proper_multiple, isPrimitiveAbundant_twenty, and twenty_least_isPrimitiveAbundant reports only the standard foundational axioms (propext, Classical.choice, Quot.sound). The numerical witnesses (20 is primitive abundant; 20 is least; 12 is not) are discharged by kernel `decide` (NOT native_decide), so no Lean.ofReduceBool is involved. Local Decidable instances for Nat.Abundant / Nat.Deficient / Nat.Perfect (each reducing to a decidable inequality/equality on a computable divisor sum) make the `decide` calls available.",
+    "originalContributions": [
+      "Proves `abundant_of_proper_dvd_abundant_or_perfect : d ∣ n → d < n → (d.Abundant ∨ d.Perfect) → n.Abundant` — abundance propagates upward to every proper multiple of an abundant or perfect number. A single uniform inequality 2·d ≤ σ(d) (strict for abundant, equality for perfect) combines with the parent strict gap n·σ(d) + d ≤ d·σ(n) to force d·(2n) < d·σ(n), hence 2n < σ(n). Directly answers open question index 1 of the parent abundant-number-oq-04-oq-01.",
+      "Defines `IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient` — the notion of a primitive abundant number (a minimal abundant number under divisibility), absent from Mathlib.",
+      "Proves the characterisation `isPrimitiveAbundant_iff : IsPrimitiveAbundant n ↔ n.Abundant ∧ ∀ d ∈ n.properDivisors, ¬d.Abundant ∧ ¬d.Perfect`, obtained by applying the deficient/abundant/perfect trichotomy (Nat.deficient_iff_not_abundant_and_not_perfect) to each positive proper divisor.",
+      "Proves `not_isPrimitiveAbundant_of_proper_multiple : IsPrimitiveAbundant d → d ∣ n → d < n → ¬IsPrimitiveAbundant n` — the contrapositive structural consequence of propagation: a primitive abundant number, being abundant hence non-deficient, can never be a proper divisor of another primitive abundant number.",
+      "Certifies the extremal witness: `isPrimitiveAbundant_twenty : IsPrimitiveAbundant 20` and `twenty_least_isPrimitiveAbundant : ∀ m, m < 20 → ¬IsPrimitiveAbundant m` (with the sanity check `twelve_not_isPrimitiveAbundant`), establishing 20 = A091191(1) as the smallest primitive abundant number — the smaller abundant numbers 12 and 18 fail precisely because their proper divisor 6 is perfect."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Every abundant number is a multiple of a primitive abundant number — an abundant number all of whose proper divisors are deficient — so the primitive abundant numbers (OEIS A091191: 20, 70, 88, 104, ...) are the multiplicative building blocks that control the density and structure of the abundant numbers. The parent chain (abundant-number-oq-04 → oq-04-oq-01) formalized the abundancy index σ(n)/n and sharpened its monotonicity along divisibility to a strict, lower-bounded gap of size 1/n. The natural structural payoff of that gap is exactly the present pair of results: abundance is contagious upward, and the minimal abundant numbers are the primitive ones.",
+    "problemStatement": "Use the parent's strict abundancy gap to prove (1) that a proper multiple of an abundant or perfect number is abundant, and (2) the characterisation and least-element facts for primitive abundant numbers: IsPrimitiveAbundant n ↔ n.Abundant ∧ (no proper divisor is abundant or perfect), no proper multiple of a primitive abundant number is primitive abundant, and 20 is the smallest primitive abundant number — all axiom-free.",
+    "text": "A self-contained Lean 4 / Mathlib formalization (128 lines, 0 sorries, 0 axioms) that converts the parent's quantitative abundancy gap into structural theorems about the divisor lattice of abundant numbers. The propagation law abundant_of_proper_dvd_abundant_or_perfect handles abundant and perfect divisors uniformly through the single bound 2·d ≤ σ(d), which is strict in the abundant case and an equality in the perfect case; feeding it to the parent's sigma_dvd_strict_mono yields strict abundance of the multiple. The notion IsPrimitiveAbundant is then defined and characterised via the deficient/abundant/perfect trichotomy, the no-proper-multiple corollary is read off as the contrapositive of propagation, and 20 is certified as the least primitive abundant number by kernel decide over the local Decidable instances for the three factorisation predicates.",
+    "proofStrategy": "1. **Decidability instances.** Nat.Abundant, Nat.Deficient, Nat.Perfect are plain defs, so their Decidable instances are not found by typeclass search; we expose them by `unfold; infer_instance` (each reduces to a decidable inequality/equality on a computable divisor sum), enabling kernel `decide` on concrete numbers.\n\n2. **Uniform bound (two_mul_le_sigma_of_abundant_or_perfect).** For abundant d, 2d < σ(d) (abundant_iff_two_mul_lt_sigma); for perfect d, σ(d) = 2d (properDivisors definition + Nat.sum_divisors_eq_sum_properDivisors_add_self). Either way 2d ≤ σ(d).\n\n3. **Propagation (abundant_of_proper_dvd_abundant_or_perfect).** With hge : 2d ≤ σ(d) and the parent gap hkey : n·σ(d) + d ≤ d·σ(n), monotonicity gives n·(2d) ≤ n·σ(d) (gcongr), so d·σ(n) ≥ n·σ(d) + d ≥ 2nd + d > 2nd = d·(2n); cancel d (> 0) to get 2n < σ(n), i.e. n.Abundant (abundant_iff_two_mul_lt_sigma). nlinarith closes the arithmetic.\n\n4. **Characterisation (isPrimitiveAbundant_iff).** and_congr_right reduces to a pointwise equivalence over proper divisors; each proper divisor d is positive (Nat.pos_of_mem_properDivisors), so Nat.deficient_iff_not_abundant_and_not_perfect turns 'd deficient' into '¬d abundant ∧ ¬d perfect'.\n\n5. **No proper multiple (not_isPrimitiveAbundant_of_proper_multiple).** If n were primitive abundant, its proper divisor d (a primitive abundant number) would be deficient, hence not abundant — contradicting that d is abundant.\n\n6. **Extremal witness.** isPrimitiveAbundant_twenty and twenty_least_isPrimitiveAbundant are kernel `decide` (Nat.decidableBallLT handles the bounded ∀ m < 20).",
+    "keyInsights": [
+      "**One inequality unifies the abundant and perfect cases.** Both 'd abundant' (2d < σ(d)) and 'd perfect' (σ(d) = 2d) are captured by the single bound 2d ≤ σ(d), so propagation needs no case split downstream: the parent's strict +d gap then upgrades the non-strict 2nd ≤ d·σ(n) to the strict 2nd < d·σ(n) automatically.",
+      "**Primitive abundance is the trichotomy in disguise.** Defining primitivity by 'every proper divisor is deficient' and characterising it by 'no proper divisor is abundant or perfect' is exactly the deficient/abundant/perfect trichotomy applied divisor-by-divisor — no new machinery, just Nat.deficient_iff_not_abundant_and_not_perfect on each positive proper divisor.",
+      "**Minimality of 20 is a finite, decidable fact — and 6 is the obstruction.** The smaller abundant numbers are 12 and 18; both contain the perfect number 6 as a proper divisor, so by propagation they are non-primitive. Everything below 20 is settled by kernel decide over Nat.decidableBallLT, with no native_decide and hence no Lean.ofReduceBool dependency.",
+      "**Structural closure from a quantitative gap.** The parent recorded only the size of the abundancy jump; here that jump is spent to prove a qualitative closure law (abundance propagates upward) and to pin down the minimal generators (primitive abundant numbers) of the abundant-number divisibility order."
+    ],
+    "prerequisites": [
+      "The sum-of-divisors function σ(n) = ∑_{e ∣ n} e and the abundant / deficient / perfect classification (Nat.Abundant, Nat.Deficient, Nat.Perfect) with the trichotomy lemma Nat.deficient_iff_not_abundant_and_not_perfect",
+      "The parent strict gap sigma_dvd_strict_mono (n·σ(d) + d ≤ d·σ(n) for d ∣ n, d < n) and the bridge abundant_iff_two_mul_lt_sigma (abundant-number-oq-04 / oq-04-oq-01)",
+      "Finset proper-divisor facts: Nat.mem_properDivisors, Nat.pos_of_mem_properDivisors, Nat.sum_divisors_eq_sum_properDivisors_add_self",
+      "Kernel decidability for bounded quantifiers over ℕ (Nat.decidableBallLT) and the monotonicity tactic gcongr / nlinarith for the ℕ arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Statement and Strategy",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring: extends the parent strict abundancy gap to (1) propagation of abundance to proper multiples of abundant or perfect numbers and (2) the characterisation, no-proper-multiple law, and least element (20) for primitive abundant numbers.",
+      "mathContext": "A quantitative gap of size 1/n is spent to obtain qualitative closure and minimality results."
+    },
+    {
+      "id": "decidability",
+      "title": "Decidability of the Factorisation Predicates",
+      "startLine": 32,
+      "endLine": 48,
+      "summary": "Local Decidable instances for Nat.Abundant, Nat.Deficient, Nat.Perfect (each `unfold; infer_instance` to a decidable inequality/equality on a computable divisor sum), enabling kernel `decide` on concrete numbers.",
+      "mathContext": "The Mathlib predicates are plain defs; exposing their Decidable instances lets numerical witnesses be checked by the kernel."
+    },
+    {
+      "id": "propagation",
+      "title": "Propagation of Abundance",
+      "startLine": 49,
+      "endLine": 76,
+      "summary": "`two_mul_le_sigma_of_abundant_or_perfect`: 2d ≤ σ(d) for abundant or perfect d. `abundant_of_proper_dvd_abundant_or_perfect`: feeding this to the parent strict gap gives d·(2n) < d·σ(n), hence n abundant.",
+      "mathContext": "Abundance is contagious upward: every proper multiple of an abundant or perfect number is abundant."
+    },
+    {
+      "id": "primitive",
+      "title": "Primitive Abundant Numbers",
+      "startLine": 77,
+      "endLine": 111,
+      "summary": "`IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ properDivisors n, d.Deficient`; `isPrimitiveAbundant_iff` characterises these as abundant numbers with no abundant-or-perfect proper divisor; `not_isPrimitiveAbundant_of_proper_multiple` rules out primitive abundant proper multiples.",
+      "mathContext": "Primitive abundant numbers are the minimal generators of the abundant numbers under divisibility."
+    },
+    {
+      "id": "least",
+      "title": "20 Is the Least Primitive Abundant Number",
+      "startLine": 112,
+      "endLine": 128,
+      "summary": "`isPrimitiveAbundant_twenty`, `twenty_least_isPrimitiveAbundant` (∀ m < 20), and the sanity check `twelve_not_isPrimitiveAbundant` — all by kernel `decide`. 12 and 18 fail because their proper divisor 6 is perfect.",
+      "mathContext": "20 = A091191(1); the obstruction below it is the perfect number 6 sitting inside 12 and 18."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "abundant_of_proper_dvd_abundant_or_perfect",
+      "type": "core",
+      "description": "d ∣ n → d < n → (d.Abundant ∨ d.Perfect) → n.Abundant: abundance propagates upward to every proper multiple of an abundant or perfect number. Answers open question index 1 of abundant-number-oq-04-oq-01.",
+      "leanType": "d ∣ n → d < n → (d.Abundant ∨ d.Perfect) → n.Abundant"
+    },
+    {
+      "name": "isPrimitiveAbundant_iff",
+      "type": "core",
+      "description": "IsPrimitiveAbundant n ↔ n.Abundant ∧ ∀ d ∈ n.properDivisors, ¬d.Abundant ∧ ¬d.Perfect: a primitive abundant number is an abundant number none of whose proper divisors is abundant or perfect.",
+      "leanType": "IsPrimitiveAbundant n ↔ n.Abundant ∧ ∀ d ∈ n.properDivisors, ¬ d.Abundant ∧ ¬ d.Perfect"
+    },
+    {
+      "name": "not_isPrimitiveAbundant_of_proper_multiple",
+      "type": "core",
+      "description": "IsPrimitiveAbundant d → d ∣ n → d < n → ¬IsPrimitiveAbundant n: no proper multiple of a primitive abundant number is itself primitive abundant (contrapositive of propagation).",
+      "leanType": "IsPrimitiveAbundant d → d ∣ n → d < n → ¬ IsPrimitiveAbundant n"
+    },
+    {
+      "name": "twenty_least_isPrimitiveAbundant",
+      "type": "core",
+      "description": "∀ m, m < 20 → ¬IsPrimitiveAbundant m, together with isPrimitiveAbundant_twenty : IsPrimitiveAbundant 20, certifies 20 as the least primitive abundant number (A091191(1)). Kernel decide; no native_decide.",
+      "leanType": "∀ m, m < 20 → ¬ IsPrimitiveAbundant m"
+    },
+    {
+      "name": "two_mul_le_sigma_of_abundant_or_perfect",
+      "type": "supporting",
+      "description": "(d.Abundant ∨ d.Perfect) → 2·d ≤ σ(d): the uniform bound (strict for abundant, equality for perfect) that drives propagation.",
+      "leanType": "d.Abundant ∨ d.Perfect → 2 * d ≤ ∑ e ∈ d.divisors, e"
+    },
+    {
+      "name": "isPrimitiveAbundant_twenty",
+      "type": "supporting",
+      "description": "IsPrimitiveAbundant 20: σ(20)=42>40 and proper divisors 1,2,4,5,10 are all deficient. Kernel decide.",
+      "leanType": "IsPrimitiveAbundant 20"
+    }
+  ],
+  "conclusion": {
+    "summary": "Turns the parent's strict abundancy gap into structural theorems about abundant numbers: (1) a proper multiple of an abundant or perfect number is abundant (abundant_of_proper_dvd_abundant_or_perfect), via the uniform bound 2d ≤ σ(d); (2) primitive abundant numbers — abundant numbers all of whose proper divisors are deficient — are exactly the abundant numbers with no abundant-or-perfect proper divisor (isPrimitiveAbundant_iff), no proper multiple of one is primitive abundant (not_isPrimitiveAbundant_of_proper_multiple), and 20 is the least primitive abundant number (twenty_least_isPrimitiveAbundant, isPrimitiveAbundant_twenty). Fully machine-checked, 0 axioms and 0 sorries.",
+    "implications": "Mathlib has the abundant/deficient/perfect predicates but no closure-under-multiples law and no primitive abundant number; this entry supplies the first formal propagation theorem and primitive-abundant characterisation, plus the certified least element 20. The no-proper-multiple corollary realises the standard fact that the primitive abundant numbers are the minimal generators of the abundant numbers under divisibility, giving a reusable handle for density and structure results on abundant numbers.",
+    "openQuestions": [
+      "Prove that every abundant number has a primitive abundant divisor (well-founded descent on the divisor order), making 'primitive abundant numbers generate the abundant numbers' a theorem rather than a slogan.",
+      "Characterise or enumerate the next primitive abundant numbers (70, 88, 104, ...) and show there are infinitely many — e.g. via the odd primitive abundant numbers — using the propagation law to exclude proper multiples."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Nicomachus of Gerasa",
+      "title": "Introduction to Arithmetic",
+      "year": "~100 CE",
+      "venue": "—",
+      "note": "Earliest classification of numbers as deficient, perfect, and abundant."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A091191: Primitive abundant numbers (abundant numbers with no abundant proper divisor)",
+      "year": "—",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "Begins 20, 70, 88, 104, 272, ...; this entry certifies 20 as the least and characterises the sequence."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abundant-number-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent. abundant-number-oq-04-oq-01 proves the strict, lower-bounded abundancy gap sigma_dvd_strict_mono (n·σ(d) + d ≤ d·σ(n) for d ∣ n, d < n). This entry uses that gap to prove propagation of abundance (its open question index 1) and to develop primitive abundant numbers, including the least element 20."
+    },
+    {
+      "targetId": "abundant-number-oq-04",
+      "relationship": "related",
+      "description": "Grandparent. Supplies the divisor-sum bridge deficient_iff_sigma_lt_two_mul / abundant_iff_two_mul_lt_sigma and the non-strict monotonicity that the parent sharpened; these bridges are reused here to read abundance off the strict gap."
+    },
+    {
+      "targetId": "abundant-number-oq-01",
+      "relationship": "related",
+      "description": "Establishes the abundant-side closure lemmas (abundant_mul_right, abundant_of_perfect_mul) via the same scaled-divisor injection; this entry gives the unified abundant-or-perfect propagation directly from the strict gap and adds the primitive abundant theory."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AbundantPrimitiveOQ040102.lean",
+    "namespace": "AbundantPrimitiveOQ040102",
+    "imports": [
+      "Mathlib",
+      "Proofs.AbundantStrictAbundancyOQ0401"
+    ],
+    "lineCount": 128,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 6,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Extends the parent **abundant-number-oq-04-oq-01** (the strict abundancy gap `sigma_dvd_strict_mono : n·σ(d) + d ≤ d·σ(n)` for `d ∣ n`, `d < n`) into two structural theorems on the divisor lattice of abundant numbers — directly answering the parent's open question index 1.

**(1) Propagation of abundance.** `abundant_of_proper_dvd_abundant_or_perfect : d ∣ n → d < n → (d.Abundant ∨ d.Perfect) → n.Abundant`. The abundant and perfect cases are unified by the single bound `2·d ≤ σ(d)` (strict for abundant, an equality for perfect); fed to the parent's strict `+d` gap it forces `d·(2n) < d·σ(n)`, hence `2n < σ(n)`.

**(2) Primitive abundant numbers.** Defines `IsPrimitiveAbundant n := n.Abundant ∧ ∀ d ∈ n.properDivisors, d.Deficient` (absent from Mathlib) and:
- `isPrimitiveAbundant_iff` — these are exactly the abundant numbers none of whose proper divisors is abundant or perfect (the deficient/abundant/perfect trichotomy applied divisor-by-divisor);
- `not_isPrimitiveAbundant_of_proper_multiple` — no proper multiple of a primitive abundant number is primitive abundant (contrapositive of propagation);
- `isPrimitiveAbundant_twenty` + `twenty_least_isPrimitiveAbundant` — **20 is the least primitive abundant number** (A091191(1)); the smaller abundant numbers 12 and 18 fail because their proper divisor 6 is perfect (`twelve_not_isPrimitiveAbundant`).

## Verification

- **6 theorems, 1 definition, 128 lines.** `Proofs/AbundantPrimitiveOQ040102.lean`.
- `#print axioms` on all results reports only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries**.
- Numerical witnesses use **kernel `decide`** (not `native_decide`), so **no `Lean.ofReduceBool`**. Local `Decidable` instances for `Nat.Abundant`/`Nat.Deficient`/`Nat.Perfect` enable them.
- Compiles against pinned Mathlib v4.26.0 (`lake env lean`); gallery `annotations:build` is clean for this slug (listings/manifest regenerated).

Status: `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)