### PR TITLE
Enrich 'The Fixed Field of the Frobenius' (frobenius-endomorphism-oq-01-oq-02): deepen annotations + sections

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/annotations.json
@@ -3,44 +3,60 @@
     "id": "frobenius-endomorphism-oq-01-oq-02-module-header",
     "proofId": "frobenius-endomorphism-oq-01-oq-02",
     "type": "concept",
-    "range": {
-      "startLine": 1,
-      "endLine": 38
-    },
+    "range": { "startLine": 1, "endLine": 31 },
     "title": "Module Header: The Fixed Field of the Frobenius",
-    "content": "The parent showed the Frobenius $x \\mapsto x^p$ is a ring homomorphism and is the identity on $\\mathbb{Z}/p$ (Fermat). This file answers: **which elements of a field $F$ of characteristic $p$ does the Frobenius fix?** The answer is the cleanest possible — the fixed points are *exactly* the prime subfield $\\mathbb{F}_p$:\n$$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F) \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x.$$\nGeometrically $x$ is fixed iff it is a root of $X^p - X$; this degree-$p$ polynomial has the $p$ elements of $\\mathbb{F}_p$ (Fermat) as $p$ distinct roots, so they exhaust the roots. On a **perfect** field (every finite field) the Frobenius is bijective — an automorphism."
+    "content": "The parent showed the Frobenius $x \\mapsto x^p$ is a ring homomorphism and is the identity on $\\mathbb{Z}/p$ (Fermat). This file answers: **which elements of a field $F$ of characteristic $p$ does the Frobenius fix?** The answer is the cleanest possible — the fixed points are *exactly* the prime subfield $\\mathbb{F}_p$:\n$$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F) \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x.$$\nGeometrically $x$ is fixed iff it is a root of $X^p - X$; this degree-$p$ polynomial has the $p$ elements of $\\mathbb{F}_p$ (Fermat) as $p$ distinct roots, so they exhaust the roots. On a **perfect** field (every finite field) the Frobenius is bijective — an automorphism.",
+    "mathContext": "$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x\\in(\\bot:\\mathrm{Subfield}\\,F) = \\mathbb{F}_p$; fixed points are the roots of $X^p - X$, exhausted by the $p$ Fermat-fixed elements.",
+    "significance": "context",
+    "relatedConcepts": ["fixed field", "prime subfield", "X^p − X", "perfect field", "Galois group of finite fields"],
+    "prerequisites": ["Frobenius endomorphism (parent)", "subfields", "characteristic p"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-02-fixed-field-bot",
     "proofId": "frobenius-endomorphism-oq-01-oq-02",
     "type": "theorem",
-    "range": {
-      "startLine": 40,
-      "endLine": 57
-    },
+    "range": { "startLine": 42, "endLine": 57 },
     "title": "The Fixed Field is the Prime Subfield ⊥",
-    "content": "`frobenius_fixed_iff_mem_bot`: $\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F)$ — the **central characterization**. The proof rewrites `frobenius_def` ($\\mathrm{frobenius}\\,F\\,p\\,x = x^p$, definitional) and applies Mathlib's `Subfield.mem_bot_iff_pow_eq_self`, whose content is that $X^p - X$ has degree $p$ and the $p$ Fermat-fixed elements of $\\mathbb{F}_p$ are all its roots.\n\n`pow_eq_self_iff_mem_bot`: the bare equation $x^p = x \\iff x \\in \\bot$. `fixedSet_frobenius_eq_bot`: the same fact as a `Set` equality $\\{x \\mid \\mathrm{frob}\\,x = x\\} = \\bot$, via `Set.ext`."
+    "content": "`frobenius_fixed_iff_mem_bot`: $\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F)$ — the **central characterization**. The proof rewrites `frobenius_def` ($\\mathrm{frobenius}\\,F\\,p\\,x = x^p$, definitional) and applies Mathlib's `Subfield.mem_bot_iff_pow_eq_self`, whose content is that $X^p - X$ has degree $p$ and the $p$ Fermat-fixed elements of $\\mathbb{F}_p$ are all its roots.\n\n`pow_eq_self_iff_mem_bot`: the bare equation $x^p = x \\iff x \\in \\bot$. `fixedSet_frobenius_eq_bot`: the same fact as a `Set` equality $\\{x \\mid \\mathrm{frob}\\,x = x\\} = \\bot$, via `Set.ext`.",
+    "mathContext": "$\\{x \\mid x^p = x\\} = (\\bot:\\mathrm{Subfield}\\,F)$; $X^p - X$ has exactly the $p$ prime-subfield elements as roots.",
+    "significance": "key",
+    "relatedConcepts": ["Subfield.mem_bot_iff_pow_eq_self", "fixed field", "roots of X^p − X", "Set.ext"],
+    "prerequisites": ["frobenius_def", "the bottom subfield ⊥"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-02-primefield",
     "proofId": "frobenius-endomorphism-oq-01-oq-02",
     "type": "theorem",
-    "range": {
-      "startLine": 59,
-      "endLine": 78
-    },
+    "range": { "startLine": 61, "endLine": 78 },
     "title": "Explicit 𝔽ₚ Description and the Element Count",
-    "content": "`frobenius_fixed_iff_mem_primeField`: the fixed points are exactly the image of the canonical map $\\mathbb{Z}/p \\to F$, i.e. $\\mathrm{frob}\\,x = x \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x$. The proof bridges the $\\bot$ characterization through `ZMod.fieldRange_castHom_eq_bot` ($\\bot$ = range of $\\mathbb{Z}/p \\to F$) and `RingHom.mem_fieldRange` (membership = existential).\n\n`frobenius_fixes_primeField`: the easy inclusion — every $\\iota(a)$, $a : \\mathbb{Z}/p$, is fixed (Fermat inside $F$).\n\n`card_fixedField_eq`: $\\mathrm{Nat.card}\\,(\\bot) = p$ (`Subfield.card_bot`) — the fixed field has exactly $p$ elements, so the Frobenius is the identity on $\\mathbb{F}_{p^n}$ only when $n = 1$."
+    "content": "`frobenius_fixed_iff_mem_primeField`: the fixed points are exactly the image of the canonical map $\\mathbb{Z}/p \\to F$, i.e. $\\mathrm{frob}\\,x = x \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x$. The proof bridges the $\\bot$ characterization through `ZMod.fieldRange_castHom_eq_bot` ($\\bot$ = range of $\\mathbb{Z}/p \\to F$) and `RingHom.mem_fieldRange` (membership = existential).\n\n`frobenius_fixes_primeField`: the easy inclusion — every $\\iota(a)$, $a : \\mathbb{Z}/p$, is fixed (Fermat inside $F$).\n\n`card_fixedField_eq`: $\\mathrm{Nat.card}\\,(\\bot) = p$ (`Subfield.card_bot`) — the fixed field has exactly $p$ elements, so the Frobenius is the identity on $\\mathbb{F}_{p^n}$ only when $n = 1$.",
+    "mathContext": "$\\mathrm{frob}\\,x = x \\iff x\\in\\mathrm{range}(\\mathbb{Z}/p\\to F)$; $|\\bot| = p$, so $\\mathrm{frob} = \\mathrm{id}$ on $\\mathbb{F}_{p^n}$ iff $n = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod.fieldRange_castHom_eq_bot", "RingHom.mem_fieldRange", "Subfield.card_bot", "prime subfield image"],
+    "prerequisites": ["the ⊥ characterization", "canonical map ZMod p → F"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-02-perfect",
     "proofId": "frobenius-endomorphism-oq-01-oq-02",
     "type": "theorem",
-    "range": {
-      "startLine": 80,
-      "endLine": 116
-    },
-    "title": "Perfect Fields, Finite-Field Synthesis, and a Concrete Check",
-    "content": "`frobenius_bijective_of_perfectField` / `frobenius_surjective_of_perfectField`: on a **perfect** field the Frobenius is bijective (`bijective_frobenius`) — an automorphism. The instances `expChar_prime` ($\\mathbb{F}_p$-characteristic $\\Rightarrow$ ExpChar) and `PerfectField.toPerfectRing` make this apply to every finite field. Bijectivity *is* the definition of perfection.\n\n`finiteField_frobenius_automorphism_with_primeField_fixed`: the synthesis — on a finite field the Frobenius is simultaneously an automorphism and has fixed field $\\mathbb{F}_p$, the generator of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$.\n\n`frobenius_zmod_five_fixes_all`: a concrete `decide` check (kernel reduction, no `native_decide`) that $x \\mapsto x^5$ fixes every element of $\\mathbb{Z}/5 = \\mathbb{F}_5$, its own prime field."
+    "range": { "startLine": 82, "endLine": 94 },
+    "title": "Perfect Fields: the Frobenius is an Automorphism",
+    "content": "`frobenius_bijective_of_perfectField` / `frobenius_surjective_of_perfectField`: on a **perfect** field the Frobenius is bijective (`bijective_frobenius`) — an automorphism. Injectivity is automatic on any field of characteristic $p$ (a field is a domain, so $x^p = y^p \\Rightarrow x = y$); surjectivity is exactly the defining property of perfection. Every finite field is perfect, so the Frobenius is always an automorphism there.",
+    "mathContext": "On a perfect field $F$: $\\mathrm{frobenius}\\,F\\,p$ is bijective. Injective always (domain), surjective $\\iff$ perfect.",
+    "significance": "key",
+    "relatedConcepts": ["perfect field", "bijective_frobenius", "Frobenius automorphism", "injectivity in a domain"],
+    "prerequisites": ["PerfectField typeclass", "fields are integral domains"]
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-02-synthesis",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02",
+    "type": "insight",
+    "range": { "startLine": 99, "endLine": 114 },
+    "title": "Finite-Field Synthesis and a Concrete Check",
+    "content": "`finiteField_frobenius_automorphism_with_primeField_fixed`: the synthesis — on a finite field the Frobenius is simultaneously an automorphism AND has fixed field $\\mathbb{F}_p$, i.e. it is the generator of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ with fixed field exactly the prime subfield. `frobenius_zmod_five_fixes_all`: a concrete `decide` check (kernel reduction, no `native_decide`) that $x \\mapsto x^5$ fixes every element of $\\mathbb{Z}/5 = \\mathbb{F}_5$ — the degenerate $n = 1$ case where the field IS its own prime subfield.",
+    "mathContext": "On $\\mathbb{F}_{p^n}$: $\\mathrm{frob}$ bijective $\\wedge$ fixed field $=\\mathbb{F}_p$, the generator of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ (cyclic of order $n$). For $\\mathbb{F}_5$: $x^5 = x$ for all $x$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois group of finite fields", "Frobenius generator", "decide vs native_decide", "n = 1 degenerate case"],
+    "prerequisites": ["the fixed-field and perfect-field results", "finite fields"]
   }
 ]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/meta.json
@@ -91,6 +91,40 @@
       "Decidability of universally-quantified statements over finite types (decide)"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Docstring framing the open question (which elements does the Frobenius fix?) and the answer: the fixed points are exactly the prime subfield 𝔽ₚ = ⊥, equivalently the roots of Xᵖ − X (exhausted by the p Fermat-fixed elements). Notes the synthesis with perfect fields (Frobenius bijective). Fully verified (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "$\\mathrm{frob}\\,x = x \\iff x\\in\\bot = \\mathbb{F}_p$; fixed set $= $ roots of $X^p - X$."
+    },
+    {
+      "id": "sec-fixed-bot",
+      "title": "The Fixed Field is the Prime Subfield ⊥",
+      "startLine": 40,
+      "endLine": 57,
+      "summary": "frobenius_fixed_iff_mem_bot (frob x = x ⟺ x ∈ ⊥, via frobenius_def + Subfield.mem_bot_iff_pow_eq_self), pow_eq_self_iff_mem_bot (the bare xᵖ = x ⟺ x ∈ ⊥), and fixedSet_frobenius_eq_bot (the same as a Set equality via Set.ext).",
+      "mathContext": "$\\{x \\mid x^p = x\\} = (\\bot:\\mathrm{Subfield}\\,F)$."
+    },
+    {
+      "id": "sec-primefield",
+      "title": "Explicit 𝔽ₚ Description and Element Count",
+      "startLine": 59,
+      "endLine": 78,
+      "summary": "frobenius_fixed_iff_mem_primeField (fixed ⟺ in the image of ZMod p → F, via fieldRange_castHom_eq_bot + mem_fieldRange), frobenius_fixes_primeField (each ι(a) is fixed by Fermat), and card_fixedField_eq (Nat.card ⊥ = p, via Subfield.card_bot).",
+      "mathContext": "$\\mathrm{frob}\\,x = x \\iff \\exists a:\\mathbb{Z}/p,\\ \\iota(a)=x$; $|\\bot| = p$."
+    },
+    {
+      "id": "sec-perfect",
+      "title": "Perfect Fields and Finite-Field Synthesis",
+      "startLine": 80,
+      "endLine": 116,
+      "summary": "frobenius_bijective_of_perfectField / frobenius_surjective_of_perfectField (the Frobenius is an automorphism on a perfect field, via bijective_frobenius); finiteField_frobenius_automorphism_with_primeField_fixed (on a finite field: automorphism ∧ fixed field = 𝔽ₚ, the Gal generator); and the decide check frobenius_zmod_five_fixes_all (x ↦ x⁵ fixes all of ZMod 5).",
+      "mathContext": "Perfect $\\Rightarrow$ $\\mathrm{frob}$ bijective; on $\\mathbb{F}_{p^n}$, fixed field $=\\mathbb{F}_p$, generator of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "frobenius-endomorphism-oq-01",


### PR DESCRIPTION
Enrichment (deepening) pass for `frobenius-endomorphism-oq-01-oq-02` (quality 55, 0 prior passes).

## Gaps addressed
The entry had 4 detailed annotations but **none carried `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**, and meta.json had **no `sections` array**.

1. **Deepened all annotations** — added the 4 structured fields to each (preserving existing prose).
2. **Split** the perfect-field annotation into perfect-fields + finite-field synthesis, giving **5 annotations** (header; fixed field = ⊥; explicit 𝔽ₚ + count; perfect fields; finite-field synthesis + decide check).
3. **Added a `sections` array** covering all four source sections.

## Verification
- meta.json and annotations.json validate as JSON; `pnpm annotations:build` reports no errors for this entry (ranges snapped to Lean constructs).
- Axiom integrity preserved: meta declares `status: verified`, `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom decls; the ZMod 5 check uses `decide` (kernel), not `native_decide`). No claims changed.