### PR TITLE
research(erdos-933-oq-05): resolve 3 sorries — verified Steinerberger bound [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos933OQ05.lean
+++ b/proofs/Proofs/Erdos933OQ05.lean
@@ -1,0 +1,203 @@
+/-
+  Erdős Problem #933 — Open Question #5 (verified resolution of the three sorries)
+
+  Parent entry: `erdos-933` ("Smooth Part of Consecutive Products"), which is
+  *axiomatized* and whose `conclusion.openQuestions[4]` asks:
+
+    "Can the 3 sorries (`steinerberger_gives_large_smooth`, `power2_consecutive`,
+     `power3_consecutive`) be resolved via Mathlib tactics?"
+
+  Answer: YES. This file discharges all three with 0 axioms and 0 sorries, and in
+  doing so gives a *fully verified* proof of the genuine Erdős/Steinerberger
+  statement:
+
+    For infinitely many n, the {2,3}-smooth part of n(n+1) exceeds n · log n.
+
+  (Erdős, "Problems and results on consecutive integers" (1976): Mahler proved
+   2^k·3^l < n^{1+o(1)}; Erdős noted it is "easy to see" that 2^k·3^l > n·log n for
+   infinitely many n; Steinerberger gave the simple witness n = 2^{3^r}.)
+
+  Mathematical note on the parent's framing.  For Steinerberger's witnesses
+  n = 2^{3^r} one has 2^k·3^l = n·3^{r+1} and n·log n = n·3^r·log 2, so the ratio
+  2^k·3^l/(n·log n) = 3/log 2 ≈ 4.33 — a CONSTANT exceeding 1, not tending to ∞.
+  Thus this construction proves precisely the "infinitely often > n·log n" claim
+  that Erdős actually stated; it does not by itself establish limsup = ∞.
+
+  Engine.  The single nontrivial input is the lifting-the-exponent fact
+    3^{r+1} ∣ 2^{3^r} + 1,
+  proved here by an elementary induction from the factorisation
+    a^3 + 1 = (a+1)(a^2 - a + 1),  with  3 ∣ a^2 - a + 1  whenever 3 ∣ a + 1.
+-/
+
+import Mathlib
+
+open Nat Real
+
+namespace Erdos933OQ05
+
+/-! ## Part I: Basic definitions (mirroring the parent entry) -/
+
+/-- The {2,3}-smooth part of `n`: the largest divisor of the form `2^a · 3^b`. -/
+def smoothPart23 (n : ℕ) : ℕ := 2 ^ n.factorization 2 * 3 ^ n.factorization 3
+
+/-- The {2,3}-smooth part of `n(n+1)`. -/
+def consecutiveSmoothPart (n : ℕ) : ℕ := smoothPart23 (n * (n + 1))
+
+/-! ## Part II: The lifting-the-exponent engine
+
+`3^{r+1} ∣ 2^{3^r} + 1`, the divisibility that powers Steinerberger's witness. -/
+
+/-- One inductive step of the LTE computation, stated over `ℤ` to dodge `ℕ`
+    truncated subtraction.  If `3^{e+1} ∣ a + 1` then `3^{e+2} ∣ a^3 + 1`. -/
+theorem lift3 (a : ℤ) (e : ℕ) (h : (3 : ℤ) ^ (e + 1) ∣ a + 1) :
+    (3 : ℤ) ^ (e + 2) ∣ a ^ 3 + 1 := by
+  obtain ⟨u, hu⟩ := h
+  -- 3 ∣ a + 1 (since 3 ∣ 3^{e+1})
+  have h3 : (3 : ℤ) ∣ a + 1 := (dvd_pow_self 3 (Nat.succ_ne_zero e)).trans ⟨u, hu⟩
+  obtain ⟨t, ht⟩ := h3
+  have e1 : a = 3 * t - 1 := by linarith
+  refine ⟨u * (3 * t ^ 2 - 3 * t + 1), ?_⟩
+  have factored : a ^ 3 + 1 = (a + 1) * (a ^ 2 - a + 1) := by ring
+  rw [factored, hu, e1, pow_succ]; ring
+
+/-- **LTE core.**  `3^{r+1}` divides `2^{3^r} + 1` for every `r`. -/
+theorem lte_core (r : ℕ) : (3 : ℕ) ^ (r + 1) ∣ 2 ^ (3 ^ r) + 1 := by
+  induction r with
+  | zero => decide
+  | succ r ih =>
+    have ihZ : (3 : ℤ) ^ (r + 1) ∣ (2 : ℤ) ^ (3 ^ r) + 1 := by exact_mod_cast ih
+    have hlift := lift3 ((2 : ℤ) ^ (3 ^ r)) r ihZ
+    have hpow : (2 : ℕ) ^ (3 ^ (r + 1)) = (2 ^ (3 ^ r)) ^ 3 := by
+      rw [pow_succ, pow_mul]
+    rw [hpow]
+    exact_mod_cast hlift
+
+/-! ## Part III: resolving `power2_consecutive` and `power3_consecutive`
+
+The two factorisation sorries of the parent file, for an arbitrary prime exponent. -/
+
+/-- The exponent of a prime in `n(n+1)` is the sum of its exponents in `n` and
+    `n+1` (the parent's `power2_consecutive` / `power3_consecutive`, uniformly). -/
+theorem factorization_consecutive (p n : ℕ) :
+    (n * (n + 1)).factorization p = n.factorization p + (n + 1).factorization p := by
+  rcases Nat.eq_zero_or_pos n with h | h
+  · subst h; simp
+  · rw [Nat.factorization_mul h.ne' (Nat.succ_ne_zero n)]; simp
+
+/-- The parent's `power2_consecutive`. -/
+theorem power2_consecutive (n : ℕ) :
+    (n * (n + 1)).factorization 2 = n.factorization 2 + (n + 1).factorization 2 :=
+  factorization_consecutive 2 n
+
+/-- The parent's `power3_consecutive`. -/
+theorem power3_consecutive (n : ℕ) :
+    (n * (n + 1)).factorization 3 = n.factorization 3 + (n + 1).factorization 3 :=
+  factorization_consecutive 3 n
+
+/-! ## Part IV: the smooth part of `2^{3^r} · (2^{3^r} + 1)` -/
+
+/-- `2^e` carries exactly `e` factors of 2. -/
+theorem fact2_pow2 (e : ℕ) : (2 ^ e).factorization 2 = e := by
+  rw [Nat.Prime.factorization_pow Nat.prime_two]; simp
+
+/-- **Resolving `steinerberger_gives_large_smooth` (ℕ form).**
+    For `n = 2^{3^r}`, the {2,3}-smooth part of `n(n+1)` is at least `n · 3^{r+1}`. -/
+theorem steinerberger_smooth_lower (r : ℕ) :
+    2 ^ (3 ^ r) * 3 ^ (r + 1) ≤ consecutiveSmoothPart (2 ^ (3 ^ r)) := by
+  have hn0 : (2 ^ (3 ^ r)) ≠ 0 := by positivity
+  have hn1 : (2 ^ (3 ^ r)) + 1 ≠ 0 := Nat.succ_ne_zero _
+  -- 2-part: at least 3^r (all of it already lives in n)
+  have hv2 : 3 ^ r ≤ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 2 := by
+    rw [power2_consecutive, fact2_pow2]; exact Nat.le_add_right _ _
+  -- 3-part: at least r+1 (all of it lives in n+1, by the LTE core)
+  have hv3n1 : r + 1 ≤ (2 ^ (3 ^ r) + 1).factorization 3 :=
+    (Nat.Prime.pow_dvd_iff_le_factorization Nat.prime_three hn1).mp (lte_core r)
+  have hv3 : r + 1 ≤ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 3 := by
+    rw [power3_consecutive]; exact le_trans hv3n1 (Nat.le_add_left _ _)
+  -- assemble the product bound
+  have e2 : 2 ^ (3 ^ r) ≤ 2 ^ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 2 :=
+    Nat.pow_le_pow_right (by norm_num) hv2
+  have e3 : 3 ^ (r + 1) ≤ 3 ^ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 3 :=
+    Nat.pow_le_pow_right (by norm_num) hv3
+  calc 2 ^ (3 ^ r) * 3 ^ (r + 1)
+      ≤ 2 ^ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 2
+          * 3 ^ (2 ^ (3 ^ r) * (2 ^ (3 ^ r) + 1)).factorization 3 := Nat.mul_le_mul e2 e3
+    _ = consecutiveSmoothPart (2 ^ (3 ^ r)) := rfl
+
+/-! ## Part V: exceeding `n · log n`, and infinitely often -/
+
+/-- For `n = 2^{3^r}`, the {2,3}-smooth part of `n(n+1)` strictly exceeds
+    `n · log n`.  Quantitatively the smooth part is `≥ n · 3^{r+1}` while
+    `n · log n = n · 3^r · log 2`, and `3^{r+1} > 3^r · log 2` because
+    `3 > log 2`. -/
+theorem steinerberger_exceeds (r : ℕ) :
+    (2 ^ (3 ^ r) : ℝ) * Real.log (2 ^ (3 ^ r))
+      < (consecutiveSmoothPart (2 ^ (3 ^ r)) : ℝ) := by
+  set n : ℝ := (2 ^ (3 ^ r) : ℝ) with hn
+  have hnpos : (0 : ℝ) < n := by rw [hn]; positivity
+  -- log (2^{3^r}) = 3^r · log 2
+  have hlog : Real.log (2 ^ (3 ^ r)) = (3 ^ r : ℝ) * Real.log 2 := by
+    rw [show ((2 : ℝ) ^ (3 ^ r)) = (2 : ℝ) ^ (3 ^ r : ℕ) from by norm_num,
+      Real.log_pow]
+    push_cast; ring
+  -- 3 > log 2
+  have hlog2 : Real.log 2 < 3 := by
+    have : Real.log 2 < 1 := by
+      have h2 : (2 : ℝ) < Real.exp 1 := by
+        have := Real.exp_one_gt_d9; linarith
+      calc Real.log 2 < Real.log (Real.exp 1) := by
+            exact Real.log_lt_log (by norm_num) h2
+        _ = 1 := Real.log_exp 1
+    linarith
+  -- n · log n < n · 3^{r+1} ≤ smooth part
+  have step1 : n * Real.log (2 ^ (3 ^ r)) < n * (3 ^ (r + 1) : ℝ) := by
+    rw [hlog]
+    have h3r : (0 : ℝ) < (3 ^ r : ℝ) := by positivity
+    have : (3 ^ r : ℝ) * Real.log 2 < (3 ^ (r + 1) : ℝ) := by
+      rw [pow_succ]
+      have : (3 ^ r : ℝ) * Real.log 2 < (3 ^ r : ℝ) * 3 := by
+        apply mul_lt_mul_of_pos_left hlog2 h3r
+      linarith
+    apply mul_lt_mul_of_pos_left this hnpos
+  have step2 : n * (3 ^ (r + 1) : ℝ) ≤ (consecutiveSmoothPart (2 ^ (3 ^ r)) : ℝ) := by
+    have hnat := steinerberger_smooth_lower r
+    have : ((2 ^ (3 ^ r) * 3 ^ (r + 1) : ℕ) : ℝ) ≤ (consecutiveSmoothPart (2 ^ (3 ^ r)) : ℝ) := by
+      exact_mod_cast hnat
+    rw [hn]; push_cast at this ⊢; linarith
+  linarith [step1, step2]
+
+/-- **Main verified result (genuine Erdős/Steinerberger claim).**
+    For every `N` there is `n > N` whose consecutive product `n(n+1)` has
+    {2,3}-smooth part exceeding `n · log n`.  In particular this holds for
+    infinitely many `n`, with no axioms. -/
+theorem smooth_part_exceeds_n_log_n_infinitely_often :
+    ∀ N : ℕ, ∃ n : ℕ, n > N ∧
+      (consecutiveSmoothPart n : ℝ) > (n : ℝ) * Real.log n := by
+  intro N
+  -- choose r with 2^{3^r} > N; r = N suffices since 2^{3^N} > N
+  refine ⟨2 ^ (3 ^ N), ?_, ?_⟩
+  · -- 2^{3^N} > N
+    calc N < 2 ^ N := Nat.lt_two_pow_self
+      _ ≤ 2 ^ (3 ^ N) := Nat.pow_le_pow_right (by norm_num) (Nat.lt_pow_self (by norm_num)).le
+  · have := steinerberger_exceeds N
+    push_cast at this ⊢
+    linarith
+
+/-! ## Part VI: small sanity checks (kernel-decidable, axiom-free) -/
+
+/-- The LTE core at `r = 2`: `3^3 = 27 ∣ 2^9 + 1 = 513`. -/
+example : (3 : ℕ) ^ 3 ∣ 2 ^ (3 ^ 2) + 1 := by decide
+
+/-- The LTE core at `r = 3`: `3^4 = 81 ∣ 2^27 + 1`. -/
+example : (3 : ℕ) ^ 4 ∣ 2 ^ (3 ^ 3) + 1 := by decide
+
+/-! ## Part VII: axiom audit -/
+
+-- All main results depend only on the standard foundational axioms
+-- (`propext`, `Classical.choice`, `Quot.sound`); no `sorryAx`, no `Lean.ofReduceBool`.
+#print axioms lte_core
+#print axioms steinerberger_smooth_lower
+#print axioms steinerberger_exceeds
+#print axioms smooth_part_exceeds_n_log_n_infinitely_often
+
+end Erdos933OQ05

--- a/src/data/proofs/erdos-933-oq-05/meta.json
+++ b/src/data/proofs/erdos-933-oq-05/meta.json
@@ -1,0 +1,96 @@
+{
+  "id": "erdos-933-oq-05",
+  "title": "Erdős 933: Resolving the Three Sorries — a Verified Steinerberger Bound",
+  "slug": "erdos-933-oq-05",
+  "description": "Answers Erdős #933's open question #5 ('Can the 3 sorries be resolved via Mathlib tactics?'): YES. Discharges power2_consecutive, power3_consecutive, and steinerberger_gives_large_smooth with 0 axioms and 0 sorries, yielding a fully verified proof of the genuine Erdős/Steinerberger statement — for infinitely many n the {2,3}-smooth part of n(n+1) exceeds n·log n. The engine is the lifting-the-exponent divisibility 3^{r+1} ∣ 2^{3^r}+1, proved by elementary induction. Also corrects the parent's framing: Steinerberger's witnesses n=2^{3^r} give ratio 2^k3^l/(n·log n)=3/log2≈4.33, a constant >1, not limsup=∞.",
+  "meta": {
+    "author": "Researcher Agent (Lean Genius)",
+    "sourceUrl": "https://erdosproblems.com/933",
+    "date": "1976",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos933OQ05.lean",
+    "tags": ["erdos", "number-theory", "smooth-numbers", "consecutive-integers", "lifting-the-exponent", "factorization", "verified", "axiom-elimination"],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 933,
+    "erdosUrl": "https://erdosproblems.com/933",
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {"theorem": "Nat.factorization_mul", "description": "(a·b).factorization = a.factorization + b.factorization for nonzero a, b — gives the additivity of prime exponents over the coprime product n(n+1)", "module": "Mathlib.Data.Nat.Factorization.Basic"},
+      {"theorem": "Nat.Prime.factorization_pow", "description": "(p^n).factorization = single p n — used to read off v₂(2^{3^r}) = 3^r exactly", "module": "Mathlib.Data.Nat.Factorization.Basic"},
+      {"theorem": "Nat.Prime.pow_dvd_iff_le_factorization", "description": "p^k ∣ n ↔ k ≤ n.factorization p (n ≠ 0): converts the LTE divisibility 3^{r+1} ∣ 2^{3^r}+1 into the valuation bound v₃ ≥ r+1", "module": "Mathlib.Data.Nat.Factorization.Basic"},
+      {"theorem": "dvd_pow_self", "description": "a ∣ a^n for n ≠ 0 — extracts 3 ∣ a+1 from 3^{e+1} ∣ a+1 in the LTE inductive step", "module": "Mathlib.Algebra.GroupPower.Basic"},
+      {"theorem": "Real.log_pow", "description": "log(x^n) = n·log x — gives log(2^{3^r}) = 3^r·log 2 for the real-number comparison", "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"},
+      {"theorem": "Real.exp_one_gt_d9", "description": "e > 2.7182818283 — used to certify log 2 < 1 < 3, the inequality 3 > log 2 behind 'exceeds n·log n'", "module": "Mathlib.Analysis.SpecialFunctions.Exp"},
+      {"theorem": "Nat.lt_two_pow_self", "description": "n < 2^n — picks a witness n = 2^{3^N} > N to make the result hold for infinitely many n", "module": "Mathlib.Algebra.Order.Monoid.Lemmas"}
+    ],
+    "originalContributions": [
+      "lift3: the lifting-the-exponent inductive step over ℤ — if 3^{e+1} ∣ a+1 then 3^{e+2} ∣ a^3+1, via a^3+1=(a+1)(a^2-a+1) with 3 ∣ a^2-a+1 whenever 3 ∣ a+1 (ℤ avoids ℕ truncated subtraction)",
+      "lte_core: 3^{r+1} ∣ 2^{3^r}+1 for all r, by induction using lift3 and 2^{3^{r+1}}=(2^{3^r})^3 — the genuine number-theoretic engine of Steinerberger's construction",
+      "factorization_consecutive: resolves the parent's power2_consecutive and power3_consecutive sorries uniformly for every prime p, via Nat.factorization_mul plus the n=0 edge case",
+      "fact2_pow2: v₂(2^e)=e, the exact 2-adic valuation of a power of two",
+      "steinerberger_smooth_lower: resolves the parent's steinerberger_gives_large_smooth sorry — for n=2^{3^r}, the {2,3}-smooth part of n(n+1) is ≥ n·3^{r+1} (ℕ form, no logarithm)",
+      "steinerberger_exceeds: the {2,3}-smooth part of n(n+1) strictly exceeds n·log n for n=2^{3^r}, using 3^{r+1} > 3^r·log 2 because 3 > log 2",
+      "smooth_part_exceeds_n_log_n_infinitely_often: the verified headline — for every N there is n>N with consecutiveSmoothPart n > n·log n, i.e. Erdős's actual 'infinitely often' claim, 0 axioms",
+      "Corrects the parent entry's mathematical framing: Steinerberger's n=2^{3^r} give a CONSTANT ratio 2^k3^l/(n·log n)=3/log2≈4.33 (>1), establishing the i.o. claim Erdős stated, not limsup=∞"
+    ],
+    "axiomCount": 0,
+    "lineCount": 203,
+    "assumptions": "None. All four headline results (lte_core, steinerberger_smooth_lower, steinerberger_exceeds, smooth_part_exceeds_n_log_n_infinitely_often) depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (verified by #print axioms). No sorryAx, no Lean.ofReduceBool; the two example sanity checks use kernel decide, not native_decide.",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat", "Real"],
+    "namespace": "Erdos933OQ05",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos933OQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {"targetId": "erdos-933", "relationship": "parent", "description": "Original Erdős #933 formalization (axiomatized: 1 axiom + 3 sorries). This entry answers its open question #5 by discharging all three sorries with 0 axioms and proving the genuine Steinerberger result."}
+  ],
+  "overview": {
+    "historicalContext": "Write n(n+1) = 2^k·3^l·m with gcd(m,6)=1. Mahler proved 2^k·3^l < n^{1+o(1)} (an upper bound from the theory of S-unit equations). Erdős, in 'Problems and results on consecutive integers' (1976), remarked that 'it is easy to see' that 2^k·3^l > n·log n for infinitely many n. Steinerberger supplied the simple witness: take n = 2^{3^r}, so that the 2-part is exactly k = 3^r and (by lifting the exponent) the 3-part is l = r+1. The parent gallery entry encoded this with one axiom and three sorries; this entry removes them.",
+    "problemStatement": "Open question #5 of Erdos933Problem.lean: can the three sorries — power2_consecutive, power3_consecutive, and steinerberger_gives_large_smooth — be resolved via Mathlib tactics (and, with them, the result de-axiomatized)?",
+    "text": "All three sorries are elementary once the one genuinely number-theoretic fact is isolated: 3^{r+1} ∣ 2^{3^r}+1. This is the lifting-the-exponent (LTE) input v₃(2^{3^r}+1) = r+1, here proved by induction on r. The inductive step uses the factorisation a^3+1 = (a+1)(a^2-a+1): if 3^{e+1} ∣ a+1 then in particular 3 ∣ a+1, whence a ≡ -1 (mod 3) and a^2-a+1 ≡ 3 ≡ 0 (mod 3), so the product gains exactly one more factor of 3 and 3^{e+2} ∣ a^3+1. Working over ℤ sidesteps ℕ truncated subtraction. The two factorisation sorries reduce to Nat.factorization_mul (additivity of prime exponents over a product of nonzero naturals). The smooth-part lower bound then assembles: for n = 2^{3^r}, v₂(n(n+1)) ≥ v₂(n) = 3^r so the 2-part is ≥ n, and v₃(n(n+1)) ≥ v₃(n+1) ≥ r+1 so the 3-part is ≥ 3^{r+1}, giving smooth part ≥ n·3^{r+1}.",
+    "proofStrategy": "(I) Prove the LTE step lift3 over ℤ and induct to get lte_core: 3^{r+1} ∣ 2^{3^r}+1. (II) Resolve power2_consecutive / power3_consecutive via Nat.factorization_mul (factorization_consecutive). (III) Combine to lower-bound the smooth part: smoothPart23(n(n+1)) ≥ 2^{v₂} · 3^{v₃} ≥ n · 3^{r+1} for n = 2^{3^r}. (IV) Compare with n·log n: since log(2^{3^r}) = 3^r·log 2 and 3 > log 2, n·3^{r+1} > n·log n. (V) Conclude infinitely often by choosing n = 2^{3^N} > N.",
+    "keyInsights": [
+      "The only nontrivial ingredient is the lifting-the-exponent divisibility 3^{r+1} ∣ 2^{3^r}+1; everything else is bookkeeping with prime valuations.",
+      "LTE here needs no special-function machinery — the single identity a^3+1=(a+1)(a^2-a+1) plus '3 ∣ a+1 ⟹ 3 ∣ a^2-a+1' powers the whole induction, and working over ℤ avoids ℕ subtraction pitfalls.",
+      "Steinerberger's construction gives a CONSTANT ratio 2^k·3^l/(n·log n) = 3^{r+1}/(3^r·log 2) = 3/log 2 ≈ 4.33, so it proves exactly Erdős's 'infinitely often > n·log n', not limsup = ∞ — a clarification of the parent entry's framing.",
+      "The {2,3}-smooth part factors as 2^{v₂} · 3^{v₃}, so a lower bound on each valuation immediately lower-bounds the smooth part; the 2-part already accounts for the full size of n."
+    ],
+    "prerequisites": ["Prime factorization / p-adic valuation (Nat.factorization)", "Lifting the Exponent lemma", "Coprimality of consecutive integers", "Basic real logarithm inequalities"]
+  },
+  "sections": [
+    {"id": "part-1", "title": "Part I: Basic definitions", "startLine": 38, "endLine": 44, "summary": "smoothPart23 and consecutiveSmoothPart, mirroring the parent entry.", "mathContext": "smoothPart23(n) = 2^{v₂(n)} · 3^{v₃(n)}; the {2,3}-smooth part of n(n+1)."},
+    {"id": "part-2", "title": "Part II: The lifting-the-exponent engine", "startLine": 46, "endLine": 73, "summary": "lift3 (ℤ inductive step) and lte_core: 3^{r+1} ∣ 2^{3^r}+1.", "mathContext": "v₃(2^{3^r}+1) = r+1, from a^3+1=(a+1)(a^2-a+1)."},
+    {"id": "part-3", "title": "Part III: Resolving power2_consecutive and power3_consecutive", "startLine": 75, "endLine": 95, "summary": "factorization_consecutive: additivity of prime exponents over n(n+1), discharging two parent sorries.", "mathContext": "(n(n+1)).factorization p = n.factorization p + (n+1).factorization p."},
+    {"id": "part-4", "title": "Part IV: The smooth part of 2^{3^r}·(2^{3^r}+1)", "startLine": 97, "endLine": 125, "summary": "fact2_pow2 and steinerberger_smooth_lower: the {2,3}-smooth part is ≥ n·3^{r+1}.", "mathContext": "Resolves steinerberger_gives_large_smooth (ℕ form)."},
+    {"id": "part-5", "title": "Part V: Exceeding n·log n, infinitely often", "startLine": 127, "endLine": 184, "summary": "steinerberger_exceeds and the headline smooth_part_exceeds_n_log_n_infinitely_often.", "mathContext": "n·3^{r+1} > n·log n via 3 > log 2; witnesses n = 2^{3^N} > N."},
+    {"id": "part-6", "title": "Part VI–VII: Sanity checks and axiom audit", "startLine": 186, "endLine": 203, "summary": "Kernel-decidable LTE checks at r=2,3; #print axioms confirming only propext/Classical.choice/Quot.sound.", "mathContext": "27 ∣ 513, 81 ∣ 2^27+1; 0-axiom certification."}
+  ],
+  "conclusion": {
+    "summary": "Erdős #933's open question #5 is answered affirmatively: all three sorries (power2_consecutive, power3_consecutive, steinerberger_gives_large_smooth) are discharged with Mathlib tactics, with 0 axioms and 0 sorries. The result is the genuine Erdős/Steinerberger statement — for infinitely many n, the {2,3}-smooth part of n(n+1) exceeds n·log n — now fully machine-verified. The engine is the elementary lifting-the-exponent fact 3^{r+1} ∣ 2^{3^r}+1.",
+    "implications": "This de-axiomatizes the heart of Problem #933 and isolates exactly what Steinerberger's construction does and does not prove. It establishes Erdős's stated 'infinitely often > n·log n' with no assumptions, while clarifying that these witnesses give a bounded (constant ≈ 4.33) ratio, so they do NOT establish limsup = ∞ — that stronger claim, asserted by the parent entry, remains open. The reusable contribution is the verified, axiom-free LTE divisibility 3^{r+1} ∣ 2^{3^r}+1 and the smooth-part lower bound smoothPart23(n(n+1)) ≥ n·3^{r+1} for n = 2^{3^r}.",
+    "openQuestions": [
+      "Is limsup_{n→∞} 2^k·3^l/(n·log n) actually infinite, or bounded? Steinerberger's witnesses give only the constant 3/log 2 ≈ 4.33; a different family (or a proof of boundedness) is needed to settle the parent entry's stronger framing.",
+      "Can the exact valuation v₃(2^{3^r}+1) = r+1 (not merely ≥) be formalized via Mathlib's multiplicity / LTE API, sharpening lte_core to an equality?",
+      "Does the n = 3^{2^r} family give an analogous verified bound with the roles of 2 and 3 exchanged, and does it improve the constant?",
+      "For a general finite set S = {p₁,…,p_k} of primes, what is the verified threshold for the S-smooth part of n(n+1), and does an LTE-style witness construction generalize?"
+    ]
+  },
+  "references": [
+    {"key": "erdos1976", "title": "Problems and results on consecutive integers", "author": "P. Erdős", "year": "1976", "venue": "Publ. Math. Debrecen / Eureka 38"},
+    {"key": "mahler1953", "title": "On the greatest prime factor of ax^m + by^n", "author": "K. Mahler", "year": "1953", "venue": "Nieuw Arch. Wisk."},
+    {"key": "steinerberger", "title": "Note on Erdős Problem #933 (simple construction n = 2^{3^r})", "author": "S. Steinerberger", "year": "2024", "venue": "erdosproblems.com/933"}
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #933 — Open Question #5 (verified)

Parent `erdos-933` ("Smooth Part of Consecutive Products") is **axiomatized** (1 axiom + 3 sorries). Its open question #5 asks:

> Can the 3 sorries (`steinerberger_gives_large_smooth`, `power2_consecutive`, `power3_consecutive`) be resolved via Mathlib tactics?

**Answer: YES.** This leaf discharges all three with **0 axioms, 0 sorries**, yielding a fully verified proof of the genuine Erdős/Steinerberger statement:

> For infinitely many `n`, the {2,3}-smooth part of `n(n+1)` exceeds `n·log n`.

### Engine
The one nontrivial input is the lifting-the-exponent divisibility **3^{r+1} ∣ 2^{3^r}+1**, proved by elementary induction from `a^3+1 = (a+1)(a^2-a+1)` (with `3 ∣ a+1 ⟹ 3 ∣ a^2-a+1`), worked over ℤ to dodge ℕ truncated subtraction. Everything else is bookkeeping with prime valuations (`Nat.factorization_mul`, `Nat.Prime.pow_dvd_iff_le_factorization`).

### Key results
- `lte_core : 3^{r+1} ∣ 2^{3^r}+1`
- `factorization_consecutive` — resolves `power2_consecutive` / `power3_consecutive`
- `steinerberger_smooth_lower` — resolves `steinerberger_gives_large_smooth`: smooth part ≥ n·3^{r+1}
- `smooth_part_exceeds_n_log_n_infinitely_often` — the verified headline

### Framing correction
Steinerberger's witnesses `n=2^{3^r}` give a **constant** ratio `2^k·3^l/(n·log n) = 3/log2 ≈ 4.33` (>1) — exactly Erdős's stated *infinitely-often* claim, **not** `limsup = ∞` (which the parent asserts and which remains open).

### Verification
`#print axioms` on all four headline theorems: only `propext, Classical.choice, Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool` (sanity checks use kernel `decide`). Built against pinned Mathlib v4.26.0.

203 lines · 9 theorems · 2 defs · 0 axioms · 0 sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)