### PR TITLE
research(gauss-lemma-primitive-oq-01-oq-02): X³−X−1 irreducible over ℚ via mod-2 reduction [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2996,6 +2996,7 @@ import Proofs.GammaReflectionFormulaOQ01OQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GammaReflectionFormulaOQ01OQ03OQ01
 import Proofs.GaussLemmaPrimitiveOQ01
+import Proofs.GaussLemmaPrimitiveOQ01OQ02
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01
 import Proofs.GaussWilsonNonCyclicOQ01A

--- a/proofs/Proofs/GaussLemmaPrimitiveOQ01OQ02.lean
+++ b/proofs/Proofs/GaussLemmaPrimitiveOQ01OQ02.lean
@@ -1,0 +1,115 @@
+/-
+Gauss's Lemma in action: the monic cubic `X^3 - X - 1` is irreducible over ℚ,
+proved entirely on the integer / finite-field side.
+
+Source: open question 2 of the gauss-lemma-primitive family
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry `gauss-lemma-primitive-oq-01` packaged Gauss's Lemma as a *bridge*:
+for a monic integer polynomial, irreducibility over ℚ coincides with irreducibility
+over ℤ (Mathlib's `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` specialized to
+monic polynomials, where primitivity is automatic).  The parent only exhibited a
+*negative* witness (`2X`, showing primitivity cannot be dropped).  This entry supplies
+the missing *positive* worked example: it pushes a genuine irreducibility question across
+the bridge and dispatches it cheaply on the integer side.
+
+The route is the standard "reduce mod a prime" obstruction:
+
+  * `X^3 - X - 1` is monic, hence primitive;
+  * its reduction mod 2 is `X^3 + X + 1 ∈ (ℤ/2)[X]`, which has no root in `ℤ/2`
+    (it evaluates to 1 at both 0 and 1) and therefore — being a cubic over a field —
+    is irreducible;
+  * a monic polynomial whose reduction modulo a prime is irreducible is itself
+    irreducible over ℤ (`Monic.irreducible_of_irreducible_map`);
+  * Gauss's Lemma lifts integer irreducibility to irreducibility over ℚ.
+
+We also package the general reusable step as
+`irreducible_rat_of_irreducible_map_zmod`: a monic integer polynomial whose mod-`p`
+reduction is irreducible is irreducible over ℚ.  No step ever touches a rational
+denominator.
+
+We prove:
+1. `gauss_lemma_int_monic`                 — the monic Gauss bridge (parent's packaging)
+2. `irreducible_rat_of_irreducible_map_zmod` — the reusable mod-`p` ⟹ over-ℚ bridge
+3. `f_monic`                                — `X^3 - X - 1` is monic
+4. `f_map_zmod_two`                         — its mod-2 reduction is `X^3 - X - 1` over ℤ/2
+5. `f_no_root_zmod_two`                     — the reduction has no root in ℤ/2
+6. `f_irreducible_zmod_two`                 — hence the reduction is irreducible
+7. `f_irreducible_int`                      — `X^3 - X - 1` is irreducible over ℤ
+8. `cubic_irreducible_over_rat`             — `X^3 - X - 1` is irreducible over ℚ (headline)
+-/
+
+import Mathlib
+
+open Polynomial
+
+namespace GaussLemmaPrimitiveOQ01OQ02
+
+/-- **Monic Gauss bridge** (parent `gauss-lemma-primitive-oq-01`'s packaging).
+For a monic integer polynomial, irreducibility over ℤ is equivalent to irreducibility
+of its image in ℚ[X].  Monicity makes the polynomial primitive, so this is Mathlib's
+`IsPrimitive.Int.irreducible_iff_irreducible_map_cast` with no side condition. -/
+theorem gauss_lemma_int_monic {p : ℤ[X]} (hp : p.Monic) :
+    Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)) :=
+  IsPrimitive.Int.irreducible_iff_irreducible_map_cast hp.isPrimitive
+
+/-- **Reusable mod-`p` bridge.**  A monic integer polynomial whose reduction modulo a
+prime `p` is irreducible over the field `ℤ/p` is irreducible over ℚ.  This composes
+`Monic.irreducible_of_irreducible_map` (mod-`p` irreducible ⟹ irreducible over ℤ) with
+the monic Gauss bridge (irreducible over ℤ ⟹ irreducible over ℚ). -/
+theorem irreducible_rat_of_irreducible_map_zmod {g : ℤ[X]} (hg : g.Monic)
+    (p : ℕ) [Fact (Nat.Prime p)]
+    (h : Irreducible (g.map (Int.castRingHom (ZMod p)))) :
+    Irreducible (g.map (Int.castRingHom ℚ)) :=
+  (gauss_lemma_int_monic hg).mp
+    (Polynomial.Monic.irreducible_of_irreducible_map (Int.castRingHom (ZMod p)) g hg h)
+
+/-- The monic cubic `X^3 - X - 1 ∈ ℤ[X]`. -/
+noncomputable def f : ℤ[X] := X ^ 3 - X - 1
+
+/-- `X^3 - X - 1` is monic. -/
+theorem f_monic : f.Monic := by
+  unfold f
+  monicity!
+
+/-- The reduction of `X^3 - X - 1` modulo 2 is `X^3 - X - 1` in `(ℤ/2)[X]`. -/
+theorem f_map_zmod_two :
+    f.map (Int.castRingHom (ZMod 2)) = (X ^ 3 - X - 1 : (ZMod 2)[X]) := by
+  simp [f, Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_one, Polynomial.map_X]
+
+/-- The mod-2 reduction has no root in `ℤ/2`: it evaluates to `1` at both `0` and `1`. -/
+theorem f_no_root_zmod_two :
+    ∀ x : ZMod 2, ¬ (f.map (Int.castRingHom (ZMod 2))).IsRoot x := by
+  rw [f_map_zmod_two]
+  intro x
+  simp only [IsRoot.def, eval_sub, eval_pow, eval_X, eval_one]
+  revert x
+  decide
+
+/-- The mod-2 reduction is irreducible: a cubic over a field with no root is irreducible. -/
+theorem f_irreducible_zmod_two :
+    Irreducible (f.map (Int.castRingHom (ZMod 2))) := by
+  have hdeg : (f.map (Int.castRingHom (ZMod 2))).natDegree = 3 := by
+    rw [f_monic.natDegree_map]
+    unfold f
+    compute_degree!
+  apply Polynomial.irreducible_of_degree_le_three_of_not_isRoot
+  · rw [hdeg]; decide
+  · exact f_no_root_zmod_two
+
+/-- `X^3 - X - 1` is irreducible over ℤ (its mod-2 reduction is irreducible and it is monic). -/
+theorem f_irreducible_int : Irreducible f :=
+  Polynomial.Monic.irreducible_of_irreducible_map (Int.castRingHom (ZMod 2)) f f_monic
+    f_irreducible_zmod_two
+
+/-- **Headline.**  The monic cubic `X^3 - X - 1` is irreducible over ℚ.  The proof never
+factors over ℚ directly: it reduces mod 2 (no root ⟹ irreducible cubic), lifts to ℤ
+(`Monic.irreducible_of_irreducible_map`), then to ℚ (Gauss's Lemma). -/
+theorem cubic_irreducible_over_rat : Irreducible (X ^ 3 - X - 1 : ℚ[X]) := by
+  have h : Irreducible (f.map (Int.castRingHom ℚ)) :=
+    irreducible_rat_of_irreducible_map_zmod f_monic 2 f_irreducible_zmod_two
+  have hmap : f.map (Int.castRingHom ℚ) = (X ^ 3 - X - 1 : ℚ[X]) := by
+    simp [f, Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_one, Polynomial.map_X]
+  rwa [hmap] at h
+
+end GaussLemmaPrimitiveOQ01OQ02

--- a/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/annotations.json
@@ -1,0 +1,133 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "A Positive Worked Example of the Monic Gauss Bridge",
+    "content": "The parent entry packaged Gauss's Lemma and exhibited only a negative witness (2X, showing primitivity is essential). This file supplies the missing positive case: the monic cubic X³ − X − 1 is irreducible over ℚ. The strategy, stated in the header, never factors over ℚ — it reduces mod 2, where root-freeness is a finite check, then descends to ℤ (monic) and lifts to ℚ (Gauss). The eight results are listed.",
+    "mathContext": "Goal: $\\text{Irreducible}\\,(X^3 - X - 1) \\in \\mathbb{Q}[X]$, via reduction mod 2.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gauss's Lemma",
+      "reduction modulo a prime",
+      "irreducibility test",
+      "monic polynomial"
+    ],
+    "prerequisites": [
+      "polynomials over ℤ, ℚ, and finite fields",
+      "irreducible elements and units"
+    ]
+  },
+  {
+    "id": "ann-gauss-bridge",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "The Monic Gauss Bridge and the Reusable mod-p Bridge",
+    "content": "gauss_lemma_int_monic restates the parent's monic packaging of Gauss's Lemma: for monic p : ℤ[X], Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)), from Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast via Monic.isPrimitive. irreducible_rat_of_irreducible_map_zmod is the reusable engine of this entry: for monic g and a prime p, if the reduction g mod p is irreducible over the field ℤ/p, then g is irreducible over ℚ. It composes Monic.irreducible_of_irreducible_map (mod-p irreducible ⟹ irreducible over ℤ) with the Gauss bridge (over ℤ ⟹ over ℚ).",
+    "mathContext": "$g$ monic, $p$ prime, $\\text{Irreducible}(g \\bmod p) \\Rightarrow \\text{Irreducible}(g \\bmod \\mathbb{Q})$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Monic.irreducible_of_irreducible_map",
+      "IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+      "reduction-mod-p test",
+      "fraction field"
+    ],
+    "prerequisites": [
+      "Gauss's Lemma",
+      "ring-hom reduction maps"
+    ]
+  },
+  {
+    "id": "ann-def-and-monic",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 90
+    },
+    "type": "definition",
+    "title": "The Cubic and its Monicity",
+    "content": "f is the monic cubic X³ − X − 1 ∈ ℤ[X]. f_monic establishes monicity with the monicity! tactic. Monicity is doubly essential downstream: it lets Monic.natDegree_map keep the degree at 3 under reduction, it powers the descent lemma Monic.irreducible_of_irreducible_map, and it makes Gauss's Lemma hypothesis-free (Monic.isPrimitive).",
+    "mathContext": "$f = X^3 - X - 1$, $\\operatorname{lc}(f) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monic polynomial",
+      "leading coefficient"
+    ],
+    "prerequisites": [
+      "polynomial degree and leading coefficient"
+    ]
+  },
+  {
+    "id": "ann-mod2-rootfree",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "The mod-2 Reduction Has No Root",
+    "content": "f_map_zmod_two computes the reduction of X³ − X − 1 modulo 2 as X³ − X − 1 over ℤ/2 (which equals X³ + X + 1 since −1 = 1). f_no_root_zmod_two then evaluates it at every element of ℤ/2: the value is x³ − x − 1, equal to 1 at both x = 0 and x = 1. The universally quantified inequality ∀ x : ZMod 2, x³ − x − 1 ≠ 0 is a finite, two-element check discharged by kernel decide — no native_decide, so no Lean.ofReduceBool enters the axiom set.",
+    "mathContext": "$\\forall x \\in \\mathbb{Z}/2:\\ x^3 - x - 1 = 1 \\neq 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "root of a polynomial",
+      "evaluation over a finite field",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "polynomial evaluation",
+      "arithmetic in ℤ/2"
+    ]
+  },
+  {
+    "id": "ann-mod2-irreducible",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 105,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "The mod-2 Reduction is an Irreducible Cubic",
+    "content": "f_irreducible_zmod_two combines the degree and root-freeness: Monic.natDegree_map gives natDegree = 3 (so the reduction is genuinely a cubic, in Finset.Icc 1 3), and irreducible_of_degree_le_three_of_not_isRoot — the field fact that a degree-1-to-3 polynomial with no root is irreducible — yields irreducibility over ℤ/2. This is the only place a field structure is used, and ℤ/2 is a field because 2 is prime.",
+    "mathContext": "Cubic over a field with no root $\\Rightarrow$ irreducible.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "irreducible_of_degree_le_three_of_not_isRoot",
+      "Monic.natDegree_map",
+      "cubic factorization over a field"
+    ],
+    "prerequisites": [
+      "degree and roots over a field"
+    ]
+  },
+  {
+    "id": "ann-descend-and-headline",
+    "proofId": "gauss-lemma-primitive-oq-01-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 130
+    },
+    "type": "theorem",
+    "title": "Descent to ℤ and the Headline over ℚ",
+    "content": "f_irreducible_int applies Monic.irreducible_of_irreducible_map: a monic polynomial whose image is irreducible is itself irreducible, so X³ − X − 1 is irreducible over ℤ. cubic_irreducible_over_rat is the headline: feeding the mod-2 irreducibility through irreducible_rat_of_irreducible_map_zmod (Gauss's Lemma) and rewriting the ℚ-image gives Irreducible (X³ − X − 1) over ℚ. The rational-side conclusion is reached without a single rational factorization argument.",
+    "mathContext": "$\\text{Irreducible}(X^3 - X - 1) \\in \\mathbb{Z}[X] \\Rightarrow \\text{Irreducible}(X^3 - X - 1) \\in \\mathbb{Q}[X]$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Monic.irreducible_of_irreducible_map",
+      "Gauss's Lemma",
+      "irreducibility over ℚ"
+    ],
+    "prerequisites": [
+      "descent of irreducibility under ring maps",
+      "Gauss's Lemma"
+    ]
+  }
+]

--- a/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gauss-lemma-primitive-oq-01-oq-02/meta.json
@@ -1,0 +1,111 @@
+{
+  "id": "gauss-lemma-primitive-oq-01-oq-02",
+  "title": "Gauss's Lemma in action: X³ − X − 1 is irreducible over ℚ via the integer side",
+  "slug": "gauss-lemma-primitive-oq-01-oq-02",
+  "description": "A worked positive example of the monic Gauss bridge. The parent entry packaged Gauss's Lemma and gave only a negative witness (2X, showing primitivity is essential). This entry supplies the missing positive case: the monic cubic X³ − X − 1 is irreducible over ℚ, proved entirely on the integer / finite-field side. Its reduction mod 2 has no root in ℤ/2, hence is an irreducible cubic over a field; Monic.irreducible_of_irreducible_map lifts this to irreducibility over ℤ, and Gauss's Lemma lifts that to ℚ — the proof never factors over ℚ directly. A reusable mod-p bridge (irreducible_rat_of_irreducible_map_zmod) is packaged for future use.",
+  "meta": {
+    "author": "Robb Walters (2026)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GaussLemmaPrimitiveOQ01OQ02.lean",
+    "tags": [
+      "ring-theory",
+      "polynomials",
+      "irreducibility",
+      "gauss-lemma",
+      "reduction-mod-p",
+      "finite-fields",
+      "cubic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's Lemma: for primitive p : ℤ[X], Irreducible p ↔ Irreducible (p.map (Int.castRingHom ℚ)); the monic bridge specializes it via Monic.isPrimitive",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Polynomial.Monic.irreducible_of_irreducible_map",
+        "description": "A monic polynomial over an integral domain is irreducible if its image in another integral domain is irreducible; used to descend mod-2 irreducibility to irreducibility over ℤ",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Irreducible"
+      },
+      {
+        "theorem": "Polynomial.irreducible_of_degree_le_three_of_not_isRoot",
+        "description": "Over a field, a polynomial of degree 1–3 with no root is irreducible; gives irreducibility of the mod-2 cubic from its root-freeness",
+        "module": "Mathlib.Algebra.Polynomial.SpecificDegree"
+      },
+      {
+        "theorem": "Polynomial.Monic.natDegree_map",
+        "description": "A monic polynomial keeps its natDegree under any ring-hom map; certifies the mod-2 reduction is still a cubic",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Polynomial.Monic.isPrimitive",
+        "description": "Every monic polynomial is primitive; drops the primitivity hypothesis from Gauss's Lemma in the monic bridge",
+        "module": "Mathlib.RingTheory.Polynomial.Content"
+      }
+    ],
+    "originalContributions": [
+      "cubic_irreducible_over_rat: a fully-formalized proof that the specific monic cubic X³ − X − 1 is irreducible over ℚ — a concrete result not present in Mathlib — established without ever factoring over ℚ",
+      "irreducible_rat_of_irreducible_map_zmod: a reusable bridge lemma packaging 'monic integer polynomial whose reduction mod a prime p is irreducible ⟹ irreducible over ℚ', composing Monic.irreducible_of_irreducible_map with the monic Gauss bridge",
+      "f_irreducible_zmod_two / f_no_root_zmod_two: the integer-side obstruction, computing that X³ − X − 1 mod 2 has no root in ℤ/2 (kernel decide over the two-element field) and is therefore an irreducible cubic over a field",
+      "Answers open question 2 of the parent gauss-lemma-primitive-oq-01: the positive worked case the parent left open, complementing its negative 2X witness"
+    ],
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries; all eight theorems machine-checked. The root-freeness of the mod-2 reduction is discharged by kernel `decide` over the two-element field ℤ/2 (not native_decide), so no Lean.ofReduceBool is introduced. The individual building blocks (Gauss's Lemma, the descent lemma, the cubic root criterion) are Mathlib's; the original content is the assembled, concrete result that X³ − X − 1 is irreducible over ℚ and the reusable mod-p bridge. Depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 115,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Reduction modulo a prime is one of the oldest and most reliable irreducibility tests for integer polynomials: if a monic f ∈ ℤ[X] stays the same degree and becomes irreducible over the finite field ℤ/p, then f is irreducible over ℤ. Gauss's Lemma (Disquisitiones Arithmeticae, 1801) is the bridge that turns ℤ-irreducibility into ℚ-irreducibility — the property one actually needs to build number fields and compute Galois groups. The cubic X³ − X − 1 is the classic first example: it has discriminant −23, generates the field of smallest discriminant with a complex place, and is a standard textbook irreducible cubic.",
+    "problemStatement": "Exhibit a concrete monic cubic and prove it irreducible over ℚ by transferring the question to the integer / finite-field side, completing open question 2 of the parent Gauss's Lemma entry (which gave only the negative 2X counterexample).\n\n**Answer:** X³ − X − 1 is irreducible over ℚ. Its reduction mod 2 has no root in ℤ/2, so it is an irreducible cubic over a field; this descends to ℤ (monic) and lifts to ℚ (Gauss).",
+    "text": "The monic cubic X³ − X − 1 is irreducible over ℚ. The proof never factors over ℚ: reduce mod 2 to get a cubic with no root in ℤ/2 (hence irreducible over that field), descend to irreducibility over ℤ since the polynomial is monic, and lift to ℚ by Gauss's Lemma.",
+    "proofStrategy": "1. f_monic: X³ − X − 1 is monic (monicity!).\n2. f_map_zmod_two: its image under Int.castRingHom (ZMod 2) is X³ − X − 1 over ℤ/2 (map_sub/map_pow/map_X/map_one).\n3. f_no_root_zmod_two: evaluating the reduction at each element of ℤ/2 gives x³ − x − 1, equal to 1 at both 0 and 1; ∀ x : ZMod 2, x³ − x − 1 ≠ 0 by kernel decide.\n4. f_irreducible_zmod_two: the reduction is a cubic (Monic.natDegree_map keeps natDegree = 3) with no root, so irreducible_of_degree_le_three_of_not_isRoot applies over the field ℤ/2.\n5. f_irreducible_int: Monic.irreducible_of_irreducible_map descends mod-2 irreducibility to irreducibility over ℤ.\n6. irreducible_rat_of_irreducible_map_zmod / cubic_irreducible_over_rat: the monic Gauss bridge (gauss_lemma_int_monic) lifts ℤ-irreducibility to ℚ; rewriting the ℚ-image gives the headline X³ − X − 1 irreducible over ℚ.",
+    "keyInsights": [
+      "**The whole argument lives on the integer side.** Factoring a cubic over ℚ directly means ruling out all rational factorizations; instead one reduces mod 2, where the field has two elements and root-freeness is a two-case finite check.",
+      "**Mod-2 is enough.** A cubic over a field factors iff it has a linear factor iff it has a root. X³ − X − 1 mod 2 = X³ + X + 1 evaluates to 1 at both 0 and 1, so it has no root and is irreducible — no need to try other primes.",
+      "**Monicity is what makes the descent work.** Monic.irreducible_of_irreducible_map needs the polynomial monic so that the leading coefficient cannot absorb a factorization; the same monicity makes Gauss's Lemma hypothesis-free via Monic.isPrimitive.",
+      "**The bridge is reusable.** irreducible_rat_of_irreducible_map_zmod isolates the general step — monic + irreducible mod some prime ⟹ irreducible over ℚ — so future entries can certify irreducibility of any monic integer polynomial by a single finite-field computation."
+    ],
+    "prerequisites": [
+      "Polynomials over ℤ, ℚ, and finite fields",
+      "Reduction of polynomials modulo a prime",
+      "Irreducible elements; root/factor criterion for cubics over a field",
+      "Gauss's Lemma (parent entry)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gauss-lemma-primitive-oq-01",
+      "relationship": "parent",
+      "description": "Answers open question 2 of the parent: a worked positive case proving a specific monic cubic irreducible over ℚ by transferring an integer-side argument through gauss_lemma_int_monic, complementing the parent's negative 2X witness"
+    }
+  ],
+  "conclusion": {
+    "summary": "The monic cubic X³ − X − 1 is proved irreducible over ℚ entirely on the integer / finite-field side: its mod-2 reduction has no root in ℤ/2 (kernel decide), hence is an irreducible cubic over a field; Monic.irreducible_of_irreducible_map descends this to irreducibility over ℤ, and Gauss's Lemma lifts it to ℚ. The general step is packaged as the reusable bridge irreducible_rat_of_irreducible_map_zmod. All eight theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the positive worked example the parent Gauss's Lemma entry left open, and a citable reusable lemma: a monic integer polynomial whose reduction modulo some prime is irreducible is irreducible over ℚ. This is the reduction-mod-p irreducibility test in fully formalized, reusable form.",
+    "openQuestions": [
+      "Can the reduction-mod-p bridge be packaged with an automatic finite-field root search so that irreducibility of a given monic integer polynomial is certified by a single tactic call?",
+      "Eisenstein's criterion is the other standard ℤ-side test that Gauss's Lemma lifts to ℚ — is there a worked example combining Eisenstein at a prime with the monic Gauss bridge in the gallery?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "GaussLemmaPrimitiveOQ01OQ02",
+    "lineCount": 115,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/GaussLemmaPrimitiveOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 2** of the parent `gauss-lemma-primitive-oq-01`: a *positive* worked example proving a specific monic cubic irreducible over ℚ by transferring the argument to the integer / finite-field side. The parent only exhibited the *negative* witness `2X` (primitivity is essential); this entry supplies the missing positive case.

**Headline:** `X³ − X − 1` is irreducible over ℚ — proved without ever factoring over ℚ.

## Proof route (integer side only)
1. `X³ − X − 1` is monic.
2. Its reduction mod 2 is `X³ + X + 1 ∈ (ℤ/2)[X]`, which has no root in ℤ/2 (evaluates to 1 at both 0 and 1) — checked by **kernel `decide`** over the two-element field.
3. A cubic over a field with no root is irreducible (`irreducible_of_degree_le_three_of_not_isRoot`), so the reduction is irreducible.
4. `Monic.irreducible_of_irreducible_map` descends this to irreducibility over ℤ.
5. Gauss's Lemma (`gauss_lemma_int_monic`) lifts ℤ-irreducibility to ℚ.

## Reusable contribution
`irreducible_rat_of_irreducible_map_zmod`: a monic integer polynomial whose reduction modulo a prime `p` is irreducible over ℤ/p is irreducible over ℚ — the reduction-mod-p irreducibility test in citable, reusable form.

## Verification
- **8 theorems, 1 definition, 115 lines**
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`
- Root check uses **kernel `decide`** (not `native_decide`), so **no `Lean.ofReduceBool`**
- Builds against Mathlib v4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)