### PR TITLE
research(lebesgue-dirichlet): Dirichlet function nowhere continuous, oscillation 1 everywhere [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02OQ02.lean
@@ -1,0 +1,182 @@
+/-
+# The Dirichlet Function is Nowhere Continuous — the Baire-Category Antipode of Thomae
+
+## Open Question (lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02)
+
+The Dirichlet function `D = 𝟙_ℚ : ℝ → ℝ` takes the value `1` on the rationals and
+`0` on the irrationals.  The parent entry `LebesgueMeasureOQ01OQ01OQ02OQ02` proves
+that *Thomae's* (popcorn) function is continuous exactly on the irrationals — a dense
+`Gδ`, comeagre set — and discontinuous only on the meagre set `ℚ`.  Thomae is "mostly
+continuous".
+
+This entry formalizes the **exact opposite**: the Dirichlet function is continuous at
+**no** point of `ℝ`.  Because both `ℚ` and `ℝ \ ℚ` are dense, every neighbourhood of
+every real number contains a point where `D = 1` and a point where `D = 0`, so `D`
+jumps by a full unit everywhere and cannot be continuous anywhere.
+
+We prove the three-part dichotomy:
+
+  1. `dirichlet_not_continuousAt`            : `¬ ContinuousAt D x` for every `x`;
+  2. `dirichlet_continuitySet_eq_empty` /
+     `dirichlet_discontinuitySet_eq_univ`    : continuity set `= ∅`, discontinuity set `= ℝ`;
+  3. `dirichlet_oscillation_eq_one`          : the oscillation `ω_D(x) = 1` at every `x`
+     (sharp quantitative form, contrasting Thomae's pointwise oscillation `1/q`).
+
+and the **Baire-category antipode** framing: the continuity set of Thomae is a dense
+`Gδ` (comeagre), whereas Dirichlet's continuity set `∅` is *not dense*
+(`dirichlet_continuitySet_not_dense`) — so the two functions realize opposite ends of
+the continuity-set theory.
+
+The key uniform device is that *every* point admits both a rational sequence (where
+`D = 1`) and an irrational sequence (where `D = 0`) converging to it; continuity would
+force `D x = 1` and `D x = 0` simultaneously.
+
+Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Set Filter Topology Metric
+open scoped ENNReal
+
+namespace LebesgueMeasureOQ01OQ01OQ02OQ02OQ02
+
+/-- The **Dirichlet function** `𝟙_ℚ`: `1` on the rationals, `0` on the irrationals. -/
+noncomputable def dirichlet : ℝ → ℝ := Set.indicator (Set.range ((↑) : ℚ → ℝ)) 1
+
+/-- `D` is `1` at every rational. -/
+theorem dirichlet_rat (q : ℚ) : dirichlet (q : ℝ) = 1 := by
+  rw [dirichlet, Set.indicator_of_mem (Set.mem_range_self q)]; rfl
+
+/-- `D` is `0` at every irrational. -/
+theorem dirichlet_irrational {x : ℝ} (h : Irrational x) : dirichlet x = 0 := by
+  rw [dirichlet, Set.indicator_of_notMem h]
+
+/-- `D` takes only the values `0` and `1`. -/
+theorem dirichlet_zero_or_one (x : ℝ) : dirichlet x = 0 ∨ dirichlet x = 1 := by
+  by_cases hx : x ∈ Set.range ((↑) : ℚ → ℝ)
+  · exact Or.inr (by rw [dirichlet, Set.indicator_of_mem hx]; rfl)
+  · exact Or.inl (by rw [dirichlet, Set.indicator_of_notMem hx])
+
+/-! ## Sequential approach to every point through rationals and irrationals -/
+
+/-- Every real is the limit of a sequence of rationals (along which `D = 1`). -/
+theorem exists_rat_seq_tendsto (x : ℝ) :
+    ∃ u : ℕ → ℝ, (∀ n, u n ∈ Set.range ((↑) : ℚ → ℝ)) ∧ Tendsto u atTop (𝓝 x) :=
+  mem_closure_iff_seq_limit.mp (Rat.denseRange_cast x)
+
+/-- Every real is the limit of a sequence of irrationals (along which `D = 0`). -/
+theorem exists_irrational_seq_tendsto (x : ℝ) :
+    ∃ u : ℕ → ℝ, (∀ n, Irrational (u n)) ∧ Tendsto u atTop (𝓝 x) :=
+  mem_closure_iff_seq_limit.mp (dense_irrational x)
+
+/-! ## The Dirichlet function is nowhere continuous -/
+
+/-- **The Dirichlet function is continuous at no point of `ℝ`.** Approaching `x` through
+rationals forces the limit to be `1`; approaching through irrationals forces it to be
+`0`; uniqueness of limits then gives `1 = 0`. -/
+theorem dirichlet_not_continuousAt (x : ℝ) : ¬ ContinuousAt dirichlet x := by
+  intro h
+  obtain ⟨u, hu, hlim⟩ := exists_rat_seq_tendsto x
+  obtain ⟨v, hv, vlim⟩ := exists_irrational_seq_tendsto x
+  -- Along rationals `D = 1`, so `D x = 1`.
+  have h1 : Tendsto (fun n => dirichlet (u n)) atTop (𝓝 (dirichlet x)) := h.tendsto.comp hlim
+  have h1c : (fun n => dirichlet (u n)) = fun _ => (1 : ℝ) := by
+    funext n; obtain ⟨q, hq⟩ := hu n; rw [← hq]; exact dirichlet_rat q
+  rw [h1c] at h1
+  have hx1 : (1 : ℝ) = dirichlet x := tendsto_nhds_unique tendsto_const_nhds h1
+  -- Along irrationals `D = 0`, so `D x = 0`.
+  have h0 : Tendsto (fun n => dirichlet (v n)) atTop (𝓝 (dirichlet x)) := h.tendsto.comp vlim
+  have h0c : (fun n => dirichlet (v n)) = fun _ => (0 : ℝ) :=
+    funext fun n => dirichlet_irrational (hv n)
+  rw [h0c] at h0
+  have hx0 : (0 : ℝ) = dirichlet x := tendsto_nhds_unique tendsto_const_nhds h0
+  exact one_ne_zero (hx1.trans hx0.symm)
+
+/-- **The continuity set of the Dirichlet function is empty.** -/
+theorem dirichlet_continuitySet_eq_empty :
+    {x : ℝ | ContinuousAt dirichlet x} = (∅ : Set ℝ) := by
+  ext x
+  simp only [Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  exact dirichlet_not_continuousAt x
+
+/-- **The discontinuity set of the Dirichlet function is all of `ℝ`.** -/
+theorem dirichlet_discontinuitySet_eq_univ :
+    {x : ℝ | ¬ ContinuousAt dirichlet x} = (Set.univ : Set ℝ) := by
+  ext x
+  simp only [Set.mem_setOf_eq, Set.mem_univ, iff_true]
+  exact dirichlet_not_continuousAt x
+
+/-! ## The oscillation is identically one -/
+
+/-- A neighbourhood of `x` contains a rational, where `D = 1`. -/
+theorem exists_rat_mem_of_nhds {x : ℝ} {N : Set ℝ} (hN : N ∈ 𝓝 x) :
+    ∃ y ∈ N, dirichlet y = 1 := by
+  obtain ⟨δ, hδ, hsub⟩ := Metric.mem_nhds_iff.mp hN
+  obtain ⟨q, hq⟩ := exists_rat_near x hδ
+  refine ⟨(q : ℝ), hsub ?_, dirichlet_rat q⟩
+  rw [Metric.mem_ball, Real.dist_eq, abs_sub_comm]
+  exact hq
+
+/-- A neighbourhood of `x` contains an irrational, where `D = 0`. -/
+theorem exists_irrational_mem_of_nhds {x : ℝ} {N : Set ℝ} (hN : N ∈ 𝓝 x) :
+    ∃ y ∈ N, dirichlet y = 0 := by
+  obtain ⟨δ, hδ, hsub⟩ := Metric.mem_nhds_iff.mp hN
+  obtain ⟨r, hr, hxr, hrδ⟩ := exists_irrational_btwn (show x < x + δ by linarith)
+  refine ⟨r, hsub ?_, dirichlet_irrational hr⟩
+  rw [Metric.mem_ball, Real.dist_eq, abs_of_pos (by linarith)]
+  linarith
+
+/-- `edist (1 : ℝ) 0 = 1`. -/
+private theorem edist_one_zero : edist (1 : ℝ) (0 : ℝ) = 1 := by
+  rw [edist_dist, Real.dist_eq]; norm_num
+
+/-- **The oscillation of the Dirichlet function equals `1` at every point.** This is the
+sharp quantitative form of nowhere-continuity: the function fluctuates by a full unit in
+every neighbourhood of every point.  Contrast Thomae, whose oscillation is `1/q` at the
+rational `p/q` and `0` at every irrational. -/
+theorem dirichlet_oscillation_eq_one (x : ℝ) : oscillation dirichlet x = 1 := by
+  refine le_antisymm ?_ ?_
+  · -- `≤ 1`: the image filter contains `range D ⊆ {0,1}`, of diameter `≤ 1`.
+    have hmem : Set.range dirichlet ∈ (𝓝 x).map dirichlet := by
+      rw [Filter.mem_map, Set.preimage_range]; exact Filter.univ_mem
+    refine (biInf_le EMetric.diam hmem).trans ?_
+    refine EMetric.diam_le ?_
+    rintro a ⟨s, rfl⟩ b ⟨t, rfl⟩
+    rw [edist_dist, Real.dist_eq]
+    have hab : |dirichlet s - dirichlet t| ≤ 1 := by
+      rcases dirichlet_zero_or_one s with hs | hs <;>
+        rcases dirichlet_zero_or_one t with ht | ht <;>
+        rw [hs, ht] <;> norm_num
+    calc ENNReal.ofReal |dirichlet s - dirichlet t| ≤ ENNReal.ofReal 1 :=
+          ENNReal.ofReal_le_ofReal hab
+      _ = 1 := by simp
+  · -- `≥ 1`: every set in the image filter contains both `0` and `1`, so has diameter `≥ 1`.
+    refine le_iInf₂ fun S hS => ?_
+    rw [Filter.mem_map] at hS
+    obtain ⟨y, hy, hy1⟩ := exists_rat_mem_of_nhds hS
+    obtain ⟨z, hz, hz0⟩ := exists_irrational_mem_of_nhds hS
+    have h1S : (1 : ℝ) ∈ S := hy1 ▸ hy
+    have h0S : (0 : ℝ) ∈ S := hz0 ▸ hz
+    calc (1 : ℝ≥0∞) = edist (1 : ℝ) 0 := edist_one_zero.symm
+      _ ≤ EMetric.diam S := EMetric.edist_le_diam_of_mem h1S h0S
+
+/-! ## The Baire-category antipode of Thomae -/
+
+/-- **The Dirichlet continuity set is not dense.** Whereas Thomae's continuity set is a
+*dense* `Gδ` (the irrationals), Dirichlet's continuity set is empty, hence not dense in
+`ℝ`.  This is the Baire-category antipode: Thomae realizes the irrationals as a continuity
+set, Dirichlet realizes `∅`. -/
+theorem dirichlet_continuitySet_not_dense :
+    ¬ Dense {x : ℝ | ContinuousAt dirichlet x} := by
+  rw [dirichlet_continuitySet_eq_empty]
+  simp [dense_iff_inter_open]
+  exact ⟨Set.univ, isOpen_univ, ⟨0, Set.mem_univ 0⟩⟩
+
+/-- **The discontinuity set of Dirichlet is comeagre (residual)** — indeed all of `ℝ`.
+The sharp opposite of Thomae, whose discontinuity set `ℚ` is meagre. -/
+theorem dirichlet_discontinuitySet_residual :
+    {x : ℝ | ¬ ContinuousAt dirichlet x} ∈ residual ℝ := by
+  rw [dirichlet_discontinuitySet_eq_univ]
+  exact Filter.univ_mem
+
+end LebesgueMeasureOQ01OQ01OQ02OQ02OQ02

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02",
+  "title": "The Dirichlet Function: nowhere continuous — the Baire-category antipode of Thomae",
+  "slug": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02",
+  "description": "The exact opposite of Thomae. The Dirichlet function D = 𝟙_ℚ (1 on the rationals, 0 on the irrationals) is continuous at NO point of ℝ, answering the parent entry's open question verbatim. Because both ℚ and ℝ∖ℚ are dense, every neighbourhood of every real contains a point where D = 1 and a point where D = 0, so D jumps by a full unit everywhere. The entry proves the three-part dichotomy: (1) ¬ ContinuousAt D x for every x; (2) the continuity set equals ∅ and the discontinuity set equals ℝ; (3) the oscillation ω_D(x) = 1 at every point — the sharp quantitative form, contrasting Thomae's pointwise oscillation 1/q at p/q. Framed as the Baire-category antipode: Thomae's continuity set is a dense Gδ (comeagre), whereas Dirichlet's continuity set ∅ is not dense, so the two functions realize opposite ends of the continuity-set theory. 14 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "namespace": "LebesgueMeasureOQ01OQ01OQ02OQ02OQ02",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "path": "Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ01OQ01OQ02OQ02OQ02.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "dirichlet-function",
+      "indicator-function",
+      "nowhere-continuous",
+      "oscillation",
+      "continuity",
+      "real-analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. Fully kernel-checked (Lean v4.26.0). `#print axioms` on the headline theorems (dirichlet_not_continuousAt, dirichlet_oscillation_eq_one, dirichlet_continuitySet_not_dense, dirichlet_discontinuitySet_residual) reports only the ordinary foundational axioms propext, Classical.choice, Quot.sound — no `axiom` declarations, no structure-encoded assumptions, no `native_decide` (so no Lean.ofReduceBool), no sorryAx. The file is self-contained: it imports only Mathlib and defines the Dirichlet function as Set.indicator (range ℚ) 1, depending on no other gallery module.",
+    "lineCount": 182,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "originalContributions": [
+      "dirichlet_not_continuousAt: the Dirichlet function is continuous at no point of ℝ — approaching x through a rational sequence forces the limit to be 1, through an irrational sequence forces it to be 0, and uniqueness of limits gives 1 = 0",
+      "dirichlet_continuitySet_eq_empty / dirichlet_discontinuitySet_eq_univ: the continuity set is ∅ and the discontinuity set is all of ℝ — the exact set-theoretic opposite of Thomae (continuity set = irrationals, discontinuity set = ℚ)",
+      "dirichlet_oscillation_eq_one: the oscillation ω_D(x) = 1 at every point, the sharp quantitative form of nowhere-continuity (the image filter contains range D ⊆ {0,1} of diameter ≤ 1 for the upper bound, and every neighbourhood image contains both 0 and 1 for the lower bound), contrasting Thomae's oscillation 1/q at p/q",
+      "dirichlet_continuitySet_not_dense: Dirichlet's continuity set (∅) is not dense — the Baire-category antipode of Thomae's dense-Gδ continuity set",
+      "dirichlet_discontinuitySet_residual: Dirichlet's discontinuity set is comeagre (residual), indeed all of ℝ — the sharp opposite of Thomae's meagre discontinuity set ℚ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet function 𝟙_ℚ (1841) is the canonical example of a function that is continuous nowhere, the foil to Thomae's popcorn function which is continuous exactly at the irrationals. The parent lineage formalized Thomae's measure-theoretic smallness (discontinuity set ℚ is Lebesgue-null) and its Baire-category structure (continuity set a dense Gδ, comeagre). The parent entry lebesgue-measure-oq-01-oq-01-oq-02-oq-02 explicitly posed, as an open question, stating the analogous category/measure dichotomy for the Dirichlet function. This entry supplies it: Dirichlet realizes the opposite extreme of the continuity-set theory.",
+    "problemStatement": "Determine the continuity set, discontinuity set, and pointwise oscillation of the Dirichlet function D = 𝟙_ℚ, and frame the result as the Baire-category antipode of Thomae's function.",
+    "text": "The Dirichlet function takes value 1 on a dense set (ℚ) and 0 on a dense set (the irrationals). Continuity at a point x would force the value D(x) to equal the limit of D along every sequence converging to x; but there is a rational sequence (along which D = 1) and an irrational sequence (along which D = 0) converging to every x, so continuity is impossible everywhere. Quantitatively the oscillation is identically 1. Where Thomae's continuity set is a dense Gδ (comeagre) and discontinuity set meagre, Dirichlet's continuity set is empty (not dense) and discontinuity set all of ℝ (comeagre).",
+    "proofStrategy": "Define dirichlet := Set.indicator (range ℚ) 1, giving dirichlet_rat (= 1 at rationals), dirichlet_irrational (= 0 at irrationals), and dirichlet_zero_or_one. For nowhere-continuity, extract a rational sequence (mem_closure_iff_seq_limit on Rat.denseRange_cast) and an irrational sequence (on dense_irrational) tending to x; composing continuity with these via tendsto_nhds_unique forces D x = 1 and D x = 0, contradiction. The continuity/discontinuity set equalities follow by ext. For the oscillation: the upper bound uses that range D is in the image filter (𝓝 x).map D with EMetric.diam ≤ 1 since |D s − D t| ≤ 1 on {0,1}; the lower bound finds, in every filter set S, a rational point (D = 1, via exists_rat_near) and an irrational point (D = 0, via exists_irrational_btwn), so edist 1 0 = 1 ≤ EMetric.diam S. The Baire framing: dirichlet_continuitySet_not_dense rewrites the continuity set to ∅, and dirichlet_discontinuitySet_residual rewrites to univ ∈ residual ℝ.",
+    "keyInsights": [
+      "Density on both sides is the whole story. Because ℚ and ℝ∖ℚ are each dense, every point is simultaneously a limit of 1-values and of 0-values; this single fact drives nowhere-continuity, the empty continuity set, and the unit oscillation.",
+      "Oscillation 1 is the sharp quantitative antipode of Thomae's 1/q. Thomae's oscillation shrinks to 0 along the irrationals; Dirichlet's is pinned at the maximum possible jump (1) at every point with no exceptions.",
+      "The Baire-category dichotomy is realized at both extremes. Thomae's continuity set is a dense Gδ (the largest a continuity set can be while excluding a dense countable set); Dirichlet's is ∅ (the smallest), so the two functions bracket the continuity-set theory.",
+      "No Baire machinery is needed for the negative result. Unlike Thomae, where the structure is genuinely Gδ/meagre, Dirichlet's discontinuity set is all of ℝ, so it is trivially comeagre; the content is in the uniform density argument, not in category theorems.",
+      "The oscillation upper bound is a clean diameter argument. Since range D ⊆ {0,1} always sits in the pushed-forward neighbourhood filter, the oscillation is at most diam{0,1} = 1 with no pointwise case analysis."
+    ],
+    "prerequisites": [
+      "The Dirichlet function as an indicator and the density of ℚ and of the irrationals in ℝ (Rat.denseRange_cast, dense_irrational)",
+      "Sequential characterization of closure (mem_closure_iff_seq_limit) and uniqueness of limits (tendsto_nhds_unique)",
+      "ContinuousAt as a filter statement (ContinuousAt.tendsto) and composition of tendsto",
+      "The oscillation as an extended-metric diameter of the image neighbourhood filter (oscillation, EMetric.diam, EMetric.edist_le_diam_of_mem)",
+      "Rational/irrational approximation lemmas exists_rat_near and exists_irrational_btwn"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Dirichlet function D = 𝟙_ℚ is continuous at no point of ℝ: its continuity set is ∅, its discontinuity set is all of ℝ, and its oscillation is identically 1. This is the Baire-category antipode of Thomae — empty (not dense) continuity set versus dense Gδ; comeagre full-ℝ discontinuity set versus meagre ℚ — and answers the parent entry's open question verbatim. 14 theorems, 1 definition, 0 axioms, 182 lines, fully kernel-checked.",
+    "implications": "Completes the Thomae/Dirichlet contrast in the gallery by realizing both extremes of the continuity-set theory with a single uniform device (every point is approached by both a rational and an irrational sequence). Demonstrates the idiom of computing pointwise oscillation as an extended-metric diameter of the pushed-forward neighbourhood filter, usable for any function with a small dense range.",
+    "openQuestions": [
+      "Quantify the failure for the family t·𝟙_ℚ (t ≠ 0): the oscillation becomes |t| everywhere — does the continuity-set/oscillation theory extend uniformly to indicator functions of an arbitrary dense, codense set with arbitrary two values?",
+      "Compare with the Riemann non-integrability of Dirichlet: the unit oscillation on every subinterval forces upper sum − lower sum = (length) for every partition, the measure-theoretic counterpart of the topological nowhere-continuity proved here."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring-imports",
+      "title": "Docstring, Imports, and the Dirichlet Function",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "States the nowhere-continuity result and the Baire-category antipode framing. Imports Mathlib; opens Set, Filter, Topology, Metric. Defines dirichlet := Set.indicator (range ℚ) 1 and proves dirichlet_rat (= 1), dirichlet_irrational (= 0), dirichlet_zero_or_one (values in {0,1})."
+    },
+    {
+      "id": "sequential-approach",
+      "title": "Approaching Every Point Through Rationals and Irrationals",
+      "startLine": 60,
+      "endLine": 71,
+      "summary": "exists_rat_seq_tendsto and exists_irrational_seq_tendsto: every real is the limit of a rational sequence (where D = 1) and of an irrational sequence (where D = 0), via mem_closure_iff_seq_limit on Rat.denseRange_cast and dense_irrational."
+    },
+    {
+      "id": "nowhere-continuous",
+      "title": "The Dirichlet Function is Nowhere Continuous",
+      "startLine": 72,
+      "endLine": 107,
+      "summary": "dirichlet_not_continuousAt: composing ContinuousAt with the rational and irrational sequences and applying tendsto_nhds_unique forces D x = 1 and D x = 0, a contradiction. dirichlet_continuitySet_eq_empty and dirichlet_discontinuitySet_eq_univ follow by ext."
+    },
+    {
+      "id": "oscillation",
+      "title": "The Oscillation is Identically One",
+      "startLine": 109,
+      "endLine": 161,
+      "summary": "exists_rat_mem_of_nhds / exists_irrational_mem_of_nhds (a neighbourhood of x contains a point with D = 1 and a point with D = 0, via exists_rat_near and exists_irrational_btwn). dirichlet_oscillation_eq_one: upper bound ≤ 1 from diam(range D) on {0,1}; lower bound ≥ 1 since every filter set contains both 0 and 1 so edist 1 0 = 1 ≤ diam."
+    },
+    {
+      "id": "baire-antipode",
+      "title": "The Baire-Category Antipode of Thomae",
+      "startLine": 163,
+      "endLine": 182,
+      "summary": "dirichlet_continuitySet_not_dense (∅ is not dense — opposite of Thomae's dense Gδ) and dirichlet_discontinuitySet_residual (the discontinuity set, = ℝ, is comeagre — opposite of Thomae's meagre ℚ)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-02-oq-02",
+      "relationship": "parent-problem",
+      "description": "Thomae's function and Baire category: continuity set a dense Gδ, discontinuity set meagre ℚ. This entry answers that entry's open question verbatim by stating the antipodal dichotomy for the Dirichlet function."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Thomae's continuity at the irrationals, the positive-continuity end of the spectrum that Dirichlet's nowhere-continuity contrasts."
+    }
+  ],
+  "references": [
+    {
+      "title": "Dirichlet function",
+      "url": "https://en.wikipedia.org/wiki/Dirichlet_function",
+      "description": "The indicator function of the rationals: continuous nowhere, the canonical nowhere-continuous function."
+    },
+    {
+      "title": "Thomae's function",
+      "url": "https://en.wikipedia.org/wiki/Thomae%27s_function",
+      "description": "The popcorn function: continuous exactly at the irrationals — the Baire-category antipode contrasted in this entry."
+    },
+    {
+      "title": "Oscillation (mathematics)",
+      "url": "https://en.wikipedia.org/wiki/Oscillation_(mathematics)",
+      "description": "Pointwise oscillation of a function; a function is continuous at x iff its oscillation there is 0. Dirichlet's oscillation is 1 everywhere."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question posed verbatim by the parent gallery entry **lebesgue-measure-oq-01-oq-01-oq-02-oq-02** ("Thomae's Function and Baire Category"): *state the analogous category/measure dichotomy for the Dirichlet function 1_ℚ (nowhere continuous: continuity set empty, discontinuity set all of ℝ), contrasting with Thomae.*

The **Dirichlet function** `D = 𝟙_ℚ` (1 on rationals, 0 on irrationals) is continuous at **no** point of ℝ. Because both ℚ and ℝ∖ℚ are dense, every neighbourhood of every real contains a point where `D = 1` and a point where `D = 0`, so `D` jumps by a full unit everywhere.

## What's proved

- `dirichlet_not_continuousAt` — `¬ ContinuousAt D x` for every `x` (rational sequence forces limit 1, irrational sequence forces limit 0, uniqueness of limits ⟹ contradiction)
- `dirichlet_continuitySet_eq_empty` / `dirichlet_discontinuitySet_eq_univ` — continuity set `= ∅`, discontinuity set `= ℝ`
- `dirichlet_oscillation_eq_one` — oscillation `ω_D(x) = 1` at every point (sharp quantitative form; upper bound from `EMetric.diam` of the image neighbourhood filter on `{0,1}`, lower bound since every filter set contains both `0` and `1`)
- `dirichlet_continuitySet_not_dense`, `dirichlet_discontinuitySet_residual` — the **Baire-category antipode** of Thomae: empty (not dense) continuity set vs dense Gδ; comeagre full-ℝ discontinuity set vs meagre ℚ

## Verification

- **14 theorems, 1 definition, 182 lines, 0 axioms, 0 sorries**
- Self-contained: imports only Mathlib (Lean v4.26.0)
- `#print axioms` on all headline theorems reports only `propext`, `Classical.choice`, `Quot.sound` — no `axiom` declarations, no structure-encoded assumptions, no `native_decide`, no `sorryAx`
- Status: `verified`, badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)