### PR TITLE
research(erdos-1029-oq-01): elementary Erdős 1947 Ramsey lower bound by exact counting [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos1029LowerBound.lean
+++ b/proofs/Proofs/Erdos1029LowerBound.lean
@@ -1,0 +1,169 @@
+import Mathlib
+
+open Finset
+
+namespace Erdos1029LB
+
+variable {n : ℕ}
+
+/-- A 2-coloring of the edges of the complete graph `K_n`, as a function on
+unordered pairs of vertices. -/
+abbrev Coloring (n : ℕ) := Sym2 (Fin n) → Bool
+
+/-- A finset `S` of vertices is monochromatic in color `b` if every edge between
+two distinct vertices of `S` has color `b`. -/
+def IsMono (c : Coloring n) (S : Finset (Fin n)) (b : Bool) : Prop :=
+  ∀ x ∈ S, ∀ y ∈ S, x ≠ y → c s(x, y) = b
+
+/-- `c` contains a monochromatic `k`-clique. -/
+def HasMonoClique (c : Coloring n) (k : ℕ) : Prop :=
+  ∃ S : Finset (Fin n), S.card = k ∧ (IsMono c S true ∨ IsMono c S false)
+
+/-- The set of edges spanned by a vertex set `S`: unordered pairs of distinct
+vertices both lying in `S`. -/
+def edgesWithin (S : Finset (Fin n)) : Finset (Sym2 (Fin n)) :=
+  S.offDiag.image Sym2.mk
+
+/-- The number of edges spanned by an `S` with `S.card = k` is `C(k, 2)`. -/
+lemma card_edgesWithin (S : Finset (Fin n)) :
+    (edgesWithin S).card = (S.card).choose 2 :=
+  Sym2.card_image_offDiag S
+
+/-- **Counting lemma.** Among all `2^N` colorings, at most `2^(N - |T|)` are
+constant equal to `b` on a fixed edge set `T` — fixing the colors on `T` leaves
+only the edges outside `T` free. -/
+lemma constOn_card_le (T : Finset (Sym2 (Fin n))) (b : Bool) :
+    (univ.filter (fun c : Coloring n => ∀ e ∈ T, c e = b)).card
+      ≤ 2 ^ (Fintype.card (Sym2 (Fin n)) - T.card) := by
+  classical
+  -- Restrict a coloring to the complement of `T`.
+  let ρ : Coloring n → (↥(Tᶜ : Finset (Sym2 (Fin n))) → Bool) := fun c x => c x.1
+  have hcard :
+      (univ.filter (fun c : Coloring n => ∀ e ∈ T, c e = b)).card
+        ≤ (univ : Finset (↥(Tᶜ : Finset (Sym2 (Fin n))) → Bool)).card := by
+    apply Finset.card_le_card_of_injOn ρ
+    · intro c _; exact mem_univ _
+    · intro c1 hc1 c2 hc2 hρ
+      have h1 : ∀ e ∈ T, c1 e = b := (mem_filter.mp hc1).2
+      have h2 : ∀ e ∈ T, c2 e = b := (mem_filter.mp hc2).2
+      funext e
+      by_cases he : e ∈ T
+      · rw [h1 e he, h2 e he]
+      · have hec : e ∈ (Tᶜ : Finset (Sym2 (Fin n))) := mem_compl.mpr he
+        have := congrFun hρ ⟨e, hec⟩
+        simpa [ρ] using this
+  calc
+    (univ.filter (fun c : Coloring n => ∀ e ∈ T, c e = b)).card
+        ≤ (univ : Finset (↥(Tᶜ : Finset (Sym2 (Fin n))) → Bool)).card := hcard
+    _ = Fintype.card (↥(Tᶜ : Finset (Sym2 (Fin n))) → Bool) := Finset.card_univ
+    _ = 2 ^ (Fintype.card (Sym2 (Fin n)) - T.card) := by
+        rw [Fintype.card_fun, Fintype.card_bool, Fintype.card_coe, Finset.card_compl]
+
+/-- **Erdős (1947) first-moment lower bound.** If `2·C(n,k) < 2^{C(k,2)}` then the
+union bound beats the total count, so some 2-coloring of `K_n` has *no*
+monochromatic `k`-clique. This is the probabilistic-method lower bound for the
+Ramsey number, here proved by an exact counting (no probability, no choice beyond
+classical logic of finite sets). -/
+theorem exists_good_coloring (n k : ℕ)
+    (h : 2 * n.choose k < 2 ^ (k.choose 2)) :
+    ∃ c : Coloring n, ¬ HasMonoClique c k := by
+  classical
+  set N := Fintype.card (Sym2 (Fin n)) with hN
+  by_contra hcon
+  push_neg at hcon
+  -- From `hcon` every coloring has a monochromatic `k`-clique; in particular `k ≤ n`.
+  have hkn : k ≤ n := by
+    obtain ⟨S, hScard, _⟩ := hcon (fun _ => true)
+    have : S.card ≤ n := by
+      have := Finset.card_le_univ S
+      simpa [Fintype.card_fin] using this
+    omega
+  -- `C(k,2) ≤ N`.
+  have hkN : k.choose 2 ≤ N := by
+    have h1 : k.choose 2 ≤ n.choose 2 := Nat.choose_le_choose 2 hkn
+    have h2 : n.choose 2 ≤ (n + 1).choose 2 := Nat.choose_le_choose 2 (Nat.le_succ n)
+    have h3 : (n + 1).choose 2 = N := by
+      rw [hN, Sym2.card, Fintype.card_fin]
+    omega
+  -- The "monochromatic on `S` in color `b`" colorings.
+  let M : Finset (Fin n) → Bool → Finset (Coloring n) :=
+    fun S b => univ.filter (fun c : Coloring n => IsMono c S b)
+  -- Every coloring is covered by some `M S true ∪ M S false` with `S` of card `k`.
+  have cover :
+      (univ : Finset (Coloring n)) ⊆
+        (powersetCard k univ).biUnion (fun S => M S true ∪ M S false) := by
+    intro c _
+    obtain ⟨S, hScard, hmono⟩ := hcon c
+    rw [mem_biUnion]
+    refine ⟨S, ?_, ?_⟩
+    · rw [mem_powersetCard]; exact ⟨subset_univ S, hScard⟩
+    · rw [mem_union]
+      rcases hmono with hT | hF
+      · exact Or.inl (mem_filter.mpr ⟨mem_univ _, hT⟩)
+      · exact Or.inr (mem_filter.mpr ⟨mem_univ _, hF⟩)
+  -- Per-set bound: |M S b| ≤ 2^(N - C(k,2)) when S has card k.
+  have hMbound : ∀ S ∈ powersetCard k univ, ∀ b,
+      (M S b).card ≤ 2 ^ (N - k.choose 2) := by
+    intro S hS b
+    have hScard : S.card = k := (mem_powersetCard.mp hS).2
+    -- `IsMono c S b` forces `c` constant `b` on `edgesWithin S`.
+    have hsub : M S b ⊆ univ.filter (fun c : Coloring n => ∀ e ∈ edgesWithin S, c e = b) := by
+      intro c hc
+      rw [mem_filter] at hc ⊢
+      refine ⟨hc.1, ?_⟩
+      intro e he
+      obtain ⟨p, hp, rfl⟩ := Finset.mem_image.mp he
+      obtain ⟨hx, hy, hxy⟩ := Finset.mem_offDiag.mp hp
+      exact hc.2 p.1 hx p.2 hy hxy
+    calc (M S b).card
+        ≤ (univ.filter (fun c : Coloring n => ∀ e ∈ edgesWithin S, c e = b)).card :=
+          Finset.card_le_card hsub
+      _ ≤ 2 ^ (N - (edgesWithin S).card) := constOn_card_le _ _
+      _ = 2 ^ (N - k.choose 2) := by rw [card_edgesWithin, hScard]
+  -- Assemble the union bound.
+  have hbig : (univ : Finset (Coloring n)).card ≤ 2 * n.choose k * 2 ^ (N - k.choose 2) := by
+    calc (univ : Finset (Coloring n)).card
+        ≤ ∑ S ∈ powersetCard k univ, (M S true ∪ M S false).card :=
+          le_trans (Finset.card_le_card cover) (Finset.card_biUnion_le)
+      _ ≤ ∑ S ∈ powersetCard k univ, 2 * 2 ^ (N - k.choose 2) := by
+          apply Finset.sum_le_sum
+          intro S hS
+          calc (M S true ∪ M S false).card
+              ≤ (M S true).card + (M S false).card := Finset.card_union_le _ _
+            _ ≤ 2 ^ (N - k.choose 2) + 2 ^ (N - k.choose 2) :=
+                Nat.add_le_add (hMbound S hS true) (hMbound S hS false)
+            _ = 2 * 2 ^ (N - k.choose 2) := by ring
+      _ = (powersetCard k univ).card * (2 * 2 ^ (N - k.choose 2)) := by
+          rw [Finset.sum_const, smul_eq_mul]
+      _ = n.choose k * (2 * 2 ^ (N - k.choose 2)) := by
+          rw [Finset.card_powersetCard]; simp [Fintype.card_fin]
+      _ = 2 * n.choose k * 2 ^ (N - k.choose 2) := by ring
+  -- But the total count is `2^N`, and the hypothesis makes the bound too small.
+  have htot : (univ : Finset (Coloring n)).card = 2 ^ N := by
+    rw [hN, Finset.card_univ]
+    simp [Coloring, Fintype.card_fun]
+  rw [htot] at hbig
+  -- `2 * C(n,k) * 2^(N-C(k,2)) < 2^(C(k,2)) * 2^(N-C(k,2)) = 2^N`, contradiction.
+  have hpos : 0 < 2 ^ (N - k.choose 2) := pow_pos (by norm_num) _
+  have hlt : 2 * n.choose k * 2 ^ (N - k.choose 2) < 2 ^ (k.choose 2) * 2 ^ (N - k.choose 2) :=
+    mul_lt_mul_of_pos_right h hpos
+  have heq : 2 ^ (k.choose 2) * 2 ^ (N - k.choose 2) = 2 ^ N := by
+    rw [← pow_add, Nat.add_sub_cancel' hkN]
+  rw [heq] at hlt
+  exact absurd (lt_of_le_of_lt hbig hlt) (lt_irrefl _)
+
+/-!
+## Consequences
+
+The counting bound gives concrete Ramsey lower bounds: if `2·C(n,k) < 2^{C(k,2)}`
+then every red/blue coloring evading a monochromatic `K_k` exists on `K_n`, so the
+Ramsey number `R(k) > n`. For example `R(3) > 3` and the asymptotic
+`R(k) ≥ (1+o(1))·(k/e)·2^{k/2}` both follow from this single inequality.
+-/
+
+/-- `R(3) > 3`: there is a 2-coloring of `K_3` with no monochromatic triangle. -/
+theorem exists_good_coloring_three : ∃ c : Coloring 3, ¬ HasMonoClique c 3 := by
+  apply exists_good_coloring
+  decide
+
+end Erdos1029LB

--- a/research/problems/erdos-1029-oq-01/state.md
+++ b/research/problems/erdos-1029-oq-01/state.md
@@ -1,27 +1,46 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T21:46:38.106Z
-**Iteration**: 1
+**Phase**: COMPLETED (iteration result shipped)
+**Since**: 2026-06-24
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalized the elementary Erdős (1947) first-moment lower bound for diagonal
+Ramsey numbers as a self-contained, 0-axiom Lean theorem.
 
-## Active Approach
+## Result
 
-None yet.
+`Proofs/Erdos1029LowerBound.lean` (verified, 0 axioms, original):
+- `exists_good_coloring`: if `2·C(n,k) < 2^{C(k,2)}` then some 2-coloring of K_n
+  has no monochromatic K_k (hence R(k) > n), by an exact union-bound count of
+  colorings — no probability measure, no Lovász Local Lemma.
+- Counting lemma `constOn_card_le`: ≤ 2^(N − |T|) colorings are constant on a
+  fixed edge set T (restriction-to-complement injection).
+- `exists_good_coloring_three`: R(3) > 3.
 
-## Blockers
+Gallery entry: `src/data/proofs/erdos-1029-oq-01/`.
 
-None.
+## Scope / Honesty
+
+This does NOT resolve Erdős #1029 (R(k)/(k·2^{k/2}) → ∞ remains OPEN). It is the
+elementary lower bound (base √2), weaker than Spencer's √2/e. It strengthens the
+parent entry `erdos-1029`, which assumed the lower bound as the axiom
+`spencer_lower_bound`.
+
+## Note on parent
+
+`proofs/Proofs/Erdos1029Problem.lean` does NOT build against pinned Mathlib
+v4.26 (orphan `/-- -/` docstrings = parse errors; `List.Mem.elim`/`Tendsto`
+API drift). Reported for a separate repair; this entry is self-contained
+(imports Mathlib only) and verified independently.
 
 ## Next Action
 
-Begin problem exploration.
+None — iteration complete, PR opened.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (exact counting / first-moment union bound — succeeded)

--- a/src/data/proofs/erdos-1029-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1029-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "ann-coloring-defs",
+    "proofId": "erdos-1029-oq-01",
+    "range": { "startLine": 9, "endLine": 30 },
+    "type": "concept",
+    "title": "Colorings as Functions on Edges",
+    "content": "A 2-coloring is modelled as `c : Sym2 (Fin n) → Bool`, a function on unordered pairs of vertices. `IsMono c S b` asserts that every edge between two distinct vertices of S receives color b, and `HasMonoClique c k` that some k-vertex set is monochromatic. The key auxiliary object is `edgesWithin S = S.offDiag.image Sym2.mk`, the set of edges spanned by S; for |S| = k it has exactly C(k,2) elements. Because the whole argument is a finite count, the diagonal of Sym2 is harmless — it never appears among the constrained edges and cancels out of every ratio."
+  },
+  {
+    "id": "ann-counting-lemma",
+    "proofId": "erdos-1029-oq-01",
+    "range": { "startLine": 32, "endLine": 60 },
+    "type": "technique",
+    "title": "Counting Colorings Constant on an Edge Set",
+    "content": "constOn_card_le bounds the number of colorings that are constant equal to b on a fixed edge set T by 2^(N − |T|), where N is the total number of edges. The trick is a restriction map ρ sending a coloring to its values on the complement Tᶜ. On the set of colorings constant on T this map is injective: two such colorings already agree on T (both equal b), so agreeing on Tᶜ makes them equal. Hence their count is at most the number of functions Tᶜ → Bool, which Fintype.card_fun evaluates to 2^(N − |T|). This is the heart of the 'first moment' estimate, done with cardinalities rather than a probability measure."
+  },
+  {
+    "id": "ann-union-bound",
+    "proofId": "erdos-1029-oq-01",
+    "range": { "startLine": 62, "endLine": 150 },
+    "type": "proof-step",
+    "title": "The Union Bound and the Cancelling Free-Edge Factor",
+    "content": "Assume for contradiction that every coloring has a monochromatic K_k. Then the universe of all 2^N colorings is covered by the union, over the C(n,k) candidate k-sets S, of the colorings monochromatic on S (in either color). Each such set has at most 2·2^(N − C(k,2)) colorings by the counting lemma applied with T = edgesWithin S. The union bound gives 2^N ≤ 2·C(n,k)·2^(N − C(k,2)). But the hypothesis 2·C(n,k) < 2^{C(k,2)}, multiplied by the positive free-edge factor 2^(N − C(k,2)) and using 2^{C(k,2)}·2^(N − C(k,2)) = 2^N (valid since C(k,2) ≤ N), forces 2^N < 2^N — a contradiction. So a coloring with no monochromatic K_k exists, i.e. R(k) > n."
+  },
+  {
+    "id": "ann-scope-and-consequences",
+    "proofId": "erdos-1029-oq-01",
+    "range": { "startLine": 152, "endLine": 169 },
+    "type": "concept",
+    "title": "What This Proves — and What Stays Open",
+    "content": "Instantiating the threshold gives concrete lower bounds such as R(3) > 3 and, asymptotically, R(k) ≳ 2^{k/2}. This is the elementary Erdős (1947) bound (exponential base √2), strictly weaker than Spencer's √2/e refinement via the Lovász Local Lemma, and far weaker than would be needed to settle Erdős #1029. The open conjecture R(k)/(k·2^{k/2}) → ∞ — whether the probabilistic lower bound is far from tight — is untouched here; the gap between this base √2 and the upper bound's base 4 is exactly its content. The contribution is to replace an assumed lower bound (the parent's spencer_lower_bound axiom) with a fully machine-checked, 0-axiom counting proof of its elementary form."
+  }
+]

--- a/src/data/proofs/erdos-1029-oq-01/meta.json
+++ b/src/data/proofs/erdos-1029-oq-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "erdos-1029-oq-01",
+  "title": "Erdős #1029 (oq-01): The Elementary First-Moment Lower Bound for Ramsey Numbers, by Exact Counting",
+  "slug": "erdos-1029-oq-01",
+  "description": "A self-contained, 0-axiom formalization of the Erdős (1947) probabilistic lower bound for the diagonal Ramsey number: if 2·C(n,k) < 2^{C(k,2)} then some 2-coloring of K_n has no monochromatic K_k, so R(k) > n. Proved by an exact union-bound count of colorings — no probability measure, no Lovász Local Lemma. This is the foundational lower bound that the parent entry erdos-1029 only assumed (as the stronger Spencer axiom); it does NOT resolve the open conjecture R(k)/(k·2^{k/2}) → ∞.",
+  "meta": {
+    "author": "Lean formalization original (lower bound: Erdős 1947, 'Some remarks on the theory of graphs')",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1029LowerBound.lean",
+    "tags": [
+      "erdos",
+      "ramsey-theory",
+      "graph-theory",
+      "probabilistic-method",
+      "counting",
+      "union-bound",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Sym2.card_image_offDiag",
+        "description": "#(S.offDiag.image Sym2.mk) = (#S).choose 2 — the number of edges spanned by a k-set is C(k,2); this is the exact exponent in the per-set counting bound",
+        "module": "Mathlib.Data.Sym.Card"
+      },
+      {
+        "theorem": "Sym2.card",
+        "description": "Fintype.card (Sym2 α) = (Fintype.card α + 1).choose 2 — the total edge count C(n+1,2) bounding C(k,2) ≤ N",
+        "module": "Mathlib.Data.Sym.Card"
+      },
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "Fintype.card (α → β) = (Fintype.card β) ^ (Fintype.card α) — counts the 2^N colorings and the 2^(N−|T|) colorings free off an edge set T",
+        "module": "Mathlib.Data.Fintype.Pi"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "Cardinality bound via an injection on a subset; restriction-to-complement injects monochromatic colorings into functions on the un-constrained edges",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_biUnion_le",
+        "description": "(s.biUnion t).card ≤ ∑ a ∈ s, (t a).card — the union bound over all k-subsets",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "(powersetCard k s).card = s.card.choose k — there are C(n,k) candidate cliques to union over",
+        "module": "Mathlib.Data.Finset.Powerset"
+      }
+    ],
+    "originalContributions": [
+      "First Lean formalization of the elementary Erdős (1947) Ramsey lower bound, proved by exact finite counting rather than a probability measure or the Lovász Local Lemma",
+      "The counting lemma constOn_card_le: at most 2^(N − |T|) colorings are constant on a fixed edge set T, via a restriction-to-complement injection",
+      "A clean union-bound assembly giving the threshold 2·C(n,k) < 2^{C(k,2)} ⟹ ∃ good coloring, with the free-edge factor 2^(N−C(k,2)) cancelling exactly",
+      "Strengthens the parent entry erdos-1029, which assumed the (stronger) lower bound as the axiom spencer_lower_bound; here the elementary version is discharged with 0 axioms"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound), 0 sorries. The result is the elementary lower bound and is deliberately weaker than Spencer's √2/e constant; it does not resolve Erdős #1029.",
+    "lineCount": 169,
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "In his 1947 paper 'Some remarks on the theory of graphs', Erdős gave one of the first applications of the probabilistic method: color the edges of K_n at random and show the expected number of monochromatic k-cliques is < 1, so a coloring avoiding all of them must exist. This proves R(k) > n whenever C(n,k)·2^{1−C(k,2)} < 1, i.e. roughly R(k) ≳ 2^{k/2}. The argument is purely a counting argument — the 'probability' is just normalized cardinality — and it underlies the entire lower-bound side of problem #1029. Spencer (1975) later refined the constant to √2/e using the Lovász Local Lemma; the present formalization proves the original 1947 version directly, as an exact count of finite sets, which is what makes it 0-axiom and self-contained.",
+    "problemStatement": "Erdős #1029 asks whether R(k)/(k·2^{k/2}) → ∞ (OPEN, $100 proof / $1000 disproof). This entry does NOT resolve that question. It formalizes the foundational lower bound on which the problem rests: if 2·C(n,k) < 2^{C(k,2)} then there is a 2-coloring of the edges of K_n with no monochromatic K_k, hence the diagonal Ramsey number satisfies R(k) > n.",
+    "proofStrategy": "Count colorings c : Sym2(Fin n) → Bool. There are 2^N of them, N = C(n+1,2). For a fixed k-set S, a coloring monochromatic on S is constant on the C(k,2) edges spanned by S, so it is free only on the remaining N − C(k,2) edges; by a restriction-to-complement injection, at most 2^(N−C(k,2)) such colorings exist, times 2 for the two colors. Union-bounding over the C(n,k) candidate cliques, the number of colorings containing some monochromatic K_k is at most 2·C(n,k)·2^(N−C(k,2)). When 2·C(n,k) < 2^{C(k,2)} this is strictly below the total 2^N (the free-edge factor 2^(N−C(k,2)) cancels exactly), so a good coloring must exist.",
+    "keyInsights": [
+      "The probabilistic method here is literally counting: 'probability < 1' = 'bad colorings < total colorings'",
+      "Per-clique count: fixing the C(k,2) interior edges to one color leaves N − C(k,2) edges free, giving exactly 2^(N−C(k,2)) colorings (bounded via an injection into functions on the complementary edge set)",
+      "The threshold 2·C(n,k) < 2^{C(k,2)} is the clean integer form of Erdős's inequality C(n,k)·2^{1−C(k,2)} < 1",
+      "The free-edge factor cancels: 2^{C(k,2)}·2^{N−C(k,2)} = 2^N exactly because C(k,2) ≤ N",
+      "This is the elementary bound (base √2); the huge gap to the upper bound (base 4) is precisely what #1029 conjectures is real"
+    ],
+    "prerequisites": [
+      "Ramsey theory (diagonal Ramsey numbers, monochromatic cliques)",
+      "The probabilistic / first-moment method in combinatorics",
+      "Finite cardinality arguments (union bound, counting functions on finite sets)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Colorings and Monochromatic Cliques",
+      "summary": "Coloring n := Sym2 (Fin n) → Bool; IsMono c S b; HasMonoClique c k; edgesWithin S",
+      "startLine": 1,
+      "endLine": 36,
+      "mathContext": "A 2-coloring is a function on unordered pairs. `IsMono c S b` says every edge between distinct vertices of S has color b; `HasMonoClique c k` says some k-set is monochromatic. `edgesWithin S = S.offDiag.image Sym2.mk` is the C(k,2) edges spanned by S."
+    },
+    {
+      "id": "counting-lemma",
+      "title": "The Counting Lemma",
+      "summary": "constOn_card_le: at most 2^(N − |T|) colorings are constant equal to b on a fixed edge set T",
+      "startLine": 38,
+      "endLine": 67,
+      "mathContext": "Restriction to the complement of T is injective on the set of colorings constant on T (their values on T are all forced to b), so their number is at most the number of functions on the complement, namely 2^(Fintype.card (Sym2 (Fin n)) − T.card)."
+    },
+    {
+      "id": "main-bound",
+      "title": "Erdős's First-Moment Lower Bound",
+      "summary": "exists_good_coloring: 2·C(n,k) < 2^{C(k,2)} ⟹ ∃ coloring with no monochromatic K_k",
+      "startLine": 69,
+      "endLine": 150,
+      "mathContext": "The union bound over all k-subsets, each contributing ≤ 2·2^(N−C(k,2)) monochromatic colorings, is strictly below the total 2^N under the hypothesis; the existence of a coloring outside the bad set follows."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences",
+      "summary": "exists_good_coloring_three (R(3) > 3) and the asymptotic R(k) ≳ 2^{k/2}",
+      "startLine": 152,
+      "endLine": 169,
+      "mathContext": "Instantiating the threshold yields concrete Ramsey lower bounds. The bound is elementary and weaker than Spencer's; the conjecture #1029 asserts the true ratio is unbounded."
+    }
+  ],
+  "references": [
+    {
+      "citation": "Erdős, P. (1947). 'Some remarks on the theory of graphs.' Bulletin of the American Mathematical Society 53, 292–294.",
+      "url": "https://doi.org/10.1090/S0002-9904-1947-08785-1"
+    },
+    {
+      "citation": "Spencer, J. (1975). 'Ramsey's theorem — a new lower bound.' Journal of Combinatorial Theory, Series A 18, 108–115.",
+      "url": "https://doi.org/10.1016/0097-3165(75)90071-0"
+    },
+    {
+      "citation": "Erdős, P., Szekeres, G. (1935). 'A combinatorial problem in geometry.' Compositio Mathematica 2, 463–470.",
+      "url": "https://erdosproblems.com/1029"
+    },
+    {
+      "citation": "Erdős Problem #1029.",
+      "url": "https://erdosproblems.com/1029"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "erdos-1029",
+      "relevance": "Parent entry: states the open conjecture R(k)/(k·2^{k/2}) → ∞ and assumes the lower bound as the axiom spencer_lower_bound. This entry discharges the elementary version of that lower bound with 0 axioms."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 0-axiom, self-contained Lean proof of Erdős's 1947 first-moment lower bound for Ramsey numbers: if 2·C(n,k) < 2^{C(k,2)} then K_n admits a 2-coloring with no monochromatic K_k, so R(k) > n. The proof is an exact count — total colorings 2^N, at most 2·C(n,k)·2^(N−C(k,2)) of them bad — with the free-edge factor cancelling precisely. The parent entry erdos-1029 only assumed this bound (in the stronger Spencer form) as an axiom.",
+    "implications": "Replaces an assumed lower bound by a machine-checked counting argument, isolating exactly which finite-combinatorial facts the Ramsey lower bound needs (a per-clique injection plus a union bound). The result is deliberately the elementary bound (exponential base √2) and does not touch the open conjecture; the gap between this base and the upper bound's base 4 is the content of #1029.",
+    "openQuestions": [
+      "Does R(k)/(k·2^{k/2}) → ∞? (Erdős #1029, OPEN — this entry does not address it.)",
+      "Can the formalization be sharpened from the elementary base √2 to Spencer's √2/e constant by formalizing the Lovász Local Lemma deletion step?",
+      "Can the abstract coloring count here be bridged to the parent's Nat.find-based R(k) to turn 'R(k) > n' into a theorem about the parent's definition once that file builds against pinned Mathlib?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1029LB",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1029LowerBound.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **first-moment lower bound** for diagonal Ramsey numbers, self-contained (`import Mathlib` only):

```
exists_good_coloring : 2*C(n,k) < 2^C(k,2) → ∃ coloring of K_n with
                       no monochromatic K_k   (hence R(k) > n)
```

The proof is an **exact union-bound count** of 2-colorings — no probability measure, no Lovász Local Lemma. The counting lemma `constOn_card_le` bounds the colorings constant on a fixed edge set via a restriction-to-complement injection; the free-edge factor `2^(N-C(k,2))` cancels exactly.

This strengthens parent `erdos-1029`, which assumed this lower bound (in the stronger Spencer form) as the axiom `spencer_lower_bound`. It does **not** resolve the open conjecture `R(k)/(k·2^{k/2}) → ∞`.

## Verification

- Builds clean against pinned Mathlib v4.26 (host `lake env lean`), 0 sorries.
- `#print axioms exists_good_coloring` → `[propext, Classical.choice, Quot.sound]` only — **0-axiom**, no `Lean.ofReduceBool`.
- Includes a concrete check `exists_good_coloring_three` (a good 2-coloring of K₃ with no mono K₃).

## Files

- `proofs/Proofs/Erdos1029LowerBound.lean` (169 L)
- `src/data/proofs/erdos-1029-oq-01/{meta.json,annotations.json}`
- `research/problems/erdos-1029-oq-01/state.md`

Note: parent `Proofs/Erdos1029Problem.lean` does not build against pinned Mathlib v4.26 (orphan docstring parse errors + API drift) — flagged for separate repair; this entry is independently checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)