### PR TITLE
research(mellin-oq-01-oq-01): general interval (b^s-a^s)/s and power-weighted strip Re s > -c

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -594,6 +594,7 @@ import Proofs.CantorsTheoremOQ03OQ02
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CarnotTheoremOQ01OQ01
+import Proofs.CarnotTheoremOQ01OQ01OQ01
 import Proofs.CarnotTheoremOQ01OQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ03

--- a/proofs/Proofs/CarnotTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CarnotTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,221 @@
+import Mathlib
+import Proofs.CarnotTheorem
+
+/-
+# Carnot's Theorem — the metric signed-distance form with an explicit circumcenter
+
+The parent files work entirely in the *angle* form.  `CarnotTheorem.lean`
+proves
+
+  `cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`,
+
+and `CarnotTheoremOQ01OQ01.lean` pins down the range of that cosine sum.  Both
+live in a bespoke trigonometric encoding: there is no actual triangle, no
+circumcenter, and no perpendicular distances — only three reals summing to `π`.
+
+The parent's open question asks whether the genuinely *geometric* statement can
+be formalized:
+
+  > Can the metric signed-distance form with an explicit circumcenter over
+  > `EuclideanSpace ℝ (Fin 2)` be formalized?
+
+This file answers **yes**.  We build the triangle concretely in the Euclidean
+plane `EuclideanSpace ℝ (Fin 2)`:
+
+* the circumcenter is the **explicit point** `O = (0, 0)`;
+* the three vertices `Pa, Pb, Pc` sit on the circle of radius `R` about `O`,
+  placed by the inscribed-angle convention so that side `BC` subtends central
+  angle `2A`, etc.;
+* `O` is verified to be the circumcenter: `dist O Pa = dist O Pb = dist O Pc = R`
+  (`circumradius`);
+* for each side we exhibit the inward unit normal and take Mathlib's
+  `signedDist` (the trilinear signed distance, `⟪normalize v, q -ᵥ p⟫`) from `O`
+  to that side.
+
+The geometric heart is that each signed distance is exactly `R cos` of the
+opposite angle:
+
+  `signedDist (na A) Pc O = R cos A`   (`dA_eq`),  and similarly `R cos B`, `R cos C`,
+
+with the cosine carrying the correct sign automatically — negative precisely
+when the circumcenter falls on the far side of an obtuse angle's opposite side.
+We also certify each normal really is perpendicular to its side (`na_perp`,
+`nb_perp`, `nc_perp`).
+
+Summing and feeding the parent identity through gives **Carnot's theorem in
+metric form**:
+
+  `signedDist_a + signedDist_b + signedDist_c = R + r`,
+
+where `r = 4 R sin(A/2) sin(B/2) sin(C/2)` is the inradius
+(`carnot_signedDist_sum`).
+
+**No axioms, no sorries.**
+-/
+
+open Real NormedSpace
+open scoped RealInnerProductSpace
+
+namespace CarnotTheoremOQ01OQ01OQ01
+
+/-- The Euclidean plane. -/
+abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
+
+/-! ## Coordinate helpers -/
+
+/-- The norm of an explicit plane vector. -/
+private lemma norm_two (a b : ℝ) :
+    ‖(!₂[a, b] : Vec2)‖ = Real.sqrt (a ^ 2 + b ^ 2) := by
+  rw [EuclideanSpace.norm_eq, Fin.sum_univ_two]
+  simp [Real.norm_eq_abs, sq_abs]
+
+/-- A vector `(a, b)` with `a² + b² = 1` is a unit vector. -/
+private lemma norm_unit (a b : ℝ) (h : a ^ 2 + b ^ 2 = 1) :
+    ‖(!₂[a, b] : Vec2)‖ = 1 := by
+  rw [norm_two, h, Real.sqrt_one]
+
+/-- A point on the circle of radius `r` has norm `r`. -/
+private lemma norm_circle (r t : ℝ) (hr : 0 ≤ r) :
+    ‖(!₂[r * Real.cos t, r * Real.sin t] : Vec2)‖ = r := by
+  rw [norm_two,
+    show (r * Real.cos t) ^ 2 + (r * Real.sin t) ^ 2 = r ^ 2 by
+      nlinarith [Real.sin_sq_add_cos_sq t]]
+  exact Real.sqrt_sq hr
+
+/-- The inner product of two explicit plane vectors. -/
+private lemma inner_two (a b c d : ℝ) :
+    ⟪(!₂[a, b] : Vec2), !₂[c, d]⟫ = a * c + b * d := by
+  have h : ⟪(!₂[a, b] : Vec2), !₂[c, d]⟫ = c * a + d * b := by
+    simp [PiLp.inner_apply, Fin.sum_univ_two]
+  rw [h]; ring
+
+/-! ## The configuration -/
+
+/-- The circumcenter, placed at the origin. -/
+def O : Vec2 := 0
+
+/-- Vertex `A`, at position angle `2A + 2C` (so arc `CA = 2B`). -/
+noncomputable def Pa (R A C : ℝ) : Vec2 := !₂[R * Real.cos (2 * A + 2 * C), R * Real.sin (2 * A + 2 * C)]
+
+/-- Vertex `B`, at position angle `2A`. -/
+noncomputable def Pb (R A : ℝ) : Vec2 := !₂[R * Real.cos (2 * A), R * Real.sin (2 * A)]
+
+/-- Vertex `C`, at position angle `0`. -/
+def Pc (R : ℝ) : Vec2 := !₂[R, 0]
+
+/-- Inward unit normal to side `BC` (pointing toward `A`); midangle of `BC` is `A`. -/
+noncomputable def na (A : ℝ) : Vec2 := !₂[-Real.cos A, -Real.sin A]
+
+/-- Inward unit normal to side `CA` (pointing toward `B`); midangle of `CA` is `-B`. -/
+noncomputable def nb (B : ℝ) : Vec2 := !₂[-Real.cos B, Real.sin B]
+
+/-- Inward unit normal to side `AB` (pointing toward `C`); midangle of `AB` is `2A + C`. -/
+noncomputable def nc (A C : ℝ) : Vec2 := !₂[-Real.cos (2 * A + C), -Real.sin (2 * A + C)]
+
+/-! ## The circumcenter is genuine: equidistant from all three vertices -/
+
+/-- `O` is the circumcenter: it is equidistant (`= R`) from the three vertices. -/
+theorem circumradius (R A C : ℝ) (hR : 0 ≤ R) :
+    dist O (Pa R A C) = R ∧ dist O (Pb R A) = R ∧ dist O (Pc R) = R := by
+  refine ⟨?_, ?_, ?_⟩ <;>
+    rw [dist_eq_norm, O, zero_sub, norm_neg]
+  · exact norm_circle R (2 * A + 2 * C) hR
+  · exact norm_circle R (2 * A) hR
+  · rw [Pc, norm_two]
+    rw [show (R : ℝ) ^ 2 + (0 : ℝ) ^ 2 = R ^ 2 by ring, Real.sqrt_sq hR]
+
+/-! ## The normals are unit vectors and perpendicular to their sides -/
+
+private lemma norm_na (A : ℝ) : ‖na A‖ = 1 := by
+  rw [na]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq A])
+
+private lemma norm_nb (B : ℝ) : ‖nb B‖ = 1 := by
+  rw [nb]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq B])
+
+private lemma norm_nc (A C : ℝ) : ‖nc A C‖ = 1 := by
+  rw [nc]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq (2 * A + C)])
+
+/-- `na` is perpendicular to side `BC` (direction `Pc - Pb`). -/
+theorem na_perp (R A : ℝ) : ⟪na A, Pc R - Pb R A⟫ = 0 := by
+  rw [inner_sub_right, na, Pc, Pb, inner_two, inner_two]
+  have h : Real.cos A * Real.cos (2 * A) + Real.sin A * Real.sin (2 * A) = Real.cos A := by
+    rw [← Real.cos_sub, show A - 2 * A = -A by ring, Real.cos_neg]
+  linear_combination R * h
+
+/-- `nb` is perpendicular to side `CA` (direction `Pa - Pc`). -/
+theorem nb_perp (R A B C : ℝ) (h : A + B + C = π) :
+    ⟪nb B, Pa R A C - Pc R⟫ = 0 := by
+  rw [inner_sub_right, nb, Pa, Pc, inner_two, inner_two]
+  -- `B + (2A+2C) = 2π - B`, so `cos B cos(2A+2C) - sin B sin(2A+2C) = cos(2π - B) = cos B`.
+  have key : Real.cos B * Real.cos (2 * A + 2 * C)
+        - Real.sin B * Real.sin (2 * A + 2 * C) = Real.cos B := by
+    rw [← Real.cos_add, show B + (2 * A + 2 * C) = 2 * π - B by linarith, Real.cos_sub]
+    simp [Real.cos_two_pi, Real.sin_two_pi]
+  linear_combination (-R) * key
+
+/-- `nc` is perpendicular to side `AB` (direction `Pa - Pb`). -/
+theorem nc_perp (R A C : ℝ) :
+    ⟪nc A C, Pa R A C - Pb R A⟫ = 0 := by
+  rw [inner_sub_right, nc, Pa, Pb, inner_two, inner_two]
+  -- midangle of `AB` is `2A + C`; both endpoints are equidistant in angle from it.
+  have ha : Real.cos (2 * A + C) * Real.cos (2 * A + 2 * C)
+        + Real.sin (2 * A + C) * Real.sin (2 * A + 2 * C) = Real.cos C := by
+    rw [← Real.cos_sub, show (2 * A + C) - (2 * A + 2 * C) = -C by ring, Real.cos_neg]
+  have hb : Real.cos (2 * A + C) * Real.cos (2 * A)
+        + Real.sin (2 * A + C) * Real.sin (2 * A) = Real.cos C := by
+    rw [← Real.cos_sub]; congr 1; ring
+  linear_combination (-R) * ha + R * hb
+
+/-! ## The signed distances are `R cos` of the opposite angle -/
+
+/-- **Signed distance from the circumcenter to side `BC` equals `R cos A`.** -/
+theorem dA_eq (R A : ℝ) : signedDist (na A) (Pc R) O = R * Real.cos A := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_na A), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, na, Pc]
+  rw [inner_two]; ring
+
+/-- **Signed distance from the circumcenter to side `CA` equals `R cos B`.** -/
+theorem dB_eq (R B : ℝ) : signedDist (nb B) (Pc R) O = R * Real.cos B := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_nb B), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, nb, Pc]
+  rw [inner_two]; ring
+
+/-- **Signed distance from the circumcenter to side `AB` equals `R cos C`.** -/
+theorem dC_eq (R A C : ℝ) : signedDist (nc A C) (Pb R A) O = R * Real.cos C := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_nc A C), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, nc, Pb]
+  rw [inner_two]
+  have hcos : Real.cos (2 * A + C) * Real.cos (2 * A)
+        + Real.sin (2 * A + C) * Real.sin (2 * A) = Real.cos C := by
+    rw [← Real.cos_sub]; congr 1; ring
+  linear_combination R * hcos
+
+/-! ## Carnot's theorem, metric form -/
+
+/-- **Carnot's theorem (metric signed-distance form).**
+
+For a triangle with angles `A, B, C > 0` (`A + B + C = π`) and circumradius
+`R > 0`, realized explicitly in `EuclideanSpace ℝ (Fin 2)` with circumcenter
+`O = (0,0)`, the sum of the signed perpendicular distances from `O` to the three
+sides equals `R + r`, where `r = 4 R sin(A/2) sin(B/2) sin(C/2)` is the inradius:
+
+  `d_a + d_b + d_c = R + r`.
+
+The signs are handled automatically by `signedDist`: a distance is negative
+exactly when the circumcenter lies on the far side of the corresponding side
+(the obtuse case).  The identity reduces, via `dA_eq`/`dB_eq`/`dC_eq`, to
+`R (cos A + cos B + cos C) = R + r`, which is the parent angle identity scaled
+by `R`.
+
+Only `A + B + C = π` is needed for the identity itself; for a *genuine*
+(non-degenerate) triangle one additionally takes `R > 0` and `A, B, C > 0`,
+under which `circumradius` certifies that `O` really is the circumcenter. -/
+theorem carnot_signedDist_sum (R A B C : ℝ) (h : A + B + C = π) :
+    signedDist (na A) (Pc R) O + signedDist (nb B) (Pc R) O
+        + signedDist (nc A C) (Pb R A) O
+      = R + R * (4 * Real.sin (A / 2) * Real.sin (B / 2) * Real.sin (C / 2)) := by
+  rw [dA_eq, dB_eq, dC_eq]
+  have hsum := CarnotTheorem.carnot_cos_sum A B C h
+  linear_combination R * hsum
+
+end CarnotTheoremOQ01OQ01OQ01

--- a/proofs/Proofs/MellinPowerConvergenceOQ01OQ01.lean
+++ b/proofs/Proofs/MellinPowerConvergenceOQ01OQ01.lean
@@ -1,0 +1,144 @@
+/-
+  Mellin transform of the unit indicator — open question oq-01 (child oq-01-oq-01).
+
+  The parent entry (`MellinPowerConvergenceOQ01`) computes the Mellin transform
+  of the unit indicator `𝟙_{(0,1]}`, its sharp convergence strip `Re s > 0`, and
+  the scaling law `mellin 𝟙_{(0,a]} s = a^s / s`. Its first open question asks to
+  extend this to
+
+    (1) the indicator of a *general interval* `𝟙_{[a,b]}` (here `𝟙_{(a,b]}`),
+        giving `(b^s - a^s)/s`, and
+    (2) the *power-weighted* indicator `t^c · 𝟙_{(0,1]}`, which shifts the
+        convergence strip to `Re s > -c` and yields `1/(s + c)`.
+
+  This file answers both, axiom-free and sorry-free, building on the parent's
+  scaling law and Mathlib's Mellin API (`hasMellin_sub`, `hasMellin_cpow_Ioc`,
+  `mellin_cpow_smul`, `MellinConvergent.cpow_smul`):
+
+    * `hasMellin_indicator_interval` / `mellin_indicator_interval`
+        — the general-interval transform `(b^s - a^s)/s` (Re s > 0), via the
+          difference `𝟙_{(a,b]} = 𝟙_{(0,b]} - 𝟙_{(0,a]}`;
+    * `mellin_indicator_interval_one` — at `s = 1` it returns the length `b - a`;
+    * `hasMellin_powerWeighted_unit` / `mellin_powerWeighted_unit`
+        — the power-weighted transform `1/(s + c)` on the shifted strip `Re s > -c`;
+    * `mellinConvergent_powerWeighted_unit_iff`
+        — the convergence strip is *exactly* `Re s > -c` (sharp, both directions);
+    * `hasMellin_powerWeighted_interval`
+        — the capstone combining both: `mellin (t^c · 𝟙_{(a,b]}) s
+          = (b^{s+c} - a^{s+c})/(s + c)`.
+-/
+
+import Mathlib
+import Proofs.MellinPowerConvergenceOQ01
+
+open Complex MeasureTheory Set
+open MellinPowerConvergenceOQ01
+
+namespace MellinPowerConvergenceOQ01OQ01
+
+/-! ## Part 1: the general interval `𝟙_{(a,b]}` gives `(b^s - a^s)/s` -/
+
+/-- **General interval.** For `0 < a ≤ b` and `Re s > 0`, the Mellin transform of
+the indicator of `(a, b]` exists and equals `(b^s - a^s)/s`. The proof writes
+`𝟙_{(a,b]} = 𝟙_{(0,b]} - 𝟙_{(0,a]}` and subtracts two instances of the parent's
+scaling law. -/
+theorem hasMellin_indicator_interval {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) {s : ℂ}
+    (hs : 0 < s.re) :
+    HasMellin (Set.indicator (Set.Ioc a b) (fun _ => 1)) s (((b : ℂ) ^ s - (a : ℂ) ^ s) / s) := by
+  have hb : 0 < b := lt_of_lt_of_le ha hab
+  -- `𝟙_{(a,b]}(t) = 𝟙_{(0,b]}(t) - 𝟙_{(0,a]}(t)` pointwise.
+  have hfun : Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ))
+      = fun t => Set.indicator (Set.Ioc 0 b) (fun _ => (1 : ℂ)) t
+               - Set.indicator (Set.Ioc 0 a) (fun _ => (1 : ℂ)) t := by
+    funext t
+    by_cases htab : t ∈ Set.Ioc a b
+    · have hat := htab.1
+      have htb := htab.2
+      rw [Set.indicator_of_mem htab,
+          Set.indicator_of_mem (show t ∈ Set.Ioc 0 b from ⟨lt_trans ha hat, htb⟩),
+          Set.indicator_of_notMem (show t ∉ Set.Ioc 0 a from fun h => absurd h.2 (not_le.mpr hat))]
+      ring
+    · rw [Set.indicator_of_notMem htab]
+      by_cases ht0b : t ∈ Set.Ioc 0 b
+      · have hta : t ∈ Set.Ioc 0 a := by
+          refine ⟨ht0b.1, ?_⟩
+          by_contra h
+          exact htab ⟨lt_of_not_le h, ht0b.2⟩
+        rw [Set.indicator_of_mem ht0b, Set.indicator_of_mem hta]; ring
+      · have hta : t ∉ Set.Ioc 0 a := fun h => ht0b ⟨h.1, le_trans h.2 hab⟩
+        rw [Set.indicator_of_notMem ht0b, Set.indicator_of_notMem hta]; ring
+  rw [hfun, sub_div]
+  have hMb := hasMellin_indicator_Ioc hb hs
+  have hMa := hasMellin_indicator_Ioc ha hs
+  have hsub := hasMellin_sub hMb.1 hMa.1
+  rwa [hMb.2, hMa.2] at hsub
+
+/-- The value form of the general-interval transform. -/
+theorem mellin_indicator_interval {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) {s : ℂ} (hs : 0 < s.re) :
+    mellin (Set.indicator (Set.Ioc a b) (fun _ => 1)) s = ((b : ℂ) ^ s - (a : ℂ) ^ s) / s :=
+  (hasMellin_indicator_interval ha hab hs).2
+
+/-- At `s = 1` the general-interval transform returns the length of the interval:
+`mellin 𝟙_{(a,b]} 1 = b - a`. -/
+theorem mellin_indicator_interval_one {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) :
+    mellin (Set.indicator (Set.Ioc a b) (fun _ => 1)) 1 = (b : ℂ) - (a : ℂ) := by
+  rw [mellin_indicator_interval ha hab (by rw [Complex.one_re]; norm_num)]
+  rw [Complex.cpow_one, Complex.cpow_one, div_one]
+
+/-! ## Part 2: the power-weighted indicator `t^c · 𝟙_{(0,1]}`, strip `Re s > -c` -/
+
+/-- **Power-weighted unit indicator.** For real weight `c` and `Re s > -c`, the
+Mellin transform of `t^c · 𝟙_{(0,1]}` exists and equals `1/(s + c)`. The strip
+of the base case `Re s > 0` is shifted to `Re s > -c`. -/
+theorem hasMellin_powerWeighted_unit (c : ℝ) {s : ℂ} (hs : -c < s.re) :
+    HasMellin (Set.indicator (Set.Ioc (0:ℝ) 1) (fun t : ℝ => (t : ℂ) ^ (c : ℂ))) s (1 / (s + c)) := by
+  apply hasMellin_cpow_Ioc (c : ℂ)
+  rw [Complex.ofReal_re]
+  linarith
+
+/-- The value form of the power-weighted transform. -/
+theorem mellin_powerWeighted_unit (c : ℝ) {s : ℂ} (hs : -c < s.re) :
+    mellin (Set.indicator (Set.Ioc (0:ℝ) 1) (fun t : ℝ => (t : ℂ) ^ (c : ℂ))) s = 1 / (s + c) :=
+  (hasMellin_powerWeighted_unit c hs).2
+
+/-- **Sharp shifted strip.** The Mellin integral of the power-weighted unit
+indicator converges *iff* `Re s > -c`. The boundary `Re s = -c` is exactly where
+`∫_0^1 t^{s + c - 1} dt` diverges — the parent's `Re s > 0` strip translated by
+`-c`. -/
+theorem mellinConvergent_powerWeighted_unit_iff (c : ℝ) {s : ℂ} :
+    MellinConvergent (Set.indicator (Set.Ioc (0:ℝ) 1) (fun t : ℝ => (t : ℂ) ^ (c : ℂ))) s ↔ -c < s.re := by
+  have hfun : Set.indicator (Set.Ioc (0:ℝ) 1) (fun t : ℝ => (t : ℂ) ^ (c : ℂ))
+      = fun t : ℝ => (t : ℂ) ^ (c : ℂ) • unitIndicator t := by
+    funext t
+    by_cases ht : t ∈ Set.Ioc (0 : ℝ) 1
+    · simp [unitIndicator, Set.indicator_of_mem ht]
+    · simp [unitIndicator, Set.indicator_of_notMem ht]
+  rw [hfun, MellinConvergent.cpow_smul, mellinConvergent_unitIndicator_iff,
+    Complex.add_re, Complex.ofReal_re]
+  constructor <;> intro h <;> linarith
+
+/-! ## Part 3: the power-weighted general interval (capstone) -/
+
+/-- **Capstone.** Combining Parts 1 and 2: for `0 < a ≤ b` and `Re s > -c`, the
+Mellin transform of `t^c · 𝟙_{(a,b]}` exists and equals
+`(b^{s+c} - a^{s+c})/(s + c)`. The weight `t^c` shifts the spectral parameter
+from `s` to `s + c`, applied to the general-interval law of Part 1. -/
+theorem hasMellin_powerWeighted_interval (c : ℝ) {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) {s : ℂ}
+    (hs : -c < s.re) :
+    HasMellin (Set.indicator (Set.Ioc a b) (fun t => (t : ℂ) ^ (c : ℂ))) s
+      (((b : ℂ) ^ (s + c) - (a : ℂ) ^ (s + c)) / (s + c)) := by
+  have hsc : 0 < (s + (c : ℂ)).re := by rw [Complex.add_re, Complex.ofReal_re]; linarith
+  have hbase := hasMellin_indicator_interval ha hab hsc
+  -- `t^c · 𝟙_{(a,b]}(t) = t^c • 𝟙_{(a,b]}(t)`.
+  have hfun : Set.indicator (Set.Ioc a b) (fun t => (t : ℂ) ^ (c : ℂ))
+      = fun t : ℝ => (t : ℂ) ^ (c : ℂ) • Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ)) t := by
+    funext t
+    by_cases ht : t ∈ Set.Ioc a b
+    · simp [Set.indicator_of_mem ht]
+    · simp [Set.indicator_of_notMem ht]
+  rw [hfun]
+  refine ⟨?_, ?_⟩
+  · rw [MellinConvergent.cpow_smul]; exact hbase.1
+  · rw [mellin_cpow_smul]; exact hbase.2
+
+end MellinPowerConvergenceOQ01OQ01

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-carnot-oq010101-overview",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 54 },
+    "type": "concept",
+    "title": "Carnot's Theorem in Metric Form",
+    "content": "The docstring contrasts the parent files — which encode Carnot's theorem purely as the angle identity cos A + cos B + cos C = 1 + r/R, with no actual triangle, circumcenter, or distances — with the genuinely geometric statement the parent left open. Here the triangle is built concretely in EuclideanSpace ℝ (Fin 2): the circumcenter is the explicit point O = (0,0), the vertices sit on the radius-R circle, and the signed perpendicular distance from O to each side is taken with Mathlib's signedDist. The goal is d_a + d_b + d_c = R + r.",
+    "mathContext": "$d_a + d_b + d_c = R + r, \\qquad r = 4R\\,\\sin\\tfrac{A}{2}\\sin\\tfrac{B}{2}\\sin\\tfrac{C}{2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Carnot's theorem", "signed distance", "circumcenter", "circumradius", "inradius", "EuclideanSpace"],
+    "prerequisites": ["Euclidean geometry", "trigonometry"]
+  },
+  {
+    "id": "ann-carnot-oq010101-helpers",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 90 },
+    "type": "lemma",
+    "title": "Reducing Plane Geometry to Real Algebra",
+    "content": "Four private helpers turn EuclideanSpace ℝ (Fin 2) into ordinary coordinate algebra. norm_two expands ‖(a,b)‖ to sqrt(a²+b²) via EuclideanSpace.norm_eq and Fin.sum_univ_two; norm_unit and norm_circle specialise it (a²+b²=1 gives a unit vector; (r cos t, r sin t) has norm r). inner_two expands ⟪(a,b),(c,d)⟫ to ac + bd via PiLp.inner_apply. These let every later geometric claim be discharged by trigonometric identities.",
+    "mathContext": "$\\|(a,b)\\| = \\sqrt{a^2+b^2}, \\qquad \\langle (a,b),(c,d)\\rangle = ac + bd.$",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace.norm_eq", "PiLp.inner_apply", "Fin.sum_univ_two", "coordinate computation"],
+    "prerequisites": ["inner product spaces", "PiLp / EuclideanSpace"]
+  },
+  {
+    "id": "ann-carnot-oq010101-config",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 113 },
+    "type": "definition",
+    "title": "Explicit Circumcenter, Vertices, and Side Normals",
+    "content": "The configuration is fully explicit. O = (0,0) is the circumcenter; the vertices Pa, Pb, Pc are placed on the radius-R circle at position angles 2A+2C, 2A, 0, so that side BC subtends central angle 2A (the inscribed-angle convention, inscribed angle = half the central angle). Each inward unit normal is na, nb, nc = −(cos μ, sin μ), where μ is the side's midangle (A for BC, −B for CA, 2A+C for AB) — because the perpendicular foot from the center to a chord is its midpoint, lying in the midangle direction.",
+    "mathContext": "$P_B = R(\\cos 2A, \\sin 2A), \\quad P_C = R(1,0), \\qquad \\hat n_a = (-\\cos A, -\\sin A).$",
+    "significance": "key",
+    "relatedConcepts": ["inscribed angle theorem", "chord midpoint", "unit normal", "circumcircle"],
+    "prerequisites": ["circle geometry", "inscribed angle theorem"]
+  },
+  {
+    "id": "ann-carnot-oq010101-circumradius",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "theorem",
+    "title": "O Really Is the Circumcenter",
+    "content": "circumradius proves dist O Pa = dist O Pb = dist O Pc = R: the point O = (0,0) is equidistant from all three explicitly-placed vertices, hence is genuinely their circumcenter with circumradius R. Each distance reduces, via norm_circle (and a direct computation for Pc = (R,0)), to sin² + cos² = 1. This makes the 'explicit circumcenter' of the title a proved fact, not an assumption.",
+    "mathContext": "$\\operatorname{dist}(O, P_A) = \\operatorname{dist}(O, P_B) = \\operatorname{dist}(O, P_C) = R.$",
+    "significance": "key",
+    "relatedConcepts": ["circumcenter", "circumradius", "equidistance", "Pythagorean identity"],
+    "prerequisites": ["Euclidean distance"]
+  },
+  {
+    "id": "ann-carnot-oq010101-perp",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 127, "endLine": 167 },
+    "type": "lemma",
+    "title": "The Normals Are Unit Vectors Perpendicular to Their Sides",
+    "content": "norm_na/nb/nc confirm each side normal is a unit vector (sin²+cos² = 1); na_perp/nb_perp/nc_perp confirm each is perpendicular to its side, e.g. ⟪na, Pc − Pb⟫ = 0, by collapsing the inner product with cos(x−y) (and, for nb, cos(x+y) with B + (2A+2C) = 2π − B). Perpendicularity is exactly what makes the subsequent signedDist values genuine perpendicular distances to the side lines rather than projections along an arbitrary direction.",
+    "mathContext": "$\\|\\hat n_a\\| = 1, \\qquad \\langle \\hat n_a,\\, P_C - P_B\\rangle = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["unit vector", "perpendicularity", "cos(x−y)", "chord direction"],
+    "prerequisites": ["inner products", "trigonometric identities"]
+  },
+  {
+    "id": "ann-carnot-oq010101-distances",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 169, "endLine": 191 },
+    "type": "theorem",
+    "title": "Each Signed Distance Equals R cos of the Opposite Angle",
+    "content": "The geometric heart: dA_eq, dB_eq, dC_eq prove signedDist (na A) (Pc R) O = R cos A, and likewise R cos B, R cos C. Each unfolds Mathlib's signedDist to ⟪normalize n, O −ᵥ p⟫, drops normalize using the unit-norm lemma, and collapses the inner product with inner_two and cos_sub. The cosine carries the orientation for free — R cos A is negative exactly when A is obtuse, precisely the case where the circumcenter lies on the far side of side BC. No acute/obtuse case split is ever made.",
+    "mathContext": "$\\operatorname{signedDist}(\\hat n_a, P_C, O) = R\\cos A, \\quad \\operatorname{signedDist}(\\hat n_b, P_C, O) = R\\cos B, \\quad \\operatorname{signedDist}(\\hat n_c, P_B, O) = R\\cos C.$",
+    "significance": "key",
+    "relatedConcepts": ["signedDist", "signed perpendicular distance", "obtuse triangle sign", "R cos A"],
+    "prerequisites": ["signed distance to a line", "trigonometry"]
+  },
+  {
+    "id": "ann-carnot-oq010101-main",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 193, "endLine": 219 },
+    "type": "theorem",
+    "title": "Carnot's Theorem: Sum of Signed Distances = R + r",
+    "content": "carnot_signedDist_sum assembles the result: the three signed perpendicular distances from the circumcenter to the sides sum to R + r, with r = 4R sin(A/2) sin(B/2) sin(C/2) the inradius. By dA_eq/dB_eq/dC_eq the sum is R(cos A + cos B + cos C), and the parent angle identity carnot_cos_sum (cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)), scaled by R, finishes via linear_combination. Only A + B + C = π is needed; positivity of R, A, B, C is what makes the configuration a non-degenerate triangle.",
+    "mathContext": "$d_a + d_b + d_c = R(\\cos A + \\cos B + \\cos C) = R + r.$",
+    "significance": "key",
+    "relatedConcepts": ["Carnot's theorem", "inradius", "circumradius", "linear_combination"],
+    "prerequisites": ["the parent Carnot angle identity"]
+  }
+]

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "carnot-theorem-oq-01-oq-01-oq-01",
+  "title": "Carnot's Theorem — the metric signed-distance form with an explicit circumcenter",
+  "slug": "carnot-theorem-oq-01-oq-01-oq-01",
+  "description": "The metric form of Carnot's theorem, built concretely in EuclideanSpace ℝ (Fin 2): the circumcenter is the explicit point O = (0,0), the three vertices sit on the radius-R circle (and O is certified equidistant from all three), and the signed perpendicular distance from O to each side is exactly R cos of the opposite angle. Summing and feeding the parent angle identity through gives d_a + d_b + d_c = R + r with r = 4R sin(A/2) sin(B/2) sin(C/2). The signs are carried automatically by Mathlib's signedDist (negative exactly in the obtuse case). This answers the parent's open question of whether the metric signed-distance form can be formalized. Axiom- and sorry-free.",
+  "meta": {
+    "author": "Lazare Carnot (1803)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carnot%27s_theorem_(perpendiculars)",
+    "date": "1803",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CarnotTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "trigonometry",
+      "euclidean-geometry",
+      "signed-distance",
+      "circumcenter",
+      "circumradius",
+      "inradius",
+      "carnot-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "signedDist",
+        "description": "Mathlib's signed distance signedDist v p q = ⟪normalize v, q -ᵥ p⟫ in a Euclidean space (trilinear coordinates); used as the authoritative metric signed perpendicular distance from the circumcenter to each side",
+        "module": "Mathlib.Geometry.Euclidean.SignedDist"
+      },
+      {
+        "theorem": "NormedSpace.normalize_eq_self_of_norm_eq_one",
+        "description": "normalize v = v when ‖v‖ = 1, used to discharge the normalize in signedDist once each side normal is shown to be a unit vector",
+        "module": "Mathlib.Analysis.NormedSpace.Normalize"
+      },
+      {
+        "theorem": "EuclideanSpace.norm_eq",
+        "description": "‖x‖ = sqrt (∑ i, ‖x i‖²) over EuclideanSpace, used to compute norms of explicit plane vectors via Fin.sum_univ_two",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "PiLp.inner_apply",
+        "description": "Coordinate expansion of the inner product on EuclideanSpace, used (with Fin.sum_univ_two) to compute ⟪(a,b),(c,d)⟫ = ac + bd",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Real.cos_sub",
+        "description": "cos(x − y) = cos x cos y + sin x sin y; collapses each side's inner product to R cos of the opposite angle and certifies the normals are perpendicular to their sides",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "sin²x + cos²x = 1; gives that each side normal is a unit vector and that the vertices lie on the circle of radius R",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "CarnotTheorem.carnot_cos_sum",
+        "description": "Parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2); scaled by R it turns the sum of signed distances R(cos A + cos B + cos C) into R + r",
+        "module": "Proofs.CarnotTheorem"
+      }
+    ],
+    "originalContributions": [
+      "A complete metric formalization of Carnot's theorem over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter O = (0,0), answering the parent entry's stated open question",
+      "Each signed perpendicular distance from the circumcenter to a side equals R cos of the opposite angle (dA_eq, dB_eq, dC_eq), with the obtuse-case sign carried automatically by Mathlib's signedDist — no acute/obtuse case split",
+      "The circumcenter is certified genuine: O is proved equidistant (= R) from all three explicitly-placed vertices (circumradius)",
+      "Each side normal is certified perpendicular to its side (na_perp, nb_perp, nc_perp), so the signedDist values are bona fide perpendicular distances to the side lines",
+      "The metric identity d_a + d_b + d_c = R + r obtained by scaling the parent angle identity by R, with r = 4R sin(A/2) sin(B/2) sin(C/2) the inradius"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 221,
+    "assumptions": "0 axioms (only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, appear in #print axioms; no Lean.ofReduceBool, no sorryAx). 0 sorries. The signed-distance sum identity needs only A + B + C = π; the circumradius certification additionally uses R ≥ 0, and the genuine-triangle reading takes A, B, C > 0. Builds on the parent file Proofs/CarnotTheorem.lean (itself axiom-free). Note: local Docker kernel build was unavailable this session, so verification used host single-file elaboration (lake env lean) against Mathlib v4.26.0; the entry is gated by the deployer build before merge.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 7
+  },
+  "sections": [
+    {
+      "title": "Module header",
+      "startLine": 4,
+      "endLine": 54,
+      "description": "Docstring contrasting the parent's bespoke angle encoding (three reals summing to π, no actual triangle) with the genuinely geometric metric statement asked for by the parent's open question, and laying out the explicit construction: circumcenter O = (0,0), vertices on the radius-R circle by the inscribed-angle convention, inward unit normals, and Mathlib's signedDist as the signed perpendicular distance.",
+      "summary": "Module header",
+      "id": "module-header"
+    },
+    {
+      "title": "Coordinate helpers",
+      "startLine": 64,
+      "endLine": 90,
+      "description": "Four private lemmas reducing EuclideanSpace ℝ (Fin 2) computations to ordinary real algebra: norm_two (‖(a,b)‖ = sqrt(a²+b²)), norm_unit (a²+b² = 1 ⟹ unit vector), norm_circle (a point (r cos t, r sin t) has norm r), and inner_two (⟪(a,b),(c,d)⟫ = ac + bd via PiLp.inner_apply and Fin.sum_univ_two).",
+      "summary": "Norm and inner-product helpers for explicit plane vectors",
+      "id": "coordinate-helpers"
+    },
+    {
+      "title": "The configuration",
+      "startLine": 92,
+      "endLine": 113,
+      "description": "The explicit objects: circumcenter O = (0,0); vertices Pa, Pb, Pc placed on the radius-R circle at position angles 2A+2C, 2A, 0 so that side BC subtends central angle 2A (inscribed-angle convention); and the three inward unit normals na, nb, nc = −(cos μ, sin μ) where μ is each side's midangle (A, −B, 2A+C respectively).",
+      "summary": "Explicit circumcenter, vertices, and side normals",
+      "id": "configuration"
+    },
+    {
+      "title": "The circumcenter is genuine",
+      "startLine": 115,
+      "endLine": 125,
+      "description": "circumradius proves dist O Pa = dist O Pb = dist O Pc = R, i.e. O is equidistant from the three vertices and is therefore their circumcenter with circumradius R. Reduces via norm_circle (and a direct computation for Pc) to sin²+cos² = 1.",
+      "summary": "O is equidistant (= R) from all three vertices",
+      "id": "circumradius"
+    },
+    {
+      "title": "Unit normals perpendicular to the sides",
+      "startLine": 127,
+      "endLine": 167,
+      "description": "norm_na/nb/nc show each side normal is a unit vector (sin²+cos² = 1). na_perp/nb_perp/nc_perp show each normal is perpendicular to its side (⟪na, Pc − Pb⟫ = 0, etc.), via cos(x−y) and cos(x+y) identities. Together these certify that the subsequent signedDist values are bona fide signed perpendicular distances to the side lines.",
+      "summary": "Each normal is a unit vector perpendicular to its side",
+      "id": "normals"
+    },
+    {
+      "title": "Each signed distance is R cos of the opposite angle",
+      "startLine": 169,
+      "endLine": 191,
+      "description": "The geometric heart. dA_eq, dB_eq, dC_eq compute Mathlib's signedDist from the circumcenter O to each side: signedDist (na A) (Pc R) O = R cos A, and likewise R cos B, R cos C. Each unfolds signedDist to ⟪normalize n, O −ᵥ p⟫, uses the unit-norm fact to drop normalize, and collapses the inner product via inner_two and cos_sub. The cosine carries the correct sign automatically — negative exactly when the circumcenter falls on the far side of an obtuse angle's opposite side.",
+      "summary": "signedDist from circumcenter to each side = R cos(opposite angle)",
+      "id": "signed-distances"
+    },
+    {
+      "title": "Carnot's theorem, metric form",
+      "startLine": 193,
+      "endLine": 219,
+      "description": "carnot_signedDist_sum: the sum of the three signed perpendicular distances from the circumcenter to the sides equals R + r, where r = 4R sin(A/2) sin(B/2) sin(C/2) is the inradius. Reduces via dA_eq/dB_eq/dC_eq to R(cos A + cos B + cos C) = R + r, which is the parent angle identity carnot_cos_sum scaled by R.",
+      "summary": "Sum of signed circumcenter-to-side distances = R + r",
+      "id": "main-theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Carnot's theorem (Lazare Carnot, 1803) states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r, the sum of the circumradius and the inradius — with a side's contribution counted negative when the circumcenter lies on the far side of that side, as happens at an obtuse angle. The parent gallery entries formalize only the equivalent angle identity cos A + cos B + cos C = 1 + r/R, living in a bespoke trigonometric encoding with no actual triangle, circumcenter, or distances. The parent explicitly left open whether the genuinely metric statement — with an explicit circumcenter and real perpendicular distances over EuclideanSpace ℝ (Fin 2) — could be formalized. This entry does exactly that.",
+    "problemStatement": "Realize a triangle with circumradius R > 0 and angles A, B, C > 0 (A + B + C = π) concretely in EuclideanSpace ℝ (Fin 2): place the circumcenter at an explicit point and the vertices on the circle of radius R about it. Define the signed perpendicular distances from the circumcenter to the three sides (with the orientation convention that makes obtuse contributions negative) and prove that they sum to R + r, where r is the inradius.",
+    "text": "Place the circumcenter at the origin O = (0,0) and the vertices on the radius-R circle. The signed perpendicular distance from O to each side is exactly R cos of the opposite angle, and the three sum to R + r.",
+    "proofStrategy": "Place the circumcenter at O = (0,0) and the vertices Pa, Pb, Pc on the circle of radius R, at position angles chosen by the inscribed-angle convention (side BC subtends central angle 2A, etc.). For a chord, the foot of the perpendicular from the center is its midpoint, whose direction is the chord's midangle μ; the inward unit normal to that side is therefore −(cos μ, sin μ). Taking Mathlib's signedDist (= ⟪normalize v, q −ᵥ p⟫) from O along this normal, the normalize drops once the normal is shown to be a unit vector (sin² + cos² = 1), and the inner product collapses by cos(x − y) to exactly R cos of the opposite angle — negative precisely in the obtuse case, with no manual case split. Each normal is independently certified perpendicular to its side, and O is certified equidistant (= R) from the three vertices, so it genuinely is the circumcenter. Summing the three signed distances gives R(cos A + cos B + cos C), and the parent angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, turns this into R + r.",
+    "keyInsights": [
+      "**Center-to-chord = midpoint, so the inward unit normal is −(cos μ, sin μ)**: the perpendicular foot from the circumcenter to a chord is the chord's midpoint, whose direction is the chord's midangle μ; this makes every side normal an explicit unit vector and the signed distance a one-line inner product",
+      "**Mathlib's signedDist carries the obtuse sign for free**: writing the distance as ⟪normalize v, O −ᵥ p⟫ with v the inward normal yields exactly R cos of the opposite angle, whose sign already flips for obtuse triangles — the orientation bookkeeping that makes the metric form hard is handled by the cosine itself",
+      "**The metric statement is the angle statement scaled by R**: each signed distance is R cos(angle), so the whole theorem reduces to the parent identity multiplied by R — the geometric content is entirely in the dA_eq/dB_eq/dC_eq distance computations",
+      "**An explicit, certified circumcenter**: O = (0,0) is not assumed to be the circumcenter — it is proved equidistant from the three explicitly-placed vertices, anchoring the construction in genuine Euclidean geometry rather than a coordinate fiction"
+    ],
+    "prerequisites": [
+      "Euclidean plane EuclideanSpace ℝ (Fin 2): norms, inner products, and the !₂[·,·] coordinate notation",
+      "Mathlib's signedDist (trilinear signed distance) and normalize",
+      "Trigonometric identities cos(x ± y) and sin² + cos² = 1, plus the inscribed-angle convention relating central and inscribed angles",
+      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
+    ],
+    "openQuestions": [
+      "Can the construction be repackaged through Mathlib's Affine.Simplex.circumcenter / circumradius API so the circumcenter is derived from the triangle rather than placed by hand, recovering the same R + r identity?",
+      "Does the same explicit signed-distance technique extend to the excircles, giving the signed-distance forms d_a − d_b − d_c = R − r_A for the exradii?"
+    ]
+  },
+  "conclusion": {
+    "summary": "Carnot's theorem is formalized in genuinely metric form over EuclideanSpace ℝ (Fin 2): with the circumcenter placed at the explicit point O = (0,0) and the vertices on the radius-R circle (O certified equidistant from all three), each signed perpendicular distance from O to a side equals R cos of the opposite angle, and the three sum to R + r. The obtuse-case sign is carried automatically by Mathlib's signedDist. This answers the parent entry's open question. Axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry closes the gap between the parent's analytic angle identity and the classical metric statement of Carnot's theorem, showing that the much-feared orientation bookkeeping (a side's distance flipping sign at an obtuse angle) needs no case analysis once the signed distance is taken along the inward unit normal: the cosine supplies the sign. It anchors Carnot's theorem in Mathlib's signedDist / EuclideanSpace API, making it composable with other Euclidean-geometry formalizations.",
+    "openQuestions": [
+      "Repackage through Mathlib's Affine.Simplex.circumcenter API so the circumcenter is derived rather than placed by hand.",
+      "Extend the signed-distance technique to the excircles (exradius forms d_a − d_b − d_c = R − r_A)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "carnot-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Answers this parent's stated open question — whether the metric signed-distance form with an explicit circumcenter over EuclideanSpace ℝ (Fin 2) can be formalized. Reuses the parent's grandparent identity carnot_cos_sum (scaled by R) for the final sum."
+    },
+    {
+      "targetId": "carnot-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "The root Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, is what turns the sum of signed distances R(cos A + cos B + cos C) into R + r."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CarnotTheorem"
+    ],
+    "opens": [
+      "Real",
+      "NormedSpace",
+      "RealInnerProductSpace (scoped)"
+    ],
+    "namespace": "CarnotTheoremOQ01OQ01OQ01",
+    "lineCount": 221,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 7,
+    "sorries": 0,
+    "path": "Proofs/CarnotTheoremOQ01OQ01OQ01.lean"
+  }
+}

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "general-interval",
+    "startLine": 45,
+    "endLine": 74,
+    "type": "theorem",
+    "title": "General interval: (b^s − a^s)/s",
+    "body": "For 0 < a ≤ b and Re s > 0, mellin 𝟙_{(a,b]} s = (b^s − a^s)/s. Proof: 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} pointwise, then `hasMellin_sub` plus the parent's scaling law mellin 𝟙_{(0,a]} s = a^s/s. The first half of open question oq-01."
+  },
+  {
+    "id": "interval-length",
+    "startLine": 83,
+    "endLine": 86,
+    "type": "theorem",
+    "title": "At s=1: the interval length b − a",
+    "body": "Specializing the general-interval transform to s = 1 gives mellin 𝟙_{(a,b]} 1 = b − a — the Mellin transform recovers Lebesgue length, since the integrand becomes the plain indicator."
+  },
+  {
+    "id": "power-weighted-unit",
+    "startLine": 93,
+    "endLine": 97,
+    "type": "theorem",
+    "title": "Power weight: 1/(s+c), strip Re s > −c",
+    "body": "For real weight c and Re s > −c, mellin (t^c·𝟙_{(0,1]}) s = 1/(s+c). The weight t^c shifts the spectral variable s ↦ s+c, translating the base strip Re s > 0 to Re s > −c. Via Mathlib's hasMellin_cpow_Ioc. The second half of oq-01."
+  },
+  {
+    "id": "sharp-shifted-strip",
+    "startLine": 108,
+    "endLine": 118,
+    "type": "theorem",
+    "title": "The shifted strip is sharp",
+    "body": "MellinConvergent (t^c·𝟙_{(0,1]}) s ⇔ Re s > −c, both directions. Reduces to the parent's sharp strip via the convergence shift MellinConvergent.cpow_smul; the boundary Re s = −c is exactly where ∫₀¹ t^{s+c−1} dt diverges."
+  },
+  {
+    "id": "power-weighted-interval",
+    "startLine": 126,
+    "endLine": 142,
+    "type": "theorem",
+    "title": "Capstone: power-weighted general interval",
+    "body": "Combining both extensions: mellin (t^c·𝟙_{(a,b]}) s = (b^{s+c} − a^{s+c})/(s+c) for 0 < a ≤ b, Re s > −c. The shift s ↦ s+c (mellin_cpow_smul) applied to the general-interval law of Part 1."
+  }
+]

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
@@ -1,0 +1,83 @@
+{
+  "id": "mellin-power-convergence-oq-01-oq-01",
+  "title": "Mellin transform: general interval (b^s−a^s)/s and power-weighted strip Re s > −c",
+  "slug": "mellin-power-convergence-oq-01-oq-01",
+  "description": "Open question oq-01 of the Mellin-transform entry asks to extend the unit-indicator transform mellin 𝟙_{(0,1]} s = 1/s in two directions: (1) a general interval 𝟙_{(a,b]}, giving (b^s−a^s)/s, and (2) a power-weighted indicator t^c·𝟙_{(0,1]}, which shifts the convergence strip from Re s > 0 to Re s > −c and yields 1/(s+c). This formalization proves both, axiom-free: the general interval via the difference 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} (Mellin is linear), the power weight via Mathlib's hasMellin_cpow_Ioc and the shift mellin(t^c·f)(s) = mellin(f)(s+c). The shifted convergence strip is shown sharp (Re s > −c exactly), and a capstone combines both into mellin(t^c·𝟙_{(a,b]}) s = (b^{s+c}−a^{s+c})/(s+c).",
+  "meta": {
+    "author": "Hjalmar Mellin (c. 1900); Lean formalization original (researcher-10)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MellinPowerConvergenceOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "complex-analysis",
+      "mellin-transform",
+      "integral-transform",
+      "improper-integral",
+      "convergence",
+      "convergence-strip",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Every result is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). Builds on the parent entry's scaling law (hasMellin_indicator_Ioc) and Mathlib's Mellin API (hasMellin_sub, hasMellin_cpow_Ioc, mellin_cpow_smul, MellinConvergent.cpow_smul).",
+    "mathlib_version": "4.x",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasMellin_cpow_Ioc",
+        "description": "Mellin transform of a power restricted to (0,1]",
+        "module": "Mathlib.Analysis.MellinTransform"
+      },
+      {
+        "theorem": "hasMellin_sub",
+        "description": "Mellin transform is linear (difference)",
+        "module": "Mathlib.Analysis.MellinTransform"
+      },
+      {
+        "theorem": "mellin_cpow_smul",
+        "description": "Mellin shift: mellin(t^a·f)(s)=mellin(f)(s+a)",
+        "module": "Mathlib.Analysis.MellinTransform"
+      }
+    ],
+    "originalContributions": [
+      "hasMellin_indicator_interval: mellin 𝟙_{(a,b]} s = (b^s−a^s)/s for 0<a≤b, Re s>0 (general interval via 𝟙_{(a,b]}=𝟙_{(0,b]}−𝟙_{(0,a]} and hasMellin_sub)",
+      "mellin_indicator_interval_one: at s=1 the transform returns the interval length b−a",
+      "hasMellin_powerWeighted_unit: mellin (t^c·𝟙_{(0,1]}) s = 1/(s+c) on the shifted strip Re s>−c",
+      "mellinConvergent_powerWeighted_unit_iff: the shifted strip is SHARP — convergence ⇔ Re s>−c (both directions)",
+      "hasMellin_powerWeighted_interval: capstone — mellin (t^c·𝟙_{(a,b]}) s = (b^{s+c}−a^{s+c})/(s+c)"
+    ],
+    "lineCount": 144,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/MellinPowerConvergenceOQ01OQ01.lean",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7,
+    "additionalFiles": [
+      "Proofs/MellinPowerConvergenceOQ01.lean"
+    ]
+  },
+  "conclusion": {
+    "summary": "Both extensions requested by oq-01 are formalized. Linearity of the Mellin transform turns the general interval into a difference of scaling laws, giving (b^s−a^s)/s; at s=1 this is the interval length b−a. A power weight t^c shifts the spectral variable s↦s+c, so t^c·𝟙_{(0,1]} has transform 1/(s+c) on the strip Re s>−c, which is shown to be exactly the convergence region. The two combine into the power-weighted interval law (b^{s+c}−a^{s+c})/(s+c).",
+    "implications": [
+      "Confirms the Mellin transform's linearity and dilation/shift covariance suffice to compute a broad family of indicator transforms.",
+      "The convergence strip translates rigidly by the weight exponent, Re s > −c, with a sharp boundary."
+    ],
+    "openQuestions": [
+      "Formalize the meromorphic continuation of these transforms (1/s, 1/(s+c)) to the whole plane with their simple poles — parent oq-01 question (2).",
+      "Extend to complex weights c and to half-open/closed interval variants, and to finite sums of weighted indicators (step functions)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Answers the first open question (general interval + power weight) of the Mellin unit-indicator entry",
+      "targetId": "mellin-power-convergence-oq-01"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-01** of the Mellin unit-indicator entry (`mellin-power-convergence-oq-01`), which asks to extend `mellin 𝟙_{(0,1]} s = 1/s` in two directions: a general interval, and a power-weighted indicator that shifts the convergence strip.

### Results (verified, 0 axioms, 0 sorries)

**Part 1 — general interval.**
- `hasMellin_indicator_interval`: for `0 < a ≤ b`, `Re s > 0`, `mellin 𝟙_{(a,b]} s = (bˢ − aˢ)/s`. Proof writes `𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]}` pointwise and subtracts two instances of the parent's scaling law via `hasMellin_sub`.
- `mellin_indicator_interval_one`: at `s = 1` the transform returns the interval **length** `b − a`.

**Part 2 — power-weighted indicator (strip shift).**
- `hasMellin_powerWeighted_unit`: `mellin (tᶜ·𝟙_{(0,1]}) s = 1/(s+c)` on the shifted strip `Re s > −c` — the weight `tᶜ` shifts the spectral variable `s ↦ s+c`.
- `mellinConvergent_powerWeighted_unit_iff`: the shifted strip is **sharp** — convergence holds **iff** `Re s > −c` (both directions), with the boundary `Re s = −c` exactly where `∫₀¹ t^{s+c−1} dt` diverges.

**Part 3 — capstone.**
- `hasMellin_powerWeighted_interval`: combining both, `mellin (tᶜ·𝟙_{(a,b]}) s = (b^{s+c} − a^{s+c})/(s+c)`.

### Approach

Imports the parent entry (reusing its scaling law `hasMellin_indicator_Ioc` and sharp strip `mellinConvergent_unitIndicator_iff`) and Mathlib's Mellin API (`hasMellin_sub`, `hasMellin_cpow_Ioc`, `mellin_cpow_smul`, `MellinConvergent.cpow_smul`). `#print axioms` returns only `[propext, Classical.choice, Quot.sound]`.

New gallery entry `src/data/proofs/mellin-power-convergence-oq-01-oq-01/` (`status: verified`, `badge: original`). The remaining parent open question — meromorphic continuation of `1/s`, `1/(s+c)` to the whole plane — is recorded in the entry's `openQuestions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
