### PR TITLE
research(banach-steinhaus-resonance-comeagre-oq-01-oq-02): resonance set is comeagre [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BanachSteinhausTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/BanachSteinhausTheoremOQ01OQ02.lean
@@ -1,0 +1,163 @@
+/-
+# Banach–Steinhaus: the resonance set is comeagre (condensation of singularities)
+
+The gallery entry `banach-steinhaus-theorem-oq-01` packages Mathlib's uniform
+boundedness principle together with its *condensation of singularities*
+contrapositive (`resonance`): if a family `g : ι → E →SL[σ₁₂] F` of continuous
+linear maps out of a Banach space has unbounded operator norms, then there is a
+*single* resonance point `x` at which the values `‖g i x‖` are unbounded.
+
+That contrapositive only asserts the resonance set is *nonempty*. Its open
+question asks for the **quantitative Baire-category strengthening**: the
+resonance set
+
+  `R = { x : E | ∀ C, ∃ i, C < ‖g i x‖ }`   (equivalently `⨆ i, ‖g i x‖ = ∞`)
+
+is not merely nonempty but **comeagre** — it is a residual set, hence (since a
+Banach space is a Baire space) *dense*. The set of points where the family
+condenses its singularities is topologically generic.
+
+This file proves that strengthening from scratch:
+
+* `resonanceSet` — the set of resonance points;
+* `sublevel_isClosed` — the sublevel sets `{x | ∀ i, ‖g i x‖ ≤ n}` are closed;
+* `sublevel_interior_eq_empty` — under unbounded operator norms each sublevel
+  set has empty interior (the only place Banach–Steinhaus itself is used: a
+  sublevel set with nonempty interior would force pointwise — hence uniform —
+  boundedness);
+* `resonanceSet_comeagre` — **the main result**: `R` is residual (comeagre);
+* `resonanceSet_compl_isMeagre` — equivalently, its complement is meagre;
+* `resonanceSet_dense` — `R` is dense in a Banach space;
+* `resonance_of_comeagre` — the comeagre statement recovers the parent's single
+  resonance point, so this genuinely strengthens `resonance`.
+
+All results are verified with no axioms and no `sorry`.
+-/
+import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+import Mathlib.Tactic
+
+open Filter Topology Set Metric
+
+namespace BanachSteinhausResonance
+
+variable {𝕜 𝕜₂ : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [RingHomIsometric σ₁₂]
+  {E : Type*} [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜₂ F]
+  {ι : Type*}
+
+/-- The **resonance set** of an operator family `g`: the points `x` at which the
+values `‖g i x‖` are unbounded over `i` (equivalently `⨆ i, ‖g i x‖ = ∞`). -/
+def resonanceSet (g : ι → E →SL[σ₁₂] F) : Set E :=
+  {x | ∀ C : ℝ, ∃ i, C < ‖g i x‖}
+
+set_option linter.unusedSectionVars false in
+/-- The sublevel set `{x | ∀ i, ‖g i x‖ ≤ n}` is closed: it is an intersection of
+the closed sets `{x | ‖g i x‖ ≤ n}`, each a sublevel set of the continuous map
+`x ↦ ‖g i x‖`. -/
+theorem sublevel_isClosed (g : ι → E →SL[σ₁₂] F) (n : ℝ) :
+    IsClosed {x : E | ∀ i, ‖g i x‖ ≤ n} := by
+  rw [setOf_forall]
+  exact isClosed_iInter fun i =>
+    isClosed_le (continuous_norm.comp (g i).continuous) continuous_const
+
+/-- Under **unbounded operator norms**, every sublevel set `{x | ∀ i, ‖g i x‖ ≤ n}`
+has empty interior. This is the heart of the Baire-category argument and the only
+step that invokes Banach–Steinhaus: a sublevel set with nonempty interior would
+contain a ball, and rescaling translates of that ball through the (semi)linear
+maps would bound the values `‖g i x‖` at *every* point — pointwise boundedness,
+which `banach_steinhaus` upgrades to a uniform bound, contradicting the
+hypothesis. -/
+theorem sublevel_interior_eq_empty [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) (n : ℝ) :
+    interior {x : E | ∀ i, ‖g i x‖ ≤ n} = ∅ := by
+  by_contra hne
+  -- A nonempty interior contains a ball `ball x₀ r ⊆ {x | ∀ i, ‖g i x‖ ≤ n}`.
+  obtain ⟨x₀, hx₀⟩ := Set.nonempty_iff_ne_empty.mpr hne
+  obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp isOpen_interior x₀ hx₀
+  have hballV : ball x₀ r ⊆ {x : E | ∀ i, ‖g i x‖ ≤ n} := hball.trans interior_subset
+  have hx0V : ∀ i, ‖g i x₀‖ ≤ n := interior_subset hx₀
+  -- The family is pointwise bounded everywhere.
+  have hpb : ∀ x : E, ∃ C, ∀ i, ‖g i x‖ ≤ C := by
+    intro x
+    -- Pick a small nonzero scalar `c` with `‖c‖ * (‖x‖ + 1) < r`.
+    obtain ⟨c, hc_pos, hc_lt⟩ :=
+      NormedField.exists_norm_lt 𝕜 (show (0:ℝ) < r / (‖x‖ + 1) by positivity)
+    have hcx : ‖c‖ * (‖x‖ + 1) < r := (lt_div_iff₀ (by positivity)).mp hc_lt
+    refine ⟨2 * n / ‖c‖, fun i => ?_⟩
+    -- `x₀ + c • x` lies in the ball, hence in the sublevel set.
+    have hnorm_cx : ‖c • x‖ < r := by
+      rw [norm_smul]
+      calc ‖c‖ * ‖x‖ ≤ ‖c‖ * (‖x‖ + 1) := by gcongr; linarith [norm_nonneg x]
+        _ < r := hcx
+    have hmem : ∀ j, ‖g j (x₀ + c • x)‖ ≤ n :=
+      hballV (by rw [mem_ball, dist_eq_norm, add_sub_cancel_left]; exact hnorm_cx)
+    -- `g i (c • x) = g i (x₀ + c • x) - g i x₀`, so its norm is `≤ 2 * n`.
+    have hsplit : σ₁₂ c • g i x = g i (x₀ + c • x) - g i x₀ := by
+      rw [map_add, map_smulₛₗ]; abel
+    have hbound : ‖c‖ * ‖g i x‖ ≤ 2 * n := by
+      have hle : ‖σ₁₂ c • g i x‖ ≤ 2 * n := by
+        rw [hsplit]
+        calc ‖g i (x₀ + c • x) - g i x₀‖
+            ≤ ‖g i (x₀ + c • x)‖ + ‖g i x₀‖ := norm_sub_le _ _
+          _ ≤ n + n := add_le_add (hmem i) (hx0V i)
+          _ = 2 * n := by ring
+      rwa [norm_smul, RingHomIsometric.norm_map] at hle
+    -- Divide by `‖c‖ > 0`.
+    rw [le_div_iff₀ hc_pos, mul_comm]
+    exact hbound
+  -- Pointwise bounded ⇒ uniformly bounded, contradicting unbounded norms.
+  obtain ⟨C', hC'⟩ := banach_steinhaus hpb
+  obtain ⟨i, hi⟩ := h C'
+  exact absurd (hC' i) (not_le.mpr hi)
+
+/-- **The resonance set is comeagre.** If the operator norms of a family of
+continuous linear maps out of a Banach space are unbounded, then the set of
+resonance points (where the values `‖g i x‖` are unbounded) is residual.
+
+This is the Baire-category strengthening of the condensation-of-singularities
+contrapositive: failure of uniform boundedness is witnessed not just at one
+point, but on a topologically generic (comeagre) set. -/
+theorem resonanceSet_comeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : resonanceSet g ∈ residual E := by
+  -- It suffices to show the complement is meagre.
+  suffices hmeagre : IsMeagre (resonanceSet g)ᶜ by
+    rwa [IsMeagre, compl_compl] at hmeagre
+  -- The complement is contained in a countable union of sublevel sets.
+  have hsub : (resonanceSet g)ᶜ ⊆ ⋃ n : ℕ, {x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)} := by
+    intro x hx
+    simp only [resonanceSet, mem_compl_iff, mem_setOf_eq, not_forall, not_exists,
+      not_lt] at hx
+    obtain ⟨C, hC⟩ := hx
+    obtain ⟨n, hn⟩ := exists_nat_ge C
+    exact mem_iUnion.mpr ⟨n, fun i => (hC i).trans hn⟩
+  refine IsMeagre.mono hsub (isMeagre_iUnion fun n => ?_)
+  -- Each sublevel set is closed with empty interior, hence nowhere dense, hence meagre.
+  have hnwd : IsNowhereDense {x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)} :=
+    (sublevel_isClosed g _).isNowhereDense_iff.mpr (sublevel_interior_eq_empty h _)
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  exact ⟨{{x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)}}, by simpa using hnwd, countable_singleton _,
+    by simp⟩
+
+/-- Equivalent phrasing of `resonanceSet_comeagre`: the complement of the
+resonance set — the points where the family is pointwise bounded — is meagre. -/
+theorem resonanceSet_compl_isMeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : IsMeagre (resonanceSet g)ᶜ := by
+  rw [IsMeagre, compl_compl]; exact resonanceSet_comeagre h
+
+/-- **The resonance set is dense.** Since a Banach space is a Baire space, the
+comeagre resonance set is dense: resonance points are not just generic, they are
+arbitrarily close to every point of the space. -/
+theorem resonanceSet_dense [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : Dense (resonanceSet g) :=
+  dense_of_mem_residual (resonanceSet_comeagre h)
+
+/-- The comeagre strengthening recovers the parent gallery entry's `resonance`
+statement: a comeagre (in particular nonempty) resonance set yields a single
+point at which the values `‖g i x‖` are unbounded. This shows the present result
+genuinely strengthens the condensation-of-singularities contrapositive. -/
+theorem resonance_of_comeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : ∃ x : E, ∀ C : ℝ, ∃ i, C < ‖g i x‖ :=
+  (resonanceSet_dense h).nonempty
+
+end BanachSteinhausResonance

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "From One Resonance Point to a Comeagre Set",
+    "content": "The parent entry's `resonance` (condensation of singularities) only asserts the resonance set is nonempty: a single point where a family of operators with unbounded norms blows up. The Baire-category proof actually gives more — the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is comeagre (residual), hence dense. Resonance points are topologically generic. This entry answers the open question posed by the parent entry.",
+    "mathContext": "If $\\sup_i\\|g_i\\| = \\infty$ for continuous linear maps out of a Banach space, then $R = \\{x : \\sup_i\\|g_i x\\| = \\infty\\}$ is comeagre.",
+    "significance": "context",
+    "relatedConcepts": ["condensation of singularities", "comeagre set", "residual set", "Baire category theorem", "Banach–Steinhaus theorem"],
+    "prerequisites": ["Banach spaces", "continuous linear maps", "meagre and residual sets"]
+  },
+  {
+    "id": "ann-resonance-set",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 52 },
+    "type": "definition",
+    "title": "The Resonance Set",
+    "content": "`resonanceSet g` is the set of points x at which the values ‖gᵢx‖ are unbounded over i: ∀ C, ∃ i, C < ‖gᵢx‖. Equivalently ⨆ᵢ ‖gᵢx‖ = ∞. The goal is to show this set is comeagre whenever the operator norms are unbounded.",
+    "mathContext": "$R = \\{x : \\forall C,\\ \\exists i,\\ C < \\|g_i x\\|\\} = \\{x : \\sup_i \\|g_i x\\| = \\infty\\}.$",
+    "significance": "key",
+    "relatedConcepts": ["resonance set", "unbounded family", "supremum of norms"],
+    "prerequisites": ["operator norm", "supremum"]
+  },
+  {
+    "id": "ann-sublevel-closed",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 58, "endLine": 62 },
+    "type": "theorem",
+    "title": "Sublevel Sets Are Closed",
+    "content": "The sublevel set {x | ∀i ‖gᵢx‖ ≤ n} is an intersection ⋂ᵢ {x | ‖gᵢx‖ ≤ n} of closed sets, each a sublevel set of the continuous map x ↦ ‖gᵢx‖. Closedness is what lets us identify these sets as nowhere dense (closed + empty interior) later.",
+    "mathContext": "$\\{x : \\forall i,\\ \\|g_i x\\| \\le n\\} = \\bigcap_i \\{x : \\|g_i x\\| \\le n\\}$ is closed.",
+    "significance": "standard",
+    "relatedConcepts": ["closed set", "sublevel set", "continuity of operator evaluation"],
+    "prerequisites": ["continuous functions", "intersections of closed sets"]
+  },
+  {
+    "id": "ann-empty-interior",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 64, "endLine": 112 },
+    "type": "theorem",
+    "title": "Sublevel Sets Have Empty Interior (the Crux)",
+    "content": "Under unbounded operator norms, each sublevel set has empty interior. Suppose not: the interior contains a ball ball x₀ r. For any x, choose a small nonzero scalar c with ‖c‖(‖x‖+1) < r so that x₀ + c•x stays in the ball; then ‖gᵢ(c•x)‖ ≤ ‖gᵢ(x₀+c•x)‖ + ‖gᵢx₀‖ ≤ 2n, and by isometric semilinearity ‖c‖·‖gᵢx‖ ≤ 2n, i.e. ‖gᵢx‖ ≤ 2n/‖c‖ for every i. That is pointwise boundedness; `banach_steinhaus` upgrades it to a uniform norm bound, contradicting the unboundedness hypothesis. This is the only place the Banach–Steinhaus theorem is used.",
+    "mathContext": "A ball $B(x_0,r)$ inside a sublevel set forces $\\|g_i x\\| \\le 2n/\\|c\\|$ for all $i$ at every $x$, hence uniform boundedness — a contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["empty interior", "rescaling argument", "pointwise boundedness", "uniform boundedness principle"],
+    "prerequisites": ["interior and balls", "operator norm scaling", "Banach–Steinhaus theorem"]
+  },
+  {
+    "id": "ann-comeagre",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 114, "endLine": 140 },
+    "type": "theorem",
+    "title": "The Resonance Set Is Comeagre",
+    "content": "The complement of R is contained in the countable union ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}. Each sublevel set is closed with empty interior, hence nowhere dense, hence meagre; a countable union of meagre sets is meagre, so Rᶜ is meagre and R is residual (comeagre). This is the main result.",
+    "mathContext": "$R^c \\subseteq \\bigcup_{n} \\{x : \\forall i,\\ \\|g_i x\\| \\le n\\}$, a countable union of nowhere-dense sets, so $R^c$ is meagre and $R$ is comeagre.",
+    "significance": "key",
+    "relatedConcepts": ["comeagre set", "residual filter", "meagre set", "nowhere dense set", "countable union"],
+    "prerequisites": ["meagre and residual sets", "Baire category"]
+  },
+  {
+    "id": "ann-dense-recover",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 162 },
+    "type": "theorem",
+    "title": "Dense, and Recovering the Single Resonance Point",
+    "content": "resonanceSet_compl_isMeagre restates the result as 'the pointwise-bounded set is meagre'. resonanceSet_dense upgrades comeagre to dense: a Banach space is a Baire space, where residual sets are dense. resonance_of_comeagre recovers the parent entry's `resonance` — a dense set is nonempty, so there is a single resonance point — confirming this is a genuine strengthening.",
+    "mathContext": "In a Baire space a residual set is dense, hence nonempty; this recovers the parent's existence of a resonance point.",
+    "significance": "supporting",
+    "relatedConcepts": ["dense set", "Baire space", "density of residual sets", "strengthening"],
+    "prerequisites": ["Baire spaces", "density"]
+  }
+]

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "banach-steinhaus-theorem-oq-01-oq-02",
+  "title": "The resonance set of an unbounded operator family is comeagre",
+  "slug": "banach-steinhaus-theorem-oq-01-oq-02",
+  "description": "The Banach–Steinhaus entry's condensation-of-singularities contrapositive (`resonance`) only asserts the resonance set is nonempty: a single point where a family of operators with unbounded norms blows up. This entry proves the Baire-category strengthening asked for in that entry's open questions — the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is not merely nonempty but comeagre (residual), hence dense in a Banach space. The set of resonance points is topologically generic. The argument is built from scratch: the sublevel sets {x | ∀i ‖gᵢx‖ ≤ n} are closed, and have empty interior (a sublevel set with interior would force pointwise — hence, by Banach–Steinhaus, uniform — boundedness), so the complement of R is a countable union of nowhere-dense sets.",
+  "meta": {
+    "author": "Stefan Banach / Hugo Steinhaus (condensation of singularities, 1927); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachSteinhausTheoremOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "functional-analysis",
+      "banach-space",
+      "operator-theory",
+      "uniform-boundedness",
+      "baire-category",
+      "comeagre",
+      "condensation-of-singularities"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "banach_steinhaus",
+        "description": "The Banach–Steinhaus theorem: a pointwise-bounded family of continuous linear maps out of a complete space is uniformly bounded in operator norm. Used only inside the empty-interior lemma to derive a contradiction.",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      },
+      {
+        "theorem": "isMeagre_iUnion",
+        "description": "A countable union of meagre sets is meagre — assembles meagreness of the complement of the resonance set from the sublevel sets",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "IsClosed.isNowhereDense_iff",
+        "description": "A closed set is nowhere dense iff its interior is empty — converts the empty-interior sublevel sets into nowhere-dense sets",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "dense_of_mem_residual",
+        "description": "In a Baire space, a residual (comeagre) set is dense — upgrades comeagre to dense for the Banach space",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "resonanceSet: definition of the resonance set R = {x | ∀ C, ∃ i, C < ‖gᵢx‖} (equivalently ⨆ᵢ ‖gᵢx‖ = ∞)",
+      "sublevel_isClosed: the sublevel sets {x | ∀i ‖gᵢx‖ ≤ n} are closed, as intersections of sublevel sets of the continuous maps x ↦ ‖gᵢx‖",
+      "sublevel_interior_eq_empty: the heart of the argument — under unbounded operator norms every sublevel set has empty interior, because a sublevel set containing a ball would, by rescaling translates of that ball through the (semi)linear maps, bound ‖gᵢx‖ at every point, giving pointwise boundedness that banach_steinhaus upgrades to a uniform bound, contradicting unboundedness",
+      "resonanceSet_comeagre: the main result — the resonance set is residual (comeagre): its complement is contained in the countable union ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n} of closed nowhere-dense sets, hence meagre",
+      "resonanceSet_compl_isMeagre: equivalent phrasing — the pointwise-bounded set (complement of the resonance set) is meagre",
+      "resonanceSet_dense: in a Banach (Baire) space the comeagre resonance set is dense",
+      "resonance_of_comeagre: the comeagre statement recovers the parent entry's single resonance point (nonemptiness), confirming this is a genuine strengthening of the condensation-of-singularities contrapositive"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 163,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The principle of condensation of singularities — the contrapositive of the Banach–Steinhaus theorem — produces a point at which a family of operators with unbounded norms resonates (its values blow up). Banach and Steinhaus's 1927 paper is titled precisely 'Sur le principe de la condensation de singularités'. The Baire-category proof gives more than one resonance point: the set of resonance points is residual (comeagre), so 'most' points (in the topological sense of category) are resonance points. This generic-singularity phenomenon is the standard route to existence results such as a continuous periodic function whose Fourier series diverges on a comeagre set of points.",
+    "problemStatement": "The gallery entry `banach-steinhaus-theorem-oq-01` states `resonance`: if the operator norms ‖gᵢ‖ are unbounded then there is a single point x where the values ‖gᵢx‖ are unbounded. Its open questions ask whether the quantitative refinement holds — that the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is comeagre, not merely nonempty.\n\n**Answer:** Yes. The complement of R is the union over n of the closed sublevel sets {x | ∀i ‖gᵢx‖ ≤ n}; each has empty interior (else Banach–Steinhaus would force the norms to be bounded), so each is nowhere dense and the complement is meagre. Hence R is comeagre, and dense in the Banach space.",
+    "text": "If a family of continuous linear maps out of a Banach space has unbounded operator norms, the set of points at which the values ‖gᵢx‖ are unbounded is comeagre (residual) — hence dense. The Baire-category strengthening of the condensation-of-singularities contrapositive, verified in Lean with no axioms.",
+    "proofStrategy": "1. resonanceSet: define R = {x | ∀ C, ∃ i, C < ‖gᵢx‖}.\n2. sublevel_isClosed: {x | ∀i ‖gᵢx‖ ≤ n} = ⋂ᵢ {x | ‖gᵢx‖ ≤ n} is closed, each factor being a sublevel set of the continuous map x ↦ ‖gᵢx‖.\n3. sublevel_interior_eq_empty (the crux): suppose some sublevel set has nonempty interior; it then contains a ball ball x₀ r. For any x, pick a small nonzero scalar c with ‖c‖(‖x‖+1) < r so that x₀ + c•x stays in the ball; then ‖gᵢ(c•x)‖ ≤ ‖gᵢ(x₀+c•x)‖ + ‖gᵢx₀‖ ≤ 2n, and since the maps are isometric-semilinear, ‖c‖·‖gᵢx‖ ≤ 2n, i.e. ‖gᵢx‖ ≤ 2n/‖c‖ uniformly in i. That is pointwise boundedness; banach_steinhaus upgrades it to a uniform norm bound, contradicting the unboundedness hypothesis. So the interior is empty.\n4. resonanceSet_comeagre: Rᶜ ⊆ ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}; each sublevel set is closed with empty interior, hence nowhere dense, hence meagre, and a countable union of meagre sets is meagre, so Rᶜ is meagre — i.e. R is residual.\n5. resonanceSet_dense: a Banach space is a Baire space, so the residual set R is dense.\n6. resonance_of_comeagre: R is dense, hence nonempty, recovering the parent's single resonance point.",
+    "keyInsights": [
+      "**Category, not just nonemptiness**: the Baire argument that proves Banach–Steinhaus actually shows the complement of the resonance set is a *countable union of nowhere-dense sets*. Reading that off gives a comeagre — generic — set of resonance points, strictly more than the one point the bare contrapositive provides.",
+      "**Banach–Steinhaus is reused, not reproved**: the only analytic input is the empty-interior lemma, and there the contradiction is obtained by invoking `banach_steinhaus` itself. A sublevel set with interior gives a ball; rescaling translates of the ball through the linear maps converts 'bounded on a ball' into 'pointwise bounded everywhere', which the theorem turns into a uniform bound — the contradiction.",
+      "**Rescaling needs only a small scalar**: nontriviality of the scalar field supplies arbitrarily small nonzero scalars c, and isometric semilinearity (‖σ₁₂ c‖ = ‖c‖) makes ‖gᵢ(c•x)‖ = ‖c‖·‖gᵢx‖, so a uniform value bound on a neighbourhood of x₀ transfers to a pointwise bound at every x.",
+      "**Comeagre ⟹ dense for free**: completeness makes the space Baire, and in a Baire space residual sets are dense, so the topological-genericity statement immediately yields the stronger-sounding 'resonance points are dense'."
+    ],
+    "prerequisites": [
+      "Normed and Banach spaces; continuous (semi)linear maps and the operator norm",
+      "The Baire category theorem; meagre, nowhere-dense, and residual (comeagre) sets",
+      "The Banach–Steinhaus / uniform boundedness principle",
+      "Interiors, closures, and density in metric spaces"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "File-level docstring framing the strengthening: the parent entry's `resonance` only gives a single resonance point; here the resonance set is shown comeagre and dense. Imports `Analysis.Normed.Operator.BanachSteinhaus` (which transitively supplies the meagre/residual machinery) and sets up the Banach-space variable context.",
+      "mathContext": "The resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} for a family of continuous linear maps out of a Banach space."
+    },
+    {
+      "id": "resonance-set",
+      "title": "The Resonance Set and Closed Sublevel Sets",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "resonanceSet defines R = {x | ∀ C, ∃ i, C < ‖gᵢx‖}. sublevel_isClosed shows each sublevel set {x | ∀i ‖gᵢx‖ ≤ n} is closed, as an intersection over i of the closed sublevel sets of the continuous maps x ↦ ‖gᵢx‖.",
+      "mathContext": "R is the complement of ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}; each sublevel set is closed."
+    },
+    {
+      "id": "empty-interior",
+      "title": "Sublevel Sets Have Empty Interior",
+      "startLine": 64,
+      "endLine": 112,
+      "summary": "sublevel_interior_eq_empty: under unbounded operator norms each sublevel set has empty interior. A sublevel set with nonempty interior contains a ball; rescaling translates of that ball through the maps bounds ‖gᵢx‖ at every point (pointwise boundedness), which banach_steinhaus turns into a uniform bound, contradicting the hypothesis. This is the only step that invokes the Banach–Steinhaus theorem.",
+      "mathContext": "Nonempty interior of a sublevel set would force pointwise — hence uniform — boundedness."
+    },
+    {
+      "id": "comeagre",
+      "title": "The Resonance Set Is Comeagre and Dense",
+      "startLine": 114,
+      "endLine": 163,
+      "summary": "resonanceSet_comeagre: Rᶜ ⊆ ⋃ₙ (closed, empty-interior, hence nowhere-dense) sublevel sets, so Rᶜ is meagre and R is residual. resonanceSet_compl_isMeagre is the equivalent meagre phrasing. resonanceSet_dense upgrades comeagre to dense via the Baire property. resonance_of_comeagre recovers the parent's single resonance point.",
+      "mathContext": "Residual = comeagre; in a Baire space residual sets are dense."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Banach, Stefan; Steinhaus, Hugo",
+      "title": "Sur le principe de la condensation de singularités",
+      "year": "1927",
+      "note": "Fundamenta Mathematicae 9, 50–61 — the original uniform boundedness principle and condensation of singularities"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Functional Analysis",
+      "year": "1991",
+      "note": "Theorem 2.5 (Banach–Steinhaus) and Theorem 2.7 (condensation of singularities), where the resonance set is shown comeagre"
+    },
+    {
+      "authors": "Brezis, Haïm",
+      "title": "Functional Analysis, Sobolev Spaces and Partial Differential Equations",
+      "year": "2011",
+      "note": "Theorem 2.2 (uniform boundedness) and the Baire-category proof underlying the condensation of singularities"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "banach-steinhaus-theorem-oq-01",
+      "relation": "Parent entry: states the uniform boundedness principle and the `resonance` contrapositive whose open question (comeagre resonance set) this entry answers."
+    }
+  ],
+  "conclusion": {
+    "summary": "The resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} of a family of continuous linear maps out of a Banach space with unbounded operator norms is comeagre (residual): its complement is a countable union of the closed, empty-interior sublevel sets {x | ∀i ‖gᵢx‖ ≤ n}, hence meagre. Consequently R is dense, and in particular nonempty — recovering the parent entry's `resonance`. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Strengthens the condensation-of-singularities contrapositive from 'there exists a resonance point' to 'the resonance points form a topologically generic (comeagre, hence dense) set', the form used in existence proofs such as Fourier series diverging on a comeagre set of points.",
+    "openQuestions": [
+      "Can the comeagre resonance statement be specialized to the partial-sum operators of Fourier series to produce a continuous 2π-periodic function whose Fourier series diverges on a comeagre set of points?",
+      "Does the analogous comeagre strengthening hold for barrelled (locally convex) spaces, matching Mathlib's general `WithSeminorms.banach_steinhaus`?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Normed.Operator.BanachSteinhaus",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Set",
+      "Metric"
+    ],
+    "namespace": "BanachSteinhausResonance",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BanachSteinhausTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by the gallery entry **banach-steinhaus-theorem-oq-01** (`conclusion.openQuestions[1]`):

> *Does the quantitative refinement hold, that the resonance set (points where the values are unbounded) is comeagre, not merely nonempty, packaging the Baire-category strengthening of the contrapositive?*

The parent's `resonance` only asserts the resonance set is **nonempty** — a single point where a family of operators with unbounded norms blows up. This entry proves the **Baire-category strengthening**: the resonance set

```
R = { x : E | ∀ C, ∃ i, C < ‖gᵢ x‖ }   (i.e. ⨆ᵢ ‖gᵢ x‖ = ∞)
```

is **comeagre (residual)**, hence **dense** in a Banach space. Resonance points are topologically generic.

## Proof structure (`Proofs/BanachSteinhausTheoremOQ01OQ02.lean`)

Built from scratch; `banach_steinhaus` is reused only for the crux lemma.

- `resonanceSet` — definition of `R`.
- `sublevel_isClosed` — `{x | ∀i ‖gᵢx‖ ≤ n} = ⋂ᵢ {x | ‖gᵢx‖ ≤ n}` is closed.
- `sublevel_interior_eq_empty` (**crux**) — under unbounded operator norms each sublevel set has empty interior: a sublevel set containing a ball, rescaled through the isometric-semilinear maps (`‖σ₁₂ c‖ = ‖c‖`), yields a pointwise bound `‖gᵢx‖ ≤ 2n/‖c‖` at every `x`; `banach_steinhaus` upgrades this to a uniform norm bound, contradicting the hypothesis.
- `resonanceSet_comeagre` (**main**) — `Rᶜ ⊆ ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}`, a countable union of closed nowhere-dense sets, so `Rᶜ` is meagre and `R` is residual.
- `resonanceSet_compl_isMeagre` — equivalent meagre phrasing.
- `resonanceSet_dense` — comeagre ⇒ dense (Banach ⇒ Baire).
- `resonance_of_comeagre` — recovers the parent's single resonance point, confirming a genuine strengthening.

## Verification

- **6 theorems + 1 definition, 163 lines.**
- `#print axioms` on the main results lists only `propext`, `Classical.choice`, `Quot.sound` — the standard foundational axioms.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- Type-checks against pinned Mathlib v4.26.0 (`lake env lean`).
- `pnpm annotations:build` clean for this entry.

Status: **verified**, badge **original**, axiomCount **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)