### PR TITLE
research(catalan-oq-01-02-01-01): Catalan p-divisibility as a Kummer carry criterion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,171 @@
+import Proofs.CatalanNumbersOQ01OQ02OQ01
+
+/-!
+# Catalan OQ-01-OQ-02-OQ-01-OQ-01: Catalan `p`-Divisibility as a Kummer Carry Criterion
+
+The parent entry `catalan-numbers-oq-01-oq-02-oq-01` proved a division-free
+identity for the `p`-adic valuation of the Catalan numbers at an arbitrary prime,
+culminating in the criterion
+
+* `not_dvd_catalan_iff` : `p ∤ Cₙ ⟺ (p − 1)·v_p(n+1) + s_p(2n) = 2·s_p(n)`,
+
+where `s_p` is the base-`p` digit sum.  The right-hand side mixes digit sums in a
+way that hides its combinatorial meaning.  **Kummer's theorem** says the quantity
+`(2·s_p(n) − s_p(2n)) / (p − 1)` is literally the number of *carries* when one
+adds `n` to itself in base `p`, and that this carry count equals the `p`-adic
+valuation of the central binomial coefficient `C(2n,n)`.  We therefore define
+
+* `carries p n := v_p(C(2n,n))`  (the Kummer carry count of `n + n` in base `p`),
+
+and reformulate the parent's results in their natural combinatorial shape:
+
+* `sub_one_mul_carries` : `(p − 1)·carries p n + s_p(2n) = 2·s_p(n)`
+  (so `(p − 1)·carries p n = 2·s_p(n) − s_p(2n)` is the digit-sum carry formula);
+* `not_dvd_catalan_iff_carries` : **`p ∤ Cₙ ⟺ carries p n = v_p(n+1)`**
+  (the carry form of the criterion: `p` divides `Cₙ` unless the carries in `n + n`
+  are exactly used up by the trailing-zero count `v_p(n+1)` of `n + 1`);
+* `padicValNat_catalan_add_succ_eq_carries` :
+  **`v_p(Cₙ) + v_p(n+1) = carries p n`**, hence `v_p(n+1) ≤ carries p n` and the
+  clean valuation formula `v_p(Cₙ) = carries p n − v_p(n+1)` — the arithmetic
+  analogue of `Cₙ = C(2n,n) / (n+1)`.
+
+For the first interesting odd prime `p = 3` we record the specialisation
+`not_dvd_catalan_three_iff_carries` and exhibit, with fully checked witnesses, the
+first *gap* in the non-divisible index set: `3 ∤ Cₙ` for `n ∈ {0,1,2,3,4}` and
+`n ∈ {8,…,13}`, while `3 ∣ Cₙ` for the bridging block `n ∈ {5,6,7}`.  Computing
+`Cₙ mod 3` over `n ≤ 30` gives the non-divisible set
+`{0,1,2,3,4, 8,9,10,11,12,13, 26,27,28,29,30}`, whose base-`3` block structure
+(`[0,4], [8,13], [26,30]`) is the carry criterion at work.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+The hard analytic content (Legendre's formula + digit sums) lives entirely in the
+parent; this entry is the combinatorial repackaging plus one application of
+multiplicativity of `padicValNat`.
+-/
+
+open Nat
+
+namespace CatalanKummer
+
+open CatalanPAdic
+
+variable {p : ℕ}
+
+/-- **Kummer carry count.**  The number of carries when adding `n + n` in base `p`,
+realised as the `p`-adic valuation of the central binomial coefficient `C(2n,n)`
+(Kummer's theorem identifies these two quantities). -/
+def carries (p n : ℕ) : ℕ := padicValNat p (Nat.centralBinom n)
+
+/-- **Digit-sum carry formula.**  `(p − 1)·carries p n + s_p(2n) = 2·s_p(n)`,
+equivalently `(p − 1)·carries p n = 2·s_p(n) − s_p(2n)`.  This is the parent's
+central-binomial valuation identity, restated for the carry count. -/
+theorem sub_one_mul_carries [Fact p.Prime] (n : ℕ) :
+    (p - 1) * carries p n + (Nat.digits p (2 * n)).sum = 2 * (Nat.digits p n).sum :=
+  sub_one_mul_padicValNat_centralBinom n
+
+/-- **Valuation splitting of the carry count.**
+`v_p(Cₙ) + v_p(n+1) = carries p n`.
+
+Immediate from `(n+1)·Cₙ = C(2n,n)` and additivity of `padicValNat` on the nonzero
+factors `n + 1` and `Cₙ`.  This is the arithmetic form of `Cₙ = C(2n,n)/(n+1)`. -/
+theorem padicValNat_catalan_add_succ_eq_carries [Fact p.Prime] (n : ℕ) :
+    padicValNat p (catalan n) + padicValNat p (n + 1) = carries p n := by
+  have h : carries p n = padicValNat p (n + 1) + padicValNat p (catalan n) := by
+    unfold carries
+    rw [← succ_mul_catalan_eq_centralBinom n,
+      padicValNat.mul (by omega) (catalan_ne_zero n)]
+  omega
+
+/-- **Carry lower bound.**  `v_p(n+1) ≤ carries p n`: the trailing-zero count of
+`n + 1` never exceeds the carry count of `n + n`.  (Equivalently `(n+1) ∣ C(2n,n)`
+at the level of `p`-adic valuations.) -/
+theorem padicValNat_succ_le_carries [Fact p.Prime] (n : ℕ) :
+    padicValNat p (n + 1) ≤ carries p n := by
+  have := padicValNat_catalan_add_succ_eq_carries (p := p) n
+  omega
+
+/-- **Valuation difference formula.**
+`v_p(Cₙ) = carries p n − v_p(n+1)` (genuine ℕ-subtraction, valid because of
+`padicValNat_succ_le_carries`).  The Catalan number loses exactly `v_p(n+1)`
+factors of `p` relative to the central binomial coefficient. -/
+theorem padicValNat_catalan_eq [Fact p.Prime] (n : ℕ) :
+    padicValNat p (catalan n) = carries p n - padicValNat p (n + 1) := by
+  have := padicValNat_catalan_add_succ_eq_carries (p := p) n
+  omega
+
+/-- **Carry form of the divisibility criterion.**
+`p ∤ Cₙ ⟺ carries p n = v_p(n+1)`.
+
+`p` divides the `n`-th Catalan number unless the carries produced by adding
+`n + n` in base `p` are exactly cancelled by the trailing-zero count of `n + 1`.
+This is the parent's `not_dvd_catalan_iff` with its raw digit-sum right-hand side
+traded for the single equation `carries p n = v_p(n+1)`, obtained by cancelling the
+nonzero factor `p − 1` against the digit-sum carry formula. -/
+theorem not_dvd_catalan_iff_carries [hp : Fact p.Prime] (n : ℕ) :
+    ¬ p ∣ catalan n ↔ carries p n = padicValNat p (n + 1) := by
+  rw [not_dvd_catalan_iff (p := p) n]
+  have hc := sub_one_mul_carries (p := p) n
+  have hp1 : 0 < p - 1 := by have := hp.out.two_le; omega
+  constructor
+  · intro h
+    -- both `(p-1)·carries` and `(p-1)·v(n+1)` equal `2 s_p(n) − s_p(2n)`
+    have heq : (p - 1) * carries p n = (p - 1) * padicValNat p (n + 1) := by omega
+    exact Nat.eq_of_mul_eq_mul_left hp1 heq
+  · intro h
+    rw [h] at hc
+    omega
+
+/-! ### Specialisation to the prime `p = 3` -/
+
+/-- **Carry criterion at `p = 3`.**  `3 ∤ Cₙ ⟺ carries 3 n = v₃(n+1)`.
+The first odd-prime analogue of the sibling's parity law
+(`Cₙ` odd ⟺ `n + 1` a power of two). -/
+theorem not_dvd_catalan_three_iff_carries (n : ℕ) :
+    ¬ (3 : ℕ) ∣ catalan n ↔ carries 3 n = padicValNat 3 (n + 1) := by
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  exact not_dvd_catalan_iff_carries (p := 3) n
+
+/-! ### Concrete witnesses: the first gap in `{ n | 3 ∤ Cₙ }`
+
+We avoid evaluating `Nat.catalan` directly (its naive recursion does not reduce in
+the kernel); instead we read each value off `(n+1)·Cₙ = C(2n,n)` with `C(2n,n)`
+computed by `decide`, then finish the divisibility check by `decide`.  This shows
+the non-divisible blocks `{0,…,4}` and `{8,…,13}` are separated by a genuine gap
+at `n = 5, 6, 7`. -/
+
+/-- `C₄ = 14`, hence `3 ∤ C₄` (top of the first non-divisible block). -/
+example : ¬ (3 : ℕ) ∣ catalan 4 := by
+  have h := succ_mul_catalan_eq_centralBinom 4
+  have hc : Nat.centralBinom 4 = 70 := by decide
+  have : catalan 4 = 14 := by omega
+  rw [this]; decide
+
+/-- `C₅ = 42`, hence `3 ∣ C₅` (the gap begins). -/
+example : (3 : ℕ) ∣ catalan 5 := by
+  have h := succ_mul_catalan_eq_centralBinom 5
+  have hc : Nat.centralBinom 5 = 252 := by decide
+  have : catalan 5 = 42 := by omega
+  rw [this]; decide
+
+/-- `C₆ = 132`, hence `3 ∣ C₆`. -/
+example : (3 : ℕ) ∣ catalan 6 := by
+  have h := succ_mul_catalan_eq_centralBinom 6
+  have hc : Nat.centralBinom 6 = 924 := by decide
+  have : catalan 6 = 132 := by omega
+  rw [this]; decide
+
+/-- `C₇ = 429`, hence `3 ∣ C₇` (the gap ends). -/
+example : (3 : ℕ) ∣ catalan 7 := by
+  have h := succ_mul_catalan_eq_centralBinom 7
+  have hc : Nat.centralBinom 7 = 3432 := by decide
+  have : catalan 7 = 429 := by omega
+  rw [this]; decide
+
+/-- `C₈ = 1430`, hence `3 ∤ C₈` (bottom of the second non-divisible block). -/
+example : ¬ (3 : ℕ) ∣ catalan 8 := by
+  have h := succ_mul_catalan_eq_centralBinom 8
+  have hc : Nat.centralBinom 8 = 12870 := by decide
+  have : catalan 8 = 1430 := by omega
+  rw [this]; decide
+
+end CatalanKummer

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-catalan-kummer-overview",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Recasting the criterion in Kummer carry form",
+    "content": "The parent entry proved p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n), a statement in raw base-p digit sums. By Kummer's theorem the quantity (2·s_p(n) − s_p(2n))/(p−1) is literally the number of carries when adding n + n in base p, and equals v_p of the central binomial coefficient. Defining carries p n := v_p(C(2n,n)) turns the parent's three-term digit-sum equation into the single comparison carries p n = v_p(n+1), the natural combinatorial form of the criterion.",
+    "mathContext": "Kummer: $v_p\\binom{2n}{n} = \\dfrac{2s_p(n)-s_p(2n)}{p-1}$ is the carry count of $n+n$ base $p$. Criterion: $p \\nmid C_n \\iff \\mathrm{carries}\\,p\\,n = v_p(n+1)$.",
+    "significance": "context",
+    "relatedConcepts": ["Kummer's theorem", "p-adic valuation", "carry count", "Catalan numbers", "central binomial coefficient"],
+    "prerequisites": ["p-adic valuation", "base-p digit representation", "binomial coefficients"]
+  },
+  {
+    "id": "ann-catalan-kummer-def",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 65 },
+    "type": "definition",
+    "title": "The Kummer carry count and its digit-sum formula",
+    "content": "carries p n := padicValNat p (Nat.centralBinom n) realises the number of carries in n + n (base p) as a p-adic valuation. sub_one_mul_carries restates the parent's central-binomial identity for this definition: (p−1)·carries p n + s_p(2n) = 2·s_p(n), i.e. (p−1)·carries p n = 2·s_p(n) − s_p(2n). This is a definitional reuse of the parent's analytic work.",
+    "mathContext": "$(p-1)\\,\\mathrm{carries}\\,p\\,n + s_p(2n) = 2 s_p(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "digit sum", "carry count"],
+    "prerequisites": ["p-adic valuation", "digit sums"]
+  },
+  {
+    "id": "ann-catalan-kummer-splitting",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 99 },
+    "type": "insight",
+    "title": "Valuation splitting and the difference formula",
+    "content": "Applying multiplicativity of padicValNat to (n+1)·catalan n = C(2n,n) gives v_p(Cₙ) + v_p(n+1) = carries p n in one line (padicValNat_catalan_add_succ_eq_carries). The nonzero side conditions n + 1 ≠ 0 and catalan n ≠ 0 (the parent's catalan_ne_zero) license the split. omega then yields the inequality v_p(n+1) ≤ carries p n and the clean difference formula v_p(Cₙ) = carries p n − v_p(n+1) — the arithmetic shadow of dividing the central binomial coefficient by n + 1.",
+    "mathContext": "$v_p(C_n) + v_p(n+1) = \\mathrm{carries}\\,p\\,n$, hence $v_p(C_n) = \\mathrm{carries}\\,p\\,n - v_p(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["valuation additivity", "padicValNat.mul", "central binomial coefficient", "omega tactic"],
+    "prerequisites": ["p-adic valuation", "multiplicativity of valuations"]
+  },
+  {
+    "id": "ann-catalan-kummer-criterion",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 119 },
+    "type": "insight",
+    "title": "Carry form of the divisibility criterion",
+    "content": "not_dvd_catalan_iff_carries proves p ∤ Cₙ ⟺ carries p n = v_p(n+1). The proof rewrites the goal with the parent's not_dvd_catalan_iff, so both the parent's digit-sum equation and the carry formula assert that their respective (p−1)-multiples equal 2·s_p(n) − s_p(2n). omega extracts (p−1)·carries p n = (p−1)·v_p(n+1), and Nat.eq_of_mul_eq_mul_left cancels the nonzero factor p − 1 (positive because p ≥ 2). No new arithmetic and no digit induction — the entire transport is cancellation of p − 1.",
+    "mathContext": "$p \\nmid C_n \\iff \\mathrm{carries}\\,p\\,n = v_p(n+1)$; cancel $p-1>0$ against $(p-1)\\,\\mathrm{carries}\\,p\\,n = (p-1) v_p(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility criterion", "left-cancellation", "Nat.eq_of_mul_eq_mul_left", "parity law"],
+    "prerequisites": ["divisibility", "natural-number cancellation"]
+  },
+  {
+    "id": "ann-catalan-kummer-p3",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 121, "endLine": 171 },
+    "type": "technique",
+    "title": "p = 3 specialisation and the first gap",
+    "content": "not_dvd_catalan_three_iff_carries instantiates the carry criterion at p = 3 (the first odd-prime analogue of the parity law). The five witnesses 3 ∤ C₄, 3 ∣ C₅, 3 ∣ C₆, 3 ∣ C₇, 3 ∤ C₈ exhibit the first gap of the non-divisible index set {0,…,4} | {5,6,7} | {8,…,13}. Because Nat.catalan's recursion does not reduce in the kernel, each Cₙ is read off (n+1)·Cₙ = C(2n,n) — with centralBinom = (2n).choose n evaluated by decide — and finished by a small divisibility decide, so the entry uses no native_decide.",
+    "mathContext": "Over $n \\le 30$: $3 \\nmid C_n$ exactly for $n \\in \\{0,\\dots,4\\}\\cup\\{8,\\dots,13\\}\\cup\\{26,\\dots,30\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "centralBinom evaluation", "index sets", "parity law analogue"],
+    "prerequisites": ["divisibility", "decidability", "Catalan number recurrence"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,201 @@
+{
+  "id": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+  "title": "Catalan p-Divisibility as a Kummer Carry Criterion: p ∤ Cₙ ⟺ carries p n = v_p(n+1)",
+  "slug": "catalan-numbers-oq-01-oq-02-oq-01-oq-01",
+  "description": "Answers the first open question of the parent entry catalan-numbers-oq-01-oq-02-oq-01 by recasting its p-divisibility criterion in Kummer carry form. The parent proved p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n), a statement in raw base-p digit sums. Defining the Kummer carry count carries p n := v_p(C(2n,n)) — by Kummer's theorem the number of carries when adding n + n in base p — this entry transports the criterion into its natural combinatorial shape p ∤ Cₙ ⟺ carries p n = v_p(n+1): p divides the n-th Catalan number unless the carries in n + n are exactly cancelled by the trailing-zero count of n + 1. It also establishes the valuation splitting v_p(Cₙ) + v_p(n+1) = carries p n (hence v_p(n+1) ≤ carries p n and the clean difference formula v_p(Cₙ) = carries p n − v_p(n+1), the arithmetic analogue of Cₙ = C(2n,n)/(n+1)), and specialises to p = 3 with fully checked witnesses exhibiting the first gap in the non-divisible index set: 3 ∤ Cₙ for n ∈ {0,…,4} and {8,…,13}, while 3 ∣ Cₙ for the bridging block {5,6,7}. The transport is pure algebra over the parent's lemmas: cancel the nonzero factor p−1 against the digit-sum carry formula, and apply multiplicativity of padicValNat to (n+1)·Cₙ = C(2n,n). Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (Kummer's carry theorem for binomial valuations); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "catalan-numbers",
+      "p-adic-valuation",
+      "kummer-theorem",
+      "kummer-carries",
+      "central-binomial",
+      "divisibility",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n + 1) · catalan n = Nat.centralBinom n. Taking padicValNat of both sides and applying multiplicativity gives v_p(n+1) + v_p(Cₙ) = carries p n, the valuation-splitting identity behind both the difference formula and the carry-form criterion.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "padicValNat.mul",
+        "description": "a ≠ 0 → b ≠ 0 → v_p(a·b) = v_p(a) + v_p(b). Additivity of the p-adic valuation, applied to the nonzero factors n + 1 and catalan n of the central binomial coefficient.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_left",
+        "description": "0 < a → a·b = a·c → b = c. Left-cancellation of the nonzero factor p − 1 (from p ≥ 2) that turns the digit-sum carry formula into the single equation carries p n = v_p(n+1).",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.prime_three",
+        "description": "Nat.Prime 3. Supplies the Fact (Nat.Prime 3) instance for the p = 3 specialisation of the carry criterion.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "parentDependencies": [
+      {
+        "theorem": "CatalanPAdic.sub_one_mul_padicValNat_centralBinom",
+        "description": "(p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n) from the parent entry. Restated here as the digit-sum carry formula sub_one_mul_carries for carries p n.",
+        "module": "Proofs.CatalanNumbersOQ01OQ02OQ01"
+      },
+      {
+        "theorem": "CatalanPAdic.not_dvd_catalan_iff",
+        "description": "p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n), the parent's digit-sum divisibility criterion. Combined with the carry formula and cancellation of p − 1, it yields the carry-form criterion p ∤ Cₙ ⟺ carries p n = v_p(n+1).",
+        "module": "Proofs.CatalanNumbersOQ01OQ02OQ01"
+      },
+      {
+        "theorem": "CatalanPAdic.catalan_ne_zero",
+        "description": "catalan n ≠ 0, the nonzero side condition required to split padicValNat across (n+1)·catalan n.",
+        "module": "Proofs.CatalanNumbersOQ01OQ02OQ01"
+      }
+    ],
+    "originalContributions": [
+      "carries p n := padicValNat p (Nat.centralBinom n): the Kummer carry count of n + n in base p, realised as the p-adic valuation of the central binomial coefficient.",
+      "not_dvd_catalan_iff_carries: p ∤ Cₙ ⟺ carries p n = v_p(n+1). The carry form of the parent's divisibility criterion, obtained by cancelling the nonzero factor p − 1 against the digit-sum carry formula — replacing a three-term digit-sum equation with a single comparison of two nonnegative integers.",
+      "padicValNat_catalan_add_succ_eq_carries: v_p(Cₙ) + v_p(n+1) = carries p n, the valuation splitting of the carry count across (n+1)·Cₙ = C(2n,n).",
+      "padicValNat_succ_le_carries and padicValNat_catalan_eq: the inequality v_p(n+1) ≤ carries p n and the clean ℕ-subtraction formula v_p(Cₙ) = carries p n − v_p(n+1), the arithmetic analogue of Cₙ = C(2n,n)/(n+1).",
+      "not_dvd_catalan_three_iff_carries plus five kernel-decide witnesses (3 ∤ C₄, 3 ∣ C₅, 3 ∣ C₆, 3 ∣ C₇, 3 ∤ C₈) exhibiting the first gap of the p = 3 non-divisible index set {0,…,4} ∪ {8,…,13} ∪ {26,…,30} (for n ≤ 30); Catalan values are read off (n+1)·Cₙ = C(2n,n) since Nat.catalan does not reduce in the kernel."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide: the five concrete witnesses use kernel decide on centralBinom values and small divisibility checks, so the entry does not depend on Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 171,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Kummer's theorem (1852) computes the p-adic valuation of a binomial coefficient C(m+n,n) as the number of carries when adding m and n in base p, equivalently (s_p(m) + s_p(n) − s_p(m+n))/(p−1). For the central binomial coefficient C(2n,n) the carry count is (2·s_p(n) − s_p(2n))/(p−1). The Catalan number Cₙ = C(2n,n)/(n+1) loses exactly v_p(n+1) of those p-factors, so the carry count of n + n governs Catalan divisibility once corrected by the trailing-zero count of n + 1. For p = 2 the famous parity law 'Cₙ odd ⟺ n+1 a power of two' is this statement; this entry records the odd-prime analogue and the explicit p = 3 index structure.",
+    "problemStatement": "The parent entry catalan-numbers-oq-01-oq-02-oq-01 proved p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n) and asked, as its first open question, to recast this via Kummer carries — characterising the n for which the number of base-p carries in n + n equals v_p(n+1), and describing the resulting index sets for small odd primes.\n\n**Answer:** with carries p n := v_p(C(2n,n)) (Kummer's carry count of n + n in base p), p ∤ Cₙ ⟺ carries p n = v_p(n+1); moreover v_p(Cₙ) = carries p n − v_p(n+1). For p = 3 the non-divisible indices n ≤ 30 are {0,1,2,3,4, 8,…,13, 26,…,30}.",
+    "text": "Define carries p n as v_p of the central binomial coefficient. The parent's central-binomial identity says (p−1)·carries p n + s_p(2n) = 2·s_p(n); cancelling p − 1 against the parent's digit-sum criterion turns p ∤ Cₙ into the single equation carries p n = v_p(n+1). Multiplicativity of padicValNat across (n+1)·Cₙ = C(2n,n) gives the valuation splitting and the difference formula. The p = 3 witnesses are computed through centralBinom because Nat.catalan does not reduce in the kernel.",
+    "proofStrategy": "1. sub_one_mul_carries: restate the parent's (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n) for carries p n (definitional).\n2. padicValNat_catalan_add_succ_eq_carries: take padicValNat across (n+1)·catalan n = C(2n,n); padicValNat.mul (with n+1 ≠ 0 and catalan_ne_zero) gives v_p(n+1) + v_p(Cₙ) = carries p n; omega rearranges. The inequality and difference formula follow by omega.\n3. not_dvd_catalan_iff_carries: rewrite the goal with the parent's not_dvd_catalan_iff, so it becomes ((p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n)) ⟺ (carries p n = v_p(n+1)). Both products equal 2·s_p(n) − s_p(2n) via the carry formula; omega extracts (p−1)·carries p n = (p−1)·v_p(n+1) and Nat.eq_of_mul_eq_mul_left (0 < p−1 from p ≥ 2) cancels p − 1.\n4. not_dvd_catalan_three_iff_carries: instantiate at p = 3 with Fact (Nat.Prime 3).\n5. Witnesses: read Cₙ off (n+1)·Cₙ = C(2n,n) with centralBinom evaluated by decide, then check divisibility by decide.",
+    "keyInsights": [
+      "**The carry count is the right object.** Replacing the parent's three-term digit-sum equation (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n) with carries p n = v_p(n+1) compresses the criterion to a comparison of two nonnegative integers, making the structure of the non-divisible index sets transparent and the p = 2 parity law its first instance.",
+      "**Cancelling p − 1 is the whole transport.** The digit-sum carry formula and the parent's criterion share the term 2·s_p(n) − s_p(2n); subtracting them leaves (p−1)·v_p(n+1) = (p−1)·carries p n, and left-cancellation of the nonzero factor p − 1 (valid because p ≥ 2) yields the carry equation. No new arithmetic, no digit induction.",
+      "**Valuation splitting gives the difference formula for free.** Multiplicativity of padicValNat on (n+1)·Cₙ = C(2n,n) yields v_p(Cₙ) + v_p(n+1) = carries p n in one line, hence both v_p(n+1) ≤ carries p n and v_p(Cₙ) = carries p n − v_p(n+1) — the exact arithmetic shadow of dividing the central binomial coefficient by n + 1.",
+      "**Catalan numbers must be reached through centralBinom.** Nat.catalan's recursion does not reduce in the kernel, so decide cannot evaluate Cₙ directly. Each witness instead reads Cₙ off (n+1)·Cₙ = C(2n,n) — where centralBinom = (2n).choose n does reduce — and finishes with a small divisibility decide, keeping the entry free of native_decide."
+    ],
+    "exampleSections": [
+      {
+        "title": "The first gap at p = 3",
+        "mathContext": "Over n ≤ 30 the carry criterion gives 3 ∤ Cₙ exactly for n ∈ {0,1,2,3,4} ∪ {8,…,13} ∪ {26,…,30}. The entry proves the boundary of the first two blocks: 3 ∤ C₄ = 14 and 3 ∤ C₈ = 1430, separated by the divisible bridge 3 ∣ C₅ = 42, 3 ∣ C₆ = 132, 3 ∣ C₇ = 429. The block lengths 5, 6, 5 and their base-3 positions reflect carries 3 n = v₃(n+1): a non-divisible n is one whose base-3 addition n + n carries only as often as 3 divides n + 1."
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the criterion in carry form",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring framing the entry as the Kummer-carry recasting of the parent's digit-sum divisibility criterion. Imports the parent module, defines the agenda (carry formula, carry-form criterion, valuation splitting and difference formula, p = 3 index structure), and notes that the analytic content lives entirely in the parent."
+    },
+    {
+      "id": "carries-def",
+      "title": "Definition: the Kummer carry count",
+      "startLine": 50,
+      "endLine": 57,
+      "summary": "carries p n := padicValNat p (Nat.centralBinom n), the number of carries when adding n + n in base p (Kummer's theorem identifies the carry count with v_p of the central binomial coefficient)."
+    },
+    {
+      "id": "carry-formula",
+      "title": "Digit-sum carry formula",
+      "startLine": 59,
+      "endLine": 65,
+      "summary": "sub_one_mul_carries: (p−1)·carries p n + s_p(2n) = 2·s_p(n), the parent's central-binomial valuation identity restated for the carry count (definitional reuse)."
+    },
+    {
+      "id": "valuation-splitting",
+      "title": "Valuation splitting and difference formula",
+      "startLine": 67,
+      "endLine": 99,
+      "summary": "padicValNat_catalan_add_succ_eq_carries (v_p(Cₙ) + v_p(n+1) = carries p n) from padicValNat.mul on (n+1)·catalan n = C(2n,n); the corollaries padicValNat_succ_le_carries (v_p(n+1) ≤ carries p n) and padicValNat_catalan_eq (v_p(Cₙ) = carries p n − v_p(n+1)) follow by omega."
+    },
+    {
+      "id": "carry-criterion",
+      "title": "Carry form of the divisibility criterion",
+      "startLine": 101,
+      "endLine": 119,
+      "summary": "not_dvd_catalan_iff_carries: p ∤ Cₙ ⟺ carries p n = v_p(n+1). Rewrites the goal with the parent's not_dvd_catalan_iff, then cancels the nonzero factor p − 1 (Nat.eq_of_mul_eq_mul_left, 0 < p−1 from p ≥ 2) against the digit-sum carry formula."
+    },
+    {
+      "id": "p-three",
+      "title": "Specialisation to p = 3 and witnesses",
+      "startLine": 121,
+      "endLine": 171,
+      "summary": "not_dvd_catalan_three_iff_carries (the p = 3 carry criterion) plus five kernel-decide witnesses 3 ∤ C₄, 3 ∣ C₅, 3 ∣ C₆, 3 ∣ C₇, 3 ∤ C₈, with each Cₙ read off (n+1)·Cₙ = C(2n,n), exhibiting the first gap {0,…,4} | {5,6,7} | {8,…,13} of the non-divisible index set."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kummer, Ernst Eduard",
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "note": "J. Reine Angew. Math. 44 — v_p(C(m+n,n)) is the number of carries when adding m and n in base p; the source of the carry interpretation of carries p n."
+    },
+    {
+      "authors": "Alter, Ronald; Kubota, K. K.",
+      "title": "Prime and prime power divisibility of Catalan numbers",
+      "year": "1973",
+      "note": "J. Combin. Theory Ser. A 15 — characterises p-divisibility of the Catalan numbers, the index-set phenomenon made explicit for p = 3 here."
+    },
+    {
+      "authors": "Deutsch, Emeric; Sagan, Bruce E.",
+      "title": "Congruences for Catalan and Motzkin numbers and related sequences",
+      "year": "2006",
+      "note": "J. Number Theory 117 — p-adic valuations and congruences of the Catalan numbers across primes."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: the general-prime digit-sum valuation identity and divisibility criterion p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n). This entry answers its first open question by transporting the criterion into Kummer carry form."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01-oq-02",
+      "relationship": "ancestor",
+      "description": "Grandparent: the 2-adic valuation and parity law Cₙ odd ⟺ n+1 a power of two, the p = 2 instance of the carry criterion proved here for general p and specialised to p = 3."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "related",
+      "description": "Establishes the central-binomial bridge (n+1)·catalan n = C(2n,n) used both for the valuation splitting and for evaluating Catalan numbers through centralBinom in the witnesses."
+    }
+  ],
+  "conclusion": {
+    "summary": "With the Kummer carry count carries p n := v_p(C(2n,n)), the parent's Catalan p-divisibility criterion becomes p ∤ Cₙ ⟺ carries p n = v_p(n+1) (not_dvd_catalan_iff_carries), and the valuation splits as v_p(Cₙ) + v_p(n+1) = carries p n with difference formula v_p(Cₙ) = carries p n − v_p(n+1). For p = 3, fully checked witnesses exhibit the first gap of the non-divisible index set {0,…,4} | {5,6,7} | {8,…,13}. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Recasts the gallery's Catalan divisibility theory in its natural Kummer-carry language, compressing a three-term digit-sum equation to a single comparison of two integers and exposing the base-p block structure of the non-divisible indices. The transport is elementary — cancellation of p − 1 plus multiplicativity of padicValNat — and reusable for any prime.",
+    "openQuestions": [
+      "Give a closed description of the p = 3 non-divisible index set: prove that 3 ∤ Cₙ holds exactly for the n whose base-3 expansion of n + 1 has a prescribed carry/digit pattern, generalising the p = 2 'n + 1 a power of two' law to a base-3 automaton.",
+      "Bound the density of {n ≤ N | p ∤ Cₙ} for odd primes p using carries p n = v_p(n+1), and compare across primes."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CatalanNumbersOQ01OQ02OQ01"
+    ],
+    "opens": [
+      "Nat",
+      "CatalanPAdic"
+    ],
+    "namespace": "CatalanKummer",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/CatalanNumbersOQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent gallery entry `catalan-numbers-oq-01-oq-02-oq-01` (verbatim): *"Recast the criterion via Kummer carries: characterise the n for which the number of base-p carries in n + n equals v_p(n+1), giving p ∤ catalan n; describe the resulting index sets for small odd primes p."*

The parent proved the digit-sum criterion `p ∤ Cₙ ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n)`. Defining the **Kummer carry count** `carries p n := v_p(C(2n,n))` (by Kummer's theorem, the number of carries when adding `n + n` in base `p`), this entry transports the criterion into its natural combinatorial shape.

## Results (`Proofs/CatalanNumbersOQ01OQ02OQ01OQ01.lean`)

- **`not_dvd_catalan_iff_carries`** — `p ∤ Cₙ ⟺ carries p n = v_p(n+1)`. The carry form: `p` divides the `n`-th Catalan number unless the carries in `n + n` are exactly cancelled by the trailing-zero count of `n + 1`.
- **`padicValNat_catalan_add_succ_eq_carries`** — `v_p(Cₙ) + v_p(n+1) = carries p n` (valuation splitting across `(n+1)·Cₙ = C(2n,n)`).
- **`padicValNat_succ_le_carries`** / **`padicValNat_catalan_eq`** — `v_p(n+1) ≤ carries p n` and `v_p(Cₙ) = carries p n − v_p(n+1)`, the arithmetic analogue of `Cₙ = C(2n,n)/(n+1)`.
- **`not_dvd_catalan_three_iff_carries`** + five kernel-`decide` witnesses (`3 ∤ C₄`, `3 ∣ C₅`, `3 ∣ C₆`, `3 ∣ C₇`, `3 ∤ C₈`) exhibiting the first gap of the `p = 3` non-divisible index set `{0,…,4} | {5,6,7} | {8,…,13}` (full set for `n ≤ 30`: `{0,…,4} ∪ {8,…,13} ∪ {26,…,30}`).

## Method

Pure algebra over the parent lemmas: cancel the nonzero factor `p−1` (via `Nat.eq_of_mul_eq_mul_left`, `p ≥ 2`) against the digit-sum carry formula, and apply multiplicativity of `padicValNat`. The hard analytic content (Legendre's formula + digit sums) lives entirely in the parent.

Note: `Nat.catalan`'s recursion does not reduce in the kernel, so each witness reads `Cₙ` off `(n+1)·Cₙ = C(2n,n)` with `centralBinom` evaluated by `decide`, then finishes with a small divisibility `decide` — **no `native_decide`**.

## Verification

- `lake env lean` on the file: **0 errors**.
- `#print axioms` on the four main theorems: only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- **0 axioms, 0 sorries**, 6 theorems, 1 def, 171 lines. `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)