### PR TITLE
research(mellin-power-convergence-oq-01-oq-01): general-interval (b^s−a^s)/s and power-weighted 1/(s+c) on strip Re s>−c [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/MellinPowerConvergenceOQ01OQ01.lean
+++ b/proofs/Proofs/MellinPowerConvergenceOQ01OQ01.lean
@@ -1,0 +1,146 @@
+import Mathlib
+import Proofs.MellinPowerConvergenceOQ01
+
+/-
+# General intervals and power weights for the Mellin transform
+
+The parent entry `mellin-power-convergence-oq-01` proves the base pair
+`mellin 𝟙_{(0,1]} s = 1/s`, its sharp convergence strip `Re s > 0`, and the
+dilation law `mellin 𝟙_{(0,a]} s = a^s/s`. This grandchild closes the two
+natural algebraic gaps left open, turning the single base pair into a working
+calculus.
+
+* **General half-open interval** (`hasMellin_indicator_Ioc_pair`): for
+  `0 < a < b` and `Re s > 0`,
+  `mellin 𝟙_{(a,b]} s = (b^s - a^s)/s`.
+  Since `(a,b] = (0,b] \ (0,a]` we have the pointwise identity
+  `𝟙_{(a,b]} = 𝟙_{(0,b]} - 𝟙_{(0,a]}`, so subtracting the two parent dilation
+  results (`hasMellin_sub`) gives `b^s/s - a^s/s = (b^s - a^s)/s`. This is the
+  elementary building block of every piecewise-constant Mellin transform
+  (Perron-type summation, truncated Dirichlet integrals). At `s = 1` it returns
+  the length `b - a`.
+
+* **Power-weighted unit indicator** (`hasMellin_powerIndicator`,
+  `mellinConvergent_powerIndicator_iff`): for real `c` and `Re s > -c`,
+  `mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c)`, with convergence holding **iff**
+  `Re s > -c`. Absorbing the monomial weight into the Mellin exponent,
+  `t^{s-1} · t^c = t^{(s+c)-1}`, reduces the whole computation to the parent
+  base case at the shifted argument `s + c`; the fundamental strip slides left
+  by `c`. This is the prototype for how decay/growth weights move the
+  convergence strip — the mechanism behind the analytic continuation of `Γ`.
+
+Both results reuse Mathlib's Mellin API (`hasMellin_sub`,
+`MellinConvergent.cpow_smul`, `mellin_cpow_smul`) together with the parent
+entry, so they are genuinely new packagings rather than restatements of a
+single Mathlib lemma. No axioms.
+-/
+
+open Complex MeasureTheory Set
+
+namespace MellinPowerConvergenceOQ01OQ01
+
+open MellinPowerConvergenceOQ01
+
+/-! ## General half-open interval: `mellin 𝟙_{(a,b]} s = (b^s - a^s)/s` -/
+
+/-- **Set-difference decomposition.** For `0 < a < b`, the indicator of the
+half-open interval `(a,b]` is the difference of the two nested unit-anchored
+indicators: `𝟙_{(a,b]} = 𝟙_{(0,b]} - 𝟙_{(0,a]}`. -/
+theorem indicator_Ioc_sub {a b : ℝ} (ha : 0 < a) (hab : a < b) :
+    (Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ)))
+      = fun t => Set.indicator (Set.Ioc (0 : ℝ) b) (fun _ => (1 : ℂ)) t
+              - Set.indicator (Set.Ioc (0 : ℝ) a) (fun _ => (1 : ℂ)) t := by
+  have hb : (0 : ℝ) < b := ha.trans hab
+  funext t
+  by_cases htb : t ∈ Set.Ioc (0 : ℝ) b
+  · by_cases hta : t ∈ Set.Ioc (0 : ℝ) a
+    · -- `t ∈ (0,a]`, hence not in `(a,b]`
+      have hnab : t ∉ Set.Ioc a b := by
+        simp only [Set.mem_Ioc] at hta ⊢
+        rintro ⟨h, _⟩; linarith [hta.2]
+      rw [Set.indicator_of_notMem hnab, Set.indicator_of_mem htb,
+        Set.indicator_of_mem hta, sub_self]
+    · -- `t ∈ (0,b]` but `t ∉ (0,a]`, hence `a < t ≤ b`, i.e. `t ∈ (a,b]`
+      have hmem : t ∈ Set.Ioc a b := by
+        simp only [Set.mem_Ioc] at htb hta ⊢
+        refine ⟨?_, htb.2⟩
+        by_contra h; push_neg at h
+        exact hta ⟨htb.1, h⟩
+      rw [Set.indicator_of_mem hmem, Set.indicator_of_mem htb,
+        Set.indicator_of_notMem hta, sub_zero]
+  · -- `t ∉ (0,b]`, hence in neither `(a,b]` nor `(0,a]`
+    have hna : t ∉ Set.Ioc (0 : ℝ) a := fun h => htb (by
+      simp only [Set.mem_Ioc] at h ⊢; exact ⟨h.1, h.2.trans hab.le⟩)
+    have hnab : t ∉ Set.Ioc a b := fun h => htb (by
+      simp only [Set.mem_Ioc] at h ⊢; exact ⟨ha.trans h.1, h.2⟩)
+    rw [Set.indicator_of_notMem hnab, Set.indicator_of_notMem htb,
+      Set.indicator_of_notMem hna, sub_zero]
+
+/-- **General interval transform.** For `0 < a < b` and `Re s > 0`, the Mellin
+transform of `𝟙_{(a,b]}` exists and equals `(b^s - a^s)/s`. The half-open
+interval `(a,b]` is `(0,b] \ (0,a]`, so the result is the difference of the two
+parent dilation laws. -/
+theorem hasMellin_indicator_Ioc_pair {a b : ℝ} (ha : 0 < a) (hab : a < b)
+    {s : ℂ} (hs : 0 < s.re) :
+    HasMellin (Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ))) s
+      (((b : ℂ) ^ s - (a : ℂ) ^ s) / s) := by
+  have hb : (0 : ℝ) < b := ha.trans hab
+  rw [indicator_Ioc_sub ha hab]
+  have hcb := hasMellin_indicator_Ioc hb hs
+  have hca := hasMellin_indicator_Ioc ha hs
+  have hsub := hasMellin_sub hcb.1 hca.1
+  rwa [mellin_indicator_Ioc hb hs, mellin_indicator_Ioc ha hs, ← sub_div] at hsub
+
+/-- The value form of the general-interval transform. -/
+theorem mellin_indicator_Ioc_pair {a b : ℝ} (ha : 0 < a) (hab : a < b)
+    {s : ℂ} (hs : 0 < s.re) :
+    mellin (Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ))) s
+      = ((b : ℂ) ^ s - (a : ℂ) ^ s) / s :=
+  (hasMellin_indicator_Ioc_pair ha hab hs).2
+
+/-- **Length at `s = 1`.** Specialising to `s = 1` recovers the Lebesgue length
+of the interval: `mellin 𝟙_{(a,b]} 1 = b - a`. -/
+theorem mellin_indicator_Ioc_pair_one {a b : ℝ} (ha : 0 < a) (hab : a < b) :
+    mellin (Set.indicator (Set.Ioc a b) (fun _ => (1 : ℂ))) 1
+      = (b : ℂ) - (a : ℂ) := by
+  rw [mellin_indicator_Ioc_pair ha hab (by norm_num), Complex.cpow_one,
+    Complex.cpow_one, div_one]
+
+/-! ## Power-weighted unit indicator: `mellin (t^c · 𝟙_{(0,1]}) s = 1/(s+c)` -/
+
+/-- The power-weighted unit indicator `t ↦ t^c · 𝟙_{(0,1]}(t)` valued in `ℂ`,
+for a real exponent `c`. -/
+noncomputable abbrev powerIndicator (c : ℝ) : ℝ → ℂ :=
+  fun t => (t : ℂ) ^ (c : ℂ) • unitIndicator t
+
+/-- **Power-weight transform.** For real `c` and `Re s > -c`, the Mellin
+transform of `t^c · 𝟙_{(0,1]}` exists and equals `1/(s + c)`. Absorbing the
+weight `t^c` into the exponent reduces the computation to the parent base case
+at the shifted argument `s + c`. -/
+theorem hasMellin_powerIndicator {c : ℝ} {s : ℂ} (hs : -c < s.re) :
+    HasMellin (powerIndicator c) s (1 / (s + (c : ℂ))) := by
+  have hsc : 0 < (s + (c : ℂ)).re := by
+    rw [Complex.add_re, Complex.ofReal_re]; linarith
+  refine ⟨?_, ?_⟩
+  · -- convergence via the `cpow_smul` shift
+    exact MellinConvergent.cpow_smul.mpr (hasMellin_unitIndicator hsc).1
+  · -- value: `mellin (t^c • 𝟙) s = mellin 𝟙 (s+c) = 1/(s+c)`
+    rw [mellin_cpow_smul, mellin_unitIndicator hsc]
+
+/-- The value form of the power-weight transform. -/
+theorem mellin_powerIndicator {c : ℝ} {s : ℂ} (hs : -c < s.re) :
+    mellin (powerIndicator c) s = 1 / (s + (c : ℂ)) :=
+  (hasMellin_powerIndicator hs).2
+
+/-- **Sharp shifted convergence strip.** The Mellin integral of
+`t^c · 𝟙_{(0,1]}` converges **if and only if** `Re s > -c`: the parent strip
+`Re s > 0` slides left by `c`. -/
+theorem mellinConvergent_powerIndicator_iff {c : ℝ} {s : ℂ} :
+    MellinConvergent (powerIndicator c) s ↔ -c < s.re := by
+  rw [show (powerIndicator c)
+        = (fun t : ℝ => (t : ℂ) ^ (c : ℂ) • unitIndicator t) from rfl,
+    MellinConvergent.cpow_smul, mellinConvergent_unitIndicator_iff,
+    Complex.add_re, Complex.ofReal_re]
+  constructor <;> intro h <;> linarith
+
+end MellinPowerConvergenceOQ01OQ01

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 36 },
+    "type": "context",
+    "title": "From a Single Base Pair to a Working Mellin Calculus",
+    "content": "The parent entry computes only the base pair mellin 𝟙_{(0,1]} s = 1/s, its sharp strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s, and asks (open question 1) for two extensions. This grandchild supplies both: the general half-open interval (a,b], whose transform is (b^s − a^s)/s, and the power-weighted unit indicator t^c · 𝟙_{(0,1]}, whose transform is 1/(s + c) on the shifted strip Re s > −c. Both reduce to the parent — the first by additivity of the transform over a set difference, the second by absorbing the monomial weight into the Mellin exponent — so they are genuinely new packagings rather than restatements of a single Mathlib lemma. No axioms.",
+    "mathContext": "$\\mathrm{mellin}\\,\\mathbb{1}_{(a,b]}\\,s = (b^s - a^s)/s$; $\\mathrm{mellin}\\,(t^c\\,\\mathbb{1}_{(0,1]})\\,s = 1/(s+c)$ for $\\mathrm{Re}\\,s > -c$.",
+    "significance": "context",
+    "relatedConcepts": ["Mellin transform", "fundamental strip", "Perron formula", "Dirichlet series", "Gamma function"],
+    "prerequisites": ["complex analysis", "improper integrals", "indicator functions"]
+  },
+  {
+    "id": "ann-set-difference",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 77 },
+    "type": "theorem",
+    "title": "indicator_Ioc_sub: A General Interval as a Difference",
+    "content": "indicator_Ioc_sub proves the pointwise identity 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} for 0 < a < b, the bridge that lets the additive Mellin API see a general interval. The proof is funext followed by a complete three-way membership case split: (i) t ∈ (0,a] ⊆ (0,b] but t ∉ (a,b], giving 0 = 1 − 1; (ii) t ∈ (0,b] ∖ (0,a], i.e. a < t ≤ b, hence t ∈ (a,b], giving 1 = 1 − 0; (iii) t ∉ (0,b], hence in none of the three, giving 0 = 0 − 0. Each branch closes with Set.indicator_of_mem / Set.indicator_of_notMem and sub_self / sub_zero.",
+    "mathContext": "$(a,b] = (0,b]\\setminus(0,a]$, so $\\mathbb{1}_{(a,b]} = \\mathbb{1}_{(0,b]} - \\mathbb{1}_{(0,a]}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.indicator", "set difference", "membership case split"],
+    "prerequisites": ["indicator functions", "intervals"]
+  },
+  {
+    "id": "ann-general-interval",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "theorem",
+    "title": "hasMellin_indicator_Ioc_pair: The General-Interval Transform (b^s − a^s)/s",
+    "content": "The first answer to the parent's open question: for 0 < a < b and Re s > 0, mellin 𝟙_{(a,b]} s = (b^s − a^s)/s, with the transform existing. This is the elementary building block of every piecewise-constant Mellin transform — Perron-type summation, truncated Dirichlet integrals. The proof rewrites by indicator_Ioc_sub, takes the two parent dilation results hasMellin_indicator_Ioc at the cut-offs b and a, subtracts them with the additivity lemma hasMellin_sub, then rewrites each value via mellin_indicator_Ioc and combines b^s/s − a^s/s = (b^s − a^s)/s with ← sub_div. No new integration is performed — the whole result rides on the parent dilation law and linearity.",
+    "mathContext": "$\\mathrm{mellin}\\,\\mathbb{1}_{(a,b]}\\,s = b^s/s - a^s/s = (b^s - a^s)/s$ for $0<a<b$, $\\mathrm{Re}\\,s>0$.",
+    "significance": "key",
+    "relatedConcepts": ["hasMellin_sub", "mellin_indicator_Ioc", "Perron formula", "sub_div"],
+    "prerequisites": ["Mellin transform", "complex powers", "linearity of integration"]
+  },
+  {
+    "id": "ann-length-at-one",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 107 },
+    "type": "insight",
+    "title": "mellin_indicator_Ioc_pair_one: The Length b − a at s = 1",
+    "content": "Specialising the general-interval transform to s = 1 recovers the Lebesgue length of the interval: mellin 𝟙_{(a,b]} 1 = b − a. Since mellin f 1 = ∫₀^∞ f, the transform of an indicator at s = 1 is the measure of its support; Complex.cpow_one collapses b^1 − a^1 over 1 to the honest difference of endpoints. This anchors the analytic kernel (b^s − a^s)/s to elementary geometry, extending the parent's a^1 = a.",
+    "mathContext": "$\\mathrm{mellin}\\,\\mathbb{1}_{(a,b]}\\,1 = b - a$, the Lebesgue length of $(a,b]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.cpow_one", "Lebesgue measure", "interval length"],
+    "prerequisites": ["Mellin transform at s = 1", "complex powers"]
+  },
+  {
+    "id": "ann-power-weight",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 133 },
+    "type": "theorem",
+    "title": "hasMellin_powerIndicator: The Power-Weighted Transform 1/(s + c)",
+    "content": "The second answer to the parent's open question: for a real exponent c and Re s > −c, the Mellin transform of t^c · 𝟙_{(0,1]} exists and equals 1/(s + c). The defining move is that multiplying by t^c and integrating t^{s-1}·t^c = t^{(s+c)-1} is literally the base computation at the shifted argument s + c. From Re s > −c one derives 0 < Re(s + c) (Complex.add_re, Complex.ofReal_re, linarith); the convergence half is MellinConvergent.cpow_smul.mpr applied to the parent base case at s + c, and the value half is mellin_cpow_smul followed by mellin_unitIndicator at s + c. This is the prototype for how decay/growth weights translate the convergence strip — the mechanism behind the analytic continuation of Γ.",
+    "mathContext": "$\\mathrm{mellin}\\,(t^c\\,\\mathbb{1}_{(0,1]})\\,s = \\mathrm{mellin}\\,\\mathbb{1}_{(0,1]}(s+c) = 1/(s+c)$ for $\\mathrm{Re}\\,s > -c$.",
+    "significance": "key",
+    "relatedConcepts": ["mellin_cpow_smul", "MellinConvergent.cpow_smul", "spectral shift", "Gamma function"],
+    "prerequisites": ["Mellin transform", "complex powers", "convergence of improper integrals"]
+  },
+  {
+    "id": "ann-shifted-strip",
+    "proofId": "mellin-power-convergence-oq-01-oq-01",
+    "range": { "startLine": 135, "endLine": 145 },
+    "type": "insight",
+    "title": "mellinConvergent_powerIndicator_iff: The Sharp Shifted Strip Re s > −c",
+    "content": "The strip statement that makes the power weight sharp: the Mellin integral of t^c · 𝟙_{(0,1]} converges IF AND ONLY IF Re s > −c — the parent strip Re s > 0 slid rigidly left by c. The proof rewrites powerIndicator as a cpow-smul of the unit indicator, transports the equivalence through MellinConvergent.cpow_smul and the parent's own iff mellinConvergent_unitIndicator_iff, reduces to 0 < Re(s + c) via Complex.add_re and Complex.ofReal_re, and closes both directions with linarith on Re(s + c) = Re s + c. Because both the value and the convergence go through the substitution s ↦ s + c, the strip translates without changing shape — the elementary mechanism behind the leftward march of convergence regions in analytic continuation.",
+    "mathContext": "$\\mathrm{MellinConvergent}\\,(t^c\\,\\mathbb{1}_{(0,1]})\\,s \\iff \\mathrm{Re}\\,s > -c$.",
+    "significance": "key",
+    "relatedConcepts": ["MellinConvergent.cpow_smul", "fundamental strip translation", "Complex.add_re", "analytic continuation"],
+    "prerequisites": ["convergence of improper integrals", "complex powers", "real part arithmetic"]
+  }
+]

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/index.ts
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MellinPowerConvergenceOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const mellinPowerConvergenceOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const mellinPowerConvergenceOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const mellinPowerConvergenceOq01Oq01Data: ProofData = {
+  proof: mellinPowerConvergenceOq01Oq01Proof,
+  annotations: mellinPowerConvergenceOq01Oq01Annotations,
+}

--- a/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/mellin-power-convergence-oq-01-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "mellin-power-convergence-oq-01-oq-01",
+  "title": "General-interval and power-weighted Mellin transforms: (b^s − a^s)/s and the shifted strip Re s > −c",
+  "slug": "mellin-power-convergence-oq-01-oq-01",
+  "description": "Turns the single parent base pair mellin 𝟙_{(0,1]} s = 1/s into a working calculus by closing the two algebraic gaps its open question names. For 0 < a < b and Re s > 0, the Mellin transform of the indicator of a general half-open interval is mellin 𝟙_{(a,b]} s = (b^s − a^s)/s — obtained from the set difference (a,b] = (0,b] ∖ (0,a] by subtracting two parent dilation laws — and at s = 1 it returns the Lebesgue length b − a. For a real exponent c, the power-weighted unit indicator has mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c), with the Mellin integral converging if and only if Re s > −c: absorbing the monomial weight t^c into the exponent slides the parent's fundamental strip Re s > 0 left by c. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Hjalmar Mellin (c. 1900); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MellinPowerConvergenceOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "complex-analysis",
+      "mellin-transform",
+      "integral-transform",
+      "improper-integral",
+      "convergence",
+      "fundamental-strip"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasMellin_sub",
+        "description": "The Mellin transform is additive: if f and g both have Mellin transforms at s, so does f − g, with value the difference — the engine of the general-interval law via the set-difference decomposition",
+        "module": "Mathlib.Analysis.MellinTransform"
+      },
+      {
+        "theorem": "MellinConvergent.cpow_smul",
+        "description": "Convergence of the Mellin integral of t^c • f at s is equivalent to convergence of the Mellin integral of f at s + c — the shift that moves the fundamental strip under a power weight",
+        "module": "Mathlib.Analysis.MellinTransform"
+      },
+      {
+        "theorem": "mellin_cpow_smul",
+        "description": "mellin (fun t => t^c • f t) s = mellin f (s + c) — absorbs the monomial weight into the Mellin exponent",
+        "module": "Mathlib.Analysis.MellinTransform"
+      }
+    ],
+    "originalContributions": [
+      "indicator_Ioc_sub: the pointwise set-difference identity 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} for 0 < a < b, proved by a complete three-way membership case split — the bridge that lets the additive Mellin API see a general interval as a difference of two unit-anchored ones",
+      "hasMellin_indicator_Ioc_pair / mellin_indicator_Ioc_pair: the GENERAL-INTERVAL transform mellin 𝟙_{(a,b]} s = (b^s − a^s)/s for 0 < a < b and Re s > 0, the elementary building block of every piecewise-constant Mellin transform (Perron-type summation, truncated Dirichlet integrals), obtained by subtracting two parent dilation laws (hasMellin_sub) and combining b^s/s − a^s/s = (b^s − a^s)/s",
+      "mellin_indicator_Ioc_pair_one: at s = 1 the general-interval transform returns the Lebesgue length b − a of the interval",
+      "powerIndicator / hasMellin_powerIndicator / mellin_powerIndicator: the POWER-WEIGHTED transform mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c) for real c and Re s > −c, reducing to the parent base case at the shifted argument s + c via mellin_cpow_smul — the prototype for how decay/growth weights translate the convergence strip",
+      "mellinConvergent_powerIndicator_iff: the SHARP shifted strip — the Mellin integral of t^c · 𝟙_{(0,1]} converges if and only if Re s > −c, the parent strip Re s > 0 slid left by c, obtained by transporting the parent's iff through MellinConvergent.cpow_smul"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas and the verified parent entry.",
+    "lineCount": 146,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Mellin transform turns scaling t ↦ at into multiplication by a^{-s}, and the indicator of a unit interval — with transform 1/s — is the atom from which every elementary Mellin computation is assembled. Two operations immediately enlarge that atom into a usable calculus: cutting the interval to an arbitrary range (a,b], which underlies the Perron / truncated-Dirichlet integrals at the heart of analytic number theory, and weighting it by a monomial t^c, which is the mechanism by which decay and growth factors translate the fundamental strip — the same translation that produces the analytic continuation of the Gamma function.",
+    "problemStatement": "The parent entry computes mellin 𝟙_{(0,1]} s = 1/s, its sharp strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s, and asks (open question 1) whether these extend to (i) a general interval 𝟙_{(a,b]}, giving (b^s − a^s)/s, and (ii) a power-weighted indicator t^c · 𝟙_{(0,1]}, shifting the convergence strip to Re s > −c.\n\n**Answers:** (i) For 0 < a < b and Re s > 0, mellin 𝟙_{(a,b]} s = (b^s − a^s)/s, since (a,b] = (0,b] ∖ (0,a] and the transform is additive; at s = 1 this is the length b − a. (ii) For real c, mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c) and the integral converges exactly when Re s > −c — the parent strip translated left by c.",
+    "text": "The general half-open interval (a,b] has Mellin transform (b^s − a^s)/s, and the power-weighted unit indicator t^c · 𝟙_{(0,1]} has transform 1/(s + c) converging precisely on Re s > −c — both reduced to the parent base case, verified with no axioms.",
+    "proofStrategy": "1. indicator_Ioc_sub: prove the pointwise identity 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} by funext and a three-way case split on membership in (0,b] and (0,a], using Set.indicator_of_mem / Set.indicator_of_notMem in each branch.\n2. hasMellin_indicator_Ioc_pair: rewrite by indicator_Ioc_sub, take the two parent dilation results hasMellin_indicator_Ioc at b and at a, subtract them with hasMellin_sub, then rewrite each value via mellin_indicator_Ioc and combine b^s/s − a^s/s = (b^s − a^s)/s with ← sub_div.\n3. mellin_indicator_Ioc_pair_one: specialise to s = 1, where Complex.cpow_one collapses b^1 − a^1 over 1 to b − a.\n4. hasMellin_powerIndicator: from Re s > −c derive 0 < Re(s + c); the convergence half is MellinConvergent.cpow_smul.mpr applied to the parent base case at s + c, and the value half is mellin_cpow_smul followed by mellin_unitIndicator at s + c.\n5. mellinConvergent_powerIndicator_iff: rewrite powerIndicator as a cpow-smul of the unit indicator, transport through MellinConvergent.cpow_smul and the parent's mellinConvergent_unitIndicator_iff, and finish with linarith on the real parts (Re(s + c) = Re s + c).",
+    "keyInsights": [
+      "**A general interval is a difference of unit-anchored ones**: (a,b] = (0,b] ∖ (0,a], so its indicator is 𝟙_{(0,b]} − 𝟙_{(0,a]} and the additive Mellin transform turns the geometric subtraction into the algebraic (b^s − a^s)/s — no new integration, just the linearity of the transform on top of the parent dilation law.",
+      "**A power weight is a shift of the spectral variable**: multiplying by t^c and integrating t^{s-1}·t^c = t^{(s+c)-1} is literally the base computation at the shifted argument s + c. Hence mellin (t^c · 𝟙) s = 1/(s + c), and every statement about the weighted transform is a statement about the unweighted one with s replaced by s + c.",
+      "**The fundamental strip translates rigidly under weighting**: because the value and the convergence both go through the substitution s ↦ s + c, the sharp strip Re s > 0 becomes Re s > −c with no change of shape. This rigid translation is the elementary mechanism behind the leftward march of convergence regions in the analytic continuation of Gamma and Dirichlet series.",
+      "**At s = 1 the transform is still the measure**: the general-interval transform returns b − a, the Lebesgue length of (a,b], extending the parent's a^1 = a to an honest difference of endpoints and keeping a^s/s-type kernels anchored to elementary geometry."
+    ],
+    "prerequisites": [
+      "The parent entry: mellin 𝟙_{(0,1]} s = 1/s, its strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s",
+      "Additivity of the Mellin transform (hasMellin_sub) and the power-weight shift API (mellin_cpow_smul, MellinConvergent.cpow_smul)",
+      "Indicator functions, set differences, and three-way membership case analysis",
+      "Complex powers t ↦ t^s and the translation of real parts Re(s + c) = Re s + c"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "File-level docstring framing the two gaps left by the parent: the general half-open interval (a,b] and the power-weighted unit indicator. Imports Mathlib and the parent entry, opens the parent namespace.",
+      "mathContext": "Extending the base pair mellin 𝟙_{(0,1]} s = 1/s into a calculus of intervals and weights."
+    },
+    {
+      "id": "set-difference",
+      "title": "Set-Difference Decomposition",
+      "startLine": 44,
+      "endLine": 77,
+      "summary": "indicator_Ioc_sub: for 0 < a < b, 𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]} pointwise, via a complete three-way membership case split.",
+      "mathContext": "(a,b] = (0,b] ∖ (0,a]; the indicator of a general interval as a difference of unit-anchored indicators."
+    },
+    {
+      "id": "general-interval",
+      "title": "General-Interval Transform (b^s − a^s)/s",
+      "startLine": 78,
+      "endLine": 107,
+      "summary": "hasMellin_indicator_Ioc_pair and mellin_indicator_Ioc_pair: for 0 < a < b and Re s > 0, mellin 𝟙_{(a,b]} s = (b^s − a^s)/s, by subtracting two parent dilation laws with hasMellin_sub; mellin_indicator_Ioc_pair_one returns the length b − a at s = 1.",
+      "mathContext": "Additivity of the transform converts (0,b] ∖ (0,a] into b^s/s − a^s/s = (b^s − a^s)/s."
+    },
+    {
+      "id": "power-weight",
+      "title": "Power-Weighted Unit Indicator 1/(s + c)",
+      "startLine": 109,
+      "endLine": 133,
+      "summary": "powerIndicator c = t^c • 𝟙_{(0,1]}; hasMellin_powerIndicator and mellin_powerIndicator: for real c and Re s > −c, its transform exists and equals 1/(s + c), reducing to the parent base case at the shifted argument s + c.",
+      "mathContext": "t^{s-1}·t^c = t^{(s+c)-1}: the monomial weight is absorbed into the Mellin exponent."
+    },
+    {
+      "id": "shifted-strip",
+      "title": "Sharp Shifted Convergence Strip Re s > −c",
+      "startLine": 135,
+      "endLine": 146,
+      "summary": "mellinConvergent_powerIndicator_iff: the Mellin integral of t^c · 𝟙_{(0,1]} converges if and only if Re s > −c, transporting the parent's iff through MellinConvergent.cpow_smul.",
+      "mathContext": "The parent strip Re s > 0 slides left by c under the weight t^c."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Mellin, Hjalmar",
+      "title": "Über die fundamentale Wichtigkeit des Satzes von Cauchy für die Theorien der Gamma- und der hypergeometrischen Funktionen",
+      "year": "1896",
+      "note": "Acta Societatis Scientiarum Fennicae — early development of the transform now bearing his name"
+    },
+    {
+      "authors": "Flajolet, Philippe; Gourdon, Xavier; Dumas, Philippe",
+      "title": "Mellin transforms and asymptotics: Harmonic sums",
+      "year": "1995",
+      "note": "Theoretical Computer Science 144 — the fundamental strip, its translation under monomial weights, and piecewise-constant transforms"
+    },
+    {
+      "authors": "Titchmarsh, E. C.",
+      "title": "Introduction to the Theory of Fourier Integrals",
+      "year": "1948",
+      "note": "Chapter I — the Mellin transform, its strip of convergence, and the effect of power weights"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "mellin-power-convergence-oq-01",
+      "title": "The Mellin transform of the unit indicator: convergence strip and scaling law",
+      "relation": "Parent entry. Supplies the base pair mellin 𝟙_{(0,1]} s = 1/s, the sharp strip Re s > 0, and the dilation law mellin 𝟙_{(0,a]} s = a^s/s; this entry answers its first open question by extending to general intervals and power weights."
+    }
+  ],
+  "conclusion": {
+    "summary": "Extending the parent base pair into a calculus: for 0 < a < b and Re s > 0 the general half-open interval has mellin 𝟙_{(a,b]} s = (b^s − a^s)/s (hasMellin_indicator_Ioc_pair), returning the length b − a at s = 1; and for real c the power-weighted unit indicator has mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c) (hasMellin_powerIndicator), converging exactly on the shifted strip Re s > −c (mellinConvergent_powerIndicator_iff). Both reduce to the verified parent — the first by additivity over a set difference, the second by a shift of the spectral variable — and are verified with 0 axioms and 0 sorries.",
+    "implications": "Closes the parent's first open question and gives the gallery the two algebraic operations that turn the single 1/s atom into a working tool: arbitrary cut-offs (the building block of Perron-type and truncated-Dirichlet integrals) and monomial weights (the mechanism that translates the fundamental strip in the analytic continuation of Gamma and Dirichlet series).",
+    "openQuestions": [
+      "Can the general-interval and power-weight results be combined and iterated to give the Mellin transform of an arbitrary step function ∑ cᵢ 𝟙_{(aᵢ,bᵢ]} as ∑ cᵢ (bᵢ^s − aᵢ^s)/s, the finite-sum Perron kernel?",
+      "Does the meromorphic continuation of 1/(s + c) — a simple pole at s = −c with residue 1 — admit a clean formalization linking the leftward translation of the strip under t^c to the pole's position, as a first step toward the analytic continuation of the Gamma integral?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MellinPowerConvergenceOQ01"
+    ],
+    "opens": [
+      "Complex",
+      "MeasureTheory",
+      "Set",
+      "MellinPowerConvergenceOQ01"
+    ],
+    "namespace": "MellinPowerConvergenceOQ01OQ01",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/MellinPowerConvergenceOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `mellin-power-convergence-oq-01` verbatim, turning its single base pair `mellin 𝟙_{(0,1]} s = 1/s` into a working calculus by closing the two algebraic gaps the open question names.

**(i) General half-open interval** — for `0 < a < b` and `Re s > 0`,
```
mellin 𝟙_{(a,b]} s = (b^s − a^s)/s
```
Since `(a,b] = (0,b] ∖ (0,a]`, the pointwise identity `𝟙_{(a,b]} = 𝟙_{(0,b]} − 𝟙_{(0,a]}` (`indicator_Ioc_sub`, a complete three-way membership split) feeds the **additive** Mellin transform (`hasMellin_sub`), so subtracting two parent dilation laws gives `b^s/s − a^s/s = (b^s − a^s)/s` — no new integration. At `s = 1` it returns the Lebesgue length `b − a`. This is the building block of every piecewise-constant / Perron-type Mellin transform.

**(ii) Power-weighted unit indicator** — for real `c` and `Re s > −c`,
```
mellin (t^c · 𝟙_{(0,1]}) s = 1/(s + c),   converges  ⟺  Re s > −c
```
Absorbing the monomial weight into the exponent (`t^{s-1}·t^c = t^{(s+c)-1}`) reduces the whole computation to the parent base case at the shifted argument `s + c` (`mellin_cpow_smul`, `MellinConvergent.cpow_smul`). The fundamental strip `Re s > 0` slides **rigidly left by c** — the elementary mechanism behind the leftward march of convergence in the analytic continuation of Γ.

## Verification
- **Status:** verified · **badge:** original
- **0 axioms** (`propext` / `Classical.choice` / `Quot.sound` only — checked via `#print axioms`), **0 sorries**, no `native_decide`
- 7 theorems, 1 definition, 146 lines
- Builds against pinned Mathlib v4.26 on top of the verified parent
- Gallery: new `src/data/proofs/mellin-power-convergence-oq-01-oq-01/` (meta + 6 annotations, all line-resolved clean); registered in build-generated listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)