### PR TITLE
Enrich Fast Zeta Transform Correctness (inclusion-exclusion-oq-03-oq-01): add annotations

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-03-oq-01/annotations.json
@@ -1,0 +1,180 @@
+[
+  {
+    "id": "iexc-oq0301-fold-defs",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 54, "endLine": 61 },
+    "type": "definition",
+    "title": "The SOS step folded over the ground set",
+    "content": "`zetaFoldList l f := l.foldr zetaStep f` processes the elements of l one at a time, applying the parent's single-element SOS update for each — `zetaFoldList [a₁,…,aₙ] f = ζ_{a₁}(ζ_{a₂}(⋯ζ_{aₙ} f))`. `zetaFold f := zetaFoldList univ.toList f` runs the whole sweep over every element of the finite type. This fold IS the O(n·2ⁿ) fast subset-sum dynamic program; the rest of the file proves it computes the zeta transform. Both are `noncomputable` only because SubsetFn lands in ℤ-valued functions on Finsets, not for any deep reason.",
+    "mathContext": "$\\mathrm{zetaFold}\\,f = \\zeta_{a_1}\\!\\bigl(\\zeta_{a_2}(\\cdots \\zeta_{a_n} f)\\bigr),\\quad \\{a_1,\\dots,a_n\\}=\\alpha.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.foldr",
+      "sum-over-subsets DP",
+      "Yates's algorithm",
+      "fast zeta transform"
+    ],
+    "prerequisites": [
+      "parent zetaStep and its pointwise laws",
+      "List.foldr",
+      "Finset.univ.toList"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-invariant",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 67, "endLine": 78 },
+    "type": "theorem",
+    "title": "The partial-sweep invariant",
+    "content": "`zetaFoldList_apply`: for any duplicate-free list l and every S, the running value at S after folding equals ∑ over T with S \\ l.toFinset ⊆ T ⊆ S of f(T) — exactly the subsets of S that still agree with S on the not-yet-processed coordinates. This is the right strengthening of the goal: the bare statement zetaFold f S = ∑_{T⊆S} f(T) is not directly inductive, but the constraint-carrying version is. The full correctness theorem is the special case l = univ.toList, where S \\ univ = ∅ removes the constraint.",
+    "mathContext": "$(\\,l.\\mathrm{foldr}\\,\\zeta_\\bullet\\,f\\,)(S) = \\sum_{\\,S\\setminus l \\,\\subseteq\\, T \\,\\subseteq\\, S} f(T).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "loop invariant",
+      "induction on lists",
+      "Finset.powerset / filter",
+      "Finset.sdiff"
+    ],
+    "prerequisites": [
+      "List.Nodup",
+      "Finset.sdiff and subset filters",
+      "strengthening an induction hypothesis"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-base-case",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 81, "endLine": 89 },
+    "type": "technique",
+    "title": "Base case: the empty sweep isolates S",
+    "content": "With l = [], the constraint set is S \\ ∅ = S, so the filter {T ⊆ S : S ⊆ T} forces T = S by antisymmetry (le_antisymm of S ⊆ T and T ⊆ S), collapsing the sum to the single term f(S). This matches zetaFoldList [] f = f exactly — no element has been absorbed yet, so the array still holds the raw input.",
+    "mathContext": "$S\\setminus\\varnothing = S;\\quad \\{T : S\\subseteq T\\subseteq S\\}=\\{S\\};\\quad \\sum = f(S).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "le_antisymm",
+      "Finset.filter singleton",
+      "Finset.sum_singleton"
+    ],
+    "prerequisites": [
+      "antisymmetry of ⊆",
+      "Finset.sdiff_empty"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-cons-step",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 90, "endLine": 101 },
+    "type": "technique",
+    "title": "Inductive step: one fresh element, two cases",
+    "content": "Processing l = a :: rest peels off one fold step: zetaFoldList (a::rest) f S = zetaStep a (zetaFoldList rest f) S. `List.nodup_cons` supplies a ∉ rest (hence a ∉ rest.toFinset) — duplicate-freeness is consumed here so each element is absorbed exactly once and the keep-a/drop-a split stays disjoint. The proof then branches on whether a ∈ S, since zetaStep only acts on sets containing a.",
+    "mathContext": "$\\mathrm{zetaFoldList}\\,(a::\\mathit{rest})\\,f\\,S = \\zeta_a\\bigl(\\mathrm{zetaFoldList}\\,\\mathit{rest}\\,f\\bigr)(S).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.nodup_cons",
+      "List.foldr_cons",
+      "List.toFinset_cons",
+      "case split on membership"
+    ],
+    "prerequisites": [
+      "List induction",
+      "List.Nodup decomposition"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-sos-recurrence",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 102, "endLine": 133 },
+    "type": "insight",
+    "title": "The SOS recurrence as a sum partition by membership of a",
+    "content": "The heart of the proof. When a ∈ S, zetaStep_mem gives value(S) + value(S.erase a); applying the IH to both turns the goal into showing the target index set {T : (S\\rest).erase a ⊆ T ⊆ S} partitions by 'does T contain a' into exactly the keep-a part (hP1, equal to the S index set — a is forced in via insert_erase) and the drop-a part (hP2, equal to the (S.erase a) index set, using sdiff_insert: S \\ insert a rest = (S\\rest).erase a). `Finset.sum_filter_add_sum_filter_not` then turns that disjoint partition into the additive recurrence with zero arithmetic — the SOS update f(S) = f(S) + f(S\\{a}) is purely a re-indexing of subsets.",
+    "mathContext": "$\\sum_{(S\\setminus r).\\mathrm{erase}\\,a\\,\\subseteq T\\subseteq S}\\!\\! f(T) = \\sum_{a\\in T}\\!f(T) + \\sum_{a\\notin T}\\!f(T).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_filter_add_sum_filter_not",
+      "Finset.sdiff_insert",
+      "Finset.insert_erase",
+      "subset re-indexing"
+    ],
+    "prerequisites": [
+      "zetaStep_mem (parent)",
+      "partitioning a Finset sum by a predicate",
+      "Finset.erase / sdiff identities"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-untouched-branch",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 134, "endLine": 136 },
+    "type": "technique",
+    "title": "Skipping an element not in S",
+    "content": "When a ∉ S the step leaves S untouched (zetaStep_not_mem), so only the constraint set must be reconciled: S \\ insert a rest = (S \\ rest).erase a by sdiff_insert, and erasing a from S \\ rest is a no-op because a ∉ S \\ rest (Finset.erase_eq_of_notMem). The invariant is therefore unchanged, matching the IH directly.",
+    "mathContext": "$a\\notin S\\Rightarrow S\\setminus\\mathrm{insert}\\,a\\,r = S\\setminus r;\\quad \\zeta_a\\,g\\,S = g\\,S.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "zetaStep_not_mem (parent)",
+      "Finset.erase_eq_of_notMem",
+      "Finset.sdiff_insert"
+    ],
+    "prerequisites": [
+      "Finset membership lemmas"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-correctness",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 142, "endLine": 161 },
+    "type": "theorem",
+    "title": "Fast zeta transform correctness",
+    "content": "`zetaFold_eq_zetaTransform`: folding the SOS step over every element equals the full zeta transform. Specializing zetaFoldList_apply to l = univ.toList (duplicate-free by Finset.nodup_toList), the constraint S \\ univ.toFinset = S \\ univ = ∅ (via sdiff_eq_empty_iff_subset and subset_univ), so filter_true_of_mem drops it and the sum runs over all of S.powerset — precisely ζf(S) = ∑_{T⊆S} f(T). This is the correctness statement of the O(n·2ⁿ) fast subset-sum DP, the parent's open question #1.",
+    "mathContext": "$\\mathrm{zetaFold}\\,f = \\zeta f;\\qquad S\\setminus\\mathrm{univ}=\\varnothing\\ \\Rightarrow\\ \\text{filter is vacuous}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.nodup_toList",
+      "Finset.sdiff_eq_empty_iff_subset",
+      "Finset.filter_true_of_mem",
+      "zeta transform"
+    ],
+    "prerequisites": [
+      "the partial-sweep invariant above",
+      "Finset.subset_univ",
+      "Finset.powerset"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-pointwise",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 163, "endLine": 166 },
+    "type": "theorem",
+    "title": "Pointwise corollary",
+    "content": "`zetaFold_apply`: the value form zetaFold f S = ∑_{T ∈ S.powerset} f(T), an immediate `rfl` after rewriting with the correctness theorem. This is the shape most directly usable when reasoning about a single output cell of the DP.",
+    "mathContext": "$\\mathrm{zetaFold}\\,f\\,S = \\sum_{T\\subseteq S} f(T).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pointwise evaluation",
+      "Finset.powerset"
+    ],
+    "prerequisites": [
+      "zetaFold_eq_zetaTransform"
+    ]
+  },
+  {
+    "id": "iexc-oq0301-mobius-inverse",
+    "proofId": "inclusion-exclusion-oq-03-oq-01",
+    "range": { "startLine": 168, "endLine": 172 },
+    "type": "theorem",
+    "title": "The fast fold is inverted by Möbius",
+    "content": "`mobius_inverts_zetaFold`: applying the parent's Möbius inversion to the fast fold recovers f, i.e. μ(zetaFold f) = f. Since zetaFold f = zetaTransform f, this is just mobius_inverts_zeta transported across the correctness theorem. The upshot is a fully verified forward-and-inverse fast transform pair — the same fold computing ζ, inverted exactly by μ — the subset-lattice analogue of FFT/inverse-FFT.",
+    "mathContext": "$\\mu\\bigl(\\mathrm{zetaFold}\\,f\\bigr) = f.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Möbius inversion",
+      "mobius_inverts_zeta (parent)",
+      "inverse transform pair",
+      "subset convolution"
+    ],
+    "prerequisites": [
+      "parent's mobiusTransform and mobius_inverts_zeta",
+      "zetaFold_eq_zetaTransform"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `inclusion-exclusion-oq-03-oq-01` (quality 41, 0 prior passes).

## Gap addressed
This entry already had a rich `overview`, `sections`, `references`, and `conclusion`, but **shipped with no `annotations.json` at all** — the proof page had zero inline annotations. This PR creates it.

## What was added
`annotations.json` with **9 annotations** (full canonical schema: `proofId`, `range`, `content`, `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the whole 174-line proof:
1. the fold definitions (`zetaFoldList` / `zetaFold`) — the fast subset-sum DP itself
2. the partial-sweep invariant `zetaFoldList_apply` (the load-bearing strengthening)
3. base case (empty sweep isolates S)
4. inductive cons step (one fresh element, Nodup consumed)
5. the SOS recurrence as a sum-partition by membership of `a` (the heart — `sum_filter_add_sum_filter_not`)
6. the `a ∉ S` skip branch
7. `zetaFold_eq_zetaTransform` correctness (S \\ univ = ∅ collapses the constraint)
8. `zetaFold_apply` pointwise corollary
9. `mobius_inverts_zetaFold` (verified forward/inverse fast transform pair)

## Verification
- `pnpm annotations:build` runs clean: **no "No Lean construct found" warnings** — all 9 ranges resolve to real Lean constructs.
- Axiom integrity preserved: `verified`/`original`, 0 axioms, 0 sorries.

Branch named per-target to keep this PR independent of the agent's other open enrichment PRs.