### PR TITLE
research(abel-ruffini-oq-04-oq-01): prove simple quotient ⇔ maximal normal (IsMaxNorm/IsSimpleGroup bridge)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -594,6 +594,7 @@ import Proofs.CantorsTheoremOQ03OQ02
 import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CarnotTheoremOQ01OQ01
+import Proofs.CarnotTheoremOQ01OQ01OQ01
 import Proofs.CarnotTheoremOQ01OQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ02
 import Proofs.CarnotTheoremOQ01OQ03

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean
@@ -1,0 +1,121 @@
+/-
+  Abel–Ruffini / Galois extensions, Jordan–Hölder branch (oq-04), open
+  question oq-01:
+
+      "Mathlib contribution: can `JordanHolderLattice (Subgroup G)` be
+       contributed upstream? The main challenge is generalizing the `IsMaxNorm`
+       predicate to work with `IsSimpleGroup (K ⧸ H)` directly."
+
+  The parent entry (`AbelRuffiniGaloisExtensionsOQ04`) defines a combinatorial
+  predicate `IsMaxNorm H K` ("H is a maximal normal subgroup of K") and remarks
+  that it is *equivalent* to `IsSimpleGroup (K ⧸ H.subgroupOf K)` "by the
+  correspondence theorem, but avoids quotient typeclass issues" — without
+  proving that equivalence.
+
+  This file proves exactly that bridge in the essential case `K = ⊤`,
+  axiom-free: a normal subgroup `N ◁ G` has a *simple quotient* `G ⧸ N` iff it
+  is a *maximal normal subgroup* of `G`. The proof is short because it routes
+  everything through Mathlib's fourth isomorphism / correspondence theorem
+  (`QuotientGroup.comapMk'OrderIso`) rather than re-deriving the lattice
+  correspondence.
+
+  Main results:
+    * `isSimpleGroup_quotient_iff` — `IsSimpleGroup (G ⧸ N) ↔ N` is maximal
+      among proper normal subgroups;
+    * `isSimpleGroup_quotient_iff_isMaximalNormal` — the packaged form using the
+      `IsMaximalNormal` predicate;
+    * `IsMaximalNormal.isSimpleGroup_quotient` / `.of_isSimpleGroup_quotient`
+      — the two directions as standalone lemmas.
+
+  This settles the `IsMaxNorm`↔`IsSimpleGroup` correspondence that the open
+  question identifies as the crux; the fully general `K`/`subgroupOf` version
+  (working inside the subtype group `↥K`) is left for the upstream Mathlib
+  development.
+-/
+
+import Mathlib
+
+open Subgroup QuotientGroup
+
+namespace AbelRuffiniGaloisExtensionsOQ04OQ01
+
+variable {G : Type*} [Group G]
+
+/-- `N` is a **maximal normal subgroup** of `G`: normal, proper, and not strictly
+contained in any proper normal subgroup. (The `K = ⊤` instance of the parent
+entry's `IsMaxNorm`.) -/
+def IsMaximalNormal (N : Subgroup G) : Prop :=
+  N.Normal ∧ N ≠ ⊤ ∧ ∀ M : Subgroup G, N ≤ M → M.Normal → M = N ∨ M = ⊤
+
+/-- **Simple quotient ⇔ maximal normal subgroup.**
+
+For a normal subgroup `N ◁ G`, the quotient `G ⧸ N` is simple if and only if
+`N` is proper and maximal among proper normal subgroups. This is the
+`IsMaxNorm`/`IsSimpleGroup` correspondence (for `K = ⊤`) flagged by oq-01. -/
+theorem isSimpleGroup_quotient_iff (N : Subgroup G) [N.Normal] :
+    IsSimpleGroup (G ⧸ N) ↔
+      N ≠ ⊤ ∧ ∀ M : Subgroup G, N ≤ M → M.Normal → M = N ∨ M = ⊤ := by
+  rw [isSimpleGroup_iff]
+  constructor
+  · rintro ⟨hnt, hbt⟩
+    refine ⟨?_, ?_⟩
+    · -- `N ≠ ⊤`, else the quotient is trivial.
+      intro hN
+      subst hN
+      exact (not_subsingleton (G ⧸ (⊤ : Subgroup G))) subsingleton_quotient_top
+    · intro M hNM hM
+      -- Push `M` into the quotient; normal, so `⊥` or `⊤`.
+      rcases hbt (M.map (mk' N)) inferInstance with h | h
+      · left
+        have hc : Subgroup.comap (mk' N) (M.map (mk' N))
+            = Subgroup.comap (mk' N) (⊥ : Subgroup (G ⧸ N)) := by rw [h]
+        rw [comap_map_mk' N M, MonoidHom.comap_bot, ker_mk', sup_eq_right.mpr hNM] at hc
+        exact hc
+      · right
+        have hc : Subgroup.comap (mk' N) (M.map (mk' N))
+            = Subgroup.comap (mk' N) (⊤ : Subgroup (G ⧸ N)) := by rw [h]
+        rw [comap_map_mk' N M, comap_top, sup_eq_right.mpr hNM] at hc
+        exact hc
+  · rintro ⟨hNtop, hmax⟩
+    refine ⟨?_, ?_⟩
+    · -- `G ⧸ N` is nontrivial because `N ≠ ⊤`.
+      have hns : ¬ Subsingleton (G ⧸ N) :=
+        fun h => hNtop (subgroup_eq_top_of_subsingleton N h)
+      exact not_subsingleton_iff_nontrivial.mp hns
+    · intro H' hH'
+      -- Pull `H'` back; it is normal and contains `N`, so equals `N` or `⊤`.
+      have hcN : N ≤ Subgroup.comap (mk' N) H' := le_comap_mk' N H'
+      rcases hmax (Subgroup.comap (mk' N) H') hcN inferInstance with h | h
+      · left
+        -- `comap H' = N = comap ⊥`, and `comap` (the correspondence map) is injective.
+        have hb : Subgroup.comap (mk' N) (⊥ : Subgroup (G ⧸ N)) = N := by
+          rw [MonoidHom.comap_bot, ker_mk']
+        apply (comapMk'OrderIso N).injective
+        apply Subtype.ext
+        simp only [comapMk'OrderIso, RelIso.coe_fn_mk, Equiv.coe_fn_mk]
+        rw [h, hb]
+      · right
+        have ht : Subgroup.comap (mk' N) (⊤ : Subgroup (G ⧸ N)) = ⊤ := comap_top _
+        apply (comapMk'OrderIso N).injective
+        apply Subtype.ext
+        simp only [comapMk'OrderIso, RelIso.coe_fn_mk, Equiv.coe_fn_mk]
+        rw [h, ht]
+
+/-- The packaged equivalence with the `IsMaximalNormal` predicate. -/
+theorem isSimpleGroup_quotient_iff_isMaximalNormal (N : Subgroup G) [hN : N.Normal] :
+    IsSimpleGroup (G ⧸ N) ↔ IsMaximalNormal N := by
+  rw [isSimpleGroup_quotient_iff N, IsMaximalNormal]
+  exact ⟨fun h => ⟨hN, h.1, h.2⟩, fun h => ⟨h.2.1, h.2.2⟩⟩
+
+/-- A maximal normal subgroup has a simple quotient. -/
+theorem IsMaximalNormal.isSimpleGroup_quotient {N : Subgroup G} (h : IsMaximalNormal N) :
+    haveI := h.1; IsSimpleGroup (G ⧸ N) := by
+  haveI := h.1
+  exact (isSimpleGroup_quotient_iff_isMaximalNormal N).mpr h
+
+/-- If `G ⧸ N` is simple (with `N` normal) then `N` is a maximal normal subgroup. -/
+theorem IsMaximalNormal.of_isSimpleGroup_quotient {N : Subgroup G} [N.Normal]
+    (h : IsSimpleGroup (G ⧸ N)) : IsMaximalNormal N :=
+  (isSimpleGroup_quotient_iff_isMaximalNormal N).mp h
+
+end AbelRuffiniGaloisExtensionsOQ04OQ01

--- a/proofs/Proofs/CarnotTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CarnotTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,221 @@
+import Mathlib
+import Proofs.CarnotTheorem
+
+/-
+# Carnot's Theorem — the metric signed-distance form with an explicit circumcenter
+
+The parent files work entirely in the *angle* form.  `CarnotTheorem.lean`
+proves
+
+  `cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)`,
+
+and `CarnotTheoremOQ01OQ01.lean` pins down the range of that cosine sum.  Both
+live in a bespoke trigonometric encoding: there is no actual triangle, no
+circumcenter, and no perpendicular distances — only three reals summing to `π`.
+
+The parent's open question asks whether the genuinely *geometric* statement can
+be formalized:
+
+  > Can the metric signed-distance form with an explicit circumcenter over
+  > `EuclideanSpace ℝ (Fin 2)` be formalized?
+
+This file answers **yes**.  We build the triangle concretely in the Euclidean
+plane `EuclideanSpace ℝ (Fin 2)`:
+
+* the circumcenter is the **explicit point** `O = (0, 0)`;
+* the three vertices `Pa, Pb, Pc` sit on the circle of radius `R` about `O`,
+  placed by the inscribed-angle convention so that side `BC` subtends central
+  angle `2A`, etc.;
+* `O` is verified to be the circumcenter: `dist O Pa = dist O Pb = dist O Pc = R`
+  (`circumradius`);
+* for each side we exhibit the inward unit normal and take Mathlib's
+  `signedDist` (the trilinear signed distance, `⟪normalize v, q -ᵥ p⟫`) from `O`
+  to that side.
+
+The geometric heart is that each signed distance is exactly `R cos` of the
+opposite angle:
+
+  `signedDist (na A) Pc O = R cos A`   (`dA_eq`),  and similarly `R cos B`, `R cos C`,
+
+with the cosine carrying the correct sign automatically — negative precisely
+when the circumcenter falls on the far side of an obtuse angle's opposite side.
+We also certify each normal really is perpendicular to its side (`na_perp`,
+`nb_perp`, `nc_perp`).
+
+Summing and feeding the parent identity through gives **Carnot's theorem in
+metric form**:
+
+  `signedDist_a + signedDist_b + signedDist_c = R + r`,
+
+where `r = 4 R sin(A/2) sin(B/2) sin(C/2)` is the inradius
+(`carnot_signedDist_sum`).
+
+**No axioms, no sorries.**
+-/
+
+open Real NormedSpace
+open scoped RealInnerProductSpace
+
+namespace CarnotTheoremOQ01OQ01OQ01
+
+/-- The Euclidean plane. -/
+abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
+
+/-! ## Coordinate helpers -/
+
+/-- The norm of an explicit plane vector. -/
+private lemma norm_two (a b : ℝ) :
+    ‖(!₂[a, b] : Vec2)‖ = Real.sqrt (a ^ 2 + b ^ 2) := by
+  rw [EuclideanSpace.norm_eq, Fin.sum_univ_two]
+  simp [Real.norm_eq_abs, sq_abs]
+
+/-- A vector `(a, b)` with `a² + b² = 1` is a unit vector. -/
+private lemma norm_unit (a b : ℝ) (h : a ^ 2 + b ^ 2 = 1) :
+    ‖(!₂[a, b] : Vec2)‖ = 1 := by
+  rw [norm_two, h, Real.sqrt_one]
+
+/-- A point on the circle of radius `r` has norm `r`. -/
+private lemma norm_circle (r t : ℝ) (hr : 0 ≤ r) :
+    ‖(!₂[r * Real.cos t, r * Real.sin t] : Vec2)‖ = r := by
+  rw [norm_two,
+    show (r * Real.cos t) ^ 2 + (r * Real.sin t) ^ 2 = r ^ 2 by
+      nlinarith [Real.sin_sq_add_cos_sq t]]
+  exact Real.sqrt_sq hr
+
+/-- The inner product of two explicit plane vectors. -/
+private lemma inner_two (a b c d : ℝ) :
+    ⟪(!₂[a, b] : Vec2), !₂[c, d]⟫ = a * c + b * d := by
+  have h : ⟪(!₂[a, b] : Vec2), !₂[c, d]⟫ = c * a + d * b := by
+    simp [PiLp.inner_apply, Fin.sum_univ_two]
+  rw [h]; ring
+
+/-! ## The configuration -/
+
+/-- The circumcenter, placed at the origin. -/
+def O : Vec2 := 0
+
+/-- Vertex `A`, at position angle `2A + 2C` (so arc `CA = 2B`). -/
+noncomputable def Pa (R A C : ℝ) : Vec2 := !₂[R * Real.cos (2 * A + 2 * C), R * Real.sin (2 * A + 2 * C)]
+
+/-- Vertex `B`, at position angle `2A`. -/
+noncomputable def Pb (R A : ℝ) : Vec2 := !₂[R * Real.cos (2 * A), R * Real.sin (2 * A)]
+
+/-- Vertex `C`, at position angle `0`. -/
+def Pc (R : ℝ) : Vec2 := !₂[R, 0]
+
+/-- Inward unit normal to side `BC` (pointing toward `A`); midangle of `BC` is `A`. -/
+noncomputable def na (A : ℝ) : Vec2 := !₂[-Real.cos A, -Real.sin A]
+
+/-- Inward unit normal to side `CA` (pointing toward `B`); midangle of `CA` is `-B`. -/
+noncomputable def nb (B : ℝ) : Vec2 := !₂[-Real.cos B, Real.sin B]
+
+/-- Inward unit normal to side `AB` (pointing toward `C`); midangle of `AB` is `2A + C`. -/
+noncomputable def nc (A C : ℝ) : Vec2 := !₂[-Real.cos (2 * A + C), -Real.sin (2 * A + C)]
+
+/-! ## The circumcenter is genuine: equidistant from all three vertices -/
+
+/-- `O` is the circumcenter: it is equidistant (`= R`) from the three vertices. -/
+theorem circumradius (R A C : ℝ) (hR : 0 ≤ R) :
+    dist O (Pa R A C) = R ∧ dist O (Pb R A) = R ∧ dist O (Pc R) = R := by
+  refine ⟨?_, ?_, ?_⟩ <;>
+    rw [dist_eq_norm, O, zero_sub, norm_neg]
+  · exact norm_circle R (2 * A + 2 * C) hR
+  · exact norm_circle R (2 * A) hR
+  · rw [Pc, norm_two]
+    rw [show (R : ℝ) ^ 2 + (0 : ℝ) ^ 2 = R ^ 2 by ring, Real.sqrt_sq hR]
+
+/-! ## The normals are unit vectors and perpendicular to their sides -/
+
+private lemma norm_na (A : ℝ) : ‖na A‖ = 1 := by
+  rw [na]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq A])
+
+private lemma norm_nb (B : ℝ) : ‖nb B‖ = 1 := by
+  rw [nb]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq B])
+
+private lemma norm_nc (A C : ℝ) : ‖nc A C‖ = 1 := by
+  rw [nc]; exact norm_unit _ _ (by nlinarith [Real.sin_sq_add_cos_sq (2 * A + C)])
+
+/-- `na` is perpendicular to side `BC` (direction `Pc - Pb`). -/
+theorem na_perp (R A : ℝ) : ⟪na A, Pc R - Pb R A⟫ = 0 := by
+  rw [inner_sub_right, na, Pc, Pb, inner_two, inner_two]
+  have h : Real.cos A * Real.cos (2 * A) + Real.sin A * Real.sin (2 * A) = Real.cos A := by
+    rw [← Real.cos_sub, show A - 2 * A = -A by ring, Real.cos_neg]
+  linear_combination R * h
+
+/-- `nb` is perpendicular to side `CA` (direction `Pa - Pc`). -/
+theorem nb_perp (R A B C : ℝ) (h : A + B + C = π) :
+    ⟪nb B, Pa R A C - Pc R⟫ = 0 := by
+  rw [inner_sub_right, nb, Pa, Pc, inner_two, inner_two]
+  -- `B + (2A+2C) = 2π - B`, so `cos B cos(2A+2C) - sin B sin(2A+2C) = cos(2π - B) = cos B`.
+  have key : Real.cos B * Real.cos (2 * A + 2 * C)
+        - Real.sin B * Real.sin (2 * A + 2 * C) = Real.cos B := by
+    rw [← Real.cos_add, show B + (2 * A + 2 * C) = 2 * π - B by linarith, Real.cos_sub]
+    simp [Real.cos_two_pi, Real.sin_two_pi]
+  linear_combination (-R) * key
+
+/-- `nc` is perpendicular to side `AB` (direction `Pa - Pb`). -/
+theorem nc_perp (R A C : ℝ) :
+    ⟪nc A C, Pa R A C - Pb R A⟫ = 0 := by
+  rw [inner_sub_right, nc, Pa, Pb, inner_two, inner_two]
+  -- midangle of `AB` is `2A + C`; both endpoints are equidistant in angle from it.
+  have ha : Real.cos (2 * A + C) * Real.cos (2 * A + 2 * C)
+        + Real.sin (2 * A + C) * Real.sin (2 * A + 2 * C) = Real.cos C := by
+    rw [← Real.cos_sub, show (2 * A + C) - (2 * A + 2 * C) = -C by ring, Real.cos_neg]
+  have hb : Real.cos (2 * A + C) * Real.cos (2 * A)
+        + Real.sin (2 * A + C) * Real.sin (2 * A) = Real.cos C := by
+    rw [← Real.cos_sub]; congr 1; ring
+  linear_combination (-R) * ha + R * hb
+
+/-! ## The signed distances are `R cos` of the opposite angle -/
+
+/-- **Signed distance from the circumcenter to side `BC` equals `R cos A`.** -/
+theorem dA_eq (R A : ℝ) : signedDist (na A) (Pc R) O = R * Real.cos A := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_na A), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, na, Pc]
+  rw [inner_two]; ring
+
+/-- **Signed distance from the circumcenter to side `CA` equals `R cos B`.** -/
+theorem dB_eq (R B : ℝ) : signedDist (nb B) (Pc R) O = R * Real.cos B := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_nb B), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, nb, Pc]
+  rw [inner_two]; ring
+
+/-- **Signed distance from the circumcenter to side `AB` equals `R cos C`.** -/
+theorem dC_eq (R A C : ℝ) : signedDist (nc A C) (Pb R A) O = R * Real.cos C := by
+  rw [signedDist_apply_apply, normalize_eq_self_of_norm_eq_one (norm_nc A C), vsub_eq_sub]
+  simp only [O, zero_sub, inner_neg_right, nc, Pb]
+  rw [inner_two]
+  have hcos : Real.cos (2 * A + C) * Real.cos (2 * A)
+        + Real.sin (2 * A + C) * Real.sin (2 * A) = Real.cos C := by
+    rw [← Real.cos_sub]; congr 1; ring
+  linear_combination R * hcos
+
+/-! ## Carnot's theorem, metric form -/
+
+/-- **Carnot's theorem (metric signed-distance form).**
+
+For a triangle with angles `A, B, C > 0` (`A + B + C = π`) and circumradius
+`R > 0`, realized explicitly in `EuclideanSpace ℝ (Fin 2)` with circumcenter
+`O = (0,0)`, the sum of the signed perpendicular distances from `O` to the three
+sides equals `R + r`, where `r = 4 R sin(A/2) sin(B/2) sin(C/2)` is the inradius:
+
+  `d_a + d_b + d_c = R + r`.
+
+The signs are handled automatically by `signedDist`: a distance is negative
+exactly when the circumcenter lies on the far side of the corresponding side
+(the obtuse case).  The identity reduces, via `dA_eq`/`dB_eq`/`dC_eq`, to
+`R (cos A + cos B + cos C) = R + r`, which is the parent angle identity scaled
+by `R`.
+
+Only `A + B + C = π` is needed for the identity itself; for a *genuine*
+(non-degenerate) triangle one additionally takes `R > 0` and `A, B, C > 0`,
+under which `circumradius` certifies that `O` really is the circumcenter. -/
+theorem carnot_signedDist_sum (R A B C : ℝ) (h : A + B + C = π) :
+    signedDist (na A) (Pc R) O + signedDist (nb B) (Pc R) O
+        + signedDist (nc A C) (Pb R A) O
+      = R + R * (4 * Real.sin (A / 2) * Real.sin (B / 2) * Real.sin (C / 2)) := by
+  rw [dA_eq, dB_eq, dC_eq]
+  have hsum := CarnotTheorem.carnot_cos_sum A B C h
+  linear_combination R * hsum
+
+end CarnotTheoremOQ01OQ01OQ01

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "is-maximal-normal",
+    "startLine": 47,
+    "endLine": 48,
+    "type": "definition",
+    "title": "Maximal normal subgroup",
+    "body": "IsMaximalNormal N: N is normal, proper (N ≠ ⊤), and not strictly contained in any proper normal subgroup. This is the K = ⊤ instance of the parent entry's combinatorial IsMaxNorm predicate."
+  },
+  {
+    "id": "simple-quotient-iff",
+    "startLine": 55,
+    "endLine": 102,
+    "type": "theorem",
+    "title": "Simple quotient ⇔ maximal normal",
+    "body": "IsSimpleGroup (G ⧸ N) ↔ N is proper and maximal among proper normal subgroups. Forward: push a normal M ⊇ N into the quotient (must be ⊥ or ⊤ by simplicity, giving M = N or M = ⊤, via comap_map_mk'). Reverse: pull a normal subgroup of G ⧸ N back through mk' (normal, contains N, so = N or ⊤), then transfer via injectivity of the correspondence map comapMk'OrderIso. The bridge the parent only asserted."
+  },
+  {
+    "id": "packaged-iff",
+    "startLine": 105,
+    "endLine": 108,
+    "type": "theorem",
+    "title": "Packaged with IsMaximalNormal",
+    "body": "isSimpleGroup_quotient_iff_isMaximalNormal: the same equivalence stated with the IsMaximalNormal predicate, folding in the ambient normality hypothesis."
+  },
+  {
+    "id": "directions",
+    "startLine": 111,
+    "endLine": 119,
+    "type": "theorem",
+    "title": "Both directions as lemmas",
+    "body": "IsMaximalNormal.isSimpleGroup_quotient (maximal normal ⟹ simple quotient) and .of_isSimpleGroup_quotient (simple quotient ⟹ maximal normal), reusable in composition-series arguments."
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
@@ -1,0 +1,78 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-04-oq-01",
+  "title": "Simple quotient ⇔ maximal normal subgroup (the IsMaxNorm/IsSimpleGroup bridge)",
+  "slug": "abel-ruffini-galois-extensions-oq-04-oq-01",
+  "description": "Open question oq-01 of the Jordan-Hölder branch asks to contribute JordanHolderLattice (Subgroup G) to Mathlib, whose 'main challenge' is generalizing the combinatorial IsMaxNorm predicate to IsSimpleGroup (K ⧸ H) directly. The parent entry only ASSERTS (in a comment) that IsMaxNorm H K is equivalent to IsSimpleGroup (K ⧸ H.subgroupOf K) 'by the correspondence theorem'. This formalization PROVES that bridge, axiom-free, in the essential case K = ⊤: a normal subgroup N ◁ G has a simple quotient G ⧸ N if and only if N is a maximal normal subgroup of G. The proof routes through Mathlib's fourth isomorphism / correspondence theorem (QuotientGroup.comapMk'OrderIso) rather than re-deriving the lattice correspondence, giving a short, clean equivalence that settles the crux the open question identifies.",
+  "meta": {
+    "author": "Jordan, Hölder; Lean formalization original (researcher-10)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean",
+    "tags": [
+      "group-theory",
+      "jordan-holder",
+      "simple-group",
+      "maximal-normal-subgroup",
+      "correspondence-theorem",
+      "quotient-group",
+      "abel-ruffini",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Every result is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). Built on Mathlib's QuotientGroup.comapMk'OrderIso (correspondence theorem), comap_map_mk', normal_comap, ker_mk'. NOTE: this proves the K = ⊤ case (N ◁ G); the fully general K/subgroupOf version — working inside the subtype group ↥K, the 'quotient typeclass issues' the open question flags — and the actual Mathlib upstreaming remain open.",
+    "mathlibDependencies": [
+      {
+        "theorem": "QuotientGroup.comapMk'OrderIso",
+        "description": "Correspondence (fourth isomorphism) theorem: Subgroup (G⧸N) ≃o subgroups containing N",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.comap_map_mk'",
+        "description": "comap(mk' N)(map(mk' N) H) = N ⊔ H",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.normal_comap",
+        "description": "normality is preserved under comap",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      }
+    ],
+    "originalContributions": [
+      "IsMaximalNormal: the K=⊤ instance of the parent's IsMaxNorm predicate (normal, proper, maximal among proper normal subgroups)",
+      "isSimpleGroup_quotient_iff: IsSimpleGroup (G⧸N) ↔ N proper and maximal among proper normal subgroups — the correspondence-theorem bridge, both directions",
+      "isSimpleGroup_quotient_iff_isMaximalNormal: packaged equivalence with the IsMaximalNormal predicate",
+      "IsMaximalNormal.isSimpleGroup_quotient / .of_isSimpleGroup_quotient: the two directions as reusable lemmas"
+    ],
+    "lineCount": 121,
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ01.lean",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "conclusion": {
+    "summary": "The combinatorial maximality predicate IsMaxNorm and the categorical simplicity predicate IsSimpleGroup of the quotient are equivalent, for K = ⊤: G ⧸ N is simple iff N is a maximal normal subgroup. The forward direction pushes a normal M ⊇ N into the quotient (it must be ⊥ or ⊤, giving M = N or M = ⊤); the reverse pulls a normal subgroup of G ⧸ N back through mk' and uses injectivity of the correspondence map. This is the bridge the parent entry asserted but did not prove.",
+    "implications": [
+      "Confirms IsMaxNorm and IsSimpleGroup carry the same information for K = ⊤, supporting the upstreaming goal.",
+      "The correspondence theorem (comapMk'OrderIso) makes the equivalence a short, robust proof."
+    ],
+    "openQuestions": [
+      "Generalize to arbitrary K via H.subgroupOf K, navigating the subtype-group quotient typeclasses — the part the open question flags as the main obstacle.",
+      "Actually contribute JordanHolderLattice (Subgroup G) and this bridge upstream to Mathlib."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Proves the IsMaxNorm↔IsSimpleGroup correspondence asserted by the Jordan-Hölder lattice entry",
+      "targetId": "abel-ruffini-galois-extensions-oq-04"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-carnot-oq010101-overview",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 54 },
+    "type": "concept",
+    "title": "Carnot's Theorem in Metric Form",
+    "content": "The docstring contrasts the parent files — which encode Carnot's theorem purely as the angle identity cos A + cos B + cos C = 1 + r/R, with no actual triangle, circumcenter, or distances — with the genuinely geometric statement the parent left open. Here the triangle is built concretely in EuclideanSpace ℝ (Fin 2): the circumcenter is the explicit point O = (0,0), the vertices sit on the radius-R circle, and the signed perpendicular distance from O to each side is taken with Mathlib's signedDist. The goal is d_a + d_b + d_c = R + r.",
+    "mathContext": "$d_a + d_b + d_c = R + r, \\qquad r = 4R\\,\\sin\\tfrac{A}{2}\\sin\\tfrac{B}{2}\\sin\\tfrac{C}{2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Carnot's theorem", "signed distance", "circumcenter", "circumradius", "inradius", "EuclideanSpace"],
+    "prerequisites": ["Euclidean geometry", "trigonometry"]
+  },
+  {
+    "id": "ann-carnot-oq010101-helpers",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 90 },
+    "type": "lemma",
+    "title": "Reducing Plane Geometry to Real Algebra",
+    "content": "Four private helpers turn EuclideanSpace ℝ (Fin 2) into ordinary coordinate algebra. norm_two expands ‖(a,b)‖ to sqrt(a²+b²) via EuclideanSpace.norm_eq and Fin.sum_univ_two; norm_unit and norm_circle specialise it (a²+b²=1 gives a unit vector; (r cos t, r sin t) has norm r). inner_two expands ⟪(a,b),(c,d)⟫ to ac + bd via PiLp.inner_apply. These let every later geometric claim be discharged by trigonometric identities.",
+    "mathContext": "$\\|(a,b)\\| = \\sqrt{a^2+b^2}, \\qquad \\langle (a,b),(c,d)\\rangle = ac + bd.$",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace.norm_eq", "PiLp.inner_apply", "Fin.sum_univ_two", "coordinate computation"],
+    "prerequisites": ["inner product spaces", "PiLp / EuclideanSpace"]
+  },
+  {
+    "id": "ann-carnot-oq010101-config",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 113 },
+    "type": "definition",
+    "title": "Explicit Circumcenter, Vertices, and Side Normals",
+    "content": "The configuration is fully explicit. O = (0,0) is the circumcenter; the vertices Pa, Pb, Pc are placed on the radius-R circle at position angles 2A+2C, 2A, 0, so that side BC subtends central angle 2A (the inscribed-angle convention, inscribed angle = half the central angle). Each inward unit normal is na, nb, nc = −(cos μ, sin μ), where μ is the side's midangle (A for BC, −B for CA, 2A+C for AB) — because the perpendicular foot from the center to a chord is its midpoint, lying in the midangle direction.",
+    "mathContext": "$P_B = R(\\cos 2A, \\sin 2A), \\quad P_C = R(1,0), \\qquad \\hat n_a = (-\\cos A, -\\sin A).$",
+    "significance": "key",
+    "relatedConcepts": ["inscribed angle theorem", "chord midpoint", "unit normal", "circumcircle"],
+    "prerequisites": ["circle geometry", "inscribed angle theorem"]
+  },
+  {
+    "id": "ann-carnot-oq010101-circumradius",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "theorem",
+    "title": "O Really Is the Circumcenter",
+    "content": "circumradius proves dist O Pa = dist O Pb = dist O Pc = R: the point O = (0,0) is equidistant from all three explicitly-placed vertices, hence is genuinely their circumcenter with circumradius R. Each distance reduces, via norm_circle (and a direct computation for Pc = (R,0)), to sin² + cos² = 1. This makes the 'explicit circumcenter' of the title a proved fact, not an assumption.",
+    "mathContext": "$\\operatorname{dist}(O, P_A) = \\operatorname{dist}(O, P_B) = \\operatorname{dist}(O, P_C) = R.$",
+    "significance": "key",
+    "relatedConcepts": ["circumcenter", "circumradius", "equidistance", "Pythagorean identity"],
+    "prerequisites": ["Euclidean distance"]
+  },
+  {
+    "id": "ann-carnot-oq010101-perp",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 127, "endLine": 167 },
+    "type": "lemma",
+    "title": "The Normals Are Unit Vectors Perpendicular to Their Sides",
+    "content": "norm_na/nb/nc confirm each side normal is a unit vector (sin²+cos² = 1); na_perp/nb_perp/nc_perp confirm each is perpendicular to its side, e.g. ⟪na, Pc − Pb⟫ = 0, by collapsing the inner product with cos(x−y) (and, for nb, cos(x+y) with B + (2A+2C) = 2π − B). Perpendicularity is exactly what makes the subsequent signedDist values genuine perpendicular distances to the side lines rather than projections along an arbitrary direction.",
+    "mathContext": "$\\|\\hat n_a\\| = 1, \\qquad \\langle \\hat n_a,\\, P_C - P_B\\rangle = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["unit vector", "perpendicularity", "cos(x−y)", "chord direction"],
+    "prerequisites": ["inner products", "trigonometric identities"]
+  },
+  {
+    "id": "ann-carnot-oq010101-distances",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 169, "endLine": 191 },
+    "type": "theorem",
+    "title": "Each Signed Distance Equals R cos of the Opposite Angle",
+    "content": "The geometric heart: dA_eq, dB_eq, dC_eq prove signedDist (na A) (Pc R) O = R cos A, and likewise R cos B, R cos C. Each unfolds Mathlib's signedDist to ⟪normalize n, O −ᵥ p⟫, drops normalize using the unit-norm lemma, and collapses the inner product with inner_two and cos_sub. The cosine carries the orientation for free — R cos A is negative exactly when A is obtuse, precisely the case where the circumcenter lies on the far side of side BC. No acute/obtuse case split is ever made.",
+    "mathContext": "$\\operatorname{signedDist}(\\hat n_a, P_C, O) = R\\cos A, \\quad \\operatorname{signedDist}(\\hat n_b, P_C, O) = R\\cos B, \\quad \\operatorname{signedDist}(\\hat n_c, P_B, O) = R\\cos C.$",
+    "significance": "key",
+    "relatedConcepts": ["signedDist", "signed perpendicular distance", "obtuse triangle sign", "R cos A"],
+    "prerequisites": ["signed distance to a line", "trigonometry"]
+  },
+  {
+    "id": "ann-carnot-oq010101-main",
+    "proofId": "carnot-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 193, "endLine": 219 },
+    "type": "theorem",
+    "title": "Carnot's Theorem: Sum of Signed Distances = R + r",
+    "content": "carnot_signedDist_sum assembles the result: the three signed perpendicular distances from the circumcenter to the sides sum to R + r, with r = 4R sin(A/2) sin(B/2) sin(C/2) the inradius. By dA_eq/dB_eq/dC_eq the sum is R(cos A + cos B + cos C), and the parent angle identity carnot_cos_sum (cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)), scaled by R, finishes via linear_combination. Only A + B + C = π is needed; positivity of R, A, B, C is what makes the configuration a non-degenerate triangle.",
+    "mathContext": "$d_a + d_b + d_c = R(\\cos A + \\cos B + \\cos C) = R + r.$",
+    "significance": "key",
+    "relatedConcepts": ["Carnot's theorem", "inradius", "circumradius", "linear_combination"],
+    "prerequisites": ["the parent Carnot angle identity"]
+  }
+]

--- a/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "carnot-theorem-oq-01-oq-01-oq-01",
+  "title": "Carnot's Theorem — the metric signed-distance form with an explicit circumcenter",
+  "slug": "carnot-theorem-oq-01-oq-01-oq-01",
+  "description": "The metric form of Carnot's theorem, built concretely in EuclideanSpace ℝ (Fin 2): the circumcenter is the explicit point O = (0,0), the three vertices sit on the radius-R circle (and O is certified equidistant from all three), and the signed perpendicular distance from O to each side is exactly R cos of the opposite angle. Summing and feeding the parent angle identity through gives d_a + d_b + d_c = R + r with r = 4R sin(A/2) sin(B/2) sin(C/2). The signs are carried automatically by Mathlib's signedDist (negative exactly in the obtuse case). This answers the parent's open question of whether the metric signed-distance form can be formalized. Axiom- and sorry-free.",
+  "meta": {
+    "author": "Lazare Carnot (1803)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carnot%27s_theorem_(perpendiculars)",
+    "date": "1803",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CarnotTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "triangle",
+      "trigonometry",
+      "euclidean-geometry",
+      "signed-distance",
+      "circumcenter",
+      "circumradius",
+      "inradius",
+      "carnot-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "signedDist",
+        "description": "Mathlib's signed distance signedDist v p q = ⟪normalize v, q -ᵥ p⟫ in a Euclidean space (trilinear coordinates); used as the authoritative metric signed perpendicular distance from the circumcenter to each side",
+        "module": "Mathlib.Geometry.Euclidean.SignedDist"
+      },
+      {
+        "theorem": "NormedSpace.normalize_eq_self_of_norm_eq_one",
+        "description": "normalize v = v when ‖v‖ = 1, used to discharge the normalize in signedDist once each side normal is shown to be a unit vector",
+        "module": "Mathlib.Analysis.NormedSpace.Normalize"
+      },
+      {
+        "theorem": "EuclideanSpace.norm_eq",
+        "description": "‖x‖ = sqrt (∑ i, ‖x i‖²) over EuclideanSpace, used to compute norms of explicit plane vectors via Fin.sum_univ_two",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "PiLp.inner_apply",
+        "description": "Coordinate expansion of the inner product on EuclideanSpace, used (with Fin.sum_univ_two) to compute ⟪(a,b),(c,d)⟫ = ac + bd",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Real.cos_sub",
+        "description": "cos(x − y) = cos x cos y + sin x sin y; collapses each side's inner product to R cos of the opposite angle and certifies the normals are perpendicular to their sides",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "sin²x + cos²x = 1; gives that each side normal is a unit vector and that the vertices lie on the circle of radius R",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "CarnotTheorem.carnot_cos_sum",
+        "description": "Parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2); scaled by R it turns the sum of signed distances R(cos A + cos B + cos C) into R + r",
+        "module": "Proofs.CarnotTheorem"
+      }
+    ],
+    "originalContributions": [
+      "A complete metric formalization of Carnot's theorem over EuclideanSpace ℝ (Fin 2) with an explicit circumcenter O = (0,0), answering the parent entry's stated open question",
+      "Each signed perpendicular distance from the circumcenter to a side equals R cos of the opposite angle (dA_eq, dB_eq, dC_eq), with the obtuse-case sign carried automatically by Mathlib's signedDist — no acute/obtuse case split",
+      "The circumcenter is certified genuine: O is proved equidistant (= R) from all three explicitly-placed vertices (circumradius)",
+      "Each side normal is certified perpendicular to its side (na_perp, nb_perp, nc_perp), so the signedDist values are bona fide perpendicular distances to the side lines",
+      "The metric identity d_a + d_b + d_c = R + r obtained by scaling the parent angle identity by R, with r = 4R sin(A/2) sin(B/2) sin(C/2) the inradius"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 221,
+    "assumptions": "0 axioms (only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, appear in #print axioms; no Lean.ofReduceBool, no sorryAx). 0 sorries. The signed-distance sum identity needs only A + B + C = π; the circumradius certification additionally uses R ≥ 0, and the genuine-triangle reading takes A, B, C > 0. Builds on the parent file Proofs/CarnotTheorem.lean (itself axiom-free). Note: local Docker kernel build was unavailable this session, so verification used host single-file elaboration (lake env lean) against Mathlib v4.26.0; the entry is gated by the deployer build before merge.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 7
+  },
+  "sections": [
+    {
+      "title": "Module header",
+      "startLine": 4,
+      "endLine": 54,
+      "description": "Docstring contrasting the parent's bespoke angle encoding (three reals summing to π, no actual triangle) with the genuinely geometric metric statement asked for by the parent's open question, and laying out the explicit construction: circumcenter O = (0,0), vertices on the radius-R circle by the inscribed-angle convention, inward unit normals, and Mathlib's signedDist as the signed perpendicular distance.",
+      "summary": "Module header",
+      "id": "module-header"
+    },
+    {
+      "title": "Coordinate helpers",
+      "startLine": 64,
+      "endLine": 90,
+      "description": "Four private lemmas reducing EuclideanSpace ℝ (Fin 2) computations to ordinary real algebra: norm_two (‖(a,b)‖ = sqrt(a²+b²)), norm_unit (a²+b² = 1 ⟹ unit vector), norm_circle (a point (r cos t, r sin t) has norm r), and inner_two (⟪(a,b),(c,d)⟫ = ac + bd via PiLp.inner_apply and Fin.sum_univ_two).",
+      "summary": "Norm and inner-product helpers for explicit plane vectors",
+      "id": "coordinate-helpers"
+    },
+    {
+      "title": "The configuration",
+      "startLine": 92,
+      "endLine": 113,
+      "description": "The explicit objects: circumcenter O = (0,0); vertices Pa, Pb, Pc placed on the radius-R circle at position angles 2A+2C, 2A, 0 so that side BC subtends central angle 2A (inscribed-angle convention); and the three inward unit normals na, nb, nc = −(cos μ, sin μ) where μ is each side's midangle (A, −B, 2A+C respectively).",
+      "summary": "Explicit circumcenter, vertices, and side normals",
+      "id": "configuration"
+    },
+    {
+      "title": "The circumcenter is genuine",
+      "startLine": 115,
+      "endLine": 125,
+      "description": "circumradius proves dist O Pa = dist O Pb = dist O Pc = R, i.e. O is equidistant from the three vertices and is therefore their circumcenter with circumradius R. Reduces via norm_circle (and a direct computation for Pc) to sin²+cos² = 1.",
+      "summary": "O is equidistant (= R) from all three vertices",
+      "id": "circumradius"
+    },
+    {
+      "title": "Unit normals perpendicular to the sides",
+      "startLine": 127,
+      "endLine": 167,
+      "description": "norm_na/nb/nc show each side normal is a unit vector (sin²+cos² = 1). na_perp/nb_perp/nc_perp show each normal is perpendicular to its side (⟪na, Pc − Pb⟫ = 0, etc.), via cos(x−y) and cos(x+y) identities. Together these certify that the subsequent signedDist values are bona fide signed perpendicular distances to the side lines.",
+      "summary": "Each normal is a unit vector perpendicular to its side",
+      "id": "normals"
+    },
+    {
+      "title": "Each signed distance is R cos of the opposite angle",
+      "startLine": 169,
+      "endLine": 191,
+      "description": "The geometric heart. dA_eq, dB_eq, dC_eq compute Mathlib's signedDist from the circumcenter O to each side: signedDist (na A) (Pc R) O = R cos A, and likewise R cos B, R cos C. Each unfolds signedDist to ⟪normalize n, O −ᵥ p⟫, uses the unit-norm fact to drop normalize, and collapses the inner product via inner_two and cos_sub. The cosine carries the correct sign automatically — negative exactly when the circumcenter falls on the far side of an obtuse angle's opposite side.",
+      "summary": "signedDist from circumcenter to each side = R cos(opposite angle)",
+      "id": "signed-distances"
+    },
+    {
+      "title": "Carnot's theorem, metric form",
+      "startLine": 193,
+      "endLine": 219,
+      "description": "carnot_signedDist_sum: the sum of the three signed perpendicular distances from the circumcenter to the sides equals R + r, where r = 4R sin(A/2) sin(B/2) sin(C/2) is the inradius. Reduces via dA_eq/dB_eq/dC_eq to R(cos A + cos B + cos C) = R + r, which is the parent angle identity carnot_cos_sum scaled by R.",
+      "summary": "Sum of signed circumcenter-to-side distances = R + r",
+      "id": "main-theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Carnot's theorem (Lazare Carnot, 1803) states that the sum of the signed distances from the circumcenter of a triangle to its three sides equals R + r, the sum of the circumradius and the inradius — with a side's contribution counted negative when the circumcenter lies on the far side of that side, as happens at an obtuse angle. The parent gallery entries formalize only the equivalent angle identity cos A + cos B + cos C = 1 + r/R, living in a bespoke trigonometric encoding with no actual triangle, circumcenter, or distances. The parent explicitly left open whether the genuinely metric statement — with an explicit circumcenter and real perpendicular distances over EuclideanSpace ℝ (Fin 2) — could be formalized. This entry does exactly that.",
+    "problemStatement": "Realize a triangle with circumradius R > 0 and angles A, B, C > 0 (A + B + C = π) concretely in EuclideanSpace ℝ (Fin 2): place the circumcenter at an explicit point and the vertices on the circle of radius R about it. Define the signed perpendicular distances from the circumcenter to the three sides (with the orientation convention that makes obtuse contributions negative) and prove that they sum to R + r, where r is the inradius.",
+    "text": "Place the circumcenter at the origin O = (0,0) and the vertices on the radius-R circle. The signed perpendicular distance from O to each side is exactly R cos of the opposite angle, and the three sum to R + r.",
+    "proofStrategy": "Place the circumcenter at O = (0,0) and the vertices Pa, Pb, Pc on the circle of radius R, at position angles chosen by the inscribed-angle convention (side BC subtends central angle 2A, etc.). For a chord, the foot of the perpendicular from the center is its midpoint, whose direction is the chord's midangle μ; the inward unit normal to that side is therefore −(cos μ, sin μ). Taking Mathlib's signedDist (= ⟪normalize v, q −ᵥ p⟫) from O along this normal, the normalize drops once the normal is shown to be a unit vector (sin² + cos² = 1), and the inner product collapses by cos(x − y) to exactly R cos of the opposite angle — negative precisely in the obtuse case, with no manual case split. Each normal is independently certified perpendicular to its side, and O is certified equidistant (= R) from the three vertices, so it genuinely is the circumcenter. Summing the three signed distances gives R(cos A + cos B + cos C), and the parent angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, turns this into R + r.",
+    "keyInsights": [
+      "**Center-to-chord = midpoint, so the inward unit normal is −(cos μ, sin μ)**: the perpendicular foot from the circumcenter to a chord is the chord's midpoint, whose direction is the chord's midangle μ; this makes every side normal an explicit unit vector and the signed distance a one-line inner product",
+      "**Mathlib's signedDist carries the obtuse sign for free**: writing the distance as ⟪normalize v, O −ᵥ p⟫ with v the inward normal yields exactly R cos of the opposite angle, whose sign already flips for obtuse triangles — the orientation bookkeeping that makes the metric form hard is handled by the cosine itself",
+      "**The metric statement is the angle statement scaled by R**: each signed distance is R cos(angle), so the whole theorem reduces to the parent identity multiplied by R — the geometric content is entirely in the dA_eq/dB_eq/dC_eq distance computations",
+      "**An explicit, certified circumcenter**: O = (0,0) is not assumed to be the circumcenter — it is proved equidistant from the three explicitly-placed vertices, anchoring the construction in genuine Euclidean geometry rather than a coordinate fiction"
+    ],
+    "prerequisites": [
+      "Euclidean plane EuclideanSpace ℝ (Fin 2): norms, inner products, and the !₂[·,·] coordinate notation",
+      "Mathlib's signedDist (trilinear signed distance) and normalize",
+      "Trigonometric identities cos(x ± y) and sin² + cos² = 1, plus the inscribed-angle convention relating central and inscribed angles",
+      "The parent Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2)"
+    ],
+    "openQuestions": [
+      "Can the construction be repackaged through Mathlib's Affine.Simplex.circumcenter / circumradius API so the circumcenter is derived from the triangle rather than placed by hand, recovering the same R + r identity?",
+      "Does the same explicit signed-distance technique extend to the excircles, giving the signed-distance forms d_a − d_b − d_c = R − r_A for the exradii?"
+    ]
+  },
+  "conclusion": {
+    "summary": "Carnot's theorem is formalized in genuinely metric form over EuclideanSpace ℝ (Fin 2): with the circumcenter placed at the explicit point O = (0,0) and the vertices on the radius-R circle (O certified equidistant from all three), each signed perpendicular distance from O to a side equals R cos of the opposite angle, and the three sum to R + r. The obtuse-case sign is carried automatically by Mathlib's signedDist. This answers the parent entry's open question. Axiom- and sorry-free.",
+    "implications": "**Theoretical Significance**: The entry closes the gap between the parent's analytic angle identity and the classical metric statement of Carnot's theorem, showing that the much-feared orientation bookkeeping (a side's distance flipping sign at an obtuse angle) needs no case analysis once the signed distance is taken along the inward unit normal: the cosine supplies the sign. It anchors Carnot's theorem in Mathlib's signedDist / EuclideanSpace API, making it composable with other Euclidean-geometry formalizations.",
+    "openQuestions": [
+      "Repackage through Mathlib's Affine.Simplex.circumcenter API so the circumcenter is derived rather than placed by hand.",
+      "Extend the signed-distance technique to the excircles (exradius forms d_a − d_b − d_c = R − r_A)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "carnot-theorem-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Answers this parent's stated open question — whether the metric signed-distance form with an explicit circumcenter over EuclideanSpace ℝ (Fin 2) can be formalized. Reuses the parent's grandparent identity carnot_cos_sum (scaled by R) for the final sum."
+    },
+    {
+      "targetId": "carnot-theorem-oq-01",
+      "relationship": "ancestor",
+      "description": "The root Carnot angle identity cos A + cos B + cos C = 1 + 4 sin(A/2) sin(B/2) sin(C/2), scaled by R, is what turns the sum of signed distances R(cos A + cos B + cos C) into R + r."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CarnotTheorem"
+    ],
+    "opens": [
+      "Real",
+      "NormedSpace",
+      "RealInnerProductSpace (scoped)"
+    ],
+    "namespace": "CarnotTheoremOQ01OQ01OQ01",
+    "lineCount": 221,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 7,
+    "sorries": 0,
+    "path": "Proofs/CarnotTheoremOQ01OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Open question **oq-01** of the Jordan–Hölder branch (`abel-ruffini-galois-extensions-oq-04`) asks to contribute `JordanHolderLattice (Subgroup G)` to Mathlib, whose stated "main challenge" is relating the combinatorial `IsMaxNorm` predicate to `IsSimpleGroup (K ⧸ H)`. The parent entry only **asserts** (in a comment) that `IsMaxNorm H K` is equivalent to `IsSimpleGroup (K ⧸ H.subgroupOf K)` "by the correspondence theorem, but avoids quotient typeclass issues" — without proving it.

This PR **proves** that bridge, axiom-free, in the essential case `K = ⊤`.

### Results (verified, 0 axioms, 0 sorries)

- `isSimpleGroup_quotient_iff`: for `N ◁ G`, `IsSimpleGroup (G ⧸ N) ↔ N` is proper and maximal among proper normal subgroups.
  - **Forward**: push a normal `M ⊇ N` into the quotient; simplicity forces `map M = ⊥` or `⊤`, i.e. `M = N` or `M = ⊤` (via `comap_map_mk'`).
  - **Reverse**: pull a normal subgroup of `G ⧸ N` back through `mk'` (normal, contains `N`, so `= N` or `⊤`), then transfer via injectivity of the correspondence map `comapMk'OrderIso`.
- `isSimpleGroup_quotient_iff_isMaximalNormal`: packaged with an `IsMaximalNormal` predicate (the `K = ⊤` instance of the parent's `IsMaxNorm`).
- `IsMaximalNormal.isSimpleGroup_quotient` / `.of_isSimpleGroup_quotient`: the two directions as reusable lemmas.

### Approach

Routes everything through Mathlib's fourth isomorphism / correspondence theorem (`QuotientGroup.comapMk'OrderIso`) rather than re-deriving the lattice correspondence, yielding a short, robust proof. `#print axioms` returns only `[propext, Classical.choice, Quot.sound]`.

### Honesty note

This settles the `IsMaxNorm`↔`IsSimpleGroup` correspondence the open question identifies as the crux, for `K = ⊤`. The fully general `K`/`subgroupOf` version — working inside the subtype group `↥K`, the "quotient typeclass issues" the question flags — and the actual Mathlib upstreaming remain open (recorded in the entry's `openQuestions`). New gallery entry `src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/` (`status: verified`, `badge: original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
