### PR TITLE
research(newton-inductive-step-oq-01-oq-02): Maclaurin's chain from Newton's log-concavity

### DIFF
--- a/proofs/Proofs/NewtonInductiveStepOQ01OQ02.lean
+++ b/proofs/Proofs/NewtonInductiveStepOQ01OQ02.lean
@@ -1,0 +1,179 @@
+/-
+  Maclaurin's Inequality Chain from Newton's Log-Concavity
+  (Newton Inductive Step OQ-01-OQ-02)
+
+  Open question from NewtonInductiveStepOQ01 (openQuestions[1]):
+    "Derive the full Maclaurin inequality chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}."
+
+  Setup. The normalized elementary symmetric means ēₖ = eₖ/C(n,k) of nonnegative
+  reals are positive (for ≤ n nonzero entries), satisfy ē₀ = 1, and — this is
+  Newton's inequality — are log-concave: ēₖ² ≥ ēₖ₋₁·ēₖ₊₁.  Maclaurin's theorem
+  states that the sequence ēₖ^{1/k} is non-increasing.
+
+  This file gives the complete, axiom-free **reduction** Newton ⟹ Maclaurin for
+  an abstract positive log-concave sequence `a : ℕ → ℝ` with `a 0 = 1`:
+
+  - `ratioSeq_antitone_of_logConcave`: log-concavity makes the consecutive ratios
+    `a k / a (k-1)` non-increasing.
+  - `prod_ratioSeq`: `a k` telescopes as `∏_{j=1}^k (a j / a (j-1))`.
+  - `maclaurin_pow`: the Maclaurin chain in **polynomial form**,
+        `a (k+1) ^ k ≤ a k ^ (k+1)`   (k ≥ 1),
+    which is equivalent to `a (k+1)^{1/(k+1)} ≤ a k^{1/k}` but avoids real powers.
+  - `maclaurin_root`: the genuine **radical form**
+        `a (k+1) ^ (1/(k+1) : ℝ) ≤ a k ^ (1/k : ℝ)`   (k ≥ 1),
+    via `Real.rpow`.
+
+  Why a reduction. The parent's general Newton inequality `newton_inequality_means`
+  (for k ≥ 2) still rests on an open inductive `sorry`. Rather than build on that,
+  we keep Newton's inequalities as an explicit hypothesis and prove the chain
+  follows — so the file is 0-axiom and 0-sorry. Instantiating `a := ēₖ` then yields
+  the full Maclaurin chain the moment the parent's Newton inequality is completed.
+  As a tightness witness, the geometric sequence `a k = t^k` (equal entries) meets
+  all hypotheses with equality and the chain holds with equality.
+
+  References:
+  - Maclaurin (1729), A second letter ... concerning the roots of equations
+  - Hardy–Littlewood–Pólya (1952), Inequalities, §2.22 (Theorem 52)
+  - Niculescu (2000), A new look at Newton's inequalities
+-/
+
+import Mathlib
+
+namespace NewtonMaclaurinChain
+
+open Finset
+
+/-- The consecutive-ratio sequence `r k = a k / a (k-1)` of a sequence `a`.
+    For `k = 0` this is `a 0 / a 0`; the results below only use it for `k ≥ 1`. -/
+noncomputable def ratioSeq (a : ℕ → ℝ) (k : ℕ) : ℝ := a k / a (k - 1)
+
+/-- Each ratio is positive when the sequence is positive. -/
+theorem ratioSeq_pos {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n) (m : ℕ) :
+    0 < ratioSeq a m := by
+  unfold ratioSeq; exact div_pos (hpos _) (hpos _)
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART I: LOG-CONCAVITY ⇒ RATIOS NON-INCREASING
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- One step: log-concavity `a (k-1)·a (k+1) ≤ a k²` forces the ratio to drop,
+    `a (k+1)/a k ≤ a k/a (k-1)`. -/
+theorem ratioSeq_step_of_logConcave {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n)
+    {k : ℕ} (hk : 1 ≤ k) (hlc : a (k - 1) * a (k + 1) ≤ a k ^ 2) :
+    ratioSeq a (k + 1) ≤ ratioSeq a k := by
+  unfold ratioSeq
+  rw [show k + 1 - 1 = k by omega,
+      div_le_div_iff₀ (hpos k) (hpos (k - 1))]
+  nlinarith [hlc]
+
+/-- The ratios are non-increasing from index 1 onward: `m ≤ n` (with `1 ≤ m`)
+    gives `ratioSeq a n ≤ ratioSeq a m`. -/
+theorem ratioSeq_antitone_of_logConcave {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n)
+    (hlc : ∀ k, 1 ≤ k → a (k - 1) * a (k + 1) ≤ a k ^ 2) :
+    ∀ n m, 1 ≤ m → m ≤ n → ratioSeq a n ≤ ratioSeq a m := by
+  intro n
+  induction n with
+  | zero => intro m hm hmn; omega
+  | succ p ih =>
+    intro m hm hmn
+    rcases Nat.lt_or_ge m (p + 1) with hlt | hge
+    · have hmp : m ≤ p := by omega
+      have hp1 : 1 ≤ p := by omega
+      exact (ratioSeq_step_of_logConcave hpos hp1 (hlc p hp1)).trans (ih m hm hmp)
+    · have : m = p + 1 := by omega
+      rw [this]
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART II: TELESCOPING PRODUCT
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- `a k` telescopes as the product of consecutive ratios:
+    `a k = ∏_{j=1}^{k} (a j / a (j-1))`, using `a 0 = 1`. -/
+theorem prod_ratioSeq {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n) (h0 : a 0 = 1) :
+    ∀ k, ∏ j ∈ Finset.Icc 1 k, ratioSeq a j = a k := by
+  intro k
+  induction k with
+  | zero => simp [h0]
+  | succ p ih =>
+    rw [Finset.prod_Icc_succ_top (by omega : 1 ≤ p + 1), ih]
+    unfold ratioSeq
+    rw [show p + 1 - 1 = p by omega,
+        mul_div_cancel₀ _ (ne_of_gt (hpos p))]
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART III: THE MACLAURIN CHAIN (POLYNOMIAL FORM)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Key estimate: `a k` dominates the `k`-th power of the *last* ratio,
+    `ratioSeq a (k+1) ^ k ≤ a k`, because every earlier ratio is at least as big
+    (ratios are non-increasing) and `a k` is their product. -/
+theorem lastRatio_pow_le {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n) (h0 : a 0 = 1)
+    (hlc : ∀ k, 1 ≤ k → a (k - 1) * a (k + 1) ≤ a k ^ 2) {k : ℕ} (hk : 1 ≤ k) :
+    ratioSeq a (k + 1) ^ k ≤ a k := by
+  rw [← prod_ratioSeq hpos h0 k]
+  have hcard : (Finset.Icc 1 k).card = k := by rw [Nat.card_Icc]; omega
+  calc ratioSeq a (k + 1) ^ k
+      = ∏ _j ∈ Finset.Icc 1 k, ratioSeq a (k + 1) := by
+        rw [Finset.prod_const, hcard]
+    _ ≤ ∏ j ∈ Finset.Icc 1 k, ratioSeq a j := by
+        apply Finset.prod_le_prod
+        · intro j _; exact (ratioSeq_pos hpos (k + 1)).le
+        · intro j hj
+          rw [Finset.mem_Icc] at hj
+          exact ratioSeq_antitone_of_logConcave hpos hlc (k + 1) j hj.1 (by omega)
+
+/-- **Maclaurin's inequality chain, polynomial form.** For a positive log-concave
+    sequence with `a 0 = 1` and `k ≥ 1`,
+        `a (k+1) ^ k ≤ a k ^ (k+1)`.
+    Equivalently `a (k+1)^{1/(k+1)} ≤ a k^{1/k}` (see `maclaurin_root`), i.e. the
+    sequence `a k^{1/k}` is non-increasing — Maclaurin's theorem. -/
+theorem maclaurin_pow {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n) (h0 : a 0 = 1)
+    (hlc : ∀ k, 1 ≤ k → a (k - 1) * a (k + 1) ≤ a k ^ 2) {k : ℕ} (hk : 1 ≤ k) :
+    a (k + 1) ^ k ≤ a k ^ (k + 1) := by
+  have hkey : ratioSeq a (k + 1) ^ k ≤ a k := lastRatio_pow_le hpos h0 hlc hk
+  have hrec : a (k + 1) = a k * ratioSeq a (k + 1) := by
+    unfold ratioSeq
+    rw [show k + 1 - 1 = k by omega,
+        mul_div_cancel₀ _ (ne_of_gt (hpos k))]
+  calc a (k + 1) ^ k
+      = a k ^ k * ratioSeq a (k + 1) ^ k := by rw [hrec, mul_pow]
+    _ ≤ a k ^ k * a k := by
+        exact mul_le_mul_of_nonneg_left hkey (pow_nonneg (hpos k).le k)
+    _ = a k ^ (k + 1) := (pow_succ (a k) k).symm
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART IV: THE MACLAURIN CHAIN (RADICAL FORM)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **Maclaurin's inequality chain, radical form.** For a positive log-concave
+    sequence with `a 0 = 1` and `k ≥ 1`,
+        `a (k+1) ^ (1/(k+1)) ≤ a k ^ (1/k)`   (real powers),
+    i.e. `ē₁ ≥ ē₂^{1/2} ≥ ē₃^{1/3} ≥ ⋯` — the chain exactly as stated. -/
+theorem maclaurin_root {a : ℕ → ℝ} (hpos : ∀ n, 0 < a n) (h0 : a 0 = 1)
+    (hlc : ∀ k, 1 ≤ k → a (k - 1) * a (k + 1) ≤ a k ^ 2) {k : ℕ} (hk : 1 ≤ k) :
+    a (k + 1) ^ (1 / (k + 1 : ℝ)) ≤ a k ^ (1 / k : ℝ) := by
+  have hkpos : (0 : ℝ) < k := by exact_mod_cast hk
+  have hx := hpos k
+  have hy := hpos (k + 1)
+  -- polynomial form (npow), recast with real exponents
+  have hpoly : a (k + 1) ^ (k : ℝ) ≤ a k ^ ((k : ℝ) + 1) := by
+    have h := maclaurin_pow hpos h0 hlc hk
+    rw [Real.rpow_natCast,
+        show ((k : ℝ) + 1) = ((k + 1 : ℕ) : ℝ) by push_cast; ring,
+        Real.rpow_natCast]
+    exact h
+  -- raise both sides to the positive power e = 1/(k(k+1))
+  set e : ℝ := 1 / ((k : ℝ) * ((k : ℝ) + 1)) with he
+  have hmono :
+      (a (k + 1) ^ (k : ℝ)) ^ e ≤ (a k ^ ((k : ℝ) + 1)) ^ e :=
+    Real.rpow_le_rpow (by positivity) hpoly (by rw [he]; positivity)
+  -- collapse the iterated powers and simplify the exponents
+  rw [← Real.rpow_mul hy.le, ← Real.rpow_mul hx.le] at hmono
+  have eL : (k : ℝ) * e = 1 / ((k : ℝ) + 1) := by
+    rw [he]; field_simp
+  have eR : ((k : ℝ) + 1) * e = 1 / (k : ℝ) := by
+    rw [he]; field_simp
+  rw [eL, eR] at hmono
+  exact hmono
+
+end NewtonMaclaurinChain

--- a/src/data/proofs/newton-inductive-step-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/newton-inductive-step-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-01-strategy",
+    "proofId": "newton-inductive-step-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "Deriving Maclaurin's Chain from Newton: Strategy",
+    "content": "Newton's inequality is the log-concavity ēₖ² ≥ ēₖ₋₁·ēₖ₊₁ of the elementary symmetric means; Maclaurin's inequality is the resulting chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}. The parent file proved Newton only for k = 1 (the general k ≥ 2 case is still an open sorry). Rather than build on that sorry, this file proves the REDUCTION: for any abstract positive sequence a with a₀ = 1, log-concavity implies the Maclaurin chain. The whole development is 0-axiom and 0-sorry; Newton's inequalities are an explicit hypothesis, so instantiating a := ēₖ gives the full chain once the parent's Newton case is completed.",
+    "mathContext": "Log-concavity ⟹ non-increasing ratios ⟹ non-increasing running geometric mean ēₖ^{1/k}."
+  },
+  {
+    "id": "ann-02-ratios",
+    "proofId": "newton-inductive-step-oq-01-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Log-concavity ⇒ ratios non-increasing",
+    "content": "Define ratioSeq a k = a k / a (k-1). ratioSeq_step_of_logConcave: the log-concavity a(k-1)·a(k+1) ≤ a k² cross-multiplies (div_le_div_iff₀, the v4.26 name) to r(k+1) ≤ r k. ratioSeq_antitone_of_logConcave: by induction on n, for 1 ≤ m ≤ n the ratio r n ≤ r m — the ratios are non-increasing from index 1 onward. This monotonicity of ratios is the entire content of Newton's inequality for the chain.",
+    "mathContext": "$a(k-1)a(k+1) \\le a(k)^2 \\iff \\tfrac{a(k+1)}{a(k)} \\le \\tfrac{a(k)}{a(k-1)}$."
+  },
+  {
+    "id": "ann-03-telescope",
+    "proofId": "newton-inductive-step-oq-01-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "Telescoping product",
+    "content": "prod_ratioSeq: ∏_{j=1}^k (a j / a (j-1)) = a k. By induction with Finset.prod_Icc_succ_top, peeling the top factor a(k+1)/a k; mul_div_cancel₀ collapses a k · (a(k+1)/a k) = a(k+1), and a₀ = 1 seeds the empty product. This expresses a k as a product of the (non-increasing) ratios — the key to viewing ēₖ^{1/k} as a running geometric mean.",
+    "mathContext": "$\\prod_{j=1}^k r_j = a_k$ with $r_j = a_j/a_{j-1}$ and $a_0 = 1$."
+  },
+  {
+    "id": "ann-04-maclaurin-poly",
+    "proofId": "newton-inductive-step-oq-01-oq-02",
+    "range": {
+      "startLine": 110,
+      "endLine": 142
+    },
+    "type": "theorem",
+    "title": "Maclaurin's chain, polynomial form",
+    "content": "lastRatio_pow_le: r(k+1)^k ≤ a k, because r(k+1)^k = ∏_{j≤k} r(k+1) ≤ ∏_{j≤k} r j = a k by Finset.prod_le_prod (each earlier ratio r j is ≥ r(k+1)) and prod_ratioSeq; the card of Icc 1 k is k (Nat.card_Icc). maclaurin_pow then writes a(k+1) = a k·r(k+1), so a(k+1)^k = a k^k·r(k+1)^k ≤ a k^k·a k = a k^{k+1}. This polynomial form avoids real powers entirely.",
+    "mathContext": "$a_{k+1}^k \\le a_k^{k+1}$, equivalent to $a_{k+1}^{1/(k+1)} \\le a_k^{1/k}$."
+  },
+  {
+    "id": "ann-05-maclaurin-root",
+    "proofId": "newton-inductive-step-oq-01-oq-02",
+    "range": {
+      "startLine": 152,
+      "endLine": 179
+    },
+    "type": "theorem",
+    "title": "Maclaurin's chain, radical form",
+    "content": "maclaurin_root: a(k+1)^{1/(k+1)} ≤ a k^{1/k} with genuine real powers (Real.rpow). The polynomial form is recast with real exponents via Real.rpow_natCast, then both sides are raised to the nonnegative power 1/(k(k+1)) by Real.rpow_le_rpow; Real.rpow_mul collapses the iterated powers and field_simp simplifies (k)·(1/(k(k+1))) = 1/(k+1) and (k+1)·(1/(k(k+1))) = 1/k. This is the Maclaurin chain ē₁ ≥ ē₂^{1/2} ≥ ... exactly as classically stated.",
+    "mathContext": "$\\bar e_1 \\ge \\bar e_2^{1/2} \\ge \\bar e_3^{1/3} \\ge \\cdots$"
+  }
+]

--- a/src/data/proofs/newton-inductive-step-oq-01-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01-oq-02/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "newton-inductive-step-oq-01-oq-02",
+  "title": "Maclaurin's Inequality Chain from Newton's Log-Concavity",
+  "slug": "newton-inductive-step-oq-01-oq-02",
+  "description": "Answers the parent's open question to derive the full Maclaurin chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}. Gives the complete, axiom-free reduction Newton ⟹ Maclaurin for an abstract positive log-concave sequence a with a₀ = 1: log-concavity makes the consecutive ratios non-increasing, a telescopes as a product of ratios, and these combine (via Finset.prod_le_prod) to the Maclaurin chain — proved in both the polynomial form a_{k+1}^k ≤ a_k^{k+1} and the genuine radical form a_{k+1}^{1/(k+1)} ≤ a_k^{1/k} (Real.rpow). 0 axioms, 0 sorries; Newton's inequalities are the explicit hypothesis, so instantiating a := ēₖ yields the full chain once the parent's Newton inequality is completed.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Maclaurin%27s_inequality",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "inequalities",
+      "symmetric-functions",
+      "maclaurin",
+      "newton-inequality",
+      "log-concavity",
+      "advanced"
+    ],
+    "proofRepoPath": "Proofs/NewtonInductiveStepOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 179,
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_le_prod",
+        "description": "(∀ i ∈ s, 0 ≤ f i) → (∀ i ∈ s, f i ≤ g i) → ∏ f ≤ ∏ g",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring"
+      },
+      {
+        "theorem": "Finset.prod_Icc_succ_top",
+        "description": "a ≤ b+1 → ∏ i ∈ Icc a (b+1), f i = (∏ i ∈ Icc a b, f i) * f (b+1)",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.prod_const",
+        "description": "∏ _ ∈ s, c = c ^ s.card",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "0 < b → 0 < d → (a / b ≤ c / d ↔ a * d ≤ c * b)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "x ^ (n : ℝ) = x ^ n",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "0 ≤ x → x ≤ y → 0 ≤ z → x ^ z ≤ y ^ z",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "ratioSeq: the consecutive-ratio sequence a k / a (k-1), with positivity",
+      "ratioSeq_step_of_logConcave / ratioSeq_antitone_of_logConcave: log-concavity ⟹ the ratios are non-increasing from index 1",
+      "prod_ratioSeq: a k telescopes as ∏_{j=1}^k (a j / a (j-1)) using a₀ = 1",
+      "lastRatio_pow_le: a k dominates the k-th power of its last ratio, via Finset.prod_le_prod over non-increasing ratios",
+      "maclaurin_pow: Maclaurin's chain in polynomial form a_{k+1}^k ≤ a_k^{k+1} (real-power-free)",
+      "maclaurin_root: Maclaurin's chain in radical form a_{k+1}^{1/(k+1)} ≤ a_k^{1/k} via Real.rpow — the chain exactly as classically stated"
+    ],
+    "assumptions": "None as axioms — the file declares 0 axioms and #print axioms shows only propext / Classical.choice / Quot.sound. The mathematical input (Newton's inequalities, i.e. log-concavity a(k-1)·a(k+1) ≤ a k², together with positivity and a₀ = 1) is an explicit hypothesis of every theorem, NOT a global axiom. The file proves the reduction Newton ⟹ Maclaurin; it does not re-prove Newton's inequalities (the parent's general k ≥ 2 case is still open with a sorry).",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "For nonnegative reals x₁,…,xₙ, the elementary symmetric means ēₖ = eₖ/C(n,k) interpolate between the arithmetic mean (ē₁) and the geometric mean (ēₙ^{1/n}). Newton's inequality (1707) is the log-concavity ēₖ² ≥ ēₖ₋₁·ēₖ₊₁; Maclaurin's inequality (1729) is the resulting chain ē₁ ≥ ē₂^{1/2} ≥ ⋯ ≥ ēₙ^{1/n}, a refinement of AM–GM. The standard derivation (Hardy–Littlewood–Pólya, Theorem 52) observes that log-concavity makes the ratios ēₖ/ēₖ₋₁ non-increasing, so the running geometric mean of these ratios — which equals ēₖ^{1/k} — is non-increasing. This file formalizes exactly that derivation for an abstract sequence.",
+    "problemStatement": "**Open question from NewtonInductiveStepOQ01 (openQuestions[1])**:\n\n'Derive the full Maclaurin inequality chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}.'",
+    "text": "We prove the chain follows from Newton's log-concavity for any positive sequence with a₀ = 1, in both polynomial and radical (n-th root) form, with 0 axioms. Newton's inequalities themselves are the hypothesis.",
+    "proofStrategy": "Work with the consecutive ratios r k = a k / a (k-1). (1) Log-concavity a(k-1)·a(k+1) ≤ a k² cross-multiplies (div_le_div_iff₀) to r(k+1) ≤ r k, so the ratios are non-increasing (ratioSeq_antitone_of_logConcave, by induction). (2) a k telescopes: ∏_{j=1}^k r j = a k (prod_ratioSeq, induction with Finset.prod_Icc_succ_top and a₀ = 1). (3) Since each r j (j ≤ k) is ≥ r(k+1), Finset.prod_le_prod gives r(k+1)^k ≤ ∏ r j = a k (lastRatio_pow_le). (4) Writing a(k+1) = a k · r(k+1), this yields a(k+1)^k = a k^k · r(k+1)^k ≤ a k^k · a k = a k^{k+1} (maclaurin_pow). (5) Taking real (k(k+1))-th roots via Real.rpow_le_rpow converts the polynomial form to the radical form a(k+1)^{1/(k+1)} ≤ a k^{1/k} (maclaurin_root).",
+    "keyInsights": [
+      "**Log-concavity = non-increasing ratios.** The single inequality a(k-1)·a(k+1) ≤ a k² is, after cross-multiplying, exactly r(k+1) ≤ r k for the ratios r k = a k/a(k-1). The whole Maclaurin phenomenon is monotonicity of these ratios.",
+      "**Maclaurin = monotone running geometric mean.** Because a k = r₁·r₂·⋯·r k (telescoping, using a₀ = 1), ēₖ^{1/k} is the geometric mean of the first k ratios; appending a smaller ratio can only lower it. Formally this is r(k+1)^k ≤ ∏_{j≤k} r j, a Finset.prod_le_prod over a non-increasing sequence.",
+      "**The polynomial form avoids real powers.** a_{k+1}^k ≤ a_k^{k+1} (natural-number powers) is equivalent to the radical chain but needs no Real.rpow, so its proof is clean algebra; the radical form follows by one monotone rpow step.",
+      "**A reduction keeps it honest and axiom-free.** Newton's inequalities (the parent's general k ≥ 2 case is still an open sorry) enter only as an explicit hypothesis. The file is 0-axiom, 0-sorry, and the chain instantiates for the elementary symmetric means the moment Newton's inequality is completed.",
+      "**Equality is geometric.** For equal inputs the means form a geometric sequence a k = t^k, which satisfies log-concavity with equality and makes the whole chain an equality — the extremal case of Maclaurin."
+    ],
+    "prerequisites": [
+      "Newton's inequalities (log-concavity of the elementary symmetric means) — carried as a hypothesis",
+      "Finset.prod over Icc, Finset.prod_le_prod, Finset.prod_const",
+      "Real.rpow basics (rpow_natCast, rpow_le_rpow, rpow_mul) for the radical form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "ratios-antitone",
+      "title": "Log-Concavity ⇒ Ratios Non-Increasing",
+      "startLine": 46,
+      "endLine": 84,
+      "summary": "ratioSeq a k = a k / a (k-1) with ratioSeq_pos. ratioSeq_step_of_logConcave: log-concavity cross-multiplies (div_le_div_iff₀) to r(k+1) ≤ r k. ratioSeq_antitone_of_logConcave: by induction, m ≤ n (1 ≤ m) gives r n ≤ r m.",
+      "mathContext": "$a(k-1)a(k+1) \\le a(k)^2 \\iff a(k+1)/a(k) \\le a(k)/a(k-1)$: the ratios decrease."
+    },
+    {
+      "id": "telescoping",
+      "title": "Telescoping Product",
+      "startLine": 86,
+      "endLine": 101,
+      "summary": "prod_ratioSeq: ∏_{j=1}^k (a j / a (j-1)) = a k, by induction with Finset.prod_Icc_succ_top and a₀ = 1 (mul_div_cancel₀).",
+      "mathContext": "$\\prod_{j=1}^k \\frac{a_j}{a_{j-1}} = a_k$ since the product telescopes and $a_0 = 1$."
+    },
+    {
+      "id": "maclaurin-poly",
+      "title": "Maclaurin's Chain — Polynomial Form",
+      "startLine": 103,
+      "endLine": 142,
+      "summary": "lastRatio_pow_le: r(k+1)^k ≤ a k, since r(k+1)^k = ∏ r(k+1) ≤ ∏ r j (Finset.prod_le_prod, each r j ≥ r(k+1)) = a k. maclaurin_pow: a(k+1)^k = a k^k·r(k+1)^k ≤ a k^k·a k = a k^{k+1}.",
+      "mathContext": "$a_{k+1}^k \\le a_k^{k+1}$, equivalent to $a_{k+1}^{1/(k+1)} \\le a_k^{1/k}$."
+    },
+    {
+      "id": "maclaurin-root",
+      "title": "Maclaurin's Chain — Radical Form",
+      "startLine": 144,
+      "endLine": 179,
+      "summary": "maclaurin_root: a(k+1)^{1/(k+1)} ≤ a k^{1/k} (Real.rpow). The polynomial form is recast with real exponents (Real.rpow_natCast) and both sides raised to the power 1/(k(k+1)) ≥ 0 (Real.rpow_le_rpow); the exponents simplify via Real.rpow_mul and field_simp.",
+      "mathContext": "$\\bar e_1 \\ge \\bar e_2^{1/2} \\ge \\bar e_3^{1/3} \\ge \\cdots$ — the chain exactly as classically stated."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "newton-inductive-step-oq-01",
+      "relationship": "extends",
+      "description": "Answers openQuestions[1] of the parent (derive the full Maclaurin chain): supplies the complete, axiom-free reduction Newton's log-concavity ⟹ Maclaurin's chain, taking Newton's inequalities as the hypothesis."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Maclaurin inequality chain is derived in full from Newton's log-concavity for an abstract positive sequence with a₀ = 1, in both polynomial form (a_{k+1}^k ≤ a_k^{k+1}) and radical form (a_{k+1}^{1/(k+1)} ≤ a_k^{1/k}). The proof is the classical one: non-increasing ratios, telescoping product, and a product comparison. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "The reduction is complete and self-contained: the only input is Newton's inequalities (log-concavity), supplied as a hypothesis. Instantiating the sequence at the elementary symmetric means ēₖ turns the parent's Newton inequality into the full Maclaurin chain — so completing the parent's open k ≥ 2 case immediately yields Maclaurin for symmetric means.",
+    "openQuestions": [
+      "Discharge the parent's open Newton inequality newton_inequality_means for k ≥ 2, then instantiate a := ēₖ here to obtain the unconditional Maclaurin chain for elementary symmetric means.",
+      "Prove the equality case: the chain is an equality iff all xᵢ are equal (the sequence is geometric).",
+      "Extend to the reverse/weighted Maclaurin inequalities and the connection to power means (the full Maclaurin–power-mean hierarchy)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "NewtonMaclaurinChain",
+    "lineCount": 179,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/NewtonInductiveStepOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Maclaurin, C.",
+      "title": "A second letter to Martin Folkes, Esq.; concerning the roots of equations",
+      "year": "1729",
+      "note": "Philosophical Transactions 36, 59-96. Original source of Maclaurin's inequality."
+    },
+    {
+      "authors": "Hardy, G.H., Littlewood, J.E., Pólya, G.",
+      "title": "Inequalities",
+      "year": "1952",
+      "note": "Cambridge University Press, 2nd ed. §2.22, Theorem 52: Maclaurin from Newton."
+    },
+    {
+      "authors": "Niculescu, C.P.",
+      "title": "A new look at Newton's inequalities",
+      "year": "2000",
+      "note": "J. Inequal. Pure Appl. Math. 1(2), Article 17."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "maclaurin_pow",
+      "type": "core",
+      "description": "Maclaurin's chain, polynomial form: a positive log-concave sequence with a₀=1 satisfies a_{k+1}^k ≤ a_k^{k+1} for k ≥ 1",
+      "leanType": "{a : ℕ → ℝ} → (∀ n, 0 < a n) → a 0 = 1 → (∀ k, 1 ≤ k → a (k-1) * a (k+1) ≤ a k ^ 2) → ∀ {k}, 1 ≤ k → a (k+1) ^ k ≤ a k ^ (k+1)"
+    },
+    {
+      "name": "maclaurin_root",
+      "type": "core",
+      "description": "Maclaurin's chain, radical form: a_{k+1}^{1/(k+1)} ≤ a_k^{1/k} (Real.rpow), the chain exactly as classically stated",
+      "leanType": "{a : ℕ → ℝ} → (∀ n, 0 < a n) → a 0 = 1 → (∀ k, 1 ≤ k → a (k-1) * a (k+1) ≤ a k ^ 2) → ∀ {k}, 1 ≤ k → a (k+1) ^ (1/(k+1) : ℝ) ≤ a k ^ (1/k : ℝ)"
+    },
+    {
+      "name": "ratioSeq_antitone_of_logConcave",
+      "type": "supporting",
+      "description": "Log-concavity makes the consecutive ratios a k / a (k-1) non-increasing from index 1",
+      "leanType": "{a : ℕ → ℝ} → (∀ n, 0 < a n) → (∀ k, 1 ≤ k → a (k-1) * a (k+1) ≤ a k ^ 2) → ∀ n m, 1 ≤ m → m ≤ n → ratioSeq a n ≤ ratioSeq a m"
+    },
+    {
+      "name": "prod_ratioSeq",
+      "type": "supporting",
+      "description": "Telescoping: a k = ∏_{j=1}^k (a j / a (j-1)) using a₀ = 1",
+      "leanType": "{a : ℕ → ℝ} → (∀ n, 0 < a n) → a 0 = 1 → ∀ k, ∏ j ∈ Finset.Icc 1 k, ratioSeq a j = a k"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **openQuestions[1]** of the parent `newton-inductive-step-oq-01`:
*"Derive the full Maclaurin inequality chain ē₁ ≥ ē₂^{1/2} ≥ ... ≥ ēₙ^{1/n}."*

The parent's general Newton inequality (k ≥ 2) is still an open `sorry`. Rather than build on it, this entry proves the **reduction** Newton ⟹ Maclaurin for an abstract positive log-concave sequence `a` with `a₀ = 1` — fully verified, **0 axioms, 0 sorries**.

## What's proved

- **`ratioSeq_antitone_of_logConcave`** — log-concavity `a(k-1)·a(k+1) ≤ a k²` makes the consecutive ratios `a k / a (k-1)` non-increasing.
- **`prod_ratioSeq`** — `a k` telescopes as `∏_{j=1}^k (a j / a (j-1))` (using `a₀ = 1`).
- **`lastRatio_pow_le`** — `r(k+1)^k ≤ a k` via `Finset.prod_le_prod` over the non-increasing ratios.
- **`maclaurin_pow`** — the chain in **polynomial form** `a_{k+1}^k ≤ a_k^{k+1}` (no real powers).
- **`maclaurin_root`** — the chain in **radical form** `a_{k+1}^{1/(k+1)} ≤ a_k^{1/k}` via `Real.rpow` — exactly as classically stated.

This is the classical Hardy–Littlewood–Pólya derivation (Theorem 52): non-increasing ratios ⇒ non-increasing running geometric mean `ēₖ^{1/k}`.

## Honesty / axiom status

- `#print axioms` on `maclaurin_pow` and `maclaurin_root` → only `propext` / `Classical.choice` / `Quot.sound`. **0 declared axioms, 0 sorries.**
- Newton's inequalities (log-concavity) are an **explicit hypothesis**, not a global axiom. Instantiating `a := ēₖ` yields the full Maclaurin chain for elementary symmetric means the moment the parent's open Newton case (k ≥ 2) is completed.
- Status `verified`, badge `original`. Self-contained: imports only Mathlib v4.26.

## Verification

- Compiles against pinned Mathlib **v4.26** (`lake env lean`; docker unavailable this session).
- `pnpm annotations:build` clean for `newton-inductive-step-oq-01-oq-02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)