### PR TITLE
research(schroeder-bernstein-gfp-oq-02-oq-01): greatest fixed point variant [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BanachSteinhausTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/BanachSteinhausTheoremOQ01OQ02.lean
@@ -1,0 +1,163 @@
+/-
+# Banach–Steinhaus: the resonance set is comeagre (condensation of singularities)
+
+The gallery entry `banach-steinhaus-theorem-oq-01` packages Mathlib's uniform
+boundedness principle together with its *condensation of singularities*
+contrapositive (`resonance`): if a family `g : ι → E →SL[σ₁₂] F` of continuous
+linear maps out of a Banach space has unbounded operator norms, then there is a
+*single* resonance point `x` at which the values `‖g i x‖` are unbounded.
+
+That contrapositive only asserts the resonance set is *nonempty*. Its open
+question asks for the **quantitative Baire-category strengthening**: the
+resonance set
+
+  `R = { x : E | ∀ C, ∃ i, C < ‖g i x‖ }`   (equivalently `⨆ i, ‖g i x‖ = ∞`)
+
+is not merely nonempty but **comeagre** — it is a residual set, hence (since a
+Banach space is a Baire space) *dense*. The set of points where the family
+condenses its singularities is topologically generic.
+
+This file proves that strengthening from scratch:
+
+* `resonanceSet` — the set of resonance points;
+* `sublevel_isClosed` — the sublevel sets `{x | ∀ i, ‖g i x‖ ≤ n}` are closed;
+* `sublevel_interior_eq_empty` — under unbounded operator norms each sublevel
+  set has empty interior (the only place Banach–Steinhaus itself is used: a
+  sublevel set with nonempty interior would force pointwise — hence uniform —
+  boundedness);
+* `resonanceSet_comeagre` — **the main result**: `R` is residual (comeagre);
+* `resonanceSet_compl_isMeagre` — equivalently, its complement is meagre;
+* `resonanceSet_dense` — `R` is dense in a Banach space;
+* `resonance_of_comeagre` — the comeagre statement recovers the parent's single
+  resonance point, so this genuinely strengthens `resonance`.
+
+All results are verified with no axioms and no `sorry`.
+-/
+import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+import Mathlib.Tactic
+
+open Filter Topology Set Metric
+
+namespace BanachSteinhausResonance
+
+variable {𝕜 𝕜₂ : Type*} [NontriviallyNormedField 𝕜] [NontriviallyNormedField 𝕜₂]
+  {σ₁₂ : 𝕜 →+* 𝕜₂} [RingHomIsometric σ₁₂]
+  {E : Type*} [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜₂ F]
+  {ι : Type*}
+
+/-- The **resonance set** of an operator family `g`: the points `x` at which the
+values `‖g i x‖` are unbounded over `i` (equivalently `⨆ i, ‖g i x‖ = ∞`). -/
+def resonanceSet (g : ι → E →SL[σ₁₂] F) : Set E :=
+  {x | ∀ C : ℝ, ∃ i, C < ‖g i x‖}
+
+set_option linter.unusedSectionVars false in
+/-- The sublevel set `{x | ∀ i, ‖g i x‖ ≤ n}` is closed: it is an intersection of
+the closed sets `{x | ‖g i x‖ ≤ n}`, each a sublevel set of the continuous map
+`x ↦ ‖g i x‖`. -/
+theorem sublevel_isClosed (g : ι → E →SL[σ₁₂] F) (n : ℝ) :
+    IsClosed {x : E | ∀ i, ‖g i x‖ ≤ n} := by
+  rw [setOf_forall]
+  exact isClosed_iInter fun i =>
+    isClosed_le (continuous_norm.comp (g i).continuous) continuous_const
+
+/-- Under **unbounded operator norms**, every sublevel set `{x | ∀ i, ‖g i x‖ ≤ n}`
+has empty interior. This is the heart of the Baire-category argument and the only
+step that invokes Banach–Steinhaus: a sublevel set with nonempty interior would
+contain a ball, and rescaling translates of that ball through the (semi)linear
+maps would bound the values `‖g i x‖` at *every* point — pointwise boundedness,
+which `banach_steinhaus` upgrades to a uniform bound, contradicting the
+hypothesis. -/
+theorem sublevel_interior_eq_empty [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) (n : ℝ) :
+    interior {x : E | ∀ i, ‖g i x‖ ≤ n} = ∅ := by
+  by_contra hne
+  -- A nonempty interior contains a ball `ball x₀ r ⊆ {x | ∀ i, ‖g i x‖ ≤ n}`.
+  obtain ⟨x₀, hx₀⟩ := Set.nonempty_iff_ne_empty.mpr hne
+  obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp isOpen_interior x₀ hx₀
+  have hballV : ball x₀ r ⊆ {x : E | ∀ i, ‖g i x‖ ≤ n} := hball.trans interior_subset
+  have hx0V : ∀ i, ‖g i x₀‖ ≤ n := interior_subset hx₀
+  -- The family is pointwise bounded everywhere.
+  have hpb : ∀ x : E, ∃ C, ∀ i, ‖g i x‖ ≤ C := by
+    intro x
+    -- Pick a small nonzero scalar `c` with `‖c‖ * (‖x‖ + 1) < r`.
+    obtain ⟨c, hc_pos, hc_lt⟩ :=
+      NormedField.exists_norm_lt 𝕜 (show (0:ℝ) < r / (‖x‖ + 1) by positivity)
+    have hcx : ‖c‖ * (‖x‖ + 1) < r := (lt_div_iff₀ (by positivity)).mp hc_lt
+    refine ⟨2 * n / ‖c‖, fun i => ?_⟩
+    -- `x₀ + c • x` lies in the ball, hence in the sublevel set.
+    have hnorm_cx : ‖c • x‖ < r := by
+      rw [norm_smul]
+      calc ‖c‖ * ‖x‖ ≤ ‖c‖ * (‖x‖ + 1) := by gcongr; linarith [norm_nonneg x]
+        _ < r := hcx
+    have hmem : ∀ j, ‖g j (x₀ + c • x)‖ ≤ n :=
+      hballV (by rw [mem_ball, dist_eq_norm, add_sub_cancel_left]; exact hnorm_cx)
+    -- `g i (c • x) = g i (x₀ + c • x) - g i x₀`, so its norm is `≤ 2 * n`.
+    have hsplit : σ₁₂ c • g i x = g i (x₀ + c • x) - g i x₀ := by
+      rw [map_add, map_smulₛₗ]; abel
+    have hbound : ‖c‖ * ‖g i x‖ ≤ 2 * n := by
+      have hle : ‖σ₁₂ c • g i x‖ ≤ 2 * n := by
+        rw [hsplit]
+        calc ‖g i (x₀ + c • x) - g i x₀‖
+            ≤ ‖g i (x₀ + c • x)‖ + ‖g i x₀‖ := norm_sub_le _ _
+          _ ≤ n + n := add_le_add (hmem i) (hx0V i)
+          _ = 2 * n := by ring
+      rwa [norm_smul, RingHomIsometric.norm_map] at hle
+    -- Divide by `‖c‖ > 0`.
+    rw [le_div_iff₀ hc_pos, mul_comm]
+    exact hbound
+  -- Pointwise bounded ⇒ uniformly bounded, contradicting unbounded norms.
+  obtain ⟨C', hC'⟩ := banach_steinhaus hpb
+  obtain ⟨i, hi⟩ := h C'
+  exact absurd (hC' i) (not_le.mpr hi)
+
+/-- **The resonance set is comeagre.** If the operator norms of a family of
+continuous linear maps out of a Banach space are unbounded, then the set of
+resonance points (where the values `‖g i x‖` are unbounded) is residual.
+
+This is the Baire-category strengthening of the condensation-of-singularities
+contrapositive: failure of uniform boundedness is witnessed not just at one
+point, but on a topologically generic (comeagre) set. -/
+theorem resonanceSet_comeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : resonanceSet g ∈ residual E := by
+  -- It suffices to show the complement is meagre.
+  suffices hmeagre : IsMeagre (resonanceSet g)ᶜ by
+    rwa [IsMeagre, compl_compl] at hmeagre
+  -- The complement is contained in a countable union of sublevel sets.
+  have hsub : (resonanceSet g)ᶜ ⊆ ⋃ n : ℕ, {x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)} := by
+    intro x hx
+    simp only [resonanceSet, mem_compl_iff, mem_setOf_eq, not_forall, not_exists,
+      not_lt] at hx
+    obtain ⟨C, hC⟩ := hx
+    obtain ⟨n, hn⟩ := exists_nat_ge C
+    exact mem_iUnion.mpr ⟨n, fun i => (hC i).trans hn⟩
+  refine IsMeagre.mono hsub (isMeagre_iUnion fun n => ?_)
+  -- Each sublevel set is closed with empty interior, hence nowhere dense, hence meagre.
+  have hnwd : IsNowhereDense {x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)} :=
+    (sublevel_isClosed g _).isNowhereDense_iff.mpr (sublevel_interior_eq_empty h _)
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  exact ⟨{{x : E | ∀ i, ‖g i x‖ ≤ (n : ℝ)}}, by simpa using hnwd, countable_singleton _,
+    by simp⟩
+
+/-- Equivalent phrasing of `resonanceSet_comeagre`: the complement of the
+resonance set — the points where the family is pointwise bounded — is meagre. -/
+theorem resonanceSet_compl_isMeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : IsMeagre (resonanceSet g)ᶜ := by
+  rw [IsMeagre, compl_compl]; exact resonanceSet_comeagre h
+
+/-- **The resonance set is dense.** Since a Banach space is a Baire space, the
+comeagre resonance set is dense: resonance points are not just generic, they are
+arbitrarily close to every point of the space. -/
+theorem resonanceSet_dense [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : Dense (resonanceSet g) :=
+  dense_of_mem_residual (resonanceSet_comeagre h)
+
+/-- The comeagre strengthening recovers the parent gallery entry's `resonance`
+statement: a comeagre (in particular nonempty) resonance set yields a single
+point at which the values `‖g i x‖` are unbounded. This shows the present result
+genuinely strengthens the condensation-of-singularities contrapositive. -/
+theorem resonance_of_comeagre [CompleteSpace E] {g : ι → E →SL[σ₁₂] F}
+    (h : ∀ C : ℝ, ∃ i, C < ‖g i‖) : ∃ x : E, ∀ C : ℝ, ∃ i, C < ‖g i x‖ :=
+  (resonanceSet_dense h).nonempty
+
+end BanachSteinhausResonance

--- a/proofs/Proofs/SchroederBernsteinOQ02OQ01.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ02OQ01.lean
@@ -1,0 +1,266 @@
+import Mathlib.Order.FixedPoints
+import Mathlib.Data.Set.Lattice
+import Mathlib.Logic.Equiv.Defs
+import Mathlib.Tactic
+
+/-
+# The Greatest Fixed Point Variant of Schroeder–Bernstein
+
+## Open Question (OQ-02 → OQ-01)
+
+The Knaster–Tarski proof of Schroeder–Bernstein (gallery entry
+`schroeder-bernstein-oq-02`) builds the bijection from the **least** fixed point
+`S* = lfp(T)` of the monotone operator `T(S) = (range g)ᶜ ∪ g '' (f '' S)`. Its
+open question asks:
+
+> The Knaster–Tarski fixed point is the *least* fixed point of `T`. Is the
+> greatest fixed point `S** = gfp(T)` equally useful? What is `S** ∖ S*`
+> geometrically?
+
+## Answer
+
+**Yes — and the right statement is stronger:** *every* fixed point of `T` yields
+a Schroeder–Bernstein bijection by the same piecewise formula. The parent's
+constructions never used minimality of `lfp`; they used only the fixed-point
+equation `T(S) = S`, injectivity of `f`, and injectivity of `g`. We therefore
+generalize the whole construction to an arbitrary fixed point `S` and then
+instantiate it at both `lfp(T)` and `gfp(T)`. The `gfp` route is a genuinely
+different, equally valid proof.
+
+The difference `D = gfp(T) ∖ lfp(T)` has a clean geometric description in terms
+of the dynamics of `φ = g ∘ f : α → α`:
+
+* `D ⊆ range g` — `D` contains no "sources" (`(range g)ᶜ` lies entirely in
+  `lfp`);
+* `φ` maps `D` into `D`, and **every** point of `D` has a `φ`-preimage in `D`;
+* hence `φ` restricts to a **bijection** `D → D` (`Set.BijOn`).
+
+So `D` is the maximal set on which `g ∘ f` acts bijectively with neither sources
+nor sinks: the union of the **bi-infinite `φ`-chains**. The least fixed point
+collects exactly the chains that *start* at a source in `(range g)ᶜ`; the
+greatest fixed point adds back these doubly-infinite chains. (In the classical
+orbit decomposition of Schroeder–Bernstein these are the `ℤ`-orbits; `lfp`
+resolves them "towards `A`", `gfp` "towards `B`".)
+
+All results are verified with no axioms and no `sorry`.
+-/
+
+open Classical Function
+
+noncomputable section
+
+namespace KnasterTarskiGFP
+
+variable {α β : Type*}
+
+/-! ## Section 1: The Monotone Operator (as in OQ-02) -/
+
+/-- The CBS operator `T(S) = (range g)ᶜ ∪ g '' (f '' S)`. -/
+def cbsOp (f : α → β) (g : β → α) (S : Set α) : Set α :=
+  (Set.range g)ᶜ ∪ g '' (f '' S)
+
+/-- `T` is monotone. -/
+theorem cbsOp_mono (f : α → β) (g : β → α) : Monotone (cbsOp f g) := by
+  intro S₁ S₂ h
+  exact Set.union_subset_union_right _ (Set.image_mono (Set.image_mono h))
+
+/-- `T` bundled as an order homomorphism, enabling Knaster–Tarski (both fixed points). -/
+def cbsHom (f : α → β) (g : β → α) : Set α →o Set α where
+  toFun := cbsOp f g
+  monotone' := cbsOp_mono f g
+
+/-! ## Section 2: The Bijection from an *Arbitrary* Fixed Point
+
+The key observation answering the open question: the parent's lemmas use only
+the fixed-point equation `T(S) = S`, never minimality. We package them for any
+`S` with `cbsOp f g S = S`. -/
+
+variable (f : α → β) (g : β → α)
+
+/-- Elements outside `range g` lie in any fixed point. -/
+theorem compl_range_subset_fp {S : Set α} (hS : cbsOp f g S = S) :
+    (Set.range g)ᶜ ⊆ S := by
+  intro a ha
+  have h : a ∈ cbsOp f g S := Or.inl ha
+  rwa [hS] at h
+
+/-- Elements outside a fixed point have a `g`-preimage. -/
+theorem mem_range_of_not_mem_fp {S : Set α} (hS : cbsOp f g S = S) {a : α}
+    (ha : a ∉ S) : a ∈ Set.range g := by
+  by_contra h
+  exact ha (compl_range_subset_fp f g hS h)
+
+/-- A fixed point is closed under `g ∘ f` (set form). -/
+theorem gf_image_subset_fp {S : Set α} (hS : cbsOp f g S = S) :
+    g '' (f '' S) ⊆ S := by
+  intro a ha
+  have h : a ∈ cbsOp f g S := Or.inr ha
+  rwa [hS] at h
+
+/-- A fixed point is closed under `g ∘ f` (pointwise form). -/
+theorem gf_mem_fp {S : Set α} (hS : cbsOp f g S = S) {a : α} (ha : a ∈ S) :
+    g (f a) ∈ S :=
+  gf_image_subset_fp f g hS ⟨f a, ⟨a, ha, rfl⟩, rfl⟩
+
+/-- If `g b` lies in a fixed point then `b ∈ f '' S` (needs injectivity of `g`). -/
+theorem mem_fimage_of_gb_mem_fp (hg : Injective g) {S : Set α}
+    (hS : cbsOp f g S = S) {b : β} (hgb : g b ∈ S) : b ∈ f '' S := by
+  have h : g b ∈ cbsOp f g S := by rw [hS]; exact hgb
+  rw [cbsOp] at h
+  rcases h with h' | ⟨x, hx, hgx⟩
+  · exact absurd (Set.mem_range.mpr ⟨b, rfl⟩) h'
+  · rwa [hg hgx] at hx
+
+/-- Contrapositive: if `b ∉ f '' S` then `g b ∉ S`. -/
+theorem gb_not_mem_fp (hg : Injective g) {S : Set α} (hS : cbsOp f g S = S)
+    {b : β} (hb : b ∉ f '' S) : g b ∉ S :=
+  fun h => hb (mem_fimage_of_gb_mem_fp f g hg hS h)
+
+/-- The piecewise bijection attached to a fixed point `S`:
+`a ↦ f a` on `S`, and `a ↦ g⁻¹ a` off `S`. -/
+def bijFP {S : Set α} (hS : cbsOp f g S = S) (a : α) : β :=
+  if h : a ∈ S then f a else (mem_range_of_not_mem_fp f g hS h).choose
+
+theorem bijFP_of_mem {S : Set α} (hS : cbsOp f g S = S) {a : α} (ha : a ∈ S) :
+    bijFP f g hS a = f a :=
+  dif_pos ha
+
+theorem bijFP_of_not_mem_spec {S : Set α} (hS : cbsOp f g S = S) {a : α}
+    (ha : a ∉ S) : g (bijFP f g hS a) = a := by
+  have heq : bijFP f g hS a = (mem_range_of_not_mem_fp f g hS ha).choose := dif_neg ha
+  rw [heq]
+  exact (mem_range_of_not_mem_fp f g hS ha).choose_spec
+
+theorem bijFP_injective {S : Set α} (hS : cbsOp f g S = S)
+    (hf : Injective f) : Injective (bijFP f g hS) := by
+  intro a₁ a₂ heq
+  by_cases h₁ : a₁ ∈ S <;> by_cases h₂ : a₂ ∈ S
+  · rw [bijFP_of_mem f g hS h₁, bijFP_of_mem f g hS h₂] at heq
+    exact hf heq
+  · exfalso
+    have hg12 := congr_arg g heq
+    rw [bijFP_of_mem f g hS h₁, bijFP_of_not_mem_spec f g hS h₂] at hg12
+    exact h₂ (hg12 ▸ gf_mem_fp f g hS h₁)
+  · exfalso
+    have hg12 := congr_arg g heq
+    rw [bijFP_of_not_mem_spec f g hS h₁, bijFP_of_mem f g hS h₂] at hg12
+    exact h₁ (hg12 ▸ gf_mem_fp f g hS h₂)
+  · have hg12 := congr_arg g heq
+    rw [bijFP_of_not_mem_spec f g hS h₁, bijFP_of_not_mem_spec f g hS h₂] at hg12
+    exact hg12
+
+theorem bijFP_surjective {S : Set α} (hS : cbsOp f g S = S) (hg : Injective g) :
+    Surjective (bijFP f g hS) := by
+  intro b
+  by_cases hb : b ∈ f '' S
+  · obtain ⟨a, ha, rfl⟩ := hb
+    exact ⟨a, bijFP_of_mem f g hS ha⟩
+  · have hgb : g b ∉ S := gb_not_mem_fp f g hg hS hb
+    exact ⟨g b, hg (bijFP_of_not_mem_spec f g hS hgb)⟩
+
+/-- **Every** fixed point of `T` yields a Schroeder–Bernstein bijection. -/
+def equivFP {S : Set α} (hS : cbsOp f g S = S) (hf : Injective f)
+    (hg : Injective g) : α ≃ β :=
+  Equiv.ofBijective (bijFP f g hS)
+    ⟨bijFP_injective f g hS hf, bijFP_surjective f g hS hg⟩
+
+/-! ## Section 3: The Least and Greatest Fixed Points
+
+Both `lfp(T)` and `gfp(T)` are fixed points (Knaster–Tarski), so both feed the
+construction of Section 2. -/
+
+/-- The least fixed point `S* = lfp(T)` (the parent's choice). -/
+def lfpSet : Set α := (cbsHom f g).lfp
+
+/-- The greatest fixed point `S** = gfp(T)` (this entry's choice). -/
+def gfpSet : Set α := (cbsHom f g).gfp
+
+theorem lfpSet_fp : cbsOp f g (lfpSet f g) = lfpSet f g := (cbsHom f g).map_lfp
+
+theorem gfpSet_fp : cbsOp f g (gfpSet f g) = gfpSet f g := (cbsHom f g).map_gfp
+
+/-- The least fixed point is contained in the greatest. -/
+theorem lfpSet_subset_gfpSet : lfpSet f g ⊆ gfpSet f g :=
+  OrderHom.le_gfp _ (cbsHom f g).map_lfp.ge
+
+/-- **Greatest-fixed-point Schroeder–Bernstein**: the `gfp` bijection. -/
+def gfp_equiv (hf : Injective f) (hg : Injective g) : α ≃ β :=
+  equivFP f g (gfpSet_fp f g) hf hg
+
+/-- The `gfp` route recovers the Schroeder–Bernstein theorem. -/
+theorem gfp_schroeder_bernstein (hf : Injective f) (hg : Injective g) :
+    ∃ h : α → β, Function.Bijective h :=
+  ⟨bijFP f g (gfpSet_fp f g),
+    bijFP_injective f g _ hf, bijFP_surjective f g _ hg⟩
+
+/-- The least-fixed-point bijection (the parent's), exhibited from the same
+general construction — so `lfp` and `gfp` are two instances of one theorem. -/
+def lfp_equiv (hf : Injective f) (hg : Injective g) : α ≃ β :=
+  equivFP f g (lfpSet_fp f g) hf hg
+
+/-! ## Section 4: The Geometry of `gfp ∖ lfp`
+
+`D = gfp(T) ∖ lfp(T)` is exactly the set on which `φ = g ∘ f` acts bijectively:
+no sources (`D ⊆ range g`), `φ` maps `D` into `D`, and every point of `D` has a
+`φ`-predecessor in `D`. These are the bi-infinite `φ`-chains. -/
+
+/-- The difference `D = gfp(T) ∖ lfp(T)`. -/
+def diffSet : Set α := gfpSet f g \ lfpSet f g
+
+/-- `gfp = lfp ∪ D`: the greatest fixed point adds exactly `D` to the least. -/
+theorem gfpSet_eq_lfp_union_diff :
+    gfpSet f g = lfpSet f g ∪ diffSet f g :=
+  (Set.union_diff_cancel (lfpSet_subset_gfpSet f g)).symm
+
+/-- `D` contains no sources: it lies entirely inside `range g`. Equivalently,
+all of `(range g)ᶜ` is already in the least fixed point. -/
+theorem diffSet_subset_range : diffSet f g ⊆ Set.range g := by
+  intro a ha
+  by_contra h
+  exact ha.2 (compl_range_subset_fp f g (lfpSet_fp f g) h)
+
+/-- `φ = g ∘ f` maps `D` into `D`. -/
+theorem diffSet_gf_mem (hf : Injective f) (hg : Injective g) {a : α}
+    (ha : a ∈ diffSet f g) : g (f a) ∈ diffSet f g := by
+  refine ⟨gf_mem_fp f g (gfpSet_fp f g) ha.1, ?_⟩
+  intro hlfp
+  obtain ⟨a', ha', haa'⟩ := mem_fimage_of_gb_mem_fp f g hg (lfpSet_fp f g) hlfp
+  exact ha.2 (hf haa' ▸ ha')
+
+/-- Every point of `D` has a `φ`-predecessor inside `D`: there is no sink, the
+chains extend backward indefinitely within `D`. (No injectivity needed — this is
+forced by the two fixed-point equations alone.) -/
+theorem diffSet_has_pred {a : α}
+    (ha : a ∈ diffSet f g) : ∃ a', a' ∈ diffSet f g ∧ g (f a') = a := by
+  have ha_in_op : a ∈ cbsOp f g (gfpSet f g) := by rw [gfpSet_fp]; exact ha.1
+  rw [cbsOp] at ha_in_op
+  rcases ha_in_op with hc | ⟨b, hb, hgb⟩
+  · exact absurd (compl_range_subset_fp f g (lfpSet_fp f g) hc) ha.2
+  · obtain ⟨a', ha'gfp, hfa'⟩ := hb
+    refine ⟨a', ⟨ha'gfp, ?_⟩, by rw [hfa', hgb]⟩
+    intro hlfp
+    apply ha.2
+    have hmem : g (f a') ∈ lfpSet f g := gf_mem_fp f g (lfpSet_fp f g) hlfp
+    rwa [hfa', hgb] at hmem
+
+/-- **`φ = g ∘ f` restricts to a bijection of `D = gfp ∖ lfp`.** This is the
+geometric content of the open question: the difference between the greatest and
+least fixed points is precisely the maximal set on which `g ∘ f` acts bijectively
+— the union of the bi-infinite chains, with neither sources nor sinks. -/
+theorem diffSet_gf_bijOn (hf : Injective f) (hg : Injective g) :
+    Set.BijOn (fun a => g (f a)) (diffSet f g) (diffSet f g) :=
+  ⟨fun _ ha => diffSet_gf_mem f g hf hg ha,
+   fun _ _ _ _ h => hf (hg h),
+   fun _ ha => diffSet_has_pred f g ha⟩
+
+/-- The least and greatest fixed points coincide iff `D` is empty — iff there are
+no bi-infinite `φ`-chains. -/
+theorem lfpSet_eq_gfpSet_iff_diff_empty :
+    lfpSet f g = gfpSet f g ↔ diffSet f g = ∅ := by
+  rw [diffSet, Set.diff_eq_empty]
+  exact ⟨fun h => h ▸ subset_rfl,
+    fun h => Set.Subset.antisymm (lfpSet_subset_gfpSet f g) h⟩
+
+end KnasterTarskiGFP
+
+end

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "From One Resonance Point to a Comeagre Set",
+    "content": "The parent entry's `resonance` (condensation of singularities) only asserts the resonance set is nonempty: a single point where a family of operators with unbounded norms blows up. The Baire-category proof actually gives more — the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is comeagre (residual), hence dense. Resonance points are topologically generic. This entry answers the open question posed by the parent entry.",
+    "mathContext": "If $\\sup_i\\|g_i\\| = \\infty$ for continuous linear maps out of a Banach space, then $R = \\{x : \\sup_i\\|g_i x\\| = \\infty\\}$ is comeagre.",
+    "significance": "context",
+    "relatedConcepts": ["condensation of singularities", "comeagre set", "residual set", "Baire category theorem", "Banach–Steinhaus theorem"],
+    "prerequisites": ["Banach spaces", "continuous linear maps", "meagre and residual sets"]
+  },
+  {
+    "id": "ann-resonance-set",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 52 },
+    "type": "definition",
+    "title": "The Resonance Set",
+    "content": "`resonanceSet g` is the set of points x at which the values ‖gᵢx‖ are unbounded over i: ∀ C, ∃ i, C < ‖gᵢx‖. Equivalently ⨆ᵢ ‖gᵢx‖ = ∞. The goal is to show this set is comeagre whenever the operator norms are unbounded.",
+    "mathContext": "$R = \\{x : \\forall C,\\ \\exists i,\\ C < \\|g_i x\\|\\} = \\{x : \\sup_i \\|g_i x\\| = \\infty\\}.$",
+    "significance": "key",
+    "relatedConcepts": ["resonance set", "unbounded family", "supremum of norms"],
+    "prerequisites": ["operator norm", "supremum"]
+  },
+  {
+    "id": "ann-sublevel-closed",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 58, "endLine": 62 },
+    "type": "theorem",
+    "title": "Sublevel Sets Are Closed",
+    "content": "The sublevel set {x | ∀i ‖gᵢx‖ ≤ n} is an intersection ⋂ᵢ {x | ‖gᵢx‖ ≤ n} of closed sets, each a sublevel set of the continuous map x ↦ ‖gᵢx‖. Closedness is what lets us identify these sets as nowhere dense (closed + empty interior) later.",
+    "mathContext": "$\\{x : \\forall i,\\ \\|g_i x\\| \\le n\\} = \\bigcap_i \\{x : \\|g_i x\\| \\le n\\}$ is closed.",
+    "significance": "standard",
+    "relatedConcepts": ["closed set", "sublevel set", "continuity of operator evaluation"],
+    "prerequisites": ["continuous functions", "intersections of closed sets"]
+  },
+  {
+    "id": "ann-empty-interior",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 64, "endLine": 112 },
+    "type": "theorem",
+    "title": "Sublevel Sets Have Empty Interior (the Crux)",
+    "content": "Under unbounded operator norms, each sublevel set has empty interior. Suppose not: the interior contains a ball ball x₀ r. For any x, choose a small nonzero scalar c with ‖c‖(‖x‖+1) < r so that x₀ + c•x stays in the ball; then ‖gᵢ(c•x)‖ ≤ ‖gᵢ(x₀+c•x)‖ + ‖gᵢx₀‖ ≤ 2n, and by isometric semilinearity ‖c‖·‖gᵢx‖ ≤ 2n, i.e. ‖gᵢx‖ ≤ 2n/‖c‖ for every i. That is pointwise boundedness; `banach_steinhaus` upgrades it to a uniform norm bound, contradicting the unboundedness hypothesis. This is the only place the Banach–Steinhaus theorem is used.",
+    "mathContext": "A ball $B(x_0,r)$ inside a sublevel set forces $\\|g_i x\\| \\le 2n/\\|c\\|$ for all $i$ at every $x$, hence uniform boundedness — a contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["empty interior", "rescaling argument", "pointwise boundedness", "uniform boundedness principle"],
+    "prerequisites": ["interior and balls", "operator norm scaling", "Banach–Steinhaus theorem"]
+  },
+  {
+    "id": "ann-comeagre",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 114, "endLine": 140 },
+    "type": "theorem",
+    "title": "The Resonance Set Is Comeagre",
+    "content": "The complement of R is contained in the countable union ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}. Each sublevel set is closed with empty interior, hence nowhere dense, hence meagre; a countable union of meagre sets is meagre, so Rᶜ is meagre and R is residual (comeagre). This is the main result.",
+    "mathContext": "$R^c \\subseteq \\bigcup_{n} \\{x : \\forall i,\\ \\|g_i x\\| \\le n\\}$, a countable union of nowhere-dense sets, so $R^c$ is meagre and $R$ is comeagre.",
+    "significance": "key",
+    "relatedConcepts": ["comeagre set", "residual filter", "meagre set", "nowhere dense set", "countable union"],
+    "prerequisites": ["meagre and residual sets", "Baire category"]
+  },
+  {
+    "id": "ann-dense-recover",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 162 },
+    "type": "theorem",
+    "title": "Dense, and Recovering the Single Resonance Point",
+    "content": "resonanceSet_compl_isMeagre restates the result as 'the pointwise-bounded set is meagre'. resonanceSet_dense upgrades comeagre to dense: a Banach space is a Baire space, where residual sets are dense. resonance_of_comeagre recovers the parent entry's `resonance` — a dense set is nonempty, so there is a single resonance point — confirming this is a genuine strengthening.",
+    "mathContext": "In a Baire space a residual set is dense, hence nonempty; this recovers the parent's existence of a resonance point.",
+    "significance": "supporting",
+    "relatedConcepts": ["dense set", "Baire space", "density of residual sets", "strengthening"],
+    "prerequisites": ["Baire spaces", "density"]
+  }
+]

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "banach-steinhaus-theorem-oq-01-oq-02",
+  "title": "The resonance set of an unbounded operator family is comeagre",
+  "slug": "banach-steinhaus-theorem-oq-01-oq-02",
+  "description": "The Banach–Steinhaus entry's condensation-of-singularities contrapositive (`resonance`) only asserts the resonance set is nonempty: a single point where a family of operators with unbounded norms blows up. This entry proves the Baire-category strengthening asked for in that entry's open questions — the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is not merely nonempty but comeagre (residual), hence dense in a Banach space. The set of resonance points is topologically generic. The argument is built from scratch: the sublevel sets {x | ∀i ‖gᵢx‖ ≤ n} are closed, and have empty interior (a sublevel set with interior would force pointwise — hence, by Banach–Steinhaus, uniform — boundedness), so the complement of R is a countable union of nowhere-dense sets.",
+  "meta": {
+    "author": "Stefan Banach / Hugo Steinhaus (condensation of singularities, 1927); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BanachSteinhausTheoremOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "functional-analysis",
+      "banach-space",
+      "operator-theory",
+      "uniform-boundedness",
+      "baire-category",
+      "comeagre",
+      "condensation-of-singularities"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "banach_steinhaus",
+        "description": "The Banach–Steinhaus theorem: a pointwise-bounded family of continuous linear maps out of a complete space is uniformly bounded in operator norm. Used only inside the empty-interior lemma to derive a contradiction.",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      },
+      {
+        "theorem": "isMeagre_iUnion",
+        "description": "A countable union of meagre sets is meagre — assembles meagreness of the complement of the resonance set from the sublevel sets",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "IsClosed.isNowhereDense_iff",
+        "description": "A closed set is nowhere dense iff its interior is empty — converts the empty-interior sublevel sets into nowhere-dense sets",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "dense_of_mem_residual",
+        "description": "In a Baire space, a residual (comeagre) set is dense — upgrades comeagre to dense for the Banach space",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "resonanceSet: definition of the resonance set R = {x | ∀ C, ∃ i, C < ‖gᵢx‖} (equivalently ⨆ᵢ ‖gᵢx‖ = ∞)",
+      "sublevel_isClosed: the sublevel sets {x | ∀i ‖gᵢx‖ ≤ n} are closed, as intersections of sublevel sets of the continuous maps x ↦ ‖gᵢx‖",
+      "sublevel_interior_eq_empty: the heart of the argument — under unbounded operator norms every sublevel set has empty interior, because a sublevel set containing a ball would, by rescaling translates of that ball through the (semi)linear maps, bound ‖gᵢx‖ at every point, giving pointwise boundedness that banach_steinhaus upgrades to a uniform bound, contradicting unboundedness",
+      "resonanceSet_comeagre: the main result — the resonance set is residual (comeagre): its complement is contained in the countable union ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n} of closed nowhere-dense sets, hence meagre",
+      "resonanceSet_compl_isMeagre: equivalent phrasing — the pointwise-bounded set (complement of the resonance set) is meagre",
+      "resonanceSet_dense: in a Banach (Baire) space the comeagre resonance set is dense",
+      "resonance_of_comeagre: the comeagre statement recovers the parent entry's single resonance point (nonemptiness), confirming this is a genuine strengthening of the condensation-of-singularities contrapositive"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 163,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The principle of condensation of singularities — the contrapositive of the Banach–Steinhaus theorem — produces a point at which a family of operators with unbounded norms resonates (its values blow up). Banach and Steinhaus's 1927 paper is titled precisely 'Sur le principe de la condensation de singularités'. The Baire-category proof gives more than one resonance point: the set of resonance points is residual (comeagre), so 'most' points (in the topological sense of category) are resonance points. This generic-singularity phenomenon is the standard route to existence results such as a continuous periodic function whose Fourier series diverges on a comeagre set of points.",
+    "problemStatement": "The gallery entry `banach-steinhaus-theorem-oq-01` states `resonance`: if the operator norms ‖gᵢ‖ are unbounded then there is a single point x where the values ‖gᵢx‖ are unbounded. Its open questions ask whether the quantitative refinement holds — that the resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} is comeagre, not merely nonempty.\n\n**Answer:** Yes. The complement of R is the union over n of the closed sublevel sets {x | ∀i ‖gᵢx‖ ≤ n}; each has empty interior (else Banach–Steinhaus would force the norms to be bounded), so each is nowhere dense and the complement is meagre. Hence R is comeagre, and dense in the Banach space.",
+    "text": "If a family of continuous linear maps out of a Banach space has unbounded operator norms, the set of points at which the values ‖gᵢx‖ are unbounded is comeagre (residual) — hence dense. The Baire-category strengthening of the condensation-of-singularities contrapositive, verified in Lean with no axioms.",
+    "proofStrategy": "1. resonanceSet: define R = {x | ∀ C, ∃ i, C < ‖gᵢx‖}.\n2. sublevel_isClosed: {x | ∀i ‖gᵢx‖ ≤ n} = ⋂ᵢ {x | ‖gᵢx‖ ≤ n} is closed, each factor being a sublevel set of the continuous map x ↦ ‖gᵢx‖.\n3. sublevel_interior_eq_empty (the crux): suppose some sublevel set has nonempty interior; it then contains a ball ball x₀ r. For any x, pick a small nonzero scalar c with ‖c‖(‖x‖+1) < r so that x₀ + c•x stays in the ball; then ‖gᵢ(c•x)‖ ≤ ‖gᵢ(x₀+c•x)‖ + ‖gᵢx₀‖ ≤ 2n, and since the maps are isometric-semilinear, ‖c‖·‖gᵢx‖ ≤ 2n, i.e. ‖gᵢx‖ ≤ 2n/‖c‖ uniformly in i. That is pointwise boundedness; banach_steinhaus upgrades it to a uniform norm bound, contradicting the unboundedness hypothesis. So the interior is empty.\n4. resonanceSet_comeagre: Rᶜ ⊆ ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}; each sublevel set is closed with empty interior, hence nowhere dense, hence meagre, and a countable union of meagre sets is meagre, so Rᶜ is meagre — i.e. R is residual.\n5. resonanceSet_dense: a Banach space is a Baire space, so the residual set R is dense.\n6. resonance_of_comeagre: R is dense, hence nonempty, recovering the parent's single resonance point.",
+    "keyInsights": [
+      "**Category, not just nonemptiness**: the Baire argument that proves Banach–Steinhaus actually shows the complement of the resonance set is a *countable union of nowhere-dense sets*. Reading that off gives a comeagre — generic — set of resonance points, strictly more than the one point the bare contrapositive provides.",
+      "**Banach–Steinhaus is reused, not reproved**: the only analytic input is the empty-interior lemma, and there the contradiction is obtained by invoking `banach_steinhaus` itself. A sublevel set with interior gives a ball; rescaling translates of the ball through the linear maps converts 'bounded on a ball' into 'pointwise bounded everywhere', which the theorem turns into a uniform bound — the contradiction.",
+      "**Rescaling needs only a small scalar**: nontriviality of the scalar field supplies arbitrarily small nonzero scalars c, and isometric semilinearity (‖σ₁₂ c‖ = ‖c‖) makes ‖gᵢ(c•x)‖ = ‖c‖·‖gᵢx‖, so a uniform value bound on a neighbourhood of x₀ transfers to a pointwise bound at every x.",
+      "**Comeagre ⟹ dense for free**: completeness makes the space Baire, and in a Baire space residual sets are dense, so the topological-genericity statement immediately yields the stronger-sounding 'resonance points are dense'."
+    ],
+    "prerequisites": [
+      "Normed and Banach spaces; continuous (semi)linear maps and the operator norm",
+      "The Baire category theorem; meagre, nowhere-dense, and residual (comeagre) sets",
+      "The Banach–Steinhaus / uniform boundedness principle",
+      "Interiors, closures, and density in metric spaces"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "File-level docstring framing the strengthening: the parent entry's `resonance` only gives a single resonance point; here the resonance set is shown comeagre and dense. Imports `Analysis.Normed.Operator.BanachSteinhaus` (which transitively supplies the meagre/residual machinery) and sets up the Banach-space variable context.",
+      "mathContext": "The resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} for a family of continuous linear maps out of a Banach space."
+    },
+    {
+      "id": "resonance-set",
+      "title": "The Resonance Set and Closed Sublevel Sets",
+      "startLine": 49,
+      "endLine": 62,
+      "summary": "resonanceSet defines R = {x | ∀ C, ∃ i, C < ‖gᵢx‖}. sublevel_isClosed shows each sublevel set {x | ∀i ‖gᵢx‖ ≤ n} is closed, as an intersection over i of the closed sublevel sets of the continuous maps x ↦ ‖gᵢx‖.",
+      "mathContext": "R is the complement of ⋃ₙ {x | ∀i ‖gᵢx‖ ≤ n}; each sublevel set is closed."
+    },
+    {
+      "id": "empty-interior",
+      "title": "Sublevel Sets Have Empty Interior",
+      "startLine": 64,
+      "endLine": 112,
+      "summary": "sublevel_interior_eq_empty: under unbounded operator norms each sublevel set has empty interior. A sublevel set with nonempty interior contains a ball; rescaling translates of that ball through the maps bounds ‖gᵢx‖ at every point (pointwise boundedness), which banach_steinhaus turns into a uniform bound, contradicting the hypothesis. This is the only step that invokes the Banach–Steinhaus theorem.",
+      "mathContext": "Nonempty interior of a sublevel set would force pointwise — hence uniform — boundedness."
+    },
+    {
+      "id": "comeagre",
+      "title": "The Resonance Set Is Comeagre and Dense",
+      "startLine": 114,
+      "endLine": 163,
+      "summary": "resonanceSet_comeagre: Rᶜ ⊆ ⋃ₙ (closed, empty-interior, hence nowhere-dense) sublevel sets, so Rᶜ is meagre and R is residual. resonanceSet_compl_isMeagre is the equivalent meagre phrasing. resonanceSet_dense upgrades comeagre to dense via the Baire property. resonance_of_comeagre recovers the parent's single resonance point.",
+      "mathContext": "Residual = comeagre; in a Baire space residual sets are dense."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Banach, Stefan; Steinhaus, Hugo",
+      "title": "Sur le principe de la condensation de singularités",
+      "year": "1927",
+      "note": "Fundamenta Mathematicae 9, 50–61 — the original uniform boundedness principle and condensation of singularities"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Functional Analysis",
+      "year": "1991",
+      "note": "Theorem 2.5 (Banach–Steinhaus) and Theorem 2.7 (condensation of singularities), where the resonance set is shown comeagre"
+    },
+    {
+      "authors": "Brezis, Haïm",
+      "title": "Functional Analysis, Sobolev Spaces and Partial Differential Equations",
+      "year": "2011",
+      "note": "Theorem 2.2 (uniform boundedness) and the Baire-category proof underlying the condensation of singularities"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "banach-steinhaus-theorem-oq-01",
+      "relation": "Parent entry: states the uniform boundedness principle and the `resonance` contrapositive whose open question (comeagre resonance set) this entry answers."
+    }
+  ],
+  "conclusion": {
+    "summary": "The resonance set R = {x | ⨆ᵢ ‖gᵢx‖ = ∞} of a family of continuous linear maps out of a Banach space with unbounded operator norms is comeagre (residual): its complement is a countable union of the closed, empty-interior sublevel sets {x | ∀i ‖gᵢx‖ ≤ n}, hence meagre. Consequently R is dense, and in particular nonempty — recovering the parent entry's `resonance`. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Strengthens the condensation-of-singularities contrapositive from 'there exists a resonance point' to 'the resonance points form a topologically generic (comeagre, hence dense) set', the form used in existence proofs such as Fourier series diverging on a comeagre set of points.",
+    "openQuestions": [
+      "Can the comeagre resonance statement be specialized to the partial-sum operators of Fourier series to produce a continuous 2π-periodic function whose Fourier series diverges on a comeagre set of points?",
+      "Does the analogous comeagre strengthening hold for barrelled (locally convex) spaces, matching Mathlib's general `WithSeminorms.banach_steinhaus`?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Normed.Operator.BanachSteinhaus",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Set",
+      "Metric"
+    ],
+    "namespace": "BanachSteinhausResonance",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BanachSteinhausTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/schroeder-bernstein-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Least vs. Greatest Fixed Point",
+    "content": "The Knaster–Tarski proof of Schroeder–Bernstein (parent entry) builds the bijection from the LEAST fixed point of T(S) = (range g)ᶜ ∪ g''(f''S). The open question asks whether the GREATEST fixed point is equally useful and what gfp ∖ lfp is geometrically. The answer: every fixed point of T works (the parent's lemmas never used minimality), and gfp ∖ lfp is exactly the set on which g∘f acts bijectively — the bi-infinite chains.",
+    "mathContext": "For monotone $T$ on a complete lattice, Knaster–Tarski gives both $\\mathrm{lfp}(T)$ and $\\mathrm{gfp}(T)$; both partition $\\alpha$ for Schroeder–Bernstein.",
+    "significance": "context",
+    "relatedConcepts": ["Knaster–Tarski theorem", "least fixed point", "greatest fixed point", "Schroeder–Bernstein theorem"],
+    "prerequisites": ["complete lattices", "monotone maps", "fixed points"]
+  },
+  {
+    "id": "ann-operator",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 59, "endLine": 70 },
+    "type": "definition",
+    "title": "The CBS Operator",
+    "content": "cbsOp f g S = (range g)ᶜ ∪ g''(f''S), monotone (cbsOp_mono), bundled as the OrderHom cbsHom. Monotonicity is exactly what Knaster–Tarski needs to produce BOTH a least and a greatest fixed point.",
+    "mathContext": "$T(S) = (\\mathrm{range}\\,g)^c \\cup g(f(S))$ on the complete lattice $\\mathrm{Set}\\,\\alpha$.",
+    "significance": "standard",
+    "relatedConcepts": ["monotone operator", "order homomorphism", "complete lattice"],
+    "prerequisites": ["set image", "set complement", "monotonicity"]
+  },
+  {
+    "id": "ann-any-fixed-point",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 81, "endLine": 165 },
+    "type": "theorem",
+    "title": "A Bijection from ANY Fixed Point (the crux)",
+    "content": "The key generalization answering the open question. For any S with cbsOp f g S = S, the parent's structural lemmas are re-derived from the fixed-point equation alone — (range g)ᶜ ⊆ S, complement of S ⊆ range g, g''(f''S) ⊆ S, and g b ∈ S → b ∈ f''S. The piecewise map bijFP (a ↦ f a on S, a ↦ g⁻¹ a off S) is injective (needs only f injective) and surjective (needs only g injective), giving equivFP : α ≃ β. Minimality of the fixed point is never used.",
+    "mathContext": "$h(a) = f(a)$ if $a \\in S$, else $g^{-1}(a)$; injective and surjective for every fixed point $S$ of $T$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point equation", "piecewise bijection", "injectivity", "surjectivity"],
+    "prerequisites": ["fixed points", "injective and surjective functions", "Equiv.ofBijective"]
+  },
+  {
+    "id": "ann-lfp-gfp",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 173, "endLine": 199 },
+    "type": "theorem",
+    "title": "Both lfp and gfp Give the Bijection",
+    "content": "lfpSet = lfp(T) and gfpSet = gfp(T) are both fixed points (map_lfp, map_gfp), so both feed equivFP. gfp_equiv and gfp_schroeder_bernstein are the greatest-fixed-point bijection — the equally-valid 'other' proof; lfp_equiv re-exhibits the parent's least-fixed-point bijection. Two instances of one theorem.",
+    "mathContext": "$T(\\mathrm{lfp}\\,T) = \\mathrm{lfp}\\,T$ and $T(\\mathrm{gfp}\\,T) = \\mathrm{gfp}\\,T$, so $\\mathrm{equivFP}$ applies to each.",
+    "significance": "key",
+    "relatedConcepts": ["least fixed point", "greatest fixed point", "OrderHom.map_lfp", "OrderHom.map_gfp"],
+    "prerequisites": ["Knaster–Tarski fixed points"]
+  },
+  {
+    "id": "ann-geometry",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 201, "endLine": 256 },
+    "type": "theorem",
+    "title": "gfp ∖ lfp Is the Set of Bi-Infinite Chains",
+    "content": "The geometric answer. D = gfp ∖ lfp satisfies gfp = lfp ∪ D. D ⊆ range g (no sources: (range g)ᶜ is forced into lfp). φ = g∘f maps D into D, and every point of D has a φ-predecessor in D (forced by the two fixed-point equations alone — no injectivity). With injectivity of f and g, φ restricts to a BIJECTION of D (diffSet_gf_bijOn): D is the maximal set on which g∘f acts bijectively, the union of bi-infinite chains.",
+    "mathContext": "$\\varphi = g\\circ f$ is a bijection $D \\to D$ with no sources and no sinks — the doubly-infinite orbits.",
+    "significance": "key",
+    "relatedConcepts": ["set difference", "Set.BijOn", "bi-infinite chains", "orbit decomposition", "g∘f dynamics"],
+    "prerequisites": ["set difference", "bijection on a set", "function dynamics"]
+  },
+  {
+    "id": "ann-iff-empty",
+    "proofId": "schroeder-bernstein-oq-02-oq-01",
+    "range": { "startLine": 258, "endLine": 264 },
+    "type": "theorem",
+    "title": "lfp = gfp Iff No Bi-Infinite Chains",
+    "content": "The least and greatest fixed points coincide exactly when D = ∅, i.e. when there are no bi-infinite g∘f-chains. This pinpoints when the Knaster–Tarski partition is unique.",
+    "mathContext": "$\\mathrm{lfp}(T) = \\mathrm{gfp}(T) \\iff D = \\emptyset$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uniqueness of fixed point", "empty difference"],
+    "prerequisites": ["set difference", "antisymmetry of inclusion"]
+  }
+]

--- a/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "schroeder-bernstein-oq-02-oq-01",
+  "title": "The Greatest Fixed Point Variant of Schroeder–Bernstein",
+  "slug": "schroeder-bernstein-oq-02-oq-01",
+  "description": "The Knaster–Tarski proof of Schroeder–Bernstein (entry schroeder-bernstein-oq-02) builds the bijection from the LEAST fixed point of the monotone operator T(S) = (range g)ᶜ ∪ g''(f''S). Its open question asks whether the GREATEST fixed point gfp(T) is equally useful, and what gfp(T) ∖ lfp(T) is geometrically. Answer: every fixed point of T yields a Schroeder–Bernstein bijection by the same piecewise formula (the parent's lemmas used only the fixed-point equation, never minimality), so lfp and gfp are two instances of one theorem; and the difference D = gfp ∖ lfp is exactly the set on which φ = g∘f acts bijectively (no sources, no sinks) — the union of the bi-infinite φ-chains.",
+  "meta": {
+    "author": "Knaster–Tarski (1928/1955); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroederBernsteinOQ02OQ01.lean",
+    "tags": [
+      "set-theory",
+      "order-theory",
+      "fixed-points",
+      "knaster-tarski",
+      "schroeder-bernstein",
+      "lattice-theory",
+      "bijection"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "OrderHom.lfp",
+        "description": "The Knaster–Tarski least fixed point of a monotone self-map of a complete lattice (the parent's choice S*)",
+        "module": "Mathlib.Order.FixedPoints"
+      },
+      {
+        "theorem": "OrderHom.gfp",
+        "description": "The Knaster–Tarski greatest fixed point (this entry's choice S**)",
+        "module": "Mathlib.Order.FixedPoints"
+      },
+      {
+        "theorem": "OrderHom.map_gfp",
+        "description": "gfp is a fixed point: T(gfp T) = gfp T — what makes the gfp route a valid Schroeder–Bernstein proof",
+        "module": "Mathlib.Order.FixedPoints"
+      },
+      {
+        "theorem": "OrderHom.le_gfp",
+        "description": "Any post-fixed point lies below gfp; used to show lfp ⊆ gfp",
+        "module": "Mathlib.Order.FixedPoints"
+      },
+      {
+        "theorem": "Equiv.ofBijective",
+        "description": "Packages the piecewise bijection as an equivalence α ≃ β",
+        "module": "Mathlib.Logic.Equiv.Defs"
+      }
+    ],
+    "originalContributions": [
+      "equivFP: EVERY fixed point S of the CBS operator (cbsOp f g S = S) yields a Schroeder–Bernstein bijection α ≃ β by the piecewise formula a ↦ (f a if a∈S else g⁻¹ a). The parent's lemmas are re-derived from the fixed-point equation alone, with no appeal to minimality — generalizing the whole OQ-02 construction",
+      "lfpSet / gfpSet, lfpSet_fp / gfpSet_fp: both the least and greatest Knaster–Tarski fixed points are fixed points, hence both feed equivFP",
+      "gfp_equiv / gfp_schroeder_bernstein: the greatest-fixed-point Schroeder–Bernstein bijection — a genuinely different but equally valid proof (answering the open question's first half)",
+      "lfp_equiv: the parent's least-fixed-point bijection re-exhibited as the lfp instance of equivFP, so lfp and gfp are visibly two specializations of one theorem",
+      "lfpSet_subset_gfpSet, gfpSet_eq_lfp_union_diff: gfp = lfp ∪ D where D = gfp ∖ lfp",
+      "diffSet_subset_range: D contains no sources — (range g)ᶜ lies entirely inside lfp",
+      "diffSet_gf_mem: φ = g∘f maps D into D",
+      "diffSet_has_pred: every point of D has a φ-predecessor inside D (forced by the two fixed-point equations alone, no injectivity needed) — D has no sinks",
+      "diffSet_gf_bijOn: φ = g∘f restricts to a BIJECTION of D (Set.BijOn) — the geometric answer to the open question: gfp ∖ lfp is the maximal set on which g∘f acts bijectively, the union of the bi-infinite chains",
+      "lfpSet_eq_gfpSet_iff_diff_empty: lfp = gfp iff there are no bi-infinite φ-chains"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Uses Classical for the piecewise definition; depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 266,
+    "theoremCount": 21,
+    "definitionCount": 9
+  },
+  "overview": {
+    "historicalContext": "The Knaster–Tarski fixed point theorem (Knaster 1928, Tarski 1955) states that a monotone self-map of a complete lattice has both a least and a greatest fixed point. The standard Knaster–Tarski proof of Schroeder–Bernstein uses the least fixed point of the operator T(S) = (range g)ᶜ ∪ g''(f''S) to partition the domain. But the greatest fixed point is just as good a partition, and the gap between them illuminates the classical orbit decomposition: the bi-infinite (ℤ-indexed) orbits of g∘f, which the least fixed point resolves 'towards A' and the greatest resolves 'towards B'.",
+    "problemStatement": "Entry schroeder-bernstein-oq-02 formalizes the Knaster–Tarski proof using lfp(T). Its open question: is the greatest fixed point gfp(T) equally useful, and what is gfp(T) ∖ lfp(T) geometrically?\n\n**Answer:** Yes, and more — every fixed point works. The parent's bijection lemmas use only T(S) = S, so they apply verbatim to gfp. The difference D = gfp ∖ lfp is precisely the set on which φ = g∘f acts as a bijection (no sources since D ⊆ range g, no sinks since every point has a φ-predecessor in D): the union of the bi-infinite chains.",
+    "text": "Every fixed point of the Knaster–Tarski CBS operator — least, greatest, or any in between — yields a Schroeder–Bernstein bijection by the same piecewise formula. The greatest fixed point gives an equally valid proof, and gfp ∖ lfp is exactly the set on which g∘f acts bijectively: the bi-infinite chains. Verified in Lean with no axioms.",
+    "proofStrategy": "1. Re-introduce the operator cbsOp, its monotonicity, and the bundled OrderHom cbsHom (as in OQ-02).\n2. Generalize the parent's construction to an arbitrary fixed point: for any S with cbsOp f g S = S, prove (range g)ᶜ ⊆ S, S-complement ⊆ range g, g''(f''S) ⊆ S, and g b ∈ S → b ∈ f''S; then define the piecewise map bijFP and prove it injective (needs only f injective) and surjective (needs only g injective), packaged as equivFP : α ≃ β.\n3. Instantiate at lfp and gfp: lfpSet_fp = map_lfp, gfpSet_fp = map_gfp give both as fixed points; gfp_equiv / gfp_schroeder_bernstein are the gfp instances, lfp_equiv the parent's lfp instance.\n4. Order: lfpSet ⊆ gfpSet via le_gfp, so gfp = lfp ∪ D with D = gfp ∖ lfp.\n5. Geometry of D: D ⊆ range g (no sources, since (range g)ᶜ ⊆ lfp); φ = g∘f maps D into D (closure on gfp, plus g b ∈ lfp → b ∈ f''lfp rules out landing in lfp); every point of D has a φ-predecessor in D (it lies in g''(f''gfp) and the predecessor cannot be in lfp). Combined with injectivity of f and g, φ restricts to a bijection D → D (diffSet_gf_bijOn).\n6. lfp = gfp iff D = ∅ (no bi-infinite chains).",
+    "keyInsights": [
+      "**Minimality was never used**: the parent's entire bijection argument rests on the single equation T(S) = S, injectivity of f, and injectivity of g. Abstracting the fixed point S turns one proof into a theorem schema with lfp and gfp as two instances — the cleanest possible answer to 'is gfp equally useful?'.",
+      "**The difference is a dynamical object**: gfp ∖ lfp is not an arbitrary set — φ = g∘f acts on it as a bijection. There are no sources (every point is in range g, so has a φ-image landing back in D) and no sinks (every point has a φ-preimage in D). That is exactly the structure of a disjoint union of bi-infinite chains.",
+      "**Sources live in the least fixed point**: (range g)ᶜ — the points with no g-preimage, the 'A-stoppers' of the orbit decomposition — are forced into lfp by the fixed-point equation, so they can never appear in the difference. lfp captures the chains that start at a source; gfp adds the chains that have no start.",
+      "**Predecessors need no injectivity**: that every point of D has a φ-predecessor in D follows purely from the two fixed-point equations (for lfp and gfp); injectivity is needed only to upgrade 'has a predecessor' to 'acts bijectively'."
+    ],
+    "prerequisites": [
+      "The Knaster–Tarski fixed point theorem (least and greatest fixed points on a complete lattice)",
+      "The Knaster–Tarski proof of Schroeder–Bernstein (entry schroeder-bernstein-oq-02)",
+      "Set operations: image, range, complement, difference in Mathlib",
+      "Injective/surjective/bijective functions; Set.BijOn"
+    ]
+  },
+  "sections": [
+    {
+      "id": "operator",
+      "title": "The Monotone Operator",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "File docstring framing the open question and answer. Re-introduces cbsOp T(S) = (range g)ᶜ ∪ g''(f''S), its monotonicity, and the bundled OrderHom cbsHom enabling both lfp and gfp.",
+      "mathContext": "The CBS operator on the complete lattice Set α, as in OQ-02."
+    },
+    {
+      "id": "any-fixed-point",
+      "title": "A Bijection from Any Fixed Point",
+      "startLine": 72,
+      "endLine": 165,
+      "summary": "The crux generalization: for any S with cbsOp f g S = S, the parent's lemmas (compl_range_subset_fp, mem_range_of_not_mem_fp, gf_image_subset_fp, gf_mem_fp, mem_fimage_of_gb_mem_fp, gb_not_mem_fp) are re-derived from the fixed-point equation alone. The piecewise map bijFP is injective (needs only f injective) and surjective (needs only g injective), packaged as equivFP : α ≃ β.",
+      "mathContext": "Every fixed point of T yields a Schroeder–Bernstein bijection — minimality is not used."
+    },
+    {
+      "id": "lfp-gfp",
+      "title": "The Least and Greatest Fixed Points",
+      "startLine": 167,
+      "endLine": 199,
+      "summary": "lfpSet = lfp(T), gfpSet = gfp(T); both are fixed points (map_lfp, map_gfp), so both feed equivFP. gfp_equiv / gfp_schroeder_bernstein are the greatest-fixed-point bijection; lfp_equiv re-exhibits the parent's least-fixed-point bijection — two instances of one theorem.",
+      "mathContext": "lfp and gfp are both Knaster–Tarski fixed points, hence both give the bijection."
+    },
+    {
+      "id": "geometry",
+      "title": "The Geometry of gfp ∖ lfp",
+      "startLine": 201,
+      "endLine": 266,
+      "summary": "D = gfp ∖ lfp, and gfp = lfp ∪ D. D ⊆ range g (no sources); φ = g∘f maps D into D; every point of D has a φ-predecessor in D; hence φ restricts to a bijection of D (diffSet_gf_bijOn) — the bi-infinite chains. lfp = gfp iff D = ∅.",
+      "mathContext": "gfp ∖ lfp is the maximal set on which g∘f acts bijectively: the union of bi-infinite chains."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Tarski, Alfred",
+      "title": "A lattice-theoretical fixpoint theorem and its applications",
+      "year": "1955",
+      "note": "Pacific J. Math. 5, 285–309 — least and greatest fixed points of monotone maps on complete lattices"
+    },
+    {
+      "authors": "Knaster, Bronisław",
+      "title": "Un théorème sur les fonctions d'ensembles",
+      "year": "1928",
+      "note": "Ann. Soc. Polon. Math. 6, 133–134 — the original set-theoretic fixed point theorem"
+    },
+    {
+      "authors": "Hinkis, Arie",
+      "title": "Proofs of the Cantor–Bernstein Theorem",
+      "year": "2013",
+      "note": "Birkhäuser — survey of Schroeder–Bernstein proofs, including the fixed-point and orbit-decomposition variants"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "schroeder-bernstein-oq-02",
+      "relation": "Parent entry: the Knaster–Tarski (least fixed point) proof whose open question — is gfp equally useful, and what is gfp ∖ lfp — this entry answers."
+    },
+    {
+      "slug": "schroeder-bernstein",
+      "relation": "The base Schroeder–Bernstein gallery entry."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every fixed point of the Knaster–Tarski CBS operator T(S) = (range g)ᶜ ∪ g''(f''S) yields a Schroeder–Bernstein bijection by the piecewise formula, since the construction uses only the fixed-point equation and injectivity of f and g — so the greatest fixed point gives an equally valid proof (gfp_equiv, gfp_schroeder_bernstein), with the parent's least-fixed-point bijection re-exhibited as the lfp instance. The difference D = gfp ∖ lfp is exactly the set on which φ = g∘f acts bijectively (diffSet_gf_bijOn): no sources (D ⊆ range g) and no sinks (every point has a φ-predecessor in D) — the union of the bi-infinite chains. All results verified with 0 axioms and 0 sorries.",
+    "implications": "Recasts the Knaster–Tarski proof as a theorem schema parametrized by the fixed point, with lfp and gfp as two instances, and gives the precise dynamical meaning of the gap between them — the bi-infinite g∘f-orbits of the classical Schroeder–Bernstein orbit decomposition.",
+    "openQuestions": [
+      "Can the in-between fixed points (between lfp and gfp) be parametrized by subsets of the set of bi-infinite chains, exhibiting the full lattice of CBS bijections?",
+      "Does the bijection D ≃ D induced by φ = g∘f decompose D canonically into its ℤ-indexed chains, recovering the orbit decomposition proof of Schroeder–Bernstein from the fixed-point proof?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Order.FixedPoints",
+      "Mathlib.Data.Set.Lattice",
+      "Mathlib.Logic.Equiv.Defs",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Classical",
+      "Function"
+    ],
+    "namespace": "KnasterTarskiGFP",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 21,
+    "definitionCount": 9,
+    "path": "Proofs/SchroederBernsteinOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of **schroeder-bernstein-oq-02** (`conclusion.openQuestions[0]`):

> *The Knaster–Tarski fixed point is the **least** fixed point of T. Is the greatest fixed point S** = gfp(T) equally useful? What is S** ∖ S* geometrically?*

**Answer (stronger than asked):** *every* fixed point of the CBS operator `T(S) = (range g)ᶜ ∪ g''(f''S)` yields a Schroeder–Bernstein bijection by the same piecewise formula. The parent's construction used only the fixed-point equation `T(S) = S`, injectivity of `f`, and injectivity of `g` — never minimality. So `lfp` and `gfp` are two instances of one theorem.

## What's proved (`Proofs/SchroederBernsteinOQ02OQ01.lean`)

- **`equivFP`** — any `S` with `cbsOp f g S = S` gives `α ≃ β` (the parent's lemmas re-derived from the fixed-point equation alone; injectivity of the piecewise map needs only `f` injective, surjectivity only `g` injective).
- **`gfp_equiv` / `gfp_schroeder_bernstein`** — the greatest-fixed-point Schroeder–Bernstein bijection: a genuinely different, equally valid proof.
- **`lfp_equiv`** — the parent's least-fixed-point bijection, re-exhibited as the `lfp` instance of `equivFP`.
- **`diffSet_gf_bijOn`** — the geometric answer: `φ = g∘f` restricts to a **bijection** of `D = gfp ∖ lfp` (`Set.BijOn`). `D` has **no sources** (`D ⊆ range g`, since `(range g)ᶜ ⊆ lfp`) and **no sinks** (every point has a `φ`-predecessor in `D`, forced by the two fixed-point equations alone — no injectivity needed). So `D` is the maximal set on which `g∘f` acts bijectively: the union of the **bi-infinite chains** (the `ℤ`-orbits of the classical orbit decomposition).
- **`lfpSet_eq_gfpSet_iff_diff_empty`** — `lfp = gfp` iff there are no bi-infinite chains.

## Verification

- **21 theorems + 9 definitions, 266 lines.**
- `#print axioms` on `gfp_schroeder_bernstein`, `gfp_equiv`, `diffSet_gf_bijOn`, `equivFP` lists only `propext`, `Classical.choice`, `Quot.sound`.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- Type-checks against pinned Mathlib v4.26.0 (`lake env lean`); `pnpm annotations:build` clean for this entry.

Status: **verified**, badge **original**, axiomCount **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)