### PR TITLE
research(hurwitz-theorem-oq-03-incomplete-01): Hurwitz square identities are universal commutative-ring identities [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/HurwitzUniversal.lean
+++ b/proofs/Proofs/HurwitzUniversal.lean
@@ -1,0 +1,195 @@
+import Mathlib
+
+/-
+# Hurwitz square identities are universal commutative-ring identities
+
+Hurwitz's theorem concerns the bilinear `n`-square identities
+
+  (x_1^2 + ... + x_n^2)(y_1^2 + ... + y_n^2) = z_1^2 + ... + z_n^2,    z_i bilinear in x, y,
+
+which exist exactly for `n in {1, 2, 4, 8}` (the dimensions of the four normed
+division algebras R, C, H, O).  The gallery entry `hurwitz-theorem-oq-03`
+formalizes the *existence* direction over the real numbers `R`, deriving the
+4-square identity from Mathlib's quaternion norm.
+
+This file sharpens the existence direction in a different way: the four
+identities are not special to `R`.  Each `z_i` is an explicit polynomial with
+*integer* coefficients in the `x`'s and `y`'s, so the identity holds **formally
+over every commutative ring** -- it is a universal identity, provable by `ring`
+over an arbitrary `CommRing R`.
+
+The concrete payoff is purely arithmetic and needs no analysis: in *any*
+commutative ring the set of elements expressible as a sum of `1, 2, 4`, or `8`
+squares is closed under multiplication.  Specialised to `Z` this is the
+multiplicative engine behind the two-square and four-square theorems
+(e.g. a product of two sums of four squares is again a sum of four squares).
+
+Everything here is checked by `ring` / elementary `Exists` manipulation:
+0 axioms beyond Lean's foundations, 0 sorries.
+-/
+
+namespace HurwitzUniversal
+
+open Finset
+
+variable {R : Type*} [CommRing R]
+
+/-- The squared norm (sum of coordinate squares) of an `n`-vector over a
+commutative ring. -/
+def normSq {n : ℕ} (v : Fin n → R) : R := ∑ i, v i ^ 2
+
+/-! ## The four bilinear multiplications
+
+Each `nMul a b` lists the `n` bilinear components `z_i`.  The coefficients are
+the multiplication tables of `R` (`n = 1`), `C` (`n = 2`), `H` (`n = 4`) and
+`O` (`n = 8`); identical to the real-valued versions in `HurwitzTheorem`, but
+stated here over an arbitrary `R`. -/
+
+/-- `n = 1`: multiplication in `R` itself. -/
+def oneMul (a b : Fin 1 → R) : Fin 1 → R := fun _ => a 0 * b 0
+
+/-- `n = 2`: the Brahmagupta–Fibonacci (complex-number) product. -/
+def twoMul (a b : Fin 2 → R) : Fin 2 → R :=
+  ![a 0 * b 0 - a 1 * b 1,
+    a 0 * b 1 + a 1 * b 0]
+
+/-- `n = 4`: Euler's (quaternion) product. -/
+def fourMul (a b : Fin 4 → R) : Fin 4 → R :=
+  ![a 0 * b 0 - a 1 * b 1 - a 2 * b 2 - a 3 * b 3,
+    a 0 * b 1 + a 1 * b 0 + a 2 * b 3 - a 3 * b 2,
+    a 0 * b 2 - a 1 * b 3 + a 2 * b 0 + a 3 * b 1,
+    a 0 * b 3 + a 1 * b 2 - a 2 * b 1 + a 3 * b 0]
+
+/-- `n = 8`: Degen's (octonion / Cayley–Dickson) product. -/
+def eightMul (a b : Fin 8 → R) : Fin 8 → R :=
+  ![a 0*b 0 - a 1*b 1 - a 2*b 2 - a 3*b 3 - a 4*b 4 - a 5*b 5 - a 6*b 6 - a 7*b 7,
+    a 0*b 1 + a 1*b 0 + a 2*b 3 - a 3*b 2 + a 4*b 5 - a 5*b 4 - a 6*b 7 + a 7*b 6,
+    a 0*b 2 - a 1*b 3 + a 2*b 0 + a 3*b 1 + a 4*b 6 + a 5*b 7 - a 6*b 4 - a 7*b 5,
+    a 0*b 3 + a 1*b 2 - a 2*b 1 + a 3*b 0 + a 4*b 7 - a 5*b 6 + a 6*b 5 - a 7*b 4,
+    a 0*b 4 - a 1*b 5 - a 2*b 6 - a 3*b 7 + a 4*b 0 + a 5*b 1 + a 6*b 2 + a 7*b 3,
+    a 0*b 5 + a 1*b 4 - a 2*b 7 + a 3*b 6 - a 4*b 1 + a 5*b 0 - a 6*b 3 + a 7*b 2,
+    a 0*b 6 + a 1*b 7 + a 2*b 4 - a 3*b 5 - a 4*b 2 + a 5*b 3 + a 6*b 0 - a 7*b 1,
+    a 0*b 7 - a 1*b 6 + a 2*b 5 + a 3*b 4 - a 4*b 3 - a 5*b 2 + a 6*b 1 + a 7*b 0]
+
+/-! ## The universal identities
+
+Each is a single `ring` call after expanding the finite sum and the matrix
+literals.  Being a `CommRing`-level identity, it specialises to `Z`, `Q`, `R`,
+`C`, `ZMod m`, polynomial rings, etc. -/
+
+/-- `n = 1`: `x^2 * y^2 = (xy)^2` over any commutative ring. -/
+theorem one_square (a b : Fin 1 → R) :
+    normSq a * normSq b = normSq (oneMul a b) := by
+  simp only [normSq, oneMul, Fin.sum_univ_one]
+  ring
+
+/-- `n = 2` (Brahmagupta–Fibonacci) over any commutative ring. -/
+theorem two_square (a b : Fin 2 → R) :
+    normSq a * normSq b = normSq (twoMul a b) := by
+  simp only [normSq, twoMul, Fin.sum_univ_two,
+    Matrix.cons_val_zero, Matrix.cons_val_one]
+  ring
+
+set_option maxHeartbeats 800000 in
+/-- `n = 4` (Euler) over any commutative ring. -/
+theorem four_square (a b : Fin 4 → R) :
+    normSq a * normSq b = normSq (fourMul a b) := by
+  simp only [normSq, fourMul, Fin.sum_univ_four, Fin.isValue]
+  simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+        Matrix.cons_val_two, Matrix.cons_val_three]
+  ring
+
+private lemma sum_fin_eight {f : Fin 8 → R} :
+    ∑ i : Fin 8, f i = f 0 + f 1 + f 2 + f 3 + f 4 + f 5 + f 6 + f 7 := by
+  simp only [Fin.sum_univ_succ, Fin.sum_univ_zero]
+  abel
+
+set_option maxHeartbeats 32000000 in
+/-- `n = 8` (Degen) over any commutative ring. -/
+theorem eight_square (a b : Fin 8 → R) :
+    normSq a * normSq b = normSq (eightMul a b) := by
+  simp only [normSq, eightMul, sum_fin_eight, Fin.isValue]
+  simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+        Matrix.cons_val_two, Matrix.cons_val_three]
+  ring
+
+/-! ## Arithmetic consequence: multiplicative closure of sums of squares
+
+`IsSumOfSquares n r` says `r` is a sum of `n` squares in `R`.  For
+`n in {1, 2, 4, 8}` the universal identities show this predicate is closed
+under multiplication, and it always contains `0` and `1`. -/
+
+/-- `r` is a sum of `n` squares in the commutative ring `R`. -/
+def IsSumOfSquares (n : ℕ) (r : R) : Prop := ∃ v : Fin n → R, normSq v = r
+
+theorem isSumOfSquares_zero (n : ℕ) : IsSumOfSquares (R := R) n 0 :=
+  ⟨0, by simp [normSq]⟩
+
+theorem isSumOfSquares_one (n : ℕ) [NeZero n] : IsSumOfSquares (R := R) n 1 :=
+  ⟨Pi.single ⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩ 1, by
+    simp only [normSq]
+    rw [Finset.sum_eq_single ⟨0, Nat.pos_of_ne_zero (NeZero.ne n)⟩]
+    · simp
+    · intro i _ hi
+      rw [Pi.single_eq_of_ne hi]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h⟩
+
+/-- Sums of two squares are closed under multiplication (any commutative ring). -/
+theorem isSumOfSquares_two_mul {x y : R}
+    (hx : IsSumOfSquares 2 x) (hy : IsSumOfSquares 2 y) :
+    IsSumOfSquares 2 (x * y) := by
+  obtain ⟨a, ha⟩ := hx; obtain ⟨b, hb⟩ := hy
+  exact ⟨twoMul a b, by rw [← two_square, ha, hb]⟩
+
+/-- Sums of four squares are closed under multiplication (any commutative ring). -/
+theorem isSumOfSquares_four_mul {x y : R}
+    (hx : IsSumOfSquares 4 x) (hy : IsSumOfSquares 4 y) :
+    IsSumOfSquares 4 (x * y) := by
+  obtain ⟨a, ha⟩ := hx; obtain ⟨b, hb⟩ := hy
+  exact ⟨fourMul a b, by rw [← four_square, ha, hb]⟩
+
+/-- Sums of eight squares are closed under multiplication (any commutative ring). -/
+theorem isSumOfSquares_eight_mul {x y : R}
+    (hx : IsSumOfSquares 8 x) (hy : IsSumOfSquares 8 y) :
+    IsSumOfSquares 8 (x * y) := by
+  obtain ⟨a, ha⟩ := hx; obtain ⟨b, hb⟩ := hy
+  exact ⟨eightMul a b, by rw [← eight_square, ha, hb]⟩
+
+/-! ## Specialisation to the integers
+
+The closure lemmas are the elementary "easy" direction behind the classical
+two-square and four-square theorems. -/
+
+/-- In `Z`, a product of two sums of four squares is a sum of four squares —
+the multiplicative step in Lagrange's four-square theorem. -/
+theorem int_sumFourSq_mul {x y : ℤ}
+    (hx : IsSumOfSquares (R := ℤ) 4 x) (hy : IsSumOfSquares (R := ℤ) 4 y) :
+    IsSumOfSquares (R := ℤ) 4 (x * y) :=
+  isSumOfSquares_four_mul hx hy
+
+/-- In `Z`, a product of two sums of two squares is a sum of two squares. -/
+theorem int_sumTwoSq_mul {x y : ℤ}
+    (hx : IsSumOfSquares (R := ℤ) 2 x) (hy : IsSumOfSquares (R := ℤ) 2 y) :
+    IsSumOfSquares (R := ℤ) 2 (x * y) :=
+  isSumOfSquares_two_mul hx hy
+
+/-- Worked witnesses: `3 = 1^2+1^2+1^2+0^2` and `5 = 2^2+1^2+0^2+0^2`, so the
+identity exhibits `15` as a sum of four squares. -/
+private lemma three_eq : normSq (R := ℤ) ![1, 1, 1, 0] = 3 := by
+  simp only [normSq, Fin.sum_univ_four, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_two, Matrix.cons_val_three]
+  norm_num
+
+private lemma five_eq : normSq (R := ℤ) ![2, 1, 0, 0] = 5 := by
+  simp only [normSq, Fin.sum_univ_four, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.cons_val_two, Matrix.cons_val_three]
+  norm_num
+
+example : IsSumOfSquares (R := ℤ) 4 3 := ⟨_, three_eq⟩
+
+example : IsSumOfSquares (R := ℤ) 4 5 := ⟨_, five_eq⟩
+
+example : IsSumOfSquares (R := ℤ) 4 15 :=
+  int_sumFourSq_mul ⟨_, three_eq⟩ ⟨_, five_eq⟩
+
+end HurwitzUniversal

--- a/research/problems/hurwitz-theorem-oq-03-incomplete-01/state.md
+++ b/research/problems/hurwitz-theorem-oq-03-incomplete-01/state.md
@@ -1,0 +1,38 @@
+# Hurwitz (oq-03) — Universal Commutative-Ring Square Identities
+
+**Status:** COMPLETED — shipped as gallery entry `hurwitz-theorem-oq-03-incomplete-01`
+**Lean:** `proofs/Proofs/HurwitzUniversal.lean` (195 lines, 14 theorems/lemmas, 6 defs, 0 axioms, 0 sorries)
+**Verification:** builds against pinned Mathlib v4.26; `#print axioms` on every result returns only `propext, Classical.choice, Quot.sound`.
+
+## Result
+
+The Hurwitz 1-, 2-, 4-, and 8-square identities are **universal** polynomial identities — they
+hold over **every commutative ring**, not only over ℝ:
+
+```
+normSq a * normSq b = normSq (nMul a b)      for n ∈ {1, 2, 4, 8}, over any CommRing R
+```
+
+where `nMul` is the multiplication table of ℝ / ℂ / ℍ / 𝕆 and `normSq v = ∑ (v i)²`. Each is
+closed by a single `ring` call (the n=8 Degen identity included), so no quaternion/octonion
+library is used.
+
+### Arithmetic corollary
+
+`IsSumOfSquares n r := ∃ v : Fin n → R, normSq v = r` is multiplicatively closed for
+n ∈ {1,2,4,8} in any commutative ring, and contains 0 and 1. Over ℤ this gives the elementary
+multiplicative steps `int_sumTwoSq_mul` and `int_sumFourSq_mul` behind the two- and four-square
+theorems; worked witnesses exhibit `15 = 3·5` as a sum of four squares via Euler's identity.
+
+## Relation to parent
+
+Strengthens `hurwitz-theorem-oq-03`, which proves the existence direction only over ℝ (n=4 from
+Mathlib quaternions). This entry does **not** touch the parent's remaining `sorry`: the
+impossibility of bilinear n-square identities for n ∉ {1,2,4,8}, which needs Clifford-algebra /
+Bott-periodicity machinery.
+
+## Next steps
+
+- Impossibility direction (parent's open sorry).
+- Bridge `IsSumOfSquares` to Mathlib's number-theoretic two-/four-square theorems.
+- Pfister denominator identities for all 2-powers.

--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-norm-and-products",
+    "proofId": "hurwitz-theorem-oq-03-incomplete-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 84
+    },
+    "type": "concept",
+    "title": "The Norm and the Four Multiplication Tables",
+    "content": "Over a generic `CommRing R`, `normSq v = ∑ i, (v i)^2` is the squared norm of an n-vector. The four bilinear products oneMul, twoMul, fourMul, eightMul are exactly the multiplication tables of the real numbers ℝ (n=1), the complex numbers ℂ (n=2), the quaternions ℍ (n=4), and the octonions 𝕆 (n=8). Crucially, every coefficient in these tables is ±1, an integer — so the products, and the identities they satisfy, are formal expressions valid over any commutative ring, with no appeal to ℝ or to a division-algebra structure."
+  },
+  {
+    "id": "ann-universal-identities",
+    "proofId": "hurwitz-theorem-oq-03-incomplete-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 116
+    },
+    "type": "proof-technique",
+    "title": "One `ring` Call per Identity",
+    "content": "Each identity normSq a * normSq b = normSq (nMul a b) is proved by expanding the finite sum (Fin.sum_univ_two / four, or a helper for Fin 8) and the matrix literals (Matrix.cons_val_*), then invoking `ring`. Because `ring` is a decision procedure for commutative-ring equalities, a successful call is a complete machine-checked proof — and it certifies the (sign-sensitive) Degen 8-square identity just as readily as the simpler n=2 case. The n=8 expansion has hundreds of monomials on each side, so it needs a raised `maxHeartbeats`, but it remains a single decision-procedure call with no case analysis."
+  },
+  {
+    "id": "ann-closure",
+    "proofId": "hurwitz-theorem-oq-03-incomplete-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 163
+    },
+    "type": "key-insight",
+    "title": "Norm-Multiplicativity = Closure of Sums of Squares",
+    "content": "Define `IsSumOfSquares n r := ∃ v : Fin n → R, normSq v = r`. The identity normSq a * normSq b = normSq (nMul a b) says precisely that if x and y are each sums of n squares then so is x·y — the witness for the product is nMul of the two witnesses. This gives isSumOfSquares_two_mul / four_mul / eight_mul in any commutative ring. The set also always contains 0 (the zero vector) and 1 (a standard basis vector), so for n ∈ {1,2,4,8} the sums of n squares form a multiplicative submonoid of R."
+  },
+  {
+    "id": "ann-integers",
+    "proofId": "hurwitz-theorem-oq-03-incomplete-01",
+    "range": {
+      "startLine": 164,
+      "endLine": 195
+    },
+    "type": "concept",
+    "title": "The Classical Arithmetic Corollary over ℤ",
+    "content": "Specialising R := ℤ recovers the elementary multiplicative steps behind two classical theorems: int_sumTwoSq_mul (a product of two sums of two squares is a sum of two squares — the Brahmagupta–Fibonacci step in Fermat's two-square theorem) and int_sumFourSq_mul (the Euler step that reduces Lagrange's four-square theorem to primes). The worked witnesses 3 = 1²+1²+1²+0² and 5 = 2²+1²+0²+0² combine through Euler's identity to exhibit 15 = 3·5 as a sum of four squares — a concrete instance of the abstract closure lemma."
+  }
+]

--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "hurwitz-theorem-oq-03-incomplete-01",
+  "title": "Hurwitz (oq-03): The 1·2·4·8-Square Identities are Universal Commutative-Ring Identities",
+  "slug": "hurwitz-theorem-oq-03-incomplete-01",
+  "description": "A self-contained, 0-axiom formalization showing that the four Hurwitz square identities — the 1-square, the Brahmagupta–Fibonacci (n=2), Euler (n=4), and Degen (n=8) identities — are universal polynomial identities valid over EVERY commutative ring, not just over ℝ. The parent entry hurwitz-theorem-oq-03 proves the existence direction only over the reals (deriving n=4 from Mathlib's quaternion norm). Here each z_i has integer coefficients, so (∑xᵢ²)(∑yᵢ²)=∑zᵢ² is closed by `ring` over an arbitrary CommRing. The arithmetic payoff: in any commutative ring the set of sums of 1, 2, 4, or 8 squares is multiplicatively closed — specialised to ℤ this is the multiplicative engine behind the two-square and four-square theorems.",
+  "meta": {
+    "author": "Lean formalization original (identities: Brahmagupta 628 / Fibonacci 1225 (n=2), Euler 1748 (n=4), Degen 1818 (n=8))",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HurwitzUniversal.lean",
+    "tags": [
+      "hurwitz",
+      "square-identities",
+      "composition-algebras",
+      "normed-division-algebras",
+      "quaternions",
+      "octonions",
+      "commutative-ring",
+      "sum-of-squares",
+      "number-theory",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_univ_two / sum_univ_four / sum_univ_succ",
+        "description": "Expand the finite sum ∑ i : Fin n, v i ^ 2 into the explicit n-term polynomial so that `ring` can verify the identity",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Matrix.cons_val_zero / cons_val_one / cons_val_two / cons_val_three / ...",
+        "description": "Reduce the matrix-literal coordinates ![z₀,…] i to the explicit bilinear component zᵢ before normalisation",
+        "module": "Mathlib.Data.Matrix.Notation"
+      },
+      {
+        "theorem": "Pi.single_eq_of_ne / Finset.sum_eq_single",
+        "description": "Evaluate the standard-basis witness used to show 1 is a sum of n squares in every ring",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Strengthens the parent's ℝ-only existence direction to a universal statement: the 1-, 2-, 4-, and 8-square identities hold over every commutative ring, proved purely by `ring` (no quaternion/octonion library, no analysis)",
+      "An n=8 (Degen) identity over an arbitrary CommRing proved by a single `ring` call after sum/matrix expansion — independent of Mathlib's quaternion norm route used by the parent for n=4",
+      "The predicate IsSumOfSquares n and three multiplicative-closure theorems (n=2,4,8) holding in any commutative ring, plus the always-present 0 and 1 elements",
+      "ℤ specialisations int_sumTwoSq_mul and int_sumFourSq_mul (the elementary multiplicative step underlying the two-square and four-square theorems), with worked witnesses 3=1²+1²+1²+0², 5=2²+1²+0²+0², 15=3·5 a sum of four squares"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound), 0 sorries. This covers only the existence/universality direction; it does not address the impossibility of n-square identities for n ∉ {1,2,4,8} (the parent's remaining sorry, which needs Clifford-algebra / Bott-periodicity machinery).",
+    "lineCount": 195,
+    "theoremCount": 14,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Hurwitz (1898) proved that a bilinear n-square identity (x₁²+⋯+xₙ²)(y₁²+⋯+yₙ²)=z₁²+⋯+zₙ² exists exactly for n ∈ {1,2,4,8}, the dimensions of the four normed division algebras ℝ, ℂ, ℍ, 𝕆. The existence formulas are classical and far older than Hurwitz's impossibility theorem: n=2 is the Brahmagupta–Fibonacci identity (Brahmagupta 628, Fibonacci 1225), n=4 is Euler's four-square identity (1748, used by Lagrange), and n=8 is Degen's eight-square identity (1818, rediscovered by Graves and Cayley with the octonions). A key but often-unstated fact is that each zᵢ is a polynomial with integer coefficients, so the identities are formal: they hold over any commutative ring, with ℝ being just one instance.",
+    "problemStatement": "The parent entry hurwitz-theorem-oq-03 formalizes the existence direction over ℝ (deriving the 4-square identity from Mathlib's quaternion norm multiplicativity) and leaves the general impossibility direction as a single sorry. This entry isolates and generalises the existence direction: it proves the n=1,2,4,8 square identities hold over an arbitrary commutative ring R, and derives the arithmetic corollary that sums of 1,2,4,8 squares form a multiplicative set in every commutative ring.",
+    "proofStrategy": "Define normSq v = ∑ i, (v i)² and the explicit bilinear products oneMul, twoMul, fourMul, eightMul (the multiplication tables of ℝ, ℂ, ℍ, 𝕆) over a generic `CommRing R`. Each identity normSq a * normSq b = normSq (nMul a b) is closed by expanding the finite sum and the matrix literals and calling `ring` — the n=8 case needs a high heartbeat budget but is still a single decision-procedure call. Multiplicative closure of IsSumOfSquares n then follows by feeding the witness vectors through nMul; the unit is the standard basis vector. Specialising R := ℤ yields the classical number-theoretic statements.",
+    "keyInsights": [
+      "The square identities are universal polynomial identities over ℤ, hence valid in every commutative ring; the parent's ℝ proof is one special case",
+      "No division-algebra library is needed: `ring` discharges all four identities directly from the explicit bilinear forms, including Degen's 8-square identity",
+      "Norm-multiplicativity is exactly multiplicative closure of sums of squares: IsSumOfSquares n x → IsSumOfSquares n y → IsSumOfSquares n (x·y) for n ∈ {1,2,4,8}",
+      "Over ℤ this is the elementary 'easy' direction behind Lagrange's four-square theorem (reduce to primes) and Fermat's two-square theorem",
+      "The same identities fail to extend to n=16: a bilinear 16-square identity does not exist over ℝ — that impossibility (Hurwitz's theorem proper) is the hard direction the parent leaves open"
+    ],
+    "prerequisites": [
+      "Composition algebras and the normed division algebras ℝ, ℂ, ℍ, 𝕆",
+      "Polynomial identities over commutative rings",
+      "Sums of squares and the classical two-/four-square theorems"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Norm and the Four Bilinear Products",
+      "summary": "normSq v = ∑ (v i)²; oneMul, twoMul, fourMul, eightMul over a generic CommRing R",
+      "startLine": 39,
+      "endLine": 84,
+      "mathContext": "The squared norm and the four multiplication tables (ℝ, ℂ, ℍ, 𝕆) written with integer coefficients over an arbitrary commutative ring R. Identical formulas to the parent's HurwitzTheorem, but no longer specialised to ℝ."
+    },
+    {
+      "id": "universal-identities",
+      "title": "The Universal Identities",
+      "summary": "one_square, two_square, four_square, eight_square: normSq a * normSq b = normSq (nMul a b) over any CommRing",
+      "startLine": 85,
+      "endLine": 116,
+      "mathContext": "Each identity is closed by `ring` after expanding the sum and matrix literals. Being CommRing-level, they specialise to ℤ, ℚ, ℝ, ℂ, ZMod m, polynomial rings, etc."
+    },
+    {
+      "id": "closure",
+      "title": "Multiplicative Closure of Sums of Squares",
+      "summary": "IsSumOfSquares n; closure under × for n=2,4,8; 0 and 1 are always sums of squares",
+      "startLine": 117,
+      "endLine": 163,
+      "mathContext": "Norm-multiplicativity restated as: the set of sums of n squares (n ∈ {1,2,4,8}) is closed under multiplication in every commutative ring, with witnesses produced by the bilinear products."
+    },
+    {
+      "id": "integers",
+      "title": "Specialisation to ℤ",
+      "summary": "int_sumTwoSq_mul, int_sumFourSq_mul, and worked witnesses 3, 5, 15",
+      "startLine": 164,
+      "endLine": 195,
+      "mathContext": "The closure lemmas over ℤ are the elementary multiplicative steps behind the two-square and four-square theorems; 3·5 = 15 is exhibited as a sum of four squares via Euler's identity."
+    }
+  ],
+  "references": [
+    {
+      "citation": "Hurwitz, A. (1898). 'Über die Komposition der quadratischen Formen von beliebig vielen Variablen.' Nachr. Ges. Wiss. Göttingen, 309–316.",
+      "url": "https://eudml.org/doc/58671"
+    },
+    {
+      "citation": "Euler, L. (1748). Four-square identity (letter to Goldbach).",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_four-square_identity"
+    },
+    {
+      "citation": "Degen, C. F. (1818). Eight-square identity.",
+      "url": "https://en.wikipedia.org/wiki/Degen%27s_eight-square_identity"
+    },
+    {
+      "citation": "Baez, J. (2002). 'The Octonions.' Bulletin of the American Mathematical Society 39, 145–205.",
+      "url": "https://doi.org/10.1090/S0273-0979-01-00934-X"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "hurwitz-theorem-oq-03",
+      "relevance": "Parent entry: formalizes the existence direction over ℝ (n=4 via Mathlib quaternions) and leaves the impossibility direction for n ∉ {1,2,4,8} as a sorry. This entry generalises the existence direction to all commutative rings and extracts the arithmetic consequence."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 0-axiom, self-contained proof that the 1-, 2-, 4-, and 8-square identities are universal commutative-ring identities, proved by `ring` over a generic CommRing without any division-algebra library. As a corollary, the set of sums of 1, 2, 4, or 8 squares is multiplicatively closed in every commutative ring; over ℤ these are the elementary multiplicative steps behind the two-square and four-square theorems, illustrated by exhibiting 15 = 3·5 as a sum of four squares.",
+    "implications": "Separates the two halves of Hurwitz's theorem cleanly: the existence direction is elementary and universal (formal polynomial identities over ℤ), whereas the impossibility direction (no bilinear n-square identity for n ∉ {1,2,4,8}) is the genuinely deep part that needs Clifford-algebra / Bott-periodicity machinery and remains the parent's open sorry. The universality framing also makes the identities directly reusable over ℤ, ℚ, finite fields, and polynomial rings.",
+    "openQuestions": [
+      "Prove the impossibility direction: no bilinear n-square identity exists for n ∉ {1,2,4,8} (the parent's remaining sorry; needs Clifford algebras / Bott periodicity).",
+      "Connect IsSumOfSquares to Mathlib's number-theoretic two-/four-square theorems to recover the hard 'which integers are sums of squares' direction.",
+      "Formalise the Pfister theory of n-square identities with denominators (which exist for all 2-powers), contrasting with the bilinear case settled by Hurwitz."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "HurwitzUniversal",
+    "lineCount": 195,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 6,
+    "path": "Proofs/HurwitzUniversal.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent entry `hurwitz-theorem-oq-03` formalizes the **existence** direction of Hurwitz's theorem only over **ℝ** (deriving the 4-square identity from Mathlib's quaternion norm). This entry sharpens it: the 1-, 2-, 4-, and 8-square identities are **universal polynomial identities**, valid over **every commutative ring**.

```
one/two/four/eight_square :
    normSq a * normSq b = normSq (nMul a b)      over an arbitrary CommRing R
```

where `nMul` is the multiplication table of ℝ / ℂ / ℍ / 𝕆 and `normSq v = ∑ (v i)²`. Each `zᵢ` has integer coefficients, so each identity is closed by a single **`ring`** call after expanding the finite sum and the matrix literals — including the sign-sensitive **Degen 8-square identity**, with **no quaternion/octonion library**.

### Arithmetic corollary

`IsSumOfSquares n r := ∃ v : Fin n → R, normSq v = r` is multiplicatively closed for `n ∈ {1,2,4,8}` in any commutative ring (and always contains 0 and 1). Specialised to **ℤ** this gives `int_sumTwoSq_mul` and `int_sumFourSq_mul` — the elementary multiplicative steps behind the two-square and four-square theorems — with worked witnesses `3 = 1²+1²+1²+0²`, `5 = 2²+1²+0²+0²`, and `15 = 3·5` exhibited as a sum of four squares.

## Verification

- Self-contained (`import Mathlib` only): 195 lines, 14 theorems/lemmas, 6 defs.
- Builds against pinned Mathlib v4.26 (host `lake env lean`), 0 sorries.
- `#print axioms` on `two_square`, `four_square`, `eight_square`, `isSumOfSquares_four_mul`, `int_sumFourSq_mul` → only `[propext, Classical.choice, Quot.sound]` — **0-axiom**, no `Lean.ofReduceBool`.

## Scope

Does **not** address the parent's remaining `sorry`: the impossibility of bilinear n-square identities for `n ∉ {1,2,4,8}`, which needs Clifford-algebra / Bott-periodicity machinery. This entry covers and generalises the existence/universality direction only.

## Files

- `proofs/Proofs/HurwitzUniversal.lean`
- `src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/{meta.json,annotations.json}`
- `research/problems/hurwitz-theorem-oq-03-incomplete-01/state.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)