### PR TITLE
research(fibonacci-identities-oq-04-oq-02): Fibonacci Q-matrix det(Qⁿ)=(−1)ⁿ, Cassini/Vajda by determinants

### DIFF
--- a/proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean
@@ -1,0 +1,138 @@
+import Mathlib
+
+/-
+# The Fibonacci Q-matrix: `det(Qⁿ) = (−1)ⁿ` and the Cassini / Vajda identities
+
+The classical **Q-matrix** of the Fibonacci numbers is
+
+  `Q = !![1, 1; 1, 0]`,
+
+whose powers encode the Fibonacci sequence:
+
+  `Qⁿ = !![F (n+1), F n; F n, F (n+1) − F n]`   (with `F (n+1) − F n = F (n−1)`).
+
+This file formalises the matrix form requested as an open question of the entry
+*Vajda's and d'Ocagne's Identities* (`fibonacci-identities-oq-04`):
+
+> Formalize the matrix form `det([[1,1],[1,0]]ⁿ) = (−1)ⁿ` and deduce Vajda from the
+> multiplicativity of determinants.
+
+The development is purely matrix-theoretic and self-contained over `Nat.fib`:
+
+* `Q_pow`         — the closed form of `Qⁿ` (induction on `n`);
+* `det_Q_pow`     — `det (Qⁿ) = (−1)ⁿ`, an instant corollary of `det (A·B) = det A · det B`
+                    via `Matrix.det_pow`;
+* `fib_cassini`   — **Cassini's identity** `F (n+1)² − F n · F (n+2) = (−1)ⁿ`, read directly
+                    off `det_Q_pow` and the explicit `2×2` determinant;
+* `fib_add'`      — the Fibonacci **addition law** `F (a+b) = F (a+1)·F b + F a·(F (b+1) − F b)`,
+                    read off the `(0,1)` entry of `Qᵃ⁺ᵇ = Qᵃ · Qᵇ` (multiplicativity of `Q`);
+* `fib_vajda`     — **Vajda's identity** `F (x+i)·F (x+j) − F x·F (x+i+j) = (−1)ˣ·F i·F j`,
+                    deduced from `fib_cassini` (determinant) and `fib_add'` (multiplicativity);
+* `fib_catalan`   — Catalan's identity as the `i = j` specialisation of Vajda.
+
+Everything is over `Nat.fib` cast to `ℤ` (so the signs `(−1)ⁿ` make sense). No axioms,
+no `sorry`, no `native_decide`. The Fibonacci Q-matrix and `det(Qⁿ) = (−1)ⁿ` are **absent
+from Mathlib** (Mathlib records `Nat.fib_add` but no matrix encoding).
+-/
+
+namespace FibonacciIdentitiesOQ04OQ02
+
+open Matrix
+
+/-- The Fibonacci **Q-matrix** `!![1, 1; 1, 0]` over `ℤ`. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- `det Q = −1`. -/
+theorem det_Q : Q.det = -1 := by
+  simp [Q, Matrix.det_fin_two_of]
+
+/-- The integer recurrence `F (n+2) = F n + F (n+1)` over `ℤ`. -/
+theorem fib_rec (n : ℕ) : (Nat.fib (n + 2) : ℤ) = Nat.fib n + Nat.fib (n + 1) := by
+  exact_mod_cast Nat.fib_add_two
+
+/-- **Closed form of the Q-matrix powers.**
+`Qⁿ = !![F (n+1), F n; F n, F (n+1) − F n]`, where the bottom-right entry equals `F (n−1)`.
+Proved by induction on `n` using only `Q · Qⁿ` and the Fibonacci recurrence. -/
+theorem Q_pow (n : ℕ) :
+    Q ^ n =
+      !![(Nat.fib (n + 1) : ℤ), (Nat.fib n : ℤ);
+         (Nat.fib n : ℤ), (Nat.fib (n + 1) : ℤ) - (Nat.fib n : ℤ)] := by
+  induction n with
+  | zero =>
+    rw [pow_zero, Matrix.one_fin_two]
+    norm_num [Nat.fib_one, Nat.fib_zero]
+  | succ k ih =>
+    rw [pow_succ, ih, Q]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Matrix.mul_apply, Fin.sum_univ_two, fib_rec k]
+    all_goals ring
+
+/-- **`det (Qⁿ) = (−1)ⁿ`** — the headline matrix identity, immediate from
+`det (A·B) = det A · det B` (`Matrix.det_pow`) and `det Q = −1`. -/
+theorem det_Q_pow (n : ℕ) : (Q ^ n).det = (-1) ^ n := by
+  rw [Matrix.det_pow, det_Q]
+
+/-- **Cassini's identity** `F (n+1)² − F n · F (n+2) = (−1)ⁿ`, read directly off
+`det (Qⁿ) = (−1)ⁿ` by computing the determinant of the explicit `2×2` closed form. -/
+theorem fib_cassini (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - (Nat.fib n : ℤ) * (Nat.fib (n + 2) : ℤ) = (-1) ^ n := by
+  have h := det_Q_pow n
+  rw [Q_pow, Matrix.det_fin_two_of] at h
+  -- h : F (n+1) * (F (n+1) - F n) - F n * F n = (-1)^n
+  rw [fib_rec n]
+  linear_combination h
+
+/-- **Fibonacci addition law from the Q-matrix.**
+`F (a+b) = F (a+1)·F b + F a·(F (b+1) − F b)`, obtained by reading the `(0,1)` entry of
+`Qᵃ⁺ᵇ = Qᵃ · Qᵇ` (multiplicativity of matrix powers). -/
+theorem fib_add' (a b : ℕ) :
+    (Nat.fib (a + b) : ℤ)
+      = (Nat.fib (a + 1) : ℤ) * (Nat.fib b : ℤ)
+        + (Nat.fib a : ℤ) * ((Nat.fib (b + 1) : ℤ) - (Nat.fib b : ℤ)) := by
+  have h : Q ^ (a + b) = Q ^ a * Q ^ b := pow_add Q a b
+  rw [Q_pow, Q_pow, Q_pow] at h
+  have h01 := congr_fun (congr_fun h 0) 1
+  simpa [Matrix.mul_apply, Fin.sum_univ_two] using h01
+
+/-- **Vajda's identity** `F (x+i)·F (x+j) − F x·F (x+i+j) = (−1)ˣ·(F i·F j)`,
+the two-parameter master identity of the Fibonacci product family.
+
+Deduced entirely from the matrix theory above: the sign `(−1)ˣ` comes from Cassini
+(`det (Qˣ) = (−1)ˣ`) and every shifted Fibonacci number is expanded with the
+multiplicativity addition law `fib_add'`. -/
+theorem fib_vajda (x i j : ℕ) :
+    (Nat.fib (x + i) : ℤ) * (Nat.fib (x + j) : ℤ)
+        - (Nat.fib x : ℤ) * (Nat.fib (x + i + j) : ℤ)
+      = (-1) ^ x * ((Nat.fib i : ℤ) * (Nat.fib j : ℤ)) := by
+  -- Cassini in determinant form: F(x+1)² − F(x+1)·F x − F x² = (−1)ˣ
+  have hcx : (Nat.fib (x + 1) : ℤ) ^ 2
+      - (Nat.fib (x + 1) : ℤ) * (Nat.fib x : ℤ) - (Nat.fib x : ℤ) ^ 2 = (-1) ^ x := by
+    have h := fib_cassini x
+    rw [fib_rec x] at h
+    linear_combination h
+  -- addition-law expansions of the three shifted indices
+  have h1 := fib_add' x i
+  have h2 := fib_add' x j
+  have h3 := fib_add' x (i + j)
+  have h4 := fib_add' i j
+  -- F (i + j + 1) via `fib_add' i (j+1)` together with `F (j+2) − F (j+1) = F j`
+  have h5 : (Nat.fib (i + j + 1) : ℤ)
+      = (Nat.fib (i + 1) : ℤ) * (Nat.fib (j + 1) : ℤ) + (Nat.fib i : ℤ) * (Nat.fib j : ℤ) := by
+    have h := fib_add' i (j + 1)
+    rw [show i + (j + 1) = i + j + 1 by ring, fib_rec j] at h
+    linear_combination h
+  rw [show x + i + j = x + (i + j) by ring]
+  rw [h1, h2, h3, h4, h5]
+  linear_combination ((Nat.fib i : ℤ) * (Nat.fib j : ℤ)) * hcx
+
+/-- **Catalan's identity** `F (x+a)² − F x · F (x+2a) = (−1)ˣ · F a²`,
+the `i = j = a` specialisation of Vajda. -/
+theorem fib_catalan (x a : ℕ) :
+    (Nat.fib (x + a) : ℤ) ^ 2 - (Nat.fib x : ℤ) * (Nat.fib (x + 2 * a) : ℤ)
+      = (-1) ^ x * (Nat.fib a : ℤ) ^ 2 := by
+  have h := fib_vajda x a a
+  rw [show x + a + a = x + 2 * a by ring] at h
+  linear_combination h
+
+end FibonacciIdentitiesOQ04OQ02

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-fiboq0402-1",
+    "proofId": "fibonacci-identities-oq-04-oq-02",
+    "range": { "startLine": 3, "endLine": 36 },
+    "type": "context",
+    "title": "The Fibonacci Q-Matrix and the Determinant Route",
+    "content": "**Module framing.** The matrix $Q = \\begin{pmatrix}1&1\\\\1&0\\end{pmatrix}$ encodes the Fibonacci numbers: $Q^n = \\begin{pmatrix}F_{n+1}&F_n\\\\F_n&F_{n-1}\\end{pmatrix}$. Because $\\det$ is multiplicative, $\\det(Q^n) = (\\det Q)^n = (-1)^n$, and expanding the left side is exactly Cassini's identity. This entry answers the **second open question** of `fibonacci-identities-oq-04` — to formalize $\\det([[1,1],[1,0]]^n) = (-1)^n$ and deduce Vajda from determinant multiplicativity. The Q-matrix and this determinant identity are **absent from Mathlib** (which records only `Nat.fib_add`).",
+    "mathContext": "$Q = \\begin{pmatrix}1&1\\\\1&0\\end{pmatrix}$, $\\det(Q^n) = (-1)^n$, the source of every alternating sign in the Fibonacci product family.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Fibonacci Q-matrix",
+      "Multiplicativity of determinants",
+      "Cassini / Vajda / Catalan identities"
+    ],
+    "prerequisites": [
+      "2×2 determinants and their multiplicativity",
+      "The Fibonacci recurrence"
+    ],
+    "tags": ["module-header", "framing", "q-matrix"]
+  },
+  {
+    "id": "ann-fiboq0402-2",
+    "proofId": "fibonacci-identities-oq-04-oq-02",
+    "range": { "startLine": 53, "endLine": 69 },
+    "type": "insight",
+    "title": "Closed Form of Qⁿ — Subtraction-Free Induction",
+    "content": "**`Q_pow`** proves $Q^n = $ `!![F(n+1), F n; F n, F(n+1) − F n]` by induction. The trick is writing the bottom-right entry as $F_{n+1} - F_n$ (which equals $F_{n-1}$) rather than $F_{n-1}$ directly: this keeps the statement **subtraction-free in the indices** and correct at $n=0$, where it is the identity matrix $Q^0 = I = $ `!![1,0;0,1]` (since $F_1 - F_0 = 1$). A single induction then covers all $n$ with no case split. The step rewrites $Q^{n+1} = Q^n \\cdot Q$ and computes each of the four entries with `Matrix.mul_apply` / `Fin.sum_univ_two`, closing them with the recurrence $F_{n+2} = F_n + F_{n+1}$ and `ring`.",
+    "mathContext": "$Q^n = \\begin{pmatrix}F_{n+1}&F_n\\\\F_n&F_{n+1}-F_n\\end{pmatrix}$; the $-$ avoids natural-number subtraction at $n=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix power by induction",
+      "Matrix.mul_apply / Fin.sum_univ_two",
+      "Fibonacci recurrence (Nat.fib_add_two)"
+    ],
+    "prerequisites": [
+      "Induction on matrix powers",
+      "Entrywise matrix multiplication"
+    ],
+    "tags": ["closed-form", "induction", "matrix"]
+  },
+  {
+    "id": "ann-fiboq0402-3",
+    "proofId": "fibonacci-identities-oq-04-oq-02",
+    "range": { "startLine": 71, "endLine": 84 },
+    "type": "insight",
+    "title": "det(Qⁿ) = (−1)ⁿ — Cassini in One Line",
+    "content": "**`det_Q_pow`** is the headline: $\\det(Q^n) = (\\det Q)^n = (-1)^n$, a one-liner from `Matrix.det_pow` and $\\det Q = -1$. This is the open question verbatim. **`fib_cassini`** then equates the determinant of the *explicit* closed form, $F_{n+1}(F_{n+1}-F_n) - F_n^2$, with $(-1)^n$ and rewrites $F_{n+2} = F_n + F_{n+1}$ to land the standard Cassini form $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$. The alternating sign is thus revealed to be *literally a determinant* — the cleanest possible proof of Cassini's identity.",
+    "mathContext": "$\\det(Q^n) = (-1)^n \\;\\Rightarrow\\; F_{n+1}^2 - F_n F_{n+2} = (-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.det_pow (multiplicativity)",
+      "Matrix.det_fin_two_of",
+      "Cassini's identity"
+    ],
+    "prerequisites": [
+      "Multiplicativity of determinants",
+      "Explicit 2×2 determinant"
+    ],
+    "tags": ["determinant", "cassini", "headline"]
+  },
+  {
+    "id": "ann-fiboq0402-4",
+    "proofId": "fibonacci-identities-oq-04-oq-02",
+    "range": { "startLine": 86, "endLine": 96 },
+    "type": "insight",
+    "title": "Addition Law from Qᵃ⁺ᵇ = Qᵃ·Qᵇ",
+    "content": "**`fib_add'`** extracts the Fibonacci addition law $F_{a+b} = F_{a+1}F_b + F_a(F_{b+1} - F_b)$ from the multiplicativity of matrix powers $Q^{a+b} = Q^a \\cdot Q^b$ (`pow_add`): rewrite all three powers by their closed form, then read off the $(0,1)$ entry via `Matrix.mul_apply` / `Fin.sum_univ_two`. This is the *second* engine the matrix supplies — alongside the determinant — and it is all the Fibonacci-specific input Vajda needs.",
+    "mathContext": "$(Q^{a+b})_{0,1} = (Q^a Q^b)_{0,1}$ gives $F_{a+b} = F_{a+1}F_b + F_a(F_{b+1} - F_b)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "pow_add (matrix multiplicativity)",
+      "Fibonacci addition formula",
+      "Reading identities off matrix entries"
+    ],
+    "prerequisites": [
+      "Matrix power laws",
+      "Entrywise extraction"
+    ],
+    "tags": ["addition-law", "multiplicativity"]
+  },
+  {
+    "id": "ann-fiboq0402-5",
+    "proofId": "fibonacci-identities-oq-04-oq-02",
+    "range": { "startLine": 98, "endLine": 127 },
+    "type": "insight",
+    "title": "Vajda's Identity from Determinant + Multiplicativity",
+    "content": "**`fib_vajda`** assembles the two-parameter master identity $F_{x+i}F_{x+j} - F_x F_{x+i+j} = (-1)^x F_i F_j$ from the two matrix facts. Every shifted term $F_{x+i}, F_{x+j}, F_{x+i+j}, F_{i+j}, F_{i+j+1}$ is expanded with the addition law `fib_add'` (multiplicativity), and the determinant form of Cassini for $x$ — $F_{x+1}^2 - F_{x+1}F_x - F_x^2 = (-1)^x$ — supplies the sign. The remainder is a polynomial identity closed by `linear_combination (F_i F_j)·(Cassini)`: the $F_{x+1}F_x$ cross-terms and the $F_x^2$ terms each collapse to exactly $-F_i F_j$, matching the Cassini coefficient. **`fib_catalan`** is then the $i = j$ case.",
+    "mathContext": "$F_{x+i}F_{x+j} - F_x F_{x+i+j} = (-1)^x F_i F_j$; the coefficient of $(-1)^x$ is $F_i F_j$ by the Cassini reduction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vajda's identity",
+      "linear_combination",
+      "Cassini as the sign source",
+      "Catalan as i = j"
+    ],
+    "prerequisites": [
+      "fib_add' (addition law)",
+      "fib_cassini (determinant form)",
+      "linear_combination tactic"
+    ],
+    "tags": ["vajda", "catalan", "synthesis"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ04OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ04OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ04OQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ04OQ02Proof,
+  annotations: fibonacciIdentitiesOQ04OQ02Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-02/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "fibonacci-identities-oq-04-oq-02",
+  "title": "The Fibonacci Q-Matrix: det(Qⁿ) = (−1)ⁿ and Cassini / Vajda by Determinants",
+  "slug": "fibonacci-identities-oq-04-oq-02",
+  "description": "The classical Fibonacci Q-matrix Q = [[1,1],[1,0]] satisfies Qⁿ = [[Fₙ₊₁, Fₙ],[Fₙ, Fₙ₊₁−Fₙ]], so its powers encode the Fibonacci sequence. This entry formalizes the matrix form requested as an open question of fibonacci-identities-oq-04: det(Qⁿ) = (−1)ⁿ, obtained instantly from the multiplicativity of determinants det(A·B) = det A · det B (Matrix.det_pow) together with det Q = −1. Reading the explicit 2×2 determinant of the closed form gives Cassini's identity Fₙ₊₁² − Fₙ·Fₙ₊₂ = (−1)ⁿ for free. The Fibonacci addition law Fₐ₊ᵦ = Fₐ₊₁·Fᵦ + Fₐ·(Fᵦ₊₁−Fᵦ) is read off the (0,1) entry of Qᵃ⁺ᵇ = Qᵃ·Qᵇ (multiplicativity of matrix powers), and from Cassini (determinant) plus this addition law the two-parameter Vajda identity Fₓ₊ᵢ·Fₓ₊ⱼ − Fₓ·Fₓ₊ᵢ₊ⱼ = (−1)ˣ·Fᵢ·Fⱼ is deduced, with Catalan as the i=j specialization. The Fibonacci Q-matrix and det(Qⁿ) = (−1)ⁿ are absent from Mathlib (which records only Nat.fib_add). Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Q-matrix folklore, 19th–20th c.); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Matrix_form",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "q-matrix",
+      "determinant",
+      "cassini",
+      "vajda",
+      "catalan-identity",
+      "linear-algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ04OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_pow",
+        "description": "det (M ^ n) = (det M) ^ n — multiplicativity of determinants over powers; the single line that turns det Q = −1 into det (Qⁿ) = (−1)ⁿ",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_two_of",
+        "description": "det !![a,b;c,d] = a*d − b*c — the explicit 2×2 determinant, used both for det Q and to read Cassini off the closed form of Qⁿ",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.one_fin_two",
+        "description": "(1 : Matrix (Fin 2) (Fin 2) α) = !![1,0;0,1] — base case Q⁰ = I of the closed-form induction",
+        "module": "Mathlib.Data.Matrix.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the defining Fibonacci recurrence, cast to ℤ and used in the induction step of the Q-matrix closed form",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Q_pow: ∀ n, Q ^ n = !![F(n+1), F n; F n, F(n+1) − F n] — closed form of the Fibonacci Q-matrix powers (the Q-matrix is absent from Mathlib), proved by induction with only the Fibonacci recurrence",
+      "det_Q_pow: ∀ n, det (Q ^ n) = (−1)ⁿ — the headline matrix identity, the open question of fibonacci-identities-oq-04, immediate from Matrix.det_pow and det Q = −1",
+      "fib_cassini: ∀ n, F(n+1)² − F n·F(n+2) = (−1)ⁿ — Cassini's identity read directly off det(Qⁿ) = (−1)ⁿ and the explicit 2×2 determinant",
+      "fib_add': ∀ a b, F(a+b) = F(a+1)·F b + F a·(F(b+1) − F b) — the Fibonacci addition law obtained from the (0,1) entry of the matrix multiplicativity Qᵃ⁺ᵇ = Qᵃ·Qᵇ",
+      "fib_vajda: ∀ x i j, F(x+i)·F(x+j) − F x·F(x+i+j) = (−1)ˣ·(F i·F j) — Vajda's two-parameter identity deduced from the matrix Cassini (determinant) and addition law (multiplicativity), an independent matrix-theoretic proof of the result of fibonacci-identities-oq-04",
+      "fib_catalan: ∀ x a, F(x+a)² − F x·F(x+2a) = (−1)ˣ·F a² — Catalan's identity as the i=j case of the matrix-derived Vajda"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 138,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The matrix encoding of the Fibonacci numbers is folklore going back to the 19th century: with Q = [[1,1],[1,0]] one has Qⁿ = [[Fₙ₊₁, Fₙ],[Fₙ, Fₙ₋₁]]. Because the determinant is multiplicative, det(Qⁿ) = (det Q)ⁿ = (−1)ⁿ, and expanding the left side gives Fₙ₊₁Fₙ₋₁ − Fₙ² = (−1)ⁿ — Cassini's identity (1680). This is the canonical 'one-line' proof of Cassini and the conceptual reason every identity in the family carries an alternating sign: the sign is a determinant. The parent entry fibonacci-identities-oq-04 proved Vajda's master identity over Int.fib by the addition-formula/ring route and explicitly asked for the matrix form. This entry supplies it: det(Qⁿ) = (−1)ⁿ as the determinant statement, and a fully matrix-theoretic re-derivation of Cassini, the Fibonacci addition law (from Qᵃ⁺ᵇ = Qᵃ·Qᵇ), Vajda, and Catalan.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-04, second open question)**: Formalize the matrix form det([[1,1],[1,0]]ⁿ) = (−1)ⁿ and deduce Vajda's identity from the multiplicativity of determinants.\n\n**Result**: det_Q_pow (det(Qⁿ) = (−1)ⁿ) with fib_cassini read off the determinant, fib_add' from matrix multiplicativity, and fib_vajda / fib_catalan deduced from them.",
+    "text": "For the integer matrix Q = [[1,1],[1,0]], the n-th power is Qⁿ = [[Fₙ₊₁, Fₙ],[Fₙ, Fₙ₊₁−Fₙ]] and its determinant is det(Qⁿ) = (−1)ⁿ. The two consequences of these facts — the determinant identity (multiplicativity) and the matrix product identity Qᵃ⁺ᵇ = Qᵃ·Qᵇ (the addition law) — together yield the entire elementary Fibonacci product hierarchy: Cassini, Vajda, and Catalan.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Closed form (Q_pow).** Prove Qⁿ = !![F(n+1), F n; F n, F(n+1)−F n] by induction on n. The bottom-right entry is written F(n+1)−F n (= F(n−1)) so the statement is subtraction-free in the indices and valid at n = 0 (where it is the identity matrix). The step computes Qⁿ·Q entrywise via Matrix.mul_apply / Fin.sum_univ_two and closes each of the four entries with the recurrence F(n+2) = F n + F(n+1) and ring.\n2. **Determinant (det_Q_pow).** det(Qⁿ) = (det Q)ⁿ = (−1)ⁿ, a one-liner from Matrix.det_pow and det Q = −1.\n3. **Cassini (fib_cassini).** Equate the determinant of the explicit closed form, F(n+1)·(F(n+1)−F n) − F n·F n, with (−1)ⁿ via det_Q_pow, then rewrite F(n+2) = F n + F(n+1) to land the standard form F(n+1)² − F n·F(n+2) = (−1)ⁿ.\n4. **Addition law (fib_add').** From Qᵃ⁺ᵇ = Qᵃ·Qᵇ (pow_add), read the (0,1) entry of both sides through the closed form: F(a+b) = F(a+1)·F b + F a·(F(b+1)−F b). This is the multiplicativity input.\n5. **Vajda (fib_vajda).** Expand F(x+i), F(x+j), F(x+i+j), F(i+j), F(i+j+1) with fib_add', and substitute Cassini for x in determinant form F(x+1)² − F(x+1)·F x − F x² = (−1)ˣ. The result is a polynomial identity closed by linear_combination (F i·F j)·(Cassini): the (F(x+1)·F x) cross-terms and the F x² terms each contribute exactly −F i·F j, matching the Cassini coefficient.\n6. **Catalan (fib_catalan).** The i = j = a case of Vajda, after x+a+a = x+2a, by linear_combination.",
+    "keyInsights": [
+      "**The alternating sign is a determinant.** Cassini's (−1)ⁿ is not an accident of the recurrence but literally det(Qⁿ) = (det Q)ⁿ with det Q = −1. Formalizing it this way reduces Cassini to the multiplicativity of determinants — the cleanest possible proof.",
+      "**One matrix, two engines.** det(Qⁿ) = (−1)ⁿ supplies the sign (Cassini) and Qᵃ⁺ᵇ = Qᵃ·Qᵇ supplies the addition law; together they generate the whole product hierarchy. Vajda needs nothing Fibonacci-specific beyond these two matrix facts.",
+      "**Subtraction-free closed form.** Writing the bottom-right entry as F(n+1) − F n (rather than F(n−1)) keeps the closed form valid at n = 0 and lets a single induction cover all n with no case split, since the determinant and addition-law extractions then hold uniformly.",
+      "**Independent of the parent's route.** fibonacci-identities-oq-04 proved Vajda over Int.fib by five Int.fib_add expansions; this entry re-derives the same identity purely from the 2×2 Q-matrix over Nat.fib, exhibiting the matrix proof the parent flagged as open."
+    ],
+    "prerequisites": [
+      "The 2×2 determinant det !![a,b;c,d] = a*d − b*c and its multiplicativity det(M^n) = (det M)^n",
+      "Matrix multiplication of explicit matrices (Matrix.mul_apply, Fin.sum_univ_two)",
+      "The Fibonacci recurrence Nat.fib_add_two and casting to ℤ",
+      "The linear_combination tactic for closing polynomial identities modulo a hypothesis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Q-Matrix",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "Module docstring describing the Fibonacci Q-matrix, the closed form of its powers, and the determinant route to Cassini/Vajda; the definition Q = !![1,1;1,0] and det Q = −1.",
+      "mathContext": "$Q = \\begin{pmatrix}1&1\\\\1&0\\end{pmatrix}$, $\\det Q = -1$."
+    },
+    {
+      "id": "qpow",
+      "title": "Closed Form of the Q-Matrix Powers",
+      "startLine": 49,
+      "endLine": 69,
+      "summary": "fib_rec casts the Fibonacci recurrence to ℤ; Q_pow proves Qⁿ = !![F(n+1), F n; F n, F(n+1)−F n] by induction, computing Qⁿ·Q entrywise in the step.",
+      "mathContext": "$Q^n = \\begin{pmatrix}F_{n+1}&F_n\\\\F_n&F_{n+1}-F_n\\end{pmatrix}$."
+    },
+    {
+      "id": "det",
+      "title": "det(Qⁿ) = (−1)ⁿ and Cassini",
+      "startLine": 71,
+      "endLine": 84,
+      "summary": "det_Q_pow: det(Qⁿ) = (−1)ⁿ from Matrix.det_pow and det Q = −1 — the open-question headline. fib_cassini reads Cassini's identity off the determinant of the explicit closed form.",
+      "mathContext": "$\\det(Q^n) = (-1)^n$, hence $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$."
+    },
+    {
+      "id": "addition",
+      "title": "Addition Law from Matrix Multiplicativity",
+      "startLine": 86,
+      "endLine": 96,
+      "summary": "fib_add': the Fibonacci addition law F(a+b) = F(a+1)·F b + F a·(F(b+1)−F b), read off the (0,1) entry of Qᵃ⁺ᵇ = Qᵃ·Qᵇ via the closed form.",
+      "mathContext": "$F_{a+b} = F_{a+1}F_b + F_a(F_{b+1} - F_b)$."
+    },
+    {
+      "id": "vajda",
+      "title": "Vajda's Identity by Determinants",
+      "startLine": 98,
+      "endLine": 127,
+      "summary": "fib_vajda: the two-parameter master identity, deduced by expanding every shifted term with the matrix addition law and substituting the determinant form of Cassini, closed by linear_combination.",
+      "mathContext": "$F_{x+i}F_{x+j} - F_x F_{x+i+j} = (-1)^x F_i F_j$."
+    },
+    {
+      "id": "catalan",
+      "title": "Catalan's Identity (recovered)",
+      "startLine": 129,
+      "endLine": 137,
+      "summary": "fib_catalan: the diagonal i = j = a specialization of the matrix-derived Vajda identity.",
+      "mathContext": "$F_{x+a}^2 - F_x F_{x+2a} = (-1)^x F_a^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-04",
+      "relationship": "specializes",
+      "description": "Resolves the second open question of fibonacci-identities-oq-04 — the matrix form det([[1,1],[1,0]]ⁿ) = (−1)ⁿ and the deduction of Vajda from determinant multiplicativity — giving an independent matrix-theoretic proof of that entry's Vajda identity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the Fibonacci Q-matrix: the closed form Qⁿ = [[Fₙ₊₁,Fₙ],[Fₙ,Fₙ₊₁−Fₙ]], the determinant identity det(Qⁿ) = (−1)ⁿ, and a matrix-theoretic derivation of Cassini's, Vajda's, and Catalan's identities from the multiplicativity of determinants and matrix powers.",
+    "implications": "Adds the Fibonacci Q-matrix and the identity det(Qⁿ) = (−1)ⁿ — both absent from Mathlib — to the formalized record, and exhibits the determinant proof of Cassini (the conceptual source of the alternating sign) and the matrix-multiplicativity proof of the addition law and Vajda's identity that the parent entry flagged as an open question.",
+    "openQuestions": [
+      "Formalize the Q-matrix over a general 2×2 companion matrix to obtain the analogous det identity for Lucas and Gibonacci (Horadam) sequences, where det = −(p²+q) replaces −1.",
+      "Derive d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ from the same matrix machinery via the transpose/cofactor structure of Qⁿ.",
+      "Prove the Honsberger doubling identities F₂ₙ = Fₙ(2Fₙ₊₁ − Fₙ) and F₂ₙ₊₁ = Fₙ₊₁² + Fₙ² as the entries of Q²ⁿ = (Qⁿ)²."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix"
+    ],
+    "namespace": "FibonacciIdentitiesOQ04OQ02",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "The Q-matrix and the product-identity hierarchy"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Matrix form of the Fibonacci numbers and det(Qⁿ) = (−1)ⁿ"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/fibonacci-identities-oq-04-oq-02.json
+++ b/src/data/research/problems/fibonacci-identities-oq-04-oq-02.json
@@ -1,0 +1,53 @@
+{
+  "slug": "fibonacci-identities-oq-04-oq-02",
+  "title": "Fibonacci Q-Matrix: det(Qⁿ) = (−1)ⁿ and Vajda by Determinants",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 9,
+  "significance": 6,
+  "started": "2026-06-24T00:00:00Z",
+  "lastUpdate": "2026-06-24T00:00:00Z",
+  "tags": [
+    "number-theory",
+    "fibonacci",
+    "q-matrix",
+    "determinant",
+    "cassini",
+    "vajda",
+    "linear-algebra"
+  ],
+  "problemStatement": "Formalize the matrix form det([[1,1],[1,0]]ⁿ) = (−1)ⁿ and deduce Vajda's identity from the multiplicativity of determinants — the second open question of fibonacci-identities-oq-04.",
+  "significanceText": "Provides the conceptual (determinant) proof of Cassini's identity and the matrix-multiplicativity proof of the Fibonacci addition law and Vajda's identity, both flagged as open by the parent entry. The Fibonacci Q-matrix and det(Qⁿ) = (−1)ⁿ are absent from Mathlib.",
+  "currentState": "SOLVED. proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean compiles with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound). The Q-matrix closed form, det(Qⁿ) = (−1)ⁿ, Cassini, the addition law, Vajda, and Catalan are all proved.",
+  "knownResults": [
+    "Mathlib records Nat.fib_add (addition formula) and Int.fib Cassini/Catalan, but no matrix encoding of the Fibonacci numbers.",
+    "Parent fibonacci-identities-oq-04 proved Vajda over Int.fib by the Int.fib_add/ring route."
+  ],
+  "knowledge": {
+    "insights": [
+      "The alternating sign (−1)ⁿ in Cassini's identity is literally det(Qⁿ) = (det Q)ⁿ with det Q = −1; the determinant proof is the cleanest possible derivation of Cassini.",
+      "Writing the bottom-right entry of Qⁿ as F(n+1) − F n (rather than F(n−1)) makes the closed form subtraction-free in the indices and valid at n = 0 (identity matrix), so a single induction covers all n with no case split.",
+      "The Q-matrix supplies two engines: det(Qⁿ) = (−1)ⁿ gives the sign (Cassini), and Qᵃ⁺ᵇ = Qᵃ·Qᵇ gives the addition law (the (0,1) entry). Vajda needs nothing Fibonacci-specific beyond these two matrix facts.",
+      "Vajda closes by linear_combination (F i · F j)·(Cassini-in-determinant-form): after expanding every shifted term with the addition law, the F(x+1)F x cross-terms and the F x² terms each collapse to exactly −F i F j, matching the Cassini coefficient."
+    ],
+    "builtItems": [
+      "Q : Matrix (Fin 2) (Fin 2) ℤ := !![1,1;1,0] and det_Q : Q.det = −1 (FibonacciIdentitiesOQ04OQ02.lean)",
+      "Q_pow : Q ^ n = !![F(n+1), F n; F n, F(n+1) − F n] — closed form by induction",
+      "det_Q_pow : det (Q ^ n) = (−1)ⁿ — the open-question headline, via Matrix.det_pow",
+      "fib_cassini : F(n+1)² − F n·F(n+2) = (−1)ⁿ — read off the determinant",
+      "fib_add' : F(a+b) = F(a+1)·F b + F a·(F(b+1) − F b) — from the (0,1) entry of Qᵃ⁺ᵇ = Qᵃ·Qᵇ",
+      "fib_vajda : F(x+i)·F(x+j) − F x·F(x+i+j) = (−1)ˣ·(F i·F j) — deduced from determinant + multiplicativity",
+      "fib_catalan : F(x+a)² − F x·F(x+2a) = (−1)ˣ·F a² — i = j case of Vajda"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Fibonacci Q-matrix and no det(Qⁿ) = (−1)ⁿ; only Nat.fib_add and the Int.fib Cassini/Catalan lemmas exist."
+    ],
+    "nextSteps": [
+      "Generalize to a companion matrix [[p,q],[1,0]] for Lucas/Gibonacci sequences, where det = −q.",
+      "Derive d'Ocagne and the Honsberger doubling identities F₂ₙ, F₂ₙ₊₁ from Q²ⁿ = (Qⁿ)²."
+    ],
+    "progressSummary": "COMPLETE: matrix form det(Qⁿ) = (−1)ⁿ formalized (0 sorries, 0 axioms); Cassini from the determinant, the addition law from matrix multiplicativity, and Vajda/Catalan deduced from both. Gallery entry fibonacci-identities-oq-04-oq-02 added."
+  },
+  "path": "proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean"
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `fibonacci-identities-oq-04`:

> Formalize the matrix form `det([[1,1],[1,0]]ⁿ) = (−1)ⁿ` and deduce Vajda from the multiplicativity of determinants.

The classical Fibonacci **Q-matrix** `Q = !![1,1;1,0]` satisfies `Qⁿ = !![F(n+1), F n; F n, F(n+1)−F n]`, so `det(Qⁿ) = (det Q)ⁿ = (−1)ⁿ`. Expanding that determinant *is* Cassini's identity — the alternating sign is literally a determinant. From `det(Qⁿ) = (−1)ⁿ` (the sign) and `Qᵃ⁺ᵇ = Qᵃ·Qᵇ` (the addition law), the full two-parameter Vajda identity follows.

This is an **independent matrix-theoretic derivation**, distinct from the parent entry's `Int.fib_add`/`ring` route.

## Results (`proofs/Proofs/FibonacciIdentitiesOQ04OQ02.lean`)

| Theorem | Statement |
|---|---|
| `Q_pow` | `Qⁿ = !![F(n+1), F n; F n, F(n+1)−F n]` (subtraction-free induction, valid at `n=0`) |
| `det_Q_pow` | `det(Qⁿ) = (−1)ⁿ` — the open-question headline, one line from `Matrix.det_pow` |
| `fib_cassini` | `F(n+1)² − F n·F(n+2) = (−1)ⁿ` — read off the determinant |
| `fib_add'` | `F(a+b) = F(a+1)·F b + F a·(F(b+1)−F b)` — `(0,1)` entry of `Qᵃ⁺ᵇ = Qᵃ·Qᵇ` |
| `fib_vajda` | `F(x+i)·F(x+j) − F x·F(x+i+j) = (−1)ˣ·F i·F j` — from determinant + multiplicativity |
| `fib_catalan` | `F(x+a)² − F x·F(x+2a) = (−1)ˣ·F a²` — the `i = j` case |

## Verification

- **6 theorems, 1 definition, 138 lines.**
- `#print axioms` on all main theorems: `[propext, Classical.choice, Quot.sound]` only.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.** Status: `verified`, badge `original`.
- The Fibonacci Q-matrix and `det(Qⁿ) = (−1)ⁿ` are **absent from Mathlib** (which records only `Nat.fib_add`).

## Gallery

Adds `src/data/proofs/fibonacci-identities-oq-04-oq-02/` (meta.json, annotations.json, index.ts) and the research knowledge file. Cross-references the parent `fibonacci-identities-oq-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)