### PR TITLE
Fix: remove contradictory 'machine-verified' claim in Lp-duality meta (#28788)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -124,7 +124,7 @@
   ],
   "conclusion": {
     "summary": "The `riesz_lp_surjective` axiom in the parent file is proved using Mathlib's existing infrastructure. The Rudin route via Radon-Nikodým is fully formalized: signed measure construction, RN derivative, Hölder extremizer bound, and Lp.induction extension.",
-    "implications": "This is a complete machine-verified proof of the Riesz representation theorem (surjectivity direction) for $L^p$ spaces with $1 < p < \\infty$ in Lean 4. The proof is elementary in structure, requiring no beyond-Mathlib infrastructure.",
+    "implications": "This is a complete formalization of the Riesz representation theorem (surjectivity direction) for $L^p$ spaces with $1 < p < \\infty$ in Lean 4, elementary in structure and requiring no beyond-Mathlib infrastructure. NOTE (2026-06-24, #28788): the formalization is not currently machine-checked — the file does not compile against the pinned v4.26.0 toolchain due to Mathlib API drift (53 errors); repair is tracked separately and the status has been downgraded to formalized until the build is green.",
     "openQuestions": [
       "Can the proof be generalized to sigma-finite measures without IsFiniteMeasure (would require localizing the argument)?",
       "Does the proof extend to complex-valued Lp spaces (Riesz representation for complex functionals)?"


### PR DESCRIPTION
## Fix

The `conclusion.implications` field of `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01` still asserted **"a complete machine-verified proof"**, contradicting every other field in the same meta.json.

## Evidence

**Before**: `conclusion.implications` = "This is a complete **machine-verified** proof of the Riesz representation theorem ..." — while `meta.status` = `formalized`, `meta.buildStatus` = `broken`, and `meta.assumptions` already disclose the file does **not** compile against `leanprover/lean4:v4.26.0` (53 Mathlib-drift errors, issue #28788) and is "not currently machine-checked".

**After**: reworded to "a complete **formalization** ... **not currently machine-checked** — the file does not compile against the pinned v4.26.0 toolchain due to Mathlib API drift; repair tracked separately; status downgraded to formalized until green."

Addresses remediation step 3 of #28788 (correct the metas to an honest status). The substantive Lean repair (steps 1–2: ~53 errors across the 1077-line measure-theory chain) remains researcher-scope and multi-session. Single-line, minimal-diff metadata fix.

Part of #28788

---
Automated fix by lean-mechanic agent.