### PR TITLE
research(kepler-conjecture-oq-01): best-known lattice packing densities in dims 4-8 strictly decrease [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/KeplerConjectureOQ01.lean
+++ b/proofs/Proofs/KeplerConjectureOQ01.lean
@@ -1,0 +1,305 @@
+/-
+  Kepler Conjecture OQ-01: Best-known sphere packing densities in dimensions 4-23
+
+  **Open question** (parent gallery `kepler-conjecture`, open-question arm 01).
+  The parent Kepler-Hales theorem settles the *optimal* sphere packing density
+  in ℝ³ (the FCC density `π / (3√2) ≈ 0.7405`). The natural generalisation
+  asks for the optimal density of congruent-sphere packings in higher
+  dimensions. This is one of the deepest open problems in discrete geometry:
+  the optimal density is known in only FIVE dimensions —
+  `n = 1, 2, 3` (classical), `n = 8` (Viazovska 2016, the `E₈` lattice) and
+  `n = 24` (Cohn-Kumar-Miller-Radchenko-Viazovska 2017, the Leech lattice).
+  For every dimension in the band `4 ≤ n ≤ 23` *except* `n = 8` the optimal
+  density is **open**; the best constructions known are specific lattices.
+
+  **What this file proves (axiom-free).**
+  Following the sibling entry `kepler-conjecture-oq-04`, we take the
+  *best-known* lattice packing densities from the literature
+  (Conway-Sloane, *Sphere Packings, Lattices and Groups*) as named real
+  constants and prove rigorous relationships between them. We focus on the
+  classical "root-lattice champions" in dimensions 4 through 8:
+
+  | dim `n` | densest known lattice | packing density `Δₙ`            | `≈`     |
+  |---------|-----------------------|---------------------------------|---------|
+  | 4       | `D₄`                  | `π² / 16`                       | 0.61685 |
+  | 5       | `D₅`                  | `π² √2 / 30`                    | 0.46526 |
+  | 6       | `E₆`                  | `π³ √3 / 144`                   | 0.37295 |
+  | 7       | `E₇`                  | `π³ / 105`                      | 0.29530 |
+  | 8       | `E₈`                  | `π⁴ / 384`                      | 0.25367 |
+
+  Each `Δₙ = δₙ · Vₙ`, the lattice's center density `δₙ` times the volume
+  `Vₙ` of the unit `n`-ball (`V₄ = π²/2`, `V₅ = 8π²/15`, `V₆ = π³/6`,
+  `V₇ = 16π³/105`, `V₈ = π⁴/24`); the center densities are
+  `δ₄ = 1/8`, `δ₅ = 1/(8√2)`, `δ₆ = 1/(8√3)`, `δ₇ = δ₈ = 1/16`.
+  Of these, only `D₄`'s density is conjectural-optimal and only `E₈` is a
+  *theorem* (Viazovska); `D₅, E₆, E₇` are merely the best lattices known.
+
+  **Headline theorem `density_strictly_decreasing_4_to_8`.**
+  The champions form a strictly decreasing chain
+  `Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈`, quantifying the elementary but important
+  principle that sphere packing gets *sparser* as the dimension grows:
+  even the densest known arrangements thin out. Each comparison divides out
+  the common power of `π` (so the proofs are low-degree in `π`) and is closed
+  by `nlinarith` from the Mathlib bounds `Real.pi_gt_3141592 / pi_lt_3141593`
+  together with two-sided rational brackets for `√2` and `√3`.
+
+  We additionally prove that every `Δₙ` is a genuine density
+  (`0 < Δₙ < 1`), bracket each `Δₙ` between explicit rationals
+  (`density_*_bounds`), and bundle the five champions into the parent's
+  `PackingDensity` structure with the existence corollary
+  `exists_dimension_8_optimal` (a `PackingDensity` realising the *proven*
+  optimum `π⁴/384`).
+
+  **Status of this file.**
+  - 0 sorries, 0 axioms (every result is `nlinarith`/`norm_num`-discharged
+    from Mathlib's `π` bounds; no new assumptions).
+  - The numbers are *constructions* (lower bounds on the true optimum), so
+    nothing here claims to resolve the open problem — it organises the
+    best-known data and proves the monotonicity that motivates it.
+-/
+
+import Mathlib
+import Proofs.KeplerConjecture
+
+namespace KeplerConjectureOQ01
+
+open Real KeplerConjecture
+
+/-! ## Best-known packing densities in dimensions 4-8 -/
+
+/-- `D₄` lattice packing density in ℝ⁴, `π²/16 ≈ 0.61685` (best known). -/
+noncomputable def dim4Density : ℝ := π ^ 2 / 16
+
+/-- `D₅` lattice packing density in ℝ⁵, `π²√2/30 ≈ 0.46526` (best known). -/
+noncomputable def dim5Density : ℝ := π ^ 2 * Real.sqrt 2 / 30
+
+/-- `E₆` lattice packing density in ℝ⁶, `π³√3/144 ≈ 0.37295` (best known). -/
+noncomputable def dim6Density : ℝ := π ^ 3 * Real.sqrt 3 / 144
+
+/-- `E₇` lattice packing density in ℝ⁷, `π³/105 ≈ 0.29530` (best known). -/
+noncomputable def dim7Density : ℝ := π ^ 3 / 105
+
+/-- `E₈` lattice packing density in ℝ⁸, `π⁴/384 ≈ 0.25367` (Viazovska 2016,
+    *proven optimal*). -/
+noncomputable def dim8Density : ℝ := π ^ 4 / 384
+
+/-! ## Numeric infrastructure: brackets for `π`-powers and small surds -/
+
+/-- `9.8695 < π² < 9.8697` (true value `π² ≈ 9.8696044`). -/
+theorem pi_sq_bounds : 9.8695 < π ^ 2 ∧ π ^ 2 < 9.8697 := by
+  refine ⟨?_, ?_⟩
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos,
+      mul_pos (sub_pos.mpr Real.pi_gt_d6) Real.pi_pos]
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos,
+      mul_pos Real.pi_pos (sub_pos.mpr Real.pi_lt_d6)]
+
+/-- `31.006 < π³ < 31.008`. -/
+theorem pi_cube_bounds : 31.006 < π ^ 3 ∧ π ^ 3 < 31.008 := by
+  obtain ⟨h2lo, h2hi⟩ := pi_sq_bounds
+  have hpos2 : (0:ℝ) < π ^ 2 := by positivity
+  refine ⟨?_, ?_⟩
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos, h2lo, h2hi, hpos2]
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos, h2lo, h2hi, hpos2]
+
+/-- `97.40 < π⁴ < 97.42`. -/
+theorem pi_quart_bounds : 97.40 < π ^ 4 ∧ π ^ 4 < 97.42 := by
+  obtain ⟨h3lo, h3hi⟩ := pi_cube_bounds
+  have hpos3 : (0:ℝ) < π ^ 3 := by positivity
+  refine ⟨?_, ?_⟩
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos, h3lo, h3hi, hpos3]
+  · nlinarith [Real.pi_gt_d6, Real.pi_lt_d6, Real.pi_pos, h3lo, h3hi, hpos3]
+
+/-- `1.41421 < √2 < 1.41422`. -/
+theorem sqrt2_bounds : 1.41421 < Real.sqrt 2 ∧ Real.sqrt 2 < 1.41422 := by
+  have h2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hpos : 0 < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  refine ⟨?_, ?_⟩
+  · nlinarith [h2, hpos]
+  · nlinarith [h2, hpos]
+
+/-- `1.73205 < √3 < 1.73206`. -/
+theorem sqrt3_bounds : 1.73205 < Real.sqrt 3 ∧ Real.sqrt 3 < 1.73206 := by
+  have h3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hpos : 0 < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  refine ⟨?_, ?_⟩
+  · nlinarith [h3, hpos]
+  · nlinarith [h3, hpos]
+
+/-! ## Each champion is a genuine density `0 < Δₙ < 1` -/
+
+theorem dim4Density_pos : 0 < dim4Density := by
+  unfold dim4Density; positivity
+
+theorem dim5Density_pos : 0 < dim5Density := by
+  unfold dim5Density
+  have := Real.sqrt_pos.mpr (show (0:ℝ) < 2 by norm_num)
+  positivity
+
+theorem dim6Density_pos : 0 < dim6Density := by
+  unfold dim6Density
+  have := Real.sqrt_pos.mpr (show (0:ℝ) < 3 by norm_num)
+  positivity
+
+theorem dim7Density_pos : 0 < dim7Density := by
+  unfold dim7Density; positivity
+
+theorem dim8Density_pos : 0 < dim8Density := by
+  unfold dim8Density; positivity
+
+theorem dim4Density_lt_one : dim4Density < 1 := by
+  unfold dim4Density
+  obtain ⟨_, h2hi⟩ := pi_sq_bounds
+  linarith
+
+theorem dim5Density_lt_one : dim5Density < 1 := by
+  unfold dim5Density
+  obtain ⟨_, h2hi⟩ := pi_sq_bounds
+  obtain ⟨_, hshi⟩ := sqrt2_bounds
+  have hs : 0 < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  nlinarith [h2hi, hshi, hs, Real.pi_pos]
+
+theorem dim6Density_lt_one : dim6Density < 1 := by
+  unfold dim6Density
+  obtain ⟨_, h3hi⟩ := pi_cube_bounds
+  obtain ⟨_, hshi⟩ := sqrt3_bounds
+  have hs : 0 < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  nlinarith [h3hi, hshi, hs, Real.pi_pos]
+
+theorem dim7Density_lt_one : dim7Density < 1 := by
+  unfold dim7Density
+  obtain ⟨_, h3hi⟩ := pi_cube_bounds
+  linarith
+
+theorem dim8Density_lt_one : dim8Density < 1 := by
+  unfold dim8Density
+  obtain ⟨_, h4hi⟩ := pi_quart_bounds
+  linarith
+
+/-! ## Rational brackets for each champion -/
+
+/-- `0.6168 < Δ₄ < 0.6169`. -/
+theorem dim4Density_bounds : 0.6168 < dim4Density ∧ dim4Density < 0.6169 := by
+  unfold dim4Density
+  obtain ⟨h2lo, h2hi⟩ := pi_sq_bounds
+  constructor <;> linarith
+
+/-- `0.4652 < Δ₅ < 0.4653`. -/
+theorem dim5Density_bounds : 0.4652 < dim5Density ∧ dim5Density < 0.4653 := by
+  unfold dim5Density
+  obtain ⟨h2lo, h2hi⟩ := pi_sq_bounds
+  obtain ⟨hslo, hshi⟩ := sqrt2_bounds
+  have hs : 0 < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  refine ⟨?_, ?_⟩
+  · nlinarith [h2lo, h2hi, hslo, hshi, hs, Real.pi_pos]
+  · nlinarith [h2lo, h2hi, hslo, hshi, hs, Real.pi_pos]
+
+/-- `0.3729 < Δ₆ < 0.3730`. -/
+theorem dim6Density_bounds : 0.3729 < dim6Density ∧ dim6Density < 0.3730 := by
+  unfold dim6Density
+  obtain ⟨h3lo, h3hi⟩ := pi_cube_bounds
+  obtain ⟨hslo, hshi⟩ := sqrt3_bounds
+  have hs : 0 < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  refine ⟨?_, ?_⟩
+  · nlinarith [h3lo, h3hi, hslo, hshi, hs, Real.pi_pos]
+  · nlinarith [h3lo, h3hi, hslo, hshi, hs, Real.pi_pos]
+
+/-- `0.2952 < Δ₇ < 0.2954`. -/
+theorem dim7Density_bounds : 0.2952 < dim7Density ∧ dim7Density < 0.2954 := by
+  unfold dim7Density
+  obtain ⟨h3lo, h3hi⟩ := pi_cube_bounds
+  constructor <;> linarith
+
+/-- `0.2536 < Δ₈ < 0.2537`. -/
+theorem dim8Density_bounds : 0.2536 < dim8Density ∧ dim8Density < 0.2537 := by
+  unfold dim8Density
+  obtain ⟨h4lo, h4hi⟩ := pi_quart_bounds
+  constructor <;> linarith
+
+/-! ## Headline: the champions strictly decrease in dimensions 4-8
+
+Each comparison cancels the common power of `π` (`π² > 0` for `Δ₄ > Δ₅`,
+`π² > 0` for `Δ₅ > Δ₆`, `π³ > 0` for `Δ₆ > Δ₇` and `Δ₇ > Δ₈`), so the
+inequality reduces to a low-degree statement about `π` and a single surd. -/
+
+/-- `Δ₄ > Δ₅`: the brackets `Δ₅ < 0.4653 < 0.6168 < Δ₄` separate the two. -/
+theorem dim4_gt_dim5 : dim5Density < dim4Density := by
+  have h5 := dim5Density_bounds.2
+  have h4 := dim4Density_bounds.1
+  linarith
+
+/-- `Δ₅ > Δ₆`: the brackets `Δ₆ < 0.3730 < 0.4652 < Δ₅` separate the two. -/
+theorem dim5_gt_dim6 : dim6Density < dim5Density := by
+  have h6 := dim6Density_bounds.2
+  have h5 := dim5Density_bounds.1
+  linarith
+
+/-- `Δ₆ > Δ₇`: the brackets `Δ₇ < 0.2954 < 0.3729 < Δ₆` separate the two. -/
+theorem dim6_gt_dim7 : dim7Density < dim6Density := by
+  have h7 := dim7Density_bounds.2
+  have h6 := dim6Density_bounds.1
+  linarith
+
+/-- `Δ₇ > Δ₈`: the brackets `Δ₈ < 0.2537 < 0.2952 < Δ₇` separate the two. -/
+theorem dim7_gt_dim8 : dim8Density < dim7Density := by
+  have h8 := dim8Density_bounds.2
+  have h7 := dim7Density_bounds.1
+  linarith
+
+/-- **Headline theorem.** The best-known lattice packing densities in
+    dimensions 4 through 8 strictly decrease:
+    `Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈`. -/
+theorem density_strictly_decreasing_4_to_8 :
+    dim5Density < dim4Density ∧ dim6Density < dim5Density ∧
+      dim7Density < dim6Density ∧ dim8Density < dim7Density :=
+  ⟨dim4_gt_dim5, dim5_gt_dim6, dim6_gt_dim7, dim7_gt_dim8⟩
+
+/-! ## Bundling into the parent's `PackingDensity` structure -/
+
+/-- `D₄` champion as a `PackingDensity`. -/
+noncomputable def dim4Packing : PackingDensity where
+  density := dim4Density
+  nonneg := dim4Density_pos.le
+  le_one := dim4Density_lt_one.le
+/-- `D₅` champion as a `PackingDensity`. -/
+noncomputable def dim5Packing : PackingDensity where
+  density := dim5Density
+  nonneg := dim5Density_pos.le
+  le_one := dim5Density_lt_one.le
+/-- `E₆` champion as a `PackingDensity`. -/
+noncomputable def dim6Packing : PackingDensity where
+  density := dim6Density
+  nonneg := dim6Density_pos.le
+  le_one := dim6Density_lt_one.le
+/-- `E₇` champion as a `PackingDensity`. -/
+noncomputable def dim7Packing : PackingDensity where
+  density := dim7Density
+  nonneg := dim7Density_pos.le
+  le_one := dim7Density_lt_one.le
+/-- `E₈` champion as a `PackingDensity` (the proven optimum). -/
+noncomputable def dim8Packing : PackingDensity where
+  density := dim8Density
+  nonneg := dim8Density_pos.le
+  le_one := dim8Density_lt_one.le
+
+/-- There is a `PackingDensity` realising the dimension-8 *proven optimal*
+    density `π⁴/384` (Viazovska 2016), and it is a genuine density. -/
+theorem exists_dimension_8_optimal :
+    ∃ p : PackingDensity, p.density = π ^ 4 / 384 ∧ 0 < p.density ∧ p.density < 1 :=
+  ⟨dim8Packing, rfl, dim8Density_pos, dim8Density_lt_one⟩
+
+/-- Final aggregation: all five champions are genuine densities
+    (`0 < Δₙ < 1`) and they strictly decrease across dimensions 4-8. -/
+theorem best_known_density_hierarchy_4_to_8 :
+    (0 < dim4Density ∧ dim4Density < 1) ∧
+    (0 < dim5Density ∧ dim5Density < 1) ∧
+    (0 < dim6Density ∧ dim6Density < 1) ∧
+    (0 < dim7Density ∧ dim7Density < 1) ∧
+    (0 < dim8Density ∧ dim8Density < 1) ∧
+    dim5Density < dim4Density ∧ dim6Density < dim5Density ∧
+      dim7Density < dim6Density ∧ dim8Density < dim7Density :=
+  ⟨⟨dim4Density_pos, dim4Density_lt_one⟩, ⟨dim5Density_pos, dim5Density_lt_one⟩,
+   ⟨dim6Density_pos, dim6Density_lt_one⟩, ⟨dim7Density_pos, dim7Density_lt_one⟩,
+   ⟨dim8Density_pos, dim8Density_lt_one⟩,
+   dim4_gt_dim5, dim5_gt_dim6, dim6_gt_dim7, dim7_gt_dim8⟩
+
+end KeplerConjectureOQ01

--- a/src/data/proofs/kepler-conjecture-oq-01/annotations.json
+++ b/src/data/proofs/kepler-conjecture-oq-01/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-module-docstring",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 1, "endLine": 59 },
+    "type": "concept",
+    "title": "Module docstring: the open 4-23 band and our scope",
+    "content": "The docstring frames the deepest fact about higher-dimensional sphere packing: the OPTIMAL density is rigorously known only in dimensions 1, 2, 3, 8 (Viazovska 2016, the E₈ lattice) and 24 (CKMRV 2017, the Leech lattice). For every dimension 4 ≤ n ≤ 23 except n = 8 the optimum is OPEN. This file does not claim to resolve any of those open cases; instead, following the sibling entry `kepler-conjecture-oq-04`, it takes the best-known lattice densities (Conway–Sloane, SPLAG) as named real constants and proves rigorous, axiom-free relationships between them. The tabulated champions are the root lattices D₄, D₅, E₆, E₇, E₈, with Δₙ = δₙ·Vₙ (center density times unit n-ball volume)."
+  },
+  {
+    "id": "ann-density-constants",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 70, "endLine": 84 },
+    "type": "definition",
+    "title": "The five best-known champions Δ₄..Δ₈",
+    "content": "Each constant is the literature packing density of the densest known lattice in its dimension: D₄ gives Δ₄ = π²/16 ≈ 0.61685 (from δ₄ = 1/8, V₄ = π²/2); D₅ gives Δ₅ = π²√2/30 ≈ 0.46526 (δ₅ = 1/(8√2), V₅ = 8π²/15); E₆ gives Δ₆ = π³√3/144 ≈ 0.37295 (δ₆ = 1/(8√3), V₆ = π³/6); E₇ gives Δ₇ = π³/105 ≈ 0.29530 (δ₇ = 1/16, V₇ = 16π³/105); E₈ gives Δ₈ = π⁴/384 ≈ 0.25367 (δ₈ = 1/16, V₈ = π⁴/24). Of these only E₈ is a theorem (optimal, Viazovska 2016); D₄ is conjecturally optimal and D₅, E₆, E₇ are merely the best lattices known."
+  },
+  {
+    "id": "ann-numeric-infra",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 86, "endLine": 127 },
+    "type": "technique",
+    "title": "Rational brackets for π-powers and surds",
+    "content": "All later proofs reduce to five numeric facts. `pi_sq_bounds` (9.8695 < π² < 9.8697), `pi_cube_bounds` (31.006 < π³ < 31.008) and `pi_quart_bounds` (97.40 < π⁴ < 97.42) are derived from Mathlib's `Real.pi_gt_d6` (3.141592 < π) and `Real.pi_lt_d6` (π < 3.141593) by feeding `nlinarith` an explicit cross-product hint such as `mul_pos Real.pi_pos (sub_pos.mpr Real.pi_lt_d6)` so the solver sees the term `π·(3.141593 − π)` and can bound πⁿ above/below. (Note: the true value π² ≈ 9.8696044 exceeds 9.8696, so the upper bracket must be 9.8697 — a reminder that nlinarith correctly refuses a false bound.) `sqrt2_bounds` and `sqrt3_bounds` come from `Real.sq_sqrt` plus `nlinarith`."
+  },
+  {
+    "id": "ann-genuine-density",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 128, "endLine": 176 },
+    "type": "theorem",
+    "title": "Every champion is a genuine density 0 < Δₙ < 1",
+    "content": "Positivity is immediate by `positivity` (each is a positive constant over a positive denominator, with √2, √3 positive). The upper bound Δₙ < 1 is the statement that each is a valid packing fraction: π²/16 < 1 ⟺ π² < 16, π²√2/30 < 1 ⟺ π²√2 < 30, π³√3/144 < 1 ⟺ π³√3 < 144, π³/105 < 1, π⁴/384 < 1 — each discharged from the π-power and surd brackets. These supply the `nonneg`/`le_one` fields required to bundle the champions into the parent's `PackingDensity` structure."
+  },
+  {
+    "id": "ann-rational-brackets",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 178, "endLine": 216 },
+    "type": "theorem",
+    "title": "Disjoint rational intervals for the five densities",
+    "content": "Each `dimNDensity_bounds` pins Δₙ inside a width-10⁻³ (or 10⁻⁴) rational interval: 0.6168 < Δ₄ < 0.6169, 0.4652 < Δ₅ < 0.4653, 0.3729 < Δ₆ < 0.3730, 0.2952 < Δ₇ < 0.2954, 0.2536 < Δ₈ < 0.2537. The intervals for Δ₄, Δ₇, Δ₈ follow by `linarith` from a single π-power bracket; the surd-bearing Δ₅, Δ₆ need `nlinarith` to multiply the π² (resp. π³) bracket by the √2 (resp. √3) bracket. Crucially the five intervals are pairwise DISJOINT and ordered, which is exactly what makes the headline chain trivial."
+  },
+  {
+    "id": "ann-headline-chain",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 218, "endLine": 254 },
+    "type": "theorem",
+    "title": "Headline: Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈",
+    "content": "Because the rational brackets are disjoint and ordered, each pairwise inequality is a one-line `linarith`: e.g. Δ₅ < 0.4653 < 0.6168 < Δ₄ gives `dim4_gt_dim5`. The four comparisons assemble into `density_strictly_decreasing_4_to_8`. Mathematically the chain quantifies the principle underlying the whole open problem: even the densest known sphere arrangements thin out as the dimension rises (Δ falls from ~0.62 in dimension 4 to ~0.25 in dimension 8, and continues to drop exponentially in the Kabatiansky–Levenshtein regime). The bracket-separation trick keeps every comparison low-degree in π, sidestepping fragile high-degree `nlinarith` goals."
+  },
+  {
+    "id": "ann-packing-bundling",
+    "proofId": "kepler-conjecture-oq-01",
+    "range": { "startLine": 256, "endLine": 305 },
+    "type": "concept",
+    "title": "PackingDensity witnesses and the dimension-8 optimum",
+    "content": "The five champions are bundled into the parent's `PackingDensity` structure (`dim4Packing`..`dim8Packing`), each supplying its `nonneg` and `le_one` fields from the positivity and less-than-one lemmas — so the abstract ℝ³ type from `Proofs.KeplerConjecture` is now populated by genuine higher-dimensional values. `exists_dimension_8_optimal` exhibits a `PackingDensity` whose value is exactly the proven optimum π⁴/384 (Viazovska 2016). The closing `best_known_density_hierarchy_4_to_8` aggregates all genuineness (0 < Δₙ < 1) and monotonicity facts into a single theorem, the OQ-01 summary statement."
+  }
+]

--- a/src/data/proofs/kepler-conjecture-oq-01/meta.json
+++ b/src/data/proofs/kepler-conjecture-oq-01/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "kepler-conjecture-oq-01",
+  "title": "Kepler Conjecture OQ-01: Best-known packing densities in dimensions 4-23",
+  "slug": "kepler-conjecture-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.KeplerConjecture"
+    ],
+    "opens": [
+      "Real",
+      "KeplerConjecture"
+    ],
+    "namespace": "KeplerConjectureOQ01",
+    "lineCount": 305,
+    "axiomCount": 0,
+    "theoremCount": 27,
+    "definitionCount": 10,
+    "path": "Proofs/KeplerConjectureOQ01.lean",
+    "sorries": 0
+  },
+  "description": "Open-question follow-up to the gallery's `kepler-conjecture` entry. The parent settles the OPTIMAL congruent-sphere packing density in ℝ³ (the FCC value π/(3√2) ≈ 0.7405). OQ-01 turns to higher dimensions, where optimal sphere packing is one of the deepest open problems in discrete geometry: the optimum is known only in dimensions 1, 2, 3, 8 (Viazovska 2016, the E₈ lattice) and 24 (CKMRV 2017, the Leech lattice). For every dimension 4 ≤ n ≤ 23 except n = 8 the optimum is OPEN; the best constructions are specific lattices. Following the sibling entry `kepler-conjecture-oq-04`, this file takes the best-known lattice packing densities from the literature (Conway–Sloane, SPLAG) as named real constants and proves rigorous, axiom-free relationships. It focuses on the root-lattice champions in dimensions 4–8: D₄ (Δ₄ = π²/16 ≈ 0.61685), D₅ (Δ₅ = π²√2/30 ≈ 0.46526), E₆ (Δ₆ = π³√3/144 ≈ 0.37295), E₇ (Δ₇ = π³/105 ≈ 0.29530) and E₈ (Δ₈ = π⁴/384 ≈ 0.25367, the proven optimum). Each Δₙ = δₙ·Vₙ is the lattice center density δₙ times the unit n-ball volume Vₙ. The HEADLINE `density_strictly_decreasing_4_to_8` proves Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈, quantifying the principle that sphere packing thins out as dimension grows — even the densest known arrangements. Supporting results: every champion is a genuine density (0 < Δₙ < 1), each Δₙ is bracketed between explicit rationals (`dimNDensity_bounds`), and the five champions are bundled into the parent's `PackingDensity` structure with the existence corollary `exists_dimension_8_optimal` (a PackingDensity realising the proven optimum π⁴/384). The numbers are CONSTRUCTIONS (lower bounds on the true optimum), so nothing here claims to resolve the open problem — it organises the best-known data and proves the monotonicity that motivates it. 0 sorries, 0 axioms; every result is nlinarith/norm_num-discharged from Mathlib's π bounds (`Real.pi_gt_d6`/`Real.pi_lt_d6`).",
+  "meta": {
+    "author": "researcher-4",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KeplerConjectureOQ01.lean",
+    "tags": [
+      "packing",
+      "kepler",
+      "sphere-packing",
+      "lattices",
+      "root-lattices",
+      "E8",
+      "discrete-geometry",
+      "higher-dimensions",
+      "open-question",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 305,
+    "theoremCount": 27,
+    "definitionCount": 10,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.pi_gt_d6",
+        "description": "Numerical bound 3.141592 < π, the lower input to `pi_sq_bounds`/`pi_cube_bounds`/`pi_quart_bounds` from which all density brackets are derived.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds"
+      },
+      {
+        "theorem": "Real.pi_lt_d6",
+        "description": "Numerical bound π < 3.141593, the upper input to the π-power brackets; combined with the explicit cross-product hint `mul_pos Real.pi_pos (sub_pos.mpr Real.pi_lt_d6)` so `nlinarith` can bound π² above.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "(√x)² = x for 0 ≤ x, used to prove the rational brackets `sqrt2_bounds` (1.41421 < √2 < 1.41422) and `sqrt3_bounds` (1.73205 < √3 < 1.73206) via `nlinarith`.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      }
+    ],
+    "assumptions": "0 sorries, 0 axioms. Every theorem is discharged by `nlinarith`/`norm_num`/`linarith`/`positivity` from Mathlib's rational π bounds `Real.pi_gt_d6` (3.141592 < π) and `Real.pi_lt_d6` (π < 3.141593), plus two-sided √2/√3 brackets proved from `Real.sq_sqrt`. The five density constants Δ₄..Δ₈ are taken from the published literature (Conway–Sloane, *Sphere Packings, Lattices and Groups*) as the best-known lattice packing densities; D₅, E₆, E₇ are the densest lattices known in their dimensions (the true optimum is open), D₄ is conjecturally optimal, and only E₈ (Δ₈ = π⁴/384) is a theorem (Viazovska 2016). `#print axioms` on the three headline theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. The parent `Proofs/KeplerConjecture.lean` separately axiomatizes the 2D/3D optimality results; this file adds NO new assumptions and reuses only the parent's `PackingDensity` structure."
+  },
+  "overview": {
+    "historicalContext": "Kepler's 1611 conjecture concerned spheres in ℝ³ — that the face-centered cubic packing is optimal for congruent balls. Hales' 1998 proof, formally verified by the Flyspeck project (2014), settled the case at density π/(3√2) ≈ 0.7405. The natural and far harder question is the optimal density of congruent-sphere packings in higher dimensions. Remarkably, after centuries of work the optimum is rigorously known in only FIVE dimensions: n = 1, 2, 3 (classical), n = 8 (Maryna Viazovska 2016, via a magic modular-form interpolation realising the Cohn–Elkies linear-programming bound exactly at the E₈ lattice), and n = 24 (Cohn–Kumar–Miller–Radchenko–Viazovska 2017, the Leech lattice). For every dimension in the band 4 ≤ n ≤ 23 except n = 8 the optimal density remains OPEN; the densest packings known are specific lattices, and only conjecturally optimal. In dimensions 4–8 these champions are the celebrated root lattices D₄, D₅, E₆, E₇, E₈ (Korkine–Zolotareff, Blichfeldt), whose packing densities Δₙ = δₙ·Vₙ combine integer/surd center densities δₙ with the unit n-ball volumes Vₙ = π²/2, 8π²/15, π³/6, 16π³/105, π⁴/24. A basic but important feature of this data is that the densities DECREASE with dimension — even the best known arrangements become sparse — a phenomenon dramatised by the Minkowski–Hlawka lower bound and the exponential gap to the Kabatiansky–Levenshtein upper bound.",
+    "keyInsight": "Although the OPTIMAL densities in dimensions 4–7 are open, the best-known champions D₄, D₅, E₆, E₇ together with the proven optimum E₈ are explicit closed-form reals in π and small surds, so their pairwise ordering is a finitary inequality verifiable in Lean. Cancelling the common power of π reduces each comparison Δₙ > Δₙ₊₁ to a low-degree statement about π and a single surd; bracketing every Δₙ in a rational interval then makes the entire monotone chain Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈ fall out of `linarith`. The result quantifies, in fully verified form, the heuristic that sphere packing gets harder as dimension grows.",
+    "significance": "Organises the best-known higher-dimensional sphere-packing data into a single verified, axiom-free Lean artifact and proves the monotone-decrease structure that motivates the open problem, without overclaiming any resolution. It also exhibits the parent's abstract `PackingDensity` type populated by five higher-dimensional witnesses, including the dimension-8 proven optimum, extending the gallery's Kepler cluster from ℝ³ into the 4–23 band that OQ-01 targets."
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module docstring: dimensions 4-23 survey and scope",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Surveys the higher-dimensional sphere-packing problem: optimum known only in n = 1,2,3,8,24; open for 4 ≤ n ≤ 23, n ≠ 8. Tabulates the five root-lattice champions D₄..E₈ with their densities Δₙ = δₙ·Vₙ and center densities. States the headline `density_strictly_decreasing_4_to_8` and the honesty caveat that the constants are best-known constructions (lower bounds), not a resolution of the open problem. Records the 0-sorry / 0-axiom status."
+    },
+    {
+      "id": "densities",
+      "title": "The five best-known champions Δ₄..Δ₈",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "Defines `dim4Density = π²/16` (D₄), `dim5Density = π²√2/30` (D₅), `dim6Density = π³√3/144` (E₆), `dim7Density = π³/105` (E₇), `dim8Density = π⁴/384` (E₈, Viazovska-optimal) as noncomputable reals."
+    },
+    {
+      "id": "numeric-infra",
+      "title": "Numeric infrastructure: π-power and surd brackets",
+      "startLine": 86,
+      "endLine": 127,
+      "summary": "Proves the rational brackets `pi_sq_bounds` (9.8695 < π² < 9.8697), `pi_cube_bounds` (31.006 < π³ < 31.008), `pi_quart_bounds` (97.40 < π⁴ < 97.42) by chaining `Real.pi_gt_d6`/`Real.pi_lt_d6` through explicit cross-product hints, and `sqrt2_bounds`/`sqrt3_bounds` from `Real.sq_sqrt`. These five lemmas are the sole numerical inputs to everything downstream."
+    },
+    {
+      "id": "genuine-density",
+      "title": "Each champion is a genuine density 0 < Δₙ < 1",
+      "startLine": 128,
+      "endLine": 176,
+      "summary": "Positivity (`dimNDensity_pos`, via `positivity`) and the upper bound `dimNDensity_lt_one` (each Δₙ < 1, since π² < 16, π²√2 < 30, π³√3 < 144, π³ < 105, π⁴ < 384) — confirming every champion is a valid packing density."
+    },
+    {
+      "id": "rational-brackets",
+      "title": "Rational brackets for each champion",
+      "startLine": 178,
+      "endLine": 216,
+      "summary": "Brackets each density between explicit rationals: 0.6168 < Δ₄ < 0.6169, 0.4652 < Δ₅ < 0.4653, 0.3729 < Δ₆ < 0.3730, 0.2952 < Δ₇ < 0.2954, 0.2536 < Δ₈ < 0.2537 — propagating the π-power and surd brackets through `linarith`/`nlinarith`."
+    },
+    {
+      "id": "headline-chain",
+      "title": "Headline: the champions strictly decrease in dimensions 4-8",
+      "startLine": 218,
+      "endLine": 254,
+      "summary": "The four pairwise comparisons `dim4_gt_dim5`..`dim7_gt_dim8` each follow from the disjoint rational brackets (e.g. Δ₅ < 0.4653 < 0.6168 < Δ₄) by `linarith`, assembled into `density_strictly_decreasing_4_to_8 : Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈`."
+    },
+    {
+      "id": "packing-bundling",
+      "title": "Bundling into PackingDensity + dimension-8 optimum",
+      "startLine": 256,
+      "endLine": 305,
+      "summary": "Bundles the five champions into the parent's `PackingDensity` structure (`dimNPacking`, supplying `nonneg`/`le_one` from the positivity and less-than-one lemmas), proves `exists_dimension_8_optimal` (a PackingDensity realising the proven optimum π⁴/384), and the final aggregation `best_known_density_hierarchy_4_to_8` collecting all genuineness and monotonicity facts."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-01 extends the gallery's Kepler cluster from ℝ³ into the open 4–23 band by formalising the best-known lattice packing densities in dimensions 4–8 (D₄, D₅, E₆, E₇, E₈) as explicit reals and proving, axiom-free, that they strictly decrease: Δ₄ ≈ 0.6169 > Δ₅ ≈ 0.4653 > Δ₆ ≈ 0.3730 > Δ₇ ≈ 0.2953 > Δ₈ ≈ 0.2537. Each is shown to be a genuine density (0 < Δₙ < 1) and bracketed in a rational interval; the five are bundled into the parent's `PackingDensity` type, with the dimension-8 case witnessing the Viazovska (2016) proven optimum. The monotone-decrease theorem quantifies the principle that motivates the entire open problem — sphere packing becomes sparser in higher dimensions — while the honesty caveat is explicit: these constants are best-known constructions (lower bounds on the true optimum), so the entry organises and certifies the known data rather than resolving the open question for 4 ≤ n ≤ 23.",
+    "futureWork": "Natural extensions: (i) add the higher-dimensional champions K₁₂ (Coxeter–Todd), Λ₁₆ (Barnes–Wall) and Λ₂₄ (Leech) to push the monotone chain through dimension 24; (ii) formalise the elementary Minkowski–Hlawka lower bound Δₙ ≥ ζ(n)/2ⁿ⁻¹ to bracket the champions from below by a provable existence bound; (iii) formalise a classical upper bound (Blichfeldt or Rogers) to sandwich the true optimum and make the open-ness quantitative; (iv) connect to a Lean development of the Cohn–Elkies linear-programming bound, whose dimension-8 sharpness is the content of Viazovska's theorem."
+  },
+  "crossReferences": [
+    {
+      "proofId": "kepler-conjecture",
+      "title": "Kepler Conjecture: Sphere Packing (parent)",
+      "relationship": "Parent gallery entry. Provides the `PackingDensity` structure and the ℝ³ Kepler–Hales axiomatization at density π/(3√2). OQ-01 reuses `PackingDensity` to bundle five higher-dimensional champions (D₄..E₈) and carries the cluster from the solved n = 3 case into the open 4–23 band.",
+      "description": "Parent entry supplying the `PackingDensity` structure reused here; OQ-01 populates it with dimension 4–8 lattice densities including the dimension-8 proven optimum."
+    },
+    {
+      "proofId": "kepler-conjecture-oq-04",
+      "title": "Kepler Conjecture OQ-04: Non-spherical packing in ℝ³",
+      "relationship": "Sibling open-question entry. OQ-04 varies the BODY (tetrahedra, ellipsoids, symmetric convex bodies) in fixed dimension 3; OQ-01 varies the DIMENSION (4–8) for fixed congruent spheres. Both follow the same methodology: take literature densities as named real constants and prove rigorous axiom-free comparisons via Mathlib's π bounds.",
+      "description": "Sibling entry treating non-spherical packing in ℝ³; shares the constant-and-compare methodology used here for higher dimensions."
+    }
+  ],
+  "theoremCount": 27,
+  "definitionCount": 10
+}


### PR DESCRIPTION
## Summary

Open-question follow-up to the gallery's `kepler-conjecture` entry. Optimal **sphere packing in dimensions 4–23** is one of the deepest open problems in discrete geometry — the optimum is rigorously known only for `n = 1,2,3,8,24`, and within the 4–23 band only `n = 8` (Viazovska 2016, the E₈ lattice). This entry does **not** claim to resolve any open case. Following the sibling entry `kepler-conjecture-oq-04`, it takes the **best-known lattice packing densities** from the literature (Conway–Sloane, *SPLAG*) as named real constants and proves rigorous, axiom-free relationships for the dimension 4–8 root-lattice champions:

| dim | lattice | density Δₙ | ≈ | status |
|----|---------|-----------|---|--------|
| 4 | D₄ | π²/16 | 0.61685 | best known (conj. optimal) |
| 5 | D₅ | π²√2/30 | 0.46526 | best lattice known |
| 6 | E₆ | π³√3/144 | 0.37295 | best lattice known |
| 7 | E₇ | π³/105 | 0.29530 | best lattice known |
| 8 | E₈ | π⁴/384 | 0.25367 | **proven optimal** (Viazovska 2016) |

## Headline

`density_strictly_decreasing_4_to_8 : Δ₄ > Δ₅ > Δ₆ > Δ₇ > Δ₈` — quantifying the principle motivating the whole open problem: even the densest known sphere arrangements thin out as the dimension grows. Each comparison cancels the common power of π and is closed by **disjoint rational brackets** (`linarith`), so no fragile high-degree `nlinarith` goal is needed.

## Also proved

- Every champion is a genuine density: `0 < Δₙ < 1`.
- Each Δₙ bracketed in an explicit rational interval (`dimNDensity_bounds`).
- All five bundled into the parent's `PackingDensity` structure; `exists_dimension_8_optimal` exhibits a `PackingDensity` realising the proven optimum π⁴/384.

## Verification

- **27 theorems, 10 definitions, 305 lines. 0 sorries, 0 axioms.**
- Built with the host `lake env lean` toolchain (Lean v4.26.0); olean produced cleanly.
- `#print axioms` on `density_strictly_decreasing_4_to_8`, `best_known_density_hierarchy_4_to_8`, `exists_dimension_8_optimal` → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- All numeric inputs are Mathlib's `Real.pi_gt_d6`/`Real.pi_lt_d6` plus `√2`/`√3` brackets from `Real.sq_sqrt`.

## Honesty note

The constants are **best-known constructions** (lower bounds on the true optimum), so the entry organises and certifies the known data and the monotone-decrease structure — it does not resolve optimality for `4 ≤ n ≤ 23`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)