### PR TITLE
research(stirling-second-kind-oq-01-oq-03): second subdiagonal S(n,n−2)=C(n,3)+3C(n,4) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/StirlingSecondKindOQ01OQ03.lean
+++ b/proofs/Proofs/StirlingSecondKindOQ01OQ03.lean
@@ -1,0 +1,118 @@
+/-
+Stirling Numbers of the Second Kind — OQ-01-OQ-03:
+the second subdiagonal closed form
+
+  S(m+2, m) = C(m+2, 3) + 3·C(m+2, 4),
+
+equivalently  S(n, n−2) = C(n,3) + 3·C(n,4)  for n ≥ 2.
+
+Source: Open question OQ-03 of the gallery entry `stirling-second-kind-oq-01`
+(itself OQ-01 of the parent `stirling-second-kind`).
+
+## The open question
+
+Mathlib (`Mathlib/Combinatorics/Enumerative/Stirling.lean`) records the Pascal-style
+recurrence for `Nat.stirlingSecond`, the value on the diagonal
+`stirlingSecond_self : S(n,n) = 1`, and the **first subdiagonal**
+`stirlingSecond_succ_self_left : S(n+1,n) = C(n+1,2)`.  It stops there: the next
+diagonal `S(n, n−2)` has no closed form in Mathlib.  This file supplies it.
+
+## The formula and a sanity check
+
+The classical second-subdiagonal value is
+
+  S(n, n−2) = C(n,3) + 3·C(n,4).
+
+Reindexed by `n = m+2` this is `S(m+2,m) = C(m+2,3) + 3·C(m+2,4)`, valid for all
+`m : ℕ` (both sides are `0` at `m = 0`, since `S(2,0)=0` and `C(2,3)=C(2,4)=0`).
+Numeric checks: `S(4,2)=7 = C(4,3)+3C(4,4) = 4+3`; `S(5,3)=25 = C(5,3)+3C(5,4) =
+10+15`; `S(6,4)=65 = C(6,3)+3C(6,4) = 20+45`.
+
+## Strategy — induction on m off the first subdiagonal
+
+Apply the Pascal recurrence `S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k)` with
+`n = m+2`, `k = m`:
+
+  S(m+3, m+1) = (m+1)·S(m+2, m+1) + S(m+2, m).
+
+Here `S(m+2, m+1)` is the **first subdiagonal** `C(m+2,2)` (Mathlib's
+`stirlingSecond_succ_self_left`), and `S(m+2, m)` is the induction hypothesis.  The
+inductive step then reduces to a pure binomial identity, whose only nontrivial input
+is the **absorption identity**
+
+  3·C(m+2, 3) = m·C(m+2, 2),
+
+an instance of `Nat.choose_succ_right_eq`.  Two applications of Pascal's rule on the
+target binomials `C(m+3,3)`, `C(m+3,4)` then make both sides agree by `ring`.
+-/
+import Mathlib
+
+namespace StirlingSecondKindOQ01OQ03
+
+open Nat
+
+/-- **Absorption identity** specialised to the third column:
+`3·C(m+2, 3) = m·C(m+2, 2)`.  This is `Nat.choose_succ_right_eq (m+2) 2`, namely
+`C(m+2,3)·3 = C(m+2,2)·(m+2−2)`, after simplifying `m+2−2 = m`. -/
+theorem three_mul_choose_three (m : ℕ) :
+    (m + 2).choose 3 * 3 = (m + 2).choose 2 * m := by
+  have h := Nat.choose_succ_right_eq (m + 2) 2
+  simpa using h
+
+/-- **Main theorem — the second subdiagonal of the Stirling triangle.**
+
+For all `m : ℕ`,
+
+  `S(m+2, m) = C(m+2, 3) + 3·C(m+2, 4)`.
+
+Proved by induction on `m`, stepping down the diagonal via the Pascal recurrence and
+the first-subdiagonal value `S(m+2,m+1) = C(m+2,2)`. -/
+theorem stirlingSecond_add_two_sub_two (m : ℕ) :
+    Nat.stirlingSecond (m + 2) m = (m + 2).choose 3 + 3 * (m + 2).choose 4 := by
+  induction m with
+  | zero =>
+    -- S(2,0) = 0 and C(2,3) + 3·C(2,4) = 0 + 0.
+    decide
+  | succ m ih =>
+    -- Pascal recurrence with n = m+2, k = m :
+    --   S(m+3, m+1) = (m+1)·S(m+2, m+1) + S(m+2, m).
+    have key : Nat.stirlingSecond (m + 3) (m + 1)
+        = (m + 1) * Nat.stirlingSecond (m + 2) (m + 1) + Nat.stirlingSecond (m + 2) m :=
+      Nat.stirlingSecond_succ_succ (m + 2) m
+    -- First subdiagonal: S(m+2, m+1) = C(m+2, 2).
+    have hsub : Nat.stirlingSecond (m + 2) (m + 1) = (m + 2).choose 2 :=
+      Nat.stirlingSecond_succ_self_left (m + 1)
+    -- Pascal's rule on the two target binomials.
+    have p1 : (m + 3).choose 3 = (m + 2).choose 2 + (m + 2).choose 3 :=
+      Nat.choose_succ_succ (m + 2) 2
+    have p2 : (m + 3).choose 4 = (m + 2).choose 3 + (m + 2).choose 4 :=
+      Nat.choose_succ_succ (m + 2) 3
+    -- Absorption identity, cast to ℤ for the final `linear_combination`.
+    have haZ : ((m + 2).choose 3 : ℤ) * 3 = ((m + 2).choose 2 : ℤ) * m := by
+      exact_mod_cast three_mul_choose_three m
+    show Nat.stirlingSecond (m + 3) (m + 1)
+        = (m + 3).choose 3 + 3 * (m + 3).choose 4
+    rw [key, hsub, ih, p1, p2]
+    zify
+    linear_combination -haZ
+
+/-- **Subdiagonal restatement.**  For `n ≥ 2`,
+`S(n, n−2) = C(n,3) + 3·C(n,4)`. -/
+theorem stirlingSecond_sub_two {n : ℕ} (hn : 2 ≤ n) :
+    Nat.stirlingSecond n (n - 2) = n.choose 3 + 3 * n.choose 4 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_add_of_le hn
+  -- n = 2 + m ; rewrite to m + 2 and apply the main theorem.
+  have hm : 2 + m - 2 = m := by omega
+  rw [hm, show 2 + m = m + 2 from by ring]
+  exact stirlingSecond_add_two_sub_two m
+
+/-- Sanity check: `S(4,2) = 7`. -/
+theorem stirlingSecond_four_two : Nat.stirlingSecond 4 2 = 7 := by decide
+
+/-- Sanity check: `S(5,3) = 25`. -/
+theorem stirlingSecond_five_three : Nat.stirlingSecond 5 3 = 25 := by decide
+
+/-- Sanity check: `S(6,4) = 65`. -/
+theorem stirlingSecond_six_four : Nat.stirlingSecond 6 4 = 65 := by decide
+
+end StirlingSecondKindOQ01OQ03

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-03/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "stirling-second-kind-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "The Second Subdiagonal of the Stirling Triangle",
+    "content": "Reading the triangle of Stirling numbers of the second kind by diagonals, Mathlib knows the diagonal S(n,n)=1 and the first subdiagonal S(n+1,n)=C(n+1,2) but stops there. This file supplies the next diagonal, the classical closed form S(m+2,m) = C(m+2,3) + 3·C(m+2,4) — equivalently S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2. The combinatorial reading: a partition of n elements into n−2 blocks either has one block of three (C(n,3) ways) or two blocks of two (3·C(n,4) ways).",
+    "mathContext": "$S(n,n-2) = \\binom{n}{3} + 3\\binom{n}{4}$ for $n \\ge 2$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Stirling numbers of the second kind",
+      "set partitions",
+      "subdiagonal closed forms",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "set partitions",
+      "Pascal's rule"
+    ]
+  },
+  {
+    "id": "ann-absorption",
+    "proofId": "stirling-second-kind-oq-01-oq-03",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "lemma",
+    "title": "The Absorption Identity 3·C(m+2,3) = m·C(m+2,2)",
+    "content": "The single arithmetic fact that powers the inductive step. It is `Nat.choose_succ_right_eq (m+2) 2`, which reads C(m+2,3)·3 = C(m+2,2)·(m+2−2); simplifying m+2−2 = m gives the stated form. This is the binomial analogue of differentiating x^3 into 3x^2: it converts the third-column coefficient into the second-column one with the linear factor m.",
+    "mathContext": "$3\\binom{m+2}{3} = m\\binom{m+2}{2}$, an instance of $\\binom{n}{k+1}(k+1) = \\binom{n}{k}(n-k)$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "absorption identity",
+      "binomial coefficients"
+    ],
+    "prerequisites": [
+      "binomial coefficient identities"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "stirling-second-kind-oq-01-oq-03",
+    "range": { "startLine": 69, "endLine": 100 },
+    "type": "theorem",
+    "title": "Induction Down the Diagonal",
+    "content": "stirlingSecond_add_two_sub_two proves S(m+2,m) = C(m+2,3) + 3·C(m+2,4) by induction on m. The base m=0 is S(2,0)=0, closed by `decide`. For the step, the Pascal recurrence at n=m+2, k=m gives S(m+3,m+1) = (m+1)·S(m+2,m+1) + S(m+2,m): the middle term S(m+2,m+1) is the first subdiagonal C(m+2,2) (Mathlib's stirlingSecond_succ_self_left), and S(m+2,m) is the induction hypothesis. After expanding the target binomials C(m+3,3), C(m+3,4) by Pascal's rule, `zify; linear_combination` against the cast absorption identity closes the goal — the only nonlinear term m·C(m+2,2) being exactly what absorption supplies.",
+    "mathContext": "$S(m+3,m+1) = (m+1)S(m+2,m+1) + S(m+2,m)$, with $S(m+2,m+1) = \\binom{m+2}{2}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Stirling recurrence",
+      "first subdiagonal",
+      "induction down a diagonal"
+    ],
+    "prerequisites": [
+      "Stirling recurrence",
+      "induction"
+    ]
+  },
+  {
+    "id": "ann-subdiagonal-form",
+    "proofId": "stirling-second-kind-oq-01-oq-03",
+    "range": { "startLine": 102, "endLine": 118 },
+    "type": "theorem",
+    "title": "Subdiagonal Restatement and Numeric Checks",
+    "content": "stirlingSecond_sub_two reindexes n = 2+m to state the result in its natural form S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2. Three kernel-checked values — S(4,2)=7, S(5,3)=25, S(6,4)=65 — confirm the formula by `decide` (kernel reduction, not native_decide, so no extra axioms).",
+    "mathContext": "$S(4,2)=7,\\ S(5,3)=25,\\ S(6,4)=65$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "subdiagonal indexing",
+      "sanity checks"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-03/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-03/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "stirling-second-kind-oq-01-oq-03",
+  "title": "Stirling Numbers of the Second Kind: the second subdiagonal S(n, n−2) = C(n,3) + 3·C(n,4)",
+  "slug": "stirling-second-kind-oq-01-oq-03",
+  "description": "The closed form for the second subdiagonal of the Stirling triangle of the second kind: S(m+2, m) = C(m+2,3) + 3·C(m+2,4), equivalently S(n, n−2) = C(n,3) + 3·C(n,4) for n ≥ 2. Proved over ℕ by induction on m, stepping down the diagonal via the Pascal recurrence S(n+1,k+1)=(k+1)S(n,k+1)+S(n,k) and Mathlib's first-subdiagonal value S(m+2,m+1)=C(m+2,2); the inductive step collapses to the absorption identity 3·C(m+2,3)=m·C(m+2,2) plus two applications of Pascal's rule. Mathlib records the diagonal S(n,n)=1 and the first subdiagonal S(n+1,n)=C(n+1,2) but stops there — the next diagonal has no closed form in Mathlib.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingSecondKindOQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "set-partitions",
+      "binomial-coefficients",
+      "subdiagonal",
+      "closed-form",
+      "induction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "Pascal recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k); with n=m+2, k=m it expresses S(m+3,m+1) in terms of the first subdiagonal and the induction hypothesis",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.stirlingSecond_succ_self_left",
+        "description": "First subdiagonal S(n+1,n) = C(n+1,2); supplies S(m+2,m+1) = C(m+2,2), the value one diagonal up that drives the induction",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "C(n,k+1)·(k+1) = C(n,k)·(n−k); instantiated at (m+2,2) it gives the absorption identity 3·C(m+2,3) = m·C(m+2,2), the only nontrivial arithmetic input to the inductive step",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1,k+1) = C(n,k) + C(n,k+1); applied to C(m+3,3) and C(m+3,4) to express the target binomials over the column m+2",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "stirlingSecond_add_two_sub_two: the second-subdiagonal closed form S(m+2,m) = C(m+2,3) + 3·C(m+2,4) for all m, proved by induction on m — absent from Mathlib, which records only the diagonal S(n,n)=1 and the first subdiagonal S(n+1,n)=C(n+1,2)",
+      "stirlingSecond_sub_two: the same result in the natural subdiagonal indexing S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2, obtained by reindexing n = m+2",
+      "three_mul_choose_three: the absorption identity 3·C(m+2,3) = m·C(m+2,2) specialising Nat.choose_succ_right_eq, the arithmetic engine of the inductive step",
+      "stirlingSecond_four_two / stirlingSecond_five_three / stirlingSecond_six_four: kernel-checked sanity values S(4,2)=7, S(5,3)=25, S(6,4)=65 confirming the formula"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. Both stirlingSecond_add_two_sub_two and stirlingSecond_sub_two depend only on propext, Classical.choice, Quot.sound. The base case and sanity checks use `decide` (kernel reduction via the Decidable instance), not `native_decide`, so no Lean.ofReduceBool is introduced. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 118,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Stirling number of the second kind S(n,k) counts partitions of an n-element set into k nonempty blocks. Reading the triangle by diagonals (fixing n−k), the diagonal entries are S(n,n)=1, the first subdiagonal is S(n+1,n)=C(n+1,2) (choose two elements to share a block), and the second subdiagonal is the classical value S(n,n−2)=C(n,3)+3C(n,4): either one block of three elements (C(n,3) ways) or two blocks of two (3·C(n,4) ways, the 3 being the number of ways to pair four chosen elements). These subdiagonal polynomials are the low-order coefficients in the asymptotics of set partitions and appear throughout enumerative combinatorics. Mathlib formalizes the recurrence, the diagonal, and the first subdiagonal but not this next one.",
+    "problemStatement": "Prove in Lean the second-subdiagonal closed form for Stirling numbers of the second kind, S(m+2,m) = C(m+2,3) + 3·C(m+2,4) for all m (equivalently S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2), building on Mathlib's first-subdiagonal value S(n+1,n)=C(n+1,2).",
+    "text": "Apply the Pascal recurrence S(n+1,k+1)=(k+1)S(n,k+1)+S(n,k) at n=m+2, k=m to get S(m+3,m+1)=(m+1)·S(m+2,m+1)+S(m+2,m). The middle factor S(m+2,m+1) is the first subdiagonal C(m+2,2); the last term is the induction hypothesis. The step then reduces to the absorption identity 3·C(m+2,3)=m·C(m+2,2) and two uses of Pascal's rule.",
+    "proofStrategy": "1. three_mul_choose_three: derive 3·C(m+2,3) = m·C(m+2,2) from Nat.choose_succ_right_eq (m+2) 2 (which gives C(m+2,3)·3 = C(m+2,2)·(m+2−2)), simplifying m+2−2 = m.\n2. stirlingSecond_add_two_sub_two: induct on m. Base m=0 is S(2,0)=0=C(2,3)+3C(2,4), closed by `decide`. Step: rewrite S(m+3,m+1) by the Pascal recurrence (Nat.stirlingSecond_succ_succ (m+2) m), replace S(m+2,m+1) by C(m+2,2) (Nat.stirlingSecond_succ_self_left), substitute the induction hypothesis for S(m+2,m), expand the target binomials C(m+3,3), C(m+3,4) by Pascal's rule (Nat.choose_succ_succ), then `zify` and close with `linear_combination` against the cast absorption identity.\n3. stirlingSecond_sub_two: reindex n = 2+m via Nat.exists_eq_add_of_le and rewrite to the m+2 form to state the result as S(n,n−2) = C(n,3)+3C(n,4) for n ≥ 2.\n4. Record kernel-checked sanity values S(4,2)=7, S(5,3)=25, S(6,4)=65 by `decide`.",
+    "keyInsights": [
+      "**Climb down the diagonal, not across the row.** Indexing the target as S(m+2,m) and inducting on m turns the Pascal recurrence into a recurrence *along the second subdiagonal*: S(m+3,m+1) sees S(m+2,m) (the previous diagonal entry, the induction hypothesis) and S(m+2,m+1) (the first subdiagonal, already in Mathlib). No double induction is needed.",
+      "**Mathlib's first subdiagonal is the launchpad.** The whole proof rests on `stirlingSecond_succ_self_left : S(n+1,n) = C(n+1,2)`. Having that single neighbouring diagonal already formalized reduces the second subdiagonal to one clean induction.",
+      "**The step is one absorption identity.** After substituting the recurrence and the hypothesis, the inductive goal is a pure binomial equation whose only non-Pascal ingredient is 3·C(m+2,3) = m·C(m+2,2) — itself a one-line instance of Nat.choose_succ_right_eq. Everything else is Pascal's rule and `ring`.",
+      "**zify + linear_combination tames the mixed arithmetic.** The goal mixes a product (m+1)·C(m+2,2) with several binomials; casting to ℤ and feeding the absorption identity to `linear_combination` discharges it deterministically, sidestepping ℕ-subtraction and nonlinear `omega` limitations.",
+      "**The constant 3 is the pairing count.** The coefficient 3 in 3·C(n,4) is exactly the number of ways to split four chosen elements into two unordered pairs — the combinatorial meaning the algebra reproduces."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind and set partitions",
+      "Binomial coefficients and Pascal's rule",
+      "The Stirling recurrence S(n+1,k+1) = (k+1)S(n,k+1) + S(n,k)",
+      "Induction on the natural numbers",
+      "Absorption identities for binomial coefficients"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Overview and Strategy",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "File docstring stating the second-subdiagonal formula S(m+2,m) = C(m+2,3)+3C(m+2,4), the numeric sanity checks, and the down-the-diagonal induction plan resting on Mathlib's first subdiagonal and one absorption identity.",
+      "mathContext": "S(n,n−2) = C(n,3) + 3·C(n,4): the second diagonal of the Stirling-second-kind triangle."
+    },
+    {
+      "id": "absorption",
+      "title": "The Absorption Identity",
+      "startLine": 57,
+      "endLine": 67,
+      "summary": "three_mul_choose_three: 3·C(m+2,3) = m·C(m+2,2), an instance of Nat.choose_succ_right_eq (m+2) 2 after simplifying m+2−2 = m.",
+      "mathContext": "3·C(m+2,3) = m·C(m+2,2); the arithmetic engine of the inductive step."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Second Subdiagonal S(m+2,m) = C(m+2,3) + 3·C(m+2,4)",
+      "startLine": 69,
+      "endLine": 100,
+      "summary": "stirlingSecond_add_two_sub_two: induction on m. Base m=0 by `decide`. Step rewrites the Pascal recurrence (n=m+2,k=m), substitutes the first subdiagonal C(m+2,2) and the induction hypothesis, expands C(m+3,3), C(m+3,4) by Pascal's rule, then closes by `zify; linear_combination` against the cast absorption identity.",
+      "mathContext": "S(m+2,m) = C(m+2,3) + 3·C(m+2,4) for all m : ℕ."
+    },
+    {
+      "id": "subdiagonal-form",
+      "title": "Subdiagonal Restatement and Sanity Checks",
+      "startLine": 102,
+      "endLine": 118,
+      "summary": "stirlingSecond_sub_two: reindex n = 2+m to state S(n,n−2) = C(n,3)+3C(n,4) for n ≥ 2. Three kernel-checked values S(4,2)=7, S(5,3)=25, S(6,4)=65 confirm the formula by `decide`.",
+      "mathContext": "S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2; numeric confirmation."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6: Stirling numbers of the second kind, their recurrence and subdiagonal closed forms"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "note": "Set partitions and the triangle of Stirling numbers of the second kind"
+    },
+    {
+      "authors": "Comtet, Louis",
+      "title": "Advanced Combinatorics",
+      "year": "1974",
+      "note": "Tables and closed forms for S(n,n−r) as polynomials in n; the case r=2 gives C(n,3)+3C(n,4)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry on the two-block column S(n,2); this entry establishes a different cross-section of the same triangle, the second subdiagonal S(n,n−2)"
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01-oq-02",
+      "relationship": "complements",
+      "description": "Sibling entry proving the general finite-difference closed form k!·S(n,k); this entry gives the elementary subdiagonal polynomial directly from the recurrence without the inclusion–exclusion sum"
+    }
+  ],
+  "conclusion": {
+    "summary": "The second subdiagonal of the Stirling-second-kind triangle has the closed form S(m+2,m) = C(m+2,3) + 3·C(m+2,4) (stirlingSecond_add_two_sub_two), equivalently S(n,n−2) = C(n,3) + 3·C(n,4) for n ≥ 2 (stirlingSecond_sub_two). The proof is a single induction on m down the diagonal, using Mathlib's first-subdiagonal value S(n+1,n)=C(n+1,2) and the absorption identity 3·C(m+2,3)=m·C(m+2,2). All six theorems are verified with 0 axioms and 0 sorries; sanity values S(4,2)=7, S(5,3)=25, S(6,4)=65 are kernel-checked.",
+    "implications": "Extends Mathlib's diagonal/first-subdiagonal development of Nat.stirlingSecond by one diagonal, providing a directly citable polynomial value and a reusable down-the-diagonal induction template that the third subdiagonal S(n,n−3) and beyond can follow.",
+    "openQuestions": [
+      "Does the third subdiagonal S(n,n−3) = C(n,4) + 10·C(n,5) + 15·C(n,6) admit the same down-the-diagonal induction, now consuming both the first and second subdiagonals as inputs?",
+      "Can the coefficients (1, 3) of the second subdiagonal be identified inside Lean with the associated Stirling/Bessel-number pattern, giving a uniform generating identity for all S(n,n−r)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "StirlingSecondKindOQ01OQ03",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/StirlingSecondKindOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes open question OQ-03 of `stirling-second-kind-oq-01`: the **second subdiagonal** of the Stirling-second-kind triangle has the closed form
$$S(m+2,\,m) = \binom{m+2}{3} + 3\binom{m+2}{4},$$
equivalently $S(n,n-2) = \binom{n}{3} + 3\binom{n}{4}$ for $n \ge 2$.

Mathlib records the diagonal $S(n,n)=1$ and the **first** subdiagonal $S(n+1,n)=\binom{n+1}{2}$ but no closed form for the next diagonal. This entry fills that gap.

## Proof

Induction on $m$ **down the diagonal**. The Pascal recurrence $S(n+1,k+1)=(k+1)S(n,k+1)+S(n,k)$ at $n=m+2,\,k=m$ gives
$$S(m+3,m+1) = (m+1)\,S(m+2,m+1) + S(m+2,m),$$
where $S(m+2,m+1)=\binom{m+2}{2}$ is Mathlib's first subdiagonal (`stirlingSecond_succ_self_left`) and $S(m+2,m)$ is the induction hypothesis. The step collapses to the absorption identity $3\binom{m+2}{3}=m\binom{m+2}{2}$ (an instance of `Nat.choose_succ_right_eq`) plus two applications of Pascal's rule, discharged by `zify; linear_combination`.

## Verification

- **6 theorems, 0 definitions, 118 lines**, builds clean on Mathlib 4.26.0
- **0 axioms** beyond `propext` / `Classical.choice` / `Quot.sound`; base case and sanity checks use `decide` (kernel reduction, **not** `native_decide`, so no `Lean.ofReduceBool`)
- **0 sorries**
- Kernel-checked sanity values: $S(4,2)=7$, $S(5,3)=25$, $S(6,4)=65$

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)