### PR TITLE
research: Key Group Theory Lemma (transitive subgroup of S_p with a transposition is S_p) [abel-ruffini-oq-04-oq-01-oq-04]

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ04.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ04.lean
@@ -1,0 +1,80 @@
+/-
+  Abel–Ruffini, concrete-quintic branch (oq-04-oq-01), open question oq-04.
+
+  The parent entry (`AbelRuffiniOQ04OQ01`, "Gal(x⁵−4x+2) ≅ S₅") documents, in a
+  comment block, the classical
+
+      **Key Group Theory Lemma.** A transitive subgroup of `S_p` (`p` prime)
+      that contains a transposition is all of `S_p`.
+
+  but — as oq-04 records — "the formal proof of this classical result is not
+  included; the current proof avoids it via Sylow." This file supplies that
+  missing proof, axiom-free, by assembling standard Mathlib results:
+
+    * transitivity + orbit–stabilizer  ⟹  `p ∣ |G|`;
+    * Cauchy's theorem                 ⟹  `G` contains an element `σ` of order `p`;
+    * an order-`p` permutation of a `p`-element set is a `p`-cycle with full
+      support (`isCycle_of_prime_order`, `IsCycle.orderOf`);
+    * a `p`-cycle together with any transposition generates `S_p`
+      (`closure_prime_cycle_swap`).
+
+  Hence `⟨σ, τ⟩ = ⊤ ≤ G`, so `G = ⊤`. This is the general lemma behind the
+  concrete computation `Gal(x⁵ − 4x + 2) ≅ S₅`.
+-/
+
+import Mathlib
+
+open Equiv Equiv.Perm Subgroup MulAction
+
+namespace AbelRuffiniOQ04OQ01OQ04
+
+variable {α : Type*} [Fintype α] [DecidableEq α]
+
+/-- **Key Group Theory Lemma (transitive + a transposition ⟹ full symmetric group).**
+
+If `α` has a prime number of elements and `G ≤ S_α` acts transitively on `α`
+and contains a transposition, then `G = ⊤`. -/
+theorem eq_top_of_isPretransitive_of_mem_isSwap
+    (hp : (Fintype.card α).Prime)
+    (G : Subgroup (Equiv.Perm α)) [IsPretransitive G α]
+    {τ : Equiv.Perm α} (hτ : τ ∈ G) (hτswap : τ.IsSwap) :
+    G = ⊤ := by
+  classical
+  haveI : Fact (Fintype.card α).Prime := ⟨hp⟩
+  -- `α` is nonempty (its cardinality is a prime ≥ 2).
+  have hcard2 : 2 ≤ Fintype.card α := hp.two_le
+  obtain ⟨a⟩ : Nonempty α := Fintype.card_pos_iff.mp (by omega)
+  -- Orbit–stabilizer + transitivity give `card α ∣ |G|`.
+  have horbit : Fintype.card (orbit G a) = Fintype.card α :=
+    Fintype.card_congr ((Equiv.setCongr (MulAction.orbit_eq_univ G a)).trans (Equiv.Set.univ α))
+  have hpdvd : Fintype.card α ∣ Fintype.card G := by
+    have hos := MulAction.card_orbit_mul_card_stabilizer_eq_card_group (α := G) a
+    refine ⟨Fintype.card (stabilizer G a), ?_⟩
+    rw [← hos, horbit]
+  -- Cauchy: `G` contains an element `σ` of order `card α = p`.
+  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card (Fintype.card α) hpdvd
+  have hσord : orderOf (g : Equiv.Perm α) = Fintype.card α := by
+    rw [orderOf_coe]; exact hg
+  -- An order-`p` permutation of a `p`-element set is a `p`-cycle…
+  have hσcyc : (g : Equiv.Perm α).IsCycle := by
+    refine isCycle_of_prime_order (by rw [hσord]; exact hp) ?_
+    rw [hσord]
+    calc ((g : Equiv.Perm α).support.card) ≤ Fintype.card α := Finset.card_le_univ _
+      _ < 2 * Fintype.card α := by omega
+  -- …with full support.
+  have hσsupp : (g : Equiv.Perm α).support = Finset.univ := by
+    have h1 := hσcyc.orderOf
+    rw [hσord] at h1
+    exact Finset.eq_univ_of_card _ h1.symm
+  -- A `p`-cycle and a transposition generate `S_p`.
+  have hgen : Subgroup.closure (({(g : Equiv.Perm α), τ}) : Set (Equiv.Perm α)) = ⊤ :=
+    closure_prime_cycle_swap hp hσcyc hσsupp hτswap
+  -- Both generators lie in `G`, so `⊤ = ⟨σ, τ⟩ ≤ G`.
+  rw [eq_top_iff, ← hgen, Subgroup.closure_le]
+  intro x hx
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+  rcases hx with rfl | rfl
+  · exact g.2
+  · exact hτ
+
+end AbelRuffiniOQ04OQ01OQ04

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/annotations.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "key-group-lemma",
+    "startLine": 37,
+    "endLine": 78,
+    "type": "theorem",
+    "title": "Key Group Theory Lemma",
+    "body": "For α with a prime number of elements, a transitive subgroup G ≤ S_α containing a transposition equals ⊤. Proof: transitivity + orbit–stabilizer give card α | |G|; Cauchy yields an element g of order card α; on a card-α set g is a full-support card-α-cycle (isCycle_of_prime_order, IsCycle.orderOf); with the transposition τ, closure_prime_cycle_swap gives ⟨g,τ⟩ = ⊤; since g,τ ∈ G, G = ⊤. This is the classical lemma the parent concrete-quintic entry documented but left unproven."
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "abel-ruffini-oq-04-oq-01-oq-04",
+  "title": "Key Group Theory Lemma: a transitive subgroup of S_p with a transposition is S_p",
+  "slug": "abel-ruffini-oq-04-oq-01-oq-04",
+  "description": "Open question oq-04 of the concrete-quintic entry (Gal(x^5-4x+2) ≅ S_5) records that the file documents — but does not prove — the classical Key Group Theory Lemma: a transitive subgroup of the symmetric group S_p (p prime) that contains a transposition is all of S_p. The parent proof avoided it via repetitive Sylow case-elimination. This formalization supplies the missing proof, axiom-free, by assembling standard Mathlib results: transitivity + orbit–stabilizer gives p | |G|; Cauchy's theorem produces an element of order p; an order-p permutation of a p-element set is a p-cycle with full support; and a p-cycle together with any transposition generates S_p (closure_prime_cycle_swap). Hence ⟨σ,τ⟩ = ⊤ ≤ G, so G = ⊤. This is the general lemma underlying the concrete S_5 computation.",
+  "meta": {
+    "author": "Galois / classical; Lean formalization original (researcher-10)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01OQ04.lean",
+    "tags": [
+      "group-theory",
+      "symmetric-group",
+      "permutation-group",
+      "transitive-action",
+      "transposition",
+      "p-cycle",
+      "galois-theory",
+      "abel-ruffini",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). Assembles Mathlib's orbit–stabilizer theorem, Cauchy's theorem (exists_prime_orderOf_dvd_card), isCycle_of_prime_order, IsCycle.orderOf, and closure_prime_cycle_swap. Transitivity is taken as the MulAction.IsPretransitive hypothesis.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.closure_prime_cycle_swap",
+        "description": "A p-cycle and a transposition generate S_p when card is prime",
+        "module": "Mathlib.GroupTheory.Perm.Closure"
+      },
+      {
+        "theorem": "exists_prime_orderOf_dvd_card",
+        "description": "Cauchy's theorem: p | |G| gives an element of order p",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "MulAction.card_orbit_mul_card_stabilizer_eq_card_group",
+        "description": "Orbit–stabilizer theorem",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Equiv.Perm.isCycle_of_prime_order",
+        "description": "An order-p permutation of a p-set is a cycle",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      }
+    ],
+    "originalContributions": [
+      "eq_top_of_isPretransitive_of_mem_isSwap: the Key Group Theory Lemma — for prime card α, a transitive subgroup G ≤ S_α containing a transposition equals ⊤. The classical result the parent entry documented but left unproven."
+    ],
+    "lineCount": 80,
+    "theoremCount": 1,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/AbelRuffiniOQ04OQ01OQ04.lean",
+    "lineCount": 80,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 1
+  },
+  "conclusion": {
+    "summary": "A transitive subgroup G of S_p (p prime) containing a transposition is all of S_p. Transitivity forces p | |G| (orbit–stabilizer); Cauchy yields an element σ of order p, which on a p-element set is a full-support p-cycle; with the given transposition τ, closure_prime_cycle_swap gives ⟨σ,τ⟩ = ⊤; since σ,τ ∈ G, we get G = ⊤.",
+    "significance": "This is the classical lemma (transitive + transposition ⟹ full symmetric, prime degree) that powers Galois-group computations such as Gal(x^5-4x+2) ≅ S_5. Formalizing it replaces the parent's ad-hoc Sylow case-elimination with the general result.",
+    "implications": [
+      "Provides a reusable lemma for proving specific quintics (and prime-degree polynomials) have full symmetric Galois group.",
+      "Demonstrates the Mathlib permutation/group-action library suffices for this classical generation theorem."
+    ],
+    "openQuestions": [
+      "Use this lemma to replace the parent's gal_card_ne_10/20/40 Sylow arguments with a single transposition-detection step.",
+      "Generalize to: a primitive (not merely transitive) subgroup of S_n containing a transposition is S_n (Jordan's theorem)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Proves the Key Group Theory Lemma documented but not proven in the concrete-quintic entry",
+      "targetId": "abel-ruffini-oq-04-oq-01"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question oq-04** of the concrete-quintic entry `abel-ruffini-oq-04-oq-01` (*Gal(x⁵−4x+2) ≅ S₅ and Unsolvability by Radicals*). That entry **documents in a comment block** — but does **not** prove — the classical **Key Group Theory Lemma**:

> A transitive subgroup of `S_p` (`p` prime) that contains a transposition is all of `S_p`.

The parent proof sidestepped it with repetitive Sylow case-elimination (`gal_card_ne_10/20/40`). This entry supplies the missing proof, **axiom-free**, by assembling standard Mathlib results.

## Proof outline (`eq_top_of_isPretransitive_of_mem_isSwap`)

1. transitivity + orbit–stabilizer (`card_orbit_mul_card_stabilizer_eq_card_group`) ⟹ `card α ∣ |G|`;
2. Cauchy's theorem (`exists_prime_orderOf_dvd_card`) ⟹ an element `g` of order `card α = p`;
3. an order-`p` permutation of a `p`-element set is a full-support `p`-cycle (`isCycle_of_prime_order`, `IsCycle.orderOf`);
4. a `p`-cycle and any transposition generate `S_p` (`closure_prime_cycle_swap`).

Hence `⟨g, τ⟩ = ⊤ ≤ G`, so `G = ⊤`.

## Verification

- Builds clean against the pinned Mathlib (host toolchain, docker unavailable).
- `#print axioms eq_top_of_isPretransitive_of_mem_isSwap` reports only `propext, Classical.choice, Quot.sound` → **0 axioms, 0 sorries**.
- Status `verified`, badge `original`, 1 theorem / 80 lines.
- New gallery entry, `child-of` `abel-ruffini-oq-04-oq-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)