### PR TITLE
research(schroder-numbers-oq-01-oq-01-oq-02): Dyck ⊆ Schröder, catalan(n) ≤ largeSchroder(n) by comparing recurrences [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SchroderNumbersOQ010102.lean
+++ b/proofs/Proofs/SchroderNumbersOQ010102.lean
@@ -1,0 +1,105 @@
+import Mathlib
+
+/-
+# Dyck ⊆ Schröder: the Catalan numbers are dominated by the large Schröder numbers
+
+The **Catalan number** `catalan n` counts Dyck paths (lattice paths with unit
+up/down steps staying weakly above the axis), while the **large Schröder number**
+`largeSchroder n` counts Schröder paths, which additionally allow horizontal
+`(2,0)` steps. Every Dyck path *is* a Schröder path, so combinatorially
+`catalan n ≤ largeSchroder n`. This file proves that inequality **purely from the
+two convolution recurrences**, as requested by the open question of the entry
+*Large Schröder numbers: the sharp tripling step* (`schroder-numbers-oq-01-oq-01`):
+
+> Can the dominance `L(n) ≥ catalan(n)` over the Catalan numbers be proved by
+> comparing their recurrences, formalizing the lattice-path inclusion of Dyck
+> paths into Schröder paths?
+
+Both sequences are governed by the *same* Cauchy-product shape over `Fin (n+1)`:
+
+* `catalan (n+1)      = ∑ i, catalan i · catalan (n−i)`               (`catalan_succ`)
+* `largeSchroder (n+1) = largeSchroder n + ∑ i, L i · L (n−i)`        (defining equation)
+
+The large Schröder recurrence is the Catalan recurrence **plus** the extra
+non-negative term `largeSchroder n`. A single strong induction therefore yields
+the termwise domination, and the extra term makes the inequality *strict* for
+every `n ≥ 1`. Equality holds exactly at `n = 0`.
+
+Results:
+
+* `largeSchroder_pos`            — `0 < largeSchroder n`;
+* `catalan_le_largeSchroder`     — **`catalan n ≤ largeSchroder n`** (the open question, verbatim);
+* `catalan_lt_largeSchroder`     — strict domination `catalan n < largeSchroder n` for `n ≥ 1`;
+* `catalan_eq_largeSchroder_iff` — equality holds **iff** `n = 0`.
+
+No axioms, no `sorry`, no `native_decide`. Mathlib records both `Nat.catalan` and
+`Nat.largeSchroder` with their recurrences, but not the comparison between them.
+-/
+
+namespace SchroderNumbersOQ010102
+
+open Finset
+open Nat (largeSchroder)
+
+/-- The large Schröder numbers are strictly positive. Immediate from the
+recurrence `largeSchroder (n+1) = largeSchroder n + (non-negative sum)` and
+`largeSchroder 0 = 1`. -/
+theorem largeSchroder_pos : ∀ n, 0 < largeSchroder n
+  | 0 => by simp
+  | n + 1 => by
+      rw [Nat.largeSchroder]
+      exact Nat.lt_of_lt_of_le (largeSchroder_pos n) (Nat.le_add_right _ _)
+
+/-- **Dyck ⊆ Schröder.** The Catalan numbers are dominated by the large Schröder
+numbers, proved by strong induction comparing the two Cauchy-product recurrences.
+The Schröder recurrence is the Catalan recurrence plus the extra term
+`largeSchroder n ≥ 0`, so each convolution term dominates by the inductive
+hypothesis. This is the open question of `schroder-numbers-oq-01-oq-01`, verbatim. -/
+theorem catalan_le_largeSchroder : ∀ n, catalan n ≤ largeSchroder n := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    match n with
+    | 0 => simp
+    | m + 1 =>
+      rw [catalan_succ, Nat.largeSchroder]
+      -- goal: ∑ i : Fin m.succ, catalan i * catalan (m - i)
+      --        ≤ largeSchroder m + ∑ i : Fin m.succ, L i * L (m - i)
+      refine le_trans ?_ (Nat.le_add_left _ _)
+      apply Finset.sum_le_sum
+      intro i _
+      have h1 : catalan (i : ℕ) ≤ largeSchroder i := ih i i.isLt
+      have h2 : catalan (m - i) ≤ largeSchroder (m - i) :=
+        ih (m - i) (by have := i.isLt; omega)
+      exact Nat.mul_le_mul h1 h2
+
+/-- Strict domination for every positive index: the extra `largeSchroder (n−1) ≥ 1`
+term in the Schröder recurrence is absent from the Catalan recurrence. -/
+theorem catalan_lt_largeSchroder : ∀ {n}, 1 ≤ n → catalan n < largeSchroder n := by
+  intro n hn
+  match n, hn with
+  | m + 1, _ =>
+    rw [catalan_succ, Nat.largeSchroder]
+    -- ∑ i, catalan i * catalan (m-i) < largeSchroder m + ∑ i, L i * L (m-i)
+    have hsum : ∑ i : Fin m.succ, catalan (i : ℕ) * catalan (m - i)
+              ≤ ∑ i : Fin m.succ, largeSchroder (i : ℕ) * largeSchroder (m - i) := by
+      apply Finset.sum_le_sum
+      intro i _
+      exact Nat.mul_le_mul (catalan_le_largeSchroder i) (catalan_le_largeSchroder (m - i))
+    have hpos : 0 < largeSchroder m := largeSchroder_pos m
+    omega
+
+/-- Equality between the Catalan and large Schröder numbers holds **exactly** at
+`n = 0` (where both equal `1`); for all `n ≥ 1` the Schröder count strictly exceeds. -/
+theorem catalan_eq_largeSchroder_iff {n : ℕ} : catalan n = largeSchroder n ↔ n = 0 := by
+  constructor
+  · intro h
+    by_contra hne
+    have hn : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr hne
+    exact absurd h (Nat.ne_of_lt (catalan_lt_largeSchroder hn))
+  · rintro rfl; simp
+
+/-- Sanity check at `n = 3`: `catalan 3 = 5 ≤ 22 = largeSchroder 3`. -/
+example : catalan 3 ≤ largeSchroder 3 := catalan_le_largeSchroder 3
+
+end SchroderNumbersOQ010102

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "schroder-numbers-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "Dyck ⊆ Schröder, Recurrence by Recurrence",
+    "content": "Every Dyck path is a Schröder path — Schröder paths simply allow extra horizontal (2,0) steps — so combinatorially catalan(n) ≤ largeSchroder(n). The parent entry's second open question asked for a proof of this dominance by comparing the two recurrences rather than building a path bijection. Mathlib presents both sequences with the same Cauchy-product body over Fin(n+1): catalan(n+1) = ∑ᵢ catalan(i)·catalan(n−i) and largeSchroder(n+1) = largeSchroder(n) + ∑ᵢ L(i)·L(n−i). The Schröder recurrence is the Catalan recurrence plus the single extra non-negative term largeSchroder(n) — that lone term is the entire content of the inequality."
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "schroder-numbers-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 51
+    },
+    "type": "key-step",
+    "title": "Positivity from the Recurrence",
+    "content": "largeSchroder_pos records 0 < largeSchroder(n). The induction is immediate: L(0) = 1 > 0, and unfolding the recurrence gives L(n+1) = L(n) + (a sum of products), which is at least L(n) by Nat.le_add_right, hence positive by the inductive hypothesis. This positivity is exactly what later promotes the non-strict domination to a strict one for n ≥ 1."
+  },
+  {
+    "id": "ann-domination",
+    "proofId": "schroder-numbers-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 74
+    },
+    "type": "key-step",
+    "title": "Termwise Domination by Strong Induction",
+    "content": "catalan_le_largeSchroder is the main result. The Cauchy product couples each index i with its complement n−i, so ordinary induction is too weak — strong induction (Nat.strong_induction_on) is required. After rewriting the Catalan side by catalan_succ and the Schröder side by its defining equation, the extra largeSchroder(m) term is discarded with Nat.le_add_left, and Finset.sum_le_sum reduces the goal to a single pointwise inequality catalan(i)·catalan(m−i) ≤ L(i)·L(m−i). Both i and m−i are < m+1 (the key omega facts via i.isLt), so the strong hypothesis applies to each factor and Nat.mul_le_mul finishes. No reindexing is needed because both sums live over the identical type Fin(m+1)."
+  },
+  {
+    "id": "ann-strictness",
+    "proofId": "schroder-numbers-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "The Extra Term Makes It Strict",
+    "content": "catalan_lt_largeSchroder keeps the term that the domination proof threw away. The same Finset.sum_le_sum bound gives ∑ catalan(i)·catalan(m−i) ≤ ∑ L(i)·L(m−i); then largeSchroder(m) > 0 (largeSchroder_pos) means largeSchroder(m+1) = largeSchroder(m) + ∑ L(i)·L(m−i) strictly exceeds the Catalan sum. omega closes the gap from the sum bound and the positivity fact. So strict domination holds for every n ≥ 1 — the inequality is never tight away from the seed."
+  },
+  {
+    "id": "ann-equality",
+    "proofId": "schroder-numbers-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 105
+    },
+    "type": "context",
+    "title": "Equality Exactly at n = 0",
+    "content": "catalan_eq_largeSchroder_iff turns the strict bound into a clean characterization: catalan(n) = largeSchroder(n) iff n = 0. If n ≥ 1 then strict domination forbids equality; at n = 0 both sequences are seeded at 1. The closing example, catalan 3 = 5 ≤ 22 = largeSchroder 3, is a concrete instance of the dominance."
+  }
+]

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchroderNumbersOQ010102.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schroderNumbersOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schroderNumbersOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schroderNumbersOq01Oq01Oq02Data: ProofData = {
+  proof: schroderNumbersOq01Oq01Oq02Proof,
+  annotations: schroderNumbersOq01Oq01Oq02Annotations,
+}

--- a/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "schroder-numbers-oq-01-oq-01-oq-02",
+  "title": "Dyck ⊆ Schröder: catalan(n) ≤ largeSchroder(n) by comparing convolution recurrences",
+  "slug": "schroder-numbers-oq-01-oq-01-oq-02",
+  "description": "Every Dyck path is a Schröder path, so the Catalan numbers are dominated by the large Schröder numbers: catalan(n) ≤ largeSchroder(n) for all n. This entry proves that inequality purely from the two Cauchy-product recurrences, answering the parent's second open question verbatim. Both sequences obey the same convolution shape over Fin(n+1) — catalan(n+1) = ∑ᵢ catalan(i)·catalan(n−i) and largeSchroder(n+1) = largeSchroder(n) + ∑ᵢ L(i)·L(n−i) — the Schröder recurrence being the Catalan one plus the extra non-negative term L(n). A single strong induction makes each convolution term dominate; the extra term forces strict domination for every n ≥ 1, with equality holding exactly at n = 0.",
+  "meta": {
+    "author": "Robb Walters",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroderNumbersOQ010102.lean",
+    "tags": [
+      "combinatorics",
+      "schroder-numbers",
+      "catalan-numbers",
+      "enumerative",
+      "recurrence",
+      "lattice-paths",
+      "inequality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.catalan_succ",
+        "description": "The Catalan convolution recurrence catalan(n+1) = ∑_{i : Fin (n+1)} catalan(i)·catalan(n−i)",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.largeSchroder",
+        "description": "The defining equation largeSchroder(n+1) = largeSchroder(n) + ∑_{i : Fin (n+1)} L(i)·L(n−i), unfolded to match the Catalan recurrence index-for-index",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "Termwise domination of one sum by another over a common index set; applied over Fin (n+1) so each convolution term catalan(i)·catalan(n−i) ≤ L(i)·L(n−i)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "Strong induction on ℕ, needed because each convolution term references arbitrary smaller indices i and n−i",
+        "module": "Mathlib.Order.Basic"
+      }
+    ],
+    "originalContributions": [
+      "largeSchroder_pos: 0 < largeSchroder(n), a one-line induction off the recurrence that the strict-domination argument needs",
+      "catalan_le_largeSchroder: the open question verbatim — catalan(n) ≤ largeSchroder(n) for all n, by strong induction comparing the Catalan and Schröder convolution recurrences term-for-term over Fin(n+1)",
+      "catalan_lt_largeSchroder: strict domination catalan(n) < largeSchroder(n) for every n ≥ 1, since the Schröder recurrence carries the extra positive term largeSchroder(n−1) absent from the Catalan one",
+      "catalan_eq_largeSchroder_iff: equality catalan(n) = largeSchroder(n) holds iff n = 0 — a complete characterization of where the two enumerations coincide"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound (confirmed by #print axioms on all three theorems). No `native_decide`, hence no `Lean.ofReduceBool`.",
+    "lineCount": 105,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Catalan numbers C(n) = 1, 1, 2, 5, 14, 42, … (OEIS A000108) count Dyck paths — lattice paths with unit up/down steps that stay weakly above the axis. The large Schröder numbers L(n) = 1, 2, 6, 22, 90, … (OEIS A006318) count Schröder paths, which additionally permit horizontal (2,0) steps. Since adjoining horizontal steps can only add paths, every Dyck path is a Schröder path and C(n) ≤ L(n) combinatorially. The parent entry (schroder-numbers-oq-01-oq-01) established the sharp tripling step 3·L(n) ≤ L(n+1) and its second open question asked whether this domination over the Catalan numbers could be proved formally by comparing the two recurrences — i.e. an algebraic shadow of the lattice-path inclusion Dyck ⊆ Schröder.",
+    "problemStatement": "Prove catalan(n) ≤ largeSchroder(n) for all n by comparing the Catalan and large-Schröder convolution recurrences, rather than by an explicit path bijection.",
+    "text": "Mathlib gives both sequences the same Cauchy-product shape over Fin(n+1): catalan(n+1) = ∑ᵢ catalan(i)·catalan(n−i) and, by definition, largeSchroder(n+1) = largeSchroder(n) + ∑ᵢ L(i)·L(n−i). The Schröder recurrence is literally the Catalan recurrence plus the extra non-negative term largeSchroder(n). Strong induction therefore dominates the convolution termwise, and the extra term upgrades the inequality to strict for n ≥ 1.",
+    "proofStrategy": "1. largeSchroder_pos: induction off the recurrence — L(0) = 1 > 0 and L(n+1) = L(n) + (sum) ≥ L(n) > 0.\n2. catalan_le_largeSchroder: strong induction on n. For n = 0 both equal 1. For n = m+1, rewrite the Catalan side by catalan_succ and the Schröder side by its defining equation; drop the extra largeSchroder(m) term (Nat.le_add_left) and apply Finset.sum_le_sum over Fin(m+1), where each factor catalan(i) ≤ L(i) and catalan(m−i) ≤ L(m−i) by the strong inductive hypothesis (both i and m−i are < m+1).\n3. catalan_lt_largeSchroder: the same termwise sum bound, but now keep the extra term: catalan(m+1) = ∑ ≤ ∑ L(i)·L(m−i) < largeSchroder(m) + ∑ = largeSchroder(m+1) since largeSchroder(m) > 0 — closed by omega from the sum bound and positivity.\n4. catalan_eq_largeSchroder_iff: equality forces n = 0 (otherwise strict domination contradicts it); conversely both sides are 1 at n = 0.",
+    "keyInsights": [
+      "**Same recurrence, plus one term**: the large Schröder recurrence largeSchroder(n+1) = largeSchroder(n) + ∑ᵢ L(i)·L(n−i) and the Catalan recurrence catalan(n+1) = ∑ᵢ catalan(i)·catalan(n−i) share an identical convolution body over Fin(n+1). The entire domination is the observation that Schröder carries one extra non-negative summand — the algebraic fingerprint of the extra horizontal step that distinguishes Schröder paths from Dyck paths.",
+      "**Strong induction, not ordinary**: each convolution term couples the index i with its complement n−i, both strictly below n+1 but neither equal to n. Ordinary induction cannot reach catalan(n−i) ≤ L(n−i); strong induction on n is exactly what the Cauchy product demands.",
+      "**The extra term is the strictness**: keeping (rather than discarding) the leading largeSchroder(n) term turns ≤ into <. Because that term is positive for every n, strict domination holds for all n ≥ 1, and equality survives only at n = 0 where both sequences are seeded at 1.",
+      "**Index alignment over Fin(n+1)**: using catalan_succ (the Fin-indexed form) against the raw definitional unfolding of largeSchroder keeps both sums over the identical index type Fin(n+1), so Finset.sum_le_sum applies with no reindexing — avoiding the Iic/range bookkeeping that the named largeSchroder_succ lemma would force."
+    ],
+    "prerequisites": [
+      "The Catalan and large Schröder numbers and their convolution recurrences (Nat.catalan_succ, Nat.largeSchroder)",
+      "Termwise comparison of finite sums (Finset.sum_le_sum)",
+      "Strong induction on the natural numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "File-level docstring explaining the lattice-path inclusion Dyck ⊆ Schröder, the shared convolution shape of the two recurrences, and the role of the extra largeSchroder(n) term. Imports Mathlib and opens Finset / Nat.largeSchroder.",
+      "mathContext": "C(n) counts Dyck paths, L(n) counts Schröder paths; Mathlib supplies both convolution recurrences."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity of the Large Schröder Numbers",
+      "startLine": 44,
+      "endLine": 51,
+      "summary": "largeSchroder_pos: 0 < largeSchroder(n) by induction off the recurrence, since L(n+1) = L(n) + (non-negative sum) ≥ L(n) and L(0) = 1.",
+      "mathContext": "Needed to turn the non-strict domination into strict for n ≥ 1."
+    },
+    {
+      "id": "domination",
+      "title": "Dyck ⊆ Schröder: Termwise Domination",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "catalan_le_largeSchroder: strong induction. Rewrite by catalan_succ and the largeSchroder defining equation, drop the extra term, then Finset.sum_le_sum bounds each convolution term using the strong IH on i and n−i.",
+      "mathContext": "catalan(n) ≤ largeSchroder(n) for all n — the parent's second open question, verbatim."
+    },
+    {
+      "id": "strictness",
+      "title": "Strict Domination for n ≥ 1",
+      "startLine": 76,
+      "endLine": 90,
+      "summary": "catalan_lt_largeSchroder: the same termwise sum bound, but the positive extra term largeSchroder(m) is retained, so omega upgrades ≤ to < for n = m+1.",
+      "mathContext": "catalan(n) < largeSchroder(n) for every n ≥ 1."
+    },
+    {
+      "id": "equality-iff",
+      "title": "Equality Characterization",
+      "startLine": 92,
+      "endLine": 105,
+      "summary": "catalan_eq_largeSchroder_iff: equality holds iff n = 0, combining strict domination (n ≥ 1) with the shared seed value 1 at n = 0. A sanity-check example confirms catalan 3 = 5 ≤ 22 = largeSchroder 3.",
+      "mathContext": "The two enumerations coincide exactly at n = 0."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Dyck and Schröder paths, their generating functions, and the lattice-path inclusion underlying C(n) ≤ L(n)"
+    },
+    {
+      "authors": "Schröder, Ernst",
+      "title": "Vier combinatorische Probleme",
+      "year": "1870",
+      "note": "Origin of the Schröder numbers"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "schroder-numbers-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's second open question: proves the dominance L(n) ≥ catalan(n) by comparing the Catalan and Schröder convolution recurrences"
+    }
+  ],
+  "conclusion": {
+    "summary": "The Catalan numbers are dominated by the large Schröder numbers: catalan(n) ≤ largeSchroder(n) for all n (catalan_le_largeSchroder), strictly so for every n ≥ 1 (catalan_lt_largeSchroder), with equality holding exactly at n = 0 (catalan_eq_largeSchroder_iff). The proof is the algebraic shadow of the lattice-path inclusion Dyck ⊆ Schröder: both sequences share the same convolution body over Fin(n+1), and the Schröder recurrence simply carries one extra non-negative term. All four theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Confirms, by a recurrence comparison rather than an explicit path bijection, that adjoining horizontal steps to Dyck paths can only increase the count, and pins down the unique index n = 0 where the two enumerations agree. The argument is a reusable template: any two Cauchy-product sequences whose recurrences differ by a non-negative term inherit a termwise domination by the same strong induction.",
+    "openQuestions": [
+      "Quantify the gap: is largeSchroder(n) / catalan(n) → ∞, and at what rate? (The growth ratios are 3 + 2√2 ≈ 5.828 for L versus 4 for C, suggesting an exponential gap (3+2√2)/4 per step.)",
+      "Formalize the explicit injection of Dyck paths into Schröder paths and prove catalan(n) ≤ largeSchroder(n) bijectively, recovering this inequality as a Finset.card_le_card from an embedding of path sets."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "SchroderNumbersOQ010102",
+    "lineCount": 105,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SchroderNumbersOQ010102.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent entry `schroder-numbers-oq-01-oq-01` **verbatim**:

> Can the dominance `L(n) ≥ catalan(n)` over the Catalan numbers be proved by comparing their recurrences, formalizing the lattice-path inclusion of Dyck paths into Schröder paths?

Every Dyck path is a Schröder path, so `catalan(n) ≤ largeSchroder(n)`. This entry proves it **purely from the two convolution recurrences** — no explicit path bijection.

Both sequences share the same Cauchy-product body over `Fin(n+1)`:

```
catalan(n+1)       = ∑ᵢ catalan(i)·catalan(n−i)         -- Nat.catalan_succ
largeSchroder(n+1) = largeSchroder(n) + ∑ᵢ L(i)·L(n−i)  -- defining equation
```

The large Schröder recurrence is the Catalan recurrence **plus** the extra non-negative term `largeSchroder(n)`. A single strong induction dominates the convolution termwise; that extra term forces strict domination for every `n ≥ 1`.

## Results (4 theorems, 0 definitions, 105 lines)

| Theorem | Statement |
|---|---|
| `largeSchroder_pos` | `0 < largeSchroder n` |
| `catalan_le_largeSchroder` | `catalan n ≤ largeSchroder n` for all n — **the open question** |
| `catalan_lt_largeSchroder` | strict domination for every `n ≥ 1` |
| `catalan_eq_largeSchroder_iff` | equality holds **iff** `n = 0` |

## Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- `#print axioms` on all three theorems → only `propext`, `Classical.choice`, `Quot.sound`.
- Builds against Mathlib 4.26.0 (host toolchain).
- Gallery entry registers cleanly in generated `listings.json`; annotations resolve with no errors.

**Badge:** `original` — Mathlib records both `Nat.catalan` and `Nat.largeSchroder` with their recurrences, but not the comparison between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)