### PR TITLE
audit: 10 fresh research entries clean (abel-ruffini/banach-steinhaus/catalan/dirichlet/erdos-933/fibonacci/gauss-lemma/hurwitz/lebesgue/mellin)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22811,8 +22811,68 @@
       "lastAudited": "2026-06-25T01:13:18Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-04-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "banach-steinhaus-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "catalan-numbers-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "dirichlets-theorem-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "erdos-933-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "fibonacci-identities-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "gauss-lemma-primitive-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "hurwitz-theorem-oq-03-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
+    },
+    "mellin-power-convergence-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T02:12:18Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T01:06:01Z"
+  "lastUpdated": "2026-06-25T02:12:18Z"
 }


### PR DESCRIPTION
Auditor batch: marks 10 never-audited gallery entries as `clean` in `audit-tracker.json` (tracker-only change).

## Entries audited (all status=verified / badge=original / axiomCount=0 / sorries=0)
- abel-ruffini-galois-extensions-oq-04-oq-01
- banach-steinhaus-theorem-oq-01-oq-02
- catalan-numbers-oq-01-oq-02-oq-01-oq-01
- dirichlets-theorem-oq-01-oq-01-oq-04
- erdos-933-oq-05
- fibonacci-identities-oq-04-oq-02
- gauss-lemma-primitive-oq-01-oq-02
- hurwitz-theorem-oq-03-incomplete-01
- lebesgue-measure-oq-01-oq-01-oq-02-oq-02-oq-02
- mellin-power-convergence-oq-01-oq-01

## Verification
- **Mechanical**: comment-stripped grep on each Lean source → 0 real `sorry`/`admit`/`native_decide`/`axiom` declarations; all flagged hits were docstring prose. Substantive content (4–13 theorems/lemmas each, no `: True` stubs).
- **Qualitative**: deep claim-vs-substance review per entry. Lean theorems prove what each meta title/description/conclusion claims (non-vacuous). `original` badges defensible — Mathlib reuse (e.g. banach_steinhaus, Matrix.det_pow, Mellin API) is disclosed, not dressed up as novel. No structure-encoded hidden assumptions inflating axiomCount.
- **erdos-933-oq-05**: discharges 3 parent sorries via elementary LTE divisibility; `#print axioms` in-file confirms only foundational axioms; honestly notes limsup=∞ remains open.
- **hurwitz-theorem-oq-03-incomplete-01**: transparently scoped to the existence direction (1/2/4/8-square identities over CommRing); impossibility direction listed as open. `verified` reflects the formalized content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)