### PR TITLE
research: de-axiomatize Erdős probabilistic lower bound R(k,k) > 2^(k/2) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ErdosRamseyLowerBound.lean
+++ b/proofs/Proofs/ErdosRamseyLowerBound.lean
@@ -1,0 +1,329 @@
+/-
+  Erdős Probabilistic Lower Bound for Diagonal Ramsey Numbers (Erdős 1947)
+
+  The first application of the probabilistic method to Ramsey theory.
+
+  Main result (`erdos_ramsey_criterion`): if
+      `2 * (n.choose k) < 2 ^ (k.choose 2)`
+  then there is a symmetric, irreflexive 2-colouring of the edges of the
+  complete graph `K_n` with **no** monochromatic `k`-clique (neither all-red
+  nor all-blue).  Equivalently the diagonal Ramsey number satisfies
+  `R(k, k) > n`.
+
+  The proof is the *counting* form of the first moment method.  Among the
+  `2 ^ (#edges)` colourings, the number that are monochromatic on a fixed
+  `k`-clique is `2 * 2 ^ (#edges − C(k,2))`.  A union bound over the `C(n,k)`
+  cliques leaves a colouring avoiding all of them whenever the displayed
+  inequality holds.  **No measure theory is required** — the whole argument
+  lives in a finite probability (= counting) space, so it is fully
+  machine-checked with no axioms.
+
+  This de-axiomatizes `erdos_probabilistic_lower_bound` from
+  `Proofs/RamseyR4kExtensions.lean`, where it had been stated as an `axiom`.
+
+  Tags: combinatorics, ramsey-theory, probabilistic-method, first-moment-method
+-/
+
+import Mathlib
+
+namespace ErdosRamsey
+
+open Finset
+
+/-!
+## Part I.  The abstract counting (first-moment) lemma
+
+Work over an arbitrary finite type `E` of "edges".  A colouring is a function
+`c : E → Bool`.  Given a family `bad` of edge-sets, if the total count of
+colourings that are *constant* on some member of `bad` is strictly below the
+number of colourings, a colouring avoiding all of them exists.
+-/
+
+/-- The number of colourings `c : E → Bool` that are identically `b` on a
+finite set `W` of edges is `2 ^ (|E| − |W|)`: the `|W|` coordinates of `W` are
+pinned, the remaining `|E| − |W|` are free. -/
+lemma card_const_on {E : Type*} [Fintype E] [DecidableEq E]
+    (W : Finset E) (b : Bool) :
+    (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = b)).card
+      = 2 ^ (Fintype.card E - W.card) := by
+  classical
+  have hset : (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = b))
+      = Fintype.piFinset (fun e => if e ∈ W then {b} else (univ : Finset Bool)) := by
+    ext c
+    simp only [mem_filter, mem_univ, true_and, Fintype.mem_piFinset]
+    constructor
+    · intro hc e
+      by_cases he : e ∈ W
+      · simp [he, hc e he]
+      · simp [he]
+    · intro hc e he
+      have := hc e
+      simp only [he, if_true, mem_singleton] at this
+      exact this
+  rw [hset, Fintype.card_piFinset]
+  have hprod : (∏ e : E, (if e ∈ W then ({b} : Finset Bool) else univ).card)
+      = ∏ e : E, 2 ^ (if e ∈ W then 0 else 1) := by
+    apply Finset.prod_congr rfl
+    intro e _
+    by_cases he : e ∈ W <;> simp [he]
+  rw [hprod, Finset.prod_pow_eq_pow_sum]
+  congr 1
+  -- ∑ e, (if e ∈ W then 0 else 1) = |E| − |W|
+  rw [Finset.sum_ite, Finset.sum_const_zero, zero_add, Finset.sum_const, smul_eq_mul,
+      mul_one, Finset.filter_not, Finset.card_univ_diff, Finset.filter_mem_eq_inter,
+      Finset.univ_inter]
+
+/-- **First moment / counting lemma.**  If the number of colourings that are
+constant on some `W ∈ bad`, bounded by `∑_{W ∈ bad} 2·2^(|E|−|W|)`, is below
+`2^|E|`, then some colouring is non-constant on every `W ∈ bad`. -/
+theorem exists_avoiding_coloring {E : Type*} [Fintype E] [DecidableEq E]
+    (bad : Finset (Finset E))
+    (hbound : (∑ W ∈ bad, 2 * 2 ^ (Fintype.card E - W.card)) < 2 ^ Fintype.card E) :
+    ∃ c : E → Bool, ∀ W ∈ bad, ¬ ∃ b, ∀ e ∈ W, c e = b := by
+  classical
+  set badC : Finset (E → Bool) :=
+    bad.biUnion (fun W => univ.filter (fun c => ∃ b, ∀ e ∈ W, c e = b)) with hbadC
+  have hcard_badC : badC.card < 2 ^ Fintype.card E := by
+    calc badC.card
+        ≤ ∑ W ∈ bad, (univ.filter (fun c : E → Bool => ∃ b, ∀ e ∈ W, c e = b)).card :=
+          Finset.card_biUnion_le
+      _ ≤ ∑ W ∈ bad, 2 * 2 ^ (Fintype.card E - W.card) := by
+          apply Finset.sum_le_sum
+          intro W _
+          have hsub : (univ.filter (fun c : E → Bool => ∃ b, ∀ e ∈ W, c e = b))
+              ⊆ (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = true))
+                ∪ (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = false)) := by
+            intro c hc
+            simp only [mem_filter, mem_univ, true_and, mem_union] at hc ⊢
+            obtain ⟨b, hb⟩ := hc
+            cases b
+            · right; exact hb
+            · left; exact hb
+          calc (univ.filter (fun c : E → Bool => ∃ b, ∀ e ∈ W, c e = b)).card
+              ≤ ((univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = true))
+                  ∪ (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = false))).card :=
+                Finset.card_le_card hsub
+            _ ≤ (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = true)).card
+                + (univ.filter (fun c : E → Bool => ∀ e ∈ W, c e = false)).card :=
+                Finset.card_union_le _ _
+            _ = 2 * 2 ^ (Fintype.card E - W.card) := by
+                rw [card_const_on, card_const_on]; ring
+      _ < 2 ^ Fintype.card E := hbound
+  have hne : badC ≠ univ := by
+    intro h
+    rw [h, Finset.card_univ, Fintype.card_fun, Fintype.card_bool] at hcard_badC
+    exact lt_irrefl _ hcard_badC
+  have hss : badC ⊂ univ := Finset.ssubset_univ_iff.mpr hne
+  obtain ⟨c, _, hc⟩ := Finset.exists_of_ssubset hss
+  refine ⟨c, ?_⟩
+  intro W hW hcon
+  apply hc
+  rw [hbadC, Finset.mem_biUnion]
+  exact ⟨W, hW, by simp only [mem_filter, mem_univ, true_and]; exact hcon⟩
+
+/-!
+## Part II.  The Ramsey specialisation
+
+Specialise `E := Sym2 (Fin n)` (unordered pairs of vertices; the diagonal
+"loops" are harmless and cancel).  The edge set of a `k`-subset `S` is
+`S.offDiag.image Sym2.mk`, which has exactly `C(k,2)` elements by
+`Finset.card_image_offDiag`.
+-/
+
+/-- The Erdős counting criterion in `Sym2` form: if `2·C(n,k) < 2^C(k,2)` then
+some 2-colouring of the pairs of `Fin n` is monochromatic on no `k`-clique. -/
+theorem exists_good_coloring_sym2 (n k : ℕ)
+    (h : 2 * n.choose k < 2 ^ (k.choose 2)) :
+    ∃ c : Sym2 (Fin n) → Bool, ∀ S : Finset (Fin n), S.card = k →
+      ¬ ∃ b, ∀ e ∈ S.offDiag.image Sym2.mk, c e = b := by
+  classical
+  set E := Sym2 (Fin n)
+  set edgesOf : Finset (Fin n) → Finset E := fun S => S.offDiag.image Sym2.mk with hedges
+  set bad : Finset (Finset E) := (univ.powersetCard k).image edgesOf with hbad
+  -- Every W ∈ bad is the edge set of some k-clique, so has card C(k,2).
+  have hWcard : ∀ W ∈ bad, W.card = k.choose 2 := by
+    intro W hW
+    rw [hbad, Finset.mem_image] at hW
+    obtain ⟨S, hS, rfl⟩ := hW
+    rw [Finset.mem_powersetCard] at hS
+    show #(S.offDiag.image Sym2.mk) = k.choose 2
+    rw [Sym2.card_image_offDiag, hS.2]
+  -- The union bound.
+  have hbound : (∑ W ∈ bad, 2 * 2 ^ (Fintype.card E - W.card)) < 2 ^ Fintype.card E := by
+    rcases bad.eq_empty_or_nonempty with he | hbne
+    · rw [he, Finset.sum_empty]; positivity
+    · obtain ⟨W₀, hW₀⟩ := hbne
+      -- C(k,2) ≤ |E| since W₀ ⊆ univ has card C(k,2)
+      have hCM : k.choose 2 ≤ Fintype.card E := by
+        have h1 : W₀.card ≤ Fintype.card E := Finset.card_le_univ W₀
+        rw [hWcard W₀ hW₀] at h1; exact h1
+      -- rewrite the sum with constant summand
+      rw [Finset.sum_congr rfl (fun W hW => by rw [hWcard W hW])]
+      rw [Finset.sum_const, smul_eq_mul]
+      -- bad.card ≤ n.choose k
+      have hbc : bad.card ≤ n.choose k := by
+        rw [hbad]
+        calc (Finset.image edgesOf (univ.powersetCard k)).card
+            ≤ (univ.powersetCard k).card := Finset.card_image_le
+          _ = n.choose k := by rw [Finset.card_powersetCard, Finset.card_univ,
+                Fintype.card_fin]
+      calc bad.card * (2 * 2 ^ (Fintype.card E - k.choose 2))
+          ≤ n.choose k * (2 * 2 ^ (Fintype.card E - k.choose 2)) := by gcongr
+        _ = (2 * n.choose k) * 2 ^ (Fintype.card E - k.choose 2) := by ring
+        _ < 2 ^ (k.choose 2) * 2 ^ (Fintype.card E - k.choose 2) :=
+            mul_lt_mul_of_pos_right h (pow_pos (by norm_num) _)
+        _ = 2 ^ Fintype.card E := by
+            rw [← pow_add, Nat.add_sub_cancel' hCM]
+  -- apply the abstract lemma
+  obtain ⟨c, hc⟩ := exists_avoiding_coloring bad hbound
+  refine ⟨c, ?_⟩
+  intro S hS
+  apply hc
+  rw [hbad, Finset.mem_image]
+  exact ⟨S, Finset.mem_powersetCard.mpr ⟨Finset.subset_univ S, hS⟩, rfl⟩
+
+/-!
+## Part III.  The classical statement
+
+Repackage in terms of a symmetric, irreflexive colouring
+`color : Fin n → Fin n → Bool`, matching exactly the (previously axiomatized)
+`erdos_probabilistic_lower_bound`.
+-/
+
+/-- **Erdős (1947), counting form.**  If `2·C(n,k) < 2^C(k,2)` then there is a
+symmetric, irreflexive 2-colouring of `K_n` with no monochromatic `k`-clique of
+either colour.  Hence the diagonal Ramsey number satisfies `R(k,k) > n`. -/
+theorem erdos_ramsey_criterion (n k : ℕ)
+    (h : 2 * n.choose k < 2 ^ (k.choose 2)) :
+    ∃ color : Fin n → Fin n → Bool,
+      (∀ x y, color x y = color y x) ∧
+      (∀ x, color x x = false) ∧
+      (∀ s : Finset (Fin n), s.card = k →
+        ¬ (∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
+      (∀ s : Finset (Fin n), s.card = k →
+        ¬ (∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false)) := by
+  classical
+  obtain ⟨c, hc⟩ := exists_good_coloring_sym2 n k h
+  refine ⟨fun x y => if x = y then false else c (Sym2.mk (x, y)), ?_, ?_, ?_, ?_⟩
+  · -- symmetric
+    intro x y
+    show (if x = y then false else c (Sym2.mk (x, y)))
+        = (if y = x then false else c (Sym2.mk (y, x)))
+    by_cases hxy : x = y
+    · rw [hxy]
+    · rw [if_neg hxy, if_neg (Ne.symm hxy), Sym2.eq_swap]
+  · -- irreflexive
+    intro x
+    show (if x = x then false else c (Sym2.mk (x, x))) = false
+    rw [if_pos rfl]
+  · -- no all-true k-clique
+    intro s hs hmono
+    apply hc s hs
+    refine ⟨true, ?_⟩
+    intro e he
+    rw [Finset.mem_image] at he
+    obtain ⟨⟨x, y⟩, hxy, rfl⟩ := he
+    rw [Finset.mem_offDiag] at hxy
+    obtain ⟨hx, hy, hne⟩ := hxy
+    have hm := hmono x y hx hy hne
+    simp only [if_neg hne] at hm
+    exact hm
+  · -- no all-false k-clique
+    intro s hs hmono
+    apply hc s hs
+    refine ⟨false, ?_⟩
+    intro e he
+    rw [Finset.mem_image] at he
+    obtain ⟨⟨x, y⟩, hxy, rfl⟩ := he
+    rw [Finset.mem_offDiag] at hxy
+    obtain ⟨hx, hy, hne⟩ := hxy
+    have hm := hmono x y hx hy hne
+    simp only [if_neg hne] at hm
+    exact hm
+
+/-!
+## Part IV.  The classical `R(k,k) > 2^(k/2)` bound
+
+The Erdős criterion `2·C(n,k) < 2^C(k,2)` is implied by `n ≤ 2^(⌊k/2⌋)` once
+`k ≥ 3`.  The elementary estimate combines `k! · C(n,k) = n^{falling k} ≤ n^k`
+with the exponent comparison `⌊k/2⌋·k ≤ C(k,2) + ⌊k/2⌋` and the factorial
+growth `2^{⌊k/2⌋+1} < k!`.
+-/
+
+/-- Elementary numeric estimate: for `k ≥ 3` and `n ≤ 2^⌊k/2⌋`, the Erdős
+counting criterion `2·C(n,k) < 2^C(k,2)` holds. -/
+theorem erdos_diagonal_numeric (n k : ℕ) (hk : 3 ≤ k) (hn : n ≤ 2 ^ (k / 2)) :
+    2 * n.choose k < 2 ^ (k.choose 2) := by
+  -- k! · C(n,k) ≤ n^k
+  have hfac : k.factorial * n.choose k ≤ n ^ k := by
+    rw [← Nat.descFactorial_eq_factorial_mul_choose]
+    exact Nat.descFactorial_le_pow n k
+  -- n^k ≤ 2^(⌊k/2⌋·k)
+  have hpow : n ^ k ≤ 2 ^ ((k / 2) * k) := by
+    calc n ^ k ≤ (2 ^ (k / 2)) ^ k := Nat.pow_le_pow_left hn k
+      _ = 2 ^ ((k / 2) * k) := by rw [← pow_mul]
+  -- 2^(⌊k/2⌋+1) < k!
+  have hC2 : 2 ^ (k / 2 + 1) < k.factorial := by
+    have step : ∀ j, 3 ≤ j → 2 ^ (j - 1) < j.factorial := by
+      intro j hj
+      induction j, hj using Nat.le_induction with
+      | base => decide
+      | succ m hm ih =>
+          have e : 2 ^ m = 2 * 2 ^ (m - 1) := by
+            conv_lhs => rw [show m = (m - 1) + 1 from by omega]
+            rw [pow_succ']
+          rw [Nat.add_sub_cancel, Nat.factorial_succ]
+          calc 2 ^ m = 2 * 2 ^ (m - 1) := e
+            _ < 2 * m.factorial := by omega
+            _ ≤ (m + 1) * m.factorial := Nat.mul_le_mul (by omega) (le_refl _)
+    calc 2 ^ (k / 2 + 1) ≤ 2 ^ (k - 1) := by
+          apply Nat.pow_le_pow_right (by norm_num); omega
+      _ < k.factorial := step k hk
+  -- ⌊k/2⌋·k ≤ C(k,2) + ⌊k/2⌋
+  have hchoose : k * (k - 1) / 2 = k.choose 2 := (Nat.choose_two_right k).symm
+  have hC1' : (k - 1) * (k / 2) ≤ k * (k - 1) / 2 := by
+    rw [Nat.le_div_iff_mul_le (by norm_num : 0 < 2)]
+    calc (k - 1) * (k / 2) * 2 = (k - 1) * (2 * (k / 2)) := by ring
+      _ ≤ (k - 1) * k := by gcongr; omega
+      _ = k * (k - 1) := by ring
+  have expand : (k / 2) * k = (k - 1) * (k / 2) + k / 2 := by
+    have h1 : (k - 1) + 1 = k := by omega
+    calc (k / 2) * k = (k / 2) * ((k - 1) + 1) := by rw [h1]
+      _ = (k / 2) * (k - 1) + k / 2 := by ring
+      _ = (k - 1) * (k / 2) + k / 2 := by rw [Nat.mul_comm (k / 2) (k - 1)]
+  have hC1 : (k / 2) * k ≤ k.choose 2 + k / 2 := by
+    rw [expand, ← hchoose]
+    exact Nat.add_le_add_right hC1' (k / 2)
+  -- Step C : 2·2^(⌊k/2⌋·k) < k!·2^C(k,2)
+  have hStepC : 2 * 2 ^ ((k / 2) * k) < k.factorial * 2 ^ (k.choose 2) := by
+    calc 2 * 2 ^ ((k / 2) * k) = 2 ^ ((k / 2) * k + 1) := by rw [pow_succ']
+      _ ≤ 2 ^ (k.choose 2 + k / 2 + 1) := by
+          apply Nat.pow_le_pow_right (by norm_num); omega
+      _ = 2 ^ (k.choose 2) * 2 ^ (k / 2 + 1) := by ring
+      _ < 2 ^ (k.choose 2) * k.factorial := mul_lt_mul_of_pos_left hC2 (pow_pos (by norm_num) _)
+      _ = k.factorial * 2 ^ (k.choose 2) := by ring
+  -- assemble: k! · (2·C(n,k)) < k! · 2^C(k,2)
+  have chain : k.factorial * (2 * n.choose k) < k.factorial * 2 ^ (k.choose 2) := by
+    calc k.factorial * (2 * n.choose k) = 2 * (k.factorial * n.choose k) := by ring
+      _ ≤ 2 * n ^ k := by gcongr
+      _ ≤ 2 * 2 ^ ((k / 2) * k) := by gcongr
+      _ < k.factorial * 2 ^ (k.choose 2) := hStepC
+  exact lt_of_mul_lt_mul_left chain (Nat.zero_le _)
+
+/-- **Erdős (1947).**  `R(k, k) > 2^⌊k/2⌋`:  for `k ≥ 3` and any `n ≤ 2^⌊k/2⌋`
+there is a symmetric, irreflexive 2-colouring of `K_n` with no monochromatic
+`k`-clique of either colour.  This is the exact statement that was previously
+the `axiom erdos_probabilistic_lower_bound` in `Proofs/RamseyR4kExtensions.lean`,
+now proved with no axioms. -/
+theorem erdos_probabilistic_lower_bound (k : ℕ) (hk : 3 ≤ k) :
+    ∀ n : ℕ, n ≤ 2 ^ (k / 2) →
+    ∃ color : Fin n → Fin n → Bool,
+      (∀ x y, color x y = color y x) ∧
+      (∀ x, color x x = false) ∧
+      (∀ s : Finset (Fin n), s.card = k →
+        ¬ (∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = true)) ∧
+      (∀ s : Finset (Fin n), s.card = k →
+        ¬ (∀ x y, x ∈ s → y ∈ s → x ≠ y → color x y = false)) :=
+  fun n hn => erdos_ramsey_criterion n k (erdos_diagonal_numeric n k hk hn)
+
+end ErdosRamsey

--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/annotations.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "erb-oq01-ann-docstring",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 1, "endLine": 25 },
+    "type": "context",
+    "title": "Erdős's probabilistic method as exact counting",
+    "content": "The module proves Erdős's 1947 lower bound R(k,k) > 2^⌊k/2⌋ — the first application of the probabilistic method — without any measure theory. The key reframing is that 'colour the edges of K_n at random and show the expected number of monochromatic k-cliques is below 1' is, in a finite space, exactly the counting statement '#(colourings with a monochromatic k-clique) < #(all colourings)'. Working with counts keeps the whole development axiom-free and de-axiomatizes the parent file's `axiom erdos_probabilistic_lower_bound`.",
+    "mathContext": "Goal: for $k\\ge 3$ and $n\\le 2^{\\lfloor k/2\\rfloor}$, there is a 2-colouring of $K_n$ with no monochromatic $K_k$, hence $R(k,k)>2^{\\lfloor k/2\\rfloor}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "probabilistic method",
+      "first moment method",
+      "diagonal Ramsey numbers",
+      "union bound",
+      "monochromatic clique"
+    ],
+    "prerequisites": [
+      "Ramsey numbers R(k,k)",
+      "the probabilistic method (Erdős 1947)"
+    ]
+  },
+  {
+    "id": "erb-oq01-ann-card-const",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 42, "endLine": 74 },
+    "type": "lemma",
+    "title": "Counting colourings constant on an edge set",
+    "content": "card_const_on computes the number of Boolean colourings c : E → Bool that take a fixed value b on every edge of a finite set W. Identifying such colourings with the product Finset that pins the coordinates in W to {b} and frees the rest (Fintype.piFinset), the count is the product ∏ (1 if e∈W else 2) = 2^(|E|−|W|). This single exact count is what later turns 'expected number of monochromatic cliques' into a clean cardinality, with no probability measure.",
+    "mathContext": "$\\#\\{c:E\\to\\mathbb{B}\\mid c|_W\\equiv b\\}=2^{|E|-|W|}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fintype.piFinset",
+      "product of cardinalities",
+      "counting functions"
+    ],
+    "prerequisites": [
+      "finite products and Finset cardinality"
+    ]
+  },
+  {
+    "id": "erb-oq01-ann-union-bound",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 76, "endLine": 122 },
+    "type": "theorem",
+    "title": "The abstract first-moment / union-bound lemma",
+    "content": "exists_avoiding_coloring is the reusable combinatorial heart. Over an arbitrary finite edge type E and an arbitrary family `bad` of forbidden monochromatic sets, the colourings that are constant on some W ∈ bad number at most Σ_{W∈bad} 2·2^(|E|−|W|) (the union bound via Finset.card_biUnion_le, with a factor 2 for the two colours). If this total is below 2^|E| the bad colourings form a proper subset of all colourings, so a colouring non-constant on every W exists. Nothing here is Ramsey-specific — only the family `bad` changes for Schur, van der Waerden, or other Ramsey-type bounds.",
+    "mathContext": "If $\\sum_{W\\in\\mathrm{bad}}2\\cdot 2^{|E|-|W|}<2^{|E|}$ then $\\exists c$ non-constant on every $W\\in\\mathrm{bad}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "union bound",
+      "first moment method",
+      "Finset.card_biUnion_le",
+      "pigeonhole on a proper subset"
+    ],
+    "prerequisites": [
+      "union bound for finite sets",
+      "card_const_on"
+    ]
+  },
+  {
+    "id": "erb-oq01-ann-criterion",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 124, "endLine": 243 },
+    "type": "theorem",
+    "title": "Specialisation to K_n: the Erdős criterion R(k,k) > n",
+    "content": "exists_good_coloring_sym2 instantiates E = Sym2 (Fin n) (unordered vertex pairs; the diagonal loops are harmless) and `bad` = the edge sets of all k-subsets. Each k-clique has exactly C(k,2) edges (Sym2.card_image_offDiag) and there are at most C(n,k) of them, so the |E|-dependent powers cancel on both sides of the union bound and the hypothesis collapses to the clean integer criterion 2·C(n,k) < 2^C(k,2) — one never computes |E|. erdos_ramsey_criterion then repackages the colouring as a symmetric, irreflexive color : Fin n → Fin n → Bool with no monochromatic k-clique of either colour, i.e. R(k,k) > n.",
+    "mathContext": "$2\\binom{n}{k}<2^{\\binom{k}{2}}\\ \\Rightarrow\\ R(k,k)>n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sym2",
+      "edges of a clique",
+      "C(k,2) and C(n,k)",
+      "symmetric irreflexive colouring"
+    ],
+    "prerequisites": [
+      "exists_avoiding_coloring",
+      "Sym2.card_image_offDiag",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "erb-oq01-ann-numeric",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 244, "endLine": 316 },
+    "type": "lemma",
+    "title": "The elementary 2^(k/2) estimate",
+    "content": "erdos_diagonal_numeric proves the criterion 2·C(n,k) < 2^C(k,2) from n ≤ 2^⌊k/2⌋ and k ≥ 3, entirely in ℕ. The chain is: k!·C(n,k) = n^{falling k} ≤ n^k ≤ 2^(⌊k/2⌋·k); the exponent comparison ⌊k/2⌋·k ≤ C(k,2)+⌊k/2⌋ (proved without parity case-split, via Nat.le_div_iff_mul_le); and the factorial growth 2^(⌊k/2⌋+1) < k! (a clean +1 induction from the base k=3). Cancelling k! > 0 yields the criterion. The floor in 2^⌊k/2⌋ makes a single inequality cover both parities of k.",
+    "mathContext": "$k\\ge 3,\\ n\\le 2^{\\lfloor k/2\\rfloor}\\ \\Rightarrow\\ 2\\binom{n}{k}<2^{\\binom{k}{2}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "k!·C(n,k) ≤ n^k",
+      "Nat.descFactorial_le_pow",
+      "factorial growth",
+      "floor division"
+    ],
+    "prerequisites": [
+      "binomial / factorial inequalities in ℕ"
+    ]
+  },
+  {
+    "id": "erb-oq01-ann-headline",
+    "proofId": "ramsey-r4k-extensions-oq-01",
+    "range": { "startLine": 317, "endLine": 328 },
+    "type": "theorem",
+    "title": "Headline: R(k,k) > 2^(k/2), 0 axioms",
+    "content": "erdos_probabilistic_lower_bound assembles the criterion and the numeric estimate into the exact statement that the parent file Proofs/RamseyR4kExtensions.lean had declared as an `axiom`: for k ≥ 3 and any n ≤ 2^⌊k/2⌋ there is a symmetric, irreflexive 2-colouring of K_n with no all-true and no all-false k-clique. It is now a theorem with no axioms, no sorries, and no native_decide (confirmed by #print axioms). The off-diagonal biased-coin bound R(4,k) ≥ c·k²/log k remains the open next step.",
+    "mathContext": "$R(k,k)>2^{\\lfloor k/2\\rfloor}$ for $k\\ge 3$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Erdős 1947",
+      "diagonal Ramsey lower bound",
+      "de-axiomatization"
+    ],
+    "prerequisites": [
+      "erdos_ramsey_criterion",
+      "erdos_diagonal_numeric"
+    ]
+  }
+]

--- a/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-extensions-oq-01/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "ramsey-r4k-extensions-oq-01",
+  "title": "Erdős Probabilistic Lower Bound for Diagonal Ramsey Numbers: R(k,k) > 2^(k/2)",
+  "slug": "ramsey-r4k-extensions-oq-01",
+  "description": "A fully machine-checked, axiom-free formalization of Erdős's 1947 probabilistic lower bound for diagonal Ramsey numbers, the very first application of the probabilistic method. The headline result erdos_probabilistic_lower_bound proves that for k ≥ 3 and any n ≤ 2^⌊k/2⌋ there is a symmetric, irreflexive 2-colouring of K_n with no monochromatic k-clique of either colour — i.e. R(k,k) > 2^⌊k/2⌋. This is exactly the statement that the parent file Proofs/RamseyR4kExtensions.lean had stated as an `axiom`; it is now proved with 0 axioms via the counting (first-moment) form of the probabilistic method, with no measure theory. The general criterion erdos_ramsey_criterion shows R(k,k) > n whenever 2·C(n,k) < 2^C(k,2), and the reusable abstract lemma exists_avoiding_coloring captures the union-bound counting core.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosRamseyLowerBound.lean",
+    "tags": [
+      "combinatorics",
+      "ramsey-theory",
+      "probabilistic-method",
+      "first-moment-method",
+      "graph-theory",
+      "counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 329,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. The proof uses only the standard foundational axioms of Lean/Mathlib (propext, Classical.choice, Quot.sound), which are not counted as assumptions. There are no `axiom` declarations, no structure-encoded hypotheses, no `sorry`, and no `native_decide`. Verified by `#print axioms erdos_probabilistic_lower_bound`.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_piFinset",
+        "description": "Cardinality of a product Finset ∏ (t a).card — used to count colourings constant on a fixed edge set",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "Finset.card_biUnion_le",
+        "description": "Union bound: |⋃ Wᵢ| ≤ Σ|Wᵢ| — the first-moment / union step over all k-cliques",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Sym2.card_image_offDiag",
+        "description": "#(s.offDiag.image Sym2.mk) = C(#s, 2): a k-clique has exactly C(k,2) edges",
+        "module": "Mathlib.Data.Sym.Card"
+      },
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "n.descFactorial k = k!·C(n,k); combined with descFactorial_le_pow gives k!·C(n,k) ≤ n^k",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "C(k,2) = k·(k-1)/2 — used in the exponent comparison ⌊k/2⌋·k ≤ C(k,2)+⌊k/2⌋",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "De-axiomatizes erdos_probabilistic_lower_bound — previously an `axiom` in Proofs/RamseyR4kExtensions.lean — proving the exact same statement (symmetric, irreflexive colouring of K_n, n ≤ 2^⌊k/2⌋, no monochromatic k-clique of either colour) with 0 axioms.",
+      "exists_avoiding_coloring: a reusable abstract first-moment counting lemma over an arbitrary finite edge type E — if Σ_{W∈bad} 2·2^(|E|−|W|) < 2^|E| then a colouring non-constant on every W exists. This is the combinatorial heart of the probabilistic method and applies to any monochromatic-avoidance problem (Ramsey, Schur, van der Waerden).",
+      "card_const_on: exact count 2^(|E|−|W|) of Boolean colourings constant on a fixed edge set, via a clean piFinset bijection — no measure theory.",
+      "erdos_ramsey_criterion: the sharp Erdős criterion R(k,k) > n whenever 2·C(n,k) < 2^C(k,2), stated directly on Fin n → Fin n → Bool colourings.",
+      "erdos_diagonal_numeric: the elementary ℕ-only estimate that n ≤ 2^⌊k/2⌋ (k ≥ 3) implies the criterion, via k!·C(n,k) ≤ n^k, the exponent bound ⌊k/2⌋·k ≤ C(k,2)+⌊k/2⌋, and factorial growth 2^(⌊k/2⌋+1) < k!."
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "The probabilistic / first-moment method (Erdős 1947)",
+      "Diagonal Ramsey numbers R(k,k) and monochromatic cliques",
+      "Finite counting in Lean 4 Mathlib (Finset, piFinset, Sym2)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "In 1947 Paul Erdős gave a one-page proof that the diagonal Ramsey number satisfies R(k,k) > 2^(k/2), introducing what is now called the probabilistic method. The argument is strikingly simple: colour the edges of the complete graph K_n red/blue uniformly at random; the expected number of monochromatic k-cliques is C(n,k)·2^(1−C(k,2)); if this is below 1 then some colouring has none, so R(k,k) > n. Choosing n ≈ 2^(k/2) makes the expectation small. This was the first non-constructive existence proof in combinatorics and launched a vast field. The lower bound 2^(k/2) and the corresponding upper bound R(k,k) ≤ 4^k (Erdős–Szekeres) have barely been improved in 75 years — the constant in the exponent of the diagonal Ramsey number remains one of the most famous open problems in combinatorics (recently 4^k was improved to (4−ε)^k by Campos–Griffiths–Morris–Sahasrabudhe, 2023).",
+    "problemStatement": "The gallery problem ramsey-r4k-extensions-oq-01 asks to formalize the probabilistic lower bound for Ramsey numbers. The parent file Proofs/RamseyR4kExtensions.lean states the diagonal case as `axiom erdos_probabilistic_lower_bound (k : ℕ) (hk : k ≥ 3) : ∀ n ≤ 2^(k/2), ∃ colouring of K_n with no monochromatic k-clique`. This entry proves that exact statement with no axioms. (The off-diagonal, biased-coin bound R(4,k) ≥ c·k²/log k requested in the original problem note — which needs a non-uniform random colouring and real-valued expectations — remains open; this entry settles the foundational symmetric case, which the problem's own 'Why this matters' section calls 'one of the cleanest examples of Erdős's probabilistic combinatorics technique'.)",
+    "proofStrategy": "The whole argument is recast as exact counting in the finite space of all 2^(#edges) colourings, so no probability measure is needed. (1) card_const_on counts the colourings c : E → Bool that are constant on a fixed edge set W: identifying such colourings with the product Finset that pins the |W| coordinates of W and frees the rest gives exactly 2^(|E|−|W|). (2) exists_avoiding_coloring runs the union bound: the colourings monochromatic on some W ∈ bad number at most Σ_W 2·2^(|E|−|W|) (factor 2 for the two colours); if this is below 2^(|E|) the bad colourings form a proper subset and a good colouring exists. (3) The Ramsey specialisation takes E = Sym2 (Fin n) and bad = the edge sets of all k-subsets; each has C(k,2) edges (Sym2.card_image_offDiag) and there are at most C(n,k) of them, so the |E|-dependent factors cancel and the hypothesis collapses to exactly 2·C(n,k) < 2^C(k,2). (4) erdos_diagonal_numeric supplies the elementary estimate that n ≤ 2^⌊k/2⌋ implies this for k ≥ 3, combining k!·C(n,k) ≤ n^k with the exponent comparison ⌊k/2⌋·k ≤ C(k,2)+⌊k/2⌋ and the factorial growth 2^(⌊k/2⌋+1) < k! (a clean induction).",
+    "keyInsights": [
+      "The probabilistic method here is pure counting. 'Expected number of monochromatic k-cliques < 1' is literally '#(bad colourings) < #(all colourings)', a statement about finite cardinalities. Replacing the random colouring by counting eliminates all measure theory and keeps the proof axiom-free.",
+      "The size of the edge set never matters. Working over E = Sym2 (Fin n) — which even includes harmless diagonal 'loops' — the factor 2^|E| appears on both sides of the union bound and cancels exactly, leaving the clean integer criterion 2·C(n,k) < 2^C(k,2). One never has to compute |E| = C(n,2).",
+      "The counting core is reusable. exists_avoiding_coloring is stated for an arbitrary finite edge type and an arbitrary family of forbidden monochromatic sets, so the same lemma proves lower bounds for Schur numbers, van der Waerden numbers, and other Ramsey-type problems — only the family `bad` changes.",
+      "The floor in 2^⌊k/2⌋ makes the numeric estimate uniform. For odd k the bound ⌊k/2⌋·k = C(k,2) is tight and the criterion holds with room k! > 2; for even k there is an extra factor 2^(k/2) absorbed by k! ≫ 2^(k/2+1). A single inequality 2^(⌊k/2⌋+1) < k! covers both parities."
+    ],
+    "prerequisites": [
+      "Ramsey numbers R(k,k) and the notion of a monochromatic clique",
+      "The probabilistic / first-moment method (Erdős 1947)",
+      "Binomial coefficients, factorials, and finite counting in Lean 4 Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "counting-core",
+      "title": "The abstract first-moment counting lemma",
+      "startLine": 42,
+      "endLine": 122,
+      "summary": "card_const_on counts colourings constant on a fixed edge set as 2^(|E|−|W|) via a piFinset bijection. exists_avoiding_coloring runs the union bound over an arbitrary family `bad`: if Σ 2·2^(|E|−|W|) < 2^|E| then a colouring non-constant on every W ∈ bad exists."
+    },
+    {
+      "id": "ramsey-specialisation",
+      "title": "Specialisation to K_n and the Erdős criterion",
+      "startLine": 124,
+      "endLine": 243,
+      "summary": "exists_good_coloring_sym2 instantiates E = Sym2 (Fin n), with `bad` the C(k,2)-element edge sets of the k-cliques; the |E|-factors cancel to the criterion 2·C(n,k) < 2^C(k,2). erdos_ramsey_criterion repackages this on symmetric, irreflexive Fin n → Fin n → Bool colourings: R(k,k) > n."
+    },
+    {
+      "id": "diagonal-bound",
+      "title": "The classical R(k,k) > 2^(k/2) bound",
+      "startLine": 244,
+      "endLine": 326,
+      "summary": "erdos_diagonal_numeric is the elementary ℕ estimate that n ≤ 2^⌊k/2⌋ implies 2·C(n,k) < 2^C(k,2) for k ≥ 3. erdos_probabilistic_lower_bound assembles the headline result, exactly matching the statement axiomatized in the parent RamseyR4kExtensions file, now with 0 axioms."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry gives an axiom-free, sorry-free formalization of Erdős's 1947 probabilistic lower bound R(k,k) > 2^⌊k/2⌋, de-axiomatizing erdos_probabilistic_lower_bound from the parent RamseyR4kExtensions file. The probabilistic method is realised as exact counting in the finite space of 2-colourings, so the whole proof — abstract union-bound lemma, Sym2 specialisation, and the elementary 2^(k/2) numeric estimate — is fully machine-checked with no measure theory and no assumptions.",
+    "implications": "The reusable lemma exists_avoiding_coloring isolates the combinatorial heart of the first-moment method and can be applied to other Ramsey-type lower bounds. The sharp criterion R(k,k) > n ⟸ 2·C(n,k) < 2^C(k,2) is available for direct use. The off-diagonal biased-coin bound R(4,k) ≥ c·k²/log k (which requires a non-uniform random colouring and real-valued expectations) remains open and is the natural next target."
+  },
+  "crossReferences": [
+    {
+      "targetId": "ramsey-r4k-extensions",
+      "relationship": "parent",
+      "description": "Stated erdos_probabilistic_lower_bound as an `axiom`; this entry proves that exact statement with 0 axioms"
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Existence of Ramsey numbers R(r,s); this entry provides the matching probabilistic lower bound for the diagonal case"
+    },
+    {
+      "targetId": "ramsey-r4k-oq-01",
+      "relationship": "related",
+      "description": "Sibling: off-diagonal R(4,k) = Θ(k³/(log k)^c) bounds (AKS upper, Mattheus-Verstraëte lower)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/ErdosRamseyLowerBound.lean",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "lineCount": 329,
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

De-axiomatizes `erdos_probabilistic_lower_bound` — the Erdős (1947) diagonal Ramsey lower bound and the **first application of the probabilistic method** — proving the exact statement previously declared as an `axiom` in `Proofs/RamseyR4kExtensions.lean`, now with **0 axioms**.

Answers gallery problem `ramsey-r4k-extensions-oq-01` (the probabilistic lower-bound side of R(4,k)). This entry settles the foundational symmetric/diagonal case; the off-diagonal biased-coin bound $R(4,k)\ge c\,k^2/\log k$ (needing a non-uniform random colouring and real expectations) remains open.

## Key idea — probabilistic method as exact counting

"Colour the edges of $K_n$ at random and show the expected number of monochromatic $k$-cliques is $<1$" is, in a finite space, literally "#(bad colourings) < #(all colourings)". Recasting as counting removes **all measure theory** and keeps the proof axiom-free.

## Results (`proofs/Proofs/ErdosRamseyLowerBound.lean`)

- `card_const_on` — exact count $2^{|E|-|W|}$ of Boolean colourings constant on a fixed edge set (clean `piFinset` bijection).
- `exists_avoiding_coloring` — **reusable** abstract first-moment / union-bound lemma over an arbitrary finite edge type: if $\sum_{W\in\mathrm{bad}} 2\cdot 2^{|E|-|W|} < 2^{|E|}$ then a colouring non-constant on every $W$ exists.
- `exists_good_coloring_sym2` / `erdos_ramsey_criterion` — specialise to $E=\mathrm{Sym2}(\mathrm{Fin}\,n)$; the $|E|$-factors cancel to the sharp criterion $2\binom{n}{k} < 2^{\binom{k}{2}} \Rightarrow R(k,k) > n$.
- `erdos_diagonal_numeric` — elementary ℕ estimate that $n \le 2^{\lfloor k/2\rfloor}$ ($k\ge 3$) implies the criterion.
- `erdos_probabilistic_lower_bound` — headline: $R(k,k) > 2^{\lfloor k/2\rfloor}$, matching the parent axiom's exact statement.

## Verification

- 329 lines, 6 theorems, 0 defs, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms erdos_probabilistic_lower_bound` → only `propext`, `Classical.choice`, `Quot.sound`.
- Compiles against pinned Mathlib v4.26 (`lake env lean`).
- Gallery annotations resolve cleanly (`annotations:build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)