### PR TITLE
Enrich The Leibniz–Lagrange Identity for a Triangle

### DIFF
--- a/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-07-oq-02-oq-01/annotations.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "ann-coordinate-free-setup",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 48
+    },
+    "type": "concept",
+    "title": "Coordinate-Free Setting: an Inner-Product Affine Space",
+    "content": "The whole development takes place over an abstract affine space: V is a real inner-product space and P is a NormedAddTorsor over V, so a, b, c, p, g are honest points, not coordinate tuples. The metric dist comes from the norm via dist x y = ‖x -ᵥ y‖, and `open scoped RealInnerProductSpace` brings the ⟪·,·⟫ notation into scope. Because nothing fixes a dimension or a basis, every identity proved below holds verbatim in the Euclidean plane, in 3-space, and in any (even infinite-dimensional) Euclidean affine space.",
+    "mathContext": "$V$ a real inner-product space, $P$ a $\\mathrm{NormedAddTorsor}$ over $V$; $\\operatorname{dist}(x,y)=\\lVert x -_v y\\rVert$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "inner-product affine space",
+      "NormedAddTorsor",
+      "coordinate-free geometry",
+      "affine torsor action -ᵥ / +ᵥ"
+    ],
+    "prerequisites": [
+      "InnerProductSpace",
+      "NormedAddTorsor",
+      "metric induced by a norm"
+    ]
+  },
+  {
+    "id": "ann-centroid-definition",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "Explicit Construction of the Centroid",
+    "content": "Rather than postulate a barycentre, the centroid is built by hand as g = ⅓·((b -ᵥ a) + (c -ᵥ a)) +ᵥ a, an honest point of P obtained by translating a along the averaged displacement to the other two vertices. Making the construction explicit (rather than invoking Finset.centroid) is what lets the later identities carry no side hypotheses: the balance property is then a computation, not an assumption. This g is exactly the point dividing each median in ratio 2 : 1.",
+    "mathContext": "$g = \\tfrac13\\big((b -_v a) + (c -_v a)\\big) +_v a$, equivalently $g = \\tfrac{1}{3}(a+b+c)$ in any affine chart.",
+    "significance": "key",
+    "relatedConcepts": [
+      "centroid / barycentre",
+      "median 2:1 ratio",
+      "affine combination"
+    ],
+    "prerequisites": [
+      "scalar action on vectors",
+      "torsor vadd +ᵥ"
+    ]
+  },
+  {
+    "id": "ann-centroid-balance",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "The Balance Property of the Centroid",
+    "content": "The defining feature of a barycentre: the displacement vectors from the three vertices to g sum to zero. After unfolding the definition and rewriting vsub_vadd / vsub_self, the goal is a purely linear identity in the free vector algebra, discharged by Mathlib's `module` tactic (a linear-arithmetic decision procedure for module expressions). This single equation is the engine that kills the cross term in the Leibniz identity.",
+    "mathContext": "$(a -_v g) + (b -_v g) + (c -_v g) = 0$, the vanishing first moment about the centroid.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "vanishing first moment",
+      "barycentric coordinates",
+      "module tactic"
+    ],
+    "prerequisites": [
+      "vsub_vadd_eq_vsub_sub",
+      "linear algebra over ℝ"
+    ]
+  },
+  {
+    "id": "ann-leibniz-identity",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "The Leibniz / Lagrange Identity (Abstract Form)",
+    "content": "The central result, stated for any point g whose vertex-displacements balance: the total squared distance from a moving point p to the three vertices splits into a p-dependent part 3·dist(p,g)² and a constant moment of inertia ∑ dist(g,vertex)². This is the affine generalisation of Apollonius's median theorem and the geometric form of the parallel-axis theorem. Phrasing it for an abstract balanced g (not just the explicit centroid) is what makes the n=3 case a clean specialisation and exposes the reusable mechanism.",
+    "mathContext": "$\\operatorname{dist}(p,a)^2 + \\operatorname{dist}(p,b)^2 + \\operatorname{dist}(p,c)^2 = 3\\,\\operatorname{dist}(p,g)^2 + \\sum_v \\operatorname{dist}(g,v)^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Leibniz / Lagrange identity",
+      "parallel-axis theorem",
+      "Apollonius median theorem",
+      "moment of inertia"
+    ],
+    "prerequisites": [
+      "centroid balance",
+      "squared-distance algebra"
+    ]
+  },
+  {
+    "id": "ann-polarisation-key",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 92
+    },
+    "type": "tactic",
+    "title": "Polarisation About the Centroid",
+    "content": "The only analytic input of the entire file. Each squared distance is rewritten via dist x y = ‖x -ᵥ y‖, the displacement is split as p -ᵥ x = (p -ᵥ g) + (g -ᵥ x) using vsub_add_vsub_cancel, and `norm_add_sq_real` expands ‖u+v‖² = ‖u‖² + 2⟪u,v⟫ + ‖v‖². This produces, for each vertex x, the term dist(p,g)² + 2⟪p -ᵥ g, g -ᵥ x⟫ + dist(g,x)² — collecting the three constant dist(p,g)² pieces gives the 3·dist(p,g)² of the statement.",
+    "mathContext": "$\\lVert u+v\\rVert^2 = \\lVert u\\rVert^2 + 2\\langle u,v\\rangle + \\lVert v\\rVert^2$ applied to $u = p -_v g,\\; v = g -_v x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polarisation identity",
+      "norm_add_sq_real",
+      "bilinearity of the inner product"
+    ],
+    "prerequisites": [
+      "dist_eq_norm_vsub",
+      "vsub_add_vsub_cancel"
+    ]
+  },
+  {
+    "id": "ann-cross-term-vanishes",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 93,
+      "endLine": 96
+    },
+    "type": "insight",
+    "title": "Why the Cross Term Disappears",
+    "content": "Summing the three polarised expansions, the cross terms collect into 2(⟪p -ᵥ g, g -ᵥ a⟫ + ⟪p -ᵥ g, g -ᵥ b⟫ + ⟪p -ᵥ g, g -ᵥ c⟫). By right-additivity of the inner product (inner_add_right) this is 2⟪p -ᵥ g, (g -ᵥ a)+(g -ᵥ b)+(g -ᵥ c)⟫, and the inner factor is exactly the centroid balance (with vertices as the second argument), hence zero. `linear_combination 2 * hcross` then closes the goal. This is the precise point at which 'g is the centroid' is used — no other property of g enters.",
+    "mathContext": "$2\\langle p -_v g,\\; (g -_v a)+(g -_v b)+(g -_v c)\\rangle = 2\\langle p -_v g, 0\\rangle = 0$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "linearity of the inner product",
+      "inner_add_right",
+      "linear_combination tactic"
+    ],
+    "prerequisites": [
+      "inner product bilinearity",
+      "centroid balance"
+    ]
+  },
+  {
+    "id": "ann-leibniz-centroid",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "Specialisation to the Triangle Centroid",
+    "content": "The abstract Leibniz identity is instantiated at g = centroid₃ a b c, with the balance hypothesis discharged automatically by centroid₃_balance. The proof term is a single application — no further tactic work — illustrating the payoff of separating the abstract mechanism (leibniz_identity) from the concrete centroid. This is the form directly usable for any moving point p in a concrete triangle.",
+    "mathContext": "$\\sum_v \\operatorname{dist}(p,v)^2 = 3\\,\\operatorname{dist}(p,g)^2 + \\sum_v \\operatorname{dist}(g,v)^2$ with $g = \\mathrm{centroid}_3(a,b,c)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialisation",
+      "centroid"
+    ],
+    "prerequisites": [
+      "leibniz_identity",
+      "centroid₃_balance"
+    ]
+  },
+  {
+    "id": "ann-centroid-moment-identity",
+    "proofId": "law-of-cosines-oq-07-oq-02-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 133
+    },
+    "type": "theorem",
+    "title": "The Centroid Moment Identity ∑ dist(g,v)² = ⅓·∑ side²",
+    "content": "Feeding leibniz_centroid at p = a, p = b, p = c gives three equations. On the left, the self-distance dist a a = 0 etc. drop out (zero_pow), and on the right the dist(p,g)² and ∑ dist(g,v)² appear. Adding the three relations and aligning atoms with the squared-distance symmetries (dist x y = dist y x) lets `linarith` solve a linear system whose conclusion is that the centroid's mean-square distance to the vertices is exactly ⅓ of the sum of squared side lengths — independent of the triangle's shape. Notably this recovers the centroid relation without ever invoking the 2:1 median ratio.",
+    "mathContext": "$\\operatorname{dist}(g,a)^2 + \\operatorname{dist}(g,b)^2 + \\operatorname{dist}(g,c)^2 = \\tfrac13\\big(\\operatorname{dist}(a,b)^2 + \\operatorname{dist}(b,c)^2 + \\operatorname{dist}(c,a)^2\\big)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "moment of inertia",
+      "side-length sum",
+      "dist_comm symmetry",
+      "linarith"
+    ],
+    "prerequisites": [
+      "leibniz_centroid",
+      "dist_self / zero_pow",
+      "linear arithmetic"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `law-of-cosines-oq-07-oq-02-oq-01` (quality 39, passes 0).

## Gap addressed
The entry shipped with a rich `meta.json` (overview, sections, conclusion, cross-references, references) but **no `annotations.json`** — the proof page had zero inline annotations.

## Added
`annotations.json` with **8 annotations** covering the full Lean file:
1. Coordinate-free setting (inner-product affine space / NormedAddTorsor)
2. Explicit centroid construction `centroid₃`
3. The centroid balance property (vanishing first moment)
4. The abstract Leibniz/Lagrange identity
5. Polarisation about the centroid (the sole analytic input, `norm_add_sq_real`)
6. Why the cross term vanishes (inner-product against the balance = 0)
7. Specialisation to the triangle centroid
8. The centroid moment identity ∑ dist(g,v)² = ⅓·∑ side²

Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Validation
All 8 annotation line-ranges validated against the Lean source via the annotations resolver — **0 misaligned**. `status`/`badge`/`axiomCount` in meta.json reviewed against the Lean file (verified / original / 0 axioms, only propext·Classical.choice·Quot.sound) — accurate, left unchanged.

(`index.ts` not added: obsolete under the phase-2 fetch-by-slug loader, issue #20993.)