### PR TITLE
Enrich Key Group Theory Lemma (transitive + transposition ⟹ S_p)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/annotations.json
@@ -1,10 +1,116 @@
 [
   {
-    "id": "key-group-lemma",
-    "startLine": 37,
-    "endLine": 78,
+    "id": "ann-statement",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04",
+    "range": {
+      "startLine": 33,
+      "endLine": 41
+    },
     "type": "theorem",
-    "title": "Key Group Theory Lemma",
-    "body": "For α with a prime number of elements, a transitive subgroup G ≤ S_α containing a transposition equals ⊤. Proof: transitivity + orbit–stabilizer give card α | |G|; Cauchy yields an element g of order card α; on a card-α set g is a full-support card-α-cycle (isCycle_of_prime_order, IsCycle.orderOf); with the transposition τ, closure_prime_cycle_swap gives ⟨g,τ⟩ = ⊤; since g,τ ∈ G, G = ⊤. This is the classical lemma the parent concrete-quintic entry documented but left unproven."
+    "title": "The Key Group Theory Lemma",
+    "content": "The single theorem of the file: if α has a prime number of elements and G ≤ S_α acts transitively (the `[IsPretransitive G α]` instance) and contains a transposition τ, then G is the whole symmetric group. The hypotheses are exactly the data available in a Galois-group computation — the action on the roots is transitive when the polynomial is irreducible, and a transposition appears when the discriminant analysis or a real-root count forces a complex-conjugation swap. This is the classical generation theorem the parent concrete-quintic entry stated in a comment but discharged only by ad-hoc Sylow case-elimination.",
+    "mathContext": "$G \\le S_\\alpha,\\ |\\alpha| = p$ prime, $G$ transitive, $\\tau \\in G$ a transposition $\\implies G = S_\\alpha$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "symmetric group",
+      "transitive permutation group",
+      "transposition",
+      "Galois group of a quintic"
+    ],
+    "prerequisites": [
+      "MulAction.IsPretransitive",
+      "Equiv.Perm",
+      "Subgroup ⊤"
+    ]
+  },
+  {
+    "id": "ann-orbit-stabilizer",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04",
+    "range": {
+      "startLine": 44,
+      "endLine": 53
+    },
+    "type": "technique",
+    "title": "Transitivity ⟹ p Divides |G|",
+    "content": "The first ingredient. Because the cardinality of α is a prime p ≥ 2, α is nonempty; pick a point a. Transitivity means the orbit of a is all of α, so |orbit a| = p. The orbit–stabilizer theorem (card_orbit_mul_card_stabilizer_eq_card_group) gives |orbit a|·|stab a| = |G|, hence p = |orbit a| divides |G|. This divisibility is what lets Cauchy's theorem produce an element of order exactly p in the next step.",
+    "mathContext": "$|G| = |G\\cdot a|\\cdot|G_a| = p\\cdot|G_a| \\implies p \\mid |G|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "orbit–stabilizer theorem",
+      "transitive action",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "MulAction.orbit_eq_univ",
+      "card_orbit_mul_card_stabilizer_eq_card_group"
+    ]
+  },
+  {
+    "id": "ann-cauchy",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04",
+    "range": {
+      "startLine": 54,
+      "endLine": 57
+    },
+    "type": "technique",
+    "title": "Cauchy's Theorem: an Element of Order p",
+    "content": "With p | |G| established, Cauchy's theorem (exists_prime_orderOf_dvd_card) yields an element g ∈ G whose order is exactly p. The cast lemma orderOf_coe transfers the order from the subgroup element to the underlying permutation, giving orderOf (g : Perm α) = p. Cauchy's theorem is the converse of Lagrange's divisibility for the prime case, and is precisely what is needed to manufacture a p-cycle out of nothing but the divisibility fact.",
+    "mathContext": "$p \\mid |G| \\implies \\exists\\, g \\in G,\\ \\operatorname{ord}(g) = p.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy's theorem",
+      "order of an element",
+      "Sylow theory"
+    ],
+    "prerequisites": [
+      "exists_prime_orderOf_dvd_card",
+      "orderOf_coe"
+    ]
+  },
+  {
+    "id": "ann-pcycle-full-support",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04",
+    "range": {
+      "startLine": 58,
+      "endLine": 68
+    },
+    "type": "insight",
+    "title": "An Order-p Permutation of a p-Set is a Full p-Cycle",
+    "content": "The crux that uses primality of p twice. A permutation whose order is the prime p must be a single cycle (isCycle_of_prime_order) — if it split into several disjoint cycles their lengths would all divide p, forcing a non-prime order or a fixed point. Then IsCycle.orderOf says the order of a cycle equals the cardinality of its support, so the support has exactly p elements; since the whole set α has p elements, the support is all of α (Finset.eq_univ_of_card). Thus g is a p-cycle moving every point — the strongest possible single permutation.",
+    "mathContext": "$\\operatorname{ord}(g) = p$ prime $\\implies g$ is a $p$-cycle, and $|\\operatorname{supp}(g)| = p = |\\alpha| \\implies \\operatorname{supp}(g) = \\alpha.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "cycle type",
+      "support of a permutation",
+      "disjoint cycle decomposition"
+    ],
+    "prerequisites": [
+      "isCycle_of_prime_order",
+      "IsCycle.orderOf",
+      "Finset.eq_univ_of_card"
+    ]
+  },
+  {
+    "id": "ann-generation",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-04",
+    "range": {
+      "startLine": 69,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "Generation: a p-Cycle and a Transposition Generate S_p",
+    "content": "The final ingredient and the conclusion. The classical fact that a p-cycle together with any transposition generates the full symmetric group when p is prime is supplied by Mathlib as closure_prime_cycle_swap — primality is essential, since for composite n a single n-cycle and a single transposition need not generate S_n. Applying it to the full-support p-cycle g and the given transposition τ shows ⟨g, τ⟩ = ⊤. Both generators lie in G (g by construction, τ by hypothesis), so ⊤ = closure{g,τ} ≤ G, forcing G = ⊤. The proof closes by the antisymmetry eq_top_iff together with closure_le and a two-case membership check.",
+    "mathContext": "$\\langle g, \\tau\\rangle = S_\\alpha$ and $g,\\tau \\in G \\implies S_\\alpha = \\langle g,\\tau\\rangle \\le G \\implies G = S_\\alpha.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "subgroup generation / closure",
+      "generators of the symmetric group",
+      "closure_prime_cycle_swap"
+    ],
+    "prerequisites": [
+      "Subgroup.closure_le",
+      "eq_top_iff",
+      "Equiv.Perm.closure_prime_cycle_swap"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-04/meta.json
@@ -59,6 +59,61 @@
     "definitionCount": 0,
     "theoremCount": 1
   },
+  "overview": {
+    "historicalContext": "The unsolvability of the general quintic — Abel's 1824 theorem, anticipated by Ruffini (1799) and recast by Galois — rests on exhibiting polynomials whose Galois group is not solvable. The cleanest concrete witnesses are quintics with Galois group the full symmetric group S_5, which is not solvable because its only nontrivial normal subgroup A_5 is simple. To certify that a quintic has Galois group S_5 one shows the group is a transitive subgroup of S_5 (irreducibility) that contains a transposition (typically from a single pair of complex-conjugate roots). The bridge from those two facts to 'the group is all of S_5' is a classical generation lemma — for prime degree p, a transitive subgroup of S_p containing a transposition is the whole of S_p — going back to the 19th-century study of permutation groups (Galois, Jordan, Serret). It is the prime-degree special case of Jordan's theorem that a primitive group containing a transposition is symmetric. The parent concrete-quintic entry Gal(x^5−4x+2) ≅ S_5 cited this lemma in a comment but sidestepped its proof with repetitive Sylow case-elimination; this entry supplies the general lemma directly.",
+    "problemStatement": "Let $\\alpha$ be a finite type whose cardinality $p = |\\alpha|$ is prime, and let $G \\le S_\\alpha = \\operatorname{Perm}(\\alpha)$ act transitively on $\\alpha$ and contain a transposition $\\tau$. Prove that $G = S_\\alpha$.",
+    "proofStrategy": "Four standard results are assembled. (1) Transitivity makes the orbit of any point all of $\\alpha$, so by orbit–stabilizer $p = |\\alpha|$ divides $|G|$. (2) Cauchy's theorem then produces $g \\in G$ of order exactly $p$. (3) Because $p$ is prime, an order-$p$ permutation of a $p$-element set is forced to be a single $p$-cycle (isCycle_of_prime_order), and since the order of a cycle equals its support size, the support is all of $\\alpha$ — $g$ is a full $p$-cycle. (4) A $p$-cycle together with any transposition generates $S_p$ for prime $p$ (closure_prime_cycle_swap), so $\\langle g, \\tau\\rangle = \\top$; as both generators lie in $G$, $\\top \\le G$ and hence $G = \\top$.",
+    "keyInsights": [
+      "Primality of the degree is used twice and is indispensable: it lets Cauchy extract an element of order exactly p, and it is the hypothesis under which a single p-cycle and one transposition already generate the whole symmetric group (false for composite n).",
+      "Transitivity is consumed purely through divisibility — orbit–stabilizer turns 'one orbit' into 'p ∣ |G|' — after which all the work is internal group theory, no further geometry of the action is needed.",
+      "An order-p permutation of a p-point set cannot be anything but a full p-cycle: any disjoint-cycle decomposition would give an order that is an lcm of smaller divisors of p, contradicting primality, so the support must be the entire set.",
+      "The proof is a pure assembly of existing Mathlib theorems (orbit–stabilizer, Cauchy, isCycle_of_prime_order, IsCycle.orderOf, closure_prime_cycle_swap) into the classical lemma, replacing the parent's bespoke Sylow case analysis with a single reusable statement.",
+      "This is exactly the prime-degree case of Jordan's theorem (a primitive group containing a transposition is symmetric); transitivity suffices because for prime degree every transitive action is automatically primitive."
+    ],
+    "prerequisites": [
+      "Group actions: orbits, stabilizers, transitivity (MulAction.IsPretransitive)",
+      "Orbit–stabilizer and Lagrange divisibility",
+      "Cauchy's theorem on elements of prime order",
+      "Symmetric groups: cycle type, support, generation by cycles and transpositions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement",
+      "title": "The Key Group Theory Lemma",
+      "startLine": 33,
+      "endLine": 41,
+      "summary": "Statement: for prime |α|, a transitive subgroup G ≤ S_α containing a transposition τ equals ⊤."
+    },
+    {
+      "id": "orbit-stabilizer",
+      "title": "Transitivity ⟹ p ∣ |G|",
+      "startLine": 44,
+      "endLine": 53,
+      "summary": "α is nonempty; transitivity gives |orbit a| = p, and orbit–stabilizer turns this into p ∣ |G|."
+    },
+    {
+      "id": "cauchy",
+      "title": "Cauchy: an Element of Order p",
+      "startLine": 54,
+      "endLine": 57,
+      "summary": "From p ∣ |G|, Cauchy's theorem yields g ∈ G with orderOf (g : Perm α) = p."
+    },
+    {
+      "id": "full-pcycle",
+      "title": "Order-p ⟹ Full p-Cycle",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "isCycle_of_prime_order makes g a cycle; IsCycle.orderOf forces its support to be all of α."
+    },
+    {
+      "id": "generation",
+      "title": "Generation and Conclusion",
+      "startLine": 69,
+      "endLine": 78,
+      "summary": "closure_prime_cycle_swap gives ⟨g,τ⟩ = ⊤; both generators lie in G, so G = ⊤."
+    }
+  ],
   "conclusion": {
     "summary": "A transitive subgroup G of S_p (p prime) containing a transposition is all of S_p. Transitivity forces p | |G| (orbit–stabilizer); Cauchy yields an element σ of order p, which on a p-element set is a full-support p-cycle; with the given transposition τ, closure_prime_cycle_swap gives ⟨σ,τ⟩ = ⊤; since σ,τ ∈ G, we get G = ⊤.",
     "significance": "This is the classical lemma (transitive + transposition ⟹ full symmetric, prime degree) that powers Galois-group computations such as Gal(x^5-4x+2) ≅ S_5. Formalizing it replaces the parent's ad-hoc Sylow case-elimination with the general result.",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-04` (quality 20, passes 0).

## Gaps addressed
- **annotations.json used the wrong schema** — top-level `startLine`/`endLine` and a `body` field, no `range`. The runtime loader (`normalizeAnnotations`) drops annotations without `range`/`lineNumber`, so the page showed **zero** annotations.
- **meta.json had no `overview`** (no historicalContext / problemStatement / proofStrategy / keyInsights).
- **meta.json had no `sections`.**

## Added / fixed
- Rewrote `annotations.json` into **5 staged annotations** with the correct schema (`range`, `content`, `proofId`, `type`, `significance`, `mathContext`, `relatedConcepts`, `prerequisites`): statement → orbit–stabilizer (p ∣ |G|) → Cauchy (order-p element) → full p-cycle → generation/conclusion.
- Added `meta.overview`: historical context (Abel–Ruffini, Galois, Jordan's theorem, the prime-degree special case), LaTeX problem statement, proof strategy, 5 key insights, prerequisites.
- Added `meta.sections` covering all five stages of the 80-line proof.

## Validation
All 5 annotation ranges validated against the Lean source via the annotations resolver — **0 misaligned**. Axiom integrity reviewed: `status: verified` / `badge: original` / `axiomCount: 0` accurate (assembles Mathlib lemmas; only propext·Classical.choice·Quot.sound). Left unchanged.