### PR TITLE
audit: 10 fresh research entries clean (abel-ruffini/amgm/euler-polyhedral/kepler/newton/prime-reciprocal/ramsey/schroder/schroeder-bernstein/stirling)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22871,6 +22871,66 @@
       "issues": [],
       "lastAudited": "2026-06-25T02:12:18Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:07Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-polyhedral-formula-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "kepler-conjecture-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "newton-inductive-step-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prime-reciprocal-divergence-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ramsey-r4k-extensions-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schroder-numbers-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schroeder-bernstein-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stirling-second-kind-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T02:32:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 10 remaining unaudited gallery entries (all claiming `verified`/`original`). **All 10 CLEAN** — public claims match the Lean kernel.

### Checks performed (per entry)
- Real sorry/admit count = 0 (flagged grep hits are all docstring prose)
- `axiom` declarations = 0; no assumption-carrying structure fields
- No `True` stubs
- `native_decide` = 0 → no `Lean.ofReduceBool`. The `decide` calls in euler-polyhedral / stirling / ramsey are kernel-reduction on `Decidable` instances (foundational axioms only).
- meta `sorries`/`axiomCount`/`status`/`badge` consistent with source
- All Lean files + meta dirs git-tracked (no phantoms)

### Notable framing checks
- **kepler-conjecture-oq-01** (topical high-risk): title scoped to *"Best-known packing densities in dimensions 4-23"* — does **not** claim the Kepler conjecture. Assumptions field exemplary (D₅/E₆/E₇ best-known not optimal; only E₈ a theorem; parent file axiomatizes 2D/3D separately). Clean.
- **abel-ruffini-oq-04-oq-01-oq-04** (heavy Mathlib reliance): badge `original` defensible — the result is a multi-step *assembly* (orbit-stabilizer ⟹ Cauchy ⟹ cycle structure ⟹ `closure_prime_cycle_swap`), not a verbatim Mathlib re-export, and every building block is disclosed in `assumptions`.

Entries: abel-ruffini-oq-04-oq-01-oq-04, amgm-inequality-oq-03-oq-01-oq-02, euler-polyhedral-formula-oq-01-oq-02-oq-01, kepler-conjecture-oq-01, newton-inductive-step-oq-01-oq-02, prime-reciprocal-divergence-oq-02, ramsey-r4k-extensions-oq-01, schroder-numbers-oq-01-oq-01-oq-02, schroeder-bernstein-oq-02-oq-01, stirling-second-kind-oq-01-oq-03.

Tracker-only change (`src/data/proofs/audit-tracker.json`, +60). Unaudited count: 10 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)