### PR TITLE
research(british-flag-theorem-oq-01-oq-03): Leibniz parallel-axis identity [verified, 0-axiom, original]

### DIFF
--- a/src/data/research/problems/british-flag-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/british-flag-theorem-oq-01-oq-03.json
@@ -1,0 +1,29 @@
+{
+  "id": "british-flag-theorem-oq-01-oq-03",
+  "slug": "british-flag-theorem-oq-01-oq-03",
+  "title": "The Leibniz Parallel-Axis Identity",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved the Leibniz/parallel-axis total-sum-of-squared-distances identity in an arbitrary real inner product space (general finite-family form), the three-vertex centroid case, and the centroid-minimizer corollaries. Verified, 0 sorries, 0 custom axioms.",
+    "insights": [
+      "The total sum ∑ ‖P − V_i‖² is the additive complement of the parent British-flag *alternating* sum: translating to the centroid isolates the entire observer dependence into the single term (card)·‖P − G‖².",
+      "The centroid is exactly the base point that kills the linear cross term ∑ 2⟪P − G, G − v i⟫, because ∑ (G − v i) = 0 is its defining property.",
+      "Stating the identity for an arbitrary finite index type in an abstract inner product space yields the planar triangle case, simplices in ℝⁿ, and arbitrary point clouds at once.",
+      "The nonnegative residual (card)·‖P − G‖² gives the centroid-minimizer property for free; nonemptiness + norm definiteness make the minimizer unique."
+    ],
+    "builtItems": [
+      "leibniz_parallel_axis_sum (Proofs/BritishFlagTheoremOQ0103.lean): general finite-family parallel-axis decomposition",
+      "leibniz_parallel_axis (Proofs/BritishFlagTheoremOQ0103.lean): three-vertex centroid identity with G = ⅓(A+B+C)",
+      "centroid_minimizes_sum_sq_dist + eq_centroid_of_sum_sq_dist_eq: centroid is the unique minimizer of the sum of squared distances",
+      "leibniz_parallel_axis_plane: specialization to EuclideanSpace ℝ (Fin 2)"
+    ],
+    "mathlibGaps": [
+      "Mathlib has norm_add_sq_real and inner_sum but no packaged 'parallel-axis / Leibniz centroid identity' lemma for finite point families; this entry supplies it."
+    ],
+    "nextSteps": [
+      "Weighted-centroid version (barycentric weights) underlying the variance/bias decomposition.",
+      "Link the three-vertex case to Stewart's theorem and the Apollonius median formula."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes open question `british-flag-theorem-oq-01-oq-03`. Where the British-Flag branch studies the **alternating** signed sum of squared distances (observer-independent), this leaf proves the **complementary total-sum** identity — the classical **Leibniz / parallel-axis** decomposition — in an arbitrary real inner product space.

For a finite family of points `v : ι → V` with centroid `G` (`∑ i, (v i − G) = 0`) and any observer `P`:

```
∑ i, ‖P − v i‖²  =  (∑ i, ‖G − v i‖²)  +  (card ι)·‖P − G‖²
```

The total sum, unlike the alternating sum, carries an exact P-dependence isolated into the single centroid term `(card)·‖P − G‖²`.

## Theorems (5, all verified)

- **`leibniz_parallel_axis_sum`** — general finite-family decomposition (MAIN)
- **`leibniz_parallel_axis`** — three-vertex case with `G = ⅓(A+B+C)`: `‖P−A‖²+‖P−B‖²+‖P−C‖² = (‖G−A‖²+‖G−B‖²+‖G−C‖²)+3‖P−G‖²`
- **`centroid_minimizes_sum_sq_dist`** — the centroid minimizes the total sum of squared distances
- **`eq_centroid_of_sum_sq_dist_eq`** — for a nonempty family, that minimizer is unique
- **`leibniz_parallel_axis_plane`** — specialization to `EuclideanSpace ℝ (Fin 2)`

## Proof strategy

Translate to the centroid: `P − v i = (P − G) + (G − v i)`, expand with `norm_add_sq_real`, sum. The constant term gives `(card)·‖P−G‖²`, the squared term gives `∑ ‖G − v i‖²`, and the linear cross term `2⟪P − G, ∑ (G − v i)⟫` vanishes because `∑ (G − v i) = 0` (the defining centroid property). The minimizer corollaries follow from `positivity` on the nonnegative residual.

## Verification

- Builds clean against Mathlib v4.26 (`lake env lean`, exit 0).
- `#print axioms` for all 5 theorems reports **only** `propext, Classical.choice, Quot.sound` — 0 custom axioms, 0 sorries.
- 138 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)