### PR TITLE
research(frobenius-oq-01-oq-02-oq-02): explicit imperfect field 𝔽ₚ(X) — Frobenius not surjective

### DIFF
--- a/proofs/Proofs/FrobeniusEndomorphismOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ01OQ02OQ02.lean
@@ -1,0 +1,138 @@
+/-
+  An explicit imperfect ring (and field): Frobenius is not surjective on 𝔽ₚ[X].
+
+  The grandparent thread (`FrobeniusEndomorphism…`) established that over a
+  commutative ring of prime characteristic `p` the Frobenius `x ↦ x ^ p` is a
+  ring homomorphism, and the parent (`FrobeniusEndomorphismOQ01OQ02`) showed
+  that on a *finite* field the Frobenius is an automorphism — finite fields are
+  *perfect*.  The parent's second open question asks us to sharpen the
+  perfect-field dichotomy from the other side:
+
+      **Exhibit an explicit imperfect field where Frobenius fails to be
+      surjective.**
+
+  This file answers that verbatim with the simplest possible witness.
+
+  * In the polynomial ring `𝔽ₚ[X]` the Frobenius is still *injective* (it is a
+    domain, hence reduced, so `frobenius_inj` applies), but it is *not
+    surjective*: the indeterminate `X` has no `p`-th root.  Indeed if `f ^ p = X`
+    then comparing `natDegree` gives `p · deg f = 1`, forcing `p ∣ 1`,
+    impossible for a prime `p ≥ 2`.  So `𝔽ₚ[X]` is an explicit imperfect ring
+    (`¬ PerfectRing`).
+
+  * Passing to the fraction field `𝔽ₚ(X) = RatFunc (ZMod p)`, the same `X` still
+    has no `p`-th root — now the obstruction is the *integer* degree
+    `intDegree`, which is multiplicative on nonzero elements, so `f ^ p = X`
+    would give `p · intDegree f = 1` in `ℤ`.  Hence `𝔽ₚ(X)` is an explicit
+    imperfect *field* (`¬ PerfectField`), the sharp counterpoint to the
+    finite-field case.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.  Built from the
+  Mathlib results `frobenius_inj`, `Polynomial.natDegree_pow`,
+  `RatFunc.intDegree_mul`, `surjective_frobenius`, and
+  `PerfectField.toPerfectRing`.
+-/
+import Mathlib
+
+namespace FrobeniusEndomorphismOQ01OQ02OQ02
+
+open Polynomial Function
+
+variable (p : ℕ) [Fact p.Prime]
+
+/-! ### Part 1: the polynomial ring `𝔽ₚ[X]` is an explicit imperfect ring -/
+
+/-- The Frobenius `x ↦ xᵖ` is **injective** on `𝔽ₚ[X]`: the polynomial ring over
+a field is a domain, hence reduced, and Frobenius is injective on any reduced
+ring of characteristic `p`. -/
+theorem frobenius_injective_polynomial :
+    Injective (frobenius (ZMod p)[X] p) :=
+  frobenius_inj (ZMod p)[X] p
+
+/-- The indeterminate `X` has **no `p`-th root** in `𝔽ₚ[X]`: a degree obstruction.
+If `f ^ p = X` then `p · natDegree f = 1`, so `p ∣ 1`, impossible for `p` prime. -/
+theorem X_isNotPthPower : ¬ ∃ f : (ZMod p)[X], f ^ p = X := by
+  rintro ⟨f, hf⟩
+  have hpp : p.Prime := Fact.out
+  have hdeg : (f ^ p).natDegree = (X : (ZMod p)[X]).natDegree := by rw [hf]
+  rw [natDegree_pow, natDegree_X] at hdeg
+  -- hdeg : p * f.natDegree = 1
+  have hpdvd : p ∣ 1 := ⟨f.natDegree, hdeg.symm⟩
+  have hp1 : p = 1 := Nat.dvd_one.mp hpdvd
+  exact hpp.one_lt.ne' hp1
+
+/-- Therefore the Frobenius is **not surjective** on `𝔽ₚ[X]`: `X` is not in its
+image. -/
+theorem frobenius_not_surjective_polynomial :
+    ¬ Surjective (frobenius (ZMod p)[X] p) := by
+  intro hsurj
+  obtain ⟨f, hf⟩ := hsurj X
+  rw [frobenius_def] at hf
+  exact X_isNotPthPower p ⟨f, hf⟩
+
+/-- `𝔽ₚ[X]` is an **explicit imperfect ring**: the Frobenius is not bijective
+(it fails surjectivity). -/
+theorem not_perfectRing_polynomial :
+    ¬ PerfectRing (ZMod p)[X] p := by
+  intro h
+  haveI := h
+  exact frobenius_not_surjective_polynomial p (surjective_frobenius _ p)
+
+/-! ### Part 2: the rational function field `𝔽ₚ(X)` is an explicit imperfect field -/
+
+/-- The integer degree `intDegree` is multiplicative under powers of a nonzero
+rational function: `intDegree (rⁿ) = n · intDegree r`. -/
+theorem intDegree_pow (r : RatFunc (ZMod p)) (hr : r ≠ 0) (n : ℕ) :
+    (r ^ n).intDegree = (n : ℤ) * r.intDegree := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, RatFunc.intDegree_mul (pow_ne_zero k hr) hr, ih]
+      push_cast
+      ring
+
+/-- The indeterminate `X` has **no `p`-th root** in the rational function field
+`𝔽ₚ(X)`.  Now the obstruction lives in `ℤ`: `f ^ p = X` would give
+`p · intDegree f = 1`, forcing `(p : ℤ) ∣ 1`, impossible for a prime `p`. -/
+theorem ratfunc_X_isNotPthPower :
+    ¬ ∃ r : RatFunc (ZMod p), r ^ p = RatFunc.X := by
+  rintro ⟨r, hr⟩
+  have hpp : p.Prime := Fact.out
+  -- `X ≠ 0`, via its degree.
+  have hX : (RatFunc.X : RatFunc (ZMod p)) ≠ 0 := by
+    intro h
+    have hd := RatFunc.intDegree_X (K := ZMod p)
+    rw [h, RatFunc.intDegree_zero] at hd
+    exact absurd hd (by norm_num)
+  -- hence `r ≠ 0`.
+  have hr0 : r ≠ 0 := by
+    rintro rfl
+    rw [zero_pow (show p ≠ 0 by exact hpp.ne_zero)] at hr
+    exact hX hr.symm
+  have hdeg : (r ^ p).intDegree = (RatFunc.X : RatFunc (ZMod p)).intDegree := by rw [hr]
+  rw [intDegree_pow p r hr0, RatFunc.intDegree_X] at hdeg
+  -- hdeg : (p : ℤ) * r.intDegree = 1
+  have hpdvd : (p : ℤ) ∣ 1 := ⟨r.intDegree, hdeg.symm⟩
+  have hle : (p : ℤ) ≤ 1 := Int.le_of_dvd one_pos hpdvd
+  have : 2 ≤ p := hpp.two_le
+  omega
+
+/-- Therefore the Frobenius is **not surjective** on `𝔽ₚ(X)`. -/
+theorem frobenius_not_surjective_ratfunc :
+    ¬ Surjective (frobenius (RatFunc (ZMod p)) p) := by
+  intro hsurj
+  obtain ⟨r, hr⟩ := hsurj RatFunc.X
+  rw [frobenius_def] at hr
+  exact ratfunc_X_isNotPthPower p ⟨r, hr⟩
+
+/-- **The main result.** `𝔽ₚ(X)` is an explicit *imperfect field*: it is not a
+`PerfectField`.  This is the sharp counterpoint to the finite-field case, where
+every field is perfect. -/
+theorem not_perfectField_ratfunc :
+    ¬ PerfectField (RatFunc (ZMod p)) := by
+  intro h
+  haveI := h
+  haveI : PerfectRing (RatFunc (ZMod p)) p := PerfectField.toPerfectRing p
+  exact frobenius_not_surjective_ratfunc p (surjective_frobenius _ p)
+
+end FrobeniusEndomorphismOQ01OQ02OQ02

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "The Other Side of the Perfect-Field Dichotomy",
+    "content": "A field is perfect when its Frobenius x ↦ x^p is surjective; every finite field is perfect. The parent entry characterized the fixed field of the Frobenius on a perfect field. This file answers the parent's open question from the opposite direction: it exhibits the simplest explicit IMPERFECT field, 𝔽ₚ(X), where the Frobenius misses the indeterminate X. The polynomial ring 𝔽ₚ[X] is the imperfect-ring stepping stone. In both settings the Frobenius stays injective (the rings are reduced) but loses surjectivity, the property that finiteness — not characteristic — forced on finite fields.",
+    "mathContext": "Perfect ⇔ Frobenius surjective. Finite fields are perfect; $\\mathbb{F}_p(X)$ is not.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Frobenius endomorphism",
+      "perfect and imperfect fields",
+      "separability",
+      "function fields"
+    ],
+    "prerequisites": [
+      "characteristic p",
+      "the Frobenius map x ↦ x^p"
+    ]
+  },
+  {
+    "id": "ann-polynomial-ring",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+    "range": { "startLine": 46, "endLine": 88 },
+    "type": "technique",
+    "title": "𝔽ₚ[X] Is an Imperfect Ring: a Degree Obstruction",
+    "content": "On the polynomial ring (ZMod p)[X] — a domain, hence reduced — the Frobenius is injective by Mathlib's frobenius_inj. It is not surjective because X has no p-th root: if f^p = X, then Polynomial.natDegree_pow gives p · natDegree f = natDegree X = 1, so p ∣ 1, contradicting p ≥ 2. Reading this through frobenius_def shows the Frobenius misses X, and a PerfectRing would force it surjective, so 𝔽ₚ[X] is an explicit imperfect ring.",
+    "mathContext": "$f^p = X \\Rightarrow p\\cdot\\deg f = 1 \\Rightarrow p \\mid 1$, impossible.",
+    "significance": "high",
+    "relatedConcepts": [
+      "reduced rings",
+      "polynomial degree",
+      "PerfectRing"
+    ],
+    "prerequisites": [
+      "natDegree of a power over a domain",
+      "frobenius injectivity on reduced rings"
+    ]
+  },
+  {
+    "id": "ann-intdegree",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 104 },
+    "type": "technique",
+    "title": "Lifting Degree to the Function Field via intDegree",
+    "content": "In the fraction field 𝔽ₚ(X) = RatFunc (ZMod p) the degree becomes ℤ-valued (numerator degree minus denominator degree). The lemma intDegree_pow shows it is multiplicative under powers of a nonzero element, intDegree (r^n) = n · intDegree r, by a short induction on the exponent using RatFunc.intDegree_mul. This is exactly the tool that lets the polynomial-ring obstruction carry over to the field.",
+    "mathContext": "$\\operatorname{intDegree}(r^n) = n\\cdot\\operatorname{intDegree}(r)$ for $r \\neq 0$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "rational function field",
+      "integer degree (valuation)",
+      "multiplicativity"
+    ],
+    "prerequisites": [
+      "RatFunc.intDegree_mul",
+      "induction on exponents"
+    ]
+  },
+  {
+    "id": "ann-imperfect-field",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+    "range": { "startLine": 105, "endLine": 138 },
+    "type": "concept",
+    "title": "𝔽ₚ(X) Is an Explicit Imperfect Field",
+    "content": "The same X has no p-th root in the field: f^p = X would give (p : ℤ) · intDegree f = intDegree X = 1, so (p : ℤ) ∣ 1, impossible for a prime. Hence the Frobenius is not surjective on 𝔽ₚ(X). Since a PerfectField is, through the PerfectField.toPerfectRing instance, a PerfectRing on which the Frobenius is surjective, 𝔽ₚ(X) cannot be a PerfectField. This is the headline result and the sharp counterpoint to the finite-field case, where every field is perfect.",
+    "mathContext": "$\\neg\\, \\mathrm{PerfectField}\\,\\mathbb{F}_p(X)$ — the simplest imperfect field.",
+    "significance": "central",
+    "relatedConcepts": [
+      "PerfectField",
+      "imperfect fields",
+      "Frobenius surjectivity"
+    ],
+    "prerequisites": [
+      "PerfectField ⇒ PerfectRing",
+      "surjective_frobenius"
+    ]
+  }
+]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+  "slug": "frobenius-endomorphism-oq-01-oq-02-oq-02",
+  "title": "An Explicit Imperfect Field: Frobenius Is Not Surjective on 𝔽ₚ(X)",
+  "description": "Answers the parent's open question by exhibiting the simplest explicit imperfect field. In the polynomial ring 𝔽ₚ[X] the Frobenius x ↦ x^p is injective (a domain is reduced, frobenius_inj) but not surjective: the indeterminate X has no p-th root, because f^p = X would force p · natDegree f = 1, hence p ∣ 1, impossible for a prime. So 𝔽ₚ[X] is an explicit imperfect ring (¬ PerfectRing). Passing to the fraction field 𝔽ₚ(X) = RatFunc (ZMod p), the same X has no p-th root — now the obstruction is the integer degree intDegree, which is multiplicative on nonzero elements, so f^p = X gives (p : ℤ) · intDegree f = 1. Hence 𝔽ₚ(X) is an explicit imperfect FIELD (¬ PerfectField), the sharp counterpoint to the finite-field case where every field is perfect. 8 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "Perfection is the dividing line of characteristic-p field theory: a field is perfect when its Frobenius x ↦ x^p is surjective (equivalently bijective), which is exactly the condition that every algebraic extension is separable. Every finite field is perfect (an injective self-map of a finite set is surjective), and so is every field of characteristic zero. The parent entry characterized the fixed field of the Frobenius on a perfect field as the prime subfield. The natural sharpening — and the content here — is the other side of the dichotomy: the simplest explicit field that is NOT perfect. The function field 𝔽ₚ(X) is the textbook example, with the transcendental X playing the role of the element with no p-th root. These imperfect function fields are the local models for inseparability phenomena in arithmetic geometry over function fields.",
+    "problemStatement": "**Open Question (OQ-02 of frobenius-endomorphism-oq-01-oq-02)**: Exhibit an explicit imperfect field (e.g. 𝔽ₚ(t)) where the Frobenius fails to be surjective, sharpening the perfect-field dichotomy.\n\n**Formalized**: frobenius_injective_polynomial (Frobenius injective on 𝔽ₚ[X]), X_isNotPthPower (X has no p-th root in 𝔽ₚ[X], degree obstruction), frobenius_not_surjective_polynomial and not_perfectRing_polynomial (𝔽ₚ[X] is an imperfect ring), intDegree_pow (intDegree is multiplicative under powers of a nonzero rational function), ratfunc_X_isNotPthPower (X has no p-th root in 𝔽ₚ(X), integer-degree obstruction), frobenius_not_surjective_ratfunc, and the headline not_perfectField_ratfunc (𝔽ₚ(X) is an explicit imperfect field).",
+    "text": "A 138-line formalization answering the parent's second open question. Two parallel obstructions, each a one-line degree comparison. Part 1 works in the polynomial ring 𝔽ₚ[X] = (ZMod p)[X]: it is a domain, hence reduced, so Mathlib's frobenius_inj gives injectivity (frobenius_injective_polynomial). Surjectivity fails because X has no p-th root (X_isNotPthPower): if f^p = X then Polynomial.natDegree_pow gives p · natDegree f = natDegree X = 1, so p ∣ 1, contradicting p ≥ 2. Reading this through frobenius_def yields frobenius_not_surjective_polynomial, and feeding the surjectivity that a PerfectRing would supply (surjective_frobenius) into the contradiction yields not_perfectRing_polynomial: 𝔽ₚ[X] is an explicit imperfect ring. Part 2 lifts the obstruction to the fraction field 𝔽ₚ(X) = RatFunc (ZMod p). The degree obstruction is now valued in ℤ via RatFunc.intDegree. A short induction (intDegree_pow) shows intDegree (r^n) = n · intDegree r for r ≠ 0, using RatFunc.intDegree_mul. Then f^p = X forces (p : ℤ) · intDegree f = intDegree X = 1, so (p : ℤ) ∣ 1, impossible (ratfunc_X_isNotPthPower). Hence the Frobenius is not surjective on the field (frobenius_not_surjective_ratfunc), and since a PerfectField would, through the PerfectField.toPerfectRing instance, make the Frobenius surjective, 𝔽ₚ(X) cannot be a PerfectField (not_perfectField_ratfunc). All 8 theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**Injectivity (Part 1)**: frobenius_injective_polynomial is exactly Mathlib's frobenius_inj applied to (ZMod p)[X], which is a domain (ZMod p is a field), hence IsReduced; the CharP and ExpChar instances on the polynomial ring are supplied automatically (Polynomial.charP, expChar_prime).\n\n**No p-th root of X in 𝔽ₚ[X]**: X_isNotPthPower assumes f^p = X, compares natDegree via Polynomial.natDegree_pow (exact equality over a domain) and natDegree_X, obtaining p * natDegree f = 1; this exhibits p ∣ 1, so Nat.dvd_one forces p = 1, contradicting hpp.one_lt.\n\n**Imperfect ring**: frobenius_not_surjective_polynomial specializes surjectivity at X and rewrites frobenius_def to land in X_isNotPthPower. not_perfectRing_polynomial assumes PerfectRing, extracts surjective_frobenius, and applies the previous theorem.\n\n**intDegree is multiplicative on powers**: intDegree_pow inducts on the exponent; the successor step rewrites pow_succ and RatFunc.intDegree_mul (pow_ne_zero k hr) hr, then closes with push_cast; ring.\n\n**No p-th root of X in 𝔽ₚ(X)**: ratfunc_X_isNotPthPower first shows X ≠ 0 (its intDegree is 1 ≠ 0) and hence r ≠ 0, then compares intDegree via intDegree_pow and RatFunc.intDegree_X to get (p : ℤ) * intDegree r = 1; Int.le_of_dvd one_pos on (p : ℤ) ∣ 1 gives (p : ℤ) ≤ 1, contradicting p ≥ 2 by omega.\n\n**Imperfect field**: not_perfectField_ratfunc assumes PerfectField (RatFunc (ZMod p)), uses the instance PerfectField.toPerfectRing to obtain PerfectRing, and contradicts frobenius_not_surjective_ratfunc via surjective_frobenius.",
+    "keyInsights": [
+      "**One transcendental kills surjectivity**: the entire failure of perfection is concentrated in the single element X. It is not in the image of x ↦ x^p for a degree reason, and that is all it takes for the field to be imperfect.",
+      "**Same obstruction, two valuations**: over the ring 𝔽ₚ[X] the witness is the ℕ-valued natDegree (p · deg f = 1 ⇒ p ∣ 1); over the field 𝔽ₚ(X) it is the ℤ-valued intDegree (p · intDegree f = 1 ⇒ p ∣ 1 in ℤ). The polynomial-degree argument lifts verbatim to the function field once degree is allowed to go negative.",
+      "**Injective but not surjective**: in the infinite setting the Frobenius remains injective (every reduced characteristic-p ring) yet loses surjectivity. This is precisely what fails on a finite field, where injective forces surjective — the finiteness, not the characteristic, is what made finite fields perfect.",
+      "**Perfection is exactly surjectivity of Frobenius**: the proof that 𝔽ₚ(X) is not a PerfectField routes through PerfectField.toPerfectRing and surjective_frobenius — a PerfectField would make x ↦ x^p surjective, and X witnesses that it is not. The abstract definition (every irreducible polynomial separable) and the concrete one (Frobenius surjective) coincide.",
+      "**0-axiom, no decide**: the obstruction is a pure degree inequality, so the whole file rests only on Lean's foundational propext / Classical.choice / Quot.sound — no native_decide, no kernel decide."
+    ],
+    "prerequisites": [
+      "The Frobenius ring homomorphism x ↦ x^p and its injectivity on reduced characteristic-p rings (Mathlib frobenius, frobenius_inj)",
+      "Polynomial degree and its behaviour under products and powers over a domain (Polynomial.natDegree_pow, natDegree_X)",
+      "The rational function field RatFunc K and its integer degree intDegree, multiplicative on nonzero elements (RatFunc.intDegree_mul, RatFunc.intDegree_X)",
+      "Perfect rings and perfect fields: PerfectRing / PerfectField, surjective_frobenius, and the PerfectField → PerfectRing instance",
+      "Characteristic and exponential characteristic instances for polynomial and rational function fields (Polynomial.charP, RatFunc CharP, expChar_prime)"
+    ]
+  },
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_field",
+    "date": "Ferdinand Georg Frobenius (late 19th century); perfect/imperfect fields (Steinitz, 1910)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "characteristic-p",
+      "frobenius",
+      "perfect-fields",
+      "function-fields",
+      "separability",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 8 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide and no kernel decide are used, so no Lean.ofReduceBool is introduced.",
+    "originalContributions": [
+      "Original synthesis: Mathlib supplies the building blocks (frobenius_inj, Polynomial.natDegree_pow, RatFunc.intDegree_mul/intDegree_X, surjective_frobenius, PerfectField.toPerfectRing) but does not record that 𝔽ₚ[X] / 𝔽ₚ(X) are explicit imperfect ring/field witnesses; this file assembles that statement and its proof.",
+      "frobenius_injective_polynomial: the Frobenius x ↦ x^p is injective on 𝔽ₚ[X] (the polynomial ring over a field is a domain, hence reduced)",
+      "X_isNotPthPower: the indeterminate X has no p-th root in 𝔽ₚ[X] — the degree obstruction p · natDegree f = 1 ⇒ p ∣ 1",
+      "frobenius_not_surjective_polynomial: the Frobenius is not surjective on 𝔽ₚ[X], with X as the explicit missed value",
+      "not_perfectRing_polynomial: 𝔽ₚ[X] is an explicit imperfect ring (¬ PerfectRing)",
+      "intDegree_pow: the integer degree of a power, intDegree (r^n) = n · intDegree r for r ≠ 0 in RatFunc (ZMod p)",
+      "ratfunc_X_isNotPthPower: X has no p-th root in the function field 𝔽ₚ(X) — the ℤ-valued obstruction (p : ℤ) · intDegree f = 1 ⇒ (p : ℤ) ∣ 1",
+      "frobenius_not_surjective_ratfunc: the Frobenius is not surjective on 𝔽ₚ(X)",
+      "not_perfectField_ratfunc: 𝔽ₚ(X) is an explicit imperfect field (¬ PerfectField) — the headline, the sharp counterpoint to the finite-field case"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "frobenius_inj",
+        "description": "On a reduced commutative ring of characteristic p the Frobenius x ↦ x^p is injective. Applied to the domain (ZMod p)[X] to give frobenius_injective_polynomial.",
+        "module": "Mathlib.Algebra.CharP.Reduced"
+      },
+      {
+        "theorem": "Polynomial.natDegree_pow",
+        "description": "Over a domain, natDegree (p^n) = n * natDegree p. The exact-degree identity behind X_isNotPthPower.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Domain"
+      },
+      {
+        "theorem": "RatFunc.intDegree_mul",
+        "description": "For nonzero x, y in RatFunc K, intDegree (x*y) = intDegree x + intDegree y. The multiplicativity used to prove intDegree_pow.",
+        "module": "Mathlib.FieldTheory.RatFunc.Degree"
+      },
+      {
+        "theorem": "RatFunc.intDegree_X",
+        "description": "intDegree (X : RatFunc K) = 1. The right-hand side of the function-field degree obstruction.",
+        "module": "Mathlib.FieldTheory.RatFunc.Degree"
+      },
+      {
+        "theorem": "surjective_frobenius",
+        "description": "On a perfect ring/field the Frobenius is surjective. Used to derive the contradiction in not_perfectRing_polynomial and not_perfectField_ratfunc.",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "PerfectField.toPerfectRing",
+        "description": "A perfect field of characteristic p is a perfect ring (instance). Lets not_perfectField_ratfunc reduce the field statement to the surjectivity of the Frobenius.",
+        "module": "Mathlib.FieldTheory.Perfect"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 138,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ01OQ02OQ02",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/FrobeniusEndomorphismOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "mainTheorems": 8,
+  "sections": 2,
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The parent characterizes the fixed field of the Frobenius as the prime subfield 𝔽ₚ and records that on a perfect field (every finite field) the Frobenius is bijective. This entry answers the parent's second open question from the other side of the dichotomy: it exhibits an explicit imperfect field 𝔽ₚ(X) where the Frobenius fails to be surjective, with the polynomial ring 𝔽ₚ[X] as the imperfect-ring stepping stone."
+    }
+  ],
+  "references": [
+    {
+      "text": "Perfect field — a field on which the Frobenius is surjective (hence bijective); 𝔽ₚ(t) is the standard example of an imperfect field, since t has no p-th root.",
+      "url": "https://en.wikipedia.org/wiki/Perfect_field"
+    },
+    {
+      "text": "Frobenius endomorphism — the p-power map in characteristic p; injective on any reduced ring but surjective only on perfect rings/fields.",
+      "url": "https://en.wikipedia.org/wiki/Frobenius_endomorphism"
+    },
+    {
+      "text": "Mathlib4: frobenius_inj (Algebra/CharP/Reduced.lean), Polynomial.natDegree_pow (Algebra/Polynomial/Degree/Domain.lean), RatFunc.intDegree_mul / intDegree_X (FieldTheory/RatFunc/Degree.lean), surjective_frobenius and PerfectField.toPerfectRing (FieldTheory/Perfect.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question **OQ-02** of `frobenius-endomorphism-oq-01-oq-02` *verbatim*: **exhibit an explicit imperfect field where the Frobenius fails to be surjective**, sharpening the perfect-field dichotomy.

The parent characterized the fixed field of the Frobenius on a *perfect* field (every finite field). This entry gives the other side: the simplest explicit **imperfect** field, `𝔽ₚ(X)`, with the polynomial ring `𝔽ₚ[X]` as the imperfect-ring stepping stone.

### Part 1 — `𝔽ₚ[X]` is an imperfect ring
- `frobenius_injective_polynomial`: Frobenius `x ↦ xᵖ` is **injective** (the polynomial ring over a field is a domain, hence reduced; `frobenius_inj`).
- `X_isNotPthPower`: `X` has **no `p`-th root** — if `f^p = X` then `Polynomial.natDegree_pow` gives `p · natDegree f = 1`, so `p ∣ 1`, impossible for a prime.
- `frobenius_not_surjective_polynomial`, `not_perfectRing_polynomial`: hence `¬ PerfectRing`.

### Part 2 — `𝔽ₚ(X) = RatFunc (ZMod p)` is an imperfect field
- `intDegree_pow`: the integer degree is multiplicative under powers of a nonzero element (`intDegree (rⁿ) = n · intDegree r`), by induction via `RatFunc.intDegree_mul`.
- `ratfunc_X_isNotPthPower`: same obstruction lifted to `ℤ` — `f^p = X` forces `(p : ℤ) · intDegree f = 1`, so `(p : ℤ) ∣ 1`, impossible.
- `frobenius_not_surjective_ratfunc`, **`not_perfectField_ratfunc`**: the headline — `𝔽ₚ(X)` is an explicit **imperfect field** (`¬ PerfectField`), via `PerfectField.toPerfectRing` + `surjective_frobenius`.

### Verification
- **8 theorems, 0 definitions, 138 lines, 0 sorries.**
- `#print axioms` on all main results: only `[propext, Classical.choice, Quot.sound]` — **0 axioms**, no `native_decide`, no kernel `decide`.
- Status: **verified**, badge **original**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)