### PR TITLE
Enrich Simple quotient ⇔ maximal normal subgroup (IsMaxNorm/IsSimpleGroup bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/annotations.json
@@ -1,34 +1,136 @@
 [
   {
-    "id": "is-maximal-normal",
-    "startLine": 47,
-    "endLine": 48,
+    "id": "ann-ismaximalnormal-def",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 48
+    },
     "type": "definition",
-    "title": "Maximal normal subgroup",
-    "body": "IsMaximalNormal N: N is normal, proper (N ≠ ⊤), and not strictly contained in any proper normal subgroup. This is the K = ⊤ instance of the parent entry's combinatorial IsMaxNorm predicate."
+    "title": "The Maximal-Normal Predicate",
+    "content": "IsMaximalNormal N bundles three conditions: N is normal, N is proper (N ≠ ⊤), and N is maximal among proper normal subgroups — any normal M with N ≤ M is either N itself or all of G. This is the K = ⊤ instance of the parent entry's combinatorial IsMaxNorm predicate. Phrasing maximality as a ∀-quantified disjunction (M = N ∨ M = ⊤) is exactly what makes it line up, under the correspondence theorem, with the quotient G ⧸ N having no nontrivial normal subgroups — i.e. being simple.",
+    "mathContext": "$\\mathrm{IsMaximalNormal}(N) :\\Leftrightarrow N \\lhd G \\wedge N \\ne G \\wedge \\big(\\forall M \\lhd G,\\ N \\le M \\Rightarrow M = N \\vee M = G\\big).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal normal subgroup",
+      "normal subgroup lattice",
+      "composition series"
+    ],
+    "prerequisites": [
+      "Subgroup.Normal",
+      "subgroup order ≤ / ⊤"
+    ]
   },
   {
-    "id": "simple-quotient-iff",
-    "startLine": 55,
-    "endLine": 102,
+    "id": "ann-main-equivalence",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 57
+    },
     "type": "theorem",
-    "title": "Simple quotient ⇔ maximal normal",
-    "body": "IsSimpleGroup (G ⧸ N) ↔ N is proper and maximal among proper normal subgroups. Forward: push a normal M ⊇ N into the quotient (must be ⊥ or ⊤ by simplicity, giving M = N or M = ⊤, via comap_map_mk'). Reverse: pull a normal subgroup of G ⧸ N back through mk' (normal, contains N, so = N or ⊤), then transfer via injectivity of the correspondence map comapMk'OrderIso. The bridge the parent only asserted."
+    "title": "Simple Quotient ⇔ Maximal Normal Subgroup",
+    "content": "The central bridge: for a normal N ◁ G, the quotient G ⧸ N is a simple group exactly when N is proper and maximal among proper normal subgroups. This is the IsMaxNorm ↔ IsSimpleGroup correspondence the parent Jordan–Hölder entry asserted (\"by the correspondence theorem\") but never proved. It is the fact that lets a composition series be described interchangeably as a maximal chain of normal subgroups or as a chain with simple successive quotients — the foundation of the Jordan–Hölder theorem and hence of the Abel–Ruffini solvability criterion.",
+    "mathContext": "$\\mathrm{IsSimpleGroup}(G/N) \\iff N \\ne G \\wedge \\big(\\forall M \\lhd G,\\ N \\le M \\Rightarrow M = N \\vee M = G\\big).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "simple group",
+      "Jordan–Hölder theorem",
+      "composition factors",
+      "correspondence theorem"
+    ],
+    "prerequisites": [
+      "IsSimpleGroup",
+      "quotient group G ⧸ N",
+      "isSimpleGroup_iff"
+    ]
   },
   {
-    "id": "packaged-iff",
-    "startLine": 105,
-    "endLine": 108,
-    "type": "theorem",
-    "title": "Packaged with IsMaximalNormal",
-    "body": "isSimpleGroup_quotient_iff_isMaximalNormal: the same equivalence stated with the IsMaximalNormal predicate, folding in the ambient normality hypothesis."
+    "id": "ann-forward-direction",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "Forward: Pushing M into the Quotient",
+    "content": "Assuming G ⧸ N is simple, to show N is maximal take a normal M ⊇ N and map it into the quotient via mk'. Its image map(mk' N) M is a normal subgroup of the simple group G ⧸ N, hence ⊥ or ⊤. Pulling back with comap and using comap_map_mk' (which gives comap(mk')(map(mk') M) = N ⊔ M = M, since N ≤ M) converts these to M = N (image ⊥, via ker_mk' = N) or M = ⊤ (image ⊤). So N admits no proper normal subgroup strictly above it.",
+    "mathContext": "$\\mathrm{map}(\\pi)\\,M \\in \\{\\bot,\\top\\}$, and $\\mathrm{comap}(\\pi)(\\mathrm{map}(\\pi)\\,M) = N \\sqcup M = M \\Rightarrow M = N \\text{ or } M = G.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "image of a subgroup under a quotient map",
+      "comap_map_mk'",
+      "kernel of mk'"
+    ],
+    "prerequisites": [
+      "Subgroup.map / comap",
+      "QuotientGroup.mk'",
+      "ker_mk'"
+    ]
   },
   {
-    "id": "directions",
-    "startLine": 111,
-    "endLine": 119,
+    "id": "ann-reverse-direction",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 102
+    },
+    "type": "technique",
+    "title": "Reverse: Injectivity of the Correspondence Map",
+    "content": "Assuming N is maximal, to show G ⧸ N is simple take any normal H' ≤ G ⧸ N and pull it back to comap(mk') H', which contains N (le_comap_mk') and is normal, so by maximality equals N or ⊤. To turn this into a statement about H' itself, the proof invokes the fourth isomorphism theorem as an order isomorphism comapMk'OrderIso between subgroups of G ⧸ N and subgroups of G containing N. Since comap is injective on that range, matching comap H' with comap ⊥ = N (or comap ⊤ = ⊤) forces H' = ⊥ (or H' = ⊤). Nontriviality of G ⧸ N comes from N ≠ ⊤.",
+    "mathContext": "Correspondence iso $\\{H' \\le G/N\\} \\cong \\{H : N \\le H \\le G\\}$; injectivity of $\\mathrm{comap}(\\pi)$ on this range sends $\\mathrm{comap}\\,H' \\in \\{N,\\top\\}$ back to $H' \\in \\{\\bot,\\top\\}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "fourth isomorphism theorem",
+      "lattice correspondence",
+      "order isomorphism injectivity",
+      "comapMk'OrderIso"
+    ],
+    "prerequisites": [
+      "QuotientGroup.comapMk'OrderIso",
+      "le_comap_mk'",
+      "RelIso injectivity"
+    ]
+  },
+  {
+    "id": "ann-packaged",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 108
+    },
     "type": "theorem",
-    "title": "Both directions as lemmas",
-    "body": "IsMaximalNormal.isSimpleGroup_quotient (maximal normal ⟹ simple quotient) and .of_isSimpleGroup_quotient (simple quotient ⟹ maximal normal), reusable in composition-series arguments."
+    "title": "Packaged with the IsMaximalNormal Predicate",
+    "content": "Re-states the equivalence in the clean form IsSimpleGroup (G ⧸ N) ↔ IsMaximalNormal N, folding the ambient normality instance [hN : N.Normal] back into the predicate. This is the directly reusable statement: it matches the named predicate exactly and so plugs into composition-series and Jordan–Hölder developments without unpacking the raw maximality conjunction.",
+    "mathContext": "$\\mathrm{IsSimpleGroup}(G/N) \\iff \\mathrm{IsMaximalNormal}(N).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "predicate packaging",
+      "Jordan–Hölder lattice"
+    ],
+    "prerequisites": [
+      "isSimpleGroup_quotient_iff",
+      "Subgroup.Normal instance"
+    ]
+  },
+  {
+    "id": "ann-two-directions",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-01",
+    "range": {
+      "startLine": 110,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "The Two Directions as Standalone Lemmas",
+    "content": "IsMaximalNormal.isSimpleGroup_quotient (maximal normal ⟹ simple quotient) and IsMaximalNormal.of_isSimpleGroup_quotient (simple quotient ⟹ maximal normal) expose each implication of the equivalence as a dot-notation lemma. Splitting them out is the ergonomic move for downstream use: composition-series arguments typically need just one direction at a time, and the forward lemma even carries the normality instance through the `haveI := h.1` so a bare IsMaximalNormal hypothesis suffices.",
+    "mathContext": "$\\mathrm{IsMaximalNormal}(N) \\Rightarrow \\mathrm{IsSimpleGroup}(G/N)$ and conversely.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dot-notation lemmas",
+      "instance threading"
+    ],
+    "prerequisites": [
+      "isSimpleGroup_quotient_iff_isMaximalNormal"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-01/meta.json
@@ -56,6 +56,54 @@
     "definitionCount": 1,
     "theoremCount": 4
   },
+  "overview": {
+    "historicalContext": "The Jordan–Hölder theorem (Camille Jordan, 1870; Otto Hölder, 1889) states that any two composition series of a finite group have the same length and, up to permutation and isomorphism, the same simple composition factors. It underlies the modern proof of the Abel–Ruffini theorem: a polynomial is solvable by radicals iff its Galois group is solvable, and solvability is detected by the composition factors all being abelian (equivalently cyclic of prime order). A composition series is a maximal chain of normal subgroups, and the link between 'maximal step' and 'simple quotient' is the correspondence (fourth isomorphism) theorem: normal subgroups of G containing N correspond bijectively, preserving order, to normal subgroups of G ⧸ N. Mathlib models composition series abstractly through a JordanHolderLattice typeclass; open question oq-01 of the parent entry asks whether Subgroup G can be made an instance, the obstacle being to relate the parent's combinatorial IsMaxNorm predicate to IsSimpleGroup of the quotient. This entry proves precisely that equivalence in the case K = ⊤.",
+    "problemStatement": "Let $G$ be a group and $N \\lhd G$ a normal subgroup. Prove that the quotient group $G/N$ is simple if and only if $N$ is a proper, maximal normal subgroup of $G$ — i.e. $N \\ne G$ and every normal subgroup $M$ with $N \\le M$ satisfies $M = N$ or $M = G$.",
+    "proofStrategy": "Unfold IsSimpleGroup via isSimpleGroup_iff (nontrivial + no proper nontrivial normal subgroup) and prove both directions through the canonical projection π = mk' N. Forward (simple ⟹ maximal): a normal M ⊇ N maps to a normal subgroup of the simple G/N, hence ⊥ or ⊤; comap_map_mk' rewrites the pullback as N ⊔ M = M, yielding M = N or M = ⊤. Reverse (maximal ⟹ simple): a normal H' ≤ G/N pulls back to comap π H' ⊇ N, normal, so = N or ⊤ by maximality; the order isomorphism comapMk'OrderIso (the correspondence theorem) is injective, so transferring comap π H' = N (= comap ⊥) or = ⊤ (= comap ⊤) forces H' = ⊥ or ⊤. Nontriviality of G/N follows from N ≠ ⊤. The result is then packaged with the IsMaximalNormal predicate and split into two dot-notation lemmas.",
+    "keyInsights": [
+      "The correspondence (fourth isomorphism) theorem is the entire engine: it turns the lattice of normal subgroups of G ⧸ N into the interval of normal subgroups of G between N and G, so 'no proper nontrivial normal subgroup of the quotient' becomes 'no proper normal subgroup strictly between N and G'.",
+      "Routing through Mathlib's comapMk'OrderIso, rather than re-deriving the lattice correspondence by hand, is what keeps the proof short and robust — its injectivity does the work of identifying pulled-back subgroups with their quotient originals.",
+      "comap_map_mk' (comap ∘ map = N ⊔ ·) is the precise lemma that lets the forward direction recover M from its image: because N ≤ M the join collapses to M, so the dichotomy on the image transfers cleanly to M.",
+      "Restricting to K = ⊤ (a genuine quotient G ⧸ N rather than the subtype quotient ↥K ⧸ H.subgroupOf K) sidesteps exactly the 'quotient typeclass issues' the open question flags, isolating the mathematical content of the IsMaxNorm ↔ IsSimpleGroup bridge.",
+      "Splitting the equivalence into named one-directional lemmas mirrors how composition-series arguments consume it — usually one implication at a time — and threads the normality instance so a bare IsMaximalNormal hypothesis is enough."
+    ],
+    "prerequisites": [
+      "Normal subgroups, quotient groups, and the canonical projection mk'",
+      "Simple groups and IsSimpleGroup / isSimpleGroup_iff",
+      "The correspondence (fourth isomorphism) theorem and Subgroup.map / comap",
+      "Composition series and the Jordan–Hölder theorem (motivation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "predicate",
+      "title": "The Maximal-Normal Predicate",
+      "startLine": 44,
+      "endLine": 48,
+      "summary": "IsMaximalNormal N: normal, proper, and maximal among proper normal subgroups — the K = ⊤ instance of the parent's IsMaxNorm."
+    },
+    {
+      "id": "main-equivalence",
+      "title": "Simple Quotient ⇔ Maximal Normal",
+      "startLine": 50,
+      "endLine": 102,
+      "summary": "IsSimpleGroup (G ⧸ N) ↔ N maximal normal; forward pushes M into the quotient (comap_map_mk'), reverse pulls back via injectivity of comapMk'OrderIso."
+    },
+    {
+      "id": "packaged",
+      "title": "Packaged with IsMaximalNormal",
+      "startLine": 104,
+      "endLine": 108,
+      "summary": "The same equivalence stated with the IsMaximalNormal predicate, folding in the ambient normality instance."
+    },
+    {
+      "id": "directions",
+      "title": "The Two Directions as Lemmas",
+      "startLine": 110,
+      "endLine": 119,
+      "summary": "isSimpleGroup_quotient and of_isSimpleGroup_quotient: each implication as a reusable dot-notation lemma."
+    }
+  ],
   "conclusion": {
     "summary": "The combinatorial maximality predicate IsMaxNorm and the categorical simplicity predicate IsSimpleGroup of the quotient are equivalent, for K = ⊤: G ⧸ N is simple iff N is a maximal normal subgroup. The forward direction pushes a normal M ⊇ N into the quotient (it must be ⊥ or ⊤, giving M = N or M = ⊤); the reverse pulls a normal subgroup of G ⧸ N back through mk' and uses injectivity of the correspondence map. This is the bridge the parent entry asserted but did not prove.",
     "implications": [


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-04-oq-01` (quality 35, passes 0).

## Gaps addressed
- **annotations.json used the wrong schema** — top-level `startLine`/`endLine` + a `body` field, no `range`. The runtime loader drops annotations without `range`, so the page showed **zero** annotations.
- **meta.json had no `overview`** and **no `sections`**.

## Added / fixed
- Rewrote `annotations.json` into **6 annotations** with the correct schema (`range`, `content`, `proofId`, `type`, `significance`, `mathContext`, `relatedConcepts`, `prerequisites`): the IsMaximalNormal predicate, the main equivalence, the forward direction (push M into the quotient via `comap_map_mk'`), the reverse direction (injectivity of `comapMk'OrderIso`), the packaged predicate form, and the two standalone direction lemmas.
- Added `meta.overview`: Jordan–Hölder / Abel–Ruffini historical context, LaTeX problem statement, proof strategy, 5 key insights, prerequisites.
- Added `meta.sections` covering all four parts of the 121-line proof.

## Validation
All 6 annotation ranges validated against the Lean source via the annotations resolver — **0 misaligned**. Axiom integrity reviewed: `status: verified` / `badge: original` / `axiomCount: 0` accurate (assembles Mathlib correspondence-theorem lemmas; only propext·Classical.choice·Quot.sound). Left unchanged.