### PR TITLE
research(euler-criterion-squares-oq-01-oq-03): second supplement — 2 is a QR mod p iff p≡±1 (mod 8) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/EulerCriterionSquaresOQ01OQ03.lean
+++ b/proofs/Proofs/EulerCriterionSquaresOQ01OQ03.lean
@@ -1,0 +1,190 @@
+/-
+# Euler's Criterion OQ-01-OQ-03: The Second Supplement — `2` is a QR mod `p` iff `p ≡ ±1 (mod 8)`
+
+The parent leaf `euler-criterion-squares-oq-01` (`EulerCriterionSquaresOQ01.lean`) proves
+**Euler's criterion**: for an odd prime `p` and `a ≠ 0` in `ZMod p`,
+
+  `IsSquare a  ⟺  a^((p−1)/2) = 1`,   and dually   `¬ IsSquare a  ⟺  a^((p−1)/2) = −1`.
+
+That criterion is universal but does not tell you, for a *fixed* `a`, which primes `p` make
+`a` a square. This leaf carries out that computation for the smallest interesting case `a = 2`,
+the classical **second supplementary law of quadratic reciprocity**:
+
+  `IsSquare (2 : ZMod p)  ⟺  p ≡ 1 (mod 8) ∨ p ≡ 7 (mod 8)`,
+
+with the complementary non-residue characterisation `p ≡ 3 (mod 8) ∨ p ≡ 5 (mod 8)`, and the
+explicit **Euler-criterion bridge** linking the parent's exponential test to the mod-8 sign:
+
+  `(2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8)`.
+
+## What this proves
+
+* `isSquare_two_iff`            — `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7`.
+* `not_isSquare_two_iff`        — `¬ IsSquare (2 : ZMod p) ↔ p % 8 = 3 ∨ p % 8 = 5`.
+* `legendreSym_two_eq_chi8`     — `legendreSym p 2 = χ₈ p`.
+* `legendreSym_two_eq_neg_one_pow` — `legendreSym p 2 = (−1)^((p²−1)/8)`.
+* `two_pow_half_eq_neg_one_pow` — the bridge `(2)^((p−1)/2) = (−1)^((p²−1)/8)` in `ZMod p`.
+* `isSquare_two_iff_legendreSym` — residuacity ⟺ symbol value, `IsSquare 2 ↔ legendreSym p 2 = 1`.
+* Concrete corollaries: `2` is a residue mod `7, 17, 23` and a non-residue mod `5, 11, 13`.
+
+## Method
+
+The headline equivalence `isSquare_two_iff` is Mathlib's `ZMod.exists_sq_eq_two_iff`, restated
+for the parent's odd-prime convention `[Fact (2 < p)]`. The non-residue complement is the
+exhaustive case split `p % 8 ∈ {1,3,5,7}` (`p` odd) against the residue classes.
+
+The mathematically substantive piece — distinct from the sibling Jacobi leaf, which states the
+sign formula but has *no* residuacity interpretation — is the bridge back to the parent's
+Euler-criterion exponential `2^((p−1)/2)`. Combining Mathlib's `legendreSym.eq_pow`
+(`(legendreSym p 2 : ZMod p) = 2^(p/2)`), `legendreSym.at_two` (`legendreSym p 2 = χ₈ p`), and
+the elementary closed form `χ₈ p = (−1)^((p²−1)/8)` (a mod-8 case analysis, reproved here since
+Mathlib supplies only the χ₄ analogue) yields the second supplement in its Gauss-sum exponent
+form and exhibits `±1 = (−1)^((p²−1)/8)` as exactly the value of Euler's exponential test at `2`.
+
+All results are machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide` (concrete checks
+use `decide`).
+-/
+import Mathlib
+
+open ZMod
+
+namespace EulerCriterionSquaresOQ01OQ03
+
+variable (p : ℕ) [Fact p.Prime] [Fact (2 < p)]
+
+omit [Fact p.Prime] in
+/-- An odd prime is not `2`. -/
+theorem ne_two : p ≠ 2 := by have : 2 < p := Fact.out; omega
+
+/-- An odd prime is odd. -/
+theorem p_mod_two : p % 2 = 1 :=
+  (Fact.out : p.Prime).eq_two_or_odd.resolve_left (by have := (Fact.out : 2 < p); omega)
+
+/-- For an odd prime, `p / 2 = (p − 1) / 2` — the exponent in Euler's criterion. -/
+theorem half_eq : p / 2 = (p - 1) / 2 := by have := p_mod_two p; omega
+
+/-- An odd prime lies in one of the four reduced residue classes mod `8`. -/
+theorem mod_eight_cases : p % 8 = 1 ∨ p % 8 = 3 ∨ p % 8 = 5 ∨ p % 8 = 7 := by
+  have := p_mod_two p; omega
+
+/-! ## The residue / non-residue characterisation -/
+
+/-- **Second supplementary law.** `2` is a quadratic residue mod an odd prime `p` iff
+`p ≡ 1` or `7 (mod 8)`. This is Mathlib's `ZMod.exists_sq_eq_two_iff`, restated for the parent's
+odd-prime convention. -/
+theorem isSquare_two_iff : IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+  ZMod.exists_sq_eq_two_iff (ne_two p)
+
+/-- **Non-residue complement.** `2` is a quadratic *non*-residue mod an odd prime `p` iff
+`p ≡ 3` or `5 (mod 8)`. The complement of `isSquare_two_iff` across the four odd classes. -/
+theorem not_isSquare_two_iff : ¬ IsSquare (2 : ZMod p) ↔ p % 8 = 3 ∨ p % 8 = 5 := by
+  rw [isSquare_two_iff]
+  have := mod_eight_cases p
+  omega
+
+/-! ## The Legendre symbol at `2` and the `(−1)^((p²−1)/8)` exponent -/
+
+/-- The arithmetic heart of the second supplement: for odd `n`, `χ₈ n = (−1)^((n²−1)/8)`.
+
+Mathlib provides the χ₄ analogue (`ZMod.χ₄_eq_neg_one_pow`) but no power-of-`(−1)` form for χ₈.
+Proof by case analysis on `n mod 8`: writing `n = 8k + r` with `r ∈ {1,3,5,7}`, the quotient
+`(n²−1)/8` is `2·(…)` when `r ∈ {1,7}` (sign `+1`) and `2·(…)+1` when `r ∈ {3,5}` (sign `−1`). -/
+theorem chi8_eq_neg_one_pow {n : ℕ} (hn : n % 2 = 1) :
+    χ₈ (n : ZMod 8) = (-1 : ℤ) ^ ((n ^ 2 - 1) / 8) := by
+  rw [χ₈_nat_eq_if_mod_eight, if_neg (by omega : ¬ n % 2 = 0)]
+  obtain ⟨k, hk⟩ : ∃ k, n = 8 * k + n % 8 := ⟨n / 8, by omega⟩
+  have hr : n % 8 = 1 ∨ n % 8 = 3 ∨ n % 8 = 5 ∨ n % 8 = 7 := by omega
+  rcases hr with hr | hr | hr | hr <;> rw [hr] at hk <;> subst hk
+  · rw [if_pos (by omega)]
+    have hX : ((8 * k + 1) ^ 2 - 1) / 8 = 2 * (4 * k ^ 2 + k) := by
+      have h : (8 * k + 1) ^ 2 = 8 * (2 * (4 * k ^ 2 + k)) + 1 := by ring
+      omega
+    rw [hX, pow_mul, neg_one_sq, one_pow]
+  · rw [if_neg (by omega)]
+    have hX : ((8 * k + 3) ^ 2 - 1) / 8 = 2 * (4 * k ^ 2 + 3 * k) + 1 := by
+      have h : (8 * k + 3) ^ 2 = 8 * (2 * (4 * k ^ 2 + 3 * k) + 1) + 1 := by ring
+      omega
+    rw [hX, pow_succ, pow_mul, neg_one_sq, one_pow, one_mul]
+  · rw [if_neg (by omega)]
+    have hX : ((8 * k + 5) ^ 2 - 1) / 8 = 2 * (4 * k ^ 2 + 5 * k + 1) + 1 := by
+      have h : (8 * k + 5) ^ 2 = 8 * (2 * (4 * k ^ 2 + 5 * k + 1) + 1) + 1 := by ring
+      omega
+    rw [hX, pow_succ, pow_mul, neg_one_sq, one_pow, one_mul]
+  · rw [if_pos (by omega)]
+    have hX : ((8 * k + 7) ^ 2 - 1) / 8 = 2 * (4 * k ^ 2 + 7 * k + 3) := by
+      have h : (8 * k + 7) ^ 2 = 8 * (2 * (4 * k ^ 2 + 7 * k + 3)) + 1 := by ring
+      omega
+    rw [hX, pow_mul, neg_one_sq, one_pow]
+
+/-- **Legendre symbol at `2`.** `legendreSym p 2 = χ₈ p` (Mathlib's `legendreSym.at_two`). -/
+theorem legendreSym_two_eq_chi8 : legendreSym p 2 = χ₈ p :=
+  legendreSym.at_two (ne_two p)
+
+/-- **Second supplement, exponent form.** `legendreSym p 2 = (−1)^((p²−1)/8)`. -/
+theorem legendreSym_two_eq_neg_one_pow :
+    legendreSym p 2 = (-1 : ℤ) ^ ((p ^ 2 - 1) / 8) := by
+  rw [legendreSym_two_eq_chi8 p, chi8_eq_neg_one_pow (p_mod_two p)]
+
+/-! ## The Euler-criterion bridge -/
+
+/-- The parent's Euler-criterion exponential equals the Legendre symbol as an element of
+`ZMod p`: `(2 : ZMod p)^((p−1)/2) = (legendreSym p 2 : ZMod p)`. Mathlib's `legendreSym.eq_pow`
+gives the `p/2` form; `half_eq` rewrites the exponent to `(p−1)/2`. -/
+theorem two_pow_half_eq_legendreSym :
+    (2 : ZMod p) ^ ((p - 1) / 2) = ((legendreSym p 2 : ℤ) : ZMod p) := by
+  rw [← half_eq p, legendreSym.eq_pow p 2]
+  norm_cast
+
+/-- **The Euler-criterion bridge.** Euler's exponential test at `2` is the mod-8 Gauss-sum sign:
+
+  `(2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8)`.
+
+This is the piece that connects the parent's universal criterion `a^((p−1)/2)` to the concrete
+`p mod 8` statement — the residue/non-residue dichotomy for `2` is read off from the right-hand
+sign being `+1` (for `p ≡ ±1`) or `−1` (for `p ≡ ±3`). -/
+theorem two_pow_half_eq_neg_one_pow :
+    (2 : ZMod p) ^ ((p - 1) / 2) = (-1 : ZMod p) ^ ((p ^ 2 - 1) / 8) := by
+  rw [two_pow_half_eq_legendreSym p, legendreSym_two_eq_neg_one_pow p]
+  push_cast
+  ring
+
+/-! ## Residuacity ⟺ symbol value (the prime-only feature) -/
+
+/-- `(2 : ZMod p) ≠ 0` for an odd prime `p`. -/
+theorem two_ne_zero : (2 : ZMod p) ≠ 0 := by
+  have h2 : ((2 : ℕ) : ZMod p) ≠ 0 := by
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    intro hdvd
+    have := Nat.le_of_dvd (by norm_num) hdvd
+    have : 2 < p := Fact.out
+    omega
+  simpa using h2
+
+/-- **Residuacity is symbol value `+1`.** For the *prime* modulus, `2` is a quadratic residue iff
+`legendreSym p 2 = 1`. (This equivalence is what fails for composite Jacobi moduli, where the
+sibling leaf can state the sign formula but not the residue interpretation.) -/
+theorem isSquare_two_iff_legendreSym : IsSquare (2 : ZMod p) ↔ legendreSym p 2 = 1 := by
+  rw [legendreSym.eq_one_iff p (by exact_mod_cast two_ne_zero p)]
+  norm_num
+
+/-! ## Concrete checks (decide, no native_decide) -/
+
+/-- `2` is a quadratic residue mod `7` (`p ≡ 7 (mod 8)`), witnessed by `3² = 2`. -/
+theorem isSquare_two_mod_seven : IsSquare (2 : ZMod 7) := ⟨3, by decide⟩
+
+/-- `2` is a quadratic residue mod `17` (`p ≡ 1 (mod 8)`), witnessed by `6² = 36 = 2`. -/
+theorem isSquare_two_mod_seventeen : IsSquare (2 : ZMod 17) := ⟨6, by decide⟩
+
+/-- `2` is a quadratic residue mod `23` (`p ≡ 7 (mod 8)`), witnessed by `5² = 25 = 2`. -/
+theorem isSquare_two_mod_twentythree : IsSquare (2 : ZMod 23) := ⟨5, by decide⟩
+
+/-- `2` is a quadratic non-residue mod `5` (`p ≡ 5 (mod 8)`). -/
+theorem not_isSquare_two_mod_five : ¬ IsSquare (2 : ZMod 5) := by decide
+
+/-- `2` is a quadratic non-residue mod `11` (`p ≡ 3 (mod 8)`). -/
+theorem not_isSquare_two_mod_eleven : ¬ IsSquare (2 : ZMod 11) := by decide
+
+/-- `2` is a quadratic non-residue mod `13` (`p ≡ 5 (mod 8)`). -/
+theorem not_isSquare_two_mod_thirteen : ¬ IsSquare (2 : ZMod 13) := by decide
+
+end EulerCriterionSquaresOQ01OQ03

--- a/research/problems/euler-criterion-squares-oq-01-oq-03/problem.md
+++ b/research/problems/euler-criterion-squares-oq-01-oq-03/problem.md
@@ -1,0 +1,73 @@
+# Problem: The Second Supplement — 2 is a Quadratic Residue mod p iff p ≡ ±1 (mod 8)
+
+**Slug**: euler-criterion-squares-oq-01-oq-03
+**Created**: 2026-06-24
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+Let $p$ be an odd prime. Then $2$ is a quadratic residue modulo $p$ if and only if $p \equiv \pm 1 \pmod 8$:
+
+$$
+\exists\, x \in \mathbb{Z}/p\mathbb{Z},\ x^2 = 2
+\quad\Longleftrightarrow\quad
+p \equiv 1 \pmod 8 \ \lor\ p \equiv 7 \pmod 8.
+$$
+
+Equivalently, in terms of Euler's criterion and the Legendre symbol,
+
+$$
+\left(\frac{2}{p}\right) \equiv 2^{(p-1)/2} \equiv (-1)^{(p^2-1)/8} \pmod p,
+$$
+
+so that $2$ is a residue exactly when $(p^2-1)/8$ is even, i.e. when $p \equiv \pm 1 \pmod 8$.
+
+### Plain Language
+
+The parent entry proves Euler's criterion: a nonzero residue $a$ is a perfect square modulo an odd prime $p$ exactly when $a^{(p-1)/2} \equiv 1 \pmod p$. That criterion is universal but it does not by itself tell you, for a *specific* number $a$, which primes $p$ make $a$ a square. This leaf carries out that computation for the smallest interesting case, $a = 2$: it asks to prove the classical "second supplementary law" of quadratic reciprocity, namely that $2$ is a square mod $p$ precisely when $p$ leaves remainder $1$ or $7$ when divided by $8$ (and is a non-residue when the remainder is $3$ or $5$). For example $2$ is a square mod $7$ ($4^2 = 16 \equiv 2$) and mod $17$, but not mod $5$ or mod $11$.
+
+### Why This Matters
+
+The two supplementary laws — the value of $(-1/p)$ governed by $p \bmod 4$ and the value of $(2/p)$ governed by $p \bmod 8$ — are, alongside the main reciprocity law, the complete toolkit for evaluating Legendre symbols by hand. Pinning the $a=2$ case down as a clean residue-class criterion turns Euler's abstract exponentiation test into a concrete, decidable congruence condition, and gives downstream entries (Gauss sums, reciprocity algorithms, primality of Mersenne-style numbers, and quadratic-form representability) a directly reusable lemma. It also showcases the bridge from the parent's $a^{(p-1)/2}$ formulation to a $p \bmod 8$ statement that needs no exponentiation at all.
+
+## Known Results
+
+### What's Already Proven
+
+- Parent `euler-criterion-squares-oq-01` (verified): Euler's criterion $a^{(p-1)/2} \equiv \pm 1$ characterizing quadratic residues.
+- Sibling `euler-criterion-squares-oq-01-oq-01`: exactly $(p-1)/2$ nonzero quadratic residues mod an odd prime.
+- Mathlib: `ZMod.exists_sq_eq_two_iff` states exactly this — for `[Fact p.Prime]` and `p ≠ 2`, `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7`. Supporting API: `ZMod.exists_sq_eq_prime_iff_of_mod_four_eq_one/_three`, `legendreSym`, `ZMod.euler_criterion`, `Nat.Prime` facts, and the cyclic structure of `(ZMod p)ˣ`.
+- Classical: the second supplement, provable via Gauss's lemma counting sign changes of $\{2, 4, \dots, p-1\}$ reduced into $(-p/2, p/2)$, or via the Gauss-sum / $(-1)^{(p^2-1)/8}$ identity.
+
+### What's Still Open
+
+- A self-contained gallery Lean theorem packaging `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7` for odd primes, together with the equivalent non-residue characterization (`p % 8 = 3 ∨ p % 8 = 5`).
+- The explicit bridge from the parent's Euler-criterion form $2^{(p-1)/2} \equiv (-1)^{(p^2-1)/8}$ to the $p \bmod 8$ statement, recorded as a reusable lemma.
+
+### Our Goal
+
+State and prove, for an odd prime $p$ (`[Fact (Nat.Prime p)]`, `hp : p ≠ 2`), the equivalence `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7`, and derive the complementary non-residue characterization. Use `ZMod.exists_sq_eq_two_iff` as the engine, then add the worked numerical corollaries (e.g. $2$ is a residue mod $7, 17, 23$ and a non-residue mod $5, 11, 13$) as `decide`/`native_decide` sanity checks.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| euler-criterion-squares-oq-01 | Direct parent; Euler's criterion $a^{(p-1)/2}\equiv\pm1$ | quadratic residues, finite fields |
+| euler-criterion-squares-oq-01-oq-01 | Sibling; counts $(p-1)/2$ residues | fiber counting, cyclic groups |
+| elementary-quadratic-reciprocity | Main law that the supplements accompany | Legendre symbol, reciprocity |
+| jacobi-symbol-oq-01 | Generalizes Legendre symbol multiplicatively | Jacobi symbol, congruences |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct application of `ZMod.exists_sq_eq_two_iff`.** The result is essentially in Mathlib; the gallery contribution is to restate it cleanly for odd primes, derive the non-residue complement (`¬ IsSquare (2 : ZMod p) ↔ p % 8 = 3 ∨ p % 8 = 5`), and connect it back to the parent's Euler-criterion form.
+   - Why it might work: Mathlib provides the headline equivalence directly; the remaining work is the complement (a case split on `p % 8 ∈ {1,3,5,7}` since `p` is odd) and packaging.
+   - Risk: handling the odd-prime case split on `p % 8` cleanly and discharging the impossible even residues; choosing whether to present via `IsSquare` or `legendreSym p 2 = 1`.
+
+2. **Euler-criterion bridge $2^{(p-1)/2} \equiv (-1)^{(p^2-1)/8}$.** Prove the exponent identity linking the parent's criterion to the $p \bmod 8$ sign, then conclude residue-ness from the sign being $+1$.
+   - Why it might work: makes the entry genuinely "child of Euler's criterion" rather than a re-export, exposing the $(p^2-1)/8$ exponent as a reusable lemma; `legendreSym.eq_pow` and `ZMod.euler_criterion` supply the criterion side.
+   - Risk: the parity bookkeeping for $(p^2-1)/8$ across the four classes $p \equiv 1,3,5,7 \pmod 8$ is fiddly; cleaner to feed it from `exists_sq_eq_two_iff` rather than re-derive Gauss's lemma.

--- a/research/problems/euler-criterion-squares-oq-01-oq-03/state.md
+++ b/research/problems/euler-criterion-squares-oq-01-oq-03/state.md
@@ -1,0 +1,24 @@
+# Research State: euler-criterion-squares-oq-01-oq-03
+
+## Current State
+**Phase**: COMPLETED
+**Path**: full
+**Since**: 2026-06-24T19:36:29-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm `ZMod.exists_sq_eq_two_iff` and the surrounding Legendre-symbol API in Mathlib v4.26, and draft the first Lean skeleton stating `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7` for an odd prime `p`.

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 2, "endLine": 46 },
+    "type": "context",
+    "title": "Specializing Euler's Criterion to the Base 2",
+    "content": "The parent entry proves Euler's criterion: a nonzero residue a is a square mod an odd prime p exactly when a^((p−1)/2) = 1. That test is universal but does not say, for a fixed a, which primes p make a a square. This leaf carries out that computation for the smallest interesting case a = 2, recovering the classical second supplementary law of quadratic reciprocity: 2 is a quadratic residue mod p iff p ≡ 1 or 7 (mod 8). Beyond restating Mathlib's headline equivalence for the parent's odd-prime convention, the file supplies the non-residue complement, the prime-only residuacity interpretation, and — its distinctive content — the explicit bridge from the parent's exponential test 2^((p−1)/2) to the mod-8 Gauss-sum sign (−1)^((p²−1)/8).",
+    "mathContext": "$\\exists x\\in\\mathbb{Z}/p\\mathbb{Z},\\ x^2 = 2 \\iff p\\equiv\\pm1\\pmod 8$, equivalently $2^{(p-1)/2}\\equiv(-1)^{(p^2-1)/8}\\pmod p$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euler's criterion",
+      "second supplementary law of quadratic reciprocity",
+      "Legendre symbol",
+      "Dirichlet character χ₈"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "quadratic residues",
+      "the Legendre symbol"
+    ]
+  },
+  {
+    "id": "ann-issquare-two-iff",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 72, "endLine": 82 },
+    "type": "key-step",
+    "title": "Residue / Non-Residue Characterization",
+    "content": "isSquare_two_iff is Mathlib's ZMod.exists_sq_eq_two_iff, restated for the parent's [Fact (2 < p)] convention via p ≠ 2. The non-residue complement not_isSquare_two_iff is then the complement across the four reduced residue classes: an odd prime satisfies p % 8 ∈ {1,3,5,7}, so the negation of 'p ≡ 1 or 7' is exactly 'p ≡ 3 or 5', closed by omega.",
+    "mathContext": "$\\text{IsSquare}(2:\\mathbb{Z}/p) \\iff p\\bmod 8\\in\\{1,7\\}$; complement $\\iff p\\bmod 8\\in\\{3,5\\}$.",
+    "significance": "central",
+    "relatedConcepts": ["quadratic residues", "residue classes mod 8"],
+    "prerequisites": ["quadratic residues", "case analysis mod 8"]
+  },
+  {
+    "id": "ann-chi8-closed-form",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 118 },
+    "type": "key-step",
+    "title": "The Closed Form χ₈ n = (−1)^((n²−1)/8)",
+    "content": "Mathlib provides the (−1)-power form of χ₄ (χ₄_eq_neg_one_pow) but no analogue for χ₈. This lemma fills that gap by a case analysis on n mod 8: writing n = 8k + r with r ∈ {1,3,5,7}, a single `ring` identity (8k+r)² = 8·E + 1 lets omega evaluate (n²−1)/8 = E. The quotient is even (2·…) for r ∈ {1,7} — sign +1 — and odd (2·…+1) for r ∈ {3,5} — sign −1 — exactly matching χ₈'s residue-class values. (The sibling Jacobi leaf reproves the same identity for the composite-modulus setting.)",
+    "mathContext": "For odd $n$: $8\\mid n^2-1$ and $(n^2-1)/8$ is even $\\iff n\\bmod 8\\in\\{1,7\\}$.",
+    "significance": "central",
+    "relatedConcepts": ["quadratic Dirichlet character χ₈", "Gauss-sum sign", "parity"],
+    "prerequisites": ["modular arithmetic", "parity of integer divisions"]
+  },
+  {
+    "id": "ann-euler-bridge",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 128, "endLine": 149 },
+    "type": "insight",
+    "title": "The Euler-Criterion Bridge",
+    "content": "two_pow_half_eq_neg_one_pow is the leaf's headline contribution: (2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8). It chains Mathlib's legendreSym.eq_pow ((legendreSym p 2 : ZMod p) = 2^(p/2)), rewritten via p/2 = (p−1)/2, with the exponent form legendreSym p 2 = (−1)^((p²−1)/8), then casts the right-hand sign into ZMod p. This equates the parent's universal exponential test, evaluated at 2, with the concrete mod-8 Gauss-sum sign — the link the sibling Jacobi leaf cannot form, having no Euler criterion for composite moduli.",
+    "mathContext": "$2^{(p-1)/2}\\equiv(-1)^{(p^2-1)/8}\\pmod p$, the textbook Euler-criterion form of the second supplement.",
+    "significance": "central",
+    "relatedConcepts": ["Euler's criterion", "Gauss sums", "Legendre symbol as a power"],
+    "prerequisites": ["Euler's criterion", "the Legendre symbol congruence"]
+  },
+  {
+    "id": "ann-residuacity",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 151, "endLine": 168 },
+    "type": "insight",
+    "title": "Symbol Value +1 Means Residue — for Primes Only",
+    "content": "isSquare_two_iff_legendreSym records IsSquare (2 : ZMod p) ↔ legendreSym p 2 = 1, via Mathlib's legendreSym.eq_one_iff at a = 2 (which needs 2 ≠ 0 mod p, supplied by two_ne_zero). For a prime modulus the symbol value +1 genuinely detects quadratic residuacity — exactly the interpretation the sibling Jacobi leaf must drop, since for composite moduli the Jacobi symbol can equal +1 at a non-residue.",
+    "mathContext": "$\\text{IsSquare}(2:\\mathbb{Z}/p)\\iff\\left(\\tfrac{2}{p}\\right)=1$ (prime $p$ only).",
+    "significance": "supporting",
+    "relatedConcepts": ["Legendre symbol", "quadratic residuacity", "Jacobi symbol contrast"],
+    "prerequisites": ["the Legendre symbol", "quadratic residues"]
+  },
+  {
+    "id": "ann-numerics",
+    "proofId": "euler-criterion-squares-oq-01-oq-03",
+    "range": { "startLine": 170, "endLine": 189 },
+    "type": "context",
+    "title": "Concrete Checks (decide, no native_decide)",
+    "content": "Worked corollaries confirm the criterion in both directions: 2 is a residue mod 7 (3²=2), mod 17 (6²=36=2), and mod 23 (5²=25=2) — the classes p ≡ 7, 1, 7 (mod 8) — and a non-residue mod 5, 11, 13 — the classes p ≡ 5, 3, 5 (mod 8). All checks use decide, keeping the entry free of native_decide and the Lean.ofReduceBool axiom.",
+    "mathContext": "$2$ a residue mod $7,17,23$; non-residue mod $5,11,13$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decidable quadratic residues", "worked examples"],
+    "prerequisites": ["ZMod arithmetic"]
+  }
+]

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "euler-criterion-squares-oq-01-oq-03",
+  "slug": "euler-criterion-squares-oq-01-oq-03",
+  "title": "The Second Supplement — 2 is a Quadratic Residue mod p iff p ≡ ±1 (mod 8)",
+  "meta": {
+    "author": "classical number theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerCriterionSquaresOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "legendre-symbol",
+      "euler-criterion",
+      "second-supplement",
+      "quadratic-reciprocity",
+      "ZMod",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.exists_sq_eq_two_iff",
+        "description": "For [Fact p.Prime] and p ≠ 2, IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 — the headline second-supplement equivalence, which the entry restates for the parent's odd-prime convention [Fact (2 < p)] and complements.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "legendreSym.at_two",
+        "description": "For p ≠ 2, legendreSym p 2 = χ₈ p — evaluates the Legendre symbol at 2 via the mod-8 Dirichlet character; the input to the (-1)-power closed form and the Euler-criterion bridge.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "legendreSym.eq_pow",
+        "description": "(legendreSym p a : ZMod p) = (a : ZMod p)^(p/2) — the Legendre symbol congruent to the Euler-criterion exponential; rewritten via p/2 = (p-1)/2 to identify legendreSym p 2 with 2^((p-1)/2) and build the bridge.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "legendreSym.eq_one_iff",
+        "description": "For (a : ZMod p) ≠ 0, legendreSym p a = 1 ↔ IsSquare (a : ZMod p) — the prime-only residuacity ⟺ symbol-value-+1 bridge, used for isSquare_two_iff_legendreSym (this is exactly the equivalence that fails for composite Jacobi moduli).",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.χ₈_nat_eq_if_mod_eight",
+        "description": "χ₈ n = if n%2=0 then 0 else if n%8 ∈ {1,7} then 1 else -1 — the explicit residue-class value of χ₈, the starting point for the closed-form lemma chi8_eq_neg_one_pow (Mathlib supplies only the χ₄ analogue χ₄_eq_neg_one_pow).",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.ZModChar"
+      }
+    ],
+    "originalContributions": [
+      "two_pow_half_eq_neg_one_pow: the Euler-criterion bridge (2 : ZMod p)^((p-1)/2) = (-1 : ZMod p)^((p²-1)/8) — connects the parent's universal exponential test a^((p-1)/2) to the concrete mod-8 Gauss-sum sign for a = 2. This is the piece distinct from the sibling Jacobi leaf, which states the sign formula but has no Euler criterion to bridge to.",
+      "not_isSquare_two_iff: the explicit non-residue complement ¬ IsSquare (2 : ZMod p) ↔ p % 8 = 3 ∨ p % 8 = 5, obtained as the complement of the headline equivalence across the four odd residue classes mod 8.",
+      "isSquare_two_iff_legendreSym: residuacity ⟺ symbol value +1 at the prime modulus — the interpretation that holds only for primes, contrasting the sibling Jacobi leaf where +1 no longer signals quadratic residuacity.",
+      "legendreSym_two_eq_neg_one_pow: the second supplement in exponent form legendreSym p 2 = (-1)^((p²-1)/8), composing legendreSym.at_two with the closed-form χ₈ identity.",
+      "Honest framing: the headline equivalence IsSquare (2 : ZMod p) ↔ p ≡ ±1 (mod 8) is Mathlib's ZMod.exists_sq_eq_two_iff (restated for the [Fact (2 < p)] convention), and the χ₈ value / Euler-criterion exponential are Mathlib results; the original work is the non-residue complement, the residuacity bridge, and especially the Euler-criterion bridge 2^((p-1)/2) = (-1)^((p²-1)/8) tying the parent's criterion to the mod-8 sign. The closed-form χ₈ n = (-1)^((n²-1)/8) (absent from Mathlib) is reproved here for self-containment; the analogous lemma also appears in the sibling Jacobi leaf."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries; depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (no sorry, no native_decide / Lean.ofReduceBool — concrete numerical checks use decide). Honest scope: the headline residue equivalence (ZMod.exists_sq_eq_two_iff), the Legendre symbol's value at 2 (legendreSym.at_two), its Euler-criterion congruence (legendreSym.eq_pow), and the residuacity bridge (legendreSym.eq_one_iff) are Mathlib results; the original contributions are the non-residue complement, the Euler-criterion bridge 2^((p-1)/2) = (-1)^((p²-1)/8), the prime-only residuacity ⟺ symbol-value characterization, and the reproved closed form χ₈ n = (-1)^((n²-1)/8).",
+    "lineCount": 190,
+    "theoremCount": 19,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "EulerCriterionSquaresOQ01OQ03",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 0,
+    "path": "Proofs/EulerCriterionSquaresOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "description": "Specializes the parent's Euler criterion (IsSquare a ⟺ a^((p-1)/2) = 1) to the fixed base a = 2, proving the classical second supplementary law of quadratic reciprocity: for an odd prime p, 2 is a quadratic residue mod p iff p ≡ 1 or 7 (mod 8), and a non-residue iff p ≡ 3 or 5 (mod 8). The headline equivalence is Mathlib's ZMod.exists_sq_eq_two_iff, restated for the parent's [Fact (2 < p)] convention. The substantive new content is the Euler-criterion bridge (2 : ZMod p)^((p-1)/2) = (-1 : ZMod p)^((p²-1)/8), which ties the parent's universal exponential test to the concrete mod-8 Gauss-sum sign, together with the non-residue complement and the prime-only residuacity ⟺ symbol-value-+1 characterization (the interpretation that fails for the composite Jacobi moduli of the sibling leaf). Includes the reproved closed form χ₈ n = (-1)^((n²-1)/8) and worked numerical corollaries (2 is a residue mod 7, 17, 23; a non-residue mod 5, 11, 13).",
+  "overview": {
+    "historicalContext": "The two supplementary laws — the value of (-1/p) governed by p mod 4 and the value of (2/p) governed by p mod 8 — are, alongside the main law of quadratic reciprocity, the complete toolkit for evaluating Legendre symbols by hand. The second supplement, that 2 is a quadratic residue mod an odd prime p exactly when p ≡ ±1 (mod 8), goes back to Euler and Lagrange and was given its definitive proof by Gauss (via his lemma counting sign changes of {2, 4, …, p−1} folded into (−p/2, p/2), or equivalently via the Gauss-sum identity (2/p) = (−1)^((p²−1)/8)). It is the canonical first worked example of turning Euler's abstract exponentiation test a^((p−1)/2) into a decidable congruence condition on a single residue class.",
+    "problemStatement": "For an odd prime p, prove IsSquare (2 : ZMod p) ↔ p ≡ 1 ∨ 7 (mod 8) together with the non-residue complement p ≡ 3 ∨ 5 (mod 8), and record the explicit bridge from the parent's Euler-criterion form 2^((p−1)/2) to the mod-8 sign (−1)^((p²−1)/8) as a reusable lemma.",
+    "keyResults": [
+      "Second supplementary law: IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7 for an odd prime p.",
+      "Non-residue complement: ¬ IsSquare (2 : ZMod p) ↔ p % 8 = 3 ∨ p % 8 = 5.",
+      "Euler-criterion bridge: (2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8).",
+      "Exponent form of the symbol: legendreSym p 2 = (−1)^((p²−1)/8), and the closed form χ₈ n = (−1)^((n²−1)/8) for odd n.",
+      "Prime-only residuacity: IsSquare (2 : ZMod p) ↔ legendreSym p 2 = 1.",
+      "Worked checks: 2 is a residue mod 7, 17, 23 and a non-residue mod 5, 11, 13 (decide)."
+    ],
+    "proofStrategy": "The headline equivalence isSquare_two_iff is Mathlib's ZMod.exists_sq_eq_two_iff, applied with p ≠ 2 (from [Fact (2 < p)]). The complement not_isSquare_two_iff follows by omega after recording that an odd prime satisfies p % 8 ∈ {1,3,5,7}. For the exponent side, chi8_eq_neg_one_pow proves χ₈ n = (−1)^((n²−1)/8) for odd n by a case split on n mod 8: writing n = 8k + r with r ∈ {1,3,5,7}, a single `ring` identity (8k+r)² = 8·E + 1 lets omega evaluate (n²−1)/8 = E, whose parity (even for r ∈ {1,7}, odd for r ∈ {3,5}) is read off by pow_mul / pow_succ with neg_one_sq. Composing legendreSym.at_two (legendreSym p 2 = χ₈ p) with this gives legendreSym_two_eq_neg_one_pow. The bridge two_pow_half_eq_neg_one_pow rewrites legendreSym.eq_pow (legendreSym p 2 ≡ 2^(p/2)) with p/2 = (p−1)/2, then substitutes the exponent form and casts (−1)^((p²−1)/8) into ZMod p. Residuacity isSquare_two_iff_legendreSym is Mathlib's legendreSym.eq_one_iff at a = 2 (needing 2 ≠ 0 mod p).",
+    "keyInsights": [
+      "**The fixed-base specialization is where Euler's abstract test becomes a decidable congruence.** The parent characterizes residues by a^((p−1)/2) = 1 for variable a; this leaf pins a = 2 down to a condition on p mod 8 that needs no exponentiation at all.",
+      "**The Euler-criterion bridge is the leaf's distinctive content.** Equating 2^((p−1)/2) with (−1)^((p²−1)/8) inside ZMod p is exactly the link from the parent's universal exponential to the Gauss-sum sign; the sibling Jacobi leaf can state the same (−1)^((n²−1)/8) sign formula but, lacking a notion of Euler's criterion for composite moduli, has nothing to bridge it to.",
+      "**For prime moduli, symbol value +1 means quadratic residue; for composite moduli it does not.** isSquare_two_iff_legendreSym records the prime-only equivalence IsSquare 2 ⟺ legendreSym p 2 = 1, the residue interpretation that the Jacobi sibling explicitly cannot claim.",
+      "**The exponent (p²−1)/8 is a parity in disguise.** For odd p, 8 ∣ p²−1, and writing p = 8k + r the quotient is even exactly when r ∈ {1,7} — the same period-8 sign extracted by one `ring` identity per residue class feeding omega's division reasoning."
+    ]
+  },
+  "conclusion": {
+    "summary": "Carries out the parent's Euler criterion for the smallest fixed base, a = 2, recovering the classical second supplementary law of quadratic reciprocity: 2 is a quadratic residue mod an odd prime p iff p ≡ ±1 (mod 8), and a non-residue iff p ≡ ±3 (mod 8). The headline equivalence is Mathlib's ZMod.exists_sq_eq_two_iff; the original work is the non-residue complement, the prime-only residuacity ⟺ symbol-value characterization, and the Euler-criterion bridge (2)^((p−1)/2) = (−1)^((p²−1)/8) tying the parent's universal exponential test to the mod-8 Gauss-sum sign. The closed form χ₈ n = (−1)^((n²−1)/8) (absent from Mathlib) is reproved for self-containment. 19 theorems, 0 sorries, 0 axioms.",
+    "implications": [
+      "Turns the parent's universal but abstract residue test a^((p−1)/2) = 1 into a concrete, decidable congruence condition for the base 2, reusable in downstream entries (Gauss sums, reciprocity algorithms, Mersenne-style primality, quadratic-form representability).",
+      "Records the explicit bridge from Euler's criterion to the (−1)^((p²−1)/8) Gauss-sum form, the standard textbook identity, as a machine-checked reusable lemma.",
+      "Sharpens the prime/composite contrast: the residue interpretation of symbol value +1 (here) is exactly what the sibling Jacobi leaf must drop for composite moduli."
+    ],
+    "openQuestions": [
+      "Prove the first supplement and the half-base case in matching style: (-1/p) = (−1)^((p−1)/2) governing p mod 4, and the value of (−2/p) governing p mod 8, packaged as residue/non-residue dichotomies bridged to Euler's criterion.",
+      "Derive a concrete consequence for Mersenne/Fermat-style numbers: e.g. use the second supplement to show that for a prime p ≡ 3 (mod 4) with 2p+1 also prime, 2p+1 divides the Mersenne number 2^p − 1 (the Euler/Lagrange criterion for Mersenne divisors)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "extends",
+      "description": "The direct parent: Euler's criterion IsSquare a ⟺ a^((p−1)/2) = 1 for an odd prime p. This leaf specializes it to the fixed base a = 2 and bridges the exponential test to the p mod 8 sign."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01-oq-02-oq-03",
+      "relationship": "related",
+      "description": "The sibling Jacobi leaf, which proves the same (−1)^((n²−1)/8) sign formula for arbitrary odd composite moduli but, lacking Euler's criterion, has no residuacity interpretation and no Euler-criterion bridge — exactly the prime-only content supplied here."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A sibling leaf of the same Euler-criterion parent, counting the (p−1)/2 nonzero quadratic residues mod an odd prime."
+    },
+    {
+      "proofId": "elementary-quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The main reciprocity law the supplements accompany; together they form the complete by-hand Legendre-symbol evaluation toolkit."
+    }
+  ],
+  "sections": []
+}

--- a/src/data/research/problems/euler-criterion-squares-oq-01-oq-03.json
+++ b/src/data/research/problems/euler-criterion-squares-oq-01-oq-03.json
@@ -1,0 +1,131 @@
+{
+  "slug": "euler-criterion-squares-oq-01-oq-03",
+  "title": "The Second Supplement — 2 is a Quadratic Residue mod p iff p ≡ ±1 (mod 8)",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\exists\\, x \\in \\mathbb{Z}/p\\mathbb{Z},\\ x^2 = 2\n\\quad\\Longleftrightarrow\\quad\np \\equiv 1 \\pmod 8 \\ \\lor\\ p \\equiv 7 \\pmod 8.",
+    "plain": "The parent entry proves Euler's criterion: a nonzero residue $a$ is a perfect square modulo an odd prime $p$ exactly when $a^{(p-1)/2} \\equiv 1 \\pmod p$. That criterion is universal but it does not by itself tell you, for a *specific* number $a$, which primes $p$ make $a$ a square. This leaf carries out that computation for the smallest interesting case, $a = 2$: it asks to prove the classical \"second supplementary law\" of quadratic reciprocity, namely that $2$ is a square mod $p$ precisely when $p$ leaves remainder $1$ or $7$ when divided by $8$ (and is a non-residue when the remainder is $3$ or $5$). For example $2$ is a square mod $7$ ($4^2 = 16 \\equiv 2$) and mod $17$, but not mod $5$ or mod $11$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T00:00:00+0000",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Seeker-seeded stub. A Researcher should begin the OBSERVE phase: read problem.md, confirm `ZMod.exists_sq_eq_two_iff` and the surrounding Legendre-symbol API in Mathlib v4.26, and draft the first Lean skeleton stating `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7` for an odd prime `p`.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: second supplement IsSquare(2:ZMod p) ↔ p≡±1 mod 8 verified (Mathlib engine), plus non-residue complement, Euler-criterion bridge 2^((p-1)/2)=(-1)^((p²-1)/8), prime-only residuacity, χ₈ closed form. PR opened.",
+    "builtItems": [
+      "EulerCriterionSquaresOQ01OQ03.lean: 19 theorems, 0 sorry, 0 axiom, 190 lines",
+      "two_pow_half_eq_neg_one_pow (the Euler-criterion bridge)",
+      "not_isSquare_two_iff, isSquare_two_iff_legendreSym, chi8_eq_neg_one_pow, legendreSym_two_eq_neg_one_pow"
+    ],
+    "insights": [
+      "Headline IsSquare(2:ZMod p) ↔ p%8∈{1,7} is Mathlib ZMod.exists_sq_eq_two_iff; restated for [Fact (2<p)] convention.",
+      "Distinct content vs sibling Jacobi leaf: the Euler-criterion bridge 2^((p-1)/2)=(-1)^((p²-1)/8) in ZMod p (sibling has the sign formula but no Euler criterion to bridge to), and prime-only residuacity IsSquare 2 ↔ legendreSym p 2 = 1.",
+      "χ₈ n=(-1)^((n²-1)/8) reproved by mod-8 case split: (8k+r)²=8E+1 ring identity feeds omega; quotient even for r∈{1,7}, odd for r∈{3,5}."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Follow-up: first supplement (-1/p) and (-2/p) bridged to Euler criterion; Mersenne-divisor consequence (2p+1 ∣ 2^p-1 for p≡3 mod4 Sophie Germain)."
+    ]
+  },
+  "tags": [],
+  "relatedProofs": [
+    "euler-criterion-squares-oq-01",
+    "euler-criterion-squares-oq-01-oq-01",
+    "euler-criterion-squares-oq-01-oq-01-oq-01",
+    "euler-criterion-squares-oq-01-oq-02",
+    "euler-criterion-squares-oq-01-oq-02-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T02:11:48.265Z",
+  "lastUpdate": "2026-06-25T02:11:48.265Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01.lean",
+      "filename": "EulerCriterionSquaresOQ01.lean",
+      "lineCount": 106,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ01.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ01.lean",
+      "lineCount": 130,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ01OQ01.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ01OQ01.lean",
+      "lineCount": 118,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ02.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ02OQ03.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ02OQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/EulerCriterionSquaresOQ01OQ03.lean",
+      "filename": "EulerCriterionSquaresOQ01OQ03.lean",
+      "lineCount": 191,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerCriterionSquaresOQ01OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Specializes the parent entry's **Euler criterion** (`IsSquare a ⟺ a^((p−1)/2) = 1`) to the fixed base `a = 2`, recovering the classical **second supplementary law of quadratic reciprocity**: for an odd prime `p`, `2` is a quadratic residue mod `p` iff `p ≡ 1` or `7 (mod 8)`.

Answers the parent's open question verbatim, and is distinct from the sibling Jacobi leaf (`euler-criterion-squares-oq-01-oq-02-oq-03`), which states the same sign formula for composite moduli but has **no** residuacity interpretation and no Euler criterion to bridge to.

## What's proved (19 theorems, 0 sorries, 0 axioms)

- `isSquare_two_iff` — `IsSquare (2 : ZMod p) ↔ p % 8 = 1 ∨ p % 8 = 7` (Mathlib's `ZMod.exists_sq_eq_two_iff`, restated for the parent's `[Fact (2 < p)]` convention).
- `not_isSquare_two_iff` — non-residue complement `↔ p % 8 = 3 ∨ p % 8 = 5`.
- **`two_pow_half_eq_neg_one_pow`** — the **Euler-criterion bridge** `(2 : ZMod p)^((p−1)/2) = (−1 : ZMod p)^((p²−1)/8)`, the leaf's distinctive content.
- `isSquare_two_iff_legendreSym` — prime-only residuacity `IsSquare 2 ↔ legendreSym p 2 = 1`.
- `chi8_eq_neg_one_pow` — closed form `χ₈ n = (−1)^((n²−1)/8)` (absent from Mathlib; reproved for self-containment).
- Worked checks: `2` is a residue mod `7, 17, 23`; non-residue mod `5, 11, 13` (via `decide`, no `native_decide`).

## Verification

Builds against Mathlib 4.26.0. `#print axioms` on the main results lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`, badge `original` (honest scope: the headline equivalence and character/criterion API are Mathlib; the original work is the bridge, complement, residuacity characterization, and reproved χ₈ closed form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)