### PR TITLE
research(hilbert-4-oq-04): Birkhoff contraction → Perron–Frobenius power iteration (2×2) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Hilbert4OQ04.lean
+++ b/proofs/Proofs/Hilbert4OQ04.lean
@@ -1,0 +1,363 @@
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Topology.Algebra.Order.Field
+import Mathlib.Tactic
+
+/-
+# Hilbert metric, Birkhoff contraction, and Perron–Frobenius power iteration (2×2)
+
+This file realizes openQuestions[3] of the gallery entry `hilbert-4`
+(*Hilbert's 4th problem*): the bridge between the **Hilbert projective metric**
+and **Perron–Frobenius theory**.  Birkhoff's theorem says a positive matrix
+contracts the Hilbert (projective) metric, so by the Banach contraction-mapping
+theorem its normalized power iteration converges geometrically to the
+(positive, dominant) Perron eigenvector.
+
+We formalize the **2×2 case**, where the geometry is one–dimensional: a positive
+matrix `A = !![a, b; c, d]` (all entries `> 0`) acts on the projective coordinate
+`t = x / y ∈ (0, ∞)` by the increasing **Möbius map**
+
+  `φ(t) = (a·t + b) / (c·t + d)`.
+
+The Hilbert metric on the positive ray is `d_H(t₁, t₂) = |log t₁ − log t₂|`, and
+Birkhoff's theorem is the statement that `φ` strictly contracts `d_H`.  Instead of
+the analytic (logistic-derivative) proof of the optimal contraction constant
+`tanh(Δ/4)`, we use the **exact projective-dynamics identity** that is the
+algebraic heart of the matter: a real Möbius map with two distinct real fixed
+points is conjugate, via the cross-ratio coordinate, to multiplication by a
+constant — its **multiplier** `ρ`.  For a positive matrix this multiplier is
+exactly the eigenvalue ratio `ρ = λ₂ / λ₁`, with `|ρ| < 1`.
+
+Concretely, the two fixed points of `φ` are the roots `t⋆ > 0 > t†` of
+`c·t² + (d − a)·t − b = 0` (the two eigenvector ratios; `t⋆` is the Perron one,
+since it is positive).  With the cross-ratio coordinate `g(t) = (t − t⋆)/(t − t†)`
+we prove the **semiconjugacy**
+
+  `g(φ(t)) = ρ · g(t)`,            `ρ = (a + d − √Δ)/(a + d + √Δ) = λ₂/λ₁`,
+
+whence `g(φⁿ(t)) = ρⁿ · g(t) → 0`, and solving back for `φⁿ(t)` gives geometric
+convergence `φⁿ(t) → t⋆`.  This is precisely Birkhoff's "the power iteration
+converges to the Perron direction", with the contraction rate identified in
+closed form.
+
+Everything below is over `ℝ` and fully verified: 0 axioms, 0 sorries, no
+`native_decide`.
+
+References:
+* Birkhoff, G. (1957). *Extensions of Jentzsch's theorem.* Trans. AMS 85.
+* Bushell, P. (1973). *Hilbert's metric and positive contraction mappings.*
+  Arch. Rational Mech. Anal. 52.
+-/
+
+namespace Hilbert4Birkhoff
+
+open Filter Topology
+
+/-- The Möbius action of `A = !![a,b;c,d]` on the projective coordinate `t`. -/
+noncomputable def mobius (a b c d t : ℝ) : ℝ := (a * t + b) / (c * t + d)
+
+/-- Discriminant of the fixed-point quadratic `c·t² + (d−a)·t − b`. -/
+noncomputable def fpDisc (a b c d : ℝ) : ℝ := (d - a) ^ 2 + 4 * b * c
+
+/-- The Perron (positive) fixed point of `φ`: the dominant eigenvector ratio. -/
+noncomputable def perronRatio (a b c d : ℝ) : ℝ :=
+  (a - d + Real.sqrt (fpDisc a b c d)) / (2 * c)
+
+/-- The subdominant (negative) fixed point of `φ`: the other eigenvector ratio. -/
+noncomputable def subRatio (a b c d : ℝ) : ℝ :=
+  (a - d - Real.sqrt (fpDisc a b c d)) / (2 * c)
+
+/-- The Möbius multiplier `ρ = λ₂/λ₁` — the contraction ratio of the iteration. -/
+noncomputable def contractionRatio (a b c d : ℝ) : ℝ :=
+  (a + d - Real.sqrt (fpDisc a b c d)) / (a + d + Real.sqrt (fpDisc a b c d))
+
+/-- Cross-ratio coordinate straightening `φ` to multiplication by `ρ`. -/
+noncomputable def cross (a b c d t : ℝ) : ℝ :=
+  (t - perronRatio a b c d) / (t - subRatio a b c d)
+
+section Positive
+variable {a b c d : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)
+include ha hb hc hd
+
+/-- The discriminant is strictly positive (so the two fixed points are real and
+distinct): `(d−a)² ≥ 0` and `4bc > 0`. -/
+theorem fpDisc_pos : 0 < fpDisc a b c d := by
+  unfold fpDisc; nlinarith [sq_nonneg (d - a), mul_pos hb hc]
+
+/-- `√Δ ^ 2 = Δ`. -/
+theorem sq_sqrt_fpDisc : Real.sqrt (fpDisc a b c d) ^ 2 = fpDisc a b c d :=
+  Real.sq_sqrt (fpDisc_pos ha hb hc hd).le
+
+/-- `√Δ > 0`. -/
+theorem sqrt_fpDisc_pos : 0 < Real.sqrt (fpDisc a b c d) :=
+  Real.sqrt_pos.mpr (fpDisc_pos ha hb hc hd)
+
+/-- `√Δ > |a − d|`, since `Δ = (a−d)² + 4bc > (a−d)²`. -/
+theorem abs_lt_sqrt_fpDisc : |a - d| < Real.sqrt (fpDisc a b c d) := by
+  have h1 : |a - d| ^ 2 < Real.sqrt (fpDisc a b c d) ^ 2 := by
+    rw [sq_abs, sq_sqrt_fpDisc ha hb hc hd]; unfold fpDisc
+    nlinarith [mul_pos hb hc, sq_nonneg (a - d)]
+  exact lt_of_pow_lt_pow_left₀ 2 (sqrt_fpDisc_pos ha hb hc hd).le h1
+
+/-- Key linear relation: `2c · t⋆ = a − d + √Δ`. -/
+theorem two_c_perron : 2 * c * perronRatio a b c d = a - d + Real.sqrt (fpDisc a b c d) := by
+  have h2c : (2 * c : ℝ) ≠ 0 := by positivity
+  rw [perronRatio, mul_comm (2 * c) _, div_mul_cancel₀ _ h2c]
+
+/-- Key linear relation: `2c · t† = a − d − √Δ`. -/
+theorem two_c_sub : 2 * c * subRatio a b c d = a - d - Real.sqrt (fpDisc a b c d) := by
+  have h2c : (2 * c : ℝ) ≠ 0 := by positivity
+  rw [subRatio, mul_comm (2 * c) _, div_mul_cancel₀ _ h2c]
+
+/-- The Perron fixed point is positive: `t⋆ > 0`. -/
+theorem perronRatio_pos : 0 < perronRatio a b c d := by
+  have h := abs_lt_sqrt_fpDisc ha hb hc hd
+  have hnum : 0 < a - d + Real.sqrt (fpDisc a b c d) := by
+    have := neg_abs_le (a - d); linarith
+  rw [perronRatio]; exact div_pos hnum (by positivity)
+
+/-- The subdominant fixed point is negative: `t† < 0`. -/
+theorem subRatio_neg : subRatio a b c d < 0 := by
+  have h := abs_lt_sqrt_fpDisc ha hb hc hd
+  have hnum : a - d - Real.sqrt (fpDisc a b c d) < 0 := by
+    have := le_abs_self (a - d); linarith
+  rw [subRatio]; exact div_neg_of_neg_of_pos hnum (by positivity)
+
+/-- `t⋆ > t†` (distinct fixed points). -/
+theorem sub_lt_perron : subRatio a b c d < perronRatio a b c d :=
+  lt_trans (subRatio_neg ha hb hc hd) (perronRatio_pos ha hb hc hd)
+
+/-- `2·(a − c·t⋆) = a + d − √Δ = 2λ₂`. -/
+theorem two_a_sub_c_perron :
+    2 * (a - c * perronRatio a b c d) = a + d - Real.sqrt (fpDisc a b c d) := by
+  linear_combination -(two_c_perron ha hb hc hd)
+
+/-- `2·(a − c·t†) = a + d + √Δ = 2λ₁ > 0`. -/
+theorem two_a_sub_c_sub :
+    2 * (a - c * subRatio a b c d) = a + d + Real.sqrt (fpDisc a b c d) := by
+  linear_combination -(two_c_sub ha hb hc hd)
+
+/-- `a − c·t† > 0` (`= λ₁`, the dominant eigenvalue). -/
+theorem a_sub_c_sub_pos : 0 < a - c * subRatio a b c d := by
+  have h := two_a_sub_c_sub ha hb hc hd
+  have hS := sqrt_fpDisc_pos ha hb hc hd
+  linarith
+
+/-- The fixed-point quadratic holds at `t⋆`: `b = c·t⋆² + (d−a)·t⋆`. -/
+theorem perron_quadratic : b = c * perronRatio a b c d ^ 2 + (d - a) * perronRatio a b c d := by
+  have hc' : (4 * c) ≠ 0 := by positivity
+  have hsq : (2 * c * perronRatio a b c d - (a - d)) ^ 2 = (d - a) ^ 2 + 4 * b * c := by
+    rw [show 2 * c * perronRatio a b c d - (a - d) = Real.sqrt (fpDisc a b c d) by
+          have := two_c_perron ha hb hc hd; linarith]
+    rw [sq_sqrt_fpDisc ha hb hc hd]; unfold fpDisc; ring
+  have h4 : 4 * c * (c * perronRatio a b c d ^ 2 + (d - a) * perronRatio a b c d - b) = 0 := by
+    linear_combination hsq
+  have := (mul_eq_zero.mp h4).resolve_left hc'
+  linarith [this]
+
+/-- The fixed-point quadratic holds at `t†`: `b = c·t†² + (d−a)·t†`. -/
+theorem sub_quadratic : b = c * subRatio a b c d ^ 2 + (d - a) * subRatio a b c d := by
+  have hc' : (4 * c) ≠ 0 := by positivity
+  have hsq : (2 * c * subRatio a b c d - (a - d)) ^ 2 = (d - a) ^ 2 + 4 * b * c := by
+    rw [show 2 * c * subRatio a b c d - (a - d) = -Real.sqrt (fpDisc a b c d) by
+          have := two_c_sub ha hb hc hd; linarith]
+    rw [neg_sq, sq_sqrt_fpDisc ha hb hc hd]; unfold fpDisc; ring
+  have h4 : 4 * c * (c * subRatio a b c d ^ 2 + (d - a) * subRatio a b c d - b) = 0 := by
+    linear_combination hsq
+  have := (mul_eq_zero.mp h4).resolve_left hc'
+  linarith [this]
+
+/-- For `t > 0` the denominator `c·t + d` is positive. -/
+theorem den_pos {t : ℝ} (ht : 0 < t) : 0 < c * t + d := by positivity
+
+/-- `φ` maps the positive ray to itself: `t > 0 → φ(t) > 0`. -/
+theorem mobius_pos {t : ℝ} (ht : 0 < t) : 0 < mobius a b c d t := by
+  unfold mobius; apply div_pos <;> positivity
+
+/-- The Perron ratio is a fixed point of `φ`: `φ(t⋆) = t⋆`. -/
+theorem mobius_perron : mobius a b c d (perronRatio a b c d) = perronRatio a b c d := by
+  have hden : c * perronRatio a b c d + d ≠ 0 :=
+    ne_of_gt (den_pos ha hb hc hd (perronRatio_pos ha hb hc hd))
+  unfold mobius
+  rw [div_eq_iff hden]
+  linear_combination perron_quadratic ha hb hc hd
+
+/-- The factorization at `t⋆`: `φ(t) − t⋆ = (a − c·t⋆)·(t − t⋆)/(c·t + d)`. -/
+theorem mobius_factor_perron {t : ℝ} (ht : 0 < t) :
+    mobius a b c d t - perronRatio a b c d
+      = (a - c * perronRatio a b c d) * (t - perronRatio a b c d) / (c * t + d) := by
+  have hden : c * t + d ≠ 0 := ne_of_gt (den_pos ha hb hc hd ht)
+  rw [mobius, div_sub' hden, div_eq_div_iff hden hden]
+  linear_combination (c * t + d) * (perron_quadratic ha hb hc hd)
+
+/-- The factorization at `t†`: `φ(t) − t† = (a − c·t†)·(t − t†)/(c·t + d)`. -/
+theorem mobius_factor_sub {t : ℝ} (ht : 0 < t) :
+    mobius a b c d t - subRatio a b c d
+      = (a - c * subRatio a b c d) * (t - subRatio a b c d) / (c * t + d) := by
+  have hden : c * t + d ≠ 0 := ne_of_gt (den_pos ha hb hc hd ht)
+  rw [mobius, div_sub' hden, div_eq_div_iff hden hden]
+  linear_combination (c * t + d) * (sub_quadratic ha hb hc hd)
+
+/-- The eigenvalue identity `a − c·t⋆ = ρ·(a − c·t†)`, i.e. `λ₂ = ρ·λ₁`. -/
+theorem a_sub_c_perron_eq :
+    a - c * perronRatio a b c d = contractionRatio a b c d * (a - c * subRatio a b c d) := by
+  have e1 := two_a_sub_c_perron ha hb hc hd
+  have e2 := two_a_sub_c_sub ha hb hc hd
+  have hsum : a + d + Real.sqrt (fpDisc a b c d) ≠ 0 := by
+    have := sqrt_fpDisc_pos ha hb hc hd; positivity
+  unfold contractionRatio
+  rw [div_mul_eq_mul_div, eq_div_iff hsum]
+  linear_combination (a - c * subRatio a b c d) * e1 - (a - c * perronRatio a b c d) * e2
+
+/-- **Semiconjugacy (the Birkhoff/Perron heart).** In the cross-ratio coordinate
+`g`, the Möbius map `φ` is multiplication by the constant `ρ`:
+`g(φ(t)) = ρ · g(t)`.  Here `ρ = (a+d−√Δ)/(a+d+√Δ) = λ₂/λ₁`. -/
+theorem cross_mobius {t : ℝ} (ht : 0 < t) :
+    cross a b c d (mobius a b c d t) = contractionRatio a b c d * cross a b c d t := by
+  have hden : c * t + d ≠ 0 := ne_of_gt (den_pos ha hb hc hd ht)
+  have hts : t - subRatio a b c d ≠ 0 :=
+    ne_of_gt (by have := subRatio_neg ha hb hc hd; linarith)
+  have hacs : a - c * subRatio a b c d ≠ 0 := ne_of_gt (a_sub_c_sub_pos ha hb hc hd)
+  have key := a_sub_c_perron_eq ha hb hc hd
+  unfold cross
+  rw [mobius_factor_perron ha hb hc hd ht, mobius_factor_sub ha hb hc hd ht,
+    div_div_div_cancel_right₀ hden, key]
+  field_simp
+
+/-- `g` never takes the value `1` on the positive ray (since `t⋆ ≠ t†`). -/
+theorem cross_ne_one {t : ℝ} (ht : 0 < t) : cross a b c d t ≠ 1 := by
+  have hts : t - subRatio a b c d ≠ 0 :=
+    ne_of_gt (by have := subRatio_neg ha hb hc hd; linarith)
+  intro h
+  unfold cross at h
+  rw [div_eq_one_iff_eq hts] at h
+  have : perronRatio a b c d = subRatio a b c d := by linarith
+  exact absurd this (ne_of_gt (sub_lt_perron ha hb hc hd))
+
+/-- The contraction ratio is a genuine contraction: `|ρ| < 1`. -/
+theorem abs_contractionRatio_lt_one : |contractionRatio a b c d| < 1 := by
+  have hS := sqrt_fpDisc_pos ha hb hc hd
+  have hden : 0 < a + d + Real.sqrt (fpDisc a b c d) := by linarith
+  unfold contractionRatio
+  rw [abs_div, abs_of_pos hden, div_lt_one hden, abs_lt]
+  constructor <;> linarith
+
+end Positive
+
+section Iteration
+variable {a b c d : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)
+include ha hb hc hd
+
+/-- Iterates of `φ` stay on the positive ray. -/
+theorem iterate_pos (n : ℕ) {t : ℝ} (ht : 0 < t) : 0 < (mobius a b c d)^[n] t := by
+  induction n with
+  | zero => simpa using ht
+  | succ k ih =>
+      rw [Function.iterate_succ_apply']
+      exact mobius_pos ha hb hc hd ih
+
+/-- **Geometric straightening.** `g(φⁿ(t)) = ρⁿ · g(t)`: the cross-ratio coordinate
+of the `n`-th power iterate decays like the `n`-th power of the multiplier `ρ`. -/
+theorem cross_iterate (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    cross a b c d ((mobius a b c d)^[n] t)
+      = contractionRatio a b c d ^ n * cross a b c d t := by
+  induction n with
+  | zero => simp
+  | succ k ih =>
+      rw [Function.iterate_succ_apply', cross_mobius ha hb hc hd (iterate_pos ha hb hc hd k ht),
+        ih, pow_succ]
+      ring
+
+/-- **Closed form of the power iteration.**
+`φⁿ(t) = t⋆ + wₙ·(t⋆ − t†)/(1 − wₙ)` with `wₙ = ρⁿ·g(t)`. -/
+theorem iterate_closed_form (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    (mobius a b c d)^[n] t
+      = perronRatio a b c d
+        + contractionRatio a b c d ^ n * cross a b c d t * (perronRatio a b c d - subRatio a b c d)
+            / (1 - contractionRatio a b c d ^ n * cross a b c d t) := by
+  set s := (mobius a b c d)^[n] t with hs
+  have hspos : 0 < s := iterate_pos ha hb hc hd n ht
+  set w := contractionRatio a b c d ^ n * cross a b c d t with hw
+  have hgs : cross a b c d s = w := by rw [hs, hw, cross_iterate ha hb hc hd n ht]
+  have hts : s - subRatio a b c d ≠ 0 :=
+    ne_of_gt (by have := subRatio_neg ha hb hc hd; linarith)
+  have hwne : w ≠ 1 := by rw [← hgs]; exact cross_ne_one ha hb hc hd hspos
+  have h1mw : (1 - w) ≠ 0 := sub_ne_zero.mpr (Ne.symm hwne)
+  have hrel : s - perronRatio a b c d = w * (s - subRatio a b c d) := by
+    have h := hgs; unfold cross at h; rwa [div_eq_iff hts] at h
+  have h2 : s * (1 - w) = perronRatio a b c d - w * subRatio a b c d := by
+    linear_combination hrel
+  have hsval : s = (perronRatio a b c d - w * subRatio a b c d) / (1 - w) :=
+    (eq_div_iff h1mw).mpr h2
+  rw [hsval]
+  field_simp
+  ring
+
+/-- **Main theorem (Birkhoff → Perron–Frobenius power iteration, 2×2).**
+For a positive `2×2` matrix `A = !![a,b;c,d]`, the normalized power iteration on
+the projective ray — `t ↦ φ(t) = (a·t+b)/(c·t+d)` — converges, from any positive
+start `t`, to the Perron eigenvector ratio `t⋆`.  Convergence is geometric: the
+cross-ratio coordinate decays like `ρⁿ` with `|ρ| < 1` (`cross_iterate`,
+`abs_contractionRatio_lt_one`). -/
+theorem power_iteration_tendsto {t : ℝ} (ht : 0 < t) :
+    Tendsto (fun n => (mobius a b c d)^[n] t) atTop (nhds (perronRatio a b c d)) := by
+  -- ρⁿ → 0
+  have hpow : Tendsto (fun n => contractionRatio a b c d ^ n) atTop (nhds 0) :=
+    tendsto_pow_atTop_nhds_zero_of_abs_lt_one (abs_contractionRatio_lt_one ha hb hc hd)
+  -- wₙ = ρⁿ·g(t) → 0
+  have hw : Tendsto (fun n => contractionRatio a b c d ^ n * cross a b c d t) atTop (nhds 0) := by
+    have h := hpow.mul_const (cross a b c d t)
+    rwa [zero_mul] at h
+  -- numerator wₙ·(t⋆ − t†) → 0
+  have hnum : Tendsto
+      (fun n => contractionRatio a b c d ^ n * cross a b c d t
+        * (perronRatio a b c d - subRatio a b c d)) atTop (nhds 0) := by
+    have h := hw.mul_const (perronRatio a b c d - subRatio a b c d)
+    rwa [zero_mul] at h
+  -- denominator 1 − wₙ → 1
+  have hden1 : Tendsto (fun n => 1 - contractionRatio a b c d ^ n * cross a b c d t)
+      atTop (nhds 1) := by
+    have h := (tendsto_const_nhds (x := (1 : ℝ))).sub hw
+    rwa [sub_zero] at h
+  -- the quotient → 0
+  have hfrac : Tendsto
+      (fun n => contractionRatio a b c d ^ n * cross a b c d t
+        * (perronRatio a b c d - subRatio a b c d)
+        / (1 - contractionRatio a b c d ^ n * cross a b c d t)) atTop (nhds 0) := by
+    have h := hnum.div hden1 one_ne_zero
+    rwa [zero_div] at h
+  have hmain := hfrac.const_add (perronRatio a b c d)
+  rw [add_zero] at hmain
+  exact hmain.congr (fun n => (iterate_closed_form ha hb hc hd n ht).symm)
+
+end Iteration
+
+section Eigen
+variable {a b c d : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (hd : 0 < d)
+include ha hb hc hd
+
+/-- The dominant (Perron) eigenvalue equals `c·t⋆ + d = (a + d + √Δ)/2 = λ₁`. -/
+theorem perron_eigenvalue :
+    c * perronRatio a b c d + d = (a + d + Real.sqrt (fpDisc a b c d)) / 2 := by
+  linear_combination (two_c_perron ha hb hc hd) / 2
+
+/-- `(t⋆, 1)` is a genuine eigenvector of `A = !![a,b;c,d]` with eigenvalue
+`λ₁ = c·t⋆ + d`: applying `A` scales the vector by `λ₁`.  This pins `t⋆` as the
+Perron eigenvector direction. -/
+theorem perron_eigenvector :
+    a * perronRatio a b c d + b = (c * perronRatio a b c d + d) * perronRatio a b c d := by
+  linear_combination perron_quadratic ha hb hc hd
+
+/-- The multiplier is the eigenvalue ratio: `ρ · λ₁ = λ₂`, i.e.
+`ρ = λ₂ / λ₁` with `λ₁ = (a+d+√Δ)/2`, `λ₂ = (a+d−√Δ)/2`. -/
+theorem contractionRatio_eq_eigenvalue_ratio :
+    contractionRatio a b c d * ((a + d + Real.sqrt (fpDisc a b c d)) / 2)
+      = (a + d - Real.sqrt (fpDisc a b c d)) / 2 := by
+  have hden : a + d + Real.sqrt (fpDisc a b c d) ≠ 0 := by
+    have := sqrt_fpDisc_pos ha hb hc hd; positivity
+  unfold contractionRatio
+  field_simp
+
+end Eigen
+
+end Hilbert4Birkhoff

--- a/src/data/proofs/hilbert-4-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-4-oq-04/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "context",
+    "title": "Hilbert Metric, Birkhoff Contraction, Perron–Frobenius",
+    "content": "Birkhoff's theorem: a positive matrix strictly contracts the Hilbert projective metric, so its normalized power iteration converges geometrically to the Perron (dominant positive) eigenvector. We formalize the 2×2 case, where the cone is one-dimensional: A = !![a,b;c,d] acts on the projective coordinate t = x/y ∈ (0,∞) by the Möbius map φ(t) = (a·t+b)/(c·t+d), and the Hilbert metric is d_H(t₁,t₂) = |log t₁ − log t₂|. Instead of the analytic tanh(Δ/4) estimate we use the exact cross-ratio multiplier ρ = λ₂/λ₁.",
+    "mathContext": "$d_H(t_1,t_2) = |\\log t_1 - \\log t_2|$ on $(0,\\infty)$; $\\varphi(t) = \\frac{at+b}{ct+d}$ is the projective action of $A$.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert projective metric", "Birkhoff contraction theorem", "Perron–Frobenius theorem", "power iteration", "Möbius transformation"],
+    "prerequisites": ["positive matrices", "projective coordinates", "geometric convergence"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 62, "endLine": 92 },
+    "type": "definition",
+    "title": "The Projective-Dynamics Setup",
+    "content": "mobius is φ. fpDisc is the discriminant Δ = (d−a)² + 4bc of the fixed-point quadratic c·t² + (d−a)·t − b. perronRatio (t⋆) and subRatio (t†) are its two roots — the eigenvector ratios. contractionRatio is the multiplier ρ = (a+d−√Δ)/(a+d+√Δ). cross is the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†) in which φ will become exact multiplication by ρ.",
+    "mathContext": "$t_\\star, t_\\dagger = \\frac{a-d\\pm\\sqrt{\\Delta}}{2c}$, $\\rho = \\frac{a+d-\\sqrt\\Delta}{a+d+\\sqrt\\Delta}$, $g(t) = \\frac{t-t_\\star}{t-t_\\dagger}$.",
+    "significance": "standard",
+    "relatedConcepts": ["fixed points of a Möbius map", "cross-ratio", "eigenvector ratio", "Möbius multiplier"],
+    "prerequisites": ["quadratic formula", "linear-fractional transformations"]
+  },
+  {
+    "id": "ann-quadratic",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 142, "endLine": 167 },
+    "type": "theorem",
+    "title": "The Fixed-Point Quadratic at Both Roots",
+    "content": "perron_quadratic / sub_quadratic: each fixed point satisfies b = c·t² + (d−a)·t, the eigenvalue quadratic. Proved from the explicit quadratic-formula roots by squaring 2c·t − (a−d) = ±√Δ and using √Δ ^ 2 = Δ, then cancelling 4c. These relations drive every later algebraic identity (the factorizations and the semiconjugacy).",
+    "mathContext": "$c\\,t^2 + (d-a)\\,t - b = 0$ at $t = t_\\star, t_\\dagger$; equivalently $A\\,(t,1)^\\top \\parallel (t,1)^\\top$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic equation", "eigenvalue quadratic", "fixed-point equation"],
+    "prerequisites": ["Real.sq_sqrt", "quadratic roots"]
+  },
+  {
+    "id": "ann-factor",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 184, "endLine": 205 },
+    "type": "theorem",
+    "title": "Exact Factorizations of φ(t) − t⋆ and φ(t) − t†",
+    "content": "mobius_factor_perron / mobius_factor_sub: φ(t) − t⋆ = (a−c·t⋆)(t−t⋆)/(c·t+d), and the same at t†. The displacement from a fixed point factors as a constant (the local multiplier numerator) times (t − fixed point), over the common denominator c·t+d. This is what makes the cross-ratio collapse to a constant.",
+    "mathContext": "$\\varphi(t) - t_\\star = \\dfrac{(a-c\\,t_\\star)(t-t_\\star)}{c\\,t+d}$.",
+    "significance": "key",
+    "relatedConcepts": ["local linearization", "Möbius fixed-point factorization"],
+    "prerequisites": ["the fixed-point quadratic", "field algebra"]
+  },
+  {
+    "id": "ann-semiconjugacy",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 207, "endLine": 235 },
+    "type": "theorem",
+    "title": "The Semiconjugacy g(φ(t)) = ρ·g(t) — the Birkhoff/Perron Heart",
+    "content": "cross_mobius: dividing the two factorizations cancels the common denominator c·t+d (div_div_div_cancel_right₀), leaving (a−c·t⋆)(t−t⋆) / ((a−c·t†)(t−t†)). The eigenvalue identity a−c·t⋆ = ρ·(a−c·t†) (a_sub_c_perron_eq) turns this into ρ·g(t). So in the cross-ratio coordinate, the Möbius map φ is EXACTLY multiplication by the constant ρ — the exact algebraic form of Birkhoff's strict-contraction theorem, with rate ρ = λ₂/λ₁ instead of the analytic tanh(Δ/4).",
+    "mathContext": "$g(\\varphi(t)) = \\rho\\,g(t)$ with $\\rho = \\lambda_2/\\lambda_1$; $\\varphi$ is conjugate to $w \\mapsto \\rho w$.",
+    "significance": "key",
+    "relatedConcepts": ["semiconjugacy", "Möbius multiplier", "Birkhoff contraction", "spectral gap"],
+    "prerequisites": ["the factorizations", "the eigenvalue identity λ₂ = ρ·λ₁"]
+  },
+  {
+    "id": "ann-contraction",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 237, "endLine": 245 },
+    "type": "theorem",
+    "title": "|ρ| < 1: the Genuine Contraction",
+    "content": "abs_contractionRatio_lt_one: because a+d > 0 and √Δ > 0, one always has |a+d−√Δ| < a+d+√Δ, so |ρ| < 1 for EVERY positive matrix — no determinant hypothesis needed. This is the contraction property that powers geometric convergence.",
+    "mathContext": "$|\\rho| = \\dfrac{|a+d-\\sqrt\\Delta|}{a+d+\\sqrt\\Delta} < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["contraction constant", "spectral gap", "Perron dominance"],
+    "prerequisites": ["absolute value inequalities"]
+  },
+  {
+    "id": "ann-iterate",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 256, "endLine": 311 },
+    "type": "theorem",
+    "title": "Geometric Straightening and the Closed Form",
+    "content": "cross_iterate: iterating the semiconjugacy gives g(φⁿ(t)) = ρⁿ·g(t) — the cross-ratio coordinate decays exactly geometrically. iterate_closed_form inverts this to the explicit rational form φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1 − ρⁿ·g(t)), valid because the iterates stay positive (iterate_pos) and g never hits 1.",
+    "mathContext": "$g(\\varphi^n(t)) = \\rho^n g(t)$; $\\varphi^n(t) = t_\\star + \\dfrac{\\rho^n g(t)\\,(t_\\star - t_\\dagger)}{1 - \\rho^n g(t)}$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric decay", "conjugation to linear map", "orbit closed form"],
+    "prerequisites": ["induction on iterates", "field algebra"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 313, "endLine": 330 },
+    "type": "theorem",
+    "title": "Main: Power Iteration Converges to the Perron Eigenvector",
+    "content": "power_iteration_tendsto: since |ρ| < 1 gives ρⁿ → 0, the closed form tends to t⋆ (Tendsto.div with denominator limit 1). So from ANY positive start, φⁿ(t) → t⋆ geometrically — the Birkhoff → Perron–Frobenius conclusion: the normalized power iteration converges to the dominant positive eigenvector direction.",
+    "mathContext": "$\\varphi^n(t) \\to t_\\star$ as $n \\to \\infty$, geometrically at rate $|\\rho| = \\lambda_2/\\lambda_1$.",
+    "significance": "key",
+    "relatedConcepts": ["Perron–Frobenius convergence", "power method", "contraction-mapping theorem"],
+    "prerequisites": ["tendsto_pow_atTop_nhds_zero_of_abs_lt_one", "Filter.Tendsto.div"]
+  },
+  {
+    "id": "ann-perron",
+    "proofId": "hilbert-4-oq-04",
+    "range": { "startLine": 331, "endLine": 363 },
+    "type": "theorem",
+    "title": "Identifying the Perron Eigenvector and the Rate",
+    "content": "perron_eigenvector: (t⋆, 1) is a genuine eigenvector of A, with eigenvalue λ₁ = c·t⋆+d = (a+d+√Δ)/2 (perron_eigenvalue) — so the limit really is the Perron direction. contractionRatio_eq_eigenvalue_ratio: ρ·λ₁ = λ₂, so the metric contraction rate equals the spectral-gap ratio λ₂/λ₁. The metric and spectral faces of Perron–Frobenius coincide.",
+    "mathContext": "$A\\,(t_\\star,1)^\\top = \\lambda_1\\,(t_\\star,1)^\\top$, $\\lambda_1 = \\tfrac{a+d+\\sqrt\\Delta}{2}$, $\\rho\\lambda_1 = \\lambda_2$.",
+    "significance": "key",
+    "relatedConcepts": ["Perron eigenvector", "dominant eigenvalue", "spectral gap", "convergence rate"],
+    "prerequisites": ["eigenvalue/eigenvector definitions"]
+  }
+]

--- a/src/data/proofs/hilbert-4-oq-04/meta.json
+++ b/src/data/proofs/hilbert-4-oq-04/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "hilbert-4-oq-04",
+  "title": "Birkhoff Contraction and Perron–Frobenius Power Iteration (2×2)",
+  "slug": "hilbert-4-oq-04",
+  "description": "Realizes an open question of the Hilbert's-4th-problem gallery entry: the bridge between the Hilbert projective metric and Perron–Frobenius theory. Birkhoff's theorem says a positive matrix contracts the Hilbert metric, so its normalized power iteration converges geometrically to the Perron eigenvector. We formalize the 2×2 case, where the positive cone is one-dimensional: A = !![a,b;c,d] (all entries > 0) acts on the projective coordinate t = x/y ∈ (0,∞) by the Möbius map φ(t) = (a·t+b)/(c·t+d). Rather than the analytic logistic-derivative proof of the optimal contraction constant tanh(Δ/4), we use the exact projective-dynamics identity that is the algebraic heart of Birkhoff's theorem: a real Möbius map with two distinct real fixed points is conjugate, via the cross-ratio coordinate, to multiplication by its multiplier ρ. For a positive matrix ρ is exactly the eigenvalue ratio λ₂/λ₁ = (a+d−√Δ)/(a+d+√Δ), with |ρ| < 1. The semiconjugacy g(φ(t)) = ρ·g(t) for g(t) = (t−t⋆)/(t−t†) gives g(φⁿ(t)) = ρⁿ·g(t) → 0, hence geometric convergence φⁿ(t) → t⋆, the positive (Perron) eigenvector ratio. Fully verified, 0 axioms.",
+  "meta": {
+    "author": "Birkhoff (1957); Bushell (1973); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert4OQ04.lean",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "metric-geometry",
+      "perron-frobenius",
+      "hilbert-metric",
+      "birkhoff-contraction",
+      "fixed-points",
+      "mobius-transformation",
+      "projective-dynamics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "√Δ ^ 2 = Δ for Δ ≥ 0; turns the discriminant into a usable square so the fixed-point quadratic can be verified algebraically",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_abs_lt_one",
+        "description": "|ρ| < 1 ⟹ ρⁿ → 0; the geometric-decay engine behind power-iteration convergence",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Filter.Tendsto.div",
+        "description": "Limit of a quotient with nonzero denominator limit; used to pass wₙ → 0 through the closed-form rational expression for φⁿ(t)",
+        "module": "Mathlib.Topology.Algebra.Order.Field"
+      },
+      {
+        "theorem": "div_div_div_cancel_right₀",
+        "description": "(X/D)/(Y/D) = X/Y; cancels the common denominator c·t+d in the cross-ratio of the two factorizations, the algebraic step that produces the semiconjugacy",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "lt_of_pow_lt_pow_left₀",
+        "description": "a² < b², 0 ≤ b ⟹ a < b; used to deduce √Δ > |a−d|, separating the two fixed points across 0",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "mobius / fpDisc / perronRatio / subRatio / contractionRatio / cross: the full 2×2 projective-dynamics setup. The fixed points t⋆ > 0 > t† of φ are the two eigenvector ratios (roots of c·t² + (d−a)·t − b), and ρ = (a+d−√Δ)/(a+d+√Δ) is the Möbius multiplier",
+      "perron_quadratic / sub_quadratic: each fixed point satisfies the eigenvalue quadratic b = c·t² + (d−a)·t, proved from the explicit quadratic-formula expressions via √Δ ^ 2 = Δ",
+      "perronRatio_pos / subRatio_neg: t⋆ > 0 > t† — the Perron fixed point is the positive eigenvector direction; the other root is negative (their product −b/c < 0), so the positive ray (0,∞) avoids t† entirely",
+      "mobius_factor_perron / mobius_factor_sub: the exact factorizations φ(t) − t⋆ = (a−c·t⋆)(t−t⋆)/(c·t+d) and likewise for t†, derived from the quadratic relations",
+      "a_sub_c_perron_eq: the eigenvalue identity a − c·t⋆ = ρ·(a − c·t†), i.e. λ₂ = ρ·λ₁, identifying the multiplier as the eigenvalue ratio",
+      "cross_mobius (the Birkhoff/Perron heart): the semiconjugacy g(φ(t)) = ρ·g(t) — in the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†), the Möbius map φ is exactly multiplication by the constant ρ. This is the exact algebraic form of Birkhoff's strict-contraction theorem, replacing the analytic tanh(Δ/4) estimate",
+      "abs_contractionRatio_lt_one: |ρ| < 1 unconditionally for positive a,b,c,d (since |a+d−√Δ| < a+d+√Δ) — the genuine contraction property",
+      "cross_iterate: g(φⁿ(t)) = ρⁿ·g(t) by induction — geometric decay of the cross-ratio coordinate",
+      "iterate_closed_form: the exact closed form φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1 − ρⁿ·g(t)), inverting the cross-ratio straightening",
+      "power_iteration_tendsto (main): from any positive start t, the power iteration φⁿ(t) → t⋆, the Perron eigenvector ratio — geometric convergence to the dominant eigenvector, the Birkhoff → Perron–Frobenius conclusion",
+      "perron_eigenvalue / perron_eigenvector: (t⋆, 1) is a genuine eigenvector of A with eigenvalue λ₁ = c·t⋆ + d = (a+d+√Δ)/2, pinning t⋆ as the Perron direction",
+      "contractionRatio_eq_eigenvalue_ratio: ρ·λ₁ = λ₂ — the contraction rate is the spectral gap ratio λ₂/λ₁"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None beyond the foundational axioms propext, Classical.choice, Quot.sound (used via standard Mathlib lemmas). Fully verified: 0 axiom declarations, 0 sorries, no native_decide. The only hypotheses are the positivity of the four matrix entries a, b, c, d > 0 (the positive-matrix assumption of the Perron–Frobenius / Birkhoff setting). Scope: the 2×2 case; the general n-dimensional Hilbert metric / Birkhoff cone machinery is not formalized (Mathlib has neither a Perron–Frobenius theorem nor a Hilbert projective metric).",
+    "lineCount": 363,
+    "theoremCount": 30,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "The Hilbert projective metric on a cone measures distance by the logarithm of a cross-ratio; on the positive ray (0,∞) it is simply d_H(t₁,t₂) = |log t₁ − log t₂|. Garrett Birkhoff (1957) proved that a positive linear map strictly contracts this metric, with explicit ratio tanh(Δ/4) where Δ is the projective diameter of the image. Because the cone of normalized vectors is complete in d_H, the Banach contraction-mapping theorem then yields existence and uniqueness of a dominant positive eigenvector (Perron–Frobenius) together with geometric convergence of the normalized power iteration — a purely metric/dynamical proof, independent of spectral arguments. Bushell (1973) developed the theory further for positive contraction mappings. In the 2×2 case the positive cone is one-dimensional and the Hilbert metric reduces to the log-distance on a single projective coordinate, where Birkhoff's contraction is captured exactly by the classical Möbius multiplier.",
+    "problemStatement": "Formalize the connection between the Hilbert projective metric and Perron–Frobenius theory: a positive matrix contracts the Hilbert metric (Birkhoff's theorem), so by the contraction-mapping theorem its normalized power iteration converges to the Perron eigenvector. Realize this for a positive 2×2 matrix.",
+    "text": "For a positive 2×2 matrix the projective action is the Möbius map φ(t) = (a·t+b)/(c·t+d) on (0,∞). Its two fixed points are the eigenvector ratios t⋆ > 0 > t†, and in the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†) the map φ becomes exact multiplication by ρ = λ₂/λ₁, with |ρ| < 1. Hence g(φⁿ(t)) = ρⁿ·g(t) → 0 and φⁿ(t) → t⋆: the power iteration converges geometrically to the Perron eigenvector direction. Verified in Lean with no axioms.",
+    "proofStrategy": "1. Setup: the Möbius map φ, the discriminant Δ = (d−a)² + 4bc > 0, the two fixed points t⋆ = (a−d+√Δ)/(2c) > 0 and t† = (a−d−√Δ)/(2c) < 0 (perronRatio, subRatio), and the multiplier ρ (contractionRatio).\n2. Fixed-point quadratic: from the explicit roots and √Δ ^ 2 = Δ, prove b = c·t² + (d−a)·t at both roots (perron_quadratic, sub_quadratic), and that t⋆ is a genuine fixed point φ(t⋆) = t⋆.\n3. Factorizations: φ(t) − t⋆ = (a−c·t⋆)(t−t⋆)/(c·t+d) and the analogue at t† (mobius_factor_perron/sub), from the quadratic relations.\n4. Semiconjugacy: dividing the two factorizations cancels the common denominator (div_div_div_cancel_right₀); together with the eigenvalue identity a−c·t⋆ = ρ·(a−c·t†) this gives g(φ(t)) = ρ·g(t) (cross_mobius).\n5. Contraction: |ρ| < 1 because |a+d−√Δ| < a+d+√Δ for positive entries (abs_contractionRatio_lt_one).\n6. Iteration: g(φⁿ(t)) = ρⁿ·g(t) by induction (cross_iterate); invert to the closed form φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1−ρⁿ·g(t)) (iterate_closed_form).\n7. Convergence: ρⁿ → 0 (tendsto_pow_atTop_nhds_zero_of_abs_lt_one), so the closed form tends to t⋆ via Tendsto.div with denominator limit 1 (power_iteration_tendsto).\n8. Perron identification: (t⋆,1) is an eigenvector with eigenvalue λ₁ = c·t⋆+d = (a+d+√Δ)/2, and ρ = λ₂/λ₁ (perron_eigenvalue, perron_eigenvector, contractionRatio_eq_eigenvalue_ratio).",
+    "keyInsights": [
+      "**Cross-ratio straightening replaces the analytic estimate.** Birkhoff's theorem is usually proved by bounding a logistic-difference derivative to get the optimal constant tanh(Δ/4). But the same conclusion — geometric convergence with explicit rate — falls out of an exact algebraic identity: in the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†) the Möbius map is *literally* multiplication by ρ. No calculus, no transcendental constant.",
+      "**The multiplier is the spectral gap.** The contraction ratio is ρ = (a+d−√Δ)/(a+d+√Δ) = λ₂/λ₁, the ratio of the subdominant to the dominant eigenvalue. The metric contraction rate and the spectral convergence rate of power iteration are literally the same number — the two faces of Perron–Frobenius (metric vs. spectral) meet here.",
+      "**Positivity puts the fixed points on opposite sides of 0.** The product of the two roots is −b/c < 0, so exactly one (t⋆) is positive — the Perron direction — and the other (t†) is negative. The positive ray (0,∞) therefore never meets t†, so g(t) = (t−t⋆)/(t−t†) is well-defined and finite throughout the iteration, and the denominator stays bounded away from 0.",
+      "**|ρ| < 1 needs only positivity, not det > 0.** Because a+d > 0 and √Δ > 0, one always has |a+d−√Δ| < a+d+√Δ, so the iteration contracts for *every* positive matrix — even rank-deficient ones (det = 0 gives ρ = 0, one-step convergence)."
+    ],
+    "prerequisites": [
+      "The Möbius (linear-fractional) action of a 2×2 matrix on projective coordinates",
+      "Perron–Frobenius theory: dominant positive eigenvalue and eigenvector of a positive matrix",
+      "The Hilbert projective metric and Birkhoff's contraction theorem (background)",
+      "Geometric convergence and the contraction-mapping principle",
+      "The cross-ratio and conjugation of a Möbius map to its multiplier form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "The Möbius Action and Its Fixed Points",
+      "startLine": 1,
+      "endLine": 100,
+      "summary": "File docstring framing Birkhoff's theorem and the cross-ratio approach. Definitions: the Möbius map mobius, the discriminant fpDisc, the two fixed points perronRatio (t⋆ > 0) and subRatio (t† < 0), the multiplier contractionRatio (ρ), and the cross-ratio coordinate cross. Positivity of the discriminant.",
+      "mathContext": "φ(t) = (a·t+b)/(c·t+d) on (0,∞); fixed points are roots of c·t² + (d−a)·t − b = 0."
+    },
+    {
+      "id": "fixed-points",
+      "title": "Fixed-Point Quadratic and Factorizations",
+      "startLine": 101,
+      "endLine": 205,
+      "summary": "The quadratic-formula expressions yield b = c·t² + (d−a)·t at both roots (perron_quadratic, sub_quadratic), t⋆ > 0 > t†, φ(t⋆) = t⋆, and the exact factorizations φ(t) − t⋆ = (a−c·t⋆)(t−t⋆)/(c·t+d) and its t† analogue.",
+      "mathContext": "Both eigenvector ratios satisfy the eigenvalue quadratic; the factorizations expose the Möbius map's local linear behaviour at each fixed point."
+    },
+    {
+      "id": "semiconjugacy",
+      "title": "The Semiconjugacy g(φ(t)) = ρ·g(t)",
+      "startLine": 206,
+      "endLine": 245,
+      "summary": "The eigenvalue identity a−c·t⋆ = ρ·(a−c·t†) (a_sub_c_perron_eq) and the cross-ratio cancellation give the semiconjugacy cross_mobius: φ is multiplication by ρ in the coordinate g. The contraction |ρ| < 1 (abs_contractionRatio_lt_one).",
+      "mathContext": "The exact algebraic form of Birkhoff's strict-contraction theorem, with rate ρ = λ₂/λ₁."
+    },
+    {
+      "id": "iteration",
+      "title": "Geometric Convergence of the Power Iteration",
+      "startLine": 246,
+      "endLine": 330,
+      "summary": "Iterates stay positive (iterate_pos); g(φⁿ(t)) = ρⁿ·g(t) (cross_iterate); the closed form φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1−ρⁿ·g(t)) (iterate_closed_form); and the main convergence theorem φⁿ(t) → t⋆ (power_iteration_tendsto) via ρⁿ → 0.",
+      "mathContext": "Banach contraction-mapping conclusion realized concretely: geometric convergence to the Perron eigenvector ratio."
+    },
+    {
+      "id": "perron",
+      "title": "Identifying the Perron Eigenvector and Rate",
+      "startLine": 331,
+      "endLine": 363,
+      "summary": "(t⋆,1) is a genuine eigenvector of A with eigenvalue λ₁ = c·t⋆+d = (a+d+√Δ)/2 (perron_eigenvalue, perron_eigenvector), and ρ·λ₁ = λ₂ (contractionRatio_eq_eigenvalue_ratio): the limit is the Perron direction and the convergence rate is the spectral-gap ratio.",
+      "mathContext": "Closes the loop: the metric limit is the dominant eigenvector and the metric contraction rate is λ₂/λ₁."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Birkhoff, Garrett",
+      "title": "Extensions of Jentzsch's theorem",
+      "year": "1957",
+      "note": "Trans. Amer. Math. Soc. 85, 219–227 — a positive linear map strictly contracts the Hilbert projective metric, with ratio tanh(Δ/4)"
+    },
+    {
+      "authors": "Bushell, Peter J.",
+      "title": "Hilbert's metric and positive contraction mappings in a Banach space",
+      "year": "1973",
+      "note": "Arch. Rational Mech. Anal. 52, 330–338 — systematic development of the Hilbert-metric contraction method"
+    },
+    {
+      "authors": "Seneta, Eugene",
+      "title": "Non-negative Matrices and Markov Chains",
+      "year": "1981",
+      "note": "Springer — Perron–Frobenius theory and the projective/contraction view of power iteration"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "hilbert-4",
+      "relation": "Parent entry: Hilbert's 4th problem, whose open question on the Hilbert metric / Birkhoff contraction / Perron–Frobenius power-iteration bridge this entry realizes for the 2×2 case."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a positive 2×2 matrix, the normalized power iteration on the projective ray — t ↦ φ(t) = (a·t+b)/(c·t+d) — converges geometrically, from any positive start, to the Perron eigenvector ratio t⋆ (power_iteration_tendsto). The mechanism is the exact projective-dynamics identity cross_mobius: in the cross-ratio coordinate g(t) = (t−t⋆)/(t−t†), the Möbius map is multiplication by the constant ρ = λ₂/λ₁ with |ρ| < 1 — the algebraic heart of Birkhoff's Hilbert-metric contraction theorem. The limit t⋆ is pinned as a genuine eigenvector with the dominant eigenvalue λ₁ (perron_eigenvector), and the contraction rate equals the spectral-gap ratio (contractionRatio_eq_eigenvalue_ratio). Verified with 0 axioms and 0 sorries.",
+    "implications": "Gives a complete, calculus-free, fully verified instance of the Hilbert-metric → Perron–Frobenius bridge: the metric contraction rate and the spectral convergence rate of power iteration are exhibited as the same number λ₂/λ₁, via the Möbius multiplier. It also supplies a clean, reusable template — cross-ratio straightening of a fixed-point iteration to exact geometric decay.",
+    "openQuestions": [
+      "Extend to n×n positive matrices: formalize the Hilbert projective metric on the positive cone and Birkhoff's strict-contraction theorem with the general projective-diameter ratio tanh(Δ/4), then derive Perron–Frobenius convergence in higher dimensions.",
+      "Prove the optimal 2×2 contraction constant tanh(Δ/4) analytically (the logistic-difference derivative bound) and reconcile it with the exact multiplier ρ = λ₂/λ₁ obtained here.",
+      "Lift the result to the projective line ℝP¹ / the full Hilbert geodesic structure, connecting back to the straight-line geometry of Hilbert's 4th problem."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Topology.Algebra.Order.Field",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Hilbert4Birkhoff",
+    "lineCount": 363,
+    "axiomCount": 0,
+    "theoremCount": 30,
+    "definitionCount": 6,
+    "path": "Proofs/Hilbert4OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Realizes an open question of the **hilbert-4** gallery entry (*Hilbert's 4th problem*): the bridge between the **Hilbert projective metric** and **Perron–Frobenius theory**. Birkhoff's theorem says a positive matrix contracts the Hilbert metric, so its normalized power iteration converges geometrically to the Perron eigenvector. Formalized for the **2×2 case**, fully verified, 0 axioms.

A positive matrix `A = !![a,b;c,d]` acts on the projective coordinate `t = x/y ∈ (0,∞)` by the Möbius map `φ(t) = (a·t+b)/(c·t+d)`. Instead of the analytic logistic-derivative proof of the optimal constant `tanh(Δ/4)`, we use the **exact projective-dynamics identity** that is the algebraic heart of Birkhoff's theorem: in the cross-ratio coordinate `g(t) = (t−t⋆)/(t−t†)`, the Möbius map is *exactly* multiplication by its multiplier `ρ = λ₂/λ₁ = (a+d−√Δ)/(a+d+√Δ)`.

## Key results

| theorem | statement |
|---|---|
| `cross_mobius` (the heart) | semiconjugacy `g(φ(t)) = ρ·g(t)` |
| `abs_contractionRatio_lt_one` | `|ρ| < 1` for **every** positive matrix (no determinant hypothesis) |
| `cross_iterate` | `g(φⁿ(t)) = ρⁿ·g(t)` (geometric decay) |
| `iterate_closed_form` | `φⁿ(t) = t⋆ + ρⁿ·g(t)·(t⋆−t†)/(1 − ρⁿ·g(t))` |
| **`power_iteration_tendsto`** | `φⁿ(t) → t⋆` geometrically, from any `t > 0` |
| `perron_eigenvector` / `perron_eigenvalue` | `(t⋆,1)` is a genuine eigenvector with dominant eigenvalue `λ₁ = c·t⋆+d = (a+d+√Δ)/2` |
| `contractionRatio_eq_eigenvalue_ratio` | `ρ·λ₁ = λ₂` — the metric contraction rate **is** the spectral-gap ratio `λ₂/λ₁` |

The two fixed points `t⋆ > 0 > t†` are the eigenvector ratios (roots of `c·t² + (d−a)·t − b`); positivity puts them on opposite sides of `0`, so the positive ray never meets `t†` and `g` stays finite throughout the iteration.

## Verification

- **30 theorems + 6 defs, 363 lines**
- `#print axioms power_iteration_tendsto` → only `propext`, `Classical.choice`, `Quot.sound`
- 0 sorries, 0 `axiom` declarations, no `native_decide`
- Builds clean against Mathlib v4.26.0 (`lake env lean Proofs/Hilbert4OQ04.lean`)

## Scope

The 2×2 case. Mathlib has neither a Perron–Frobenius theorem nor a Hilbert projective metric, so both the downstream contraction-mapping target and the analytic crux are built from scratch here. The general n-dimensional Birkhoff cone machinery (and the optimal `tanh(Δ/4)` constant) remain open, noted in the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)