### PR TITLE
Enrich Erdős 933 OQ-05: Verified Steinerberger Bound

### DIFF
--- a/src/data/proofs/erdos-933-oq-05/annotations.json
+++ b/src/data/proofs/erdos-933-oq-05/annotations.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 40,
+      "endLine": 44
+    },
+    "type": "definition",
+    "title": "The {2,3}-Smooth Part",
+    "content": "smoothPart23 n = 2^{v₂(n)} · 3^{v₃(n)} is the largest divisor of n of the form 2^a·3^b, read directly off the prime factorization (Nat.factorization). consecutiveSmoothPart n applies it to the product n(n+1). These mirror the parent entry's definitions so the resolved sorries plug back in unchanged. Because the smooth part factors as a product of prime powers, lower-bounding each valuation lower-bounds the whole quantity — the strategy the rest of the file follows.",
+    "mathContext": "$\\mathrm{smoothPart23}(n) = 2^{v_2(n)}\\,3^{v_3(n)};\\quad \\mathrm{consecutiveSmoothPart}(n) = \\mathrm{smoothPart23}(n(n+1)).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "smooth number",
+      "p-adic valuation",
+      "Nat.factorization"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "Nat.factorization"
+    ]
+  },
+  {
+    "id": "ann-lift3",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 50,
+      "endLine": 61
+    },
+    "type": "theorem",
+    "title": "The Lifting-the-Exponent Step",
+    "content": "lift3 is one inductive step of LTE, stated over ℤ to avoid ℕ truncated subtraction: if 3^{e+1} ∣ a+1 then 3^{e+2} ∣ a³+1. The proof uses the factorization a³+1 = (a+1)(a²−a+1); from 3 ∣ a+1 (since 3 ∣ 3^{e+1}) one gets a ≡ −1 (mod 3), so a²−a+1 ≡ 1+1+1 = 3 ≡ 0 (mod 3) — the second factor contributes exactly one more 3. Writing a = 3t−1 and expanding with `ring` makes the gained factor explicit.",
+    "mathContext": "$a^3+1 = (a+1)(a^2-a+1),\\ \\ 3\\mid a+1 \\Rightarrow 3\\mid a^2-a+1 \\Rightarrow 3^{e+2}\\mid a^3+1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "lifting the exponent",
+      "p-adic valuation of a^n+1",
+      "factorization a³+1"
+    ],
+    "prerequisites": [
+      "dvd_pow_self",
+      "ring tactic over ℤ"
+    ]
+  },
+  {
+    "id": "ann-lte-core",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 63,
+      "endLine": 73
+    },
+    "type": "theorem",
+    "title": "LTE Core: 3^{r+1} ∣ 2^{3^r}+1",
+    "content": "lte_core is the single genuinely number-theoretic input of the whole development. By induction on r: the base r=0 (3 ∣ 3) is decidable; the step casts the hypothesis to ℤ, applies lift3 to a = 2^{3^r}, and uses 2^{3^{r+1}} = (2^{3^r})³ (pow_succ + pow_mul) to land back at the natural-number statement via exact_mod_cast. This is exactly the 3-adic valuation v₃(2^{3^r}+1) ≥ r+1 that gives Steinerberger's witness its 3-part.",
+    "mathContext": "$3^{r+1} \\mid 2^{3^r}+1 \\quad\\text{for all } r,\\ \\text{i.e. } v_3(2^{3^r}+1) \\ge r+1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "lifting the exponent",
+      "induction",
+      "ℤ/ℕ cast"
+    ],
+    "prerequisites": [
+      "lift3",
+      "pow_succ / pow_mul",
+      "exact_mod_cast"
+    ]
+  },
+  {
+    "id": "ann-factorization-consecutive",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 79,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "Resolving the Two Factorization Sorries",
+    "content": "factorization_consecutive proves the additivity v_p(n(n+1)) = v_p(n) + v_p(n+1) for every prime exponent p, via Nat.factorization_mul (which needs both factors nonzero, handled with an n=0 edge case). The parent's power2_consecutive and power3_consecutive are then the p=2 and p=3 specializations — two of the three sorries discharged in one stroke. Additivity holds with no coprimality hypothesis because factorization counts the exponent of a fixed prime, which is additive over any nonzero product.",
+    "mathContext": "$(n(n+1)).\\mathrm{factorization}\\,p = n.\\mathrm{factorization}\\,p + (n+1).\\mathrm{factorization}\\,p.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "additivity of valuations",
+      "Nat.factorization_mul"
+    ],
+    "prerequisites": [
+      "Nat.factorization_mul",
+      "nonzero factors"
+    ]
+  },
+  {
+    "id": "ann-fact2-pow2",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 99,
+      "endLine": 101
+    },
+    "type": "theorem",
+    "title": "The 2-adic Valuation of a Power of Two",
+    "content": "fact2_pow2: v₂(2^e) = e, via Nat.Prime.factorization_pow. This pins down the 2-part of Steinerberger's witness n = 2^{3^r} exactly — its 2-adic valuation is 3^r, so the 2-part already accounts for the full size of n.",
+    "mathContext": "$v_2(2^e) = e.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factorization of prime powers",
+      "Nat.Prime.factorization_pow"
+    ],
+    "prerequisites": [
+      "Nat.Prime.factorization_pow"
+    ]
+  },
+  {
+    "id": "ann-smooth-lower",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 103,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "Smooth-Part Lower Bound (ℕ form)",
+    "content": "steinerberger_smooth_lower resolves the third sorry: for n = 2^{3^r}, the {2,3}-smooth part of n(n+1) is ≥ n·3^{r+1}. The 2-part is ≥ 3^r (from fact2_pow2, all of it living in n), and the 3-part is ≥ r+1 (from lte_core via pow_dvd_iff_le_factorization, all of it living in n+1). Monotonicity of x↦2^x and x↦3^x lifts the valuation bounds to power bounds, and Nat.mul_le_mul assembles them into the product bound that equals consecutiveSmoothPart by rfl.",
+    "mathContext": "$\\mathrm{consecutiveSmoothPart}(2^{3^r}) \\ge 2^{3^r}\\cdot 3^{r+1} = n\\cdot 3^{r+1}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "smooth part",
+      "valuation bounds",
+      "Nat.Prime.pow_dvd_iff_le_factorization"
+    ],
+    "prerequisites": [
+      "lte_core",
+      "fact2_pow2",
+      "Nat.pow_le_pow_right"
+    ]
+  },
+  {
+    "id": "ann-exceeds",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 129,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "Exceeding n·log n",
+    "content": "steinerberger_exceeds turns the ℕ bound into the real inequality smoothPart > n·log n for n = 2^{3^r}. Since log(2^{3^r}) = 3^r·log 2 (Real.log_pow) and log 2 < 1 < 3 (from e > 2.718, so log 2 < log e = 1), one has n·log n = n·3^r·log 2 < n·3^{r+1} ≤ smooth part. This is where the constant ratio 3/log 2 ≈ 4.33 originates — the witnesses exceed n·log n by a fixed factor, not by an amount tending to ∞.",
+    "mathContext": "$n\\log n = n\\,3^r\\log 2 < n\\,3^{r+1} \\le \\mathrm{smoothPart},\\quad \\text{since } \\log 2 < 1 < 3.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.log_pow",
+      "log 2 < 1",
+      "constant ratio 3/log 2"
+    ],
+    "prerequisites": [
+      "steinerberger_smooth_lower",
+      "Real.log_pow",
+      "Real.exp_one_gt_d9"
+    ]
+  },
+  {
+    "id": "ann-infinitely-often",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 169,
+      "endLine": 184
+    },
+    "type": "theorem",
+    "title": "Main Result: Infinitely Often",
+    "content": "smooth_part_exceeds_n_log_n_infinitely_often is the verified headline: for every N there is n > N with consecutiveSmoothPart n > n·log n. The witness is n = 2^{3^N}, which exceeds N because N < 2^N ≤ 2^{3^N} (Nat.lt_two_pow_self and monotonicity), and the inequality is steinerberger_exceeds at r = N. This is exactly Erdős's stated 'infinitely often' claim, now machine-checked with 0 axioms; the strictly stronger limsup = ∞ framing of the parent entry remains open.",
+    "mathContext": "$\\forall N,\\ \\exists n>N:\\ \\mathrm{consecutiveSmoothPart}(n) > n\\log n;\\quad n = 2^{3^N}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "infinitely often",
+      "Erdős #933",
+      "Nat.lt_two_pow_self"
+    ],
+    "prerequisites": [
+      "steinerberger_exceeds",
+      "Nat.lt_two_pow_self"
+    ]
+  },
+  {
+    "id": "ann-audit",
+    "proofId": "erdos-933-oq-05",
+    "range": {
+      "startLine": 188,
+      "endLine": 201
+    },
+    "type": "insight",
+    "title": "Sanity Checks and Axiom Audit",
+    "content": "Two kernel-decidable examples certify the LTE core at r=2 (27 ∣ 513) and r=3 (81 ∣ 2²⁷+1) using `decide` (kernel reduction, not native_decide, so axiom-free). The closing #print axioms commands confirm that all four headline results depend only on propext, Classical.choice, and Quot.sound — no sorryAx and no Lean.ofReduceBool — substantiating the 0-axiom claim.",
+    "mathContext": "$3^3 \\mid 2^9+1 = 513,\\quad 3^4 \\mid 2^{27}+1;\\quad \\text{axioms} = \\{\\mathrm{propext},\\mathrm{Classical.choice},\\mathrm{Quot.sound}\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide vs native_decide",
+      "#print axioms",
+      "axiom audit"
+    ],
+    "prerequisites": [
+      "Decidable instances",
+      "axiom integrity policy"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-933-oq-05` (quality 43, passes 0).

## Gap addressed
Rich `meta.json` (overview, sections, conclusion, references) but **no `annotations.json`** — zero inline annotations on the page.

## Added
`annotations.json` with **9 annotations** covering the 203-line file: smooth-part definitions; the lifting-the-exponent step `lift3`; `lte_core` (3^{r+1} ∣ 2^{3^r}+1); the factorization-additivity lemma resolving `power2/power3_consecutive`; `fact2_pow2`; the smooth-part lower bound (≥ n·3^{r+1}); exceeding n·log n (constant ratio 3/log 2 ≈ 4.33); the infinitely-often headline; and the sanity-check + axiom audit. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
All 9 annotation ranges validated against the Lean source — **0 misaligned**. Axiom integrity reviewed: `status: verified` / `badge: original` / `axiomCount: 0` accurate (only propext·Classical.choice·Quot.sound; examples use kernel `decide`, not `native_decide`). `meta.json` unchanged.