### PR TITLE
Enrich Erdős Coprime Pigeonhole (oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-02/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-consecutive-coprime",
+    "proofId": "erdos-divisibility-pigeonhole-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 57
+    },
+    "type": "lemma",
+    "title": "Consecutive Integers Are Coprime",
+    "content": "The only number theory the argument needs downstream. coprime_succ proves gcd(b, b+1) = 1 directly from Nat.coprime_self_add_right (Coprime m (m+n) ↔ Coprime m n) at n = 1 together with Coprime b 1. coprime_of_consecutive lifts this to either order — given a = b+1 ∨ b = a+1 it returns Coprime a b — using symmetry of coprimality. The block collision in the main theorem delivers exactly this 'consecutive in some order' hypothesis.",
+    "mathContext": "$\\gcd(b, b+1) = 1$; and $a = b+1 \\vee b = a+1 \\Rightarrow \\gcd(a,b)=1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprimality of consecutive integers",
+      "Nat.coprime_self_add_right",
+      "Nat.Coprime.symm"
+    ],
+    "prerequisites": [
+      "Nat.Coprime",
+      "Nat.coprime_one_right"
+    ]
+  },
+  {
+    "id": "ann-main-statement",
+    "proofId": "erdos-divisibility-pigeonhole-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "theorem",
+    "title": "The Coprime Pigeonhole",
+    "content": "The headline dual gem: any n+1 elements chosen from {1,…,2n} contain two distinct coprime numbers. The hypotheses are exactly the inclusion S ⊆ Icc 1 (2n) and the cardinality bound n+1 ≤ |S|. This is the coprimality counterpart of the parent divisibility pigeonhole — same interval, same threshold, dual conclusion — obtained by pigeonholing on a different partition of {1,…,2n}.",
+    "mathContext": "$S \\subseteq \\{1,\\dots,2n\\},\\ |S| \\ge n+1 \\Rightarrow \\exists\\,a\\ne b \\in S,\\ \\gcd(a,b)=1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "pigeonhole principle",
+      "Erdős divisibility gem",
+      "coprime pair"
+    ],
+    "prerequisites": [
+      "Finset.Icc",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "ann-pigeonhole-mechanism",
+    "proofId": "erdos-divisibility-pigeonhole-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 87
+    },
+    "type": "insight",
+    "title": "The Consecutive-Block Index Map",
+    "content": "The mechanism. Each m ∈ S is sent to its block index g(m) = ⌊(m−1)/2⌋, which collapses {2k+1, 2k+2} to k and lands in range n exactly when m ≤ 2n (the maps-to fact, immediate by omega after Nat.div_lt_iff_lt_mul). Since |S| ≥ n+1 > n = |range n|, Finset.exists_ne_map_eq_of_card_lt_of_maps_to forces two distinct a, b ∈ S with the same block index. Equal ⌊(·−1)/2⌋ plus a ≠ b is an omega arithmetic that yields a = b+1 ∨ b = a+1 — they are consecutive — and coprime_of_consecutive closes the goal.",
+    "mathContext": "$g(m) = \\lfloor (m-1)/2 \\rfloor < n \\iff m \\le 2n;\\quad g(a)=g(b),\\ a\\ne b \\Rightarrow |a-b| = 1.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+      "floor division",
+      "omega"
+    ],
+    "prerequisites": [
+      "finite pigeonhole principle",
+      "Nat.div_lt_iff_lt_mul"
+    ]
+  },
+  {
+    "id": "ann-sharpness",
+    "proofId": "erdos-divisibility-pigeonhole-oq-02",
+    "range": {
+      "startLine": 89,
+      "endLine": 114
+    },
+    "type": "theorem",
+    "title": "Sharpness: the n Evens Have No Coprime Pair",
+    "content": "erdos_coprime_pigeonhole_sharp shows n+1 is optimal by exhibiting an n-element coprime-free subset: the evens {2,4,…,2n}, the image of Icc 1 n under k ↦ 2k. Injectivity of doubling gives card = n (card_image_of_injective + Nat.card_Icc), and any two members 2ka, 2kb have 2 ∣ gcd (Nat.dvd_gcd), so are never coprime. This is the coprime-side extremal witness, dual to the divisibility side's top block {n+1,…,2n}.",
+    "mathContext": "$|\\{2,4,\\dots,2n\\}| = n,\\quad 2 \\mid \\gcd(2k_a, 2k_b) \\Rightarrow \\neg\\,\\mathrm{Coprime}(2k_a, 2k_b).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "extremal set",
+      "sharp threshold",
+      "Nat.dvd_gcd",
+      "injective image cardinality"
+    ],
+    "prerequisites": [
+      "Finset.card_image_of_injective",
+      "Nat.card_Icc"
+    ]
+  },
+  {
+    "id": "ann-unification",
+    "proofId": "erdos-divisibility-pigeonhole-oq-02",
+    "range": {
+      "startLine": 116,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Unification: Both Pigeonholes at Once",
+    "content": "erdos_pigeonhole_div_and_coprime runs both pigeonholes on the identical hypothesis, returning simultaneously a ∣-comparable pair (the parent's erdos_divisibility_pigeonhole, pigeonholing on the odd part) and a coprime pair (this entry, pigeonholing on the consecutive block). It records that the two phenomena co-occur rather than compete: one (n+1)-element set is at once rich in divisor structure and in coprimality, each conclusion forced by its own partition with its own dual extremal obstruction.",
+    "mathContext": "$|S|\\ge n+1 \\Rightarrow (\\exists\\,a\\ne b,\\ a\\mid b) \\wedge (\\exists\\,a\\ne b,\\ \\gcd(a,b)=1).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dual pigeonholes",
+      "odd-part vs consecutive-block partition"
+    ],
+    "prerequisites": [
+      "erdos_divisibility_pigeonhole (parent)",
+      "erdos_coprime_pigeonhole"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-divisibility-pigeonhole-oq-02` (quality 45, passes 0).

## Gap addressed
Rich `meta.json` (overview, sections, conclusion, cross-references) but **no `annotations.json`** — zero inline annotations on the page.

## Added
`annotations.json` with **5 annotations** covering the 126-line file: the consecutive-coprime lemmas (gcd(b,b+1)=1), the main coprime-pigeonhole statement, the consecutive-block index map ⌊(m−1)/2⌋ + pigeonhole mechanism, the evens sharpness witness (n+1 optimal), and the unification theorem (both pigeonholes at once). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
All 5 annotation ranges validated against the Lean source — **0 misaligned**. Axiom integrity reviewed: `status: verified` / `badge: original` / `axiomCount: 0` accurate (only propext·Classical.choice·Quot.sound). `meta.json` unchanged.