### PR TITLE
research(euler-criterion-squares-oq-01-oq-01-oq-02): sum of nonzero quadratic residues vanishes mod p>3 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/EulerCriterionSquaresOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/EulerCriterionSquaresOQ01OQ01OQ02.lean
@@ -1,0 +1,131 @@
+/-
+  Sum of the nonzero quadratic residues vanishes: for an odd prime `p > 3`,
+
+      ∑_{x ≠ 0, x a square} x = 0   in   ZMod p.
+
+  The nonzero quadratic residues form a multiplicative subgroup of the field
+  `ZMod p`: a product of two squares is a square. Hence multiplication by a
+  fixed nonzero square `t` permutes the residue set among itself, so the total
+  sum `S = ∑ x` is unchanged when every term is scaled by `t`:
+
+      t · S = ∑ x (t·x) = ∑ x x = S,   i.e.   (t − 1) · S = 0.
+
+  Taking the explicit witness `t = 4 = 2²` (a nonzero square, and `≠ 1` once
+  `p > 3`), the factor `t − 1 = 3` is nonzero in the field, so `S = 0`.
+
+  This is the additive companion to the parent's *counting* result
+  (`euler-criterion-squares-oq-01-oq-01`, there are `(p−1)/2` residues): the
+  same multiplicative closure that fixes the cardinality also forces the sum to
+  vanish. It is genuinely distinct from Mathlib's `quadraticChar_sum_zero`,
+  which sums the *character values* `±1`, not the residue elements themselves.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Finset
+
+namespace EulerCriterionSquaresOQ01OQ01OQ02
+
+variable (p : ℕ) [Fact p.Prime]
+
+/-- The finite set of nonzero quadratic residues in `ZMod p`. -/
+def residues : Finset (ZMod p) :=
+  Finset.univ.filter (fun x : ZMod p => x ≠ 0 ∧ IsSquare x)
+
+@[simp] theorem mem_residues {x : ZMod p} :
+    x ∈ residues p ↔ x ≠ 0 ∧ IsSquare x := by
+  simp [residues]
+
+/-- `4 = 2²` is a square in any commutative ring. -/
+theorem isSquare_four : IsSquare (4 : ZMod p) := ⟨2, by norm_num⟩
+
+/-- For `p > 3`, the field element `2` is nonzero (`p ∤ 2`). -/
+theorem two_ne_zero (hp : 3 < p) : (2 : ZMod p) ≠ 0 := by
+  have h : ((2 : ℕ) : ZMod p) ≠ 0 := by
+    rw [Ne, CharP.cast_eq_zero_iff (ZMod p) p 2]
+    intro hd
+    have := Nat.le_of_dvd (by norm_num) hd
+    omega
+  simpa using h
+
+/-- For `p > 3`, the field element `4 = 2·2` is nonzero (`p ∤ 4`). -/
+theorem four_ne_zero (hp : 3 < p) : (4 : ZMod p) ≠ 0 := by
+  have h4 : (4 : ZMod p) = 2 * 2 := by norm_num
+  rw [h4]
+  exact mul_ne_zero (two_ne_zero p hp) (two_ne_zero p hp)
+
+/-- For `p > 3`, the field element `3 = 4 − 1` is nonzero (`p ∤ 3`). -/
+theorem three_ne_zero (hp : 3 < p) : (3 : ZMod p) ≠ 0 := by
+  have h : ((3 : ℕ) : ZMod p) ≠ 0 := by
+    rw [Ne, CharP.cast_eq_zero_iff (ZMod p) p 3]
+    intro hd
+    have := Nat.le_of_dvd (by norm_num) hd
+    omega
+  simpa using h
+
+/-- **Closure under scaling.** Multiplying a nonzero residue by `4` (a nonzero
+square) lands back in the residue set. -/
+theorem mul_four_mem_residues (hp : 3 < p) {x : ZMod p}
+    (hx : x ∈ residues p) : (4 : ZMod p) * x ∈ residues p := by
+  rw [mem_residues] at hx ⊢
+  obtain ⟨hx0, hxsq⟩ := hx
+  exact ⟨mul_ne_zero (four_ne_zero p hp) hx0, (isSquare_four p).mul hxsq⟩
+
+/-- Scaling by `4` is a bijection of the residue set onto itself, hence the
+image finset is the set itself. -/
+theorem image_mul_four (hp : 3 < p) :
+    (residues p).image (fun x => (4 : ZMod p) * x) = residues p := by
+  have hinj : Function.Injective (fun x : ZMod p => (4 : ZMod p) * x) :=
+    fun a b h => mul_left_cancel₀ (four_ne_zero p hp) h
+  apply Finset.eq_of_subset_of_card_le
+  · intro y hy
+    rw [Finset.mem_image] at hy
+    obtain ⟨x, hx, rfl⟩ := hy
+    exact mul_four_mem_residues p hp hx
+  · exact le_of_eq (Finset.card_image_of_injective _ hinj).symm
+
+/-- **The sum is fixed by scaling.** `4 · S = S` where `S` is the residue sum. -/
+theorem four_mul_sum_eq_sum (hp : 3 < p) :
+    (4 : ZMod p) * ∑ x ∈ residues p, x = ∑ x ∈ residues p, x := by
+  have hinj : ∀ x ∈ residues p, ∀ y ∈ residues p,
+      (4 : ZMod p) * x = 4 * y → x = y :=
+    fun x _ y _ h => mul_left_cancel₀ (four_ne_zero p hp) h
+  calc
+    (4 : ZMod p) * ∑ x ∈ residues p, x
+        = ∑ x ∈ residues p, (4 : ZMod p) * x := by rw [Finset.mul_sum]
+    _ = ∑ x ∈ (residues p).image (fun x => (4 : ZMod p) * x), x := by
+          rw [Finset.sum_image hinj]
+    _ = ∑ x ∈ residues p, x := by rw [image_mul_four p hp]
+
+/-- **Main theorem.** For an odd prime `p > 3`, the sum of the nonzero
+quadratic residues in `ZMod p` is zero. -/
+theorem sum_quadratic_residues_eq_zero (hp : 3 < p) :
+    ∑ x ∈ Finset.univ.filter (fun x : ZMod p => x ≠ 0 ∧ IsSquare x), x = 0 := by
+  have hfix := four_mul_sum_eq_sum p hp
+  have h3 : (3 : ZMod p) * ∑ x ∈ residues p, x = 0 := by linear_combination hfix
+  have : ∑ x ∈ residues p, x = 0 :=
+    (mul_eq_zero.mp h3).resolve_left (three_ne_zero p hp)
+  simpa [residues] using this
+
+/-! ### Concrete checks at small primes -/
+
+/-- Mod `5` the nonzero residues are `{1, 4}` with sum `5 ≡ 0`. -/
+theorem sum_residues_mod_five :
+    ∑ x ∈ Finset.univ.filter (fun x : ZMod 5 => x ≠ 0 ∧ IsSquare x), x = 0 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  exact sum_quadratic_residues_eq_zero 5 (by norm_num)
+
+/-- Mod `7` the nonzero residues are `{1, 2, 4}` with sum `7 ≡ 0`. -/
+theorem sum_residues_mod_seven :
+    ∑ x ∈ Finset.univ.filter (fun x : ZMod 7 => x ≠ 0 ∧ IsSquare x), x = 0 := by
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  exact sum_quadratic_residues_eq_zero 7 (by norm_num)
+
+/-- Mod `11` the nonzero residues are `{1, 3, 4, 5, 9}` with sum `22 ≡ 0`. -/
+theorem sum_residues_mod_eleven :
+    ∑ x ∈ Finset.univ.filter (fun x : ZMod 11 => x ≠ 0 ∧ IsSquare x), x = 0 := by
+  haveI : Fact (Nat.Prime 11) := ⟨by norm_num⟩
+  exact sum_quadratic_residues_eq_zero 11 (by norm_num)
+
+end EulerCriterionSquaresOQ01OQ01OQ02

--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "euler-criterion-squares-oq-01-oq-01-oq-02",
+  "title": "Sum of the Nonzero Quadratic Residues Vanishes mod a Prime p > 3",
+  "slug": "euler-criterion-squares-oq-01-oq-01-oq-02",
+  "description": "For an odd prime p > 3, the sum of the nonzero quadratic residues in ZMod p is zero: ∑_{x ≠ 0, x a square} x = 0. The nonzero residues form a multiplicative subgroup (a product of two squares is a square), so multiplication by a fixed nonzero square t permutes the residue set; reindexing the sum gives t·S = S, i.e. (t−1)·S = 0. The explicit witness t = 4 = 2² is a nonzero square with t ≠ 1 once p > 3, so the factor t − 1 = 3 is nonzero in the field and S = 0. This is the additive companion to the parent's counting result (there are (p−1)/2 residues): the same multiplicative closure that fixes the cardinality forces the sum to vanish. Genuinely distinct from Mathlib's quadraticChar_sum_zero, which sums the character values ±1 rather than the residue elements. Confirmed concretely mod 5, 7, and 11. 12 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Quadratic_residue",
+    "date": "Classical (Gauss; elementary number theory)",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-residues",
+      "euler-criterion",
+      "finite-fields",
+      "character-sums",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EulerCriterionSquaresOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 12 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete checks modulo 5, 7, and 11 reuse the general theorem applied at those primes, so no native_decide and no Lean.ofReduceBool is introduced.",
+    "originalContributions": [
+      "sum_quadratic_residues_eq_zero: the headline result — for an odd prime p > 3, the sum of the nonzero quadratic residues in ZMod p is 0, ∑ x ∈ univ.filter (x ≠ 0 ∧ IsSquare x), x = 0",
+      "four_mul_sum_eq_sum: the scaling-invariance heart of the argument — 4 · S = S, obtained by reindexing the residue sum along the bijection x ↦ 4·x",
+      "image_mul_four: multiplication by the nonzero square 4 permutes the residue finset onto itself (subset + equal cardinality via injectivity of x ↦ 4·x)",
+      "mul_four_mem_residues: closure of the nonzero residues under scaling by 4, from IsSquare.mul and field non-vanishing",
+      "two_ne_zero / four_ne_zero / three_ne_zero: the witness arithmetic — for p > 3 the field elements 2, 4 and the cancellation factor 3 = 4 − 1 are all nonzero (p ∤ 2, p ∤ 3)",
+      "sum_residues_mod_five / sum_residues_mod_seven / sum_residues_mod_eleven: concrete confirmations at p = 5 ({1,4}), p = 7 ({1,2,4}), p = 11 ({1,3,4,5,9}), each obtained by specializing the general theorem"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 131,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "That the nonzero quadratic residues modulo a prime sum to a multiple of p (for p > 3) is a staple of elementary number theory and olympiad training, traceable to Gauss's study of residues and periods. It is the additive shadow of the residues forming the unique index-2 multiplicative subgroup of (ℤ/pℤ)ˣ: a subset closed under multiplication and stable under scaling by any of its members must sum to zero in a field. The same mechanism — a nontrivial multiplicative scaling fixes a sum, hence the sum vanishes — recurs throughout the subject (vanishing of nontrivial character sums, Gaussian periods, Gauss-sum magnitudes).",
+    "problemStatement": "**Open Question (OQ-01-01-02, from euler-criterion-squares-oq-01-oq-01)**: Pass from counting the nonzero quadratic residues to summing them — show the residue sum vanishes in ZMod p.\n\n**Formalized**: sum_quadratic_residues_eq_zero, ∑ x ∈ univ.filter (fun x : ZMod p => x ≠ 0 ∧ IsSquare x), x = 0 for a prime p > 3, via the scaling bijection x ↦ 4·x and a single field cancellation.",
+    "text": "A 131-line, self-contained formalization (imports only Mathlib). The nonzero residues are packaged as the finset residues p = univ.filter (x ≠ 0 ∧ IsSquare x). The witness 4 = 2² is a square (isSquare_four) and, for p > 3, nonzero (four_ne_zero, via two_ne_zero and p ∤ 2); the cancellation factor 3 = 4 − 1 is likewise nonzero (three_ne_zero, via p ∤ 3). Closure mul_four_mem_residues shows x ↦ 4·x maps residues into residues (IsSquare.mul plus mul_ne_zero); since this map is injective (mul_left_cancel₀), image_mul_four upgrades the inclusion to an equality of finsets by a cardinality argument (Finset.eq_of_subset_of_card_le and Finset.card_image_of_injective). Reindexing the sum (Finset.sum_image) and pulling out the scalar (Finset.mul_sum) yields four_mul_sum_eq_sum: 4·S = S. A one-line linear_combination then gives 3·S = 0, and mul_eq_zero.resolve_left with 3 ≠ 0 forces S = 0. The mod-5/7/11 instances are the general theorem specialized, so the file depends only on propext / Classical.choice / Quot.sound — no native_decide.",
+    "proofStrategy": "**residues / mem_residues**: package the nonzero quadratic residues as a filtered finset of ZMod p.\n\n**isSquare_four**: 4 = 2·2 is a square in any commutative ring.\n\n**two_ne_zero / four_ne_zero / three_ne_zero**: for p > 3, p divides none of 2, 3, so (2 : ZMod p), (3 : ZMod p) ≠ 0 (CharP.cast_eq_zero_iff, Nat.le_of_dvd, omega); 4 = 2·2 ≠ 0 by mul_ne_zero.\n\n**mul_four_mem_residues**: if x ≠ 0 is a square then so is 4·x (IsSquare.mul) and it is nonzero (mul_ne_zero), so scaling by 4 preserves membership.\n\n**image_mul_four**: scaling by 4 is injective (mul_left_cancel₀), so the image finset has the same cardinality as residues p and is contained in it, hence equals it (Finset.eq_of_subset_of_card_le).\n\n**four_mul_sum_eq_sum**: 4·S = ∑ x, 4·x (Finset.mul_sum) = ∑ over the image (Finset.sum_image) = ∑ over residues p (image_mul_four) = S.\n\n**sum_quadratic_residues_eq_zero**: from 4·S = S, linear_combination gives 3·S = 0; since 3 ≠ 0 in the field, mul_eq_zero forces S = 0.\n\n**sum_residues_mod_five / seven / eleven**: instantiate the general theorem at p = 5, 7, 11 (Fact p.Prime, 3 < p by norm_num).",
+    "keyInsights": [
+      "**Scaling fixes the sum**: the residues are closed under multiplication, so multiplying every residue by a fixed residue t merely permutes them. Reindexing gives t·S = S, hence (t−1)·S = 0 — a purely structural identity that needs no knowledge of which elements are residues.",
+      "**An explicit witness sidesteps the parent's count**: choosing t = 4 = 2² makes the residue t entirely concrete. The whole argument then needs only that 4 is a nonzero square and that 3 = 4 − 1 is nonzero, both of which are exactly the hypothesis p > 3 (p ∤ 2 and p ∤ 3).",
+      "**Why p > 3 and not merely p odd**: for p = 3 the only nonzero residue is 1, t = 4 = 1, and the cancellation factor 3 = 0 collapses — the sum 1 is genuinely nonzero in ZMod 3. The bound p > 3 is the sharp threshold at which a residue t ≠ 1 first exists.",
+      "**Distinct from the Mathlib character sum**: Mathlib's quadraticChar_sum_zero and MulChar.sum_eq_zero_of_ne_one sum the ±1 character values over all of ZMod p. Here we add the residue elements themselves over the residue subset — a different object, with no Mathlib lemma, supplied by the scaling bijection on the filtered finset.",
+      "**0-axiom, including the numerics**: the mod-5/7/11 confirmations are the general theorem applied at those primes, not separate decide computations, so the file depends only on propext / Classical.choice / Quot.sound — no native_decide, no Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Quadratic residues as IsSquare in the field ZMod p, and closure of squares under multiplication (IsSquare.mul)",
+      "The field structure of ZMod p for prime p: no zero divisors, mul_left_cancel₀, mul_eq_zero",
+      "Characteristic and divisibility: CharP.cast_eq_zero_iff to certify 2, 3 ≠ 0 from p ∤ 2, p ∤ 3",
+      "Finset reindexing along an injective map: Finset.sum_image, Finset.card_image_of_injective, Finset.eq_of_subset_of_card_le, Finset.mul_sum",
+      "linear_combination for the final field cancellation 4·S = S ⟹ 3·S = 0"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "euler-criterion-squares-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent counts the nonzero quadratic residues — there are (p−1)/2 of them — from the kernel/image of the squaring map. This entry passes from that count to the sum, using the same multiplicative closure of the residue set: scaling by a nonzero square fixes the sum, so a field forces it to zero."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "ancestor",
+      "description": "The grandparent establishes Euler's criterion and the ±1 dichotomy a^((p−1)/2) = ±1, identifying the residues. This leaf works with the same residue subset but adds its elements rather than detecting membership."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Introduction",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Docstring framing the scaling-bijection strategy (multiplication by 4 = 2² permutes the residues, so t·S = S) and contrasting it with Mathlib's character sum, plus imports and namespace.",
+      "mathContext": "$t \\cdot S = \\sum_x (t x) = \\sum_x x = S \\implies (t-1) S = 0$, with $t = 4$, $t - 1 = 3 \\neq 0$ for $p > 3$."
+    },
+    {
+      "id": "residue-set",
+      "title": "The Residue Finset and the Witness",
+      "startLine": 35,
+      "endLine": 70,
+      "summary": "Defines residues p as the filtered finset, proves 4 is a square, and certifies 2, 4, and 3 = 4 − 1 are nonzero in ZMod p for p > 3.",
+      "mathContext": "$4 = 2^2$ is a nonzero square; $3 = 4 - 1 \\neq 0$ once $p \\nmid 3$."
+    },
+    {
+      "id": "scaling-bijection",
+      "title": "Scaling by 4 Permutes the Residues",
+      "startLine": 72,
+      "endLine": 100,
+      "summary": "Closure under scaling (mul_four_mem_residues) and the upgrade to a finset equality image_mul_four via injectivity and a cardinality argument.",
+      "mathContext": "$x \\mapsto 4x$ is an injective self-map of the residue set, hence a bijection of the finset."
+    },
+    {
+      "id": "cancellation",
+      "title": "Invariance and Cancellation",
+      "startLine": 101,
+      "endLine": 122,
+      "summary": "Reindexing yields 4·S = S (four_mul_sum_eq_sum); a linear_combination gives 3·S = 0, and 3 ≠ 0 forces S = 0 (sum_quadratic_residues_eq_zero).",
+      "mathContext": "$4S = S \\implies 3S = 0 \\implies S = 0$ in the field $\\mathbb{Z}/p\\mathbb{Z}$."
+    },
+    {
+      "id": "concrete-checks",
+      "title": "Concrete Checks at p = 5, 7, 11",
+      "startLine": 123,
+      "endLine": 131,
+      "summary": "Specializations of the general theorem confirming the vanishing sum mod 5 ({1,4}), 7 ({1,2,4}), and 11 ({1,3,4,5,9}).",
+      "mathContext": "$1+4 = 5 \\equiv 0$, $1+2+4 = 7 \\equiv 0$, $1+3+4+5+9 = 22 \\equiv 0$."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/EulerCriterionSquaresOQ01OQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorryCount": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "sum_quadratic_residues_eq_zero",
+      "statement": "For an odd prime p > 3, ∑ x ∈ univ.filter (fun x : ZMod p => x ≠ 0 ∧ IsSquare x), x = 0.",
+      "description": "The sum of the nonzero quadratic residues in ZMod p vanishes, proved by reindexing the sum along x ↦ 4·x to get 4·S = S, then cancelling the nonzero factor 3."
+    },
+    {
+      "name": "four_mul_sum_eq_sum",
+      "statement": "(4 : ZMod p) * ∑ x ∈ residues p, x = ∑ x ∈ residues p, x for p > 3.",
+      "description": "Scaling invariance of the residue sum, the structural heart of the argument: multiplication by the nonzero square 4 permutes the residue set, so the sum is unchanged."
+    },
+    {
+      "name": "image_mul_four",
+      "statement": "(residues p).image (fun x => 4 * x) = residues p for p > 3.",
+      "description": "Multiplication by 4 is an injective self-map of the residue finset, hence a bijection onto the same finset (subset plus equal cardinality)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Quadratic residue",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_residue",
+      "type": "encyclopedia"
+    },
+    {
+      "title": "Ireland & Rosen, A Classical Introduction to Modern Number Theory, Ch. 5",
+      "url": "https://link.springer.com/book/10.1007/978-1-4757-2103-4",
+      "type": "book"
+    }
+  ],
+  "conclusion": "The nonzero quadratic residues modulo a prime p > 3 sum to zero in ZMod p. The proof is the additive counterpart of the parent's count: the residues are closed under multiplication, so scaling by a fixed nonzero square (the explicit 4 = 2²) permutes them and fixes their sum S, giving (4−1)·S = 3·S = 0; since 3 ≠ 0 in the field for p > 3, S = 0. The argument is the prototypical 'a nontrivial multiplicative scaling fixes a sum, so a field forces the sum to zero' template, and is genuinely distinct from Mathlib's character-value sum quadraticChar_sum_zero. Fully machine-checked: 12 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers open question **OQ-01-01-02** of `euler-criterion-squares-oq-01-oq-01` **verbatim**: for an odd prime $p > 3$, the sum of the nonzero quadratic residues in $\mathbb{Z}/p\mathbb{Z}$ vanishes.

$$\sum_{\substack{x \neq 0 \\ x \text{ a square}}} x = 0 \quad \text{in } \mathbb{Z}/p\mathbb{Z}.$$

```lean
theorem sum_quadratic_residues_eq_zero (hp : 3 < p) :
    ∑ x ∈ Finset.univ.filter (fun x : ZMod p => x ≠ 0 ∧ IsSquare x), x = 0
```

## Mathematical content

The additive companion to the parent's **counting** result (there are $(p-1)/2$ residues). The same multiplicative closure that fixes the cardinality forces the sum to vanish:

- **Scaling fixes the sum.** The nonzero residues are closed under multiplication (`IsSquare.mul`), so $x \mapsto t\cdot x$ permutes the residue set for any nonzero square $t$. Reindexing the sum (`Finset.sum_image` + `Finset.mul_sum`) gives $t\cdot S = S$, i.e. $(t-1)\cdot S = 0$ — a structural identity needing no enumeration of which elements are residues.
- **Explicit witness $t = 4 = 2^2$.** A nonzero square with $t \neq 1$ once $p > 3$, so the cancellation factor $t - 1 = 3$ is nonzero in the field and $S = 0$. The whole argument reduces to $p \nmid 2$ and $p \nmid 3$, exactly the hypothesis $p > 3$.
- **$p > 3$ is sharp** (not merely $p$ odd): for $p = 3$ the only nonzero residue is $1$, $t = 4 = 1$, and $3 = 0$ collapses — the sum $1$ is genuinely nonzero in $\mathbb{Z}/3\mathbb{Z}$.

**Distinct from Mathlib.** `quadraticChar_sum_zero` / `MulChar.sum_eq_zero_of_ne_one` sum the $\pm 1$ character *values* over all of $\mathbb{Z}/p\mathbb{Z}$; here we add the residue *elements* over the residue subset. No Mathlib lemma covers this.

Confirmed concretely at $p = 5$ ($\{1,4\}$), $p = 7$ ($\{1,2,4\}$), $p = 11$ ($\{1,3,4,5,9\}$) — each a specialization of the general theorem, so no `native_decide`.

## Verification

- **12 theorems, 1 definition, 131 lines**, imports only Mathlib (v4.26.0)
- **0 sorries, 0 axioms**, no `native_decide`
- `#print axioms sum_quadratic_residues_eq_zero` → `[propext, Classical.choice, Quot.sound]` (foundational only)
- Builds clean via host `lake env lean` against the pinned Mathlib cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)