### PR TITLE
Enrich Puiseux fails in positive characteristic: populate annotations.json

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-01/annotations.json
+++ b/src/data/proofs/puiseux-theorem-oq-01/annotations.json
@@ -1,1 +1,113 @@
-[]
+[
+  {
+    "id": "ann-ispuiseux",
+    "proofId": "puiseux-theorem-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 69
+    },
+    "type": "definition",
+    "title": "Puiseux Series: Bounded Ramification",
+    "content": "IsPuiseuxSeries f holds when all exponents in the support of the Hahn series f share a common denominator n — every exponent lies in (1/n)·ℤ. Reproduced verbatim from the parent puiseux-theorem entry. The single quantifier ∃ n : ℕ+ binding all exponents is the crux: it is precisely this uniform bound on denominators that the characteristic-p counterexample will violate.",
+    "mathContext": "$\\mathrm{IsPuiseuxSeries}(f) :\\Leftrightarrow \\exists\\,n\\in\\mathbb{N}^+,\\ \\forall q\\in\\mathrm{supp}(f),\\ \\exists k\\in\\mathbb{Z},\\ q = k/n.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Puiseux series",
+      "Hahn series",
+      "ramification / bounded denominators"
+    ],
+    "prerequisites": [
+      "HahnSeries",
+      "support of a Hahn series"
+    ]
+  },
+  {
+    "id": "ann-artinschreier-exp",
+    "proofId": "puiseux-theorem-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 73
+    },
+    "type": "definition",
+    "title": "The Artin–Schreier Exponent Sequence",
+    "content": "artinSchreierExp p k = −1/p^{k+1} is the sequence of exponents in the Hahn-series root y = ∑_{k≥1} x^{−1/pᵏ} of the Artin–Schreier equation yᵖ − y = x⁻¹ over 𝔽_p((x)). This equation is separable of degree p, so y is algebraic over the Laurent series; the Frobenius/freshman's-dream identity yᵖ = x⁻¹ + y is what makes these exact exponents appear. Their denominators p^{k+1} grow without bound — the seed of the obstruction.",
+    "mathContext": "$\\mathrm{artinSchreierExp}(p,k) = -\\frac{1}{p^{k+1}};\\quad y = \\sum_{k\\ge 1} x^{-1/p^k},\\ y^p - y = x^{-1}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Artin–Schreier theory",
+      "Frobenius / freshman's dream",
+      "separable extensions"
+    ],
+    "prerequisites": [
+      "characteristic p",
+      "Laurent series 𝔽_p((x))"
+    ]
+  },
+  {
+    "id": "ann-distinct-levels",
+    "proofId": "puiseux-theorem-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "Infinitely Many Distinct Ramification Levels",
+    "content": "artinSchreierExp_strictMono shows the exponents strictly increase toward 0 (−1/p < −1/p² < ⋯), via one_div_lt_one_div_of_lt and pow_lt_pow_right₀; artinSchreierExp_injective is the immediate corollary that they are pairwise distinct. Together they certify there are genuinely infinitely many ramification levels — the support of y is an infinite set, not a finite one that could be cleared by a single denominator.",
+    "mathContext": "$-\\tfrac1p < -\\tfrac1{p^2} < -\\tfrac1{p^3} < \\cdots \\to 0;\\ \\text{strictly monotone}\\Rightarrow\\text{injective}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict monotonicity",
+      "injectivity",
+      "pow_lt_pow_right₀"
+    ],
+    "prerequisites": [
+      "one_div_lt_one_div_of_lt",
+      "StrictMono.injective"
+    ]
+  },
+  {
+    "id": "ann-unbounded-denominators",
+    "proofId": "puiseux-theorem-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Unbounded Ramification: No Common Denominator",
+    "content": "artinSchreierExp_denominators_unbounded is the technical heart: the exponent set lies in no (1/n)·ℤ. Given a candidate n, pow_unbounded_of_one_lt picks a level k with p^{k+1} > n; if −1/p^{k+1} = j/n then clearing denominators gives n = −j·p^{k+1}, so p^{k+1} ∣ n, forcing p^{k+1} ≤ n (Int.le_of_dvd) — contradicting p^{k+1} > n by omega. This is exactly the failure of the bounded-denominator condition that defines a Puiseux series.",
+    "mathContext": "$\\forall n,\\ \\exists k:\\ p^{k+1} > n,\\ \\text{so } -\\tfrac{1}{p^{k+1}} \\notin \\tfrac1n\\mathbb{Z}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "unbounded ramification",
+      "divisibility",
+      "pow_unbounded_of_one_lt",
+      "Int.le_of_dvd"
+    ],
+    "prerequisites": [
+      "artinSchreierExp",
+      "field_simp / clearing denominators"
+    ]
+  },
+  {
+    "id": "ann-obstruction",
+    "proofId": "puiseux-theorem-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 129
+    },
+    "type": "theorem",
+    "title": "The Artin–Schreier Obstruction",
+    "content": "artinSchreier_support_not_puiseux is the headline: any Hahn series whose support contains all the Artin–Schreier exponents is not a Puiseux series — a one-line consequence of denominators_unbounded. Applied to the Artin–Schreier root y (whose support is exactly {−1/pᵏ}), it is the formal statement that y is algebraic over the Laurent series yet not a Puiseux series, so Puiseux's theorem fails in characteristic p. This is the negative half of the open question; identifying the actual algebraic closure (Kedlaya's theorem) remains open.",
+    "mathContext": "$\\mathrm{supp}(f)\\supseteq\\{-1/p^{k+1}\\} \\Rightarrow \\neg\\,\\mathrm{IsPuiseuxSeries}(f).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "counterexample",
+      "algebraic closure of 𝔽_p((x))",
+      "Kedlaya's theorem"
+    ],
+    "prerequisites": [
+      "artinSchreierExp_denominators_unbounded",
+      "IsPuiseuxSeries"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `puiseux-theorem-oq-01` (quality 45, passes 0).

## Gap addressed
`meta.json` was fully developed (overview, sections, conclusion, references) but **`annotations.json` was empty (`[]`)** — zero inline annotations on the page.

## Added
Populated `annotations.json` with **5 annotations** covering the 131-line file: the `IsPuiseuxSeries` bounded-ramification predicate, the Artin–Schreier exponent sequence (root of yᵖ−y=x⁻¹), the infinitely-many-distinct-levels lemmas (strictMono/injective), the unbounded-ramification theorem (no common denominator), and the headline Artin–Schreier obstruction (such a series is not Puiseux). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
All 5 annotation ranges validated against the Lean source — **0 misaligned**. Axiom integrity reviewed: `status: verified` / `badge: original` / `axiomCount: 0` accurate (only propext·Classical.choice·Quot.sound). `meta.json` unchanged.