### PR TITLE
research(wilsons-theorem-oq-01-oq-03): Clement's twin-prime criterion via Wilson at two moduli [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/WilsonsClementTwinPrimeOQ0103.lean
+++ b/proofs/Proofs/WilsonsClementTwinPrimeOQ0103.lean
@@ -1,0 +1,129 @@
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Tactic
+
+/-!
+# Clement's twin-prime criterion (Wilson, OQ-01 OQ-03)
+
+**Clement's theorem (1949).** For an odd `n ≥ 3`, the pair `(n, n+2)` consists of two
+primes if and only if
+
+  `4·((n-1)! + 1) + n ≡ 0  (mod n·(n+2))`.
+
+This packages two instances of Wilson's theorem — at the moduli `n` and `n+2` — and fuses
+them with the Chinese remainder theorem (here realised as the fact that coprime divisors of
+a number divide it simultaneously iff their product does).
+
+Mathlib provides the Wilson biconditional `Nat.prime_iff_fac_equiv_neg_one`
+(`Prime n ↔ (n-1)! ≡ -1 mod n`) but has **no twin-prime / simultaneous-primality criterion**.
+The two contributions here are:
+
+* `factorial_succ_succ_cast`: the modular bridge `(n+1)! ≡ 2·(n-1)! (mod n+2)`, obtained from
+  `n+1 ≡ -1` and `n ≡ -2` modulo `n+2`. This is what lets a *single* factorial `(n-1)!`
+  control Wilson's congruence at *both* moduli.
+* `clement_twin_prime`: the full biconditional criterion.
+
+We restrict to odd `n` (equivalently `n ≥ 3` odd): every genuine twin-prime candidate `n ≥ 3`
+is odd, and for even `n` the divisor `n·(n+2)` is a multiple of `4` that the criterion quantity
+never meets, so the odd hypothesis discards only the degenerate composite branch. The oddness is
+used exactly twice: to make `4` invertible mod `n` and `2` invertible mod `n+2`, and to give the
+coprimality `gcd(n, n+2) = 1`.
+-/
+
+open Nat
+open scoped Nat
+
+namespace ClementTwinPrime
+
+/-- The Clement criterion quantity `C(n) = 4·((n-1)! + 1) + n`. -/
+def clementValue (n : ℕ) : ℕ := 4 * ((n - 1)! + 1) + n
+
+/-- Natural-number factorial expansion: `(n+1)! = (n+1)·n·(n-1)!` for `n ≥ 1`. -/
+theorem factorial_succ_eq (n : ℕ) (hn : 1 ≤ n) :
+    (n + 1)! = (n + 1) * (n * (n - 1)!) := by
+  rw [Nat.factorial_succ, ← Nat.mul_factorial_pred (show n ≠ 0 by omega)]
+
+/-- **Modular bridge.** Working modulo `n+2`, where `n+1 ≡ -1` and `n ≡ -2`, the factorial
+`(n+1)!` collapses to `2·(n-1)!`. This is the key identity that lets the single factorial
+`(n-1)!` carry Wilson's congruence at the modulus `n+2`. -/
+theorem factorial_succ_succ_cast (n : ℕ) (hn : 1 ≤ n) :
+    (((n + 1)! : ℕ) : ZMod (n + 2)) = 2 * (((n - 1)! : ℕ) : ZMod (n + 2)) := by
+  have hncast : (n : ZMod (n + 2)) = -2 := by
+    have h0 : ((n + 2 : ℕ) : ZMod (n + 2)) = 0 := ZMod.natCast_self (n + 2)
+    push_cast at h0
+    linear_combination h0
+  rw [factorial_succ_eq n hn]
+  push_cast
+  rw [hncast]
+  ring
+
+variable {n : ℕ}
+
+/-- **Clement's twin-prime criterion.** For odd `n ≥ 3`, the pair `(n, n+2)` is a pair of
+primes iff `n·(n+2)` divides `4·((n-1)! + 1) + n`. -/
+theorem clement_twin_prime (hn : 3 ≤ n) (hodd : Odd n) :
+    (Nat.Prime n ∧ Nat.Prime (n + 2)) ↔ n * (n + 2) ∣ clementValue n := by
+  haveI : NeZero n := ⟨by omega⟩
+  haveI : NeZero (n + 2) := ⟨by omega⟩
+  -- `4` is a unit mod `n` and `2` is a unit mod `n+2` (both from oddness of `n`).
+  have hcop4 : Nat.Coprime 4 n := by
+    have h2 : Nat.Coprime 2 n := Nat.coprime_two_left.mpr hodd
+    have h44 : (4 : ℕ) = 2 * 2 := by norm_num
+    rw [h44, Nat.coprime_mul_iff_left]
+    exact ⟨h2, h2⟩
+  have h4u : IsUnit (4 : ZMod n) := by
+    simpa using (ZMod.isUnit_iff_coprime 4 n).mpr hcop4
+  have hcop2 : Nat.Coprime 2 (n + 2) := Nat.coprime_two_left.mpr (hodd.add_even even_two)
+  have h2u : IsUnit (2 : ZMod (n + 2)) := by
+    simpa using (ZMod.isUnit_iff_coprime 2 (n + 2)).mpr hcop2
+  -- Bridge: `n ∣ C(n)` is exactly Wilson's congruence `(n-1)! ≡ -1 (mod n)`.
+  have hA : n ∣ clementValue n ↔ (((n - 1)! : ℕ) : ZMod n) = -1 := by
+    rw [← ZMod.natCast_eq_zero_iff]
+    unfold clementValue
+    push_cast
+    rw [ZMod.natCast_self n, add_zero, h4u.mul_right_eq_zero, add_eq_zero_iff_eq_neg]
+  -- Bridge: `(n+2) ∣ C(n)` is exactly Wilson's congruence `(n+1)! ≡ -1 (mod n+2)`.
+  have hncast2 : (n : ZMod (n + 2)) = -2 := by
+    have h0 : ((n + 2 : ℕ) : ZMod (n + 2)) = 0 := ZMod.natCast_self (n + 2)
+    push_cast at h0
+    linear_combination h0
+  have hval2 :
+      ((clementValue n : ℕ) : ZMod (n + 2))
+        = 2 * ((((n + 1)! : ℕ) : ZMod (n + 2)) + 1) := by
+    rw [factorial_succ_succ_cast n (by omega)]
+    unfold clementValue
+    push_cast
+    rw [hncast2]
+    ring
+  have hB : (n + 2) ∣ clementValue n ↔ (((n + 1)! : ℕ) : ZMod (n + 2)) = -1 := by
+    rw [← ZMod.natCast_eq_zero_iff, hval2, h2u.mul_right_eq_zero, add_eq_zero_iff_eq_neg]
+  -- Wilson's biconditional at each modulus.
+  have hWn : Nat.Prime n ↔ (((n - 1)! : ℕ) : ZMod n) = -1 :=
+    Nat.prime_iff_fac_equiv_neg_one (by omega)
+  have hWn2 : Nat.Prime (n + 2) ↔ (((n + 1)! : ℕ) : ZMod (n + 2)) = -1 := by
+    have h := Nat.prime_iff_fac_equiv_neg_one (show (n + 2) ≠ 1 by omega)
+    have he : n + 2 - 1 = n + 1 := by omega
+    rwa [he] at h
+  -- Coprimality and the CRT split.
+  have hcop : Nat.Coprime n (n + 2) := by
+    have h := Nat.coprime_add_self_right.mpr (Nat.coprime_two_right.mpr hodd)
+    rwa [Nat.add_comm 2 n] at h
+  have hsplit :
+      n * (n + 2) ∣ clementValue n ↔
+        (n ∣ clementValue n ∧ (n + 2) ∣ clementValue n) := by
+    constructor
+    · intro h
+      exact ⟨(dvd_mul_right n (n + 2)).trans h, (dvd_mul_left (n + 2) n).trans h⟩
+    · rintro ⟨h1, h2⟩
+      exact hcop.mul_dvd_of_dvd_of_dvd h1 h2
+  calc
+    (Nat.Prime n ∧ Nat.Prime (n + 2))
+        ↔ ((((n - 1)! : ℕ) : ZMod n) = -1 ∧ (((n + 1)! : ℕ) : ZMod (n + 2)) = -1) := by
+          rw [hWn, hWn2]
+    _ ↔ (n ∣ clementValue n ∧ (n + 2) ∣ clementValue n) := by rw [hA, hB]
+    _ ↔ n * (n + 2) ∣ clementValue n := hsplit.symm
+
+/-- The smallest twin pair `(3, 5)`: the criterion fires. `C(3) = 4·(2!+1)+3 = 15 = 3·5`. -/
+example : (Nat.Prime 3 ∧ Nat.Prime 5) ↔ 3 * 5 ∣ clementValue 3 :=
+  clement_twin_prime (by norm_num) (by norm_num)
+
+end ClementTwinPrime

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "wilsons-theorem-oq-01-oq-03",
+  "slug": "wilsons-theorem-oq-01-oq-03",
+  "title": "Clement's Twin-Prime Criterion via Wilson at Two Moduli",
+  "meta": {
+    "author": "P. A. Clement (1949); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsClementTwinPrimeOQ0103.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "twin-primes",
+      "primality-criterion",
+      "factorial",
+      "modular-arithmetic",
+      "CRT",
+      "ZMod",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "For n ≠ 1, Prime n ↔ ((n-1)! : ZMod n) = -1 — the full Wilson biconditional (both the forward direction wilsons_lemma and the converse prime_of_fac_equiv_neg_one). Applied at the two moduli n and n+2 to convert each primality into a factorial congruence.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a — the bridge translating the integer divisibility n ∣ C(n) and (n+2) ∣ C(n) into the ring ZMod n / ZMod (n+2) where Wilson's congruences live.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.isUnit_iff_coprime",
+        "description": "IsUnit (m : ZMod n) ↔ Nat.Coprime m n — used (via oddness of n) to make 4 invertible mod n and 2 invertible mod n+2, the cancellations that strip the leading coefficients from the criterion quantity.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+        "description": "For coprime a, b: a ∣ c → b ∣ c → a*b ∣ c. The CRT fusion step: gcd(n, n+2) = 1 (n odd) lets the two single-modulus divisibilities recombine into n*(n+2) ∣ C(n).",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.mul_factorial_pred",
+        "description": "For n ≠ 0, n * (n-1)! = n! — feeds the natural-number expansion (n+1)! = (n+1)·n·(n-1)! underlying the modular bridge lemma.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ],
+    "originalContributions": [
+      "clement_twin_prime: the full simultaneous-primality biconditional — for odd n ≥ 3, (Nat.Prime n ∧ Nat.Prime (n+2)) ↔ n*(n+2) ∣ 4·((n-1)!+1) + n. Mathlib has the single-modulus Wilson biconditional but no twin-prime / simultaneous-primality criterion; this assembles one.",
+      "factorial_succ_succ_cast: the modular bridge (n+1)! ≡ 2·(n-1)! (mod n+2), obtained from n+1 ≡ -1 and n ≡ -2 modulo n+2. This is the device that lets a single factorial (n-1)! carry Wilson's congruence at BOTH moduli n and n+2, so the criterion needs only one factorial rather than two.",
+      "The CRT fusion: reducing n*(n+2) ∣ C(n) to the conjunction n ∣ C(n) ∧ (n+2) ∣ C(n) via the coprimality gcd(n, n+2) = 1 for odd n, then identifying each conjunct with a Wilson congruence by cancelling the invertible leading coefficients (4 mod n, 2 mod n+2).",
+      "Honest framing: the per-modulus content — Prime m ↔ (m-1)! ≡ -1 (mod m) — is Mathlib's Nat.prime_iff_fac_equiv_neg_one (both directions). The original work is the two-modulus assembly: the modular bridge collapsing (n+1)! to 2·(n-1)! mod n+2, the coprimality-driven CRT split, and the unit cancellations that turn the criterion quantity 4·((n-1)!+1)+n into the two Wilson congruences simultaneously."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries; depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (no sorry, no native_decide / Lean.ofReduceBool). Scope note: the result is stated for odd n ≥ 3. Every genuine twin-prime candidate n ≥ 3 is odd (the only even prime is 2, and (2,4) is not a twin pair), so the odd hypothesis discards only the degenerate even branch where n*(n+2) is a multiple of 4 that the criterion quantity never meets. Oddness is used exactly twice: to make 4 a unit mod n and 2 a unit mod n+2, and to give gcd(n, n+2) = 1.",
+    "lineCount": 129,
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Wilson",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "ClementTwinPrime",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/WilsonsClementTwinPrimeOQ0103.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "description": "Clement's theorem (1949): for an odd n ≥ 3, the pair (n, n+2) consists of two primes if and only if n·(n+2) divides 4·((n-1)! + 1) + n. The proof packages two instances of Wilson's theorem — at the moduli n and n+2 — and fuses them by the Chinese remainder theorem (coprime divisors divide simultaneously iff their product does). Mathlib supplies the single-modulus Wilson biconditional Nat.prime_iff_fac_equiv_neg_one but no twin-prime criterion. The distinctive content is the modular bridge (n+1)! ≡ 2·(n-1)! (mod n+2) — from n+1 ≡ -1 and n ≡ -2 — which lets a single factorial (n-1)! govern Wilson's congruence at both moduli, together with the coprimality CRT split and the unit cancellations (4 mod n, 2 mod n+2) that turn the criterion quantity into the two simultaneous Wilson congruences. Includes the worked smallest twin pair (3,5), where C(3) = 4·(2!+1)+3 = 15 = 3·5.",
+  "overview": {
+    "historicalContext": "Wilson's theorem — (p-1)! ≡ -1 (mod p) iff p is prime — is the prototypical factorial primality test. In 1949 P. A. Clement observed that applying it simultaneously at two moduli that differ by 2 yields a single congruence detecting twin primes: (n, n+2) are both prime iff 4((n-1)!+1) + n ≡ 0 (mod n(n+2)). Like Wilson's theorem itself the criterion is of theoretical rather than computational interest — the factorial makes it impractical for large n — but it is a clean, exact, finite characterization of the twin-prime property, and a textbook illustration of fusing two congruences by the Chinese remainder theorem. It remains one of very few closed-form criteria for twin primes.",
+    "problemStatement": "Formalize Clement's criterion: for odd n ≥ 3, prove (Nat.Prime n ∧ Nat.Prime (n+2)) ↔ n*(n+2) ∣ 4·((n-1)!+1) + n, using Mathlib's Wilson biconditional at each modulus and recording the modular factorial bridge that makes a single factorial suffice.",
+    "keyResults": [
+      "Clement's criterion: for odd n ≥ 3, (Nat.Prime n ∧ Nat.Prime (n+2)) ↔ n*(n+2) ∣ 4·((n-1)!+1) + n.",
+      "Modular bridge: (n+1)! ≡ 2·(n-1)! (mod n+2), the reduction of (n+1)! = (n+1)·n·(n-1)! under n+1 ≡ -1, n ≡ -2.",
+      "Factorial expansion: (n+1)! = (n+1)·n·(n-1)! for n ≥ 1.",
+      "Worked instance: the smallest twin pair (3,5), with C(3) = 4·(2!+1)+3 = 15 = 3·5."
+    ],
+    "proofStrategy": "Fix odd n ≥ 3 and let C(n) = 4·((n-1)!+1) + n. Because n and n+2 are coprime (both odd, differing by 2), n*(n+2) ∣ C(n) iff n ∣ C(n) and (n+2) ∣ C(n) (forward by transitivity through n, n+2 ∣ n(n+2); backward by Nat.Coprime.mul_dvd_of_dvd_of_dvd). Each divisibility is transported to ZMod via ZMod.natCast_eq_zero_iff. Modulo n: C(n) ≡ 4·((n-1)!+1) (since n ≡ 0), and 4 is a unit (n odd ⇒ Coprime 4 n), so n ∣ C(n) ↔ (n-1)! ≡ -1 (mod n) — exactly Wilson at n. Modulo n+2: the bridge (n+1)! ≡ 2·(n-1)! turns C(n) ≡ 4·(n-1)! + 4 + n ≡ 4·(n-1)! + 2 into 2·((n+1)! + 1); 2 is a unit (n+2 odd), so (n+2) ∣ C(n) ↔ (n+1)! ≡ -1 (mod n+2) — exactly Wilson at n+2. Mathlib's Nat.prime_iff_fac_equiv_neg_one then converts each congruence to the corresponding primality, and a short calc chains the equivalences.",
+    "keyInsights": [
+      "**Two Wilson congruences at moduli differing by 2 fuse into one divisibility.** The Chinese remainder theorem (here: coprime divisors divide together iff their product does) is what turns the conjunction 'n prime and n+2 prime' into a single n(n+2)-divisibility — the whole point of Clement's reformulation.",
+      "**A single factorial suffices for both moduli.** Naively the criterion mixes (n-1)! (Wilson at n) and (n+1)! (Wilson at n+2). The bridge (n+1)! ≡ 2·(n-1)! (mod n+2), read off from n+1 ≡ -1 and n ≡ -2, expresses the larger factorial through the smaller one, so the criterion quantity uses only (n-1)!.",
+      "**The leading coefficients are invertible exactly because n is odd.** The 4 in 4((n-1)!+1) is a unit mod n and the 2 produced mod n+2 is a unit mod n+2 precisely when n (hence n+2) is odd; this is the only role of the oddness beyond the coprimality, and it is exactly what lets the criterion strip back to Wilson's bare congruences.",
+      "**The criterion is exact, not heuristic.** Unlike density or sieve statements about twin primes, this is a biconditional: it both certifies and refutes twin-primality of (n, n+2) for every odd n ≥ 3."
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes Clement's 1949 twin-prime criterion: for odd n ≥ 3, (n, n+2) are both prime iff n·(n+2) ∣ 4·((n-1)!+1) + n. The per-modulus ingredient is Mathlib's Wilson biconditional Nat.prime_iff_fac_equiv_neg_one; the original work is the two-modulus assembly — the modular bridge (n+1)! ≡ 2·(n-1)! (mod n+2) that lets one factorial serve both moduli, the coprimality-driven CRT split, and the unit cancellations of 4 (mod n) and 2 (mod n+2). 3 theorems, 1 definition, 0 sorries, 0 axioms.",
+    "implications": [
+      "Provides a machine-checked exact criterion for twin primes — a closed-form biconditional rather than an asymptotic or sieve statement — complementing Mathlib's single-modulus Wilson theorem.",
+      "The modular bridge (n+1)! ≡ 2·(n-1)! (mod n+2) is a reusable idiom for any criterion relating factorials at nearby moduli (e.g. cousin primes n, n+4, or other Wilson-style simultaneous tests).",
+      "Illustrates the CRT-fusion pattern — turning a conjunction of primalities into a single divisibility through coprimality — in a fully formal setting."
+    ],
+    "openQuestions": [
+      "Formalize the analogous criterion for cousin primes (n, n+4) or for prime triples, by fusing Wilson at the relevant coprime moduli and supplying the matching factorial bridges.",
+      "Derive the explicit even-n statement (for even n ≥ 4 the criterion quantity is never divisible by n·(n+2)), removing the oddness hypothesis to obtain Clement's criterion verbatim for all n ≥ 2."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "wilsons-theorem-oq-01",
+      "relationship": "extends",
+      "description": "The Wilson-classification parent. This leaf applies the prime ⟺ (m-1)! ≡ -1 (mod m) biconditional simultaneously at two moduli to obtain a twin-prime criterion."
+    },
+    {
+      "proofId": "wilsons-theorem",
+      "relationship": "related",
+      "description": "The base Wilson's theorem entry; Clement's criterion is its canonical two-modulus application."
+    }
+  ],
+  "sections": []
+}


### PR DESCRIPTION
## Clement's Twin-Prime Criterion

**Theorem (Clement, 1949).** For an odd `n ≥ 3`, the pair `(n, n+2)` consists of two primes **iff**
```
4·((n-1)! + 1) + n  ≡  0   (mod n·(n+2)).
```

Answers the open question of pool problem `wilsons-theorem-oq-01-oq-03` (parent: Wilson classification).

### What's new vs. Mathlib
Mathlib has the **single-modulus** Wilson biconditional `Nat.prime_iff_fac_equiv_neg_one` (`Prime n ↔ (n-1)! ≡ -1 mod n`, both directions) but **no twin-prime / simultaneous-primality criterion**. This entry assembles one. The distinctive content:

- **`factorial_succ_succ_cast`** — the modular bridge `(n+1)! ≡ 2·(n-1)! (mod n+2)`, read off from `n+1 ≡ -1` and `n ≡ -2`. This lets a *single* factorial `(n-1)!` carry Wilson's congruence at **both** moduli, so the criterion quantity needs only one factorial.
- **CRT fusion** — `gcd(n, n+2) = 1` (n odd) reduces `n·(n+2) ∣ C(n)` to `n ∣ C(n) ∧ (n+2) ∣ C(n)`.
- **Unit cancellations** — `4` is a unit mod `n` and the `2` produced mod `n+2` is a unit there (both from oddness), stripping the criterion quantity back to the two bare Wilson congruences.

### Scope
Stated for odd `n ≥ 3`. Every genuine twin-prime candidate `n ≥ 3` is odd (the only even prime is 2, and `(2,4)` is not a twin pair), so the hypothesis discards only the degenerate even branch. Oddness is used exactly twice — to invert `4`/`2` and to give `gcd(n, n+2) = 1`.

### Verification
- **0 sorries, 0 axioms** beyond `propext` / `Classical.choice` / `Quot.sound` (no `sorry`, no `native_decide` / `Lean.ofReduceBool`).
- Builds against Mathlib 4.26.0.
- 3 theorems, 1 definition, 129 lines.
- Includes the worked smallest twin pair `(3,5)`: `C(3) = 4·(2!+1)+3 = 15 = 3·5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)