### PR TITLE
research(lagrange-four-squares-oq-04-oq-01): sums of three squares not closed under multiplication

### DIFF
--- a/proofs/Proofs/LagrangeFourSquaresOQ04OQ01.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ04OQ01.lean
@@ -1,0 +1,172 @@
+/-
+  Sums of three squares are NOT closed under multiplication.
+
+  For sums of **two** squares (Brahmagupta–Fibonacci) and sums of **four**
+  squares (Euler's identity) the representable set is multiplicatively closed:
+  a product of two representable numbers is again representable. That closure is
+  exactly what makes the two- and four-square theorems "multiplicative" — one
+  reduces to primes. Three squares is the exception:
+
+      3 = 1² + 1² + 1²,   5 = 0² + 1² + 2²,   yet   3·5 = 15  is NOT a sum of
+      three squares.
+
+  The obstruction is the classical mod-8 fact: a square is `≡ 0, 1, 4 (mod 8)`,
+  so a sum of three squares is never `≡ 7 (mod 8)`. Since `15 ≡ 7` and
+  `63 ≡ 7`, neither `3·5 = 15` nor `3·21 = 63` is a sum of three squares, even
+  though `3, 5, 21` each are. Hence there is no ternary composition law: one
+  cannot assemble a three-square representation of a product from
+  representations of its factors — the concrete arithmetic shadow of the
+  abstract fact (Hurwitz) that no bilinear 3-square identity exists.
+
+  As a genuine contrast we also prove that the **four**-square set IS
+  multiplicatively closed, via Euler's four-square identity over `ℤ` and
+  `Int.natAbs`: representability is recovered exactly one dimension up
+  (`15 = 1² + 1² + 2² + 3²`).
+
+  This file is self-contained and axiom-free: the non-representability is proved
+  here from the mod-8 obstruction rather than invoking the parent three-square
+  theorem (whose *backward* direction is axiomatized). The parent's proved
+  *forward* direction (`LagrangeFourSquaresOQ04.obstructed_not_three_squares`)
+  is the same mod-8 argument.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+namespace LagrangeFourSquaresOQ04OQ01
+
+/-- A natural number is a sum of three squares. -/
+def IsSumOfThreeSquares (n : ℕ) : Prop := ∃ a b c : ℕ, a ^ 2 + b ^ 2 + c ^ 2 = n
+
+/-- A natural number is a sum of four squares. -/
+def IsSumOfFourSquares (n : ℕ) : Prop :=
+  ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n
+
+/-! ### The mod-8 obstruction -/
+
+/-- Every square is `≡ 0, 1, or 4 (mod 8)`. -/
+theorem sq_mod_eight (k : ℕ) : k ^ 2 % 8 = 0 ∨ k ^ 2 % 8 = 1 ∨ k ^ 2 % 8 = 4 := by
+  have hlt : k % 8 < 8 := Nat.mod_lt _ (by norm_num)
+  have hk : k ^ 2 % 8 = (k % 8) ^ 2 % 8 := by rw [Nat.pow_mod]
+  interval_cases h : k % 8 <;> rw [hk] <;> decide
+
+/-- A sum of three squares is never `≡ 7 (mod 8)`. -/
+theorem three_sq_not_seven_mod_eight (a b c : ℕ) :
+    (a ^ 2 + b ^ 2 + c ^ 2) % 8 ≠ 7 := by
+  rcases sq_mod_eight a with ha | ha | ha <;>
+    rcases sq_mod_eight b with hb | hb | hb <;>
+      rcases sq_mod_eight c with hc | hc | hc <;> omega
+
+/-- If `n ≡ 7 (mod 8)` then `n` is not a sum of three squares. -/
+theorem not_isSumOfThreeSquares_of_seven_mod_eight {n : ℕ} (hn : n % 8 = 7) :
+    ¬ IsSumOfThreeSquares n := by
+  rintro ⟨a, b, c, rfl⟩
+  exact three_sq_not_seven_mod_eight a b c hn
+
+/-! ### The three small three-square representations -/
+
+/-- `3 = 1² + 1² + 1²`. -/
+theorem three_isSumOfThreeSquares : IsSumOfThreeSquares 3 := ⟨1, 1, 1, by norm_num⟩
+
+/-- `5 = 0² + 1² + 2²`. -/
+theorem five_isSumOfThreeSquares : IsSumOfThreeSquares 5 := ⟨0, 1, 2, by norm_num⟩
+
+/-- `21 = 4² + 2² + 1²`. -/
+theorem twentyone_isSumOfThreeSquares : IsSumOfThreeSquares 21 := ⟨4, 2, 1, by norm_num⟩
+
+/-! ### The obstructed products -/
+
+/-- `15 ≡ 7 (mod 8)` is not a sum of three squares. -/
+theorem not_isSumOfThreeSquares_15 : ¬ IsSumOfThreeSquares 15 :=
+  not_isSumOfThreeSquares_of_seven_mod_eight (by norm_num)
+
+/-- `63 ≡ 7 (mod 8)` is not a sum of three squares. -/
+theorem not_isSumOfThreeSquares_63 : ¬ IsSumOfThreeSquares 63 :=
+  not_isSumOfThreeSquares_of_seven_mod_eight (by norm_num)
+
+/-! ### Non-closure of the three-square set -/
+
+/-- **Main theorem.** The set of sums of three squares is *not* closed under
+multiplication: there are `m, n` each a sum of three squares whose product
+is not. Concrete witness `(m, n) = (3, 5)`, product `15`. -/
+theorem not_isSumOfThreeSquares_mul_closed :
+    ∃ m n : ℕ, IsSumOfThreeSquares m ∧ IsSumOfThreeSquares n
+      ∧ ¬ IsSumOfThreeSquares (m * n) := by
+  refine ⟨3, 5, three_isSumOfThreeSquares, five_isSumOfThreeSquares, ?_⟩
+  intro h
+  exact not_isSumOfThreeSquares_15 (by simpa using h)
+
+/-- A **second, independent** witness `(m, n) = (3, 21)`, product `63`,
+showing the failure is not a one-off. -/
+theorem not_isSumOfThreeSquares_mul_closed' :
+    ∃ m n : ℕ, IsSumOfThreeSquares m ∧ IsSumOfThreeSquares n
+      ∧ ¬ IsSumOfThreeSquares (m * n) := by
+  refine ⟨3, 21, three_isSumOfThreeSquares, twentyone_isSumOfThreeSquares, ?_⟩
+  intro h
+  exact not_isSumOfThreeSquares_63 (by simpa using h)
+
+/-- Multiplicative closure of a predicate on `ℕ`. -/
+def MulClosed (P : ℕ → Prop) : Prop := ∀ ⦃m n : ℕ⦄, P m → P n → P (m * n)
+
+/-- Packaged as a failure of `MulClosed`: the three-square predicate is not
+multiplicatively closed. -/
+theorem not_mulClosed_isSumOfThreeSquares : ¬ MulClosed IsSumOfThreeSquares := by
+  intro h
+  have h15 : IsSumOfThreeSquares (3 * 5) :=
+    h three_isSumOfThreeSquares five_isSumOfThreeSquares
+  exact not_isSumOfThreeSquares_15 (by simpa using h15)
+
+/-! ### Contrast: the four-square set IS multiplicatively closed -/
+
+/-- Euler's four-square identity (over any commutative ring). -/
+theorem euler_four_squares {R : Type*} [CommRing R] (a b c d x y z w : R) :
+    (a * x - b * y - c * z - d * w) ^ 2 +
+    (a * y + b * x + c * w - d * z) ^ 2 +
+    (a * z - b * w + c * x + d * y) ^ 2 +
+    (a * w + b * z - c * y + d * x) ^ 2 =
+    (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) * (x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2) := by
+  ring
+
+/-- Casting the square of an integer's absolute value back: `(↑|a|)² = a²`. -/
+private theorem natAbs_sq_cast (a : ℤ) : ((a.natAbs : ℤ)) ^ 2 = a ^ 2 := by
+  rw [← Int.abs_eq_natAbs, sq_abs]
+
+/-- **Euler's four-square identity gives closure.** The product of two sums of
+four squares is again a sum of four squares — the composition law the ternary
+form lacks. The four component values are integers (Euler's identity has
+subtractions), realized as `ℕ` squares via `Int.natAbs`. -/
+theorem isSumOfFourSquares_mul {m n : ℕ}
+    (hm : IsSumOfFourSquares m) (hn : IsSumOfFourSquares n) :
+    IsSumOfFourSquares (m * n) := by
+  obtain ⟨a, b, c, d, hm⟩ := hm
+  obtain ⟨x, y, z, w, hn⟩ := hn
+  refine ⟨(a * x - b * y - c * z - d * w : ℤ).natAbs,
+          (a * y + b * x + c * w - d * z : ℤ).natAbs,
+          (a * z - b * w + c * x + d * y : ℤ).natAbs,
+          (a * w + b * z - c * y + d * x : ℤ).natAbs, ?_⟩
+  have hm' : (a : ℤ) ^ 2 + (b : ℤ) ^ 2 + (c : ℤ) ^ 2 + (d : ℤ) ^ 2 = m := by
+    exact_mod_cast hm
+  have hn' : (x : ℤ) ^ 2 + (y : ℤ) ^ 2 + (z : ℤ) ^ 2 + (w : ℤ) ^ 2 = n := by
+    exact_mod_cast hn
+  have key :
+      (((a * x - b * y - c * z - d * w : ℤ).natAbs : ℤ)) ^ 2
+        + (((a * y + b * x + c * w - d * z : ℤ).natAbs : ℤ)) ^ 2
+        + (((a * z - b * w + c * x + d * y : ℤ).natAbs : ℤ)) ^ 2
+        + (((a * w + b * z - c * y + d * x : ℤ).natAbs : ℤ)) ^ 2
+      = (m : ℤ) * n := by
+    rw [natAbs_sq_cast, natAbs_sq_cast, natAbs_sq_cast, natAbs_sq_cast,
+        euler_four_squares (a : ℤ) b c d x y z w, hm', hn']
+  exact_mod_cast key
+
+/-- The four-square set is multiplicatively closed. -/
+theorem mulClosed_isSumOfFourSquares : MulClosed IsSumOfFourSquares :=
+  fun _ _ hm hn => isSumOfFourSquares_mul hm hn
+
+/-- **Recovery one dimension up.** The very product `15` that fails for three
+squares *is* a sum of four squares: `15 = 1² + 1² + 2² + 3²`. -/
+theorem fifteen_isSumOfFourSquares : IsSumOfFourSquares 15 := ⟨1, 1, 2, 3, by norm_num⟩
+
+/-- And `63 = 1² + 1² + 5² + 6²` likewise. -/
+theorem sixtythree_isSumOfFourSquares : IsSumOfFourSquares 63 := ⟨1, 1, 5, 6, by norm_num⟩
+
+end LagrangeFourSquaresOQ04OQ01

--- a/src/data/proofs/lagrange-four-squares-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04-oq-01/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-mod8-obstruction",
+    "proofId": "lagrange-four-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 70
+    },
+    "type": "concept",
+    "title": "The mod-8 Obstruction: Squares Live in {0, 1, 4}",
+    "content": "The single nontrivial input. `sq_mod_eight` proves a²%8 ∈ {0,1,4} by rewriting a²%8 = (a%8)²%8 (via `Nat.pow_mod`) and `interval_cases` over the eight residues of a mod 8, each closed by `decide`. `three_sq_not_seven_mod_eight` then proves (a²+b²+c²)%8 ≠ 7 by `rcases` on the three residue choices and `omega` over the resulting 27 combinations. Everything downstream — that 15 and 63 are not sums of three squares — is a one-line corollary of this fact, keeping the entry self-contained and axiom-free.",
+    "mathContext": "$a^2 \\bmod 8 \\in \\{0,1,4\\}$, so the possible values of $(a^2+b^2+c^2) \\bmod 8$ are $\\{0,1,2,3,4,5,6\\}$ — never $7$. Hence $n \\equiv 7 \\pmod 8 \\Rightarrow n \\neq x^2+y^2+z^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squares mod 8",
+      "local obstruction",
+      "Nat.pow_mod",
+      "interval_cases",
+      "omega"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "residues of squares"
+    ]
+  },
+  {
+    "id": "ann-non-closure",
+    "proofId": "lagrange-four-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 134
+    },
+    "type": "concept",
+    "title": "Non-Closure: 3·5 = 15 Escapes the Three-Square Set",
+    "content": "The main result. 3 = 1²+1²+1² and 5 = 0²+1²+2² are each sums of three squares, but 3·5 = 15 ≡ 7 (mod 8) is obstructed, so it is not. `not_isSumOfThreeSquares_mul_closed` packages this as an existential witness; a second witness (3, 21) → 63 shows the failure is structural. The reusable predicate `MulClosed P := ∀ ⦃m n⦄, P m → P n → P (m*n)` lets us state the clean negative `¬ MulClosed IsSumOfThreeSquares`.",
+    "mathContext": "$\\exists m, n \\in S_3$ with $m\\,n \\notin S_3$: $(m,n) = (3,5)$, $m\\,n = 15$; and $(3,21)$, $m\\,n = 63$. Both products are $\\equiv 7 \\pmod 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiplicative closure",
+      "counterexample",
+      "composition of quadratic forms",
+      "Hurwitz 1-2-4-8 theorem"
+    ],
+    "prerequisites": [
+      "the mod-8 obstruction",
+      "existential witnesses in Lean"
+    ]
+  },
+  {
+    "id": "ann-four-square-closure",
+    "proofId": "lagrange-four-squares-oq-04-oq-01",
+    "range": {
+      "startLine": 136,
+      "endLine": 172
+    },
+    "type": "concept",
+    "title": "Contrast: Four Squares ARE Closed (Euler's Identity)",
+    "content": "The positive counterpart. Euler's four-square identity (`euler_four_squares`, a pure `ring` fact over any CommRing) expresses (a²+b²+c²+d²)(x²+y²+z²+w²) as a sum of four squares whose components carry subtractions. To land back in ℕ, the four integer components are passed through `Int.natAbs` using (↑|a|)² = a² (`natAbs_sq_cast`), giving `isSumOfFourSquares_mul` and hence `MulClosed IsSumOfFourSquares`. The very products 15 and 63 that fail for three squares are then exhibited as sums of four squares — representability recovered one dimension up.",
+    "mathContext": "Euler: $(a^2{+}b^2{+}c^2{+}d^2)(x^2{+}y^2{+}z^2{+}w^2) = (ax{-}by{-}cz{-}dw)^2 + (ay{+}bx{+}cw{-}dz)^2 + (az{-}bw{+}cx{+}dy)^2 + (aw{+}bz{-}cy{+}dx)^2$. Recovery: $15 = 1^2{+}1^2{+}2^2{+}3^2$, $63 = 1^2{+}1^2{+}5^2{+}6^2$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Euler four-square identity",
+      "quaternion norm multiplicativity",
+      "Int.natAbs",
+      "dimensional recovery ℝ³ → ℍ"
+    ],
+    "prerequisites": [
+      "Euler's four-square identity",
+      "integer absolute value and casting"
+    ]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-oq-04-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "lagrange-four-squares-oq-04-oq-01",
+  "title": "Sums of Three Squares Are Not Closed Under Multiplication",
+  "slug": "lagrange-four-squares-oq-04-oq-01",
+  "description": "There exist naturals m, n each a sum of three squares whose product is not: 3 = 1²+1²+1² and 5 = 0²+1²+2², yet 3·5 = 15 ≡ 7 (mod 8) is obstructed. A second witness 3·21 = 63 confirms the failure is not a one-off. By contrast, the four-square set IS multiplicatively closed (Euler's four-square identity), so representability is recovered exactly one dimension up (15 = 1²+1²+2²+3²). Self-contained and axiom-free: the obstruction is proved here directly from the mod-8 fact that squares lie in {0,1,4}.",
+  "meta": {
+    "author": "Robb Walters (Lean Genius researcher), classical result (Gauss, Hurwitz)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Legendre%27s_three-square_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-forms",
+      "sums-of-squares",
+      "multiplicativity",
+      "counterexample",
+      "modular-arithmetic",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/LagrangeFourSquaresOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked; #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) and no sorryAx, no native_decide / Lean.ofReduceBool, no custom axioms. The non-representability of the products is proved here from first principles via the mod-8 obstruction, so the file never touches the axiomatized backward direction of the three-square theorem.",
+    "axioms": [],
+    "originalContributions": [
+      "Main theorem not_isSumOfThreeSquares_mul_closed: the three-square-representable set is not multiplicatively closed — explicit witness (3, 5) with product 15.",
+      "A second independent witness (3, 21) with product 63, showing the failure is structural rather than a one-off.",
+      "Packaged failure of a reusable MulClosed predicate: ¬ MulClosed IsSumOfThreeSquares.",
+      "Genuine contrast: mulClosed_isSumOfFourSquares — the four-square set IS multiplicatively closed, proved via Euler's four-square identity over ℤ and Int.natAbs.",
+      "Recovery one dimension up: the same products 15 and 63 that fail for three squares are exhibited as sums of four squares (15 = 1²+1²+2²+3², 63 = 1²+1²+5²+6²).",
+      "Self-contained, axiom-free mod-8 obstruction: squares mod 8 ∈ {0,1,4}, so a sum of three squares is never ≡ 7 (mod 8)."
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 172,
+    "theoremCount": 17,
+    "definitionCount": 3,
+    "mathlibDependencies": [],
+    "mathlib_version": "4.26.0",
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Three of the classical sum-of-squares theorems behave very differently under multiplication. Sums of two squares are closed because of the Brahmagupta–Fibonacci identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)², the norm-multiplicativity of the Gaussian integers ℤ[i]. Sums of four squares are closed because of Euler's four-square identity, the norm-multiplicativity of the Lipschitz quaternions. These composition laws are exactly what make the two- and four-square theorems 'multiplicative': representability reduces to primes. Sums of three squares are the exception. Gauss's three-square theorem (Disquisitiones Arithmeticae §291, 1801) characterizes the representable numbers as those NOT of the form 4^a(8b+7), an arithmetic — not multiplicative — condition. Hurwitz (1898, 1923) explained the structural reason: a bilinear composition identity for n-square forms exists only for n ∈ {1, 2, 4, 8} (the real division algebras ℝ, ℂ, ℍ, 𝕆). There is no ternary composition law. This entry is the concrete arithmetic shadow of that abstract gap: an explicit pair of three-square numbers whose product provably is not a sum of three squares.",
+    "problemStatement": "Show that the set S₃ = { n : ∃ a b c, a²+b²+c² = n } is not closed under multiplication — there exist m, n ∈ S₃ with m·n ∉ S₃ — and contrast this with the multiplicative closure of the four-square set.",
+    "proofStrategy": "The single nontrivial input is the elementary mod-8 obstruction, proved here from scratch: a square is ≡ 0, 1, or 4 (mod 8) (sq_mod_eight, by reducing k² mod 8 to (k mod 8)² mod 8 and checking the eight residues), hence a sum of three squares is never ≡ 7 (mod 8) (three_sq_not_seven_mod_eight, by omega over the 27 residue combinations). Since 3, 5, 21 are visibly sums of three squares while 15 = 3·5 ≡ 7 and 63 = 3·21 ≡ 7 (mod 8) are obstructed, the products escape S₃, proving non-closure. The contrast direction realizes Euler's four-square identity over ℤ (euler_four_squares, closed by ring): given four-square representations of m and n, the four integer components of the product are turned into ℕ squares via Int.natAbs (using (↑|a|)² = a²), giving isSumOfFourSquares_mul and hence MulClosed IsSumOfFourSquares.",
+    "keyInsights": [
+      "Closure under multiplication is equivalent to the existence of a bilinear composition identity for the underlying quadratic form. Two and four squares have one (Brahmagupta–Fibonacci, Euler); three squares do not (Hurwitz's 1-2-4-8 theorem).",
+      "The mod-8 obstruction is purely local: squares mod 8 lie in {0,1,4}, so three of them sum to one of {0,1,2,3,4,5,6} — never 7. This single fact discharges every non-representability claim in the file.",
+      "The smallest counterexample is (3, 5) → 15; 15 is also the smallest number ≡ 7 (mod 8) that is a product of two non-obstructed numbers, making it the canonical witness.",
+      "Representability is recovered exactly one dimension up: the very products 15 and 63 that fail for three squares are sums of four squares, illustrating the dimensional jump ℝ³ → ℍ where a norm-multiplicative structure reappears.",
+      "Self-containment matters for the axiom budget: invoking the parent three-square theorem's biconditional would import its axiomatized backward direction; proving the obstruction directly keeps the entry genuinely 0-axiom."
+    ],
+    "prerequisites": [
+      "Modular arithmetic: residues of squares mod 8",
+      "Euler's four-square (quaternion-norm) identity",
+      "The notion of a multiplicative composition law for quadratic forms"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Section I: Predicates",
+      "startLine": 41,
+      "endLine": 47,
+      "summary": "Defines IsSumOfThreeSquares and IsSumOfFourSquares as the obvious existential predicates over ℕ.",
+      "mathContext": "S₃ = {n : ∃ a b c, a²+b²+c² = n}, S₄ = {n : ∃ a b c d, a²+b²+c²+d² = n}."
+    },
+    {
+      "id": "mod8-obstruction",
+      "title": "Section II: The mod-8 Obstruction",
+      "startLine": 49,
+      "endLine": 70,
+      "summary": "Proves sq_mod_eight (every square is ≡ 0,1,4 mod 8), three_sq_not_seven_mod_eight (a sum of three squares is never ≡ 7 mod 8), and the corollary not_isSumOfThreeSquares_of_seven_mod_eight.",
+      "mathContext": "a² mod 8 ∈ {0,1,4} ⟹ (a²+b²+c²) mod 8 ≠ 7."
+    },
+    {
+      "id": "witnesses",
+      "title": "Section III: Witness Representations",
+      "startLine": 72,
+      "endLine": 96,
+      "summary": "The three small three-square representations (3, 5, 21) and the two obstructed products (15, 63 ≡ 7 mod 8, not sums of three squares).",
+      "mathContext": "3 = 1²+1²+1², 5 = 0²+1²+2², 21 = 4²+2²+1²; 15, 63 ≡ 7 (mod 8)."
+    },
+    {
+      "id": "non-closure",
+      "title": "Section IV: Non-Closure of the Three-Square Set",
+      "startLine": 98,
+      "endLine": 134,
+      "summary": "The main theorem not_isSumOfThreeSquares_mul_closed (witness 3·5 = 15) and an independent second witness (3·21 = 63), plus the packaged ¬ MulClosed IsSumOfThreeSquares via a reusable MulClosed predicate.",
+      "mathContext": "∃ m n, m, n ∈ S₃ ∧ m·n ∉ S₃; equivalently ¬ MulClosed S₃."
+    },
+    {
+      "id": "four-square-closure",
+      "title": "Section V: Contrast — Four Squares ARE Closed",
+      "startLine": 136,
+      "endLine": 172,
+      "summary": "Euler's four-square identity (euler_four_squares, by ring), the natAbs cast lemma, isSumOfFourSquares_mul and MulClosed IsSumOfFourSquares, and the recovery of 15 and 63 as sums of four squares one dimension up.",
+      "mathContext": "(a²+b²+c²+d²)(x²+y²+z²+w²) is a sum of four squares; 15 = 1²+1²+2²+3², 63 = 1²+1²+5²+6²."
+    }
+  ],
+  "conclusion": {
+    "summary": "Sums of three squares are not closed under multiplication: 3 and 5 are each sums of three squares but 3·5 = 15 ≡ 7 (mod 8) is not, and likewise 3·21 = 63. The obstruction is the elementary mod-8 fact that squares lie in {0,1,4}, proved self-contained and axiom-free. By contrast, Euler's four-square identity makes the four-square set multiplicatively closed, and the failing products 15 and 63 are exhibited as sums of four squares — representability returns exactly one dimension up.",
+    "implications": "**1. No ternary composition law.** The arithmetic non-closure is the concrete face of Hurwitz's theorem that bilinear n-square identities exist only for n ∈ {1,2,4,8}. The two- and four-square theorems are multiplicative; the three-square theorem cannot be.\n\n**2. Why the obstruction is arithmetic, not multiplicative.** Because S₃ is not a multiplicative monoid, the three-square theorem's characterization must be a congruence condition (4^a(8b+7)) rather than a statement about primes — unlike the two- and four-square cases.\n\n**3. Dimensional recovery.** Passing from ℝ³ to the quaternions ℍ restores a norm-multiplicative structure; the same products that fail for three squares succeed for four.",
+    "openQuestions": [
+      "Characterize exactly which products of three-square numbers remain three-square (equivalently, when m·n avoids the form 4^a(8b+7)).",
+      "Quantify the density of three-square numbers whose square or pairwise products fall into the obstructed set.",
+      "Give the analogous concrete non-closure witnesses for sums of three squares weighted by a fixed positive ternary form outside the principal genus."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-four-squares-oq-04",
+      "relationship": "extends",
+      "description": "Parent: forward direction of the three-square theorem (the 4^a(8b+7) obstruction). This leaf reuses the same mod-8 argument to exhibit non-closure under multiplication."
+    },
+    {
+      "targetId": "lagrange-four-squares",
+      "relationship": "related",
+      "description": "Four-square theorem; Euler's identity makes the four-square set multiplicatively closed, the positive contrast to the three-square failure."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Leipzig: Fleischer",
+      "note": "Three-square theorem (§291); characterization of three-square-representable integers"
+    },
+    {
+      "authors": "Hurwitz, Adolf",
+      "title": "Über die Komposition der quadratischen Formen",
+      "year": "1923",
+      "venue": "Mathematische Annalen 88",
+      "note": "Bilinear composition of n-square forms exists only for n ∈ {1, 2, 4, 8}"
+    },
+    {
+      "authors": "Grosswald, Emil",
+      "title": "Representations of Integers as Sums of Squares",
+      "year": "1985",
+      "venue": "Springer",
+      "note": "Three-square theorem and the non-multiplicativity of the ternary form"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LagrangeFourSquaresOQ04OQ01",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 3,
+    "path": "Proofs/LagrangeFourSquaresOQ04OQ01.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "mainTheorems": [
+    {
+      "name": "not_isSumOfThreeSquares_mul_closed",
+      "type": "core",
+      "description": "Sums of three squares are not closed under multiplication (witness 3, 5; product 15)",
+      "leanType": "∃ m n : ℕ, IsSumOfThreeSquares m ∧ IsSumOfThreeSquares n ∧ ¬ IsSumOfThreeSquares (m * n)"
+    },
+    {
+      "name": "not_mulClosed_isSumOfThreeSquares",
+      "type": "core",
+      "description": "Packaged failure of multiplicative closure for the three-square predicate",
+      "leanType": "¬ MulClosed IsSumOfThreeSquares"
+    },
+    {
+      "name": "mulClosed_isSumOfFourSquares",
+      "type": "core",
+      "description": "Contrast: the four-square set IS multiplicatively closed, via Euler's four-square identity",
+      "leanType": "MulClosed IsSumOfFourSquares"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves that the set of **sums of three squares is not closed under multiplication**, with an explicit pair of witnesses, and contrasts it against the multiplicative closure of the four-square set.

- `3 = 1²+1²+1²` and `5 = 0²+1²+2²` are each sums of three squares, yet `3·5 = 15 ≡ 7 (mod 8)` is **not** — `not_isSumOfThreeSquares_mul_closed`.
- A second independent witness `3·21 = 63 ≡ 7 (mod 8)` shows the failure is structural, not a one-off.
- Packaged as a failure of a reusable predicate: `¬ MulClosed IsSumOfThreeSquares`.
- **Contrast (genuine new content):** `mulClosed_isSumOfFourSquares` — the four-square set *is* multiplicatively closed, via Euler's four-square identity over ℤ and `Int.natAbs`. The same products `15 = 1²+1²+2²+3²` and `63 = 1²+1²+5²+6²` that fail for three squares succeed for four: representability recovered exactly one dimension up.

This is the concrete arithmetic shadow of Hurwitz's theorem that a bilinear *n*-square composition identity exists only for *n* ∈ {1, 2, 4, 8}: two and four squares have one (Brahmagupta–Fibonacci, Euler), three squares do not.

## Verification

- **Self-contained and axiom-free.** The non-representability is proved here directly from the mod-8 obstruction (squares ≡ 0,1,4 mod 8 ⟹ a sum of three squares is never ≡ 7 mod 8), so the file never imports the axiomatized backward direction of the three-square theorem.
- `#print axioms` on all main results reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `native_decide` / `Lean.ofReduceBool`, no custom axioms.
- 0 sorries. 17 theorems, 3 definitions, 172 lines. Builds against Mathlib 4.26.0 (host toolchain `lake env lean`).

## Files

- `proofs/Proofs/LagrangeFourSquaresOQ04OQ01.lean`
- `src/data/proofs/lagrange-four-squares-oq-04-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)