### PR TITLE
research(quadratic-reciprocity-oq-03-oq-02): mod-4 decision rule for the reciprocity swap sign [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityOQ03OQ02.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ03OQ02.lean
@@ -1,0 +1,235 @@
+import Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity
+import Mathlib.Tactic
+
+/-
+# The Reciprocity Swap Sign as a mod-4 Decision Rule
+
+Open Question (from `quadratic-reciprocity-oq-03`, sibling of the `p % 8`
+factor-2 decision form `quadratic-reciprocity-oq-03-oq-01`):
+
+  The parent's reduction toolkit carries the reciprocity sign as the opaque
+  exponent `(-1)^((p/2)·(q/2))`. Package that sign as a **decidable mod-4 test**:
+  a branch-free criterion, in terms of `p % 4` and `q % 4` alone, telling the
+  Legendre-symbol algorithm whether the swap `(q/p) ↔ (p/q)` is sign-preserving
+  or sign-flipping.
+
+Answer: **YES.** The textbook rule — the two symbols *agree* unless **both**
+primes are `≡ 3 (mod 4)`, in which case they have *opposite* signs — becomes a
+proved biconditional. Mathlib provides only the two one-directional special
+cases `legendreSym.quadratic_reciprocity_one_mod_four` (if `p ≡ 1`, agree) and
+`legendreSym.quadratic_reciprocity_three_mod_four` (if both `≡ 3`, flip), plus
+the exponent-form swap `legendreSym.quadratic_reciprocity'`. It has **no single
+iff** stating the full agree/disagree dichotomy in residue terms. This file
+supplies it.
+
+## Results
+
+1. `reciprocity_sign_eq_neg_one_iff` — the standalone sign lemma
+   `(-1)^((p/2)(q/2)) = -1 ↔ p ≡ 3 ∧ q ≡ 3 (mod 4)` (pure parity arithmetic).
+2. `reciprocity_disagree_iff` — `(p/q) = -(q/p) ↔ p ≡ 3 ∧ q ≡ 3 (mod 4)`.
+3. `reciprocity_agree_iff` — `(p/q) = (q/p) ↔ p ≡ 1 ∨ q ≡ 1 (mod 4)`.
+4. `reciprocity_swap_value` — the sign as a branch: `(p/q) = (if both ≡ 3 then
+   -1 else 1) · (q/p)`, the form a recursive algorithm actually evaluates.
+5. `agree_iff_not_disagree` — the dichotomy is exhaustive and exclusive.
+6. `decide`-verified corroboration on small primes.
+
+Here `legendreSym n a` is the symbol `(a / n)` (modulus first), so
+`legendreSym q p` is `(p / q)` and `legendreSym p q` is `(q / p)`.
+
+## Status
+- [x] Complete — 0 sorries, 0 axioms
+-/
+
+set_option linter.unusedVariables false
+
+open ZMod
+
+namespace QRMod4Sign
+
+-- ============================================================
+-- PART 1: The standalone sign lemma (pure parity arithmetic)
+-- ============================================================
+
+/-- **The reciprocity sign as a mod-4 condition.**
+
+    For odd `p, q`, the swap sign `(-1)^((p/2)·(q/2))` is `-1` exactly when both
+    `p` and `q` are `≡ 3 (mod 4)`. This is the purely arithmetic core of the
+    decision rule: it ties the exponent `(p/2)(q/2)` to the joint residue
+    condition. The exponent is odd iff both factors `p/2` and `q/2` are odd, and
+    for an odd number `p` the half `p/2` is odd iff `p ≡ 3 (mod 4)`. -/
+theorem reciprocity_sign_eq_neg_one_iff (p q : ℕ) (hp : p % 2 = 1) (hq : q % 2 = 1) :
+    ((-1 : ℤ)) ^ (p / 2 * (q / 2)) = -1 ↔ (p % 4 = 3 ∧ q % 4 = 3) := by
+  have hpow : ((-1 : ℤ)) ^ (p / 2 * (q / 2)) = -1 ↔ Odd (p / 2 * (q / 2)) := by
+    constructor
+    · intro h
+      by_contra hodd
+      rw [Nat.not_odd_iff_even] at hodd
+      rw [hodd.neg_one_pow] at h
+      norm_num at h
+    · intro h
+      exact h.neg_one_pow
+  have key : Odd (p / 2 * (q / 2)) ↔ (p % 4 = 3 ∧ q % 4 = 3) := by
+    rw [Nat.odd_mul, Nat.odd_iff, Nat.odd_iff]
+    omega
+  exact hpow.trans key
+
+-- ============================================================
+-- PART 2: The agree / disagree biconditionals
+-- ============================================================
+
+/-- An odd prime is `≡ 1` or `≡ 3 (mod 4)`. -/
+private theorem mod_two_one (p : ℕ) [Fact p.Prime] (hp : p ≠ 2) : p % 2 = 1 :=
+  ((Fact.out : p.Prime).eq_two_or_odd).resolve_left hp
+
+/-- `(q / p)` (i.e. `legendreSym p q`) is nonzero when `p ≠ q` are primes, since
+    then `p ∤ q`. -/
+private theorem legendre_ne_zero (p q : ℕ) [Fact p.Prime] [Fact q.Prime]
+    (hpq : p ≠ q) : ((q : ℤ) : ZMod p) ≠ 0 := by
+  have e : ((q : ℤ) : ZMod p) = ((q : ℕ) : ZMod p) := by norm_cast
+  rw [e]
+  intro hz
+  rw [ZMod.natCast_eq_zero_iff] at hz
+  rw [Nat.prime_dvd_prime_iff_eq (Fact.out : p.Prime) (Fact.out : q.Prime)] at hz
+  exact hpq hz
+
+/-- **Disagree criterion.** For distinct odd primes `p, q`, the reciprocity swap
+    flips the sign — `(p/q) = -(q/p)` — **iff** both primes are `≡ 3 (mod 4)`.
+
+    This is the genuine biconditional behind Mathlib's one-directional
+    `quadratic_reciprocity_three_mod_four`. The forward direction uses that the
+    symbols are `±1` (hence nonzero), so `(p/q) = -(q/p)` cannot hold when the
+    swap sign is `+1`. -/
+theorem reciprocity_disagree_iff (p q : ℕ) [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym q p = - legendreSym p q ↔ (p % 4 = 3 ∧ q % 4 = 3) := by
+  have hp2 := mod_two_one p hp
+  have hq2 := mod_two_one q hq
+  have hL0 := legendre_ne_zero p q hpq
+  have hval := legendreSym.eq_one_or_neg_one (p := p) hL0
+  have hrec := legendreSym.quadratic_reciprocity' (p := p) (q := q) hp hq
+  have hsign := reciprocity_sign_eq_neg_one_iff p q hp2 hq2
+  rcases Nat.even_or_odd (p / 2 * (q / 2)) with hev | hod
+  · -- swap sign is +1: both sides of the iff are false
+    rw [hev.neg_one_pow, one_mul] at hrec
+    rw [hrec]
+    constructor
+    · intro hbad
+      rcases hval with h1 | h1 <;> rw [h1] at hbad <;> norm_num at hbad
+    · intro hbad
+      have heq : ((-1 : ℤ)) ^ (p / 2 * (q / 2)) = -1 := hsign.mpr hbad
+      rw [hev.neg_one_pow] at heq
+      norm_num at heq
+  · -- swap sign is -1: both sides of the iff are true
+    rw [hod.neg_one_pow, neg_one_mul] at hrec
+    constructor
+    · intro _
+      exact hsign.mp hod.neg_one_pow
+    · intro _
+      exact hrec
+
+/-- **Agree criterion.** For distinct odd primes `p, q`, the reciprocity swap is
+    sign-preserving — `(p/q) = (q/p)` — **iff** at least one of `p, q` is
+    `≡ 1 (mod 4)`. This is the exact complement of `reciprocity_disagree_iff`. -/
+theorem reciprocity_agree_iff (p q : ℕ) [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym q p = legendreSym p q ↔ (p % 4 = 1 ∨ q % 4 = 1) := by
+  have hp2 := mod_two_one p hp
+  have hq2 := mod_two_one q hq
+  have hp4 : p % 4 = 1 ∨ p % 4 = 3 := by omega
+  have hq4 : q % 4 = 1 ∨ q % 4 = 3 := by omega
+  have hL0 := legendre_ne_zero p q hpq
+  have hval := legendreSym.eq_one_or_neg_one (p := p) hL0
+  have hrec := legendreSym.quadratic_reciprocity' (p := p) (q := q) hp hq
+  have hsign := reciprocity_sign_eq_neg_one_iff p q hp2 hq2
+  rcases Nat.even_or_odd (p / 2 * (q / 2)) with hev | hod
+  · -- swap sign is +1: LHS holds, and RHS holds since not both ≡ 3
+    rw [hev.neg_one_pow, one_mul] at hrec
+    constructor
+    · intro _
+      have hnb : ¬ (p % 4 = 3 ∧ q % 4 = 3) := by
+        rw [← hsign, hev.neg_one_pow]; norm_num
+      omega
+    · intro _
+      exact hrec
+  · -- swap sign is -1: LHS fails (symbols are ±1) and RHS fails (both ≡ 3)
+    rw [hod.neg_one_pow, neg_one_mul] at hrec
+    constructor
+    · intro hbad
+      rw [hrec] at hbad
+      rcases hval with h1 | h1 <;> rw [h1] at hbad <;> norm_num at hbad
+    · intro hbad
+      have heq : ((-1 : ℤ)) ^ (p / 2 * (q / 2)) = -1 := hod.neg_one_pow
+      rw [hsign] at heq
+      omega
+
+-- ============================================================
+-- PART 3: The sign as a branch, and exhaustive/exclusive dichotomy
+-- ============================================================
+
+/-- **The swap sign as a branch-free decision.** This is the form a recursive
+    Legendre-symbol algorithm actually evaluates: read `p % 4` and `q % 4`, and
+    the swap multiplies by `-1` precisely when both are `3`, otherwise by `1`. -/
+theorem reciprocity_swap_value (p q : ℕ) [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) :
+    legendreSym q p = (if p % 4 = 3 ∧ q % 4 = 3 then (-1 : ℤ) else 1) * legendreSym p q := by
+  have hp2 := mod_two_one p hp
+  have hq2 := mod_two_one q hq
+  have hsign := reciprocity_sign_eq_neg_one_iff p q hp2 hq2
+  rw [legendreSym.quadratic_reciprocity' hp hq]
+  congr 1
+  by_cases h : p % 4 = 3 ∧ q % 4 = 3
+  · rw [if_pos h]; exact hsign.mpr h
+  · rw [if_neg h]
+    rcases Nat.even_or_odd (p / 2 * (q / 2)) with hev | hod
+    · exact hev.neg_one_pow
+    · exact absurd (hsign.mp hod.neg_one_pow) h
+
+/-- **The dichotomy is exhaustive and exclusive.** For distinct odd primes the
+    swap either preserves or flips the sign — never both, never neither — so the
+    agree predicate is exactly the negation of the disagree predicate. -/
+theorem agree_iff_not_disagree (p q : ℕ) [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+    legendreSym q p = legendreSym p q ↔ ¬ (legendreSym q p = - legendreSym p q) := by
+  have hp2 := mod_two_one p hp
+  have hq2 := mod_two_one q hq
+  have hp4 : p % 4 = 1 ∨ p % 4 = 3 := by omega
+  have hq4 : q % 4 = 1 ∨ q % 4 = 3 := by omega
+  rw [reciprocity_agree_iff p q hp hq hpq, reciprocity_disagree_iff p q hp hq hpq]
+  omega
+
+-- ============================================================
+-- PART 4: Verified corroboration on small primes
+-- ============================================================
+
+section Examples
+
+local instance : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+local instance : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+local instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+local instance : Fact (Nat.Prime 11) := ⟨by norm_num⟩
+local instance : Fact (Nat.Prime 13) := ⟨by norm_num⟩
+
+/-- `3, 7 ≡ 3 (mod 4)`, so the swap **disagrees**: `(7/3) = -(3/7)`. -/
+example : legendreSym 7 3 = - legendreSym 3 7 := by decide
+
+/-- `13 ≡ 1 (mod 4)`, so the swap **agrees**: `(5/13) = (13/5)`. -/
+example : legendreSym 13 5 = legendreSym 5 13 := by decide
+
+/-- `11, 7 ≡ 3 (mod 4)`, so the swap **disagrees**: `(7/11) = -(11/7)`. -/
+example : legendreSym 11 7 = - legendreSym 7 11 := by decide
+
+/-- `5 ≡ 1 (mod 4)`, so the swap **agrees**: `(3/5) = (5/3)`. -/
+example : legendreSym 5 3 = legendreSym 3 5 := by decide
+
+/-- The standalone sign lemma, checked at `p = q = 3` (both `≡ 3 (mod 4)`). -/
+example : ((-1 : ℤ)) ^ (3 / 2 * (3 / 2)) = -1 := by decide
+
+end Examples
+
+#check @reciprocity_sign_eq_neg_one_iff
+#check @reciprocity_agree_iff
+#check @reciprocity_disagree_iff
+#check @reciprocity_swap_value
+#check @agree_iff_not_disagree
+
+end QRMod4Sign

--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "ann-qroq0302-header",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "Module Overview: the mod-4 Decision Rule",
+    "content": "This module turns the reciprocity swap sign — carried by the parent's Legendre-symbol algorithm as the opaque exponent (-1)^((p/2)(q/2)) — into a proved, branch-free mod-4 decision rule. It imports only Mathlib (the LegendreSymbol/QuadraticReciprocity development and Mathlib.Tactic), so it is decoupled from the parent file. The convention is modulus-first: legendreSym n a denotes (a/n), hence legendreSym q p is (p/q) and legendreSym p q is (q/p).",
+    "mathContext": "Quadratic reciprocity relates (p/q) and (q/p) by the sign (-1)^{((p-1)/2)((q-1)/2)}; the textbook rule reads that sign mod 4.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic reciprocity",
+      "Legendre symbol",
+      "decision procedure",
+      "mod 4 residues"
+    ],
+    "prerequisites": [
+      "Legendre symbol basics",
+      "the Law of Quadratic Reciprocity"
+    ]
+  },
+  {
+    "id": "ann-qroq0302-sign-lemma",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 50, "endLine": 76 },
+    "type": "key_step",
+    "title": "The Standalone Sign Lemma",
+    "content": "reciprocity_sign_eq_neg_one_iff proves, for odd p and q, that (-1)^((p/2)(q/2)) = -1 ↔ (p % 4 = 3 ∧ q % 4 = 3). The power equals -1 exactly when the exponent is odd (Even.neg_one_pow gives 1, Odd.neg_one_pow gives -1); the exponent (p/2)(q/2) is odd iff both factors are (Nat.odd_mul); and for an odd number p the half p/2 is odd iff p ≡ 3 (mod 4). The residue bookkeeping is discharged by omega after rewriting through Nat.odd_iff.",
+    "mathContext": "This is the purely arithmetic heart of the decision rule: it pins the swap sign to the joint condition p ≡ q ≡ 3 (mod 4).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Odd.neg_one_pow",
+      "Nat.odd_mul",
+      "Nat.odd_iff",
+      "omega"
+    ],
+    "prerequisites": [
+      "parity of integer powers of -1",
+      "natural-number division and modular arithmetic"
+    ]
+  },
+  {
+    "id": "ann-qroq0302-helpers",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 79, "endLine": 100 },
+    "type": "key_step",
+    "title": "Helper Lemmas: Oddness and Non-Vanishing",
+    "content": "Two private helpers support the biconditionals. mod_two_one shows an odd prime satisfies p % 2 = 1 (resolving Nat.Prime.eq_two_or_odd against p ≠ 2). legendre_ne_zero shows that for distinct primes p and q the cast (q : ZMod p) is nonzero — because p ∤ q (Nat.prime_dvd_prime_iff_eq turns divisibility into equality), so the Legendre symbol (q/p) is a unit.",
+    "mathContext": "Non-vanishing of the symbol is what makes the forward directions of the biconditionals work: in {±1}, x = -x has no solution.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.Prime.eq_two_or_odd",
+      "Nat.prime_dvd_prime_iff_eq",
+      "ZMod.natCast_eq_zero_iff"
+    ],
+    "prerequisites": [
+      "primes and divisibility",
+      "ZMod and the Legendre symbol"
+    ]
+  },
+  {
+    "id": "ann-qroq0302-biconditionals",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 102, "endLine": 164 },
+    "type": "key_step",
+    "title": "The Agree / Disagree Biconditionals",
+    "content": "reciprocity_disagree_iff proves (p/q) = -(q/p) ↔ (p % 4 = 3 ∧ q % 4 = 3), and reciprocity_agree_iff proves (p/q) = (q/p) ↔ (p % 4 = 1 ∨ q % 4 = 1). Both start from Mathlib's exponent swap legendreSym.quadratic_reciprocity' and split on whether the swap exponent is even or odd. When the sign is +1 the swap preserves the symbol; when -1 it negates it. Using that the symbols are ±1 (legendreSym.eq_one_or_neg_one), an accidental equality x = -x is impossible, so each one-directional Mathlib special case is upgraded to a full iff; omega closes the residue-class reasoning.",
+    "mathContext": "(p/q) = -(q/p) ⟺ p ≡ q ≡ 3 (mod 4); (p/q) = (q/p) ⟺ p ≡ 1 ∨ q ≡ 1 (mod 4). Mathlib provides only the backward implications.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "legendreSym.quadratic_reciprocity'",
+      "legendreSym.eq_one_or_neg_one",
+      "even/odd case split",
+      "quadratic_reciprocity_three_mod_four"
+    ],
+    "prerequisites": [
+      "the standalone sign lemma",
+      "values of the Legendre symbol are ±1 for units"
+    ]
+  },
+  {
+    "id": "ann-qroq0302-branch-dichotomy",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 166, "endLine": 199 },
+    "type": "key_step",
+    "title": "Branch Form and Exhaustive/Exclusive Dichotomy",
+    "content": "reciprocity_swap_value packages the sign as a decidable branch: (q/p) = (if p % 4 = 3 ∧ q % 4 = 3 then -1 else 1) * (p/q), proved by congr onto the sign lemma plus an even/odd split for the else-branch. agree_iff_not_disagree proves that for distinct odd primes the agree predicate is exactly the negation of the disagree predicate, by rewriting through both biconditionals and finishing with omega over the residue classes {1,3}.",
+    "mathContext": "The branch form is what a recursive symbol computer evaluates; the dichotomy theorem certifies the rule is both exhaustive and exclusive.",
+    "significance": "important",
+    "relatedConcepts": [
+      "if-then-else decision",
+      "complementary predicates",
+      "omega"
+    ],
+    "prerequisites": [
+      "the agree/disagree biconditionals"
+    ]
+  },
+  {
+    "id": "ann-qroq0302-examples",
+    "proofId": "quadratic-reciprocity-oq-03-oq-02",
+    "range": { "startLine": 201, "endLine": 227 },
+    "type": "example",
+    "title": "Verified Corroboration via decide",
+    "content": "In a section with local Fact (Nat.Prime n) instances for 3,5,7,11,13, five kernel-decide checks corroborate the rule: (7/3) = -(3/7) and (7/11) = -(11/7) disagree (3,7,11 ≡ 3 mod 4); (5/13) = (13/5) and (3/5) = (5/3) agree (13,5 ≡ 1 mod 4); and the sign lemma holds at p = q = 3. These use Lean's kernel decide (not native_decide), so they add no axioms.",
+    "mathContext": "Each example exercises a residue configuration: both ≡ 3 flips the sign, a partner ≡ 1 (mod 4) preserves it.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide tactic",
+      "Euler's criterion in ZMod p",
+      "Fact (Nat.Prime n) instances"
+    ],
+    "prerequisites": [
+      "decidable evaluation of Legendre symbols"
+    ]
+  }
+]

--- a/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "quadratic-reciprocity-oq-03-oq-02",
+  "title": "The Reciprocity Swap Sign as a mod-4 Decision Rule",
+  "slug": "quadratic-reciprocity-oq-03-oq-02",
+  "description": "Turns the opaque reciprocity exponent (-1)^((p/2)(q/2)) from the parent's Legendre-symbol algorithm into a proved, branch-free mod-4 decision rule. Proves the full agree/disagree dichotomy as genuine biconditionals — the two symbols (p/q) and (q/p) agree iff at least one prime is 1 mod 4, and flip iff both are 3 mod 4 — together with a standalone sign lemma, a branch-form swap value, and the exhaustive/exclusive complementarity statement. Mathlib only has the two one-directional special cases; the iffs are new. Zero sorries, zero axioms.",
+  "meta": {
+    "author": "Gauss (1801) / textbook folklore; formalized by lean-genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+    "date": "1801",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityOQ03OQ02.lean",
+    "parentProofId": "quadratic-reciprocity-oq-03",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "legendre-symbol",
+      "mod-4-decision",
+      "algorithm",
+      "verified-computation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-24",
+    "lineCount": 235,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "reciprocity_sign_eq_neg_one_iff: the standalone sign lemma (-1)^((p/2)(q/2)) = -1 ↔ p % 4 = 3 ∧ q % 4 = 3 for odd p, q — pure parity arithmetic tying the swap exponent to the joint residue condition, via `Odd.neg_one_pow` / `Even.neg_one_pow`, `Nat.odd_mul`, `Nat.odd_iff`, and `omega`. Not a named Mathlib lemma.",
+      "reciprocity_disagree_iff: the genuine biconditional (p/q) = -(q/p) ↔ p % 4 = 3 ∧ q % 4 = 3 for distinct odd primes. Mathlib's `quadratic_reciprocity_three_mod_four` gives only the backward implication; the forward direction is new, using that the symbols are ±1 (nonzero) so equality with the negation forces the swap sign to be -1.",
+      "reciprocity_agree_iff: the complementary biconditional (p/q) = (q/p) ↔ p % 4 = 1 ∨ q % 4 = 1 for distinct odd primes. Mathlib's `quadratic_reciprocity_one_mod_four` gives only one implication of one disjunct; the full iff is new.",
+      "reciprocity_swap_value: the sign as a branch — (p/q) = (if p % 4 = 3 ∧ q % 4 = 3 then -1 else 1) · (q/p), the decidable form a recursive Legendre-symbol algorithm actually evaluates.",
+      "agree_iff_not_disagree: the dichotomy is exhaustive and exclusive — for distinct odd primes the agree predicate is exactly the negation of the disagree predicate.",
+      "Five `decide`-verified corroborations: (7/3)=-(3/7) and (7/11)=-(11/7) (disagree, both ≡3), (5/13)=(13/5) and (3/5)=(5/3) (agree, one ≡1), plus the sign lemma at p=q=3."
+    ],
+    "assumptions": "No axioms, no sorries (`#print axioms` reports only propext, Classical.choice, Quot.sound for all five exported theorems). The proofs build on Mathlib's exponent-form reciprocity `legendreSym.quadratic_reciprocity'` and the dichotomy `legendreSym.eq_one_or_neg_one`; the new content is the parity computation `reciprocity_sign_eq_neg_one_iff` and the packaging of the two one-directional Mathlib special cases into full biconditionals using the ±1 value information to rule out the degenerate cases. The five example computations are verified by Lean's kernel `decide` (no `native_decide`, so no `Lean.ofReduceBool`). Literal-prime `Fact (Nat.Prime n)` instances are supplied locally for the examples.",
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.quadratic_reciprocity'",
+        "description": "Exponent-form swap: legendreSym q p = (-1)^(p/2*(q/2)) * legendreSym p q for odd primes p ≠ 2, q ≠ 2",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity"
+      },
+      {
+        "theorem": "legendreSym.eq_one_or_neg_one",
+        "description": "For p ∤ a, the symbol legendreSym p a is 1 or -1 (nonzero)",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod n) = 0 ↔ n ∣ a; with Nat.prime_dvd_prime_iff_eq gives p ∤ q for distinct primes",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow / Even.neg_one_pow",
+        "description": "(-1)^n = -1 for odd n and = 1 for even n in a monoid/ring",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Law of Quadratic Reciprocity (Gauss, Disquisitiones Arithmeticae, 1801) relates the two Legendre symbols $\\left(\\tfrac{p}{q}\\right)$ and $\\left(\\tfrac{q}{p}\\right)$ of distinct odd primes by the sign $(-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$. The schoolbook way to read that sign is purely mod 4: the two symbols agree unless both primes are $\\equiv 3 \\pmod 4$, in which case they have opposite signs. This entry promotes that one-line rule to a proved Lean decision predicate, completing the parent `quadratic-reciprocity-oq-03` whose reduction step carried the sign as the opaque exponent.",
+    "problemStatement": "The parent's Legendre-symbol algorithm carries the reciprocity sign as the exponent $(-1)^{(p/2)(q/2)}$. Package that sign as a decidable mod-4 test: a branch-free criterion in $p \\bmod 4$ and $q \\bmod 4$ alone that says whether the swap $\\left(\\tfrac{q}{p}\\right) \\leftrightarrow \\left(\\tfrac{p}{q}\\right)$ preserves or flips the sign — as genuine biconditionals, the way the sibling `quadratic-reciprocity-oq-03-oq-01` repackaged the factor-2 sign as a $p \\bmod 8$ decision.",
+    "proofStrategy": "First a standalone parity lemma `reciprocity_sign_eq_neg_one_iff` proves $(-1)^{(p/2)(q/2)} = -1 \\iff p \\equiv 3 \\wedge q \\equiv 3 \\pmod 4$: the power is $-1$ iff the exponent is odd (`Odd.neg_one_pow`/`Even.neg_one_pow`), the product is odd iff both halves are (`Nat.odd_mul`), and for odd $p$ the half $p/2$ is odd iff $p \\equiv 3 \\pmod 4$ (`Nat.odd_iff` + `omega`). The two biconditionals then combine Mathlib's exponent swap `legendreSym.quadratic_reciprocity'` with the sign lemma, splitting on whether the swap exponent is even or odd. The key to the forward directions is that for distinct primes $p \\nmid q$, so $\\left(\\tfrac{q}{p}\\right)$ is $\\pm 1$ and nonzero (`legendreSym.eq_one_or_neg_one`): this rules out the degenerate case where an equality could hold accidentally, turning the one-directional Mathlib lemmas into full iffs. `reciprocity_swap_value` repackages the sign as an `if`-branch, and `agree_iff_not_disagree` shows the two predicates are exact complements via `omega` over the residue classes.",
+    "keyInsights": [
+      "The swap exponent $(p/2)(q/2)$ is odd exactly when both $p/2$ and $q/2$ are odd, and for an odd number the half is odd precisely on the residue class $3 \\pmod 4$ — so the whole sign collapses to the joint condition $p \\equiv q \\equiv 3 \\pmod 4$.",
+      "Mathlib provides only one-directional special cases (`quadratic_reciprocity_one_mod_four`, `quadratic_reciprocity_three_mod_four`); upgrading them to biconditionals needs the extra fact that the symbols are $\\pm 1$, which excludes the spurious solutions of $x = -x$ in $\\{\\pm 1\\}$.",
+      "Because the Legendre symbols are units ($\\pm 1$), 'agree' and 'disagree' are genuinely complementary: $x = y$ and $x = -y$ cannot both hold (that would force $y = 0$), and for $\\pm 1$ at least one holds — so the dichotomy is exhaustive and exclusive.",
+      "The branch form $(if both \\equiv 3 then -1 else 1)$ is the shape a recursive symbol computer evaluates: once $p \\bmod 4$ and $q \\bmod 4$ are known, the swap sign needs no exponent arithmetic.",
+      "Kernel `decide` evaluates concrete Legendre symbols at elaboration time, giving independent corroboration of the decision rule on small twin/non-twin residue configurations without `native_decide`."
+    ]
+  },
+  "sections": [
+    {
+      "id": "doc-comment",
+      "title": "Doc-Comment: the mod-4 Decision Rule",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports `Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity` and `Mathlib.Tactic`. The doc-comment states the open question (package the reciprocity sign as a decidable mod-4 test), its answer (yes, as full biconditionals), and lists the six results, noting the modulus-first convention `legendreSym n a = (a/n)`.",
+      "mathContext": "Reciprocity swap $\\left(\\tfrac{q}{p}\\right) = (-1)^{(p/2)(q/2)}\\left(\\tfrac{p}{q}\\right)$ and the textbook rule: agree unless both $\\equiv 3 \\pmod 4$."
+    },
+    {
+      "id": "sign-lemma",
+      "title": "Part 1 — The Standalone Sign Lemma",
+      "startLine": 50,
+      "endLine": 76,
+      "summary": "`reciprocity_sign_eq_neg_one_iff`: for odd p, q, the swap sign (-1)^((p/2)(q/2)) = -1 ↔ p % 4 = 3 ∧ q % 4 = 3. Proved by reducing the power to oddness of the exponent (`Odd.neg_one_pow`/`Even.neg_one_pow`), splitting the product oddness (`Nat.odd_mul`, `Nat.odd_iff`), and closing the residue arithmetic with `omega`.",
+      "mathContext": "$(-1)^{(p/2)(q/2)} = -1 \\iff p \\equiv 3 \\wedge q \\equiv 3 \\pmod 4$ — the purely arithmetic core of the decision rule.",
+      "relatedConcepts": [
+        "parity of (-1)^n",
+        "Odd.neg_one_pow",
+        "Nat.odd_mul / Nat.odd_iff",
+        "omega tactic"
+      ]
+    },
+    {
+      "id": "biconditionals",
+      "title": "Part 2 — The Agree / Disagree Biconditionals",
+      "startLine": 77,
+      "endLine": 164,
+      "summary": "Helper lemmas `mod_two_one` (an odd prime has p % 2 = 1) and `legendre_ne_zero` (for distinct primes (q : ZMod p) ≠ 0). Then `reciprocity_disagree_iff`: (p/q) = -(q/p) ↔ both ≡ 3 (mod 4), and `reciprocity_agree_iff`: (p/q) = (q/p) ↔ at least one ≡ 1 (mod 4). Each splits on parity of the swap exponent and uses that the symbols are ±1 to upgrade Mathlib's one-directional lemmas to full biconditionals.",
+      "mathContext": "$\\left(\\tfrac{p}{q}\\right) = -\\left(\\tfrac{q}{p}\\right) \\iff p \\equiv q \\equiv 3 \\pmod 4$ and $\\left(\\tfrac{p}{q}\\right) = \\left(\\tfrac{q}{p}\\right) \\iff p \\equiv 1 \\vee q \\equiv 1 \\pmod 4$.",
+      "relatedConcepts": [
+        "legendreSym.quadratic_reciprocity'",
+        "legendreSym.eq_one_or_neg_one",
+        "Nat.prime_dvd_prime_iff_eq",
+        "even/odd case split"
+      ]
+    },
+    {
+      "id": "branch-and-dichotomy",
+      "title": "Part 3 — Branch Form and Exhaustive/Exclusive Dichotomy",
+      "startLine": 166,
+      "endLine": 199,
+      "summary": "`reciprocity_swap_value`: (q/p) = (if p%4=3 ∧ q%4=3 then -1 else 1) * (p/q), the branch a recursive algorithm evaluates, proved by `congr` onto the sign lemma. `agree_iff_not_disagree`: the agree predicate is exactly the negation of the disagree predicate, closed by `omega` after rewriting through the two biconditionals.",
+      "mathContext": "The swap sign as a decidable branch, and the proof that 'agree' and 'disagree' partition the outcomes for distinct odd primes.",
+      "relatedConcepts": [
+        "if-then-else decision",
+        "complementary predicates",
+        "omega over residue classes"
+      ]
+    },
+    {
+      "id": "examples",
+      "title": "Part 4 — Verified Corroboration via decide",
+      "startLine": 201,
+      "endLine": 227,
+      "summary": "In a section with local `Fact (Nat.Prime n)` instances, five kernel-`decide` checks: (7/3)=-(3/7) and (7/11)=-(11/7) disagree (3,7,11 ≡ 3 mod 4), (5/13)=(13/5) and (3/5)=(5/3) agree (13,5 ≡ 1 mod 4), and the sign lemma at p=q=3.",
+      "mathContext": "Concrete evaluations: both $\\equiv 3$ pairs flip the sign, while a partner $\\equiv 1 \\pmod 4$ preserves it — matching the decision rule.",
+      "relatedConcepts": [
+        "decide tactic",
+        "Euler's criterion in ZMod p",
+        "Fact (Nat.Prime n) instances",
+        "elaboration-time evaluation"
+      ]
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry converts the parent's opaque reciprocity exponent $(-1)^{(p/2)(q/2)}$ into a proved, branch-free mod-4 decision rule. It supplies the standalone sign lemma, the two full agree/disagree biconditionals (Mathlib has only one-directional special cases), the branch-form swap value, and a proof that the dichotomy is exhaustive and exclusive — all with zero sorries and zero axioms, plus five kernel-`decide` corroborations.",
+    "implications": "The biconditionals give a recursive Legendre/Jacobi-symbol computer a decidable, exponent-free branch for the reciprocity step, matching the sibling `quadratic-reciprocity-oq-03-oq-01`'s $p \\bmod 8$ form for the factor 2. Packaging the one-directional Mathlib lemmas as iffs (using the $\\pm 1$ value information) is a small but reusable pattern wherever a sign condition must be decided rather than merely implied.",
+    "openQuestions": [
+      "Assemble the reduction steps (multiplicativity, the $-1$ and $2$ supplementary laws, and this mod-4 reciprocity branch) into a single verified recursive Legendre-symbol evaluator with a well-founded termination measure.",
+      "Lift the mod-4 decision rule to the Jacobi symbol, where the same agree/disagree-by-residue statement holds for odd coprime arguments and underlies fast symbol computation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity-oq-03",
+      "relationship": "foundation",
+      "description": "The parent toolkit whose reduction step carries the reciprocity sign as the opaque exponent (-1)^((p/2)(q/2)); this entry packages that sign as a decidable mod-4 rule."
+    },
+    {
+      "targetId": "quadratic-reciprocity-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling leaf that repackaged the factor-2 sign as a p % 8 decision iff; this entry is its mod-4 analogue for the reciprocity swap itself."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "foundation",
+      "description": "The underlying Law of Quadratic Reciprocity, whose sign this entry turns into a residue decision rule."
+    }
+  ],
+  "references": {
+    "papers": [
+      {
+        "title": "Disquisitiones Arithmeticae",
+        "author": "C. F. Gauss",
+        "year": 1801,
+        "url": "https://en.wikipedia.org/wiki/Disquisitiones_Arithmeticae"
+      }
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Quadratic_reciprocity",
+      "https://en.wikipedia.org/wiki/Legendre_symbol"
+    ],
+    "mathlib": [
+      "Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity",
+      "Mathlib.NumberTheory.LegendreSymbol.Basic"
+    ]
+  },
+  "leanFile": {
+    "namespace": "QRMod4Sign",
+    "lineCount": 235,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/QuadraticReciprocityOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the open question of the parent `quadratic-reciprocity-oq-03`: turn the reciprocity swap sign — carried there as the opaque exponent $(-1)^{(p/2)(q/2)}$ — into a **proved, branch-free mod-4 decision rule**, as genuine biconditionals (the sibling `quadratic-reciprocity-oq-03-oq-01` did the analogous $p \bmod 8$ form for the factor 2).

Convention: `legendreSym n a` = $(a/n)$ (modulus first), so `legendreSym q p` = $(p/q)$.

## Results (all 0-sorry, 0-axiom)
- **`reciprocity_sign_eq_neg_one_iff`** — standalone parity lemma: $(-1)^{(p/2)(q/2)} = -1 \iff p \equiv 3 \wedge q \equiv 3 \pmod 4$ for odd $p,q$.
- **`reciprocity_disagree_iff`** — $(p/q) = -(q/p) \iff p \equiv q \equiv 3 \pmod 4$.
- **`reciprocity_agree_iff`** — $(p/q) = (q/p) \iff p \equiv 1 \vee q \equiv 1 \pmod 4$.
- **`reciprocity_swap_value`** — the sign as an `if`-branch a recursive symbol evaluator can use directly.
- **`agree_iff_not_disagree`** — the dichotomy is exhaustive and exclusive.
- Five kernel-`decide` corroborations on small primes (3,5,7,11,13).

## Originality
Mathlib provides only the **one-directional** special cases `quadratic_reciprocity_one_mod_four` and `quadratic_reciprocity_three_mod_four`, plus the exponent-form swap. The **biconditionals are new**: the forward directions are obtained by using that the Legendre symbols are $\pm 1$ (nonzero for distinct primes), which rules out the degenerate $x = -x$ case. The parity sign lemma is also not a named Mathlib lemma.

## Verification
`#print axioms` on all five exported theorems reports only `[propext, Classical.choice, Quot.sound]` — no `Lean.ofReduceBool` (kernel `decide`, not `native_decide`), no `sorryAx`. Built with the host Lean toolchain against the pinned Mathlib.

- Lean: `proofs/Proofs/QuadraticReciprocityOQ03OQ02.lean` (235 lines, 7 theorems, 0 defs)
- Gallery: `src/data/proofs/quadratic-reciprocity-oq-03-oq-02/` (meta.json + annotations.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)