### PR TITLE
audit: 6 fresh research entries clean (descartes/euler-criterion/lagrange/napoleon/QR/wilson)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22955,6 +22955,42 @@
       "lastAudited": "2026-06-25T02:38:55Z",
       "result": "clean",
       "issues": []
+    },
+    "descartes-rule-of-signs-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-criterion-squares-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "napoleons-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-reciprocity-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:10:22Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — 6 fresh entries, all CLEAN

Audited the 6 never-audited entries not already covered by open PR #29603:

| slug | status/badge | verdict |
|------|--------------|---------|
| descartes-rule-of-signs-oq-01-oq-01-oq-02 | verified/original | clean — scoped to "endpoint backbone of Budan–Fourier", not full theorem |
| euler-criterion-squares-oq-01-oq-01-oq-02 | verified/original | clean — sum of nonzero QR vanishes mod p>3, distinct from Mathlib `quadraticChar_sum_zero` |
| lagrange-four-squares-oq-04-oq-01 | verified/original | clean — three-squares not closed under mult (counterexample) |
| napoleons-theorem-oq-03-oq-01 | verified/original | clean — Napoleon orbit half-turn period structure |
| quadratic-reciprocity-oq-03-oq-02 | verified/original | clean — recasts QR exponent as mod-4 decision rule; Mathlib `legendreSym.quadratic_reciprocity'` credited in deps+desc |
| wilsons-theorem-oq-01-oq-03 | verified/original | clean — Clement twin-prime criterion via Wilson at two moduli; Mathlib Wilson credited; Mathlib has no twin-prime criterion |

**Checks run:** meta status/badge/axiomCount/sorries vs Lean source; code-only integrity grep (comments stripped) for sorry/admit/native_decide/axiom/True-stubs → all clean; delegation-opacity review of the two Mathlib-headline entries (QR, Wilson) → both credit dependencies and scope the `original` badge to genuinely-new content.

No issues found. Tracker-only change. The 4 remaining unaudited (bounded-prime-gaps/derangements/euler-criterion-oq0103/hilbert-4) are covered by open PR #29603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)