### PR TITLE
research(harmonic-divergence-oq-02-oq-01): Bertrand series threshold — converges ⟺ p>1 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/HarmonicDivergenceOQ02OQ01.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ02OQ01.lean
@@ -1,0 +1,213 @@
+/-
+Harmonic Divergence, Open Question 02 → 01:
+The Bertrand series convergence dichotomy for a *real* exponent.
+
+The parent (OQ-02) treated two isolated cases of the iterated-log series
+  Σ_{n≥2} 1 / (n · (log n)^p):
+the borderline divergent case p = 1, and the convergent case p = 2.
+
+This file proves the full **threshold theorem** for every real exponent p:
+
+      Σ_{n≥2} 1 / (n · (log n)^p)  converges  ⟺  p > 1.
+
+The exponent is a genuine real number `p : ℝ` (an `rpow` of `Real.log n`),
+so the statement interpolates continuously across the entire family and pins
+the convergence boundary at p = 1. The parent's two cases (p = 1 divergent,
+p = 2 convergent) are recovered as immediate corollaries, and the new content
+is the uniform dichotomy — including the delicate strip 0 < p < 1 (divergent)
+and the full divergent half-line p ≤ 1 (negative p included).
+
+Proof architecture:
+* For p ≥ 0 the term is antitone, so the Cauchy condensation test applies.
+  The condensed term at k ≥ 1 is
+      2^k / (2^k · (log 2^k)^p) = 1 / (k·log 2)^p = (1/(log 2)^p) · (1/k^p),
+  a constant multiple of the real p-series `Σ 1/k^p`, which converges iff p > 1
+  (`Real.summable_one_div_nat_rpow`).
+* For p < 0 the term dominates the harmonic term 1/n on the tail n ≥ 3
+  (there `(log n)^p ≤ 1`), so the series diverges by comparison.
+
+A note on the small-index convention: `log 1 = 0` makes `1/(1·(log 1)^p)`
+singular, and the naive `if n < 2 then 0` truncation is *not* antitone at
+n = 1 (it dips to 0 below the n = 2 term, breaking the condensation
+hypothesis). We instead cap the values at n = 0, 1 to the n = 2 term. This
+changes only finitely many terms and therefore leaves convergence — the sole
+quantity the theorem speaks about — unchanged, while making the sequence
+genuinely non-increasing on all positive indices.
+
+Axiom count: 0
+Sorry count: 0
+-/
+
+import Mathlib
+
+open Filter Topology
+
+namespace HarmonicDivergenceOQ02OQ01
+
+/-! ## The real-exponent Bertrand term -/
+
+/-- The Bertrand term `1 / (n · (log n)^p)` for `n ≥ 2`, capped at the `n = 2`
+value for `n < 2`. The cap is a finite modification (it touches only `n = 0, 1`)
+and is chosen so that the sequence is non-increasing on all positive indices,
+which the Cauchy condensation test requires. -/
+noncomputable def bertrand (p : ℝ) (n : ℕ) : ℝ :=
+  if n < 2 then 1 / ((2 : ℝ) * (Real.log 2) ^ p)
+           else 1 / ((n : ℝ) * (Real.log n) ^ p)
+
+/-- For `n ≥ 2`, `bertrand p n` is the genuine term `1 / (n · (log n)^p)`. -/
+theorem bertrand_of_ge_two (p : ℝ) {n : ℕ} (hn : 2 ≤ n) :
+    bertrand p n = 1 / ((n : ℝ) * (Real.log n) ^ p) := by
+  unfold bertrand; rw [if_neg (by omega)]
+
+/-- The denominator `n · (log n)^p` is positive for `n ≥ 2`. -/
+private theorem denom_pos {n : ℕ} (hn : 2 ≤ n) (p : ℝ) :
+    0 < (n : ℝ) * (Real.log n) ^ p := by
+  have h1 : (1 : ℝ) < (n : ℝ) := by exact_mod_cast (show 1 < n by omega)
+  exact mul_pos (by linarith) (Real.rpow_pos_of_pos (Real.log_pos h1) p)
+
+/-- Monotonicity of the denominator for `p ≥ 0`: larger index ⇒ larger
+`n · (log n)^p`. -/
+private theorem denom_mono (p : ℝ) (hp : 0 ≤ p) {a b : ℕ} (ha : 2 ≤ a) (hab : a ≤ b) :
+    (a : ℝ) * (Real.log a) ^ p ≤ (b : ℝ) * (Real.log b) ^ p := by
+  have ha1 : (1 : ℝ) < (a : ℝ) := by exact_mod_cast (show 1 < a by omega)
+  have hlogapos : 0 < Real.log a := Real.log_pos ha1
+  apply mul_le_mul
+  · exact_mod_cast hab
+  · exact Real.rpow_le_rpow (le_of_lt hlogapos)
+      (Real.log_le_log (by linarith) (by exact_mod_cast hab)) hp
+  · exact Real.rpow_nonneg (le_of_lt hlogapos) p
+  · positivity
+
+/-- `bertrand p` is nonnegative everywhere. -/
+theorem bertrand_nonneg (p : ℝ) (n : ℕ) : 0 ≤ bertrand p n := by
+  unfold bertrand
+  split_ifs with h
+  · have : 0 < (2 : ℝ) * (Real.log 2) ^ p :=
+      mul_pos (by norm_num) (Real.rpow_pos_of_pos (Real.log_pos (by norm_num)) p)
+    exact le_of_lt (one_div_pos.mpr this)
+  · exact le_of_lt (one_div_pos.mpr (denom_pos (by omega) p))
+
+/-- For `p ≥ 0`, `bertrand p` is antitone on the positive integers:
+`0 < m ≤ n → bertrand p n ≤ bertrand p m`. -/
+theorem bertrand_antitone (p : ℝ) (hp : 0 ≤ p) :
+    ∀ ⦃m n : ℕ⦄, 0 < m → m ≤ n → bertrand p n ≤ bertrand p m := by
+  intro m n hm hmn
+  have hCval : bertrand p 1 = 1 / ((2 : ℝ) * (Real.log 2) ^ p) := by
+    unfold bertrand; rw [if_pos (by omega)]
+  by_cases hm2 : m < 2
+  · have hm1 : m = 1 := by omega
+    subst hm1
+    rw [hCval]
+    by_cases hn2 : n < 2
+    · have : n = 1 := by omega
+      subst this; rw [hCval]
+    · push_neg at hn2
+      rw [bertrand_of_ge_two p hn2]
+      have hle : (2 : ℝ) * (Real.log 2) ^ p ≤ (n : ℝ) * (Real.log n) ^ p := by
+        have := denom_mono p hp (show (2 : ℕ) ≤ 2 by norm_num) hn2
+        simpa using this
+      exact one_div_le_one_div_of_le
+        (mul_pos (by norm_num) (Real.rpow_pos_of_pos (Real.log_pos (by norm_num)) p)) hle
+  · push_neg at hm2
+    rw [bertrand_of_ge_two p hm2, bertrand_of_ge_two p (le_trans hm2 hmn)]
+    exact one_div_le_one_div_of_le (denom_pos hm2 p) (denom_mono p hp hm2 hmn)
+
+/-! ## The condensed term -/
+
+/-- The Cauchy-condensed term at `k ≥ 1`:
+`2^k · bertrand p (2^k) = (1/(log 2)^p) · (1/k^p)`. -/
+theorem condensed_eq (p : ℝ) (k : ℕ) (hk : 1 ≤ k) :
+    (2 : ℝ) ^ k * bertrand p (2 ^ k) =
+      (1 / (Real.log 2) ^ p) * (1 / ((k : ℝ) ^ p)) := by
+  have h2k : 2 ≤ 2 ^ k := by
+    calc 2 = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+  rw [bertrand_of_ge_two p h2k]
+  have hlog : Real.log ((2 ^ k : ℕ) : ℝ) = (k : ℝ) * Real.log 2 := by
+    simp only [Nat.cast_pow, Nat.cast_ofNat, Real.log_pow]
+  rw [hlog, Real.mul_rpow (by positivity) (Real.log_nonneg (by norm_num))]
+  have hkpos : (0 : ℝ) < (k : ℝ) := by exact_mod_cast (show 0 < k by omega)
+  have h2 : ((2 ^ k : ℕ) : ℝ) ≠ 0 := by positivity
+  have hkp : ((k : ℝ) ^ p) ≠ 0 := (Real.rpow_pos_of_pos hkpos p).ne'
+  have hlp : ((Real.log 2) ^ p) ≠ 0 := (Real.rpow_pos_of_pos (Real.log_pos (by norm_num)) p).ne'
+  push_cast
+  field_simp
+
+/-! ## The convergence dichotomy -/
+
+/-- **Bertrand series, nonnegative exponent.** For `p ≥ 0`,
+`Σ bertrand p n` converges iff `p > 1`. Proved by Cauchy condensation:
+the condensed series is a constant multiple of the real p-series `Σ 1/k^p`. -/
+theorem bertrand_summable_iff_of_nonneg (p : ℝ) (hp : 0 ≤ p) :
+    Summable (bertrand p) ↔ 1 < p := by
+  rw [← summable_condensed_iff_of_nonneg (bertrand_nonneg p) (bertrand_antitone p hp)]
+  rw [← summable_nat_add_iff 1]
+  have hc : (1 / (Real.log 2) ^ p) ≠ 0 :=
+    one_div_ne_zero (Real.rpow_pos_of_pos (Real.log_pos (by norm_num)) p).ne'
+  have hcong : (fun k : ℕ => (2 : ℝ) ^ (k + 1) * bertrand p (2 ^ (k + 1)))
+             = (fun k : ℕ => (1 / (Real.log 2) ^ p) * (1 / (((k + 1 : ℕ) : ℝ) ^ p))) := by
+    funext k; exact condensed_eq p (k + 1) (by omega)
+  rw [hcong, summable_mul_left_iff hc]
+  exact (summable_nat_add_iff 1).trans Real.summable_one_div_nat_rpow
+
+/-- The `p = 0` Bertrand series (essentially the harmonic series) diverges. -/
+theorem bertrand_zero_not_summable : ¬ Summable (bertrand 0) := by
+  rw [bertrand_summable_iff_of_nonneg 0 le_rfl]; norm_num
+
+/-- **Bertrand series, negative exponent.** For `p < 0` the series diverges,
+because on the tail `n ≥ 3` the term dominates the harmonic term `1/n`. -/
+theorem bertrand_not_summable_of_neg {p : ℝ} (hp : p < 0) :
+    ¬ Summable (bertrand p) := by
+  intro hsum
+  have h3 : Summable (fun n : ℕ => bertrand p (n + 3)) := (summable_nat_add_iff 3).mpr hsum
+  have hle : ∀ n : ℕ, bertrand 0 (n + 3) ≤ bertrand p (n + 3) := by
+    intro n
+    have hn3 : 2 ≤ n + 3 := by omega
+    rw [bertrand_of_ge_two 0 hn3, bertrand_of_ge_two p hn3, Real.rpow_zero]
+    apply one_div_le_one_div_of_le (denom_pos hn3 p)
+    have hlog1 : (1 : ℝ) ≤ Real.log ((n + 3 : ℕ) : ℝ) := by
+      have hy : (0 : ℝ) < ((n + 3 : ℕ) : ℝ) := by positivity
+      rw [Real.le_log_iff_exp_le hy]
+      have he : Real.exp 1 < 3 := lt_trans Real.exp_one_lt_d9 (by norm_num)
+      have h3le : (3 : ℝ) ≤ ((n + 3 : ℕ) : ℝ) := by
+        push_cast; linarith [Nat.cast_nonneg (α := ℝ) n]
+      linarith
+    have hp1 : (Real.log ((n + 3 : ℕ) : ℝ)) ^ p ≤ 1 :=
+      Real.rpow_le_one_of_one_le_of_nonpos hlog1 hp.le
+    exact mul_le_mul_of_nonneg_left hp1 (by positivity)
+  have h0shift : Summable (fun n : ℕ => bertrand 0 (n + 3)) :=
+    Summable.of_nonneg_of_le (fun n => bertrand_nonneg 0 (n + 3)) hle h3
+  exact bertrand_zero_not_summable ((summable_nat_add_iff 3).mp h0shift)
+
+/-- **The Bertrand convergence threshold (all real exponents).**
+
+  `Σ_{n} 1 / (n · (log n)^p)` converges  ⟺  `p > 1`. -/
+theorem bertrand_summable_iff (p : ℝ) : Summable (bertrand p) ↔ 1 < p := by
+  rcases lt_or_ge p 0 with hp | hp
+  · constructor
+    · intro h; exact absurd h (bertrand_not_summable_of_neg hp)
+    · intro h; linarith
+  · exact bertrand_summable_iff_of_nonneg p hp
+
+/-! ## Corollaries: recovering the parent's two cases and the full dichotomy -/
+
+/-- For `p ≤ 1` the Bertrand series diverges (includes the borderline `p = 1`
+and the entire strip `0 < p < 1`). -/
+theorem bertrand_not_summable_of_le_one {p : ℝ} (hp : p ≤ 1) :
+    ¬ Summable (bertrand p) := by
+  rw [bertrand_summable_iff]; exact not_lt.mpr hp
+
+/-- For `p > 1` the Bertrand series converges. -/
+theorem bertrand_summable_of_one_lt {p : ℝ} (hp : 1 < p) :
+    Summable (bertrand p) := by
+  rw [bertrand_summable_iff]; exact hp
+
+/-- **Parent case p = 1** (borderline): `Σ 1/(n·log n)` diverges. -/
+theorem logHarmonic_diverges : ¬ Summable (bertrand 1) :=
+  bertrand_not_summable_of_le_one le_rfl
+
+/-- **Parent case p = 2**: `Σ 1/(n·(log n)²)` converges. -/
+theorem logHarmonicSq_converges : Summable (bertrand 2) :=
+  bertrand_summable_of_one_lt (by norm_num)
+
+end HarmonicDivergenceOQ02OQ01

--- a/src/data/proofs/harmonic-divergence-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/harmonic-divergence-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-bertrand-def",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 89
+    },
+    "type": "definition",
+    "title": "The Real-Exponent Bertrand Term with a Repaired Small-Index Cap",
+    "content": "bertrand p n is 1/(n·(log n)^p) for n ≥ 2, where (log n)^p is a genuine real power (Real.rpow). For n < 2 the value is capped at the n=2 term rather than set to 0. This cap matters: the parent's `if n < 2 then 0` makes f(1)=0 lie below f(2)>0, so the sequence is NOT non-increasing on the positives and the antitone hypothesis of the condensation test is unprovable at (m,n)=(1,2). Capping at the n=2 value changes only finitely many terms (so convergence is unaffected) while making the sequence genuinely antitone on all positive indices.",
+    "mathContext": "The exponent on $\\log n$ is real, so the family $\\{1/(n(\\log n)^p)\\}_{p\\in\\mathbb{R}}$ is parameterized continuously. `denom_pos` shows $n(\\log n)^p>0$ for $n\\ge 2$ via `Real.rpow_pos_of_pos` and $\\log n>0$, and `bertrand_nonneg` follows."
+  },
+  {
+    "id": "ann-bertrand-antitone",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "Antitonicity for p ≥ 0",
+    "content": "For p ≥ 0 the term is non-increasing on positive indices — exactly the hypothesis summable_condensed_iff_of_nonneg requires. The core fact is monotonicity of the denominator: m·(log m)^p ≤ n·(log n)^p for 2 ≤ m ≤ n, since m ≤ n and (log m)^p ≤ (log n)^p (Real.rpow_le_rpow, using p ≥ 0 and log m ≥ 0). The m=1 boundary is dispatched by the cap, which equals the n=2 value and therefore dominates every later term.",
+    "mathContext": "`one_div_le_one_div_of_le` converts the denominator inequality into $1/(n(\\log n)^p)\\le 1/(m(\\log m)^p)$. The p ≥ 0 hypothesis is essential and genuinely used (for p < 0 antitonicity is false)."
+  },
+  {
+    "id": "ann-bertrand-condensed",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 139
+    },
+    "type": "theorem",
+    "title": "Condensed Term = Rescaled Real p-Series",
+    "content": "The Cauchy-condensed term at k ≥ 1 is 2^k · bertrand p (2^k) = (1/(log 2)^p)·(1/k^p). The 2^k factors cancel, log(2^k) = k·log 2, and Real.mul_rpow splits (k·log 2)^p = k^p·(log 2)^p. This exposes the condensed series as a constant multiple of the real p-series Σ 1/k^p — the single identity that drives the whole p ≥ 0 dichotomy.",
+    "mathContext": "After substituting $\\log(2^k)=k\\log 2$ and splitting the rpow, `field_simp` clears the denominators using the nonzero guards $2^k\\ne 0$, $k^p\\ne 0$, $(\\log 2)^p\\ne 0$ (each from `Real.rpow_pos_of_pos`)."
+  },
+  {
+    "id": "ann-bertrand-nonneg-dichotomy",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "Convergence Dichotomy for p ≥ 0",
+    "content": "For p ≥ 0, Σ bertrand p converges ⟺ p > 1. The proof is a clean iff-chain: summable_condensed_iff_of_nonneg reduces to the condensed series; summable_nat_add_iff drops the k=0 term; summable_mul_left_iff removes the constant 1/(log 2)^p; and Real.summable_one_div_nat_rpow says Σ 1/k^p converges ⟺ 1 < p. No case split on whether p is an integer is needed.",
+    "mathContext": "Each step is an `Iff` rewrite, so the whole statement is settled without ever constructing the sum, only transporting summability across condensation, shifting, and a nonzero scalar."
+  },
+  {
+    "id": "ann-bertrand-negative",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 157,
+      "endLine": 184
+    },
+    "type": "theorem",
+    "title": "Divergence for p < 0 by Comparison",
+    "content": "When p < 0 the term is not antitone, so condensation is unavailable. Instead it dominates the harmonic term: for n ≥ 3, log n > 1 and p ≤ 0 give (log n)^p ≤ 1 (Real.rpow_le_one_of_one_le_of_nonpos), hence bertrand 0 (n) ≤ bertrand p (n). Since the p=0 series diverges, Summable.of_nonneg_of_le on the tail n ≥ 3 forces the p < 0 series to diverge.",
+    "mathContext": "The bound $1\\le\\log(n+3)$ comes from `Real.le_log_iff_exp_le` together with $e<3$ (`Real.exp_one_lt_d9`). The tail is isolated with `summable_nat_add_iff 3`."
+  },
+  {
+    "id": "ann-bertrand-threshold",
+    "proofId": "harmonic-divergence-oq-02-oq-01",
+    "range": {
+      "startLine": 185,
+      "endLine": 211
+    },
+    "type": "theorem",
+    "title": "The Full Threshold and Parent Corollaries",
+    "content": "Splitting at p = 0 combines the two analyses into the all-real-p theorem: Σ bertrand p converges ⟺ p > 1. The parent's two cases are now one-line corollaries: logHarmonic_diverges (p=1) = bertrand_not_summable_of_le_one le_rfl, and logHarmonicSq_converges (p=2) = bertrand_summable_of_one_lt (by norm_num). The general dichotomy strictly subsumes and re-derives the parent.",
+    "mathContext": "For $p<0$ both sides are false; for $p\\ge 0$ the condensation dichotomy applies. The corollaries `bertrand_not_summable_of_le_one` (covers $p=1$ and the strip $0<p<1$) and `bertrand_summable_of_one_lt` package the two regimes."
+  }
+]

--- a/src/data/proofs/harmonic-divergence-oq-02-oq-01/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-02-oq-01/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "harmonic-divergence-oq-02-oq-01",
+  "title": "The Bertrand Series Threshold: Σ 1/(n·(log n)^p) Converges ⟺ p > 1",
+  "slug": "harmonic-divergence-oq-02-oq-01",
+  "description": "Promotes the parent's two isolated cases (p=1 divergent, p=2 convergent) to the full real-exponent dichotomy: for every p ∈ ℝ, the Bertrand series Σ 1/(n·(log n)^p) converges if and only if p > 1. For p ≥ 0 the term is antitone and Cauchy condensation reduces it to (1/(log 2)^p)·Σ 1/k^p, a real p-series; for p < 0 it dominates the harmonic series on the tail. Recovers the parent's p=1 and p=2 as corollaries.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "convergence",
+      "divergence",
+      "condensation test",
+      "rpow",
+      "p-series",
+      "Bertrand series",
+      "logarithmic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "lineCount": 213,
+    "definitionCount": 1,
+    "assumptions": "None. Fully machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound (no extra axioms, no sorries).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The series Σ 1/(n·(log n)^p) is the classical Bertrand series, named for Joseph Bertrand who studied such logarithmic refinements of the p-series in the mid-19th century. It is the first non-trivial rung of du Bois-Reymond's (1873) logarithmico-exponential scale and the standard textbook example separating convergence from divergence at a logarithmic correction: the bare p-series Σ 1/n^q has its threshold at q = 1, and inserting a single logarithm shifts the delicate boundary to the exponent of that logarithm. The whole family is handled by one tool, Cauchy's condensation test (Cours d'Analyse, 1827), which collapses Σ f(n) to Σ 2^k f(2^k); for the Bertrand term the 2^k factors cancel exactly and log(2^k) = k·log 2 turns the condensed series into a constant multiple of an ordinary p-series. The parent entry (OQ-02) formalized only the two endpoints p = 1 (divergent borderline) and p = 2 (convergent); this entry establishes the complete threshold for a continuous real exponent.",
+    "problemStatement": "For a real exponent $p$, determine exactly when the Bertrand series $\\sum_{n \\geq 2} \\frac{1}{n (\\log n)^p}$ converges. Theorem: it converges if and only if $p > 1$. The exponent is realized as a genuine real power (`rpow`) of $\\log n$, so the result interpolates across the entire family and pins the convergence boundary at $p = 1$, recovering the parent's $p = 1$ (divergent) and $p = 2$ (convergent) as the two sides of the threshold.",
+    "text": "Cauchy condensation reduces the Bertrand series to its condensed form 2^k·f(2^k) = 1/(k·log 2)^p = (1/(log 2)^p)·(1/k^p). This is a constant multiple of the real p-series Σ 1/k^p, which converges iff p > 1 (Mathlib's Real.summable_one_div_nat_rpow). For p < 0, antitonicity fails, but the term then dominates 1/n on the tail n ≥ 3 (where (log n)^p ≤ 1), giving divergence by comparison. Combining, the series converges iff p > 1 for every real p.",
+    "proofStrategy": "1. Define `bertrand p n = 1/(n·(log n)^p)` for n ≥ 2, capped at the n=2 value for n < 2 (a finite modification that makes the sequence genuinely non-increasing on all positive indices — the naive `if n<2 then 0` truncation of the parent is NOT antitone at n=1, where it dips below the n=2 term and breaks the condensation hypothesis). 2. Prove nonnegativity and, for p ≥ 0, antitonicity via monotonicity of the denominator n·(log n)^p (`Real.rpow_le_rpow`). 3. Compute the condensed identity `condensed_eq`: 2^k·bertrand p (2^k) = (1/(log 2)^p)·(1/k^p), using log(2^k) = k·log 2 and `Real.mul_rpow` to split (k·log 2)^p. 4. For p ≥ 0, chain Cauchy condensation (`summable_condensed_iff_of_nonneg`) with a shift past k=0 (`summable_nat_add_iff`), a constant-multiple cancellation (`summable_mul_left_iff`), and the real p-series test (`Real.summable_one_div_nat_rpow`) to get `Summable ↔ 1 < p`. 5. For p < 0, compare with the p=0 (harmonic) series on the tail n ≥ 3 using `Real.rpow_le_one_of_one_le_of_nonpos` and `Summable.of_nonneg_of_le`. 6. Assemble the full real-p dichotomy and derive the parent's p=1 and p=2 cases as corollaries.",
+    "keyInsights": [
+      "Promoting the natural-number/discrete cases of the parent to a continuous real exponent via `rpow` turns two isolated facts into a single sharp threshold theorem: convergence ⟺ p > 1, valid for ALL real p. The threshold value p = 1 is the boundary, p = 2 sits strictly inside the convergent region, and the entire strip 0 < p < 1 — invisible to the parent — is divergent.",
+      "The condensation cancellation is exponent-uniform: 2^k·1/(2^k·(log 2^k)^p) = 1/(k·log 2)^p, and Real.mul_rpow splits (k·log 2)^p = k^p·(log 2)^p, exposing the condensed series as a constant multiple of the real p-series Σ 1/k^p. One Mathlib lemma (Real.summable_one_div_nat_rpow) then supplies the entire 0 ≤ p dichotomy with no case split on whether p is an integer.",
+      "The parent's `if n < 2 then 0` convention is mathematically unsound for the condensation test: f(1)=0 lies BELOW f(2)>0, so f is not non-increasing on the positives and the antitone hypothesis is unprovable at (m,n)=(1,2). Capping the n<2 values at the n=2 term repairs antitonicity while changing only finitely many terms, hence leaving convergence — the only property the theorem asserts — untouched.",
+      "Negative exponents need a different mechanism: antitonicity genuinely fails, but the term then exceeds the harmonic term 1/n on the tail (for n ≥ 3, log n > 1 forces (log n)^p ≤ 1), so divergence follows by direct comparison with the p=0 case rather than by condensation. The proof therefore splits at p = 0, condensation above and comparison below.",
+      "Both parent cases are now one-line corollaries of the general theorem: `logHarmonic_diverges` (p=1) is `bertrand_not_summable_of_le_one le_rfl`, and `logHarmonicSq_converges` (p=2) is `bertrand_summable_of_one_lt (by norm_num)`. The general dichotomy strictly subsumes and re-derives the parent."
+    ],
+    "prerequisites": [
+      "Cauchy condensation test (Mathlib's summable_condensed_iff_of_nonneg)",
+      "Real p-series convergence test (Real.summable_one_div_nat_rpow: Σ 1/n^p summable ⟺ 1 < p)",
+      "Real rpow API (Real.mul_rpow, Real.rpow_le_rpow, Real.rpow_pos_of_pos, Real.rpow_le_one_of_one_le_of_nonpos, Real.rpow_zero)",
+      "Real.log properties (Real.log_pow, Real.log_pos, Real.le_log_iff_exp_le, Real.exp_one_lt_d9)",
+      "Tail/shift and constant-multiple summability lemmas (summable_nat_add_iff, summable_mul_left_iff, Summable.of_nonneg_of_le)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Real-Exponent Bertrand Term",
+      "startLine": 49,
+      "endLine": 89,
+      "summary": "Defines bertrand p n = 1/(n·(log n)^p) for n ≥ 2 (capped at the n=2 value for n < 2) and proves positivity of the denominator and nonnegativity of the term.",
+      "mathContext": "The exponent is a real power $(\\log n)^p$ via `Real.rpow`. The small-index cap (value at $n=0,1$ set equal to the $n=2$ term) is a finite modification preserving convergence; it is chosen precisely so the sequence is non-increasing on all positive indices, repairing the antitonicity defect of the parent's `if n<2 then 0` definition."
+    },
+    {
+      "id": "antitone",
+      "title": "Antitonicity for p ≥ 0",
+      "startLine": 90,
+      "endLine": 117,
+      "summary": "For p ≥ 0, bertrand p is antitone on positive indices, the hypothesis the condensation test requires. Reduces to monotonicity of the denominator n·(log n)^p.",
+      "mathContext": "For $0 < m \\le n$ with both $\\ge 2$, $1/(n(\\log n)^p) \\le 1/(m(\\log m)^p)$ because $m(\\log m)^p \\le n(\\log n)^p$: the factor $n$ grows and $(\\log n)^p$ is non-decreasing in $n$ for $p \\ge 0$ (`Real.rpow_le_rpow`). The $m=1$ boundary is handled by the cap, which equals the $n=2$ value and dominates every later term."
+    },
+    {
+      "id": "condensation",
+      "title": "The Condensed Term Is a Rescaled p-Series",
+      "startLine": 118,
+      "endLine": 139,
+      "summary": "Key computation: 2^k · bertrand p (2^k) = (1/(log 2)^p)·(1/k^p) for k ≥ 1.",
+      "mathContext": "Using $\\log(2^k) = k\\log 2$ and `Real.mul_rpow`, $(k\\log 2)^p = k^p (\\log 2)^p$, so $2^k \\cdot \\frac{1}{2^k (k\\log 2)^p} = \\frac{1}{(\\log 2)^p}\\cdot\\frac{1}{k^p}$. The nonzero guards ($2^k$, $k^p$, $(\\log 2)^p$) feed `field_simp`."
+    },
+    {
+      "id": "dichotomy-nonneg",
+      "title": "Convergence Dichotomy for p ≥ 0",
+      "startLine": 140,
+      "endLine": 156,
+      "summary": "For p ≥ 0, Σ bertrand p converges iff p > 1, by chaining condensation, a shift past k=0, constant-multiple cancellation, and the real p-series test.",
+      "mathContext": "`summable_condensed_iff_of_nonneg` reduces to the condensed series; `summable_nat_add_iff` drops the $k=0$ term; `summable_mul_left_iff` removes the constant $1/(\\log 2)^p$; `Real.summable_one_div_nat_rpow` gives Σ $1/k^p$ summable $\\iff 1 < p$."
+    },
+    {
+      "id": "negative-exponent",
+      "title": "Divergence for p < 0 by Comparison",
+      "startLine": 157,
+      "endLine": 184,
+      "summary": "For p < 0 antitonicity fails; instead the term dominates the harmonic term on the tail n ≥ 3, giving divergence by comparison with the p=0 case.",
+      "mathContext": "For $n \\ge 3$, $\\log n > 1$ and $p \\le 0$ give $(\\log n)^p \\le 1$ (`Real.rpow_le_one_of_one_le_of_nonpos`), so $\\text{bertrand } 0\\,(n) \\le \\text{bertrand } p\\,(n)$. Since the $p=0$ series diverges, `Summable.of_nonneg_of_le` on the tail forces divergence of the $p<0$ series."
+    },
+    {
+      "id": "threshold-and-corollaries",
+      "title": "The Full Threshold and Parent Corollaries",
+      "startLine": 185,
+      "endLine": 211,
+      "summary": "Combines the p ≥ 0 and p < 0 analyses into the all-real-p theorem Σ bertrand p converges ⟺ p > 1, and recovers the parent's p=1 (divergent) and p=2 (convergent) as one-line corollaries.",
+      "mathContext": "Splitting at $p=0$: for $p<0$ both `Summable` and $1<p$ are false; for $p \\ge 0$ the condensation dichotomy applies. Corollaries: $p \\le 1 \\Rightarrow$ divergent (includes $p=1$ and $0<p<1$), $p>1 \\Rightarrow$ convergent."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every real exponent p, the Bertrand series Σ 1/(n·(log n)^p) converges if and only if p > 1. The p ≥ 0 half is Cauchy condensation reducing the series to a constant multiple of the real p-series Σ 1/k^p; the p < 0 half is direct comparison with the harmonic series. The theorem strictly subsumes the parent entry, whose p=1 (divergent) and p=2 (convergent) cases drop out as immediate corollaries, and repairs the parent's antitonicity defect by capping the singular small-index values.",
+    "openQuestions": [
+      "Iterated logarithms: does the same threshold persist one level up, i.e. is Σ 1/(n·log n·(log log n)^p) convergent ⟺ p > 1? This is the next rung of the du Bois-Reymond scale and should again yield to condensation after one extra peeling.",
+      "Two-parameter refinement: classify convergence of Σ 1/(n^q·(log n)^p) in the full (q,p) plane — convergent for q > 1 (any p), divergent for q < 1 (any p), and governed by p at the critical line q = 1, which is exactly the present theorem.",
+      "Sharp asymptotics in the divergent regime: for 0 ≤ p < 1 the partial sums grow like (log N)^{1-p}/(1-p); can this rate (and the log log N rate at p = 1) be formalized via the integral test in Mathlib's MeasureTheory?"
+    ],
+    "implications": "Casting the exponent as a real `rpow` collapses an entire family of convergence questions into a single sharp statement and shows that the discrete cases formalized in the parent are samples of one continuous threshold. Methodologically, it illustrates that the condensation test plus the real p-series test is enough to settle the borderline logarithmic series uniformly in the exponent, and it flags a reusable subtlety: truncating a singular term to 0 can silently break the antitonicity hypothesis of the condensation test."
+  },
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence-oq-02",
+      "relationship": "extends",
+      "description": "Generalizes the parent's two isolated cases (p=1 divergent, p=2 convergent) to the full real-exponent threshold p > 1, recovering both as corollaries and repairing the parent's antitonicity convention."
+    },
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "extends",
+      "description": "Continues the logarithmic-hierarchy story begun with the harmonic series Σ 1/n (the q=1, p=0 corner of the Bertrand family)."
+    }
+  ],
+  "references": [
+    {
+      "author": "Cauchy, A.-L.",
+      "title": "Cours d'Analyse de l'École Royale Polytechnique",
+      "year": 1827,
+      "note": "Condensation test reducing Σ f(n) to Σ 2^k f(2^k)."
+    },
+    {
+      "author": "du Bois-Reymond, P.",
+      "title": "Sur la grandeur relative des infinis des fonctions",
+      "year": 1873,
+      "note": "Logarithmic comparison scale in which the Bertrand series is the first refined rung."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "HarmonicDivergenceOQ02OQ01",
+    "lineCount": 213,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 1,
+    "path": "Proofs/HarmonicDivergenceOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes parent **harmonic-divergence-oq-02** (which formalized only the two isolated cases *p=1* divergent and *p=2* convergent) to the full **real-exponent Bertrand-series threshold**:

> For every real $p$,  $\sum_{n\ge 2} \frac{1}{n(\log n)^p}$  converges  **⟺**  $p > 1$.

The exponent is a genuine real power (`Real.rpow`) of $\log n$, so the result is one sharp threshold rather than scattered integer cases. The parent's $p=1$ and $p=2$ drop out as one-line corollaries.

## Proof architecture
- **$p \ge 0$** — the term is antitone, so **Cauchy condensation** applies. The condensed term at $k\ge1$ is $2^k/(2^k(\log 2^k)^p) = (1/(\log 2)^p)\cdot(1/k^p)$, a constant multiple of the real p-series $\sum 1/k^p$ (`Real.summable_one_div_nat_rpow`).
- **$p < 0$** — antitonicity fails; instead the term dominates the harmonic term $1/n$ on the tail $n\ge3$ (there $(\log n)^p\le1$), giving divergence by comparison.

## Repaired a parent defect
The parent's `if n < 2 then 0` convention is **not** non-increasing on the positives ($f(1)=0<f(2)$), so its antitone hypothesis is unprovable at $(m,n)=(1,2)$ — the parent file does not build against Mathlib v4.26. This entry caps the singular small-index values at the $n=2$ term (a finite, convergence-preserving modification), restoring genuine antitonicity.

## Verification
- **14 theorems / 1 definition / 213 lines**, Mathlib v4.26.0
- Builds clean via host `lake env lean`
- `#print axioms bertrand_summable_iff` → only `propext, Classical.choice, Quot.sound` (**0 counted axioms, 0 sorries**)
- Status `verified`, badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)