### PR TITLE
Enrich Sum of Nonzero Quadratic Residues Vanishes mod p>3: add annotations.json

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-ecs0102-residue-set",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 32, "endLine": 38 },
+    "type": "definition",
+    "title": "The Nonzero Quadratic Residue Finset",
+    "content": "`residues p` packages the nonzero quadratic residues of `ZMod p` as the finite set `univ.filter (x ≠ 0 ∧ IsSquare x)`, with `mem_residues` recording the membership characterization. Working with a concrete `Finset` (rather than the abstract subgroup) is what lets the proof reindex the sum along an explicit bijection later.",
+    "mathContext": "$\\operatorname{residues}(p) = \\{x \\in \\mathbb{Z}/p\\mathbb{Z} : x \\neq 0,\\ \\exists y,\\ x = y^2\\}$, the unique index-2 multiplicative subgroup of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residue", "IsSquare", "Finset.filter", "index-2 subgroup"],
+    "prerequisites": ["finite sets in Lean", "squares in a field"]
+  },
+  {
+    "id": "ann-ecs0102-witness",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 65 },
+    "type": "technique",
+    "title": "The Witness 4 = 2² and the Nonvanishing Arithmetic",
+    "content": "The argument hinges on a concrete nonzero square `t ≠ 1`. The witness is `4 = 2²`: `isSquare_four` makes it a square in any commutative ring, and for `p > 3` the elements `2`, `4 = 2·2`, and the cancellation factor `3 = 4−1` are all nonzero in the field. Each nonvanishing comes from `CharP.cast_eq_zero_iff` (so `(n : ZMod p) = 0 ↔ p ∣ n`) combined with `p ∤ 2`, `p ∤ 3`, discharged by `omega`. The hypothesis `p > 3` is used here and only here — it is exactly `p ∤ 2 ∧ p ∤ 3`.",
+    "mathContext": "$4 = 2^2$ is a square; for $p>3$, $p \\nmid 2$ and $p \\nmid 3$, so $2, 4, 3 \\neq 0$ in $\\mathbb{Z}/p\\mathbb{Z}$. The threshold is sharp: at $p=3$, $4 = 1$ and $3 = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic of a field", "CharP.cast_eq_zero_iff", "nonzero divisors", "sharp threshold p>3"],
+    "prerequisites": ["divisibility and characteristic", "mul_ne_zero", "omega"]
+  },
+  {
+    "id": "ann-ecs0102-closure",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "insight",
+    "title": "Closure: Scaling by 4 Preserves Residues",
+    "content": "`mul_four_mem_residues` shows that multiplying a nonzero residue by `4` stays in the residue set: the product is a square because squares are closed under multiplication (`IsSquare.mul` — the multiplicative subgroup property), and it is nonzero because a field has no zero divisors (`mul_ne_zero`). This is the structural fact that the residues form a multiplicative subgroup, instantiated for the single scalar `4`.",
+    "mathContext": "$x \\neq 0,\\ x = y^2 \\Rightarrow 4x = (2y)^2 \\neq 0$, so $4 \\cdot \\operatorname{residues}(p) \\subseteq \\operatorname{residues}(p)$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative closure of squares", "IsSquare.mul", "subgroup stability", "no zero divisors"],
+    "prerequisites": ["product of squares is a square", "field has no zero divisors"]
+  },
+  {
+    "id": "ann-ecs0102-bijection",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 99 },
+    "type": "technique",
+    "title": "Scaling by 4 Is a Bijection of the Finset",
+    "content": "`image_mul_four` upgrades closure (a subset relation) to an equality of finsets. Because `x ↦ 4x` is injective (`mul_left_cancel₀`, using `4 ≠ 0`), the image has the same cardinality as `residues p`; a subset of equal cardinality is the whole set (`Finset.eq_of_subset_of_card_le` + `Finset.card_image_of_injective`). `four_mul_sum_eq_sum` then reindexes: pull the scalar out with `Finset.mul_sum`, rewrite the sum over the image with `Finset.sum_image`, and recognize the image as `residues p` — giving `4·S = S`.",
+    "mathContext": "$x \\mapsto 4x$ injective $\\Rightarrow |4\\cdot\\!\\operatorname{residues}| = |\\operatorname{residues}|$, so the inclusion is equality; reindexing gives $4S = \\sum_x 4x = \\sum_{u} u = S$.",
+    "significance": "key",
+    "relatedConcepts": ["injective self-map", "Finset.sum_image", "cardinality argument", "reindexing a sum"],
+    "prerequisites": ["mul_left_cancel₀", "Finset.eq_of_subset_of_card_le", "Finset.mul_sum"]
+  },
+  {
+    "id": "ann-ecs0102-cancellation",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 109 },
+    "type": "insight",
+    "title": "Invariance Forces the Sum to Zero",
+    "content": "`sum_quadratic_residues_eq_zero` is the headline. From the scaling invariance `4·S = S`, a one-line `linear_combination` gives `3·S = 0` (i.e. `(4−1)·S = 0`). Since `3 ≠ 0` in the field for `p > 3`, `mul_eq_zero.resolve_left` forces `S = 0`. This is the prototypical 'a nontrivial multiplicative scaling fixes a sum, so a field forces the sum to zero' template — no knowledge of which elements are residues is needed.",
+    "mathContext": "$4S = S \\Rightarrow 3S = 0 \\xrightarrow{3 \\neq 0} S = 0$ in $\\mathbb{Z}/p\\mathbb{Z}$, the additive companion to the parent's count of $(p-1)/2$ residues.",
+    "significance": "key",
+    "relatedConcepts": ["vanishing sums", "field cancellation", "linear_combination", "mul_eq_zero"],
+    "prerequisites": ["four_mul_sum_eq_sum", "three_ne_zero", "field with no zero divisors"]
+  },
+  {
+    "id": "ann-ecs0102-concrete",
+    "proofId": "euler-criterion-squares-oq-01-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 129 },
+    "type": "context",
+    "title": "Concrete Checks mod 5, 7, 11",
+    "content": "The vanishing sum is confirmed at `p = 5` ({1,4}), `p = 7` ({1,2,4}), and `p = 11` ({1,3,4,5,9}). Crucially these are not separate `decide` computations: each `sum_residues_mod_*` simply specializes the general theorem at the prime (supplying `Fact p.Prime` and `3 < p` by `norm_num`). Reusing the general result rather than kernel evaluation keeps the file genuinely axiom-free — no `native_decide`, hence no `Lean.ofReduceBool`.",
+    "mathContext": "$1+4=5\\equiv 0$, $1+2+4=7\\equiv 0$, $1+3+4+5+9=22\\equiv 0 \\pmod{p}$.",
+    "significance": "context",
+    "relatedConcepts": ["instantiation vs decide", "axiom integrity", "native_decide avoidance"],
+    "prerequisites": ["Fact instances", "specializing universally quantified theorems"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-01-oq-02` (quality 30 → adds the missing inline annotations).

The entry had a rich meta.json (overview, 5 sections, key insights, cross-references) but **no annotations.json**, so the proof page rendered without inline annotations. This pass adds 6 substantive annotations:

1. **Residue finset** — the nonzero quadratic residues as a filtered `Finset`
2. **Witness 4 = 2²** — and the `p > 3` arithmetic certifying 2, 4, 3 ≠ 0 (the sharp threshold)
3. **Multiplicative closure** — scaling by 4 preserves residues (`IsSquare.mul`)
4. **Finset bijection** — injectivity → image equals the set → reindex to 4·S = S
5. **Cancellation** — 4·S = S ⟹ 3·S = 0 ⟹ S = 0 in the field
6. **Concrete checks mod 5/7/11** — specializations of the general theorem (no `native_decide`, stays axiom-free)

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. All line ranges validated via `pnpm annotations:build` (my slug resolves with 0 errors). Axiom integrity unchanged: `verified`, 0 axioms, 0 sorries, no `native_decide`.