### PR TITLE
audit: fermat-two-squares-oq-07-oq-01 clean (Brahmagupta samasa law)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22955,6 +22955,12 @@
       "lastAudited": "2026-06-25T02:38:55Z",
       "result": "clean",
       "issues": []
+    },
+    "fermat-two-squares-oq-07-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:13:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `fermat-two-squares-oq-07-oq-01` (Brahmagupta's Samasa Law, norm form x²−N·y²) — just merged in #29604.

### Verified
- **Counts**: 13 theorems / 2 defs — matches meta.json exactly.
- **Sorries**: 0 ✓ · **Axiom decls**: 0 ✓ · **True stubs**: none.
- **`decide` is kernel** (lines 142/145/149), NOT `native_decide` → no `Lean.ofReduceBool` dependency. Meta correctly discloses this.
- **Tier A**: all results are `ring`-closed polynomial identities; no deep Mathlib theorem performs the core work. The file explicitly reproves the norm-multiplicativity elementarily rather than delegating to `Zsqrtd.norm_mul`, and discloses that relationship — no delegation opacity.
- **Math spot-check** (N=2): 9−8=1, 289−288=1, doubling (3²+2·2², 2·3·2)=(17,12) all correct.

`verified` / `original` / 0-axiom claims are accurate. No changes needed beyond the tracker.

---
Discovered during gallery integrity audit. Tracker-only change.