### PR TITLE
Enrich Clement twin-prime criterion (wilsons-theorem-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-clement-header",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 30 },
+    "type": "context",
+    "title": "Clement's criterion and its scope",
+    "content": "The module docstring states Clement's 1949 theorem and the proof plan: apply Wilson's biconditional at the two moduli n and n+2 and fuse them by the Chinese remainder theorem. It also fixes the scope to odd n ≥ 3, noting oddness is used exactly twice — to make 4 a unit mod n and 2 a unit mod n+2, and to give gcd(n, n+2) = 1. Every genuine twin-prime candidate n ≥ 3 is odd, so the hypothesis discards only the degenerate even branch.",
+    "mathContext": "Clement (1949): for odd $n \\ge 3$, $(n,\\,n+2)$ are both prime $\\iff n(n+2) \\mid 4((n-1)!+1)+n$.",
+    "significance": "context",
+    "relatedConcepts": ["Wilson's theorem", "twin primes", "Chinese remainder theorem", "primality criterion"],
+    "prerequisites": ["modular arithmetic", "factorials", "prime numbers"]
+  },
+  {
+    "id": "ann-clement-value",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 37, "endLine": 38 },
+    "type": "definition",
+    "title": "The Clement criterion quantity C(n)",
+    "content": "clementValue n = 4·((n-1)! + 1) + n is the single integer whose divisibility by n·(n+2) detects twin-primality. It bundles the two Wilson congruences: reduced mod n it exposes 4·((n-1)!+1) (Wilson at n), and reduced mod n+2 it becomes 2·((n+1)!+1) after the factorial bridge (Wilson at n+2). The constant offsets 4 and n are precisely what align the two reductions.",
+    "mathContext": "$C(n) = 4\\,((n-1)! + 1) + n$. For the smallest twin pair: $C(3) = 4(2!+1)+3 = 15 = 3 \\cdot 5$.",
+    "significance": "key",
+    "relatedConcepts": ["factorial", "Wilson congruence", "divisibility"],
+    "prerequisites": ["factorials", "natural number arithmetic"]
+  },
+  {
+    "id": "ann-clement-factorial-expand",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 40, "endLine": 43 },
+    "type": "technique",
+    "title": "Factorial expansion (n+1)! = (n+1)·n·(n-1)!",
+    "content": "factorial_succ_eq peels two factors off (n+1)! to expose the (n-1)! that Wilson at modulus n already involves. The proof combines Nat.factorial_succ ((n+1)! = (n+1)·n!) with Nat.mul_factorial_pred (n! = n·(n-1)! for n ≠ 0). This three-factor form is the algebraic substrate for the modular bridge that follows.",
+    "mathContext": "$(n+1)! = (n+1)\\cdot n!\\ = (n+1)\\cdot n \\cdot (n-1)!$ for $n \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["factorial recurrence", "Nat.factorial_succ", "Nat.mul_factorial_pred"],
+    "prerequisites": ["factorials"]
+  },
+  {
+    "id": "ann-clement-bridge",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 45, "endLine": 57 },
+    "type": "insight",
+    "title": "The modular bridge: (n+1)! ≡ 2·(n-1)! (mod n+2)",
+    "content": "This is the heart of the formalization and Mathlib has nothing like it. Working in ZMod (n+2), the residue n+1 ≡ -1 and n ≡ -2, so the expansion (n+1)! = (n+1)·n·(n-1)! collapses to (-1)·(-2)·(n-1)! = 2·(n-1)!. The cast n = -2 mod n+2 is obtained from ZMod.natCast_self (n+2 ≡ 0) via linear_combination, then push_cast/ring finish. The payoff is decisive: a single factorial (n-1)! now carries Wilson's congruence at BOTH moduli, so the criterion needs only one factorial instead of two.",
+    "mathContext": "In $\\mathbb{Z}/(n+2)$: $n+1 \\equiv -1,\\ n \\equiv -2$, so $(n+1)! = (n+1)\\,n\\,(n-1)! \\equiv (-1)(-2)(n-1)! = 2\\,(n-1)!$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod", "negative residues", "Frobenius-style reduction", "factorial congruence"],
+    "prerequisites": ["ZMod", "ZMod.natCast_self", "linear_combination"]
+  },
+  {
+    "id": "ann-clement-units",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 67, "endLine": 98 },
+    "type": "technique",
+    "title": "Unit cancellation strips the leading coefficients",
+    "content": "Oddness of n makes 4 = 2·2 coprime to n (so 4 is a unit in ZMod n) and 2 coprime to n+2 (so 2 is a unit in ZMod (n+2)), via ZMod.isUnit_iff_coprime. The two bridge lemmas hA and hB then read: n ∣ C(n) ↔ (n-1)! ≡ -1 (mod n), and (n+2) ∣ C(n) ↔ (n+1)! ≡ -1 (mod n+2). Each is obtained by transporting divisibility into ZMod (ZMod.natCast_eq_zero_iff), reducing the constant terms (ZMod.natCast_self), and using IsUnit.mul_right_eq_zero to cancel the invertible leading 4 (resp. 2) — leaving exactly the bare Wilson congruence.",
+    "mathContext": "$n \\text{ odd} \\Rightarrow \\gcd(4,n)=1,\\ \\gcd(2,n+2)=1$; a unit $u$ satisfies $u\\cdot a = 0 \\iff a = 0$, so $4((n-1)!+1)\\equiv 0 \\iff (n-1)!\\equiv -1$.",
+    "significance": "key",
+    "relatedConcepts": ["units in ZMod", "ZMod.isUnit_iff_coprime", "coprimality", "IsUnit.mul_right_eq_zero"],
+    "prerequisites": ["ring units", "ZMod", "coprimality"]
+  },
+  {
+    "id": "ann-clement-crt-fusion",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 99, "endLine": 123 },
+    "type": "concept",
+    "title": "CRT fusion and the final equivalence chain",
+    "content": "Wilson's biconditional Nat.prime_iff_fac_equiv_neg_one supplies Prime n ↔ (n-1)! ≡ -1 (mod n) and Prime (n+2) ↔ (n+1)! ≡ -1 (mod n+2). The coprimality gcd(n, n+2) = 1 (both odd, differing by 2) gives the CRT split: n·(n+2) ∣ C(n) ↔ (n ∣ C(n) ∧ (n+2) ∣ C(n)) — forward by transitivity through n, n+2 ∣ n(n+2), backward by Nat.Coprime.mul_dvd_of_dvd_of_dvd. A short calc chains primality ↔ Wilson congruences ↔ single-modulus divisibilities ↔ the product divisibility, completing the criterion.",
+    "mathContext": "$\\gcd(n,n+2)=1 \\Rightarrow \\big(n(n+2)\\mid C \\iff n\\mid C \\wedge (n+2)\\mid C\\big)$; chained with Wilson at each modulus.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese remainder theorem", "Nat.prime_iff_fac_equiv_neg_one", "Nat.Coprime.mul_dvd_of_dvd_of_dvd", "coprime divisors"],
+    "prerequisites": ["Wilson's theorem", "Chinese remainder theorem", "divisibility"]
+  },
+  {
+    "id": "ann-clement-example",
+    "proofId": "wilsons-theorem-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 127 },
+    "type": "context",
+    "title": "Worked instance: the twin pair (3, 5)",
+    "content": "The smallest twin pair instantiates the criterion: C(3) = 4·(2!+1) + 3 = 4·3 + 3 = 15 = 3·5, so 3·5 ∣ C(3) and the biconditional certifies (3, 5) as twin primes. This concrete check makes the abstract criterion tangible and confirms the constants line up.",
+    "mathContext": "$C(3) = 4(2!+1)+3 = 15 = 3\\cdot 5$, and indeed both $3$ and $5$ are prime.",
+    "significance": "context",
+    "relatedConcepts": ["twin primes", "worked example"],
+    "prerequisites": ["factorials", "divisibility"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-03/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsClementTwinPrimeOQ0103.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOq01Oq03Data: ProofData = {
+  proof: wilsonsTheoremOq01Oq03Proof,
+  annotations: wilsonsTheoremOq01Oq03Annotations,
+}

--- a/src/data/proofs/wilsons-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01-oq-03/meta.json
@@ -119,5 +119,54 @@
       "description": "The base Wilson's theorem entry; Clement's criterion is its canonical two-modulus application."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Statement, Strategy, and Scope",
+      "startLine": 4,
+      "endLine": 35,
+      "summary": "Docstring stating Clement's 1949 criterion (odd n ≥ 3: (n, n+2) both prime ↔ n·(n+2) ∣ 4·((n-1)!+1)+n), the proof plan (Wilson at moduli n and n+2 fused by CRT), the two original contributions (the factorial bridge and the full biconditional), and the scope note that oddness is used only for the two unit cancellations and the coprimality.",
+      "mathContext": "Mathlib has the single-modulus Wilson biconditional but no twin-prime criterion; this entry assembles one."
+    },
+    {
+      "id": "sec-value",
+      "title": "The Criterion Quantity",
+      "startLine": 37,
+      "endLine": 38,
+      "summary": "def clementValue n = 4·((n-1)!+1)+n — the single integer whose divisibility by n·(n+2) characterizes twin-primality.",
+      "mathContext": "C(n) = 4·((n-1)!+1)+n bundles both Wilson congruences into one quantity."
+    },
+    {
+      "id": "sec-factorial-expand",
+      "title": "Factorial Expansion",
+      "startLine": 40,
+      "endLine": 43,
+      "summary": "factorial_succ_eq: (n+1)! = (n+1)·n·(n-1)! for n ≥ 1, via Nat.factorial_succ and Nat.mul_factorial_pred — the algebraic substrate for the modular bridge.",
+      "mathContext": "(n+1)! = (n+1)·n·(n-1)! exposes the (n-1)! shared with Wilson at modulus n."
+    },
+    {
+      "id": "sec-bridge",
+      "title": "The Modular Bridge",
+      "startLine": 45,
+      "endLine": 57,
+      "summary": "factorial_succ_succ_cast: (n+1)! ≡ 2·(n-1)! (mod n+2), from n+1 ≡ -1 and n ≡ -2 in ZMod (n+2). The key device letting one factorial (n-1)! carry Wilson's congruence at both moduli.",
+      "mathContext": "In ZMod (n+2): (n+1)! ≡ (-1)·(-2)·(n-1)! = 2·(n-1)!."
+    },
+    {
+      "id": "sec-criterion",
+      "title": "Clement's Biconditional",
+      "startLine": 59,
+      "endLine": 123,
+      "summary": "clement_twin_prime: the full criterion. Establishes 4 a unit mod n and 2 a unit mod n+2 (oddness), the two single-modulus bridges hA/hB identifying each divisibility with a Wilson congruence (unit cancellation), Wilson's biconditional at each modulus, the coprimality CRT split hsplit, and a calc chaining primality ↔ congruences ↔ divisibilities ↔ the product divisibility.",
+      "mathContext": "(Prime n ∧ Prime (n+2)) ↔ n·(n+2) ∣ C(n), assembled from Wilson at two moduli via CRT."
+    },
+    {
+      "id": "sec-example",
+      "title": "Worked Twin Pair (3, 5)",
+      "startLine": 125,
+      "endLine": 129,
+      "summary": "example: the smallest twin pair instantiates the criterion, C(3) = 4·(2!+1)+3 = 15 = 3·5.",
+      "mathContext": "C(3) = 15 = 3·5 confirms the constants align for the base case."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-01-oq-03` (Clement's twin-prime criterion via Wilson at two moduli).

**Gaps addressed** — the entry had only `meta.json`:
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site despite appearing in the gallery listing.
- **Added `annotations.json`** (was absent) — 7 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Header / scope (oddness used exactly twice)
  2. `clementValue` C(n) = 4·((n-1)!+1)+n
  3. Factorial expansion (n+1)! = (n+1)·n·(n-1)!
  4. The modular bridge (n+1)! ≡ 2·(n-1)! (mod n+2) — the original contribution
  5. Unit cancellation (4 mod n, 2 mod n+2) stripping the leading coefficients
  6. CRT fusion + final equivalence chain
  7. Worked twin pair (3, 5): C(3) = 15 = 3·5
- **Filled empty `sections`** — 6 sections covering lines 4–129.

Annotation line ranges validate against the Lean source (build's annotation validator reports zero errors for this entry). No meta claims altered (status/badge/axiomCount already accurate: verified / original / 0 axioms).

Per-cycle branch used to avoid disturbing the agent's other open PR.