### PR TITLE
research(erdos-129-wip-01): monotonicity of the Ramsey-avoidance property [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos129WIP01.lean
+++ b/proofs/Proofs/Erdos129WIP01.lean
@@ -1,0 +1,137 @@
+/-
+# Erdős Problem 129 (leaf wip-01): Monotonicity of the Ramsey-avoidance property
+
+Let `R(n; k, r)` denote the smallest `N` such that every `r`-coloring of the edges
+of `K_N` admits a set of `n` vertices containing no monochromatic `K_k`
+(Erdős–Gyárfás, "A variant of the classical Ramsey problem", 1997).
+
+The parent entry `Erdos129Problem` sets up the predicate `HasRamseyAvoid N n k r`
+("every `r`-coloring of `K_N` has an `n`-vertex monochromatic-`K_k`-free set") and
+states the Erdős–Gyárfás exponential conjecture, but lists the *monotonicity*
+properties of `R(n;k,r)` among the structural facts whose proofs "require embedding
+arguments not yet in Mathlib".
+
+This leaf supplies those embedding arguments and proves them from Mathlib alone:
+
+* `hasRamseyAvoid_mono_N`  — **monotonicity in `N`**: enlarging the host complete
+  graph preserves the avoidance property (`HasRamseyAvoid N n k r → N ≤ N' →
+  HasRamseyAvoid N' n k r`). This is the genuinely non-trivial direction: given a
+  coloring of `K_{N'}`, we pull it back along `Fin.castLE` to a coloring of `K_N`,
+  use the hypothesis to find an avoiding set there, and push that set forward.
+* `hasRamseyAvoid_antitone_n` — **antitonicity in `n`**: requiring fewer
+  clique-free vertices is easier (`HasRamseyAvoid N n k r → m ≤ n →
+  HasRamseyAvoid N m k r`), by passing to a sub-Finset.
+* `hasRamseyAvoid_mono` — the combined statement.
+
+Equivalently, in terms of `R`: `R(n;k,r)` is monotone non-decreasing in `n`
+(antitonicity of the *property* in `n` is exactly monotonicity of the *threshold*),
+and any `N ≥ R(n;k,r)` already witnesses the property — the content the parent
+deferred.
+
+The definitions mirror `Erdos129Problem.lean` so this file is self-contained.
+
+*Reference:* [erdosproblems.com/129](https://www.erdosproblems.com/129)
+-/
+
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Tactic
+
+open Finset
+
+/- ## Setup (mirrors the parent `Erdos129Problem` definitions) -/
+
+/-- An `r`-coloring of the edges of the complete graph on `Fin N`,
+represented as a function on ordered pairs `i < j`. -/
+def EdgeColoring (N : ℕ) (r : ℕ) : Type :=
+    { p : Fin N × Fin N // p.1 < p.2 } → Fin r
+
+/-- A set `S` of vertices avoids monochromatic `K_k` in color `c` if no `k`-element
+subset of `S` has all of its edges colored `c` (witnessed by a non-`c` edge). -/
+def AvoidsMono (N : ℕ) (r : ℕ) (coloring : EdgeColoring N r)
+    (S : Finset (Fin N)) (k : ℕ) (c : Fin r) : Prop :=
+    ∀ T : Finset (Fin N), T ⊆ S → T.card = k →
+      ∃ e : { p : Fin N × Fin N // p.1 < p.2 },
+        e.val.1 ∈ T ∧ e.val.2 ∈ T ∧ coloring e ≠ c
+
+/-- A set `S` contains no monochromatic `K_k` in any color. -/
+def NoMonoClique (N : ℕ) (r : ℕ) (coloring : EdgeColoring N r)
+    (S : Finset (Fin N)) (k : ℕ) : Prop :=
+    ∀ c : Fin r, AvoidsMono N r coloring S k c
+
+/-- `HasRamseyAvoid N n k r` holds when every `r`-coloring of `K_N`
+admits a set of `n` vertices with no monochromatic `K_k`. -/
+def HasRamseyAvoid (N n k r : ℕ) : Prop :=
+    ∀ coloring : EdgeColoring N r,
+      ∃ S : Finset (Fin N), S.card ≥ n ∧ NoMonoClique N r coloring S k
+
+/- ## Antitonicity in the number of required vertices -/
+
+/-- `NoMonoClique` is downward closed in the vertex set: a subset of a
+monochromatic-`K_k`-free set is itself monochromatic-`K_k`-free. -/
+theorem noMonoClique_subset (N r : ℕ) (coloring : EdgeColoring N r)
+    {S S' : Finset (Fin N)} (k : ℕ) (hsub : S' ⊆ S)
+    (h : NoMonoClique N r coloring S k) :
+    NoMonoClique N r coloring S' k := by
+  intro c T hT hTk
+  exact h c T (hT.trans hsub) hTk
+
+/-- **Antitonicity in `n`.** Requiring fewer clique-free vertices is easier:
+if `K_N` always has an `n`-vertex avoiding set, it always has an `m`-vertex one
+for every `m ≤ n`. Equivalently, `R(n;k,r)` is non-decreasing in `n`. -/
+theorem hasRamseyAvoid_antitone_n {N n k r : ℕ} (m : ℕ) (hm : m ≤ n)
+    (h : HasRamseyAvoid N n k r) :
+    HasRamseyAvoid N m k r := by
+  intro coloring
+  obtain ⟨S, hScard, hSavoid⟩ := h coloring
+  obtain ⟨S', hS'sub, hS'card⟩ :=
+    Finset.exists_subset_card_eq (s := S) (n := m) (by omega)
+  exact ⟨S', by omega, noMonoClique_subset N r coloring k hS'sub hSavoid⟩
+
+/- ## Monotonicity in the size of the host graph -/
+
+/-- **Monotonicity in `N`.** Enlarging the complete graph preserves the
+avoidance property: if every `r`-coloring of `K_N` has an `n`-vertex
+monochromatic-`K_k`-free set, then so does every `r`-coloring of `K_{N'}`
+for `N ≤ N'`.
+
+The proof pulls an arbitrary coloring `χ'` of `K_{N'}` back along the order
+embedding `Fin.castLE : Fin N ↪ Fin N'` to a coloring `χ` of `K_N`, applies the
+hypothesis to obtain an avoiding set `S ⊆ Fin N`, and pushes `S` forward to
+`S.map (Fin.castLEEmb _) ⊆ Fin N'`. Any `k`-subset upstairs is the image of a
+`k`-subset downstairs, whose non-`c` witness edge maps to a non-`c` witness edge
+upstairs. -/
+theorem hasRamseyAvoid_mono_N {N N' n k r : ℕ} (hNN' : N ≤ N')
+    (h : HasRamseyAvoid N n k r) :
+    HasRamseyAvoid N' n k r := by
+  intro χ'
+  -- Pull `χ'` back to a coloring of `K_N` via the strictly monotone `castLE`.
+  let χ : EdgeColoring N r := fun e =>
+    χ' ⟨(Fin.castLE hNN' e.val.1, Fin.castLE hNN' e.val.2),
+        (Fin.castLE_lt_castLE_iff hNN').mpr e.property⟩
+  obtain ⟨S, hScard, hSavoid⟩ := h χ
+  refine ⟨S.map (Fin.castLEEmb hNN'), ?_, ?_⟩
+  · -- The image has the same cardinality.
+    rw [Finset.card_map]; exact hScard
+  · -- Image of an avoiding set is avoiding.
+    intro c T' hT' hT'card
+    -- Every `k`-subset `T'` upstairs is `T.map castLEEmb` for a `k`-subset `T` of `S`.
+    obtain ⟨T, hTsub, hTeq⟩ := Finset.subset_map_iff.mp hT'
+    have hTcard : T.card = k := by
+      rw [hTeq, Finset.card_map] at hT'card; exact hT'card
+    obtain ⟨e, he1, he2, hne⟩ := hSavoid c T hTsub hTcard
+    -- The downstairs witness edge maps to an upstairs witness edge.
+    refine ⟨⟨(Fin.castLE hNN' e.val.1, Fin.castLE hNN' e.val.2),
+            (Fin.castLE_lt_castLE_iff hNN').mpr e.property⟩, ?_, ?_, ?_⟩
+    · rw [hTeq]; exact Finset.mem_map_of_mem _ he1
+    · rw [hTeq]; exact Finset.mem_map_of_mem _ he2
+    · -- `χ'` of the mapped edge is, by construction, `χ e ≠ c`.
+      exact hne
+
+/-- **Combined monotonicity.** The avoidance property is preserved under
+enlarging the host graph (`N ≤ N'`) and shrinking the required clique-free
+set (`n' ≤ n`). -/
+theorem hasRamseyAvoid_mono {N N' n n' k r : ℕ}
+    (hN : N ≤ N') (hn : n' ≤ n) (h : HasRamseyAvoid N n k r) :
+    HasRamseyAvoid N' n' k r :=
+  hasRamseyAvoid_antitone_n n' hn (hasRamseyAvoid_mono_N hN h)

--- a/src/data/proofs/erdos-129-wip-01/annotations.json
+++ b/src/data/proofs/erdos-129-wip-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "The monotonicity laws Erdős Problem 129 deferred",
+    "content": "R(n;k,r) is the least N such that every r-coloring of K_N has an n-vertex set with no monochromatic K_k. The parent entry Erdos129Problem formalizes the predicate HasRamseyAvoid N n k r ('N ≥ R(n;k,r)') and the Erdős-Gyárfás exponential conjecture, but records the monotonicity properties only informally — their proofs, it notes, 'require embedding arguments not yet in Mathlib'. This file supplies them: HasRamseyAvoid is monotone in the host-graph size N and antitone in the number of required clique-free vertices n. Both are elementary structural facts, independent of the open asymptotics, yet they are exactly what makes R(n;k,r) a well-behaved threshold."
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "Edge colorings and clique avoidance",
+    "content": "The definitions mirror the parent entry so the file is self-contained. An EdgeColoring N r colors ordered edges {(i,j) // i < j} of K_N with Fin r colors. A vertex set S AvoidsMono in color c if every k-subset T ⊆ S has some edge not colored c (so T is not a monochromatic K_k in color c); NoMonoClique demands this for all colors. HasRamseyAvoid N n k r holds when every coloring admits an n-vertex set S with NoMonoClique — the avoidance threshold being R(n;k,r)."
+  },
+  {
+    "id": "ann-noMonoClique-subset",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 79
+    },
+    "type": "lemma",
+    "title": "NoMonoClique is downward closed",
+    "content": "noMonoClique_subset: if S' ⊆ S and S has no monochromatic K_k, then neither does S'. The proof is one line — a k-subset T ⊆ S' is also a k-subset of S (hT.trans hsub), so the avoidance witness for S applies verbatim. Shrinking the vertex set only removes the k-subsets that must be checked, never adds any. This downward closure is the engine of antitonicity in n."
+  },
+  {
+    "id": "ann-antitone-n",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 89
+    },
+    "type": "theorem",
+    "title": "Antitonicity in n: fewer vertices is easier",
+    "content": "hasRamseyAvoid_antitone_n: HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r. Given a coloring, the hypothesis yields an avoiding set S with |S| ≥ n ≥ m; Finset.exists_subset_card_eq cuts out an exactly-m-vertex subset S' ⊆ S, still avoiding by noMonoClique_subset. In terms of the threshold this says R(n;k,r) is non-decreasing in n: needing fewer monochromatic-clique-free vertices cannot require a larger graph."
+  },
+  {
+    "id": "ann-mono-N",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 131
+    },
+    "type": "theorem",
+    "title": "Monotonicity in N: the embedding argument",
+    "content": "hasRamseyAvoid_mono_N: HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r — the substantive direction. Given a coloring χ' of K_{N'}, pull it back to χ on K_N by sending an edge (i,j), i < j, to χ' of (castLE i, castLE j); this is again an edge because Fin.castLE is strictly monotone (castLE_lt_castLE_iff). The hypothesis hands back an avoiding set S ⊆ Fin N, which is pushed forward to S.map (Fin.castLEEmb _) ⊆ Fin N' with the same cardinality. Any k-subset T' upstairs reflects, via Finset.subset_map_iff, to T = its preimage downstairs; the avoidance witness edge of T lifts to a witness edge of T', and because χ was defined as the pull-back the lifted edge has color χ e ≠ c by rfl. No probabilistic input is needed — just restriction and embedding."
+  },
+  {
+    "id": "ann-mono-combined",
+    "proofId": "erdos-129-wip-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 137
+    },
+    "type": "theorem",
+    "title": "The combined monotonicity law",
+    "content": "hasRamseyAvoid_mono: composing the two laws, avoidance is preserved when the host graph grows (N ≤ N') and the required clique-free set shrinks (n' ≤ n). This is the form most useful downstream: it lets one transport a known avoidance instance to any at-least-as-favorable pair (N', n'), the basic move in inductive comparisons of Ramsey values."
+  }
+]

--- a/src/data/proofs/erdos-129-wip-01/meta.json
+++ b/src/data/proofs/erdos-129-wip-01/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "erdos-129-wip-01",
+  "title": "Ramsey Numbers Avoiding Monochromatic Cliques: monotonicity of the avoidance property",
+  "slug": "erdos-129-wip-01",
+  "description": "For Erdős Problem 129's predicate HasRamseyAvoid N n k r ('every r-coloring of K_N admits an n-vertex set with no monochromatic K_k'), this leaf proves the two monotonicity laws the parent entry leaves as deferred 'embedding arguments not yet in Mathlib': monotonicity in N (enlarging the host graph preserves avoidance, HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r) and antitonicity in n (requiring fewer clique-free vertices is easier). The N-monotonicity is the substantive direction: an arbitrary coloring of K_{N'} is pulled back along the order embedding Fin.castLE to a coloring of K_N, the hypothesis supplies an avoiding set downstairs, and it is pushed forward by Finset.map; any k-clique upstairs is the image of one downstairs whose non-c witness edge lifts. Equivalently, R(n;k,r) is non-decreasing in n and any N ≥ R(n;k,r) witnesses the property. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos129WIP01.lean",
+    "tags": [
+      "erdos",
+      "ramsey-theory",
+      "graph-theory",
+      "combinatorics",
+      "edge-coloring",
+      "monotonicity",
+      "embedding"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "erdosNumber": 129,
+    "erdosUrl": "https://erdosproblems.com/129",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.castLE",
+        "description": "The canonical order-preserving inclusion Fin N → Fin N' for N ≤ N'; used to pull back an r-coloring of K_{N'} to one of K_N (preserving the i < j edge condition)",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Fin.castLE_lt_castLE_iff",
+        "description": "castLE h i < castLE h j ↔ i < j (definitional); supplies the i < j proof obligation for the pulled-back and lifted edges, witnessing that castLE is strictly monotone",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Fin.castLEEmb",
+        "description": "Fin.castLE packaged as an injective embedding Fin N ↪ Fin N'; used as the Finset.map function that pushes the downstairs avoiding set up to Fin N'",
+        "module": "Mathlib.Data.Fin.Embedding"
+      },
+      {
+        "theorem": "Finset.subset_map_iff",
+        "description": "T' ⊆ S.map f ↔ ∃ T ⊆ S, T' = T.map f; reflects a k-subset of the lifted vertex set back to a k-subset of the original set, where the avoidance hypothesis applies",
+        "module": "Mathlib.Data.Finset.Preimage"
+      },
+      {
+        "theorem": "Finset.exists_subset_card_eq",
+        "description": "m ≤ #S → ∃ T ⊆ S, #T = m; extracts an exactly-m-vertex avoiding subset for the antitonicity-in-n lemma",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.mem_map_of_mem",
+        "description": "a ∈ S → f a ∈ S.map f; places the lifted witness-edge endpoints in the mapped k-subset",
+        "module": "Mathlib.Data.Finset.Image"
+      }
+    ],
+    "originalContributions": [
+      "hasRamseyAvoid_mono_N: monotonicity in N — HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r, proved by pulling an r-coloring of K_{N'} back along Fin.castLE, applying the hypothesis, and pushing the avoiding set forward by Finset.map. The parent Erdos129Problem lists this 'larger complete graphs make it easier to find clique-free sets' fact among properties whose proofs 'require embedding arguments not yet in Mathlib'; this supplies the embedding argument.",
+      "hasRamseyAvoid_antitone_n: antitonicity in n — HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r, by restricting any n-vertex avoiding set to an m-vertex subset (NoMonoClique is downward closed). Equivalently R(n;k,r) is non-decreasing in n.",
+      "noMonoClique_subset: NoMonoClique is downward closed in the vertex set (a subset of a monochromatic-K_k-free set is monochromatic-K_k-free), the structural lemma behind antitonicity in n.",
+      "hasRamseyAvoid_mono: the combined law — avoidance is preserved under enlarging the host graph (N ≤ N') and shrinking the required clique-free set (n' ≤ n)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound; noMonoClique_subset uses only propext and Quot.sound). No native_decide, so no Lean.ofReduceBool dependency. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 137,
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Erdős and Gyárfás introduced R(n;k,r) — the least N such that every r-coloring of K_N contains an n-vertex set with no monochromatic K_k — in their 1997 paper 'A variant of the classical Ramsey problem', conjecturing growth C₁^{n^{1/(k-1)}} < R(n;k,r) < C₂^{n^{1/(k-1)}}. The exponential bounds remain open for k = 3. Long before the asymptotics, however, R(n;k,r) obeys elementary structural laws: it is non-decreasing in n (more required clique-free vertices need a larger graph) and any N at least R(n;k,r) already forces an avoiding set. The parent Lean entry Erdos129Problem formalizes the avoidance predicate HasRamseyAvoid but records these monotonicities only informally, noting their proofs 'require embedding arguments not yet in Mathlib'. This leaf discharges them.",
+    "problemStatement": "Prove from Mathlib that the Erdős-Gyárfás avoidance predicate HasRamseyAvoid N n k r is monotone in the host-graph size N (HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r) and antitone in the number of required clique-free vertices n (HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r).",
+    "proofStrategy": "Monotonicity in N is the substantive direction. Given an r-coloring χ' of K_{N'} and N ≤ N', pull χ' back to a coloring χ of K_N: an ordered edge (i,j) of K_N with i < j maps to (castLE i, castLE j), still an edge since castLE is strictly monotone (Fin.castLE_lt_castLE_iff), and χ assigns it χ' of that image. The hypothesis applied to χ yields an avoiding set S ⊆ Fin N with |S| ≥ n. Push it forward by S.map (Fin.castLEEmb _), preserving cardinality (Finset.card_map). For any color c and k-subset T' of the image, Finset.subset_map_iff reflects T' = T.map (castLEEmb _) for a k-subset T ⊆ S; the hypothesis gives an edge e in T with χ e ≠ c, and its castLE-image is an edge of T' with χ' value equal to χ e (by the definitional pull-back) hence ≠ c. Antitonicity in n restricts any n-vertex avoiding set to an exactly-m-vertex subset via Finset.exists_subset_card_eq; NoMonoClique is downward closed (noMonoClique_subset) because every k-subset of the smaller set is a k-subset of the larger.",
+    "keyInsights": [
+      "**Monotonicity in N is a pull-back/push-forward argument, not a probabilistic one.** The Erdős-Gyárfás exponential bounds need the probabilistic method, but the qualitative law 'a bigger complete graph is at least as good' is purely structural: restrict the coloring to N of the N' vertices, find the avoiding set there, and read it back among the original vertices. Fin.castLE provides the order-preserving inclusion that makes both directions canonical.",
+      "**The strict monotonicity of castLE is exactly the edge-condition transport.** The edge type {p : Fin N × Fin N // p.1 < p.2} encodes 'i < j'; pulling back or lifting an edge requires castLE i < castLE j, which is castLE_lt_castLE_iff — a definitional equivalence in Mathlib. Both the pulled-back coloring and the lifted witness edge reuse the same one-line proof obligation.",
+      "**The pulled-back coloring makes the witness transport definitional.** χ is defined so that χ e is literally χ' applied to the castLE-image edge; the lifted witness edge is that very image, so χ' (lifted edge) = χ e holds by rfl (the two i<j proofs are identical), and the non-c property transfers with no rewriting.",
+      "**Antitonicity in n is downward closure plus a cardinality cut.** Because AvoidsMono quantifies over all k-subsets, shrinking the vertex set only removes constraints: any k-subset of S' ⊆ S is already a k-subset of S. Extracting a subset of the exact required cardinality (exists_subset_card_eq) then yields the smaller-n instance, which is precisely monotonicity of R(n;k,r) in n.",
+      "**These laws are prerequisites for the asymptotics.** Monotonicity in N is what makes R(n;k,r) = inf {N : HasRamseyAvoid N n k r} well-behaved (any larger N still works), and antitonicity in n underlies inductive arguments that relate consecutive Ramsey values — the structural scaffolding on which the conjectured exponential bounds would rest."
+    ],
+    "prerequisites": [
+      "Ramsey theory and the Erdős-Gyárfás avoidance problem (R(n;k,r))",
+      "Edge colorings of complete graphs",
+      "Order embeddings of finite types (Fin.castLE) and Finset.map",
+      "Monotonicity arguments by restriction and embedding"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: the avoidance predicate",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "File docstring framing Erdős Problem 129 and the deferred monotonicity properties, followed by the definitions mirrored from the parent entry: EdgeColoring N r (functions on ordered edges i < j into Fin r), AvoidsMono (a vertex set has a non-c edge in every k-subset), NoMonoClique (avoidance in all colors), and HasRamseyAvoid N n k r (every coloring admits an n-vertex avoiding set).",
+      "mathContext": "HasRamseyAvoid N n k r captures 'N ≥ R(n;k,r)'; the file proves it is monotone in N and antitone in n."
+    },
+    {
+      "id": "antitone-n",
+      "title": "Antitonicity in n",
+      "startLine": 68,
+      "endLine": 89,
+      "summary": "noMonoClique_subset shows NoMonoClique is downward closed in the vertex set (a k-subset of S' ⊆ S is a k-subset of S). hasRamseyAvoid_antitone_n then extracts, from any n-vertex avoiding set, an exactly-m-vertex subset via Finset.exists_subset_card_eq, proving HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r — i.e. R(n;k,r) is non-decreasing in n.",
+      "mathContext": "Fewer required clique-free vertices is easier; the threshold R(n;k,r) is monotone in n."
+    },
+    {
+      "id": "mono-N",
+      "title": "Monotonicity in N (embedding argument)",
+      "startLine": 91,
+      "endLine": 137,
+      "summary": "hasRamseyAvoid_mono_N pulls an arbitrary coloring of K_{N'} back along Fin.castLE to a coloring of K_N (using castLE_lt_castLE_iff for the i < j edge condition), applies the hypothesis to get an avoiding set S, and pushes it forward by Finset.map (Fin.castLEEmb _). Each k-clique upstairs reflects via Finset.subset_map_iff to a k-clique downstairs whose non-c witness edge lifts back with the same color value. hasRamseyAvoid_mono combines this with antitonicity in n.",
+      "mathContext": "Enlarging the host graph preserves avoidance: HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, Paul; Gyárfás, András",
+      "title": "A variant of the classical Ramsey problem",
+      "year": "1997",
+      "note": "Combinatorica 17(4), 459-467. Introduces R(n;k,r) and the conjectured C₁^{n^{1/(k-1)}} < R(n;k,r) < C₂^{n^{1/(k-1)}} bounds."
+    },
+    {
+      "authors": "Erdős problems database",
+      "title": "Problem 129",
+      "year": "2025",
+      "note": "https://erdosproblems.com/129 — current status (open for the k = 3 upper bound)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-129",
+      "relationship": "extends",
+      "description": "Parent entry. It defines HasRamseyAvoid and states the Erdős-Gyárfás conjecture but lists monotonicity in N and antitonicity among the structural facts whose proofs 'require embedding arguments not yet in Mathlib'; this leaf supplies those proofs."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "foundational",
+      "description": "Classical Ramsey theory underlies the avoidance problem; R(n;k,r) generalizes the classical Ramsey number R(n) = R(n;2,2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Erdős-Gyárfás avoidance predicate HasRamseyAvoid N n k r is monotone in the host-graph size N (hasRamseyAvoid_mono_N) and antitone in the number of required clique-free vertices n (hasRamseyAvoid_antitone_n), with the combined law hasRamseyAvoid_mono. The N-monotonicity is proved by pulling an r-coloring of K_{N'} back along Fin.castLE, applying the hypothesis, and pushing the avoiding set forward by Finset.map; antitonicity follows from downward closure of NoMonoClique (noMonoClique_subset) and a cardinality cut. All four theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "These are the structural laws the parent entry deferred. Monotonicity in N is what makes R(n;k,r) = inf {N : HasRamseyAvoid N n k r} well-defined as a threshold (every larger N still witnesses the property), and antitonicity in n is monotonicity of that threshold — the scaffolding underlying inductive comparisons of consecutive Ramsey values and, ultimately, the conjectured exponential bounds.",
+    "openQuestions": [
+      "Does R(n;3,r) < C^{√n} hold for some C > 1 depending on r (the open upper bound)?",
+      "Is HasRamseyAvoid antitone in the number of colors r in a usable form, given the parent's color-embedding lemma changes the coloring?",
+      "Can these monotonicities drive an inductive Lean proof relating R(n;k,r) to R(n-1;k,r)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Data.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": null,
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos129WIP01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős Problem 129 (leaf wip-01): monotonicity of `HasRamseyAvoid`

`R(n;k,r)` is the least `N` such that every `r`-coloring of `K_N` admits an `n`-vertex set with no monochromatic `K_k` (Erdős–Gyárfás, 1997). The parent entry **`erdos-129`** formalizes the predicate `HasRamseyAvoid N n k r` and the conjectured exponential bounds, but records the *monotonicity* properties only informally, noting their proofs "require embedding arguments not yet in Mathlib". This leaf supplies those arguments, from Mathlib alone.

### Results (`proofs/Proofs/Erdos129WIP01.lean`, 4 theorems / 4 defs / 137 L)

| theorem | statement |
|---|---|
| `hasRamseyAvoid_mono_N` | `HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r` (monotone in `N`) |
| `hasRamseyAvoid_antitone_n` | `HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r` (antitone in `n`) |
| `noMonoClique_subset` | `NoMonoClique` is downward closed in the vertex set |
| `hasRamseyAvoid_mono` | combined law (`N ≤ N'`, `n' ≤ n`) |

### Proof idea (the `N`-monotonicity is the substantive direction)

Given an `r`-coloring `χ'` of `K_{N'}` and `N ≤ N'`:
1. **Pull back** `χ'` to a coloring `χ` of `K_N` along `Fin.castLE` — an edge `(i,j)` with `i < j` maps to `(castLE i, castLE j)`, still an edge because `castLE` is strictly monotone (`Fin.castLE_lt_castLE_iff`).
2. **Apply the hypothesis** to `χ`, obtaining an avoiding set `S ⊆ Fin N`, `|S| ≥ n`.
3. **Push forward** by `S.map (Fin.castLEEmb _)` (same cardinality). Any `k`-subset `T'` of the image reflects via `Finset.subset_map_iff` to a `k`-subset `T ⊆ S`; its non-`c` witness edge lifts to a witness edge of `T'`, with color `χ' (lifted edge) = χ e ≠ c` by `rfl` (the pull-back is definitional).

Antitonicity in `n` restricts an `n`-vertex avoiding set to an exactly-`m`-vertex subset (`Finset.exists_subset_card_eq`); `NoMonoClique` is downward closed since shrinking the vertex set only removes `k`-subsets to check.

### Verification

- **0 axioms, 0 sorries.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (and `noMonoClique_subset` only the first and last). No `native_decide` ⇒ no `Lean.ofReduceBool`.
- Kernel-checked on Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)