### PR TITLE
research(gamma-log-convexity-oq-01-oq-01): full weighted geometric-mean inequality for Γ + n-point Jensen [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/GammaLogConvexityOQ01OQ01.lean
+++ b/proofs/Proofs/GammaLogConvexityOQ01OQ01.lean
@@ -1,0 +1,127 @@
+import Mathlib
+
+/-
+# Gamma Log-Convexity OQ-01-OQ-01: the full weighted geometric-mean inequality
+
+The parent entry `gamma-log-convexity-oq-01` records only the **midpoint**
+instance of log-convexity of the Gamma function,
+`gamma_midpoint_sq_le : Γ((a+b)/2)² ≤ Γ(a)·Γ(b)` (the case `t = 1/2`, squared).
+This leaf upgrades that single point to the **full one-parameter family** — the
+exact multiplicative form of log-convexity:
+
+  for `a, b > 0` and `t ∈ [0,1]`,   `Γ(t·a + (1-t)·b) ≤ Γ(a)^t · Γ(b)^(1-t)`,
+
+and then to the **finite (n-point) weighted Jensen** form
+
+  for `xᵢ > 0` and weights `wᵢ ≥ 0` with `∑ wᵢ = 1`,
+  `Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ)`.
+
+Everything rests on Mathlib's `Real.convexOn_log_Gamma` (log ∘ Γ is convex on
+`(0,∞)`): apply two-point convexity (resp. `ConvexOn.map_sum_le`, Jensen) to get
+the additive bound on `log Γ`, then exponentiate, turning `t · log Γ(a)` into the
+real power `Γ(a)^t` via `Real.log_rpow`. The parent's midpoint inequality is
+recovered as the `t = 1/2` case, so this entry genuinely subsumes it.
+
+`0` axioms.
+-/
+
+namespace GammaLogConvexityOQ01OQ01
+
+open Real Set
+
+/-- The two-point additive bound from log-convexity of `Γ`: for `a, b > 0` and
+`t ∈ [0,1]`, `log Γ(t·a + (1-t)·b) ≤ t·log Γ(a) + (1-t)·log Γ(b)`. This is just
+`convexOn_log_Gamma` evaluated at the convex combination, unfolded. -/
+lemma logGamma_weighted_le {a b t : ℝ} (ha : 0 < a) (hb : 0 < b)
+    (ht0 : 0 ≤ t) (ht1 : t ≤ 1) :
+    Real.log (Real.Gamma (t * a + (1 - t) * b))
+      ≤ t * Real.log (Real.Gamma a) + (1 - t) * Real.log (Real.Gamma b) := by
+  have h := convexOn_log_Gamma.2 (Set.mem_Ioi.mpr ha) (Set.mem_Ioi.mpr hb)
+    ht0 (by linarith : (0 : ℝ) ≤ 1 - t) (by ring)
+  simpa only [Function.comp_apply, smul_eq_mul] using h
+
+/-- **Weighted multiplicative (geometric-mean) inequality for the Gamma function.**
+For positive reals `a, b` and a weight `t ∈ [0,1]`,
+`Γ(t·a + (1-t)·b) ≤ Γ(a)^t · Γ(b)^(1-t)` (real `rpow` exponents). This is the exact
+multiplicative form of log-convexity of `Γ`, generalizing the parent's `t = 1/2`
+midpoint inequality to the full family. -/
+theorem gamma_weighted_geom_le {a b t : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (ht0 : 0 ≤ t) (ht1 : t ≤ 1) :
+    Real.Gamma (t * a + (1 - t) * b)
+      ≤ Real.Gamma a ^ t * Real.Gamma b ^ (1 - t) := by
+  have hGa : 0 < Real.Gamma a := Real.Gamma_pos_of_pos ha
+  have hGb : 0 < Real.Gamma b := Real.Gamma_pos_of_pos hb
+  -- the argument `t·a + (1-t)·b` is a convex combination of positives, hence positive
+  have harg : 0 < t * a + (1 - t) * b := by
+    rcases ht0.lt_or_eq with ht | ht
+    · exact add_pos_of_pos_of_nonneg (mul_pos ht ha) (mul_nonneg (by linarith) hb.le)
+    · rw [← ht]; simpa using hb
+  have hRHS : (0 : ℝ) < Real.Gamma a ^ t * Real.Gamma b ^ (1 - t) :=
+    mul_pos (Real.rpow_pos_of_pos hGa t) (Real.rpow_pos_of_pos hGb (1 - t))
+  -- `log` of the right-hand side equals the additive bound's right-hand side
+  have hlogRHS : Real.log (Real.Gamma a ^ t * Real.Gamma b ^ (1 - t))
+      = t * Real.log (Real.Gamma a) + (1 - t) * Real.log (Real.Gamma b) := by
+    rw [Real.log_mul (Real.rpow_pos_of_pos hGa t).ne' (Real.rpow_pos_of_pos hGb (1 - t)).ne',
+      Real.log_rpow hGa, Real.log_rpow hGb]
+  -- compare logs, then exponentiate
+  have hlog : Real.log (Real.Gamma (t * a + (1 - t) * b))
+      ≤ Real.log (Real.Gamma a ^ t * Real.Gamma b ^ (1 - t)) := by
+    rw [hlogRHS]; exact logGamma_weighted_le ha hb ht0 ht1
+  have hexp := Real.exp_le_exp.mpr hlog
+  rwa [Real.exp_log (Real.Gamma_pos_of_pos harg), Real.exp_log hRHS] at hexp
+
+/-- **Finite weighted geometric-mean (Jensen) inequality for `Γ`.** For a finite
+index set `t`, positive points `xᵢ > 0`, and weights `wᵢ ≥ 0` with `∑ wᵢ = 1`,
+`Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ)`. The full n-point form of multiplicative log-convexity,
+obtained from `ConvexOn.map_sum_le` (Jensen) applied to `log ∘ Γ`. -/
+theorem gamma_weighted_geom_le_finset {ι : Type*} (s : Finset ι)
+    (w x : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i) (hsum : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 < x i) :
+    Real.Gamma (∑ i ∈ s, w i * x i) ≤ ∏ i ∈ s, Real.Gamma (x i) ^ w i := by
+  -- Jensen on the convex function `log ∘ Γ`
+  have hJ := convexOn_log_Gamma.map_sum_le hw hsum (fun i hi => Set.mem_Ioi.mpr (hx i hi))
+  simp only [Function.comp_apply, smul_eq_mul] at hJ
+  -- some weight is strictly positive (else the weights would sum to `0 ≠ 1`)
+  obtain ⟨j, hjs, hjpos⟩ : ∃ i ∈ s, 0 < w i := by
+    by_contra hcon
+    push_neg at hcon
+    have hz : ∑ i ∈ s, w i = 0 :=
+      Finset.sum_eq_zero (fun i hi => le_antisymm (hcon i hi) (hw i hi))
+    rw [hz] at hsum; exact one_ne_zero hsum.symm
+  -- the argument is positive, and so is the product
+  have harg : 0 < ∑ i ∈ s, w i * x i :=
+    Finset.sum_pos' (fun i hi => mul_nonneg (hw i hi) (hx i hi).le)
+      ⟨j, hjs, mul_pos hjpos (hx j hjs)⟩
+  have hprodpos : 0 < ∏ i ∈ s, Real.Gamma (x i) ^ w i :=
+    Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (Real.Gamma_pos_of_pos (hx i hi)) _)
+  -- `log` of the product is the additive (Jensen) right-hand side
+  have hlogprod : Real.log (∏ i ∈ s, Real.Gamma (x i) ^ w i)
+      = ∑ i ∈ s, w i * Real.log (Real.Gamma (x i)) := by
+    rw [Real.log_prod
+      (fun i hi => (Real.rpow_pos_of_pos (Real.Gamma_pos_of_pos (hx i hi)) _).ne')]
+    exact Finset.sum_congr rfl
+      (fun i hi => Real.log_rpow (Real.Gamma_pos_of_pos (hx i hi)) _)
+  have hlog : Real.log (Real.Gamma (∑ i ∈ s, w i * x i))
+      ≤ Real.log (∏ i ∈ s, Real.Gamma (x i) ^ w i) := by
+    rw [hlogprod]; exact hJ
+  have hexp := Real.exp_le_exp.mpr hlog
+  rwa [Real.exp_log (Real.Gamma_pos_of_pos harg), Real.exp_log hprodpos] at hexp
+
+/-- **Parent midpoint inequality, recovered as the `t = 1/2` case.** For `a, b > 0`,
+`Γ((a+b)/2)² ≤ Γ(a)·Γ(b)`: specialize `gamma_weighted_geom_le` at `t = 1/2`
+(turning the `1/2`-powers into square roots) and square both nonnegative sides. -/
+theorem gamma_midpoint_sq_le {a b : ℝ} (ha : 0 < a) (hb : 0 < b) :
+    Real.Gamma ((a + b) / 2) ^ 2 ≤ Real.Gamma a * Real.Gamma b := by
+  have hmid : 0 < (a + b) / 2 := by linarith
+  have h := gamma_weighted_geom_le ha hb (by norm_num : (0 : ℝ) ≤ 1 / 2)
+    (by norm_num : (1 : ℝ) / 2 ≤ 1)
+  rw [show (1 : ℝ) / 2 * a + (1 - 1 / 2) * b = (a + b) / 2 by ring,
+    show (1 : ℝ) - 1 / 2 = 1 / 2 by norm_num,
+    ← Real.sqrt_eq_rpow, ← Real.sqrt_eq_rpow,
+    ← Real.sqrt_mul (Real.Gamma_pos_of_pos ha).le] at h
+  -- h : Γ((a+b)/2) ≤ √(Γ a · Γ b); square it
+  nlinarith [h, Real.sqrt_nonneg (Real.Gamma a * Real.Gamma b),
+    Real.sq_sqrt (mul_nonneg (Real.Gamma_pos_of_pos ha).le (Real.Gamma_pos_of_pos hb).le),
+    (Real.Gamma_pos_of_pos hmid).le]
+
+end GammaLogConvexityOQ01OQ01

--- a/src/data/proofs/gamma-log-convexity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-log-convexity-oq-01-oq-01/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "gamma-log-convexity-oq-01-oq-01",
+  "title": "The Full Weighted Geometric-Mean Inequality for the Gamma Function",
+  "slug": "gamma-log-convexity-oq-01-oq-01",
+  "description": "Upgrades the parent's single midpoint instance of Gamma log-convexity to the full one-parameter family: for a, b > 0 and t ∈ [0,1], Γ(t·a + (1−t)·b) ≤ Γ(a)^t · Γ(b)^(1−t) (the exact multiplicative form of log-convexity, with real rpow exponents), and further to the finite n-point weighted Jensen form Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ) for weights summing to 1. The parent's midpoint inequality Γ((a+b)/2)² ≤ Γ(a)·Γ(b) is recovered as the t = 1/2 case. Built from Mathlib's Real.convexOn_log_Gamma by exponentiating two-point convexity and Jensen. 3 theorems, 1 lemma, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-5",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaLogConvexityOQ01OQ01.lean",
+    "tags": [
+      "gamma-function",
+      "log-convexity",
+      "real-analysis",
+      "jensen-inequality",
+      "geometric-mean",
+      "convexity",
+      "special-functions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 127,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All 4 results proved, 0 axioms. Verified axiom-free: #print axioms on gamma_weighted_geom_le, gamma_weighted_geom_le_finset, and gamma_midpoint_sq_le reports only propext, Classical.choice, Quot.sound. Requires positive arguments and weights in [0,1] (resp. nonnegative weights summing to 1).",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.convexOn_log_Gamma",
+        "description": "log ∘ Γ is convex on (0,∞) — the single structural input; two-point convexity (.2) gives the weighted bound, ConvexOn.map_sum_le gives the n-point Jensen bound",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup"
+      },
+      {
+        "theorem": "ConvexOn.map_sum_le",
+        "description": "Finset Jensen inequality: f(∑ wᵢ•pᵢ) ≤ ∑ wᵢ•f(pᵢ) for weights wᵢ ≥ 0 summing to 1 — drives the n-point form",
+        "module": "Mathlib.Analysis.Convex.Jensen"
+      },
+      {
+        "theorem": "Real.log_rpow",
+        "description": "0 < x → log(x^y) = y·log x — converts the additive bound t·log Γ(a) into the multiplicative power Γ(a)^t upon exponentiation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.Gamma_pos_of_pos",
+        "description": "0 < x → 0 < Γ(x) — positivity needed to take logs and exponentiate (exp_log) on both sides",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.exp_log / Real.exp_le_exp",
+        "description": "exp(log x) = x for x > 0 and monotonicity of exp — turn the additive log-inequality back into the multiplicative inequality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.sqrt_eq_rpow / Real.sq_sqrt / Real.sqrt_mul",
+        "description": "√x = x^(1/2) and (√x)² = x — used to recover the parent's squared midpoint inequality from the t = 1/2 case",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      }
+    ],
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "That the Gamma function is logarithmically convex — log Γ is convex on (0,∞) — is the analytic heart of the Bohr–Mollerup theorem, which characterizes Γ as the unique log-convex interpolation of the factorial. Mathlib records the convexity itself (Real.convexOn_log_Gamma) but few of its multiplicative consequences. The parent entry gamma-log-convexity-oq-01 extracted only the midpoint instance Γ((a+b)/2)² ≤ Γ(a)·Γ(b), the t = 1/2 case squared. The general statement of log-convexity, however, is a whole one-parameter family of multiplicative bounds (and, through Jensen, an n-point family) — the precise sense in which Γ behaves like a geometric mean.",
+    "problemStatement": "Prove the full weighted geometric-mean inequality Γ(t·a + (1−t)·b) ≤ Γ(a)^t · Γ(b)^(1−t) for a, b > 0 and t ∈ [0,1] (real rpow exponents), generalizing the parent's single midpoint case, and extend it to the finite weighted Jensen form Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ).",
+    "proofStrategy": "log-convexity gives the additive bound, then exponentiate. (1) logGamma_weighted_le: convexOn_log_Gamma.2 at the convex combination t·a + (1−t)·b yields log Γ(t·a+(1−t)·b) ≤ t·log Γ(a) + (1−t)·log Γ(b). (2) gamma_weighted_geom_le: the right-hand side equals log(Γ(a)^t · Γ(b)^(1−t)) via Real.log_mul + Real.log_rpow; both arguments are positive, so applying exp (monotone, exp∘log = id) gives the multiplicative inequality. The convex-combination argument is positive because at least one weight is positive. (3) gamma_weighted_geom_le_finset: the same exponentiation applied to ConvexOn.map_sum_le (Jensen), with Real.log_prod handling the product and Finset.sum_pos'/Finset.prod_pos the positivity. (4) gamma_midpoint_sq_le: specialize at t = 1/2 (so the 1/2-powers become square roots) and square both nonnegative sides.",
+    "keyInsights": [
+      "**Log-convexity is exactly the multiplicative geometric-mean bound.** Convexity of log Γ says log Γ(t·a+(1−t)·b) ≤ t·log Γ(a)+(1−t)·log Γ(b); exponentiating turns the weighted sum of logs into the weighted product of powers Γ(a)^t·Γ(b)^(1−t). The two statements are literally the same fact read additively vs. multiplicatively.",
+      "**Real.log_rpow is the bridge.** The factor t·log Γ(a) on the convexity side is precisely log(Γ(a)^t); without rpow one cannot even state the multiplicative inequality for non-rational t. This is why the result needs Real.rpow rather than monoid powers.",
+      "**The n-point form is the honest generalization.** Jensen (ConvexOn.map_sum_le) gives Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ) for any finite family with weights summing to 1 — the two-point inequality is just |index| = 2. This is the full content of 'Γ is a geometric mean over its arguments'.",
+      "**The parent is a single point of this family.** Setting t = 1/2 and squaring recovers Γ((a+b)/2)² ≤ Γ(a)·Γ(b) exactly, so the leaf strictly subsumes gamma-log-convexity-oq-01's headline rather than merely paralleling it."
+    ]
+  },
+  "sections": [
+    {
+      "id": "additive-bound",
+      "title": "Two-point additive bound from log-convexity",
+      "startLine": 33,
+      "endLine": 44,
+      "summary": "logGamma_weighted_le: convexOn_log_Gamma.2 evaluated at the convex combination t·a + (1−t)·b, unfolded to log Γ(t·a+(1−t)·b) ≤ t·log Γ(a) + (1−t)·log Γ(b).",
+      "mathContext": "$\\log\\Gamma(t a + (1-t) b) \\le t\\log\\Gamma(a) + (1-t)\\log\\Gamma(b)$."
+    },
+    {
+      "id": "weighted-geom",
+      "title": "Weighted geometric-mean inequality",
+      "startLine": 46,
+      "endLine": 75,
+      "summary": "gamma_weighted_geom_le: the headline. The additive bound's right-hand side is log(Γ(a)^t·Γ(b)^(1−t)) by log_mul + log_rpow; positivity of the convex combination and of the product lets exp turn it into Γ(t·a+(1−t)·b) ≤ Γ(a)^t·Γ(b)^(1−t).",
+      "mathContext": "$\\Gamma(t a + (1-t) b) \\le \\Gamma(a)^{t}\\,\\Gamma(b)^{1-t}$."
+    },
+    {
+      "id": "jensen",
+      "title": "Finite weighted Jensen form",
+      "startLine": 77,
+      "endLine": 114,
+      "summary": "gamma_weighted_geom_le_finset: applies ConvexOn.map_sum_le (Jensen) to log∘Γ, exponentiating with Real.log_prod to reach Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ). Positivity of the argument (some weight is positive) and product via Finset.sum_pos'/Finset.prod_pos.",
+      "mathContext": "$\\Gamma\\Big(\\sum_i w_i x_i\\Big) \\le \\prod_i \\Gamma(x_i)^{w_i}$, $\\sum_i w_i = 1$, $w_i \\ge 0$."
+    },
+    {
+      "id": "midpoint-recovery",
+      "title": "Recovering the parent midpoint inequality",
+      "startLine": 116,
+      "endLine": 127,
+      "summary": "gamma_midpoint_sq_le: specializes gamma_weighted_geom_le at t = 1/2 (1/2-powers become √ via sqrt_eq_rpow) and squares both nonnegative sides to recover the parent's Γ((a+b)/2)² ≤ Γ(a)·Γ(b).",
+      "mathContext": "$\\Gamma\\!\\left(\\tfrac{a+b}{2}\\right)^2 \\le \\Gamma(a)\\,\\Gamma(b)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The full multiplicative form of Gamma log-convexity: Γ(t·a+(1−t)·b) ≤ Γ(a)^t·Γ(b)^(1−t) for t ∈ [0,1], and the n-point Jensen generalization Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ). The parent's midpoint inequality is the t = 1/2 case. 3 theorems, 1 lemma, 0 sorries, 0 axioms.",
+    "implications": "Promotes the parent's isolated midpoint bound to the complete one-parameter (and finite-weight) family that log-convexity actually asserts, expressed multiplicatively with real powers. The n-point form is the precise statement that Γ dominates the weighted geometric mean of its argument samples — the inequality underlying log-convex interpolation in the Bohr–Mollerup characterization.",
+    "openQuestions": [
+      "State the integral (continuous-weight) Jensen form Γ(∫ x dμ) ≤ exp(∫ log Γ(x) dμ) for a probability measure μ on (0,∞), the measure-theoretic limit of the finite weighted bound.",
+      "Establish the strict inequality for non-constant data using StrictConvexOn machinery (Γ is strictly log-convex), characterizing the equality case as a = b (resp. all xᵢ equal)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "GammaLogConvexityOQ01OQ01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/GammaLogConvexityOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "gamma-log-convexity-oq-01",
+      "relationship": "extends",
+      "description": "Parent records only the midpoint case Γ((a+b)/2)² ≤ Γ(a)·Γ(b); this leaf proves the full weighted family Γ(t·a+(1−t)·b) ≤ Γ(a)^t·Γ(b)^(1−t) and recovers the parent's inequality as the t = 1/2 corollary"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "gamma_weighted_geom_le",
+      "type": "core",
+      "statement": "0 < a → 0 < b → 0 ≤ t → t ≤ 1 → Γ(t·a + (1−t)·b) ≤ Γ(a)^t · Γ(b)^(1−t)",
+      "description": "The weighted multiplicative (geometric-mean) inequality for Γ — the exact multiplicative form of log-convexity.",
+      "significance": "Generalizes the parent's single midpoint instance to the full one-parameter family"
+    },
+    {
+      "name": "gamma_weighted_geom_le_finset",
+      "type": "core",
+      "statement": "(∀ i ∈ s, 0 ≤ w i) → ∑ w i = 1 → (∀ i ∈ s, 0 < x i) → Γ(∑ w i · x i) ≤ ∏ Γ(x i)^(w i)",
+      "description": "The finite n-point weighted Jensen form of Gamma log-convexity.",
+      "significance": "Full geometric-mean statement: Γ dominates the weighted geometric mean of its argument samples"
+    },
+    {
+      "name": "gamma_midpoint_sq_le",
+      "type": "corollary",
+      "statement": "0 < a → 0 < b → Γ((a+b)/2)² ≤ Γ(a)·Γ(b)",
+      "description": "The parent's midpoint inequality recovered as the t = 1/2 case of gamma_weighted_geom_le.",
+      "significance": "Confirms the leaf strictly subsumes the parent entry"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's first open question by upgrading **gamma-log-convexity-oq-01**'s single *midpoint* instance of Gamma log-convexity to the **full weighted family** — the exact multiplicative form of log-convexity — and further to the **finite n-point Jensen** form.

For `a, b > 0` and `t ∈ [0,1]`:
```
Γ(t·a + (1−t)·b) ≤ Γ(a)^t · Γ(b)^(1−t)        -- gamma_weighted_geom_le  (real rpow exponents)
```
and for positive points `xᵢ` with weights `wᵢ ≥ 0`, `∑ wᵢ = 1`:
```
Γ(∑ wᵢ·xᵢ) ≤ ∏ Γ(xᵢ)^(wᵢ)                     -- gamma_weighted_geom_le_finset  (Jensen)
```
The parent's `Γ((a+b)/2)² ≤ Γ(a)·Γ(b)` is recovered as the `t = 1/2` corollary (`gamma_midpoint_sq_le`), so the leaf strictly subsumes it.

## Technique

Log-convexity (`Real.convexOn_log_Gamma`) gives the **additive** bound on `log Γ`; exponentiating turns it **multiplicative**. The key bridge is `Real.log_rpow`: the convexity term `t·log Γ(a)` is precisely `log(Γ(a)^t)`, which is what lets the inequality even be *stated* for irrational `t`. The two-point case uses `ConvexOn.2`; the n-point case uses `ConvexOn.map_sum_le` (Finset Jensen) with `Real.log_prod`.

## Verification

- Builds against Mathlib v4.26.0 (host `lake env lean`, exit 0).
- **0 sorries, 0 axioms.** `#print axioms` on all three theorems reports only `propext, Classical.choice, Quot.sound`.
- 3 theorems + 1 lemma, 127 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)