### PR TITLE
audit: 4 fresh research entries clean (erdos-634/erdos-858/harmonic-divergence/pell)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22961,6 +22961,30 @@
       "lastAudited": "2026-06-25T03:13:53Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-634-medial-congruence": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:20:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-858-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:20:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "harmonic-divergence-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:20:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pell-equation-oq-01-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T03:20:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 4 fresh entries CLEAN

Audited 4 newly-shipped gallery entries not covered by open audit PRs #29617/#29603. All four pass: status/badge/sorries/axiomCount claims match the Lean source.

| Slug | Verdict | Notes |
|------|---------|-------|
| `erdos-634-medial-congruence` | clean | Medial reptiling over arbitrary real normed space; 11 thms. Mathlib isometry primitives disclosed in `mathlibDependencies`; no delegation opacity. |
| `erdos-858-oq-03` | clean | Elementary reciprocal-sum **lower** bound (≥ 1/2) on a primitive top-half interval. Title honestly scoped to "Bounded Below"; `assumptions` explicitly disclose the parent's deep o(1) Alexander 1966 estimate is **not** used. No inequality≠theorem inflation. |
| `harmonic-divergence-oq-02-oq-01` | clean | `bertrand_summable_iff` (line 185) proves the full **unconditional** iff `Summable (bertrand p) ↔ 1 < p`, exactly matching the "Converges ⟺ p>1" headline. |
| `pell-equation-oq-01-oq-04-oq-01` | clean | zpow extension of the Pell regulator scaling law. Mathlib Pell group law (Brahmagupta composition) disclosed; new content (`pellRegulator` ℤ-linearity) genuinely original. |

### Integrity checks (all four)
- ✅ 0 real sorries / admits (code, not docstring prose)
- ✅ 0 `axiom` declarations
- ✅ 0 `native_decide` (no `Lean.ofReduceBool`)
- ✅ 0 `True` stubs
- ✅ theorem counts match meta (858→6, harmonic→12, pell→9, 634→11)
- ✅ `#print axioms` disclosures consistent (only propext/Classical.choice/Quot.sound)
- ✅ Mathlib dependencies disclosed where the core relies on them; `original` badges defensible

Tracker-only change (`src/data/proofs/audit-tracker.json`, +24 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)