### PR TITLE
Research: multinomial covariance matrix is singular (binomial-theorem-oq-02-oq-01-oq-01-incomplete-01)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -396,6 +396,7 @@ import Proofs.BinomialTheoremOQ01OQ01
 import Proofs.BinomialTheoremOQ02
 import Proofs.BinomialTheoremOQ02OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01
+import Proofs.BinomialTheoremOQ02OQ01OQ01Incomplete01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01OQ01OQ02

--- a/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean
@@ -1,0 +1,132 @@
+import Mathlib
+
+/-
+# Singularity of the Multinomial Covariance Matrix
+
+## Question
+The multinomial mean (`E[Xᵢ] = n·pᵢ`), variance (`Var Xᵢ = n·pᵢ(1 - pᵢ)`) and
+off-diagonal covariance (`Cov(Xᵢ,Xⱼ) = -n·pᵢ·pⱼ` for `i ≠ j`) are already
+formalized in the sibling files (`BinomialTheoremOQ02OQ01`,
+`BinomialTheoremOQ02OQ01OQ01`, `BinomialTheoremOQ02OQ01OQ04`). Assembled, they
+form the `|s| × |s|` covariance matrix `Σ` of the count vector `X = (Xᵢ)`.
+Is this matrix *singular*, and if so, what is its kernel?
+
+## Answer
+**Yes — `Σ` is singular, with the all-ones vector `𝟙` in its kernel.**
+
+The multinomial counts obey the hard linear constraint `∑ᵢ Xᵢ = n`: every one of
+the `n` draws is classified into exactly one category. The random vector `X`
+therefore lives on the hyperplane `{x : ∑ xᵢ = n}`, so its covariance matrix is
+degenerate. Concretely, the rows of `Σ` sum to zero:
+
+    ∀ i,  ∑ⱼ Cov(Xᵢ, Xⱼ) = Cov(Xᵢ, ∑ⱼ Xⱼ) = Cov(Xᵢ, n) = 0.
+
+We prove this directly at the level of the defining `piAntidiag` sums, where the
+mechanism is transparent: on the support, every composition `k` satisfies
+`∑ⱼ kⱼ = n`, so the *centered partner sum* collapses,
+
+    ∑ⱼ (kⱼ - n·pⱼ) = (∑ⱼ kⱼ) - n·(∑ⱼ pⱼ) = n - n·1 = 0,
+
+and the entire row sum vanishes term by term — no cancellation between distinct
+covariance entries is needed.
+
+## Results
+* `centered_partner_sum_zero` — the engine: `∑ⱼ (kⱼ - n·pⱼ) = 0` on the support.
+* `multinomial_cov_row_sum_zero` — each row of `Σ` sums to `0` (the kernel
+  statement: `𝟙 ∈ ker Σ`).
+* `multinomial_cov_total_sum_zero` — every entry of `Σ` sums to `0`, i.e.
+  `Var(∑ᵢ Xᵢ) = 0`, the variance of the (constant) total count.
+* `multinomial_var_eq_neg_offdiag` — the diagonal is *forced* by the
+  off-diagonals: `Var(Xᵢ) = -∑_{j ≠ i} Cov(Xᵢ, Xⱼ)`. The covariance matrix has
+  no independent diagonal; given its off-diagonal entries, the variances are
+  determined.
+
+These facts are the geometry behind the standard practice of dropping one
+category in multinomial logistic regression: `Σ` has rank at most `|s| - 1`.
+
+Axiom-free: only `propext` / `Classical.choice` / `Quot.sound`.
+-/
+
+namespace BinomialTheoremOQ02OQ01OQ01Incomplete01
+
+open Finset BigOperators
+open scoped Nat
+
+variable {α : Type*} [DecidableEq α]
+
+/-- The multinomial mass weight at a composition `k`:
+    `multinomial(s, k) · ∏ₗ pₗ ^ kₗ`. Summed against a function of `k` over
+    `s.piAntidiag n` this computes expectations under the multinomial law. -/
+noncomputable def w (s : Finset α) (p : α → ℝ) (k : α → ℕ) : ℝ :=
+  (Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l
+
+/-- The `(i, j)` entry of the multinomial covariance matrix, written directly as
+    a sum over compositions: `Cov(Xᵢ, Xⱼ) = ∑ₖ (kᵢ - n·pᵢ)(kⱼ - n·pⱼ) · w(k)`.
+    For `i = j` this is the variance `Var(Xᵢ)`. -/
+noncomputable def covEntry (s : Finset α) (p : α → ℝ) (n : ℕ) (i j : α) : ℝ :=
+  ∑ k ∈ s.piAntidiag n,
+    ((k i : ℝ) - n * p i) * ((k j : ℝ) - n * p j) * w s p k
+
+/-- **The vanishing engine.** On the support of the multinomial, every
+    composition `k` has total count `n`, so the centered counts sum to zero:
+    `∑ⱼ (kⱼ - n·pⱼ) = (∑ⱼ kⱼ) - n·(∑ⱼ pⱼ) = n - n = 0`. This single identity is
+    the reason the covariance matrix is singular. -/
+theorem centered_partner_sum_zero (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp : ∑ i ∈ s, p i = 1) {k : α → ℕ} (hk : k ∈ s.piAntidiag n) :
+    ∑ j ∈ s, ((k j : ℝ) - n * p j) = 0 := by
+  have hk1 : ∑ j ∈ s, k j = n := (Finset.mem_piAntidiag.mp hk).1
+  rw [Finset.sum_sub_distrib, ← Finset.mul_sum, hp, mul_one,
+      show (∑ j ∈ s, (k j : ℝ)) = (n : ℝ) from by rw [← Nat.cast_sum, hk1],
+      sub_self]
+
+/-- **Rows of the multinomial covariance matrix sum to zero.**
+    For each category `i`, `∑ⱼ Cov(Xᵢ, Xⱼ) = 0`; equivalently the all-ones vector
+    lies in the kernel of `Σ`, so `Σ` is singular. The proof swaps the order of
+    summation and factors out the `j`-independent part `(kᵢ - n·pᵢ)·w(k)`, leaving
+    the centered partner sum, which vanishes by `centered_partner_sum_zero`. -/
+theorem multinomial_cov_row_sum_zero (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp : ∑ i ∈ s, p i = 1) (i : α) :
+    ∑ j ∈ s, covEntry s p n i j = 0 := by
+  unfold covEntry
+  rw [Finset.sum_comm]
+  refine Finset.sum_eq_zero (fun k hk => ?_)
+  have hfactor : ∑ j ∈ s, ((k i : ℝ) - n * p i) * ((k j : ℝ) - n * p j) * w s p k
+      = (((k i : ℝ) - n * p i) * w s p k) * ∑ j ∈ s, ((k j : ℝ) - n * p j) := by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun j _ => by ring)
+  rw [hfactor, centered_partner_sum_zero s p n hp hk, mul_zero]
+
+/-- **Every entry of `Σ` sums to zero.** Summing the (already zero) row sums,
+    `∑ᵢ ∑ⱼ Cov(Xᵢ, Xⱼ) = 0`. Probabilistically this is `Var(∑ᵢ Xᵢ) = 0`: the total
+    count `∑ᵢ Xᵢ ≡ n` is constant, hence has zero variance. -/
+theorem multinomial_cov_total_sum_zero (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp : ∑ i ∈ s, p i = 1) :
+    ∑ i ∈ s, ∑ j ∈ s, covEntry s p n i j = 0 :=
+  Finset.sum_eq_zero (fun i _ => multinomial_cov_row_sum_zero s p n hp i)
+
+/-- **The diagonal is forced by the off-diagonals.** Splitting the zero row sum at
+    `j = i`, the variance equals minus the sum of the off-diagonal covariances:
+    `Var(Xᵢ) = -∑_{j ≠ i} Cov(Xᵢ, Xⱼ)`. The covariance matrix carries no independent
+    diagonal information — once the off-diagonal entries are fixed, the variances
+    are determined by the constraint `∑ᵢ Xᵢ = n`. -/
+theorem multinomial_var_eq_neg_offdiag (s : Finset α) (p : α → ℝ) (n : ℕ)
+    (hp : ∑ i ∈ s, p i = 1) (i : α) (hi : i ∈ s) :
+    covEntry s p n i i = - ∑ j ∈ s.erase i, covEntry s p n i j := by
+  have hrow := multinomial_cov_row_sum_zero s p n hp i
+  rw [← Finset.add_sum_erase s (fun j => covEntry s p n i j) hi] at hrow
+  linarith [hrow]
+
+-- ============================================================
+-- Sanity checks and axiom audit
+-- ============================================================
+
+#check @multinomial_cov_row_sum_zero
+#check @multinomial_cov_total_sum_zero
+#check @multinomial_var_eq_neg_offdiag
+
+-- Should list only propext / Classical.choice / Quot.sound
+#print axioms multinomial_cov_row_sum_zero
+#print axioms multinomial_cov_total_sum_zero
+#print axioms multinomial_var_eq_neg_offdiag
+
+end BinomialTheoremOQ02OQ01OQ01Incomplete01

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-strategy",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "Why the Multinomial Covariance Matrix Is Singular",
+    "content": "The multinomial count vector X=(Xᵢ) satisfies the hard linear constraint ∑ᵢXᵢ=n (every draw lands in exactly one category), so X is confined to the hyperplane {x : ∑xᵢ=n}. A random vector trapped on a hyperplane has a degenerate (singular) covariance matrix: the normal direction of the hyperplane — here the all-ones vector 𝟙 — lies in the kernel. The file proves this directly at the level of the defining `piAntidiag` sums, with no appeal to the explicit entry values; the only input is ∑ᵢpᵢ=1.",
+    "mathContext": "X on {∑xᵢ=n} ⟹ 𝟙ᵀ(X−E X)=0 a.s. ⟹ Σ𝟙=0. Equivalently each row sums to zero: ∑ⱼCov(Xᵢ,Xⱼ)=Cov(Xᵢ,∑ⱼXⱼ)=Cov(Xᵢ,n)=0.",
+    "significance": "key",
+    "relatedConcepts": ["covariance matrix", "Finset.piAntidiag", "rank", "multinomial distribution"],
+    "prerequisites": ["multinomial distribution", "covariance"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "definition",
+    "title": "Mass Weight w and Covariance Entry covEntry",
+    "content": "`w s p k = (Nat.multinomial s k : ℝ) · ∏ₗ∈s pₗ^{kₗ}` is the multinomial mass at composition k. `covEntry s p n i j = ∑_{k∈s.piAntidiag n} (kᵢ−n·pᵢ)(kⱼ−n·pⱼ)·w s p k` is the (i,j) entry of the covariance matrix Σ written as an explicit expectation over compositions. When i=j the centered factors coincide and covEntry(i,i) is the variance Var(Xᵢ).",
+    "mathContext": "Cov(Xᵢ,Xⱼ)=E[(Xᵢ−EXᵢ)(Xⱼ−EXⱼ)]=∑_k (kᵢ−n pᵢ)(kⱼ−n pⱼ)·P(X=k), with EXᵢ=n pᵢ.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.multinomial", "Finset.piAntidiag", "covariance"],
+    "prerequisites": ["multinomial coefficient"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 74, "endLine": 85 },
+    "type": "technique",
+    "title": "The Vanishing Engine: Centered Partner Sum Collapses",
+    "content": "`centered_partner_sum_zero` proves ∑ⱼ∈s (kⱼ−n·pⱼ)=0 for any composition k on the support. The proof splits the sum (`Finset.sum_sub_distrib`), turns ∑ⱼkⱼ into n by `Finset.mem_piAntidiag` + `Nat.cast_sum`, and turns ∑ⱼ n·pⱼ into n via `Finset.mul_sum` and the hypothesis ∑ⱼpⱼ=1; the result is n−n=0. This single collapse is the entire reason the covariance matrix is singular.",
+    "mathContext": "∑ⱼ(kⱼ−n·pⱼ)=(∑ⱼkⱼ)−n(∑ⱼpⱼ)=n−n·1=0. The constraint ∑ⱼkⱼ=n is what makes the centered counts sum to zero.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.mem_piAntidiag", "Finset.sum_sub_distrib", "Nat.cast_sum"],
+    "prerequisites": ["Finset summation"]
+  },
+  {
+    "id": "ann-row-sum",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 87, "endLine": 100 },
+    "type": "theorem",
+    "title": "Rows of Σ Sum to Zero — Singularity",
+    "content": "`multinomial_cov_row_sum_zero`: for each i, ∑ⱼ∈s covEntry(i,j)=0. After `Finset.sum_comm` swaps the order of the double sum, each inner sum over j factors as ((kᵢ−n·pᵢ)·w(k))·∑ⱼ(kⱼ−n·pⱼ); the partner sum vanishes by the engine, so every term is zero. This is the formal statement that the all-ones vector lies in ker Σ, i.e. Σ is singular and rank Σ ≤ |s|−1.",
+    "mathContext": "Σ𝟙=0. Probabilistically, ∑ⱼCov(Xᵢ,Xⱼ)=Cov(Xᵢ,∑ⱼXⱼ)=Cov(Xᵢ,n)=0 because the total count is constant.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_comm", "Finset.mul_sum", "kernel", "rank"],
+    "prerequisites": ["covariance matrix"]
+  },
+  {
+    "id": "ann-total-diagonal",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+    "range": { "startLine": 102, "endLine": 121 },
+    "type": "theorem",
+    "title": "Total Sum Zero and Diagonal Forced by Off-Diagonals",
+    "content": "Two corollaries of the zero row sums. `multinomial_cov_total_sum_zero`: ∑ᵢ∑ⱼ covEntry(i,j)=0, i.e. Var(∑ᵢXᵢ)=0 — the variance of the (constant) total count. `multinomial_var_eq_neg_offdiag`: splitting the zero row sum at j=i (`Finset.add_sum_erase`) gives covEntry(i,i)=−∑_{j≠i}covEntry(i,j), so the variance is determined by the off-diagonal covariances. This is a third, purely structural derivation of Var(Xᵢ)=n·pᵢ(1−pᵢ), independent of the MGF and binomial-marginal routes in the sibling files.",
+    "mathContext": "Var(∑ᵢXᵢ)=0 since ∑ᵢXᵢ≡n. Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ)=∑_{j≠i}n·pᵢ·pⱼ=n·pᵢ(1−pᵢ).",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.add_sum_erase", "variance", "covariance"],
+    "prerequisites": ["covariance matrix"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+  "title": "Singularity of the Multinomial Covariance Matrix",
+  "slug": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+  "description": "The multinomial covariance matrix is singular: its rows sum to zero (the all-ones vector lies in its kernel), because the count vector obeys the hard constraint ∑Xᵢ = n. Proved directly at the level of the defining piAntidiag sums.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib (researcher-9)",
+    "date": "2026-06-24",
+    "status": "verified",
+    "tags": [
+      "probability",
+      "combinatorics",
+      "multinomial",
+      "covariance-matrix",
+      "linear-algebra"
+    ],
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "No axioms, no sorries — fully machine-checked. `#print axioms` lists only propext / Classical.choice / Quot.sound for all three theorems. The covariance entries are written directly as sums over `s.piAntidiag n` of the centered weight `(kᵢ − n·pᵢ)(kⱼ − n·pⱼ) · multinomial(s,k) · ∏ pₗ^{kₗ}`; the only hypothesis is `∑ᵢ pᵢ = 1`.",
+    "originalContributions": [
+      "Formal statement and proof that the multinomial covariance matrix Σ is singular: each row sums to zero (multinomial_cov_row_sum_zero), i.e. the all-ones vector 𝟙 lies in ker Σ",
+      "The vanishing engine centered_partner_sum_zero: on the support ∑ⱼ(kⱼ − n·pⱼ) = n − n = 0, isolating exactly why the matrix is degenerate (the constraint ∑Xᵢ = n)",
+      "Total-sum identity multinomial_cov_total_sum_zero: ∑ᵢⱼ Cov(Xᵢ,Xⱼ) = 0, equivalently Var(∑ᵢXᵢ) = 0 for the constant total count",
+      "Structural identity multinomial_var_eq_neg_offdiag: Var(Xᵢ) = −∑_{j≠i} Cov(Xᵢ,Xⱼ) — the diagonal is forced by the off-diagonals, so Σ carries no independent diagonal information"
+    ],
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That the covariance matrix of a multinomial count vector is singular is a classical fact of categorical statistics: because the counts X₁,…,X_k always sum to the fixed number of trials n, the random vector is confined to a hyperplane and one degree of freedom is redundant. This is precisely why, in multinomial logistic regression and in the analysis of contingency tables, one category is designated as a baseline and dropped — the full k×k covariance (or Fisher information) matrix has rank only k−1. The negative pairwise correlations of the multinomial, first systematized in the early 20th-century development of categorical data analysis, are the off-diagonal shadow of the same constraint.",
+    "problemStatement": "The mean E[Xᵢ]=n·pᵢ, variance Var(Xᵢ)=n·pᵢ(1−pᵢ) and off-diagonal covariance Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ (i≠j) of the multinomial are already formalized in the sibling files. Assembled, they form the covariance matrix Σ of the count vector X=(Xᵢ). **Is Σ singular, and what is its kernel?**\n\n**Answer**: Yes. Because every draw is classified into exactly one category, ∑ᵢXᵢ=n is constant, so X lives on the hyperplane {x : ∑xᵢ=n} and Σ is degenerate. Concretely the rows of Σ sum to zero: ∑ⱼCov(Xᵢ,Xⱼ)=Cov(Xᵢ,∑ⱼXⱼ)=Cov(Xᵢ,n)=0, i.e. the all-ones vector 𝟙 spans a kernel direction and rank Σ ≤ |s|−1.",
+    "text": "The multinomial covariance matrix is singular; the all-ones vector lies in its kernel because the count vector is constrained to the hyperplane ∑Xᵢ = n.",
+    "proofStrategy": "Write each covariance entry as a sum over compositions k ∈ s.piAntidiag n of the centered weight (kᵢ−n·pᵢ)(kⱼ−n·pⱼ)·w(k). For the row sum, swap the order of summation and factor out the j-independent part (kᵢ−n·pᵢ)·w(k); what remains is the centered partner sum ∑ⱼ(kⱼ−n·pⱼ), which on the support equals (∑ⱼkⱼ)−n·(∑ⱼpⱼ)=n−n=0. Hence every term vanishes and the row sum is zero. The total sum and the diagonal-from-off-diagonal identities follow by summing / by splitting the (zero) row sum at j=i.",
+    "keyInsights": [
+      "The singularity has a one-line cause: on the support of the multinomial every composition k satisfies ∑ⱼkⱼ=n, so the centered partner sum ∑ⱼ(kⱼ−n·pⱼ) collapses to n−n·1=0. No cancellation between distinct covariance entries is required — the row sum vanishes term by term.",
+      "This is the linear-algebra dual of the negative-correlation fact: Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ<0 for i≠j is exactly what is needed for the rows npᵢ(1−pᵢ) − ∑_{j≠i}npᵢpⱼ = 0 to vanish.",
+      "Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ): the diagonal of Σ is determined by its off-diagonals. This gives a third, purely structural derivation of the variance npᵢ(1−pᵢ) — complementary to the MGF route (BinomialTheoremOQ02OQ01) and the binomial-marginal route (BinomialTheoremOQ02OQ01OQ04).",
+      "Rank Σ ≤ |s|−1 is the formal content behind dropping a baseline category in multinomial logistic regression: the full covariance/information matrix is never invertible."
+    ],
+    "prerequisites": [
+      "Multinomial distribution and its covariance Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ (parent file)",
+      "Finset.piAntidiag and the multinomial weight",
+      "Basic Finset summation (sum_comm, sum_sub_distrib, mul_sum, add_sum_erase)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-docs",
+      "title": "Problem Documentation and Imports",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring posing the singularity question, giving the kernel answer (𝟙 ∈ ker Σ from ∑Xᵢ=n), and listing the four results. Imports Mathlib; opens Finset/BigOperators.",
+      "mathContext": "Question: is the multinomial covariance matrix Σ singular? Answer: yes — its rows sum to zero because the counts obey the constraint ∑ᵢXᵢ=n, confining X to a hyperplane."
+    },
+    {
+      "id": "sec-defs",
+      "title": "Mass Weight and Covariance Entry",
+      "startLine": 50,
+      "endLine": 72,
+      "summary": "Defines `w s p k = multinomial(s,k)·∏ₗ pₗ^{kₗ}` (the multinomial mass weight) and `covEntry s p n i j = ∑ₖ (kᵢ−n·pᵢ)(kⱼ−n·pⱼ)·w(k)` (the (i,j) entry of Σ; the diagonal i=j is the variance).",
+      "mathContext": "covEntry(i,j)=∑_{k∈piAntidiag(s,n)} (kᵢ−n·pᵢ)(kⱼ−n·pⱼ)·binom(n;k)·∏pₗ^{kₗ}=Cov(Xᵢ,Xⱼ)."
+    },
+    {
+      "id": "sec-engine",
+      "title": "The Vanishing Engine",
+      "startLine": 73,
+      "endLine": 85,
+      "summary": "centered_partner_sum_zero: on the support, ∑ⱼ(kⱼ−n·pⱼ)=0. Proof: split the sum, cast ∑ⱼkⱼ=n via mem_piAntidiag, and use ∑ⱼpⱼ=1, giving n−n=0.",
+      "mathContext": "For k with ∑ⱼkⱼ=n: ∑ⱼ(kⱼ−n·pⱼ)=(∑ⱼkⱼ)−n(∑ⱼpⱼ)=n−n·1=0. This single identity is the source of the singularity."
+    },
+    {
+      "id": "sec-row-sum",
+      "title": "Rows of Σ Sum to Zero (Singularity)",
+      "startLine": 86,
+      "endLine": 100,
+      "summary": "multinomial_cov_row_sum_zero: ∑ⱼ covEntry(i,j)=0. Swap summation order, factor out the j-independent (kᵢ−n·pᵢ)·w(k), and apply the vanishing engine to the remaining partner sum.",
+      "mathContext": "∑ⱼ Cov(Xᵢ,Xⱼ)=Cov(Xᵢ,∑ⱼXⱼ)=Cov(Xᵢ,n)=0. The all-ones vector lies in ker Σ, so Σ is singular (rank ≤ |s|−1)."
+    },
+    {
+      "id": "sec-total-and-diagonal",
+      "title": "Total Sum and Diagonal-from-Off-Diagonals",
+      "startLine": 101,
+      "endLine": 132,
+      "summary": "multinomial_cov_total_sum_zero (∑ᵢⱼ covEntry=0, i.e. Var(∑Xᵢ)=0) by summing the zero rows; multinomial_var_eq_neg_offdiag (covEntry(i,i)=−∑_{j≠i}covEntry(i,j)) by splitting the zero row sum at j=i. Ends with `#check` and `#print axioms` audit.",
+      "mathContext": "Var(∑ᵢXᵢ)=0 since ∑ᵢXᵢ≡n. Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ): the variance is forced by the off-diagonal covariances and the constraint."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Parent: the multinomial PMF integration, which proves Cov(Xᵢ,Xⱼ)=−n·pᵢ·pⱼ and the mean. This entry adds the matrix-level structural fact that those entries assemble into a singular matrix."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Establishes Var(Xᵢ)=n·pᵢ(1−pᵢ) by the binomial-marginal route; here the same variance is re-derived structurally as −∑_{j≠i}Cov(Xᵢ,Xⱼ)."
+    },
+    {
+      "targetId": "binomial-theorem-oq-02",
+      "relationship": "ancestor",
+      "description": "Multinomial theorem / distribution lineage."
+    }
+  ],
+  "conclusion": {
+    "summary": "The multinomial covariance matrix Σ is singular: its rows sum to zero, so the all-ones vector 𝟙 ∈ ker Σ and rank Σ ≤ |s|−1. The cause is the hard constraint ∑ᵢXᵢ=n, which collapses the centered partner sum on the support.",
+    "implications": "This is the formal content behind dropping a baseline category in multinomial logistic regression and contingency-table analysis: the full covariance / Fisher information matrix is never invertible. It also yields a third, purely structural derivation of the coordinate variance.",
+    "openQuestions": [
+      "Can the rank be pinned down exactly as |s|−1 (not just ≤), e.g. by exhibiting that the kernel is one-dimensional when all pᵢ>0?",
+      "Can these entry-level identities be repackaged against Mathlib's `Matrix` API to state ‘Σ ⬝ 𝟙 = 0’ as a genuine matrix–vector equation?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ01OQ01Incomplete01",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 2,
+    "path": "Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "multinomial_cov_row_sum_zero",
+      "type": "core",
+      "description": "Each row of the multinomial covariance matrix sums to zero: ∑ⱼ Cov(Xᵢ,Xⱼ)=0 (the all-ones vector is in the kernel; Σ is singular)",
+      "leanType": "(∑ᵢpᵢ=1) → ∀ i, ∑ j ∈ s, covEntry s p n i j = 0"
+    },
+    {
+      "name": "multinomial_var_eq_neg_offdiag",
+      "type": "core",
+      "description": "The diagonal is forced by the off-diagonals: Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ)",
+      "leanType": "(∑ᵢpᵢ=1) → ∀ i ∈ s, covEntry s p n i i = -∑ j ∈ s.erase i, covEntry s p n i j"
+    },
+    {
+      "name": "multinomial_cov_total_sum_zero",
+      "type": "supporting",
+      "description": "Every entry of Σ sums to zero: ∑ᵢⱼ Cov(Xᵢ,Xⱼ)=0, i.e. Var(∑ᵢXᵢ)=0",
+      "leanType": "(∑ᵢpᵢ=1) → ∑ i ∈ s, ∑ j ∈ s, covEntry s p n i j = 0"
+    },
+    {
+      "name": "centered_partner_sum_zero",
+      "type": "supporting",
+      "description": "The vanishing engine: on the support, ∑ⱼ(kⱼ−n·pⱼ)=0",
+      "leanType": "(∑ᵢpᵢ=1) → k ∈ s.piAntidiag n → ∑ j ∈ s, ((k j) - n·p j) = 0"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01.json
@@ -1,0 +1,32 @@
+{
+  "id": "binomial-theorem-oq-02-oq-01-oq-01-incomplete-01",
+  "name": "Singularity of the Multinomial Covariance Matrix",
+  "status": "completed",
+  "knowledge": {
+    "progressSummary": "COMPLETED (verified, 0-axiom, original): proved that the multinomial covariance matrix Σ is singular — its rows sum to zero, so the all-ones vector 𝟙 lies in ker Σ and rank Σ ≤ |s|−1. Working directly with the covariance entries as sums over s.piAntidiag n, the row sum collapses term by term because on the support ∑ⱼkⱼ=n forces the centered partner sum ∑ⱼ(kⱼ−n·pⱼ)=n−n=0. Corollaries: total sum of all entries = 0 (Var(∑Xᵢ)=0), and Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ) (diagonal forced by off-diagonals — a third structural derivation of the coordinate variance). Lean file BinomialTheoremOQ02OQ01OQ01Incomplete01.lean, 132 lines, 4 theorems / 2 defs, Mathlib-only, #print axioms = propext/Classical.choice/Quot.sound.",
+    "insights": [
+      "The claimed leaf duplicated the parent's title 'Multinomial PMF Integration'; the parent already proves mean, variance (twice, via MGF and binomial-marginal routes), marginals and off-diagonal covariance. The genuinely missing piece was the matrix-level structural fact: Σ is singular.",
+      "Singularity has a one-line cause requiring no entry values: on s.piAntidiag n every composition has ∑ⱼkⱼ=n, so ∑ⱼ(kⱼ−n·pⱼ)=(∑ⱼkⱼ)−n(∑ⱼpⱼ)=n−n·1=0. The row sum then vanishes term by term after Finset.sum_comm + factoring the j-independent part.",
+      "Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ) is obtained purely by splitting the zero row sum at j=i (Finset.add_sum_erase) — no recomputation of the variance, giving a derivation independent of the MGF and fiber-grouping routes in sibling files.",
+      "Mathematically this is rank Σ ≤ |s|−1, the formal content behind dropping a baseline category in multinomial logistic regression / contingency-table analysis."
+    ],
+    "builtItems": [
+      "centered_partner_sum_zero (BinomialTheoremOQ02OQ01OQ01Incomplete01.lean): ∑ⱼ(kⱼ−n·pⱼ)=0 on the support — the vanishing engine",
+      "multinomial_cov_row_sum_zero: each row of Σ sums to 0 (𝟙 ∈ ker Σ; Σ singular)",
+      "multinomial_cov_total_sum_zero: ∑ᵢⱼ Cov(Xᵢ,Xⱼ)=0, i.e. Var(∑Xᵢ)=0",
+      "multinomial_var_eq_neg_offdiag: Var(Xᵢ)=−∑_{j≠i}Cov(Xᵢ,Xⱼ) (diagonal forced by off-diagonals)",
+      "Defs w (mass weight) and covEntry (covariance entry as a piAntidiag sum)"
+    ],
+    "openGaps": [
+      "Pin the rank exactly to |s|−1 (kernel one-dimensional) when all pᵢ>0.",
+      "Restate Σ𝟙=0 against Mathlib's Matrix API as a genuine matrix–vector equation."
+    ]
+  },
+  "leanFiles": [
+    "Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean"
+  ],
+  "relatedProofs": [
+    "binomial-theorem-oq-02-oq-01-oq-01",
+    "binomial-theorem-oq-02-oq-01-oq-04"
+  ]
+}


### PR DESCRIPTION
## Summary
Research session for `binomial-theorem-oq-02-oq-01-oq-01-incomplete-01` ("Multinomial PMF Integration with Mathlib Framework" — an *incomplete* leaf that duplicated its parent's title).

The parent (`binomial-theorem-oq-02-oq-01-oq-01`) already proves the multinomial mean, variance (twice — MGF route and binomial-marginal route in sibling files), marginals, and **off-diagonal** covariance `Cov(Xᵢ,Xⱼ) = −n·pᵢ·pⱼ`. Rather than re-prove a covered result, this entry adds the genuinely missing **matrix-level structural fact**:

> **The multinomial covariance matrix Σ is singular.** Its rows sum to zero, so the all-ones vector `𝟙` lies in `ker Σ` and `rank Σ ≤ |s|−1`.

This is the formal content behind dropping a baseline category in multinomial logistic regression / contingency-table analysis: because every draw is classified into exactly one category, `∑ᵢXᵢ = n` is constant, the count vector lives on a hyperplane, and its covariance matrix is degenerate.

## What was proved (`Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean`, 132 lines)
- **`centered_partner_sum_zero`** — the engine: on the support, `∑ⱼ(kⱼ − n·pⱼ) = (∑ⱼkⱼ) − n(∑ⱼpⱼ) = n − n = 0`.
- **`multinomial_cov_row_sum_zero`** — each row of Σ sums to 0 (`𝟙 ∈ ker Σ`; Σ singular). Proof: `Finset.sum_comm`, factor the `j`-independent part, apply the engine.
- **`multinomial_cov_total_sum_zero`** — `∑ᵢⱼ Cov(Xᵢ,Xⱼ) = 0`, i.e. `Var(∑ᵢXᵢ) = 0`.
- **`multinomial_var_eq_neg_offdiag`** — `Var(Xᵢ) = −∑_{j≠i} Cov(Xᵢ,Xⱼ)`: the diagonal is forced by the off-diagonals (a third, purely structural derivation of the coordinate variance).

## Verification
- Compiles against Mathlib v4.26 via `lake env lean` (Docker host down this session).
- 0 sorries, 0 `axiom` declarations. `#print axioms` lists only `propext / Classical.choice / Quot.sound` for all three theorems — **verified, axiom-free**.
- Self-contained (`import Mathlib` only); registered in `proofs/Proofs.lean`.

## Files
- `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Incomplete01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-incomplete-01.json` (knowledge)

## Status
**Outcome**: completed (verified / 0-axiom / original)
**Next steps**: pin the rank exactly to `|s|−1` (one-dimensional kernel when all `pᵢ>0`); restate `Σ𝟙=0` against Mathlib's `Matrix` API.

🤖 Generated by researcher-9