### PR TITLE
research(composition-parts-choose-oq010101): second moment & variance of the number of parts of a composition [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean
@@ -1,0 +1,213 @@
+import Proofs.CompositionPartsChooseOQ01OQ01
+import Mathlib.Tactic
+
+/-
+# The second moment and variance of the number of parts of a composition
+
+## What this proves
+
+A *composition* of `n` is an ordered tuple of positive integers summing to `n`
+(Mathlib's `Composition n`); its number of parts is `c.length`. Earlier entries
+in this family establish:
+
+* grandparent (`composition-card-2pow-oq-01`): there are `2^(n−1)` compositions of `n`;
+* parent (`composition-parts-choose-oq-01`): exactly `C(n−1, k−1)` of them have `k` parts;
+* parent (`composition-parts-choose-oq-01-oq-01`): the **first moment** — total number
+  of parts `(n+1)·2^(n−2)`, equivalently mean `(n+1)/2`.
+
+This leaf computes the **second moment** of the part-count, and from it the
+**variance**.
+
+Write `X(c) = c.length`. The key closed form (stated multiplied by `4` to stay in `ℕ`
+without truncating division) is
+
+```
+4 · Σ_{c : Composition n} X(c)²  =  n · (n + 3) · 2^(n−1)        (second_moment)
+```
+
+and consequently the variance of the number of parts (under the uniform distribution
+on the `2^(n−1)` compositions of `n`, whose mean the parent fixed at `(n+1)/2`) is
+
+```
+Var(X) = (1 / 2^(n−1)) · Σ_c (X(c) − (n+1)/2)²  =  (n − 1)/4        (variance)
+```
+
+## The mechanism
+
+Exactly as for the first moment, the work is done by the bijection
+`gapsEquiv n : Composition n ≃ Finset (Fin (n−1))` (a composition is the set of internal
+gaps it cuts) together with `length_eq_card_gaps : c.length = (gaps c).card + 1`.
+Transporting the sum across this equivalence reduces everything to a sum over subsets
+of an `(n−1)`-element set, where
+
+```
+Σ_{s ⊆ Fin m} (|s| + 1)²  =  Σ_s |s|²  +  2 Σ_s |s|  +  Σ_s 1.
+```
+
+The three pieces are: the new second-moment subset sum `Σ_s |s|²` (proved here via the
+binomial identity `4 Σ_k C(m,k) k² = m(m+1)2^m`), the parent's `Σ_s |s| = m 2^(m−1)`,
+and the count `Σ_s 1 = 2^m`. Assembling gives the closed form; the variance follows by
+expanding `(X − μ)²` and feeding in the first and second moments.
+
+The binomial identity `4 Σ_k C(m,k) k² = m(m+1)2^m` is proved by the same absorption
+trick as the parent's `Σ_k C(m,k) k = m 2^(m−1)`: peel the `k = 0` term, then use
+`(k+1)·C(m,k+1) = m·C(m−1,k)` (`Nat.succ_mul_choose_eq`) once to drop a factor `k+1`,
+reducing the `k²` sum to the already-known `k`-sum plus the plain sum `Σ C(m,k) = 2^m`.
+
+## Originality
+
+Mathlib has `Σ C(m,k) = 2^m` but neither the weighted sums `Σ k·C(m,k)`, `Σ k²·C(m,k)`
+nor any statement about the distribution of the part-count of a composition. The
+variance of the number of parts of a random composition is, to our knowledge, not in
+the gallery either.
+-/
+
+namespace CompositionPartsChooseOQ01OQ01OQ01
+
+open Finset CompositionPartsChooseOQ01OQ01
+
+/-! ## The second-moment binomial sum -/
+
+/-- **Second-moment binomial identity.** `4·Σ_k C(m,k)·k² = m·(m+1)·2^m`.
+Stated with the factor `4` so that it holds in `ℕ` for *all* `m` (including the small
+cases where `m·(m+1)·2^(m−2)` would truncate). Proved by the absorption rule
+`(k+1)·C(m,k+1) = m·C(m−1,k)` (`Nat.succ_mul_choose_eq`), which lowers one factor of
+`k+1`, reducing the `k²`-sum to the parent's `k`-sum plus the plain binomial sum. -/
+theorem sum_choose_mul_sq (m : ℕ) :
+    4 * ∑ k ∈ range (m + 1), m.choose k * k ^ 2 = m * (m + 1) * 2 ^ m := by
+  cases m with
+  | zero => simp
+  | succ M =>
+    rw [Finset.sum_range_succ']
+    simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+      zero_pow, mul_zero, add_zero]
+    -- `∑ k ∈ range (M+1), C(M+1, k+1) · (k+1)²`
+    have step : ∀ k ∈ range (M + 1),
+        (M + 1).choose (k + 1) * (k + 1) ^ 2 = (M + 1) * (M.choose k * (k + 1)) := by
+      intro k _
+      have h : (M + 1) * M.choose k = (M + 1).choose (k + 1) * (k + 1) :=
+        Nat.add_one_mul_choose_eq M k  -- (M+1)·C(M,k) = C(M+1,k+1)·(k+1)
+      calc (M + 1).choose (k + 1) * (k + 1) ^ 2
+            = ((M + 1).choose (k + 1) * (k + 1)) * (k + 1) := by ring
+        _ = ((M + 1) * M.choose k) * (k + 1) := by rw [← h]
+        _ = (M + 1) * (M.choose k * (k + 1)) := by ring
+    rw [Finset.sum_congr rfl step, ← Finset.mul_sum]
+    -- `4 · ((M+1) · ∑ C(M,k)·(k+1)) = (M+1)·(M+2)·2^(M+1)`
+    have esplit : ∑ k ∈ range (M + 1), M.choose k * (k + 1)
+        = (∑ k ∈ range (M + 1), M.choose k * k) + ∑ k ∈ range (M + 1), M.choose k := by
+      rw [← Finset.sum_add_distrib]; exact Finset.sum_congr rfl (fun k _ => by ring)
+    rw [esplit, sum_choose_mul M, Nat.sum_range_choose]
+    -- `4 · ((M+1) · (M·2^(M−1) + 2^M)) = (M+1)·(M+1+1)·2^(M+1)`
+    cases M with
+    | zero => norm_num
+    | succ N =>
+      simp only [Nat.add_sub_cancel, pow_succ]
+      ring
+
+/-- **Second-moment subset sum.** `4·Σ_{s ⊆ Fin m} |s|² = m·(m+1)·2^m`.
+Transported from `sum_choose_mul_sq` via `Finset.sum_powerset_apply_card`, which groups
+subsets by their cardinality. -/
+theorem sum_finset_card_sq (m : ℕ) :
+    4 * ∑ s : Finset (Fin m), s.card ^ 2 = m * (m + 1) * 2 ^ m := by
+  have h1 : ∑ s : Finset (Fin m), s.card ^ 2
+      = ∑ s ∈ (univ : Finset (Fin m)).powerset, s.card ^ 2 := by rw [Finset.powerset_univ]
+  rw [h1, Finset.sum_powerset_apply_card (fun k => k ^ 2)]
+  simp only [smul_eq_mul, Finset.card_univ, Fintype.card_fin]
+  exact sum_choose_mul_sq m
+
+/-! ## The second moment over compositions -/
+
+/-- **Second moment of the number of parts.** Summed over all `2^(n−1)` compositions of
+`n ≥ 2`, the total of the *squared* part-counts satisfies
+
+`4 · Σ_{c : Composition n} (c.length)²  =  n·(n+3)·2^(n−1)`.
+
+(The factor `4` clears the `2^(n−3)` that the exact form `n(n+3)2^(n−3)` would carry,
+keeping the statement in `ℕ`.) Same route as the first moment: push the sum across
+`gapsEquiv` to subsets of `Fin (n−1)`, expand `(|s|+1)²`, and combine the three subset
+sums. -/
+theorem second_moment (n : ℕ) (hn : 2 ≤ n) :
+    4 * ∑ c : Composition n, c.length ^ 2 = n * (n + 3) * 2 ^ (n - 1) := by
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 2 := ⟨n - 2, by omega⟩
+  have e1 : ∑ c : Composition (M + 2), c.length ^ 2
+      = ∑ c : Composition (M + 2), ((gapsEquiv (M + 2) c).card + 1) ^ 2 :=
+    Finset.sum_congr rfl (fun c _ => by rw [length_eq_card_gaps (M + 2) (by omega) c])
+  rw [e1, show (∑ c : Composition (M + 2), ((gapsEquiv (M + 2) c).card + 1) ^ 2)
+        = ∑ s : Finset (Fin (M + 2 - 1)), (s.card + 1) ^ 2
+        from Equiv.sum_comp (gapsEquiv (M + 2)) (fun s => (s.card + 1) ^ 2)]
+  rw [show M + 2 - 1 = M + 1 from rfl]
+  -- `4 · Σ_{s ⊆ Fin (M+1)} (|s|+1)² = (M+2)·(M+5)·2^(M+1)`
+  have hsplit : ∑ s : Finset (Fin (M + 1)), (s.card + 1) ^ 2
+      = (∑ s : Finset (Fin (M + 1)), s.card ^ 2)
+        + 2 * (∑ s : Finset (Fin (M + 1)), s.card)
+        + (∑ _s : Finset (Fin (M + 1)), 1) := by
+    rw [Finset.mul_sum, ← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun s _ => by ring)
+  have hC : (∑ _s : Finset (Fin (M + 1)), 1) = 2 ^ (M + 1) := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_finset, Fintype.card_fin,
+      smul_eq_mul, mul_one]
+  rw [hsplit]
+  have expand : 4 * ((∑ s : Finset (Fin (M + 1)), s.card ^ 2)
+        + 2 * (∑ s : Finset (Fin (M + 1)), s.card)
+        + (∑ _s : Finset (Fin (M + 1)), 1))
+      = (4 * ∑ s : Finset (Fin (M + 1)), s.card ^ 2)
+        + 8 * (∑ s : Finset (Fin (M + 1)), s.card)
+        + 4 * (∑ _s : Finset (Fin (M + 1)), 1) := by ring
+  rw [expand, sum_finset_card_sq (M + 1), sum_finset_card (M + 1), hC]
+  rw [show M + 1 - 1 = M from rfl]
+  simp only [pow_succ]
+  ring
+
+/-! ## The variance -/
+
+/-- **Variance of the number of parts is `(n−1)/4`.** Under the uniform distribution on
+the `2^(n−1)` compositions of `n ≥ 2`, with mean `μ = (n+1)/2` (the parent's
+`mean_parts`),
+
+`(1 / 2^(n−1)) · Σ_c (c.length − (n+1)/2)²  =  (n−1)/4`.
+
+Proved by expanding `(X − μ)² = X² − 2μX + μ²`, then feeding in the second moment
+(`second_moment`), the first moment (`total_parts`) and the count (`composition_card`).
+-/
+theorem variance (n : ℕ) (hn : 2 ≤ n) :
+    (∑ c : Composition n, ((c.length : ℚ) - (n + 1) / 2) ^ 2)
+        / (Fintype.card (Composition n) : ℚ)
+      = (n - 1) / 4 := by
+  -- cardinality and its positivity
+  have hcard : (Fintype.card (Composition n) : ℚ) = 2 ^ (n - 1) := by
+    rw [composition_card]; push_cast; ring
+  have hpos : (Fintype.card (Composition n) : ℚ) ≠ 0 := by rw [hcard]; positivity
+  -- first moment in ℚ
+  have hfirst : (∑ c : Composition n, (c.length : ℚ)) = ((n : ℚ) + 1) * 2 ^ (n - 2) := by
+    have : (∑ c : Composition n, (c.length : ℚ)) = ((∑ c : Composition n, c.length : ℕ) : ℚ) := by
+      push_cast; ring
+    rw [this, total_parts n hn]; push_cast; ring
+  -- second moment in ℚ (divide the ℕ identity by 4)
+  have hsecond : (∑ c : Composition n, (c.length : ℚ) ^ 2)
+      = (n : ℚ) * (n + 3) * 2 ^ (n - 1) / 4 := by
+    have hnat : ((4 * ∑ c : Composition n, c.length ^ 2 : ℕ) : ℚ)
+        = ((n * (n + 3) * 2 ^ (n - 1) : ℕ) : ℚ) := by rw [second_moment n hn]
+    push_cast at hnat
+    linarith [hnat]
+  -- expand the square sum
+  have hexp : (∑ c : Composition n, ((c.length : ℚ) - ((n : ℚ) + 1) / 2) ^ 2)
+      = (∑ c : Composition n, (c.length : ℚ) ^ 2)
+        - 2 * (((n : ℚ) + 1) / 2) * (∑ c : Composition n, (c.length : ℚ))
+        + (Fintype.card (Composition n) : ℚ) * (((n : ℚ) + 1) / 2) ^ 2 := by
+    rw [Finset.mul_sum]
+    rw [show (Fintype.card (Composition n) : ℚ) * (((n : ℚ) + 1) / 2) ^ 2
+          = ∑ _c : Composition n, (((n : ℚ) + 1) / 2) ^ 2 by
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]]
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun c _ => by ring)
+  rw [hexp, hsecond, hfirst, hcard]
+  -- reduce exponents to a common base and clear denominators
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 2 := ⟨n - 2, by omega⟩
+  rw [show M + 2 - 1 = M + 1 from rfl, show M + 2 - 2 = M from rfl]
+  have hne : (2 : ℚ) ^ M ≠ 0 := by positivity
+  rw [show (2 : ℚ) ^ (M + 1) = 2 ^ M * 2 from by rw [pow_succ]]
+  push_cast
+  field_simp
+  ring
+
+end CompositionPartsChooseOQ01OQ01OQ01

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "composition-parts-choose-oq-01-oq-01-oq-01",
+  "title": "Composition Parts OQ-01-OQ-01-OQ-01: The Second Moment and Variance of the Number of Parts of a Composition",
+  "slug": "composition-parts-choose-oq-01-oq-01-oq-01",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n); its number of parts is c.length. The grandparent counts compositions (card (Composition n) = 2^(n−1)), the parent grades that count by part number (C(n−1, k−1) compositions of n into k parts), and the direct parent computes the first moment (total parts (n+1)·2^(n−2), mean (n+1)/2). This entry computes the second moment of the part-count and hence its variance. The headline second_moment proves that, summed over all 2^(n−1) compositions of n ≥ 2, the total of the squared part-counts satisfies 4·∑_{c} c.length² = n·(n+3)·2^(n−1) (the factor 4 keeps the statement in ℕ without truncating the 2^(n−3) of the exact form n(n+3)2^(n−3)). From this, variance proves that the variance of the number of parts under the uniform distribution on compositions is exactly (n−1)/4: (1/2^(n−1))·∑_c (c.length − (n+1)/2)² = (n−1)/4. The route mirrors the first moment: transport the sum along the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) via the bridge length_eq_card_gaps (length c = (gaps c).card + 1), reducing ∑_c c.length² to ∑_{s ⊆ Fin (n−1)} (|s|+1)² = ∑_s |s|² + 2∑_s |s| + 2^(n−1). The new arithmetic core is the second-moment subset sum ∑_{s ⊆ [m]} |s|² (sum_finset_card_sq), itself reduced to the binomial identity 4·∑_k C(m,k)·k² = m(m+1)2^m (sum_choose_mul_sq), proved by the absorption rule (k+1)·C(m,k+1) = m·C(m,k) applied once to drop a factor k+1, reducing the k²-sum to the parent's k-sum plus ∑_k C(m,k) = 2^m. The variance follows by expanding (X − μ)² and feeding in the first moment (total_parts), second moment, and count (composition_card). Mathlib has ∑_k C(m,k) = 2^m but neither the weighted binomial sums ∑ k·C(m,k), ∑ k²·C(m,k) nor any moment of the part-count distribution of a composition; all of that is original content here.",
+  "leanFile": {
+    "imports": [
+      "Proofs.CompositionPartsChooseOQ01OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "CompositionPartsChooseOQ01OQ01"
+    ],
+    "namespace": "CompositionPartsChooseOQ01OQ01OQ01",
+    "lineCount": 213,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionPartsChooseOQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "binomial-coefficients",
+      "variance",
+      "second-moment"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "relatedProblems": [
+      {
+        "id": "composition-parts-choose-oq-01-oq-01",
+        "relationship": "Direct parent: that entry computes the first moment of the number of parts (total (n+1)·2^(n−2), mean (n+1)/2). This entry computes the second moment 4·∑ length² = n(n+3)2^(n−1) and the variance (n−1)/4, reusing the same gap bridge length = (gaps).card + 1 and the subset-sum reduction, and feeding the parent's total_parts and mean into the variance computation."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Grandparent: the part-graded count C(n−1, k−1) of compositions of n into exactly k parts — the distribution whose second moment and variance are computed here."
+      },
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Great-grandparent: the ungraded total card (Composition n) = 2^(n−1), used as the count of compositions (the 2^(n−1) term in the second-moment expansion) and the denominator of the variance."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 213,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All four named theorems (sum_choose_mul_sq, sum_finset_card_sq, second_moment, variance) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. Mathlib contains ∑_k C(m,k) = 2^m (Nat.sum_range_choose) and the absorption rule Nat.add_one_mul_choose_eq, but neither the second-moment binomial sum 4∑ k²C(m,k) = m(m+1)2^m nor any moment of the part-count distribution of a composition; both are original content here, built on the parent's gapsEquiv, length_eq_card_gaps, sum_choose_mul, sum_finset_card together with Finset.sum_powerset_apply_card, Equiv.sum_comp, and Fintype.card_finset. The results are unconditional; the hypothesis n ≥ 2 is the natural domain (for n = 1 the single composition has one part, variance 0, and the closed forms degenerate under truncated subtraction). The headline second moment is stated multiplied by 4 to remain in ℕ; the variance is stated over ℚ where the division is exact.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Compositions of n are ordered sequences of positive parts summing to n. There are 2^(n−1) of them, C(n−1, k−1) with exactly k parts. Once the distribution of the number of parts is known — symmetric about its mean (n+1)/2 — the next natural statistics are its spread: the second moment ∑ length² and the variance. Treating a uniformly random composition of n as a random variable X = (number of parts), the part-count is distributed as 1 + Binomial(n−1, 1/2) (each of the n−1 internal gaps is independently cut or not), so X has mean (n+1)/2 and variance (n−1)/4 — exactly the Binomial(n−1, 1/2) variance. This entry proves both the integer second-moment identity and the rational variance directly from the combinatorics, without invoking probability theory.",
+    "problemStatement": "Across all 2^(n−1) compositions of n, compute the second moment of the number of parts and its variance. Show, for n ≥ 2,\n\n$$4\\sum_{c : \\mathrm{Composition}\\ n} (c.\\mathrm{length})^2 = n\\,(n+3)\\,2^{\\,n-1}, \\qquad \\mathrm{Var}(X) = \\frac{1}{2^{\\,n-1}}\\sum_{c}\\Bigl(c.\\mathrm{length} - \\tfrac{n+1}{2}\\Bigr)^2 = \\frac{n-1}{4}.$$",
+    "text": "The part-count of a composition equals one plus the number of internal gaps it cuts, and a composition of n corresponds bijectively to the subset of the n−1 internal gaps it cuts (gapsEquiv : Composition n ≃ Finset (Fin (n−1))). Transporting the squared part-count along this bijection reduces the second moment to the subset sum ∑_{s ⊆ [m]} (|s|+1)², and hence to the three elementary subset sums ∑|s|², ∑|s|, ∑1. Mathlib supplies ∑_k C(m,k) = 2^m but not the weighted sums; the second-moment binomial identity 4∑_k k²C(m,k) = m(m+1)2^m is established here. The variance then follows from the second moment, the parent's first moment, and the count of compositions.",
+    "proofStrategy": "sum_choose_mul_sq proves 4·∑_{k≤m} C(m,k)·k² = m(m+1)2^m: peel the k = 0 term (Finset.sum_range_succ'), then for the shifted sum use C(m,k+1)·(k+1)² = (m)·(C(m−1,k)·(k+1)) via the absorption rule Nat.add_one_mul_choose_eq (which drops one factor k+1), split C(m−1,k)·(k+1) = C(m−1,k)·k + C(m−1,k) into the parent's sum_choose_mul (= (m−1)·2^(m−2)) and Nat.sum_range_choose (= 2^(m−1)), and close by ring after a second case split to resolve the 2^(m−1). sum_finset_card_sq transports this to ∑_{s ⊆ Fin m} |s|² = via Finset.powerset_univ and Finset.sum_powerset_apply_card. second_moment rewrites ∑_c c.length² through the bridge length_eq_card_gaps as ∑_c ((gapsEquiv n c).card + 1)², reindexes by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} (|s|+1)², expands (|s|+1)² = |s|² + 2|s| + 1, and combines sum_finset_card_sq, sum_finset_card and the count 2^(n−1) (Fintype.card_finset); the closed form n(n+3)2^(n−1) follows by ring after substituting n = M + 2. variance expands ∑_c (length − μ)² = ∑ length² − 2μ∑ length + (card)μ² with μ = (n+1)/2 over ℚ, substitutes the second moment, the parent's total_parts and composition_card, and closes with field_simp and ring.",
+    "keyInsights": [
+      "**The variance is the Binomial(n−1, 1/2) variance.** The part-count of a composition is 1 + (number of cut gaps), and each of the n−1 internal gaps is cut independently, so X − 1 ~ Binomial(n−1, 1/2). The mean (n+1)/2 and variance (n−1)/4 are exactly the shifted-Binomial mean and variance — recovered here purely combinatorially, by transporting the moments along the gap bijection rather than invoking probability theory.",
+      "**The second moment collapses to three subset sums.** Under the gap bijection, ∑_c c.length² becomes ∑_{s ⊆ Fin (n−1)} (|s|+1)² = ∑_s |s|² + 2∑_s |s| + ∑_s 1, reducing everything to the subset-size second moment ∑|s|², the first moment ∑|s| = m·2^(m−1) (the parent's), and the count ∑1 = 2^m.",
+      "**4∑ k²C(m,k) = m(m+1)2^m from a single absorption.** The arithmetic core sum_choose_mul_sq is proved by applying the absorption rule (k+1)·C(m,k+1) = m·C(m−1,k) once: it lowers the troublesome k² to (k+1) inside an (m−1)-binomial, reducing the second-moment sum to the already-known first-moment sum plus the plain binomial sum. Stating it times 4 sidesteps the truncated ℕ-subtraction in the exact form m(m+1)2^(m−2).",
+      "**Mathlib stops at ∑ C(m,k) = 2^m.** Neither the weighted binomial sums ∑ k·C(m,k), ∑ k²·C(m,k) nor any moment of the part-count of a composition is in Mathlib; the second-moment identity and the variance are the original content of this entry, extending the parent's first moment."
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n), the number of parts c.length, and the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) with the bridge length c = (gaps c).card + 1 (from the parent entry)",
+      "Finite-sum reindexing along an equivalence (Equiv.sum_comp) and the powerset-by-cardinality grouping Finset.sum_powerset_apply_card",
+      "Binomial identities: the absorption rule Nat.add_one_mul_choose_eq, ∑_{j=0}^m C(m,j) = 2^m (Nat.sum_range_choose), and the parent's ∑_k k·C(m,k) = m·2^(m−1)",
+      "Variance as a second-moment computation: Var(X) = E[X²] − (E[X])², expanded as (1/N)∑(X−μ)² with μ the mean, cleared over ℚ with field_simp using card (Composition n) = 2^(n−1) ≠ 0"
+    ]
+  },
+  "sections": [
+    {
+      "id": "second-moment-binomial",
+      "title": "The Second-Moment Binomial Sum",
+      "startLine": 71,
+      "endLine": 124,
+      "mathContext": "$4\\sum_{k} k^2\\binom{m}{k} = m(m+1)2^m$ and $4\\sum_{s \\subseteq \\mathrm{Fin}\\,m} \\#s^2 = m(m+1)2^m$.",
+      "summary": "sum_choose_mul_sq proves 4·∑_{k=0}^m k²·C(m,k) = m(m+1)2^m by peeling the k = 0 term and applying the absorption identity (k+1)·C(m,k+1) = m·C(m−1,k) (Nat.add_one_mul_choose_eq) once, lowering the k²-sum to ∑_k C(m−1,k)·(k+1) = ∑_k C(m−1,k)·k + ∑_k C(m−1,k), evaluated by the parent's sum_choose_mul and Nat.sum_range_choose; a final case split resolves the 2^(m−1) and ring closes. The factor 4 keeps the identity in ℕ for all m. sum_finset_card_sq transports this to the subset sum ∑_{s ⊆ Fin m} |s|² via Finset.powerset_univ and Finset.sum_powerset_apply_card."
+    },
+    {
+      "id": "second-moment",
+      "title": "The Second Moment of the Number of Parts",
+      "startLine": 126,
+      "endLine": 170,
+      "mathContext": "$4\\sum_{c} (c.\\mathrm{length})^2 = n(n+3)2^{n-1}$ for $n \\ge 2$.",
+      "summary": "second_moment rewrites ∑_c c.length² through length_eq_card_gaps as ∑_c ((gapsEquiv n c).card + 1)², reindexes by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} (|s|+1)², expands (|s|+1)² = |s|² + 2|s| + 1, and combines the three subset sums — sum_finset_card_sq, the parent's sum_finset_card (∑|s| = m·2^(m−1)), and the count ∑1 = 2^(n−1) (Fintype.card_finset) — to give n(n+3)2^(n−1) by ring after substituting n = M + 2."
+    },
+    {
+      "id": "variance",
+      "title": "The Variance",
+      "startLine": 172,
+      "endLine": 211,
+      "mathContext": "$\\mathrm{Var}(X) = \\tfrac{1}{2^{n-1}}\\sum_c (c.\\mathrm{length} - \\tfrac{n+1}{2})^2 = \\tfrac{n-1}{4}$ for $n \\ge 2$.",
+      "summary": "variance expands ∑_c (length − μ)² = ∑ length² − 2μ∑ length + (card)·μ² over ℚ with μ = (n+1)/2 (Finset.mul_sum, sum_sub_distrib, sum_add_distrib), substitutes the second moment (divided by 4), the parent's first moment total_parts, and composition_card for the count, then clears denominators with field_simp and closes by ring after substituting n = M + 2 — yielding exactly (n−1)/4, the Binomial(n−1, 1/2) variance."
+    }
+  ],
+  "conclusion": "The second moment and variance of the number of parts of a composition are formalised sorry-free and axiom-free. Across all 2^(n−1) compositions of n ≥ 2, the total of the squared part-counts is 4·∑ c.length² = n(n+3)2^(n−1) (second_moment) and the variance of the number of parts under the uniform distribution is exactly (n−1)/4 (variance) — the variance of 1 + Binomial(n−1, 1/2), reflecting that each of the n−1 internal gaps is cut independently. The content beyond Mathlib is the second-moment binomial identity 4∑ k²C(m,k) = m(m+1)2^m (sum_choose_mul_sq) — proved by a single application of the absorption rule reducing it to the parent's first-moment sum — and its assembly, via the gap bijection, into the second moment and variance of the part-count statistic. This completes the first- and second-moment description of the part-count distribution begun by the parent. A natural follow-up is the analogous moments of the part-size (rather than the part-count), or higher moments / the full moment generating function of the Binomial(n−1, 1/2) part-count.",
+  "crossReferences": [
+    "composition-parts-choose-oq-01-oq-01",
+    "composition-parts-choose-oq-01",
+    "composition-card-2pow-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the second open question of `composition-parts-choose-oq-01-oq-01`: the **second moment** of the number of parts of a composition, and hence its **variance**.

A composition of `n` is an ordered tuple of positive integers summing to `n` (`Composition n`), with `c.length` parts. Building on the family:
- grandparent: `card (Composition n) = 2^(n−1)`
- parent: `C(n−1, k−1)` compositions of `n` into `k` parts
- direct parent (`oq-01-oq-01`): first moment — total `(n+1)·2^(n−2)`, mean `(n+1)/2`

this entry adds:

| Theorem | Statement |
|---|---|
| `second_moment` | `4·∑_{c} c.length² = n·(n+3)·2^(n−1)` for `n ≥ 2` |
| `variance` | `(1/2^(n−1))·∑_c (c.length − (n+1)/2)² = (n−1)/4` for `n ≥ 2` |
| `sum_choose_mul_sq` | `4·∑_k k²·C(m,k) = m(m+1)2^m` (arithmetic core) |
| `sum_finset_card_sq` | `4·∑_{s ⊆ Fin m} |s|² = m(m+1)2^m` |

## Mechanism

The part-count of a composition is `1 + (number of internal gaps it cuts)`, and each of the `n−1` gaps is cut independently — so `X − 1 ~ Binomial(n−1, 1/2)` and the variance `(n−1)/4` is the shifted-Binomial variance, recovered **purely combinatorially**. Transporting `∑_c c.length²` along the parent's gap bijection `gapsEquiv : Composition n ≃ Finset (Fin (n−1))` reduces the second moment to `∑_{s ⊆ Fin(n−1)} (|s|+1)² = ∑|s|² + 2∑|s| + 2^(n−1)`. The new binomial identity `sum_choose_mul_sq` is proved by **one** application of the absorption rule `(k+1)·C(m,k+1) = m·C(m−1,k)`, reducing the `k²`-sum to the parent's `k`-sum plus `∑_k C(m,k) = 2^m`. The variance follows by expanding `(X − μ)²` and feeding in the first/second moments and the count.

## Verification

- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- Built with `lake env lean` against pinned Mathlib v4.26 (Docker unavailable this session).

**Originality**: Mathlib has `∑_k C(m,k) = 2^m` but neither the weighted binomial sums `∑ k·C(m,k)`, `∑ k²·C(m,k)` nor any moment of the composition part-count distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)