### PR TITLE
research(harmonic-divergence-oq-02-oq-01): register orphaned Bertrand-series proof in build aggregator

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3102,6 +3102,7 @@ import Proofs.HappyNumberOQ01
 import Proofs.HarmonicDivergence
 import Proofs.HarmonicDivergenceOQ01
 import Proofs.HarmonicDivergenceOQ02
+import Proofs.HarmonicDivergenceOQ02OQ01
 import Proofs.HarmonicDivergenceOQ03
 import Proofs.HarmonicDivergenceOQ04
 import Proofs.HarmonicDivergenceOQ05


### PR DESCRIPTION
## Summary

PR #29619 merged the verified **Bertrand-series threshold** proof — `Σ_{n≥2} 1/(n·(log n)^p)` converges ⟺ `p > 1` — adding:

- `proofs/Proofs/HarmonicDivergenceOQ02OQ01.lean` (213 lines, 14 theorems, 1 def)
- `src/data/proofs/harmonic-divergence-oq-02-oq-01/meta.json`
- `src/data/proofs/harmonic-divergence-oq-02-oq-01/annotations.json`

…but it **omitted the `import` line in `proofs/Proofs.lean`**. The aggregator `Proofs.lean` is what the project build compiles (`./proofs/scripts/docker-build.sh Proofs`), so the proof file was **orphaned from the build** — its `verified, 0-axiom` claim was never actually enforced by CI.

## Change

One line: `import Proofs.HarmonicDivergenceOQ02OQ01`, inserted alphabetically after `HarmonicDivergenceOQ02`. This wires the already-merged proof into the build aggregator so it is type-checked alongside every other gallery proof.

## Verification

Built locally against the pinned Mathlib (v4.26):

```
lake env lean Proofs/HarmonicDivergenceOQ02OQ01.lean   # builds clean, no errors
#print axioms HarmonicDivergenceOQ02OQ01.bertrand_summable_iff
#   → [propext, Classical.choice, Quot.sound]
```

No `native_decide` / `Lean.ofReduceBool`, no `sorry` — consistent with the entry's `verified` / `axiomCount: 0` metadata.

## Notes

- Research PR — deployer merges directly; no `loom:review-requested`.
- Pure build-wiring fix; the merged proof content is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)