### PR TITLE
research(matrix-similarity-invariants-oq-01-oq-02): minimal polynomial is a similarity invariant [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/MatrixSimilarityInvariantsOQ01OQ02.lean
+++ b/proofs/Proofs/MatrixSimilarityInvariantsOQ01OQ02.lean
@@ -1,0 +1,177 @@
+import Mathlib
+
+/-
+# The Minimal Polynomial Is a Similarity Invariant
+
+Two square matrices `A` and `B` over a commutative ring `R` are **similar** when
+`B = P A P⁻¹` for an invertible `P` — the matrix-level shadow of "the same linear map
+written in a different basis".  The parent entry [oq-01]
+(`MatrixSimilarityInvariantsOQ01`) collects the three *classical* similarity invariants —
+the **determinant**, the **trace**, and the **characteristic polynomial** — and the sibling
+[oq-01-oq-01] adds rank / nullity / invertibility.
+
+This entry adds the **minimal polynomial**, a strictly *finer* invariant than the
+characteristic polynomial:
+
+* `Similar.minpoly_eq` — **the minimal polynomial is a similarity invariant**, over *any*
+  commutative ring `R`.  The proof is the conceptual one: conjugation by an invertible `P`
+  is an *algebra automorphism* of the matrix ring, and any algebra equivalence preserves the
+  minimal polynomial (`minpoly.algEquiv_eq`).  We realise the conjugation automorphism as
+  `MulSemiringAction.toAlgEquiv` for the `ConjAct (Matrix n n R)ˣ` action.
+* `Similar.minpoly_eq'`, `minpolyOfSimilarityClass` — the corollary that `minpoly` is
+  well-defined on the similarity setoid (it descends to the quotient by `Similar`).
+* `notSimilar_zero_stdNilpotent`, `charpoly_zero_eq_stdNilpotent` — a worked **separating
+  example** over a field: the `2 × 2` zero matrix and the single nilpotent Jordan block
+  `!![0,1;0,0]` share the characteristic polynomial `X ^ 2` yet have *different* minimal
+  polynomials (`X` versus a non-`X` polynomial), so they are **not similar**.  This both
+  certifies that `minpoly` is strictly finer than `charpoly` and shows the new invariant
+  doing real work as a non-similarity certificate via the contrapositive of
+  `Similar.minpoly_eq`.
+
+Mathlib has `minpoly.algEquiv_eq` (invariance of `minpoly` under any algebra equivalence)
+and the conjugation `AlgEquiv` (`MulSemiringAction.toAlgEquiv` for `ConjAct`) separately, but
+states **no** theorem that similar matrices share a minimal polynomial.  This leaf supplies
+exactly that bridge in the parent's `Similar` vocabulary.  Absent from Mathlib.
+-/
+
+namespace MatrixSimilarityInvariantsOQ01OQ02
+
+open Matrix Polynomial
+
+variable {n : Type*} [Fintype n] [DecidableEq n] {R : Type*} [CommRing R]
+
+/-- Two square matrices are **similar** if one is a conjugate of the other by an invertible
+matrix: `B = P * A * P⁻¹`.  (Same relation as the parent entry.) -/
+def Similar (A B : Matrix n n R) : Prop :=
+  ∃ P : (Matrix n n R)ˣ, B = P.val * A * P⁻¹.val
+
+@[refl]
+theorem Similar.refl (A : Matrix n n R) : Similar A A :=
+  ⟨1, by simp⟩
+
+theorem Similar.symm {A B : Matrix n n R} (h : Similar A B) : Similar B A := by
+  obtain ⟨P, rfl⟩ := h
+  refine ⟨P⁻¹, ?_⟩
+  simp [mul_assoc]
+
+theorem Similar.trans {A B C : Matrix n n R} (hab : Similar A B) (hbc : Similar B C) :
+    Similar A C := by
+  obtain ⟨P, rfl⟩ := hab
+  obtain ⟨Q, rfl⟩ := hbc
+  refine ⟨Q * P, ?_⟩
+  simp [Units.val_mul, mul_assoc, _root_.mul_inv_rev]
+
+/-- Similarity is an equivalence relation on square matrices. -/
+theorem similar_equivalence : Equivalence (Similar (n := n) (R := R)) :=
+  ⟨Similar.refl, Similar.symm, Similar.trans⟩
+
+/-- The setoid of square matrices up to similarity. -/
+def similarSetoid : Setoid (Matrix n n R) :=
+  ⟨Similar, similar_equivalence⟩
+
+/-!
+## The minimal polynomial is a similarity invariant
+
+The engine is `minpoly.algEquiv_eq`: the minimal polynomial is invariant under any algebra
+equivalence.  Conjugation by an invertible matrix `P` is such an equivalence — the image of
+`A` under the `ConjAct (Matrix n n R)ˣ` algebra action — so `minpoly R (P A P⁻¹) = minpoly R A`.
+-/
+
+/-- Conjugation by an invertible matrix `P`, packaged as the algebra automorphism
+`MulSemiringAction.toAlgEquiv` of the `ConjAct (Matrix n n R)ˣ` action, sends `A` to
+`P * A * P⁻¹`. -/
+theorem conj_algEquiv_apply (P : (Matrix n n R)ˣ) (A : Matrix n n R) :
+    (MulSemiringAction.toAlgEquiv R (Matrix n n R) (ConjAct.toConjAct P)) A
+      = P.val * A * P⁻¹.val := by
+  rw [MulSemiringAction.toAlgEquiv_apply, ConjAct.units_smul_def]
+  simp
+
+/-- **The minimal polynomial is a similarity invariant.**  If `B = P A P⁻¹` then
+`minpoly R B = minpoly R A`, over any commutative ring `R`. -/
+theorem Similar.minpoly_eq {A B : Matrix n n R} (h : Similar A B) :
+    minpoly R B = minpoly R A := by
+  obtain ⟨P, rfl⟩ := h
+  rw [← conj_algEquiv_apply P A, minpoly.algEquiv_eq]
+
+/-- Symmetric restatement: the minimal polynomial of the two matrices in a similarity
+agrees, oriented as a well-definedness statement. -/
+theorem Similar.minpoly_eq' {A B : Matrix n n R} (h : Similar A B) :
+    minpoly R A = minpoly R B :=
+  (h.minpoly_eq).symm
+
+/-- The minimal polynomial **descends to the similarity setoid**: it is a well-defined
+function on similarity classes of square matrices. -/
+noncomputable def minpolyOfSimilarityClass :
+    Quotient (similarSetoid (n := n) (R := R)) → R[X] :=
+  Quotient.lift (fun A => minpoly R A) fun _ _ h => (Similar.minpoly_eq h).symm
+
+@[simp]
+theorem minpolyOfSimilarityClass_mk (A : Matrix n n R) :
+    minpolyOfSimilarityClass (Quotient.mk (similarSetoid) A) = minpoly R A :=
+  rfl
+
+/-!
+## A separating example: `minpoly` is strictly finer than `charpoly`
+
+Over any field `F`, the `2 × 2` zero matrix and the single nilpotent Jordan block
+`!![0,1;0,0]` have the **same** characteristic polynomial `X ^ 2` but **different** minimal
+polynomials — so the minimal polynomial detects a non-similarity that the characteristic
+polynomial cannot.  This exhibits `minpoly` as a strictly finer invariant and uses
+`Similar.minpoly_eq` contrapositively as a non-similarity certificate.
+-/
+
+section Separating
+
+variable {F : Type*} [Field F]
+
+/-- The single nilpotent `2 × 2` Jordan block `!![0,1;0,0]`. -/
+def stdNilpotent : Matrix (Fin 2) (Fin 2) F := !![0, 1; 0, 0]
+
+theorem stdNilpotent_ne_zero : (stdNilpotent : Matrix (Fin 2) (Fin 2) F) ≠ 0 := by
+  intro h
+  have h01 : (stdNilpotent : Matrix (Fin 2) (Fin 2) F) 0 1 = 1 := by simp [stdNilpotent]
+  rw [h] at h01
+  simp at h01
+
+/-- The zero matrix and the nilpotent block share the characteristic polynomial `X ^ 2`. -/
+theorem charpoly_zero_eq_stdNilpotent :
+    (0 : Matrix (Fin 2) (Fin 2) F).charpoly
+      = (stdNilpotent : Matrix (Fin 2) (Fin 2) F).charpoly := by
+  rw [Matrix.charpoly_fin_two, Matrix.charpoly_fin_two]
+  simp [stdNilpotent, Matrix.trace_fin_two, Matrix.det_fin_two]
+
+/-- The minimal polynomial of the zero matrix is `X`. -/
+theorem minpoly_zero_matrix :
+    minpoly F (0 : Matrix (Fin 2) (Fin 2) F) = X :=
+  minpoly.zero F (Matrix (Fin 2) (Fin 2) F)
+
+/-- The minimal polynomial of the nilpotent block is **not** `X` (it is annihilated only by
+a higher-degree polynomial, since the block itself is nonzero). -/
+theorem minpoly_stdNilpotent_ne_X :
+    minpoly F (stdNilpotent : Matrix (Fin 2) (Fin 2) F) ≠ X := by
+  intro hX
+  have hae := minpoly.aeval F (stdNilpotent : Matrix (Fin 2) (Fin 2) F)
+  rw [hX] at hae
+  rw [aeval_X] at hae
+  exact stdNilpotent_ne_zero hae
+
+/-- The two matrices have **different** minimal polynomials. -/
+theorem minpoly_zero_ne_stdNilpotent :
+    minpoly F (0 : Matrix (Fin 2) (Fin 2) F)
+      ≠ minpoly F (stdNilpotent : Matrix (Fin 2) (Fin 2) F) := by
+  rw [minpoly_zero_matrix]
+  exact fun h => minpoly_stdNilpotent_ne_X h.symm
+
+/-- **Non-similarity certificate.**  The zero matrix and the nilpotent block `!![0,1;0,0]`
+are *not similar*, even though they share the characteristic polynomial `X ^ 2`: their
+minimal polynomials differ, so `Similar.minpoly_eq` rules out a similarity.  This is the
+classical witness that the minimal polynomial is a strictly finer similarity invariant than
+the characteristic polynomial. -/
+theorem notSimilar_zero_stdNilpotent :
+    ¬ Similar (0 : Matrix (Fin 2) (Fin 2) F) stdNilpotent := by
+  intro h
+  exact minpoly_zero_ne_stdNilpotent (h.minpoly_eq).symm
+
+end Separating
+
+end MatrixSimilarityInvariantsOQ01OQ02

--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-similar-def",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 70 },
+    "type": "definition",
+    "title": "The Similarity Relation and Setoid",
+    "content": "Reuses the `Similar A B := ∃ P : (Matrix n n R)ˣ, B = P·A·P⁻¹` relation from the companion entry [oq-01], phrasing the conjugator P as a unit of the matrix ring so that `P⁻¹` is available definitionally. Reflexivity, symmetry, and transitivity package it as `similarSetoid`, the quotient by which the minimal polynomial will be shown to be well-defined.",
+    "mathContext": "$A \\sim B \\iff \\exists\\,P \\in (\\mathrm{Mat}_n(R))^\\times,\\ B = P A P^{-1}$ — an equivalence relation on square matrices.",
+    "significance": "supporting",
+    "relatedConcepts": ["matrix similarity", "conjugation", "change of basis", "setoid / quotient"],
+    "prerequisites": ["matrices over a commutative ring", "invertible matrices", "equivalence relations"]
+  },
+  {
+    "id": "ann-conj-algequiv",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 80, "endLine": 89 },
+    "type": "insight",
+    "title": "Conjugation Is an Algebra Automorphism",
+    "content": "The conceptual heart of the proof: conjugation X ↦ P·X·P⁻¹ by an invertible matrix preserves sums, products, scalars, and the identity, hence is an algebra automorphism of the matrix ring. Mathlib provides this automorphism abstractly as `MulSemiringAction.toAlgEquiv R (Matrix n n R) (ConjAct.toConjAct P)` for the `ConjAct (Matrix n n R)ˣ` conjugation action. `conj_algEquiv_apply` is the plumbing lemma that unfolds this abstract automorphism (via `ConjAct.units_smul_def`) to the parent's concrete normal form P·A·P⁻¹, bridging the two vocabularies — the only genuine friction in the whole argument.",
+    "mathContext": "$\\mathrm{conj}_P : X \\mapsto P X P^{-1}$ is an $R$-algebra automorphism of $\\mathrm{Mat}_n(R)$; realized as $\\mathrm{toAlgEquiv}(\\mathrm{ConjAct}\\,P)$ with $\\mathrm{toAlgEquiv}(\\mathrm{ConjAct}\\,P)\\,A = P A P^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": ["algebra automorphism", "AlgEquiv", "conjugation action", "ConjAct", "MulSemiringAction"],
+    "prerequisites": ["algebra homomorphisms and equivalences", "group actions by automorphisms"]
+  },
+  {
+    "id": "ann-minpoly-eq",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 96 },
+    "type": "theorem",
+    "title": "The Minimal Polynomial Is a Similarity Invariant",
+    "content": "The headline result, absent from Mathlib: if B = P·A·P⁻¹ then `minpoly R B = minpoly R A`, over any commutative ring R. The proof is two lines — rewrite B as the image of A under the conjugation automorphism f (`conj_algEquiv_apply`), then apply `minpoly.algEquiv_eq f A`, which says the minimal polynomial is invariant under every algebra equivalence. No field hypothesis, no characteristic polynomial, no eigenvalues: the invariance is purely structural. Concretely, if p(A) = 0 then p(B) = p(P A P⁻¹) = P·p(A)·P⁻¹ = 0, so A and B satisfy exactly the same polynomials and hence have the same minimal one.",
+    "mathContext": "$B = P A P^{-1} \\implies \\operatorname{minpoly}_R(B) = \\operatorname{minpoly}_R(A)$, via $\\operatorname{minpoly}(f\\,A) = \\operatorname{minpoly}(A)$ for the conjugation automorphism $f$.",
+    "significance": "critical",
+    "relatedConcepts": ["minimal polynomial", "similarity invariant", "algebra equivalence invariance"],
+    "prerequisites": ["minimal polynomial of an algebra element", "invariance of minpoly under AlgEquiv"]
+  },
+  {
+    "id": "ann-setoid-descent",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "definition",
+    "title": "minpoly Descends to the Similarity Setoid",
+    "content": "`minpolyOfSimilarityClass` lifts the minimal polynomial through `Quotient.lift` to a well-defined function on similarity classes — the formal statement that minpoly is an invariant of the class, not merely of a representative. The well-definedness obligation is discharged by `Similar.minpoly_eq`.",
+    "mathContext": "$\\overline{\\operatorname{minpoly}} : \\mathrm{Mat}_n(R)/{\\sim}\\ \\to R[X]$, $[A] \\mapsto \\operatorname{minpoly}_R(A)$, well-defined.",
+    "significance": "supporting",
+    "relatedConcepts": ["quotient by an equivalence relation", "well-definedness", "invariant of a class"],
+    "prerequisites": ["setoids and quotients", "Quotient.lift"]
+  },
+  {
+    "id": "ann-charpoly-same",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 137, "endLine": 142 },
+    "type": "insight",
+    "title": "Same Characteristic Polynomial",
+    "content": "The separating example begins by showing the 2×2 zero matrix and the nilpotent Jordan block N = !![0,1;0,0] have the *same* characteristic polynomial X². For the zero matrix this is `charpoly_zero` (X^card = X²); for N, `Matrix.charpoly_fin_two` gives X² − C(trace N)·X + C(det N) = X² since N has trace 0 and det 0. So the characteristic polynomial cannot tell these two matrices apart — the setup for demonstrating that the minimal polynomial can.",
+    "mathContext": "$\\operatorname{charpoly}(0) = \\operatorname{charpoly}(N) = X^2$, with $N = \\bigl(\\begin{smallmatrix}0&1\\\\0&0\\end{smallmatrix}\\bigr)$, $\\operatorname{tr} N = \\det N = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic polynomial", "nilpotent matrix", "Jordan block", "trace", "determinant"],
+    "prerequisites": ["characteristic polynomial of a 2×2 matrix"]
+  },
+  {
+    "id": "ann-not-similar",
+    "proofId": "matrix-similarity-invariants-oq-01-oq-02",
+    "range": { "startLine": 150, "endLine": 177 },
+    "type": "theorem",
+    "title": "Non-Similarity Certificate: minpoly Strictly Finer Than charpoly",
+    "content": "The payoff: although 0 and N share the characteristic polynomial X², their minimal polynomials differ — `minpoly.zero` gives minpoly(0) = X, while `minpoly_stdNilpotent_ne_X` shows minpoly(N) ≠ X (else N, which equals aeval N at the polynomial X, would be zero, contradicting N ≠ 0). By the contrapositive of `Similar.minpoly_eq`, two matrices with different minimal polynomials cannot be similar, so `notSimilar_zero_stdNilpotent` certifies 0 ≁ N. This exhibits the minimal polynomial as a strictly finer similarity invariant than the characteristic polynomial and shows the invariant doing real classifying work — ruling out *every* conjugator P at once by comparing a basis-independent quantity, without exhibiting any explicit P.",
+    "mathContext": "$\\operatorname{minpoly}(0)=X \\neq \\operatorname{minpoly}(N)$ while $\\operatorname{charpoly}(0)=\\operatorname{charpoly}(N)=X^2$, hence $0 \\not\\sim N$.",
+    "significance": "critical",
+    "relatedConcepts": ["non-similarity certificate", "minimal vs characteristic polynomial", "nilpotent matrix", "finer invariant"],
+    "prerequisites": ["minimal polynomial", "the defining annihilation property minpoly.aeval", "contrapositive reasoning"]
+  }
+]

--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-02/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-02/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "matrix-similarity-invariants-oq-01-oq-02",
+  "title": "The Minimal Polynomial Is a Similarity Invariant",
+  "slug": "matrix-similarity-invariants-oq-01-oq-02",
+  "description": "Extends the classical similarity invariants (determinant, trace, characteristic polynomial) with the minimal polynomial: similar matrices B = P·A·P⁻¹ have equal minimal polynomials over any commutative ring. Conjugation by an invertible matrix is realized as the algebra automorphism MulSemiringAction.toAlgEquiv of the ConjAct (Matrix n n R)ˣ action, and minpoly.algEquiv_eq gives the invariance in two lines. The minimal polynomial descends to the similarity setoid. A worked separating example over a field — the 2×2 zero matrix vs. the nilpotent Jordan block !![0,1;0,0] — shares the characteristic polynomial X² but has a different minimal polynomial, so the two are NOT similar: minpoly is a strictly finer invariant than charpoly, used here contrapositively as a non-similarity certificate. Mathlib has minpoly.algEquiv_eq and the conjugation AlgEquiv separately but states no theorem that similar matrices share a minimal polynomial.",
+  "meta": {
+    "author": "classical linear algebra; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MatrixSimilarityInvariantsOQ01OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "similarity",
+      "minimal-polynomial",
+      "characteristic-polynomial",
+      "canonical-forms",
+      "invariants",
+      "nilpotent"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "minpoly.algEquiv_eq",
+        "description": "minpoly A (f x) = minpoly A x for any algebra equivalence f — the minimal polynomial is invariant under algebra isomorphisms; the engine of the proof",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "MulSemiringAction.toAlgEquiv",
+        "description": "Each element of a group acting by ring/algebra automorphisms gives an A ≃ₐ[R] A; instantiated with ConjAct (Matrix n n R)ˣ to realize conjugation X ↦ P·X·P⁻¹ as an algebra automorphism",
+        "module": "Mathlib.Algebra.Algebra.Equiv"
+      },
+      {
+        "theorem": "ConjAct.units_smul_def",
+        "description": "(g • h) = ofConjAct g · h · (ofConjAct g)⁻¹ for the ConjAct Mˣ action — unfolds the conjugation smul into the parent's P·A·P⁻¹ form",
+        "module": "Mathlib.GroupTheory.GroupAction.ConjAct"
+      },
+      {
+        "theorem": "Matrix.charpoly_fin_two",
+        "description": "charpoly of a 2×2 matrix M is X² − C(trace M)·X + C(det M); used to compute the shared characteristic polynomial X² of the separating example",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      },
+      {
+        "theorem": "minpoly.zero",
+        "description": "minpoly A (0 : B) = X over a field A with B a nontrivial algebra — gives minpoly of the zero matrix in the separating example",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      },
+      {
+        "theorem": "minpoly.aeval",
+        "description": "aeval x (minpoly R x) = 0 — the defining annihilation property, used to show the nilpotent block's minimal polynomial cannot be X (since the block is nonzero)",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Similar.minpoly_eq: the minimal polynomial is a similarity invariant over any commutative ring — the bridge Mathlib does not state, realizing conjugation as MulSemiringAction.toAlgEquiv of the ConjAct units action and applying minpoly.algEquiv_eq",
+      "conj_algEquiv_apply: identifies the abstract ConjAct algebra automorphism applied to A with the parent's concrete conjugate P·A·P⁻¹, the plumbing lemma joining the two vocabularies",
+      "minpolyOfSimilarityClass: the minimal polynomial descends to a well-defined function on the similarity setoid Quotient",
+      "notSimilar_zero_stdNilpotent: a non-similarity certificate — the 2×2 zero matrix and the nilpotent Jordan block !![0,1;0,0] are not similar, proved contrapositively from Similar.minpoly_eq",
+      "charpoly_zero_eq_stdNilpotent: both matrices share the characteristic polynomial X², so charpoly alone cannot distinguish them — exhibiting minpoly as a strictly finer invariant",
+      "minpoly_stdNilpotent_ne_X: the nilpotent block's minimal polynomial differs from X (the zero matrix's), the key inequality powering the non-similarity certificate"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms on Similar.minpoly_eq, notSimilar_zero_stdNilpotent, and minpolyOfSimilarityClass). The invariance theorem holds over an arbitrary commutative ring; the separating example is stated over a field (where minpoly.zero applies).",
+    "lineCount": 177,
+    "theoremCount": 14,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Among the invariants of a similarity class B = P·A·P⁻¹, the minimal polynomial occupies a special place: it is the finest of the polynomial invariants, strictly refining the characteristic polynomial. Two matrices can share a characteristic polynomial yet differ in minimal polynomial — the 2×2 zero matrix and a single nilpotent Jordan block both have characteristic polynomial X², but minimal polynomials X and X² — so the minimal polynomial detects the Jordan-block structure that the characteristic polynomial blurs. It is the central object of canonical-form theory: it controls diagonalizability (over a field, a matrix is diagonalizable iff its minimal polynomial is squarefree and splits) and the size of the largest Jordan block of each eigenvalue.",
+    "problemStatement": "Do similar matrices B = P·A·P⁻¹ have the same minimal polynomial, and is this invariant strictly finer than the characteristic polynomial?\n\n**Answer:** yes on both counts. The minimal polynomial is a similarity invariant over any commutative ring, and the 2×2 zero matrix and the nilpotent block !![0,1;0,0] — equal characteristic polynomial X², different minimal polynomial — are not similar, witnessing the strict refinement.",
+    "text": "Similar matrices share their minimal polynomial; since two matrices can agree on charpoly but differ on minpoly, the minimal polynomial is a strictly finer similarity invariant.",
+    "proofStrategy": "Reuse the Similar relation B = P·A·P⁻¹ from the companion entry [oq-01]. The proof is conceptual: conjugation by an invertible matrix P is an algebra automorphism of the matrix ring. Realize it as f := MulSemiringAction.toAlgEquiv R (Matrix n n R) (ConjAct.toConjAct P); the lemma conj_algEquiv_apply unfolds f A (via ConjAct.units_smul_def) to the parent's concrete P·A·P⁻¹. Then minpoly.algEquiv_eq f A gives minpoly R (f A) = minpoly R A, i.e. minpoly R B = minpoly R A. Well-definedness on the similarity setoid follows by Quotient.lift. For the separating example over a field: charpoly_fin_two computes both characteristic polynomials as X² (the nilpotent block has trace 0 and det 0); minpoly.zero gives minpoly of the zero matrix as X, while minpoly.aeval forces the nilpotent block's minimal polynomial to differ from X (else the block, equal to aeval at X, would be zero). The contrapositive of Similar.minpoly_eq then certifies the two matrices are not similar.",
+    "keyInsights": [
+      "Invariance of minpoly is not a computation but a structural fact: conjugation is an algebra automorphism, and minpoly is preserved by every algebra equivalence (minpoly.algEquiv_eq) — so no field hypothesis, no charpoly, no eigenvalues are needed, and the result holds over any commutative ring",
+      "The only real work is vocabulary plumbing: the parent's Similar uses a concrete unit P with B = P·A·P⁻¹, while Mathlib's automorphism lives in the ConjAct units action; conj_algEquiv_apply is the one lemma bridging ConjAct.toConjAct P • A and P·A·P⁻¹",
+      "The minimal polynomial is a strictly finer invariant than the characteristic polynomial: the zero matrix and a nilpotent block agree on charpoly (X²) but not on minpoly, so charpoly cannot separate similarity classes that minpoly can",
+      "The separating example doubles as a non-similarity certificate: rather than exhibiting an explicit P, one rules out every P at once by comparing a basis-independent invariant — the contrapositive of Similar.minpoly_eq turns 'different minpoly' into 'provably not similar'",
+      "Distinguishing the two minimal polynomials needs no full computation of minpoly for the nilpotent block: it suffices that it is not X, which follows immediately from minpoly.aeval because the block itself is nonzero"
+    ],
+    "prerequisites": [
+      "Matrices over a commutative ring; the unit (invertible-matrix) group and conjugation",
+      "The minimal polynomial of an element of an algebra, and its defining annihilation property",
+      "Algebra automorphisms and the invariance of minpoly under algebra equivalences",
+      "The characteristic polynomial of a 2×2 matrix; nilpotent matrices and Jordan blocks"
+    ]
+  },
+  "sections": [
+    {
+      "id": "relation",
+      "title": "The Similarity Relation",
+      "startLine": 43,
+      "endLine": 70,
+      "summary": "Similar A B := ∃ P : (Matrix n n R)ˣ, B = P·A·P⁻¹, packaged as an equivalence relation and the similarity setoid (the same relation as the companion entry [oq-01]).",
+      "mathContext": "$A \\sim B \\iff \\exists P,\\ B = P A P^{-1}$."
+    },
+    {
+      "id": "conjugation-automorphism",
+      "title": "Conjugation as an Algebra Automorphism",
+      "startLine": 72,
+      "endLine": 89,
+      "summary": "conj_algEquiv_apply identifies MulSemiringAction.toAlgEquiv of ConjAct.toConjAct P applied to A with the concrete conjugate P·A·P⁻¹, unfolding the ConjAct units smul.",
+      "mathContext": "$\\mathrm{toAlgEquiv}(\\mathrm{ConjAct}\\,P)\\,A = P A P^{-1}$."
+    },
+    {
+      "id": "minpoly-invariant",
+      "title": "The Minimal Polynomial Is a Similarity Invariant",
+      "startLine": 90,
+      "endLine": 115,
+      "summary": "Similar.minpoly_eq composes conj_algEquiv_apply with minpoly.algEquiv_eq; minpolyOfSimilarityClass lifts minpoly to the similarity setoid.",
+      "mathContext": "$A \\sim B \\Rightarrow \\operatorname{minpoly}_R B = \\operatorname{minpoly}_R A$."
+    },
+    {
+      "id": "separating-example",
+      "title": "minpoly Is Strictly Finer Than charpoly",
+      "startLine": 116,
+      "endLine": 177,
+      "summary": "Over a field, the zero matrix and the nilpotent block !![0,1;0,0] share charpoly X² but have different minpoly (X vs. not-X), so notSimilar_zero_stdNilpotent certifies they are not similar via the contrapositive of Similar.minpoly_eq.",
+      "mathContext": "$\\operatorname{charpoly}(0)=\\operatorname{charpoly}(N)=X^2,\\ \\operatorname{minpoly}(0)=X\\neq\\operatorname{minpoly}(N)\\Rightarrow 0\\not\\sim N$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Horn, R. A.; Johnson, C. R.",
+      "title": "Matrix Analysis (2nd ed.)",
+      "year": "2013",
+      "note": "§3.3: the minimal polynomial and similarity; minpoly as a finer invariant than charpoly"
+    },
+    {
+      "authors": "Jacobson, N.",
+      "title": "Basic Algebra I",
+      "year": "1985",
+      "note": "Ch. 3: minimal polynomial, rational canonical form, invariant factors"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "matrix-similarity-invariants-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: determinant, trace, and characteristic polynomial as similarity invariants; defines the Similar relation reused here. This entry adds the minimal polynomial, a strictly finer polynomial invariant than the characteristic polynomial."
+    },
+    {
+      "targetId": "matrix-similarity-invariants-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Companion leaf adding the structural invariants (rank, nullity, invertibility) over the same Similar relation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The minimal polynomial is shown to be a similarity invariant over any commutative ring, by realizing conjugation as an algebra automorphism (MulSemiringAction.toAlgEquiv of the ConjAct units action) and invoking minpoly.algEquiv_eq, with the invariant descending to the similarity setoid. A worked example over a field — the zero matrix vs. the nilpotent block !![0,1;0,0], equal charpoly X² but unequal minpoly — certifies their non-similarity and exhibits minpoly as strictly finer than charpoly. Verified with 0 axioms.",
+    "implications": "Completes the polynomial side of the similarity-invariants interface begun in [oq-01]: det ⊂ trace ⊂ charpoly ⊂ minpoly, with minpoly the finest. This is the natural foundational lemma for any subsequent formalization of rational or Jordan canonical form, where the invariants must depend only on the similarity class, and the non-similarity certificate shows the invariant doing real classifying work.",
+    "openQuestions": [
+      "Can the nilpotent block's minimal polynomial be computed exactly as X² (via minpoly ∣ charpoly and the degree-2 lower bound) to strengthen the separating example from 'different' to a fully explicit pair X vs. X²?",
+      "Does conjugation transport the whole invariant-factor decomposition, giving Similar A B → the Smith normal forms of the characteristic matrices agree, not merely the minimal polynomial?",
+      "Over a field, can Similar.minpoly_eq be combined with the diagonalizability criterion (squarefree split minpoly) to show diagonalizability is itself a similarity invariant?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "MatrixSimilarityInvariantsOQ01OQ02",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 4,
+    "path": "Proofs/MatrixSimilarityInvariantsOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the parent entry's classical similarity invariants (determinant, trace, characteristic polynomial) with the **minimal polynomial** — a strictly *finer* invariant.

**Main theorem** `Similar.minpoly_eq`: if $B = P A P^{-1}$ then $\operatorname{minpoly}_R B = \operatorname{minpoly}_R A$, over **any commutative ring** $R$. The proof realizes conjugation as the algebra automorphism `MulSemiringAction.toAlgEquiv` of the `ConjAct (Matrix n n R)ˣ` action and applies `minpoly.algEquiv_eq`. The plumbing lemma `conj_algEquiv_apply` bridges the abstract `ConjAct` automorphism and the parent's concrete `P·A·P⁻¹` form.

**Setoid descent** `minpolyOfSimilarityClass`: the minimal polynomial is a well-defined function on similarity classes (`Quotient.lift`).

**Separating example** (over a field): the $2\times2$ zero matrix and the nilpotent Jordan block `!![0,1;0,0]` share the characteristic polynomial $X^2$ (`charpoly_zero_eq_stdNilpotent`) but have **different** minimal polynomials ($X$ vs. not-$X$), so `notSimilar_zero_stdNilpotent` certifies they are **not similar** via the contrapositive of `Similar.minpoly_eq`. This shows `minpoly` is strictly finer than `charpoly` and doing real classifying work.

## Verification

- ✅ Builds clean against Mathlib 4.26.0 (`lake env lean`)
- ✅ 0 sorries, 0 `axiom` declarations
- ✅ `#print axioms` on the main results shows only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom**, status `verified`
- 14 theorems, 4 definitions, 177 lines

## Originality

Mathlib has `minpoly.algEquiv_eq` and the conjugation `AlgEquiv` separately but states **no** theorem that similar matrices share a minimal polynomial. This leaf supplies that bridge in the parent's `Similar` vocabulary, plus the non-similarity certificate. All Mathlib dependencies are disclosed in `meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)