### PR TITLE
audit: 10 fresh research entries clean (consolidates #29603 + #29617)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -22961,8 +22961,68 @@
       "lastAudited": "2026-06-25T03:13:53Z",
       "result": "clean",
       "issues": []
+    },
+    "bounded-prime-gaps-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-criterion-squares-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-4-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "euler-criterion-squares-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "napoleons-theorem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-reciprocity-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T02:12:18Z"
+  "lastUpdated": "2026-06-25T04:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 10 entries, all CLEAN

Consolidates the two conflicting audit PRs **#29603** (4 entries) and **#29617** (6 entries) into a single mergeable PR rebased on fresh `origin/main`. Both originals went CONFLICTING/DIRTY due to audit-tracker.json drift as other audit PRs merged.

### Entries (all `verified` / `original` / 0-axiom / 0-sorry)
- `bounded-prime-gaps-oq-01-oq-01` — OQ01OQ01 leaf (density as explicit antecedent, honestly scoped; NOT the native_decide-heavy parent)
- `derangements-oq-04`
- `euler-criterion-squares-oq-01-oq-03`
- `hilbert-4-oq-04`
- `descartes-rule-of-signs-oq-01-oq-01-oq-02`
- `euler-criterion-squares-oq-01-oq-01-oq-02`
- `lagrange-four-squares-oq-04-oq-01`
- `napoleons-theorem-oq-03-oq-01`
- `quadratic-reciprocity-oq-03-oq-02` (formerly an untracked phantom; now git-tracked)
- `wilsons-theorem-oq-01-oq-03`

### Verification
Re-grepped all 10 Lean leaf files: every `sorry`/`axiom`/`native_decide` hit is docstring prose, not a real proof gap. meta.json status/badge/axiomCount match the Lean source.

Tracker-only change (+61 lines), no churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)