### PR TITLE
research(cauchy-schwarz-oq-02-oq-05): Riesz representation theorem in L² [verified, 0-axiom, mathlib]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ02OQ05.lean
+++ b/proofs/Proofs/CauchySchwarzOQ02OQ05.lean
@@ -1,0 +1,90 @@
+/-
+# Cauchy–Schwarz OQ-02 (leaf oq-05): the Riesz representation theorem in L²
+
+The parent entry `cauchy-schwarz-oq-02` ("Hölder, L² Theory, and Minkowski") lists,
+as its fifth open question:
+
+> Formalize the Riesz representation theorem in L²: every bounded linear functional
+> on L² is given by inner product with a unique element.
+
+This file answers it. `L² = α →₂[μ] 𝕜` (Mathlib's `Lp 𝕜 2 μ`) is, for `RCLike 𝕜`, a
+complete inner product space, so Mathlib's abstract Fréchet–Riesz representation
+`InnerProductSpace.toDual 𝕜 E : E ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 E` specializes to it. We
+extract from that isometric equivalence the four statements that make up the
+classical L² Riesz theorem:
+
+* `riesz_L2_exists`        — existence of a representing element;
+* `riesz_L2_inner_ext`     — an element of L² is determined by its inner products,
+                              giving uniqueness;
+* `riesz_L2_existsUnique`  — the packaged `∃!` form (the verbatim open question);
+* `riesz_L2_integral`      — the **concrete L² form**: the functional is integration
+                              against the representing element,
+                              `g h = ∫ a, ⟪f a, h a⟫ ∂μ` (via `L2.inner_def`);
+* `riesz_L2_norm`          — the representation is **isometric**, `‖f‖ = ‖g‖`,
+                              because `toDual` is a linear isometry.
+
+The integral form and the isometry are the genuinely L²-specific content beyond the
+abstract Hilbert-space statement. This is the inner-product (Hilbert) route to Riesz,
+complementary to the general-`Lp` duality entries in this tree, which take the harder
+Radon–Nikodým / Hölder route valid for all `p`.
+
+*Reference:* Riesz (1907); see also Mathlib `Mathlib.Analysis.InnerProductSpace.Dual`.
+-/
+
+import Mathlib
+
+open MeasureTheory
+open scoped InnerProductSpace ENNReal
+
+namespace CauchySchwarzOQ02OQ05
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+/- `α →₂[μ] 𝕜` is `MeasureTheory.Lp 𝕜 2 μ`, the space of (a.e.-equivalence classes of)
+square-integrable scalar functions. For `RCLike 𝕜` it is automatically a complete
+inner product space, so all instances below are found by typeclass resolution. -/
+
+/-- **Existence (Fréchet–Riesz in L²).** Every bounded linear functional `g` on `L²`
+is given by inner product with some element `f`: `g h = ⟪f, h⟫` for all `h`.
+The witness is `(InnerProductSpace.toDual 𝕜 _).symm g`. -/
+theorem riesz_L2_exists (g : (α →₂[μ] 𝕜) →L[𝕜] 𝕜) :
+    ∃ f : α →₂[μ] 𝕜, ∀ h : α →₂[μ] 𝕜, g h = ⟪f, h⟫_𝕜 :=
+  ⟨(InnerProductSpace.toDual 𝕜 _).symm g,
+    fun _ => (InnerProductSpace.toDual_symm_apply).symm⟩
+
+/-- **Inner-product extensionality in L².** An element of `L²` is determined by its
+inner products against all of `L²`. This furnishes the uniqueness half of Riesz. -/
+theorem riesz_L2_inner_ext {f₁ f₂ : α →₂[μ] 𝕜}
+    (h : ∀ h : α →₂[μ] 𝕜, ⟪f₁, h⟫_𝕜 = ⟪f₂, h⟫_𝕜) :
+    f₁ = f₂ := by
+  have := ext_inner_right 𝕜 (x := f₁) (y := f₂)
+  exact this h
+
+/-- **Riesz representation theorem in L² (∃! form).** Every bounded linear functional
+on `L²` is inner product with a *unique* element. This is the parent's open question
+verbatim: `∃! f, ∀ h, g h = ⟪f, h⟫`. -/
+theorem riesz_L2_existsUnique (g : (α →₂[μ] 𝕜) →L[𝕜] 𝕜) :
+    ∃! f : α →₂[μ] 𝕜, ∀ h : α →₂[μ] 𝕜, g h = ⟪f, h⟫_𝕜 := by
+  obtain ⟨f, hf⟩ := riesz_L2_exists g
+  refine ⟨f, hf, ?_⟩
+  intro f' hf'
+  exact riesz_L2_inner_ext (fun h => by rw [← hf', ← hf])
+
+/-- **Concrete L² form.** The representing element acts by integration: the functional
+is `g h = ∫ a, ⟪f a, h a⟫ ∂μ`, the L² inner product unfolded pointwise (`L2.inner_def`).
+This is the form in which the Riesz theorem is usually stated for `L²`. -/
+theorem riesz_L2_integral (g : (α →₂[μ] 𝕜) →L[𝕜] 𝕜) :
+    ∃ f : α →₂[μ] 𝕜, ∀ h : α →₂[μ] 𝕜,
+      g h = ∫ a, ⟪f a, h a⟫_𝕜 ∂μ := by
+  obtain ⟨f, hf⟩ := riesz_L2_exists g
+  exact ⟨f, fun h => by rw [hf h, L2.inner_def]⟩
+
+/-- **The representation is isometric.** The representing element has the same norm as
+the functional, `‖f‖ = ‖g‖`, because `InnerProductSpace.toDual` is a linear isometry.
+Equivalently, Riesz identifies `L²` with its dual norm-preservingly. -/
+theorem riesz_L2_norm (g : (α →₂[μ] 𝕜) →L[𝕜] 𝕜) :
+    ‖(InnerProductSpace.toDual 𝕜 (α →₂[μ] 𝕜)).symm g‖ = ‖g‖ :=
+  LinearIsometryEquiv.norm_map _ g
+
+end CauchySchwarzOQ02OQ05

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-05/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "concept",
+    "title": "Riesz in L²: the inner-product route",
+    "content": "Riesz (1907) proved that every continuous linear functional on L² is integration against a fixed L² function — the prototype of (L²)* ≅ L². Because L² is a Hilbert space, the representing element comes for free from the inner product structure (the Fréchet–Riesz argument), with no Radon–Nikodým theorem, unlike the general-Lp case. Mathlib packages this as InnerProductSpace.toDual, an isometric conjugate-linear equivalence E ≃ StrongDual 𝕜 E for any complete inner product space E. This file specializes it to E = L² = α →₂[μ] 𝕜 and records the L²-specific consequences: the integral form and the norm identity."
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 39, "endLine": 49 },
+    "type": "definition",
+    "title": "L² as a complete inner product space",
+    "content": "Variables: a measure μ on a measurable space α and an RCLike scalar field 𝕜 (covering ℝ and ℂ uniformly). Then L² = α →₂[μ] 𝕜 = Lp 𝕜 2 μ is automatically a complete inner product space — MeasureTheory.L2.innerProductSpace supplies the inner product, Lp completeness with Fact (1 ≤ 2) supplies completeness — so InnerProductSpace.toDual applies with no extra hypotheses. Every instance below is found by typeclass resolution."
+  },
+  {
+    "id": "ann-exists",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 50, "endLine": 56 },
+    "type": "theorem",
+    "title": "Existence: the representing element",
+    "content": "riesz_L2_exists: every bounded functional g on L² is g h = ⟪f, h⟫ for some f. The witness is f = (InnerProductSpace.toDual 𝕜 _).symm g, and the defining property is immediate from toDual_symm_apply, which states ⟪(toDual).symm y, x⟫ = y x. No orthogonal-projection bookkeeping is needed at this level — Mathlib's toDual already carries the Fréchet–Riesz construction."
+  },
+  {
+    "id": "ann-inner-ext",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "lemma",
+    "title": "Uniqueness via inner-product extensionality",
+    "content": "riesz_L2_inner_ext: if ⟪f₁, h⟫ = ⟪f₂, h⟫ for all h ∈ L², then f₁ = f₂. This is ext_inner_right — an element of an inner product space is determined by its inner products against everything. It is the uniqueness half of Riesz: two representing elements for the same functional have equal inner products against all h, hence coincide."
+  },
+  {
+    "id": "ann-exists-unique",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 65, "endLine": 75 },
+    "type": "theorem",
+    "title": "The Riesz theorem (∃! form)",
+    "content": "riesz_L2_existsUnique: every bounded linear functional on L² is inner product with a unique element, ∃! f, ∀ h, g h = ⟪f, h⟫. This is the parent's fifth open question verbatim. It combines riesz_L2_exists (existence) with riesz_L2_inner_ext (uniqueness): any other representative f' satisfies ⟪f', h⟫ = g h = ⟪f, h⟫ for all h, so f' = f."
+  },
+  {
+    "id": "ann-integral",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 76, "endLine": 84 },
+    "type": "theorem",
+    "title": "The classical integral form",
+    "content": "riesz_L2_integral: the functional is integration against the representing element, g h = ∫ a, ⟪f a, h a⟫ ∂μ. Starting from g h = ⟪f, h⟫, the L² inner product is unfolded pointwise by L2.inner_def (⟪f, h⟫ = ∫ a, ⟪f a, h a⟫ ∂μ). This recovers Riesz's original 1907 statement — functional = integration against a fixed function — which is the concrete content beyond the abstract Hilbert-space lemma."
+  },
+  {
+    "id": "ann-norm",
+    "proofId": "cauchy-schwarz-oq-02-oq-05",
+    "range": { "startLine": 85, "endLine": 90 },
+    "type": "theorem",
+    "title": "The representation is isometric",
+    "content": "riesz_L2_norm: the representing element has the same norm as the functional, ‖(toDual).symm g‖ = ‖g‖. Mathlib's toDual is a LinearIsometryEquiv, so its inverse preserves norms (LinearIsometryEquiv.norm_map). This is genuine Hilbert (p = 2) content: Riesz identifies L² with its dual norm-preservingly and conjugate-linearly — the foundation for adjoints, the weak topology, and the spectral theorem on L²."
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-05/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-05/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-05",
+  "title": "The Riesz Representation Theorem in L²: every bounded functional is inner product with a unique element",
+  "slug": "cauchy-schwarz-oq-02-oq-05",
+  "description": "Answers the parent's fifth open question verbatim: every bounded linear functional g on L² = Lp 𝕜 2 μ (RCLike 𝕜) is g h = ⟪f, h⟫ for a unique f ∈ L² (riesz_L2_existsUnique). Since L² is a complete inner product space, the result specializes Mathlib's abstract Fréchet–Riesz representation InnerProductSpace.toDual; the witness is (toDual 𝕜 _).symm g and uniqueness is inner-product extensionality (riesz_L2_inner_ext). Beyond the abstract statement, the file gives the concrete L² form g h = ∫ a, ⟪f a, h a⟫ ∂μ (riesz_L2_integral, via L2.inner_def) and shows the representation is isometric, ‖f‖ = ‖g‖ (riesz_L2_norm), since toDual is a linear isometry. This is the inner-product (Hilbert) route to Riesz in L², complementary to the general-Lp duality entries in this tree that use the harder Radon–Nikodým / Hölder route. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ05.lean",
+    "tags": [
+      "functional-analysis",
+      "hilbert-space",
+      "riesz-representation",
+      "L2-space",
+      "inner-product-space",
+      "duality",
+      "measure-theory"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "InnerProductSpace.toDual",
+        "description": "The Fréchet–Riesz representation E ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 E for a complete inner product space E; the headline result, specialized here to E = L² = α →₂[μ] 𝕜",
+        "module": "Mathlib.Analysis.InnerProductSpace.Dual"
+      },
+      {
+        "theorem": "InnerProductSpace.toDual_symm_apply",
+        "description": "⟪(toDual 𝕜 E).symm y, x⟫ = y x; gives the representation g h = ⟪(toDual).symm g, h⟫ directly, supplying the existence witness and its defining property",
+        "module": "Mathlib.Analysis.InnerProductSpace.Dual"
+      },
+      {
+        "theorem": "ext_inner_right",
+        "description": "(∀ w, ⟪x, w⟫ = ⟪y, w⟫) → x = y; inner-product extensionality, used to prove uniqueness of the representing element",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.L2.inner_def",
+        "description": "⟪f, g⟫ = ∫ a, ⟪f a, g a⟫ ∂μ for f, g ∈ L²; unfolds the L² inner product into a pointwise integral, yielding the concrete integral form of Riesz",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      },
+      {
+        "theorem": "LinearIsometryEquiv.norm_map",
+        "description": "‖e x‖ = ‖x‖ for a linear isometry equivalence e; applied to (toDual).symm to show the Riesz representation preserves norms (‖f‖ = ‖g‖)",
+        "module": "Mathlib.Analysis.Normed.Operator.LinearIsometry"
+      },
+      {
+        "theorem": "MeasureTheory.L2.innerProductSpace",
+        "description": "α →₂[μ] E is an inner product space for RCLike 𝕜 and inner-product-space E; with E = 𝕜 it makes L² a complete inner product space so toDual applies",
+        "module": "Mathlib.MeasureTheory.Function.L2Space"
+      }
+    ],
+    "originalContributions": [
+      "riesz_L2_existsUnique: the Riesz representation theorem in L² in ∃! form — every bounded linear functional g on L² is g h = ⟪f, h⟫ for a unique f — assembled by specializing InnerProductSpace.toDual to L² and adding uniqueness. This is the parent open question verbatim.",
+      "riesz_L2_integral: the concrete L² form g h = ∫ a, ⟪f a, h a⟫ ∂μ, obtained by composing the abstract representation with L2.inner_def. This integral statement (functional = integration against the representing element) is the form in which Riesz is classically stated for L² and is not the abstract Hilbert-space lemma.",
+      "riesz_L2_norm: the representation is isometric, ‖(toDual).symm g‖ = ‖g‖, recording that Riesz identifies L² with its dual norm-preservingly — a property of the Hilbert (p=2) case specifically.",
+      "riesz_L2_exists, riesz_L2_inner_ext: the existence and uniqueness halves stated standalone for L²."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound). No native_decide, so no Lean.ofReduceBool dependency. The headline theorem (Fréchet–Riesz representation) is Mathlib's InnerProductSpace.toDual — hence badge 'mathlib'; the contribution is its specialization to L², the integral form, and the isometry. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 90,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Frigyes Riesz proved in 1907 that every continuous linear functional on L²[a,b] is given by integration against a fixed L² function — one of the founding theorems of functional analysis, and the prototype of the duality (L²)* ≅ L². In modern terms it is the special case p = 2 of Lp–Lq duality, but it is far more elementary than the general case: because L² is a Hilbert space, the representing element is produced by orthogonal projection onto the kernel of the functional (the Fréchet–Riesz argument), with no Radon–Nikodým theorem required. Mathlib packages this as InnerProductSpace.toDual, an isometric conjugate-linear equivalence between any complete inner product space and its dual. This entry specializes it to L² = Lp 𝕜 2 μ and records the concrete consequences — the integral representation and the norm identity — that distinguish the L² statement.",
+    "problemStatement": "Formalize the Riesz representation theorem in L²: prove that for any measure μ and RCLike scalar field 𝕜, every bounded linear functional g : (α →₂[μ] 𝕜) →L[𝕜] 𝕜 equals h ↦ ⟪f, h⟫ for a unique f ∈ L², exhibit the integral form g h = ∫ a, ⟪f a, h a⟫ ∂μ, and show ‖f‖ = ‖g‖.",
+    "proofStrategy": "L² = α →₂[μ] 𝕜 is, for RCLike 𝕜, a complete inner product space (MeasureTheory.L2.innerProductSpace together with Lp completeness and Fact (1 ≤ 2)), so Mathlib's Fréchet–Riesz equivalence InnerProductSpace.toDual 𝕜 (α →₂[μ] 𝕜) : L² ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 L² applies with no extra hypotheses. Existence: take f = (toDual).symm g; then toDual_symm_apply gives g h = ⟪f, h⟫ directly. Uniqueness: if ⟪f₁, h⟫ = ⟪f₂, h⟫ for all h then f₁ = f₂ by ext_inner_right (inner-product extensionality). Integral form: rewrite ⟪f, h⟫ with L2.inner_def to get ∫ a, ⟪f a, h a⟫ ∂μ. Isometry: (toDual).symm is a linear isometry equivalence, so LinearIsometryEquiv.norm_map yields ‖f‖ = ‖g‖.",
+    "keyInsights": [
+      "**In L² the representing element is free.** For general Lp the duality (Lp)* ≅ Lq requires the Radon–Nikodým theorem and Hölder's inequality (the route taken by the sibling Lp-Riesz entries). At p = 2 the inner product structure supplies the representing element directly: f = (toDual).symm g, with no measure-theoretic machinery. This is why the Hilbert case is both the oldest and the easiest.",
+      "**toDual is conjugate-linear and isometric, not just a bijection.** Mathlib's InnerProductSpace.toDual is a LinearIsometryEquiv (semilinear for the star ring hom), so the Riesz correspondence automatically preserves norms — ‖f‖ = ‖g‖ — and conjugate-linearly identifies L² with its dual. The norm identity riesz_L2_norm is a one-line consequence (LinearIsometryEquiv.norm_map) but is genuine L²/Hilbert content absent from a bare existence-uniqueness statement.",
+      "**The classical form is the integral form.** Riesz's 1907 statement is that the functional is integration against f: g h = ∫ a, ⟪f a, h a⟫ ∂μ. Mathlib's abstract lemma gives the inner product ⟪f, h⟫; L2.inner_def unfolds it to the pointwise integral, recovering the historically original statement. The bridge from abstract to concrete is exactly L2.inner_def.",
+      "**Uniqueness is inner-product extensionality.** Two L² elements with the same inner products against everything coincide (ext_inner_right). Combined with existence this packages the theorem as a clean ∃!, matching the parent's phrasing 'a unique element'.",
+      "**RCLike covers both ℝ and ℂ uniformly.** Stating everything over an RCLike field 𝕜 gives the real-L² and complex-L² Riesz theorems simultaneously, with the conjugate-linearity handled by Mathlib's star-semilinear toDual."
+    ],
+    "prerequisites": [
+      "Hilbert spaces and the inner product structure of L²",
+      "Bounded (continuous) linear functionals and the dual space",
+      "The Fréchet–Riesz representation theorem",
+      "Mathlib's Lp / L² spaces and the integral form of the L² inner product"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: L² as a complete inner product space",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "File docstring framing the parent open question and the inner-product (Hilbert) route to Riesz. Sets up variables: a measure μ on α and an RCLike scalar field 𝕜, so that L² = α →₂[μ] 𝕜 is automatically a complete inner product space and Mathlib's InnerProductSpace.toDual applies by typeclass resolution.",
+      "mathContext": "L² = Lp 𝕜 2 μ; for RCLike 𝕜 it is a Hilbert space, so (L²)* ≅ L² via the inner product."
+    },
+    {
+      "id": "exists-unique",
+      "title": "Existence and uniqueness of the representing element",
+      "startLine": 50,
+      "endLine": 75,
+      "summary": "riesz_L2_exists produces the witness (toDual 𝕜 _).symm g with g h = ⟪f, h⟫ from toDual_symm_apply. riesz_L2_inner_ext is inner-product extensionality (ext_inner_right): an L² element is determined by its inner products. riesz_L2_existsUnique packages these into the parent's ∃! statement.",
+      "mathContext": "Every bounded functional on L² is inner product with a unique element."
+    },
+    {
+      "id": "integral-norm",
+      "title": "The concrete integral form and the isometry",
+      "startLine": 76,
+      "endLine": 90,
+      "summary": "riesz_L2_integral rewrites ⟪f, h⟫ via L2.inner_def to the classical integral form g h = ∫ a, ⟪f a, h a⟫ ∂μ. riesz_L2_norm records that the representation preserves norms, ‖f‖ = ‖g‖, since toDual is a linear isometry (LinearIsometryEquiv.norm_map).",
+      "mathContext": "Functional = integration against f; the L² ≅ (L²)* identification is isometric."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Riesz, Frigyes",
+      "title": "Sur une espèce de géométrie analytique des systèmes de fonctions sommables",
+      "year": "1907",
+      "note": "C. R. Acad. Sci. Paris 144, 1409–1411. The original representation theorem for continuous functionals on L²."
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Real and Complex Analysis",
+      "year": "1987",
+      "note": "Chapter 4: the Riesz representation theorem for Hilbert spaces and its specialization to L²."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry ('Hölder, L² Theory, and Minkowski'). This leaf answers its fifth open question — formalizing the Riesz representation theorem in L² — verbatim."
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling 'Riesz Representation for Lp Spaces' takes the general-p Radon–Nikodým / Hölder route. This entry is the complementary inner-product route valid only at p = 2, which is far more elementary."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Bessel's inequality for Hilbert spaces; part of the same L²/Hilbert-space circle of ideas underlying the inner-product route to duality."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every bounded linear functional g on L² = α →₂[μ] 𝕜 (RCLike 𝕜) is given by inner product with a unique element f, g h = ⟪f, h⟫ (riesz_L2_existsUnique), equivalently by integration g h = ∫ a, ⟪f a, h a⟫ ∂μ (riesz_L2_integral), and the correspondence is isometric, ‖f‖ = ‖g‖ (riesz_L2_norm). The proof specializes Mathlib's Fréchet–Riesz representation InnerProductSpace.toDual to L², using L2.inner_def for the integral form and the linear-isometry structure of toDual for the norm identity. All five theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Completes the L² duality picture in this tree via the inner-product route, complementary to the harder general-Lp Radon–Nikodým entries. The isometric, conjugate-linear identification (L²)* ≅ L² is the basis for the adjoint of operators on L², the weak topology, and the spectral theorem in the L² setting.",
+    "openQuestions": [
+      "Can the integral form be strengthened to identify f explicitly for concrete functionals (e.g. evaluation-type or convolution functionals)?",
+      "How does this inner-product route relate quantitatively to the general-Lp Radon–Nikodým route at p = 2 (do the representing elements provably coincide)?",
+      "Can the adjoint of a bounded operator on L² be constructed from riesz_L2_existsUnique as the next step?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "InnerProductSpace",
+      "ENNReal"
+    ],
+    "namespace": "CauchySchwarzOQ02OQ05",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02OQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Cauchy–Schwarz OQ-02 (leaf oq-05): the Riesz representation theorem in L²

Answers the parent **`cauchy-schwarz-oq-02`** ("Hölder, L² Theory, and Minkowski") open question #5 **verbatim**:

> Formalize the Riesz representation theorem in L²: every bounded linear functional on L² is given by inner product with a unique element.

Since `L² = α →₂[μ] 𝕜` (Mathlib's `Lp 𝕜 2 μ`) is, for `RCLike 𝕜`, a complete inner product space, this specializes Mathlib's abstract **Fréchet–Riesz** representation `InnerProductSpace.toDual : E ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 E` to it — the inner-product (Hilbert) route, far more elementary than the general-`Lp` Radon–Nikodým route used by sibling entries.

### Results (`proofs/Proofs/CauchySchwarzOQ02OQ05.lean`, 5 theorems / 90 L)

| theorem | statement |
|---|---|
| `riesz_L2_exists` | `∃ f, ∀ h, g h = ⟪f, h⟫` (witness `(toDual 𝕜 _).symm g`) |
| `riesz_L2_inner_ext` | `(∀ h, ⟪f₁,h⟫ = ⟪f₂,h⟫) → f₁ = f₂` (uniqueness) |
| `riesz_L2_existsUnique` | `∃! f, ∀ h, g h = ⟪f, h⟫` — **the open question** |
| `riesz_L2_integral` | `g h = ∫ a, ⟪f a, h a⟫ ∂μ` (concrete integral form, via `L2.inner_def`) |
| `riesz_L2_norm` | `‖(toDual).symm g‖ = ‖g‖` (the representation is isometric) |

### What is the contribution beyond Mathlib?

The **headline** (Fréchet–Riesz) is Mathlib's `InnerProductSpace.toDual`, hence badge **`mathlib`**. The new assembly is the L²-specific content:
- **Integral form** `g h = ∫ a, ⟪f a, h a⟫ ∂μ` — Riesz's original 1907 statement (functional = integration against `f`), obtained by unfolding the inner product with `L2.inner_def`.
- **Isometry** `‖f‖ = ‖g‖` — Riesz identifies L² with its dual norm-preservingly (`toDual` is a `LinearIsometryEquiv`).
- The `∃!` packaging matching the parent's "a unique element".

`RCLike 𝕜` covers real and complex L² uniformly.

### Verification

- **0 axioms, 0 sorries.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide` ⇒ no `Lean.ofReduceBool`.
- Kernel-checked on Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)