### PR TITLE
Enrich Brahmagupta's Samasa Law (x²−N·y²): add annotations

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-07-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-brahmagupta-pell",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 48, "endLine": 55 },
+    "type": "concept",
+    "title": "Brahmagupta's Samasa Law for x² − N·y²",
+    "content": "`brahmagupta_pell` states the real-quadratic composition identity (a²−N·b²)(c²−N·d²) = (ac+N·bd)² − N·(ad+bc)² over an arbitrary `CommRing R`, dispatched in one line by `ring`. This is exactly the multiplicativity of the norm N(x+y√N) = x²−N·y² on the quadratic ring ℤ[√N]: the product of two represented values is again represented, with the composite coordinates given explicitly. Stating it over a general ring makes manifest that the entire Pell theory downstream rests on a purely formal polynomial identity. This is the −N sibling of the parent entry's +N (imaginary-quadratic) law.",
+    "mathContext": "$(a^2 - N b^2)(c^2 - N d^2) = (ac + Nbd)^2 - N(ad + bc)^2$, i.e. $N(z_1)N(z_2) = N(z_1 z_2)$ for $z = x + y\\sqrt{N}$ with $N(z) = x^2 - N y^2$.",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "quadratic ring ℤ[√N]", "Brahmagupta–Fibonacci identity", "composition of quadratic forms"],
+    "prerequisites": ["commutative ring", "polynomial identities", "quadratic number fields"]
+  },
+  {
+    "id": "ann-brahmagupta-pell-conjugate",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "insight",
+    "title": "The Conjugate Sign Variant",
+    "content": "`brahmagupta_pell'` is the conjugate composition (a²−N·b²)(c²−N·d²) = (ac−N·bd)² − N·(ad−bc)², obtained from the principal law by sending d ↦ −d. The two distinct composition laws are exactly why a product of represented values typically admits more than one representation. Algebraically the two variants correspond to multiplying by z₂ versus its conjugate z̄₂ in ℤ[√N]: norm is invariant under conjugation, so both products carry the same norm.",
+    "mathContext": "$(a^2 - N b^2)(c^2 - N d^2) = (ac - Nbd)^2 - N(ad - bc)^2$; the swap $d \\mapsto -d$ corresponds to conjugation $z_2 \\mapsto \\bar z_2$ in $\\mathbb{Z}[\\sqrt N]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjugation in quadratic rings", "multiple representations", "Galois conjugate"],
+    "prerequisites": ["commutative ring", "field conjugation"]
+  },
+  {
+    "id": "ann-normform",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 70, "endLine": 72 },
+    "type": "definition",
+    "title": "The Real-Quadratic Norm Form",
+    "content": "`normForm N x y = x² − N·y²` packages the form as a function on ℤ, the norm of x + y√N in ℤ[√N]. Naming the form lets the multiplicativity be stated as a clean monoid-style composition law rather than a bare polynomial identity, and it is the elementary parameter-explicit shadow of Mathlib's `Zsqrtd.norm`.",
+    "mathContext": "$f_N(x,y) = x^2 - N y^2 = \\mathrm{N}(x + y\\sqrt N)$, the field norm on the real-quadratic ring $\\mathbb{Z}[\\sqrt N]$.",
+    "significance": "technical",
+    "relatedConcepts": ["field norm", "Zsqrtd.norm", "quadratic form"],
+    "prerequisites": ["quadratic forms", "ring of integers"]
+  },
+  {
+    "id": "ann-normform-mul",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 74, "endLine": 81 },
+    "type": "concept",
+    "title": "The Norm Form Is Multiplicative",
+    "content": "`normForm_mul` restates Brahmagupta's identity as N(z₁)·N(z₂) = N(z₁ ⊙ z₂) with the explicit composition ⊙(a,b,c,d) = (ac+N·bd, ad+bc). The proof unfolds `normForm` and closes by `ring`. This exhibits the represented values as the image of a multiplicative map — the elementary, parameter-explicit form of `Zsqrtd.norm_mul`, established here without unfolding Mathlib's `Zsqrtd` machinery.",
+    "mathContext": "$f_N(a,b)\\,f_N(c,d) = f_N(ac+Nbd,\\; ad+bc)$, the multiplicativity of the norm as a monoid homomorphism $\\mathbb{Z}[\\sqrt N]^\\times \\to \\mathbb{Z}^\\times$.",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "monoid homomorphism", "Zsqrtd.norm_mul"],
+    "prerequisites": ["quadratic forms", "monoid homomorphisms"]
+  },
+  {
+    "id": "ann-issolution",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 85, "endLine": 86 },
+    "type": "definition",
+    "title": "Norm-k Solutions",
+    "content": "`IsSolution N k a b` is the predicate a²−N·b² = k, i.e. (a,b) represents k by the form f_N. The general Pell equation is the case k = 1; the negative Pell equation is k = −1. Abstracting the right-hand side to a parameter k is what lets the single law `solution_mul` track the norm value exactly through composition.",
+    "mathContext": "$\\mathrm{IsSolution}\\,N\\,k\\,a\\,b \\iff a^2 - N b^2 = k$; Pell is $k=1$, negative Pell is $k=-1$.",
+    "significance": "technical",
+    "relatedConcepts": ["Pell's equation", "representation by a quadratic form"],
+    "prerequisites": ["Diophantine equations"]
+  },
+  {
+    "id": "ann-solution-mul",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 88, "endLine": 94 },
+    "type": "technique",
+    "title": "The General Multiplicative Law",
+    "content": "`solution_mul` is the master theorem: a norm-k₁ solution and a norm-k₂ solution compose, via Brahmagupta's coordinates, to a norm-(k₁·k₂) solution. The proof unfolds `IsSolution`, rewrites the goal backward through both hypotheses, and closes by `ring`. Every later result — Pell closure, negative-Pell composition, the doubling formula — is a specialization of this one law by fixing k₁, k₂.",
+    "mathContext": "If $a^2 - N b^2 = k_1$ and $c^2 - N d^2 = k_2$, then $(ac+Nbd)^2 - N(ad+bc)^2 = k_1 k_2$ — the norm is a multiplicative map on values.",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "composition of forms", "specialization"],
+    "prerequisites": ["quadratic forms", "Diophantine equations"]
+  },
+  {
+    "id": "ann-pell-closure",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 96, "endLine": 108 },
+    "type": "insight",
+    "title": "Pell Closure and the Monoid Structure",
+    "content": "`pell_sol_mul` is the k₁=k₂=1 case of `solution_mul`: the solutions of x²−N·y²=1 are closed under Brahmagupta composition. Together with `pell_sol_one`, the identity solution (1,0), this makes the Pell solution set a commutative monoid (in fact a group, the unit group of ℤ[√N]). This is the elementary reason a single fundamental solution generates infinitely many — the algebraic heart of Pell's equation — and it is obtained here without invoking Mathlib's `Pell.Solution₁`.",
+    "mathContext": "$\\{(x,y) : x^2 - N y^2 = 1\\}$ is closed under $(a,b)\\cdot(c,d) = (ac+Nbd,\\, ad+bc)$ with identity $(1,0)$ — the unit group of $\\mathbb{Z}[\\sqrt N]$.",
+    "significance": "key",
+    "relatedConcepts": ["Pell's equation", "commutative monoid", "unit group", "fundamental solution", "Pell.Solution₁"],
+    "prerequisites": ["group theory", "Pell's equation", "units of a ring"]
+  },
+  {
+    "id": "ann-neg-pell",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 110, "endLine": 117 },
+    "type": "insight",
+    "title": "Negative-Pell Composition",
+    "content": "`neg_pell_compose` is the k₁=k₂=−1 case: two solutions of the negative Pell equation x²−N·y²=−1 compose to a solution of the positive equation x²−N·y²=1, because (−1)·(−1)=1. Since `solution_mul` tracks the norm value exactly, this falls out with no extra work — a direct manifestation of the sign multiplicativity of the norm.",
+    "mathContext": "$\\mathrm{N}(z) = -1$ and $\\mathrm{N}(w) = -1$ imply $\\mathrm{N}(zw) = (-1)(-1) = 1$; two negative-Pell solutions multiply to a Pell solution.",
+    "significance": "supporting",
+    "relatedConcepts": ["negative Pell equation", "norm sign", "continued fractions"],
+    "prerequisites": ["Pell's equation", "quadratic forms"]
+  },
+  {
+    "id": "ann-doubling",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 119, "endLine": 133 },
+    "type": "technique",
+    "title": "The Doubling Formula",
+    "content": "`pell_square` is the diagonal c=a, d=b of the composition: it sends (a,b) to (a²+N·b², 2ab) and squares the norm, k ↦ k². `pell_square_coords` confirms the doubling coordinates are precisely the diagonal of Brahmagupta's general coordinates. Iterating the doubling map is the explicit mechanism by which one fundamental solution of Pell's equation climbs the solution ladder, generating an infinite family of ever-larger solutions.",
+    "mathContext": "If $a^2 - N b^2 = k$ then $(a^2 + N b^2)^2 - N(2ab)^2 = k^2$ — squaring $z = a + b\\sqrt N$ doubles in the additive sense and squares the norm.",
+    "significance": "key",
+    "relatedConcepts": ["doubling map", "fundamental solution", "iteration", "diagonal of composition"],
+    "prerequisites": ["Pell's equation", "quadratic forms"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "fermat-two-squares-oq-07-oq-01",
+    "range": { "startLine": 135, "endLine": 159 },
+    "type": "context",
+    "title": "Concrete N = 2 Witnesses: (3,2) → (17,12)",
+    "content": "The fundamental solution of x²−2y²=1 is (3,2), since 9−8=1; `three_two_sol` and `seventeen_twelve_sol` confirm both (3,2) and (17,12) by kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool` dependency — the file stays genuinely axiom-free). `three_two_square_is_seventeen_twelve` checks the doubling formula sends (3,2) to exactly (17,12), and `three_two_square_sol` re-derives that (17,12) solves the equation purely from `pell_square` fed `three_two_sol` — the abstract machinery and the concrete arithmetic agreeing on the first rung of the ladder.",
+    "mathContext": "$(3,2)$: $3^2 - 2\\cdot 2^2 = 1$; doubling: $(3^2 + 2\\cdot 2^2,\\, 2\\cdot 3\\cdot 2) = (17,12)$; $17^2 - 2\\cdot 12^2 = 289 - 288 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["fundamental solution", "Pell ladder", "kernel decide", "√2 continued fraction"],
+    "prerequisites": ["Diophantine arithmetic", "decision procedures in Lean"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fermat-two-squares-oq-07-oq-01` (quality 45, pass 0).

## Gap addressed
The entry had a rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage. (Note: `index.ts` is no longer required; the build generates per-proof data from meta.json + annotations.json since #20993.)

## Added
`annotations.json` with **10 substantive annotations** covering the full Lean file (lines 48–159), each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- the samasa identity `brahmagupta_pell` + conjugate variant (conjugation in ℤ[√N])
- `normForm` / `normForm_mul` — norm-multiplicativity as a monoid hom
- `IsSolution` / `solution_mul` — the master multiplicative law
- Pell closure + commutative-monoid (unit-group) structure
- negative-Pell composition ((−1)·(−1)=1)
- the doubling formula (a,b)↦(a²+N·b², 2ab)
- concrete N=2 witnesses (3,2)→(17,12), noting kernel `decide` keeps the file axiom-free

## Verification
- Both JSON files validate
- `pnpm build` succeeds; entry resolves in generated `listings.json`
- Axiom integrity confirmed: status `verified`/`original`/0-axiom matches the Lean source (kernel `decide`, not `native_decide`)