### PR TITLE
research(beta-integral-recurrence-oq-01-oq-03): symmetric Beta density on [0,1] and its real integral [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03.lean
+++ b/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03.lean
@@ -1,0 +1,94 @@
+/-
+# Beta Integral OQ-01 (leaf oq-03): the symmetric Beta density on [0,1] and its real integral
+
+The diagonal Beta value `B(n+1, n+1) = (n!)²/(2n+1)!` is, on the parent and sibling
+entries, established over ℂ via Mathlib's `Complex.betaIntegral` and the Gamma
+relation:
+
+* parent `BetaIntegralRecurrence.betaIntegral_nat_nat`: `B(m+1,n+1) = m!·n!/(m+n+1)!`;
+* sibling `BetaCentralBinomial`: `B(n+1,n+1) = 1/((2n+1)·C(2n,n))`.
+
+This leaf supplies the **real-variable** statement those entries do not give, and the
+probabilistic content it unlocks. We bring `Complex.betaIntegral ((n:ℂ)+1) ((n:ℂ)+1)`
+down to ℝ — its integrand `x^(u-1)(1-x)^(v-1)` is, on the diagonal with `u = v = n+1`
+and `x ∈ [0,1]`, the real polynomial `x^n (1-x)^n` cast into ℂ — to prove:
+
+* `integral_diag_eq_factorial` : `∫ x in 0..1, x^n (1-x)^n = (n!)²/(2n+1)!`
+  (the real Euler integral of the symmetric Beta integrand);
+* `integral_diag_central_binom` : the same integral equals `1/((2n+1)·C(2n,n))`;
+* `betaDensity_integral_eq_one` : the **normalization of the symmetric Beta(n+1,n+1)
+  density** — `∫ x in 0..1, x^n (1-x)^n / B = 1`, where `B = (n!)²/(2n+1)!`, so that
+  `x ↦ x^n(1-x)^n / B` is a probability density on `[0,1]`.
+
+The bridge ℂ → ℝ (`Complex.cpow_natCast` to turn the complex powers into monoid powers,
+then `intervalIntegral.integral_ofReal`) is the new ingredient; the closed-form value is
+reused from the parent. This is the real-analysis / probability face of the diagonal Beta
+value, complementary to the complex `betaIntegral` siblings.
+
+*Reference:* [erdosproblems.com] Beta–Gamma; Mathlib `Mathlib.Analysis.SpecialFunctions.Gamma.Beta`.
+-/
+
+import Proofs.BetaIntegralRecurrence
+import Proofs.BetaCentralBinomial
+import Mathlib.Tactic
+
+open Complex intervalIntegral
+
+namespace BetaIntegralRecurrenceOQ01OQ03
+
+/-- **Bridge to the real line.** The complex diagonal Beta integral is the real integral
+of the symmetric integrand `x^n (1-x)^n`, cast into ℂ. On `[0,1]` the complex powers
+`(x:ℂ)^((n+1)-1)` collapse to monoid powers via `Complex.cpow_natCast`, and the integral
+descends through `ofReal`. -/
+theorem ofReal_integral_diag (n : ℕ) :
+    (((∫ x in (0:ℝ)..1, x ^ n * (1 - x) ^ n) : ℝ) : ℂ)
+      = betaIntegral ((n : ℂ) + 1) ((n : ℂ) + 1) := by
+  rw [betaIntegral, ← intervalIntegral.integral_ofReal]
+  refine intervalIntegral.integral_congr (fun x _ => ?_)
+  have he : ((n : ℂ) + 1) - 1 = (n : ℂ) := by ring
+  rw [he, Complex.cpow_natCast, Complex.cpow_natCast]
+  push_cast
+  ring
+
+/-- **The real Euler integral of the symmetric Beta integrand.**
+`∫₀¹ x^n (1-x)^n dx = (n!)² / (2n+1)!`. -/
+theorem integral_diag_eq_factorial (n : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ n * (1 - x) ^ n
+      = (n.factorial : ℝ) ^ 2 / ((2 * n + 1).factorial : ℝ) := by
+  have h := ofReal_integral_diag n
+  rw [BetaIntegralRecurrence.betaIntegral_nat_nat n n] at h
+  have hrhs :
+      (n.factorial : ℂ) * (n.factorial : ℂ) / ((n + n + 1).factorial : ℂ)
+        = (((n.factorial : ℝ) ^ 2 / ((2 * n + 1).factorial : ℝ)) : ℂ) := by
+    rw [two_mul]; push_cast; ring
+  rw [hrhs] at h
+  exact_mod_cast h
+
+/-- The same real integral as a central-binomial reciprocal:
+`∫₀¹ x^n (1-x)^n dx = 1 / ((2n+1)·C(2n,n))`. -/
+theorem integral_diag_central_binom (n : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ n * (1 - x) ^ n
+      = 1 / ((2 * n + 1) * Nat.choose (2 * n) n : ℝ) := by
+  rw [integral_diag_eq_factorial]
+  -- (2n+1)! = (2n+1)·C(2n,n)·(n!·n!), reusing the sibling's factorial factorization
+  have hfact : ((2 * n + 1).factorial : ℝ)
+      = (2 * n + 1 : ℝ) * (Nat.choose (2 * n) n : ℝ) * ((n.factorial : ℝ) * (n.factorial : ℝ)) := by
+    have h := BetaCentralBinomial.factorial_two_mul_succ n
+    exact_mod_cast congrArg (Nat.cast : ℕ → ℝ) h
+  have hn : (0:ℝ) < (n.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos n
+  rw [hfact]
+  field_simp
+
+/-- **Normalization of the symmetric Beta(n+1, n+1) density on [0,1].**
+With `B = (n!)²/(2n+1)! = ∫₀¹ x^n(1-x)^n dx`, the function `x ↦ x^n(1-x)^n / B`
+integrates to `1`, hence is a probability density on `[0,1]`. -/
+theorem betaDensity_integral_eq_one (n : ℕ) :
+    ∫ x in (0:ℝ)..1,
+        x ^ n * (1 - x) ^ n / ((n.factorial : ℝ) ^ 2 / ((2 * n + 1).factorial : ℝ)) = 1 := by
+  have hn : (0:ℝ) < (n.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos n
+  have hd : (0:ℝ) < ((2 * n + 1).factorial : ℝ) := by exact_mod_cast Nat.factorial_pos _
+  have hB : (0:ℝ) < (n.factorial : ℝ) ^ 2 / ((2 * n + 1).factorial : ℝ) := by positivity
+  rw [intervalIntegral.integral_div, integral_diag_eq_factorial]
+  exact div_self (ne_of_gt hB)
+
+end BetaIntegralRecurrenceOQ01OQ03

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "The real face of the diagonal Beta value",
+    "content": "The diagonal value B(n+1,n+1) = (n!)²/(2n+1)! is, on the parent and sibling entries, proved over ℂ via Mathlib's Complex.betaIntegral and the Gamma relation. This leaf supplies the real-variable statement those entries do not give: the Euler integral ∫₀¹ xⁿ(1-x)ⁿ dx = (n!)²/(2n+1)! and the normalization of the symmetric Beta(n+1,n+1) probability density on [0,1]. The new ingredient is the descent ℂ→ℝ; the closed-form value is reused from the parent."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03",
+    "range": { "startLine": 43, "endLine": 53 },
+    "type": "theorem",
+    "title": "The ℂ → ℝ bridge",
+    "content": "ofReal_integral_diag: ↑(∫ x in 0..1, xⁿ(1-x)ⁿ) = Complex.betaIntegral (n+1) (n+1). Unfolding the definition, the diagonal integrand is (x:ℂ)^((n+1)-1)·(1-x)^((n+1)-1); the exponent (n+1)-1 reduces to n (ring), and Complex.cpow_natCast collapses (x:ℂ)^(n:ℂ) to the monoid power (x:ℂ)^n — valid for all x with no positivity side condition. The integrand is then ↑(xⁿ(1-x)ⁿ), and intervalIntegral.integral_ofReal (applied via integral_congr on [0,1]) descends the integral. This is the key technical step that makes the real integral reachable without redeveloping Beta theory over ℝ."
+  },
+  {
+    "id": "ann-factorial",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 68 },
+    "type": "theorem",
+    "title": "The real Euler integral",
+    "content": "integral_diag_eq_factorial: ∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)!. Rewrite the bridged identity with the parent's betaIntegral_nat_nat n n (= n!·n!/(n+n+1)!), match (n!)²/(2n+1)! by two_mul and push_cast, and transfer the equality from ℂ down to ℝ by injectivity of the cast (exact_mod_cast). This is the real-analysis form of the Wallis-type diagonal Beta value."
+  },
+  {
+    "id": "ann-central-binom",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03",
+    "range": { "startLine": 69, "endLine": 83 },
+    "type": "theorem",
+    "title": "Central-binomial form",
+    "content": "integral_diag_central_binom: ∫₀¹ xⁿ(1-x)ⁿ = 1/((2n+1)·C(2n,n)). The sibling's factorial factorization (2n+1)! = (2n+1)·C(2n,n)·(n!·n!) (factorial_two_mul_succ, cast to ℝ) converts the factorial form into the central-binomial reciprocal; field_simp discharges the rational identity once factorial positivity is supplied."
+  },
+  {
+    "id": "ann-density",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 94 },
+    "type": "theorem",
+    "title": "The Beta density normalizes",
+    "content": "betaDensity_integral_eq_one: ∫ x in 0..1, xⁿ(1-x)ⁿ / B = 1, where B = (n!)²/(2n+1)!. intervalIntegral.integral_div pulls the constant normalizer out of the integral, integral_diag_eq_factorial substitutes the value, and the result is B/B = 1 (B > 0 by Nat.factorial_pos). This is the probabilistic payoff the parent open question asked for: x ↦ xⁿ(1-x)ⁿ/B is a probability density on [0,1] — the symmetric Beta(n+1,n+1) distribution."
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "beta-integral-recurrence-oq-01-oq-03",
+  "title": "The Symmetric Beta Density on [0,1]: the real Euler integral ∫₀¹ xⁿ(1-x)ⁿ dx = (n!)²/(2n+1)! and its normalization",
+  "slug": "beta-integral-recurrence-oq-01-oq-03",
+  "description": "Brings the diagonal Beta value down to the real line. The parent and sibling entries establish B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) over ℂ via Mathlib's Complex.betaIntegral and the Gamma relation. This leaf proves the real-variable Euler integral ∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)! (integral_diag_eq_factorial) by descending the complex betaIntegral to ℝ — its diagonal integrand (x:ℂ)^((n+1)-1)(1-x)^((n+1)-1) collapses to the real polynomial xⁿ(1-x)ⁿ via Complex.cpow_natCast, and the integral passes through intervalIntegral.integral_ofReal. From it: the central-binomial form ∫₀¹ xⁿ(1-x)ⁿ = 1/((2n+1)·C(2n,n)) (reusing the sibling factorial factorization), and the normalization of the symmetric Beta(n+1,n+1) probability density, ∫₀¹ xⁿ(1-x)ⁿ / B = 1 (betaDensity_integral_eq_one). The ℂ→ℝ bridge is the new ingredient; the closed-form value is reused. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralRecurrenceOQ01OQ03.lean",
+    "tags": [
+      "special-functions",
+      "beta-function",
+      "central-binomial",
+      "probability-density",
+      "interval-integral",
+      "wallis",
+      "measure-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.betaIntegral",
+        "description": "B(u,v) = ∫ x:ℝ in 0..1, (x:ℂ)^(u-1)·(1-x)^(v-1); the definition whose diagonal u=v=n+1 integrand is descended to the real polynomial xⁿ(1-x)ⁿ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.cpow_natCast",
+        "description": "z^(n:ℂ) = z^n; collapses the complex powers (x:ℂ)^((n+1)-1) to the monoid power (x:ℂ)^n, the key step turning the complex integrand into a cast real polynomial",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      },
+      {
+        "theorem": "intervalIntegral.integral_ofReal",
+        "description": "∫ x in a..b, (f x : ℂ) = ↑(∫ x in a..b, f x); descends the complex Beta integral to the real integral once the integrand is recognized as a cast real function",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_congr",
+        "description": "EqOn f g [[a,b]] → ∫ f = ∫ g; used to replace the complex integrand by the cast real integrand pointwise on [0,1]",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_div",
+        "description": "∫ x in a..b, f x / r = (∫ f)/r; pulls the density normalizer B out of the integral so the result reduces to B/B = 1",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "BetaIntegralRecurrence.betaIntegral_nat_nat",
+        "description": "Parent: B(m+1,n+1) = m!·n!/(m+n+1)! over ℂ; its m=n diagonal supplies the closed-form value (n!)²/(2n+1)! reused after the ℂ→ℝ bridge",
+        "module": "Proofs.BetaIntegralRecurrence"
+      },
+      {
+        "theorem": "BetaCentralBinomial.factorial_two_mul_succ",
+        "description": "Sibling: (2n+1)! = (2n+1)·C(2n,n)·(n!·n!); converts the factorial form of the real integral into the central-binomial reciprocal form",
+        "module": "Proofs.BetaCentralBinomial"
+      }
+    ],
+    "originalContributions": [
+      "integral_diag_eq_factorial: the real-variable Euler integral ∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)!. The parent/sibling entries only give the ℂ-valued Complex.betaIntegral; this is the real integral of the symmetric polynomial integrand, the form used in real analysis and probability.",
+      "ofReal_integral_diag: the ℂ→ℝ bridge — ↑(∫ x in 0..1, xⁿ(1-x)ⁿ) = Complex.betaIntegral (n+1) (n+1) — proved by collapsing the complex powers (Complex.cpow_natCast) on [0,1] and descending through intervalIntegral.integral_ofReal. This is the new technical ingredient.",
+      "integral_diag_central_binom: the real integral as a central-binomial reciprocal, ∫₀¹ xⁿ(1-x)ⁿ = 1/((2n+1)·C(2n,n)), via the sibling's factorial factorization.",
+      "betaDensity_integral_eq_one: the normalization of the symmetric Beta(n+1,n+1) density on [0,1] — ∫₀¹ xⁿ(1-x)ⁿ / B = 1 with B = (n!)²/(2n+1)! — establishing that x ↦ xⁿ(1-x)ⁿ/B is a probability density, the probabilistic content the parent open question asked to connect."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound). No native_decide, so no Lean.ofReduceBool dependency. Imports the parent BetaIntegralRecurrence and sibling BetaCentralBinomial to reuse the established closed-form value and factorial factorization. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 94,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Euler Beta integral B(u,v) = ∫₀¹ x^(u-1)(1-x)^(v-1) dx is one of the oldest special-function integrals; on the integer diagonal it gives B(n+1,n+1) = (n!)²/(2n+1)!, a Wallis-type value central to probability (the symmetric Beta(n+1,n+1) distribution) and to the asymptotics of the central binomial coefficient. Mathlib develops the Beta function as the ℂ-valued Complex.betaIntegral, and the parent/sibling gallery entries prove the diagonal closed form over ℂ. But the statement most users want — and the one the problem asks to 'connect to the normalization of the symmetric Beta density on [0,1]' — is the real integral ∫₀¹ xⁿ(1-x)ⁿ dx and the fact that dividing the integrand by this value yields a probability density. That real-variable statement is what this entry supplies.",
+    "problemStatement": "Prove the real-variable diagonal Beta integral ∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)), and use it to show the symmetric Beta(n+1,n+1) density xⁿ(1-x)ⁿ/B integrates to 1 on [0,1].",
+    "proofStrategy": "Bridge ℂ→ℝ then reuse the complex value. (1) ofReal_integral_diag: unfold Complex.betaIntegral on the diagonal u=v=n+1; the exponent (n+1)-1 simplifies to n, and Complex.cpow_natCast turns (x:ℂ)^(n:ℂ) into the monoid power (x:ℂ)^n, so the complex integrand equals ↑(xⁿ(1-x)ⁿ); intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral, giving ↑(real integral) = Complex.betaIntegral (n+1)(n+1). (2) integral_diag_eq_factorial: rewrite the right side with the parent's betaIntegral_nat_nat n n (= n!·n!/(n+n+1)!), match (n!)²/(2n+1)! by push_cast/two_mul, and conclude over ℝ by injectivity of the ℝ→ℂ cast (exact_mod_cast). (3) integral_diag_central_binom: apply the sibling's factorial factorization (2n+1)! = (2n+1)·C(2n,n)·(n!·n!) and field_simp. (4) betaDensity_integral_eq_one: pull the constant normalizer B out with intervalIntegral.integral_div, substitute the integral's value, and finish with B/B = 1 (B > 0 by factorial positivity).",
+    "keyInsights": [
+      "**The complex Beta integrand is a cast real polynomial on the diagonal.** For u = v = n+1 the exponents (n+1)-1 are exactly the natural number n, so the cpow `(x:ℂ)^((n+1)-1)` is the ordinary power `(x:ℂ)^n` (Complex.cpow_natCast) — no branch cuts, no positivity side conditions. The whole integrand is `↑(xⁿ(1-x)ⁿ)`, and the integral descends by `integral_ofReal`. This is why the diagonal real integral is reachable without redeveloping the Beta theory over ℝ.",
+      "**Reuse the value, supply the bridge.** The closed form (n!)²/(2n+1)! is already proved over ℂ (parent betaIntegral_nat_nat). The only genuinely new work is the ℂ→ℝ descent; once ↑(real integral) = complex value is established, exact_mod_cast transfers the equality to ℝ. Separating 'bridge' from 'value' keeps the proof short and avoids duplicating the Gamma-based derivation.",
+      "**The Wallis-type value is a probability normalizer.** Dividing the symmetric integrand xⁿ(1-x)ⁿ by its integral B = (n!)²/(2n+1)! gives a density that integrates to 1 — the Beta(n+1,n+1) distribution. intervalIntegral.integral_div makes this a one-line consequence of the value, turning the closed form into the statement a probabilist actually uses.",
+      "**Central binomial bridges factorial and reciprocal forms.** The identity (2n+1)! = (2n+1)·C(2n,n)·(n!·n!) (sibling factorial_two_mul_succ) converts (n!)²/(2n+1)! into 1/((2n+1)·C(2n,n)); field_simp discharges the resulting rational identity once factorial positivity is in hand.",
+      "**Positivity is elementary.** All denominators are factorials, positive by Nat.factorial_pos; this makes B > 0 (positivity) and licenses both field_simp and the final B/B = 1."
+    ],
+    "prerequisites": [
+      "The Euler Beta integral and its integer closed form",
+      "Complex powers (cpow) versus monoid powers, and Complex.cpow_natCast",
+      "Interval integrals and the ofReal bridge ∫ ↑f = ↑∫ f",
+      "The symmetric Beta distribution and density normalization"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bridge",
+      "title": "The ℂ → ℝ bridge",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Docstring framing the real-variable goal and the relation to the complex siblings. ofReal_integral_diag unfolds Complex.betaIntegral on the diagonal: the exponent (n+1)-1 reduces to n, Complex.cpow_natCast collapses the complex powers to monoid powers, the integrand becomes a cast real polynomial, and intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral to ↑(∫₀¹ xⁿ(1-x)ⁿ).",
+      "mathContext": "Complex.betaIntegral (n+1)(n+1) = ↑(∫ x in 0..1, xⁿ(1-x)ⁿ)."
+    },
+    {
+      "id": "real-value",
+      "title": "The real Euler integral and central-binomial form",
+      "startLine": 54,
+      "endLine": 83,
+      "summary": "integral_diag_eq_factorial rewrites the bridged identity with the parent betaIntegral_nat_nat to get ∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)! over ℝ (exact_mod_cast through the ℝ→ℂ cast). integral_diag_central_binom converts this to 1/((2n+1)·C(2n,n)) using the sibling factorial factorization and field_simp.",
+      "mathContext": "∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n))."
+    },
+    {
+      "id": "density",
+      "title": "Normalization of the symmetric Beta density",
+      "startLine": 84,
+      "endLine": 94,
+      "summary": "betaDensity_integral_eq_one pulls the constant normalizer B = (n!)²/(2n+1)! out of the integral (intervalIntegral.integral_div), substitutes the integral's value, and finishes with B/B = 1 (B > 0 by factorial positivity), establishing that x ↦ xⁿ(1-x)ⁿ/B is a probability density on [0,1].",
+      "mathContext": "∫₀¹ xⁿ(1-x)ⁿ / B = 1: the Beta(n+1,n+1) density normalizes."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Whittaker, E. T.; Watson, G. N.",
+      "title": "A Course of Modern Analysis",
+      "year": "1927",
+      "note": "The Euler Beta and Gamma integrals and the relation B(u,v) = Γ(u)Γ(v)/Γ(u+v)."
+    },
+    {
+      "authors": "Johnson, Kotz, Balakrishnan",
+      "title": "Continuous Univariate Distributions, Vol. 2",
+      "year": "1995",
+      "note": "The Beta distribution; the symmetric Beta(n+1,n+1) density on [0,1] and its normalizing constant B(n+1,n+1)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. Its first open question asks to derive B(n+1,n+1) = (n!)²/(2n+1)! and connect it to the central binomial coefficient and the symmetric Beta density; this leaf supplies the real-variable integral and the density normalization."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling 'Diagonal Beta Value as a Central Binomial Reciprocal' proves B(n+1,n+1) = 1/((2n+1)·C(2n,n)) over ℂ; this entry reuses its factorial factorization and gives the real-integral counterpart."
+    }
+  ],
+  "conclusion": {
+    "summary": "The real Euler integral of the symmetric Beta integrand is ∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n)) (integral_diag_eq_factorial, integral_diag_central_binom), and the symmetric Beta(n+1,n+1) density xⁿ(1-x)ⁿ/B integrates to 1 on [0,1] (betaDensity_integral_eq_one). The proof descends Mathlib's Complex.betaIntegral to ℝ via Complex.cpow_natCast and intervalIntegral.integral_ofReal (ofReal_integral_diag), then reuses the parent's complex closed form and the sibling's factorial factorization. All four theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Gives the diagonal Beta value its real-analysis and probabilistic form: the normalizing constant of the symmetric Beta distribution and the real integral underlying Wallis-type asymptotics, complementary to the ℂ-valued betaIntegral entries. The ℂ→ℝ descent pattern (cpow_natCast + integral_ofReal) applies to any integer-parameter Beta value.",
+    "openQuestions": [
+      "Can the descent be generalized to the off-diagonal real integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!?",
+      "Does the density normalization extend to the Beta(a,b) density for real a,b > 0 using Mathlib's real Gamma?",
+      "Can the mean and variance of the symmetric Beta(n+1,n+1) distribution be derived from the same real integrals?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.BetaIntegralRecurrence",
+      "Proofs.BetaCentralBinomial",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "intervalIntegral"
+    ],
+    "namespace": "BetaIntegralRecurrenceOQ01OQ03",
+    "lineCount": 94,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralRecurrenceOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Beta Integral OQ-01 (leaf oq-03): the symmetric Beta density on [0,1]

The diagonal Beta value `B(n+1,n+1) = (n!)²/(2n+1)! = 1/((2n+1)·C(2n,n))` is established **over ℂ** by the parent (`betaIntegral_nat_nat`) and sibling (`BetaCentralBinomial`) via Mathlib's `Complex.betaIntegral`. This leaf supplies the **real-variable** statement and the **probability-density normalization** the parent open question asked to connect — content none of the ℂ entries provide.

### Results (`proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03.lean`, 4 theorems / 94 L)

| theorem | statement |
|---|---|
| `ofReal_integral_diag` | `↑(∫₀¹ xⁿ(1-x)ⁿ) = betaIntegral (n+1) (n+1)` (the ℂ→ℝ bridge) |
| `integral_diag_eq_factorial` | `∫ x in 0..1, xⁿ(1-x)ⁿ = (n!)²/(2n+1)!` (real Euler integral) |
| `integral_diag_central_binom` | `= 1/((2n+1)·C(2n,n))` |
| `betaDensity_integral_eq_one` | `∫₀¹ xⁿ(1-x)ⁿ / B = 1` — the **density normalizes** |

### The new ingredient: descending `Complex.betaIntegral` to ℝ

On the diagonal `u = v = n+1`, the integrand `(x:ℂ)^((n+1)-1)·(1-x)^((n+1)-1)` has exponent `(n+1)-1 = n` (a nat), so `Complex.cpow_natCast` collapses the complex powers to monoid powers — valid for **all** `x`, no positivity side condition. The integrand becomes `↑(xⁿ(1-x)ⁿ)`, and `intervalIntegral.integral_ofReal` (via `integral_congr` on `[0,1]`) descends the integral. The closed-form value is then reused from the parent over ℂ and transferred to ℝ by `exact_mod_cast`.

`betaDensity_integral_eq_one` pulls the constant normalizer `B = (n!)²/(2n+1)!` out with `intervalIntegral.integral_div` and reduces to `B/B = 1` (`B > 0` by `Nat.factorial_pos`) — establishing that `x ↦ xⁿ(1-x)ⁿ/B` is the **symmetric Beta(n+1,n+1) probability density** on `[0,1]`.

### Verification

- **0 axioms, 0 sorries.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`.
- Kernel-checked on Mathlib 4.26.0. Imports parent `BetaIntegralRecurrence` and sibling `BetaCentralBinomial` to reuse the established value and factorial factorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)