### PR TITLE
research(herons-formula-oq-06): Euler's inequality R ≥ 2r from Heron [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/HeronsFormulaOQ06.lean
+++ b/proofs/Proofs/HeronsFormulaOQ06.lean
@@ -1,0 +1,248 @@
+/-
+  Euler's Inequality R ≥ 2r from Heron's Formula
+
+  For any nondegenerate triangle with sides a, b, c, the circumradius R
+  and inradius r satisfy Euler's inequality
+
+      R ≥ 2r,
+
+  with equality if and only if the triangle is equilateral.
+
+  This is a child of the Heron's formula gallery entry (oq-06). The standard
+  circumradius / inradius formulas are
+
+      R = abc / (4·Area),      r = Area / s,
+
+  where s = (a+b+c)/2 is the semi-perimeter and Area = √(s(s-a)(s-b)(s-c)) is
+  Heron's area. Euler's inequality is purely algebraic once these are plugged in:
+
+      R ≥ 2r
+    ⟺ abc / (4·Area) ≥ 2·Area / s          (Area, s > 0)
+    ⟺ abc · s ≥ 8·Area²
+    ⟺ abc · s ≥ 8·s·(s-a)(s-b)(s-c)        (Heron: Area² = s(s-a)(s-b)(s-c))
+    ⟺ abc ≥ 8·(s-a)(s-b)(s-c).             (s > 0)
+
+  Writing x = s-a, y = s-b, z = s-c (all positive for a nondegenerate triangle),
+  we have a = y+z, b = z+x, c = x+y, and the inequality becomes the symmetric
+  AM-GM consequence
+
+      (y+z)(z+x)(x+y) ≥ 8·xyz,
+
+  with equality iff x = y = z, i.e. a = b = c. This last inequality is the
+  mathematical heart of Euler's inequality; the SOS certificate is
+
+      (y+z)(z+x)(x+y) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)²  ≥ 0.
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace EulerInequalityHeronOQ06
+
+open Real
+
+-- ════════════════════════════════════════════════════════════════
+-- PART I: The algebraic core — an SOS form of AM-GM
+-- ════════════════════════════════════════════════════════════════
+
+/-- The mathematical heart of Euler's inequality: for nonnegative reals,
+    `(y+z)(z+x)(x+y) ≥ 8·xyz`.
+
+    The certificate is the sum-of-squares identity
+    `(y+z)(z+x)(x+y) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)²`. -/
+theorem prod_sum_ge_eight_mul {x y z : ℝ}
+    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    8 * (x * y * z) ≤ (y + z) * (z + x) * (x + y) := by
+  nlinarith [mul_nonneg hx (sq_nonneg (y - z)),
+             mul_nonneg hy (sq_nonneg (z - x)),
+             mul_nonneg hz (sq_nonneg (x - y)),
+             mul_nonneg (mul_nonneg hx hy) hz]
+
+/-- The SOS identity made explicit (gives the equality certificate). -/
+theorem prod_sum_sub_eight_mul (x y z : ℝ) :
+    (y + z) * (z + x) * (x + y) - 8 * (x * y * z)
+      = x * (y - z) ^ 2 + y * (z - x) ^ 2 + z * (x - y) ^ 2 := by
+  ring
+
+/-- Equality in AM-GM forces `x = y = z` when the variables are positive. -/
+theorem prod_sum_eq_iff {x y z : ℝ}
+    (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
+    (y + z) * (z + x) * (x + y) = 8 * (x * y * z) ↔ x = y ∧ y = z := by
+  constructor
+  · intro h
+    -- The SOS form is zero, so each nonnegative summand vanishes.
+    have hsos : x * (y - z) ^ 2 + y * (z - x) ^ 2 + z * (x - y) ^ 2 = 0 := by
+      have := prod_sum_sub_eight_mul x y z
+      linarith
+    have t1 : 0 ≤ x * (y - z) ^ 2 := mul_nonneg hx.le (sq_nonneg _)
+    have t2 : 0 ≤ y * (z - x) ^ 2 := mul_nonneg hy.le (sq_nonneg _)
+    have t3 : 0 ≤ z * (x - y) ^ 2 := mul_nonneg hz.le (sq_nonneg _)
+    have e3 : z * (x - y) ^ 2 = 0 := by linarith
+    have e2 : y * (z - x) ^ 2 = 0 := by linarith
+    have hsq_xy : (x - y) ^ 2 = 0 := by
+      rcases mul_eq_zero.1 e3 with h0 | h0
+      · exact absurd h0 (ne_of_gt hz)
+      · exact h0
+    have hsq_zx : (z - x) ^ 2 = 0 := by
+      rcases mul_eq_zero.1 e2 with h0 | h0
+      · exact absurd h0 (ne_of_gt hy)
+      · exact h0
+    have hxy0 : x - y = 0 := by
+      have := sq_eq_zero_iff.mp hsq_xy; linarith
+    have hzx0 : z - x = 0 := by
+      have := sq_eq_zero_iff.mp hsq_zx; linarith
+    exact ⟨by linarith, by linarith⟩
+  · rintro ⟨hxy, hyz⟩
+    subst hxy; subst hyz; ring
+
+-- ════════════════════════════════════════════════════════════════
+-- PART II: Triangle data — semi-perimeter, Heron product, area
+-- ════════════════════════════════════════════════════════════════
+
+/-- Semi-perimeter. -/
+noncomputable def semiperimeter (a b c : ℝ) : ℝ := (a + b + c) / 2
+
+/-- Heron's product `s(s-a)(s-b)(s-c)`; the squared area. -/
+noncomputable def heronProduct (a b c : ℝ) : ℝ :=
+  semiperimeter a b c * (semiperimeter a b c - a)
+    * (semiperimeter a b c - b) * (semiperimeter a b c - c)
+
+/-- Heron's area `√(s(s-a)(s-b)(s-c))`. -/
+noncomputable def area (a b c : ℝ) : ℝ := sqrt (heronProduct a b c)
+
+/-- Circumradius `R = abc / (4·Area)`. -/
+noncomputable def circumradius (a b c : ℝ) : ℝ := a * b * c / (4 * area a b c)
+
+/-- Inradius `r = Area / s`. -/
+noncomputable def inradius (a b c : ℝ) : ℝ := area a b c / semiperimeter a b c
+
+/-- For a nondegenerate triangle the semi-perimeter is strictly positive. -/
+theorem semiperimeter_pos {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    0 < semiperimeter a b c := by
+  unfold semiperimeter; linarith
+
+theorem heronProduct_pos {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    0 < heronProduct a b c := by
+  unfold heronProduct semiperimeter
+  have hs : 0 < (a + b + c) / 2 := by linarith
+  have hsa : 0 < (a + b + c) / 2 - a := by linarith
+  have hsb : 0 < (a + b + c) / 2 - b := by linarith
+  have hsc : 0 < (a + b + c) / 2 - c := by linarith
+  positivity
+
+theorem area_pos {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    0 < area a b c := by
+  unfold area
+  exact sqrt_pos.mpr (heronProduct_pos ha hb hc hab hbc hca)
+
+/-- Area squared equals Heron's product (no sqrt remaining). -/
+theorem area_sq {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    area a b c ^ 2 = heronProduct a b c := by
+  unfold area
+  rw [sq_sqrt (heronProduct_pos ha hb hc hab hbc hca).le]
+
+-- ════════════════════════════════════════════════════════════════
+-- PART III: The reduced side inequality `abc ≥ 8(s-a)(s-b)(s-c)`
+-- ════════════════════════════════════════════════════════════════
+
+/-- The product inequality in triangle form: `abc ≥ 8(s-a)(s-b)(s-c)`.
+    Obtained from `prod_sum_ge_eight_mul` via `x = s-a`, `y = s-b`, `z = s-c`. -/
+theorem sides_ge_eight_prod {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    8 * ((semiperimeter a b c - a) * (semiperimeter a b c - b)
+        * (semiperimeter a b c - c)) ≤ a * b * c := by
+  have hsa : 0 ≤ semiperimeter a b c - a := by unfold semiperimeter; linarith
+  have hsb : 0 ≤ semiperimeter a b c - b := by unfold semiperimeter; linarith
+  have hsc : 0 ≤ semiperimeter a b c - c := by unfold semiperimeter; linarith
+  have key := prod_sum_ge_eight_mul hsa hsb hsc
+  have ea : a = (semiperimeter a b c - b) + (semiperimeter a b c - c) := by
+    unfold semiperimeter; ring
+  have eb : b = (semiperimeter a b c - c) + (semiperimeter a b c - a) := by
+    unfold semiperimeter; ring
+  have ec : c = (semiperimeter a b c - a) + (semiperimeter a b c - b) := by
+    unfold semiperimeter; ring
+  calc 8 * ((semiperimeter a b c - a) * (semiperimeter a b c - b)
+            * (semiperimeter a b c - c))
+      ≤ ((semiperimeter a b c - b) + (semiperimeter a b c - c))
+        * ((semiperimeter a b c - c) + (semiperimeter a b c - a))
+        * ((semiperimeter a b c - a) + (semiperimeter a b c - b)) := key
+    _ = a * b * c := by rw [← ea, ← eb, ← ec]
+
+-- ════════════════════════════════════════════════════════════════
+-- PART IV: Euler's inequality R ≥ 2r
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Euler's inequality.** For any nondegenerate triangle, `R ≥ 2r`. -/
+theorem euler_inequality {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    2 * inradius a b c ≤ circumradius a b c := by
+  have hs : 0 < semiperimeter a b c := semiperimeter_pos ha hb hc
+  have hA : 0 < area a b c := area_pos ha hb hc hab hbc hca
+  have hA2 : area a b c ^ 2 = heronProduct a b c := area_sq ha hb hc hab hbc hca
+  have hsides := sides_ge_eight_prod ha hb hc hab hbc hca
+  -- 8·Area² ≤ abc·s
+  have hkey : 8 * area a b c ^ 2 ≤ a * b * c * semiperimeter a b c := by
+    rw [hA2]; unfold heronProduct
+    nlinarith [mul_le_mul_of_nonneg_left hsides hs.le]
+  -- Clear denominators in R ≥ 2r.
+  unfold inradius circumradius
+  rw [← mul_div_assoc, div_le_div_iff₀ hs (mul_pos (by norm_num) hA)]
+  nlinarith [hkey]
+
+/-- **Equality case.** `R = 2r` holds iff the triangle is equilateral. -/
+theorem euler_equality_iff {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    2 * inradius a b c = circumradius a b c ↔ a = b ∧ b = c := by
+  have hs : 0 < semiperimeter a b c := semiperimeter_pos ha hb hc
+  have hA : 0 < area a b c := area_pos ha hb hc hab hbc hca
+  have hA2 : area a b c ^ 2 = heronProduct a b c := area_sq ha hb hc hab hbc hca
+  -- `R = 2r` ⟺ `abc·s = 8·Area²`.
+  have requiv : 2 * inradius a b c = circumradius a b c
+      ↔ a * b * c * semiperimeter a b c = 8 * area a b c ^ 2 := by
+    unfold circumradius inradius
+    rw [← mul_div_assoc,
+        div_eq_div_iff hs.ne' (mul_pos (by norm_num) hA).ne']
+    constructor
+    · intro h; linear_combination -h
+    · intro h; linear_combination -h
+  rw [requiv, hA2]
+  unfold heronProduct
+  set s := semiperimeter a b c with hsdef
+  have hsa : 0 < s - a := by rw [hsdef]; unfold semiperimeter; linarith
+  have hsb : 0 < s - b := by rw [hsdef]; unfold semiperimeter; linarith
+  have hsc : 0 < s - c := by rw [hsdef]; unfold semiperimeter; linarith
+  have ea : a = (s - b) + (s - c) := by rw [hsdef]; unfold semiperimeter; ring
+  have eb : b = (s - c) + (s - a) := by rw [hsdef]; unfold semiperimeter; ring
+  have ec : c = (s - a) + (s - b) := by rw [hsdef]; unfold semiperimeter; ring
+  rw [show a * b * c * s = s * (a * b * c) by ring,
+      show (8 : ℝ) * (s * (s - a) * (s - b) * (s - c))
+        = s * (8 * ((s - a) * (s - b) * (s - c))) by ring]
+  constructor
+  · intro h
+    have hcancel : a * b * c = 8 * ((s - a) * (s - b) * (s - c)) :=
+      mul_left_cancel₀ hs.ne' h
+    have hform : ((s - b) + (s - c)) * ((s - c) + (s - a)) * ((s - a) + (s - b))
+                  = 8 * ((s - a) * (s - b) * (s - c)) := by
+      rw [← ea, ← eb, ← ec]; exact hcancel
+    obtain ⟨h1, h2⟩ := (prod_sum_eq_iff hsa hsb hsc).1 hform
+    exact ⟨by linarith, by linarith⟩
+  · rintro ⟨hab', hbc'⟩
+    have hform : ((s - b) + (s - c)) * ((s - c) + (s - a)) * ((s - a) + (s - b))
+                  = 8 * ((s - a) * (s - b) * (s - c)) :=
+      (prod_sum_eq_iff hsa hsb hsc).2 ⟨by linarith, by linarith⟩
+    rw [← ea, ← eb, ← ec] at hform
+    rw [hform]
+
+end EulerInequalityHeronOQ06

--- a/src/data/proofs/herons-formula-oq-06/annotations.json
+++ b/src/data/proofs/herons-formula-oq-06/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-euler-context",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "Euler's Inequality R ≥ 2r",
+    "content": "Euler's inequality (Euler, 1765) states that the circumradius R of any triangle is at least twice its inradius r, with equality exactly for the equilateral triangle. Euler proved it as a corollary of his distance formula OI² = R(R - 2r) between the circumcenter O and incenter I: since OI² ≥ 0, we get R(R - 2r) ≥ 0, hence R ≥ 2r. This formalization avoids constructing O and I and instead works directly from the radius formulas R = abc/(4·Area) and r = Area/s, reducing the whole statement to an algebraic inequality.",
+    "mathContext": "**Euler's inequality**: $R \\geq 2r$ for every triangle, equality iff equilateral. It is the basic constraint between a triangle's two characteristic radii and the gateway to sharper relations (Gerretsen's $s^2 \\le 4R^2 + 4Rr + 3r^2$, Blundon's inequalities).",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "circumradius",
+      "inradius",
+      "Euler's triangle formula OI² = R(R-2r)",
+      "Heron's formula"
+    ],
+    "prerequisites": [
+      "Heron's formula (herons-formula)",
+      "circumradius and inradius formulas"
+    ]
+  },
+  {
+    "id": "ann-sos-core",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 50, "endLine": 67 },
+    "type": "technique",
+    "title": "The Sum-of-Squares Certificate for AM-GM",
+    "content": "The mathematical heart is the symmetric inequality (y+z)(z+x)(x+y) ≥ 8xyz for nonnegative reals. It is proved from the explicit identity (y+z)(z+x)(x+y) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)², whose right-hand side is a sum of products of a nonnegative variable with a square, hence nonnegative. `nlinarith` is fed exactly these three nonnegative products. The same identity (theorem prod_sum_sub_eight_mul, proved by `ring`) is what makes the equality case transparent.",
+    "mathContext": "This is the three-variable instance of $(a+b) \\geq 2\\sqrt{ab}$ multiplied out: $\\prod (x+y) \\geq \\prod 2\\sqrt{xy} = 8xyz$. The SOS form $\\sum x(y-z)^2 \\geq 0$ is a Schur-like certificate that simultaneously yields the inequality and its equality locus.",
+    "significance": "key",
+    "relatedConcepts": ["AM-GM inequality", "sum of squares", "Schur's inequality", "nlinarith"],
+    "prerequisites": ["nonnegativity of squares"]
+  },
+  {
+    "id": "ann-amgm-equality",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 69, "endLine": 98 },
+    "type": "technique",
+    "title": "Extracting the Equality Case from the SOS Form",
+    "content": "When (y+z)(z+x)(x+y) = 8xyz, the SOS sum x(y-z)² + y(z-x)² + z(x-y)² is zero. Since each summand is nonnegative, every summand vanishes. With x, y, z strictly positive, z(x-y)² = 0 forces (x-y)² = 0 and y(z-x)² = 0 forces (z-x)² = 0; `sq_eq_zero_iff` then gives x = y and z = x, so x = y = z. The converse is a one-line `ring` after substitution. This is the standard 'SOS ⟹ equality locus' argument.",
+    "mathContext": "Equality in AM-GM holds iff all variables are equal. The strict positivity hypotheses are essential: they let one cancel the nonnegative coefficients to conclude the squared differences vanish.",
+    "significance": "supporting",
+    "relatedConcepts": ["equality case", "sq_eq_zero_iff", "no zero divisors"],
+    "prerequisites": ["a² = 0 ↔ a = 0"]
+  },
+  {
+    "id": "ann-triangle-data",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 100, "endLine": 151 },
+    "type": "concept",
+    "title": "Radii from Heron, and the Square-Root-Free Setup",
+    "content": "The semi-perimeter s = (a+b+c)/2, Heron product s(s-a)(s-b)(s-c), area = √(Heron product), circumradius R = abc/(4·Area) and inradius r = Area/s are defined exactly as in classical geometry. The key lemma area_sq proves Area² = Heron product via Real.sq_sqrt (valid because the Heron product is positive for a nondegenerate triangle). After this single step, no square roots remain — every subsequent manipulation is polynomial, which is what makes `nlinarith` and `linear_combination` effective.",
+    "mathContext": "$R = \\frac{abc}{4K}$ and $r = \\frac{K}{s}$ where $K$ is the area. Working with $K^2 = s(s-a)(s-b)(s-c)$ instead of $K$ keeps the algebra rational.",
+    "significance": "supporting",
+    "relatedConcepts": ["Heron's formula", "circumradius formula", "inradius formula", "Real.sq_sqrt"],
+    "prerequisites": ["triangle inequality", "positivity of the Heron product"]
+  },
+  {
+    "id": "ann-ravi-reduction",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 153, "endLine": 179 },
+    "type": "technique",
+    "title": "Ravi Substitution: abc ≥ 8(s-a)(s-b)(s-c)",
+    "content": "Setting x = s-a, y = s-b, z = s-c (all positive iff the triangle inequalities are strict), the sides become a = y+z, b = z+x, c = x+y. The AM-GM core then reads exactly (y+z)(z+x)(x+y) ≥ 8xyz, i.e. abc ≥ 8(s-a)(s-b)(s-c). The lemma sides_ge_eight_prod packages this substitution, rewriting a, b, c via the three identities a = (s-b)+(s-c), etc.",
+    "mathContext": "The **Ravi substitution** is the standard change of variables for triangle inequalities: it converts the triangle-inequality constraints into plain positivity of x, y, z, turning geometric inequalities into symmetric polynomial inequalities.",
+    "significance": "key",
+    "relatedConcepts": ["Ravi substitution", "triangle inequality", "symmetric polynomials"],
+    "prerequisites": ["AM-GM core (prod_sum_ge_eight_mul)"]
+  },
+  {
+    "id": "ann-euler-main",
+    "proofId": "herons-formula-oq-06",
+    "range": { "startLine": 181, "endLine": 248 },
+    "type": "proof",
+    "title": "Clearing Denominators to Prove R ≥ 2r and its Equality Case",
+    "content": "R ≥ 2r is 2·(Area/s) ≤ abc/(4·Area). Since s and Area are positive, div_le_div_iff₀ clears denominators to 2·Area·(4·Area) ≤ abc·s, i.e. 8·Area² ≤ abc·s; substituting Area² = Heron product and the reduced inequality finishes via `nlinarith`. For the equality case, the same denominator-clearing turns R = 2r into abc·s = 8·Area², and after cancelling s > 0 the AM-GM equality characterization (prod_sum_eq_iff) transported through the Ravi substitution gives a = b ∧ b = c.",
+    "mathContext": "$R \\geq 2r \\iff abc \\cdot s \\geq 8 K^2 = 8 s (s-a)(s-b)(s-c) \\iff abc \\geq 8(s-a)(s-b)(s-c)$. The equality case threads the AM-GM equality locus $x=y=z$ back to $a=b=c$.",
+    "significance": "key",
+    "relatedConcepts": ["div_le_div_iff₀", "nlinarith", "linear_combination", "equality characterization"],
+    "prerequisites": ["reduced inequality (sides_ge_eight_prod)", "AM-GM equality case (prod_sum_eq_iff)"]
+  }
+]

--- a/src/data/proofs/herons-formula-oq-06/meta.json
+++ b/src/data/proofs/herons-formula-oq-06/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "herons-formula-oq-06",
+  "slug": "herons-formula-oq-06",
+  "title": "Euler's Inequality R ≥ 2r from Heron's Formula",
+  "description": "For any nondegenerate triangle, the circumradius R and inradius r satisfy Euler's inequality R ≥ 2r, with equality iff the triangle is equilateral. Using R = abc/(4·Area) and r = Area/s, the inequality reduces algebraically (via Heron's Area² = s(s-a)(s-b)(s-c)) to abc ≥ 8(s-a)(s-b)(s-c), which under the substitution x = s-a, y = s-b, z = s-c becomes the symmetric AM-GM consequence (x+y)(y+z)(z+x) ≥ 8xyz with SOS certificate x(y-z)² + y(z-x)² + z(x-y)².",
+  "conclusion": {
+    "summary": "A complete, axiom-free formalization of Euler's inequality R ≥ 2r together with its equality characterization (equilateral). The geometric statement is reduced to the symmetric inequality (x+y)(y+z)(z+x) ≥ 8xyz on the positive 'Ravi' variables x = s-a, y = s-b, z = s-c, which is proved from the explicit sum-of-squares identity (x+y)(y+z)(z+x) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)².",
+    "implications": "Euler's inequality is the basic relation constraining the two characteristic radii of a triangle and is the entry point for the Euler triangle formula OI² = R(R-2r). The SOS identity proved here gives the sharp equality case for free: R = 2r exactly when the triangle is equilateral. The reusable core — a positivity-respecting product/AM-GM inequality with full equality characterization — is independently useful for other triangle extremal problems.",
+    "openQuestions": [
+      "Can the full Euler triangle formula OI² = R² - 2Rr (with O the circumcenter, I the incenter) be formalized, recovering R ≥ 2r as the nonnegativity OI² ≥ 0?",
+      "Does the same Ravi-substitution SOS technique give a clean Lean proof of the related inequality chain (e.g. the Gerretsen inequalities s² ≤ 4R² + 4Rr + 3r²)?"
+    ]
+  },
+  "overview": "{\"historicalContext\":\"Euler's inequality R ≥ 2r, relating a triangle's circumradius R and inradius r, was published by Leonhard Euler in 1765 as a corollary of his formula OI² = R(R - 2r) for the distance between the circumcenter and incenter. Since OI² ≥ 0, one obtains R(R - 2r) ≥ 0, hence R ≥ 2r, with equality exactly when O = I, i.e. the triangle is equilateral. The inequality is one of the cornerstones of classical triangle geometry and the starting point for a large family of sharper relations (Gerretsen, Blundon).\",\"problemStatement\":\"For a triangle with side lengths a, b, c (satisfying the strict triangle inequalities), let s = (a+b+c)/2, Area = √(s(s-a)(s-b)(s-c)) (Heron), circumradius R = abc/(4·Area) and inradius r = Area/s. Prove R ≥ 2r, with equality iff a = b = c.\",\"proofStrategy\":\"Rather than constructing O and I and computing OI², we give a purely algebraic proof from the radius formulas. Clearing the positive denominators, R ≥ 2r ⟺ abc·s ≥ 8·Area². By Heron, Area² = s(s-a)(s-b)(s-c), and cancelling s > 0 leaves abc ≥ 8(s-a)(s-b)(s-c). The Ravi substitution x = s-a, y = s-b, z = s-c (all positive for a nondegenerate triangle) turns a, b, c into y+z, z+x, x+y, so the target is the symmetric inequality (x+y)(y+z)(z+x) ≥ 8xyz. This is settled by the explicit SOS identity (x+y)(y+z)(z+x) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)², which is manifestly ≥ 0 and vanishes iff x = y = z.\",\"keyInsights\":[\"The whole geometric inequality collapses, after clearing denominators and applying Heron, to a single symmetric polynomial inequality on the positive Ravi variables.\",\"The product–AM–GM inequality (x+y)(y+z)(z+x) ≥ 8xyz has a one-line sum-of-squares certificate, which simultaneously proves the inequality and pins down the equality case.\",\"Working with Area² (not Area) keeps the proof free of square roots everywhere except the single definitional step Area² = s(s-a)(s-b)(s-c) (Real.sq_sqrt).\"],\"prerequisites\":[\"Heron's formula Area² = s(s-a)(s-b)(s-c)\",\"AM-GM / sum-of-squares positivity\",\"Ravi substitution x = s-a, y = s-b, z = s-c\"],\"text\":\"This entry formalizes Euler's inequality R ≥ 2r for triangles as an algebraic consequence of Heron's formula. The circumradius and inradius are defined by the standard formulas R = abc/(4·Area) and r = Area/s. After clearing denominators the inequality becomes abc·s ≥ 8·Area², and Heron's formula reduces it to abc ≥ 8(s-a)(s-b)(s-c). The Ravi substitution converts this to the symmetric AM-GM inequality (x+y)(y+z)(z+x) ≥ 8xyz, proved (with its equality case) from an explicit sum-of-squares identity. Both the inequality and the equality characterization R = 2r ⟺ equilateral are machine-checked with 0 axioms and 0 sorries.\"}",
+  "mainTheorems": [
+    {
+      "name": "prod_sum_ge_eight_mul",
+      "type": "supporting",
+      "description": "Symmetric AM-GM core: (y+z)(z+x)(x+y) ≥ 8xyz for x,y,z ≥ 0, via a sum-of-squares certificate.",
+      "leanType": "8 * (x * y * z) ≤ (y + z) * (z + x) * (x + y)"
+    },
+    {
+      "name": "prod_sum_eq_iff",
+      "type": "supporting",
+      "description": "Equality characterization for the AM-GM core: equality holds iff x = y = z (for positive reals).",
+      "leanType": "(y + z) * (z + x) * (x + y) = 8 * (x * y * z) ↔ x = y ∧ y = z"
+    },
+    {
+      "name": "euler_inequality",
+      "type": "main",
+      "description": "Euler's inequality: for any nondegenerate triangle, 2r ≤ R.",
+      "leanType": "2 * inradius a b c ≤ circumradius a b c"
+    },
+    {
+      "name": "euler_equality_iff",
+      "type": "main",
+      "description": "Equality case: R = 2r holds iff the triangle is equilateral (a = b = c).",
+      "leanType": "2 * inradius a b c = circumradius a b c ↔ a = b ∧ b = c"
+    }
+  ],
+  "sections": [
+    {
+      "id": "amgm-core",
+      "title": "The Algebraic Core — an SOS form of AM-GM",
+      "startLine": 46,
+      "endLine": 98,
+      "summary": "Proves the symmetric inequality (y+z)(z+x)(x+y) ≥ 8xyz from the explicit SOS identity (y+z)(z+x)(x+y) - 8xyz = x(y-z)² + y(z-x)² + z(x-y)², and derives the equality characterization x = y = z for positive reals.",
+      "mathContext": "The mathematical heart of Euler's inequality, independent of any geometry. The SOS identity gives both the inequality (nlinarith on nonnegative summands) and the equality case (each summand vanishes)."
+    },
+    {
+      "id": "triangle-data",
+      "title": "Triangle Data — semi-perimeter, Heron product, area, radii",
+      "startLine": 100,
+      "endLine": 151,
+      "summary": "Defines the semi-perimeter s, Heron product s(s-a)(s-b)(s-c), area = √(Heron product), circumradius R = abc/(4·Area) and inradius r = Area/s, and proves positivity facts plus Area² = Heron product.",
+      "mathContext": "Standard triangle quantities. area_sq (via Real.sq_sqrt) is the only place a square root is removed; everything downstream is polynomial."
+    },
+    {
+      "id": "reduced-inequality",
+      "title": "The Reduced Side Inequality abc ≥ 8(s-a)(s-b)(s-c)",
+      "startLine": 153,
+      "endLine": 179,
+      "summary": "Specializes the AM-GM core to x = s-a, y = s-b, z = s-c, where a = y+z, b = z+x, c = x+y, giving abc ≥ 8(s-a)(s-b)(s-c) for any nondegenerate triangle.",
+      "mathContext": "The Ravi substitution. This is the algebraic content of Euler's inequality once Heron and denominator-clearing are applied."
+    },
+    {
+      "id": "euler-inequality",
+      "title": "Euler's Inequality R ≥ 2r and its Equality Case",
+      "startLine": 181,
+      "endLine": 248,
+      "summary": "Clears the positive denominators in R ≥ 2r to abc·s ≥ 8·Area², applies Heron and the reduced inequality to prove 2r ≤ R, and characterizes equality R = 2r ⟺ equilateral via the AM-GM equality case.",
+      "mathContext": "The main results. euler_inequality uses div_le_div_iff₀ and nlinarith; euler_equality_iff transports the AM-GM equality characterization through the Ravi substitution."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "herons-formula",
+      "relationship": "extends",
+      "description": "Uses Heron's formula Area² = s(s-a)(s-b)(s-c) to eliminate the area from the radius formulas."
+    },
+    {
+      "targetId": "herons-formula-oq-04",
+      "relationship": "related",
+      "description": "Shares the Ravi substitution x = s-a, y = s-b, z = s-c and an AM-GM core with full equality characterization; there for the isoperimetric inequality, here for Euler's inequality."
+    }
+  ],
+  "references": [
+    {
+      "title": "Euler's theorem in geometry (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_theorem_in_geometry"
+    },
+    {
+      "title": "Euler's inequality (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_theorem_in_geometry#Euler's_inequality"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "EulerInequalityHeronOQ06",
+    "lineCount": 248,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HeronsFormulaOQ06.lean",
+    "theoremCount": 10,
+    "definitionCount": 5
+  },
+  "meta": {
+    "author": "Classical result (Euler, 1765), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_theorem_in_geometry",
+    "date": "1765",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HeronsFormulaOQ06.lean",
+    "tags": [
+      "geometry",
+      "euler-inequality",
+      "triangle",
+      "circumradius",
+      "inradius",
+      "amgm",
+      "ravi-substitution",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext, Classical.choice, Quot.sound).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "sqrt(x)^2 = x for x ≥ 0; used to obtain Area² = Heron product.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.sqrt_pos",
+        "description": "0 < sqrt x ↔ 0 < x; used for area positivity.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "a/b ≤ c/d ↔ a*d ≤ c*b for positive denominators; clears denominators in R ≥ 2r.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Euler's inequality R ≥ 2r formalized directly from the radius formulas R = abc/(4·Area), r = Area/s and Heron's formula — no circumcenter/incenter construction needed.",
+      "Equality characterization R = 2r ⟺ equilateral, obtained from the AM-GM equality case.",
+      "Symmetric AM-GM core (x+y)(y+z)(z+x) ≥ 8xyz with explicit sum-of-squares certificate x(y-z)² + y(z-x)² + z(x-y)² and full equality characterization (reusable).",
+      "Reduction of the geometric inequality to abc ≥ 8(s-a)(s-b)(s-c) via the Ravi substitution.",
+      "Square-root-free proof: the only sqrt elimination is the single definitional step Area² = s(s-a)(s-b)(s-c)."
+    ],
+    "prerequisites": [
+      "Heron's formula",
+      "AM-GM / sum-of-squares positivity",
+      "Ravi substitution"
+    ],
+    "difficulty": "intermediate",
+    "category": "geometry",
+    "parentSlug": "herons-formula",
+    "dateAdded": "2026-06-24",
+    "lineCount": 248,
+    "theoremCount": 10,
+    "definitionCount": 5,
+    "mathlib_version": "v4.26"
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes **Euler's inequality** $R \ge 2r$ for triangles (circumradius $\ge$ twice inradius), with equality **iff equilateral**, as a purely algebraic consequence of Heron's formula. Child of the `herons-formula` gallery entry (oq-06).

## Mathematical content

Using $R = abc/(4\,\text{Area})$ and $r = \text{Area}/s$, clearing the positive denominators reduces $R \ge 2r$ to $abc\cdot s \ge 8\,\text{Area}^2$. Heron's $\text{Area}^2 = s(s-a)(s-b)(s-c)$ and cancelling $s>0$ leave
$$abc \ge 8(s-a)(s-b)(s-c).$$
The **Ravi substitution** $x=s-a,\,y=s-b,\,z=s-c$ turns this into the symmetric AM-GM core
$$(x+y)(y+z)(z+x) \ge 8xyz,$$
proved from the explicit **sum-of-squares certificate**
$$(x+y)(y+z)(z+x) - 8xyz = x(y-z)^2 + y(z-x)^2 + z(x-y)^2 \ge 0,$$
which also pins the equality case $x=y=z \iff a=b=c$.

## Results
- `euler_inequality` : `2 * inradius a b c ≤ circumradius a b c`
- `euler_equality_iff` : `2 * inradius a b c = circumradius a b c ↔ a = b ∧ b = c`
- plus reusable AM-GM core `prod_sum_ge_eight_mul` / `prod_sum_eq_iff` with full equality characterization.

## Verification
- 10 theorems, 5 definitions, 248 lines, **0 sorries**.
- `#print axioms` on both main theorems: only `propext`, `Classical.choice`, `Quot.sound` → **0 axioms, status verified, badge original**.
- Built against pinned Mathlib (host `lake env lean`, Docker unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)