### PR TITLE
Enrich Euler totient Möbius inversion (oq-04-oq-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/euler-totient-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-totient-moebius-header",
+    "proofId": "euler-totient-oq-04-oq-02",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Inverting Gauss's Identity by Möbius Inversion",
+    "content": "The docstring frames the result as the inverse of the parent's Gauss identity n = Σ_{d∣n} φ(d). In the Dirichlet-convolution language of arithmetic functions, Gauss says id = φ ∗ 1 (where 1 is the constant function); convolving both sides by the Möbius function μ (the convolution inverse of 1) gives φ = μ ∗ id, i.e. φ(n) = Σ_{d∣n} μ(d)·(n/d). The file is a clean instantiation of Mathlib's abstract Möbius inversion (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq) with f = φ and g = id, turning the forward sum into the signed divisor sum. Everything is over ℤ so the signs from μ make sense.",
+    "mathContext": "$\\mathrm{id} = \\varphi * \\mathbf{1} \\iff \\varphi = \\mu * \\mathrm{id}$, since $\\mu$ is the Dirichlet inverse of $\\mathbf{1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Möbius inversion", "Dirichlet convolution", "Euler totient", "Gauss's divisor identity"],
+    "prerequisites": ["arithmetic functions", "Dirichlet convolution", "Möbius function μ"]
+  },
+  {
+    "id": "ann-totient-moebius-gauss",
+    "proofId": "euler-totient-oq-04-oq-02",
+    "range": { "startLine": 62, "endLine": 66 },
+    "type": "technique",
+    "title": "Gauss's Identity over ℤ (the Hypothesis Side)",
+    "content": "sum_totient_int casts Mathlib's Nat.sum_totient (Σ_{d∣n} φ(d) = n in ℕ) up to ℤ. This is the forward hypothesis that Möbius inversion consumes: the inversion theorem requires the relation g(n) = Σ_{d∣n} f(d) to hold for all n, and here g = id, f = φ. Working in ℤ is necessary because μ takes values in {−1, 0, 1} and the inverted sum carries genuine subtractions.",
+    "mathContext": "$\\sum_{d\\mid n} \\varphi(d) = n$, cast to $\\mathbb{Z}$ via exact_mod_cast.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss's theorem", "Nat.sum_totient", "integer casts"],
+    "prerequisites": ["Euler totient", "divisor sums"]
+  },
+  {
+    "id": "ann-totient-moebius-antidiagonal",
+    "proofId": "euler-totient-oq-04-oq-02",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "insight",
+    "title": "Antidiagonal Convolution Form",
+    "content": "totient_eq_sum_antidiagonal is the direct output of Mathlib's Möbius inversion: for n > 0, φ(n) = Σ_{(a,b)∈antidiagonal n} μ(a)·b, the Dirichlet convolution (μ ∗ id)(n) written over the divisor antidiagonal {(a,b) : a·b = n}. The proof feeds sum_totient_int as the all-n hypothesis to sum_eq_iff_sum_mul_moebius_eq (instantiated at f = φ, g = id over ℤ) and reads off the equivalent form. The antidiagonal form is the most symmetric statement of φ = μ ∗ id.",
+    "mathContext": "$\\varphi(n) = \\sum_{ab = n} \\mu(a)\\,b = (\\mu * \\mathrm{id})(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "divisor antidiagonal", "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq"],
+    "prerequisites": ["antidiagonal of n", "abstract Möbius inversion"]
+  },
+  {
+    "id": "ann-totient-moebius-divisorsum",
+    "proofId": "euler-totient-oq-04-oq-02",
+    "range": { "startLine": 79, "endLine": 89 },
+    "type": "concept",
+    "title": "The Headline: φ(n) = Σ_{d∣n} μ(d)·(n/d)",
+    "content": "totient_eq_sum_moebius is the named Möbius-inversion formula for the totient. It rewrites the antidiagonal form into the familiar divisor-sum form over {d : d∣n} by Nat.sum_divisorsAntidiagonal (which identifies (a,b)↦a with d↦(d, n/d)). It holds for ALL n including n = 0, where both sides are 0 (empty divisor sum) — handled by a case split. This is φ = μ ∗ id in its most recognizable elementary form.",
+    "mathContext": "$\\varphi(n) = \\sum_{d\\mid n} \\mu(d)\\,\\frac{n}{d}$, valid for all $n$ (including $n=0$).",
+    "significance": "key",
+    "relatedConcepts": ["Möbius inversion formula", "divisor sum", "totient identity"],
+    "prerequisites": ["Nat.sum_divisorsAntidiagonal", "divisors of n"]
+  },
+  {
+    "id": "ann-totient-moebius-swap",
+    "proofId": "euler-totient-oq-04-oq-02",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "technique",
+    "title": "The Reflected n/d ↔ d Form",
+    "content": "totient_eq_sum_moebius_swap gives the symmetric variant φ(n) = Σ_{d∣n} μ(n/d)·d, obtained from the antidiagonal form via Nat.sum_divisorsAntidiagonal' (the reflection (a,b)↦b). It is the same identity reindexed so that μ acts on the cofactor n/d and the linear weight is d itself — convenient when one wants the id factor to range over the divisors directly.",
+    "mathContext": "$\\varphi(n) = \\sum_{d\\mid n} \\mu(n/d)\\,d$ — the $d \\leftrightarrow n/d$ reflection of the headline form.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor reflection", "Nat.sum_divisorsAntidiagonal'", "reindexing"],
+    "prerequisites": ["divisor antidiagonal reflection"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-04-oq-02/index.ts
+++ b/src/data/proofs/euler-totient-oq-04-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ04OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOq04Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOq04Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOq04Oq02Data: ProofData = {
+  proof: eulerTotientOq04Oq02Proof,
+  annotations: eulerTotientOq04Oq02Annotations,
+}

--- a/src/data/proofs/euler-totient-oq-04-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-04-oq-02/meta.json
@@ -87,6 +87,14 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Overview and Imports",
+      "summary": "Module docstring framing φ = μ ∗ id as the Möbius inverse of the parent's Gauss identity n = Σ_{d|n} φ(d), via Mathlib's abstract Möbius inversion instantiated at f = φ, g = id. Imports the Möbius arithmetic-function and totient APIs; opens Nat / ArithmeticFunction and the μ scope.",
+      "startLine": 1,
+      "endLine": 60,
+      "mathContext": "id = φ ∗ 1 ⟺ φ = μ ∗ id, since μ is the Dirichlet inverse of the constant function 1."
+    },
+    {
       "id": "gauss-identity-cast",
       "title": "Gauss's Identity over ℤ",
       "summary": "sum_totient_int: casts Nat.sum_totient (Σ_{d|n} φ(d) = n) to ℤ, the hypothesis side of Möbius inversion.",


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-04-oq-02` (φ = μ ∗ id, Möbius inversion of the totient).

**Gaps addressed** — the entry had a complete `meta.json` (overview, sections, structured conclusion, crossRefs) but was missing two files:
- **Created missing `index.ts`** — without it the page renders 'proof not found' on the live site.
- **Added `annotations.json`** (was absent) — 5 annotations covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. Möbius-inversion framing (id = φ ∗ 1 ⟺ φ = μ ∗ id)
  2. Gauss's identity over ℤ (the hypothesis side)
  3. The antidiagonal convolution form
  4. The headline φ(n) = Σ_{d∣n} μ(d)·(n/d) (valid incl. n=0)
  5. The reflected n/d ↔ d form
- **Added a header section** (lines 1–60) to the existing three sections.

Annotation line ranges validate against the Lean source (build's annotation validator clean for this entry). No mathematical claims altered (verified / 0 axioms / 0 sorries).

Per-cycle branch used to avoid disturbing this agent's other open PRs.