### PR TITLE
research(prime-number-theorem-oq-03): von Mangoldt summatory identity ∑Λ(m)⌊N/m⌋=log(N!) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/PrimeNumberTheoremOQ03.lean
+++ b/proofs/Proofs/PrimeNumberTheoremOQ03.lean
@@ -1,0 +1,122 @@
+import Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Tactic
+
+/-
+# Elementary PNT: the fundamental von Mangoldt summatory identity
+
+This file formalises the exact identity at the heart of the *elementary* approach to the
+Prime Number Theorem (the route of Chebyshev, Mertens, and ultimately Selberg–Erdős):
+
+$$\sum_{m=1}^{N} \Lambda(m)\left\lfloor \frac{N}{m}\right\rfloor = \log(N!).$$
+
+Here `Λ` is the von Mangoldt function (`Λ(p^k) = log p`, and `0` otherwise) and the floor
+`⌊N/m⌋` is ordinary natural-number division.
+
+## Why this is the cornerstone of elementary PNT
+
+Every elementary proof of the Prime Number Theorem begins by estimating `log(N!)` in two ways:
+
+* **Analytically**, via Stirling's formula: `log(N!) = N log N - N + O(log N)`.
+* **Arithmetically**, via the divisor identity `log n = ∑_{d ∣ n} Λ(d)`, which on summing over
+  `n ≤ N` and exchanging the order of summation produces exactly the floor-weighted sum
+  formalised here.
+
+Equating the two yields `∑_{m ≤ N} Λ(m) ⌊N/m⌋ = N log N - N + O(log N)`, the first
+*error-bounded* statement on the road to `ψ(x) ∼ x`. This file supplies the arithmetic
+identity in fully verified, axiom-free form, together with the immediate upper estimate
+`log(N!) ≤ N · ∑_{m ≤ N} Λ(m)/m` obtained from `⌊N/m⌋ ≤ N/m`.
+
+## Main results
+
+* `PrimeNumberTheoremOQ03.log_factorial_eq_sum_log` —
+  `log(N!) = ∑_{n=1}^{N} log n`.
+* `PrimeNumberTheoremOQ03.vonMangoldt_summatory` —
+  `∑_{m=1}^{N} Λ(m) ⌊N/m⌋ = log(N!)`.
+* `PrimeNumberTheoremOQ03.log_factorial_le` —
+  `log(N!) ≤ N · ∑_{m=1}^{N} Λ(m)/m`.
+
+## Mathlib dependencies
+
+The arithmetic input is `ArithmeticFunction.vonMangoldt_sum` (`∑_{d ∣ n} Λ(d) = log n`).
+The counting input is `Nat.Ioc_filter_dvd_card_eq_div` (`#{x ∈ (0,N] : m ∣ x} = N/m`).
+The order-exchange is `Finset.sum_comm'`. None of these supply the floor-weighted identity,
+which is new here and absent from `Mathlib.NumberTheory.Chebyshev`.
+-/
+
+open Finset
+open ArithmeticFunction
+open scoped ArithmeticFunction
+
+namespace PrimeNumberTheoremOQ03
+
+/-- `log(N!)` expands as the sum of `log n` for `n = 1, …, N`. -/
+theorem log_factorial_eq_sum_log (N : ℕ) :
+    Real.log ((Nat.factorial N : ℕ) : ℝ) = ∑ n ∈ Finset.Icc 1 N, Real.log (n : ℝ) := by
+  have hprod : ∏ n ∈ Finset.Icc 1 N, (n : ℝ) = ((Nat.factorial N : ℕ) : ℝ) := by
+    induction N with
+    | zero => simp
+    | succ k ih =>
+      rw [Finset.prod_Icc_succ_top (by omega), ih, Nat.factorial_succ]
+      push_cast; ring
+  rw [← hprod, Real.log_prod]
+  intro n hn
+  rw [Finset.mem_Icc] at hn
+  exact Nat.cast_ne_zero.mpr (by omega)
+
+/-- **Fundamental von Mangoldt summatory identity.**
+
+`∑_{m=1}^{N} Λ(m) ⌊N/m⌋ = log(N!)`, where `⌊N/m⌋` is natural-number division.
+
+This is the exact identity underlying Chebyshev's and Mertens' elementary estimates for the
+distribution of primes. -/
+theorem vonMangoldt_summatory (N : ℕ) :
+    ∑ m ∈ Finset.Icc 1 N, Λ m * ((N / m : ℕ) : ℝ) = Real.log ((Nat.factorial N : ℕ) : ℝ) := by
+  -- The set `{1, …, N}` agrees with the half-open interval `(0, N]`.
+  have hset : Finset.Icc 1 N = Finset.Ioc 0 N := by
+    ext x; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  -- Membership equivalence driving the exchange of summation order.
+  have hmem : ∀ (n d : ℕ), n ∈ Finset.Icc 1 N ∧ d ∈ n.divisors ↔
+      n ∈ (Finset.Icc 1 N).filter (fun x => d ∣ x) ∧ d ∈ Finset.Icc 1 N := by
+    intro n d
+    simp only [Finset.mem_filter, Finset.mem_Icc, Nat.mem_divisors]
+    constructor
+    · rintro ⟨⟨h1, h2⟩, hdvd, hne⟩
+      have hd0 : d ≠ 0 := by rintro rfl; exact hne (Nat.eq_zero_of_zero_dvd hdvd)
+      exact ⟨⟨⟨h1, h2⟩, hdvd⟩, Nat.one_le_iff_ne_zero.mpr hd0,
+        le_trans (Nat.le_of_dvd (by omega) hdvd) h2⟩
+    · rintro ⟨⟨⟨h1, h2⟩, hdvd⟩, hd1, hdN⟩
+      exact ⟨⟨h1, h2⟩, hdvd, by omega⟩
+  calc ∑ m ∈ Finset.Icc 1 N, Λ m * ((N / m : ℕ) : ℝ)
+      = ∑ d ∈ Finset.Icc 1 N,
+          ∑ _n ∈ (Finset.Icc 1 N).filter (fun x => d ∣ x), Λ d := by
+        apply Finset.sum_congr rfl
+        intro d _hd
+        rw [Finset.sum_const, hset, Nat.Ioc_filter_dvd_card_eq_div N d, nsmul_eq_mul]
+        exact mul_comm _ _
+    _ = ∑ n ∈ Finset.Icc 1 N, ∑ d ∈ n.divisors, Λ d := (Finset.sum_comm' hmem).symm
+    _ = ∑ n ∈ Finset.Icc 1 N, Real.log (n : ℝ) := by
+        apply Finset.sum_congr rfl
+        intro n _hn
+        exact ArithmeticFunction.vonMangoldt_sum
+    _ = Real.log ((Nat.factorial N : ℕ) : ℝ) := (log_factorial_eq_sum_log N).symm
+
+/-- **Upper estimate for `log(N!)`.**
+
+From the summatory identity and `⌊N/m⌋ ≤ N/m` together with `Λ ≥ 0` we obtain
+`log(N!) ≤ N · ∑_{m=1}^{N} Λ(m)/m`, the easy half of Mertens' first theorem. -/
+theorem log_factorial_le (N : ℕ) :
+    Real.log ((Nat.factorial N : ℕ) : ℝ) ≤ (N : ℝ) * ∑ m ∈ Finset.Icc 1 N, Λ m / (m : ℝ) := by
+  rw [← vonMangoldt_summatory, Finset.mul_sum]
+  apply Finset.sum_le_sum
+  intro m hm
+  rw [Finset.mem_Icc] at hm
+  have hm0 : (0 : ℝ) < (m : ℝ) := by exact_mod_cast (by omega : 0 < m)
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hm0
+  have hΛ : 0 ≤ Λ m := ArithmeticFunction.vonMangoldt_nonneg
+  have hcast : ((N / m : ℕ) : ℝ) ≤ (N : ℝ) / (m : ℝ) := Nat.cast_div_le
+  calc Λ m * ((N / m : ℕ) : ℝ)
+      ≤ Λ m * ((N : ℝ) / (m : ℝ)) := mul_le_mul_of_nonneg_left hcast hΛ
+    _ = (N : ℝ) * (Λ m / (m : ℝ)) := by ring
+
+end PrimeNumberTheoremOQ03

--- a/research/problems/prime-number-theorem-oq-03/state.md
+++ b/research/problems/prime-number-theorem-oq-03/state.md
@@ -1,27 +1,43 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T12:03:52.281Z
-**Iteration**: 1
+**Phase**: RESEARCH-COMPLETE (one verified leaf shipped; open question remains)
+**Since**: 2026-06-24
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalized the cornerstone identity of the elementary approach to PNT.
 
 ## Active Approach
 
-None yet.
+Elementary (Chebyshev–Mertens) route, von Mangoldt summatory function.
+
+## Result Shipped
+
+`Proofs/PrimeNumberTheoremOQ03.lean` (verified, 0-axiom, original), gallery slug
+`prime-number-theorem-oq-03`:
+
+- `vonMangoldt_summatory`: ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!) — the exact arithmetic
+  identity behind every elementary PNT proof; absent from Mathlib's Chebyshev file.
+- `log_factorial_eq_sum_log`: log(N!) = ∑_{n=1}^{N} log n.
+- `log_factorial_le`: log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m — easy half of Mertens' first theorem.
+
+Proof: expand log n = ∑_{d∣n} Λ(d) (Mathlib `vonMangoldt_sum`), sum over n ≤ N, exchange
+order of summation (`Finset.sum_comm'`), count multiples #{n≤N : m∣n} = ⌊N/m⌋
+(`Nat.Ioc_filter_dvd_card_eq_div`).
 
 ## Blockers
 
-None.
+None for the shipped piece.
 
 ## Next Action
 
-Begin problem exploration.
+Open follow-ups (see meta.json openQuestions): combine with a Lean Stirling bound to get
+∑ Λ(m)⌊N/m⌋ = N log N − N + O(log N); prove full Mertens ∑ Λ(m)/m = log N + O(1) via
+Chebyshev ψ(N) = O(N); build the Selberg symmetry formula on this summatory framework.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/prime-number-theorem-oq-03/annotations.json
+++ b/src/data/proofs/prime-number-theorem-oq-03/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 5,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "The cornerstone identity of elementary PNT",
+    "content": "Every elementary proof of the Prime Number Theorem — Chebyshev (1852), Mertens (1874), and ultimately Selberg–Erdős (1949) — begins by computing log(N!) in two ways. Arithmetically, the divisor identity log n = ∑_{d∣n} Λ(d) summed over n ≤ N and re-indexed by divisor gives the floor-weighted sum ∑_{m≤N} Λ(m)⌊N/m⌋. Analytically, Stirling's formula gives log(N!) = N log N − N + O(log N). The identity formalized here, ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!), is the exact bridge between the two — and the first place error bounds enter the elementary theory. Mathlib's Chebyshev file defines ψ and θ and bounds |ψ−θ|, but does not contain this floor-weighted identity.",
+    "mathContext": "$\\sum_{m=1}^{N} \\Lambda(m)\\lfloor N/m\\rfloor = \\log(N!)$, the arithmetic = analytic bridge of elementary prime distribution.",
+    "significance": "central",
+    "relatedConcepts": [
+      "von Mangoldt function",
+      "Chebyshev functions ψ and θ",
+      "Mertens' theorems",
+      "Dirichlet double-counting"
+    ],
+    "prerequisites": [
+      "von Mangoldt function Λ",
+      "the divisor identity ∑_{d∣n} Λ(d) = log n"
+    ]
+  },
+  {
+    "id": "ann-log-factorial",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "log(N!) = ∑_{n≤N} log n",
+    "content": "The analytic side is made additive here. N! is rewritten as the product ∏_{n∈[1,N]} n by induction on N — the successor step is Finset.prod_Icc_succ_top together with Nat.factorial_succ. Casting to ℝ and applying Real.log_prod (legal because every factor n ≥ 1 is nonzero) turns the log of the product into the sum of logs. Stirling's formula would then estimate this sum as N log N − N + O(log N), but that analytic input is deliberately not used: the identity in the next theorem is exact and axiom-free.",
+    "mathContext": "$\\log(N!) = \\log\\!\\left(\\prod_{n=1}^{N} n\\right) = \\sum_{n=1}^{N} \\log n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "Finset.prod_Icc_succ_top",
+      "Stirling's formula"
+    ],
+    "prerequisites": [
+      "logarithm of a product"
+    ]
+  },
+  {
+    "id": "ann-swap",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 102,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "type": "technique",
+    "title": "Exchanging the order of summation",
+    "content": "The heart of the proof is a Dirichlet double-counting. Starting from ∑_{n≤N} ∑_{d∣n} Λ(d), the inner sum runs over the divisors of each n; after swapping, the outer index becomes the divisor d and the inner sum runs over the multiples of d that are ≤ N. The swap is Finset.sum_comm', driven by the membership equivalence n∈[1,N] ∧ d∈divisors n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N] (the forward direction needs d ≥ 1 from d∣n, n≠0, and d ≤ n ≤ N from Nat.le_of_dvd). Because the inner summand Λ(d) is constant in n, the inner sum collapses to Λ(d) times the number of multiples of d in {1,…,N}, which Nat.Ioc_filter_dvd_card_eq_div evaluates to exactly ⌊N/d⌋ — recovering the floor weights.",
+    "mathContext": "$\\sum_{n\\le N}\\sum_{d\\mid n}\\Lambda(d) = \\sum_{d\\le N}\\Lambda(d)\\,\\#\\{n\\le N : d\\mid n\\} = \\sum_{d\\le N}\\Lambda(d)\\lfloor N/d\\rfloor$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Finset.sum_comm'",
+      "Nat.Ioc_filter_dvd_card_eq_div",
+      "counting multiples",
+      "Dirichlet hyperbola method"
+    ],
+    "prerequisites": [
+      "exchange of order of summation",
+      "counting multiples of d up to N"
+    ]
+  },
+  {
+    "id": "ann-mertens-bound",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 104,
+      "endLine": 120
+    },
+    "type": "technique",
+    "title": "The error-bounded corollary (easy half of Mertens)",
+    "content": "Replacing the floor ⌊N/m⌋ by the true quotient N/m can only increase each term, since Λ(m) ≥ 0 and ⌊N/m⌋ ≤ N/m (Nat.cast_div_le). Summing gives log(N!) ≤ N·∑_{m≤N} Λ(m)/m. This is the easy direction of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1): the displacement between the exact identity and its smoothed version N·∑ Λ(m)/m is bounded by the fractional parts, i.e. by ψ(N) = ∑_{m≤N} Λ(m), the quantitative seed of Chebyshev's ψ(x) ≍ x.",
+    "mathContext": "$\\log(N!) \\le N\\sum_{m=1}^{N}\\frac{\\Lambda(m)}{m}$ from $\\lfloor N/m\\rfloor \\le N/m$ and $\\Lambda(m)\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Mertens' first theorem",
+      "Nat.cast_div_le",
+      "vonMangoldt_nonneg"
+    ],
+    "prerequisites": [
+      "floor versus true quotient",
+      "monotonicity of finite sums"
+    ]
+  }
+]

--- a/src/data/proofs/prime-number-theorem-oq-03/meta.json
+++ b/src/data/proofs/prime-number-theorem-oq-03/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "prime-number-theorem-oq-03",
+  "title": "Elementary PNT: the von Mangoldt summatory identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!)",
+  "slug": "prime-number-theorem-oq-03",
+  "description": "Formalizes the exact arithmetic identity at the foundation of every elementary proof of the Prime Number Theorem (Chebyshev, Mertens, Selberg–Erdős): ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!), where Λ is the von Mangoldt function and ⌊N/m⌋ is natural-number division. Derived by expanding log n = ∑_{d∣n} Λ(d) (Mathlib's vonMangoldt_sum), summing over n ≤ N, and exchanging the order of summation so that each divisor m is counted with multiplicity ⌊N/m⌋ = #{n ≤ N : m∣n}. Mathlib's Chebyshev file defines ψ and θ and bounds |ψ−θ|, but does NOT contain this floor-weighted summatory identity. The entry adds the immediate error-bounded corollary log(N!) ≤ N·∑_{m≤N} Λ(m)/m from ⌊N/m⌋ ≤ N/m — the easy half of Mertens' first theorem. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimeNumberTheoremOQ03.lean",
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "von-mangoldt",
+      "chebyshev",
+      "mertens",
+      "summatory-function",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "lineCount": 122,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. All three theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (no `axiom` declarations, no structure-encoded assumptions, no native_decide / Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_sum",
+        "description": "∑_{d ∣ n} Λ(d) = log n. The arithmetic input: each log n is replaced by the divisor sum of the von Mangoldt function before the summation order is exchanged.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_nonneg",
+        "description": "0 ≤ Λ(m). Used in the upper-estimate corollary to compare ⌊N/m⌋ with N/m term by term.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "Nat.Ioc_filter_dvd_card_eq_div",
+        "description": "#{x ∈ (0,N] : m ∣ x} = N / m. The counting input: after the swap, divisor m appears with multiplicity equal to the number of its multiples in {1,…,N}.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm'",
+        "description": "Generalised order-exchange for a double sum whose inner index set depends on the outer variable; instantiated with the membership equivalence n∈[1,N] ∧ d∣n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N].",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Sigma"
+      },
+      {
+        "theorem": "Real.log_prod",
+        "description": "log(∏ f) = ∑ log f for nonzero factors; turns log(N!) = log(∏_{n≤N} n) into ∑_{n≤N} log n.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.cast_div_le",
+        "description": "(↑(N/m) : ℝ) ≤ ↑N/↑m. Bounds the floor by the true quotient in the Mertens upper-estimate corollary.",
+        "module": "Mathlib.Data.Nat.Cast.Order.Basic"
+      }
+    ],
+    "originalContributions": [
+      "vonMangoldt_summatory: the exact identity ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!), absent from Mathlib's Chebyshev development",
+      "log_factorial_eq_sum_log: the auxiliary identity log(N!) = ∑_{n=1}^{N} log n proved via prod_Icc_succ_top induction",
+      "log_factorial_le: the error-bounded corollary log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m (the easy direction of Mertens' first theorem)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Long before Hadamard and de la Vallée Poussin's 1896 analytic proof, Chebyshev (1852) obtained the order of magnitude of π(x) by elementary means. His starting point — reused by Mertens (1874) and, ultimately, by the Selberg–Erdős elementary proof of the full Prime Number Theorem (1949) — is the double-counting identity\n\n  ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!),\n\nwhere Λ is the von Mangoldt function. The left-hand side is purely arithmetic; the right-hand side is estimated analytically by Stirling's formula as N log N − N + O(log N). Equating the two estimates is the first place 'error bounds' enter the elementary theory, and every subsequent refinement (Chebyshev's ψ(x) ≍ x, Mertens' ∑_{p≤x} log p / p = log x + O(1), and the Tauberian endgame) is built on top of it.",
+    "problemStatement": "Open question OQ-03 of the Prime Number Theorem entry asks whether PNT can be proved elementarily with error bounds matching the analytic proof. This entry formalizes the foundational identity from which all elementary estimates depart, in fully verified axiom-free form, together with the first error-bounded corollary it yields.",
+    "text": "The exact identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) — the cornerstone of Chebyshev's and Mertens' elementary approach to the distribution of primes — with the immediate upper estimate log(N!) ≤ N·∑_{m≤N} Λ(m)/m.",
+    "proofStrategy": "1. log(N!) = ∑_{n=1}^{N} log n: write N! = ∏_{n=1}^{N} n (induction with prod_Icc_succ_top) and apply Real.log_prod (each factor n ≥ 1 is nonzero).\n2. log n = ∑_{d∣n} Λ(d): Mathlib's vonMangoldt_sum.\n3. Exchange the order of summation: ∑_{n≤N} ∑_{d∣n} Λ(d) = ∑_{d≤N} Λ(d)·#{n≤N : d∣n} via Finset.sum_comm', with the membership equivalence n∈[1,N] ∧ d∈divisors n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N].\n4. Count the multiples: #{n≤N : d∣n} = N/d via Nat.Ioc_filter_dvd_card_eq_div (after rewriting Icc 1 N = Ioc 0 N), and the inner constant sum becomes Λ(d)·⌊N/d⌋.\n5. Corollary: from ⌊N/m⌋ ≤ N/m (Nat.cast_div_le) and Λ ≥ 0, bound each summand to obtain log(N!) ≤ N·∑_{m≤N} Λ(m)/m.",
+    "keyInsights": [
+      "The identity is a clean instance of Dirichlet double-counting: summing the divisor identity log n = ∑_{d∣n} Λ(d) over n ≤ N and swapping the two sums replaces 'for each n, run over its divisors' by 'for each d, run over its multiples ≤ N', and the number of those multiples is exactly the floor ⌊N/d⌋.",
+      "Mathlib's Chebyshev file (psi, theta, |psi − theta| ≤ √x·log x, Chebyshev's upper bounds) deliberately works with the UNWEIGHTED sum ψ(x) = ∑_{n≤x} Λ(n); the FLOOR-WEIGHTED summatory function formalized here is a different object and is the one that connects directly to log(N!).",
+      "This is exactly where error bounds originate in the elementary theory: the arithmetic side is exact, while the analytic side log(N!) = N log N − N + O(log N) (Stirling) injects the first error term. The corollary log(N!) ≤ N·∑ Λ(m)/m is the easy half of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1).",
+      "Replacing ⌊N/m⌋ by N/m costs at most a fractional part in [0,1) per term, so the displacement between the exact identity and its smoothed version N·∑ Λ(m)/m is controlled by ψ(N) = ∑_{m≤N} Λ(m) — the quantitative seed of Chebyshev's ψ(x) ≍ x."
+    ],
+    "prerequisites": [
+      "Prime Number Theorem (Proofs.PrimeNumberTheorem): π(x) ~ x/log x",
+      "The von Mangoldt function Λ and the identity ∑_{d∣n} Λ(d) = log n",
+      "Dirichlet double-counting / exchange of order of summation over divisors"
+    ]
+  },
+  "sections": [
+    {
+      "id": "log-factorial",
+      "title": "log(N!) as a sum of logarithms",
+      "startLine": 53,
+      "endLine": 65,
+      "summary": "`log_factorial_eq_sum_log`: log(N!) = ∑_{n=1}^{N} log n. Proves N! = ∏_{n∈[1,N]} n by induction (prod_Icc_succ_top), casts to ℝ, and applies Real.log_prod since each factor is nonzero.",
+      "mathContext": "Turning a factorial into an additive sum of logs is the analytic side of the elementary method; Stirling's formula then evaluates it as N log N − N + O(log N)."
+    },
+    {
+      "id": "summatory-identity",
+      "title": "The von Mangoldt summatory identity",
+      "startLine": 67,
+      "endLine": 102,
+      "summary": "`vonMangoldt_summatory`: ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!). A calc chain runs the floor-weighted sum back to ∑_{d≤N} ∑_{n∈multiples} Λ(d) (constant inner sum, card = N/d via Nat.Ioc_filter_dvd_card_eq_div), exchanges order with Finset.sum_comm', then folds each ∑_{d∣n} Λ(d) into log n and reassembles log(N!).",
+      "mathContext": "This is the exact arithmetic identity of Chebyshev and Mertens. The floor multiplicities ⌊N/m⌋ count, for each prime power m, how many integers ≤ N it divides."
+    },
+    {
+      "id": "mertens-bound",
+      "title": "Upper estimate (easy half of Mertens)",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "`log_factorial_le`: log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m. Substitutes the identity, distributes N over the sum, and compares term by term using ⌊N/m⌋ ≤ N/m (Nat.cast_div_le) and Λ(m) ≥ 0.",
+      "mathContext": "Mertens' first theorem states ∑_{m≤N} Λ(m)/m = log N + O(1); this provides the lower bound on that sum (equivalently, the upper bound on log(N!) in terms of it), the direction that follows purely from ⌊N/m⌋ ≤ N/m."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes, fully verified and axiom-free, the foundational identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) of the elementary theory of prime distribution, plus the auxiliary log(N!) = ∑_{n≤N} log n and the Mertens-direction estimate log(N!) ≤ N·∑_{m≤N} Λ(m)/m. The floor-weighted summatory identity is not present in Mathlib's Chebyshev development.",
+    "implications": "This identity is the launching point for: (1) Chebyshev's bounds ψ(x) ≍ x, by combining it with Stirling's N log N − N + O(log N); (2) Mertens' theorems on ∑ Λ(m)/m and ∑_{p} log p / p; and (3) the Selberg–Erdős elementary proof of PNT. Supplying it in verified form is a concrete step toward an elementary, error-bounded PNT formalization in Lean.",
+    "openQuestions": [
+      "Combine this identity with a Lean formalization of Stirling's bound to derive ∑_{m≤N} Λ(m)⌊N/m⌋ = N log N − N + O(log N) with explicit constants.",
+      "Prove the full Mertens first theorem ∑_{m≤N} Λ(m)/m = log N + O(1) by controlling the displacement between ⌊N/m⌋ and N/m via Chebyshev's ψ(N) = O(N).",
+      "Can the Selberg symmetry formula ∑_{m≤N} Λ(m) log m + ∑_{mn≤N} Λ(m)Λ(n) = 2N log N + O(N), the engine of the elementary PNT proof, be built on top of this summatory framework?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "extends",
+      "description": "Parent entry π(x) ~ x/log x; this formalizes the cornerstone identity of the elementary route to PNT"
+    },
+    {
+      "targetId": "prime-number-theorem-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question on PNT error bounds via the Riemann Hypothesis; this entry pursues the complementary elementary (Chebyshev–Mertens) error-bound route"
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "∑ 1/p diverges; Mertens' refinement ∑ log p / p = log x + O(1) descends from the summatory identity formalized here"
+    }
+  ],
+  "references": [
+    {
+      "title": "Mémoire sur les nombres premiers",
+      "author": "P. L. Chebyshev",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées",
+      "description": "Elementary bounds on π(x) via the summatory von Mangoldt / factorial identity"
+    },
+    {
+      "title": "Ein Beitrag zur analytischen Zahlentheorie",
+      "author": "F. Mertens",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "description": "Mertens' theorems on ∑ Λ(m)/m and ∑ log p / p, built on the same identity"
+    },
+    {
+      "title": "An elementary proof of the prime-number theorem",
+      "author": "A. Selberg",
+      "year": "1949",
+      "venue": "Annals of Mathematics",
+      "description": "Elementary proof of PNT whose symmetry formula rests on summatory von Mangoldt estimates"
+    },
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "T. M. Apostol",
+      "year": "1976",
+      "venue": "Springer",
+      "description": "Textbook derivation of ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) and the Chebyshev/Mertens estimates (Ch. 3–4)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "ArithmeticFunction"
+    ],
+    "namespace": "PrimeNumberTheoremOQ03",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/PrimeNumberTheoremOQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "vonMangoldt_summatory",
+      "type": "core",
+      "statement": "$\\displaystyle\\sum_{m=1}^{N} \\Lambda(m)\\left\\lfloor \\tfrac{N}{m}\\right\\rfloor = \\log(N!)$",
+      "significance": "**The cornerstone identity of elementary PNT.** Exact, axiom-free, and not present in Mathlib's Chebyshev file. Equating its analytic estimate (Stirling) with its arithmetic content drives Chebyshev's ψ(x) ≍ x and Mertens' theorems, and ultimately the Selberg–Erdős elementary proof.",
+      "description": "Proved by expanding log n = ∑_{d∣n} Λ(d), summing over n ≤ N, and exchanging the order of summation so each divisor m is weighted by its multiple-count ⌊N/m⌋."
+    },
+    {
+      "name": "log_factorial_eq_sum_log",
+      "type": "supporting",
+      "statement": "$\\displaystyle\\log(N!) = \\sum_{n=1}^{N} \\log n$",
+      "significance": "Auxiliary identity turning the factorial into the additive object that Stirling's formula estimates; the analytic half of the elementary method.",
+      "description": "N! = ∏_{n∈[1,N]} n by induction (prod_Icc_succ_top), then Real.log_prod over nonzero factors."
+    },
+    {
+      "name": "log_factorial_le",
+      "type": "supporting",
+      "statement": "$\\displaystyle\\log(N!) \\le N\\sum_{m=1}^{N} \\frac{\\Lambda(m)}{m}$",
+      "significance": "First error-bounded corollary: the easy half of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1). Follows from ⌊N/m⌋ ≤ N/m and Λ ≥ 0.",
+      "description": "Substitutes the summatory identity and bounds each summand using Nat.cast_div_le and vonMangoldt_nonneg."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/prime-number-theorem-oq-03.json
+++ b/src/data/research/problems/prime-number-theorem-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "prime-number-theorem-oq-03",
   "title": "Elementary PNT with Error Bounds",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Shipped a verified, axiom-free leaf: the von Mangoldt summatory identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!), the cornerstone of the elementary (Chebyshev–Mertens) approach to PNT, plus log(N!)=∑_{n≤N} log n and the Mertens-direction bound log(N!) ≤ N·∑_{m≤N} Λ(m)/m. Gallery slug prime-number-theorem-oq-03, PR #29656.",
+    "builtItems": [
+      "vonMangoldt_summatory : ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) (exact, 0-axiom)",
+      "log_factorial_eq_sum_log : log(N!) = ∑_{n≤N} log n",
+      "log_factorial_le : log(N!) ≤ N·∑_{m≤N} Λ(m)/m (easy half of Mertens I)"
+    ],
+    "insights": [
+      "The floor-weighted summatory von Mangoldt function is absent from Mathlib's Chebyshev file, which only develops the unweighted ψ(x)=∑_{n≤x}Λ(n); the floor weights ⌊N/m⌋ are what tie it to log(N!).",
+      "Proof is Dirichlet double-counting: log n = ∑_{d∣n} Λ(d) (vonMangoldt_sum) summed over n≤N, then Finset.sum_comm' swaps to ∑_{d≤N} Λ(d)·#{n≤N:d∣n}, and Nat.Ioc_filter_dvd_card_eq_div evaluates the count to ⌊N/d⌋.",
+      "This identity is the entry point for error bounds in elementary PNT: equating it with Stirling's log(N!)=N log N−N+O(log N) yields Chebyshev ψ(x)≍x and Mertens ∑Λ(m)/m=log N+O(1)."
+    ],
+    "mathlibGaps": [
+      "No floor-weighted von Mangoldt summatory identity in Mathlib.NumberTheory.Chebyshev.",
+      "No Lean Stirling error bound log(N!)=N log N−N+O(log N) wired to this summatory framework yet."
+    ],
+    "nextSteps": [
+      "Combine with a Lean Stirling bound to derive ∑Λ(m)⌊N/m⌋ = N log N − N + O(log N) with explicit constants.",
+      "Prove full Mertens first theorem ∑_{m≤N}Λ(m)/m = log N + O(1) via Chebyshev ψ(N)=O(N).",
+      "Build the Selberg symmetry formula on top of this summatory framework toward elementary PNT."
+    ]
   },
   "tags": [
     "analytic-number-theory",


### PR DESCRIPTION
## Summary

Formalizes the **exact identity at the foundation of the elementary (Chebyshev–Mertens) approach to the Prime Number Theorem**:

$$\sum_{m=1}^{N} \Lambda(m)\left\lfloor \frac{N}{m}\right\rfloor = \log(N!)$$

where `Λ` is the von Mangoldt function and `⌊N/m⌋` is natural-number division. This floor-weighted summatory identity is **absent from Mathlib's `Chebyshev` file** (which defines `ψ`, `θ` and bounds `|ψ−θ|`, but works with the *unweighted* `ψ(x) = ∑_{n≤x} Λ(n)`).

Addresses open question **OQ-03** of the PNT entry ("Can PNT be proved elementarily with error bounds matching the analytic proof?") by supplying, in verified axiom-free form, the identity from which every elementary estimate departs — plus the first error-bounded corollary it yields.

## Theorems (`Proofs/PrimeNumberTheoremOQ03.lean`, 122 lines)

| Theorem | Statement |
|---|---|
| `vonMangoldt_summatory` | `∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!)` — the cornerstone identity |
| `log_factorial_eq_sum_log` | `log(N!) = ∑_{n≤N} log n` |
| `log_factorial_le` | `log(N!) ≤ N·∑_{m≤N} Λ(m)/m` — easy half of Mertens' first theorem |

## Proof

1. `log n = ∑_{d∣n} Λ(d)` (Mathlib `ArithmeticFunction.vonMangoldt_sum`), summed over `n ≤ N`.
2. Exchange order of summation (`Finset.sum_comm'`): `for each n, run over divisors` ↦ `for each d, run over multiples ≤ N`.
3. Count the multiples: `#{n≤N : d∣n} = ⌊N/d⌋` (`Nat.Ioc_filter_dvd_card_eq_div`), giving the floor weights.
4. `log(N!) = ∑_{n≤N} log n` via `Real.log_prod` over `N! = ∏_{n≤N} n`.
5. Corollary: `⌊N/m⌋ ≤ N/m` (`Nat.cast_div_le`) with `Λ ≥ 0`.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` lists only `propext, Classical.choice, Quot.sound` for all three theorems. No `native_decide` / `Lean.ofReduceBool`.
- Builds clean against Mathlib `v4.26.0` (`lake env lean Proofs/PrimeNumberTheoremOQ03.lean`).
- Gallery: `src/data/proofs/prime-number-theorem-oq-03/` (meta.json + annotations.json), status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)