### PR TITLE
research(frobenius-endomorphism-oq-02-oq-01): fixed field of the Frobenius is the prime subfield 𝔽_p

### DIFF
--- a/proofs/Proofs/FrobeniusEndomorphismOQ02OQ01.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ02OQ01.lean
@@ -1,0 +1,117 @@
+/-
+  The fixed field of the Frobenius is the prime subfield 𝔽_p.
+
+  Let `K` be a finite field of characteristic `p`, regarded as an extension of its
+  prime subfield `𝔽_p = ZMod p`.  The parent entry (`FrobeniusEndomorphismOQ02`)
+  packaged the prime Frobenius `x ↦ x ^ p` as an automorphism
+  `frob ∈ Gal(K / 𝔽_p) = K ≃ₐ[ZMod p] K` and proved that it **generates** the
+  cyclic Galois group (`zpowers frob = ⊤`).  This file supplies the dual,
+  "downstairs" half of the Galois correspondence at the bottom of the lattice:
+  the elements **fixed** by the Frobenius are exactly the prime subfield.
+
+    * `frob_pow_fixed`   — if `x` is fixed by `frob` then it is fixed by every
+      power `frob ^ k` (the easy induction that turns "fixed by the generator"
+      into "fixed by the whole cyclic group");
+    * `frob_fixed_iff_forall` — `frob x = x ↔ ∀ g ∈ Gal(K/𝔽_p), g x = x`, the
+      bridge from one automorphism to the entire group, using the parent's
+      generation result;
+    * `frob_fixed_iff_mem_bot` — `frob x = x ↔ x ∈ (⊥ : IntermediateField …)`,
+      i.e. the fixed points of the Frobenius are precisely `𝔽_p`
+      (Galois route via `IsGalois.mem_bot_iff_fixed`);
+    * `frob_fixed_iff_mem_range` — the elementary restatement
+      `x ^ p = x ↔ x ∈ range (algebraMap (ZMod p) K)`;
+    * `card_frob_fixedPoints` — the exact count `#{x // frob x = x} = p`;
+    * `fixedField_zpowers_frob` — the packaged Galois statement
+      `fixedField ⟨frob⟩ = 𝔽_p`, true *precisely because* `frob` generates `⊤`.
+
+  Together with the parent's "frob generates `⊤`" this is the base case of the
+  Galois theory of finite fields: it turns the abstract group action into the
+  concrete subfield lattice (each intermediate field `𝔽_{p^d}` is the fixed
+  field of `frob ^ d`, i.e. the solution set of `x ^ {p^d} = x`).
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.  Built on the parent's
+  generation lemmas together with the Mathlib results `IsGalois.mem_bot_iff_fixed`,
+  `IsGalois.mem_range_algebraMap_iff_fixed`, `AlgEquiv.mul_apply`, and
+  `IntermediateField.botEquiv`.
+-/
+import Mathlib
+import Proofs.FrobeniusEndomorphismOQ02
+
+namespace FrobeniusEndomorphismOQ02OQ01
+
+open FrobeniusEndomorphismOQ02
+
+variable (p : ℕ) [Fact p.Prime]
+variable {K : Type*} [Field K] [Fintype K] [Algebra (ZMod p) K]
+
+/-! ### From the generator to the whole group -/
+
+/-- If `x` is fixed by the Frobenius, it is fixed by every power `frob ^ k`.
+This is the induction that promotes "fixed by the generator" to "fixed by the
+whole cyclic group `⟨frob⟩`". -/
+theorem frob_pow_fixed {x : K} (hx : frob p x = x) (k : ℕ) :
+    (frob p ^ k) x = x := by
+  induction k with
+  | zero => simp
+  | succ k ih => rw [pow_succ, AlgEquiv.mul_apply, hx, ih]
+
+/-- An element is fixed by the Frobenius iff it is fixed by **every** automorphism
+in `Gal(K / 𝔽_p)`.  The `←` direction is immediate; the `→` direction uses the
+parent's generation result `exists_pow_frob` (every `g` is a power of `frob`)
+together with `frob_pow_fixed`. -/
+theorem frob_fixed_iff_forall (x : K) :
+    frob p x = x ↔ ∀ g : K ≃ₐ[ZMod p] K, g x = x := by
+  constructor
+  · intro hx g
+    obtain ⟨k, rfl⟩ := exists_pow_frob p g
+    exact frob_pow_fixed p hx k
+  · intro h
+    exact h (frob p)
+
+/-! ### The fixed points are exactly the prime subfield 𝔽_p -/
+
+/-- **The fixed field of the Frobenius is the prime subfield.** An element of a
+finite field is fixed by the prime Frobenius `x ↦ x ^ p` iff it lies in the
+bottom intermediate field `𝔽_p = ZMod p`.  Galois route: `frob` generates `⊤`,
+so being fixed by `frob` is being fixed by all of `Gal(K/𝔽_p)`, which by
+`IsGalois.mem_bot_iff_fixed` is membership in `⊥`. -/
+theorem frob_fixed_iff_mem_bot (x : K) :
+    frob p x = x ↔ x ∈ (⊥ : IntermediateField (ZMod p) K) :=
+  (frob_fixed_iff_forall p x).trans (IsGalois.mem_bot_iff_fixed x).symm
+
+/-- The elementary restatement: `x ^ p = x` iff `x` is in the image of the prime
+subfield `ZMod p ↪ K`.  This is the classical "`x ^ p = x` cuts out `𝔽_p`". -/
+theorem frob_fixed_iff_mem_range (x : K) :
+    x ^ p = x ↔ x ∈ Set.range (algebraMap (ZMod p) K) := by
+  rw [← frob_apply p x, frob_fixed_iff_forall, ← IsGalois.mem_range_algebraMap_iff_fixed]
+
+/-! ### The exact count of fixed points -/
+
+noncomputable instance fintypeFrobFixed : Fintype {x : K // frob p x = x} :=
+  Fintype.ofFinite _
+
+/-- **The Frobenius has exactly `p` fixed points**, namely the prime subfield.
+The fixed-point subtype is in bijection with `⊥ ≃ₐ[𝔽_p] 𝔽_p = ZMod p`, which has
+`p` elements. -/
+theorem card_frob_fixedPoints :
+    Fintype.card {x : K // frob p x = x} = p := by
+  have e : {x : K // frob p x = x} ≃ ZMod p :=
+    (Equiv.subtypeEquivRight (frob_fixed_iff_mem_bot p)).trans
+      (IntermediateField.botEquiv (ZMod p) K).toEquiv
+  rw [Fintype.card_congr e, ZMod.card]
+
+/-! ### Galois packaging: the fixed field of ⟨frob⟩ is 𝔽_p -/
+
+/-- The intermediate field fixed by the cyclic group `⟨frob⟩` generated by the
+Frobenius is exactly the base field `𝔽_p`.  This holds *precisely because* `frob`
+generates the full Galois group (`zpowers_frob_eq_top`): the fixed field of the
+whole group is the base field (`IsGalois.fixedField_top`).  Contrast a proper
+power `frob ^ d`, which fixes the strictly larger solution set of `x ^ {p^d} = x`
+— the seed of the divisor-lattice correspondence
+`subfields of 𝔽_{p^n} ↔ divisors of n`. -/
+theorem fixedField_zpowers_frob :
+    IntermediateField.fixedField (Subgroup.zpowers (frob p))
+      = (⊥ : IntermediateField (ZMod p) K) := by
+  rw [zpowers_frob_eq_top, IsGalois.fixedField_top]
+
+end FrobeniusEndomorphismOQ02OQ01

--- a/src/data/proofs/frobenius-endomorphism-oq-02-oq-01/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-02-oq-01/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "frobenius-endomorphism-oq-02-oq-01",
+  "title": "The Fixed Field of the Frobenius is the Prime Subfield 𝔽_p",
+  "slug": "frobenius-endomorphism-oq-02-oq-01",
+  "description": "For a finite field K of characteristic p with prime subfield 𝔽_p = ZMod p, the elements fixed by the prime Frobenius x ↦ x^p are exactly 𝔽_p. This is the 'downstairs' half of the Galois correspondence complementing the parent (frob generates Gal(K/𝔽_p)): frob_fixed_iff_mem_bot shows frob x = x ↔ x ∈ ⊥, frob_fixed_iff_mem_range gives the elementary x^p = x ↔ x ∈ range(ZMod p → K), card_frob_fixedPoints counts exactly p fixed points, and fixedField_zpowers_frob packages it as fixedField ⟨frob⟩ = 𝔽_p. Answers OQ-02-OQ-01 (the d = n case) of the parent Frobenius Galois entry. 6 theorems, 1 instance, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Finite_field#Frobenius_automorphism_and_Galois_theory",
+    "date": "Évariste Galois / Ferdinand Georg Frobenius (19th century)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "galois-theory",
+      "finite-fields",
+      "characteristic-p",
+      "frobenius",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 6 theorems and the Fintype instance are fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count — confirmed by #print axioms on frob_fixed_iff_mem_bot, frob_fixed_iff_mem_range, card_frob_fixedPoints, and fixedField_zpowers_frob). No native_decide, so no Lean.ofReduceBool. The Galois-correspondence heavy lifting is supplied by Mathlib (IsGalois.mem_bot_iff_fixed, IsGalois.fixedField_top, IntermediateField.botEquiv); the new content is the reduction from 'fixed by all of Gal(K/𝔽_p)' to 'fixed by the single generator frob' (using the parent's generation theorem) and the explicit fixed-point count and fixed-field identification.",
+    "originalContributions": [
+      "frob_pow_fixed: if x is fixed by the Frobenius then it is fixed by every power frob^k — the induction (pow_succ + AlgEquiv.mul_apply) that promotes 'fixed by the generator' to 'fixed by the whole cyclic group ⟨frob⟩'",
+      "frob_fixed_iff_forall: frob x = x ↔ ∀ g ∈ Gal(K/𝔽_p), g x = x — the bridge from one automorphism to the entire group, combining frob_pow_fixed with the parent's exists_pow_frob (every g is a power of frob). This is the genuinely new step: Mathlib's mem_bot_iff_fixed needs ALL automorphisms to fix x; reducing that universal quantifier to the single condition frob x = x is what turns it into a statement about THE Frobenius",
+      "frob_fixed_iff_mem_bot: the fixed points of the prime Frobenius are exactly the prime subfield, frob x = x ↔ x ∈ (⊥ : IntermediateField (ZMod p) K) — the 'fixed field of the Frobenius is the base field' theorem, the d = n base case of the divisor-lattice correspondence",
+      "frob_fixed_iff_mem_range: the elementary restatement x^p = x ↔ x ∈ range(algebraMap (ZMod p) K) — the classical fact that x^p = x cuts out 𝔽_p inside K",
+      "card_frob_fixedPoints: the Frobenius has exactly p fixed points, via the bijection {x // frob x = x} ≃ ⊥ ≃ₐ ZMod p (IntermediateField.botEquiv) of cardinality p",
+      "fixedField_zpowers_frob: the packaged Galois statement fixedField ⟨frob⟩ = 𝔽_p, true precisely because frob generates ⊤ (parent's zpowers_frob_eq_top) and the fixed field of the whole group is the base field (IsGalois.fixedField_top)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsGalois.mem_bot_iff_fixed",
+        "description": "For a finite Galois extension E/F, x ∈ (⊥ : IntermediateField F E) ↔ ∀ f : Gal(E/F), f x = x. The Galois-correspondence headline; frob_fixed_iff_mem_bot composes it with the single-generator reduction.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IsGalois.mem_range_algebraMap_iff_fixed",
+        "description": "x ∈ range(algebraMap F E) ↔ ∀ f, f x = x. Yields the elementary restatement frob_fixed_iff_mem_range.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IsGalois.fixedField_top",
+        "description": "For a finite Galois extension, fixedField (⊤ : Subgroup Gal(E/F)) = ⊥. Combined with the parent's zpowers_frob_eq_top it gives fixedField_zpowers_frob.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IntermediateField.botEquiv",
+        "description": "The bottom intermediate field is isomorphic to the base field: (⊥ : IntermediateField F E) ≃ₐ[F] F. Used to compute card ⊥ = card (ZMod p) = p in card_frob_fixedPoints.",
+        "module": "Mathlib.FieldTheory.IntermediateField.Adjoin.Defs"
+      },
+      {
+        "theorem": "AlgEquiv.mul_apply",
+        "description": "(e₁ * e₂) x = e₁ (e₂ x) for algebra automorphisms. The composition rule driving the frob_pow_fixed induction.",
+        "module": "Mathlib.Algebra.Algebra.Equiv"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "Fintype.card (ZMod n) = n for NeZero n. Closes card_frob_fixedPoints at p.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "parentDependencies": [
+      {
+        "theorem": "FrobeniusEndomorphismOQ02.exists_pow_frob",
+        "description": "Every automorphism in Gal(K/𝔽_p) is a natural-number power of the Frobenius. The engine of frob_fixed_iff_forall.",
+        "module": "Proofs/FrobeniusEndomorphismOQ02.lean"
+      },
+      {
+        "theorem": "FrobeniusEndomorphismOQ02.zpowers_frob_eq_top",
+        "description": "The Frobenius generates the Galois group, ⟨frob⟩ = ⊤. Used in fixedField_zpowers_frob.",
+        "module": "Proofs/FrobeniusEndomorphismOQ02.lean"
+      },
+      {
+        "theorem": "FrobeniusEndomorphismOQ02.frob_apply",
+        "description": "frob x = x^p. Lets the elementary statement x^p = x rewrite to frob x = x.",
+        "module": "Proofs/FrobeniusEndomorphismOQ02.lean"
+      }
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 117,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Galois theory of finite fields rests on two complementary facts: the Frobenius x ↦ x^p generates the cyclic Galois group Gal(𝔽_{p^n}/𝔽_p), and the field it fixes is the prime field 𝔽_p. The parent entry established generation; this entry establishes what the Frobenius fixes. The statement that the solutions of x^p = x are exactly 𝔽_p is the historical seed of the whole subject — it is how 𝔽_p is recovered inside any extension, and (with frob^d in place of frob) how the entire subfield lattice 𝔽_{p^d} ⊆ 𝔽_{p^n} ⇔ d ∣ n is cut out by the equations x^{p^d} = x.",
+    "problemStatement": "**Open Question (OQ-02-OQ-01, Frobenius endomorphism)**: Identify the fixed field of the full Frobenius as the prime field 𝔽_p (the degree-1 subfield), the d = n case of the Galois correspondence for finite fields.\n\n**Formalized**: frob_pow_fixed and frob_fixed_iff_forall (fixed by frob ⟺ fixed by all of Gal); frob_fixed_iff_mem_bot (frob x = x ↔ x ∈ ⊥ = 𝔽_p); frob_fixed_iff_mem_range (elementary x^p = x ↔ x ∈ range(ZMod p → K)); card_frob_fixedPoints (exactly p fixed points); fixedField_zpowers_frob (fixedField ⟨frob⟩ = 𝔽_p).",
+    "text": "A 117-line formalization supplying the 'downstairs' half of the Galois correspondence for finite fields, complementing the parent's 'frob generates Gal'. The key reduction is frob_fixed_iff_forall: an element is fixed by the single Frobenius automorphism iff it is fixed by every element of Gal(K/𝔽_p). The easy direction is immediate; the hard direction uses the parent's generation theorem (every g = frob^k) together with frob_pow_fixed (fixed by frob ⟹ fixed by frob^k, an induction on k via AlgEquiv.mul_apply). Feeding this into Mathlib's IsGalois.mem_bot_iff_fixed collapses the universal quantifier to the single condition, yielding frob_fixed_iff_mem_bot: the fixed points of the Frobenius are exactly the prime subfield ⊥ = 𝔽_p. The elementary restatement frob_fixed_iff_mem_range reads this as 'x^p = x cuts out 𝔽_p'. The fixed-point set is then counted exactly: card_frob_fixedPoints = p, via the bijection with ⊥ ≃ₐ ZMod p (IntermediateField.botEquiv). Finally fixedField_zpowers_frob packages the whole story as fixedField ⟨frob⟩ = 𝔽_p — true precisely because frob generates ⊤. All results verified with 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "**Single generator ⟹ whole group**: frob_pow_fixed proves (frob^k) x = x by induction on k: the base case is AlgEquiv.one_apply, and the step rewrites frob^(k+1) = frob^k * frob, applies AlgEquiv.mul_apply to get (frob^k)((frob) x), then uses hx : frob x = x and the inductive hypothesis. frob_fixed_iff_forall then closes the forward direction with the parent's exists_pow_frob (g = frob^k) and the backward direction by evaluating at frob.\n\n**Fixed points = 𝔽_p**: frob_fixed_iff_mem_bot is (frob_fixed_iff_forall).trans (IsGalois.mem_bot_iff_fixed).symm — the IsGalois and FiniteDimensional instances for finite fields are automatic. frob_fixed_iff_mem_range is the same with mem_range_algebraMap_iff_fixed, after rewriting x^p = x to frob x = x via the parent's frob_apply.\n\n**Counting**: card_frob_fixedPoints builds the equiv {x // frob x = x} ≃ {x // x ∈ ⊥} (Equiv.subtypeEquivRight applied to frob_fixed_iff_mem_bot) and composes with IntermediateField.botEquiv (ZMod p) K : ⊥ ≃ₐ ZMod p; Fintype.card_congr and ZMod.card give p. A noncomputable Fintype instance on the fixed-point subtype (Fintype.ofFinite) makes Fintype.card well-typed.\n\n**Galois packaging**: fixedField_zpowers_frob rewrites with the parent's zpowers_frob_eq_top (⟨frob⟩ = ⊤) and IsGalois.fixedField_top (fixedField ⊤ = ⊥).",
+    "keyInsights": [
+      "**The universal quantifier collapses to a single condition**: Mathlib's mem_bot_iff_fixed characterizes ⊥ as the elements fixed by EVERY automorphism. On its own that is unusable for 'the Frobenius' — one would have to check all n automorphisms. Because frob generates the group (parent), being fixed by frob already forces being fixed by all of ⟨frob⟩ = Gal. This reduction, not the Mathlib lemma, is the mathematical content.",
+      "**Two faces of the same theorem**: the Galois face (frob x = x ↔ x ∈ ⊥) and the elementary face (x^p = x ↔ x ∈ range(𝔽_p)) are literally the same statement read through frob_apply. The elementary face is the classical 'the roots of x^p − x are exactly 𝔽_p'; the Galois face is 'the fixed field of the Frobenius is the base field'.",
+      "**Exactly p, no more no fewer**: the fixed-point count is forced by the field isomorphism ⊥ ≃ 𝔽_p, not by a degree/root-counting bound. The same bijection that identifies the fixed set with the prime subfield also pins its cardinality at p.",
+      "**The base case of the divisor lattice**: fixedField ⟨frob⟩ = 𝔽_p is the d = n endpoint of the correspondence subfields 𝔽_{p^d} ↔ ⟨frob^d⟩. A proper power frob^d fixes the strictly larger solution set of x^{p^d} = x; the full Frobenius (d = 1 power, generating the whole group) fixes the smallest subfield 𝔽_p."
+    ],
+    "prerequisites": [
+      "The parent entry FrobeniusEndomorphismOQ02: the Frobenius frob as an element of Gal(K/𝔽_p), frob_apply (frob x = x^p), and the generation theorem zpowers_frob_eq_top / exists_pow_frob",
+      "Galois theory of finite fields: the automatic IsGalois (ZMod p) K and FiniteDimensional instances, and IsGalois.mem_bot_iff_fixed / fixedField_top",
+      "Intermediate fields: (⊥ : IntermediateField F E) as the image of the base field, and IntermediateField.botEquiv : ⊥ ≃ₐ[F] F",
+      "Group actions on fields: AlgEquiv.mul_apply (composition of automorphisms) and the order/power structure of a finite cyclic group"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves the Frobenius generates the cyclic group Gal(K/𝔽_p) and lists as its second open question 'identify the fixed field of the full Frobenius as the prime field 𝔽_p'. This entry answers it: the fixed points of frob are exactly ⊥ = 𝔽_p, with the explicit count p and the packaged fixedField ⟨frob⟩ = 𝔽_p."
+    },
+    {
+      "proofId": "frobenius-endomorphism-oq-01",
+      "relationship": "related",
+      "description": "The grandparent packages the Frobenius x ↦ x^p as a ring endomorphism with x^(p^n) = x. This entry uses the same map's fixed points to recover the prime subfield, the bottom of the Galois lattice the grandparent's iterate sits atop."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FrobeniusEndomorphismOQ02"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ02OQ01",
+    "lineCount": 117,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/FrobeniusEndomorphismOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "frob_fixed_iff_mem_bot",
+      "type": "core",
+      "statement": "$\\mathrm{frob}\\,x = x \\iff x \\in (\\bot : \\mathrm{IntermediateField}\\ \\mathbb{F}_p\\ K)$",
+      "significance": "The fixed field of the Frobenius is the prime subfield 𝔽_p — the central theorem of the entry and the d = n case of the Galois correspondence for finite fields.",
+      "description": "Fixed points of the Frobenius are exactly 𝔽_p."
+    },
+    {
+      "name": "frob_fixed_iff_forall",
+      "type": "core",
+      "statement": "$\\mathrm{frob}\\,x = x \\iff \\forall g \\in \\mathrm{Gal}(K/\\mathbb{F}_p),\\ g\\,x = x$",
+      "significance": "The single-generator reduction: fixed by the Frobenius alone is equivalent to fixed by the entire Galois group. This is the new mathematical content that makes Mathlib's mem_bot_iff_fixed usable for THE Frobenius.",
+      "description": "Fixed by frob ⟺ fixed by all of Gal."
+    },
+    {
+      "name": "frob_fixed_iff_mem_range",
+      "type": "supporting",
+      "statement": "$x^p = x \\iff x \\in \\mathrm{range}(\\mathbb{F}_p \\to K)$",
+      "significance": "The elementary restatement: x^p = x cuts out exactly the prime subfield 𝔽_p inside K — the classical 'roots of x^p − x are 𝔽_p'.",
+      "description": "Elementary form: x^p = x ⟺ x ∈ 𝔽_p."
+    },
+    {
+      "name": "frob_pow_fixed",
+      "type": "supporting",
+      "statement": "$\\mathrm{frob}\\,x = x \\Rightarrow (\\mathrm{frob}^k)\\,x = x$",
+      "significance": "The induction promoting 'fixed by the generator' to 'fixed by every power', via AlgEquiv.mul_apply. Engine of the single-generator reduction.",
+      "description": "Fixed by frob implies fixed by every power."
+    },
+    {
+      "name": "card_frob_fixedPoints",
+      "type": "core",
+      "statement": "$\\#\\{x : K \\mid \\mathrm{frob}\\,x = x\\} = p$",
+      "significance": "The Frobenius has exactly p fixed points, via the field isomorphism ⊥ ≃ 𝔽_p — no more, no fewer.",
+      "description": "Exactly p fixed points."
+    },
+    {
+      "name": "fixedField_zpowers_frob",
+      "type": "core",
+      "statement": "$\\mathrm{fixedField}\\ \\langle \\mathrm{frob} \\rangle = (\\bot : \\mathrm{IntermediateField}\\ \\mathbb{F}_p\\ K)$",
+      "significance": "The packaged Galois statement: the field fixed by the cyclic group generated by the Frobenius is the base field 𝔽_p — true precisely because frob generates the whole group.",
+      "description": "Fixed field of ⟨frob⟩ is 𝔽_p."
+    }
+  ],
+  "references": [
+    {
+      "text": "Finite field — the prime subfield 𝔽_p is exactly the set of solutions of x^p = x, the fixed field of the Frobenius automorphism.",
+      "url": "https://en.wikipedia.org/wiki/Finite_field#Frobenius_automorphism_and_Galois_theory"
+    },
+    {
+      "text": "Galois group of a finite field — cyclic, generated by Frobenius; subfields correspond to divisors of n, each the fixed field of a power of Frobenius.",
+      "url": "https://en.wikipedia.org/wiki/Galois_group"
+    },
+    {
+      "text": "Mathlib4: IsGalois.mem_bot_iff_fixed, IsGalois.fixedField_top, IntermediateField.botEquiv, AlgEquiv.mul_apply.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the 'downstairs' half of the Galois correspondence for finite fields: the elements of K fixed by the prime Frobenius x ↦ x^p are exactly the prime subfield 𝔽_p. The key step (frob_fixed_iff_forall) reduces 'fixed by all of Gal(K/𝔽_p)' to 'fixed by the single generator frob', using the parent's generation theorem; composed with Mathlib's mem_bot_iff_fixed this gives frob_fixed_iff_mem_bot (frob x = x ↔ x ∈ ⊥), with elementary form x^p = x ↔ x ∈ 𝔽_p, exact count card_frob_fixedPoints = p, and the packaged fixedField ⟨frob⟩ = 𝔽_p. 6 theorems and 1 instance, 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Together with the parent's 'frob generates Gal' this is the base case of the subfield correspondence for finite fields: the fixed field of the whole group ⟨frob⟩ is 𝔽_p, while a proper power frob^d fixes the strictly larger 𝔽_{p^d} (the solutions of x^{p^d} = x). Iterating this over divisors d ∣ n produces the full lattice 𝔽_{p^d} ⊆ 𝔽_{p^n} ⇔ d ∣ n. The fixed-field-of-Frobenius picture is also the local model for Frobenius elements in global Galois groups, where the residue-field extension is exactly this finite-field situation.",
+    "openQuestions": [
+      "Establish the full divisor-lattice correspondence: for d ∣ n, fixedField ⟨frob^d⟩ = 𝔽_{p^d} (the solution set of x^{p^d} = x), and the count #{x // x^{p^d} = x} = p^d, generalizing card_frob_fixedPoints from d = n to all d",
+      "Characterize the fixed points of frob^d elementarily as the unique subfield of order p^d, completing the bijection {subfields of 𝔽_{p^n}} ↔ {divisors of n}"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-02-OQ-01** of the Frobenius Galois entry (`frobenius-endomorphism-oq-02`): for a finite field `K` of characteristic `p`, the elements fixed by the prime Frobenius `x ↦ x^p` are exactly the prime subfield `𝔽_p = ZMod p`. This is the "downstairs" half of the Galois correspondence, complementing the parent's "frob generates `Gal(K/𝔽_p)`" — the `d = n` base case of the divisor-lattice correspondence `𝔽_{p^d} ⊆ 𝔽_{p^n} ⇔ d ∣ n`.

## Results (`Proofs/FrobeniusEndomorphismOQ02OQ01.lean`)

- `frob_pow_fixed` — fixed by `frob` ⟹ fixed by every power `frob^k` (induction via `AlgEquiv.mul_apply`).
- `frob_fixed_iff_forall` — `frob x = x ↔ ∀ g ∈ Gal(K/𝔽_p), g x = x`. **The new content**: reduces the universal quantifier over the whole Galois group to the single generator, using the parent's `exists_pow_frob`.
- `frob_fixed_iff_mem_bot` — `frob x = x ↔ x ∈ (⊥ : IntermediateField (ZMod p) K)`, i.e. fixed points of Frobenius `= 𝔽_p` (composes the above with Mathlib's `IsGalois.mem_bot_iff_fixed`).
- `frob_fixed_iff_mem_range` — elementary restatement `x^p = x ↔ x ∈ range(algebraMap (ZMod p) K)`.
- `card_frob_fixedPoints` — exactly `p` fixed points (bijection with `⊥ ≃ₐ ZMod p` via `IntermediateField.botEquiv`).
- `fixedField_zpowers_frob` — packaged Galois form `fixedField ⟨frob⟩ = 𝔽_p`.

## Verification

- **6 theorems, 1 instance, 117 lines.** 0 sorries, 0 axioms, no `native_decide`.
- `#print axioms` on the headline results lists only `propext` / `Classical.choice` / `Quot.sound` (foundational; do not count).
- Reuses the parent `Proofs.FrobeniusEndomorphismOQ02` (generation theorem) rather than re-deriving it — a non-wrapper bridge entry.

Badge **original**: the genuinely new step is the single-generator reduction (`frob_fixed_iff_forall`) plus the explicit fixed-point count and fixed-field identification. Mathlib's Galois-correspondence lemmas (`mem_bot_iff_fixed`, `fixedField_top`, `botEquiv`) are credited in `meta.json`'s `assumptions` / `mathlibDependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)