### PR TITLE
Enrich Birthday k-Way Histogram Recurrence: add annotations

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-transition",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "definition",
+    "title": "The Histogram Transition Step",
+    "content": "`transition c i` is one placement step on the multiplicity histogram. The state c : List ℕ records, at index i, the number of *live* days currently at occupancy level i. Placing a person on a level-i day decrements the level-i count (`List.set` with `getD i 0 − 1`) and, when level i+1 is still a live level (i+1 < c.length), increments the level-(i+1) count; a day at the top live level c.length−1 becomes full and simply leaves the histogram. Nat subtraction is safe because the recurrence weights this branch by c.getD i 0, which is 0 exactly when level i is empty.",
+    "mathContext": "$\\mathrm{transition}(c, i)$ moves one day from occupancy level $i$ to $i+1$ (or off the histogram at the top), so the state always tracks the full occupancy profile $(e_0, e_1, \\ldots, e_{M-1})$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicity histogram", "occupancy levels", "List.set / List.getD", "state-transition recurrence"],
+    "prerequisites": ["lists in Lean", "Nat subtraction semantics"]
+  },
+  {
+    "id": "ann-rk",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 89 },
+    "type": "definition",
+    "title": "The General k-Way Recurrence Rk and Its Invariants",
+    "content": "`Rk n c` counts the ways to place n more people into the live slots described by histogram c, with maximum occupancy M = c.length = k−1. The recurrence sums over occupancy levels: Rk(n+1, c) = ∑_{i<c.length} c.getD i 0 · Rk n (transition c i), with base case Rk 0 c = 1. Because both `transition` and `Rk` are computable, concrete instances reduce under kernel `decide`. Two structural lemmas anchor it: `transition_length` shows the histogram width M is invariant under a step (via `List.length_set` on both branches of the `if`), and `Rk_nil_succ` shows an empty histogram admits no placement (the sum ranges over range 0 = ∅).",
+    "mathContext": "$R_k(n+1, c) = \\sum_{i < |c|} c_i \\cdot R_k(n, \\mathrm{transition}(c,i))$, $R_k(0, c) = 1$ — the histogram analogue of the parent's two-state $R$.",
+    "significance": "key",
+    "relatedConcepts": ["recurrence relation", "computable counting", "structural invariant", "Finset.range sum"],
+    "prerequisites": ["recursive definitions in Lean", "Finset sums", "the parent's k=3 recurrence"]
+  },
+  {
+    "id": "ann-faithful",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 122 },
+    "type": "insight",
+    "title": "Faithful Specialization to the Parent's k=3 Recurrence",
+    "content": "The centerpiece `Rk_eq_Rpar` proves Rk n [e,s] = Rpar n e s, where Rpar is the parent's two-state recurrence e·R(n,e−1,s+1) + s·R(n,e,s−1). On width-2 states the two transitions hold definitionally: transition [e,s] 0 = [e−1,s+1] and transition [e,s] 1 = [e,s−1] (both by `rfl`). The proof inducts on n (generalizing e, s), expands the level sum with `Finset.sum_range_succ`/`sum_range_one`, rewrites the two transitions and `getD` lookups, applies the induction hypothesis twice, and closes by `rfl`. This is a *provable* equality of recurrences, not mere numerical agreement on examples — nothing is lost passing to the general list-state formulation.",
+    "mathContext": "$R_k(n, [e, s]) = R_{\\mathrm{par}}(n, e, s)$: the $M = 2$ instance of the histogram recurrence is definitionally the parent's two-state $k=3$ recurrence.",
+    "significance": "key",
+    "relatedConcepts": ["faithful generalization", "induction on ℕ", "definitional equality (rfl)", "specialization"],
+    "prerequisites": ["induction proofs in Lean", "Finset.sum_range_succ", "the parent recurrence"]
+  },
+  {
+    "id": "ann-unified-count",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 124, "endLine": 140 },
+    "type": "concept",
+    "title": "The Unified k-Way Birthday Count",
+    "content": "`birthdayCountK n d k = Rk n (d :: replicate (k−2) 0)` counts functions f : Fin n → Fin d whose every fiber has size < k (no k people share a day), starting from all d days empty in a width-(k−1) histogram. `birthdayCountK_eq_Rpar_k3` proves that at k = 3 the start state reduces definitionally to [d, 0], so the unified count recovers the parent's Rpar n d 0 (= birthdayCount3) via the faithfulness theorem. One definition thus subsumes the injective count (k=2), the parent's triple-avoiding count (k=3), and the new k≥4 counts.",
+    "mathContext": "$\\mathrm{birthdayCountK}(n,d,k) = R_k(n, d :: 0^{k-2})$ = number of $f : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,d$ with all fibers of size $< k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["bounded-fiber functions", "k-way coincidence", "unified counting formula"],
+    "prerequisites": ["functions with bounded fibers", "List.replicate"]
+  },
+  {
+    "id": "ann-concrete-counts",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 209 },
+    "type": "context",
+    "title": "Concrete k=2, 3, 4 Counts and Monotonicity in k",
+    "content": "Kernel `decide` (not `native_decide`, keeping the file axiom-free) evaluates the recurrence on small inputs across three regimes: k=2 gives the descending factorial d·(d−1)···(d−n+1) of injective placements (e.g. birthdayCountK 5 5 2 = 120 = 5!, and 0 when n > d); k=3 recovers the parent's values 24, 90, and capacity-zero; k=4 produces genuinely new quadruple-avoiding counts the parent never computed (birthdayCountK 4 3 4 = 78, birthdayCountK 7 2 4 = 0 at n > 2·3 capacity). `k_monotone_4_3` checks the count is monotone in k — relaxing the maximum occupancy can only admit more assignments — with 0 ≤ 54 ≤ 78 for n=4, d=3. `kway_summary` bundles faithfulness, k=3 recovery, and a new k=4 value.",
+    "mathContext": "$k=2$: descending factorial; capacity-zero when $n > M\\cdot d = (k-1)d$; monotone $0 \\le 54 \\le 78$ for $k = 2,3,4$ at $n=4, d=3$.",
+    "significance": "context",
+    "relatedConcepts": ["descending factorial", "kernel decide", "capacity bound", "monotonicity in k"],
+    "prerequisites": ["decision procedures in Lean", "the birthday problem"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-02`.

## Gap addressed
The entry had a rich, well-formed `meta.json` (structured conclusion + crossReferences) but **no `annotations.json`** — zero inline annotation coverage.

## Added
`annotations.json` with **5 substantive annotations** spanning the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- the histogram `transition` step
- the general recurrence `Rk` and its structural invariants (`transition_length`, `Rk_nil_succ`)
- the faithful specialization `Rk_eq_Rpar` to the parent's k=3 recurrence
- the unified count `birthdayCountK` and its k=3 recovery
- the concrete kernel-`decide` k=2/3/4 counts and monotonicity in k

## Verification
- JSON validates; `pnpm build` succeeds.
- Axiom integrity unchanged: `verified`/`original`/0-axiom matches the Lean source (kernel `decide`, no `native_decide`).