### PR TITLE
Enrich Cantor Intersection Theorem (complete metric spaces): add annotations.json

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cantor-setup",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "The Metric-Space Cantor Theorem and What Is New vs Mathlib",
+    "content": "The docstring frames the entry against its parent (nested closed intervals in ℝ) and against Mathlib. Mathlib's `Metric.nonempty_iInter_of_nonempty_biInter` proves only that the intersection is nonempty, and it consumes a finite-intersection hypothesis (every ⋂ over a finite index set is nonempty) rather than the natural nested form a working mathematician writes down. This file does two things Mathlib does not: (1) it bridges the natural nested + nonempty hypotheses to the finite-intersection form, and (2) it proves uniqueness, upgrading 'nonempty' to 'a single point'. The ambient setup `variable {α} [MetricSpace α] [CompleteSpace α] {s : ℕ → Set α}` fixes a sequence of sets in a complete metric space; completeness is exactly the hypothesis that makes the existence half true — in ℚ a nested family of closed sets trapping √2 has empty intersection.",
+    "mathContext": "$s_0 \\supseteq s_1 \\supseteq \\cdots,\\ \\operatorname{diam}(s_n) \\to 0 \\ \\Rightarrow\\ \\bigcap_n s_n = \\{x\\}$ in a complete metric space.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor intersection theorem", "completeness", "metric space", "diameter", "nested sets"],
+    "prerequisites": ["metric spaces", "completeness and Cauchy sequences", "set intersections"]
+  },
+  {
+    "id": "ann-biinter-antitone",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 52, "endLine": 64 },
+    "type": "technique",
+    "title": "Collapsing the Prefix Intersection to the Smallest Set",
+    "content": "`biInter_nonempty_of_antitone` is the bridge lemma. Mathlib's existence lemma asks for `(⋂ n ≤ N, s n).Nonempty` for each N, but the natural hypothesis is only that the family is nested decreasing and each set nonempty. The proof turns `∀ n, s (n+1) ⊆ s n` into `Antitone s` via `antitone_nat_of_succ_le` (one-step containment ⟹ containment for all n ≤ N), so the smallest set s N is contained in every earlier s n. Therefore any point x ∈ s N already lies in every s n with n ≤ N, i.e. in the prefix intersection. `simp only [mem_iInter]` unfolds the bounded intersection to the goal `∀ n ≤ N, x ∈ s n`, discharged by `hanti hn hx`. The prefix intersection collapses to s N — nestedness does all the work.",
+    "mathContext": "$\\bigcap_{n \\le N} s_n = s_N$ because $s_N \\subseteq s_n$ for $n \\le N$ (antitonicity); nonempty since $s_N$ is.",
+    "significance": "key",
+    "relatedConcepts": ["Antitone", "antitone_nat_of_succ_le", "Set.mem_iInter", "bounded intersection", "nested family"],
+    "prerequisites": ["monotone/antitone sequences", "indexed intersections"]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 66, "endLine": 75 },
+    "type": "theorem",
+    "title": "Existence: Where Completeness Enters",
+    "content": "`nonempty_iInter` is the existence half. With the bridge lemma in hand, the proof is a one-liner: feed the closed, bounded, finite-intersection (from `biInter_nonempty_of_antitone`), and diam → 0 hypotheses straight into `Metric.nonempty_iInter_of_nonempty_biInter`. This is the only step that uses `CompleteSpace α`: completeness is what guarantees the Cauchy sequence formed by picking one point from each s n converges, and the limit lands in every (closed) s n. Conceptually the diameters shrinking to 0 make any choice sequence Cauchy, and completeness supplies the limit. Drop completeness and the theorem fails — the same construction in ℚ produces an empty intersection.",
+    "mathContext": "Pick $x_n \\in s_n$; $\\operatorname{diam}(s_n)\\to 0$ makes $(x_n)$ Cauchy; completeness gives $x_n \\to x$, and each $s_n$ closed forces $x \\in s_n$.",
+    "significance": "critical",
+    "relatedConcepts": ["nonempty_iInter_of_nonempty_biInter", "CompleteSpace", "Cauchy sequence", "closed sets", "completeness ⟺ Cantor property"],
+    "prerequisites": ["completeness", "Cauchy sequences", "closed sets contain their limits"]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 77, "endLine": 91 },
+    "type": "technique",
+    "title": "Uniqueness: the Shrinking-Diameter Squeeze",
+    "content": "`subsingleton_iInter` is the new content over Mathlib and needs only diam → 0 — not completeness. If x and y both lie in every s n, then by `dist_le_diam_of_mem` (two points of a bounded set are within its diameter) we get dist x y ≤ diam (s n) for all n. This is an eventual (in fact pointwise) lower bound on the convergent sequence diam (s n) → 0, so `ge_of_tendsto` passes it to the limit: dist x y ≤ 0. Then `dist_le_zero.mp` gives x = y. Notice the asymmetry with existence: existence is powered by 'diam → 0 makes choices Cauchy', uniqueness by 'diam → 0 squeezes any two common points together' — two different consequences of the same hypothesis, only one of which needs the space to be complete.",
+    "mathContext": "$\\operatorname{dist}(x,y) \\le \\operatorname{diam}(s_n) \\ \\forall n,\\ \\operatorname{diam}(s_n)\\to 0 \\ \\Rightarrow\\ \\operatorname{dist}(x,y) \\le 0 \\ \\Rightarrow\\ x = y$.",
+    "significance": "critical",
+    "relatedConcepts": ["dist_le_diam_of_mem", "ge_of_tendsto", "squeeze argument", "Set.Subsingleton", "dist_le_zero"],
+    "prerequisites": ["diameter of a bounded set", "passing inequalities to limits", "metric axioms"]
+  },
+  {
+    "id": "ann-singleton",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 102 },
+    "type": "theorem",
+    "title": "Assembling the Singleton Characterization",
+    "content": "`iInter_eq_singleton` combines the two halves into the full theorem ⋂ n, s n = {x}. Existence (`nonempty_iInter`) produces a witness x ∈ ⋂ n, s n; uniqueness (`subsingleton_iInter`) says the intersection has at most one point. `Set.Subsingleton.eq_singleton_of_mem` is the exact glue: a subsingleton set that contains a point equals the singleton of that point. This is the form analysts actually use — not 'the intersection is nonempty' but 'the nested family determines one specific limit point' — which is what lets the theorem extract the fixed point in a contraction argument or the limit of a bisection.",
+    "mathContext": "nonempty $\\wedge$ subsingleton $\\Rightarrow$ singleton: $\\bigcap_n s_n = \\{x\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Subsingleton.eq_singleton_of_mem", "existence + uniqueness", "singleton", "limit point extraction"],
+    "prerequisites": ["subsingletons and singletons", "set equality"]
+  },
+  {
+    "id": "ann-existsunique",
+    "proofId": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 104, "endLine": 116 },
+    "type": "theorem",
+    "title": "Repackaging as ∃! — the Analyst's Interface",
+    "content": "`existsUnique_mem_iInter` restates the result as `∃! x, x ∈ ⋂ n, s n`, the most directly usable form. The proof rewrites by `iInter_eq_singleton`'s equation ⋂ n, s n = {x}: membership in the intersection becomes membership in {x}, so existence is `rfl` (x ∈ {x}) and uniqueness is just unfolding `y ∈ {x}` to y = x. The two packagings (set equality and ∃!) are logically equivalent but ergonomically different: the singleton form is convenient for rewriting, the ∃! form plugs straight into definite-description and 'the unique point such that' constructions, e.g. defining the limit of a contracting sequence.",
+    "mathContext": "$\\exists! x,\\ x \\in \\bigcap_n s_n$, equivalent to $\\bigcap_n s_n = \\{x\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ExistsUnique", "Set.mem_singleton_iff", "definite description", "Banach fixed point"],
+    "prerequisites": ["existential uniqueness", "singleton membership"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02` (The Cantor Intersection Theorem for Complete Metric Spaces).

## Gap addressed
The entry had a rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage on the proof page.

## Added
6 annotations covering the full Lean file (lines 1–116), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. **Setup & vs-Mathlib framing** — nested closed bounded sets, why completeness matters
2. **`biInter_nonempty_of_antitone`** — collapsing the prefix intersection to the smallest set (bridge to Mathlib's finite-intersection lemma)
3. **`nonempty_iInter` (existence)** — the single step that uses `CompleteSpace`
4. **`subsingleton_iInter` (uniqueness)** — the shrinking-diameter squeeze, needing only diam → 0
5. **`iInter_eq_singleton`** — assembling existence + uniqueness into the singleton form
6. **`existsUnique_mem_iInter`** — the ∃! repackaging (analyst's interface)

## Verification
- JSON validated; build's data-generation step regenerated `public/data/proofs/.../annotations.json` (8193 bytes) successfully.
- Axiom integrity unchanged: meta reports `verified` / `badge: original` / `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axioms).
- Only `annotations.json` added; no existing content modified.