### PR TITLE
research(catalan-numbers-oq-01-oq-04): strict log-convexity C(n+1)²<C(n)·C(n+2) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4119,6 +4119,7 @@ import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
 import Proofs.CatalanNumbersOQ01OQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ01OQ02OQ03
+import Proofs.CatalanNumbersOQ01OQ04
 import Proofs.MarkovCoprime
 import Proofs.MarkovEquation
 import Proofs.MarkovHurwitz

--- a/proofs/Proofs/CatalanNumbersOQ01OQ04.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ04.lean
@@ -1,0 +1,114 @@
+import Mathlib
+
+/-
+# Strict log-convexity of the Catalan numbers (a Turán-type inequality)
+
+For every `n` the Catalan numbers satisfy the **strict** Turán inequality
+
+  `catalan (n+1) ^ 2 < catalan n * catalan (n+2)`.
+
+Equivalently, the sequence `n ↦ catalan n` is *strictly* log-convex.  This is
+the leaf `oq-01-oq-04` of `catalan-numbers-oq-01`.
+
+## Proof idea (pointwise, no induction)
+
+The only inputs are two instances of the standard one-step recurrence
+`(n+2) · catalan (n+1) = 2(2n+1) · catalan n`, derived here from Mathlib's
+central-binomial API:
+
+* `succ_mul_catalan_eq_centralBinom : (n+1) * catalan n = centralBinom n`
+* `Nat.succ_mul_centralBinom_succ : (n+1) * centralBinom (n+1)
+      = 2(2n+1) * centralBinom n`.
+
+Combining them and cancelling the positive factor `n+1` yields the catalan
+recurrence; doing the same one step further gives the `n+1` instance.  Writing
+`a = catalan n`, `b = catalan (n+1)`, `c = catalan (n+2)`, the two recurrences
+
+  `(n+2) b = 2(2n+1) a`,   `(n+3) c = 2(2n+3) b`
+
+force, after multiplying out by the positive quantity `2(2n+1)(2n+3)`,
+
+  `D · (a·c) = D · b² + 3 · (b·c)`   with `D = 2(2n+1)(2n+3) > 0`,
+
+because `(2n+3)(n+2) − (2n+1)(n+3) = 3`.  Since `b, c > 0` the surplus
+`3 · (b·c)` is strictly positive, so `b² < a·c`.
+
+All arithmetic is carried out over `ℤ` (where `linear_combination` and
+cancellation are available) and transferred back to `ℕ` at the end.
+-/
+
+namespace CatalanNumbersOQ01OQ04
+
+open Nat
+
+/-- The one-step Catalan recurrence `(n+2) · catalan (n+1) = 2(2n+1) · catalan n`,
+expressed over `ℤ`.  Derived from the central-binomial recurrence by cancelling
+the positive factor `n+1`. -/
+theorem catalan_recurrence (n : ℕ) :
+    ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) = 2 * (2 * n + 1) * (catalan n : ℤ) := by
+  -- cast the two Mathlib identities to ℤ
+  have e1 : ((Nat.centralBinom n : ℤ)) = ((n : ℤ) + 1) * (catalan n : ℤ) := by
+    exact_mod_cast (succ_mul_catalan_eq_centralBinom n).symm
+  have e2 : ((Nat.centralBinom (n + 1) : ℤ)) = ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) := by
+    exact_mod_cast (succ_mul_catalan_eq_centralBinom (n + 1)).symm
+  have r1 : ((n : ℤ) + 1) * (Nat.centralBinom (n + 1) : ℤ)
+      = 2 * (2 * n + 1) * (Nat.centralBinom n : ℤ) := by
+    exact_mod_cast Nat.succ_mul_centralBinom_succ n
+  have hn1 : ((n : ℤ) + 1) ≠ 0 := by positivity
+  -- cancel (n+1) after substituting e1, e2 into r1
+  apply mul_left_cancel₀ hn1
+  linear_combination r1 + 2 * (2 * n + 1) * e1 - ((n : ℤ) + 1) * e2
+
+/-- Positivity of the Catalan numbers, recovered from the central-binomial API:
+`(n+1) · catalan n = centralBinom n > 0`, and `n+1 > 0`. -/
+theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  have h : (n + 1) * catalan n = Nat.centralBinom n :=
+    succ_mul_catalan_eq_centralBinom n
+  have hb : 0 < Nat.centralBinom n := Nat.centralBinom_pos n
+  -- if catalan n = 0 then (n+1)*catalan n = 0, contradicting centralBinom n > 0
+  rcases Nat.eq_zero_or_pos (catalan n) with h0 | hpos
+  · rw [h0, Nat.mul_zero] at h; omega
+  · exact hpos
+
+/-- **Strict log-convexity (Turán inequality) of the Catalan numbers.**
+
+For every `n`,
+`catalan (n+1) ^ 2 < catalan n * catalan (n+2)`.
+
+This is strict for all `n` (the multiplicative gap is exactly the factor
+`(2n²+7n+6)/(2n²+7n+3) > 1`); Mathlib has the Catalan API but no Turán-type
+inequality. -/
+theorem catalan_turan (n : ℕ) :
+    catalan (n + 1) ^ 2 < catalan n * catalan (n + 2) := by
+  -- Two consecutive recurrence instances, as facts over ℤ.
+  have R1 : ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) = 2 * (2 * n + 1) * (catalan n : ℤ) :=
+    catalan_recurrence n
+  have R2 : ((n : ℤ) + 3) * (catalan (n + 2) : ℤ)
+      = 2 * (2 * n + 3) * (catalan (n + 1) : ℤ) := by
+    have h := catalan_recurrence (n + 1)
+    have he : n + 1 + 1 = n + 2 := rfl
+    rw [he] at h
+    push_cast at h ⊢
+    linear_combination h
+  have hBpos : 0 < (catalan (n + 1) : ℤ) := by exact_mod_cast catalan_pos (n + 1)
+  have hCpos : 0 < (catalan (n + 2) : ℤ) := by exact_mod_cast catalan_pos (n + 2)
+  -- abbreviate; `set` folds the facts above to use A, B, C automatically
+  set A : ℤ := (catalan n : ℤ) with hA
+  set B : ℤ := (catalan (n + 1) : ℤ) with hB
+  set C : ℤ := (catalan (n + 2) : ℤ) with hC
+  have hD : (0 : ℤ) < 2 * (2 * n + 1) * (2 * n + 3) := by positivity
+  -- the key surplus identity: D·(A·C) = D·B² + 3·(B·C)
+  have key : 2 * (2 * n + 1) * (2 * n + 3) * (A * C)
+      = 2 * (2 * n + 1) * (2 * n + 3) * B ^ 2 + 3 * (B * C) := by
+    linear_combination ((2 * (n : ℤ) + 1) * B) * R2 - (((2 : ℤ) * n + 3) * C) * R1
+  -- 3·(B·C) > 0, so D·B² < D·(A·C), hence B² < A·C
+  have hbc : 0 < 3 * (B * C) := by positivity
+  have hlt : 2 * (2 * n + 1) * (2 * n + 3) * B ^ 2
+      < 2 * (2 * n + 1) * (2 * n + 3) * (A * C) := by
+    rw [key]; linarith
+  have hZ : B ^ 2 < A * C := lt_of_mul_lt_mul_left hlt (le_of_lt hD)
+  -- transfer back to ℕ
+  rw [hA, hB, hC] at hZ
+  exact_mod_cast hZ
+
+end CatalanNumbersOQ01OQ04

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": { "startLine": 4, "endLine": 38 },
+    "type": "context",
+    "title": "Strict Log-Convexity (Turán Inequality) of the Catalan Numbers",
+    "content": "The Catalan numbers satisfy the strict Turán inequality catalan(n+1)² < catalan n · catalan(n+2) — strict log-convexity. Mathlib has a rich Catalan API but no log-convexity inequality. The proof is pointwise (no induction): it first reconstructs the first-order Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n from Mathlib's central-binomial recurrence, then combines two consecutive instances into a single surplus identity whose constant surplus 3·(catalan(n+1)·catalan(n+2)) > 0 forces strictness for every n.",
+    "mathContext": "$C(n{+}1)^2 < C(n)\\,C(n{+}2)$; the multiplicative gap is $(2n^2{+}7n{+}6)/(2n^2{+}7n{+}3) > 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "log-convexity", "Turán inequality", "central binomial coefficients", "first-order recurrence"],
+    "prerequisites": ["the central-binomial recurrence", "linear_combination over ℤ"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": { "startLine": 44, "endLine": 60 },
+    "type": "theorem",
+    "title": "First-Order Catalan Recurrence over ℤ",
+    "content": "catalan_recurrence: (n+2)·catalan(n+1) = 2(2n+1)·catalan n. Mathlib records the central-binomial recurrence (n+1)·centralBinom(n+1) = 2(2n+1)·centralBinom n and the bridge (n+1)·catalan n = centralBinom n, but not this Catalan form. Casting both to ℤ, substituting, and cancelling the positive factor n+1 (mul_left_cancel₀ + linear_combination) yields it cleanly.",
+    "mathContext": "$(n{+}2)\\,C(n{+}1) = 2(2n{+}1)\\,C(n)$, by cancelling $n{+}1$ from the central-binomial recurrence.",
+    "significance": "key",
+    "relatedConcepts": ["recurrence relation", "central binomial coefficients", "factor cancellation", "linear_combination"],
+    "prerequisites": ["succ_mul_catalan_eq_centralBinom", "succ_mul_centralBinom_succ", "mul_left_cancel₀"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": { "startLine": 62, "endLine": 72 },
+    "type": "theorem",
+    "title": "Positivity: 0 < catalan n",
+    "content": "catalan_pos: the Catalan numbers are positive. From (n+1)·catalan n = centralBinom n > 0, a zero value of catalan n would make the left side 0, contradicting positivity of the central binomial coefficient. Positivity is what licenses the strict comparison in the Turán inequality.",
+    "mathContext": "$0 < C(n)$, from $(n{+}1)\\,C(n) = \\binom{2n}{n} > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["positivity", "central binomial coefficients"],
+    "prerequisites": ["centralBinom_pos", "succ_mul_catalan_eq_centralBinom"]
+  },
+  {
+    "id": "ann-turan",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": { "startLine": 73, "endLine": 114 },
+    "type": "theorem",
+    "title": "Strict Turán Inequality via a Surplus Identity",
+    "content": "catalan_turan: catalan(n+1)² < catalan n · catalan(n+2). Writing A = catalan n, B = catalan(n+1), C = catalan(n+2), the recurrence at n and n+1 gives (n+2)B = 2(2n+1)A and (n+3)C = 2(2n+3)B. One linear_combination of these (scaled by (2n+1)B and (2n+3)C) yields D·(A·C) = D·B² + 3·(B·C) with D = 2(2n+1)(2n+3) > 0. Since B, C > 0 the surplus 3·(B·C) is strictly positive, so D·B² < D·(A·C); cancelling D (lt_of_mul_lt_mul_left) gives B² < A·C over ℤ, cast back to ℕ. The surplus constant 3 is exactly (2n+3)(n+2) − (2n+1)(n+3).",
+    "mathContext": "$D\\,(AC) = D\\,B^2 + 3(BC)$ with $D = 2(2n{+}1)(2n{+}3) > 0 \\Rightarrow B^2 < AC$.",
+    "significance": "primary",
+    "relatedConcepts": ["Turán inequality", "log-convexity", "surplus identity", "linear_combination", "cancellation of a positive factor"],
+    "prerequisites": ["catalan_recurrence", "catalan_pos", "lt_of_mul_lt_mul_left"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "catalan-numbers-oq-01-oq-04",
+  "title": "Strict Log-Convexity of the Catalan Numbers (a Turán-Type Inequality)",
+  "slug": "catalan-numbers-oq-01-oq-04",
+  "description": "For every n the Catalan numbers satisfy the strict Turán inequality catalan(n+1)² < catalan n · catalan(n+2); equivalently the sequence n ↦ catalan n is strictly log-convex. The proof is pointwise (no induction): it derives the first-order Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n over ℤ from Mathlib's central-binomial API (succ_mul_catalan_eq_centralBinom and Nat.succ_mul_centralBinom_succ, cancelling the positive factor n+1), takes the two consecutive instances at n and n+1, and combines them by a single linear_combination into the surplus identity D·(A·C) = D·B² + 3·(B·C) with D = 2(2n+1)(2n+3) > 0, where A = catalan n, B = catalan(n+1), C = catalan(n+2). The strict gap comes from (2n+3)(n+2) − (2n+1)(n+3) = 3 > 0 and the positivity of B, C; the multiplicative gap is exactly (2n²+7n+6)/(2n²+7n+3) > 1. All arithmetic is carried over ℤ and transferred back to ℕ. Fully verified over ℕ with 0 axioms, 0 sorries, no decide/native_decide. Mathlib has the Catalan API but no Turán-type / log-convexity inequality for it. This is the leaf oq-01-oq-04 of catalan-numbers-oq-01.",
+  "meta": {
+    "author": "Classical (log-convexity of Catalan numbers); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://oeis.org/A000108",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "catalan",
+      "log-convexity",
+      "turan-inequality",
+      "inequality",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.succ_mul_catalan_eq_centralBinom",
+        "description": "(n+1)·catalan n = centralBinom n. Bridges the Catalan numbers to the central binomial coefficients; used (cast to ℤ) to convert the central-binomial recurrence into the Catalan recurrence.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "(n+1)·centralBinom(n+1) = 2(2n+1)·centralBinom n. The standard one-step recurrence for central binomial coefficients — the sole quantitative input from Mathlib, turned into the Catalan recurrence by cancelling n+1.",
+        "module": "Mathlib.Combinatorics.Enumerative.CentralBinom"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < centralBinom n. Used to recover positivity of the Catalan numbers from (n+1)·catalan n = centralBinom n.",
+        "module": "Mathlib.Combinatorics.Enumerative.CentralBinom"
+      },
+      {
+        "theorem": "mul_left_cancel₀ / lt_of_mul_lt_mul_left",
+        "description": "Cancellation of a nonzero/positive left factor in an equality (to extract the Catalan recurrence after cancelling n+1) and in a strict inequality (to pass from D·B² < D·(A·C) to B² < A·C).",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "catalan_recurrence: ((n:ℤ)+2)·catalan(n+1) = 2(2n+1)·catalan n — the first-order linear recurrence for the Catalan numbers, derived over ℤ from the central-binomial recurrence by cancelling the positive factor n+1 (Mathlib states the central-binomial recurrence but not this Catalan form)",
+      "catalan_pos: 0 < catalan n — positivity, recovered from (n+1)·catalan n = centralBinom n > 0",
+      "catalan_turan: catalan(n+1)² < catalan n · catalan(n+2) — the strict Turán inequality / strict log-convexity of the Catalan numbers, which Mathlib does not record"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 114,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Catalan numbers C n = 1, 1, 2, 5, 14, 42, 132, … (OEIS A000108) count Dyck paths, triangulations, binary trees, and a hundred other families. A sequence (a n) is log-convex when a(n+1)² ≤ a n · a(n+2); log-convexity is the discrete analogue of convexity of log a and underlies unimodality and Turán-type inequalities throughout combinatorics. For the Catalan numbers the inequality is strict, reflecting that the ratio C(n+1)/C n = 2(2n+1)/(n+2) is itself strictly increasing.",
+    "problemStatement": "**Open Question (catalan-numbers-oq-01, follow-up oq-04)**: catalan-numbers-oq-01 studied the holonomic / recurrence structure of the Catalan and related sequences. This leaf asks for the log-convexity (Turán-type) inequality of the Catalan numbers themselves.\n\n**Result**: catalan(n+1)² < catalan n · catalan(n+2) for every n — strict log-convexity — proved pointwise from two instances of the first-order Catalan recurrence, which is itself derived here from Mathlib's central-binomial API.",
+    "text": "For every natural number n, catalan(n+1)² < catalan n · catalan(n+2). The strictness is uniform: the multiplicative gap catalan n · catalan(n+2) / catalan(n+1)² equals (2n²+7n+6)/(2n²+7n+3) = 1 + 3/(2n²+7n+3) > 1.",
+    "proofStrategy": "**Proof Strategy (pointwise, no induction).**\n\n1. **Catalan recurrence** (catalan_recurrence): cast the two Mathlib identities (n+1)·catalan n = centralBinom n and (n+1)·centralBinom(n+1) = 2(2n+1)·centralBinom n to ℤ, substitute, and cancel the positive factor n+1 with mul_left_cancel₀, closing by linear_combination. This yields (n+2)·catalan(n+1) = 2(2n+1)·catalan n over ℤ.\n\n2. **Positivity** (catalan_pos): from (n+1)·catalan n = centralBinom n > 0, a zero value of catalan n would force centralBinom n = 0, contradiction.\n\n3. **Turán inequality** (catalan_turan): take the recurrence at n and at n+1, giving (n+2)B = 2(2n+1)A and (n+3)C = 2(2n+3)B with A = catalan n, B = catalan(n+1), C = catalan(n+2). A single linear_combination of these two facts (scaled by (2n+1)B and (2n+3)C) produces the surplus identity D·(A·C) = D·B² + 3·(B·C) with D = 2(2n+1)(2n+3). Since B, C > 0 the term 3·(B·C) is strictly positive, so D·B² < D·(A·C); cancelling the positive D (lt_of_mul_lt_mul_left) gives B² < A·C over ℤ, transferred back to ℕ by exact_mod_cast.",
+    "keyInsights": [
+      "**The Catalan recurrence is not a Mathlib lemma — it is reconstructed.** Mathlib records the central-binomial recurrence (n+1)·centralBinom(n+1) = 2(2n+1)·centralBinom n and the bridge (n+1)·catalan n = centralBinom n, but not the first-order Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n. Cancelling the common factor n+1 derives it cleanly over ℤ.",
+      "**Log-convexity is pointwise here, not inductive.** Because the recurrence is first-order, two consecutive instances determine the three relevant Catalan values' cross-ratio exactly; no induction is needed. The whole inequality collapses to the integer fact (2n+3)(n+2) − (2n+1)(n+3) = 3 > 0.",
+      "**The surplus is exactly 3.** Multiplying out by D = 2(2n+1)(2n+3) > 0 turns the inequality B² < A·C into the equality D·(A·C) = D·B² + 3·(B·C), where the constant surplus 3·(B·C) > 0 makes the inequality strict for every n. The multiplicative gap (2n²+7n+6)/(2n²+7n+3) → 1 as n → ∞, so log-convexity tightens but never degenerates to equality.",
+      "**Working over ℤ avoids truncated subtraction.** All cancellations and the linear_combination are performed over ℤ, where ring arithmetic is available; the final B² < A·C is cast back to ℕ at the end."
+    ],
+    "prerequisites": [
+      "The Catalan numbers and the central binomial coefficients with their one-step recurrence",
+      "Cancellation of positive factors in equalities and strict inequalities over an ordered ring",
+      "The linear_combination tactic for closing polynomial identities over ℤ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring stating the strict Turán inequality, the pointwise (no-induction) proof idea via two instances of the first-order Catalan recurrence, and the central-binomial API it is derived from; imports Mathlib and opens Nat.",
+      "mathContext": "$C(n{+}1)^2 < C(n)\\,C(n{+}2)$; recurrence $(n{+}2)C(n{+}1) = 2(2n{+}1)C(n)$."
+    },
+    {
+      "id": "recurrence",
+      "title": "First-Order Catalan Recurrence",
+      "startLine": 44,
+      "endLine": 60,
+      "summary": "catalan_recurrence: ((n:ℤ)+2)·catalan(n+1) = 2(2n+1)·catalan n, derived from the central-binomial recurrence and the catalan↔centralBinom bridge by cancelling the positive factor n+1 (mul_left_cancel₀, linear_combination).",
+      "mathContext": "$(n{+}2)\\,C(n{+}1) = 2(2n{+}1)\\,C(n)$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity of the Catalan Numbers",
+      "startLine": 62,
+      "endLine": 72,
+      "summary": "catalan_pos: 0 < catalan n, recovered from (n+1)·catalan n = centralBinom n > 0.",
+      "mathContext": "$0 < C(n)$."
+    },
+    {
+      "id": "turan",
+      "title": "Strict Turán Inequality",
+      "startLine": 73,
+      "endLine": 114,
+      "summary": "catalan_turan: catalan(n+1)² < catalan n · catalan(n+2). Two consecutive recurrence instances combine by one linear_combination into D·(A·C) = D·B² + 3·(B·C) with D = 2(2n+1)(2n+3) > 0; positivity of B, C makes the surplus 3·(B·C) strictly positive, giving B² < A·C after cancelling D, then cast back to ℕ.",
+      "mathContext": "$D\\,(A C) = D\\,B^2 + 3\\,(BC)$, $D = 2(2n{+}1)(2n{+}3) > 0 \\Rightarrow B^2 < AC$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "catalan-numbers-oq-01",
+      "relationship": "Parent open question on the holonomic / recurrence structure of the Catalan and related sequences; this leaf supplies the strict log-convexity (Turán) inequality of the Catalan numbers themselves."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) strict log-convexity of the Catalan numbers: catalan(n+1)² < catalan n · catalan(n+2) for all n, proved pointwise from two instances of the first-order Catalan recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n, itself derived from Mathlib's central-binomial API.",
+    "implications": "Supplies a Turán-type inequality that Mathlib's Catalan development lacks, and as a byproduct records the first-order Catalan recurrence and positivity over ℤ/ℕ. Strict log-convexity gives, for instance, that the ratio sequence C(n+1)/C n is strictly increasing.",
+    "openQuestions": [
+      "Prove the sharp two-sided Turán bound: catalan n · catalan(n+2) / catalan(n+1)² = (2n²+7n+6)/(2n²+7n+3), which both proves strictness and exhibits the gap → 1.",
+      "Establish log-concavity of the shifted/normalized Catalan sequence or the analogous strict Turán inequalities for the Motzkin and Schröder numbers, where the first-order shortcut is unavailable and an order-two recurrence is needed."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CatalanNumbersOQ01OQ04",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "OEIS Foundation",
+      "title": "A000108: Catalan numbers",
+      "year": "2024",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "Values, the ratio recurrence C(n+1) = 2(2n+1)/(n+2)·C(n), and log-convexity"
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "venue": "Cambridge University Press",
+      "note": "Comprehensive reference on the Catalan numbers and their inequalities"
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.Catalan",
+      "year": "2025",
+      "venue": "Mathlib4",
+      "note": "Source of Nat.catalan, Nat.succ_mul_catalan_eq_centralBinom, and the central-binomial recurrence Nat.succ_mul_centralBinom_succ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **catalan-numbers-oq-01-oq-04**: the strict Turán-type inequality / strict log-convexity of the Catalan numbers,

  catalan(n+1)² < catalan n · catalan(n+2)   for every n.

Mathlib has a rich Catalan API but records no log-convexity / Turán inequality for it.

## Proof (pointwise, no induction)

1. **`catalan_recurrence`** — reconstruct the first-order Catalan recurrence `(n+2)·catalan(n+1) = 2(2n+1)·catalan n` over ℤ from Mathlib's `Nat.succ_mul_catalan_eq_centralBinom` and `Nat.succ_mul_centralBinom_succ`, cancelling the positive factor `n+1`.
2. **`catalan_pos`** — positivity from `(n+1)·catalan n = centralBinom n > 0`.
3. **`catalan_turan`** — two consecutive recurrence instances combine by a single `linear_combination` into the surplus identity `D·(A·C) = D·B² + 3·(B·C)` with `D = 2(2n+1)(2n+3) > 0` and `A,B,C` the three Catalan values. Since `B,C > 0` the surplus `3·(B·C)` is strictly positive, giving `B² < A·C` after cancelling `D`, then cast back to ℕ. The surplus constant `3 = (2n+3)(n+2) − (2n+1)(n+3)`.

The multiplicative gap is exactly `(2n²+7n+6)/(2n²+7n+3) > 1`.

## Verification

- Builds clean with `lake env lean Proofs/CatalanNumbersOQ01OQ04.lean` (Mathlib 4.26.0).
- `#print axioms catalan_turan` → only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- **status: verified, badge: original, axiomCount 0, sorries 0**, no `decide`/`native_decide`.
- 114 lines, 3 theorems, 0 definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)