### PR TITLE
research(catalan-numbers-oq-01-oq-04): strict log-convexity Cₙ₊₁² < Cₙ·Cₙ₊₂ (Turán-type) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CatalanNumbersOQ01OQ04.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ04.lean
@@ -1,0 +1,115 @@
+import Mathlib
+
+/-
+# Strict log-convexity of the Catalan numbers (a Turán-type inequality)
+
+For every `n` the Catalan numbers satisfy the **strict** Turán inequality
+
+  `catalan (n+1) ^ 2 < catalan n * catalan (n+2)`.
+
+Equivalently, the sequence `n ↦ catalan n` is *strictly* log-convex.  This is
+the leaf `oq-01-oq-04` of `catalan-numbers-oq-01`.
+
+## Proof idea (pointwise, no induction)
+
+The only inputs are two instances of the standard one-step recurrence
+`(n+2) · catalan (n+1) = 2(2n+1) · catalan n`, derived here from Mathlib's
+central-binomial API:
+
+* `succ_mul_catalan_eq_centralBinom : (n+1) * catalan n = centralBinom n`
+* `Nat.succ_mul_centralBinom_succ : (n+1) * centralBinom (n+1)
+      = 2(2n+1) * centralBinom n`.
+
+Combining them and cancelling the positive factor `n+1` yields the catalan
+recurrence; doing the same one step further gives the `n+1` instance.  Writing
+`a = catalan n`, `b = catalan (n+1)`, `c = catalan (n+2)`, the two recurrences
+
+  `(n+2) b = 2(2n+1) a`,   `(n+3) c = 2(2n+3) b`
+
+force, after multiplying out by the positive quantity `2(2n+1)(2n+3)`,
+
+  `D · (a·c) = D · b² + 3 · (b·c)`   with `D = 2(2n+1)(2n+3) > 0`,
+
+because `(2n+3)(n+2) − (2n+1)(n+3) = 3`.  Since `b, c > 0` the surplus
+`3 · (b·c)` is strictly positive, so `b² < a·c`.
+
+All arithmetic is carried out over `ℤ` (where `linear_combination` and
+cancellation are available) and transferred back to `ℕ` at the end.
+-/
+
+namespace CatalanNumbersOQ01OQ04
+
+open Nat
+
+/-- The one-step Catalan recurrence `(n+2) · catalan (n+1) = 2(2n+1) · catalan n`,
+expressed over `ℤ`.  Derived from the central-binomial recurrence by cancelling
+the positive factor `n+1`. -/
+theorem catalan_recurrence (n : ℕ) :
+    ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) = 2 * (2 * n + 1) * (catalan n : ℤ) := by
+  -- cast the two Mathlib identities to ℤ
+  have e1 : ((Nat.centralBinom n : ℤ)) = ((n : ℤ) + 1) * (catalan n : ℤ) := by
+    exact_mod_cast (succ_mul_catalan_eq_centralBinom n).symm
+  have e2 : ((Nat.centralBinom (n + 1) : ℤ)) = ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) := by
+    exact_mod_cast (succ_mul_catalan_eq_centralBinom (n + 1)).symm
+  have r1 : ((n : ℤ) + 1) * (Nat.centralBinom (n + 1) : ℤ)
+      = 2 * (2 * n + 1) * (Nat.centralBinom n : ℤ) := by
+    exact_mod_cast Nat.succ_mul_centralBinom_succ n
+  have hn1 : ((n : ℤ) + 1) ≠ 0 := by positivity
+  -- cancel (n+1) after substituting e1, e2 into r1
+  apply mul_left_cancel₀ hn1
+  linear_combination r1 + 2 * (2 * n + 1) * e1 - ((n : ℤ) + 1) * e2
+
+/-- Positivity of the Catalan numbers, recovered from the central-binomial API:
+`(n+1) · catalan n = centralBinom n > 0`, and `n+1 > 0`. -/
+theorem catalan_pos (n : ℕ) : 0 < catalan n := by
+  have h : (n + 1) * catalan n = Nat.centralBinom n :=
+    succ_mul_catalan_eq_centralBinom n
+  have hb : 0 < Nat.centralBinom n := Nat.centralBinom_pos n
+  -- if catalan n = 0 then (n+1)*catalan n = 0, contradicting centralBinom n > 0
+  rcases Nat.eq_zero_or_pos (catalan n) with h0 | hpos
+  · rw [h0, Nat.mul_zero] at h; omega
+  · exact hpos
+
+/-- **Strict log-convexity (Turán inequality) of the Catalan numbers.**
+
+For every `n`,
+`catalan (n+1) ^ 2 < catalan n * catalan (n+2)`.
+
+This is strict for all `n` (the multiplicative gap is exactly the factor
+`(2n²+7n+6)/(2n²+7n+3) > 1`); Mathlib has the Catalan API but no Turán-type
+inequality. -/
+theorem catalan_turan (n : ℕ) :
+    catalan (n + 1) ^ 2 < catalan n * catalan (n + 2) := by
+  -- Two consecutive recurrence instances, as facts over ℤ.
+  have R1 : ((n : ℤ) + 2) * (catalan (n + 1) : ℤ) = 2 * (2 * n + 1) * (catalan n : ℤ) :=
+    catalan_recurrence n
+  have R2 : ((n : ℤ) + 3) * (catalan (n + 2) : ℤ)
+      = 2 * (2 * n + 3) * (catalan (n + 1) : ℤ) := by
+    have h := catalan_recurrence (n + 1)
+    have he : n + 1 + 1 = n + 2 := rfl
+    rw [he] at h
+    push_cast at h ⊢
+    linear_combination h
+  have hBpos : 0 < (catalan (n + 1) : ℤ) := by exact_mod_cast catalan_pos (n + 1)
+  have hCpos : 0 < (catalan (n + 2) : ℤ) := by exact_mod_cast catalan_pos (n + 2)
+  -- abbreviate; `set` folds the facts above to use A, B, C automatically
+  set A : ℤ := (catalan n : ℤ) with hA
+  set B : ℤ := (catalan (n + 1) : ℤ) with hB
+  set C : ℤ := (catalan (n + 2) : ℤ) with hC
+  have hD : (0 : ℤ) < 2 * (2 * n + 1) * (2 * n + 3) := by positivity
+  -- the key surplus identity: D·(A·C) = D·B² + 3·(B·C)
+  have key : 2 * (2 * n + 1) * (2 * n + 3) * (A * C)
+      = 2 * (2 * n + 1) * (2 * n + 3) * B ^ 2 + 3 * (B * C) := by
+    linear_combination ((2 * (n : ℤ) + 1) * B) * R2 - (((2 : ℤ) * n + 3) * C) * R1
+  -- 3·(B·C) > 0, so D·B² < D·(A·C), hence B² < A·C
+  have hbc : 0 < 3 * (B * C) := by positivity
+  have hlt : 2 * (2 * n + 1) * (2 * n + 3) * B ^ 2
+      < 2 * (2 * n + 1) * (2 * n + 3) * (A * C) := by
+    rw [key]; linarith
+  have hZ : B ^ 2 < A * C := lt_of_mul_lt_mul_left hlt (le_of_lt hD)
+  -- transfer back to ℕ
+  rw [hA, hB, hC] at hZ
+  exact_mod_cast hZ
+
+end CatalanNumbersOQ01OQ04
+

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-catalan-turan-overview",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Strict log-convexity as a Turán-type inequality",
+    "content": "A sequence (aₙ) is log-convex when aₙ₊₁² ≤ aₙ·aₙ₊₂; the strict version aₙ₊₁² < aₙ·aₙ₊₂ says the consecutive ratios aₙ₊₁/aₙ are strictly increasing. For the Catalan numbers this is usually read off the closed ratio Cₙ₊₁/Cₙ = 2(2n+1)/(n+2). This entry instead stays inside the integers: it uses only the one-step recurrence (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ at two consecutive indices, so the whole argument is a single pointwise computation with no induction and no rational arithmetic.",
+    "mathContext": "Target: $C_{n+1}^2 < C_n\\,C_{n+2}$. Equivalent to $\\frac{C_{n+1}}{C_n} < \\frac{C_{n+2}}{C_{n+1}}$, i.e. strictly increasing ratios.",
+    "significance": "context",
+    "relatedConcepts": [
+      "log-convexity",
+      "Turán inequality",
+      "Catalan numbers",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Catalan numbers",
+      "recurrence relations"
+    ]
+  },
+  {
+    "id": "ann-catalan-turan-recurrence",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": {
+      "startLine": 44,
+      "endLine": 60
+    },
+    "type": "technique",
+    "title": "Division-free Catalan recurrence by cancellation",
+    "content": "catalan_recurrence proves (n+2)·catalan (n+1) = 2(2n+1)·catalan n over ℤ. Mathlib gives the central-binomial recurrence (n+1)·centralBinom (n+1) = 2(2n+1)·centralBinom n and the bridge (n+1)·catalan n = centralBinom n. Substituting the bridge (at n and n+1) into the central-binomial recurrence yields (n+1)·[(n+2)·Cₙ₊₁] = (n+1)·[2(2n+1)·Cₙ]; cancelling the nonzero factor n+1 with mul_left_cancel₀ gives the Catalan recurrence. The cancellation step is the reason the work is done over ℤ rather than ℕ — together with linear_combination, which needs a commutative ring.",
+    "mathContext": "From $(n{+}1)B_{n+1} = 2(2n{+}1)B_n$ and $B_k = (k{+}1)C_k$: $(n{+}1)(n{+}2)C_{n+1} = (n{+}1)\\,2(2n{+}1)C_n \\Rightarrow (n{+}2)C_{n+1} = 2(2n{+}1)C_n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "linear_combination",
+      "cancellation"
+    ],
+    "prerequisites": [
+      "p-adic / integer cancellation",
+      "Catalan–central binomial bridge"
+    ]
+  },
+  {
+    "id": "ann-catalan-turan-positivity",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": {
+      "startLine": 62,
+      "endLine": 71
+    },
+    "type": "technique",
+    "title": "Positivity of the Catalan numbers",
+    "content": "catalan_pos proves 0 < catalan n from (n+1)·catalan n = centralBinom n: since centralBinom n > 0 (Nat.centralBinom_pos), catalan n cannot be 0. This strict positivity of catalan (n+1) and catalan (n+2) is exactly what upgrades the nonnegative surplus 3·(b·c) in the main proof to a strictly positive one, making the Turán inequality strict rather than merely ≤.",
+    "mathContext": "$C_n > 0$ because $(n+1)C_n = \\binom{2n}{n} > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Catalan numbers",
+      "positivity of binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-catalan-turan-surplus",
+    "proofId": "catalan-numbers-oq-01-oq-04",
+    "range": {
+      "startLine": 73,
+      "endLine": 112
+    },
+    "type": "key-insight",
+    "title": "The constant-3 surplus identity",
+    "content": "Writing a = Cₙ, b = Cₙ₊₁, c = Cₙ₊₂ and D = 2(2n+1)(2n+3) > 0, the two recurrence instances (n+2)b = 2(2n+1)a and (n+3)c = 2(2n+3)b let one rewrite both D·(a·c) and D·b² as multiples of b·c: D·(a·c) = (2n+3)(n+2)·b·c and D·b² = (2n+1)(n+3)·b·c. Subtracting, the b·c coefficients differ by exactly (2n+3)(n+2) − (2n+1)(n+3) = (2n²+7n+6) − (2n²+7n+3) = 3 — independent of n. So D·(a·c) = D·b² + 3·(b·c). The single linear_combination ((2n+1)·b)·R2 − ((2n+3)·c)·R1 discharges this identity; then 3·(b·c) > 0 and cancellation of D give b² < a·c. The n-independence of the constant 3 is precisely why the inequality holds, and holds strictly, for every n.",
+    "mathContext": "$\\frac{C_n C_{n+2}}{C_{n+1}^2} = \\frac{(2n+3)(n+2)}{(2n+1)(n+3)} = \\frac{2n^2+7n+6}{2n^2+7n+3} > 1$, gap exactly $3$ in the numerator.",
+    "significance": "core",
+    "relatedConcepts": [
+      "linear_combination",
+      "Turán inequality",
+      "log-convexity",
+      "surplus term"
+    ],
+    "prerequisites": [
+      "ring identities",
+      "ordered cancellation"
+    ]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-04/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "catalan-numbers-oq-01-oq-04",
+  "title": "Strict log-convexity of the Catalan numbers: Cₙ₊₁² < Cₙ·Cₙ₊₂ (a Turán-type inequality)",
+  "slug": "catalan-numbers-oq-01-oq-04",
+  "description": "Proves the strict Turán-type inequality catalan (n+1)² < catalan n · catalan (n+2) for every n — equivalently, the Catalan sequence is strictly log-convex. The proof is pointwise (no induction): it uses only two consecutive instances of the one-step recurrence (n+2)·catalan (n+1) = 2(2n+1)·catalan n, derived here from Mathlib's central-binomial API (succ_mul_catalan_eq_centralBinom and Nat.succ_mul_centralBinom_succ) by cancelling the positive factor n+1. Writing a = Cₙ, b = Cₙ₊₁, c = Cₙ₊₂, the two recurrences (n+2)b = 2(2n+1)a and (n+3)c = 2(2n+3)b force, after scaling by the positive quantity D = 2(2n+1)(2n+3), the surplus identity D·(a·c) = D·b² + 3·(b·c). The decisive constant 3 is exactly (2n+3)(n+2) − (2n+1)(n+3) = (2n²+7n+6) − (2n²+7n+3); since b, c > 0 the surplus 3·(b·c) is strictly positive, giving b² < a·c. All arithmetic is done over ℤ (where linear_combination and left-cancellation are available) and transferred back to ℕ by exact_mod_cast. Mathlib has the full Catalan/central-binomial API but no Turán inequality or log-convexity statement for the Catalan numbers. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (Turán-type / log-convexity inequality for the Catalan numbers); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "catalan-numbers",
+      "log-convexity",
+      "turan-inequality",
+      "inequality",
+      "central-binomial",
+      "recurrence",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "succ_mul_catalan_eq_centralBinom",
+        "description": "(n + 1) · catalan n = Nat.centralBinom n. The multiplicative bridge between the Catalan numbers and the central binomial coefficient; used three times (at n, n+1, n+2) to turn the central-binomial recurrence into the Catalan recurrence, and once more to recover positivity of the Catalan numbers.",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.succ_mul_centralBinom_succ",
+        "description": "(n + 1) · centralBinom (n + 1) = 2·(2n+1)·centralBinom n. The one-step recurrence of the central binomial coefficient; combined with the bridge above and cancellation of n+1 it yields the Catalan recurrence (n+2)·catalan (n+1) = 2(2n+1)·catalan n.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.centralBinom_pos",
+        "description": "0 < centralBinom n. Together with the bridge (n+1)·catalan n = centralBinom n it gives 0 < catalan n, the strict positivity of b = Cₙ₊₁ and c = Cₙ₊₂ that turns the surplus 3·(b·c) into a strict inequality.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "a ≠ 0 → a·b = a·c → b = c. Cancels the positive factor (n+1) over ℤ when extracting the Catalan recurrence from the central-binomial recurrence.",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "lt_of_mul_lt_mul_left",
+        "description": "a·b < a·c → 0 ≤ a → b < c. Cancels the positive scaling factor D = 2(2n+1)(2n+3) to pass from D·b² < D·(a·c) to b² < a·c.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "catalan_turan: catalan (n+1)² < catalan n · catalan (n+2) for every n — the strict Turán-type inequality / strict log-convexity of the Catalan numbers. Mathlib has no Turán inequality or log-convexity statement for the Catalan numbers; this is assembled here from the central-binomial recurrence.",
+      "catalan_recurrence: the division-free Catalan recurrence (n+2)·catalan (n+1) = 2(2n+1)·catalan n over ℤ, obtained by combining succ_mul_catalan_eq_centralBinom with Nat.succ_mul_centralBinom_succ and cancelling n+1 via mul_left_cancel₀ and linear_combination.",
+      "The surplus identity D·(a·c) = D·b² + 3·(b·c) with D = 2(2n+1)(2n+3), discharged by a single linear_combination of the two recurrence instances. The decisive constant 3 = (2n+3)(n+2) − (2n+1)(n+3) is what makes the inequality both true and strict for all n (independent of n)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide and no decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms catalan_turan).",
+    "lineCount": 115,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A real sequence (aₙ) is log-convex when aₙ₊₁² ≤ aₙ·aₙ₊₂; Turán's classical inequality Pₙ(x)² ≥ Pₙ₋₁(x)·Pₙ₊₁(x) for Legendre polynomials is the archetype of such two-term concavity/convexity phenomena, and the same shape recurs across combinatorial sequences (binomial coefficients, Bell numbers, Motzkin and Catalan numbers). Log-convexity of the Catalan numbers is a standard fact, usually proved from the closed ratio Cₙ₊₁/Cₙ = 2(2n+1)/(n+2): the consecutive ratios are increasing, which is exactly log-convexity. Here the statement is sharpened to the strict inequality and obtained without ever forming the rational ratio, working entirely with the integer recurrence and a single positive surplus term.",
+    "problemStatement": "The Catalan numbers Cₙ = (1/(n+1))·C(2n,n) satisfy the one-step recurrence (n+2)·Cₙ₊₁ = 2(2n+1)·Cₙ. The Turán-type / log-convexity question asks whether the sequence is (strictly) log-convex, i.e. whether Cₙ₊₁² < Cₙ·Cₙ₊₂ holds for every n. This entry (leaf oq-01-oq-04 of catalan-numbers-oq-01) proves the strict inequality for all n by a uniform pointwise computation, with no induction and no case analysis.",
+    "keyIdea": "Multiply the target Cₙ₊₁² < Cₙ·Cₙ₊₂ by the positive integer D = 2(2n+1)(2n+3). Using the two recurrence instances (n+2)Cₙ₊₁ = 2(2n+1)Cₙ and (n+3)Cₙ₊₂ = 2(2n+3)Cₙ₊₁ to substitute, both D·(Cₙ·Cₙ₊₂) and D·Cₙ₊₁² collapse to a common multiple of Cₙ₊₁·Cₙ₊₂, leaving the exact surplus D·(Cₙ·Cₙ₊₂) − D·Cₙ₊₁² = 3·Cₙ₊₁·Cₙ₊₂. The constant 3 = (2n+3)(n+2) − (2n+1)(n+3) is independent of n, and Cₙ₊₁·Cₙ₊₂ > 0, so the surplus is strictly positive — the inequality is strict everywhere."
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: strict log-convexity from the integer recurrence",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring framing the Turán-type inequality catalan (n+1)² < catalan n · catalan (n+2) as strict log-convexity, and outlining the pointwise (induction-free) route: two instances of the Catalan recurrence plus a single positive surplus term 3·(b·c), with the decisive constant 3 = (2n+3)(n+2) − (2n+1)(n+3)."
+    },
+    {
+      "id": "catalan-recurrence",
+      "title": "The division-free Catalan recurrence",
+      "startLine": 44,
+      "endLine": 60,
+      "summary": "catalan_recurrence: (n+2)·catalan (n+1) = 2(2n+1)·catalan n over ℤ. Casts succ_mul_catalan_eq_centralBinom (at n and n+1) and Nat.succ_mul_centralBinom_succ to ℤ, then cancels the positive factor n+1 via mul_left_cancel₀ and closes with a single linear_combination of the three substituted identities."
+    },
+    {
+      "id": "catalan-positivity",
+      "title": "Positivity of the Catalan numbers",
+      "startLine": 62,
+      "endLine": 71,
+      "summary": "catalan_pos: 0 < catalan n, recovered from (n+1)·catalan n = centralBinom n > 0 (Nat.centralBinom_pos). The strict positivity of catalan (n+1) and catalan (n+2) is what upgrades the nonnegative surplus 3·(b·c) to a strictly positive one."
+    },
+    {
+      "id": "turan-inequality",
+      "title": "The Turán inequality via a positive surplus",
+      "startLine": 73,
+      "endLine": 112,
+      "summary": "catalan_turan: builds the two recurrence instances (R1 at n, R2 at n+1, the latter reindexed n+1+1 = n+2), proves the surplus identity D·(a·c) = D·b² + 3·(b·c) with D = 2(2n+1)(2n+3) by one linear_combination, then uses 3·(b·c) > 0 and left-cancellation of D (lt_of_mul_lt_mul_left) to conclude b² < a·c, transferred back to ℕ by exact_mod_cast."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Turán, Paul",
+      "title": "On the zeros of the polynomials of Legendre",
+      "year": "1950",
+      "note": "Časopis Pěst. Mat. Fys. 75 — the prototype two-term inequality Pₙ² ≥ Pₙ₋₁·Pₙ₊₁ that names this class of log-concavity/convexity results."
+    },
+    {
+      "authors": "Liu, Lily L.; Wang, Yi",
+      "title": "On the log-convexity of combinatorial sequences",
+      "year": "2007",
+      "note": "Adv. in Appl. Math. 39 — systematic criteria establishing log-convexity (the Cₙ₊₁² ≤ Cₙ·Cₙ₊₂ shape) for the Catalan, Motzkin, Bell, and related sequences."
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "note": "Cambridge University Press — the Catalan ratio Cₙ₊₁/Cₙ = 2(2n+1)/(n+2) and the recurrence used here as the sole input."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry on the Catalan numbers. This leaf (oq-01-oq-04) proves the strict Turán-type log-convexity inequality Cₙ₊₁² < Cₙ·Cₙ₊₂."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling leaf on the p-adic valuation of the Catalan numbers; also built on succ_mul_catalan_eq_centralBinom as the bridge to the central binomial coefficient."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Central-binomial reflection form of the Catalan numbers; shares the Cₙ ↔ centralBinom n correspondence that this entry differentiates twice through the recurrence."
+    }
+  ],
+  "conclusion": {
+    "summary": "catalan_turan establishes catalan (n+1)² < catalan n · catalan (n+2) for every n: the Catalan numbers are strictly log-convex. The proof reduces, after scaling by D = 2(2n+1)(2n+3) > 0, to the exact surplus D·(Cₙ·Cₙ₊₂) = D·Cₙ₊₁² + 3·Cₙ₊₁·Cₙ₊₂, where the n-independent constant 3 and the positivity Cₙ₊₁·Cₙ₊₂ > 0 give strictness. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Supplies the gallery's Catalan arithmetic with the Turán/log-convexity inequality (absent from Mathlib), via a uniform pointwise argument that never forms the rational ratio Cₙ₊₁/Cₙ. The same two-recurrence-plus-surplus template applies to other sequences with a first-order rational recurrence (central binomial coefficients, falling/rising factorials).",
+    "openQuestions": [
+      "Quantify the gap: prove the exact multiplicative form Cₙ·Cₙ₊₂ = Cₙ₊₁²·(2n²+7n+6)/(2n²+7n+3), making the ratio of consecutive ratios explicit.",
+      "Establish strict log-concavity of the shifted/derived sequences (e.g. n ↦ Cₙ/(n+1) or the Catalan triangle rows) by the same surplus method."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CatalanNumbersOQ01OQ04",
+    "lineCount": 115,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **strict Turán-type inequality** `catalan (n+1)² < catalan n · catalan (n+2)` for every `n` — equivalently, the Catalan numbers are **strictly log-convex**. Leaf `oq-01-oq-04` of `catalan-numbers-oq-01`.

Mathlib has the full Catalan / central-binomial API but **no Turán inequality or log-convexity statement** for the Catalan numbers.

## Proof (pointwise, no induction)

Only input: two consecutive instances of the one-step recurrence
`(n+2)·catalan (n+1) = 2(2n+1)·catalan n`, derived here from
`succ_mul_catalan_eq_centralBinom` + `Nat.succ_mul_centralBinom_succ` by cancelling the positive factor `n+1`.

Writing `a = Cₙ`, `b = Cₙ₊₁`, `c = Cₙ₊₂` and `D = 2(2n+1)(2n+3) > 0`, the two recurrences force the **surplus identity**

```
D·(a·c) = D·b² + 3·(b·c)
```

The decisive constant `3 = (2n+3)(n+2) − (2n+1)(n+3) = (2n²+7n+6) − (2n²+7n+3)` is **independent of n**; since `b, c > 0` the surplus `3·(b·c)` is strictly positive, giving `b² < a·c`. All arithmetic is done over `ℤ` (for `linear_combination` + left-cancellation) and transferred back to `ℕ` by `exact_mod_cast`.

## Verification

- **Status:** verified · **badge:** original · **axioms:** 0 · **sorries:** 0
- `#print axioms catalan_turan` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`; no `native_decide`/`decide`).
- Builds clean against pinned Mathlib 4.26.0.

## Files

- `proofs/Proofs/CatalanNumbersOQ01OQ04.lean` (115 lines, 3 theorems, 0 defs)
- `src/data/proofs/catalan-numbers-oq-01-oq-04/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)