### PR TITLE
research(alternating-series-test-oq-01-oq-02-oq-02): quantitative abstract Dirichlet test [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AlternatingSeriesTestOQ01OQ02OQ02.lean
@@ -1,0 +1,187 @@
+import Mathlib
+
+/-
+# The Quantitative Abstract Dirichlet Test: Total-Variation Error Bounds for Arbitrary Factor Sequences
+
+The parent file `AlternatingSeriesTestOQ01OQ02` proves, via summation by parts, a
+total-variation error bound for the **sign-weighted** block sum
+`∑_{i∈[N,M)} (-1)^i a i` of an arbitrary (non-monotone) real coefficient sequence:
+
+`|∑_{i∈[N,M)} (-1)^i a i| ≤ |a (M-1)| + ∑_{i∈[N,M-1)} |a (i+1) - a i|`.
+
+The sibling `AlternatingSeriesTestOQ01OQ02OQ01` sharpens this to a two-sided
+Jordan-decomposition trap. **Both are specialized to the single factor sequence `(-1)^i`.**
+
+This file removes that specialization. The actual mechanism of Abel summation cares only
+that the factor sequence `b` has **bounded partial sums**; the value `(-1)^i` is irrelevant.
+We prove the *abstract Dirichlet test in quantitative form*: for any real factor sequence
+`b` whose partial sums obey `|∑_{i<k} b i| ≤ B`, and any real coefficient sequence `a`,
+
+`|∑_{j<n} b j · a j| ≤ B·|a (n-1)| + B·∑_{j<n-1} |a (j+1) - a j|`                 (`abs_dirichlet_range_le`)
+
+and, over an arbitrary window `[N,M)` (where the relevant shifted partial sums are bounded
+by `2B`),
+
+`|∑_{j∈[N,M)} b j · a j| ≤ 2B·|a (M-1)| + 2B·∑_{j∈[N,M-1)} |a (j+1) - a j|`.       (`abs_dirichlet_Ico_le`)
+
+Three consequences are recorded:
+
+* `abs_alternating_range_le` — taking `b = (-1)^i` and `B = 1` recovers the parent's bound
+  (range form). The abstract estimate therefore *contains* the classical alternating one as
+  the special case of the sign factor.
+
+* `abs_dirichlet_diff_le_of_antitone` — for an antitone, nonnegative coefficient sequence
+  the boundary term and the total variation combine and collapse the window bound to the
+  clean **quantitative Dirichlet remainder** `|S_M - S_N| ≤ 2B·a N`, where
+  `S_k = ∑_{i<k} b i · a i`.
+
+* `abs_dirichlet_sub_limit_le` — passing `M → ∞` for a convergent Dirichlet series bounds
+  the genuine truncation error `|S_N - l| ≤ 2B·a N`.
+
+The contrast with Mathlib is the point. Mathlib's `Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded`
+proves Dirichlet's test **qualitatively** (the partial sums are Cauchy, hence converge) and
+requires monotonicity of `a` throughout. It gives **no rate**. The bounds here are
+quantitative: an explicit total-variation estimate valid for *non-monotone* `a`, and an
+explicit `2B·a N` remainder in the monotone case — neither is in Mathlib.
+
+All results are over `ℝ` and build on `Finset.sum_range_by_parts`.
+-/
+
+namespace AlternatingSeriesTestOQ01OQ02OQ02
+
+open Finset Filter Topology
+
+/-- Elementary triangle bound `|x - y| ≤ |x| + |y|`. -/
+private theorem abs_sub_le_add (x y : ℝ) : |x - y| ≤ |x| + |y| := by
+  rw [sub_eq_add_neg]
+  exact (abs_add_le x (-y)).trans_eq (by rw [abs_neg])
+
+/-- **Quantitative abstract Dirichlet test (range form).** For any real factor sequence `b`
+whose partial sums are bounded by `B`, and any real coefficient sequence `a`, the weighted
+sum `∑_{j<n} b j · a j` is controlled by a boundary term plus the total variation of `a`,
+each scaled by `B`:
+
+`|∑_{j<n} b j · a j| ≤ B·|a (n-1)| + B·∑_{j<n-1} |a (j+1) - a j|`.
+
+No monotonicity of `a` and no special structure of `b` (beyond bounded partial sums) is
+required. This is the engine of the Dirichlet test: Abel summation trades the oscillation of
+the factor `b` for its uniform partial-sum bound `B`, leaving the total variation of `a`. -/
+theorem abs_dirichlet_range_le (a b : ℕ → ℝ) {B : ℝ}
+    (hB : ∀ k, |∑ i ∈ range k, b i| ≤ B) (n : ℕ) :
+    |∑ j ∈ range n, b j * a j|
+      ≤ B * |a (n - 1)| + B * ∑ j ∈ range (n - 1), |a (j + 1) - a j| := by
+  -- Summation by parts: peel off the boundary term and the increment sum.
+  have hbp := Finset.sum_range_by_parts a b n
+  simp only [smul_eq_mul] at hbp
+  have hcomm : ∑ j ∈ range n, b j * a j = ∑ i ∈ range n, a i * b i :=
+    Finset.sum_congr rfl fun j _ => by ring
+  rw [hcomm, hbp]
+  refine (abs_sub_le_add _ _).trans (add_le_add ?_ ?_)
+  · -- boundary term: `|a(n-1) · ∑_{i<n} b i| ≤ B·|a(n-1)|`
+    rw [abs_mul, mul_comm B]
+    exact mul_le_mul_of_nonneg_left (hB n) (abs_nonneg _)
+  · -- increment sum: triangle inequality, then bound each factor partial sum by `B`
+    rw [Finset.mul_sum]
+    refine (Finset.abs_sum_le_sum_abs _ _).trans (Finset.sum_le_sum fun j _ => ?_)
+    rw [abs_mul, mul_comm B]
+    exact mul_le_mul_of_nonneg_left (hB _) (abs_nonneg _)
+
+/-- **Quantitative abstract Dirichlet test (window form).** Over an arbitrary window
+`[N,M)`, the partial sums of the *shifted* factor sequence are bounded by `2B` (difference
+of two `B`-bounded prefix sums), so the window weighted sum obeys
+
+`|∑_{j∈[N,M)} b j · a j| ≤ 2B·|a (M-1)| + 2B·∑_{j∈[N,M-1)} |a (j+1) - a j|`. -/
+theorem abs_dirichlet_Ico_le (a b : ℕ → ℝ) {B : ℝ}
+    (hB : ∀ k, |∑ i ∈ range k, b i| ≤ B) {N M : ℕ} (hNM : N < M) :
+    |∑ j ∈ Ico N M, b j * a j|
+      ≤ 2 * B * |a (M - 1)| + 2 * B * ∑ j ∈ Ico N (M - 1), |a (j + 1) - a j| := by
+  set n := M - N with hn
+  have hn1 : 1 ≤ n := by omega
+  -- Reindex the window `[N,M)` to `range n` via the shifted sequences `a(N+·)`, `b(N+·)`.
+  have hreindex : ∑ j ∈ Ico N M, b j * a j
+      = ∑ k ∈ range n, b (N + k) * a (N + k) := by
+    rw [hn, Finset.sum_Ico_eq_sum_range]
+  -- The shifted prefix sums are differences of two `B`-bounded prefix sums ⇒ bounded by `2B`.
+  have hB' : ∀ k, |∑ i ∈ range k, (fun i => b (N + i)) i| ≤ 2 * B := by
+    intro k
+    show |∑ i ∈ range k, b (N + i)| ≤ 2 * B
+    have hsplit : ∑ i ∈ range k, b (N + i)
+        = (∑ i ∈ range (N + k), b i) - ∑ i ∈ range N, b i := by
+      have h1 : ∑ i ∈ range k, b (N + i) = ∑ i ∈ Ico N (N + k), b i := by
+        rw [Finset.sum_Ico_eq_sum_range]; simp
+      rw [h1, eq_sub_iff_add_eq, add_comm,
+        Finset.sum_range_add_sum_Ico b (Nat.le_add_right N k)]
+    rw [hsplit]
+    calc |(∑ i ∈ range (N + k), b i) - ∑ i ∈ range N, b i|
+        ≤ |∑ i ∈ range (N + k), b i| + |∑ i ∈ range N, b i| := abs_sub_le_add _ _
+      _ ≤ B + B := add_le_add (hB _) (hB _)
+      _ = 2 * B := by ring
+  rw [hreindex]
+  have hmain := abs_dirichlet_range_le (fun i => a (N + i)) (fun i => b (N + i)) hB' n
+  refine hmain.trans (le_of_eq ?_)
+  have hidx : N + (n - 1) = M - 1 := by omega
+  have hsum : (∑ j ∈ range (n - 1), |a (N + (j + 1)) - a (N + j)|)
+      = ∑ j ∈ Ico N (M - 1), |a (j + 1) - a j| := by
+    rw [Finset.sum_Ico_eq_sum_range, show M - 1 - N = n - 1 from by omega]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [show N + j + 1 = N + (j + 1) from by omega]
+  rw [hidx, hsum]
+
+/-- **Specialization to the sign factor recovers the classical bound.** Taking
+`b = (-1)^i` (whose partial sums are bounded by `1`) collapses the abstract range bound to
+the parent file's alternating-series estimate. -/
+theorem abs_alternating_range_le (a : ℕ → ℝ) (n : ℕ) :
+    |∑ j ∈ range n, (-1 : ℝ) ^ j * a j|
+      ≤ |a (n - 1)| + ∑ j ∈ range (n - 1), |a (j + 1) - a j| := by
+  have hsign : ∀ k, |∑ i ∈ range k, (-1 : ℝ) ^ i| ≤ 1 := by
+    intro k; rw [neg_one_geom_sum]; split <;> simp
+  have := abs_dirichlet_range_le a (fun i => (-1 : ℝ) ^ i) hsign n
+  simpa using this
+
+/-- **Quantitative Dirichlet remainder for monotone coefficients.** When `a` is antitone and
+nonnegative the boundary term and the total variation telescope, collapsing the window bound
+to the explicit rate `|S_M - S_N| ≤ 2B·a N`, where `S_k = ∑_{i<k} b i · a i`. This is the
+quantitative content Mathlib's qualitative `cauchySeq_series_mul_of_tendsto_zero_of_bounded`
+omits. -/
+theorem abs_dirichlet_diff_le_of_antitone (a b : ℕ → ℝ) {B : ℝ}
+    (hB : ∀ k, |∑ i ∈ range k, b i| ≤ B) (hmono : Antitone a) (hpos : ∀ i, 0 ≤ a i)
+    {N M : ℕ} (hNM : N < M) :
+    |(∑ j ∈ range M, b j * a j) - ∑ j ∈ range N, b j * a j| ≤ 2 * B * a N := by
+  rw [← Finset.sum_Ico_eq_sub _ (le_of_lt hNM)]
+  refine (abs_dirichlet_Ico_le a b hB hNM).trans ?_
+  -- The total variation of an antitone sequence telescopes.
+  have hvar : ∑ j ∈ Ico N (M - 1), |a (j + 1) - a j| = a N - a (M - 1) := by
+    have hpoint : ∀ j ∈ Ico N (M - 1), |a (j + 1) - a j| = a j - a (j + 1) := by
+      intro j _
+      rw [abs_of_nonpos (by linarith [hmono (Nat.le_succ j)])]; ring
+    rw [Finset.sum_congr rfl hpoint, Finset.sum_Ico_eq_sum_range]
+    have htel : ∑ j ∈ range (M - 1 - N), (a (N + j) - a (N + (j + 1)))
+        = a (N + 0) - a (N + (M - 1 - N)) := Finset.sum_range_sub' (fun j => a (N + j)) _
+    rw [show (∑ j ∈ range (M - 1 - N), (a (N + j) - a (N + j + 1)))
+          = ∑ j ∈ range (M - 1 - N), (a (N + j) - a (N + (j + 1))) from
+        Finset.sum_congr rfl fun j _ => by rw [show N + j + 1 = N + (j + 1) from by omega]]
+    rw [htel, Nat.add_zero, show N + (M - 1 - N) = M - 1 from by omega]
+  rw [hvar, abs_of_nonneg (hpos (M - 1))]
+  have hkey : 2 * B * a (M - 1) + 2 * B * (a N - a (M - 1)) = 2 * B * a N := by ring
+  linarith [hkey]
+
+/-- **Quantitative Dirichlet remainder at the limit.** If the Dirichlet series
+`S_n = ∑_{i<n} b i · a i` converges to `l` (with `a` antitone, nonnegative — exactly the
+hypotheses under which Mathlib guarantees convergence when `a → 0`), then the truncation
+error obeys the explicit bound `|S_N - l| ≤ 2B·a N`.
+
+Mathlib proves convergence but supplies no rate; this is the rate. -/
+theorem abs_dirichlet_sub_limit_le (a b : ℕ → ℝ) {B : ℝ} {l : ℝ}
+    (hB : ∀ k, |∑ i ∈ range k, b i| ≤ B) (hmono : Antitone a) (hpos : ∀ i, 0 ≤ a i)
+    (hl : Tendsto (fun n => ∑ i ∈ range n, b i * a i) atTop (𝓝 l)) (N : ℕ) :
+    |(∑ i ∈ range N, b i * a i) - l| ≤ 2 * B * a N := by
+  have hcont : Tendsto (fun M => |(∑ i ∈ range N, b i * a i)
+      - (∑ i ∈ range M, b i * a i)|) atTop
+      (𝓝 |(∑ i ∈ range N, b i * a i) - l|) :=
+    (Filter.Tendsto.const_sub _ hl).abs
+  refine le_of_tendsto hcont ?_
+  filter_upwards [eventually_gt_atTop N] with M hM
+  have hbound := abs_dirichlet_diff_le_of_antitone a b hB hmono hpos hM
+  rwa [abs_sub_comm] at hbound
+
+end AlternatingSeriesTestOQ01OQ02OQ02

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ast-oq010202-ann-header",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "context",
+    "title": "Generalising the Factor: From (−1)ⁱ to an Arbitrary Bounded-Partial-Sum Weight",
+    "content": "The parent entry and its sibling both prove total-variation error bounds specialized to the single factor sequence (−1)ⁱ, whose partial sums lie in {0,1}. But Abel summation never uses the VALUE (−1)ⁱ — only that the factor's partial sums are bounded. This file removes the specialization: for any real factor sequence b with |∑_{i<k} b_i| ≤ B and any real coefficient sequence a, |∑_{j<n} b_j a_j| ≤ B·|a(n−1)| + B·∑_{j<n−1} |a(j+1) − a(j)|. This is the quantitative abstract Dirichlet test, answering the parent's open question 2 verbatim. The contrast with Mathlib is the point: Mathlib's Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded proves the Dirichlet test only qualitatively (Cauchy ⇒ converges) and needs monotone coefficients; the explicit total-variation estimate and the 2B·a_N truncation rate are new.",
+    "mathContext": "$\\left|\\sum_{j<n} b_j a_j\\right| \\le B\\,|a_{n-1}| + B\\sum_{j<n-1}|a_{j+1}-a_j|,\\quad |\\textstyle\\sum_{i<k} b_i| \\le B$",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet test", "Abel summation", "total variation", "bounded partial sums", "alternating series"],
+    "prerequisites": ["convergence of series", "summation by parts"]
+  },
+  {
+    "id": "ast-oq010202-ann-range",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-02",
+    "range": { "startLine": 59, "endLine": 88 },
+    "type": "theorem",
+    "title": "The Quantitative Abstract Dirichlet Test (Range Form)",
+    "content": "abs_dirichlet_range_le is the core result. Apply Finset.sum_range_by_parts to ∑_{j<n} a_j b_j: this produces a boundary term a(n−1)·(∑_{i<n} b_i) minus a sum of coefficient-differences (a(j+1) − a(j)) each weighted by a factor partial sum ∑_{i<j+1} b_i. The single hypothesis |∑_{i<k} b_i| ≤ B bounds every factor partial sum; the triangle inequality (Finset.abs_sum_le_sum_abs) then lands exactly on B·|a(n−1)| + B·∑ |a(j+1) − a(j)|. No monotonicity of a and no structure of b beyond bounded partial sums is used. The private helper abs_sub_le_add supplies the elementary |x − y| ≤ |x| + |y|.",
+    "mathContext": "$\\left|\\sum_{j<n} b_j a_j\\right| \\le B\\,|a_{n-1}| + B\\sum_{j<n-1}|a_{j+1}-a_j|$",
+    "significance": "key",
+    "relatedConcepts": ["summation by parts", "Finset.sum_range_by_parts", "Abel transformation", "total variation", "triangle inequality"],
+    "prerequisites": ["bounded partial sums", "reindexing finite sums"]
+  },
+  {
+    "id": "ast-oq010202-ann-window",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 128 },
+    "type": "technique",
+    "title": "Window Form: the 2B Constant from Shifted Prefix Sums",
+    "content": "abs_dirichlet_Ico_le extends the range bound to an arbitrary window [N,M). Reindex [N,M) to range (M−N) via Finset.sum_Ico_eq_sum_range using the shifted sequences a(N+·), b(N+·). The catch: the shifted factor's prefix sum ∑_{i<k} b(N+i) is NOT bounded by B but by 2B, because it equals (∑_{i<N+k} b_i) − (∑_{i<N} b_i) (Finset.sum_range_add_sum_Ico), a difference of two B-bounded prefix sums. Feeding this 2B bound into the range form gives |∑_{j∈[N,M)} b_j a_j| ≤ 2B·|a(M−1)| + 2B·∑_{j∈[N,M−1)} |a(j+1) − a(j)|.",
+    "mathContext": "$\\left|\\sum_{j=N}^{M-1} b_j a_j\\right| \\le 2B\\,|a_{M-1}| + 2B\\sum_{j=N}^{M-2}|a_{j+1}-a_j|$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_Ico_eq_sum_range", "Finset.sum_range_add_sum_Ico", "shifted partial sums", "windowed estimate"],
+    "prerequisites": ["the range-form bound", "interval-sum manipulation"]
+  },
+  {
+    "id": "ast-oq010202-ann-recover",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-02",
+    "range": { "startLine": 130, "endLine": 139 },
+    "type": "insight",
+    "title": "The Abstract Bound Contains the Classical One",
+    "content": "abs_alternating_range_le specializes b = (−1)ⁱ with the partial-sum bound 1 (from neg_one_geom_sum), B = 1, and recovers the parent file's alternating-series estimate |∑_{j<n} (−1)ʲ a_j| ≤ |a(n−1)| + ∑_{j<n−1} |a(j+1) − a(j)| in one line. This exhibits the entire classical alternating-series error theory as the single special case of the abstract Dirichlet bound where the factor is the sign sequence.",
+    "mathContext": "$b=(-1)^i,\\ B=1:\\ \\left|\\sum_{j<n}(-1)^j a_j\\right| \\le |a_{n-1}| + \\sum_{j<n-1}|a_{j+1}-a_j|$",
+    "significance": "supporting",
+    "relatedConcepts": ["neg_one_geom_sum", "specialisation", "sign sequence", "alternating series test"],
+    "prerequisites": ["the abstract range bound"]
+  },
+  {
+    "id": "ast-oq010202-ann-remainder",
+    "proofId": "alternating-series-test-oq-01-oq-02-oq-02",
+    "range": { "startLine": 141, "endLine": 186 },
+    "type": "insight",
+    "title": "The Explicit Rate Mathlib Omits: |S_N − l| ≤ 2B·a_N",
+    "content": "abs_dirichlet_diff_le_of_antitone collapses the window bound for antitone a ≥ 0: each |a(j+1) − a(j)| = a(j) − a(j+1), so the total variation telescopes (Finset.sum_range_sub') to a_N − a(M−1), which combines with the boundary 2B·a(M−1) to give exactly |S_M − S_N| ≤ 2B·a_N. abs_dirichlet_sub_limit_le then passes M → ∞: M ↦ |S_N − S_M| is continuous (Tendsto.const_sub of the convergent partial sums, composed with abs), so le_of_tendsto yields |S_N − l| ≤ 2B·a_N. Mathlib's Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded proves only that the partial sums are Cauchy — it gives no rate. This is the rate.",
+    "mathContext": "antitone $a\\ge 0$, $S_n\\to l$: $|S_M - S_N| \\le 2B\\,a_N$ and $|S_N - l| \\le 2B\\,a_N$",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "Finset.sum_range_sub'", "le_of_tendsto", "Dirichlet remainder", "quantitative convergence"],
+    "prerequisites": ["the window bound", "antitone sequences", "order limits"]
+  }
+]

--- a/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/alternating-series-test-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,199 @@
+{
+  "id": "alternating-series-test-oq-01-oq-02-oq-02",
+  "title": "The Quantitative Abstract Dirichlet Test: Total-Variation Error Bounds for Arbitrary Factor Sequences",
+  "slug": "alternating-series-test-oq-01-oq-02-oq-02",
+  "description": "Answers the parent entry's open question verbatim: does the Abel-summation error bound extend from the sign sequence (-1)^i to a general Dirichlet weight b_i with uniformly bounded partial sums, recovering the full Dirichlet test with explicit constants? The parent (alternating-series-test-oq-01-oq-02) and its sibling are both specialized to the single factor sequence (-1)^i, whose partial sums lie in {0,1}. But Abel summation never uses the value (-1)^i — only that the factor has bounded partial sums. This entry removes the specialization: for ANY real factor sequence b with |∑_{i<k} b_i| ≤ B and ANY real coefficient sequence a, |∑_{j<n} b_j·a_j| ≤ B·|a(n−1)| + B·∑_{j<n−1} |a(j+1) − a(j)| (the quantitative abstract Dirichlet test, range form). Over an arbitrary window [N,M) the shifted partial sums are bounded by 2B (difference of two B-bounded prefix sums), giving |∑_{j∈[N,M)} b_j·a_j| ≤ 2B·|a(M−1)| + 2B·∑_{j∈[N,M−1)} |a(j+1) − a(j)|. Three consequences: (1) taking b = (-1)^i, B = 1 recovers the parent's alternating bound (range form) — so the abstract estimate CONTAINS the classical one; (2) for antitone a ≥ 0 the boundary term and total variation telescope and collapse the window bound to the clean Dirichlet remainder |S_M − S_N| ≤ 2B·a_N; (3) passing M → ∞ for a convergent Dirichlet series bounds the genuine truncation error |S_N − l| ≤ 2B·a_N. The contrast with Mathlib is the point: Mathlib's Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded proves the Dirichlet test only QUALITATIVELY (partial sums are Cauchy, hence converge) and requires monotonicity of a throughout — it gives no rate. The bounds here are quantitative: an explicit total-variation estimate valid for non-monotone a, and an explicit 2B·a_N remainder in the monotone case, neither of which is in Mathlib.",
+  "meta": {
+    "author": "Abel/Dirichlet (summation by parts); quantitative abstract Dirichlet test formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlternatingSeriesTestOQ01OQ02OQ02.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "convergence",
+      "dirichlet-test",
+      "error-bound",
+      "summation-by-parts",
+      "abel-summation",
+      "bounded-variation",
+      "total-variation",
+      "alternating-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_by_parts",
+        "description": "Summation by parts (Abel transformation): rewrites ∑ b_j a_j as a boundary term minus a sum of coefficient-differences weighted by factor partial sums — the engine of the whole estimate",
+        "module": "Mathlib.Algebra.BigOperators.Module"
+      },
+      {
+        "theorem": "Finset.sum_range_add_sum_Ico",
+        "description": "∑_{i<N} f + ∑_{i∈[N,N+k)} f = ∑_{i<N+k} f: expresses a shifted prefix sum ∑_{i<k} b(N+i) as a difference of two B-bounded prefix sums, yielding the 2B window bound",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sum_range",
+        "description": "Reindexes the window [N,M) to range (M−N) via the shifted sequences a(N+·), b(N+·)",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_Ico_eq_sub",
+        "description": "∑_{i∈[N,M)} f = (∑_{i<M} f) − (∑_{i<N} f): converts the window sum into the partial-sum difference S_M − S_N",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "neg_one_geom_sum",
+        "description": "∑_{i<n} (-1)^i = if Even n then 0 else 1 — supplies the partial-sum bound 1 for the sign specialization that recovers the parent",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Finset.sum_range_sub'",
+        "description": "Telescoping identity, collapsing the total variation to a_N − a(M−1) in the antitone remainder",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.abs_sum_le_sum_abs",
+        "description": "Triangle inequality for finite sums |∑ f| ≤ ∑ |f|, applied to the variation term",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "le_of_tendsto",
+        "description": "Limits preserve ≤: passes the finite 2B·a_N bound through M → ∞ to bound the genuine remainder |S_N − l|",
+        "module": "Mathlib.Order.Topology.Basic"
+      }
+    ],
+    "originalContributions": [
+      "abs_dirichlet_range_le: the quantitative abstract Dirichlet test (range form) — for any factor sequence b with |∑_{i<k} b_i| ≤ B and any coefficient sequence a, |∑_{j<n} b_j a_j| ≤ B·|a(n−1)| + B·∑_{j<n−1} |a(j+1) − a(j)|. Generalizes the parent's (-1)^i specialization to an ARBITRARY bounded-partial-sum factor; absent from Mathlib",
+      "abs_dirichlet_Ico_le: the window form |∑_{j∈[N,M)} b_j a_j| ≤ 2B·|a(M−1)| + 2B·∑_{j∈[N,M−1)} |a(j+1) − a(j)|, where the 2B arises because shifted prefix sums are differences of two B-bounded prefix sums",
+      "abs_alternating_range_le: the b = (-1)^i, B = 1 specialization recovering the parent's alternating bound — exhibiting the classical estimate as a special case of the abstract one",
+      "abs_dirichlet_diff_le_of_antitone: the quantitative Dirichlet remainder |S_M − S_N| ≤ 2B·a_N for antitone a ≥ 0 — the explicit rate that Mathlib's qualitative Dirichlet test omits",
+      "abs_dirichlet_sub_limit_le: the limit-error bound |S_N − l| ≤ 2B·a_N for a convergent Dirichlet series, obtained by passing M → ∞ — Mathlib proves convergence but supplies no rate; this is the rate"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms propext, Classical.choice, Quot.sound on all five headline theorems.",
+    "lineCount": 187,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dirichlet's test (Dirichlet, 1862; Rudin, Theorem 3.42) generalises the Leibniz alternating series test: ∑ b_i a_i converges whenever the partial sums of b are uniformly bounded and a is of bounded variation tending to 0. Its proof is summation by parts (Abel's transformation). The alternating series test is the special case b_i = (-1)^i, whose partial sums lie in {0,1}. What is rarely packaged is the QUANTITATIVE form: an explicit error bound, with the boundedness constant B of the factor sequence appearing explicitly, that survives the loss of monotonicity of the coefficients. Abel summation trades the oscillation of the factor for its uniform partial-sum bound, leaving the total variation of the coefficients as the controlling quantity.",
+    "problemStatement": "The parent entry alternating-series-test-oq-01-oq-02 asks (open question 2): does the Abel-summation error bound extend from the sign sequence (-1)^i to a general Dirichlet weight b_i with uniformly bounded partial sums, recovering the full Dirichlet test with explicit constants?\n\n**Answer: yes.** For any real factor sequence b with |∑_{i<k} b_i| ≤ B and any real coefficient sequence a, |∑_{j<n} b_j a_j| ≤ B·|a(n−1)| + B·∑_{j<n−1} |a(j+1) − a(j)|, and over a window [N,M), |∑_{j∈[N,M)} b_j a_j| ≤ 2B·|a(M−1)| + 2B·∑_{j∈[N,M−1)} |a(j+1) − a(j)|. The sign case b = (-1)^i, B = 1 recovers the parent; for antitone a ≥ 0 the window bound collapses to the explicit Dirichlet remainder |S_M − S_N| ≤ 2B·a_N, and its M → ∞ limit bounds |S_N − l| ≤ 2B·a_N.",
+    "text": "Summation by parts only ever uses that the factor sequence has bounded partial sums, not its specific values. Replacing (-1)^i by an arbitrary bounded-partial-sum weight b yields the quantitative abstract Dirichlet test: the weighted sum is controlled by the factor's uniform bound B times the total variation of the coefficients, recovering the classical alternating estimate and supplying the explicit remainder rate that Mathlib's qualitative Dirichlet test omits.",
+    "proofStrategy": "Apply Finset.sum_range_by_parts to ∑_{j<n} a_j b_j, producing a boundary term a(n−1)·(∑_{i<n} b_i) minus a sum of coefficient-differences (a(j+1) − a(j)) each weighted by a factor partial sum ∑_{i<j+1} b_i. Bound every factor partial sum by B (hypothesis), apply the triangle inequality, and collect: B·|a(n−1)| + B·∑ |a(j+1) − a(j)| (abs_dirichlet_range_le). For the window form, reindex [N,M) to range (M−N) via Finset.sum_Ico_eq_sum_range; the shifted factor's prefix sum ∑_{i<k} b(N+i) equals (∑_{i<N+k} b_i) − (∑_{i<N} b_i) by Finset.sum_range_add_sum_Ico, so its absolute value is ≤ 2B by the triangle inequality; feed this 2B bound into the range form (abs_dirichlet_Ico_le). The sign specialization plugs b = (-1)^i with the partial-sum bound 1 from neg_one_geom_sum (abs_alternating_range_le). For the antitone remainder, each |a(j+1) − a(j)| = a(j) − a(j+1), so the variation telescopes (Finset.sum_range_sub') to a_N − a(M−1) and combines with the boundary 2B·a(M−1) to give exactly 2B·a_N (abs_dirichlet_diff_le_of_antitone). The limit form takes the continuous M → ∞ limit of the partial-sum difference and applies le_of_tendsto (abs_dirichlet_sub_limit_le).",
+    "keyInsights": [
+      "Abel summation is indifferent to the factor's values: it uses ONLY the uniform bound B on the factor's partial sums, so the entire alternating-series machinery generalises to an arbitrary Dirichlet weight with no extra work",
+      "A window [N,M) costs a factor of 2 in the constant: the shifted prefix sum ∑_{i<k} b(N+i) is a difference of two B-bounded prefix sums, hence bounded by 2B rather than B",
+      "The abstract bound CONTAINS the classical alternating estimate: setting b = (-1)^i with B = 1 reproduces the parent's range-form bound exactly",
+      "The quantitative gap with Mathlib: Mathlib's Dirichlet test proves only that the partial sums are Cauchy (qualitative convergence) and needs monotone coefficients; the explicit 2B·a_N truncation-error rate and the non-monotone total-variation estimate are new"
+    ],
+    "prerequisites": [
+      "Convergence of sequences and series in ℝ",
+      "Summation by parts (Abel's transformation) and the Dirichlet/Abel convergence tests",
+      "Total variation of a sequence and the notion of bounded variation",
+      "The parent entry's sign-weighted total-variation error bound"
+    ]
+  },
+  "sections": [
+    {
+      "id": "abstract-dirichlet-range",
+      "title": "The Quantitative Abstract Dirichlet Test (Range Form)",
+      "startLine": 59,
+      "endLine": 88,
+      "summary": "abs_dirichlet_range_le: for any factor b with |∑_{i<k} b_i| ≤ B, |∑_{j<n} b_j a_j| ≤ B·|a(n−1)| + B·∑_{j<n−1} |a(j+1) − a(j)|. Summation by parts, then bound each factor partial sum by B and triangle-inequality the rest.",
+      "mathContext": "$\\left|\\sum_{j<n} b_j a_j\\right| \\le B\\,|a_{n-1}| + B\\sum_{j<n-1}|a_{j+1}-a_j|$."
+    },
+    {
+      "id": "window-form",
+      "title": "Window Form with the 2B Constant",
+      "startLine": 89,
+      "endLine": 128,
+      "summary": "abs_dirichlet_Ico_le: over [N,M) the shifted prefix sums are differences of two B-bounded prefix sums (Finset.sum_range_add_sum_Ico), hence bounded by 2B; reindexing to range and applying the range form gives the window estimate with constant 2B.",
+      "mathContext": "$\\left|\\sum_{j=N}^{M-1} b_j a_j\\right| \\le 2B\\,|a_{M-1}| + 2B\\sum_{j=N}^{M-2}|a_{j+1}-a_j|$."
+    },
+    {
+      "id": "recovers-alternating",
+      "title": "Sign Specialization Recovers the Parent",
+      "startLine": 130,
+      "endLine": 139,
+      "summary": "abs_alternating_range_le: taking b = (-1)^i (partial sums bounded by 1 via neg_one_geom_sum) and B = 1 collapses the abstract range bound to the parent file's alternating-series estimate.",
+      "mathContext": "$\\left|\\sum_{j<n}(-1)^j a_j\\right| \\le |a_{n-1}| + \\sum_{j<n-1}|a_{j+1}-a_j|$."
+    },
+    {
+      "id": "antitone-remainder",
+      "title": "Quantitative Dirichlet Remainder (Monotone Case)",
+      "startLine": 141,
+      "endLine": 166,
+      "summary": "abs_dirichlet_diff_le_of_antitone: for antitone a ≥ 0 the total variation telescopes to a_N − a(M−1) and combines with the boundary 2B·a(M−1) to give the explicit rate |S_M − S_N| ≤ 2B·a_N — the quantitative content Mathlib's qualitative test omits.",
+      "mathContext": "antitone $a \\ge 0 \\Rightarrow |S_M - S_N| \\le 2B\\,a_N$."
+    },
+    {
+      "id": "limit-remainder",
+      "title": "Quantitative Remainder at the Limit",
+      "startLine": 168,
+      "endLine": 186,
+      "summary": "abs_dirichlet_sub_limit_le: if the Dirichlet series S_n → l with a antitone ≥ 0, then |S_N − l| ≤ 2B·a_N, obtained by passing the finite difference bound through the continuous M → ∞ limit (le_of_tendsto). Mathlib proves convergence but supplies no rate; this is the rate.",
+      "mathContext": "$S_n \\to l,\\ a \\text{ antitone} \\ge 0 \\Rightarrow |S_N - l| \\le 2B\\,a_N$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Abel, N. H.",
+      "title": "Untersuchungen über die Reihe ...",
+      "year": "1826",
+      "note": "Summation by parts (Abel's transformation)"
+    },
+    {
+      "authors": "Dirichlet, P. G. L.",
+      "title": "Sur la convergence des séries trigonométriques",
+      "year": "1862",
+      "note": "The Dirichlet convergence test: ∑ b_i a_i converges when the partial sums of b are bounded and a is of bounded variation → 0"
+    },
+    {
+      "authors": "Rudin, W.",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "note": "Summation by parts (Theorem 3.41), Dirichlet and Abel tests (Theorem 3.42), alternating series test (Theorem 3.43)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "alternating-series-test-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: the sign-weighted (b = (-1)^i) total-variation error bound. This entry answers that entry's open question 2 verbatim, generalising the factor (-1)^i to an arbitrary weight b with bounded partial sums and recovering the parent as the B = 1 special case."
+    },
+    {
+      "targetId": "alternating-series-test-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Sibling entry: a two-sided Jordan-decomposition trap, also specialized to (-1)^i. This entry instead generalises the factor sequence, giving the abstract Dirichlet test with explicit constants."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Abel-summation error bound depends only on the factor sequence having bounded partial sums, not on its being (-1)^i. Replacing (-1)^i by an arbitrary weight b with |∑_{i<k} b_i| ≤ B yields the quantitative abstract Dirichlet test |∑_{j<n} b_j a_j| ≤ B·|a(n−1)| + B·(total variation of a), proved with 0 axioms. The sign case b = (-1)^i, B = 1 recovers the parent; for antitone a ≥ 0 the window bound collapses to the explicit Dirichlet remainder |S_M − S_N| ≤ 2B·a_N, whose M → ∞ limit bounds |S_N − l| ≤ 2B·a_N.",
+    "implications": "Lifts the gallery's alternating-series error theory to the full Dirichlet setting with explicit constants. Where Mathlib's Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded establishes only qualitative convergence under monotonicity, this entry supplies the quantitative truncation-error rate 2B·a_N and a non-monotone total-variation estimate, unifying the alternating series test (b = (-1)^i) and the Dirichlet test (general bounded-partial-sum b) under one quantitative bound.",
+    "openQuestions": [
+      "Is the window constant 2B sharp, or can a careful choice of basepoint reduce it back toward B for symmetric factor sequences?",
+      "Does the same Abel-summation argument deliver a quantitative Abel test (factor b summable, coefficients a monotone bounded) with an explicit error rate, complementing the Dirichlet test proved here?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "AlternatingSeriesTestOQ01OQ02OQ02",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AlternatingSeriesTestOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (`alternating-series-test-oq-01-oq-02`) **open question 2 verbatim**: *does the Abel-summation error bound extend from the sign sequence $(-1)^i$ to a general Dirichlet weight $b_i$ with uniformly bounded partial sums, recovering the full Dirichlet test with explicit constants?* **Yes.**

The parent and its sibling are both specialized to the single factor $(-1)^i$. But Abel summation never uses the *value* $(-1)^i$ — only that the factor has bounded partial sums. This entry removes the specialization.

## Results (all over ℝ, via `Finset.sum_range_by_parts`)

For any real factor $b$ with $|\sum_{i<k} b_i| \le B$ and any real coefficient sequence $a$:

- **`abs_dirichlet_range_le`** — $|\sum_{j<n} b_j a_j| \le B\,|a_{n-1}| + B\sum_{j<n-1}|a_{j+1}-a_j|$ (quantitative abstract Dirichlet test)
- **`abs_dirichlet_Ico_le`** — window form over $[N,M)$ with constant $2B$ (shifted prefix sums are differences of two $B$-bounded prefix sums)
- **`abs_alternating_range_le`** — $b=(-1)^i, B=1$ recovers the parent's alternating bound (the abstract estimate *contains* the classical one)
- **`abs_dirichlet_diff_le_of_antitone`** — for antitone $a \ge 0$ the bound collapses to the explicit Dirichlet remainder $|S_M-S_N| \le 2B\,a_N$
- **`abs_dirichlet_sub_limit_le`** — $|S_N - l| \le 2B\,a_N$ at the limit

## Why it's new

Mathlib's `Antitone.cauchySeq_series_mul_of_tendsto_zero_of_bounded` proves the Dirichlet test only **qualitatively** (partial sums are Cauchy ⇒ converge) and requires **monotone** coefficients — it gives **no rate**. The bounds here are quantitative: an explicit total-variation estimate valid for **non-monotone** $a$, plus the explicit $2B\,a_N$ truncation rate.

## Verification

- 5 theorems, 187 lines, **0 sorries**
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` on all five headline theorems — **0 axioms** (`axiomCount: 0`, `status: verified`, `badge: original`)
- Type-checked against Mathlib 4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)