### PR TITLE
Enrich Schur's Lemma abelian corollary: irreducible reps of abelian groups are 1-dimensional

### DIFF
--- a/src/data/proofs/schur-lemma-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/schur-lemma-oq-01-oq-02/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-smul-k-comm",
+    "proofId": "schur-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 81
+    },
+    "type": "technique",
+    "title": "The k- and A-Actions Commute (smul_k_comm)",
+    "content": "smul_k_comm establishes the compatibility a • (t • w) = t • (a • w) for a ∈ A, t ∈ k, w ∈ M — the scalar-tower bookkeeping that lets the proof slide a base-field scalar t past an algebra element a. It routes both base-field scalars through algebraMap (t • w = (algebraMap k A t) • w, by algebraMap_smul under IsScalarTower k A M), turning two A-action multiplications into one, then commutes the algebra product with mul_comm — the single place where this lemma uses that A is commutative. It is marked private and omits the [IsAlgClosed k], [IsSimpleModule A M], [FiniteDimensional k M] instances since none are needed: pure scalar-tower algebra, valid for any commutative algebra over k.",
+    "mathContext": "$a \\cdot (t \\cdot w) = (\\mathrm{algebraMap}\\,t \\cdot a)\\cdot w = (a \\cdot \\mathrm{algebraMap}\\,t)\\cdot w = t\\cdot(a\\cdot w)$.",
+    "significance": "technical",
+    "prerequisites": [
+      "Scalar towers IsScalarTower k A M and algebraMap_smul",
+      "Commutativity of the algebra A (mul_comm on algebra products)"
+    ],
+    "relatedConcepts": [
+      "scalar tower",
+      "algebra over a field",
+      "commuting actions",
+      "algebraMap compatibility"
+    ]
+  },
+  {
+    "id": "ann-exists-scalar-smul",
+    "proofId": "schur-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Every Algebra Element Acts as a Scalar (exists_scalar_smul)",
+    "content": "exists_scalar_smul is where the parent's Schur form does its work: for each a ∈ A there is a scalar c ∈ k with a • m = c • m for all m. The proof packages multiplication-by-a as the A-linear endomorphism LinearMap.lsmul A M a — and this map is A-linear precisely because A is commutative (a • (b • m) = (ab) • m = (ba) • m = b • (a • m), so it commutes with every b-action). Feeding that endomorphism into the parent's schur_endomorphism_scalar (over the algebraically closed field k, on the simple finite-dimensional module M) returns the scalar. The general theory only forces the *centralizer* of the action to be scalars; commutativity makes the centralizer the entire algebra, so every element is scalar at once.",
+    "mathContext": "$\\forall a \\in A,\\ \\exists c \\in k,\\ \\forall m,\\ a \\cdot m = c \\cdot m$, via Schur applied to $\\mathrm{lsmul}_A\\, a \\in \\mathrm{End}_A(M)$.",
+    "significance": "key",
+    "prerequisites": [
+      "LinearMap.lsmul A M a: multiplication by a as an A-linear map (needs A commutative)",
+      "The parent's schur_endomorphism_scalar: A-linear endomorphisms of a simple f.d. module over an algebraically closed field are scalars",
+      "Algebraic closure of k (consumed inside the parent lemma)"
+    ],
+    "relatedConcepts": [
+      "Schur's Lemma",
+      "centralizer of a module action",
+      "commutative algebra",
+      "endomorphism ring of a simple module"
+    ]
+  },
+  {
+    "id": "ann-finrank-one",
+    "proofId": "schur-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 93,
+      "endLine": 133
+    },
+    "type": "concept",
+    "title": "Simple over Commutative ⟹ One-Dimensional (the algebraic core)",
+    "content": "simple_module_over_commutative_finrank_eq_one is the heart: finrank k M = 1 for a simple module M over a commutative k-algebra A, finite-dimensional over an algebraically closed field k. Simplicity gives nontriviality (IsSimpleModule.nontrivial), hence a nonzero vector v. The k-line L = span k {v} is shown to be A-invariant: for a ∈ A and t • v ∈ L, smul_k_comm and exists_scalar_smul give a • (t • v) = t • (c • v) = (t·c) • v ∈ L — every line is A-stable because A acts by scalars. L is then repackaged as an honest Submodule A M (carrier the same set, A-closure from hsmul_mem). Since v ≠ 0 this A-submodule is not ⊥, so by simplicity (eq_bot_or_eq_top on the simple-module lattice) it is ⊤; transferring back, span k {v} = ⊤, and finrank_span_singleton gives finrank k M = finrank k (span k {v}) = 1.",
+    "mathContext": "$M = \\mathrm{span}_k\\{v\\}$ since the $k$-line is an $A$-submodule and $M$ is simple, so $\\dim_k M = 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "exists_scalar_smul (A acts by scalars) and smul_k_comm",
+      "Simple-module lattice: eq_bot_or_eq_top and IsSimpleModule.nontrivial",
+      "Submodule.span, Submodule.mem_span_singleton, finrank_span_singleton, finrank_top"
+    ],
+    "relatedConcepts": [
+      "simple module",
+      "submodule lattice",
+      "invariant line",
+      "dimension of a span",
+      "irreducibility"
+    ]
+  },
+  {
+    "id": "ann-abelian-group",
+    "proofId": "schur-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 152
+    },
+    "type": "concept",
+    "title": "Irreducible Representations of Abelian Groups (group-algebra instance)",
+    "content": "irreducible_rep_abelian_group_finrank_eq_one specializes the commutative core to the group algebra A = k[G] = MonoidAlgebra k G of an abelian group G. The only new ingredient is that k[G] is commutative exactly when G is abelian (the MonoidAlgebra.commRing instance fires from [CommGroup G]) — a representation of G over k is the same as a k[G]-module, so a finite-dimensional irreducible representation is a simple finite-dimensional k[G]-module, and the core forces finrank k M = 1. No representation-theoretic machinery beyond the group-algebra correspondence is needed; the proof is a one-line instantiation.",
+    "mathContext": "$A = k[G]$ is commutative $\\iff G$ abelian; so every f.d. simple $k[G]$-module has $\\dim_k = 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "The group algebra k[G] = MonoidAlgebra k G and MonoidAlgebra.commRing for commutative G",
+      "Representations of G as k[G]-modules; irreducible ↔ simple module",
+      "simple_module_over_commutative_finrank_eq_one"
+    ],
+    "relatedConcepts": [
+      "group algebra",
+      "abelian group",
+      "irreducible representation",
+      "representation as module"
+    ]
+  },
+  {
+    "id": "ann-complex-case",
+    "proofId": "schur-lemma-oq-01-oq-02",
+    "range": {
+      "startLine": 164,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "The Headline Complex Case (k = ℂ)",
+    "content": "irreducible_complex_rep_abelian_one_dim instantiates the abelian-group result at k = ℂ (algebraically closed by the fundamental theorem of algebra): every finite-dimensional irreducible complex representation of an abelian group is one-dimensional. This is the structural fact underpinning the character theory of abelian groups — it is why the irreducible characters of a finite abelian group are precisely its homomorphisms G → ℂˣ, why the dual group Ĝ is defined as it is, and why Fourier analysis / Pontryagin duality on abelian groups takes the form it does. Sharpness comes from the parent: the conclusion fails over ℝ, where ℤ/4 has an irreducible 2-dimensional real representation (rotation by 90°), so algebraic closure is essential.",
+    "mathContext": "Over $\\mathbb{C}$ every irreducible representation of an abelian $G$ is a character $G \\to \\mathbb{C}^\\times$; $\\dim = 1$.",
+    "significance": "key",
+    "prerequisites": [
+      "irreducible_rep_abelian_group_finrank_eq_one specialized to k = ℂ",
+      "ℂ is algebraically closed (fundamental theorem of algebra)",
+      "Characters of abelian groups as 1-dimensional representations"
+    ],
+    "relatedConcepts": [
+      "character theory",
+      "Pontryagin duality",
+      "dual group",
+      "Fourier analysis on groups",
+      "complex representations"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `schur-lemma-oq-01-oq-02` (irreducible representations of abelian groups are one-dimensional).

## What this adds
The entry previously had only `meta.json` (already rich) and **no `annotations.json`**. This PR adds 5 substantive inline annotations covering the full Lean file:

1. **smul_k_comm** — the k- and A-actions commute (the one place commutativity of A enters at the scalar-tower level).
2. **exists_scalar_smul** — every algebra element acts as a scalar, by feeding `LinearMap.lsmul A M a` into the parent's `schur_endomorphism_scalar`; commutativity makes the centralizer the *whole* algebra.
3. **simple_module_over_commutative_finrank_eq_one** — the algebraic core: a k-line is A-invariant since A acts by scalars, and simplicity collapses it to all of M, so $\dim_k M = 1$.
4. **irreducible_rep_abelian_group_finrank_eq_one** — the group-algebra instance $A = k[G]$, commutative iff G abelian.
5. **irreducible_complex_rep_abelian_one_dim** — the headline $k = \mathbb{C}$ case underlying character theory / Pontryagin duality; sharp (fails over $\mathbb{R}$ via $\mathbb{Z}/4$).

Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Validation
- JSON valid; `annotations:build --strict` resolves every annotation in this entry to a Lean construct (no errors for this slug).
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, consistent with the sorry-free, axiom-free Lean file.