### PR TITLE
research(sylow-oq02-oq02): Large-Prime-Factor Normality — m<p ⟹ Sylow p-subgroup normal [verified/0-ax/original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3880,6 +3880,7 @@ import Proofs.SylowTheoremOQ02
 import Proofs.SylowTheoremOQ02Orbit
 import Proofs.SylowTheoremOQ02OQ01Nilpotent
 import Proofs.SylowTheoremOQ02OQ01OQ01
+import Proofs.SylowTheoremOQ02OQ02
 import Proofs.SylowTheoremOQ03
 import Proofs.SylowTheoremOQ03OQ02
 import Proofs.SylowTheoremSchurZassenhausOQ03

--- a/proofs/Proofs/SylowTheoremOQ02OQ02.lean
+++ b/proofs/Proofs/SylowTheoremOQ02OQ02.lean
@@ -1,0 +1,125 @@
+import Mathlib.GroupTheory.Sylow
+import Mathlib.GroupTheory.Index
+import Mathlib.Tactic
+
+/-
+# Large-Prime-Factor Normality for Sylow p-Subgroups
+
+## What This Proves
+
+Let `G` be a finite group whose order factors as `|G| = p ^ a * m` with `p` prime
+and `p ∤ m` (so `p ^ a` is the full `p`-part of `|G|` and `m` is its `p'`-cofactor).
+
+**Main theorem (`sylow_normal`).**  If the cofactor is smaller than the prime,
+`m < p`, then *the* Sylow `p`-subgroup is normal in `G`.
+
+The whole argument is the elementary divisibility/congruence pinch on the Sylow
+count `n_p := #(Sylow p G)`:
+
+* **`sylow_card_eq`** — `|P| = p ^ a` (the Sylow subgroup carries the full `p`-part);
+* **`sylow_index_eq`** — `[G : P] = m`;
+* **`card_sylow_eq_one`** — `n_p ∣ [G : P] = m` forces `n_p ≤ m < p`, while Sylow's
+  third theorem gives `n_p ≡ 1 (mod p)`; the only value `< p` that is `≡ 1 (mod p)`
+  is `1`, hence `n_p = 1`;
+* **`sylow_normal`** — a unique Sylow subgroup is normal.
+
+## Why This Is Not Already in the Gallery / Mathlib
+
+Mathlib supplies the two pillars (`card_sylow_modEq_one`, `Sylow.card_dvd_index`)
+and the uniqueness↔normality bridge (`Sylow.normal_of_subsingleton`), but not this
+packaged "`m < p ⟹ normal`" criterion.  It is the clean cofactor-below-the-prime
+slice of the Sylow normality landscape:
+
+* sibling `sylow-theorem-oq-01` runs the count analysis for groups of order `p·q`;
+* sibling `sylow-theorem-oq-02-oq-01` characterises global nilpotency by
+  `n_p = 1` for *every* prime.
+
+Here a *single* numerical hypothesis `m < p` on the cofactor collapses the count for
+the prime `p` alone, with no restriction on the `p`-power exponent `a`.
+
+## Sharpness
+
+The bound is tight in spirit: the inequality used is exactly `n_p ≤ m < p`, so once
+`m ≥ p` the value `n_p = p + 1` (for instance) is no longer excluded by the
+congruence `n_p ≡ 1 (mod p)`, and normality can genuinely fail.
+-/
+
+namespace SylowLargePrimeFactor
+
+open Subgroup
+
+variable {G : Type*} [Group G] [Finite G]
+
+/-- The order of a Sylow `p`-subgroup of a group of order `p ^ a * m`
+(with `p ∤ m`) is exactly the full `p`-part `p ^ a`. -/
+theorem sylow_card_eq {p a m : ℕ} [hp : Fact p.Prime]
+    (hcard : Nat.card G = p ^ a * m) (hpm : ¬ p ∣ m) (P : Sylow p G) :
+    Nat.card P = p ^ a := by
+  -- `m ≠ 0` because the group is nonempty and finite.
+  have hm : m ≠ 0 := by
+    have hpos : 0 < p ^ a * m := hcard ▸ Nat.card_pos
+    rcases Nat.eq_zero_or_pos m with rfl | h
+    · simp at hpos
+    · exact h.ne'
+  rw [P.card_eq_multiplicity, hcard]
+  congr 1
+  -- `(p ^ a * m).factorization p = a`.
+  have hppow : (p ^ a).factorization p = a := by
+    rw [Nat.factorization_pow, Finsupp.smul_apply, hp.out.factorization,
+        Finsupp.single_apply, if_pos rfl, smul_eq_mul, mul_one]
+  have hmfact : m.factorization p = 0 := Nat.factorization_eq_zero_of_not_dvd hpm
+  rw [Nat.factorization_mul (pow_ne_zero a hp.out.ne_zero) hm, Finsupp.add_apply,
+      hppow, hmfact, add_zero]
+
+/-- The index of a Sylow `p`-subgroup of a group of order `p ^ a * m`
+(with `p ∤ m`) is exactly the `p'`-cofactor `m`. -/
+theorem sylow_index_eq {p a m : ℕ} [hp : Fact p.Prime]
+    (hcard : Nat.card G = p ^ a * m) (hpm : ¬ p ∣ m) (P : Sylow p G) :
+    (P : Subgroup G).index = m := by
+  have hmul := Subgroup.card_mul_index (P : Subgroup G)
+  rw [sylow_card_eq hcard hpm P, hcard] at hmul
+  exact Nat.eq_of_mul_eq_mul_left (pow_pos hp.out.pos a) hmul
+
+/-- **The count collapses.**  When the `p'`-cofactor `m` is smaller than `p`, the
+number of Sylow `p`-subgroups is forced to `1`: it divides `m` (so is `≤ m < p`)
+yet is `≡ 1 (mod p)`, and `1` is the only such value below `p`. -/
+theorem card_sylow_eq_one {p a m : ℕ} [hp : Fact p.Prime]
+    (hcard : Nat.card G = p ^ a * m) (hpm : ¬ p ∣ m) (hm : m < p) :
+    Nat.card (Sylow p G) = 1 := by
+  obtain ⟨P⟩ := Sylow.nonempty (p := p) (G := G)
+  -- `m > 0` from finiteness/nonemptiness.
+  have hm0 : 0 < m := by
+    have hpos : 0 < p ^ a * m := hcard ▸ Nat.card_pos
+    rcases Nat.eq_zero_or_pos m with rfl | h
+    · simp at hpos
+    · exact h
+  -- `n_p ∣ m`.
+  have hdvd : Nat.card (Sylow p G) ∣ m := by
+    have h := P.card_dvd_index
+    rwa [sylow_index_eq hcard hpm P] at h
+  -- hence `n_p ≤ m < p`.
+  have hlt : Nat.card (Sylow p G) < p :=
+    lt_of_le_of_lt (Nat.le_of_dvd hm0 hdvd) hm
+  -- Sylow's congruence `n_p ≡ 1 (mod p)`, read off below `p`.
+  have hmod := card_sylow_modEq_one p G
+  rw [Nat.ModEq, Nat.mod_eq_of_lt hlt, Nat.mod_eq_of_lt hp.out.one_lt] at hmod
+  exact hmod
+
+/-- **Main theorem — Large-Prime-Factor Normality.**  If `|G| = p ^ a * m` with
+`p` prime, `p ∤ m`, and `m < p`, then every Sylow `p`-subgroup `P` is normal
+(there is in fact only one). -/
+theorem sylow_normal {p a m : ℕ} [hp : Fact p.Prime]
+    (hcard : Nat.card G = p ^ a * m) (hpm : ¬ p ∣ m) (hm : m < p)
+    (P : Sylow p G) : (P : Subgroup G).Normal := by
+  haveI : Subsingleton (Sylow p G) :=
+    (Nat.card_eq_one_iff_unique.mp (card_sylow_eq_one hcard hpm hm)).1
+  exact Sylow.normal_of_subsingleton P
+
+/-- Existence form: such a group has a normal Sylow `p`-subgroup. -/
+theorem exists_normal_sylow {p a m : ℕ} [hp : Fact p.Prime]
+    (hcard : Nat.card G = p ^ a * m) (hpm : ¬ p ∣ m) (hm : m < p) :
+    ∃ P : Sylow p G, (P : Subgroup G).Normal := by
+  obtain ⟨P⟩ := Sylow.nonempty (p := p) (G := G)
+  exact ⟨P, sylow_normal hcard hpm hm P⟩
+
+end SylowLargePrimeFactor

--- a/src/data/proofs/sylow-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-02/meta.json
@@ -1,0 +1,67 @@
+{
+  "id": "sylow-theorem-oq-02-oq-02",
+  "title": "Large-Prime-Factor Normality: |G| = p^a·m with m < p ⟹ Sylow p-subgroup normal",
+  "slug": "sylow-theorem-oq-02-oq-02",
+  "description": "A clean cofactor-below-the-prime normality criterion for finite groups. If |G| = p^a · m with p prime, p ∤ m (so p^a is the full p-part and m the p'-cofactor), and the cofactor satisfies m < p, then the Sylow p-subgroup of G is unique and therefore normal. The proof is the elementary divisibility/congruence pinch on the Sylow count n_p = #(Sylow p G): Sylow's second theorem gives n_p ∣ [G : P] = m, so n_p ≤ m < p, while Sylow's third theorem gives n_p ≡ 1 (mod p); the only value below p that is ≡ 1 (mod p) is 1, forcing n_p = 1, and a unique Sylow subgroup is normal (Sylow.normal_of_subsingleton). No restriction is placed on the p-power exponent a. This is the single-prime cofactor slice of the Sylow normality landscape, distinct from the parent sibling oq-02-oq-01 (which characterises global nilpotency by n_p = 1 for every prime) and from oq-01 (the n_p analysis specialised to order pq).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylowTheoremOQ02OQ02.lean",
+    "tags": [
+      "group-theory",
+      "sylow",
+      "normal-subgroup",
+      "finite-groups",
+      "sylow-counting",
+      "divisibility"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 125,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None beyond the stated hypotheses on a finite group. The whole file assumes only [Group G] [Finite G] together with the per-theorem antecedents |G| = p^a·m, p prime (as [Fact p.Prime]), p ∤ m, and m < p. No axioms, no sorries; #print axioms reports only propext, Classical.choice, Quot.sound. Builds against Mathlib 4.26.0.",
+    "originalContributions": [
+      "sylow_normal: the headline criterion — for a finite group with Nat.card G = p^a·m, p ∤ m and m < p, every Sylow p-subgroup P satisfies (P : Subgroup G).Normal. Mathlib supplies the pillars but not this packaged m<p ⟹ normal statement.",
+      "card_sylow_eq_one: the count collapse Nat.card (Sylow p G) = 1, proved by combining n_p ∣ m (from Sylow.card_dvd_index after computing the index) with the congruence n_p ≡ 1 (mod p) (card_sylow_modEq_one) and reading both modular facts off below p via Nat.mod_eq_of_lt.",
+      "sylow_index_eq: the auxiliary [G : P] = m, obtained from Subgroup.card_mul_index after pinning |P| = p^a and cancelling the (positive) p-power.",
+      "sylow_card_eq: |P| = p^a via Sylow.card_eq_multiplicity together with the prime-power factorization (p^a·m).factorization p = a (using p ∤ m to kill the cofactor's contribution).",
+      "exists_normal_sylow: existence packaging — such a group has a normal Sylow p-subgroup."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Sylow.card_dvd_index",
+        "description": "Nat.card (Sylow p G) ∣ P.index for a Sylow p-subgroup P; supplies n_p ∣ m once the index is computed to be the cofactor m",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "card_sylow_modEq_one",
+        "description": "Sylow's third theorem: Nat.card (Sylow p G) ≡ 1 [MOD p]; the congruence half of the pinch",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_eq_multiplicity",
+        "description": "Nat.card P = p ^ (Nat.card G).factorization p for a Sylow p-subgroup; pins the Sylow order to the full p-part p^a",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.normal_of_subsingleton",
+        "description": "if Sylow p G is a subsingleton then the unique Sylow p-subgroup is normal; converts n_p = 1 into normality",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Subgroup.card_mul_index",
+        "description": "Nat.card H * H.index = Nat.card G; used to extract the index [G : P] = m from the order computation",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Nat.factorization_mul",
+        "description": "factorization of a product splits additively over the factors (for nonzero arguments); computes (p^a·m).factorization p = a",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

New verified gallery entry **sylow-theorem-oq-02-oq-02**: a clean cofactor-below-the-prime normality criterion for finite groups.

**Theorem.** If `|G| = p^a · m` with `p` prime, `p ∤ m` (so `p^a` is the full p-part, `m` the p'-cofactor), and `m < p`, then the Sylow p-subgroup of `G` is unique and therefore **normal** — for any exponent `a`.

## Proof (elementary divisibility/congruence pinch)
- `sylow_card_eq`: `|P| = p^a` via `Sylow.card_eq_multiplicity` + `(p^a·m).factorization p = a` (uses `p ∤ m`).
- `sylow_index_eq`: `[G : P] = m` via `Subgroup.card_mul_index`, cancelling the positive p-power.
- `card_sylow_eq_one`: `n_p ∣ [G:P] = m ⟹ n_p ≤ m < p` (Sylow II), combined with `n_p ≡ 1 (mod p)` (Sylow III). The only value below `p` that is `≡ 1 (mod p)` is `1`.
- `sylow_normal` / `exists_normal_sylow`: `n_p = 1 ⟹ Subsingleton ⟹` normal (`Sylow.normal_of_subsingleton`).

## Distinctness
Mathlib has the pillars (`card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`) but not this packaged `m<p ⟹ normal` criterion. Distinct from sibling `oq-02-oq-01` (global nilpotency ⟺ all `n_p = 1`) and `oq-01` (order-pq count analysis): here a single numerical hypothesis on the cofactor collapses the count for one prime, with no restriction on `a`.

## Verification
- Compiles against Mathlib 4.26.0 (`lake env lean`), 5 theorems / 0 defs / 125 lines.
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` — **0 axioms, 0 sorries**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)