### PR TITLE
Enrich König's Constraint on the Continuum: add annotations

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-continuum-def",
+    "proofId": "cantor-diagonalization-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 73 },
+    "type": "definition",
+    "title": "The Continuum 2^ℵ₀",
+    "content": "`continuum` is defined as 2^ℵ₀, the cardinality of the real line (equivalently of 𝒫(ℕ)). The whole entry studies the one structural fact ZFC pins down about this cardinal's place in the aleph hierarchy: its cofinality. Cantor's diagonal argument gives ℵ₀ < 2^ℵ₀ but leaves the exact value open; König's theorem supplies the only nontrivial provable constraint.",
+    "mathContext": "$\\mathfrak{c} = 2^{\\aleph_0} = |\\mathcal{P}(\\mathbb{N})| = |\\mathbb{R}|$.",
+    "significance": "technical",
+    "relatedConcepts": ["cardinality of the continuum", "power set", "aleph hierarchy"],
+    "prerequisites": ["cardinal arithmetic", "Cantor's theorem"]
+  },
+  {
+    "id": "ann-konig-general",
+    "proofId": "cantor-diagonalization-oq-01-oq-03",
+    "range": { "startLine": 75, "endLine": 103 },
+    "type": "concept",
+    "title": "König's Cofinality Bound: cf(2^κ) > κ",
+    "content": "Part I derives König's constraint. `konig_cofinality_general` proves κ < cf(2^κ) for every infinite κ, directly from Mathlib's `Cardinal.lt_cof_power` (the cardinal form of König's inequality Σκᵢ < Πλᵢ) instantiated with 1 < 2. `continuum_cofinality_gt_aleph0` specializes to κ = ℵ₀, giving ℵ₀ < cf(2^ℵ₀) — the parent entry's first axiom `konig_cofinality_bound`, now a theorem. `continuum_uncountable_cofinality` restates it as ¬(cf(2^ℵ₀) ≤ ℵ₀): the continuum is not the supremum of any countable family of smaller cardinals.",
+    "mathContext": "$\\operatorname{cf}(2^\\kappa) > \\kappa$ for infinite $\\kappa$; in particular $\\operatorname{cf}(2^{\\aleph_0}) > \\aleph_0$, so $2^{\\aleph_0}$ has uncountable cofinality.",
+    "significance": "key",
+    "relatedConcepts": ["König's theorem", "cofinality", "Cardinal.lt_cof_power", "regular vs singular cardinals"],
+    "prerequisites": ["König's inequality", "cofinality of a cardinal"]
+  },
+  {
+    "id": "ann-cof-aleph-omega",
+    "proofId": "cantor-diagonalization-oq-01-oq-03",
+    "range": { "startLine": 105, "endLine": 117 },
+    "type": "concept",
+    "title": "The Cofinality of ℵ_ω Is ℵ₀",
+    "content": "Part II proves `cof_aleph_omega`: cf(ℵ_ω) = ℵ₀, the parent's second axiom `aleph_omega_cofinality_is_aleph_zero`. The cofinality of a singular aleph at a limit ordinal reduces to the cofinality of that ordinal. The proof rewrites (aleph ω).ord = ω_ω via `Cardinal.ord_aleph` (bridging the aleph/cardinal and omega/initial-ordinal hierarchies), applies `Ordinal.cof_omega` at the succ-limit ω (`Ordinal.isSuccLimit_omega0`), and finishes with `Ordinal.cof_omega0` (cf(ω) = ℵ₀). ℵ_ω is the first singular aleph: it is the countable supremum ℵ_ω = sup_n ℵ_n.",
+    "mathContext": "$\\operatorname{cf}(\\aleph_\\omega) = \\operatorname{cf}(\\omega) = \\aleph_0$, since $\\aleph_\\omega = \\sup_n \\aleph_n$.",
+    "significance": "key",
+    "relatedConcepts": ["singular cardinal", "cofinality of an ordinal", "Cardinal.ord_aleph", "initial ordinal"],
+    "prerequisites": ["ordinal cofinality", "the aleph and omega hierarchies"]
+  },
+  {
+    "id": "ann-skips-singular",
+    "proofId": "cantor-diagonalization-oq-01-oq-03",
+    "range": { "startLine": 119, "endLine": 148 },
+    "type": "insight",
+    "title": "The Continuum Skips Every Cardinal of Countable Cofinality",
+    "content": "Part III combines the two halves. `continuum_ne_aleph_omega` proves 2^ℵ₀ ≠ ℵ_ω: equality would force cf(2^ℵ₀) = cf(ℵ_ω) = ℵ₀, contradicting Part I. `continuum_ne_of_cof_aleph0` sharpens this to the full obstruction — 2^ℵ₀ differs from EVERY cardinal c with cf(c) = ℵ₀, by the same one-line cofinality contradiction. ℵ_ω is just the first instance; ℵ_{ω+ω}, ℵ_{ω·ω}, and every ℵ_α with cf(α) = ω are equally excluded, as the closing `example` re-derives ℵ_ω from the general theorem.",
+    "mathContext": "$2^{\\aleph_0} \\neq c$ whenever $\\operatorname{cf}(c) = \\aleph_0$; the singular alephs $\\aleph_\\omega, \\aleph_{\\omega+\\omega}, \\aleph_{\\omega\\cdot\\omega}, \\ldots$ are all forbidden values of the continuum.",
+    "significance": "key",
+    "relatedConcepts": ["value of the continuum", "singular alephs", "Easton's theorem", "ZFC-provable constraints"],
+    "prerequisites": ["cofinality", "cardinal comparison"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "cantor-diagonalization-oq-01-oq-03",
+    "range": { "startLine": 150, "endLine": 173 },
+    "type": "context",
+    "title": "Summary: The Diagonal Argument's Axiom-Free Reach",
+    "content": "Part IV's `konig_constraint_summary` bundles the three facts the diagonal argument plus ZFC establish about the continuum's cofinality, all axiom-free: (1) ℵ₀ < 2^ℵ₀ (Cantor's diagonal argument, `Cardinal.cantor`); (2) ℵ₀ < cf(2^ℵ₀) (König); (3) 2^ℵ₀ ≠ ℵ_ω. Facts (2) and (3) were axioms in the parent CH entry and are here discharged as theorems. The result marks the precise boundary of what the diagonal method reaches: it proves a gap exists and that the gap has uncountable cofinality, but cannot decide CH or pin the continuum's exact place in the hierarchy.",
+    "mathContext": "$\\aleph_0 < 2^{\\aleph_0}$ (Cantor) $\\wedge\\ \\aleph_0 < \\operatorname{cf}(2^{\\aleph_0})$ (König) $\\wedge\\ 2^{\\aleph_0} \\neq \\aleph_\\omega$ — all provable in ZFC, no extra axioms.",
+    "significance": "context",
+    "relatedConcepts": ["Continuum Hypothesis", "Cantor's theorem", "independence of CH", "limits of diagonalization"],
+    "prerequisites": ["the Continuum Hypothesis", "cofinality"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-01-oq-03`.

## Gap addressed
The entry had a rich, well-formed `meta.json` (overview, 5 sections, structured conclusion + crossReferences) but **no `annotations.json`** — zero inline annotation coverage.

## Added
`annotations.json` with **5 substantive annotations** aligned to the file's four parts, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
- the `continuum` = 2^ℵ₀ definition
- Part I: König's cofinality bound cf(2^κ) > κ via `Cardinal.lt_cof_power` (discharges the parent's first axiom)
- Part II: cf(ℵ_ω) = ℵ₀ via `Ordinal.cof_omega`/`cof_omega0` (discharges the parent's second axiom)
- Part III: 2^ℵ₀ ≠ every cardinal of countable cofinality (sharp form)
- Part IV: the axiom-free summary of the diagonal argument's reach

## Verification
- JSON validates; `pnpm build` succeeds.
- Axiom integrity unchanged: `verified`/`original`/0-axiom — the entry's whole point is discharging the parent's two axioms (confirmed by the docstring; only propext/Classical.choice/Quot.sound).