### PR TITLE
research(erdos-1209): Erdős's trivial counterexample for shifts avoiding primes/squarefrees [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos1209Problem.lean
+++ b/proofs/Proofs/Erdos1209Problem.lean
@@ -1,0 +1,207 @@
+/-
+Erdős Problem #1209: Sequences whose shifts avoid primes / squarefrees
+
+Source: https://erdosproblems.com/1209
+Status: OPEN (Erdős called the questions "quite hopeless"); a trivial
+counterexample exists, and this file formalizes that counterexample.
+
+Statement (informal):
+Erdős asked questions about strictly increasing sequences A = {a₁ < a₂ < ⋯}
+and the arithmetic nature of the shifts aₖ + k — in particular whether one can
+force aₖ + k to be prime (resp. squarefree) infinitely often. In [Er80] Erdős
+remarked that "unless I overlook a trivial way of getting a counterexample
+these questions are quite hopeless". Indeed there is a trivial counterexample
+(a variant of the construction in problem #429):
+
+    define a₁ = 2, and for k ≥ 2 let aₖ > aₖ₋₁ be a prime with
+        aₖ + k ≡ 0 (mod qₖ),
+    where qₖ is a prime not dividing k.
+
+The same idea with qₖ² in place of qₖ produces a counterexample to the
+squarefree question (then qₖ² ∣ aₖ + k, so aₖ + k is not squarefree).
+The sequence can be made to grow arbitrarily fast.
+
+What this file proves (faithful formalization of the counterexample):
+
+  * `exists_prime_add_not_prime`     — for every shift k ≥ 1 and every bound N
+        there is a prime p > N with p + k composite (it is divisible by a prime
+        q ∤ k, by Dirichlet's theorem on primes in arithmetic progressions);
+  * `exists_prime_add_not_squarefree` — the qₖ² variant: a prime p > N with
+        p + k divisible by a square q² > 1, hence not squarefree;
+  * `erdos1209_prime_counterexample` — there is a STRICTLY INCREASING sequence
+        a : ℕ → ℕ of primes, growing faster than any prescribed g, with
+        aₖ + k never prime (k ≥ 1);
+  * `erdos1209_squarefree_counterexample` — the same with "never squarefree".
+
+The only nontrivial ingredient is Dirichlet's theorem on primes in arithmetic
+progressions (`Nat.forall_exists_prime_gt_and_modEq`), which is in Mathlib.
+The "grows arbitrarily fast" clause is captured by quantifying over an
+arbitrary growth function g : ℕ → ℕ and requiring g k < a k for all k.
+
+References:
+- [Er80] P. Erdős, "Some applications of graph theory and combinatorial methods
+  to number theory and geometry", 1980.
+- Erdős problem #429 (the construction this is a variant of).
+
+Tags: erdos, number-theory, primes, squarefree, dirichlet, arithmetic-progressions
+-/
+
+import Mathlib
+
+namespace Erdos1209
+
+/-- **Building block (prime shift).**
+For every shift `k ≥ 1` and every bound `N`, there is a prime `p > N` such that
+`p + k` is *not* prime.
+
+Construction: pick a prime `q > k` (so `q ∤ k`). Then the residue `q - k` is a
+unit mod `q`, so by Dirichlet's theorem there is a prime `p` larger than both `N`
+and `q` with `p ≡ q - k (mod q)`. Hence `q ∣ p + k` with `1 < q < p + k`, so
+`p + k` is composite. -/
+theorem exists_prime_add_not_prime (k : ℕ) (hk : 1 ≤ k) (N : ℕ) :
+    ∃ p, N < p ∧ p.Prime ∧ ¬ (p + k).Prime := by
+  -- a prime `q` strictly larger than `k`
+  obtain ⟨q, hqk, hq⟩ := Nat.exists_infinite_primes (k + 1)
+  have hkq : k < q := hqk
+  have hk0 : 0 < k := hk
+  -- `q` does not divide the residue `q - k`
+  have hndvd : ¬ q ∣ (q - k) := by
+    intro hd
+    have hqk' : q ∣ k := by
+      have h := Nat.dvd_sub (dvd_refl q) hd
+      rwa [Nat.sub_sub_self hkq.le] at h
+    exact absurd (Nat.le_of_dvd hk0 hqk') (not_le.mpr hkq)
+  -- hence `q - k` is coprime to `q`
+  have hcop : (q - k).Coprime q :=
+    Nat.coprime_comm.mp (hq.coprime_iff_not_dvd.mpr hndvd)
+  -- Dirichlet: a prime `p` beyond `max N q` with `p ≡ q - k (mod q)`
+  obtain ⟨p, hpgt, hp, hpmod⟩ :=
+    Nat.forall_exists_prime_gt_and_modEq (max N q) hq.pos.ne' hcop
+  have hNp : N < p := (le_max_left N q).trans_lt hpgt
+  have hqp : q < p := (le_max_right N q).trans_lt hpgt
+  -- `q ∣ p + k`
+  have hdvd : q ∣ p + k := by
+    have h1 : p + k ≡ (q - k) + k [MOD q] := hpmod.add_right k
+    rw [Nat.sub_add_cancel hkq.le] at h1
+    have h2 : p + k ≡ 0 [MOD q] := h1.trans (Nat.modEq_zero_iff_dvd.mpr (dvd_refl q))
+    exact Nat.modEq_zero_iff_dvd.mp h2
+  refine ⟨p, hNp, hp, ?_⟩
+  intro hpk
+  rcases hpk.eq_one_or_self_of_dvd q hdvd with h | h
+  · exact hq.one_lt.ne' h
+  · have : q < p + k := hqp.trans_le (Nat.le_add_right p k)
+    omega
+
+/-- **Building block (squarefree shift).**
+For every shift `k ≥ 1` and every bound `N`, there is a prime `p > N` such that
+`p + k` is *not* squarefree.
+
+Same idea as `exists_prime_add_not_prime` but with modulus `q²`: choose a prime
+`p ≡ q² - k (mod q²)`, so `q² ∣ p + k` and the square `q·q > 1` divides `p + k`. -/
+theorem exists_prime_add_not_squarefree (k : ℕ) (hk : 1 ≤ k) (N : ℕ) :
+    ∃ p, N < p ∧ p.Prime ∧ ¬ Squarefree (p + k) := by
+  obtain ⟨q, hqk, hq⟩ := Nat.exists_infinite_primes (k + 1)
+  have hkq : k < q := hqk
+  have hk0 : 0 < k := hk
+  have hqle : q ≤ q ^ 2 := le_self_pow hq.one_lt.le (by norm_num)
+  have hkq2 : k ≤ q ^ 2 := (hkq.le).trans hqle
+  -- `q` does not divide the residue `q² - k`
+  have hndvd : ¬ q ∣ (q ^ 2 - k) := by
+    intro hd
+    have hqdvd2 : q ∣ q ^ 2 := dvd_pow_self q (by norm_num)
+    have hqk' : q ∣ k := by
+      have h := Nat.dvd_sub hqdvd2 hd
+      rwa [Nat.sub_sub_self hkq2] at h
+    exact absurd (Nat.le_of_dvd hk0 hqk') (not_le.mpr hkq)
+  -- hence `q² - k` is coprime to `q²`
+  have hcop1 : (q ^ 2 - k).Coprime q :=
+    Nat.coprime_comm.mp (hq.coprime_iff_not_dvd.mpr hndvd)
+  have hcop : (q ^ 2 - k).Coprime (q ^ 2) :=
+    (Nat.coprime_pow_right_iff (n := 2) (by norm_num) (q ^ 2 - k) q).mpr hcop1
+  -- Dirichlet with modulus `q²`
+  obtain ⟨p, hpgt, hp, hpmod⟩ :=
+    Nat.forall_exists_prime_gt_and_modEq (max N q) (pow_ne_zero 2 hq.pos.ne') hcop
+  have hNp : N < p := (le_max_left N q).trans_lt hpgt
+  -- `q² ∣ p + k`
+  have hdvd : q ^ 2 ∣ p + k := by
+    have h1 : p + k ≡ (q ^ 2 - k) + k [MOD q ^ 2] := hpmod.add_right k
+    rw [Nat.sub_add_cancel hkq2] at h1
+    have h2 : p + k ≡ 0 [MOD q ^ 2] := h1.trans (Nat.modEq_zero_iff_dvd.mpr (dvd_refl _))
+    exact Nat.modEq_zero_iff_dvd.mp h2
+  refine ⟨p, hNp, hp, ?_⟩
+  intro hsf
+  -- `Squarefree` forces the square factor `q` to be a unit, impossible for a prime
+  have hunit : IsUnit q := hsf q (by rw [← pow_two]; exact hdvd)
+  exact absurd (Nat.isUnit_iff.mp hunit) hq.one_lt.ne'
+
+/-- Recursive skeleton for the strictly increasing sequence: `seq f 0 = f 0 0`
+and `seq f (n+1) = f (n+1) (seq f n)`, so each term is built from a chooser `f`
+that, given an index and the previous value, returns the next term. -/
+private def seq (f : ℕ → ℕ → ℕ) : ℕ → ℕ
+  | 0 => f 0 0
+  | (n + 1) => f (n + 1) (seq f n)
+
+/-- **Generic builder.**
+If for every index `k` and every bound `N` we can find some `p > N` satisfying a
+per-index predicate `Q k`, then there is a *strictly increasing* sequence
+`a : ℕ → ℕ` with `Q k (a k)` for all `k`. Each term is chosen larger than the
+previous one, which yields strict monotonicity. -/
+theorem exists_strictMono_forall {Q : ℕ → ℕ → Prop}
+    (H : ∀ k N, ∃ p, N < p ∧ Q k p) :
+    ∃ a : ℕ → ℕ, StrictMono a ∧ ∀ k, Q k (a k) := by
+  choose f hf using H
+  refine ⟨seq f, strictMono_nat_of_lt_succ (fun n => ?_), ?_⟩
+  · -- `seq f n < seq f (n+1) = f (n+1) (seq f n)` by the chooser's bound
+    exact (hf (n + 1) (seq f n)).1
+  · intro k
+    cases k with
+    | zero => exact (hf 0 0).2
+    | succ n => exact (hf (n + 1) (seq f n)).2
+
+/-- **Erdős #1209, prime counterexample.**
+For any prescribed growth function `g`, there is a strictly increasing sequence
+`a : ℕ → ℕ` of primes, with `a k > g k` for all `k` (so it can grow arbitrarily
+fast), such that the shift `a k + k` is never prime for `k ≥ 1`.
+
+This refutes the existence of any positive-density / fast-growth hypothesis that
+would force the shifts `aₖ + k` to be prime infinitely often. -/
+theorem erdos1209_prime_counterexample (g : ℕ → ℕ) :
+    ∃ a : ℕ → ℕ, StrictMono a ∧ (∀ k, g k < a k) ∧ (∀ k, (a k).Prime) ∧
+      (∀ k, 1 ≤ k → ¬ (a k + k).Prime) := by
+  -- the per-index predicate bundles primality, the growth bound, and the shift
+  have H : ∀ k N, ∃ p, N < p ∧
+      (p.Prime ∧ g k < p ∧ (1 ≤ k → ¬ (p + k).Prime)) := by
+    intro k N
+    rcases Nat.eq_zero_or_pos k with hk0 | hk0
+    · -- shift condition vacuous: just grab a large prime
+      obtain ⟨p, hple, hp⟩ := Nat.exists_infinite_primes (max N (g k) + 1)
+      exact ⟨p, lt_of_le_of_lt (le_max_left N (g k)) (by omega), hp,
+        lt_of_le_of_lt (le_max_right N (g k)) (by omega), fun h => absurd h (by omega)⟩
+    · -- use the building block above with bound `max N (g k)`
+      obtain ⟨p, hpgt, hp, hnp⟩ := exists_prime_add_not_prime k hk0 (max N (g k))
+      exact ⟨p, (le_max_left N (g k)).trans_lt hpgt, hp,
+        (le_max_right N (g k)).trans_lt hpgt, fun _ => hnp⟩
+  obtain ⟨a, hmono, hspec⟩ := exists_strictMono_forall H
+  exact ⟨a, hmono, fun k => (hspec k).2.1, fun k => (hspec k).1, fun k => (hspec k).2.2⟩
+
+/-- **Erdős #1209, squarefree counterexample.**
+For any prescribed growth function `g`, there is a strictly increasing sequence
+`a : ℕ → ℕ` of primes, with `a k > g k` for all `k`, such that the shift
+`a k + k` is never squarefree for `k ≥ 1`. -/
+theorem erdos1209_squarefree_counterexample (g : ℕ → ℕ) :
+    ∃ a : ℕ → ℕ, StrictMono a ∧ (∀ k, g k < a k) ∧ (∀ k, (a k).Prime) ∧
+      (∀ k, 1 ≤ k → ¬ Squarefree (a k + k)) := by
+  have H : ∀ k N, ∃ p, N < p ∧
+      (p.Prime ∧ g k < p ∧ (1 ≤ k → ¬ Squarefree (p + k))) := by
+    intro k N
+    rcases Nat.eq_zero_or_pos k with hk0 | hk0
+    · obtain ⟨p, hple, hp⟩ := Nat.exists_infinite_primes (max N (g k) + 1)
+      exact ⟨p, lt_of_le_of_lt (le_max_left N (g k)) (by omega), hp,
+        lt_of_le_of_lt (le_max_right N (g k)) (by omega), fun h => absurd h (by omega)⟩
+    · obtain ⟨p, hpgt, hp, hnp⟩ := exists_prime_add_not_squarefree k hk0 (max N (g k))
+      exact ⟨p, (le_max_left N (g k)).trans_lt hpgt, hp,
+        (le_max_right N (g k)).trans_lt hpgt, fun _ => hnp⟩
+  obtain ⟨a, hmono, hspec⟩ := exists_strictMono_forall H
+  exact ⟨a, hmono, fun k => (hspec k).2.1, fun k => (hspec k).1, fun k => (hspec k).2.2⟩
+
+end Erdos1209

--- a/src/data/proofs/erdos-1209/annotations.json
+++ b/src/data/proofs/erdos-1209/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-1209-overview",
+    "proofId": "erdos-1209",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "Problem Overview: Avoiding Primes and Squarefrees in Shifts",
+    "content": "Erdős Problem #1209 asks whether the shifts aₖ + k of a strictly increasing sequence A = {a₁ < a₂ < ⋯} must be prime (or squarefree) infinitely often under growth hypotheses on A. Erdős remarked the questions were 'quite hopeless' because of a trivial counterexample, a variant of the construction in problem #429. This file formalizes that counterexample: a strictly increasing sequence of primes, growing faster than any prescribed rate, with aₖ + k never prime — and a squarefree variant.",
+    "mathContext": "The construction sets a₁ = 2 and, for k ≥ 2, picks a prime aₖ > aₖ₋₁ with aₖ + k ≡ 0 (mod qₖ) for some prime qₖ ∤ k. Then qₖ ∣ aₖ + k makes the shift composite; using qₖ² makes it non-squarefree.",
+    "significance": "key",
+    "relatedConcepts": ["number-theory", "primes", "squarefree", "dirichlet", "arithmetic-progressions"],
+    "prerequisites": ["Dirichlet's theorem on primes in arithmetic progressions", "divisibility and congruences"]
+  },
+  {
+    "id": "ann-1209-prime-block",
+    "proofId": "erdos-1209",
+    "range": { "startLine": 63, "endLine": 98 },
+    "type": "technique",
+    "title": "Forcing a Composite Shift via Dirichlet",
+    "content": "exists_prime_add_not_prime shows that for every shift k ≥ 1 and every bound N there is a prime p > N with p + k composite. A prime q > k is chosen, so q ∤ k and the residue q − k is coprime to q; Dirichlet's theorem (Nat.forall_exists_prime_gt_and_modEq) then yields a prime p ≡ q − k (mod q) larger than both N and q. Hence q ∣ p + k with 1 < q < p + k, so p + k is not prime.",
+    "mathContext": "The single deep input is Dirichlet's theorem on primes in arithmetic progressions. The coprimality requirement is met precisely because q is a prime exceeding k, so q ∤ k.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet's theorem", "coprimality", "composite numbers"],
+    "prerequisites": ["Nat.ModEq", "Nat.Prime.coprime_iff_not_dvd"]
+  },
+  {
+    "id": "ann-1209-squarefree-block",
+    "proofId": "erdos-1209",
+    "range": { "startLine": 99, "endLine": 140 },
+    "type": "technique",
+    "title": "From Non-Prime to Non-Squarefree",
+    "content": "exists_prime_add_not_squarefree repeats the argument with modulus q² instead of q. Choosing a prime p ≡ q² − k (mod q²) gives q² ∣ p + k, so the square q·q divides p + k. Squarefreeness would force the prime q to be a unit, a contradiction, so p + k is not squarefree.",
+    "mathContext": "Squaring the modulus upgrades 'never prime' to 'never squarefree' with essentially no extra work; the same coprimality (q ∤ k) suffices because Coprime to q² ⇔ Coprime to q for a prime q.",
+    "significance": "standard",
+    "relatedConcepts": ["squarefree numbers", "prime square divisors"],
+    "prerequisites": ["Squarefree definition", "Nat.coprime_pow_right_iff"]
+  },
+  {
+    "id": "ann-1209-builder",
+    "proofId": "erdos-1209",
+    "range": { "startLine": 141, "endLine": 171 },
+    "type": "technique",
+    "title": "Assembling a Strictly Increasing Sequence",
+    "content": "exists_strictMono_forall is a reusable builder: from a per-index existence statement (∀ k N, ∃ p > N, Q k p) it produces a single strictly increasing sequence a with Q k (a k) for all k. The chooser f picks each term larger than the previous one (and any prescribed bound), so strict monotonicity is automatic via strictMono_nat_of_lt_succ.",
+    "mathContext": "This packaging is what turns the per-shift building blocks into the actual sequences Erdős described, and it is where the 'grows arbitrarily fast' clause is injected by feeding g k into the bound.",
+    "significance": "standard",
+    "relatedConcepts": ["strictly monotone sequences", "recursion", "choice"],
+    "prerequisites": ["strictMono_nat_of_lt_succ", "Classical.choice"]
+  },
+  {
+    "id": "ann-1209-counterexamples",
+    "proofId": "erdos-1209",
+    "range": { "startLine": 172, "endLine": 207 },
+    "type": "concept",
+    "title": "The Two Counterexamples",
+    "content": "erdos1209_prime_counterexample and erdos1209_squarefree_counterexample combine the building blocks with the builder to produce, for any growth function g, a strictly increasing sequence of primes with a k > g k for all k such that a k + k is never prime (resp. never squarefree) for k ≥ 1. These are the explicit counterexamples that make Erdős's 'quite hopeless' remark rigorous.",
+    "mathContext": "Because g is arbitrary, the sequence can grow faster than any prescribed rate, matching Erdős's observation that the construction 'can be made to grow arbitrarily fast'.",
+    "significance": "key",
+    "relatedConcepts": ["counterexamples", "open problems", "fast-growing sequences"],
+    "prerequisites": ["the building-block lemmas", "the sequence builder"]
+  }
+]

--- a/src/data/proofs/erdos-1209/meta.json
+++ b/src/data/proofs/erdos-1209/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "erdos-1209",
+  "title": "Shifted Sequences Avoiding Primes and Squarefrees",
+  "slug": "erdos-1209",
+  "description": "Erdős asked whether a fast-growing sequence a₁ < a₂ < ⋯ must have its shifts aₖ + k be prime (or squarefree) infinitely often, calling the questions 'quite hopeless'. This formalizes the trivial counterexample: using Dirichlet's theorem one builds a strictly increasing sequence of primes, growing faster than any prescribed rate, with aₖ + k never prime — and a squarefree variant where aₖ + k is never squarefree.",
+  "meta": {
+    "author": "Paul Erdős (problem), Lean formalization of the counterexample",
+    "sourceUrl": "https://erdosproblems.com/1209",
+    "date": "1980",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1209Problem.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primes",
+      "squarefree",
+      "dirichlet",
+      "arithmetic-progressions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 1209,
+    "erdosUrl": "https://erdosproblems.com/1209",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.forall_exists_prime_gt_and_modEq",
+        "description": "Dirichlet's theorem on primes in arithmetic progressions: for coprime a, q there are arbitrarily large primes p ≡ a (mod q)",
+        "module": "Mathlib.NumberTheory.LSeries.PrimesInAP"
+      },
+      {
+        "theorem": "Nat.exists_infinite_primes",
+        "description": "There exist arbitrarily large primes",
+        "module": "Mathlib.Data.Nat.Prime.Infinite"
+      },
+      {
+        "theorem": "Nat.modEq_zero_iff_dvd",
+        "description": "a ≡ 0 (mod n) ↔ n ∣ a",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Squarefree",
+        "description": "Squarefreeness defined via square-divisor units",
+        "module": "Mathlib.Algebra.Squarefree.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Faithful Lean formalization of Erdős's own 'trivial counterexample' to problem #1209 (a variant of the construction in problem #429)",
+      "exists_prime_add_not_prime: for every shift k ≥ 1 and bound N, a prime p > N with p + k composite, obtained by forcing a prime q ∤ k to divide p + k via Dirichlet's theorem on primes in arithmetic progressions",
+      "exists_prime_add_not_squarefree: the q² variant forcing q² ∣ p + k so that p + k is not squarefree",
+      "exists_strictMono_forall: a reusable builder turning a per-index 'find something larger than any bound' existence statement into a single strictly increasing sequence satisfying every per-index predicate",
+      "erdos1209_prime_counterexample / erdos1209_squarefree_counterexample: strictly increasing sequences of primes that grow faster than any prescribed g : ℕ → ℕ, with aₖ + k never prime (resp. never squarefree) for k ≥ 1"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "0 axiom declarations, 0 sorries. All 5 theorems are fully machine-checked and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on both headline theorems; no sorryAx, no Lean.ofReduceBool). The open Erdős questions themselves are not claimed to be resolved — what is proved is the existence of the explicit counterexamples Erdős described, which show the questions have no positive answer under any fast-growth hypothesis. The single nontrivial input is Mathlib's Dirichlet theorem on primes in arithmetic progressions.",
+    "lineCount": 207,
+    "theoremCount": 5,
+    "prerequisites": [
+      "Dirichlet's theorem on primes in arithmetic progressions",
+      "Modular arithmetic and divisibility (Nat.ModEq)",
+      "Squarefree numbers and prime square divisors",
+      "Strictly monotone sequences built by recursion"
+    ],
+    "definitionCount": 1,
+    "lastUpdated": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "In [Er80] Erdős posed questions about strictly increasing sequences A = {a₁ < a₂ < ⋯} and the arithmetic nature of the shifts aₖ + k — whether one could force these shifts to be prime, or squarefree, infinitely often under growth hypotheses on A. Erdős himself remarked 'unless I overlook a trivial way of getting a counterexample these questions are quite hopeless', and pointed to a construction (a variant of problem #429) that does exactly that. The point is that primality and squarefreeness of aₖ + k can be destroyed for every k by a single congruence condition, while still leaving enormous freedom (via Dirichlet's theorem) to choose the primes aₖ as large as one likes.",
+    "problemStatement": "For a strictly increasing sequence a₁ < a₂ < ⋯, must the shifts aₖ + k be prime (resp. squarefree) for infinitely many k under suitable hypotheses on A? Erdős called these questions 'quite hopeless' because of a trivial counterexample.",
+    "text": "Using Dirichlet's theorem, build a strictly increasing sequence of primes growing arbitrarily fast in which aₖ + k is never prime — and, with squares of primes, never squarefree.",
+    "proofStrategy": "For a shift k ≥ 1, choose a prime q > k, so q ∤ k and the residue −k is a unit mod q. Dirichlet's theorem then supplies arbitrarily large primes p with p ≡ −k (mod q), i.e. q ∣ p + k; since q < p + k this makes p + k composite. Replacing q by q² forces q² ∣ p + k, so p + k is not squarefree (the prime q would have to be a unit). A generic builder threads these per-index existence statements into one strictly increasing sequence, choosing each term larger than both the previous term and a prescribed growth bound g k, which yields the 'grows arbitrarily fast' clause.",
+    "keyInsights": [
+      "A single linear congruence aₖ + k ≡ 0 (mod qₖ) destroys primality of every shift while leaving the primes aₖ free to be arbitrarily large",
+      "The condition 'qₖ does not divide k' is exactly what makes the target residue a unit mod qₖ, so Dirichlet's theorem applies — choosing qₖ to be any prime larger than k secures it automatically",
+      "Squaring the modulus (qₖ²) upgrades 'never prime' to 'never squarefree' with no extra work",
+      "Arbitrary growth is free: build the sequence recursively, each term exceeding both its predecessor and a prescribed bound g k",
+      "Dirichlet's theorem on primes in arithmetic progressions is the only deep ingredient; everything else is elementary divisibility"
+    ],
+    "prerequisites": [
+      "Dirichlet's theorem on primes in arithmetic progressions",
+      "Modular arithmetic and divisibility",
+      "Squarefree numbers",
+      "Recursive construction of strictly monotone sequences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring stating Erdős #1209, the counterexample construction, and what is proved; imports Mathlib; opens namespace Erdos1209",
+      "mathContext": "Erdős #1209: can the shifts aₖ + k of a fast-growing sequence be forced prime/squarefree infinitely often? Answer: no, by a trivial counterexample."
+    },
+    {
+      "id": "prime-block",
+      "title": "Prime-Avoiding Building Block",
+      "startLine": 63,
+      "endLine": 98,
+      "summary": "exists_prime_add_not_prime: for k ≥ 1 and any bound N, a prime p > N with p + k composite, via a prime q > k and Dirichlet's theorem",
+      "mathContext": "$\\forall k\\ge 1,\\ \\forall N,\\ \\exists p>N:\\ p\\ \\text{prime} \\wedge q\\mid p+k\\ \\text{with}\\ q\\nmid k,\\ q<p+k \\Rightarrow p+k\\ \\text{composite}$"
+    },
+    {
+      "id": "squarefree-block",
+      "title": "Squarefree-Avoiding Building Block",
+      "startLine": 99,
+      "endLine": 140,
+      "summary": "exists_prime_add_not_squarefree: the q² variant forcing q² ∣ p + k, so p + k is not squarefree",
+      "mathContext": "$\\forall k\\ge 1,\\ \\forall N,\\ \\exists p>N:\\ p\\ \\text{prime} \\wedge q^2\\mid p+k \\Rightarrow p+k\\ \\text{not squarefree}$"
+    },
+    {
+      "id": "builder",
+      "title": "Strictly Increasing Sequence Builder",
+      "startLine": 141,
+      "endLine": 171,
+      "summary": "seq and exists_strictMono_forall: assemble per-index existence statements into a single strictly increasing sequence satisfying every per-index predicate",
+      "mathContext": "$(\\forall k\\,N,\\ \\exists p>N,\\ Q\\,k\\,p) \\Rightarrow \\exists a\\ \\text{StrictMono},\\ \\forall k,\\ Q\\,k\\,(a\\,k)$"
+    },
+    {
+      "id": "counterexamples",
+      "title": "The Two Counterexamples",
+      "startLine": 172,
+      "endLine": 207,
+      "summary": "erdos1209_prime_counterexample and erdos1209_squarefree_counterexample: strictly increasing prime sequences growing faster than any g with aₖ + k never prime / never squarefree",
+      "mathContext": "$\\exists a\\ \\text{StrictMono of primes},\\ a_k>g_k,\\ \\forall k\\ge 1:\\ \\neg\\,(a_k+k)\\ \\text{prime}\\ (\\text{resp. not squarefree})$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #1209 is OPEN, but Erdős's own remark that a 'trivial counterexample' exists is here made fully rigorous: there are strictly increasing sequences of primes, of arbitrarily fast growth, whose shifts aₖ + k are never prime, and a variant where they are never squarefree.",
+    "implications": "Any conjecture forcing the shifts of a sufficiently fast-growing sequence to be prime or squarefree infinitely often is false. The mechanism is a single congruence per index, leaving the magnitude of each term completely free thanks to Dirichlet's theorem.",
+    "openQuestions": [
+      "What is the slowest growth rate of A for which the prime-avoidance / squarefree-avoidance constructions still succeed?",
+      "Can the squarefree-avoidance sequence be made to also avoid k-free numbers for fixed k simultaneously across a range of k?",
+      "Which of Erdős's related sequence questions (#429, #1102) admit analogous congruence-based counterexamples?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos1209",
+    "lineCount": 207,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1209Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-429",
+      "relationship": "related",
+      "description": "Erdős #1209's counterexample is explicitly a variant of the construction in problem #429"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1209.json
+++ b/src/data/research/problems/erdos-1209.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1209",
   "title": "Erdős #1209",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Formalized Erdős's trivial counterexample. Built (verified, 0-axiom) Erdos1209Problem.lean: strictly increasing prime sequences of arbitrarily fast growth with aₖ+k never prime, and a squarefree variant where aₖ+k is never squarefree. Key input: Mathlib Dirichlet theorem on primes in AP.",
+    "builtItems": [
+      "exists_prime_add_not_prime in Proofs/Erdos1209Problem.lean",
+      "exists_prime_add_not_squarefree in Proofs/Erdos1209Problem.lean",
+      "exists_strictMono_forall (reusable sequence builder) in Proofs/Erdos1209Problem.lean",
+      "erdos1209_prime_counterexample, erdos1209_squarefree_counterexample in Proofs/Erdos1209Problem.lean"
+    ],
+    "insights": [
+      "A single congruence aₖ+k ≡ 0 (mod qₖ) with qₖ a prime > k destroys primality of every shift; qₖ ∤ k makes the residue a unit so Dirichlet supplies arbitrarily large prime aₖ.",
+      "Squaring the modulus (qₖ²) upgrades non-prime to non-squarefree shifts at no extra cost.",
+      "Arbitrary growth is free via a recursive builder choosing each term above both the previous term and a prescribed bound g k."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Determine the slowest growth rate of A for which prime/squarefree avoidance still succeeds.",
+      "Compare with the related sequence problems #429 and #1102."
+    ],
     "markdown": "# Erdős #1209 - Knowledge Base\n\n## Problem Statement\n\nLet $A=\\{a_1[Er80] wrote 'unless I overlook a trivial way of getting a counterexample these questions are quite hopeless'. There is indeed a trivial counterexample (a variant of the construction in [429]): define $a_1=2$ and for $k\\geq 2$ let $a_k>a_{k-1}$ be a prime such that $a_k+k\\equiv \\pmod{q_k}$, where $q_k$ is some prime not dividing $k$. This sequence can be made to grow arbitrarily fast. A similar construction with $\\pmod{q_k^2}$ provides a counterexample to the squarefree question. See also [429] and [1102].## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #429\n- Problem #1102\n- Problem #1208\n- Problem #1210\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Erdős Problem **#1209** asks whether the shifts $a_k + k$ of a strictly increasing sequence $A = \{a_1 < a_2 < \cdots\}$ must be prime (resp. squarefree) infinitely often under growth hypotheses on $A$. In [Er80] Erdős remarked that "unless I overlook a trivial way of getting a counterexample these questions are quite hopeless", pointing to a construction (a variant of problem #429). This PR makes that counterexample fully rigorous in Lean.

## What is proved (`Proofs/Erdos1209Problem.lean`)
- **`exists_prime_add_not_prime`** — for every shift $k \ge 1$ and every bound $N$, there is a prime $p > N$ with $p + k$ composite. Pick a prime $q > k$ (so $q \nmid k$); then $q - k$ is a unit mod $q$ and Dirichlet's theorem (`Nat.forall_exists_prime_gt_and_modEq`) gives a prime $p \equiv q - k \pmod q$, i.e. $q \mid p + k$ with $1 < q < p + k$.
- **`exists_prime_add_not_squarefree`** — the $q^2$ variant: $q^2 \mid p + k$, so $p + k$ is not squarefree.
- **`exists_strictMono_forall`** — a reusable builder turning a per-index "find something larger than any bound" existence statement into a single strictly increasing sequence satisfying every per-index predicate.
- **`erdos1209_prime_counterexample` / `erdos1209_squarefree_counterexample`** — for any growth function $g$, a strictly increasing sequence of primes with $a_k > g_k$ such that $a_k + k$ is never prime (resp. never squarefree) for $k \ge 1$. The arbitrary $g$ captures Erdős's "can be made to grow arbitrarily fast".

## Status
**Outcome**: completed. 5 theorems, 1 definition, **0 sorries, 0 axiom declarations**.
`#print axioms` on both headline theorems lists only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Builds clean against pinned Mathlib v4.26 via host `lake env lean`.

The open Erdős questions are not claimed resolved — what is proved is the existence of the explicit counterexamples Erdős described, the only deep input being Mathlib's Dirichlet theorem on primes in arithmetic progressions.

## Files
- `proofs/Proofs/Erdos1209Problem.lean` (new, 207 lines)
- `src/data/proofs/erdos-1209/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/erdos-1209.json` (knowledge update, status → completed)

🤖 Generated by researcher-1