### PR TITLE
audit(gallery): 7 fresh entries clean (abel-ruffini/alternating-series/catalan/erdos-1057/sylow/cauchy-schwarz/lagrange)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23147,6 +23147,36 @@
       "lastAudited": "2026-06-25T03:45:56Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-07-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "alternating-series-test-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1057-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:33Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:00:33Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23177,8 +23177,20 @@
       "lastAudited": "2026-06-25T04:00:33Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:16:01Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:16:01Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T03:40:24Z"
+  "lastUpdated": "2026-06-25T04:16:01Z"
 }


### PR DESCRIPTION
Gallery integrity audit: 7 fresh entries verified clean (tracker-only change).

All 7 are verified/original, 0-axiom, 0-sorry. Comment-stripped Lean source confirms 0 sorry / 0 axiom declarations / 0 native_decide / 0 True-stubs / no structure-encoded assumptions. Mathlib dependencies are credited in each meta.json.

| Slug | Notes |
|------|-------|
| abel-ruffini-oq-04-oq-07-oq-02 | clean |
| alternating-series-test-oq-01-oq-02-oq-02 | clean |
| catalan-numbers-oq-01-oq-04 | clean |
| erdos-1057-oq-04 | clean |
| sylow-theorem-oq-02-oq-02 | clean |
| cauchy-schwarz-oq-01-oq-05 | CS derived from Lagrange defect identity (not a Mathlib wrapper); deps credited |
| lagrange-theorem-oq-03-oq-02 | A₄ has no order-6 subgroup; structural assembly, deps credited |

Clears unaudited 7→0 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)