### PR TITLE
research(cauchy-schwarz-oq-01-oq-05): division-free Lagrange defect identity for complex Cauchy-Schwarz [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ05.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ05.lean
@@ -1,0 +1,212 @@
+/-
+Quantitative Cauchy-Schwarz via the Lagrange / Gram defect identity
+for complex (RCLike) inner product spaces
+
+Open Question (cauchy-schwarz-oq-01-oq-05):
+"For complex (and general RCLike) inner product spaces, is there an exact,
+division-free algebraic identity for the Cauchy-Schwarz *defect*
+‖x‖²·‖y‖² − ‖⟪x,y⟫‖², from which both the inequality and its equality
+characterization follow directly — without invoking Mathlib's
+`inner_mul_le_norm_mul_norm` or an orthogonal-projection coefficient?"
+
+Answer: YES. The key is the scaled Gram vector
+
+    w := ⟪x,x⟫ • y − ⟪x,y⟫ • x          (no division: ⟪x,x⟫ is a scalar)
+
+which is orthogonal to x and satisfies the abstract Lagrange identity
+
+    ‖w‖² = ‖x‖² · ( ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² ).                 (★)
+
+Since the left side is ≥ 0 and ‖x‖² ≥ 0, the bracket is ≥ 0, giving
+Cauchy-Schwarz; equality forces w = 0, i.e. ⟪x,x⟫ • y = ⟪x,y⟫ • x, which
+for x ≠ 0 means y is a scalar multiple of x.
+
+Distinct from the sibling entry cauchy-schwarz-oq-01-oq-01, which uses the
+projection coefficient ⟪v,u⟫/⟪v,v⟫ and a Pythagoras argument: here the
+identity (★) is purely algebraic, division-free, and valid for *all* x
+(including x = 0). It is the inner-product-space analogue of the classical
+Lagrange identity, here proved over an arbitrary RCLike field with the
+sesquilinear bookkeeping (conjugate-linearity in the first slot) handled
+explicitly.
+
+This file formalizes:
+1. The 𝕜-valued Gram identity ⟪w,w⟫ = ⟪x,x⟫·(⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫)
+2. The real Lagrange defect identity (★)
+3. Cauchy-Schwarz (squared and norm form), recovered from (★)
+4. Nonnegativity of the defect
+5. Equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ⟪x,x⟫ • y = ⟪x,y⟫ • x
+6. Linear-dependence corollary for x ≠ 0
+7. Specializations to ℝ and ℂ
+
+References:
+- Mathlib: inner_self_eq_norm_sq_to_K, inner_conj_symm, RCLike.mul_conj
+- Lagrange (1773); Schwarz (1885); Bunyakovsky (1859); Gram (1883)
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+open RCLike
+
+namespace CauchySchwarzOQ01OQ05
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+-- ============================================================
+-- PART I: The 𝕜-valued Gram identity
+-- ============================================================
+
+/-- **Gram identity (𝕜-valued).** For the scaled Gram vector
+`w = ⟪x,x⟫ • y − ⟪x,y⟫ • x`, the self inner product factors as
+`⟪w,w⟫ = ⟪x,x⟫ · (⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫)`.
+
+The middle cross term cancels because `w ⊥ x`; what remains is the
+Gram determinant of `x, y` scaled by `⟪x,x⟫`. Proof: expand the
+sesquilinear form and simplify the conjugates `conj⟪x,x⟫ = ⟪x,x⟫`,
+`conj⟪x,y⟫ = ⟪y,x⟫`. -/
+theorem inner_gram_self (x y : E) :
+    ⟪⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x, ⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x⟫_𝕜
+      = ⟪x, x⟫_𝕜 * (⟪x, x⟫_𝕜 * ⟪y, y⟫_𝕜 - ⟪x, y⟫_𝕜 * ⟪y, x⟫_𝕜) := by
+  simp only [inner_sub_left, inner_sub_right, inner_smul_left, inner_smul_right,
+    inner_conj_symm]
+  ring
+
+-- ============================================================
+-- PART II: The real Lagrange defect identity (★)
+-- ============================================================
+
+/-- **Lagrange / Gram defect identity (★).** The squared norm of the scaled
+Gram vector equals `‖x‖²` times the Cauchy-Schwarz defect:
+`‖⟪x,x⟫ • y − ⟪x,y⟫ • x‖² = ‖x‖² · (‖x‖²·‖y‖² − ‖⟪x,y⟫‖²)`.
+
+This is an exact, division-free identity valid for *all* `x, y` (including
+`x = 0`, where both sides vanish). -/
+theorem gram_norm_sq (x y : E) :
+    ‖⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x‖ ^ 2
+      = ‖x‖ ^ 2 * (‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_𝕜‖ ^ 2) := by
+  apply RCLike.ofReal_injective (K := 𝕜)
+  rw [RCLike.ofReal_pow,
+      ← inner_self_eq_norm_sq_to_K (𝕜 := 𝕜) (⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x),
+      inner_gram_self,
+      ← inner_conj_symm y x, RCLike.mul_conj]
+  simp only [inner_self_eq_norm_sq_to_K]
+  push_cast
+  ring
+
+-- ============================================================
+-- PART III: Cauchy-Schwarz, recovered from (★)
+-- ============================================================
+
+/-- The Cauchy-Schwarz defect is nonnegative:
+`‖⟪x,y⟫‖² ≤ ‖x‖²·‖y‖²`. Proved directly from the Lagrange identity (★):
+the left side of (★) is a square, hence `≥ 0`, and for `x ≠ 0` we may
+cancel the positive factor `‖x‖²`; the case `x = 0` is immediate. -/
+theorem cauchy_schwarz_sq (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ ^ 2 ≤ ‖x‖ ^ 2 * ‖y‖ ^ 2 := by
+  have hw : (0 : ℝ) ≤ ‖x‖ ^ 2 * (‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_𝕜‖ ^ 2) := by
+    rw [← gram_norm_sq]; exact sq_nonneg _
+  rcases eq_or_ne x 0 with hx | hx
+  · subst hx; simp
+  · have hxpos : 0 < ‖x‖ ^ 2 := by
+      have : 0 < ‖x‖ := norm_pos_iff.mpr hx
+      positivity
+    nlinarith [hw, hxpos]
+
+/-- **Cauchy-Schwarz inequality** for complex (RCLike) inner product spaces,
+`‖⟪x,y⟫‖ ≤ ‖x‖·‖y‖`, obtained from the squared form by monotonicity of
+`√`. This re-derives the headline result of the parent problem
+(`cauchy-schwarz-oq-01`) *without* calling `inner_mul_le_norm_mul_norm`. -/
+theorem cauchy_schwarz (x y : E) : ‖⟪x, y⟫_𝕜‖ ≤ ‖x‖ * ‖y‖ := by
+  have h2 : ‖⟪x, y⟫_𝕜‖ ^ 2 ≤ (‖x‖ * ‖y‖) ^ 2 := by
+    rw [mul_pow]; exact cauchy_schwarz_sq x y
+  have hb : (0 : ℝ) ≤ ‖x‖ * ‖y‖ := by positivity
+  calc ‖⟪x, y⟫_𝕜‖ = Real.sqrt (‖⟪x, y⟫_𝕜‖ ^ 2) := (Real.sqrt_sq (norm_nonneg _)).symm
+    _ ≤ Real.sqrt ((‖x‖ * ‖y‖) ^ 2) := Real.sqrt_le_sqrt h2
+    _ = ‖x‖ * ‖y‖ := Real.sqrt_sq hb
+
+/-- The Gram determinant of `x, y` is nonnegative:
+`‖x‖²·‖y‖² − ‖⟪x,y⟫‖² ≥ 0`. -/
+theorem gram_det_nonneg (x y : E) :
+    0 ≤ ‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_𝕜‖ ^ 2 := by
+  have := cauchy_schwarz_sq (𝕜 := 𝕜) x y
+  linarith
+
+-- ============================================================
+-- PART IV: Equality characterization
+-- ============================================================
+
+/-- **Equality in Cauchy-Schwarz, characterized by the Gram vector.**
+`‖⟪x,y⟫‖ = ‖x‖·‖y‖` holds **iff** the scaled Gram vector vanishes,
+`⟪x,x⟫ • y = ⟪x,y⟫ • x`.
+
+Forward: equality makes the defect `0`, so by (★) `‖w‖² = ‖x‖²·0 = 0`, hence
+`w = 0` — with no case split. Backward: `w = 0` makes `‖x‖²·defect = 0`; for
+`x ≠ 0` the defect is `0`, and for `x = 0` both sides are `0`. -/
+theorem cauchy_schwarz_eq_iff (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ⟪x, x⟫_𝕜 • y = ⟪x, y⟫_𝕜 • x := by
+  rw [← sub_eq_zero (a := ⟪x, x⟫_𝕜 • y), ← norm_eq_zero (a := ⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x),
+      ← sq_eq_zero_iff (a := ‖⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x‖), gram_norm_sq]
+  constructor
+  · intro h
+    have hsq : ‖⟪x, y⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2 * ‖y‖ ^ 2 := by
+      rw [h, mul_pow]
+    rw [hsq]; ring
+  · intro h
+    rcases eq_or_ne x 0 with hx | hx
+    · subst hx; simp
+    · have hxpos : 0 < ‖x‖ ^ 2 := by
+        have : 0 < ‖x‖ := norm_pos_iff.mpr hx
+        positivity
+      have hdef : ‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_𝕜‖ ^ 2 = 0 := by
+        rcases mul_eq_zero.mp h with h1 | h2
+        · exact absurd h1 (ne_of_gt hxpos)
+        · exact h2
+      have hsq : ‖⟪x, y⟫_𝕜‖ ^ 2 = (‖x‖ * ‖y‖) ^ 2 := by
+        rw [mul_pow]; linarith
+      have := norm_nonneg (⟪x, y⟫_𝕜)
+      have hb : (0 : ℝ) ≤ ‖x‖ * ‖y‖ := by positivity
+      nlinarith [hsq, this, hb]
+
+/-- **Linear-dependence corollary.** For `x ≠ 0`, equality in Cauchy-Schwarz
+holds **iff** `y` is a scalar multiple of `x`. -/
+theorem eq_iff_smul_of_ne_zero (x y : E) (hx : x ≠ 0) :
+    ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ ∃ c : 𝕜, y = c • x := by
+  have hxx : ⟪x, x⟫_𝕜 ≠ 0 := fun h => hx (inner_self_eq_zero.mp h)
+  rw [cauchy_schwarz_eq_iff]
+  constructor
+  · intro hgram
+    refine ⟨(⟪x, x⟫_𝕜)⁻¹ * ⟪x, y⟫_𝕜, ?_⟩
+    rw [mul_smul, ← hgram, smul_smul, inv_mul_cancel₀ hxx, one_smul]
+  · rintro ⟨c, rfl⟩
+    rw [inner_smul_right, smul_smul, mul_comm c (⟪x, x⟫_𝕜)]
+
+-- ============================================================
+-- PART V: Specializations
+-- ============================================================
+
+/-- The Lagrange defect identity over a **real** inner product space. -/
+theorem gram_norm_sq_real
+    {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F) :
+    ‖(⟪x, x⟫_ℝ : ℝ) • y - (⟪x, y⟫_ℝ : ℝ) • x‖ ^ 2
+      = ‖x‖ ^ 2 * (‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_ℝ‖ ^ 2) :=
+  gram_norm_sq (𝕜 := ℝ) x y
+
+/-- The Lagrange defect identity over a **complex** inner product space. -/
+theorem gram_norm_sq_complex
+    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] (x y : H) :
+    ‖⟪x, x⟫_ℂ • y - ⟪x, y⟫_ℂ • x‖ ^ 2
+      = ‖x‖ ^ 2 * (‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_ℂ‖ ^ 2) :=
+  gram_norm_sq (𝕜 := ℂ) x y
+
+/-- Cauchy-Schwarz over a complex inner product space, via (★). -/
+theorem cauchy_schwarz_complex
+    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] (x y : H) :
+    ‖⟪x, y⟫_ℂ‖ ≤ ‖x‖ * ‖y‖ :=
+  cauchy_schwarz (𝕜 := ℂ) x y
+
+end CauchySchwarzOQ01OQ05

--- a/proofs/Proofs/PrimeNumberTheoremOQ03.lean
+++ b/proofs/Proofs/PrimeNumberTheoremOQ03.lean
@@ -1,0 +1,122 @@
+import Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Tactic
+
+/-
+# Elementary PNT: the fundamental von Mangoldt summatory identity
+
+This file formalises the exact identity at the heart of the *elementary* approach to the
+Prime Number Theorem (the route of Chebyshev, Mertens, and ultimately Selberg–Erdős):
+
+$$\sum_{m=1}^{N} \Lambda(m)\left\lfloor \frac{N}{m}\right\rfloor = \log(N!).$$
+
+Here `Λ` is the von Mangoldt function (`Λ(p^k) = log p`, and `0` otherwise) and the floor
+`⌊N/m⌋` is ordinary natural-number division.
+
+## Why this is the cornerstone of elementary PNT
+
+Every elementary proof of the Prime Number Theorem begins by estimating `log(N!)` in two ways:
+
+* **Analytically**, via Stirling's formula: `log(N!) = N log N - N + O(log N)`.
+* **Arithmetically**, via the divisor identity `log n = ∑_{d ∣ n} Λ(d)`, which on summing over
+  `n ≤ N` and exchanging the order of summation produces exactly the floor-weighted sum
+  formalised here.
+
+Equating the two yields `∑_{m ≤ N} Λ(m) ⌊N/m⌋ = N log N - N + O(log N)`, the first
+*error-bounded* statement on the road to `ψ(x) ∼ x`. This file supplies the arithmetic
+identity in fully verified, axiom-free form, together with the immediate upper estimate
+`log(N!) ≤ N · ∑_{m ≤ N} Λ(m)/m` obtained from `⌊N/m⌋ ≤ N/m`.
+
+## Main results
+
+* `PrimeNumberTheoremOQ03.log_factorial_eq_sum_log` —
+  `log(N!) = ∑_{n=1}^{N} log n`.
+* `PrimeNumberTheoremOQ03.vonMangoldt_summatory` —
+  `∑_{m=1}^{N} Λ(m) ⌊N/m⌋ = log(N!)`.
+* `PrimeNumberTheoremOQ03.log_factorial_le` —
+  `log(N!) ≤ N · ∑_{m=1}^{N} Λ(m)/m`.
+
+## Mathlib dependencies
+
+The arithmetic input is `ArithmeticFunction.vonMangoldt_sum` (`∑_{d ∣ n} Λ(d) = log n`).
+The counting input is `Nat.Ioc_filter_dvd_card_eq_div` (`#{x ∈ (0,N] : m ∣ x} = N/m`).
+The order-exchange is `Finset.sum_comm'`. None of these supply the floor-weighted identity,
+which is new here and absent from `Mathlib.NumberTheory.Chebyshev`.
+-/
+
+open Finset
+open ArithmeticFunction
+open scoped ArithmeticFunction
+
+namespace PrimeNumberTheoremOQ03
+
+/-- `log(N!)` expands as the sum of `log n` for `n = 1, …, N`. -/
+theorem log_factorial_eq_sum_log (N : ℕ) :
+    Real.log ((Nat.factorial N : ℕ) : ℝ) = ∑ n ∈ Finset.Icc 1 N, Real.log (n : ℝ) := by
+  have hprod : ∏ n ∈ Finset.Icc 1 N, (n : ℝ) = ((Nat.factorial N : ℕ) : ℝ) := by
+    induction N with
+    | zero => simp
+    | succ k ih =>
+      rw [Finset.prod_Icc_succ_top (by omega), ih, Nat.factorial_succ]
+      push_cast; ring
+  rw [← hprod, Real.log_prod]
+  intro n hn
+  rw [Finset.mem_Icc] at hn
+  exact Nat.cast_ne_zero.mpr (by omega)
+
+/-- **Fundamental von Mangoldt summatory identity.**
+
+`∑_{m=1}^{N} Λ(m) ⌊N/m⌋ = log(N!)`, where `⌊N/m⌋` is natural-number division.
+
+This is the exact identity underlying Chebyshev's and Mertens' elementary estimates for the
+distribution of primes. -/
+theorem vonMangoldt_summatory (N : ℕ) :
+    ∑ m ∈ Finset.Icc 1 N, Λ m * ((N / m : ℕ) : ℝ) = Real.log ((Nat.factorial N : ℕ) : ℝ) := by
+  -- The set `{1, …, N}` agrees with the half-open interval `(0, N]`.
+  have hset : Finset.Icc 1 N = Finset.Ioc 0 N := by
+    ext x; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  -- Membership equivalence driving the exchange of summation order.
+  have hmem : ∀ (n d : ℕ), n ∈ Finset.Icc 1 N ∧ d ∈ n.divisors ↔
+      n ∈ (Finset.Icc 1 N).filter (fun x => d ∣ x) ∧ d ∈ Finset.Icc 1 N := by
+    intro n d
+    simp only [Finset.mem_filter, Finset.mem_Icc, Nat.mem_divisors]
+    constructor
+    · rintro ⟨⟨h1, h2⟩, hdvd, hne⟩
+      have hd0 : d ≠ 0 := by rintro rfl; exact hne (Nat.eq_zero_of_zero_dvd hdvd)
+      exact ⟨⟨⟨h1, h2⟩, hdvd⟩, Nat.one_le_iff_ne_zero.mpr hd0,
+        le_trans (Nat.le_of_dvd (by omega) hdvd) h2⟩
+    · rintro ⟨⟨⟨h1, h2⟩, hdvd⟩, hd1, hdN⟩
+      exact ⟨⟨h1, h2⟩, hdvd, by omega⟩
+  calc ∑ m ∈ Finset.Icc 1 N, Λ m * ((N / m : ℕ) : ℝ)
+      = ∑ d ∈ Finset.Icc 1 N,
+          ∑ _n ∈ (Finset.Icc 1 N).filter (fun x => d ∣ x), Λ d := by
+        apply Finset.sum_congr rfl
+        intro d _hd
+        rw [Finset.sum_const, hset, Nat.Ioc_filter_dvd_card_eq_div N d, nsmul_eq_mul]
+        exact mul_comm _ _
+    _ = ∑ n ∈ Finset.Icc 1 N, ∑ d ∈ n.divisors, Λ d := (Finset.sum_comm' hmem).symm
+    _ = ∑ n ∈ Finset.Icc 1 N, Real.log (n : ℝ) := by
+        apply Finset.sum_congr rfl
+        intro n _hn
+        exact ArithmeticFunction.vonMangoldt_sum
+    _ = Real.log ((Nat.factorial N : ℕ) : ℝ) := (log_factorial_eq_sum_log N).symm
+
+/-- **Upper estimate for `log(N!)`.**
+
+From the summatory identity and `⌊N/m⌋ ≤ N/m` together with `Λ ≥ 0` we obtain
+`log(N!) ≤ N · ∑_{m=1}^{N} Λ(m)/m`, the easy half of Mertens' first theorem. -/
+theorem log_factorial_le (N : ℕ) :
+    Real.log ((Nat.factorial N : ℕ) : ℝ) ≤ (N : ℝ) * ∑ m ∈ Finset.Icc 1 N, Λ m / (m : ℝ) := by
+  rw [← vonMangoldt_summatory, Finset.mul_sum]
+  apply Finset.sum_le_sum
+  intro m hm
+  rw [Finset.mem_Icc] at hm
+  have hm0 : (0 : ℝ) < (m : ℝ) := by exact_mod_cast (by omega : 0 < m)
+  have hmne : (m : ℝ) ≠ 0 := ne_of_gt hm0
+  have hΛ : 0 ≤ Λ m := ArithmeticFunction.vonMangoldt_nonneg
+  have hcast : ((N / m : ℕ) : ℝ) ≤ (N : ℝ) / (m : ℝ) := Nat.cast_div_le
+  calc Λ m * ((N / m : ℕ) : ℝ)
+      ≤ Λ m * ((N : ℝ) / (m : ℝ)) := mul_le_mul_of_nonneg_left hcast hΛ
+    _ = (N : ℝ) * (Λ m / (m : ℝ)) := by ring
+
+end PrimeNumberTheoremOQ03

--- a/research/problems/prime-number-theorem-oq-03/state.md
+++ b/research/problems/prime-number-theorem-oq-03/state.md
@@ -1,27 +1,43 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-03T12:03:52.281Z
-**Iteration**: 1
+**Phase**: RESEARCH-COMPLETE (one verified leaf shipped; open question remains)
+**Since**: 2026-06-24
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalized the cornerstone identity of the elementary approach to PNT.
 
 ## Active Approach
 
-None yet.
+Elementary (Chebyshev–Mertens) route, von Mangoldt summatory function.
+
+## Result Shipped
+
+`Proofs/PrimeNumberTheoremOQ03.lean` (verified, 0-axiom, original), gallery slug
+`prime-number-theorem-oq-03`:
+
+- `vonMangoldt_summatory`: ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!) — the exact arithmetic
+  identity behind every elementary PNT proof; absent from Mathlib's Chebyshev file.
+- `log_factorial_eq_sum_log`: log(N!) = ∑_{n=1}^{N} log n.
+- `log_factorial_le`: log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m — easy half of Mertens' first theorem.
+
+Proof: expand log n = ∑_{d∣n} Λ(d) (Mathlib `vonMangoldt_sum`), sum over n ≤ N, exchange
+order of summation (`Finset.sum_comm'`), count multiples #{n≤N : m∣n} = ⌊N/m⌋
+(`Nat.Ioc_filter_dvd_card_eq_div`).
 
 ## Blockers
 
-None.
+None for the shipped piece.
 
 ## Next Action
 
-Begin problem exploration.
+Open follow-ups (see meta.json openQuestions): combine with a Lean Stirling bound to get
+∑ Λ(m)⌊N/m⌋ = N log N − N + O(log N); prove full Mertens ∑ Λ(m)/m = log N + O(1) via
+Chebyshev ψ(N) = O(N); build the Selberg symmetry formula on this summatory framework.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-05/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-gram-identity",
+    "proofId": "cauchy-schwarz-oq-01-oq-05",
+    "range": {
+      "startLine": 72,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "The 𝕜-Valued Gram Identity",
+    "content": "The core algebraic step. For the scaled Gram vector $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x$, expanding $\\langle w,w\\rangle$ by `inner_sub_left`, `inner_sub_right`, `inner_smul_left`, `inner_smul_right` produces conjugates of the scalars. Crucially $\\langle x,x\\rangle$ is self-conjugate and $\\overline{\\langle x,y\\rangle} = \\langle y,x\\rangle$ (`inner_conj_symm`), after which the cross term $\\langle x,x\\rangle\\langle x,y\\rangle - \\langle x,y\\rangle\\langle x,x\\rangle$ cancels and a single `ring` yields $\\langle w,w\\rangle = \\langle x,x\\rangle\\big(\\langle x,x\\rangle\\langle y,y\\rangle - \\langle x,y\\rangle\\langle y,x\\rangle\\big)$.",
+    "mathContext": "$\\langle w,w\\rangle = \\langle x,x\\rangle\\big(\\langle x,x\\rangle\\langle y,y\\rangle - \\langle x,y\\rangle\\langle y,x\\rangle\\big)$",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "sesquilinearity",
+      "Gram determinant",
+      "inner_conj_symm"
+    ],
+    "prerequisites": [
+      "inner product axioms",
+      "conjugate-linearity"
+    ]
+  },
+  {
+    "id": "ann-lagrange-identity",
+    "proofId": "cauchy-schwarz-oq-01-oq-05",
+    "range": {
+      "startLine": 89,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "The Real Lagrange Defect Identity (★)",
+    "content": "The 𝕜-valued identity is converted to a statement about real norms. `inner_self_eq_norm_sq_to_K` rewrites each self inner product $\\langle x,x\\rangle$ as $(\\|x\\|:\\mathbb{k})^2$, and `RCLike.mul_conj` turns $\\langle x,y\\rangle\\langle y,x\\rangle = \\langle x,y\\rangle\\,\\overline{\\langle x,y\\rangle}$ into $\\uparrow(\\|\\langle x,y\\rangle\\|^2)$. Both sides are then coercions of reals, so `RCLike.ofReal_injective` lifts the identity down to $\\mathbb{R}$, giving $\\|w\\|^2 = \\|x\\|^2(\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2)$.",
+    "mathContext": "$\\big\\|\\langle x,x\\rangle y - \\langle x,y\\rangle x\\big\\|^2 = \\|x\\|^2\\big(\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2\\big)$",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "Lagrange identity",
+      "ofReal injectivity",
+      "RCLike.mul_conj"
+    ],
+    "prerequisites": [
+      "norm-inner relations",
+      "field coercions"
+    ]
+  },
+  {
+    "id": "ann-cauchy-schwarz",
+    "proofId": "cauchy-schwarz-oq-01-oq-05",
+    "range": {
+      "startLine": 109,
+      "endLine": 132
+    },
+    "type": "concept",
+    "title": "Recovering Cauchy-Schwarz Without Mathlib's Bound",
+    "content": "Since the left side of (★) is a square, $\\|x\\|^2(\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2) \\ge 0$. For $x \\ne 0$ the factor $\\|x\\|^2 > 0$ cancels (`nlinarith`), giving $\\|\\langle x,y\\rangle\\|^2 \\le \\|x\\|^2\\|y\\|^2$; the $x = 0$ case is closed by `simp`. The norm form follows by monotonicity of `Real.sqrt`. Notably this never invokes `norm_inner_le_norm`, so the inequality is shown to be logically downstream of the elementary identity.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| \\le \\|x\\| \\cdot \\|y\\|$",
+    "significance": "major",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "nonnegativity of squares",
+      "sqrt monotonicity"
+    ],
+    "prerequisites": [
+      "ordered fields",
+      "square roots"
+    ]
+  },
+  {
+    "id": "ann-equality",
+    "proofId": "cauchy-schwarz-oq-01-oq-05",
+    "range": {
+      "startLine": 150,
+      "endLine": 186
+    },
+    "type": "insight",
+    "title": "Equality Characterization, Division-Free",
+    "content": "Equality $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\|$ holds iff the residual $w$ vanishes, i.e. $\\langle x,x\\rangle\\,y = \\langle x,y\\rangle\\,x$. The forward direction needs no case split: equality makes the defect $0$, so $\\|w\\|^2 = \\|x\\|^2 \\cdot 0 = 0$ by (★). The backward direction splits on $x = 0$. The corollary `eq_iff_smul_of_ne_zero` packages this for $x \\ne 0$ as the linear-dependence statement $\\exists c,\\ y = c\\,x$.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff \\langle x,x\\rangle y = \\langle x,y\\rangle x \\iff (x \\ne 0 \\Rightarrow \\exists c,\\ y = c x)$",
+    "significance": "major",
+    "relatedConcepts": [
+      "linear dependence",
+      "equality conditions",
+      "positive-definiteness"
+    ],
+    "prerequisites": [
+      "inner product axioms",
+      "scalar multiplication"
+    ]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "cauchy-schwarz-oq-01-oq-05",
+    "range": {
+      "startLine": 192,
+      "endLine": 210
+    },
+    "type": "concept",
+    "title": "Real and Complex Specializations",
+    "content": "Instantiating the RCLike field at $\\mathbb{k} = \\mathbb{R}$ and $\\mathbb{k} = \\mathbb{C}$ yields the classical real and complex defect identities and the complex Cauchy-Schwarz inequality as immediate corollaries of the single uniform development — no separate proof per field.",
+    "mathContext": "$\\mathbb{k} \\in \\{\\mathbb{R}, \\mathbb{C}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "RCLike abstraction",
+      "real vs complex inner products"
+    ],
+    "prerequisites": [
+      "type class instantiation"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-05/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-05/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-05",
+  "title": "Quantitative Cauchy-Schwarz via the Lagrange Defect Identity",
+  "slug": "cauchy-schwarz-oq-01-oq-05",
+  "description": "An exact, division-free Lagrange identity for the Cauchy-Schwarz defect over complex (RCLike) inner product spaces: ‖⟪x,x⟫•y − ⟪x,y⟫•x‖² = ‖x‖²·(‖x‖²·‖y‖² − ‖⟪x,y⟫‖²). The inequality and its equality characterization both fall out directly, without invoking Mathlib's Cauchy-Schwarz or any projection coefficient.",
+  "meta": {
+    "author": "Lagrange (1773), Cauchy (1821), Schwarz (1885); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange%27s_identity",
+    "date": "1773",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "inner-product-spaces",
+      "complex-analysis",
+      "functional-analysis",
+      "classic",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ05.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "inner_self_eq_norm_sq_to_K",
+        "description": "Self-inner product as a field element: ⟪x, x⟫_𝕜 = (‖x‖:𝕜)²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_conj_symm",
+        "description": "Conjugate symmetry: conj ⟪x,y⟫_𝕜 = ⟪y,x⟫_𝕜",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "inner_self_eq_zero",
+        "description": "Positive-definiteness: ⟪x, x⟫_𝕜 = 0 ↔ x = 0",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.mul_conj",
+        "description": "z · conj z = ↑(‖z‖²) for an RCLike field element z",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "RCLike.ofReal_injective",
+        "description": "The real-to-𝕜 coercion is injective, lifting a 𝕜-identity to a real one",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Scalar Gram vector w := ⟪x,x⟫•y − ⟪x,y⟫•x — division-free, defined for all x (including x = 0)",
+      "𝕜-valued Gram identity ⟪w,w⟫ = ⟪x,x⟫·(⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫), proved by one sesquilinear expansion + ring",
+      "Real Lagrange defect identity ‖w‖² = ‖x‖²·(‖x‖²·‖y‖² − ‖⟪x,y⟫‖²) over an arbitrary RCLike field",
+      "Cauchy-Schwarz (squared and norm forms) recovered from the identity WITHOUT calling inner_mul_le_norm_mul_norm / norm_inner_le_norm",
+      "Equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ⟪x,x⟫•y = ⟪x,y⟫•x, with the forward direction needing no case split",
+      "Linear-dependence corollary: for x ≠ 0, equality ↔ ∃ c, y = c•x",
+      "ℝ and ℂ specializations of the defect identity and the inequality"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 212,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**The Lagrange Identity Behind Cauchy-Schwarz**\n\nLong before Cauchy's 1821 sum inequality, Joseph-Louis Lagrange recorded (1773) an algebraic *identity* whose nonnegativity instantly yields the inequality for finite sums:\n$$\\Big(\\sum a_i^2\\Big)\\Big(\\sum b_i^2\\Big) - \\Big(\\sum a_i b_i\\Big)^2 = \\sum_{i<j} (a_i b_j - a_j b_i)^2 \\ge 0.$$\nThe abstract inner-product-space version replaces the right-hand sum of squares with a single squared norm — the norm of the *residual* of $y$ after removing its component along $x$. Schwarz's 1885 proof used exactly this orthogonal residual, but divided by $\\langle v,v\\rangle$ to form the projection coefficient.\n\nThe entry here keeps the spirit of Lagrange's identity but **avoids division entirely**: it scales the Gram vector by $\\langle x,x\\rangle$ rather than dividing by it, so the identity\n$$\\big\\|\\,\\langle x,x\\rangle\\, y - \\langle x,y\\rangle\\, x\\,\\big\\|^2 = \\|x\\|^2\\big(\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2\\big)$$\nholds for *every* pair $x, y$, including $x = 0$ where both sides vanish. Over a complex (or general RCLike) field, the only subtlety is sesquilinear bookkeeping: the inner product is conjugate-linear in its first slot, so the cross term cancels precisely because $\\overline{\\langle x,x\\rangle} = \\langle x,x\\rangle$ and $\\overline{\\langle x,y\\rangle} = \\langle y,x\\rangle$.",
+    "problemStatement": "**Quantitative Cauchy-Schwarz (Complex / RCLike)**\n\nFor vectors x, y in an inner product space over an RCLike field 𝕜:\n$$\\big\\|\\,\\langle x,x\\rangle\\, y - \\langle x,y\\rangle\\, x\\,\\big\\|^2 = \\|x\\|^2\\Big(\\|x\\|^2\\,\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2\\Big).$$\n\nSince the left side is a square and $\\|x\\|^2 \\ge 0$, the Cauchy-Schwarz defect $\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2$ is nonnegative, and equality holds iff the scaled Gram vector $\\langle x,x\\rangle y - \\langle x,y\\rangle x$ is zero.",
+    "text": "An exact, division-free Lagrange identity for the Cauchy-Schwarz defect over complex (RCLike) inner product spaces, from which both the inequality and its equality characterization follow directly.",
+    "proofStrategy": "**Proof via the Scaled Gram Vector**\n\n1. **Set** w = ⟪x,x⟫•y − ⟪x,y⟫•x (scalars in 𝕜; no division).\n2. **Expand** ⟪w,w⟫ by sesquilinearity. The conjugates simplify via conj⟪x,x⟫ = ⟪x,x⟫ and conj⟪x,y⟫ = ⟪y,x⟫; the cross term aⁿb − bⁿa cancels, leaving ⟪w,w⟫ = ⟪x,x⟫·(⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫).\n3. **Cast to reals** via inner_self_eq_norm_sq_to_K and RCLike.mul_conj, then lift the 𝕜-identity to ℝ by injectivity of the coercion, giving the Lagrange defect identity.\n4. **Inequality**: the left side is a square ≥ 0; cancel the positive ‖x‖² for x ≠ 0 (the x = 0 case is trivial), and take square roots.\n5. **Equality**: equality makes the defect 0, so ‖w‖² = ‖x‖²·0 = 0, forcing w = 0 — no case split. Conversely w = 0 gives ‖x‖²·defect = 0, hence the defect vanishes (x ≠ 0) or both sides are 0 (x = 0).",
+    "keyInsights": [
+      "**Scale, don't divide**: Using the coefficient ⟪x,x⟫ (a scalar) instead of dividing by it makes the identity hold for *all* x, eliminating the v ≠ 0 hypothesis that the projection approach requires at the identity level.",
+      "**The defect is literally a squared norm**: ‖x‖²·(‖x‖²‖y‖² − ‖⟪x,y⟫‖²) = ‖w‖² exhibits the Cauchy-Schwarz gap as ‖x‖² times the squared length of y's component orthogonal to x.",
+      "**Sesquilinear cancellation**: Over ℂ the cross term survives only as a − b·b̄ structure; it cancels because conj⟪x,x⟫ = ⟪x,x⟫ and the residual is orthogonal to x. A single `ring` closes the 𝕜-identity once conjugates are rewritten.",
+      "**Self-contained inequality**: Cauchy-Schwarz is re-derived purely from nonnegativity of a square, never invoking Mathlib's norm_inner_le_norm — the identity is logically upstream of the inequality.",
+      "**Forward equality needs no case split**: Because ‖w‖² = ‖x‖²·defect, vanishing defect forces ‖w‖² = 0 directly, regardless of whether x is zero."
+    ],
+    "prerequisites": [
+      "Mathematical analysis",
+      "Linear algebra",
+      "Complex analysis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "gram-identity",
+      "title": "The 𝕜-Valued Gram Identity",
+      "summary": "⟪w,w⟫ = ⟪x,x⟫·(⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫) for w = ⟪x,x⟫•y − ⟪x,y⟫•x, by one sesquilinear expansion plus ring.",
+      "startLine": 72,
+      "endLine": 77,
+      "mathContext": "Expanding the self inner product of the scaled Gram vector and simplifying the conjugates $\\overline{\\langle x,x\\rangle} = \\langle x,x\\rangle$, $\\overline{\\langle x,y\\rangle} = \\langle y,x\\rangle$ collapses the cross term, leaving the Gram determinant scaled by $\\langle x,x\\rangle$."
+    },
+    {
+      "id": "lagrange-identity",
+      "title": "The Real Lagrange Defect Identity (★)",
+      "summary": "‖w‖² = ‖x‖²·(‖x‖²·‖y‖² − ‖⟪x,y⟫‖²), obtained from the 𝕜-identity by casting via inner_self_eq_norm_sq_to_K and RCLike.mul_conj and lifting through ofReal injectivity.",
+      "startLine": 89,
+      "endLine": 99,
+      "mathContext": "The exact, division-free Lagrange identity: the squared norm of the residual equals $\\|x\\|^2$ times the Cauchy-Schwarz defect. Valid for all $x, y$, including $x = 0$."
+    },
+    {
+      "id": "cauchy-schwarz",
+      "title": "Cauchy-Schwarz, Recovered from (★)",
+      "summary": "Squared form ‖⟪x,y⟫‖² ≤ ‖x‖²‖y‖² (from nonnegativity of ‖w‖²), the norm form via √-monotonicity, and nonnegativity of the Gram determinant.",
+      "startLine": 109,
+      "endLine": 137,
+      "mathContext": "Because $\\|w\\|^2 \\ge 0$ and $\\|x\\|^2 \\ge 0$, the defect is nonnegative, giving $\\|\\langle x,y\\rangle\\| \\le \\|x\\|\\,\\|y\\|$ — the headline of the parent problem — without using Mathlib's Cauchy-Schwarz lemma."
+    },
+    {
+      "id": "equality",
+      "title": "Equality Characterization",
+      "summary": "‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ⟪x,x⟫•y = ⟪x,y⟫•x, and the linear-dependence corollary ∃ c, y = c•x for x ≠ 0.",
+      "startLine": 150,
+      "endLine": 186,
+      "mathContext": "Equality holds iff the residual vanishes. For $x \\ne 0$ this is exactly $y = (\\langle x,y\\rangle/\\langle x,x\\rangle)\\,x$, i.e. $y$ is a scalar multiple of $x$."
+    },
+    {
+      "id": "specializations",
+      "title": "Specializations to ℝ and ℂ",
+      "summary": "The defect identity over real inner product spaces, over complex inner product spaces, and complex Cauchy-Schwarz, all as direct instantiations of the RCLike results.",
+      "startLine": 192,
+      "endLine": 210,
+      "mathContext": "Instantiating $\\mathbb{k} = \\mathbb{R}$ and $\\mathbb{k} = \\mathbb{C}$ recovers the classical real and complex statements from the single uniform RCLike development."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered affirmatively: there is an exact, division-free Lagrange identity for the Cauchy-Schwarz defect over any RCLike inner product space. All 10 theorems are proved with 0 sorries and 0 axioms; the inequality and its equality condition both follow from a single squared-norm identity.",
+    "implications": "**Theoretical Significance**\n\n1. **Quantitative refinement**: The identity exposes the Cauchy-Schwarz gap as an exact squared norm, not just a bound — useful wherever the *sharpness* of Cauchy-Schwarz matters (least squares, stability estimates).\n2. **Logical independence from Mathlib's CS**: The inequality is derived from the identity alone, demonstrating that Cauchy-Schwarz is downstream of an elementary algebraic identity even over complex fields.\n3. **Contrast with cauchy-schwarz-oq-01-oq-01**: That sibling proves the equality condition via the projection coefficient ⟪v,u⟫/⟪v,v⟫ and Pythagoras; here the same conclusion is reached division-free, with the forward equality direction requiring no case split.",
+    "openQuestions": [
+      "Can the Lagrange identity be packaged as the squared norm of an explicit orthogonal residual to connect with Mathlib's orthogonalProjection?",
+      "Does the scaled Gram-vector identity generalize to a Gram-matrix determinant identity for n vectors (Gram determinant ≥ 0)?",
+      "Can the same division-free technique give a quantitative reverse Cauchy-Schwarz (Pólya–Szegő) bound?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "RCLike"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ05",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ01OQ05.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "J.-L. Lagrange",
+      "title": "Solutions analytiques de quelques problèmes sur les pyramides triangulaires",
+      "year": "1773",
+      "venue": "Nouveaux mémoires de l'Académie de Berlin",
+      "note": "Original algebraic identity underlying the inequality"
+    },
+    {
+      "authors": "A.-L. Cauchy",
+      "title": "Cours d'Analyse",
+      "year": "1821",
+      "venue": "Imprimerie Royale, Paris",
+      "note": "Finite sum form of the inequality"
+    },
+    {
+      "authors": "H. A. Schwarz",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem",
+      "year": "1885",
+      "venue": "Acta Societatis Scientiarum Fennicae",
+      "note": "Inner product space formulation via orthogonal residual"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01",
+      "relationship": "extends",
+      "description": "Parent problem (complex Cauchy-Schwarz); this entry re-derives the inequality from an exact defect identity rather than from Mathlib's bound"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling equality characterization via the projection coefficient and Pythagoras; this entry reaches the same equality condition division-free"
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "extends",
+      "description": "Base Cauchy-Schwarz inequality; quantified here as an exact squared-norm identity"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The defect identity is the orthogonal-decomposition Pythagoras relation in disguise, scaled by ‖x‖²"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/prime-number-theorem-oq-03/annotations.json
+++ b/src/data/proofs/prime-number-theorem-oq-03/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 5,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "The cornerstone identity of elementary PNT",
+    "content": "Every elementary proof of the Prime Number Theorem — Chebyshev (1852), Mertens (1874), and ultimately Selberg–Erdős (1949) — begins by computing log(N!) in two ways. Arithmetically, the divisor identity log n = ∑_{d∣n} Λ(d) summed over n ≤ N and re-indexed by divisor gives the floor-weighted sum ∑_{m≤N} Λ(m)⌊N/m⌋. Analytically, Stirling's formula gives log(N!) = N log N − N + O(log N). The identity formalized here, ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!), is the exact bridge between the two — and the first place error bounds enter the elementary theory. Mathlib's Chebyshev file defines ψ and θ and bounds |ψ−θ|, but does not contain this floor-weighted identity.",
+    "mathContext": "$\\sum_{m=1}^{N} \\Lambda(m)\\lfloor N/m\\rfloor = \\log(N!)$, the arithmetic = analytic bridge of elementary prime distribution.",
+    "significance": "central",
+    "relatedConcepts": [
+      "von Mangoldt function",
+      "Chebyshev functions ψ and θ",
+      "Mertens' theorems",
+      "Dirichlet double-counting"
+    ],
+    "prerequisites": [
+      "von Mangoldt function Λ",
+      "the divisor identity ∑_{d∣n} Λ(d) = log n"
+    ]
+  },
+  {
+    "id": "ann-log-factorial",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "log(N!) = ∑_{n≤N} log n",
+    "content": "The analytic side is made additive here. N! is rewritten as the product ∏_{n∈[1,N]} n by induction on N — the successor step is Finset.prod_Icc_succ_top together with Nat.factorial_succ. Casting to ℝ and applying Real.log_prod (legal because every factor n ≥ 1 is nonzero) turns the log of the product into the sum of logs. Stirling's formula would then estimate this sum as N log N − N + O(log N), but that analytic input is deliberately not used: the identity in the next theorem is exact and axiom-free.",
+    "mathContext": "$\\log(N!) = \\log\\!\\left(\\prod_{n=1}^{N} n\\right) = \\sum_{n=1}^{N} \\log n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "Finset.prod_Icc_succ_top",
+      "Stirling's formula"
+    ],
+    "prerequisites": [
+      "logarithm of a product"
+    ]
+  },
+  {
+    "id": "ann-swap",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 102,
+      "startColumn": 0,
+      "endColumn": 0
+    },
+    "type": "technique",
+    "title": "Exchanging the order of summation",
+    "content": "The heart of the proof is a Dirichlet double-counting. Starting from ∑_{n≤N} ∑_{d∣n} Λ(d), the inner sum runs over the divisors of each n; after swapping, the outer index becomes the divisor d and the inner sum runs over the multiples of d that are ≤ N. The swap is Finset.sum_comm', driven by the membership equivalence n∈[1,N] ∧ d∈divisors n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N] (the forward direction needs d ≥ 1 from d∣n, n≠0, and d ≤ n ≤ N from Nat.le_of_dvd). Because the inner summand Λ(d) is constant in n, the inner sum collapses to Λ(d) times the number of multiples of d in {1,…,N}, which Nat.Ioc_filter_dvd_card_eq_div evaluates to exactly ⌊N/d⌋ — recovering the floor weights.",
+    "mathContext": "$\\sum_{n\\le N}\\sum_{d\\mid n}\\Lambda(d) = \\sum_{d\\le N}\\Lambda(d)\\,\\#\\{n\\le N : d\\mid n\\} = \\sum_{d\\le N}\\Lambda(d)\\lfloor N/d\\rfloor$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Finset.sum_comm'",
+      "Nat.Ioc_filter_dvd_card_eq_div",
+      "counting multiples",
+      "Dirichlet hyperbola method"
+    ],
+    "prerequisites": [
+      "exchange of order of summation",
+      "counting multiples of d up to N"
+    ]
+  },
+  {
+    "id": "ann-mertens-bound",
+    "proofId": "prime-number-theorem-oq-03",
+    "range": {
+      "startLine": 104,
+      "endLine": 120
+    },
+    "type": "technique",
+    "title": "The error-bounded corollary (easy half of Mertens)",
+    "content": "Replacing the floor ⌊N/m⌋ by the true quotient N/m can only increase each term, since Λ(m) ≥ 0 and ⌊N/m⌋ ≤ N/m (Nat.cast_div_le). Summing gives log(N!) ≤ N·∑_{m≤N} Λ(m)/m. This is the easy direction of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1): the displacement between the exact identity and its smoothed version N·∑ Λ(m)/m is bounded by the fractional parts, i.e. by ψ(N) = ∑_{m≤N} Λ(m), the quantitative seed of Chebyshev's ψ(x) ≍ x.",
+    "mathContext": "$\\log(N!) \\le N\\sum_{m=1}^{N}\\frac{\\Lambda(m)}{m}$ from $\\lfloor N/m\\rfloor \\le N/m$ and $\\Lambda(m)\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Mertens' first theorem",
+      "Nat.cast_div_le",
+      "vonMangoldt_nonneg"
+    ],
+    "prerequisites": [
+      "floor versus true quotient",
+      "monotonicity of finite sums"
+    ]
+  }
+]

--- a/src/data/proofs/prime-number-theorem-oq-03/meta.json
+++ b/src/data/proofs/prime-number-theorem-oq-03/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "prime-number-theorem-oq-03",
+  "title": "Elementary PNT: the von Mangoldt summatory identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!)",
+  "slug": "prime-number-theorem-oq-03",
+  "description": "Formalizes the exact arithmetic identity at the foundation of every elementary proof of the Prime Number Theorem (Chebyshev, Mertens, Selberg–Erdős): ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!), where Λ is the von Mangoldt function and ⌊N/m⌋ is natural-number division. Derived by expanding log n = ∑_{d∣n} Λ(d) (Mathlib's vonMangoldt_sum), summing over n ≤ N, and exchanging the order of summation so that each divisor m is counted with multiplicity ⌊N/m⌋ = #{n ≤ N : m∣n}. Mathlib's Chebyshev file defines ψ and θ and bounds |ψ−θ|, but does NOT contain this floor-weighted summatory identity. The entry adds the immediate error-bounded corollary log(N!) ≤ N·∑_{m≤N} Λ(m)/m from ⌊N/m⌋ ≤ N/m — the easy half of Mertens' first theorem. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimeNumberTheoremOQ03.lean",
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "von-mangoldt",
+      "chebyshev",
+      "mertens",
+      "summatory-function",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "lineCount": 122,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. All three theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (no `axiom` declarations, no structure-encoded assumptions, no native_decide / Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_sum",
+        "description": "∑_{d ∣ n} Λ(d) = log n. The arithmetic input: each log n is replaced by the divisor sum of the von Mangoldt function before the summation order is exchanged.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_nonneg",
+        "description": "0 ≤ Λ(m). Used in the upper-estimate corollary to compare ⌊N/m⌋ with N/m term by term.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "Nat.Ioc_filter_dvd_card_eq_div",
+        "description": "#{x ∈ (0,N] : m ∣ x} = N / m. The counting input: after the swap, divisor m appears with multiplicity equal to the number of its multiples in {1,…,N}.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm'",
+        "description": "Generalised order-exchange for a double sum whose inner index set depends on the outer variable; instantiated with the membership equivalence n∈[1,N] ∧ d∣n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N].",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Sigma"
+      },
+      {
+        "theorem": "Real.log_prod",
+        "description": "log(∏ f) = ∑ log f for nonzero factors; turns log(N!) = log(∏_{n≤N} n) into ∑_{n≤N} log n.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.cast_div_le",
+        "description": "(↑(N/m) : ℝ) ≤ ↑N/↑m. Bounds the floor by the true quotient in the Mertens upper-estimate corollary.",
+        "module": "Mathlib.Data.Nat.Cast.Order.Basic"
+      }
+    ],
+    "originalContributions": [
+      "vonMangoldt_summatory: the exact identity ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!), absent from Mathlib's Chebyshev development",
+      "log_factorial_eq_sum_log: the auxiliary identity log(N!) = ∑_{n=1}^{N} log n proved via prod_Icc_succ_top induction",
+      "log_factorial_le: the error-bounded corollary log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m (the easy direction of Mertens' first theorem)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Long before Hadamard and de la Vallée Poussin's 1896 analytic proof, Chebyshev (1852) obtained the order of magnitude of π(x) by elementary means. His starting point — reused by Mertens (1874) and, ultimately, by the Selberg–Erdős elementary proof of the full Prime Number Theorem (1949) — is the double-counting identity\n\n  ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!),\n\nwhere Λ is the von Mangoldt function. The left-hand side is purely arithmetic; the right-hand side is estimated analytically by Stirling's formula as N log N − N + O(log N). Equating the two estimates is the first place 'error bounds' enter the elementary theory, and every subsequent refinement (Chebyshev's ψ(x) ≍ x, Mertens' ∑_{p≤x} log p / p = log x + O(1), and the Tauberian endgame) is built on top of it.",
+    "problemStatement": "Open question OQ-03 of the Prime Number Theorem entry asks whether PNT can be proved elementarily with error bounds matching the analytic proof. This entry formalizes the foundational identity from which all elementary estimates depart, in fully verified axiom-free form, together with the first error-bounded corollary it yields.",
+    "text": "The exact identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) — the cornerstone of Chebyshev's and Mertens' elementary approach to the distribution of primes — with the immediate upper estimate log(N!) ≤ N·∑_{m≤N} Λ(m)/m.",
+    "proofStrategy": "1. log(N!) = ∑_{n=1}^{N} log n: write N! = ∏_{n=1}^{N} n (induction with prod_Icc_succ_top) and apply Real.log_prod (each factor n ≥ 1 is nonzero).\n2. log n = ∑_{d∣n} Λ(d): Mathlib's vonMangoldt_sum.\n3. Exchange the order of summation: ∑_{n≤N} ∑_{d∣n} Λ(d) = ∑_{d≤N} Λ(d)·#{n≤N : d∣n} via Finset.sum_comm', with the membership equivalence n∈[1,N] ∧ d∈divisors n ⟺ (n∈[1,N] ∧ d∣n) ∧ d∈[1,N].\n4. Count the multiples: #{n≤N : d∣n} = N/d via Nat.Ioc_filter_dvd_card_eq_div (after rewriting Icc 1 N = Ioc 0 N), and the inner constant sum becomes Λ(d)·⌊N/d⌋.\n5. Corollary: from ⌊N/m⌋ ≤ N/m (Nat.cast_div_le) and Λ ≥ 0, bound each summand to obtain log(N!) ≤ N·∑_{m≤N} Λ(m)/m.",
+    "keyInsights": [
+      "The identity is a clean instance of Dirichlet double-counting: summing the divisor identity log n = ∑_{d∣n} Λ(d) over n ≤ N and swapping the two sums replaces 'for each n, run over its divisors' by 'for each d, run over its multiples ≤ N', and the number of those multiples is exactly the floor ⌊N/d⌋.",
+      "Mathlib's Chebyshev file (psi, theta, |psi − theta| ≤ √x·log x, Chebyshev's upper bounds) deliberately works with the UNWEIGHTED sum ψ(x) = ∑_{n≤x} Λ(n); the FLOOR-WEIGHTED summatory function formalized here is a different object and is the one that connects directly to log(N!).",
+      "This is exactly where error bounds originate in the elementary theory: the arithmetic side is exact, while the analytic side log(N!) = N log N − N + O(log N) (Stirling) injects the first error term. The corollary log(N!) ≤ N·∑ Λ(m)/m is the easy half of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1).",
+      "Replacing ⌊N/m⌋ by N/m costs at most a fractional part in [0,1) per term, so the displacement between the exact identity and its smoothed version N·∑ Λ(m)/m is controlled by ψ(N) = ∑_{m≤N} Λ(m) — the quantitative seed of Chebyshev's ψ(x) ≍ x."
+    ],
+    "prerequisites": [
+      "Prime Number Theorem (Proofs.PrimeNumberTheorem): π(x) ~ x/log x",
+      "The von Mangoldt function Λ and the identity ∑_{d∣n} Λ(d) = log n",
+      "Dirichlet double-counting / exchange of order of summation over divisors"
+    ]
+  },
+  "sections": [
+    {
+      "id": "log-factorial",
+      "title": "log(N!) as a sum of logarithms",
+      "startLine": 53,
+      "endLine": 65,
+      "summary": "`log_factorial_eq_sum_log`: log(N!) = ∑_{n=1}^{N} log n. Proves N! = ∏_{n∈[1,N]} n by induction (prod_Icc_succ_top), casts to ℝ, and applies Real.log_prod since each factor is nonzero.",
+      "mathContext": "Turning a factorial into an additive sum of logs is the analytic side of the elementary method; Stirling's formula then evaluates it as N log N − N + O(log N)."
+    },
+    {
+      "id": "summatory-identity",
+      "title": "The von Mangoldt summatory identity",
+      "startLine": 67,
+      "endLine": 102,
+      "summary": "`vonMangoldt_summatory`: ∑_{m=1}^{N} Λ(m)⌊N/m⌋ = log(N!). A calc chain runs the floor-weighted sum back to ∑_{d≤N} ∑_{n∈multiples} Λ(d) (constant inner sum, card = N/d via Nat.Ioc_filter_dvd_card_eq_div), exchanges order with Finset.sum_comm', then folds each ∑_{d∣n} Λ(d) into log n and reassembles log(N!).",
+      "mathContext": "This is the exact arithmetic identity of Chebyshev and Mertens. The floor multiplicities ⌊N/m⌋ count, for each prime power m, how many integers ≤ N it divides."
+    },
+    {
+      "id": "mertens-bound",
+      "title": "Upper estimate (easy half of Mertens)",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "`log_factorial_le`: log(N!) ≤ N·∑_{m=1}^{N} Λ(m)/m. Substitutes the identity, distributes N over the sum, and compares term by term using ⌊N/m⌋ ≤ N/m (Nat.cast_div_le) and Λ(m) ≥ 0.",
+      "mathContext": "Mertens' first theorem states ∑_{m≤N} Λ(m)/m = log N + O(1); this provides the lower bound on that sum (equivalently, the upper bound on log(N!) in terms of it), the direction that follows purely from ⌊N/m⌋ ≤ N/m."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes, fully verified and axiom-free, the foundational identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) of the elementary theory of prime distribution, plus the auxiliary log(N!) = ∑_{n≤N} log n and the Mertens-direction estimate log(N!) ≤ N·∑_{m≤N} Λ(m)/m. The floor-weighted summatory identity is not present in Mathlib's Chebyshev development.",
+    "implications": "This identity is the launching point for: (1) Chebyshev's bounds ψ(x) ≍ x, by combining it with Stirling's N log N − N + O(log N); (2) Mertens' theorems on ∑ Λ(m)/m and ∑_{p} log p / p; and (3) the Selberg–Erdős elementary proof of PNT. Supplying it in verified form is a concrete step toward an elementary, error-bounded PNT formalization in Lean.",
+    "openQuestions": [
+      "Combine this identity with a Lean formalization of Stirling's bound to derive ∑_{m≤N} Λ(m)⌊N/m⌋ = N log N − N + O(log N) with explicit constants.",
+      "Prove the full Mertens first theorem ∑_{m≤N} Λ(m)/m = log N + O(1) by controlling the displacement between ⌊N/m⌋ and N/m via Chebyshev's ψ(N) = O(N).",
+      "Can the Selberg symmetry formula ∑_{m≤N} Λ(m) log m + ∑_{mn≤N} Λ(m)Λ(n) = 2N log N + O(N), the engine of the elementary PNT proof, be built on top of this summatory framework?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "extends",
+      "description": "Parent entry π(x) ~ x/log x; this formalizes the cornerstone identity of the elementary route to PNT"
+    },
+    {
+      "targetId": "prime-number-theorem-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question on PNT error bounds via the Riemann Hypothesis; this entry pursues the complementary elementary (Chebyshev–Mertens) error-bound route"
+    },
+    {
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "∑ 1/p diverges; Mertens' refinement ∑ log p / p = log x + O(1) descends from the summatory identity formalized here"
+    }
+  ],
+  "references": [
+    {
+      "title": "Mémoire sur les nombres premiers",
+      "author": "P. L. Chebyshev",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées",
+      "description": "Elementary bounds on π(x) via the summatory von Mangoldt / factorial identity"
+    },
+    {
+      "title": "Ein Beitrag zur analytischen Zahlentheorie",
+      "author": "F. Mertens",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik",
+      "description": "Mertens' theorems on ∑ Λ(m)/m and ∑ log p / p, built on the same identity"
+    },
+    {
+      "title": "An elementary proof of the prime-number theorem",
+      "author": "A. Selberg",
+      "year": "1949",
+      "venue": "Annals of Mathematics",
+      "description": "Elementary proof of PNT whose symmetry formula rests on summatory von Mangoldt estimates"
+    },
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "T. M. Apostol",
+      "year": "1976",
+      "venue": "Springer",
+      "description": "Textbook derivation of ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) and the Chebyshev/Mertens estimates (Ch. 3–4)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "ArithmeticFunction"
+    ],
+    "namespace": "PrimeNumberTheoremOQ03",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/PrimeNumberTheoremOQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "vonMangoldt_summatory",
+      "type": "core",
+      "statement": "$\\displaystyle\\sum_{m=1}^{N} \\Lambda(m)\\left\\lfloor \\tfrac{N}{m}\\right\\rfloor = \\log(N!)$",
+      "significance": "**The cornerstone identity of elementary PNT.** Exact, axiom-free, and not present in Mathlib's Chebyshev file. Equating its analytic estimate (Stirling) with its arithmetic content drives Chebyshev's ψ(x) ≍ x and Mertens' theorems, and ultimately the Selberg–Erdős elementary proof.",
+      "description": "Proved by expanding log n = ∑_{d∣n} Λ(d), summing over n ≤ N, and exchanging the order of summation so each divisor m is weighted by its multiple-count ⌊N/m⌋."
+    },
+    {
+      "name": "log_factorial_eq_sum_log",
+      "type": "supporting",
+      "statement": "$\\displaystyle\\log(N!) = \\sum_{n=1}^{N} \\log n$",
+      "significance": "Auxiliary identity turning the factorial into the additive object that Stirling's formula estimates; the analytic half of the elementary method.",
+      "description": "N! = ∏_{n∈[1,N]} n by induction (prod_Icc_succ_top), then Real.log_prod over nonzero factors."
+    },
+    {
+      "name": "log_factorial_le",
+      "type": "supporting",
+      "statement": "$\\displaystyle\\log(N!) \\le N\\sum_{m=1}^{N} \\frac{\\Lambda(m)}{m}$",
+      "significance": "First error-bounded corollary: the easy half of Mertens' first theorem ∑_{m≤N} Λ(m)/m = log N + O(1). Follows from ⌊N/m⌋ ≤ N/m and Λ ≥ 0.",
+      "description": "Substitutes the summatory identity and bounds each summand using Nat.cast_div_le and vonMangoldt_nonneg."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-05.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-05.json
@@ -1,0 +1,114 @@
+{
+  "slug": "cauchy-schwarz-oq-01-oq-05",
+  "title": "Quantitative Cauchy-Schwarz via the Lagrange Defect Identity",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\big\\|\\langle x,x\\rangle\\, y - \\langle x,y\\rangle\\, x\\big\\|^2 = \\|x\\|^2\\big(\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2\\big)",
+    "plain": "For complex (and general RCLike) inner product spaces, is there an exact, division-free algebraic identity for the Cauchy-Schwarz defect ‖x‖²‖y‖² − ‖⟪x,y⟫‖², from which both the inequality and its equality characterization follow directly — without invoking Mathlib's inner_mul_le_norm_mul_norm or an orthogonal-projection coefficient?",
+    "whyMatters": [
+      "Exhibits the Cauchy-Schwarz gap as an exact squared norm rather than a bound, which matters wherever sharpness is needed (least squares, stability estimates).",
+      "Shows the inequality is logically downstream of an elementary algebraic identity, even over complex fields.",
+      "Provides a division-free alternative to the projection-coefficient proof used by the sibling equality-characterization entry."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "𝕜-valued Gram identity ⟪w,w⟫ = ⟪x,x⟫·(⟪x,x⟫⟪y,y⟫ − ⟪x,y⟫⟪y,x⟫) for w = ⟪x,x⟫•y − ⟪x,y⟫•x",
+      "Real Lagrange defect identity ‖w‖² = ‖x‖²·(‖x‖²‖y‖² − ‖⟪x,y⟫‖²)",
+      "Cauchy-Schwarz (squared and norm forms), derived without Mathlib's CS lemma",
+      "Equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ⟪x,x⟫•y = ⟪x,y⟫•x",
+      "Linear-dependence corollary for x ≠ 0: equality ↔ ∃ c, y = c•x",
+      "ℝ and ℂ specializations"
+    ],
+    "open": [],
+    "goal": "Establish and formalize an exact division-free Lagrange identity for the complex Cauchy-Schwarz defect."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00Z",
+    "iteration": 1,
+    "focus": "Formalized and verified in Lean 4 (0 axioms, 0 sorries).",
+    "blockers": [],
+    "nextAction": "None — shipped to gallery.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Fully solved and formalized. The scaled Gram vector w = ⟪x,x⟫•y − ⟪x,y⟫•x (division-free, scalars in 𝕜) satisfies the abstract Lagrange identity ‖w‖² = ‖x‖²·(‖x‖²‖y‖² − ‖⟪x,y⟫‖²) over any RCLike inner product space. Nonnegativity of the left side yields Cauchy-Schwarz directly (no appeal to inner_mul_le_norm_mul_norm), and vanishing of w characterizes equality. The Lean file CauchySchwarzOQ01OQ05.lean has 10 theorems, 212 lines, 0 axioms, 0 sorries; #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "builtItems": [
+      "inner_gram_self — 𝕜-valued Gram identity, proved by sesquilinear expansion + ring after rewriting conjugates",
+      "gram_norm_sq — the real Lagrange defect identity (★), via inner_self_eq_norm_sq_to_K, RCLike.mul_conj and ofReal injectivity",
+      "cauchy_schwarz_sq / cauchy_schwarz — the inequality recovered from (★) without Mathlib's CS lemma",
+      "gram_det_nonneg — nonnegativity of the Gram determinant ‖x‖²‖y‖² − ‖⟪x,y⟫‖²",
+      "cauchy_schwarz_eq_iff — equality ↔ ⟪x,x⟫•y = ⟪x,y⟫•x (forward direction with no case split)",
+      "eq_iff_smul_of_ne_zero — linear-dependence corollary for x ≠ 0",
+      "gram_norm_sq_real / gram_norm_sq_complex / cauchy_schwarz_complex — ℝ and ℂ specializations"
+    ],
+    "insights": [
+      "Scaling the Gram vector by ⟪x,x⟫ instead of dividing by it makes the identity hold for ALL x (including x = 0), removing the v ≠ 0 hypothesis that the projection approach needs.",
+      "The Cauchy-Schwarz defect is literally a squared norm: ‖x‖²·(‖x‖²‖y‖² − ‖⟪x,y⟫‖²) = ‖w‖², so the inequality is just nonnegativity of a square.",
+      "Over a complex/RCLike field the sesquilinear cross term cancels precisely because conj⟪x,x⟫ = ⟪x,x⟫ and conj⟪x,y⟫ = ⟪y,x⟫; a single ring closes the 𝕜-identity once those conjugates are rewritten.",
+      "Lifting a 𝕜-identity whose two sides are both ofReal-coercions down to ℝ via RCLike.ofReal_injective avoids all re/im bookkeeping.",
+      "The forward equality direction needs no case split: equality zeroes the defect, hence ‖w‖² = ‖x‖²·0 = 0 regardless of whether x is zero."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the finite-sum Lagrange identity context but no abstract division-free inner-product-space Lagrange defect identity ‖⟪x,x⟫•y − ⟪x,y⟫•x‖² = ‖x‖²·(defect)."
+    ],
+    "nextSteps": [
+      "Generalize to an n-vector Gram-determinant nonnegativity identity.",
+      "Use the same division-free technique for a reverse Cauchy-Schwarz (Pólya–Szegő) bound.",
+      "Connect the residual to Mathlib's orthogonalProjection."
+    ],
+    "markdown": "# Knowledge Base: cauchy-schwarz-oq-01-oq-05\n\n## Result\n\nThe division-free Lagrange defect identity over RCLike inner product spaces:\n\n  ‖⟪x,x⟫•y − ⟪x,y⟫•x‖² = ‖x‖²·(‖x‖²‖y‖² − ‖⟪x,y⟫‖²)\n\nyields Cauchy-Schwarz (nonnegativity of the LHS) and its equality characterization (LHS = 0) for free, without Mathlib's inner_mul_le_norm_mul_norm and without dividing by ⟪x,x⟫.\n\n## Key technique\n\nScale, don't divide: use the scalar ⟪x,x⟫ as the coefficient so the identity holds for all x. Expand ⟪w,w⟫ sesquilinearly; conj⟪x,x⟫ = ⟪x,x⟫ and conj⟪x,y⟫ = ⟪y,x⟫ make the cross term cancel; ring closes it. Cast to reals via inner_self_eq_norm_sq_to_K + RCLike.mul_conj and lift through ofReal injectivity.\n"
+  },
+  "tags": [
+    "analysis",
+    "linear-algebra",
+    "inner-product-spaces",
+    "complex-analysis",
+    "functional-analysis",
+    "classic"
+  ],
+  "relatedProofs": [
+    "cauchy-schwarz",
+    "cauchy-schwarz-oq-01",
+    "cauchy-schwarz-oq-01-oq-01",
+    "cauchy-schwarz-integral"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Lagrange%27s_identity"
+    ],
+    "mathlib": [
+      "inner_self_eq_norm_sq_to_K",
+      "inner_conj_symm",
+      "RCLike.mul_conj",
+      "RCLike.ofReal_injective"
+    ]
+  },
+  "started": "2026-06-24T00:00:00Z",
+  "lastUpdate": "2026-06-24T00:00:00Z",
+  "completed": "2026-06-24T00:00:00Z",
+  "significance": 8,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/CauchySchwarzOQ01OQ05.lean",
+      "filename": "CauchySchwarzOQ01OQ05.lean",
+      "lineCount": 212,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzOQ01OQ05.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/prime-number-theorem-oq-03.json
+++ b/src/data/research/problems/prime-number-theorem-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "prime-number-theorem-oq-03",
   "title": "Elementary PNT with Error Bounds",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Shipped a verified, axiom-free leaf: the von Mangoldt summatory identity ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!), the cornerstone of the elementary (Chebyshev–Mertens) approach to PNT, plus log(N!)=∑_{n≤N} log n and the Mertens-direction bound log(N!) ≤ N·∑_{m≤N} Λ(m)/m. Gallery slug prime-number-theorem-oq-03, PR #29656.",
+    "builtItems": [
+      "vonMangoldt_summatory : ∑_{m≤N} Λ(m)⌊N/m⌋ = log(N!) (exact, 0-axiom)",
+      "log_factorial_eq_sum_log : log(N!) = ∑_{n≤N} log n",
+      "log_factorial_le : log(N!) ≤ N·∑_{m≤N} Λ(m)/m (easy half of Mertens I)"
+    ],
+    "insights": [
+      "The floor-weighted summatory von Mangoldt function is absent from Mathlib's Chebyshev file, which only develops the unweighted ψ(x)=∑_{n≤x}Λ(n); the floor weights ⌊N/m⌋ are what tie it to log(N!).",
+      "Proof is Dirichlet double-counting: log n = ∑_{d∣n} Λ(d) (vonMangoldt_sum) summed over n≤N, then Finset.sum_comm' swaps to ∑_{d≤N} Λ(d)·#{n≤N:d∣n}, and Nat.Ioc_filter_dvd_card_eq_div evaluates the count to ⌊N/d⌋.",
+      "This identity is the entry point for error bounds in elementary PNT: equating it with Stirling's log(N!)=N log N−N+O(log N) yields Chebyshev ψ(x)≍x and Mertens ∑Λ(m)/m=log N+O(1)."
+    ],
+    "mathlibGaps": [
+      "No floor-weighted von Mangoldt summatory identity in Mathlib.NumberTheory.Chebyshev.",
+      "No Lean Stirling error bound log(N!)=N log N−N+O(log N) wired to this summatory framework yet."
+    ],
+    "nextSteps": [
+      "Combine with a Lean Stirling bound to derive ∑Λ(m)⌊N/m⌋ = N log N − N + O(log N) with explicit constants.",
+      "Prove full Mertens first theorem ∑_{m≤N}Λ(m)/m = log N + O(1) via Chebyshev ψ(N)=O(N).",
+      "Build the Selberg symmetry formula on top of this summatory framework toward elementary PNT."
+    ]
   },
   "tags": [
     "analytic-number-theory",


### PR DESCRIPTION
## Summary

Ships the gallery entry **cauchy-schwarz-oq-01-oq-05** — an exact, division-free Lagrange/Gram defect identity for the Cauchy-Schwarz gap over **complex (RCLike) inner product spaces**:

$$\big\|\,\langle x,x\rangle\, y - \langle x,y\rangle\, x\,\big\|^2 = \|x\|^2\big(\|x\|^2\|y\|^2 - \|\langle x,y\rangle\|^2\big)$$

**Key idea — scale, don't divide.** Using the scalar $\langle x,x\rangle$ as the coefficient (rather than dividing by it, as the projection-coefficient proof does) makes the identity hold for *every* $x$, including $x = 0$. Cauchy-Schwarz is then just nonnegativity of a square, and equality $\Leftrightarrow$ the scaled Gram vector vanishes — both **without** invoking Mathlib's `inner_mul_le_norm_mul_norm` or `norm_inner_le_norm`.

Distinct from the sibling `cauchy-schwarz-oq-01-oq-01`, which divides by $\langle v,v\rangle$ and uses Pythagoras.

## What's proved (`Proofs/CauchySchwarzOQ01OQ05.lean`)

- `inner_gram_self` — 𝕜-valued Gram identity, one sesquilinear expansion + `ring`
- `gram_norm_sq` — the real Lagrange defect identity (★)
- `cauchy_schwarz_sq` / `cauchy_schwarz` — the inequality recovered from (★)
- `gram_det_nonneg` — Gram determinant nonnegativity
- `cauchy_schwarz_eq_iff` — equality ↔ $\langle x,x\rangle\,y = \langle x,y\rangle\,x$ (forward direction needs no case split)
- `eq_iff_smul_of_ne_zero` — linear-dependence corollary for $x \ne 0$
- ℝ and ℂ specializations

## Verification

- **10 theorems, 212 lines, 0 defs, 0 sorries, 0 `axiom` declarations**
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` → **verified / original / 0-axiom**
- Compiles clean against Mathlib 4.26.0 (`lake env lean`, EXIT 0, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)