### PR TITLE
Enrich Large-Prime-Factor Sylow Normality (sylow-theorem-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-02/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "ann-sylmp-overview",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 47, "endLine": 51 },
+    "type": "concept",
+    "title": "The Cofactor-Below-the-Prime Setup",
+    "content": "The file works inside namespace SylowLargePrimeFactor with the minimal ambient assumptions [Group G] [Finite G]. Every theorem then adds the arithmetic hypotheses Nat.card G = p ^ a * m, [Fact p.Prime], ¬ p ∣ m, and (for the normality results) m < p. The factorization is canonical: because p ∤ m, the power p ^ a is exactly the p-part of |G| and m is the p'-cofactor — there is no hidden divisibility relating the two. No restriction is placed on the exponent a, so the criterion covers arbitrarily large p-power Sylow subgroups.",
+    "mathContext": "$$|G| = p^{a}\\,m,\\qquad p\\nmid m,\\qquad m < p.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Sylow p-subgroup",
+      "p-part and p'-cofactor",
+      "prime factorization of group order"
+    ],
+    "prerequisites": [
+      "finite group order",
+      "Nat.card",
+      "Fact p.Prime"
+    ]
+  },
+  {
+    "id": "ann-sylmp-card",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 53, "endLine": 72 },
+    "type": "lemma",
+    "title": "Sylow Order Equals the Full p-Part p^a",
+    "content": "sylow_card_eq pins |P| = p ^ a. Sylow.card_eq_multiplicity gives |P| = p ^ ((Nat.card G).factorization p), so the work is purely arithmetic: compute (p ^ a * m).factorization p = a. Nat.factorization_mul splits the product additively (both factors nonzero), (p ^ a).factorization p = a comes from factorization_pow and the prime's own factorization single, and m.factorization p = 0 is exactly the content of p ∤ m via Nat.factorization_eq_zero_of_not_dvd. The hypothesis p ∤ m is what guarantees p ^ a is the entire p-part rather than a proper p-power divisor.",
+    "mathContext": "$$|P| = p^{\\,v_p(|G|)} = p^{\\,v_p(p^{a}m)} = p^{\\,a},\\qquad v_p(m)=0 \\iff p\\nmid m.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "Sylow.card_eq_multiplicity",
+      "Nat.factorization",
+      "multiplicity of a prime"
+    ],
+    "prerequisites": [
+      "Sylow.card_eq_multiplicity",
+      "Nat.factorization_mul",
+      "Nat.factorization_eq_zero_of_not_dvd"
+    ]
+  },
+  {
+    "id": "ann-sylmp-index",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 74, "endLine": 81 },
+    "type": "lemma",
+    "title": "Index of the Sylow Subgroup Equals the Cofactor m",
+    "content": "sylow_index_eq turns the order computation into the index [G : P] = m. The Lagrange identity Subgroup.card_mul_index reads |P| * [G : P] = |G|; substituting |P| = p ^ a (from sylow_card_eq) and |G| = p ^ a * m gives p ^ a * [G : P] = p ^ a * m, and cancelling the strictly positive factor p ^ a (Nat.eq_of_mul_eq_mul_left, pow_pos) leaves [G : P] = m. This is the bridge that lets the next step apply the Sylow divisibility theorem against the concrete number m.",
+    "mathContext": "$$|P|\\cdot[G:P] = |G| \\ \\Longrightarrow\\ p^{a}\\,[G:P] = p^{a}\\,m \\ \\Longrightarrow\\ [G:P] = m.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "subgroup index",
+      "Subgroup.card_mul_index"
+    ],
+    "prerequisites": [
+      "Subgroup.card_mul_index",
+      "Nat.eq_of_mul_eq_mul_left"
+    ]
+  },
+  {
+    "id": "ann-sylmp-collapse",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 83, "endLine": 106 },
+    "type": "insight",
+    "title": "The Divisibility/Congruence Pinch Forcing n_p = 1",
+    "content": "card_sylow_eq_one is the mathematical heart. Two Mathlib facts about the Sylow count n_p = #(Sylow p G) are played against each other. First, Sylow.card_dvd_index gives n_p ∣ [G : P], and with [G : P] = m this yields n_p ∣ m, hence n_p ≤ m < p by Nat.le_of_dvd (m > 0 from finiteness). Second, card_sylow_modEq_one (Sylow's third theorem) gives n_p ≡ 1 (mod p). Reading the congruence below p — both n_p mod p = n_p (since n_p < p) and 1 mod p = 1 (since p > 1) via Nat.mod_eq_of_lt — collapses it to n_p = 1. The only natural number that is both < p and ≡ 1 (mod p) is 1 itself.",
+    "mathContext": "$$n_p \\mid m \\Rightarrow n_p \\le m < p,\\qquad n_p \\equiv 1 \\ (\\mathrm{mod}\\ p)\\ \\xrightarrow{\\,n_p<p\\,}\\ n_p = 1.$$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sylow's third theorem",
+      "counting Sylow subgroups",
+      "modular arithmetic",
+      "divisibility pinch"
+    ],
+    "prerequisites": [
+      "Sylow.card_dvd_index",
+      "card_sylow_modEq_one",
+      "Nat.mod_eq_of_lt",
+      "Nat.le_of_dvd"
+    ]
+  },
+  {
+    "id": "ann-sylmp-normal",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 108, "endLine": 116 },
+    "type": "theorem",
+    "title": "Uniqueness Promotes to Normality",
+    "content": "sylow_normal is the headline. Once n_p = 1, Nat.card_eq_one_iff_unique produces Unique (Sylow p G), whose Subsingleton component is installed as an instance. Sylow.normal_of_subsingleton then converts 'there is at most one Sylow p-subgroup' into normality of that subgroup. The deep reason is that all Sylow p-subgroups are conjugate (Sylow's second theorem); a unique one is fixed by every conjugation, i.e. normal. So the entire structural conclusion P ◁ G is reached purely by counting, with no examination of the internal structure of G.",
+    "mathContext": "$$n_p = 1 \\iff \\mathrm{Syl}_p(G)\\ \\text{is a subsingleton} \\ \\Longrightarrow\\ P \\trianglelefteq G.$$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "normal subgroup",
+      "Sylow uniqueness",
+      "conjugacy of Sylow subgroups",
+      "Sylow.normal_of_subsingleton"
+    ],
+    "prerequisites": [
+      "Nat.card_eq_one_iff_unique",
+      "Sylow.normal_of_subsingleton",
+      "Subsingleton"
+    ]
+  },
+  {
+    "id": "ann-sylmp-exists",
+    "proofId": "sylow-theorem-oq-02-oq-02",
+    "range": { "startLine": 118, "endLine": 123 },
+    "type": "theorem",
+    "title": "Existence Packaging of the Normal Sylow Subgroup",
+    "content": "exists_normal_sylow restates the result existentially: such a group has a normal Sylow p-subgroup. Sylow.nonempty (a consequence of Sylow's first/existence theorem) supplies a witness P, and sylow_normal certifies its normality. This existential form is the convenient hypothesis to feed downstream structural arguments — for instance, that G has a nontrivial proper normal subgroup whenever 1 < p ^ a < |G|, a stepping stone toward solvability/non-simplicity conclusions.",
+    "mathContext": "$$\\exists\\, P \\in \\mathrm{Syl}_p(G),\\ P \\trianglelefteq G.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "existence of Sylow subgroups",
+      "normal subgroup",
+      "non-simplicity criteria"
+    ],
+    "prerequisites": [
+      "Sylow.nonempty",
+      "Sylow's first theorem"
+    ]
+  }
+]

--- a/src/data/proofs/sylow-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-02-oq-02/meta.json
@@ -63,5 +63,113 @@
         "module": "Mathlib.NumberTheory.Padics.PadicVal"
       }
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "The three Sylow theorems (Ludwig Sylow, 1872) are the cornerstone of finite-group structure theory. Beyond mere existence, their arithmetic content — that the number n_p of Sylow p-subgroups divides the cofactor [G : P] and satisfies n_p ≡ 1 (mod p) — is the standard engine of the classical 'counting arguments' that prove particular groups are non-simple or possess normal subgroups. A first course in algebra exercises this engine repeatedly: groups of order pq, p²q, 15, 30, and so on, are shown to have a normal Sylow subgroup by checking that n_p is pinned to 1. The criterion formalized here, |G| = p^a·m with m < p ⟹ the Sylow p-subgroup is normal, is the cleanest possible distillation of that recurring move: a single inequality on the cofactor forces the count. It generalizes the textbook 'smallest prime divisor' lemma (if p is the smallest prime dividing |G| and the cofactor below it is forced, the Sylow subgroup is normal) and underlies many first non-trivial steps toward solvability and the classification of small groups.",
+    "problemStatement": "Let $G$ be a finite group with $|G| = p^{a} m$, where $p$ is prime, $p \\nmid m$ (so $p^{a}$ is the full $p$-part and $m$ the $p'$-cofactor), and $m < p$. Then $G$ has a unique Sylow $p$-subgroup $P$, and $P \\trianglelefteq G$.",
+    "proofStrategy": "Pure Sylow counting against the concrete cofactor. (1) Compute the order of a Sylow subgroup: |P| = p^a, the full p-part, using the prime factorization and p ∤ m. (2) Compute its index: [G : P] = m, by cancelling p^a in Lagrange's identity |P|·[G : P] = |G|. (3) Pinch the count: n_p ∣ [G : P] = m gives n_p ≤ m < p (Sylow's second theorem), while n_p ≡ 1 (mod p) (Sylow's third theorem); the only value below p congruent to 1 modulo p is 1, so n_p = 1. (4) Promote uniqueness to normality: a subsingleton Sylow class means the unique Sylow subgroup is fixed under all conjugation, i.e. normal (Sylow.normal_of_subsingleton).",
+    "keyInsights": [
+      "A single arithmetic inequality m < p on the p'-cofactor — with no constraint at all on the p-power exponent a — already forces normality of the Sylow p-subgroup. The size of the p-part is irrelevant; only the smallness of the cofactor relative to p matters.",
+      "The proof never inspects the internal structure of G. Normality, a structural property, is extracted entirely from the two numerical Sylow constraints n_p ∣ m and n_p ≡ 1 (mod p). This is the paradigm of 'structure from counting'.",
+      "The mechanism is the interaction of a divisibility bound and a congruence: divisibility caps n_p at m < p, the congruence pins it to the residue class of 1, and below p those two facts have a unique common solution n_p = 1. Reading both modular facts via Nat.mod_eq_of_lt is the formal crux.",
+      "The bound is sharp in spirit. Once m ≥ p the congruence n_p ≡ 1 (mod p) no longer excludes values like n_p = p + 1, so the count need not collapse and normality can genuinely fail — the hypothesis m < p is exactly what makes 1 the unique admissible count.",
+      "This is the cofactor-below-the-prime slice of the broader Sylow normality landscape: it isolates a single prime p, in contrast to the global nilpotency characterization (n_p = 1 for every prime) of the sibling entry."
+    ],
+    "prerequisites": [
+      "Sylow's three theorems (existence, conjugacy, counting)",
+      "Lagrange's theorem and subgroup index",
+      "p-adic valuation / prime factorization of integers",
+      "modular arithmetic (congruences mod p)",
+      "normal subgroups and the uniqueness ⟺ normality bridge for Sylow subgroups"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Namespace and Standing Hypotheses",
+      "startLine": 47,
+      "endLine": 51,
+      "summary": "Opens namespace SylowLargePrimeFactor with ambient [Group G] [Finite G]; the per-theorem hypotheses Nat.card G = p^a·m, [Fact p.Prime], ¬ p ∣ m, and m < p are introduced theorem-by-theorem. The factorization is canonical because p ∤ m forces p^a to be the full p-part."
+    },
+    {
+      "id": "sylow-card",
+      "title": "Sylow Order = Full p-Part (sylow_card_eq)",
+      "startLine": 53,
+      "endLine": 72,
+      "summary": "Proves |P| = p^a via Sylow.card_eq_multiplicity together with (p^a·m).factorization p = a, splitting the factorization additively and using p ∤ m to zero out the cofactor's contribution."
+    },
+    {
+      "id": "sylow-index",
+      "title": "Index = Cofactor m (sylow_index_eq)",
+      "startLine": 74,
+      "endLine": 81,
+      "summary": "Derives [G : P] = m from Lagrange's identity Subgroup.card_mul_index by substituting |P| = p^a and |G| = p^a·m and cancelling the positive factor p^a."
+    },
+    {
+      "id": "count-collapse",
+      "title": "The Count Collapses to 1 (card_sylow_eq_one)",
+      "startLine": 83,
+      "endLine": 106,
+      "summary": "The mathematical heart: n_p ∣ m (Sylow's second theorem) gives n_p ≤ m < p, while n_p ≡ 1 (mod p) (Sylow's third theorem) read below p via Nat.mod_eq_of_lt forces n_p = 1 — the unique value < p that is ≡ 1 (mod p)."
+    },
+    {
+      "id": "normality",
+      "title": "Uniqueness ⟹ Normality (sylow_normal)",
+      "startLine": 108,
+      "endLine": 116,
+      "summary": "From n_p = 1 obtains Subsingleton (Sylow p G) via Nat.card_eq_one_iff_unique, then Sylow.normal_of_subsingleton promotes the unique Sylow p-subgroup to a normal one."
+    },
+    {
+      "id": "existence",
+      "title": "Existential Packaging (exists_normal_sylow)",
+      "startLine": 118,
+      "endLine": 123,
+      "summary": "Restates the result existentially: Sylow.nonempty supplies a witness P and sylow_normal certifies its normality, giving ∃ P, (P : Subgroup G).Normal — the convenient form for downstream non-simplicity arguments."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a finite group with |G| = p^a·m (p prime, p ∤ m, m < p), the Sylow p-subgroup is unique and hence normal. The entire conclusion is reached by playing the Sylow divisibility theorem (n_p ∣ m, so n_p ≤ m < p) against the Sylow congruence theorem (n_p ≡ 1 mod p): the only natural number below p in the residue class of 1 is 1, so the count collapses and a unique Sylow subgroup is automatically normal.",
+    "implications": "This packages one of the most frequently used moves in elementary finite-group theory — proving non-simplicity / existence of a normal subgroup by pinning a Sylow count to 1 — into a single reusable criterion with no hypothesis on the p-power exponent. It subsumes the classical 'smallest prime divisor' normality lemma and the standard order-pq analysis, and it is exactly the lever that turns arithmetic of |G| into structural decompositions on the road to solvability and the classification of small groups.",
+    "openQuestions": [
+      "What is the sharp generalization when m ≥ p? Characterize precisely which cofactors m admit a non-normal Sylow p-subgroup, i.e. for which m there exists a group of order p^a·m with n_p > 1.",
+      "Can the criterion be combined across several primes to mechanically certify nilpotency or solvability of all groups of a given order range, recovering the sibling nilpotency characterization as a corollary?",
+      "How far does the analogue extend to Hall π-subgroups in solvable groups, where conjugacy and counting theorems also hold but the congruence constraint is weaker?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "sylow-theorem-oq-02",
+      "relationship": "Parent entry — enumerates Sylow p-subgroups via the conjugation orbit, proving n_p = [G : N_G(P)] and the per-prime criterion n_p = 1 ⟺ P ◁ G. This entry feeds a concrete arithmetic hypothesis (m < p) into that counting machinery to force n_p = 1 for the single prime p."
+    },
+    {
+      "proofId": "sylow-theorem-oq-02-oq-01",
+      "relationship": "Sibling entry — characterizes global nilpotency by n_p = 1 for every prime simultaneously. This entry is the single-prime cofactor slice: one numerical hypothesis collapses the count at one prime, rather than asserting collapse at all primes at once."
+    },
+    {
+      "proofId": "sylow-theorem-oq-01",
+      "relationship": "Sibling entry — runs the same n_p counting analysis specialized to groups of order p·q. The present criterion generalizes the cofactor-pinch used there (m = q < p case) to an arbitrary p-power times a small cofactor."
+    },
+    {
+      "proofId": "sylow-theorem",
+      "relationship": "Root entry — Sylow's existence, conjugacy, and counting theorems. Sylow.card_dvd_index, card_sylow_modEq_one, and Sylow.normal_of_subsingleton used here are the formal incarnations of the second and third Sylow theorems and the uniqueness⟹normality bridge."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Sylow",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "SylowLargePrimeFactor",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/SylowTheoremOQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-02-oq-02` (m < p ⟹ Sylow p-subgroup normal).

The entry previously had only a `meta` block (no `overview`, `sections`, `conclusion`, `crossReferences`, or annotations). This pass adds:

- **annotations.json** — 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering every theorem: `sylow_card_eq` (|P| = p^a), `sylow_index_eq` ([G:P] = m), `card_sylow_eq_one` (the divisibility/congruence pinch), `sylow_normal`, and `exists_normal_sylow`.
- **overview** — historicalContext (Sylow 1872, the counting-argument engine, smallest-prime-divisor lemma), problemStatement, proofStrategy, 5 keyInsights, prerequisites.
- **sections** — 6 sections mapping the full Lean file (lines 47–123).
- **conclusion** — summary, implications, 3 open questions (sharpness for m ≥ p, multi-prime composition, Hall π-subgroup analogue).
- **crossReferences** — parent `sylow-theorem-oq-02`, siblings `sylow-theorem-oq-02-oq-01` and `sylow-theorem-oq-01`, root `sylow-theorem`.
- **leanFile** metadata block.

Axiom integrity: status `verified` / badge `original` / axiomCount 0 confirmed against the Lean source (#print axioms reports only propext/Classical.choice/Quot.sound; no structure-encoded assumptions). Validated via `annotations:build` — no errors for this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)