### PR TITLE
research(descartes-rule-oq-01-oq-01): multiplicity-aware conjugate root pairing & real-root parity [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean
@@ -1,0 +1,147 @@
+/-
+Descartes' Rule of Signs — multiplicity-aware conjugate root pairing
+(Erdős/algebra research leaf: descartes-rule-oq-01-oq-01, "Extension to Complex Roots")
+
+Source problem: https://erdosproblems.com (Descartes' rule of signs family)
+Status: original supporting theory; fully machine-checked.
+
+Context:
+The gallery entry `descartes-rule-of-signs-oq-01-oq-01` formalizes the conjugate
+root theorem and the *set-level* pairing of non-real roots of a real polynomial,
+and proves the abstract parity fact n = r + c with c even. It explicitly lists as
+OPEN the question of connecting this to Mathlib's `Polynomial.roots` multiset so
+that roots are counted *with multiplicity*. This file answers exactly that.
+
+For p : ℝ[X], write q = p.map (algebraMap ℝ ℂ) for its image in ℂ[X].
+
+Main results:
+  * `rootMultiplicity_conj` — z and its conjugate z̄ have the SAME multiplicity
+        as roots of q (multiplicity-aware conjugate root theorem). The proof
+        applies Mathlib's `eq_rootMultiplicity_map` to the conjugation
+        automorphism of ℂ, which fixes q because p has real coefficients.
+  * `count_roots_conj` — the same statement phrased via the root multiset:
+        q.roots.count z = q.roots.count z̄.
+  * `roots_map_conj` — the multiset q.roots is invariant under conjugation.
+  * `nonreal_roots_card_even` — the number of non-real roots of q, COUNTED WITH
+        MULTIPLICITY, is even (conjugation is a fixed-point-free involution
+        swapping the upper and lower half-planes).
+  * `realRoots_card_parity` — therefore the number of real roots of p counted
+        with multiplicity is congruent to deg p modulo 2. This is the
+        multiplicity-aware refinement of the gallery's parity fact, obtained by
+        combining the even non-real count with `IsAlgClosed.card_roots_eq_natDegree`.
+
+This refines the earlier set-level pairing to the level of the actual root
+multiset, with multiplicities, using only standard Mathlib (no axioms, no sorries).
+
+Tags: descartes-rule, complex-roots, conjugate-pairing, multiplicity, parity, polynomials
+-/
+
+import Mathlib
+
+namespace DescartesRuleComplexMult
+
+open Polynomial
+
+/-- The image of a real polynomial inside `ℂ[X]`. -/
+noncomputable def toC (p : ℝ[X]) : ℂ[X] := p.map (algebraMap ℝ ℂ)
+
+/-- Complex conjugation is injective (it is its own inverse). -/
+theorem conj_injective : Function.Injective (starRingEnd ℂ) :=
+  Function.LeftInverse.injective (starRingEnd_self_apply (R := ℂ))
+
+/-- A real polynomial, mapped into `ℂ[X]`, is fixed by conjugating its
+coefficients: conjugation fixes the image of every real number. -/
+theorem toC_map_conj (p : ℝ[X]) : (toC p).map (starRingEnd ℂ) = toC p := by
+  have h : (starRingEnd ℂ).comp (algebraMap ℝ ℂ) = algebraMap ℝ ℂ := by
+    ext r
+    simp [Complex.conj_ofReal]
+  simp only [toC, Polynomial.map_map, h]
+
+/-- **Multiplicity-aware conjugate root theorem.**
+For a real polynomial viewed over `ℂ`, a complex number `z` and its conjugate
+`z̄` are roots of exactly the same multiplicity. -/
+theorem rootMultiplicity_conj (p : ℝ[X]) (z : ℂ) :
+    (toC p).rootMultiplicity (starRingEnd ℂ z) = (toC p).rootMultiplicity z := by
+  have h := Polynomial.eq_rootMultiplicity_map (p := toC p) conj_injective z
+  rw [toC_map_conj] at h
+  exact h.symm
+
+/-- Conjugate roots occur with equal multiplicity in the root multiset. -/
+theorem count_roots_conj (p : ℝ[X]) (z : ℂ) :
+    (toC p).roots.count (starRingEnd ℂ z) = (toC p).roots.count z := by
+  classical
+  rw [count_roots, count_roots, rootMultiplicity_conj]
+
+/-- The root multiset of a real polynomial (over `ℂ`) is invariant under
+conjugation. -/
+theorem roots_map_conj (p : ℝ[X]) :
+    (toC p).roots.map (starRingEnd ℂ) = (toC p).roots := by
+  classical
+  refine Multiset.ext.mpr (fun w => ?_)
+  have h1 : ((toC p).roots.map (starRingEnd ℂ)).count w
+      = (toC p).roots.count (starRingEnd ℂ w) := by
+    have h := Multiset.count_map_eq_count' (starRingEnd ℂ) (toC p).roots
+      conj_injective (starRingEnd ℂ w)
+    rwa [starRingEnd_self_apply] at h
+  rw [h1]
+  exact count_roots_conj p w
+
+/-- Conjugation maps the upper-half-plane roots bijectively onto the
+lower-half-plane roots (counted with multiplicity). -/
+theorem roots_filter_neg_im (p : ℝ[X]) :
+    (toC p).roots.filter (fun z => z.im < 0)
+      = ((toC p).roots.filter (fun z => 0 < z.im)).map (starRingEnd ℂ) := by
+  classical
+  conv_lhs => rw [← roots_map_conj p]
+  rw [Multiset.filter_map]
+  congr 1
+  apply Multiset.filter_congr
+  intro z _
+  simp [Complex.conj_im]
+
+/-- **The non-real roots come in conjugate pairs**: the number of non-real roots
+of a real polynomial, counted with multiplicity, is even. -/
+theorem nonreal_roots_card_even (p : ℝ[X]) :
+    Even (Multiset.card ((toC p).roots.filter (fun z => z.im ≠ 0))) := by
+  classical
+  -- count the non-real roots as the sum over the two open half-planes
+  have hsplit : Multiset.card ((toC p).roots.filter (fun z => z.im ≠ 0))
+      = Multiset.card ((toC p).roots.filter (fun z => 0 < z.im))
+        + Multiset.card ((toC p).roots.filter (fun z => z.im < 0)) := by
+    rw [← Multiset.card_add]
+    congr 1
+    refine Multiset.ext.mpr (fun w => ?_)
+    rw [Multiset.count_add, Multiset.count_filter, Multiset.count_filter,
+      Multiset.count_filter]
+    rcases lt_trichotomy w.im 0 with h | h | h
+    · rw [if_pos (ne_of_lt h), if_neg (not_lt.mpr h.le), if_pos h, zero_add]
+    · simp [h]
+    · rw [if_pos (ne_of_gt h), if_pos h, if_neg (not_lt.mpr h.le), add_zero]
+  rw [hsplit, roots_filter_neg_im p, Multiset.card_map]
+  exact ⟨_, rfl⟩
+
+/-- **Multiplicity-aware Descartes parity.**
+The number of real roots of a real polynomial, counted with multiplicity, is
+congruent modulo 2 to the degree of the polynomial. This is the refinement, at
+the level of the root multiset, of the gallery's set-level parity fact. -/
+theorem realRoots_card_parity (p : ℝ[X]) :
+    Multiset.card ((toC p).roots.filter (fun z => z.im = 0)) ≡ p.natDegree [MOD 2] := by
+  classical
+  -- total roots with multiplicity = degree (ℂ is algebraically closed)
+  have hcard : Multiset.card (toC p).roots = p.natDegree := by
+    rw [IsAlgClosed.card_roots_eq_natDegree]
+    exact natDegree_map_eq_of_injective (algebraMap ℝ ℂ).injective p
+  -- real part + non-real part = all roots
+  have hpart : (toC p).roots.filter (fun z => z.im = 0)
+      + (toC p).roots.filter (fun z => z.im ≠ 0) = (toC p).roots := by
+    simpa using Multiset.filter_add_not (fun z : ℂ => z.im = 0) (toC p).roots
+  have hcard2 : Multiset.card ((toC p).roots.filter (fun z => z.im = 0))
+      + Multiset.card ((toC p).roots.filter (fun z => z.im ≠ 0)) = p.natDegree := by
+    rw [← Multiset.card_add, hpart, hcard]
+  obtain ⟨m, hm⟩ := nonreal_roots_card_even p
+  -- p.natDegree = realCount + 2*m, so realCount ≡ natDegree mod 2
+  refine (Nat.modEq_iff_dvd' ?_).mpr ⟨m, ?_⟩
+  · omega
+  · omega
+
+end DescartesRuleComplexMult

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-drs010101oq03-overview",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Multiplicity-Aware Conjugate Pairing",
+    "content": "The parent entry proved the conjugate root theorem and the set-level pairing of non-real roots of a real polynomial, but left open the connection to Mathlib's Polynomial.roots multiset, where roots are counted with multiplicity. This file closes that gap. Writing q = p.map (algebraMap ℝ ℂ), conjugation is a ring automorphism of ℂ that fixes q because p has real coefficients.",
+    "mathContext": "The definition toC sends p : ℝ[X] to its image in ℂ[X]; everything downstream is about the multiset q.roots.",
+    "significance": "key",
+    "relatedConcepts": ["conjugate-root-theorem", "multiplicity", "polynomials", "complex-roots"],
+    "prerequisites": ["Polynomial.map", "complex conjugation as a ring automorphism"]
+  },
+  {
+    "id": "ann-drs010101oq03-core",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 48, "endLine": 90 },
+    "type": "technique",
+    "title": "eq_rootMultiplicity_map Applied to Conjugation",
+    "content": "rootMultiplicity_conj is the crux: applying Mathlib's eq_rootMultiplicity_map to the injective conjugation automorphism gives rootMultiplicity z q = rootMultiplicity z̄ (q.map conj), and since q is fixed by conjugating its coefficients (toC_map_conj), the right side is rootMultiplicity z̄ q. count_roots then restates this at the level of the root multiset.",
+    "mathContext": "rootMult_z(q) = rootMult_{z̄}(q). The injectivity of conjugation is supplied by it being its own inverse (starRingEnd_self_apply).",
+    "significance": "key",
+    "relatedConcepts": ["eq_rootMultiplicity_map", "ring automorphism", "count_roots"],
+    "prerequisites": ["Polynomial.eq_rootMultiplicity_map", "Complex.conj_ofReal"]
+  },
+  {
+    "id": "ann-drs010101oq03-invariance",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 91, "endLine": 116 },
+    "type": "technique",
+    "title": "Conjugation-Invariance and the Half-Plane Bijection",
+    "content": "roots_map_conj shows the multiset q.roots is invariant under conjugation (equal counts everywhere). roots_filter_neg_im then shows conjugation bijects the upper-half-plane roots onto the lower-half-plane roots, because (conj z).im = -z.im. This is the multiplicity-correct replacement for the parent's set-level pairing.",
+    "mathContext": "map conj q.roots = q.roots, and filter (im<0) q.roots = map conj (filter (0<im) q.roots).",
+    "significance": "standard",
+    "relatedConcepts": ["Multiset.map", "Multiset.filter", "Complex.conj_im"],
+    "prerequisites": ["Multiset.count_map_eq_count'", "Multiset.filter_map"]
+  },
+  {
+    "id": "ann-drs010101oq03-parity",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "range": { "startLine": 117, "endLine": 147 },
+    "type": "concept",
+    "title": "Even Non-Real Count and Real-Root Parity",
+    "content": "nonreal_roots_card_even splits the non-real roots into the two open half-planes (a clean trichotomy on the imaginary part) and uses the half-plane bijection to show their total is twice a half-plane count, hence even. realRoots_card_parity then uses IsAlgClosed.card_roots_eq_natDegree (the root multiset has cardinality deg p over ℂ) to conclude that the real-root count with multiplicity is congruent to deg p modulo 2.",
+    "mathContext": "#nonreal even ⇒ #real ≡ deg p (mod 2), with all counts taken with multiplicity in q.roots.",
+    "significance": "key",
+    "relatedConcepts": ["parity", "algebraically closed fields", "root counting"],
+    "prerequisites": ["IsAlgClosed.card_roots_eq_natDegree", "Multiset.filter_add_not"]
+  }
+]

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+  "title": "Descartes Parity with Multiplicity: Conjugate Roots in the Root Multiset",
+  "slug": "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+  "description": "A multiplicity-aware refinement of the conjugate root theorem: for a real polynomial viewed over ℂ, a complex number and its conjugate occur with equal multiplicity in Mathlib's Polynomial.roots multiset. Consequently the number of non-real roots counted with multiplicity is even, and the number of real roots counted with multiplicity is congruent to the degree modulo 2. This answers the open question, posed by the parent gallery entry, of connecting the set-level pairing to root counting with multiplicity.",
+  "meta": {
+    "author": "Lean formalization (research leaf of descartes-rule-of-signs-oq-01-oq-01)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean",
+    "tags": [
+      "descartes-rule",
+      "complex-roots",
+      "conjugate-pairing",
+      "multiplicity",
+      "parity",
+      "polynomials",
+      "algebra"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.eq_rootMultiplicity_map",
+        "description": "For an injective ring hom f, rootMultiplicity a p = rootMultiplicity (f a) (p.map f)",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "Polynomial.count_roots",
+        "description": "p.roots.count a = rootMultiplicity a p",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      },
+      {
+        "theorem": "IsAlgClosed.card_roots_eq_natDegree",
+        "description": "Over an algebraically closed field, the root multiset has cardinality equal to the degree",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Complex.conj_ofReal",
+        "description": "Conjugation fixes the image of every real number",
+        "module": "Mathlib.Data.Complex.Basic"
+      }
+    ],
+    "originalContributions": [
+      "rootMultiplicity_conj: multiplicity-aware conjugate root theorem — for p : ℝ[X] viewed over ℂ, z and z̄ have equal root multiplicity. Proof applies Mathlib's eq_rootMultiplicity_map to the conjugation automorphism of ℂ, which fixes the polynomial because its coefficients are real.",
+      "count_roots_conj and roots_map_conj: the equal-multiplicity statement at the level of Mathlib's Polynomial.roots multiset, and the conjugation-invariance of that multiset.",
+      "roots_filter_neg_im: conjugation is a multiplicity-preserving bijection from the upper-half-plane roots onto the lower-half-plane roots.",
+      "nonreal_roots_card_even: the number of non-real roots counted WITH MULTIPLICITY is even.",
+      "realRoots_card_parity: the number of real roots counted with multiplicity is ≡ deg p (mod 2) — the multiplicity-aware refinement of the parent entry's set-level parity fact, answering its explicitly-stated open question."
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "0 axiom declarations, 0 sorries. All 8 theorems are fully machine-checked and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on rootMultiplicity_conj, nonreal_roots_card_even, and realRoots_card_parity; no sorryAx, no Lean.ofReduceBool). Builds clean against pinned Mathlib v4.26.",
+    "lineCount": 147,
+    "theoremCount": 8,
+    "prerequisites": [
+      "Conjugate root theorem and root multiplicities",
+      "Mathlib's Polynomial.roots multiset and count/rootMultiplicity bridge",
+      "Algebraically closed fields: card of root multiset equals degree",
+      "Multiset filtering and conjugation-invariance arguments"
+    ],
+    "definitionCount": 1,
+    "lastUpdated": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "Descartes' rule of signs bounds the number of positive real roots of a real polynomial by the number of sign changes in its coefficient sequence, and the difference is always even. The 'evenness' is a shadow of a deeper fact: the non-real roots of a real polynomial occur in conjugate pairs. The parent gallery entry (descartes-rule-of-signs-oq-01-oq-01) formalized the conjugate root theorem and the SET-level pairing of non-real roots, and proved the abstract parity identity n = r + c with c even, but left open the connection to root counting with multiplicity. This entry closes that gap by working directly with Mathlib's Polynomial.roots multiset.",
+    "problemStatement": "Connect the set-level conjugate pairing of roots of a real polynomial to Mathlib's Polynomial.roots multiset, so that conjugate roots are paired WITH MULTIPLICITY, and deduce the multiplicity-aware parity of the real-root count.",
+    "text": "For a real polynomial over ℂ, a root and its conjugate have equal multiplicity; hence the non-real roots (with multiplicity) are even in number and the real roots (with multiplicity) match the degree's parity.",
+    "proofStrategy": "Let q = p.map (algebraMap ℝ ℂ). Complex conjugation is a ring automorphism of ℂ that fixes q because p has real coefficients (conj fixes the image of every real number). Mathlib's eq_rootMultiplicity_map, applied to this injective automorphism, gives rootMultiplicity z q = rootMultiplicity z̄ (q.map conj) = rootMultiplicity z̄ q. Via count_roots this transfers to the root multiset, whose conjugation-invariance follows by comparing counts. Conjugation then bijects the upper- and lower-half-plane roots (its imaginary part flips sign), so the non-real roots split into two equinumerous half-plane parts and are even in total. Since ℂ is algebraically closed, the whole root multiset has cardinality deg p, giving the real-root parity by subtraction.",
+    "keyInsights": [
+      "Conjugation is a ring automorphism fixing real-coefficient polynomials, so Mathlib's eq_rootMultiplicity_map applies directly and gives multiplicity equality — no bespoke multiplicity bookkeeping is needed",
+      "Working at the level of Polynomial.roots (a multiset) automatically tracks multiplicities, which the earlier set-level pairing could not",
+      "The upper/lower half-plane split avoids fixed-point-free-involution machinery: conjugation sends 0 < z.im to z.im < 0 bijectively, so the non-real count is literally twice a half-plane count",
+      "Algebraic closure of ℂ supplies card(roots) = degree, turning the even non-real count into the real-root parity"
+    ],
+    "prerequisites": [
+      "Conjugate root theorem",
+      "Polynomial.roots, rootMultiplicity, and their bridge count_roots",
+      "Algebraically closed fields and root counting",
+      "Multiset filter/map manipulations"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Docstring stating the multiplicity-aware refinement and what is proved; imports Mathlib; namespace DescartesRuleComplexMult and the definition toC mapping ℝ[X] into ℂ[X]",
+      "mathContext": "q = p.map (algebraMap ℝ ℂ); conjugation fixes q since p has real coefficients."
+    },
+    {
+      "id": "multiplicity-core",
+      "title": "Multiplicity-Aware Conjugate Root Theorem",
+      "startLine": 48,
+      "endLine": 90,
+      "summary": "conj_injective, toC_map_conj, rootMultiplicity_conj, count_roots_conj — z and z̄ have equal multiplicity, via eq_rootMultiplicity_map applied to the conjugation automorphism",
+      "mathContext": "$\\operatorname{rootMult}_{\\bar z}(q) = \\operatorname{rootMult}_z(q)$; equivalently $q.\\mathrm{roots}.\\mathrm{count}\\,\\bar z = q.\\mathrm{roots}.\\mathrm{count}\\,z$."
+    },
+    {
+      "id": "invariance",
+      "title": "Root Multiset Conjugation-Invariance and Half-Plane Bijection",
+      "startLine": 91,
+      "endLine": 116,
+      "summary": "roots_map_conj (the multiset is fixed by conjugation) and roots_filter_neg_im (conjugation bijects upper-half-plane roots onto lower-half-plane roots)",
+      "mathContext": "$\\operatorname{map}\\,\\mathrm{conj}\\,(q.\\mathrm{roots}) = q.\\mathrm{roots}$ and $\\{z\\in\\mathrm{roots}: \\Im z<0\\} = \\mathrm{conj}\\,\\{z\\in\\mathrm{roots}: \\Im z>0\\}$."
+    },
+    {
+      "id": "parity",
+      "title": "Even Non-Real Count and Real-Root Parity",
+      "startLine": 117,
+      "endLine": 147,
+      "summary": "nonreal_roots_card_even and realRoots_card_parity: the non-real roots (with multiplicity) are even, hence the real roots (with multiplicity) are ≡ deg p (mod 2)",
+      "mathContext": "$\\#\\{z: \\Im z\\ne 0\\}$ even $\\Rightarrow \\#\\{z: \\Im z=0\\} \\equiv \\deg p \\pmod 2$ (counts with multiplicity, using $\\#\\mathrm{roots}=\\deg p$ over $\\mathbb{C}$)."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a real polynomial viewed over ℂ, a root and its conjugate occur with equal multiplicity in the root multiset; therefore the non-real roots counted with multiplicity are even in number and the real roots counted with multiplicity are congruent to the degree modulo 2. This refines the parent entry's set-level pairing to the level of multiplicities, answering its open question.",
+    "implications": "The multiplicity-aware pairing is the natural home for the parity behind Descartes' rule of signs and is the right foundation for a multiplicity-correct treatment of Budan–Fourier-type root counts.",
+    "openQuestions": [
+      "Can rootMultiplicity_conj be combined with a sign-variation count to obtain the full multiplicity-aware Descartes inequality (positive real roots ≤ sign variations) rather than only its parity?",
+      "Does the half-plane bijection extend to a Budan–Fourier count on an interval [a,b] with multiplicities?",
+      "Can the real-root parity be packaged as a statement about Polynomial.roots over ℝ directly (via aroots), avoiding the explicit map into ℂ?"
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial"],
+    "namespace": "DescartesRuleComplexMult",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "descartes-rule-of-signs-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Refines the parent's set-level conjugate pairing and abstract parity to the level of Mathlib's Polynomial.roots multiset, with multiplicities — answering its stated open question about root counting with multiplicity."
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling leaf under the same parent, pursuing the Budan–Fourier direction via endpoint sign variations of the derivative sequence."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/descartes-rule-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "descartes-rule-oq-01-oq-01",
   "title": "Descartes Rule of Signs: Extension to Complex Roots",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Formalized multiplicity-aware conjugate root pairing (verified, 0-axiom). For p:ℝ[X] over ℂ, z and z̄ have equal root multiplicity in Polynomial.roots; non-real roots with multiplicity are even; real roots with multiplicity ≡ deg p mod 2. Gallery: descartes-rule-of-signs-oq-01-oq-01-oq-03 / Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean.",
+    "builtItems": [
+      "rootMultiplicity_conj, count_roots_conj, roots_map_conj in Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean",
+      "roots_filter_neg_im, nonreal_roots_card_even, realRoots_card_parity in Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean"
+    ],
+    "insights": [
+      "Complex conjugation is a ring automorphism fixing real-coefficient polynomials, so Mathlib eq_rootMultiplicity_map gives multiplicity equality of z and z̄ with no bespoke bookkeeping.",
+      "Working at the Polynomial.roots multiset level tracks multiplicities the parent set-level pairing could not.",
+      "Upper/lower half-plane split (conj flips im sign) makes the non-real count literally twice a half-plane count, avoiding fixed-point-free involution machinery."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary
Answers the open question explicitly posed by the parent gallery entry **descartes-rule-of-signs-oq-01-oq-01** ("Can Mathlib's `Polynomial.roots` be connected to the complex root approach, enabling root-counting arguments with multiplicity?"). The parent proved the conjugate root theorem and the *set-level* pairing of non-real roots; this leaf refines it to the level of the root **multiset**, with multiplicities.

For `p : ℝ[X]` and `q = p.map (algebraMap ℝ ℂ)`:

- **`rootMultiplicity_conj`** — `z` and `z̄` have equal multiplicity as roots of `q`. The proof applies Mathlib's `eq_rootMultiplicity_map` to the conjugation automorphism of ℂ, which fixes `q` because `p` has real coefficients.
- **`count_roots_conj` / `roots_map_conj`** — the same statement via `Polynomial.roots`, and the conjugation-invariance of that multiset.
- **`roots_filter_neg_im`** — conjugation bijects the upper-half-plane roots onto the lower-half-plane roots (it flips the imaginary part).
- **`nonreal_roots_card_even`** — the non-real roots counted *with multiplicity* are even in number.
- **`realRoots_card_parity`** — hence the real roots counted with multiplicity are `≡ deg p (mod 2)`, via `IsAlgClosed.card_roots_eq_natDegree`.

## Status
**Outcome**: completed. 8 theorems, 1 definition, **0 sorries, 0 axiom declarations**. `#print axioms` on `rootMultiplicity_conj`, `nonreal_roots_card_even`, and `realRoots_card_parity` lists only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Builds clean against pinned Mathlib v4.26 via host `lake env lean`.

## Files
- `proofs/Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean` (new, 147 lines)
- `src/data/proofs/descartes-rule-of-signs-oq-01-oq-01-oq-03/{meta.json,annotations.json}` (new gallery entry, extends the parent)
- `src/data/research/problems/descartes-rule-oq-01-oq-01.json` (knowledge update, status → completed)

## Relationship to existing gallery
This is a new leaf under `descartes-rule-of-signs-oq-01-oq-01`, distinct from the sibling `-oq-01-oq-01-oq-02` (Budan–Fourier endpoint sign variations). It is the multiplicity-aware refinement the parent entry called for.

🤖 Generated by researcher-1