### PR TITLE
Enrich Basel problem ζ(4)=π⁴/90: deepen annotations

### DIFF
--- a/src/data/proofs/basel-problem-oq-08/annotations.json
+++ b/src/data/proofs/basel-problem-oq-08/annotations.json
@@ -4,32 +4,120 @@
     "proofId": "basel-problem-oq-08",
     "range": {
       "startLine": 1,
-      "endLine": 23
+      "endLine": 22
     },
-    "type": "concept",
+    "type": "context",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for $\\sum_{n=1}^\\infty 1/n^4 = \\pi^4/90$, the degree-4 analogue of the Basel problem $\\sum 1/n^2 = \\pi^2/6$. Euler's 1740 even-argument formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=2$ (using $B_4 = -1/30$). Mathlib formalizes the underlying Hurwitz-zeta computation, so the entry specialises it."
+    "content": "The open question asks for $\\sum_{n=1}^\\infty 1/n^4 = \\pi^4/90$, the degree-4 analogue of the Basel problem $\\sum 1/n^2 = \\pi^2/6$. Euler's 1740 even-argument formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=2$ (using the Bernoulli number $B_4 = -1/30$). Mathlib formalizes the underlying Bernoulli/Hurwitz-zeta computation as hasSum_zeta_four, so the entry's job is to specialise and repackage it: the tsum value, the riemannZeta value over ℂ, and the dimensionless Euler ratio.",
+    "mathContext": "$\\zeta(2k) = (-1)^{k+1}\\dfrac{B_{2k}(2\\pi)^{2k}}{2(2k)!}$; at $k=2$, $B_4=-\\tfrac{1}{30}$ gives $\\zeta(4)=\\tfrac{\\pi^4}{90}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Basel problem",
+      "Riemann zeta function",
+      "even-argument zeta values",
+      "Bernoulli numbers",
+      "Euler's formula"
+    ],
+    "prerequisites": [
+      "The Basel problem ζ(2) = π²/6",
+      "Bernoulli numbers and Euler's even-zeta formula",
+      "Infinite series / tsum in Lean"
+    ]
   },
   {
-    "id": "baseloq08-zeta-four",
+    "id": "baseloq08-hassum",
     "proofId": "basel-problem-oq-08",
     "range": {
-      "startLine": 24,
-      "endLine": 39
+      "startLine": 23,
+      "endLine": 26
     },
-    "type": "theorem",
-    "title": "The Value ζ(4) = π⁴/90",
-    "content": "`tsum_one_div_nat_pow_four` is the headline result $\\sum' n,\\ 1/n^4 = \\pi^4/90$, obtained as `hasSum_zeta_four.tsum_eq`. `hasSum_one_div_nat_pow_four` re-exports the `HasSum` form, and `riemannZeta_four_eq` records the same value for the analytically continued zeta function, $\\zeta(4) = \\pi^4/90$ over $\\mathbb{C}$ (Mathlib's `riemannZeta_four`)."
+    "type": "concept",
+    "title": "The Summable Family Has Sum π⁴/90 (HasSum form)",
+    "content": "hasSum_one_div_nat_pow_four re-exports Mathlib's hasSum_zeta_four: the family n ↦ 1/n⁴ HasSum π⁴/90. The HasSum predicate carries both the convergence (the net of partial sums converges) and the limit value at once, which is strictly stronger than the tsum equation and is the form needed to feed further analytic manipulations (e.g. multiplying or dividing series). It is the Bernoulli/Hurwitz-zeta even-argument computation specialised to argument 4.",
+    "mathContext": "$\\mathrm{HasSum}\\ (n \\mapsto 1/n^4)\\ (\\pi^4/90)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum predicate",
+      "summability",
+      "convergent series",
+      "ζ(4)"
+    ],
+    "prerequisites": [
+      "Mathlib's hasSum_zeta_four",
+      "The HasSum predicate vs tsum",
+      "Convergence of ∑ 1/n^s for s > 1"
+    ]
+  },
+  {
+    "id": "baseloq08-tsum",
+    "proofId": "basel-problem-oq-08",
+    "range": {
+      "startLine": 28,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "ζ(4) = π⁴/90 (the headline tsum)",
+    "content": "tsum_one_div_nat_pow_four is the headline: ∑' n, 1/n⁴ = π⁴/90, extracted from the HasSum form by hasSum_zeta_four.tsum_eq (a HasSum statement determines the tsum). This is the degree-4 Basel value, the second even zeta value after ζ(2) = π²/6. Its appearance of π⁴ (an irrational, indeed transcendental, multiple of the rational 1/90) reflects the deep fact that even zeta values are rational multiples of powers of π.",
+    "mathContext": "$\\displaystyle\\sum_{n=1}^{\\infty} \\frac{1}{n^4} = \\frac{\\pi^4}{90}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "tsum",
+      "ζ(4)",
+      "even zeta values",
+      "powers of π"
+    ],
+    "prerequisites": [
+      "HasSum.tsum_eq (a HasSum value is the tsum)",
+      "hasSum_one_div_nat_pow_four",
+      "The Basel problem as the k=1 analogue"
+    ]
+  },
+  {
+    "id": "baseloq08-riemann",
+    "proofId": "basel-problem-oq-08",
+    "range": {
+      "startLine": 33,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "The Analytically Continued ζ(4) over ℂ",
+    "content": "riemannZeta_four_eq records riemannZeta 4 = π⁴/90 over ℂ (Mathlib's riemannZeta_four). This is the same value, but for the analytically continued Riemann zeta function rather than the real Dirichlet series — at s = 4 the series converges, so the continuation agrees with the sum, but stating it for riemannZeta ties the entry to the full complex-analytic object whose nontrivial zeros are the subject of the Riemann hypothesis.",
+    "mathContext": "$\\zeta(4) = \\dfrac{\\pi^4}{90}$ for the analytically continued $\\zeta : \\mathbb{C}\\to\\mathbb{C}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Riemann zeta function",
+      "analytic continuation",
+      "Dirichlet series",
+      "complex analysis"
+    ],
+    "prerequisites": [
+      "Mathlib's riemannZeta and riemannZeta_four",
+      "Analytic continuation of the zeta function",
+      "Agreement of continuation and series for Re(s) > 1"
+    ]
   },
   {
     "id": "baseloq08-ratio",
     "proofId": "basel-problem-oq-08",
     "range": {
-      "startLine": 41,
-      "endLine": 47
+      "startLine": 37,
+      "endLine": 45
     },
-    "type": "theorem",
+    "type": "insight",
     "title": "Euler's π-free Ratio ζ(4)/ζ(2)² = 2/5",
-    "content": "`tsum_four_div_tsum_two_sq` divides the two classical even-zeta values: $\\zeta(4)/\\zeta(2)^2 = (\\pi^4/90)/(\\pi^2/6)^2 = (\\pi^4/90)/(\\pi^4/36) = 36/90 = 2/5$. The factor of $\\pi^4$ cancels, so the ratio is a rational number determined purely by the Bernoulli numbers, independent of the transcendence of $\\pi$. Proved by rewriting both sums and finishing with `field_simp` (using $\\pi \\neq 0$) and `ring`."
+    "content": "tsum_four_div_tsum_two_sq divides the two classical even-zeta values: ζ(4)/ζ(2)² = (π⁴/90)/(π²/6)² = (π⁴/90)/(π⁴/36) = 36/90 = 2/5. The factor of π⁴ cancels exactly, so the ratio is a rational number determined purely by the Bernoulli numbers, completely independent of the transcendence of π — a clean instance of the general fact that ratios ζ(2k)/ζ(2)^k are rational. The proof rewrites both sums (tsum_one_div_nat_pow_four and hasSum_zeta_two.tsum_eq) and finishes with field_simp (using π ≠ 0, via Real.pi_ne_zero) and ring.",
+    "mathContext": "$\\dfrac{\\zeta(4)}{\\zeta(2)^2} = \\dfrac{\\pi^4/90}{(\\pi^2/6)^2} = \\dfrac{36}{90} = \\dfrac{2}{5}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's even-zeta ratios",
+      "rationality of ζ(2k)/ζ(2)^k",
+      "cancellation of π",
+      "Bernoulli numbers"
+    ],
+    "prerequisites": [
+      "Both even-zeta values ζ(2) = π²/6 and ζ(4) = π⁴/90",
+      "field_simp and ring with π ≠ 0 (Real.pi_ne_zero)",
+      "Rationality of even-zeta ratios"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment (deepening) pass for `basel-problem-oq-08` (ζ(4) = π⁴/90 and the π-free ratio ζ(4)/ζ(2)² = 2/5).

## What this adds
The entry was already meta-rich (overview, sections, conclusion all present), but its 3 annotations carried only `content` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. This PR:

- **Expands 3 → 5 annotations**, splitting the zeta-four block into the `HasSum` form, the `tsum` headline, and the analytically-continued `riemannZeta` value (each is a distinct theorem in the file).
- Adds **`mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`** to every annotation.
- Frames ζ(4) as the degree-4 Basel value, the HasSum-vs-tsum distinction, the complex-analytic continuation, and the rationality of even-zeta ratios (π cancels in ζ(4)/ζ(2)²).

## Validation
- JSON valid; `annotations:build --strict` resolves every annotation in this entry to a Lean construct.
- Axiom integrity unchanged: `status`/`badge`/`axiomCount` untouched.