### PR TITLE
research(compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02): Cantor intersection theorem for complete metric spaces [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean
@@ -1,0 +1,116 @@
+/-
+# The Cantor Intersection Theorem for Complete Metric Spaces
+
+A nested sequence of nonempty, closed, bounded sets
+
+  s₀ ⊇ s₁ ⊇ s₂ ⊇ ⋯
+
+in a **complete** metric space whose diameters shrink to `0` has an intersection
+that is **exactly one point**:
+
+  ⋂ₙ sₙ = {x}.
+
+This is the metric-space form of the Cantor intersection theorem. The parent entry
+(`compactness-finite-subcover-oq-01-oq-02-oq-01`) handles the special case of nested
+closed *intervals* in `ℝ` shrinking to a point. Here we generalize to an arbitrary
+complete metric space and, crucially, prove the **singleton characterization**:
+existence *and* uniqueness of the limit point.
+
+## What is new relative to Mathlib
+
+Mathlib's `Metric.nonempty_iInter_of_nonempty_biInter` gives only that the
+intersection is **nonempty** (and from *finite-intersection* hypotheses, not from a
+nested family). It says nothing about uniqueness. This file:
+
+1. derives the finite-intersection hypothesis from the natural *nested + nonempty*
+   hypotheses (so the existence half applies), and
+2. adds the **uniqueness** half — any two points of the intersection are within
+   `diam (sₙ)` of each other for every `n`, and `diam (sₙ) → 0`, forcing them to
+   coincide — packaging the result as `⋂ₙ sₙ = {x}` and `∃! x, x ∈ ⋂ₙ sₙ`.
+
+The completeness hypothesis is essential: in an incomplete space (e.g. `ℚ`) such an
+intersection can be empty.
+
+This file contains no `axiom`s and no `sorry`s.
+
+## References
+- Cantor, G. (1879–1884). Über unendliche, lineare Punktmannigfaltigkeiten.
+- Mathlib: `Mathlib.Topology.MetricSpace.Bounded`
+  (`Metric.nonempty_iInter_of_nonempty_biInter`).
+-/
+import Mathlib.Topology.MetricSpace.Bounded
+import Mathlib.Tactic
+
+set_option linter.unusedSectionVars false
+
+open Metric Filter Topology Set
+
+namespace CantorIntersection
+
+variable {α : Type*} [MetricSpace α] [CompleteSpace α] {s : ℕ → Set α}
+
+/-- For a **nested decreasing** family, every finite "prefix" intersection
+`⋂ n ≤ N, s n` equals the last (smallest) set `s N`, hence is nonempty whenever
+each `s n` is. This converts the natural nested hypothesis into the
+finite-intersection hypothesis required by `nonempty_iInter_of_nonempty_biInter`. -/
+theorem biInter_nonempty_of_antitone
+    (hne : ∀ n, (s n).Nonempty) (hnest : ∀ n, s (n + 1) ⊆ s n) (N : ℕ) :
+    (⋂ n ≤ N, s n).Nonempty := by
+  have hanti : Antitone s := antitone_nat_of_succ_le hnest
+  obtain ⟨x, hx⟩ := hne N
+  refine ⟨x, ?_⟩
+  simp only [mem_iInter]
+  intro n hn
+  exact hanti hn hx
+
+/-- **Existence (Cantor intersection, complete metric space).** A nested sequence of
+nonempty closed bounded sets with diameters tending to `0` has nonempty
+intersection. -/
+theorem nonempty_iInter
+    (hne : ∀ n, (s n).Nonempty) (hclosed : ∀ n, IsClosed (s n))
+    (hbdd : ∀ n, Bornology.IsBounded (s n)) (hnest : ∀ n, s (n + 1) ⊆ s n)
+    (hdiam : Tendsto (fun n => diam (s n)) atTop (𝓝 0)) :
+    (⋂ n, s n).Nonempty :=
+  nonempty_iInter_of_nonempty_biInter hclosed hbdd
+    (biInter_nonempty_of_antitone hne hnest) hdiam
+
+/-- **Uniqueness.** If the diameters tend to `0`, the intersection contains at most
+one point: any two of its points are within `diam (s n)` for every `n`, and that
+bound goes to `0`. -/
+theorem subsingleton_iInter
+    (hbdd : ∀ n, Bornology.IsBounded (s n))
+    (hdiam : Tendsto (fun n => diam (s n)) atTop (𝓝 0)) :
+    (⋂ n, s n).Subsingleton := by
+  intro x hx y hy
+  simp only [mem_iInter] at hx hy
+  -- `dist x y ≤ diam (s n)` for every `n`.
+  have hbound : ∀ n, dist x y ≤ diam (s n) := fun n =>
+    dist_le_diam_of_mem (hbdd n) (hx n) (hy n)
+  -- Passing to the limit, `dist x y ≤ 0`, hence `x = y`.
+  have hle : dist x y ≤ 0 := ge_of_tendsto hdiam (Eventually.of_forall hbound)
+  exact dist_le_zero.mp hle
+
+/-- **Cantor Intersection Theorem (singleton form).** A nested sequence of nonempty
+closed bounded sets with diameters tending to `0` in a complete metric space
+intersects in exactly one point. -/
+theorem iInter_eq_singleton
+    (hne : ∀ n, (s n).Nonempty) (hclosed : ∀ n, IsClosed (s n))
+    (hbdd : ∀ n, Bornology.IsBounded (s n)) (hnest : ∀ n, s (n + 1) ⊆ s n)
+    (hdiam : Tendsto (fun n => diam (s n)) atTop (𝓝 0)) :
+    ∃ x, (⋂ n, s n) = {x} := by
+  obtain ⟨x, hx⟩ := nonempty_iInter hne hclosed hbdd hnest hdiam
+  exact ⟨x, (subsingleton_iInter hbdd hdiam).eq_singleton_of_mem hx⟩
+
+/-- **Cantor Intersection Theorem (`∃!` form).** There is a unique point common to
+all the sets. -/
+theorem existsUnique_mem_iInter
+    (hne : ∀ n, (s n).Nonempty) (hclosed : ∀ n, IsClosed (s n))
+    (hbdd : ∀ n, Bornology.IsBounded (s n)) (hnest : ∀ n, s (n + 1) ⊆ s n)
+    (hdiam : Tendsto (fun n => diam (s n)) atTop (𝓝 0)) :
+    ∃! x, x ∈ ⋂ n, s n := by
+  obtain ⟨x, hx⟩ := iInter_eq_singleton hne hclosed hbdd hnest hdiam
+  refine ⟨x, ?_, ?_⟩
+  · rw [hx]; exact rfl
+  · intro y hy; rw [hx] at hy; exact hy
+
+end CantorIntersection

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+  "title": "The Cantor Intersection Theorem for Complete Metric Spaces",
+  "slug": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+  "description": "A nested sequence of nonempty, closed, bounded sets s₀ ⊇ s₁ ⊇ s₂ ⊇ ⋯ in a complete metric space whose diameters shrink to 0 intersects in exactly one point: ⋂ₙ sₙ = {x}. The parent entry handles nested closed intervals in ℝ; this entry generalizes to an arbitrary complete metric space and proves the full singleton characterization — existence and uniqueness. Mathlib's library lemma gives only nonemptiness (and from finite-intersection hypotheses); this entry derives the finite-intersection hypothesis from the natural nested+nonempty form and adds the uniqueness half via a diameter-to-zero argument.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_intersection_theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean",
+    "tags": [
+      "topology",
+      "metric-spaces",
+      "completeness",
+      "cantor-intersection-theorem",
+      "real-analysis",
+      "axiom-free",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Metric.nonempty_iInter_of_nonempty_biInter",
+        "description": "In a complete space, closed bounded sets with diam → 0 and nonempty finite intersections have nonempty total intersection (the existence half)",
+        "module": "Mathlib.Topology.MetricSpace.Bounded"
+      },
+      {
+        "theorem": "Metric.dist_le_diam_of_mem",
+        "description": "Two points of a bounded set are within its diameter",
+        "module": "Mathlib.Topology.MetricSpace.Bounded"
+      },
+      {
+        "theorem": "ge_of_tendsto",
+        "description": "Passing an eventual lower bound to the limit of a convergent sequence",
+        "module": "Mathlib.Topology.Order.Basic"
+      },
+      {
+        "theorem": "antitone_nat_of_succ_le",
+        "description": "A sequence with s(n+1) ⊆ s n is antitone, so s N ⊆ s n for n ≤ N",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Set.Subsingleton.eq_singleton_of_mem",
+        "description": "A subsingleton set containing a point equals that singleton",
+        "module": "Mathlib.Data.Set.Basic"
+      }
+    ],
+    "originalContributions": [
+      "0-axiom proof of the Cantor intersection theorem in singleton form (`#print axioms` shows only propext / Classical.choice / Quot.sound)",
+      "biInter_nonempty_of_antitone: converts the natural nested+nonempty hypotheses into the finite-intersection hypothesis Mathlib's existence lemma requires (⋂ n ≤ N, s n is nonempty because s N ⊆ each s n)",
+      "nonempty_iInter: the existence half stated for a nested family, bridging to Mathlib's biInter formulation",
+      "subsingleton_iInter: the uniqueness half — any two points of the intersection satisfy dist x y ≤ diam (s n) for all n, and diam → 0 forces dist x y = 0",
+      "iInter_eq_singleton: the full Cantor theorem ⋂ₙ sₙ = {x}, combining existence and uniqueness, which Mathlib does not state",
+      "existsUnique_mem_iInter: the ∃! packaging of the theorem"
+    ],
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 116,
+    "assumptions": "None. Fully machine-checked; #print axioms reports only propext, Classical.choice, Quot.sound (the standard foundational axioms, which do not count as assumptions). No native_decide, no Lean.ofReduceBool. The mathematical hypotheses (nonempty, closed, bounded, nested, diam → 0, complete space) are explicit antecedents of the theorems, not global axioms.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's intersection theorem (Georg Cantor, 1879–1884) is a cornerstone of point-set topology and real analysis: it characterizes completeness through nested sets. On the real line it specializes to the nested interval property [aₙ, bₙ] with bₙ − aₙ → 0, which underlies the construction of real numbers and the proof of the Bolzano–Weierstrass and Heine–Borel theorems. In a general metric space the theorem holds precisely when the space is complete: completeness is equivalent to the statement that every nested sequence of nonempty closed sets with diameters tending to zero has nonempty intersection.",
+    "problemStatement": "OQ-01-OQ-02-OQ-01-OQ-02: The parent entry establishes that nested closed intervals in ℝ shrink to a single point. Does the result generalize to an arbitrary complete metric space, and can the intersection be characterized exactly — not merely as nonempty (Mathlib's library lemma) but as a single point, proving uniqueness as well as existence?",
+    "text": "A 0-axiom formalization of the Cantor intersection theorem for complete metric spaces in its sharpest form: a nested sequence of nonempty closed bounded sets with diameters tending to 0 intersects in exactly one point. The entry supplies both the bridge from nested+nonempty hypotheses to Mathlib's finite-intersection existence lemma and the uniqueness argument that Mathlib omits.",
+    "proofStrategy": "Let s : ℕ → Set α be nested decreasing (s(n+1) ⊆ s n), with each s n nonempty, closed, bounded, and diam (s n) → 0, in a complete metric space.\n\n1. **Finite intersections are nonempty** (`biInter_nonempty_of_antitone`): nestedness gives s N ⊆ s n for all n ≤ N (antitone), so a point of s N lies in ⋂ n ≤ N, s n. This is exactly the hypothesis Mathlib's existence lemma needs.\n2. **Existence** (`nonempty_iInter`): apply `Metric.nonempty_iInter_of_nonempty_biInter` with the closed/bounded/finite-intersection/diam → 0 hypotheses to get a point in ⋂ n, s n.\n3. **Uniqueness** (`subsingleton_iInter`): if x, y ∈ ⋂ n, s n then dist x y ≤ diam (s n) for every n by `dist_le_diam_of_mem`; since diam (s n) → 0, `ge_of_tendsto` gives dist x y ≤ 0, hence x = y.\n4. **Singleton** (`iInter_eq_singleton`): a nonempty subsingleton set is a singleton, so ⋂ n, s n = {x}; the `∃!` form follows.\n\nCompleteness enters only through step 2 (Mathlib's lemma); the uniqueness half needs only diam → 0.",
+    "keyInsights": [
+      "**Nested + nonempty ⟹ finite intersections nonempty.** Antitonicity collapses each prefix intersection ⋂ n ≤ N, s n to the smallest set s N, which is nonempty — converting the textbook hypothesis into the form Mathlib's existence lemma consumes.",
+      "**Diameter controls uniqueness.** Two points common to all sets are within diam (s n) for every n; with diam → 0 their distance is squeezed to 0. Existence and uniqueness are powered by two different consequences of diam → 0.",
+      "**Completeness is exactly what makes existence hold.** The same nested family in ℚ (e.g. closed sets trapping √2) has empty intersection; completeness is the precise hypothesis that rescues nonemptiness, isolating where the analytic content lives.",
+      "**Singleton beats nonempty.** Mathlib stops at nonemptiness; packaging the result as ⋂ₙ sₙ = {x} and ∃! x captures the full theorem analysts actually use to extract the limit point."
+    ],
+    "prerequisites": [
+      "Metric spaces: distance, diameter of a bounded set, closed sets",
+      "Completeness of a metric space and Cauchy sequences",
+      "Convergence of real sequences and passing inequalities to the limit",
+      "Set operations: indexed and bounded intersections, subsingletons and singletons"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Statement",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring explaining the Cantor intersection theorem, the generalization from ℝ-intervals to complete metric spaces, and what is new relative to Mathlib (uniqueness / singleton form, and the bridge from nested to finite-intersection hypotheses). Imports `Mathlib.Topology.MetricSpace.Bounded`, opens `Metric`/`Filter`/`Topology`/`Set`, and declares the ambient complete metric space with a sequence s : ℕ → Set α.",
+      "mathContext": "Sets up a nested decreasing family of nonempty closed bounded sets with diameters tending to 0 in a complete metric space — the exact hypotheses of the Cantor intersection theorem."
+    },
+    {
+      "id": "biinter-nonempty",
+      "title": "Finite Intersections Are Nonempty",
+      "startLine": 52,
+      "endLine": 64,
+      "summary": "`biInter_nonempty_of_antitone`: for a nested decreasing family, ⋂ n ≤ N, s n is nonempty. Uses `antitone_nat_of_succ_le` to get s N ⊆ s n for n ≤ N, then exhibits a point of s N in the prefix intersection.",
+      "mathContext": "Converts the natural nested+nonempty hypothesis into the finite-intersection hypothesis required by Mathlib's existence lemma; the prefix intersection collapses to the smallest set s N."
+    },
+    {
+      "id": "existence",
+      "title": "Existence of a Common Point",
+      "startLine": 66,
+      "endLine": 75,
+      "summary": "`nonempty_iInter`: the total intersection ⋂ n, s n is nonempty, by feeding the closed/bounded/finite-intersection/diam → 0 hypotheses into `Metric.nonempty_iInter_of_nonempty_biInter`.",
+      "mathContext": "The existence half of the Cantor theorem, where completeness of the space is the essential ingredient (supplied by the Mathlib lemma)."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness via Shrinking Diameter",
+      "startLine": 77,
+      "endLine": 91,
+      "summary": "`subsingleton_iInter`: any two points x, y of the intersection satisfy dist x y ≤ diam (s n) for every n (`dist_le_diam_of_mem`); passing to the limit with `ge_of_tendsto` and diam → 0 gives dist x y ≤ 0, hence x = y.",
+      "mathContext": "The uniqueness half, needing only diam → 0 (not completeness): a point common to all sets is pinned down to within every diameter, and the diameters vanish."
+    },
+    {
+      "id": "singleton",
+      "title": "The Intersection Is a Single Point",
+      "startLine": 93,
+      "endLine": 116,
+      "summary": "`iInter_eq_singleton` combines existence and uniqueness into ⋂ n, s n = {x} via `Set.Subsingleton.eq_singleton_of_mem`; `existsUnique_mem_iInter` repackages this as ∃! x, x ∈ ⋂ n, s n.",
+      "mathContext": "The full Cantor intersection theorem in the form used in analysis: the nested family determines a unique limit point."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 116-line, 5-theorem, 0-sorry, axiom-free formalization of the Cantor intersection theorem for complete metric spaces in singleton form: a nested sequence of nonempty closed bounded sets with diameters tending to 0 intersects in exactly one point. It strengthens both the parent ℝ-interval entry (by generalizing to any complete metric space) and Mathlib's library lemma (by adding uniqueness, which Mathlib omits). `#print axioms` reports only propext / Classical.choice / Quot.sound.",
+    "implications": "The singleton characterization is the form analysts actually invoke — to extract the limit point of a contracting construction (e.g. the Banach fixed-point theorem, the construction of self-similar fractals, or completeness proofs). Separating the existence half (which needs completeness) from the uniqueness half (which needs only diam → 0) clarifies exactly where each hypothesis is used and makes the completeness ⟺ Cantor-property equivalence transparent.",
+    "openQuestions": [
+      "Can the converse be formalized: if every nested sequence of nonempty closed sets with diam → 0 has nonempty intersection, then the metric space is complete?",
+      "Does the singleton form yield a clean Lean proof of the Banach fixed-point theorem by applying it to the nested closed balls around the iterates of a contraction?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+      "relationship": "Parent entry: nested closed intervals in ℝ shrinking to a point; this entry generalizes to complete metric spaces and adds the singleton characterization"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Topology.MetricSpace.Bounded",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Metric",
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "CantorIntersection",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "G. Cantor",
+      "title": "Über unendliche, lineare Punktmannigfaltigkeiten",
+      "year": "1879–1884",
+      "venue": "Mathematische Annalen",
+      "note": "Origin of the nested-set intersection theorem"
+    },
+    {
+      "authors": "W. Rudin",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "Theorem 3.10: nested compact / closed sets and the metric completeness connection"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves the nested-interval property on ℝ; this entry generalizes it to an arbitrary complete metric space and proves the full singleton (existence + uniqueness) characterization."
+    },
+    {
+      "targetId": "compactness-finite-subcover",
+      "relationship": "related",
+      "description": "Root compactness theme: the finite-intersection / nested-set viewpoint here is the metric, sequential counterpart of the finite-subcover characterization of compactness."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02.json
@@ -1,0 +1,48 @@
+{
+  "slug": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+  "title": "The Cantor Intersection Theorem for Complete Metric Spaces",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 7,
+  "tractability": 7,
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "path": "proofs/Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean",
+  "problemStatement": "Generalize the parent's nested-closed-interval-in-ℝ result to an arbitrary complete metric space, and characterize the intersection exactly: a nested sequence of nonempty closed bounded sets with diameters tending to 0 intersects in exactly one point (⋂ₙ sₙ = {x}). Mathlib's library lemma gives only nonemptiness, from finite-intersection hypotheses; prove the uniqueness half and bridge from the natural nested+nonempty form.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: 0-axiom, 5-theorem, 116-line formalization of the Cantor intersection theorem in singleton form for complete metric spaces. Verified, badge original. PR opened.",
+    "insights": [
+      "Mathlib's Metric.nonempty_iInter_of_nonempty_biInter supplies only the existence half, and it takes finite-intersection (⋂ n ≤ N) hypotheses rather than the textbook nested form — so a bridge lemma is needed.",
+      "Antitonicity (antitone_nat_of_succ_le) collapses each prefix intersection ⋂ n ≤ N, s n to the smallest set s N, which is nonempty; this converts nested+nonempty into the finite-intersection hypothesis Mathlib consumes.",
+      "Uniqueness needs only diam → 0, NOT completeness: any two points common to all sets are within diam (s n) for every n (dist_le_diam_of_mem), and ge_of_tendsto squeezes their distance to 0. Existence and uniqueness draw on two different consequences of diam → 0.",
+      "Completeness is precisely the hypothesis that rescues existence: the same nested family in ℚ can have empty intersection. Separating the two halves isolates where the analytic content lives."
+    ],
+    "builtItems": [
+      "biInter_nonempty_of_antitone (CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean:56): nested+nonempty ⟹ ⋂ n ≤ N, s n nonempty",
+      "nonempty_iInter (:69): existence half for a nested family via the Mathlib lemma",
+      "subsingleton_iInter (:80): uniqueness half via dist ≤ diam → 0",
+      "iInter_eq_singleton (:96): full Cantor theorem ⋂ₙ sₙ = {x}",
+      "existsUnique_mem_iInter (:106): ∃! packaging"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the nonemptiness of the intersection but no singleton/uniqueness statement and no nested-family (antitone) wrapper for the Cantor intersection theorem."
+    ],
+    "nextSteps": [
+      "Formalize the converse (Cantor property ⟹ completeness).",
+      "Derive the Banach fixed-point theorem by applying the singleton form to nested closed balls around the iterates of a contraction."
+    ],
+    "markdown": ""
+  },
+  "knownResults": [],
+  "references": [],
+  "relatedProofs": [
+    "compactness-finite-subcover-oq-01-oq-02-oq-01"
+  ],
+  "tags": [
+    "topology",
+    "metric-spaces",
+    "completeness",
+    "cantor-intersection-theorem"
+  ]
+}


### PR DESCRIPTION
## Summary

The **Cantor Intersection Theorem** for complete metric spaces, in its sharpest (singleton) form: a nested sequence of nonempty, closed, bounded sets
\`s₀ ⊇ s₁ ⊇ s₂ ⊇ ⋯\` whose diameters tend to 0 in a **complete** metric space intersects in **exactly one point**:

\`\`\`
⋂ₙ sₙ = {x}
\`\`\`

This **generalizes the parent entry** (`compactness-finite-subcover-oq-01-oq-02-oq-01`, nested closed *intervals* in ℝ) to an arbitrary complete metric space, and proves the **uniqueness** half that Mathlib's library lemma omits.

## What is new relative to Mathlib

Mathlib's `Metric.nonempty_iInter_of_nonempty_biInter` gives only that the intersection is **nonempty**, and from *finite-intersection* hypotheses rather than a nested family. This entry:

1. `biInter_nonempty_of_antitone` — derives the finite-intersection hypothesis from the natural *nested + nonempty* form (antitonicity collapses `⋂ n ≤ N, s n` to `s N`).
2. `subsingleton_iInter` — the **uniqueness** half: any two points of the intersection are within `diam (sₙ)` for every `n`, and `diam → 0` squeezes their distance to 0. (Notably, uniqueness needs only `diam → 0`, *not* completeness.)
3. `iInter_eq_singleton` / `existsUnique_mem_iInter` — package the full theorem as `⋂ₙ sₙ = {x}` and `∃! x`.

## Verification

- **5 theorems, 116 lines, 0 sorries.**
- **0 axioms**: `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`. No `native_decide`, no `Lean.ofReduceBool`.
- Builds against Mathlib 4.26.0 (`lake env lean`).

## Files

- `proofs/Proofs/CompactnessFiniteSubcoverOQ01OQ02OQ01OQ02.lean`
- `src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02/meta.json`
- `src/data/research/problems/compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)