### PR TITLE
Enrich Pell regulator infinite-order: add inline annotations

### DIFF
--- a/src/data/proofs/pell-equation-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-pell-defs",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 48,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "The Pell Norm and Regulator (pellNorm, pellRegulator)",
+    "content": "pellNorm d x y = x + y√d is the real embedding of a Pell solution, sending the abstract solution a ∈ Solution₁ d (a pair (x,y) with x² − d·y² = 1) to a concrete real number under the ring embedding ℤ[√d] ↪ ℝ. pellRegulator d a = log(pellNorm d a.x a.y) is its logarithm — the 'length' of a solution on a logarithmic scale. These match the grandparent's definitions and set up the whole strategy: the multiplicative structure of Pell solutions (composition a·b) becomes additive under log, so the cyclic subgroup ⟨a⟩ is measured by an arithmetic-progression ruler n ↦ R(aⁿ) = n·R(a).",
+    "mathContext": "$\\|a\\| = x + y\\sqrt d,\\qquad R(a) = \\log\\|a\\|$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Pell's equation x² − d·y² = 1 and Mathlib's Solution₁ d",
+      "The real embedding ℤ[√d] ↪ ℝ",
+      "Logarithm turning products into sums"
+    ],
+    "relatedConcepts": [
+      "Pell's equation",
+      "real quadratic field",
+      "regulator",
+      "fundamental solution"
+    ]
+  },
+  {
+    "id": "ann-pell-norm-infra",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 116
+    },
+    "type": "technique",
+    "title": "The Parent Norm Homomorphism and the zpow Law",
+    "content": "This block restates the parent's multiplicative infrastructure. pellNorm_one (‖1‖ = 1), pellNorm_mul (Brahmagupta's identity: ‖a·b‖ = ‖a‖·‖b‖, proved by linear_combination against √d² = d), pellNorm_mul_inv (‖a‖·‖a⁻¹‖ = 1, using the Pell relation x² − d·y² = 1), pellNorm_ne_zero, and pellNorm_inv together make pellNorm a group homomorphism Solution₁ d → ℝˣ. pellNorm_zpow (‖aⁿ‖ = ‖a‖ⁿ for all n ∈ ℤ, by Int.induction_on) and pellRegulator_zpow (R(aⁿ) = n·R(a), by Real.log_zpow) are the punchline: the regulator is ℤ-linear along the cyclic subgroup ⟨a⟩. Everything downstream consumes only pellRegulator_zpow.",
+    "mathContext": "$\\|a b\\| = \\|a\\|\\,\\|b\\|,\\quad \\|a^n\\| = \\|a\\|^n,\\quad R(a^n) = n\\,R(a)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Brahmagupta's composition identity for Pell solutions",
+      "Int.induction_on and zpow lemmas (zpow_add_one, zpow_sub_one)",
+      "Real.log_zpow (log of an integer power)"
+    ],
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci identity",
+      "norm-multiplicativity",
+      "group homomorphism",
+      "ℤ-linear regulator"
+    ]
+  },
+  {
+    "id": "ann-pell-positivity",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 118,
+      "endLine": 131
+    },
+    "type": "insight",
+    "title": "The Origin and Positivity of the Regulator (the key inequality)",
+    "content": "The order/faithfulness layer hinges on a single inequality. pellRegulator_one places the identity at the origin of the ruler: R(1) = log‖(1,0)‖ = log 1 = 0. pellRegulator_pos is the crux: if ‖a‖ > 1 then R(a) = log‖a‖ > 0 (Real.log_pos). This is the ONLY obstruction to infinite order — a Pell solution has infinite order unless ‖a‖ = 1. As soon as ‖a‖ > 1 the ℤ-linear law R(aⁿ) = n·R(a) becomes a strictly increasing ruler, and everything below is pure order theory on (ℝ, +, <).",
+    "mathContext": "$R(1) = 0$; $\\ \\|a\\| > 1 \\Rightarrow R(a) = \\log\\|a\\| > 0$ (Real.log_pos).",
+    "significance": "key",
+    "prerequisites": [
+      "Real.log_pos: log x > 0 for x > 1",
+      "Real.log_one and pellNorm_one",
+      "The ℤ-linear law pellRegulator_zpow"
+    ],
+    "relatedConcepts": [
+      "positivity of the regulator",
+      "logarithm monotonicity",
+      "ordered additive group",
+      "obstruction to finite order"
+    ]
+  },
+  {
+    "id": "ann-pell-mono-inj",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 133,
+      "endLine": 154
+    },
+    "type": "insight",
+    "title": "Strict Monotonicity and Injectivity of the Power Map",
+    "content": "pellRegulator_zpow_strictMono shows n ↦ R(a⁇) is StrictMono when ‖a‖ > 1: since R(aⁿ) = n·R(a) with R(a) > 0, scaling by a positive real preserves strict order (mul_lt_mul_of_pos_right). The regulator is thus a faithful, order-preserving ruler for the cyclic subgroup ⟨a⟩ — it embeds (ℤ, +, <) into (ℝ, +, <). zpow_injective then reads off faithfulness: n ↦ aⁿ is injective, because aᵐ = aⁿ forces R(aᵐ) = R(aⁿ), and a strictly monotone function is injective. No two integer powers of a coincide.",
+    "mathContext": "$R(a^n) = n\\,R(a)$ with $R(a)>0 \\Rightarrow n \\mapsto R(a^n)$ strictly increasing $\\Rightarrow n \\mapsto a^n$ injective.",
+    "significance": "key",
+    "prerequisites": [
+      "pellRegulator_pos (R(a) > 0) and the ℤ-linear law",
+      "mul_lt_mul_of_pos_right (positive scaling preserves order)",
+      "StrictMono.injective"
+    ],
+    "relatedConcepts": [
+      "strict monotonicity",
+      "injective power map",
+      "faithful action",
+      "embedding ℤ ↪ ℝ"
+    ]
+  },
+  {
+    "id": "ann-pell-infinite-order",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 156,
+      "endLine": 178
+    },
+    "type": "concept",
+    "title": "Infinite Order (orderOf_eq_zero, not_isOfFinOrder)",
+    "content": "orderOf_eq_zero is the headline answer to the parent's open question: a Pell solution with ‖a‖ > 1 has orderOf a = 0 (infinite order). Via orderOf_eq_zero_iff', suppose some positive power aⁿ = 1; applying the regulator gives 0 = R(1) = R(aⁿ) = n·R(a) with both n > 0 and R(a) > 0 — contradiction (the product is strictly positive). not_isOfFinOrder restates this through Mathlib's predicate: ¬ IsOfFinOrder a (orderOf_eq_zero_iff). Together with the fundamental solution being > 1, this is why Solution₁ d is infinite for non-square d: the cyclic subgroup ⟨a⟩ ≅ ℤ is a free copy of the integers measured by the regulator.",
+    "mathContext": "$a^n = 1,\\ n>0 \\Rightarrow 0 = n\\,R(a) > 0$, contradiction; so $\\mathrm{orderOf}\\,a = 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "orderOf_eq_zero_iff' and orderOf_eq_zero_iff (Mathlib order predicates)",
+      "pellRegulator_one, pellRegulator_pos, pellRegulator_zpow",
+      "mul_pos and lt_irrefl for the contradiction"
+    ],
+    "relatedConcepts": [
+      "order of a group element",
+      "infinite cyclic group",
+      "torsion-free",
+      "structure of the Pell solution group"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-01-oq-04-oq-02` (a Pell solution with ‖a‖ > 1 has infinite order, via the strictly positive regulator).

## What this adds
The entry was meta-rich (overview, 5 sections, conclusion) but had **no `annotations.json`**. This PR creates it with 5 substantive annotations covering the full Lean file:

1. **pellNorm / pellRegulator** — the real embedding ‖a‖ = x + y√d and its log.
2. **parent norm infrastructure** — Brahmagupta multiplicativity, the homomorphism, and the ℤ-linear law R(aⁿ) = n·R(a).
3. **origin & positivity** — the single key inequality: ‖a‖ > 1 ⟹ R(a) > 0 (Real.log_pos).
4. **strict monotonicity & injectivity** — n ↦ R(aⁿ) StrictMono ⟹ n ↦ aⁿ injective.
5. **infinite order** — orderOf a = 0 / ¬ IsOfFinOrder a, embedding (ℤ,+,<) into (ℝ,+,<).

Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Validation
- JSON valid; `annotations:build --strict` resolves every annotation in this entry to a Lean construct.
- Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`.