### PR TITLE
research(quadratic-reciprocity-oq-04): Jacobi symbol generalizes reciprocity but loses residue-detection [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/QuadraticReciprocityOQ04.lean
+++ b/proofs/Proofs/QuadraticReciprocityOQ04.lean
@@ -1,0 +1,86 @@
+/-
+Quadratic Reciprocity — the Jacobi symbol generalization, and the limit of its
+residue-detection (research leaf: quadratic-reciprocity-oq-04)
+
+Source problem family: https://erdosproblems.com (quadratic reciprocity)
+Status: original supporting theory; fully machine-checked.
+
+Context:
+The Jacobi symbol J(a | b) extends the Legendre symbol to odd b > 0 by
+multiplicativity over the prime factorization of b, and it satisfies the same
+quadratic reciprocity law (Mathlib: `jacobiSym.quadratic_reciprocity`), which is
+what makes the symbol efficiently computable WITHOUT factoring b.
+
+A subtle and important point — the one that powers the Solovay–Strassen
+primality test and the notion of "Euler liar" — is that this generalization
+LOSES the residue-detection property of the Legendre symbol:
+
+  * For a PRIME p, J(a | p) is the Legendre symbol, so J(a | p) = 1 ⇔ a is a
+    nonzero square mod p (Mathlib: `ZMod.isSquare_of_jacobiSym_eq_one`,
+    `ZMod.nonsquare_iff_jacobiSym_eq_neg_one`).
+  * For COMPOSITE b this equivalence FAILS in the `= 1` direction:
+    J(a | b) = 1 does NOT imply that a is a square mod b.
+
+What survives for all b is only the one-way test `J(a | b) = -1 ⟹ a is a
+non-square mod b` (Mathlib: `ZMod.nonsquare_of_jacobiSym_eq_neg_one`).
+
+This file makes the failure of the converse explicit and machine-checked with
+the smallest classical witness: a = 2, b = 15.
+
+  * `jacobiSym_two_fifteen` — J(2 | 15) = 1.
+  * `jacobiSym_two_fifteen_factor` — J(2 | 15) = J(2 | 3)·J(2 | 5), the
+        multiplicative decomposition that defines the Jacobi generalization.
+  * `two_nonsquare_mod_fifteen` — 2 is not a square in ℤ/15.
+  * `jacobi_one_not_isSquare_of_composite` — there is an odd composite b and an
+        a with J(a | b) = 1 yet a not a square mod b (so the prime-only
+        `isSquare_of_jacobiSym_eq_one` cannot be relaxed to composite b).
+  * `jacobiSym_neg_one_imp_nonsquare` — the surviving one-way direction, valid
+        for every b (re-exported from Mathlib to frame the contrast).
+
+Reference: Solovay–Strassen primality test; the J(a|n)=1 non-squares are the
+"Euler liars".
+
+Tags: quadratic-reciprocity, jacobi-symbol, legendre-symbol, quadratic-residue, number-theory
+-/
+
+import Mathlib
+
+namespace QuadraticReciprocityJacobi
+
+/-- The Jacobi symbol `J(2 | 15)` equals `1`. -/
+theorem jacobiSym_two_fifteen : jacobiSym 2 15 = 1 := by norm_num
+
+/-- The defining multiplicative decomposition of the Jacobi symbol over the
+factorization `15 = 3 · 5`. Each factor is the Legendre symbol `(2 | p) = -1`,
+and the two `-1`s multiply to `+1` — this is exactly how a non-square can hide
+behind a Jacobi value of `1`. -/
+theorem jacobiSym_two_fifteen_factor :
+    jacobiSym 2 15 = jacobiSym 2 3 * jacobiSym 2 5 := by
+  have h : (15 : ℕ) = 3 * 5 := by norm_num
+  rw [h, jacobiSym.mul_right]
+
+/-- `2` is not a square in `ℤ/15` (the squares mod 15 are `{0,1,4,6,9,10}`). -/
+theorem two_nonsquare_mod_fifteen : ¬ IsSquare (2 : ZMod 15) := by decide
+
+/-- **The converse of `isSquare_of_jacobiSym_eq_one` fails for composite moduli.**
+There is an odd composite `b` and an `a` with `J(a | b) = 1` yet `a` is not a
+square modulo `b`. Hence Mathlib's prime-only implication
+`J(a | p) = 1 → IsSquare (a : ZMod p)` genuinely requires `p` to be prime: the
+witness `a = 2`, `b = 15` is an "Euler liar". -/
+theorem jacobi_one_not_isSquare_of_composite :
+    ∃ (a : ℤ) (b : ℕ), ¬ b.Prime ∧ Odd b ∧ jacobiSym a b = 1 ∧
+      ¬ IsSquare (a : ZMod b) := by
+  refine ⟨2, 15, by decide, by decide, jacobiSym_two_fifteen, ?_⟩
+  have hcast : ((2 : ℤ) : ZMod 15) = (2 : ZMod 15) := by push_cast; ring
+  rw [hcast]
+  exact two_nonsquare_mod_fifteen
+
+/-- **The direction that survives for all `b`** (re-exported from Mathlib for
+contrast): a Jacobi value of `-1` always certifies a non-square, even for
+composite `b`. Together with the previous theorem this pins down exactly what
+the Jacobi symbol can and cannot detect. -/
+theorem jacobiSym_neg_one_imp_nonsquare {a : ℤ} {b : ℕ} (h : jacobiSym a b = -1) :
+    ¬ IsSquare (a : ZMod b) :=
+  ZMod.nonsquare_of_jacobiSym_eq_neg_one h
+
+end QuadraticReciprocityJacobi

--- a/src/data/proofs/quadratic-reciprocity-oq-04/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-qr-oq04-overview",
+    "proofId": "quadratic-reciprocity-oq-04",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "What the Jacobi Symbol Keeps and Loses",
+    "content": "The Jacobi symbol J(a | b) extends the Legendre symbol to odd b by multiplicativity over the prime factorization, and keeps the quadratic reciprocity law — so it stays efficiently computable without factoring b. But it loses residue-detection: for composite b, J(a | b) = 1 no longer implies that a is a square mod b. Mathlib has the residue equivalence only for prime moduli.",
+    "mathContext": "For prime p, J(a|p) = legendreSym p a detects squares; for composite b only J = -1 ⟹ non-square survives.",
+    "significance": "key",
+    "relatedConcepts": ["jacobi-symbol", "legendre-symbol", "quadratic-reciprocity", "quadratic-residue"],
+    "prerequisites": ["Legendre symbol", "Jacobi symbol multiplicativity and reciprocity"]
+  },
+  {
+    "id": "ann-qr-oq04-evaluation",
+    "proofId": "quadratic-reciprocity-oq-04",
+    "range": { "startLine": 49, "endLine": 64 },
+    "type": "technique",
+    "title": "Computing J(2 | 15) and Its Factorization",
+    "content": "jacobiSym_two_fifteen evaluates J(2 | 15) = 1 using Mathlib's reciprocity-based norm_num extension (axiom-clean, not native_decide). jacobiSym_two_fifteen_factor exhibits the multiplicative decomposition J(2 | 15) = J(2 | 3)·J(2 | 5) = (-1)(-1), the mechanism by which two Legendre non-residues produce a Jacobi value of +1.",
+    "mathContext": "J(2|15) = J(2|3)·J(2|5) = (-1)(-1) = 1.",
+    "significance": "standard",
+    "relatedConcepts": ["jacobiSym.mul_right", "norm_num extension"],
+    "prerequisites": ["jacobiSym.mul_right"]
+  },
+  {
+    "id": "ann-qr-oq04-nonsquare",
+    "proofId": "quadratic-reciprocity-oq-04",
+    "range": { "startLine": 65, "endLine": 68 },
+    "type": "technique",
+    "title": "2 Is Not a Square mod 15",
+    "content": "two_nonsquare_mod_fifteen is decided over the finite ring ℤ/15: the squares are {0,1,4,6,9,10}, and 2 is not among them. This uses kernel decide (no native_decide), so it adds no axioms.",
+    "mathContext": "2 ∉ {x² : x ∈ ℤ/15}.",
+    "significance": "standard",
+    "relatedConcepts": ["quadratic residues", "ZMod", "decidability"],
+    "prerequisites": ["IsSquare over a finite ring"]
+  },
+  {
+    "id": "ann-qr-oq04-counterexample",
+    "proofId": "quadratic-reciprocity-oq-04",
+    "range": { "startLine": 69, "endLine": 86 },
+    "type": "concept",
+    "title": "Converse Fails; One-Way Test Survives",
+    "content": "jacobi_one_not_isSquare_of_composite packages the witness a = 2, b = 15 into the statement that there is an odd composite b with J(a | b) = 1 yet a not a square mod b — so Mathlib's prime-only isSquare_of_jacobiSym_eq_one is sharp. jacobiSym_neg_one_imp_nonsquare re-exports the surviving direction (J = -1 ⟹ non-square, valid for all b), framing exactly what detection remains. These J=1 non-squares are the Euler liars of the Solovay–Strassen test.",
+    "mathContext": "∃ a b, ¬Prime b ∧ Odd b ∧ J(a|b)=1 ∧ ¬IsSquare (a : ZMod b); and J(a|b)=-1 ⇒ ¬IsSquare.",
+    "significance": "key",
+    "relatedConcepts": ["Euler liars", "Solovay–Strassen", "primality testing"],
+    "prerequisites": ["ZMod.nonsquare_of_jacobiSym_eq_neg_one"]
+  }
+]

--- a/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-oq-04/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "quadratic-reciprocity-oq-04",
+  "title": "Jacobi Symbol: Reciprocity Generalizes, Residue-Detection Does Not",
+  "slug": "quadratic-reciprocity-oq-04",
+  "description": "The Jacobi symbol extends the Legendre symbol to odd composite moduli and satisfies the same quadratic reciprocity law, which is what makes it computable without factoring. But the generalization loses residue-detection: for composite b, J(a | b) = 1 does NOT imply that a is a square mod b. This entry makes that failure explicit and machine-checked with the smallest witness a = 2, b = 15 (an 'Euler liar'), while noting the one-way direction J(a | b) = -1 ⟹ non-square that survives for all b.",
+  "meta": {
+    "author": "Lean formalization (research leaf: quadratic-reciprocity-oq-04, Jacobi symbol generalization)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityOQ04.lean",
+    "tags": [
+      "quadratic-reciprocity",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "quadratic-residue",
+      "number-theory",
+      "primality-testing"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym",
+        "description": "The Jacobi symbol J(a | b), multiplicative over the factorization of b",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.mul_right",
+        "description": "J(a | b₁·b₂) = J(a | b₁)·J(a | b₂) — the defining multiplicativity",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "ZMod.nonsquare_of_jacobiSym_eq_neg_one",
+        "description": "J(a | b) = -1 ⟹ a is not a square mod b (valid for all b)",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "Mathlib.Tactic.NormNum.LegendreSymbol",
+        "description": "norm_num extension provably evaluating Jacobi/Legendre symbols via reciprocity",
+        "module": "Mathlib.Tactic.NormNum.LegendreSymbol"
+      }
+    ],
+    "originalContributions": [
+      "jacobi_one_not_isSquare_of_composite: an explicit, machine-checked counterexample showing Mathlib's prime-only ZMod.isSquare_of_jacobiSym_eq_one cannot be relaxed to composite moduli — J(2 | 15) = 1 yet 2 is not a square mod 15 (the smallest 'Euler liar')",
+      "jacobiSym_two_fifteen: J(2 | 15) = 1 (evaluated via the reciprocity norm_num extension, axiom-clean)",
+      "jacobiSym_two_fifteen_factor: the multiplicative decomposition J(2 | 15) = J(2 | 3)·J(2 | 5) = (-1)·(-1) exhibiting exactly how two Legendre non-residues combine to a Jacobi value of +1",
+      "two_nonsquare_mod_fifteen: 2 is not a square in ℤ/15 (squares mod 15 are {0,1,4,6,9,10}), by kernel decide",
+      "jacobiSym_neg_one_imp_nonsquare: a framed re-export of the one-way direction that survives for all b, pinning down precisely what the Jacobi symbol can and cannot detect"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "0 axiom declarations, 0 sorries. All 5 theorems are fully machine-checked and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms on the headline counterexample and the symbol evaluations; no sorryAx, no Lean.ofReduceBool — the Jacobi values are produced by Mathlib's reciprocity-based norm_num extension and by kernel decide, not native_decide). Builds clean against pinned Mathlib v4.26.",
+    "lineCount": 86,
+    "theoremCount": 5,
+    "prerequisites": [
+      "Legendre and Jacobi symbols",
+      "Quadratic reciprocity for the Jacobi symbol",
+      "Quadratic residues modulo composite numbers",
+      "Solovay–Strassen primality test and Euler liars"
+    ],
+    "definitionCount": 0,
+    "lastUpdated": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "The Legendre symbol (a | p) for a prime p detects quadratic residues exactly: it is +1 for nonzero squares and -1 for non-squares. Jacobi extended the symbol to all odd b by multiplicativity over the prime factorization, preserving the quadratic reciprocity law — and crucially preserving efficient computability, since reciprocity lets one evaluate J(a | b) without factoring b. The price of this generalization is that residue-detection breaks: a Jacobi value of +1 can arise from an even number of Legendre -1 factors, so it no longer certifies a square. This is precisely the phenomenon exploited (and worked around) by the Solovay–Strassen primality test, where composite n can have 'Euler liars' a with J(a | n) consistent with a^((n-1)/2).",
+    "problemStatement": "The Jacobi symbol generalizes quadratic reciprocity to composite moduli. Does it also generalize the Legendre symbol's residue-detection? Specifically, does J(a | b) = 1 imply that a is a square mod b for composite b?",
+    "text": "No: J(2 | 15) = 1 (because (2|3) = (2|5) = -1 multiply to +1) yet 2 is not a square mod 15. Reciprocity generalizes; residue-detection does not.",
+    "proofStrategy": "Evaluate J(2 | 15) = 1 with Mathlib's reciprocity-based norm_num extension, and exhibit the decomposition J(2 | 15) = J(2 | 3)·J(2 | 5) via multiplicativity to show the +1 arises from two -1 Legendre factors. Separately decide that 2 is not a square in ℤ/15. Packaging these gives an odd composite b and an a with J(a | b) = 1 but a not a square mod b, so Mathlib's prime-only isSquare_of_jacobiSym_eq_one is sharp. Finally re-export the surviving one-way test J(a | b) = -1 ⟹ non-square to frame exactly what detection remains.",
+    "keyInsights": [
+      "The Jacobi symbol is +1 whenever an EVEN number of its Legendre factors are -1, regardless of whether a is actually a square — this is the mechanism of the failure",
+      "J(2 | 15) = J(2 | 3)·J(2 | 5) = (-1)(-1) = 1 is the minimal instance",
+      "What survives for composite b is only the one-way implication J = -1 ⟹ non-square; the J = 1 direction is exactly the set of Euler liars used to define the Solovay–Strassen test",
+      "Reciprocity (hence fast computation) is fully retained — it is residue-detection, not reciprocity, that the generalization sacrifices"
+    ],
+    "prerequisites": [
+      "Legendre symbol and Euler's criterion",
+      "Jacobi symbol multiplicativity and reciprocity",
+      "Quadratic residues mod composite numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Docstring framing the Jacobi generalization, what is retained (reciprocity, computability) and what is lost (residue-detection); imports Mathlib; namespace QuadraticReciprocityJacobi",
+      "mathContext": "J(a | b) extends (a | p) multiplicatively; reciprocity holds for all odd b, but J(a|b)=1 ⇏ square for composite b."
+    },
+    {
+      "id": "evaluation",
+      "title": "Evaluating J(2 | 15) and Its Factorization",
+      "startLine": 49,
+      "endLine": 64,
+      "summary": "jacobiSym_two_fifteen (= 1, via the norm_num extension) and jacobiSym_two_fifteen_factor (= J(2|3)·J(2|5)), exhibiting the (-1)(-1) = 1 mechanism",
+      "mathContext": "$J(2|15) = 1 = J(2|3)\\,J(2|5) = (-1)(-1)$."
+    },
+    {
+      "id": "nonsquare",
+      "title": "2 Is Not a Square mod 15",
+      "startLine": 65,
+      "endLine": 68,
+      "summary": "two_nonsquare_mod_fifteen by kernel decide (squares mod 15 are {0,1,4,6,9,10})",
+      "mathContext": "$2 \\notin \\{x^2 : x \\in \\mathbb{Z}/15\\} = \\{0,1,4,6,9,10\\}$."
+    },
+    {
+      "id": "counterexample",
+      "title": "Failure of the Converse and the Surviving Direction",
+      "startLine": 69,
+      "endLine": 86,
+      "summary": "jacobi_one_not_isSquare_of_composite (J = 1 but non-square for composite b) and jacobiSym_neg_one_imp_nonsquare (J = -1 ⟹ non-square, all b)",
+      "mathContext": "$\\exists a,b:\\ \\neg\\,\\mathrm{Prime}\\,b \\wedge \\mathrm{Odd}\\,b \\wedge J(a|b)=1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,(a:\\mathbb{Z}/b)$; and $J(a|b)=-1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Jacobi symbol generalizes the Legendre symbol's quadratic reciprocity to odd composite moduli, keeping the symbol efficiently computable, but it loses residue-detection: J(2 | 15) = 1 while 2 is not a square mod 15. The only detection that survives for composite b is the one-way test J(a | b) = -1 ⟹ a is a non-square.",
+    "implications": "This is the precise gap that the Solovay–Strassen primality test must contend with: a Jacobi value of +1 does not certify a square, and the offending a are the 'Euler liars'. The result also shows Mathlib's prime-only isSquare_of_jacobiSym_eq_one is sharp.",
+    "openQuestions": [
+      "Can one formalize that every odd composite n admits an a with J(a | n) = 1 and a a non-residue (so Euler liars always exist), and bound their number?",
+      "Can the Solovay–Strassen Euler-witness condition be formalized on top of this, including the ≤ 1/2 density of liars for composite n?",
+      "Does an analogous detection-failure hold for higher-power residue symbols (cubic/quartic) and their reciprocity laws?"
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "QuadraticReciprocityJacobi",
+    "lineCount": 86,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/QuadraticReciprocityOQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "extends",
+      "description": "Studies the Jacobi-symbol generalization of the quadratic reciprocity law and the detection property it sacrifices."
+    },
+    {
+      "targetId": "quadratic-reciprocity-oq-03",
+      "relationship": "related",
+      "description": "Sibling open-question leaf in the quadratic reciprocity family."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/quadratic-reciprocity-oq-04.json
+++ b/src/data/research/problems/quadratic-reciprocity-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "quadratic-reciprocity-oq-04",
   "title": "Jacobi symbol generalization of quadratic reciprocity",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Formalized (verified, 0-axiom) that the Jacobi-symbol generalization of quadratic reciprocity LOSES residue-detection for composite moduli: J(2|15)=1 yet 2 is not a square mod 15 (smallest Euler liar). Reciprocity/computability retained; only J=-1 ⟹ non-square survives. Gallery quadratic-reciprocity-oq-04 / Proofs/QuadraticReciprocityOQ04.lean.",
+    "builtItems": [
+      "jacobi_one_not_isSquare_of_composite (headline Euler-liar counterexample) in Proofs/QuadraticReciprocityOQ04.lean",
+      "jacobiSym_two_fifteen, jacobiSym_two_fifteen_factor, two_nonsquare_mod_fifteen, jacobiSym_neg_one_imp_nonsquare"
+    ],
+    "insights": [
+      "Jacobi J(a|b)=1 arises from an EVEN number of Legendre -1 factors, so for composite b it does not certify a square; J(2|15)=(2|3)(2|5)=(-1)(-1)=1 is minimal.",
+      "Mathlib has the residue iff only for PRIME moduli (isSquare_of_jacobiSym_eq_one); the composite converse genuinely fails — this entry shows it is sharp.",
+      "Jacobi values evaluate axiom-clean via Mathlib reciprocity norm_num extension (not native_decide)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: quadratic-reciprocity-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
The **Jacobi symbol** generalizes the Legendre symbol to odd composite moduli and satisfies the same **quadratic reciprocity** law (Mathlib: `jacobiSym.quadratic_reciprocity`), which keeps it efficiently computable *without factoring*. This entry makes explicit, and machine-checks, that the generalization **loses residue-detection**: for composite `b`, `J(a | b) = 1` does **not** imply that `a` is a square mod `b`.

Mathlib only has the residue equivalence for **prime** moduli (`ZMod.isSquare_of_jacobiSym_eq_one`, `ZMod.nonsquare_iff_jacobiSym_eq_neg_one`). This PR shows that prime hypothesis is sharp.

## What is proved (`Proofs/QuadraticReciprocityOQ04.lean`)
- **`jacobiSym_two_fifteen`** — `J(2 | 15) = 1`, via Mathlib's reciprocity-based `norm_num` extension (axiom-clean — not `native_decide`).
- **`jacobiSym_two_fifteen_factor`** — `J(2 | 15) = J(2 | 3)·J(2 | 5) = (-1)(-1)`, the mechanism by which two Legendre non-residues combine to a Jacobi `+1`.
- **`two_nonsquare_mod_fifteen`** — `2` is not a square in `ℤ/15` (squares are `{0,1,4,6,9,10}`), by kernel `decide`.
- **`jacobi_one_not_isSquare_of_composite`** — `∃ a b, ¬Prime b ∧ Odd b ∧ J(a|b)=1 ∧ ¬IsSquare (a : ZMod b)`. The witness `a=2, b=15` is the smallest **Euler liar**.
- **`jacobiSym_neg_one_imp_nonsquare`** — the one-way direction `J(a|b) = -1 ⟹ non-square` that survives for all `b` (framed re-export), pinning down exactly what detection remains.

This is the gap the Solovay–Strassen primality test must handle: a Jacobi value of `+1` does not certify a square.

## Status
**Outcome**: completed. 5 theorems, **0 sorries, 0 axiom declarations**. `#print axioms` on the headline counterexample and the symbol evaluations lists only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Builds clean against pinned Mathlib v4.26 via host `lake env lean`.

## Files
- `proofs/Proofs/QuadraticReciprocityOQ04.lean` (new, 86 lines)
- `src/data/proofs/quadratic-reciprocity-oq-04/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/quadratic-reciprocity-oq-04.json` (knowledge update, status → completed)

🤖 Generated by researcher-1