### PR TITLE
research(burnside-counting-oq-04-oq-02-oq-01): rotation half of bracelet Burnside sum = gcd-cycle sum [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ02OQ01.lean
@@ -1,0 +1,190 @@
+import Mathlib.Tactic
+import Proofs.BurnsideCountingOQ04OQ02
+
+/-
+# Burnside Counting, OQ-04 → OQ-02 → OQ-01: the rotation half is the gcd-cycle sum
+
+## What this file proves
+
+The parent file `BurnsideCountingOQ04OQ02` built, for every `n`, the dihedral action of
+`Dₙ` on the binary colourings `Coloring n = ZMod n → Fin 2` of the `n`-cycle and the
+orbit-counting identity
+
+      ∑_{g ∈ Dₙ} |Fix(g)|  =  b(n) · (2n)            (`bracelet_burnside`),
+
+leaving the *closed* evaluation of each side as documented follow-up.  This file discharges
+the **rotation half** of that left-hand sum: it evaluates `∑_{rotations} |Fix(r i)|` as the
+**gcd-cycle sum**
+
+      ∑_{i ∈ ZMod n} |Fix(r i)|  =  ∑_{i ∈ ZMod n} 2 ^ gcd(n, i)            (`rotation_sum_eq_gcd_cycle_sum`).
+
+The single new ingredient is the per-rotation count
+
+      |Fix(r i)|  =  2 ^ gcd(n, i)            (`card_fixedBy_rotation`).
+
+## Why `gcd(n, i)`
+
+A colouring is fixed by the rotation `r i` (which acts on positions by `x ↦ x + i`) exactly
+when it is **constant on the `⟨i⟩-orbits** of `ZMod n`, i.e. constant on the cosets of the
+cyclic subgroup `H = ⟨i⟩ = AddSubgroup.zmultiples i`.  Such colourings are therefore in
+bijection with functions `(ZMod n ⧸ H) → Fin 2`, of which there are `2 ^ [ZMod n : H]`.  The
+index is computed by Lagrange together with `addOrderOf (i : ZMod n) = n / gcd(n, i)`:
+
+      [ZMod n : H]  =  n / |H|  =  n / addOrderOf i  =  n / (n / gcd(n, i))  =  gcd(n, i).
+
+The number of orbits of the rotation is exactly `gcd(n, i)`, recovering the classical fact
+that adding `i` modulo `n` decomposes the `n` positions into `gcd(n, i)` cycles.
+
+## Proof strategy
+
+* `rotation_smul_apply`: unfold the parent action at a rotation, `(r i • c) p = c (p - i)`.
+* `fixed_iff_periodic`: `r i • c = c ↔ c` is `i`-periodic.
+* `periodic_zsmul`: an `i`-periodic colouring is invariant under every `k • i`, `k : ℤ`
+  (`Int.induction_on`).
+* `fixedRotationEquiv`: the bijection `Fix(r i) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2)`.
+* `card_quotient_zmultiples`: `[ZMod n : ⟨i⟩] = gcd(n, i)` via Lagrange + `addOrderOf_coe`.
+
+`#print axioms` confirms only `propext, Classical.choice, Quot.sound` — no `native_decide`.
+-/
+
+namespace BurnsideCountingOQ04OQ02OQ01
+
+open Finset MulAction AddSubgroup BurnsideCountingOQ04OQ02
+
+variable {n : ℕ}
+
+/-! ### Unfolding the rotation action -/
+
+/-- The rotation `r i` acts on a colouring by translating the *argument* by `-i`:
+`(r i • c) p = c (p - i)`.  This reads off the parent's `smul_apply` at `g = r i`, where the
+position permutation is `ρ (r i) = Equiv.addRight i`, whose inverse is `· - i`. -/
+theorem rotation_smul_apply (i : ZMod n) (c : Coloring n) (p : ZMod n) :
+    ((DihedralGroup.r i : DihedralGroup n) • c) p = c (p - i) := by
+  rw [smul_apply]
+  congr 1
+  have hρ : (ρ (DihedralGroup.r i) : Equiv.Perm (ZMod n)) = Equiv.addRight i := rfl
+  rw [hρ, Equiv.symm_apply_eq]; simp
+
+/-- A colouring is fixed by the rotation `r i` iff it is `i`-periodic: `c (p - i) = c p`. -/
+theorem fixed_iff_periodic (i : ZMod n) (c : Coloring n) :
+    (DihedralGroup.r i : DihedralGroup n) • c = c ↔ ∀ p, c (p - i) = c p := by
+  constructor
+  · intro h p
+    have := congrFun h p
+    rwa [rotation_smul_apply] at this
+  · intro h
+    funext p
+    rw [rotation_smul_apply]
+    exact h p
+
+/-- An `i`-periodic colouring is invariant under translation by every integer multiple of `i`:
+`c (a + k • i) = c a` for all `k : ℤ`.  Proved by integer induction, using the periodicity in
+both the `+ i` and `- i` directions. -/
+theorem periodic_zsmul (i : ZMod n) {c : Coloring n} (hc : ∀ p, c (p - i) = c p) :
+    ∀ (k : ℤ) (a : ZMod n), c (a + k • i) = c a := by
+  have hplus : ∀ p, c (p + i) = c p := by
+    intro p; have h := hc (p + i); rw [add_sub_cancel_right] at h; exact h.symm
+  intro k
+  induction k using Int.induction_on with
+  | zero => intro a; simp
+  | succ k ih =>
+    intro a
+    have key : a + (k + 1 : ℤ) • i = a + (k : ℤ) • i + i := by
+      rw [add_smul, one_smul, add_assoc]
+    rw [key, hplus]; exact ih a
+  | pred k ih =>
+    intro a
+    have key : a + (-(k : ℤ) - 1) • i = a + (-(k : ℤ)) • i - i := by
+      rw [sub_smul, one_smul, ← add_sub_assoc]
+    rw [key, hc]; exact ih a
+
+/-! ### The bijection with functions on the orbit quotient -/
+
+/-- **Fixed colourings ≃ functions on the orbit quotient.**  A colouring fixed by `r i` is
+constant on the cosets of `H = ⟨i⟩`, so it descends to a function on `ZMod n ⧸ H`; conversely
+any function on the quotient pulls back to an `i`-periodic colouring.  These are mutually
+inverse. -/
+def fixedRotationEquiv (i : ZMod n) :
+    ↥(fixedBy (Coloring n) (DihedralGroup.r i))
+      ≃ (ZMod n ⧸ AddSubgroup.zmultiples i → Fin 2) where
+  toFun c := Quotient.lift c.1 (by
+    intro a b hab
+    replace hab : -a + b ∈ AddSubgroup.zmultiples i := QuotientAddGroup.leftRel_apply.mp hab
+    obtain ⟨k, hk⟩ := AddSubgroup.mem_zmultiples_iff.mp hab
+    have hper : ∀ p, c.1 (p - i) = c.1 p :=
+      (fixed_iff_periodic i c.1).mp ((mem_fixedBy).mp c.2)
+    have hb : b = a + k • i := by rw [hk]; abel
+    rw [hb, periodic_zsmul i hper k a])
+  invFun f :=
+    ⟨fun p => f (QuotientAddGroup.mk p), by
+      rw [mem_fixedBy, fixed_iff_periodic]
+      intro p
+      show f (QuotientAddGroup.mk (p - i)) = f (QuotientAddGroup.mk p)
+      congr 1
+      rw [QuotientAddGroup.eq]
+      have : -(p - i) + p = i := by abel
+      rw [this]
+      exact AddSubgroup.mem_zmultiples i⟩
+  left_inv := by
+    rintro ⟨c, hc⟩
+    rfl
+  right_inv := by
+    intro f
+    funext q
+    induction q using QuotientAddGroup.induction_on with
+    | _ a => rfl
+
+/-! ### Counting the quotient: the index is `gcd(n, i)` -/
+
+/-- **Index of the rotation subgroup.**  The cyclic subgroup `⟨i⟩ ≤ ZMod n` has index
+`gcd(n, i)`: by Lagrange the index is `n / |⟨i⟩| = n / addOrderOf i`, and
+`addOrderOf (i : ZMod n) = n / gcd(n, i)`. -/
+theorem card_quotient_zmultiples [NeZero n] (i : ZMod n) :
+    Nat.card (ZMod n ⧸ AddSubgroup.zmultiples i) = Nat.gcd n i.val := by
+  have hn : n ≠ 0 := NeZero.ne n
+  -- addOrderOf i = n / gcd(n, i.val)
+  have hord : addOrderOf i = n / Nat.gcd n i.val := by
+    conv_lhs => rw [← ZMod.natCast_zmod_val i]
+    exact ZMod.addOrderOf_coe i.val hn
+  -- Lagrange: n = card quotient * card subgroup
+  have hlag := AddSubgroup.card_eq_card_quotient_mul_card_addSubgroup (AddSubgroup.zmultiples i)
+  rw [Nat.card_zmultiples, hord, Nat.card_zmod] at hlag
+  -- hlag : n = Nat.card (quotient) * (n / gcd)
+  have hgdvd : Nat.gcd n i.val ∣ n := Nat.gcd_dvd_left _ _
+  have hgpos : 0 < Nat.gcd n i.val := Nat.gcd_pos_of_pos_left _ (Nat.pos_of_ne_zero hn)
+  have hdpos : 0 < n / Nat.gcd n i.val := Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hn) hgdvd) hgpos
+  -- gcd * (n / gcd) = n, so n = card * (n/gcd) = gcd * (n/gcd) ⟹ card = gcd
+  have hmul : Nat.gcd n i.val * (n / Nat.gcd n i.val) = n := Nat.mul_div_cancel' hgdvd
+  have : Nat.card (ZMod n ⧸ AddSubgroup.zmultiples i) * (n / Nat.gcd n i.val)
+      = Nat.gcd n i.val * (n / Nat.gcd n i.val) := by
+    rw [hmul, ← hlag]
+  exact Nat.eq_of_mul_eq_mul_right hdpos this
+
+/-! ### The per-rotation fixed count and the rotation half -/
+
+/-- **Per-rotation count.**  The number of binary colourings fixed by the rotation `r i` is
+`2 ^ gcd(n, i)`: the colourings are functions on the `gcd(n, i)` rotation orbits. -/
+theorem card_fixedBy_rotation [NeZero n] (i : ZMod n) :
+    Fintype.card (fixedBy (Coloring n) (DihedralGroup.r i)) = 2 ^ Nat.gcd n i.val := by
+  classical
+  rw [Fintype.card_congr (fixedRotationEquiv i), Fintype.card_fun, Fintype.card_fin]
+  congr 1
+  rw [← Nat.card_eq_fintype_card, card_quotient_zmultiples]
+
+/-- **The rotation half of the Burnside sum is the gcd-cycle sum.**
+
+      ∑_{i ∈ ZMod n} |Fix(r i)|  =  ∑_{i ∈ ZMod n} 2 ^ gcd(n, i).
+
+This is the closed evaluation, promised by the parent, of the rotation contribution to the
+bracelet orbit-counting identity. -/
+theorem rotation_sum_eq_gcd_cycle_sum [NeZero n] :
+    ∑ i : ZMod n, Fintype.card (fixedBy (Coloring n) (DihedralGroup.r i))
+      = ∑ i : ZMod n, 2 ^ Nat.gcd n i.val := by
+  exact Finset.sum_congr rfl (fun i _ => card_fixedBy_rotation i)
+
+end BurnsideCountingOQ04OQ02OQ01
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideCountingOQ04OQ02OQ01.card_fixedBy_rotation
+#print axioms BurnsideCountingOQ04OQ02OQ01.rotation_sum_eq_gcd_cycle_sum

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "burnside-oq040201-ann-smul",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 81 },
+    "type": "technique",
+    "title": "Fixed-by-rotation is a periodicity condition",
+    "content": "rotation_smul_apply unfolds the parent's dihedral colouring action at a rotation: since the position permutation ρ(r i) = Equiv.addRight i has inverse · - i, the action reads (r i • c) p = c (p - i). fixed_iff_periodic then recasts the fixed-point equation r i • c = c as the periodicity statement ∀ p, c (p - i) = c p — i.e. c is invariant under translating its argument by i. This is the bridge that turns a question about a group action into a number-theoretic count: a fixed colouring is one that is constant along the orbit x ↦ x + i.",
+    "mathContext": "$(r_i \\bullet c)(p) = c(p - i)$, so $r_i \\bullet c = c \\iff \\forall p,\\; c(p-i) = c(p)$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed points of a group action", "Equiv.addRight", "translation invariance", "periodic functions"],
+    "prerequisites": ["group actions", "permutations of ZMod n"]
+  },
+  {
+    "id": "burnside-oq040201-ann-zsmul",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-01",
+    "range": { "startLine": 82, "endLine": 105 },
+    "type": "technique",
+    "title": "Periodicity propagates to the whole cyclic subgroup",
+    "content": "periodic_zsmul shows that a single-step periodicity c (p - i) = c p forces invariance under every integer multiple: c (a + k • i) = c a for all k : ℤ. The proof is Int.induction_on, stepping by +i (succ case) and -i (pred case), using the periodicity in both directions. This is exactly what makes a fixed colouring descend to the coset quotient ZMod n ⧸ ⟨i⟩: two positions in the same ⟨i⟩-coset differ by some k • i, so a periodic colouring assigns them the same colour.",
+    "mathContext": "$c(p \\pm i) = c(p) \\;\\Rightarrow\\; c(a + k\\,i) = c(a)$ for all $k \\in \\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["integer induction", "cyclic subgroup zmultiples", "coset invariance", "zsmul"],
+    "prerequisites": ["Int.induction_on", "additive group structure of ZMod n"]
+  },
+  {
+    "id": "burnside-oq040201-ann-equiv",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 140 },
+    "type": "insight",
+    "title": "Fixed colourings biject with functions on the orbit quotient",
+    "content": "fixedRotationEquiv builds the bijection ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2). Forward: a fixed colouring is constant on ⟨i⟩-cosets (extracted from the coset relation via QuotientAddGroup.leftRel_apply and mem_zmultiples_iff, then periodic_zsmul), so it descends through Quotient.lift to a function on the quotient. Backward: any function on the quotient pulls back along QuotientAddGroup.mk to a colouring that is automatically i-periodic because mk(p - i) = mk(p). The two are mutually inverse. This is the structural identity |Fix(r i)| = 2^{(number of rotation orbits)}.",
+    "mathContext": "$\\mathrm{Fix}(r_i) \\;\\simeq\\; \\big(\\mathbb{Z}/n\\mathbb{Z} \\,/\\, \\langle i\\rangle \\to \\{0,1\\}\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["Quotient.lift", "coset quotient", "universal property of quotients", "counting functions on a quotient"],
+    "prerequisites": ["quotients by subgroups", "the universal property of Quotient"]
+  },
+  {
+    "id": "burnside-oq040201-ann-index",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-01",
+    "range": { "startLine": 141, "endLine": 165 },
+    "type": "technique",
+    "title": "The number of orbits is gcd(n, i)",
+    "content": "card_quotient_zmultiples computes the index [ZMod n : ⟨i⟩] = gcd(n, i.val). Lagrange's theorem gives Nat.card (ZMod n) = Nat.card (ZMod n ⧸ ⟨i⟩) · Nat.card ⟨i⟩; Nat.card_zmultiples identifies the subgroup order with addOrderOf i; and ZMod.addOrderOf_coe evaluates addOrderOf (i) = n / gcd(n, i.val). The index is therefore n / (n / gcd(n,i)) = gcd(n,i), the cancellation handled by n / (n / d) = d for d ∣ n. This is the classical statement that adding i modulo n decomposes the n positions into gcd(n,i) cycles.",
+    "mathContext": "$[\\mathbb{Z}/n\\mathbb{Z} : \\langle i\\rangle] = \\dfrac{n}{\\mathrm{addOrderOf}\\,i} = \\dfrac{n}{n/\\gcd(n,i)} = \\gcd(n,i).$",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's theorem", "order of an element in ZMod n", "subgroup index", "gcd cycle count"],
+    "prerequisites": ["Lagrange's theorem", "addOrderOf in ZMod n", "divisibility arithmetic"]
+  },
+  {
+    "id": "burnside-oq040201-ann-headline",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-01",
+    "range": { "startLine": 166, "endLine": 190 },
+    "type": "insight",
+    "title": "The rotation half as the gcd-cycle sum",
+    "content": "card_fixedBy_rotation assembles the bijection and the index count into the headline per-rotation formula |Fix(r i)| = 2^{gcd(n, i.val)}, via Fintype.card_congr fixedRotationEquiv and Fintype.card_fun (which evaluates |Q → Fin 2| = 2^{|Q|}). rotation_sum_eq_gcd_cycle_sum then sums termwise to Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)} — the closed evaluation of the rotation contribution to the parent's bracelet_burnside identity, answering its first open question verbatim. Both headlines are verified with 0 axioms and no native_decide.",
+    "mathContext": "$\\sum_{i \\in \\mathbb{Z}/n\\mathbb{Z}} |\\mathrm{Fix}(r_i)| = \\sum_{i \\in \\mathbb{Z}/n\\mathbb{Z}} 2^{\\gcd(n,\\,i)}.$",
+    "significance": "key",
+    "relatedConcepts": ["necklace generating function", "OEIS A000029", "Burnside rotation contribution", "Fintype.card_fun"],
+    "prerequisites": ["the orbit-quotient bijection", "the index computation"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-01/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "burnside-counting-oq-04-oq-02-oq-01",
+  "title": "The Rotation Half of the Bracelet Burnside Sum as a gcd-Cycle Sum",
+  "slug": "burnside-counting-oq-04-oq-02-oq-01",
+  "description": "Discharges the first open question of the parent burnside-counting-oq-04-oq-02: the closed evaluation of the rotation contribution to the n-uniform Burnside bracelet identity Σ_{g∈Dₙ} |Fix(g)| = b(n)·(2n). The parent built the dihedral action of D_n on the binary colourings Coloring n = ZMod n → Fin 2 and the orbit-counting identity, leaving the closed form of each half as documented follow-up. This entry evaluates the rotation half as the gcd-cycle sum Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)} (rotation_sum_eq_gcd_cycle_sum), via the single new ingredient |Fix(r i)| = 2^{gcd(n, i.val)} (card_fixedBy_rotation). The count is explained structurally: a colouring is fixed by the rotation r i (which acts on positions by x ↦ x + i) exactly when it is constant on the ⟨i⟩-orbits of ZMod n, i.e. constant on the cosets of the cyclic subgroup H = ⟨i⟩ = AddSubgroup.zmultiples i; such colourings biject with functions (ZMod n ⧸ H) → Fin 2, of which there are 2^[ZMod n : H]. The index is computed by Lagrange together with addOrderOf (i : ZMod n) = n / gcd(n, i): [ZMod n : H] = n / |H| = n / addOrderOf i = n / (n / gcd(n,i)) = gcd(n,i). The number of rotation orbits is therefore exactly gcd(n,i), recovering the classical fact that adding i modulo n decomposes the n positions into gcd(n,i) cycles. #print axioms on both headlines confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius (researcher-5)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "necklaces",
+      "orbit-counting",
+      "cyclic-groups",
+      "gcd",
+      "number-theory",
+      "native-decide-free"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.addOrderOf_coe",
+        "description": "addOrderOf (a : ZMod n) = n / gcd(n, a) for n ≠ 0. The arithmetic heart of the index computation [ZMod n : ⟨i⟩] = gcd(n, i.val).",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "AddSubgroup.card_eq_card_quotient_mul_card_addSubgroup",
+        "description": "Lagrange's theorem (additive): Nat.card α = Nat.card (α ⧸ s) · Nat.card s. Combined with Nat.card_zmultiples it gives [ZMod n : ⟨i⟩] = n / addOrderOf i.",
+        "module": "Mathlib.GroupTheory.Coset.Card"
+      },
+      {
+        "theorem": "Nat.card_zmultiples",
+        "description": "Nat.card (AddSubgroup.zmultiples a) = addOrderOf a; identifies the subgroup order |⟨i⟩| with the additive order of i.",
+        "module": "Mathlib.Data.ZMod.QuotientGroup"
+      },
+      {
+        "theorem": "QuotientAddGroup.leftRel_apply / QuotientAddGroup.eq",
+        "description": "Characterise the coset relation on ZMod n ⧸ ⟨i⟩ as -a + b ∈ ⟨i⟩; used to build the bijection fixedRotationEquiv between fixed colourings and functions on the orbit quotient.",
+        "module": "Mathlib.GroupTheory.Coset.Defs"
+      },
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "Fintype.card (α → β) = (card β)^(card α); turns the orbit-quotient bijection into the count 2^{gcd(n,i)}.",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "MulAction.fixedBy / mem_fixedBy",
+        "description": "The fixed-point set of a group element under the parent's dihedral colouring action; rotation_smul_apply unfolds it at a rotation to the periodicity condition c (p - i) = c p.",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      }
+    ],
+    "originalContributions": [
+      "card_fixedBy_rotation: |Fix(r i)| = 2^{gcd(n, i.val)} — the per-rotation fixed-colouring count, the single new ingredient the parent left as its first open question. Proved by exhibiting the bijection between fixed colourings and functions on the rotation-orbit quotient and computing the number of orbits as the subgroup index gcd(n, i.val).",
+      "fixedRotationEquiv: the explicit bijection ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2). Forward by Quotient.lift of a fixed colouring (well-defined because an i-periodic colouring is constant on ⟨i⟩-cosets); backward by pullback along QuotientAddGroup.mk.",
+      "periodic_zsmul: an i-periodic colouring (c (p - i) = c p for all p) is invariant under translation by every integer multiple k • i, proved by integer induction in both the +i and -i directions — the lemma that makes the descent to the orbit quotient well-defined.",
+      "card_quotient_zmultiples: [ZMod n : ⟨i⟩] = gcd(n, i.val), assembling Lagrange, Nat.card_zmultiples, and ZMod.addOrderOf_coe with the divisor identity n / (n / gcd) = gcd.",
+      "rotation_sum_eq_gcd_cycle_sum: Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)} — the closed evaluation of the rotation half of the parent's bracelet_burnside identity, answering parent open question 1 verbatim."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, and no native_decide: both headlines (card_fixedBy_rotation, rotation_sum_eq_gcd_cycle_sum) depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — in particular no Lean.ofReduceBool and no sorryAx). The hypothesis NeZero n (i.e. n > 0) is required only where the Fintype/cardinality layer is used; the action, periodicity, and orbit-quotient bijection are stated without it.",
+    "lineCount": 190,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the dihedral group D_n acting on the beads of an n-cycle this yields the bracelet numbers (OEIS A000029). Closing the bracelet count requires evaluating the fixed-point total Σ_{g∈Dₙ} |Fix(g)| in closed form, split into a rotation half and a reflection half. The rotation r i acts on positions by x ↦ x + i, a permutation whose cycle structure (gcd(n,i) cycles of length n/gcd(n,i)) is the classical content behind the necklace generating function Σ_{d|n} φ(d) x^{n/d}. The parent burnside-counting-oq-04-oq-02 built the n-uniform action and orbit-counting identity but left the closed form of each half as its first two open questions; this entry discharges the rotation half.",
+    "problemStatement": "Evaluate the rotation contribution Σ_{i∈ZMod n} |Fix(r i)| to the n-uniform Burnside bracelet identity in closed form, by proving the per-rotation count |Fix(r i)| = 2^{gcd(n, i.val)} (a rotation by i has gcd(n,i) orbits, on each of which a fixed colouring is constant).",
+    "text": "A binary colouring is fixed by the rotation r i iff it is i-periodic, hence constant on the cosets of the cyclic subgroup ⟨i⟩ ≤ ZMod n. Such colourings biject with functions on the quotient ZMod n ⧸ ⟨i⟩, giving |Fix(r i)| = 2^{[ZMod n : ⟨i⟩]} = 2^{gcd(n, i.val)} by Lagrange and addOrderOf (i) = n / gcd(n, i). Summing over i yields Σ_{i} |Fix(r i)| = Σ_{i} 2^{gcd(n, i.val)}.",
+    "proofStrategy": "rotation_smul_apply unfolds the parent action at a rotation: (r i • c) p = c (p - i), since the position permutation ρ (r i) = Equiv.addRight i has inverse · - i. fixed_iff_periodic recasts r i • c = c as the periodicity ∀ p, c (p - i) = c p. periodic_zsmul promotes periodicity to invariance under every k • i (k : ℤ) by integer induction. These let fixedRotationEquiv build the bijection ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2): forward by Quotient.lift (well-defined since a periodic colouring is constant on cosets, extracted from the coset relation via QuotientAddGroup.leftRel_apply and mem_zmultiples_iff), backward by pullback along the quotient map. card_quotient_zmultiples computes the index [ZMod n : ⟨i⟩] = gcd(n, i.val) from Lagrange, Nat.card_zmultiples (= addOrderOf i), ZMod.addOrderOf_coe (= n / gcd(n, i.val)), and the cancellation n / (n / gcd) = gcd. card_fixedBy_rotation then reads |Fix(r i)| = 2^{gcd} via Fintype.card_congr and Fintype.card_fun, and rotation_sum_eq_gcd_cycle_sum sums termwise.",
+    "keyInsights": [
+      "Fixed-by-rotation is a periodicity condition: r i • c = c unfolds to c (p - i) = c p, i.e. c is constant along the orbit x ↦ x + i — the bridge from the group action to a number-theoretic count",
+      "Periodicity is a one-step condition that propagates to a full subgroup: c (p ± i) = c p forces c (a + k • i) = c a for all k : ℤ (integer induction), so c factors through the coset quotient ZMod n ⧸ ⟨i⟩",
+      "Counting the fixed set is counting functions on the orbit quotient: the bijection fixedRotationEquiv turns |Fix(r i)| into 2^{(number of orbits)}, and the number of orbits is the subgroup index",
+      "The index is gcd by Lagrange plus the ZMod order formula: [ZMod n : ⟨i⟩] = n / addOrderOf i = n / (n / gcd(n,i)) = gcd(n,i) — the classical statement that adding i mod n produces gcd(n,i) cycles",
+      "Together with the reflection half (still open) this gives the closed bracelet number b(n) = (Σ_i 2^{gcd(n,i)} + reflection-total)/(2n); the rotation sum Σ_i 2^{gcd(n,i)} = Σ_{d|n} φ(n/d) 2^d is exactly n times the binary necklace count"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, fixed-point sets, and the orbit-counting (Burnside) lemma",
+      "Cyclic subgroups ⟨i⟩ = AddSubgroup.zmultiples i, cosets, and Lagrange's theorem",
+      "The order of an element of ZMod n: addOrderOf (i) = n / gcd(n, i)",
+      "Quotient.lift and the universal property of the coset quotient"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; the rotation cycle index Σ_{d|n} φ(d) x^{n/d} for the cyclic group"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question by evaluating the rotation half Σ_i |Fix(r i)| of its bracelet_burnside identity as the gcd-cycle sum Σ_i 2^{gcd(n, i.val)}, via the per-rotation count |Fix(r i)| = 2^{gcd(n, i.val)}."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Supplies the closed rotation-contribution formula for the bracelet machinery whose concrete D₄ instance the sibling introduced."
+    }
+  ],
+  "conclusion": {
+    "summary": "A binary colouring is fixed by the rotation r i exactly when it is constant on the ⟨i⟩-orbits of ZMod n, so fixed colourings biject with functions on the quotient ZMod n ⧸ ⟨i⟩. By Lagrange and addOrderOf (i) = n / gcd(n, i) the index of ⟨i⟩ is gcd(n, i.val), giving |Fix(r i)| = 2^{gcd(n, i.val)} and hence the closed evaluation of the rotation half of the Burnside bracelet sum, Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)} — verified, 0 axioms, no native_decide.",
+    "implications": "Completes the rotation contribution to the closed-form bracelet number b(n) = (necklaces(n) + reflection-total(n))/(2n): the rotation sum Σ_i 2^{gcd(n,i)} reindexes by divisors to Σ_{d|n} φ(n/d) 2^d = n · (binary necklace count). With the reflection half it would yield b(n) without per-n kernel computation.",
+    "openQuestions": [
+      "Evaluate the reflection half Σ_{i} |Fix(sr i)| by the parity of n (odd n: every reflection fixes 2^{(n+1)/2}; even n: the two reflection classes fix 2^{n/2+1} and 2^{n/2}), and combine with this rotation half to prove the full closed form b(n) = (necklaces(n) + reflection-total(n))/(2n) with no per-n computation.",
+      "Reindex the gcd-cycle sum Σ_{i=0}^{n-1} 2^{gcd(n, i)} as the divisor sum Σ_{d|n} φ(n/d) 2^d, recovering the standard binary necklace generating expression directly from the count of i with gcd(n,i) = d (which is φ(n/d))."
+    ]
+  },
+  "sections": [
+    {
+      "title": "Module header and scope",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "States the goal — the closed evaluation of the rotation half of the parent's bracelet_burnside identity as the gcd-cycle sum — and the structural reason the count is 2^{gcd(n,i)}: fixed colourings are constant on the gcd(n,i) rotation orbits. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound)."
+    },
+    {
+      "title": "Unfolding the rotation action",
+      "startLine": 56,
+      "endLine": 81,
+      "summary": "rotation_smul_apply: (r i • c) p = c (p - i), reading off the parent's smul_apply with ρ (r i) = Equiv.addRight i and inverse · - i. fixed_iff_periodic: r i • c = c ↔ ∀ p, c (p - i) = c p."
+    },
+    {
+      "title": "Invariance under the cyclic subgroup",
+      "startLine": 82,
+      "endLine": 105,
+      "summary": "periodic_zsmul: an i-periodic colouring satisfies c (a + k • i) = c a for every k : ℤ, by Int.induction_on using periodicity in both the +i and -i directions — the fact that lets a fixed colouring descend to the coset quotient."
+    },
+    {
+      "title": "The bijection with functions on the orbit quotient",
+      "startLine": 106,
+      "endLine": 140,
+      "summary": "fixedRotationEquiv: ↥(fixedBy (Coloring n) (r i)) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2). Forward by Quotient.lift of the fixed colouring (well-defined via QuotientAddGroup.leftRel_apply + mem_zmultiples_iff + periodic_zsmul); backward by pullback along QuotientAddGroup.mk; the two are mutually inverse."
+    },
+    {
+      "title": "Counting the quotient: the index is gcd(n, i)",
+      "startLine": 141,
+      "endLine": 165,
+      "summary": "card_quotient_zmultiples: Nat.card (ZMod n ⧸ ⟨i⟩) = gcd(n, i.val), from Lagrange (card α = card quotient · card subgroup), Nat.card_zmultiples (subgroup order = addOrderOf i), ZMod.addOrderOf_coe (= n / gcd(n,i)), and the cancellation n / (n / gcd) = gcd."
+    },
+    {
+      "title": "The per-rotation count and the rotation half",
+      "startLine": 166,
+      "endLine": 190,
+      "summary": "card_fixedBy_rotation: |Fix(r i)| = 2^{gcd(n, i.val)} via Fintype.card_congr fixedRotationEquiv and Fintype.card_fun. rotation_sum_eq_gcd_cycle_sum: Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2^{gcd(n, i.val)}, the closed rotation half. Axiom audit confirms only the foundational axioms."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.BurnsideCountingOQ04OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction",
+      "AddSubgroup",
+      "BurnsideCountingOQ04OQ02"
+    ],
+    "namespace": "BurnsideCountingOQ04OQ02OQ01",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/BurnsideCountingOQ04OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Discharges the **first open question** recorded by the parent `burnside-counting-oq-04-oq-02`: the closed evaluation of the **rotation contribution** to the n-uniform Burnside bracelet identity `Σ_{g∈Dₙ} |Fix(g)| = b(n)·(2n)`.

**Headline results** (in `Proofs/BurnsideCountingOQ04OQ02OQ01.lean`):

- `card_fixedBy_rotation`: `|Fix(r i)| = 2 ^ gcd(n, i.val)` — the per-rotation fixed-colouring count.
- `rotation_sum_eq_gcd_cycle_sum`: `Σ_{i∈ZMod n} |Fix(r i)| = Σ_{i∈ZMod n} 2 ^ gcd(n, i.val)`.

## Why gcd(n, i)

A binary colouring is fixed by the rotation `r i` (which acts on positions by `x ↦ x + i`) exactly when it is constant on the `⟨i⟩`-orbits of `ZMod n`, i.e. on the cosets of `H = ⟨i⟩ = AddSubgroup.zmultiples i`. Such colourings biject with functions `(ZMod n ⧸ H) → Fin 2`, of which there are `2 ^ [ZMod n : H]`. By Lagrange together with `addOrderOf (i : ZMod n) = n / gcd(n, i)`:

```
[ZMod n : H] = n / |H| = n / addOrderOf i = n / (n / gcd(n,i)) = gcd(n,i).
```

The rotation by `i` therefore has exactly `gcd(n,i)` orbits — the classical cycle count of adding `i` modulo `n`.

## Structure (6 thm / 1 def / 190 L)

- `rotation_smul_apply` / `fixed_iff_periodic`: fixed-by-`r i` ⇔ `i`-periodic (`c (p - i) = c p`).
- `periodic_zsmul`: periodicity propagates to invariance under every `k • i` (`Int.induction_on`).
- `fixedRotationEquiv`: the bijection `Fix(r i) ≃ (ZMod n ⧸ ⟨i⟩ → Fin 2)`.
- `card_quotient_zmultiples`: `[ZMod n : ⟨i⟩] = gcd(n, i.val)`.

## Verification

`#print axioms` on both headlines lists only `propext, Classical.choice, Quot.sound` — **no `native_decide`** (no `Lean.ofReduceBool`) and **no `sorryAx`**. Status: `verified`, badge `original`, 0 axioms, 0 sorries.

Builds on the parent's dihedral colouring action; imports `Proofs.BurnsideCountingOQ04OQ02`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)