### PR TITLE
research(amgm-inequality-oq-05-oq-02): equality case of weighted AM-GM for n terms [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ05OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ05OQ02.lean
@@ -1,0 +1,114 @@
+/-
+  The weighted AM-GM inequality: its equality case for `n` terms.
+
+  For strictly positive weights `w : ι → ℝ` summing to `1` over a finite index
+  set `t` and strictly positive reals `x : ι → ℝ`, the weighted arithmetic mean
+  dominates the weighted geometric mean,
+
+      ∏ i ∈ t, (x i) ^ (w i)  ≤  ∑ i ∈ t, w i * x i.
+
+  This file pins down the **equality case**: equality holds **iff every `xⱼ`
+  equals the weighted mean**, equivalently iff all the `xⱼ` are equal.
+
+  The parent entry proved the two-variable pointwise Young equality case from the
+  strict convexity of `exp`; one of its stated open questions was to upgrade this
+  to the `n`-term weighted AM-GM equality case "again via strict convexity of
+  `exp`".  That is exactly what we do here, in the dual (and equivalent) form:
+  the logarithm is *strictly concave* on `(0, ∞)`, so Jensen's inequality for
+  `Real.log` is strict unless all evaluation points coincide.  Concretely we
+  take logs to turn the multiplicative AM-GM equality into the additive Jensen
+  equality
+
+      Real.log (∑ wᵢ xᵢ)  =  ∑ wᵢ · Real.log (xᵢ),
+
+  and feed it to Mathlib's canonical equality-case lemma
+  `StrictConcaveOn.map_sum_eq_iff` for the strictly concave `Real.log`
+  (`strictConcaveOn_log_Ioi`).  Mathlib has the weighted AM-GM inequality and the
+  strict Jensen machinery, but does not package this particular equality
+  characterisation of the geometric/arithmetic mean.
+
+  All exponents are real, so `^` denotes `Real.rpow` throughout.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Real Finset
+
+namespace AmgmInequalityOQ05OQ02
+
+variable {ι : Type*}
+
+/-- Taking logs turns the weighted geometric mean into the weighted sum of
+logarithms: `log (∏ xᵢ ^ wᵢ) = ∑ wᵢ · log xᵢ`. -/
+theorem log_prod_rpow {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    Real.log (∏ i ∈ t, x i ^ w i) = ∑ i ∈ t, w i * Real.log (x i) := by
+  rw [Real.log_prod (fun i hi => (Real.rpow_pos_of_pos (hx i hi) (w i)).ne')]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  rw [Real.log_rpow (hx i hi)]
+
+/-- The weighted geometric mean of positive reals is positive. -/
+theorem prod_rpow_pos {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    0 < ∏ i ∈ t, x i ^ w i :=
+  Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hx i hi) (w i))
+
+/-- The weighted arithmetic mean of positive reals with positive weights, over a
+nonempty index set, is positive. -/
+theorem mean_pos {t : Finset ι} {w x : ι → ℝ} (hw : ∀ i ∈ t, 0 < w i)
+    (hx : ∀ i ∈ t, 0 < x i) (hne : t.Nonempty) :
+    0 < ∑ i ∈ t, w i * x i :=
+  Finset.sum_pos (fun i hi => mul_pos (hw i hi) (hx i hi)) hne
+
+/-- **Equality case of the weighted AM-GM inequality (canonical form).**
+
+For strictly positive weights summing to `1` and strictly positive `x`, the
+weighted geometric mean equals the weighted arithmetic mean **iff every `xⱼ`
+equals that common mean**. -/
+theorem weighted_amgm_eq_iff {t : Finset ι} {w x : ι → ℝ} (hw : ∀ i ∈ t, 0 < w i)
+    (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i) :
+    (∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i) ↔
+      (∀ j ∈ t, x j = ∑ i ∈ t, w i * x i) := by
+  -- A sum of weights equal to `1` forces the index set to be nonempty.
+  have hne : t.Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]
+    rintro rfl
+    simp at hsum
+  have hA : 0 < ∑ i ∈ t, w i * x i := mean_pos hw hx hne
+  have hP : 0 < ∏ i ∈ t, x i ^ w i := prod_rpow_pos hx
+  -- Both means are positive, so the equality is equivalent to its image under `log`.
+  rw [← Real.log_injOn_pos.eq_iff (Set.mem_Ioi.mpr hP) (Set.mem_Ioi.mpr hA),
+      log_prod_rpow hx, eq_comm]
+  -- The strict concavity of `log` supplies the equality case of Jensen.
+  have key := strictConcaveOn_log_Ioi.map_sum_eq_iff (t := t) (w := w) (p := x)
+      hw hsum (fun i hi => Set.mem_Ioi.mpr (hx i hi))
+  simpa only [smul_eq_mul] using key
+
+/-- **Equality case of the weighted AM-GM inequality (pairwise form).**
+
+Equality holds iff all the `xⱼ` (over the support of the weights) are equal. -/
+theorem weighted_amgm_eq_iff_pairwise {t : Finset ι} {w x : ι → ℝ}
+    (hw : ∀ i ∈ t, 0 < w i) (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i) :
+    (∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i) ↔
+      (∀ i ∈ t, ∀ j ∈ t, x i = x j) := by
+  rw [weighted_amgm_eq_iff hw hsum hx]
+  constructor
+  · intro h i hi j hj
+    rw [h i hi, h j hj]
+  · intro h j hj
+    have hconst : ∑ i ∈ t, w i * x i = ∑ i ∈ t, w i * x j := by
+      refine Finset.sum_congr rfl ?_
+      intro i hi
+      rw [h i hi j hj]
+    rw [hconst, ← Finset.sum_mul, hsum, one_mul]
+
+/-- The trivial direction, recorded explicitly: if all `xⱼ` are equal then the
+weighted geometric and arithmetic means coincide. -/
+theorem weighted_amgm_eq_of_const {t : Finset ι} {w x : ι → ℝ} {c : ℝ}
+    (hw : ∀ i ∈ t, 0 < w i) (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i)
+    (hc : ∀ i ∈ t, x i = c) :
+    ∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i :=
+  (weighted_amgm_eq_iff_pairwise hw hsum hx).mpr
+    (fun i hi j hj => (hc i hi).trans (hc j hj).symm)
+
+end AmgmInequalityOQ05OQ02

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "ann-log-prod-rpow",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "theorem",
+    "title": "log_prod_rpow: log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ",
+    "content": "The logarithmic bridge. For strictly positive xᵢ, the logarithm of the weighted geometric mean equals the weighted sum of logarithms. The proof applies Real.log_prod (each factor xᵢ^{wᵢ} is positive, hence nonzero, by Real.rpow_pos_of_pos) and then Real.log_rpow on each term to turn log(xᵢ^{wᵢ}) into wᵢ·log xᵢ. This is what linearises the multiplicative geometric mean into the additive form on which Jensen's inequality acts.",
+    "mathContext": "$\\log\\!\\left(\\prod_i x_i^{w_i}\\right) = \\sum_i w_i \\log x_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "Real.log_rpow",
+      "weighted geometric mean"
+    ],
+    "prerequisites": [
+      "Real.log_prod",
+      "Real.log_rpow",
+      "Real.rpow_pos_of_pos"
+    ]
+  },
+  {
+    "id": "ann-prod-rpow-pos",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 55
+    },
+    "type": "theorem",
+    "title": "prod_rpow_pos: positivity of the geometric mean",
+    "content": "The weighted geometric mean ∏ xᵢ^{wᵢ} of positive reals is positive, since it is a finite product of positive rpows (Finset.prod_pos with Real.rpow_pos_of_pos). Needed so that the geometric mean lies in the domain (0,∞) where log is injective.",
+    "mathContext": "$\\prod_i x_i^{w_i} > 0$ when each $x_i > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_pos",
+      "Real.rpow_pos_of_pos"
+    ],
+    "prerequisites": [
+      "Finset.prod_pos"
+    ]
+  },
+  {
+    "id": "ann-mean-pos",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "mean_pos: positivity of the arithmetic mean",
+    "content": "The weighted arithmetic mean ∑ wᵢxᵢ is positive: each summand wᵢxᵢ is a product of positive numbers, and the index set is nonempty, so Finset.sum_pos applies. Positivity places the arithmetic mean in the domain of log, the other endpoint of the bridge.",
+    "mathContext": "$\\sum_i w_i x_i > 0$ over a nonempty index set with $w_i, x_i > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_pos",
+      "weighted arithmetic mean"
+    ],
+    "prerequisites": [
+      "Finset.sum_pos"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-iff",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_iff: equality iff every xⱼ equals the mean",
+    "content": "The headline result (canonical form). For positive weights summing to 1 and positive x, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals that common mean. Proof: the index set is nonempty (weights sum to 1 ≠ 0), so both means are positive; by injectivity of log on (0,∞) (Real.log_injOn_pos) the multiplicative equality is equivalent to the equality of logs; rewriting the geometric side by log_prod_rpow reduces this to the additive equality log(∑ wᵢxᵢ) = ∑ wᵢ·log xᵢ, which is exactly the equality case of Jensen for the strictly concave Real.log. Mathlib's StrictConcaveOn.map_sum_eq_iff applied to strictConcaveOn_log_Ioi, with smul = mul on ℝ, finishes the equivalence.",
+    "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall j,\\; x_j = \\sum_i w_i x_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "StrictConcaveOn.map_sum_eq_iff",
+      "strictConcaveOn_log_Ioi",
+      "Real.log_injOn_pos",
+      "equality case of Jensen's inequality"
+    ],
+    "prerequisites": [
+      "StrictConcaveOn.map_sum_eq_iff",
+      "strictConcaveOn_log_Ioi",
+      "Real.log_injOn_pos"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-iff-pairwise",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_iff_pairwise: equality iff all xⱼ equal",
+    "content": "The familiar phrasing. Equality in weighted AM-GM holds iff all the xⱼ are pairwise equal. Derived from the canonical form: if all xⱼ equal the mean they are pairwise equal; conversely, if the sequence is constant then its weighted mean (with weights summing to 1) equals that constant, so each xⱼ equals the mean. This recovers the textbook statement that the geometric and arithmetic means coincide exactly for constant data.",
+    "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall i\\,j,\\; x_i = x_j$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weighted AM-GM equality case",
+      "constant sequence"
+    ],
+    "prerequisites": [
+      "weighted_amgm_eq_iff",
+      "Finset.sum_mul"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-of-const",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_of_const: the trivial direction",
+    "content": "Recorded explicitly for completeness: if all xⱼ equal a common value c, the weighted geometric and arithmetic means coincide. Immediate from the pairwise equality characterisation.",
+    "mathContext": "$(\\forall i,\\, x_i = c) \\implies \\prod_i x_i^{w_i} = \\sum_i w_i x_i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weighted AM-GM equality case"
+    ],
+    "prerequisites": [
+      "weighted_amgm_eq_iff_pairwise"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "amgm-inequality-oq-05-oq-02",
+  "title": "The Equality Case of the Weighted AM-GM Inequality (n Terms)",
+  "slug": "amgm-inequality-oq-05-oq-02",
+  "description": "For strictly positive weights w summing to 1 over a finite index set and strictly positive reals x, the weighted geometric mean ∏ xᵢ^{wᵢ} equals the weighted arithmetic mean ∑ wᵢxᵢ iff every xⱼ equals their common mean — equivalently, iff all the xⱼ are equal. Mathlib has the weighted AM-GM inequality and the strict Jensen machinery but not this equality characterization. Following the parent Young-inequality entry's open question, the sharp boundary is obtained by taking logs to convert the multiplicative AM-GM equality into the additive Jensen equality and feeding it to the equality case of Jensen for the strictly concave Real.log (the dual of strict convexity of exp).",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inequality_of_arithmetic_and_geometric_means#Weighted_AM%E2%80%93GM_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "amgm",
+      "weighted-amgm",
+      "convexity",
+      "jensen",
+      "equality-case",
+      "logarithm",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). #print axioms on the headline theorems reports exactly these three. The equality characterization is proved from strictConcaveOn_log_Ioi via StrictConcaveOn.map_sum_eq_iff.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The weighted arithmetic–geometric mean inequality, ∏ xᵢ^{wᵢ} ≤ ∑ wᵢxᵢ for positive weights wᵢ summing to 1, is the central inequality of the AM-GM family; the equal-weight case wᵢ = 1/n recovers the classical statement that the geometric mean of n positive numbers is at most their arithmetic mean. Its modern proof is one line of convexity: applying Jensen's inequality to the concave logarithm gives ∑ wᵢ log xᵢ ≤ log(∑ wᵢxᵢ), and exponentiating yields AM-GM. The equality case — equality holds precisely when all the xⱼ coincide — is exactly the statement that Jensen's inequality is strict for a strictly concave function unless all evaluation points are equal. The parent entry characterised the equality case of the two-variable Young inequality (weights (1/p, 1/q)) from the strict convexity of exp, and posed the n-term weighted AM-GM equality case as an open question. This entry answers it, working with the strict concavity of log (the dual, and equivalent, formulation: log = −(−log) and exp is strictly convex iff log is strictly concave). While Mathlib carries the weighted AM-GM inequality and a full suite of strict-Jensen equality lemmas, it does not package this multiplicative equality characterisation of the geometric and arithmetic means.",
+    "problemStatement": "Let t be a finite index set, w : ι → ℝ strictly positive weights with ∑_{i∈t} wᵢ = 1, and x : ι → ℝ strictly positive. Prove that ∏_{i∈t} xᵢ^{wᵢ} = ∑_{i∈t} wᵢxᵢ holds if and only if every xⱼ equals the weighted mean ∑_{i∈t} wᵢxᵢ, equivalently if and only if all the xⱼ are equal.",
+    "text": "Equality in the weighted AM-GM inequality ∏ xᵢ^{wᵢ} ≤ ∑ wᵢxᵢ holds iff all xⱼ are equal. The proof takes logs and applies the equality case of Jensen for the strictly concave logarithm.",
+    "proofStrategy": "The argument is a logarithmic bridge to Jensen's equality case. (1) log_prod_rpow: for positive xᵢ, log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ, by Real.log_prod (each factor xᵢ^{wᵢ} is positive hence nonzero) followed by Real.log_rpow on each term. (2) Both means are positive: the geometric mean ∏ xᵢ^{wᵢ} is a product of positive rpows (prod_rpow_pos), and the arithmetic mean ∑ wᵢxᵢ is positive because each wᵢxᵢ > 0 over the necessarily nonempty index set (mean_pos; the index set is nonempty because the weights sum to 1 ≠ 0). (3) weighted_amgm_eq_iff: since both means lie in (0,∞) and log is injective there (Real.log_injOn_pos), the multiplicative equality ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ is equivalent to log(∏ xᵢ^{wᵢ}) = log(∑ wᵢxᵢ). Rewriting the left side by step (1) turns this into ∑ wᵢ·log xᵢ = log(∑ wᵢxᵢ), which is precisely the equality case of Jensen's inequality for Real.log. Mathlib's StrictConcaveOn.map_sum_eq_iff, applied to strictConcaveOn_log_Ioi, states that log(∑ wᵢ•xᵢ) = ∑ wᵢ•log xᵢ iff every xⱼ equals the center of mass ∑ wᵢ•xᵢ; with smul = mul on ℝ this closes the equivalence. (4) weighted_amgm_eq_iff_pairwise repackages the 'every xⱼ = mean' condition as the symmetric 'all xⱼ are pairwise equal' (a constant sequence has mean equal to its value, using ∑ wᵢ = 1). (5) weighted_amgm_eq_of_const records the trivial forward implication explicitly.",
+    "keyInsights": [
+      "**Strict concavity of log is the equality engine.** The ordinary weighted AM-GM inequality holds because log is concave (Jensen). The *sharp* equality case requires *strict* concavity: Mathlib's StrictConcaveOn.map_sum_eq_iff says that for a strictly concave f and positive weights, f(∑ wᵢ•xᵢ) = ∑ wᵢ•f(xᵢ) forces every xⱼ to equal the center of mass. Specialising f = log on (0,∞) (strictConcaveOn_log_Ioi) is exactly the AM-GM equality case. This is the dual of the parent entry's strict-convexity-of-exp argument.",
+      "**Logs linearise the geometric mean.** The multiplicative quantity ∏ xᵢ^{wᵢ} becomes the linear ∑ wᵢ·log xᵢ under log (log_prod_rpow), turning the geometric/arithmetic equality into the additive Jensen equality on which the convexity lemma acts directly. The two rpow facts needed are that xᵢ^{wᵢ} > 0 and log(xᵢ^{wᵢ}) = wᵢ·log xᵢ.",
+      "**Injectivity of log transports equality across the bridge.** Because both means are strictly positive and log is injective on (0,∞) (Real.log_injOn_pos), the multiplicative equality and its logarithm are interchangeable; this is what lets the Jensen equality case, an additive statement, characterise the original multiplicative one.",
+      "**Two equivalent phrasings of the equality locus.** The canonical Jensen output is 'every xⱼ equals the weighted mean'; the more familiar phrasing is 'all the xⱼ are equal'. These coincide here precisely because the weights sum to 1, so the mean of a constant sequence is that constant — the bridge in weighted_amgm_eq_iff_pairwise."
+    ],
+    "prerequisites": [
+      "Real powers Real.rpow and Real.log_rpow, Real.rpow_pos_of_pos",
+      "Logarithm of a product Real.log_prod and injectivity Real.log_injOn_pos",
+      "Strict concavity of the logarithm strictConcaveOn_log_Ioi",
+      "Equality case of Jensen's inequality StrictConcaveOn.map_sum_eq_iff"
+    ]
+  },
+  "conclusion": {
+    "summary": "The equality case of the n-term weighted AM-GM inequality is fully verified: 6 theorems, 0 definitions, 0 axioms, 0 sorries. For positive weights summing to 1 and positive reals x, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals their common mean (weighted_amgm_eq_iff), equivalently iff all the xⱼ are equal (weighted_amgm_eq_iff_pairwise). The proof bridges the multiplicative equality to the additive equality case of Jensen for the strictly concave Real.log via the logarithm, answering the parent Young-inequality entry's open question.",
+    "implications": "This pins down the tightness of the most-used inequality in the AM-GM family: in every downstream application of weighted AM-GM the estimate is sharp exactly when the inputs are constant. The proof exhibits the canonical template for upgrading a convexity inequality to its equality case — replace concavity by strict concavity, linearise in logarithmic coordinates, and use injectivity to transport equality across the bridge — and is the direct multiplicative companion of the parent's strict-convexity-of-exp treatment of the two-variable Young equality case.",
+    "openQuestions": [
+      "Specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case (n-th root of a product equals the average iff all terms are equal) as a standalone corollary indexed over Fin n.",
+      "Use the equality case as the base of an induction or smoothing ('mixing') argument to give an independent proof of the weighted AM-GM inequality itself, tracking the strict gain at each unequal pair."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-05",
+      "relationship": "extends",
+      "description": "The parent entry proved the two-variable Young equality case (weights (1/p, 1/q)) from strict convexity of exp and posed the n-term weighted AM-GM equality case as an open question. This entry answers it, using the dual strict concavity of log."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Sharpens the AM-GM family: the equal-weight specialisation of the equality characterisation proved here is the classical statement that the geometric and arithmetic means of n positive reals coincide iff all the reals are equal."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "AmgmInequalityOQ05OQ02",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for the weighted AM-GM inequality and its equality case (Theorem 9 and the surrounding discussion of the geometric and arithmetic means)."
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Develops AM-GM, Jensen, and the role of strict convexity in equality cases."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/amgm-inequality-oq-05-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-05-oq-02.json
@@ -1,0 +1,63 @@
+{
+  "slug": "amgm-inequality-oq-05-oq-02",
+  "title": "The Equality Case of the Weighted AM-GM Inequality (n Terms)",
+  "problemStatement": "For strictly positive weights w summing to 1 over a finite index set t and strictly positive reals x, prove that the weighted geometric mean ∏ xᵢ^{wᵢ} equals the weighted arithmetic mean ∑ wᵢxᵢ if and only if every xⱼ equals their common mean, equivalently iff all the xⱼ are equal. Use the strict convexity of exp / strict concavity of log, as posed in the parent Young-inequality entry's open questions.",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 7,
+  "status": "completed",
+  "phase": "COMPLETED",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "path": "Proofs/AmgmInequalityOQ05OQ02.lean",
+  "leanFiles": [
+    "proofs/Proofs/AmgmInequalityOQ05OQ02.lean"
+  ],
+  "relatedProofs": [
+    "amgm-inequality-oq-05",
+    "amgm-inequality"
+  ],
+  "tags": [
+    "analysis",
+    "inequalities",
+    "amgm",
+    "weighted-amgm",
+    "convexity",
+    "jensen",
+    "equality-case"
+  ],
+  "knowledge": {
+    "insights": [
+      "The equality case of weighted AM-GM is exactly the equality case of Jensen's inequality for the strictly concave logarithm: Mathlib's StrictConcaveOn.map_sum_eq_iff, applied to strictConcaveOn_log_Ioi, gives that log(∑ wᵢ•xᵢ) = ∑ wᵢ•log xᵢ iff every xⱼ equals the center of mass.",
+      "Taking logs linearises the multiplicative geometric mean: log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ via Real.log_prod + Real.log_rpow, converting the AM-GM equality into an additive Jensen equality.",
+      "Injectivity of log on (0,∞) (Real.log_injOn_pos) is what transports equality across the bridge: both means are strictly positive, so the multiplicative equality and the equality of their logs are interchangeable.",
+      "The 'every xⱼ equals the mean' and 'all xⱼ pairwise equal' phrasings coincide precisely because the weights sum to 1 — the weighted mean of a constant sequence is that constant.",
+      "This is the dual of the parent entry's route: exp strictly convex ⟺ log strictly concave, so the n-term weighted AM-GM equality case can be obtained from log-concavity instead of exp-convexity, and Mathlib packages the strict-Jensen equality case directly."
+    ],
+    "builtItems": [
+      "log_prod_rpow (Proofs/AmgmInequalityOQ05OQ02.lean:44): log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ for positive xᵢ.",
+      "prod_rpow_pos (Proofs/AmgmInequalityOQ05OQ02.lean:52): positivity of the weighted geometric mean.",
+      "mean_pos (Proofs/AmgmInequalityOQ05OQ02.lean:58): positivity of the weighted arithmetic mean over a nonempty index set.",
+      "weighted_amgm_eq_iff (Proofs/AmgmInequalityOQ05OQ02.lean:68): headline — equality iff every xⱼ equals the weighted mean.",
+      "weighted_amgm_eq_iff_pairwise (Proofs/AmgmInequalityOQ05OQ02.lean:90): equality iff all xⱼ are pairwise equal.",
+      "weighted_amgm_eq_of_const (Proofs/AmgmInequalityOQ05OQ02.lean:107): the trivial forward direction."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the weighted AM-GM inequality and a full suite of strict-Jensen equality lemmas (StrictConcaveOn.map_sum_eq_iff), but does not package the multiplicative equality characterisation ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ ↔ constant data."
+    ],
+    "nextSteps": [
+      "Specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case over Fin n as a standalone corollary.",
+      "Use the equality case as the base of a smoothing/mixing induction to give an independent proof of the weighted AM-GM inequality, tracking the strict gain at each unequal pair."
+    ],
+    "progressSummary": "COMPLETE: weighted AM-GM equality case proved for n terms, 0 axioms / 0 sorries, 6 theorems / 114 lines. Verified via lake env lean; #print axioms reports only propext/Classical.choice/Quot.sound. Answers the parent Young-inequality entry's second open question."
+  },
+  "currentState": "Completed and verified. The headline equivalence ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ ↔ all xⱼ equal is machine-checked from Mathlib's strict-Jensen equality case for the logarithm, with no axioms beyond Lean's foundational three.",
+  "knownResults": [
+    "Weighted AM-GM inequality (classical; Mathlib has the inequality direction).",
+    "Equality in Jensen's inequality for a strictly concave function forces all evaluation points equal (Mathlib: StrictConcaveOn.map_sum_eq_iff)."
+  ],
+  "references": [
+    "Hardy, Littlewood, Pólya, Inequalities (1934), Theorem 9.",
+    "J. M. Steele, The Cauchy–Schwarz Master Class (2004)."
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **equality case of the n-term weighted AM-GM inequality**, answering the parent Young-inequality entry's (`amgm-inequality-oq-05`) second open question.

For strictly positive weights `w` summing to `1` over a finite index set and strictly positive reals `x`:
```
∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ  ↔  ∀ j, xⱼ = ∑ wᵢxᵢ   (equivalently: all xⱼ equal)
```

## Proof idea

A logarithmic bridge to Jensen's equality case (the dual of the parent's strict-convexity-of-exp argument):
- `log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ` (`Real.log_prod` + `Real.log_rpow`) linearises the geometric mean;
- both means are positive, so by injectivity of `log` on `(0,∞)` (`Real.log_injOn_pos`) the multiplicative equality ⟺ equality of logs;
- that is exactly the equality case of Jensen for the strictly concave `Real.log`: `StrictConcaveOn.map_sum_eq_iff` applied to `strictConcaveOn_log_Ioi`.

Mathlib has the weighted AM-GM inequality and the strict-Jensen equality lemmas, but not this multiplicative equality characterisation.

## Verification
- 6 theorems, 114 lines, **0 sorries, 0 axioms**, no `native_decide`.
- `#print axioms` on the headline theorems reports only `propext`, `Classical.choice`, `Quot.sound`.
- Verified with `lake env lean` against the pinned Mathlib (4.26.0).

## Files
- `proofs/Proofs/AmgmInequalityOQ05OQ02.lean`
- `src/data/proofs/amgm-inequality-oq-05-oq-02/{meta,annotations}.json`
- `src/data/research/problems/amgm-inequality-oq-05-oq-02.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)