### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-02): weighted AM–HM inequality + equality case [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,124 @@
+/-
+# The Weighted Arithmetic–Harmonic Mean Inequality and its Equality Case
+(jensen-inequality-oq-01-oq-01-oq-01-oq-02)
+
+The weighted power-mean `M_r` of strictly positive data `xᵢ` with weights `wᵢ > 0`
+summing to `1` is monotone in the exponent `r`. The parent chain established the
+weighted AM–GM inequality `weighted_amgm_le` and its equality case
+`weighted_amgm_eq_iff` — the `M₀ ≤ M₁` rung (geometric mean ≤ arithmetic mean).
+
+This file proves the rung *below* it, the **arithmetic–harmonic mean inequality**
+`M₋₁ ≤ M₁`: the weighted harmonic mean is at most the weighted arithmetic mean,
+
+    (∑ᵢ wᵢ · xᵢ⁻¹)⁻¹  ≤  ∑ᵢ wᵢ · xᵢ ,     with equality iff all the `xᵢ` are equal.
+
+## Proof
+
+Let `G = ∏ᵢ xᵢ^{wᵢ}` be the weighted geometric mean. Two applications of the
+parent's weighted AM–GM inequality bracket `G` between the harmonic mean `H` and
+the arithmetic mean `A`:
+
+  * to the data `xᵢ`:    `G = ∏ xᵢ^{wᵢ} ≤ ∑ wᵢ xᵢ = A`              (so `G ≤ A`),
+  * to the data `xᵢ⁻¹`:  `G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ xᵢ⁻¹ = D`     (so `G⁻¹ ≤ D`),
+
+using `∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹ = G⁻¹`. Since `G > 0`, the second bound
+inverts to the harmonic mean `H = D⁻¹ ≤ G`, and chaining gives `H ≤ G ≤ A`.
+
+The equality case falls out of the same bracketing: `H = A` squeezes `G = A`,
+which by `weighted_amgm_eq_iff` forces all `xᵢ` equal; conversely constancy makes
+all three means coincide.
+
+This is the `M₋₁ ≤ M₁` power-mean rung, obtained purely from two AM–GM
+applications, and is distinct from the Hölder/Minkowski siblings.
+
+## Main results
+
+* `weighted_amhm_le` — the weighted AM–HM inequality `(∑ wᵢ xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ xᵢ`.
+* `weighted_amhm_eq_iff` — equality holds **iff all the `xᵢ` are equal**.
+* `weighted_amhm_lt_of_ne` — the strict form when two of the `xᵢ` differ.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.JensenInequalityOQ01
+
+open Finset Real
+
+namespace WeightedAMHM
+
+variable {ι : Type*} {s : Finset ι} {w x : ι → ℝ}
+
+/-- The weighted geometric mean of the reciprocals is the reciprocal of the weighted
+geometric mean: `∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹`. -/
+private theorem prod_rpow_inv (hx : ∀ i ∈ s, 0 < x i) :
+    ∏ i ∈ s, (x i)⁻¹ ^ w i = (∏ i ∈ s, x i ^ w i)⁻¹ := by
+  rw [← Finset.prod_inv_distrib]
+  exact Finset.prod_congr rfl fun i hi => Real.inv_rpow (hx i hi).le _
+
+/-- **Harmonic mean ≤ geometric mean.** Applying the parent's weighted AM–GM
+inequality to the reciprocals `xᵢ⁻¹` gives `G⁻¹ ≤ ∑ wᵢ xᵢ⁻¹`, which inverts (using
+`G > 0`) to `(∑ wᵢ xᵢ⁻¹)⁻¹ ≤ G`. -/
+private theorem harm_le_geom (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 < x i) :
+    (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ ≤ ∏ i ∈ s, x i ^ w i := by
+  have hGpos : 0 < ∏ i ∈ s, x i ^ w i :=
+    Finset.prod_pos fun i hi => Real.rpow_pos_of_pos (hx i hi) _
+  have hGinvD : (∏ i ∈ s, x i ^ w i)⁻¹ ≤ ∑ i ∈ s, w i * (x i)⁻¹ := by
+    have h := weighted_amgm_le (z := fun i => (x i)⁻¹) hw hw'
+      (fun i hi => inv_nonneg.mpr (hx i hi).le)
+    rwa [prod_rpow_inv hx] at h
+  have h2 := inv_anti₀ (inv_pos.mpr hGpos) hGinvD
+  rwa [inv_inv] at h2
+
+/-- **The weighted arithmetic–harmonic mean inequality.** For nonnegative weights
+summing to `1` and strictly positive data, the weighted harmonic mean is at most the
+weighted arithmetic mean. -/
+theorem weighted_amhm_le (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 < x i) :
+    (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ ≤ ∑ i ∈ s, w i * x i :=
+  le_trans (harm_le_geom hw hw' hx)
+    (weighted_amgm_le hw hw' (fun i hi => (hx i hi).le))
+
+/-- **Equality case of the weighted AM–HM inequality.** With strictly positive weights
+summing to `1` and strictly positive data, the harmonic and arithmetic means coincide
+**iff all the data are equal**.
+
+Forward: the bracketing `H ≤ G ≤ A` squeezes `G = A`, and `weighted_amgm_eq_iff`
+turns that into constancy. Backward: constancy makes both AM–GM applications
+equalities, so `H = G = A`. -/
+theorem weighted_amhm_eq_iff (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 < x i) :
+    (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ = ∑ i ∈ s, w i * x i ↔ ∀ j ∈ s, ∀ k ∈ s, x j = x k := by
+  constructor
+  · intro hEq
+    -- `G ≤ A` and `H ≤ G` with `H = A` squeeze `G = A`.
+    have hGA : ∏ i ∈ s, x i ^ w i ≤ ∑ i ∈ s, w i * x i :=
+      weighted_amgm_le (fun i hi => (hw i hi).le) hw' (fun i hi => (hx i hi).le)
+    have hHG : (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ ≤ ∏ i ∈ s, x i ^ w i :=
+      harm_le_geom (fun i hi => (hw i hi).le) hw' hx
+    have hGAeq : ∏ i ∈ s, x i ^ w i = ∑ i ∈ s, w i * x i := by
+      refine le_antisymm hGA ?_
+      calc ∑ i ∈ s, w i * x i = (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ := hEq.symm
+        _ ≤ ∏ i ∈ s, x i ^ w i := hHG
+    exact (weighted_amgm_eq_iff hw hw' (fun i hi => (hx i hi).le)).mp hGAeq
+  · intro hconst
+    -- Both AM–GM applications become equalities, so `H = G⁻¹⁻¹ = A`.
+    have hGA : ∏ i ∈ s, x i ^ w i = ∑ i ∈ s, w i * x i :=
+      (weighted_amgm_eq_iff hw hw' (fun i hi => (hx i hi).le)).mpr hconst
+    have hDeq : ∑ i ∈ s, w i * (x i)⁻¹ = (∏ i ∈ s, x i ^ w i)⁻¹ := by
+      rw [← prod_rpow_inv hx]
+      exact ((weighted_amgm_eq_iff hw hw' (fun i hi => inv_nonneg.mpr (hx i hi).le)).mpr
+        (fun j hj k hk => by rw [hconst j hj k hk])).symm
+    rw [hDeq, inv_inv]; exact hGA
+
+/-- **Strict weighted AM–HM inequality.** If two of the data values differ, the
+weighted harmonic mean is *strictly* less than the weighted arithmetic mean. -/
+theorem weighted_amhm_lt_of_ne (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 < x i) (hne : ∃ j ∈ s, ∃ k ∈ s, x j ≠ x k) :
+    (∑ i ∈ s, w i * (x i)⁻¹)⁻¹ < ∑ i ∈ s, w i * x i := by
+  refine lt_of_le_of_ne (weighted_amhm_le (fun i hi => (hw i hi).le) hw' hx) fun h => ?_
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((weighted_amhm_eq_iff hw hw' hx).mp h j hj k hk)
+
+end WeightedAMHM

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
+    "title": "Goal: the weighted AM–HM inequality, a gap in Mathlib",
+    "content": "Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but not the harmonic-mean rung M₋₁ ≤ M₁ or its equality case. This file supplies both: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean (∑ wᵢ·xᵢ⁻¹)⁻¹ is at most the weighted arithmetic mean ∑ wᵢ·xᵢ, with equality iff all xᵢ are equal. The header sets up the base chain H ≤ G ≤ A of the power-mean ladder and the strategy of bracketing the geometric mean G via two applications of the parent's weighted AM–GM."
+  },
+  {
+    "id": "ann-prod-rpow-inv",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 60 },
+    "type": "lemma",
+    "title": "Reciprocal of the weighted geometric mean",
+    "content": "prod_rpow_inv proves ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹. Pointwise, Real.inv_rpow (valid since each xᵢ > 0) gives (xᵢ⁻¹)^{wᵢ} = (xᵢ^{wᵢ})⁻¹; Finset.prod_inv_distrib then pulls the inverse out of the product. This is exactly what lets the second AM–GM application — applied to the reciprocals — bound G⁻¹ rather than some unrelated quantity."
+  },
+  {
+    "id": "ann-harm-le-geom",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 75 },
+    "type": "lemma",
+    "title": "Harmonic mean ≤ geometric mean",
+    "content": "harm_le_geom applies the parent's weighted_amgm_le to the reciprocal data xᵢ⁻¹, yielding G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D. Because the geometric mean G > 0 (a product of positive rpow values, Real.rpow_pos_of_pos + Finset.prod_pos), the bound G⁻¹ ≤ D inverts via inv_anti₀ to D⁻¹ ≤ (G⁻¹)⁻¹ = G. This is the H ≤ G half of the base chain."
+  },
+  {
+    "id": "ann-amhm-le",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 76, "endLine": 89 },
+    "type": "theorem",
+    "title": "The weighted AM–HM inequality",
+    "content": "weighted_amhm_le chains the two halves: H ≤ G (harm_le_geom) and G ≤ A (the parent's weighted_amgm_le applied to the data xᵢ), giving (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ. The whole inequality is thus two applications of one parent lemma joined at the common pivot G — no fresh convexity argument."
+  },
+  {
+    "id": "ann-amhm-eq-iff",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 115 },
+    "type": "theorem",
+    "title": "Equality case: harmonic = arithmetic iff data constant",
+    "content": "weighted_amhm_eq_iff characterizes equality. Forward: if H = A then the squeeze H ≤ G ≤ A forces G = A, and the parent's weighted_amgm_eq_iff converts G = A into the constancy of the xᵢ. Backward: constancy makes both AM–GM applications equalities (weighted_amgm_eq_iff in the mpr direction, applied to xᵢ and to xᵢ⁻¹), so D = G⁻¹ and hence H = D⁻¹ = G = A. The squeeze structure makes the harmonic equality case fall out of the geometric one with no extra strict-convexity work."
+  },
+  {
+    "id": "ann-amhm-lt",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 116, "endLine": 124 },
+    "type": "theorem",
+    "title": "Strict inequality when data differ",
+    "content": "weighted_amhm_lt_of_ne upgrades the inequality to strict: if two data values xⱼ ≠ xₖ, then (∑ wᵢ·xᵢ⁻¹)⁻¹ < ∑ wᵢ·xᵢ. Proof: lt_of_le_of_ne from weighted_amhm_le, with the equality ruled out by the contrapositive of weighted_amhm_eq_iff."
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "title": "The Weighted Arithmetic–Harmonic Mean Inequality and its Equality Case",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "description": "Proves the weighted arithmetic–harmonic mean inequality — the M₋₁ ≤ M₁ rung of the weighted power-mean ladder — together with its equality case, neither of which Mathlib provides. For strictly positive data xᵢ and weights wᵢ ≥ 0 summing to 1, the weighted harmonic mean is at most the weighted arithmetic mean: (∑ᵢ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ᵢ wᵢ·xᵢ, with equality iff all the xᵢ are equal. The proof is a clean double application of the parent chain's weighted AM–GM inequality (weighted_amgm_le) and its equality case (weighted_amgm_eq_iff): letting G = ∏ᵢ xᵢ^{wᵢ} be the weighted geometric mean, AM–GM applied to xᵢ gives G ≤ A (the arithmetic mean), and AM–GM applied to the reciprocals xᵢ⁻¹ gives G⁻¹ ≤ D = ∑ᵢ wᵢ·xᵢ⁻¹ (using ∏ (xᵢ⁻¹)^{wᵢ} = G⁻¹); since G > 0 the latter inverts to the harmonic mean D⁻¹ ≤ G, and chaining yields D⁻¹ ≤ G ≤ A. The equality case is obtained by squeezing: H = A forces G = A, which by weighted_amgm_eq_iff means all xᵢ are equal.",
+  "meta": {
+    "author": "Lean Genius (weighted AM–HM via two AM–GM applications); A.-L. Cauchy (means inequalities, 1821)",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "am-gm-inequality",
+      "power-means",
+      "harmonic-mean",
+      "inequalities",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-24",
+    "lineCount": 124,
+    "originalContributions": [
+      "weighted_amhm_le: the weighted arithmetic–harmonic mean inequality (∑ᵢ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ᵢ wᵢ·xᵢ for nonnegative weights summing to 1 and strictly positive data — the M₋₁ ≤ M₁ rung of the weighted power-mean ladder, absent from Mathlib. Proved by bracketing the weighted geometric mean G between the harmonic and arithmetic means via two applications of weighted AM–GM (to xᵢ and to xᵢ⁻¹).",
+      "weighted_amhm_eq_iff: the equality case — the weighted harmonic and arithmetic means coincide iff all the data xᵢ are equal — obtained by squeezing H ≤ G ≤ A to force G = A and invoking the parent's weighted AM–GM equality case.",
+      "weighted_amhm_lt_of_ne: the strict form — if two of the data values differ, the weighted harmonic mean is strictly less than the weighted arithmetic mean.",
+      "prod_rpow_inv: the supporting identity ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹, the reciprocal-distributes-over-the-weighted-geometric-mean fact that makes the second AM–GM application bracket G⁻¹."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. #print axioms reports only propext / Classical.choice / Quot.sound. Builds on the gallery parent JensenInequalityOQ01.lean (weighted_amgm_le, weighted_amgm_eq_iff) and the Mathlib rpow library.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent proves the n-variable Young product inequality (the AM–GM specialization to a^{p}) with its equality case. This entry sits one rung lower on the power-mean ladder, proving M₋₁ ≤ M₁ from the same weighted AM–GM engine, and is a sibling of the Hölder (-oq-01) and Minkowski (-oq-03/-oq-04) leaves."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "extends",
+      "description": "Directly applies the parent's weighted AM–GM inequality weighted_amgm_le and its equality case weighted_amgm_eq_iff, used twice (to the data and to the reciprocals) to bracket the weighted geometric mean between the harmonic and arithmetic means."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The arithmetic–harmonic mean inequality H ≤ A is one of the oldest chapters in the theory of means, systematized by Cauchy (1821) alongside the arithmetic–geometric inequality. Together with G it forms the chain H ≤ G ≤ A, the three-term base of the power-mean ladder M_r, monotone in the exponent r (M₋₁ = H, M₀ = G, M₁ = A). Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but does not separately record the harmonic-mean rung or its equality case; this entry supplies both.",
+    "problemStatement": "Prove the weighted arithmetic–harmonic mean inequality (∑ᵢ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ᵢ wᵢ·xᵢ for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, and characterize equality (it holds iff all the xᵢ are equal).",
+    "proofStrategy": "Let G = ∏ᵢ xᵢ^{wᵢ} be the weighted geometric mean. Apply the parent's weighted AM–GM inequality twice. (1) To the data xᵢ: G = ∏ xᵢ^{wᵢ} ≤ ∑ wᵢ·xᵢ = A. (2) To the reciprocals xᵢ⁻¹: G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D, where the identity ∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹ = G⁻¹ is prod_rpow_inv. Since G > 0, bound (2) inverts (inv_anti₀) to the harmonic mean H = D⁻¹ ≤ G. Chaining gives H ≤ G ≤ A. For equality: if H = A then the squeeze H ≤ G ≤ A collapses to G = A, and weighted_amgm_eq_iff turns G = A into the constancy of the xᵢ; conversely constancy makes both AM–GM applications equalities so H = G = A.",
+    "keyInsights": [
+      "The harmonic-mean rung is not a new inequality but the geometric-mean rung read through reciprocals: applying weighted AM–GM to xᵢ⁻¹ bounds G⁻¹, and inverting (legal because G > 0) turns that into the harmonic mean bound. No convexity argument beyond the two AM–GM calls is needed.",
+      "The single geometric mean G serves as the common pivot: G ≤ A from one AM–GM call and H ≤ G from the other, so the whole chain H ≤ G ≤ A is two invocations of one parent lemma.",
+      "The reciprocal-distributes identity ∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹ rests on Real.inv_rpow (pointwise) and Finset.prod_inv_distrib (over the product), valid because each xᵢ > 0.",
+      "The equality case is free once the inequality is set up as a squeeze: H = A pins G between two equal endpoints, so G = A, and the parent's AM–GM equality case finishes — no separate strict-convexity analysis is required for the harmonic rung."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States the goal — the weighted AM–HM inequality M₋₁ ≤ M₁ and its equality case, a gap in Mathlib — and outlines the two-AM–GM bracketing strategy through the weighted geometric mean.",
+      "mathContext": "Weighted AM–HM: $(\\sum_i w_i x_i^{-1})^{-1} \\le \\sum_i w_i x_i$ for $x_i>0$, $w_i\\ge0$, $\\sum_i w_i = 1$, with equality iff all $x_i$ equal."
+    },
+    {
+      "id": "prod-rpow-inv",
+      "title": "Reciprocal of the weighted geometric mean",
+      "startLine": 53,
+      "endLine": 60,
+      "summary": "prod_rpow_inv: ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹, via Real.inv_rpow pointwise and Finset.prod_inv_distrib over the product.",
+      "mathContext": "$\\prod_i (x_i^{-1})^{w_i} = \\prod_i (x_i^{w_i})^{-1} = \\big(\\prod_i x_i^{w_i}\\big)^{-1}$ for $x_i>0$."
+    },
+    {
+      "id": "harm-le-geom",
+      "title": "Harmonic mean ≤ geometric mean",
+      "startLine": 61,
+      "endLine": 75,
+      "summary": "harm_le_geom: weighted AM–GM applied to the reciprocals gives G⁻¹ ≤ ∑ wᵢ·xᵢ⁻¹, which inverts (G > 0, inv_anti₀) to (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ G.",
+      "mathContext": "$G^{-1} \\le \\sum_i w_i x_i^{-1}$ and $G>0$ give $(\\sum_i w_i x_i^{-1})^{-1} \\le G$ where $G=\\prod_i x_i^{w_i}$."
+    },
+    {
+      "id": "amhm-le",
+      "title": "The weighted AM–HM inequality",
+      "startLine": 76,
+      "endLine": 89,
+      "summary": "weighted_amhm_le: chain H ≤ G (harm_le_geom) with G ≤ A (weighted_amgm_le) to obtain (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ.",
+      "mathContext": "$(\\sum_i w_i x_i^{-1})^{-1} \\le \\prod_i x_i^{w_i} \\le \\sum_i w_i x_i$."
+    },
+    {
+      "id": "amhm-eq-iff",
+      "title": "Equality case",
+      "startLine": 90,
+      "endLine": 115,
+      "summary": "weighted_amhm_eq_iff: H = A squeezes G = A (forward), invoking weighted_amgm_eq_iff for constancy; conversely constancy makes both AM–GM applications equalities so H = G = A (backward).",
+      "mathContext": "$(\\sum_i w_i x_i^{-1})^{-1} = \\sum_i w_i x_i \\iff \\forall j\\,k,\\ x_j = x_k$."
+    },
+    {
+      "id": "amhm-lt",
+      "title": "Strict inequality",
+      "startLine": 116,
+      "endLine": 124,
+      "summary": "weighted_amhm_lt_of_ne: if two data values differ, the inequality is strict, via lt_of_le_of_ne and the equality case.",
+      "mathContext": "If $\\exists j\\,k,\\ x_j \\ne x_k$ then $(\\sum_i w_i x_i^{-1})^{-1} < \\sum_i w_i x_i$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 124-line file (0 sorries, 0 axioms, no native_decide) supplies the weighted arithmetic–harmonic mean inequality and its equality case — the M₋₁ ≤ M₁ rung of the weighted power-mean ladder — which Mathlib does not separately provide. The proof is a clean double application of the gallery parent's weighted AM–GM inequality and its equality case, bracketing the weighted geometric mean between the harmonic and arithmetic means.",
+    "implications": "Together with the parent entries this completes the base H ≤ G ≤ A of the weighted power-mean chain: weighted AM–GM gives both G ≤ A and (read through reciprocals) H ≤ G. The same bracketing makes the equality cases uniform — all three means coincide exactly when the data are constant.",
+    "openQuestions": [
+      "Prove the full weighted power-mean monotonicity M_r ≤ M_s for all real exponents r ≤ s (not just r ∈ {-1, 0, 1}), via convexity/concavity of t ↦ t^{s/r} and Jensen, recovering this AM–HM rung as the (r, s) = (-1, 1) instance.",
+      "Establish the limiting identifications M_r → G as r → 0 and M_r → max/min as r → ±∞, connecting the discrete ladder to its endpoints.",
+      "Derive the Cauchy–Schwarz / Chebyshev-sum consequences of the AM–HM inequality, e.g. (∑ wᵢ xᵢ)(∑ wᵢ xᵢ⁻¹) ≥ 1 with equality iff constant, as an immediate restatement."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 124,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4,
+    "imports": [
+      "Mathlib",
+      "Proofs.JensenInequalityOQ01"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,68 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "title": "The Weighted Arithmetic–Harmonic Mean Inequality and its Equality Case",
+  "problemStatement": "Prove the M₋₁ ≤ M₁ rung of the weighted power-mean ladder: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean is at most the weighted arithmetic mean, (∑ᵢ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ᵢ wᵢ·xᵢ, with equality iff all the xᵢ are equal. Mathlib provides the weighted AM–GM inequality but not the harmonic-mean rung or its equality case.",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "B",
+  "tractability": 8,
+  "significance": 6,
+  "started": "2026-06-24T00:00:00.000Z",
+  "completed": "2026-06-24T21:30:00.000Z",
+  "lastUpdate": "2026-06-24T21:30:00.000Z",
+  "path": "full",
+  "tags": [
+    "analysis",
+    "convexity",
+    "am-gm-inequality",
+    "power-means",
+    "harmonic-mean",
+    "inequalities"
+  ],
+  "knowledge": {
+    "insights": [
+      "The harmonic-mean rung is the geometric-mean rung read through reciprocals: applying weighted AM–GM to xᵢ⁻¹ bounds G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ}, and inverting (legal since G > 0) turns that into the harmonic-mean bound H ≤ G. No convexity argument beyond two AM–GM calls is needed.",
+      "The single weighted geometric mean G = ∏ xᵢ^{wᵢ} is the common pivot: G ≤ A from one AM–GM application and H ≤ G from the other, so the entire chain H ≤ G ≤ A is two invocations of one parent lemma.",
+      "The reciprocal-distributes identity ∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹ rests on Real.inv_rpow pointwise and Finset.prod_inv_distrib over the product (valid because each xᵢ > 0); it is what makes the second AM–GM application bracket G⁻¹.",
+      "The equality case is free once the inequality is a squeeze: H = A pins G between two equal endpoints, so G = A, and the parent's weighted_amgm_eq_iff finishes — no separate strict-convexity analysis is required for the harmonic rung.",
+      "Inverting an order relation between positive reals uses inv_anti₀ (b ≤ a, 0 < b ⟹ a⁻¹ ≤ b⁻¹); positivity of G comes from Real.rpow_pos_of_pos + Finset.prod_pos."
+    ],
+    "builtItems": [
+      "weighted_amhm_le: the weighted AM–HM inequality (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ (JensenInequalityOQ01OQ01OQ01OQ02.lean:77)",
+      "weighted_amhm_eq_iff: equality iff all data equal, by squeezing G = A (JensenInequalityOQ01OQ01OQ01OQ02.lean:90)",
+      "weighted_amhm_lt_of_ne: strict form when two data values differ (JensenInequalityOQ01OQ01OQ01OQ02.lean:117)",
+      "harm_le_geom: harmonic mean ≤ geometric mean via AM–GM on reciprocals + inv_anti₀ (JensenInequalityOQ01OQ01OQ01OQ02.lean:62)",
+      "prod_rpow_inv: ∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹ (JensenInequalityOQ01OQ01OQ01OQ02.lean:54)"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but no separate weighted arithmetic–harmonic mean inequality and no equality case for the harmonic rung; both are supplied here on top of the gallery parent's weighted_amgm_le / weighted_amgm_eq_iff."
+    ],
+    "nextSteps": [
+      "Prove full weighted power-mean monotonicity M_r ≤ M_s for all real exponents r ≤ s, recovering this AM–HM rung as the (r, s) = (-1, 1) instance.",
+      "Derive the Cauchy–Schwarz/Chebyshev-sum consequence (∑ wᵢ xᵢ)(∑ wᵢ xᵢ⁻¹) ≥ 1 with equality iff constant, as an immediate restatement of the AM–HM inequality."
+    ],
+    "progressSummary": "COMPLETE: 0-axiom, 0-sorry proof of the weighted arithmetic–harmonic mean inequality and its equality/strict cases, built as a double application of the gallery parent's weighted AM–GM. #print axioms reports only propext / Classical.choice / Quot.sound."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean",
+      "filename": "JensenInequalityOQ01OQ01OQ01OQ02.lean",
+      "lineCount": 124,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean"
+    }
+  ],
+  "relatedProofs": [
+    "jensen-inequality-oq-01-oq-01-oq-01",
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+    "jensen-inequality-oq-01"
+  ],
+  "references": [
+    "G. H. Hardy, J. E. Littlewood, G. Pólya, Inequalities (1934), Ch. II (means)",
+    "A.-L. Cauchy, Cours d'analyse (1821), Note II"
+  ]
+}


### PR DESCRIPTION
## Weighted Arithmetic–Harmonic Mean Inequality and its Equality Case

Answers the open `-oq-02` leaf of `jensen-inequality-oq-01-oq-01-oq-01`: the **M₋₁ ≤ M₁** rung of the weighted power-mean ladder.

For strictly positive data `xᵢ` and nonnegative weights `wᵢ` summing to `1`:

> `(∑ᵢ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ᵢ wᵢ·xᵢ`,  with **equality iff all `xᵢ` are equal**.

### Proof (two AM–GM applications, one pivot)

Let `G = ∏ᵢ xᵢ^{wᵢ}` be the weighted geometric mean. The parent's weighted AM–GM (`weighted_amgm_le`) is applied twice:

- to the data `xᵢ`:   `G ≤ ∑ wᵢ·xᵢ = A`,
- to the reciprocals `xᵢ⁻¹`:   `G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D`.

Since `G > 0`, the second bound inverts (`inv_anti₀`) to the harmonic mean `H = D⁻¹ ≤ G`, giving the chain `H ≤ G ≤ A`. The equality case is a squeeze: `H = A` forces `G = A`, and `weighted_amgm_eq_iff` turns that into constancy of the `xᵢ`.

### Results

| Theorem | Statement |
|---|---|
| `weighted_amhm_le` | `(∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ` |
| `weighted_amhm_eq_iff` | equality `⟺` all `xᵢ` equal |
| `weighted_amhm_lt_of_ne` | strict when two `xᵢ` differ |
| `prod_rpow_inv` (private) | `∏ (xᵢ⁻¹)^{wᵢ} = (∏ xᵢ^{wᵢ})⁻¹` |

### Verification

- **124 lines, 4 theorems, 0 definitions, 0 sorries, 0 axioms.**
- `#print axioms` on all three public theorems reports only `propext / Classical.choice / Quot.sound` — **no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`**.
- Builds on gallery parent `Proofs/JensenInequalityOQ01.lean` (`weighted_amgm_le`, `weighted_amgm_eq_iff`) + Mathlib rpow library. Compiled with `lake env lean` against the Mathlib v4.26 cache.

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)