### PR TITLE
research(menelaus-theorem-oq-01-oq-03): cevian triangle, Ceva concurrency & Routh's theorem [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/MenelausTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/MenelausTheoremOQ01OQ03.lean
@@ -1,0 +1,239 @@
+import Proofs.MenelausTheorem
+import Mathlib.Tactic
+
+/-
+# Menelaus follow-up: the cevian triangle and Routh's theorem
+
+Open question: `menelaus-theorem-oq-01-oq-03`
+Parent: `Proofs/MenelausTheorem.lean` (`menelaus-theorem-oq-01`).
+
+## What this adds
+
+The parent characterises when a *transversal* meets the three sides of a triangle
+collinearly (signed-ratio product `= -1`). Its Ceva companion characterises when the
+three *cevians* `AX, BY, CZ` are concurrent (signed-ratio product `= +1`, equivalently
+`t·u·v = (1-t)(1-u)(1-v)`).
+
+This file studies the **cevian triangle** `P Q R` cut out by the three cevians:
+
+  `P = AX ∩ BY`,  `Q = BY ∩ CZ`,  `R = CZ ∩ AX`.
+
+Two results, both built on the parent's `collinearDet` machinery:
+
+1. **Concurrency criterion (general triangle).** For an arbitrary non-degenerate
+   triangle, the intersection `P = AX ∩ BY` lies on the third cevian `CZ` — i.e. the
+   three cevians are concurrent and the cevian triangle collapses to a point — **iff**
+   `t·u·v = (1-t)(1-u)(1-v)`. The driving identity
+
+     `collinearDet C Z P · detP
+        = ((1-t)(1-u)(1-v) - t·u·v) · (collinearDet A B C)²`
+
+   is a pure polynomial identity in the six triangle coordinates and `t, u, v`.
+
+2. **Routh's theorem (signed-area formula).** For the canonical reference triangle
+   `A=(0,0), B=(1,0), C=(0,1)` (where `collinearDet A B C = 1`), the signed area of the
+   cevian triangle is
+
+     `collinearDet P Q R
+        = (t·u·v - (1-t)(1-u)(1-v))²
+          / ((1-u+t·u)·(1-v+u·v)·(1-t+v·t))`.
+
+   The vertices `P, Q, R` are *certified* to lie on the correct pairs of cevians, so this
+   really is the cevian triangle. The numerator is the *square* of the concurrency
+   defect, so the cevian triangle collapses to a point exactly when the cevians concur —
+   recovering result (1). Because the area ratio `area(PQR)/area(ABC)` is an affine
+   invariant and every triangle is the affine image of the reference triangle, this
+   closed form is the general Routh ratio. The classical "one-seventh area" triangle
+   (`t=u=v=1/3`, trisection cevians) drops out with value `1/7`.
+
+Routh's theorem is **not** in Mathlib.
+
+## Status
+- [x] Cevian line intersection point, explicit closed form
+- [x] Concurrency criterion (general triangle, polynomial identity)
+- [x] Cevians-concurrent ↔ `t·u·v = (1-t)(1-u)(1-v)`
+- [x] Cevian-triangle vertices certified on their cevians
+- [x] Routh signed-area formula (reference triangle)
+- [x] Cevian triangle degenerate ↔ concurrent (corollary of Routh)
+- [x] One-seventh area triangle as a concrete instance
+- [x] 0 sorries, 0 axioms
+-/
+
+namespace MenelausTheoremOQ01OQ03
+
+open MenelausTheorem
+
+set_option linter.unusedVariables false
+
+/-! ### Cevian line intersection (general triangle) -/
+
+/-- The cross product of the direction vectors of the line `P→Q` and the line `R→S`.
+    It vanishes exactly when the two lines are parallel, and is the denominator that
+    appears when solving for their intersection. -/
+def detLines (P Q R S : Pt) : ℝ :=
+  (Q.1 - P.1) * (S.2 - R.2) - (Q.2 - P.2) * (S.1 - R.1)
+
+/-- The intersection point of the line through `P, Q` and the line through `R, S`,
+    via Cramer's rule on the two line equations. Valid when `detLines P Q R S ≠ 0`. -/
+noncomputable def interPt (P Q R S : Pt) : Pt :=
+  let c1 := (Q.1 - P.1) * P.2 - (Q.2 - P.2) * P.1
+  let c2 := (S.1 - R.1) * R.2 - (S.2 - R.2) * R.1
+  let d := detLines P Q R S
+  ((c1 * (S.1 - R.1) - c2 * (Q.1 - P.1)) / d,
+   ((S.2 - R.2) * c1 - (Q.2 - P.2) * c2) / d)
+
+/-- Vertex `P = AX ∩ BY` of the cevian triangle. -/
+noncomputable def cevP (cfg : MenelausConfig) : Pt :=
+  interPt cfg.A (ptX cfg) cfg.B (ptY cfg)
+
+/-- Parallelism denominator for the pair of cevians `AX, BY`. -/
+def detP (cfg : MenelausConfig) : ℝ := detLines cfg.A (ptX cfg) cfg.B (ptY cfg)
+
+/-- `cevP` lies on the cevian `AX` (when `AX, BY` are not parallel). -/
+theorem cevP_on_AX (cfg : MenelausConfig) (hP : detP cfg ≠ 0) :
+    collinearDet cfg.A (ptX cfg) (cevP cfg) = 0 := by
+  simp only [collinearDet, cevP, interPt, ptX, ptY, detP, detLines] at hP ⊢
+  field_simp at hP ⊢
+  ring
+
+/-- `cevP` lies on the cevian `BY` (when `AX, BY` are not parallel). -/
+theorem cevP_on_BY (cfg : MenelausConfig) (hP : detP cfg ≠ 0) :
+    collinearDet cfg.B (ptY cfg) (cevP cfg) = 0 := by
+  simp only [collinearDet, cevP, interPt, ptX, ptY, detP, detLines] at hP ⊢
+  field_simp at hP ⊢
+  ring
+
+/-! ### Concurrency criterion (general triangle) -/
+
+/-- **Concurrency defect identity.** For an arbitrary triangle, the signed area of
+    `C, Z, P` (which vanishes exactly when `P` lies on the third cevian `CZ`) equals the
+    concurrency defect `(1-t)(1-u)(1-v) - t·u·v` times the square of the triangle's own
+    signed area. A pure polynomial identity in all six coordinates and `t, u, v`. -/
+theorem concurrency_defect (cfg : MenelausConfig) (hP : detP cfg ≠ 0) :
+    collinearDet cfg.C (ptZ cfg) (cevP cfg) * detP cfg
+      = ((1 - cfg.t) * (1 - cfg.u) * (1 - cfg.v) - cfg.t * cfg.u * cfg.v)
+        * (collinearDet cfg.A cfg.B cfg.C) ^ 2 := by
+  simp only [collinearDet, cevP, interPt, ptX, ptY, ptZ, detP, detLines] at hP ⊢
+  field_simp at hP ⊢
+  ring
+
+/-- **Cevian concurrency criterion.** For a non-degenerate triangle whose cevians
+    `AX, BY` are not parallel, the three cevians `AX, BY, CZ` are concurrent (the vertex
+    `P = AX ∩ BY` lies on `CZ`) **iff** `t·u·v = (1-t)(1-u)(1-v)`. This is the cevian
+    (Ceva-type) companion of the parent's transversal (Menelaus) criterion. -/
+theorem cevians_concurrent_iff (cfg : MenelausConfig) (hP : detP cfg ≠ 0) :
+    collinearDet cfg.C (ptZ cfg) (cevP cfg) = 0
+      ↔ cfg.t * cfg.u * cfg.v = (1 - cfg.t) * (1 - cfg.u) * (1 - cfg.v) := by
+  have hΔ : collinearDet cfg.A cfg.B cfg.C ≠ 0 := cfg.nondegen
+  have key := concurrency_defect cfg hP
+  constructor
+  · intro h
+    rw [h, zero_mul] at key
+    have hsq : (collinearDet cfg.A cfg.B cfg.C) ^ 2 ≠ 0 := pow_ne_zero _ hΔ
+    have : (1 - cfg.t) * (1 - cfg.u) * (1 - cfg.v) - cfg.t * cfg.u * cfg.v = 0 :=
+      (mul_eq_zero.mp key.symm).resolve_right hsq
+    linarith
+  · intro h
+    have hz : (1 - cfg.t) * (1 - cfg.u) * (1 - cfg.v) - cfg.t * cfg.u * cfg.v = 0 := by
+      linarith
+    have hzero : collinearDet cfg.C (ptZ cfg) (cevP cfg) * detP cfg = 0 := by
+      rw [key, hz, zero_mul]
+    exact (mul_eq_zero.mp hzero).resolve_right hP
+
+/-! ### Routh's theorem on the reference triangle
+
+We work with the canonical reference triangle `A=(0,0), B=(1,0), C=(0,1)`, where the
+division points are `X=(1-t,t)`, `Y=(0,1-u)`, `Z=(v,0)`. Every triangle is an affine
+image of this one and the cevian area ratio is affine-invariant, so the closed form
+below is the general Routh ratio. The cevian-triangle vertices are written in explicit
+closed form and then *certified* to lie on the correct cevians. -/
+
+/-- Cevian-triangle vertex `P = AX ∩ BY`, reference triangle, closed form. -/
+noncomputable def vP (t u v : ℝ) : Pt :=
+  ((1 - t) * (1 - u) / (1 - u + t * u), t * (1 - u) / (1 - u + t * u))
+
+/-- Cevian-triangle vertex `Q = BY ∩ CZ`, reference triangle, closed form. -/
+noncomputable def vQ (t u v : ℝ) : Pt :=
+  (u * v / (1 - v + u * v), (1 - u) * (1 - v) / (1 - v + u * v))
+
+/-- Cevian-triangle vertex `R = CZ ∩ AX`, reference triangle, closed form. -/
+noncomputable def vR (t u v : ℝ) : Pt :=
+  ((1 - t) * v / (1 - t + v * t), t * v / (1 - t + v * t))
+
+/-- `vP` lies on cevian `AX` (from `A=(0,0)` to `X=(1-t,t)`). -/
+theorem vP_on_AX (t u v : ℝ) (hDP : 1 - u + t * u ≠ 0) :
+    collinearDet (0, 0) (1 - t, t) (vP t u v) = 0 := by
+  simp only [collinearDet, vP]; field_simp; ring
+
+/-- `vP` lies on cevian `BY` (from `B=(1,0)` to `Y=(0,1-u)`). -/
+theorem vP_on_BY (t u v : ℝ) (hDP : 1 - u + t * u ≠ 0) :
+    collinearDet (1, 0) (0, 1 - u) (vP t u v) = 0 := by
+  simp only [collinearDet, vP]; field_simp; ring
+
+/-- `vQ` lies on cevian `BY`. -/
+theorem vQ_on_BY (t u v : ℝ) (hDQ : 1 - v + u * v ≠ 0) :
+    collinearDet (1, 0) (0, 1 - u) (vQ t u v) = 0 := by
+  simp only [collinearDet, vQ]; field_simp; ring
+
+/-- `vQ` lies on cevian `CZ` (from `C=(0,1)` to `Z=(v,0)`). -/
+theorem vQ_on_CZ (t u v : ℝ) (hDQ : 1 - v + u * v ≠ 0) :
+    collinearDet (0, 1) (v, 0) (vQ t u v) = 0 := by
+  have hDQ2 : 1 - v + v * u ≠ 0 := by rwa [mul_comm u v] at hDQ
+  simp only [collinearDet, vQ]; field_simp [hDQ, hDQ2]; ring
+
+/-- `vR` lies on cevian `CZ`. -/
+theorem vR_on_CZ (t u v : ℝ) (hDR : 1 - t + v * t ≠ 0) :
+    collinearDet (0, 1) (v, 0) (vR t u v) = 0 := by
+  simp only [collinearDet, vR]; field_simp; ring
+
+/-- `vR` lies on cevian `AX`. -/
+theorem vR_on_AX (t u v : ℝ) (hDR : 1 - t + v * t ≠ 0) :
+    collinearDet (0, 0) (1 - t, t) (vR t u v) = 0 := by
+  simp only [collinearDet, vR]; field_simp; ring
+
+/-- **Routh's theorem (signed-area form).** For the reference triangle, the signed area
+    of the cevian triangle `P Q R` is the square of the concurrency defect divided by the
+    product of the three "Routh denominators" `1-u+t·u`, `1-v+u·v`, `1-t+v·t`. Since
+    `collinearDet A B C = 1` here, this is exactly the area ratio. -/
+theorem routh_area (t u v : ℝ)
+    (hDP : 1 - u + t * u ≠ 0) (hDQ : 1 - v + u * v ≠ 0) (hDR : 1 - t + v * t ≠ 0) :
+    collinearDet (vP t u v) (vQ t u v) (vR t u v)
+      = (t * u * v - (1 - t) * (1 - u) * (1 - v)) ^ 2
+        / ((1 - u + t * u) * (1 - v + u * v) * (1 - t + v * t)) := by
+  have hDP2 : 1 - u + u * t ≠ 0 := by rwa [mul_comm t u] at hDP
+  have hDQ2 : 1 - v + v * u ≠ 0 := by rwa [mul_comm u v] at hDQ
+  have hDR2 : 1 - t + t * v ≠ 0 := by rwa [mul_comm v t] at hDR
+  simp only [collinearDet, vP, vQ, vR]
+  field_simp [hDP, hDP2, hDQ, hDQ2, hDR, hDR2]
+  ring
+
+/-- **Cevian triangle degenerates iff cevians concur** (reference triangle). The signed
+    area vanishes exactly at the Ceva concurrency condition — the numerator of Routh's
+    ratio is the *square* of the concurrency defect. -/
+theorem routh_area_zero_iff (t u v : ℝ)
+    (hDP : 1 - u + t * u ≠ 0) (hDQ : 1 - v + u * v ≠ 0) (hDR : 1 - t + v * t ≠ 0) :
+    collinearDet (vP t u v) (vQ t u v) (vR t u v) = 0
+      ↔ t * u * v = (1 - t) * (1 - u) * (1 - v) := by
+  rw [routh_area t u v hDP hDQ hDR, div_eq_zero_iff]
+  constructor
+  · rintro (h | h)
+    · have : t * u * v - (1 - t) * (1 - u) * (1 - v) = 0 :=
+        pow_eq_zero_iff (by norm_num) |>.mp h
+      linarith
+    · exact absurd h (by
+        simp only [mul_ne_zero_iff]; exact ⟨⟨hDP, hDQ⟩, hDR⟩)
+  · intro h
+    left
+    have : t * u * v - (1 - t) * (1 - u) * (1 - v) = 0 := by linarith
+    rw [this]; norm_num
+
+/-- **The one-seventh area triangle.** When `t = u = v = 1/3` the cevians trisect the
+    sides (each cuts `1 : 2`), and the cevian triangle has exactly `1/7` the signed area
+    of the reference triangle — the classical Routh "one-seventh" instance. -/
+theorem routh_one_seventh :
+    collinearDet (vP (1/3) (1/3) (1/3)) (vQ (1/3) (1/3) (1/3)) (vR (1/3) (1/3) (1/3))
+      = 1 / 7 := by
+  rw [routh_area (1/3) (1/3) (1/3) (by norm_num) (by norm_num) (by norm_num)]
+  norm_num
+
+end MenelausTheoremOQ01OQ03

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,163 @@
+[
+  {
+    "id": "ann-menOQ0103-overview",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
+    "type": "context",
+    "title": "From the Transversal to the Cevian Triangle: Ceva, Routh, and Menelaus",
+    "content": "The parent entry characterises when a TRANSVERSAL line meets the three sides of a triangle collinearly (signed-ratio product −1). This entry turns to the dual configuration: the three CEVIANS AX, BY, CZ, which generically bound a small central triangle PQR — the cevian triangle. Two questions are answered. First, when do the cevians instead concur (PQR shrinks to a point)? This is Ceva's theorem, and it appears here as the exact sign-flip of the parent's Menelaus condition: product +1 instead of −1, i.e. t·u·v = (1−t)(1−u)(1−v). Second, what is the area of PQR? This is Routh's 1891 theorem, recovered in closed form. The whole development rides on the parent's signed-area determinant collinearDet — no new geometric primitive is needed.",
+    "mathContext": "Cevians $AX,BY,CZ$; cevian triangle $PQR$ with $P=AX\\cap BY$, $Q=BY\\cap CZ$, $R=CZ\\cap AX$. Concurrency $\\iff tuv=(1-t)(1-u)(1-v)$; Routh area $\\frac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Routh's theorem",
+      "Ceva's theorem",
+      "Menelaus's theorem",
+      "cevian triangle",
+      "signed area"
+    ],
+    "prerequisites": [
+      "parent Menelaus formalization",
+      "cevians and transversals",
+      "affine invariance of area ratios"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-interpt",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 68,
+      "endLine": 104
+    },
+    "type": "technique",
+    "title": "Line Intersection by Cramer's Rule",
+    "content": "The cevian-triangle vertices are intersections of pairs of cevian lines. interPt computes the intersection of the line through P,Q and the line through R,S by Cramer's rule: the denominator detLines is the cross product of the two direction vectors (zero exactly when the lines are parallel), and the numerators are the corresponding 2×2 determinants. For the cevian P = AX∩BY this denominator is detP. The two lemmas cevP_on_AX and cevP_on_BY then certify — by clearing detP and calling ring — that the computed point genuinely lies on both cevians, so it really is their intersection.",
+    "mathContext": "For lines through $P,Q$ and $R,S$: $\\det=(Q-P)\\times(S-R)$, $P^*=\\bigl(\\tfrac{c_1\\Delta x_2-c_2\\Delta x_1}{\\det},\\tfrac{\\Delta y_2 c_1-\\Delta y_1 c_2}{\\det}\\bigr)$.",
+    "significance": "core technique",
+    "relatedConcepts": [
+      "Cramer's rule",
+      "line intersection",
+      "cross product",
+      "parallelism"
+    ],
+    "prerequisites": [
+      "2×2 linear systems",
+      "determinants"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-concurrency-defect",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 109,
+      "endLine": 122
+    },
+    "type": "key-step",
+    "title": "The Concurrency Defect Identity",
+    "content": "This is the engine of the general concurrency criterion. The signed area collinearDet C Z P (which vanishes exactly when P=AX∩BY also lies on the third cevian CZ) is shown, after clearing the single denominator detP, to equal the concurrency defect (1−t)(1−u)(1−v) − t·u·v times the SQUARE of the triangle's own signed area. It is a pure polynomial identity in all nine variables — the six coordinates of A, B, C and the three parameters t, u, v — discharged by field_simp followed by ring. Crucially this holds for an ARBITRARY triangle, not just a reference one.",
+    "mathContext": "$\\operatorname{collinearDet}(C,Z,P)\\cdot\\det_P = \\big((1-t)(1-u)(1-v)-tuv\\big)\\,(\\operatorname{collinearDet}(A,B,C))^2.$",
+    "significance": "the key polynomial identity",
+    "relatedConcepts": [
+      "polynomial identity",
+      "concurrency defect",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "signed-area determinant",
+      "clearing denominators"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-concurrency-iff",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 124,
+      "endLine": 141
+    },
+    "type": "key-step",
+    "title": "Cevian Concurrency Criterion (the Ceva companion)",
+    "content": "Because the triangle is non-degenerate, its signed area collinearDet A B C is nonzero, hence so is its square. Dividing the concurrency defect identity by that square gives the clean biconditional: the three cevians AX, BY, CZ are concurrent iff t·u·v = (1−t)(1−u)(1−v). Comparing with the parent's Menelaus criterion t·u·v = −(1−t)(1−u)(1−v), the only difference is the SIGN — concurrency (Ceva, +) versus transversal collinearity (Menelaus, −) — exactly the classical Ceva/Menelaus duality, now both proved in the same affine framework.",
+    "mathContext": "$AX,BY,CZ$ concurrent $\\iff tuv=(1-t)(1-u)(1-v)$ (Ceva), vs. transversal collinear $\\iff tuv=-(1-t)(1-u)(1-v)$ (Menelaus).",
+    "significance": "general-triangle result",
+    "relatedConcepts": [
+      "Ceva's theorem",
+      "Menelaus's theorem",
+      "concurrency",
+      "duality"
+    ],
+    "prerequisites": [
+      "non-degeneracy",
+      "pow_ne_zero",
+      "mul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-vertices",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 143,
+      "endLine": 196
+    },
+    "type": "key-step",
+    "title": "Closed-Form Cevian-Triangle Vertices, Certified on Their Cevians",
+    "content": "For the Routh area computation we work on the canonical reference triangle A=(0,0), B=(1,0), C=(0,1), where X=(1−t,t), Y=(0,1−u), Z=(v,0). The three cevian-triangle vertices then have the explicit closed forms vP, vQ, vR with the cyclic Routh denominators D₁=1−u+tu, D₂=1−v+uv, D₃=1−t+vt. To guarantee these really are the cevian triangle (and not merely convenient points), six on-line lemmas certify each vertex lies on its two cevians — e.g. vP on AX and on BY. Working on the reference triangle keeps every later ring call in three variables, so proof terms stay small and #print axioms remains clean.",
+    "mathContext": "$P=\\bigl(\\tfrac{(1-t)(1-u)}{D_1},\\tfrac{t(1-u)}{D_1}\\bigr),\\ Q=\\bigl(\\tfrac{uv}{D_2},\\tfrac{(1-u)(1-v)}{D_2}\\bigr),\\ R=\\bigl(\\tfrac{(1-t)v}{D_3},\\tfrac{tv}{D_3}\\bigr).$",
+    "significance": "construction with certification",
+    "relatedConcepts": [
+      "reference triangle",
+      "affine invariance",
+      "cevian triangle"
+    ],
+    "prerequisites": [
+      "barycentric/affine coordinates",
+      "on-line membership via collinearDet"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-routh",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 197,
+      "endLine": 231
+    },
+    "type": "key-step",
+    "title": "Routh's Theorem and the Square-of-Defect Numerator",
+    "content": "Clearing the three Routh denominators and calling ring yields Routh's theorem in signed-area form: the signed area of the cevian triangle is (tuv−(1−t)(1−u)(1−v))² divided by (1−u+tu)(1−v+uv)(1−t+vt). The numerator is the SQUARE of the concurrency defect from the general criterion above, so routh_area_zero_iff reads off immediately that the cevian triangle collapses to a point exactly when the cevians concur — Ceva as a corollary of Routh. Since the cevian-triangle area ratio is an affine invariant and collinearDet A B C = 1 on the reference triangle, this closed form is the general Routh ratio.",
+    "mathContext": "$\\operatorname{collinearDet}(P,Q,R)=\\dfrac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}$; zero $\\iff tuv=(1-t)(1-u)(1-v)$.",
+    "significance": "main result",
+    "relatedConcepts": [
+      "Routh's theorem",
+      "area ratio",
+      "concurrency degeneration"
+    ],
+    "prerequisites": [
+      "field_simp / ring",
+      "div_eq_zero_iff",
+      "pow_eq_zero_iff"
+    ]
+  },
+  {
+    "id": "ann-menOQ0103-oneseventh",
+    "proofId": "menelaus-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 233,
+      "endLine": 239
+    },
+    "type": "example",
+    "title": "The Classical One-Seventh-Area Triangle",
+    "content": "Setting t=u=v=1/3 makes each cevian run to the nearer trisection point of its side (cutting it 1:2). Routh's formula then gives signed area exactly 1/7 — the famous one-seventh-area triangle that motivated Routh's general formula and is a staple of competition geometry. Here it is a one-line corollary: substitute into routh_area and call norm_num.",
+    "mathContext": "$t=u=v=\\tfrac13:\\ \\dfrac{\\left(\\tfrac1{27}-\\tfrac{8}{27}\\right)^2}{(\\tfrac79)^3}=\\dfrac{49/729}{343/729}=\\dfrac{49}{343}=\\tfrac17.$",
+    "significance": "classical instance",
+    "relatedConcepts": [
+      "one-seventh area triangle",
+      "trisection cevians",
+      "Routh's theorem"
+    ],
+    "prerequisites": [
+      "substitution",
+      "norm_num"
+    ]
+  }
+]

--- a/src/data/proofs/menelaus-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/menelaus-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "menelaus-theorem-oq-01-oq-03",
+  "title": "The Cevian Triangle and Routh's Theorem",
+  "slug": "menelaus-theorem-oq-01-oq-03",
+  "description": "Builds on the parent Menelaus formalization to study the cevian triangle PQR cut out by the three cevians AX, BY, CZ. Two results, both from the parent's signed-area determinant collinearDet: (1) a general-triangle concurrency criterion — P=AX∩BY lies on CZ iff t·u·v=(1-t)(1-u)(1-v), driven by the polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - tuv)·(collinearDet A B C)²; and (2) Routh's theorem in signed-area form on the reference triangle: collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))² / ((1-u+tu)(1-v+uv)(1-t+vt)), with the three vertices certified to lie on the correct cevians. The Routh numerator is the square of the concurrency defect, so the cevian triangle collapses to a point exactly when the cevians concur; the classical 1/7-area triangle (t=u=v=1/3) drops out as a corollary. 13 theorems, 7 definitions, 0 sorries, 0 axioms. Routh's theorem is not in Mathlib.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Routh%27s_theorem",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MenelausTheoremOQ01OQ03.lean",
+    "tags": [
+      "geometry",
+      "routh-theorem",
+      "menelaus",
+      "ceva",
+      "cevian-triangle",
+      "affine-coordinates",
+      "triangles",
+      "signed-area"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified; #print axioms reports only propext, Classical.choice, Quot.sound for every theorem (no native_decide, no sorry). The Routh area formula is proved for the canonical reference triangle A=(0,0), B=(1,0), C=(0,1); since the cevian-triangle area ratio is an affine invariant and every triangle is an affine image of the reference triangle, the closed form is the general Routh ratio. The concurrency criterion is proved for a fully general non-degenerate triangle.",
+    "lineCount": 239,
+    "theoremCount": 13,
+    "definitionCount": 7,
+    "originalContributions": [
+      "detLines / interPt: cross-product parallelism denominator and Cramer's-rule intersection point of two lines in ℝ²",
+      "cevP: the cevian-triangle vertex AX∩BY, with cevP_on_AX / cevP_on_BY certifying it lies on both cevians",
+      "concurrency_defect: the general-triangle polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - tuv)·(collinearDet A B C)², the engine of the concurrency criterion",
+      "cevians_concurrent_iff: the cevian (Ceva-type) concurrency criterion — cevians AX, BY, CZ concur iff t·u·v = (1-t)(1-u)(1-v), the companion of the parent's transversal Menelaus criterion",
+      "vP, vQ, vR: closed-form cevian-triangle vertices on the reference triangle, each certified on its two cevians by the six on-line lemmas",
+      "routh_area: Routh's theorem in signed-area form — collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))² / ((1-u+tu)(1-v+uv)(1-t+vt)), with explicit closed-form Routh denominators",
+      "routh_area_zero_iff: the cevian triangle degenerates to a point iff the cevians concur (numerator is the square of the concurrency defect)",
+      "routh_one_seventh: the classical one-seventh-area triangle (t=u=v=1/3) as a concrete instance"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Edward John Routh published this area formula in his 1891 treatise on analytical statics, generalizing the classical 'one-seventh area' puzzle: if each side of a triangle is trisected and a cevian is drawn to the nearer trisection point, the three cevians bound a central triangle of exactly one-seventh the area. Routh's theorem subsumes both Ceva's theorem (the central triangle degenerates to a point — concurrency — precisely when the area is zero) and, through that degeneration, the cevian companion of Menelaus's transversal theorem. Where the parent entry characterises when a transversal line meets the three sides collinearly (signed-ratio product -1), this entry characterises the triangle cut out by the three cevians and computes its area in closed form.",
+    "problemStatement": "Given triangle ABC with cevians AX, BY, CZ to the division points X=(1-t)B+tC, Y=(1-u)C+uA, Z=(1-v)A+vB, let P=AX∩BY, Q=BY∩CZ, R=CZ∩AX be the vertices of the cevian triangle. (1) When are the three cevians concurrent (cevian triangle a single point)? (2) What is the signed area of the cevian triangle relative to ABC?",
+    "text": "Both questions reduce to the parent's signed-area determinant collinearDet. For (1), the intersection point P=AX∩BY is computed by Cramer's rule (denominator detP = the cross product of the two cevian directions). The signed area collinearDet C Z P, which vanishes exactly when P also lies on CZ, satisfies the pure polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - t·u·v)·(collinearDet A B C)². For a non-degenerate triangle (collinearDet A B C ≠ 0) the cevians therefore concur iff t·u·v = (1-t)(1-u)(1-v) — the Ceva condition, mirroring the parent's Menelaus condition with the opposite sign. For (2), on the reference triangle the three cevian-triangle vertices have the closed forms P=((1-t)(1-u)/D₁, t(1-u)/D₁), Q=(uv/D₂, (1-u)(1-v)/D₂), R=((1-t)v/D₃, tv/D₃) with Routh denominators D₁=1-u+tu, D₂=1-v+uv, D₃=1-t+vt. Each is certified to lie on its two cevians, and a field_simp/ring computation yields Routh's formula collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))² / (D₁D₂D₃). The numerator is the square of the concurrency defect from part (1), so the area vanishes exactly at concurrency.",
+    "proofStrategy": "Part I builds the general intersection machinery: detLines (parallelism denominator) and interPt (Cramer's-rule intersection). cevP = AX∩BY is certified on both cevians by cevP_on_AX and cevP_on_BY (field_simp; ring). Part II proves concurrency_defect — a 9-variable polynomial identity over the six triangle coordinates and t,u,v, discharged by field_simp/ring after clearing the single intersection denominator — and derives cevians_concurrent_iff by cancelling the squared (nonzero) area factor. Part III works on the reference triangle: the three vertices vP, vQ, vR are given in closed form, certified to lie on the correct cevians by six on-line lemmas, and Routh's area formula routh_area is proved by clearing the three Routh denominators and applying ring. routh_area_zero_iff reads off the concurrency corollary from the squared numerator, and routh_one_seventh instantiates t=u=v=1/3.",
+    "keyInsights": [
+      "The cevian intersection point P=AX∩BY is a rational function of the coordinates and t,u,v with denominator detP (the cross product of the two cevian directions)",
+      "Concurrency is governed by the polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - tuv)·(collinearDet A B C)² — a single ring computation valid for any triangle",
+      "Cevians concur iff t·u·v = (1-t)(1-u)(1-v) (signed-ratio product +1), the exact sign-flip of the parent's Menelaus collinearity condition (product -1)",
+      "Routh's area numerator (tuv-(1-t)(1-u)(1-v))² is the SQUARE of the concurrency defect, so the cevian triangle collapses to a point precisely when the cevians concur",
+      "The three Routh denominators have the clean cyclic closed form 1-u+tu, 1-v+uv, 1-t+vt",
+      "Because the area ratio is an affine invariant, the reference-triangle computation gives the general Routh ratio; t=u=v=1/3 recovers the classical 1/7-area triangle"
+    ],
+    "prerequisites": [
+      "Parent Menelaus formalization: Pt = ℝ×ℝ, collinearDet, MenelausConfig, ptX/ptY/ptZ",
+      "Line intersection via Cramer's rule and the cross-product parallelism test",
+      "Affine invariance of area ratios; the reference triangle A=(0,0),B=(1,0),C=(0,1)",
+      "Real field arithmetic: field_simp, ring, the square-of-defect factorisation"
+    ]
+  },
+  "conclusion": {
+    "summary": "The cevian triangle PQR cut from triangle ABC by the cevians AX, BY, CZ is fully analysed via the parent's signed-area determinant. A general-triangle polynomial identity yields the cevian concurrency criterion t·u·v = (1-t)(1-u)(1-v) — the sign-flipped companion of the parent's Menelaus condition — and, on the reference triangle, Routh's theorem in signed-area form collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))²/((1-u+tu)(1-v+uv)(1-t+vt)), with all three vertices certified on their cevians. The squared numerator makes the Ceva degeneracy immediate, and the classical one-seventh-area triangle is recovered. 13 theorems, 7 definitions, 239 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the Ceva/Menelaus picture in the gallery: the parent handles transversal collinearity, this entry handles cevian concurrency and the full cevian-triangle area (Routh). The intersection-point machinery (detLines, interPt) and the square-of-defect factorisation are reusable for further triangle-geometry area formulas. Routh's theorem is not present in Mathlib.",
+    "openQuestions": [
+      "Lift the Routh area formula from the reference triangle to a fully general triangle by formalizing affine invariance of the area ratio (or by a direct 9-variable ring identity)",
+      "Specialize to the medial/Gergonne/Nagel cevians and recover their classical area ratios as corollaries of routh_area",
+      "Prove the converse Routh problem: given a target area ratio, characterize the (t,u,v) achieving it"
+    ]
+  },
+  "leanFile": {
+    "namespace": "MenelausTheoremOQ01OQ03",
+    "lineCount": 239,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 7,
+    "path": "Proofs/MenelausTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "menelaus-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the transversal Menelaus criterion (product -1). This entry reuses its collinearDet / MenelausConfig / ptX,ptY,ptZ machinery for the cevian (product +1) and area story."
+    },
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "Ceva's concurrency theorem (product +1); cevians_concurrent_iff is the determinant-form companion, and routh_area_zero_iff shows the cevian triangle degenerates exactly at Ceva's condition."
+    }
+  ],
+  "references": [
+    {
+      "text": "Routh, E. J. (1891). A Treatise on Analytical Statics, Vol. 1. The cevian-triangle area ratio.",
+      "url": "https://en.wikipedia.org/wiki/Routh%27s_theorem"
+    },
+    {
+      "text": "Coxeter, H. S. M. & Greitzer, S. L. (1967). Geometry Revisited. MAA. §1.3 (Ceva), §3.4 (Menelaus), and Routh's theorem.",
+      "url": "https://en.wikipedia.org/wiki/Geometry_Revisited"
+    }
+  ],
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 64,
+      "description": "Module docstring framing the cevian triangle PQR as the natural successor to the parent's transversal Menelaus theorem: a general concurrency criterion plus Routh's signed-area formula, both from the parent's collinearDet.",
+      "mathContext": "Cevian triangle of $AX,BY,CZ$; concurrency iff $tuv=(1-t)(1-u)(1-v)$; Routh area $\\frac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}$."
+    },
+    {
+      "id": "intersection",
+      "title": "Cevian Line Intersection (General Triangle)",
+      "startLine": 65,
+      "endLine": 108,
+      "description": "detLines (cross product of two line directions — the parallelism denominator) and interPt (the intersection point by Cramer's rule). cevP = AX∩BY, with detP its denominator; cevP_on_AX and cevP_on_BY certify cevP lies on both cevians.",
+      "mathContext": "$P=AX\\cap BY$ with $\\det_P=(X-A)\\times(Y-B)$; $P=\\bigl(\\tfrac{c_1\\Delta x_2-c_2\\Delta x_1}{\\det_P},\\dots\\bigr)$."
+    },
+    {
+      "id": "concurrency",
+      "title": "Concurrency Criterion (General Triangle)",
+      "startLine": 109,
+      "endLine": 155,
+      "description": "concurrency_defect: the polynomial identity collinearDet C Z P · detP = ((1-t)(1-u)(1-v) - tuv)·(collinearDet A B C)², valid for any triangle. cevians_concurrent_iff cancels the squared nonzero area factor to conclude the cevians concur iff t·u·v = (1-t)(1-u)(1-v).",
+      "mathContext": "$AX,BY,CZ$ concurrent $\\iff tuv=(1-t)(1-u)(1-v)$ — the cevian companion of Menelaus's $tuv=-(1-t)(1-u)(1-v)$."
+    },
+    {
+      "id": "routh-vertices",
+      "title": "Cevian-Triangle Vertices (Reference Triangle)",
+      "startLine": 156,
+      "endLine": 191,
+      "description": "Closed-form vertices vP, vQ, vR of the cevian triangle on the reference triangle A=(0,0),B=(1,0),C=(0,1), each certified to lie on its two cevians by the six on-line lemmas vP_on_AX, vP_on_BY, vQ_on_BY, vQ_on_CZ, vR_on_CZ, vR_on_AX.",
+      "mathContext": "$P=\\bigl(\\tfrac{(1-t)(1-u)}{D_1},\\tfrac{t(1-u)}{D_1}\\bigr)$, $D_1=1-u+tu$; similarly $Q,R$ with $D_2=1-v+uv$, $D_3=1-t+vt$."
+    },
+    {
+      "id": "routh-theorem",
+      "title": "Routh's Theorem (Signed-Area Formula)",
+      "startLine": 192,
+      "endLine": 239,
+      "description": "routh_area: collinearDet P Q R = (tuv-(1-t)(1-u)(1-v))² / ((1-u+tu)(1-v+uv)(1-t+vt)). routh_area_zero_iff reads off the Ceva degeneracy (squared numerator), and routh_one_seventh instantiates t=u=v=1/3 to the classical one-seventh-area triangle.",
+      "mathContext": "$[PQR]=\\frac{(tuv-(1-t)(1-u)(1-v))^2}{(1-u+tu)(1-v+uv)(1-t+vt)}\\,[ABC]$; $t=u=v=\\tfrac13\\Rightarrow\\tfrac17$."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up leaf of `menelaus-theorem-oq-01` (the parent even names Routh's theorem as a follow-up direction). Where the parent characterises a **transversal** meeting the three sides collinearly (signed-ratio product −1), this entry studies the **cevian triangle** `PQR` cut out by the three cevians `AX, BY, CZ`, reusing the parent's `collinearDet` machinery.

**Two results:**

1. **Concurrency criterion (general triangle).** The intersection `P = AX ∩ BY` lies on the third cevian `CZ` — i.e. the cevians concur — **iff** `t·u·v = (1−t)(1−u)(1−v)`. Driven by the pure polynomial identity (all 6 coordinates + t,u,v):
   ```
   collinearDet C Z P · detP = ((1−t)(1−u)(1−v) − t·u·v) · (collinearDet A B C)²
   ```
   This is the exact **sign-flip** of the parent's Menelaus condition (Ceva +1 vs Menelaus −1).

2. **Routh's theorem (signed-area form, reference triangle).**
   ```
   collinearDet P Q R = (t·u·v − (1−t)(1−u)(1−v))² / ((1−u+tu)(1−v+uv)(1−t+vt))
   ```
   All three cevian-triangle vertices are **certified** to lie on their correct cevians (six on-line lemmas). The numerator is the *square* of the concurrency defect, so the cevian triangle collapses to a point exactly when the cevians concur (Ceva as a corollary, `routh_area_zero_iff`). The classical **one-seventh-area triangle** (`t=u=v=1/3`) drops out as `routh_one_seventh`.

The Routh area ratio is an affine invariant and every triangle is an affine image of the reference triangle, so the closed form is the general Routh ratio (disclosed honestly in `assumptions`). The concurrency criterion is for a fully general triangle.

## Verification
- **13 theorems, 7 definitions, 239 lines, 0 sorries, 0 axioms**
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for every theorem — **no `native_decide`/`Lean.ofReduceBool`, no `sorryAx`**
- Builds clean via host `lake env lean` (Lean 4.26.0 / Mathlib)
- Routh's theorem is **not** in Mathlib

## Files
- `proofs/Proofs/MenelausTheoremOQ01OQ03.lean`
- `src/data/proofs/menelaus-theorem-oq-01-oq-03/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)