### PR TITLE
audit(gallery): 4 fresh entries clean (compactness/erdos-1101/quad-recip-oq04/jensen-amhm)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23231,8 +23231,26 @@
       "lastAudited": "2026-06-24T00:00:00Z",
       "result": "clean",
       "issues": []
+    },
+    "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1101-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:30:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-reciprocity-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:30:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T04:22:40Z"
+  "lastUpdated": "2026-06-25T04:30:00Z"
 }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23249,6 +23249,12 @@
       "lastAudited": "2026-06-25T04:30:00Z",
       "result": "clean",
       "issues": []
+    },
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T04:54:52Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — 3 newly-shipped entries, all clean

Audited the entries that became unaudited after #29696 merged. All three are `verified`/`original`/0-axiom/0-sorry; Lean source comment-stripped shows no sorry, axiom, native_decide, or True stubs.

| Slug | Verdict | Notes |
|------|---------|-------|
| compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02 | clean | Cantor intersection for complete metric spaces, singleton form (5 thm) |
| erdos-1101-oq-01 | clean | Prime squares meet necessary good-sequence conditions; title honestly scoped to *necessary* hurdles (5 thm + 6 def) |
| quadratic-reciprocity-oq-04 | clean | Jacobi reciprocity generalizes, residue-detection does not. Composite counterexample J(2\|15)=1 is genuine new content; Mathlib deps + kernel `decide` fully credited; one-way re-export transparently labeled (5 thm) |

No delegation-opacity or axiom-masking: Mathlib reliance is disclosed in each `assumptions`/`mathlibDependencies`. Tracker-only change. Clears unaudited 3→0 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)