### PR TITLE
research(amgm-inequality-oq-03-oq-01-oq-01): mixed-sign power mean monotonicity M_r ≤ M_s for r < 0 < s [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean
@@ -1,0 +1,160 @@
+/-
+# Power Mean Monotonicity: The Mixed-Sign Case M_r ≤ M_s for r < 0 < s
+
+## Open Question: amgm-inequality-oq-03-oq-01-oq-01
+
+The parent file `AmgmInequalityOQ03.lean` proves power-mean monotonicity in two
+regimes that do *not* cross zero:
+
+  * `power_mean_monotone_pos` — M_r ≤ M_s for 0 < r ≤ s, and
+  * `power_mean_monotone_neg` — M_r ≤ M_s for r ≤ s < 0.
+
+It explicitly leaves open the **mixed-sign case** r < 0 < s, where the comparison
+must cross the geometric-mean limit at the exponent 0. This file closes that gap.
+
+## Result
+
+For positive reals z₁,…,zₙ with nonnegative weights w₁,…,wₙ summing to 1, and any
+exponents r < 0 < s,
+
+  M_r(z, w) ≤ M_s(z, w),
+
+where M_p(z, w) = (∑ᵢ wᵢ zᵢ^p)^{1/p} is the weighted power mean of order p.
+
+## Proof Strategy
+
+We route the comparison through the **weighted geometric mean** GM = ∏ zᵢ^{wᵢ},
+which is precisely lim_{p→0} M_p. The single Mathlib analytic input is the weighted
+arithmetic–geometric mean inequality `Real.geom_mean_le_arith_mean_weighted`:
+
+  ∏ yᵢ^{wᵢ} ≤ ∑ wᵢ yᵢ.
+
+Applied to yᵢ = zᵢ^p, together with the identity ∏ (zᵢ^p)^{wᵢ} = GM^p, this yields
+the single *core estimate*
+
+  GM^p ≤ ∑ wᵢ zᵢ^p   for every exponent p.            (★)
+
+Now the sign of p controls the direction of the comparison after taking 1/p-th powers:
+
+  * For **s > 0** the map t ↦ t^{1/s} is increasing, so (★) gives GM ≤ M_s.
+  * For **r < 0** the map t ↦ t^{1/r} is decreasing, so (★) *reverses* to M_r ≤ GM.
+
+Chaining,  M_r ≤ GM ≤ M_s.
+
+The crossing of zero is exactly the sign flip of 1/p — which is why the two
+same-sign theorems of the parent file cannot be combined directly: there is no
+common exponent between a negative r and a positive s to transit through, except
+the degenerate order 0 represented by the geometric mean itself.
+
+## What This File Proves
+
+1. `geomMean_rpow_le_weighted_sum` — the core estimate (★): GM^p ≤ ∑ wᵢ zᵢ^p.
+2. `geomMean_le_powerMean_pos` — GM ≤ M_s for s > 0.
+3. `powerMean_le_geomMean_neg` — M_r ≤ GM for r < 0.
+4. `power_mean_monotone_mixed` — M_r ≤ M_s for r < 0 < s (the open question).
+
+## References
+
+- Hardy, G.H., Littlewood, J.E., Pólya, G. (1934). *Inequalities*. Cambridge.
+- Mathlib: `Real.geom_mean_le_arith_mean_weighted` (Mathlib.Analysis.MeanInequalities).
+-/
+
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+import Proofs.AmgmInequalityOQ03
+
+variable {ι : Type*} (s : Finset ι) (w z : ι → ℝ)
+
+/-- **Core estimate (★)**: for *every* exponent `p`, the `p`-th power of the weighted
+geometric mean `GM = ∏ zᵢ^{wᵢ}` is bounded by the weighted arithmetic mean of the
+`p`-th powers:
+
+  `GM ^ p ≤ ∑ᵢ wᵢ · zᵢ ^ p`.
+
+This is the sole use of Mathlib's weighted AM-GM inequality
+`Real.geom_mean_le_arith_mean_weighted`, applied to the values `yᵢ = zᵢ ^ p`,
+combined with the identity `∏ (zᵢ ^ p) ^ wᵢ = (∏ zᵢ ^ wᵢ) ^ p`. Note the
+inequality holds for *all* real `p`, including negative ones; the direction of
+the resulting mean comparison only emerges after raising to the power `1/p`. -/
+theorem geomMean_rpow_le_weighted_sum
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i)
+    (p : ℝ) :
+    (weightedGeomMean s w z) ^ p ≤ ∑ i ∈ s, w i * z i ^ p := by
+  have hz_nn : ∀ i ∈ s, 0 ≤ z i := fun i hi => (hz i hi).le
+  -- Weighted AM-GM applied to the values yᵢ = zᵢ^p.
+  have key := Real.geom_mean_le_arith_mean_weighted s w (fun i => z i ^ p) hw hw'
+    (fun i hi => Real.rpow_nonneg (hz_nn i hi) p)
+  -- key : ∏ (zᵢ^p)^wᵢ ≤ ∑ wᵢ * zᵢ^p.
+  -- Rewrite the left-hand product into GM^p.
+  have lhs_eq : ∏ i ∈ s, (z i ^ p) ^ w i = (weightedGeomMean s w z) ^ p := by
+    have hterm : ∀ i ∈ s, (z i ^ p) ^ w i = (z i ^ w i) ^ p := by
+      intro i hi
+      rw [← Real.rpow_mul (hz_nn i hi), ← Real.rpow_mul (hz_nn i hi), mul_comm p (w i)]
+    rw [Finset.prod_congr rfl hterm,
+        Real.finset_prod_rpow s (fun i => z i ^ w i)
+          (fun i hi => Real.rpow_nonneg (hz_nn i hi) _) p,
+        weightedGeomMean]
+  rwa [lhs_eq] at key
+
+/-- **GM ≤ M_s for positive order** `s > 0`. Raising the core estimate (★)
+`GM^s ≤ ∑ wᵢ zᵢ^s` to the positive power `1/s` (which preserves the inequality)
+gives `GM ≤ (∑ wᵢ zᵢ^s)^{1/s} = M_s`. -/
+theorem geomMean_le_powerMean_pos
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i)
+    {p : ℝ} (hp : 0 < p) (hpne : p ≠ 0) :
+    weightedGeomMean s w z ≤ weightedPowerMean s w z p hpne := by
+  have hGM_pos : 0 < weightedGeomMean s w z := by
+    rw [weightedGeomMean]
+    exact Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hz i hi) _)
+  have core := geomMean_rpow_le_weighted_sum s w z hw hw' hz p
+  have h1p : (0 : ℝ) ≤ 1 / p := by positivity
+  -- Raise both sides of (★) to the nonnegative power 1/p (monotone).
+  have step := Real.rpow_le_rpow (Real.rpow_nonneg hGM_pos.le p) core h1p
+  rw [weightedPowerMean]
+  -- (GM^p)^(1/p) = GM since p ≠ 0.
+  rwa [← Real.rpow_mul hGM_pos.le, mul_one_div_cancel hpne, Real.rpow_one] at step
+
+/-- **M_r ≤ GM for negative order** `r < 0`. Raising the core estimate (★)
+`GM^r ≤ ∑ wᵢ zᵢ^r` to the *negative* power `1/r` *reverses* the inequality, giving
+`M_r = (∑ wᵢ zᵢ^r)^{1/r} ≤ GM`. The sign flip of `1/r` is the heart of the
+mixed-sign case. -/
+theorem powerMean_le_geomMean_neg
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i)
+    {p : ℝ} (hp : p < 0) (hpne : p ≠ 0) :
+    weightedPowerMean s w z p hpne ≤ weightedGeomMean s w z := by
+  have hGM_pos : 0 < weightedGeomMean s w z := by
+    rw [weightedGeomMean]
+    exact Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hz i hi) _)
+  have core := geomMean_rpow_le_weighted_sum s w z hw hw' hz p
+  have h1p : 1 / p ≤ 0 := (div_neg_of_pos_of_neg one_pos hp).le
+  -- Raise both sides of (★) to the nonpositive power 1/p (antitone): direction reverses.
+  have step := Real.rpow_le_rpow_of_nonpos (Real.rpow_pos_of_pos hGM_pos p) core h1p
+  rw [weightedPowerMean]
+  -- (GM^p)^(1/p) = GM since p ≠ 0; the base GM fixes the rewrite to the RHS only.
+  rwa [← Real.rpow_mul hGM_pos.le, mul_one_div_cancel hpne, Real.rpow_one] at step
+
+/-- **Power-Mean Monotonicity, mixed-sign case** — closes
+`amgm-inequality-oq-03-oq-01-oq-01`.
+
+For positive reals with weights summing to 1, and exponents `r < 0 < t`,
+
+  M_r(z, w) ≤ M_t(z, w).
+
+The comparison crosses the geometric-mean limit at order 0: `M_r ≤ GM ≤ M_t`. -/
+theorem power_mean_monotone_mixed
+    (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hr : r < 0) (ht : 0 < t)
+    (hrne : r ≠ 0) (htne : t ≠ 0) :
+    weightedPowerMean s w z r hrne ≤ weightedPowerMean s w z t htne :=
+  le_trans
+    (powerMean_le_geomMean_neg s w z hw hw' hz hr hrne)
+    (geomMean_le_powerMean_pos s w z hw hw' hz ht htne)

--- a/proofs/Proofs/AmgmInequalityOQ05OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ05OQ02.lean
@@ -1,0 +1,114 @@
+/-
+  The weighted AM-GM inequality: its equality case for `n` terms.
+
+  For strictly positive weights `w : ι → ℝ` summing to `1` over a finite index
+  set `t` and strictly positive reals `x : ι → ℝ`, the weighted arithmetic mean
+  dominates the weighted geometric mean,
+
+      ∏ i ∈ t, (x i) ^ (w i)  ≤  ∑ i ∈ t, w i * x i.
+
+  This file pins down the **equality case**: equality holds **iff every `xⱼ`
+  equals the weighted mean**, equivalently iff all the `xⱼ` are equal.
+
+  The parent entry proved the two-variable pointwise Young equality case from the
+  strict convexity of `exp`; one of its stated open questions was to upgrade this
+  to the `n`-term weighted AM-GM equality case "again via strict convexity of
+  `exp`".  That is exactly what we do here, in the dual (and equivalent) form:
+  the logarithm is *strictly concave* on `(0, ∞)`, so Jensen's inequality for
+  `Real.log` is strict unless all evaluation points coincide.  Concretely we
+  take logs to turn the multiplicative AM-GM equality into the additive Jensen
+  equality
+
+      Real.log (∑ wᵢ xᵢ)  =  ∑ wᵢ · Real.log (xᵢ),
+
+  and feed it to Mathlib's canonical equality-case lemma
+  `StrictConcaveOn.map_sum_eq_iff` for the strictly concave `Real.log`
+  (`strictConcaveOn_log_Ioi`).  Mathlib has the weighted AM-GM inequality and the
+  strict Jensen machinery, but does not package this particular equality
+  characterisation of the geometric/arithmetic mean.
+
+  All exponents are real, so `^` denotes `Real.rpow` throughout.
+
+  Verified: 0 sorries, 0 axioms.
+-/
+import Mathlib
+
+open Real Finset
+
+namespace AmgmInequalityOQ05OQ02
+
+variable {ι : Type*}
+
+/-- Taking logs turns the weighted geometric mean into the weighted sum of
+logarithms: `log (∏ xᵢ ^ wᵢ) = ∑ wᵢ · log xᵢ`. -/
+theorem log_prod_rpow {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    Real.log (∏ i ∈ t, x i ^ w i) = ∑ i ∈ t, w i * Real.log (x i) := by
+  rw [Real.log_prod (fun i hi => (Real.rpow_pos_of_pos (hx i hi) (w i)).ne')]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  rw [Real.log_rpow (hx i hi)]
+
+/-- The weighted geometric mean of positive reals is positive. -/
+theorem prod_rpow_pos {t : Finset ι} {w x : ι → ℝ} (hx : ∀ i ∈ t, 0 < x i) :
+    0 < ∏ i ∈ t, x i ^ w i :=
+  Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hx i hi) (w i))
+
+/-- The weighted arithmetic mean of positive reals with positive weights, over a
+nonempty index set, is positive. -/
+theorem mean_pos {t : Finset ι} {w x : ι → ℝ} (hw : ∀ i ∈ t, 0 < w i)
+    (hx : ∀ i ∈ t, 0 < x i) (hne : t.Nonempty) :
+    0 < ∑ i ∈ t, w i * x i :=
+  Finset.sum_pos (fun i hi => mul_pos (hw i hi) (hx i hi)) hne
+
+/-- **Equality case of the weighted AM-GM inequality (canonical form).**
+
+For strictly positive weights summing to `1` and strictly positive `x`, the
+weighted geometric mean equals the weighted arithmetic mean **iff every `xⱼ`
+equals that common mean**. -/
+theorem weighted_amgm_eq_iff {t : Finset ι} {w x : ι → ℝ} (hw : ∀ i ∈ t, 0 < w i)
+    (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i) :
+    (∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i) ↔
+      (∀ j ∈ t, x j = ∑ i ∈ t, w i * x i) := by
+  -- A sum of weights equal to `1` forces the index set to be nonempty.
+  have hne : t.Nonempty := by
+    rw [Finset.nonempty_iff_ne_empty]
+    rintro rfl
+    simp at hsum
+  have hA : 0 < ∑ i ∈ t, w i * x i := mean_pos hw hx hne
+  have hP : 0 < ∏ i ∈ t, x i ^ w i := prod_rpow_pos hx
+  -- Both means are positive, so the equality is equivalent to its image under `log`.
+  rw [← Real.log_injOn_pos.eq_iff (Set.mem_Ioi.mpr hP) (Set.mem_Ioi.mpr hA),
+      log_prod_rpow hx, eq_comm]
+  -- The strict concavity of `log` supplies the equality case of Jensen.
+  have key := strictConcaveOn_log_Ioi.map_sum_eq_iff (t := t) (w := w) (p := x)
+      hw hsum (fun i hi => Set.mem_Ioi.mpr (hx i hi))
+  simpa only [smul_eq_mul] using key
+
+/-- **Equality case of the weighted AM-GM inequality (pairwise form).**
+
+Equality holds iff all the `xⱼ` (over the support of the weights) are equal. -/
+theorem weighted_amgm_eq_iff_pairwise {t : Finset ι} {w x : ι → ℝ}
+    (hw : ∀ i ∈ t, 0 < w i) (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i) :
+    (∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i) ↔
+      (∀ i ∈ t, ∀ j ∈ t, x i = x j) := by
+  rw [weighted_amgm_eq_iff hw hsum hx]
+  constructor
+  · intro h i hi j hj
+    rw [h i hi, h j hj]
+  · intro h j hj
+    have hconst : ∑ i ∈ t, w i * x i = ∑ i ∈ t, w i * x j := by
+      refine Finset.sum_congr rfl ?_
+      intro i hi
+      rw [h i hi j hj]
+    rw [hconst, ← Finset.sum_mul, hsum, one_mul]
+
+/-- The trivial direction, recorded explicitly: if all `xⱼ` are equal then the
+weighted geometric and arithmetic means coincide. -/
+theorem weighted_amgm_eq_of_const {t : Finset ι} {w x : ι → ℝ} {c : ℝ}
+    (hw : ∀ i ∈ t, 0 < w i) (hsum : ∑ i ∈ t, w i = 1) (hx : ∀ i ∈ t, 0 < x i)
+    (hc : ∀ i ∈ t, x i = c) :
+    ∏ i ∈ t, x i ^ w i = ∑ i ∈ t, w i * x i :=
+  (weighted_amgm_eq_iff_pairwise hw hsum hx).mpr
+    (fun i hi j hj => (hc i hi).trans (hc j hj).symm)
+
+end AmgmInequalityOQ05OQ02

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-amgm-oq030101-01-core",
+    "proofId": "amgm-inequality-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 103
+    },
+    "type": "concept",
+    "title": "Core Estimate (★): GM^p ≤ ∑ wᵢzᵢ^p for every real p",
+    "content": "geomMean_rpow_le_weighted_sum is the single load-bearing lemma. It applies Mathlib's weighted AM-GM (Real.geom_mean_le_arith_mean_weighted) to the family yᵢ = zᵢ^p, yielding ∏ (zᵢ^p)^{wᵢ} ≤ ∑ wᵢ·zᵢ^p. The left side is then folded into GM^p: each term satisfies (zᵢ^p)^{wᵢ} = (zᵢ^{wᵢ})^p (both equal zᵢ^{p·wᵢ} by Real.rpow_mul, with the exponents commuted via mul_comm), and the product of these p-th powers is (∏ zᵢ^{wᵢ})^p = GM^p by Real.finset_prod_rpow. Crucially, the lemma is stated and proved for ALL real p — no sign hypothesis appears — so the same estimate serves both halves of the main theorem.",
+    "mathContext": "$\\prod_i (z_i^p)^{w_i} \\leq \\sum_i w_i z_i^p$, and $\\prod_i (z_i^p)^{w_i} = \\prod_i (z_i^{w_i})^p = \\left(\\prod_i z_i^{w_i}\\right)^p = \\mathrm{GM}^p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.geom_mean_le_arith_mean_weighted",
+      "Real.finset_prod_rpow",
+      "Real.rpow_mul",
+      "weighted AM-GM"
+    ],
+    "prerequisites": [
+      "weighted arithmetic–geometric mean inequality",
+      "rpow arithmetic (rpow_mul, rpow_nonneg)",
+      "Finset.prod_congr"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq030101-02-positive",
+    "proofId": "amgm-inequality-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 124
+    },
+    "type": "technique",
+    "title": "Positive Side: GM ≤ M_s via order-preserving 1/s power",
+    "content": "geomMean_le_powerMean_pos takes the core estimate at exponent s > 0, namely GM^s ≤ ∑ wᵢzᵢ^s, and raises both sides to the nonnegative power 1/s using Real.rpow_le_rpow (which requires 0 ≤ 1/s, discharged by positivity). The left side collapses: (GM^s)^(1/s) = GM^(s·(1/s)) = GM^1 = GM, via ← Real.rpow_mul, mul_one_div_cancel, and Real.rpow_one. The right side is exactly M_s = (∑ wᵢzᵢ^s)^(1/s). Positivity of GM (needed for the rpow base) comes from Finset.prod_pos over the strictly positive zᵢ^{wᵢ}.",
+    "mathContext": "$s>0 \\Rightarrow 1/s>0$: applying the increasing map $t\\mapsto t^{1/s}$ to $\\mathrm{GM}^s \\leq \\sum w_i z_i^s$ gives $\\mathrm{GM} \\leq M_s$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Real.rpow_le_rpow",
+      "Real.rpow_mul",
+      "mul_one_div_cancel",
+      "Finset.prod_pos"
+    ],
+    "prerequisites": [
+      "monotonicity of rpow in the base for nonnegative exponent",
+      "core estimate (★)"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq030101-03-negative",
+    "proofId": "amgm-inequality-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 149
+    },
+    "type": "technique",
+    "title": "Negative Side: M_r ≤ GM — the sign flip of 1/r",
+    "content": "powerMean_le_geomMean_neg is where crossing zero earns its keep. The core estimate at r < 0 gives GM^r ≤ ∑ wᵢzᵢ^r, but now the exponent 1/r is NEGATIVE (div_neg_of_pos_of_neg). Raising to a nonpositive power is antitone, so Real.rpow_le_rpow_of_nonpos REVERSES the inequality: (∑ wᵢzᵢ^r)^(1/r) ≤ (GM^r)^(1/r). The left side is M_r and the right collapses to GM exactly as in the positive case. Because the rewrite ← Real.rpow_mul is specialized to the base GM (via hGM_pos.le), it touches only the (GM^r)^(1/r) term and leaves M_r untouched. This single direction reversal is the entire substance of the mixed-sign case.",
+    "mathContext": "$r<0 \\Rightarrow 1/r<0$: applying the decreasing map $t\\mapsto t^{1/r}$ to $\\mathrm{GM}^r \\leq \\sum w_i z_i^r$ reverses it to $M_r \\leq \\mathrm{GM}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_le_rpow_of_nonpos",
+      "div_neg_of_pos_of_neg",
+      "antitone power map",
+      "sign of 1/p"
+    ],
+    "prerequisites": [
+      "antitonicity of rpow in the base for nonpositive exponent",
+      "core estimate (★)"
+    ]
+  },
+  {
+    "id": "ann-amgm-oq030101-04-main",
+    "proofId": "amgm-inequality-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 151,
+      "endLine": 160
+    },
+    "type": "concept",
+    "title": "Mixed-Sign Monotonicity: M_r ≤ GM ≤ M_t",
+    "content": "power_mean_monotone_mixed is a one-line transitivity: le_trans of the negative-side comparison (M_r ≤ GM) and the positive-side comparison (GM ≤ M_t), for r < 0 < t. This closes the regime the parent entries flagged as open and conjectured would need the r→0 limit. The geometric mean GM = ∏ zᵢ^{wᵢ} serves as the fixed order-0 pivot through which the negative and positive power means are compared without any analytic limit.",
+    "mathContext": "$M_r \\leq \\mathrm{GM} \\leq M_t$ for $r < 0 < t$, where $\\mathrm{GM}=\\prod_i z_i^{w_i}=\\lim_{p\\to0}M_p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_trans",
+      "geometric mean as order-0 pivot",
+      "power mean monotonicity chain",
+      "HM ≤ GM ≤ AM"
+    ],
+    "prerequisites": [
+      "geomMean_le_powerMean_pos",
+      "powerMean_le_geomMean_neg"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "amgm-inequality-oq-03-oq-01-oq-01",
+  "title": "Mixed-Sign Power Mean Monotonicity: M_r ≤ M_s for r < 0 < s",
+  "slug": "amgm-inequality-oq-03-oq-01-oq-01",
+  "description": "For exponents r < 0 < s, the weighted power mean M_p(z,w) = (∑ wᵢzᵢ^p)^(1/p) satisfies M_r ≤ M_s. This is the one regime the parent files leave open: it must cross the geometric-mean limit at order 0. The proof routes the comparison through the weighted geometric mean GM = ∏ zᵢ^{wᵢ} using a single core estimate, GM^p ≤ ∑ wᵢzᵢ^p (the weighted AM-GM applied to the values zᵢ^p), valid for every real p. Raising to the power 1/p then gives GM ≤ M_s for s > 0 and — because 1/r flips sign — M_r ≤ GM for r < 0, so M_r ≤ GM ≤ M_s. Notably this needs no r→0 limiting argument.",
+  "meta": {
+    "author": "Hardy, Littlewood, Pólya (1934); formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Power_mean",
+    "date": "1934",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "mean-inequalities",
+      "classic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.geom_mean_le_arith_mean_weighted",
+        "description": "Weighted AM-GM: ∏ zᵢ^{wᵢ} ≤ ∑ wᵢzᵢ for nonnegative weights summing to 1 — the sole analytic input, applied to the values zᵢ^p to produce the core estimate GM^p ≤ ∑ wᵢzᵢ^p",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of t ↦ t^c for c ≥ 0 — raises the core estimate to the positive power 1/s to give GM ≤ M_s",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow_of_nonpos",
+        "description": "Antitonicity of t ↦ t^c for c ≤ 0 — raises the core estimate to the negative power 1/r, reversing the inequality to give M_r ≤ GM; this sign flip is the crux of the mixed-sign case",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.finset_prod_rpow",
+        "description": "(∏ fᵢ)^r = ∏ fᵢ^r for nonnegative fᵢ — used to fold ∏ (zᵢ^p)^{wᵢ} into GM^p",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "x^(a·b) = (x^a)^b for x ≥ 0 — used for the identity (zᵢ^p)^{wᵢ} = (zᵢ^{wᵢ})^p and for collapsing (GM^p)^(1/p) = GM",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "power_mean_monotone_mixed: full proof of M_r ≤ M_s for r < 0 < s — the regime explicitly listed as unproved in the parent files, completing the power mean monotonicity chain across the sign boundary",
+      "geomMean_rpow_le_weighted_sum: the single core estimate GM^p ≤ ∑ wᵢzᵢ^p, valid for ALL real p, isolating the entire analytic content into one sign-agnostic inequality",
+      "Limit-free routing through the geometric mean: the parent file conjectured the mixed-sign case 'likely requires the r→0 limit'; this proof avoids any limiting argument by comparing each one-sided power mean to GM = ∏ zᵢ^{wᵢ} directly via AM-GM",
+      "Sign-flip mechanism: the direction of the mean comparison is governed entirely by the sign of 1/p (rpow_le_rpow for s > 0 vs rpow_le_rpow_of_nonpos for r < 0), making explicit why the two same-sign theorems cannot be chained"
+    ],
+    "prerequisites": [
+      "Power mean and geometric mean definitions (from parent file AmgmInequalityOQ03)",
+      "Weighted arithmetic–geometric mean inequality (Real.geom_mean_le_arith_mean_weighted)",
+      "Real power function (rpow) monotonicity in the exponent and base: rpow_le_rpow, rpow_le_rpow_of_nonpos, rpow_mul",
+      "Finset positivity (Finset.prod_pos)"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 160,
+    "focusedRange": {
+      "startLine": 80,
+      "endLine": 160
+    },
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound (the standard foundational axioms; no sorryAx, no Lean.ofReduceBool). The sole analytic input is Mathlib's weighted AM-GM; everything else is rpow bookkeeping.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Power Mean Inequality $M_r \\leq M_s$ for $r \\leq s$ splits naturally into three regimes by the sign of the exponents. The positive case $0 < r \\leq s$ follows from Jensen's inequality applied to the convex map $t \\mapsto t^{s/r}$; the negative case $r \\leq s < 0$ follows by the duality $M_r(z) = M_{-r}(z^{-1})^{-1}$, reducing to the positive case on inverted values. Both were formalized in the parent entries. The **mixed-sign** case $r < 0 < s$ is the genuinely different one: there is no common positive exponent to transit through, and no value-inversion that maps it to a same-sign comparison. The only object 'between' a negative and a positive order is the order-$0$ limit, the weighted geometric mean $\\mathrm{GM} = \\prod z_i^{w_i} = \\lim_{p\\to 0} M_p$.\n\nThe parent file conjectured that closing this gap 'likely requires the $r \\to 0$ limit from the sibling formalization.' This entry shows that a limit is unnecessary: the geometric mean can be compared to each one-sided power mean *directly* through the weighted AM-GM inequality, with the sign of $1/p$ supplying the change of direction. As of early 2026 Mathlib4 still carried an explicit TODO for the 'generalized mean inequality with any $p \\leq q$, including negative numbers'; this formalization disposes of the hardest, boundary-crossing piece of it.",
+    "problemStatement": "**Theorem (power_mean_monotone_mixed)**: For a finite set $s$ with weights $w_i \\geq 0$ summing to $1$ and values $z_i > 0$, if $r < 0 < t$ then\n\n  $\\mathrm{weightedPowerMean}\\,s\\,w\\,z\\,r \\;\\leq\\; \\mathrm{weightedPowerMean}\\,s\\,w\\,z\\,t$,\n\nwhere $M_p = (\\sum_i w_i z_i^p)^{1/p}$.\n\n**Core estimate (geomMean_rpow_le_weighted_sum)**: for every real $p$, $\\mathrm{GM}^p \\leq \\sum_i w_i z_i^p$, where $\\mathrm{GM} = \\prod_i z_i^{w_i}$.",
+    "text": "For exponents r < 0 < s, the weighted power mean M_p(z,w) = (∑ wᵢzᵢ^p)^(1/p) satisfies M_r ≤ M_s. The proof passes through the weighted geometric mean GM = ∏ zᵢ^{wᵢ}: a single AM-GM estimate gives GM^p ≤ ∑ wᵢzᵢ^p for every p, and raising to the 1/p power yields GM ≤ M_s for s > 0 and M_r ≤ GM for r < 0 (the inequality reverses because 1/r < 0). Hence M_r ≤ GM ≤ M_s.",
+    "proofStrategy": "**Three steps, all elementary once the core estimate is in hand.**\n\n**Step 1 — Core estimate (★), one AM-GM call.** Apply Mathlib's `Real.geom_mean_le_arith_mean_weighted` to the values $y_i = z_i^p$:\n  $\\prod_i (z_i^p)^{w_i} \\leq \\sum_i w_i z_i^p$.\nFold the left side using $(z_i^p)^{w_i} = (z_i^{w_i})^p$ (both equal $z_i^{p w_i}$) and $\\prod_i (z_i^{w_i})^p = (\\prod_i z_i^{w_i})^p$, giving\n  $\\mathrm{GM}^p \\leq \\sum_i w_i z_i^p \\qquad (\\star)$\nfor **every** real $p$ — the sign of $p$ has not yet entered.\n\n**Step 2 — Positive side, $s > 0$.** $1/s > 0$, so $t \\mapsto t^{1/s}$ is increasing; apply it to $(\\star)$ and collapse $(\\mathrm{GM}^s)^{1/s} = \\mathrm{GM}$:\n  $\\mathrm{GM} \\leq \\Big(\\sum_i w_i z_i^s\\Big)^{1/s} = M_s.$\n\n**Step 3 — Negative side, $r < 0$.** Now $1/r < 0$, so $t \\mapsto t^{1/r}$ is *decreasing*; applying `rpow_le_rpow_of_nonpos` to $(\\star)$ **reverses** it:\n  $M_r = \\Big(\\sum_i w_i z_i^r\\Big)^{1/r} \\leq (\\mathrm{GM}^r)^{1/r} = \\mathrm{GM}.$\n\nChaining Steps 2–3: $M_r \\leq \\mathrm{GM} \\leq M_s$.",
+    "keyInsights": [
+      "The entire analytic content is a single sign-agnostic inequality: GM^p ≤ ∑ wᵢzᵢ^p holds for every real p. Both the positive and negative halves of the theorem are this one estimate viewed through t ↦ t^{1/p}.",
+      "Crossing zero is exactly the sign flip of 1/p. For s > 0 the map t ↦ t^{1/s} preserves order (rpow_le_rpow); for r < 0 the map t ↦ t^{1/r} reverses it (rpow_le_rpow_of_nonpos). This is precisely why the parent's two same-sign theorems cannot be chained — there is no shared exponent to transit through.",
+      "No limit is required. The parent entry expected the mixed-sign case to need the r→0 limiting value of M_p; instead, the geometric mean (the r=0 limit's closed form ∏ zᵢ^{wᵢ}) is compared to each side directly through AM-GM, sidestepping any analytic limit.",
+      "The geometric mean acts as a fixed 'pivot' at order 0: M_r ≤ GM ≤ M_s. This recovers the classical chain HM ≤ GM ≤ AM (r = -1, s = 1) and, more generally, shows GM is the order-0 member of the monotone family.",
+      "The folding identity ∏ (zᵢ^p)^{wᵢ} = (∏ zᵢ^{wᵢ})^p = GM^p is what lets a *single* AM-GM application serve both signs — the weights wᵢ and exponent p commute through rpow_mul."
+    ],
+    "prerequisites": [
+      "Power mean and geometric mean definitions (from parent file AmgmInequalityOQ03)",
+      "Weighted arithmetic–geometric mean inequality (Real.geom_mean_le_arith_mean_weighted)",
+      "Real power function (rpow) monotonicity: rpow_le_rpow, rpow_le_rpow_of_nonpos, rpow_mul",
+      "Finset positivity (Finset.prod_pos)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core-estimate",
+      "title": "Core Estimate: GM^p ≤ ∑ wᵢzᵢ^p for every p",
+      "startLine": 80,
+      "endLine": 103,
+      "summary": "geomMean_rpow_le_weighted_sum applies Mathlib's weighted AM-GM to the values zᵢ^p, then folds the resulting product ∏ (zᵢ^p)^{wᵢ} into GM^p via the identity (zᵢ^p)^{wᵢ} = (zᵢ^{wᵢ})^p (rpow_mul) and finset_prod_rpow. The inequality is established for ALL real p — no sign hypothesis.",
+      "mathContext": "AM-GM on $y_i = z_i^p$ gives $\\prod (z_i^p)^{w_i} \\leq \\sum w_i z_i^p$, and $\\prod (z_i^p)^{w_i} = \\prod (z_i^{w_i})^p = (\\prod z_i^{w_i})^p = \\mathrm{GM}^p$."
+    },
+    {
+      "id": "positive-side",
+      "title": "Positive Order: GM ≤ M_s",
+      "startLine": 105,
+      "endLine": 124,
+      "summary": "geomMean_le_powerMean_pos raises the core estimate to the nonnegative power 1/s (rpow_le_rpow), then collapses (GM^s)^(1/s) = GM via rpow_mul and mul_one_div_cancel. GM > 0 from Finset.prod_pos.",
+      "mathContext": "For $s > 0$: $(\\mathrm{GM}^s)^{1/s} \\leq (\\sum w_i z_i^s)^{1/s}$, i.e. $\\mathrm{GM} \\leq M_s$."
+    },
+    {
+      "id": "negative-side",
+      "title": "Negative Order: M_r ≤ GM (the sign flip)",
+      "startLine": 126,
+      "endLine": 149,
+      "summary": "powerMean_le_geomMean_neg raises the core estimate to the NONPOSITIVE power 1/r (rpow_le_rpow_of_nonpos), which reverses the inequality, then collapses (GM^r)^(1/r) = GM. This antitone step is the heart of the mixed-sign case.",
+      "mathContext": "For $r < 0$, $1/r < 0$: $(\\sum w_i z_i^r)^{1/r} \\leq (\\mathrm{GM}^r)^{1/r}$, i.e. $M_r \\leq \\mathrm{GM}$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Mixed-Sign Monotonicity M_r ≤ M_s",
+      "startLine": 151,
+      "endLine": 160,
+      "summary": "power_mean_monotone_mixed chains the two one-sided comparisons by transitivity: M_r ≤ GM ≤ M_s for r < 0 < t. This closes the open question from the parent files.",
+      "mathContext": "$M_r \\leq \\mathrm{GM} \\leq M_t$ for $r < 0 < t$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves M_r ≤ M_s for r < 0 < s with 0 axioms and 0 sorries, closing the mixed-sign case that the parent entries explicitly left open. The proof isolates all analytic content into one sign-agnostic estimate GM^p ≤ ∑ wᵢzᵢ^p, then recovers both halves of the theorem by raising to the power 1/p — increasing for s > 0, decreasing for r < 0. Combined with the positive case (power_mean_monotone_pos) and the negative case (power_mean_monotone_neg), this completes weighted power mean monotonicity across the full real line of exponents.",
+    "implications": "**For the power mean chain**: With the same-sign cases already formalized, the mixed-sign crossing completes the monotonicity of p ↦ M_p over all of ℝ, with the geometric mean as the order-0 pivot. The classical chain HM ≤ GM ≤ AM is the r = -1, s = 1 instance.\n\n**For Mathlib**: Disposes of the boundary-crossing piece of the TODO in Mathlib.Analysis.MeanInequalitiesPow for the generalized mean inequality with negative exponents.\n\n**Technique**: Pivoting a two-sided comparison through a single intermediate object, reached by a sign-agnostic inequality and a direction-flipping monotonicity, is reusable wherever a parameterized family must be compared across a critical value.",
+    "openQuestions": [
+      "Assemble the three regimes (pos, neg, mixed) into a single uniform theorem M_p ≤ M_q for all p ≤ q in ℝ, with the p = 0 / q = 0 cases handled by the geometric mean",
+      "Contribute the full real-exponent power mean monotonicity to Mathlib upstream, retiring the explicit TODO",
+      "Quantify the gap M_s − M_r in terms of the variance of (log zᵢ) under the weights, sharpening the inequality near the geometric-mean pivot"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.MeanInequalities",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Tactic",
+      "Proofs.AmgmInequalityOQ03"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 160,
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "lemmaCount": 0,
+    "path": "Proofs/AmgmInequalityOQ03OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The parent negative-case entry; its openQuestions list this mixed-sign case as unproved and conjecture it needs the r→0 limit. This entry closes it without any limit."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03",
+      "relationship": "extends",
+      "description": "Provides the weightedPowerMean and weightedGeomMean definitions and the positive-case theorem; this entry adds the sign-crossing regime."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Sibling work on the power mean chain; together the same-sign and mixed-sign cases give monotonicity of p ↦ M_p over all exponents."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The AM-GM inequality GM ≤ AM is the s = 1 instance of the positive-side comparison GM ≤ M_s proved here, and HM ≤ GM the r = -1 instance of the negative side."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G.H.; Littlewood, J.E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Chapter 2: the power mean inequality, including the geometric mean as the order-0 member of the family"
+    },
+    {
+      "authors": "Bullen, P.S.",
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Kluwer Academic Publishers",
+      "note": "Comprehensive treatment of power means and their monotonicity across all real orders"
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Develops the power mean inequality and the central role of the AM-GM inequality used here as the core estimate"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/annotations.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "ann-log-prod-rpow",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "theorem",
+    "title": "log_prod_rpow: log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ",
+    "content": "The logarithmic bridge. For strictly positive xᵢ, the logarithm of the weighted geometric mean equals the weighted sum of logarithms. The proof applies Real.log_prod (each factor xᵢ^{wᵢ} is positive, hence nonzero, by Real.rpow_pos_of_pos) and then Real.log_rpow on each term to turn log(xᵢ^{wᵢ}) into wᵢ·log xᵢ. This is what linearises the multiplicative geometric mean into the additive form on which Jensen's inequality acts.",
+    "mathContext": "$\\log\\!\\left(\\prod_i x_i^{w_i}\\right) = \\sum_i w_i \\log x_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "Real.log_rpow",
+      "weighted geometric mean"
+    ],
+    "prerequisites": [
+      "Real.log_prod",
+      "Real.log_rpow",
+      "Real.rpow_pos_of_pos"
+    ]
+  },
+  {
+    "id": "ann-prod-rpow-pos",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 55
+    },
+    "type": "theorem",
+    "title": "prod_rpow_pos: positivity of the geometric mean",
+    "content": "The weighted geometric mean ∏ xᵢ^{wᵢ} of positive reals is positive, since it is a finite product of positive rpows (Finset.prod_pos with Real.rpow_pos_of_pos). Needed so that the geometric mean lies in the domain (0,∞) where log is injective.",
+    "mathContext": "$\\prod_i x_i^{w_i} > 0$ when each $x_i > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_pos",
+      "Real.rpow_pos_of_pos"
+    ],
+    "prerequisites": [
+      "Finset.prod_pos"
+    ]
+  },
+  {
+    "id": "ann-mean-pos",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 58,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "mean_pos: positivity of the arithmetic mean",
+    "content": "The weighted arithmetic mean ∑ wᵢxᵢ is positive: each summand wᵢxᵢ is a product of positive numbers, and the index set is nonempty, so Finset.sum_pos applies. Positivity places the arithmetic mean in the domain of log, the other endpoint of the bridge.",
+    "mathContext": "$\\sum_i w_i x_i > 0$ over a nonempty index set with $w_i, x_i > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_pos",
+      "weighted arithmetic mean"
+    ],
+    "prerequisites": [
+      "Finset.sum_pos"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-iff",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_iff: equality iff every xⱼ equals the mean",
+    "content": "The headline result (canonical form). For positive weights summing to 1 and positive x, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals that common mean. Proof: the index set is nonempty (weights sum to 1 ≠ 0), so both means are positive; by injectivity of log on (0,∞) (Real.log_injOn_pos) the multiplicative equality is equivalent to the equality of logs; rewriting the geometric side by log_prod_rpow reduces this to the additive equality log(∑ wᵢxᵢ) = ∑ wᵢ·log xᵢ, which is exactly the equality case of Jensen for the strictly concave Real.log. Mathlib's StrictConcaveOn.map_sum_eq_iff applied to strictConcaveOn_log_Ioi, with smul = mul on ℝ, finishes the equivalence.",
+    "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall j,\\; x_j = \\sum_i w_i x_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "StrictConcaveOn.map_sum_eq_iff",
+      "strictConcaveOn_log_Ioi",
+      "Real.log_injOn_pos",
+      "equality case of Jensen's inequality"
+    ],
+    "prerequisites": [
+      "StrictConcaveOn.map_sum_eq_iff",
+      "strictConcaveOn_log_Ioi",
+      "Real.log_injOn_pos"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-iff-pairwise",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_iff_pairwise: equality iff all xⱼ equal",
+    "content": "The familiar phrasing. Equality in weighted AM-GM holds iff all the xⱼ are pairwise equal. Derived from the canonical form: if all xⱼ equal the mean they are pairwise equal; conversely, if the sequence is constant then its weighted mean (with weights summing to 1) equals that constant, so each xⱼ equals the mean. This recovers the textbook statement that the geometric and arithmetic means coincide exactly for constant data.",
+    "mathContext": "$\\prod_i x_i^{w_i} = \\sum_i w_i x_i \\iff \\forall i\\,j,\\; x_i = x_j$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "weighted AM-GM equality case",
+      "constant sequence"
+    ],
+    "prerequisites": [
+      "weighted_amgm_eq_iff",
+      "Finset.sum_mul"
+    ]
+  },
+  {
+    "id": "ann-weighted-amgm-eq-of-const",
+    "proofId": "amgm-inequality-oq-05-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 113
+    },
+    "type": "theorem",
+    "title": "weighted_amgm_eq_of_const: the trivial direction",
+    "content": "Recorded explicitly for completeness: if all xⱼ equal a common value c, the weighted geometric and arithmetic means coincide. Immediate from the pairwise equality characterisation.",
+    "mathContext": "$(\\forall i,\\, x_i = c) \\implies \\prod_i x_i^{w_i} = \\sum_i w_i x_i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "weighted AM-GM equality case"
+    ],
+    "prerequisites": [
+      "weighted_amgm_eq_iff_pairwise"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-05-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "amgm-inequality-oq-05-oq-02",
+  "title": "The Equality Case of the Weighted AM-GM Inequality (n Terms)",
+  "slug": "amgm-inequality-oq-05-oq-02",
+  "description": "For strictly positive weights w summing to 1 over a finite index set and strictly positive reals x, the weighted geometric mean ∏ xᵢ^{wᵢ} equals the weighted arithmetic mean ∑ wᵢxᵢ iff every xⱼ equals their common mean — equivalently, iff all the xⱼ are equal. Mathlib has the weighted AM-GM inequality and the strict Jensen machinery but not this equality characterization. Following the parent Young-inequality entry's open question, the sharp boundary is obtained by taking logs to convert the multiplicative AM-GM equality into the additive Jensen equality and feeding it to the equality case of Jensen for the strictly concave Real.log (the dual of strict convexity of exp).",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inequality_of_arithmetic_and_geometric_means#Weighted_AM%E2%80%93GM_inequality",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "amgm",
+      "weighted-amgm",
+      "convexity",
+      "jensen",
+      "equality-case",
+      "logarithm",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 114,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). #print axioms on the headline theorems reports exactly these three. The equality characterization is proved from strictConcaveOn_log_Ioi via StrictConcaveOn.map_sum_eq_iff.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The weighted arithmetic–geometric mean inequality, ∏ xᵢ^{wᵢ} ≤ ∑ wᵢxᵢ for positive weights wᵢ summing to 1, is the central inequality of the AM-GM family; the equal-weight case wᵢ = 1/n recovers the classical statement that the geometric mean of n positive numbers is at most their arithmetic mean. Its modern proof is one line of convexity: applying Jensen's inequality to the concave logarithm gives ∑ wᵢ log xᵢ ≤ log(∑ wᵢxᵢ), and exponentiating yields AM-GM. The equality case — equality holds precisely when all the xⱼ coincide — is exactly the statement that Jensen's inequality is strict for a strictly concave function unless all evaluation points are equal. The parent entry characterised the equality case of the two-variable Young inequality (weights (1/p, 1/q)) from the strict convexity of exp, and posed the n-term weighted AM-GM equality case as an open question. This entry answers it, working with the strict concavity of log (the dual, and equivalent, formulation: log = −(−log) and exp is strictly convex iff log is strictly concave). While Mathlib carries the weighted AM-GM inequality and a full suite of strict-Jensen equality lemmas, it does not package this multiplicative equality characterisation of the geometric and arithmetic means.",
+    "problemStatement": "Let t be a finite index set, w : ι → ℝ strictly positive weights with ∑_{i∈t} wᵢ = 1, and x : ι → ℝ strictly positive. Prove that ∏_{i∈t} xᵢ^{wᵢ} = ∑_{i∈t} wᵢxᵢ holds if and only if every xⱼ equals the weighted mean ∑_{i∈t} wᵢxᵢ, equivalently if and only if all the xⱼ are equal.",
+    "text": "Equality in the weighted AM-GM inequality ∏ xᵢ^{wᵢ} ≤ ∑ wᵢxᵢ holds iff all xⱼ are equal. The proof takes logs and applies the equality case of Jensen for the strictly concave logarithm.",
+    "proofStrategy": "The argument is a logarithmic bridge to Jensen's equality case. (1) log_prod_rpow: for positive xᵢ, log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ, by Real.log_prod (each factor xᵢ^{wᵢ} is positive hence nonzero) followed by Real.log_rpow on each term. (2) Both means are positive: the geometric mean ∏ xᵢ^{wᵢ} is a product of positive rpows (prod_rpow_pos), and the arithmetic mean ∑ wᵢxᵢ is positive because each wᵢxᵢ > 0 over the necessarily nonempty index set (mean_pos; the index set is nonempty because the weights sum to 1 ≠ 0). (3) weighted_amgm_eq_iff: since both means lie in (0,∞) and log is injective there (Real.log_injOn_pos), the multiplicative equality ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ is equivalent to log(∏ xᵢ^{wᵢ}) = log(∑ wᵢxᵢ). Rewriting the left side by step (1) turns this into ∑ wᵢ·log xᵢ = log(∑ wᵢxᵢ), which is precisely the equality case of Jensen's inequality for Real.log. Mathlib's StrictConcaveOn.map_sum_eq_iff, applied to strictConcaveOn_log_Ioi, states that log(∑ wᵢ•xᵢ) = ∑ wᵢ•log xᵢ iff every xⱼ equals the center of mass ∑ wᵢ•xᵢ; with smul = mul on ℝ this closes the equivalence. (4) weighted_amgm_eq_iff_pairwise repackages the 'every xⱼ = mean' condition as the symmetric 'all xⱼ are pairwise equal' (a constant sequence has mean equal to its value, using ∑ wᵢ = 1). (5) weighted_amgm_eq_of_const records the trivial forward implication explicitly.",
+    "keyInsights": [
+      "**Strict concavity of log is the equality engine.** The ordinary weighted AM-GM inequality holds because log is concave (Jensen). The *sharp* equality case requires *strict* concavity: Mathlib's StrictConcaveOn.map_sum_eq_iff says that for a strictly concave f and positive weights, f(∑ wᵢ•xᵢ) = ∑ wᵢ•f(xᵢ) forces every xⱼ to equal the center of mass. Specialising f = log on (0,∞) (strictConcaveOn_log_Ioi) is exactly the AM-GM equality case. This is the dual of the parent entry's strict-convexity-of-exp argument.",
+      "**Logs linearise the geometric mean.** The multiplicative quantity ∏ xᵢ^{wᵢ} becomes the linear ∑ wᵢ·log xᵢ under log (log_prod_rpow), turning the geometric/arithmetic equality into the additive Jensen equality on which the convexity lemma acts directly. The two rpow facts needed are that xᵢ^{wᵢ} > 0 and log(xᵢ^{wᵢ}) = wᵢ·log xᵢ.",
+      "**Injectivity of log transports equality across the bridge.** Because both means are strictly positive and log is injective on (0,∞) (Real.log_injOn_pos), the multiplicative equality and its logarithm are interchangeable; this is what lets the Jensen equality case, an additive statement, characterise the original multiplicative one.",
+      "**Two equivalent phrasings of the equality locus.** The canonical Jensen output is 'every xⱼ equals the weighted mean'; the more familiar phrasing is 'all the xⱼ are equal'. These coincide here precisely because the weights sum to 1, so the mean of a constant sequence is that constant — the bridge in weighted_amgm_eq_iff_pairwise."
+    ],
+    "prerequisites": [
+      "Real powers Real.rpow and Real.log_rpow, Real.rpow_pos_of_pos",
+      "Logarithm of a product Real.log_prod and injectivity Real.log_injOn_pos",
+      "Strict concavity of the logarithm strictConcaveOn_log_Ioi",
+      "Equality case of Jensen's inequality StrictConcaveOn.map_sum_eq_iff"
+    ]
+  },
+  "conclusion": {
+    "summary": "The equality case of the n-term weighted AM-GM inequality is fully verified: 6 theorems, 0 definitions, 0 axioms, 0 sorries. For positive weights summing to 1 and positive reals x, the weighted geometric mean equals the weighted arithmetic mean iff every xⱼ equals their common mean (weighted_amgm_eq_iff), equivalently iff all the xⱼ are equal (weighted_amgm_eq_iff_pairwise). The proof bridges the multiplicative equality to the additive equality case of Jensen for the strictly concave Real.log via the logarithm, answering the parent Young-inequality entry's open question.",
+    "implications": "This pins down the tightness of the most-used inequality in the AM-GM family: in every downstream application of weighted AM-GM the estimate is sharp exactly when the inputs are constant. The proof exhibits the canonical template for upgrading a convexity inequality to its equality case — replace concavity by strict concavity, linearise in logarithmic coordinates, and use injectivity to transport equality across the bridge — and is the direct multiplicative companion of the parent's strict-convexity-of-exp treatment of the two-variable Young equality case.",
+    "openQuestions": [
+      "Specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case (n-th root of a product equals the average iff all terms are equal) as a standalone corollary indexed over Fin n.",
+      "Use the equality case as the base of an induction or smoothing ('mixing') argument to give an independent proof of the weighted AM-GM inequality itself, tracking the strict gain at each unequal pair."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-05",
+      "relationship": "extends",
+      "description": "The parent entry proved the two-variable Young equality case (weights (1/p, 1/q)) from strict convexity of exp and posed the n-term weighted AM-GM equality case as an open question. This entry answers it, using the dual strict concavity of log."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Sharpens the AM-GM family: the equal-weight specialisation of the equality characterisation proved here is the classical statement that the geometric and arithmetic means of n positive reals coincide iff all the reals are equal."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "AmgmInequalityOQ05OQ02",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for the weighted AM-GM inequality and its equality case (Theorem 9 and the surrounding discussion of the geometric and arithmetic means)."
+    },
+    {
+      "authors": "Steele, J. Michael",
+      "title": "The Cauchy–Schwarz Master Class",
+      "year": "2004",
+      "venue": "Cambridge University Press",
+      "note": "Develops AM-GM, Jensen, and the role of strict convexity in equality cases."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-01.json
@@ -1,0 +1,85 @@
+{
+  "slug": "amgm-inequality-oq-03-oq-01-oq-01",
+  "title": "Mixed-Sign Power Means: M_r ≤ M_s for r < 0 < s",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "theorem power_mean_monotone_mixed : ∀ r t, r < 0 → 0 < t → weightedPowerMean s w z r ≤ weightedPowerMean s w z t",
+    "plain": "For exponents r < 0 < s, the weighted power mean satisfies M_r ≤ M_s. This is the boundary-crossing regime left open by the same-sign parent files; it is settled by routing through the weighted geometric mean GM = ∏ zᵢ^{wᵢ}.",
+    "whyMatters": [
+      "Closes the only remaining regime of weighted power mean monotonicity — the crossing of order 0",
+      "Disposes of the boundary-crossing part of the Mathlib TODO for the generalized mean inequality with negative exponents",
+      "Shows the mixed-sign case needs NO r→0 limit, contrary to the parent file's conjecture"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "power_mean_monotone_mixed (M_r ≤ M_s for r < 0 < s)",
+      "geomMean_rpow_le_weighted_sum (core estimate GM^p ≤ ∑ wᵢzᵢ^p, for all real p)",
+      "geomMean_le_powerMean_pos (GM ≤ M_s for s > 0)",
+      "powerMean_le_geomMean_neg (M_r ≤ GM for r < 0)"
+    ],
+    "open": [
+      "Assemble pos/neg/mixed into a single uniform theorem M_p ≤ M_q for all p ≤ q over ℝ"
+    ],
+    "goal": "Prove M_r ≤ M_s for r < 0 < s — COMPLETED"
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Proved the mixed-sign monotonicity in AmgmInequalityOQ03OQ01OQ01.lean and created the gallery entry.",
+    "blockers": [],
+    "nextAction": "None — completed.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: Proved power_mean_monotone_mixed (M_r ≤ M_s for r < 0 < s) in proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean — 4 theorems, 160 lines, 0 axioms, 0 sorries (#print axioms reports only propext/Classical.choice/Quot.sound). The proof isolates all analytic content into one sign-agnostic core estimate GM^p ≤ ∑ wᵢzᵢ^p (the weighted AM-GM applied to zᵢ^p), then recovers both halves by raising to the power 1/p: order-preserving for s > 0 (rpow_le_rpow) gives GM ≤ M_s, order-reversing for r < 0 (rpow_le_rpow_of_nonpos) gives M_r ≤ GM. Transitivity through the geometric-mean pivot yields M_r ≤ GM ≤ M_s. Created gallery entry src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/ (meta.json + annotations.json).",
+    "builtItems": [
+      "proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean (4 theorems, 160 lines, 0 axioms, 0 sorries)",
+      "Gallery entry: src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/meta.json",
+      "Gallery annotations: src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/annotations.json"
+    ],
+    "insights": [
+      "The mixed-sign case needs NO limiting argument: the parent entry conjectured it 'likely requires the r→0 limit', but comparing GM = ∏ zᵢ^{wᵢ} (the closed form of that limit) to each side directly via AM-GM avoids any analytic limit entirely.",
+      "All analytic content collapses into ONE sign-agnostic inequality, GM^p ≤ ∑ wᵢzᵢ^p, valid for every real p. The positive and negative halves of the theorem are this single estimate viewed through the map t ↦ t^{1/p}.",
+      "Crossing zero is exactly the sign flip of 1/p: rpow_le_rpow (1/s ≥ 0) preserves order while rpow_le_rpow_of_nonpos (1/r ≤ 0) reverses it — which is precisely why the parent's two same-sign theorems cannot be chained through a common exponent.",
+      "The folding identity ∏ (zᵢ^p)^{wᵢ} = (∏ zᵢ^{wᵢ})^p = GM^p (rpow_mul + finset_prod_rpow) is what lets a single AM-GM call serve both signs."
+    ],
+    "mathlibGaps": [
+      "Mathlib.Analysis.MeanInequalitiesPow has an explicit TODO for the generalized mean inequality with any p ≤ q including negative numbers; the boundary-crossing piece is now formalized here and could be upstreamed."
+    ],
+    "nextSteps": [
+      "Assemble pos/neg/mixed regimes into a single uniform statement M_p ≤ M_q for p ≤ q over ℝ",
+      "Quantify the gap M_s − M_r via the weighted variance of log zᵢ near the geometric-mean pivot"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "analysis",
+    "inequalities",
+    "power-means"
+  ],
+  "relatedProofs": [
+    "amgm-inequality-oq-03-oq-01",
+    "amgm-inequality-oq-03",
+    "amgm-inequality"
+  ],
+  "references": [
+    "Hardy, Littlewood, Pólya — Inequalities (1934), Chapter 2",
+    "Bullen — Handbook of Means and Their Inequalities (2003)"
+  ],
+  "started": "2026-06-24T00:00:00.000Z",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 6,
+  "leanFiles": [
+    "proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean"
+  ]
+}

--- a/src/data/research/problems/amgm-inequality-oq-05-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-05-oq-02.json
@@ -1,0 +1,63 @@
+{
+  "slug": "amgm-inequality-oq-05-oq-02",
+  "title": "The Equality Case of the Weighted AM-GM Inequality (n Terms)",
+  "problemStatement": "For strictly positive weights w summing to 1 over a finite index set t and strictly positive reals x, prove that the weighted geometric mean ∏ xᵢ^{wᵢ} equals the weighted arithmetic mean ∑ wᵢxᵢ if and only if every xⱼ equals their common mean, equivalently iff all the xⱼ are equal. Use the strict convexity of exp / strict concavity of log, as posed in the parent Young-inequality entry's open questions.",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 7,
+  "status": "completed",
+  "phase": "COMPLETED",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "path": "Proofs/AmgmInequalityOQ05OQ02.lean",
+  "leanFiles": [
+    "proofs/Proofs/AmgmInequalityOQ05OQ02.lean"
+  ],
+  "relatedProofs": [
+    "amgm-inequality-oq-05",
+    "amgm-inequality"
+  ],
+  "tags": [
+    "analysis",
+    "inequalities",
+    "amgm",
+    "weighted-amgm",
+    "convexity",
+    "jensen",
+    "equality-case"
+  ],
+  "knowledge": {
+    "insights": [
+      "The equality case of weighted AM-GM is exactly the equality case of Jensen's inequality for the strictly concave logarithm: Mathlib's StrictConcaveOn.map_sum_eq_iff, applied to strictConcaveOn_log_Ioi, gives that log(∑ wᵢ•xᵢ) = ∑ wᵢ•log xᵢ iff every xⱼ equals the center of mass.",
+      "Taking logs linearises the multiplicative geometric mean: log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ via Real.log_prod + Real.log_rpow, converting the AM-GM equality into an additive Jensen equality.",
+      "Injectivity of log on (0,∞) (Real.log_injOn_pos) is what transports equality across the bridge: both means are strictly positive, so the multiplicative equality and the equality of their logs are interchangeable.",
+      "The 'every xⱼ equals the mean' and 'all xⱼ pairwise equal' phrasings coincide precisely because the weights sum to 1 — the weighted mean of a constant sequence is that constant.",
+      "This is the dual of the parent entry's route: exp strictly convex ⟺ log strictly concave, so the n-term weighted AM-GM equality case can be obtained from log-concavity instead of exp-convexity, and Mathlib packages the strict-Jensen equality case directly."
+    ],
+    "builtItems": [
+      "log_prod_rpow (Proofs/AmgmInequalityOQ05OQ02.lean:44): log(∏ xᵢ^{wᵢ}) = ∑ wᵢ·log xᵢ for positive xᵢ.",
+      "prod_rpow_pos (Proofs/AmgmInequalityOQ05OQ02.lean:52): positivity of the weighted geometric mean.",
+      "mean_pos (Proofs/AmgmInequalityOQ05OQ02.lean:58): positivity of the weighted arithmetic mean over a nonempty index set.",
+      "weighted_amgm_eq_iff (Proofs/AmgmInequalityOQ05OQ02.lean:68): headline — equality iff every xⱼ equals the weighted mean.",
+      "weighted_amgm_eq_iff_pairwise (Proofs/AmgmInequalityOQ05OQ02.lean:90): equality iff all xⱼ are pairwise equal.",
+      "weighted_amgm_eq_of_const (Proofs/AmgmInequalityOQ05OQ02.lean:107): the trivial forward direction."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the weighted AM-GM inequality and a full suite of strict-Jensen equality lemmas (StrictConcaveOn.map_sum_eq_iff), but does not package the multiplicative equality characterisation ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ ↔ constant data."
+    ],
+    "nextSteps": [
+      "Specialise to equal weights wᵢ = 1/n to state the classical AM-GM equality case over Fin n as a standalone corollary.",
+      "Use the equality case as the base of a smoothing/mixing induction to give an independent proof of the weighted AM-GM inequality, tracking the strict gain at each unequal pair."
+    ],
+    "progressSummary": "COMPLETE: weighted AM-GM equality case proved for n terms, 0 axioms / 0 sorries, 6 theorems / 114 lines. Verified via lake env lean; #print axioms reports only propext/Classical.choice/Quot.sound. Answers the parent Young-inequality entry's second open question."
+  },
+  "currentState": "Completed and verified. The headline equivalence ∏ xᵢ^{wᵢ} = ∑ wᵢxᵢ ↔ all xⱼ equal is machine-checked from Mathlib's strict-Jensen equality case for the logarithm, with no axioms beyond Lean's foundational three.",
+  "knownResults": [
+    "Weighted AM-GM inequality (classical; Mathlib has the inequality direction).",
+    "Equality in Jensen's inequality for a strictly concave function forces all evaluation points equal (Mathlib: StrictConcaveOn.map_sum_eq_iff)."
+  ],
+  "references": [
+    "Hardy, Littlewood, Pólya, Inequalities (1934), Theorem 9.",
+    "J. M. Steele, The Cauchy–Schwarz Master Class (2004)."
+  ]
+}


### PR DESCRIPTION
## Summary

Closes **amgm-inequality-oq-03-oq-01-oq-01** — the **mixed-sign case** of weighted power mean monotonicity:

> For positive reals $z_i$ with weights $w_i \ge 0$ summing to $1$, and exponents $r < 0 < s$,
> $$M_r(z,w) \le M_s(z,w), \qquad M_p = \Big(\sum_i w_i z_i^p\Big)^{1/p}.$$

This is the one regime the parent files (`AmgmInequalityOQ03.lean`: `power_mean_monotone_pos`, `power_mean_monotone_neg`) explicitly leave open — the comparison must **cross the geometric-mean limit at order 0**.

## Approach — pivot through the geometric mean, no limit

All analytic content is isolated into **one sign-agnostic estimate** (`geomMean_rpow_le_weighted_sum`), the weighted AM-GM applied to $y_i = z_i^p$:
$$\mathrm{GM}^p \le \sum_i w_i z_i^p \quad\text{for \emph{every} real } p, \qquad \mathrm{GM} = \prod_i z_i^{w_i}.$$

Raising to the power $1/p$ then recovers both halves, with the **sign of $1/p$** flipping the direction:

- $s > 0$: $t \mapsto t^{1/s}$ is increasing (`rpow_le_rpow`) ⟹ $\mathrm{GM} \le M_s$.
- $r < 0$: $t \mapsto t^{1/r}$ is decreasing (`rpow_le_rpow_of_nonpos`) ⟹ $M_r \le \mathrm{GM}$.

Transitivity gives $M_r \le \mathrm{GM} \le M_s$.

**Notable:** the parent entry conjectured this case "likely requires the $r\to0$ limit." It does **not** — comparing the geometric mean (the closed form $\prod z_i^{w_i}$ of that limit) to each side directly via AM-GM sidesteps any analytic limit.

## Verification

- **4 theorems, 160 lines, 0 axioms, 0 sorries.**
- `#print axioms power_mean_monotone_mixed` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- Builds against Mathlib 4.26.0 via `lake env lean Proofs/AmgmInequalityOQ03OQ01OQ01.lean`.

## Files

- `proofs/Proofs/AmgmInequalityOQ03OQ01OQ01.lean`
- `src/data/proofs/amgm-inequality-oq-03-oq-01-oq-01/{meta,annotations}.json`
- `src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)