### PR TITLE
research(greens-theorem-oq-01-oq-03): Green's theorem is additive under subdivision [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ03.lean
@@ -1,0 +1,219 @@
+import Mathlib
+import Proofs.GreensTheoremOQ01
+
+/-
+# OQ-03: Green's Theorem is Additive Under Subdivision
+
+## The Open Question (greens-theorem-oq-01-oq-03)
+
+The parent result `greens_theorem_concrete` (greens-theorem-oq-01) proves Green's
+theorem for a *single* rectangle, and its Part VI flags the natural next step:
+extending the identity from one rectangle to general regions.  The standard route
+is to **tile** a region with rectangles and add the cell-wise identities, relying
+on the fact that the contributions along shared interior edges cancel.
+
+**Open question:** Are the two sides of Green's identity — the concrete boundary
+line integral `rectLineIntegral` and the concrete double integral
+`rectDoubleIntegral` — *additive under subdivision* of the rectangle, with shared
+edges canceling by orientation?
+
+## Answer: YES — and the cancellation is exact
+
+We prove that both `rectLineIntegral` and `rectDoubleIntegral` split additively
+when a rectangle `[a,b]×[c,d]` is cut by a vertical line `x = e` or a horizontal
+line `y = g`:
+
+  rectLineIntegral over [a,b] = rectLineIntegral over [a,e] + rectLineIntegral over [e,b]
+  rectDoubleIntegral over [a,b] = rectDoubleIntegral over [a,e] + rectDoubleIntegral over [e,b]
+
+For the **line integral** the interior edge `x = e` is traversed *upward* as the
+right edge of the left cell (contribution `+∫_c^d Q(e,y)`) and *downward* as the
+left edge of the right cell (contribution `−∫_c^d Q(e,y)`); the two cancel by pure
+`ring` arithmetic — no hypothesis is needed for the cancellation itself.  The
+outer boundary edges glue via `intervalIntegral.integral_add_adjacent_intervals`.
+
+For the **double integral** the split is the additivity of the iterated integral
+over adjacent sub-intervals.
+
+Adding the two facts gives the capstone `greens_additive_vertical`: if Green's
+theorem holds on the two sub-rectangles, it holds on their union.  This is exactly
+the inductive step that lets one prove Green's theorem on a *staircase region*
+(a finite union of rectangles) by proving it cell by cell — the interior edges
+take care of themselves.
+
+## What is new relative to the gallery
+
+- The parent (oq-01) and the discharged-Fubini siblings (oq-01-oq-01, oq-01-oq-02)
+  all work with a **fixed single rectangle**.  None of them prove that the Green
+  identity *tiles*.
+- The shared-edge cancellation `∫Q(e,·) − ∫Q(e,·) = 0` is the orientation
+  phenomenon at the heart of every "cut the region into pieces" argument, here
+  isolated as a reusable algebraic fact.
+- No ordering hypotheses (`a ≤ e ≤ b`) are required: `integral_add_adjacent_intervals`
+  is sign-aware, so the lemmas hold for signed/overlapping cuts as well.
+
+## Proof Status
+
+- [x] Vertical line-integral additivity (0 sorries)
+- [x] Vertical double-integral additivity (0 sorries)
+- [x] Horizontal line-integral additivity (0 sorries)
+- [x] Horizontal double-integral additivity (0 sorries)
+- [x] Capstone: Green's theorem glues across a vertical cut (0 sorries)
+- [x] Concrete numeric sanity check (0 sorries)
+-/
+
+namespace GreensTheoremOQ01OQ03
+
+open MeasureTheory intervalIntegral
+open GreensTheoremOQ01
+
+/-!
+## Part I: Vertical subdivision (cut at `x = e`)
+
+The interior edge is the vertical segment `x = e`.  It appears as the right edge
+of the left cell `[a,e]×[c,d]` and as the left edge of the right cell
+`[e,b]×[c,d]`, with opposite orientations.
+-/
+
+/-- **Line integral is additive under a vertical cut.**
+
+    Splitting `[a,b]×[c,d]` at `x = e`, the boundary line integral of the whole
+    rectangle equals the sum of the boundary line integrals of the two halves.
+
+    The shared interior edge `x = e` contributes `+∫_c^d Q(e,y)` to the left cell
+    and `−∫_c^d Q(e,y)` to the right cell; these cancel identically.  Only the
+    outer edges (`P(·,c)` and `P(·,d)` integrated in `x`) need to be glued, via
+    `integral_add_adjacent_intervals` — hence the four integrability hypotheses. -/
+theorem rectLineIntegral_vsplit (P Q : ℝ × ℝ → ℝ) (a e b c d : ℝ)
+    (hPc_ae : IntervalIntegrable (fun x => P (x, c)) volume a e)
+    (hPc_eb : IntervalIntegrable (fun x => P (x, c)) volume e b)
+    (hPd_ae : IntervalIntegrable (fun x => P (x, d)) volume a e)
+    (hPd_eb : IntervalIntegrable (fun x => P (x, d)) volume e b) :
+    rectLineIntegral P Q a e c d + rectLineIntegral P Q e b c d =
+    rectLineIntegral P Q a b c d := by
+  have hc : (∫ x in a..e, P (x, c)) + ∫ x in e..b, P (x, c) = ∫ x in a..b, P (x, c) :=
+    integral_add_adjacent_intervals hPc_ae hPc_eb
+  have hd : (∫ x in a..e, P (x, d)) + ∫ x in e..b, P (x, d) = ∫ x in a..b, P (x, d) :=
+    integral_add_adjacent_intervals hPd_ae hPd_eb
+  simp only [rectLineIntegral]
+  -- the `∫ Q(e,·)` terms cancel; the `P(·,c)` and `P(·,d)` terms glue via hc, hd
+  linarith [hc, hd]
+
+/-- **Double integral is additive under a vertical cut.**
+
+    `∬_{[a,b]×[c,d]} f = ∬_{[a,e]×[c,d]} f + ∬_{[e,b]×[c,d]} f`.
+
+    Inner additivity of `∫_a^e f(·,y) + ∫_e^b f(·,y) = ∫_a^b f(·,y)` (pointwise in
+    `y`) is lifted through the outer `y`-integral. -/
+theorem rectDoubleIntegral_vsplit (f : ℝ × ℝ → ℝ) (a e b c d : ℝ)
+    (hf_ae : ∀ y ∈ Set.uIcc c d, IntervalIntegrable (fun x => f (x, y)) volume a e)
+    (hf_eb : ∀ y ∈ Set.uIcc c d, IntervalIntegrable (fun x => f (x, y)) volume e b)
+    (hfo_ae : IntervalIntegrable (fun y => ∫ x in a..e, f (x, y)) volume c d)
+    (hfo_eb : IntervalIntegrable (fun y => ∫ x in e..b, f (x, y)) volume c d) :
+    rectDoubleIntegral f a e c d + rectDoubleIntegral f e b c d =
+    rectDoubleIntegral f a b c d := by
+  have hinner : ∀ y ∈ Set.uIcc c d,
+      (∫ x in a..e, f (x, y)) + (∫ x in e..b, f (x, y)) = ∫ x in a..b, f (x, y) :=
+    fun y hy => integral_add_adjacent_intervals (hf_ae y hy) (hf_eb y hy)
+  simp only [rectDoubleIntegral]
+  rw [← integral_add hfo_ae hfo_eb]
+  exact integral_congr hinner
+
+/-!
+## Part II: Horizontal subdivision (cut at `y = g`)
+
+By symmetry, the interior edge is the horizontal segment `y = g`, shared (with
+opposite orientation) by the bottom cell `[a,b]×[c,g]` and the top cell
+`[a,b]×[g,d]`.
+-/
+
+/-- **Line integral is additive under a horizontal cut.**
+
+    Splitting `[a,b]×[c,d]` at `y = g`.  The shared edge `y = g` contributes
+    `−∫_a^b P(x,g)` to the bottom cell and `+∫_a^b P(x,g)` to the top cell; these
+    cancel.  The outer edges (`Q(b,·)` and `Q(a,·)` integrated in `y`) glue via
+    `integral_add_adjacent_intervals`. -/
+theorem rectLineIntegral_hsplit (P Q : ℝ × ℝ → ℝ) (a b c g d : ℝ)
+    (hQb_cg : IntervalIntegrable (fun y => Q (b, y)) volume c g)
+    (hQb_gd : IntervalIntegrable (fun y => Q (b, y)) volume g d)
+    (hQa_cg : IntervalIntegrable (fun y => Q (a, y)) volume c g)
+    (hQa_gd : IntervalIntegrable (fun y => Q (a, y)) volume g d) :
+    rectLineIntegral P Q a b c g + rectLineIntegral P Q a b g d =
+    rectLineIntegral P Q a b c d := by
+  have hb : (∫ y in c..g, Q (b, y)) + ∫ y in g..d, Q (b, y) = ∫ y in c..d, Q (b, y) :=
+    integral_add_adjacent_intervals hQb_cg hQb_gd
+  have ha : (∫ y in c..g, Q (a, y)) + ∫ y in g..d, Q (a, y) = ∫ y in c..d, Q (a, y) :=
+    integral_add_adjacent_intervals hQa_cg hQa_gd
+  simp only [rectLineIntegral]
+  -- the `∫ P(·,g)` terms cancel; the `Q(b,·)` and `Q(a,·)` terms glue via hb, ha
+  linarith [hb, ha]
+
+/-- **Double integral is additive under a horizontal cut.**
+
+    `∬_{[a,b]×[c,d]} f = ∬_{[a,b]×[c,g]} f + ∬_{[a,b]×[g,d]} f`.  Here the split is
+    a single application of adjacent-interval additivity on the *outer* integral. -/
+theorem rectDoubleIntegral_hsplit (f : ℝ × ℝ → ℝ) (a b c g d : ℝ)
+    (hfo_cg : IntervalIntegrable (fun y => ∫ x in a..b, f (x, y)) volume c g)
+    (hfo_gd : IntervalIntegrable (fun y => ∫ x in a..b, f (x, y)) volume g d) :
+    rectDoubleIntegral f a b c g + rectDoubleIntegral f a b g d =
+    rectDoubleIntegral f a b c d := by
+  simp only [rectDoubleIntegral]
+  exact integral_add_adjacent_intervals hfo_cg hfo_gd
+
+/-!
+## Part III: Capstone — Green's theorem glues across a cut
+
+If Green's identity holds on each of two sub-rectangles meeting along a vertical
+interior edge, it holds on their union.  Because both sides are additive
+(`rectLineIntegral_vsplit`, `rectDoubleIntegral_vsplit`) the proof is a pure
+rewrite — the interior edge cancels with no extra input.  This is the inductive
+step for proving Green's theorem on any rectangle-tiled region.
+-/
+
+/-- **Green's theorem is preserved by vertical subdivision (gluing).**
+
+    Given that the concrete Green identity holds on the left cell `[a,e]×[c,d]`
+    and the right cell `[e,b]×[c,d]` for the curl field `F`, it holds on the whole
+    rectangle `[a,b]×[c,d]`.  The four line-integral and four double-integral
+    integrability hypotheses are exactly those that make the two sides additive. -/
+theorem greens_additive_vertical (P Q F : ℝ × ℝ → ℝ) (a e b c d : ℝ)
+    -- gluing data for the line integral
+    (hPc_ae : IntervalIntegrable (fun x => P (x, c)) volume a e)
+    (hPc_eb : IntervalIntegrable (fun x => P (x, c)) volume e b)
+    (hPd_ae : IntervalIntegrable (fun x => P (x, d)) volume a e)
+    (hPd_eb : IntervalIntegrable (fun x => P (x, d)) volume e b)
+    -- gluing data for the double integral
+    (hF_ae : ∀ y ∈ Set.uIcc c d, IntervalIntegrable (fun x => F (x, y)) volume a e)
+    (hF_eb : ∀ y ∈ Set.uIcc c d, IntervalIntegrable (fun x => F (x, y)) volume e b)
+    (hFo_ae : IntervalIntegrable (fun y => ∫ x in a..e, F (x, y)) volume c d)
+    (hFo_eb : IntervalIntegrable (fun y => ∫ x in e..b, F (x, y)) volume c d)
+    -- Green's theorem on each cell
+    (hL : rectLineIntegral P Q a e c d = rectDoubleIntegral F a e c d)
+    (hR : rectLineIntegral P Q e b c d = rectDoubleIntegral F e b c d) :
+    rectLineIntegral P Q a b c d = rectDoubleIntegral F a b c d := by
+  rw [← rectLineIntegral_vsplit P Q a e b c d hPc_ae hPc_eb hPd_ae hPd_eb,
+      ← rectDoubleIntegral_vsplit F a e b c d hF_ae hF_eb hFo_ae hFo_eb, hL, hR]
+
+/-!
+## Part IV: Concrete sanity check
+
+A fully concrete instance: the area of the unit square computed as
+`∬ 1` splits at `x = 1/2` into two half-rectangles of area `1/2` each.
+-/
+
+/-- The double integral of `1` over `[0,1]²` equals the sum of its values over the
+    two halves `[0,½]×[0,1]` and `[½,1]×[0,1]`, each `½`. -/
+theorem area_vsplit_unit_square :
+    rectDoubleIntegral (fun _ => 1) 0 (1/2) 0 1 +
+    rectDoubleIntegral (fun _ => 1) (1/2) 1 0 1 =
+    rectDoubleIntegral (fun _ => 1) 0 1 0 1 := by
+  rw [area_double_integral, area_double_integral, area_double_integral]
+  ring
+
+#check @rectLineIntegral_vsplit
+#check @rectDoubleIntegral_vsplit
+#check @rectLineIntegral_hsplit
+#check @rectDoubleIntegral_hsplit
+#check @greens_additive_vertical
+
+end GreensTheoremOQ01OQ03

--- a/src/data/proofs/greens-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "greens-theorem-oq-01-oq-03",
+  "title": "Green's Theorem is Additive Under Subdivision",
+  "slug": "greens-theorem-oq-01-oq-03",
+  "description": "Both sides of the concrete Green's-theorem identity — the boundary line integral and the double integral of curl — are additive when a rectangle is cut by a vertical or horizontal line. The contribution of the shared interior edge cancels by orientation, so Green's theorem proved cell-by-cell glues into the identity on the whole tiled region.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GreensTheoremOQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "multivariable-calculus",
+      "integration",
+      "greens-theorem",
+      "additivity"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No axioms. 0 sorries. All six theorems fully machine-checked. #print axioms reports only propext / Classical.choice / Quot.sound (the standard foundational axioms). Built on intervalIntegral.integral_add_adjacent_intervals and intervalIntegral.integral_add from Mathlib.",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_add_adjacent_intervals",
+        "description": "∫_a^b f + ∫_b^c f = ∫_a^c f for f interval-integrable on both pieces (sign-aware, no ordering required)",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_add",
+        "description": "∫(f+g) = ∫f + ∫g for interval-integrable f, g — lifts inner additivity through the outer integral",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_congr",
+        "description": "Pointwise equality of integrands on the interval implies equality of integrals",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Vertical subdivision additivity for the boundary line integral (rectLineIntegral_vsplit): the shared edge x=e cancels by ring, outer edges glue via integral_add_adjacent_intervals",
+      "Vertical subdivision additivity for the double integral of curl (rectDoubleIntegral_vsplit)",
+      "Horizontal subdivision additivity for both sides (rectLineIntegral_hsplit, rectDoubleIntegral_hsplit)",
+      "Capstone gluing theorem (greens_additive_vertical): if Green's theorem holds on two sub-rectangles meeting along an interior edge, it holds on their union — the inductive step for proving Green's theorem on rectangle-tiled regions",
+      "Isolation of the orientation cancellation ∫Q(e,·) − ∫Q(e,·) = 0 as a reusable algebraic fact; no a≤e≤b ordering hypotheses needed"
+    ],
+    "lineCount": 219,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The standard textbook route from Green's theorem on a single rectangle to Green's theorem on a general region is to approximate the region by a union of rectangles (a grid or 'staircase' region) and add the rectangle-wise identities. The crucial — and often hand-waved — observation is that the contributions along the interior edges shared by adjacent rectangles cancel, because each interior edge is traversed once in each direction. This file formalizes exactly that cancellation for the concrete intervalIntegral formulation of Green's theorem introduced in greens-theorem-oq-01.",
+    "problemStatement": "Open Question (greens-theorem-oq-01-oq-03): Are the two sides of the concrete Green identity — rectLineIntegral and rectDoubleIntegral — additive under subdivision of the rectangle, with shared interior edges canceling by orientation? Answer: YES, and the cancellation is exact and hypothesis-free.",
+    "text": "Cutting a rectangle [a,b]×[c,d] by a vertical line x=e (or horizontal line y=g) splits both the boundary line integral and the double integral of curl additively into the two sub-rectangles. The interior edge contributes with opposite orientation to the two cells and cancels identically; only the outer boundary edges need gluing, via Mathlib's adjacent-interval additivity. Adding the two facts yields the capstone: Green's theorem proved cell-by-cell glues into the identity on the union.",
+    "proofStrategy": "For the LINE integral under a vertical cut: expand rectLineIntegral on each cell. The shared right/left edge at x=e contributes +∫_c^d Q(e,y) to the left cell and −∫_c^d Q(e,y) to the right cell, cancelling by pure ring/linarith arithmetic with no hypothesis. The outer edges P(·,c), P(·,d) integrated in x glue via integral_add_adjacent_intervals (hence four integrability hypotheses). For the DOUBLE integral under a vertical cut: inner additivity ∫_a^e f(·,y)+∫_e^b f(·,y)=∫_a^b f(·,y) (pointwise in y, via integral_add_adjacent_intervals) is lifted through the outer y-integral using integral_add and integral_congr. Horizontal cuts are symmetric (shared edge y=g cancels the P(·,g) terms; the double-integral split is a single adjacent-interval additivity on the outer integral). The capstone greens_additive_vertical rewrites both sides with the vertical-split lemmas and substitutes the two cell-wise Green identities.",
+    "keyInsights": [
+      "Orientation is what makes regions tile: each interior edge is traversed once upward and once downward, so its two line-integral contributions are exact negatives and cancel with no analytic input.",
+      "The cancellation needs no integrability or ordering hypothesis — it is pure algebra (ring/linarith). Only the *outer* edges, which genuinely combine into a longer integral, require interval-integrability.",
+      "Both sides of Green's identity decompose the same way, so the identity is subdivision-invariant: proving it on a partition into cells proves it on the whole, and vice versa.",
+      "integral_add_adjacent_intervals is sign-aware, so the additivity holds for signed/overlapping cuts as well — no a≤e≤b is assumed.",
+      "greens_additive_vertical is precisely the inductive step for extending Green's theorem from one rectangle to any rectangle-tiled (staircase) region."
+    ],
+    "prerequisites": [
+      "Green's theorem for a rectangle via concrete intervalIntegrals (greens-theorem-oq-01)",
+      "Additivity of the interval integral over adjacent intervals",
+      "Orientation conventions for boundary line integrals"
+    ]
+  },
+  "conclusion": {
+    "summary": "The concrete Green's-theorem identity is additive under subdivision: both the boundary line integral and the double integral of curl split into adjacent sub-rectangles, with the shared interior edge cancelling by orientation. The capstone greens_additive_vertical shows Green's theorem glues across a cut, giving the inductive step toward Green's theorem on rectangle-tiled regions.",
+    "implications": "This isolates the structural ingredient — orientation-driven edge cancellation — that lets the single-rectangle result (OQ-01) extend to general regions. Combined with the discharged-Fubini siblings (OQ-01-OQ-01, OQ-01-OQ-02), it points toward an axiom-free Green's theorem on staircase domains.",
+    "futureDirections": [
+      "Iterate greens_additive_vertical over a finite grid to obtain Green's theorem on an arbitrary rectangle-tiled region by induction (Finset.sum form).",
+      "Combine horizontal and vertical splits to handle 2D grids of cells.",
+      "Quantify the staircase approximation error to reach Green's theorem on regions with curved boundary."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GreensTheoremOQ01"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "intervalIntegral",
+      "GreensTheoremOQ01"
+    ],
+    "namespace": "GreensTheoremOQ01OQ03",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GreensTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "greens-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Proves the concrete Green identity from OQ-01 is additive under subdivision, supplying the inductive step toward general regions"
+    },
+    {
+      "targetId": "greens-theorem-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Complements the Fubini-elimination sibling: that removes the hFubini hypothesis on one rectangle; this tiles the result across many"
+    },
+    {
+      "targetId": "greens-theorem",
+      "relationship": "related",
+      "description": "Edge-cancellation under subdivision is the structural mechanism behind Green's theorem on general regions"
+    }
+  ],
+  "references": [
+    {
+      "title": "Green's theorem",
+      "url": "https://en.wikipedia.org/wiki/Green%27s_theorem"
+    },
+    {
+      "title": "Mathlib: intervalIntegral.integral_add_adjacent_intervals",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.html"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/greens-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-03.json
@@ -1,0 +1,80 @@
+{
+  "slug": "greens-theorem-oq-01-oq-03",
+  "title": "Is Green's theorem (concrete intervalIntegral form) additive under subdivision?",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "verified",
+  "path": "proofs/Proofs/GreensTheoremOQ01OQ03.lean",
+  "problemStatement": "The parent result greens_theorem_concrete (greens-theorem-oq-01) proves Green's theorem for a single rectangle and flags, in its Part VI, the extension to general regions. The standard route tiles a region with rectangles and adds the cell-wise identities, relying on cancellation along shared interior edges. Are the two sides of the concrete Green identity — rectLineIntegral and rectDoubleIntegral — additive under a vertical or horizontal subdivision, with the shared interior edge cancelling by orientation?",
+  "knownResults": {
+    "proven": [
+      "rectLineIntegral_vsplit: line integral splits additively under a vertical cut x=e; shared edge Q(e,·) cancels",
+      "rectDoubleIntegral_vsplit: double integral of curl splits additively under a vertical cut",
+      "rectLineIntegral_hsplit: line integral splits additively under a horizontal cut y=g; shared edge P(·,g) cancels",
+      "rectDoubleIntegral_hsplit: double integral splits additively under a horizontal cut",
+      "greens_additive_vertical: if Green's theorem holds on two sub-rectangles, it holds on their union (inductive gluing step)",
+      "area_vsplit_unit_square: concrete numeric sanity check (½ + ½ = 1)"
+    ],
+    "open": [
+      "Iterate greens_additive_vertical over a finite grid (Finset.sum form) to obtain Green's theorem on a rectangle-tiled region",
+      "Quantify staircase approximation error to reach regions with curved boundary"
+    ],
+    "goal": "Show the concrete Green identity is subdivision-invariant and supply the inductive step toward general regions."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "All six theorems fully proved. 0 axioms, 0 sorries.",
+    "blockers": [],
+    "nextAction": "None - results complete. Follow-ups: grid induction, staircase approximation.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED in one session: proved that both sides of the concrete Green's-theorem identity (boundary line integral and double integral of curl) are additive under vertical and horizontal subdivision of the rectangle. The interior edge shared by adjacent cells cancels by orientation with no hypothesis (pure ring/linarith); only the outer edges, which genuinely combine into a longer integral, need interval-integrability, supplied via intervalIntegral.integral_add_adjacent_intervals. The capstone greens_additive_vertical glues two cell-wise Green identities into the identity on their union — the inductive step for Green's theorem on rectangle-tiled regions. 6 theorems, 219 lines, 0 axioms, 0 sorries; #print axioms shows only propext/Classical.choice/Quot.sound.",
+    "builtItems": [
+      "Created proofs/Proofs/GreensTheoremOQ01OQ03.lean importing the parent Proofs.GreensTheoremOQ01 to reuse rectLineIntegral / rectDoubleIntegral",
+      "rectLineIntegral_vsplit + rectLineIntegral_hsplit: orientation cancellation of the shared edge (ring/linarith) + adjacent-interval gluing of outer edges",
+      "rectDoubleIntegral_vsplit + rectDoubleIntegral_hsplit: adjacent-interval additivity lifted through the outer integral via integral_add / integral_congr",
+      "greens_additive_vertical: pure-rewrite capstone gluing two cell-wise Green identities",
+      "area_vsplit_unit_square: concrete check using parent's area_double_integral"
+    ],
+    "insights": [
+      "Orientation is what makes regions tile: each interior edge is traversed once up and once down, so its two line-integral contributions are exact negatives and cancel with zero analytic input.",
+      "The cancellation needs neither integrability nor ordering hypotheses — only the outer edges that combine into a longer integral do. This cleanly separates the algebraic (cancellation) and analytic (gluing) content.",
+      "integral_add_adjacent_intervals is sign-aware, so additivity holds for signed/overlapping cuts; no a≤e≤b assumption is required.",
+      "Both sides of Green's identity decompose identically, so the identity is subdivision-invariant — proving it on a partition proves it on the whole.",
+      "Build gotcha: the parent Proofs.GreensTheoremOQ01 olean must sit at .lake/build/lib/lean/Proofs/ (not lib/Proofs/) for the worktree's lake env lean import search to resolve it."
+    ],
+    "techniques": [
+      "intervalIntegral.integral_add_adjacent_intervals for boundary-edge gluing",
+      "integral_add + integral_congr to lift pointwise inner additivity through an outer integral",
+      "linarith over interval integrals treated as atoms to discharge edge cancellation"
+    ]
+  },
+  "tags": [
+    "analysis",
+    "multivariable-calculus",
+    "integration",
+    "greens-theorem",
+    "additivity"
+  ],
+  "relatedProofs": [
+    "greens-theorem-oq-01",
+    "greens-theorem-oq-01-oq-01",
+    "greens-theorem-oq-01-oq-02",
+    "greens-theorem"
+  ],
+  "references": [
+    "https://en.wikipedia.org/wiki/Green%27s_theorem"
+  ],
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "leanFiles": [
+    "proofs/Proofs/GreensTheoremOQ01OQ03.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **greens-theorem-oq-01-oq-03**: the concrete intervalIntegral form of Green's theorem (from `greens-theorem-oq-01`) is **additive under subdivision** of the rectangle, with shared interior edges cancelling by orientation. This is the structural bridge from a single rectangle to rectangle-tiled regions — the extension flagged in the parent's Part VI.

Built on `Proofs.GreensTheoremOQ01` (imported, reusing `rectLineIntegral` / `rectDoubleIntegral`).

## Results (6 theorems, 219 lines, 0 axioms, 0 sorries)

| Theorem | Statement |
|---|---|
| `rectLineIntegral_vsplit` | Line integral splits additively under a vertical cut `x=e`; shared edge `∫Q(e,·)` cancels |
| `rectDoubleIntegral_vsplit` | Double integral of curl splits additively under a vertical cut |
| `rectLineIntegral_hsplit` | Line integral splits under a horizontal cut `y=g`; shared edge `∫P(·,g)` cancels |
| `rectDoubleIntegral_hsplit` | Double integral splits under a horizontal cut |
| `greens_additive_vertical` | **Capstone**: Green's theorem on two sub-rectangles ⟹ Green's theorem on their union |
| `area_vsplit_unit_square` | Concrete numeric check (½ + ½ = 1) |

## Why it's new

The parent (OQ-01) and the Fubini-elimination siblings (OQ-01-OQ-01, OQ-01-OQ-02) all work with a **fixed single rectangle**. None prove that the Green identity *tiles*. Here:

- **Orientation makes regions tile.** Each interior edge is traversed once upward, once downward; its two line-integral contributions are exact negatives and cancel with **zero analytic input** (pure `ring`/`linarith`).
- Only the **outer** edges — which genuinely combine into a longer integral — need interval-integrability, supplied via `intervalIntegral.integral_add_adjacent_intervals`. This cleanly separates the algebraic (cancellation) from the analytic (gluing) content.
- No `a ≤ e ≤ b` ordering hypotheses: the Mathlib adjacency lemma is sign-aware, so additivity holds for signed/overlapping cuts.
- `greens_additive_vertical` is exactly the **inductive step** for proving Green's theorem on any staircase region.

## Verification

- `lake env lean Proofs/GreensTheoremOQ01OQ03.lean` compiles clean (host single-file build against shared Mathlib cache).
- `#print axioms` on each main theorem reports only `propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **0 axioms, 0 sorries** per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)